### PR TITLE
docs-gate: budget every packages/*/CLAUDE.md at 20K with frozen grandfathered exemptions

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,6 +5,6 @@ npx lint-staged
 # Enforce instruction-file size budgets when a budgeted file is staged
 # (root/agent CLAUDE.md or a GitHub Copilot instruction file).
 # Runs once, after lint-staged formatting (race-free).
-if git diff --cached --name-only | grep -qE '^(CLAUDE\.md|packages/vfs-root/shared/CLAUDE\.md|\.github/copilot-instructions\.md|\.github/instructions/.*\.instructions\.md)$'; then
+if git diff --cached --name-only | grep -qE '^(CLAUDE\.md|packages/vfs-root/shared/CLAUDE\.md|\.github/copilot-instructions\.md|\.github/instructions/.*\.instructions\.md|packages/.*/CLAUDE\.md)$'; then
   node packages/dev-tools/tools/check-doc-sizes.mjs
 fi

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -16,6 +16,30 @@ This file covers the documentation surface in `docs/`.
 - Update the root `CLAUDE.md` only for repo-wide navigation, CI gates, or cross-cutting principles.
 - Put long-form implementation detail in the appropriate `docs/*.md` file rather than bloating a `CLAUDE.md`.
 
+### Size budgets (enforced by `npm run lint:docs`)
+
+| File                                                    | Limit  | Unit  | Note                                |
+| ------------------------------------------------------- | ------ | ----- | ----------------------------------- |
+| `CLAUDE.md` (root)                                      | 30,000 | chars | → 15,000 planned (#1469)            |
+| `packages/*/CLAUDE.md`                                  | 20,000 | chars | four files grandfathered; see below |
+| `packages/vfs-root/shared/CLAUDE.md`                    | 3,000  | bytes | bundled into the VFS                |
+| `.github/copilot-instructions.md` + `*.instructions.md` | 4,000  | chars | Copilot truncation limit            |
+
+Four package files exceed the 20,000-char cap as of the gate's introduction and
+are grandfathered with frozen per-file exemptions (in `check-doc-sizes-lib.mjs`):
+`packages/webapp/CLAUDE.md` (67,000), `packages/cloudflare-worker/CLAUDE.md` (45,000),
+`packages/chrome-extension/CLAUDE.md` (35,000), `packages/dev-tools/CLAUDE.md` (28,000).
+The nightly ratchet (#1469 Wave 3) will lower these mechanically. Exemption values
+may only be lowered or deleted — never added or raised.
+
+### No PR breadcrumbs
+
+Do not add "Added in PR #NNN" or "Changed in PR #NNN" lines to `CLAUDE.md` files.
+Provenance belongs in `git log`; durable lessons (gotchas, anti-patterns, decisions)
+belong in `docs/pitfalls.md` or `docs/review-patterns.md`, not inline breadcrumbs.
+Deep implementation detail that does not fit the budget should move to `docs/`, not
+shrink to a one-liner in a `CLAUDE.md`.
+
 ## Common Destinations in `docs/`
 
 Architecture and build:

--- a/packages/dev-tools/tools/check-doc-sizes-lib.mjs
+++ b/packages/dev-tools/tools/check-doc-sizes-lib.mjs
@@ -1,0 +1,63 @@
+// Pure logic for the packages/*/CLAUDE.md size-budget check.
+//
+// Every `packages/*/CLAUDE.md` is budgeted at PACKAGE_CLAUDE_MAX_CHARS.
+// Four files that already exceeded the cap when the gate was introduced are
+// grandfathered with per-file exemptions at current-size-rounded-up. The
+// exemption list is FROZEN: values may only be lowered or deleted, never
+// added or raised. The nightly ratchet (follow-up issue #1469) will lower
+// them mechanically.
+//
+// The pure functions here (no IO) are unit-tested by the `dev-tools` vitest
+// project. The thin IO + CLI wiring lives in `check-doc-sizes.mjs`.
+
+export const PACKAGE_CLAUDE_MAX_CHARS = 20000;
+
+// Frozen grandfathered exemptions for files that exceeded PACKAGE_CLAUDE_MAX_CHARS
+// when this gate was introduced (issue #1532, part of #1469 Wave 1).
+// FROZEN: never add or raise entries. Lower or remove only.
+export const PACKAGE_CLAUDE_EXEMPTIONS = {
+  'packages/webapp/CLAUDE.md': 67000, // TODO(#1469) trim to ≤20K
+  'packages/cloudflare-worker/CLAUDE.md': 45000, // TODO(#1469) trim to ≤20K
+  'packages/chrome-extension/CLAUDE.md': 35000, // TODO(#1469) trim to ≤20K
+  'packages/dev-tools/CLAUDE.md': 28000, // TODO(#1469) trim to ≤20K
+};
+
+/**
+ * Resolve the effective character limit for a given package CLAUDE.md path.
+ *
+ * @param {string} relPath - Repo-relative path, e.g. 'packages/webapp/CLAUDE.md'
+ * @returns {number} The cap in characters (exempted cap or default)
+ */
+export function resolvePackageClaudeLimit(relPath) {
+  return PACKAGE_CLAUDE_EXEMPTIONS[relPath] ?? PACKAGE_CLAUDE_MAX_CHARS;
+}
+
+/**
+ * Given a list of 'packages/*\/CLAUDE.md' relative paths and a size map,
+ * return the check results for each path.
+ *
+ * @param {string[]} relPaths - Repo-relative paths to check
+ * @param {Map<string, number>} sizeMap - Map from path to character count
+ * @returns {{ path: string; size: number; limit: number; pass: boolean }[]}
+ */
+export function checkPackageClaudes(relPaths, sizeMap) {
+  return relPaths.map((relPath) => {
+    const size = sizeMap.get(relPath) ?? 0;
+    const limit = resolvePackageClaudeLimit(relPath);
+    return { path: relPath, size, limit, pass: size <= limit };
+  });
+}
+
+/**
+ * Discover 'packages/*\/CLAUDE.md' relative paths from a list of package
+ * directory names. Returns repo-relative paths sorted alphabetically.
+ *
+ * @param {string[]} packageDirs - Names of entries under the 'packages/' dir
+ * @returns {string[]} Sorted repo-relative paths like 'packages/webapp/CLAUDE.md'
+ */
+export function discoverPackageClaudes(packageDirs) {
+  return packageDirs
+    .filter((name) => typeof name === 'string' && name.length > 0)
+    .map((name) => `packages/${name}/CLAUDE.md`)
+    .sort();
+}

--- a/packages/dev-tools/tools/check-doc-sizes-lib.test.mjs
+++ b/packages/dev-tools/tools/check-doc-sizes-lib.test.mjs
@@ -1,0 +1,200 @@
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  checkPackageClaudes,
+  discoverPackageClaudes,
+  PACKAGE_CLAUDE_EXEMPTIONS,
+  PACKAGE_CLAUDE_MAX_CHARS,
+  resolvePackageClaudeLimit,
+} from './check-doc-sizes-lib.mjs';
+
+const filename = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(filename), '..', '..', '..');
+const scriptPath = resolve(repoRoot, 'packages/dev-tools/tools/check-doc-sizes.mjs');
+
+/** Run check-doc-sizes.mjs, capturing output even on non-zero exit. */
+function runCheckDocSizes() {
+  try {
+    return { code: 0, out: execFileSync('node', [scriptPath], { encoding: 'utf8' }) };
+  } catch (err) {
+    return { code: err.status ?? 1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+describe('PACKAGE_CLAUDE_MAX_CHARS', () => {
+  it('is 20000', () => {
+    expect(PACKAGE_CLAUDE_MAX_CHARS).toBe(20000);
+  });
+});
+
+describe('PACKAGE_CLAUDE_EXEMPTIONS', () => {
+  it('contains exactly the four grandfathered files', () => {
+    const keys = Object.keys(PACKAGE_CLAUDE_EXEMPTIONS).sort();
+    expect(keys).toEqual([
+      'packages/chrome-extension/CLAUDE.md',
+      'packages/cloudflare-worker/CLAUDE.md',
+      'packages/dev-tools/CLAUDE.md',
+      'packages/webapp/CLAUDE.md',
+    ]);
+  });
+
+  it('has the correct exemption values', () => {
+    expect(PACKAGE_CLAUDE_EXEMPTIONS['packages/webapp/CLAUDE.md']).toBe(67000);
+    expect(PACKAGE_CLAUDE_EXEMPTIONS['packages/cloudflare-worker/CLAUDE.md']).toBe(45000);
+    expect(PACKAGE_CLAUDE_EXEMPTIONS['packages/chrome-extension/CLAUDE.md']).toBe(35000);
+    expect(PACKAGE_CLAUDE_EXEMPTIONS['packages/dev-tools/CLAUDE.md']).toBe(28000);
+  });
+
+  it('all exemption values exceed the default cap (they are grandfathered)', () => {
+    for (const [path, limit] of Object.entries(PACKAGE_CLAUDE_EXEMPTIONS)) {
+      expect(limit, `${path} exemption should exceed PACKAGE_CLAUDE_MAX_CHARS`).toBeGreaterThan(
+        PACKAGE_CLAUDE_MAX_CHARS
+      );
+    }
+  });
+});
+
+describe('resolvePackageClaudeLimit', () => {
+  it('returns the exemption value for grandfathered files', () => {
+    expect(resolvePackageClaudeLimit('packages/webapp/CLAUDE.md')).toBe(67000);
+    expect(resolvePackageClaudeLimit('packages/cloudflare-worker/CLAUDE.md')).toBe(45000);
+    expect(resolvePackageClaudeLimit('packages/chrome-extension/CLAUDE.md')).toBe(35000);
+    expect(resolvePackageClaudeLimit('packages/dev-tools/CLAUDE.md')).toBe(28000);
+  });
+
+  it('returns PACKAGE_CLAUDE_MAX_CHARS for non-exempted packages', () => {
+    expect(resolvePackageClaudeLimit('packages/cherry/CLAUDE.md')).toBe(PACKAGE_CLAUDE_MAX_CHARS);
+    expect(resolvePackageClaudeLimit('packages/node-server/CLAUDE.md')).toBe(
+      PACKAGE_CLAUDE_MAX_CHARS
+    );
+    expect(resolvePackageClaudeLimit('packages/shared-ts/CLAUDE.md')).toBe(
+      PACKAGE_CLAUDE_MAX_CHARS
+    );
+  });
+
+  it('returns PACKAGE_CLAUDE_MAX_CHARS for unknown paths', () => {
+    expect(resolvePackageClaudeLimit('packages/new-package/CLAUDE.md')).toBe(
+      PACKAGE_CLAUDE_MAX_CHARS
+    );
+    expect(resolvePackageClaudeLimit('')).toBe(PACKAGE_CLAUDE_MAX_CHARS);
+  });
+});
+
+describe('discoverPackageClaudes', () => {
+  it('maps package dir names to repo-relative paths', () => {
+    expect(discoverPackageClaudes(['webapp', 'cherry'])).toEqual([
+      'packages/cherry/CLAUDE.md',
+      'packages/webapp/CLAUDE.md',
+    ]);
+  });
+
+  it('sorts results alphabetically', () => {
+    const result = discoverPackageClaudes(['zebra', 'apple', 'mango']);
+    expect(result).toEqual([
+      'packages/apple/CLAUDE.md',
+      'packages/mango/CLAUDE.md',
+      'packages/zebra/CLAUDE.md',
+    ]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(discoverPackageClaudes([])).toEqual([]);
+  });
+
+  it('skips empty strings', () => {
+    expect(discoverPackageClaudes(['', 'cherry', ''])).toEqual(['packages/cherry/CLAUDE.md']);
+  });
+});
+
+describe('checkPackageClaudes', () => {
+  it('marks paths under the limit as passing', () => {
+    const sizes = new Map([['packages/cherry/CLAUDE.md', 10000]]);
+    const results = checkPackageClaudes(['packages/cherry/CLAUDE.md'], sizes);
+    expect(results).toEqual([
+      {
+        path: 'packages/cherry/CLAUDE.md',
+        size: 10000,
+        limit: PACKAGE_CLAUDE_MAX_CHARS,
+        pass: true,
+      },
+    ]);
+  });
+
+  it('marks paths at the limit as passing', () => {
+    const sizes = new Map([['packages/cherry/CLAUDE.md', PACKAGE_CLAUDE_MAX_CHARS]]);
+    const results = checkPackageClaudes(['packages/cherry/CLAUDE.md'], sizes);
+    expect(results[0].pass).toBe(true);
+  });
+
+  it('marks paths over the limit as failing', () => {
+    const sizes = new Map([['packages/cherry/CLAUDE.md', PACKAGE_CLAUDE_MAX_CHARS + 1]]);
+    const results = checkPackageClaudes(['packages/cherry/CLAUDE.md'], sizes);
+    expect(results[0].pass).toBe(false);
+    expect(results[0].size).toBe(PACKAGE_CLAUDE_MAX_CHARS + 1);
+  });
+
+  it('uses the exemption limit for grandfathered files', () => {
+    const path = 'packages/webapp/CLAUDE.md';
+    const sizes = new Map([[path, 60000]]);
+    const [result] = checkPackageClaudes([path], sizes);
+    expect(result.limit).toBe(67000);
+    expect(result.pass).toBe(true);
+  });
+
+  it('fails a grandfathered file if it exceeds its own exemption', () => {
+    const path = 'packages/webapp/CLAUDE.md';
+    const sizes = new Map([[path, 68000]]);
+    const [result] = checkPackageClaudes([path], sizes);
+    expect(result.limit).toBe(67000);
+    expect(result.pass).toBe(false);
+  });
+
+  it('returns size 0 for paths not in the size map', () => {
+    const sizes = new Map();
+    const results = checkPackageClaudes(['packages/cherry/CLAUDE.md'], sizes);
+    expect(results[0].size).toBe(0);
+    expect(results[0].pass).toBe(true);
+  });
+
+  it('handles multiple paths in one call', () => {
+    const sizes = new Map([
+      ['packages/cherry/CLAUDE.md', 5000],
+      ['packages/webapp/CLAUDE.md', 50000],
+    ]);
+    const results = checkPackageClaudes(
+      ['packages/cherry/CLAUDE.md', 'packages/webapp/CLAUDE.md'],
+      sizes
+    );
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({ path: 'packages/cherry/CLAUDE.md', pass: true });
+    expect(results[1]).toMatchObject({ path: 'packages/webapp/CLAUDE.md', pass: true });
+  });
+});
+
+describe('check-doc-sizes.mjs: package CLAUDE.md integration', () => {
+  const { code, out } = runCheckDocSizes();
+
+  it('exits 0 on the current repo (all files within their limits)', () => {
+    expect(code).toBe(0);
+  });
+
+  it('reports ok for every packages/*/CLAUDE.md discovered', () => {
+    expect(out).toMatch(/ok: packages\/cherry\/CLAUDE\.md is \d+\/20000 chars/);
+    expect(out).toMatch(/ok: packages\/node-server\/CLAUDE\.md is \d+\/20000 chars/);
+  });
+
+  it('labels grandfathered files in the output', () => {
+    expect(out).toMatch(/ok: packages\/webapp\/CLAUDE\.md is \d+\/67000 chars \(grandfathered\)/);
+    expect(out).toMatch(
+      /ok: packages\/cloudflare-worker\/CLAUDE\.md is \d+\/45000 chars \(grandfathered\)/
+    );
+    expect(out).toMatch(
+      /ok: packages\/chrome-extension\/CLAUDE\.md is \d+\/35000 chars \(grandfathered\)/
+    );
+    expect(out).toMatch(
+      /ok: packages\/dev-tools\/CLAUDE\.md is \d+\/28000 chars \(grandfathered\)/
+    );
+  });
+});

--- a/packages/dev-tools/tools/check-doc-sizes.mjs
+++ b/packages/dev-tools/tools/check-doc-sizes.mjs
@@ -15,10 +15,18 @@
  *   every `.github/instructions/*.instructions.md`) are budgeted in characters:
  *   Copilot code review only reads the first 4,000 characters of any
  *   instruction file and silently ignores the rest.
+ * - Every 'packages/*\/CLAUDE.md' is budgeted in characters at
+ *   PACKAGE_CLAUDE_MAX_CHARS (see check-doc-sizes-lib.mjs for exemptions).
  */
-import { readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  checkPackageClaudes,
+  discoverPackageClaudes,
+  PACKAGE_CLAUDE_MAX_CHARS,
+  resolvePackageClaudeLimit,
+} from './check-doc-sizes-lib.mjs';
 
 const Filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(Filename), '..', '..', '..');
@@ -80,6 +88,31 @@ try {
   if (err.code !== 'ENOENT') throw err;
 }
 
+// packages/*/CLAUDE.md — every package is budgeted at PACKAGE_CLAUDE_MAX_CHARS.
+// Auto-discovered so new packages are covered without editing this script.
+// Four files that already exceeded the cap are grandfathered with frozen
+// per-file exemptions in check-doc-sizes-lib.mjs; the nightly ratchet
+// (issue #1469) will lower them mechanically.
+const packagesDir = resolve(repoRoot, 'packages');
+const packageDirs = readdirSync(packagesDir).filter((entry) => {
+  try {
+    return statSync(resolve(packagesDir, entry)).isDirectory();
+  } catch {
+    return false;
+  }
+});
+const packageClaudes = discoverPackageClaudes(packageDirs);
+const packageClaudeSizes = new Map();
+for (const relPath of packageClaudes) {
+  const abs = resolve(repoRoot, relPath);
+  try {
+    packageClaudeSizes.set(relPath, measureChars(readFileSync(abs, 'utf8')));
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+    // Package has no CLAUDE.md — nothing to budget.
+  }
+}
+
 const failures = [];
 
 for (const check of checks) {
@@ -99,6 +132,22 @@ for (const check of checks) {
     );
   } else {
     process.stdout.write(`ok: ${check.path} is ${size}/${check.limit} ${check.unit}\n`);
+  }
+}
+
+const packageClaudeResults = checkPackageClaudes(
+  [...packageClaudeSizes.keys()],
+  packageClaudeSizes
+);
+for (const { path, size, limit, pass } of packageClaudeResults) {
+  const exempted = resolvePackageClaudeLimit(path) > PACKAGE_CLAUDE_MAX_CHARS;
+  const tag = exempted ? ' (grandfathered)' : '';
+  if (!pass) {
+    failures.push(
+      `${path} exceeds ${limit} chars limit (${size} chars)${tag}. Trim it or lower its exemption.`
+    );
+  } else {
+    process.stdout.write(`ok: ${path} is ${size}/${limit} chars${tag}\n`);
   }
 }
 

--- a/packages/dev-tools/tools/precommit-doc-check.test.mjs
+++ b/packages/dev-tools/tools/precommit-doc-check.test.mjs
@@ -43,6 +43,7 @@ describe('pre-commit doc-size wiring (husky hook)', () => {
       'packages/vfs-root/shared/CLAUDE\\.md',
       '.github/copilot-instructions\\.md',
       '.github/instructions/.*\\.instructions\\.md',
+      'packages/.*/CLAUDE\\.md',
     ]) {
       expect(hook).toContain(token);
     }


### PR DESCRIPTION
Part of #1469 Wave 1. Closes #1532.

## What this does

Extends `packages/dev-tools/tools/check-doc-sizes.mjs` (wired into `npm run lint:docs`, pre-commit hook, and CI) to gate every `packages/*/CLAUDE.md` at 20,000 characters.

### New files

- **`check-doc-sizes-lib.mjs`** — pure IO-free functions for the package CLAUDE.md budget:
  - `PACKAGE_CLAUDE_MAX_CHARS = 20000`
  - `PACKAGE_CLAUDE_EXEMPTIONS` — frozen per-file caps for the four files that exceeded the default when the gate was introduced (`packages/webapp/CLAUDE.md` 67K, `packages/cloudflare-worker/CLAUDE.md` 45K, `packages/chrome-extension/CLAUDE.md` 35K, `packages/dev-tools/CLAUDE.md` 28K), each with `TODO(#1469)` comment. The list is frozen: values may only be lowered or deleted.
  - `resolvePackageClaudeLimit()`, `discoverPackageClaudes()`, `checkPackageClaudes()`

- **`check-doc-sizes-lib.test.mjs`** — 21 unit tests covering constant values, limit resolution, discovery, and pass/fail logic including grandfathered exemptions. End-to-end test that the script exits 0 on the current repo and prints `(grandfathered)` tags.

### Changed files

- **`check-doc-sizes.mjs`** — auto-discovers `packages/*/CLAUDE.md` via `readdirSync` (no manual list maintenance needed for new packages), reads sizes, delegates to the lib for limit resolution and pass/fail, prints ok lines with `(grandfathered)` tag where applicable.

- **`.husky/pre-commit`** — adds `packages/.*/CLAUDE\.md` to the staged-files guard so the check runs locally when a package CLAUDE.md is staged.

- **`precommit-doc-check.test.mjs`** — adds the new token to the guard-regex assertion.

- **`docs/CLAUDE.md`** — adds "Size budgets" subsection to "How to Update Docs" (budget table, frozen-exemption note) and "No PR breadcrumbs" guideline (provenance in git log; lessons in docs/).

## Verification

`npm run lint:docs` passes — all 15 package CLAUDE.md files are within their limits. All 331 dev-tools tests pass.