### PR TITLE
feat(slicc-cli): slicc update self-update + once-a-day upgrade notice

### DIFF
--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -100,9 +100,11 @@ running binary (Windows: parks the old file at `.old`, swept on later runs).
 Regular verbs call `startUpdateNotice()` (main-package `update.go`): the upgrade
 notice prints from a local cache (`<user-cache-dir>/slicc/update-check.json`)
 and a background refresh runs at most once per 24 h, bounded-flushed at command
-exit so short verbs still persist it. Disabled for `dev` builds and via
-`SLICC_NO_UPDATE_CHECK=1`; `SLICC_UPDATE_API_BASE` overrides the API base
-(tests/mirrors).
+exit so short verbs still persist it. Disabled via `SLICC_NO_UPDATE_CHECK=1`
+and for any non-release-stamped version (`dev`, `git describe` output) —
+`IsReleaseVersion` gates both the notice and the self-replace, so `slicc
+update` refuses to clobber a local build that is ahead of the latest tag.
+`SLICC_UPDATE_API_BASE` overrides the API base (tests/mirrors).
 
 ## Build / test
 

--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -10,6 +10,7 @@ slicc <join-url> prompt "<text>"                Stream one assistant turn, then 
 slicc <join-url> exec "<command>"               Run a command in the leader's shell, stream output
 slicc <join-url> watch [scoop]                  Tail the leader's live agent output, read-only
 slicc <join-url> follow [--no-banner] [runner]  Stay connected; run leader-issued commands via <runner>
+slicc update [--check]                          Self-update to the newest released CLI binary
 ```
 
 `watch` is a passive `tail -f` on the agent that mirrors the browser thread: it
@@ -49,6 +50,8 @@ with `CGO_ENABLED=0` (see the `dist` target). No native toolchain required.
 | `internal/signaling/` | HTTP follower client for `tray-signaling.ts` (attach → poll/answer/ice/retry), ported from the iOS connector |
 | `internal/tray/`      | pion peer + `tray-control` data channel + follower state machine (hello, ping/pong, dispatch)                |
 | `internal/execrun/`   | Cross-platform OS command runner backing `follow` (streams stdout/stderr, forwards signals)                  |
+| `update.go`           | `cmdUpdate` (`slicc update [--check]`) + the on-launch update-notice hook                                    |
+| `internal/update/`    | Release discovery (sparse-release scan), self-update apply, once-a-day cached notice                         |
 
 ## Protocol parity
 
@@ -83,6 +86,23 @@ Startup ergonomics (all in `commands.go`):
   leader captures it in `tray-leader-sync.ts` (`getFollowerMotds`) and, alongside
   `getBrowserCapableBootstrapIds`, tags followers `[ssh]` / `[playwright]` in
   `host`. Additive + optional on the wire (browser/iOS peers omit it).
+
+## Self-update (`slicc update`)
+
+`internal/update` scans GitHub releases newest→oldest for the first one carrying
+this platform's `slicc-<os>-<arch>[.exe]` asset — releases are **sparse** (CLI
+binaries only attach when `packages/slicc-cli` changed), so `releases/latest` is
+not enough. The same bounded pagination as the worker's `/download/slicc-cli`
+route (30/page, 5 pages max). `Apply` downloads next to the executable, runs the
+staged binary's `--version` as a sanity gate, then atomically renames over the
+running binary (Windows: parks the old file at `.old`, swept on later runs).
+
+Regular verbs call `startUpdateNotice()` (main-package `update.go`): the upgrade
+notice prints from a local cache (`<user-cache-dir>/slicc/update-check.json`)
+and a background refresh runs at most once per 24 h, bounded-flushed at command
+exit so short verbs still persist it. Disabled for `dev` builds and via
+`SLICC_NO_UPDATE_CHECK=1`; `SLICC_UPDATE_API_BASE` overrides the API base
+(tests/mirrors).
 
 ## Build / test
 

--- a/packages/slicc-cli/README.md
+++ b/packages/slicc-cli/README.md
@@ -66,8 +66,9 @@ On regular launches the CLI also checks for a newer release **at most once a
 day**, in the background, and prints a one-line notice on stderr when one
 exists. The notice comes from a local cache
 (`<user-cache-dir>/slicc/update-check.json`), so launches never wait on the
-network. `SLICC_NO_UPDATE_CHECK=1` disables the launch check entirely; dev
-(unstamped) builds never check.
+network. `SLICC_NO_UPDATE_CHECK=1` disables the launch check entirely. Dev
+builds (any non-release-stamped version, incl. `git describe` output) never
+check, and `slicc update` refuses to replace them with a release binary.
 
 ## Build
 

--- a/packages/slicc-cli/README.md
+++ b/packages/slicc-cli/README.md
@@ -12,6 +12,7 @@ slicc <join-url> prompt "<text>"                Send one message, stream the ass
 slicc <join-url> exec "<command>"               Run a command in the leader's shell, stream output, exit
 slicc <join-url> watch [scoop]                  Tail the agent's output live (a scoop jid filters), until Ctrl+C
 slicc <join-url> follow [--no-banner] [runner]  Stay connected; let the leader run commands on THIS machine
+slicc update [--check]                          Self-update to the newest released CLI binary
 ```
 
 `watch` is read-only: it prints the leader's agent output as it streams (a
@@ -54,6 +55,19 @@ slicc <url> follow docker exec -i sandbox sh -c  # scope the leader to a contain
 ⚠️ **`follow <runner>` is remote code execution by design.** The leader gets to
 run commands on your machine. Only point it at leaders you trust, and prefer a
 sandboxing runner. Set `SLICC_DEBUG=1` to see connection diagnostics on stderr.
+
+## update — keep the binary fresh
+
+`slicc update` finds the newest release that ships CLI binaries (not every SLICC
+release does), downloads the one for your platform, verifies it runs, and
+atomically replaces the running executable. `slicc update --check` only reports.
+
+On regular launches the CLI also checks for a newer release **at most once a
+day**, in the background, and prints a one-line notice on stderr when one
+exists. The notice comes from a local cache
+(`<user-cache-dir>/slicc/update-check.json`), so launches never wait on the
+network. `SLICC_NO_UPDATE_CHECK=1` disables the launch check entirely; dev
+(unstamped) builds never check.
 
 ## Build
 

--- a/packages/slicc-cli/internal/update/notify.go
+++ b/packages/slicc-cli/internal/update/notify.go
@@ -1,0 +1,132 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// checkState is the cached result of the once-a-day release check, persisted
+// at <user-cache-dir>/slicc/update-check.json. The notice itself is printed
+// from THIS cache, never from a live request — so a launch is never delayed
+// by the network, and a fresh result shows on the next launch.
+type checkState struct {
+	CheckedAt     time.Time `json:"checkedAt"`
+	LatestVersion string    `json:"latestVersion"`
+}
+
+// DefaultStatePath is <os.UserCacheDir>/slicc/update-check.json.
+func DefaultStatePath() (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "slicc", "update-check.json"), nil
+}
+
+// Notifier prints the cached upgrade notice and refreshes the cache at most
+// once per CheckInterval. Fields are injectable for tests; use NewNotifier
+// for production wiring.
+type Notifier struct {
+	Checker       *Checker
+	StatePath     string
+	Out           io.Writer
+	Version       string
+	Now           func() time.Time
+	CheckInterval time.Duration
+	// RefreshWait bounds how long Flush waits for an in-flight background
+	// refresh, so a short-lived command still persists the result without
+	// stalling long past its own work.
+	RefreshWait    time.Duration
+	RefreshTimeout time.Duration
+}
+
+// NewNotifier builds the production Notifier. Returns nil (a no-op for Start)
+// when the check is disabled: dev builds, SLICC_NO_UPDATE_CHECK set, or no
+// resolvable cache dir.
+func NewNotifier(version string, out io.Writer) *Notifier {
+	if version == "dev" || os.Getenv("SLICC_NO_UPDATE_CHECK") != "" {
+		return nil
+	}
+	statePath, err := DefaultStatePath()
+	if err != nil {
+		return nil
+	}
+	return &Notifier{
+		Checker:        NewChecker(),
+		StatePath:      statePath,
+		Out:            out,
+		Version:        version,
+		Now:            time.Now,
+		CheckInterval:  24 * time.Hour,
+		RefreshWait:    3 * time.Second,
+		RefreshTimeout: 10 * time.Second,
+	}
+}
+
+func (n *Notifier) readState() checkState {
+	var state checkState
+	data, err := os.ReadFile(n.StatePath)
+	if err != nil {
+		return state
+	}
+	// A corrupt state file is treated as absent.
+	_ = json.Unmarshal(data, &state)
+	return state
+}
+
+func (n *Notifier) writeState(state checkState) {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(n.StatePath), 0o755); err != nil {
+		return
+	}
+	// Best-effort: a read-only cache dir just means no notice, never a failure.
+	_ = os.WriteFile(n.StatePath, data, 0o600)
+}
+
+// Start prints the upgrade notice when the cached latest version is newer than
+// the running one, and — at most once per CheckInterval — kicks off a
+// background refresh of the cache. The returned flush func waits (bounded by
+// RefreshWait) for that refresh so short commands still persist it; it never
+// blocks longer. Both the receiver and the returned func are nil-safe.
+func (n *Notifier) Start() func() {
+	noop := func() {}
+	if n == nil {
+		return noop
+	}
+	state := n.readState()
+	if n.Out != nil && state.LatestVersion != "" && IsNewer(state.LatestVersion, n.Version) {
+		fmt.Fprintf(n.Out, "slicc %s is available (you have %s) — run `slicc update`\n",
+			state.LatestVersion, n.Version)
+	}
+	if n.Now().Sub(state.CheckedAt) < n.CheckInterval {
+		return noop
+	}
+	// Stamp CheckedAt before the fetch so overlapping launches don't stampede
+	// the API; the version refresh lands when the fetch completes.
+	n.writeState(checkState{CheckedAt: n.Now(), LatestVersion: state.LatestVersion})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ctx, cancel := context.WithTimeout(context.Background(), n.RefreshTimeout)
+		defer cancel()
+		release, err := n.Checker.LatestCLIRelease(ctx)
+		if err != nil {
+			return
+		}
+		n.writeState(checkState{CheckedAt: n.Now(), LatestVersion: release.Version})
+	}()
+	return func() {
+		select {
+		case <-done:
+		case <-time.After(n.RefreshWait):
+		}
+	}
+}

--- a/packages/slicc-cli/internal/update/notify.go
+++ b/packages/slicc-cli/internal/update/notify.go
@@ -46,10 +46,11 @@ type Notifier struct {
 }
 
 // NewNotifier builds the production Notifier. Returns nil (a no-op for Start)
-// when the check is disabled: dev builds, SLICC_NO_UPDATE_CHECK set, or no
-// resolvable cache dir.
+// when the check is disabled: dev/git-describe builds (anything that is not a
+// stamped release version), SLICC_NO_UPDATE_CHECK set, or no resolvable cache
+// dir.
 func NewNotifier(version string, out io.Writer) *Notifier {
-	if version == "dev" || os.Getenv("SLICC_NO_UPDATE_CHECK") != "" {
+	if !IsReleaseVersion(version) || os.Getenv("SLICC_NO_UPDATE_CHECK") != "" {
 		return nil
 	}
 	statePath, err := DefaultStatePath()

--- a/packages/slicc-cli/internal/update/notify_test.go
+++ b/packages/slicc-cli/internal/update/notify_test.go
@@ -1,0 +1,156 @@
+package update
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testNotifier(t *testing.T, server serverHandle, now time.Time) (*Notifier, *bytes.Buffer) {
+	t.Helper()
+	out := &bytes.Buffer{}
+	notifier := &Notifier{
+		Checker:        testChecker(server.server),
+		StatePath:      filepath.Join(t.TempDir(), "update-check.json"),
+		Out:            out,
+		Version:        "v5.71.1",
+		Now:            func() time.Time { return now },
+		CheckInterval:  24 * time.Hour,
+		RefreshWait:    5 * time.Second,
+		RefreshTimeout: 5 * time.Second,
+	}
+	return notifier, out
+}
+
+type serverHandle struct {
+	server   *httptest.Server
+	requests *int
+}
+
+func newReleasesHandle(t *testing.T, tag string) serverHandle {
+	server, requests := releasesServer(t, map[int][]fakeRelease{
+		1: {carrier(tag, "slicc-darwin-arm64", "https://example.com/asset")},
+	})
+	return serverHandle{server: server, requests: requests}
+}
+
+func readStateFile(t *testing.T, path string) checkState {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading state: %v", err)
+	}
+	var state checkState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("parsing state: %v", err)
+	}
+	return state
+}
+
+func TestNotifierFirstRunRefreshesCacheWithoutNotice(t *testing.T) {
+	handle := newReleasesHandle(t, "v9.9.9")
+	notifier, out := testNotifier(t, handle, time.Now())
+
+	flush := notifier.Start()
+	flush()
+
+	if out.Len() != 0 {
+		t.Fatalf("first run printed %q, want silence (notice comes from cache)", out.String())
+	}
+	state := readStateFile(t, notifier.StatePath)
+	if state.LatestVersion != "v9.9.9" {
+		t.Fatalf("cached latest = %q, want v9.9.9", state.LatestVersion)
+	}
+	if *handle.requests != 1 {
+		t.Fatalf("requests = %d, want 1", *handle.requests)
+	}
+}
+
+func TestNotifierPrintsCachedNoticeAndSkipsFreshCheck(t *testing.T) {
+	handle := newReleasesHandle(t, "v9.9.9")
+	now := time.Now()
+	notifier, out := testNotifier(t, handle, now)
+
+	// Seed the cache as a recent check that saw a newer version.
+	notifier.writeState(checkState{CheckedAt: now.Add(-time.Hour), LatestVersion: "v9.9.9"})
+
+	flush := notifier.Start()
+	flush()
+
+	if !strings.Contains(out.String(), "v9.9.9 is available") {
+		t.Fatalf("notice missing from %q", out.String())
+	}
+	if !strings.Contains(out.String(), "slicc update") {
+		t.Fatalf("notice does not point at `slicc update`: %q", out.String())
+	}
+	if *handle.requests != 0 {
+		t.Fatalf("requests = %d, want 0 (checked an hour ago)", *handle.requests)
+	}
+}
+
+func TestNotifierRefreshesAfterInterval(t *testing.T) {
+	handle := newReleasesHandle(t, "v9.9.9")
+	now := time.Now()
+	notifier, _ := testNotifier(t, handle, now)
+	notifier.writeState(checkState{CheckedAt: now.Add(-25 * time.Hour), LatestVersion: ""})
+
+	flush := notifier.Start()
+	flush()
+
+	if *handle.requests != 1 {
+		t.Fatalf("requests = %d, want 1 (interval elapsed)", *handle.requests)
+	}
+	if got := readStateFile(t, notifier.StatePath).LatestVersion; got != "v9.9.9" {
+		t.Fatalf("cached latest = %q", got)
+	}
+}
+
+func TestNotifierUpToDateStaysQuiet(t *testing.T) {
+	handle := newReleasesHandle(t, "v5.71.1")
+	now := time.Now()
+	notifier, out := testNotifier(t, handle, now)
+	notifier.writeState(checkState{CheckedAt: now.Add(-time.Hour), LatestVersion: "v5.71.1"})
+
+	notifier.Start()()
+
+	if out.Len() != 0 {
+		t.Fatalf("printed %q for an up-to-date binary", out.String())
+	}
+}
+
+func TestNotifierToleratesCorruptStateFile(t *testing.T) {
+	handle := newReleasesHandle(t, "v9.9.9")
+	notifier, out := testNotifier(t, handle, time.Now())
+	if err := os.WriteFile(notifier.StatePath, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	notifier.Start()()
+
+	if out.Len() != 0 {
+		t.Fatalf("printed %q from a corrupt state file", out.String())
+	}
+	if got := readStateFile(t, notifier.StatePath).LatestVersion; got != "v9.9.9" {
+		t.Fatalf("cache not refreshed after corrupt state, latest = %q", got)
+	}
+}
+
+func TestNilNotifierIsSafe(_ *testing.T) {
+	var notifier *Notifier
+	notifier.Start()() // must not panic
+}
+
+func TestNewNotifierDisabledForDevAndOptOut(t *testing.T) {
+	if NewNotifier("dev", os.Stderr) != nil {
+		t.Fatal("dev builds must not check for updates")
+	}
+	t.Setenv("SLICC_NO_UPDATE_CHECK", "1")
+	if NewNotifier("v5.71.1", os.Stderr) != nil {
+		t.Fatal("SLICC_NO_UPDATE_CHECK must disable the check")
+	}
+}

--- a/packages/slicc-cli/internal/update/notify_test.go
+++ b/packages/slicc-cli/internal/update/notify_test.go
@@ -149,6 +149,9 @@ func TestNewNotifierDisabledForDevAndOptOut(t *testing.T) {
 	if NewNotifier("dev", os.Stderr) != nil {
 		t.Fatal("dev builds must not check for updates")
 	}
+	if NewNotifier("v5.71.1-4-gabc123-dirty", os.Stderr) != nil {
+		t.Fatal("git-describe builds must not check for updates")
+	}
 	t.Setenv("SLICC_NO_UPDATE_CHECK", "1")
 	if NewNotifier("v5.71.1", os.Stderr) != nil {
 		t.Fatal("SLICC_NO_UPDATE_CHECK must disable the check")

--- a/packages/slicc-cli/internal/update/update.go
+++ b/packages/slicc-cli/internal/update/update.go
@@ -142,6 +142,29 @@ func (c *Checker) LatestCLIRelease(ctx context.Context) (*Release, error) {
 	return nil, fmt.Errorf("no recent release carries %s (CLI binaries only attach to releases where packages/slicc-cli changed)", asset)
 }
 
+// IsReleaseVersion reports whether v looks like a stamped release version
+// (`v5.71.1` / `5.71.1`). Local builds stamp `git describe` output —
+// `v5.71.1-4-gabc123`, a bare hash, "dev", or a `-dirty` suffix — which must
+// never be compared against releases: segment-wise they read OLDER than the
+// tag they are ahead of, so an update would replace newer local code.
+func IsReleaseVersion(v string) bool {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if trimmed == "" {
+		return false
+	}
+	for _, part := range strings.Split(trimmed, ".") {
+		if part == "" {
+			return false
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // IsNewer reports whether version `latest` is strictly newer than `current`.
 // A leading "v" is tolerated; non-numeric segments count as 0, so a "dev"
 // current always reads as older than a real release.
@@ -172,6 +195,10 @@ func IsNewer(latest, current string) bool {
 	}
 	return false
 }
+
+// renameFile is os.Rename, indirected so tests can fail the final swap and
+// exercise the Windows rollback path.
+var renameFile = os.Rename
 
 func runVersionCheck(ctx context.Context, path string) error {
 	if err := exec.CommandContext(ctx, path, "--version").Run(); err != nil {
@@ -226,15 +253,22 @@ func (c *Checker) Apply(ctx context.Context, release *Release, exePath string) e
 		_ = os.Remove(staging)
 		return err
 	}
+	parked := false
 	if c.GOOS == "windows" {
 		old := exePath + ".old"
 		_ = os.Remove(old)
-		if err := os.Rename(exePath, old); err != nil {
+		if err := renameFile(exePath, old); err != nil {
 			_ = os.Remove(staging)
 			return fmt.Errorf("parking the running executable: %w", err)
 		}
+		parked = true
 	}
-	if err := os.Rename(staging, exePath); err != nil {
+	if err := renameFile(staging, exePath); err != nil {
+		// Roll the parked executable back so a failed swap never leaves the
+		// install path empty (e.g. antivirus locking the staged file).
+		if parked {
+			_ = renameFile(exePath+".old", exePath)
+		}
 		_ = os.Remove(staging)
 		return err
 	}

--- a/packages/slicc-cli/internal/update/update.go
+++ b/packages/slicc-cli/internal/update/update.go
@@ -1,0 +1,248 @@
+// Package update finds, downloads, and applies newer slicc CLI release
+// binaries, and backs the once-a-day upgrade notice printed on launch.
+//
+// Release binaries are sparse: they only attach to GitHub releases where
+// packages/slicc-cli changed (release-native.mjs gating), so discovery scans
+// releases newest→oldest for the first one carrying this platform's
+// slicc-<os>-<arch>[.exe] asset — the same bounded pagination the tray hub
+// worker uses for /download/slicc.dmg and /download/slicc-cli/:target.
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAPIBase  = "https://api.github.com"
+	repoPath        = "ai-ecoverse/slicc"
+	releasesPerPage = 30
+	// Bounded pagination: 5 × 30 releases scanned before giving up, so a long
+	// streak of binary-less releases cannot drive unbounded GitHub API calls.
+	maxReleasePages = 5
+	userAgent       = "slicc-cli"
+)
+
+// Release is the newest release that carries this platform's CLI binary.
+type Release struct {
+	Version  string // tag name, e.g. "v5.71.1"
+	AssetURL string
+}
+
+// Checker resolves and downloads CLI release binaries. The zero value is not
+// usable; construct with NewChecker.
+type Checker struct {
+	APIBase string
+	HTTP    *http.Client
+	GOOS    string
+	GOARCH  string
+	// Verify is run on the staged binary before it replaces the executable
+	// (default: exec `<staged> --version`). Injectable for tests, where the
+	// staged download is not a runnable binary.
+	Verify func(ctx context.Context, path string) error
+}
+
+// NewChecker builds a production Checker. SLICC_UPDATE_API_BASE overrides the
+// GitHub API base URL (tests, mirrors).
+func NewChecker() *Checker {
+	base := os.Getenv("SLICC_UPDATE_API_BASE")
+	if base == "" {
+		base = defaultAPIBase
+	}
+	return &Checker{
+		APIBase: base,
+		HTTP:    &http.Client{Timeout: 60 * time.Second},
+		GOOS:    runtime.GOOS,
+		GOARCH:  runtime.GOARCH,
+		Verify:  runVersionCheck,
+	}
+}
+
+// AssetName is the release-asset name for a GOOS/GOARCH pair, mirroring the
+// Makefile dist matrix (slicc-<os>-<arch>, ".exe" on windows).
+func AssetName(goos, goarch string) string {
+	ext := ""
+	if goos == "windows" {
+		ext = ".exe"
+	}
+	return fmt.Sprintf("slicc-%s-%s%s", goos, goarch, ext)
+}
+
+type githubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type githubRelease struct {
+	Draft      bool          `json:"draft"`
+	Prerelease bool          `json:"prerelease"`
+	TagName    string        `json:"tag_name"`
+	Assets     []githubAsset `json:"assets"`
+}
+
+func (c *Checker) fetchReleasesPage(ctx context.Context, page int) ([]githubRelease, error) {
+	url := fmt.Sprintf("%s/repos/%s/releases?per_page=%d&page=%d", c.APIBase, repoPath, releasesPerPage, page)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	res, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub releases API responded %d", res.StatusCode)
+	}
+	var releases []githubRelease
+	if err := json.NewDecoder(res.Body).Decode(&releases); err != nil {
+		return nil, fmt.Errorf("decoding GitHub releases: %w", err)
+	}
+	return releases, nil
+}
+
+// LatestCLIRelease scans releases newest→oldest for the first published one
+// carrying this platform's CLI asset.
+func (c *Checker) LatestCLIRelease(ctx context.Context) (*Release, error) {
+	asset := AssetName(c.GOOS, c.GOARCH)
+	for page := 1; page <= maxReleasePages; page++ {
+		releases, err := c.fetchReleasesPage(ctx, page)
+		if err != nil {
+			return nil, err
+		}
+		if len(releases) == 0 {
+			break
+		}
+		for _, release := range releases {
+			if release.Draft || release.Prerelease {
+				continue
+			}
+			for _, candidate := range release.Assets {
+				if candidate.Name == asset && candidate.BrowserDownloadURL != "" {
+					return &Release{Version: release.TagName, AssetURL: candidate.BrowserDownloadURL}, nil
+				}
+			}
+		}
+		// Fewer than a full page means the last page — stop early.
+		if len(releases) < releasesPerPage {
+			break
+		}
+	}
+	return nil, fmt.Errorf("no recent release carries %s (CLI binaries only attach to releases where packages/slicc-cli changed)", asset)
+}
+
+// IsNewer reports whether version `latest` is strictly newer than `current`.
+// A leading "v" is tolerated; non-numeric segments count as 0, so a "dev"
+// current always reads as older than a real release.
+func IsNewer(latest, current string) bool {
+	parse := func(v string) []int {
+		parts := strings.Split(strings.TrimPrefix(strings.TrimSpace(v), "v"), ".")
+		nums := make([]int, len(parts))
+		for i, part := range parts {
+			n, err := strconv.Atoi(part)
+			if err == nil {
+				nums[i] = n
+			}
+		}
+		return nums
+	}
+	a, b := parse(latest), parse(current)
+	for i := 0; i < len(a) || i < len(b); i++ {
+		av, bv := 0, 0
+		if i < len(a) {
+			av = a[i]
+		}
+		if i < len(b) {
+			bv = b[i]
+		}
+		if av != bv {
+			return av > bv
+		}
+	}
+	return false
+}
+
+func runVersionCheck(ctx context.Context, path string) error {
+	if err := exec.CommandContext(ctx, path, "--version").Run(); err != nil {
+		return fmt.Errorf("downloaded binary failed to run --version: %w", err)
+	}
+	return nil
+}
+
+func (c *Checker) downloadTo(ctx context.Context, url, destination string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	res, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed with HTTP %d for %s", res.StatusCode, url)
+	}
+	out, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	written, copyErr := io.Copy(out, res.Body)
+	closeErr := out.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if written == 0 {
+		return fmt.Errorf("download of %s produced an empty file", url)
+	}
+	return nil
+}
+
+// Apply downloads the release binary next to exePath, verifies it runs, and
+// atomically swaps it in. On Windows the running executable cannot be
+// overwritten, but it CAN be renamed — the old binary is parked at
+// exePath+".old" (removed by RemoveStaleBinary on a later run).
+func (c *Checker) Apply(ctx context.Context, release *Release, exePath string) error {
+	staging := exePath + ".new"
+	if err := c.downloadTo(ctx, release.AssetURL, staging); err != nil {
+		_ = os.Remove(staging)
+		return err
+	}
+	if err := c.Verify(ctx, staging); err != nil {
+		_ = os.Remove(staging)
+		return err
+	}
+	if c.GOOS == "windows" {
+		old := exePath + ".old"
+		_ = os.Remove(old)
+		if err := os.Rename(exePath, old); err != nil {
+			_ = os.Remove(staging)
+			return fmt.Errorf("parking the running executable: %w", err)
+		}
+	}
+	if err := os.Rename(staging, exePath); err != nil {
+		_ = os.Remove(staging)
+		return err
+	}
+	return nil
+}
+
+// RemoveStaleBinary clears the ".old" binary a Windows self-update parks next
+// to the executable. Best-effort; safe to call on every launch.
+func RemoveStaleBinary(exePath string) {
+	_ = os.Remove(exePath + ".old")
+}

--- a/packages/slicc-cli/internal/update/update_test.go
+++ b/packages/slicc-cli/internal/update/update_test.go
@@ -1,0 +1,313 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestAssetName(t *testing.T) {
+	cases := []struct {
+		goos, goarch, want string
+	}{
+		{"darwin", "arm64", "slicc-darwin-arm64"},
+		{"darwin", "amd64", "slicc-darwin-amd64"},
+		{"linux", "amd64", "slicc-linux-amd64"},
+		{"windows", "amd64", "slicc-windows-amd64.exe"},
+		{"windows", "arm64", "slicc-windows-arm64.exe"},
+	}
+	for _, tc := range cases {
+		if got := AssetName(tc.goos, tc.goarch); got != tc.want {
+			t.Errorf("AssetName(%q, %q) = %q, want %q", tc.goos, tc.goarch, got, tc.want)
+		}
+	}
+}
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		latest, current string
+		want            bool
+	}{
+		{"v5.72.0", "v5.71.1", true},
+		{"v5.71.1", "v5.71.1", false},
+		{"v5.71.0", "v5.71.1", false},
+		{"5.72.0", "v5.71.1", true},
+		{"v6.0.0", "v5.99.99", true},
+		{"v5.71.1.1", "v5.71.1", true},
+		{"v5.71.1", "dev", true},
+		{"dev", "v5.71.1", false},
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		if got := IsNewer(tc.latest, tc.current); got != tc.want {
+			t.Errorf("IsNewer(%q, %q) = %v, want %v", tc.latest, tc.current, got, tc.want)
+		}
+	}
+}
+
+type fakeRelease struct {
+	Draft      bool        `json:"draft"`
+	Prerelease bool        `json:"prerelease"`
+	TagName    string      `json:"tag_name"`
+	Assets     []fakeAsset `json:"assets"`
+}
+
+type fakeAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+func carrier(tag, assetName, url string) fakeRelease {
+	return fakeRelease{TagName: tag, Assets: []fakeAsset{{Name: assetName, BrowserDownloadURL: url}}}
+}
+
+func binaryless(tag string) fakeRelease {
+	return fakeRelease{TagName: tag, Assets: []fakeAsset{{Name: "sliccy-1.0.0.tgz", BrowserDownloadURL: "x"}}}
+}
+
+// releasesServer serves canned per-page release lists and counts requests.
+func releasesServer(t *testing.T, pages map[int][]fakeRelease) (*httptest.Server, *int) {
+	t.Helper()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		releases := pages[page]
+		if releases == nil {
+			releases = []fakeRelease{}
+		}
+		if err := json.NewEncoder(w).Encode(releases); err != nil {
+			t.Errorf("encoding releases: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, &requests
+}
+
+func testChecker(server *httptest.Server) *Checker {
+	return &Checker{
+		APIBase: server.URL,
+		HTTP:    server.Client(),
+		GOOS:    "darwin",
+		GOARCH:  "arm64",
+		Verify:  func(context.Context, string) error { return nil },
+	}
+}
+
+func TestLatestCLIReleaseSkipsSparseDraftAndPrerelease(t *testing.T) {
+	server, requests := releasesServer(t, map[int][]fakeRelease{
+		1: {
+			binaryless("v5.72.0"),
+			{Draft: true, TagName: "v5.71.9", Assets: []fakeAsset{{Name: "slicc-darwin-arm64", BrowserDownloadURL: "draft"}}},
+			{Prerelease: true, TagName: "v5.71.8", Assets: []fakeAsset{{Name: "slicc-darwin-arm64", BrowserDownloadURL: "pre"}}},
+			carrier("v5.71.1", "slicc-darwin-arm64", "https://example.com/slicc-darwin-arm64"),
+		},
+	})
+	release, err := testChecker(server).LatestCLIRelease(context.Background())
+	if err != nil {
+		t.Fatalf("LatestCLIRelease: %v", err)
+	}
+	if release.Version != "v5.71.1" || release.AssetURL != "https://example.com/slicc-darwin-arm64" {
+		t.Fatalf("got %+v", release)
+	}
+	if *requests != 1 {
+		t.Fatalf("requests = %d, want 1", *requests)
+	}
+}
+
+func fullBinarylessPage() []fakeRelease {
+	page := make([]fakeRelease, releasesPerPage)
+	for i := range page {
+		page[i] = binaryless(fmt.Sprintf("v5.%d.0", i))
+	}
+	return page
+}
+
+func TestLatestCLIReleasePaginates(t *testing.T) {
+	server, requests := releasesServer(t, map[int][]fakeRelease{
+		1: fullBinarylessPage(),
+		2: {carrier("v5.60.0", "slicc-darwin-arm64", "https://example.com/asset")},
+	})
+	release, err := testChecker(server).LatestCLIRelease(context.Background())
+	if err != nil {
+		t.Fatalf("LatestCLIRelease: %v", err)
+	}
+	if release.Version != "v5.60.0" {
+		t.Fatalf("version = %q", release.Version)
+	}
+	if *requests != 2 {
+		t.Fatalf("requests = %d, want 2", *requests)
+	}
+}
+
+func TestLatestCLIReleaseStopsAtShortPage(t *testing.T) {
+	server, requests := releasesServer(t, map[int][]fakeRelease{
+		1: {binaryless("v5.72.0")},
+	})
+	if _, err := testChecker(server).LatestCLIRelease(context.Background()); err == nil {
+		t.Fatal("want error when no release carries the asset")
+	}
+	if *requests != 1 {
+		t.Fatalf("requests = %d, want 1 (short page ends pagination)", *requests)
+	}
+}
+
+func TestLatestCLIReleasePageCap(t *testing.T) {
+	pages := map[int][]fakeRelease{}
+	for page := 1; page <= 10; page++ {
+		pages[page] = fullBinarylessPage()
+	}
+	server, requests := releasesServer(t, pages)
+	if _, err := testChecker(server).LatestCLIRelease(context.Background()); err == nil {
+		t.Fatal("want error after the page cap")
+	}
+	if *requests != maxReleasePages {
+		t.Fatalf("requests = %d, want %d", *requests, maxReleasePages)
+	}
+}
+
+func TestLatestCLIReleaseAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "rate limited", http.StatusForbidden)
+	}))
+	t.Cleanup(server.Close)
+	if _, err := testChecker(server).LatestCLIRelease(context.Background()); err == nil {
+		t.Fatal("want error on non-200 API response")
+	}
+}
+
+// assetServer serves a fake binary body at /asset.
+func assetServer(t *testing.T, body string, status int) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func applyFixture(t *testing.T, server *httptest.Server) (checker *Checker, exePath string, release *Release) {
+	t.Helper()
+	dir := t.TempDir()
+	exePath = filepath.Join(dir, "slicc")
+	if err := os.WriteFile(exePath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	checker = &Checker{
+		HTTP:   server.Client(),
+		GOOS:   "darwin",
+		GOARCH: "arm64",
+		Verify: func(context.Context, string) error { return nil },
+	}
+	release = &Release{Version: "v9.9.9", AssetURL: server.URL + "/asset"}
+	return checker, exePath, release
+}
+
+func TestApplyReplacesExecutable(t *testing.T) {
+	server := assetServer(t, "new-binary", http.StatusOK)
+	checker, exePath, release := applyFixture(t, server)
+	verified := ""
+	checker.Verify = func(_ context.Context, path string) error {
+		verified = path
+		return nil
+	}
+
+	if err := checker.Apply(context.Background(), release, exePath); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	content, err := os.ReadFile(exePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "new-binary" {
+		t.Fatalf("executable content = %q", content)
+	}
+	if verified != exePath+".new" {
+		t.Fatalf("Verify ran on %q, want the staged file", verified)
+	}
+	if _, err := os.Stat(exePath + ".new"); !os.IsNotExist(err) {
+		t.Fatal("staging file left behind")
+	}
+	info, err := os.Stat(exePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Fatal("executable bit lost")
+	}
+}
+
+func TestApplyWindowsParksOldBinary(t *testing.T) {
+	server := assetServer(t, "new-binary", http.StatusOK)
+	checker, exePath, release := applyFixture(t, server)
+	checker.GOOS = "windows"
+
+	if err := checker.Apply(context.Background(), release, exePath); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	parked, err := os.ReadFile(exePath + ".old")
+	if err != nil {
+		t.Fatalf("parked binary missing: %v", err)
+	}
+	if string(parked) != "old-binary" {
+		t.Fatalf("parked content = %q", parked)
+	}
+	current, _ := os.ReadFile(exePath)
+	if string(current) != "new-binary" {
+		t.Fatalf("executable content = %q", current)
+	}
+
+	RemoveStaleBinary(exePath)
+	if _, err := os.Stat(exePath + ".old"); !os.IsNotExist(err) {
+		t.Fatal("RemoveStaleBinary left the .old binary")
+	}
+}
+
+func TestApplyVerifyFailureKeepsOldBinary(t *testing.T) {
+	server := assetServer(t, "corrupt", http.StatusOK)
+	checker, exePath, release := applyFixture(t, server)
+	checker.Verify = func(context.Context, string) error { return fmt.Errorf("does not run") }
+
+	if err := checker.Apply(context.Background(), release, exePath); err == nil {
+		t.Fatal("want error when verification fails")
+	}
+	content, _ := os.ReadFile(exePath)
+	if string(content) != "old-binary" {
+		t.Fatalf("executable content = %q, want untouched old binary", content)
+	}
+	if _, err := os.Stat(exePath + ".new"); !os.IsNotExist(err) {
+		t.Fatal("staging file left behind")
+	}
+}
+
+func TestApplyDownloadErrorKeepsOldBinary(t *testing.T) {
+	server := assetServer(t, "not found", http.StatusNotFound)
+	checker, exePath, release := applyFixture(t, server)
+
+	if err := checker.Apply(context.Background(), release, exePath); err == nil {
+		t.Fatal("want error on HTTP 404 download")
+	}
+	content, _ := os.ReadFile(exePath)
+	if string(content) != "old-binary" {
+		t.Fatalf("executable content = %q", content)
+	}
+}
+
+func TestApplyEmptyDownloadRejected(t *testing.T) {
+	server := assetServer(t, "", http.StatusOK)
+	checker, exePath, release := applyFixture(t, server)
+
+	if err := checker.Apply(context.Background(), release, exePath); err == nil {
+		t.Fatal("want error on empty download")
+	}
+	if _, err := os.Stat(exePath + ".new"); !os.IsNotExist(err) {
+		t.Fatal("staging file left behind")
+	}
+}

--- a/packages/slicc-cli/internal/update/update_test.go
+++ b/packages/slicc-cli/internal/update/update_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -235,12 +237,14 @@ func TestApplyReplacesExecutable(t *testing.T) {
 	if _, err := os.Stat(exePath + ".new"); !os.IsNotExist(err) {
 		t.Fatal("staging file left behind")
 	}
-	info, err := os.Stat(exePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm()&0o111 == 0 {
-		t.Fatal("executable bit lost")
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(exePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Fatal("executable bit lost")
+		}
 	}
 }
 
@@ -267,6 +271,61 @@ func TestApplyWindowsParksOldBinary(t *testing.T) {
 	RemoveStaleBinary(exePath)
 	if _, err := os.Stat(exePath + ".old"); !os.IsNotExist(err) {
 		t.Fatal("RemoveStaleBinary left the .old binary")
+	}
+}
+
+func TestIsReleaseVersion(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"v5.71.1", true},
+		{"5.71.1", true},
+		{"v5.71", true},
+		{"dev", false},
+		{"", false},
+		{"v5.71.1-4-gabc123", false},
+		{"v5.71.1-dirty", false},
+		{"gabc123", false},
+		{"v5..1", false},
+	}
+	for _, tc := range cases {
+		if got := IsReleaseVersion(tc.version); got != tc.want {
+			t.Errorf("IsReleaseVersion(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestApplyWindowsRollsBackParkedBinaryOnSwapFailure(t *testing.T) {
+	server := assetServer(t, "new-binary", http.StatusOK)
+	checker, exePath, release := applyFixture(t, server)
+	checker.GOOS = "windows"
+
+	original := renameFile
+	renameFile = func(src, dst string) error {
+		// Fail only the staged→exe swap; parking and rollback use real renames.
+		if strings.HasSuffix(src, ".new") {
+			return fmt.Errorf("simulated lock on %s", src)
+		}
+		return original(src, dst)
+	}
+	t.Cleanup(func() { renameFile = original })
+
+	if err := checker.Apply(context.Background(), release, exePath); err == nil {
+		t.Fatal("want error when the final swap fails")
+	}
+	content, err := os.ReadFile(exePath)
+	if err != nil {
+		t.Fatalf("executable missing after failed swap: %v", err)
+	}
+	if string(content) != "old-binary" {
+		t.Fatalf("executable content = %q, want the rolled-back old binary", content)
+	}
+	if _, err := os.Stat(exePath + ".old"); !os.IsNotExist(err) {
+		t.Fatal("rollback left the parked .old binary behind")
+	}
+	if _, err := os.Stat(exePath + ".new"); !os.IsNotExist(err) {
+		t.Fatal("staging file left behind")
 	}
 }
 

--- a/packages/slicc-cli/main.go
+++ b/packages/slicc-cli/main.go
@@ -41,6 +41,10 @@ func run(args []string) int {
 	case "-v", "--version", "version":
 		fmt.Println("slicc", version)
 		return 0
+	case "update":
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		return cmdUpdate(ctx, args[1:])
 	}
 
 	joinURL := args[0]
@@ -58,6 +62,10 @@ func run(args []string) int {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Once-a-day cached upgrade notice (stderr), refreshed in the background;
+	// the deferred flush lets a short-lived verb persist the refresh result.
+	defer startUpdateNotice()()
 
 	switch sub {
 	case "prompt":
@@ -127,6 +135,9 @@ Usage:
                                         follow bash -c
                                         follow sh -c
                                         follow docker exec -i sandbox sh -c
+  slicc update [--check]              Self-update to the newest released CLI binary
+                                      (--check only reports; SLICC_NO_UPDATE_CHECK=1
+                                      disables the once-a-day launch check)
   slicc --version
   slicc --help
 

--- a/packages/slicc-cli/update.go
+++ b/packages/slicc-cli/update.go
@@ -34,6 +34,17 @@ func cmdUpdate(ctx context.Context, args []string) int {
 		fmt.Fprintf(os.Stderr, "slicc update: %s\n", err)
 		return 1
 	}
+	// A git-describe / dev build is not comparable to release tags (its
+	// numeric segments read OLDER than the tag it is ahead of), so never
+	// silently replace it with a release binary.
+	if !update.IsReleaseVersion(version) {
+		if checkOnly {
+			fmt.Printf("latest CLI release: %s (you run a development build, %s — not comparable)\n", release.Version, version)
+			return 0
+		}
+		fmt.Fprintf(os.Stderr, "slicc update: refusing to replace a development build (%s) with release %s — rebuild with `make build`, or download the release binary explicitly\n", version, release.Version)
+		return 1
+	}
 	if !update.IsNewer(release.Version, version) {
 		fmt.Printf("slicc %s is up to date (latest CLI release: %s)\n", version, release.Version)
 		return 0

--- a/packages/slicc-cli/update.go
+++ b/packages/slicc-cli/update.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ai-ecoverse/slicc-cli/internal/update"
+)
+
+// cmdUpdate implements `slicc update [--check]`: find the newest release
+// carrying this platform's CLI binary (releases are sparse — binaries only
+// attach when packages/slicc-cli changed) and replace the running executable
+// with it. `--check` reports without installing.
+func cmdUpdate(ctx context.Context, args []string) int {
+	checkOnly := false
+	for _, arg := range args {
+		switch arg {
+		case "--check":
+			checkOnly = true
+		case "-h", "--help":
+			usage(os.Stdout)
+			return 0
+		default:
+			fmt.Fprintf(os.Stderr, "slicc update: unknown argument %q\n", arg)
+			return 2
+		}
+	}
+
+	checker := update.NewChecker()
+	release, err := checker.LatestCLIRelease(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "slicc update: %s\n", err)
+		return 1
+	}
+	if !update.IsNewer(release.Version, version) {
+		fmt.Printf("slicc %s is up to date (latest CLI release: %s)\n", version, release.Version)
+		return 0
+	}
+	if checkOnly {
+		fmt.Printf("slicc %s is available (you have %s) — run `slicc update`\n", release.Version, version)
+		return 0
+	}
+
+	exePath, err := executablePath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "slicc update: locating the running executable: %s\n", err)
+		return 1
+	}
+	fmt.Printf("updating slicc %s → %s ...\n", version, release.Version)
+	if err := checker.Apply(ctx, release, exePath); err != nil {
+		fmt.Fprintf(os.Stderr, "slicc update: %s\n", err)
+		return 1
+	}
+	fmt.Printf("updated %s to slicc %s\n", exePath, release.Version)
+	return 0
+}
+
+// executablePath resolves the running binary with symlinks flattened, so an
+// update through a `~/bin/slicc → ~/.slicc/bin/slicc` symlink replaces the
+// real file instead of the link.
+func executablePath() (string, error) {
+	exePath, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
+		return resolved, nil
+	}
+	return exePath, nil
+}
+
+// startUpdateNotice begins the once-a-day cached release check for regular
+// verbs. It prints the (cached) upgrade notice to stderr immediately and
+// returns a flush func that briefly waits for the background cache refresh —
+// call it after the verb finishes. Also sweeps the ".old" binary a Windows
+// self-update leaves behind.
+func startUpdateNotice() func() {
+	if exePath, err := os.Executable(); err == nil {
+		update.RemoveStaleBinary(exePath)
+	}
+	return update.NewNotifier(version, os.Stderr).Start()
+}

--- a/packages/slicc-cli/update_command_test.go
+++ b/packages/slicc-cli/update_command_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// releasesStub serves one page with a single release carrying every CLI asset,
+// so cmdUpdate resolves regardless of the platform the tests run on.
+func releasesStub(t *testing.T, tag string) *httptest.Server {
+	t.Helper()
+	type asset struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	}
+	assets := []asset{}
+	for _, name := range []string{
+		"slicc-darwin-amd64", "slicc-darwin-arm64",
+		"slicc-linux-amd64", "slicc-linux-arm64",
+		"slicc-windows-amd64.exe", "slicc-windows-arm64.exe",
+	} {
+		assets = append(assets, asset{Name: name, BrowserDownloadURL: "https://example.com/" + name})
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") != "1" {
+			_, _ = w.Write([]byte("[]"))
+			return
+		}
+		payload := []map[string]any{{"tag_name": tag, "assets": assets}}
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			t.Errorf("encoding releases: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestRunUpdateDispatch(t *testing.T) {
+	// Argument errors and --help return before any network access.
+	if got := run([]string{"update", "--bogus"}); got != 2 {
+		t.Fatalf("run(update --bogus) = %d, want 2", got)
+	}
+	if got := run([]string{"update", "--help"}); got != 0 {
+		t.Fatalf("run(update --help) = %d, want 0", got)
+	}
+}
+
+func TestUpdateCheckReportsNewerRelease(t *testing.T) {
+	server := releasesStub(t, "v99.0.0")
+	t.Setenv("SLICC_UPDATE_API_BASE", server.URL)
+
+	// version is "dev" in tests — every real release counts as newer, and
+	// --check must report without touching the running executable.
+	if got := run([]string{"update", "--check"}); got != 0 {
+		t.Fatalf("run(update --check) = %d, want 0", got)
+	}
+}
+
+func TestUpdateCheckUpToDate(t *testing.T) {
+	// "v0.0.0" compares equal to the unstamped "dev" version (both parse to
+	// zeros), so the up-to-date path runs without installing anything.
+	server := releasesStub(t, "v0.0.0")
+	t.Setenv("SLICC_UPDATE_API_BASE", server.URL)
+
+	if got := run([]string{"update"}); got != 0 {
+		t.Fatalf("run(update) = %d, want 0 (up to date)", got)
+	}
+}
+
+func TestUpdateSurfacesResolutionErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "rate limited", http.StatusForbidden)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("SLICC_UPDATE_API_BASE", server.URL)
+
+	if got := run([]string{"update"}); got != 1 {
+		t.Fatalf("run(update) = %d, want 1 on API failure", got)
+	}
+}

--- a/packages/slicc-cli/update_command_test.go
+++ b/packages/slicc-cli/update_command_test.go
@@ -47,25 +47,25 @@ func TestRunUpdateDispatch(t *testing.T) {
 	}
 }
 
-func TestUpdateCheckReportsNewerRelease(t *testing.T) {
+func TestUpdateCheckReportsOnDevBuild(t *testing.T) {
 	server := releasesStub(t, "v99.0.0")
 	t.Setenv("SLICC_UPDATE_API_BASE", server.URL)
 
-	// version is "dev" in tests — every real release counts as newer, and
-	// --check must report without touching the running executable.
+	// version is "dev" in tests — not a release version, so --check reports
+	// the latest release as not-comparable without touching the executable.
 	if got := run([]string{"update", "--check"}); got != 0 {
 		t.Fatalf("run(update --check) = %d, want 0", got)
 	}
 }
 
-func TestUpdateCheckUpToDate(t *testing.T) {
-	// "v0.0.0" compares equal to the unstamped "dev" version (both parse to
-	// zeros), so the up-to-date path runs without installing anything.
-	server := releasesStub(t, "v0.0.0")
+func TestUpdateRefusesToReplaceDevBuild(t *testing.T) {
+	// A dev/git-describe build must never be silently replaced by a release
+	// binary (its numeric segments read older than the tag it is ahead of).
+	server := releasesStub(t, "v99.0.0")
 	t.Setenv("SLICC_UPDATE_API_BASE", server.URL)
 
-	if got := run([]string{"update"}); got != 0 {
-		t.Fatalf("run(update) = %d, want 0 (up to date)", got)
+	if got := run([]string{"update"}); got != 1 {
+		t.Fatalf("run(update) = %d, want 1 (refuse to replace dev build)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `slicc update [--check]` — the Go follower CLI can now self-update to the newest released binary — plus a once-a-day on-launch check that prints a one-line stderr notice when a newer CLI release exists.

## Why

The CLI ships as bare release binaries with no upgrade path beyond re-downloading by hand. With the installers landing in #1674 / #1675, `slicc update` closes the loop. Completes the installer series.

## Approach / Implementation notes

- New `internal/update` package:
  - **Discovery** — releases are sparse (CLI binaries only attach when `packages/slicc-cli` changed), so `LatestCLIRelease` scans releases newest→oldest for the first published one carrying this platform's `slicc-<os>-<arch>[.exe]` asset, skipping drafts/prereleases, with the same bounded pagination (30/page, 5 pages) as the worker's release routes. `SLICC_UPDATE_API_BASE` overrides the API base (tests, mirrors).
  - **Apply** — downloads to `<exe>.new`, runs the staged binary's `--version` as a sanity gate (injectable `Verify` for tests), then atomically renames over the running executable. POSIX allows renaming over a running binary; on Windows the old exe is parked at `.old` first and swept on later runs (`RemoveStaleBinary`).
  - **Daily notice** (`Notifier`) — the notice prints from a local cache (`<user-cache-dir>/slicc/update-check.json`), never from a live request, so launches never wait on the network; a background refresh runs at most once per 24 h (`CheckedAt` is stamped before the fetch so overlapping launches don't stampede), and a bounded flush (≤3 s) at command exit lets short verbs persist the result. Disabled for `dev` builds and via `SLICC_NO_UPDATE_CHECK=1`.
- `main.go`: `update` joins `-h`/`-v` as a bare subcommand (no join-URL needed); regular verbs get `defer startUpdateNotice()()`. `cmdUpdate` resolves the executable through `EvalSymlinks` so updating through a symlink replaces the real file.
- Docs: usage text, `README.md`, and `CLAUDE.md` (new Self-update section).

## Cross-cutting impact

- **Floats exercised**: slicc-cli only. No wire-protocol change, no leader/follower contract change.
- The daily check is skipped for unstamped (`dev`) builds, so `go test` and local `make build` binaries never hit the network.
- New persisted state: one JSON cache file under the OS user-cache dir.

## Test plan

- [x] `make check` — gofmt, `go vet`, golangci-lint clean; race tests green; coverage 55.2 % vs 48 % floor
- [x] `make dist` — all six targets cross-compile
- [x] Unit tests (`internal/update`): asset naming, version compare (incl. `dev`), sparse/draft/prerelease skip, pagination + short-page stop + page cap, API errors; Apply success (content, exec bit, staged-file cleanup, Verify-on-staged), Windows `.old` parking + sweep, verify-failure/download-error/empty-download keep the old binary; Notifier first-run silence + cache refresh, cached notice, interval gating, up-to-date silence, corrupt state tolerance, nil-safety, dev/opt-out disablement
- [x] Dispatch tests (main package): `update --bogus` → 2, `update --help` → 0, `--check` newer/up-to-date/API-failure paths against a stubbed API via `SLICC_UPDATE_API_BASE`
- [x] Manual smoke against **real** GitHub releases: binary stamped `v0.0.1` → `slicc update` → "updating slicc v0.0.1 → v5.71.1" → `slicc --version` = `slicc v5.71.1` (signed asset, `--version` gate passed)
- [x] Manual smoke of the notice: first verb launch silent + cache written; second launch prints `slicc v5.71.1 is available (you have v0.0.1) — run 'slicc update'`; `SLICC_NO_UPDATE_CHECK=1` silences it
- [x] N/A — no UI change

## Documentation

- [x] `packages/slicc-cli/README.md` — verbs list + new "update" section
- [x] `packages/slicc-cli/CLAUDE.md` — layout table + Self-update section

## Risk & rollback

- Blast radius: slicc-cli binary only. The daily check is cache-first, background, once-a-day, opt-out-able, and disabled on dev builds; worst case on total API failure is silence.
- Self-replace is staged + verified + atomic; every failure path leaves the current binary untouched.
- Reverts cleanly. Note this PR touches `packages/slicc-cli`, so its release will cut fresh CLI binaries (the first ones that can self-update).

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] CLI verb addition reflected in usage text + README + CLAUDE.md
- [x] No cross-float contract changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gr5eqc3LPa9Zi88xD9LjMv
