### PR TITLE
feat(secrets): timestamp-bound HMAC signing via 3-segment x-slicc-hmac-sign spec

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -194,6 +194,56 @@ Different types of HTTP traffic route through different code paths:
 | LLM provider streaming (Anthropic, etc.)   | direct `fetch()` from page; routed via `llm-proxy-sw.ts` to `/api/fetch-proxy` (CLI) or extension `host_permissions` (CORS bypass; no secret injection — provider holds real key in webapp memory) |
 | `aws s3 cp` from agent shell (raw S3 HTTP) | shell → `createProxiedFetch` → upstream. NOT signed. **Use `mount` instead.**                                                                                                                      |
 
+## HMAC request signing
+
+Some APIs (webhook receivers, signed job queues) don't take a bearer token — they require the caller to attach an `HMAC-SHA256(secret, body)` digest as a custom header. The agent can't compute that itself without seeing the real secret, so the fetch proxy computes it on the agent's behalf.
+
+Send the request through the fetch proxy with an `x-slicc-hmac-sign` directive header:
+
+```
+x-slicc-hmac-sign: <secretName>:<targetHeaderName>
+```
+
+For example, to call a webhook that expects the signature in `x-job-signature`, signed with a secret named `SIGNING_KEY`:
+
+```bash
+curl -X POST https://jobs.example.com/enqueue \
+  -H "x-slicc-hmac-sign: SIGNING_KEY:x-job-signature" \
+  -d '{"task":"rebuild"}'
+```
+
+The proxy:
+
+1. Reads the `x-slicc-hmac-sign` spec and looks up `SIGNING_KEY` in the secret store.
+2. Checks the target hostname against `SIGNING_KEY`'s domain allowlist (same rule as any other secret — a mismatch returns `403` before anything is signed or forwarded).
+3. Computes `HMAC-SHA256(SIGNING_KEY_real_value, requestBody)` as a hex digest and attaches it under the header name you asked for (`x-job-signature` above).
+4. Strips the `x-slicc-hmac-sign` directive itself before forwarding — upstream never sees it.
+
+### Timestamp-bound signing (replay protection)
+
+A bare body digest never expires: whoever captures one valid signed request (a proxy log, a browser devtools tab, a MITM'd TLS termination point) can replay it forever, since the signature is a pure function of content that never changes. Many webhook schemes (Stripe, Slack, GitHub) guard against this by folding a timestamp into the signed message so the receiver can reject stale requests.
+
+Add a third, colon-separated segment naming the header the timestamp itself should be attached under:
+
+```
+x-slicc-hmac-sign: <secretName>:<targetHeaderName>:<timestampHeaderName>
+```
+
+```bash
+curl -X POST https://jobs.example.com/enqueue \
+  -H "x-slicc-hmac-sign: SIGNING_KEY:x-job-signature:x-job-timestamp" \
+  -d '{"task":"rebuild"}'
+```
+
+With the 3-segment form, the proxy signs `HMAC-SHA256(SIGNING_KEY_real_value, "<unixSeconds>.<requestBody>")` instead of the raw body, and attaches the unix-seconds timestamp it signed with under `x-job-timestamp` alongside the signature under `x-job-signature`. The receiver recomputes the same `<timestamp>.<body>` message using the timestamp header's value and rejects requests whose timestamp falls outside its freshness window (e.g. ±5 minutes) — this is what actually stops replay, since a captured request goes stale once the window passes.
+
+The 2-segment form (raw body digest, no expiry) is unchanged and still the right choice for receivers that don't check a timestamp at all.
+
+Notes:
+
+- `SIGNING_KEY` is a secret like any other — set it via `secret set SIGNING_KEY <value> --domain jobs.example.com --persist` or a `SIGNING_KEY=...` / `SIGNING_KEY_DOMAINS=...` pair in `~/.slicc/secrets.env`.
+- Implementation: `SecretsPipeline.signHmac` (`packages/shared-ts/src/secrets-pipeline.ts`), wired into the route in `packages/node-server/src/routes/fetch-proxy.ts` (and mirrored for the extension bridge in `packages/chrome-extension/src/fetch-proxy-shared.ts` and the swift-server bridge in `packages/swift-server/Sources/Keychain/SecretInjector.swift` / `packages/swift-server/Sources/Server/APIRoutes.swift`). The header-stripping is in `FETCH_PROXY_SKIP_HEADERS` (`packages/node-server/src/fetch-proxy-headers.ts`).
+
 ### Migration note for file-PAT users
 
 The file-on-disk PAT workaround (writing the real PAT to a file in the VFS so the agent could `cat` it) is no longer needed. Put PATs in `~/.slicc/secrets.env` (CLI) or the extension options page (extension); the agent sees only the masked value. The fetch proxy unmasks at the network boundary when the request domain matches the secret's allowlist.

--- a/packages/chrome-extension/src/fetch-proxy-shared.ts
+++ b/packages/chrome-extension/src/fetch-proxy-shared.ts
@@ -267,6 +267,9 @@ async function prepareUpstreamRequest(
     if (signResult.headerName && signResult.signatureHex) {
       headers[signResult.headerName] = signResult.signatureHex;
     }
+    if (signResult.timestampHeaderName && signResult.timestampValue) {
+      headers[signResult.timestampHeaderName] = signResult.timestampValue;
+    }
   }
 
   return { cleanedUrl, headers, body };

--- a/packages/chrome-extension/tests/fetch-proxy-shared.test.ts
+++ b/packages/chrome-extension/tests/fetch-proxy-shared.test.ts
@@ -366,6 +366,40 @@ describe('handleFetchProxyConnection — x-slicc-hmac-sign', () => {
     );
   });
 
+  it('signs "<unixSeconds>.<body>" and attaches the timestamp header for the 3-segment spec', async () => {
+    let fetchHeaders: Record<string, string> | undefined;
+    let fetchBody: unknown;
+    (globalThis as any).fetch = vi.fn(async (_url: string, init: any) => {
+      fetchHeaders = init.headers;
+      fetchBody = init.body;
+      return new Response('ok', { status: 200, statusText: 'OK' });
+    });
+
+    const body = JSON.stringify({ step: 3, status: 'running' });
+    const posts: any[] = [];
+    const port = makePort((m) => posts.push(m));
+    handleFetchProxyConnection(port, hmacPipeline);
+    port.fireMessage({
+      type: 'request',
+      url: 'https://worker.example.com/api/jobs/j1/events',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-slicc-hmac-sign': 'SIGNING_KEY:x-job-signature:x-job-timestamp',
+      },
+      bodyBase64: encodeBase64(body),
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(new TextDecoder().decode(fetchBody as Uint8Array)).toBe(body);
+    expect(fetchHeaders?.['x-slicc-hmac-sign']).toBeUndefined();
+    const timestamp = fetchHeaders?.['x-job-timestamp'];
+    expect(typeof timestamp).toBe('string');
+    expect(fetchHeaders?.['x-job-signature']).toBe(
+      createHmac('sha256', HMAC_SECRET).update(`${timestamp}.${body}`).digest('hex')
+    );
+  });
+
   it('response-error when the signing secret is scoped to a different domain', async () => {
     const fetchSpy = vi.fn();
     (globalThis as any).fetch = fetchSpy;

--- a/packages/node-server/src/routes/fetch-proxy.ts
+++ b/packages/node-server/src/routes/fetch-proxy.ts
@@ -164,6 +164,9 @@ async function applyHmacSigning(
   if (signResult.headerName && signResult.signatureHex) {
     headers[signResult.headerName] = signResult.signatureHex;
   }
+  if (signResult.timestampHeaderName && signResult.timestampValue) {
+    headers[signResult.timestampHeaderName] = signResult.timestampValue;
+  }
   return undefined;
 }
 

--- a/packages/node-server/src/secrets/proxy-manager.ts
+++ b/packages/node-server/src/secrets/proxy-manager.ts
@@ -121,6 +121,8 @@ export class SecretProxyManager {
   ): Promise<{
     headerName?: string;
     signatureHex?: string;
+    timestampHeaderName?: string;
+    timestampValue?: string;
     forbidden?: { secretName: string; hostname: string };
   }> {
     return this.pipeline.signHmac(spec, body, targetHostname);

--- a/packages/node-server/tests/routes/fetch-proxy.test.ts
+++ b/packages/node-server/tests/routes/fetch-proxy.test.ts
@@ -178,6 +178,38 @@ describe('registerFetchProxyRoute', () => {
     expect(receivedHeaders['x-slicc-hmac-sign']).toBeUndefined();
   });
 
+  it('signs "<unixSeconds>.<body>" and attaches the timestamp header for the 3-segment spec', async () => {
+    let receivedBody = '';
+    let receivedHeaders: import('node:http').IncomingHttpHeaders = {};
+    await setup((req, res) => {
+      receivedHeaders = req.headers;
+      const chunks: Buffer[] = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        receivedBody = Buffer.concat(chunks).toString('utf-8');
+        res.end('done');
+      });
+    });
+    const body = JSON.stringify({ step: 3, status: 'running' });
+    const res = await fetch(`${proxyBase}/api/fetch-proxy`, {
+      method: 'POST',
+      headers: {
+        'x-target-url': upstreamUrl,
+        'content-type': 'application/json',
+        'x-slicc-hmac-sign': 'SIGNING_KEY:x-job-signature:x-job-timestamp',
+      },
+      body,
+    });
+    expect(res.status).toBe(200);
+    expect(receivedBody).toBe(body);
+    const timestamp = receivedHeaders['x-job-timestamp'];
+    expect(typeof timestamp).toBe('string');
+    expect(receivedHeaders['x-job-signature']).toBe(
+      expectedSignature(HMAC_SECRET, `${timestamp}.${body}`)
+    );
+    expect(receivedHeaders['x-slicc-hmac-sign']).toBeUndefined();
+  });
+
   it('returns 403 when the hmac-sign secret is scoped to a different domain', async () => {
     // SIGNING_KEY scoped to api.github.com only; the request targets 127.0.0.1.
     await setup((_req, res) => res.end('should-not-reach'), 'api.github.com');

--- a/packages/shared-ts/src/secrets-pipeline.ts
+++ b/packages/shared-ts/src/secrets-pipeline.ts
@@ -45,6 +45,14 @@ function replaceAllBytes(
  * computes `HMAC-SHA256(body, secretName's real value)`, attaches the hex
  * result under `targetHeader`, and strips this header before forwarding —
  * see `SecretsPipeline.signHmac`.
+ *
+ * An optional third segment, `<secretName>:<targetHeader>:<timestampHeader>`,
+ * switches to timestamp-bound signing: the MAC covers `<unixSeconds>.<body>`
+ * instead of the raw body, and the proxy also attaches the unix-seconds
+ * timestamp it signed with under `timestampHeader`. This is what a receiver
+ * needs to enforce a replay window (reject requests whose timestamp is too
+ * far from "now") — a bare body digest has no way to do that, since the same
+ * signed request stays valid forever.
  */
 export const HMAC_SIGN_HEADER = 'x-slicc-hmac-sign';
 
@@ -78,6 +86,10 @@ export interface HmacSignResult {
   /** Header the computed signature should be attached under. Absent when `spec` was malformed or named an unknown secret — callers should leave the request unsigned in that case. */
   headerName?: string;
   signatureHex?: string;
+  /** Header the signed timestamp should be attached under. Present only when `spec` used the 3-segment timestamp-bound form. */
+  timestampHeaderName?: string;
+  /** Unix-seconds timestamp folded into the signed message as `<timestampValue>.<body>`. Present only alongside `timestampHeaderName`. */
+  timestampValue?: string;
   forbidden?: ForbiddenInfo;
 }
 
@@ -356,23 +368,38 @@ export class SecretsPipeline {
   }
 
   /**
-   * Resolve an `x-slicc-hmac-sign: <secretName>:<targetHeader>` directive
-   * against the (already-unmasked) request body. The real secret value is
-   * looked up by name, domain-checked exactly like `unmaskHeaders`, and used
-   * to compute `HMAC-SHA256(body, realValue)` — the caller attaches the hex
-   * result under `targetHeader` and forwards. The real value never leaves
-   * this method.
+   * Resolve an `x-slicc-hmac-sign: <secretName>:<targetHeader>[:<timestampHeader>]`
+   * directive against the (already-unmasked) request body. The real secret
+   * value is looked up by name, domain-checked exactly like `unmaskHeaders`,
+   * and used to compute the MAC — the caller attaches the hex result under
+   * `targetHeader` and forwards. The real value never leaves this method.
+   *
+   * Two-segment specs (no `timestampHeader`) sign the raw body, unchanged
+   * from the original behavior. Three-segment specs sign
+   * `<unixSeconds>.<body>` instead and additionally return `timestampValue`
+   * for the caller to attach under `timestampHeaderName`, so the receiver can
+   * enforce a replay window. `now` is injectable for tests; defaults to the
+   * real clock.
    *
    * Returns `{}` (no-op) for a malformed spec or an unknown secret name —
    * the fetch proxy is expected to treat that as "nothing to sign", not a
    * hard error, since the header may have been set for a different purpose.
    */
-  async signHmac(spec: string, body: Uint8Array, hostname: string): Promise<HmacSignResult> {
+  async signHmac(
+    spec: string,
+    body: Uint8Array,
+    hostname: string,
+    now: () => number = Date.now
+  ): Promise<HmacSignResult> {
     const sep = spec.indexOf(':');
     if (sep < 0) return {};
     const secretName = spec.slice(0, sep).trim();
-    const headerName = spec.slice(sep + 1).trim();
+    const rest = spec.slice(sep + 1);
+    const sep2 = rest.indexOf(':');
+    const headerName = (sep2 < 0 ? rest : rest.slice(0, sep2)).trim();
+    const timestampHeader = sep2 < 0 ? undefined : rest.slice(sep2 + 1).trim();
     if (!secretName || !headerName) return {};
+    if (timestampHeader === '') return {};
 
     const ms = this.byName.get(secretName);
     if (!ms) {
@@ -385,6 +412,16 @@ export class SecretsPipeline {
     if (!matchesDomains(hostname, ms.domains)) {
       return { forbidden: { secretName: ms.name, hostname } };
     }
+
+    if (timestampHeader) {
+      const timestampValue = String(Math.floor(now() / 1000));
+      const message = new Uint8Array(body.length + timestampValue.length + 1);
+      message.set(new TextEncoder().encode(`${timestampValue}.`), 0);
+      message.set(body, timestampValue.length + 1);
+      const signatureHex = await hmacSha256Hex(ms.realValue, message);
+      return { headerName, signatureHex, timestampHeaderName: timestampHeader, timestampValue };
+    }
+
     const signatureHex = await hmacSha256Hex(ms.realValue, body);
     return { headerName, signatureHex };
   }

--- a/packages/shared-ts/tests/secrets-pipeline.test.ts
+++ b/packages/shared-ts/tests/secrets-pipeline.test.ts
@@ -467,4 +467,63 @@ describe('SecretsPipeline.signHmac', () => {
     const result = await pipeline.signHmac('SIGNING_KEY', body, 'worker.example.com');
     expect(result).toEqual({});
   });
+
+  describe('timestamp-bound signing (3-segment spec)', () => {
+    it('signs "<unixSeconds>.<body>" and returns the timestamp header/value', async () => {
+      const body = new TextEncoder().encode('{"step":3,"status":"running"}');
+      const fixedNow = () => 1_700_000_000_123;
+      const expectedMessage = new TextEncoder().encode('1700000000.{"step":3,"status":"running"}');
+      const expected = await hmacSha256Hex('job-signing-secret-value', expectedMessage);
+
+      const result = await pipeline.signHmac(
+        'SIGNING_KEY:x-job-signature:x-job-timestamp',
+        body,
+        'worker.example.com',
+        fixedNow
+      );
+      expect(result.forbidden).toBeUndefined();
+      expect(result.headerName).toBe('x-job-signature');
+      expect(result.signatureHex).toBe(expected);
+      expect(result.timestampHeaderName).toBe('x-job-timestamp');
+      expect(result.timestampValue).toBe('1700000000');
+    });
+
+    it('produces a different signature than the raw-body (2-segment) form for the same body/secret', async () => {
+      const body = new TextEncoder().encode('{}');
+      const twoSegment = await pipeline.signHmac(
+        'SIGNING_KEY:x-job-signature',
+        body,
+        'worker.example.com'
+      );
+      const threeSegment = await pipeline.signHmac(
+        'SIGNING_KEY:x-job-signature:x-job-timestamp',
+        body,
+        'worker.example.com',
+        () => 1_700_000_000_000
+      );
+      expect(threeSegment.signatureHex).not.toBe(twoSegment.signatureHex);
+    });
+
+    it('still returns forbidden for a target host outside the domain scope', async () => {
+      const body = new TextEncoder().encode('{}');
+      const result = await pipeline.signHmac(
+        'SIGNING_KEY:x-job-signature:x-job-timestamp',
+        body,
+        'evil.example.com'
+      );
+      expect(result.forbidden).toEqual({ secretName: 'SIGNING_KEY', hostname: 'evil.example.com' });
+      expect(result.signatureHex).toBeUndefined();
+      expect(result.timestampHeaderName).toBeUndefined();
+    });
+
+    it('is a no-op for a trailing-colon spec with no timestamp header name', async () => {
+      const body = new TextEncoder().encode('{}');
+      const result = await pipeline.signHmac(
+        'SIGNING_KEY:x-job-signature:',
+        body,
+        'worker.example.com'
+      );
+      expect(result).toEqual({});
+    });
+  });
 });

--- a/packages/swift-server/Sources/Keychain/SecretInjector.swift
+++ b/packages/swift-server/Sources/Keychain/SecretInjector.swift
@@ -73,9 +73,13 @@ public final class SecretInjector: @unchecked Sendable {
     /// Result of `signHmac`. Mirrors TS `HmacSignResult`. `headerName` /
     /// `signatureHex` are both nil for a malformed spec or unknown secret
     /// name — callers should leave the request unsigned in that case.
+    /// `timestampHeaderName` / `timestampValue` are set only for the
+    /// 3-segment timestamp-bound spec form.
     struct HmacSignResult: Sendable, Equatable {
         let headerName: String?
         let signatureHex: String?
+        let timestampHeaderName: String?
+        let timestampValue: String?
         let forbidden: ForbiddenInfo?
     }
 
@@ -578,43 +582,80 @@ public final class SecretInjector: @unchecked Sendable {
         return out
     }
 
-    /// Resolve an `x-slicc-hmac-sign: <secretName>:<targetHeader>` directive
-    /// against the (already-unmasked) request body. Mirrors TS
+    /// Resolve an `x-slicc-hmac-sign: <secretName>:<targetHeader>[:<timestampHeader>]`
+    /// directive against the (already-unmasked) request body. Mirrors TS
     /// `SecretsPipeline.signHmac` — looks up the real value by name,
-    /// domain-checks it exactly like `inject`, and returns
-    /// `HMAC-SHA256(body, realValue)` hex for the caller to attach under
-    /// `targetHeader`. The real value never leaves this method.
+    /// domain-checks it exactly like `inject`, and returns the MAC hex for
+    /// the caller to attach under `targetHeader`. The real value never
+    /// leaves this method.
+    ///
+    /// Two-segment specs sign the raw body, unchanged from the original
+    /// behavior. Three-segment specs sign `<unixSeconds>.<body>` instead and
+    /// additionally return `timestampValue` for the caller to attach under
+    /// `timestampHeaderName`, so the receiver can enforce a replay window.
+    /// `now` is injectable for tests; defaults to the real clock.
     ///
     /// Returns a result with nil `headerName`/`signatureHex` (no `forbidden`)
     /// for a malformed spec or an unknown secret name — the fetch proxy is
     /// expected to treat that as "nothing to sign", not a hard error, since
     /// the header may have been set for a different purpose. An unknown name
     /// is logged (without the value) so a typo doesn't fail silently.
-    func signHmac(spec: String, body: [UInt8], targetHostname: String) -> HmacSignResult {
-        guard let sep = spec.firstIndex(of: ":") else {
-            return HmacSignResult(headerName: nil, signatureHex: nil, forbidden: nil)
+    func signHmac(
+        spec: String,
+        body: [UInt8],
+        targetHostname: String,
+        now: () -> Date = { Date() }
+    ) -> HmacSignResult {
+        func empty() -> HmacSignResult {
+            HmacSignResult(headerName: nil, signatureHex: nil, timestampHeaderName: nil, timestampValue: nil, forbidden: nil)
         }
+
+        guard let sep = spec.firstIndex(of: ":") else { return empty() }
         let secretName = String(spec[spec.startIndex..<sep]).trimmingCharacters(in: .whitespaces)
-        let headerName = String(spec[spec.index(after: sep)...]).trimmingCharacters(in: .whitespaces)
-        guard !secretName.isEmpty, !headerName.isEmpty else {
-            return HmacSignResult(headerName: nil, signatureHex: nil, forbidden: nil)
+        let rest = String(spec[spec.index(after: sep)...])
+        let headerName: String
+        let timestampHeader: String?
+        if let sep2 = rest.firstIndex(of: ":") {
+            headerName = String(rest[rest.startIndex..<sep2]).trimmingCharacters(in: .whitespaces)
+            timestampHeader = String(rest[rest.index(after: sep2)...]).trimmingCharacters(in: .whitespaces)
+        } else {
+            headerName = rest.trimmingCharacters(in: .whitespaces)
+            timestampHeader = nil
         }
+        guard !secretName.isEmpty, !headerName.isEmpty else { return empty() }
+        if let timestampHeader, timestampHeader.isEmpty { return empty() }
 
         guard let secret = secrets.first(where: { $0.name == secretName }) else {
             FileHandle.standardError.write(Data(
                 "[slicc:secrets] signHmac: no secret named \"\(secretName)\"\n".utf8
             ))
-            return HmacSignResult(headerName: nil, signatureHex: nil, forbidden: nil)
+            return empty()
         }
         guard isAllowedDomain(patterns: secret.domains, hostname: targetHostname) else {
             return HmacSignResult(
                 headerName: nil,
                 signatureHex: nil,
+                timestampHeaderName: nil,
+                timestampValue: nil,
                 forbidden: ForbiddenInfo(secretName: secret.name, hostname: targetHostname)
             )
         }
+
+        if let timestampHeader, !timestampHeader.isEmpty {
+            let timestampValue = String(Int(now().timeIntervalSince1970))
+            let message = Array("\(timestampValue).".utf8) + body
+            let signatureHex = hmacSHA256Hex(key: secret.realValue, message: message)
+            return HmacSignResult(
+                headerName: headerName,
+                signatureHex: signatureHex,
+                timestampHeaderName: timestampHeader,
+                timestampValue: timestampValue,
+                forbidden: nil
+            )
+        }
+
         let signatureHex = hmacSHA256Hex(key: secret.realValue, message: body)
-        return HmacSignResult(headerName: headerName, signatureHex: signatureHex, forbidden: nil)
+        return HmacSignResult(headerName: headerName, signatureHex: signatureHex, timestampHeaderName: nil, timestampValue: nil, forbidden: nil)
     }
 
     /// Mirrors TS `SecretsPipeline.scrubResponseBytes`.

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -510,6 +510,11 @@ func registerAPIRoutes(
                        let field = HTTPField.Name(headerName) {
                         injectedHeaders[field] = signatureHex
                     }
+                    if let timestampHeaderName = signResult.timestampHeaderName,
+                       let timestampValue = signResult.timestampValue,
+                       let field = HTTPField.Name(timestampHeaderName) {
+                        injectedHeaders[field] = timestampValue
+                    }
                 }
 
                 let injectedRequest = Request(

--- a/packages/swift-server/Tests/SecretInjectorTests.swift
+++ b/packages/swift-server/Tests/SecretInjectorTests.swift
@@ -564,4 +564,65 @@ final class SecretInjectorTests: XCTestCase {
         XCTAssertNil(result.signatureHex)
         XCTAssertNil(result.forbidden)
     }
+
+    // MARK: - signHmac() timestamp-bound (3-segment spec)
+
+    func testSignHmacTimestampBoundSignsPrefixedMessageAndReturnsTimestamp() {
+        let injector = makeInjector(secrets: [
+            makeSecret(name: "SIGNING_KEY", realValue: "job-signing-secret-value", domains: ["worker.example.com"]),
+        ])
+        let body = Array("{\"step\":3,\"status\":\"running\"}".utf8)
+        let fixedNow = Date(timeIntervalSince1970: 1_700_000_000)
+        let expectedMessage = Array("1700000000.".utf8) + body
+        let expected = hmacSHA256Hex(key: "job-signing-secret-value", message: expectedMessage)
+
+        let result = injector.signHmac(
+            spec: "SIGNING_KEY:x-job-signature:x-job-timestamp",
+            body: body,
+            targetHostname: "worker.example.com",
+            now: { fixedNow }
+        )
+        XCTAssertNil(result.forbidden)
+        XCTAssertEqual(result.headerName, "x-job-signature")
+        XCTAssertEqual(result.signatureHex, expected)
+        XCTAssertEqual(result.timestampHeaderName, "x-job-timestamp")
+        XCTAssertEqual(result.timestampValue, "1700000000")
+    }
+
+    func testSignHmacTimestampBoundDiffersFromRawBodyForm() {
+        let injector = makeInjector(secrets: [
+            makeSecret(name: "SIGNING_KEY", realValue: "job-signing-secret-value", domains: ["worker.example.com"]),
+        ])
+        let body = Array("{}".utf8)
+        let raw = injector.signHmac(spec: "SIGNING_KEY:x-job-signature", body: body, targetHostname: "worker.example.com")
+        let timestamped = injector.signHmac(
+            spec: "SIGNING_KEY:x-job-signature:x-job-timestamp",
+            body: body,
+            targetHostname: "worker.example.com",
+            now: { Date(timeIntervalSince1970: 1_700_000_000) }
+        )
+        XCTAssertNotEqual(raw.signatureHex, timestamped.signatureHex)
+    }
+
+    func testSignHmacTimestampBoundReturnsForbiddenForOutOfScopeDomain() {
+        let injector = makeInjector(secrets: [
+            makeSecret(name: "SIGNING_KEY", realValue: "job-signing-secret-value", domains: ["worker.example.com"]),
+        ])
+        let result = injector.signHmac(
+            spec: "SIGNING_KEY:x-job-signature:x-job-timestamp",
+            body: [],
+            targetHostname: "evil.example.com"
+        )
+        XCTAssertEqual(result.forbidden, SecretInjector.ForbiddenInfo(secretName: "SIGNING_KEY", hostname: "evil.example.com"))
+        XCTAssertNil(result.signatureHex)
+        XCTAssertNil(result.timestampHeaderName)
+    }
+
+    func testSignHmacIsNoOpForTrailingColonWithNoTimestampHeaderName() {
+        let injector = makeInjector(secrets: [makeSecret(name: "SIGNING_KEY")])
+        let result = injector.signHmac(spec: "SIGNING_KEY:x-job-signature:", body: [], targetHostname: "worker.example.com")
+        XCTAssertNil(result.headerName)
+        XCTAssertNil(result.signatureHex)
+        XCTAssertNil(result.forbidden)
+    }
 }


### PR DESCRIPTION
## Summary
- `x-slicc-hmac-sign: secretName:targetHeader` only ever signed the raw body — no replay protection, since a captured request/signature pair stays valid forever.
- Adds an optional 3rd spec segment, `secretName:targetHeader:timestampHeader`, which signs `<unixSeconds>.<body>` instead and attaches the timestamp under the named header — the shape Stripe/Slack/GitHub-style webhook receivers expect, letting them enforce a replay window.
- The existing 2-segment (raw body) form is unchanged and still the right choice for receivers with no timestamp check.
- Mirrored across all three fetch-proxy implementations to keep parity: `shared-ts` (`SecretsPipeline.signHmac`, used by node-server + chrome-extension) and `swift-server` (`SecretInjector.signHmac` / `APIRoutes.swift`).

## Test plan
- [x] `npx vitest run packages/shared-ts packages/node-server packages/chrome-extension` — 1111 tests passed
- [x] `swift build` in `packages/swift-server` — builds clean
- [x] `swift test --filter SecretInjectorTests` — 46 tests passed
- [x] `npx biome check` on all touched files — clean
- [x] `npx tsc --noEmit` on affected configs (cli/node-server) — clean (unrelated pre-existing errors in other configs confirmed present on `main` too, not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)