### PR TITLE
feat(slicc-cli): follow --eval — persistent REPL runners

### DIFF
--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -93,10 +93,15 @@ Startup ergonomics (all in `commands.go`):
 `execrun.EvalSession` spawns the runner ONCE and serializes leader commands
 into its stdin as lines; responses are framed by **output quiescence**
 (`--eval-quiet`, default 500 ms) because REPLs never signal completion. The
-session outlives connections (state survives reconnects), late output is
-forwarded at the head of the next response, exec exit codes are always 0
-while the REPL lives, `req.Cwd`/`req.Env` are ignored, and REPL death marks
-the session dead (commands then error until restart). `follow.NewEvalSession`
+session outlives connections AND connection drops — a cancelled per-connection
+context interrupts the in-flight computation (`interruptProcess`, SIGINT to
+the group; no-op on Windows) but never kills the REPL; only `Close` (process
+shutdown) and leader-sent SIGTERM/SIGKILL do. Leader SIGINT likewise
+interrupts without killing (ignored on Windows — a hard kill would destroy
+session state). Late output is forwarded at the head of the next response,
+exec exit codes are always 0 while the REPL lives, `req.Cwd`/`req.Env` are
+ignored, and REPL death marks the session dead (commands then error until
+restart). `follow.NewEvalSession`
 routes `exec.request` into it; the MOTD advertises a REPL target so the
 leader's agent sends language code, not shell. The banner warns about `node`
 without `-i` (it buffers piped stdin until EOF). Tests fake the REPL with a

--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -10,6 +10,7 @@ slicc <join-url> prompt "<text>"                Stream one assistant turn, then 
 slicc <join-url> exec "<command>"               Run a command in the leader's shell, stream output
 slicc <join-url> watch [scoop]                  Tail the leader's live agent output, read-only
 slicc <join-url> follow [--no-banner] [runner]  Stay connected; run leader-issued commands via <runner>
+slicc <join-url> follow --eval [repl]           Same, into ONE persistent REPL (state persists; see README)
 slicc update [--check]                          Self-update to the newest released CLI binary
 ```
 
@@ -42,16 +43,16 @@ with `CGO_ENABLED=0` (see the `dist` target). No native toolchain required.
 
 ## Layout
 
-| Path                  | Purpose                                                                                                      |
-| --------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `main.go`             | Arg parsing + subcommand dispatch + Ctrl+C handling                                                          |
-| `commands.go`         | `prompt` / `exec` / `follow` implementations                                                                 |
-| `internal/protocol/`  | Wire structs mirroring `packages/shared-ts/src/tray-sync-protocol.ts` (the subset the CLI uses)              |
-| `internal/signaling/` | HTTP follower client for `tray-signaling.ts` (attach → poll/answer/ice/retry), ported from the iOS connector |
-| `internal/tray/`      | pion peer + `tray-control` data channel + follower state machine (hello, ping/pong, dispatch)                |
-| `internal/execrun/`   | Cross-platform OS command runner backing `follow` (streams stdout/stderr, forwards signals)                  |
-| `update.go`           | `cmdUpdate` (`slicc update [--check]`) + the on-launch update-notice hook                                    |
-| `internal/update/`    | Release discovery (sparse-release scan), self-update apply, once-a-day cached notice                         |
+| Path                  | Purpose                                                                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main.go`             | Arg parsing + subcommand dispatch + Ctrl+C handling                                                                                         |
+| `commands.go`         | `prompt` / `exec` / `follow` implementations                                                                                                |
+| `internal/protocol/`  | Wire structs mirroring `packages/shared-ts/src/tray-sync-protocol.ts` (the subset the CLI uses)                                             |
+| `internal/signaling/` | HTTP follower client for `tray-signaling.ts` (attach → poll/answer/ice/retry), ported from the iOS connector                                |
+| `internal/tray/`      | pion peer + `tray-control` data channel + follower state machine (hello, ping/pong, dispatch)                                               |
+| `internal/execrun/`   | Cross-platform OS command runner backing `follow` (streams stdout/stderr, forwards signals) + `EvalSession` (persistent-REPL `--eval` mode) |
+| `update.go`           | `cmdUpdate` (`slicc update [--check]`) + the on-launch update-notice hook                                                                   |
+| `internal/update/`    | Release discovery (sparse-release scan), self-update apply, once-a-day cached notice                                                        |
 
 ## Protocol parity
 
@@ -86,6 +87,22 @@ Startup ergonomics (all in `commands.go`):
   leader captures it in `tray-leader-sync.ts` (`getFollowerMotds`) and, alongside
   `getBrowserCapableBootstrapIds`, tags followers `[ssh]` / `[playwright]` in
   `host`. Additive + optional on the wire (browser/iOS peers omit it).
+
+## follow `--eval` (persistent REPL)
+
+`execrun.EvalSession` spawns the runner ONCE and serializes leader commands
+into its stdin as lines; responses are framed by **output quiescence**
+(`--eval-quiet`, default 500 ms) because REPLs never signal completion. The
+session outlives connections (state survives reconnects), late output is
+forwarded at the head of the next response, exec exit codes are always 0
+while the REPL lives, `req.Cwd`/`req.Env` are ignored, and REPL death marks
+the session dead (commands then error until restart). `follow.NewEvalSession`
+routes `exec.request` into it; the MOTD advertises a REPL target so the
+leader's agent sends language code, not shell. The banner warns about `node`
+without `-i` (it buffers piped stdin until EOF). Tests fake the REPL with a
+self-exec helper process (`TestEvalHelperProcess`) so the suite runs on all
+three CI OSes; the e2e (`TestCLIFollowEvalPersistsState`) proves cross-command
+state over real WebRTC using the platform shell as a line-eval stand-in.
 
 ## Self-update (`slicc update`)
 

--- a/packages/slicc-cli/README.md
+++ b/packages/slicc-cli/README.md
@@ -14,6 +14,7 @@ slicc <join-url> prompt "<text>"                Send one message, stream the ass
 slicc <join-url> exec "<command>"               Run a command in the leader's shell, stream output, exit
 slicc <join-url> watch [scoop]                  Tail the agent's output live (a scoop jid filters), until Ctrl+C
 slicc <join-url> follow [--no-banner] [runner]  Stay connected; let the leader run commands on THIS machine
+slicc <join-url> follow --eval [repl]           Same, but into ONE persistent REPL process (state persists)
 slicc update [--check]                          Self-update to the newest released CLI binary
 ```
 
@@ -66,6 +67,36 @@ Sliccstart resolves an existing managed, development-tree, or PATH-style binary
 first and, with confirmation, downloads the signed and notarized Darwin release
 into `~/Library/Application Support/Sliccstart/bin/slicc` when none is available.
 The CLI is downloaded on demand and is not bundled in `Sliccstart.app`.
+
+## follow --eval — lend the leader a persistent REPL
+
+Plain `follow <runner>` spawns a fresh process per command, so REPL runners
+lose all state between commands (and bare `node`/`python` would treat the
+command as a script _file_). `follow --eval <repl>` fixes both: the REPL is
+spawned **once**, each leader command is written as a line to its stdin, and
+the output that follows streams back as the response. Variables, defs, and
+imports persist across commands — and across reconnects, since the REPL
+outlives the connection.
+
+```
+slicc <url> follow --eval python -i     # -i forces per-line eval on a pipe (prompts land on stderr)
+slicc <url> follow --eval node -i       # node BUFFERS piped stdin until EOF without -i
+slicc <url> follow --eval clojure       # clojure's REPL reads forms from a pipe as-is
+```
+
+Because REPLs never signal "this result is complete", a response ends once the
+REPL has been **quiet for a window** (default 500 ms; tune with
+`--eval-quiet <dur>`, e.g. `--eval-quiet 2s` for slow-printing REPLs). Output
+of a long computation that stays silent past the window lands at the head of
+the _next_ response instead — raise the window if that bites. Exit codes are
+always 0 while the REPL lives (REPLs report errors in their output); if the
+REPL process dies, the command errors and the follower needs a restart for a
+fresh session. `exec.signal` SIGINT interrupts the current computation the way
+Ctrl+C would in that REPL. The leader's agent sees a REPL-flavored MOTD via
+`ssh --list`, so it knows to send language code rather than shell commands.
+Prompt/banner noise in responses is the REPL's own — quiet it with the REPL's
+flags (`python -q`, etc.). `req.Cwd`/`req.Env` are ignored (the process is
+already running).
 
 ## update — keep the binary fresh
 

--- a/packages/slicc-cli/README.md
+++ b/packages/slicc-cli/README.md
@@ -92,7 +92,12 @@ the _next_ response instead — raise the window if that bites. Exit codes are
 always 0 while the REPL lives (REPLs report errors in their output); if the
 REPL process dies, the command errors and the follower needs a restart for a
 fresh session. `exec.signal` SIGINT interrupts the current computation the way
-Ctrl+C would in that REPL. The leader's agent sees a REPL-flavored MOTD via
+Ctrl+C would in that REPL — the REPL itself survives (on Windows the signal is
+ignored: nothing can interrupt a piped child there without killing it, and
+killing the session would lose its state). A dropped connection never kills
+the REPL either — it outlives reconnects; the in-flight command is interrupted
+and any late output surfaces at the next response. The leader's agent sees a
+REPL-flavored MOTD via
 `ssh --list`, so it knows to send language code rather than shell commands.
 Prompt/banner noise in responses is the REPL's own — quiet it with the REPL's
 flags (`python -q`, etc.). `req.Cwd`/`req.Env` are ignored (the process is

--- a/packages/slicc-cli/cli_e2e_test.go
+++ b/packages/slicc-cli/cli_e2e_test.go
@@ -294,3 +294,95 @@ func TestCLIPromptCompletesOnLiveFloat(t *testing.T) {
 		t.Fatalf("prompt stdout = %q, want to contain PROMPT-E2E-OK", stdout.String())
 	}
 }
+
+// TestCLIFollowEvalPersistsState: `slicc <url> follow --eval <repl>` — the
+// leader issues two exec.requests into ONE persistent runner process and the
+// second sees state set by the first (the whole point of eval mode; per-command
+// spawning would lose it). The stand-in REPL is the platform shell reading
+// commands line-by-line from its stdin (`sh` / `cmd /q`), so this runs on every
+// OS in the matrix without needing python/node installed.
+func TestCLIFollowEvalPersistsState(t *testing.T) {
+	bin := sliccBinary(t)
+	leader := newBridgedLeader(t)
+
+	evalRunner := []string{"sh"}
+	setCmd := "x=EVAL-STATE-77"
+	echoCmd := "echo $x"
+	if runtime.GOOS == "windows" {
+		evalRunner = []string{"cmd", "/q"}
+		setCmd = "set x=EVAL-STATE-77"
+		echoCmd = "echo %x%"
+	}
+
+	var mu sync.Mutex
+	var got strings.Builder
+	done := make(chan int, 1)
+
+	leader.dc.OnOpen(func() {
+		_ = sendJSON(leader.dc, protocol.Hello{Type: protocol.TypeHello, ProtocolVersion: 1})
+		_ = sendJSON(leader.dc, protocol.ExecRequest{
+			Type: protocol.TypeExecRequest, RequestID: "eval-1", Command: setCmd,
+		})
+	})
+	leader.dc.OnMessage(func(msg webrtc.DataChannelMessage) {
+		var env protocol.Envelope
+		if json.Unmarshal(msg.Data, &env) != nil {
+			return
+		}
+		switch env.Type {
+		case protocol.TypeExecChunk:
+			var ch protocol.ExecChunk
+			if json.Unmarshal(msg.Data, &ch) != nil || ch.RequestID != "eval-2" {
+				return
+			}
+			b, _ := base64.StdEncoding.DecodeString(ch.Data)
+			mu.Lock()
+			got.Write(b)
+			mu.Unlock()
+		case protocol.TypeExecResponse:
+			var r protocol.ExecResponse
+			if json.Unmarshal(msg.Data, &r) != nil {
+				return
+			}
+			switch r.RequestID {
+			case "eval-1":
+				// State planted in the persistent shell; now read it back.
+				_ = sendJSON(leader.dc, protocol.ExecRequest{
+					Type: protocol.TypeExecRequest, RequestID: "eval-2", Command: echoCmd,
+				})
+			case "eval-2":
+				select {
+				case done <- r.ExitCode:
+				default:
+				}
+			}
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	followArgs := append([]string{leader.joinURL, "follow", "--eval", "--eval-quiet=300ms"}, evalRunner...)
+	cmd := exec.CommandContext(ctx, bin, followArgs...)
+	cmd.Env = append(os.Environ(), "SLICC_DEBUG=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start eval follower: %v", err)
+	}
+	defer func() { _ = cmd.Process.Kill(); _ = cmd.Wait() }()
+
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("eval-2 exit=%d; follower stderr:\n%s", code, stderr.String())
+		}
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for the second eval response; follower stderr:\n%s", stderr.String())
+	}
+	mu.Lock()
+	out := got.String()
+	mu.Unlock()
+	if !strings.Contains(out, "EVAL-STATE-77") {
+		t.Fatalf("second command's output %q does not contain the state set by the first — the REPL did not persist", out)
+	}
+}

--- a/packages/slicc-cli/cli_test.go
+++ b/packages/slicc-cli/cli_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestReadTextArg(t *testing.T) {
@@ -54,25 +56,27 @@ func TestReadTextArg(t *testing.T) {
 
 func TestParseFollowArgs(t *testing.T) {
 	cases := []struct {
-		name       string
-		in         []string
-		wantRunner []string
-		wantBanner bool
-		wantHelp   bool
+		name string
+		in   []string
+		want followArgs
 	}{
-		{"bare runner", []string{"sh", "-c"}, []string{"sh", "-c"}, true, false},
-		{"no-banner strips flag", []string{"--no-banner", "sh", "-c"}, []string{"sh", "-c"}, false, false},
-		{"help long", []string{"--help"}, nil, true, true},
-		{"help short", []string{"-h"}, nil, true, true},
-		{"terminator lets runner start with a flag", []string{"--", "--no-banner"}, []string{"--no-banner"}, true, false},
-		{"empty", nil, nil, true, false},
+		{"bare runner", []string{"sh", "-c"}, followArgs{runner: []string{"sh", "-c"}, showBanner: true}},
+		{"no-banner strips flag", []string{"--no-banner", "sh", "-c"}, followArgs{runner: []string{"sh", "-c"}}},
+		{"help long", []string{"--help"}, followArgs{showBanner: true, help: true}},
+		{"help short", []string{"-h"}, followArgs{showBanner: true, help: true}},
+		{"terminator lets runner start with a flag", []string{"--", "--no-banner"}, followArgs{runner: []string{"--no-banner"}, showBanner: true}},
+		{"empty", nil, followArgs{showBanner: true}},
+		{"eval mode", []string{"--eval", "python", "-i"}, followArgs{runner: []string{"python", "-i"}, showBanner: true, eval: true}},
+		{"eval quiet equals form", []string{"--eval", "--eval-quiet=750ms", "clojure"}, followArgs{runner: []string{"clojure"}, showBanner: true, eval: true, evalQuiet: 750 * time.Millisecond}},
+		{"eval quiet value form", []string{"--eval", "--eval-quiet", "2s", "node", "-i"}, followArgs{runner: []string{"node", "-i"}, showBanner: true, eval: true, evalQuiet: 2 * time.Second}},
+		{"invalid eval quiet falls back to default", []string{"--eval", "--eval-quiet=soon", "clojure"}, followArgs{runner: []string{"clojure"}, showBanner: true, eval: true}},
+		{"eval composes with no-banner", []string{"--no-banner", "--eval", "python", "-i"}, followArgs{runner: []string{"python", "-i"}, eval: true}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			runner, banner, help := parseFollowArgs(tc.in)
-			if help != tc.wantHelp || banner != tc.wantBanner || strings.Join(runner, " ") != strings.Join(tc.wantRunner, " ") {
-				t.Fatalf("parseFollowArgs(%v) = (%v, banner=%v, help=%v); want (%v, banner=%v, help=%v)",
-					tc.in, runner, banner, help, tc.wantRunner, tc.wantBanner, tc.wantHelp)
+			got := parseFollowArgs(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("parseFollowArgs(%v) = %+v; want %+v", tc.in, got, tc.want)
 			}
 		})
 	}
@@ -105,10 +109,10 @@ func TestRunnerExecWarning(t *testing.T) {
 }
 
 func TestFollowMotd(t *testing.T) {
-	if followMotd(nil) != "" {
+	if followMotd(nil, false) != "" {
 		t.Fatal("no-runner follow should advertise no motd")
 	}
-	motd := followMotd([]string{"sh", "-c"})
+	motd := followMotd([]string{"sh", "-c"}, false)
 	for _, want := range []string{"exec target", "runner: sh -c", "@"} {
 		if !strings.Contains(motd, want) {
 			t.Errorf("motd %q missing %q", motd, want)
@@ -119,7 +123,7 @@ func TestFollowMotd(t *testing.T) {
 func TestPrintFollowBanner(t *testing.T) {
 	t.Run("art + exec warning + heuristic when runner is bare bash", func(t *testing.T) {
 		var buf bytes.Buffer
-		printFollowBanner(&buf, []string{"bash"}, true)
+		printFollowBanner(&buf, followArgs{runner: []string{"bash"}, showBanner: true})
 		out := buf.String()
 		if !strings.Contains(out, "follow") { // the ASCII wordmark ends with "follow"
 			t.Error("expected the ASCII wordmark when showArt=true")
@@ -133,7 +137,7 @@ func TestPrintFollowBanner(t *testing.T) {
 	})
 	t.Run("no art when suppressed, but exec warning stays", func(t *testing.T) {
 		var buf bytes.Buffer
-		printFollowBanner(&buf, []string{"sh", "-c"}, false)
+		printFollowBanner(&buf, followArgs{runner: []string{"sh", "-c"}})
 		out := buf.String()
 		if strings.Contains(out, "_____") {
 			t.Error("art should be suppressed when showArt=false")
@@ -144,7 +148,7 @@ func TestPrintFollowBanner(t *testing.T) {
 	})
 	t.Run("no runner => exec-disabled notice", func(t *testing.T) {
 		var buf bytes.Buffer
-		printFollowBanner(&buf, nil, true)
+		printFollowBanner(&buf, followArgs{showBanner: true})
 		if !strings.Contains(buf.String(), "exec disabled") {
 			t.Error("expected the exec-disabled notice for a no-runner follow")
 		}

--- a/packages/slicc-cli/commands.go
+++ b/packages/slicc-cli/commands.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ai-ecoverse/slicc-cli/internal/execrun"
 	"github.com/ai-ecoverse/slicc-cli/internal/follow"
 	"github.com/ai-ecoverse/slicc-cli/internal/protocol"
 	"github.com/ai-ecoverse/slicc-cli/internal/tray"
@@ -312,15 +313,32 @@ func truncateOneLine(s string, limit int) string {
 // cmdFollow stays connected and runs leader-issued commands locally through the
 // given runner argv, reconnecting with backoff. An empty runner means the leader
 // gets no exec on this box.
-func cmdFollow(ctx context.Context, joinURL string, runner []string, showBanner bool) int {
-	printFollowBanner(os.Stderr, runner, showBanner)
+func cmdFollow(ctx context.Context, joinURL string, fa followArgs) int {
+	// Eval mode: spawn the REPL ONCE, before connecting, so a missing binary
+	// fails fast. The session outlives individual connections — REPL state
+	// survives reconnects.
+	var eval *execrun.EvalSession
+	if fa.eval {
+		if len(fa.runner) == 0 {
+			fmt.Fprintln(os.Stderr, "slicc follow --eval: missing REPL runner (e.g. follow --eval python -i)")
+			return 2
+		}
+		var err error
+		eval, err = execrun.StartEval(execrun.EvalOptions{Runner: fa.runner, Quiet: fa.evalQuiet})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "slicc follow --eval: starting %s: %s\n", strings.Join(fa.runner, " "), err)
+			return 1
+		}
+		defer eval.Close()
+	}
+	printFollowBanner(os.Stderr, fa)
 	backoff := time.Second
 	failures := 0
 	for {
 		if ctx.Err() != nil {
 			return 0
 		}
-		connected, err := followOnce(ctx, joinURL, runner)
+		connected, err := followOnce(ctx, joinURL, fa.runner, eval)
 		if ctx.Err() != nil {
 			return 0
 		}
@@ -345,7 +363,12 @@ func cmdFollow(ctx context.Context, joinURL string, runner []string, showBanner 
 	}
 }
 
-func followOnce(ctx context.Context, joinURL string, runner []string) (connected bool, err error) {
+func followOnce(
+	ctx context.Context,
+	joinURL string,
+	runner []string,
+	eval *execrun.EvalSession,
+) (connected bool, err error) {
 	// Connection-scoped context: cancelled on ANY return (disconnect, ctx done),
 	// so a leader-issued command that's still running is killed with the
 	// connection instead of surviving on the follower's machine across reconnects.
@@ -361,7 +384,7 @@ func followOnce(ctx context.Context, joinURL string, runner []string) (connected
 
 	conn, dialErr := tray.Dial(connCtx, joinURL, tray.Options{
 		Capabilities: caps,
-		Motd:         followMotd(runner),
+		Motd:         followMotd(runner, eval != nil),
 		Logf:         debugLogf,
 		OnMessage: func(typ string, raw []byte) {
 			select {
@@ -374,7 +397,12 @@ func followOnce(ctx context.Context, joinURL string, runner []string) (connected
 		return false, dialErr
 	}
 	defer conn.Close()
-	session := follow.NewSession(conn, runner, os.Stderr)
+	var session *follow.Session
+	if eval != nil {
+		session = follow.NewEvalSession(conn, eval, os.Stderr)
+	} else {
+		session = follow.NewSession(conn, runner, os.Stderr)
+	}
 	fmt.Fprintln(os.Stderr, "slicc follow: connected")
 
 	for {
@@ -406,29 +434,57 @@ const followArt = `   _____ _ _
 // printFollowBanner writes the startup banner: the ASCII wordmark (unless
 // suppressed), who the leader would run as, the runner, and — when the runner
 // looks like it won't actually execute commands — a heuristic warning.
-func printFollowBanner(w io.Writer, runner []string, showArt bool) {
-	if showArt {
+func printFollowBanner(w io.Writer, fa followArgs) {
+	if fa.showBanner {
 		fmt.Fprint(w, followArt)
 	}
 	who := fmt.Sprintf("%s@%s", currentUser(), hostname())
-	if len(runner) == 0 {
+	if len(fa.runner) == 0 {
 		fmt.Fprintf(w, "slicc follow: connecting as %s (exec disabled — no runner given)\n", who)
 		return
 	}
 	fmt.Fprintf(w, "⚠  the leader can run commands on this machine as %s\n", who)
-	fmt.Fprintf(w, "   via: %s <command>   (each command is printed here as it runs)\n", strings.Join(runner, " "))
-	if warn := runnerExecWarning(runner); warn != "" {
+	if fa.eval {
+		fmt.Fprintf(w, "   REPL/eval mode: one persistent `%s` process; each command is a line on its stdin\n", strings.Join(fa.runner, " "))
+		fmt.Fprint(w, "   (a response ends once the REPL goes quiet; state persists across commands)\n")
+		if warn := evalRunnerWarning(fa.runner); warn != "" {
+			fmt.Fprintf(w, "⚠  %s\n", warn)
+		}
+		return
+	}
+	fmt.Fprintf(w, "   via: %s <command>   (each command is printed here as it runs)\n", strings.Join(fa.runner, " "))
+	if warn := runnerExecWarning(fa.runner); warn != "" {
 		fmt.Fprintf(w, "⚠  %s\n", warn)
 	}
+}
+
+// evalRunnerWarning flags REPLs that are known to buffer piped stdin instead
+// of evaluating per line — the eval-mode counterpart of the `follow bash`
+// footgun. node reads the WHOLE pipe before running unless forced interactive.
+func evalRunnerWarning(runner []string) string {
+	base := shellBase(runner[0])
+	if base != "node" {
+		return ""
+	}
+	for _, tok := range runner[1:] {
+		if tok == "-i" || tok == "--interactive" {
+			return ""
+		}
+	}
+	return "node buffers piped stdin until EOF — you probably want: follow --eval node -i"
 }
 
 // followMotd is the concise, one-line description the follower advertises in its
 // hello handshake. The leader surfaces it to the agent (via `ssh --list`) so the
 // first `ssh` reveals what the target is, who it runs as, and its platform.
 // Empty for a no-runner follower (nothing is exec-capable to describe).
-func followMotd(runner []string) string {
+func followMotd(runner []string, eval bool) string {
 	if len(runner) == 0 {
 		return ""
+	}
+	if eval {
+		return fmt.Sprintf("slicc-cli REPL target · %s@%s · %s/%s · persistent `%s` session: send %s code, not shell commands; state persists across commands",
+			currentUser(), hostname(), runtime.GOOS, runtime.GOARCH, strings.Join(runner, " "), shellBase(runner[0]))
 	}
 	return fmt.Sprintf("slicc-cli exec target · %s@%s · %s/%s · runner: %s · runs as this user (RCE by design)",
 		currentUser(), hostname(), runtime.GOOS, runtime.GOARCH, strings.Join(runner, " "))

--- a/packages/slicc-cli/internal/execrun/eval.go
+++ b/packages/slicc-cli/internal/execrun/eval.go
@@ -188,11 +188,24 @@ func (e *EvalSession) collect(ctx context.Context, onChunk ChunkFunc, control <-
 		case <-timer.C:
 			return Result{ExitCode: 0}
 		case <-ctx.Done():
-			killProcess(e.cmd, "SIGKILL")
-			return e.finishDead()
+			// A connection-scoped cancellation (the tray dropped mid-eval) must
+			// NOT kill the shared REPL — it outlives connections by design so
+			// state survives reconnects. Best-effort interrupt the in-flight
+			// computation (POSIX; no-op on Windows) and stop collecting; late
+			// output surfaces at the head of the next response. Process
+			// shutdown kills the REPL via Close, not here.
+			interruptProcess(e.cmd)
+			return Result{ExitCode: 130, Signal: "interrupted", Err: ctx.Err()}
 		case name, ok := <-control:
 			if !ok {
 				control = nil
+				continue
+			}
+			if name == "SIGINT" {
+				// Ctrl+C semantics: interrupt the computation, keep the REPL.
+				// On Windows nothing can be sent without killing the child —
+				// ignoring the signal beats destroying the session's state.
+				interruptProcess(e.cmd)
 				continue
 			}
 			killProcess(e.cmd, name)

--- a/packages/slicc-cli/internal/execrun/eval.go
+++ b/packages/slicc-cli/internal/execrun/eval.go
@@ -1,0 +1,242 @@
+package execrun
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultEvalQuiet is the output-quiescence window that ends an Eval response.
+// REPLs never signal "this result is complete", so a response is considered
+// done once the REPL has been silent this long after the command was written.
+const DefaultEvalQuiet = 500 * time.Millisecond
+
+// EvalOptions configures StartEval.
+type EvalOptions struct {
+	// Runner is the REPL argv, spawned ONCE for the whole session
+	// (e.g. ["python","-i"], ["node","-i"], ["clojure"]). Required.
+	Runner []string
+	// Quiet is the output-quiescence window ending each response
+	// (DefaultEvalQuiet when zero).
+	Quiet time.Duration
+	// Env adds environment variables to the spawned REPL (tests).
+	Env map[string]string
+}
+
+type evalEvent struct {
+	stream string
+	data   []byte
+}
+
+// EvalSession is a persistent REPL child process. Each Eval writes one command
+// as a line to its stdin and replies with the output that follows — so state
+// (variables, defs, imports) survives across commands, unlike Run, which
+// spawns a fresh process per command. Eval calls are serialized: a REPL has
+// one stdin, so concurrent leader commands queue.
+type EvalSession struct {
+	quiet time.Duration
+	cmd   *exec.Cmd
+	stdin io.WriteCloser
+	// events carries merged stdout/stderr chunks; closed when both pumps end
+	// (the REPL closed its output = it exited or is exiting).
+	events chan evalEvent
+	// exited is closed after cmd.Wait; exitResult then holds the outcome.
+	exited     chan struct{}
+	exitResult Result
+
+	mu   sync.Mutex
+	dead bool
+}
+
+// StartEval spawns the REPL and starts its output pumps. The returned session
+// is ready for Eval calls; Close kills the REPL.
+func StartEval(opts EvalOptions) (*EvalSession, error) {
+	if len(opts.Runner) == 0 {
+		return nil, errors.New("eval mode requires a runner (the REPL argv)")
+	}
+	quiet := opts.Quiet
+	if quiet <= 0 {
+		quiet = DefaultEvalQuiet
+	}
+	cmd := exec.Command(opts.Runner[0], opts.Runner[1:]...)
+	cmd.Env = mergedEnv(opts.Env)
+	setProcAttr(cmd)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	session := &EvalSession{
+		quiet:  quiet,
+		cmd:    cmd,
+		stdin:  stdin,
+		events: make(chan evalEvent, 64),
+		exited: make(chan struct{}),
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go session.pumpInto(stdout, "stdout", &wg)
+	go session.pumpInto(stderr, "stderr", &wg)
+	go func() {
+		wg.Wait()
+		close(session.events)
+		session.exitResult = waitResult(cmd.Wait())
+		close(session.exited)
+	}()
+	return session, nil
+}
+
+func (e *EvalSession) pumpInto(r io.Reader, stream string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	buf := make([]byte, chunkBytes)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			e.events <- evalEvent{stream: stream, data: chunk}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// waitResult maps a cmd.Wait error to the same Result shape Run produces.
+func waitResult(err error) Result {
+	if err == nil {
+		return Result{ExitCode: 0}
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		if code := ee.ExitCode(); code >= 0 {
+			return Result{ExitCode: code}
+		}
+		return Result{ExitCode: 137, Signal: "killed"}
+	}
+	return Result{ExitCode: 1, Err: err}
+}
+
+// Eval writes command as one line to the REPL's stdin and streams the output
+// that follows through onChunk. The response ends after the quiescence window;
+// exit code 0 means "the REPL is still alive", not per-command success — REPLs
+// report errors in their output, not via exit codes. control forwards signal
+// names to the REPL process (SIGINT interrupts most REPLs' current
+// computation without killing them). Calls are serialized.
+func (e *EvalSession) Eval(
+	ctx context.Context,
+	command string,
+	onChunk ChunkFunc,
+	control <-chan string,
+) Result {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.dead {
+		return e.deadResult()
+	}
+	// Output that arrived between commands (late output of the previous
+	// command, or the prompt the REPL printed while idle) is forwarded at the
+	// head of this response rather than silently dropped.
+	e.drainPending(onChunk)
+
+	if !strings.HasSuffix(command, "\n") {
+		command += "\n"
+	}
+	if _, err := io.WriteString(e.stdin, command); err != nil {
+		// A failed stdin write means the REPL is gone (EPIPE); finishDead
+		// synchronizes on cmd.Wait before reading the exit result.
+		return e.finishDead()
+	}
+	return e.collect(ctx, onChunk, control)
+}
+
+// collect forwards output events until the quiescence window elapses, the REPL
+// exits, the context ends, or a kill signal arrives.
+func (e *EvalSession) collect(ctx context.Context, onChunk ChunkFunc, control <-chan string) Result {
+	timer := time.NewTimer(e.quiet)
+	defer timer.Stop()
+	for {
+		select {
+		case event, ok := <-e.events:
+			if !ok {
+				return e.finishDead()
+			}
+			if onChunk != nil {
+				onChunk(event.stream, event.data)
+			}
+			if !timer.Stop() {
+				<-timer.C
+			}
+			timer.Reset(e.quiet)
+		case <-timer.C:
+			return Result{ExitCode: 0}
+		case <-ctx.Done():
+			killProcess(e.cmd, "SIGKILL")
+			return e.finishDead()
+		case name, ok := <-control:
+			if !ok {
+				control = nil
+				continue
+			}
+			killProcess(e.cmd, name)
+		}
+	}
+}
+
+// drainPending forwards already-buffered output without blocking.
+func (e *EvalSession) drainPending(onChunk ChunkFunc) {
+	for {
+		select {
+		case event, ok := <-e.events:
+			if !ok {
+				return
+			}
+			if onChunk != nil {
+				onChunk(event.stream, event.data)
+			}
+		default:
+			return
+		}
+	}
+}
+
+// finishDead waits for the exit result, marks the session dead, and reports it.
+func (e *EvalSession) finishDead() Result {
+	<-e.exited
+	e.dead = true
+	return e.deadResult()
+}
+
+func (e *EvalSession) deadResult() Result {
+	res := e.exitResult
+	if res.Err == nil {
+		res.Err = fmt.Errorf("the REPL process exited (code %d) — restart slicc follow to get a fresh session", res.ExitCode)
+	}
+	if res.ExitCode == 0 {
+		res.ExitCode = 1
+	}
+	return res
+}
+
+// Close kills the REPL process. Safe to call once Eval callers are done.
+func (e *EvalSession) Close() {
+	killProcess(e.cmd, "SIGKILL")
+	_ = e.stdin.Close()
+}

--- a/packages/slicc-cli/internal/execrun/eval_test.go
+++ b/packages/slicc-cli/internal/execrun/eval_test.go
@@ -1,0 +1,175 @@
+package execrun
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestEvalHelperProcess is not a real test: it is the fake REPL the EvalSession
+// tests spawn (the standard self-exec helper pattern, portable across the
+// three CI OSes where no common REPL binary exists). It echoes each stdin line
+// back as "echo:<line>", routes "stderr:<x>" lines to stderr, and exits with
+// code 3 on "die".
+func TestEvalHelperProcess(_ *testing.T) {
+	if os.Getenv("SLICC_TEST_EVAL_REPL") == "" {
+		return
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == "die":
+			os.Exit(3)
+		case strings.HasPrefix(line, "stderr:"):
+			fmt.Fprintf(os.Stderr, "err:%s\n", strings.TrimPrefix(line, "stderr:"))
+		default:
+			fmt.Printf("echo:%s\n", line)
+		}
+	}
+	os.Exit(0)
+}
+
+func startTestEval(t *testing.T) *EvalSession {
+	t.Helper()
+	session, err := StartEval(EvalOptions{
+		Runner: []string{os.Args[0], "-test.run=TestEvalHelperProcess"},
+		Quiet:  150 * time.Millisecond,
+		Env:    map[string]string{"SLICC_TEST_EVAL_REPL": "1"},
+	})
+	if err != nil {
+		t.Fatalf("StartEval: %v", err)
+	}
+	t.Cleanup(session.Close)
+	return session
+}
+
+type chunkLog struct {
+	mu     sync.Mutex
+	chunks []string
+}
+
+func (c *chunkLog) add(stream string, data []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.chunks = append(c.chunks, stream+"|"+string(data))
+}
+
+func (c *chunkLog) joined() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return strings.Join(c.chunks, "")
+}
+
+func TestEvalPersistsAcrossCommands(t *testing.T) {
+	session := startTestEval(t)
+
+	first := &chunkLog{}
+	res := session.Eval(context.Background(), "one", first.add, nil)
+	if res.Err != nil || res.ExitCode != 0 {
+		t.Fatalf("first Eval: %+v", res)
+	}
+	if !strings.Contains(first.joined(), "echo:one") {
+		t.Fatalf("first output %q missing echo:one", first.joined())
+	}
+
+	// Same process answers the second command — the session did not respawn.
+	second := &chunkLog{}
+	res = session.Eval(context.Background(), "two\n", second.add, nil)
+	if res.Err != nil || res.ExitCode != 0 {
+		t.Fatalf("second Eval: %+v", res)
+	}
+	out := second.joined()
+	if !strings.Contains(out, "echo:two") {
+		t.Fatalf("second output %q missing echo:two", out)
+	}
+	// The trailing newline in the command must not produce an extra empty echo.
+	if strings.Contains(out, "echo:\n") {
+		t.Fatalf("second output %q contains an empty echo — newline was doubled", out)
+	}
+}
+
+func TestEvalRoutesStderr(t *testing.T) {
+	session := startTestEval(t)
+	log := &chunkLog{}
+	res := session.Eval(context.Background(), "stderr:boom", log.add, nil)
+	if res.Err != nil {
+		t.Fatalf("Eval: %+v", res)
+	}
+	if !strings.Contains(log.joined(), "stderr|err:boom") {
+		t.Fatalf("output %q missing stderr-attributed chunk", log.joined())
+	}
+}
+
+func TestEvalSerializesConcurrentCommands(t *testing.T) {
+	session := startTestEval(t)
+	var wg sync.WaitGroup
+	logs := [2]*chunkLog{{}, {}}
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			res := session.Eval(context.Background(), fmt.Sprintf("cmd%d", n), logs[n].add, nil)
+			if res.Err != nil {
+				t.Errorf("Eval cmd%d: %+v", n, res)
+			}
+		}(i)
+	}
+	wg.Wait()
+	// Each response must contain its own echo; ordering between the two is
+	// unspecified, but output must not leak across responses.
+	combined := logs[0].joined() + logs[1].joined()
+	for _, want := range []string{"echo:cmd0", "echo:cmd1"} {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("combined output %q missing %q", combined, want)
+		}
+	}
+}
+
+func TestEvalReportsReplDeath(t *testing.T) {
+	session := startTestEval(t)
+	res := session.Eval(context.Background(), "die", nil, nil)
+	if res.Err == nil {
+		t.Fatalf("want death error, got %+v", res)
+	}
+	if res.ExitCode != 3 {
+		t.Fatalf("exit code = %d, want the REPL's 3", res.ExitCode)
+	}
+
+	// Subsequent commands refuse immediately with the same explanation.
+	res = session.Eval(context.Background(), "after", nil, nil)
+	if res.Err == nil || !strings.Contains(res.Err.Error(), "exited") {
+		t.Fatalf("post-death Eval: %+v", res)
+	}
+}
+
+func TestEvalHonorsContextCancellation(t *testing.T) {
+	session := startTestEval(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	res := session.Eval(ctx, "anything", nil, nil)
+	if time.Since(start) > 5*time.Second {
+		t.Fatal("cancelled Eval did not return promptly")
+	}
+	if res.Err == nil {
+		t.Fatalf("want an error after context cancellation, got %+v", res)
+	}
+}
+
+func TestStartEvalRequiresRunner(t *testing.T) {
+	if _, err := StartEval(EvalOptions{}); err == nil {
+		t.Fatal("want an error for an empty runner")
+	}
+}
+
+func TestStartEvalMissingBinary(t *testing.T) {
+	if _, err := StartEval(EvalOptions{Runner: []string{"slicc-no-such-repl-binary"}}); err == nil {
+		t.Fatal("want an error for a missing REPL binary")
+	}
+}

--- a/packages/slicc-cli/internal/execrun/eval_test.go
+++ b/packages/slicc-cli/internal/execrun/eval_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
 	"sync"
 	"testing"
@@ -20,6 +21,10 @@ func TestEvalHelperProcess(_ *testing.T) {
 	if os.Getenv("SLICC_TEST_EVAL_REPL") == "" {
 		return
 	}
+	// Real REPLs (python, clojure) catch SIGINT to abort the current
+	// computation without dying; mirror that so the interrupt tests exercise
+	// the keep-alive path.
+	signal.Ignore(os.Interrupt)
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -47,6 +52,20 @@ func startTestEval(t *testing.T) *EvalSession {
 	}
 	t.Cleanup(session.Close)
 	return session
+}
+
+// warmUpEval runs one round-trip so the helper REPL is provably past its
+// startup (scanner loop running ⇒ its SIGINT-ignore handler is installed)
+// before a test interrupts it.
+func warmUpEval(t *testing.T, session *EvalSession) {
+	t.Helper()
+	log := &chunkLog{}
+	if res := session.Eval(context.Background(), "warmup", log.add, nil); res.Err != nil {
+		t.Fatalf("warmup Eval: %+v", res)
+	}
+	if !strings.Contains(log.joined(), "echo:warmup") {
+		t.Fatalf("warmup output %q missing echo", log.joined())
+	}
 }
 
 type chunkLog struct {
@@ -159,6 +178,51 @@ func TestEvalHonorsContextCancellation(t *testing.T) {
 	}
 	if res.Err == nil {
 		t.Fatalf("want an error after context cancellation, got %+v", res)
+	}
+}
+
+func TestEvalSurvivesConnectionScopedCancel(t *testing.T) {
+	// A dropped connection cancels the in-flight Eval's context; the shared
+	// REPL must survive it so state persists across reconnects (the P1 from
+	// review: SIGKILLing here handed a dead session to the next connection).
+	session := startTestEval(t)
+	warmUpEval(t, session)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if res := session.Eval(ctx, "during-drop", nil, nil); res.Err == nil {
+		t.Fatalf("want an error for the cancelled eval, got %+v", res)
+	}
+
+	log := &chunkLog{}
+	res := session.Eval(context.Background(), "after-reconnect", log.add, nil)
+	if res.Err != nil || res.ExitCode != 0 {
+		t.Fatalf("post-cancel Eval: %+v", res)
+	}
+	if !strings.Contains(log.joined(), "echo:after-reconnect") {
+		t.Fatalf("output %q missing echo — the REPL did not survive the dropped connection", log.joined())
+	}
+}
+
+func TestEvalSigintKeepsReplAlive(t *testing.T) {
+	// Leader-sent SIGINT means "abort this computation", never "destroy the
+	// session". The fake REPL ignores SIGINT like python/clojure do; on
+	// Windows interruptProcess is a documented no-op — either way the session
+	// must answer the next command.
+	session := startTestEval(t)
+	warmUpEval(t, session)
+	control := make(chan string, 1)
+	control <- "SIGINT"
+	if res := session.Eval(context.Background(), "interrupted", nil, control); res.Err != nil {
+		t.Fatalf("interrupted Eval: %+v", res)
+	}
+
+	log := &chunkLog{}
+	res := session.Eval(context.Background(), "still-alive", log.add, nil)
+	if res.Err != nil || res.ExitCode != 0 {
+		t.Fatalf("post-SIGINT Eval: %+v", res)
+	}
+	if !strings.Contains(log.joined(), "echo:still-alive") {
+		t.Fatalf("output %q missing echo — SIGINT killed the persistent REPL", log.joined())
 	}
 }
 

--- a/packages/slicc-cli/internal/execrun/signal_unix.go
+++ b/packages/slicc-cli/internal/execrun/signal_unix.go
@@ -29,3 +29,13 @@ func killProcess(cmd *exec.Cmd, name string) {
 	}
 	_ = syscall.Kill(-cmd.Process.Pid, sig)
 }
+
+// interruptProcess delivers SIGINT to the child's process group — the
+// Ctrl+C-equivalent a REPL can catch to abort its current computation without
+// dying. Returns true when the interrupt was actually sent.
+func interruptProcess(cmd *exec.Cmd) bool {
+	if cmd.Process == nil {
+		return false
+	}
+	return syscall.Kill(-cmd.Process.Pid, syscall.SIGINT) == nil
+}

--- a/packages/slicc-cli/internal/execrun/signal_windows.go
+++ b/packages/slicc-cli/internal/execrun/signal_windows.go
@@ -15,3 +15,9 @@ func killProcess(cmd *exec.Cmd, _ string) {
 		_ = cmd.Process.Kill()
 	}
 }
+
+// interruptProcess is a no-op on Windows: there is no way to deliver a
+// Ctrl+C-equivalent to a piped child without killing it, and killing a
+// persistent REPL to "interrupt" it would destroy its state. Returns false so
+// callers know nothing was sent.
+func interruptProcess(_ *exec.Cmd) bool { return false }

--- a/packages/slicc-cli/internal/follow/follow.go
+++ b/packages/slicc-cli/internal/follow/follow.go
@@ -28,6 +28,11 @@ type Session struct {
 	// runner is the argv each command is handed to (command appended as the final
 	// arg). Empty means exec is disabled: every exec.request is refused.
 	runner []string
+	// eval, when set, replaces per-command runner spawns with a persistent REPL
+	// session: each command is written as a line to its stdin (see
+	// execrun.EvalSession). The eval session outlives this connection so REPL
+	// state survives reconnects.
+	eval *execrun.EvalSession
 	// Log receives one line per command as it starts (per-command visibility).
 	log io.Writer
 
@@ -40,6 +45,20 @@ type Session struct {
 // log (optional) receives a one-line notice per command.
 func NewSession(sender Sender, runner []string, log io.Writer) *Session {
 	return &Session{sender: sender, runner: runner, log: log, running: make(map[string]chan string)}
+}
+
+// NewEvalSession builds a follow session that routes every exec.request into
+// the persistent REPL session instead of spawning the runner per command.
+func NewEvalSession(sender Sender, eval *execrun.EvalSession, log io.Writer) *Session {
+	return &Session{
+		sender: sender,
+		// non-nil marker so Handle's exec-disabled refusal does not trigger;
+		// commands never spawn through it while eval is set.
+		runner:  []string{"eval"},
+		eval:    eval,
+		log:     log,
+		running: make(map[string]chan string),
+	}
 }
 
 // Handle routes an inbound message. Only exec.request / exec.signal are acted
@@ -86,18 +105,26 @@ func (s *Session) startExec(ctx context.Context, req protocol.ExecRequest) {
 	s.mu.Unlock()
 
 	go func() {
-		res := execrun.Run(ctx, req.Command, execrun.Options{
-			Runner:  s.runner,
-			Cwd:     req.Cwd,
-			Env:     req.Env,
-			Control: ctrl,
-			OnChunk: func(stream string, data []byte) {
-				_ = s.sender.SendJSON(protocol.ExecChunk{
-					Type: protocol.TypeExecChunk, RequestID: req.RequestID, Stream: stream,
-					Data: base64.StdEncoding.EncodeToString(data),
-				})
-			},
-		})
+		onChunk := func(stream string, data []byte) {
+			_ = s.sender.SendJSON(protocol.ExecChunk{
+				Type: protocol.TypeExecChunk, RequestID: req.RequestID, Stream: stream,
+				Data: base64.StdEncoding.EncodeToString(data),
+			})
+		}
+		var res execrun.Result
+		if s.eval != nil {
+			// Persistent REPL: req.Cwd/req.Env cannot apply to an already-running
+			// process and are intentionally ignored.
+			res = s.eval.Eval(ctx, req.Command, onChunk, ctrl)
+		} else {
+			res = execrun.Run(ctx, req.Command, execrun.Options{
+				Runner:  s.runner,
+				Cwd:     req.Cwd,
+				Env:     req.Env,
+				Control: ctrl,
+				OnChunk: onChunk,
+			})
+		}
 		resp := protocol.ExecResponse{
 			Type: protocol.TypeExecResponse, RequestID: req.RequestID,
 			ExitCode: res.ExitCode, Signal: res.Signal,

--- a/packages/slicc-cli/internal/follow/follow_test.go
+++ b/packages/slicc-cli/internal/follow/follow_test.go
@@ -1,14 +1,19 @@
 package follow
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/ai-ecoverse/slicc-cli/internal/execrun"
 	"github.com/ai-ecoverse/slicc-cli/internal/protocol"
 )
 
@@ -125,4 +130,57 @@ func TestSessionSignalAborts(t *testing.T) {
 func mustJSON(v any) []byte {
 	b, _ := json.Marshal(v)
 	return b
+}
+
+// startTestEvalSession spawns the execrun test-helper fake REPL (see
+// TestEvalHelperProcess in internal/execrun) for eval-mode session tests.
+func startTestEvalSession(t *testing.T) *execrun.EvalSession {
+	t.Helper()
+	eval, err := execrun.StartEval(execrun.EvalOptions{
+		Runner: []string{os.Args[0], "-test.run=TestFollowEvalHelperProcess"},
+		Quiet:  150 * time.Millisecond,
+		Env:    map[string]string{"SLICC_TEST_EVAL_REPL": "1"},
+	})
+	if err != nil {
+		t.Fatalf("StartEval: %v", err)
+	}
+	t.Cleanup(eval.Close)
+	return eval
+}
+
+// TestFollowEvalHelperProcess is the fake REPL for this package's eval tests
+// (line-echo loop; see the execrun twin for the pattern).
+func TestFollowEvalHelperProcess(_ *testing.T) {
+	if os.Getenv("SLICC_TEST_EVAL_REPL") == "" {
+		return
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		fmt.Printf("echo:%s\n", scanner.Text())
+	}
+	os.Exit(0)
+}
+
+func TestEvalSessionAnswersSequentialRequestsFromOneRepl(t *testing.T) {
+	sender := newFakeSender()
+	session := NewEvalSession(sender, startTestEvalSession(t), nil)
+
+	session.Handle(context.Background(), protocol.TypeExecRequest,
+		mustJSON(protocol.ExecRequest{Type: protocol.TypeExecRequest, RequestID: "r1", Command: "alpha"}))
+	resp := waitResponse(t, sender)
+	if resp["requestId"] != "r1" || resp["exitCode"] != float64(0) {
+		t.Fatalf("first response = %v", resp)
+	}
+
+	session.Handle(context.Background(), protocol.TypeExecRequest,
+		mustJSON(protocol.ExecRequest{Type: protocol.TypeExecRequest, RequestID: "r2", Command: "beta"}))
+	resp = waitResponse(t, sender)
+	if resp["requestId"] != "r2" || resp["exitCode"] != float64(0) {
+		t.Fatalf("second response = %v", resp)
+	}
+
+	out := sender.chunks("stdout")
+	if !strings.Contains(out, "echo:alpha") || !strings.Contains(out, "echo:beta") {
+		t.Fatalf("streamed output %q missing echoes from the persistent REPL", out)
+	}
 }

--- a/packages/slicc-cli/main.go
+++ b/packages/slicc-cli/main.go
@@ -20,6 +20,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 )
 
 // version is stamped at build time via -ldflags "-X main.version=…".
@@ -104,15 +105,15 @@ func run(args []string) int {
 		}
 		return cmdWatch(ctx, joinURL, scoopJid)
 	case "follow":
-		// A leading `--no-banner` (or `--`) is consumed by slicc; everything
-		// after is the runner argv (verbatim), so runner flags like `-i` / `-c`
-		// pass straight through.
-		runner, showBanner, help := parseFollowArgs(rest)
-		if help {
+		// Leading slicc-owned options (`--no-banner`, `--eval`, `--eval-quiet`,
+		// `--`) are consumed; everything after is the runner argv (verbatim), so
+		// runner flags like `-i` / `-c` pass straight through.
+		fa := parseFollowArgs(rest)
+		if fa.help {
 			usage(os.Stdout)
 			return 0
 		}
-		return cmdFollow(ctx, joinURL, runner, showBanner)
+		return cmdFollow(ctx, joinURL, fa)
 	default:
 		fmt.Fprintf(os.Stderr, "slicc: unknown subcommand %q\n", sub)
 		usage(os.Stderr)
@@ -135,6 +136,14 @@ Usage:
                                         follow bash -c
                                         follow sh -c
                                         follow docker exec -i sandbox sh -c
+  slicc <join-url> follow --eval [--eval-quiet <dur>] <repl...>
+                                      REPL mode: spawn <repl> ONCE and write each leader
+                                      command as a line to its stdin; the reply is the
+                                      output that follows, ended by <dur> (default 500ms)
+                                      of quiet. State persists across commands.
+                                        follow --eval python -i
+                                        follow --eval node -i
+                                        follow --eval clojure
   slicc update [--check]              Self-update to the newest released CLI binary
                                       (--check only reports; SLICC_NO_UPDATE_CHECK=1
                                       disables the once-a-day launch check)
@@ -179,24 +188,65 @@ func readTextArg(args []string, stdin io.Reader) (string, error) {
 	return strings.Join(args, " "), nil
 }
 
+// followArgs is the parsed `follow` invocation: slicc-owned options plus the
+// runner argv.
+type followArgs struct {
+	runner     []string
+	showBanner bool
+	help       bool
+	// eval switches follow into persistent-REPL mode: the runner is spawned
+	// once and each leader command is written as a line to its stdin.
+	eval bool
+	// evalQuiet overrides the output-quiescence window ending each eval
+	// response (0 = execrun.DefaultEvalQuiet).
+	evalQuiet time.Duration
+}
+
 // parseFollowArgs consumes slicc's own leading `follow` options (`--no-banner`,
-// `--help`, and the `--` end-of-options terminator) and returns the remaining
-// argv as the runner (verbatim). `--` lets a runner whose first token would
-// otherwise look like a slicc flag pass through untouched.
-func parseFollowArgs(rest []string) (runner []string, showBanner bool, help bool) {
-	showBanner = true
+// `--eval`, `--eval-quiet <dur>`, `--help`, and the `--` end-of-options
+// terminator) and returns the remaining argv as the runner (verbatim). `--`
+// lets a runner whose first token would otherwise look like a slicc flag pass
+// through untouched.
+func parseFollowArgs(rest []string) followArgs {
+	fa := followArgs{showBanner: true}
 	for len(rest) > 0 {
-		switch rest[0] {
-		case "-h", "--help":
-			return nil, showBanner, true
-		case "--no-banner":
-			showBanner = false
+		switch {
+		case rest[0] == "-h" || rest[0] == "--help":
+			fa.help = true
+			return fa
+		case rest[0] == "--no-banner":
+			fa.showBanner = false
 			rest = rest[1:]
 			continue
-		case "--":
-			return rest[1:], showBanner, false
+		case rest[0] == "--eval":
+			fa.eval = true
+			rest = rest[1:]
+			continue
+		case strings.HasPrefix(rest[0], "--eval-quiet="):
+			fa.evalQuiet = parseEvalQuiet(rest[0][len("--eval-quiet="):])
+			rest = rest[1:]
+			continue
+		case rest[0] == "--eval-quiet" && len(rest) > 1:
+			fa.evalQuiet = parseEvalQuiet(rest[1])
+			rest = rest[2:]
+			continue
+		case rest[0] == "--":
+			fa.runner = rest[1:]
+			return fa
 		}
 		break
 	}
-	return rest, showBanner, false
+	fa.runner = rest
+	return fa
+}
+
+// parseEvalQuiet parses a `--eval-quiet` duration ("750ms", "2s"); invalid or
+// non-positive values fall back to the default (0), matching how other flags
+// ignore unusable values.
+func parseEvalQuiet(value string) time.Duration {
+	d, err := time.ParseDuration(strings.TrimSpace(value))
+	if err != nil || d <= 0 {
+		return 0
+	}
+	return d
 }


### PR DESCRIPTION
## Summary

Adds `slicc <url> follow --eval <repl>` — persistent-REPL follow mode. The runner (e.g. `python -i`, `node -i`, `clojure`) is spawned **once**; each leader command is written as a line to its stdin and the output that follows streams back as the response. State persists across commands and across reconnects.

## Why

Discussed on the heels of #1676: plain `follow <runner>` spawns a fresh process per command, so pointing it at a REPL either fails outright (bare `node`/`python` treat the command text as a script *file*) or degrades to stateless one-shot eval with `-e`/`-c`. Real REPL semantics need one long-lived process. Direct follow-up to the review question "can we build a follow --eval mode … each input is a line of stdin and the next lines are sent as output" — this is exactly that.

## Approach / Implementation notes

- **`execrun.EvalSession`** (new `internal/execrun/eval.go`): spawns the runner once with piped stdin/stdout/stderr; `Eval` serializes commands (a REPL has one stdin), writes the command + `\n`, and forwards merged output chunks.
- **Response framing is the hard part**: REPLs never signal completion, so a response ends after an **output-quiescence window** (`--eval-quiet <dur>`, default 500 ms). Trade-off documented: output of a long silently-computing command lands at the head of the next response — raise the window if that bites. Late/idle output (e.g. prompts) is forwarded, never silently dropped.
- Exit codes are 0 while the REPL lives (REPLs report errors in their output, not exit codes). `exec.signal` SIGINT reaches the REPL's process group — interrupts the computation the way Ctrl+C would. REPL death → error response with a restart hint; subsequent commands refuse cleanly. A failed final swap can't happen here (no self-replace); a failed stdin write synchronizes on `cmd.Wait` before reporting.
- **`follow.NewEvalSession`** routes `exec.request` into the shared session; `req.Cwd`/`req.Env` are intentionally ignored (the process is already running). The eval session is created *before* connecting (missing binary fails fast) and outlives connections, so REPL state survives reconnects.
- **MOTD** advertises "REPL target … send <repl> code, not shell commands" so the leader's agent knows what language to speak via `ssh --list`. The banner explains eval mode; a heuristic warns on `node` without `-i` (node buffers piped stdin until EOF — the eval-mode cousin of the `follow bash` footgun). WSL/`python -i` prompt-on-stderr behavior verified by hand.
- `parseFollowArgs` grew into a `followArgs` struct (`--eval`, `--eval-quiet` in both `=` and value forms; invalid durations fall back to the default, matching existing flag style).

## Cross-cutting impact

- **No wire-protocol change** — same `exec.request`/`exec.chunk`/`exec.response` messages; leaders and other followers are unaffected. Plain `follow` behavior is untouched (the per-command `execrun.Run` path is byte-identical).
- slicc-cli only; no npm workspaces touched.

## Test plan

- [x] `make check` — gofmt, vet, golangci-lint clean; race tests green; coverage 58.1 % vs 48 % floor
- [x] `make dist` — all six targets cross-compile
- [x] `EvalSession` unit suite against a **self-exec fake REPL** (portable across the 3-OS CI matrix, no python/node needed on runners): cross-command persistence, no doubled trailing newline, stderr attribution, concurrent-request serialization, REPL-death reporting + post-death refusal, context cancellation, missing-binary and empty-runner errors
- [x] Eval-mode `follow.Session` suite (fake sender): two sequential requests answered from one REPL with correctly attributed chunks
- [x] **Real-WebRTC e2e** (`TestCLIFollowEvalPersistsState`): a pion leader plants state (`x=EVAL-STATE-77`) via one exec.request and reads it back via a second, through the actual built binary in `follow --eval` mode, using the platform shell (`sh` / `cmd /q`) as a line-eval stand-in
- [x] Manual sanity: `printf 'x=41\nx+1\n' | python3 -i` → `42` on stdout, prompts/banner on stderr — matches the documented `python -i` guidance
- [x] N/A — no UI change

## Documentation

- [x] `packages/slicc-cli/README.md` — verbs list + new "follow --eval" section (per-REPL flag guidance, quiescence trade-off, signal behavior)
- [x] `packages/slicc-cli/CLAUDE.md` — layout table + design section (framing, late output, death semantics, test strategy)
- [x] usage() text

## Risk & rollback

- Blast radius: the new `--eval` flag path only; plain `follow` is untouched. Reverts cleanly.
- The quiescence window is a heuristic by design — documented, tunable, and conservative (500 ms default). Worst case is output attributed to the next response, never lost.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] CLI verb surface change reflected in usage/README/CLAUDE.md; MOTD keeps the leader-side agent informed
- [x] No cross-float contract changes (wire protocol unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gr5eqc3LPa9Zi88xD9LjMv
