### PR TITLE
fix(cherry): negotiate protocol version so vendored older SDKs connect

### DIFF
--- a/packages/cherry/CLAUDE.md
+++ b/packages/cherry/CLAUDE.md
@@ -194,6 +194,31 @@ same `CherryEnvelope` union, `CHERRY_PROTOCOL_VERSION`, `isCherryEnvelope`,
 difference is the package location (the SDK copy carries no webapp import). When
 you change one, change the other.
 
+## Protocol version negotiation and bump rules
+
+Embedders **vendor** this SDK, so the two sides of the handshake routinely run
+different builds. The contract that keeps that safe:
+
+- The follower iframe posts one `handshake.hello` per entry in
+  `SUPPORTED_CHERRY_PROTOCOL_VERSIONS` (newest first, same `channelId`) and pins
+  the negotiated version from whichever `handshake.welcome` the host answers
+  with. All subsequent envelopes — both directions — are stamped with the
+  negotiated version. Version-gated envelope kinds (e.g. `session.export.*`,
+  v2+) must not be used on a lower-negotiated channel.
+- The host SDK accepts only its own `CHERRY_PROTOCOL_VERSION`. When a
+  handshake attempt arrives at a version it cannot speak (and origin + source
+  prove it is our iframe), it replies `handshake.version-mismatch` so the
+  follower fails `connect()` fast with an actionable error instead of eating
+  the handshake timeout, and fires `hooks.onProtocolMismatch`.
+- **When bumping `CHERRY_PROTOCOL_VERSION`:** keep the previous version in
+  `SUPPORTED_CHERRY_PROTOCOL_VERSIONS` and gate any new envelope kinds on the
+  negotiated version. Removing a version from the supported set hard-breaks
+  every embedder still shipping a vendored SDK at that version — do it only
+  for a genuinely breaking wire change, and say so in the changelog. The
+  2026-07-27 labs incident (P1: every embed failed with an opaque 30s
+  "Cherry handshake timed out") was caused by bumping 1 → 2 for an _additive_
+  feature while both sides still validated with strict equality.
+
 ## Build and test
 
 ```bash

--- a/packages/cherry/src/index.ts
+++ b/packages/cherry/src/index.ts
@@ -60,6 +60,14 @@ export interface HostHooks {
   onPermissionRequest?: (domain: string) => boolean | Promise<boolean>;
   /** Called once the Cherry postMessage handshake completes (welcome sent to follower). */
   onHandshakeComplete?: () => void;
+  /**
+   * Called when the follower iframe attempts a handshake with a cherry
+   * protocol version this SDK build cannot speak (after the follower's own
+   * version fallbacks are exhausted). The mount will not come up until the
+   * older side (this vendored SDK or the SLICC origin) is updated — surface
+   * this to telemetry instead of waiting out the handshake timeout.
+   */
+  onProtocolMismatch?: (peerVersion: number, sdkVersion: number) => void;
 }
 
 /** Effort / thinking level the cone should use. Locked — the UI picker is hidden. */

--- a/packages/cherry/src/index.ts
+++ b/packages/cherry/src/index.ts
@@ -61,11 +61,13 @@ export interface HostHooks {
   /** Called once the Cherry postMessage handshake completes (welcome sent to follower). */
   onHandshakeComplete?: () => void;
   /**
-   * Called when the follower iframe attempts a handshake with a cherry
-   * protocol version this SDK build cannot speak (after the follower's own
-   * version fallbacks are exhausted). The mount will not come up until the
-   * older side (this vendored SDK or the SLICC origin) is updated — surface
-   * this to telemetry instead of waiting out the handshake timeout.
+   * Called at most once per handshake attempt, after a short grace window,
+   * when the follower iframe offered ONLY cherry protocol versions this SDK
+   * build cannot speak. Never fires when a fallback succeeds: a follower that
+   * also offers a version this SDK speaks completes the handshake and cancels
+   * the report. When it does fire, the mount will not come up until the older
+   * side (this vendored SDK or the SLICC origin) is updated — surface this to
+   * telemetry instead of waiting out the handshake timeout.
    */
   onProtocolMismatch?: (peerVersion: number, sdkVersion: number) => void;
 }

--- a/packages/cherry/src/mount.ts
+++ b/packages/cherry/src/mount.ts
@@ -13,6 +13,14 @@ import {
   type TranscriptExportProgress,
 } from './transcript-types.js';
 
+/**
+ * How long a version-skewed hello may wait for a supported companion hello
+ * (same channelId) before onProtocolMismatch fires. The follower posts all its
+ * hellos synchronously in one burst, so a real fallback arrives within the
+ * same task queue turn — this window is generous headroom, not a race.
+ */
+const MISMATCH_HOOK_GRACE_MS = 250;
+
 interface CdpResponseShape {
   result?: Record<string, unknown>;
   error?: { code: number; message: string };
@@ -206,6 +214,42 @@ function buildExportSession(
   };
 }
 
+/**
+ * Handle a trusted `handshake.hello` at a protocol version this SDK cannot
+ * speak: reply `handshake.version-mismatch` immediately (so the follower
+ * fails its connect() fast — a follower that still has a version this SDK
+ * speaks ignores the reply and proceeds with its lower-version companion
+ * hello), and DEFER `onProtocolMismatch` by MISMATCH_HOOK_GRACE_MS. The
+ * hook's contract is "fallbacks exhausted / the mount will not come up", but
+ * a [newer, current] follower completes the handshake with its companion
+ * hello milliseconds after the skewed one — an accepted hello for the same
+ * attempt cancels the deferred report. Deduped per handshake-attempt
+ * channelId: a no-overlap follower posts several skewed hellos (one per
+ * version it speaks, same channelId) and gets one reply + one report.
+ */
+function buildSkewedHelloHandler(
+  pendingMismatchHooks: Map<string, ReturnType<typeof setTimeout>>,
+  post: (env: CherryEnvelope) => void,
+  hooks: MountSliccOptions['hooks']
+): (data: { cherry: number; channelId: string }) => void {
+  return (data) => {
+    if (pendingMismatchHooks.has(data.channelId)) return;
+    post({
+      cherry: CHERRY_PROTOCOL_VERSION,
+      channelId: data.channelId,
+      kind: 'handshake.version-mismatch',
+      peerVersion: data.cherry,
+    });
+    pendingMismatchHooks.set(
+      data.channelId,
+      setTimeout(() => {
+        pendingMismatchHooks.delete(data.channelId);
+        hooks?.onProtocolMismatch?.(data.cherry, CHERRY_PROTOCOL_VERSION);
+      }, MISMATCH_HOOK_GRACE_MS)
+    );
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Mount
 // ---------------------------------------------------------------------------
@@ -241,9 +285,24 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
   };
   const exportSession = buildExportSession(pending, post, () => channelId);
 
+  /** Pending deferred onProtocolMismatch reports, keyed by handshake-attempt channelId. */
+  const pendingMismatchHooks = new Map<string, ReturnType<typeof setTimeout>>();
+  const handleVersionSkewedHello = buildSkewedHelloHandler(
+    pendingMismatchHooks,
+    post,
+    options.hooks
+  );
+
   const handleEnvelope = async (env: CherryEnvelope): Promise<CdpResponseShape | undefined> => {
     switch (env.kind) {
       case 'handshake.hello': {
+        // A supported hello completes negotiation for this attempt — cancel any
+        // deferred mismatch report from its higher-version companion hellos.
+        const mismatchTimer = pendingMismatchHooks.get(env.channelId);
+        if (mismatchTimer !== undefined) {
+          clearTimeout(mismatchTimer);
+          pendingMismatchHooks.delete(env.channelId);
+        }
         rejectAllPending(pending, 'transfer-aborted');
         channelId = env.channelId;
         post(buildWelcomeEnvelope(channelId, options));
@@ -326,13 +385,7 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
           event.data.kind === 'handshake.hello' &&
           event.data.channelId !== channelId
         ) {
-          post({
-            cherry: CHERRY_PROTOCOL_VERSION,
-            channelId: event.data.channelId,
-            kind: 'handshake.version-mismatch',
-            peerVersion: event.data.cherry,
-          });
-          options.hooks?.onProtocolMismatch?.(event.data.cherry, CHERRY_PROTOCOL_VERSION);
+          handleVersionSkewedHello(event.data);
         }
       } else if (isCherryEnvelope(event.data)) {
         console.warn('[cherry] rejected a cherry envelope (origin/source/channel mismatch)', {
@@ -359,6 +412,8 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
     destroy() {
       window.removeEventListener('message', onMessage);
       rejectAllPending(pending, 'transfer-aborted');
+      for (const [, timer] of pendingMismatchHooks) clearTimeout(timer);
+      pendingMismatchHooks.clear();
       if (sdkCreatedIframe) iframe.remove();
     },
     testReceive: (env) => handleEnvelope(env),

--- a/packages/cherry/src/mount.ts
+++ b/packages/cherry/src/mount.ts
@@ -314,6 +314,26 @@ export function mountSliccImpl(options: MountSliccImplOptions): CherrySliccHandl
           peerVersion: event.data.cherry,
           ourVersion: CHERRY_PROTOCOL_VERSION,
         });
+        // Reply to a version-skewed HANDSHAKE attempt so the follower fails its
+        // connect() fast with an actionable error instead of eating the full
+        // handshake timeout (the follower can't otherwise tell "host SDK too
+        // old/new" from "no host SDK at all"). Reply ONLY when origin + source
+        // prove the sender is OUR iframe, and never for the companion
+        // lower-version hello of an already-completed handshake (the follower
+        // posts one hello per version it speaks, all with the same channelId).
+        if (
+          passesTrust(event) &&
+          event.data.kind === 'handshake.hello' &&
+          event.data.channelId !== channelId
+        ) {
+          post({
+            cherry: CHERRY_PROTOCOL_VERSION,
+            channelId: event.data.channelId,
+            kind: 'handshake.version-mismatch',
+            peerVersion: event.data.cherry,
+          });
+          options.hooks?.onProtocolMismatch?.(event.data.cherry, CHERRY_PROTOCOL_VERSION);
+        }
       } else if (isCherryEnvelope(event.data)) {
         console.warn('[cherry] rejected a cherry envelope (origin/source/channel mismatch)', {
           origin: event.origin,

--- a/packages/cherry/src/protocol.ts
+++ b/packages/cherry/src/protocol.ts
@@ -19,15 +19,28 @@
 
 export const CHERRY_PROTOCOL_VERSION = 2;
 
+/**
+ * Every wire version this build can negotiate, newest first (the first entry
+ * MUST be CHERRY_PROTOCOL_VERSION). The follower iframe posts one
+ * `handshake.hello` per entry (same channelId) and pins the negotiated version
+ * from whichever `handshake.welcome` the host answers with; the host SDK keeps
+ * accepting only its own CHERRY_PROTOCOL_VERSION. Embedders VENDOR the host
+ * SDK, so a protocol bump must keep the previous version listed here until no
+ * known embedder still ships it — dropping an entry hard-breaks those hosts
+ * with an opaque handshake timeout (the 2026-07-27 labs incident).
+ */
+export const SUPPORTED_CHERRY_PROTOCOL_VERSIONS: readonly number[] = [2, 1];
+
 export interface CherryHandshakeHello {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  /** Wire version stamp. Runtime-validated against an accepted-versions set. */
+  cherry: number;
   channelId: string;
   kind: 'handshake.hello';
   capabilities: { navigate: boolean; screenshot: boolean; openUrl: boolean };
 }
 
 export interface CherryHandshakeWelcome {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'handshake.welcome';
   /** Tray join URL the host supplied; the follower embeds against it. */
@@ -51,8 +64,24 @@ export interface CherryHandshakeWelcome {
   effortLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 }
 
+/**
+ * Host → iframe: reply to a `handshake.hello` whose protocol version this host
+ * cannot speak. Lets a version-skewed follower fail its connect() fast with an
+ * actionable error instead of eating the full handshake timeout. Stamped with
+ * the HOST's version (the follower diagnoses the skew from it); `channelId`
+ * echoes the rejected hello's so the follower's three-factor gate attributes
+ * the reply to its own handshake attempt.
+ */
+export interface CherryHandshakeVersionMismatch {
+  cherry: number;
+  channelId: string;
+  kind: 'handshake.version-mismatch';
+  /** The rejected hello's version, echoed for diagnostics. */
+  peerVersion: number;
+}
+
 export interface CherryCdpRequest {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'cdp.request';
   id: number;
@@ -62,7 +91,7 @@ export interface CherryCdpRequest {
 }
 
 export interface CherryCdpResponse {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'cdp.response';
   id: number;
@@ -71,7 +100,7 @@ export interface CherryCdpResponse {
 }
 
 export interface CherryCdpEvent {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'cdp.event';
   method: string;
@@ -80,7 +109,7 @@ export interface CherryCdpEvent {
 }
 
 export interface CherryPermissionRequest {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'permission.request';
   id: number;
@@ -88,7 +117,7 @@ export interface CherryPermissionRequest {
 }
 
 export interface CherryPermissionResponse {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'permission.response';
   id: number;
@@ -96,7 +125,7 @@ export interface CherryPermissionResponse {
 }
 
 export interface CherryHostEvent {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'host.event';
   name: string;
@@ -104,7 +133,7 @@ export interface CherryHostEvent {
 }
 
 export interface CherrySliccEvent {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'slicc.event';
   name: string;
@@ -112,12 +141,12 @@ export interface CherrySliccEvent {
 }
 
 // ---------------------------------------------------------------------------
-// Session export envelopes (host → iframe and iframe → host)
+// Session export envelopes (host → iframe and iframe → host) — v2+ only.
 // ---------------------------------------------------------------------------
 
 /** Host → iframe: initiate a transcript export for the given session. */
 export interface CherrySessionExportRequest {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'session.export.request';
   requestId: string;
@@ -127,7 +156,7 @@ export interface CherrySessionExportRequest {
 
 /** Host → iframe: cancel an in-flight export (AbortSignal fired). */
 export interface CherrySessionExportCancel {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'session.export.cancel';
   requestId: string;
@@ -138,7 +167,7 @@ export interface CherrySessionExportCancel {
  * All fields are JSON-cloneable; no Blob or binary here.
  */
 export interface CherrySessionExportProgress {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'session.export.progress';
   requestId: string;
@@ -159,7 +188,7 @@ export interface CherrySessionExportProgress {
  * JSON-cloneable and may be structured-cloned through any postMessage bridge.
  */
 export interface CherrySessionExportResponse {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'session.export.response';
   requestId: string;
@@ -169,7 +198,7 @@ export interface CherrySessionExportResponse {
 
 /** Iframe → host: the export failed with a terminal error code. */
 export interface CherrySessionExportError {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'session.export.error';
   requestId: string;
@@ -179,6 +208,7 @@ export interface CherrySessionExportError {
 export type CherryEnvelope =
   | CherryHandshakeHello
   | CherryHandshakeWelcome
+  | CherryHandshakeVersionMismatch
   | CherryCdpRequest
   | CherryCdpResponse
   | CherryCdpEvent
@@ -195,6 +225,7 @@ export type CherryEnvelope =
 const KINDS = new Set<CherryEnvelope['kind']>([
   'handshake.hello',
   'handshake.welcome',
+  'handshake.version-mismatch',
   'cdp.request',
   'cdp.response',
   'cdp.event',
@@ -209,18 +240,29 @@ const KINDS = new Set<CherryEnvelope['kind']>([
   'session.export.error',
 ]);
 
-export function isCherryEnvelope(value: unknown): value is CherryEnvelope {
+/**
+ * Structural envelope validator. `versions` is the set of wire versions the
+ * caller currently accepts — strict own-version by default; the follower
+ * passes SUPPORTED_CHERRY_PROTOCOL_VERSIONS while negotiating and narrows to
+ * the single negotiated version once connected.
+ */
+export function isCherryEnvelope(
+  value: unknown,
+  versions: readonly number[] = [CHERRY_PROTOCOL_VERSION]
+): value is CherryEnvelope {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
   if (
-    v.cherry !== CHERRY_PROTOCOL_VERSION ||
+    typeof v.cherry !== 'number' ||
+    !versions.includes(v.cherry) ||
     typeof v.channelId !== 'string' ||
     typeof v.kind !== 'string' ||
     !KINDS.has(v.kind as CherryEnvelope['kind'])
   )
     return false;
-  // Export envelopes require a non-empty requestId and kind-specific fields.
   const k = v.kind as CherryEnvelope['kind'];
+  if (k === 'handshake.version-mismatch' && typeof v.peerVersion !== 'number') return false;
+  // Export envelopes require a non-empty requestId and kind-specific fields.
   if (
     k === 'session.export.request' ||
     k === 'session.export.cancel' ||
@@ -248,6 +290,11 @@ export interface AcceptContext {
   expectedSource: MessageEventSource | null;
   /** Pinned channel nonce. null only during pre-handshake (accept any). */
   channelId: string | null;
+  /**
+   * Wire versions to accept. Defaults to strict [CHERRY_PROTOCOL_VERSION];
+   * see isCherryEnvelope.
+   */
+  versions?: readonly number[];
 }
 
 /**
@@ -259,26 +306,28 @@ export interface AcceptContext {
 export function acceptEnvelope(event: MessageEvent, ctx: AcceptContext): boolean {
   if (!ctx.allowOrigins.includes(event.origin)) return false;
   if (ctx.expectedSource !== null && event.source !== ctx.expectedSource) return false;
-  if (!isCherryEnvelope(event.data)) return false;
+  if (!isCherryEnvelope(event.data, ctx.versions)) return false;
   if (ctx.channelId !== null && event.data.channelId !== ctx.channelId) return false;
   return true;
 }
 
 /**
- * True when a message is shaped like a cherry envelope but carries a DIFFERENT
- * protocol version — i.e. the peer is a version-skewed build, not postMessage
- * noise. `isCherryEnvelope` (and therefore `acceptEnvelope`) rejects these, so
- * without this check a skewed peer is indistinguishable from the generic
- * handshake timeout. Callers log it distinctly ("update the older side").
+ * True when a message is shaped like a cherry envelope but carries a protocol
+ * version outside the caller's accepted set — i.e. the peer is a version-skewed
+ * build, not postMessage noise. `isCherryEnvelope` (and therefore
+ * `acceptEnvelope`) rejects these, so without this check a skewed peer is
+ * indistinguishable from the generic handshake timeout. Callers log it
+ * distinctly ("update the older side").
  */
 export function isCherryVersionMismatch(
-  value: unknown
+  value: unknown,
+  supported: readonly number[] = [CHERRY_PROTOCOL_VERSION]
 ): value is { cherry: number; channelId: string; kind: string } {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
   return (
     typeof v.cherry === 'number' &&
-    v.cherry !== CHERRY_PROTOCOL_VERSION &&
+    !supported.includes(v.cherry) &&
     typeof v.channelId === 'string' &&
     typeof v.kind === 'string'
   );

--- a/packages/cherry/tests/mount.test.ts
+++ b/packages/cherry/tests/mount.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 import { mountSliccImpl } from '../src/mount.js';
+import { CHERRY_PROTOCOL_VERSION } from '../src/protocol.js';
 import { TranscriptExportError } from '../src/transcript-types.js';
+
+interface VersionMismatchShape {
+  kind?: string;
+  cherry?: number;
+  channelId?: string;
+  peerVersion?: number;
+}
 
 describe('mountSliccImpl', () => {
   it('creates an iframe in the container pointed at ?cherry=1', () => {
@@ -328,6 +336,84 @@ describe('mountSliccImpl', () => {
     handle.emitHostEvent('too-early');
     expect(posted.find((e) => (e as { kind?: string }).kind === 'host.event')).toBeUndefined();
     expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+    handle.destroy();
+  });
+});
+
+describe('protocol version skew', () => {
+  function mountWithCapture(hooks?: { onProtocolMismatch?: (peer: number, sdk: number) => void }) {
+    const container = document.createElement('div');
+    const posted: VersionMismatchShape[] = [];
+    const handle = mountSliccImpl({
+      container,
+      sliccOrigin: 'https://app.example',
+      capabilities: { navigate: true, screenshot: 'none', openUrl: true },
+      ...(hooks ? { hooks } : {}),
+      joinToken: 'https://app.example/join?t=X',
+      __test_post: (env) => posted.push(env as never),
+    });
+    const iframe = container.querySelector('iframe')!;
+    const dispatch = (data: unknown, origin = 'https://app.example', source?: unknown) =>
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data,
+          origin,
+          source: (source === undefined ? iframe.contentWindow : source) as MessageEventSource,
+        })
+      );
+    return { handle, posted, dispatch };
+  }
+
+  it('replies handshake.version-mismatch to a version-skewed hello from its own iframe', () => {
+    const onProtocolMismatch = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { handle, posted, dispatch } = mountWithCapture({ onProtocolMismatch });
+    dispatch({ cherry: 99, channelId: 'ch-skew', kind: 'handshake.hello' });
+    const reply = posted.find((e) => e.kind === 'handshake.version-mismatch');
+    expect(reply).toBeTruthy();
+    expect(reply?.cherry).toBe(CHERRY_PROTOCOL_VERSION);
+    expect(reply?.channelId).toBe('ch-skew'); // echoed so the follower's gate accepts it
+    expect(reply?.peerVersion).toBe(99);
+    expect(onProtocolMismatch).toHaveBeenCalledWith(99, CHERRY_PROTOCOL_VERSION);
+    warn.mockRestore();
+    handle.destroy();
+  });
+
+  it('does not reply to the companion lower-version hello of a completed handshake', () => {
+    // The follower posts one hello per version it speaks (same channelId).
+    // After the own-version hello completes the handshake, the lower-version
+    // companion must be warn-dropped — not answered, not re-handshaken.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { handle, posted, dispatch } = mountWithCapture();
+    dispatch({ cherry: CHERRY_PROTOCOL_VERSION, channelId: 'ch-dual', kind: 'handshake.hello' });
+    expect(posted.some((e) => e.kind === 'handshake.welcome')).toBe(true);
+    dispatch({ cherry: 1, channelId: 'ch-dual', kind: 'handshake.hello' });
+    expect(posted.find((e) => e.kind === 'handshake.version-mismatch')).toBeUndefined();
+    expect(posted.filter((e) => e.kind === 'handshake.welcome').length).toBe(1);
+    warn.mockRestore();
+    handle.destroy();
+  });
+
+  it('ignores a version-skewed hello from an untrusted origin or source', () => {
+    const onProtocolMismatch = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { handle, posted, dispatch } = mountWithCapture({ onProtocolMismatch });
+    // Wrong origin — a hostile frame must not be able to probe the SDK version.
+    dispatch({ cherry: 99, channelId: 'ch-evil', kind: 'handshake.hello' }, 'https://evil.example');
+    // Right origin, wrong source window.
+    dispatch({ cherry: 99, channelId: 'ch-forged', kind: 'handshake.hello' }, undefined, {});
+    expect(posted.find((e) => e.kind === 'handshake.version-mismatch')).toBeUndefined();
+    expect(onProtocolMismatch).not.toHaveBeenCalled();
+    warn.mockRestore();
+    handle.destroy();
+  });
+
+  it('does not reply to version-skewed non-handshake envelopes', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { handle, posted, dispatch } = mountWithCapture();
+    dispatch({ cherry: 99, channelId: 'ch-ev', kind: 'slicc.event', name: 'x' });
+    expect(posted.find((e) => e.kind === 'handshake.version-mismatch')).toBeUndefined();
     warn.mockRestore();
     handle.destroy();
   });

--- a/packages/cherry/tests/mount.test.ts
+++ b/packages/cherry/tests/mount.test.ts
@@ -366,18 +366,77 @@ describe('protocol version skew', () => {
   }
 
   it('replies handshake.version-mismatch to a version-skewed hello from its own iframe', () => {
+    vi.useFakeTimers();
     const onProtocolMismatch = vi.fn();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { handle, posted, dispatch } = mountWithCapture({ onProtocolMismatch });
     dispatch({ cherry: 99, channelId: 'ch-skew', kind: 'handshake.hello' });
+    // The wire reply is immediate (fast connect() failure in the follower)…
     const reply = posted.find((e) => e.kind === 'handshake.version-mismatch');
     expect(reply).toBeTruthy();
     expect(reply?.cherry).toBe(CHERRY_PROTOCOL_VERSION);
     expect(reply?.channelId).toBe('ch-skew'); // echoed so the follower's gate accepts it
     expect(reply?.peerVersion).toBe(99);
-    expect(onProtocolMismatch).toHaveBeenCalledWith(99, CHERRY_PROTOCOL_VERSION);
+    // …but the hook waits out the negotiation grace window (a supported
+    // companion hello may still complete the handshake).
+    expect(onProtocolMismatch).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(300);
+    expect(onProtocolMismatch).toHaveBeenCalledExactlyOnceWith(99, CHERRY_PROTOCOL_VERSION);
     warn.mockRestore();
     handle.destroy();
+    vi.useRealTimers();
+  });
+
+  it('does not fire onProtocolMismatch when a supported companion hello completes the handshake', () => {
+    // A FUTURE [3, 2]-style follower: its v3 hello is skewed for this v2 SDK,
+    // but its v2 companion (same channelId) succeeds — the mount comes up and
+    // the "fallbacks exhausted" hook must stay silent.
+    vi.useFakeTimers();
+    const onProtocolMismatch = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { handle, posted, dispatch } = mountWithCapture({ onProtocolMismatch });
+    dispatch({ cherry: 3, channelId: 'ch-fallback', kind: 'handshake.hello' });
+    dispatch({
+      cherry: CHERRY_PROTOCOL_VERSION,
+      channelId: 'ch-fallback',
+      kind: 'handshake.hello',
+    });
+    expect(posted.some((e) => e.kind === 'handshake.welcome')).toBe(true);
+    vi.advanceTimersByTime(1000);
+    expect(onProtocolMismatch).not.toHaveBeenCalled();
+    warn.mockRestore();
+    handle.destroy();
+    vi.useRealTimers();
+  });
+
+  it('replies and reports once for multiple skewed hellos of one no-overlap attempt', () => {
+    // A no-overlap follower (e.g. [99, 98]) posts one hello per version, all
+    // with the same channelId — one reply on the wire, one hook report.
+    vi.useFakeTimers();
+    const onProtocolMismatch = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { handle, posted, dispatch } = mountWithCapture({ onProtocolMismatch });
+    dispatch({ cherry: 99, channelId: 'ch-noover', kind: 'handshake.hello' });
+    dispatch({ cherry: 98, channelId: 'ch-noover', kind: 'handshake.hello' });
+    expect(posted.filter((e) => e.kind === 'handshake.version-mismatch').length).toBe(1);
+    vi.advanceTimersByTime(300);
+    expect(onProtocolMismatch).toHaveBeenCalledExactlyOnceWith(99, CHERRY_PROTOCOL_VERSION);
+    warn.mockRestore();
+    handle.destroy();
+    vi.useRealTimers();
+  });
+
+  it('destroy() cancels a pending onProtocolMismatch report', () => {
+    vi.useFakeTimers();
+    const onProtocolMismatch = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { handle, dispatch } = mountWithCapture({ onProtocolMismatch });
+    dispatch({ cherry: 99, channelId: 'ch-destroyed', kind: 'handshake.hello' });
+    handle.destroy();
+    vi.advanceTimersByTime(1000);
+    expect(onProtocolMismatch).not.toHaveBeenCalled();
+    warn.mockRestore();
+    vi.useRealTimers();
   });
 
   it('does not reply to the companion lower-version hello of a completed handshake', () => {

--- a/packages/webapp/src/cdp/cherry-host-protocol.ts
+++ b/packages/webapp/src/cdp/cherry-host-protocol.ts
@@ -9,15 +9,28 @@
 
 export const CHERRY_PROTOCOL_VERSION = 2;
 
+/**
+ * Every wire version this build can negotiate, newest first (the first entry
+ * MUST be CHERRY_PROTOCOL_VERSION). The follower iframe posts one
+ * `handshake.hello` per entry (same channelId) and pins the negotiated version
+ * from whichever `handshake.welcome` the host answers with; the host SDK keeps
+ * accepting only its own CHERRY_PROTOCOL_VERSION. Embedders VENDOR the host
+ * SDK, so a protocol bump must keep the previous version listed here until no
+ * known embedder still ships it — dropping an entry hard-breaks those hosts
+ * with an opaque handshake timeout (the 2026-07-27 labs incident).
+ */
+export const SUPPORTED_CHERRY_PROTOCOL_VERSIONS: readonly number[] = [2, 1];
+
 export interface CherryHandshakeHello {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  /** Wire version stamp. Runtime-validated against an accepted-versions set. */
+  cherry: number;
   channelId: string;
   kind: 'handshake.hello';
   capabilities: { navigate: boolean; screenshot: boolean; openUrl: boolean };
 }
 
 export interface CherryHandshakeWelcome {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'handshake.welcome';
   /** Tray join URL the host supplied; the follower embeds against it. */
@@ -41,8 +54,24 @@ export interface CherryHandshakeWelcome {
   effortLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 }
 
+/**
+ * Host → iframe: reply to a `handshake.hello` whose protocol version this host
+ * cannot speak. Lets a version-skewed follower fail its connect() fast with an
+ * actionable error instead of eating the full handshake timeout. Stamped with
+ * the HOST's version (the follower diagnoses the skew from it); `channelId`
+ * echoes the rejected hello's so the follower's three-factor gate attributes
+ * the reply to its own handshake attempt.
+ */
+export interface CherryHandshakeVersionMismatch {
+  cherry: number;
+  channelId: string;
+  kind: 'handshake.version-mismatch';
+  /** The rejected hello's version, echoed for diagnostics. */
+  peerVersion: number;
+}
+
 export interface CherryCdpRequest {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'cdp.request';
   id: number;
@@ -52,7 +81,7 @@ export interface CherryCdpRequest {
 }
 
 export interface CherryCdpResponse {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'cdp.response';
   id: number;
@@ -61,7 +90,7 @@ export interface CherryCdpResponse {
 }
 
 export interface CherryCdpEvent {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'cdp.event';
   method: string;
@@ -70,7 +99,7 @@ export interface CherryCdpEvent {
 }
 
 export interface CherryPermissionRequest {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'permission.request';
   id: number;
@@ -78,7 +107,7 @@ export interface CherryPermissionRequest {
 }
 
 export interface CherryPermissionResponse {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'permission.response';
   id: number;
@@ -86,7 +115,7 @@ export interface CherryPermissionResponse {
 }
 
 export interface CherryHostEvent {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'host.event';
   name: string;
@@ -94,7 +123,7 @@ export interface CherryHostEvent {
 }
 
 export interface CherrySliccEvent {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'slicc.event';
   name: string;
@@ -102,12 +131,12 @@ export interface CherrySliccEvent {
 }
 
 // ---------------------------------------------------------------------------
-// Session export envelopes (host → iframe and iframe → host)
+// Session export envelopes (host → iframe and iframe → host) — v2+ only.
 // ---------------------------------------------------------------------------
 
 /** Host → iframe: initiate a transcript export for the given session. */
 export interface CherrySessionExportRequest {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'session.export.request';
   requestId: string;
@@ -117,7 +146,7 @@ export interface CherrySessionExportRequest {
 
 /** Host → iframe: cancel an in-flight export (AbortSignal fired). */
 export interface CherrySessionExportCancel {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'session.export.cancel';
   requestId: string;
@@ -128,7 +157,7 @@ export interface CherrySessionExportCancel {
  * All fields are JSON-cloneable; no Blob or binary here.
  */
 export interface CherrySessionExportProgress {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'session.export.progress';
   requestId: string;
@@ -149,7 +178,7 @@ export interface CherrySessionExportProgress {
  * JSON-cloneable and may be structured-cloned through any postMessage bridge.
  */
 export interface CherrySessionExportResponse {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'session.export.response';
   requestId: string;
@@ -159,7 +188,7 @@ export interface CherrySessionExportResponse {
 
 /** Iframe → host: the export failed with a terminal error code. */
 export interface CherrySessionExportError {
-  cherry: typeof CHERRY_PROTOCOL_VERSION;
+  cherry: number;
   channelId: string;
   kind: 'session.export.error';
   requestId: string;
@@ -169,6 +198,7 @@ export interface CherrySessionExportError {
 export type CherryEnvelope =
   | CherryHandshakeHello
   | CherryHandshakeWelcome
+  | CherryHandshakeVersionMismatch
   | CherryCdpRequest
   | CherryCdpResponse
   | CherryCdpEvent
@@ -185,6 +215,7 @@ export type CherryEnvelope =
 const KINDS = new Set<CherryEnvelope['kind']>([
   'handshake.hello',
   'handshake.welcome',
+  'handshake.version-mismatch',
   'cdp.request',
   'cdp.response',
   'cdp.event',
@@ -199,18 +230,29 @@ const KINDS = new Set<CherryEnvelope['kind']>([
   'session.export.error',
 ]);
 
-export function isCherryEnvelope(value: unknown): value is CherryEnvelope {
+/**
+ * Structural envelope validator. `versions` is the set of wire versions the
+ * caller currently accepts — strict own-version by default; the follower
+ * passes SUPPORTED_CHERRY_PROTOCOL_VERSIONS while negotiating and narrows to
+ * the single negotiated version once connected.
+ */
+export function isCherryEnvelope(
+  value: unknown,
+  versions: readonly number[] = [CHERRY_PROTOCOL_VERSION]
+): value is CherryEnvelope {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
   if (
-    v.cherry !== CHERRY_PROTOCOL_VERSION ||
+    typeof v.cherry !== 'number' ||
+    !versions.includes(v.cherry) ||
     typeof v.channelId !== 'string' ||
     typeof v.kind !== 'string' ||
     !KINDS.has(v.kind as CherryEnvelope['kind'])
   )
     return false;
-  // Export envelopes require a non-empty requestId and kind-specific fields.
   const k = v.kind as CherryEnvelope['kind'];
+  if (k === 'handshake.version-mismatch' && typeof v.peerVersion !== 'number') return false;
+  // Export envelopes require a non-empty requestId and kind-specific fields.
   if (
     k === 'session.export.request' ||
     k === 'session.export.cancel' ||
@@ -238,6 +280,11 @@ export interface AcceptContext {
   expectedSource: MessageEventSource | null;
   /** Pinned channel nonce. null only during pre-handshake (accept any). */
   channelId: string | null;
+  /**
+   * Wire versions to accept. Defaults to strict [CHERRY_PROTOCOL_VERSION];
+   * see isCherryEnvelope.
+   */
+  versions?: readonly number[];
 }
 
 /**
@@ -249,26 +296,28 @@ export interface AcceptContext {
 export function acceptEnvelope(event: MessageEvent, ctx: AcceptContext): boolean {
   if (!ctx.allowOrigins.includes(event.origin)) return false;
   if (ctx.expectedSource !== null && event.source !== ctx.expectedSource) return false;
-  if (!isCherryEnvelope(event.data)) return false;
+  if (!isCherryEnvelope(event.data, ctx.versions)) return false;
   if (ctx.channelId !== null && event.data.channelId !== ctx.channelId) return false;
   return true;
 }
 
 /**
- * True when a message is shaped like a cherry envelope but carries a DIFFERENT
- * protocol version — i.e. the peer is a version-skewed build, not postMessage
- * noise. `isCherryEnvelope` (and therefore `acceptEnvelope`) rejects these, so
- * without this check a skewed peer is indistinguishable from the generic
- * handshake timeout. Callers log it distinctly ("update the older side").
+ * True when a message is shaped like a cherry envelope but carries a protocol
+ * version outside the caller's accepted set — i.e. the peer is a version-skewed
+ * build, not postMessage noise. `isCherryEnvelope` (and therefore
+ * `acceptEnvelope`) rejects these, so without this check a skewed peer is
+ * indistinguishable from the generic handshake timeout. Callers log it
+ * distinctly ("update the older side").
  */
 export function isCherryVersionMismatch(
-  value: unknown
+  value: unknown,
+  supported: readonly number[] = [CHERRY_PROTOCOL_VERSION]
 ): value is { cherry: number; channelId: string; kind: string } {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
   return (
     typeof v.cherry === 'number' &&
-    v.cherry !== CHERRY_PROTOCOL_VERSION &&
+    !supported.includes(v.cherry) &&
     typeof v.channelId === 'string' &&
     typeof v.kind === 'string'
   );

--- a/packages/webapp/src/cdp/cherry-host-transport.ts
+++ b/packages/webapp/src/cdp/cherry-host-transport.ts
@@ -431,10 +431,15 @@ export class CherryHostTransport extends SyntheticCdpTransport {
         origin: event.origin,
       });
       // Fail the pending connect() immediately instead of eating the 30s
-      // timeout — but ONLY when origin + source match the pinned host page.
-      // Without that gate any hostile frame could post a mismatch-shaped
-      // message and kill the handshake.
+      // timeout — but ONLY when ALL THREE factors match: origin, source, AND
+      // the channelId nonce. acceptEnvelope rejected on version before its
+      // nonce check could run, so restore it here — without it any hostile
+      // frame could kill the handshake, and a DELAYED mismatch reply from a
+      // previous connect attempt (different channelId) would fail an
+      // unrelated pending connect. The host's genuine reply echoes this
+      // attempt's hello channelId, so the nonce always matches when it should.
       const trustedPeer =
+        event.data.channelId === this.channelId &&
         this.opts.allowOrigins.includes(event.origin) &&
         event.source === (this.opts.counterpart as unknown as MessageEventSource);
       if (trustedPeer) {

--- a/packages/webapp/src/cdp/cherry-host-transport.ts
+++ b/packages/webapp/src/cdp/cherry-host-transport.ts
@@ -19,6 +19,7 @@ import {
   type CherrySessionExportProgress,
   isCherryEnvelope,
   isCherryVersionMismatch,
+  SUPPORTED_CHERRY_PROTOCOL_VERSIONS,
 } from './cherry-host-protocol.js';
 import { SyntheticCdpTransport } from './synthetic-cdp-transport.js';
 import type { CDPConnectOptions } from './types.js';
@@ -72,6 +73,13 @@ export class CherryHostTransport extends SyntheticCdpTransport {
   };
   private _theme: string | null = null;
   private _effortLevel: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | null = null;
+  /**
+   * Wire version negotiated with the host SDK. connect() posts one hello per
+   * SUPPORTED_CHERRY_PROTOCOL_VERSIONS entry; the version of the welcome the
+   * host answers with is pinned here and stamped on all subsequent outbound
+   * envelopes (a vendored older SDK drops envelopes at any other version).
+   */
+  private negotiatedVersion: number = CHERRY_PROTOCOL_VERSION;
   private boundHandler = (ev: MessageEvent) => this.handleMessage(ev);
 
   /**
@@ -186,11 +194,17 @@ export class CherryHostTransport extends SyntheticCdpTransport {
     return this._effortLevel;
   }
 
+  /** The wire version negotiated at handshake (own version until connected). */
+  get negotiatedProtocolVersion(): number {
+    return this.negotiatedVersion;
+  }
+
   async connect(options?: CDPConnectOptions): Promise<void> {
     if (this._state !== 'disconnected') {
       throw new Error(`Cannot connect: state is ${this._state}`);
     }
     this._state = 'connecting';
+    this.negotiatedVersion = CHERRY_PROTOCOL_VERSION;
     this.channelId = `cherry-${crypto.randomUUID()}`;
     if (typeof window !== 'undefined') {
       window.addEventListener('message', this.boundHandler);
@@ -208,18 +222,30 @@ export class CherryHostTransport extends SyntheticCdpTransport {
         this.channelId = null;
         this.connectResolve = null;
         this.connectReject = null;
-        reject(new Error(`Cherry handshake timed out after ${timeoutMs}ms`));
+        reject(
+          new Error(
+            `Cherry handshake timed out after ${timeoutMs}ms — no handshake.welcome ` +
+              `from the embedding page (host SDK missing, not listening, or ` +
+              `version-skewed; check the host page's console)`
+          )
+        );
       }, timeoutMs);
-      this.post({
-        cherry: CHERRY_PROTOCOL_VERSION,
-        channelId: this.channelId!,
-        kind: 'handshake.hello',
-        capabilities: this.opts.capabilities ?? {
-          navigate: true,
-          screenshot: true,
-          openUrl: true,
-        },
-      });
+      // One hello per supported wire version, newest first, SAME channelId (a
+      // host must not read the extra hellos as a reloaded-iframe re-handshake).
+      // A host only answers the hello at its own version and warn-drops the
+      // others, so a vendored older SDK still completes the handshake.
+      for (const version of SUPPORTED_CHERRY_PROTOCOL_VERSIONS) {
+        this.post({
+          cherry: version,
+          channelId: this.channelId!,
+          kind: 'handshake.hello',
+          capabilities: this.opts.capabilities ?? {
+            navigate: true,
+            screenshot: true,
+            openUrl: true,
+          },
+        });
+      }
     });
   }
 
@@ -284,7 +310,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
         },
       });
       this.post({
-        cherry: CHERRY_PROTOCOL_VERSION,
+        cherry: this.negotiatedVersion,
         channelId: this.channelId!,
         kind: 'cdp.request',
         id,
@@ -314,7 +340,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
       return;
     }
     this.post({
-      cherry: CHERRY_PROTOCOL_VERSION,
+      cherry: this.negotiatedVersion,
       channelId: this.channelId,
       kind: 'slicc.event',
       name,
@@ -329,74 +355,33 @@ export class CherryHostTransport extends SyntheticCdpTransport {
   }
 
   private handleMessage(event: MessageEvent): void {
+    // While negotiating, accept any supported wire version; once connected,
+    // narrow to the single version the welcome pinned.
+    const versions =
+      this._state === 'connected' ? [this.negotiatedVersion] : SUPPORTED_CHERRY_PROTOCOL_VERSIONS;
     if (
       !acceptEnvelope(event, {
         allowOrigins: this.opts.allowOrigins,
         expectedSource: this.opts.counterpart as unknown as MessageEventSource,
         channelId: this.channelId,
+        versions,
       })
     ) {
-      // A version-skewed peer fails `isCherryEnvelope` itself — without this
-      // distinct log the skew is indistinguishable from the 30s timeout.
-      if (isCherryVersionMismatch(event.data)) {
-        log.warn('Cherry protocol version mismatch — update the older side', {
-          peerVersion: event.data.cherry,
-          ourVersion: CHERRY_PROTOCOL_VERSION,
-          origin: event.origin,
-        });
-        // Fail the pending connect() immediately instead of eating the 30s
-        // timeout — but ONLY when origin + source match the pinned host page.
-        // Without that gate any hostile frame could post a mismatch-shaped
-        // message and kill the handshake.
-        const trustedPeer =
-          this.opts.allowOrigins.includes(event.origin) &&
-          event.source === (this.opts.counterpart as unknown as MessageEventSource);
-        if (trustedPeer) {
-          this.failPendingConnect(
-            new Error(
-              `Cherry protocol version mismatch (peer v${event.data.cherry}, ` +
-                `ours v${CHERRY_PROTOCOL_VERSION}) — update the older side`
-            )
-          );
-        }
-      } else if (isCherryEnvelope(event.data)) {
-        // A well-formed cherry envelope rejected by the gate signals a
-        // misconfiguration (wrong host origin, source/channel mismatch) rather
-        // than unrelated postMessage noise — log it so it doesn't surface only
-        // as an opaque 30s connect timeout. Plain noise is filtered silently.
-        log.warn('Rejected a cherry envelope (origin/source/channel mismatch)', {
-          origin: event.origin,
-          allowOrigins: this.opts.allowOrigins,
-        });
-      }
+      this.diagnoseRejectedMessage(event, versions);
       return;
     }
     const env = event.data as CherryEnvelope;
+    // v2-only envelope kinds must not be acted on over a v1-negotiated channel
+    // (the host would silently drop our v2-shaped replies anyway).
+    if (this.negotiatedVersion < 2 && env.kind.startsWith('session.export.')) {
+      log.warn('Ignoring a v2-only envelope on a v1-negotiated cherry channel', {
+        kind: env.kind,
+      });
+      return;
+    }
     switch (env.kind) {
       case 'handshake.welcome':
-        if (this.connectTimer !== null) {
-          clearTimeout(this.connectTimer);
-          this.connectTimer = null;
-        }
-        this._state = 'connected';
-        this._joinUrl = env.joinUrl ?? null;
-        this._theme = env.theme ?? null;
-        this._effortLevel = env.effortLevel ?? null;
-        this._features = env.features ?? {
-          terminal: true,
-          files: true,
-          memory: true,
-          browser: true,
-          modelPicker: true,
-          history: true,
-          nav: true,
-          newSprinkle: true,
-          monitor: true,
-        };
-        log.info('Cherry handshake complete', { channelId: this.channelId });
-        this.connectResolve?.();
-        this.connectResolve = null;
-        this.connectReject = null;
+        this.handleWelcome(env);
         return;
       case 'cdp.response': {
         const p = this.pending.get(env.id);
@@ -432,6 +417,77 @@ export class CherryHostTransport extends SyntheticCdpTransport {
     }
   }
 
+  /**
+   * Diagnose a message that failed the three-factor gate. A version-skewed
+   * peer fails `isCherryEnvelope` itself — without a distinct log (and the
+   * fast connect() rejection) the skew is indistinguishable from the 30s
+   * handshake timeout.
+   */
+  private diagnoseRejectedMessage(event: MessageEvent, versions: readonly number[]): void {
+    if (isCherryVersionMismatch(event.data, versions)) {
+      log.warn('Cherry protocol version mismatch — update the older side', {
+        peerVersion: event.data.cherry,
+        supportedVersions: [...SUPPORTED_CHERRY_PROTOCOL_VERSIONS],
+        origin: event.origin,
+      });
+      // Fail the pending connect() immediately instead of eating the 30s
+      // timeout — but ONLY when origin + source match the pinned host page.
+      // Without that gate any hostile frame could post a mismatch-shaped
+      // message and kill the handshake.
+      const trustedPeer =
+        this.opts.allowOrigins.includes(event.origin) &&
+        event.source === (this.opts.counterpart as unknown as MessageEventSource);
+      if (trustedPeer) {
+        this.failPendingConnect(
+          new Error(
+            `Cherry protocol version mismatch (peer v${event.data.cherry}, ` +
+              `ours v${CHERRY_PROTOCOL_VERSION}) — update the older side`
+          )
+        );
+      }
+    } else if (isCherryEnvelope(event.data, SUPPORTED_CHERRY_PROTOCOL_VERSIONS)) {
+      // A well-formed cherry envelope rejected by the gate signals a
+      // misconfiguration (wrong host origin, source/channel mismatch) rather
+      // than unrelated postMessage noise — log it so it doesn't surface only
+      // as an opaque 30s connect timeout. Plain noise is filtered silently.
+      log.warn('Rejected a cherry envelope (origin/source/channel mismatch)', {
+        origin: event.origin,
+        allowOrigins: this.opts.allowOrigins,
+      });
+    }
+  }
+
+  /** Complete the handshake: pin the negotiated wire version and host-supplied config. */
+  private handleWelcome(env: Extract<CherryEnvelope, { kind: 'handshake.welcome' }>): void {
+    if (this.connectTimer !== null) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
+    this._state = 'connected';
+    this.negotiatedVersion = env.cherry;
+    this._joinUrl = env.joinUrl ?? null;
+    this._theme = env.theme ?? null;
+    this._effortLevel = env.effortLevel ?? null;
+    this._features = env.features ?? {
+      terminal: true,
+      files: true,
+      memory: true,
+      browser: true,
+      modelPicker: true,
+      history: true,
+      nav: true,
+      newSprinkle: true,
+      monitor: true,
+    };
+    log.info('Cherry handshake complete', {
+      channelId: this.channelId,
+      negotiatedVersion: this.negotiatedVersion,
+    });
+    this.connectResolve?.();
+    this.connectResolve = null;
+    this.connectReject = null;
+  }
+
   private handleExportRequest(
     env: Extract<CherryEnvelope, { kind: 'session.export.request' }>
   ): void {
@@ -447,7 +503,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
       // Only post progress if the request is still live.
       if (!this.pendingHostExports.has(requestId)) return;
       this.post({
-        cherry: CHERRY_PROTOCOL_VERSION,
+        cherry: this.negotiatedVersion,
         channelId,
         kind: 'session.export.progress',
         requestId,
@@ -464,7 +520,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
       .then((blob) => {
         this.pendingHostExports.delete(requestId);
         this.post({
-          cherry: CHERRY_PROTOCOL_VERSION,
+          cherry: this.negotiatedVersion,
           channelId,
           kind: 'session.export.response',
           requestId,
@@ -488,7 +544,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
   private postExportError(requestId: string, code: string): void {
     if (!this.channelId) return;
     this.post({
-      cherry: CHERRY_PROTOCOL_VERSION,
+      cherry: this.negotiatedVersion,
       channelId: this.channelId,
       kind: 'session.export.error',
       requestId,

--- a/packages/webapp/tests/cdp/cherry-host-transport.test.ts
+++ b/packages/webapp/tests/cdp/cherry-host-transport.test.ts
@@ -252,6 +252,34 @@ describe('CherryHostTransport', () => {
     expect(h.transport.state).toBe('disconnected');
   });
 
+  it('does not fail a pending connect on a version-skewed envelope with a stale channelId', async () => {
+    // A delayed handshake.version-mismatch reply from a PREVIOUS connect
+    // attempt (or another transport on the same parent) carries a different
+    // channelId — it must not kill the current pending handshake.
+    const p = h.transport.connect();
+    const hello = h.posted.find((m) => m.kind === 'handshake.hello');
+    const unsupported = Math.max(...SUPPORTED_CHERRY_PROTOCOL_VERSIONS) + 1;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      h.inbound({
+        cherry: unsupported,
+        channelId: 'cherry-stale-previous-attempt',
+        kind: 'handshake.version-mismatch',
+        peerVersion: 2,
+      });
+      // Still pending — a valid welcome for THIS attempt completes it.
+      h.inbound({
+        cherry: CHERRY_PROTOCOL_VERSION,
+        channelId: hello.channelId,
+        kind: 'handshake.welcome',
+      });
+      await expect(p).resolves.toBeUndefined();
+    } finally {
+      warnSpy.mockRestore();
+    }
+    expect(h.transport.state).toBe('connected');
+  });
+
   it('rejects connect and resets state when the handshake times out', async () => {
     vi.useFakeTimers();
     const p = h.transport.connect();

--- a/packages/webapp/tests/cdp/cherry-host-transport.test.ts
+++ b/packages/webapp/tests/cdp/cherry-host-transport.test.ts
@@ -1,6 +1,9 @@
 import type { TranscriptExportProgress } from '@slicc/shared-ts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { CHERRY_PROTOCOL_VERSION } from '../../src/cdp/cherry-host-protocol.js';
+import {
+  CHERRY_PROTOCOL_VERSION,
+  SUPPORTED_CHERRY_PROTOCOL_VERSIONS,
+} from '../../src/cdp/cherry-host-protocol.js';
 import { CherryHostTransport } from '../../src/cdp/cherry-host-transport.js';
 
 function makeTransport() {
@@ -138,6 +141,115 @@ describe('CherryHostTransport', () => {
     });
     await p;
     expect(events).toEqual(['frameNavigated', 'loadEventFired']);
+  });
+
+  // -------------------------------------------------------------------------
+  // Protocol version negotiation (regression: 2026-07-27 labs handshake timeout
+  // — a host page with a vendored v1 SDK silently dropped the v2 hello and the
+  // iframe ate the full 30s timeout).
+  // -------------------------------------------------------------------------
+
+  it('posts one hello per supported protocol version, newest first, same channelId', async () => {
+    const p = h.transport.connect();
+    const hellos = h.posted.filter((m) => m.kind === 'handshake.hello');
+    expect(hellos.map((m) => m.cherry)).toEqual([...SUPPORTED_CHERRY_PROTOCOL_VERSIONS]);
+    expect(SUPPORTED_CHERRY_PROTOCOL_VERSIONS[0]).toBe(CHERRY_PROTOCOL_VERSION);
+    // Same channelId on every hello: a legacy host must not read the extra
+    // hello as a reloaded-iframe re-handshake (isReHello keys on channelId).
+    expect(new Set(hellos.map((m) => m.channelId)).size).toBe(1);
+    // Settle the connect so the test doesn't leak a pending timer.
+    h.inbound({
+      cherry: CHERRY_PROTOCOL_VERSION,
+      channelId: hellos[0].channelId,
+      kind: 'handshake.welcome',
+    });
+    await p;
+  });
+
+  it('completes the handshake against a legacy v1 host SDK', async () => {
+    const p = h.transport.connect();
+    // A vendored v1 host rejects the v2 hello (console.warn only, no reply) and
+    // answers ONLY a v1 hello with a v1 welcome.
+    const v1Hello = h.posted.find((m) => m.kind === 'handshake.hello' && m.cherry === 1);
+    expect(v1Hello).toBeTruthy();
+    h.inbound({
+      cherry: 1,
+      channelId: v1Hello.channelId,
+      kind: 'handshake.welcome',
+      joinUrl: 'https://app.example/join?t=L',
+    });
+    await expect(p).resolves.toBeUndefined();
+    expect(h.transport.state).toBe('connected');
+    expect(h.transport.joinUrl).toBe('https://app.example/join?t=L');
+    expect(h.transport.negotiatedProtocolVersion).toBe(1);
+  });
+
+  it('stamps outbound envelopes with the negotiated version after a v1 welcome', async () => {
+    const p = h.transport.connect();
+    const v1Hello = h.posted.find((m) => m.kind === 'handshake.hello' && m.cherry === 1);
+    h.inbound({ cherry: 1, channelId: v1Hello.channelId, kind: 'handshake.welcome' });
+    await p;
+    // slicc.event — the v1 host's acceptEnvelope would drop a v2-stamped one.
+    h.transport.emitSliccEventToHost('build.done');
+    const ev = h.posted.find((m) => m.kind === 'slicc.event');
+    expect(ev.cherry).toBe(1);
+    // cdp.request — same wire-version requirement.
+    void h.transport.send('Runtime.evaluate', { expression: '1' }).catch(() => {});
+    const req = h.posted.find((m) => m.kind === 'cdp.request');
+    expect(req.cherry).toBe(1);
+    h.transport.disconnect();
+  });
+
+  it('accepts inbound v1 envelopes after negotiating v1', async () => {
+    const p = h.transport.connect();
+    const v1Hello = h.posted.find((m) => m.kind === 'handshake.hello' && m.cherry === 1);
+    h.inbound({ cherry: 1, channelId: v1Hello.channelId, kind: 'handshake.welcome' });
+    await p;
+    const seen: string[] = [];
+    h.transport.onHostEvent = (name) => seen.push(name);
+    h.inbound({
+      cherry: 1,
+      channelId: v1Hello.channelId,
+      kind: 'host.event',
+      name: 'checkout-done',
+    });
+    expect(seen).toEqual(['checkout-done']);
+  });
+
+  it('ignores session.export.request after negotiating v1 (v2-only envelope kind)', async () => {
+    const p = h.transport.connect();
+    const v1Hello = h.posted.find((m) => m.kind === 'handshake.hello' && m.cherry === 1);
+    h.inbound({ cherry: 1, channelId: v1Hello.channelId, kind: 'handshake.welcome' });
+    await p;
+    h.transport.onExportRequest = vi.fn();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      h.inbound({
+        cherry: 1,
+        channelId: v1Hello.channelId,
+        kind: 'session.export.request',
+        requestId: 'req-v1-export',
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+    expect(h.transport.onExportRequest).not.toHaveBeenCalled();
+    expect(h.posted.find((m) => m.kind === 'session.export.error')).toBeUndefined();
+  });
+
+  it('fails fast on a trusted welcome with a version outside the supported set', async () => {
+    const p = h.transport.connect();
+    const hello = h.posted.find((m) => m.kind === 'handshake.hello');
+    const unsupported = Math.max(...SUPPORTED_CHERRY_PROTOCOL_VERSIONS) + 1;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      h.inbound({ cherry: unsupported, channelId: hello.channelId, kind: 'handshake.welcome' });
+      // String argument = substring match (avoids a dynamically-built RegExp).
+      await expect(p).rejects.toThrow(`version mismatch (peer v${unsupported}`);
+    } finally {
+      warnSpy.mockRestore();
+    }
+    expect(h.transport.state).toBe('disconnected');
   });
 
   it('rejects connect and resets state when the handshake times out', async () => {


### PR DESCRIPTION
## Problem

Since 2026-07-27, every production Cherry embed running a vendored pre-v2 SDK fails with:

> **Could not start follower** — Cherry handshake timed out after 30000ms

(P1 incident on `labs.of1.live/liftoff`.)

## Root cause

e1865d39d (2026-07-23) bumped `CHERRY_PROTOCOL_VERSION` 1 → 2 for transcript exports — an additive feature — while `isCherryEnvelope` on both sides validates the version with strict equality. Embedders vendor the host SDK, so a v1 host receives the v2 `handshake.hello`, rejects it with only a console warning in the host page, and never replies. The follower iframe's fast-fail skew detection needs to *receive* a mismatched envelope, so it never fires and the connect eats the full 30s timeout. The error surfaces inside the iframe as "Could not start follower", misdirecting diagnosis toward the cone/joinUrl (which are fine — the failure is in the host↔iframe postMessage handshake, before any cone connection).

## Change

**Follower (webapp, `CherryHostTransport`):**

- Posts one `handshake.hello` per entry in the new `SUPPORTED_CHERRY_PROTOCOL_VERSIONS` ([2, 1], same `channelId` so a host's re-hello logic doesn't misread it), pins the negotiated version from whichever `handshake.welcome` the host answers, and stamps all subsequent outbound envelopes with it. A vendored v1 host now completes the handshake against the current webapp with no re-vendor.
- Ignores v2-only `session.export.*` envelope kinds on a v1-negotiated channel.
- The timeout error message now names the plausible causes (host SDK missing, not listening, or version-skewed).

**Host SDK (`mount.ts`):**

- Replies `handshake.version-mismatch` (new envelope) to a version-skewed hello — only when origin + source prove it is our iframe, and never for the companion lower-version hello of a completed handshake — so a future no-overlap skew fails `connect()` in seconds with "update the older side" instead of the opaque timeout.
- New `hooks.onProtocolMismatch(peerVersion, sdkVersion)` lets embedders surface the skew.

**Protocol mirrors:** `cherry-host-protocol.ts` and `cherry/src/protocol.ts` updated identically (enforced by `protocol-mirror.test.ts`); envelope `cherry` fields are now `number` with runtime validation against an accepted-versions set.

## Tests

- 6 new transport tests: dual-hello shape, v1-host handshake (regression for the incident), negotiated-version stamping in/out, v2-only kind gating, unsupported-version fast-fail.
- 4 new mount tests: mismatch reply + hook, companion-hello suppression, untrusted origin/source, non-handshake skewed envelopes.
- Mutation-verified: removing v1 support fails 4 tests; disabling the mismatch reply fails 1.

## Docs

`packages/cherry/CLAUDE.md` gains a "Protocol version negotiation and bump rules" section: keep the previous version in the supported set when bumping, gate new envelope kinds on the negotiated version, and only drop a version for a genuinely breaking wire change.
