### PR TITLE
feat(biome-jsh): add `lint` subcommand + publish-warning cleanup

### DIFF
--- a/packages/dev-tools/biome-jsh/README.md
+++ b/packages/dev-tools/biome-jsh/README.md
@@ -34,14 +34,16 @@ path); this CLI is the binary path.
 
 ```sh
 biome-jsh check  [paths...]           # lint + format-check (github reporter)
+biome-jsh lint   [paths...]           # lint only, no format-check
 biome-jsh format [paths...]           # print formatted output to stdout
 biome-jsh format --write [paths...]   # format files in place
 ```
 
 Paths may be files or directories (walked recursively; `node_modules` and
 `.git` skipped). `check` exits non-zero when any file has an error or is not
-formatted, and emits GitHub Actions annotations on stdout so CI surfaces them
-inline.
+formatted; `lint` skips the format-check (useful for repos that don't enforce
+formatting on legacy files). Both emit GitHub Actions annotations on stdout so
+CI surfaces them inline.
 
 ```sh
 biome-jsh check skills/

--- a/packages/dev-tools/biome-jsh/biome-jsh.mjs
+++ b/packages/dev-tools/biome-jsh/biome-jsh.mjs
@@ -52,6 +52,7 @@ const HELP = `biome-jsh - a jsh-aware Biome runner
 
 Usage:
   biome-jsh check  [paths...]          Lint + format-check (--reporter=github)
+  biome-jsh lint   [paths...]          Lint only, no format-check (--reporter=github)
   biome-jsh format [paths...]          Print formatted output to stdout
   biome-jsh format --write [paths...]  Format files in place
 
@@ -99,7 +100,7 @@ function parseArgs(argv) {
     if (arg === '-h' || arg === '--help') parsed.help = true;
     else if (arg === '-v' || arg === '--version') parsed.version = true;
     else if (arg === '--write') parsed.write = true;
-    else if (parsed.subcommand === null && (arg === 'check' || arg === 'format'))
+    else if (parsed.subcommand === null && (arg === 'check' || arg === 'lint' || arg === 'format'))
       parsed.subcommand = arg;
     else if (arg.startsWith('-')) fail(`unknown option: ${arg}`);
     else parsed.paths.push(arg);
@@ -155,7 +156,7 @@ function formatWrapped(bin, source, dir, tempBase, tempPath) {
   return { safe, changed: safe !== source, failed: false };
 }
 
-function processWrappedCheck(bin, file) {
+function processWrappedLint(bin, file) {
   const dir = dirname(file);
   const source = readFileSync(file, 'utf8');
   const tempBase = tempName(file);
@@ -173,6 +174,19 @@ function processWrappedCheck(bin, file) {
       out.errorCount++;
       out.lines.push(makeStderrLines(lint.stderr));
     }
+  } finally {
+    safeUnlink(tempPath);
+  }
+  return out;
+}
+
+function processWrappedCheck(bin, file) {
+  const out = processWrappedLint(bin, file);
+  const dir = dirname(file);
+  const source = readFileSync(file, 'utf8');
+  const tempBase = tempName(file);
+  const tempPath = join(dir, tempBase);
+  try {
     const fmt = formatWrapped(bin, source, dir, tempBase, tempPath);
     if (fmt.failed) {
       out.lines.push(
@@ -218,6 +232,17 @@ function processWrappedFormat(bin, file, write) {
 function processPlainCheck(bin, file) {
   const dir = dirname(file);
   const result = runBiome(bin, ['check', '--reporter=github', basename(file)], dir);
+  const remapped = remapGithubOutput(result.stdout, file, 0);
+  if (result.status !== 0 && remapped.errorCount === 0 && remapped.warningCount === 0) {
+    remapped.errorCount++;
+    remapped.lines.push(makeStderrLines(result.stderr));
+  }
+  return remapped;
+}
+
+function processPlainLint(bin, file) {
+  const dir = dirname(file);
+  const result = runBiome(bin, ['lint', '--reporter=github', basename(file)], dir);
   const remapped = remapGithubOutput(result.stdout, file, 0);
   if (result.status !== 0 && remapped.errorCount === 0 && remapped.warningCount === 0) {
     remapped.errorCount++;
@@ -284,14 +309,14 @@ function fail(message) {
   process.exit(2);
 }
 
-function runCheck(bin, files, missing) {
+// Shared reporter for `check`/`lint`: run a per-file processor, aggregate the
+// github annotations + counts, and set the exit code (1 if any errors).
+function runReport(bin, files, missing, wrappedFn, plainFn) {
   const outLines = [];
   let errorCount = missing.length;
   let warningCount = 0;
   for (const file of files) {
-    const r = shouldWrapForBiome(file)
-      ? processWrappedCheck(bin, file)
-      : processPlainCheck(bin, file);
+    const r = shouldWrapForBiome(file) ? wrappedFn(bin, file) : plainFn(bin, file);
     outLines.push(...r.lines);
     errorCount += r.errorCount;
     warningCount += r.warningCount;
@@ -301,6 +326,14 @@ function runCheck(bin, files, missing) {
     `biome-jsh: ${files.length} file(s), ${errorCount} error(s), ${warningCount} warning(s)\n`
   );
   process.exitCode = errorCount > 0 ? 1 : 0;
+}
+
+function runCheck(bin, files, missing) {
+  runReport(bin, files, missing, processWrappedCheck, processPlainCheck);
+}
+
+function runLint(bin, files, missing) {
+  runReport(bin, files, missing, processWrappedLint, processPlainLint);
 }
 
 function runFormat(bin, files, write, hadMissing) {
@@ -329,13 +362,14 @@ function main() {
     process.stdout.write(v.stdout || v.stderr);
     return;
   }
-  if (!parsed.subcommand) fail('missing subcommand (expected check or format)');
+  if (!parsed.subcommand) fail('missing subcommand (expected check, lint, or format)');
   if (parsed.paths.length === 0) fail('no files or directories specified');
 
   const { files, missing } = expandPaths(parsed.paths);
   for (const m of missing) process.stderr.write(`biome-jsh: ${m}: no such file or directory\n`);
 
   if (parsed.subcommand === 'check') runCheck(bin, files, missing);
+  else if (parsed.subcommand === 'lint') runLint(bin, files, missing);
   else runFormat(bin, files, parsed.write, missing.length > 0);
 }
 

--- a/packages/dev-tools/biome-jsh/biome-jsh.test.mjs
+++ b/packages/dev-tools/biome-jsh/biome-jsh.test.mjs
@@ -120,4 +120,32 @@ describe.skipIf(!BIOME_BIN)('biome-jsh CLI (integration)', () => {
     // The invalid source is left unchanged, not silently "formatted".
     expect(readFileSync(join(dir, 'broken.jsh'), 'utf8')).toBe(broken);
   });
+
+  it('lint checks lint rules but skips formatting (unlike check)', () => {
+    // Unformatted but lint-clean: `check` flags "not formatted"; `lint` doesn't.
+    const messy = 'const x=1\nawait Promise.resolve()\nif(x){return x}\n';
+    writeFileSync(join(dir, 'messy.jsh'), messy);
+
+    const lint = runCli(dir, ['lint', 'messy.jsh']);
+    expect(lint.stdout).not.toMatch(/not formatted/i);
+    expect(lint.status).toBe(0);
+
+    const check = runCli(dir, ['check', 'messy.jsh']);
+    expect(check.stdout).toMatch(/not formatted/i);
+    expect(check.status).toBe(1);
+  });
+
+  it('lint still catches a real lint error, mapped to the real line', () => {
+    const body = 'const x = 1;\nif (x == 2) {\n\tawait Promise.resolve();\n}\nreturn x;\n';
+    writeFileSync(join(dir, 'lint.jsh'), body);
+
+    const result = runCli(dir, ['lint', 'lint.jsh']);
+    const annotation = result.stdout
+      .split('\n')
+      .map(parseGithubAnnotation)
+      .find((a) => a?.fields.title.includes('noDoubleEquals'));
+    expect(annotation).toBeTruthy();
+    expect(annotation.fields.line).toBe('2');
+    expect(result.status).toBe(1);
+  });
 });

--- a/packages/dev-tools/biome-jsh/package.json
+++ b/packages/dev-tools/biome-jsh/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "bin": {
-    "biome-jsh": "./biome-jsh.mjs"
+    "biome-jsh": "biome-jsh.mjs"
   },
   "main": "./lib.mjs",
   "files": [
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ai-ecoverse/slicc",
+    "url": "git+https://github.com/ai-ecoverse/slicc.git",
     "directory": "packages/dev-tools/biome-jsh"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

Add a `lint` subcommand to `@ai-ecoverse/biome-jsh` that runs **only** the linter (no format-check), so downstream repos can lint legacy `.jsh` files without retroactively enforcing formatting. Also cleans up two npm publish auto-corrections so releases stop warning.

## Why

`biome-jsh check` runs lint **and** format-check together. `ai-ecoverse/skills` deliberately does **lint-only** on its legacy `.jsh` scripts (its curated Biome config is lint-focused; the skills aren't Biome-formatted). Swapping its CI to `biome-jsh check` would newly fail on formatting — so it needs a `lint` subcommand. Verified against the real skills: `biome-jsh lint <31 .jsh files>` → **0 errors, 122 warnings, exit 0** (identical to the repo's current hack), whereas `check` flags `teams.jsh` as unformatted.

The bin/repository fixes silence the `npm warn publish "bin[biome-jsh]" … was invalid and removed` / `repository.url … normalized` warnings seen on the 5.66.0 release.

## Approach / Implementation notes

- Split `processWrappedCheck` into `processWrappedLint` (lint) + a thin `check` wrapper that adds the format-check; added `processPlainLint`.
- Factored the check/lint reporter loop into a shared `runReport(bin, files, missing, wrappedFn, plainFn)`; `runCheck`/`runLint` are one-liners over it.
- `parseArgs`/dispatch/HELP now accept `lint`.
- `bin: "./biome-jsh.mjs"` → `"biome-jsh.mjs"`; `repository.url` → `git+https://github.com/ai-ecoverse/slicc.git`.

## Test plan

- [x] `npx vitest run packages/dev-tools/biome-jsh/` — **27 passed** (adds: `lint` ignores formatting where `check` flags it; `lint` still catches a real lint error mapped to the real line).
- [x] `biome-jsh lint` over the real skills `.jsh` set → 0 errors, exit 0.
- [x] `npm publish --dry-run` → no bin/repository warnings.

## Risk & rollback

Low — additive subcommand + metadata cleanup; existing `check`/`format` behavior unchanged (same 25 prior tests pass). Reverts cleanly.
