### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -66,9 +66,9 @@
       ]
     },
     "webapp": {
-      "lines": 77,
-      "statements": 75,
-      "functions": 76,
+      "lines": 78,
+      "statements": 76,
+      "functions": 77,
       "branches": 66,
       "coverageExclude": [
         "**/node_modules/**",


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.