### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -69,7 +69,7 @@
       "lines": 79,
       "statements": 77,
       "functions": 78,
-      "branches": 67,
+      "branches": 68,
       "coverageExclude": [
         "**/node_modules/**",
         "**/dist/**",


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.