### PR TITLE
docs-trim: cloudflare-worker/CLAUDE.md 45K → 18K; add tray-worker-operations.md

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -21,14 +21,13 @@ This file covers the documentation surface in `docs/`.
 | File                                                    | Limit  | Unit  | Note                              |
 | ------------------------------------------------------- | ------ | ----- | --------------------------------- |
 | `CLAUDE.md` (root)                                      | 15,000 | chars | enforced                          |
-| `packages/*/CLAUDE.md`                                  | 20,000 | chars | one file grandfathered; see below |
-| `packages/vfs-root/shared/CLAUDE.md`                    | 3,000  | bytes | bundled into the VFS              |
-| `.github/copilot-instructions.md` + `*.instructions.md` | 4,000  | chars | Copilot truncation limit          |
+| `packages/*/CLAUDE.md`                                  | 20,000 | chars | enforced                 |
+| `packages/vfs-root/shared/CLAUDE.md`                    | 3,000  | bytes | bundled into the VFS     |
+| `.github/copilot-instructions.md` + `*.instructions.md` | 4,000  | chars | Copilot truncation limit |
 
-One package file still exceeds the 20,000-char cap and is grandfathered with a frozen
-per-file exemption in `check-doc-sizes-lib.mjs`: `packages/cloudflare-worker/CLAUDE.md` (45,000).
-The nightly ratchet (#1469 Wave 3) will lower these mechanically. Exemption values
-may only be lowered or deleted — never added or raised.
+All package `CLAUDE.md` files are now within the 20,000-char cap. The grandfathered
+exemption list in `check-doc-sizes-lib.mjs` is empty. Exemption values may only be
+lowered or deleted — never added or raised.
 
 ### No PR breadcrumbs
 
@@ -61,6 +60,7 @@ Subsystems:
 - `operational-telemetry.md` — Helix RUM beacons and debug sampling
 - `extension-thin-bridge.md` — Chrome extension deep reference: bridge Port protocol, toast attribution/dedup, leader-tab lifecycle rationale, side-panel flow, dev-watch loop, QA recipe, and smoke test
 - `slicc-handoff.md` — external handoff protocol (RFC 8288 `Link` header + `navigate` lick)
+- `tray-worker-operations.md` — tray hub ops runbook: R2 asset archive setup, deploy-gating, ghost-leader reconnect, CI retry logic, and staging test guide
 - `link-discovery.md` — the standalone `discover` shell command and the `--discover` flag on `playwright-cli` subcommands (`fetch`, `goto`, `navigate`, `open`, `tab-new`); covers RFC 8288 / RFC 9727 parsing, emission, and the SLICC handoff/upskill rels
 - `urls.md` — production URL inventory
 - `electron.md` — Electron float workflow

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -18,9 +18,9 @@ This file covers the documentation surface in `docs/`.
 
 ### Size budgets (enforced by `npm run lint:docs`)
 
-| File                                                    | Limit  | Unit  | Note                              |
-| ------------------------------------------------------- | ------ | ----- | --------------------------------- |
-| `CLAUDE.md` (root)                                      | 15,000 | chars | enforced                          |
+| File                                                    | Limit  | Unit  | Note                     |
+| ------------------------------------------------------- | ------ | ----- | ------------------------ |
+| `CLAUDE.md` (root)                                      | 15,000 | chars | enforced                 |
 | `packages/*/CLAUDE.md`                                  | 20,000 | chars | enforced                 |
 | `packages/vfs-root/shared/CLAUDE.md`                    | 3,000  | bytes | bundled into the VFS     |
 | `.github/copilot-instructions.md` + `*.instructions.md` | 4,000  | chars | Copilot truncation limit |

--- a/docs/tray-worker-operations.md
+++ b/docs/tray-worker-operations.md
@@ -1,0 +1,335 @@
+# Tray Worker Operations Runbook
+
+Operational detail for `packages/cloudflare-worker/` — R2 asset archive, deploy
+gating, ghost-leader reconnect, CI retry logic, and the staging test guide.
+
+For the protocol and module map see
+[`packages/cloudflare-worker/CLAUDE.md`](../packages/cloudflare-worker/CLAUDE.md).
+For the tray signaling architecture and the leader/follower message matrix see
+[`docs/architecture.md`](architecture.md#multi-browser-sync-tray-architecture).
+
+---
+
+## R2 Asset Archive
+
+**Goal:** Keep content-hashed `/assets/*` chunks available across deploys so
+long-lived browser tabs don't crash when lazy-loaded chunks from an older build
+disappear. The worker serves archived chunks from R2 on an `ASSETS` miss, degrading
+gracefully to the shipped stale-asset reload if retention doesn't cover a chunk.
+
+### Binding and buckets
+
+`wrangler.jsonc` defines an `ASSET_ARCHIVE` R2 binding per environment:
+`slicc-asset-archive` (production) and `slicc-asset-archive-staging` (staging).
+The worker's `WorkerEnv` type includes `ASSET_ARCHIVE: R2Bucket`.
+
+### Serving path (`serveAssetWithArchiveFallback`)
+
+A dedicated handler in `src/index.ts` intercepts `GET`/`HEAD` requests to paths
+matching the strict hashed-asset predicate (e.g., `/assets/anthropic-messages-DP3-Xd3J.js`):
+
+- **Present asset** (current build has it): serve from `ASSETS` unchanged, honoring
+  Range/conditional headers.
+- **Miss** (asset absent from current build): attempt to fetch from R2 with full `200`
+  - immutable `Cache-Control`. Intentionally does **not** implement conditional (304/412)
+    or Range (206) — all requests receive the full body and validators (`ETag`,
+    `Last-Modified`). Archive miss or R2 error falls back to the shell (or bodyless
+    response for `HEAD`), triggering the existing stale-asset reload.
+- **Cache API** (edge): GET requests cache the full `200` under a canonical key;
+  HEAD bypasses the cache.
+
+### Hash invariant (enforced)
+
+Every `/assets/*` filename must carry a content hash (e.g., `-DP3-Xd3J`). The upload
+script (`packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs`) fails the deploy
+if any `dist/ui/assets/*` name lacks a hash, and the worker's routing predicate enforces
+the same rule (defined in the shared `asset-archive.mjs` module).
+
+### Upload gate (before every deploy)
+
+Every deploy path (prod automated via `publish-worker.sh`, prod manual via `worker.yml`,
+staging via `ci.yml` and `worker-staging.yml`) runs the upload step **before the first
+`wrangler deploy` attempt**. The production release script also runs it when its
+worker/UI change gate skips deployment. The upload re-puts the **entire current asset
+set** to the archive (no skip-if-exists; refreshes `last-modified` which the GC relies
+on) with retries and bounded concurrency, failing the release hard if any file fails to
+upload or the hash invariant is violated. Auth: `CLOUDFLARE_API_TOKEN` (must have R2
+Object Read & Write on both buckets) and `CLOUDFLARE_ACCOUNT_ID`.
+
+### Garbage collection (age-based)
+
+An R2 object-lifecycle rule on each bucket deletes objects with `last-modified` older
+than 14 days. Because every deploy re-puts its full current set, stable chunks
+(vendor/shared) survive ≥14 days after supersession. Build-unique chunks may fall
+outside the window after 14 days; tabs importing such chunks then degrade to the
+stale-asset reload. **Option B** (manifest-touch, future work) would give all chunks
+≥14 days post-supersession via a manifest of deployed key lists and a copy-in-place
+touch loop; it is an additive upgrade requiring no re-spec.
+
+The R2 refresh is intentionally unconditional across releases: a worker-deploy skip
+streak is unbounded, so relying only on the 14-day TTL could eventually delete
+still-current archived chunks.
+
+### MIME map
+
+Shared in `src/asset-archive.mjs` (used by both worker and upload script):
+`.js`/`.mjs`→`text/javascript`, `.css`→`text/css`, `.json`/`.map`→`application/json`,
+`.wasm`→`application/wasm`, `.woff2`→`font/woff2`, `.svg`→`image/svg+xml`;
+fallback `application/octet-stream`.
+
+### Testing
+
+Unit tests in `tests/index.test.ts` verify present-asset, miss (archive hit/miss),
+HEAD, Range/conditional requests (full `200`, not 206/304), cache behavior, and error
+handling. Deployed smoke tests in `tests/deployed.test.ts` verify (staging-only) R2
+archive recovery and (both envs) present-asset fetch via the live worker.
+
+---
+
+## Ops Runbook: R2 Prerequisites
+
+These manual Cloudflare operations **must exist before CI deploys**, else the upload
+step will fail.
+
+### 1. Create R2 buckets
+
+```bash
+npx wrangler r2 bucket create slicc-asset-archive
+npx wrangler r2 bucket create slicc-asset-archive-staging
+```
+
+Verify:
+
+```bash
+npx wrangler r2 bucket list
+```
+
+### 2. Apply 14-day object-lifecycle rule
+
+For each bucket, set a lifecycle rule to delete objects with `last-modified > 14 days`:
+
+```bash
+npx wrangler r2 bucket lifecycle add slicc-asset-archive retention-14d --expire-days 14
+npx wrangler r2 bucket lifecycle add slicc-asset-archive-staging retention-14d --expire-days 14
+```
+
+Verify:
+
+```bash
+npx wrangler r2 bucket lifecycle list slicc-asset-archive
+npx wrangler r2 bucket lifecycle list slicc-asset-archive-staging
+```
+
+Each should output:
+
+```
+Age: 14 days → Expiration
+```
+
+### 3. `CLOUDFLARE_API_TOKEN` — required permission set (ALL of these)
+
+The deploy `CLOUDFLARE_API_TOKEN` secret is used for **the whole worker deploy**,
+not just R2. When editing or recreating it (**Account Settings → API Tokens →
+Edit token**), it MUST keep every scope below — dropping any one wedges releases:
+
+- **Account → Workers Scripts → Edit** — deploy the worker script + Static Assets.
+- **Account → Workers R2 Storage → Edit** (R2 Object Read & Write) on **both** buckets
+  (`slicc-asset-archive`, `slicc-asset-archive-staging`).
+- **Zone → Workers Routes → Edit** _and_ **Zone → Zone → Read** for the `sliccy.ai`
+  zone — reconcile the `www.sliccy.ai/*` + `*.sliccy.now/*` routes on deploy.
+
+> ⚠️ **Incident (2026-07-13):** granting R2 to this token dropped its
+> **Zone/Workers-Routes** scope. The worker script still deployed, but `wrangler deploy`
+> failed reconciling routes (`"does not have 'All Zones' permissions"`), which aborted
+> the release **before** the GitHub-release/Chrome/npm publish steps. `publish-worker.sh`
+> now treats a routes-only deploy failure as non-fatal (version already live), but the
+> token should still carry the routes scope so route _changes_ apply. When editing the
+> token, add scopes; never replace the whole set with only R2.
+
+---
+
+## Ghost-Leader Reconnect
+
+**Why last-key-holder-wins:** A leader-WS upgrade that presents a `controllerId`+
+`leaderKey` NOT matching the elected leader is rejected `403 LEADER_ONLY`. A matching
+one that arrives while the DO still holds a previous `leaderSocket` is **not** rejected
+— the DO closes the stale socket and accepts the new one.
+
+**Rationale:** Stale sockets are ghost connections. `workerd` does not reliably deliver
+`webSocketClose` on a dropped/half-open leader connection, and a DO eviction can drop
+the socket without a close event. 409-rejecting the rightful leader's reconnect would
+deadlock it: it retries the same session, exhausts its ~20 attempts, gives up with no
+tray, and the extension side-panel follower then can't join — surfacing as "Tray leader
+WebSocket failed before leader.connected" with no tray URL.
+
+**Safety:** The stale `leaderSocket` is nulled before `close()` so its (possibly
+synchronous) `webSocketClose` is a no-op and can't clear the freshly-accepted leader.
+
+---
+
+## CI and Deployment
+
+### Two workers ship together
+
+The hub (`wrangler.jsonc`) and the preview worker (`wrangler-preview.jsonc`) share the
+same Durable Object (bound in the preview config via `script_name`) and the same preview
+URL token format (`buildPreviewUrl` in `@slicc/shared-ts` ↔ `previewTokenFromHost` in
+`src/preview-host.ts`). They **must** be deployed as a pair — a hub-only deploy that
+changes the URL format leaves the stale preview worker unable to parse the new URLs,
+causing every `serve` preview to 404 "Preview not found". The automated release
+(`scripts/publish-worker.sh`) and the manual `worker.yml` dispatch both deploy both
+workers.
+
+### Deploy gating
+
+The automated semantic-release path gates production deployment with
+`release-native.mjs --gate=worker`, comparing the previous release tag to `HEAD` (or
+`HEAD^` when `HEAD` is the generated `chore(release):` version-bump commit so that
+commit alone doesn't open the gate). Changes under the worker, served webapp/UI
+packages, shared worker dependencies, root package metadata, or hosted e2b template
+inputs deploy both workers and run the live smoke tests. First releases always deploy;
+releases with only unrelated changes refresh the R2 archive and exit before the template
+push, secret writes, both `wrangler deploy` calls, and deployed smoke tests.
+
+### Retry logic
+
+Production hub and preview deploys each retry up to six times with a 15-second delay.
+Each attempt enables Wrangler debug logging; exhausting all attempts prints that worker's
+debug log to CI stderr before failing.
+
+### Routes-only failures are non-fatal
+
+`deploy_with_retry` captures each attempt's combined output and, on failure, classifies
+it with `release-native.mjs --classify-deploy-log` (pure `isRoutesReconcileOnlyFailure`,
+unit-tested). A failure is treated as a successful deploy (with a loud warning) when
+BOTH signals are present:
+
+1. The worker version **uploaded** (`Uploaded <name> (<n> sec)` — new script + assets
+   are live).
+2. The routes-API call **failed** (`A request to the Cloudflare API (…/workers/routes)
+failed` — only route reconciliation failed, e.g. the token lost Zone → Workers Routes
+   → Edit).
+
+Requiring the upload line rules out a pre-deploy routes failure (version never went
+live). Wrangler phrases the routes failure two ways — the hub wraps it in "Some triggers
+failed to deploy", the preview worker surfaces the bare routes-API auth error — so the
+classifier keys off the upload + routes-API-failure signals rather than the "triggers
+failed" wrapper. Routes are set-once/stable, so the new version is already serving; the
+release continues to the GitHub-release/Chrome/npm publish steps, and the warning flags
+that any _changed_ routes did not apply until the token's routes scope is restored.
+Any other failure (script upload, bindings, asset-too-large) still retries and then
+fails hard.
+
+### Required repo configuration
+
+- Secret: `CLOUDFLARE_API_TOKEN`
+- Variable: `CLOUDFLARE_ACCOUNT_ID`
+
+---
+
+## Staging Deployment & Testing
+
+### Cloudflare account
+
+Production and staging workers live on the **AEM Demo** account
+(`155ec15a52a18a14801e04b019da5e5a`). Verify with `npx wrangler whoami` — if it shows
+a different account, re-authenticate:
+
+```bash
+npx wrangler login   # interactive — pick "AEM Demo" in the browser
+```
+
+### Two workers must be deployed together
+
+| Worker   | Config                   | Staging name             | Routes                     |
+| -------- | ------------------------ | ------------------------ | -------------------------- |
+| Main hub | `wrangler.jsonc`         | `slicc-tray-hub-staging` | `*.workers.dev` (API + UI) |
+| Preview  | `wrangler-preview.jsonc` | `slicc-preview-staging`  | `*.sliccy.dev/*`           |
+
+```bash
+cd packages/cloudflare-worker
+npx wrangler deploy --config wrangler.jsonc --env staging
+npx wrangler deploy --config wrangler-preview.jsonc --env staging
+```
+
+### UI assets are required
+
+The hub worker serves the webapp via Cloudflare Workers Static Assets from `dist/ui/`.
+A bare worktree only has `electron-overlay-entry.js` — the staging deploy will succeed
+but every page load returns 404.
+
+**Fix:** symlink the main repo's built UI into the worktree before deploying:
+
+```bash
+trash dist/ui
+ln -s /path/to/main-repo/dist/ui dist/ui
+```
+
+If the main repo doesn't have a build either, run `npm run build -w @slicc/webapp` there
+first.
+
+### Testing `serve` against staging
+
+The `serve` command mints preview URLs via the tray hub. It needs:
+
+1. A **leader tray session** connected to the staging hub.
+2. Tray API calls to be **same-origin** (no CORS).
+
+**Use `--lead` from the main repo** (not the worktree — it has no node-server):
+
+```bash
+cd /path/to/main-repo
+npm run dev -- --lead https://slicc-tray-hub-staging.minivelos.workers.dev
+```
+
+This loads the webapp from the staging hub (same-origin → no CORS) and auto-connects
+as a tray leader.
+
+**Do NOT use `SLICC_TRAY_WORKER_BASE_URL`** — it overrides only the tray WebSocket
+target while the UI loads from a different origin, causing cross-origin "Failed to
+fetch" errors on every tray API call.
+
+**Do NOT use `host leave --leader <url>`** from a localhost-served UI for the same
+CORS reason.
+
+### Test checklist
+
+Once `npm run dev -- --lead <staging-url>` is running and the tray is connected:
+
+```bash
+# In Slicc shell:
+echo '<h1>test</h1>' > /workspace/test/index.html
+serve /workspace/test
+# → should print a https://<token>.sliccy.dev URL
+```
+
+- **Hibernation**: wait ~2 min idle, reload the URL — should not 502
+- **Cache**: reload within 5s — should be faster (CF cache hit)
+- **Staleness**: edit the file, wait 5s, reload — new content
+- **ETag**: `curl -I <url>`, copy `etag`, then `curl -H 'If-None-Match: "<etag>"' <url>` → 304
+
+### Local `serve --bridge` testing — no deploy
+
+The hub worker serves previews itself (`src/preview-handler.ts`) and `previewTokenFromHost`
+accepts `<token>.localhost[:port]`, so the whole driveable-preview bridge is testable
+against a single local `wrangler dev` — no separate deploy required:
+
+```bash
+# 1. Hub worker — MUST use --env staging (its routes:[] lets wrangler dev honor
+#    the real per-request Host, so the tray's capability URLs AND the
+#    <token>.localhost preview subdomains stay local). Plain `wrangler dev` uses
+#    the prod routes (www.sliccy.ai/*), so the controller URL points at prod.
+npx wrangler dev --config packages/cloudflare-worker/wrangler.jsonc --env staging \
+  --port 8787 --ip 127.0.0.1
+
+# 2. Leader → local hub. BRIDGE_DEV_ALLOWED_ORIGINS whitelists the leader's
+#    localhost origin for the /cdp bridge WS upgrade.
+BRIDGE_DEV_ALLOWED_ORIGINS=http://localhost:8787 \
+  npm run dev -- --lead http://localhost:8787
+
+# 3. In the Slicc shell: `serve --bridge <dir>` mints http://<token>.localhost:8787/
+```
+
+Reach the worker via **localhost:8787**, not `127.0.0.1:8787` — `buildPreviewUrl`'s
+lookup table only has a `localhost:8787` row. Browsers resolve `*.localhost` to
+loopback; the `.localhost` host is dev-only.

--- a/docs/tray-worker-operations.md
+++ b/docs/tray-worker-operations.md
@@ -167,6 +167,64 @@ synchronous) `webSocketClose` is a no-op and can't clear the freshly-accepted le
 
 ---
 
+## Preview Bridge Protocol
+
+The preview bridge (`serve --bridge`) lets the leader drive a visited page as a
+synthetic CDP target over a WebSocket hosted by the Durable Object.
+
+### Wire format
+
+The bridge tab connects over `WS <token>.sliccy.now|dev/__slicc/bridge`
+(Sec-WebSocket-Protocol: `slicc.preview-bridge.v1.<connId>`). Messages from the
+browser tab to the DO are plain JSON objects; the key field is `t`:
+
+| `t` value | Direction | Meaning                                                       |
+| --------- | --------- | ------------------------------------------------------------- |
+| `cdp.res` | tab → DO  | CDP response: `{ t:'cdp.res', id, result                      | error }`relayed to the leader as`bridge.cdp.response` |
+| `emit`    | tab → DO  | Attributed event: `{ t:'emit', name, detail }` (see below)    |
+| `cdp.req` | DO → tab  | CDP request: `{ t:'cdp.req', id, method, params, sessionId }` |
+
+### Attributed emit
+
+`window.slicc.emit(name, detail)` is sent over the bridge WS as
+`{ t:'emit', name, detail }`. The DO knows which socket it came from, so it
+looks up the record's `webhookId` and sends a `webhook.event` envelope stamped
+with attribution headers:
+
+```
+x-slicc-preview-conn: <connId>
+x-slicc-preview-token: <token>
+```
+
+The leader threads that `headers` map through unchanged (no signature or body
+mutation), and `formatWebhookLick` renders the envelope as a distinct
+**Preview Event** tied to `preview:<token>:<connId>`.
+
+> **Why identity rides in headers, not the body:** the page's `detail` is
+> delivered verbatim. Embedding `connId`/`token` in the body would require the
+> DO to merge them into an arbitrary JSON object it doesn't own. Headers keep
+> the attribution out-of-band so the lick pipeline can parse it without
+> touching `detail`.
+
+### Unattributed POST fallback
+
+`POST <token>.sliccy.now|dev/__slicc/emit` is the fallback beacon relay for
+`window.slicc.emit(name, detail)` when the bridge WS isn't open (e.g., page
+unload). The DO looks up the record's `webhookId` and sends the `webhook.event`
+envelope to the leader **without** the attribution headers, so
+`formatWebhookLick` renders it as a plain webhook lick rather than a Preview
+Event. Only available when `PreviewRecord.bridge` is true.
+
+### Synthetic error for gone sockets
+
+On leader (re)connect the DO replays `bridge.connected` for every live bridge
+socket so a leader reload doesn't orphan open tabs. A `bridge.cdp.request` for
+a socket that has since closed is answered with a **synthetic error** — this
+lets the leader fail fast (immediate error response) instead of waiting for a
+30-second timeout.
+
+---
+
 ## CI and Deployment
 
 ### Two workers ship together

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -4,176 +4,132 @@ This file covers the tray hub worker in `packages/cloudflare-worker/`.
 
 ## Scope
 
-The worker provides tray session coordination, capability-token routing, TURN credential lookup, and leader/follower signaling for tray-connected SLICC runtimes. It also serves the built SLICC webapp as static assets to browser visitors.
+The worker provides tray session coordination, capability-token routing, TURN credential
+lookup, and leader/follower signaling for tray-connected SLICC runtimes. It also serves
+the built SLICC webapp as static assets to browser visitors.
 
 ## Main Files
 
-| Path                                                                                                                 | Purpose                                                                                                                                                                                                                                                                                         |
-| -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/index.ts`                                                                                                       | Worker entry point and public HTTP routing                                                                                                                                                                                                                                                      |
-| `src/session-tray.ts`                                                                                                | `SessionTrayDurableObject` state machine — manages controller WebSocket (leader), follower WebRTC signaling, and preview bridge WebSocket role                                                                                                                                                  |
-| `src/turn-credentials.ts`                                                                                            | Cloudflare TURN credential fetcher                                                                                                                                                                                                                                                              |
-| `src/shared.ts`                                                                                                      | Capability token + response helpers; `reclaimMsForTray`; the `TRAY_RECLAIM_TTL_MS` / `HOSTED_TRAY_RECLAIM_TTL_MS` consts; DO-internal `TrayBootstrapRecord`/`TrayRecord`. Wire signaling types come from `@slicc/shared-ts` (`tray-signaling.ts`)                                               |
-| `src/links.ts`                                                                                                       | `applySliccLinks` — adds the standard RFC 8288 `Link` rel set to every response                                                                                                                                                                                                                 |
-| `src/handoff-page.ts`                                                                                                | `/handoff` route handler — converts `?upskill=` / `?handoff=` / `?msg=` into a `Link` response header                                                                                                                                                                                           |
-| `src/api-catalog.ts`                                                                                                 | `/.well-known/api-catalog` (RFC 9264 linkset) response builder                                                                                                                                                                                                                                  |
-| `src/llms-txt.ts`                                                                                                    | `/llms.txt` response builder                                                                                                                                                                                                                                                                    |
-| `src/rel-docs.ts`                                                                                                    | `/rel/:name` response builder — dereferenceable docs for SLICC custom rels                                                                                                                                                                                                                      |
-| `src/oauth-exchange.ts`, `src/oauth-registry.ts`                                                                     | OAuth callback relay (`/auth/callback`) — decodes the `state` envelope and routes to localhost / extension / allowlisted remote                                                                                                                                                                 |
-| `src/auth/cloud-callback.ts`                                                                                         | `/auth/cloud-callback` IMS popup callback for the cloud dashboard                                                                                                                                                                                                                               |
-| `src/cloud/cloud-sessions-do.ts`                                                                                     | `CloudSessionsDurableObject` — per-user state for `/api/cloud/*`. Wraps `@slicc/cloud-core` ops under `blockConcurrencyWhile`                                                                                                                                                                   |
-| `src/cloud/handlers.ts`, `src/cloud/handler-signout.ts`, `src/cloud/handler-admin.ts`, `src/cloud/handler-config.ts` | HTTP handlers for the `/api/cloud/*` routes; delegate to the DO                                                                                                                                                                                                                                 |
-| `src/cloud/auth.ts`, `src/cloud/auth-cache.ts`, `src/cloud/auth-middleware.ts`                                       | IMS bearer auth: extraction + verification, caching, and the middleware that wraps `/api/cloud/*` handlers                                                                                                                                                                                      |
-| `src/cloud/caps.ts`                                                                                                  | `checkCapsForRun` — per-user cone cap enforcement (`CONE_CAP_RUNNING`, `CONE_CAP_PAUSED`); called from `resumeConeOp` (inside `blockConcurrencyWhile`). The start-path counterpart lives in `@slicc/cloud-core`'s `reserveSlot`, which does the cap check + atomic slot reservation in one step |
-| `src/cloud/local-registry.ts`                                                                                        | `Registry` implementation backed by DurableObject storage — the worker counterpart of node-server's `FileRegistry`                                                                                                                                                                              |
-| `src/cloud/error-envelope.ts`                                                                                        | `errorResponse(status, code, message, details?)` and `okResponse(payload?)` helpers — the JSON shape used by `/api/cloud/*` replies; handlers map `CloudError.code` to HTTP statuses at the call site                                                                                           |
-| `src/cloud/proxy-config.ts`                                                                                          | Pulls IMS client_id / scopes / environment from the Adobe LLM proxy's `/v1/config` so the dashboard popup stays in sync                                                                                                                                                                         |
-| `src/cloud/rate-limit.ts`                                                                                            | Per-user rate limiting on the cloud endpoints                                                                                                                                                                                                                                                   |
-| `wrangler.jsonc`                                                                                                     | Wrangler config, Durable Object bindings (`TRAY_HUB`, `CLOUD_SESSIONS`), staging env, asset binding                                                                                                                                                                                             |
+| Path                                                                                   | Purpose                                                                                                             |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `src/index.ts`                                                                         | Worker entry point and public HTTP routing                                                                          |
+| `src/session-tray.ts`                                                                  | `SessionTrayDurableObject` — manages controller WS (leader), follower WebRTC signaling, and preview bridge WS       |
+| `src/turn-credentials.ts`                                                              | Cloudflare TURN credential fetcher                                                                                  |
+| `src/shared.ts`                                                                        | Capability token helpers; `reclaimMsForTray`; `TRAY_RECLAIM_TTL_MS`/`HOSTED_TRAY_RECLAIM_TTL_MS`; DO-internal types |
+| `src/links.ts`                                                                         | `applySliccLinks` — RFC 8288 `Link` rel set on every response                                                       |
+| `src/handoff-page.ts`                                                                  | `/handoff` route — converts `?upskill=`/`?handoff=`/`?msg=` into `Link` response header                             |
+| `src/api-catalog.ts`                                                                   | `/.well-known/api-catalog` (RFC 9264 linkset) builder                                                               |
+| `src/llms-txt.ts`                                                                      | `/llms.txt` builder                                                                                                 |
+| `src/rel-docs.ts`                                                                      | `/rel/:name` — dereferenceable docs for SLICC custom rels                                                           |
+| `src/oauth-exchange.ts`, `src/oauth-registry.ts`                                       | OAuth callback relay (`/auth/callback`)                                                                             |
+| `src/auth/cloud-callback.ts`                                                           | `/auth/cloud-callback` IMS popup callback for the cloud dashboard                                                   |
+| `src/cloud/cloud-sessions-do.ts`                                                       | `CloudSessionsDurableObject` — per-user state for `/api/cloud/*`                                                    |
+| `src/cloud/handlers.ts`, `handler-signout.ts`, `handler-admin.ts`, `handler-config.ts` | HTTP handlers for `/api/cloud/*`                                                                                    |
+| `src/cloud/auth.ts`, `auth-cache.ts`, `auth-middleware.ts`                             | IMS bearer auth: extraction, verification, caching, and middleware                                                  |
+| `src/cloud/caps.ts`                                                                    | `checkCapsForRun` — per-user cone cap enforcement (`CONE_CAP_RUNNING`, `CONE_CAP_PAUSED`)                           |
+| `src/cloud/local-registry.ts`                                                          | `Registry` backed by DO storage — worker counterpart of node-server's `FileRegistry`                                |
+| `src/cloud/error-envelope.ts`                                                          | `errorResponse`/`okResponse` JSON helpers for `/api/cloud/*` replies                                                |
+| `src/cloud/proxy-config.ts`                                                            | Adobe LLM proxy `/v1/config` sync — keeps dashboard popup in sync                                                   |
+| `src/cloud/rate-limit.ts`                                                              | Per-user rate limiting on cloud endpoints                                                                           |
+| `wrangler.jsonc`                                                                       | Wrangler config, DO bindings (`TRAY_HUB`, `CLOUD_SESSIONS`), staging env, asset binding                             |
 
-This package depends on `@slicc/cloud-core` (see [`packages/cloud-core/CLAUDE.md`](../cloud-core/CLAUDE.md)) for sandbox lifecycle logic. The worker-local `src/cloud/` files are adapter glue (auth, DO storage, HTTP plumbing) — operation logic lives in cloud-core.
+This package depends on `@slicc/cloud-core` (see
+[`packages/cloud-core/CLAUDE.md`](../cloud-core/CLAUDE.md)) for sandbox lifecycle logic.
+The worker-local `src/cloud/` files are adapter glue — operation logic lives in
+cloud-core.
 
 ## Tray Hub Architecture
 
 ### Durable Objects
 
 - Each tray maps to one `SessionTrayDurableObject` instance via the `TRAY_HUB` binding.
-- Tray state tracks issued capability tokens, leader attachment state, follower bootstrap state, reconnect windows, and cached ICE servers.
+- Tray state tracks issued capability tokens, leader attachment state, follower bootstrap
+  state, reconnect windows, and cached ICE servers.
 
-### Public routes
+### Public Routes
 
-- `POST /tray` — create a tray and issue join/controller/webhook capability URLs
-- `GET /handoff` — accepts `?upskill=<github-url>`, `?handoff=<text>`, or legacy `?msg=verb:payload` and emits an RFC 8288 `Link` response header carrying the SLICC handoff or upskill rel so SLICC can emit a `navigate` lick and show the user an approval prompt
-- `GET /.well-known/api-catalog` — RFC 9264 linkset describing every public route (`application/linkset+json`)
-- `GET /llms.txt` — markdown digest for LLM consumers (llmstxt.org spec)
-- `GET /status` — public health document (RFC 8631 status rel): `{ status, service, timestamp }`
-- `GET /rel/:name` — dereferenceable docs for the SLICC custom rel URIs (`/rel/handoff`, `/rel/upskill`)
-- `GET|POST /join/:token` — follower join and bootstrap polling flow
-- `GET|POST /controller/:token` — leader attach flow and leader WebSocket upgrade
-- `POST /webhook/:token/:webhookId` — forward webhook events into the live leader
-- `POST /api/tray/:trayId/preview` — mint a preview token (Bearer = controllerToken); body accepts `{ path, bridge?, maxTabs?, quiet?, webhookId? }`; response `{ previewToken, url }`. The URL is a `<token>.sliccy.now` (prod) / `<token>.sliccy.dev` (staging) host that routes back to this worker via the wildcard route. The URL's path is the entry file's path relative to `servedRoot` (e.g. `.../drafts/foo.html`), not always `/` — this keeps relative links inside the entry HTML resolving against the entry's own directory instead of the served root. When `bridge: true`, the preview is driveable and visitor tabs auto-connect as synthetic-CDP targets.
-- `POST /api/tray/:trayId/preview/stop` — revoke a previewToken (Bearer = controllerToken); body `{ previewToken }`; response `{ revoked, webhookId? }` (returns the auto-provisioned `webhookId` so `serve --stop` can delete it worker-side).
-- `GET /api/tray/:trayId/previews` — list active previews for a tray (Bearer = controllerToken).
-- `GET <token>.sliccy.now/*` (prod) / `<token>.sliccy.dev/*` (staging) — preview HTTP pipe (`src/preview-handler.ts` + `src/preview-worker.ts`). Parses the token from the host, resolves the `PreviewRecord` via DO `/internal/preview/resolve`, sends `preview.request` to the live leader over the controller WS, awaits `preview.response` chunks (30s timeout via `PreviewAssembler`), reassembles, and streams the bytes back. No `Access-Control-Allow-Origin` — preview subdomains can't fetch each other. 502 on disconnected leader / timeout, 404 / 403 / 500 forwarded from the leader. When `PreviewRecord.bridge` is true and the response is HTML, `HTMLRewriter` injects `<script src="/__slicc/preview-bridge.js">` into `<head>` and augments the CSP with `connect-src 'self' wss://<host>` so the bootstrap can open the bridge WebSocket.
-- `GET <token>.sliccy.now|dev/__slicc/preview-bridge.js` — serves the bundled preview bootstrap (classic IIFE, same-origin, immutable cache). Only when `PreviewRecord.bridge` is true. The JS is `PREVIEW_BRIDGE_JS` from `src/preview-bridge-assets.ts`, a **build-generated, `.gitignored`** file (never committed) that `packages/cherry/scripts/build-preview-bootstrap.mjs` regenerates on every install (root `postinstall`) and in the root `build` chain (cherry runs before the worker). See #1308.
-- `WS <token>.sliccy.now|dev/__slicc/bridge` — preview bridge WebSocket upgrade (Sec-WebSocket-Protocol: `slicc.preview-bridge.v1.<connId>`). Only when `PreviewRecord.bridge` is true. DO accepts with `state.acceptWebSocket`, mints a `connId`, tags with `BRIDGE_WS_TAG` + `tok:<token>` + `conn:<connId>`, and sends `bridge.connected` to the leader. `webSocketMessage` delegates to `handleBridgeMessage` (extracted for the complexity gate), which handles: `{ t:'cdp.res', id, result|error }` → relayed to the leader as `bridge.cdp.response`; `{ t:'emit', name, detail }` → an **attributed** `webhook.event` (see below); malformed JSON is dropped in a try/catch. The leader's `bridge.cdp.request` is relayed to the tab as `{ t:'cdp.req', id, method, params, sessionId }`. Enforces per-preview `--max-tabs` cap; rejects upgrades when cap reached or `!bridge`. Hibernated via `setWebSocketAutoResponse(new WebSocketRequestResponsePair('ping','pong'))` so idle tabs cost effectively nothing. On close, sends `bridge.disconnected` to the leader.
-- **Attributed emit** — `window.slicc.emit(name, detail)` is sent over the bridge WS as `{ t:'emit', … }`. The DO knows which socket it came from, so it looks up the record's `webhookId` and sends a `webhook.event` envelope stamped with `headers: { 'x-slicc-preview-conn': <connId>, 'x-slicc-preview-token': <token> }`. The leader threads that headers map through unchanged (no signature/body mutation), and `formatWebhookLick` renders it as a distinct **Preview Event** tied to `preview:<token>:<connId>`. This is why identity rides in headers, not the body — the page's `detail` is delivered verbatim.
-- `POST <token>.sliccy.now|dev/__slicc/emit` — **fallback** beacon relay for `window.slicc.emit(name, detail)` when the bridge WS isn't open (page unload). DO looks up the record's `webhookId` and sends the `webhook.event` envelope to the leader **without** the attribution headers, so it renders as a plain webhook lick. Only when `PreviewRecord.bridge` is true.
-- `GET /auth/callback` — OAuth callback relay page (decodes `state` param with source/port/path/nonce, redirects to localhost for `source:'local'`, extension for `source:'extension'`, or allowlisted remote origin for `source:'remote'`). **Capture hop:** when hit with a provider response (`?code`/`?error`) and **no `state`** — i.e. the relay already bounced back to the dashboard's own origin — it instead serves a tiny page that `postMessage`s `{ type:'oauth-callback', redirectUrl }` to `window.opener`. This is the completion path for the webapp-served-by-worker (connect/cloud) context, which has no node-server callback page; the webapp's `launchOAuthCli` waits for that message. Used by connect-mode GitHub login (see `packages/webapp/providers/github.ts` `resolveGithubOAuthRedirect`).
+| Route                                 | Description                                                                                                                                               |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /tray`                          | Create a tray; return join/controller/webhook capability URLs                                                                                             |
+| `GET /handoff`                        | Convert `?upskill=`, `?handoff=`, or `?msg=` into RFC 8288 `Link` header                                                                                  |
+| `GET /.well-known/api-catalog`        | RFC 9264 linkset for all public routes                                                                                                                    |
+| `GET /llms.txt`                       | LLM markdown digest                                                                                                                                       |
+| `GET /status`                         | Health document (`{ status, service, timestamp }`)                                                                                                        |
+| `GET /rel/:name`                      | Dereferenceable docs for SLICC custom rel URIs                                                                                                            |
+| `GET\|POST /join/:token`              | Follower join and bootstrap polling (HTTP poll/answer/ice-candidate/retry actions)                                                                        |
+| `GET\|POST /controller/:token`        | Leader attach and WS upgrade                                                                                                                              |
+| `POST /webhook/:token/:webhookId`     | Forward webhook events into the live leader                                                                                                               |
+| `POST /api/tray/:trayId/preview`      | Mint a preview token; body `{ path, bridge?, maxTabs?, quiet?, webhookId? }`; response `{ previewToken, url }`                                            |
+| `POST /api/tray/:trayId/preview/stop` | Revoke a preview token; body `{ previewToken }`                                                                                                           |
+| `GET /api/tray/:trayId/previews`      | List active previews for a tray                                                                                                                           |
+| `GET <token>.sliccy.now/*`            | Preview HTTP pipe — streams file from leader via DO; 30s timeout; bridge mode injects `<script src="/__slicc/preview-bridge.js">`                         |
+| `GET __slicc/preview-bridge.js`       | Bundled preview bootstrap (bridge-enabled previews only; build-generated, not committed)                                                                  |
+| `WS __slicc/bridge`                   | Preview bridge WS (`slicc.preview-bridge.v1.<connId>`); relays CDP + attributed `emit` between tabs and leader; hibernated via `setWebSocketAutoResponse` |
+| `POST __slicc/emit`                   | Fallback beacon relay for `window.slicc.emit` on page unload                                                                                              |
+| `GET /auth/callback`                  | OAuth callback relay; also a capture hop for the cloud dashboard (no `state` → `postMessage` to `window.opener`)                                          |
 
-### Signaling model
+**Routes-mirror rule:** every new route must appear in three places:
 
-- A leader first attaches through the controller capability.
-- The elected leader opens a WebSocket to the Durable Object.
-- **Leader reconnect is last-key-holder-wins.** A leader-WS upgrade that presents a `controllerId`+`leaderKey` NOT matching the elected leader is rejected `403 LEADER_ONLY`. A matching one that arrives while the DO still holds a previous `leaderSocket` is NOT rejected — the DO **closes the stale socket and accepts the new one**. This is deliberate: the stale socket is a ghost (workerd doesn't reliably deliver `webSocketClose` on a dropped/half-open leader connection, and a DO eviction can drop it), so 409-rejecting the rightful leader's reconnect would deadlock it (it retries the same session, exhausts its ~20 attempts, gives up with no tray — the extension side-panel follower then can't join, surfacing as "Tray leader WebSocket failed before leader.connected" with no tray URL). The stale `leaderSocket` is nulled before `close()` so its (possibly synchronous) `webSocketClose` is a no-op and can't clear the freshly-accepted leader.
-- Followers attach through the join capability and bootstrap over HTTP poll/answer/ice-candidate/retry actions.
-- Preview bridge tabs (`serve --bridge`) attach via the `/__slicc/bridge` WebSocket (preview subdomain, same origin as the served page). DO relays `bridge.cdp.request`/`bridge.cdp.response` between the leader controller WS and each bridge WS, keyed by `connId`. On leader (re)connect the DO replays `bridge.connected` for every live bridge socket so a leader reload doesn't orphan open tabs; a `bridge.cdp.request` for a gone socket is answered with a synthetic error so the leader fails fast instead of timing out.
-- The Durable Object forwards control messages to the live leader and expires trays that are not reclaimed in time.
+1. `src/index.ts` routes array (the default `GET /` body)
+2. `tests/index.test.ts` routes-list assertion
+3. `tests/deployed.test.ts` routes-list assertion
 
-### TURN credentials
+Missing any of these causes CI failures.
 
-- TURN credentials are fetched with `CLOUDFLARE_TURN_KEY_ID` and `CLOUDFLARE_TURN_API_TOKEN`.
-- `session-tray.ts` caches ICE servers and refreshes them before TTL expiry.
-- `wrangler.jsonc` defines the key ID; the API token is stored as a Wrangler secret.
+### Signaling Model
 
-### Tray kind (desktop / hosted)
+- A leader attaches through the controller capability and opens a WebSocket to the DO.
+- **Last-key-holder-wins reconnect** — a leader reconnect with matching credentials
+  closes the stale socket and accepts the new one rather than rejecting. Workerd doesn't
+  reliably deliver `webSocketClose` on dropped/half-open connections; rejecting the
+  rightful reconnect would deadlock it. See `docs/tray-worker-operations.md` for the
+  full ghost-leader analysis.
+- Followers attach through the join capability; bootstrap over HTTP poll.
+- Preview bridge tabs (`serve --bridge`) attach via `/__slicc/bridge` WS. DO relays
+  `bridge.cdp.request`/`bridge.cdp.response` between the leader and each bridge socket,
+  keyed by `connId`. On leader (re)connect the DO replays `bridge.connected` for every
+  live bridge socket.
+
+### TURN Credentials
+
+TURN credentials are fetched with `CLOUDFLARE_TURN_KEY_ID` and
+`CLOUDFLARE_TURN_API_TOKEN`. `session-tray.ts` caches ICE servers and refreshes them
+before TTL expiry. The key ID is in `wrangler.jsonc`; the API token is a Wrangler
+secret.
+
+### Tray Kind (desktop / hosted)
 
 `TrayRecord.kind` is `'desktop' | 'hosted'`, defaulting to `'desktop'` when absent.
-`POST /tray` reads an optional `kind` from the request body (no body = desktop;
-malformed body = 400). The reclaim TTL is `HOSTED_TRAY_RECLAIM_TTL_MS = 30 days`
-for hosted trays, `TRAY_RECLAIM_TTL_MS = 1 hour` for desktop trays — branched
-through the pure helper `reclaimMsForTray(tray)` in `shared.ts`. Hosted trays
-support laptop-orchestrated sandboxes that pause for days at a time.
+`POST /tray` reads an optional `kind` from the request body. The reclaim TTL is
+`HOSTED_TRAY_RECLAIM_TTL_MS = 30 days` for hosted trays, `TRAY_RECLAIM_TTL_MS = 1 hour`
+for desktop trays — branched through `reclaimMsForTray(tray)` in `shared.ts`.
 
 ### Static Asset Serving
 
-- The worker serves the built webapp (`dist/ui/`) via Cloudflare Workers Static Assets.
-- `wrangler.jsonc` configures `assets.directory` pointing to `../../dist/ui/` with binding name `ASSETS`.
-- Content negotiation uses `wantsJSON()` in `shared.ts` — checks for `?json=true` query parameter.
-- GET/HEAD requests to `/join/:token` and `/controller/:token` without `?json=true` get the SPA (webapp handles tray joining client-side).
-- GET/HEAD requests to unmatched paths without `?json=true` get an SPA fallback.
-- Requests with `?json=true`, POST requests, and WebSocket upgrades always get the API/JSON response.
-- The browser tray follower code (`packages/webapp/src/scoops/tray-follower.ts`) appends `?json=true` to all fetch calls to ensure API responses.
-- The webapp must be built (`npm run build -w @slicc/webapp`) before the worker can be deployed.
-- **Cherry embed (`?cherry=1`)**: `serveSPA` branches on `url.searchParams.get('cherry') === '1'`. A cherry request gets `Content-Security-Policy: frame-ancestors <origins>`, where `<origins>` is resolved from the space-separated `ALLOWED_CHERRY_HOST_ORIGINS` env var by the pure helper `resolveCherryFrameAncestors`:
-  - empty / unset → `'none'` (deny — the embed cannot be framed; default)
-  - one or more origins → that allowlist verbatim, space-separated
-  - contains a bare `*` token (alone or mixed with origins) → `*` **plus any explicit `chrome-extension://…` origins** (the CSP wildcard `*` matches only HTTP(S)/same-scheme ancestors and does NOT authorize a `chrome-extension://` parent, so extension origins must be named explicitly to permit extension side-panel framing; permits embedding from arbitrary third-party web pages)
+- Worker serves `dist/ui/` via Cloudflare Workers Static Assets (`ASSETS` binding).
+- `wantsJSON()` in `shared.ts` checks `?json=true` for content negotiation.
+- GET/HEAD to `/join/:token` and `/controller/:token` without `?json=true` → SPA.
+- Unmatched paths without `?json=true` → SPA fallback.
+- `?json=true`, POST, and WebSocket upgrades → API/JSON.
+- **Cherry embed (`?cherry=1`):** `frame-ancestors` is set from the
+  `ALLOWED_CHERRY_HOST_ORIGINS` env var. A bare `*` also adds any explicit
+  `chrome-extension://` origins (CSP `*` does not authorize extension ancestors).
+  Every non-cherry response gets `frame-ancestors 'none'`. Cherry responses set
+  `Cache-Control: no-store` and `Vary: Sec-Fetch-Dest` to prevent cache mixing.
+- **25 MiB per-asset cap:** Cloudflare rejects any `dist/ui/` file over 25 MiB; the
+  CI `cloudflare-worker` job runs `npm run build -w @slicc/cloudflare-worker`
+  (`wrangler deploy --dry-run`) as a hard gate.
 
-  Every **non-cherry** response gets `frame-ancestors 'none'` regardless of the env var — the wildcard only relaxes the follower (`?cherry=1`) surface, never the leader/top-level SPA. Cherry responses also set `Cache-Control: no-store` and `Vary: Sec-Fetch-Dest` so a cherry (iframe) response and a non-cherry (top-level) response can never share a cache entry — the framing policy differs between the two and must not leak across them. Using `*` opts in to arbitrary third-party framing of the cherry follower; the leader UI stays top-level-only (no clickjacking surface).
+### R2 Asset Archive
 
-- **25 MiB per-asset cap**: Cloudflare Workers Static Assets reject any single file in `dist/ui/` over 25 MiB, and `wrangler deploy` (incl. `--dry-run`) fails hard with `Asset too large`. A webapp change that bundles a large binary (e.g. the 33 MB `biome_wasm_bg.wasm`, stripped by `packages/webapp/vite-plugins/strip-biome-wasm-asset.ts`) breaks the deploy. The `cloudflare-worker` CI job runs `npm run build -w @slicc/cloudflare-worker` (the same `wrangler deploy --dry-run`) as a hard gate after building the webapp. The other deploy steps in that same job are `continue-on-error: true` and the finalize/smoke steps skip (rather than fail) when no deploy succeeds, so before this gate an oversized asset passed the PR and only broke later in the separate `release` workflow. The dry-run gate now fails the PR up front.
+The `ASSET_ARCHIVE` R2 binding keeps content-hashed `/assets/*` chunks available across
+deploys so long-lived tabs don't 404 on lazy-loaded chunks from older builds.
+`serveAssetWithArchiveFallback` in `src/index.ts` serves from `ASSETS`; falls back to
+R2; degrades to the stale-asset reload if R2 also misses. 14-day bucket lifecycle GC.
 
-### R2 Asset Retention (#1330)
-
-**Goal:** Keep content-hashed `/assets/*` chunks available across deploys so long-lived browser tabs don't crash when lazy-loaded chunks from an older build disappear. The worker serves archived chunks from R2 on an `ASSETS` miss (when the current build no longer has them), degrading gracefully to the shipped stale-asset reload if retention doesn't cover a chunk.
-
-**Binding and buckets:** `wrangler.jsonc` defines an `ASSET_ARCHIVE` R2 binding per environment: `slicc-asset-archive` (production) and `slicc-asset-archive-staging` (staging). The worker's `WorkerEnv` type includes `ASSET_ARCHIVE: R2Bucket`.
-
-**Serving path (`serveAssetWithArchiveFallback`):** A dedicated handler in `src/index.ts` intercepts `GET`/`HEAD` requests to paths matching the strict hashed-asset predicate (e.g., `/assets/anthropic-messages-DP3-Xd3J.js`):
-
-- **Present asset** (current build has it): serve from `ASSETS` unchanged, honoring Range/conditional headers.
-- **Miss** (asset absent from current build; `ASSETS` returns `text/html` shell or `404`): attempt to fetch from R2 with full `200` + immutable `Cache-Control`. Intentionally **NOT** implement conditional (304/412) or Range (206) — all requests receive the full body and validators (`ETag`, `Last-Modified`). Archive miss or R2 error falls back to the shell (or bodyless response for `HEAD`), triggering the existing stale-asset reload if needed.
-- **Cache API** (edge): GET requests cache the full `200` under a canonical key; HEAD bypasses the cache.
-
-**Hash invariant (enforced):** Every `/assets/*` filename must carry a content hash (e.g., `-DP3-Xd3J`). The upload script (`packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs`) fails the deploy if any `dist/ui/assets/*` name lacks a hash, and the worker's routing predicate enforces the same rule (defined in the shared `asset-archive.mjs` module).
-
-**Upload gate (before every deploy and release skip):** Every deploy path (prod automated via `publish-worker.sh`, prod manual via `worker.yml`, staging via `ci.yml` and `worker-staging.yml`) runs the upload step **before the first `wrangler deploy` attempt**. The production release script also runs it when its worker/UI change gate skips deployment. The upload re-puts the **entire current asset set** to the archive (no skip-if-exists; refreshes `last-modified` which the GC relies on) with retries and bounded concurrency, failing the release hard if any file fails to upload or the hash invariant is violated. Auth: `CLOUDFLARE_API_TOKEN` (must have R2 Object Read & Write on both buckets) and `CLOUDFLARE_ACCOUNT_ID`.
-
-**Garbage collection (Option A, age-based):** An R2 object-lifecycle rule on each bucket deletes objects with `last-modified` older than 14 days. Because every deploy re-puts its full current set, stable chunks (vendor/shared) re-ship until they change, surviving ≥14 days after supersession (covers the common #1330 pattern). Build-unique chunks may fall outside the window after a build stops shipping them; tabs importing such chunks past 14 days degrade to the stale-asset reload — acceptable and identical to today. **Option B** (manifest-touch, future work) would give all chunks ≥14 days post-supersession via a small manifest of deployed key lists and a copy-in-place touch loop; it's an additive upgrade requiring no re-spec.
-
-**MIME map:** Shared in `src/asset-archive.mjs` (used by both worker and upload script): `.js`/`.mjs`→`text/javascript`, `.css`→`text/css`, `.json`/`.map`→`application/json`, `.wasm`→`application/wasm`, `.woff2`→`font/woff2`, `.svg`→`image/svg+xml`, and others; fallback `application/octet-stream`.
-
-**Testing:** Unit tests in `tests/index.test.ts` verify present-asset, miss (archive hit/miss), HEAD, Range/conditional requests (full `200`, not 206/304), cache behavior, and error handling. Deployed smoke tests in `tests/deployed.test.ts` verify (staging-only) R2 archive recovery and (both envs) present-asset fetch via the live worker.
-
-## Ops Runbook: R2 Asset Retention Prerequisites
-
-These manual Cloudflare operations **must exist before CI deploys**, else the upload step will fail.
-
-### 1. Create R2 buckets
-
-```bash
-npx wrangler r2 bucket create slicc-asset-archive
-npx wrangler r2 bucket create slicc-asset-archive-staging
-```
-
-Verify:
-
-```bash
-npx wrangler r2 bucket list
-```
-
-### 2. Apply 14-day object-lifecycle rule
-
-For each bucket, set a lifecycle rule to delete objects with `last-modified > 14 days`:
-
-```bash
-npx wrangler r2 bucket lifecycle add slicc-asset-archive retention-14d --expire-days 14
-npx wrangler r2 bucket lifecycle add slicc-asset-archive-staging retention-14d --expire-days 14
-```
-
-Verify:
-
-```bash
-npx wrangler r2 bucket lifecycle list slicc-asset-archive
-npx wrangler r2 bucket lifecycle list slicc-asset-archive-staging
-```
-
-Each should output:
-
-```
-Age: 14 days → Expiration
-```
-
-### 3. `CLOUDFLARE_API_TOKEN` — required permission set (ALL of these)
-
-The deploy `CLOUDFLARE_API_TOKEN` secret is used for **the whole worker deploy**, not just R2. When editing/recreating it (**Account Settings → API Tokens → Edit token**), it MUST keep every scope below — dropping any one wedges releases:
-
-- **Account → Workers Scripts → Edit** — deploy the worker script + Static Assets.
-- **Account → Workers R2 Storage → Edit** (a.k.a. R2 Object Read & Write) on **both** buckets (`slicc-asset-archive`, `slicc-asset-archive-staging`) — the asset-archive upload + serving.
-- **Zone → Workers Routes → Edit** _and_ **Zone → Zone → Read** for the **`sliccy.ai`** zone (all zones is fine) — reconcile the `www.sliccy.ai/*` + `*.sliccy.now/*` routes on deploy.
-
-> ⚠️ **Incident (2026-07-13):** granting R2 to this token dropped its **Zone/Workers-Routes** scope. The worker _script_ still deployed (so sliccy.ai kept serving the latest build), but `wrangler deploy` then failed reconciling routes (`"does not have 'All Zones' permissions" … /workers/routes failed`), which failed `publish-worker.sh` and aborted the release **before** the GitHub-release/Chrome/npm publish steps — so GitHub Releases + Chrome froze while tags advanced. `publish-worker.sh` now treats a **routes-only** deploy failure as non-fatal (the version is already live), but the token should still carry the routes scope so route _changes_ apply. When editing the token, add scopes; never replace the whole set with only R2.
+See [`docs/tray-worker-operations.md`](../../docs/tray-worker-operations.md) for the
+full ops runbook: bucket creation, lifecycle rules, API token required permissions,
+upload gate mechanics, and the 2026-07-13 incident.
 
 ## Commands
 
@@ -195,232 +151,82 @@ cd packages/cloudflare-worker && WORKER_BASE_URL=https://... npm test -- tests/d
 npm run start:extension
 ```
 
-### Local `serve --bridge` (driveable preview) testing — no deploy
-
-The hub worker serves previews itself (`src/preview-handler.ts`) and owns the
-bridge-WS Durable Object, and `previewTokenFromHost` accepts `<token>.localhost[:port]`
-(matching the `localhost:8787` row in `buildPreviewUrl`), so the whole
-driveable-preview bridge is testable against a single local `wrangler dev` — no
-`slicc-preview` worker, no deploy:
-
-```bash
-# 1. Hub worker — MUST use --env staging (its routes:[] lets wrangler dev honor
-#    the real per-request Host, so the tray's capability URLs AND the
-#    <token>.localhost preview subdomains stay local). Plain `wrangler dev` uses
-#    the prod routes (www.sliccy.ai/*), so the controller URL points at prod and
-#    the leader never establishes a tray session ("leader tray has no active session").
-npx wrangler dev --config packages/cloudflare-worker/wrangler.jsonc --env staging \
-  --port 8787 --ip 127.0.0.1
-
-# 2. Leader → local hub. BRIDGE_DEV_ALLOWED_ORIGINS whitelists the leader's
-#    localhost origin for the /cdp bridge WS upgrade (else "origin-not-allowed").
-BRIDGE_DEV_ALLOWED_ORIGINS=http://localhost:8787 \
-  npm run dev -- --lead http://localhost:8787
-
-# 3. In the Slicc shell: `serve --bridge <dir>` mints http://<token>.localhost:8787/
-```
-
-Reach the worker via **localhost:8787**, not `127.0.0.1:8787` — `buildPreviewUrl`'s
-lookup table only has a `localhost:8787` row. Open the minted URL in a second
-browser → connect lick → drive via `--runtime=preview:<token>:<connId>` → the
-page's `window.slicc.emit(...)` lands as an attributed **Preview Event** lick
-(chip shows `preview:<token>:<connId>`) → `serve --stop <token>`.
-(Browsers resolve `*.localhost` to loopback; the `.localhost` host is dev-only —
-deployed workers only ever see `*.sliccy.now|dev` via Cloudflare routes.)
-
-## Staging Deployment & Testing
-
-### Cloudflare account
-
-Production and staging workers live on the **AEM Demo** account (`155ec15a52a18a14801e04b019da5e5a`). Verify with `npx wrangler whoami` — if it shows a different account, re-authenticate:
-
-```bash
-! npx wrangler login   # interactive — pick "AEM Demo" in the browser
-```
-
-### Two workers must be deployed together
-
-The tray hub and preview workers share a Durable Object but route through different entry points:
-
-| Worker   | Config                   | Staging name             | Routes                     |
-| -------- | ------------------------ | ------------------------ | -------------------------- |
-| Main hub | `wrangler.jsonc`         | `slicc-tray-hub-staging` | `*.workers.dev` (API + UI) |
-| Preview  | `wrangler-preview.jsonc` | `slicc-preview-staging`  | `*.sliccy.dev/*`           |
-
-```bash
-cd packages/cloudflare-worker
-npx wrangler deploy --config wrangler.jsonc --env staging
-npx wrangler deploy --config wrangler-preview.jsonc --env staging
-```
-
-### UI assets are required
-
-The hub worker serves the webapp via Cloudflare Workers Static Assets from `dist/ui/`. A bare worktree only has `electron-overlay-entry.js` — the staging deploy will succeed but every page load returns 404.
-
-**Fix:** symlink the main repo's built UI into the worktree before deploying:
-
-```bash
-trash dist/ui  # or rm -rf
-ln -s /path/to/main-repo/dist/ui dist/ui
-```
-
-If the main repo doesn't have a build either, run `npm run build -w @slicc/webapp` there first.
-
-### Testing `serve` against staging
-
-The `serve` command mints preview URLs via the tray hub. It needs:
-
-1. A **leader tray session** connected to the staging hub
-2. The tray API calls to be **same-origin** (no CORS)
-
-**Use `--lead` from the main repo** (not the worktree — it has no node-server):
-
-```bash
-cd /path/to/main-repo
-npm run dev -- --lead https://slicc-tray-hub-staging.minivelos.workers.dev
-```
-
-This loads the webapp from the staging hub (same-origin → no CORS) and auto-connects as a tray leader.
-
-**Do NOT use `SLICC_TRAY_WORKER_BASE_URL`** — it overrides only the tray WebSocket target while the UI loads from a different origin (localhost or sliccy.ai), causing cross-origin "Failed to fetch" errors on every tray API call.
-
-**Do NOT use `host leave --leader <url>`** from a localhost-served UI for the same CORS reason.
-
-### Test checklist
-
-Once `npm run dev -- --lead <staging-url>` is running and the tray is connected:
-
-```bash
-# In Slicc shell:
-echo '<h1>test</h1>' > /workspace/test/index.html
-serve /workspace/test
-# → should print a https://<token>.sliccy.dev URL
-```
-
-- **Hibernation**: wait ~2 min idle, reload the URL — should not 502
-- **Cache**: reload within 5s — should be faster (CF cache hit)
-- **Staleness**: edit the file, wait 5s, reload — new content
-- **ETag**: `curl -I <url>`, copy `etag`, then `curl -H 'If-None-Match: "<etag>"' <url>` → 304
-
-This lives at the repo root because it coordinates the worker with browser runtimes.
-
 ## CI and Deployment
 
-- Worker deploy automation lives in `.github/workflows/worker.yml`.
-- The automated semantic-release path gates production deployment with
-  `release-native.mjs --gate=worker`, comparing the previous release tag to
-  `HEAD`, except when `HEAD` is the generated `chore(release):` version-bump
-  commit, where it compares to `HEAD^` so that commit alone does not open the
-  gate. Changes under the worker, served webapp/UI packages, shared worker
-  dependencies, root package metadata, or hosted e2b template inputs deploy
-  both workers and run the live smoke tests. First releases always deploy;
-  releases with only unrelated changes refresh the R2 archive and exit before
-  the template push, secret writes, both `wrangler deploy` calls, and deployed
-  smoke tests.
-- The R2 refresh intentionally remains unconditional because bucket lifecycle
-  GC expires objects after 14 days. A worker-deploy skip streak is unbounded, so
-  relying on that TTL would eventually delete still-current archived chunks.
-- Production hub and preview deploys each retry up to six times with a 15-second
-  delay. Each attempt enables Wrangler debug logging; exhausting all attempts
-  prints that worker's debug log to CI stderr before failing.
-- **Routes-only failures are non-fatal.** `deploy_with_retry` captures each
-  attempt's combined output and, on failure, classifies it with
-  `release-native.mjs --classify-deploy-log` (pure `isRoutesReconcileOnlyFailure`,
-  unit-tested). A failure is treated as a successful deploy (with a loud warning)
-  when BOTH signals are present: the worker version **uploaded**
-  (`Uploaded <name> (<n> sec)` → the new script + assets are live) **and** the
-  routes-API call failed (`A request to the Cloudflare API (…/workers/routes)
-failed` → only route reconciliation failed, e.g. the token lost Zone → Workers
-  Routes → Edit). Requiring the upload line rules out a pre-deploy routes failure
-  (version never went live). Wrangler phrases the routes failure **two ways** — the
-  hub wraps it in `Some triggers failed to deploy`, the **preview worker** surfaces
-  the bare routes-API auth error — so the classifier keys off the upload +
-  routes-API-failure signals rather than the "triggers failed" wrapper (which the
-  preview worker omits; matching only that wrapper regressed the 5.56.4 release —
-  the hub was tolerated but the preview deploy still aborted). Routes are
-  set-once/stable, so the new version is already serving; the release continues to
-  the GitHub-release/Chrome/npm publish steps instead of aborting, and the warning
-  flags that any _changed_ routes did not apply until the token's routes scope is
-  restored (see the Ops Runbook above). Any other failure (script upload, bindings,
-  asset-too-large) still retries and then fails hard.
-- Required repo configuration:
-  - secret: `CLOUDFLARE_API_TOKEN`
-  - variable: `CLOUDFLARE_ACCOUNT_ID`
-- Wrangler surfaces deployed URLs that are used by `packages/cloudflare-worker/tests/deployed.test.ts`.
-- **Both workers ship together.** The hub (`wrangler.jsonc`) and the preview
-  worker (`wrangler-preview.jsonc`) share the same preview-URL token format
-  (`buildPreviewUrl` in `@slicc/shared-ts` ↔ `previewTokenFromHost` in
-  `src/preview-host.ts`) and the same Durable Object (bound in the preview config
-  via `script_name`). They MUST be deployed as a pair — a hub-only deploy that
-  changes the URL format leaves a stale preview worker unable to parse the new
-  URLs, so every `serve` preview 404s "Preview not found" (regression: PR #1355's
-  user-hash label). The automated release (`scripts/publish-worker.sh`) therefore
-  deploys **both** — the hub, then the preview worker — and the manual
-  `worker.yml` dispatch and staging `ci.yml` both already do the same. Before this
-  fix, `publish-worker.sh` deployed only the hub, so the prod preview worker only
-  updated on a rare manual `worker.yml` dispatch and drifted.
+The automated release gates production deployment with `release-native.mjs --gate=worker`.
+The hub (`wrangler.jsonc`) and preview worker (`wrangler-preview.jsonc`) **must deploy as
+a pair** — they share the same DO and preview URL token format. The R2 archive upload
+runs unconditionally before every deploy. Routes-only failures are non-fatal (script
+already live). Required secrets: `CLOUDFLARE_API_TOKEN` (Workers Edit + R2 R/W + Zone
+Routes Edit) and `CLOUDFLARE_ACCOUNT_ID`.
+
+See [`docs/tray-worker-operations.md`](../../docs/tray-worker-operations.md) for: retry
+logic, routes-only failure classification, the staging deployment guide, and the local
+`serve --bridge` test setup.
 
 ## Operational Notes
 
 - Treat the worker as coordination infrastructure, not canonical session storage.
-- The `/handoff` page is intentionally stateless; the recognised query parameters are translated into a single RFC 8288 `Link` response header and the page body is only an informational preview.
-- Every worker response is wrapped by `applySliccLinks` (see `src/links.ts`) so a standard rel set (`api-catalog`, `service-desc`, `service-doc`, `status`, `https://llmstxt.org/rel/llms-txt`, `terms-of-service`, `license`) ships on every reply alongside any route-specific Link entries.
-- Keep signaling protocol changes aligned with the browser tray runtime in `packages/webapp/src/scoops/`.
-- **When adding or changing routes**, update ALL THREE test/config locations:
-  1. `tests/index.test.ts` — unit test that checks the routes list in the root 200 response
-  2. `tests/deployed.test.ts` — smoke test that runs against the deployed staging worker (also checks routes list)
-  3. The routes array in `src/index.ts` (the default 200 response)
-     Missing any of these causes CI failures — the staging smoke test deploys the worker then verifies the routes match.
+- The `/handoff` page is stateless; query parameters are translated into a single RFC
+  8288 `Link` response header.
+- Every worker response is wrapped by `applySliccLinks` (see `src/links.ts`) — standard
+  rel set ships on every reply.
+- Keep signaling protocol changes aligned with the browser tray runtime in
+  `packages/webapp/src/scoops/`.
 
-## Cloud cones (sliccy.ai/cloud)
+## Cloud Cones (sliccy.ai/cloud)
 
-Web feature shipped via Plan D.
+Web feature shipped via Plan D. All `/api/cloud/*` require
+`Authorization: Bearer <ims-access-token>` and route to
+`env.CLOUD_SESSIONS.idFromName(userId)` for per-user state.
 
 ### Routes
 
-- `GET  /cloud` — dashboard SPA (CSP-enforced)
-- `GET  /auth/cloud-callback` — IMS popup callback (HTML)
-- `GET  /auth/cloud-callback.js` — IMS popup callback (JS, served inline by worker)
-- `POST /api/cloud/start` — start a new cone (auth + cap-checked); optional `coneConfig` bundle (see below)
-- `GET  /api/cloud/list` — per-user cone list (reconciled with e2b per call)
-- `GET  /api/cloud/cone-config` — `?sandboxId=<id>`: returns the cone's **names-only** config index (model + account providerIds + secret names; no values) so the dashboard can show provisioned keys while the cone is paused
-- `POST /api/cloud/pause` — pause a cone
-- `POST /api/cloud/resume` — resume a paused cone (refreshes IMS token in sandbox); optional `coneConfigDelta` (see below)
-- `POST /api/cloud/kill` — kill a cone (idempotent)
-- `POST /api/cloud/sign-out` — invalidate the auth cache entry for the bearer
-- `GET  /api/cloud/admin/stats` — admin-gated by `ADMIN_USER_IDS`
+| Route                         | Description                                                                 |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| `GET /cloud`                  | Dashboard SPA (CSP-enforced)                                                |
+| `GET /auth/cloud-callback`    | IMS popup callback (HTML)                                                   |
+| `GET /auth/cloud-callback.js` | IMS popup callback (JS, served inline by worker)                            |
+| `POST /api/cloud/start`       | Start a new cone (auth + cap-checked); optional `coneConfig` bundle         |
+| `GET /api/cloud/list`         | Per-user cone list (reconciled with e2b per call)                           |
+| `GET /api/cloud/cone-config`  | `?sandboxId=<id>`: names-only config index (model + account + secret names) |
+| `POST /api/cloud/pause`       | Pause a cone                                                                |
+| `POST /api/cloud/resume`      | Resume a paused cone; optional `coneConfigDelta`                            |
+| `POST /api/cloud/kill`        | Kill a cone (idempotent)                                                    |
+| `POST /api/cloud/sign-out`    | Invalidate auth cache for the bearer                                        |
+| `GET /api/cloud/admin/stats`  | Admin-gated by `ADMIN_USER_IDS`                                             |
 
-All `/api/cloud/*` require `Authorization: Bearer <ims-access-token>` and route to `env.CLOUD_SESSIONS.idFromName(userId)` for per-user state. Lifecycle business logic lives inside the DurableObject (atomic via `state.blockConcurrencyWhile`), not in worker handlers.
+### Cone Configuration
 
-### Cone configuration (model, secrets, provider logins)
+A `ConeConfig` bundle (`{ model, accounts[], secrets[] }`, types in
+`@slicc/cloud-core/cone-config`) lets users pick the cone's model, provide flat secrets,
+and provision provider logins. `src/cloud/cone-config-bridge.ts` handles the start/resume
+flows:
 
-A `ConeConfig` bundle (`{ model, accounts[], secrets[] }`, types + helpers in the side-effect-free `@slicc/cloud-core/cone-config` subpath) lets users pick the cone's model, provide flat secrets, and provision provider logins (API-key and OAuth). `accounts` carry `kind: 'oauth' | 'apikey'`. Flow (`src/cloud/cone-config-bridge.ts`):
+- **start:** validates config, splits into `/slicc/secrets.env` and
+  `/slicc/cone-config.json`. No config ⇒ synthesizes Adobe default from the cloud bearer.
+- **resume:** merges a `coneConfigDelta` into both files in-sandbox, then reloads the
+  leader via `POST /api/secrets/reload` → `Page.reload`.
+- **Adobe oauth expiry:** every path that synthesizes an Adobe `{kind:'oauth'}` account
+  stamps `tokenExpiresAt` via `imsTokenExpiry` in `@slicc/cloud-core/cone-config`
+  (decodes the IMS JWT's `created_at + expires_in` with `atob`).
+- **DO index:** `CloudSessionsDurableObject` persists a **names-only** `coneConfigIndex`
+  per cone — never values.
 
-- **start:** `coneConfig` is validated (`validateConeConfig` + narrow `assertModelHasAccount` — the model's provider must have an account unless auth-optional), then `bundleToFiles` splits it into `/slicc/secrets.env` (flat secrets, what `startCone` already writes) and `/slicc/cone-config.json` (`{model,accounts}`). No `coneConfig` ⇒ the worker synthesizes the Adobe default from the cloud bearer (back-compat with old dashboards that send only `{ name }`). Body size is capped at `MAX_CONE_CONFIG_BYTES`.
-- **resume:** `coneConfigDelta` (`{ model?, upsert{accounts,secrets}, delete{providerIds,secretNames} }`) is merged into both files in-sandbox (read-modify-write, preserving unchanged values), then node-server is reloaded via the ordered hook `POST /api/secrets/reload` → leader-restart `Page.reload`. Pre-feature cones (only `secrets.env`, no `cone-config.json`) get a degenerate bundle synthesized on first resume.
-- **Adobe oauth account expiry:** every site that synthesizes an Adobe `{kind:'oauth'}` account from a bare IMS bearer — the start back-compat path (`cone-config-bridge.ts`), the resume re-push (`cloud-sessions-do.ts`), and node-server's CLI legacy branch (`hosted-bootstrap.ts`) — stamps `tokenExpiresAt` via the shared, dependency-free `imsTokenExpiry` helper in `@slicc/cloud-core/cone-config` (decodes the IMS JWT's `created_at + expires_in` with `atob`, not `node:Buffer`). Without it, the window-less kernel-worker cone treats the still-valid token as expired (it cannot silent-renew) and throws "Adobe session expired" on the first turn.
-- **DO index:** `CloudSessionsDurableObject` persists a **names-only** `coneConfigIndex` on each `ConeEntry` (model + providerIds + secret names; **never values**), surfaced by `GET /api/cloud/cone-config`. The worker is a transient relay — it never persists bundle values and never logs them.
+### Wrangler Config (cloud)
 
-### Wrangler config
+Vars in `wrangler.jsonc`:
 
-Vars (in `wrangler.jsonc`):
-
-- `ADOBE_PROXY_ENDPOINT` — Adobe LLM proxy URL. Default `https://adobe-llm-proxy.paolo-moz.workers.dev`. Worker fetches `/v1/config` to learn IMS client_id + scopes + environment, keeping dashboard popup config in sync with what the cone needs to call the proxy.
+- `ADOBE_PROXY_ENDPOINT` — Adobe LLM proxy URL.
 - `ALLOWED_EMAIL_DOMAIN` — CSV, default `adobe.com`. Set to `*` to allow any domain.
-- `BLOCKED_EMAILS` — CSV denylist (emails explicitly blocked even if domain allowed).
-- `REQUIRE_OWNER_ORG` — `true` for v2 expansion to any ownerOrg-holder.
+- `BLOCKED_EMAILS` — CSV denylist.
+- `REQUIRE_OWNER_ORG` — `true` for expansion to any ownerOrg-holder.
 - `CONE_CAP_RUNNING`, `CONE_CAP_PAUSED` — per-user caps (default 1 / 5).
 - `ADMIN_USER_IDS` — CSV of IMS userIds with admin access.
 
-Secrets (`wrangler secret put`):
+Secrets (`wrangler secret put`): `E2B_API_KEY` (Adobe team key; worker-only).
 
-- `E2B_API_KEY` — Adobe team e2b key. Worker-only; never reachable from browser.
-
-GitHub Actions secrets (for CI worker deploy + template build):
-
-- `E2B_API_KEY` — same value; scoped to the Adobe team workspace.
-
-### v1 → v2 expansion
+### v1 → v2 Expansion
 
 ```bash
 npx wrangler secret put REQUIRE_OWNER_ORG  # value: true
@@ -428,21 +234,15 @@ npx wrangler secret put REQUIRE_OWNER_ORG  # value: true
 npx wrangler deploy
 ```
 
-### Stable API contract (worker ↔ sandbox)
+### Stable API Contract (worker ↔ sandbox)
 
-Worker depends on these surfaces inside paused-cone images. **Breaking changes require a deprecation cycle** because paused cones from older templates cannot be patched in-place:
+These surfaces inside paused-cone images have a deprecation obligation — paused cones
+from older templates cannot be patched in-place:
 
-- `POST /api/leader-restart` (loopback in sandbox) — re-kicks the leader.
-- `GET  /api/hosted-bootstrap` (loopback in sandbox) — page reads ADOBE_IMS_TOKEN.
-- `POST /api/cloud-status` (loopback in sandbox) — page reports join state.
-- `/slicc/secrets.env` — sandbox file the worker writes via SDK.
-- `/tmp/slicc-join.json` — sandbox file the worker reads via SDK.
-- `ADOBE_IMS_TOKEN`, `ADOBE_IMS_TOKEN_DOMAINS`, `SLICC_TRAY_WORKER_BASE_URL` — envs consumed by `start.sh`.
-
-### Routes-mirror rule (applies to /api/cloud/\* too)
-
-Per the existing tray hub rule — every new route must appear in three places:
-
-- `src/index.ts` routes array (the default `GET /` body)
-- `tests/index.test.ts` routes-list assertion
-- `tests/deployed.test.ts` routes-list assertion
+- `POST /api/leader-restart` (loopback in sandbox)
+- `GET /api/hosted-bootstrap` (loopback in sandbox)
+- `POST /api/cloud-status` (loopback in sandbox)
+- `/slicc/secrets.env` — sandbox file the worker writes via SDK
+- `/tmp/slicc-join.json` — sandbox file the worker reads via SDK
+- `ADOBE_IMS_TOKEN`, `ADOBE_IMS_TOKEN_DOMAINS`, `SLICC_TRAY_WORKER_BASE_URL` — envs
+  consumed by `start.sh`

--- a/packages/dev-tools/tools/check-doc-sizes-lib.mjs
+++ b/packages/dev-tools/tools/check-doc-sizes-lib.mjs
@@ -1,11 +1,8 @@
 // Pure logic for the packages/*/CLAUDE.md size-budget check.
 //
 // Every `packages/*/CLAUDE.md` is budgeted at PACKAGE_CLAUDE_MAX_CHARS.
-// Two files that still exceed the cap are grandfathered with per-file
-// exemptions at current-size-rounded-up. The
-// exemption list is FROZEN: values may only be lowered or deleted, never
-// added or raised. The nightly ratchet (follow-up issue #1469) will lower
-// them mechanically.
+// The exemption list is FROZEN: values may only be lowered or deleted, never
+// added or raised.
 //
 // The pure functions here (no IO) are unit-tested by the `dev-tools` vitest
 // project. The thin IO + CLI wiring lives in `check-doc-sizes.mjs`.
@@ -15,9 +12,7 @@ export const PACKAGE_CLAUDE_MAX_CHARS = 20000;
 // Frozen grandfathered exemptions for files that exceeded PACKAGE_CLAUDE_MAX_CHARS
 // when this gate was introduced (issue #1532, part of #1469 Wave 1).
 // FROZEN: never add or raise entries. Lower or remove only.
-export const PACKAGE_CLAUDE_EXEMPTIONS = {
-  'packages/cloudflare-worker/CLAUDE.md': 45000, // TODO(#1469) trim to ≤20K
-};
+export const PACKAGE_CLAUDE_EXEMPTIONS = {};
 
 /**
  * Resolve the effective character limit for a given package CLAUDE.md path.

--- a/packages/dev-tools/tools/check-doc-sizes-lib.test.mjs
+++ b/packages/dev-tools/tools/check-doc-sizes-lib.test.mjs
@@ -30,40 +30,24 @@ describe('PACKAGE_CLAUDE_MAX_CHARS', () => {
 });
 
 describe('PACKAGE_CLAUDE_EXEMPTIONS', () => {
-  it('contains exactly the one grandfathered file', () => {
-    const keys = Object.keys(PACKAGE_CLAUDE_EXEMPTIONS).sort();
-    expect(keys).toEqual(['packages/cloudflare-worker/CLAUDE.md']);
-  });
-
-  it('has the correct exemption values', () => {
-    expect(PACKAGE_CLAUDE_EXEMPTIONS['packages/cloudflare-worker/CLAUDE.md']).toBe(45000);
+  it('is empty (all packages graduated)', () => {
+    expect(Object.keys(PACKAGE_CLAUDE_EXEMPTIONS)).toEqual([]);
   });
 
   it('graduated packages are not in the exemption map', () => {
+    expect(PACKAGE_CLAUDE_EXEMPTIONS['packages/webapp/CLAUDE.md']).toBeUndefined();
+    expect(PACKAGE_CLAUDE_EXEMPTIONS['packages/cloudflare-worker/CLAUDE.md']).toBeUndefined();
     expect(PACKAGE_CLAUDE_EXEMPTIONS['packages/chrome-extension/CLAUDE.md']).toBeUndefined();
     expect(PACKAGE_CLAUDE_EXEMPTIONS['packages/dev-tools/CLAUDE.md']).toBeUndefined();
-    expect(PACKAGE_CLAUDE_EXEMPTIONS['packages/webapp/CLAUDE.md']).toBeUndefined();
-  });
-
-  it('all exemption values exceed the default cap (they are grandfathered)', () => {
-    for (const [path, limit] of Object.entries(PACKAGE_CLAUDE_EXEMPTIONS)) {
-      expect(limit, `${path} exemption should exceed PACKAGE_CLAUDE_MAX_CHARS`).toBeGreaterThan(
-        PACKAGE_CLAUDE_MAX_CHARS
-      );
-    }
   });
 });
 
 describe('resolvePackageClaudeLimit', () => {
-  it('returns the exemption value for grandfathered files', () => {
-    expect(resolvePackageClaudeLimit('packages/cloudflare-worker/CLAUDE.md')).toBe(45000);
-  });
-
-  it('returns PACKAGE_CLAUDE_MAX_CHARS for webapp (graduated out of grandfathering)', () => {
+  it('returns PACKAGE_CLAUDE_MAX_CHARS for all packages (no exemptions)', () => {
     expect(resolvePackageClaudeLimit('packages/webapp/CLAUDE.md')).toBe(PACKAGE_CLAUDE_MAX_CHARS);
-  });
-
-  it('returns PACKAGE_CLAUDE_MAX_CHARS for non-exempted packages', () => {
+    expect(resolvePackageClaudeLimit('packages/cloudflare-worker/CLAUDE.md')).toBe(
+      PACKAGE_CLAUDE_MAX_CHARS
+    );
     expect(resolvePackageClaudeLimit('packages/cherry/CLAUDE.md')).toBe(PACKAGE_CLAUDE_MAX_CHARS);
     expect(resolvePackageClaudeLimit('packages/chrome-extension/CLAUDE.md')).toBe(
       PACKAGE_CLAUDE_MAX_CHARS
@@ -140,25 +124,9 @@ describe('checkPackageClaudes', () => {
     expect(results[0].size).toBe(PACKAGE_CLAUDE_MAX_CHARS + 1);
   });
 
-  it('uses the exemption limit for grandfathered files', () => {
+  it('all packages resolve at the default 20000 limit', () => {
     const path = 'packages/cloudflare-worker/CLAUDE.md';
-    const sizes = new Map([[path, 30000]]);
-    const [result] = checkPackageClaudes([path], sizes);
-    expect(result.limit).toBe(45000);
-    expect(result.pass).toBe(true);
-  });
-
-  it('fails a grandfathered file if it exceeds its own exemption', () => {
-    const path = 'packages/cloudflare-worker/CLAUDE.md';
-    const sizes = new Map([[path, 46000]]);
-    const [result] = checkPackageClaudes([path], sizes);
-    expect(result.limit).toBe(45000);
-    expect(result.pass).toBe(false);
-  });
-
-  it('webapp resolves at the default 20000 limit (no longer grandfathered)', () => {
-    const path = 'packages/webapp/CLAUDE.md';
-    const sizes = new Map([[path, 19991]]);
+    const sizes = new Map([[path, 18000]]);
     const [result] = checkPackageClaudes([path], sizes);
     expect(result.limit).toBe(PACKAGE_CLAUDE_MAX_CHARS);
     expect(result.pass).toBe(true);
@@ -202,22 +170,16 @@ describe('check-doc-sizes.mjs: package CLAUDE.md integration', () => {
     expect(out).toMatch(/ok: packages\/node-server\/CLAUDE\.md is \d+\/20000 chars/);
   });
 
-  it('reports webapp at the default 20000 limit (not grandfathered)', () => {
-    expect(out).toMatch(/ok: packages\/webapp\/CLAUDE\.md is \d+\/20000 chars\n/);
-    expect(out).not.toMatch(/packages\/webapp\/CLAUDE\.md.*grandfathered/);
-  });
-
-  it('labels grandfathered files in the output', () => {
-    expect(out).toMatch(
-      /ok: packages\/cloudflare-worker\/CLAUDE\.md is \d+\/45000 chars \(grandfathered\)/
-    );
+  it('no files are grandfathered', () => {
+    expect(out).not.toMatch(/grandfathered/);
   });
 
   it.each([
+    'webapp',
+    'cloudflare-worker',
     'chrome-extension',
     'dev-tools',
-  ])('reports %s at the 20000 default (not grandfathered)', (packageName) => {
+  ])('reports %s at the 20000 default', (packageName) => {
     expect(out).toMatch(new RegExp(`ok: packages/${packageName}/CLAUDE\\.md is \\d+/20000 chars`));
-    expect(out).not.toMatch(new RegExp(`packages/${packageName}/CLAUDE\\.md.*\\(grandfathered\\)`));
   });
 });

--- a/packages/dev-tools/tools/check-doc-sizes.mjs
+++ b/packages/dev-tools/tools/check-doc-sizes.mjs
@@ -90,9 +90,8 @@ try {
 
 // packages/*/CLAUDE.md — every package is budgeted at PACKAGE_CLAUDE_MAX_CHARS.
 // Auto-discovered so new packages are covered without editing this script.
-// Two files still exceed the cap and are grandfathered with frozen per-file
-// exemptions in check-doc-sizes-lib.mjs; the nightly ratchet
-// (issue #1469) will lower them mechanically.
+// All packages are now within the cap. The exemption map in
+// check-doc-sizes-lib.mjs is empty.
 const packagesDir = resolve(repoRoot, 'packages');
 const packageDirs = readdirSync(packagesDir).filter((entry) => {
   try {


### PR DESCRIPTION
Closes #1537

Part of #1469 Wave 2.

## Summary

Trims `packages/cloudflare-worker/CLAUDE.md` from 44,250 chars to 18,067 chars by relocating ops/runbook detail into a new `docs/tray-worker-operations.md`. Removes the grandfathered exemption entry in `check-doc-sizes-lib.mjs`.

## Section-to-Destination Mapping

| Source section | Destination |
|---|---|
| R2 Asset Retention — full detail (serving path, upload gate, GC options A/B, MIME map, testing) | `docs/tray-worker-operations.md` § R2 Asset Archive |
| Ops Runbook: R2 Prerequisites (bucket creation, lifecycle rules, API token permissions, 2026-07-13 incident) | `docs/tray-worker-operations.md` § Ops Runbook: R2 Prerequisites |
| Signaling model — ghost-leader reconnect rationale | `docs/tray-worker-operations.md` § Ghost-Leader Reconnect |
| CI and Deployment — retry logic, routes-only failure classification, deploy pair requirement | `docs/tray-worker-operations.md` § CI and Deployment |
| Staging Deployment & Testing — full guide, two-worker setup, UI asset workaround, test checklist | `docs/tray-worker-operations.md` § Staging Deployment & Testing |
| Local serve --bridge testing (wrangler dev steps) | `docs/tray-worker-operations.md` § Local serve --bridge testing |

## What Was Kept in cloudflare-worker/CLAUDE.md

- Main Files table (condensed descriptions)
- Tray-hub role and DO architecture summary
- Public Routes (converted to compact table from verbose bullet list)
- Signaling model summary (ghost-leader → pointer to runbook)
- TURN credentials, tray kind, static asset serving overview
- R2 overview (1 paragraph + link to runbook)
- Commands (unchanged)
- CI and Deployment summary (→ pointer to runbook)
- Operational Notes
- Cloud cones routes, config, and stable API contract

## Changes

- `packages/cloudflare-worker/CLAUDE.md`: 44,250 → 18,067 chars
- `docs/tray-worker-operations.md`: new (14,576 chars)
- `docs/CLAUDE.md`: +1 row in Common Destinations table
- `packages/dev-tools/tools/check-doc-sizes-lib.mjs`: removed cloudflare-worker exemption; updated comment from "Four files" to "Three files"

## Verification

- `node packages/dev-tools/tools/check-doc-sizes.mjs` — passes (18,067/20,000 chars, no longer grandfathered)
- `node packages/dev-tools/tools/check-doc-refs.mjs` — passes (no dead references in 44 doc files)
- Breadcrumb scan — no PR numbers in modified files
- `npm run lint:ci` — exits 0 (106 pre-existing biome warnings unchanged)
