### PR TITLE
Fix jsh fetch binary request body corruption

### DIFF
--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -201,7 +201,7 @@ export async function runJsRealm(init: RealmInitMsg, port: RealmPortLike): Promi
           : String(input);
     const serialized: SerializedFetchResponse = await rpc.call('fetch', 'request', [
       url,
-      serializeRequestInit(opts, input),
+      await serializeRequestInit(opts, input),
     ]);
     const body =
       serialized.body.byteLength === 0

--- a/packages/webapp/src/kernel/realm/realm-browser-bridge.ts
+++ b/packages/webapp/src/kernel/realm/realm-browser-bridge.ts
@@ -37,31 +37,42 @@ export async function serializeRequestInit(
     });
   }
   let body: string | undefined;
-  let isBinaryBody = false;
+  let defaultContentType: string | undefined;
   if (init?.body !== undefined && init?.body !== null && init?.body !== '') {
     const serialized = await serializeRequestBody(init.body);
     body = serialized.body;
-    isBinaryBody = serialized.isBinary;
+    defaultContentType = serialized.defaultContentType;
   }
-  if (isBinaryBody && !Object.keys(headers).some((name) => name.toLowerCase() === 'content-type')) {
-    headers['Content-Type'] = 'application/octet-stream';
+  if (
+    defaultContentType &&
+    !Object.keys(headers).some((name) => name.toLowerCase() === 'content-type')
+  ) {
+    headers['Content-Type'] = defaultContentType;
   }
   return { method, headers, body };
 }
 
-async function serializeRequestBody(body: BodyInit): Promise<{ body: string; isBinary: boolean }> {
+async function serializeRequestBody(
+  body: BodyInit
+): Promise<{ body: string; defaultContentType?: string }> {
   if (typeof body === 'string' || body instanceof URLSearchParams) {
-    return { body: body.toString(), isBinary: false };
+    return { body: body.toString() };
   }
   if (body instanceof Blob) {
-    return { body: bytesToLatin1(new Uint8Array(await body.arrayBuffer())), isBinary: true };
+    return {
+      body: bytesToLatin1(new Uint8Array(await body.arrayBuffer())),
+      defaultContentType: body.type || 'application/octet-stream',
+    };
   }
   if (body instanceof ArrayBuffer) {
-    return { body: bytesToLatin1(new Uint8Array(body)), isBinary: true };
+    return {
+      body: bytesToLatin1(new Uint8Array(body)),
+      defaultContentType: 'application/octet-stream',
+    };
   }
   if (ArrayBuffer.isView(body)) {
     const bytes = new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
-    return { body: bytesToLatin1(bytes), isBinary: true };
+    return { body: bytesToLatin1(bytes), defaultContentType: 'application/octet-stream' };
   }
   if (typeof FormData !== 'undefined' && body instanceof FormData) {
     throw new Error(

--- a/packages/webapp/src/kernel/realm/realm-browser-bridge.ts
+++ b/packages/webapp/src/kernel/realm/realm-browser-bridge.ts
@@ -63,7 +63,19 @@ async function serializeRequestBody(body: BodyInit): Promise<{ body: string; isB
     const bytes = new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
     return { body: bytesToLatin1(bytes), isBinary: true };
   }
-  return { body: String(body), isBinary: false };
+  if (typeof FormData !== 'undefined' && body instanceof FormData) {
+    throw new Error(
+      'node fetch shim: FormData request bodies are not supported (post raw application/x-www-form-urlencoded with URLSearchParams instead)'
+    );
+  }
+  if (typeof ReadableStream !== 'undefined' && body instanceof ReadableStream) {
+    throw new Error(
+      'node fetch shim: ReadableStream request bodies are not supported (collect into a Uint8Array or string before calling fetch)'
+    );
+  }
+  throw new Error(
+    `node fetch shim: unsupported request body type (${Object.prototype.toString.call(body)}); use a string, Uint8Array, ArrayBuffer, Blob, or URLSearchParams`
+  );
 }
 
 function bytesToLatin1(bytes: Uint8Array): string {

--- a/packages/webapp/src/kernel/realm/realm-browser-bridge.ts
+++ b/packages/webapp/src/kernel/realm/realm-browser-bridge.ts
@@ -13,10 +13,10 @@ import type { RealmRpcClient } from './realm-rpc.js';
 import type { TabHandle } from './realm-types.js';
 import { createWsObserverApi } from './realm-ws-observer.js';
 
-export function serializeRequestInit(
+export async function serializeRequestInit(
   init: RequestInit | undefined,
   input: string | URL | Request
-): RequestInit | undefined {
+): Promise<RequestInit | undefined> {
   if (!init && !(input instanceof Request)) return undefined;
   const fromRequest = input instanceof Request ? input : null;
   const method = (init?.method ?? fromRequest?.method ?? 'GET').toUpperCase();
@@ -37,10 +37,41 @@ export function serializeRequestInit(
     });
   }
   let body: string | undefined;
+  let isBinaryBody = false;
   if (init?.body !== undefined && init?.body !== null && init?.body !== '') {
-    body = typeof init.body === 'string' ? init.body : String(init.body);
+    const serialized = await serializeRequestBody(init.body);
+    body = serialized.body;
+    isBinaryBody = serialized.isBinary;
+  }
+  if (isBinaryBody && !Object.keys(headers).some((name) => name.toLowerCase() === 'content-type')) {
+    headers['Content-Type'] = 'application/octet-stream';
   }
   return { method, headers, body };
+}
+
+async function serializeRequestBody(body: BodyInit): Promise<{ body: string; isBinary: boolean }> {
+  if (typeof body === 'string' || body instanceof URLSearchParams) {
+    return { body: body.toString(), isBinary: false };
+  }
+  if (body instanceof Blob) {
+    return { body: bytesToLatin1(new Uint8Array(await body.arrayBuffer())), isBinary: true };
+  }
+  if (body instanceof ArrayBuffer) {
+    return { body: bytesToLatin1(new Uint8Array(body)), isBinary: true };
+  }
+  if (ArrayBuffer.isView(body)) {
+    const bytes = new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+    return { body: bytesToLatin1(bytes), isBinary: true };
+  }
+  return { body: String(body), isBinary: false };
+}
+
+function bytesToLatin1(bytes: Uint8Array): string {
+  const chunks: string[] = [];
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    chunks.push(String.fromCharCode(...bytes.subarray(offset, offset + 0x8000)));
+  }
+  return chunks.join('');
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/webapp/src/shell/proxied-fetch.ts
+++ b/packages/webapp/src/shell/proxied-fetch.ts
@@ -226,7 +226,8 @@ export function prepareRequestBody(
   headers?: Record<string, string>
 ): BodyInit | undefined {
   if (!body) return undefined;
-  const ct = headers?.['Content-Type'] ?? headers?.['content-type'] ?? '';
+  const ct =
+    Object.entries(headers ?? {}).find(([key]) => key.toLowerCase() === 'content-type')?.[1] ?? '';
   if (!isTextContentType(ct)) {
     const bytes = getFetchBodyBytes(body) as Uint8Array<ArrayBuffer>;
     return new Blob([bytes]);

--- a/packages/webapp/src/shell/supplemental-commands/node-fetch-adapter.ts
+++ b/packages/webapp/src/shell/supplemental-commands/node-fetch-adapter.ts
@@ -18,6 +18,7 @@
  */
 
 import type { SecureFetch } from 'just-bash';
+import { isTextContentType } from '../proxied-fetch.js';
 
 /**
  * Build a `globalThis.fetch`-shaped function from a just-bash `SecureFetch`.
@@ -46,40 +47,15 @@ export function createNodeFetchAdapter(secureFetch: SecureFetch): typeof globalT
     // on top so explicit init values win — mirroring the browser fetch spec.
     const headers = mergeHeaders(request?.headers, init?.headers);
 
-    // Body: prefer init.body when explicitly provided. When init.body is
-    // omitted but a Request was passed, read the Request's body so prebuilt
-    // Request objects with auth bodies still go through the proxy intact.
-    let body: string | undefined;
-    let bodyForContentType: BodyInit | null | undefined;
-    if (init && 'body' in init && init.body !== undefined) {
-      body = encodeBody(init.body, method);
-      bodyForContentType = init.body;
-    } else if (request && method !== 'GET' && method !== 'HEAD') {
-      const buf = await request.arrayBuffer();
-      body =
-        buf.byteLength === 0 ? undefined : new TextDecoder('utf-8').decode(new Uint8Array(buf));
-      bodyForContentType = undefined; // Content-Type already on request.headers
-    } else {
-      body = undefined;
-      bodyForContentType = undefined;
-    }
-
-    // Real fetch sets `Content-Type: application/x-www-form-urlencoded;
-    // charset=UTF-8` automatically when the body is a URLSearchParams and no
-    // Content-Type is explicitly set. Without this, OAuth token POSTs land
-    // with the wrong Content-Type and get rejected with `invalid_request`.
-    if (
-      bodyForContentType instanceof URLSearchParams &&
-      headers &&
-      !hasHeader(headers, 'content-type')
-    ) {
-      headers['Content-Type'] = 'application/x-www-form-urlencoded;charset=UTF-8';
+    const encoded = await resolveRequestBody(init, request, method, headers);
+    if (encoded.defaultContentType && !hasHeader(headers, 'content-type')) {
+      headers['Content-Type'] = encoded.defaultContentType;
     }
 
     const result = await secureFetch(url, {
       method,
       headers,
-      body,
+      body: encoded.body,
     });
 
     const responseHeaders = new Headers();
@@ -183,38 +159,82 @@ function mergeHeaders(
 
 /** Case-insensitive presence check for a header name in a record. */
 function hasHeader(headers: Record<string, string>, name: string): boolean {
+  return getHeader(headers, name) !== undefined;
+}
+
+/** Case-insensitive lookup that lets later merged header entries win. */
+function getHeader(headers: Record<string, string>, name: string): string | undefined {
   const lower = name.toLowerCase();
-  for (const k of Object.keys(headers)) {
-    if (k.toLowerCase() === lower) return true;
+  let value: string | undefined;
+  for (const [key, candidate] of Object.entries(headers)) {
+    if (key.toLowerCase() === lower) value = candidate;
   }
-  return false;
+  return value;
+}
+
+interface EncodedRequestBody {
+  body?: string;
+  defaultContentType?: string;
+}
+
+/** Encode an init or Request body and select the fetch-compatible default Content-Type. */
+async function resolveRequestBody(
+  init: RequestInit | undefined,
+  request: Request | null,
+  method: string,
+  headers: Record<string, string>
+): Promise<EncodedRequestBody> {
+  if (init && 'body' in init && init.body !== undefined) {
+    const defaultContentType =
+      init.body instanceof URLSearchParams
+        ? 'application/x-www-form-urlencoded;charset=UTF-8'
+        : method !== 'GET' && method !== 'HEAD' && isRawBinaryBody(init.body)
+          ? 'application/octet-stream'
+          : undefined;
+    return { body: await encodeBody(init.body, method), defaultContentType };
+  }
+
+  if (request && method !== 'GET' && method !== 'HEAD') {
+    const hadBody = request.body !== null;
+    const bytes = new Uint8Array(await request.arrayBuffer());
+    const contentType = getHeader(headers, 'content-type') ?? '';
+    const isBinary = hadBody && (!contentType || !isTextContentType(contentType));
+    return {
+      body:
+        bytes.byteLength === 0
+          ? undefined
+          : isBinary
+            ? bytesToLatin1(bytes)
+            : new TextDecoder('utf-8').decode(bytes),
+      defaultContentType: isBinary ? 'application/octet-stream' : undefined,
+    };
+  }
+
+  return {};
 }
 
 /**
  * SecureFetch's body type is `string | undefined`, so we coerce common
- * BodyInit shapes (URLSearchParams, ArrayBuffer, typed arrays) into a
- * string. Streaming bodies (Blob, FormData, ReadableStream) throw — they
- * aren't compatible with the proxy contract on the wire today.
+ * BodyInit shapes into a string. Binary shapes use the proxy's latin1
+ * convention (one character per byte). FormData and ReadableStream remain
+ * unsupported because they require multipart or streaming wire semantics.
  */
-function encodeBody(body: BodyInit | null | undefined, method: string): string | undefined {
+async function encodeBody(
+  body: BodyInit | null | undefined,
+  method: string
+): Promise<string | undefined> {
   if (body == null) return undefined;
   if (method === 'GET' || method === 'HEAD') return undefined;
   if (typeof body === 'string') return body;
   if (body instanceof URLSearchParams) return body.toString();
-  if (body instanceof Uint8Array) return new TextDecoder('utf-8').decode(body);
-  if (body instanceof ArrayBuffer) {
-    return new TextDecoder('utf-8').decode(new Uint8Array(body));
-  }
+  if (body instanceof Uint8Array) return bytesToLatin1(body);
+  if (body instanceof ArrayBuffer) return bytesToLatin1(new Uint8Array(body));
   if (ArrayBuffer.isView(body)) {
     const view = body as ArrayBufferView;
-    return new TextDecoder('utf-8').decode(
-      new Uint8Array(view.buffer, view.byteOffset, view.byteLength)
-    );
+    return bytesToLatin1(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
   }
   if (typeof Blob !== 'undefined' && body instanceof Blob) {
-    throw new Error(
-      'node fetch shim: Blob request bodies are not supported (use a string, Uint8Array, or URLSearchParams)'
-    );
+    return bytesToLatin1(new Uint8Array(await body.arrayBuffer()));
   }
   if (typeof FormData !== 'undefined' && body instanceof FormData) {
     throw new Error(
@@ -230,6 +250,24 @@ function encodeBody(body: BodyInit | null | undefined, method: string): string |
   // refuse explicitly instead of silently sending "[object Foo]" through
   // the proxy, which would never match an upstream API contract.
   throw new Error(
-    `node fetch shim: unsupported request body type (${Object.prototype.toString.call(body)}); use a string, Uint8Array, ArrayBuffer, or URLSearchParams`
+    `node fetch shim: unsupported request body type (${Object.prototype.toString.call(body)}); use a string, Uint8Array, ArrayBuffer, Blob, or URLSearchParams`
   );
+}
+
+function isRawBinaryBody(body: BodyInit | null | undefined): boolean {
+  return (
+    body instanceof Uint8Array ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body) ||
+    (typeof Blob !== 'undefined' && body instanceof Blob)
+  );
+}
+
+function bytesToLatin1(bytes: Uint8Array): string {
+  const chunkSize = 0x8000;
+  let latin1 = '';
+  for (let i = 0; i < bytes.byteLength; i += chunkSize) {
+    latin1 += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return latin1;
 }

--- a/packages/webapp/src/shell/supplemental-commands/node-fetch-adapter.ts
+++ b/packages/webapp/src/shell/supplemental-commands/node-fetch-adapter.ts
@@ -185,12 +185,7 @@ async function resolveRequestBody(
   headers: Record<string, string>
 ): Promise<EncodedRequestBody> {
   if (init && 'body' in init && init.body !== undefined) {
-    const defaultContentType =
-      init.body instanceof URLSearchParams
-        ? 'application/x-www-form-urlencoded;charset=UTF-8'
-        : method !== 'GET' && method !== 'HEAD' && isRawBinaryBody(init.body)
-          ? 'application/octet-stream'
-          : undefined;
+    const defaultContentType = getDefaultContentType(init.body, method);
     return { body: await encodeBody(init.body, method), defaultContentType };
   }
 
@@ -261,6 +256,18 @@ function isRawBinaryBody(body: BodyInit | null | undefined): boolean {
     ArrayBuffer.isView(body) ||
     (typeof Blob !== 'undefined' && body instanceof Blob)
   );
+}
+
+function getDefaultContentType(
+  body: BodyInit | null | undefined,
+  method: string
+): string | undefined {
+  if (body instanceof URLSearchParams) {
+    return 'application/x-www-form-urlencoded;charset=UTF-8';
+  }
+  if (method === 'GET' || method === 'HEAD' || !isRawBinaryBody(body)) return undefined;
+  if (typeof Blob !== 'undefined' && body instanceof Blob && body.type) return body.type;
+  return 'application/octet-stream';
 }
 
 function bytesToLatin1(bytes: Uint8Array): string {

--- a/packages/webapp/tests/kernel/realm/realm-browser-bridge.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-browser-bridge.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { serializeRequestInit } from '../../../src/kernel/realm/realm-browser-bridge.js';
+import { getFetchBodyBytes } from '../../../src/shell/fetch-body.js';
+
+const expectedBytes = [0x00, 0x7f, 0x80, 0xff, 0x2a];
+
+function bytesBuffer(): ArrayBuffer {
+  return new Uint8Array(expectedBytes).buffer;
+}
+
+describe('serializeRequestInit', () => {
+  const binaryBodies: Array<[string, () => BodyInit]> = [
+    ['Uint8Array', () => new Uint8Array(expectedBytes)],
+    ['ArrayBuffer', bytesBuffer],
+    [
+      'ArrayBufferView',
+      () => {
+        const framed = new Uint8Array([0xaa, ...expectedBytes, 0xbb]);
+        return new DataView(framed.buffer, 1, expectedBytes.length);
+      },
+    ],
+    ['Blob', () => new Blob([new Uint8Array(expectedBytes)])],
+  ];
+
+  it.each(binaryBodies)('round-trips a %s body through latin1', async (_name, makeBody) => {
+    const serialized = await serializeRequestInit({ method: 'post', body: makeBody() }, '/upload');
+
+    expect(serialized?.method).toBe('POST');
+    expect(serialized?.headers).toEqual({ 'Content-Type': 'application/octet-stream' });
+    expect(Array.from(getFetchBodyBytes(serialized?.body as string))).toEqual(expectedBytes);
+  });
+
+  it('preserves a caller-provided binary Content-Type case-insensitively', async () => {
+    const serialized = await serializeRequestInit(
+      {
+        headers: { 'content-type': 'image/png' },
+        body: new Uint8Array(expectedBytes),
+      },
+      '/upload'
+    );
+
+    expect(serialized?.headers).toEqual({ 'content-type': 'image/png' });
+  });
+
+  it('leaves string and URLSearchParams bodies unchanged', async () => {
+    const text = await serializeRequestInit({ body: 'hello\u0000world' }, '/text');
+    const params = new URLSearchParams({ grant_type: 'client_credentials', scope: 'a b' });
+    const form = await serializeRequestInit({ body: params }, '/token');
+
+    expect(text?.body).toBe('hello\u0000world');
+    expect(text?.headers).toEqual({});
+    expect(form?.body).toBe(params.toString());
+    expect(form?.headers).toEqual({});
+  });
+
+  it('rejects unsupported FormData and ReadableStream bodies explicitly', async () => {
+    await expect(serializeRequestInit({ body: new FormData() }, '/form')).rejects.toThrow(
+      'node fetch shim: FormData request bodies are not supported (post raw application/x-www-form-urlencoded with URLSearchParams instead)'
+    );
+    await expect(
+      serializeRequestInit({ body: new ReadableStream<Uint8Array>() }, '/stream')
+    ).rejects.toThrow(
+      'node fetch shim: ReadableStream request bodies are not supported (collect into a Uint8Array or string before calling fetch)'
+    );
+  });
+});

--- a/packages/webapp/tests/kernel/realm/realm-browser-bridge.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-browser-bridge.test.ts
@@ -30,16 +30,29 @@ describe('serializeRequestInit', () => {
     expect(Array.from(getFetchBodyBytes(serialized?.body as string))).toEqual(expectedBytes);
   });
 
-  it('preserves a caller-provided binary Content-Type case-insensitively', async () => {
+  it.each([
+    ['image/png', 'image/png'],
+    ['', 'application/octet-stream'],
+  ])('defaults a Blob with type %j to %s', async (type, contentType) => {
+    const serialized = await serializeRequestInit(
+      { body: new Blob([new Uint8Array(expectedBytes)], { type }) },
+      '/upload'
+    );
+
+    expect(serialized?.headers).toEqual({ 'Content-Type': contentType });
+    expect(Array.from(getFetchBodyBytes(serialized?.body as string))).toEqual(expectedBytes);
+  });
+
+  it('preserves a caller-provided Blob Content-Type case-insensitively', async () => {
     const serialized = await serializeRequestInit(
       {
-        headers: { 'content-type': 'image/png' },
-        body: new Uint8Array(expectedBytes),
+        headers: { 'CONTENT-TYPE': 'application/custom' },
+        body: new Blob([new Uint8Array(expectedBytes)], { type: 'image/png' }),
       },
       '/upload'
     );
 
-    expect(serialized?.headers).toEqual({ 'content-type': 'image/png' });
+    expect(serialized?.headers).toEqual({ 'CONTENT-TYPE': 'application/custom' });
   });
 
   it('leaves string and URLSearchParams bodies unchanged', async () => {

--- a/packages/webapp/tests/shell/node-fetch-adapter.test.ts
+++ b/packages/webapp/tests/shell/node-fetch-adapter.test.ts
@@ -126,15 +126,27 @@ describe('createNodeFetchAdapter', () => {
     expect(opts.body).toBe('grant_type=refresh_token&client_id=GWS_CLIENT_ID_MASKED');
   });
 
-  it('decodes Uint8Array body as UTF-8 text', async () => {
+  it.each([
+    ['Uint8Array', (bytes: Uint8Array) => bytes as BodyInit],
+    ['ArrayBuffer', (bytes: Uint8Array) => bytes.buffer as BodyInit],
+    [
+      'ArrayBufferView',
+      (bytes: Uint8Array) =>
+        new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength) as BodyInit,
+    ],
+  ])('encodes %s body as latin1 and defaults its Content-Type', async (_name, makeBody) => {
     const secureFetch: SecureFetch = vi.fn(async () => okResult());
     const fetch = createNodeFetchAdapter(secureFetch);
 
-    const bytes = new TextEncoder().encode('hello body');
-    await fetch('https://api.example.com/x', { method: 'POST', body: bytes });
+    const bytes = new Uint8Array([0x00, 0x7f, 0x80, 0xff]);
+    await fetch('https://api.example.com/x', { method: 'POST', body: makeBody(bytes) });
 
-    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as { body: string };
-    expect(opts.body).toBe('hello body');
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      body: string;
+      headers: Record<string, string>;
+    };
+    expect(Array.from(opts.body, (char) => char.charCodeAt(0))).toEqual(Array.from(bytes));
+    expect(opts.headers['Content-Type']).toBe('application/octet-stream');
   });
 
   it('strips bodies on GET / HEAD per fetch semantics', async () => {
@@ -205,13 +217,24 @@ describe('createNodeFetchAdapter', () => {
     expect(await resp.text()).toBe('');
   });
 
-  it('rejects Blob and FormData bodies with a clear message', async () => {
+  it('encodes Blob bodies as latin1', async () => {
     const secureFetch: SecureFetch = vi.fn(async () => okResult());
     const fetch = createNodeFetchAdapter(secureFetch);
+    const bytes = new Uint8Array([0x00, 0x80, 0xff]);
 
-    await expect(
-      fetch('https://api.example.com/x', { method: 'POST', body: new Blob(['x']) })
-    ).rejects.toThrow(/Blob request bodies are not supported/);
+    await fetch('https://api.example.com/x', { method: 'POST', body: new Blob([bytes]) });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      body: string;
+      headers: Record<string, string>;
+    };
+    expect(Array.from(opts.body, (char) => char.charCodeAt(0))).toEqual(Array.from(bytes));
+    expect(opts.headers['Content-Type']).toBe('application/octet-stream');
+  });
+
+  it('rejects FormData bodies with a clear message', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
 
     const fd = new FormData();
     fd.set('a', 'b');
@@ -257,6 +280,25 @@ describe('createNodeFetchAdapter', () => {
     expect(opts.headers['content-type']).toBe('text/plain');
     expect(opts.headers['authorization']).toBe('Bearer from-request');
     expect(opts.body).toBe('from-request-body');
+  });
+
+  it('encodes a binary Request body as latin1 and defaults its Content-Type', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+    const bytes = new Uint8Array([0x00, 0x7f, 0x80, 0xff]);
+    const request = new Request('https://api.example.com/request', {
+      method: 'POST',
+      body: bytes,
+    });
+
+    await fetch(request);
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      body: string;
+      headers: Record<string, string>;
+    };
+    expect(Array.from(opts.body, (char) => char.charCodeAt(0))).toEqual(Array.from(bytes));
+    expect(opts.headers['Content-Type']).toBe('application/octet-stream');
   });
 
   it('lets init override method, headers, and body from a Request input', async () => {

--- a/packages/webapp/tests/shell/prepare-request-body.test.ts
+++ b/packages/webapp/tests/shell/prepare-request-body.test.ts
@@ -75,6 +75,14 @@ describe('prepareRequestBody — binary content-type preservation', () => {
     expect(Array.from(out)).toEqual(Array.from(packBytes));
   });
 
+  it('matches an uppercase binary Content-Type header and preserves arbitrary bytes', async () => {
+    const body = bytesToLatin1(packBytes);
+    const result = prepareRequestBody(body, { 'CONTENT-TYPE': 'application/octet-stream' });
+    expect(result).toBeInstanceOf(Blob);
+    const out = await blobBytes(result as Blob);
+    expect(Array.from(out)).toEqual(Array.from(packBytes));
+  });
+
   it('multipart/form-data still returns a Blob (pre-existing behavior)', async () => {
     const body = bytesToLatin1(packBytes);
     const result = prepareRequestBody(body, {

--- a/packages/webapp/tests/shell/supplemental-commands/node-fetch-adapter.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/node-fetch-adapter.test.ts
@@ -1,6 +1,6 @@
 import type { SecureFetch } from 'just-bash';
 import { describe, expect, it, vi } from 'vitest';
-import { createNodeFetchAdapter } from '../../src/shell/supplemental-commands/node-fetch-adapter.js';
+import { createNodeFetchAdapter } from '../../../src/shell/supplemental-commands/node-fetch-adapter.js';
 
 const okResult = (
   overrides: Partial<{
@@ -382,8 +382,6 @@ describe('createNodeFetchAdapter', () => {
       fetch('https://api.example.com/x', {
         method: 'POST',
         body: stream as unknown as BodyInit,
-        // @ts-expect-error duplex is required for stream bodies in some envs
-        duplex: 'half',
       })
     ).rejects.toThrow(/ReadableStream request bodies are not supported/);
   });

--- a/packages/webapp/tests/shell/supplemental-commands/node-fetch-adapter.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/node-fetch-adapter.test.ts
@@ -217,19 +217,41 @@ describe('createNodeFetchAdapter', () => {
     expect(await resp.text()).toBe('');
   });
 
-  it('encodes Blob bodies as latin1', async () => {
+  it.each([
+    ['image/png', 'image/png'],
+    ['', 'application/octet-stream'],
+  ])('encodes a Blob with type %j as latin1 and defaults to %s', async (type, contentType) => {
     const secureFetch: SecureFetch = vi.fn(async () => okResult());
     const fetch = createNodeFetchAdapter(secureFetch);
     const bytes = new Uint8Array([0x00, 0x80, 0xff]);
 
-    await fetch('https://api.example.com/x', { method: 'POST', body: new Blob([bytes]) });
+    await fetch('https://api.example.com/x', {
+      method: 'POST',
+      body: new Blob([bytes], { type }),
+    });
 
     const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
       body: string;
       headers: Record<string, string>;
     };
     expect(Array.from(opts.body, (char) => char.charCodeAt(0))).toEqual(Array.from(bytes));
-    expect(opts.headers['Content-Type']).toBe('application/octet-stream');
+    expect(opts.headers['Content-Type']).toBe(contentType);
+  });
+
+  it('preserves a caller-provided Content-Type for a Blob case-insensitively', async () => {
+    const secureFetch: SecureFetch = vi.fn(async () => okResult());
+    const fetch = createNodeFetchAdapter(secureFetch);
+
+    await fetch('https://api.example.com/x', {
+      method: 'POST',
+      headers: { 'CONTENT-TYPE': 'application/custom' },
+      body: new Blob(['data'], { type: 'image/png' }),
+    });
+
+    const opts = (secureFetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
+    expect(opts.headers).toEqual({ 'CONTENT-TYPE': 'application/custom' });
   });
 
   it('rejects FormData bodies with a clear message', async () => {


### PR DESCRIPTION
## Problem

The jsh `fetch` shim corrupted **every** binary request body. For a 50,000-byte payload the server received:

| Body type | Server size | Cause |
|---|---|---|
| `Uint8Array` | 178,565 bytes | `String(uint8array)` -> comma-joined decimals |
| `ArrayBuffer` | 20 bytes | `String(arrayBuffer)` -> `"[object ArrayBuffer]"` |
| `Blob` | 13 bytes | `String(blob)` -> `"[object Blob]"` |

Binary was stringified at **two** encode layers before it ever left the realm.

## Fix

Thread binary through the existing `SecureFetch` `body: string` contract using a **latin1 (one-byte-per-char)** convention, reconstituted into a `Blob` at the proxy. No change to the RPC wire types.

- **`kernel/realm/realm-browser-bridge.ts`** - `serializeRequestInit` latin1-encodes `Uint8Array` / `ArrayBuffer` / `ArrayBufferView` / `Blob`, defaults a missing binary `Content-Type` to `application/octet-stream`, and throws explicit unsupported-body errors for `FormData` / `ReadableStream` (plus a catch-all). Now async.
- **`kernel/realm/js-realm-shared.ts`** - awaits the now-async `serializeRequestInit`.
- **`shell/supplemental-commands/node-fetch-adapter.ts`** - `encodeBody` + `Request` path latin1-encode binary, support `Blob`, default octet-stream, preserve text / `URLSearchParams`.
- **`shell/proxied-fetch.ts`** - `prepareRequestBody` uses a case-insensitive `Content-Type` lookup so bytes survive an all-caps header.

## Intentional deviation

A raw binary body with no `Content-Type` is defaulted to `application/octet-stream` (browser `fetch` sends none). Required so the proxy's non-text branch preserves the bytes.

## Tests

- New `tests/kernel/realm/realm-browser-bridge.test.ts` - latin1 round-trip for all binary types + unsupported-body throws.
- Adapter test relocated to `tests/shell/supplemental-commands/` to mirror `src/`; 28-test suite.
- `tests/shell/prepare-request-body.test.ts` - uppercase `CONTENT-TYPE` regression.

## Verification

Independent verifier **APPROVED** (criteria A-F): 50,000-byte probe byte-exact for Uint8Array / ArrayBuffer / Blob across both encode layers; layer consistency; throws; text passthrough; uppercase header; moved test path. `lint` 0, `typecheck` 0, full webapp suite 0 (535 files / 9,486 tests), coverage passed.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author