### PR TITLE
fix(slicc-cli): stamp the real release version into the signed binaries

### DIFF
--- a/packages/dev-tools/tools/release-native.mjs
+++ b/packages/dev-tools/tools/release-native.mjs
@@ -77,9 +77,10 @@ export const IOS_SCRIPT_CMD =
   'chmod +x packages/ios-app/scripts/package-and-upload-testflight.sh && packages/ios-app/scripts/package-and-upload-testflight.sh';
 // Build + Developer ID-sign + notarize the Go CLI binaries, staging them into
 // artifacts/release/ (attached by @semantic-release/github). Reuses the cert +
-// notarytool creds already set up in the macOS release job.
-export const SLICC_CLI_SCRIPT_CMD =
-  'chmod +x packages/slicc-cli/sign-and-package.sh && packages/slicc-cli/sign-and-package.sh';
+// notarytool creds already set up in the macOS release job. The version env is
+// applied to the script invocation (not the preceding `chmod`) by the caller —
+// `VAR=v chmod && script` would scope VAR to `chmod` only.
+export const SLICC_CLI_SCRIPT = 'packages/slicc-cli/sign-and-package.sh';
 // A failing publish must fail the release (fail-fast preserved via execSync).
 export const CHROME_PUBLISH_CMD = 'npm run publish:chrome';
 
@@ -340,12 +341,14 @@ function runNativeGate(args, changedFiles) {
 
   const cliDecision = decideSliccCliGating({ lastTag: args.last, changedFiles });
   if (cliDecision.sliccCli) {
-    // Pass the next version so the binaries stamp the release tag; empty (a
-    // dry-run / manual run) falls back to git describe inside the script.
+    // Pass the next version so the binaries stamp the release tag. The env MUST
+    // sit on the script invocation, not the `chmod` before the `&&` (which would
+    // scope it to `chmod`). Empty (a dry-run / manual run) → the script falls
+    // back to package.json, then git describe.
     const versionEnv = args.next.trim() ? `SLICC_RELEASE_VERSION='${args.next.trim()}' ` : '';
     runStep(
       'slicc CLI (signed + notarized binaries)',
-      `${versionEnv}${SLICC_CLI_SCRIPT_CMD}`,
+      `chmod +x ${SLICC_CLI_SCRIPT} && ${versionEnv}${SLICC_CLI_SCRIPT}`,
       args.dryRun
     );
   } else {

--- a/packages/slicc-cli/sign-and-package.sh
+++ b/packages/slicc-cli/sign-and-package.sh
@@ -19,10 +19,17 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
 
-# nextRelease.version (e.g. "5.70.0") → the v-prefixed tag style the binaries
-# stamp; fall back to git describe for a manual/local run.
+# Version to stamp into the binaries. Priority:
+#   1. SLICC_RELEASE_VERSION (nextRelease.version, e.g. "5.71.0"), passed by
+#      release-native.mjs.
+#   2. package.json — @semantic-release/npm bumps it to the release version in an
+#      earlier prepare step, so this is correct during a release even if (1) is
+#      unset. Reliable belt-and-suspenders against env-passing mistakes.
+#   3. git describe — a manual / local run outside a release.
 if [ -n "${SLICC_RELEASE_VERSION:-}" ]; then
   VERSION="v${SLICC_RELEASE_VERSION#v}"
+elif pkgver="$(node -p "require('./package.json').version" 2>/dev/null)" && [ -n "$pkgver" ]; then
+  VERSION="v${pkgver#v}"
 else
   VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"
 fi


### PR DESCRIPTION
### Problem
`v5.71.0`'s Go binaries report `v5.70.0-19-g<sha>-dirty` instead of `v5.71.0`. The release gate built `SLICC_RELEASE_VERSION='x' chmod +x script && script`, which scopes the env var to `chmod` only — so the script ran without it and fell back to `git describe` (which, at prepareCmd time, points at the previous tag with a dirty tree).

Signing / notarization / attachment were all correct in v5.71.0 — this is only the version string.

### Fix (two layers)
- **`release-native.mjs`** puts the version env on the *script* invocation (after `&&`), not the preceding `chmod`.
- **`sign-and-package.sh`** falls back to `package.json` (already bumped to the release version by `@semantic-release/npm` in an earlier prepare step) before `git describe`, so the stamp is correct even if the env is ever dropped again.

### Verification
- Dry-run now emits `chmod +x … && SLICC_RELEASE_VERSION='5.71.1' …sign-and-package.sh`.
- A local run with no env stamps `v5.71.0` from `package.json` (`slicc v5.71.0`).
- 65 release-native unit tests pass; shellcheck clean.

This `fix:` will cut `v5.71.1`, which rebuilds + re-signs the binaries with the correct version, superseding v5.71.0's mis-stamped ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)