### PR TITLE
npx/ipx: redirect to SLICC built-ins that shadow an npm package (#1691)

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -82,6 +82,35 @@ Custom commands implemented in TypeScript and registered in just-bash.
 | **afplay / chime**                          | `afplay-command.ts`        | Play a sound file. `chime` is a convenience alias for the bundled notification sounds in `/shared/sounds/`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | `afplay <path>`, `chime [done\|alert\|...]`                                                                                                                                                                                                                                                                                                     |
 | **pbcopy / pbpaste / xclip / xsel**         | `clipboard-commands.ts`    | Copy stdin to the clipboard / paste clipboard to stdout via the browser Clipboard API. All four aliases share the same implementation.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | `echo hi \| pbcopy`, `pbpaste`                                                                                                                                                                                                                                                                                                                  |
 
+### `ipx` / `npx` built-in redirects
+
+`ipx` runs JavaScript package bins from the nearest installed `node_modules`; `npx` is an
+alias with the same behavior. When no local bin or installed package resolves, the command
+normally installs the requested package and runs its bin. Before that network install,
+`ipx`/`npx` consults `builtin-shadow-map.ts`. A match exits non-zero and prints a stderr hint
+that names the SLICC built-in, suggests an invocation using the user's arguments, and includes
+the exact `ipk add` bootstrap when the built-in needs one.
+
+Prefer the suggested built-in. To deliberately bypass the redirect and install the npm package,
+place `--force` before its name: `npx --force <package> [args...]` (or the equivalent `ipx`
+form). Already-installed packages, locally resolved bins, and unmapped package names retain the
+normal behavior.
+
+`packages/webapp/src/shell/supplemental-commands/builtin-shadow-map.ts` is authoritative. It
+currently maps exactly these npm package names:
+
+| npm package names                                       | SLICC built-in   |
+| ------------------------------------------------------- | ---------------- |
+| `@biomejs/biome`, `biome`                               | `biome`          |
+| `esbuild`                                               | `esbuild`        |
+| `playwright`, `@playwright/test`, `playwright-core`     | `playwright-cli` |
+| `puppeteer`, `puppeteer-core`                           | `puppeteer`      |
+| `typescript`                                            | `tsc`            |
+| `imagemagick`, `imagemagick-cli`, `imagemagick-convert` | `convert`        |
+| `magick-cli`, `@imagemagick/magick-wasm`                | `magick`         |
+| `ffmpeg`, `@ffmpeg/ffmpeg`                              | `ffmpeg`         |
+| `sqlite3`                                               | `sqlite3`        |
+
 **Example usage**:
 
 ```bash

--- a/packages/vfs-root/workspace/skills/package-execution/SKILL.md
+++ b/packages/vfs-root/workspace/skills/package-execution/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: package-execution
+description: |
+  Use this when the user asks to run or install a JavaScript/npm package with
+  `npx` or `ipx`, or when either command redirects to a SLICC built-in. Covers
+  built-in hints, any required `ipk add` bootstrap, and the `--force` bypass.
+allowed-tools: bash
+---
+
+# JavaScript package execution
+
+`ipx` runs package bins from the nearest installed `node_modules`; `npx` is an alias with the same behavior. If no local bin or installed package resolves, it normally installs the requested package and runs its bin.
+
+Before that network install, mapped package names that duplicate SLICC built-ins redirect to the built-in instead. The command exits non-zero and prints an actionable stderr hint naming the built-in and suggesting an invocation with the original arguments. The hint may also include an exact `ipk add` bootstrap; run that bootstrap first when present, then use the suggested built-in.
+
+Prefer the built-in. To deliberately preserve install-and-run behavior for the npm package, put `--force` before its name:
+
+```bash
+npx --force <package> [args...]
+ipx --force <package> [args...]
+```
+
+Already-installed packages, locally resolved bins, and unmapped package names keep their normal behavior. Use `commands` to discover available built-ins instead of maintaining a package mapping here.

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -95,6 +95,7 @@ See `docs/mounts.md`.
 - `supplemental-commands/` — built-ins (see `docs/shell-reference.md`).
   `typescript` v7 (native) runs checks/builds; `typescript-js` (JS v6) powers browser
   `tsc`/`test`/`esm-transpile` because v7 has no browser/WASM API.
+- `builtin-shadow-map.ts` is authoritative for `ipx`/`npx` npm-name → built-in redirects.
 - `jsh-discovery.ts` / `bsh-discovery.ts` — raw VFS scans backing the shared catalog.
 - `vfs-adapter.ts` — bridges shell calls into VFS; forwards `canWrite` (duck-typed for
   both `VirtualFS` and `RestrictedFS`).

--- a/packages/webapp/src/shell/bsh-watchdog.ts
+++ b/packages/webapp/src/shell/bsh-watchdog.ts
@@ -21,10 +21,10 @@ const log = createLogger('bsh-watchdog');
  * an unbundled `require(...)` for a bare specifier. The .bsh runs in
  * the target browser page via CDP `Runtime.evaluate` and has no way
  * to resolve bare specifiers at runtime — the user must pre-bundle
- * via `ipx esbuild --bundle` so every bare specifier is inlined.
+ * via `esbuild --bundle` so every bare specifier is inlined.
  */
 const BSH_BUNDLE_HINT =
-  '.bsh scripts must be pre-bundled. Install deps via `ipk add <pkg>`, then bundle with `ipx esbuild --bundle <script>.bsh --outfile=<script>.bundled.bsh` and drop the bundled file in place. There is no runtime resolver in the target page.';
+  '.bsh scripts must be pre-bundled. Install deps via `ipk add <pkg>`, then bundle with `esbuild --bundle <script>.bsh --outfile=<script>.bundled.bsh` and drop the bundled file in place. There is no runtime resolver in the target page.';
 
 export interface BshWatchdogOptions {
   /** Optional CDP transport to subscribe to navigation events on.
@@ -209,7 +209,7 @@ export class BshWatchdog {
     // module graph, no ipk node_modules walk, and no CDN fallback. The
     // wrapper pre-scans the script for `require(...)` specifiers and emits a
     // clear bundle-first error before evaluating the body when any survive.
-    // Bundle the script via `ipx esbuild --bundle <script>.bsh --outfile=...`
+    // Bundle the script via `esbuild --bundle <script>.bsh --outfile=...`
     // so esbuild inlines every bare specifier from the ipk-installed
     // `node_modules` tree (see `esbuild-command.ts`).
     const wrappedScript = `(async () => {

--- a/packages/webapp/src/shell/bsh-watchdog.ts
+++ b/packages/webapp/src/shell/bsh-watchdog.ts
@@ -13,6 +13,7 @@ import type { CDPTransport } from '../cdp/transport.js';
 import { createLogger } from '../core/logger.js';
 import type { BshDiscoveryFS, BshEntry } from './bsh-discovery.js';
 import type { ScriptCatalog } from './script-catalog.js';
+import { ESBUILD_VERSION } from './supplemental-commands/esbuild-wasm.js';
 
 const log = createLogger('bsh-watchdog');
 
@@ -21,10 +22,10 @@ const log = createLogger('bsh-watchdog');
  * an unbundled `require(...)` for a bare specifier. The .bsh runs in
  * the target browser page via CDP `Runtime.evaluate` and has no way
  * to resolve bare specifiers at runtime — the user must pre-bundle
- * via `esbuild --bundle` so every bare specifier is inlined.
+ * after installing the pinned `esbuild-wasm` bootstrap, then run direct
+ * `esbuild --bundle` so every bare specifier is inlined.
  */
-const BSH_BUNDLE_HINT =
-  '.bsh scripts must be pre-bundled. Install deps via `ipk add <pkg>`, then bundle with `esbuild --bundle <script>.bsh --outfile=<script>.bundled.bsh` and drop the bundled file in place. There is no runtime resolver in the target page.';
+const BSH_BUNDLE_HINT = `.bsh scripts must be pre-bundled. Install deps via \`ipk add <pkg>\`, then bootstrap esbuild via \`ipk add esbuild-wasm@${ESBUILD_VERSION}\` and bundle with \`esbuild --bundle <script>.bsh --outfile=<script>.bundled.bsh\`. Drop the bundled file in place. There is no runtime resolver in the target page.`;
 
 export interface BshWatchdogOptions {
   /** Optional CDP transport to subscribe to navigation events on.
@@ -209,9 +210,10 @@ export class BshWatchdog {
     // module graph, no ipk node_modules walk, and no CDN fallback. The
     // wrapper pre-scans the script for `require(...)` specifiers and emits a
     // clear bundle-first error before evaluating the body when any survive.
-    // Bundle the script via `esbuild --bundle <script>.bsh --outfile=...`
-    // so esbuild inlines every bare specifier from the ipk-installed
-    // `node_modules` tree (see `esbuild-command.ts`).
+    // Bootstrap the pinned esbuild-wasm package via `ipk add`, then bundle
+    // the script via direct `esbuild --bundle <script>.bsh --outfile=...` so
+    // every bare specifier is inlined from the ipk-installed `node_modules`
+    // tree (see `esbuild-command.ts`).
     const wrappedScript = `(async () => {
   const __requireSpecifiers = (function() {
     const re = /require\\s*\\(\\s*['"]([^'"]+)['"]\\s*\\)/g;

--- a/packages/webapp/src/shell/supplemental-commands/biome-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/biome-command.ts
@@ -114,10 +114,10 @@ const BIOME_WASM_WEB_VERSION = __BIOME_WASM_WEB_VERSION__;
 const BIOME_JS_API_VERSION = __BIOME_JS_API_VERSION__;
 const ESBUILD_WASM_VERSION = ESBUILD_VERSION;
 
-const INSTALL_PACKAGES = `@biomejs/wasm-web@${BIOME_WASM_WEB_VERSION} @biomejs/js-api@${BIOME_JS_API_VERSION} esbuild-wasm@${ESBUILD_WASM_VERSION}`;
+export const INSTALL_PACKAGES = `@biomejs/wasm-web@${BIOME_WASM_WEB_VERSION} @biomejs/js-api@${BIOME_JS_API_VERSION} esbuild-wasm@${ESBUILD_WASM_VERSION}`;
 
 /** Pinned `ipk add` spec for each backing package, by bare name. */
-const PINNED_SPEC: Record<string, string> = {
+export const PINNED_SPEC: Record<string, string> = {
   '@biomejs/wasm-web': `@biomejs/wasm-web@${BIOME_WASM_WEB_VERSION}`,
   '@biomejs/js-api': `@biomejs/js-api@${BIOME_JS_API_VERSION}`,
   'esbuild-wasm': `esbuild-wasm@${ESBUILD_WASM_VERSION}`,

--- a/packages/webapp/src/shell/supplemental-commands/builtin-shadow-map.ts
+++ b/packages/webapp/src/shell/supplemental-commands/builtin-shadow-map.ts
@@ -71,7 +71,9 @@ export const BUILTIN_SHADOW_MAP: Readonly<Record<string, BuiltinShadow>> = {
 };
 
 export function lookupBuiltinShadow(requestedPackage: string): BuiltinShadow | undefined {
-  return BUILTIN_SHADOW_MAP[requestedPackage];
+  return Object.hasOwn(BUILTIN_SHADOW_MAP, requestedPackage)
+    ? BUILTIN_SHADOW_MAP[requestedPackage]
+    : undefined;
 }
 
 function quoteArg(arg: string): string {

--- a/packages/webapp/src/shell/supplemental-commands/builtin-shadow-map.ts
+++ b/packages/webapp/src/shell/supplemental-commands/builtin-shadow-map.ts
@@ -1,0 +1,100 @@
+import { INSTALL_PACKAGES } from './biome-command.js';
+import { ESBUILD_VERSION } from './esbuild-wasm.js';
+import { BUNDLED_FFMPEG_CORE_VERSION } from './ffmpeg-wasm.js';
+import { BUNDLED_MAGICK_VERSION } from './magick-wasm.js';
+import { TYPESCRIPT_VFS_INSTALL_COMMAND } from './shared.js';
+
+export interface BuiltinShadow {
+  command: string;
+  example: string;
+  bootstrap?: string;
+}
+
+const biome: BuiltinShadow = {
+  command: 'biome',
+  example: 'biome check foo.js',
+  bootstrap: `ipk add ${INSTALL_PACKAGES}`,
+};
+const playwright: BuiltinShadow = {
+  command: 'playwright-cli',
+  example: 'playwright-cli open https://example.com',
+};
+const puppeteer: BuiltinShadow = {
+  command: 'puppeteer',
+  example: 'puppeteer open https://example.com',
+};
+const convert: BuiltinShadow = {
+  command: 'convert',
+  example: 'convert input.png output.jpg',
+  bootstrap: `ipk add @imagemagick/magick-wasm@${BUNDLED_MAGICK_VERSION}`,
+};
+const magick: BuiltinShadow = {
+  ...convert,
+  command: 'magick',
+  example: 'magick input.png output.jpg',
+};
+
+export const BUILTIN_SHADOW_MAP: Readonly<Record<string, BuiltinShadow>> = {
+  '@biomejs/biome': biome,
+  biome,
+  esbuild: {
+    command: 'esbuild',
+    example: 'esbuild --bundle src/index.js --outfile=dist/bundle.js',
+    bootstrap: `ipk add esbuild-wasm@${ESBUILD_VERSION}`,
+  },
+  playwright,
+  '@playwright/test': playwright,
+  'playwright-core': playwright,
+  puppeteer,
+  'puppeteer-core': puppeteer,
+  typescript: {
+    command: 'tsc',
+    example: 'tsc --noEmit',
+    bootstrap: TYPESCRIPT_VFS_INSTALL_COMMAND,
+  },
+  imagemagick: convert,
+  'imagemagick-cli': convert,
+  'imagemagick-convert': convert,
+  'magick-cli': magick,
+  '@imagemagick/magick-wasm': magick,
+  ffmpeg: {
+    command: 'ffmpeg',
+    example: 'ffmpeg -i input.mp4 output.webm',
+    bootstrap: `ipk add @ffmpeg/core@${BUNDLED_FFMPEG_CORE_VERSION}`,
+  },
+  '@ffmpeg/ffmpeg': {
+    command: 'ffmpeg',
+    example: 'ffmpeg -i input.mp4 output.webm',
+    bootstrap: `ipk add @ffmpeg/core@${BUNDLED_FFMPEG_CORE_VERSION}`,
+  },
+  sqlite3: { command: 'sqlite3', example: 'sqlite3 database.db "SELECT 1"' },
+};
+
+export function lookupBuiltinShadow(requestedPackage: string): BuiltinShadow | undefined {
+  return BUILTIN_SHADOW_MAP[requestedPackage];
+}
+
+function quoteArg(arg: string): string {
+  if (/^[A-Za-z0-9_./:=@%+-]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+export function formatBuiltinShadowHint(
+  runnerName: string,
+  requestedPackage: string,
+  requestedArgs: readonly string[],
+  shadow: BuiltinShadow
+): string {
+  const invocation = requestedArgs.length
+    ? [shadow.command, ...requestedArgs].map(quoteArg).join(' ')
+    : shadow.example;
+  const lines = [
+    `${runnerName}: SLICC has a built-in \`${shadow.command}\` for npm package \`${requestedPackage}\`.`,
+    `  try: ${invocation}`,
+  ];
+  if (shadow.bootstrap) lines.push(`  first run: ${shadow.bootstrap}`);
+  lines.push(
+    `  install anyway: ${[runnerName, '--force', requestedPackage, ...requestedArgs].map(quoteArg).join(' ')}`
+  );
+  return `${lines.join('\n')}\n`;
+}

--- a/packages/webapp/src/shell/supplemental-commands/esbuild-wasm.ts
+++ b/packages/webapp/src/shell/supplemental-commands/esbuild-wasm.ts
@@ -127,13 +127,13 @@ async function loadEsbuild(
   // out to the network.
   if (!ipk) {
     throw new Error(
-      'esbuild-wasm is not available: install via `ipk add esbuild-wasm` or invoke through `ipx esbuild`'
+      `esbuild-wasm is not available: install via \`ipk add esbuild-wasm@${ESBUILD_VERSION}\``
     );
   }
   const bytes = await tryLoadEsbuildWasmFromNodeModules(ipk);
   if (!bytes) {
     throw new Error(
-      'esbuild-wasm is not installed in node_modules: run `ipk add esbuild-wasm` or invoke through `ipx esbuild`'
+      `esbuild-wasm is not installed in node_modules: run \`ipk add esbuild-wasm@${ESBUILD_VERSION}\``
     );
   }
   log(`esbuild.wasm loaded from ipk node_modules (${bytes.byteLength} bytes)`);

--- a/packages/webapp/src/shell/supplemental-commands/ipx-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/ipx-command.ts
@@ -25,6 +25,7 @@ import { joinPath, normalizePath, splitPath } from '../../fs/path-utils.js';
 import { installPackages } from '../ipk/installer.js';
 import { executeJsCode } from '../jsh-executor.js';
 import { stripShebang } from '../strip-shebang.js';
+import { formatBuiltinShadowHint, lookupBuiltinShadow } from './builtin-shadow-map.js';
 
 export interface IpxCommandDeps {
   fs: VirtualFS;
@@ -44,13 +45,14 @@ function usage(name: string): string {
   return `${name} - run an installed package's executable bin
 
 Usage:
-  ${name} <pkg-or-bin> [args...]
+  ${name} [--force] <pkg-or-bin> [args...]
 
 Resolves <pkg-or-bin> to a bin (nearest node_modules/.bin/<name>, else the
 package's package.json "bin" field) and runs it through the JS runtime,
 forwarding argv and stdin. Exit codes propagate.
 
 Options:
+  --force      Install a package even when a SLICC built-in shadows it
   -h, --help   Show this help message
 `;
 }
@@ -229,6 +231,43 @@ async function validateBinFile(
   return failure(name, `bin file '${binFilePath}' for '${binName}' does not exist`);
 }
 
+async function resolveMissingBin(
+  name: string,
+  binName: string,
+  binArgs: string[],
+  forceInstall: boolean,
+  ctx: CommandContext,
+  deps: IpxCommandDeps
+): Promise<{ resolved: ResolvedBin; installProgress: string } | { error: ExecResult }> {
+  if (await isPackageInstalled(deps.fs, ctx.cwd, binName)) {
+    return { error: failure(name, `package '${binName}' does not expose an executable bin`) };
+  }
+
+  const shadow = forceInstall ? undefined : lookupBuiltinShadow(binName);
+  if (shadow) {
+    return {
+      error: {
+        stdout: '',
+        stderr: formatBuiltinShadowHint(name, binName, binArgs, shadow),
+        exitCode: 1,
+      },
+    };
+  }
+
+  const installed = await autoInstall(name, binName, ctx, deps);
+  if ('error' in installed) return installed;
+  const resolved = await resolveBin(deps.fs, ctx.cwd, binName);
+  if (!resolved) {
+    return {
+      error: failure(
+        name,
+        `package '${binName}' was installed but does not expose an executable bin`
+      ),
+    };
+  }
+  return { resolved, installProgress: installed.progress };
+}
+
 export function createIpxCommand(name: string, deps: IpxCommandDeps): Command {
   return {
     name,
@@ -241,8 +280,13 @@ export function createIpxCommand(name: string, deps: IpxCommandDeps): Command {
         return { stdout: usage(name), stderr: '', exitCode: args.length === 0 ? 1 : 0 };
       }
 
-      const binName = args[0];
-      const binArgs = args.slice(1);
+      const forceInstall = args[0] === '--force';
+      const invocationArgs = forceInstall ? args.slice(1) : args;
+      if (invocationArgs.length === 0) {
+        return { stdout: usage(name), stderr: '', exitCode: 1 };
+      }
+      const binName = invocationArgs[0];
+      const binArgs = invocationArgs.slice(1);
 
       let resolved: ResolvedBin | null;
       try {
@@ -255,22 +299,10 @@ export function createIpxCommand(name: string, deps: IpxCommandDeps): Command {
       // reinstall); an absent one is installed (full transitive tree) first.
       let installProgress = '';
       if (!resolved) {
-        const alreadyInstalled = await isPackageInstalled(deps.fs, ctx.cwd, binName);
-        if (alreadyInstalled) {
-          return failure(name, `package '${binName}' does not expose an executable bin`);
-        }
-
-        const installed = await autoInstall(name, binName, ctx, deps);
-        if ('error' in installed) return installed.error;
-        installProgress = installed.progress;
-        resolved = await resolveBin(deps.fs, ctx.cwd, binName);
-
-        if (!resolved) {
-          return failure(
-            name,
-            `package '${binName}' was installed but does not expose an executable bin`
-          );
-        }
+        const prepared = await resolveMissingBin(name, binName, binArgs, forceInstall, ctx, deps);
+        if ('error' in prepared) return prepared.error;
+        resolved = prepared.resolved;
+        installProgress = prepared.installProgress;
       }
 
       const invalid = await validateBinFile(name, binName, resolved.binFilePath, deps.fs);

--- a/packages/webapp/tests/shell/bsh-watchdog.test.ts
+++ b/packages/webapp/tests/shell/bsh-watchdog.test.ts
@@ -5,6 +5,7 @@ import { FsWatcher } from '../../src/fs/index.js';
 import { VirtualFS } from '../../src/fs/virtual-fs.js';
 import { BshWatchdog } from '../../src/shell/bsh-watchdog.js';
 import { ScriptCatalog } from '../../src/shell/script-catalog.js';
+import { ESBUILD_VERSION } from '../../src/shell/supplemental-commands/esbuild-wasm.js';
 
 let dbCounter = 0;
 
@@ -613,8 +614,9 @@ describe('BshWatchdog', () => {
       expect(evaluateCalls).toHaveLength(1);
       const expression = String(evaluateCalls[0].params['expression']);
       // Wrapper carries the bundle hint and the unbundled-specifier guard.
+      expect(expression).toContain(`ipk add esbuild-wasm@${ESBUILD_VERSION}`);
       expect(expression).toContain('esbuild --bundle');
-      expect(expression).not.toContain('ipx esbuild --bundle');
+      expect(expression).not.toContain('ipx esbuild');
       expect(expression).toContain('unbundled require() specifiers');
       // No CDN URL or dynamic-import pre-fetch in the wrapper.
       expect(expression).not.toContain('esm.sh');
@@ -683,8 +685,9 @@ describe('BshWatchdog mirror of require-guards', () => {
   it('emits a clear bundle-first error when require() specifiers survive bundling', () => {
     // No CDN pre-fetch anymore — the .bsh runtime has no resolver, so the
     // wrapper must point the user at the bundle-first workflow.
+    expect(watchdogSource).toContain('ipk add esbuild-wasm@${ESBUILD_VERSION}');
     expect(watchdogSource).toContain('esbuild --bundle');
-    expect(watchdogSource).not.toContain('ipx esbuild --bundle');
+    expect(watchdogSource).not.toContain('ipx esbuild');
     expect(watchdogSource).toContain('unbundled require() specifiers');
     expect(watchdogSource).toContain('[bsh]');
   });

--- a/packages/webapp/tests/shell/bsh-watchdog.test.ts
+++ b/packages/webapp/tests/shell/bsh-watchdog.test.ts
@@ -614,6 +614,7 @@ describe('BshWatchdog', () => {
       const expression = String(evaluateCalls[0].params['expression']);
       // Wrapper carries the bundle hint and the unbundled-specifier guard.
       expect(expression).toContain('esbuild --bundle');
+      expect(expression).not.toContain('ipx esbuild --bundle');
       expect(expression).toContain('unbundled require() specifiers');
       // No CDN URL or dynamic-import pre-fetch in the wrapper.
       expect(expression).not.toContain('esm.sh');
@@ -683,6 +684,7 @@ describe('BshWatchdog mirror of require-guards', () => {
     // No CDN pre-fetch anymore — the .bsh runtime has no resolver, so the
     // wrapper must point the user at the bundle-first workflow.
     expect(watchdogSource).toContain('esbuild --bundle');
+    expect(watchdogSource).not.toContain('ipx esbuild --bundle');
     expect(watchdogSource).toContain('unbundled require() specifiers');
     expect(watchdogSource).toContain('[bsh]');
   });

--- a/packages/webapp/tests/shell/bsh-watchdog.test.ts
+++ b/packages/webapp/tests/shell/bsh-watchdog.test.ts
@@ -613,7 +613,7 @@ describe('BshWatchdog', () => {
       expect(evaluateCalls).toHaveLength(1);
       const expression = String(evaluateCalls[0].params['expression']);
       // Wrapper carries the bundle hint and the unbundled-specifier guard.
-      expect(expression).toContain('ipx esbuild --bundle');
+      expect(expression).toContain('esbuild --bundle');
       expect(expression).toContain('unbundled require() specifiers');
       // No CDN URL or dynamic-import pre-fetch in the wrapper.
       expect(expression).not.toContain('esm.sh');
@@ -682,7 +682,7 @@ describe('BshWatchdog mirror of require-guards', () => {
   it('emits a clear bundle-first error when require() specifiers survive bundling', () => {
     // No CDN pre-fetch anymore — the .bsh runtime has no resolver, so the
     // wrapper must point the user at the bundle-first workflow.
-    expect(watchdogSource).toContain('ipx esbuild --bundle');
+    expect(watchdogSource).toContain('esbuild --bundle');
     expect(watchdogSource).toContain('unbundled require() specifiers');
     expect(watchdogSource).toContain('[bsh]');
   });

--- a/packages/webapp/tests/shell/ipk/ipx-errors-and-usage.test.ts
+++ b/packages/webapp/tests/shell/ipk/ipx-errors-and-usage.test.ts
@@ -182,6 +182,15 @@ const sayPkg: SyntheticPackage = {
   },
 };
 
+const shadowedBiomePkg: SyntheticPackage = {
+  name: '@biomejs/biome',
+  version: '1.0.0',
+  files: {
+    'package.json': pkgJson({ name: '@biomejs/biome', bin: './cli.js' }),
+    'cli.js': 'console.log("NATIVE-BIOME:" + process.argv.slice(2).join("|"));\n',
+  },
+};
+
 describe('ipx error and usage handling', () => {
   beforeEach(() => {
     sharedRegistry.current = { packuments: {}, tarballs: {} };
@@ -193,7 +202,7 @@ describe('ipx error and usage handling', () => {
     const { shell, fs } = await newShell();
     const run = await shell.executeCommand('ipx');
     expect(run.stdout).toContain('Usage:');
-    expect(run.stdout).toContain('ipx <pkg-or-bin>');
+    expect(run.stdout).toContain('ipx [--force] <pkg-or-bin>');
     expect(run.exitCode).not.toBe(0);
     // A follow-up command still runs, proving the shell did not crash or hang.
     const after = await shell.executeCommand('echo still-here');
@@ -205,7 +214,39 @@ describe('ipx error and usage handling', () => {
     const { shell, fs } = await newShell();
     const run = await shell.executeCommand('ipx --help');
     expect(run.stdout).toContain('Usage:');
+    expect(run.stdout).toContain('--force');
     expect(run.exitCode).toBe(0);
+    await fs.dispose();
+  });
+
+  it('redirects a shadowed package before any registry fetch or install', async () => {
+    sharedRegistry.current = buildRegistry([shadowedBiomePkg]);
+    const { shell, fs } = await newShell();
+
+    const run = await shell.executeCommand('npx @biomejs/biome check foo.js');
+
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stdout).toBe('');
+    expect(run.stderr).toMatch(/^npx:/);
+    expect(run.stderr).toContain('try: biome check foo.js');
+    expect(fetchCounter.packument).toBe(0);
+    expect(fetchCounter.tarball).toBe(0);
+    expect(await fs.exists('/work/node_modules/@biomejs/biome')).toBe(false);
+    await fs.dispose();
+  });
+
+  it('passes a leading --force through the existing install-and-run path', async () => {
+    sharedRegistry.current = buildRegistry([shadowedBiomePkg]);
+    const { shell, fs } = await newShell();
+
+    const run = await shell.executeCommand('npx --force @biomejs/biome check foo.js');
+
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout.trim()).toBe('NATIVE-BIOME:check|foo.js');
+    expect(run.stderr).not.toContain('SLICC has a built-in');
+    expect(fetchCounter.packument).toBeGreaterThan(0);
+    expect(fetchCounter.tarball).toBeGreaterThan(0);
+    expect(await fs.exists('/work/node_modules/@biomejs/biome/package.json')).toBe(true);
     await fs.dispose();
   });
 

--- a/packages/webapp/tests/shell/supplemental-commands/builtin-shadow-map.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/builtin-shadow-map.test.ts
@@ -21,6 +21,11 @@ describe('built-in shadow map', () => {
     expect(lookupBuiltinShadow('some-unmapped-pkg')).toBeUndefined();
   });
 
+  it('ignores inherited keys while resolving own entries', () => {
+    expect(lookupBuiltinShadow('constructor')).toBeUndefined();
+    expect(lookupBuiltinShadow('biome')?.command).toBe('biome');
+  });
+
   it('keeps bootstrap versions tied to the command version constants', () => {
     expect(BUILTIN_SHADOW_MAP.biome.bootstrap).toBe(`ipk add ${INSTALL_PACKAGES}`);
     expect(BUILTIN_SHADOW_MAP.esbuild.bootstrap).toBe(`ipk add esbuild-wasm@${ESBUILD_VERSION}`);

--- a/packages/webapp/tests/shell/supplemental-commands/builtin-shadow-map.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/builtin-shadow-map.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { INSTALL_PACKAGES } from '../../../src/shell/supplemental-commands/biome-command.js';
+import {
+  BUILTIN_SHADOW_MAP,
+  formatBuiltinShadowHint,
+  lookupBuiltinShadow,
+} from '../../../src/shell/supplemental-commands/builtin-shadow-map.js';
+import { ESBUILD_VERSION } from '../../../src/shell/supplemental-commands/esbuild-wasm.js';
+import { BUNDLED_FFMPEG_CORE_VERSION } from '../../../src/shell/supplemental-commands/ffmpeg-wasm.js';
+import { BUNDLED_MAGICK_VERSION } from '../../../src/shell/supplemental-commands/magick-wasm.js';
+
+describe('built-in shadow map', () => {
+  it('looks up unscoped and scoped package names', () => {
+    expect(lookupBuiltinShadow('biome')?.command).toBe('biome');
+    expect(lookupBuiltinShadow('@biomejs/biome')?.command).toBe('biome');
+    expect(lookupBuiltinShadow('@playwright/test')?.command).toBe('playwright-cli');
+    expect(lookupBuiltinShadow('@imagemagick/magick-wasm')?.command).toBe('magick');
+  });
+
+  it('returns undefined for an unknown package', () => {
+    expect(lookupBuiltinShadow('some-unmapped-pkg')).toBeUndefined();
+  });
+
+  it('keeps bootstrap versions tied to the command version constants', () => {
+    expect(BUILTIN_SHADOW_MAP.biome.bootstrap).toBe(`ipk add ${INSTALL_PACKAGES}`);
+    expect(BUILTIN_SHADOW_MAP.esbuild.bootstrap).toBe(`ipk add esbuild-wasm@${ESBUILD_VERSION}`);
+    expect(BUILTIN_SHADOW_MAP.ffmpeg.bootstrap).toBe(
+      `ipk add @ffmpeg/core@${BUNDLED_FFMPEG_CORE_VERSION}`
+    );
+    expect(BUILTIN_SHADOW_MAP.imagemagick.bootstrap).toBe(
+      `ipk add @imagemagick/magick-wasm@${BUNDLED_MAGICK_VERSION}`
+    );
+  });
+});
+
+describe('formatBuiltinShadowHint', () => {
+  it('uses the runner name and repeats user arguments in the suggested invocation', () => {
+    const shadow = lookupBuiltinShadow('@biomejs/biome')!;
+    const hint = formatBuiltinShadowHint('npx', '@biomejs/biome', ['check', 'foo.js'], shadow);
+
+    expect(hint).toMatch(/^npx:/);
+    expect(hint).toContain('try: biome check foo.js');
+    expect(hint).toContain(`first run: ipk add ${INSTALL_PACKAGES}`);
+    expect(hint).toContain('npx --force @biomejs/biome check foo.js');
+  });
+
+  it('uses the entry example when no user arguments were supplied', () => {
+    const shadow = lookupBuiltinShadow('sqlite3')!;
+    const hint = formatBuiltinShadowHint('ipx', 'sqlite3', [], shadow);
+
+    expect(hint).toMatch(/^ipx:/);
+    expect(hint).toContain(`try: ${shadow.example}`);
+    expect(hint).not.toContain('first run:');
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/esbuild-wasm.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/esbuild-wasm.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ModuleReader } from '../../../src/shell/ipk/resolver.js';
+import {
+  ESBUILD_VERSION,
+  getEsbuild,
+  resetEsbuildForTests,
+} from '../../../src/shell/supplemental-commands/esbuild-wasm.js';
+
+const bootstrap = `ipk add esbuild-wasm@${ESBUILD_VERSION}`;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetEsbuildForTests();
+});
+
+describe('getEsbuild browser recovery guidance', () => {
+  it('uses the pinned bootstrap when no ipk context is available', async () => {
+    vi.stubGlobal('process', undefined);
+
+    const error = await getEsbuild().catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      `esbuild-wasm is not available: install via \`${bootstrap}\``
+    );
+    expect((error as Error).message).not.toContain('ipx esbuild');
+  });
+
+  it('uses the pinned bootstrap when esbuild-wasm is not installed', async () => {
+    vi.stubGlobal('process', undefined);
+    const reader: ModuleReader = {
+      exists: async () => false,
+      isDirectory: async () => false,
+      readFile: async () => {
+        throw new Error('ENOENT');
+      },
+    };
+
+    const error = await getEsbuild({
+      ipk: { reader, readBytes: async () => new Uint8Array(), fromDir: '/workspace' },
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      `esbuild-wasm is not installed in node_modules: run \`${bootstrap}\``
+    );
+    expect((error as Error).message).not.toContain('ipx esbuild');
+  });
+});


### PR DESCRIPTION
Closes #1691

## Summary

`npx` and `ipx` now redirect unresolved npm package requests to SLICC built-ins when one of 17 known package names shadows a supported built-in command. Mapped requests abort before installation with an actionable hint, while a leading `--force` retains the prior install-and-run behavior.

## Why

Issue #1691 describes how reflexively running `npx` for packages such as Biome can install native npm packages that cannot run in SLICC's worker sandbox. Users then get a dead-end runtime error and an unusable `node_modules`, despite SLICC already shipping a working built-in command.

## Approach / Implementation notes

- Added `packages/webapp/src/shell/supplemental-commands/builtin-shadow-map.ts`, the authoritative map of 17 npm package names to the built-ins `biome`, `esbuild`, `playwright-cli`, `puppeteer`, `tsc`, `convert`/`magick`, `ffmpeg`, and `sqlite3`. Bootstrap commands reuse the existing pinned version constants.
- Updated the `npx`/`ipx` auto-install path so an unresolved, not-yet-installed mapped package writes a stderr hint naming the built-in, shows an example invocation derived from the user's arguments, and includes the pinned `ipk add` bootstrap when needed.
- The mapped path exits non-zero before any network install and leaves nothing installed.
- A leading `--force` bypasses the redirect: `npx --force <package> ...` and `ipx --force <package> ...` preserve the previous install-and-run behavior.
- Unmapped packages, already-installed packages, and locally resolved bins retain their existing behavior.

## Cross-cutting impact

- **Floats exercised:** the shared webapp supplemental-command path is used by the CLI, Chrome extension leader, and Electron shell runtimes; no float-specific implementation was added.
- **Shell contexts:** behavior changes only in the shared `AlmostBashShell` `npx`/`ipx` command before auto-install.
- **Persisted state:** none. The redirect aborts before package installation or filesystem mutation.
- **Security / lifecycle:** no new external calls, permissions, listeners, timers, or dependencies.

## Test plan

- [x] `npm run verify` — all seven lint checks passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — 0 touched files remain on debt lists
- [x] `npm run typecheck`
- [x] Full test run — 12,351 tests passed; one transient existing Playwright iframe suite Chrome-launch failure passed on immediate isolated rerun
- [x] Targeted IPK and shadow-map tests — 446 passed
- [x] `npm run test:coverage`
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] New unit coverage in `packages/webapp/tests/shell/supplemental-commands/builtin-shadow-map.test.ts` verifies lookup, pinned bootstraps, and hint formatting
- [x] Shell regressions in `packages/webapp/tests/shell/ipk/ipx-errors-and-usage.test.ts` verify stderr hints, argument-derived invocation, non-zero/no-fetch/no-install behavior, usage, and `--force` passthrough
- [x] Manual smoke not required: no UI behavior changed

**Pre-existing failures:** none persistent. The one transient Chrome launch failure described above passed in isolation, and the subsequent full coverage run passed.

## Documentation

- [ ] `README.md` — not needed; this is detailed shell behavior rather than onboarding
- [x] Relevant `CLAUDE.md` — `packages/webapp/CLAUDE.md` names the source-of-truth map
- [x] `docs/` — `docs/shell-reference.md` documents the exact 17 names, hint behavior, bootstrap, and `--force`
- [ ] Agent-facing runtime skill — no existing package-execution skill applies

## Risk & rollback

Risk is limited to the unresolved-package auto-install branch of `npx`/`ipx`; installed, resolvable, unmapped, and forced requests are preserved by tests. Roll back by reverting this PR; there is no persisted-state migration or cleanup.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] The intentional shell-command behavior change is reflected in docs
- [x] No cross-float protocol contract changed
