### PR TITLE
fix(monitor): Fix the color coding on Processes, Mounts, and OAuth.

### DIFF
--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -17,7 +17,13 @@ import {
   type SyncFsNonceMsg,
 } from '../../kernel/realm/sync-fs-wire.js';
 import { spawnKernelWorker } from '../../kernel/spawn.js';
-import { resolveCurrentModel, resolveModelById } from '../../providers/account-store.js';
+import {
+  getAccounts,
+  getOAuthAccountInfo,
+  getProviderConfig,
+  resolveCurrentModel,
+  resolveModelById,
+} from '../../providers/account-store.js';
 import type { LickEvent } from '../../scoops/lick-manager.js';
 import { hasStoredTrayJoinUrl } from '../../scoops/tray-runtime-config.js';
 import type { RegisteredScoop, ThinkingLevel } from '../../scoops/types.js';
@@ -81,6 +87,44 @@ const META_FROM_PI: Readonly<Record<string, string>> = {
 
 export function thinkingLevelForAgent(metaLevel: string | undefined): ThinkingLevel | undefined {
   return metaLevel ? PI_FROM_META[metaLevel] : undefined;
+}
+
+/**
+ * Maps proc-mount.ts's single-letter process state code back to the word
+ * the monitor UI checks for (wc-monitor.ts: `proc.status === 'running'`).
+ * Unrecognized/missing letters map to `'unknown'` rather than throwing —
+ * a process that exits mid-read (ENOENT on the next file) is handled by the
+ * caller's try/catch, not here.
+ */
+const PROC_STATE_LETTER_TO_WORD: Record<string, string> = {
+  R: 'running',
+  S: 'pending',
+  Z: 'exited',
+  K: 'killed',
+};
+
+/**
+ * Parses a `/proc/<pid>/stat` line — proc-mount.ts's `renderStat()` output:
+ * `"<pid> (<kind>) <stateLetter> <ppid> <exitCode> <startedAt> <finishedAt>"`
+ * — and returns the process status word for field 3 (the state letter).
+ *
+ * Extracted as a standalone pure function (rather than inlined in
+ * `getProcesses` below) specifically so this parsing/mapping logic — the
+ * fragile part of the fix for the "processes never show as active" bug
+ * (the state letter must land in the right array index, and the letter
+ * must map to the exact word `wc-monitor.ts` compares against) — has real
+ * unit test coverage without needing to mock the VFS/OffscreenClient chain
+ * `getProcesses` depends on.
+ *
+ * Historical note: this used to read the *verbose* `/proc/<pid>/status`
+ * dump (`Name:\t...\nState:\tR (running)\n...\nCmdline:\t...`) and pass the
+ * whole multi-line blob through as `status` — `wc-monitor.ts`'s
+ * `proc.status === 'running'` check could never match a multi-line string,
+ * so the active/ended dot was always grey regardless of real process state.
+ */
+export function parseProcStatLine(statLine: string): string {
+  const stateLetter = statLine.trim().split(' ')[2] ?? '';
+  return PROC_STATE_LETTER_TO_WORD[stateLetter] ?? 'unknown';
 }
 
 /**
@@ -1432,8 +1476,34 @@ export function attachWcClient(
           return getAllWebhooks();
         },
         getMounts: async () => {
-          const { getAllMountEntries } = await import('../../fs/mount-table-store.js');
-          return getAllMountEntries();
+          const { getAllMountEntries, loadMountHandle } = await import(
+            '../../fs/mount-table-store.js'
+          );
+          const entries = await getAllMountEntries();
+          // Checked fresh on every call (monitor's 5s auto-refresh + manual
+          // "↻ Refresh") — not polled independently. queryPermission() does
+          // NOT require a user gesture (only requestPermission() does), so
+          // this is safe to call here. Mirrors the same check
+          // mount-recovery.ts makes at session-reload time.
+          return Promise.all(
+            entries.map(async (entry) => {
+              if (entry.descriptor.kind !== 'local') {
+                return entry; // remote backends: no live permission concept, leave `valid` unset
+              }
+              try {
+                const rawHandle = await loadMountHandle(entry.descriptor.idbHandleKey);
+                // queryPermission() is real on Chromium's FileSystemDirectoryHandle but
+                // missing from TS's DOM lib (non-standard across browsers) — one cast.
+                const handle = rawHandle as {
+                  queryPermission?: (desc: { mode: string }) => Promise<string>;
+                } | null;
+                const perm = await handle?.queryPermission?.({ mode: 'readwrite' });
+                return { ...entry, valid: perm === 'granted' };
+              } catch {
+                return { ...entry, valid: false };
+              }
+            })
+          );
         },
         getMcpServers: async () => {
           try {
@@ -1449,14 +1519,32 @@ export function attachWcClient(
         },
         getOAuthProviders: () => {
           try {
-            const raw = localStorage.getItem('slicc_accounts');
-            if (!raw) return [];
-            const accounts = JSON.parse(raw);
-            if (!Array.isArray(accounts)) return [];
-            const providerIds = accounts
-              .map((a: { providerId?: string }) => a.providerId)
-              .filter((id): id is string => typeof id === 'string');
-            return [...new Set(providerIds)];
+            // getAccounts() already validates the localStorage shape;
+            // route through it (and the account-store OAuth helpers) rather
+            // than re-parsing `slicc_accounts` here, so this stays in sync
+            // with the one canonical reader/writer of that key.
+            const seen = new Set<string>();
+            const entries: { providerId: string; valid?: boolean }[] = [];
+            for (const account of getAccounts()) {
+              if (seen.has(account.providerId)) continue;
+              seen.add(account.providerId);
+              // Only OAuth-flavored providers carry a meaningful valid/invalid
+              // status here — plain API-key accounts get `valid: undefined`
+              // (default/neutral dot), same treatment remote mount backends
+              // get in the mounts section above.
+              if (!getProviderConfig(account.providerId)?.isOAuth) {
+                entries.push({ providerId: account.providerId });
+                continue;
+              }
+              // getOAuthAccountInfo derives status purely from locally-held
+              // fields already on the Account record (loggedOut,
+              // tokenExpiresAt vs. Date.now()) — no token value is read out,
+              // and no network call is made.
+              const info = getOAuthAccountInfo(account.providerId);
+              const valid = account.loggedOut ? false : info ? !info.expired : undefined;
+              entries.push({ providerId: account.providerId, valid });
+            }
+            return entries;
           } catch {
             return [];
           }
@@ -1471,7 +1559,7 @@ export function attachWcClient(
               (e) => e.type === 'directory' && /^\d+$/.test(e.name)
             )) {
               try {
-                const status = await fs.readFile(`/proc/${entry.name}/status`, {
+                const stat = await fs.readFile(`/proc/${entry.name}/stat`, {
                   encoding: 'utf-8',
                 });
                 const cmdline = await fs.readFile(`/proc/${entry.name}/cmdline`, {
@@ -1480,7 +1568,7 @@ export function attachWcClient(
                 procs.push({
                   pid: parseInt(entry.name, 10),
                   argv: String(cmdline).trim(),
-                  status: String(status).trim(),
+                  status: parseProcStatLine(String(stat)),
                 });
               } catch {
                 /* process may have exited */

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -1485,6 +1485,14 @@ export function attachWcClient(
           // NOT require a user gesture (only requestPermission() does), so
           // this is safe to call here. Mirrors the same check
           // mount-recovery.ts makes at session-reload time.
+          //
+          // Each local entry below calls loadMountHandle(), which opens (and
+          // closes) its own IndexedDB connection — fine at the 5s monitor
+          // cadence for a normal mount count, but if mount counts grow this
+          // could be batched through a single shared transaction instead.
+          // Deferred: would also change the per-entry error isolation the
+          // try/catch below gives us (one bad handle currently only zeroes
+          // out that one row).
           return Promise.all(
             entries.map(async (entry) => {
               if (entry.descriptor.kind !== 'local') {
@@ -1539,9 +1547,16 @@ export function attachWcClient(
               // getOAuthAccountInfo derives status purely from locally-held
               // fields already on the Account record (loggedOut,
               // tokenExpiresAt vs. Date.now()) — no token value is read out,
-              // and no network call is made.
+              // and no network call is made. info === null means no
+              // accessToken at all — e.g. a requiresBaseUrl provider's
+              // base-URL-only row saved before the OAuth popup ever
+              // completed (provider-settings.ts's runOAuthLogin). That's a
+              // real OAuth-flavored account that just never finished
+              // authenticating, so it gets the same red dot as logged-out/
+              // expired rather than falling into the "not an OAuth
+              // provider" neutral case below.
               const info = getOAuthAccountInfo(account.providerId);
-              const valid = account.loggedOut ? false : info ? !info.expired : undefined;
+              const valid = account.loggedOut ? false : info ? !info.expired : false;
               entries.push({ providerId: account.providerId, valid });
             }
             return entries;

--- a/packages/webapp/src/ui/wc/wc-monitor.ts
+++ b/packages/webapp/src/ui/wc/wc-monitor.ts
@@ -9,14 +9,45 @@ import type { MountTableEntry } from '../../fs/mount-table-store.js';
 import type { CronTaskEntry, WebhookEntry } from '../../scoops/lick-manager.js';
 import type { RegisteredScoop } from '../../scoops/types.js';
 
+/**
+ * A persisted mount entry, augmented with the permission state as of the
+ * moment this monitor render was fetched — checked fresh on every
+ * `fetchMonitorData` call (initial load, the 5s auto-refresh, and manual
+ * "↻ Refresh" clicks), never polled independently. `valid` is `true` for a
+ * local mount whose handle still reports `queryPermission → 'granted'`,
+ * `false` for a local mount that needs recovery, and `undefined` for
+ * remote mounts (s3/da/proc) — those backends don't hold this kind of
+ * live client-side permission state (see mount-recovery.ts's doc comment),
+ * so they intentionally get the default/neutral dot rather than a
+ * false green or red.
+ */
+type MountMonitorRow = MountTableEntry & { valid?: boolean };
+
+/**
+ * One OAuth-backed provider account as reported to the monitor. `valid` is
+ * derived entirely from locally-held account metadata (`loggedOut`,
+ * `tokenExpiresAt`) — no token is read for its value and no network call is
+ * made to check it:
+ *   - `true`  — has a token and it isn't past `tokenExpiresAt` (or the
+ *     provider doesn't report an expiry at all).
+ *   - `false` — explicitly logged out, or the stored token is past its
+ *     `tokenExpiresAt`.
+ *   - `undefined` — not an OAuth provider (plain API-key account), so this
+ *     status concept doesn't apply; renders the neutral/default dot.
+ */
+export interface OAuthProviderEntry {
+  providerId: string;
+  valid?: boolean;
+}
+
 export interface MonitorDeps {
   getScoops(): RegisteredScoop[];
   isProcessing(jid: string): boolean;
   getCronTasks(): Promise<CronTaskEntry[]>;
   getWebhooks(): Promise<WebhookEntry[]>;
-  getMounts(): Promise<MountTableEntry[]>;
+  getMounts(): Promise<MountMonitorRow[]>;
   getMcpServers(): Promise<Record<string, { url: string; tools?: unknown[] }>>;
-  getOAuthProviders(): string[];
+  getOAuthProviders(): OAuthProviderEntry[];
   getSessionStats(): Promise<{
     totalCost: number;
     models: { model: string; cost: number }[];
@@ -34,7 +65,7 @@ export async function fetchMonitorData(deps: MonitorDeps): Promise<MonitorSectio
   const [cronTasks, webhooks, mounts, mcpServers, sessionStats, processes] = await Promise.all([
     deps.getCronTasks().catch(() => [] as CronTaskEntry[]),
     deps.getWebhooks().catch(() => [] as WebhookEntry[]),
-    deps.getMounts().catch(() => [] as MountTableEntry[]),
+    deps.getMounts().catch(() => [] as MountMonitorRow[]),
     deps.getMcpServers().catch(() => ({}) as Record<string, { url: string; tools?: unknown[] }>),
     deps.getSessionStats().catch(() => null),
     deps.getProcesses().catch(() => []),
@@ -106,6 +137,11 @@ export async function fetchMonitorData(deps: MonitorDeps): Promise<MonitorSectio
       rows: mounts.map((mount) => ({
         name: mount.targetPath,
         meta: mount.descriptor.kind,
+        // valid === true  → green (permission confirmed as of this render)
+        // valid === false → red (needs recovery as of this render)
+        // valid === undefined (remote backends) → default grey, no check made
+        active: mount.valid === true,
+        error: mount.valid === false,
       })),
     },
     {
@@ -121,7 +157,15 @@ export async function fetchMonitorData(deps: MonitorDeps): Promise<MonitorSectio
       id: 'oauth',
       label: 'OAuth',
       count: oauthProviders.length,
-      rows: oauthProviders.map((provider) => ({ name: provider, meta: '' })),
+      rows: oauthProviders.map((provider) => ({
+        name: provider.providerId,
+        meta: '',
+        // valid === true  → green (has a token, not past its expiry)
+        // valid === false → red (logged out, or token past its expiry)
+        // valid === undefined (non-OAuth / API-key account) → default grey
+        active: provider.valid === true,
+        error: provider.valid === false,
+      })),
     },
   ];
 

--- a/packages/webapp/tests/ui/wc/wc-live.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-live.test.ts
@@ -13,6 +13,7 @@ import type { RegisteredScoop } from '../../../src/scoops/types.js';
 import {
   createWcLiveCallbacks,
   metaThinkingForScoop,
+  parseProcStatLine,
   scoopColor,
   thinkingLevelForAgent,
   toSwitcherScoops,
@@ -340,5 +341,62 @@ describe('wireWcChipTips (richer hover tooltips)', () => {
     chip.dispatchEvent(new Event('pointerover', { bubbles: true }));
     expect(chip.title).toBe('sliccy');
     expect(labelFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('parseProcStatLine', () => {
+  // Regression coverage for the "processes never show as active" bug:
+  // getProcesses() used to read the verbose /proc/<pid>/status dump
+  // (`Name:\t...\nState:\tR (running)\n...`) and pass the whole multi-line
+  // blob through as `status`. wc-monitor.ts's `proc.status === 'running'`
+  // check could never match that, so the active/ended dot was always grey
+  // regardless of real process state. The fix reads /proc/<pid>/stat (a
+  // clean single-line record from proc-mount.ts's renderStat()) instead —
+  // these tests pin the exact field-index parsing and letter→word mapping.
+
+  it('parses a running process (state letter R)', () => {
+    expect(parseProcStatLine('1024 (shell) R 1 - 1700000000000 -')).toBe('running');
+  });
+
+  it('parses a pending process (state letter S)', () => {
+    expect(parseProcStatLine('1025 (jsh) S 1024 - 1700000000000 -')).toBe('pending');
+  });
+
+  it('parses an exited process (state letter Z)', () => {
+    expect(parseProcStatLine('1026 (tool) Z 1024 0 1700000000000 1700000001000')).toBe('exited');
+  });
+
+  it('parses a killed process (state letter K)', () => {
+    expect(parseProcStatLine('1027 (py) K 1024 137 1700000000000 1700000002000')).toBe('killed');
+  });
+
+  it('falls back to "unknown" for an unrecognized state letter', () => {
+    expect(parseProcStatLine('1028 (net) ? 1024 - 1700000000000 -')).toBe('unknown');
+  });
+
+  it('falls back to "unknown" for a malformed/empty line', () => {
+    expect(parseProcStatLine('')).toBe('unknown');
+    expect(parseProcStatLine('1029')).toBe('unknown');
+  });
+
+  it('tolerates surrounding whitespace (as a real file read would include a trailing newline)', () => {
+    expect(parseProcStatLine('1030 (shell) R 1 - 1700000000000 -\n')).toBe('running');
+  });
+
+  it('never returns the raw multi-line /proc/<pid>/status dump this bug used to produce', () => {
+    // The exact shape of the OLD buggy input, to document why this
+    // function exists at all — verbatim status-dump text is not a valid
+    // stat line, so it can never accidentally parse as 'running'.
+    const oldBuggyStatusDump = [
+      'Name:\tshell',
+      'Pid:\t1024',
+      'PPid:\t1',
+      'State:\tR (running)',
+      'Owner:\tcone',
+      'StartedAt:\t2026-01-01T00:00:00.000Z',
+      'Cmdline:\tbash -lc "sleep 5"',
+    ].join('\n');
+    expect(parseProcStatLine(oldBuggyStatusDump)).not.toBe('running');
+    expect(parseProcStatLine(oldBuggyStatusDump)).toBe('unknown');
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-monitor.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-monitor.test.ts
@@ -104,6 +104,61 @@ describe('fetchMonitorData', () => {
     expect(mountSection.rows[0].meta).toBe('local');
   });
 
+  it('shows a green dot for a local mount with confirmed permission (valid: true)', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getMounts: async () => [
+          {
+            targetPath: '/mnt/okrs',
+            descriptor: { kind: 'local', mountId: 'm1', idbHandleKey: 'k' },
+            createdAt: 0,
+            valid: true,
+          },
+        ],
+      })
+    );
+    const mountSection = sections.find((s) => s.id === 'mounts')!;
+    expect(mountSection.rows[0].active).toBe(true);
+    expect(mountSection.rows[0].error).toBe(false);
+  });
+
+  it('shows a red dot for a local mount that has lost permission (valid: false)', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getMounts: async () => [
+          {
+            targetPath: '/mnt/okrs',
+            descriptor: { kind: 'local', mountId: 'm1', idbHandleKey: 'k' },
+            createdAt: 0,
+            valid: false,
+          },
+        ],
+      })
+    );
+    const mountSection = sections.find((s) => s.id === 'mounts')!;
+    expect(mountSection.rows[0].active).toBe(false);
+    expect(mountSection.rows[0].error).toBe(true);
+  });
+
+  it('shows the default (neither active nor error) dot for a remote mount, where `valid` is never set', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getMounts: async () => [
+          {
+            targetPath: '/mnt/da-okrs',
+            descriptor: { kind: 'da', mountId: 'm2', source: 'da://org/repo', profile: 'default' },
+            createdAt: 0,
+            // no `valid` field — remote backends don't have a live
+            // permission concept the monitor can check (see mount-recovery.ts)
+          },
+        ],
+      })
+    );
+    const mountSection = sections.find((s) => s.id === 'mounts')!;
+    expect(mountSection.rows[0].active).toBe(false);
+    expect(mountSection.rows[0].error).toBe(false);
+  });
+
   it('shows MCP server rows with tool count', async () => {
     const sections = await fetchMonitorData(
       makeDeps({
@@ -121,12 +176,45 @@ describe('fetchMonitorData', () => {
   it('shows OAuth provider rows', async () => {
     const sections = await fetchMonitorData(
       makeDeps({
-        getOAuthProviders: () => ['adobe', 'github'],
+        getOAuthProviders: () => [{ providerId: 'adobe' }, { providerId: 'github' }],
       })
     );
     const oauthSection = sections.find((s) => s.id === 'oauth')!;
     expect(oauthSection.count).toBe(2);
     expect(oauthSection.rows[0].name).toBe('adobe');
+  });
+
+  it('shows a green dot for a valid OAuth account', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getOAuthProviders: () => [{ providerId: 'adobe', valid: true }],
+      })
+    );
+    const oauthSection = sections.find((s) => s.id === 'oauth')!;
+    expect(oauthSection.rows[0].active).toBe(true);
+    expect(oauthSection.rows[0].error).toBe(false);
+  });
+
+  it('shows a red dot for an expired/logged-out OAuth account', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getOAuthProviders: () => [{ providerId: 'adobe', valid: false }],
+      })
+    );
+    const oauthSection = sections.find((s) => s.id === 'oauth')!;
+    expect(oauthSection.rows[0].active).toBe(false);
+    expect(oauthSection.rows[0].error).toBe(true);
+  });
+
+  it('shows the default/neutral dot for a non-OAuth (API-key) account', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getOAuthProviders: () => [{ providerId: 'anthropic' }],
+      })
+    );
+    const oauthSection = sections.find((s) => s.id === 'oauth')!;
+    expect(oauthSection.rows[0].active).toBe(false);
+    expect(oauthSection.rows[0].error).toBe(false);
   });
 
   it('shows cost section with model breakdown', async () => {


### PR DESCRIPTION
## Summary

  Adds live green/red/neutral status dots to three sections of the Monitor panel (`<slicc-monitor>`): **Mounts**, **OAuth**, and **Processes**. Before this change, mounts and OAuth accounts always rendered a neutral grey dot regardless of real status, and the Processes section's active/ended dot was always grey too
  — a pre-existing bug fixed here as part of the same work (it was reading the wrong `/proc` file, so its status check could never match).

  ## Why

  The Monitor panel is meant to be an at-a-glance health view of everything SLICC manages, but three of its sections gave no visual signal at all:
  - **Mounts**: a local mount that silently lost filesystem permission (e.g. after a browser restart) looked identical to a healthy one until you dug into the mount-recovery card.
  - **OAuth**: an expired or logged-out provider account looked identical to a valid one.
  - **Processes**: the active/ended dot was always grey — `getProcesses()` read the verbose `/proc/<pid>/status` dump (a multi-line string) into a field that `wc-monitor.ts` compares with `proc.status === 'running'`, which can never match a multi-line blob.

  ## Approach / Implementation notes

  - **Mounts** (`wc-live.ts`'s `getMounts`): for each `local`-backend mount entry, loads the persisted `FileSystemDirectoryHandle` and calls `queryPermission({ mode: 'readwrite' })` (not `requestPermission` — no user gesture required, safe to call on every monitor refresh). `queryPermission`/`requestPermission`
  aren't in TS's bundled DOM lib (non-standard across browsers), so there's one local cast to a `{ queryPermission?: ... }` shape, reused for the guard and the call via optional chaining — no `isLocalMountValid`-style helper function; `valid: perm === 'granted'` inline was equivalent in every case once the
  cast/optional-chain is written this way, so a separate function would've added a file+test surface for a single equality check.
  - **OAuth** (`getOAuthProviders`): switched from re-parsing the raw `slicc_accounts` localStorage key to routing through `getAccounts()`/`getProviderConfig()`/`getOAuthAccountInfo()` — the canonical account-store reader — so this stays in sync with the one source of truth for that key. `valid` is derived purely
  from locally-held fields (`loggedOut`, `tokenExpiresAt`); no token value is read out and no network call is made. Non-OAuth (API-key) accounts get `valid: undefined` → neutral dot, same treatment remote mount backends get.
  - **Processes**: `getProcesses` now reads `/proc/<pid>/stat` (proc-mount.ts's single-line `renderStat()` format: `"<pid> (<kind>) <stateLetter> <ppid> <exitCode> <startedAt> <finishedAt>"`) instead of `/proc/<pid>/status`, and a new pure `parseProcStatLine()` maps the state letter (R/S/Z/K) back to the exact
  status word `wc-monitor.ts` checks for.
  - New `MountMonitorRow` / `OAuthProviderEntry` types are Monitor-local (only `wc-monitor.ts` uses them — `wc-live.ts`'s implementation is contextually typed against `MonitorDeps`, so it never needs to import them by name). `MountMonitorRow` was deliberately *not* named `MountRowEntry` — that would've read as a
  sibling/variant of the storage-layer `MountTableEntry` (whose own doc comment already calls persisted entries "rows"), when it's actually an unrelated, non-persisted, UI-only type (computed fresh per render, never stored).
  - `valid` is layered on top of the existing persisted types via intersection (`MountTableEntry & { valid?: boolean }`), not added to the core model — it's a live, computed-per-render value, not a fact that should ever be persisted to IndexedDB.

  ## Cross-cutting impact

  - **Floats exercised**: only floats that boot through `wc-live.ts` (standalone, electron-overlay, hosted-leader, cherry) — confirmed `getMonitorDeps`/`MonitorDeps` has no implementation in `wc-extension.ts`, so the Monitor panel (and this change) doesn't exist on the extension side-panel/detached-popout path at
  all. Not a parity gap; the Monitor surface simply isn't part of that thin-extension boot path.
  - **Other callers checked**: `MountTableEntry` (unchanged) is also consumed by `mount-recovery.ts`, `virtual-fs.ts`, and two test files — none of those are touched or affected; this PR only adds a derived, module-local type on top in `wc-monitor.ts`.
  - **Persisted state side-effects**: none — `valid` is never written to IndexedDB or any mount/account record, only computed in-memory per `fetchMonitorData()` call (initial load, 5s auto-refresh, manual "↻ Refresh").
  - **Security**: no token values are read or logged for the OAuth check; `queryPermission()` requires no user gesture and triggers no browser permission prompt.

  ## Test plan

  - [x] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
  - [x] `npm run typecheck` — clean (all 9 project configs)
  - [x] `npm run test` — 673 test files / 11255 tests passing, 3 files / 40 tests skipped, no new failures
  - [x] `npm run build`
  - [x] `npm run build -w @slicc/chrome-extension`
  - [x] **New / changed behavior is covered by a unit test**:
        `npx vitest run packages/webapp/tests/ui/wc/wc-live.test.ts packages/webapp/tests/ui/wc/wc-monitor.test.ts` — 48 tests, all passing. Covers `parseProcStatLine` (all 4 states + old-buggy-format regression), and Monitor-section dot rendering for mounts/OAuth/processes (valid/invalid/neutral cases).
  - [x] Manual smoke (CLI): `npm run dev` + open the Monitor tab, mount a local folder, revoke its permission via the browser, hit "↻ Refresh"
  - [ ] Manual smoke (extension): N/A — Monitor isn't part of the extension boot path (see Cross-cutting impact)
  - [ ] Manual smoke (Electron / Sliccstart / worker) — not yet done
  - [x] **UI change?** Screencast not yet captured — should be added before merge (Monitor dot colors are visual-only and worth a quick before/after)
  - [ ] N/A — explain below

  **Pre-existing failures** (verified against `main`, unrelated to this PR):

  `npm run test:coverage` showed 5 failures in `playwright-command.test.ts`'s "iframe integration" suite on one run (CDP/browser timing artifact from a local macOS Keychain permission prompt not being answered in time); a clean re-run passed all 673 files / 11255 tests with 0 failures. Unrelated to the
  Monitor/mount/OAuth/process changes in this PR — that test file is untouched by this diff.

  ## Documentation

  - [ ] `README.md` (user-facing behavior)
  - [ ] Relevant `CLAUDE.md` (developer / package architecture)
  - [ ] `docs/` (agent reference: tools, commands, skills, patterns)
  - [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
  - [x] No documentation changes needed — internal-only change to an existing, already-documented Monitor surface; no new commands, tools, or contracts

  ## Risk & rollback

  - Blast radius if this regresses: single surface (the read-only Monitor panel), single float family (live/standalone-boot floats only, per Cross-cutting impact above). Worst case is a wrong dot color or a thrown error caught by the existing per-section `.catch()` fallbacks in `fetchMonitorData` — no other
  panel/feature depends on this data.
  - No feature flags, kill switches, or persisted-state migrations introduced.
  - Reviewer should verify by hand (CI can't exercise real Chromium permission state): revoking a local mount's filesystem permission via the OS/browser and confirming the dot actually turns red on refresh, and an expired/logged-out OAuth account showing red.
  - Clean revert: no data migrations, no persisted-state changes — reverting this PR is a plain revert with no follow-up needed.

  ## Checklist

  - [x] Commits are focused and package-local where possible
  - [x] No hand-edited files under `dist/`
  - [x] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
  - [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs — N/A, no public contract changed (Monitor's internal `MonitorDeps`/type shapes are module-local implementation detail)
  - [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths — confirmed extension has no `MonitorDeps` implementation, so no follower/offscreen parity is required