### PR TITLE
fix(ui): guard requestAnimationFrame in iframe-repaint (kill the merge-queue flake)

### DIFF
--- a/packages/webapp/src/ui/iframe-repaint.ts
+++ b/packages/webapp/src/ui/iframe-repaint.ts
@@ -93,8 +93,16 @@ function performNudge(
     onDone?.();
   };
 
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => restore(true));
-  });
+  // rAF may be absent — a non-browser context, or (the common case) a test
+  // whose 500ms safety-net setTimeout fires AFTER the test tore down its jsdom
+  // global. Guard it so a missing rAF just falls through to the setTimeout
+  // ceiling below rather than throwing an unhandled `requestAnimationFrame is
+  // not a function` (which fails the whole vitest run — see #1603's merge-queue
+  // flake). In a real browser rAF is always present, so behavior is unchanged.
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => restore(true));
+    });
+  }
   setTimeout(() => restore(false), 100);
 }

--- a/packages/webapp/tests/ui/iframe-repaint.test.ts
+++ b/packages/webapp/tests/ui/iframe-repaint.test.ts
@@ -165,4 +165,29 @@ describe('nudgeIframeRepaint', () => {
       expect(onDone).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('missing requestAnimationFrame (regression: #1603 merge-queue flake)', () => {
+    it('does not throw and restores via the setTimeout ceiling when rAF is unavailable', () => {
+      // The real flake: the 500ms safety-net setTimeout fired AFTER a test tore
+      // down its jsdom global, so `performNudge` hit an undefined
+      // `requestAnimationFrame` and threw an unhandled error that failed the
+      // whole vitest run. Simulate rAF being absent throughout — both the direct
+      // performNudge and the 500ms safety-net retry must fall back to the
+      // setTimeout ceiling without throwing.
+      vi.stubGlobal('requestAnimationFrame', undefined);
+      const iframe = makeIframe('block');
+
+      expect(() => nudgeIframeRepaint(iframe)).not.toThrow();
+      expect(iframe.style.display).toBe('none'); // toggled off, rAF skipped
+      // No rAF → the 100ms setTimeout ceiling restores it.
+      expect(() => vi.advanceTimersByTime(100)).not.toThrow();
+      expect(iframe.style.display).toBe('block');
+      // The 500ms safety-net retry re-enters performNudge with rAF still absent —
+      // the exact path that threw in the flake. It must not throw.
+      expect(() => vi.advanceTimersByTime(400)).not.toThrow();
+      expect(iframe.style.display).toBe('none'); // retry toggled off
+      expect(() => vi.advanceTimersByTime(100)).not.toThrow();
+      expect(iframe.style.display).toBe('block'); // retry's ceiling restored it
+    });
+  });
 });


### PR DESCRIPTION
## Problem

A flaky **merge-queue** failure (seen on #1603's `@biomejs/wasm-web` bump, but unrelated to it — its own CI was green): all 9,484 webapp tests passed, yet the run exited 1 on a single **unhandled error**:

```
TypeError: requestAnimationFrame is not a function
 ❯ performNudge packages/webapp/src/ui/iframe-repaint.ts:96
 ❯ Timeout._onTimeout packages/webapp/src/ui/iframe-repaint.ts:67   (the 500ms safety-net)
This error originated in "packages/webapp/tests/ui/sprinkle-renderer.test.ts"
```

`nudgeIframeRepaint` schedules a 500 ms safety-net `setTimeout` that re-enters `performNudge` → `requestAnimationFrame`. When that timer fires **after a test has torn down its jsdom global**, `requestAnimationFrame` is gone, the unguarded call throws, and because it's in a detached timer it surfaces as an **unhandled error that fails the whole vitest run**. It's timing-dependent, so it passes on most runs and randomly bites the merge queue for *any* PR.

## Fix

Guard the rAF call in `performNudge` — a missing `requestAnimationFrame` now falls through to the **existing `setTimeout` ceiling** (the same fallback already used when rAF is *throttled*) instead of throwing:

```ts
if (typeof requestAnimationFrame === 'function') {
  requestAnimationFrame(() => {
    requestAnimationFrame(() => restore(true));
  });
}
setTimeout(() => restore(false), 100);
```

In a real browser rAF is always present, so production behavior is unchanged — this only affects the non-browser / torn-down-global case.

## Testing
- Added a regression test in `iframe-repaint.test.ts` (rAF unavailable → no throw + the setTimeout ceiling restores, exercising both the direct call and the 500 ms safety-net re-entry). **Verified it fails without the guard** (`requestAnimationFrame is not a function`) and passes with it.
- `iframe-repaint.test.ts`: 12/12 pass. Browser typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)