### PR TITLE
fix(webapp): untangle sprinkle-command from ui/sprinkle-bridge (#1630)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -280,8 +280,7 @@
       "includes": [
         "packages/webapp/cloud/app.js",
         "packages/webapp/src/shell/supplemental-commands/pdftk-command.ts",
-        "packages/webapp/src/shell/supplemental-commands/websocat-command.ts",
-        "packages/webapp/src/ui/sprinkle-bridge.ts"
+        "packages/webapp/src/shell/supplemental-commands/websocat-command.ts"
       ],
       "linter": {
         "rules": {

--- a/packages/webapp/src/shell/sprinkle-manager-handle.ts
+++ b/packages/webapp/src/shell/sprinkle-manager-handle.ts
@@ -1,0 +1,17 @@
+/** Sprinkle metadata consumed by the shell command. */
+export interface ShellSprinkle {
+  name: string;
+  title: string;
+  path: string;
+}
+
+/** Worker-safe slice of the sprinkle manager used by the shell command. */
+export interface SprinkleManagerHandle {
+  refresh(): Promise<void>;
+  available(): ShellSprinkle[];
+  opened(): string[];
+  open(name: string): Promise<void>;
+  close(name: string): void;
+  reload(name: string): Promise<void>;
+  sendToSprinkle(name: string, data: unknown): void;
+}

--- a/packages/webapp/src/shell/sprinkle-routes.ts
+++ b/packages/webapp/src/shell/sprinkle-routes.ts
@@ -1,0 +1,44 @@
+// ── Sprinkle → scoop routing config (localStorage-backed) ──
+
+const SPRINKLE_ROUTES_KEY = 'slicc-sprinkle-routes';
+
+function loadRoutes(): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(SPRINKLE_ROUTES_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveRoutes(routes: Record<string, string>): void {
+  try {
+    localStorage.setItem(SPRINKLE_ROUTES_KEY, JSON.stringify(routes));
+  } catch {
+    /* localStorage full */
+  }
+}
+
+/** Get the target scoop for a sprinkle, or undefined (→ cone). */
+export function getSprinkleRoute(sprinkleName: string): string | undefined {
+  return loadRoutes()[sprinkleName];
+}
+
+/** Set the target scoop for a sprinkle's lick events. */
+export function setSprinkleRoute(sprinkleName: string, scoop: string): void {
+  const routes = loadRoutes();
+  routes[sprinkleName] = scoop;
+  saveRoutes(routes);
+}
+
+/** Clear the target scoop for a sprinkle (reverts to cone). */
+export function clearSprinkleRoute(sprinkleName: string): void {
+  const routes = loadRoutes();
+  delete routes[sprinkleName];
+  saveRoutes(routes);
+}
+
+/** Get all sprinkle → scoop routes. */
+export function getAllSprinkleRoutes(): Record<string, string> {
+  return loadRoutes();
+}

--- a/packages/webapp/src/shell/supplemental-commands/sprinkle-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/sprinkle-command.ts
@@ -14,14 +14,14 @@
 import type { Command, CommandContext } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import { showToolUIFromContext } from '../../tools/tool-ui.js';
+import { stdinAsText } from '../just-bash-compat.js';
+import type { SprinkleManagerHandle } from '../sprinkle-manager-handle.js';
 import {
   clearSprinkleRoute,
   getAllSprinkleRoutes,
   getSprinkleRoute,
   setSprinkleRoute,
-} from '../../ui/sprinkle-bridge.js';
-import type { SprinkleManager } from '../../ui/sprinkle-manager.js';
-import { stdinAsText } from '../just-bash-compat.js';
+} from '../sprinkle-routes.js';
 
 type Result = { stdout: string; stderr: string; exitCode: number };
 
@@ -46,9 +46,9 @@ function sprinkleHelp(): Result {
   };
 }
 
-function getSprinkleManager(): SprinkleManager | null {
+function getSprinkleManager(): SprinkleManagerHandle | null {
   const mgr = (globalThis as Record<string, unknown>).__slicc_sprinkleManager;
-  return (mgr as SprinkleManager) ?? null;
+  return (mgr as SprinkleManagerHandle) ?? null;
 }
 
 async function handleChat(args: string[], ctx: CommandContext): Promise<Result> {
@@ -70,7 +70,7 @@ async function handleChat(args: string[], ctx: CommandContext): Promise<Result> 
   return { stdout: JSON.stringify(result) + '\n', stderr: '', exitCode: 0 };
 }
 
-async function handleList(mgr: SprinkleManager): Promise<Result> {
+async function handleList(mgr: SprinkleManagerHandle): Promise<Result> {
   await mgr.refresh();
   const sprinkles = mgr.available();
   if (sprinkles.length === 0) {
@@ -84,7 +84,7 @@ async function handleList(mgr: SprinkleManager): Promise<Result> {
   return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
 }
 
-async function handleOpen(mgr: SprinkleManager, args: string[]): Promise<Result> {
+async function handleOpen(mgr: SprinkleManagerHandle, args: string[]): Promise<Result> {
   const name = args[1];
   if (!name) return { stdout: '', stderr: 'sprinkle open: name required\n', exitCode: 1 };
   try {
@@ -99,14 +99,14 @@ async function handleOpen(mgr: SprinkleManager, args: string[]): Promise<Result>
   }
 }
 
-function handleClose(mgr: SprinkleManager, args: string[]): Result {
+function handleClose(mgr: SprinkleManagerHandle, args: string[]): Result {
   const name = args[1];
   if (!name) return { stdout: '', stderr: 'sprinkle close: name required\n', exitCode: 1 };
   mgr.close(name);
   return { stdout: `Sprinkle "${name}" closed.\n`, stderr: '', exitCode: 0 };
 }
 
-async function handleReload(mgr: SprinkleManager, args: string[]): Promise<Result> {
+async function handleReload(mgr: SprinkleManagerHandle, args: string[]): Promise<Result> {
   const name = args[1];
   if (!name) return { stdout: '', stderr: 'sprinkle reload: name required\n', exitCode: 1 };
   try {
@@ -121,7 +121,7 @@ async function handleReload(mgr: SprinkleManager, args: string[]): Promise<Resul
   }
 }
 
-async function handleRefresh(mgr: SprinkleManager): Promise<Result> {
+async function handleRefresh(mgr: SprinkleManagerHandle): Promise<Result> {
   await mgr.refresh();
   const count = mgr.available().length;
   return {
@@ -169,7 +169,7 @@ function handleRoute(args: string[]): Result {
   };
 }
 
-function handleSend(mgr: SprinkleManager, args: string[]): Result {
+function handleSend(mgr: SprinkleManagerHandle, args: string[]): Result {
   const name = args[1];
   if (!name) return { stdout: '', stderr: 'sprinkle send: name required\n', exitCode: 1 };
   const jsonStr = args.slice(2).join(' ');

--- a/packages/webapp/src/ui/sprinkle-bridge.ts
+++ b/packages/webapp/src/ui/sprinkle-bridge.ts
@@ -27,6 +27,7 @@ import {
 } from '../kernel/usb-device-registry.js';
 import * as usbOps from '../kernel/usb-operations.js';
 import type { LickEvent } from '../scoops/lick-manager.js';
+import { getSprinkleRoute } from '../shell/sprinkle-routes.js';
 import { toPreviewUrl } from '../shell/supplemental-commands/shared.js';
 
 export interface CaptureScreenResult {
@@ -826,22 +827,183 @@ export class SprinkleBridge {
     return value;
   }
 
+  /**
+   * Handle the `slicc.lick()` call from a sprinkle. Constructs a
+   * LickEvent and forwards it to the lick handler.
+   */
+  private createLickHandler(
+    sprinkleName: string
+  ): (event: { action: string; data?: unknown } | string) => void {
+    return (event) => {
+      const action = typeof event === 'string' ? event : event.action;
+      const data = typeof event === 'string' ? undefined : event.data;
+      const lickEvent: LickEvent = {
+        type: 'sprinkle',
+        sprinkleName,
+        targetScoop: getSprinkleRoute(sprinkleName),
+        timestamp: new Date().toISOString(),
+        body: { action, data },
+      };
+      this.lickHandler(lickEvent);
+    };
+  }
+
+  /**
+   * Capture a sprinkle DOM element or its child as a PNG data URL.
+   * Uses SVG foreignObject trick + canvas rendering to capture styled content.
+   */
+  private createScreenshotHandler(
+    container: HTMLElement | undefined
+  ): (selector?: string) => Promise<string> {
+    return async (selector) => {
+      if (!container) return '';
+      const target = selector ? container.querySelector<HTMLElement>(selector) : container;
+      if (!target) throw new Error('Element not found: ' + (selector || 'container'));
+      const rect = target.getBoundingClientRect();
+      const w = Math.ceil(rect.width);
+      const h = Math.ceil(rect.height);
+      if (w === 0 || h === 0) throw new Error('Element has zero dimensions');
+      const canvas = document.createElement('canvas');
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      const ctx = canvas.getContext('2d')!;
+      ctx.scale(dpr, dpr);
+      const clone = (target as HTMLElement).cloneNode(true) as HTMLElement;
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}"><foreignObject width="100%" height="100%">${new XMLSerializer().serializeToString(clone)}</foreignObject></svg>`;
+      return new Promise<string>((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => {
+          ctx.drawImage(img, 0, 0);
+          resolve(canvas.toDataURL('image/png'));
+        };
+        img.onerror = () => reject(new Error('Screenshot rendering failed'));
+        img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+      });
+    };
+  }
+
+  /**
+   * Build the `slicc.agent()` sprinkle helper that spawns a scoop and
+   * returns its final message. Wraps the `agent` shell command.
+   */
+  private createAgentHandler(
+    sprinkleName: string
+  ): (prompt: string, opts?: SprinkleAgentOptions) => Promise<SprinkleAgentResult> {
+    return async (prompt, opts) => {
+      const cwd = opts?.cwd ?? '.';
+      const allowed = opts?.allowedCommands ?? '*';
+      // Flags precede positionals — the `agent` parser treats the
+      // third positional as the prompt verbatim, so any flags must
+      // come first.
+      const parts = ['agent'];
+      if (opts?.model) parts.push('--model', shellQuote(opts.model));
+      if (opts?.thinking) parts.push('--thinking', shellQuote(opts.thinking));
+      if (opts?.readOnly) parts.push('--read-only', shellQuote(opts.readOnly));
+      parts.push(shellQuote(cwd), shellQuote(allowed), shellQuote(prompt));
+      const result = await this.runExec(parts.join(' '));
+      // `agent` writes its final message to stdout on success and the
+      // error text to stderr on failure; fold them into a single
+      // `stdout` field so the sprinkle always sees the relevant text.
+      return { stdout: result.stdout || result.stderr, exitCode: result.exitCode };
+    };
+  }
+
+  /**
+   * Build the `slicc.hid` device API object for a sprinkle.
+   */
+  private createHidApi(sprinkleName: string): SprinkleHidApi {
+    return {
+      list: () => this.hidOp(sprinkleName, 'list', []) as Promise<HidDeviceInfo[]>,
+      request: (filters?: HidDeviceFilter[]) =>
+        this.hidOp(sprinkleName, 'request', [filters ?? []]) as Promise<HidDeviceInfo[]>,
+      open: async (handle: string) => {
+        await this.hidOp(sprinkleName, 'open', [handle]);
+      },
+      close: async (handle: string) => {
+        await this.hidOp(sprinkleName, 'close', [handle]);
+      },
+      sendReport: async (handle: string, reportId: number, data: Uint8Array) => {
+        await this.hidOp(sprinkleName, 'sendReport', [handle, reportId, data]);
+      },
+      on: (event: 'inputreport', cb: SprinkleHidInputReportListener) => {
+        if (event !== 'inputreport') return;
+        const key = `${sprinkleName}:hid:inputreport`;
+        let set = this.listeners.get(key);
+        if (!set) {
+          set = new Set();
+          this.listeners.set(key, set);
+        }
+        set.add(cb as unknown as UpdateCallback);
+      },
+      off: (event: 'inputreport', cb: SprinkleHidInputReportListener) => {
+        if (event !== 'inputreport') return;
+        this.listeners
+          .get(`${sprinkleName}:hid:inputreport`)
+          ?.delete(cb as unknown as UpdateCallback);
+      },
+    };
+  }
+
+  /**
+   * Build the `slicc.serial` device API object for a sprinkle.
+   */
+  private createSerialApi(sprinkleName: string): SprinkleSerialApi {
+    return {
+      list: () => this.serialOp(sprinkleName, 'list', []) as Promise<SerialDeviceInfo[]>,
+      request: (filters?: SerialFilter[]) =>
+        this.serialOp(sprinkleName, 'request', [filters ?? []]) as Promise<SerialDeviceInfo>,
+      open: async (handle: string, options: SerialOpenOptions) => {
+        await this.serialOp(sprinkleName, 'open', [handle, options]);
+      },
+      close: async (handle: string) => {
+        await this.serialOp(sprinkleName, 'close', [handle]);
+      },
+    };
+  }
+
+  /**
+   * Build the `slicc.usb` device API object for a sprinkle.
+   */
+  private createUsbApi(sprinkleName: string): SprinkleUsbApi {
+    return {
+      list: () => this.usbOp(sprinkleName, 'list', []) as Promise<UsbDeviceInfo[]>,
+      request: (filters?: UsbDeviceFilter[]) =>
+        this.usbOp(sprinkleName, 'request', [filters ?? []]) as Promise<UsbDeviceInfo>,
+      open: async (handle: string) => {
+        await this.usbOp(sprinkleName, 'open', [handle]);
+      },
+      close: async (handle: string) => {
+        await this.usbOp(sprinkleName, 'close', [handle]);
+      },
+    };
+  }
+
+  /**
+   * Build the `slicc.http.client()` factory for a sprinkle.
+   */
+  private createHttpClient(config: SprinkleHttpClientConfig): SprinkleHttpClient {
+    const make = (method: string) => (path: string, opts?: SprinkleHttpRequestOpts) =>
+      this.jshDispatch('http', [
+        config,
+        method,
+        path,
+        opts ?? null,
+      ]) as Promise<SprinkleHttpResponse>;
+    return {
+      get: make('get'),
+      post: make('post'),
+      put: make('put'),
+      patch: make('patch'),
+      delete: make('delete'),
+    };
+  }
+
   /** Create a bridge API for a specific sprinkle. */
   createAPI(sprinkleName: string): SprinkleBridgeAPI {
     const api: SprinkleBridgeAPI = {
       name: sprinkleName,
-      lick: (event: { action: string; data?: unknown } | string) => {
-        const action = typeof event === 'string' ? event : event.action;
-        const data = typeof event === 'string' ? undefined : event.data;
-        const lickEvent: LickEvent = {
-          type: 'sprinkle',
-          sprinkleName,
-          targetScoop: getSprinkleRoute(sprinkleName),
-          timestamp: new Date().toISOString(),
-          body: { action, data },
-        };
-        this.lickHandler(lickEvent);
-      },
+      lick: this.createLickHandler(sprinkleName),
       on: (event: string, callback: UpdateCallback) => {
         const key = `${sprinkleName}:${event}`;
         let set = this.listeners.get(key);
@@ -875,32 +1037,9 @@ export class SprinkleBridge {
       rm: async (path: string) => {
         await this.fs.rm(path);
       },
-      screenshot: async (selector?: string) => {
-        const container = api._container;
-        if (!container) return '';
-        const target = selector ? container.querySelector<HTMLElement>(selector) : container;
-        if (!target) throw new Error('Element not found: ' + (selector || 'container'));
-        const rect = target.getBoundingClientRect();
-        const w = Math.ceil(rect.width);
-        const h = Math.ceil(rect.height);
-        if (w === 0 || h === 0) throw new Error('Element has zero dimensions');
-        const canvas = document.createElement('canvas');
-        const dpr = window.devicePixelRatio || 1;
-        canvas.width = w * dpr;
-        canvas.height = h * dpr;
-        const ctx = canvas.getContext('2d')!;
-        ctx.scale(dpr, dpr);
-        const clone = (target as HTMLElement).cloneNode(true) as HTMLElement;
-        const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}"><foreignObject width="100%" height="100%">${new XMLSerializer().serializeToString(clone)}</foreignObject></svg>`;
-        return new Promise<string>((resolve, reject) => {
-          const img = new Image();
-          img.onload = () => {
-            ctx.drawImage(img, 0, 0);
-            resolve(canvas.toDataURL('image/png'));
-          };
-          img.onerror = () => reject(new Error('Screenshot rendering failed'));
-          img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
-        });
+      screenshot: (selector?: string) => {
+        const handler = this.createScreenshotHandler(api._container);
+        return handler(selector);
       },
       setState: (data: unknown) => {
         try {
@@ -933,22 +1072,7 @@ export class SprinkleBridge {
       fetch: (url: string, init?: SprinkleFetchInit) =>
         this.jshDispatch('fetch', [url, init ?? null]) as Promise<Response>,
       http: {
-        client: (config: SprinkleHttpClientConfig): SprinkleHttpClient => {
-          const make = (method: string) => (path: string, opts?: SprinkleHttpRequestOpts) =>
-            this.jshDispatch('http', [
-              config,
-              method,
-              path,
-              opts ?? null,
-            ]) as Promise<SprinkleHttpResponse>;
-          return {
-            get: make('get'),
-            post: make('post'),
-            put: make('put'),
-            patch: make('patch'),
-            delete: make('delete'),
-          };
-        },
+        client: (config: SprinkleHttpClientConfig) => this.createHttpClient(config),
       },
       browser: {
         findTab: (query) => this.jshDispatch('browser', ['findTab', query]),
@@ -961,58 +1085,9 @@ export class SprinkleBridge {
           this.jshDispatch('browser', ['localStorage', tab, key]) as Promise<string | null>,
         fetch: (tab, url, opts) => this.jshDispatch('browser', ['fetch', tab, url, opts ?? {}]),
       },
-      hid: {
-        list: () => this.hidOp(sprinkleName, 'list', []) as Promise<HidDeviceInfo[]>,
-        request: (filters?: HidDeviceFilter[]) =>
-          this.hidOp(sprinkleName, 'request', [filters ?? []]) as Promise<HidDeviceInfo[]>,
-        open: async (handle: string) => {
-          await this.hidOp(sprinkleName, 'open', [handle]);
-        },
-        close: async (handle: string) => {
-          await this.hidOp(sprinkleName, 'close', [handle]);
-        },
-        sendReport: async (handle: string, reportId: number, data: Uint8Array) => {
-          await this.hidOp(sprinkleName, 'sendReport', [handle, reportId, data]);
-        },
-        on: (event: 'inputreport', cb: SprinkleHidInputReportListener) => {
-          if (event !== 'inputreport') return;
-          const key = `${sprinkleName}:hid:inputreport`;
-          let set = this.listeners.get(key);
-          if (!set) {
-            set = new Set();
-            this.listeners.set(key, set);
-          }
-          set.add(cb as unknown as UpdateCallback);
-        },
-        off: (event: 'inputreport', cb: SprinkleHidInputReportListener) => {
-          if (event !== 'inputreport') return;
-          this.listeners
-            .get(`${sprinkleName}:hid:inputreport`)
-            ?.delete(cb as unknown as UpdateCallback);
-        },
-      },
-      serial: {
-        list: () => this.serialOp(sprinkleName, 'list', []) as Promise<SerialDeviceInfo[]>,
-        request: (filters?: SerialFilter[]) =>
-          this.serialOp(sprinkleName, 'request', [filters ?? []]) as Promise<SerialDeviceInfo>,
-        open: async (handle: string, options: SerialOpenOptions) => {
-          await this.serialOp(sprinkleName, 'open', [handle, options]);
-        },
-        close: async (handle: string) => {
-          await this.serialOp(sprinkleName, 'close', [handle]);
-        },
-      },
-      usb: {
-        list: () => this.usbOp(sprinkleName, 'list', []) as Promise<UsbDeviceInfo[]>,
-        request: (filters?: UsbDeviceFilter[]) =>
-          this.usbOp(sprinkleName, 'request', [filters ?? []]) as Promise<UsbDeviceInfo>,
-        open: async (handle: string) => {
-          await this.usbOp(sprinkleName, 'open', [handle]);
-        },
-        close: async (handle: string) => {
-          await this.usbOp(sprinkleName, 'close', [handle]);
-        },
-      },
+      hid: this.createHidApi(sprinkleName),
+      serial: this.createSerialApi(sprinkleName),
+      usb: this.createUsbApi(sprinkleName),
       readFileBinary: async (path: string) =>
         base64ToU8(
           ((await this.jshDispatch('readFileBinary', [path])) as { base64: string }).base64
@@ -1025,23 +1100,7 @@ export class SprinkleBridge {
       _jsh: (op: string, args: unknown[]) => this.jshDispatch(op, args),
       _device: (channel: 'hid' | 'serial' | 'usb', op: string, args: unknown[]) =>
         this.deviceOp(sprinkleName, channel, op, args),
-      agent: async (prompt: string, opts?: SprinkleAgentOptions) => {
-        const cwd = opts?.cwd ?? '.';
-        const allowed = opts?.allowedCommands ?? '*';
-        // Flags precede positionals — the `agent` parser treats the
-        // third positional as the prompt verbatim, so any flags must
-        // come first.
-        const parts = ['agent'];
-        if (opts?.model) parts.push('--model', shellQuote(opts.model));
-        if (opts?.thinking) parts.push('--thinking', shellQuote(opts.thinking));
-        if (opts?.readOnly) parts.push('--read-only', shellQuote(opts.readOnly));
-        parts.push(shellQuote(cwd), shellQuote(allowed), shellQuote(prompt));
-        const result = await this.runExec(parts.join(' '));
-        // `agent` writes its final message to stdout on success and the
-        // error text to stderr on failure; fold them into a single
-        // `stdout` field so the sprinkle always sees the relevant text.
-        return { stdout: result.stdout || result.stderr, exitCode: result.exitCode };
-      },
+      agent: this.createAgentHandler(sprinkleName),
     };
     return api;
   }
@@ -1090,49 +1149,4 @@ export class SprinkleBridge {
       this.hidSubs.delete(sprinkleName);
     }
   }
-}
-
-// ── Sprinkle → scoop routing config (localStorage-backed) ──
-
-const SPRINKLE_ROUTES_KEY = 'slicc-sprinkle-routes';
-
-function loadRoutes(): Record<string, string> {
-  try {
-    const raw = localStorage.getItem(SPRINKLE_ROUTES_KEY);
-    return raw ? JSON.parse(raw) : {};
-  } catch {
-    return {};
-  }
-}
-
-function saveRoutes(routes: Record<string, string>): void {
-  try {
-    localStorage.setItem(SPRINKLE_ROUTES_KEY, JSON.stringify(routes));
-  } catch {
-    /* localStorage full */
-  }
-}
-
-/** Get the target scoop for a sprinkle, or undefined (→ cone). */
-export function getSprinkleRoute(sprinkleName: string): string | undefined {
-  return loadRoutes()[sprinkleName];
-}
-
-/** Set the target scoop for a sprinkle's lick events. */
-export function setSprinkleRoute(sprinkleName: string, scoop: string): void {
-  const routes = loadRoutes();
-  routes[sprinkleName] = scoop;
-  saveRoutes(routes);
-}
-
-/** Clear the target scoop for a sprinkle (reverts to cone). */
-export function clearSprinkleRoute(sprinkleName: string): void {
-  const routes = loadRoutes();
-  delete routes[sprinkleName];
-  saveRoutes(routes);
-}
-
-/** Get all sprinkle → scoop routes. */
-export function getAllSprinkleRoutes(): Record<string, string> {
-  return loadRoutes();
 }

--- a/packages/webapp/src/ui/sprinkle-bridge.ts
+++ b/packages/webapp/src/ui/sprinkle-bridge.ts
@@ -887,9 +887,10 @@ export class SprinkleBridge {
    * Build the `slicc.agent()` sprinkle helper that spawns a scoop and
    * returns its final message. Wraps the `agent` shell command.
    */
-  private createAgentHandler(
-    sprinkleName: string
-  ): (prompt: string, opts?: SprinkleAgentOptions) => Promise<SprinkleAgentResult> {
+  private createAgentHandler(): (
+    prompt: string,
+    opts?: SprinkleAgentOptions
+  ) => Promise<SprinkleAgentResult> {
     return async (prompt, opts) => {
       const cwd = opts?.cwd ?? '.';
       const allowed = opts?.allowedCommands ?? '*';
@@ -1100,7 +1101,7 @@ export class SprinkleBridge {
       _jsh: (op: string, args: unknown[]) => this.jshDispatch(op, args),
       _device: (channel: 'hid' | 'serial' | 'usb', op: string, args: unknown[]) =>
         this.deviceOp(sprinkleName, channel, op, args),
-      agent: this.createAgentHandler(sprinkleName),
+      agent: this.createAgentHandler(),
     };
     return api;
   }

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -7,6 +7,7 @@ import { createLogger } from '../core/logger.js';
 import type { FsWatcher, VirtualFS } from '../fs/index.js';
 import { getPanelRpcClient, hasLocalDom } from '../kernel/panel-rpc.js';
 import type { LickEvent } from '../scoops/lick-manager.js';
+import type { SprinkleManagerHandle } from '../shell/sprinkle-manager-handle.js';
 import {
   type CaptureScreenResult,
   SprinkleBridge,
@@ -277,7 +278,7 @@ const WATCHER_ROOTS = ['/workspace', '/shared', '/scoops'] as const;
  */
 const REFRESH_COOLDOWN_MS = 250;
 
-export class SprinkleManager {
+export class SprinkleManager implements SprinkleManagerHandle {
   private fs: VirtualFS;
   private bridge: SprinkleBridge;
   private callbacks: SprinkleManagerCallbacks;

--- a/packages/webapp/tests/shell/sprinkle-routes.test.ts
+++ b/packages/webapp/tests/shell/sprinkle-routes.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearSprinkleRoute,
+  getAllSprinkleRoutes,
+  getSprinkleRoute,
+  setSprinkleRoute,
+} from '../../src/shell/sprinkle-routes.js';
+
+describe('sprinkle route helpers', () => {
+  let store: Record<string, string>;
+  const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+
+  beforeEach(() => {
+    store = {};
+    const polyfill: Storage = {
+      get length() {
+        return Object.keys(store).length;
+      },
+      clear: () => {
+        store = {};
+      },
+      getItem: (key: string) => (key in store ? store[key] : null),
+      key: (index: number) => Object.keys(store)[index] ?? null,
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      setItem: (key: string, value: string) => {
+        store[key] = String(value);
+      },
+    };
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: polyfill,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (originalLocalStorage === undefined) {
+      delete (globalThis as { localStorage?: Storage }).localStorage;
+    } else {
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: originalLocalStorage,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it('returns undefined when no route is set', () => {
+    expect(getSprinkleRoute('foo')).toBeUndefined();
+    expect(getAllSprinkleRoutes()).toEqual({});
+  });
+
+  it('persists set and clears a route through localStorage', () => {
+    setSprinkleRoute('foo', 'scoop-a');
+    expect(getSprinkleRoute('foo')).toBe('scoop-a');
+    expect(getAllSprinkleRoutes()).toEqual({ foo: 'scoop-a' });
+    // Reuses the existing store on subsequent set, preserving siblings.
+    setSprinkleRoute('bar', 'scoop-b');
+    expect(getAllSprinkleRoutes()).toEqual({ foo: 'scoop-a', bar: 'scoop-b' });
+
+    clearSprinkleRoute('foo');
+    expect(getSprinkleRoute('foo')).toBeUndefined();
+    expect(getAllSprinkleRoutes()).toEqual({ bar: 'scoop-b' });
+  });
+
+  it('treats corrupted localStorage payloads as empty', () => {
+    (globalThis as { localStorage: Storage }).localStorage.setItem(
+      'slicc-sprinkle-routes',
+      '{not json'
+    );
+    expect(getAllSprinkleRoutes()).toEqual({});
+  });
+
+  it('silently swallows setItem failures (quota etc.)', () => {
+    const ls = (globalThis as { localStorage: Storage }).localStorage;
+    ls.setItem = () => {
+      throw new Error('QuotaExceeded');
+    };
+    expect(() => setSprinkleRoute('foo', 'scoop-a')).not.toThrow();
+  });
+});

--- a/packages/webapp/tests/ui/sprinkle-bridge.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-bridge.test.ts
@@ -1,18 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import type { VirtualFS } from '../../src/fs/index.js';
 import type { LickEvent } from '../../src/scoops/lick-manager.js';
 import {
   buildJshNodeCommand,
   type CaptureScreenResult,
-  clearSprinkleRoute,
-  getAllSprinkleRoutes,
-  getSprinkleRoute,
   JSH_RESULT_PREFIX,
   parseJshResult,
   runJshOp,
   SprinkleBridge,
   type SprinkleExecResult,
-  setSprinkleRoute,
 } from '../../src/ui/sprinkle-bridge.js';
 
 /** Build a worker-shell stdout payload carrying a successful jsh result. */
@@ -633,81 +629,5 @@ describe('jsh node-command helpers', () => {
     const out = await runJshOp(exec, 'fetchToFile', ['https://h/a', '/a']);
     expect(out).toBe('done');
     expect((exec.mock.calls[0][0] as string).startsWith('node -e ')).toBe(true);
-  });
-});
-
-describe('sprinkle route helpers', () => {
-  let store: Record<string, string>;
-  const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
-
-  beforeEach(() => {
-    store = {};
-    const polyfill: Storage = {
-      get length() {
-        return Object.keys(store).length;
-      },
-      clear: () => {
-        store = {};
-      },
-      getItem: (key: string) => (key in store ? store[key] : null),
-      key: (index: number) => Object.keys(store)[index] ?? null,
-      removeItem: (key: string) => {
-        delete store[key];
-      },
-      setItem: (key: string, value: string) => {
-        store[key] = String(value);
-      },
-    };
-    Object.defineProperty(globalThis, 'localStorage', {
-      value: polyfill,
-      configurable: true,
-      writable: true,
-    });
-  });
-
-  afterEach(() => {
-    if (originalLocalStorage === undefined) {
-      delete (globalThis as { localStorage?: Storage }).localStorage;
-    } else {
-      Object.defineProperty(globalThis, 'localStorage', {
-        value: originalLocalStorage,
-        configurable: true,
-        writable: true,
-      });
-    }
-  });
-
-  it('returns undefined when no route is set', () => {
-    expect(getSprinkleRoute('foo')).toBeUndefined();
-    expect(getAllSprinkleRoutes()).toEqual({});
-  });
-
-  it('persists set and clears a route through localStorage', () => {
-    setSprinkleRoute('foo', 'scoop-a');
-    expect(getSprinkleRoute('foo')).toBe('scoop-a');
-    expect(getAllSprinkleRoutes()).toEqual({ foo: 'scoop-a' });
-    // Reuses the existing store on subsequent set, preserving siblings.
-    setSprinkleRoute('bar', 'scoop-b');
-    expect(getAllSprinkleRoutes()).toEqual({ foo: 'scoop-a', bar: 'scoop-b' });
-
-    clearSprinkleRoute('foo');
-    expect(getSprinkleRoute('foo')).toBeUndefined();
-    expect(getAllSprinkleRoutes()).toEqual({ bar: 'scoop-b' });
-  });
-
-  it('treats corrupted localStorage payloads as empty', () => {
-    (globalThis as { localStorage: Storage }).localStorage.setItem(
-      'slicc-sprinkle-routes',
-      '{not json'
-    );
-    expect(getAllSprinkleRoutes()).toEqual({});
-  });
-
-  it('silently swallows setItem failures (quota etc.)', () => {
-    const ls = (globalThis as { localStorage: Storage }).localStorage;
-    ls.setItem = () => {
-      throw new Error('QuotaExceeded');
-    };
-    expect(() => setSprinkleRoute('foo', 'scoop-a')).not.toThrow();
   });
 });


### PR DESCRIPTION
Extract localStorage route helpers into shell/sprinkle-routes.ts to break the back-edge where worker-resident sprinkle-command.ts imported from the DOM-heavy ui/sprinkle-bridge.ts.

Changes:
- New shell/sprinkle-routes.ts with DOM-free route helpers
- New shell/sprinkle-manager-handle.ts contract
- sprinkle-command.ts imports from shell/ only
- ui/sprinkle-bridge.ts refactored (extracted 7 helpers, cleared function-size debt)
- Removed biome.json exemption for ui/sprinkle-bridge.ts
- Moved route tests to tests/shell/sprinkle-routes.test.ts

Verification:
- Kernel worker bundle no longer imports sprinkle-bridge.js ✓
- All 9,469 tests pass ✓
- Coverage above floors ✓
- check-touched-exemptions.mjs gate passes ✓

Fixes #1630