### PR TITLE
refactor(webapp): consolidate duplicated PKCE helpers into shared module

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -305,7 +305,6 @@
         "packages/webapp/src/kernel/realm/ws-router-page.ts",
         "packages/webapp/src/kernel/remote-sprinkle-vfs.ts",
         "packages/webapp/src/net/link-header.ts",
-        "packages/webapp/src/shell/mcp/oauth.ts",
         "packages/webapp/src/shell/supplemental-commands/afplay-command.ts",
         "packages/webapp/src/shell/supplemental-commands/dig-command.ts",
         "packages/webapp/src/shell/supplemental-commands/fswatch-command.ts",

--- a/packages/webapp/providers/openai-codex.ts
+++ b/packages/webapp/providers/openai-codex.ts
@@ -38,6 +38,7 @@ import {
   streamOpenAICodexResponses,
   streamSimpleOpenAICodexResponses,
 } from '@earendil-works/pi-ai/compat';
+import { deriveCodeChallenge, generateCodeVerifier, randomState } from '../src/providers/pkce.js';
 import type {
   InterceptingOAuthLauncher,
   ModelMetadata,
@@ -98,34 +99,6 @@ const CODEX_MODELS: CodexModelDef[] = [
   max_tokens: 128000,
   thinkingLevelMap: CODEX_THINKING_LEVEL_MAP,
 }));
-
-// ── PKCE helpers ───────────────────────────────────────────────────
-
-function base64UrlEncode(bytes: Uint8Array): string {
-  let str = '';
-  for (const b of bytes) str += String.fromCharCode(b);
-  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-function randomBytes(n: number): Uint8Array {
-  const out = new Uint8Array(n);
-  crypto.getRandomValues(out);
-  return out;
-}
-
-function generateCodeVerifier(): string {
-  return base64UrlEncode(randomBytes(32));
-}
-
-async function deriveCodeChallenge(verifier: string): Promise<string> {
-  const data = new TextEncoder().encode(verifier);
-  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', data));
-  return base64UrlEncode(digest);
-}
-
-function randomState(): string {
-  return base64UrlEncode(randomBytes(16));
-}
 
 // ── Token exchange ─────────────────────────────────────────────────
 

--- a/packages/webapp/providers/openrouter-oauth.ts
+++ b/packages/webapp/providers/openrouter-oauth.ts
@@ -5,8 +5,11 @@
  * https://github.com/espennilsen/pi/blob/main/extensions/pi-openrouter/src/oauth.ts
  */
 
+import { deriveCodeChallenge, generateCodeVerifier } from '../src/providers/pkce.js';
 import type { InterceptingOAuthLauncher, OAuthLoginOptions } from '../src/providers/types.js';
 import { saveOAuthAccount } from '../src/ui/provider-settings.js';
+
+export { deriveCodeChallenge, generateCodeVerifier };
 
 const OPENROUTER_AUTH_URL = 'https://openrouter.ai/auth';
 const OPENROUTER_KEYS_URL = 'https://openrouter.ai/api/v1/auth/keys';
@@ -14,23 +17,6 @@ const OPENROUTER_API_BASE_URL = 'https://openrouter.ai/api/v1';
 
 export const OPENROUTER_CALLBACK_URL = 'http://127.0.0.1:3000/callback';
 export const OPENROUTER_REDIRECT_URI_PATTERN = 'http://127.0.0.1:3000/*';
-
-function base64UrlEncode(bytes: Uint8Array): string {
-  let value = '';
-  for (const byte of bytes) value += String.fromCharCode(byte);
-  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-export function generateCodeVerifier(): string {
-  const bytes = new Uint8Array(32);
-  crypto.getRandomValues(bytes);
-  return base64UrlEncode(bytes);
-}
-
-export async function deriveCodeChallenge(verifier: string): Promise<string> {
-  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
-  return base64UrlEncode(new Uint8Array(digest));
-}
 
 export function buildAuthorizeUrl(callbackUrl: string, codeChallenge: string): string {
   const authorize = new URL(OPENROUTER_AUTH_URL);

--- a/packages/webapp/providers/xai-grok.ts
+++ b/packages/webapp/providers/xai-grok.ts
@@ -35,6 +35,7 @@ import {
   streamSimpleOpenAICompletions,
   streamSimpleOpenAIResponses,
 } from '@earendil-works/pi-ai/compat';
+import { deriveCodeChallenge, generateCodeVerifier, randomState } from '../src/providers/pkce.js';
 import type {
   InterceptingOAuthLauncher,
   OAuthLoginOptions,
@@ -118,34 +119,6 @@ function resolveNativeXaiModel(model: Model<Api>): NativeXaiModel {
     ...nativeModel,
     baseUrl: XAI_API_BASE_URL,
   } as NativeXaiModel;
-}
-
-// ── PKCE helpers ───────────────────────────────────────────────────
-
-function base64UrlEncode(bytes: Uint8Array): string {
-  let str = '';
-  for (const b of bytes) str += String.fromCharCode(b);
-  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
-function randomBytes(n: number): Uint8Array {
-  const out = new Uint8Array(n);
-  crypto.getRandomValues(out);
-  return out;
-}
-
-function generateCodeVerifier(): string {
-  return base64UrlEncode(randomBytes(32));
-}
-
-async function deriveCodeChallenge(verifier: string): Promise<string> {
-  const data = new TextEncoder().encode(verifier);
-  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', data));
-  return base64UrlEncode(digest);
-}
-
-function randomState(): string {
-  return base64UrlEncode(randomBytes(16));
 }
 
 // ── Token exchange ─────────────────────────────────────────────────

--- a/packages/webapp/src/providers/pkce.ts
+++ b/packages/webapp/src/providers/pkce.ts
@@ -1,0 +1,28 @@
+/** Encode bytes using the unpadded URL-safe Base64 alphabet. */
+export function base64UrlEncode(bytes: Uint8Array): string {
+  let value = '';
+  for (const byte of bytes) value += String.fromCharCode(byte);
+  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+/** Generate a 256-bit PKCE code verifier. */
+export function generateCodeVerifier(): string {
+  return base64UrlEncode(randomBytes(32));
+}
+
+/** Derive the RFC 7636 S256 challenge for a code verifier. */
+export async function deriveCodeChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+/** Generate a 128-bit OAuth state value. */
+export function randomState(): string {
+  return base64UrlEncode(randomBytes(16));
+}

--- a/packages/webapp/src/shell/mcp/oauth.ts
+++ b/packages/webapp/src/shell/mcp/oauth.ts
@@ -11,6 +11,7 @@
  */
 
 import { createLogger } from '../../core/logger.js';
+import { deriveCodeChallenge, generateCodeVerifier, randomState } from '../../providers/pkce.js';
 
 const log = createLogger('mcp-oauth');
 
@@ -72,6 +73,41 @@ export type FetchLike = (
   json(): Promise<unknown>;
   headers?: { get(name: string): string | null };
 }>;
+
+interface DiscoveryValidationContext {
+  discoveryPath: 'prm' | 'asm-origin-fallback';
+  prmUrl: string;
+  prmReason: string | null;
+  asmUrl: string;
+  asmReason: string | null;
+}
+
+function assertValidAuthorizationServerMetadata(
+  asm: AuthorizationServerMetadata | null,
+  context: DiscoveryValidationContext
+): asserts asm is AuthorizationServerMetadata {
+  const { discoveryPath, prmUrl, prmReason, asmUrl, asmReason } = context;
+  if (!asm) {
+    if (discoveryPath === 'asm-origin-fallback') {
+      throw new Error(
+        `MCP OAuth discovery failed. ` +
+          `PRM (${prmUrl}): ${prmReason}. ` +
+          `ASM fallback (${asmUrl}): ${asmReason}.`
+      );
+    }
+    throw new Error(`ASM fetch failed: ${asmReason} (${asmUrl})`);
+  }
+  if (asm.authorization_endpoint && asm.token_endpoint) return;
+  if (discoveryPath === 'asm-origin-fallback') {
+    throw new Error(
+      `MCP OAuth discovery failed. ` +
+        `PRM (${prmUrl}): ${prmReason}. ` +
+        `ASM fallback (${asmUrl}) is missing required endpoints ` +
+        `(authorization_endpoint, token_endpoint).`
+    );
+  }
+  throw new Error(`ASM at ${asmUrl} is missing required endpoints`);
+}
 
 // ── Discovery (RFC 9728 + RFC 8414) ─────────────────────────────────
 
@@ -161,27 +197,13 @@ export async function discoverAuth(
     asmReason = err instanceof Error ? err.message : String(err);
   }
 
-  if (!asm) {
-    if (discoveryPath === 'asm-origin-fallback') {
-      throw new Error(
-        `MCP OAuth discovery failed. ` +
-          `PRM (${prmUrl}): ${prmReason}. ` +
-          `ASM fallback (${asmUrl}): ${asmReason}.`
-      );
-    }
-    throw new Error(`ASM fetch failed: ${asmReason} (${asmUrl})`);
-  }
-  if (!asm.authorization_endpoint || !asm.token_endpoint) {
-    if (discoveryPath === 'asm-origin-fallback') {
-      throw new Error(
-        `MCP OAuth discovery failed. ` +
-          `PRM (${prmUrl}): ${prmReason}. ` +
-          `ASM fallback (${asmUrl}) is missing required endpoints ` +
-          `(authorization_endpoint, token_endpoint).`
-      );
-    }
-    throw new Error(`ASM at ${asmUrl} is missing required endpoints`);
-  }
+  assertValidAuthorizationServerMetadata(asm, {
+    discoveryPath,
+    prmUrl,
+    prmReason,
+    asmUrl,
+    asmReason,
+  });
   return {
     issuer: asm.issuer || asBase,
     authorizationEndpoint: asm.authorization_endpoint,
@@ -254,22 +276,13 @@ export function pickPkceMethod(supported: string[] | undefined): 'S256' | 'plain
   return 'S256';
 }
 
-function base64UrlEncode(bytes: Uint8Array): string {
-  let bin = '';
-  for (const b of bytes) bin += String.fromCharCode(b);
-  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
 /** Generate a PKCE verifier + challenge pair using the chosen method. */
 export async function generatePkce(method: 'S256' | 'plain'): Promise<PkcePair> {
-  const rand = new Uint8Array(32);
-  crypto.getRandomValues(rand);
-  const codeVerifier = base64UrlEncode(rand);
+  const codeVerifier = generateCodeVerifier();
   if (method === 'plain') {
     return { codeVerifier, codeChallenge: codeVerifier, method };
   }
-  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
-  return { codeVerifier, codeChallenge: base64UrlEncode(new Uint8Array(digest)), method };
+  return { codeVerifier, codeChallenge: await deriveCodeChallenge(codeVerifier), method };
 }
 
 // ── Authorization-code flow ─────────────────────────────────────────
@@ -305,7 +318,7 @@ export function extractCodeFromUrl(url: string): { code: string | null; state: s
 export async function runAuthFlow(opts: RunAuthFlowOptions): Promise<TokenResponse> {
   const method = pickPkceMethod(opts.asMetadata.codeChallengeMethods);
   const pkce = await generatePkce(method);
-  const state = base64UrlEncode(crypto.getRandomValues(new Uint8Array(16)));
+  const state = randomState();
   const params = new URLSearchParams({
     response_type: 'code',
     client_id: opts.clientId,

--- a/packages/webapp/tests/providers/pkce.test.ts
+++ b/packages/webapp/tests/providers/pkce.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  base64UrlEncode,
+  deriveCodeChallenge,
+  generateCodeVerifier,
+  randomState,
+} from '../../src/providers/pkce.js';
+
+describe('PKCE primitives', () => {
+  it('encodes bytes with the unpadded base64url alphabet', () => {
+    expect(base64UrlEncode(new Uint8Array([251, 255]))).toBe('-_8');
+  });
+
+  it('generates base64url-safe verifier and state values', () => {
+    expect(generateCodeVerifier()).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(randomState()).toMatch(/^[A-Za-z0-9_-]{22}$/);
+  });
+
+  it('derives the RFC 7636 S256 challenge for a fixed verifier', async () => {
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    await expect(deriveCodeChallenge(verifier)).resolves.toBe(
+      'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'
+    );
+  });
+});


### PR DESCRIPTION
## Context

Follow-up to the pi 0.82.0 bump (SLICC 5.73.4). The question was whether pi-ai's new `openRouterOAuth` lets us retire SLICC's own OpenRouter PKCE flow.

**It does not.** pi-ai 0.82.0's OpenRouter OAuth is CLI-only by construction:

1. It binds a loopback callback server with `node:http` `createServer` — its own header says "only intended for CLI use, not browser environments". A browser can't bind a port, which is why SLICC's `openrouter-oauth.ts` uses CDP `Fetch.requestPaused` interception.
2. `loginOpenRouter(interaction)` needs `interaction.prompt({type:'manual_code'})` — a paste-the-redirect-URL terminal fallback.
3. `auth/oauth/load.ts` uses a *variable* import specifier specifically so bundlers can't follow it into Node-only code.
4. Neither the flow nor its reusable `generatePKCE()` is in pi-ai's `exports` map.

Same reason `openai-codex.ts` and `xai-grok.ts` exist as SLICC-local flows.

## What this PR does

The duplication that *was* removable: four independent copies of the same base64url/PKCE primitives in the webapp are now one shared module.

New: `packages/webapp/src/providers/pkce.ts` — base64url encoding, verifier/challenge derivation, random state.

Rewired:
- `packages/webapp/providers/openrouter-oauth.ts` (named exports preserved — its test imports them)
- `packages/webapp/providers/openai-codex.ts`
- `packages/webapp/providers/xai-grok.ts`
- `packages/webapp/src/shell/mcp/oauth.ts` (both `plain` and `S256` branches unchanged)

Also clears the now-unneeded `mcp/oauth.ts` complexity exemption from `biome.json` via a behavior-preserving validation extraction.

The string-based `base64UrlEncode` in `src/shell/supplemental-commands/extension-media-capture.ts` is unrelated and untouched.

## Behavior

No authorize URL, redirect URI pattern, `code_challenge_method`, or token-exchange payload changed at any of the four sites.

## Verification

Lint, typecheck, 10,016 webapp tests, coverage floors, touched-file complexity gate, and full build all pass. Adds an RFC 7636 fixed-vector test.

A separate verifier agent audited the diff (7 checks, including the out-of-scope MCP validation extraction) and approved with high confidence. The 5s test-timeout flake on the default coverage command was confirmed **pre-existing**, not introduced.

## Follow-ups (not in this PR)

- The pre-existing coverage-command timeout flake (needs a 15s instrumentation timeout to pass reliably).
- The OpenRouter flow uses a fixed `http://127.0.0.1:3000/callback` with no state/nonce binding, unlike `openai-codex.ts` (strict `state` validation) and unlike pi's per-login UUID callback path. Possible hardening.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author