### PR TITLE
ci(renovate): gitIgnoredAuthors for the reconcile bot (keep auto-rebase on amended PRs)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "description": [
-    "Dependency updates are intentionally NOT grouped into one 'non-major' PR — each package updates in its own PR so a breaking transitive bump fails in isolation and is trivial to identify (see the e2b 2.33.0 / Cloudflare workerd incident). Keep the purposeful cohesion groups below (semantic-release, xterm, earendil-works, just-bash, patched dependencies); do not re-add a broad catch-all group."
+    "Dependency updates are intentionally NOT grouped into one 'non-major' PR — each package updates in its own PR so a breaking transitive bump fails in isolation and is trivial to identify (see the e2b 2.33.0 / Cloudflare workerd incident). Keep the purposeful cohesion groups below (semantic-release, xterm, earendil-works, just-bash, patched dependencies); do not re-add a broad catch-all group.",
+    "gitIgnoredAuthors is the github-actions[bot] identity that the renovate-format-reconcile and renovate-patch-reconcile workflows push their reflow/reconcile commits as. Listing it here stops Renovate treating those commits as a 'someone else edited this PR' foreign edit — without it Renovate posts an Edited/Blocked notice and disables auto-rebase on the amended PR (automerge still fires once green; see #1602). Keep in sync with the `git config user.email` in those two workflows."
   ],
   "rebaseWhen": "conflicted",
+  "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"],
   "automerge": true,
   "automergeType": "pr",
   "platformAutomerge": true,


### PR DESCRIPTION
## Problem

Follow-up to #1606. The `renovate-format-reconcile` (and existing `renovate-patch-reconcile`) workflows push their reflow/reconcile commits as **`github-actions[bot]`**. Renovate treats a commit it doesn't recognize as *"someone else edited this PR"* and:

- posts an **"Edited/Blocked" notice**, and
- **disables auto-rebase** for that PR.

Observed live on **#1602** (biome 2.5.4): the format-reconcile reflow pushed → lint went green → Renovate still **automerged** it (`e88c9818a`), so the merge wasn't blocked — but Renovate posted the notice at 09:50 and would no longer auto-rebase the branch. A reflowed formatter-bump PR that *later* goes stale/conflicted would then get stuck (Renovate won't rebase a branch it thinks was hand-edited).

## Fix

Add the bot's author email to Renovate's [`gitIgnoredAuthors`](https://docs.renovatebot.com/configuration-options/#gitignoredauthors):

```json
"gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"]
```

Renovate then ignores those commits when detecting edits → no "Edited/Blocked" notice, and **auto-rebase stays enabled** on reflowed/reconciled PRs. Both companion workflows push under this same identity (`git config user.email` in each), so it covers both. `renovate-config-validator` passes.

Kept in sync note added to the top-level `description` array so the identity here and the `git config user.email` in the two workflows don't drift.
🤖 Generated with [Claude Code](https://claude.com/claude-code)