### PR TITLE
ci(release): don't cancel in-progress releases (queue instead)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,16 @@ on:
 permissions:
   contents: read
 
+# A release must never be cancelled: semantic-release publishes npm + the GitHub
+# release/tag + a git commit + signs/notarizes native artifacts, and killing it
+# mid-flight can leave those inconsistent. cancel-in-progress:true also DROPS
+# releases — when two merges land close together, the run on the newer commit can
+# be cancelled by a run on an older one (out-of-order push events), so that
+# commit's changes never get released. Queue instead: each run finishes, and a
+# later run releases whatever is new on its own commit.
 concurrency:
   group: release-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   release:


### PR DESCRIPTION
### Why
`release.yml` used `concurrency.cancel-in-progress: true`. This session it caused a **dropped release**: #1672 (a `fix`) and #1671 (renovate) merged close together, the push events fired out of order, and the release run on #1672's commit (which would have shipped the fix) was **cancelled** by a run on #1671's *older* commit. The fix had to be re-released manually via `workflow_dispatch`.

Worse than dropping: `cancel-in-progress` can also kill a release **mid-publish** — semantic-release publishes npm + the GitHub release/tag + a git commit + signs/notarizes native artifacts, and a mid-flight kill can leave those inconsistent.

### Change
`cancel-in-progress: false` — release runs **queue** instead of cancelling. Each run finishes; a later run releases whatever is new on its own commit. (No release churn from this PR: it's a `ci:` change and touches only the workflow.)

### Note
Left the pre-existing SC2086 in the cert-import script untouched (not introduced here; CI doesn't lint workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)