### PR TITLE
docs: fix jsh-realm doc drift — QuickJS claim, node-shim overstatements

### DIFF
--- a/docs/mounts.md
+++ b/docs/mounts.md
@@ -40,7 +40,7 @@ Credentials never reach the agent. Where they live depends on which deployment y
 | Sliccstart (macOS native)    | macOS Keychain (service `ai.sliccy.slicc`) | Sliccstart Settings → Secrets (form UI)              |
 | Chrome extension             | `chrome.storage.local`                     | Right-click extension icon → **Options** (form UI)   |
 
-In all three, the credential channel is server-side / SW-side: the browser bundle never holds an `access_key_id`. The agent's `bash`, `node -e`, and `javascript` tools run in CSP-locked contexts (just-bash / the QuickJS sandbox / sandbox iframes) with no access to the storage backend.
+In all three, the credential channel is server-side / SW-side: the browser bundle never holds an `access_key_id`. The agent's `bash`, `node -e`, and `javascript` tools run in isolated contexts (just-bash / the kernel worker's DedicatedWorker JS realm) with no `chrome.*` API access and no access to the storage backend.
 
 ### CLI: edit `~/.slicc/secrets.env`
 

--- a/docs/node-compat-shims.md
+++ b/docs/node-compat-shims.md
@@ -48,27 +48,36 @@ also resolves to it.
 
 Sync methods (backed by `SyncFsCache` — in-memory snapshot, standalone only):
 
-| Method                               | Notes                                     |
-| ------------------------------------ | ----------------------------------------- |
-| `readFileSync(path, opts?)`          |                                           |
-| `writeFileSync(path, data)`          |                                           |
-| `existsSync(path)`                   |                                           |
-| `mkdirSync(path, {recursive?})`      |                                           |
-| `statSync(path)`                     | Returns `{isFile(), isDirectory(), size}` |
-| `readdirSync(path)`                  |                                           |
-| `rmSync(path, {recursive?, force?})` |                                           |
-| `copyFileSync(src, dest)`            |                                           |
-| `mkdtempSync(prefix)`                |                                           |
-| `unlinkSync(path)`                   |                                           |
-| `renameSync(oldPath, newPath)`       |                                           |
+| Method                               | Notes                                                 |
+| ------------------------------------ | ----------------------------------------------------- |
+| `readFileSync(path, opts?)`          |                                                       |
+| `writeFileSync(path, data)`          |                                                       |
+| `appendFileSync(path, data)`         |                                                       |
+| `truncateSync(path, len?)`           |                                                       |
+| `existsSync(path)`                   |                                                       |
+| `accessSync(path)`                   | Throws ENOENT if missing                              |
+| `mkdirSync(path, {recursive?})`      |                                                       |
+| `statSync(path)`                     | Returns `{isFile(), isDirectory(), size}`             |
+| `lstatSync(path)`                    | Identical to `statSync` — the VFS has no symlinks     |
+| `realpathSync(path)`                 | Lexical resolution + existence check (no symlinks)    |
+| `readdirSync(path)`                  |                                                       |
+| `rmSync(path, {recursive?, force?})` |                                                       |
+| `rmdirSync(path, {recursive?})`      | ENOTDIR on a non-directory                            |
+| `copyFileSync(src, dest)`            |                                                       |
+| `cpSync(src, dest)`                  | Recursive tree copy                                   |
+| `chmodSync(path)`                    | No-op (VFS has no mode bits); keeps ENOENT-on-missing |
+| `mkdtempSync(prefix)`                |                                                       |
+| `unlinkSync(path)`                   |                                                       |
+| `renameSync(oldPath, newPath)`       |                                                       |
 
 The sync cache is populated from a VFS snapshot before user code runs and
 flushed back on completion. Files exceeding 1 MB are marked `truncated` and
 throw `ENOSYNC` on sync read (use the async API for large files).
 
 **Not available:** `watch`, `watchFile`, `createReadStream`, `createWriteStream`,
-`chmod`, `chown`, `lstat`, `symlink`, `readlink`, `realpath`, `Dirent`-returning
-readdir.
+`chown`, `symlink`, `readlink`, `Dirent`-returning readdir. `lstat`, `realpath`,
+and `chmod` exist only as the sync variants above — they have no async
+counterparts.
 
 ### `path`
 
@@ -78,19 +87,20 @@ Full POSIX path module: `join`, `resolve`, `dirname`, `basename`, `extname`,
 
 ### `crypto`
 
-| API                      | Notes                                 |
-| ------------------------ | ------------------------------------- |
-| `randomBytes(size)`      | Returns Uint8Array                    |
-| `randomFillSync(buffer)` |                                       |
-| `randomUUID()`           |                                       |
-| `getRandomValues(array)` |                                       |
-| `createHash(alg)`        | md5, sha1, sha256, sha512 (pure JS)   |
-| `webcrypto`              | Re-exports `globalThis.crypto`        |
-| `subtle`                 | Re-exports `globalThis.crypto.subtle` |
+| API                      | Notes                                                                |
+| ------------------------ | -------------------------------------------------------------------- |
+| `randomBytes(size)`      | Returns Uint8Array                                                   |
+| `randomFillSync(buffer)` |                                                                      |
+| `randomUUID()`           |                                                                      |
+| `getRandomValues(array)` |                                                                      |
+| `createHash(alg)`        | md5, sha1, sha256 only (pure JS: `js-md5` / `js-sha1` / `js-sha256`) |
+| `webcrypto`              | Re-exports `globalThis.crypto`                                       |
+| `subtle`                 | Re-exports `globalThis.crypto.subtle`                                |
 
 **Not available:** `createCipheriv`, `createDecipheriv`, `createSign`,
 `createVerify`, `createHmac`, `createDiffieHellman`, `pbkdf2`, `scrypt`,
-`generateKeyPair`.
+`generateKeyPair`. `createHash('sha512')` throws
+(`Digest method not supported`) — use `crypto.subtle.digest('SHA-512', …)`.
 
 ### `child_process`
 
@@ -110,8 +120,13 @@ and `exit`/`close`/`error` events.
 
 ### `process`
 
-`env`, `cwd()`, `exit(code?)`, `stdout`, `stderr`, `stdin`, `argv`,
-`platform` (`'browser'`), `arch` (`'wasm'`), `version`, `pid`.
+`env`, `cwd()`, `exit(code?)` (throws `NodeExitError` to unwind the stack),
+`stdout`, `stderr`, `stdin`, and `argv` (with a non-enumerable
+`argv.parseFlags()` helper).
+
+**Not available:** `platform`, `arch`, `version`, `pid`, `on()`,
+`nextTick()`, `hrtime`. (Source: `createProcessShim` in
+`realm-node-shims.ts` — the shim object has exactly the keys listed above.)
 
 ### `buffer`
 
@@ -120,14 +135,21 @@ Re-exports the global `Buffer` polyfill. Available as both
 
 ### `assert` / `assert/strict`
 
-Full assertion module: `ok`, `fail`, `equal`, `notEqual`, `strictEqual`,
-`notStrictEqual`, `deepEqual`, `deepStrictEqual`, `throws`, `doesNotThrow`,
-`rejects`, `doesNotReject`, `match`, `doesNotMatch`, `ifError`.
+`ok`, `fail`, `equal`, `notEqual`, `strictEqual`, `notStrictEqual`,
+`deepEqual`, `deepStrictEqual`, `notDeepEqual`, `notDeepStrictEqual`,
+`throws`, `doesNotThrow`, plus the `AssertionError` class and the `strict`
+self-reference.
+
+**Not available:** `rejects`, `doesNotReject`, `match`, `doesNotMatch`,
+`ifError`.
 
 ### `util`
 
-`promisify`, `inspect`, `inherits`, `types` (isDate, isRegExp, isPromise,
-etc.), `format`, `deprecate`, `TextEncoder`, `TextDecoder`.
+`promisify` (with `promisify.custom`), `inspect` (with `inspect.custom`),
+`inherits`, `format`, `formatWithOptions`.
+
+**Not available:** `types`, `deprecate`, `callbackify`,
+`TextEncoder` / `TextDecoder` (use the globals).
 
 ### `events`
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -300,7 +300,7 @@ The OAuth login popup flow is the user-approval gate. Once a token is cached, su
 
 In Chrome extension mode, agent-initiated HTTP requests now route through the `fetch-proxy.fetch` SW Port handler, providing full secret-injection coverage equivalent to CLI mode.
 
-For **mount backends specifically** (`mount --source s3://...` and `mount --source da://...`), the extension is self-contained. Secrets live in `chrome.storage.local`, the service worker holds them, signs requests with SigV4 (S3) or attaches the IMS Bearer (DA), and forwards via `fetch()` (extension `host_permissions: <all_urls>` covers any S3/da.live host). The agent's tools (`bash` via just-bash, `node -e` and `javascript` in the CSP-locked QuickJS sandbox / sandbox iframes) have no `chrome.*` API access, so they cannot read `chrome.storage` directly — the same isolation property that keeps `~/.slicc/secrets.env` out of the agent in CLI mode.
+For **mount backends specifically** (`mount --source s3://...` and `mount --source da://...`), the extension is self-contained. Secrets live in `chrome.storage.local`, the service worker holds them, signs requests with SigV4 (S3) or attaches the IMS Bearer (DA), and forwards via `fetch()` (extension `host_permissions: <all_urls>` covers any S3/da.live host). The agent's tools (`bash` via just-bash, `node -e` and `javascript` in the kernel worker's JS realm — a DedicatedWorker) have no `chrome.*` API access, so they cannot read `chrome.storage` directly — the same isolation property that keeps `~/.slicc/secrets.env` out of the agent in CLI mode.
 
 ### Extension Options page (recommended)
 

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -8,7 +8,7 @@ Complete reference for SLICC's shell capabilities, including supplemental comman
 
 SLICC uses `just-bash` (a pure-TypeScript Bash interpreter; see `packages/webapp/package.json` for the pinned version) as its core shell runtime. The interpreter itself is plain JavaScript — not WASM. This provides the standard Unix builtins (cd, ls, cat, grep, find, sed, awk, head, tail, etc.) plus ~50 custom supplemental commands registered by `packages/webapp/src/shell/supplemental-commands/index.ts` and `packages/webapp/src/shell/almost-bash-shell-headless.ts`, and any auto-discovered `.jsh` script commands on the VFS.
 
-WASM enters only for specific runtime-heavy commands, which fetch and cache their binaries on demand: `python3` (Pyodide), `sqlite3` (sql.js), the `node -e` / `javascript` sandbox (QuickJS), `convert` (ImageMagick), `ffmpeg`, `biome`, and `esbuild`. The `AlmostBashShell` / `AlmostBashShellHeadless` classes cover the whole shell, not just the WASM-backed commands.
+WASM enters only for specific runtime-heavy commands, which fetch and cache their binaries on demand: `python3` (Pyodide), `sqlite3` (sql.js), `convert` (ImageMagick), `ffmpeg`, `biome`, and `esbuild`. The `node -e` / `javascript` / `.jsh` sandbox is **not** WASM: scripts run as native JavaScript in the kernel's DedicatedWorker JS realm (V8 in Chrome), with user code compiled to an `AsyncFunction` body — see `packages/webapp/src/kernel/realm/realm-factory.ts` and `realm-module-system.ts` (`runUserCode`). The `AlmostBashShell` / `AlmostBashShellHeadless` classes cover the whole shell, not just the WASM-backed commands.
 
 **Entry point**: Via the `bash` agent tool. All shell features available to agents.
 


### PR DESCRIPTION
## Summary

Corrects four docs where descriptions of the JS realm drifted from the code: `shell-reference.md` claims the `node -e` / `javascript` sandbox is QuickJS (WASM) — it is native JS in the kernel's DedicatedWorker realm; `node-compat-shims.md` documents `process`/`crypto`/`assert`/`util`/`fs` surfaces that don't match the shims; `secrets.md` and `mounts.md` still describe the removed sandbox-iframe/QuickJS isolation path.

## Why

Found while writing a jsh style guide for ai-ecoverse/skills (skills#218) by comparing these docs against the realm source. Skill authors treat these docs as the runtime reference, and each overstatement is a latent bug in a `.jsh` script (e.g. branching on `process.platform` → `undefined`, `createHash('sha512')` → throw, `assert.rejects` → TypeError). Every correction below was verified against the code, not just removed:

- **QuickJS**: `rg -i quickjs packages/webapp/src` → zero hits. Realms are `new Worker(js-realm-worker.ts)` (`realm-factory.ts:56-62`); user code is compiled to an `AsyncFunction` body (`realm-module-system.ts` `runUserCode`).
- **process**: `createProcessShim` (`realm-node-shims.ts`) has exactly `argv`/`env`/`cwd`/`exit`/`stdin`/`stdout`/`stderr` — no `platform`/`arch`/`version`/`pid`. Now also documents `argv.parseFlags()` and the `NodeExitError` exit semantics.
- **crypto**: `HASH_FACTORIES` (`js-realm-helpers.ts:639`) bundles only `js-md5`/`js-sha1`/`js-sha256`; `createHash('sha512')` throws `Digest method not supported` (`js-realm-helpers.ts:678`).
- **assert**: `NodeAssert` has no `rejects`/`doesNotReject`/`match`/`doesNotMatch`/`ifError`; it does have `notDeepEqual`/`notDeepStrictEqual`, which were missing from the doc.
- **util**: `NodeUtil` is exactly `format`/`formatWithOptions`/`inspect`/`inherits`/`promisify` — no `types`/`deprecate`/`TextEncoder`.
- **fs**: eight implemented sync methods were undocumented (`appendFileSync`, `truncateSync`, `accessSync`, `lstatSync`, `realpathSync`, `rmdirSync`, `cpSync`, `chmodSync` — `realm-fs-bridge.ts:321-419`), and three of them (`lstat`/`realpath`/`chmod`) were listed under **Not available**. The async bridge genuinely has no `lstat`/`realpath`/`chmod`, which the new wording preserves.
- **secrets.md / mounts.md**: the "CSP-locked QuickJS sandbox / sandbox iframes" framing describes the removed path (`docs/pitfalls.md` § "Dynamic Code Execution Runs in the Kernel Worker"); the isolation claims themselves stand and now name the actual mechanism. Note the realm worker is deliberately **not** CSP-locked (`realm-factory.ts:2-6`), so "CSP-locked" was doubly wrong there.

## Approach / Implementation notes

Docs-only. Where a wrong claim was removed, the actual behavior is stated with its source location rather than silently deleted, so the next drift is checkable.

## Test plan

- [x] `npx prettier --write <changed-files>` — ran via pre-commit lint-staged (clean)
- [x] Every factual claim verified against `realm-node-shims.ts`, `js-realm-helpers.ts`, `realm-fs-bridge.ts`, `realm-factory.ts`, `realm-module-system.ts`
- [x] N/A — typecheck/test/build: no code touched

## Documentation

- [x] `docs/` (agent reference: tools, commands, skills, patterns)

## Risk & rollback

Docs-only; clean revert. One reviewer judgment call: `secrets.md`/`mounts.md` isolation wording — I kept the security claims intact and only corrected the mechanism; if the DedicatedWorker phrasing understates any extension-mode nuance, happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LuEhZuA9v2PsdXuiDVvrS