### PR TITLE
docs: drop deleted offscreen.ts from provider-registration entry points

### DIFF
--- a/packages/webapp/src/kernel/spawn.ts
+++ b/packages/webapp/src/kernel/spawn.ts
@@ -337,7 +337,7 @@ export function bootstrapKernelWorker(options: KernelWorkerBootstrapOptions): Sp
  * modules natively, no Rollup hoisting). The fix lives in
  * `providers/index.ts`: `import.meta.glob` is now lazy and
  * registration is explicit via `registerProviders()`. Entry points
- * (this worker's `boot()`, `main.ts`, `offscreen.ts`) await it during
+ * (this worker's `boot()` and the page's `main.ts`) await it during
  * boot.
  */
 export function spawnKernelWorker(options: KernelWorkerSpawnOptions): SpawnedKernelHost {

--- a/packages/webapp/src/providers/index.ts
+++ b/packages/webapp/src/providers/index.ts
@@ -64,7 +64,7 @@ interface ProviderModule {
 // ui/provider-settings → providers/index) that hits TDZ in the
 // kernel worker's native ESM module graph. Registration is now
 // explicit via `registerProviders()`; entry points (`main.ts`,
-// `offscreen.ts`, `kernel-worker.ts`) await it during boot.
+// `kernel-worker.ts`) await it during boot.
 
 const builtInModules = import.meta.glob('./built-in/*.ts') as Record<
   string,


### PR DESCRIPTION
## What

Two source comments still listed `offscreen.ts` as a `registerProviders()` entry point. That file was deleted in the thin-bridge migration (`54eb0811e`), so the claim points agents at a non-existent boot site.

- `packages/webapp/src/providers/index.ts` — removed `offscreen.ts`; real entry points are `main.ts` (page) and `kernel-worker.ts` (worker boot).
- `packages/webapp/src/kernel/spawn.ts` — same drift in the spawn JSDoc; now names the worker `boot()` and the page's `main.ts`.

## Note on the issue's primary target

The stale root `CLAUDE.md:218` line called out in the issue was already resolved: the `docs-trim` commit `e9765b0f6` relocated the "Provider composition" bullet to `packages/webapp/CLAUDE.md`, dropping the `offscreen.ts` claim. This PR cleans up the two remaining source-comment instances of the same drift.

Out of scope (verified accurate): `docs/architecture.md:417` ("no offscreen branch survives") and the `OffscreenClient` import in `spawn.ts:32` (the surviving panel client stub).

Comment-only change — biome clean; no behavior change.

Fixes #1553