### PR TITLE
chore(deps): migrate to TypeScript 7 (Option A: split native build + JS browser compiler)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
         "prettier": "3.9.5",
         "semantic-release": "25.0.7",
         "tsx": "4.23.1",
-        "typescript": "^6.0.0",
+        "typescript": "^7.0.0",
+        "typescript-js": "npm:typescript@6.0.3",
         "vite": "8.1.5",
         "vitest": "4.1.10"
       },
@@ -1968,7 +1969,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -2084,6 +2085,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2099,6 +2103,9 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2116,6 +2123,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2132,6 +2142,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2147,6 +2160,9 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7375,6 +7391,346 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -19764,6 +20120,42 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/typescript-js": {
+      "name": "typescript",
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
@@ -20925,7 +21317,7 @@
         "@types/jsdom": "^28.0.0",
         "esbuild": "^0.28.1",
         "jsdom": "^29.0.0",
-        "typescript": "6.0.3"
+        "typescript": "7.0.2"
       }
     },
     "packages/chrome-extension": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     "prettier": "3.9.5",
     "semantic-release": "25.0.7",
     "tsx": "4.23.1",
-    "typescript": "^6.0.0",
+    "typescript": "^7.0.0",
+    "typescript-js": "npm:typescript@6.0.3",
     "vite": "8.1.5",
     "vitest": "4.1.10"
   },

--- a/packages/cherry/package.json
+++ b/packages/cherry/package.json
@@ -27,6 +27,6 @@
     "@types/jsdom": "^28.0.0",
     "esbuild": "^0.28.1",
     "jsdom": "^29.0.0",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2"
   }
 }

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -89,13 +89,12 @@ See `docs/mounts.md`.
 ### Shell
 
 - Path: `packages/webapp/src/shell/`
-- `almost-bash-shell.ts` hosts the just-bash runtime.
-- `script-catalog.ts` — shared `.jsh`/`.bsh` discovery service, cache-invalidated by
-  `FsWatcher`; bypasses cache for mounted trees where external changes are invisible to the
-  watcher.
-- `supplemental-commands/` — all built-in commands. See `docs/shell-reference.md` for the
-  authoritative per-command reference and `supplemental-commands/agent-command.ts` for scoop
-  delegation details.
+- `almost-bash-shell.ts` — just-bash runtime host.
+- `script-catalog.ts` — shared `.jsh`/`.bsh` discovery for the shell and `which`; its
+  `FsWatcher` cache is bypassed for mounted trees where external changes are invisible.
+- `supplemental-commands/` — built-ins (see `docs/shell-reference.md`).
+  `typescript` v7 (native) runs checks/builds; `typescript-js` (JS v6) powers browser
+  `tsc`/`test`/`esm-transpile` because v7 has no browser/WASM API.
 - `jsh-discovery.ts` / `bsh-discovery.ts` — raw VFS scans backing the shared catalog.
 - `vfs-adapter.ts` — bridges shell calls into VFS; forwards `canWrite` (duck-typed for
   both `VirtualFS` and `RestrictedFS`).

--- a/packages/webapp/src/shell/ipk/esm-transpile.ts
+++ b/packages/webapp/src/shell/ipk/esm-transpile.ts
@@ -42,7 +42,7 @@ export interface CreateEsmTranspileOptions {
   /**
    * VFS context threaded into the default `getEsbuild` / `getTypeScript`
    * loaders so the browser branch can read the ipk-installed
-   * `esbuild-wasm` / `typescript` packages from VFS `node_modules`.
+   * `esbuild-wasm` / `typescript@6.0.3` packages from VFS `node_modules`.
    * Ignored when both loaders are supplied, and unused under Node
    * runtime (where the bundled wrappers are used directly). The
    * `IpkResolutionContext` shape is a structural superset of

--- a/packages/webapp/src/shell/supplemental-commands/shared.ts
+++ b/packages/webapp/src/shell/supplemental-commands/shared.ts
@@ -23,7 +23,7 @@ type InitSqlJs = (options?: { locateFile?: (file: string) => string }) => Promis
 
 const SQLJS_WASM_CDN = 'https://sql.js.org/dist/';
 
-export type TypeScriptModule = typeof import('typescript');
+export type TypeScriptModule = typeof import('typescript-js');
 
 export function resolvePinnedPackageVersion(packageName: string, versionSpec: unknown): string {
   if (typeof versionSpec !== 'string' || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(versionSpec)) {
@@ -227,11 +227,11 @@ const TYPESCRIPT_NOT_INSTALLED =
   'typescript is not installed in node_modules: run `ipk add typescript` (no network fallback)';
 
 /**
- * Lazy singleton for the `typescript` package. Pure JS (no WASM init).
+ * Lazy singleton for the classic TypeScript JS compiler API. Pure JS (no WASM init).
  *
  * Node runtime (vitest, build tooling): falls back to the
- * locally-installed `typescript` npm dependency via dynamic
- * `import('typescript')`. The `/* @vite-ignore *\/` comment keeps the
+ * locally-installed `typescript-js` npm alias via dynamic
+ * `import('typescript-js')`. The `/* @vite-ignore *\/` comment keeps the
  * heavy module OUT of the browser bundle while leaving the Node path
  * functional for tests and the realm host's transpile fallback.
  *
@@ -256,10 +256,10 @@ export async function getTypeScript(ipk?: TypeScriptIpkContext): Promise<TypeScr
 
 async function loadTypeScript(ipk?: TypeScriptIpkContext): Promise<TypeScriptModule> {
   if (isNodeRuntime()) {
-    // `/* @vite-ignore */` keeps `typescript` out of the browser bundle
+    // `/* @vite-ignore */` keeps `typescript-js` out of the browser bundle
     // while Node (vitest/build tooling) still resolves it from local
     // node_modules at runtime.
-    const mod = await import(/* @vite-ignore */ 'typescript');
+    const mod = await import(/* @vite-ignore */ 'typescript-js');
     return ((mod as { default?: TypeScriptModule }).default ?? mod) as TypeScriptModule;
   }
   if (!ipk) throw new Error(TYPESCRIPT_NOT_INSTALLED);

--- a/packages/webapp/src/shell/supplemental-commands/shared.ts
+++ b/packages/webapp/src/shell/supplemental-commands/shared.ts
@@ -25,6 +25,8 @@ const SQLJS_WASM_CDN = 'https://sql.js.org/dist/';
 
 export type TypeScriptModule = typeof import('typescript-js');
 
+export const TYPESCRIPT_VFS_INSTALL_COMMAND = 'ipk add typescript@6.0.3';
+
 export function resolvePinnedPackageVersion(packageName: string, versionSpec: unknown): string {
   if (typeof versionSpec !== 'string' || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(versionSpec)) {
     throw new Error(`${packageName} must use an exact semver version in package.json`);
@@ -209,7 +211,7 @@ export async function getSqlJs(): Promise<SqlJsModule> {
 
 /**
  * Read-only VFS context the loader needs to read an ipk-installed
- * `typescript` from the VFS `node_modules`. Mirrors the
+ * `typescript@6.0.3` from the VFS `node_modules`. Mirrors the
  * `IpkResolutionContext` shape used by `esbuild-wasm.ts` and
  * `biome-command.ts` so every float (standalone/hosted/extension/Node)
  * wires it the same way. `readBytes` is unused for typescript (the
@@ -224,7 +226,8 @@ export interface TypeScriptIpkContext {
 }
 
 const TYPESCRIPT_NOT_INSTALLED =
-  'typescript is not installed in node_modules: run `ipk add typescript` (no network fallback)';
+  `TypeScript 6 is not installed in node_modules: run \`${TYPESCRIPT_VFS_INSTALL_COMMAND}\` ` +
+  '(no network fallback)';
 
 /**
  * Lazy singleton for the classic TypeScript JS compiler API. Pure JS (no WASM init).
@@ -236,7 +239,8 @@ const TYPESCRIPT_NOT_INSTALLED =
  * functional for tests and the realm host's transpile fallback.
  *
  * Browser runtime (standalone OR extension): reads the
- * ipk-installed `typescript/lib/typescript.js` from VFS `node_modules`
+ * ipk-installed `typescript@6.0.3` compiler from
+ * `typescript/lib/typescript.js` in VFS `node_modules`
  * via the shared resolver, evaluates the CJS source in a fresh
  * `new Function('module', 'exports', source)` wrapper, and returns
  * the captured `module.exports` as the `ts` API surface. No CDN
@@ -270,7 +274,7 @@ async function loadTypeScript(ipk?: TypeScriptIpkContext): Promise<TypeScriptMod
 
 /**
  * Try to read `typescript/lib/typescript.js` source from an ipk-installed
- * `typescript` in the VFS. Returns `null` on any resolution / read miss
+ * TypeScript 6 package in the VFS. Returns `null` on any resolution / read miss
  * so the caller surfaces the canonical guidance error. Exported so the
  * loader's resolution behavior is unit-testable without booting the
  * heavy compiler.

--- a/packages/webapp/src/shell/supplemental-commands/test-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/test-command.ts
@@ -205,7 +205,7 @@ async function prepareTstHarness(ts: TypeScriptModule): Promise<string> {
     target: ts.ScriptTarget.ES2022,
     esModuleInterop: true,
     isolatedModules: false,
-  } as import('typescript').CompilerOptions;
+  } as import('typescript-js').CompilerOptions;
   const assertCjs = ts.transpileModule(assertSource, {
     compilerOptions: opts,
     fileName: 'assert.js',
@@ -347,7 +347,7 @@ async function collectLocalDependencies(
   ts: TypeScriptModule,
   entryPath: string,
   entryCjs: string,
-  userOpts: import('typescript').CompilerOptions
+  userOpts: import('typescript-js').CompilerOptions
 ): Promise<{
   modules: Map<string, string>;
   edgeRewrites: Map<string, Map<string, string>>;
@@ -444,7 +444,7 @@ export function _resetTstHarnessForTests(): void {
 
 type TestCmdResult = { stdout: string; stderr: string; exitCode: number };
 
-type UserCompilerOptions = import('typescript').CompilerOptions;
+type UserCompilerOptions = import('typescript-js').CompilerOptions;
 
 const USER_OPTS_TEMPLATE = {
   esModuleInterop: true,

--- a/packages/webapp/src/shell/supplemental-commands/test-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/test-command.ts
@@ -508,7 +508,7 @@ async function prepareTestRun(
     ts = await getTypeScript(createIpkContextFromCtx(ctx));
   } catch (err) {
     // `getTypeScript` already emits the canonical
-    // "run `ipk add typescript`" guidance when nothing is installed;
+    // Pinned TypeScript 6 install guidance when nothing is installed;
     // surface it verbatim.
     return {
       done: {

--- a/packages/webapp/src/shell/supplemental-commands/tsc-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/tsc-command.ts
@@ -1,8 +1,8 @@
 /**
  * `tsc` shell command — thin built-in surface that drives the
- * `typescript` package loaded from VFS `node_modules` via the shared
+ * TypeScript 6 package loaded from VFS `node_modules` via the shared
  * `getTypeScript()` ipk loader in `shared.ts`. Inert until the user
- * runs `ipk add typescript`; without the package, the loader throws
+ * runs `ipk add typescript@6.0.3`; without the package, the loader throws
  * the canonical guidance error which this command surfaces verbatim.
  * ZERO network in the not-installed path — there is no CDN fallback
  * anywhere on this code path.
@@ -30,13 +30,14 @@ import {
   basename,
   dirname,
   getTypeScript,
+  TYPESCRIPT_VFS_INSTALL_COMMAND,
   type TypeScriptIpkContext,
   type TypeScriptModule,
 } from './shared.js';
 
 /**
  * Build a {@link TypeScriptIpkContext} from a command's `ctx` so
- * `getTypeScript` can locate the ipk-installed `typescript` in the
+ * `getTypeScript` can locate the ipk-installed TypeScript 6 compiler in the
  * VFS `node_modules`. Mirrors `createIpkContextFromCtx` in
  * `esbuild-command.ts` / `biome-command.ts` so every float wires the
  * loader the same way.
@@ -67,7 +68,7 @@ export interface ParsedTscArgs {
   showVersion: boolean;
 }
 
-const HELP_TEXT = `tsc - thin wrapper over the ipk-loaded typescript package
+const HELP_TEXT = `tsc - thin wrapper over the ipk-loaded TypeScript 6 package
 
 Usage:
   tsc [options] [files...]
@@ -87,7 +88,7 @@ Notes:
 
 Install:
   Inert until the backing package is installed in node_modules:
-    ipk add typescript
+    ${TYPESCRIPT_VFS_INSTALL_COMMAND}
   Then \`tsc --version\` and the transpile commands above. There is no
   bundled binary, no CDN fallback; a missing package exits non-zero
   with a clear \`ipk add\` hint.
@@ -365,7 +366,7 @@ async function prepareTscRun(
     ts = await getTypeScript(createIpkContextFromCtx(ctx));
   } catch (err) {
     // `getTypeScript` already emits the canonical
-    // "run `ipk add typescript`" guidance when nothing is installed;
+    // Pinned TypeScript 6 install guidance when nothing is installed;
     // surface it verbatim.
     return {
       done: {

--- a/packages/webapp/src/shell/supplemental-commands/tsc-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/tsc-command.ts
@@ -205,7 +205,10 @@ export async function loadTsconfig(
   };
 }
 
-function diagnosticToString(ts: TypeScriptModule, diag: import('typescript').Diagnostic): string {
+function diagnosticToString(
+  ts: TypeScriptModule,
+  diag: import('typescript-js').Diagnostic
+): string {
   const text = ts.flattenDiagnosticMessageText(diag.messageText, '\n');
   if (diag.file && typeof diag.start === 'number') {
     const { line, character } = diag.file.getLineAndCharacterOfPosition(diag.start);
@@ -217,7 +220,7 @@ function diagnosticToString(ts: TypeScriptModule, diag: import('typescript').Dia
 function inferScriptKind(
   ts: TypeScriptModule,
   fileName: string
-): import('typescript').ScriptKind | undefined {
+): import('typescript-js').ScriptKind | undefined {
   const lower = fileName.toLowerCase();
   if (lower.endsWith('.tsx')) return ts.ScriptKind.TSX;
   if (lower.endsWith('.jsx')) return ts.ScriptKind.JSX;
@@ -228,7 +231,7 @@ function inferScriptKind(
 
 interface TranspileOneResult {
   outputText: string;
-  diagnostics: import('typescript').Diagnostic[];
+  diagnostics: import('typescript-js').Diagnostic[];
 }
 
 function transpileOne(
@@ -239,7 +242,7 @@ function transpileOne(
   reportDiagnostics: boolean
 ): TranspileOneResult {
   const result = ts.transpileModule(source, {
-    compilerOptions: compilerOptions as import('typescript').CompilerOptions,
+    compilerOptions: compilerOptions as import('typescript-js').CompilerOptions,
     fileName,
     reportDiagnostics,
   });

--- a/packages/webapp/tests/shell/ipk/esm-transpile.test.ts
+++ b/packages/webapp/tests/shell/ipk/esm-transpile.test.ts
@@ -9,7 +9,7 @@
  * module-correct URL through the transpile (so `new URL(rel, import.meta.url)`
  * resolves against the module's own VFS path).
  */
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   createEntryTranspile,
   createEsmTranspile,
@@ -18,6 +18,7 @@ import {
 } from '../../../src/shell/ipk/esm-transpile.js';
 import { buildModuleGraph } from '../../../src/shell/ipk/module-loader.js';
 import type { ModuleReader } from '../../../src/shell/ipk/resolver.js';
+import { resetTypeScriptForTests } from '../../../src/shell/supplemental-commands/shared.js';
 
 function makeReader(files: Record<string, string>): ModuleReader {
   const dirs = new Set<string>(['/']);
@@ -188,6 +189,25 @@ describe('createEsmTranspile() — typescript fallback path', () => {
     const exp = evalCjs(cjs);
     expect((exp.default as () => string)()).toBe('file:///app/node_modules/pkg/index.mjs');
     expect((exp.asset as () => string)()).toBe('file:///app/node_modules/pkg/d.txt');
+  });
+
+  it('surfaces the pinned TypeScript 6 install command when the browser fallback is absent', async () => {
+    resetTypeScriptForTests();
+    vi.stubGlobal('process', undefined);
+    try {
+      const transpile = createEsmTranspile({
+        loadEsbuild: async () => {
+          throw new Error('esbuild unavailable');
+        },
+        ipk: { reader: makeReader({}), readBytes: async () => new Uint8Array(), fromDir: '/app' },
+      });
+      await expect(transpile({ source: ESM_SRC, path: PATH, kind: 'esm' })).rejects.toThrow(
+        /ipk add typescript@6\.0\.3/
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      resetTypeScriptForTests();
+    }
   });
 });
 

--- a/packages/webapp/tests/shell/supplemental-commands/test-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/test-command.test.ts
@@ -1,5 +1,6 @@
 import type { IFileSystem } from 'just-bash';
 import { describe, expect, it, vi } from 'vitest';
+import { resetTypeScriptForTests } from '../../../src/shell/supplemental-commands/shared.js';
 import {
   _resetTstHarnessForTests,
   createTestCommand,
@@ -282,5 +283,20 @@ test('uses local add', ({ is }) => {
     const result = await cmd.execute(['--help'], createMockCtx());
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('test - run');
+  });
+
+  it('surfaces the pinned TypeScript 6 install command in a browser float', async () => {
+    resetTypeScriptForTests();
+    vi.stubGlobal('process', undefined);
+    try {
+      const ctx = createMockCtx();
+      await ctx.fs.writeFile('/workspace/example.test.ts', 'export {};');
+      const result = await createTestCommand().execute([], ctx);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('ipk add typescript@6.0.3');
+    } finally {
+      vi.unstubAllGlobals();
+      resetTypeScriptForTests();
+    }
   });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/tsc-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/tsc-command.test.ts
@@ -1,6 +1,9 @@
 import type { IFileSystem } from 'just-bash';
 import { describe, expect, it, vi } from 'vitest';
-import { tryLoadTypeScriptSourceFromNodeModules } from '../../../src/shell/supplemental-commands/shared.js';
+import {
+  resetTypeScriptForTests,
+  tryLoadTypeScriptSourceFromNodeModules,
+} from '../../../src/shell/supplemental-commands/shared.js';
 import {
   createIpkContextFromCtx,
   createTscCommand,
@@ -160,7 +163,7 @@ describe('createTscCommand', () => {
     const result = await cmd.execute(['--help'], createMockCtx());
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('tsc - thin wrapper');
-    expect(result.stdout).toContain('ipk add typescript');
+    expect(result.stdout).toContain('ipk add typescript@6.0.3');
   });
 
   it('transpiles a single .ts file to a sibling .js', async () => {
@@ -203,11 +206,10 @@ describe('createTscCommand', () => {
 
 describe('install-required guidance (browser branch)', () => {
   // Vitest runs under Node so `getTypeScript`'s Node fallback always loads the
-  // bundled `typescript` — exercise the browser-branch resolver helper
-  // directly to pin the null-when-absent / source-when-installed behavior.
-  // (The command's end-to-end guidance path is exercised manually per the
-  // task's verification plan — see the spec note.)
-  it('tryLoadTypeScriptSourceFromNodeModules returns null when typescript is absent', async () => {
+  // aliased TypeScript 6 package — exercise the browser-branch resolver helper
+  // directly to pin the null-when-absent / source-when-installed behavior,
+  // then stub the runtime for the command's browser-only guidance path.
+  it('tryLoadTypeScriptSourceFromNodeModules returns null when TypeScript is absent', async () => {
     const ctx = createMockCtx();
     const result = await tryLoadTypeScriptSourceFromNodeModules(createIpkContextFromCtx(ctx));
     expect(result).toBeNull();
@@ -227,13 +229,40 @@ describe('install-required guidance (browser branch)', () => {
     expect(result).toContain("version: '6.0.3'");
   });
 
-  it('help text includes the `ipk add typescript` hint (zero network)', () => {
+  it('returns null for the TypeScript 7 package shape without lib/typescript.js', async () => {
+    const ctx = createMockCtx();
+    await ctx.fs.writeFile(
+      '/workspace/node_modules/typescript/package.json',
+      JSON.stringify({ name: 'typescript', version: '7.0.2', main: 'lib/version.cjs' })
+    );
+    await ctx.fs.writeFile(
+      '/workspace/node_modules/typescript/lib/version.cjs',
+      "module.exports = '7.0.2';"
+    );
+    const result = await tryLoadTypeScriptSourceFromNodeModules(createIpkContextFromCtx(ctx));
+    expect(result).toBeNull();
+  });
+
+  it('surfaces the pinned TypeScript 6 install command when the browser compiler is absent', async () => {
+    resetTypeScriptForTests();
+    vi.stubGlobal('process', undefined);
+    try {
+      const result = await createTscCommand().execute(['--version'], createMockCtx());
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('ipk add typescript@6.0.3');
+    } finally {
+      vi.unstubAllGlobals();
+      resetTypeScriptForTests();
+    }
+  });
+
+  it('help text includes the pinned TypeScript 6 hint (zero network)', () => {
     // The HELP_TEXT is the canonical user-facing surface for the install
     // requirement. The command always emits it on `--help`, even when
     // typescript is absent.
     const cmd = createTscCommand();
     return cmd.execute(['--help'], createMockCtx()).then((res) => {
-      expect(res.stdout).toMatch(/ipk add typescript/);
+      expect(res.stdout).toContain('ipk add typescript@6.0.3');
       expect(res.stdout).not.toMatch(/unpkg|jsdelivr|esm\.sh|https?:\/\//);
     });
   });


### PR DESCRIPTION
Takes over and supersedes #1621 (Renovate's `typescript` 6.0.3 → 7.0.2 bump).

## Why this is not a plain version bump

TypeScript **7.0** is the **native (Go) port** of the compiler, not an incremental JS release. The npm package changed shape fundamentally:

| | `typescript@6.0.3` (JS) | `typescript@7.0.2` (native/Go) |
|---|---|---|
| main export `.` | `./lib/typescript.js` (full compiler API) | `./lib/version.cjs` (version string only) |
| `bin` | `tsc`, `tsserver` | `tsc` only (per-platform native binaries) |
| compiler API | `transpileModule`, `ModuleKind`, `ScriptTarget`, `parseConfigFileTextToJson`, `flattenDiagnosticMessageText`, `ScriptKind`, `Diagnostic`, `CompilerOptions` … | moved to `./unstable/{sync,async,ast,fs}` — async, "unstable", **no `lib/typescript.js` bundle** |

SLICC depends on the classic JS compiler API **in the browser**: it reads the ipk-installed `typescript/lib/typescript.js` from the VFS and `eval`s it to power three in-browser shell features — `shell/ipk/esm-transpile.ts` (ESM→CJS fallback), the `test` command, and the virtual `tsc` command. TS7's native binary (IPC-based, "not ready" API, no usable WASM build) cannot fill that role.

## Approach — Option A: split the two roles

- **`typescript@^7.0.0`** (native Go) → the repo's **type-checker / build tool** (all `tsc --noEmit` scripts) — the speed win.
- **`typescript-js` (`npm:typescript@6.0.3`)** → the **in-browser JS compiler API** SLICC `eval`s from the VFS.

## Changes

- `package.json`: `typescript` `^6.0.0` → `^7.0.0`; add `"typescript-js": "npm:typescript@6.0.3"`.
- `packages/cherry/package.json`: `typescript` `6.0.3` → `7.0.2` (cherry only uses `tsc` for its own build).
- `package-lock.json`: regenerated via `npm install`.
- `packages/webapp/src/shell/supplemental-commands/{shared,tsc-command,test-command}.ts`: repoint the browser compiler API types + Node runtime loader to `typescript-js`.
- `packages/webapp/CLAUDE.md`: documents the native-v7 / JS-v6 split and browser/WASM rationale.

## Verification

- `npx tsc --version` → `7.0.2`; `typescript-js` resolves to `6.0.3`.
- `npm run lint`, `npm run typecheck`: pass.
- `npm run test`: **11,525 passed**, 40 skipped.
- `npm run test:coverage:webapp`: thresholds pass.
- `npm run build` and `npm run build -w @slicc/chrome-extension`: pass.
- Touched-file complexity gate: pass.

Closes #1621.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author