### PR TITLE
Remove dead side-panel agent-spawn proxy (#1574)

### DIFF
--- a/packages/webapp/src/kernel/host.ts
+++ b/packages/webapp/src/kernel/host.ts
@@ -90,10 +90,10 @@ export interface KernelHostLogger {
 
 export interface KernelHostConfig {
   /**
-   * DOM container the orchestrator constructs scoop tabs into. Must
-   * remain valid for the host's lifetime. In offscreen this is
-   * `document.body`; in standalone it'd be the layout's iframe
-   * container.
+   * DOM container the orchestrator constructs scoop tabs into. Unused
+   * at runtime today (stored but never read); the kernel worker passes
+   * a stub since it has no DOM. Typed as `HTMLElement` to satisfy the
+   * orchestrator constructor.
    */
   container: HTMLElement;
 
@@ -182,20 +182,19 @@ export interface KernelHost {
   processManager: ProcessManager;
   /**
    * Stop the BshWatchdog and unsubscribe tray-runtime listeners. Idempotent.
-   * Callers wire this to their float's lifecycle hook (`beforeunload` in
-   * extension; worker-close in standalone).
+   * Callers wire this to their float's lifecycle hook (worker close).
    */
   dispose(): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
-// Default lick handler (mirrors offscreen.ts:186-260)
+// Default lick handler + event-name/id resolvers
 // ---------------------------------------------------------------------------
 
 /**
  * Resolve the `eventName` used to label the routed `ChannelMessage`
- * (`senderName = "<channel>:<eventName>"`). Mirrors the original nested
- * ternary chain in `defaultLickEventHandler` exactly.
+ * (`senderName = "<channel>:<eventName>"`). Extracted helper consumed by
+ * {@link defaultLickEventHandler}.
  */
 function resolveLickEventName(event: LickEvent): string | undefined {
   switch (event.type) {
@@ -224,8 +223,8 @@ function resolveLickEventName(event: LickEvent): string | undefined {
 
 /**
  * Resolve the `eventId` baked into the `ChannelMessage` id
- * (`"<channel>-<eventId>-<Date.now()>"`). Mirrors the original nested
- * ternary chain in `defaultLickEventHandler` exactly.
+ * (`"<channel>-<eventId>-<Date.now()>"`). Extracted helper consumed by
+ * {@link defaultLickEventHandler}.
  */
 function resolveLickEventId(event: LickEvent): string | undefined {
   switch (event.type) {

--- a/packages/webapp/src/kernel/host.ts
+++ b/packages/webapp/src/kernel/host.ts
@@ -1,20 +1,18 @@
 /**
  * `createKernelHost` — the kernel boot factory.
  *
- * Encapsulates the moveable parts of the offscreen-side boot sequence
- * so the same factory can back two floats:
+ * Runs once inside the kernel DedicatedWorker (`kernel-worker.ts`) for
+ * every float that hosts the cone: standalone CLI, Electron,
+ * hosted-leader, and the hosted leader tab the thin Chrome extension
+ * pins. `kernel-worker.ts` is the sole caller — it constructs the
+ * `Bridge` (over a `MessagePort` transport) and `BrowserAPI`, invokes
+ * `createKernelHost(...)`, and posts `kernel-worker-ready` back to the
+ * page once boot completes. The only per-float difference is how CDP
+ * traffic leaves the page: a local WebSocket for standalone, versus a
+ * `chrome.runtime.connect({ name: 'slicc.cdp-bridge' })` port for the
+ * extension. The factory itself is float-agnostic and worker-safe.
  *
- *  - **Extension**: `offscreen.ts` calls `createKernelHost(...)` and
- *    wraps it with extension-specific bits (CDP proxy construction,
- *    sprinkle BroadcastChannel host, tray-runtime sync, chrome.runtime
- *    listeners for `agent-spawn-request` / `get-session-costs` /
- *    `navigate-lick`, startup `offscreen-ready` emission).
- *
- *  - **Standalone**: `kernel-worker.ts` also calls `createKernelHost(...)`,
- *    with a `MessageChannel`-backed bridge instead of the chrome.runtime
- *    one.
- *
- * What the factory wires up (matches offscreen.ts 1:1):
+ * What the factory wires up:
  *
  *  1. `Orchestrator` with the supplied callbacks + `getBrowserAPI`.
  *  2. `bridge.bind(orchestrator, browser)`.
@@ -25,11 +23,10 @@
  *     no chrome.runtime).
  *  6. `registerSessionCostsProvider` — supplemental commands consult
  *     this for the `cost` shell command.
- *  7. `LickManager.init()` + default lick-event handler that mirrors
- *     offscreen's behavior (route via `formatLickEventForCone` to the
- *     cone or the named target scoop). Callers that need different
- *     routing (the standalone wizard's onboarding flow) supply
- *     `lickEventHandler`.
+ *  7. `LickManager.init()` + default lick-event handler (route via
+ *     `formatLickEventForCone` to the cone or the named target scoop).
+ *     Callers that need different routing (the standalone wizard's
+ *     onboarding flow) supply `lickEventHandler`.
  *  8. `globalThis.__slicc_lickManager = lickManager`.
  *  9. `recoverMounts` against the shared FS, emitting a `session-reload`
  *     lick if any mount needs user re-consent. Fire-and-forget.
@@ -37,17 +34,13 @@
  *  11. Upgrade detection.
  *  12. `BshWatchdog` start.
  *
- * What the factory deliberately does NOT do (because it varies per
- * float):
+ * What the factory deliberately does NOT do (handled by
+ * `kernel-worker.ts` or the page because it varies per float):
  *  - Construct the `BrowserAPI` / CDP transport. The caller passes a
- *    ready-to-use `BrowserAPI` since the extension uses chrome.debugger
- *    via the service worker, while standalone uses a WebSocket.
+ *    ready-to-use `BrowserAPI` since the extension routes CDP through
+ *    the service worker while standalone uses a WebSocket.
  *  - Tray-runtime config sync (uses `window.localStorage`).
- *  - chrome.runtime listeners (extension-only).
- *  - Sprinkle `BroadcastChannel` host or `.shtml` watcher relay
- *    (extension-only; relays panel ⇄ offscreen).
- *  - Wiring `dispose` to a lifecycle hook (`beforeunload` in extension,
- *    worker close in standalone).
+ *  - Wiring `dispose` to a lifecycle hook (worker close).
  *
  * The returned `KernelHost.dispose()` cleans up tray subscriptions and
  * the BshWatchdog. Callers wire it to whatever lifecycle hook fits

--- a/packages/webapp/src/scoops/agent-bridge.ts
+++ b/packages/webapp/src/scoops/agent-bridge.ts
@@ -163,15 +163,6 @@ export interface AgentBridgeDeps {
 /** Global hook name used by {@link publishAgentBridge}. */
 export const AGENT_BRIDGE_GLOBAL_KEY = '__slicc_agent';
 
-/**
- * Message `type` tag used on the wire when the extension side-panel proxy
- * relays a spawn request to the offscreen document's real bridge. Both ends
- * of the Manifest V3 boundary agree on this literal — see
- * {@link publishAgentBridgeProxy} and
- * `packages/webapp/src/kernel/facade.ts`.
- */
-export const AGENT_SPAWN_REQUEST_TYPE = 'agent-spawn-request';
-
 /** Context for bridge spawn helpers - closed over by the factory. */
 interface BridgeContext {
   orchestrator: Orchestrator;
@@ -509,88 +500,6 @@ export function publishAgentBridge(
   const bridge = createAgentBridge(orchestrator, sharedFs, sessionStore, deps);
   (globalThis as Record<string, unknown>)[AGENT_BRIDGE_GLOBAL_KEY] = bridge;
   log.info('agent bridge published on globalThis.__slicc_agent');
-  return bridge;
-}
-
-// ─── Extension side-panel proxy ───────────────────────────────────────
-
-/** Response envelope the offscreen document returns via `sendResponse`. */
-interface AgentSpawnProxyResponse {
-  ok: boolean;
-  result?: AgentSpawnResult;
-  error?: string;
-}
-
-/** Narrow Chrome runtime surface the proxy relies on. */
-interface ChromeRuntimeForProxy {
-  runtime: {
-    lastError?: { message?: string } | null;
-    sendMessage(message: unknown, callback?: (response: unknown) => void): unknown;
-  };
-}
-
-/**
- * Publish a proxy bridge in the extension side-panel realm. The panel has
- * no orchestrator of its own (see `packages/chrome-extension/CLAUDE.md`),
- * so it forwards spawn requests to the offscreen document, where the real
- * bridge was published via {@link publishAgentBridge}.
- *
- * The proxy is intentionally minimal: it doesn't validate options (the
- * offscreen bridge is the single source of truth) and doesn't retain any
- * state between calls. Each `spawn()` is an isolated `chrome.runtime
- * .sendMessage` round-trip.
- */
-export function publishAgentBridgeProxy(): AgentBridge {
-  const bridge: AgentBridge = {
-    spawn(options: AgentSpawnOptions): Promise<AgentSpawnResult> {
-      return new Promise<AgentSpawnResult>((resolve, reject) => {
-        const chromeGlobal = (globalThis as unknown as { chrome?: ChromeRuntimeForProxy }).chrome;
-        const runtime = chromeGlobal?.runtime;
-        if (!runtime || typeof runtime.sendMessage !== 'function') {
-          reject(new Error('agent: chrome.runtime.sendMessage not available'));
-          return;
-        }
-
-        const handleResponse = (response: unknown): void => {
-          // Read lastError BEFORE anything else — chrome clears it after
-          // each callback turn.
-          const lastError = runtime.lastError;
-          if (lastError) {
-            reject(new Error(lastError.message ?? 'chrome.runtime error'));
-            return;
-          }
-          if (response === undefined || response === null) {
-            reject(new Error('agent: empty response from offscreen bridge'));
-            return;
-          }
-          const resp = response as AgentSpawnProxyResponse;
-          if (!resp.ok) {
-            reject(new Error(resp.error ?? 'agent: offscreen bridge error'));
-            return;
-          }
-          if (!resp.result) {
-            reject(new Error('agent: offscreen bridge returned no result'));
-            return;
-          }
-          resolve(resp.result);
-        };
-
-        try {
-          runtime.sendMessage(
-            {
-              source: 'panel' as const,
-              payload: { type: AGENT_SPAWN_REQUEST_TYPE, options },
-            },
-            handleResponse
-          );
-        } catch (err) {
-          reject(err instanceof Error ? err : new Error(String(err)));
-        }
-      });
-    },
-  };
-  (globalThis as Record<string, unknown>)[AGENT_BRIDGE_GLOBAL_KEY] = bridge;
-  log.info('agent bridge proxy published on globalThis.__slicc_agent');
   return bridge;
 }
 

--- a/packages/webapp/src/sudo/extension-broker.ts
+++ b/packages/webapp/src/sudo/extension-broker.ts
@@ -6,7 +6,7 @@
  * the side-panel realm. So the offscreen broker forwards the request to the
  * panel via `chrome.runtime.sendMessage`; the panel's responder (see
  * `panel-responder.ts`) raises the real native modals and sends the decision
- * back. Mirrors the `agent-spawn-request` proxy direction in reverse.
+ * back.
  *
  * The "Always" pattern suggestion is computed here in the offscreen realm
  * (where `quickLabel` can reach the provider) and shipped as the editable

--- a/packages/webapp/src/sudo/types.ts
+++ b/packages/webapp/src/sudo/types.ts
@@ -37,7 +37,7 @@ export interface SudoBroker {
 /**
  * Wire `type` tag for the offscreen → side-panel sudo request envelope in
  * extension mode. Both ends agree on this literal — see `extension-broker.ts`
- * and `panel-responder.ts`. Mirrors the `AGENT_SPAWN_REQUEST_TYPE` pattern.
+ * and `panel-responder.ts`.
  */
 export const SUDO_REQUEST_TYPE = 'sudo-request';
 


### PR DESCRIPTION
Closes #1574.

The thin-extension refactor (`54eb0811e`) deleted the offscreen document and side-panel engine, but the webapp still shipped the sender half of the `agent-spawn-request` proxy that used to bridge those two realms. Nothing listens for the wire literal anymore.

## Changes

**Delete dead code** — `packages/webapp/src/scoops/agent-bridge.ts`
- `publishAgentBridgeProxy()` — side-panel proxy with no surviving receiver
- `AGENT_SPAWN_REQUEST_TYPE` const + JSDoc (carried the stale `{@link publishAgentBridgeProxy}`)
- `AgentSpawnProxyResponse`, `ChromeRuntimeForProxy` helper interfaces
- the "Extension side-panel proxy" section header

**Refresh stale comments**
- `kernel/host.ts` — rewrote the `createKernelHost` header to reflect reality: the factory runs inside the kernel DedicatedWorker (`kernel-worker.ts`) for every float, not an offscreen document. Removed all `offscreen.ts` / `offscreen-ready` / "relays panel ⇄ offscreen" references (cross-checked against `docs/architecture.md`).
- `sudo/extension-broker.ts`, `sudo/types.ts` — dropped the dangling `agent-spawn-request` / `AGENT_SPAWN_REQUEST_TYPE` cross-references.

Kept `AgentSpawnOptions` / `AgentSpawnResult` (live bridge types) and the still-used `offscreen-ready` wire message. The broader "offscreen" terminology drift across other files is out of scope.

## Verification
- `git grep` for all five dead symbols across `packages/` + `docs/` → zero matches
- `npm run typecheck` → clean
- `oxlint` on touched files → clean
- `npm run deadcode` (knip) → no findings for these files
- agent-bridge tests → 59 passed