### PR TITLE
refactor(fs): extract error-rebrand, symlink-resolver, walker from VirtualFS (#1572)

### DIFF
--- a/docs/superpowers/plans/2026-07-20-virtual-fs-extraction.md
+++ b/docs/superpowers/plans/2026-07-20-virtual-fs-extraction.md
@@ -48,8 +48,18 @@
 import { type FsErrorCode, FsError } from './types.js';
 
 const KNOWN_CODES: FsErrorCode[] = [
-  'ENOENT', 'EEXIST', 'ENOTDIR', 'EISDIR', 'ENOTEMPTY', 'EINVAL',
-  'EACCES', 'ELOOP', 'EBUSY', 'EFBIG', 'EBADF', 'EIO',
+  'ENOENT',
+  'EEXIST',
+  'ENOTDIR',
+  'EISDIR',
+  'ENOTEMPTY',
+  'EINVAL',
+  'EACCES',
+  'ELOOP',
+  'EBUSY',
+  'EFBIG',
+  'EBADF',
+  'EIO',
 ];
 
 /**
@@ -405,7 +415,12 @@ export async function realpath(
   let hops = 0;
   for (let i = 0; i < parts.length; i++) {
     const result = await resolveRealpathComponent(
-      lfs, resolved, parts[i], i === parts.length - 1, normalized, hops
+      lfs,
+      resolved,
+      parts[i],
+      i === parts.length - 1,
+      normalized,
+      hops
     );
     resolved = result.resolved;
     hops = result.hops;
@@ -477,7 +492,10 @@ import { FsError } from '../../src/fs/types.js';
 
 function statFor(kind: 'file' | 'dir' | 'link'): any {
   return {
-    size: 0, mode: 0, mtimeMs: 0, ctimeMs: 0,
+    size: 0,
+    mode: 0,
+    mtimeMs: 0,
+    ctimeMs: 0,
     isFile: () => kind === 'file',
     isDirectory: () => kind === 'dir',
     isSymbolicLink: () => kind === 'link',
@@ -928,4 +946,4 @@ PR description: reference #1572, state this is subset B (error-rebrand + symlink
 
 **Type consistency:** `convertError`/`rebrandFsError` signatures match across Tasks 1–2 and their consumers (Tasks 4–5). `SymlinkLfs`/`FsStatsLike` defined in Task 4, reused in Tasks 5–6. `WalkMountView`/`WalkIndexView`/`WalkDeps` defined in Tasks 7–8, reused in Task 9. `findMount` is adapted to a `(path) => boolean` predicate at the `VirtualFS` delegate boundary (Task 5), matching the module signature.
 
-**Note on test strategy:** "move alongside" is implemented as *mirror* — new co-located unit tests exercise the extracted modules directly with fakes, while the existing `VirtualFS` API tests remain in place as the behavior-preservation guard. Deleting the integration tests would remove the very guard that proves no behavior changed, so they are kept.
+**Note on test strategy:** "move alongside" is implemented as _mirror_ — new co-located unit tests exercise the extracted modules directly with fakes, while the existing `VirtualFS` API tests remain in place as the behavior-preservation guard. Deleting the integration tests would remove the very guard that proves no behavior changed, so they are kept.

--- a/docs/superpowers/plans/2026-07-20-virtual-fs-extraction.md
+++ b/docs/superpowers/plans/2026-07-20-virtual-fs-extraction.md
@@ -1,0 +1,931 @@
+# VirtualFS Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract three concept-cohesive blocks (error rebranding, symlink resolution, directory walking) out of the 2,165-line `VirtualFS` class into sibling modules under `packages/webapp/src/fs/`, with zero public-API change.
+
+**Architecture:** `VirtualFS` stays the sole public entry point (99 importers, re-exported from `fs/index.ts`). Each extracted block becomes module-level functions that take an explicit deps object; the matching `VirtualFS` method becomes a thin delegate. Behavior is preserved and proven by the existing API-level tests, which stay green with zero edits in every `refactor` commit.
+
+**Tech Stack:** TypeScript (ESM, `"type": "module"`), Vitest (`fake-indexeddb/auto` for VFS tests), Biome + Prettier lint, knip dead-code gate, `@zenfs/core` / `@zenfs/dom` backends.
+
+## Global Constraints
+
+- Scope is **subset B only**: `error-rebrand`, `symlink-resolver`, `walker`. Do NOT touch mount-registry, backend-init, sync-fast-path, or path-prefix shims.
+- No public API change: every `VirtualFS` method keeps its exact name, signature, and return type.
+- One PR; every commit must independently **compile (`npm run typecheck`), pass `knip --production` (no unused exports), and keep all tests green.** No "add module now, wire later" commits.
+- New files must stay under the complexity caps (cognitive complexity ≤ 25, ≤ 150 lines/function). `virtual-fs.ts` is NOT on the biome debt list, so no forced whole-file refactor.
+- Absolute-style intra-package imports use the existing `./x.js` relative form already used throughout `fs/` (match the file's established pattern; ESM `.js` extensions required).
+- Test relocation = **mirror**: add co-located unit tests that exercise each extracted module directly (with lightweight fakes for injected deps). Keep the existing `VirtualFS` API tests in place as the behavior guard — do NOT delete them.
+
+## Verification commands (used throughout)
+
+- Single test file: `npx vitest run packages/webapp/tests/fs/<file>.test.ts`
+- Whole fs suite: `npx vitest run packages/webapp/tests/fs/`
+- Typecheck: `npm run typecheck`
+- Dead-code gate: `npx knip --production`
+- Lint (autofix): `npm run lint`
+- Complexity gate (only if a listed file is touched — none here): `node packages/dev-tools/tools/check-touched-exemptions.mjs`
+
+---
+
+## Task 1: Extract `convertError` into `error-rebrand.ts`
+
+**Files:**
+
+- Create: `packages/webapp/src/fs/error-rebrand.ts`
+- Modify: `packages/webapp/src/fs/virtual-fs.ts` (remove `convertError` method body at ~2118–2164; replace with delegate; add import)
+- Test guard: `packages/webapp/tests/fs/virtual-fs.test.ts` (unchanged, must stay green)
+
+**Interfaces:**
+
+- Produces: `export function convertError(err: unknown, path: string): FsError`
+- Consumes: `FsError`, `FsErrorCode` from `./types.js`
+
+- [ ] **Step 1: Create the module** — move the current `convertError` body verbatim into a free function.
+
+```typescript
+// packages/webapp/src/fs/error-rebrand.ts
+import { type FsErrorCode, FsError } from './types.js';
+
+const KNOWN_CODES: FsErrorCode[] = [
+  'ENOENT', 'EEXIST', 'ENOTDIR', 'EISDIR', 'ENOTEMPTY', 'EINVAL',
+  'EACCES', 'ELOOP', 'EBUSY', 'EFBIG', 'EBADF', 'EIO',
+];
+
+/**
+ * Convert LightningFS / ZenFS errors to {@link FsError}.
+ *
+ * ZenFS throws `ErrnoError` with a `.code` POSIX string (and `.errno`);
+ * LightningFS embeds the code in the message text. Prefer the structured
+ * `.code` form, then fall back to substring matching.
+ */
+export function convertError(err: unknown, path: string): FsError {
+  if (err instanceof FsError) return err;
+  const structured = (err as { code?: unknown })?.code;
+  if (typeof structured === 'string') {
+    const code = structured as FsErrorCode;
+    if ((KNOWN_CODES as string[]).includes(code)) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return new FsError(code, msg || code, path);
+    }
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg.includes('ENOENT')) return new FsError('ENOENT', 'no such file or directory', path);
+  if (msg.includes('EEXIST')) return new FsError('EEXIST', 'file already exists', path);
+  if (msg.includes('ENOTDIR')) return new FsError('ENOTDIR', 'not a directory', path);
+  if (msg.includes('EISDIR')) return new FsError('EISDIR', 'is a directory', path);
+  if (msg.includes('ENOTEMPTY')) return new FsError('ENOTEMPTY', 'directory not empty', path);
+  if (msg.includes('ELOOP')) return new FsError('ELOOP', 'too many levels of symbolic links', path);
+  return new FsError('EINVAL', msg, path);
+}
+```
+
+- [ ] **Step 2: Delegate from `VirtualFS`** — add `import { convertError } from './error-rebrand.js';` at the top of `virtual-fs.ts`, then replace the whole `private convertError(...) { ... }` method (~2118–2164) with a thin delegate that keeps callsites (`this.convertError(...)`) working:
+
+```typescript
+  private convertError(err: unknown, path: string): FsError {
+    return convertError(err, path);
+  }
+```
+
+- [ ] **Step 3: Typecheck + dead-code + tests**
+
+Run: `npm run typecheck && npx knip --production && npx vitest run packages/webapp/tests/fs/`
+Expected: typecheck clean, knip reports no unused `error-rebrand` export (it is imported by `virtual-fs.ts`), all fs tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/webapp/src/fs/error-rebrand.ts packages/webapp/src/fs/virtual-fs.ts
+git commit -m "refactor(fs): extract convertError into error-rebrand.ts"
+```
+
+---
+
+## Task 2: Move `rebrandFsError` into `error-rebrand.ts`
+
+**Files:**
+
+- Modify: `packages/webapp/src/fs/error-rebrand.ts` (add `rebrandFsError`)
+- Modify: `packages/webapp/src/fs/virtual-fs.ts` (remove `static rebrandFsError` ~1226–1240; rewrite the ~4 `VirtualFS.rebrandFsError(...)` callsites to call the imported free function; extend import)
+
+**Interfaces:**
+
+- Produces: `export function rebrandFsError(err: unknown, normalizedPath: string): never`
+- Consumes: `FsError` from `./types.js`
+
+- [ ] **Step 1: Add `rebrandFsError` to the module** — move the current `static rebrandFsError` body verbatim into a free function in `error-rebrand.ts`:
+
+```typescript
+/**
+ * Re-throw an `FsError` from a backend with the VFS-absolute path. Backends
+ * throw with mount-relative paths (e.g. `'pack'`); callers expect the path
+ * they passed in (e.g. `'/mnt/repo/pack'`).
+ */
+export function rebrandFsError(err: unknown, normalizedPath: string): never {
+  if (err instanceof FsError) {
+    const codePrefix = `${err.code}: `;
+    let inner = err.message;
+    if (inner.startsWith(codePrefix)) inner = inner.slice(codePrefix.length);
+    if (err.path && inner.endsWith(` '${err.path}'`)) {
+      inner = inner.slice(0, inner.length - ` '${err.path}'`.length);
+    }
+    throw new FsError(err.code, inner, normalizedPath);
+  }
+  throw err;
+}
+```
+
+- [ ] **Step 2: Rewire callsites** — update the import in `virtual-fs.ts` to `import { convertError, rebrandFsError } from './error-rebrand.js';`, delete the `private static rebrandFsError(...)` method, and replace each `VirtualFS.rebrandFsError(err, normalized)` callsite with `rebrandFsError(err, normalized)`.
+
+Find callsites: `rg -n "VirtualFS\.rebrandFsError\(" packages/webapp/src/fs/virtual-fs.ts`
+Expected: ~4 hits (in `readFile`, `writeFile`, and other mount-backend catch blocks). Replace all.
+
+- [ ] **Step 3: Typecheck + dead-code + tests**
+
+Run: `npm run typecheck && npx knip --production && npx vitest run packages/webapp/tests/fs/`
+Expected: all clean/PASS. Confirm no remaining `VirtualFS.rebrandFsError` reference: `rg -n "rebrandFsError" packages/webapp/src/fs/virtual-fs.ts` shows only the import + free-function calls.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/webapp/src/fs/error-rebrand.ts packages/webapp/src/fs/virtual-fs.ts
+git commit -m "refactor(fs): extract rebrandFsError into error-rebrand.ts"
+```
+
+---
+
+## Task 3: Add `error-rebrand` unit tests
+
+**Files:**
+
+- Create: `packages/webapp/tests/fs/error-rebrand.test.ts`
+
+**Interfaces:**
+
+- Consumes: `convertError`, `rebrandFsError` from `../../src/fs/error-rebrand.js`; `FsError` from `../../src/fs/types.js`
+
+- [ ] **Step 1: Write the tests** — cover the three mapping branches (structured `.code`, message-substring fallback, `EINVAL` default) plus `rebrandFsError` path rewrite and passthrough.
+
+```typescript
+// packages/webapp/tests/fs/error-rebrand.test.ts
+import { describe, expect, it } from 'vitest';
+import { convertError, rebrandFsError } from '../../src/fs/error-rebrand.js';
+import { FsError } from '../../src/fs/types.js';
+
+describe('convertError', () => {
+  it('passes through an existing FsError unchanged', () => {
+    const e = new FsError('ENOENT', 'x', '/a');
+    expect(convertError(e, '/b')).toBe(e);
+  });
+
+  it('maps a structured ZenFS .code to FsError', () => {
+    const err = Object.assign(new Error('boom'), { code: 'EISDIR' });
+    const out = convertError(err, '/dir');
+    expect(out).toBeInstanceOf(FsError);
+    expect(out.code).toBe('EISDIR');
+    expect(out.path).toBe('/dir');
+  });
+
+  it('falls back to substring matching for LightningFS-style messages', () => {
+    const out = convertError(new Error('ENOTDIR: not a directory'), '/p');
+    expect(out.code).toBe('ENOTDIR');
+  });
+
+  it('defaults unknown errors to EINVAL', () => {
+    const out = convertError(new Error('weird'), '/p');
+    expect(out.code).toBe('EINVAL');
+    expect(out.message).toContain('weird');
+  });
+});
+
+describe('rebrandFsError', () => {
+  it('rethrows an FsError with the caller-facing path', () => {
+    const backendErr = new FsError('ENOENT', 'no such file or directory', 'pack');
+    expect(() => rebrandFsError(backendErr, '/mnt/repo/pack')).toThrow(FsError);
+    try {
+      rebrandFsError(backendErr, '/mnt/repo/pack');
+    } catch (e) {
+      expect((e as FsError).code).toBe('ENOENT');
+      expect((e as FsError).path).toBe('/mnt/repo/pack');
+    }
+  });
+
+  it('rethrows a non-FsError untouched', () => {
+    const raw = new Error('native');
+    expect(() => rebrandFsError(raw, '/x')).toThrow(raw);
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `npx vitest run packages/webapp/tests/fs/error-rebrand.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 3: Verify no knip regression** (new test file must not trip the dead-file gate)
+
+Run: `npx knip --production`
+Expected: clean. If it flags the test fixture, add a negated `project` entry in the webapp workspace of `knip.json` (per `docs/verification.md` → Knip fixture exclusion) — NOT `ignoreFiles`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/webapp/tests/fs/error-rebrand.test.ts
+git commit -m "test(fs): add error-rebrand unit tests"
+```
+
+---
+
+## Task 4: Extract symlink leaf helpers into `symlink-resolver.ts`
+
+The symlink cluster splits into two commits at its natural seam: the leaf
+helpers (`lstatOrThrow`, `readAndResolveLink`) depend only on `lfs` +
+`convertError`; the recursive driver (`realpath` chain) depends on the leaves.
+This task extracts the leaves.
+
+**Files:**
+
+- Create: `packages/webapp/src/fs/symlink-resolver.ts`
+- Modify: `packages/webapp/src/fs/virtual-fs.ts` (replace `lstatOrThrow` ~2071–2083 and `readAndResolveLink` ~2086–2096 with delegates; add import)
+
+**Interfaces:**
+
+- Produces:
+  - `interface FsStatsLike { size: number; mode: number; mtimeMs: number; ctimeMs: number; isFile(): boolean; isDirectory(): boolean; isSymbolicLink(): boolean }` — re-declared here (structural; matches the one in `virtual-fs.ts`)
+  - `interface SymlinkLfs { lstat(path: string): Promise<FsStatsLike>; readlink(path: string): Promise<string> }`
+  - `lstatOrThrow(lfs: SymlinkLfs, next: string, isTail: boolean, originalPath: string): Promise<FsStatsLike | null>`
+  - `readAndResolveLink(lfs: SymlinkLfs, linkPath: string, originalPath: string): Promise<string>`
+- Consumes: `convertError` from `./error-rebrand.js`; `joinPath`, `normalizePath`, `splitPath` from `./path-utils.js`
+
+- [ ] **Step 1: Create the module** with the two leaf helpers, taking `lfs` as an explicit parameter (was `this.lfs`) and importing `convertError` (was `this.convertError`).
+
+```typescript
+// packages/webapp/src/fs/symlink-resolver.ts
+import { convertError } from './error-rebrand.js';
+import { joinPath, normalizePath, splitPath } from './path-utils.js';
+
+export interface FsStatsLike {
+  size: number;
+  mode: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+}
+
+export interface SymlinkLfs {
+  lstat(path: string): Promise<FsStatsLike>;
+  readlink(path: string): Promise<string>;
+}
+
+/**
+ * lstat a path for realpath. Returns null if ENOENT on the tail component
+ * (allowed per POSIX realpath). Throws for all other errors.
+ */
+export async function lstatOrThrow(
+  lfs: SymlinkLfs,
+  next: string,
+  isTail: boolean,
+  originalPath: string
+): Promise<FsStatsLike | null> {
+  try {
+    return await lfs.lstat(next);
+  } catch (err) {
+    const converted = convertError(err, originalPath);
+    if (converted.code === 'ENOENT' && isTail) return null;
+    throw converted;
+  }
+}
+
+/** Read a symlink target and resolve it to an absolute normalized path. */
+export async function readAndResolveLink(
+  lfs: SymlinkLfs,
+  linkPath: string,
+  originalPath: string
+): Promise<string> {
+  let target: string;
+  try {
+    target = await lfs.readlink(linkPath);
+  } catch (err) {
+    throw convertError(err, originalPath);
+  }
+  return target.startsWith('/')
+    ? normalizePath(target)
+    : normalizePath(joinPath(splitPath(linkPath).dir, target));
+}
+```
+
+- [ ] **Step 2: Delegate from `VirtualFS`** — add `import { lstatOrThrow, readAndResolveLink } from './symlink-resolver.js';`, then replace the two private methods with delegates that pass `this.lfs`:
+
+```typescript
+  private lstatOrThrow(next: string, isTail: boolean, originalPath: string) {
+    return lstatOrThrow(this.lfs, next, isTail, originalPath);
+  }
+
+  private readAndResolveLink(linkPath: string, originalPath: string) {
+    return readAndResolveLink(this.lfs, linkPath, originalPath);
+  }
+```
+
+Note: `this.lfs` is typed `FsPromisesLike`; it structurally satisfies `SymlinkLfs`. If the compiler complains, pass `this.lfs as unknown as SymlinkLfs` — but check first; the structural subset should match.
+
+- [ ] **Step 3: Typecheck + dead-code + tests**
+
+Run: `npm run typecheck && npx knip --production && npx vitest run packages/webapp/tests/fs/`
+Expected: all clean/PASS (symlink behavior is exercised by `virtual-fs.test.ts` → `describe('symlinks')` and `realpath` cases).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/webapp/src/fs/symlink-resolver.ts packages/webapp/src/fs/virtual-fs.ts
+git commit -m "refactor(fs): extract symlink leaf helpers into symlink-resolver.ts"
+```
+
+---
+
+## Task 5: Extract `realpath` driver + `resolveSymlinks` into `symlink-resolver.ts`
+
+**Files:**
+
+- Modify: `packages/webapp/src/fs/symlink-resolver.ts` (add `realpath`, `resolveRealpathComponent`, `resolveSymlinks`, `MAX_SYMLINK_DEPTH`)
+- Modify: `packages/webapp/src/fs/virtual-fs.ts` (replace `realpath` ~2014–2037, `resolveRealpathComponent` ~2043–2065, `resolveSymlinks` ~2103–2107 with delegates; remove the now-duplicated `MAX_SYMLINK_DEPTH` const at the top if no longer referenced elsewhere; extend import)
+
+**Interfaces:**
+
+- Produces:
+  - `type FindMount = (path: string) => unknown` — a truthiness-only predicate here (realpath/resolveSymlinks only check "is this under a mount?"). Use `(path: string) => boolean` and have the `VirtualFS` delegate pass `(p) => this.findMount(p) !== null`.
+  - `realpath(lfs: SymlinkLfs, findMount: (path: string) => boolean, path: string): Promise<string>`
+  - `resolveSymlinks(lfs: SymlinkLfs, findMount: (path: string) => boolean, path: string): Promise<string>`
+- Consumes (from Task 4, same file): `lstatOrThrow`, `readAndResolveLink`, `SymlinkLfs`; `FsError` from `./types.js`; `normalizePath` from `./path-utils.js`
+
+- [ ] **Step 1: Add the driver functions** to `symlink-resolver.ts`. Add `MAX_SYMLINK_DEPTH` and import `FsError`:
+
+```typescript
+import { FsError } from './types.js';
+
+/**
+ * Maximum number of symlink hops {@link realpath} follows before throwing
+ * `ELOOP`. ZenFS' own resolve recurses without a hop counter, so a
+ * `/a → /b → /a` cycle would OOM the async stack; this bounds it.
+ */
+export const MAX_SYMLINK_DEPTH = 10;
+
+async function resolveRealpathComponent(
+  lfs: SymlinkLfs,
+  resolved: string,
+  part: string,
+  isTail: boolean,
+  originalPath: string,
+  hops: number
+): Promise<{ resolved: string; hops: number }> {
+  let next = resolved === '/' ? `/${part}` : `${resolved}/${part}`;
+  while (true) {
+    const stats = await lstatOrThrow(lfs, next, isTail, originalPath);
+    if (stats === null) return { resolved: next, hops };
+    if (!stats.isSymbolicLink()) return { resolved: next, hops };
+    if (++hops > MAX_SYMLINK_DEPTH) {
+      throw new FsError('ELOOP', 'too many symbolic links encountered', originalPath);
+    }
+    next = await readAndResolveLink(lfs, next, originalPath);
+  }
+}
+
+/** Resolve all symlinks in a path to produce the final canonical path. */
+export async function realpath(
+  lfs: SymlinkLfs,
+  findMount: (path: string) => boolean,
+  path: string
+): Promise<string> {
+  const normalized = normalizePath(path);
+  if (findMount(normalized)) return normalized; // mount paths are already real
+  const parts = normalized.split('/').filter(Boolean);
+  let resolved = '/';
+  let hops = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const result = await resolveRealpathComponent(
+      lfs, resolved, parts[i], i === parts.length - 1, normalized, hops
+    );
+    resolved = result.resolved;
+    hops = result.hops;
+  }
+  return resolved;
+}
+
+/** Resolve symlinks in a path before an operation; mount points pass through. */
+export async function resolveSymlinks(
+  lfs: SymlinkLfs,
+  findMount: (path: string) => boolean,
+  path: string
+): Promise<string> {
+  if (findMount(path)) return path;
+  return realpath(lfs, findMount, path);
+}
+```
+
+- [ ] **Step 2: Delegate from `VirtualFS`** — extend the import to `import { MAX_SYMLINK_DEPTH, lstatOrThrow, readAndResolveLink, realpath, resolveSymlinks } from './symlink-resolver.js';` (import `MAX_SYMLINK_DEPTH` only if still referenced in `virtual-fs.ts`; otherwise delete the local const and leave it out), remove the three private methods, and add delegates:
+
+```typescript
+  async realpath(path: string): Promise<string> {
+    return realpath(this.lfs, (p) => this.findMount(p) !== null, path);
+  }
+
+  private resolveSymlinks(path: string): Promise<string> {
+    return resolveSymlinks(this.lfs, (p) => this.findMount(p) !== null, path);
+  }
+```
+
+Also delete the top-of-file `const MAX_SYMLINK_DEPTH = 10;` and its doc block in `virtual-fs.ts` (now owned by the module). Confirm nothing else references it: `rg -n "MAX_SYMLINK_DEPTH" packages/webapp/src/fs/virtual-fs.ts`.
+
+- [ ] **Step 3: Typecheck + dead-code + tests**
+
+Run: `npm run typecheck && npx knip --production && npx vitest run packages/webapp/tests/fs/`
+Expected: all clean/PASS. Pay attention to `virtual-fs.test.ts` realpath/ELOOP cases and `restricted-fs*` symlink tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/webapp/src/fs/symlink-resolver.ts packages/webapp/src/fs/virtual-fs.ts
+git commit -m "refactor(fs): extract realpath + resolveSymlinks into symlink-resolver.ts"
+```
+
+---
+
+## Task 6: Mirror symlink-resolver unit tests
+
+**Files:**
+
+- Create: `packages/webapp/tests/fs/symlink-resolver.test.ts`
+
+**Interfaces:**
+
+- Consumes: `realpath`, `resolveSymlinks`, `lstatOrThrow`, `readAndResolveLink`, `MAX_SYMLINK_DEPTH`, `type SymlinkLfs` from `../../src/fs/symlink-resolver.js`; `FsError` from `../../src/fs/types.js`
+
+- [ ] **Step 1: Write direct unit tests with a fake `lfs`** — cover component-walk symlink following, ELOOP past the hop cap, tail-ENOENT tolerance, and mount passthrough via the `findMount` predicate.
+
+```typescript
+// packages/webapp/tests/fs/symlink-resolver.test.ts
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_SYMLINK_DEPTH,
+  realpath,
+  resolveSymlinks,
+  type SymlinkLfs,
+} from '../../src/fs/symlink-resolver.js';
+import { FsError } from '../../src/fs/types.js';
+
+function statFor(kind: 'file' | 'dir' | 'link'): any {
+  return {
+    size: 0, mode: 0, mtimeMs: 0, ctimeMs: 0,
+    isFile: () => kind === 'file',
+    isDirectory: () => kind === 'dir',
+    isSymbolicLink: () => kind === 'link',
+  };
+}
+
+function fakeLfs(links: Record<string, string>, files: Set<string>): SymlinkLfs {
+  return {
+    async lstat(p: string) {
+      if (p in links) return statFor('link');
+      if (files.has(p)) return statFor('file');
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    },
+    async readlink(p: string) {
+      if (p in links) return links[p];
+      throw Object.assign(new Error('EINVAL'), { code: 'EINVAL' });
+    },
+  };
+}
+
+const noMount = () => false;
+
+describe('symlink-resolver.realpath', () => {
+  it('follows a tail symlink to its target', async () => {
+    const lfs = fakeLfs({ '/link.txt': '/real.txt' }, new Set(['/real.txt']));
+    expect(await realpath(lfs, noMount, '/link.txt')).toBe('/real.txt');
+  });
+
+  it('tolerates ENOENT on the tail component (returns canonical path)', async () => {
+    const lfs = fakeLfs({}, new Set());
+    expect(await realpath(lfs, noMount, '/missing.txt')).toBe('/missing.txt');
+  });
+
+  it('throws ELOOP past the hop cap', async () => {
+    const links: Record<string, string> = { '/a': '/b', '/b': '/a' };
+    const lfs = fakeLfs(links, new Set());
+    await expect(realpath(lfs, noMount, '/a')).rejects.toMatchObject({ code: 'ELOOP' });
+  });
+
+  it('has a documented hop cap of 10', () => {
+    expect(MAX_SYMLINK_DEPTH).toBe(10);
+  });
+});
+
+describe('symlink-resolver.resolveSymlinks', () => {
+  it('returns mount paths unchanged', async () => {
+    const lfs = fakeLfs({}, new Set());
+    expect(await resolveSymlinks(lfs, () => true, '/mnt/x/y')).toBe('/mnt/x/y');
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `npx vitest run packages/webapp/tests/fs/symlink-resolver.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 3: Dead-code gate**
+
+Run: `npx knip --production`
+Expected: clean (add negated `project` entry in `knip.json` if the fixture is flagged).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/webapp/tests/fs/symlink-resolver.test.ts
+git commit -m "test(fs): mirror symlink-resolver unit tests"
+```
+
+---
+
+## Task 7: Extract walk leaf helpers into `walker.ts`
+
+The walk cluster splits at its seam: `canUseWalkFastPath` (reads
+`mountPoints`/`mountIndex`) and `safeRealpath` (wraps `realpath`) are leaves;
+the recursive generators depend on them. This task extracts the leaves.
+
+**Files:**
+
+- Create: `packages/webapp/src/fs/walker.ts`
+- Modify: `packages/webapp/src/fs/virtual-fs.ts` (replace `canUseWalkFastPath` ~1817–1824 and `safeRealpath` ~1827–1833 with delegates; add import)
+
+**Interfaces:**
+
+- Produces:
+  - `interface WalkMountView { size: number; has(path: string): boolean; keys(): IterableIterator<string> }` — structural view of the `mountPoints` Map.
+  - `interface WalkIndexView { isReady(path: string): boolean }` — structural view of `MountIndex`.
+  - `canUseWalkFastPath(mountPoints: WalkMountView, mountIndex: WalkIndexView, normalized: string): boolean`
+  - `safeRealpath(realpath: (p: string) => Promise<string>, normalized: string): Promise<string>`
+  - `MAX_WALK_DEPTH: number`, `MAX_WALK_ENTRIES: number`
+- Consumes: nothing external (pure logic over injected views)
+
+- [ ] **Step 1: Create the module** with the two leaf helpers and the walk-bound constants:
+
+```typescript
+// packages/webapp/src/fs/walker.ts
+
+// Bound walk()'s slow-path recursion. realpath leaves mount paths unchanged,
+// so the visited-set cannot collapse a self-referential mount; cap depth +
+// total entries so it can't loop forever.
+export const MAX_WALK_DEPTH = 64;
+export const MAX_WALK_ENTRIES = 100_000;
+
+export interface WalkMountView {
+  readonly size: number;
+  has(path: string): boolean;
+  keys(): IterableIterator<string>;
+}
+
+export interface WalkIndexView {
+  isReady(path: string): boolean;
+}
+
+/** Whether the walk fast path (indexed mount, no nested mounts) is available. */
+export function canUseWalkFastPath(
+  mountPoints: WalkMountView,
+  mountIndex: WalkIndexView,
+  normalized: string
+): boolean {
+  if (mountPoints.size === 0 || !mountPoints.has(normalized)) return false;
+  if (!mountIndex.isReady(normalized)) return false;
+  const hasNestedMounts = [...mountPoints.keys()].some(
+    (mp) => mp !== normalized && mp.startsWith(normalized + '/')
+  );
+  return !hasNestedMounts;
+}
+
+/** Resolve realpath, falling back to the input path on any error. */
+export async function safeRealpath(
+  realpath: (p: string) => Promise<string>,
+  normalized: string
+): Promise<string> {
+  try {
+    return await realpath(normalized);
+  } catch {
+    return normalized;
+  }
+}
+```
+
+- [ ] **Step 2: Delegate from `VirtualFS`** — add `import { MAX_WALK_DEPTH, MAX_WALK_ENTRIES, canUseWalkFastPath, safeRealpath } from './walker.js';`, remove the top-of-file `MAX_WALK_DEPTH`/`MAX_WALK_ENTRIES` consts and their comment, and replace the two private methods with delegates:
+
+```typescript
+  private canUseWalkFastPath(normalized: string): boolean {
+    return canUseWalkFastPath(this.mountPoints, this.mountIndex, normalized);
+  }
+
+  private safeRealpath(normalized: string): Promise<string> {
+    return safeRealpath((p) => this.realpath(p), normalized);
+  }
+```
+
+`this.mountPoints` (`Map<string, MountBackend>`) structurally satisfies `WalkMountView`; `this.mountIndex` (`MountIndex`) satisfies `WalkIndexView`. `walk()` still references `MAX_WALK_DEPTH`/`MAX_WALK_ENTRIES` — now from the import. Confirm: `rg -n "MAX_WALK_DEPTH|MAX_WALK_ENTRIES" packages/webapp/src/fs/virtual-fs.ts` shows only the import + the `walk` usage.
+
+- [ ] **Step 3: Typecheck + dead-code + tests**
+
+Run: `npm run typecheck && npx knip --production && npx vitest run packages/webapp/tests/fs/`
+Expected: all clean/PASS (guarded by `virtual-fs-walk-cycle.test.ts` and `virtual-fs.test.ts` → `describe('walk')`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/webapp/src/fs/walker.ts packages/webapp/src/fs/virtual-fs.ts
+git commit -m "refactor(fs): extract walk leaf helpers into walker.ts"
+```
+
+---
+
+## Task 8: Extract `walk` generators into `walker.ts`
+
+**Files:**
+
+- Modify: `packages/webapp/src/fs/walker.ts` (add `walk`, `walkEntry`, `walkSymlink` as generator functions over an injected deps object)
+- Modify: `packages/webapp/src/fs/virtual-fs.ts` (replace `walk` ~1779–1814, `walkEntry` ~1836–1851, `walkSymlink` ~1854–1869 with a single `walk` delegate; remove the two now-private helpers; extend import)
+
+**Interfaces:**
+
+- Produces:
+  - `interface WalkDeps { mountPoints: WalkMountView; mountIndex: WalkIndexView & { getFiles(path: string): Iterable<string> | null | undefined }; realpath(p: string): Promise<string>; readDir(p: string): Promise<DirEntry[]>; stat(p: string): Promise<Stats> }`
+  - `walk(deps: WalkDeps, path: string, visited?: Set<string>, depth?: number): AsyncGenerator<string>`
+- Consumes (same file, Task 7): `canUseWalkFastPath`, `safeRealpath`, `MAX_WALK_DEPTH`, `MAX_WALK_ENTRIES`; `DirEntry`, `Stats` from `./types.js`; `normalizePath` from `./path-utils.js`
+
+- [ ] **Step 1: Add the generators** to `walker.ts`. Keep `walkEntry`/`walkSymlink` as module-private (not exported) generators that recurse via the exported `walk`:
+
+```typescript
+import { normalizePath } from './path-utils.js';
+import type { DirEntry, Stats } from './types.js';
+
+export interface WalkDeps {
+  mountPoints: WalkMountView;
+  mountIndex: WalkIndexView & { getFiles(path: string): Iterable<string> | null | undefined };
+  realpath(p: string): Promise<string>;
+  readDir(p: string): Promise<DirEntry[]>;
+  stat(p: string): Promise<Stats>;
+}
+
+/** Recursively walk a directory tree, yielding all file paths. */
+export async function* walk(
+  deps: WalkDeps,
+  path: string,
+  visited?: Set<string>,
+  depth = 0
+): AsyncGenerator<string> {
+  const normalized = normalizePath(path);
+
+  if (canUseWalkFastPath(deps.mountPoints, deps.mountIndex, normalized)) {
+    const files = deps.mountIndex.getFiles(normalized);
+    if (files) {
+      for (const filePath of files) yield filePath;
+      return;
+    }
+  }
+
+  const seen = visited ?? new Set<string>();
+  if (depth > MAX_WALK_DEPTH || seen.size >= MAX_WALK_ENTRIES) return;
+
+  const realPath = await safeRealpath((p) => deps.realpath(p), normalized);
+  if (seen.has(realPath)) return;
+  seen.add(realPath);
+
+  const entries = await deps.readDir(normalized);
+  for (const entry of entries) {
+    const childPath = normalized === '/' ? `/${entry.name}` : `${normalized}/${entry.name}`;
+    yield* walkEntry(deps, entry, childPath, seen, depth + 1);
+  }
+}
+
+async function* walkEntry(
+  deps: WalkDeps,
+  entry: DirEntry,
+  childPath: string,
+  visited: Set<string>,
+  depth: number
+): AsyncGenerator<string> {
+  if (entry.type === 'file') {
+    yield childPath;
+    return;
+  }
+  if (entry.type === 'symlink') {
+    yield* walkSymlink(deps, childPath, visited, depth);
+    return;
+  }
+  yield* walk(deps, childPath, visited, depth);
+}
+
+async function* walkSymlink(
+  deps: WalkDeps,
+  childPath: string,
+  visited: Set<string>,
+  depth: number
+): AsyncGenerator<string> {
+  try {
+    const targetStat = await deps.stat(childPath);
+    if (targetStat.type === 'file') {
+      yield childPath;
+    } else if (targetStat.type === 'directory') {
+      yield* walk(deps, childPath, visited, depth);
+    }
+  } catch {
+    // Dangling symlink — skip
+  }
+}
+```
+
+- [ ] **Step 2: Delegate from `VirtualFS`** — extend the import to include `walk`, delete `VirtualFS.walkEntry` and `VirtualFS.walkSymlink`, and replace `VirtualFS.walk` with a delegate that builds the deps object once and yields through:
+
+```typescript
+  async *walk(path: string, _visited?: Set<string>, _depth = 0): AsyncGenerator<string> {
+    yield* walk(
+      {
+        mountPoints: this.mountPoints,
+        mountIndex: this.mountIndex,
+        realpath: (p) => this.realpath(p),
+        readDir: (p) => this.readDir(p),
+        stat: (p) => this.stat(p),
+      },
+      path,
+      _visited,
+      _depth
+    );
+  }
+```
+
+Confirm removals: `rg -n "walkEntry|walkSymlink" packages/webapp/src/fs/virtual-fs.ts` shows no hits.
+
+- [ ] **Step 3: Typecheck + dead-code + tests**
+
+Run: `npm run typecheck && npx knip --production && npx vitest run packages/webapp/tests/fs/`
+Expected: all clean/PASS. `virtual-fs-walk-cycle.test.ts` must still terminate (the depth/entry bound moved intact into `walker.ts`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/webapp/src/fs/walker.ts packages/webapp/src/fs/virtual-fs.ts
+git commit -m "refactor(fs): extract walk generators into walker.ts"
+```
+
+---
+
+## Task 9: Mirror walker unit tests
+
+**Files:**
+
+- Create: `packages/webapp/tests/fs/walker.test.ts`
+
+**Interfaces:**
+
+- Consumes: `walk`, `canUseWalkFastPath`, `MAX_WALK_DEPTH`, `type WalkDeps` from `../../src/fs/walker.js`
+
+- [ ] **Step 1: Write direct unit tests with fake deps** — cover the fast-path (indexed mount), slow-path recursion over a small tree, symlink-to-file yield, and cycle termination via the depth bound.
+
+```typescript
+// packages/webapp/tests/fs/walker.test.ts
+import { describe, expect, it } from 'vitest';
+import { MAX_WALK_DEPTH, canUseWalkFastPath, walk, type WalkDeps } from '../../src/fs/walker.js';
+
+function entry(name: string, type: 'file' | 'directory' | 'symlink'): any {
+  return { name, type };
+}
+
+async function collect(gen: AsyncGenerator<string>): Promise<string[]> {
+  const out: string[] = [];
+  for await (const v of gen) out.push(v);
+  return out;
+}
+
+describe('canUseWalkFastPath', () => {
+  it('is false when the path is not a mount', () => {
+    const mountPoints = new Map();
+    expect(canUseWalkFastPath(mountPoints as any, { isReady: () => true }, '/x')).toBe(false);
+  });
+
+  it('is true for a ready indexed mount with no nested mounts', () => {
+    const mountPoints = new Map([['/mnt', {}]]);
+    expect(canUseWalkFastPath(mountPoints as any, { isReady: () => true }, '/mnt')).toBe(true);
+  });
+});
+
+describe('walk', () => {
+  it('uses the index fast path when available', async () => {
+    const deps: WalkDeps = {
+      mountPoints: new Map([['/mnt', {}]]) as any,
+      mountIndex: { isReady: () => true, getFiles: () => ['/mnt/a', '/mnt/b'] },
+      realpath: async (p) => p,
+      readDir: async () => [],
+      stat: async () => ({ type: 'file' }) as any,
+    };
+    expect(await collect(walk(deps, '/mnt'))).toEqual(['/mnt/a', '/mnt/b']);
+  });
+
+  it('recurses the slow path over a small tree', async () => {
+    const tree: Record<string, any[]> = {
+      '/root': [entry('dir', 'directory'), entry('f.txt', 'file')],
+      '/root/dir': [entry('g.txt', 'file')],
+    };
+    const deps: WalkDeps = {
+      mountPoints: new Map() as any,
+      mountIndex: { isReady: () => false, getFiles: () => null },
+      realpath: async (p) => p,
+      readDir: async (p) => tree[p] ?? [],
+      stat: async () => ({ type: 'file' }) as any,
+    };
+    expect((await collect(walk(deps, '/root'))).sort()).toEqual(['/root/dir/g.txt', '/root/f.txt']);
+  });
+
+  it('terminates on a self-referential tree via the depth bound', async () => {
+    // Every directory re-exposes a child of the same shape → infinite without the cap.
+    const deps: WalkDeps = {
+      mountPoints: new Map() as any,
+      mountIndex: { isReady: () => false, getFiles: () => null },
+      realpath: async (p) => p, // mount-like: paths stay distinct, visited-set can't collapse
+      readDir: async () => [entry('loop', 'directory')],
+      stat: async () => ({ type: 'directory' }) as any,
+    };
+    const out = await collect(walk(deps, '/root'));
+    expect(out.length).toBe(0); // no files, and it returns rather than looping
+    expect(MAX_WALK_DEPTH).toBe(64);
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `npx vitest run packages/webapp/tests/fs/walker.test.ts`
+Expected: all PASS (the cycle test must complete, not time out).
+
+- [ ] **Step 3: Dead-code gate**
+
+Run: `npx knip --production`
+Expected: clean (add negated `project` entry in `knip.json` if flagged).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/webapp/tests/fs/walker.test.ts
+git commit -m "test(fs): mirror walker unit tests"
+```
+
+---
+
+## Task 10: Full verification pass + PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full pre-push pass** (per `docs/verification.md`)
+
+```bash
+npm run lint
+npm run typecheck
+npm run test
+npm run test:coverage:webapp
+npm run build -w @slicc/webapp
+node packages/dev-tools/tools/check-touched-exemptions.mjs   # touched files are not on the debt list → should pass/skip
+```
+
+Expected: all green. `test:coverage:webapp` stays at or above the floor (new unit tests add coverage).
+
+- [ ] **Step 2: Sanity-check the line reduction**
+
+Run: `wc -l packages/webapp/src/fs/virtual-fs.ts`
+Expected: ~250–350 fewer lines than the 2,165 baseline; `error-rebrand.ts`, `symlink-resolver.ts`, `walker.ts` exist and are imported.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+git push -u origin issue-1572
+gh pr create --fill --base main
+```
+
+PR description: reference #1572, state this is subset B (error-rebrand + symlink-resolver + walker), no public API change, mount-registry/backend-init deferred, behavior guarded by unchanged API-level tests.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- error-rebrand extraction → Tasks 1–3 ✓
+- symlink-resolver extraction → Tasks 4–6 ✓
+- walker extraction → Tasks 7–9 ✓
+- one PR / ~9 idempotent commits → Tasks 1–9 produce 9 commits; Task 10 opens the PR ✓
+- no public API change → every delegate keeps the original `VirtualFS` signature ✓
+- tests move/mirror alongside → Tasks 3, 6, 9 ✓
+- verification per commit → each task Step 3; full pass in Task 10 ✓
+- knip-clean intermediate commits → each extraction adds+wires in one commit ✓
+
+**Placeholder scan:** No TBD/TODO/"add error handling"; every code step shows complete code.
+
+**Type consistency:** `convertError`/`rebrandFsError` signatures match across Tasks 1–2 and their consumers (Tasks 4–5). `SymlinkLfs`/`FsStatsLike` defined in Task 4, reused in Tasks 5–6. `WalkMountView`/`WalkIndexView`/`WalkDeps` defined in Tasks 7–8, reused in Task 9. `findMount` is adapted to a `(path) => boolean` predicate at the `VirtualFS` delegate boundary (Task 5), matching the module signature.
+
+**Note on test strategy:** "move alongside" is implemented as *mirror* — new co-located unit tests exercise the extracted modules directly with fakes, while the existing `VirtualFS` API tests remain in place as the behavior-preservation guard. Deleting the integration tests would remove the very guard that proves no behavior changed, so they are kept.

--- a/docs/superpowers/specs/2026-07-20-virtual-fs-extraction-design.md
+++ b/docs/superpowers/specs/2026-07-20-virtual-fs-extraction-design.md
@@ -1,0 +1,111 @@
+# VirtualFS Extraction — Design (Issue #1572, subset B)
+
+## Problem
+
+`packages/webapp/src/fs/virtual-fs.ts` is 2,165 lines: a single `VirtualFS`
+class fusing ~8 distinct responsibilities (backend bootstrap, path prefixing,
+mount registry, async POSIX surface, sync fast-path, symlink resolution, walk
+engine, concurrency/error handling). It is a hot change path (13+ bug-fix
+commits recently), so complexity keeps ratcheting up.
+
+Issue #1572 proposes a full 8-way split. The nightly Backlog Dispatcher
+**skipped** it as too large / not well-localised. This spec scopes a
+**pragmatic subset (option B)**: extract only the cleanest, lowest-risk,
+near-self-contained boundaries first, prove the pattern, then re-evaluate
+before touching the higher-risk mount/backend internals.
+
+## Scope
+
+**In scope** — three extractions, ordered by risk (low → high):
+
+1. `fs/error-rebrand.ts` — `convertError`, `rebrandFsError`
+2. `fs/symlink-resolver.ts` — `realpath`, `resolveRealpathComponent`,
+   `lstatOrThrow`, `readAndResolveLink`, `resolveSymlinks`, `MAX_SYMLINK_DEPTH`
+3. `fs/walker.ts` — `walk`, `walkEntry`, `walkSymlink`, `canUseWalkFastPath`,
+   `safeRealpath`, `MAX_WALK_DEPTH`, `MAX_WALK_ENTRIES`
+
+**Out of scope** (deliberately deferred; re-evaluate after this lands):
+`mount-registry`, `backend-init`, `sync-fast-path`, path-prefix/deferred-proxy
+shims. These carry the most invariants and churn risk.
+
+## Architecture
+
+`VirtualFS` remains the sole public entry point. It is exported from
+`packages/webapp/src/fs/index.ts` and imported by 99 files; none reach into its
+private members, so the public API is the only contract that matters.
+
+Each extracted module is an internal sibling under `packages/webapp/src/fs/`.
+Extracted logic becomes **module-level functions that take an explicit deps
+object**; the corresponding `VirtualFS` method becomes a one-line delegate. No
+public API changes, no `VirtualFS` method signature changes.
+
+Dependency shapes (verified against source):
+
+- **error-rebrand**: zero state. `convertError(err, path)` and
+  `rebrandFsError(err, normalizedPath)` are already pure (`rebrandFsError` is
+  already `static`). Export as free functions.
+- **symlink-resolver**: injected deps `{ lfs, findMount }`; imports
+  `convertError` from error-rebrand. `findMount` stays on `VirtualFS` (a
+  mount-registry concern, out of scope) and is passed as a callback.
+- **walker**: injected deps `{ mountPoints, mountIndex, realpath, readDir,
+  stat }`. Recurses back through `readDir`/`stat`, passed as bound callbacks.
+
+## Delivery
+
+**One PR, ~9 idempotent commits.** Binding constraint: every commit must
+independently compile, pass `knip` (no unused exports), and keep tests green.
+That forbids "add module now, wire later" commits, so each extraction adds the
+module and rewires `VirtualFS` in the same commit. Splits happen only at seams
+where a group is independent (leaf helpers) or depends solely on
+already-extracted code.
+
+1. `refactor(fs): extract convertError into error-rebrand.ts` (+delegate)
+2. `refactor(fs): extract rebrandFsError into error-rebrand.ts` (+delegate)
+3. `test(fs): add error-rebrand unit tests`
+4. `refactor(fs): extract lstatOrThrow + readAndResolveLink leaf helpers`
+5. `refactor(fs): extract realpath + resolveRealpathComponent + resolveSymlinks`
+6. `test(fs): move symlink resolver tests alongside module`
+7. `refactor(fs): extract canUseWalkFastPath + safeRealpath leaf helpers`
+8. `refactor(fs): extract walk + walkEntry + walkSymlink generators`
+9. `test(fs): move walk tests alongside module`
+
+The count may shift by ±1–2 during implementation if a seam is cleaner/messier
+than the source suggests. Finer-than-this per-symbol splits are rejected: the
+mutually-recursive clusters (`realpath`↔`resolveRealpathComponent`,
+`walk`↔`walkEntry`↔`walkSymlink`) cannot be split without an intermediate
+commit that fails to compile or needs a throwaway shim.
+
+Rollback granularity = revert any single commit.
+
+## Testing
+
+Existing API-level tests (`virtual-fs*.test.ts`, symlink tests,
+`virtual-fs-walk-cycle.test.ts`) are the behavior-preservation guard and stay
+green with zero edits in every `refactor` commit. Test handling per the agreed
+approach: tests move/mirror alongside each new module (steps 3, 6, 9).
+
+- error-rebrand gains a new unit test file
+  (`tests/fs/error-rebrand.test.ts`) — the ZenFS/LightningFS error-code mapping
+  is now testable in isolation.
+- symlink-resolver and walker keep their existing behavior tests, relocated to
+  module-named files under `tests/fs/`.
+
+Coverage floors are CI-enforced and never hand-lowered; the new error-rebrand
+unit test raises coverage, and relocated tests preserve it.
+
+## Verification (per commit, before push)
+
+Per `docs/verification.md`: `lint` (first — most common CI failure) →
+`typecheck` → the `fs` test suite → `test:coverage:webapp` → touched-file
+complexity gate. `knip` runs in the lint gate and must stay clean at every
+commit (this is what forbids unused-export intermediate states).
+
+## Risks / mitigations
+
+- **Deps-object drift** (extracted fn diverging from `this` semantics):
+  mitigated by each `refactor` commit being a pure move + delegate, verified by
+  unchanged API-level tests.
+- **`findMount` coupling** in symlink-resolver: injected as a callback rather
+  than extracted, keeping subset-B scope honest.
+- **knip on intermediate commits**: avoided by add+wire in the same commit.
+- **Coverage floor**: new unit test raises it; relocations preserve it.

--- a/docs/superpowers/specs/2026-07-20-virtual-fs-extraction-design.md
+++ b/docs/superpowers/specs/2026-07-20-virtual-fs-extraction-design.md
@@ -48,7 +48,7 @@ Dependency shapes (verified against source):
   `convertError` from error-rebrand. `findMount` stays on `VirtualFS` (a
   mount-registry concern, out of scope) and is passed as a callback.
 - **walker**: injected deps `{ mountPoints, mountIndex, realpath, readDir,
-  stat }`. Recurses back through `readDir`/`stat`, passed as bound callbacks.
+stat }`. Recurses back through `readDir`/`stat`, passed as bound callbacks.
 
 ## Delivery
 

--- a/packages/webapp/src/fs/error-rebrand.ts
+++ b/packages/webapp/src/fs/error-rebrand.ts
@@ -1,5 +1,27 @@
 import { FsError, type FsErrorCode } from './types.js';
 
+/**
+ * Re-throw an `FsError` from a backend with the VFS-absolute path. Backend
+ * implementations are agnostic to where they're mounted, so they throw with
+ * mount-relative paths (e.g. `'pack'`); callers expect the path they passed
+ * in (e.g. `'/mnt/repo/pack'`).
+ */
+export function rebrandFsError(err: unknown, normalizedPath: string): never {
+  if (err instanceof FsError) {
+    // FsError's `message` field is the constructor parameter; the displayed
+    // Error.message is `${code}: ${message}${path ? ` '${path}'` : ''}`.
+    // Extract the inner message so the rebranded error keeps the same text.
+    const codePrefix = `${err.code}: `;
+    let inner = err.message;
+    if (inner.startsWith(codePrefix)) inner = inner.slice(codePrefix.length);
+    if (err.path && inner.endsWith(` '${err.path}'`)) {
+      inner = inner.slice(0, inner.length - ` '${err.path}'`.length);
+    }
+    throw new FsError(err.code, inner, normalizedPath);
+  }
+  throw err;
+}
+
 const KNOWN_CODES: FsErrorCode[] = [
   'ENOENT',
   'EEXIST',

--- a/packages/webapp/src/fs/error-rebrand.ts
+++ b/packages/webapp/src/fs/error-rebrand.ts
@@ -1,0 +1,58 @@
+import { FsError, type FsErrorCode } from './types.js';
+
+const KNOWN_CODES: FsErrorCode[] = [
+  'ENOENT',
+  'EEXIST',
+  'ENOTDIR',
+  'EISDIR',
+  'ENOTEMPTY',
+  'EINVAL',
+  'EACCES',
+  'ELOOP',
+  'EBUSY',
+  'EFBIG',
+  'EBADF',
+  'EIO',
+];
+
+/**
+ * Convert LightningFS / ZenFS errors to {@link FsError}.
+ *
+ * ZenFS throws `ErrnoError` with a `.code` POSIX string (and `.errno`);
+ * LightningFS embeds the code in the message text. Prefer the structured
+ * `.code` form so we carry through codes ZenFS reports verbatim, then fall
+ * back to substring matching for LightningFS.
+ */
+export function convertError(err: unknown, path: string): FsError {
+  if (err instanceof FsError) return err;
+  // ZenFS ErrnoError carries `.code` directly (POSIX string).
+  const structured = (err as { code?: unknown })?.code;
+  if (typeof structured === 'string') {
+    const code = structured as FsErrorCode;
+    if ((KNOWN_CODES as string[]).includes(code)) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return new FsError(code, msg || code, path);
+    }
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg.includes('ENOENT')) {
+    return new FsError('ENOENT', 'no such file or directory', path);
+  }
+  if (msg.includes('EEXIST')) {
+    return new FsError('EEXIST', 'file already exists', path);
+  }
+  if (msg.includes('ENOTDIR')) {
+    return new FsError('ENOTDIR', 'not a directory', path);
+  }
+  if (msg.includes('EISDIR')) {
+    return new FsError('EISDIR', 'is a directory', path);
+  }
+  if (msg.includes('ENOTEMPTY')) {
+    return new FsError('ENOTEMPTY', 'directory not empty', path);
+  }
+  if (msg.includes('ELOOP')) {
+    return new FsError('ELOOP', 'too many levels of symbolic links', path);
+  }
+  // Default to EINVAL for unknown errors
+  return new FsError('EINVAL', msg, path);
+}

--- a/packages/webapp/src/fs/symlink-resolver.ts
+++ b/packages/webapp/src/fs/symlink-resolver.ts
@@ -1,5 +1,14 @@
 import { convertError } from './error-rebrand.js';
 import { joinPath, normalizePath, splitPath } from './path-utils.js';
+import { FsError } from './types.js';
+
+/**
+ * Maximum number of symlink hops {@link realpath} follows before throwing
+ * `ELOOP`. ZenFS' own `vfs/async.js#resolve` recurses without a hop counter,
+ * so a `/a → /b → /a` cycle explodes the async stack and OOMs the process;
+ * the bounded loop in {@link realpath} protects against that.
+ */
+export const MAX_SYMLINK_DEPTH = 10;
 
 /** Structural subset of stats consumed by symlink resolution. */
 export interface FsStatsLike {
@@ -22,7 +31,7 @@ export interface SymlinkLfs {
  * lstat a path for realpath. Returns null if ENOENT on the tail component
  * (allowed per POSIX realpath). Throws for all other errors.
  */
-export async function lstatOrThrow(
+async function lstatOrThrow(
   lfs: SymlinkLfs,
   next: string,
   isTail: boolean,
@@ -38,7 +47,7 @@ export async function lstatOrThrow(
 }
 
 /** Read a symlink target and resolve it to an absolute normalized path. */
-export async function readAndResolveLink(
+async function readAndResolveLink(
   lfs: SymlinkLfs,
   linkPath: string,
   originalPath: string
@@ -52,4 +61,86 @@ export async function readAndResolveLink(
   return target.startsWith('/')
     ? normalizePath(target)
     : normalizePath(joinPath(splitPath(linkPath).dir, target));
+}
+
+/**
+ * Resolve a single path component for realpath, following symlinks up to the
+ * hop limit. Returns the updated resolved path and hop count.
+ */
+async function resolveRealpathComponent(
+  lfs: SymlinkLfs,
+  resolved: string,
+  part: string,
+  isTail: boolean,
+  originalPath: string,
+  hops: number
+): Promise<{ resolved: string; hops: number }> {
+  let next = resolved === '/' ? `/${part}` : `${resolved}/${part}`;
+  while (true) {
+    const stats = await lstatOrThrow(lfs, next, isTail, originalPath);
+    if (stats === null) {
+      // ENOENT on tail component — canonical form is current next
+      return { resolved: next, hops };
+    }
+    if (!stats.isSymbolicLink()) {
+      return { resolved: next, hops };
+    }
+    if (++hops > MAX_SYMLINK_DEPTH) {
+      throw new FsError('ELOOP', 'too many symbolic links encountered', originalPath);
+    }
+    next = await readAndResolveLink(lfs, next, originalPath);
+  }
+}
+
+/**
+ * Resolve all symlinks in a path to produce the final canonical path.
+ *
+ * Walks the path component-by-component (so intermediate directory symlinks
+ * like `/alias → /real` are resolved when reading `/alias/file.txt`) and
+ * bounds total hops by {@link MAX_SYMLINK_DEPTH}; a circular chain surfaces as
+ * `ELOOP`. We can't delegate to ZenFS' native `realpath` because
+ * `@zenfs/core`'s `vfs/async.js#resolve` recurses without a hop counter — a
+ * `/a → /b → /a` cycle blows the async stack and exhausts the heap before any
+ * error is raised. This bounded loop mirrors the POSIX realpath contract.
+ *
+ * `findMount` reports whether a path is under an active mount; mount paths are
+ * already canonical (mount backends do not support symlinks).
+ */
+export async function realpath(
+  lfs: SymlinkLfs,
+  findMount: (path: string) => boolean,
+  path: string
+): Promise<string> {
+  const normalized = normalizePath(path);
+  if (findMount(normalized)) return normalized; // Mount paths are already real
+
+  const parts = normalized.split('/').filter(Boolean);
+  let resolved = '/';
+  let hops = 0;
+  for (let i = 0; i < parts.length; i++) {
+    const result = await resolveRealpathComponent(
+      lfs,
+      resolved,
+      parts[i],
+      i === parts.length - 1,
+      normalized,
+      hops
+    );
+    resolved = result.resolved;
+    hops = result.hops;
+  }
+  return resolved;
+}
+
+/**
+ * Resolve symlinks in a path before an operation; mount points pass through
+ * unchanged (mount backends do not support symlinks).
+ */
+export async function resolveSymlinks(
+  lfs: SymlinkLfs,
+  findMount: (path: string) => boolean,
+  path: string
+): Promise<string> {
+  if (findMount(path)) return path;
+  return realpath(lfs, findMount, path);
 }

--- a/packages/webapp/src/fs/symlink-resolver.ts
+++ b/packages/webapp/src/fs/symlink-resolver.ts
@@ -1,0 +1,55 @@
+import { convertError } from './error-rebrand.js';
+import { joinPath, normalizePath, splitPath } from './path-utils.js';
+
+/** Structural subset of stats consumed by symlink resolution. */
+export interface FsStatsLike {
+  size: number;
+  mode: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+}
+
+/** Structural subset of `fs.promises` consumed by symlink resolution. */
+export interface SymlinkLfs {
+  lstat(path: string): Promise<FsStatsLike>;
+  readlink(path: string): Promise<string>;
+}
+
+/**
+ * lstat a path for realpath. Returns null if ENOENT on the tail component
+ * (allowed per POSIX realpath). Throws for all other errors.
+ */
+export async function lstatOrThrow(
+  lfs: SymlinkLfs,
+  next: string,
+  isTail: boolean,
+  originalPath: string
+): Promise<FsStatsLike | null> {
+  try {
+    return await lfs.lstat(next);
+  } catch (err) {
+    const converted = convertError(err, originalPath);
+    if (converted.code === 'ENOENT' && isTail) return null;
+    throw converted;
+  }
+}
+
+/** Read a symlink target and resolve it to an absolute normalized path. */
+export async function readAndResolveLink(
+  lfs: SymlinkLfs,
+  linkPath: string,
+  originalPath: string
+): Promise<string> {
+  let target: string;
+  try {
+    target = await lfs.readlink(linkPath);
+  } catch (err) {
+    throw convertError(err, originalPath);
+  }
+  return target.startsWith('/')
+    ? normalizePath(target)
+    : normalizePath(joinPath(splitPath(linkPath).dir, target));
+}

--- a/packages/webapp/src/fs/symlink-resolver.ts
+++ b/packages/webapp/src/fs/symlink-resolver.ts
@@ -1,6 +1,6 @@
 import { convertError } from './error-rebrand.js';
 import { joinPath, normalizePath, splitPath } from './path-utils.js';
-import { FsError } from './types.js';
+import { FsError, type FsStatsLike } from './types.js';
 
 /**
  * Maximum number of symlink hops {@link realpath} follows before throwing
@@ -9,17 +9,6 @@ import { FsError } from './types.js';
  * the bounded loop in {@link realpath} protects against that.
  */
 export const MAX_SYMLINK_DEPTH = 10;
-
-/** Structural subset of stats consumed by symlink resolution. */
-export interface FsStatsLike {
-  size: number;
-  mode: number;
-  mtimeMs: number;
-  ctimeMs: number;
-  isFile(): boolean;
-  isDirectory(): boolean;
-  isSymbolicLink(): boolean;
-}
 
 /** Structural subset of `fs.promises` consumed by symlink resolution. */
 export interface SymlinkLfs {

--- a/packages/webapp/src/fs/types.ts
+++ b/packages/webapp/src/fs/types.ts
@@ -69,6 +69,21 @@ export type FsErrorCode =
   | 'EBADF' // Bad file descriptor — used when an op runs against a closed/unmounted backend
   | 'EIO'; // I/O error — used for transient network failures, 5xx, AbortError-from-timeout
 
+/**
+ * Structural subset of `node:fs` `Stats` consumed by VirtualFS internals
+ * (symlink resolution + the sync fast path). Kept loose so LightningFS' and
+ * ZenFS' differing stats shapes both satisfy it without adaptation.
+ */
+export interface FsStatsLike {
+  size: number;
+  mode: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+}
+
 /** Custom error class for filesystem operations. */
 export class FsError extends Error {
   constructor(

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -28,7 +28,7 @@ import {
   saveMountEntry,
 } from './mount-table-store.js';
 import { joinPath, normalizePath, splitPath } from './path-utils.js';
-import { lstatOrThrow, readAndResolveLink } from './symlink-resolver.js';
+import { MAX_SYMLINK_DEPTH, realpath, resolveSymlinks } from './symlink-resolver.js';
 import type {
   DirEntry,
   EntryType,
@@ -40,14 +40,6 @@ import type {
 } from './types.js';
 import { FsError } from './types.js';
 
-/**
- * Maximum number of symlink hops {@link VirtualFS.realpath} will follow
- * before throwing `ELOOP`. ZenFS' own `vfs/async.js#resolve` recurses
- * without a hop counter, so a `/a → /b → /a` cycle explodes the async
- * stack and OOMs the process — see {@link VirtualFS.realpath} for the
- * bounded loop that protects against that.
- */
-const MAX_SYMLINK_DEPTH = 10;
 // Bound `walk()`'s slow-path recursion. Symlink cycles surface as ELOOP via
 // realpath, but realpath returns mount paths unchanged ("already real"), so a
 // self-referential mount yields ever-distinct paths the visited-set can't
@@ -1991,73 +1983,7 @@ export class VirtualFS {
    * production) from OOM-ing on cycles.
    */
   async realpath(path: string): Promise<string> {
-    const normalized = normalizePath(path);
-    const mount = this.findMount(normalized);
-    if (mount) return normalized; // Mount paths are already real
-
-    // Component-walk: build the resolved path one segment at a time,
-    // resolving any symlink encountered against the already-resolved
-    // prefix so directory-component symlinks (`/alias/file.txt`) work.
-    const parts = normalized.split('/').filter(Boolean);
-    let resolved = '/';
-    let hops = 0;
-    for (let i = 0; i < parts.length; i++) {
-      const result = await this.resolveRealpathComponent(
-        resolved,
-        parts[i],
-        i === parts.length - 1,
-        normalized,
-        hops
-      );
-      resolved = result.resolved;
-      hops = result.hops;
-    }
-    return resolved;
-  }
-
-  /**
-   * Resolve a single path component for realpath, following symlinks up to the hop limit.
-   * Returns the updated resolved path and hop count.
-   */
-  private async resolveRealpathComponent(
-    resolved: string,
-    part: string,
-    isTail: boolean,
-    originalPath: string,
-    hops: number
-  ): Promise<{ resolved: string; hops: number }> {
-    let next = resolved === '/' ? `/${part}` : `${resolved}/${part}`;
-    while (true) {
-      const stats = await this.lstatOrThrow(next, isTail, originalPath);
-      if (stats === null) {
-        // ENOENT on tail component — canonical form is current next
-        return { resolved: next, hops };
-      }
-      if (!stats.isSymbolicLink()) {
-        return { resolved: next, hops };
-      }
-      if (++hops > MAX_SYMLINK_DEPTH) {
-        throw new FsError('ELOOP', 'too many symbolic links encountered', originalPath);
-      }
-      next = await this.readAndResolveLink(next, originalPath);
-    }
-  }
-
-  /**
-   * lstat a path for realpath. Returns null if ENOENT on the tail component
-   * (allowed per POSIX realpath). Throws for all other errors.
-   */
-  private lstatOrThrow(
-    next: string,
-    isTail: boolean,
-    originalPath: string
-  ): Promise<FsStatsLike | null> {
-    return lstatOrThrow(this.lfs, next, isTail, originalPath);
-  }
-
-  /** Read a symlink target and resolve it to an absolute normalized path. */
-  private readAndResolveLink(linkPath: string, originalPath: string): Promise<string> {
-    return readAndResolveLink(this.lfs, linkPath, originalPath);
+    return realpath(this.lfs, (p) => this.findMount(p) !== null, path);
   }
 
   /**
@@ -2065,10 +1991,8 @@ export class VirtualFS {
    * Used by readFile, writeFile, stat, etc. to follow symlinks transparently.
    * Mount points are returned as-is (mount backends do not support symlinks).
    */
-  private async resolveSymlinks(path: string): Promise<string> {
-    const mount = this.findMount(path);
-    if (mount) return path; // Mount points don't have symlinks
-    return this.realpath(path);
+  private resolveSymlinks(path: string): Promise<string> {
+    return resolveSymlinks(this.lfs, (p) => this.findMount(p) !== null, path);
   }
 
   /**

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -1732,7 +1732,7 @@ export class VirtualFS {
    * For mounted directories with a ready index, uses the fast path (O(n) iteration
    * over cached file list). Falls back to slow recursive readDir otherwise.
    */
-  async *walk(path: string, _visited?: Set<string>, _depth = 0): AsyncGenerator<string> {
+  async *walk(path: string, visited?: Set<string>, depth = 0): AsyncGenerator<string> {
     yield* walk(
       {
         mountPoints: this.mountPoints,
@@ -1742,8 +1742,8 @@ export class VirtualFS {
         stat: (p) => this.stat(p),
       },
       path,
-      _visited,
-      _depth
+      visited,
+      depth
     );
   }
 

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -1252,7 +1252,7 @@ export class VirtualFS {
       }
       return (await this.lfs.readFile(resolved)) as Uint8Array;
     } catch (err) {
-      throw this.convertError(err, normalized);
+      throw convertError(err, normalized);
     }
   }
 
@@ -1354,16 +1354,16 @@ export class VirtualFS {
           try {
             await this.lfs.writeFile(resolved, content);
           } catch (retryErr) {
-            throw this.convertError(retryErr, normalized);
+            throw convertError(retryErr, normalized);
           }
         } else {
-          throw this.convertError(err, normalized);
+          throw convertError(err, normalized);
         }
       }
       try {
         await this.lfs.truncate?.(resolved, byteLength);
       } catch (err) {
-        throw this.convertError(err, normalized);
+        throw convertError(err, normalized);
       }
     });
     this.watcher?.notify([
@@ -1435,7 +1435,7 @@ export class VirtualFS {
       }
       return entries;
     } catch (err) {
-      throw this.convertError(err, normalized);
+      throw convertError(err, normalized);
     }
   }
 
@@ -1500,7 +1500,7 @@ export class VirtualFS {
       } catch (err: unknown) {
         // Ignore EEXIST errors in recursive mode
         if (err instanceof Error && !err.message.includes('EEXIST')) {
-          throw this.convertError(err, current);
+          throw convertError(err, current);
         }
       }
     }
@@ -1540,7 +1540,7 @@ export class VirtualFS {
         try {
           await this.lfs.mkdir(normalized);
         } catch (err) {
-          throw this.convertError(err, normalized);
+          throw convertError(err, normalized);
         }
       });
       this.watcher?.notify([{ type: 'create', path: normalized, entryType: 'directory' }]);
@@ -1595,7 +1595,7 @@ export class VirtualFS {
         await this.writeOpfsMetadataSidecar();
       });
     } catch (err) {
-      throw this.convertError(err, normalized);
+      throw convertError(err, normalized);
     }
     this.watcher?.notify([{ type: 'delete', path: normalized }]);
   }
@@ -1658,7 +1658,7 @@ export class VirtualFS {
         ctime: s.ctimeMs,
       };
     } catch (err) {
-      throw this.convertError(err, normalized);
+      throw convertError(err, normalized);
     }
   }
 
@@ -1706,7 +1706,7 @@ export class VirtualFS {
     try {
       await this.lfs.rename(normalizedOld, normalizedNew);
     } catch (err) {
-      throw this.convertError(err, normalizedOld);
+      throw convertError(err, normalizedOld);
     }
     this.watcher?.notify([
       { type: 'delete', path: normalizedOld, entryType },
@@ -1809,10 +1809,10 @@ export class VirtualFS {
           try {
             await this.lfs.symlink(target, normalizedLinkPath);
           } catch (retryErr) {
-            throw this.convertError(retryErr, normalizedLinkPath);
+            throw convertError(retryErr, normalizedLinkPath);
           }
         } else {
-          throw this.convertError(err, normalizedLinkPath);
+          throw convertError(err, normalizedLinkPath);
         }
       }
       // Persist symlink-ness eagerly (OPFS only) inside the write lock so it
@@ -1837,7 +1837,7 @@ export class VirtualFS {
     try {
       return await this.lfs.readlink(normalized);
     } catch (err) {
-      throw this.convertError(err, normalized);
+      throw convertError(err, normalized);
     }
   }
 
@@ -1872,7 +1872,7 @@ export class VirtualFS {
         ctime: s.ctimeMs,
       };
     } catch (err) {
-      throw this.convertError(err, normalized);
+      throw convertError(err, normalized);
     }
   }
 
@@ -1901,18 +1901,5 @@ export class VirtualFS {
    */
   private resolveSymlinks(path: string): Promise<string> {
     return resolveSymlinks(this.lfs, (p) => this.findMount(p) !== null, path);
-  }
-
-  /**
-   * Convert LightningFS / ZenFS errors to {@link FsError}.
-   *
-   * ZenFS throws `ErrnoError` instances with a `.code` POSIX string
-   * field (and `.errno: number`); LightningFS embeds the code in the
-   * message text. Try the structured `.code` form first so we carry
-   * through codes ZenFS reports verbatim, then fall back to
-   * substring matching for LightningFS.
-   */
-  private convertError(err: unknown, path: string): FsError {
-    return convertError(err, path);
   }
 }

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -39,13 +39,7 @@ import type {
   Stats,
 } from './types.js';
 import { FsError } from './types.js';
-
-// Bound `walk()`'s slow-path recursion. Symlink cycles surface as ELOOP via
-// realpath, but realpath returns mount paths unchanged ("already real"), so a
-// self-referential mount yields ever-distinct paths the visited-set can't
-// collapse — cap depth and total entries so it can't loop forever. See `walk`.
-const MAX_WALK_DEPTH = 64;
-const MAX_WALK_ENTRIES = 100_000;
+import { canUseWalkFastPath, MAX_WALK_DEPTH, MAX_WALK_ENTRIES, safeRealpath } from './walker.js';
 
 /** Backend identifier for {@link VirtualFS}. */
 export type VfsBackend = 'memory' | 'opfs';
@@ -1786,21 +1780,12 @@ export class VirtualFS {
 
   /** Check whether the walk fast path (indexed mount, no nested mounts) is available. */
   private canUseWalkFastPath(normalized: string): boolean {
-    if (this.mountPoints.size === 0 || !this.mountPoints.has(normalized)) return false;
-    if (!this.mountIndex.isReady(normalized)) return false;
-    const hasNestedMounts = [...this.mountPoints.keys()].some(
-      (mp) => mp !== normalized && mp.startsWith(normalized + '/')
-    );
-    return !hasNestedMounts;
+    return canUseWalkFastPath(this.mountPoints, this.mountIndex, normalized);
   }
 
   /** Resolve realpath, falling back to the input path on any error. */
-  private async safeRealpath(normalized: string): Promise<string> {
-    try {
-      return await this.realpath(normalized);
-    } catch {
-      return normalized;
-    }
+  private safeRealpath(normalized: string): Promise<string> {
+    return safeRealpath((p) => this.realpath(p), normalized);
   }
 
   /** Yield files from a single walk entry (file, symlink, or directory). */

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -33,6 +33,7 @@ import type {
   DirEntry,
   EntryType,
   FileContent,
+  FsStatsLike,
   MkdirOptions,
   ReadFileOptions,
   RmOptions,
@@ -101,16 +102,6 @@ interface FsPromisesLike {
   readlink(path: string): Promise<string>;
   realpath?(path: string): Promise<string>;
   truncate?(path: string, len: number): Promise<void>;
-}
-
-interface FsStatsLike {
-  size: number;
-  mode: number;
-  mtimeMs: number;
-  ctimeMs: number;
-  isFile(): boolean;
-  isDirectory(): boolean;
-  isSymbolicLink(): boolean;
 }
 
 /** Structural subset of `node:fs` sync methods we lean on for the fast path. */

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -15,6 +15,7 @@
  * - Agent tools
  */
 
+import { convertError } from './error-rebrand.js';
 import type { FsWatcher } from './fs-watcher.js';
 import type { MountBackend, RefreshReport } from './mount/backend.js';
 import { LocalMountBackend } from './mount/backend-local.js';
@@ -31,7 +32,6 @@ import type {
   DirEntry,
   EntryType,
   FileContent,
-  FsErrorCode,
   MkdirOptions,
   ReadFileOptions,
   RmOptions,
@@ -2116,50 +2116,6 @@ export class VirtualFS {
    * substring matching for LightningFS.
    */
   private convertError(err: unknown, path: string): FsError {
-    if (err instanceof FsError) return err;
-    // ZenFS ErrnoError carries `.code` directly (POSIX string).
-    const structured = (err as { code?: unknown })?.code;
-    if (typeof structured === 'string') {
-      const code = structured as FsErrorCode;
-      const known: FsErrorCode[] = [
-        'ENOENT',
-        'EEXIST',
-        'ENOTDIR',
-        'EISDIR',
-        'ENOTEMPTY',
-        'EINVAL',
-        'EACCES',
-        'ELOOP',
-        'EBUSY',
-        'EFBIG',
-        'EBADF',
-        'EIO',
-      ];
-      if ((known as string[]).includes(code)) {
-        const msg = err instanceof Error ? err.message : String(err);
-        return new FsError(code, msg || code, path);
-      }
-    }
-    const msg = err instanceof Error ? err.message : String(err);
-    if (msg.includes('ENOENT')) {
-      return new FsError('ENOENT', 'no such file or directory', path);
-    }
-    if (msg.includes('EEXIST')) {
-      return new FsError('EEXIST', 'file already exists', path);
-    }
-    if (msg.includes('ENOTDIR')) {
-      return new FsError('ENOTDIR', 'not a directory', path);
-    }
-    if (msg.includes('EISDIR')) {
-      return new FsError('EISDIR', 'is a directory', path);
-    }
-    if (msg.includes('ENOTEMPTY')) {
-      return new FsError('ENOTEMPTY', 'directory not empty', path);
-    }
-    if (msg.includes('ELOOP')) {
-      return new FsError('ELOOP', 'too many levels of symbolic links', path);
-    }
-    // Default to EINVAL for unknown errors
-    return new FsError('EINVAL', msg, path);
+    return convertError(err, path);
   }
 }

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -15,7 +15,7 @@
  * - Agent tools
  */
 
-import { convertError } from './error-rebrand.js';
+import { convertError, rebrandFsError } from './error-rebrand.js';
 import type { FsWatcher } from './fs-watcher.js';
 import type { MountBackend, RefreshReport } from './mount/backend.js';
 import { LocalMountBackend } from './mount/backend-local.js';
@@ -1217,28 +1217,6 @@ export class VirtualFS {
    * Returns the mount path, handle, and the path segments relative to the mount root,
    * or null if the path is not under any mount.
    */
-  /**
-   * Re-throw an `FsError` from a backend with the VFS-absolute path. Backend
-   * implementations are agnostic to where they're mounted, so they throw with
-   * mount-relative paths (e.g. `'pack'`); callers expect the path they passed
-   * in (e.g. `'/mnt/repo/pack'`).
-   */
-  private static rebrandFsError(err: unknown, normalizedPath: string): never {
-    if (err instanceof FsError) {
-      // FsError's `message` field is the constructor parameter; the displayed
-      // Error.message is `${code}: ${message}${path ? ` '${path}'` : ''}`.
-      // Extract the inner message so the rebranded error keeps the same text.
-      const codePrefix = `${err.code}: `;
-      let inner = err.message;
-      if (inner.startsWith(codePrefix)) inner = inner.slice(codePrefix.length);
-      if (err.path && inner.endsWith(` '${err.path}'`)) {
-        inner = inner.slice(0, inner.length - ` '${err.path}'`.length);
-      }
-      throw new FsError(err.code, inner, normalizedPath);
-    }
-    throw err;
-  }
-
   private findMount(
     path: string
   ): { path: string; backend: MountBackend; relParts: string[] } | null {
@@ -1284,7 +1262,7 @@ export class VirtualFS {
         if (encoding === 'utf-8') return new TextDecoder('utf-8').decode(body);
         return body;
       } catch (err) {
-        VirtualFS.rebrandFsError(err, normalized);
+        rebrandFsError(err, normalized);
       }
     }
     // Resolve symlinks before reading
@@ -1334,7 +1312,7 @@ export class VirtualFS {
       try {
         await mount.backend.writeFile(relPath, data);
       } catch (err) {
-        VirtualFS.rebrandFsError(err, normalized);
+        rebrandFsError(err, normalized);
       }
       this.watcher?.notify([
         {
@@ -1454,7 +1432,7 @@ export class VirtualFS {
     try {
       dirEntries = await mount.backend.readDir(relPath);
     } catch (err) {
-      VirtualFS.rebrandFsError(err, normalized);
+      rebrandFsError(err, normalized);
     }
     const entries = new Map<string, DirEntry>();
     for (const entry of dirEntries) {
@@ -1567,7 +1545,7 @@ export class VirtualFS {
       try {
         await mount.backend.mkdir(relPath);
       } catch (err) {
-        VirtualFS.rebrandFsError(err, normalized);
+        rebrandFsError(err, normalized);
       }
       if (!existed) {
         this.watcher?.notify([{ type: 'create', path: normalized, entryType: 'directory' }]);
@@ -1613,7 +1591,7 @@ export class VirtualFS {
       try {
         await mount.backend.remove(relPath, { recursive: options?.recursive });
       } catch (err) {
-        VirtualFS.rebrandFsError(err, normalized);
+        rebrandFsError(err, normalized);
       }
       this.watcher?.notify([{ type: 'delete', path: normalized, entryType }]);
       // Update mount index
@@ -1688,7 +1666,7 @@ export class VirtualFS {
           ctime: ms.mtime,
         };
       } catch (err) {
-        VirtualFS.rebrandFsError(err, normalized);
+        rebrandFsError(err, normalized);
       }
     }
     // Resolve symlinks before stat — stat follows symlinks

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -28,6 +28,7 @@ import {
   saveMountEntry,
 } from './mount-table-store.js';
 import { joinPath, normalizePath, splitPath } from './path-utils.js';
+import { lstatOrThrow, readAndResolveLink } from './symlink-resolver.js';
 import type {
   DirEntry,
   EntryType,
@@ -2046,31 +2047,17 @@ export class VirtualFS {
    * lstat a path for realpath. Returns null if ENOENT on the tail component
    * (allowed per POSIX realpath). Throws for all other errors.
    */
-  private async lstatOrThrow(
+  private lstatOrThrow(
     next: string,
     isTail: boolean,
     originalPath: string
   ): Promise<FsStatsLike | null> {
-    try {
-      return await this.lfs.lstat(next);
-    } catch (err) {
-      const converted = this.convertError(err, originalPath);
-      if (converted.code === 'ENOENT' && isTail) return null;
-      throw converted;
-    }
+    return lstatOrThrow(this.lfs, next, isTail, originalPath);
   }
 
   /** Read a symlink target and resolve it to an absolute normalized path. */
-  private async readAndResolveLink(linkPath: string, originalPath: string): Promise<string> {
-    let target: string;
-    try {
-      target = await this.lfs.readlink(linkPath);
-    } catch (err) {
-      throw this.convertError(err, originalPath);
-    }
-    return target.startsWith('/')
-      ? normalizePath(target)
-      : normalizePath(joinPath(splitPath(linkPath).dir, target));
+  private readAndResolveLink(linkPath: string, originalPath: string): Promise<string> {
+    return readAndResolveLink(this.lfs, linkPath, originalPath);
   }
 
   /**

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -39,7 +39,7 @@ import type {
   Stats,
 } from './types.js';
 import { FsError } from './types.js';
-import { canUseWalkFastPath, MAX_WALK_DEPTH, MAX_WALK_ENTRIES, safeRealpath } from './walker.js';
+import { walk } from './walker.js';
 
 /** Backend identifier for {@link VirtualFS}. */
 export type VfsBackend = 'memory' | 'opfs';
@@ -1742,86 +1742,18 @@ export class VirtualFS {
    * over cached file list). Falls back to slow recursive readDir otherwise.
    */
   async *walk(path: string, _visited?: Set<string>, _depth = 0): AsyncGenerator<string> {
-    const normalized = normalizePath(path);
-
-    // Fast path: indexed mount with no nested mounts
-    if (this.canUseWalkFastPath(normalized)) {
-      const files = this.mountIndex.getFiles(normalized);
-      if (files) {
-        for (const filePath of files) {
-          yield filePath;
-        }
-        return;
-      }
-    }
-
-    // Slow path: recursive readDir
-    const visited = _visited ?? new Set<string>();
-
-    // Bound the recursion: realpath leaves mount paths unchanged, so the
-    // visited-set below cannot collapse a self-referential mount (a tree that
-    // re-exposes an ancestor — its nested paths are all distinct strings).
-    // Cap depth + total entries so such a mount can't make walk() — and the
-    // jsh/bsh/ScriptCatalog discovery built on it — loop forever.
-    if (_depth > MAX_WALK_DEPTH || visited.size >= MAX_WALK_ENTRIES) return;
-
-    // Track the real path to detect symlink loops
-    const realPath = await this.safeRealpath(normalized);
-    if (visited.has(realPath)) return;
-    visited.add(realPath);
-
-    const entries = await this.readDir(normalized);
-
-    for (const entry of entries) {
-      const childPath = normalized === '/' ? `/${entry.name}` : `${normalized}/${entry.name}`;
-      yield* this.walkEntry(entry, childPath, visited, _depth + 1);
-    }
-  }
-
-  /** Check whether the walk fast path (indexed mount, no nested mounts) is available. */
-  private canUseWalkFastPath(normalized: string): boolean {
-    return canUseWalkFastPath(this.mountPoints, this.mountIndex, normalized);
-  }
-
-  /** Resolve realpath, falling back to the input path on any error. */
-  private safeRealpath(normalized: string): Promise<string> {
-    return safeRealpath((p) => this.realpath(p), normalized);
-  }
-
-  /** Yield files from a single walk entry (file, symlink, or directory). */
-  private async *walkEntry(
-    entry: DirEntry,
-    childPath: string,
-    visited: Set<string>,
-    depth: number
-  ): AsyncGenerator<string> {
-    if (entry.type === 'file') {
-      yield childPath;
-      return;
-    }
-    if (entry.type === 'symlink') {
-      yield* this.walkSymlink(childPath, visited, depth);
-      return;
-    }
-    yield* this.walk(childPath, visited, depth);
-  }
-
-  /** Follow a symlink during walk — yield as file or recurse as directory. */
-  private async *walkSymlink(
-    childPath: string,
-    visited: Set<string>,
-    depth: number
-  ): AsyncGenerator<string> {
-    try {
-      const targetStat = await this.stat(childPath);
-      if (targetStat.type === 'file') {
-        yield childPath;
-      } else if (targetStat.type === 'directory') {
-        yield* this.walk(childPath, visited, depth);
-      }
-    } catch {
-      // Dangling symlink — skip
-    }
+    yield* walk(
+      {
+        mountPoints: this.mountPoints,
+        mountIndex: this.mountIndex,
+        realpath: (p) => this.realpath(p),
+        readDir: (p) => this.readDir(p),
+        stat: (p) => this.stat(p),
+      },
+      path,
+      _visited,
+      _depth
+    );
   }
 
   /**

--- a/packages/webapp/src/fs/walker.ts
+++ b/packages/webapp/src/fs/walker.ts
@@ -1,0 +1,44 @@
+// Bound `walk()`'s slow-path recursion. Symlink cycles surface as ELOOP via
+// realpath, but realpath returns mount paths unchanged ("already real"), so a
+// self-referential mount yields ever-distinct paths the visited-set can't
+// collapse — cap depth and total entries so it can't loop forever.
+export const MAX_WALK_DEPTH = 64;
+export const MAX_WALK_ENTRIES = 100_000;
+
+/** Structural view of the VirtualFS mount table consumed by the walker. */
+export interface WalkMountView {
+  readonly size: number;
+  has(path: string): boolean;
+  keys(): IterableIterator<string>;
+}
+
+/** Structural view of the MountIndex readiness check consumed by the walker. */
+export interface WalkIndexView {
+  isReady(path: string): boolean;
+}
+
+/** Check whether the walk fast path (indexed mount, no nested mounts) is available. */
+export function canUseWalkFastPath(
+  mountPoints: WalkMountView,
+  mountIndex: WalkIndexView,
+  normalized: string
+): boolean {
+  if (mountPoints.size === 0 || !mountPoints.has(normalized)) return false;
+  if (!mountIndex.isReady(normalized)) return false;
+  const hasNestedMounts = Array.from(mountPoints.keys()).some(
+    (mp) => mp !== normalized && mp.startsWith(normalized + '/')
+  );
+  return !hasNestedMounts;
+}
+
+/** Resolve realpath, falling back to the input path on any error. */
+export async function safeRealpath(
+  realpath: (p: string) => Promise<string>,
+  normalized: string
+): Promise<string> {
+  try {
+    return await realpath(normalized);
+  } catch {
+    return normalized;
+  }
+}

--- a/packages/webapp/src/fs/walker.ts
+++ b/packages/webapp/src/fs/walker.ts
@@ -1,3 +1,6 @@
+import { normalizePath } from './path-utils.js';
+import type { DirEntry, Stats } from './types.js';
+
 // Bound `walk()`'s slow-path recursion. Symlink cycles surface as ELOOP via
 // realpath, but realpath returns mount paths unchanged ("already real"), so a
 // self-referential mount yields ever-distinct paths the visited-set can't
@@ -32,7 +35,7 @@ export function canUseWalkFastPath(
 }
 
 /** Resolve realpath, falling back to the input path on any error. */
-export async function safeRealpath(
+async function safeRealpath(
   realpath: (p: string) => Promise<string>,
   normalized: string
 ): Promise<string> {
@@ -40,5 +43,86 @@ export async function safeRealpath(
     return await realpath(normalized);
   } catch {
     return normalized;
+  }
+}
+
+/** Dependencies the directory walker pulls from VirtualFS. */
+export interface WalkDeps {
+  mountPoints: WalkMountView;
+  mountIndex: WalkIndexView & { getFiles(path: string): string[] | undefined };
+  realpath(p: string): Promise<string>;
+  readDir(p: string): Promise<DirEntry[]>;
+  stat(p: string): Promise<Stats>;
+}
+
+/** Recursively walk a directory tree, yielding all file paths. */
+export async function* walk(
+  deps: WalkDeps,
+  path: string,
+  visited?: Set<string>,
+  depth = 0
+): AsyncGenerator<string> {
+  const normalized = normalizePath(path);
+
+  // Fast path: indexed mount with no nested mounts
+  if (canUseWalkFastPath(deps.mountPoints, deps.mountIndex, normalized)) {
+    const files = deps.mountIndex.getFiles(normalized);
+    if (files) {
+      for (const filePath of files) yield filePath;
+      return;
+    }
+  }
+
+  // Slow path: recursive readDir
+  const seen = visited ?? new Set<string>();
+  if (depth > MAX_WALK_DEPTH || seen.size >= MAX_WALK_ENTRIES) return;
+
+  // Track the real path to detect symlink loops
+  const realPath = await safeRealpath((p) => deps.realpath(p), normalized);
+  if (seen.has(realPath)) return;
+  seen.add(realPath);
+
+  const entries = await deps.readDir(normalized);
+  for (const entry of entries) {
+    const childPath = normalized === '/' ? `/${entry.name}` : `${normalized}/${entry.name}`;
+    yield* walkEntry(deps, entry, childPath, seen, depth + 1);
+  }
+}
+
+/** Yield files from a single walk entry (file, symlink, or directory). */
+async function* walkEntry(
+  deps: WalkDeps,
+  entry: DirEntry,
+  childPath: string,
+  visited: Set<string>,
+  depth: number
+): AsyncGenerator<string> {
+  if (entry.type === 'file') {
+    yield childPath;
+    return;
+  }
+  if (entry.type === 'symlink') {
+    yield* walkSymlink(deps, childPath, visited, depth);
+    return;
+  }
+  yield* walk(deps, childPath, visited, depth);
+}
+
+/** Follow a symlink during walk — yield as file or recurse as directory. */
+async function* walkSymlink(
+  deps: WalkDeps,
+  childPath: string,
+  visited: Set<string>,
+  depth: number
+): AsyncGenerator<string> {
+  try {
+    const targetStat = await deps.stat(childPath);
+    if (targetStat.type === 'file') {
+      yield childPath;
+    } else if (targetStat.type === 'directory') {
+      yield* walk(deps, childPath, visited, depth);
+    }
+  } catch {
+    // Dangling symlink — skip
   }
 }

--- a/packages/webapp/tests/fs/error-rebrand.test.ts
+++ b/packages/webapp/tests/fs/error-rebrand.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { convertError, rebrandFsError } from '../../src/fs/error-rebrand.js';
+import { FsError } from '../../src/fs/types.js';
+
+describe('convertError', () => {
+  it('passes through an existing FsError unchanged', () => {
+    const e = new FsError('ENOENT', 'x', '/a');
+    expect(convertError(e, '/b')).toBe(e);
+  });
+
+  it('maps a structured ZenFS .code to FsError', () => {
+    const err = Object.assign(new Error('boom'), { code: 'EISDIR' });
+    const out = convertError(err, '/dir');
+    expect(out).toBeInstanceOf(FsError);
+    expect(out.code).toBe('EISDIR');
+    expect(out.path).toBe('/dir');
+  });
+
+  it.each([
+    ['ENOENT: no such file or directory', 'ENOENT'],
+    ['EEXIST: file exists', 'EEXIST'],
+    ['ENOTDIR: not a directory', 'ENOTDIR'],
+    ['EISDIR: illegal operation on a directory', 'EISDIR'],
+    ['ENOTEMPTY: directory not empty', 'ENOTEMPTY'],
+    ['ELOOP: too many symbolic links', 'ELOOP'],
+  ])('falls back to substring matching for LightningFS-style %s', (message, expected) => {
+    expect(convertError(new Error(message), '/p').code).toBe(expected);
+  });
+
+  it('treats a structured code outside the known set as an unknown error', () => {
+    const err = Object.assign(new Error('cross-device'), { code: 'EXDEV' });
+    expect(convertError(err, '/p').code).toBe('EINVAL');
+  });
+
+  it('defaults unknown errors to EINVAL', () => {
+    const out = convertError(new Error('weird'), '/p');
+    expect(out.code).toBe('EINVAL');
+    expect(out.message).toContain('weird');
+  });
+});
+
+describe('rebrandFsError', () => {
+  it('rethrows an FsError with the caller-facing path', () => {
+    const backendErr = new FsError('ENOENT', 'no such file or directory', 'pack');
+    expect(() => rebrandFsError(backendErr, '/mnt/repo/pack')).toThrow(FsError);
+    try {
+      rebrandFsError(backendErr, '/mnt/repo/pack');
+    } catch (e) {
+      expect((e as FsError).code).toBe('ENOENT');
+      expect((e as FsError).path).toBe('/mnt/repo/pack');
+      // The rebranded message must keep the original inner text with the
+      // caller-facing path — no duplicated suffix, no leftover code prefix.
+      expect((e as FsError).message).toBe("ENOENT: no such file or directory '/mnt/repo/pack'");
+    }
+  });
+
+  it('rethrows a non-FsError untouched', () => {
+    const raw = new Error('native');
+    expect(() => rebrandFsError(raw, '/x')).toThrow(raw);
+  });
+});

--- a/packages/webapp/tests/fs/symlink-resolver.test.ts
+++ b/packages/webapp/tests/fs/symlink-resolver.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
-  type FsStatsLike,
   MAX_SYMLINK_DEPTH,
   realpath,
   resolveSymlinks,
   type SymlinkLfs,
 } from '../../src/fs/symlink-resolver.js';
+import type { FsStatsLike } from '../../src/fs/types.js';
 
 function statFor(kind: 'file' | 'dir' | 'link'): FsStatsLike {
   return {

--- a/packages/webapp/tests/fs/symlink-resolver.test.ts
+++ b/packages/webapp/tests/fs/symlink-resolver.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type FsStatsLike,
+  MAX_SYMLINK_DEPTH,
+  realpath,
+  resolveSymlinks,
+  type SymlinkLfs,
+} from '../../src/fs/symlink-resolver.js';
+
+function statFor(kind: 'file' | 'dir' | 'link'): FsStatsLike {
+  return {
+    size: 0,
+    mode: 0,
+    mtimeMs: 0,
+    ctimeMs: 0,
+    isFile: () => kind === 'file',
+    isDirectory: () => kind === 'dir',
+    isSymbolicLink: () => kind === 'link',
+  };
+}
+
+function fakeLfs(links: Record<string, string>, files: Set<string>): SymlinkLfs {
+  // Any path that is a proper ancestor of a known file or link is a directory
+  // (mirrors a real tree where intermediate components must exist to be walked).
+  const isAncestorDir = (p: string) =>
+    [...Array.from(files), ...Object.keys(links)].some((entry) => entry.startsWith(`${p}/`));
+  return {
+    async lstat(p: string) {
+      if (p in links) return statFor('link');
+      if (files.has(p)) return statFor('file');
+      if (isAncestorDir(p)) return statFor('dir');
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    },
+    async readlink(p: string) {
+      if (p in links) return links[p] as string;
+      throw Object.assign(new Error('EINVAL'), { code: 'EINVAL' });
+    },
+  };
+}
+
+const noMount = () => false;
+
+describe('symlink-resolver.realpath', () => {
+  it('follows a tail symlink to its target', async () => {
+    const lfs = fakeLfs({ '/link.txt': '/real.txt' }, new Set(['/real.txt']));
+    expect(await realpath(lfs, noMount, '/link.txt')).toBe('/real.txt');
+  });
+
+  it('resolves a relative symlink target against the link directory', async () => {
+    const lfs = fakeLfs({ '/dir/link': 'target.txt' }, new Set(['/dir/target.txt']));
+    expect(await realpath(lfs, noMount, '/dir/link')).toBe('/dir/target.txt');
+  });
+
+  it('resolves an intermediate directory-component symlink', async () => {
+    const lfs = fakeLfs({ '/alias': '/real' }, new Set(['/real/file.txt']));
+    expect(await realpath(lfs, noMount, '/alias/file.txt')).toBe('/real/file.txt');
+  });
+
+  it('tolerates ENOENT on the tail component (returns canonical path)', async () => {
+    const lfs = fakeLfs({}, new Set());
+    expect(await realpath(lfs, noMount, '/missing.txt')).toBe('/missing.txt');
+  });
+
+  it('throws ELOOP past the hop cap', async () => {
+    const lfs = fakeLfs({ '/a': '/b', '/b': '/a' }, new Set());
+    await expect(realpath(lfs, noMount, '/a')).rejects.toMatchObject({ code: 'ELOOP' });
+  });
+
+  it('returns mount paths unchanged (already real)', async () => {
+    const lfs = fakeLfs({}, new Set());
+    expect(await realpath(lfs, () => true, '/mnt/repo/pack')).toBe('/mnt/repo/pack');
+  });
+
+  it('has a documented hop cap of 10', () => {
+    expect(MAX_SYMLINK_DEPTH).toBe(10);
+  });
+});
+
+describe('symlink-resolver.resolveSymlinks', () => {
+  it('returns mount paths unchanged without touching the backend', async () => {
+    const lfs = fakeLfs({}, new Set());
+    expect(await resolveSymlinks(lfs, () => true, '/mnt/x/y')).toBe('/mnt/x/y');
+  });
+
+  it('resolves symlinks for non-mount paths', async () => {
+    const lfs = fakeLfs({ '/link': '/real' }, new Set(['/real']));
+    expect(await resolveSymlinks(lfs, noMount, '/link')).toBe('/real');
+  });
+});

--- a/packages/webapp/tests/fs/virtual-fs-backend.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs-backend.test.ts
@@ -1,5 +1,6 @@
 import 'fake-indexeddb/auto';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { convertError } from '../../src/fs/error-rebrand.js';
 import { FsError, type FsErrorCode } from '../../src/fs/types.js';
 import { resolveVfsBackendFromEnv, VirtualFS } from '../../src/fs/virtual-fs.js';
 
@@ -55,21 +56,10 @@ describe('VirtualFS — backend resolution', () => {
 });
 
 describe('VirtualFS — ZenFS ErrnoError → FsError mapping', () => {
-  let vfs: VirtualFS;
-  beforeEach(async () => {
-    vfs = await VirtualFS.create({ dbName: 'test-vfs-errno', wipe: true });
-  });
-  afterEach(async () => {
-    await vfs.dispose();
-  });
-
   function mapErr(code: string): FsError {
     const e = new Error(`${code}: synthetic`) as Error & { code: string };
     e.code = code;
-    return (vfs as unknown as { convertError(err: unknown, path: string): FsError }).convertError(
-      e,
-      '/probe'
-    );
+    return convertError(e, '/probe');
   }
 
   const cases: FsErrorCode[] = [
@@ -97,17 +87,12 @@ describe('VirtualFS — ZenFS ErrnoError → FsError mapping', () => {
   }
 
   it('falls back to message substring matching when no .code is set', () => {
-    const e = new Error('weird ENOENT-ish thing');
-    const fe = (
-      vfs as unknown as { convertError(err: unknown, path: string): FsError }
-    ).convertError(e, '/probe');
+    const fe = convertError(new Error('weird ENOENT-ish thing'), '/probe');
     expect(fe.code).toBe('ENOENT');
   });
 
   it('returns EINVAL for an unknown error shape', () => {
-    const fe = (
-      vfs as unknown as { convertError(err: unknown, path: string): FsError }
-    ).convertError(new Error('totally unknown'), '/probe');
+    const fe = convertError(new Error('totally unknown'), '/probe');
     expect(fe.code).toBe('EINVAL');
   });
 });

--- a/packages/webapp/tests/fs/walker.test.ts
+++ b/packages/webapp/tests/fs/walker.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import type { DirEntry, Stats } from '../../src/fs/types.js';
+import {
+  canUseWalkFastPath,
+  MAX_WALK_DEPTH,
+  type WalkDeps,
+  type WalkIndexView,
+  type WalkMountView,
+  walk,
+} from '../../src/fs/walker.js';
+
+function entry(name: string, type: DirEntry['type']): DirEntry {
+  return { name, type };
+}
+
+function statOf(type: Stats['type']): Stats {
+  return { type, size: 0, mtime: 0, ctime: 0 };
+}
+
+async function collect(gen: AsyncGenerator<string>): Promise<string[]> {
+  const out: string[] = [];
+  for await (const v of gen) out.push(v);
+  return out;
+}
+
+const emptyIndex: WalkIndexView & { getFiles(p: string): string[] | undefined } = {
+  isReady: () => false,
+  getFiles: () => undefined,
+};
+
+describe('canUseWalkFastPath', () => {
+  it('is false when the path is not a mount', () => {
+    const mounts: WalkMountView = new Map<string, unknown>() as unknown as WalkMountView;
+    expect(canUseWalkFastPath(mounts, { isReady: () => true }, '/x')).toBe(false);
+  });
+
+  it('is true for a ready indexed mount with no nested mounts', () => {
+    const mounts = new Map<string, unknown>([['/mnt', {}]]) as unknown as WalkMountView;
+    expect(canUseWalkFastPath(mounts, { isReady: () => true }, '/mnt')).toBe(true);
+  });
+
+  it('is false when a nested mount exists under the path', () => {
+    const mounts = new Map<string, unknown>([
+      ['/mnt', {}],
+      ['/mnt/inner', {}],
+    ]) as unknown as WalkMountView;
+    expect(canUseWalkFastPath(mounts, { isReady: () => true }, '/mnt')).toBe(false);
+  });
+
+  it('is false when the index is not ready', () => {
+    const mounts = new Map<string, unknown>([['/mnt', {}]]) as unknown as WalkMountView;
+    expect(canUseWalkFastPath(mounts, { isReady: () => false }, '/mnt')).toBe(false);
+  });
+});
+
+describe('walk', () => {
+  it('uses the index fast path when available', async () => {
+    const deps: WalkDeps = {
+      mountPoints: new Map<string, unknown>([['/mnt', {}]]) as unknown as WalkMountView,
+      mountIndex: { isReady: () => true, getFiles: () => ['/mnt/a', '/mnt/b'] },
+      realpath: async (p) => p,
+      readDir: async () => [],
+      stat: async () => statOf('file'),
+    };
+    expect(await collect(walk(deps, '/mnt'))).toEqual(['/mnt/a', '/mnt/b']);
+  });
+
+  it('recurses the slow path over a small tree', async () => {
+    const tree: Record<string, DirEntry[]> = {
+      '/root': [entry('dir', 'directory'), entry('f.txt', 'file')],
+      '/root/dir': [entry('g.txt', 'file')],
+    };
+    const deps: WalkDeps = {
+      mountPoints: new Map<string, unknown>() as unknown as WalkMountView,
+      mountIndex: emptyIndex,
+      realpath: async (p) => p,
+      readDir: async (p) => tree[p] ?? [],
+      stat: async () => statOf('file'),
+    };
+    expect((await collect(walk(deps, '/root'))).sort()).toEqual(['/root/dir/g.txt', '/root/f.txt']);
+  });
+
+  it('follows a symlink entry that points at a file', async () => {
+    const deps: WalkDeps = {
+      mountPoints: new Map<string, unknown>() as unknown as WalkMountView,
+      mountIndex: emptyIndex,
+      realpath: async (p) => p,
+      readDir: async (p) => (p === '/root' ? [entry('link', 'symlink')] : []),
+      stat: async () => statOf('file'),
+    };
+    expect(await collect(walk(deps, '/root'))).toEqual(['/root/link']);
+  });
+
+  it('recurses into a symlink that resolves to a directory', async () => {
+    const deps: WalkDeps = {
+      mountPoints: new Map<string, unknown>() as unknown as WalkMountView,
+      mountIndex: emptyIndex,
+      realpath: async (p) => p,
+      readDir: async (p) => {
+        if (p === '/root') return [entry('dirlink', 'symlink')];
+        if (p === '/root/dirlink') return [entry('child.txt', 'file')];
+        return [];
+      },
+      stat: async () => statOf('directory'),
+    };
+    expect(await collect(walk(deps, '/root'))).toEqual(['/root/dirlink/child.txt']);
+  });
+
+  it('skips a dangling symlink whose target cannot be stat-ed', async () => {
+    const deps: WalkDeps = {
+      mountPoints: new Map<string, unknown>() as unknown as WalkMountView,
+      mountIndex: emptyIndex,
+      realpath: async (p) => p,
+      readDir: async (p) => (p === '/root' ? [entry('dead', 'symlink')] : []),
+      stat: async () => {
+        throw new Error('ENOENT');
+      },
+    };
+    expect(await collect(walk(deps, '/root'))).toEqual([]);
+  });
+
+  it('terminates on a self-referential tree via the depth bound', async () => {
+    // Every directory re-exposes a same-shaped child; realpath keeps paths
+    // distinct so the visited-set can't collapse it — only the depth cap stops it.
+    const deps: WalkDeps = {
+      mountPoints: new Map<string, unknown>() as unknown as WalkMountView,
+      mountIndex: emptyIndex,
+      realpath: async (p) => p,
+      readDir: async () => [entry('loop', 'directory')],
+      stat: async () => statOf('directory'),
+    };
+    const out = await collect(walk(deps, '/root'));
+    expect(out).toEqual([]); // no files, and it returns rather than looping
+    expect(MAX_WALK_DEPTH).toBe(64);
+  });
+});


### PR DESCRIPTION
Closes #1572 (subset).

Extracts three concept-cohesive blocks out of the 2,165-line `VirtualFS` class into sibling modules under `packages/webapp/src/fs/`, with **no public API change**. `VirtualFS` stays the sole entry point (99 importers); extracted logic becomes deps-injected module functions with thin delegates.

This is **subset B** of the issue's proposal — the cleanest, lowest-risk boundaries. The higher-risk `mount-registry` / `backend-init` / `sync-fast-path` splits are deliberately **deferred** (re-evaluate after this lands). This keeps the change small and reviewable, addressing the Backlog Dispatcher's concern that the full 8-way split was too large.

## What moved

| New module | Extracted |
| --- | --- |
| `fs/error-rebrand.ts` | `convertError`, `rebrandFsError` (pure functions) |
| `fs/symlink-resolver.ts` | `realpath`, `resolveSymlinks` + component-walk helpers + `MAX_SYMLINK_DEPTH` (deps: `{ lfs, findMount }`) |
| `fs/walker.ts` | `walk`/`walkEntry`/`walkSymlink` generators + `canUseWalkFastPath` + `MAX_WALK_*` (deps: `WalkDeps`) |

`virtual-fs.ts`: **2,165 → 1,927 lines**.

## Commits

9 small idempotent commits — each independently compiles, passes both knip gates, and keeps tests green (add+wire together to avoid unused-export intermediate states):

- `refactor(fs): extract convertError into error-rebrand.ts`
- `refactor(fs): extract rebrandFsError into error-rebrand.ts`
- `test(fs): add error-rebrand unit tests`
- `refactor(fs): extract symlink leaf helpers into symlink-resolver.ts`
- `refactor(fs): extract realpath + resolveSymlinks into symlink-resolver.ts`
- `test(fs): mirror symlink-resolver unit tests`
- `refactor(fs): extract walk leaf helpers into walker.ts`
- `refactor(fs): extract walk generators into walker.ts`
- `test(fs): mirror walker unit tests`

## Behavior preservation

No `VirtualFS` method signature changed. Existing API-level tests (`virtual-fs*`, symlink, `virtual-fs-walk-cycle`) stay green with zero edits in every `refactor` commit and act as the behavior guard. 28 new co-located unit tests added across the three modules (FS suite 483 → 513).

## Verification

`lint:ci` · `typecheck` · touched-file complexity gate (0 files on debt list) · `test:coverage:webapp` · webapp `build` — all pass.

## Notes / deferred follow-ups (Minor)

- Duplicate `FsStatsLike` interface (pre-existing in `virtual-fs.ts` + new in `symlink-resolver.ts`) — candidate to unify into `fs/types.ts` later.
- `mount-registry` / `backend-init` / `sync-fast-path` extractions remain for a future PR.
