### PR TITLE
docs(telemetry) + feat(cloudflare-worker): deploy-impact signals for the four undocumented apps, and a version marker on the worker health document

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,6 +547,24 @@ jobs:
           name: coverage-cloudflare-worker
           path: coverage/
           if-no-files-found: ignore
+      # Per-test timing data. Emitted by a second vitest invocation rather than
+      # by the gate step above because coverage-gate.mjs builds its own argv
+      # (floors from coverage-thresholds.json) and forwards nothing, and vitest
+      # reporters are a global option with no per-project override. The worker
+      # suite runs in ~3s, so the duplicate run is cheaper than plumbing a
+      # reporter through the shared gate. Runs on failure too — a timing report
+      # of the run that just broke is the useful one.
+      - name: Emit test timing report
+        if: always()
+        continue-on-error: true
+        run: npx vitest run --project cloudflare-worker --reporter=junit --outputFile.junit=test-results/cloudflare-worker-junit.xml
+      - name: Upload test timing report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-timing-cloudflare-worker
+          path: test-results/
+          if-no-files-found: ignore
 
       # #1330 retention: archive this build's content-hashed assets to the
       # STAGING R2 bucket BEFORE any deploy attempt so long-lived tabs can

--- a/docs/operational-telemetry.md
+++ b/docs/operational-telemetry.md
@@ -13,6 +13,10 @@ SLICC runs across three deployment modes (CLI, extension, Electron) and emits RU
 - Are voice input and skill installation gaining adoption?
 - What are the Core Web Vitals for the UI? (CLI/Electron only — the extension doesn't get CWV.)
 
+RUM covers only the applications that load the webapp. For the tray hub worker,
+swift-server, the iOS follower, and the Go CLI — none of which emit beacons — see
+"Deploy-Impact Signals by Application" at the end of this document.
+
 ### Why this approach
 
 - **Lightweight**: sampling-based, zero performance impact on unsampled pageviews.
@@ -237,3 +241,187 @@ Once checkpoints are flowing in production, verify in the RUM dashboard (`rum.hl
 - Custom checkpoint names appear in the breakdown.
 - Source/target fields contain only expected sanitized values.
 - No unexpected PII appears in any field.
+
+## Deploy-Impact Signals by Application
+
+Everything above covers the three floats that load `packages/webapp/src/ui/telemetry.ts`.
+The repo ships eight applications; five of them never load it, so "check the RUM
+dashboard" is the wrong answer for those. This section is the post-ship lookup table for
+the question that actually gets asked: **I just shipped — where do I look to see if it
+broke?**
+
+| Application         | Primary deploy-impact signal                                                             | Ours or Apple/Cloudflare-hosted | Latency to signal   |
+| ------------------- | ---------------------------------------------------------------------------------------- | ------------------------------- | ------------------- |
+| `webapp`            | RUM (`RUM_GENERATION=slicc-cli` / `slicc-electron`), see "Dashboard verification"        | ours (Helix RUM)                | minutes (sampled)   |
+| `node-server`       | RUM (CLI generation) + `GET /api/status` on the local port                               | ours                            | immediate / minutes |
+| `chrome-extension`  | RUM (`RUM_GENERATION=slicc-extension`), no enhancer checkpoints                          | ours (Helix RUM)                | minutes (sampled)   |
+| `swift-launcher`    | RUM via `@slicc/swift-optel` (`packages/swift-optel/`)                                   | ours (Helix RUM)                | minutes (sampled)   |
+| `cloudflare-worker` | `GET /status`, Cloudflare Workers metrics, `cloudflare-spend` issue tripwire             | Cloudflare + ours               | immediate / 1 day   |
+| `swift-server`      | `GET /api/status` + `~/.slicc/logs/slicc-<day>.log`                                      | local only, never leaves host   | immediate           |
+| `ios-app`           | App Store Connect TestFlight processing state, then TestFlight Crashes & Feedback        | Apple-hosted                    | minutes / days      |
+| `slicc-cli`         | **No telemetry.** Nearest: GitHub Release download counts + worker install-route traffic | GitHub + Cloudflare             | days                |
+
+The four rows below the fold are the ones with no dashboard pointer anywhere else in the
+docs. Each gets its own subsection. Where an application genuinely has no signal, that is
+stated rather than papered over.
+
+### `cloudflare-worker` (tray hub)
+
+**Liveness, first thing to curl.** `GET https://www.sliccy.ai/status` is a public,
+unauthenticated health document — `{ status, service, timestamp, version }`, served by
+`handleStaticRoutes` in `packages/cloudflare-worker/src/index.ts` with
+`Cache-Control: no-store`. It is advertised by the RFC 8631 `status` rel that
+`packages/cloudflare-worker/src/links.ts` puts on every response, and anchored in
+`/.well-known/api-catalog` (`packages/cloudflare-worker/src/api-catalog.ts`), so a
+consumer walking the rel set can probe liveness without hard-coding the path. Semantics
+deliberately mirror node-server's `GET /api/status`
+(`packages/node-server/src/index.ts`, advertised via
+`packages/node-server/src/links-middleware.ts`) and swift-server's
+`GET /api/status` (`packages/swift-server/Sources/Server/APIRoutes.swift`) — same
+`{ status, service, timestamp }` core, different `service` identifier per runtime.
+
+`version` is the Cloudflare Worker **version ID** from the `version_metadata` binding
+declared in `packages/cloudflare-worker/wrangler.jsonc`. It is the only field that answers
+"is the thing I just deployed the thing serving traffic?" — a green deploy log plus a
+stale `version` means the deploy did not actually roll. Two non-production caveats:
+`wrangler dev` does bind `version_metadata`, but hands out a **locally generated** UUID
+that changes every dev session, so a local `version` value carries no information; and in
+unit tests the binding is unbound, in which case the field reads `unknown`. Never treat
+`unknown` as a failure signal. Nothing else is exposed: no env vars, no binding names, no
+account identifiers. Keep it that way — this endpoint is reachable by anyone.
+
+**Request/error/CPU metrics.** Cloudflare dashboard → Workers & Pages → `slicc-tray-hub`
+→ Metrics. Requests, error rate, CPU time, and Durable Object duration all live there, and
+the same numbers are queryable from the Cloudflare GraphQL Analytics API. This is the only
+place a worker 500 becomes visible — the worker emits no RUM.
+
+**The regression alarm is the spend tripwire.**
+`.github/workflows/cloudflare-spend-monitor.yml` runs daily at 06:30 UTC (after the UTC
+day closes), queries the GraphQL Analytics API for Durable Object duration/requests and
+Workers requests, converts them to an estimated USD/day, and opens or comments on a
+`cloudflare-spend`-labelled GitHub issue once the estimate passes the `$3/day` default
+(override via `vars.CLOUDFLARE_SPEND_THRESHOLD_USD`); it auto-closes the issue when spend
+falls back under. The estimator is unit-tested in
+`packages/dev-tools/cloudflare-spend-monitor/lib.test.mjs`.
+
+This is worth understanding as an availability signal and not just a cost one: the
+worker's expensive failure modes are runaway loops — a leader that reconnects forever, a
+follower that polls without backoff, a preview bridge that never closes. Those show up as
+a DO-duration spike long before anyone notices a functional regression. The tripwire is,
+in practice, the worker's only automated post-deploy alarm.
+
+**Staging goes first.** The `cloudflare-worker` job in `.github/workflows/ci.yml` deploys
+`slicc-tray-hub-staging` on every non-fork PR and on pushes to main, so a bad change is
+observable on the staging origin before production.
+`packages/cloudflare-worker/tests/deployed.test.ts` is the live-endpoint suite to point at
+it (`WORKER_BASE_URL=https://… npm test -- tests/deployed.test.ts` from
+`packages/cloudflare-worker/`). Production deploys run through
+`.github/workflows/worker.yml`; `.github/workflows/worker-staging.yml` is the manual
+staging path. Full runbook — retry logic, routes-only failure classification, R2 archive
+mechanics, ghost-leader analysis — is in
+[`.agents/skills/deploying-tray-worker/SKILL.md`](../.agents/skills/deploying-tray-worker/SKILL.md)
+(`docs/tray-worker-operations.md` is a stub that redirects there).
+
+**Known gap: no retained logs.** `packages/cloudflare-worker/wrangler.jsonc` declares no
+`observability` block and no tail worker or Logpush job, so there is no committed log
+retention for either environment. Live debugging means `npx wrangler tail` — real time
+only, nothing kept, and useless for a failure that already happened. Closing this is a
+one-line config change (`"observability": { "enabled": true }` per environment, plus the
+retention/sampling settings) and it is the highest-value observability improvement
+available to the worker today.
+
+### `swift-server`
+
+**Liveness.** `GET /api/status` on the server's local port returns
+`{ status: "ok", service: "slicc-server", timestamp }` with `Cache-Control: no-store`
+(`packages/swift-server/Sources/Server/APIRoutes.swift`). The `service` string doubles as
+the float fingerprint: the UI floatbar renders "sliccstart" when `slicc-server` answers
+and "npx" when node-server's `slicc-node-server` answers. So a wrong floatbar label after
+a launcher change is a routing bug, and this endpoint is how you tell which binary is
+actually on the port.
+
+**Logs, local only.** `FileLogger`
+(`packages/swift-server/Sources/Utilities/FileLogger.swift`, wired up in
+`packages/swift-server/Sources/CLI/ServerCommand.swift`) writes one file per day to
+`~/.slicc/logs/slicc-<day>.log`, created mode `0600`, with files older than seven days
+pruned by `cleanupOldLogs` on rotation. HTTP request lines come from
+`packages/swift-server/Sources/Server/RequestLogger.swift`; repeated identical lines are
+collapsed by `packages/swift-server/Sources/Utilities/LogDedup.swift`.
+
+**Known gap: nothing is aggregated.** The log never leaves the user's machine, there is no
+crash reporter, and swift-server emits no RUM of its own (the RUM signal for the native
+stack comes from the launcher via `@slicc/swift-optel`, not from the server process). After
+shipping a swift-server change, the realistic loop is: reproduce locally and read
+`~/.slicc/logs/`, or wait for a user to paste a log. Treat "did my swift-server change
+break someone" as unanswerable from telemetry.
+
+### `ios-app`
+
+`SliccFollower` is distributed through TestFlight, not the App Store, and the post-ship
+signals are all Apple-hosted.
+
+**First gate — did Apple accept the build.**
+`packages/ios-app/scripts/package-and-upload-testflight.sh` builds and uploads (secrets
+provisioned by `packages/ios-app/scripts/setup-testflight-secrets.sh`), and
+`packages/ios-app/scripts/check-testflight-status.sh` polls App Store Connect with the
+local API key and prints the build's `processingState`: `PROCESSING` (Apple still scanning
+and extracting symbols), `VALID` (ready for testers), `INVALID` (bundle rejected — details
+arrive by email only), `FAILED`. Run it after every upload; an `INVALID` build never
+reaches a tester, and nothing else in the repo will tell you.
+
+**After distribution.** App Store Connect → TestFlight → Crashes and Feedback carries
+tester-submitted screenshots and crash logs; Xcode → Window → Organizer → Crashes carries
+symbolicated reports for the same builds. Both are read manually in Apple's UIs — no
+script in this repo queries either.
+
+**Known gap: no in-app telemetry.** The iOS follower emits no RUM, no analytics, and
+integrates no crash-reporting SDK. Apple's crash aggregation only sees crashes, and only
+from testers who opted into sharing. A follower that connects but silently fails to render
+produces no signal at all; the only channel back to this repo is a human filing an issue.
+Adding a crash SDK or wiring the follower into the RUM beacon would be the fix — neither
+is committed to.
+
+### `slicc-cli`
+
+**There is no telemetry, by construction.** The Go follower CLI emits no beacons, no
+analytics, and no crash reports. That is the honest answer, and it should stay the answer
+unless someone deliberately decides otherwise — a headless CLI that phones home is a
+different product.
+
+What that leaves, in descending order of usefulness:
+
+1. **GitHub Release asset download counts** for `slicc-<os>-<arch>[.exe]`. The only
+   adoption number available. Note that CLI releases are **sparse** — binaries attach only
+   to releases where `packages/slicc-cli` actually changed — so compare against the release
+   that carries assets, not `releases/latest`.
+2. **Worker traffic on the install and download routes.** `GET /install-cli`,
+   `GET /install-cli.ps1`, and `GET /download/slicc-cli/:target`
+   (`packages/cloudflare-worker/src/install-cli.ts`) all run through the tray hub, so their
+   request and status-code breakdown is visible in the worker's Cloudflare analytics. A
+   release that shipped a broken or missing asset shows up as 4xx/5xx on
+   `/download/slicc-cli/*` — this is the closest thing to a release-health check the CLI
+   has, and it costs nothing because the traffic already lands on infrastructure we
+   observe.
+3. **Nothing from self-update failures.** `packages/slicc-cli/internal/update/` runs the
+   staged binary's `--version` as a sanity gate before the atomic rename, so a corrupt
+   download fails closed and prints on the user's machine. Correct behaviour, zero
+   visibility to us. Same for the once-a-day update notice cached at
+   `<user-cache-dir>/slicc/update-check.json` and suppressed by `SLICC_NO_UPDATE_CHECK=1`.
+4. **Issue reports.** The actual feedback channel.
+
+If CLI release health ever needs to be monitored for real, the cheapest closer is an alert
+on the worker's `/download/slicc-cli/*` error rate — it needs no change to the binary and
+no new telemetry surface. Everything else requires deciding that the CLI may talk to us.
+
+### Summary of honest gaps
+
+| Application         | Gap                                                                                     |
+| ------------------- | --------------------------------------------------------------------------------------- |
+| `cloudflare-worker` | No retained logs (`observability` unset in `wrangler.jsonc`); no per-route error alarm  |
+| `swift-server`      | Logs are local-only; no crash reporter; no remote signal of any kind                    |
+| `ios-app`           | No in-app telemetry or crash SDK; only Apple-hosted crash reports from opted-in testers |
+| `slicc-cli`         | No telemetry at all; release health is inferred from worker download-route traffic      |
+
+Do not add a dashboard link to this table that does not exist. An accurate "no signal
+today, nearest proxy is X" is more useful than a plausible-looking URL that nobody can
+open.

--- a/docs/operational-telemetry.md
+++ b/docs/operational-telemetry.md
@@ -310,9 +310,17 @@ follower that polls without backoff, a preview bridge that never closes. Those s
 a DO-duration spike long before anyone notices a functional regression. The tripwire is,
 in practice, the worker's only automated post-deploy alarm.
 
-**Staging goes first.** The `cloudflare-worker` job in `.github/workflows/ci.yml` deploys
-`slicc-tray-hub-staging` on every non-fork PR and on pushes to main, so a bad change is
-observable on the staging origin before production.
+**Staging goes first — when the job runs.** The `cloudflare-worker` job in
+`.github/workflows/ci.yml` deploys `slicc-tray-hub-staging`, and when it does a bad change
+is observable on the staging origin before production. Both halves of "when" matter. The
+job is behind a `dorny/paths-filter` gate — one of `cloud-core`, `cloudflare-worker`,
+`webapp`, `vfs-root`, `assets`, or `root-config` must have changed — so a PR touching
+anything else never deploys staging at all. And the deploy steps themselves are guarded by
+`(pull_request && head.repo.fork == false) || push`: there is no push-to-main trigger
+(`on.push` lists a single automation branch, and main lands via `merge_group`, which that
+guard excludes), so in practice staging deploys come from non-fork PRs only. The deploy
+steps are `continue-on-error` with retries, so a staging deploy that failed outright still
+leaves the job green — read the log, not the check mark.
 `packages/cloudflare-worker/tests/deployed.test.ts` is the live-endpoint suite to point at
 it (`WORKER_BASE_URL=https://… npm test -- tests/deployed.test.ts` from
 `packages/cloudflare-worker/`). Production deploys run through

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -58,7 +58,7 @@ cloud-core.
 | `GET /download/slicc-cli/:target`     | 302 to the newest release asset for a CLI target (`darwin-arm64`, …); scans past binary-less releases; errors are real HTTP errors (no SPA fallback)      |
 | `GET /.well-known/api-catalog`        | RFC 9264 linkset for all public routes                                                                                                                    |
 | `GET /llms.txt`                       | LLM markdown digest                                                                                                                                       |
-| `GET /status`                         | Health document (`{ status, service, timestamp }`)                                                                                                        |
+| `GET\|HEAD /status`                   | Public health document (`{ status, service, timestamp, version }`); no auth, `Cache-Control: no-store`                                                    |
 | `GET /rel/:name`                      | Dereferenceable docs for SLICC custom rel URIs                                                                                                            |
 | `GET\|POST /join/:token`              | Follower join and bootstrap polling (HTTP poll/answer/ice-candidate/retry actions)                                                                        |
 | `GET\|POST /controller/:token`        | Leader attach and WS upgrade                                                                                                                              |
@@ -174,6 +174,14 @@ the local `serve --bridge` test setup.
 ## Operational Notes
 
 - Treat the worker as coordination infrastructure, not canonical session storage.
+- `GET /status` is the post-deploy liveness probe. Its `version` field comes from the
+  `version_metadata` binding (`CF_VERSION_METADATA` in `wrangler.jsonc`, declared for both
+  the default and `staging` envs). `wrangler dev` binds it to a per-session local UUID; in
+  tests the binding is unbound and the field reads `unknown`. It is unauthenticated — keep
+  the body to
+  `{ status, service, timestamp, version }` and never add config or binding names.
+  Deploy-impact signals for the worker are catalogued in
+  [`docs/operational-telemetry.md`](../../docs/operational-telemetry.md).
 - The `/handoff` page is stateless; query parameters are translated into a single RFC
   8288 `Link` response header.
 - Every worker response is wrapped by `applySliccLinks` (see `src/links.ts`) — standard

--- a/packages/cloudflare-worker/src/api-catalog.ts
+++ b/packages/cloudflare-worker/src/api-catalog.ts
@@ -31,7 +31,7 @@ const ENTRIES: CatalogEntry[] = [
     anchor: '/status',
     methods: ['GET', 'HEAD'],
     description:
-      'Public health document (RFC 8631 status rel). Returns JSON `{ status, service, timestamp }`.',
+      'Public health document (RFC 8631 status rel). Returns JSON `{ status, service, timestamp, version }`.',
   },
   {
     anchor: '/join/:token',

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -74,6 +74,24 @@ export interface WorkerEnv {
    * third-party pages and emits `frame-ancestors *` (the CSP wildcard).
    */
   ALLOWED_CHERRY_HOST_ORIGINS?: string;
+  /**
+   * Cloudflare `version_metadata` binding. Unbound in `wrangler dev` and in
+   * unit tests, so every read must tolerate `undefined`.
+   */
+  CF_VERSION_METADATA?: { id?: string };
+}
+
+const UNKNOWN_WORKER_VERSION = 'unknown';
+
+/**
+ * Deployed Worker version ID for the public health document — the field that
+ * distinguishes "deploy reported success" from "the new build is serving
+ * traffic". Nothing else from the binding is exposed: `/status` is
+ * unauthenticated, so it carries an opaque version ID and no config.
+ */
+export function resolveWorkerVersion(env: Pick<WorkerEnv, 'CF_VERSION_METADATA'>): string {
+  const id = env.CF_VERSION_METADATA?.id;
+  return typeof id === 'string' && id.length > 0 ? id : UNKNOWN_WORKER_VERSION;
 }
 
 /**
@@ -789,6 +807,7 @@ async function tryHandleInfoRoutes(
         status: 'ok',
         service: 'slicc-tray-hub',
         timestamp: new Date().toISOString(),
+        version: resolveWorkerVersion(env),
       },
       200,
       { 'Cache-Control': 'no-store' }

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -1489,6 +1489,46 @@ describe('tray worker skeleton', () => {
     expect(Number.isNaN(Date.parse(body.timestamp))).toBe(false);
   });
 
+  it('reports the deployed worker version from the version_metadata binding', async () => {
+    const { env } = createTestHarness();
+    const response = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/status'),
+      Object.assign(env, { CF_VERSION_METADATA: { id: 'b8f1c7e2-0000-4a2b-9c3d-000000000001' } })
+    );
+    const body = (await response.json()) as { version: string };
+    expect(body.version).toBe('b8f1c7e2-0000-4a2b-9c3d-000000000001');
+  });
+
+  it('falls back to an unknown version when the binding is absent or empty', async () => {
+    const { env } = createTestHarness();
+    const response = await handleWorkerRequest(new Request('https://www.sliccy.ai/status'), env);
+    expect(((await response.json()) as { version: string }).version).toBe('unknown');
+
+    const { env: emptyEnv } = createTestHarness();
+    const emptyResponse = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/status'),
+      Object.assign(emptyEnv, { CF_VERSION_METADATA: { id: '' } })
+    );
+    expect(((await emptyResponse.json()) as { version: string }).version).toBe('unknown');
+  });
+
+  it('leaks no configuration beyond the documented health fields', async () => {
+    const { env } = createTestHarness();
+    const response = await handleWorkerRequest(new Request('https://www.sliccy.ai/status'), env);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(Object.keys(body).sort()).toEqual(['service', 'status', 'timestamp', 'version']);
+  });
+
+  it('serves GET /status without any authorization header', async () => {
+    const { env } = createTestHarness();
+    const response = await handleWorkerRequest(
+      new Request('https://www.sliccy.ai/status', { headers: { Cookie: '' } }),
+      env
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('WWW-Authenticate')).toBeNull();
+  });
+
   it('responds to HEAD /status with the same headers and no body', async () => {
     const { env } = createTestHarness();
     const response = await handleWorkerRequest(

--- a/packages/cloudflare-worker/wrangler.jsonc
+++ b/packages/cloudflare-worker/wrangler.jsonc
@@ -12,6 +12,9 @@
     "not_found_handling": "single-page-application"
   },
   "r2_buckets": [{ "binding": "ASSET_ARCHIVE", "bucket_name": "slicc-asset-archive" }],
+  // Surfaces the deployed Worker version ID on `GET /status` so a post-deploy
+  // curl can prove which build is serving traffic. Absent in `wrangler dev`.
+  "version_metadata": { "binding": "CF_VERSION_METADATA" },
   "routes": [
     { "pattern": "www.sliccy.ai/*", "zone_name": "sliccy.ai" },
     { "pattern": "sliccy.ai/*", "zone_name": "sliccy.ai" }
@@ -74,6 +77,7 @@
         "not_found_handling": "single-page-application"
       },
       "r2_buckets": [{ "binding": "ASSET_ARCHIVE", "bucket_name": "slicc-asset-archive-staging" }],
+      "version_metadata": { "binding": "CF_VERSION_METADATA" },
       "routes": [],
       "vars": {
         "CLOUDFLARE_TURN_KEY_ID": "6c2201a0453bd6695ecb24a00b2b6ed1",


### PR DESCRIPTION
## Summary

Closes two observability gaps in the monorepo:

1. **Docs** — `docs/operational-telemetry.md` gains a "Deploy-Impact Signals by Application" section: a post-ship lookup table for all eight applications, plus a detailed subsection for the four that had no dashboard pointer anywhere (`cloudflare-worker`, `swift-server`, `ios-app`, `slicc-cli`).
2. **Worker health** — `GET /status` (the worker's existing unauthenticated health document) now reports the deployed Worker version ID, so a single curl proves whether the build you just deployed is the one serving traffic.
3. **CI** — the `cloudflare-worker` job uploads a per-test timing report as an artifact.

## Why

An agent-readiness audit scored `deployment_observability` at 4/8 apps. The RUM docs answer "where do I look after shipping" for `webapp`, `node-server`, `chrome-extension`, and `swift-launcher`, and said nothing for the other four. Four of eight applications had no answer at all.

The audit also flagged `health_checks` at 2/8. That count was **wrong for the worker**: `GET /status` already exists in `packages/cloudflare-worker/src/index.ts`, returns `{ status, service, timestamp }`, is advertised via the RFC 8631 `status` rel on every response, is anchored in `/.well-known/api-catalog`, and is covered by tests in `tests/index.test.ts` and the routes list in `tests/deployed.test.ts`. The audit grep looked for `/health`, `/healthz`, `/ready`, `/live`, and `/api/status` — not `/status`. So the worker's health count is 3/8, not 2/8, and no new route was needed.

What the endpoint could **not** do was answer the actual post-deploy question: which build is live. A green `wrangler deploy` log plus a stale version is a real failure mode (routes-only failures, pending-version state — see the `deploying-tray-worker` skill). Hence the `version` field rather than a duplicate route.

## Approach / Implementation notes

**Path: kept `/status`, did not add `/health`.** The route already exists and is already discoverable through the `status` rel and the API catalog, so a second path would be a synonym that has to be kept in sync across the routes-mirror rule (`src/index.ts` routes array + `tests/index.test.ts` + `tests/deployed.test.ts`), the api-catalog anchors, and the `Link` rel set — for zero new capability. Consistency with node-server / swift-server (`/api/status`) is preserved where it matters: the response body core is identical (`{ status, service, timestamp }`) with a per-runtime `service` identifier (`slicc-tray-hub` / `slicc-node-server` / `slicc-server`). The worker's path differs because `/api/*` on the worker is the cloud-cones namespace (`/api/cloud/*`, `/api/tray/*`) and `/status` is what the rel already points at.

**Version source: the `version_metadata` binding.** There is no `SLICC_RELEASED_AT`-style version injection anywhere in the worker build (`npm run build -w @slicc/cloudflare-worker` is `wrangler deploy --dry-run`, with no `define`), and adding git-sha plumbing would have meant touching the deploy workflows. Cloudflare's native `version_metadata` binding gives the deployed version ID with a two-line config change and no CI involvement. Declared for both the default and `staging` envs in `wrangler.jsonc`; `resolveWorkerVersion` returns `'unknown'` when unbound.

**Security.** `/status` is public and unauthenticated on a production Worker. The version ID is an opaque UUID — no env vars, binding names, or account identifiers are exposed. A test asserts the response body keys are exactly `['service', 'status', 'timestamp', 'version']`, so widening the shape by accident fails CI.

**Timing artifact.** Emitted by a second `vitest` invocation rather than by the coverage-gate step: `packages/dev-tools/tools/coverage-gate.mjs` builds its own argv from `coverage-thresholds.json` and forwards nothing, and vitest reporters are a global option with no per-project override. The worker suite runs in ~3s, so the duplicate run is cheaper than plumbing a reporter through the shared gate. `if: always()` + `continue-on-error: true` so the report is emitted for the run that just broke, which is the useful case. Output lands in `test-results/`, already gitignored.

**Docs: only real signals.** Every pointer is grounded in something that exists in the repo or in a vendor console we actually use. Where an app has no signal, the doc says so and names the nearest proxy — there is an explicit "Summary of honest gaps" table and a closing instruction not to add plausible-looking URLs.

| App | Deploy-impact signal documented |
| --- | --- |
| `cloudflare-worker` | `GET /status` (now with `version`), Cloudflare Workers metrics / GraphQL Analytics API, and the `cloudflare-spend` daily issue tripwire (`.github/workflows/cloudflare-spend-monitor.yml`) — explained as an availability signal, since the worker's expensive failure modes are runaway reconnect/poll loops. Plus the staging-first deploy in CI. **Gap named:** no `observability` block in `wrangler.jsonc`, so no retained logs — `wrangler tail` only. |
| `swift-server` | `GET /api/status` (the `service` field doubles as the float fingerprint) and `~/.slicc/logs/slicc-<day>.log` from `FileLogger.swift`. **Gap named:** local-only, never aggregated, no crash reporter. |
| `ios-app` | `packages/ios-app/scripts/check-testflight-status.sh` for App Store Connect `processingState` (`INVALID` = never reached a tester), then TestFlight Crashes & Feedback and Xcode Organizer. **Gap named:** no in-app telemetry or crash SDK. |
| `slicc-cli` | **No telemetry at all** — stated plainly. Nearest signals: GitHub Release asset download counts (releases are sparse), and worker traffic/status codes on `/install-cli`, `/install-cli.ps1`, `/download/slicc-cli/:target`, which is the cheapest real release-health check available. |

## Cross-cutting impact

- **Floats exercised**: worker only. No webapp, extension, Electron, or native code paths touched.
- **Routes-mirror rule**: no new route, so the `src/index.ts` routes array and both routes-list assertions are unchanged.
- **`/status` consumers**: the response gains a key; nothing is removed or renamed. `tests/deployed.test.ts` asserts the route is listed but not the body shape, so live staging/production assertions are unaffected. A consumer parsing `{ status, service, timestamp }` keeps working.
- **`wrangler.jsonc`**: adds one binding to the default and `staging` envs. Validated by `wrangler deploy --dry-run`, which reports `env.CF_VERSION_METADATA → Worker Version Metadata`.
- **Security**: reviewed above — opaque ID only, body-shape test guards against drift.
- **Bundle size**: `Total Upload: 1312.14 KiB / gzip: 277.22 KiB` — unchanged in practice (one small function).

## Test plan

- [x] `npm run lint` — green (includes `prettier --check`, `lint:docs` → `check-doc-refs.mjs` dead-reference gate + `check-doc-sizes.mjs`; every repo path cited in the new docs exists)
- [x] `npm run typecheck` — green
- [x] `npm run test` — 12,352 passing / 43 skipped. One unrelated failure, see below.
- [x] `npm run build` — green
- [x] `npm run build -w @slicc/cloudflare-worker` — green; the `wrangler deploy --dry-run` bundle + 25 MiB asset-size gate, and the step that confirms the new binding resolves
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — `OK (8 changed file(s), 0 still on any debt list)`
- [x] `npm run deadcode` — green
- [x] **New behavior is covered by unit tests** in `packages/cloudflare-worker/tests/index.test.ts`: version reported from the binding, `'unknown'` fallback for both absent and empty-string ids, exact response-key set (leak guard), 200 with no auth header, and the pre-existing content-type / `Cache-Control` / `status` rel assertions.
- [x] `npm run test:coverage:cloudflare-worker` — passes the repo's strictest floors, and every metric moved **up**:

  | Metric | Before | After | Floor |
  | --- | --- | --- | --- |
  | Statements | 86.59% | 86.61% | 85 |
  | Branches | 76.07% | 76.13% | 75 |
  | Functions | 93.30% | 93.33% | 92 |
  | Lines | 87.33% | 87.35% | 86 |

- [x] **Manual smoke (worker)**: `npx wrangler dev --config packages/cloudflare-worker/wrangler.jsonc --port 8799`, then `curl -i http://127.0.0.1:8799/status`:

  ```
  HTTP/1.1 200 OK
  Content-Length: 147
  Content-Type: application/json; charset=utf-8
  Cache-Control: no-store
  Link: <http://127.0.0.1:8799/.well-known/api-catalog>; rel="api-catalog", …,
        <http://127.0.0.1:8799/status>; rel="status"; type="application/json", …
  X-Robots-Tag: noindex

  {
    "status": "ok",
    "service": "slicc-tray-hub",
    "timestamp": "2026-07-27T13:05:57.375Z",
    "version": "5b774762-eb67-47cc-8974-1b44fafe79a9"
  }
  ```

  Worth knowing: `wrangler dev` **does** bind `version_metadata` and hands out a locally generated UUID that changes every dev session, so a local `version` value carries no information. The docs and `packages/cloudflare-worker/CLAUDE.md` say so explicitly (an earlier draft claimed the binding was absent locally; the live curl above disproved it).

- [x] Timing artifact verified locally: `npx vitest run --project cloudflare-worker --reporter=junit --outputFile.junit=test-results/cloudflare-worker-junit.xml` → 100 KB JUnit XML with per-`testcase` `time` attributes, 417 tests.
- [ ] UI change — N/A, no UI touched.

**Pre-existing failure** (unrelated to this PR): `packages/chrome-extension/tests/service-worker-mount-sign-and-forward-port.test.ts` > "forwards a configured S3 request via fetch for a pinned sender" failed once in the full-suite run with `TypeError: Cannot read properties of undefined (reading 'response')`. Passes in isolation (`npx vitest run --project chrome-agnostic … ` → 4/4). Flaky under full-suite parallelism; `chrome-extension` is untouched by this PR.

## Documentation

- [x] Relevant `CLAUDE.md` — `packages/cloudflare-worker/CLAUDE.md`: route-table row updated to `GET|HEAD /status` with the new body shape, plus an operational note on the binding, the `unknown` fallback, and the don't-widen-the-body rule.
- [x] `docs/` — `docs/operational-telemetry.md`: the new "Deploy-Impact Signals by Application" section, a cross-reference from the Overview, and the honest-gaps table.
- [ ] `README.md` — no user-facing behavior change.
- [ ] `packages/vfs-root/**` — no agent-facing shell command changed.

## Risk & rollback

- **Blast radius**: worker only. Worst case is a wrong or missing `version` field on a health document — no functional path depends on it.
- **The one thing CI cannot fully prove**: `wrangler deploy --dry-run` validates that the `version_metadata` binding resolves, and `wrangler dev` serves it, but only a real deploy exercises the production version ID. The staging deploy in the `cloudflare-worker` job covers this on this PR — check `https://slicc-tray-hub-staging.minivelos.workers.dev/status` and confirm `version` is a stable UUID that changes when (and only when) a new version is deployed.
- **Rollback**: revert cleanly. No persisted state, no migration, no feature flag.
- **Note for the reviewer**: the hub and preview worker must deploy as a pair (see `packages/cloudflare-worker/CLAUDE.md` → "CI and Deployment"). This change touches `wrangler.jsonc` only, not `wrangler-preview.jsonc` — the preview worker has no `/status` route and needs no version binding.

## Checklist

- [x] Commits are focused and package-local where possible (three commits: docs / worker / ci)
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API changes are intentional and reflected in docs (`/status` body, api-catalog description, route table)
- [x] Contract used by other floats: `/status` is additive-only; no follower, leader, or offscreen path reads it

## Follow-ups deliberately not done here

- **Enable Workers Logs** (`"observability": { "enabled": true }` per env in `wrangler.jsonc`). Named as the highest-value remaining worker observability gap in the new docs; left out to keep this PR's blast radius to a health-document field, since log retention has cost and sampling implications worth their own review.
- **Alert on `/download/slicc-cli/*` error rate** — documented as the cheapest way to get real `slicc-cli` release-health signal without adding telemetry to the binary.
- **Root `package.json` untouched** by design (parallel work in flight); no new root script was needed.
