### PR TITLE
fix(webapp): stop rendering transient drops as permanent errors; wire floatbar online

### DIFF
--- a/packages/webapp/src/scoops/tray-follower-sync.ts
+++ b/packages/webapp/src/scoops/tray-follower-sync.ts
@@ -321,7 +321,8 @@ export class FollowerSyncManager implements AgentHandle {
       },
     });
     this.keepalive.start();
-    // Emit an error event when the underlying channel drops
+    // Treat an unexpected underlying channel drop as a disconnect (status +
+    // cleanup + onDisconnect; no transcript error event — see handleDisconnect)
     channel.addEventListener('close', () => {
       log.warn('Data channel closed');
       this.handleDisconnect('Data channel closed');
@@ -397,8 +398,8 @@ export class FollowerSyncManager implements AgentHandle {
    * Close the sync channel and clean up. Idempotent — once called, the
    * channel-close event that follows will short-circuit in
    * `handleDisconnect`, so a caller-initiated teardown can't trigger
-   * the error-state side effects (red-error follower status, `error`
-   * event emission, `onDisconnect` callback that drives reconnect
+   * the error-state side effects (red-error follower status, error-level
+   * disconnect log, `onDisconnect` callback that drives reconnect
    * logic) that `handleDisconnect` is designed to fire only on an
    * unexpected channel drop.
    */
@@ -1202,7 +1203,9 @@ export class FollowerSyncManager implements AgentHandle {
    */
   private async executeLocalCDP(
     requestId: string,
-    localTargetId: string,
+    // Unused: the wire message carries the follower-local target id for
+    // symmetry, but the transport routes by sessionId/method alone.
+    _localTargetId: string,
     method: string,
     params: Record<string, unknown> | undefined,
     sessionId: string | undefined

--- a/packages/webapp/src/scoops/tray-follower-sync.ts
+++ b/packages/webapp/src/scoops/tray-follower-sync.ts
@@ -632,11 +632,26 @@ export class FollowerSyncManager implements AgentHandle {
 
   /**
    * Handle a detected disconnect (keepalive dead, channel close/error).
-   * Updates follower status, emits an error event, cleans up, and notifies via onDisconnect.
+   * Updates follower status, cleans up, and notifies via onDisconnect.
+   *
+   * Deliberately does NOT emit an agent 'error' event (#1707): this manager
+   * is installed as the chat panel's AgentHandle, so such an event renders a
+   * permanent `<slicc-error-card>` in the transcript and fires `trackError`
+   * into RUM — for a state that `startFollowerWithAutoReconnect` usually
+   * heals in seconds. Connection state is presented by the mount instead
+   * (`onConnectionChange`/`onGaveUp` → composer placeholders) and recorded in
+   * the follower runtime status for `host`/telemetry. Leader-SENT error
+   * events (genuine agent errors) still forward via `handleLeaderMessage`.
    */
   private handleDisconnect(reason: string): void {
     if (this.disconnected) return; // prevent duplicate cleanup
     this.disconnected = true;
+
+    // `error` (not `warn`): the prod log level is ERROR, and a real transport
+    // drop previously produced no console signal at all — only the UI knew
+    // (#1707). An EXPECTED stall stays `warn` per #1698; an unexpected drop
+    // is precisely the thing an operator console should show.
+    log.error('Follower sync disconnected', { reason });
 
     // Update follower runtime status to error
     const current = getFollowerTrayRuntimeStatus();
@@ -648,9 +663,6 @@ export class FollowerSyncManager implements AgentHandle {
       // thing it described.
       stalled: false,
     });
-
-    // Emit error to UI listeners
-    this.emitEvent({ type: 'error', error: `Connection to leader lost: ${reason}` });
 
     // Clean up keepalive, CDP event forwarding, and sync channel
     this.keepalive.stop();

--- a/packages/webapp/src/ui/wc/wc-floatbar-online.ts
+++ b/packages/webapp/src/ui/wc/wc-floatbar-online.ts
@@ -1,0 +1,65 @@
+/**
+ * `wc-floatbar-online.ts` — the single producer for `slicc-floatbar`'s
+ * `online` attribute (#1707: the component API existed, storybook exercised
+ * it, and nothing in the app ever drove it — the dot never lit and the pill
+ * tooltip always read "offline").
+ *
+ * Semantics: the dot means "this float has a live tray link" — it is lit
+ * while this page is LEADING a tray (reachable by followers) or FOLLOWING
+ * one (connected to a leader). A purely local float with no tray shows no
+ * dot, which is truthful: nothing is linked to it.
+ *
+ * A leader stall (`stalled` overlay) deliberately keeps the dot lit: the
+ * data channel is open and recovers on its own — a stalled follower is
+ * still `connected` (see `tray-follower-status.ts`).
+ *
+ * Every mount installs the same helper: the no-kernel follower
+ * (`wc-follower.ts`) and the kernel float (`wc-tray.ts`, which handles both
+ * roles). In each float the inactive role's status simply stays `inactive`,
+ * so one OR across both statuses is correct everywhere.
+ */
+
+import {
+  type FollowerTrayRuntimeStatus,
+  getFollowerTrayRuntimeStatus,
+  subscribeToFollowerTrayRuntimeStatus,
+} from '../../scoops/tray-follower-status.js';
+import {
+  getLeaderTrayRuntimeStatus,
+  type LeaderTrayRuntimeStatus,
+  subscribeToLeaderTrayRuntimeStatus,
+} from '../../scoops/tray-leader.js';
+
+/**
+ * Drive `floatbar`'s `online` attribute from the tray runtime statuses.
+ * Seeds the current state immediately and updates on every transition.
+ * Returns an uninstall function that stops both subscriptions.
+ */
+export function installFloatbarOnline(floatbar: HTMLElement): () => void {
+  let leaderOnline = isLeaderOnline(getLeaderTrayRuntimeStatus());
+  let followerOnline = isFollowerOnline(getFollowerTrayRuntimeStatus());
+  const apply = (): void => {
+    floatbar.toggleAttribute('online', leaderOnline || followerOnline);
+  };
+  const unsubscribeLeader = subscribeToLeaderTrayRuntimeStatus((status) => {
+    leaderOnline = isLeaderOnline(status);
+    apply();
+  });
+  const unsubscribeFollower = subscribeToFollowerTrayRuntimeStatus((status) => {
+    followerOnline = isFollowerOnline(status);
+    apply();
+  });
+  apply();
+  return () => {
+    unsubscribeLeader();
+    unsubscribeFollower();
+  };
+}
+
+function isLeaderOnline(status: LeaderTrayRuntimeStatus): boolean {
+  return status.state === 'leader';
+}
+
+function isFollowerOnline(status: FollowerTrayRuntimeStatus): boolean {
+  return status.state === 'connected';
+}

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -17,6 +17,7 @@ import { applyCherryTheme } from '../theme-engine.js';
 import type { AgentHandle } from '../types.js';
 import { wireWcAttach } from './wc-attach.js';
 import { WcChatController } from './wc-chat-controller.js';
+import { installFloatbarOnline } from './wc-floatbar-online.js';
 import { prepareWcShell } from './wc-live.js';
 import { scoopColor } from './wc-scoop-color.js';
 import { submittedText } from './wc-shell.js';
@@ -462,6 +463,12 @@ export async function mountWcUiFollower(
     else boot.refs.inputCard.setAttribute('disabled', '');
   };
   setComposerState(false, CONNECTING);
+
+  // Drive the floatbar's `online` dot from the tray statuses (#1707) — the
+  // no-kernel follower's install point; the kernel float installs the same
+  // helper in `wc-tray.ts`. Before this, the API existed but had no producer:
+  // the dot never lit and the pill tooltip read "offline" mid-stream.
+  installFloatbarOnline(boot.refs.floatbar);
 
   // Mirror the follower tray status into `localStorage`, matching what
   // `wc-tray.ts` does for the kernel-backed floats. Without this the

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -59,6 +59,7 @@ import {
   type LeaderRunNewSessionDetail,
 } from './leader-session-events.js';
 import type { WcChatController } from './wc-chat-controller.js';
+import { installFloatbarOnline } from './wc-floatbar-online.js';
 import { scoopColor } from './wc-scoop-color.js';
 import type { WcShellRefs } from './wc-shell.js';
 
@@ -576,6 +577,11 @@ export async function wireWcTray(deps: WcTrayDeps): Promise<WcTrayHandle> {
   });
 
   startInitialRole(deps, state, leaderOptions, wireLeaderHooks, lockManager);
+
+  // Drive the floatbar's `online` dot from the tray statuses (#1707). This is
+  // the kernel float's install point (covers both roles); the no-kernel
+  // follower mount installs the same helper in `wc-follower.ts`.
+  installFloatbarOnline(deps.refs.floatbar);
 
   subscribeToLeaderTrayRuntimeStatus((status) => {
     win.localStorage.setItem('slicc.leaderTrayStatus', JSON.stringify(status));

--- a/packages/webapp/tests/scoops/tray-follower-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-follower-sync.test.ts
@@ -1252,7 +1252,13 @@ describe('FollowerSyncManager', () => {
       });
     });
 
-    it('emits error event and updates status when channel closes', () => {
+    it('updates status WITHOUT emitting a transcript error event when channel closes (#1707)', () => {
+      // A transient drop is connection state, not conversation content: the
+      // mount presents it via onConnectionChange/onGaveUp and auto-reconnect
+      // usually heals it. Emitting an agent 'error' event here rendered a
+      // permanent <slicc-error-card> in the thread (and fired trackError into
+      // RUM) for every self-healing blip. Leader-SENT error events still
+      // forward — see 'dispatches error events from leader error messages'.
       const channel = new FakeChannel();
       const onDisconnect = vi.fn();
       const follower = new FollowerSyncManager(channel, { onDisconnect });
@@ -1261,15 +1267,14 @@ describe('FollowerSyncManager', () => {
 
       channel.simulateClose();
 
-      expect(events).toHaveLength(1);
-      expect(events[0].type).toBe('error');
+      expect(events).toHaveLength(0);
       const status = getFollowerTrayRuntimeStatus();
       expect(status.state).toBe('error');
       expect(status.error).toBe('Data channel closed');
       expect(onDisconnect).toHaveBeenCalledWith('Data channel closed');
     });
 
-    it('emits error event and updates status when channel errors', () => {
+    it('updates status WITHOUT emitting a transcript error event when channel errors (#1707)', () => {
       const channel = new FakeChannel();
       const onDisconnect = vi.fn();
       const follower = new FollowerSyncManager(channel, { onDisconnect });
@@ -1278,8 +1283,7 @@ describe('FollowerSyncManager', () => {
 
       channel.simulateError();
 
-      expect(events).toHaveLength(1);
-      expect(events[0].type).toBe('error');
+      expect(events).toHaveLength(0);
       const status = getFollowerTrayRuntimeStatus();
       expect(status.state).toBe('error');
       expect(status.error).toBe('Data channel error');
@@ -1297,7 +1301,7 @@ describe('FollowerSyncManager', () => {
       channel.simulateClose();
       channel.simulateError();
 
-      expect(events).toHaveLength(1);
+      expect(events).toHaveLength(0);
       expect(onDisconnect).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/webapp/tests/ui/wc/wc-floatbar-online.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-floatbar-online.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  setFollowerStalled,
+  setFollowerTrayRuntimeStatus,
+} from '../../../src/scoops/tray-follower-status.js';
+import { setLeaderTrayRuntimeStatus } from '../../../src/scoops/tray-leader.js';
+import { installFloatbarOnline } from '../../../src/ui/wc/wc-floatbar-online.js';
+
+const INACTIVE_FOLLOWER = {
+  state: 'inactive' as const,
+  joinUrl: null,
+  trayId: null,
+  error: null,
+  lastPingTime: null,
+  reconnectAttempts: 0,
+  attachAttempts: 0,
+  lastAttachCode: null,
+  connectingSince: null,
+  lastError: null,
+};
+
+function followerStatus(state: 'inactive' | 'connecting' | 'connected' | 'reconnecting' | 'error') {
+  return { ...INACTIVE_FOLLOWER, state };
+}
+
+describe('installFloatbarOnline (#1707)', () => {
+  let floatbar: HTMLElement;
+
+  beforeEach(() => {
+    // Reset both module-global statuses so test order can't leak state.
+    setFollowerTrayRuntimeStatus(followerStatus('inactive'));
+    setLeaderTrayRuntimeStatus({ state: 'inactive', session: null, error: null });
+    floatbar = document.createElement('div');
+  });
+
+  it('seeds the current state on install (already-connected follower lights the dot)', () => {
+    setFollowerTrayRuntimeStatus(followerStatus('connected'));
+    const uninstall = installFloatbarOnline(floatbar);
+    expect(floatbar.hasAttribute('online')).toBe(true);
+    uninstall();
+  });
+
+  it('lights the dot when the follower connects and clears it on error/reconnecting', () => {
+    const uninstall = installFloatbarOnline(floatbar);
+    expect(floatbar.hasAttribute('online')).toBe(false);
+
+    setFollowerTrayRuntimeStatus(followerStatus('connected'));
+    expect(floatbar.hasAttribute('online')).toBe(true);
+
+    // The exact regression from #1707: a transient drop must read offline…
+    setFollowerTrayRuntimeStatus(followerStatus('error'));
+    expect(floatbar.hasAttribute('online')).toBe(false);
+    setFollowerTrayRuntimeStatus(followerStatus('reconnecting'));
+    expect(floatbar.hasAttribute('online')).toBe(false);
+
+    // …and recovery must light it again without any manual action.
+    setFollowerTrayRuntimeStatus(followerStatus('connected'));
+    expect(floatbar.hasAttribute('online')).toBe(true);
+    uninstall();
+  });
+
+  it('keeps the dot lit through a leader stall (stalled is still connected)', () => {
+    const uninstall = installFloatbarOnline(floatbar);
+    setFollowerTrayRuntimeStatus(followerStatus('connected'));
+    setFollowerStalled(true);
+    expect(floatbar.hasAttribute('online')).toBe(true);
+    setFollowerStalled(false);
+    expect(floatbar.hasAttribute('online')).toBe(true);
+    uninstall();
+  });
+
+  it('lights the dot while leading a tray and clears it when the tray goes inactive', () => {
+    const uninstall = installFloatbarOnline(floatbar);
+    setLeaderTrayRuntimeStatus({ state: 'leader', session: null, error: null });
+    expect(floatbar.hasAttribute('online')).toBe(true);
+    setLeaderTrayRuntimeStatus({ state: 'inactive', session: null, error: null });
+    expect(floatbar.hasAttribute('online')).toBe(false);
+    uninstall();
+  });
+
+  it('either role alone keeps the dot lit (leader OR follower link)', () => {
+    const uninstall = installFloatbarOnline(floatbar);
+    setLeaderTrayRuntimeStatus({ state: 'leader', session: null, error: null });
+    setFollowerTrayRuntimeStatus(followerStatus('connected'));
+    // Dropping one role while the other is live must not clear the dot.
+    setLeaderTrayRuntimeStatus({ state: 'inactive', session: null, error: null });
+    expect(floatbar.hasAttribute('online')).toBe(true);
+    uninstall();
+  });
+
+  it('uninstall stops driving the attribute', () => {
+    const uninstall = installFloatbarOnline(floatbar);
+    setFollowerTrayRuntimeStatus(followerStatus('connected'));
+    expect(floatbar.hasAttribute('online')).toBe(true);
+    uninstall();
+    setFollowerTrayRuntimeStatus(followerStatus('error'));
+    // No longer subscribed — attribute stays as-is after uninstall.
+    expect(floatbar.hasAttribute('online')).toBe(true);
+  });
+});

--- a/packages/webapp/tests/ui/wc/wc-follower.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-follower.test.ts
@@ -115,6 +115,41 @@ describe('mountWcUiFollower', () => {
     expect(opts.browserAPI).toBeTruthy();
   });
 
+  it('drives the floatbar online dot from the follower tray status (#1707)', async () => {
+    // Integration guard: the slicc-floatbar `online` API existed with NO
+    // producer — the dot never lit while connected. Assert the mount installs
+    // one, end to end through the runtime-status subscription.
+    const { setFollowerTrayRuntimeStatus } = await import(
+      '../../../src/scoops/tray-follower-status.js'
+    );
+    const inactive = {
+      state: 'inactive' as const,
+      joinUrl: null,
+      trayId: null,
+      error: null,
+      lastPingTime: null,
+      reconnectAttempts: 0,
+      attachAttempts: 0,
+      lastAttachCode: null,
+      connectingSince: null,
+      lastError: null,
+    };
+    setFollowerTrayRuntimeStatus(inactive);
+    const { mountWcUiFollower } = await import('../../../src/ui/wc/wc-follower.js');
+    const app = document.getElementById('app')!;
+    await mountWcUiFollower(app, { stage: () => {} } as never, 'follower');
+
+    const floatbar = app.querySelector('slicc-floatbar') as HTMLElement;
+    expect(floatbar).toBeTruthy();
+    expect(floatbar.hasAttribute('online')).toBe(false);
+
+    setFollowerTrayRuntimeStatus({ ...inactive, state: 'connected' });
+    expect(floatbar.hasAttribute('online')).toBe(true);
+
+    setFollowerTrayRuntimeStatus({ ...inactive, state: 'error', error: 'Data channel closed' });
+    expect(floatbar.hasAttribute('online')).toBe(false);
+  });
+
   // Must run BEFORE the "Disconnect from leader" test below: that test's
   // switch-out mutates window location/localStorage so a later non-cherry
   // mount can't resolve its join URL (it falls back to mountWcUiLive).


### PR DESCRIPTION
Fixes #1707 (both halves, as scoped in the issue: "both are the follower UI misreporting link state").

## 1. Transient drop no longer renders as a permanent transcript error

`FollowerSyncManager.handleDisconnect` synthesized an agent `error` event ("Connection to leader lost: …"). Because the sync manager doubles as the chat panel's `AgentHandle`, that event rendered a permanent `<slicc-error-card>` in the conversation (with a "Try again" affordance nobody needs — `startFollowerWithAutoReconnect` heals the drop on its own) and fired `trackError('error-card')` into RUM for every self-healing blip.

Now:
- The disconnect updates the follower runtime status and notifies the mount, which owns presentation (`onConnectionChange` → "Connecting to leader…" composer state; `onGaveUp` → terminal "Couldn't reach the leader" state). No transcript card, no RUM error for a transient.
- Leader-**sent** error events (genuine agent errors) still forward and still render cards.
- The disconnect log moves `warn` → `error`, so a real transport drop finally leaves a console trace at the prod log level (`ERROR`) — the issue's secondary finding that the drop was invisible to telemetry. An *expected* stall stays `warn` per #1698's explicit guidance.

## 2. `slicc-floatbar`'s `online` attribute gets its missing producer

New `wc-floatbar-online.ts` — the single source of truth the issue asked for — drives the attribute from the tray runtime statuses:

- lit while this float is **leading** a tray (reachable by followers) or **following** one (connected to a leader);
- a purely local float shows no dot (nothing is linked to it);
- a leader **stall** keeps the dot lit — a stalled follower is still `connected` (the channel is open and recovers on its own).

Installed at both mounts: `wc-tray.ts` (kernel float, covers both roles) and `wc-follower.ts` (the no-kernel `/join/…` follower). In each float the inactive role's status stays `inactive`, so one OR across both statuses is correct everywhere.

## Tests

- `wc-floatbar-online.test.ts` (6): seeding, connect/error/reconnect transitions (the exact regression), stall keeps the dot, leader role, either-role OR, uninstall.
- `wc-follower.test.ts`: mount-level integration test proving the follower mount actually installs the producer — the original bug was precisely an integration gap (component API and app both fine, never connected). Mutation-verified: commenting out the install fails this test.
- `tray-follower-sync.test.ts`: disconnect suite updated to the new contract (status updated, `onDisconnect` fired, **no** agent error event); the existing leader-sent-error forwarding test still passes unchanged.

## Verification

lint 7/7 · check-touched-exemptions · typecheck · full test suite (12,692) · webapp coverage gate · both builds.
