### PR TITLE
Fix terminal panel erasing command output that lacks a trailing newline

### DIFF
--- a/packages/webapp/src/kernel/remote-terminal-view.ts
+++ b/packages/webapp/src/kernel/remote-terminal-view.ts
@@ -173,6 +173,14 @@ export class RemoteTerminalView {
   private programmaticResolve: ((result: TerminalExecResult) => void) | null = null;
   private isExecuting = false;
   /**
+   * Resolves when the prompt loop has entered `readline.read()` and is
+   * ready to accept programmatic input. `executeCommandInTerminal`
+   * awaits this so the `\r` it feeds is never lost in the async gap
+   * between `ensurePromptLineStart` and `readline.read()`.
+   */
+  private promptReady: Promise<void> = Promise.resolve();
+  private resolvePromptReady: (() => void) | null = null;
+  /**
    * When true, the `handleEvent` route swallows `terminal-output`
    * events so they don't render in the visible buffer. Used by
    * `handleTab()` to run `compgen` silently — the `client.exec`
@@ -279,6 +287,10 @@ export class RemoteTerminalView {
     if (this.isExecuting || this.programmaticResolve || this.readline.getLine().length > 0) {
       return { stdout: '', stderr: 'terminal is busy; finish current input first\n', exitCode: 1 };
     }
+    // Wait for the prompt loop to finish the line-start guard and enter
+    // readline.read() — otherwise the \r we feed below arrives before
+    // readline is listening and gets silently consumed by xterm.
+    await this.promptReady;
     // Render the command in the active prompt line and commit it through
     // readline (as if the user typed it, then Enter). The prompt loop's
     // `processLine` runs it and resolves this promise with the result.
@@ -399,6 +411,11 @@ export class RemoteTerminalView {
       // feeds a line, so a non-null resolver marks THIS line as a
       // programmatic (gesture-less) invocation.
       const programmatic = this.programmaticResolve !== null;
+      // Refresh the gate so the next `executeCommandInTerminal` waits
+      // for the guard + readline.read() to re-enter.
+      this.promptReady = new Promise<void>((r) => {
+        this.resolvePromptReady = r;
+      });
       const result = await this.processLine(line, programmatic);
       // Hand the result to that programmatic caller (the chat-panel
       // "run in terminal" / E2E seam).
@@ -420,7 +437,25 @@ export class RemoteTerminalView {
     const aborted = new Promise<never>((_resolve, reject) => {
       this.abortPromptLoop = reject;
     });
-    return Promise.race([this.readline.read(PROMPT), aborted]);
+    return Promise.race([this.readAfterLineGuard(), aborted]);
+  }
+
+  /**
+   * Guard the partial output line, then hand the row to readline.
+   *
+   * Command output that does not end in a newline (`echo -n foo`, `cat`
+   * of a file lacking a trailing `\n`) leaves the cursor mid-row, and
+   * readline's prompt redraw erases that row — the output became
+   * invisible (#1583). Flush pending writes first so `cursorX` reflects
+   * everything `handleEvent` streamed, then start the prompt on a fresh
+   * row only when needed.
+   */
+  private async readAfterLineGuard(): Promise<string> {
+    if (this.terminal) await ensurePromptLineStart(this.terminal);
+    if (!this.readline) throw new Error('readline not mounted');
+    // Signal that readline is about to start listening for input.
+    if (this.resolvePromptReady) this.resolvePromptReady();
+    return this.readline.read(PROMPT);
   }
 
   /**
@@ -1077,6 +1112,32 @@ export function buildCompgenPlan(beforeCursor: string): {
   const escaped = bashSingleQuote(currentWord);
   const compgenCmd = isFirstWord ? `compgen -A command -- ${escaped}` : `compgen -f -- ${escaped}`;
   return { currentWord, isFirstWord, compgenCmd };
+}
+
+/**
+ * Minimal slice of xterm's `Terminal` needed by `ensurePromptLineStart`.
+ * Lets the guard be unit-tested with a fake instead of a real xterm.
+ */
+export interface PromptLineGuardTerminal {
+  write(data: string, callback?: () => void): void;
+  buffer: { active: { cursorX: number } };
+}
+
+/**
+ * Move the cursor to a fresh row before a prompt redraw when a partial
+ * (newline-less) output line occupies the current one (#1583).
+ *
+ * xterm processes writes asynchronously, so the zero-byte write acts as
+ * a flush barrier: its callback fires only after previously queued
+ * output has been parsed, making `cursorX` trustworthy. `\r\n` is only
+ * emitted when the cursor sits mid-row, so empty prompt-to-prompt
+ * iterations stay single-spaced.
+ */
+export async function ensurePromptLineStart(terminal: PromptLineGuardTerminal): Promise<void> {
+  await new Promise<void>((resolve) => terminal.write('', resolve));
+  if (terminal.buffer.active.cursorX > 0) {
+    await new Promise<void>((resolve) => terminal.write('\r\n', resolve));
+  }
 }
 
 /**

--- a/packages/webapp/tests/kernel/remote-terminal-prompt-line-guard.test.ts
+++ b/packages/webapp/tests/kernel/remote-terminal-prompt-line-guard.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ensurePromptLineStart,
+  type PromptLineGuardTerminal,
+} from '../../src/kernel/remote-terminal-view.js';
+
+/**
+ * Fake xterm capturing writes. Mirrors xterm's async write queue: every
+ * callback is deferred to a macrotask, and `flushCursorX` (when set)
+ * only takes effect once the first flush write's callback runs —
+ * simulating queued-but-unparsed output bytes (#1583).
+ */
+function makeTerminal(options: { cursorX: number; flushCursorX?: number }) {
+  const writes: string[] = [];
+  const terminal: PromptLineGuardTerminal = {
+    buffer: { active: { cursorX: options.cursorX } },
+    write(data, callback) {
+      writes.push(data);
+      setTimeout(() => {
+        if (options.flushCursorX !== undefined) {
+          terminal.buffer.active.cursorX = options.flushCursorX;
+          options.flushCursorX = undefined;
+        }
+        callback?.();
+      }, 0);
+    },
+  };
+  return { terminal, writes };
+}
+
+describe('ensurePromptLineStart (#1583)', () => {
+  it('writes \\r\\n when a partial output line left the cursor mid-row', async () => {
+    // `echo -n ABC123` → cursor sits at column 6 when the prompt redraws.
+    const { terminal, writes } = makeTerminal({ cursorX: 6 });
+    await ensurePromptLineStart(terminal);
+    expect(writes).toEqual(['', '\r\n']);
+  });
+
+  it('leaves the row untouched when output ended with a newline', async () => {
+    const { terminal, writes } = makeTerminal({ cursorX: 0 });
+    await ensurePromptLineStart(terminal);
+    expect(writes).toEqual(['']);
+  });
+
+  it('reads cursorX only after the flush barrier settles queued output', async () => {
+    // Cursor reports column 0 now, but queued (unparsed) output will land
+    // it at column 8 — the guard must wait for the flush write's callback
+    // before deciding, or it would skip the newline and lose the line.
+    const { terminal, writes } = makeTerminal({ cursorX: 0, flushCursorX: 8 });
+    await ensurePromptLineStart(terminal);
+    expect(writes).toEqual(['', '\r\n']);
+  });
+});


### PR DESCRIPTION
Fixes #1583

## Problem

`echo -n ABC123` or `cat` of a file without a final newline showed **nothing** in the interactive Terminal panel: the output bytes arrived (`cat file; echo TAIL` proved it), but xterm-readline's prompt redraw starts with a carriage-return/line-clear and erased the unterminated row. The chat-panel shell tool was unaffected (captured stdout, not the rendered terminal).

## Fix

`runPromptLoop` → `readNextLine` now goes through `readAfterLineGuard`, which calls the new exported `ensurePromptLineStart(terminal)`:

1. zero-byte `write('')` as a flush barrier — its callback fires only after xterm parsed all queued output, so `buffer.active.cursorX` is trustworthy;
2. writes `\r\n` **only** when the cursor sits mid-row, so empty prompt iterations stay single-spaced.

The dispose-abort race in `readNextLine` is preserved (abort promise registered before the guard runs).

## Tests

`packages/webapp/tests/kernel/remote-terminal-prompt-line-guard.test.ts` — 3 cases against a fake terminal with xterm-style async writes: mid-row → `\r\n`, column-0 → untouched, and cursorX read **only after** the flush barrier (queued-output simulation).