### PR TITLE
feat(cloudflare-worker): curl|sh installer at sliccy.ai/install-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The fastest ways to try it:
 - **Open [www.sliccy.com](https://www.sliccy.com) in Chrome** — the hosted webapp boots SLICC straight in your browser tab.
 - **Install the macOS app** — grab the latest `.dmg` from [releases](https://github.com/ai-ecoverse/slicc/releases). No Windows or Linux UI yet.
 - **Run the CLI** — `npx sliccy` launches Chrome with the local workspace attached. Node 22+ required.
-- **Install the headless follower CLI** — `curl -fsSL https://www.sliccy.ai/install-cli | sh` installs the Go `slicc` follower binary (macOS/Linux) into `~/.local/bin` (or a writable `/usr/local/bin`).
+- **Install the headless follower CLI** — `curl -fsSL https://www.sliccy.ai/install-cli | sh` installs the Go `slicc` follower binary (macOS, Linux, WSL, Git Bash) into `~/.local/bin` (or a writable `/usr/local/bin`). Native Windows: `irm https://www.sliccy.ai/install-cli.ps1 | iex`.
 - **Load the Chrome extension** — a thin bridge that opens SLICC in an on-demand Chrome side panel.
 
 Once you're in, you can:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The fastest ways to try it:
 - **Open [www.sliccy.com](https://www.sliccy.com) in Chrome** — the hosted webapp boots SLICC straight in your browser tab.
 - **Install the macOS app** — grab the latest `.dmg` from [releases](https://github.com/ai-ecoverse/slicc/releases). No Windows or Linux UI yet.
 - **Run the CLI** — `npx sliccy` launches Chrome with the local workspace attached. Node 22+ required.
+- **Install the headless follower CLI** — `curl -fsSL https://www.sliccy.ai/install-cli | sh` installs the Go `slicc` follower binary (macOS/Linux) into `~/.slicc/bin`.
 - **Load the Chrome extension** — a thin bridge that opens SLICC in an on-demand Chrome side panel.
 
 Once you're in, you can:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The fastest ways to try it:
 - **Open [www.sliccy.com](https://www.sliccy.com) in Chrome** — the hosted webapp boots SLICC straight in your browser tab.
 - **Install the macOS app** — grab the latest `.dmg` from [releases](https://github.com/ai-ecoverse/slicc/releases). No Windows or Linux UI yet.
 - **Run the CLI** — `npx sliccy` launches Chrome with the local workspace attached. Node 22+ required.
-- **Install the headless follower CLI** — `curl -fsSL https://www.sliccy.ai/install-cli | sh` installs the Go `slicc` follower binary (macOS/Linux) into `~/.slicc/bin`.
+- **Install the headless follower CLI** — `curl -fsSL https://www.sliccy.ai/install-cli | sh` installs the Go `slicc` follower binary (macOS/Linux) into `~/.local/bin` (or a writable `/usr/local/bin`).
 - **Load the Chrome extension** — a thin bridge that opens SLICC in an on-demand Chrome side panel.
 
 Once you're in, you can:

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -19,6 +19,7 @@ the built SLICC webapp as static assets to browser visitors.
 | `src/links.ts`                                                                         | `applySliccLinks` — RFC 8288 `Link` rel set on every response                                                       |
 | `src/handoff-page.ts`                                                                  | `/handoff` route — converts `?upskill=`/`?handoff=`/`?msg=` into `Link` response header                             |
 | `src/api-catalog.ts`                                                                   | `/.well-known/api-catalog` (RFC 9264 linkset) builder                                                               |
+| `src/install-cli.ts`                                                                   | `/install-cli` POSIX installer script + `/download/slicc-cli/:target` release-asset resolver                        |
 | `src/llms-txt.ts`                                                                      | `/llms.txt` builder                                                                                                 |
 | `src/rel-docs.ts`                                                                      | `/rel/:name` — dereferenceable docs for SLICC custom rels                                                           |
 | `src/oauth-exchange.ts`, `src/oauth-registry.ts`                                       | OAuth callback relay (`/auth/callback`)                                                                             |
@@ -52,6 +53,8 @@ cloud-core.
 | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `POST /tray`                          | Create a tray; return join/controller/webhook capability URLs                                                                                             |
 | `GET /handoff`                        | Convert `?upskill=`, `?handoff=`, or `?msg=` into RFC 8288 `Link` header                                                                                  |
+| `GET /install-cli`                    | POSIX installer script for the Go `slicc` follower CLI (`curl -fsSL …/install-cli \| sh`)                                                                 |
+| `GET /download/slicc-cli/:target`     | 302 to the newest release asset for a CLI target (`darwin-arm64`, …); scans past binary-less releases; errors are real HTTP errors (no SPA fallback)      |
 | `GET /.well-known/api-catalog`        | RFC 9264 linkset for all public routes                                                                                                                    |
 | `GET /llms.txt`                       | LLM markdown digest                                                                                                                                       |
 | `GET /status`                         | Health document (`{ status, service, timestamp }`)                                                                                                        |

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -53,7 +53,8 @@ cloud-core.
 | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `POST /tray`                          | Create a tray; return join/controller/webhook capability URLs                                                                                             |
 | `GET /handoff`                        | Convert `?upskill=`, `?handoff=`, or `?msg=` into RFC 8288 `Link` header                                                                                  |
-| `GET /install-cli`                    | POSIX installer script for the Go `slicc` follower CLI (`curl -fsSL …/install-cli \| sh`)                                                                 |
+| `GET /install-cli`                    | POSIX installer script for the Go `slicc` follower CLI (`curl -fsSL …/install-cli \| sh`); covers macOS/Linux/WSL/Git Bash                                |
+| `GET /install-cli.ps1`                | Native-Windows PowerShell installer (`irm …/install-cli.ps1 \| iex`) — installs to `%LOCALAPPDATA%\Programs\slicc`, persists the user PATH                |
 | `GET /download/slicc-cli/:target`     | 302 to the newest release asset for a CLI target (`darwin-arm64`, …); scans past binary-less releases; errors are real HTTP errors (no SPA fallback)      |
 | `GET /.well-known/api-catalog`        | RFC 9264 linkset for all public routes                                                                                                                    |
 | `GET /llms.txt`                       | LLM markdown digest                                                                                                                                       |

--- a/packages/cloudflare-worker/src/api-catalog.ts
+++ b/packages/cloudflare-worker/src/api-catalog.ts
@@ -80,6 +80,12 @@ const ENTRIES: CatalogEntry[] = [
       'POSIX shell installer for the headless slicc follower CLI (curl -fsSL …/install-cli | sh).',
   },
   {
+    anchor: '/install-cli.ps1',
+    methods: ['GET', 'HEAD'],
+    description:
+      'Native-Windows PowerShell installer for the headless slicc follower CLI (irm …/install-cli.ps1 | iex).',
+  },
+  {
     anchor: '/download/slicc-cli/:target',
     methods: ['GET', 'HEAD'],
     description:

--- a/packages/cloudflare-worker/src/api-catalog.ts
+++ b/packages/cloudflare-worker/src/api-catalog.ts
@@ -73,6 +73,18 @@ const ENTRIES: CatalogEntry[] = [
     methods: ['GET', 'HEAD'],
     description: 'Latest macOS launcher download (302 to the GitHub release).',
   },
+  {
+    anchor: '/install-cli',
+    methods: ['GET', 'HEAD'],
+    description:
+      'POSIX shell installer for the headless slicc follower CLI (curl -fsSL …/install-cli | sh).',
+  },
+  {
+    anchor: '/download/slicc-cli/:target',
+    methods: ['GET', 'HEAD'],
+    description:
+      'Latest slicc follower CLI binary for a target such as darwin-arm64 or linux-amd64 (302 to the GitHub release asset).',
+  },
 ];
 
 export function buildApiCatalogResponse(request: Request): Response {

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -16,6 +16,7 @@ import {
 } from './cloud/handlers.js';
 import { getProxyEndpoint } from './cloud/proxy-config.js';
 import { buildHandoffResponse } from './handoff-page.js';
+import { buildInstallCliScriptResponse, handleCliDownload } from './install-cli.js';
 import knownGoodMacos from './known-good-macos.json';
 import { applySliccLinks } from './links.js';
 import { buildLlmsTxtResponse } from './llms-txt.js';
@@ -532,6 +533,8 @@ const ROUTES_INDEX_BODY = {
   routes: [
     'POST /tray',
     'GET /download/slicc.dmg',
+    'GET /install-cli',
+    'GET /download/slicc-cli/:target',
     'GET /handoff',
     'GET /.well-known/api-catalog',
     'GET /llms.txt',
@@ -728,6 +731,18 @@ async function tryHandleInfoRoutes(
     (request.method === 'GET' || request.method === 'HEAD')
   ) {
     return handleDmgDownload(fetchImpl);
+  }
+
+  if (url.pathname === '/install-cli' && (request.method === 'GET' || request.method === 'HEAD')) {
+    return buildInstallCliScriptResponse(request);
+  }
+
+  // Match ANY suffix so a typo'd target gets the route's 404 instead of the
+  // SPA fallback's 200 HTML page (which `curl -f` would happily save as the
+  // "binary"); handleCliDownload validates against the released target list.
+  const cliDownloadMatch = url.pathname.match(/^\/download\/slicc-cli\/([^/]+)$/);
+  if (cliDownloadMatch && (request.method === 'GET' || request.method === 'HEAD')) {
+    return handleCliDownload(cliDownloadMatch[1], fetchImpl);
   }
 
   if (url.pathname === '/handoff' && request.method === 'GET') {

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -16,7 +16,11 @@ import {
 } from './cloud/handlers.js';
 import { getProxyEndpoint } from './cloud/proxy-config.js';
 import { buildHandoffResponse } from './handoff-page.js';
-import { buildInstallCliScriptResponse, handleCliDownload } from './install-cli.js';
+import {
+  buildInstallCliPowershellResponse,
+  buildInstallCliScriptResponse,
+  handleCliDownload,
+} from './install-cli.js';
 import knownGoodMacos from './known-good-macos.json';
 import { applySliccLinks } from './links.js';
 import { buildLlmsTxtResponse } from './llms-txt.js';
@@ -534,6 +538,7 @@ const ROUTES_INDEX_BODY = {
     'POST /tray',
     'GET /download/slicc.dmg',
     'GET /install-cli',
+    'GET /install-cli.ps1',
     'GET /download/slicc-cli/:target',
     'GET /handoff',
     'GET /.well-known/api-catalog',
@@ -712,6 +717,31 @@ function handleRuntimeConfig(url: URL, request: Request, env: WorkerEnv): Respon
   );
 }
 
+/** The slicc CLI installer surface: both installer scripts + the binary resolver. */
+async function tryHandleInstallerRoutes(
+  url: URL,
+  request: Request,
+  fetchImpl: typeof fetch
+): Promise<Response | null> {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return null;
+  }
+  if (url.pathname === '/install-cli') {
+    return buildInstallCliScriptResponse(request);
+  }
+  if (url.pathname === '/install-cli.ps1') {
+    return buildInstallCliPowershellResponse(request);
+  }
+  // Match ANY suffix so a typo'd target gets the route's 404 instead of the
+  // SPA fallback's 200 HTML page (which `curl -f` would happily save as the
+  // "binary"); handleCliDownload validates against the released target list.
+  const cliDownloadMatch = url.pathname.match(/^\/download\/slicc-cli\/([^/]+)$/);
+  if (cliDownloadMatch) {
+    return handleCliDownload(cliDownloadMatch[1], fetchImpl);
+  }
+  return null;
+}
+
 async function tryHandleInfoRoutes(
   url: URL,
   request: Request,
@@ -733,16 +763,9 @@ async function tryHandleInfoRoutes(
     return handleDmgDownload(fetchImpl);
   }
 
-  if (url.pathname === '/install-cli' && (request.method === 'GET' || request.method === 'HEAD')) {
-    return buildInstallCliScriptResponse(request);
-  }
-
-  // Match ANY suffix so a typo'd target gets the route's 404 instead of the
-  // SPA fallback's 200 HTML page (which `curl -f` would happily save as the
-  // "binary"); handleCliDownload validates against the released target list.
-  const cliDownloadMatch = url.pathname.match(/^\/download\/slicc-cli\/([^/]+)$/);
-  if (cliDownloadMatch && (request.method === 'GET' || request.method === 'HEAD')) {
-    return handleCliDownload(cliDownloadMatch[1], fetchImpl);
+  const installerResponse = await tryHandleInstallerRoutes(url, request, fetchImpl);
+  if (installerResponse) {
+    return installerResponse;
   }
 
   if (url.pathname === '/handoff' && request.method === 'GET') {

--- a/packages/cloudflare-worker/src/install-cli.ts
+++ b/packages/cloudflare-worker/src/install-cli.ts
@@ -1,0 +1,194 @@
+/**
+ * `GET /install-cli` — POSIX shell installer for the Go `slicc` follower CLI
+ * (`packages/slicc-cli`), used as:
+ *
+ *   curl -fsSL https://www.sliccy.ai/install-cli | sh
+ *
+ * `GET /download/slicc-cli/:target` — 302 to the newest GitHub release asset
+ * for that target (`darwin-arm64`, `linux-amd64`, …). Release binaries are
+ * sparse: they only attach to releases where `packages/slicc-cli` changed, so
+ * the scan walks releases newest→oldest for the first carrier (same bounded
+ * pagination as `/download/slicc.dmg` in `index.ts`).
+ *
+ * Unlike the DMG route — which 302s to the releases *page* on failure, fine
+ * for a human in a browser — failures here return real HTTP errors so the
+ * installer script's `curl -f` aborts instead of saving an HTML page as the
+ * binary.
+ */
+
+const RELEASES_API = 'https://api.github.com/repos/ai-ecoverse/slicc/releases?per_page=30';
+const RELEASES_PER_PAGE = 30;
+// Bounded pagination: 5 × 30 releases scanned before giving up, mirroring the
+// DMG route's guard against rate-limit exhaustion.
+const MAX_RELEASE_PAGES = 5;
+
+/** Targets cross-compiled by packages/slicc-cli/Makefile (`PLATFORMS`). */
+export const CLI_TARGETS = [
+  'darwin-amd64',
+  'darwin-arm64',
+  'linux-amd64',
+  'linux-arm64',
+  'windows-amd64',
+  'windows-arm64',
+] as const;
+
+interface GithubReleaseAsset {
+  name?: string;
+  browser_download_url?: string;
+}
+
+interface GithubRelease {
+  draft?: boolean;
+  prerelease?: boolean;
+  assets?: GithubReleaseAsset[];
+}
+
+/** PURE: release-asset name for a target, or null for an unknown target. */
+export function cliAssetNameForTarget(target: string): string | null {
+  if (!(CLI_TARGETS as readonly string[]).includes(target)) {
+    return null;
+  }
+  return `slicc-${target}${target.startsWith('windows-') ? '.exe' : ''}`;
+}
+
+function textResponse(body: string, status: number): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'no-store' },
+  });
+}
+
+/**
+ * Redirect to the newest published release that ships the target's CLI binary,
+ * paginating newest→oldest past binary-less releases.
+ */
+export async function handleCliDownload(
+  target: string,
+  fetchImpl: typeof fetch
+): Promise<Response> {
+  const assetName = cliAssetNameForTarget(target);
+  if (!assetName) {
+    return textResponse(
+      `Unknown slicc CLI target "${target}". Valid targets: ${CLI_TARGETS.join(', ')}\n`,
+      404
+    );
+  }
+  try {
+    for (let page = 1; page <= MAX_RELEASE_PAGES; page++) {
+      const res = await fetchImpl(`${RELEASES_API}&page=${page}`, {
+        headers: { 'User-Agent': 'slicc-tray-hub' },
+        cf: { cacheTtl: 300, cacheEverything: true },
+      });
+      if (!res.ok) {
+        return textResponse(`GitHub releases API responded ${res.status}\n`, 502);
+      }
+      let releases: unknown;
+      try {
+        releases = await res.json();
+      } catch {
+        return textResponse('GitHub releases API returned unparseable JSON\n', 502);
+      }
+      if (!Array.isArray(releases) || releases.length === 0) {
+        break;
+      }
+      for (const release of releases as GithubRelease[]) {
+        if (release.draft || release.prerelease) {
+          continue;
+        }
+        const asset = release.assets?.find((candidate) => candidate.name === assetName);
+        if (asset?.browser_download_url) {
+          return Response.redirect(asset.browser_download_url, 302);
+        }
+      }
+      // Fewer than a full page means we've reached the last page — stop early.
+      if (releases.length < RELEASES_PER_PAGE) {
+        break;
+      }
+    }
+    return textResponse(
+      `No recent release carries ${assetName} — CLI binaries only attach to releases where packages/slicc-cli changed.\n`,
+      404
+    );
+  } catch (error) {
+    return textResponse(`Could not reach the GitHub releases API: ${String(error)}\n`, 502);
+  }
+}
+
+/** The installer script, with download URLs pinned to the serving origin. */
+export function buildInstallCliScriptResponse(request: Request): Response {
+  const url = new URL(request.url);
+  const origin = `${url.protocol}//${url.host}`;
+  const body = `#!/bin/sh
+# slicc CLI installer — the headless SLICC follower CLI.
+#
+# Usage:
+#   curl -fsSL ${origin}/install-cli | sh
+#
+# Environment overrides:
+#   SLICC_INSTALL_DIR   install directory (default: $HOME/.slicc/bin)
+#
+# On Windows, run \`npx sliccy --install-cli\` instead.
+set -eu
+
+install_dir="\${SLICC_INSTALL_DIR:-$HOME/.slicc/bin}"
+
+os="$(uname -s)"
+case "$os" in
+  Darwin) os="darwin" ;;
+  Linux) os="linux" ;;
+  *)
+    echo "install-cli: unsupported OS $os (on Windows, run: npx sliccy --install-cli)" >&2
+    exit 1
+    ;;
+esac
+
+arch="$(uname -m)"
+case "$arch" in
+  x86_64 | amd64) arch="amd64" ;;
+  arm64 | aarch64) arch="arm64" ;;
+  *)
+    echo "install-cli: unsupported architecture $arch (need amd64 or arm64)" >&2
+    exit 1
+    ;;
+esac
+
+url="${origin}/download/slicc-cli/$os-$arch"
+tmp="$install_dir/.slicc.download.$$"
+
+mkdir -p "$install_dir"
+trap 'rm -f "$tmp"' EXIT
+
+echo "Downloading slicc ($os-$arch) from $url ..."
+curl -fSL --proto '=https' -o "$tmp" "$url"
+chmod 0755 "$tmp"
+
+# End-to-end sanity check before the binary lands on PATH: the CLI must be
+# able to print its version. This also catches a server error page saved as
+# the download.
+if ! version="$("$tmp" --version 2>/dev/null)"; then
+  echo "install-cli: the downloaded file does not run on this system ($url)" >&2
+  exit 1
+fi
+
+mv "$tmp" "$install_dir/slicc"
+trap - EXIT
+
+echo "Installed $install_dir/slicc ($version)"
+
+case ":$PATH:" in
+  *":$install_dir:"*) ;;
+  *)
+    echo ""
+    echo "$install_dir is not on your PATH. Add it with:"
+    echo "  export PATH=\\"$install_dir:\\$PATH\\""
+    ;;
+esac
+`;
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/x-shellscript; charset=utf-8',
+      'Cache-Control': 'public, max-age=300',
+    },
+  });
+}

--- a/packages/cloudflare-worker/src/install-cli.ts
+++ b/packages/cloudflare-worker/src/install-cli.ts
@@ -16,10 +16,10 @@
  * binary.
  */
 
-const RELEASES_API = 'https://api.github.com/repos/ai-ecoverse/slicc/releases?per_page=30';
-const RELEASES_PER_PAGE = 30;
-// Bounded pagination: 5 × 30 releases scanned before giving up, mirroring the
-// DMG route's guard against rate-limit exhaustion.
+const RELEASES_PER_PAGE = 100;
+const RELEASES_API = `https://api.github.com/repos/ai-ecoverse/slicc/releases?per_page=${RELEASES_PER_PAGE}`;
+// Bounded pagination (5 × 100 releases ≈ months of sparse releases) mirroring
+// the DMG route's guard against rate-limit exhaustion.
 const MAX_RELEASE_PAGES = 5;
 
 /** Targets cross-compiled by packages/slicc-cli/Makefile (`PLATFORMS`). */
@@ -118,6 +118,10 @@ export async function handleCliDownload(
 export function buildInstallCliScriptResponse(request: Request): Response {
   const url = new URL(request.url);
   const origin = `${url.protocol}//${url.host}`;
+  // Lock curl to https for real deployments; an http origin only occurs in
+  // local dev (`wrangler dev`), where `--proto '=https'` would reject the
+  // download URL outright.
+  const protoFlag = origin.startsWith('https://') ? "--proto '=https' " : '';
   const body = `#!/bin/sh
 # slicc CLI installer — the headless SLICC follower CLI.
 #
@@ -159,7 +163,7 @@ mkdir -p "$install_dir"
 trap 'rm -f "$tmp"' EXIT
 
 echo "Downloading slicc ($os-$arch) from $url ..."
-curl -fSL --proto '=https' -o "$tmp" "$url"
+curl -fSL ${protoFlag}-o "$tmp" "$url"
 chmod 0755 "$tmp"
 
 # End-to-end sanity check before the binary lands on PATH: the CLI must be

--- a/packages/cloudflare-worker/src/install-cli.ts
+++ b/packages/cloudflare-worker/src/install-cli.ts
@@ -131,16 +131,37 @@ export function buildInstallCliScriptResponse(request: Request): Response {
 # Environment overrides:
 #   SLICC_INSTALL_DIR   install directory (default: ~/.local/bin when on
 #                       PATH, else /usr/local/bin when writable, else
-#                       ~/.local/bin with a PATH hint)
+#                       ~/.local/bin with a PATH hint; ~/bin under Git Bash)
 #
-# On Windows, run \`npx sliccy --install-cli\` instead.
+# Works on macOS, Linux, WSL, and Git Bash/MSYS. Native Windows PowerShell:
+#   irm ${origin}/install-cli.ps1 | iex
 set -eu
+
+# WSL reports Linux and gets the linux binary — that is the right answer
+# there. Git Bash / MSYS / Cygwin get the windows .exe.
+os="$(uname -s)"
+bin_name="slicc"
+case "$os" in
+  Darwin) os="darwin" ;;
+  Linux) os="linux" ;;
+  MINGW* | MSYS* | CYGWIN*)
+    os="windows"
+    bin_name="slicc.exe"
+    ;;
+  *)
+    echo "install-cli: unsupported OS $os (native Windows: irm ${origin}/install-cli.ps1 | iex)" >&2
+    exit 1
+    ;;
+esac
 
 # OS-idiomatic install dir: prefer the XDG user-binaries dir when the shell
 # already resolves it, fall back to a writable /usr/local/bin, else create
-# ~/.local/bin and print a PATH hint at the end.
+# ~/.local/bin and print a PATH hint at the end. Git Bash uses ~/bin, which
+# its /etc/profile puts on PATH once it exists.
 if [ -n "\${SLICC_INSTALL_DIR:-}" ]; then
   install_dir="$SLICC_INSTALL_DIR"
+elif [ "$os" = "windows" ]; then
+  install_dir="$HOME/bin"
 else
   install_dir="$HOME/.local/bin"
   case ":$PATH:" in
@@ -152,16 +173,6 @@ else
       ;;
   esac
 fi
-
-os="$(uname -s)"
-case "$os" in
-  Darwin) os="darwin" ;;
-  Linux) os="linux" ;;
-  *)
-    echo "install-cli: unsupported OS $os (on Windows, run: npx sliccy --install-cli)" >&2
-    exit 1
-    ;;
-esac
 
 arch="$(uname -m)"
 case "$arch" in
@@ -191,10 +202,10 @@ if ! version="$("$tmp" --version 2>/dev/null)"; then
   exit 1
 fi
 
-mv "$tmp" "$install_dir/slicc"
+mv "$tmp" "$install_dir/$bin_name"
 trap - EXIT
 
-echo "Installed $install_dir/slicc ($version)"
+echo "Installed $install_dir/$bin_name ($version)"
 
 case ":$PATH:" in
   *":$install_dir:"*) ;;
@@ -209,6 +220,76 @@ esac
     status: 200,
     headers: {
       'Content-Type': 'text/x-shellscript; charset=utf-8',
+      'Cache-Control': 'public, max-age=300',
+    },
+  });
+}
+
+/**
+ * The native-Windows installer (`irm …/install-cli.ps1 | iex`), mirroring the
+ * POSIX script: arch detection, download via the resolver route, a --version
+ * sanity gate before the binary lands, install to %LOCALAPPDATA%\Programs\slicc
+ * (the per-user programs idiom), and a persistent user-scope PATH update.
+ */
+export function buildInstallCliPowershellResponse(request: Request): Response {
+  const url = new URL(request.url);
+  const origin = `${url.protocol}//${url.host}`;
+  const body = `# slicc CLI installer — the headless SLICC follower CLI (native Windows).
+#
+# Usage:
+#   irm ${origin}/install-cli.ps1 | iex
+#
+# Environment overrides:
+#   SLICC_INSTALL_DIR   install directory (default: %LOCALAPPDATA%\\Programs\\slicc)
+#
+# WSL and Git Bash users: curl -fsSL ${origin}/install-cli | sh
+$ErrorActionPreference = 'Stop'
+# Windows PowerShell 5.1 defaults to TLS 1.0 — force 1.2 for the download.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+$arch = 'amd64'
+if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) {
+  $arch = 'arm64'
+}
+
+$installDir = $env:SLICC_INSTALL_DIR
+if (-not $installDir) {
+  $installDir = Join-Path $env:LOCALAPPDATA 'Programs\\slicc'
+}
+$null = New-Item -ItemType Directory -Force -Path $installDir
+
+$url = "${origin}/download/slicc-cli/windows-$arch"
+$tmp = Join-Path $installDir ".slicc.download.$PID.exe"
+$exe = Join-Path $installDir 'slicc.exe'
+
+Write-Host "Downloading slicc (windows-$arch) from $url ..."
+try {
+  Invoke-WebRequest -Uri $url -OutFile $tmp -UseBasicParsing
+  # Sanity gate before the binary lands on PATH: it must print its version.
+  $version = & $tmp --version
+  if ($LASTEXITCODE -ne 0) {
+    throw "the downloaded file does not run on this system ($url)"
+  }
+  Move-Item -Force $tmp $exe
+} catch {
+  Remove-Item -Force -ErrorAction SilentlyContinue $tmp
+  throw
+}
+
+Write-Host "Installed $exe ($version)"
+
+# Persist the install dir on the user PATH (new terminals pick it up).
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if (($userPath -split ';') -notcontains $installDir) {
+  [Environment]::SetEnvironmentVariable('Path', "$userPath;$installDir", 'User')
+  $env:Path = "$env:Path;$installDir"
+  Write-Host "Added $installDir to your user PATH."
+}
+`;
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/x-powershell; charset=utf-8',
       'Cache-Control': 'public, max-age=300',
     },
   });

--- a/packages/cloudflare-worker/src/install-cli.ts
+++ b/packages/cloudflare-worker/src/install-cli.ts
@@ -129,12 +129,29 @@ export function buildInstallCliScriptResponse(request: Request): Response {
 #   curl -fsSL ${origin}/install-cli | sh
 #
 # Environment overrides:
-#   SLICC_INSTALL_DIR   install directory (default: $HOME/.slicc/bin)
+#   SLICC_INSTALL_DIR   install directory (default: ~/.local/bin when on
+#                       PATH, else /usr/local/bin when writable, else
+#                       ~/.local/bin with a PATH hint)
 #
 # On Windows, run \`npx sliccy --install-cli\` instead.
 set -eu
 
-install_dir="\${SLICC_INSTALL_DIR:-$HOME/.slicc/bin}"
+# OS-idiomatic install dir: prefer the XDG user-binaries dir when the shell
+# already resolves it, fall back to a writable /usr/local/bin, else create
+# ~/.local/bin and print a PATH hint at the end.
+if [ -n "\${SLICC_INSTALL_DIR:-}" ]; then
+  install_dir="$SLICC_INSTALL_DIR"
+else
+  install_dir="$HOME/.local/bin"
+  case ":$PATH:" in
+    *":$install_dir:"*) ;;
+    *)
+      if [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
+        install_dir=/usr/local/bin
+      fi
+      ;;
+  esac
+fi
 
 os="$(uname -s)"
 case "$os" in

--- a/packages/cloudflare-worker/src/llms-txt.ts
+++ b/packages/cloudflare-worker/src/llms-txt.ts
@@ -21,6 +21,7 @@ export function buildLlmsTxtResponse(request: Request): Response {
 - [API catalog](${origin}/.well-known/api-catalog): RFC 9264 linkset of every public route on this host.
 - [Handoff endpoint](${origin}/handoff): cross-agent handoff convenience URL.
 - [CLI installer](${origin}/install-cli): POSIX shell installer for the headless slicc follower CLI (\`curl -fsSL ${origin}/install-cli | sh\`).
+- [CLI installer, Windows](${origin}/install-cli.ps1): native-Windows PowerShell installer (\`irm ${origin}/install-cli.ps1 | iex\`).
 
 ## Handoff protocol
 

--- a/packages/cloudflare-worker/src/llms-txt.ts
+++ b/packages/cloudflare-worker/src/llms-txt.ts
@@ -20,6 +20,7 @@ export function buildLlmsTxtResponse(request: Request): Response {
 
 - [API catalog](${origin}/.well-known/api-catalog): RFC 9264 linkset of every public route on this host.
 - [Handoff endpoint](${origin}/handoff): cross-agent handoff convenience URL.
+- [CLI installer](${origin}/install-cli): POSIX shell installer for the headless slicc follower CLI (\`curl -fsSL ${origin}/install-cli | sh\`).
 
 ## Handoff protocol
 

--- a/packages/cloudflare-worker/tests/deployed.test.ts
+++ b/packages/cloudflare-worker/tests/deployed.test.ts
@@ -30,6 +30,7 @@ describeIfConfigured('deployed tray worker', () => {
         'POST /tray',
         'GET /download/slicc.dmg',
         'GET /install-cli',
+        'GET /install-cli.ps1',
         'GET /download/slicc-cli/:target',
         'GET /handoff',
         'GET /.well-known/api-catalog',

--- a/packages/cloudflare-worker/tests/deployed.test.ts
+++ b/packages/cloudflare-worker/tests/deployed.test.ts
@@ -29,6 +29,8 @@ describeIfConfigured('deployed tray worker', () => {
       routes: [
         'POST /tray',
         'GET /download/slicc.dmg',
+        'GET /install-cli',
+        'GET /download/slicc-cli/:target',
         'GET /handoff',
         'GET /.well-known/api-catalog',
         'GET /llms.txt',

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -1207,6 +1207,8 @@ describe('tray worker skeleton', () => {
       routes: [
         'POST /tray',
         'GET /download/slicc.dmg',
+        'GET /install-cli',
+        'GET /download/slicc-cli/:target',
         'GET /handoff',
         'GET /.well-known/api-catalog',
         'GET /llms.txt',
@@ -3668,5 +3670,219 @@ describe('asset archive fallback (#1330 retention)', () => {
     expect(res.headers.get('link') ?? '').toContain('rel=');
     // still no SPA frame-ancestors CSP on an asset
     expect(res.headers.get('content-security-policy')).toBeNull();
+  });
+});
+
+describe('GET /install-cli', () => {
+  it('serves the POSIX installer script with download URLs pinned to the serving origin', async () => {
+    const { env } = createTestHarness();
+    const response = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/install-cli'),
+      env
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('text/x-shellscript');
+    const body = await response.text();
+    expect(body).toMatch(/^#!\/bin\/sh/);
+    expect(body).toContain('https://www.sliccy.ai/download/slicc-cli/$os-$arch');
+    expect(body).toContain('curl -fsSL https://www.sliccy.ai/install-cli | sh');
+    // OS/arch detection covers the released matrix and bails out elsewhere
+    expect(body).toContain('Darwin) os="darwin"');
+    expect(body).toContain('Linux) os="linux"');
+    expect(body).toContain('x86_64 | amd64) arch="amd64"');
+    expect(body).toContain('arm64 | aarch64) arch="arm64"');
+    expect(body).toContain('npx sliccy --install-cli');
+    // Installs into the overridable ~/.slicc/bin default
+    expect(body).toContain('${SLICC_INSTALL_DIR:-$HOME/.slicc/bin}');
+  });
+
+  it('pins the script to a staging origin when served from one', async () => {
+    const { env } = createTestHarness();
+    const response = await handleWorkerRequest(
+      new Request('https://slicc-tray-hub-staging.minivelos.workers.dev/install-cli'),
+      env
+    );
+    const body = await response.text();
+    expect(body).toContain(
+      'https://slicc-tray-hub-staging.minivelos.workers.dev/download/slicc-cli/$os-$arch'
+    );
+  });
+
+  it('answers HEAD requests', async () => {
+    const { env } = createTestHarness();
+    const response = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/install-cli', { method: 'HEAD' }),
+      env
+    );
+    expect(response.status).toBe(200);
+  });
+});
+
+describe('GET /download/slicc-cli/:target', () => {
+  const CLI_DOWNLOAD_URL = 'https://www.sliccy.ai/download/slicc-cli/darwin-arm64';
+  const ASSET_URL =
+    'https://github.com/ai-ecoverse/slicc/releases/download/v5.71.1/slicc-darwin-arm64';
+
+  function cliRelease(assets: Array<{ name: string; url: string }>, extra = {}) {
+    return {
+      draft: false,
+      prerelease: false,
+      ...extra,
+      assets: assets.map((a) => ({ name: a.name, browser_download_url: a.url })),
+    };
+  }
+
+  it('redirects to the newest release carrying the target binary, skipping binary-less releases', async () => {
+    const { env } = createTestHarness();
+    const releases = [
+      cliRelease([{ name: 'sliccy-5.72.0.tgz', url: 'x' }]),
+      cliRelease([
+        { name: 'slicc-darwin-arm64', url: ASSET_URL },
+        { name: 'slicc-linux-amd64', url: 'y' },
+      ]),
+    ];
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify(releases), { status: 200 }));
+
+    const res = await handleWorkerRequest(new Request(CLI_DOWNLOAD_URL), env, fetchImpl);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe(ASSET_URL);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl.mock.calls[0]?.[0]).toContain('api.github.com');
+  });
+
+  it('skips draft and prerelease releases', async () => {
+    const { env } = createTestHarness();
+    const releases = [
+      cliRelease([{ name: 'slicc-darwin-arm64', url: 'draft' }], { draft: true }),
+      cliRelease([{ name: 'slicc-darwin-arm64', url: 'pre' }], { prerelease: true }),
+      cliRelease([{ name: 'slicc-darwin-arm64', url: ASSET_URL }]),
+    ];
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify(releases), { status: 200 }));
+
+    const res = await handleWorkerRequest(new Request(CLI_DOWNLOAD_URL), env, fetchImpl);
+    expect(res.headers.get('Location')).toBe(ASSET_URL);
+  });
+
+  it('maps windows targets to the .exe asset name', async () => {
+    const { env } = createTestHarness();
+    const exeUrl =
+      'https://github.com/ai-ecoverse/slicc/releases/download/v5.71.1/slicc-windows-amd64.exe';
+    const releases = [cliRelease([{ name: 'slicc-windows-amd64.exe', url: exeUrl }])];
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(JSON.stringify(releases), { status: 200 }));
+
+    const res = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/download/slicc-cli/windows-amd64'),
+      env,
+      fetchImpl
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe(exeUrl);
+  });
+
+  it('404s an unknown target without calling GitHub', async () => {
+    const { env } = createTestHarness();
+    const fetchImpl = vi.fn<typeof fetch>();
+    const res = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/download/slicc-cli/freebsd-amd64'),
+      env,
+      fetchImpl
+    );
+    expect(res.status).toBe(404);
+    expect(await res.text()).toContain('darwin-arm64');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('404s a typo-cased target instead of falling through to the SPA 200 page', async () => {
+    const { env } = createTestHarness();
+    const fetchImpl = vi.fn<typeof fetch>();
+    const res = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/download/slicc-cli/DARWIN-ARM64'),
+      env,
+      fetchImpl
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get('Content-Type')).toContain('text/plain');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('404s with an explanation when no recent release carries the binary (sparse releases)', async () => {
+    const { env } = createTestHarness();
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(
+      async () =>
+        new Response(JSON.stringify([cliRelease([{ name: 'notes.txt', url: 'x' }])]), {
+          status: 200,
+        })
+    );
+
+    const res = await handleWorkerRequest(new Request(CLI_DOWNLOAD_URL), env, fetchImpl);
+    expect(res.status).toBe(404);
+    expect(await res.text()).toContain('slicc-darwin-arm64');
+    // Short page (< 30 releases) means last page — no further pagination
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('paginates past a full page of binary-less releases', async () => {
+    const { env } = createTestHarness();
+    const page1 = Array.from({ length: 30 }, () => cliRelease([{ name: 'notes.txt', url: 'x' }]));
+    const page2 = [cliRelease([{ name: 'slicc-darwin-arm64', url: ASSET_URL }])];
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify(page1), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(page2), { status: 200 }));
+
+    const res = await handleWorkerRequest(new Request(CLI_DOWNLOAD_URL), env, fetchImpl);
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toBe(ASSET_URL);
+    expect(fetchImpl.mock.calls[1]?.[0]).toContain('page=2');
+  });
+
+  it('gives up after the page cap with a 404 instead of unbounded GitHub calls', async () => {
+    const { env } = createTestHarness();
+    const fullPage = Array.from({ length: 30 }, () =>
+      cliRelease([{ name: 'notes.txt', url: 'x' }])
+    );
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () => new Response(JSON.stringify(fullPage), { status: 200 }));
+
+    const res = await handleWorkerRequest(new Request(CLI_DOWNLOAD_URL), env, fetchImpl);
+    expect(res.status).toBe(404);
+    expect(fetchImpl).toHaveBeenCalledTimes(5);
+  });
+
+  it('502s when the GitHub API responds non-OK so curl -f fails loudly', async () => {
+    const { env } = createTestHarness();
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('rate limited', { status: 403 }));
+
+    const res = await handleWorkerRequest(new Request(CLI_DOWNLOAD_URL), env, fetchImpl);
+    expect(res.status).toBe(502);
+    expect(await res.text()).toContain('403');
+  });
+
+  it('502s when the GitHub API throws', async () => {
+    const { env } = createTestHarness();
+    const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(new Error('network down'));
+
+    const res = await handleWorkerRequest(new Request(CLI_DOWNLOAD_URL), env, fetchImpl);
+    expect(res.status).toBe(502);
+    expect(await res.text()).toContain('network down');
+  });
+
+  it('502s on unparseable GitHub JSON', async () => {
+    const { env } = createTestHarness();
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('<!doctype html>', { status: 200 }));
+
+    const res = await handleWorkerRequest(new Request(CLI_DOWNLOAD_URL), env, fetchImpl);
+    expect(res.status).toBe(502);
   });
 });

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -3692,8 +3692,11 @@ describe('GET /install-cli', () => {
     expect(body).toContain('x86_64 | amd64) arch="amd64"');
     expect(body).toContain('arm64 | aarch64) arch="arm64"');
     expect(body).toContain('npx sliccy --install-cli');
-    // Installs into the overridable ~/.slicc/bin default
-    expect(body).toContain('${SLICC_INSTALL_DIR:-$HOME/.slicc/bin}');
+    // OS-idiomatic install dir: overridable, ~/.local/bin first, then a
+    // writable /usr/local/bin
+    expect(body).toContain('SLICC_INSTALL_DIR');
+    expect(body).toContain('install_dir="$HOME/.local/bin"');
+    expect(body).toContain('[ -w /usr/local/bin ]');
   });
 
   it('pins the script to a staging origin when served from one', async () => {

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -3716,6 +3716,22 @@ describe('GET /install-cli', () => {
     );
     expect(response.status).toBe(200);
   });
+
+  it('locks curl to https on https origins but not on the http dev origin', async () => {
+    const { env } = createTestHarness();
+    const httpsBody = await (
+      await handleWorkerRequest(new Request('https://www.sliccy.ai/install-cli'), env)
+    ).text();
+    expect(httpsBody).toContain("--proto '=https'");
+
+    // `wrangler dev` serves over http, where --proto '=https' would reject the
+    // download URL outright and break the local end-to-end loop.
+    const httpBody = await (
+      await handleWorkerRequest(new Request('http://www.sliccy.ai/install-cli'), env)
+    ).text();
+    expect(httpBody).not.toContain('--proto');
+    expect(httpBody).toContain('curl -fSL -o');
+  });
 });
 
 describe('GET /download/slicc-cli/:target', () => {
@@ -3823,13 +3839,13 @@ describe('GET /download/slicc-cli/:target', () => {
     const res = await handleWorkerRequest(new Request(CLI_DOWNLOAD_URL), env, fetchImpl);
     expect(res.status).toBe(404);
     expect(await res.text()).toContain('slicc-darwin-arm64');
-    // Short page (< 30 releases) means last page — no further pagination
+    // Short page (< 100 releases) means last page — no further pagination
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it('paginates past a full page of binary-less releases', async () => {
     const { env } = createTestHarness();
-    const page1 = Array.from({ length: 30 }, () => cliRelease([{ name: 'notes.txt', url: 'x' }]));
+    const page1 = Array.from({ length: 100 }, () => cliRelease([{ name: 'notes.txt', url: 'x' }]));
     const page2 = [cliRelease([{ name: 'slicc-darwin-arm64', url: ASSET_URL }])];
     const fetchImpl = vi
       .fn<typeof fetch>()
@@ -3844,7 +3860,7 @@ describe('GET /download/slicc-cli/:target', () => {
 
   it('gives up after the page cap with a 404 instead of unbounded GitHub calls', async () => {
     const { env } = createTestHarness();
-    const fullPage = Array.from({ length: 30 }, () =>
+    const fullPage = Array.from({ length: 100 }, () =>
       cliRelease([{ name: 'notes.txt', url: 'x' }])
     );
     const fetchImpl = vi

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -1208,6 +1208,7 @@ describe('tray worker skeleton', () => {
         'POST /tray',
         'GET /download/slicc.dmg',
         'GET /install-cli',
+        'GET /install-cli.ps1',
         'GET /download/slicc-cli/:target',
         'GET /handoff',
         'GET /.well-known/api-catalog',
@@ -3691,7 +3692,7 @@ describe('GET /install-cli', () => {
     expect(body).toContain('Linux) os="linux"');
     expect(body).toContain('x86_64 | amd64) arch="amd64"');
     expect(body).toContain('arm64 | aarch64) arch="arm64"');
-    expect(body).toContain('npx sliccy --install-cli');
+    expect(body).toContain('install-cli.ps1 | iex');
     // OS-idiomatic install dir: overridable, ~/.local/bin first, then a
     // writable /usr/local/bin
     expect(body).toContain('SLICC_INSTALL_DIR');
@@ -3715,6 +3716,45 @@ describe('GET /install-cli', () => {
     const { env } = createTestHarness();
     const response = await handleWorkerRequest(
       new Request('https://www.sliccy.ai/install-cli', { method: 'HEAD' }),
+      env
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it('maps Git Bash / MSYS unames to the windows .exe and WSL to linux', async () => {
+    const { env } = createTestHarness();
+    const body = await (
+      await handleWorkerRequest(new Request('https://www.sliccy.ai/install-cli'), env)
+    ).text();
+    expect(body).toContain('MINGW* | MSYS* | CYGWIN*)');
+    expect(body).toContain('bin_name="slicc.exe"');
+    // WSL reports Linux and correctly gets the linux binary
+    expect(body).toContain('Linux) os="linux"');
+    // Native Windows is pointed at the PowerShell installer
+    expect(body).toContain('irm https://www.sliccy.ai/install-cli.ps1 | iex');
+  });
+
+  it('serves the PowerShell installer at /install-cli.ps1 pinned to the serving origin', async () => {
+    const { env } = createTestHarness();
+    const response = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/install-cli.ps1'),
+      env
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('text/x-powershell');
+    const body = await response.text();
+    expect(body).toContain('https://www.sliccy.ai/download/slicc-cli/windows-$arch');
+    expect(body).toContain("Join-Path $env:LOCALAPPDATA 'Programs\\slicc'");
+    // Sanity gate + PATH persistence, mirroring the POSIX script
+    expect(body).toContain('& $tmp --version');
+    expect(body).toContain("[Environment]::SetEnvironmentVariable('Path'");
+    expect(body).toContain('$env:SLICC_INSTALL_DIR');
+  });
+
+  it('answers HEAD for the PowerShell installer', async () => {
+    const { env } = createTestHarness();
+    const response = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/install-cli.ps1', { method: 'HEAD' }),
       env
     );
     expect(response.status).toBe(200);


### PR DESCRIPTION
## Summary

Adds a web-hosted installer for the Go `slicc` follower CLI: `curl -fsSL https://www.sliccy.ai/install-cli | sh`. The tray hub gains two routes — `GET /install-cli` (serves a POSIX installer script) and `GET /download/slicc-cli/:target` (302-resolves the newest release asset for a target such as `darwin-arm64`).

## Why

The `slicc` CLI ships as bare signed binaries on GitHub releases with no install story for people without Node. A curl|sh one-liner is the standard answer. Companion to #1674 (`npx sliccy --install-cli`) and an upcoming `slicc update` self-update command.

## Approach / Implementation notes

- New `src/install-cli.ts`, modeled on `src/llms-txt.ts` (per-request origin, inline script string) and `handleDmgDownload` (release scan with `cf: { cacheTtl: 300 }` edge caching, `MAX_RELEASE_PAGES` bound, injected `fetchImpl` for tests).
- **Sparse releases**: CLI binaries only attach to releases where `packages/slicc-cli` changed, so `/download/slicc-cli/:target` scans releases newest→oldest for the first carrier, skipping drafts/prereleases.
- **Deliberate divergence from the DMG route's failure mode**: the DMG route 302s to the releases *page* on failure (fine for a browser). Here that would make the piped `curl -f` save an HTML page as the binary, so failures are real HTTP errors (404/502 with text bodies).
- The route regex matches any `/download/slicc-cli/*` suffix so a typo'd target (`DARWIN-ARM64`) gets the route's 404 instead of the SPA fallback's 200 HTML — found via a live `wrangler dev` round-trip during development.
- The script detects `uname -s`/`uname -m` (darwin/linux × amd64/arm64; Windows users are pointed at `npx sliccy --install-cli`), downloads to a staging file, and **requires the binary to pass `--version` before it lands** in `$SLICC_INSTALL_DIR` (default `~/.slicc/bin`) — catching wrong-arch downloads and error pages. `trap` cleans the staging file on every failure path. PATH hint printed when needed.
- Script-side download resolves against the serving origin, so staging (`workers.dev`) serves staging URLs.
- The apex `sliccy.ai` → `www` redirect is already followed by `curl -fsSL`'s `-L`, so both hosts work.
- Kept the module self-contained (own `RELEASES_API` constants) rather than exporting the DMG machinery from `index.ts` — importing from `index.ts` would be circular, and the pointer-floor logic there is DMG-specific.

## Cross-cutting impact

- **Floats exercised**: worker only; new routes are additive. `wrangler.jsonc` zone routes are wildcarded, so no route config change.
- Routes-mirror rule satisfied: routes index in `src/index.ts`, `tests/index.test.ts`, `tests/deployed.test.ts`, plus `api-catalog.ts` and `llms.txt`.
- No new env vars/secrets; GitHub API calls are unauthenticated + UA-tagged + edge-cached (300 s), page-capped at 5, same as the DMG route.

## Test plan

- [x] `biome check` / `prettier --check` clean on touched paths; `check-touched-exemptions.mjs` OK
- [x] `npm run typecheck`
- [x] `npx vitest run --project cloudflare-worker` — 170 passing in `index.test.ts`, no new failures
- [x] `npm run test:coverage:cloudflare-worker` — 87.25/86.51/93.26/75.94 vs floors 86/85/92/75
- [x] `npm run build -w @slicc/cloudflare-worker` (wrangler `--dry-run`) clean
- [x] New tests: script serving (origin pinning incl. staging, HEAD, shape markers), resolver (sparse-release skip, draft/prerelease skip, `.exe` mapping, unknown + typo-cased target 404s, page-cap 404, non-OK/throw/unparseable-JSON 502s, pagination)
- [x] Manual smoke: `wrangler dev` on :8799 → `curl -fsSL http://localhost:8799/install-cli | sh` (origin rewritten to localhost) downloaded the real `slicc-darwin-arm64` release asset via the resolver, verified `--version`, installed → `slicc v5.71.1`. Script also passes `sh -n`.
- [x] N/A — no UI change

## Documentation

- [x] `README.md` — curl one-liner added to the "fastest ways to try it" list
- [x] `packages/cloudflare-worker/CLAUDE.md` — Main Files + Public Routes tables

## Risk & rollback

- Blast radius: two additive public routes; nothing existing changes. Reverts cleanly.
- Worth verifying by hand after deploy: `curl -fsSL https://www.sliccy.ai/install-cli | sh` on a mac (the deployed `/download/slicc-cli/darwin-arm64` 302 → GitHub asset chain).

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API changes are intentional and reflected in docs (routes index, api-catalog, llms.txt)
- [x] No cross-float contract changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gr5eqc3LPa9Zi88xD9LjMv
