### PR TITLE
fix(dev-tools): make check-skill-router-sync robust to bash 3.2 empty arrays (unblocks releases)

### DIFF
--- a/packages/dev-tools/tools/check-skill-router-sync.sh
+++ b/packages/dev-tools/tools/check-skill-router-sync.sh
@@ -45,7 +45,7 @@ awk '
 
 shopt -s nullglob
 skill_files=("$AGENT_SKILLS"/*/SKILL.md)
-for skill_file in "${skill_files[@]}"; do
+for skill_file in ${skill_files[@]+"${skill_files[@]}"}; do
   basename "$(dirname "$skill_file")"
 done | sort -u >"$ACTUAL_SKILLS"
 
@@ -74,7 +74,7 @@ if [[ -s "$MISSING_FROM_DISK" ]]; then
   sed 's/^/  - /' "$MISSING_FROM_DISK" >&2
 fi
 
-for skill_file in "${skill_files[@]}"; do
+for skill_file in ${skill_files[@]+"${skill_files[@]}"}; do
   name="$(basename "$(dirname "$skill_file")")"
   if [[ ! -e "$CLAUDE_SKILLS/$name" && ! -L "$CLAUDE_SKILLS/$name" ]]; then
     STATUS=1
@@ -83,7 +83,13 @@ for skill_file in "${skill_files[@]}"; do
 done
 
 claude_entries=("$CLAUDE_SKILLS"/*)
-for entry in "${claude_entries[@]}"; do
+# ${arr[@]+"${arr[@]}"} guards an empty array under `set -u` on bash < 4.4 (the
+# macOS release runner ships bash 3.2), where a bare "${arr[@]}" is a fatal
+# "unbound variable" error. Without the guard, an empty .claude/skills aborts
+# here — after STATUS=1 was set for a missing skill — before the final
+# `exit 1`, and the EXIT trap's `rm` then reset the exit code to 0, so the
+# check silently passed when it should have failed.
+for entry in ${claude_entries[@]+"${claude_entries[@]}"}; do
   name="$(basename "$entry")"
   canonical="$AGENT_SKILLS/$name"
   if [[ ! -d "$canonical" || ! -f "$canonical/SKILL.md" ]]; then


### PR DESCRIPTION
## Summary

Fix a bash-3.2 bug in `check-skill-router-sync.sh` that fails the *"rejects a canonical skill missing from the Claude skill directory"* test — which has blocked **every SLICC release** (the release job's `npm run test` gate never reaches semantic-release). The missing-skill check set `STATUS=1` correctly, but the script then aborted and exited "green"; now it exits 1 as intended.

## Why

The release job runs on a macOS runner (bash 3.2). There, iterating an **empty** array under `set -u` — `for entry in "${claude_entries[@]}"` when `.claude/skills` has no entries — is a fatal `unbound variable` error. It aborted the script *after* `STATUS=1` was set for the missing skill but *before* the final `exit 1`, and the `EXIT` trap's `rm` then reset the exit code to `0`. So on macOS the check reported success when it should have failed; a dev on bash ≥ 4.4 never saw it.

This has failed releases since ~15:27 UTC today (runs `30020661367`, `30022308142`, and mine `30027162467`), so neither `sliccy` nor the new `@ai-ecoverse/biome-jsh` (#1642) can publish until it's green.

**Repro** (before: `exit=0` wrong · after: `exit=1` correct):
```sh
root=$(mktemp -d); mkdir -p "$root/.agents/skills/alpha" "$root/.claude/skills"
printf -- '---\nname: alpha\n---\n' > "$root/.agents/skills/alpha/SKILL.md"
ln -s ../../.agents/skills/alpha "$root/.claude/skills/alpha"
printf '## Developer Agent Skills (.agents/skills/)\n\n- x \xe2\x86\x92 use `alpha`\n' > "$root/AGENTS.md"
rm "$root/.claude/skills/alpha"
bash packages/dev-tools/tools/check-skill-router-sync.sh "$root"; echo "exit=$?"
```

## Approach / Implementation notes

Guard the array iterations with `${arr[@]+"${arr[@]}"}` so an empty array expands to nothing instead of erroring under `set -u` on bash < 4.4. Applied to both `skill_files` loops and the `claude_entries` loop; a comment on the latter documents the empty-array + `set -u` + `EXIT`-trap interaction so it isn't reintroduced.

## Test plan

- [x] `npx vitest run packages/dev-tools/tools/check-skill-router-sync.test.mjs` — **7 passed** (was 1 failed) under bash 3.2 (local macOS) and bash 5.
- [x] Manual repro above: `exit 0` → `exit 1`.

## Risk & rollback

Minimal — one script, quoting-only change. Behavior is identical on bash ≥ 4.4 and corrected on bash 3.2; reverts cleanly.
