### PR TITLE
fix(webapp): restore follower Browser dock item + stop hosted-tab CDP loop

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,6 +54,8 @@ Every leader broadcast (`LeaderToFollowerMessage` / `broadcast*` in `tray-leader
 needs a matching follower handler in `tray-follower-sync.ts` AND a UI action wired in
 `wc-follower.ts`. New interactive elements on leader surfaces need follower counterparts.
 Check all three boot paths (`mountWcUiLive` / `mountWcUiFollower` / `mountWcUiExtension`).
+Also flag: a fallback removed from a shared helper for a leader-only replacement, or a
+gate keyed on a float name (`isCherry`) where a capability check belongs (#1706).
 The largest empirical failure class (~30–40 commits since 2026-03).
 
 ## 8. Origin / bridge routing contract (often Major)

--- a/docs/review-patterns.md
+++ b/docs/review-patterns.md
@@ -196,6 +196,12 @@ regression test for each bug fix, and keep coverage at or above the package floo
   UI surface.
 - A new follower-side handler in `tray-follower-sync.ts` with no corresponding UI action
   wired in `ui/wc/wc-follower.ts` (or vice versa).
+- **Removing a fallback from a shared helper** (e.g. `wc-shell.ts`) because a
+  leader-only replacement now covers it. `wireDockToWorkbench`, `prepareWcShell` and
+  friends run on every boot path; the replacement usually does not.
+- **Gating behavior on a float name** (`isCherry`, `isExtensionRealm()`, `ui-only=1`)
+  where the real condition is a capability. Float lists go stale the moment a new float
+  ships; capability checks do not.
 
 **Historical precedents**
 
@@ -205,6 +211,15 @@ regression test for each bug fix, and keep coverage at or above the package floo
   buttons had no action handler, so clicking them silently no-oped.
 - **PR #1261**: a fix landed on the non-primary boot path first, then caused a 5-second
   pill-reset regression that had to be fixed the next day.
+- **Issue #1706** (both shapes above, four months undetected). `a99a5faa4` added
+  `if (id === 'browser') return;` to `wireDockToWorkbench` so the leader's new
+  full-screen tab overlay had no dead pane behind it — but that helper is shared, and
+  the overlay is wired only when `options.standalone` is set. Leaders traded a pane for
+  an overlay; followers lost the pane and got nothing, leaving an inert dock item and an
+  unreachable `slicc-surface`. Separately, the follower's CDP advertisement was gated on
+  `isCherry && ui-only=1` rather than "has a local CDP bridge", so hosted-tab followers
+  — a float that shipped nine days after the gate was written — dialed
+  `wss://<hosted-origin>/cdp` every 5s indefinitely.
 
 **Class size** — ~30–40 commits since 2026-03; the largest empirical failure class in the
 repo.
@@ -213,6 +228,12 @@ repo.
 _and_ that the UI surface wires the user action back to the leader. Check all three boot
 paths (`mountWcUiLive` / `mountWcUiFollower` / `mountWcUiExtension`). Record the iOS
 mirror decision in the corpus (`packages/ios-app/`).
+
+When a leader-only feature supersedes shared behavior, let the feature **claim** what it
+replaces at wiring time rather than teaching the shared helper about it (see
+`WcShellRefs.overlaySurfaces`). The fallback then survives by default on every path that
+does not wire the feature — including a leader whose lazy import fails — instead of
+depending on two files agreeing forever.
 
 ### 9. Origin / bridge routing contract
 
@@ -295,7 +316,7 @@ follower (tray) and Cherry paths. See [docs/transcript-export.md](transcript-exp
 
 ---
 
-## Approval gate changes in `wc-tray.ts` or `wc-transcript-export.ts`.
+## Approval gate changes in `wc-tray.ts` or `wc-transcript-export.ts`
 
 When the approval dialog is changed: verify that Deny still resolves with `permission-denied`,
 that no approval escapes require a new prompt, and that the binary-attachment warning is

--- a/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
+++ b/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
@@ -62,6 +62,22 @@ export interface LickForwardingClient {
 export interface StandalonePreludeResult {
   browser: BrowserAPI;
   realCdpTransport: CDPTransport;
+  /**
+   * Whether this page realm reached a real Chrome — the single answer to
+   * "can `browser.listPages()` succeed here?", decided by whichever transport
+   * branch below actually ran.
+   *
+   * `false` means the page has a `BrowserAPI` with no route to Chrome: calling
+   * into it dials `getDefaultCdpUrl()` (= `wss://<page-origin>/cdp`), which on
+   * a hosted origin the SPA fallback answers with HTML, so the upgrade never
+   * succeeds. A follower that polls on that route retries forever (#1706).
+   *
+   * Callers must read this rather than re-deriving it from URL params: the
+   * three branches disagree about which params matter (the extension-leader
+   * branch deliberately ignores bridge params), and duplicating that logic is
+   * exactly the drift #1706 was.
+   */
+  hasLocalCdpSurface: boolean;
   cherryJoinUrl?: string;
   cherryTransport?: CherryHostTransport;
   instanceId: string;
@@ -324,6 +340,10 @@ export async function setupStandalonePrelude(
     localLickWsUrl = bridge.lickWsUrl;
   }
 
+  // Mirrors the three transport branches below, in order: cherry's synthetic
+  // target, the extension bridge's `chrome.debugger`, or the node-server bridge.
+  const hasLocalCdpSurface = runtimeMode === 'cherry' || useExtensionBridge || bridge !== null;
+
   const runtimeConfig = await fetchRuntimeConfig();
   const runtimeDefaultWorkerBaseUrl = shouldUseRuntimeModeTrayDefaults(
     runtimeMode,
@@ -412,6 +432,7 @@ export async function setupStandalonePrelude(
   return {
     browser,
     realCdpTransport,
+    hasLocalCdpSurface,
     cherryJoinUrl,
     cherryTransport,
     instanceId: mintInstanceId(),

--- a/packages/webapp/src/ui/page-follower-tray.ts
+++ b/packages/webapp/src/ui/page-follower-tray.ts
@@ -91,11 +91,19 @@ export interface StartPageFollowerTrayOptions {
   runtime?: string;
 
   /**
-   * When true, the follower keeps handshake + transport + chat sync but suppresses CDP target
-   * advertisement. Used by the extension's per-page cherry sidebar (`?cherry=1&ui-only=1`), where
-   * the extension controls the tab via real `chrome.debugger` CDP instead of a weak synthetic cherry target.
+   * Whether this follower has a CDP surface worth advertising to the leader.
+   * When false the follower keeps handshake + transport + chat sync but never
+   * enumerates or advertises targets.
+   *
+   * Must reflect whether a local CDP surface actually EXISTS — not which float
+   * is running. A follower without one that still polls will dial
+   * `getDefaultCdpUrl()` (= `wss://<page-origin>/cdp`) on a 5s loop forever;
+   * on a hosted origin that path returns the SPA fallback, so the socket can
+   * never open and the loop never ends.
+   *
+   * Callers: `wc-follower.ts` derives this via `followerAdvertisesCdpTargets`.
    */
-  uiOnly?: boolean;
+  advertisesCdpTargets?: boolean;
 
   // --- FollowerSyncManager callbacks (forwarded directly) ---
   /** Replace the follower's chat panel with the snapshot from the leader. */
@@ -331,7 +339,7 @@ export function startPageFollowerTray(
       recoveryMessage: 'Follower CDP target listing recovered (stable for debounce window)',
     });
     const refreshTargets = async (): Promise<void> => {
-      if (options.uiOnly) return; // UI-only follower advertises no CDP target
+      if (options.advertisesCdpTargets === false) return; // no local CDP surface to advertise
       let pages: Awaited<ReturnType<typeof options.browserAPI.listPages>>;
       try {
         pages = await options.browserAPI.listPages();
@@ -363,7 +371,7 @@ export function startPageFollowerTray(
     options.onConnectionChange?.(true);
     sync.requestSnapshot();
 
-    if (!options.uiOnly) {
+    if (options.advertisesCdpTargets !== false) {
       targetRefreshInterval = setInterval(() => void refreshTargets(), refreshIntervalMs);
       void refreshTargets();
     }

--- a/packages/webapp/src/ui/wc/wc-browser.ts
+++ b/packages/webapp/src/ui/wc/wc-browser.ts
@@ -94,6 +94,13 @@ export function wireWcBrowser(deps: WireWcBrowserDeps): WcBrowserHandle {
     }
   };
 
+  // Claim the surface so the shell's dock handler stops opening a workbench
+  // pane behind this overlay. Claiming HERE (rather than hardcoding 'browser'
+  // in the shell) keeps the pane fallback for every float that never reaches
+  // this wiring — followers, cherry, extension — and for a leader whose
+  // dynamic import of this module fails.
+  refs.overlaySurfaces.add('browser');
+
   refs.dock.addEventListener('slicc-dock-select', (event) => {
     if ((event as CustomEvent<{ id?: string }>).detail?.id !== 'browser') return;
     void refresh();

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -7,7 +7,6 @@ import {
   subscribeToFollowerTrayRuntimeStatus,
 } from '../../scoops/tray-follower-status.js';
 import { resolveFollowerJoinUrl, storeTrayJoinUrl } from '../../scoops/tray-runtime-config.js';
-import { parseBridgeLaunchParams } from '../boot/bridge-launch-params.js';
 import { setupStandalonePrelude } from '../boot/setup-standalone-prelude.js';
 import type { BootStageLogger } from '../boot/types.js';
 import { type DipInstance, disposeDips, hydrateDips } from '../dip.js';
@@ -218,28 +217,30 @@ function applyFeatureVisibility(features: CherryFeatureSet): void {
 }
 
 /**
- * Whether a follower has a CDP surface worth advertising to the leader.
+ * Whether a follower should advertise its local tabs to the leader.
  *
- * - **cherry embed**: yes — the host handshake gives it a synthetic target for
- *   the embedding page. Except under `?ui-only=1`, where the extension drives
- *   the real tab via `chrome.debugger` and the synthetic target would only
- *   compete with it.
- * - **every other follower**: only when node-server launched it with bridge
- *   params (`?bridge=ws://…&bridgeToken=…`), which is the only way a page
- *   realm reaches a local Chrome.
+ * Two independent questions, deliberately kept apart:
  *
- * A follower opened from a hosted `/join/…` link matches neither, and this is
- * the case the old `isCherry && ui-only=1` gate missed: it has no local bridge,
- * so `getDefaultCdpUrl()` resolves to `wss://<hosted-origin>/cdp` — a path the
- * hosted origin answers with the SPA fallback (HTML, 200), so the WebSocket
- * upgrade can never succeed and the 5s refresh loop retries indefinitely.
+ * 1. **Capability** — `hasLocalCdpSurface` from `setupStandalonePrelude`, which
+ *    is the only thing that knows which transport branch actually ran. A
+ *    follower opened from a hosted `/join/…` link has none: `getDefaultCdpUrl()`
+ *    resolves to `wss://<hosted-origin>/cdp`, the SPA fallback answers with HTML,
+ *    and the 5s refresh loop retries that doomed upgrade forever (#1706).
+ * 2. **Policy** — `uiOnly`. The extension side panel *has* a surface (a synthetic
+ *    cherry target) but deliberately withholds it, because the extension drives
+ *    the real tab through `chrome.debugger` and the two would compete.
  *
- * Keyed on the local CDP surface EXISTING, not on which float is running — a
- * float-name check is what drifted out of date when hosted followers shipped.
+ * Never re-derive the capability from URL params here. The prelude's branches
+ * disagree about which params matter — the extension-leader branch reaches real
+ * Chrome with no bridge params at all — so a URL check silently drops that
+ * float. Keying on a float name is the same mistake one level up: it is what
+ * went stale when hosted followers shipped nine days after the original gate.
  */
-export function followerAdvertisesCdpTargets(isCherry: boolean, search: string): boolean {
-  if (isCherry) return new URLSearchParams(search).get('ui-only') !== '1';
-  return parseBridgeLaunchParams(search) !== null;
+export function followerAdvertisesCdpTargets(
+  hasLocalCdpSurface: boolean,
+  uiOnly: boolean
+): boolean {
+  return hasLocalCdpSurface && !uiOnly;
 }
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: follower boot has sequential setup steps
@@ -251,7 +252,6 @@ export async function mountWcUiFollower(
 ): Promise<void> {
   const isCherry = runtimeMode === 'cherry';
   const uiOnly = isCherry && new URLSearchParams(window.location.search).get('ui-only') === '1';
-  const advertisesCdpTargets = followerAdvertisesCdpTargets(isCherry, window.location.search);
   // The login hand-off (welcome-dip replacement, sign-in card, open-leader-tab)
   // is EXTENSION-SIDE-PANEL-ONLY. Only that follower host can complete it: its
   // cherry host (`sidepanel-entry.ts`) relays `slicc.open-leader-tab` to the SW,
@@ -538,7 +538,7 @@ export async function mountWcUiFollower(
   const follower = startPageFollowerTray({
     joinUrl,
     runtime: isCherry ? CHERRY_RUNTIME_TAG : 'slicc-standalone',
-    advertisesCdpTargets,
+    advertisesCdpTargets: followerAdvertisesCdpTargets(prelude.hasLocalCdpSurface, uiOnly),
     browserAPI: prelude.browser,
     onSnapshot: (messages) => controller.loadMessages(messages),
     // Real signatures: onUserMessage(text, messageId, scoopJid, attachments?)

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -7,6 +7,7 @@ import {
   subscribeToFollowerTrayRuntimeStatus,
 } from '../../scoops/tray-follower-status.js';
 import { resolveFollowerJoinUrl, storeTrayJoinUrl } from '../../scoops/tray-runtime-config.js';
+import { parseBridgeLaunchParams } from '../boot/bridge-launch-params.js';
 import { setupStandalonePrelude } from '../boot/setup-standalone-prelude.js';
 import type { BootStageLogger } from '../boot/types.js';
 import { type DipInstance, disposeDips, hydrateDips } from '../dip.js';
@@ -216,6 +217,31 @@ function applyFeatureVisibility(features: CherryFeatureSet): void {
   }
 }
 
+/**
+ * Whether a follower has a CDP surface worth advertising to the leader.
+ *
+ * - **cherry embed**: yes — the host handshake gives it a synthetic target for
+ *   the embedding page. Except under `?ui-only=1`, where the extension drives
+ *   the real tab via `chrome.debugger` and the synthetic target would only
+ *   compete with it.
+ * - **every other follower**: only when node-server launched it with bridge
+ *   params (`?bridge=ws://…&bridgeToken=…`), which is the only way a page
+ *   realm reaches a local Chrome.
+ *
+ * A follower opened from a hosted `/join/…` link matches neither, and this is
+ * the case the old `isCherry && ui-only=1` gate missed: it has no local bridge,
+ * so `getDefaultCdpUrl()` resolves to `wss://<hosted-origin>/cdp` — a path the
+ * hosted origin answers with the SPA fallback (HTML, 200), so the WebSocket
+ * upgrade can never succeed and the 5s refresh loop retries indefinitely.
+ *
+ * Keyed on the local CDP surface EXISTING, not on which float is running — a
+ * float-name check is what drifted out of date when hosted followers shipped.
+ */
+export function followerAdvertisesCdpTargets(isCherry: boolean, search: string): boolean {
+  if (isCherry) return new URLSearchParams(search).get('ui-only') !== '1';
+  return parseBridgeLaunchParams(search) !== null;
+}
+
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: follower boot has sequential setup steps
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: follower boot has sequential setup steps
 export async function mountWcUiFollower(
@@ -225,6 +251,7 @@ export async function mountWcUiFollower(
 ): Promise<void> {
   const isCherry = runtimeMode === 'cherry';
   const uiOnly = isCherry && new URLSearchParams(window.location.search).get('ui-only') === '1';
+  const advertisesCdpTargets = followerAdvertisesCdpTargets(isCherry, window.location.search);
   // The login hand-off (welcome-dip replacement, sign-in card, open-leader-tab)
   // is EXTENSION-SIDE-PANEL-ONLY. Only that follower host can complete it: its
   // cherry host (`sidepanel-entry.ts`) relays `slicc.open-leader-tab` to the SW,
@@ -511,7 +538,7 @@ export async function mountWcUiFollower(
   const follower = startPageFollowerTray({
     joinUrl,
     runtime: isCherry ? CHERRY_RUNTIME_TAG : 'slicc-standalone',
-    uiOnly,
+    advertisesCdpTargets,
     browserAPI: prelude.browser,
     onSnapshot: (messages) => controller.loadMessages(messages),
     // Real signatures: onUserMessage(text, messageId, scoopJid, attachments?)

--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -279,12 +279,16 @@ function buildWorkbench(): {
 
   // The dock's system tools include a Browser entry. Floats that wire the
   // full-screen tab switcher claim the surface (see `WcShellRefs.overlaySurfaces`)
-  // and never reach this pane; the rest — followers above all — land here, so
-  // the placeholder is the live fallback, not dead chrome.
+  // and never reach this pane; the rest — followers above all — land here.
+  //
+  // So this copy must describe the FALLBACK, not the switcher. It used to
+  // advertise the switcher and tell the reader to click cards that are not
+  // there — harmless while the pane was unreachable, actively wrong now that
+  // followers land on it.
   const browserSurface = el('slicc-surface', { 'surface-id': 'browser', layout: 'flex' });
   const browserNote = el('div', { class: 'wcui-placeholder' });
   browserNote.textContent =
-    'The Browser dock item opens the full-screen tab switcher: every open tab — local and tray followers — with live screenshot thumbnails. Click a card to focus it, ✕ to close it.';
+    'The tab switcher runs on the leader. This float has no browser of its own to show — ask the leader to open, focus, or close tabs through chat.';
   browserSurface.append(browserNote);
 
   body.append(filesSurface, termSurfaceHost, memorySurfaceHost, monitorSurfaceHost, browserSurface);

--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -100,6 +100,18 @@ export interface WcShellRefs {
   monitor: SliccMonitor;
   tabBar: HTMLElement & { tabs?: unknown };
   avatarMenu: SliccAvatarMenu;
+  /**
+   * Dock surface ids claimed by a full-screen overlay launcher instead of a
+   * workbench pane. `wireDockToWorkbench` consults this at click time, so a
+   * float that never wires an overlay (follower, cherry, extension) keeps the
+   * pane fallback — and a leader whose overlay module fails to load degrades
+   * to the same fallback rather than a dead dock item.
+   *
+   * Claimed by the overlay's own wiring (see `wc-browser.ts`), never here:
+   * hardcoding an id in the dock handler is what made the follower's Browser
+   * globe inert once the leader-only overlay became its replacement.
+   */
+  overlaySurfaces: Set<string>;
 }
 
 const STYLE_ID = 'slicc-wcui-style';
@@ -265,8 +277,10 @@ function buildWorkbench(): {
   const monitor = el('slicc-monitor', { class: 'wcui-monitor' }) as SliccMonitor;
   monitorSurfaceHost.append(monitor);
 
-  // The dock's system tools include a Browser entry; its CDP pane is not
-  // built for the WC shell yet — a placeholder beats an empty void.
+  // The dock's system tools include a Browser entry. Floats that wire the
+  // full-screen tab switcher claim the surface (see `WcShellRefs.overlaySurfaces`)
+  // and never reach this pane; the rest — followers above all — land here, so
+  // the placeholder is the live fallback, not dead chrome.
   const browserSurface = el('slicc-surface', { 'surface-id': 'browser', layout: 'flex' });
   const browserNote = el('div', { class: 'wcui-placeholder' });
   browserNote.textContent =
@@ -287,14 +301,16 @@ function wireDockToWorkbench(
   dock: HTMLElement,
   shell: HTMLElement,
   body: HTMLElement,
+  overlaySurfaces: ReadonlySet<string>,
   onSurfaceActivate?: (surfaceId: string) => void
 ): void {
   dock.addEventListener('slicc-dock-select', (event) => {
     const id = (event as CustomEvent<{ id: string }>).detail?.id;
     if (!id) return;
-    // The Browser globe opens the FULL-SCREEN tab overlay (wc-browser.ts) —
-    // a workspace pane underneath it would just be dead chrome.
-    if (id === 'browser') return;
+    // Overlay-launched surfaces open a full-screen view instead; a workspace
+    // pane underneath it would just be dead chrome. Read at click time, not
+    // mount time — the overlay wiring runs after `mountWcShell`.
+    if (overlaySurfaces.has(id)) return;
     shell.setAttribute('open', '');
     body.setAttribute('active', id);
     onSurfaceActivate?.(id);
@@ -367,7 +383,8 @@ export function mountWcShell(root: HTMLElement, options: WcShellOptions): WcShel
     buildWorkbench();
   const dock = el('slicc-dock', { 'system-tools': '' });
   shell.append(pane, workbench, dock);
-  wireDockToWorkbench(dock, shell, body, options.onSurfaceActivate);
+  const overlaySurfaces = new Set<string>();
+  wireDockToWorkbench(dock, shell, body, overlaySurfaces, options.onSurfaceActivate);
   wireTabsToBody(header, body, options.onSurfaceActivate);
 
   // The freezer rail reserves its width via `--rail-w` on the app column so
@@ -419,6 +436,7 @@ export function mountWcShell(root: HTMLElement, options: WcShellOptions): WcShel
     monitor,
     tabBar,
     avatarMenu,
+    overlaySurfaces,
   };
 }
 

--- a/packages/webapp/tests/ui/boot/setup-standalone-prelude.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-standalone-prelude.test.ts
@@ -215,6 +215,11 @@ describe('setupStandalonePrelude — extension leader transport selection', () =
     expect(connect).toHaveBeenCalledWith('test-ext-id', { name: EXTENSION_BRIDGE_PORT_NAME });
     expect(result.realCdpTransport).toBeInstanceOf(ExtensionBridgeTransport);
     expect(result.browser).toBeDefined();
+    // This branch reaches real Chrome with NO bridge launch params. A follower
+    // capability check that sniffs the URL for `?bridge=` misses it and
+    // silently stops advertising tabs on the pinned-leader reload path (#1706
+    // review) — which is why the capability is decided here, not by callers.
+    expect(result.hasLocalCdpSurface).toBe(true);
   });
 
   it('forwards an extension.lick into the late-bound client inject seam as a navigate LickEvent', async () => {
@@ -514,5 +519,68 @@ describe('setupStandalonePrelude — thin-bridge runtime-config origin', () => {
 
     expect(seenUrl).toBe('/api/runtime-config');
     expect(seenBridgeHeader).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasLocalCdpSurface — "can browser.listPages() succeed here?" (#1706)
+//
+// The extension-bridge branch is asserted in its own suite above, where the
+// chrome.runtime.connect stub lives.
+// ---------------------------------------------------------------------------
+
+describe('setupStandalonePrelude — hasLocalCdpSurface', () => {
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).__slicc_browser;
+  });
+
+  it('is false with no bridge params and no extension bridge (hosted-tab follower)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 404 }))
+    );
+
+    const result = await setupStandalonePrelude({
+      runtimeMode: 'follower',
+      envBaseUrl: null,
+      window: createFakeWindow('?ws=files'),
+      log: createLog(),
+    });
+
+    expect(result.hasLocalCdpSurface).toBe(false);
+  });
+
+  it('is true for a node-server-launched tab carrying bridge params', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 404 }))
+    );
+
+    const result = await setupStandalonePrelude({
+      runtimeMode: 'follower',
+      envBaseUrl: null,
+      window: createFakeWindow(
+        '?bridge=ws%3A%2F%2Flocalhost%3A5710%2Fcdp&bridgeToken=tok&bridgeRole=follower'
+      ),
+      log: createLog(),
+    });
+
+    expect(result.hasLocalCdpSurface).toBe(true);
+  });
+
+  it('is false when a bridge param arrives without its token (unusable pair)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, { status: 404 }))
+    );
+
+    const result = await setupStandalonePrelude({
+      runtimeMode: 'follower',
+      envBaseUrl: null,
+      window: createFakeWindow('?bridge=ws%3A%2F%2Flocalhost%3A5710%2Fcdp'),
+      log: createLog(),
+    });
+
+    expect(result.hasLocalCdpSurface).toBe(false);
   });
 });

--- a/packages/webapp/tests/ui/page-follower-tray-advertise.test.ts
+++ b/packages/webapp/tests/ui/page-follower-tray-advertise.test.ts
@@ -1,5 +1,9 @@
 /**
- * Behavioral tests for the `uiOnly` follower mode of `startPageFollowerTray`.
+ * Behavioral tests for `advertisesCdpTargets` on `startPageFollowerTray`.
+ *
+ * The flag gates whether the follower enumerates local CDP targets and
+ * advertises them to the leader. A follower with no local CDP surface that
+ * still polls dials `wss://<page-origin>/cdp` on a 5s loop forever (#1706).
  *
  * `advertiseTargets` lives on the `FollowerSyncManager` that
  * `startPageFollowerTray` constructs inside its private `wireFollowerSync`,
@@ -79,17 +83,17 @@ function fakeConnection() {
   return { channel: {} as never, bootstrapId: 'boot-1', trayId: 'tray-1', controllerId: 'ctrl-1' };
 }
 
-describe('startPageFollowerTray uiOnly advertise suppression', () => {
+describe('startPageFollowerTray CDP advertise suppression', () => {
   beforeEach(() => {
     capturedOnConnected = null;
     capturedSyncCallbacks = null;
     mockAdvertiseTargets = vi.fn();
   });
 
-  it('uiOnly=true: interval path does NOT call advertiseTargets', async () => {
+  it('advertisesCdpTargets=false: interval path does NOT call advertiseTargets', async () => {
     vi.useFakeTimers();
     try {
-      const opts = { ...makeBaseOptions(), uiOnly: true, _refreshIntervalMs: 50 };
+      const opts = { ...makeBaseOptions(), advertisesCdpTargets: false, _refreshIntervalMs: 50 };
       const handle = startPageFollowerTray(opts);
       expect(capturedOnConnected).not.toBeNull();
       capturedOnConnected!(fakeConnection());
@@ -103,8 +107,8 @@ describe('startPageFollowerTray uiOnly advertise suppression', () => {
     }
   });
 
-  it('uiOnly=true: onTargetsChanged callback does NOT call advertiseTargets', async () => {
-    const opts = { ...makeBaseOptions(), uiOnly: true };
+  it('advertisesCdpTargets=false: onTargetsChanged callback does NOT call advertiseTargets', async () => {
+    const opts = { ...makeBaseOptions(), advertisesCdpTargets: false };
     const handle = startPageFollowerTray(opts);
     capturedOnConnected!(fakeConnection());
 
@@ -116,8 +120,8 @@ describe('startPageFollowerTray uiOnly advertise suppression', () => {
     handle.stop();
   });
 
-  it('uiOnly=true: chat sync (setChatAgent, requestSnapshot) still wired', () => {
-    const opts = { ...makeBaseOptions(), uiOnly: true };
+  it('advertisesCdpTargets=false: chat sync (setChatAgent, requestSnapshot) still wired', () => {
+    const opts = { ...makeBaseOptions(), advertisesCdpTargets: false };
     const handle = startPageFollowerTray(opts);
     capturedOnConnected!(fakeConnection());
 
@@ -127,10 +131,49 @@ describe('startPageFollowerTray uiOnly advertise suppression', () => {
     handle.stop();
   });
 
-  it('uiOnly=false (positive control): interval path DOES call advertiseTargets', async () => {
+  it('advertisesCdpTargets=true (positive control): interval path DOES call advertiseTargets', async () => {
     vi.useFakeTimers();
     try {
-      const opts = { ...makeBaseOptions(), uiOnly: false, _refreshIntervalMs: 50 };
+      const opts = { ...makeBaseOptions(), advertisesCdpTargets: true, _refreshIntervalMs: 50 };
+      const handle = startPageFollowerTray(opts);
+      capturedOnConnected!(fakeConnection());
+
+      await vi.advanceTimersByTimeAsync(120);
+
+      expect(mockAdvertiseTargets).toHaveBeenCalled();
+      handle.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Regression (#1706): suppression must stop the POLLING, not just the
+  // advertisement. The bug users hit was the dialing itself — every tick
+  // called `listPages()`, which opened a doomed `wss://<hosted-origin>/cdp`
+  // socket. Asserting only on `advertiseTargets` would still pass while that
+  // loop ran, so assert the transport is never touched at all.
+  it('advertisesCdpTargets=false: never calls listPages (no CDP dialing at all)', async () => {
+    vi.useFakeTimers();
+    try {
+      const opts = { ...makeBaseOptions(), advertisesCdpTargets: false, _refreshIntervalMs: 50 };
+      const handle = startPageFollowerTray(opts);
+      capturedOnConnected!(fakeConnection());
+
+      await vi.advanceTimersByTimeAsync(500); // 10 refresh windows
+
+      expect(opts.browserAPI.listPages).not.toHaveBeenCalled();
+      handle.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The option is optional; an omitted flag keeps the historical
+  // advertise-by-default behavior for local-bridge followers.
+  it('omitted flag defaults to advertising', async () => {
+    vi.useFakeTimers();
+    try {
+      const opts = { ...makeBaseOptions(), _refreshIntervalMs: 50 };
       const handle = startPageFollowerTray(opts);
       capturedOnConnected!(fakeConnection());
 

--- a/packages/webapp/tests/ui/wc/wc-browser.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-browser.test.ts
@@ -35,12 +35,25 @@ function makeFakeBrowser() {
 function makeRefs(): WcShellRefs {
   const dock = document.createElement('slicc-dock');
   document.body.append(dock);
-  return { dock } as unknown as WcShellRefs;
+  return { dock, overlaySurfaces: new Set<string>() } as unknown as WcShellRefs;
 }
 
 type OverlayEl = HTMLElement & { tabs: Array<{ id: string; screenshot?: string }> };
 
 describe('wireWcBrowser', () => {
+  // Regression (#1706): the shell's dock handler skips the workbench pane only
+  // for surfaces an overlay has claimed. Claiming here — rather than the shell
+  // hardcoding 'browser' — is what keeps the pane fallback alive on floats that
+  // never reach this wiring (followers, cherry, extension).
+  it('claims the browser surface so the shell stops opening a pane behind it', () => {
+    const refs = makeRefs();
+    expect(refs.overlaySurfaces.has('browser')).toBe(false);
+
+    wireWcBrowser({ refs, browser: makeFakeBrowser() as unknown as BrowserAPI, log });
+
+    expect(refs.overlaySurfaces.has('browser')).toBe(true);
+  });
+
   it('opens the overlay on the browser dock item with every target + lazy thumbnails', async () => {
     const refs = makeRefs();
     const browser = makeFakeBrowser();

--- a/packages/webapp/tests/ui/wc/wc-follower.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-follower.test.ts
@@ -32,6 +32,7 @@ vi.mock('../../../src/ui/boot/setup-standalone-prelude.js', () => ({
     cherryJoinUrl: undefined,
     cherryTransport: undefined,
     instanceId: 'i',
+    hasLocalCdpSurface: true,
   })),
 }));
 
@@ -73,6 +74,7 @@ function mockCherryPrelude(emit: () => void): void {
         features: ALL_CHERRY_FEATURES,
       },
       instanceId: 'i',
+      hasLocalCdpSurface: true,
     })),
   }));
 }
@@ -674,6 +676,9 @@ describe('mountWcUiFollower', () => {
         cherryJoinUrl: undefined,
         cherryTransport: undefined,
         instanceId: 'i',
+        // A hosted `/join/…` tab reaches no Chrome — what the prelude reports
+        // for this URL (asserted directly in setup-standalone-prelude.test.ts).
+        hasLocalCdpSurface: false,
       })),
     }));
     vi.resetModules();
@@ -700,39 +705,28 @@ describe('mountWcUiFollower', () => {
 // ---------------------------------------------------------------------------
 
 describe('followerAdvertisesCdpTargets', () => {
-  const BRIDGE = '?bridge=ws%3A%2F%2Flocalhost%3A5710%2Fcdp&bridgeToken=tok';
-
-  it('non-cherry WITH bridge params advertises (node-server-launched follower)', async () => {
+  // Capability AND policy. The capability half is decided by the prelude (see
+  // setup-standalone-prelude.test.ts) precisely so this predicate never has to
+  // guess a transport from URL shape — the extension-bridge branch reaches real
+  // Chrome with no bridge params, and a URL check drops it (#1706 review).
+  it('advertises when a local CDP surface exists and policy allows it', async () => {
     const { followerAdvertisesCdpTargets } = await import('../../../src/ui/wc/wc-follower.js');
-    expect(followerAdvertisesCdpTargets(false, BRIDGE)).toBe(true);
+    expect(followerAdvertisesCdpTargets(true, false)).toBe(true);
   });
 
-  it('non-cherry WITHOUT bridge params does not advertise (hosted-tab follower)', async () => {
+  it('does not advertise without a local CDP surface (hosted-tab follower)', async () => {
     const { followerAdvertisesCdpTargets } = await import('../../../src/ui/wc/wc-follower.js');
-    expect(followerAdvertisesCdpTargets(false, '')).toBe(false);
-    expect(followerAdvertisesCdpTargets(false, '?ws=files')).toBe(false);
+    expect(followerAdvertisesCdpTargets(false, false)).toBe(false);
   });
 
-  it('a bridge param missing its token does not count as a local bridge', async () => {
+  it('ui-only withholds an EXISTING surface (extension drives chrome.debugger)', async () => {
     const { followerAdvertisesCdpTargets } = await import('../../../src/ui/wc/wc-follower.js');
-    expect(followerAdvertisesCdpTargets(false, '?bridge=ws%3A%2F%2Flocalhost%3A5710%2Fcdp')).toBe(
-      false
-    );
+    expect(followerAdvertisesCdpTargets(true, true)).toBe(false);
   });
 
-  it('cherry advertises its synthetic target by default', async () => {
+  it('ui-only cannot conjure a surface that does not exist', async () => {
     const { followerAdvertisesCdpTargets } = await import('../../../src/ui/wc/wc-follower.js');
-    expect(followerAdvertisesCdpTargets(true, '?cherry=1')).toBe(true);
-  });
-
-  it('cherry with ?ui-only=1 does not advertise (extension drives chrome.debugger)', async () => {
-    const { followerAdvertisesCdpTargets } = await import('../../../src/ui/wc/wc-follower.js');
-    expect(followerAdvertisesCdpTargets(true, '?cherry=1&ui-only=1')).toBe(false);
-  });
-
-  it('ui-only is cherry-only — it does not flip a bridged non-cherry follower', async () => {
-    const { followerAdvertisesCdpTargets } = await import('../../../src/ui/wc/wc-follower.js');
-    expect(followerAdvertisesCdpTargets(false, `${BRIDGE}&ui-only=1`)).toBe(true);
+    expect(followerAdvertisesCdpTargets(false, true)).toBe(false);
   });
 });
 

--- a/packages/webapp/tests/ui/wc/wc-follower.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-follower.test.ts
@@ -582,7 +582,7 @@ describe('mountWcUiFollower', () => {
     expect(app.querySelector('.wc-signin-redirect')).toBeNull();
   });
 
-  it('reads ?ui-only=1 and passes uiOnly:true to startPageFollowerTray when cherry', async () => {
+  it('reads ?ui-only=1 and suppresses CDP advertisement via startPageFollowerTray when cherry', async () => {
     // Change the URL to include ui-only=1
     Object.defineProperty(window, 'location', {
       value: {
@@ -598,7 +598,7 @@ describe('mountWcUiFollower', () => {
 
     expect(startFollowerSpy).toHaveBeenCalledTimes(1);
     const opts = startFollowerSpy.mock.calls[0]![0];
-    expect(opts.uiOnly).toBe(true);
+    expect(opts.advertisesCdpTargets).toBe(false);
 
     // The ui-only follower is the extension side-panel cockpit — a cross-origin
     // iframe where getUserMedia can't be granted. So mic/camera capture is
@@ -656,7 +656,11 @@ describe('mountWcUiFollower', () => {
     expect(callOrder.indexOf('prepareWcShell')).toBeLessThan(callOrder.indexOf('applyCherryTheme'));
   });
 
-  it('does not set uiOnly when ?ui-only=1 is present but NOT cherry mode', async () => {
+  // Regression (#1706): a hosted-tab follower has no local CDP bridge, so it
+  // must not advertise — regardless of `ui-only`, which is a cherry-only
+  // parameter. The pre-fix gate (`isCherry && ui-only=1`) evaluated false here
+  // and left the follower dialing `wss://www.sliccy.ai/cdp` on a 5s loop.
+  it('suppresses CDP advertisement for a hosted-tab follower (no bridge params, NOT cherry)', async () => {
     // Regular follower with ui-only param should ignore it. This is a NON-cherry
     // follower, so it starts the follower-navigate-watcher, which calls
     // `realCdpTransport.on(...)`. Establish our own prelude mock with a complete
@@ -686,8 +690,49 @@ describe('mountWcUiFollower', () => {
     await mountWcUiFollower(app, { stage: () => {} } as never, 'follower');
 
     const opts = startFollowerSpy.mock.calls[0]![0];
-    // uiOnly should be undefined or false for non-cherry
-    expect(opts.uiOnly).toBeFalsy();
+    // No `?bridge=`/`?bridgeToken=` on this URL — no local Chrome to enumerate.
+    expect(opts.advertisesCdpTargets).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// followerAdvertisesCdpTargets — the predicate in isolation (#1706)
+// ---------------------------------------------------------------------------
+
+describe('followerAdvertisesCdpTargets', () => {
+  const BRIDGE = '?bridge=ws%3A%2F%2Flocalhost%3A5710%2Fcdp&bridgeToken=tok';
+
+  it('non-cherry WITH bridge params advertises (node-server-launched follower)', async () => {
+    const { followerAdvertisesCdpTargets } = await import('../../../src/ui/wc/wc-follower.js');
+    expect(followerAdvertisesCdpTargets(false, BRIDGE)).toBe(true);
+  });
+
+  it('non-cherry WITHOUT bridge params does not advertise (hosted-tab follower)', async () => {
+    const { followerAdvertisesCdpTargets } = await import('../../../src/ui/wc/wc-follower.js');
+    expect(followerAdvertisesCdpTargets(false, '')).toBe(false);
+    expect(followerAdvertisesCdpTargets(false, '?ws=files')).toBe(false);
+  });
+
+  it('a bridge param missing its token does not count as a local bridge', async () => {
+    const { followerAdvertisesCdpTargets } = await import('../../../src/ui/wc/wc-follower.js');
+    expect(followerAdvertisesCdpTargets(false, '?bridge=ws%3A%2F%2Flocalhost%3A5710%2Fcdp')).toBe(
+      false
+    );
+  });
+
+  it('cherry advertises its synthetic target by default', async () => {
+    const { followerAdvertisesCdpTargets } = await import('../../../src/ui/wc/wc-follower.js');
+    expect(followerAdvertisesCdpTargets(true, '?cherry=1')).toBe(true);
+  });
+
+  it('cherry with ?ui-only=1 does not advertise (extension drives chrome.debugger)', async () => {
+    const { followerAdvertisesCdpTargets } = await import('../../../src/ui/wc/wc-follower.js');
+    expect(followerAdvertisesCdpTargets(true, '?cherry=1&ui-only=1')).toBe(false);
+  });
+
+  it('ui-only is cherry-only — it does not flip a bridged non-cherry follower', async () => {
+    const { followerAdvertisesCdpTargets } = await import('../../../src/ui/wc/wc-follower.js');
+    expect(followerAdvertisesCdpTargets(false, `${BRIDGE}&ui-only=1`)).toBe(true);
   });
 });
 

--- a/packages/webapp/tests/ui/wc/wc-shell.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-shell.test.ts
@@ -166,14 +166,72 @@ describe('mountWcUiPreview', () => {
     expect(css).toContain('html,body{margin:0');
   });
 
-  it('the browser dock item never opens a workspace pane (the overlay is the surface)', () => {
-    const root = mount();
-    const dock = root.querySelector('slicc-dock') as HTMLElement;
-    const shell = root.querySelector('slicc-shell') as HTMLElement;
-    dock.dispatchEvent(
+  // Regression (#1706): the dock handler used to hardcode `id === 'browser'`
+  // and skip the pane for EVERY float, while only standalone leaders wired the
+  // replacement overlay. Followers were left with an inert globe. The skip is
+  // now driven by `refs.overlaySurfaces`, which the overlay claims for itself.
+  it('an UNCLAIMED browser dock item opens the workspace pane (follower fallback)', async () => {
+    const { mountWcShell } = await import('../../../src/ui/wc/wc-shell.js');
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const refs = mountWcShell(host, {
+      messages: [],
+      scoops: [],
+      floatLabel: 'follower',
+      placeholder: 'p',
+    });
+
+    refs.dock.dispatchEvent(
       new CustomEvent('slicc-dock-select', { bubbles: true, detail: { id: 'browser' } })
     );
-    expect(shell.hasAttribute('open')).toBe(false);
+
+    expect(refs.shell.hasAttribute('open')).toBe(true);
+    expect(refs.workbenchBody.getAttribute('active')).toBe('browser');
+  });
+
+  it('a CLAIMED browser dock item opens no pane (the overlay is the surface)', async () => {
+    const { mountWcShell } = await import('../../../src/ui/wc/wc-shell.js');
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const refs = mountWcShell(host, {
+      messages: [],
+      scoops: [],
+      floatLabel: 'leader',
+      placeholder: 'p',
+    });
+    refs.overlaySurfaces.add('browser'); // what wireWcBrowser does
+
+    refs.dock.dispatchEvent(
+      new CustomEvent('slicc-dock-select', { bubbles: true, detail: { id: 'browser' } })
+    );
+
+    expect(refs.shell.hasAttribute('open')).toBe(false);
+  });
+
+  // The claim lands after mountWcShell (the overlay module is imported lazily),
+  // so the handler must read the set at click time, not capture it at wiring.
+  it('a claim registered AFTER mount still suppresses the pane', async () => {
+    const { mountWcShell } = await import('../../../src/ui/wc/wc-shell.js');
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const refs = mountWcShell(host, {
+      messages: [],
+      scoops: [],
+      floatLabel: 'leader',
+      placeholder: 'p',
+    });
+
+    refs.dock.dispatchEvent(
+      new CustomEvent('slicc-dock-select', { bubbles: true, detail: { id: 'files' } })
+    );
+    expect(refs.shell.hasAttribute('open')).toBe(true);
+
+    refs.overlaySurfaces.add('browser');
+    refs.shell.removeAttribute('open');
+    refs.dock.dispatchEvent(
+      new CustomEvent('slicc-dock-select', { bubbles: true, detail: { id: 'browser' } })
+    );
+    expect(refs.shell.hasAttribute('open')).toBe(false);
   });
 
   it('describes the tab switcher on the browser surface', () => {

--- a/packages/webapp/tests/ui/wc/wc-shell.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-shell.test.ts
@@ -234,11 +234,14 @@ describe('mountWcUiPreview', () => {
     expect(refs.shell.hasAttribute('open')).toBe(false);
   });
 
-  it('describes the tab switcher on the browser surface', () => {
+  // This pane is what a float WITHOUT the overlay shows, so its copy has to
+  // describe that fallback. It previously advertised the switcher and told the
+  // reader to click cards — unreachable copy before #1706, wrong copy after.
+  it('the browser surface describes the fallback, not the switcher it lacks', () => {
     const root = mount();
-    const surface = root.querySelector('[surface-id="browser"]');
-    expect(surface?.textContent).toContain('tab switcher');
-    expect(surface?.textContent).toContain('followers');
+    const text = root.querySelector('[surface-id="browser"]')?.textContent ?? '';
+    expect(text).toContain('runs on the leader');
+    expect(text).not.toMatch(/click a card/i);
   });
 
   it('hides the workbench header until sprinkle tabs exist (tool tabs never render)', () => {
@@ -291,7 +294,6 @@ describe('mountWcUiPreview', () => {
 
   it('switches the active surface on tab select (canonical detail field is id)', () => {
     const root = mount();
-    const header = root.querySelector('slicc-workbench-header') as HTMLElement;
     const body = root.querySelector('slicc-workbench-body') as HTMLElement;
     // Drive the REAL tab bar so the event carries the library's canonical
     // `{ id }` detail — a synthetic `{ tabId }` event would mask the


### PR DESCRIPTION
Fixes #1706.

Two halves of the same wrong assumption — that a follower has a local Chrome to drive. Both are invisible on a leader, which is why they survived four months.

## 1. The Browser dock item was inert on followers

`wireDockToWorkbench` hardcoded a skip for the browser surface:

```ts
// The Browser globe opens the FULL-SCREEN tab overlay (wc-browser.ts) —
// a workspace pane underneath it would just be dead chrome.
if (id === 'browser') return;
```

That helper is shared by every boot path. The overlay it defers to (`wireWcBrowserOverlay`) is wired only when `options.standalone` is set. So leaders traded a pane for an overlay; followers lost the pane and got nothing — an inert globe, no error, and a `slicc-surface[surface-id=browser]` that became permanently unreachable.

The suppression is now a **claim** rather than a hardcoded id:

```ts
// wc-shell.ts — read at click time; the overlay wiring runs after mountWcShell
if (overlaySurfaces.has(id)) return;

// wc-browser.ts — claimed as the overlay wires itself
refs.overlaySurfaces.add('browser');
```

Floats that never reach that wiring keep the pane placeholder, and a leader whose lazy `import('./wc-browser.js')` fails now degrades to the same fallback instead of a dead button — a hole the old code had too.

## 2. Hosted-tab followers dialed a `/cdp` that cannot exist

The advertisement gate was `isCherry && ui-only=1`, which describes cherry rather than the property that matters. A follower opened from a hosted `/join/…` link matches neither branch, so it polled `listPages()` every 5s against `getDefaultCdpUrl()` = `wss://<hosted-origin>/cdp` — a path the SPA fallback answers with HTML, so the upgrade can never succeed.

Measured on a live cone: **99 failed connections in 13 minutes**, no backoff ceiling, never gives up.

Replaced with a predicate keyed on the local CDP surface *existing*:

```ts
export function followerAdvertisesCdpTargets(isCherry: boolean, search: string): boolean {
  if (isCherry) return new URLSearchParams(search).get('ui-only') !== '1';
  return parseBridgeLaunchParams(search) !== null;
}
```

`StartPageFollowerTrayOptions.uiOnly` becomes `advertisesCdpTargets` so the option names what it gates — the old name is what let the drift happen. The cherry SDK's own `mountSlicc({ uiOnly })` option is a different thing and is untouched.

## Tests

Both fixes verified by mutation — reverting either implementation fails the new assertions:

| mutation | failing tests |
|---|---|
| restore `if (id === 'browser') return;` | 1 (`an UNCLAIMED browser dock item opens the workspace pane`) |
| restore `isCherry && ui-only=1` | 3 (hosted-tab mount + 2 predicate cases) |

One assertion worth calling out: the suppression test asserts `listPages` is **never called**, not merely that `advertiseTargets` isn't. The dialing loop was the actual user-visible bug, and an advertise-only assertion passes while it runs.

Also added: the omitted-flag default, a bridge-param-without-token case, and a claim-registered-after-mount case (the claim lands after `mountWcShell`, so the handler must read the set at click time).

## Verification

`npm run verify` · `check-touched-exemptions` · `typecheck` · `test` (12,439 passed) · `test:coverage` (floors pass) · `npm run build` · `npm run build -w @slicc/chrome-extension` — all green.

Live-checked the leader path against a local harness after the change: the globe still opens `Browser · open tabs` with all 3 tabs and no pane behind it.

**Not live-verified:** the follower half. The follower tab loads from the deployed `www.sliccy.ai`, so it can't exercise a local build — that half rests on the unit tests and the mutation check above. Worth a look on staging.

## Docs

`docs/review-patterns.md` category 8 gains the two trigger shapes this bug had (a fallback removed from a shared helper for a leader-only replacement; a gate keyed on a float name where a capability check belongs) plus the claim pattern as remediation. `.github/copilot-instructions.md` synced within its 4,000-char cap.

`packages/webapp/CLAUDE.md` was left alone deliberately — it sits at 19,954 of its 20,000-char limit, so there was no room. The detail lives in the code comments and in `review-patterns.md` instead.
