### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -23,7 +23,7 @@
       "lines": 82,
       "statements": 79,
       "functions": 84,
-      "branches": 69,
+      "branches": 70,
       "coverageExclude": [
         "**/node_modules/**",
         "**/dist/**",
@@ -109,9 +109,9 @@
     },
     "shared": {
       "lines": 95,
-      "statements": 93,
+      "statements": 94,
       "functions": 93,
-      "branches": 86
+      "branches": 87
     },
     "webcomponents": {
       "lines": 95,
@@ -128,7 +128,7 @@
   },
   "swift": {
     "swift-server": {
-      "lines": 59,
+      "lines": 60,
       "functions": 58,
       "regions": 57
     },


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.