### PR TITLE
chore(renovate): pin typescript-js alias to <7 (stop TS7 re-proposals)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,11 @@
       "allowedVersions": "<1.0.0"
     },
     {
+      "description": "TypeScript 7's native Go type-checker (adopted in PR #1633) remains on the real typescript dependency, while the in-browser compiler needs the classic JS lib/typescript.js bundle; keep the typescript-js npm alias on v6 so Renovate does not re-propose the breaking v7 bump from PR #1653.",
+      "matchDepNames": ["typescript-js"],
+      "allowedVersions": "<7"
+    },
+    {
       "description": "Apply a longer 14-day cooldown for major version bumps, which carry higher risk of breaking changes and are more attractive targets for malicious actors.",
       "matchUpdateTypes": ["major"],
       "minimumReleaseAge": "14 days"


### PR DESCRIPTION
## Why

TypeScript 7 is the **native (Go) port** of the compiler. PR #1633 adopted it via a deliberate split:

- **`typescript@^7.0.0`** (native Go) -> the repo's type-checker / build tool (all `tsc --noEmit` scripts).
- **`typescript-js`** (`npm:typescript@6.0.3`) -> the classic **JS** compiler API that SLICC reads from the VFS and `eval`s in the browser (`shell/ipk/esm-transpile.ts`, the `tsc` command, the `test` command). TS7 ships **no `lib/typescript.js` bundle**, so this alias must stay on the 6.x JS compiler.

`renovate.json` never constrained the `typescript-js` alias, so Renovate keeps re-proposing the breaking `6.0.3 -> 7.0.2` bump on it (PR #1639 closed, PR #1653 still open). Each one would re-break the in-browser compiler.

## Change

One new `packageRule` in `renovate.json`:

- `matchDepNames: ["typescript-js"]` targets **only** the alias, deliberately **not** `matchPackageNames: ["typescript"]` (which would also freeze the real v7 dep).
- `allowedVersions: "<7"` keeps the alias on the 6.x JS compiler.

The real `typescript` dependency is unaffected and keeps tracking v7+.

## Verification

- `renovate-config-validator renovate.json` -> validated successfully.
- `renovate.json` parses as valid JSON.
- Pre-push gate (lint / prettier / custom-lints / complexity / manifest / deadcode) -> all passed.

## Follow-up

Closes #1653.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author