### PR TITLE
Add pre-push lint gate mirroring CI lint job

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -12,10 +12,10 @@ set -e
 # Escape hatch: `git push --no-verify`.
 
 DEFAULT_BRANCH="main"
-BASE_REF="origin/$DEFAULT_BRANCH"
+export BASE_REF="origin/$DEFAULT_BRANCH"
 if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null 2>&1; then
   # Fresh clone without an origin/main ref — fall back to the local branch.
-  BASE_REF="$DEFAULT_BRANCH"
+  export BASE_REF="$DEFAULT_BRANCH"
 fi
 
 # Track whether we're pushing a feature branch (non-main). The lint gate only

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -18,6 +18,9 @@ if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null 2>&1; then
   BASE_REF="$DEFAULT_BRANCH"
 fi
 
+# Track whether we're pushing a feature branch (non-main). The lint gate only
+# runs for feature branches — pushes to main itself are gated by the merge queue.
+pushing_feature=false
 status=0
 while read -r local_ref local_oid remote_ref remote_oid; do
   # Skip branch deletions (local oid is all zeros).
@@ -30,9 +33,18 @@ while read -r local_ref local_oid remote_ref remote_oid; do
   if [ "$remote_ref" = "refs/heads/$DEFAULT_BRANCH" ]; then
     continue
   fi
+  pushing_feature=true
   if ! bash packages/dev-tools/tools/check-linear-history.sh "$BASE_REF" "$local_oid"; then
     status=1
   fi
 done
 
-exit "$status"
+[ "$status" -ne 0 ] && exit "$status"
+
+# ── Lint gate ────────────────────────────────────────────────────────────────
+# Mirror the CI `lint` job locally so failures surface before the push, not
+# after a red PR. Only runs for feature branches.
+# Escape hatch: `git push --no-verify`.
+if [ "$pushing_feature" = true ]; then
+  bash packages/dev-tools/tools/pre-push-lint-gate.sh
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -33,7 +33,10 @@ while read -r local_ref local_oid remote_ref remote_oid; do
   if [ "$remote_ref" = "refs/heads/$DEFAULT_BRANCH" ]; then
     continue
   fi
-  pushing_feature=true
+  # Only feature branches trigger the lint gate — skip tags and other refs.
+  case "$remote_ref" in
+    refs/heads/*) pushing_feature=true ;;
+  esac
   pushed_oid="$local_oid"
   if ! bash packages/dev-tools/tools/check-linear-history.sh "$BASE_REF" "$local_oid"; then
     status=1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -34,6 +34,7 @@ while read -r local_ref local_oid remote_ref remote_oid; do
     continue
   fi
   pushing_feature=true
+  pushed_oid="$local_oid"
   if ! bash packages/dev-tools/tools/check-linear-history.sh "$BASE_REF" "$local_oid"; then
     status=1
   fi
@@ -46,5 +47,20 @@ done
 # after a red PR. Only runs for feature branches.
 # Escape hatch: `git push --no-verify`.
 if [ "$pushing_feature" = true ]; then
+  # Ensure the working tree matches the pushed commit. Without this, the gate
+  # could pass against uncommitted fixes while the pushed commit still has
+  # lint failures, or fail due to unrelated uncommitted changes.
+  head_oid="$(git rev-parse HEAD)"
+  if [ "$pushed_oid" != "$head_oid" ]; then
+    echo "pre-push: pushed OID ($pushed_oid) differs from HEAD ($head_oid)." >&2
+    echo "Check out the branch you are pushing, or use git push --no-verify." >&2
+    exit 1
+  fi
+  if ! git diff --quiet HEAD; then
+    echo "pre-push: working tree has uncommitted changes." >&2
+    echo "Commit or stash them so the lint gate checks what will actually be pushed." >&2
+    exit 1
+  fi
+
   bash packages/dev-tools/tools/pre-push-lint-gate.sh
 fi

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -4,10 +4,25 @@ The full verification pass to run **before committing, pushing, or opening a PR*
 These mirror the CI gates in `.github/workflows/ci.yml`; running them locally first
 is the fastest way to avoid a red PR.
 
+## Pre-push lint gate (automatic)
+
+The `.husky/pre-push` hook runs the full CI lint gate automatically before every
+push to a feature branch. It mirrors every check from the CI `lint` job —
+biome, prettier, custom lint scripts, complexity gate, manifest justifications,
+and knip dead-code detection — all in parallel (~6 s wall-clock).
+
+You can also run it manually:
+
+```bash
+npm run verify                         # Same gate, run on demand
+```
+
+Escape hatch: `git push --no-verify` bypasses the gate when needed.
+
 ## The standard pass
 
 ```bash
-npm run lint                           # Format + lint FIRST — CI fails on unformatted code
+npm run verify                         # Lint gate (mirrors CI lint job)
 npm run typecheck
 npm run test
 npm run test:coverage                  # Enforces minimum coverage thresholds
@@ -65,9 +80,10 @@ To check whether a file is exempt, search `biome.json` for its path under the
 
 ## Other CI-only gates
 
-The `lint` job also checks the Chrome Web Store manifest justifications and runs knip
-dead-code detection; the `cloudflare-worker` job runs `wrangler deploy --dry-run`. These
-rarely trip for typical changes but live in `.github/workflows/ci.yml` if you need them.
+The `cloudflare-worker` job runs `wrangler deploy --dry-run`. This rarely trips for
+typical changes but lives in `.github/workflows/ci.yml` if you need it. All other
+lint-job gates (manifest justifications, knip dead-code) are now covered by the
+pre-push lint gate (`npm run verify`).
 
 ## Knip fixture exclusion
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "postinstall": "if [ -d patches ]; then npx --no-install patch-package || { echo \"ERROR: patches/ present but patch-package not installed (run a full 'npm ci' incl. devDependencies)\"; exit 1; }; fi && if [ -d packages/shared-ts ]; then npm run build -w @slicc/shared-ts; fi && if [ -d packages/cloud-core ]; then npm run build -w @slicc/cloud-core; fi && if [ -d packages/spoon ]; then npm run build -w @ai-ecoverse/spoon; fi && if [ -d packages/webcomponents ]; then npm run build -w @slicc/webcomponents; fi && if [ -d packages/cherry ]; then npm run build -w @ai-ecoverse/cherry; fi",
     "prepare": "husky",
     "lint:no-raw-chrome-runtime-id": "node packages/dev-tools/tools/check-no-raw-chrome-runtime-id.mjs",
-    "lint:hosted-origin": "node packages/dev-tools/tools/check-hosted-origin-literal.mjs"
+    "lint:hosted-origin": "node packages/dev-tools/tools/check-hosted-origin-literal.mjs",
+    "verify": "bash packages/dev-tools/tools/pre-push-lint-gate.sh"
   },
   "dependencies": {
     "e2b": "^2.35.0",

--- a/packages/dev-tools/tools/pre-push-lint-gate.sh
+++ b/packages/dev-tools/tools/pre-push-lint-gate.sh
@@ -24,7 +24,15 @@ done
 
 # ── tmp dir for per-check logs ───────────────────────────────────────────────
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT
+cleanup() {
+	# Kill any outstanding background checks before removing logs.
+	for pid in "${CHECK_PIDS[@]+${CHECK_PIDS[@]}}"; do
+		kill "$pid" 2>/dev/null || true
+	done
+	wait 2>/dev/null || true
+	rm -rf "$tmp"
+}
+trap cleanup EXIT INT TERM
 
 # ── palette (no-op when stdout is not a tty) ─────────────────────────────────
 if [ -t 1 ]; then

--- a/packages/dev-tools/tools/pre-push-lint-gate.sh
+++ b/packages/dev-tools/tools/pre-push-lint-gate.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-push lint gate — mirrors the CI `lint` job locally so failures surface
+# before the push, not after a red PR.  All independent checks run in parallel;
+# the wall-clock cost is dominated by the two heaviest scanners (biome ≈2 s,
+# prettier ≈6 s) rather than the serial sum of every step.
+#
+# Called from .husky/pre-push. Also exposed as `npm run verify`.
+# Escape hatch: `git push --no-verify`.
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# ── tmp dir for per-check logs ───────────────────────────────────────────────
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# ── palette (no-op when stdout is not a tty) ─────────────────────────────────
+if [ -t 1 ]; then
+	R=$'\033[31m' G=$'\033[32m' Y=$'\033[33m' B=$'\033[1m' Z=$'\033[0m'
+else
+	R='' G='' Y='' B='' Z=''
+fi
+
+# ── run_check NAME COMMAND… ──────────────────────────────────────────────────
+# Runs COMMAND in the background, logs output, records exit code.
+declare -a CHECK_NAMES=()
+declare -a CHECK_PIDS=()
+
+run_check() {
+	local name="$1"
+	shift
+	CHECK_NAMES+=("$name")
+	"$@" >"$tmp/$name.log" 2>&1 &
+	CHECK_PIDS+=($!)
+}
+
+# ── launch all checks in parallel ────────────────────────────────────────────
+
+# Heavy whole-repo scanners (run directly to avoid npm overhead)
+run_check "biome" npx biome check .
+run_check "prettier" npx prettier --check .
+
+# Lightweight custom lints — grouped into one sequential check to avoid
+# spawning 8 separate npm processes for sub-second scripts.
+run_check "custom-lints" bash -c '
+  npm run lint:docs --silent &&
+  npm run lint:skills --silent -- --strict &&
+  npm run lint:skill-router --silent &&
+  npm run lint:no-innerhtml --silent &&
+  npm run lint:no-ui-in-providers --silent &&
+  npm run lint:patches --silent &&
+  npm run lint:no-raw-chrome-runtime-id --silent &&
+  npm run lint:hosted-origin --silent
+'
+
+# CI-only steps (not in lint:ci)
+run_check "complexity" node packages/dev-tools/tools/check-touched-exemptions.mjs
+run_check "manifest" bash packages/dev-tools/tools/check-manifest-justifications.sh
+
+# Dead-code detection (two independent knip passes)
+run_check "deadcode" npm run deadcode --silent -- --no-progress --reporter compact
+run_check "deadcode-prod" npm run deadcode:production-files --silent -- --no-progress --reporter compact
+
+# ── wait for all, collect results ────────────────────────────────────────────
+failures=0
+i=0
+for pid in "${CHECK_PIDS[@]}"; do
+	name="${CHECK_NAMES[$i]}"
+	if wait "$pid"; then
+		echo "${G}✓${Z} $name"
+	else
+		echo "${R}✗${Z} ${B}$name${Z}"
+		# Show the failing output indented for quick scanning
+		sed 's/^/  │ /' "$tmp/$name.log"
+		failures=$((failures + 1))
+	fi
+	i=$((i + 1))
+done
+
+# ── summary ──────────────────────────────────────────────────────────────────
+total=${#CHECK_NAMES[@]}
+
+echo ""
+if [ "$failures" -eq 0 ]; then
+	echo "${G}All $total checks passed.${Z}"
+else
+	echo "${R}$failures of $total checks failed.${Z} Fix the issues above and push again."
+	echo "${Y}Tip:${Z} use ${B}git push --no-verify${Z} to bypass this gate."
+	exit 1
+fi

--- a/packages/dev-tools/tools/pre-push-lint-gate.sh
+++ b/packages/dev-tools/tools/pre-push-lint-gate.sh
@@ -12,6 +12,16 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+# ── dependency check ──────────────────────────────────────────────────────────
+BIN="$REPO_ROOT/node_modules/.bin"
+for bin in biome prettier knip; do
+	if [ ! -x "$BIN/$bin" ]; then
+		echo "pre-push-lint-gate: $bin not found in node_modules/.bin." >&2
+		echo "Run 'npm ci' before pushing." >&2
+		exit 2
+	fi
+done
+
 # ── tmp dir for per-check logs ───────────────────────────────────────────────
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
@@ -38,9 +48,9 @@ run_check() {
 
 # ── launch all checks in parallel ────────────────────────────────────────────
 
-# Heavy whole-repo scanners (run directly to avoid npm overhead)
-run_check "biome" npx biome check .
-run_check "prettier" npx prettier --check .
+# Heavy whole-repo scanners (pinned local binaries, no npx)
+run_check "biome" "$BIN/biome" check .
+run_check "prettier" "$BIN/prettier" --check .
 
 # Lightweight custom lints — grouped into one sequential check to avoid
 # spawning 8 separate npm processes for sub-second scripts.
@@ -59,9 +69,9 @@ run_check "custom-lints" bash -c '
 run_check "complexity" node packages/dev-tools/tools/check-touched-exemptions.mjs
 run_check "manifest" bash packages/dev-tools/tools/check-manifest-justifications.sh
 
-# Dead-code detection (two independent knip passes)
-run_check "deadcode" npm run deadcode --silent -- --no-progress --reporter compact
-run_check "deadcode-prod" npm run deadcode:production-files --silent -- --no-progress --reporter compact
+# Dead-code detection (two independent knip passes, pinned local binary)
+run_check "deadcode" "$BIN/knip" --include files,dependencies,devDependencies,unlisted,binaries,unresolved,duplicates --no-progress --reporter compact
+run_check "deadcode-prod" "$BIN/knip" --production --include files --no-progress --reporter compact
 
 # ── wait for all, collect results ────────────────────────────────────────────
 failures=0


### PR DESCRIPTION
## Summary

Closes #1577. The local git hooks now mirror the CI `lint` job so lint failures surface before the push, not after a red PR.

## What changed

**New: `packages/dev-tools/tools/pre-push-lint-gate.sh`**
Parallelized script running all CI lint checks (~6 s wall-clock vs ~15 s sequential):

| Group | Checks |
|-------|--------|
| `biome` | `biome check .` (whole repo) |
| `prettier` | `prettier --check .` (whole repo) |
| `custom-lints` | lint:docs, lint:skills --strict, lint:skill-router, lint:no-innerhtml, lint:no-ui-in-providers, lint:patches, lint:no-raw-chrome-runtime-id, lint:hosted-origin |
| `complexity` | Boy-scout complexity gate |
| `manifest` | CWS permission justifications |
| `deadcode` | knip default gate |
| `deadcode-prod` | knip production files gate |

**`.husky/pre-push`** — calls the gate for feature branches (skips main).

**`package.json`** — adds `npm run verify` for on-demand use.

**`docs/verification.md`** — documents the automatic gate and updates the standard pass.

Escape hatch: `git push --no-verify`.