### PR TITLE
fix(dev-tools): ignore nested worktrees in doc refs

### DIFF
--- a/packages/dev-tools/tools/check-doc-refs.mjs
+++ b/packages/dev-tools/tools/check-doc-refs.mjs
@@ -34,7 +34,7 @@ const repoRoot = resolve(dirname(Filename), '..', '..', '..');
 /** Collect all CLAUDE.md files in the repo, excluding generated/vendor dirs. */
 function collectClaudeMds(root) {
   const results = [];
-  const skipDirs = new Set(['node_modules', '.git', 'dist', '.build']);
+  const skipDirs = new Set(['node_modules', '.git', 'dist', '.build', '.worktrees', 'worktrees']);
 
   function walk(dir) {
     let entries;

--- a/packages/dev-tools/tools/check-doc-refs.test.mjs
+++ b/packages/dev-tools/tools/check-doc-refs.test.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -366,5 +367,29 @@ describe('check-doc-refs: end-to-end over the real tree', () => {
     const { code, out } = runGuard();
     expect(code).toBe(0);
     expect(out).toMatch(/^ok: no dead references in \d+ doc files \(\d+ paths checked\)$/m);
+  });
+
+  it('ignores CLAUDE.md files in linked-worktree directories', () => {
+    const fixtureDirs = [
+      resolve(repoRoot, '.worktrees/check-doc-refs-test'),
+      resolve(repoRoot, '.claude/worktrees/check-doc-refs-test'),
+    ];
+
+    try {
+      for (const fixtureDir of fixtureDirs) {
+        mkdirSync(fixtureDir, { recursive: true });
+        writeFileSync(
+          resolve(fixtureDir, 'CLAUDE.md'),
+          'Dead reference: `packages/does-not-exist.ts`\n'
+        );
+      }
+
+      const { code, out } = runGuard();
+      expect(code, out).toBe(0);
+    } finally {
+      for (const fixtureDir of fixtureDirs) {
+        rmSync(fixtureDir, { recursive: true, force: true });
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

- exclude `.worktrees` and `worktrees` directories from recursive `CLAUDE.md` discovery
- cover both project-local `.worktrees/` and `.claude/worktrees/` layouts with an end-to-end regression test
- preserve clean-clone reference checking behavior

## Verification

- `npx vitest run --project dev-tools` — 394 tests passed
- `npm run lint:docs` — 43 files / 626 paths, zero dead references
- `npm run lint:ci` — passed (existing repository-wide Biome warnings remain non-blocking)
- pi-lens diagnostics — no issues in the two changed files

Closes #1554
