### PR TITLE
test(webapp): cover shell commands and playwright handlers

### DIFF
--- a/packages/webapp/tests/shell/helpers/esbuild-mock-ctx.ts
+++ b/packages/webapp/tests/shell/helpers/esbuild-mock-ctx.ts
@@ -1,0 +1,39 @@
+import type { CommandContext, IFileSystem } from 'just-bash';
+import { vi } from 'vitest';
+
+/**
+ * File-store-backed {@link CommandContext} for esbuild command tests. Reads and
+ * writes go through an in-memory map so bundle/transform paths resolve VFS
+ * files without a real filesystem. Shared by the mocked-loader unit suite and
+ * the opt-in live-wasm suite so the ctx shape stays identical across both.
+ */
+export function createEsbuildMockCtx(
+  overrides: Partial<{ fs: Partial<IFileSystem>; cwd: string; stdin: string }> = {}
+): CommandContext {
+  const fileStore = new Map<string, string>();
+  const fs: Partial<IFileSystem> = {
+    resolvePath: (base: string, path: string) =>
+      path.startsWith('/') ? path : `${base.replace(/\/$/, '')}/${path}`,
+    exists: vi.fn().mockImplementation(async (p: string) => fileStore.has(p)),
+    readFile: vi.fn().mockImplementation(async (p: string) => {
+      const v = fileStore.get(p);
+      if (v === undefined) throw new Error(`ENOENT: ${p}`);
+      return v;
+    }),
+    writeFile: vi.fn().mockImplementation(async (p: string, content: string | Uint8Array) => {
+      fileStore.set(p, typeof content === 'string' ? content : new TextDecoder().decode(content));
+    }),
+    stat: vi.fn().mockImplementation(async (p: string) => {
+      if (!fileStore.has(p)) throw new Error(`ENOENT: ${p}`);
+      return { isFile: true, isDirectory: false, size: fileStore.get(p)!.length };
+    }),
+    readFileBuffer: vi.fn().mockImplementation(async () => new Uint8Array()),
+    ...overrides.fs,
+  };
+  return {
+    fs: fs as IFileSystem,
+    cwd: overrides.cwd ?? '/workspace',
+    env: new Map<string, string>(),
+    stdin: overrides.stdin ?? '',
+  } as unknown as CommandContext;
+}

--- a/packages/webapp/tests/shell/helpers/playwright-harness.ts
+++ b/packages/webapp/tests/shell/helpers/playwright-harness.ts
@@ -7,7 +7,7 @@ import type {
   PlaywrightState,
 } from '../../../src/shell/supplemental-commands/playwright/types.js';
 
-type EventListener = (params: Record<string, unknown>) => void;
+type EventListener = (params: Record<string, unknown>) => unknown;
 
 /** Fresh, empty {@link PlaywrightState} for handler tests. */
 export function createPlaywrightState(): PlaywrightState {
@@ -31,8 +31,12 @@ export function createPlaywrightState(): PlaywrightState {
 export interface MockTransport {
   transport: CDPTransport;
   send: ReturnType<typeof vi.fn>;
-  /** Fire a CDP event to every registered listener. */
-  emit: (event: string, params: Record<string, unknown>) => void;
+  /**
+   * Fire a CDP event to every registered listener and await async handlers, so
+   * a handler that issues follow-up `transport.send` calls has settled before
+   * the returned promise resolves (no timer flushing needed).
+   */
+  emit: (event: string, params: Record<string, unknown>) => Promise<void>;
   /** True once a listener for `event` is registered. */
   hasListener: (event: string) => boolean;
 }
@@ -62,8 +66,8 @@ export function createMockTransport(
   return {
     transport,
     send,
-    emit: (event, params) => {
-      for (const cb of listeners.get(event) ?? []) cb(params);
+    emit: async (event, params) => {
+      await Promise.all([...(listeners.get(event) ?? [])].map((cb) => cb(params)));
     },
     hasListener: (event) => (listeners.get(event)?.size ?? 0) > 0,
   };

--- a/packages/webapp/tests/shell/helpers/playwright-harness.ts
+++ b/packages/webapp/tests/shell/helpers/playwright-harness.ts
@@ -1,0 +1,117 @@
+import { vi } from 'vitest';
+import type { BrowserAPI } from '../../../src/cdp/index.js';
+import type { CDPTransport } from '../../../src/cdp/transport.js';
+import type { VirtualFS } from '../../../src/fs/index.js';
+import type {
+  PlaywrightHandlerCtx,
+  PlaywrightState,
+} from '../../../src/shell/supplemental-commands/playwright/types.js';
+
+type EventListener = (params: Record<string, unknown>) => void;
+
+/** Fresh, empty {@link PlaywrightState} for handler tests. */
+export function createPlaywrightState(): PlaywrightState {
+  return {
+    snapshots: new Map(),
+    appTabId: null,
+    harRecorder: null,
+    sessionDirsCreated: false,
+    teleportWatchers: new Map(),
+    consoleMessages: new Map(),
+    consoleCleanup: new Map(),
+    networkRequests: new Map(),
+    networkRequestIndex: new Map(),
+    networkCleanup: new Map(),
+    routes: new Map(),
+    routeCleanup: new Map(),
+    lastMousePosition: new Map(),
+  };
+}
+
+export interface MockTransport {
+  transport: CDPTransport;
+  send: ReturnType<typeof vi.fn>;
+  /** Fire a CDP event to every registered listener. */
+  emit: (event: string, params: Record<string, unknown>) => void;
+  /** True once a listener for `event` is registered. */
+  hasListener: (event: string) => boolean;
+}
+
+/**
+ * Build a mock {@link CDPTransport} whose `on`/`off` track listeners and whose
+ * `send` is a spy. `emit` drives captured events into the registered handlers.
+ */
+export function createMockTransport(
+  sendImpl?: (method: string, params?: Record<string, unknown>) => unknown
+): MockTransport {
+  const listeners = new Map<string, Set<EventListener>>();
+  const send = vi.fn(
+    async (method: string, params?: Record<string, unknown>) =>
+      (sendImpl?.(method, params) as Record<string, unknown> | undefined) ?? {}
+  );
+  const transport = {
+    send,
+    on: (event: string, cb: EventListener) => {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(cb);
+    },
+    off: (event: string, cb: EventListener) => {
+      listeners.get(event)?.delete(cb);
+    },
+  } as unknown as CDPTransport;
+  return {
+    transport,
+    send,
+    emit: (event, params) => {
+      for (const cb of listeners.get(event) ?? []) cb(params);
+    },
+    hasListener: (event) => (listeners.get(event)?.size ?? 0) > 0,
+  };
+}
+
+export interface MockBrowser {
+  browser: BrowserAPI;
+  transport: MockTransport;
+  sendCDP: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Build a mock {@link BrowserAPI}. `withTab` invokes its callback with
+ * `sessionId`; `getTransport` returns the shared mock transport; `sendCDP`
+ * is a spy backed by `sendCdpImpl`.
+ */
+export function createMockBrowser(opts?: {
+  sessionId?: string;
+  transport?: MockTransport;
+  sendCdpImpl?: (method: string, params?: Record<string, unknown>) => unknown;
+}): MockBrowser {
+  const transport = opts?.transport ?? createMockTransport();
+  const sessionId = opts?.sessionId ?? 'session-1';
+  const sendCDP = vi.fn(
+    async (method: string, params?: Record<string, unknown>) =>
+      (opts?.sendCdpImpl?.(method, params) as Record<string, unknown> | undefined) ?? {}
+  );
+  const browser = {
+    withTab: async <T>(_targetId: string, fn: (sessionId: string) => Promise<T>) => fn(sessionId),
+    getTransport: () => transport.transport,
+    sendCDP,
+  } as unknown as BrowserAPI;
+  return { browser, transport, sendCDP };
+}
+
+/** Assemble a {@link PlaywrightHandlerCtx} from the mock pieces. */
+export function createHandlerCtx(opts?: {
+  browser?: BrowserAPI;
+  fs?: Partial<VirtualFS>;
+  state?: PlaywrightState;
+  positional?: string[];
+  flags?: Record<string, string>;
+}): PlaywrightHandlerCtx {
+  return {
+    browser: opts?.browser ?? createMockBrowser().browser,
+    fs: (opts?.fs ?? {}) as VirtualFS,
+    state: opts?.state ?? createPlaywrightState(),
+    positional: opts?.positional ?? [],
+    flags: opts?.flags ?? {},
+  };
+}

--- a/packages/webapp/tests/shell/supplemental-commands/esbuild-command.live.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/esbuild-command.live.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { createEsbuildCommand } from '../../../src/shell/supplemental-commands/esbuild-command.js';
+import { resetEsbuildForTests } from '../../../src/shell/supplemental-commands/esbuild-wasm.js';
+import { createEsbuildMockCtx as createMockCtx } from '../helpers/esbuild-mock-ctx.js';
+
+/**
+ * Opt-in integration tests that boot the real esbuild-wasm loader. Kept in a
+ * dedicated file with NO `vi.mock` so the mocked unit suite
+ * (esbuild-command.test.ts) can't intercept `getEsbuild`. Gated behind
+ * SLICC_TEST_HEAVY_WASM=1 because the wasm subprocess is slow.
+ */
+const describeHeavy = process.env.SLICC_TEST_HEAVY_WASM === '1' ? describe : describe.skip;
+
+describeHeavy('esbuild command live wasm', () => {
+  it('reports --version through the loaded module', async () => {
+    resetEsbuildForTests();
+    const cmd = createEsbuildCommand();
+    const ctx = createMockCtx();
+    const result = await cmd.execute(['--version'], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('runs a single-file --transform from a VFS file', async () => {
+    resetEsbuildForTests();
+    const cmd = createEsbuildCommand();
+    const ctx = createMockCtx();
+    await ctx.fs.writeFile('/workspace/a.ts', 'const x: number = 1; export default x;');
+    const result = await cmd.execute(['/workspace/a.ts', '--format', 'cjs'], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/const x = 1/);
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/esbuild-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/esbuild-command.test.ts
@@ -1,5 +1,5 @@
 import type { IFileSystem } from 'just-bash';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createEsbuildCommand,
   createIpkContextFromCtx,
@@ -8,6 +8,30 @@ import {
   parseEsbuildArgs,
 } from '../../../src/shell/supplemental-commands/esbuild-command.js';
 import { resetEsbuildForTests } from '../../../src/shell/supplemental-commands/esbuild-wasm.js';
+
+// Mock the wasm loader so command-execute paths run deterministically without
+// booting a real esbuild wasm subprocess (the live paths stay behind
+// SLICC_TEST_HEAVY_WASM below).
+const esb = vi.hoisted(() => ({
+  loadError: null as Error | null,
+  version: '0.25.0',
+  transform: vi.fn(),
+  build: vi.fn(),
+}));
+
+vi.mock('../../../src/shell/supplemental-commands/esbuild-wasm.js', () => ({
+  resetEsbuildForTests: () => {},
+  getEsbuild: async () => {
+    if (esb.loadError) throw esb.loadError;
+    return {
+      version: esb.version,
+      transform: esb.transform,
+      build: esb.build,
+      formatMessages: async (msgs: { text: string }[], opts: { kind: 'error' | 'warning' }) =>
+        msgs.map((m) => `[${opts.kind}] ${m.text}\n`),
+    };
+  },
+}));
 
 /**
  * Heavy esbuild paths boot a real wasm subprocess (in Node) or the
@@ -177,6 +201,199 @@ describe('createVfsPlugin bare specifier resolution', () => {
   });
 });
 
+describe('createEsbuildCommand (mocked wasm loader)', () => {
+  beforeEach(() => {
+    esb.loadError = null;
+    esb.version = '0.25.0';
+    esb.transform.mockReset();
+    esb.build.mockReset();
+  });
+
+  it('prints help for --help', async () => {
+    const result = await createEsbuildCommand().execute(['--help'], createMockCtx());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('esbuild - thin wrapper');
+  });
+
+  it('prints help when no args and no stdin', async () => {
+    const result = await createEsbuildCommand().execute([], createMockCtx());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('esbuild - thin wrapper');
+  });
+
+  it('returns exit 2 on an argument parse error', async () => {
+    const result = await createEsbuildCommand().execute(['--frobnicate', 'a.js'], createMockCtx());
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('unknown option');
+  });
+
+  it('rejects multiple entries without --bundle', async () => {
+    const result = await createEsbuildCommand().execute(['a.js', 'b.js'], createMockCtx());
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('multiple entry points require --bundle');
+  });
+
+  it('surfaces the loader guidance error verbatim', async () => {
+    esb.loadError = new Error('run `ipk add esbuild-wasm`');
+    const result = await createEsbuildCommand().execute(['--version'], createMockCtx());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('esbuild: run `ipk add esbuild-wasm`\n');
+  });
+
+  it('reports the module version', async () => {
+    esb.version = '1.2.3';
+    const result = await createEsbuildCommand().execute(['--version'], createMockCtx());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('1.2.3\n');
+  });
+
+  describe('transform mode', () => {
+    it('transforms a VFS file to stdout', async () => {
+      esb.transform.mockResolvedValue({ code: 'OUT;', warnings: [] });
+      const ctx = createMockCtx();
+      await ctx.fs.writeFile('/workspace/a.ts', 'const x=1;');
+      const result = await createEsbuildCommand().execute(['a.ts'], ctx);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('OUT;');
+    });
+
+    it('errors when the transform entry does not exist', async () => {
+      const result = await createEsbuildCommand().execute(['missing.ts'], createMockCtx());
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('missing.ts: no such file');
+    });
+
+    it('transforms stdin when no entry is given', async () => {
+      esb.transform.mockResolvedValue({ code: 'FROM_STDIN;', warnings: [] });
+      const result = await createEsbuildCommand().execute(
+        ['--loader=ts'],
+        createMockCtx({ stdin: 'const y=2;' })
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('FROM_STDIN;');
+    });
+
+    it('renders transform warnings to stderr', async () => {
+      esb.transform.mockResolvedValue({ code: 'OUT;', warnings: [{ text: 'careful' }] });
+      const ctx = createMockCtx();
+      await ctx.fs.writeFile('/workspace/a.ts', 'x');
+      const result = await createEsbuildCommand().execute(['a.ts'], ctx);
+      expect(result.stderr).toContain('[warning] careful');
+    });
+
+    it('writes --outfile and a separate .map for external sourcemaps', async () => {
+      esb.transform.mockResolvedValue({ code: 'OUT;', warnings: [], map: 'MAP' });
+      const ctx = createMockCtx();
+      await ctx.fs.writeFile('/workspace/a.ts', 'x');
+      const result = await createEsbuildCommand().execute(
+        ['a.ts', '--sourcemap=external', '--outfile', 'out.js'],
+        ctx
+      );
+      expect(result.exitCode).toBe(0);
+      expect(await ctx.fs.readFile('/workspace/out.js')).toBe('OUT;');
+      expect(await ctx.fs.readFile('/workspace/out.js.map')).toBe('MAP');
+    });
+
+    it('renders a structured transform failure', async () => {
+      esb.transform.mockRejectedValue({ errors: [{ text: 'boom' }], warnings: [] });
+      const ctx = createMockCtx();
+      await ctx.fs.writeFile('/workspace/a.ts', 'x');
+      const result = await createEsbuildCommand().execute(['a.ts'], ctx);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('[error] boom');
+    });
+
+    it('renders a plain transform failure', async () => {
+      esb.transform.mockRejectedValue(new Error('kaput'));
+      const ctx = createMockCtx();
+      await ctx.fs.writeFile('/workspace/a.ts', 'x');
+      const result = await createEsbuildCommand().execute(['a.ts'], ctx);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toBe('esbuild: kaput\n');
+    });
+  });
+
+  describe('bundle mode', () => {
+    it('requires at least one entry point', async () => {
+      const result = await createEsbuildCommand().execute(['--bundle'], createMockCtx());
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('--bundle requires at least one entry point');
+    });
+
+    it('errors when a bundle entry does not exist', async () => {
+      const result = await createEsbuildCommand().execute(
+        ['--bundle', 'missing.ts'],
+        createMockCtx()
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('no such file');
+    });
+
+    it('bundles to stdout', async () => {
+      esb.build.mockResolvedValue({
+        errors: [],
+        warnings: [],
+        outputFiles: [{ path: '/out.js', text: 'BUNDLED;' }],
+      });
+      const ctx = createMockCtx();
+      await ctx.fs.writeFile('/workspace/entry.ts', 'x');
+      const result = await createEsbuildCommand().execute(['--bundle', 'entry.ts'], ctx);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('BUNDLED;');
+    });
+
+    it('writes --outfile plus extra output files', async () => {
+      esb.build.mockResolvedValue({
+        errors: [],
+        warnings: [],
+        outputFiles: [
+          { path: '/out.js', text: 'MAIN;' },
+          { path: '/out.js.map', text: 'MAP' },
+        ],
+      });
+      const ctx = createMockCtx();
+      await ctx.fs.writeFile('/workspace/entry.ts', 'x');
+      const result = await createEsbuildCommand().execute(
+        ['--bundle', 'entry.ts', '--outfile', 'dist/out.js'],
+        ctx
+      );
+      expect(result.exitCode).toBe(0);
+      expect(await ctx.fs.readFile('/workspace/dist/out.js')).toBe('MAIN;');
+      expect(await ctx.fs.readFile('/workspace/dist/out.js.map')).toBe('MAP');
+    });
+
+    it('reports when a build produces no output for --outfile', async () => {
+      esb.build.mockResolvedValue({ errors: [], warnings: [], outputFiles: [] });
+      const ctx = createMockCtx();
+      await ctx.fs.writeFile('/workspace/entry.ts', 'x');
+      const result = await createEsbuildCommand().execute(
+        ['--bundle', 'entry.ts', '--outfile', 'out.js'],
+        ctx
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('build produced no output');
+    });
+
+    it('renders a structured bundle failure', async () => {
+      esb.build.mockRejectedValue({ errors: [{ text: 'unresolved' }], warnings: [] });
+      const ctx = createMockCtx();
+      await ctx.fs.writeFile('/workspace/entry.ts', 'x');
+      const result = await createEsbuildCommand().execute(['--bundle', 'entry.ts'], ctx);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('[error] unresolved');
+    });
+
+    it('renders a plain bundle failure', async () => {
+      esb.build.mockRejectedValue(new Error('bundle boom'));
+      const ctx = createMockCtx();
+      await ctx.fs.writeFile('/workspace/entry.ts', 'x');
+      const result = await createEsbuildCommand().execute(['--bundle', 'entry.ts'], ctx);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toBe('esbuild: bundle boom\n');
+    });
+  });
+});
+
 describeHeavy('esbuild command live wasm', () => {
   it('reports --version through the loaded module', async () => {
     resetEsbuildForTests();
@@ -195,5 +412,89 @@ describeHeavy('esbuild command live wasm', () => {
     const result = await cmd.execute(['/workspace/a.ts', '--format', 'cjs'], ctx);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toMatch(/const x = 1/);
+  });
+});
+
+describe('createVfsPlugin VFS resolution + load', () => {
+  type ResolveCb = (a: { path: string; importer?: string; namespace?: string }) => Promise<{
+    path?: string;
+    external?: boolean;
+    errors?: { text: string }[];
+  }>;
+  type LoadCb = (a: {
+    path: string;
+    namespace?: string;
+  }) => Promise<{ contents: string; loader: string; resolveDir: string } | null>;
+
+  // The default mock resolvePath is naive; normalize `.`/`..` so relative
+  // imports resolve to real fileStore keys the way the production fs does.
+  const normalize = (base: string, p: string) => {
+    const start = p.startsWith('/') ? p : `${base.replace(/\/$/, '')}/${p}`;
+    const parts: string[] = [];
+    for (const seg of start.split('/')) {
+      if (seg === '' || seg === '.') continue;
+      if (seg === '..') parts.pop();
+      else parts.push(seg);
+    }
+    return `/${parts.join('/')}`;
+  };
+  const pluginCtx = () => createMockCtx({ fs: { resolvePath: normalize } });
+
+  function wirePlugin(ctx: ReturnType<typeof createMockCtx>) {
+    const ipk = createIpkContextFromCtx(ctx);
+    const plugin = createVfsPlugin(ctx.fs, ctx.cwd, ipk);
+    let resolveCb: ResolveCb | null = null;
+    let loadCb: LoadCb | null = null;
+    const build = {
+      onResolve(_f: { filter: RegExp }, cb: ResolveCb) {
+        resolveCb = cb;
+      },
+      onLoad(_f: { filter: RegExp }, cb: LoadCb) {
+        loadCb = cb;
+      },
+    };
+    plugin.setup(build as unknown as Parameters<typeof plugin.setup>[0]);
+    if (!resolveCb || !loadCb) throw new Error('plugin callbacks not registered');
+    return { resolveCb: resolveCb as ResolveCb, loadCb: loadCb as LoadCb };
+  }
+
+  it('resolves a relative import by appending a known extension', async () => {
+    const ctx = pluginCtx();
+    await ctx.fs.writeFile('/workspace/mod.ts', 'export default 1;');
+    const { resolveCb } = wirePlugin(ctx);
+    const res = await resolveCb({ path: './mod', importer: '/workspace/entry.ts' });
+    expect(res.path).toBe('/workspace/mod.ts');
+  });
+
+  it('resolves a directory import to its index file', async () => {
+    const ctx = pluginCtx();
+    await ctx.fs.writeFile('/workspace/dir/index.ts', 'export default 1;');
+    const { resolveCb } = wirePlugin(ctx);
+    const res = await resolveCb({ path: './dir', importer: '/workspace/entry.ts' });
+    expect(res.path).toBe('/workspace/dir/index.ts');
+  });
+
+  it('returns the bare candidate when nothing resolves', async () => {
+    const ctx = pluginCtx();
+    const { resolveCb } = wirePlugin(ctx);
+    const res = await resolveCb({ path: './nope', importer: '/workspace/entry.ts' });
+    expect(res.path).toBe('/workspace/nope');
+  });
+
+  it('loads file contents with the inferred loader', async () => {
+    const ctx = pluginCtx();
+    await ctx.fs.writeFile('/workspace/mod.tsx', 'export const A = 1;');
+    const { loadCb } = wirePlugin(ctx);
+    const res = await loadCb({ path: '/workspace/mod.tsx', namespace: 'file' });
+    expect(res?.contents).toBe('export const A = 1;');
+    expect(res?.loader).toBe('tsx');
+    expect(res?.resolveDir).toBe('/workspace');
+  });
+
+  it('skips load for non-file namespaces', async () => {
+    const ctx = pluginCtx();
+    const { loadCb } = wirePlugin(ctx);
+    const res = await loadCb({ path: 'react', namespace: 'ipk' });
+    expect(res).toBeNull();
   });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/esbuild-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/esbuild-command.test.ts
@@ -1,4 +1,3 @@
-import type { IFileSystem } from 'just-bash';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createEsbuildCommand,
@@ -7,11 +6,12 @@ import {
   inferLoader,
   parseEsbuildArgs,
 } from '../../../src/shell/supplemental-commands/esbuild-command.js';
-import { resetEsbuildForTests } from '../../../src/shell/supplemental-commands/esbuild-wasm.js';
+import { createEsbuildMockCtx as createMockCtx } from '../helpers/esbuild-mock-ctx.js';
 
 // Mock the wasm loader so command-execute paths run deterministically without
-// booting a real esbuild wasm subprocess (the live paths stay behind
-// SLICC_TEST_HEAVY_WASM below).
+// booting a real esbuild wasm subprocess. The mock is file-scoped; the opt-in
+// live-wasm suite lives in esbuild-command.live.test.ts so it keeps exercising
+// the real loader.
 const esb = vi.hoisted(() => ({
   loadError: null as Error | null,
   version: '0.25.0',
@@ -32,51 +32,6 @@ vi.mock('../../../src/shell/supplemental-commands/esbuild-wasm.js', () => ({
     };
   },
 }));
-
-/**
- * Heavy esbuild paths boot a real wasm subprocess (in Node) or the
- * in-realm wasm service; gate them behind SLICC_TEST_HEAVY_WASM=1
- * matching the prior `esbuild-command.test.ts` shape so logic tests
- * always run and live build/transform stays opt-in.
- */
-const heavyWasm = process.env.SLICC_TEST_HEAVY_WASM === '1';
-const describeHeavy = heavyWasm ? describe : describe.skip;
-
-function createMockCtx(
-  overrides: Partial<{ fs: Partial<IFileSystem>; cwd: string; stdin: string }> = {}
-): Parameters<ReturnType<typeof createEsbuildCommand>['execute']>[1] {
-  const fileStore = new Map<string, string>();
-  const fs: Partial<IFileSystem> = {
-    resolvePath: (base: string, path: string) =>
-      path.startsWith('/') ? path : `${base.replace(/\/$/, '')}/${path}`,
-    exists: vi.fn().mockImplementation(async (p: string) => fileStore.has(p)),
-    readFile: vi.fn().mockImplementation(async (p: string) => {
-      const v = fileStore.get(p);
-      if (v === undefined) throw new Error(`ENOENT: ${p}`);
-      return v;
-    }),
-    writeFile: vi.fn().mockImplementation(async (p: string, content: string | Uint8Array) => {
-      fileStore.set(p, typeof content === 'string' ? content : new TextDecoder().decode(content));
-    }),
-    stat: vi.fn().mockImplementation(async (p: string) => {
-      if (!fileStore.has(p)) throw new Error(`ENOENT: ${p}`);
-      return { isFile: true, isDirectory: false, size: fileStore.get(p)!.length };
-    }),
-    readFileBuffer: vi.fn().mockImplementation(async () => new Uint8Array()),
-    ...overrides.fs,
-  };
-  return {
-    fs: fs as IFileSystem,
-    cwd: overrides.cwd ?? '/workspace',
-    env: new Map<string, string>(),
-    stdin: overrides.stdin ?? '',
-  } as ReturnType<typeof createMockCtx> & {
-    fs: IFileSystem;
-    cwd: string;
-    env: Map<string, string>;
-    stdin: string;
-  };
-}
 
 describe('parseEsbuildArgs', () => {
   it('collects entry points and toggles --bundle', () => {
@@ -391,27 +346,6 @@ describe('createEsbuildCommand (mocked wasm loader)', () => {
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toBe('esbuild: bundle boom\n');
     });
-  });
-});
-
-describeHeavy('esbuild command live wasm', () => {
-  it('reports --version through the loaded module', async () => {
-    resetEsbuildForTests();
-    const cmd = createEsbuildCommand();
-    const ctx = createMockCtx();
-    const result = await cmd.execute(['--version'], ctx);
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
-  });
-
-  it('runs a single-file --transform from a VFS file', async () => {
-    resetEsbuildForTests();
-    const cmd = createEsbuildCommand();
-    const ctx = createMockCtx();
-    await ctx.fs.writeFile('/workspace/a.ts', 'const x: number = 1; export default x;');
-    const result = await cmd.execute(['/workspace/a.ts', '--format', 'cjs'], ctx);
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toMatch(/const x = 1/);
   });
 });
 

--- a/packages/webapp/tests/shell/supplemental-commands/fswatch-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/fswatch-command.test.ts
@@ -1,0 +1,194 @@
+import type { Command } from 'just-bash';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockCommandContext } from '../helpers/mock-command-context.js';
+
+/**
+ * fswatch maintains a module-level registry of active watchers, so each test
+ * re-imports the command with a fresh module graph to stay isolated.
+ */
+async function freshCommand(): Promise<Command> {
+  vi.resetModules();
+  const mod = await import('../../../src/shell/supplemental-commands/fswatch-command.js');
+  return mod.createFsWatchCommand();
+}
+
+type WatchCallback = (events: Array<{ type: string; path: string }>) => void;
+
+interface MockWatcher {
+  watch: ReturnType<typeof vi.fn>;
+  unsubscribe: ReturnType<typeof vi.fn>;
+  lastFilter?: (path: string) => boolean;
+  fire: (events: Array<{ type: string; path: string }>) => void;
+}
+
+function installWatcher(): MockWatcher {
+  const unsubscribe = vi.fn();
+  let cb: WatchCallback | undefined;
+  const watcher: MockWatcher = {
+    unsubscribe,
+    watch: vi.fn((_base: string, filter: (p: string) => boolean, callback: WatchCallback) => {
+      watcher.lastFilter = filter;
+      cb = callback;
+      return unsubscribe;
+    }),
+    fire: (events) => cb?.(events),
+  };
+  (globalThis as unknown as { __slicc_fs_watcher?: unknown }).__slicc_fs_watcher = watcher;
+  return watcher;
+}
+
+describe('fswatch command', () => {
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>).__slicc_fs_watcher;
+    delete (globalThis as Record<string, unknown>).__slicc_lick_handler;
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).__slicc_fs_watcher;
+    delete (globalThis as Record<string, unknown>).__slicc_lick_handler;
+  });
+
+  it('has correct name', async () => {
+    const cmd = await freshCommand();
+    expect(cmd.name).toBe('fswatch');
+  });
+
+  it('shows help with no subcommand', async () => {
+    const cmd = await freshCommand();
+    const result = await cmd.execute([], mockCommandContext());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('usage: fswatch');
+  });
+
+  it('shows help with --help', async () => {
+    const cmd = await freshCommand();
+    const result = await cmd.execute(['--help'], mockCommandContext());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('usage: fswatch');
+  });
+
+  it('lists nothing when no watchers are active', async () => {
+    const cmd = await freshCommand();
+    const result = await cmd.execute(['list'], mockCommandContext());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('No active file watchers.\n');
+  });
+
+  it('errors on delete without an id', async () => {
+    const cmd = await freshCommand();
+    const result = await cmd.execute(['delete'], mockCommandContext());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('fswatch: delete requires an ID\n');
+  });
+
+  it('errors on delete of an unknown id', async () => {
+    const cmd = await freshCommand();
+    const result = await cmd.execute(['delete', 'fsw-999'], mockCommandContext());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('fswatch: watcher not found: fsw-999\n');
+  });
+
+  it('errors on an unknown subcommand', async () => {
+    const cmd = await freshCommand();
+    const result = await cmd.execute(['bogus'], mockCommandContext());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('fswatch: unknown command: bogus\n');
+  });
+
+  it('errors when create is missing --path or --pattern', async () => {
+    const cmd = await freshCommand();
+    const result = await cmd.execute(['create', '--path', '/workspace'], mockCommandContext());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('fswatch: --path and --pattern are required\n');
+  });
+
+  it('errors when the VFS watcher hook is unavailable', async () => {
+    const cmd = await freshCommand();
+    const result = await cmd.execute(
+      ['create', '--path', '/workspace', '--pattern', '*.md'],
+      mockCommandContext()
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('fswatch: file system watcher not available\n');
+  });
+
+  it('creates a watcher and reports its metadata', async () => {
+    const watcher = installWatcher();
+    const cmd = await freshCommand();
+    const result = await cmd.execute(
+      ['create', '--path', '/workspace', '--pattern', '*.md', '--scoop', 'andy', '--name', 'docs'],
+      mockCommandContext()
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Created file watcher "docs"');
+    expect(result.stdout).toContain('ID:      fsw-1');
+    expect(result.stdout).toContain('Path:    /workspace');
+    expect(result.stdout).toContain('Pattern: *.md');
+    expect(result.stdout).toContain('Scoop:   andy');
+    expect(watcher.watch).toHaveBeenCalledOnce();
+  });
+
+  it('derives a default name from pattern and path when --name is omitted', async () => {
+    installWatcher();
+    const cmd = await freshCommand();
+    const result = await cmd.execute(
+      ['create', '--path', '/workspace', '--pattern', '*.bsh'],
+      mockCommandContext()
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Created file watcher "*.bsh in /workspace"');
+  });
+
+  it('builds a glob filter that matches by filename', async () => {
+    const watcher = installWatcher();
+    const cmd = await freshCommand();
+    await cmd.execute(
+      ['create', '--path', '/workspace', '--pattern', '*.md'],
+      mockCommandContext()
+    );
+    expect(watcher.lastFilter?.('/workspace/notes.md')).toBe(true);
+    expect(watcher.lastFilter?.('/workspace/script.bsh')).toBe(false);
+  });
+
+  it('routes change events to the lick handler with scoop targeting', async () => {
+    const watcher = installWatcher();
+    const lickHandler = vi.fn();
+    (globalThis as Record<string, unknown>).__slicc_lick_handler = lickHandler;
+
+    const cmd = await freshCommand();
+    await cmd.execute(
+      ['create', '--path', '/workspace', '--pattern', '*.md', '--scoop', 'andy'],
+      mockCommandContext()
+    );
+
+    watcher.fire([{ type: 'change', path: '/workspace/notes.md' }]);
+
+    expect(lickHandler).toHaveBeenCalledOnce();
+    const event = lickHandler.mock.calls[0][0];
+    expect(event.type).toBe('fswatch');
+    expect(event.targetScoop).toBe('andy');
+    expect(event.changes).toEqual([{ type: 'change', path: '/workspace/notes.md' }]);
+  });
+
+  it('lists then deletes an active watcher', async () => {
+    const watcher = installWatcher();
+    const cmd = await freshCommand();
+    await cmd.execute(
+      ['create', '--path', '/workspace', '--pattern', '*.md', '--name', 'docs'],
+      mockCommandContext()
+    );
+
+    const listed = await cmd.execute(['list'], mockCommandContext());
+    expect(listed.stdout).toContain('ID: fsw-1');
+    expect(listed.stdout).toContain('Name:    docs');
+
+    const deleted = await cmd.execute(['delete', 'fsw-1'], mockCommandContext());
+    expect(deleted.exitCode).toBe(0);
+    expect(deleted.stdout).toBe('Deleted watcher "docs" (fsw-1)\n');
+    expect(watcher.unsubscribe).toHaveBeenCalledOnce();
+
+    const afterDelete = await cmd.execute(['list'], mockCommandContext());
+    expect(afterDelete.stdout).toBe('No active file watchers.\n');
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/pdftk-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/pdftk-command.test.ts
@@ -1,7 +1,48 @@
 import type { IFileSystem } from 'just-bash';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createPdftkCommand } from '../../../src/shell/supplemental-commands/pdftk-command.js';
 import { mockCommandContext } from '../helpers/mock-command-context.js';
+
+// Shared, per-test-configurable state for the mocked PDF libraries. Lets the
+// operation-body tests below drive page counts, metadata, and extracted text
+// without shipping real PDF fixtures.
+const pdf = vi.hoisted(() => ({
+  pageCount: 3,
+  title: '',
+  author: '',
+  creator: '',
+  producer: '',
+  text: '',
+  addPage: vi.fn(),
+  setRotation: vi.fn(),
+}));
+
+vi.mock('@cantoo/pdf-lib', () => {
+  const makeDoc = () => ({
+    getPageCount: () => pdf.pageCount,
+    getTitle: () => pdf.title || undefined,
+    getAuthor: () => pdf.author || undefined,
+    getCreator: () => pdf.creator || undefined,
+    getProducer: () => pdf.producer || undefined,
+    getPages: () =>
+      Array.from({ length: pdf.pageCount }, () => ({
+        getRotation: () => ({ angle: 0 }),
+        setRotation: pdf.setRotation,
+      })),
+    copyPages: async (_doc: unknown, indices: number[]) =>
+      indices.map(() => ({ setRotation: pdf.setRotation })),
+    addPage: pdf.addPage,
+    save: async () => new Uint8Array([1, 2, 3]),
+  });
+  return {
+    PDFDocument: { load: async () => makeDoc(), create: async () => makeDoc() },
+    degrees: (angle: number) => ({ angle }),
+  };
+});
+
+vi.mock('unpdf', () => ({
+  extractText: async () => ({ text: pdf.text }),
+}));
 
 const createMockCtx = (overrides: Partial<{ fs: Partial<IFileSystem>; cwd: string }> = {}) =>
   mockCommandContext({
@@ -11,6 +52,16 @@ const createMockCtx = (overrides: Partial<{ fs: Partial<IFileSystem>; cwd: strin
       ...overrides.fs,
     },
     cwd: overrides.cwd ?? '/home',
+  });
+
+/** ctx whose reads succeed, so operation bodies (not the read guard) execute. */
+const okCtx = (overrides: Partial<IFileSystem> = {}) =>
+  mockCommandContext({
+    fs: {
+      readFileBuffer: vi.fn().mockResolvedValue(new Uint8Array([0])),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    },
   });
 
 describe('createPdftkCommand', () => {
@@ -211,5 +262,156 @@ describe('pdftk help appears in various positions', () => {
     const result = await cmd.execute(['input.pdf', '--help'], createMockCtx());
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('usage: pdftk');
+  });
+});
+
+describe('pdftk operation bodies (mocked pdf libs)', () => {
+  beforeEach(() => {
+    pdf.pageCount = 3;
+    pdf.title = '';
+    pdf.author = '';
+    pdf.creator = '';
+    pdf.producer = '';
+    pdf.text = '';
+    pdf.addPage.mockClear();
+    pdf.setRotation.mockClear();
+  });
+
+  it('dump_data prints the page count only when no metadata exists', async () => {
+    const result = await createPdftkCommand().execute(['in.pdf', 'dump_data'], okCtx());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('NumberOfPages: 3\n');
+  });
+
+  it('dump_data prints every info block that is present', async () => {
+    pdf.title = 'My Doc';
+    pdf.author = 'Ada';
+    pdf.creator = 'SLICC';
+    pdf.producer = 'pdf-lib';
+    const result = await createPdftkCommand().execute(['in.pdf', 'dump_data'], okCtx());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('InfoKey: Title');
+    expect(result.stdout).toContain('InfoValue: My Doc');
+    expect(result.stdout).toContain('InfoValue: Ada');
+    expect(result.stdout).toContain('InfoValue: SLICC');
+    expect(result.stdout).toContain('InfoValue: pdf-lib');
+  });
+
+  it('dump_data_utf8 emits the extracted text', async () => {
+    pdf.text = 'hello world';
+    const result = await createPdftkCommand().execute(['in.pdf', 'dump_data_utf8'], okCtx());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('hello world\n');
+  });
+
+  it('cat copies a page range and writes the output', async () => {
+    const writeFile = vi.fn().mockResolvedValue(undefined);
+    const result = await createPdftkCommand().execute(
+      ['in.pdf', 'cat', '1-2', 'output', 'out.pdf'],
+      okCtx({ writeFile: writeFile as unknown as IFileSystem['writeFile'] })
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('Created out.pdf\n');
+    expect(pdf.addPage).toHaveBeenCalledTimes(2);
+    expect(writeFile).toHaveBeenCalledWith('/home/out.pdf', expect.any(Uint8Array));
+  });
+
+  it('cat resolves the end keyword and a single page spec', async () => {
+    const result = await createPdftkCommand().execute(
+      ['in.pdf', 'cat', '2-end', '1', 'output', 'out.pdf'],
+      okCtx()
+    );
+    expect(result.exitCode).toBe(0);
+    // pages 2,3 (end) + page 1 = 3 added pages
+    expect(pdf.addPage).toHaveBeenCalledTimes(3);
+  });
+
+  it('cat applies a rotation suffix to copied pages', async () => {
+    const result = await createPdftkCommand().execute(
+      ['in.pdf', 'cat', '1-2right', 'output', 'out.pdf'],
+      okCtx()
+    );
+    expect(result.exitCode).toBe(0);
+    expect(pdf.setRotation).toHaveBeenCalled();
+  });
+
+  it('cat merges pages from lettered handles', async () => {
+    const result = await createPdftkCommand().execute(
+      ['A=one.pdf', 'B=two.pdf', 'cat', 'A', 'B', 'output', 'merged.pdf'],
+      okCtx()
+    );
+    expect(result.exitCode).toBe(0);
+    // both docs have 3 pages → 6 added pages
+    expect(pdf.addPage).toHaveBeenCalledTimes(6);
+  });
+
+  it('cat errors on an unknown handle reference', async () => {
+    const result = await createPdftkCommand().execute(
+      ['A=one.pdf', 'cat', 'A', 'C', 'output', 'merged.pdf'],
+      okCtx()
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("unknown handle 'C'");
+  });
+
+  it('cat rejects an unparseable page range', async () => {
+    const result = await createPdftkCommand().execute(
+      ['in.pdf', 'cat', 'xyz', 'output', 'out.pdf'],
+      okCtx()
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Invalid page range: xyz');
+  });
+
+  it('cat rejects a page number beyond the document length', async () => {
+    pdf.pageCount = 2;
+    const result = await createPdftkCommand().execute(
+      ['in.pdf', 'cat', '5', 'output', 'out.pdf'],
+      okCtx()
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('out of range');
+  });
+
+  it('rotate applies rotations and writes the output', async () => {
+    const result = await createPdftkCommand().execute(
+      ['in.pdf', 'rotate', '1-2right', 'output', 'out.pdf'],
+      okCtx()
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('Created out.pdf\n');
+    expect(pdf.setRotation).toHaveBeenCalled();
+  });
+
+  it('rotate requires a rotation suffix on each range', async () => {
+    const result = await createPdftkCommand().execute(
+      ['in.pdf', 'rotate', '1-2', 'output', 'out.pdf'],
+      okCtx()
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('rotation suffix required');
+  });
+
+  it('rotate requires an output keyword', async () => {
+    const result = await createPdftkCommand().execute(['in.pdf', 'rotate', '1-2right'], okCtx());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("rotate operation requires 'output <filename>'");
+  });
+
+  it('rotate reports a missing output filename', async () => {
+    const result = await createPdftkCommand().execute(
+      ['in.pdf', 'rotate', '1-2right', 'output'],
+      okCtx()
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('output filename not specified');
+  });
+
+  it('rejects an unknown operation once inputs parse', async () => {
+    // 'dump_data' is a known keyword so parsing stops there; feed a lone known
+    // keyword variant by using a handle input plus a bogus op keyword position.
+    const result = await createPdftkCommand().execute(['in.pdf', 'cat', 'output'], okCtx());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('output filename not specified');
   });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/pdftk-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/pdftk-command.test.ts
@@ -15,10 +15,15 @@ const pdf = vi.hoisted(() => ({
   text: '',
   addPage: vi.fn(),
   setRotation: vi.fn(),
+  // Records each copyPages(src, indices) call so tests can assert which source
+  // document and which 0-based page indices were copied, in order.
+  copyPagesCalls: [] as Array<{ docId: string; indices: number[] }>,
+  loadCount: 0,
 }));
 
 vi.mock('@cantoo/pdf-lib', () => {
-  const makeDoc = () => ({
+  const makeDoc = (docId: string) => ({
+    docId,
     getPageCount: () => pdf.pageCount,
     getTitle: () => pdf.title || undefined,
     getAuthor: () => pdf.author || undefined,
@@ -29,13 +34,18 @@ vi.mock('@cantoo/pdf-lib', () => {
         getRotation: () => ({ angle: 0 }),
         setRotation: pdf.setRotation,
       })),
-    copyPages: async (_doc: unknown, indices: number[]) =>
-      indices.map(() => ({ setRotation: pdf.setRotation })),
+    copyPages: async (src: { docId: string }, indices: number[]) => {
+      pdf.copyPagesCalls.push({ docId: src.docId, indices: [...indices] });
+      return indices.map(() => ({ setRotation: pdf.setRotation }));
+    },
     addPage: pdf.addPage,
     save: async () => new Uint8Array([1, 2, 3]),
   });
   return {
-    PDFDocument: { load: async () => makeDoc(), create: async () => makeDoc() },
+    PDFDocument: {
+      load: async () => makeDoc(`in${++pdf.loadCount}`),
+      create: async () => makeDoc('out'),
+    },
     degrees: (angle: number) => ({ angle }),
   };
 });
@@ -275,6 +285,8 @@ describe('pdftk operation bodies (mocked pdf libs)', () => {
     pdf.text = '';
     pdf.addPage.mockClear();
     pdf.setRotation.mockClear();
+    pdf.copyPagesCalls = [];
+    pdf.loadCount = 0;
   });
 
   it('dump_data prints the page count only when no metadata exists', async () => {
@@ -312,6 +324,8 @@ describe('pdftk operation bodies (mocked pdf libs)', () => {
     );
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe('Created out.pdf\n');
+    // Pages 1-2 map to 0-based indices [0, 1] copied from the single input.
+    expect(pdf.copyPagesCalls).toEqual([{ docId: 'in1', indices: [0, 1] }]);
     expect(pdf.addPage).toHaveBeenCalledTimes(2);
     expect(writeFile).toHaveBeenCalledWith('/home/out.pdf', expect.any(Uint8Array));
   });
@@ -322,26 +336,36 @@ describe('pdftk operation bodies (mocked pdf libs)', () => {
       okCtx()
     );
     expect(result.exitCode).toBe(0);
-    // pages 2,3 (end) + page 1 = 3 added pages
+    // '2-end' (pageCount 3) → indices [1, 2]; then '1' → [0], preserving order.
+    expect(pdf.copyPagesCalls).toEqual([
+      { docId: 'in1', indices: [1, 2] },
+      { docId: 'in1', indices: [0] },
+    ]);
     expect(pdf.addPage).toHaveBeenCalledTimes(3);
   });
 
-  it('cat applies a rotation suffix to copied pages', async () => {
+  it('cat applies the right-rotation angle to copied pages', async () => {
     const result = await createPdftkCommand().execute(
       ['in.pdf', 'cat', '1-2right', 'output', 'out.pdf'],
       okCtx()
     );
     expect(result.exitCode).toBe(0);
-    expect(pdf.setRotation).toHaveBeenCalled();
+    // right = 90°, applied to each of the two copied pages.
+    expect(pdf.setRotation).toHaveBeenCalledTimes(2);
+    expect(pdf.setRotation).toHaveBeenCalledWith({ angle: 90 });
   });
 
-  it('cat merges pages from lettered handles', async () => {
+  it('cat merges pages from lettered handles in handle order', async () => {
     const result = await createPdftkCommand().execute(
       ['A=one.pdf', 'B=two.pdf', 'cat', 'A', 'B', 'output', 'merged.pdf'],
       okCtx()
     );
     expect(result.exitCode).toBe(0);
-    // both docs have 3 pages → 6 added pages
+    // A (first-loaded → in1) fully, then B (in2) fully; each has 3 pages.
+    expect(pdf.copyPagesCalls).toEqual([
+      { docId: 'in1', indices: [0, 1, 2] },
+      { docId: 'in2', indices: [0, 1, 2] },
+    ]);
     expect(pdf.addPage).toHaveBeenCalledTimes(6);
   });
 
@@ -380,7 +404,9 @@ describe('pdftk operation bodies (mocked pdf libs)', () => {
     );
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe('Created out.pdf\n');
-    expect(pdf.setRotation).toHaveBeenCalled();
+    // Two pages rotated from 0° by 90° (right) → final angle 90°.
+    expect(pdf.setRotation).toHaveBeenCalledTimes(2);
+    expect(pdf.setRotation).toHaveBeenCalledWith({ angle: 90 });
   });
 
   it('rotate requires a rotation suffix on each range', async () => {

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/devtools.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/devtools.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generateLocatorHandler,
+  highlightHandler,
+} from '../../../../../src/shell/supplemental-commands/playwright/handlers/devtools.js';
+import type { TabSnapshot } from '../../../../../src/shell/supplemental-commands/playwright/types.js';
+import {
+  createHandlerCtx,
+  createMockBrowser,
+  createMockTransport,
+  createPlaywrightState,
+} from '../../../helpers/playwright-harness.js';
+
+const TAB = 'tab-1';
+
+function makeSnapshot(over: Partial<TabSnapshot> = {}): TabSnapshot {
+  return {
+    url: 'https://x',
+    title: 't',
+    content: '',
+    timestamp: 0,
+    refToSelector: new Map(),
+    refToBackendNodeId: new Map(),
+    refToFrameId: new Map(),
+    ...over,
+  };
+}
+
+/** Browser whose callFunctionOn returns the given element props JSON. */
+function browserWithProps(props: Record<string, unknown>) {
+  const transport = createMockTransport((method) => {
+    if (method === 'DOM.resolveNode') return { object: { objectId: 'o1' } };
+    if (method === 'Runtime.callFunctionOn') return { result: { value: JSON.stringify(props) } };
+    return {};
+  });
+  return createMockBrowser({ transport });
+}
+
+describe('generate-locator handler', () => {
+  it('requires a ref, a snapshot, and a known ref', async () => {
+    const noRef = await generateLocatorHandler(createHandlerCtx({ flags: { tab: TAB } }));
+    expect(noRef.stderr).toContain('requires a ref');
+
+    const noSnap = await generateLocatorHandler(
+      createHandlerCtx({ positional: ['e5'], flags: { tab: TAB } })
+    );
+    expect(noSnap.stderr).toContain('No snapshot available');
+
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot());
+    const unknown = await generateLocatorHandler(
+      createHandlerCtx({ state, positional: ['e9'], flags: { tab: TAB } })
+    );
+    expect(unknown.stderr).toContain('Unknown ref');
+  });
+
+  it('returns a CSS locator when only a selector is known', async () => {
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToSelector: new Map([['e5', '#a, .b']]) }));
+    const r = await generateLocatorHandler(
+      createHandlerCtx({ state, positional: ['e5'], flags: { tab: TAB } })
+    );
+    expect(r.stdout).toBe('page.locator("#a")\n');
+  });
+
+  it('prefers testId > label > placeholder > id > selector', async () => {
+    const cases: Array<[Record<string, unknown>, string]> = [
+      [{ testId: 'submit' }, 'page.getByTestId("submit")\n'],
+      [{ label: 'Email' }, 'page.getByLabel("Email")\n'],
+      [{ placeholder: 'Search' }, 'page.getByPlaceholder("Search")\n'],
+      [{ id: 'main' }, 'page.locator("#main")\n'],
+      [{}, 'page.locator("#el")\n'],
+    ];
+    for (const [props, expected] of cases) {
+      const { browser } = browserWithProps(props);
+      const state = createPlaywrightState();
+      state.snapshots.set(
+        TAB,
+        makeSnapshot({
+          refToBackendNodeId: new Map([['e5', 1]]),
+          refToSelector: new Map([['e5', '#el']]),
+        })
+      );
+      const r = await generateLocatorHandler(
+        createHandlerCtx({ browser, state, positional: ['e5'], flags: { tab: TAB } })
+      );
+      expect(r.stdout).toBe(expected);
+    }
+  });
+});
+
+describe('highlight handler', () => {
+  it('removes all highlights with --hide and no ref', async () => {
+    const { browser, transport } = createMockBrowser();
+    const r = await highlightHandler(
+      createHandlerCtx({ browser, flags: { tab: TAB, hide: 'true' } })
+    );
+    expect(r.stdout).toBe('All highlights removed\n');
+    expect(transport.send).toHaveBeenCalledWith(
+      'Runtime.evaluate',
+      expect.objectContaining({ expression: expect.stringContaining('data-slicc-highlight') }),
+      'session-1'
+    );
+  });
+
+  it('errors without a ref and without --hide', async () => {
+    const r = await highlightHandler(createHandlerCtx({ flags: { tab: TAB } }));
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('requires a ref');
+  });
+
+  it('errors without a snapshot', async () => {
+    const r = await highlightHandler(createHandlerCtx({ positional: ['e5'], flags: { tab: TAB } }));
+    expect(r.stderr).toContain('No snapshot available');
+  });
+
+  it('highlights via backendNodeId', async () => {
+    const { browser } = browserWithProps({});
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e5', 1]]) }));
+    const r = await highlightHandler(
+      createHandlerCtx({ browser, state, positional: ['e5'], flags: { tab: TAB } })
+    );
+    expect(r.stdout).toBe('Highlighted e5\n');
+  });
+
+  it('hides a specific ref via backendNodeId', async () => {
+    const { browser } = browserWithProps({});
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e5', 1]]) }));
+    const r = await highlightHandler(
+      createHandlerCtx({ browser, state, positional: ['e5'], flags: { tab: TAB, hide: 'true' } })
+    );
+    expect(r.stdout).toBe('Highlight removed from e5\n');
+  });
+
+  it('highlights via the CSS selector fallback', async () => {
+    const { browser, transport } = createMockBrowser();
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToSelector: new Map([['e5', '#z']]) }));
+    const r = await highlightHandler(
+      createHandlerCtx({ browser, state, positional: ['e5'], flags: { tab: TAB } })
+    );
+    expect(r.stdout).toBe('Highlighted e5\n');
+    expect(transport.send).toHaveBeenCalledWith(
+      'Runtime.evaluate',
+      expect.objectContaining({ expression: expect.stringContaining('#z') }),
+      'session-1'
+    );
+  });
+
+  it('throws when the element cannot be resolved', async () => {
+    const transport = createMockTransport((method) =>
+      method === 'DOM.resolveNode' ? { object: {} } : {}
+    );
+    const { browser } = createMockBrowser({ transport });
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e5', 1]]) }));
+    await expect(
+      highlightHandler(
+        createHandlerCtx({ browser, state, positional: ['e5'], flags: { tab: TAB } })
+      )
+    ).rejects.toThrow('Could not resolve');
+  });
+
+  it('throws on an unknown ref with no selector', async () => {
+    const { browser } = createMockBrowser();
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot());
+    await expect(
+      highlightHandler(
+        createHandlerCtx({ browser, state, positional: ['e9'], flags: { tab: TAB } })
+      )
+    ).rejects.toThrow('Unknown ref');
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/interaction.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/interaction.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { BrowserAPI } from '../../../../../src/cdp/index.js';
+import {
+  checkHandler,
+  clickHandler,
+  dblclickHandler,
+  dragHandler,
+  fillHandler,
+  hoverHandler,
+  keydownHandler,
+  keyupHandler,
+  pressHandler,
+  selectHandler,
+  typeHandler,
+  uncheckHandler,
+} from '../../../../../src/shell/supplemental-commands/playwright/handlers/interaction.js';
+import type {
+  PlaywrightState,
+  TabSnapshot,
+} from '../../../../../src/shell/supplemental-commands/playwright/types.js';
+import { createHandlerCtx, createPlaywrightState } from '../../../helpers/playwright-harness.js';
+
+const TAB = 'tab-1';
+
+function makeSnapshot(over: Partial<TabSnapshot> = {}): TabSnapshot {
+  return {
+    url: 'https://x',
+    title: 't',
+    content: '',
+    timestamp: 0,
+    refToSelector: new Map(),
+    refToBackendNodeId: new Map(),
+    refToFrameId: new Map(),
+    ...over,
+  };
+}
+
+function stateWithSnapshot(snapshot?: TabSnapshot): PlaywrightState {
+  const state = createPlaywrightState();
+  if (snapshot) state.snapshots.set(TAB, snapshot);
+  return state;
+}
+
+/** A fully-spied BrowserAPI covering every method the interaction handlers touch. */
+function makeBrowser() {
+  const send = vi.fn(async (_m: string, _p?: Record<string, unknown>) => {
+    if (_m === 'DOM.resolveNode') return { object: { objectId: 'obj-1' } };
+    if (_m === 'Runtime.callFunctionOn') return { result: { value: '' } };
+    return {};
+  });
+  const spies = {
+    send,
+    click: vi.fn(async () => undefined),
+    type: vi.fn(async () => undefined),
+    insertText: vi.fn(async () => undefined),
+    evaluate: vi.fn(async () => ''),
+    evaluateInFrame: vi.fn(async () => undefined),
+    clickByBackendNodeId: vi.fn(async () => undefined),
+    dblclickByBackendNodeId: vi.fn(async () => undefined),
+    hoverByBackendNodeId: vi.fn(async () => undefined),
+    selectByBackendNodeId: vi.fn(async () => undefined),
+    dragByBackendNodeIds: vi.fn(async () => undefined),
+    setCheckedByBackendNodeId: vi.fn(async (): Promise<'toggled' | 'already'> => 'toggled'),
+  };
+  const browser = {
+    withTab: async <T>(_t: string, fn: (sessionId: string) => Promise<T>) => fn('session-1'),
+    getTransport: () => ({ send }),
+    getSessionId: () => 'session-1',
+    click: spies.click,
+    type: spies.type,
+    insertText: spies.insertText,
+    evaluate: spies.evaluate,
+    evaluateInFrame: spies.evaluateInFrame,
+    clickByBackendNodeId: spies.clickByBackendNodeId,
+    dblclickByBackendNodeId: spies.dblclickByBackendNodeId,
+    hoverByBackendNodeId: spies.hoverByBackendNodeId,
+    selectByBackendNodeId: spies.selectByBackendNodeId,
+    dragByBackendNodeIds: spies.dragByBackendNodeIds,
+    setCheckedByBackendNodeId: spies.setCheckedByBackendNodeId,
+  } as unknown as BrowserAPI;
+  return { browser, spies };
+}
+
+describe('interaction handlers — argument validation', () => {
+  it('each handler rejects missing positionals', async () => {
+    const cases: Array<[(ctx: never) => Promise<{ stderr: string }>, string]> = [
+      [clickHandler as never, 'click requires a ref'],
+      [typeHandler as never, 'type requires text'],
+      [fillHandler as never, 'fill requires <ref> <text>'],
+      [pressHandler as never, 'press requires a key name'],
+      [keydownHandler as never, 'keydown requires a key name'],
+      [keyupHandler as never, 'keyup requires a key name'],
+      [dblclickHandler as never, 'dblclick requires a ref'],
+      [hoverHandler as never, 'hover requires a ref'],
+      [selectHandler as never, 'select requires <ref> <value>'],
+      [checkHandler as never, 'check requires a ref'],
+      [uncheckHandler as never, 'uncheck requires a ref'],
+      [dragHandler as never, 'drag requires <startRef> <endRef>'],
+    ];
+    for (const [handler, message] of cases) {
+      const result = await handler(createHandlerCtx() as never);
+      expect(result.stderr).toContain(message);
+    }
+  });
+
+  it('handlers require a --tab flag', async () => {
+    const result = await clickHandler(createHandlerCtx({ positional: ['e5'] }));
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('--tab');
+  });
+});
+
+describe('clickHandler', () => {
+  it('clicks via backendNodeId and invalidates the snapshot', async () => {
+    const { browser, spies } = makeBrowser();
+    const snapshot = makeSnapshot({ refToBackendNodeId: new Map([['e5', 42]]) });
+    const state = stateWithSnapshot(snapshot);
+    const result = await clickHandler(
+      createHandlerCtx({ browser, state, positional: ['e5'], flags: { tab: TAB } })
+    );
+    expect(result.stdout).toBe('Clicked e5\n');
+    expect(spies.clickByBackendNodeId).toHaveBeenCalledWith(42, 0);
+    expect(state.snapshots.has(TAB)).toBe(false);
+  });
+
+  it('falls back to a CSS selector and parses --modifiers', async () => {
+    const { browser, spies } = makeBrowser();
+    const snapshot = makeSnapshot({ refToSelector: new Map([['e5', '#btn']]) });
+    const result = await clickHandler(
+      createHandlerCtx({
+        browser,
+        state: stateWithSnapshot(snapshot),
+        positional: ['e5'],
+        flags: { tab: TAB, modifiers: 'Shift,Meta' },
+      })
+    );
+    expect(result.stdout).toBe('Clicked e5\n');
+    expect(spies.click).toHaveBeenCalledWith('#btn', 12); // Shift(8)|Meta(4)
+  });
+
+  it('routes clicks into an iframe ref', async () => {
+    const { browser, spies } = makeBrowser();
+    const snapshot = makeSnapshot({
+      refToFrameId: new Map([['f1e5', 'frame-1']]),
+      refToSelector: new Map([['f1e5', '#a']]),
+    });
+    const result = await clickHandler(
+      createHandlerCtx({
+        browser,
+        state: stateWithSnapshot(snapshot),
+        positional: ['f1e5'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(result.stdout).toContain('(in iframe)');
+    expect(spies.evaluateInFrame).toHaveBeenCalled();
+  });
+
+  it('rejects an unknown ref and a missing snapshot', async () => {
+    const { browser } = makeBrowser();
+    await expect(
+      clickHandler(
+        createHandlerCtx({
+          browser,
+          state: stateWithSnapshot(makeSnapshot()),
+          positional: ['e9'],
+          flags: { tab: TAB },
+        })
+      )
+    ).rejects.toThrow('Unknown ref');
+
+    await expect(
+      clickHandler(
+        createHandlerCtx({
+          browser,
+          state: createPlaywrightState(),
+          positional: ['e5'],
+          flags: { tab: TAB },
+        })
+      )
+    ).rejects.toThrow('No snapshot');
+  });
+});
+
+describe('keyboard + type handlers', () => {
+  it('types text and submits with Enter', async () => {
+    const { browser, spies } = makeBrowser();
+    const result = await typeHandler(
+      createHandlerCtx({
+        browser,
+        positional: ['hello', 'world'],
+        flags: { tab: TAB, submit: 'true' },
+      })
+    );
+    expect(result.stdout).toBe('Typed: hello world\n');
+    expect(spies.type).toHaveBeenCalledWith('hello world');
+    expect(spies.send).toHaveBeenCalledWith(
+      'Input.dispatchKeyEvent',
+      { type: 'keyDown', key: 'Enter' },
+      'session-1'
+    );
+  });
+
+  it('press dispatches keyDown + keyUp', async () => {
+    const { browser, spies } = makeBrowser();
+    const result = await pressHandler(
+      createHandlerCtx({ browser, positional: ['Escape'], flags: { tab: TAB } })
+    );
+    expect(result.stdout).toBe('Pressed Escape\n');
+    expect(spies.send).toHaveBeenCalledTimes(2);
+  });
+
+  it('keydown and keyup dispatch a single event each', async () => {
+    const { browser, spies } = makeBrowser();
+    await keydownHandler(createHandlerCtx({ browser, positional: ['A'], flags: { tab: TAB } }));
+    await keyupHandler(createHandlerCtx({ browser, positional: ['A'], flags: { tab: TAB } }));
+    expect(spies.send).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('fillHandler', () => {
+  it('fills via backendNodeId with the React fallback and submits', async () => {
+    const { browser, spies } = makeBrowser();
+    const snapshot = makeSnapshot({ refToBackendNodeId: new Map([['e5', 7]]) });
+    const state = stateWithSnapshot(snapshot);
+    const result = await fillHandler(
+      createHandlerCtx({
+        browser,
+        state,
+        positional: ['e5', 'secret', 'value'],
+        flags: { tab: TAB, submit: 'true' },
+      })
+    );
+    expect(result.stdout).toBe('Filled e5 with: secret value\n');
+    expect(spies.clickByBackendNodeId).toHaveBeenCalledWith(7);
+    expect(spies.insertText).toHaveBeenCalledWith('secret value');
+    expect(state.snapshots.has(TAB)).toBe(false);
+  });
+
+  it('fills via the CSS selector fallback', async () => {
+    const { browser, spies } = makeBrowser();
+    const snapshot = makeSnapshot({ refToSelector: new Map([['e5', '#in']]) });
+    const result = await fillHandler(
+      createHandlerCtx({
+        browser,
+        state: stateWithSnapshot(snapshot),
+        positional: ['e5', 'text'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(result.stdout).toBe('Filled e5 with: text\n');
+    expect(spies.click).toHaveBeenCalledWith('#in');
+    expect(spies.insertText).toHaveBeenCalledWith('text');
+  });
+});
+
+describe('pointer + form handlers', () => {
+  it('dblclick uses backendNodeId', async () => {
+    const { browser, spies } = makeBrowser();
+    const snapshot = makeSnapshot({ refToBackendNodeId: new Map([['e5', 3]]) });
+    const result = await dblclickHandler(
+      createHandlerCtx({
+        browser,
+        state: stateWithSnapshot(snapshot),
+        positional: ['e5'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(result.stdout).toBe('Double-clicked e5\n');
+    expect(spies.dblclickByBackendNodeId).toHaveBeenCalledWith(3, 'left', 0);
+  });
+
+  it('hover uses backendNodeId', async () => {
+    const { browser, spies } = makeBrowser();
+    const snapshot = makeSnapshot({ refToBackendNodeId: new Map([['e5', 3]]) });
+    const result = await hoverHandler(
+      createHandlerCtx({
+        browser,
+        state: stateWithSnapshot(snapshot),
+        positional: ['e5'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(result.stdout).toBe('Hovered e5\n');
+    expect(spies.hoverByBackendNodeId).toHaveBeenCalledWith(3);
+  });
+
+  it('select sets a value by backendNodeId', async () => {
+    const { browser, spies } = makeBrowser();
+    const snapshot = makeSnapshot({ refToBackendNodeId: new Map([['e5', 3]]) });
+    const result = await selectHandler(
+      createHandlerCtx({
+        browser,
+        state: stateWithSnapshot(snapshot),
+        positional: ['e5', 'opt', 'two'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(result.stdout).toBe('Selected "opt two" on e5\n');
+    expect(spies.selectByBackendNodeId).toHaveBeenCalledWith(3, 'opt two');
+  });
+
+  it('check reports toggled vs already-checked', async () => {
+    const { browser, spies } = makeBrowser();
+    const snapshot = makeSnapshot({ refToBackendNodeId: new Map([['e5', 3]]) });
+    const toggled = await checkHandler(
+      createHandlerCtx({
+        browser,
+        state: stateWithSnapshot(snapshot),
+        positional: ['e5'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(toggled.stdout).toBe('Checked e5\n');
+
+    spies.setCheckedByBackendNodeId.mockResolvedValueOnce('already');
+    const already = await checkHandler(
+      createHandlerCtx({
+        browser,
+        state: stateWithSnapshot(snapshot),
+        positional: ['e5'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(already.stdout).toBe('e5 already checked\n');
+  });
+
+  it('uncheck reports toggled state', async () => {
+    const { browser, spies } = makeBrowser();
+    const snapshot = makeSnapshot({ refToBackendNodeId: new Map([['e5', 3]]) });
+    const result = await uncheckHandler(
+      createHandlerCtx({
+        browser,
+        state: stateWithSnapshot(snapshot),
+        positional: ['e5'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(result.stdout).toBe('Unchecked e5\n');
+    expect(spies.setCheckedByBackendNodeId).toHaveBeenCalledWith(3, false);
+  });
+
+  it('drag connects two backendNodeIds and rejects missing endpoints', async () => {
+    const { browser, spies } = makeBrowser();
+    const snapshot = makeSnapshot({
+      refToBackendNodeId: new Map([
+        ['e1', 1],
+        ['e2', 2],
+      ]),
+    });
+    const ok = await dragHandler(
+      createHandlerCtx({
+        browser,
+        state: stateWithSnapshot(snapshot),
+        positional: ['e1', 'e2'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(ok.stdout).toBe('Dragged e1 to e2\n');
+    expect(spies.dragByBackendNodeIds).toHaveBeenCalledWith(1, 2);
+
+    await expect(
+      dragHandler(
+        createHandlerCtx({
+          browser,
+          state: stateWithSnapshot(makeSnapshot({ refToBackendNodeId: new Map([['e2', 2]]) })),
+          positional: ['e1', 'e2'],
+          flags: { tab: TAB },
+        })
+      )
+    ).rejects.toThrow('Unknown ref "e1"');
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/interaction.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/interaction.test.ts
@@ -199,6 +199,11 @@ describe('keyboard + type handlers', () => {
       { type: 'keyDown', key: 'Enter' },
       'session-1'
     );
+    expect(spies.send).toHaveBeenCalledWith(
+      'Input.dispatchKeyEvent',
+      { type: 'keyUp', key: 'Enter' },
+      'session-1'
+    );
   });
 
   it('press dispatches keyDown + keyUp', async () => {
@@ -234,6 +239,24 @@ describe('fillHandler', () => {
     expect(result.stdout).toBe('Filled e5 with: secret value\n');
     expect(spies.clickByBackendNodeId).toHaveBeenCalledWith(7);
     expect(spies.insertText).toHaveBeenCalledWith('secret value');
+    // The mock read-back returns '' ≠ fillText, so the React native-setter
+    // fallback fires with the target value.
+    expect(spies.send).toHaveBeenCalledWith(
+      'Runtime.callFunctionOn',
+      expect.objectContaining({ arguments: [{ value: 'secret value' }] }),
+      'session-1'
+    );
+    // --submit dispatches Enter keyDown + keyUp.
+    expect(spies.send).toHaveBeenCalledWith(
+      'Input.dispatchKeyEvent',
+      { type: 'keyDown', key: 'Enter' },
+      'session-1'
+    );
+    expect(spies.send).toHaveBeenCalledWith(
+      'Input.dispatchKeyEvent',
+      { type: 'keyUp', key: 'Enter' },
+      'session-1'
+    );
     expect(state.snapshots.has(TAB)).toBe(false);
   });
 

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/mouse.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/mouse.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { VirtualFS } from '../../../../../src/fs/index.js';
+import {
+  dropHandler,
+  mousedownHandler,
+  mousemoveHandler,
+  mouseupHandler,
+  mousewheelHandler,
+} from '../../../../../src/shell/supplemental-commands/playwright/handlers/mouse.js';
+import type { TabSnapshot } from '../../../../../src/shell/supplemental-commands/playwright/types.js';
+import {
+  createHandlerCtx,
+  createMockBrowser,
+  createMockTransport,
+  createPlaywrightState,
+} from '../../../helpers/playwright-harness.js';
+
+const TAB = 'tab-1';
+
+function makeSnapshot(over: Partial<TabSnapshot> = {}): TabSnapshot {
+  return {
+    url: 'https://x',
+    title: 't',
+    content: '',
+    timestamp: 0,
+    refToSelector: new Map(),
+    refToBackendNodeId: new Map(),
+    refToFrameId: new Map(),
+    ...over,
+  };
+}
+
+describe('mousemove handler', () => {
+  it('requires two coordinates', async () => {
+    const r = await mousemoveHandler(createHandlerCtx({ positional: ['1'], flags: { tab: TAB } }));
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('requires <x> <y>');
+  });
+
+  it('rejects non-numeric coordinates', async () => {
+    const r = await mousemoveHandler(
+      createHandlerCtx({ positional: ['a', 'b'], flags: { tab: TAB } })
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('must be numbers');
+  });
+
+  it('dispatches a mouseMoved event and records the position', async () => {
+    const { browser, transport } = createMockBrowser();
+    const state = createPlaywrightState();
+    const r = await mousemoveHandler(
+      createHandlerCtx({ browser, state, positional: ['10', '20'], flags: { tab: TAB } })
+    );
+    expect(r.stdout).toBe('Mouse moved to (10, 20)\n');
+    expect(transport.send).toHaveBeenCalledWith(
+      'Input.dispatchMouseEvent',
+      expect.objectContaining({ type: 'mouseMoved', x: 10, y: 20 }),
+      'session-1'
+    );
+    expect(state.lastMousePosition.get(TAB)).toEqual({ x: 10, y: 20 });
+  });
+});
+
+describe('mousedown / mouseup handlers', () => {
+  it('require a --tab flag', async () => {
+    const r = await mousedownHandler(createHandlerCtx());
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('--tab');
+  });
+
+  it('reject an invalid button', async () => {
+    const r = await mousedownHandler(
+      createHandlerCtx({ positional: ['sideways'], flags: { tab: TAB } })
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('Invalid button');
+  });
+
+  it('press at the last recorded position, defaulting to origin', async () => {
+    const { browser, transport } = createMockBrowser();
+    const down = await mousedownHandler(
+      createHandlerCtx({ browser, positional: ['right'], flags: { tab: TAB } })
+    );
+    expect(down.stdout).toBe('Mouse button right pressed\n');
+    expect(transport.send).toHaveBeenCalledWith(
+      'Input.dispatchMouseEvent',
+      expect.objectContaining({ type: 'mousePressed', button: 'right', x: 0, y: 0 }),
+      'session-1'
+    );
+  });
+
+  it('release uses the recorded mouse position', async () => {
+    const { browser, transport } = createMockBrowser();
+    const state = createPlaywrightState();
+    state.lastMousePosition.set(TAB, { x: 5, y: 6 });
+    const up = await mouseupHandler(createHandlerCtx({ browser, state, flags: { tab: TAB } }));
+    expect(up.stdout).toBe('Mouse button left released\n');
+    expect(transport.send).toHaveBeenCalledWith(
+      'Input.dispatchMouseEvent',
+      expect.objectContaining({ type: 'mouseReleased', x: 5, y: 6 }),
+      'session-1'
+    );
+  });
+});
+
+describe('mousewheel handler', () => {
+  it('requires two deltas and rejects non-numbers', async () => {
+    const missing = await mousewheelHandler(
+      createHandlerCtx({ positional: ['1'], flags: { tab: TAB } })
+    );
+    expect(missing.stderr).toContain('requires <dx> <dy>');
+    const nan = await mousewheelHandler(
+      createHandlerCtx({ positional: ['a', 'b'], flags: { tab: TAB } })
+    );
+    expect(nan.stderr).toContain('must be numbers');
+  });
+
+  it('dispatches a mouseWheel event', async () => {
+    const { browser, transport } = createMockBrowser();
+    const r = await mousewheelHandler(
+      createHandlerCtx({ browser, positional: ['3', '-4'], flags: { tab: TAB } })
+    );
+    expect(r.stdout).toBe('Mouse wheel scrolled (dx=3, dy=-4)\n');
+    expect(transport.send).toHaveBeenCalledWith(
+      'Input.dispatchMouseEvent',
+      expect.objectContaining({ type: 'mouseWheel', deltaX: 3, deltaY: -4 }),
+      'session-1'
+    );
+  });
+});
+
+describe('drop handler', () => {
+  it('requires a ref', async () => {
+    const r = await dropHandler(createHandlerCtx({ flags: { tab: TAB } }));
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('drop requires a ref');
+  });
+
+  it('rejects a malformed --data value', async () => {
+    const r = await dropHandler(
+      createHandlerCtx({ positional: ['e5'], flags: { tab: TAB, data: 'noequals' } })
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('--data format must be');
+  });
+
+  it('drops a VFS file via backendNodeId', async () => {
+    const transport = createMockTransport((method) => {
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'o1' } };
+      if (method === 'Runtime.callFunctionOn') return { result: { value: 'DIV' } };
+      return {};
+    });
+    const { browser } = createMockBrowser({ transport });
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e5', 9]]) }));
+    const readFile = vi.fn(async () => 'file-bytes');
+    const r = await dropHandler(
+      createHandlerCtx({
+        browser,
+        state,
+        positional: ['e5'],
+        flags: { tab: TAB, path: '/upload.txt' },
+        fs: { readFile: readFile as unknown as VirtualFS['readFile'] },
+      })
+    );
+    expect(r.stdout).toBe('Dropped onto e5\n');
+    expect(readFile).toHaveBeenCalledWith('/upload.txt');
+    expect(state.snapshots.has(TAB)).toBe(false);
+  });
+
+  it('surfaces a drop exception from the page', async () => {
+    const transport = createMockTransport((method) => {
+      if (method === 'DOM.resolveNode') return { object: { objectId: 'o1' } };
+      if (method === 'Runtime.callFunctionOn') return { exceptionDetails: { text: 'nope' } };
+      return {};
+    });
+    const { browser } = createMockBrowser({ transport });
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e5', 9]]) }));
+    await expect(
+      dropHandler(createHandlerCtx({ browser, state, positional: ['e5'], flags: { tab: TAB } }))
+    ).rejects.toThrow('nope');
+  });
+
+  it('falls back to a CSS selector when no backendNodeId exists', async () => {
+    const transport = createMockTransport(() => ({}));
+    const { browser } = createMockBrowser({ transport });
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToSelector: new Map([['e5', '#zone']]) }));
+    const r = await dropHandler(
+      createHandlerCtx({
+        browser,
+        state,
+        positional: ['e5'],
+        flags: { tab: TAB, data: 'text/plain=hi' },
+      })
+    );
+    expect(r.stdout).toBe('Dropped onto e5\n');
+    expect(transport.send).toHaveBeenCalledWith(
+      'Runtime.evaluate',
+      expect.objectContaining({ expression: expect.stringContaining('#zone') }),
+      'session-1'
+    );
+  });
+
+  it('rejects a missing snapshot and an unknown ref', async () => {
+    const { browser } = createMockBrowser();
+    await expect(
+      dropHandler(
+        createHandlerCtx({
+          browser,
+          state: createPlaywrightState(),
+          positional: ['e5'],
+          flags: { tab: TAB },
+        })
+      )
+    ).rejects.toThrow('No snapshot');
+
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot());
+    await expect(
+      dropHandler(createHandlerCtx({ browser, state, positional: ['e9'], flags: { tab: TAB } }))
+    ).rejects.toThrow('Unknown ref');
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/network-requests.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/network-requests.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { VirtualFS } from '../../../../../src/fs/index.js';
+import {
+  requestBodyHandler,
+  requestHandler,
+  requestHeadersHandler,
+  requestsHandler,
+  responseBodyHandler,
+  responseHeadersHandler,
+} from '../../../../../src/shell/supplemental-commands/playwright/handlers/network-requests.js';
+import type {
+  NetworkEntry,
+  PlaywrightState,
+} from '../../../../../src/shell/supplemental-commands/playwright/types.js';
+import {
+  createHandlerCtx,
+  createMockBrowser,
+  createMockTransport,
+  createPlaywrightState,
+} from '../../../helpers/playwright-harness.js';
+
+const TAB = 'tab-1';
+
+function makeEntry(over: Partial<NetworkEntry> = {}): NetworkEntry {
+  return {
+    index: 1,
+    requestId: 'r1',
+    method: 'GET',
+    url: 'https://example.com/api',
+    requestHeaders: { accept: 'application/json' },
+    requestBody: null,
+    status: 200,
+    responseHeaders: { 'content-type': 'application/json' },
+    responseBody: null,
+    mimeType: 'application/json',
+    isStatic: false,
+    timestamp: 0,
+    ...over,
+  };
+}
+
+/** Seed a state that already has captured entries (capture branch skipped). */
+function seeded(entries: NetworkEntry[]): PlaywrightState {
+  const state = createPlaywrightState();
+  state.networkCleanup.set(TAB, () => {});
+  state.networkRequests.set(TAB, entries);
+  const index = new Map(entries.map((e) => [e.requestId, e]));
+  state.networkRequestIndex.set(TAB, index);
+  return state;
+}
+
+describe('network-requests handlers', () => {
+  it('requires a --tab flag', async () => {
+    const result = await requestsHandler(createHandlerCtx());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('--tab');
+  });
+
+  it('captures requests, responses, and bodies through the CDP event pipeline', async () => {
+    const transport = createMockTransport((method) =>
+      method === 'Network.getResponseBody' ? { body: 'PAYLOAD' } : {}
+    );
+    const { browser } = createMockBrowser({ transport, sessionId: 'session-1' });
+    const state = createPlaywrightState();
+    const ctx = createHandlerCtx({ browser, state, flags: { tab: TAB } });
+
+    // First call subscribes and reports nothing yet.
+    const empty = await requestsHandler(ctx);
+    expect(empty.stdout).toBe('No requests\n');
+    expect(transport.send).toHaveBeenCalledWith('Network.enable', {}, 'session-1');
+    expect(transport.hasListener('Network.requestWillBeSent')).toBe(true);
+
+    // Drive the captured CDP events.
+    transport.emit('Network.requestWillBeSent', {
+      sessionId: 'session-1',
+      requestId: 'r1',
+      request: { url: 'https://example.com/data', method: 'POST', headers: {}, postData: 'q=1' },
+    });
+    transport.emit('Network.responseReceived', {
+      sessionId: 'session-1',
+      requestId: 'r1',
+      response: { status: 201, headers: { 'x-h': '1' }, mimeType: 'text/html' },
+    });
+    transport.emit('Network.loadingFinished', { sessionId: 'session-1', requestId: 'r1' });
+    await Promise.resolve();
+
+    const listed = await requestsHandler(ctx);
+    expect(listed.stdout).toContain('1 POST https://example.com/data → 201');
+    const entry = state.networkRequests.get(TAB)![0];
+    expect(entry.responseBody).toBe('PAYLOAD');
+  });
+
+  it('ignores events from a different session', async () => {
+    const transport = createMockTransport();
+    const { browser } = createMockBrowser({ transport, sessionId: 'session-1' });
+    const state = createPlaywrightState();
+    const ctx = createHandlerCtx({ browser, state, flags: { tab: TAB } });
+    await requestsHandler(ctx);
+    transport.emit('Network.requestWillBeSent', {
+      sessionId: 'other',
+      requestId: 'r9',
+      request: { url: 'x', method: 'GET', headers: {} },
+    });
+    expect(state.networkRequests.get(TAB)!.length).toBe(0);
+  });
+
+  it('filters out static resources unless --static is set', async () => {
+    const state = seeded([
+      makeEntry({ index: 1, requestId: 'a', url: 'https://x/app.js', isStatic: true }),
+      makeEntry({ index: 2, requestId: 'b', url: 'https://x/api' }),
+    ]);
+    const hidden = await requestsHandler(createHandlerCtx({ state, flags: { tab: TAB } }));
+    expect(hidden.stdout).not.toContain('app.js');
+    expect(hidden.stdout).toContain('api');
+
+    const shown = await requestsHandler(
+      createHandlerCtx({ state, flags: { tab: TAB, static: 'true' } })
+    );
+    expect(shown.stdout).toContain('app.js');
+  });
+
+  it('applies a URL filter regex and rejects an invalid one', async () => {
+    const state = seeded([
+      makeEntry({ index: 1, requestId: 'a', url: 'https://x/keep' }),
+      makeEntry({ index: 2, requestId: 'b', url: 'https://x/drop' }),
+    ]);
+    const filtered = await requestsHandler(
+      createHandlerCtx({ state, flags: { tab: TAB, filter: 'keep' } })
+    );
+    expect(filtered.stdout).toContain('keep');
+    expect(filtered.stdout).not.toContain('drop');
+
+    const bad = await requestsHandler(
+      createHandlerCtx({ state, flags: { tab: TAB, filter: '(' } })
+    );
+    expect(bad.exitCode).toBe(1);
+    expect(bad.stderr).toContain('Invalid filter regex');
+  });
+
+  it('clears captured requests when --clear is set', async () => {
+    const state = seeded([makeEntry()]);
+    await requestsHandler(createHandlerCtx({ state, flags: { tab: TAB, clear: 'true' } }));
+    expect(state.networkRequests.get(TAB)!.length).toBe(0);
+  });
+
+  it('request prints full detail and errors on a bad index', async () => {
+    const state = seeded([makeEntry({ requestBody: 'q=1' })]);
+    const detail = await requestHandler(
+      createHandlerCtx({ state, positional: ['1'], flags: { tab: TAB } })
+    );
+    expect(detail.stdout).toContain('Method: GET');
+    expect(detail.stdout).toContain('Request Body: q=1');
+    expect(detail.stdout).toContain('Response Headers:');
+
+    const missing = await requestHandler(
+      createHandlerCtx({ state, positional: ['9'], flags: { tab: TAB } })
+    );
+    expect(missing.exitCode).toBe(1);
+    expect(missing.stderr).toContain('No request at index 9');
+  });
+
+  it('request saves to a file when --filename is given', async () => {
+    const writeFile = vi.fn(async () => undefined);
+    const state = seeded([makeEntry()]);
+    const result = await requestHandler(
+      createHandlerCtx({
+        state,
+        positional: ['1'],
+        flags: { tab: TAB, filename: '/out.txt' },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+    expect(result.stdout).toBe('Saved to /out.txt\n');
+    expect(writeFile).toHaveBeenCalledWith('/out.txt', expect.any(String));
+  });
+
+  it('request-headers renders header lines', async () => {
+    const state = seeded([makeEntry({ requestHeaders: { a: '1', b: '2' } })]);
+    const result = await requestHeadersHandler(
+      createHandlerCtx({ state, positional: ['1'], flags: { tab: TAB } })
+    );
+    expect(result.stdout).toContain('a: 1');
+    expect(result.stdout).toContain('b: 2');
+  });
+
+  it('request-body reports absence and presence', async () => {
+    const none = await requestBodyHandler(
+      createHandlerCtx({ state: seeded([makeEntry()]), positional: ['1'], flags: { tab: TAB } })
+    );
+    expect(none.stdout).toBe('(no request body)\n');
+
+    const some = await requestBodyHandler(
+      createHandlerCtx({
+        state: seeded([makeEntry({ requestBody: 'BODY' })]),
+        positional: ['1'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(some.stdout).toBe('BODY\n');
+  });
+
+  it('response-headers reports pending vs received', async () => {
+    const pending = await responseHeadersHandler(
+      createHandlerCtx({
+        state: seeded([makeEntry({ responseHeaders: null })]),
+        positional: ['1'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(pending.stdout).toContain('response not yet received');
+
+    const got = await responseHeadersHandler(
+      createHandlerCtx({
+        state: seeded([makeEntry({ responseHeaders: { 'x-y': 'z' } })]),
+        positional: ['1'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(got.stdout).toContain('x-y: z');
+  });
+
+  it('response-body reports text, binary summary, and unavailable', async () => {
+    const none = await responseBodyHandler(
+      createHandlerCtx({
+        state: seeded([makeEntry({ responseBody: null })]),
+        positional: ['1'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(none.stdout).toContain('not yet available');
+
+    const text = await responseBodyHandler(
+      createHandlerCtx({
+        state: seeded([makeEntry({ responseBody: 'hello', mimeType: 'text/plain' })]),
+        positional: ['1'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(text.stdout).toBe('hello\n');
+
+    const binary = await responseBodyHandler(
+      createHandlerCtx({
+        state: seeded([makeEntry({ responseBody: btoa('abc'), mimeType: 'image/png' })]),
+        positional: ['1'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(binary.stdout).toBe('[binary body, 3 bytes]\n');
+  });
+
+  it('response-body decodes binary bytes when saving to a file', async () => {
+    const writeFile = vi.fn(async () => undefined);
+    const state = seeded([makeEntry({ responseBody: btoa('abc'), mimeType: 'image/png' })]);
+    const result = await responseBodyHandler(
+      createHandlerCtx({
+        state,
+        positional: ['1'],
+        flags: { tab: TAB, filename: '/img.png' },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+    expect(result.stdout).toBe('Saved to /img.png\n');
+    expect(writeFile).toHaveBeenCalledWith('/img.png', expect.any(Uint8Array));
+  });
+
+  it('the header/body detail handlers all honor --filename', async () => {
+    const cases: Array<[typeof requestHeadersHandler, NetworkEntry]> = [
+      [requestHeadersHandler, makeEntry()],
+      [requestBodyHandler, makeEntry({ requestBody: 'B' })],
+      [responseHeadersHandler, makeEntry()],
+      [responseBodyHandler, makeEntry({ responseBody: 'text', mimeType: 'text/plain' })],
+    ];
+    for (const [handler, entry] of cases) {
+      const writeFile = vi.fn(async () => undefined);
+      const result = await handler(
+        createHandlerCtx({
+          state: seeded([entry]),
+          positional: ['1'],
+          flags: { tab: TAB, filename: '/o' },
+          fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+        })
+      );
+      expect(result.stdout).toBe('Saved to /o\n');
+      expect(writeFile).toHaveBeenCalledOnce();
+    }
+  });
+
+  it('subscribes lazily when a detail handler runs before requests', async () => {
+    const transport = createMockTransport();
+    const { browser } = createMockBrowser({ transport, sessionId: 'session-1' });
+    const state = createPlaywrightState();
+    const result = await requestHandler(
+      createHandlerCtx({ browser, state, positional: ['1'], flags: { tab: TAB } })
+    );
+    // No entries captured yet → index miss, but the capture branch ran.
+    expect(result.exitCode).toBe(1);
+    expect(transport.send).toHaveBeenCalledWith('Network.enable', {}, 'session-1');
+    expect(state.networkCleanup.has(TAB)).toBe(true);
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/network-requests.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/network-requests.test.ts
@@ -71,18 +71,17 @@ describe('network-requests handlers', () => {
     expect(transport.hasListener('Network.requestWillBeSent')).toBe(true);
 
     // Drive the captured CDP events.
-    transport.emit('Network.requestWillBeSent', {
+    await transport.emit('Network.requestWillBeSent', {
       sessionId: 'session-1',
       requestId: 'r1',
       request: { url: 'https://example.com/data', method: 'POST', headers: {}, postData: 'q=1' },
     });
-    transport.emit('Network.responseReceived', {
+    await transport.emit('Network.responseReceived', {
       sessionId: 'session-1',
       requestId: 'r1',
       response: { status: 201, headers: { 'x-h': '1' }, mimeType: 'text/html' },
     });
-    transport.emit('Network.loadingFinished', { sessionId: 'session-1', requestId: 'r1' });
-    await Promise.resolve();
+    await transport.emit('Network.loadingFinished', { sessionId: 'session-1', requestId: 'r1' });
 
     const listed = await requestsHandler(ctx);
     expect(listed.stdout).toContain('1 POST https://example.com/data → 201');
@@ -96,7 +95,7 @@ describe('network-requests handlers', () => {
     const state = createPlaywrightState();
     const ctx = createHandlerCtx({ browser, state, flags: { tab: TAB } });
     await requestsHandler(ctx);
-    transport.emit('Network.requestWillBeSent', {
+    await transport.emit('Network.requestWillBeSent', {
       sessionId: 'other',
       requestId: 'r9',
       request: { url: 'x', method: 'GET', headers: {} },

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/routing.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/routing.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import {
+  patternToRegex,
+  routeHandler,
+  routeListHandler,
+  unrouteHandler,
+} from '../../../../../src/shell/supplemental-commands/playwright/handlers/routing.js';
+import {
+  createHandlerCtx,
+  createMockBrowser,
+  createPlaywrightState,
+} from '../../../helpers/playwright-harness.js';
+
+const TAB = 'tab-1';
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('patternToRegex', () => {
+  it('matches * within a path segment only', () => {
+    const re = patternToRegex('https://x/*');
+    expect(re.test('https://x/api')).toBe(true);
+    expect(re.test('https://x/api/nested')).toBe(false);
+  });
+
+  it('matches ** across segments', () => {
+    const re = patternToRegex('https://x/**');
+    expect(re.test('https://x/api/nested')).toBe(true);
+  });
+
+  it('anchors the whole string', () => {
+    const re = patternToRegex('https://x/api');
+    expect(re.test('https://x/api')).toBe(true);
+    expect(re.test('prefix-https://x/api')).toBe(false);
+  });
+});
+
+describe('routeHandler', () => {
+  it('requires a URL pattern', async () => {
+    const r = await routeHandler(createHandlerCtx({ flags: { tab: TAB } }));
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('requires a URL pattern');
+  });
+
+  it('requires a --tab flag', async () => {
+    const r = await routeHandler(createHandlerCtx({ positional: ['**'] }));
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('--tab');
+  });
+
+  it('adds a route, enabling Fetch interception once', async () => {
+    const { browser, transport } = createMockBrowser();
+    const state = createPlaywrightState();
+    const r = await routeHandler(
+      createHandlerCtx({
+        browser,
+        state,
+        positional: ['**'],
+        flags: {
+          tab: TAB,
+          status: '404',
+          body: 'nope',
+          'content-type': 'application/json',
+          header: 'X-A: 1',
+        },
+      })
+    );
+    expect(r.stdout).toBe('Route added: **\n');
+    expect(transport.send).toHaveBeenCalledWith('Fetch.enable', expect.anything(), 'session-1');
+    const entry = state.routes.get(TAB)![0];
+    expect(entry.status).toBe(404);
+    expect(entry.body).toBe('nope');
+    expect(entry.contentType).toBe('application/json');
+    expect(entry.headers['X-A']).toBe('1');
+    expect(state.routeCleanup.has(TAB)).toBe(true);
+  });
+
+  it('fulfills a matching intercepted request and continues a non-matching one', async () => {
+    const { browser, transport } = createMockBrowser();
+    const state = createPlaywrightState();
+    await routeHandler(
+      createHandlerCtx({
+        browser,
+        state,
+        positional: ['https://x/**'],
+        flags: { tab: TAB, body: 'B' },
+      })
+    );
+
+    transport.emit('Fetch.requestPaused', {
+      sessionId: 'session-1',
+      requestId: 'q1',
+      request: { url: 'https://x/api', headers: {} },
+    });
+    await flush();
+    expect(transport.send).toHaveBeenCalledWith(
+      'Fetch.fulfillRequest',
+      expect.objectContaining({ requestId: 'q1', responseCode: 200 }),
+      'session-1'
+    );
+
+    transport.emit('Fetch.requestPaused', {
+      sessionId: 'session-1',
+      requestId: 'q2',
+      request: { url: 'https://other/api', headers: {} },
+    });
+    await flush();
+    expect(transport.send).toHaveBeenCalledWith(
+      'Fetch.continueRequest',
+      { requestId: 'q2' },
+      'session-1'
+    );
+  });
+
+  it('ignores intercepted requests from a different session', async () => {
+    const { browser, transport } = createMockBrowser();
+    const state = createPlaywrightState();
+    await routeHandler(
+      createHandlerCtx({ browser, state, positional: ['**'], flags: { tab: TAB } })
+    );
+    transport.send.mockClear();
+    transport.emit('Fetch.requestPaused', {
+      sessionId: 'other',
+      requestId: 'q9',
+      request: { url: 'https://x', headers: {} },
+    });
+    await flush();
+    expect(transport.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('routeListHandler', () => {
+  it('reports no active routes', async () => {
+    const r = await routeListHandler(createHandlerCtx({ flags: { tab: TAB } }));
+    expect(r.stdout).toBe('No active routes\n');
+  });
+
+  it('lists active routes', async () => {
+    const state = createPlaywrightState();
+    state.routes.set(TAB, [
+      { pattern: 'a', regex: /a/, status: 200, body: '', contentType: 'text/plain', headers: {} },
+    ]);
+    const r = await routeListHandler(createHandlerCtx({ state, flags: { tab: TAB } }));
+    expect(r.stdout).toContain('1. a → 200 text/plain');
+  });
+});
+
+describe('unrouteHandler', () => {
+  it('removes all routes and runs cleanup when no pattern is given', async () => {
+    const state = createPlaywrightState();
+    let cleaned = false;
+    state.routes.set(TAB, [
+      { pattern: 'a', regex: /a/, status: 200, body: '', contentType: 'text/plain', headers: {} },
+    ]);
+    state.routeCleanup.set(TAB, () => {
+      cleaned = true;
+    });
+    const r = await unrouteHandler(createHandlerCtx({ state, flags: { tab: TAB } }));
+    expect(r.stdout).toBe('All routes removed\n');
+    expect(state.routes.get(TAB)).toEqual([]);
+    expect(cleaned).toBe(true);
+    expect(state.routeCleanup.has(TAB)).toBe(false);
+  });
+
+  it('removes only routes matching a pattern and cleans up when empty', async () => {
+    const state = createPlaywrightState();
+    let cleaned = false;
+    state.routes.set(TAB, [
+      { pattern: 'a', regex: /a/, status: 200, body: '', contentType: 'text/plain', headers: {} },
+    ]);
+    state.routeCleanup.set(TAB, () => {
+      cleaned = true;
+    });
+    const r = await unrouteHandler(
+      createHandlerCtx({ state, positional: ['a'], flags: { tab: TAB } })
+    );
+    expect(r.stdout).toBe('Removed 1 route(s) matching "a"\n');
+    expect(cleaned).toBe(true);
+  });
+
+  it('requires a --tab flag', async () => {
+    const r = await unrouteHandler(createHandlerCtx());
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('--tab');
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/routing.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/routing.test.ts
@@ -12,7 +12,6 @@ import {
 } from '../../../helpers/playwright-harness.js';
 
 const TAB = 'tab-1';
-const flush = () => new Promise((r) => setTimeout(r, 0));
 
 describe('patternToRegex', () => {
   it('matches * within a path segment only', () => {
@@ -85,24 +84,22 @@ describe('routeHandler', () => {
       })
     );
 
-    transport.emit('Fetch.requestPaused', {
+    await transport.emit('Fetch.requestPaused', {
       sessionId: 'session-1',
       requestId: 'q1',
       request: { url: 'https://x/api', headers: {} },
     });
-    await flush();
     expect(transport.send).toHaveBeenCalledWith(
       'Fetch.fulfillRequest',
       expect.objectContaining({ requestId: 'q1', responseCode: 200 }),
       'session-1'
     );
 
-    transport.emit('Fetch.requestPaused', {
+    await transport.emit('Fetch.requestPaused', {
       sessionId: 'session-1',
       requestId: 'q2',
       request: { url: 'https://other/api', headers: {} },
     });
-    await flush();
     expect(transport.send).toHaveBeenCalledWith(
       'Fetch.continueRequest',
       { requestId: 'q2' },
@@ -117,12 +114,11 @@ describe('routeHandler', () => {
       createHandlerCtx({ browser, state, positional: ['**'], flags: { tab: TAB } })
     );
     transport.send.mockClear();
-    transport.emit('Fetch.requestPaused', {
+    await transport.emit('Fetch.requestPaused', {
       sessionId: 'other',
       requestId: 'q9',
       request: { url: 'https://x', headers: {} },
     });
-    await flush();
     expect(transport.send).not.toHaveBeenCalled();
   });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/snapshot.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/snapshot.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { BrowserAPI } from '../../../../../src/cdp/index.js';
+import type { VirtualFS } from '../../../../../src/fs/index.js';
+import {
+  framesHandler,
+  pdfHandler,
+  screenshotHandler,
+  snapshotHandler,
+} from '../../../../../src/shell/supplemental-commands/playwright/handlers/snapshot.js';
+import type { TabSnapshot } from '../../../../../src/shell/supplemental-commands/playwright/types.js';
+import { createHandlerCtx, createPlaywrightState } from '../../../helpers/playwright-harness.js';
+
+vi.mock('../../../../../src/shell/supplemental-commands/playwright/snapshot.js', () => ({
+  takeSnapshot: vi.fn(async () => ({ output: 'SNAPSHOT-TEXT' })),
+}));
+vi.mock('../../../../../src/shell/supplemental-commands/playwright/session-log.js', () => ({
+  ensureSessionDirs: vi.fn(async () => undefined),
+}));
+
+const TAB = 'tab-1';
+
+type SendImpl = (method: string, params?: Record<string, unknown>) => unknown;
+
+/** A browser with the snapshot/frames/screenshot surface, all spied. */
+function makeBrowser(opts?: {
+  sendImpl?: SendImpl;
+  frames?: Array<{ frameId: string; parentFrameId?: string; url: string }>;
+  screenshotB64?: string;
+  evaluateResult?: unknown;
+}) {
+  const send = vi.fn(
+    async (m: string, p?: Record<string, unknown>) =>
+      (opts?.sendImpl?.(m, p) as Record<string, unknown>) ?? {}
+  );
+  const screenshot = vi.fn(async () => opts?.screenshotB64 ?? btoa('img'));
+  const evaluate = vi.fn(async () => opts?.evaluateResult ?? null);
+  const getFrameTree = vi.fn(async () => opts?.frames ?? []);
+  const browser = {
+    withTab: async <T>(_t: string, fn: (sessionId: string) => Promise<T>) => fn('session-1'),
+    getTransport: () => ({ send }),
+    getSessionId: () => 'session-1',
+    screenshot,
+    evaluate,
+    getFrameTree,
+  } as unknown as BrowserAPI;
+  return { browser, send, screenshot, evaluate, getFrameTree };
+}
+
+function makeSnapshot(over: Partial<TabSnapshot> = {}): TabSnapshot {
+  return {
+    url: 'https://x',
+    title: 't',
+    content: '',
+    timestamp: 0,
+    refToSelector: new Map(),
+    refToBackendNodeId: new Map(),
+    refToFrameId: new Map(),
+    ...over,
+  };
+}
+
+const okFs = (): Partial<VirtualFS> => ({ writeFile: vi.fn(async () => undefined) });
+
+describe('snapshotHandler', () => {
+  it('requires a --tab flag', async () => {
+    const r = await snapshotHandler(createHandlerCtx());
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('--tab');
+  });
+
+  it('prints the snapshot text', async () => {
+    const { browser } = makeBrowser();
+    const r = await snapshotHandler(createHandlerCtx({ browser, flags: { tab: TAB } }));
+    expect(r.stdout).toBe('SNAPSHOT-TEXT\n');
+  });
+
+  it('saves the snapshot to a file', async () => {
+    const { browser } = makeBrowser();
+    const writeFile = vi.fn(async () => undefined);
+    const r = await snapshotHandler(
+      createHandlerCtx({
+        browser,
+        flags: { tab: TAB, filename: '/snap.txt' },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+    expect(r.stdout).toBe('Snapshot saved to /snap.txt\n');
+    expect(writeFile).toHaveBeenCalledWith('/snap.txt', 'SNAPSHOT-TEXT');
+  });
+});
+
+describe('framesHandler', () => {
+  it('requires a --tab flag', async () => {
+    const r = await framesHandler(createHandlerCtx());
+    expect(r.exitCode).toBe(1);
+  });
+
+  it('lists the main frame and child frames', async () => {
+    const { browser } = makeBrowser({
+      frames: [
+        { frameId: 'F1', url: 'https://x' },
+        { frameId: 'F2', parentFrameId: 'F1', url: 'https://x/iframe' },
+      ],
+    });
+    const r = await framesHandler(createHandlerCtx({ browser, flags: { tab: TAB } }));
+    expect(r.stdout).toContain('[main] F1');
+    expect(r.stdout).toContain('[child] F2 (parent: F1)');
+  });
+});
+
+describe('pdfHandler', () => {
+  it('saves a PDF to the default path', async () => {
+    const { browser } = makeBrowser({
+      sendImpl: (m) => (m === 'Page.printToPDF' ? { data: btoa('pdf') } : {}),
+    });
+    const writeFile = vi.fn(async () => undefined);
+    const r = await pdfHandler(
+      createHandlerCtx({
+        browser,
+        flags: { tab: TAB },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain('Saved PDF to /tmp/page-');
+    expect(writeFile).toHaveBeenCalledWith(expect.stringContaining('.pdf'), expect.any(Uint8Array));
+  });
+
+  it('surfaces a print failure', async () => {
+    const { browser } = makeBrowser({
+      sendImpl: (m) => {
+        if (m === 'Page.printToPDF') throw new Error('no printer');
+        return {};
+      },
+    });
+    const r = await pdfHandler(createHandlerCtx({ browser, flags: { tab: TAB }, fs: okFs() }));
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('pdf: no printer');
+  });
+});
+
+describe('screenshotHandler', () => {
+  it('captures the viewport and saves to the default path', async () => {
+    const { browser, screenshot } = makeBrowser();
+    const writeFile = vi.fn(async () => undefined);
+    const r = await screenshotHandler(
+      createHandlerCtx({
+        browser,
+        flags: { tab: TAB },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+    expect(r.stdout).toContain('Screenshot saved to /tmp/screenshot-');
+    expect(screenshot).toHaveBeenCalledWith(expect.objectContaining({ fullPage: false }));
+  });
+
+  it('clips to an element resolved by backendNodeId', async () => {
+    const { browser, screenshot } = makeBrowser({
+      sendImpl: (m) => {
+        if (m === 'DOM.resolveNode') return { object: { objectId: 'o1' } };
+        if (m === 'Runtime.callFunctionOn') {
+          return { result: { value: { x: 1, y: 2, width: 3, height: 4 } } };
+        }
+        return {};
+      },
+    });
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e5', 9]]) }));
+    const r = await screenshotHandler(
+      createHandlerCtx({ browser, state, positional: ['e5'], flags: { tab: TAB }, fs: okFs() })
+    );
+    expect(r.exitCode).toBe(0);
+    expect(screenshot).toHaveBeenCalledWith(
+      expect.objectContaining({ clip: { x: 1, y: 2, width: 3, height: 4 } })
+    );
+  });
+
+  it('warns when the element clip cannot be resolved', async () => {
+    const { browser } = makeBrowser({ evaluateResult: null });
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToSelector: new Map([['e5', '#a']]) }));
+    const r = await screenshotHandler(
+      createHandlerCtx({ browser, state, positional: ['e5'], flags: { tab: TAB }, fs: okFs() })
+    );
+    expect(r.stderr).toContain('could not clip to element e5');
+  });
+
+  it('throws when a ref screenshot has no snapshot', async () => {
+    const { browser } = makeBrowser();
+    await expect(
+      screenshotHandler(
+        createHandlerCtx({
+          browser,
+          state: createPlaywrightState(),
+          positional: ['e5'],
+          flags: { tab: TAB },
+          fs: okFs(),
+        })
+      )
+    ).rejects.toThrow('No snapshot');
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/state.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/state.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { VirtualFS } from '../../../../../src/fs/index.js';
+import {
+  stateLoadHandler,
+  stateSaveHandler,
+} from '../../../../../src/shell/supplemental-commands/playwright/handlers/state.js';
+import { createHandlerCtx, createMockBrowser } from '../../../helpers/playwright-harness.js';
+
+const TAB = 'tab-1';
+
+/** Runtime.evaluate reply helper. */
+const evalReply = (value: unknown) => ({ result: { value } });
+
+describe('state-save handler', () => {
+  it('requires a --tab flag', async () => {
+    const result = await stateSaveHandler(createHandlerCtx());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('--tab');
+  });
+
+  it('serializes cookies + localStorage to the default path', async () => {
+    const { browser, transport } = createMockBrowser({
+      sendCdpImpl: (method) =>
+        method === 'Network.getCookies' ? { cookies: [{ name: 'sid', value: '1' }] } : {},
+    });
+    transport.send.mockImplementation(async (_m: string, params?: Record<string, unknown>) => {
+      const expr = String(params?.['expression'] ?? '');
+      if (expr === 'location.origin') return evalReply('https://site.test');
+      if (expr.includes('Object.entries(localStorage)')) {
+        return evalReply(JSON.stringify([{ name: 'token', value: 'abc' }]));
+      }
+      return {};
+    });
+
+    const writeFile = vi.fn(async () => undefined);
+    const result = await stateSaveHandler(
+      createHandlerCtx({
+        browser,
+        flags: { tab: TAB },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('/.playwright/storage-state.json');
+    const [path, json] = writeFile.mock.calls[0] as unknown as [string, string];
+    expect(path).toBe('/.playwright/storage-state.json');
+    const parsed = JSON.parse(json);
+    expect(parsed.cookies).toEqual([{ name: 'sid', value: '1' }]);
+    expect(parsed.origins[0]).toEqual({
+      origin: 'https://site.test',
+      localStorage: [{ name: 'token', value: 'abc' }],
+    });
+  });
+
+  it('omits origins when the tab has no origin and honors --filename', async () => {
+    const { browser, transport } = createMockBrowser();
+    transport.send.mockImplementation(async (_m: string, params?: Record<string, unknown>) => {
+      const expr = String(params?.['expression'] ?? '');
+      if (expr === 'location.origin') return evalReply('');
+      return evalReply('[]');
+    });
+    const writeFile = vi.fn(async () => undefined);
+    const result = await stateSaveHandler(
+      createHandlerCtx({
+        browser,
+        flags: { tab: TAB, filename: '/custom.json' },
+        fs: { writeFile: writeFile as unknown as VirtualFS['writeFile'] },
+      })
+    );
+    expect(result.stdout).toContain('/custom.json');
+    const parsed = JSON.parse((writeFile.mock.calls[0] as unknown as [string, string])[1]);
+    expect(parsed.origins).toEqual([]);
+  });
+});
+
+describe('state-load handler', () => {
+  it('requires a filename', async () => {
+    const result = await stateLoadHandler(createHandlerCtx({ flags: { tab: TAB } }));
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('requires a filename');
+  });
+
+  it('requires a --tab flag', async () => {
+    const result = await stateLoadHandler(createHandlerCtx({ positional: ['/s.json'] }));
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('--tab');
+  });
+
+  it('reports a read failure', async () => {
+    const result = await stateLoadHandler(
+      createHandlerCtx({
+        positional: ['/missing.json'],
+        flags: { tab: TAB },
+        fs: {
+          readTextFile: (async () => {
+            throw new Error('ENOENT');
+          }) as unknown as VirtualFS['readTextFile'],
+        },
+      })
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Failed to read storage state');
+  });
+
+  it('restores cookies and matching-origin localStorage, skipping others', async () => {
+    const setCookies = vi.fn();
+    const { browser, transport } = createMockBrowser({
+      sendCdpImpl: (method, params) => {
+        if (method === 'Network.setCookies') setCookies(params);
+        return {};
+      },
+    });
+    transport.send.mockImplementation(async (_m: string, params?: Record<string, unknown>) => {
+      const expr = String(params?.['expression'] ?? '');
+      if (expr === 'location.origin') return evalReply('https://a.test');
+      return {};
+    });
+
+    const storageState = {
+      cookies: [{ name: 'sid', value: '1' }],
+      origins: [
+        { origin: 'https://a.test', localStorage: [{ name: 'k', value: 'v' }] },
+        { origin: 'https://b.test', localStorage: [{ name: 'x', value: 'y' }] },
+      ],
+    };
+    const result = await stateLoadHandler(
+      createHandlerCtx({
+        browser,
+        positional: ['/s.json'],
+        flags: { tab: TAB },
+        fs: {
+          readTextFile: (async () =>
+            JSON.stringify(storageState)) as unknown as VirtualFS['readTextFile'],
+        },
+      })
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Loaded storage state from /s.json');
+    expect(setCookies).toHaveBeenCalledWith({ cookies: storageState.cookies });
+    expect(result.stderr).toContain(
+      'Skipped localStorage for non-matching origins: https://b.test'
+    );
+    // The matching origin's setItem script was evaluated.
+    const evaluatedItemScript = transport.send.mock.calls.some(
+      (c) =>
+        typeof c[1] === 'object' &&
+        String((c[1] as { expression?: string }).expression).includes('localStorage.setItem')
+    );
+    expect(evaluatedItemScript).toBe(true);
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/theme-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/theme-command.test.ts
@@ -1,0 +1,201 @@
+import type { IFileSystem } from 'just-bash';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createThemeCommand } from '../../../src/shell/supplemental-commands/theme-command.js';
+import { mockCommandContext } from '../helpers/mock-command-context.js';
+
+const hoisted = vi.hoisted(() => ({
+  client: null as { call: ReturnType<typeof vi.fn> } | null,
+}));
+
+vi.mock('../../../src/kernel/panel-rpc.js', () => ({
+  getPanelRpcClient: () => hoisted.client,
+}));
+
+function withClient(callImpl?: (...args: unknown[]) => unknown) {
+  const call = vi.fn(callImpl ?? (async () => ({ applied: 'Vanilla' })));
+  hoisted.client = { call };
+  return call;
+}
+
+const validTheme = JSON.stringify({
+  id: 'custom',
+  name: 'Custom',
+  base: 'dark',
+  tokens: { '--s2-gray-25': '#000' },
+});
+
+describe('theme command', () => {
+  beforeEach(() => {
+    hoisted.client = null;
+  });
+
+  it('has correct name', () => {
+    expect(createThemeCommand().name).toBe('theme');
+  });
+
+  it('shows help with no args, --help, and -h', async () => {
+    const cmd = createThemeCommand();
+    for (const args of [[], ['--help'], ['-h']]) {
+      const result = await cmd.execute(args, mockCommandContext());
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('usage: theme');
+    }
+  });
+
+  it('lists presets', async () => {
+    const result = await createThemeCommand().execute(['list'], mockCommandContext());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Presets:');
+    expect(result.stdout).toContain('vanilla');
+  });
+
+  it('reports where to see the current theme', async () => {
+    const result = await createThemeCommand().execute(['current'], mockCommandContext());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Theme settings dialog');
+  });
+
+  it('errors on an unknown subcommand', async () => {
+    const result = await createThemeCommand().execute(['bogus'], mockCommandContext());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('unknown subcommand "bogus"');
+  });
+
+  describe('reset', () => {
+    it('errors without a panel-RPC connection', async () => {
+      const result = await createThemeCommand().execute(['reset'], mockCommandContext());
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('no panel-RPC connection');
+    });
+
+    it('resets to the default theme via panel-RPC', async () => {
+      const call = withClient();
+      const result = await createThemeCommand().execute(['reset'], mockCommandContext());
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('Theme reset to default.\n');
+      expect(call).toHaveBeenCalledWith('theme-apply', { action: 'reset' });
+    });
+  });
+
+  describe('apply', () => {
+    it('errors when no id or path is given', async () => {
+      withClient();
+      const result = await createThemeCommand().execute(['apply'], mockCommandContext());
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('missing theme id or path');
+    });
+
+    it('errors without a panel-RPC connection', async () => {
+      const result = await createThemeCommand().execute(['apply', 'vanilla'], mockCommandContext());
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('no panel-RPC connection');
+    });
+
+    it('applies a known preset by id', async () => {
+      const call = withClient();
+      const result = await createThemeCommand().execute(['apply', 'vanilla'], mockCommandContext());
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('Applied theme: Vanilla\n');
+      const [op, payload] = call.mock.calls[0] as [string, { themeJson: string; action: string }];
+      expect(op).toBe('theme-apply');
+      expect(payload).toMatchObject({ action: 'apply' });
+      expect(JSON.parse(payload.themeJson).id).toBe('vanilla');
+    });
+
+    it('errors when the target is neither a preset nor an existing file', async () => {
+      withClient();
+      const ctx = mockCommandContext({
+        fs: {
+          readFile: (async () => {
+            throw new Error('ENOENT');
+          }) as IFileSystem['readFile'],
+        },
+      });
+      const result = await createThemeCommand().execute(['apply', 'missing.json'], ctx);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('not a known preset id and file not found');
+    });
+
+    it('errors when the file is not valid JSON', async () => {
+      withClient();
+      const ctx = mockCommandContext({
+        fs: { readFile: (async () => 'not json') as IFileSystem['readFile'] },
+      });
+      const result = await createThemeCommand().execute(['apply', 'bad.json'], ctx);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('not valid JSON');
+    });
+
+    it('errors when the theme file is missing required fields', async () => {
+      withClient();
+      const ctx = mockCommandContext({
+        fs: {
+          readFile: (async () => JSON.stringify({ id: 'x' })) as IFileSystem['readFile'],
+        },
+      });
+      const result = await createThemeCommand().execute(['apply', 'partial.json'], ctx);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('invalid theme file');
+    });
+
+    it('applies a valid theme file from the VFS', async () => {
+      const call = withClient(async () => ({ applied: 'Custom' }));
+      const ctx = mockCommandContext({
+        fs: { readFile: (async () => validTheme) as IFileSystem['readFile'] },
+      });
+      const result = await createThemeCommand().execute(['apply', 'custom.json'], ctx);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('Applied theme: Custom\n');
+      expect(call).toHaveBeenCalledWith('theme-apply', {
+        themeJson: validTheme,
+        action: 'apply',
+      });
+    });
+  });
+
+  describe('export', () => {
+    it('errors with fewer than two args', async () => {
+      const result = await createThemeCommand().execute(
+        ['export', 'vanilla'],
+        mockCommandContext()
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('usage: theme export');
+    });
+
+    it('errors for an unknown preset id', async () => {
+      const result = await createThemeCommand().execute(
+        ['export', 'nope', '/out.json'],
+        mockCommandContext()
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('unknown preset id "nope"');
+    });
+
+    it('exports a preset to a VFS path', async () => {
+      const writeFile = vi.fn(async () => undefined);
+      const ctx = mockCommandContext({
+        fs: { writeFile: writeFile as unknown as IFileSystem['writeFile'] },
+      });
+      const result = await createThemeCommand().execute(['export', 'vanilla', 'theme.json'], ctx);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Exported "Vanilla" to /home/theme.json');
+      const [path, contents] = writeFile.mock.calls[0] as unknown[];
+      expect(path).toBe('/home/theme.json');
+      expect(JSON.parse(contents as string).id).toBe('vanilla');
+    });
+
+    it('surfaces a write failure', async () => {
+      const ctx = mockCommandContext({
+        fs: {
+          writeFile: (async () => {
+            throw new Error('disk full');
+          }) as unknown as IFileSystem['writeFile'],
+        },
+      });
+      const result = await createThemeCommand().execute(['export', 'vanilla', 'theme.json'], ctx);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('write failed: disk full');
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds unit tests for 11 previously under-tested `packages/webapp` shell files, plus a reusable test harness for the playwright-cli handlers. Test-only change — no production code is modified.

### Shell commands
| File | Lines before → after |
|------|----------------------|
| `shell/supplemental-commands/fswatch-command.ts` | 4.6% → 100% |
| `shell/supplemental-commands/theme-command.ts` | 3.4% → 100% |
| `shell/supplemental-commands/pdftk-command.ts` | 39% → 97% |
| `shell/supplemental-commands/esbuild-command.ts` | 45% → 93% |

### Playwright handlers
| File | Lines before → after |
|------|----------------------|
| `playwright/handlers/network-requests.ts` | 55% → 85% |
| `playwright/handlers/state.ts` | 4% → 100% |
| `playwright/handlers/interaction.ts` | 71% → 80% |
| `playwright/handlers/mouse.ts` | 79% → 96% |
| `playwright/handlers/routing.ts` | 82% → 93% |
| `playwright/handlers/devtools.ts` | 77% → 96% |
| `playwright/handlers/snapshot.ts` | 69% → 97% |

### Test harness
`tests/shell/helpers/playwright-harness.ts` provides a mock `BrowserAPI` + `CDPTransport` (with an event-emit driver for CDP event handlers), an empty `PlaywrightState` factory, and a `createHandlerCtx` builder. The seven handler suites share it.

## How it's tested

- `fswatch`/`theme` had no test file; the rest only exercised argument parsing or happy paths. New tests cover operation bodies and error branches: `fswatch` via the `globalThis` watcher hook, `theme` via a mocked panel-RPC client, `pdftk` via mocked `@cantoo/pdf-lib`/`unpdf`, `esbuild` via a mocked `getEsbuild` wasm loader plus the VFS resolver plugin.
- Playwright handlers run against the mock browser/transport; the network-requests and routing suites drive captured CDP events (`Network.*`, `Fetch.requestPaused`) through the harness emitter.

## Notes

- 195 tests pass across the 11 files (2 heavy-wasm esbuild tests stay skipped behind `SLICC_TEST_HEAVY_WASM`, matching the existing gate).
- Commits are one-file-each for review and rollback.
- The `webapp` per-package coverage floor will rise via the nightly ratchet once CI measures these files.
