### PR TITLE
ci: freeze the debt lists, ratchet ceilings downward, and ledger the flakes

### DIFF
--- a/.agents/skills/verifying-before-push/SKILL.md
+++ b/.agents/skills/verifying-before-push/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: verifying-before-push
 description: |
-  Use when committing, pushing, opening or updating a PR, or when CI fails on lint, typecheck, build, or coverage. Covers the full verification pass (lint → typecheck → test → coverage → build), lint:ci strictness, the boy-scout complexity gate (check-touched-exemptions.mjs — not part of npm run lint, easy to miss locally), and coverage floors. Also triggered by CI error strings like 'check-touched-exemptions' failure, 'biome found errors', or 'below configured minimum coverage'.
+  Use when committing, pushing, opening or updating a PR, or when CI fails on lint, typecheck, build, or coverage. Covers the full verification pass (lint → typecheck → test → coverage → build), lint:ci strictness, the boy-scout debt-list gate (check-touched-exemptions.mjs — not part of npm run lint, easy to miss locally), the CI quarantine registry, and coverage floors. Also triggered by CI error strings like 'check-touched-exemptions' failure, 'check-ci-quarantine' failure, 'biome found errors', or 'below configured minimum coverage'.
 ---
 
 # verifying-before-push
@@ -22,6 +22,7 @@ npm run build
 npm run build -w @slicc/chrome-extension
 npm run bundle-size
 node packages/dev-tools/tools/check-touched-exemptions.mjs
+npm run lint:ci-quarantine
 ```
 
 Run `npm run verify` first because formatting is the most common CI failure. Do not omit the
@@ -50,6 +51,7 @@ Run every command in order:
 ```bash
 npm run verify                         # Lint gate (mirrors CI lint job)
 node packages/dev-tools/tools/check-touched-exemptions.mjs  # NOT in npm run verify — easy to miss
+npm run lint:ci-quarantine             # Also not in npm run verify
 npm run typecheck
 npm run test
 npm run test:coverage                  # Enforces minimum coverage thresholds
@@ -117,7 +119,7 @@ which builds both apps itself.
 Budgets are ratchets like the duplication threshold: tighten them as payloads shrink. Raising
 one needs a justification in the PR body.
 
-## Boy-scout complexity gate (`check-touched-exemptions.mjs`)
+## Boy-scout debt-list gate (`check-touched-exemptions.mjs`)
 
 Run this separate gate after lint:
 
@@ -127,6 +129,31 @@ node packages/dev-tools/tools/check-touched-exemptions.mjs
 
 CI's `lint` job runs this step **after** `lint:ci`. It is **not** part of `npm run lint`, so
 it is easy to miss locally.
+
+It covers every debt / exemption list in the repo, with **deliberately different semantics
+per list** (registry: [`packages/dev-tools/tools/debt-list-sources.mjs`](../../../packages/dev-tools/tools/debt-list-sources.mjs)):
+
+| List                                                               | Frozen (no growth) | Touched-file rule | On growth |
+| ------------------------------------------------------------------ | ------------------ | ----------------- | --------- |
+| `biome.json` complexity debt (function-size, cognitive-complexity) | yes                | **yes**           | fail      |
+| `biome.json` overrides that disable non-complexity rules           | yes                | no                | fail      |
+| `coverageExclude` in `coverage-thresholds.json`                    | yes                | no                | fail      |
+| `ignore` in `jscpd.json`                                           | yes                | no                | fail      |
+| `ignore` / `ignoreDependencies` / `ignoreBinaries` in `knip.json`  | reported           | no                | warn only |
+
+The touched-file rule applies **only** to the two complexity debt lists, because every entry
+there is a file that can actually be brought under the cap. The other lists legitimately
+contain permanent entries (generated files, `*.d.ts`, vendored code, fixtures), so touching a
+listed file is fine — growing the list is not. `knip.json` never fails: Renovate and new build
+tools legitimately add ignore entries.
+
+`coverageExclude` matters most: it is the **denominator** of the floors the nightly ratchet
+raises, so a new exclusion makes the reported percentage go up while real coverage goes down.
+
+Every list has the same bootstrapping exemption: entries in a scope the base ref does not
+have at all (a brand-new list, or a newly added package inside a per-package list) are being
+introduced rather than grown, and are ignored. If the base version of a config cannot be read
+at all, that list's growth check is skipped with a `notice —` line instead of failing.
 
 `biome.json` keeps two `overrides` "debt lists" of files that are grandfathered out of the
 complexity rules:
@@ -150,6 +177,29 @@ PR or avoid touching that file.
 
 To check whether a file is exempt, search `biome.json` for its path under the
 `noExcessiveCognitiveComplexity: "off"` / `noExcessiveLinesPerFunction: "off"` overrides.
+
+## CI quarantine registry (`lint:ci-quarantine`)
+
+```bash
+npm run lint:ci-quarantine
+```
+
+A `continue-on-error: true` step cannot fail its job, so every one of them is a hole in CI.
+[`ci-quarantine.json`](../../../ci-quarantine.json) declares each one with a `reason`, an
+`owner` (the package or area that owns paying it down) and a `reviewBy` date;
+[`packages/dev-tools/tools/check-ci-quarantine.mjs`](../../../packages/dev-tools/tools/check-ci-quarantine.mjs)
+enforces it in the CI `lint` job over the workflows listed in the registry's `workflows` key.
+
+- **Fails** on a `continue-on-error: true` step that is not declared, and on a malformed
+  registry entry (placeholder reason, missing owner, non-`YYYY-MM-DD` date). The failure output
+  prints a paste-ready JSON stub.
+- **Warns only** when an entry is past its `reviewBy`, and when an entry's step no longer
+  exists (delete the entry). A date-triggered hard failure would break unrelated PRs, which is
+  worse than the debt it flags.
+
+Adding a quarantine is therefore a deliberate, reviewable act. Removing one is always allowed —
+delete its registry entry in the same PR. Keys are `workflow` + `job` + `step` name, so
+renaming a step counts as a new quarantine.
 
 ## Coverage
 

--- a/.agents/skills/writing-slicc-tests/SKILL.md
+++ b/.agents/skills/writing-slicc-tests/SKILL.md
@@ -494,6 +494,30 @@ node -e "const r=require('./test-timing/vitest.json').testResults.flatMap(f=>f.a
 
 Reproduce it locally with `CI=1 npm run test`.
 
+### The Slow-Test Gate
+
+That report is gated, not just archived. `npm run test:timing -- <project>`
+(`packages/dev-tools/tools/test-timing-gate.mjs`) compares the project's **p95
+per-test duration** against `testTiming.<project>.p95Ms` in
+`coverage-thresholds.json`, and the `webapp`, `node-server` and
+`chrome-extension` CI jobs run it right after their coverage step.
+
+- **p95, not the slowest test.** p95 is an order statistic over hundreds of
+  tests, so one slow sample on a loaded runner cannot move it, while a genuine
+  distribution shift does. The slowest test is still printed for triage.
+- **Retried samples are excluded.** A retried test reports `status: "passed"`
+  with the failed attempt's message still in `failureMessages`, and its
+  `duration` is the _sum_ of all attempts (a 120 ms test that fails once
+  reports ~245 ms). Counting that would inflate the measurement, so
+  `summarizeTiming` drops it and reports the count instead.
+- **It skips, never fails, on missing plumbing.** No report, no project entry
+  or no durations → `[skip]` and exit 0.
+- **The ceiling only ever tightens.** The nightly ratchet
+  (`packages/dev-tools/tools/coverage-ratchet.mjs`) lowers it to 4x the
+  measured p95, rounded to 50 ms — loose on purpose, since it measures on macOS
+  while the gate runs on Linux. Never hand-raise it to make a slow suite pass;
+  make the suite faster (fake the timer, drop the sleep, share the fixture).
+
 ## Run Tests
 
 | Command                                                      | Purpose                                   |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,12 +164,20 @@ jobs:
       - uses: ./.github/actions/npm-ci
       - name: Lint (biome + prettier + CLAUDE.md sizes + tessl skill lint)
         run: npm run lint:ci
-      - name: Function-size + cognitive-complexity debt boy-scout gate
+      - name: Debt-list boy-scout gate (complexity, coverage-exclude, duplication)
         # Fail when this PR touches a file that is still on either of the
         # biome.json complexity debt lists (function-size or cognitive-
-        # complexity) without removing its override entry. Skips
-        # automatically on merge_group / push.
+        # complexity) without removing its override entry, or when it GROWS
+        # any frozen debt list: the biome non-complexity overrides,
+        # coverageExclude in coverage-thresholds.json, or jscpd.json ignore.
+        # knip ignores are reported only. Skips automatically on
+        # merge_group / push.
         run: node packages/dev-tools/tools/check-touched-exemptions.mjs
+      - name: CI quarantine registry gate
+        # Fail on a `continue-on-error: true` step that is not declared in
+        # ci-quarantine.json with a reason, an owner, and a review date.
+        # Past-review-date entries warn only.
+        run: npm run lint:ci-quarantine
       - name: Check Chrome Web Store manifest justifications
         # Fail if the extension manifest gains/drops a permission without a
         # matching reviewer justification in docs/chrome-web-store-submission.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,9 @@ jobs:
           name: test-timing-webapp
           path: test-timing/
           if-no-files-found: ignore
+      - name: Slow-test gate
+        if: always()
+        run: npm run test:timing -- webapp
       - name: Build
         run: npm run build -w @slicc/webapp
       - name: Check bundle for Node-only APIs
@@ -441,6 +444,9 @@ jobs:
           name: test-timing-node-server
           path: test-timing/
           if-no-files-found: ignore
+      - name: Slow-test gate
+        if: always()
+        run: npm run test:timing -- node-server
       - name: Build @slicc/shared-ts (runtime dependency)
         run: npm run build -w @slicc/shared-ts
       - name: Build
@@ -482,6 +488,9 @@ jobs:
           name: test-timing-chrome-extension
           path: test-timing/
           if-no-files-found: ignore
+      - name: Slow-test gate
+        if: always()
+        run: npm run test:timing -- chrome-extension
       - name: Build webapp (dependency)
         run: npm run build -w @slicc/webapp
       - name: Build extension

--- a/.github/workflows/coverage-ratchet.yml
+++ b/.github/workflows/coverage-ratchet.yml
@@ -29,11 +29,22 @@ jobs:
           node-version: 24
           cache: npm
 
+      # The Go floor (coverage-thresholds.json `go`) is measured with the same
+      # `make cover` path the slicc-cli job gates with.
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: packages/slicc-cli/go.mod
+          cache-dependency-path: packages/slicc-cli/go.sum
+
       - run: npm ci
 
-      # Dependencies the Swift coverage builds need (mirrors ci.yml).
-      - name: Build webapp (Swift launcher dependency)
+      # Dependencies the Swift coverage builds need (mirrors ci.yml). The
+      # webapp + extension builds double as the artifacts the size-limit
+      # ceilings are measured against; without them that measurement skips.
+      - name: Build webapp (Swift launcher dependency, size-limit input)
         run: npm run build -w @slicc/webapp
+      - name: Build extension (size-limit input)
+        run: npm run build -w @slicc/chrome-extension
       - name: Build swift-server (Swift launcher dependency)
         run: cd packages/swift-server && swift build -c release
       # ios-app is measured via `xcodebuild test` on a simulator, which needs the
@@ -49,13 +60,17 @@ jobs:
       - name: Install Chromium (browser-mode coverage)
         run: npx playwright install chromium
 
-      - name: Run coverage ratchet
+      # One pass measures everything: coverage floors (TypeScript, Swift, Go),
+      # the jscpd duplication ceiling, the size-limit byte ceilings and the
+      # per-test duration ceilings (the last come out of the same vitest runs
+      # the coverage measurement already pays for).
+      - name: Run coverage and ceiling ratchet
         id: ratchet
         env:
           GH_TOKEN: ${{ github.token }}
         run: node packages/dev-tools/tools/coverage-ratchet.mjs --github-output
 
-      - name: Commit raised floors
+      - name: Commit ratcheted budgets
         if: steps.ratchet.outputs.changed == 'true'
         env:
           RATCHET_BRANCH: automation/coverage-ratchet
@@ -64,8 +79,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -C "$RATCHET_BRANCH"
-          git add coverage-thresholds.json
-          git commit -m "chore(coverage): ratchet floors toward measured coverage"
+          git add coverage-thresholds.json jscpd.json \
+            packages/webapp/package.json packages/chrome-extension/package.json
+          git commit -m "chore(coverage): ratchet floors and ceilings toward measured reality"
           git push --force-with-lease origin "$RATCHET_BRANCH"
 
       - name: Create or update ratchet PR
@@ -88,6 +104,6 @@ jobs:
             gh pr create \
               --base main \
               --head "$RATCHET_BRANCH" \
-              --title "chore(coverage): ratchet coverage floors" \
-              --body "Automated nightly bump of \`coverage-thresholds.json\` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed."
+              --title "chore(coverage): ratchet coverage floors and budget ceilings" \
+              --body "Automated nightly move of every gated budget toward measured reality: coverage floors in \`coverage-thresholds.json\` rise (>=1pp steps, <1% headroom), while the duplication ceiling in \`jscpd.json\`, the \`size-limit\` budgets in \`packages/webapp/package.json\` / \`packages/chrome-extension/package.json\` and the per-test duration ceilings in \`coverage-thresholds.json\` (\`testTiming\`) fall. Floors never drop, ceilings never rise, and no PR is opened when nothing changed."
           fi

--- a/.github/workflows/flake-ledger.yml
+++ b/.github/workflows/flake-ledger.yml
@@ -1,0 +1,82 @@
+name: Flake Ledger
+
+# Nightly flake ledger. `vitest.config.ts` retries the `node-server` and
+# `chrome-extension` projects once in CI, which means a test can fail attempt 1,
+# pass attempt 2, and leave the build green and silent. This workflow reads that
+# back out of the `test-timing-*` artifacts CI already uploads and files ONE
+# GitHub issue per flaky test, labelled `debt:flake` — the same `debt:*` family
+# the nightly agentic-debt triage uses.
+#
+# Why nightly rather than per-run (`workflow_run`): a flake is only worth
+# prioritising by frequency, and frequency needs a window. One nightly pass over
+# the last day of runs reports "retried in N of M runs" and updates a single
+# issue; a per-run trigger would comment on every occurrence, could not count
+# anything, and would fire on runs whose artifacts are not yet complete.
+#
+# This never fails a build: the sweep runs here, not in ci.yml, and only writes
+# issues. A retry is a debt marker, not a fix — see docs/operational-telemetry.md.
+#
+# No secrets beyond the automatic GITHUB_TOKEN. `actions: read` is what lets
+# `gh run download` reach the artifacts.
+
+on:
+  schedule:
+    - cron: '17 4 * * *' # nightly at 04:17 UTC (between RUM triage 03:00 and agentic-debt 05:33)
+  workflow_dispatch:
+    inputs:
+      since_days:
+        description: 'Look-back window in days'
+        required: false
+        default: '1'
+      dry_run:
+        description: 'Report only; do not file or update issues'
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: flake-ledger
+  cancel-in-progress: false
+
+permissions:
+  contents: read # checkout only
+  issues: write # file / update the flake issue
+  actions: read # gh run download of the test-timing-* artifacts
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      # Third-party actions are pinned to immutable commit SHAs (matching
+      # .github/workflows/agentic-debt-triage.yml).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 24
+
+      - name: Ensure the flake label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "debt:flake" --color 5319e7 \
+            --description "Agentic-debt: test passed only on retry (flake ledger)" --force
+
+      # The sweep needs no dependencies — plain Node ESM plus the `gh` CLI that
+      # is preinstalled on the runner.
+      - name: Sweep CI artifacts for retried tests
+        id: sweep
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SINCE_DAYS: ${{ github.event.inputs.since_days || '1' }}
+          FLAKE_DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '' }}
+        run: node packages/dev-tools/flake-ledger/sweep-flakes.mjs
+
+      - name: Upload the ledger
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: flake-ledger
+          path: flake-ledger.json
+          if-no-files-found: ignore

--- a/ci-quarantine.json
+++ b/ci-quarantine.json
@@ -1,0 +1,78 @@
+{
+  "$comment": "Registry of every intentional `continue-on-error: true` step in the workflows listed under `workflows`. A quarantined step cannot fail its job, so each one is a hole in CI and must be declared here with a reason, an owning package/area, and a `reviewBy` date. Enforced by packages/dev-tools/tools/check-ci-quarantine.mjs (`npm run lint:ci-quarantine`): an undeclared quarantine FAILS; a quarantine past its `reviewBy`, or a registry entry whose step no longer exists, only WARNS — a date-triggered hard failure would break unrelated PRs, which is worse than the debt it flags. Deleting a quarantine from the workflow is always allowed; delete its entry here in the same PR.",
+  "workflows": [".github/workflows/ci.yml"],
+  "quarantines": [
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "chrome-extension",
+      "step": "Extension smoke test (CDP)",
+      "reason": "Explicitly temporary: the headed-Chrome MV3 side-panel smoke test is permitted to fail loudly while the ffmpeg-core.js bundling work lands. Keeps CI green during that rollout while still uploading the failure artifact. This is the one entry here that is a genuine broken-test quarantine rather than a structural one.",
+      "owner": "chrome-extension",
+      "reviewBy": "2026-09-30"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "cloudflare-worker",
+      "step": "Emit test timing report",
+      "reason": "Observability only: a second vitest run purely to emit a junit timing report (the coverage gate step builds its own argv and forwards no reporter flags). Runs with `if: always()`, including after a failed suite, so it must never be able to turn a red run redder or a green run red.",
+      "owner": "cloudflare-worker",
+      "reviewBy": "2027-07-31"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "cloudflare-worker",
+      "step": "Deploy staging worker (attempt 1)",
+      "reason": "Rung 1 of a 3-attempt staging-deploy retry ladder for the flaky wrangler pending-version race. Individual attempts must not fail the job; the later `Finalize staging deploy` step hard-fails when all three attempts failed, so the deploy itself stays gated.",
+      "owner": "cloudflare-worker",
+      "reviewBy": "2027-01-31"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "cloudflare-worker",
+      "step": "Upload staging secrets (attempt 1)",
+      "reason": "Second half of retry rung 1: `wrangler secret bulk` only succeeds once the latest version is deployed, so it is run as a separate attempt. Gated by `Finalize staging deploy`, which requires both halves of some rung to have succeeded.",
+      "owner": "cloudflare-worker",
+      "reviewBy": "2027-01-31"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "cloudflare-worker",
+      "step": "Deploy staging worker (attempt 2)",
+      "reason": "Rung 2 of the staging-deploy retry ladder; same rationale as attempt 1, gated by `Finalize staging deploy`.",
+      "owner": "cloudflare-worker",
+      "reviewBy": "2027-01-31"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "cloudflare-worker",
+      "step": "Upload staging secrets (attempt 2)",
+      "reason": "Rung 2 secrets upload; same rationale as attempt 1, gated by `Finalize staging deploy`.",
+      "owner": "cloudflare-worker",
+      "reviewBy": "2027-01-31"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "cloudflare-worker",
+      "step": "Deploy staging worker (attempt 3)",
+      "reason": "Final rung of the staging-deploy retry ladder; same rationale as attempt 1, gated by `Finalize staging deploy`.",
+      "owner": "cloudflare-worker",
+      "reviewBy": "2027-01-31"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "cloudflare-worker",
+      "step": "Upload staging secrets (attempt 3)",
+      "reason": "Final rung secrets upload; same rationale as attempt 1, gated by `Finalize staging deploy`.",
+      "owner": "cloudflare-worker",
+      "reviewBy": "2027-01-31"
+    },
+    {
+      "workflow": ".github/workflows/ci.yml",
+      "job": "cloudflare-worker",
+      "step": "Deploy staging preview worker",
+      "reason": "Best-effort deploy of the secret-less, asset-less preview worker after the main worker. Unlike the retry ladder above this one has NO finalize gate, so a failed staging preview-worker deploy really does leave the job green — the preview bridge can silently rot on staging. Fixing that (a finalize/verify step, or dropping continue-on-error) is the intended follow-up.",
+      "owner": "cloudflare-worker",
+      "reviewBy": "2026-12-31"
+    }
+  ]
+}

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Single source of truth for per-package coverage floors. Edited automatically by the nightly coverage ratchet (packages/dev-tools/tools/coverage-ratchet.mjs), which only ever raises floors and keeps a ~0.5-1.5pp headroom below measured coverage (a half-point safety margin then floored to a whole percentage). Consumed by the CI gates via coverage-gate.mjs (TypeScript), swift-coverage-check.sh (Swift) and the COVER_MIN floor in packages/slicc-cli/Makefile (Go). Do not hand-lower these values.",
+  "$comment": "Single source of truth for per-package coverage floors. Edited automatically by the nightly coverage ratchet (packages/dev-tools/tools/coverage-ratchet.mjs), which only ever raises floors and keeps a ~0.5-1.5pp headroom below measured coverage (a half-point safety margin then floored to a whole percentage). Consumed by the CI gates via coverage-gate.mjs (TypeScript), swift-coverage-check.sh (Swift) and the COVER_MIN floor in packages/slicc-cli/Makefile (Go). Do not hand-lower these values. The `testTiming` section is the one *ceiling* in this file: a per-vitest-project p95 per-test duration in milliseconds, gated by test-timing-gate.mjs and only ever tightened by the same nightly ratchet (4x the measured p95, rounded to 50 ms, because the ratchet measures on macOS while the gate runs on Linux). Do not hand-raise those.",
   "typescript": {
     "cloudflare-worker": {
       "lines": 86,
@@ -153,6 +153,17 @@
   "go": {
     "slicc-cli": {
       "statements": 58
+    }
+  },
+  "testTiming": {
+    "webapp": {
+      "p95Ms": 250
+    },
+    "node-server": {
+      "p95Ms": 150
+    },
+    "chrome-extension": {
+      "p95Ms": 250
     }
   }
 }

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Single source of truth for per-package coverage floors. Edited automatically by the nightly coverage ratchet (packages/dev-tools/tools/coverage-ratchet.mjs), which only ever raises floors and keeps a ~0.5-1.5pp headroom below measured coverage (a half-point safety margin then floored to a whole percentage). Consumed by the CI gates via coverage-gate.mjs (TypeScript) and swift-coverage-check.sh (Swift). Do not hand-lower these values.",
+  "$comment": "Single source of truth for per-package coverage floors. Edited automatically by the nightly coverage ratchet (packages/dev-tools/tools/coverage-ratchet.mjs), which only ever raises floors and keeps a ~0.5-1.5pp headroom below measured coverage (a half-point safety margin then floored to a whole percentage). Consumed by the CI gates via coverage-gate.mjs (TypeScript), swift-coverage-check.sh (Swift) and the COVER_MIN floor in packages/slicc-cli/Makefile (Go). Do not hand-lower these values.",
   "typescript": {
     "cloudflare-worker": {
       "lines": 86,
@@ -148,6 +148,11 @@
       "lines": 13,
       "functions": 11,
       "regions": 14
+    }
+  },
+  "go": {
+    "slicc-cli": {
+      "statements": 58
     }
   }
 }

--- a/docs/operational-telemetry.md
+++ b/docs/operational-telemetry.md
@@ -242,6 +242,56 @@ Once checkpoints are flowing in production, verify in the RUM dashboard (`rum.hl
 - Source/target fields contain only expected sanitized values.
 - No unexpected PII appears in any field.
 
+## CI Flake Ledger
+
+Everything above is production telemetry. CI has its own hidden-signal problem, and the flake ledger is the answer to it.
+
+`vitest.config.ts` gives the `node-server` and `chrome-extension` projects `retry: 1` in CI (deliberately not `webapp`, whose ~10k in-process tests would hide real nondeterminism behind retries). That retry absorbs a genuine infrastructure hiccup — and it also means a test can fail attempt 1, pass attempt 2, and leave the build **green and completely silent**. Without a ledger, flake tolerance goes up while flake visibility goes down.
+
+### Standing policy: a retry is a debt marker, not a fix
+
+1. **Every retried pass is recorded.** The build stays green; a `debt:flake` issue carries the paper trail.
+2. **The ledger never fails a build.** It runs in `.github/workflows/flake-ledger.yml`, not in `.github/workflows/ci.yml`. A gate that reddens the build on every flake is just the retry removed.
+3. **Adding a retry does not close a flake issue.** The issue closes when the nondeterminism is fixed — a real wait condition instead of a sleep, an isolated port, a deterministic clock. Raising `retry` above 1, or extending it to another project, is a decision to stop looking.
+4. **Frequency decides priority.** Issues report "retried in N of M runs"; fix the one that fires most.
+
+### How a retried test appears in vitest 4.1.10
+
+vitest's built-in `json` reporter has **no** retry field — `assertionResults` entries carry only `ancestorTitles`, `fullName`, `status`, `title`, `duration`, `failureMessages`, `location`, `meta`, `tags`. The retry evidence survives indirectly: vitest accumulates every attempt's errors on `task.result.errors` and reports only the final state, so a test that passed on retry is a `passed` assertion **with a non-empty `failureMessages`**:
+
+```json
+{
+  "fullName": "flake probe passes only on the second attempt",
+  "status": "passed",
+  "failureMessages": ["AssertionError: probe attempt 1 is deliberately failing"]
+}
+```
+
+A test that failed _every_ attempt is `"status": "failed"` with one message per attempt — a genuine failure, and the ledger ignores it. A clean pass and an `it.fails` expected failure both carry an empty `failureMessages`, so neither is a false positive.
+
+For exact counts, `packages/dev-tools/flake-ledger/flake-reporter.mjs` reads `TestCase.diagnostic().retryCount` from vitest's reporter API and writes `test-timing/flakes.json` (already covered by the `test-timing-*` artifact upload). It is optional and not currently wired into `reporters`; see the package README for the one-line change.
+
+### Where flake issues appear and how to read them
+
+Nightly at 04:17 UTC, `.github/workflows/flake-ledger.yml` sweeps the last day of completed `ci.yml` runs, downloads their `test-timing-*` artifacts, and files GitHub issues labelled **`debt:flake`** — the same `debt:*` family the nightly agentic-debt triage uses. Nightly rather than per-run because frequency needs a window: one pass can say "retried in 3 of 40 runs", a per-run trigger cannot.
+
+An issue titled `flake: [chrome-extension] <full test name>` gives you:
+
+- **File** and **Test** — where it lives, and the reproduction command (run the whole project, not the single test; these flakes usually need full-suite parallelism).
+- **Attempts before passing** — 2 means one retry saved it.
+- **Retried runs observed** — the frequency figure. This is the prioritisation number.
+- **Signal source** — `vitest-json` (inferred, attempt count is a lower bound) or `flake-reporter` (exact).
+- **Failure from the losing attempt** — the actual error the green build swallowed.
+- A hidden `flake-fp:<fingerprint>` marker. Recurrences comment on the same issue (reopening it if closed) rather than opening a new one, so the issue count tracks distinct flaky tests, not nights elapsed.
+
+Run it by hand against a wider window (reports only, files nothing):
+
+```bash
+FLAKE_DRY_RUN=1 SINCE_DAYS=7 npm run flake:ledger
+```
+
+Details, env vars, and the artifact shapes: `packages/dev-tools/flake-ledger/README.md`.
+
 ## Deploy-Impact Signals by Application
 
 Everything above covers the three floats that load `packages/webapp/src/ui/telemetry.ts`.

--- a/jscpd.json
+++ b/jscpd.json
@@ -1,10 +1,10 @@
 {
-  "$comment": "Copy/paste-detection floor for every application package, consumed by `npm run lint:duplication` (chained into `lint` and `lint:ci`). `threshold` is the maximum total duplicated-line percentage across all scanned formats; the measured baseline is 7.08%, so the floor keeps ~0.4pp of headroom in the same spirit as coverage-thresholds.json. Treat it as a one-way ratchet: lower it as duplication is paid down (the nightly `debt:duplication` triage rotation in .github/workflows/agentic-debt-triage.yml is the intended driver), never raise it to turn a red run green. jscpd's config parser rejects JSONC comments and prints a harmless `unknown field '$comment'` warning for this key — that warning is the price of documenting the floor here, do not silence it by deleting the key.",
+  "$comment": "Copy/paste-detection ceiling for every application package, consumed by `npm run lint:duplication` (chained into `lint` and `lint:ci`). `threshold` is the maximum total duplicated-line percentage across all scanned formats; it keeps 0.3-0.4pp of headroom above the measured baseline, in the same spirit as coverage-thresholds.json. It is a one-way ratchet — only ever tightened, never raised to turn a red run green — and the nightly coverage ratchet (`packages/dev-tools/tools/coverage-ratchet.mjs`, nextDuplicationThreshold) now lowers it automatically as duplication is paid down by the `debt:duplication` triage rotation in .github/workflows/agentic-debt-triage.yml. jscpd's config parser rejects JSONC comments and prints a harmless `unknown field '$comment'` warning for this key — that warning is the price of documenting the budget here, do not silence it by deleting the key.",
   "path": ["packages"],
   "format": ["typescript", "tsx", "javascript", "jsx", "swift", "go"],
   "minTokens": 50,
   "minLines": 5,
-  "threshold": 7.5,
+  "threshold": 7.4,
   "reporters": ["silent", "threshold"],
   "absolute": false,
   "ignore": [

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "prepare": "husky",
     "lint:no-raw-chrome-runtime-id": "node packages/dev-tools/tools/check-no-raw-chrome-runtime-id.mjs",
     "lint:hosted-origin": "node packages/dev-tools/tools/check-hosted-origin-literal.mjs",
+    "lint:ci-quarantine": "node packages/dev-tools/tools/check-ci-quarantine.mjs",
     "verify": "bash packages/dev-tools/tools/pre-push-lint-gate.sh"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test:coverage:webcomponents": "npm run test:coverage -w @slicc/webcomponents",
     "test:coverage:spoon": "npm run test:coverage -w @ai-ecoverse/spoon",
     "coverage:ratchet": "node packages/dev-tools/tools/coverage-ratchet.mjs",
+    "test:timing": "node packages/dev-tools/tools/test-timing-gate.mjs",
     "bundle-size": "npm run size -w @slicc/webapp && npm run size -w @slicc/chrome-extension",
     "test:server-integration": "vitest run --config packages/node-server/tests/integration/server/vitest.config.ts",
     "test:e2e": "npx playwright test --config packages/webapp/tests/e2e/playwright.config.ts",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "test:coverage:spoon": "npm run test:coverage -w @ai-ecoverse/spoon",
     "coverage:ratchet": "node packages/dev-tools/tools/coverage-ratchet.mjs",
     "test:timing": "node packages/dev-tools/tools/test-timing-gate.mjs",
+    "flake:ledger": "node packages/dev-tools/flake-ledger/sweep-flakes.mjs",
     "bundle-size": "npm run size -w @slicc/webapp && npm run size -w @slicc/chrome-extension",
     "test:server-integration": "vitest run --config packages/node-server/tests/integration/server/vitest.config.ts",
     "test:e2e": "npx playwright test --config packages/webapp/tests/e2e/playwright.config.ts",

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -16,19 +16,19 @@
       "name": "extension: service worker",
       "path": "../../dist/extension/service-worker.js",
       "brotli": false,
-      "limit": "60 kB"
+      "limit": "59 kB"
     },
     {
       "name": "extension: side panel entry",
       "path": "../../dist/extension/sidepanel.js",
       "brotli": false,
-      "limit": "14 kB"
+      "limit": "13 kB"
     },
     {
       "name": "extension: total JS payload",
       "path": "../../dist/extension/**/*.js",
       "brotli": false,
-      "limit": "105 kB"
+      "limit": "101 kB"
     }
   ],
   "dependencies": {

--- a/packages/dev-tools/flake-ledger/README.md
+++ b/packages/dev-tools/flake-ledger/README.md
@@ -1,0 +1,55 @@
+# Flake ledger
+
+Surfaces tests that **failed and then passed on retry** in CI, so a retry leaves a paper trail instead of a green build and silence.
+
+`vitest.config.ts` gives the `node-server` and `chrome-extension` projects `retry: 1` in CI. That absorbs a single infrastructure hiccup — and it also hides genuine nondeterminism, because vitest reports only the final state of a test. The ledger reads it back out of the test-timing artifacts CI already uploads and files one GitHub issue per flaky test.
+
+## How a retried test appears in vitest 4.1.10
+
+vitest's built-in `json` reporter has **no** retry field: `assertionResults` entries carry only `ancestorTitles`, `fullName`, `status`, `title`, `duration`, `failureMessages`, `location`, `meta`, and `tags`.
+
+The retry evidence survives anyway. vitest appends every attempt's errors to `task.result.errors` and reports only the last state, so a retried pass is a `passed` assertion **with a non-empty `failureMessages` array**:
+
+```json
+{
+  "fullName": "flake probe passes only on the second attempt",
+  "status": "passed",
+  "failureMessages": [
+    "AssertionError: probe attempt 1 is deliberately failing: expected 1 to be greater than 1"
+  ]
+}
+```
+
+A test that failed _every_ attempt is `"status": "failed"` with one message per attempt — a real failure, not a flake. A clean pass and an `it.fails` expected failure both carry an empty `failureMessages`, so neither is a false positive. (Verified empirically with a probe test under `--retry=1`.)
+
+`flake-reporter.mjs` is an optional precision upgrade: vitest's reporter API _does_ expose the real number via `TestCase.diagnostic().retryCount`, so the reporter writes an exact `test-timing/flakes.json`. It is not wired into `vitest.config.ts` — the ledger works without it. To enable:
+
+```ts
+reporters: isCI
+  ? ['default', 'json', './packages/dev-tools/flake-ledger/flake-reporter.mjs']
+  : ['default'],
+```
+
+Note that `diagnostic().flaky` is `true` for every `it.fails` test (vitest retries the throwing body, then flips the state to pass), which is why the reporter skips `options.fails`.
+
+## Layout
+
+| File                 | Role                                                                                 |
+| -------------------- | ------------------------------------------------------------------------------------ |
+| `lib.mjs`            | Pure logic: parsing both artifact shapes, aggregation, fingerprints, issue rendering |
+| `lib.test.mjs`       | Unit tests (`vitest run --project dev-tools`)                                        |
+| `flake-reporter.mjs` | Optional vitest reporter recording the exact `retryCount`                            |
+| `sweep-flakes.mjs`   | Orchestrator: downloads artifacts with `gh`, files/updates issues                    |
+
+## Running the sweep locally
+
+```bash
+# dry run against the last day of CI runs on main — prints, files nothing
+FLAKE_DRY_RUN=1 node packages/dev-tools/flake-ledger/sweep-flakes.mjs
+```
+
+Env: `SINCE_DAYS` (default 1), `RUN_LIMIT` (default 40), `WORKFLOW` (default `ci.yml`), `BRANCH` (default `main`), `FLAKE_LABEL` (default `debt:flake`), `FLAKE_DRY_RUN`, `OUTPUT_PATH`.
+
+## Why it never fails a build
+
+A flake ledger that turns every flake red is just the retry removed. The sweep runs in its own nightly workflow, not in `ci.yml`, and only ever writes issues. Policy: see `docs/operational-telemetry.md`.

--- a/packages/dev-tools/flake-ledger/flake-reporter.mjs
+++ b/packages/dev-tools/flake-ledger/flake-reporter.mjs
@@ -1,0 +1,68 @@
+/*
+ * Vitest reporter that records retried-but-passed tests exactly.
+ *
+ * vitest's built-in `json` reporter has no retry field; the ledger can only
+ * infer a retry from residual `failureMessages` on a passed test (see
+ * `lib.mjs`). The reporter API does expose the real number:
+ * `TestCase.diagnostic()` returns `{ retryCount, flaky }`. This reporter writes
+ * that into `test-timing/flakes.json`, which CI already uploads as part of the
+ * `test-timing-*` artifacts.
+ *
+ * Optional — the ledger works without it. Wire it up by adding it to
+ * `reporters` in `vitest.config.ts`:
+ *
+ *   reporters: isCI
+ *     ? ['default', 'json', './packages/dev-tools/flake-ledger/flake-reporter.mjs']
+ *     : ['default'],
+ *
+ * Env:
+ *   FLAKE_LEDGER_OUTPUT  output path (default test-timing/flakes.json)
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { LEDGER_KIND, toRepoRelativePath } from './lib.mjs';
+
+const DEFAULT_OUTPUT = 'test-timing/flakes.json';
+
+export default class FlakeReporter {
+  onInit(ctx) {
+    this.ctx = ctx;
+  }
+
+  onTestRunEnd(testModules) {
+    const flakes = [];
+    for (const module of testModules ?? []) {
+      for (const test of module.children?.allTests?.() ?? []) {
+        const diagnostic = test.diagnostic?.();
+        if (!diagnostic?.flaky) continue;
+        // vitest retries an `it.fails` test (its body throws by design) and
+        // then flips the final state to pass, so `diagnostic.flaky` is true for
+        // every expected failure. Those are not flakes.
+        if (test.options?.fails) continue;
+        const errors = test.result?.().errors ?? [];
+        flakes.push({
+          project: module.project?.name ?? 'unknown',
+          file: toRepoRelativePath(module.moduleId),
+          testName: test.fullName,
+          line: test.task?.location?.line,
+          retryCount: diagnostic.retryCount,
+          failureMessage: errors[0]?.message ?? errors[0]?.stack ?? '',
+        });
+      }
+    }
+
+    const payload = {
+      kind: LEDGER_KIND,
+      version: 1,
+      generatedAt: new Date().toISOString(),
+      flakes,
+    };
+    const root = this.ctx?.config?.root ?? process.cwd();
+    const output = resolve(root, process.env.FLAKE_LEDGER_OUTPUT || DEFAULT_OUTPUT);
+    mkdirSync(dirname(output), { recursive: true });
+    writeFileSync(output, `${JSON.stringify(payload, null, 2)}\n`, 'utf-8');
+    if (flakes.length > 0) {
+      console.log(`\n⚠️  ${flakes.length} test(s) passed only on retry — flake ledger: ${output}`);
+    }
+  }
+}

--- a/packages/dev-tools/flake-ledger/lib.mjs
+++ b/packages/dev-tools/flake-ledger/lib.mjs
@@ -1,0 +1,351 @@
+/*
+ * Flake ledger — pure logic.
+ *
+ * CI retries `node-server` and `chrome-extension` once (see `vitest.config.ts`).
+ * A test that fails attempt 1 and passes attempt 2 leaves the build green and
+ * says nothing, so this module reconstructs those retries from the test-timing
+ * artifacts and turns them into a deduplicated list of flaky tests.
+ *
+ * Two input shapes are supported:
+ *
+ *  1. `vitest.json` — vitest's built-in `json` reporter. It has NO retry field.
+ *     The retry evidence survives indirectly: vitest accumulates every
+ *     attempt's errors on `task.result.errors` and only the FINAL state is
+ *     reported, so a test that passed on retry appears as
+ *     `status: "passed"` with a non-empty `failureMessages` array. Verified
+ *     empirically against vitest 4.1.10 (`it.fails` does not produce this
+ *     shape, so expected failures are not false positives).
+ *  2. `flakes.json` — the ledger's own reporter (`flake-reporter.mjs`), which
+ *     reads `TestCase.diagnostic().retryCount` and is exact.
+ *
+ * It is intentionally free of I/O so it can be unit-tested in isolation; the
+ * `gh` calls live in `sweep-flakes.mjs`.
+ */
+import { createHash } from 'node:crypto';
+
+/** `kind` marker written by `flake-reporter.mjs`. */
+export const LEDGER_KIND = 'slicc-flake-ledger';
+
+/** Label used for filing and deduplicating flake issues. */
+export const FLAKE_LABEL = 'debt:flake';
+
+/** Marker embedded in issue bodies so later sweeps recognise a filed flake. */
+const FP_MARKER = /flake-fp:\s*([0-9a-f]{6,64})/gi;
+
+/**
+ * Normalize an absolute test path to a repo-relative one. Artifacts are
+ * produced on a CI runner, so the absolute prefix differs from any local
+ * checkout and must not leak into fingerprints.
+ * @param {string|null|undefined} file
+ * @returns {string}
+ */
+export function toRepoRelativePath(file) {
+  const p = String(file ?? '').replace(/\\/g, '/');
+  const idx = p.lastIndexOf('/packages/');
+  if (idx !== -1) return p.slice(idx + 1);
+  if (p.startsWith('packages/')) return p;
+  return p.replace(/^\/+/, '');
+}
+
+/**
+ * Best-effort vitest project name for a test file. Mirrors the project names
+ * in `vitest.config.ts`, where `packages/shared-ts` is the `shared` project.
+ * @param {string} file repo-relative or absolute test path
+ * @returns {string}
+ */
+export function inferProject(file) {
+  const rel = toRepoRelativePath(file);
+  const m = /^packages\/([^/]+)\//.exec(rel);
+  if (!m) return 'unknown';
+  return m[1] === 'shared-ts' ? 'shared' : m[1];
+}
+
+/**
+ * Canonical form of a full test name. The two input shapes spell the same test
+ * differently — `flake-reporter.mjs` joins suites with ` > ` while vitest's
+ * `json` reporter joins them with a plain space — so both must collapse to one
+ * key or the same flake would be filed twice.
+ * @param {string|null|undefined} testName
+ * @returns {string}
+ */
+export function normalizeTestName(testName) {
+  return String(testName ?? '')
+    .replace(/\s*>\s*/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Stable fingerprint for a flaky test. Keyed on project + repo-relative file +
+ * canonical test name, so the same flake groups across runs and CI jobs.
+ * @param {{project?: string, file?: string, testName?: string}} flake
+ * @returns {string} 12-hex-char fingerprint
+ */
+export function fingerprint(flake) {
+  const key = [
+    flake?.project ?? 'unknown',
+    toRepoRelativePath(flake?.file),
+    normalizeTestName(flake?.testName),
+  ].join('\u0000');
+  return createHash('sha256').update(key).digest('hex').slice(0, 12);
+}
+
+/** First meaningful line of a failure message, trimmed to a readable length. */
+function firstLine(message, max = 300) {
+  const line = String(message ?? '')
+    .split('\n')
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  return line ? line.slice(0, max) : '';
+}
+
+function normalizeRecord(raw) {
+  const file = toRepoRelativePath(raw.file);
+  const record = {
+    project: raw.project || inferProject(file),
+    file,
+    testName: String(raw.testName ?? '').trim(),
+    attempts: Math.max(2, Number(raw.attempts) || 0),
+    failureMessage: firstLine(raw.failureMessage),
+    source: raw.source,
+  };
+  return { ...record, fingerprint: fingerprint(record) };
+}
+
+/**
+ * Extract flakes from vitest's built-in `json` reporter output.
+ *
+ * A flake is a test whose FINAL status is `passed` but which still carries
+ * failure messages from an earlier attempt. A test that failed every attempt
+ * has status `failed` and is a genuine failure, not a flake — it is skipped.
+ * @param {any} report parsed `vitest.json`
+ * @param {{project?: string}} [opts] project override (e.g. from the artifact name)
+ * @returns {Array<object>} normalized flake records
+ */
+export function extractFlakesFromVitestJson(report, opts = {}) {
+  const out = [];
+  for (const file of report?.testResults ?? []) {
+    for (const assertion of file?.assertionResults ?? []) {
+      if (assertion?.status !== 'passed') continue;
+      const messages = Array.isArray(assertion.failureMessages) ? assertion.failureMessages : [];
+      if (messages.length === 0) continue;
+      out.push(
+        normalizeRecord({
+          project: opts.project,
+          file: file?.name,
+          testName: assertion.fullName || assertion.title,
+          // Each failed attempt contributes at least one error, so this is a
+          // lower bound on the real attempt count, never an over-count.
+          attempts: messages.length + 1,
+          failureMessage: messages[0],
+          source: 'vitest-json',
+        })
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * Extract flakes from `flake-reporter.mjs` output, which carries the exact
+ * `retryCount` from vitest's reporter API.
+ * @param {any} report parsed `flakes.json`
+ * @returns {Array<object>} normalized flake records
+ */
+export function extractFlakesFromLedger(report) {
+  return (report?.flakes ?? []).map((f) =>
+    normalizeRecord({
+      project: f?.project,
+      file: f?.file,
+      testName: f?.testName,
+      attempts: (Number(f?.retryCount) || 0) + 1,
+      failureMessage: f?.failureMessage,
+      source: 'flake-reporter',
+    })
+  );
+}
+
+/**
+ * Parse one artifact payload into flake records, dispatching on its shape.
+ * Returns `[]` for missing, empty, or unparseable input rather than throwing —
+ * a sweep over dozens of CI artifacts must survive a truncated upload.
+ * @param {string|null|undefined} text raw file contents
+ * @param {{project?: string}} [opts]
+ * @returns {Array<object>}
+ */
+export function parseReport(text, opts = {}) {
+  if (typeof text !== 'string' || text.trim() === '') return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  if (parsed?.kind === LEDGER_KIND) return extractFlakesFromLedger(parsed);
+  if (Array.isArray(parsed?.testResults)) return extractFlakesFromVitestJson(parsed, opts);
+  return [];
+}
+
+/** Fold one further sighting of a known flake into its aggregate entry. */
+function mergeFlake(existing, record, runId) {
+  // One CI run can emit both artifact shapes for the same retry; count the
+  // event once so `occurrences` stays a count of retried runs.
+  const sameRun = runId !== null && existing.runIds.includes(runId);
+  if (!sameRun) {
+    existing.occurrences += 1;
+    if (runId) existing.runIds.push(runId);
+  }
+  existing.maxAttempts = Math.max(existing.maxAttempts, record.attempts);
+  if (!existing.failureMessage && record.failureMessage) {
+    existing.failureMessage = record.failureMessage;
+  }
+  // A reporter-sourced record is exact; prefer its provenance and its richer
+  // ` > `-separated test name.
+  if (record.source === 'flake-reporter') {
+    existing.source = record.source;
+    existing.testName = record.testName;
+  }
+}
+
+/**
+ * Aggregate flake records across many artifacts into one entry per test.
+ *
+ * Each input describes one artifact: `{ text, project, runId }`. `runId`
+ * identifies the CI run so a flake seen in three different runs reports
+ * `runs: 3` — frequency is what makes one flake worth fixing before another.
+ * @param {Array<{text?: string|null, project?: string, runId?: string|number}>} inputs
+ * @returns {Array<object>} aggregated flakes, most frequent first
+ */
+export function aggregateFlakes(inputs) {
+  /** @type {Map<string, any>} */
+  const byFp = new Map();
+  for (const input of inputs ?? []) {
+    const records = parseReport(input?.text, { project: input?.project });
+    const runId = input?.runId == null ? null : String(input.runId);
+    for (const record of records) {
+      const existing = byFp.get(record.fingerprint);
+      if (existing) mergeFlake(existing, record, runId);
+      else
+        byFp.set(record.fingerprint, {
+          ...record,
+          occurrences: 1,
+          maxAttempts: record.attempts,
+          runIds: runId ? [runId] : [],
+        });
+    }
+  }
+  return [...byFp.values()]
+    .map((f) => ({ ...f, runs: f.runIds.length }))
+    .sort(
+      (a, b) =>
+        b.occurrences - a.occurrences || b.runs - a.runs || a.testName.localeCompare(b.testName)
+    );
+}
+
+/**
+ * Map `flake-fp:<fingerprint>` markers found in existing issues to their issue
+ * number, so a recurring flake updates its issue instead of opening a new one.
+ * @param {Array<{number?: number, body?: string, state?: string}>} issues as returned by `gh issue list --json number,body,state`
+ * @returns {Map<string, {number: number, state: string}>}
+ */
+export function parseFingerprints(issues) {
+  /** @type {Map<string, {number: number, state: string}>} */
+  const map = new Map();
+  for (const issue of issues ?? []) {
+    for (const m of String(issue?.body ?? '').matchAll(FP_MARKER)) {
+      const fp = m[1].toLowerCase();
+      // Prefer an open issue over a closed one for the same flake.
+      const state = String(issue?.state ?? 'OPEN').toUpperCase();
+      const prior = map.get(fp);
+      if (prior && prior.state === 'OPEN' && state !== 'OPEN') continue;
+      map.set(fp, { number: Number(issue?.number), state });
+    }
+  }
+  return map;
+}
+
+/**
+ * Split aggregated flakes into ones needing a new issue and ones whose issue
+ * already exists (and so should be commented on / reopened).
+ * @param {Array<object>} flakes aggregated flakes
+ * @param {Map<string, {number: number, state: string}>} filed see parseFingerprints
+ * @returns {{fresh: Array<object>, recurring: Array<object>}}
+ */
+export function partitionFlakes(flakes, filed) {
+  const known = filed ?? new Map();
+  const fresh = [];
+  const recurring = [];
+  for (const flake of flakes ?? []) {
+    const issue = known.get(flake.fingerprint);
+    if (issue) recurring.push({ ...flake, issue: issue.number, issueState: issue.state });
+    else fresh.push(flake);
+  }
+  return { fresh, recurring };
+}
+
+/**
+ * Issue title for a flake. Kept stable across sweeps (no counts) so a human
+ * scanning the issue list sees the test, not the churn.
+ * @param {{project?: string, testName?: string, file?: string}} flake
+ * @returns {string}
+ */
+export function renderIssueTitle(flake) {
+  const name = flake?.testName || toRepoRelativePath(flake?.file) || 'unknown test';
+  return `flake: [${flake?.project ?? 'unknown'}] ${name}`.slice(0, 240);
+}
+
+/**
+ * Issue body for a flake, including the `flake-fp:` dedup marker.
+ * @param {object} flake aggregated flake
+ * @param {{window?: string, runsScanned?: number, repoUrl?: string}} [meta]
+ * @returns {string}
+ */
+export function renderIssueBody(flake, meta = {}) {
+  const lines = [
+    'A test in this repo **failed and then passed on retry** in CI. The build went green, so',
+    'nothing else would have reported it. A retry is a debt marker, not a fix.',
+    '',
+    `- **Project**: \`${flake.project}\` (retries enabled in \`vitest.config.ts\`)`,
+    `- **File**: \`${flake.file}\``,
+    `- **Test**: \`${flake.testName}\``,
+    `- **Attempts before passing**: ${flake.maxAttempts ?? flake.attempts}`,
+    `- **Retried runs observed**: ${flake.occurrences} (in ${flake.runs ?? 0} CI run(s)${meta.window ? `, ${meta.window}` : ''})`,
+    `- **Signal source**: \`${flake.source}\``,
+  ];
+  if (flake.failureMessage) {
+    lines.push('', 'Failure from the losing attempt:', '', '```', flake.failureMessage, '```');
+  }
+  if (flake.runIds?.length && meta.repoUrl) {
+    const links = flake.runIds.slice(0, 5).map((id) => `${meta.repoUrl}/actions/runs/${id}`);
+    lines.push('', 'Runs:', ...links.map((l) => `- ${l}`));
+  }
+  lines.push(
+    '',
+    'Reproduce the parallel conditions rather than the test in isolation:',
+    '',
+    '```bash',
+    `npx vitest run --project ${flake.project} --retry=0`,
+    '```',
+    '',
+    'See `docs/operational-telemetry.md` for the flake policy.',
+    '',
+    `<!-- flake-fp:${flake.fingerprint} -->`
+  );
+  return lines.join('\n');
+}
+
+/**
+ * Comment body posted when an already-filed flake fires again.
+ * @param {object} flake aggregated flake
+ * @param {{window?: string}} [meta]
+ * @returns {string}
+ */
+export function renderRecurrenceComment(flake, meta = {}) {
+  const lines = [
+    `Still flaking: ${flake.occurrences} retried run(s)${meta.window ? ` ${meta.window}` : ''}, ` +
+      `up to ${flake.maxAttempts ?? flake.attempts} attempt(s) before passing.`,
+  ];
+  if (flake.failureMessage) lines.push('', '```', flake.failureMessage, '```');
+  lines.push('', `<!-- flake-fp:${flake.fingerprint} -->`);
+  return lines.join('\n');
+}

--- a/packages/dev-tools/flake-ledger/lib.mjs
+++ b/packages/dev-tools/flake-ledger/lib.mjs
@@ -213,7 +213,7 @@ function mergeFlake(existing, record, runId) {
  * Each input describes one artifact: `{ text, project, runId }`. `runId`
  * identifies the CI run so a flake seen in three different runs reports
  * `runs: 3` — frequency is what makes one flake worth fixing before another.
- * @param {Array<{text?: string|null, project?: string, runId?: string|number}>} inputs
+ * @param {Iterable<{text?: string|null, project?: string, runId?: string|number}>} inputs
  * @returns {Array<object>} aggregated flakes, most frequent first
  */
 export function aggregateFlakes(inputs) {

--- a/packages/dev-tools/flake-ledger/lib.test.mjs
+++ b/packages/dev-tools/flake-ledger/lib.test.mjs
@@ -1,0 +1,460 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateFlakes,
+  extractFlakesFromLedger,
+  extractFlakesFromVitestJson,
+  FLAKE_LABEL,
+  fingerprint,
+  inferProject,
+  LEDGER_KIND,
+  normalizeTestName,
+  parseFingerprints,
+  parseReport,
+  partitionFlakes,
+  renderIssueBody,
+  renderIssueTitle,
+  renderRecurrenceComment,
+  toRepoRelativePath,
+} from './lib.mjs';
+
+/**
+ * Real `vitest.json` excerpt captured from vitest 4.1.10 with `--retry=1`:
+ * the flaky test is `passed` yet still carries the losing attempt's error,
+ * the genuine failure is `failed` with one message per attempt, and the clean
+ * pass (plus an `it.fails` expected failure) carries none.
+ */
+const VITEST_JSON = {
+  numTotalTests: 4,
+  numPassedTests: 3,
+  numFailedTests: 1,
+  success: false,
+  testResults: [
+    {
+      name: '/home/runner/work/slicc/slicc/packages/chrome-extension/tests/probe.test.ts',
+      status: 'failed',
+      assertionResults: [
+        {
+          ancestorTitles: ['flake probe'],
+          fullName: 'flake probe passes only on the second attempt',
+          title: 'passes only on the second attempt',
+          status: 'passed',
+          duration: 1.96,
+          failureMessages: [
+            'AssertionError: probe attempt 1 is deliberately failing: expected 1 to be greater than 1\n    at probe.test.ts:7:5',
+          ],
+        },
+        {
+          ancestorTitles: ['flake probe'],
+          fullName: 'flake probe fails on every attempt',
+          title: 'fails on every attempt',
+          status: 'failed',
+          duration: 1.65,
+          failureMessages: [
+            "AssertionError: expected 'genuinely broken' to be 'never fixed'",
+            "AssertionError: expected 'genuinely broken' to be 'never fixed'",
+          ],
+        },
+        {
+          ancestorTitles: ['flake probe'],
+          fullName: 'flake probe passes first try',
+          title: 'passes first try',
+          status: 'passed',
+          duration: 0.06,
+          failureMessages: [],
+        },
+        {
+          ancestorTitles: ['flake probe'],
+          fullName: 'flake probe is an expected failure',
+          title: 'is an expected failure',
+          status: 'passed',
+          duration: 0.1,
+          failureMessages: [],
+        },
+      ],
+    },
+  ],
+};
+
+/** Real `flakes.json` excerpt from `flake-reporter.mjs` on the same run. */
+const LEDGER_JSON = {
+  kind: LEDGER_KIND,
+  version: 1,
+  generatedAt: '2026-07-27T16:37:59.700Z',
+  flakes: [
+    {
+      project: 'chrome-extension',
+      file: 'packages/chrome-extension/tests/probe.test.ts',
+      testName: 'flake probe > passes only on the second attempt',
+      retryCount: 1,
+      failureMessage: 'probe attempt 1 is deliberately failing: expected 1 to be greater than 1',
+    },
+  ],
+};
+
+describe('toRepoRelativePath', () => {
+  it('strips a CI runner prefix down to the packages/ root', () => {
+    expect(
+      toRepoRelativePath('/home/runner/work/slicc/slicc/packages/webapp/tests/a.test.ts')
+    ).toBe('packages/webapp/tests/a.test.ts');
+  });
+  it('normalizes windows separators', () => {
+    expect(toRepoRelativePath('D:\\a\\slicc\\packages\\node-server\\tests\\b.test.ts')).toBe(
+      'packages/node-server/tests/b.test.ts'
+    );
+  });
+  it('passes an already-relative path through', () => {
+    expect(toRepoRelativePath('packages/shared-ts/tests/c.test.ts')).toBe(
+      'packages/shared-ts/tests/c.test.ts'
+    );
+  });
+  it('tolerates missing input', () => {
+    expect(toRepoRelativePath(null)).toBe('');
+    expect(toRepoRelativePath(undefined)).toBe('');
+  });
+});
+
+describe('inferProject', () => {
+  it('derives the vitest project from the package directory', () => {
+    expect(inferProject('/x/packages/chrome-extension/tests/a.test.ts')).toBe('chrome-extension');
+    expect(inferProject('packages/node-server/tests/a.test.ts')).toBe('node-server');
+  });
+  it('maps shared-ts to the `shared` project name', () => {
+    expect(inferProject('packages/shared-ts/tests/base64.test.ts')).toBe('shared');
+  });
+  it('falls back to unknown outside packages/', () => {
+    expect(inferProject('scripts/foo.test.ts')).toBe('unknown');
+  });
+});
+
+describe('normalizeTestName', () => {
+  it('collapses the two suite separators to one canonical form', () => {
+    expect(normalizeTestName('suite > nested > test')).toBe(normalizeTestName('suite nested test'));
+  });
+  it('collapses redundant whitespace and tolerates missing input', () => {
+    expect(normalizeTestName('  a   b  ')).toBe('a b');
+    expect(normalizeTestName(undefined)).toBe('');
+  });
+});
+
+describe('fingerprint', () => {
+  it('is stable and independent of the absolute checkout path', () => {
+    const a = fingerprint({
+      project: 'webapp',
+      file: '/home/runner/work/slicc/slicc/packages/webapp/tests/a.test.ts',
+      testName: 'x y',
+    });
+    const b = fingerprint({
+      project: 'webapp',
+      file: 'packages/webapp/tests/a.test.ts',
+      testName: 'x y',
+    });
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{12}$/);
+  });
+  it('matches across the two artifact shapes for the same test', () => {
+    const fromJson = extractFlakesFromVitestJson(VITEST_JSON)[0];
+    const fromLedger = extractFlakesFromLedger(LEDGER_JSON)[0];
+    expect(fromJson.fingerprint).toBe(fromLedger.fingerprint);
+  });
+  it('separates different tests and different projects', () => {
+    const base = { project: 'webapp', file: 'packages/webapp/tests/a.test.ts', testName: 'x' };
+    expect(fingerprint(base)).not.toBe(fingerprint({ ...base, testName: 'y' }));
+    expect(fingerprint(base)).not.toBe(fingerprint({ ...base, project: 'cherry' }));
+  });
+});
+
+describe('extractFlakesFromVitestJson', () => {
+  it('flags a test that passed but still carries a failed attempt', () => {
+    const flakes = extractFlakesFromVitestJson(VITEST_JSON);
+    expect(flakes).toHaveLength(1);
+    expect(flakes[0]).toMatchObject({
+      project: 'chrome-extension',
+      file: 'packages/chrome-extension/tests/probe.test.ts',
+      testName: 'flake probe passes only on the second attempt',
+      attempts: 2,
+      source: 'vitest-json',
+    });
+    expect(flakes[0].failureMessage).toBe(
+      'AssertionError: probe attempt 1 is deliberately failing: expected 1 to be greater than 1'
+    );
+  });
+
+  it('does NOT flag a test that failed every attempt — that is a real failure', () => {
+    const names = extractFlakesFromVitestJson(VITEST_JSON).map((f) => f.testName);
+    expect(names).not.toContain('flake probe fails on every attempt');
+  });
+
+  it('does NOT flag a clean pass or an expected failure', () => {
+    const names = extractFlakesFromVitestJson(VITEST_JSON).map((f) => f.testName);
+    expect(names).not.toContain('flake probe passes first try');
+    expect(names).not.toContain('flake probe is an expected failure');
+  });
+
+  it('counts each recorded failure as an attempt', () => {
+    const report = {
+      testResults: [
+        {
+          name: 'packages/node-server/tests/a.test.ts',
+          assertionResults: [
+            {
+              fullName: 'flaked twice',
+              status: 'passed',
+              failureMessages: ['first boom', 'second boom'],
+            },
+          ],
+        },
+      ],
+    };
+    expect(extractFlakesFromVitestJson(report)[0].attempts).toBe(3);
+  });
+
+  it('honours a project override from the artifact name', () => {
+    expect(extractFlakesFromVitestJson(VITEST_JSON, { project: 'weird' })[0].project).toBe('weird');
+  });
+
+  it('tolerates empty, malformed, and missing structures', () => {
+    expect(extractFlakesFromVitestJson(undefined)).toEqual([]);
+    expect(extractFlakesFromVitestJson({})).toEqual([]);
+    expect(extractFlakesFromVitestJson({ testResults: [{}, null] })).toEqual([]);
+    expect(
+      extractFlakesFromVitestJson({
+        testResults: [
+          { name: 'a', assertionResults: [{ status: 'passed', failureMessages: null }] },
+        ],
+      })
+    ).toEqual([]);
+  });
+});
+
+describe('extractFlakesFromLedger', () => {
+  it('uses the exact retryCount to derive attempts', () => {
+    const flakes = extractFlakesFromLedger(LEDGER_JSON);
+    expect(flakes).toHaveLength(1);
+    expect(flakes[0]).toMatchObject({
+      project: 'chrome-extension',
+      attempts: 2,
+      source: 'flake-reporter',
+      testName: 'flake probe > passes only on the second attempt',
+    });
+  });
+  it('never reports fewer than two attempts', () => {
+    const flakes = extractFlakesFromLedger({ flakes: [{ file: 'packages/x/tests/a.test.ts' }] });
+    expect(flakes[0].attempts).toBe(2);
+  });
+  it('tolerates empty and missing structures', () => {
+    expect(extractFlakesFromLedger(undefined)).toEqual([]);
+    expect(extractFlakesFromLedger({ flakes: [] })).toEqual([]);
+  });
+});
+
+describe('parseReport', () => {
+  it('dispatches on the artifact shape', () => {
+    expect(parseReport(JSON.stringify(LEDGER_JSON))[0].source).toBe('flake-reporter');
+    expect(parseReport(JSON.stringify(VITEST_JSON))[0].source).toBe('vitest-json');
+  });
+  it('returns [] for a missing, empty, or unparseable artifact', () => {
+    expect(parseReport(null)).toEqual([]);
+    expect(parseReport(undefined)).toEqual([]);
+    expect(parseReport('')).toEqual([]);
+    expect(parseReport('   ')).toEqual([]);
+    expect(parseReport('{"truncated":')).toEqual([]);
+    expect(parseReport('[]')).toEqual([]);
+    expect(parseReport('{"kind":"something-else"}')).toEqual([]);
+  });
+});
+
+describe('aggregateFlakes', () => {
+  it('merges the two shapes from one run into a single flake counted once', () => {
+    const flakes = aggregateFlakes([
+      { text: JSON.stringify(VITEST_JSON), runId: 111 },
+      { text: JSON.stringify(LEDGER_JSON), runId: 111 },
+    ]);
+    expect(flakes).toHaveLength(1);
+    expect(flakes[0].occurrences).toBe(1);
+    expect(flakes[0].runs).toBe(1);
+    // The reporter record is exact, so its provenance and name win.
+    expect(flakes[0].source).toBe('flake-reporter');
+    expect(flakes[0].testName).toContain(' > ');
+  });
+
+  it('counts distinct runs and keeps the highest attempt count', () => {
+    const flakes = aggregateFlakes([
+      { text: JSON.stringify(VITEST_JSON), runId: 1 },
+      { text: JSON.stringify(VITEST_JSON), runId: 2 },
+      { text: JSON.stringify(LEDGER_JSON), runId: 3 },
+    ]);
+    expect(flakes[0].occurrences).toBe(3);
+    expect(flakes[0].runs).toBe(3);
+    expect(flakes[0].runIds).toEqual(['1', '2', '3']);
+    expect(flakes[0].maxAttempts).toBe(2);
+  });
+
+  it('keeps flakes from different projects apart and sorts by frequency', () => {
+    const other = {
+      kind: LEDGER_KIND,
+      flakes: [
+        {
+          project: 'node-server',
+          file: 'packages/node-server/tests/port.test.ts',
+          testName: 'binds a free port',
+          retryCount: 1,
+        },
+      ],
+    };
+    const flakes = aggregateFlakes([
+      { text: JSON.stringify(other), runId: 1 },
+      { text: JSON.stringify(other), runId: 2 },
+      { text: JSON.stringify(LEDGER_JSON), runId: 1 },
+    ]);
+    expect(flakes).toHaveLength(2);
+    expect(flakes[0].project).toBe('node-server');
+    expect(flakes[0].occurrences).toBe(2);
+    expect(flakes[1].project).toBe('chrome-extension');
+  });
+
+  it('skips artifacts that could not be downloaded without losing the rest', () => {
+    const flakes = aggregateFlakes([
+      { text: null, runId: 1 },
+      { text: '{truncated', runId: 2 },
+      { text: JSON.stringify(LEDGER_JSON), runId: 3 },
+    ]);
+    expect(flakes).toHaveLength(1);
+    expect(flakes[0].runs).toBe(1);
+  });
+
+  it('never reports a test that failed every attempt', () => {
+    const allFailed = {
+      testResults: [
+        {
+          name: 'packages/webapp/tests/a.test.ts',
+          assertionResults: [
+            { fullName: 'always broken', status: 'failed', failureMessages: ['boom', 'boom'] },
+          ],
+        },
+      ],
+    };
+    expect(aggregateFlakes([{ text: JSON.stringify(allFailed), runId: 1 }])).toEqual([]);
+  });
+
+  it('returns [] for empty or missing input', () => {
+    expect(aggregateFlakes([])).toEqual([]);
+    expect(aggregateFlakes(undefined)).toEqual([]);
+    expect(aggregateFlakes([{}])).toEqual([]);
+  });
+
+  it('counts every sighting when no run id is available (local use)', () => {
+    const flakes = aggregateFlakes([
+      { text: JSON.stringify(LEDGER_JSON) },
+      { text: JSON.stringify(LEDGER_JSON) },
+    ]);
+    expect(flakes[0].occurrences).toBe(2);
+    expect(flakes[0].runs).toBe(0);
+  });
+});
+
+describe('parseFingerprints', () => {
+  it('maps markers to issue numbers, case-insensitively', () => {
+    const filed = parseFingerprints([
+      { number: 12, state: 'OPEN', body: 'text\n<!-- flake-fp:abc123abc123 -->' },
+      { number: 13, state: 'CLOSED', body: 'FLAKE-FP: DEF456DEF456' },
+      { number: 14, state: 'OPEN', body: 'no marker' },
+    ]);
+    expect(filed.get('abc123abc123')).toEqual({ number: 12, state: 'OPEN' });
+    expect(filed.get('def456def456')).toEqual({ number: 13, state: 'CLOSED' });
+    expect(filed.size).toBe(2);
+  });
+
+  it('prefers an open issue over a closed one for the same flake', () => {
+    const filed = parseFingerprints([
+      { number: 1, state: 'OPEN', body: '<!-- flake-fp:aaaaaaaaaaaa -->' },
+      { number: 2, state: 'CLOSED', body: '<!-- flake-fp:aaaaaaaaaaaa -->' },
+    ]);
+    expect(filed.get('aaaaaaaaaaaa').number).toBe(1);
+  });
+
+  it('tolerates empty and missing input', () => {
+    expect(parseFingerprints([]).size).toBe(0);
+    expect(parseFingerprints(undefined).size).toBe(0);
+    expect(parseFingerprints([{}]).size).toBe(0);
+  });
+});
+
+describe('partitionFlakes', () => {
+  const flakes = aggregateFlakes([{ text: JSON.stringify(LEDGER_JSON), runId: 1 }]);
+
+  it('routes an already-filed flake to its existing issue instead of a new one', () => {
+    const filed = new Map([[flakes[0].fingerprint, { number: 42, state: 'CLOSED' }]]);
+    const { fresh, recurring } = partitionFlakes(flakes, filed);
+    expect(fresh).toEqual([]);
+    expect(recurring).toHaveLength(1);
+    expect(recurring[0].issue).toBe(42);
+    expect(recurring[0].issueState).toBe('CLOSED');
+  });
+
+  it('treats an unseen flake as fresh', () => {
+    expect(partitionFlakes(flakes, new Map()).fresh).toHaveLength(1);
+    expect(partitionFlakes(flakes, undefined).fresh).toHaveLength(1);
+    expect(partitionFlakes(undefined, new Map()).fresh).toEqual([]);
+  });
+});
+
+describe('issue rendering', () => {
+  const flake = aggregateFlakes([
+    { text: JSON.stringify(VITEST_JSON), runId: 111 },
+    { text: JSON.stringify(LEDGER_JSON), runId: 111 },
+  ])[0];
+
+  it('titles the issue by project and test, without volatile counts', () => {
+    const title = renderIssueTitle(flake);
+    expect(title).toBe('flake: [chrome-extension] flake probe > passes only on the second attempt');
+    expect(title).not.toMatch(/\d+ run/);
+  });
+
+  it('falls back to the file when a test name is missing', () => {
+    expect(renderIssueTitle({ project: 'webapp', file: 'packages/webapp/tests/a.test.ts' })).toBe(
+      'flake: [webapp] packages/webapp/tests/a.test.ts'
+    );
+    expect(renderIssueTitle({})).toBe('flake: [unknown] unknown test');
+  });
+
+  it('embeds the dedup marker, the failure, and a reproduction command', () => {
+    const body = renderIssueBody(flake, {
+      window: 'last 2 days',
+      repoUrl: 'https://github.com/ai-ecoverse/slicc',
+    });
+    expect(body).toContain(`<!-- flake-fp:${flake.fingerprint} -->`);
+    expect(body).toContain('packages/chrome-extension/tests/probe.test.ts');
+    expect(body).toContain('deliberately failing');
+    expect(body).toContain('npx vitest run --project chrome-extension --retry=0');
+    expect(body).toContain('https://github.com/ai-ecoverse/slicc/actions/runs/111');
+    expect(body).toContain('last 2 days');
+    expect(parseFingerprints([{ number: 1, state: 'OPEN', body }]).has(flake.fingerprint)).toBe(
+      true
+    );
+  });
+
+  it('omits the failure block and run links when there is nothing to show', () => {
+    const body = renderIssueBody({
+      project: 'webapp',
+      file: 'packages/webapp/tests/a.test.ts',
+      testName: 'x',
+      attempts: 2,
+      fingerprint: 'ffffffffffff',
+    });
+    expect(body).not.toContain('Failure from the losing attempt');
+    expect(body).not.toContain('Runs:');
+  });
+
+  it('renders a recurrence comment carrying the same marker', () => {
+    const comment = renderRecurrenceComment(flake, { window: 'in the last day' });
+    expect(comment).toContain('Still flaking');
+    expect(comment).toContain('in the last day');
+    expect(comment).toContain(`<!-- flake-fp:${flake.fingerprint} -->`);
+  });
+});
+
+describe('FLAKE_LABEL', () => {
+  it('stays inside the existing debt: namespace', () => {
+    expect(FLAKE_LABEL).toBe('debt:flake');
+  });
+});

--- a/packages/dev-tools/flake-ledger/lib.test.mjs
+++ b/packages/dev-tools/flake-ledger/lib.test.mjs
@@ -312,6 +312,14 @@ describe('aggregateFlakes', () => {
     expect(flakes[1].project).toBe('chrome-extension');
   });
 
+  it('accepts a lazy iterable so the sweep need not buffer every artifact', () => {
+    function* lazy() {
+      yield { text: JSON.stringify(LEDGER_JSON), runId: 1 };
+      yield { text: JSON.stringify(LEDGER_JSON), runId: 2 };
+    }
+    expect(aggregateFlakes(lazy())[0].runs).toBe(2);
+  });
+
   it('skips artifacts that could not be downloaded without losing the rest', () => {
     const flakes = aggregateFlakes([
       { text: null, runId: 1 },

--- a/packages/dev-tools/flake-ledger/sweep-flakes.mjs
+++ b/packages/dev-tools/flake-ledger/sweep-flakes.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/*
+ * Flake ledger — orchestrator (I/O).
+ *
+ * Sweeps recent CI runs, pulls their `test-timing-*` artifacts, reconstructs
+ * which tests only passed after a retry, and files or updates one GitHub issue
+ * per flaky test. Pure logic lives in `lib.mjs` (unit-tested); this file only
+ * shells out to `gh` and the filesystem.
+ *
+ * Env:
+ *   SINCE_DAYS     look-back window in days                 (default 1)
+ *   RUN_LIMIT      max CI runs to inspect                   (default 40)
+ *   WORKFLOW       workflow file to sweep                   (default ci.yml)
+ *   BRANCH         branch filter, empty for all             (default main)
+ *   FLAKE_LABEL    issue label for dedup + filing           (default debt:flake)
+ *   MAX_NEW_ISSUES cap on issues opened per sweep           (default 5)
+ *   OUTPUT_PATH    ledger JSON path                         (default ./flake-ledger.json)
+ *   FLAKE_DRY_RUN  set to skip all writes to GitHub
+ *   GH_TOKEN       token for `gh` (provided by Actions)
+ *
+ * Never exits non-zero because a flake was found: a ledger that reddens builds
+ * is just the retry removed.
+ */
+import { execFileSync } from 'node:child_process';
+import {
+  appendFileSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  aggregateFlakes,
+  FLAKE_LABEL,
+  parseFingerprints,
+  partitionFlakes,
+  renderIssueBody,
+  renderIssueTitle,
+  renderRecurrenceComment,
+} from './lib.mjs';
+
+const SINCE_DAYS = Number(process.env.SINCE_DAYS) || 1;
+const RUN_LIMIT = Number(process.env.RUN_LIMIT) || 40;
+const WORKFLOW = process.env.WORKFLOW || 'ci.yml';
+const BRANCH = process.env.BRANCH ?? 'main';
+const LABEL = process.env.FLAKE_LABEL || FLAKE_LABEL;
+const MAX_NEW_ISSUES = Number(process.env.MAX_NEW_ISSUES) || 5;
+const OUTPUT_PATH = process.env.OUTPUT_PATH || 'flake-ledger.json';
+const DRY_RUN = Boolean(process.env.FLAKE_DRY_RUN);
+const WINDOW = `last ${SINCE_DAYS} day(s)`;
+
+function gh(args, opts = {}) {
+  return execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, ...opts });
+}
+
+function ghJson(args, fallback) {
+  try {
+    return JSON.parse(gh(args).trim() || 'null') ?? fallback;
+  } catch (err) {
+    console.warn(`⚠️  gh ${args[0]} ${args[1] ?? ''} failed: ${String(err.message).split('\n')[0]}`);
+    return fallback;
+  }
+}
+
+function repoUrl() {
+  const slug = process.env.GITHUB_REPOSITORY;
+  return slug ? `https://github.com/${slug}` : null;
+}
+
+/** Completed CI runs inside the look-back window. */
+function listRuns() {
+  const args = [
+    'run',
+    'list',
+    '--workflow',
+    WORKFLOW,
+    '--limit',
+    String(RUN_LIMIT),
+    '--json',
+    'databaseId,createdAt,conclusion,status,headSha',
+  ];
+  if (BRANCH) args.push('--branch', BRANCH);
+  const runs = ghJson(args, []);
+  const cutoff = Date.now() - SINCE_DAYS * 24 * 60 * 60 * 1000;
+  return runs.filter((r) => r.status === 'completed' && Date.parse(r.createdAt) >= cutoff);
+}
+
+/** Every JSON file inside a downloaded artifact tree. */
+function readJsonFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true, recursive: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    try {
+      out.push(readFileSync(join(entry.parentPath ?? entry.path, entry.name), 'utf8'));
+    } catch {
+      // A truncated or unreadable artifact must not abort the sweep.
+    }
+  }
+  return out;
+}
+
+/**
+ * Download one run's test-timing artifacts and return their raw contents.
+ * A run whose artifacts have expired or were never uploaded yields `[]`.
+ */
+function fetchRunArtifacts(runId) {
+  const dir = mkdtempSync(join(tmpdir(), `flake-${runId}-`));
+  try {
+    gh(['run', 'download', String(runId), '--pattern', 'test-timing-*', '--dir', dir], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    return readJsonFiles(dir);
+  } catch {
+    return [];
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function collectInputs(runs) {
+  const inputs = [];
+  for (const run of runs) {
+    const texts = fetchRunArtifacts(run.databaseId);
+    for (const text of texts) inputs.push({ text, runId: run.databaseId });
+  }
+  return inputs;
+}
+
+function fetchFiledIssues() {
+  const issues = ghJson(
+    [
+      'issue',
+      'list',
+      '--label',
+      LABEL,
+      '--state',
+      'all',
+      '--limit',
+      '500',
+      '--json',
+      'number,body,state',
+    ],
+    []
+  );
+  return parseFingerprints(issues);
+}
+
+function fileNewIssue(flake) {
+  const title = renderIssueTitle(flake);
+  const body = renderIssueBody(flake, { window: WINDOW, repoUrl: repoUrl() });
+  if (DRY_RUN) {
+    console.log(`   [dry-run] would open: ${title}`);
+    return;
+  }
+  try {
+    const url = gh(['issue', 'create', '--title', title, '--body', body, '--label', LABEL]).trim();
+    console.log(`   opened ${url}`);
+  } catch (err) {
+    console.warn(`   ⚠️  could not open an issue for ${flake.fingerprint}: ${err.message}`);
+  }
+}
+
+function updateExistingIssue(flake) {
+  if (DRY_RUN) {
+    console.log(`   [dry-run] would comment on #${flake.issue}: ${flake.testName}`);
+    return;
+  }
+  try {
+    if (flake.issueState !== 'OPEN') gh(['issue', 'reopen', String(flake.issue)]);
+    gh([
+      'issue',
+      'comment',
+      String(flake.issue),
+      '--body',
+      renderRecurrenceComment(flake, { window: `in the ${WINDOW}` }),
+    ]);
+    console.log(`   updated #${flake.issue}`);
+  } catch (err) {
+    console.warn(`   ⚠️  could not update #${flake.issue}: ${err.message}`);
+  }
+}
+
+function setOutput(key, value) {
+  if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+}
+
+function main() {
+  console.log(`🔎 Sweeping ${WORKFLOW} runs from the ${WINDOW}${BRANCH ? ` on ${BRANCH}` : ''}…`);
+  const runs = listRuns();
+  console.log(`   ${runs.length} completed run(s) in window.`);
+
+  const inputs = collectInputs(runs);
+  console.log(`   ${inputs.length} test-timing artifact file(s) downloaded.`);
+
+  const flakes = aggregateFlakes(inputs);
+  writeFileSync(
+    OUTPUT_PATH,
+    JSON.stringify({ window: WINDOW, runs: runs.length, flakes }, null, 2)
+  );
+  setOutput('count', String(flakes.length));
+  setOutput('has_flakes', flakes.length > 0 ? 'true' : 'false');
+
+  if (flakes.length === 0) {
+    console.log('✅ No test passed only on retry. Nothing to record.');
+    return;
+  }
+
+  console.log(`\n⚠️  ${flakes.length} flaky test(s) → ${OUTPUT_PATH}:`);
+  for (const f of flakes) {
+    console.log(`   • [${f.project}] ${f.testName} — ${f.occurrences} retried run(s)`);
+  }
+
+  const { fresh, recurring } = partitionFlakes(flakes, fetchFiledIssues());
+  console.log(`\n${fresh.length} new, ${recurring.length} already filed.`);
+  for (const flake of fresh.slice(0, MAX_NEW_ISSUES)) fileNewIssue(flake);
+  if (fresh.length > MAX_NEW_ISSUES) {
+    console.log(`   (${fresh.length - MAX_NEW_ISSUES} more deferred to the next sweep)`);
+  }
+  for (const flake of recurring) updateExistingIssue(flake);
+}
+
+main();

--- a/packages/dev-tools/flake-ledger/sweep-flakes.mjs
+++ b/packages/dev-tools/flake-ledger/sweep-flakes.mjs
@@ -120,13 +120,18 @@ function fetchRunArtifacts(runId) {
   }
 }
 
-function collectInputs(runs) {
-  const inputs = [];
+/**
+ * Yield one artifact at a time. A single `test-timing-webapp` report is ~4 MB,
+ * so buffering a whole sweep's worth would cost hundreds of megabytes; lazily
+ * yielding lets each payload be collected once it has been parsed.
+ */
+function* collectInputs(runs, stats) {
   for (const run of runs) {
-    const texts = fetchRunArtifacts(run.databaseId);
-    for (const text of texts) inputs.push({ text, runId: run.databaseId });
+    for (const text of fetchRunArtifacts(run.databaseId)) {
+      stats.artifacts += 1;
+      yield { text, runId: run.databaseId };
+    }
   }
-  return inputs;
 }
 
 function fetchFiledIssues() {
@@ -192,10 +197,9 @@ function main() {
   const runs = listRuns();
   console.log(`   ${runs.length} completed run(s) in window.`);
 
-  const inputs = collectInputs(runs);
-  console.log(`   ${inputs.length} test-timing artifact file(s) downloaded.`);
-
-  const flakes = aggregateFlakes(inputs);
+  const stats = { artifacts: 0 };
+  const flakes = aggregateFlakes(collectInputs(runs, stats));
+  console.log(`   ${stats.artifacts} test-timing artifact file(s) inspected.`);
   writeFileSync(
     OUTPUT_PATH,
     JSON.stringify({ window: WINDOW, runs: runs.length, flakes }, null, 2)

--- a/packages/dev-tools/tools/ceiling-ratchet-lib.mjs
+++ b/packages/dev-tools/tools/ceiling-ratchet-lib.mjs
@@ -1,0 +1,251 @@
+// Shared logic for the three *ceiling* budgets the nightly ratchet tightens:
+// duplication (jscpd.json `threshold`), bundle size (`size-limit` blocks in
+// packages/*/package.json) and per-test duration (coverage-thresholds.json
+// `testTiming`). Floors live in coverage-ratchet-lib.mjs; the primitive both
+// directions share is nextCeiling/nextFloor.
+//
+// Everything above the IO helpers at the bottom is pure and unit-tested by the
+// `dev-tools` vitest project.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  BYTES_MARGIN_RATIO,
+  DUPLICATION_GRANULARITY,
+  DUPLICATION_MARGIN,
+  nextCeiling,
+  repoRoot,
+  TIMING_GRANULARITY_MS,
+  TIMING_MARGIN_RATIO,
+} from './coverage-ratchet-lib.mjs';
+
+export const jscpdConfigPath = resolve(repoRoot, 'jscpd.json');
+
+// The packages carrying a `size-limit` block, in the order `npm run
+// bundle-size` checks them.
+export const SIZE_LIMIT_PACKAGES = ['packages/webapp', 'packages/chrome-extension'];
+
+// vitest projects whose per-test timings are gated, and the test-file prefix
+// that identifies each one inside a timing report. The vitest json reporter
+// records the file path but not the project name, so a full-repo run is
+// partitioned by path.
+export const TIMED_PROJECTS = {
+  webapp: 'packages/webapp/tests/',
+  'node-server': 'packages/node-server/tests/',
+  'chrome-extension': 'packages/chrome-extension/tests/',
+};
+
+export const TIMING_METRIC = 'p95Ms';
+
+// size-limit parses limits with decimal SI units (kB = 1000 bytes), so a
+// budget written "31 MB" is 31_000_000 bytes in its JSON output.
+const BYTE_UNITS = { B: 1, kB: 1000, MB: 1e6, GB: 1e9 };
+
+// "24 kB" -> { amount: 24, unit: 'kB', bytes: 24000 }. Returns null for a
+// shape this ratchet must not rewrite (percentages, gzip specs, typos), so
+// callers skip instead of guessing a budget.
+export function parseByteLimit(limit) {
+  if (typeof limit !== 'string') return null;
+  const match = /^\s*(\d+(?:\.\d+)?)\s*(B|kB|MB|GB)\s*$/.exec(limit);
+  if (!match) return null;
+  const amount = Number(match[1]);
+  const unit = match[2];
+  return { amount, unit, bytes: amount * BYTE_UNITS[unit] };
+}
+
+export function formatByteLimit(amount, unit) {
+  return `${amount} ${unit}`;
+}
+
+// Tighten one size-limit budget toward its measured size. Rounds to a whole
+// unit of the budget's own declared unit so "1850 kB" stays kB and "31 MB"
+// stays MB — each ratchet step remains a single reviewable number.
+// Returns null when the budget cannot be parsed or does not move.
+export function nextByteLimit(limit, actualBytes) {
+  const parsed = parseByteLimit(limit);
+  if (!parsed) return null;
+  if (typeof actualBytes !== 'number' || !Number.isFinite(actualBytes) || actualBytes < 0) {
+    return null;
+  }
+  const factor = BYTE_UNITS[parsed.unit];
+  const nextAmount = nextCeiling(parsed.amount, actualBytes / factor, {
+    granularity: 1,
+    marginRatio: BYTES_MARGIN_RATIO,
+  });
+  if (nextAmount >= parsed.amount) return null;
+  return {
+    limit: formatByteLimit(nextAmount, parsed.unit),
+    from: parsed.amount,
+    to: nextAmount,
+    unit: parsed.unit,
+    actualBytes,
+  };
+}
+
+// `size-limit --json` emits [{ name, size, sizeLimit, passed }].
+export function parseSizeLimitJson(report) {
+  const sizes = {};
+  if (!Array.isArray(report)) return sizes;
+  for (const entry of report) {
+    if (entry && typeof entry.name === 'string' && typeof entry.size === 'number') {
+      sizes[entry.name] = entry.size;
+    }
+  }
+  return sizes;
+}
+
+// Which size-limit budgets in a package.json tighten against measured sizes,
+// matched by budget `name`. Pure; the text edits happen in writeSizeLimits.
+export function ratchetSizeLimits(pkgJson, measuredByName) {
+  const budgets = pkgJson?.['size-limit'];
+  if (!Array.isArray(budgets)) return [];
+  const changes = [];
+  for (const budget of budgets) {
+    const actual = measuredByName?.[budget?.name];
+    if (typeof actual !== 'number') continue;
+    const change = nextByteLimit(budget.limit, actual);
+    if (change) changes.push({ name: budget.name, ...change });
+  }
+  return changes;
+}
+
+// The ceiling files are prettier-formatted (inline arrays, specific key order),
+// so they are patched textually rather than round-tripped through
+// JSON.stringify, which would reflow every array in the document.
+export function replaceJsonNumber(text, key, value) {
+  const pattern = new RegExp(`("${key}":\\s*)-?\\d+(?:\\.\\d+)?`);
+  if (!pattern.test(text)) return null;
+  return text.replace(pattern, (_match, prefix) => `${prefix}${value}`);
+}
+
+export function replaceSizeLimit(text, name, limit) {
+  const nameIndex = text.indexOf(`"name": ${JSON.stringify(name)}`);
+  if (nameIndex === -1) return null;
+  const match = /"limit":\s*"[^"]*"/.exec(text.slice(nameIndex));
+  if (!match) return null;
+  const start = nameIndex + match.index;
+  return `${text.slice(0, start)}"limit": ${JSON.stringify(limit)}${text.slice(start + match[0].length)}`;
+}
+
+// jscpd's json reporter reports the duplicated-*line* percentage as
+// statistics.total.percentage — the same number its `threshold` reporter gates.
+export function parseJscpdPercentage(report) {
+  const pct = report?.statistics?.total?.percentage;
+  return typeof pct === 'number' && Number.isFinite(pct) ? pct : null;
+}
+
+export function nextDuplicationThreshold(current, actualPct) {
+  const to = nextCeiling(current, actualPct, {
+    granularity: DUPLICATION_GRANULARITY,
+    margin: DUPLICATION_MARGIN,
+  });
+  if (to === null) return null;
+  if (typeof current === 'number' && to >= current) return null;
+  return { from: typeof current === 'number' ? current : null, to, actual: actualPct };
+}
+
+function percentile(sortedValues, fraction) {
+  if (sortedValues.length === 0) return null;
+  const index = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.ceil(fraction * sortedValues.length) - 1)
+  );
+  return sortedValues[index];
+}
+
+// A test that was retried reports `status: 'passed'` with the failed attempt's
+// message still in `failureMessages`, and its `duration` is the *sum* of all
+// attempts (a 120 ms test that fails once reports ~245 ms). CI enables one
+// retry for node-server and chrome-extension, so those inflated samples are
+// excluded from the measurement rather than allowed to push a ceiling up.
+export function isRetriedResult(result) {
+  return result?.status === 'passed' && (result.failureMessages?.length ?? 0) > 0;
+}
+
+// Reduce a vitest json report to a per-test duration summary for one project.
+// p95 is the gated metric: it is an order statistic over hundreds of tests, so
+// a single slow sample cannot move it, whereas the slowest test is one noisy
+// sample that would ratchet the ceiling onto runner noise and then fail
+// unrelated PRs.
+export function summarizeTiming(report, pathPrefix) {
+  const durations = [];
+  let retried = 0;
+  let slowest = null;
+  for (const file of report?.testResults ?? []) {
+    const name = typeof file?.name === 'string' ? file.name : '';
+    if (pathPrefix && !name.includes(pathPrefix)) continue;
+    for (const result of file.assertionResults ?? []) {
+      if (isRetriedResult(result)) {
+        retried += 1;
+        continue;
+      }
+      const duration = result?.duration;
+      if (typeof duration !== 'number' || !Number.isFinite(duration)) continue;
+      durations.push(duration);
+      if (!slowest || duration > slowest.durationMs) {
+        slowest = { fullName: result.fullName, durationMs: duration };
+      }
+    }
+  }
+  if (durations.length === 0) return null;
+  durations.sort((a, b) => a - b);
+  return {
+    tests: durations.length,
+    retried,
+    p95Ms: Math.round(percentile(durations, 0.95) * 100) / 100,
+    slowestMs: Math.round(durations[durations.length - 1] * 100) / 100,
+    slowestTest: slowest?.fullName ?? null,
+  };
+}
+
+// Tighten the testTiming section of coverage-thresholds.json. `measured` is
+// { project: { p95Ms } }; an unmeasured project is left alone.
+export function ratchetTiming(ceilings, measured) {
+  const next = structuredClone(ceilings ?? {});
+  const changes = [];
+  for (const project of Object.keys(TIMED_PROJECTS)) {
+    const actual = measured?.[project]?.[TIMING_METRIC];
+    if (typeof actual !== 'number' || !Number.isFinite(actual)) continue;
+    const current = next[project]?.[TIMING_METRIC];
+    const to = nextCeiling(current, actual, {
+      granularity: TIMING_GRANULARITY_MS,
+      marginRatio: TIMING_MARGIN_RATIO,
+    });
+    if (to === null) continue;
+    if (typeof current === 'number' && to >= current) continue;
+    next[project] = { ...next[project], [TIMING_METRIC]: to };
+    changes.push({ project, metric: TIMING_METRIC, from: current ?? null, to, actual });
+  }
+  return { ceilings: next, changes };
+}
+
+export function readJscpdConfig() {
+  return JSON.parse(readFileSync(jscpdConfigPath, 'utf-8'));
+}
+
+export function writeJscpdThreshold(threshold) {
+  const patched = replaceJsonNumber(readFileSync(jscpdConfigPath, 'utf-8'), 'threshold', threshold);
+  if (!patched) return false;
+  writeFileSync(jscpdConfigPath, patched);
+  return true;
+}
+
+function packageJsonPath(pkgDir) {
+  return resolve(repoRoot, pkgDir, 'package.json');
+}
+
+export function readPackageJson(pkgDir) {
+  return JSON.parse(readFileSync(packageJsonPath(pkgDir), 'utf-8'));
+}
+
+export function writeSizeLimits(pkgDir, changes) {
+  const path = packageJsonPath(pkgDir);
+  let text = readFileSync(path, 'utf-8');
+  for (const change of changes) {
+    const patched = replaceSizeLimit(text, change.name, change.limit);
+    if (!patched) return false;
+    text = patched;
+  }
+  writeFileSync(path, text);
+  return true;
+}

--- a/packages/dev-tools/tools/ceiling-ratchet-lib.mjs
+++ b/packages/dev-tools/tools/ceiling-ratchet-lib.mjs
@@ -198,6 +198,20 @@ export function summarizeTiming(report, pathPrefix) {
   };
 }
 
+// The gate side of the timing ceiling. Separated from the IO so the compare
+// is unit-testable; `null` inputs mean "nothing to gate on", never a failure.
+export function evaluateTiming(summary, ceilingMs) {
+  if (!summary) return { status: 'skip', reason: 'no per-test durations in the report' };
+  if (typeof ceilingMs !== 'number' || !Number.isFinite(ceilingMs)) {
+    return { status: 'skip', reason: 'no ceiling configured', summary };
+  }
+  return {
+    status: summary[TIMING_METRIC] > ceilingMs ? 'fail' : 'pass',
+    ceilingMs,
+    summary,
+  };
+}
+
 // Tighten the testTiming section of coverage-thresholds.json. `measured` is
 // { project: { p95Ms } }; an unmeasured project is left alone.
 export function ratchetTiming(ceilings, measured) {

--- a/packages/dev-tools/tools/ceiling-ratchet-lib.test.mjs
+++ b/packages/dev-tools/tools/ceiling-ratchet-lib.test.mjs
@@ -1,0 +1,284 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatByteLimit,
+  isRetriedResult,
+  nextByteLimit,
+  nextDuplicationThreshold,
+  parseByteLimit,
+  parseJscpdPercentage,
+  parseSizeLimitJson,
+  ratchetSizeLimits,
+  ratchetTiming,
+  replaceJsonNumber,
+  replaceSizeLimit,
+  SIZE_LIMIT_PACKAGES,
+  summarizeTiming,
+  TIMED_PROJECTS,
+} from './ceiling-ratchet-lib.mjs';
+
+describe('parseByteLimit', () => {
+  it('parses the decimal SI units size-limit uses', () => {
+    expect(parseByteLimit('24 kB')).toEqual({ amount: 24, unit: 'kB', bytes: 24000 });
+    expect(parseByteLimit('31 MB')).toEqual({ amount: 31, unit: 'MB', bytes: 31000000 });
+    expect(parseByteLimit('1850kB')).toEqual({ amount: 1850, unit: 'kB', bytes: 1850000 });
+    expect(parseByteLimit('1.5 MB').bytes).toBe(1500000);
+  });
+
+  it('refuses shapes it must not rewrite', () => {
+    expect(parseByteLimit('10%')).toBe(null);
+    expect(parseByteLimit('24 kb')).toBe(null);
+    expect(parseByteLimit(24)).toBe(null);
+    expect(parseByteLimit(undefined)).toBe(null);
+  });
+});
+
+describe('nextByteLimit', () => {
+  it('tightens toward the measured size with 5% headroom, in the declared unit', () => {
+    expect(nextByteLimit('24 kB', 21388)).toMatchObject({ limit: '23 kB', from: 24, to: 23 });
+    expect(nextByteLimit('1850 kB', 1681923)).toMatchObject({ limit: '1767 kB', to: 1767 });
+    expect(nextByteLimit('60 kB', 55858)).toMatchObject({ limit: '59 kB' });
+    expect(nextByteLimit('105 kB', 95627)).toMatchObject({ limit: '101 kB' });
+  });
+
+  it('does not move when the margin already fills the budget', () => {
+    // 29.63 MB * 1.05 rounds up to 32 MB, which is looser than 31 MB.
+    expect(nextByteLimit('31 MB', 29627990)).toBe(null);
+    expect(nextByteLimit('24 kB', 23000)).toBe(null);
+  });
+
+  it('never loosens a budget the bundle already exceeds', () => {
+    expect(nextByteLimit('24 kB', 30000)).toBe(null);
+  });
+
+  it('skips unparseable budgets and missing measurements', () => {
+    expect(nextByteLimit('lots', 100)).toBe(null);
+    expect(nextByteLimit('24 kB', undefined)).toBe(null);
+    expect(nextByteLimit('24 kB', Number.NaN)).toBe(null);
+  });
+});
+
+describe('formatByteLimit', () => {
+  it('round-trips through parseByteLimit', () => {
+    expect(parseByteLimit(formatByteLimit(23, 'kB'))).toEqual({
+      amount: 23,
+      unit: 'kB',
+      bytes: 23000,
+    });
+  });
+});
+
+describe('parseSizeLimitJson', () => {
+  it('maps budget name to measured bytes', () => {
+    expect(
+      parseSizeLimitJson([
+        { name: 'a', size: 10, sizeLimit: 20, passed: true },
+        { name: 'b', size: 30 },
+      ])
+    ).toEqual({ a: 10, b: 30 });
+  });
+
+  it('tolerates junk', () => {
+    expect(parseSizeLimitJson(null)).toEqual({});
+    expect(parseSizeLimitJson([{ name: 'a' }, null, { size: 1 }])).toEqual({});
+  });
+});
+
+describe('ratchetSizeLimits', () => {
+  const pkgJson = {
+    name: '@slicc/webapp',
+    'size-limit': [
+      { name: 'main', path: 'a.js', limit: '24 kB' },
+      { name: 'total', path: '**/*.js', limit: '31 MB' },
+    ],
+  };
+
+  it('reports only the budgets that tighten', () => {
+    const changes = ratchetSizeLimits(pkgJson, { main: 21388, total: 29627990 });
+    expect(changes).toEqual([
+      { name: 'main', limit: '23 kB', from: 24, to: 23, unit: 'kB', actualBytes: 21388 },
+    ]);
+  });
+
+  it('ignores budgets with no measurement and packages with no block', () => {
+    expect(ratchetSizeLimits(pkgJson, { other: 1 })).toEqual([]);
+    expect(ratchetSizeLimits({ name: 'x' }, { main: 1 })).toEqual([]);
+    expect(ratchetSizeLimits(undefined, {})).toEqual([]);
+  });
+
+  it('covers the packages npm run bundle-size checks', () => {
+    expect(SIZE_LIMIT_PACKAGES).toEqual(['packages/webapp', 'packages/chrome-extension']);
+  });
+});
+
+describe('replaceJsonNumber', () => {
+  const text = '{\n  "minTokens": 50,\n  "threshold": 7.5,\n  "path": ["packages"]\n}\n';
+
+  it('patches the value in place without reflowing the document', () => {
+    expect(replaceJsonNumber(text, 'threshold', 7.4)).toBe(
+      '{\n  "minTokens": 50,\n  "threshold": 7.4,\n  "path": ["packages"]\n}\n'
+    );
+  });
+
+  it('returns null when the key is absent', () => {
+    expect(replaceJsonNumber(text, 'nope', 1)).toBe(null);
+  });
+});
+
+describe('replaceSizeLimit', () => {
+  const text = [
+    '{',
+    '  "size-limit": [',
+    '    {',
+    '      "name": "webapp: main entry chunk",',
+    '      "path": "../../dist/ui/assets/main-*.js",',
+    '      "brotli": false,',
+    '      "limit": "24 kB"',
+    '    },',
+    '    {',
+    '      "name": "webapp: kernel worker",',
+    '      "limit": "1850 kB"',
+    '    }',
+    '  ]',
+    '}',
+    '',
+  ].join('\n');
+
+  it('patches the limit belonging to the named budget only', () => {
+    const patched = replaceSizeLimit(text, 'webapp: kernel worker', '1767 kB');
+    expect(patched).toContain('"limit": "1767 kB"');
+    expect(patched).toContain('"limit": "24 kB"');
+    expect(patched.replace('1767 kB', '1850 kB')).toBe(text);
+  });
+
+  it('returns null for an unknown budget or a missing limit', () => {
+    expect(replaceSizeLimit(text, 'nope', '1 kB')).toBe(null);
+    expect(
+      replaceSizeLimit('{ "name": "webapp: main entry chunk" }', 'webapp: main entry chunk', '1 kB')
+    ).toBe(null);
+  });
+});
+
+describe('parseJscpdPercentage', () => {
+  it('reads the duplicated-line percentage jscpd gates on', () => {
+    expect(parseJscpdPercentage({ statistics: { total: { percentage: 7.0316 } } })).toBe(7.0316);
+  });
+
+  it('returns null when the report has no total', () => {
+    expect(parseJscpdPercentage({})).toBe(null);
+    expect(parseJscpdPercentage({ statistics: { total: { percentage: 'x' } } })).toBe(null);
+  });
+});
+
+describe('nextDuplicationThreshold', () => {
+  it('tightens in tenths of a point with 0.3pp of headroom', () => {
+    expect(nextDuplicationThreshold(7.5, 7.0316)).toEqual({ from: 7.5, to: 7.4, actual: 7.0316 });
+  });
+
+  it('does not move when the headroom is already thin', () => {
+    expect(nextDuplicationThreshold(7.5, 7.25)).toBe(null);
+    expect(nextDuplicationThreshold(7.5, 8.1)).toBe(null);
+  });
+
+  it('skips a missing measurement', () => {
+    expect(nextDuplicationThreshold(7.5, null)).toBe(null);
+  });
+});
+
+describe('isRetriedResult', () => {
+  it('detects a test that failed an attempt and then passed', () => {
+    expect(isRetriedResult({ status: 'passed', failureMessages: ['AssertionError'] })).toBe(true);
+  });
+
+  it('does not flag a clean pass or an outright failure', () => {
+    expect(isRetriedResult({ status: 'passed', failureMessages: [] })).toBe(false);
+    expect(isRetriedResult({ status: 'failed', failureMessages: ['boom'] })).toBe(false);
+    expect(isRetriedResult(null)).toBe(false);
+  });
+});
+
+describe('summarizeTiming', () => {
+  const report = {
+    testResults: [
+      {
+        name: '/repo/packages/webapp/tests/a.test.ts',
+        assertionResults: [
+          { fullName: 'a1', status: 'passed', duration: 10, failureMessages: [] },
+          { fullName: 'a2', status: 'passed', duration: 900, failureMessages: [] },
+          // Retried: 245 ms is the *sum* of a failed and a passing attempt.
+          { fullName: 'a3', status: 'passed', duration: 245, failureMessages: ['AssertionError'] },
+          { fullName: 'a4', status: 'skipped', duration: null, failureMessages: [] },
+        ],
+      },
+      {
+        name: '/repo/packages/node-server/tests/b.test.ts',
+        assertionResults: [{ fullName: 'b1', status: 'passed', duration: 5000 }],
+      },
+    ],
+  };
+
+  it('summarizes only the requested project and excludes retried samples', () => {
+    const summary = summarizeTiming(report, TIMED_PROJECTS.webapp);
+    expect(summary).toEqual({
+      tests: 2,
+      retried: 1,
+      p95Ms: 900,
+      slowestMs: 900,
+      slowestTest: 'a2',
+    });
+  });
+
+  it('partitions by project path', () => {
+    expect(summarizeTiming(report, TIMED_PROJECTS['node-server']).p95Ms).toBe(5000);
+  });
+
+  it('returns null when nothing usable was measured', () => {
+    expect(summarizeTiming(report, 'packages/cherry/tests/')).toBe(null);
+    expect(summarizeTiming({}, null)).toBe(null);
+    expect(summarizeTiming(undefined, null)).toBe(null);
+  });
+
+  it('takes p95 as an order statistic, so one slow test cannot move it', () => {
+    const many = {
+      testResults: [
+        {
+          name: 'packages/webapp/tests/x.test.ts',
+          assertionResults: Array.from({ length: 100 }, (_, i) => ({
+            fullName: `t${i}`,
+            status: 'passed',
+            duration: i === 99 ? 60000 : 10,
+            failureMessages: [],
+          })),
+        },
+      ],
+    };
+    const summary = summarizeTiming(many, TIMED_PROJECTS.webapp);
+    expect(summary.p95Ms).toBe(10);
+    expect(summary.slowestMs).toBe(60000);
+  });
+});
+
+describe('ratchetTiming', () => {
+  it('tightens a ceiling with 2x headroom at 50 ms steps', () => {
+    const { ceilings, changes } = ratchetTiming(
+      { webapp: { p95Ms: 4000 }, 'node-server': { p95Ms: 1000 } },
+      { webapp: { p95Ms: 620 }, 'node-server': { p95Ms: 700 } }
+    );
+    expect(ceilings.webapp.p95Ms).toBe(1250);
+    expect(ceilings['node-server'].p95Ms).toBe(1000);
+    expect(changes).toEqual([
+      { project: 'webapp', metric: 'p95Ms', from: 4000, to: 1250, actual: 620 },
+    ]);
+  });
+
+  it('seeds a ceiling for a project that has none yet', () => {
+    const { ceilings, changes } = ratchetTiming({}, { webapp: { p95Ms: 300 } });
+    expect(ceilings.webapp).toEqual({ p95Ms: 600 });
+    expect(changes[0]).toMatchObject({ from: null, to: 600 });
+  });
+
+  it('leaves unmeasured projects and unknown keys alone', () => {
+    const { ceilings, changes } = ratchetTiming({ webapp: { p95Ms: 900 } }, {});
+    expect(ceilings).toEqual({ webapp: { p95Ms: 900 } });
+    expect(changes).toEqual([]);
+  });
+});

--- a/packages/dev-tools/tools/ceiling-ratchet-lib.test.mjs
+++ b/packages/dev-tools/tools/ceiling-ratchet-lib.test.mjs
@@ -258,22 +258,22 @@ describe('summarizeTiming', () => {
 });
 
 describe('ratchetTiming', () => {
-  it('tightens a ceiling with 2x headroom at 50 ms steps', () => {
+  it('tightens a ceiling with 4x headroom at 50 ms steps', () => {
     const { ceilings, changes } = ratchetTiming(
       { webapp: { p95Ms: 4000 }, 'node-server': { p95Ms: 1000 } },
       { webapp: { p95Ms: 620 }, 'node-server': { p95Ms: 700 } }
     );
-    expect(ceilings.webapp.p95Ms).toBe(1250);
+    expect(ceilings.webapp.p95Ms).toBe(2500);
     expect(ceilings['node-server'].p95Ms).toBe(1000);
     expect(changes).toEqual([
-      { project: 'webapp', metric: 'p95Ms', from: 4000, to: 1250, actual: 620 },
+      { project: 'webapp', metric: 'p95Ms', from: 4000, to: 2500, actual: 620 },
     ]);
   });
 
   it('seeds a ceiling for a project that has none yet', () => {
     const { ceilings, changes } = ratchetTiming({}, { webapp: { p95Ms: 300 } });
-    expect(ceilings.webapp).toEqual({ p95Ms: 600 });
-    expect(changes[0]).toMatchObject({ from: null, to: 600 });
+    expect(ceilings.webapp).toEqual({ p95Ms: 1200 });
+    expect(changes[0]).toMatchObject({ from: null, to: 1200 });
   });
 
   it('leaves unmeasured projects and unknown keys alone', () => {

--- a/packages/dev-tools/tools/check-ci-quarantine.mjs
+++ b/packages/dev-tools/tools/check-ci-quarantine.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// CI quarantine gate: every `continue-on-error: true` step in the workflows
+// listed in ci-quarantine.json must be declared there with a reason, an owning
+// package/area, and a review date. A quarantined step cannot fail its job, so
+// an undeclared one is an invisible hole in CI.
+//
+// Exit codes:
+//   0  every quarantine is declared (warnings may still be printed)
+//   1  an undeclared quarantine, or a malformed registry
+//   2  the registry or a gated workflow could not be read
+//
+// Review dates and vanished registry entries only WARN. A gate that starts
+// failing unrelated PRs on a calendar date is worse than the debt it flags.
+//
+// Usage: node packages/dev-tools/tools/check-ci-quarantine.mjs [registry-path]
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  evaluateQuarantines,
+  formatUnregisteredHint,
+  parseContinueOnErrorSteps,
+} from './ci-quarantine-lib.mjs';
+import { repoRoot } from './size-exemption-lib.mjs';
+
+const SCRIPT = 'check-ci-quarantine';
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function main(argv) {
+  const registryPath = resolve(repoRoot, argv[0] ?? 'ci-quarantine.json');
+  let registry;
+  try {
+    registry = JSON.parse(readFileSync(registryPath, 'utf-8'));
+  } catch (err) {
+    console.error(`${SCRIPT}: cannot read ${registryPath}: ${err.message}`);
+    return 2;
+  }
+
+  const found = [];
+  for (const workflow of registry.workflows ?? []) {
+    try {
+      found.push(
+        ...parseContinueOnErrorSteps(readFileSync(resolve(repoRoot, workflow), 'utf-8'), workflow)
+      );
+    } catch (err) {
+      console.error(`${SCRIPT}: cannot read ${workflow}: ${err.message}`);
+      return 2;
+    }
+  }
+
+  const result = evaluateQuarantines({ registry, found, today: today() });
+
+  for (const entry of result.stale) {
+    console.log(
+      `${SCRIPT}: notice — registered quarantine no longer exists, delete its entry: ` +
+        `${entry.workflow} → ${entry.job} → ${entry.step}`
+    );
+  }
+  for (const entry of result.expired) {
+    console.log(
+      `${SCRIPT}: WARNING — quarantine past its review date (${entry.reviewBy}, owner ${entry.owner}): ` +
+        `${entry.workflow} → ${entry.job} → ${entry.step}`
+    );
+  }
+
+  if (result.invalid.length === 0 && result.unregistered.length === 0) {
+    console.log(`${SCRIPT}: OK (${result.ok} declared quarantine(s))`);
+    return 0;
+  }
+
+  console.error(`${SCRIPT}: FAIL`);
+  for (const problem of result.invalid) {
+    console.error(`  ci-quarantine.json: ${problem}`);
+  }
+  for (const entry of result.unregistered) {
+    console.error('');
+    console.error(
+      `Undeclared \`continue-on-error: true\` at ${entry.workflow}:${entry.line} ` +
+        `(job ${entry.job} → step "${entry.step}").`
+    );
+    console.error('A quarantined step cannot fail its job. Declare it in ci-quarantine.json:');
+    console.error('');
+    console.error(formatUnregisteredHint(entry));
+  }
+  return 1;
+}
+
+process.exit(main(process.argv.slice(2)));

--- a/packages/dev-tools/tools/check-touched-exemptions.mjs
+++ b/packages/dev-tools/tools/check-touched-exemptions.mjs
@@ -1,19 +1,24 @@
 #!/usr/bin/env node
-// PR-level "boy-scout" gate for both biome complexity debt lists.
+// PR-level "boy-scout" gate for the repo's debt / exemption lists.
 //
-// Computes the PR's changed files via `git diff --name-only <base>...HEAD`
-// and intersects them with BOTH per-rule exemption globs parsed from
-// `biome.json` (see size-exemption-lib.mjs): the function-size debt list
-// (`complexity.noExcessiveLinesPerFunction: "off"`) and the cognitive-
-// complexity debt list (`complexity.noExcessiveCognitiveComplexity: "off"`).
-// Both rules are evaluated PER FUNCTION/method, not per file.
-// Exits non-zero with a rule-appropriate fix-it message if any touched file
-// is still on EITHER list — the PR author must bring every function in the
-// file under the configured per-function biome cap and delete its
-// `overrides` entry in the same PR.
-// Also exits non-zero if a PR ADDS new globs to either debt list vs the base
-// config (the debt list is frozen — additions are only allowed when the list
-// is being introduced, i.e. base had no entries for that rule).
+// Computes the PR's changed files via `git diff --name-only <base>...HEAD` and
+// enforces, per debt list (see debt-list-sources.mjs for the registry and the
+// reasoning behind the differing semantics):
+//
+//   - biome complexity debt lists (function-size, cognitive-complexity):
+//     frozen AND subject to the touched-file rule — a PR that changes a listed
+//     file must bring every function under the biome cap and delete the
+//     `overrides` entry in the same PR.
+//   - biome non-complexity rule-disabling overrides, `coverageExclude` in
+//     coverage-thresholds.json, `ignore` in jscpd.json: frozen only. These
+//     lists legitimately contain permanent entries, so touching a listed file
+//     is fine; growing the list is not.
+//   - knip ignores: reported only, never fails.
+//
+// Every list carries the bootstrapping exemption: entries in a scope the base
+// ref does not have at all are being introduced, not grown, and are ignored.
+// Base-config reads are non-throwing: an unreadable base skips that list's
+// growth check rather than failing the build.
 // Skips gracefully on non-PR events.
 //
 // Usage:
@@ -27,37 +32,55 @@
 //   4. fallback "origin/main"
 
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  DEBT_LIST_SOURCES,
+  evaluateDebtSource,
+  evaluateRuleDebtList,
+  formatGrowthReport,
+  formatTouchedReport,
+} from './debt-list-sources.mjs';
 import {
   COMPLEXITY_RULE_KEY,
   extractExemptionGlobsFor,
-  findAddedExemptions,
-  findTouchedExemptions,
-  readBiomeConfig,
   repoRoot,
   SIZE_RULE_KEY,
 } from './size-exemption-lib.mjs';
 
 const SCRIPT = 'check-touched-exemptions';
 
+const COMPLEXITY_GROWTH_FIX_IT =
+  'Fix: bring every function in the file under the configured per-function biome cap\n' +
+  'instead of adding it to the debt list.';
+
 const RULES = [
   {
+    id: 'function-size',
     key: SIZE_RULE_KEY,
     label: 'function-size',
-    overrideName: 'complexity.noExcessiveLinesPerFunction',
-    fixIt:
+    file: 'biome.json',
+    location: 'biome.json `overrides` → complexity.noExcessiveLinesPerFunction = off',
+    semantics: { touched: true, freeze: true, failOnGrowth: true },
+    touchedFixIt:
       'Fix: in this same PR, refactor each file so every function is under the\n' +
       'configured biome cap (complexity.noExcessiveLinesPerFunction.maxLines), then\n' +
       'remove its entry from the debt-list `overrides` block in biome.json.',
+    growthFixIt: COMPLEXITY_GROWTH_FIX_IT,
   },
   {
+    id: 'cognitive-complexity',
     key: COMPLEXITY_RULE_KEY,
     label: 'cognitive-complexity',
-    overrideName: 'complexity.noExcessiveCognitiveComplexity',
-    fixIt:
+    file: 'biome.json',
+    location: 'biome.json `overrides` → complexity.noExcessiveCognitiveComplexity = off',
+    semantics: { touched: true, freeze: true, failOnGrowth: true },
+    touchedFixIt:
       "Fix: in this same PR, refactor each file so every function's cognitive\n" +
       'complexity is under the configured biome cap\n' +
       '(complexity.noExcessiveCognitiveComplexity.maxAllowedComplexity), then\n' +
       'remove its entry from the debt-list `overrides` block in biome.json.',
+    growthFixIt: COMPLEXITY_GROWTH_FIX_IT,
   },
 ];
 
@@ -102,17 +125,41 @@ function isPullRequestEvent() {
   return process.env.GITHUB_EVENT_NAME === 'pull_request' || !!process.env.GITHUB_BASE_REF;
 }
 
-// Read and parse `biome.json` from the BASE ref via `git show <ref>:biome.json`.
-// Returns the parsed config or null on ANY failure (missing ref, missing file,
-// unfetched base, malformed JSON). Intentionally non-throwing so a missing
-// base config skips the added-entry check rather than failing the build.
-function readBaseBiomeConfig(baseRef) {
+function readCurrentConfig(file) {
+  return JSON.parse(readFileSync(resolve(repoRoot, file), 'utf-8'));
+}
+
+// Read and parse a config file from the BASE ref via `git show <ref>:<file>`.
+// Returns null on ANY failure (missing ref, missing file, unfetched base,
+// malformed JSON). Intentionally non-throwing so a missing base config skips
+// that list's growth check rather than failing the build.
+function readBaseConfig(baseRef, file) {
   try {
-    const out = runGit(['show', `${baseRef}:biome.json`]);
-    return JSON.parse(out);
+    return JSON.parse(runGit(['show', `${baseRef}:${file}`]));
   } catch {
     return null;
   }
+}
+
+function makeConfigReaders(baseRef) {
+  const current = new Map();
+  const base = new Map();
+  return {
+    current(file) {
+      if (!current.has(file)) {
+        try {
+          current.set(file, readCurrentConfig(file));
+        } catch {
+          current.set(file, null);
+        }
+      }
+      return current.get(file);
+    },
+    base(file) {
+      if (!base.has(file)) base.set(file, readBaseConfig(baseRef, file));
+      return base.get(file);
+    },
+  };
 }
 
 function resolveChangedFiles() {
@@ -126,26 +173,48 @@ function resolveChangedFiles() {
   }
 }
 
+function evaluateAll({ readers, changedFiles }) {
+  const results = [];
+  for (const rule of RULES) {
+    const config = readers.current(rule.file);
+    const baseConfig = readers.base(rule.file);
+    results.push(
+      evaluateRuleDebtList(rule, {
+        currentGlobs: extractExemptionGlobsFor(config, rule.key),
+        baseGlobs: extractExemptionGlobsFor(baseConfig, rule.key),
+        baseAvailable: baseConfig !== null,
+        changedFiles,
+      })
+    );
+  }
+  for (const source of DEBT_LIST_SOURCES) {
+    const config = readers.current(source.file);
+    const baseConfig = readers.base(source.file);
+    results.push(
+      evaluateDebtSource(source, {
+        currentEntries: config === null ? [] : source.extract(config),
+        baseEntries: baseConfig === null ? [] : source.extract(baseConfig),
+        baseAvailable: baseConfig !== null,
+      })
+    );
+  }
+  return results;
+}
+
+function reportSkips(results) {
+  for (const r of results) {
+    if (r.skipReason) {
+      console.log(`${SCRIPT}: notice — ${r.source.label} growth check skipped (${r.skipReason})`);
+    }
+  }
+}
+
 function main() {
   // Skip gracefully on non-PR CI events (push, merge_group). The gate is
   // PR-only by design; merge_group runs against the queue commit and has no
   // meaningful merge base to diff against.
   if (process.env.GITHUB_ACTIONS === 'true' && !isPullRequestEvent()) {
     console.log(`${SCRIPT}: skipped (not a pull_request event)`);
-    return 0;
-  }
-
-  const biomeConfig = readBiomeConfig();
-  const baseRef = resolveBaseRef(process.argv);
-  const baseConfig = readBaseBiomeConfig(baseRef);
-  const ruleStates = RULES.map((rule) => ({
-    ...rule,
-    globs: extractExemptionGlobsFor(biomeConfig, rule.key),
-    baseGlobs: extractExemptionGlobsFor(baseConfig, rule.key),
-  }));
-
-  if (ruleStates.every((r) => r.globs.length === 0)) {
-    console.log(`${SCRIPT}: no debt lists found in biome.json — nothing to gate`);
     return 0;
   }
 
@@ -157,55 +226,30 @@ function main() {
   }
   const { changedFiles } = resolved;
 
-  const touchedViolations = ruleStates
-    .map((rule) => ({ rule, touched: findTouchedExemptions(changedFiles, rule.globs) }))
-    .filter((v) => v.touched.length > 0);
+  const readers = makeConfigReaders(resolveBaseRef(process.argv));
+  const results = evaluateAll({ readers, changedFiles });
+  reportSkips(results);
 
-  // Added-entry check: a PR may not GROW either debt list vs the base config.
-  // Bootstrapping exemption: if base has no entries for a rule, the list is
-  // being introduced — skip the added-entry check for that rule. If we
-  // couldn't read the base config at all, skip the check entirely (do not
-  // fail the build on infra/read errors); the touched-files check still runs.
-  let addedViolations = [];
-  if (baseConfig === null) {
-    console.log(
-      `${SCRIPT}: notice — could not read biome.json at ${baseRef}; skipping added-entry check`
-    );
-  } else {
-    addedViolations = ruleStates
-      .filter((rule) => rule.baseGlobs.length > 0)
-      .map((rule) => ({ rule, added: findAddedExemptions(rule.baseGlobs, rule.globs) }))
-      .filter((v) => v.added.length > 0);
+  const failures = results.filter((r) => r.failed);
+  const warnings = results.filter((r) => r.warned);
+
+  for (const result of warnings) {
+    for (const line of formatGrowthReport(result)) console.log(line);
   }
 
-  if (touchedViolations.length === 0 && addedViolations.length === 0) {
+  if (failures.length === 0) {
     console.log(`${SCRIPT}: OK (${changedFiles.length} changed file(s), 0 still on any debt list)`);
     return 0;
   }
 
   console.error(`${SCRIPT}: FAIL`);
-  for (const { rule, touched } of touchedViolations) {
-    console.error('');
-    console.error(`The following changed files are still on the ${rule.label} debt list`);
-    console.error(`(biome.json \`overrides\` → ${rule.overrideName} = off):`);
-    console.error('');
-    for (const f of touched) console.error(`  - ${f}  [${rule.label}]`);
-    console.error('');
-    console.error(rule.fixIt);
-  }
-  for (const { rule, added } of addedViolations) {
-    console.error('');
-    console.error(
-      `The ${rule.label} debt list is frozen and must not grow; this PR adds new entries`
-    );
-    console.error(`(biome.json \`overrides\` → ${rule.overrideName} = off):`);
-    console.error('');
-    for (const g of added) console.error(`  + ${g}  [${rule.label}]`);
-    console.error('');
-    console.error(
-      `Fix: bring every function in the file under the configured per-function biome cap\n` +
-        `instead of adding it to the ${rule.label} debt list.`
-    );
+  for (const result of failures) {
+    if (result.touched?.length) {
+      for (const line of formatTouchedReport(result)) console.error(line);
+    }
+    if (result.added.length) {
+      for (const line of formatGrowthReport(result)) console.error(line);
+    }
   }
   return 1;
 }

--- a/packages/dev-tools/tools/ci-quarantine-lib.mjs
+++ b/packages/dev-tools/tools/ci-quarantine-lib.mjs
@@ -1,0 +1,158 @@
+// Pure logic for the CI quarantine gate: every `continue-on-error: true` step
+// in the gated workflows must be declared in ci-quarantine.json with a reason,
+// an owner, and a review date.
+//
+// An undeclared quarantine fails. A quarantine past its review date only warns,
+// and so does a registry entry whose step has disappeared: a date-triggered
+// hard failure would break PRs that have nothing to do with the debt, which is
+// worse than the debt itself.
+//
+// The IO + CLI wiring lives in `check-ci-quarantine.mjs`.
+
+const QUARANTINE_LINE = /^continue-on-error:\s*true\b/;
+const BLOCK_SCALAR = /:\s*[|>][+-]?\d*\s*$/;
+const TOP_LEVEL_KEY = /^([A-Za-z_][\w-]*):/;
+const JOB_KEY = /^ {2}([A-Za-z_][\w-]*):\s*(#.*)?$/;
+const LIST_ITEM = /^(\s+)-\s+([A-Za-z_][\w-]*):\s*(.*)$/;
+const MAPPING_KEY = /^(\s+)([A-Za-z_][\w-]*):\s*(.*)$/;
+
+function unquote(value) {
+  const v = value.trim().replace(/\s+#.*$/, '');
+  const m = /^(['"])(.*)\1$/.exec(v);
+  return m ? m[2] : v;
+}
+
+export function quarantineKey({ workflow, job, step }) {
+  return `${workflow}\u0000${job}\u0000${step}`;
+}
+
+/**
+ * Scan a workflow file's text for step-level `continue-on-error: true`, without
+ * a YAML dependency. Block scalars (`run: |`, `if: |`) are skipped wholesale so
+ * an embedded shell script can neither hide nor fake a quarantine.
+ *
+ * @param {string} text raw workflow YAML
+ * @param {string} workflow repo-relative workflow path, echoed into results
+ * @returns {{workflow: string, job: string, step: string, line: number}[]}
+ */
+function updateJobContext(ctx, raw, trimmed, indent) {
+  if (indent === 0) {
+    const top = TOP_LEVEL_KEY.exec(trimmed);
+    if (top) {
+      ctx.inJobs = top[1] === 'jobs';
+      ctx.job = '';
+      ctx.step = '';
+      return true;
+    }
+  }
+  const jobKey = ctx.inJobs ? JOB_KEY.exec(raw) : null;
+  if (!jobKey) return false;
+  ctx.job = jobKey[1];
+  ctx.step = '';
+  return true;
+}
+
+function updateStepContext(ctx, raw) {
+  const item = LIST_ITEM.exec(raw);
+  if (item) {
+    ctx.step = item[2] === 'name' ? unquote(item[3]) : `<${item[2]}: ${unquote(item[3])}>`;
+    return true;
+  }
+  const mapping = MAPPING_KEY.exec(raw);
+  if (mapping && mapping[2] === 'name' && ctx.step) ctx.step = unquote(mapping[3]);
+  return false;
+}
+
+export function parseContinueOnErrorSteps(text, workflow = '') {
+  const out = [];
+  const ctx = { inJobs: false, job: '', step: '', blockIndent: null };
+  const lines = String(text ?? '').split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) continue;
+    const indent = raw.length - raw.trimStart().length;
+    if (ctx.blockIndent !== null) {
+      if (indent > ctx.blockIndent) continue;
+      ctx.blockIndent = null;
+    }
+    if (trimmed.startsWith('#')) continue;
+    if (BLOCK_SCALAR.test(raw)) ctx.blockIndent = indent;
+    if (updateJobContext(ctx, raw, trimmed, indent)) continue;
+    if (updateStepContext(ctx, raw)) continue;
+    if (QUARANTINE_LINE.test(trimmed)) {
+      out.push({ workflow, job: ctx.job, step: ctx.step || '(unnamed step)', line: i + 1 });
+    }
+  }
+  return out;
+}
+
+const DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function validateRegistry(registry) {
+  const problems = [];
+  const workflows = Array.isArray(registry?.workflows) ? registry.workflows : [];
+  if (workflows.length === 0) problems.push('`workflows` must list at least one workflow path');
+  const entries = Array.isArray(registry?.quarantines) ? registry.quarantines : [];
+  entries.forEach((entry, idx) => {
+    const at = `quarantines[${idx}]`;
+    for (const field of ['workflow', 'job', 'step']) {
+      if (typeof entry?.[field] !== 'string' || entry[field].trim().length === 0) {
+        problems.push(`${at}: missing \`${field}\``);
+      }
+    }
+    if (typeof entry?.reason !== 'string' || entry.reason.trim().length < 20) {
+      problems.push(`${at}: \`reason\` must be a real sentence, not a placeholder`);
+    }
+    if (typeof entry?.owner !== 'string' || entry.owner.trim().length === 0) {
+      problems.push(`${at}: missing \`owner\``);
+    }
+    if (typeof entry?.reviewBy !== 'string' || !DATE.test(entry.reviewBy)) {
+      problems.push(`${at}: \`reviewBy\` must be a YYYY-MM-DD date`);
+    }
+    if (entry?.workflow && !workflows.includes(entry.workflow)) {
+      problems.push(`${at}: \`workflow\` is not listed in \`workflows\``);
+    }
+  });
+  return problems;
+}
+
+/**
+ * Compare the quarantines found in the workflows against the registry.
+ *
+ * @param {{registry: object, found: {workflow: string, job: string, step: string, line: number}[], today: string}} input
+ * @returns {{invalid: string[], unregistered: object[], stale: object[], expired: object[], ok: number}}
+ */
+export function evaluateQuarantines({ registry, found, today }) {
+  const invalid = validateRegistry(registry);
+  const entries = Array.isArray(registry?.quarantines) ? registry.quarantines : [];
+  const byKey = new Map(entries.map((e) => [quarantineKey(e), e]));
+  const foundKeys = new Set((found ?? []).map(quarantineKey));
+  const unregistered = (found ?? []).filter((f) => !byKey.has(quarantineKey(f)));
+  const stale = entries.filter((e) => !foundKeys.has(quarantineKey(e)));
+  const expired = entries.filter(
+    (e) => typeof e?.reviewBy === 'string' && DATE.test(e.reviewBy) && e.reviewBy < today
+  );
+  return {
+    invalid,
+    unregistered,
+    stale,
+    expired,
+    ok: (found ?? []).length - unregistered.length,
+  };
+}
+
+export function formatUnregisteredHint(entry) {
+  return JSON.stringify(
+    {
+      workflow: entry.workflow,
+      job: entry.job,
+      step: entry.step,
+      reason: 'why this step is allowed to fail, and what makes that safe',
+      owner: 'owning package or area',
+      reviewBy: 'YYYY-MM-DD',
+    },
+    null,
+    2
+  );
+}

--- a/packages/dev-tools/tools/ci-quarantine-lib.test.mjs
+++ b/packages/dev-tools/tools/ci-quarantine-lib.test.mjs
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateQuarantines,
+  formatUnregisteredHint,
+  parseContinueOnErrorSteps,
+  quarantineKey,
+  validateRegistry,
+} from './ci-quarantine-lib.mjs';
+
+const WORKFLOW = `name: CI
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Lint
+        run: npm run lint:ci
+  worker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Emit timing report
+        if: always()
+        # a comment mentioning continue-on-error: true must not count
+        continue-on-error: true
+        run: npx vitest run --reporter=junit
+      - name: Deploy
+        continue-on-error: true
+        uses: cloudflare/wrangler-action@v4
+      - name: Inline script
+        run: |
+          echo "continue-on-error: true"
+          echo done
+`;
+
+const registryFor = (quarantines) => ({
+  workflows: ['.github/workflows/ci.yml'],
+  quarantines,
+});
+
+const entry = (job, step, overrides = {}) => ({
+  workflow: '.github/workflows/ci.yml',
+  job,
+  step,
+  reason: 'a genuinely explanatory reason, long enough to be meaningful',
+  owner: 'cloudflare-worker',
+  reviewBy: '2099-01-01',
+  ...overrides,
+});
+
+describe('parseContinueOnErrorSteps', () => {
+  const found = parseContinueOnErrorSteps(WORKFLOW, '.github/workflows/ci.yml');
+
+  it('attributes each quarantine to its job and step name', () => {
+    expect(found.map((f) => [f.job, f.step])).toEqual([
+      ['worker', 'Emit timing report'],
+      ['worker', 'Deploy'],
+    ]);
+  });
+
+  it('reports the workflow path and 1-based line number', () => {
+    expect(found[0].workflow).toBe('.github/workflows/ci.yml');
+    expect(WORKFLOW.split('\n')[found[0].line - 1].trim()).toBe('continue-on-error: true');
+  });
+
+  it('ignores commented-out and block-scalar occurrences', () => {
+    expect(found).toHaveLength(2);
+  });
+
+  it('does not confuse `on:` sub-keys with job names', () => {
+    expect(found.every((f) => f.job !== 'pull_request')).toBe(true);
+  });
+
+  it('tolerates empty input', () => {
+    expect(parseContinueOnErrorSteps('')).toEqual([]);
+    expect(parseContinueOnErrorSteps(null)).toEqual([]);
+  });
+
+  it('falls back to a placeholder for an unnamed step', () => {
+    const text =
+      'jobs:\n  a:\n    steps:\n      - uses: foo/bar@v1\n        continue-on-error: true\n';
+    expect(parseContinueOnErrorSteps(text)[0].step).toBe('<uses: foo/bar@v1>');
+  });
+});
+
+describe('validateRegistry', () => {
+  it('accepts a well-formed registry', () => {
+    expect(validateRegistry(registryFor([entry('worker', 'Deploy')]))).toEqual([]);
+  });
+
+  it('rejects a placeholder reason, a missing owner and a bad date', () => {
+    const problems = validateRegistry(
+      registryFor([entry('worker', 'Deploy', { reason: 'flaky', owner: '', reviewBy: 'soon' })])
+    );
+    expect(problems.join('\n')).toContain('`reason` must be a real sentence');
+    expect(problems.join('\n')).toContain('missing `owner`');
+    expect(problems.join('\n')).toContain('`reviewBy` must be a YYYY-MM-DD date');
+  });
+
+  it('rejects an entry for a workflow that is not gated', () => {
+    const problems = validateRegistry(
+      registryFor([entry('worker', 'Deploy', { workflow: '.github/workflows/other.yml' })])
+    );
+    expect(problems.join('\n')).toContain('not listed in `workflows`');
+  });
+
+  it('rejects a registry that gates no workflow', () => {
+    expect(validateRegistry({ quarantines: [] }).join('\n')).toContain('`workflows` must list');
+  });
+});
+
+describe('evaluateQuarantines', () => {
+  const found = parseContinueOnErrorSteps(WORKFLOW, '.github/workflows/ci.yml');
+
+  it('flags an undeclared quarantine', () => {
+    const result = evaluateQuarantines({
+      registry: registryFor([entry('worker', 'Emit timing report')]),
+      found,
+      today: '2026-07-27',
+    });
+    expect(result.unregistered.map((u) => u.step)).toEqual(['Deploy']);
+    expect(result.ok).toBe(1);
+  });
+
+  it('passes when every quarantine is declared', () => {
+    const result = evaluateQuarantines({
+      registry: registryFor([entry('worker', 'Emit timing report'), entry('worker', 'Deploy')]),
+      found,
+      today: '2026-07-27',
+    });
+    expect(result.unregistered).toEqual([]);
+    expect(result.invalid).toEqual([]);
+    expect(result.ok).toBe(2);
+  });
+
+  it('warns about an expired review date without making it a failure', () => {
+    const result = evaluateQuarantines({
+      registry: registryFor([
+        entry('worker', 'Emit timing report', { reviewBy: '2026-01-01' }),
+        entry('worker', 'Deploy'),
+      ]),
+      found,
+      today: '2026-07-27',
+    });
+    expect(result.expired.map((e) => e.step)).toEqual(['Emit timing report']);
+    expect(result.unregistered).toEqual([]);
+    expect(result.invalid).toEqual([]);
+  });
+
+  it('warns about a registry entry whose step no longer exists', () => {
+    const result = evaluateQuarantines({
+      registry: registryFor([
+        entry('worker', 'Emit timing report'),
+        entry('worker', 'Deploy'),
+        entry('worker', 'Step that was fixed'),
+      ]),
+      found,
+      today: '2026-07-27',
+    });
+    expect(result.stale.map((e) => e.step)).toEqual(['Step that was fixed']);
+    expect(result.unregistered).toEqual([]);
+  });
+
+  it('treats a same-named step in another job as undeclared', () => {
+    const result = evaluateQuarantines({
+      registry: registryFor([entry('lint', 'Deploy'), entry('worker', 'Emit timing report')]),
+      found,
+      today: '2026-07-27',
+    });
+    expect(result.unregistered.map((u) => `${u.job}/${u.step}`)).toEqual(['worker/Deploy']);
+  });
+
+  it('tolerates a registry with no quarantines array', () => {
+    const result = evaluateQuarantines({ registry: { workflows: ['x'] }, found: [], today: 'x' });
+    expect(result.unregistered).toEqual([]);
+    expect(result.stale).toEqual([]);
+  });
+});
+
+describe('quarantineKey', () => {
+  it('distinguishes identical step names in different jobs', () => {
+    expect(quarantineKey({ workflow: 'w', job: 'a', step: 's' })).not.toBe(
+      quarantineKey({ workflow: 'w', job: 'b', step: 's' })
+    );
+  });
+});
+
+describe('formatUnregisteredHint', () => {
+  it('emits a paste-ready registry stub', () => {
+    const hint = JSON.parse(
+      formatUnregisteredHint({ workflow: 'w.yml', job: 'worker', step: 'Deploy' })
+    );
+    expect(hint).toMatchObject({ workflow: 'w.yml', job: 'worker', step: 'Deploy' });
+    expect(hint.reviewBy).toBe('YYYY-MM-DD');
+  });
+});

--- a/packages/dev-tools/tools/coverage-ratchet-lib.mjs
+++ b/packages/dev-tools/tools/coverage-ratchet-lib.mjs
@@ -13,6 +13,19 @@ export const thresholdsPath = resolve(repoRoot, 'coverage-thresholds.json');
 
 export const TS_METRICS = ['lines', 'statements', 'functions', 'branches'];
 export const SWIFT_METRICS = ['lines', 'functions', 'regions'];
+// Go reports a single total-statement percentage (`go tool cover -func`).
+export const GO_METRICS = ['statements'];
+
+// Every floor group in coverage-thresholds.json and the metrics it carries.
+// applyRatchet walks this map instead of a hardcoded list, so adding a
+// language means adding one entry here. Ceiling sections of the same file
+// (e.g. testTiming) are deliberately absent: they ratchet downward through
+// ratchetCeilings, not upward through ratchetPackage.
+export const FLOOR_GROUPS = {
+  typescript: TS_METRICS,
+  swift: SWIFT_METRICS,
+  go: GO_METRICS,
+};
 
 // Half-point safety margin subtracted before flooring, so a measurement
 // like 63.06% won't ratchet a floor to 63 (which a 0.1pp jitter on the
@@ -29,6 +42,62 @@ export function nextFloor(currentFloor, actualPct) {
   const current = typeof currentFloor === 'number' ? currentFloor : 0;
   return Math.max(current, candidate);
 }
+
+// Round up to the next multiple of `step`, tolerating binary-float error so
+// 7.37 at a 0.1 step lands on 7.4 rather than 7.4000000000000005.
+function ceilTo(value, step) {
+  const rounded = Math.ceil(value / step - 1e-9) * step;
+  return Number(rounded.toFixed(10));
+}
+
+// The ceiling mirror of nextFloor: a budget only ever moves *down*, toward the
+// measurement, and never below it plus a safety margin. Returns the unchanged
+// ceiling when the measurement does not justify tightening (the "never move"
+// result), so callers can compare against the input to detect a change.
+//
+// Unlike floors, ceilings need per-metric granularity and margin *style*
+// (see the constants below): a straight mirror of nextFloor's whole-point step
+// would never tighten a 7.5% duplication budget measured at 7.07%, because
+// Math.ceil(7.07 + 0.5) = 8 is looser than the budget it replaces.
+export function nextCeiling(
+  currentCeiling,
+  actual,
+  { granularity = 1, margin = 0, marginRatio = 0 } = {}
+) {
+  const current =
+    typeof currentCeiling === 'number' && Number.isFinite(currentCeiling) ? currentCeiling : null;
+  if (typeof actual !== 'number' || !Number.isFinite(actual) || actual < 0) return current;
+  const candidate = ceilTo(actual + margin + actual * marginRatio, granularity);
+  return current === null ? candidate : Math.min(current, candidate);
+}
+
+// Duplication is a percentage like a coverage floor, but the budget lives one
+// order of magnitude finer (7.5%, not 75%), so whole-point steps are useless
+// here. 0.1pp granularity with a 0.3pp additive margin keeps 0.3-0.4pp of
+// headroom — the same headroom jscpd.json already documents, and the same
+// role MARGIN = 0.5 plays for floors (see PR #1015): enough slack that
+// ordinary churn cannot flip the gate red on the next run, while each ratchet
+// step is still a single reviewable tenth of a point.
+export const DUPLICATION_GRANULARITY = 0.1;
+export const DUPLICATION_MARGIN = 0.3;
+
+// Bundle bytes need a *proportional* margin, not an additive one: a 21 kB
+// entry chunk and a 31 MB payload jitter by wildly different absolute amounts
+// on an ordinary dependency bump. 5% headroom absorbs that; a tighter
+// auto-lowered byte ceiling would fail unrelated PRs, which is exactly how a
+// ratchet loses its credibility. Rounding is to a whole unit of the budget's
+// own declared unit (kB or MB), so each step stays reviewable.
+export const BYTES_MARGIN_RATIO = 0.05;
+
+// Test durations are the noisiest signal of the three: the nightly ratchet
+// measures on macos-latest while the gate runs on ubuntu-latest, and both are
+// shared runners under variable load. Cross-runner spread dwarfs the ~0.5pp
+// jitter MARGIN was sized for, so the timing ceiling keeps 100% headroom
+// (2x measured) rounded to 50 ms. That is deliberately loose: the metric
+// exists to catch order-of-magnitude drift (a 200 ms test becoming a 3 s
+// test), not to police 10% regressions.
+export const TIMING_MARGIN_RATIO = 1;
+export const TIMING_GRANULARITY_MS = 50;
 
 // Compute ratcheted floors for one package against measured percentages.
 // Returns the new floor map plus a per-metric change list (only metrics
@@ -51,14 +120,12 @@ export function ratchetPackage(currentFloors, measuredPct, metrics) {
 
 // Apply the ratchet across the whole thresholds document. `measured` mirrors
 // the thresholds shape: { typescript: { pkg: { lines, ... } }, swift: { ... } }
-// with percentage values. Preserves untouched fields (e.g. coverageExclude).
+// with percentage values. Preserves untouched fields (e.g. coverageExclude)
+// and every non-floor section of the document (e.g. testTiming ceilings).
 export function applyRatchet(thresholds, measured) {
   const next = structuredClone(thresholds);
   const changes = [];
-  for (const [group, metrics] of [
-    ['typescript', TS_METRICS],
-    ['swift', SWIFT_METRICS],
-  ]) {
+  for (const [group, metrics] of Object.entries(FLOOR_GROUPS)) {
     const groupFloors = next[group] ?? {};
     const groupMeasured = measured[group] ?? {};
     for (const pkg of Object.keys(groupFloors)) {

--- a/packages/dev-tools/tools/coverage-ratchet-lib.mjs
+++ b/packages/dev-tools/tools/coverage-ratchet-lib.mjs
@@ -91,12 +91,14 @@ export const BYTES_MARGIN_RATIO = 0.05;
 
 // Test durations are the noisiest signal of the three: the nightly ratchet
 // measures on macos-latest while the gate runs on ubuntu-latest, and both are
-// shared runners under variable load. Cross-runner spread dwarfs the ~0.5pp
-// jitter MARGIN was sized for, so the timing ceiling keeps 100% headroom
-// (2x measured) rounded to 50 ms. That is deliberately loose: the metric
-// exists to catch order-of-magnitude drift (a 200 ms test becoming a 3 s
-// test), not to police 10% regressions.
-export const TIMING_MARGIN_RATIO = 1;
+// shared runners under variable load — a factor-of-two spread between the two
+// for the same test is ordinary. That dwarfs the ~0.5pp jitter MARGIN was
+// sized for, so the timing ceiling keeps 4x the measured p95, rounded to
+// 50 ms. Deliberately loose: the metric exists to catch order-of-magnitude
+// drift (every test suddenly waiting on a 500 ms timeout), not to police 10%
+// regressions, and a ceiling that fires on unrelated PRs would discredit the
+// whole ratchet faster than the drift it watches.
+export const TIMING_MARGIN_RATIO = 3;
 export const TIMING_GRANULARITY_MS = 50;
 
 // Compute ratcheted floors for one package against measured percentages.

--- a/packages/dev-tools/tools/coverage-ratchet-lib.test.mjs
+++ b/packages/dev-tools/tools/coverage-ratchet-lib.test.mjs
@@ -73,10 +73,10 @@ describe('nextCeiling', () => {
     expect(nextCeiling(31, 29.62, bytes)).toBe(31);
   });
 
-  it('keeps 2x headroom at 50 ms steps for durations', () => {
+  it('keeps 4x headroom at 50 ms steps for durations', () => {
     const timing = { granularity: TIMING_GRANULARITY_MS, marginRatio: TIMING_MARGIN_RATIO };
-    expect(nextCeiling(4000, 620, timing)).toBe(1250);
-    expect(nextCeiling(1250, 700, timing)).toBe(1250);
+    expect(nextCeiling(4000, 620, timing)).toBe(2500);
+    expect(nextCeiling(2500, 700, timing)).toBe(2500);
   });
 
   it('adopts the measurement when no ceiling exists yet', () => {

--- a/packages/dev-tools/tools/coverage-ratchet-lib.test.mjs
+++ b/packages/dev-tools/tools/coverage-ratchet-lib.test.mjs
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyRatchet,
+  BYTES_MARGIN_RATIO,
+  DUPLICATION_GRANULARITY,
+  DUPLICATION_MARGIN,
+  FLOOR_GROUPS,
+  nextCeiling,
   nextFloor,
   parseVitestSummary,
   ratchetPackage,
+  TIMING_GRANULARITY_MS,
+  TIMING_MARGIN_RATIO,
 } from './coverage-ratchet-lib.mjs';
 
 describe('nextFloor', () => {
@@ -33,6 +40,55 @@ describe('nextFloor', () => {
   it('keeps the floor when measurement is within the margin of the next integer (PR #1015 miss)', () => {
     expect(nextFloor(62, 63.06)).toBe(62);
     expect(nextFloor(62, 63.6)).toBe(63);
+  });
+});
+
+describe('nextCeiling', () => {
+  const duplication = {
+    granularity: DUPLICATION_GRANULARITY,
+    margin: DUPLICATION_MARGIN,
+  };
+
+  it('tightens a ceiling toward the measurement at the configured granularity', () => {
+    expect(nextCeiling(7.5, 7.07, duplication)).toBe(7.4);
+    expect(nextCeiling(7.4, 6.5, duplication)).toBe(6.8);
+  });
+
+  it('never raises a ceiling', () => {
+    expect(nextCeiling(7.5, 7.4, duplication)).toBe(7.5);
+    expect(nextCeiling(7.5, 9, duplication)).toBe(7.5);
+  });
+
+  it('returns the current ceiling unchanged when tightening is not justified', () => {
+    // The whole-point mirror of nextFloor would propose Math.ceil(7.07 + 0.5)
+    // = 8 here, i.e. a *looser* budget than the 7.5 already in the tree.
+    expect(nextCeiling(7.5, 7.07, { granularity: 1, margin: 0.5 })).toBe(7.5);
+  });
+
+  it('applies a proportional margin for byte budgets', () => {
+    const bytes = { granularity: 1, marginRatio: BYTES_MARGIN_RATIO };
+    expect(nextCeiling(24, 21.39, bytes)).toBe(23);
+    expect(nextCeiling(60, 55.86, bytes)).toBe(59);
+    // 29.62 MB * 1.05 = 31.1 MB, which does not fit under a 31 MB budget.
+    expect(nextCeiling(31, 29.62, bytes)).toBe(31);
+  });
+
+  it('keeps 2x headroom at 50 ms steps for durations', () => {
+    const timing = { granularity: TIMING_GRANULARITY_MS, marginRatio: TIMING_MARGIN_RATIO };
+    expect(nextCeiling(4000, 620, timing)).toBe(1250);
+    expect(nextCeiling(1250, 700, timing)).toBe(1250);
+  });
+
+  it('adopts the measurement when no ceiling exists yet', () => {
+    expect(nextCeiling(undefined, 7.07, duplication)).toBe(7.4);
+    expect(nextCeiling(null, 7.07, duplication)).toBe(7.4);
+  });
+
+  it('never moves on a missing or nonsense measurement', () => {
+    expect(nextCeiling(7.5, Number.NaN, duplication)).toBe(7.5);
+    expect(nextCeiling(7.5, undefined, duplication)).toBe(7.5);
+    expect(nextCeiling(7.5, -1, duplication)).toBe(7.5);
+    expect(nextCeiling(undefined, Number.NaN, duplication)).toBe(null);
   });
 });
 
@@ -90,6 +146,27 @@ describe('applyRatchet', () => {
       'swift-server.lines',
       'swift-server.regions',
     ]);
+  });
+
+  it('ratchets every declared floor group, including go', () => {
+    const thresholds = {
+      typescript: {},
+      swift: {},
+      go: { 'slicc-cli': { statements: 58 } },
+      testTiming: { webapp: { p95Ms: 1250 } },
+    };
+    const { thresholds: next, changes } = applyRatchet(thresholds, {
+      go: { 'slicc-cli': { statements: 61.4 } },
+    });
+    expect(next.go['slicc-cli'].statements).toBe(60);
+    expect(next.testTiming).toEqual({ webapp: { p95Ms: 1250 } });
+    expect(changes).toEqual([
+      { group: 'go', package: 'slicc-cli', metric: 'statements', from: 58, to: 60, actual: 61.4 },
+    ]);
+  });
+
+  it('declares one metric list per floor group', () => {
+    expect(Object.keys(FLOOR_GROUPS)).toEqual(['typescript', 'swift', 'go']);
   });
 
   it('skips packages with no measurement', () => {

--- a/packages/dev-tools/tools/coverage-ratchet.mjs
+++ b/packages/dev-tools/tools/coverage-ratchet.mjs
@@ -1,22 +1,43 @@
 #!/usr/bin/env node
-// Coverage ratchet. Measures current coverage for every gated package and
-// raises the floors in coverage-thresholds.json toward reality (never
-// lowering, keeping ~0.5-1.5pp headroom via a half-point safety margin;
-// see nextFloor in coverage-ratchet-lib.mjs). Intended to run nightly; a
-// workflow then opens a PR when the file changed. Each ratchet step is a
-// clean whole-point bump, so there is never a sub-1pp change to review.
+// Coverage / budget ratchet. Measures the current state of every gated budget
+// and moves it toward reality: coverage floors in coverage-thresholds.json go
+// *up* (never down), while the ceilings — duplication in jscpd.json, the
+// `size-limit` budgets in packages/*/package.json and the per-test duration
+// ceilings in coverage-thresholds.json `testTiming` — come *down* (never up).
+// Both directions keep a safety margin so ordinary jitter cannot flip a gate
+// red on the next run (see nextFloor / nextCeiling in coverage-ratchet-lib.mjs).
+// Intended to run nightly; a workflow then opens a PR when something changed.
 //
 // Usage:
 //   node packages/dev-tools/tools/coverage-ratchet.mjs [options]
-//     --ts-only        only measure TypeScript packages
-//     --swift-only     only measure Swift packages
-//     --no-write       print proposed changes without editing the file
-//     --github-output  append `changed=<bool>` to $GITHUB_OUTPUT
+//     --ts-only            only measure TypeScript coverage
+//     --swift-only         only measure Swift coverage
+//     --go-only            only measure Go coverage
+//     --duplication-only   only measure the jscpd duplication ceiling
+//     --bundle-only        only measure the size-limit ceilings
+//     --timing-only        only measure the per-test duration ceilings
+//     --only=<pkg>         restrict TypeScript/Swift/timing to one package
+//     --no-write           print proposed changes without editing any file
+//     --github-output      append `changed=<bool>` to $GITHUB_OUTPUT
 
 import { spawnSync } from 'node:child_process';
 import { appendFileSync, existsSync, mkdtempSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import {
+  nextDuplicationThreshold,
+  parseJscpdPercentage,
+  parseSizeLimitJson,
+  ratchetSizeLimits,
+  ratchetTiming,
+  readJscpdConfig,
+  readPackageJson,
+  SIZE_LIMIT_PACKAGES,
+  summarizeTiming,
+  TIMED_PROJECTS,
+  writeJscpdThreshold,
+  writeSizeLimits,
+} from './ceiling-ratchet-lib.mjs';
 import {
   applyRatchet,
   parseVitestSummary,
@@ -26,13 +47,15 @@ import {
   writeThresholds,
 } from './coverage-ratchet-lib.mjs';
 
-const flags = new Set(process.argv.slice(2));
-const doTs = !flags.has('--swift-only');
-const doSwift = !flags.has('--ts-only');
+const argv = process.argv.slice(2);
+const flags = new Set(argv);
 const write = !flags.has('--no-write');
+const MEASUREMENTS = ['ts', 'swift', 'go', 'duplication', 'bundle', 'timing'];
+const exclusive = MEASUREMENTS.filter((name) => flags.has(`--${name}-only`));
+const enabled = (name) => exclusive.length === 0 || exclusive.includes(name);
 // `--only=<pkg>` restricts measurement to a single package (useful for
 // verifying one package's coverage path without re-measuring the whole repo).
-const onlyArg = process.argv.slice(2).find((a) => a.startsWith('--only='));
+const onlyArg = argv.find((a) => a.startsWith('--only='));
 const only = onlyArg ? onlyArg.slice('--only='.length) : null;
 
 const SWIFT_BUNDLES = {
@@ -52,6 +75,21 @@ const TS_CONFIG_OVERRIDES = {
   webcomponents: 'packages/webcomponents/vitest.config.ts',
 };
 
+const timingMeasured = {};
+
+function readTiming(file, project) {
+  if (!existsSync(file)) {
+    console.error(`  [skip] ${project} timing: no vitest json report`);
+    return;
+  }
+  const summary = summarizeTiming(JSON.parse(readFileSync(file, 'utf-8')), TIMED_PROJECTS[project]);
+  if (!summary) {
+    console.error(`  [skip] ${project} timing: no per-test durations in the report`);
+    return;
+  }
+  timingMeasured[project] = summary;
+}
+
 function measureTs(pkg, floors) {
   const out = mkdtempSync(join(tmpdir(), `cov-${pkg}-`));
   const configPath = TS_CONFIG_OVERRIDES[pkg];
@@ -67,7 +105,14 @@ function measureTs(pkg, floors) {
   if (Array.isArray(floors.coverageExclude)) {
     for (const pattern of floors.coverageExclude) args.push(`--coverage.exclude=${pattern}`);
   }
+  // The timed projects get their per-test durations out of this same run, so
+  // the timing ceilings cost no extra suite execution.
+  const timingFile = TIMED_PROJECTS[pkg] ? join(out, 'timing.json') : null;
+  if (timingFile) {
+    args.push('--reporter=default', '--reporter=json', `--outputFile=${timingFile}`);
+  }
   const res = spawnSync('npx', args, { cwd: repoRoot, stdio: 'inherit', env: process.env });
+  if (timingFile && enabled('timing')) readTiming(timingFile, pkg);
   const summaryFile = join(out, 'coverage-summary.json');
   if (!existsSync(summaryFile)) {
     console.error(`  [skip] ${pkg}: no coverage-summary.json (exit ${res.status})`);
@@ -105,10 +150,101 @@ function measureSwift(pkg) {
   return measured;
 }
 
-const thresholds = readThresholds();
-const measured = { typescript: {}, swift: {} };
+// Go total-statement coverage, via the same `make cover` path CI gates with.
+// COVER_MIN=0 so measurement never fails here; the real floor still gates in CI.
+function measureGo(pkg) {
+  const res = spawnSync('make', ['cover', 'COVER_MIN=0'], {
+    cwd: resolve(repoRoot, `packages/${pkg}`),
+    encoding: 'utf-8',
+    env: process.env,
+  });
+  const output = `${res.stdout ?? ''}${res.stderr ?? ''}`;
+  const match = /total coverage:\s*([\d.]+)%/.exec(output);
+  if (!match) {
+    console.error(`  [skip] ${pkg}: make cover produced no total (exit ${res.status})`);
+    return null;
+  }
+  return { statements: Number(match[1]) };
+}
 
-if (doTs) {
+function measureDuplication() {
+  const out = mkdtempSync(join(tmpdir(), 'jscpd-ratchet-'));
+  // --threshold 100 so jscpd reports instead of failing on the current budget.
+  const res = spawnSync(
+    'npx',
+    [
+      'jscpd',
+      '--config',
+      'jscpd.json',
+      '--no-tips',
+      '--threshold',
+      '100',
+      '--reporters',
+      'json,silent',
+      '--output',
+      out,
+    ],
+    { cwd: repoRoot, stdio: 'inherit', env: process.env }
+  );
+  const reportFile = join(out, 'jscpd-report.json');
+  if (!existsSync(reportFile)) {
+    console.error(`  [skip] duplication: no jscpd-report.json (exit ${res.status})`);
+    return null;
+  }
+  const pct = parseJscpdPercentage(JSON.parse(readFileSync(reportFile, 'utf-8')));
+  if (pct === null) console.error('  [skip] duplication: report carries no total percentage');
+  return pct;
+}
+
+// size-limit measures the built artifacts, so a stale or missing dist/ would
+// hand the ratchet a wrong number. It exits non-zero and prints nothing usable
+// when a configured path matches no file, which is the skip signal here.
+function measureBundleSizes(pkgDir) {
+  const res = spawnSync('npx', ['size-limit', '--json'], {
+    cwd: resolve(repoRoot, pkgDir),
+    encoding: 'utf-8',
+    env: process.env,
+  });
+  let report;
+  try {
+    report = JSON.parse(res.stdout ?? '');
+  } catch {
+    console.error(`  [skip] ${pkgDir}: size-limit produced no JSON (exit ${res.status}) — built?`);
+    if (res.stderr) console.error(res.stderr.trim());
+    return null;
+  }
+  const sizes = parseSizeLimitJson(report);
+  if (Object.keys(sizes).length === 0) {
+    console.error(`  [skip] ${pkgDir}: size-limit reported no budgets`);
+    return null;
+  }
+  return sizes;
+}
+
+// Timing-only mode still needs the suite to run, but not with coverage.
+function measureTimingStandalone(project) {
+  const out = mkdtempSync(join(tmpdir(), `timing-${project}-`));
+  const timingFile = join(out, 'timing.json');
+  spawnSync(
+    'npx',
+    [
+      'vitest',
+      'run',
+      '--project',
+      project,
+      '--reporter=default',
+      '--reporter=json',
+      `--outputFile=${timingFile}`,
+    ],
+    { cwd: repoRoot, stdio: 'inherit', env: process.env }
+  );
+  readTiming(timingFile, project);
+}
+
+const thresholds = readThresholds();
+const measured = { typescript: {}, swift: {}, go: {} };
+
+if (enabled('ts')) {
   for (const pkg of Object.keys(thresholds.typescript ?? {})) {
     if (only && pkg !== only) continue;
     console.error(`==> measuring TypeScript: ${pkg}`);
@@ -116,7 +252,7 @@ if (doTs) {
     if (m) measured.typescript[pkg] = m;
   }
 }
-if (doSwift) {
+if (enabled('swift')) {
   for (const pkg of Object.keys(thresholds.swift ?? {})) {
     if (only && pkg !== only) continue;
     console.error(`==> measuring Swift: ${pkg}`);
@@ -124,26 +260,116 @@ if (doSwift) {
     if (m) measured.swift[pkg] = m;
   }
 }
+if (enabled('go')) {
+  for (const pkg of Object.keys(thresholds.go ?? {})) {
+    if (only && pkg !== only) continue;
+    console.error(`==> measuring Go: ${pkg}`);
+    const m = measureGo(pkg);
+    if (m) measured.go[pkg] = m;
+  }
+}
+if (enabled('timing') && !enabled('ts')) {
+  for (const project of Object.keys(TIMED_PROJECTS)) {
+    if (only && project !== only) continue;
+    console.error(`==> measuring test timing: ${project}`);
+    measureTimingStandalone(project);
+  }
+}
 
 const { thresholds: next, changes } = applyRatchet(thresholds, measured);
 
+const timingChanges = [];
+if (enabled('timing')) {
+  const { ceilings, changes: tChanges } = ratchetTiming(next.testTiming, timingMeasured);
+  if (tChanges.length > 0) next.testTiming = ceilings;
+  timingChanges.push(...tChanges);
+}
+
+let duplicationChange = null;
+if (enabled('duplication')) {
+  console.error('==> measuring duplication');
+  const pct = measureDuplication();
+  if (pct !== null) {
+    duplicationChange = nextDuplicationThreshold(readJscpdConfig().threshold, pct);
+  }
+}
+
+const bundleUpdates = [];
+if (enabled('bundle')) {
+  for (const pkgDir of SIZE_LIMIT_PACKAGES) {
+    console.error(`==> measuring bundle size: ${pkgDir}`);
+    const sizes = measureBundleSizes(pkgDir);
+    if (!sizes) continue;
+    const sizeChanges = ratchetSizeLimits(readPackageJson(pkgDir), sizes);
+    if (sizeChanges.length > 0) bundleUpdates.push({ pkgDir, changes: sizeChanges });
+  }
+}
+
+const bundleChanges = bundleUpdates.flatMap((u) =>
+  u.changes.map((c) => ({ pkgDir: u.pkgDir, ...c }))
+);
+const changed =
+  changes.length > 0 ||
+  timingChanges.length > 0 ||
+  bundleChanges.length > 0 ||
+  duplicationChange !== null;
+
 console.log('\n=== Coverage ratchet ===');
 if (changes.length === 0) {
-  console.log('No floors raised; coverage-thresholds.json unchanged.');
+  console.log('No floors raised.');
 } else {
   for (const c of changes) {
     console.log(
       `  ${c.group}/${c.package} ${c.metric}: ${c.from} -> ${c.to} (measured ${c.actual}%)`
     );
   }
-  if (write) {
+}
+
+console.log('\n=== Ceiling ratchet ===');
+if (duplicationChange) {
+  console.log(
+    `  duplication threshold: ${duplicationChange.from} -> ${duplicationChange.to} (measured ${duplicationChange.actual.toFixed(2)}%)`
+  );
+}
+for (const c of bundleChanges) {
+  console.log(
+    `  ${c.name}: ${c.from} ${c.unit} -> ${c.to} ${c.unit} (measured ${c.actualBytes} B)`
+  );
+}
+for (const project of Object.keys(timingMeasured)) {
+  const m = timingMeasured[project];
+  console.log(
+    `  [measured] ${project} timing: p95 ${m.p95Ms}ms, slowest ${m.slowestMs}ms over ${m.tests} tests (${m.retried} retried, excluded)`
+  );
+}
+for (const c of timingChanges) {
+  console.log(
+    `  ${c.project} ${c.metric}: ${c.from ?? '(unset)'} -> ${c.to} (measured p95 ${c.actual}ms)`
+  );
+}
+if (!changed) console.log('  No ceilings tightened.');
+
+if (changed && write) {
+  if (changes.length > 0 || timingChanges.length > 0) {
     writeThresholds(next);
     console.log('coverage-thresholds.json updated.');
-  } else {
-    console.log('(--no-write: file not modified)');
   }
+  if (duplicationChange) {
+    const ok = writeJscpdThreshold(duplicationChange.to);
+    console.log(ok ? 'jscpd.json updated.' : '  [skip] jscpd.json: no threshold to patch');
+  }
+  for (const update of bundleUpdates) {
+    const ok = writeSizeLimits(update.pkgDir, update.changes);
+    console.log(
+      ok
+        ? `${update.pkgDir}/package.json updated.`
+        : `  [skip] ${update.pkgDir}: size-limit block not patchable`
+    );
+  }
+} else if (changed) {
+  console.log('(--no-write: no file modified)');
 }
 
 if (flags.has('--github-output') && process.env.GITHUB_OUTPUT) {
-  appendFileSync(process.env.GITHUB_OUTPUT, `changed=${changes.length > 0}\n`);
+  appendFileSync(process.env.GITHUB_OUTPUT, `changed=${changed}\n`);
 }

--- a/packages/dev-tools/tools/coverage-ratchet.mjs
+++ b/packages/dev-tools/tools/coverage-ratchet.mjs
@@ -308,11 +308,9 @@ if (enabled('bundle')) {
 const bundleChanges = bundleUpdates.flatMap((u) =>
   u.changes.map((c) => ({ pkgDir: u.pkgDir, ...c }))
 );
-const changed =
-  changes.length > 0 ||
-  timingChanges.length > 0 ||
-  bundleChanges.length > 0 ||
-  duplicationChange !== null;
+const ceilingChanged =
+  timingChanges.length > 0 || bundleChanges.length > 0 || duplicationChange !== null;
+const changed = changes.length > 0 || ceilingChanged;
 
 console.log('\n=== Coverage ratchet ===');
 if (changes.length === 0) {
@@ -347,7 +345,7 @@ for (const c of timingChanges) {
     `  ${c.project} ${c.metric}: ${c.from ?? '(unset)'} -> ${c.to} (measured p95 ${c.actual}ms)`
   );
 }
-if (!changed) console.log('  No ceilings tightened.');
+if (!ceilingChanged) console.log('  No ceilings tightened.');
 
 if (changed && write) {
   if (changes.length > 0 || timingChanges.length > 0) {

--- a/packages/dev-tools/tools/debt-list-sources.mjs
+++ b/packages/dev-tools/tools/debt-list-sources.mjs
@@ -1,0 +1,243 @@
+// Declarative registry of the repo's debt/exemption lists and the pure logic
+// that decides whether a PR is allowed to grow them.
+//
+// A "debt list source" is a config file plus a way to read its exemption
+// entries, plus the semantics the gate applies to it. The semantics differ per
+// source ON PURPOSE — do not unify them into uniform harshness:
+//
+//   touched: true
+//     Only for lists whose every entry is a file that CAN be fixed (the two
+//     biome complexity debt lists). Touching such a file means paying its debt
+//     down in the same PR. Applying this to a list that legitimately contains
+//     permanent entries (generated files, `*.d.ts`, vendored code, fixtures)
+//     would force pointless refactors on innocent PRs.
+//   freeze: true + failOnGrowth: true
+//     The list may not gain entries. Safe for every source here, including the
+//     ones with permanent entries: existing entries stay, new ones need either
+//     a real fix or a deliberate, reviewed config change.
+//   freeze: true + failOnGrowth: false
+//     Report growth, never fail. For lists where growth is routinely
+//     legitimate and outside the author's control (knip's ignoreDependencies
+//     grows with Renovate and with every new build tool).
+//
+// Every source carries the same bootstrapping exemption: entries whose scope
+// has no entries at all in the base ref are ignored, because that scope (a
+// whole list, or one package inside a per-package list) is being INTRODUCED by
+// the PR under test rather than grown by it.
+//
+// The functions here are pure (no IO) and unit-tested by the `dev-tools`
+// vitest project. The IO + CLI driver lives in `check-touched-exemptions.mjs`.
+
+import { findAddedExemptions, findTouchedExemptions } from './size-exemption-lib.mjs';
+
+// Separates an entry's scope from its value in the flattened entry strings the
+// extractors emit. Config globs and package names never contain it.
+export const SCOPE_DELIMITER = '::';
+
+export function scopeOfEntry(entry) {
+  if (typeof entry !== 'string') return '';
+  const i = entry.indexOf(SCOPE_DELIMITER);
+  return i === -1 ? '' : entry.slice(0, i);
+}
+
+export function scopedEntry(scope, value) {
+  return scope ? `${scope}${SCOPE_DELIMITER}${value}` : value;
+}
+
+// Entries added vs the base ref, minus every entry whose scope is absent from
+// the base (the bootstrapping exemption). Unscoped lists have the single scope
+// '', so an empty base list exempts all of its entries.
+export function findAddedEntries(baseEntries, currentEntries) {
+  const added = findAddedExemptions(baseEntries, currentEntries);
+  if (added.length === 0) return [];
+  const base = Array.isArray(baseEntries) ? baseEntries : [];
+  const baseScopes = new Set(base.filter((e) => typeof e === 'string').map(scopeOfEntry));
+  return added.filter((entry) => baseScopes.has(scopeOfEntry(entry)));
+}
+
+function collectStrings(value) {
+  return Array.isArray(value) ? value.filter((v) => typeof v === 'string' && v.length > 0) : [];
+}
+
+function dedupe(entries) {
+  return [...new Set(entries)];
+}
+
+// Biome `overrides` blocks that turn OFF rules outside the `complexity` group,
+// or disable the linter wholesale. These are policy-shaped debt: unlike the two
+// complexity debt lists they are not per-function-fixable, so they are frozen
+// but never trigger the touched-file rule.
+export function extractBiomeRuleDisablingGlobs(biomeConfig) {
+  const overrides = Array.isArray(biomeConfig?.overrides) ? biomeConfig.overrides : [];
+  const out = [];
+  for (const override of overrides) {
+    const linter = override?.linter;
+    if (!linter || typeof linter !== 'object') continue;
+    const rules = linter.rules;
+    const disablesNonComplexityRule =
+      !!rules &&
+      typeof rules === 'object' &&
+      Object.entries(rules).some(
+        ([group, groupRules]) =>
+          group !== 'complexity' &&
+          !!groupRules &&
+          typeof groupRules === 'object' &&
+          Object.values(groupRules).some((level) => level === 'off')
+      );
+    if (linter.enabled !== false && !disablesNonComplexityRule) continue;
+    out.push(...collectStrings(override.includes));
+  }
+  return dedupe(out);
+}
+
+// `coverageExclude` patterns from every group/package in coverage-thresholds.json.
+// Walked generically so a new group (or package) needs no code change here.
+// This list is the DENOMINATOR of the coverage floors the nightly ratchet
+// raises: excluding a file makes the percentage go up while real coverage goes
+// down, so an unfrozen list silently defeats the ratchet.
+export function extractCoverageExcludeEntries(thresholds) {
+  const out = [];
+  for (const [group, groupValue] of Object.entries(thresholds ?? {})) {
+    if (!groupValue || typeof groupValue !== 'object' || Array.isArray(groupValue)) continue;
+    for (const [pkg, pkgValue] of Object.entries(groupValue)) {
+      if (!pkgValue || typeof pkgValue !== 'object') continue;
+      for (const pattern of collectStrings(pkgValue.coverageExclude)) {
+        out.push(scopedEntry(`${group}.${pkg}`, pattern));
+      }
+    }
+  }
+  return dedupe(out);
+}
+
+export function extractJscpdIgnoreEntries(jscpdConfig) {
+  return dedupe(collectStrings(jscpdConfig?.ignore));
+}
+
+const KNIP_IGNORE_KEYS = ['ignore', 'ignoreDependencies', 'ignoreBinaries', 'ignoreFiles'];
+
+export function extractKnipIgnoreEntries(knipConfig) {
+  const out = [];
+  for (const key of KNIP_IGNORE_KEYS) {
+    for (const value of collectStrings(knipConfig?.[key])) out.push(scopedEntry(key, value));
+  }
+  const workspaces = knipConfig?.workspaces;
+  if (workspaces && typeof workspaces === 'object') {
+    for (const [name, ws] of Object.entries(workspaces)) {
+      if (!ws || typeof ws !== 'object') continue;
+      for (const key of KNIP_IGNORE_KEYS) {
+        for (const value of collectStrings(ws[key])) out.push(scopedEntry(`${name}.${key}`, value));
+      }
+    }
+  }
+  return dedupe(out);
+}
+
+export const DEBT_LIST_SOURCES = [
+  {
+    id: 'biome-rule-disabling',
+    label: 'biome rule-disabling override',
+    file: 'biome.json',
+    location: 'biome.json `overrides` → non-complexity rules = off',
+    extract: extractBiomeRuleDisablingGlobs,
+    semantics: { touched: false, freeze: true, failOnGrowth: true },
+    growthFixIt:
+      'Fix: satisfy the rule in the new code instead of widening the override.\n' +
+      'If the exemption is genuinely permanent (generated or vendored code), say so\n' +
+      'in the PR body — a reviewer, not this gate, is the right approver.',
+  },
+  {
+    id: 'coverage-exclude',
+    label: 'coverage-exclude',
+    file: 'coverage-thresholds.json',
+    location: 'coverage-thresholds.json `coverageExclude`',
+    extract: extractCoverageExcludeEntries,
+    semantics: { touched: false, freeze: true, failOnGrowth: true },
+    growthFixIt:
+      'Fix: test the file instead of excluding it. `coverageExclude` is the\n' +
+      'denominator of the floors the nightly ratchet raises, so a new exclusion\n' +
+      'raises the reported percentage while real coverage falls.',
+  },
+  {
+    id: 'duplication-ignore',
+    label: 'duplication-ignore',
+    file: 'jscpd.json',
+    location: 'jscpd.json `ignore`',
+    extract: extractJscpdIgnoreEntries,
+    semantics: { touched: false, freeze: true, failOnGrowth: true },
+    growthFixIt:
+      'Fix: de-duplicate the code instead of hiding it from jscpd. An over-broad\n' +
+      '`ignore` entry drops a whole app from the duplication signal.',
+  },
+  {
+    id: 'knip-ignore',
+    label: 'knip ignore',
+    file: 'knip.json',
+    location: 'knip.json `ignore` / `ignoreDependencies` / `ignoreBinaries`',
+    extract: extractKnipIgnoreEntries,
+    semantics: { touched: false, freeze: true, failOnGrowth: false },
+    growthFixIt:
+      'Note: new build tools and Renovate legitimately need entries here, so this\n' +
+      'is reported and never fails. Keep the list honest anyway.',
+  },
+];
+
+export function evaluateDebtSource(source, { currentEntries, baseEntries, baseAvailable }) {
+  const current = Array.isArray(currentEntries) ? currentEntries : [];
+  const skipReason = !source.semantics.freeze
+    ? 'not frozen'
+    : baseAvailable
+      ? null
+      : 'base config unreadable';
+  const added = skipReason ? [] : findAddedEntries(baseEntries, current);
+  return {
+    source,
+    added,
+    skipReason,
+    failed: added.length > 0 && source.semantics.failOnGrowth,
+    warned: added.length > 0 && !source.semantics.failOnGrowth,
+  };
+}
+
+// The two biome complexity debt lists keep the original per-rule semantics:
+// frozen AND subject to the touched-file rule.
+export function evaluateRuleDebtList(
+  rule,
+  { currentGlobs, baseGlobs, baseAvailable, changedFiles }
+) {
+  const globs = Array.isArray(currentGlobs) ? currentGlobs : [];
+  const touched =
+    rule.semantics?.touched === false ? [] : findTouchedExemptions(changedFiles, globs);
+  const added = baseAvailable ? findAddedEntries(baseGlobs, globs) : [];
+  return {
+    source: rule,
+    touched,
+    added,
+    skipReason: baseAvailable ? null : 'base config unreadable',
+    failed: touched.length > 0 || added.length > 0,
+    warned: false,
+  };
+}
+
+export function formatTouchedReport(result) {
+  const { source, touched } = result;
+  const lines = [
+    '',
+    `The following changed files are still on the ${source.label} debt list`,
+    `(${source.location}):`,
+    '',
+  ];
+  for (const f of touched) lines.push(`  - ${f}  [${source.label}]`);
+  lines.push('', source.touchedFixIt);
+  return lines;
+}
+
+export function formatGrowthReport(result) {
+  const { source, added, warned } = result;
+  const verdict = warned
+    ? `The ${source.label} list grew in this PR (reported, not enforced)`
+    : `The ${source.label} debt list is frozen and must not grow; this PR adds new entries`;
+  const lines = ['', verdict, `(${source.location}):`, ''];
+  for (const entry of added) lines.push(`  + ${entry}  [${source.label}]`);
+  lines.push('', source.growthFixIt);
+  return lines;
+}

--- a/packages/dev-tools/tools/debt-list-sources.test.mjs
+++ b/packages/dev-tools/tools/debt-list-sources.test.mjs
@@ -1,0 +1,302 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEBT_LIST_SOURCES,
+  evaluateDebtSource,
+  evaluateRuleDebtList,
+  extractBiomeRuleDisablingGlobs,
+  extractCoverageExcludeEntries,
+  extractJscpdIgnoreEntries,
+  extractKnipIgnoreEntries,
+  findAddedEntries,
+  formatGrowthReport,
+  scopedEntry,
+  scopeOfEntry,
+} from './debt-list-sources.mjs';
+
+const sourceById = (id) => DEBT_LIST_SOURCES.find((s) => s.id === id);
+
+describe('scopeOfEntry / scopedEntry', () => {
+  it('round-trips a scoped entry', () => {
+    const entry = scopedEntry('typescript.webapp', '**/dist/**');
+    expect(entry).toBe('typescript.webapp::**/dist/**');
+    expect(scopeOfEntry(entry)).toBe('typescript.webapp');
+  });
+
+  it('treats an unscoped entry as the empty scope', () => {
+    expect(scopedEntry('', '**/dist/**')).toBe('**/dist/**');
+    expect(scopeOfEntry('**/dist/**')).toBe('');
+    expect(scopeOfEntry(null)).toBe('');
+  });
+});
+
+describe('findAddedEntries', () => {
+  it('reports entries added to an existing list', () => {
+    expect(findAddedEntries(['a', 'b'], ['a', 'b', 'c'])).toEqual(['c']);
+  });
+
+  it('exempts a list that is being introduced (base empty)', () => {
+    expect(findAddedEntries([], ['a', 'b'])).toEqual([]);
+  });
+
+  it('exempts a scope that does not exist in the base at all', () => {
+    const base = ['typescript.webapp::**/dist/**'];
+    const current = [
+      'typescript.webapp::**/dist/**',
+      'go.slicc-cli::**/mock_*.go',
+      'go.slicc-cli::**/*_test.go',
+    ];
+    expect(findAddedEntries(base, current)).toEqual([]);
+  });
+
+  it('still catches growth inside a scope the base already has', () => {
+    const base = ['typescript.webapp::**/dist/**', 'go.slicc-cli::**/mock_*.go'];
+    const current = [...base, 'typescript.webapp::packages/webapp/src/ui/**'];
+    expect(findAddedEntries(base, current)).toEqual([
+      'typescript.webapp::packages/webapp/src/ui/**',
+    ]);
+  });
+});
+
+describe('extractBiomeRuleDisablingGlobs', () => {
+  const config = {
+    overrides: [
+      {
+        includes: ['**/*.test.ts'],
+        linter: {
+          rules: {
+            suspicious: { noExplicitAny: 'off' },
+            complexity: { noExcessiveLinesPerFunction: 'off' },
+          },
+        },
+      },
+      {
+        includes: ['packages/webapp/providers/**/*.ts'],
+        linter: { rules: { style: { useNamingConvention: 'off' } } },
+      },
+      {
+        includes: ['**/tsconfig*.json'],
+        linter: { enabled: false },
+      },
+      {
+        includes: ['packages/webapp/cloud/app.js'],
+        linter: { rules: { complexity: { noExcessiveLinesPerFunction: 'off' } } },
+      },
+    ],
+  };
+
+  it('collects globs from blocks that disable non-complexity rules', () => {
+    expect(extractBiomeRuleDisablingGlobs(config)).toEqual([
+      '**/*.test.ts',
+      'packages/webapp/providers/**/*.ts',
+      '**/tsconfig*.json',
+    ]);
+  });
+
+  it('excludes pure complexity debt blocks (gated separately)', () => {
+    expect(extractBiomeRuleDisablingGlobs(config)).not.toContain('packages/webapp/cloud/app.js');
+  });
+
+  it('ignores blocks that only downgrade a rule to warn', () => {
+    expect(
+      extractBiomeRuleDisablingGlobs({
+        overrides: [{ includes: ['x.ts'], linter: { rules: { style: { useConst: 'warn' } } } }],
+      })
+    ).toEqual([]);
+  });
+
+  it('tolerates a missing or malformed overrides array', () => {
+    expect(extractBiomeRuleDisablingGlobs({})).toEqual([]);
+    expect(extractBiomeRuleDisablingGlobs(null)).toEqual([]);
+    expect(extractBiomeRuleDisablingGlobs({ overrides: [null, {}, { linter: 3 }] })).toEqual([]);
+  });
+});
+
+describe('extractCoverageExcludeEntries', () => {
+  it('walks every group and package generically', () => {
+    const thresholds = {
+      $comment: 'ignored',
+      typescript: {
+        webapp: { lines: 79, coverageExclude: ['**/dist/**', '**/*.d.ts'] },
+        cherry: { lines: 83 },
+      },
+      go: { 'slicc-cli': { lines: 70, coverageExclude: ['**/*_test.go'] } },
+      swift: { 'swift-server': { lines: 60 } },
+    };
+    expect(extractCoverageExcludeEntries(thresholds)).toEqual([
+      'typescript.webapp::**/dist/**',
+      'typescript.webapp::**/*.d.ts',
+      'go.slicc-cli::**/*_test.go',
+    ]);
+  });
+
+  it('returns [] for an empty or malformed file', () => {
+    expect(extractCoverageExcludeEntries({})).toEqual([]);
+    expect(extractCoverageExcludeEntries(null)).toEqual([]);
+  });
+});
+
+describe('extractJscpdIgnoreEntries', () => {
+  it('returns the ignore list, deduped', () => {
+    expect(
+      extractJscpdIgnoreEntries({ ignore: ['**/dist/**', '**/dist/**', '**/*.d.ts'] })
+    ).toEqual(['**/dist/**', '**/*.d.ts']);
+  });
+
+  it('returns [] when there is no ignore list', () => {
+    expect(extractJscpdIgnoreEntries({})).toEqual([]);
+  });
+});
+
+describe('extractKnipIgnoreEntries', () => {
+  it('scopes root and per-workspace ignore keys', () => {
+    const config = {
+      ignore: ['dist/**'],
+      ignoreDependencies: ['pyodide'],
+      ignoreBinaries: ['swift'],
+      workspaces: {
+        'packages/webapp': { ignore: ['src/types/**'], ignoreDependencies: ['buffer'] },
+        'packages/cherry': {},
+      },
+    };
+    expect(extractKnipIgnoreEntries(config)).toEqual([
+      'ignore::dist/**',
+      'ignoreDependencies::pyodide',
+      'ignoreBinaries::swift',
+      'packages/webapp.ignore::src/types/**',
+      'packages/webapp.ignoreDependencies::buffer',
+    ]);
+  });
+});
+
+describe('evaluateDebtSource', () => {
+  const coverage = sourceById('coverage-exclude');
+
+  it('fails a frozen source when its list grows', () => {
+    const result = evaluateDebtSource(coverage, {
+      baseEntries: ['typescript.webapp::**/dist/**'],
+      currentEntries: ['typescript.webapp::**/dist/**', 'typescript.webapp::src/ui/**'],
+      baseAvailable: true,
+    });
+    expect(result.added).toEqual(['typescript.webapp::src/ui/**']);
+    expect(result.failed).toBe(true);
+    expect(result.warned).toBe(false);
+  });
+
+  it('passes when the list is unchanged', () => {
+    const result = evaluateDebtSource(coverage, {
+      baseEntries: ['typescript.webapp::**/dist/**'],
+      currentEntries: ['typescript.webapp::**/dist/**'],
+      baseAvailable: true,
+    });
+    expect(result.failed).toBe(false);
+    expect(result.added).toEqual([]);
+  });
+
+  it('degrades gracefully when the base config cannot be read', () => {
+    const result = evaluateDebtSource(coverage, {
+      baseEntries: [],
+      currentEntries: ['typescript.webapp::src/ui/**'],
+      baseAvailable: false,
+    });
+    expect(result.skipReason).toBe('base config unreadable');
+    expect(result.added).toEqual([]);
+    expect(result.failed).toBe(false);
+  });
+
+  it('warns instead of failing for a warn-only source', () => {
+    const knip = sourceById('knip-ignore');
+    const result = evaluateDebtSource(knip, {
+      baseEntries: ['ignoreDependencies::pyodide'],
+      currentEntries: ['ignoreDependencies::pyodide', 'ignoreDependencies::new-tool'],
+      baseAvailable: true,
+    });
+    expect(result.added).toEqual(['ignoreDependencies::new-tool']);
+    expect(result.failed).toBe(false);
+    expect(result.warned).toBe(true);
+  });
+
+  it('never applies the touched-file rule to a freeze-only source', () => {
+    for (const source of DEBT_LIST_SOURCES) {
+      expect(source.semantics.touched).toBe(false);
+      const result = evaluateDebtSource(source, {
+        baseEntries: ['**/*.d.ts'],
+        currentEntries: ['**/*.d.ts'],
+        baseAvailable: true,
+        changedFiles: ['**/*.d.ts', 'packages/webapp/src/types/foo.d.ts'],
+      });
+      expect(result.touched).toBeUndefined();
+      expect(result.failed).toBe(false);
+    }
+  });
+});
+
+describe('evaluateRuleDebtList', () => {
+  const rule = {
+    id: 'function-size',
+    label: 'function-size',
+    location: 'biome.json `overrides` → complexity.noExcessiveLinesPerFunction = off',
+    semantics: { touched: true, freeze: true, failOnGrowth: true },
+    touchedFixIt: 'refactor it',
+    growthFixIt: 'do not add it',
+  };
+
+  it('fails when a changed file is still on the list', () => {
+    const result = evaluateRuleDebtList(rule, {
+      currentGlobs: ['packages/webapp/src/a.ts'],
+      baseGlobs: ['packages/webapp/src/a.ts'],
+      baseAvailable: true,
+      changedFiles: ['packages/webapp/src/a.ts', 'packages/webapp/src/b.ts'],
+    });
+    expect(result.touched).toEqual(['packages/webapp/src/a.ts']);
+    expect(result.failed).toBe(true);
+  });
+
+  it('fails when the list grows', () => {
+    const result = evaluateRuleDebtList(rule, {
+      currentGlobs: ['packages/webapp/src/a.ts', 'packages/webapp/src/c.ts'],
+      baseGlobs: ['packages/webapp/src/a.ts'],
+      baseAvailable: true,
+      changedFiles: ['packages/webapp/src/unrelated.ts'],
+    });
+    expect(result.added).toEqual(['packages/webapp/src/c.ts']);
+    expect(result.failed).toBe(true);
+  });
+
+  it('passes when nothing is touched and nothing was added', () => {
+    const result = evaluateRuleDebtList(rule, {
+      currentGlobs: ['packages/webapp/src/a.ts'],
+      baseGlobs: ['packages/webapp/src/a.ts'],
+      baseAvailable: true,
+      changedFiles: ['packages/webapp/src/unrelated.ts'],
+    });
+    expect(result.failed).toBe(false);
+  });
+
+  it('skips the growth check when the base config is unreadable', () => {
+    const result = evaluateRuleDebtList(rule, {
+      currentGlobs: ['packages/webapp/src/a.ts', 'packages/webapp/src/c.ts'],
+      baseGlobs: [],
+      baseAvailable: false,
+      changedFiles: [],
+    });
+    expect(result.added).toEqual([]);
+    expect(result.skipReason).toBe('base config unreadable');
+    expect(result.failed).toBe(false);
+  });
+});
+
+describe('formatGrowthReport', () => {
+  it('says "must not grow" for an enforced source and names the entries', () => {
+    const source = sourceById('duplication-ignore');
+    const lines = formatGrowthReport({ source, added: ['packages/webapp/src/**'], warned: false });
+    expect(lines.join('\n')).toContain('frozen and must not grow');
+    expect(lines.join('\n')).toContain('+ packages/webapp/src/**');
+    expect(lines.join('\n')).toContain('jscpd.json `ignore`');
+  });
+
+  it('softens the verdict for a warn-only source', () => {
+    const source = sourceById('knip-ignore');
+    const lines = formatGrowthReport({ source, added: ['ignoreDependencies::x'], warned: true });
+    expect(lines.join('\n')).toContain('reported, not enforced');
+  });
+});

--- a/packages/dev-tools/tools/test-timing-gate.mjs
+++ b/packages/dev-tools/tools/test-timing-gate.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Slow-test gate. Compares the p95 per-test duration of one vitest project
+// against its ceiling in coverage-thresholds.json (`testTiming`), which the
+// nightly ratchet tightens toward reality. The timing report is produced for
+// free by the json reporter that already runs in CI (vitest.config.ts), so
+// this costs no extra suite execution.
+//
+// p95 rather than the slowest test: it is an order statistic over hundreds of
+// tests, so one slow sample on a loaded shared runner cannot move it, while a
+// genuine distribution shift (the drift that took CI from 1.5-8 min to
+// 7-12.4 min) does.
+//
+// Missing report, missing project entry or a report with no durations all
+// *skip*: observability that fails closed on its own plumbing would be worse
+// than the drift it watches.
+//
+// Usage: node packages/dev-tools/tools/test-timing-gate.mjs <project> [report.json]
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { evaluateTiming, summarizeTiming, TIMED_PROJECTS } from './ceiling-ratchet-lib.mjs';
+import { readThresholds, repoRoot } from './coverage-ratchet-lib.mjs';
+
+const DEFAULT_REPORT = 'test-timing/vitest.json';
+
+function main(argv) {
+  const [project, reportArg] = argv;
+  if (!project) {
+    console.error('usage: test-timing-gate.mjs <project> [report.json]');
+    return 2;
+  }
+  const pathPrefix = TIMED_PROJECTS[project];
+  if (!pathPrefix) {
+    console.error(`test-timing-gate: "${project}" has no test-path prefix in TIMED_PROJECTS`);
+    return 2;
+  }
+  const reportFile = resolve(repoRoot, reportArg ?? DEFAULT_REPORT);
+  if (!existsSync(reportFile)) {
+    console.log(`[skip] ${project} timing: no report at ${reportArg ?? DEFAULT_REPORT}`);
+    return 0;
+  }
+
+  const ceiling = readThresholds().testTiming?.[project]?.p95Ms;
+  const result = evaluateTiming(
+    summarizeTiming(JSON.parse(readFileSync(reportFile, 'utf-8')), pathPrefix),
+    ceiling
+  );
+  if (result.status === 'skip') {
+    console.log(`[skip] ${project} timing: ${result.reason}`);
+    return 0;
+  }
+  const { summary, ceilingMs } = result;
+  const detail = `p95 ${summary.p95Ms}ms (ceiling ${ceilingMs}ms), slowest ${summary.slowestMs}ms over ${summary.tests} tests, ${summary.retried} retried sample(s) excluded`;
+  if (result.status === 'fail') {
+    console.error(`::error::${project} tests got slower: ${detail}`);
+    console.error(`  slowest test: ${summary.slowestTest}`);
+    return 1;
+  }
+  console.log(`${project} timing ok: ${detail}`);
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/packages/dev-tools/tools/test-timing-gate.test.mjs
+++ b/packages/dev-tools/tools/test-timing-gate.test.mjs
@@ -1,0 +1,98 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, describe, expect, it } from 'vitest';
+import { evaluateTiming, TIMED_PROJECTS } from './ceiling-ratchet-lib.mjs';
+
+const scriptPath = resolve(dirname(fileURLToPath(import.meta.url)), 'test-timing-gate.mjs');
+
+const summary = { tests: 40, retried: 1, p95Ms: 900, slowestMs: 4000, slowestTest: 'slow one' };
+
+describe('evaluateTiming', () => {
+  it('passes when p95 is under the ceiling', () => {
+    expect(evaluateTiming(summary, 1250)).toEqual({ status: 'pass', ceilingMs: 1250, summary });
+  });
+
+  it('fails when p95 exceeds the ceiling', () => {
+    expect(evaluateTiming(summary, 800).status).toBe('fail');
+  });
+
+  it('passes exactly at the ceiling', () => {
+    expect(evaluateTiming(summary, 900).status).toBe('pass');
+  });
+
+  it('skips instead of failing when there is nothing to gate on', () => {
+    expect(evaluateTiming(null, 1250).status).toBe('skip');
+    expect(evaluateTiming(summary, undefined).status).toBe('skip');
+    expect(evaluateTiming(summary, Number.NaN).status).toBe('skip');
+  });
+});
+
+describe('test-timing-gate: entry script', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'timing-gate-'));
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  function writeReport(name, durations) {
+    const file = join(dir, name);
+    writeFileSync(
+      file,
+      JSON.stringify({
+        testResults: [
+          {
+            name: `/repo/${TIMED_PROJECTS.webapp}a.test.ts`,
+            assertionResults: durations.map((duration, i) => ({
+              fullName: `t${i}`,
+              status: 'passed',
+              duration,
+              failureMessages: [],
+            })),
+          },
+        ],
+      })
+    );
+    return file;
+  }
+
+  function run(args) {
+    return spawnSync('node', [scriptPath, ...args], { encoding: 'utf8' });
+  }
+
+  it('exits 2 without a project', () => {
+    const result = run([]);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('usage: test-timing-gate.mjs');
+  });
+
+  it('exits 2 for a project that is not timed', () => {
+    expect(run(['cherry']).status).toBe(2);
+  });
+
+  it('skips a missing report rather than failing', () => {
+    const result = run(['webapp', join(dir, 'absent.json')]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('[skip] webapp timing: no report');
+  });
+
+  it('skips a report with no durations for the project', () => {
+    const file = join(dir, 'empty.json');
+    writeFileSync(file, JSON.stringify({ testResults: [] }));
+    const result = run(['webapp', file]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('[skip]');
+  });
+
+  it('passes a fast report against the configured ceiling', () => {
+    const result = run(['webapp', writeReport('fast.json', [1, 2, 3, 4, 5])]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/webapp timing ok|\[skip\]/);
+  });
+
+  it('fails a report whose p95 blows past the ceiling', () => {
+    const result = run(['webapp', writeReport('slow.json', Array(20).fill(600000))]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('tests got slower');
+  });
+});

--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -153,7 +153,7 @@ make build          # → bin/slicc
 make check          # CI gate: gofmt + tidy-check + go vet + golangci-lint + race tests + coverage floor
 make lint           # golangci-lint run (config in .golangci.yml)
 make tidy-check     # fail when go.mod/go.sum drift from the tree's imports
-make cover          # race tests + total-coverage floor (COVER_MIN, default 58%)
+make cover          # race tests + total-coverage floor (COVER_MIN, read from coverage-thresholds.json)
 make test-json      # per-test timings → test-report.json (CI artifact)
 make dist           # cross-compiled static binaries → dist/
 ```
@@ -168,8 +168,13 @@ real failure and a retry would only mask it.
 Gates: `.golangci.yml` (staticcheck/errcheck/unused + funlen/gocyclo/gocognit for
 complexity, matching the TS side's biome complexity gate), `make tidy-check`
 (unused/missing module dependencies — the Go analogue of the TS side's knip run)
-and the `COVER_MIN` coverage floor in the Makefile. All run in the `slicc-cli` CI
-job via `make check`. Release binaries are cut **atomically with the semantic-release flow** and only
+and the `COVER_MIN` coverage floor. All run in the `slicc-cli` CI
+job via `make check`. `COVER_MIN` is not hardcoded: the Makefile reads
+`go.slicc-cli.statements` from the repo-root `coverage-thresholds.json`, so the
+nightly ratchet (`packages/dev-tools/tools/coverage-ratchet.mjs`) raises it like
+every other language's floor. The read uses `node` when available and falls back
+to `awk`, so `make cover` still gates without a Node toolchain; `make cover
+COVER_MIN=60` overrides it for a one-off run. Release binaries are cut **atomically with the semantic-release flow** and only
 when `packages/slicc-cli/` changed since the last tag. `release-native.mjs`
 (the prepareCmd gate) calls `sign-and-package.sh` when `decideSliccCliGating`
 opens: it cross-compiles every target on the macOS release runner, Developer

--- a/packages/slicc-cli/Makefile
+++ b/packages/slicc-cli/Makefile
@@ -12,8 +12,16 @@ BIN_DIR   := bin
 DIST_DIR  := dist
 VERSION   ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 LDFLAGS   := -s -w -X main.version=$(VERSION)
-# Total-statement coverage floor (raise as coverage improves; keep in sync with CLAUDE.md).
-COVER_MIN ?= 58
+# Total-statement coverage floor. The value lives in the repo-root
+# coverage-thresholds.json (go.slicc-cli.statements) alongside every other
+# language's floors, so the nightly coverage ratchet raises it automatically.
+# Read with node when it is on PATH and with awk otherwise, so `make cover`
+# gates identically for a Go developer with no Node toolchain. Override for a
+# one-off run with `make cover COVER_MIN=60`.
+THRESHOLDS := ../../coverage-thresholds.json
+COVER_MIN_FILE := $(shell node -e 'process.stdout.write(String(require("$(THRESHOLDS)").go["slicc-cli"].statements))' 2>/dev/null \
+	|| awk '/"go"/ { in_go = 1 } in_go && /"statements"/ { gsub(/[^0-9.]/, "", $$2); print $$2; exit }' $(THRESHOLDS) 2>/dev/null)
+COVER_MIN ?= $(COVER_MIN_FILE)
 
 # GOOS/GOARCH pairs to cross-compile for `dist`.
 PLATFORMS := darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64 windows/arm64
@@ -61,6 +69,9 @@ tidy-check:
 # of code exercised across package boundaries (e.g. internal/tray via the
 # main-package WebRTC integration test).
 cover:
+	@if [ -z "$(COVER_MIN)" ]; then \
+		echo "FAIL: no Go coverage floor in $(THRESHOLDS) (go.slicc-cli.statements)"; exit 1; \
+	fi
 	go test -race -coverpkg=./... -coverprofile=cover.out ./...
 	@total=$$(go tool cover -func=cover.out | awk '/^total:/ {print $$3}' | tr -d '%'); \
 	echo "total coverage: $$total% (floor $(COVER_MIN)%)"; \

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -13,13 +13,13 @@
       "name": "webapp: main entry chunk",
       "path": "../../dist/ui/assets/main-*.js",
       "brotli": false,
-      "limit": "24 kB"
+      "limit": "23 kB"
     },
     {
       "name": "webapp: kernel worker",
       "path": "../../dist/ui/assets/kernel-worker-*.js",
       "brotli": false,
-      "limit": "1850 kB"
+      "limit": "1767 kB"
     },
     {
       "name": "webapp: total JS payload",


### PR DESCRIPTION
Stacked on top of #1701 (base branch is `ci-test-observability`). Merge that first; this PR's diff is the 15 commits on top of it.

## Summary

Gives the repo's threshold machinery the two capabilities it was missing.

1. **Frozen debt lists.** The PR-level boy-scout gate previously covered only biome's two complexity debt lists. It now also freezes `coverageExclude` (62 patterns), `jscpd`'s `ignore`, and biome's non-complexity rule-disabling overrides, and reports (never fails) growth in `knip`'s ignore lists. A new `ci-quarantine.json` registry requires every `continue-on-error: true` in `ci.yml` to be declared with a reason, owner and review date.
2. **Ceilings that tighten.** The nightly ratchet only ever raised floors. It can now also lower ceilings: duplication, the six `size-limit` budgets, and a new per-project p95 test-duration gate. `COVER_MIN` moves out of the slicc-cli `Makefile` into `coverage-thresholds.json` as a `go` group so it ratchets like every other floor.
3. **Flake ledger.** #1701 added CI-only `retry: 1`, which makes a fail-then-pass test silently green. The ledger detects those, fingerprints them, and files or updates one `debt:flake` issue per flake, following `rum-error-triage`'s dedup pattern.

## Why

An audit of this repo found the threshold machinery was one-directional. The nightly ratchet raises coverage floors, but nothing guarded the lists that define what those floors are *measured over*, and nothing tightened the ceilings four recent PRs introduced.

The `coverageExclude` freeze is the load-bearing part: it is the denominator of the floors the ratchet raises, so adding an exclusion makes the reported percentage go up while real coverage goes down. Unfrozen, it can silently defeat the entire ratchet.

The flake ledger closes a regression this stack itself created. Enabling retries without a ledger trades visible flakes for hidden ones.

Deliberate design choices, both documented in code comments so they are not "unified" later:

- **Not all lists get the same severity.** `coverageExclude` and `jscpd` `ignore` legitimately contain permanent entries (generated files, `*.d.ts`, vendored code), so they get no-growth semantics only, never the touched-file rule. `knip` is warn-only because Renovate legitimately needs `ignoreDependencies` entries.
- **Ceiling granularity is not a mirror of `nextFloor`.** `Math.ceil(7.03 + 0.5) = 8` is *looser* than today's 7.5, so a naive mirror would never tighten. Duplication uses 0.1pp steps with a 0.3pp margin; bytes use a 5% proportional margin because bundle size jitters with dependency bumps. A regression test pins the naive-mirror case.
- **The quarantine registry warns rather than fails on an expired review date.** A date-triggered hard failure would break unrelated PRs, which is worse than the debt it flags.

## Test plan

Full pass on the combined stack (main + #1701 + these 15 commits), all green:

- `npm run lint`, `npm run typecheck`, `npm run build`
- `npx vitest run --project dev-tools` — 615 tests, 33 files
- `npm run lint:duplication` — 7.03% against the tightened 7.4 ceiling
- `npm run bundle-size` — all 6 tightened budgets pass (`webapp: main entry chunk` 21.39/23 kB, `kernel worker` 1.68/1.77 MB, `total JS payload` 29.63/31 MB, `extension: service worker` 55.86/59 kB, `side panel entry` 11.73/13 kB, `total JS payload` 95.63/101 kB)
- `cd packages/slicc-cli && make check` — Go floor read from `coverage-thresholds.json`, verified to still work with node absent from `PATH` via the awk fallback

Each new gate was also shown to actually bite: a glob was temporarily added to every frozen list and the failure output captured, then reverted. A gate that cannot be demonstrated failing is not a gate.

The flake ledger was proven end to end against a deliberate fail-once-then-pass probe, and confirmed **not** to flag a test that fails every attempt. Notable finding: vitest 4.1.10's `json` reporter exposes no retry field at all, so a retried test is detectable as `status: "passed"` with a non-empty `failureMessages`; an optional custom reporter reads the exact `retryCount`.

## Known gaps

- The `changes:` paths-filter block in `ci.yml` was not extended for the two new dev-tools scripts, so a PR touching only those will not retrigger the webapp/node-server/chrome-extension jobs.
- The Go floor ratchet proposed 58 → 59 from a macOS measurement but was left at 58; the first nightly on `ubuntu-latest` will set it from a measurement taken where the gate runs.
- 9 further `continue-on-error: true` usages live outside `ci.yml`, including the **production** worker deploy in `worker.yml`. The registry's gated-workflow list is data, so extending it is a one-line change.
- `ci.yml`'s `Deploy staging preview worker` has no finalize gate, so a failed preview deploy leaves the job green. Recorded in the registry as a known hole.
