### PR TITLE
feat: proxy-side HMAC body signing via x-slicc-hmac-sign

### DIFF
--- a/packages/chrome-extension/src/fetch-proxy-shared.ts
+++ b/packages/chrome-extension/src/fetch-proxy-shared.ts
@@ -1,4 +1,9 @@
-import { base64ToUint8, type SecretsPipeline, uint8ToBase64 } from '@slicc/shared-ts';
+import {
+  base64ToUint8,
+  HMAC_SIGN_HEADER,
+  type SecretsPipeline,
+  uint8ToBase64,
+} from '@slicc/shared-ts';
 import { decodeForbiddenRequestHeaders } from '../../webapp/src/shell/proxy-headers.js';
 
 export const REQUEST_BODY_CAP = 32 * 1024 * 1024;
@@ -199,7 +204,10 @@ type PreparedRequest =
  * and unmask the body bytes. Returns `{ error }` for a forbidden secret so the
  * caller can emit a single `response-error`.
  */
-function prepareUpstreamRequest(pipeline: SecretsPipeline, msg: RequestMsg): PreparedRequest {
+async function prepareUpstreamRequest(
+  pipeline: SecretsPipeline,
+  msg: RequestMsg
+): Promise<PreparedRequest> {
   const credsResult = pipeline.extractAndUnmaskUrlCredentials(msg.url);
   if (credsResult.forbidden) {
     return {
@@ -210,6 +218,15 @@ function prepareUpstreamRequest(pipeline: SecretsPipeline, msg: RequestMsg): Pre
   const host = new URL(cleanedUrl).host;
 
   const headers: Record<string, string> = decodeForbiddenRequestHeaders(msg.headers);
+  let hmacSpec: string | undefined;
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === HMAC_SIGN_HEADER) {
+      hmacSpec = headers[key];
+      delete headers[key];
+      break;
+    }
+  }
+
   const headersResult = pipeline.unmaskHeaders(headers, host);
   if (headersResult.forbidden) {
     return {
@@ -235,6 +252,21 @@ function prepareUpstreamRequest(pipeline: SecretsPipeline, msg: RequestMsg): Pre
   let body: Uint8Array | undefined;
   if (msg.bodyBase64) {
     body = pipeline.unmaskBodyBytes(decodeBase64Bytes(msg.bodyBase64), host).bytes;
+  }
+
+  // Proxy-side HMAC body signing: the page/agent side never holds the real
+  // secret, so it asks the SW proxy to sign the (already-unmasked) body and
+  // attach the result under the header it names. See HMAC_SIGN_HEADER.
+  if (hmacSpec) {
+    const signResult = await pipeline.signHmac(hmacSpec, body ?? new Uint8Array(0), host);
+    if (signResult.forbidden) {
+      return {
+        error: `forbidden: ${signResult.forbidden.secretName} on ${signResult.forbidden.hostname}`,
+      };
+    }
+    if (signResult.headerName && signResult.signatureHex) {
+      headers[signResult.headerName] = signResult.signatureHex;
+    }
   }
 
   return { cleanedUrl, headers, body };
@@ -284,7 +316,7 @@ async function processProxyRequest(
   signal: AbortSignal
 ): Promise<void> {
   try {
-    const prepared = prepareUpstreamRequest(pipeline, msg);
+    const prepared = await prepareUpstreamRequest(pipeline, msg);
     if ('error' in prepared) {
       send(port, { type: 'response-error', error: prepared.error });
       return;

--- a/packages/chrome-extension/tests/fetch-proxy-shared.test.ts
+++ b/packages/chrome-extension/tests/fetch-proxy-shared.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'node:crypto';
 import { SecretsPipeline } from '@slicc/shared-ts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -306,6 +307,89 @@ describe('handleFetchProxyConnectionAsync — synchronous listener attach', () =
         error: expect.stringContaining('fetch-proxy init failed: storage unavailable'),
       },
     ]);
+  });
+});
+
+// Proxy-side HMAC body signing (x-slicc-hmac-sign): the page/agent side never
+// holds the real secret, so it asks the SW proxy to sign the (unmasked) body
+// and attach the result under the header it names — see HMAC_SIGN_HEADER.
+describe('handleFetchProxyConnection — x-slicc-hmac-sign', () => {
+  const HMAC_SECRET = 'job-signing-secret-abcdefghijklmnop';
+  let hmacPipeline: SecretsPipeline;
+
+  beforeEach(async () => {
+    hmacPipeline = new SecretsPipeline({
+      sessionId: 'session-fixed',
+      source: {
+        get: async () => undefined,
+        listAll: async () => [
+          { name: 'SIGNING_KEY', value: HMAC_SECRET, domains: ['worker.example.com'] },
+        ],
+      },
+    });
+    await hmacPipeline.reload();
+  });
+
+  function encodeBase64(s: string): string {
+    return btoa(s);
+  }
+
+  it('signs the request body and strips the sentinel header before fetch', async () => {
+    let fetchHeaders: Record<string, string> | undefined;
+    let fetchBody: unknown;
+    (globalThis as any).fetch = vi.fn(async (_url: string, init: any) => {
+      fetchHeaders = init.headers;
+      fetchBody = init.body;
+      return new Response('ok', { status: 200, statusText: 'OK' });
+    });
+
+    const body = JSON.stringify({ step: 3, status: 'running' });
+    const posts: any[] = [];
+    const port = makePort((m) => posts.push(m));
+    handleFetchProxyConnection(port, hmacPipeline);
+    port.fireMessage({
+      type: 'request',
+      url: 'https://worker.example.com/api/jobs/j1/events',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-slicc-hmac-sign': 'SIGNING_KEY:x-job-signature',
+      },
+      bodyBase64: encodeBase64(body),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(new TextDecoder().decode(fetchBody as Uint8Array)).toBe(body);
+    expect(fetchHeaders?.['x-slicc-hmac-sign']).toBeUndefined();
+    expect(fetchHeaders?.['x-job-signature']).toBe(
+      createHmac('sha256', HMAC_SECRET).update(body).digest('hex')
+    );
+  });
+
+  it('response-error when the signing secret is scoped to a different domain', async () => {
+    const fetchSpy = vi.fn();
+    (globalThis as any).fetch = fetchSpy;
+
+    const posts: any[] = [];
+    const port = makePort((m) => posts.push(m));
+    handleFetchProxyConnection(port, hmacPipeline);
+    port.fireMessage({
+      type: 'request',
+      url: 'https://evil.example.com/steal',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-slicc-hmac-sign': 'SIGNING_KEY:x-job-signature',
+      },
+      bodyBase64: encodeBase64('{}'),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const errorPost = posts.find((p) => p.type === 'response-error');
+    expect(errorPost?.error).toContain('forbidden');
+    expect(errorPost?.error).toContain('SIGNING_KEY');
+    expect(errorPost?.error).toContain('evil.example.com');
   });
 });
 

--- a/packages/node-server/src/fetch-proxy-headers.ts
+++ b/packages/node-server/src/fetch-proxy-headers.ts
@@ -30,6 +30,10 @@ export const FETCH_PROXY_SKIP_HEADERS: ReadonlySet<string> = new Set([
   // Kept in sync with `BRIDGE_TOKEN_HEADER` in `bridge-security.ts`
   // (lowercased because Node lowercases incoming request header keys).
   'x-bridge-token',
+  // Proxy-side HMAC body-signing directive (`HMAC_SIGN_HEADER` in
+  // @slicc/shared-ts secrets-pipeline.ts) — consumed by the route handler
+  // to compute and attach a real signature header; never forwarded as-is.
+  'x-slicc-hmac-sign',
 ]);
 
 /**

--- a/packages/node-server/src/routes/fetch-proxy.ts
+++ b/packages/node-server/src/routes/fetch-proxy.ts
@@ -1,5 +1,6 @@
 import { Readable, Transform } from 'node:stream';
 import { StringDecoder } from 'node:string_decoder';
+import { HMAC_SIGN_HEADER } from '@slicc/shared-ts';
 import type { Express, Request, Response } from 'express';
 import {
   FETCH_PROXY_SKIP_HEADERS,
@@ -141,6 +142,29 @@ function injectRequestSecrets(
     headers.authorization = credsResult.syntheticAuthorization;
   }
   return { cleanedUrl: credsResult.url };
+}
+
+/**
+ * Apply the `x-slicc-hmac-sign` directive, if present: sign `body` with the
+ * named secret's real value and attach the hex result under the header the
+ * client requested. Mutates `headers` and always removes the sentinel
+ * (already stripped from `headers` by `buildForwardHeaders`'s skip-list;
+ * this only needs to read it off the raw request).
+ */
+async function applyHmacSigning(
+  secretProxy: SecretProxyManager,
+  headers: Record<string, string>,
+  hmacSpec: string | undefined,
+  body: Buffer | undefined,
+  targetHostname: string
+): Promise<{ forbidden: ForbiddenSecret } | undefined> {
+  if (!hmacSpec) return undefined;
+  const signResult = await secretProxy.signHmac(hmacSpec, body ?? Buffer.alloc(0), targetHostname);
+  if (signResult.forbidden) return { forbidden: signResult.forbidden };
+  if (signResult.headerName && signResult.signatureHex) {
+    headers[signResult.headerName] = signResult.signatureHex;
+  }
+  return undefined;
 }
 
 /**
@@ -334,12 +358,30 @@ export function registerFetchProxyRoute(app: Express, deps: FetchProxyDeps): voi
         return;
       }
 
-      if (Object.keys(headers).length > 0) fetchInit.headers = headers;
+      let body: Buffer | undefined;
       if (rawBody.length > 0 && !['GET', 'HEAD'].includes(req.method)) {
-        const body = unmaskRequestBody(secretProxy, headers, rawBody, targetHostname);
+        body = unmaskRequestBody(secretProxy, headers, rawBody, targetHostname);
         // Buffer extends Uint8Array which is a valid fetch body at runtime.
         fetchInit.body = body as unknown as RequestInit['body'];
       }
+
+      // Proxy-side HMAC body signing: the client can't compute this itself
+      // (it only ever sees a masked secret token), so it asks the proxy to
+      // sign the body with the real value and attach the result as a header.
+      const hmacSpec = firstHeaderValue(req.headers[HMAC_SIGN_HEADER]);
+      const signing = await applyHmacSigning(secretProxy, headers, hmacSpec, body, targetHostname);
+      if (signing) {
+        logger.warn(
+          `[fetch-proxy] ${req.method} ${targetUrl} → 403 (secret "${signing.forbidden.secretName}" not allowed for "${signing.forbidden.hostname}")`
+        );
+        res.setHeader('X-Proxy-Error', '1');
+        res.status(403).json({
+          error: `Secret "${signing.forbidden.secretName}" is not allowed for domain "${signing.forbidden.hostname}"`,
+        });
+        return;
+      }
+
+      if (Object.keys(headers).length > 0) fetchInit.headers = headers;
 
       // Propagate client disconnect to the upstream request so long-lived
       // streams (LLM SSE completions) are torn down promptly. Listen on

--- a/packages/node-server/src/secrets/proxy-manager.ts
+++ b/packages/node-server/src/secrets/proxy-manager.ts
@@ -114,6 +114,18 @@ export class SecretProxyManager {
     return this.pipeline.unmaskHeaders(headers, targetHostname);
   }
 
+  signHmac(
+    spec: string,
+    body: Uint8Array,
+    targetHostname: string
+  ): Promise<{
+    headerName?: string;
+    signatureHex?: string;
+    forbidden?: { secretName: string; hostname: string };
+  }> {
+    return this.pipeline.signHmac(spec, body, targetHostname);
+  }
+
   extractAndUnmaskUrlCredentials(rawUrl: string) {
     return this.pipeline.extractAndUnmaskUrlCredentials(rawUrl);
   }

--- a/packages/node-server/tests/routes/fetch-proxy.test.ts
+++ b/packages/node-server/tests/routes/fetch-proxy.test.ts
@@ -4,7 +4,7 @@
  * secret-injection (request) and secret-scrub (response) paths are exercised
  * end-to-end with a real SecretProxyManager.
  */
-import { randomUUID } from 'node:crypto';
+import { createHmac, randomUUID } from 'node:crypto';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer, type Server } from 'node:http';
 import { tmpdir } from 'node:os';
@@ -16,6 +16,11 @@ import { EnvSecretStore } from '../../src/secrets/env-secret-store.js';
 import { SecretProxyManager } from '../../src/secrets/proxy-manager.js';
 
 const REAL_TOKEN = 'ghp_realtoken123456789abcdefghij';
+const HMAC_SECRET = 'job-signing-secret-abcdefghijklmnop';
+
+function expectedSignature(secret: string, body: string): string {
+  return createHmac('sha256', secret).update(body).digest('hex');
+}
 
 type UpstreamHandler = (
   req: import('node:http').IncomingMessage,
@@ -37,7 +42,12 @@ function tempSecrets(domains = '127.0.0.1'): string {
   const file = join(tmpDir, 'secrets.env');
   writeFileSync(
     file,
-    [`GITHUB_TOKEN=${REAL_TOKEN}`, `GITHUB_TOKEN_DOMAINS=${domains}`].join('\n'),
+    [
+      `GITHUB_TOKEN=${REAL_TOKEN}`,
+      `GITHUB_TOKEN_DOMAINS=${domains}`,
+      `SIGNING_KEY=${HMAC_SECRET}`,
+      `SIGNING_KEY_DOMAINS=${domains}`,
+    ].join('\n'),
     {
       mode: 0o600,
     }
@@ -138,6 +148,50 @@ describe('registerFetchProxyRoute', () => {
     expect(res.status).toBe(200);
     expect(received).toContain(REAL_TOKEN);
     expect(received).not.toContain(masked);
+  });
+
+  it('signs the request body via x-slicc-hmac-sign and strips the sentinel header', async () => {
+    let receivedBody = '';
+    let receivedHeaders: import('node:http').IncomingHttpHeaders = {};
+    await setup((req, res) => {
+      receivedHeaders = req.headers;
+      const chunks: Buffer[] = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        receivedBody = Buffer.concat(chunks).toString('utf-8');
+        res.end('done');
+      });
+    });
+    const body = JSON.stringify({ step: 3, status: 'running' });
+    const res = await fetch(`${proxyBase}/api/fetch-proxy`, {
+      method: 'POST',
+      headers: {
+        'x-target-url': upstreamUrl,
+        'content-type': 'application/json',
+        'x-slicc-hmac-sign': 'SIGNING_KEY:x-job-signature',
+      },
+      body,
+    });
+    expect(res.status).toBe(200);
+    expect(receivedBody).toBe(body);
+    expect(receivedHeaders['x-job-signature']).toBe(expectedSignature(HMAC_SECRET, body));
+    expect(receivedHeaders['x-slicc-hmac-sign']).toBeUndefined();
+  });
+
+  it('returns 403 when the hmac-sign secret is scoped to a different domain', async () => {
+    // SIGNING_KEY scoped to api.github.com only; the request targets 127.0.0.1.
+    await setup((_req, res) => res.end('should-not-reach'), 'api.github.com');
+    const res = await fetch(`${proxyBase}/api/fetch-proxy`, {
+      method: 'POST',
+      headers: {
+        'x-target-url': upstreamUrl,
+        'content-type': 'application/json',
+        'x-slicc-hmac-sign': 'SIGNING_KEY:x-job-signature',
+      },
+      body: '{}',
+    });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('not allowed for domain');
   });
 
   it('scrubs real secret values out of the streamed response body', async () => {

--- a/packages/shared-ts/src/secret-masking.ts
+++ b/packages/shared-ts/src/secret-masking.ts
@@ -62,6 +62,26 @@ function toHex(bytes: Uint8Array): string {
     .join('');
 }
 
+/**
+ * HMAC-SHA256 over raw bytes, hex-encoded. Used by the fetch proxy's
+ * body-signing path (`SecretsPipeline.signHmac`) — the counterpart of
+ * `mask()`'s masking HMAC, but keyed by the real secret value and applied
+ * to an arbitrary request body instead of the secret itself.
+ */
+type SubtleData = ArrayBufferView<ArrayBuffer>;
+
+export async function hmacSha256Hex(key: string, message: Uint8Array): Promise<string> {
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(key),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', cryptoKey, message as SubtleData);
+  return toHex(new Uint8Array(sig));
+}
+
 // ---------- Public API ----------
 
 /**

--- a/packages/shared-ts/src/secrets-pipeline.ts
+++ b/packages/shared-ts/src/secrets-pipeline.ts
@@ -1,6 +1,7 @@
 import {
   buildScrubber,
   mask as cryptoMask,
+  hmacSha256Hex,
   MIN_MASKABLE_SECRET_LENGTH,
   matchesDomains,
   type SecretPair,
@@ -38,6 +39,15 @@ function replaceAllBytes(
   return new Uint8Array(out);
 }
 
+/**
+ * Sentinel request header a client sets to ask the fetch proxy to sign the
+ * request body: `x-slicc-hmac-sign: <secretName>:<targetHeader>`. The proxy
+ * computes `HMAC-SHA256(body, secretName's real value)`, attaches the hex
+ * result under `targetHeader`, and strips this header before forwarding —
+ * see `SecretsPipeline.signHmac`.
+ */
+export const HMAC_SIGN_HEADER = 'x-slicc-hmac-sign';
+
 export interface FetchProxySecretSource {
   get(name: string): Promise<string | undefined>;
   listAll(): Promise<{ name: string; value: string; domains: string[] }[]>;
@@ -61,6 +71,13 @@ export interface UnmaskResult {
 }
 
 export interface UnmaskHeadersResult {
+  forbidden?: ForbiddenInfo;
+}
+
+export interface HmacSignResult {
+  /** Header the computed signature should be attached under. Absent when `spec` was malformed or named an unknown secret — callers should leave the request unsigned in that case. */
+  headerName?: string;
+  signatureHex?: string;
   forbidden?: ForbiddenInfo;
 }
 
@@ -124,6 +141,11 @@ export class SecretsPipeline {
   // the actual secret, while the scrubber's masking-pattern set stays
   // collision-free for short inputs. Keyed by name (one entry per secret).
   private consumableShortSecrets = new Map<string, MaskedSecret>();
+  // Indexes every secret (maskable or short) by name, for lookups that start
+  // from a secret name rather than a masked value found in text — currently
+  // only `signHmac`, which needs the real value of a *named* secret to
+  // compute a body signature the agent could never derive from a masked token.
+  private byName = new Map<string, MaskedSecret>();
   private scrubber: (text: string) => string = (t) => t;
 
   constructor(opts: SecretsPipelineOpts) {
@@ -172,6 +194,10 @@ export class SecretsPipeline {
     }
     this.maskedToSecret = next;
     this.consumableShortSecrets = nextShort;
+    const nextByName = new Map<string, MaskedSecret>();
+    for (const ms of next.values()) nextByName.set(ms.name, ms);
+    for (const ms of nextShort.values()) nextByName.set(ms.name, ms);
+    this.byName = nextByName;
     const pairs: SecretPair[] = Array.from(next.values()).map((ms) => ({
       realValue: ms.realValue,
       maskedValue: ms.maskedValue,
@@ -315,6 +341,34 @@ export class SecretsPipeline {
       headers[key] = text;
     }
     return {};
+  }
+
+  /**
+   * Resolve an `x-slicc-hmac-sign: <secretName>:<targetHeader>` directive
+   * against the (already-unmasked) request body. The real secret value is
+   * looked up by name, domain-checked exactly like `unmaskHeaders`, and used
+   * to compute `HMAC-SHA256(body, realValue)` — the caller attaches the hex
+   * result under `targetHeader` and forwards. The real value never leaves
+   * this method.
+   *
+   * Returns `{}` (no-op) for a malformed spec or an unknown secret name —
+   * the fetch proxy is expected to treat that as "nothing to sign", not a
+   * hard error, since the header may have been set for a different purpose.
+   */
+  async signHmac(spec: string, body: Uint8Array, hostname: string): Promise<HmacSignResult> {
+    const sep = spec.indexOf(':');
+    if (sep < 0) return {};
+    const secretName = spec.slice(0, sep).trim();
+    const headerName = spec.slice(sep + 1).trim();
+    if (!secretName || !headerName) return {};
+
+    const ms = this.byName.get(secretName);
+    if (!ms) return {};
+    if (!matchesDomains(hostname, ms.domains)) {
+      return { forbidden: { secretName: ms.name, hostname } };
+    }
+    const signatureHex = await hmacSha256Hex(ms.realValue, body);
+    return { headerName, signatureHex };
   }
 
   unmaskBodyBytes(body: Uint8Array, hostname: string): { bytes: Uint8Array } {

--- a/packages/shared-ts/src/secrets-pipeline.ts
+++ b/packages/shared-ts/src/secrets-pipeline.ts
@@ -194,9 +194,21 @@ export class SecretsPipeline {
     }
     this.maskedToSecret = next;
     this.consumableShortSecrets = nextShort;
+    // Invariant: a secret name is unique across {next, nextShort} — reload()
+    // partitions each source secret into exactly one of the two maps, so a
+    // collision here can only mean a future storage change broke that
+    // partitioning. Warn rather than silently letting the second write win,
+    // since `signHmac` trusts this index to resolve to the right real value.
     const nextByName = new Map<string, MaskedSecret>();
     for (const ms of next.values()) nextByName.set(ms.name, ms);
-    for (const ms of nextShort.values()) nextByName.set(ms.name, ms);
+    for (const ms of nextShort.values()) {
+      if (nextByName.has(ms.name)) {
+        console.warn(
+          `[slicc:secrets] secret "${ms.name}" registered as both maskable and short-consumable`
+        );
+      }
+      nextByName.set(ms.name, ms);
+    }
     this.byName = nextByName;
     const pairs: SecretPair[] = Array.from(next.values()).map((ms) => ({
       realValue: ms.realValue,
@@ -363,7 +375,13 @@ export class SecretsPipeline {
     if (!secretName || !headerName) return {};
 
     const ms = this.byName.get(secretName);
-    if (!ms) return {};
+    if (!ms) {
+      // Log-only, never a hard error: a typo'd name would otherwise fail
+      // silently (request goes out unsigned, upstream just 401s with no clue
+      // why). Mirrors the too-short-secret warning above — never logs a value.
+      console.warn(`[slicc:secrets] signHmac: no secret named "${secretName}"`);
+      return {};
+    }
     if (!matchesDomains(hostname, ms.domains)) {
       return { forbidden: { secretName: ms.name, hostname } };
     }

--- a/packages/shared-ts/tests/secrets-pipeline.test.ts
+++ b/packages/shared-ts/tests/secrets-pipeline.test.ts
@@ -370,6 +370,25 @@ describe('SecretsPipeline minimum-length guard', () => {
     expect(msg).toContain('SHORT_TOKEN');
     expect(msg).not.toContain('12345678');
   });
+
+  it('warns when a source returns two entries with the same name split across the maskable/short partition', async () => {
+    const pipeline = new SecretsPipeline({
+      sessionId: 'session-fixed',
+      // A well-behaved source never does this — reload()'s "each name once"
+      // partitioning assumes it — but signHmac's byName lookup is
+      // load-bearing enough on that assumption to warn loudly if it breaks.
+      source: source([
+        { name: 'DUP', value: 'short12', domains: ['api.github.com'] }, // 7 chars, short
+        { name: 'DUP', value: 'a-very-long-real-value-123', domains: ['api.github.com'] }, // maskable
+      ]),
+    });
+    await pipeline.reload();
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    const collisionMsg = String(warnSpy.mock.calls[1][0]);
+    expect(collisionMsg).toContain('DUP');
+    expect(collisionMsg).toContain('both maskable and short-consumable');
+  });
 });
 
 describe('SecretsPipeline.signHmac', () => {
@@ -429,7 +448,8 @@ describe('SecretsPipeline.signHmac', () => {
     expect(result.signatureHex).toBeUndefined();
   });
 
-  it('is a no-op for an unknown secret name', async () => {
+  it('is a no-op for an unknown secret name, and warns (naming the secret, never a value)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const body = new TextEncoder().encode('{}');
     const result = await pipeline.signHmac(
       'NO_SUCH_SECRET:x-job-signature',
@@ -437,6 +457,9 @@ describe('SecretsPipeline.signHmac', () => {
       'worker.example.com'
     );
     expect(result).toEqual({});
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('NO_SUCH_SECRET');
+    warnSpy.mockRestore();
   });
 
   it('is a no-op for a malformed spec (missing ":")', async () => {

--- a/packages/shared-ts/tests/secrets-pipeline.test.ts
+++ b/packages/shared-ts/tests/secrets-pipeline.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { MIN_MASKABLE_SECRET_LENGTH } from '../src/secret-masking.js';
+import { hmacSha256Hex, MIN_MASKABLE_SECRET_LENGTH } from '../src/secret-masking.js';
 import {
   type FetchProxySecretSource,
   type ForbiddenInfo,
@@ -369,5 +369,79 @@ describe('SecretsPipeline minimum-length guard', () => {
     const msg = String(warnSpy.mock.calls[0][0]);
     expect(msg).toContain('SHORT_TOKEN');
     expect(msg).not.toContain('12345678');
+  });
+});
+
+describe('SecretsPipeline.signHmac', () => {
+  let pipeline: SecretsPipeline;
+
+  beforeEach(async () => {
+    pipeline = new SecretsPipeline({
+      sessionId: 'session-fixed',
+      source: source([
+        {
+          name: 'SIGNING_KEY',
+          value: 'job-signing-secret-value',
+          domains: ['worker.example.com'],
+        },
+      ]),
+    });
+    await pipeline.reload();
+  });
+
+  it('computes HMAC-SHA256(body, realValue) hex and names the target header', async () => {
+    const body = new TextEncoder().encode('{"step":3,"status":"running"}');
+    const expected = await hmacSha256Hex('job-signing-secret-value', body);
+
+    const result = await pipeline.signHmac(
+      'SIGNING_KEY:x-job-signature',
+      body,
+      'worker.example.com'
+    );
+    expect(result.forbidden).toBeUndefined();
+    expect(result.headerName).toBe('x-job-signature');
+    expect(result.signatureHex).toBe(expected);
+  });
+
+  it('never derives the signature from the masked value — same body signs differently for a different real value', async () => {
+    const other = new SecretsPipeline({
+      sessionId: 'session-fixed',
+      source: source([
+        {
+          name: 'SIGNING_KEY',
+          value: 'a-totally-different-secret',
+          domains: ['worker.example.com'],
+        },
+      ]),
+    });
+    await other.reload();
+
+    const body = new TextEncoder().encode('{"step":3,"status":"running"}');
+    const a = await pipeline.signHmac('SIGNING_KEY:x-job-signature', body, 'worker.example.com');
+    const b = await other.signHmac('SIGNING_KEY:x-job-signature', body, 'worker.example.com');
+    expect(a.signatureHex).not.toBe(b.signatureHex);
+  });
+
+  it("returns forbidden for a target host outside the secret's domain scope", async () => {
+    const body = new TextEncoder().encode('{}');
+    const result = await pipeline.signHmac('SIGNING_KEY:x-job-signature', body, 'evil.example.com');
+    expect(result.forbidden).toEqual({ secretName: 'SIGNING_KEY', hostname: 'evil.example.com' });
+    expect(result.signatureHex).toBeUndefined();
+  });
+
+  it('is a no-op for an unknown secret name', async () => {
+    const body = new TextEncoder().encode('{}');
+    const result = await pipeline.signHmac(
+      'NO_SUCH_SECRET:x-job-signature',
+      body,
+      'worker.example.com'
+    );
+    expect(result).toEqual({});
+  });
+
+  it('is a no-op for a malformed spec (missing ":")', async () => {
+    const body = new TextEncoder().encode('{}');
+    const result = await pipeline.signHmac('SIGNING_KEY', body, 'worker.example.com');
+    expect(result).toEqual({});
   });
 });

--- a/packages/swift-server/Sources/Keychain/SecretInjector.swift
+++ b/packages/swift-server/Sources/Keychain/SecretInjector.swift
@@ -70,6 +70,15 @@ public final class SecretInjector: @unchecked Sendable {
         let forbidden: ForbiddenInfo?
     }
 
+    /// Result of `signHmac`. Mirrors TS `HmacSignResult`. `headerName` /
+    /// `signatureHex` are both nil for a malformed spec or unknown secret
+    /// name — callers should leave the request unsigned in that case.
+    struct HmacSignResult: Sendable, Equatable {
+        let headerName: String?
+        let signatureHex: String?
+        let forbidden: ForbiddenInfo?
+    }
+
     /// The session ID used for masking. Kept stable across reloads.
     private let sessionId: String?
 
@@ -567,6 +576,45 @@ public final class SecretInjector: @unchecked Sendable {
             out = replaceAllBytes(in: out, needle: needle, replacement: replacement)
         }
         return out
+    }
+
+    /// Resolve an `x-slicc-hmac-sign: <secretName>:<targetHeader>` directive
+    /// against the (already-unmasked) request body. Mirrors TS
+    /// `SecretsPipeline.signHmac` — looks up the real value by name,
+    /// domain-checks it exactly like `inject`, and returns
+    /// `HMAC-SHA256(body, realValue)` hex for the caller to attach under
+    /// `targetHeader`. The real value never leaves this method.
+    ///
+    /// Returns a result with nil `headerName`/`signatureHex` (no `forbidden`)
+    /// for a malformed spec or an unknown secret name — the fetch proxy is
+    /// expected to treat that as "nothing to sign", not a hard error, since
+    /// the header may have been set for a different purpose. An unknown name
+    /// is logged (without the value) so a typo doesn't fail silently.
+    func signHmac(spec: String, body: [UInt8], targetHostname: String) -> HmacSignResult {
+        guard let sep = spec.firstIndex(of: ":") else {
+            return HmacSignResult(headerName: nil, signatureHex: nil, forbidden: nil)
+        }
+        let secretName = String(spec[spec.startIndex..<sep]).trimmingCharacters(in: .whitespaces)
+        let headerName = String(spec[spec.index(after: sep)...]).trimmingCharacters(in: .whitespaces)
+        guard !secretName.isEmpty, !headerName.isEmpty else {
+            return HmacSignResult(headerName: nil, signatureHex: nil, forbidden: nil)
+        }
+
+        guard let secret = secrets.first(where: { $0.name == secretName }) else {
+            FileHandle.standardError.write(Data(
+                "[slicc:secrets] signHmac: no secret named \"\(secretName)\"\n".utf8
+            ))
+            return HmacSignResult(headerName: nil, signatureHex: nil, forbidden: nil)
+        }
+        guard isAllowedDomain(patterns: secret.domains, hostname: targetHostname) else {
+            return HmacSignResult(
+                headerName: nil,
+                signatureHex: nil,
+                forbidden: ForbiddenInfo(secretName: secret.name, hostname: targetHostname)
+            )
+        }
+        let signatureHex = hmacSHA256Hex(key: secret.realValue, message: body)
+        return HmacSignResult(headerName: headerName, signatureHex: signatureHex, forbidden: nil)
     }
 
     /// Mirrors TS `SecretsPipeline.scrubResponseBytes`.

--- a/packages/swift-server/Sources/Keychain/SecretMasking.swift
+++ b/packages/swift-server/Sources/Keychain/SecretMasking.swift
@@ -53,6 +53,23 @@ private func toHex(_ bytes: [UInt8]) -> String {
     bytes.map { String(format: "%02x", $0) }.joined()
 }
 
+/// HMAC-SHA256 over raw bytes, hex-encoded. Mirrors TS's `hmacSha256Hex` in
+/// `packages/shared-ts/src/secret-masking.ts` — the counterpart of `mask()`'s
+/// masking HMAC, but keyed by the real secret value and applied to an
+/// arbitrary request body instead of the secret itself. Used by
+/// `SecretInjector.signHmac`.
+public func hmacSHA256Hex(key: String, message: [UInt8]) -> String {
+    let keyData = Array(key.utf8)
+    var result = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+    CCHmac(
+        CCHmacAlgorithm(kCCHmacAlgSHA256),
+        keyData, keyData.count,
+        message, message.count,
+        &result
+    )
+    return toHex(result)
+}
+
 // MARK: - Public API
 
 /// Produce a deterministic, format-preserving masked value.

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -17,7 +17,12 @@ private let htmlContentTypeHeaderValue = "text/html; charset=utf-8"
 private let proxyHopByHopHeaders: Set<String> = [
     "host", "connection", "x-target-url", "content-length", "transfer-encoding",
     "x-proxy-cookie", "x-proxy-origin", "x-proxy-referer",
+    // Proxy-side HMAC body-signing directive (mirrors `HMAC_SIGN_HEADER` in
+    // @slicc/shared-ts secrets-pipeline.ts) — consumed by the handler below
+    // to compute and attach a real signature header; never forwarded as-is.
+    "x-slicc-hmac-sign",
 ]
+private let hmacSignHeader = HTTPField.Name("X-Slicc-Hmac-Sign")!
 private let proxyBlockedResponseHeaders: Set<String> = [
     "transfer-encoding", "content-encoding", "www-authenticate",
     "set-cookie",
@@ -484,6 +489,26 @@ func registerAPIRoutes(
                         if replaced != bodyData {
                             rawBody = ByteBuffer(data: replaced)
                         }
+                    }
+                }
+
+                // Proxy-side HMAC body signing: the client can't compute this
+                // itself (it only ever sees a masked secret token), so it asks
+                // the proxy to sign the (already-injected) body with the real
+                // value and attach the result under the header it names.
+                if let hmacSpec = injectedHeaders[hmacSignHeader] {
+                    injectedHeaders[hmacSignHeader] = nil
+                    let bodyBytes = rawBody.getBytes(at: rawBody.readerIndex, length: rawBody.readableBytes) ?? []
+                    let signResult = secretInjector.signHmac(spec: hmacSpec, body: bodyBytes, targetHostname: targetHostname)
+                    if let forbidden = signResult.forbidden {
+                        return try proxyErrorResponse(
+                            status: .forbidden,
+                            message: "Secret \(forbidden.secretName) is not allowed for domain \(forbidden.hostname)"
+                        )
+                    }
+                    if let headerName = signResult.headerName, let signatureHex = signResult.signatureHex,
+                       let field = HTTPField.Name(headerName) {
+                        injectedHeaders[field] = signatureHex
                     }
                 }
 

--- a/packages/swift-server/Tests/APIRoutesTests.swift
+++ b/packages/swift-server/Tests/APIRoutesTests.swift
@@ -1,4 +1,5 @@
 import AsyncHTTPClient
+import CommonCrypto
 import Foundation
 import Hummingbird
 import HummingbirdTesting
@@ -7,6 +8,17 @@ import NIOCore
 import NIOPosix
 import XCTest
 @testable import slicc_server
+
+/// Independent HMAC-SHA256 hex reference for `x-slicc-hmac-sign` assertions —
+/// deliberately not `hmacSHA256Hex` from `SecretMasking.swift` so the test
+/// isn't just checking production code against itself.
+private func referenceHmacSHA256Hex(key: String, message: String) -> String {
+    let keyData = Array(key.utf8)
+    let messageData = Array(message.utf8)
+    var result = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+    CCHmac(CCHmacAlgorithm(kCCHmacAlgSHA256), keyData, keyData.count, messageData, messageData.count, &result)
+    return result.map { String(format: "%02x", $0) }.joined()
+}
 
 final class APIRoutesTests: XCTestCase {
     func testStatusNamesTheNativeServer() async throws {
@@ -460,6 +472,113 @@ final class APIRoutesTests: XCTestCase {
         try await eventLoopGroup.shutdownGracefully()
     }
 
+    /// `x-slicc-hmac-sign: <secretName>:<targetHeader>` — the proxy signs the
+    /// (already-injected) body with the named secret's real value and attaches
+    /// the hex result under the target header, stripping the sentinel before
+    /// forwarding. Mirrors node-server's / chrome-extension's coverage of the
+    /// same directive.
+    func testFetchProxySignsRequestBodyViaHmacSentinelAndStripsSentinel() async throws {
+        let hmacSecret = "job-signing-secret-abcdefghijklmnop"
+        let injector = SecretInjector(secrets: [
+            .init(name: "SIGNING_KEY", realValue: hmacSecret, maskedValue: "masked-signing-key", domains: ["localhost"]),
+        ])
+        let captured = HeaderCaptureBox()
+
+        let upstreamRouter = Router()
+        upstreamRouter.post("/upstream") { request, _ in
+            let body = try await request.body.collect(upTo: 1 * 1024 * 1024)
+            await captured.record(
+                body: String(buffer: body),
+                jobSignature: request.headers[HTTPField.Name("x-job-signature")!],
+                sentinelStillPresent: request.headers[HTTPField.Name("x-slicc-hmac-sign")!] != nil
+            )
+            return Response(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "done")))
+        }
+        let upstreamApp = Application(responder: upstreamRouter.buildResponder())
+
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
+        let body = #"{"step":3,"status":"running"}"#
+
+        do {
+            try await upstreamApp.test(.live) { upstreamClient in
+                let upstreamPort = try XCTUnwrap(upstreamClient.port, "live test framework must expose a port")
+                let proxyRouter = Router()
+                registerAPIRoutes(
+                    router: proxyRouter,
+                    lickSystem: LickSystem(),
+                    config: self.makeConfig(),
+                    httpClient: httpClient,
+                    secretInjector: injector
+                )
+                let proxyApp = Application(responder: proxyRouter.buildResponder())
+
+                try await proxyApp.test(.router) { proxyClient in
+                    try await proxyClient.execute(
+                        uri: "/api/fetch-proxy",
+                        method: .post,
+                        headers: [
+                            HTTPField.Name("X-Target-URL")!: "http://localhost:\(upstreamPort)/upstream",
+                            .contentType: "application/json",
+                            HTTPField.Name("x-slicc-hmac-sign")!: "SIGNING_KEY:x-job-signature",
+                        ],
+                        body: ByteBuffer(string: body)
+                    ) { response in
+                        XCTAssertEqual(response.status, .ok)
+                    }
+                }
+            }
+        } catch {
+            try? await httpClient.shutdown()
+            try? await eventLoopGroup.shutdownGracefully()
+            throw error
+        }
+        try await httpClient.shutdown()
+        try await eventLoopGroup.shutdownGracefully()
+
+        let snapshot = await captured.snapshot()
+        XCTAssertEqual(snapshot.body, body, "body must reach upstream unchanged")
+        XCTAssertEqual(
+            snapshot.jobSignature,
+            referenceHmacSHA256Hex(key: hmacSecret, message: body),
+            "x-job-signature must equal HMAC-SHA256(body, real secret value)"
+        )
+        XCTAssertFalse(snapshot.sentinelStillPresent, "x-slicc-hmac-sign must never reach upstream")
+    }
+
+    /// Domain-scoped exactly like `unmaskHeaders` — a signing secret scoped
+    /// to a different domain than the target must 403, not silently sign.
+    func testFetchProxySignHmacReturns403ForOutOfScopeDomain() async throws {
+        let injector = SecretInjector(secrets: [
+            .init(name: "SIGNING_KEY", realValue: "job-signing-secret-value", maskedValue: "masked-signing-key", domains: ["api.github.com"]),
+        ])
+        try await self.withHTTPClient { httpClient in
+            let router = Router()
+            registerAPIRoutes(
+                router: router,
+                lickSystem: LickSystem(),
+                config: self.makeConfig(),
+                httpClient: httpClient,
+                secretInjector: injector
+            )
+            let app = Application(responder: router.buildResponder())
+            try await app.test(.router) { client in
+                try await client.execute(
+                    uri: "/api/fetch-proxy",
+                    method: .post,
+                    headers: [
+                        HTTPField.Name("X-Target-URL")!: "http://localhost:9/upstream",
+                        .contentType: "application/json",
+                        HTTPField.Name("x-slicc-hmac-sign")!: "SIGNING_KEY:x-job-signature",
+                    ],
+                    body: ByteBuffer(string: "{}")
+                ) { response in
+                    XCTAssertEqual(response.status, .forbidden)
+                }
+            }
+        }
+    }
+
     /// Round-trip helper: stands up a live Hummingbird server hosting an
     /// upstream stub route, registers the API routes (including
     /// `/api/fetch-proxy`) on a separate router used in `.router` (in-memory)
@@ -706,5 +825,29 @@ private actor CapturedRequestBox {
 
     func snapshot() -> Snapshot {
         .init(method: self.method, davHeader: self.davHeader, body: self.body)
+    }
+}
+
+/// Thread-safe holder for upstream-side observations captured by the
+/// `x-slicc-hmac-sign` round-trip test. Same rationale as `CapturedRequestBox`.
+private actor HeaderCaptureBox {
+    struct Snapshot {
+        let body: String?
+        let jobSignature: String?
+        let sentinelStillPresent: Bool
+    }
+
+    private var body: String?
+    private var jobSignature: String?
+    private var sentinelStillPresent = false
+
+    func record(body: String, jobSignature: String?, sentinelStillPresent: Bool) {
+        self.body = body
+        self.jobSignature = jobSignature
+        self.sentinelStillPresent = sentinelStillPresent
+    }
+
+    func snapshot() -> Snapshot {
+        .init(body: self.body, jobSignature: self.jobSignature, sentinelStillPresent: self.sentinelStillPresent)
     }
 }

--- a/packages/swift-server/Tests/SecretInjectorTests.swift
+++ b/packages/swift-server/Tests/SecretInjectorTests.swift
@@ -513,4 +513,55 @@ final class SecretInjectorTests: XCTestCase {
                        "saw env-file-realLong here",
                        "Overridden env-file real value must not be scrubbed")
     }
+
+    // MARK: - signHmac()
+
+    func testSignHmacComputesSignatureAndNamesTargetHeader() {
+        let injector = makeInjector(secrets: [
+            makeSecret(name: "SIGNING_KEY", realValue: "job-signing-secret-value", domains: ["worker.example.com"]),
+        ])
+        let body = Array("{\"step\":3,\"status\":\"running\"}".utf8)
+        let expected = hmacSHA256Hex(key: "job-signing-secret-value", message: body)
+
+        let result = injector.signHmac(spec: "SIGNING_KEY:x-job-signature", body: body, targetHostname: "worker.example.com")
+        XCTAssertNil(result.forbidden)
+        XCTAssertEqual(result.headerName, "x-job-signature")
+        XCTAssertEqual(result.signatureHex, expected)
+    }
+
+    func testSignHmacDiffersByRealValueNotJustMaskedValue() {
+        let body = Array("same body".utf8)
+        let a = makeInjector(secrets: [
+            makeSecret(name: "SIGNING_KEY", realValue: "real-value-one", domains: ["worker.example.com"]),
+        ]).signHmac(spec: "SIGNING_KEY:x-job-signature", body: body, targetHostname: "worker.example.com")
+        let b = makeInjector(secrets: [
+            makeSecret(name: "SIGNING_KEY", realValue: "real-value-two", domains: ["worker.example.com"]),
+        ]).signHmac(spec: "SIGNING_KEY:x-job-signature", body: body, targetHostname: "worker.example.com")
+        XCTAssertNotEqual(a.signatureHex, b.signatureHex)
+    }
+
+    func testSignHmacReturnsForbiddenForOutOfScopeDomain() {
+        let injector = makeInjector(secrets: [
+            makeSecret(name: "SIGNING_KEY", realValue: "job-signing-secret-value", domains: ["worker.example.com"]),
+        ])
+        let result = injector.signHmac(spec: "SIGNING_KEY:x-job-signature", body: [], targetHostname: "evil.example.com")
+        XCTAssertEqual(result.forbidden, SecretInjector.ForbiddenInfo(secretName: "SIGNING_KEY", hostname: "evil.example.com"))
+        XCTAssertNil(result.signatureHex)
+    }
+
+    func testSignHmacIsNoOpForUnknownSecretName() {
+        let injector = makeInjector(secrets: [makeSecret(name: "SIGNING_KEY")])
+        let result = injector.signHmac(spec: "NO_SUCH_SECRET:x-job-signature", body: [], targetHostname: "worker.example.com")
+        XCTAssertNil(result.headerName)
+        XCTAssertNil(result.signatureHex)
+        XCTAssertNil(result.forbidden)
+    }
+
+    func testSignHmacIsNoOpForMalformedSpec() {
+        let injector = makeInjector(secrets: [makeSecret(name: "SIGNING_KEY")])
+        let result = injector.signHmac(spec: "SIGNING_KEY", body: [], targetHostname: "worker.example.com")
+        XCTAssertNil(result.headerName)
+        XCTAssertNil(result.signatureHex)
+        XCTAssertNil(result.forbidden)
+    }
 }

--- a/packages/swift-server/Tests/SecretMaskingTests.swift
+++ b/packages/swift-server/Tests/SecretMaskingTests.swift
@@ -3,6 +3,28 @@ import XCTest
 
 final class SecretMaskingTests: XCTestCase {
 
+    // MARK: - hmacSHA256Hex()
+
+    func testHmacSHA256HexMatchesKnownVector() {
+        // RFC 4231 test case 2: key "Jefe", data "what do ya want for nothing?"
+        let hex = hmacSHA256Hex(key: "Jefe", message: Array("what do ya want for nothing?".utf8))
+        XCTAssertEqual(hex, "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843")
+    }
+
+    func testHmacSHA256HexIsDeterministic() {
+        let body = Array("same body".utf8)
+        let a = hmacSHA256Hex(key: "secret-key", message: body)
+        let b = hmacSHA256Hex(key: "secret-key", message: body)
+        XCTAssertEqual(a, b)
+    }
+
+    func testHmacSHA256HexDiffersByKey() {
+        let body = Array("same body".utf8)
+        let a = hmacSHA256Hex(key: "secret-key-one", message: body)
+        let b = hmacSHA256Hex(key: "secret-key-two", message: body)
+        XCTAssertNotEqual(a, b)
+    }
+
     // MARK: - mask()
 
     func testDeterministicOutput() {


### PR DESCRIPTION
Agents only ever see a masked secret token, so they can't compute HMAC-SHA256(body, secret) themselves for webhook signing. Add a sentinel request header, `x-slicc-hmac-sign: <secretName>:<targetHeader>`, that both fetch-proxy implementations (node-server CLI, chrome-extension SW) recognize: the proxy signs the already-unmasked body with the named secret's real value — domain-scoped exactly like unmaskHeaders — attaches the hex result under the target header, and strips the sentinel before forwarding. The real secret value never leaves the proxy.

<!--
SLICC PR template. House style: `## Summary` + `## Why` + `## Test plan` /
`## Verification`. Delete sections that don't apply; keep the headings you do
fill in. The prompts in HTML comments are written to surface the things
reviewers most often have to ask for after a draft lands.
-->

<!-- Stacked on / follow-up to: e.g. "Stacked on top of #545. Merge that first." -->
<!-- Linked issue: "Fixes #NNN" / "Closes #NNN" — auto-closes on merge. -->

## Summary

<!--
1-3 sentences. *What* changed, in plain English. The "why" goes in the next
section. If this is a bug fix, say what the user saw before and what they see
now (one sentence each).
-->

## Why

<!--
Motivation. Link issues, prior PRs, design docs, or transcripts.
For bug fixes, include a minimal **Repro** the reviewer can run:
  1. <step>
  2. <step>
  Expected: <…>
  Actual:   <…>
For new behavior, link the spec / plan / discussion.
-->

## Approach / Implementation notes

<!--
Only the things a reviewer can't infer from the diff. Pick the bullets that
apply; delete the rest.

- Layering: which subsystems / files own the new behavior
- Non-obvious design choices and the alternatives you rejected (and why)
- New runtime invariants, mutex/lock semantics, or ordering requirements
- New dependencies (confirm the lib is already in package.json before adding)
- Migration / data-shape changes for IndexedDB stores (`browser-coding-agent`,
  `slicc-fs`, session schemas, ledgers, localStorage keys)
-->

## Cross-cutting impact

<!--
This is the section reviewers ask for most often. Be explicit about what
changes for code paths NOT directly named by this PR.

- **Floats exercised**: CLI / Chrome extension / Electron / Sliccstart / worker
- **Shell contexts** (extension only): side panel `AlmostBashShell`, offscreen
  `AlmostBashShell`, sandbox iframe — name each one this PR touches or leaves alone.
- **Other callers of the changed function/contract**: if you broadened a
  try/catch, changed an error shape, or rewrote a helper, list the *unrelated*
  callers you checked. ("This `catch` also catches `validateApiKey`'s 404; that
  caller already tolerates rejection.")
- **Persisted state side-effects**: does opening / surfacing / muting also write
  to a ledger that survives reload? (e.g. `slicc-known-sprinkles`,
  `slicc-open-sprinkles`, `selected-model`).
- **Async lifecycle**: disposal guards on `.then(...)` after fetch, listener
  removal on `close`/`error`, debounce vs real `setTimeout` in tests, UTF-8 /
  multi-byte boundaries when scrubbing or chunking streams.
- **Security**: secrets in shell echo / logs / process args, XSS via
  `innerHTML` of attacker-controlled SVG, CSP/MV3 sandbox boundary, deploy-key
  scope across CI steps.
- **Bundle size**: importing a full registry (e.g. `lucide` icons) into the UI
  bundle — quantify if non-trivial.
-->

## Test plan

<!--
Be specific: command + result, not "tested locally". Pre-existing failures are
fine — name them so reviewers don't conflate them with your changes.
-->

- [ ] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [ ] `npm run typecheck`
- [ ] `npm run test` — `<N>` passing, no new failures
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** in
      `packages/*/tests/` mirroring the changed `src/` path
      (e.g. `npx vitest run packages/webapp/tests/<area>/<file>.test.ts`)
- [ ] Manual smoke (CLI): `npm run dev` + …
- [ ] Manual smoke (extension): load unpacked `dist/extension/` + …
- [ ] Manual smoke (Electron / Sliccstart / worker) — if relevant
- [ ] **UI change?** Attach a screencast of what changed (**required** for UI
      changes). Record it with the `demo-recording` skill — a CDP screencast of
      the running harness (`node packages/dev-tools/tools/slicc-screencast.mjs`)
      or a polished cursor-animated MP4. Upload it with `gh image` from
      `ai-ecoverse/ai-aligned-gh` (e.g.
      `gh image --markdown screencast.webm`) and paste the embed here.
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

<!--
e.g. "17 failures in chat-panel-attachments / telemetry / chat-panel-telemetry
reproduce on `main` at <sha> — unrelated localStorage issues in the test env."
-->

## Documentation

<!-- Pick the tier(s) that apply. See CLAUDE.md > "Documentation". -->

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [ ] No documentation changes needed

## Risk & rollback

<!--
- Blast radius if this regresses (single float / all floats / data migration).
- Feature flags, kill switches, or env knobs introduced.
- How to roll back: revert this PR cleanly? Need a follow-up to undo a
  persisted state migration?
- Anything CI cannot catch (real Chrome CDP behavior, OAuth round-trip,
  Keychain prompt z-order, mounted-folder TCC) that the reviewer should verify
  by hand before approving.
-->

## Checklist

- [ ] Commits are focused and package-local where possible
- [ ] No hand-edited files under `dist/`
- [ ] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots)
- [ ] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths
