### PR TITLE
fix(deps): pin e2b <2.33.0 (workerd createRequire) + split Renovate updates one-per-PR

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -1158,8 +1158,8 @@ The tray-hub worker (`slicc-tray-hub`) bundles the **e2b SDK** — its
 and e2b enters the worker bundle transitively through `@slicc/cloud-core`
 (`packages/cloud-core` depends on `e2b`).
 
-**e2b `2.33.0` broke this.** Its build began emitting an esbuild ESM-interop
-shim at the top of `dist/index.mjs`:
+**e2b `2.33.0` broke this.** Its build began emitting an ESM-interop shim
+(from its bundler, Rolldown) at the top of `dist/index.mjs`:
 
 ```js
 import { createRequire } from 'node:module';

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -1150,6 +1150,44 @@ and Vite injects `vite:preloadError` only into the PAGE bundle — so a `window`
 listener alone can't catch it. Recovery is the four-trigger guarded reload in
 `core/stale-asset-channel.ts` + `ui/boot/setup-preload-error-reload.ts`.
 
+## e2b SDK in the Worker: `createRequire` Breaks workerd (pin < 2.33.0)
+
+The tray-hub worker (`slicc-tray-hub`) bundles the **e2b SDK** — its
+`CloudSessionsDurableObject` drives the cloud-cone lifecycle
+(`createSubstrate('e2b', …)` → `startCone`/`resumeCone`/`pauseCone`/`killCone`),
+and e2b enters the worker bundle transitively through `@slicc/cloud-core`
+(`packages/cloud-core` depends on `e2b`).
+
+**e2b `2.33.0` broke this.** Its build began emitting an esbuild ESM-interop
+shim at the top of `dist/index.mjs`:
+
+```js
+import { createRequire } from 'node:module';
+var __require = /* #__PURE__ */ (() => createRequire(import.meta.url))();
+```
+
+This runs at **module-eval time**. Under Cloudflare **workerd**, `import.meta.url`
+is `undefined`, so `createRequire(undefined)` throws
+`TypeError: The argument 'path' … Received 'undefined'` the instant the worker is
+instantiated — before any request. That kills both `wrangler dev` (the webapp E2E
+web-server can't start) and `wrangler deploy` (Cloudflare's API rejects the
+version with validation error 10021). e2b `2.32.x` had no such shim (a clean
+worker bundle has **zero** `createRequire`), and the SDK is otherwise
+fetch-based (`openapi-fetch` + `@connectrpc/connect-web`), so it runs in workerd
+fine — this is purely a build-artifact regression, and it persists through the
+latest e2b (checked 2.33.1 / 2.34.0 / 2.35.0).
+
+**Mitigation:** `e2b` is capped `>=2.23.0 <2.33.0` in `packages/cloud-core` and
+`packages/node-server`, plus an `allowedVersions: "<2.33.0"` rule in
+`renovate.json` so Renovate stops proposing it. Node runtimes (node-server
+`--cloud`) don't hit the crash — `createRequire(import.meta.url)` works in
+Node — but both are capped to keep a single hoisted version and avoid churn.
+Drop the cap once e2b makes the shim lazy (init on first `__require` use) or
+ships an edge/browser export. Do **not** un-bundle e2b from the worker as a
+"fix": the worker genuinely calls the SDK at runtime, so that would mean
+relocating the whole cloud-cone lifecycle off workerd (architectural), not a
+bundling tweak.
+
 ## Biome Build-Asset Strip: Cloudflare 25 MiB Cap
 
 `wasm-bindgen`'s `new URL('biome_wasm_bg.wasm', import.meta.url)` fallback causes

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "packages/swift-optel"
       ],
       "dependencies": {
-        "e2b": "^2.23.0",
+        "e2b": ">=2.23.0 <2.33.0",
         "express": "^5.0.0",
         "pyodide": "314.0.2",
         "ws": "^8.18.0"
@@ -20908,7 +20908,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@slicc/shared-ts": "*",
-        "e2b": "^2.23.0"
+        "e2b": ">=2.23.0 <2.33.0"
       },
       "devDependencies": {
         "@types/node": "^24.12.4",
@@ -20932,7 +20932,7 @@
       "dependencies": {
         "@slicc/cloud-core": "*",
         "@slicc/shared-ts": "*",
-        "e2b": "^2.23.0"
+        "e2b": ">=2.23.0 <2.33.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "lint:hosted-origin": "node packages/dev-tools/tools/check-hosted-origin-literal.mjs"
   },
   "dependencies": {
-    "e2b": "^2.23.0",
+    "e2b": ">=2.23.0 <2.33.0",
     "express": "^5.0.0",
     "pyodide": "314.0.2",
     "ws": "^8.18.0"

--- a/packages/cloud-core/package.json
+++ b/packages/cloud-core/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@slicc/shared-ts": "*",
-    "e2b": "^2.23.0"
+    "e2b": ">=2.23.0 <2.33.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.4",

--- a/packages/cloud-core/tests/e2b-workerd-pin.test.ts
+++ b/packages/cloud-core/tests/e2b-workerd-pin.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Regression guard for the e2b 2.33.0 / Cloudflare workerd incompatibility.
+//
+// e2b >=2.33.0 emits a top-level `createRequire(import.meta.url)` esbuild
+// ESM-interop shim in dist/index.mjs. That runs at module-eval time and throws
+// under workerd (`import.meta.url` is undefined there), crashing the tray-hub
+// worker at startup — the worker bundles e2b via @slicc/cloud-core. e2b is
+// therefore capped `>=2.23.0 <2.33.0` in the root, cloud-core, and node-server
+// package.json, plus an allowedVersions rule in renovate.json.
+//
+// If this test fails, either a cap was removed/raised or e2b resolved to
+// >=2.33.0. Do NOT lift the cap until e2b makes the shim lazy (init on first
+// use) or ships an edge/browser export — see docs/pitfalls.md
+// ("e2b SDK in the Worker: createRequire Breaks workerd").
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+function resolvedE2bVersion(): string {
+  const raw = readFileSync(resolve(repoRoot, 'package-lock.json'), 'utf8');
+  const lock = JSON.parse(raw) as {
+    packages: Record<string, { version?: string }>;
+  };
+  const version = lock.packages['node_modules/e2b']?.version;
+  if (!version) throw new Error('e2b entry not found in package-lock.json');
+  return version;
+}
+
+function isBelow2_33(version: string): boolean {
+  const [major, minor] = version.split('.').map((n) => Number.parseInt(n, 10));
+  return major < 2 || (major === 2 && minor < 33);
+}
+
+describe('e2b workerd pin', () => {
+  it('resolves e2b below 2.33.0 (workerd createRequire incompatibility)', () => {
+    const version = resolvedE2bVersion();
+    expect(
+      isBelow2_33(version),
+      `e2b resolved to ${version}; it must stay <2.33.0 until the workerd ` +
+        `createRequire shim is fixed (see docs/pitfalls.md).`
+    ).toBe(true);
+  });
+});

--- a/packages/cloud-core/tests/e2b-workerd-pin.test.ts
+++ b/packages/cloud-core/tests/e2b-workerd-pin.test.ts
@@ -5,12 +5,12 @@ import { describe, expect, it } from 'vitest';
 
 // Regression guard for the e2b 2.33.0 / Cloudflare workerd incompatibility.
 //
-// e2b >=2.33.0 emits a top-level `createRequire(import.meta.url)` esbuild
-// ESM-interop shim in dist/index.mjs. That runs at module-eval time and throws
-// under workerd (`import.meta.url` is undefined there), crashing the tray-hub
-// worker at startup — the worker bundles e2b via @slicc/cloud-core. e2b is
-// therefore capped `>=2.23.0 <2.33.0` in the root, cloud-core, and node-server
-// package.json, plus an allowedVersions rule in renovate.json.
+// e2b >=2.33.0 emits a top-level `createRequire(import.meta.url)` ESM-interop
+// shim in dist/index.mjs (from its bundler, Rolldown). That runs at module-eval
+// time and throws under workerd (`import.meta.url` is undefined there), crashing
+// the tray-hub worker at startup — the worker bundles e2b via @slicc/cloud-core.
+// e2b is therefore capped `>=2.23.0 <2.33.0` in the root, cloud-core, and
+// node-server package.json, plus an allowedVersions rule in renovate.json.
 //
 // If this test fails, either a cap was removed/raised or e2b resolved to
 // >=2.33.0. Do NOT lift the cap until e2b makes the shim lazy (init on first
@@ -18,14 +18,21 @@ import { describe, expect, it } from 'vitest';
 // ("e2b SDK in the Worker: createRequire Breaks workerd").
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
-function resolvedE2bVersion(): string {
+// Every e2b install in the tree: the hoisted copy plus any nested
+// packages/*/node_modules/e2b a future uncapped consumer could force in.
+function resolvedE2bVersions(): string[] {
   const raw = readFileSync(resolve(repoRoot, 'package-lock.json'), 'utf8');
   const lock = JSON.parse(raw) as {
     packages: Record<string, { version?: string }>;
   };
-  const version = lock.packages['node_modules/e2b']?.version;
-  if (!version) throw new Error('e2b entry not found in package-lock.json');
-  return version;
+  const versions = Object.entries(lock.packages)
+    .filter(([key]) => key === 'node_modules/e2b' || key.endsWith('/node_modules/e2b'))
+    .map(([, entry]) => entry.version)
+    .filter((v): v is string => typeof v === 'string');
+  if (versions.length === 0) {
+    throw new Error('no e2b entry found in package-lock.json');
+  }
+  return versions;
 }
 
 function isBelow2_33(version: string): boolean {
@@ -34,12 +41,13 @@ function isBelow2_33(version: string): boolean {
 }
 
 describe('e2b workerd pin', () => {
-  it('resolves e2b below 2.33.0 (workerd createRequire incompatibility)', () => {
-    const version = resolvedE2bVersion();
-    expect(
-      isBelow2_33(version),
-      `e2b resolved to ${version}; it must stay <2.33.0 until the workerd ` +
-        `createRequire shim is fixed (see docs/pitfalls.md).`
-    ).toBe(true);
+  it('resolves every e2b install below 2.33.0 (workerd createRequire incompatibility)', () => {
+    for (const version of resolvedE2bVersions()) {
+      expect(
+        isBelow2_33(version),
+        `e2b resolved to ${version}; every install must stay <2.33.0 until the ` +
+          `workerd createRequire shim is fixed (see docs/pitfalls.md).`
+      ).toBe(true);
+    }
   });
 });

--- a/packages/node-server/package.json
+++ b/packages/node-server/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@slicc/cloud-core": "*",
     "@slicc/shared-ts": "*",
-    "e2b": "^2.23.0"
+    "e2b": ">=2.23.0 <2.33.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "automergeType": "pr",
   "platformAutomerge": true,
   "minimumReleaseAge": "7 days",
+  "prHourlyLimit": 4,
   "internalChecksFilter": "strict",
   "vulnerabilityAlerts": {
     "minimumReleaseAge": "0 days",
@@ -20,7 +21,7 @@
       "rangeStrategy": "pin"
     },
     {
-      "description": "Hold e2b below 2.33.0: that release added a top-level `createRequire(import.meta.url)` (esbuild ESM-interop shim) that throws under Cloudflare workerd (import.meta.url is undefined), crashing the tray-hub worker at startup — e2b is bundled into the worker via @slicc/cloud-core. The range cap in packages/cloud-core and packages/node-server enforces it; drop this once e2b makes the shim lazy/guarded. See docs/pitfalls.md.",
+      "description": "Hold e2b below 2.33.0: that release added a top-level `createRequire(import.meta.url)` (ESM-interop shim from its bundler, Rolldown) that throws under Cloudflare workerd (import.meta.url is undefined), crashing the tray-hub worker at startup — e2b is bundled into the worker via @slicc/cloud-core. The range cap in the root, packages/cloud-core, and packages/node-server enforces it; drop this once e2b makes the shim lazy/guarded. See docs/pitfalls.md.",
       "matchPackageNames": ["e2b"],
       "allowedVersions": "<2.33.0"
     },

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "description": [
+    "Dependency updates are intentionally NOT grouped into one 'non-major' PR — each package updates in its own PR so a breaking transitive bump fails in isolation and is trivial to identify (see the e2b 2.33.0 / Cloudflare workerd incident). Keep the purposeful cohesion groups below (semantic-release, xterm, earendil-works, just-bash, patched dependencies); do not re-add a broad catch-all group."
+  ],
   "rebaseWhen": "conflicted",
   "automerge": true,
   "automergeType": "pr",
@@ -17,9 +20,9 @@
       "rangeStrategy": "pin"
     },
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "groupName": "non-major dependencies",
-      "groupSlug": "non-major"
+      "description": "Hold e2b below 2.33.0: that release added a top-level `createRequire(import.meta.url)` (esbuild ESM-interop shim) that throws under Cloudflare workerd (import.meta.url is undefined), crashing the tray-hub worker at startup — e2b is bundled into the worker via @slicc/cloud-core. The range cap in packages/cloud-core and packages/node-server enforces it; drop this once e2b makes the shim lazy/guarded. See docs/pitfalls.md.",
+      "matchPackageNames": ["e2b"],
+      "allowedVersions": "<2.33.0"
     },
     {
       "matchPackagePrefixes": ["@semantic-release/"],


### PR DESCRIPTION
## Problem

The grouped Renovate PR **#1585** went red on `webapp` (E2E) and `Deploy staging + smoke test`. Root cause: a transitive bump of **`e2b` 2.32.0 → 2.33.0** (bundled into the tray-hub worker `slicc-tray-hub` via `@slicc/cloud-core`, whose `CloudSessionsDurableObject` drives the cloud-cone lifecycle at runtime).

e2b **2.33.0** started emitting an ESM-interop shim (from its bundler, Rolldown) at the top of `dist/index.mjs`:
```js
import { createRequire } from "node:module";
var __require = /* #__PURE__ */ (() => createRequire(import.meta.url))();
```
It runs at **module-eval time**, and under Cloudflare **workerd** `import.meta.url` is `undefined`, so `createRequire(undefined)` throws the instant the worker is instantiated — before any request. That breaks `wrangler dev` (webapp E2E web-server can't start) and `wrangler deploy` (Cloudflare validation error 10021).

e2b **2.32.x** has no such shim (a clean worker bundle has **zero** `createRequire`), and the SDK is otherwise fetch-based (`openapi-fetch` + `@connectrpc/connect-web`), so it runs in workerd fine. This is purely an upstream build-artifact regression — and it **persists through the latest** e2b (verified 2.33.1 / 2.34.0 / 2.35.0), so upgrading forward does not fix it.

Full trace: this is why the *same* `renovate/non-major` branch passed staging on 07-18/19/20 and only failed 07-21 (the day e2b 2.33.0 entered the re-resolved lockfile).

## Fix (option #1: pin)

- Cap `e2b` `>=2.23.0 <2.33.0` in **root**, **cloud-core**, and **node-server** `package.json` → single hoisted `2.32.0`, no version churn in the lockfile (only the range strings change).
- Add a `renovate.json` `allowedVersions: "<2.33.0"` rule for `e2b` (with rationale) so Renovate stops proposing `>=2.33.0`.
- **Regression guard**: `packages/cloud-core/tests/e2b-workerd-pin.test.ts` asserts the resolved e2b stays `<2.33.0` (proven to catch 2.33.0/2.33.1/2.34.0/2.35.0).

We deliberately **do not** un-bundle e2b from the worker: the worker genuinely calls the SDK at runtime, so that would mean relocating the whole cloud-cone lifecycle off workerd (architectural), not a bundling tweak. Node runtimes (`node-server --cloud`) don't hit the crash but are capped too, to keep one hoisted version and avoid churn. Drop the cap once e2b makes the shim lazy or ships an edge/browser export (worth filing upstream).

## Renovate: one update per PR

The `#1585` confusion came from the broad **"non-major dependencies"** catch-all group bundling a dozen updates into one PR. This PR removes that group so **each dependency updates in its own PR** — a breaking transitive bump then fails *in isolation* and is trivial to identify, and can't block unrelated safe updates. The purposeful cohesion groups are kept (`semantic-release`, `xterm`, `@earendil-works/*`, `just-bash`, patched dependencies). We add an explicit `prHourlyLimit: 4`, and the 7-day `minimumReleaseAge` cooldown + `automerge` keep the PR volume in check.

Once this lands, Renovate closes the now-obsolete grouped #1585 and reopens isolated per-dependency PRs; the e2b one won't propose 2.33.0 (capped).

## Docs
`docs/pitfalls.md` → new **"e2b SDK in the Worker: `createRequire` Breaks workerd"** section.

## Verification
| Check | Result |
| --- | --- |
| Worker dry-run bundle `createRequire` count | ✅ 0 (was throwing on 2.33.0) |
| `wrangler dev` boot | ✅ `Ready on http://127.0.0.1:8798`, no throw |
| Regression guard test | ✅ passes; catches ≥2.33.0 |
| cloud-core tests + coverage floor | ✅ exit 0 (103 tests) |
| `renovate-config-validator` | ✅ "Config validated successfully" |
| lint:docs / biome / prettier / cloud-core typecheck | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
