### PR TITLE
fix(webapp): serve node tty built-in in js-realm worker

### DIFF
--- a/docs/node-compat-shims.md
+++ b/docs/node-compat-shims.md
@@ -169,6 +169,11 @@ Minimal stubs: `Readable`, `Writable`, `Transform`, `PassThrough`, `Stream`.
 Basic event emission and `pipe()` work. These are NOT full Node streams —
 no backpressure, no flowing/paused modes, no proper pipe chaining.
 
+### `tty`
+
+`isatty(fd)` returns `false` because the worker has no terminal. `ReadStream`
+and `WriteStream` are inert stubs provided for Node API-shape compatibility.
+
 ### `url`
 
 `URL`, `URLSearchParams` (re-exported globals), `fileURLToPath(url)`,

--- a/packages/webapp/src/kernel/realm/js-realm-helpers.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-helpers.ts
@@ -1471,6 +1471,21 @@ export const nodeOs: NodeOs = {
 };
 
 // ---------------------------------------------------------------------------
+// `nodeTty` — the minimal Node `tty` built-in served by the worker realm.
+// The browser realm has no terminal, so descriptors are never TTYs; the stream
+// constructors are harmless stubs retained for Node API shape compatibility.
+// ---------------------------------------------------------------------------
+
+class ReadStream {}
+class WriteStream {}
+
+export const nodeTty = {
+  isatty: (_fd: number): boolean => false,
+  ReadStream,
+  WriteStream,
+};
+
+// ---------------------------------------------------------------------------
 // `nodeUrl` — the subset of the Node `url` built-in served by the realm
 // `require('url')` / `require('node:url')` shim. Bridges `fileURLToPath` and
 // `pathToFileURL` (used by 5 audited .mjs files) plus re-exports the browser's

--- a/packages/webapp/src/kernel/realm/node-builtins.ts
+++ b/packages/webapp/src/kernel/realm/node-builtins.ts
@@ -22,6 +22,7 @@ export const NODE_BUILTIN_AVAILABLE: ReadonlySet<string> = new Set([
   'os',
   'path',
   'stream',
+  'tty',
   'url',
   'crypto',
   'process',

--- a/packages/webapp/src/kernel/realm/realm-module-system.ts
+++ b/packages/webapp/src/kernel/realm/realm-module-system.ts
@@ -14,6 +14,7 @@ import {
   nodeOs,
   nodePath,
   nodeStream,
+  nodeTty,
   nodeUrl,
   nodeUtil,
   nodeZlib,
@@ -246,6 +247,7 @@ function resolveServedBuiltin(
   if (bareId === 'util') return { hit: true, value: nodeUtil };
   if (bareId === 'events') return { hit: true, value: nodeEvents };
   if (bareId === 'os') return { hit: true, value: nodeOs };
+  if (bareId === 'tty') return { hit: true, value: nodeTty };
   if (bareId === 'stream') return { hit: true, value: nodeStream };
   if (bareId === 'url') return { hit: true, value: nodeUrl };
   if (bareId === 'zlib') return { hit: true, value: nodeZlib };

--- a/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
+++ b/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
@@ -10,9 +10,9 @@
  * process/buffer) and HARD-FAILS the rest with the browser-unavailable message
  * (NOT a misleading "Cannot find module 'x' (run: ipk install x)").
  *
- * `crypto` is now SERVED (Web Crypto-backed `nodeCrypto` bridge), so the
- * still-unavailable-builtin contract is pinned via `os` instead; the positive
- * crypto coverage lives in the "crypto built-in bridge" describe below.
+ * `crypto` and `os` are now SERVED, so the still-unavailable-builtin contract
+ * is pinned via `net`; the positive coverage lives in the served-builtin
+ * describe blocks below.
  *
  * Drives the same in-process `runJsRealm` engine the worker/iframe floats use,
  * so behavior parity is by construction.
@@ -65,20 +65,20 @@ describe('m4: nested package require of a browser-unavailable built-in', () => {
 
   it('a package that internally requires an unavailable built-in LOADS fine until it is actually requested', async () => {
     // Importing the package must not fail at graph-build time — only the actual
-    // require('os') at call time hard-fails. A lazily-guarded path that never
+    // require('net') at call time hard-fails. A lazily-guarded path that never
     // touches the unavailable built-in runs clean.
     const ctx = makeCtx({
       files: {
-        '/workspace/node_modules/lazyos/package.json': JSON.stringify({
-          name: 'lazyos',
+        '/workspace/node_modules/lazynet/package.json': JSON.stringify({
+          name: 'lazynet',
           version: '1.0.0',
           main: 'index.js',
         }),
-        '/workspace/node_modules/lazyos/index.js':
-          "module.exports = { host: () => require('os').hostname(), tag: 'loaded' };",
+        '/workspace/node_modules/lazynet/index.js':
+          "module.exports = { connect: () => require('net').connect(80), tag: 'loaded' };",
       },
     });
-    const out = await runCode("const m = require('lazyos'); console.log(m.tag);", ctx);
+    const out = await runCode("const m = require('lazynet'); console.log(m.tag);", ctx);
     expect(out.exitCode).toBe(0);
     expect(out.stdout.trim()).toBe('loaded');
     expect(out.stderr).not.toContain('Cannot find module');
@@ -382,6 +382,22 @@ describe('NS3: zlib built-in is served by the pako-backed shim', () => {
     );
     expect(out.exitCode).toBe(0);
     expect(out.stdout.trim()).toBe('true');
+  });
+});
+
+describe('NS3: tty built-in is served by the browser-worker shim', () => {
+  it('require("tty") and require("node:tty") return the SAME shim with non-TTY descriptors', async () => {
+    const ctx = makeCtx();
+    const out = await runCode(
+      `const tty = require('tty');
+       const aliased = require('node:tty');
+       console.log(tty.isatty(1), aliased.isatty(2), aliased === tty);`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stderr).not.toContain('not available in the browser');
+    expect(out.stderr).not.toContain('Cannot find module');
+    expect(out.stdout.trim()).toBe('false false true');
   });
 });
 


### PR DESCRIPTION
## Summary

esbuild-wasm's Node **build API** does an unconditional top-level `require('tty')` and uses only `tty.isatty(2)` for color detection. The SLICC js-realm worker served every other builtin esbuild needs (`fs`, `path`, `os`, `crypto`, `child_process`) but not `tty`, so the build API hard-failed with:

> Node built-in 'tty' is not available in the browser environment.

`initialize` / `transform` / the CLI wrapper worked because they never touch `tty`; only the programmatic build API path tripped.

This serves a minimal, pure-JS `tty` shim so `require('tty')` / `require('node:tty')` resolve. `isatty()` returns `false`, which is correct for the worker (no real TTY) and makes esbuild disable color — the desired behavior.

## Changes

- `js-realm-helpers.ts` — add a dependency-free `nodeTty` shim (`isatty() => false`).
- `realm-module-system.ts` — serve it from `resolveServedBuiltin` for `tty` (and `node:tty`, since the scheme is stripped first).
- `node-builtins.ts` — add `tty` to `NODE_BUILTIN_AVAILABLE` (the unavailable set is derived, so it updates automatically).
- `cjs-require-bare-builtins.test.ts` — regression coverage: `tty`/`node:tty` resolve to the same shim with `isatty()` false; unavailable-builtin contract re-pinned to a genuinely unavailable builtin.

## Verification

- Confirmed against installed esbuild-wasm 0.28.1: it only calls `tty.isatty(2)`, so the shim is sufficient.
- Focused realm tests pass (`cjs-require-bare-builtins`, `esm-real-path-e2e`); typecheck, webapp coverage, and canonical `lint:ci` all green.
- Scope: 3 source files + 1 test file.

## Non-goals

- The companion "esbuild CLI missing flags" issue (`external`/`platform` via the CLI). This unblocks the **programmatic** build API only.
- A full Node `tty` (raw mode, resize events, real `ReadStream`/`WriteStream` behavior).

Resolves #1631

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author