### PR TITLE
Add slicc-cli launch/error telemetry via go-optel; fix RUM doc drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       swift-optel: ${{ steps.filter.outputs.swift-optel }}
       swift-launcher: ${{ steps.filter.outputs.swift-launcher }}
       ios-app: ${{ steps.filter.outputs.ios-app }}
+      go-optel: ${{ steps.filter.outputs.go-optel }}
       slicc-cli: ${{ steps.filter.outputs.slicc-cli }}
       swift-config: ${{ steps.filter.outputs.swift-config }}
       root-config: ${{ steps.filter.outputs.root-config }}
@@ -83,11 +84,17 @@ jobs:
               - 'packages/swift-launcher/**'
             ios-app:
               - 'packages/ios-app/**'
+            go-optel:
+              - 'packages/go-optel/**'
             slicc-cli:
               - 'packages/slicc-cli/**'
               # The Go corpus test decodes the shared golden fixture; a protocol
               # change regenerates it, so run the Go job when it moves too.
               - 'packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json'
+              # slicc-cli depends on go-optel via a local `replace` directive
+              # (no go.work in this monorepo), so a go-optel-only change must
+              # still run slicc-cli's suite.
+              - 'packages/go-optel/**'
             swift-config:
               - '.swiftlint.yml'
               - '.swift-format'
@@ -806,6 +813,30 @@ jobs:
       - name: Build
         run: npm run build -w @slicc/cloud-core
 
+  go-optel:
+    needs: changes
+    if: >-
+      needs.changes.outputs.go-optel == 'true' ||
+      needs.changes.outputs.root-config == 'true'
+    # Pure stdlib string/JSON logic with no OS-specific paths, unlike
+    # slicc-cli's process-group signalling — one Linux job covers it.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: packages/go-optel/go.mod
+          # No go.sum: the module has zero third-party dependencies.
+          cache: false
+      - name: Install golangci-lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh \
+            | sh -s -- -b "$(go env GOPATH)/bin" v2.12.2
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Format, lint, vet, race tests, coverage floor
+        working-directory: packages/go-optel
+        run: make check
+
   slicc-cli:
     needs: changes
     if: >-
@@ -1375,6 +1406,7 @@ jobs:
         swift-server,
         swift-optel,
         ios-app,
+        go-optel,
         slicc-cli,
         release-gate,
       ]

--- a/docs/operational-telemetry.md
+++ b/docs/operational-telemetry.md
@@ -13,9 +13,11 @@ SLICC runs across three deployment modes (CLI, extension, Electron) and emits RU
 - Are voice input and skill installation gaining adoption?
 - What are the Core Web Vitals for the UI? (CLI/Electron only — the extension doesn't get CWV.)
 
-RUM covers only the applications that load the webapp. For the tray hub worker,
-swift-server, the iOS follower, and the Go CLI — none of which emit beacons — see
-"Deploy-Impact Signals by Application" at the end of this document.
+RUM covers the applications that load the webapp, plus `slicc-cli`, which emits a
+much narrower launch/error-only beacon via its own Go client (`packages/go-optel`)
+rather than `telemetry.ts` — see "CLI Telemetry" below. The tray hub worker,
+swift-server, and the iOS follower emit no beacons at all; see "Deploy-Impact
+Signals by Application" at the end of this document.
 
 ### Why this approach
 
@@ -112,6 +114,11 @@ SLICC uses helix-rum-js's supported checkpoint types with SLICC-specific semanti
 | `viewmedia`    | Image rendered     | context (`'chat'`)                        | (omitted)                           | `chat-panel.ts` — `MutationObserver` on `messagesEl`                                                                                                           |
 | `error`        | JS error / failure | error type (`'js'` for the auto listener) | sanitized error message (extension) | `telemetry.ts:initTelemetry()` (extension) / helix listeners (CLI/Electron)                                                                                    |
 | `signup`       | Settings opened    | trigger (`'button'`)                      | (omitted)                           | `provider-settings.ts:showProviderSettings()`                                                                                                                  |
+| `enter`        | Scoop spawned      | scoop folder name                         | `'scoop-spawn'`                     | `scoop-telemetry-hook.ts:emitScoopLifecycle('spawn', ...)` → `telemetry.ts:trackScoopLifecycle()`, called from `scoop-lifecycle-manager.ts`                    |
+| `convert`      | Cone fed a scoop   | scoop folder name                         | `'scoop-feed'`                      | `emitScoopLifecycle('feed', ...)`, called from `scoop-message-router.ts`                                                                                       |
+| `leave`        | Scoop completed    | scoop folder name                         | `'scoop-complete'`                  | `emitScoopLifecycle('complete', ...)`, called from `scoop-completion-service.ts`                                                                               |
+
+A scoop failure reuses the `error` checkpoint row above rather than getting its own row: `trackScoopLifecycle()` sets `source: 'scoop:<name>'` (not the bare scoop name used by `enter`/`convert`/`leave`) and runs the message through the same `sanitizeError` used for `trackError`, dropping known user-fixable error families (no-api-key, invalid-model, auth-expired) before emitting.
 
 ### Auto-instrumented (from enhancer, CLI/Electron only)
 
@@ -124,6 +131,7 @@ These work out of the box in CLI/Electron with no custom code. They do NOT fire 
 
 - `navigate`, `formsubmit`, `fill`, `viewblock` — wired in both CLI/Electron and extension.
 - `signup`, `viewmedia` — newly wired; fire in both modes.
+- `enter` (scoop spawn) / `convert` (scoop feed) / `leave` (scoop complete) — wired since 2026-06-14 (issue #795 Gap 3 follow-up) via `scoop-telemetry-hook.ts`. Fires in both modes: the hook lives in the worker-safe scoops layer and only needs a sink registered, which `initTelemetry()` does identically for CLI/Electron and extension. Turn-end and per-tool-call-duration checkpoints remain unwired — see "Not instrumented in this iteration" below.
 - `error` — fires in both modes, but the **automatic capture path** differs:
   - CLI/Electron: helix-rum-js installs its own `window.error` and `unhandledrejection` listeners and emits its native payload shape.
   - Extension: `telemetry.ts` registers SLICC's listeners after assigning `sampleRUM` from `rum.js`, emitting `{source: 'js', target: sanitizedMessage}`. Sanitization collapses VFS paths to `/<root>/.../` and truncates to 200 characters.
@@ -146,7 +154,7 @@ Historical note: prior to the thin-bridge release the extension had two independ
 ### Not instrumented in this iteration
 
 - The extension service worker (`packages/chrome-extension/src/service-worker.ts`). CDP attach/detach, OAuth completion, navigate-licks, tray-socket lifecycle.
-- Custom agent-loop events from the kernel worker — turn end, tool-call durations, explicit scoop create/delegate/drop. The worker's `AlmostBashShellHeadless` now emits `fill` beacons for every bash call (so the cone-side `agent ...` invocations and `feed_scoop` tool calls show up indirectly), but there are no dedicated `agent-spawn` or `scoop-delegate` checkpoints yet.
+- Turn-end and per-tool-call-duration events from the kernel worker. Scoop lifecycle itself (spawn/feed/complete/error) **is** wired — see `enter`/`convert`/`leave` in the checkpoint mapping above, shipped 2026-06-14 via `scoop-telemetry-hook.ts` — but there is no checkpoint yet for a turn finishing or for how long an individual tool call took. The worker's `AlmostBashShellHeadless` emits `fill` beacons for every bash call, so `feed_scoop` tool calls also show up indirectly through that channel.
 - Core Web Vitals and other enhancer-derived checkpoints in the extension. See "Extension Enhancer Parity Decision" above for the full rationale; the short version is that CSP makes the auto-loaded enhancer impossible, manual `web-vitals` integration is low-signal for a chat-app shell, and the highest-value piece (`error`) is already wired separately.
 
 ## Sampling Strategy
@@ -175,6 +183,32 @@ The implementations are privacy-safe by design (no cookies, no PII, ephemeral pa
 4. **No PII in scoop names**: scoop names are system-generated (e.g. `researcher`, `coder`) or short user-typed labels. They flow through unredacted; if user-typed scoop names ever grow into freeform input, add an explicit sanitizer.
 5. **Model IDs only**: model id strings like `claude-sonnet-4` flow through; base URLs and OAuth account details do not.
 6. **Opt-out**: `localStorage.setItem('telemetry-disabled', 'true')` disables init entirely. `isTelemetryEnabled()` and `setTelemetryEnabled(boolean)` are exported helpers from `telemetry.ts` for wiring this into a settings UI (the UI control itself is future work).
+
+## CLI Telemetry (`slicc-cli`)
+
+`slicc-cli` is a headless Go binary — no `window`, no `localStorage`, no `@adobe/helix-rum-js` — so it does not use `telemetry.ts` at all. It has its own dependency-free Go client, `packages/go-optel` (`github.com/ai-ecoverse/go-optel`), pulled in by `packages/slicc-cli/go.mod` via a local `replace` directive (this monorepo has no `go.work`, so cross-module deps within `packages/` are wired that way). `packages/go-optel` implements the same helix-rum-js wire format as `telemetry.ts` and `packages/swift-optel`, so beacons land in the same collector and JSON shape, just from a third independent client.
+
+### Why this is much narrower than the webapp or swift-optel
+
+A CLI has no UI to click on or navigate, so there is no `click`/`navigate`/CWV equivalent. The intended surface is deliberately two checkpoints only:
+
+- `enter` — process launch. Fires once per invocation from `packages/slicc-cli/telemetry.go:initTelemetry()`, wired into every real subcommand dispatch in `main.go` (`prompt`, `exec`, `watch`, `follow`, `update`). `source` is the subcommand name, allowlisted by `classifySubcommand()` — anything outside the fixed vocabulary (e.g. a typo) is folded into `"unknown"` rather than echoed verbatim.
+- `error` — an operational failure (leader dial failure, self-update failure), always via `reportRuntimeError(source, err)` → `optel.Client.ReportError`, never a raw `Sample(Error, ...)` call. `source` is one of a small fixed set (`dial`, `watch`, `follow`, `update`) — never user-typed input.
+
+`referer` is `https://slicc-cli/` (go-optel's `BuildReferer`, mirroring swift-optel's use of a fixed app id in place of a real hostname) — filter dashboards on that host the way webapp dashboards filter on `RUM_GENERATION`.
+
+### Privacy / security: why sanitization is mandatory here
+
+A browser's `error.message` is mostly harmless; a CLI's is not. Go's `net/http`/`net/url` errors embed the full request URL in `Error()` — and `slicc-cli` dials a leader's `https://…/join/<token>` URL, so a raw dial-error string is a bearer-token leak, not just a privacy nit. OS file errors likewise embed the user's home directory (usually containing their login name). `packages/go-optel/sanitize.go`'s `Sanitize()` is the only path from an `error.Error()` string to a beacon field, and `ReportError` is the only sanctioned caller: it collapses any absolute URL to `scheme://host/...` and any absolute path to its first segment/drive letter, **before** truncating to 200 characters, so a leaked fragment can't survive truncation ordering. Application code in `slicc-cli` must always call `reportRuntimeError(...)`, never wire `err.Error()` into a beacon field directly.
+
+### Opt-out, gating, sampling
+
+- **Opt-out**: `SLICC_NO_TELEMETRY=1` disables telemetry outright — no client is configured, no beacon fires.
+- **Release-build gating**: telemetry only configures on stamped release builds (`update.IsReleaseVersion(version)`, the same gate the update notifier uses). A `dev` / git-describe local build never phones home, so local development is silent without needing the opt-out env var at all.
+- **Sampling**: one coin flip per process (weight 100, i.e. selected by default), decided once inside `optel.Configure()` and reused for every checkpoint in that launch — matching how the webapp/swift-optel decide once per pageview/session rather than per event. `OPTEL_RATE`/`OPTEL_DEBUG` env vars are honored with the same names and semantics as swift-optel.
+- **Flush**: `initTelemetry()` returns a bounded flush closure (`defer initTelemetry(sub)()` in `main.go`) that waits up to 2 seconds for in-flight beacon goroutines before the process exits — Go has no `navigator.sendBeacon` guarantee that a fire-and-forget goroutine survives past `main()` returning.
+
+See `packages/go-optel/README.md` and `packages/go-optel/CLAUDE.md` for the library itself, and `packages/slicc-cli/telemetry.go` for the wiring.
 
 ## Self-Hosting Option (future work)
 
@@ -231,6 +265,8 @@ Telemetry tests live in `packages/webapp/tests/ui/`:
 | `chat-panel-telemetry.test.ts`        | `ChatPanel.sendMessage()` fires `trackChatSend` with the right scoop name and model id; the MutationObserver fires `trackImageView('chat')` per `<img>` attached to the chat tree.                                                            |
 | `provider-settings-telemetry.test.ts` | `showProviderSettings()` fires `trackSettingsOpen('button')` on dialog open.                                                                                                                                                                  |
 
+`slicc-cli`'s beacons are not covered by the table above — they go through `packages/go-optel` (its own Go module, tested by `go test ./...` there: sanitization, sampling, session/env/transport behavior) and `packages/slicc-cli/telemetry_test.go` (subcommand classification, opt-out/release-gating logic, nil-safety, hermetic client configuration — no real network call in any case).
+
 The dispatcher's two branches are tested via separate `describe` blocks — the CLI-branch tests run in default Vitest setup (no `chrome` global, helix mocked at file level), and the extension-branch tests stub `globalThis.chrome` and use `vi.doMock('./rum.js', ...)` after `vi.resetModules()` to override per test.
 
 ### Dashboard verification
@@ -250,16 +286,16 @@ dashboard" is the wrong answer for those. This section is the post-ship lookup t
 the question that actually gets asked: **I just shipped — where do I look to see if it
 broke?**
 
-| Application         | Primary deploy-impact signal                                                             | Ours or Apple/Cloudflare-hosted | Latency to signal   |
-| ------------------- | ---------------------------------------------------------------------------------------- | ------------------------------- | ------------------- |
-| `webapp`            | RUM (`RUM_GENERATION=slicc-cli` / `slicc-electron`), see "Dashboard verification"        | ours (Helix RUM)                | minutes (sampled)   |
-| `node-server`       | RUM (CLI generation) + `GET /api/status` on the local port                               | ours                            | immediate / minutes |
-| `chrome-extension`  | RUM (`RUM_GENERATION=slicc-extension`), no enhancer checkpoints                          | ours (Helix RUM)                | minutes (sampled)   |
-| `swift-launcher`    | RUM via `@slicc/swift-optel` (`packages/swift-optel/`)                                   | ours (Helix RUM)                | minutes (sampled)   |
-| `cloudflare-worker` | `GET /status`, Cloudflare Workers metrics, `cloudflare-spend` issue tripwire             | Cloudflare + ours               | immediate / 1 day   |
-| `swift-server`      | `GET /api/status` + `~/.slicc/logs/slicc-<day>.log`                                      | local only, never leaves host   | immediate           |
-| `ios-app`           | App Store Connect TestFlight processing state, then TestFlight Crashes & Feedback        | Apple-hosted                    | minutes / days      |
-| `slicc-cli`         | **No telemetry.** Nearest: GitHub Release download counts + worker install-route traffic | GitHub + Cloudflare             | days                |
+| Application         | Primary deploy-impact signal                                                                            | Ours or Apple/Cloudflare-hosted | Latency to signal                      |
+| ------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------- | -------------------------------------- |
+| `webapp`            | RUM (`RUM_GENERATION=slicc-cli` / `slicc-electron`), see "Dashboard verification"                       | ours (Helix RUM)                | minutes (sampled)                      |
+| `node-server`       | RUM (CLI generation) + `GET /api/status` on the local port                                              | ours                            | immediate / minutes                    |
+| `chrome-extension`  | RUM (`RUM_GENERATION=slicc-extension`), no enhancer checkpoints                                         | ours (Helix RUM)                | minutes (sampled)                      |
+| `swift-launcher`    | RUM via `@slicc/swift-optel` (`packages/swift-optel/`)                                                  | ours (Helix RUM)                | minutes (sampled)                      |
+| `cloudflare-worker` | `GET /status`, Cloudflare Workers metrics, `cloudflare-spend` issue tripwire                            | Cloudflare + ours               | immediate / 1 day                      |
+| `swift-server`      | `GET /api/status` + `~/.slicc/logs/slicc-<day>.log`                                                     | local only, never leaves host   | immediate                              |
+| `ios-app`           | App Store Connect TestFlight processing state, then TestFlight Crashes & Feedback                       | Apple-hosted                    | minutes / days                         |
+| `slicc-cli`         | RUM via `@ai-ecoverse/go-optel` (`packages/go-optel/`) — launch + error only, see "CLI Telemetry" above | ours (Helix RUM)                | minutes (sampled), release builds only |
 
 The four rows below the fold are the ones with no dashboard pointer anywhere else in the
 docs. Each gets its own subsection. Where an application genuinely has no signal, that is
@@ -391,44 +427,43 @@ is committed to.
 
 ### `slicc-cli`
 
-**There is no telemetry, by construction.** The Go follower CLI emits no beacons, no
-analytics, and no crash reports. That is the honest answer, and it should stay the answer
-unless someone deliberately decides otherwise — a headless CLI that phones home is a
-different product.
+**Launch + error telemetry only, opt-out, release builds only.** Since the `go-optel`
+client landed (see "CLI Telemetry" above), `slicc-cli` emits an `enter` beacon per launch
+and an `error` beacon on a dial/watch/follow/update failure. That is deliberately much
+narrower than the webapp: no chat content, no command text, no scoop names — a CLI
+touching a leader's bearer-token join URL and the local filesystem has a much sharper
+privacy/security overlap than a browser tab, so the checkpoint set stays minimal by
+design (see `packages/go-optel/CLAUDE.md`). Dev/git-describe builds never phone home, and
+`SLICC_NO_TELEMETRY=1` opts out of a release build too.
 
-What that leaves, in descending order of usefulness:
+What that still leaves uncovered, in descending order of usefulness:
 
-1. **GitHub Release asset download counts** for `slicc-<os>-<arch>[.exe]`. The only
-   adoption number available. Note that CLI releases are **sparse** — binaries attach only
-   to releases where `packages/slicc-cli` actually changed — so compare against the release
-   that carries assets, not `releases/latest`.
-2. **Worker traffic on the install and download routes.** `GET /install-cli`,
+1. **The once-a-day background update notice** (`startUpdateNotice()`, cached at
+   `<user-cache-dir>/slicc/update-check.json`, suppressed by `SLICC_NO_UPDATE_CHECK=1`) is
+   a best-effort banner check and swallows its own errors silently — it is not wired to
+   `reportRuntimeError`. Only the explicit `slicc update` subcommand's fetch/apply
+   failures are reported.
+2. **GitHub Release asset download counts** for `slicc-<os>-<arch>[.exe]` remain the only
+   adoption number independent of telemetry sampling. CLI releases are **sparse** —
+   binaries attach only to releases where `packages/slicc-cli` actually changed — so
+   compare against the release that carries assets, not `releases/latest`.
+3. **Worker traffic on the install and download routes.** `GET /install-cli`,
    `GET /install-cli.ps1`, and `GET /download/slicc-cli/:target`
    (`packages/cloudflare-worker/src/install-cli.ts`) all run through the tray hub, so their
-   request and status-code breakdown is visible in the worker's Cloudflare analytics. A
-   release that shipped a broken or missing asset shows up as 4xx/5xx on
-   `/download/slicc-cli/*` — this is the closest thing to a release-health check the CLI
-   has, and it costs nothing because the traffic already lands on infrastructure we
-   observe.
-3. **Nothing from self-update failures.** `packages/slicc-cli/internal/update/` runs the
-   staged binary's `--version` as a sanity gate before the atomic rename, so a corrupt
-   download fails closed and prints on the user's machine. Correct behaviour, zero
-   visibility to us. Same for the once-a-day update notice cached at
-   `<user-cache-dir>/slicc/update-check.json` and suppressed by `SLICC_NO_UPDATE_CHECK=1`.
-4. **Issue reports.** The actual feedback channel.
-
-If CLI release health ever needs to be monitored for real, the cheapest closer is an alert
-on the worker's `/download/slicc-cli/*` error rate — it needs no change to the binary and
-no new telemetry surface. Everything else requires deciding that the CLI may talk to us.
+   request and status-code breakdown is visible in the worker's Cloudflare analytics —
+   still the fastest signal for a broken release asset, independent of whether any given
+   launch happened to sample.
+4. **Issue reports.** The actual feedback channel for anything telemetry doesn't capture
+   (UX complaints, feature requests, silent hangs with no error).
 
 ### Summary of honest gaps
 
-| Application         | Gap                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------- |
-| `cloudflare-worker` | No retained logs (`observability` unset in `wrangler.jsonc`); no per-route error alarm  |
-| `swift-server`      | Logs are local-only; no crash reporter; no remote signal of any kind                    |
-| `ios-app`           | No in-app telemetry or crash SDK; only Apple-hosted crash reports from opted-in testers |
-| `slicc-cli`         | No telemetry at all; release health is inferred from worker download-route traffic      |
+| Application         | Gap                                                                                                                              |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `cloudflare-worker` | No retained logs (`observability` unset in `wrangler.jsonc`); no per-route error alarm                                           |
+| `swift-server`      | Logs are local-only; no crash reporter; no remote signal of any kind                                                             |
+| `ios-app`           | No in-app telemetry or crash SDK; only Apple-hosted crash reports from opted-in testers                                          |
+| `slicc-cli`         | Only `enter`/`error` beacons (sampled, release builds only); the background update-notice check swallows its own errors silently |
 
 Do not add a dashboard link to this table that does not exist. An accurate "no signal
 today, nearest proxy is X" is more useful than a plausible-looking URL that nobody can

--- a/packages/dev-tools/tools/release-native.mjs
+++ b/packages/dev-tools/tools/release-native.mjs
@@ -27,9 +27,13 @@ export const MACOS_PATH_PREFIXES = [
 export const IOS_PATH_PREFIXES = ['packages/ios-app/'];
 
 // APPROVED relevant path set for the `slicc` Go CLI binaries. The CLI vendors
-// its own copy of the wire protocol (internal/protocol), so only its own package
-// changes the built binary — no cross-package inputs.
-export const SLICC_CLI_PATH_PREFIXES = ['packages/slicc-cli/'];
+// its own copy of the wire protocol (internal/protocol), so that part of the
+// built binary has no cross-package inputs — but packages/go-optel/ is a real
+// build dependency (pulled in via a local `replace` in slicc-cli's go.mod;
+// this monorepo has no go.work), so a go-optel-only change must still gate a
+// release, or a go-optel fix would ship silently until an unrelated
+// slicc-cli file next changed.
+export const SLICC_CLI_PATH_PREFIXES = ['packages/slicc-cli/', 'packages/go-optel/'];
 
 // APPROVED extension-relevant path set for the Chrome Web Store publish. Covers
 // the extension entry points plus every web package bundled into the extension

--- a/packages/dev-tools/tools/release-native.test.mjs
+++ b/packages/dev-tools/tools/release-native.test.mjs
@@ -312,12 +312,24 @@ describe('decideSliccCliGating', () => {
     ).toEqual({ sliccCli: true, firstRelease: false });
   });
 
+  it('builds when only its go-optel dependency changed', () => {
+    expect(
+      decideSliccCliGating({
+        lastTag: 'v1.0.0',
+        // go-optel is a real build dependency (local `replace` in
+        // slicc-cli/go.mod), unlike the vendored internal/protocol copy below.
+        changedFiles: ['packages/go-optel/sanitize.go'],
+      })
+    ).toEqual({ sliccCli: true, firstRelease: false });
+  });
+
   it('skips when only unrelated packages changed', () => {
     expect(
       decideSliccCliGating({
         lastTag: 'v1.0.0',
         // A shared-ts protocol change does NOT rebuild the CLI (it vendors its
-        // own internal/protocol copy) — only packages/slicc-cli/ counts.
+        // own internal/protocol copy) — only packages/slicc-cli/ and
+        // packages/go-optel/ count.
         changedFiles: ['packages/shared-ts/src/tray-sync-protocol.ts', 'packages/webapp/x.ts'],
       })
     ).toEqual({ sliccCli: false, firstRelease: false });

--- a/packages/go-optel/.gitignore
+++ b/packages/go-optel/.gitignore
@@ -1,0 +1,2 @@
+# Coverage profile from `make cover`
+cover.out

--- a/packages/go-optel/.golangci.yml
+++ b/packages/go-optel/.golangci.yml
@@ -1,0 +1,36 @@
+# golangci-lint config for packages/go-optel (v2 schema), mirroring
+# packages/slicc-cli/.golangci.yml so the two Go modules share one lint bar.
+version: '2'
+
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - funlen
+    - gocyclo
+    - gocognit
+    - misspell
+    - revive
+    - unconvert
+    - unparam
+  settings:
+    funlen:
+      lines: 120
+      statements: 70
+    gocyclo:
+      min-complexity: 25
+    gocognit:
+      min-complexity: 30
+  exclusions:
+    rules:
+      # Test functions are allowed to be longer / more branchy than production.
+      - path: _test\.go
+        linters:
+          - funlen
+          - gocyclo
+          - gocognit
+
+formatters:
+  enable:
+    - gofmt

--- a/packages/go-optel/AGENTS.md
+++ b/packages/go-optel/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/go-optel/CLAUDE.md
+++ b/packages/go-optel/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+This file covers the Go Operational Telemetry / RUM client in `packages/go-optel/`.
+
+## Scope
+
+`packages/go-optel/` is a dependency-free Go module (`github.com/ai-ecoverse/go-optel`, package `optel`) implementing Adobe's `helix-rum-js` beacon wire format for headless Go binaries. It is the Go analogue of `packages/swift-optel/` — same JSON shape, same `OPTEL_RATE`/`OPTEL_DEBUG` environment variables — but deliberately exposes a much smaller surface: no UI, so no `click`/`navigate`/CWV instrumentation. Consumed today by `packages/slicc-cli/` via a local `replace` directive (this is a monorepo without a Go workspace file; each Go module has its own `go.mod`).
+
+## Build and Test Commands
+
+```bash
+cd packages/go-optel
+go test ./...
+make check   # gofmt + tidy-check + go vet + golangci-lint + race tests + coverage floor
+```
+
+No third-party dependencies — stdlib only (`net/http`, `math/rand/v2`, `regexp`, `crypto/rand`).
+
+## Intended Surface: Launch + Error Only
+
+Unlike swift-optel's `.optelAutoInstrument` (which wires four checkpoints — `enter`, `click`, `navigate`, `error`), go-optel's design intent is two checkpoints:
+
+- `Enter` on process launch (`Client.Sample(optel.Enter, subcommand, "")`).
+- `Error` on a fatal/operational failure, always via `Client.ReportError(source, err)` — never `Sample(Error, ...)` with a raw `err.Error()`.
+
+The `Checkpoint` type is a plain string (not a closed enum) so the wire format matches the webapp/Swift implementations exactly, but reaching for `Click`/`Navigate`/`CWV` in a CLI context is a smell — there is no UI to click on.
+
+## Privacy Is a Security Boundary Here, Not Just a Nicety
+
+This library exists because a naive CLI telemetry hookup would leak
+credentials, not just PII:
+
+- **Go's `net/http` / `net/url` errors embed the full request URL** —
+  including any bearer token in the path or query — in their `Error()`
+  string. `slicc-cli` dials a leader's `https://…/join/<token>` URL; a raw
+  dial-error string is a token leak.
+- **OS-level file errors embed the user's home directory**, which on most
+  platforms contains their login name.
+
+`sanitize.go`'s `Sanitize(msg string) string` is the only sanctioned path
+from an `error.Error()` string to a beacon field, and `Client.ReportError`
+is the only sanctioned caller of it — never wire a raw error message into
+`Sample` directly. Redaction order matters and is enforced in code, not just
+by convention: URLs are reduced to `scheme://host/...` (the entire
+path/query — where a token lives — is dropped, not partially truncated) and
+absolute paths are collapsed to their first segment/drive letter, **before**
+the 200-character truncation runs. Redacting after truncating would risk
+leaving a partial (still-sensitive) fragment on the wire.
+
+## Sampling Is Per-Process, Not Per-Event
+
+`Configure` resolves exactly one sampling decision (`Session.Selected`) via
+one coin flip, cached for the lifetime of the `*Client`. This mirrors how
+the webapp/swift-optel decide once per pageview/session rather than per
+beacon — a launch is the CLI's equivalent of a "pageview". Do not call
+`Configure` more than once per process to try to get a fresh decision per
+command; one `slicc` invocation is one launch.
+
+## Flush Is Not Optional
+
+Go has no `navigator.sendBeacon` guarantee that a fire-and-forget goroutine
+outlives the calling function. `HTTPTransport.Send` posts on its own
+goroutine and immediately returns so `Client.Sample`/`ReportError` never
+block the CLI's user-facing streaming output — but the process **will**
+exit and kill in-flight goroutines if nothing waits for them.
+`Client.Flush(timeout)` blocks on an internal `sync.WaitGroup` bounded by
+`timeout`; call it (deferred, with a short bound like 2s) once near process
+exit. Skipping this makes every beacon a coin flip against process exit
+timing.
+
+## Related Guides
+
+- `packages/swift-optel/CLAUDE.md` — the Swift analogue (iOS/macOS)
+- `packages/slicc-cli/CLAUDE.md` — the only current consumer
+- `docs/operational-telemetry.md` — cross-float RUM design and checkpoint mapping

--- a/packages/go-optel/Makefile
+++ b/packages/go-optel/Makefile
@@ -1,0 +1,57 @@
+# go-optel — dependency-free Go RUM client (helix-rum-js wire format)
+#
+# `make test`       go test ./...
+# `make check`       gofmt check + go mod tidy check + go vet + golangci-lint + race tests + coverage floor
+# `make tidy-check`  fail when go.mod/go.sum drift from the tree's imports
+
+# Total-statement coverage floor (raise as coverage improves; keep in sync with CLAUDE.md).
+COVER_MIN ?= 80
+
+.PHONY: test check fmt vet lint tidy-check cover
+
+test:
+	go test ./...
+
+vet:
+	go vet ./...
+
+lint:
+	golangci-lint run
+
+fmt:
+	gofmt -w .
+
+# Unused/missing-dependency gate: fails when go.mod or go.sum drifts from the
+# imports actually in the tree. `go mod tidy -diff` needs Go >= 1.23; older
+# toolchains fall back to tidying a copy and diffing it back.
+tidy-check:
+	@if go help mod tidy 2>/dev/null | grep -q -- '-diff'; then \
+		go mod tidy -diff || { echo "go.mod/go.sum are not tidy — run 'go mod tidy'"; exit 1; }; \
+	else \
+		cp go.mod go.mod.tidybak; \
+		[ -f go.sum ] && cp go.sum go.sum.tidybak || true; \
+		go mod tidy; \
+		status=0; \
+		diff -u go.mod.tidybak go.mod || status=1; \
+		mv go.mod.tidybak go.mod; \
+		if [ -f go.sum.tidybak ]; then diff -u go.sum.tidybak go.sum || status=1; mv go.sum.tidybak go.sum; fi; \
+		if [ $$status -ne 0 ]; then echo "go.mod/go.sum are not tidy — run 'go mod tidy'"; exit 1; fi; \
+	fi
+
+# Race-checked tests + total-coverage floor.
+cover:
+	go test -race -coverprofile=cover.out ./...
+	@total=$$(go tool cover -func=cover.out | awk '/^total:/ {print $$3}' | tr -d '%'); \
+	echo "total coverage: $$total% (floor $(COVER_MIN)%)"; \
+	awk -v t="$$total" -v m="$(COVER_MIN)" 'BEGIN { if (t+0 < m+0) { printf "FAIL: coverage %.1f%% is below the %d%% floor\n", t, m; exit 1 } }'
+
+# CI gate: gofmt clean, tidy go.mod, go vet, golangci-lint, race tests + coverage floor.
+check:
+	@unformatted="$$(gofmt -l .)"; \
+	if [ -n "$$unformatted" ]; then \
+		echo "gofmt needs to run on:"; echo "$$unformatted"; exit 1; \
+	fi
+	$(MAKE) tidy-check
+	go vet ./...
+	golangci-lint run
+	$(MAKE) cover

--- a/packages/go-optel/README.md
+++ b/packages/go-optel/README.md
@@ -1,0 +1,64 @@
+# go-optel
+
+Dependency-free Go client for Adobe's [`helix-rum-js`](https://github.com/adobe/helix-rum-js) wire format — the same Real User Monitoring (RUM) beacon protocol SLICC's webapp (`packages/webapp/src/ui/telemetry.ts`) and native Swift apps (`packages/swift-optel`) use. See [`docs/operational-telemetry.md`](../../docs/operational-telemetry.md) for the cross-float design.
+
+> OpTel = Operational Telemetry — Adobe's RUM-style operational telemetry; not to be confused with OpenTelemetry (OTel).
+
+## Why this is smaller than swift-optel
+
+swift-optel instruments a UI: clicks, view navigation, Core Web Vitals. A headless CLI has none of that, so go-optel's intended surface is deliberately narrow — **two checkpoints only**:
+
+- `Enter` — process launch.
+- `Error` — a fatal/operational failure, always via `ReportError` (never a raw error string).
+
+The `Checkpoint` type stays an open string (matching the other two implementations' wire format) so a future caller isn't blocked, but reaching for `Click`/`Navigate`/etc. in a CLI context is a smell.
+
+## Usage
+
+```go
+import optel "github.com/ai-ecoverse/go-optel"
+
+client := optel.Configure("slicc-cli", optel.Options{})
+defer client.Flush(2 * time.Second) // bounded wait for in-flight beacons before exit
+
+client.Sample(optel.Enter, "prompt", "") // source = subcommand name
+
+if err != nil {
+    client.ReportError("dial", err) // sanitized automatically
+}
+```
+
+## Privacy / security note
+
+Unlike a browser tab, a CLI's error strings routinely embed **credentials and PII** by construction:
+
+- Go's `net/http` / `net/url` errors embed the full request URL — including any bearer token in its path or query — in their `Error()` string.
+- OS-level file errors embed the user's home directory, which usually contains their login name.
+
+`ReportError` always runs the message through `Sanitize`, which redacts every absolute URL down to `scheme://host/...` (dropping the path/query where a token would live) and collapses absolute POSIX/Windows paths to their first segment/drive letter, **before** truncating to 200 characters — redaction never happens after truncation, which could otherwise leave a partial (still-sensitive) fragment on the wire. Never call `client.Sample(optel.Error, source, err.Error())` directly; always go through `ReportError`.
+
+## Sampling
+
+One coin flip per `Configure` call (i.e. per process launch), not per event — matching how the webapp/swift-optel decide once per pageview/session, not per beacon. `OPTEL_RATE` (`on`/`off`/`high`/`low`; default weight 100) and `OPTEL_DEBUG` (wire-level logging) environment variables are honored uniformly, same names as swift-optel's `OptelEnvConfig`.
+
+## Layout
+
+| File            | Purpose                                                           |
+| --------------- | ----------------------------------------------------------------- |
+| `client.go`     | `Client` / `Configure` / `Sample` / `ReportError` / `Flush`       |
+| `checkpoint.go` | `Checkpoint` wire-format enum                                     |
+| `event.go`      | `Event` — the JSON beacon payload                                 |
+| `session.go`    | 9-character session id generation                                 |
+| `sampling.go`   | `SamplingConfig` (weight) + `Session` (once-per-process decision) |
+| `transport.go`  | `HTTPTransport` — fire-and-forget POST, bounded by `Client.Flush` |
+| `sanitize.go`   | URL/path redaction + truncation (see Privacy above)               |
+| `referer.go`    | `referer` string construction (`https://{appID}{viewPath}`)       |
+| `env.go`        | `OPTEL_RATE` / `OPTEL_DEBUG` resolution                           |
+
+## Build and test
+
+```bash
+cd packages/go-optel
+go test ./...
+make check   # gofmt + tidy-check + go vet + golangci-lint + race tests + coverage floor
+```

--- a/packages/go-optel/checkpoint.go
+++ b/packages/go-optel/checkpoint.go
@@ -1,0 +1,25 @@
+package optel
+
+// Checkpoint is the on-the-wire checkpoint name for a RUM event. Values
+// mirror the helix-rum-js enumeration (and swift-optel's RUMCheckpoint); any
+// string is accepted so a caller can forward a future/unknown checkpoint
+// without a library update.
+type Checkpoint string
+
+// Supported checkpoints. go-optel callers are expected to use Enter and
+// Error only (see the package doc comment) but the full helix-rum-js set is
+// kept here so the type stays a drop-in match for the wire format shared
+// with swift-optel and the webapp's telemetry.ts.
+const (
+	Top         Checkpoint = "top"
+	Enter       Checkpoint = "enter"
+	Navigate    Checkpoint = "navigate"
+	Reload      Checkpoint = "reload"
+	CWV         Checkpoint = "cwv"
+	PagesViewed Checkpoint = "pagesviewed"
+	Click       Checkpoint = "click"
+	ViewBlock   Checkpoint = "viewblock"
+	ViewMedia   Checkpoint = "viewmedia"
+	FormSubmit  Checkpoint = "formsubmit"
+	Error       Checkpoint = "error"
+)

--- a/packages/go-optel/client.go
+++ b/packages/go-optel/client.go
@@ -1,0 +1,166 @@
+// Package optel is a minimal, dependency-free Go client for Adobe's
+// helix-rum-js wire protocol — the Real User Monitoring (RUM) beacon format
+// shared by SLICC's webapp (packages/webapp/src/ui/telemetry.ts) and its
+// native Swift counterpart (packages/swift-optel). See
+// docs/operational-telemetry.md for the cross-float design.
+//
+// go-optel intentionally exposes a much smaller surface than swift-optel:
+// headless CLI binaries have no UI to click on and no page to navigate, so
+// only two checkpoints make sense — Enter (process launch) and Error
+// (a fatal/operational failure). Callers should not reach for Click,
+// Navigate, or the other UI-shaped checkpoints; the Checkpoint type stays
+// open (a plain string) only so the wire format matches the other two
+// implementations exactly.
+//
+// Every Sample/ReportError call MUST pass caller-controlled, non-sensitive
+// values only. Use ReportError (which runs Sanitize internally) rather than
+// passing a raw error's message directly — see sanitize.go for why that
+// matters for a CLI that dials bearer-token URLs and runs on a user's
+// machine.
+package optel
+
+import (
+	"sync"
+	"time"
+)
+
+// Client is a configured go-optel instance. The zero value is not usable —
+// construct with Configure. A nil *Client is a valid, inert no-op for every
+// method, so callers never need to guard a disabled/not-configured client.
+type Client struct {
+	mu             sync.Mutex
+	appID          string
+	collectBaseURL string
+	transport      Transport
+	session        Session
+	sessionStart   time.Time
+	hasEmittedTop  bool
+	wg             sync.WaitGroup
+}
+
+// Options configures a Client. The zero value is the production default:
+// weight-100 sampling, https://rum.hlx.page/, HTTPTransport with logging
+// off.
+type Options struct {
+	// Rate selects the sampling weight (on/off/high/low; anything else,
+	// including "", falls back to the default weight of 100).
+	// OPTEL_RATE, when set in the environment, overrides this.
+	Rate string
+	// CollectBaseURL overrides DefaultCollectBaseURL.
+	CollectBaseURL string
+	// Transport overrides the default HTTPTransport (tests inject a mock).
+	Transport Transport
+	// RandomSource overrides the sampling coin flip's RNG (tests pin this
+	// for determinism).
+	RandomSource RandomSource
+	// Debug forces wire-level transport logging on/off, taking precedence
+	// over OPTEL_DEBUG when non-nil.
+	Debug *bool
+	// Environment overrides the process environment consulted for
+	// OPTEL_RATE / OPTEL_DEBUG. Tests only; production callers leave this
+	// nil to read the real environment.
+	Environment map[string]string
+}
+
+// Configure builds a new Client and resolves its once-per-process sampling
+// decision immediately. appID becomes the beacon `referer` hostname (see
+// BuildReferer) — pass a stable, non-identifying label such as "slicc-cli",
+// never a user- or machine-specific value.
+func Configure(appID string, opts Options) *Client {
+	rate := ResolveRate(opts.Rate, opts.Environment)
+	debug := ResolveDebug(opts.Environment)
+	if opts.Debug != nil {
+		debug = *opts.Debug
+	}
+	collectBaseURL := opts.CollectBaseURL
+	if collectBaseURL == "" {
+		collectBaseURL = DefaultCollectBaseURL
+	}
+	transport := opts.Transport
+	if transport == nil {
+		transport = NewHTTPTransport(debug)
+	}
+	config := NewSamplingConfig(rate)
+	session := NewSession(GenerateSessionID(), config, opts.RandomSource)
+
+	return &Client{
+		appID:          appID,
+		collectBaseURL: collectBaseURL,
+		transport:      transport,
+		session:        session,
+		sessionStart:   time.Now(),
+	}
+}
+
+// Sample records a checkpoint. Mirrors `sampleRUM(checkpoint, { source,
+// target })`. The first call after Configure auto-emits a `top` beacon
+// with t=0 first (matching helix-rum-js / swift-optel), unless the
+// caller's own checkpoint IS Top, in which case the two fold into a single
+// beacon. Nil-safe; an unselected session is a no-op (nothing is queued —
+// unlike the browser/Swift collectors, a short-lived CLI process has no
+// "attach session later" phase to buffer for).
+func (c *Client) Sample(checkpoint Checkpoint, source, target string) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.session.Selected {
+		return
+	}
+	isFirst := !c.hasEmittedTop
+	c.hasEmittedTop = true
+	isTopRequest := checkpoint == Top
+	if isFirst && !isTopRequest {
+		c.send(Event{Checkpoint: Top, T: 0})
+	}
+	t := 0
+	if !isFirst || !isTopRequest {
+		t = int(time.Since(c.sessionStart) / time.Millisecond)
+		if t < 0 {
+			t = 0
+		}
+	}
+	c.send(Event{Checkpoint: checkpoint, T: t, Source: source, Target: target})
+}
+
+// send fills in the session-scoped fields and hands the event to the
+// transport. Caller must hold c.mu.
+func (c *Client) send(event Event) {
+	event.Weight = c.session.Weight
+	event.ID = c.session.ID
+	event.Referer = BuildReferer(c.appID, "/")
+	c.transport.Send(event, c.collectBaseURL, &c.wg)
+}
+
+// ReportError samples an Error checkpoint with a sanitized target. source
+// classifies the error (e.g. "dial", "update") and must itself be a fixed,
+// caller-chosen label — never user-typed input. The message is run through
+// Sanitize so absolute URLs (which may embed a join-URL bearer token) and
+// filesystem paths never reach the wire. Nil-safe; a nil err is a no-op.
+func (c *Client) ReportError(source string, err error) {
+	if c == nil || err == nil {
+		return
+	}
+	c.Sample(Error, source, Sanitize(err.Error()))
+}
+
+// Flush blocks until every beacon started by this Client has completed, or
+// timeout elapses, whichever comes first. Call this (bounded) before
+// process exit: unlike navigator.sendBeacon, a Go fire-and-forget goroutine
+// has no guarantee of running past main() returning. A nil Client returns
+// immediately.
+func (c *Client) Flush(timeout time.Duration) {
+	if c == nil {
+		return
+	}
+	done := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+	}
+}

--- a/packages/go-optel/client_test.go
+++ b/packages/go-optel/client_test.go
@@ -1,0 +1,174 @@
+package optel
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingTransport is a Transport test double that records every Event
+// synchronously (no goroutine), so assertions don't need to poll.
+type recordingTransport struct {
+	mu     sync.Mutex
+	events []Event
+}
+
+func (r *recordingTransport) Send(event Event, _ string, wg *sync.WaitGroup) {
+	r.mu.Lock()
+	r.events = append(r.events, event)
+	r.mu.Unlock()
+	if wg != nil {
+		wg.Add(1)
+		wg.Done()
+	}
+}
+
+func (r *recordingTransport) snapshot() []Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]Event, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+func TestClientSampleAutoEmitsTopThenCheckpoint(t *testing.T) {
+	rec := &recordingTransport{}
+	c := Configure("slicc-cli", Options{
+		Rate:         "on", // weight 1: always selected
+		Transport:    rec,
+		RandomSource: fakeRandom(0),
+	})
+	c.Sample(Enter, "prompt", "")
+
+	events := rec.snapshot()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (auto top + enter), got %d: %+v", len(events), events)
+	}
+	if events[0].Checkpoint != Top || events[0].T != 0 {
+		t.Errorf("first event = %+v, want top/t=0", events[0])
+	}
+	if events[1].Checkpoint != Enter || events[1].Source != "prompt" {
+		t.Errorf("second event = %+v, want enter/source=prompt", events[1])
+	}
+	if events[0].ID != events[1].ID || events[0].Weight != events[1].Weight {
+		t.Errorf("events do not share session id/weight: %+v", events)
+	}
+}
+
+func TestClientSampleOnlyAutoEmitsTopOnce(t *testing.T) {
+	rec := &recordingTransport{}
+	c := Configure("slicc-cli", Options{Rate: "on", Transport: rec, RandomSource: fakeRandom(0)})
+	c.Sample(Enter, "prompt", "")
+	c.Sample(Error, "dial", "connection refused")
+
+	events := rec.snapshot()
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events (one top + two checkpoints), got %d: %+v", len(events), events)
+	}
+	topCount := 0
+	for _, e := range events {
+		if e.Checkpoint == Top {
+			topCount++
+		}
+	}
+	if topCount != 1 {
+		t.Fatalf("expected exactly one top event, got %d", topCount)
+	}
+}
+
+func TestClientSampleUnselectedSessionSendsNothing(t *testing.T) {
+	rec := &recordingTransport{}
+	c := Configure("slicc-cli", Options{Rate: "off", Transport: rec})
+	c.Sample(Enter, "prompt", "")
+	if len(rec.snapshot()) != 0 {
+		t.Fatalf("weight=0 session must send nothing, got %+v", rec.snapshot())
+	}
+}
+
+func TestClientReportErrorSanitizes(t *testing.T) {
+	rec := &recordingTransport{}
+	c := Configure("slicc-cli", Options{Rate: "on", Transport: rec, RandomSource: fakeRandom(0)})
+	c.ReportError("dial", errors.New(`Get "https://sliccy.ai/join/leaked-secret": connection refused`))
+
+	events := rec.snapshot()
+	last := events[len(events)-1]
+	if last.Checkpoint != Error || last.Source != "dial" {
+		t.Fatalf("unexpected error event: %+v", last)
+	}
+	if strings.Contains(last.Target, "leaked-secret") {
+		t.Fatalf("ReportError leaked the join token into the target field: %q", last.Target)
+	}
+}
+
+func TestClientReportErrorNilErrorIsNoop(t *testing.T) {
+	rec := &recordingTransport{}
+	c := Configure("slicc-cli", Options{Rate: "on", Transport: rec, RandomSource: fakeRandom(0)})
+	c.ReportError("dial", nil)
+	if len(rec.snapshot()) != 0 {
+		t.Fatalf("nil error must not emit a beacon, got %+v", rec.snapshot())
+	}
+}
+
+func TestNilClientIsInertNoop(_ *testing.T) {
+	var c *Client
+	// None of these may panic.
+	c.Sample(Enter, "prompt", "")
+	c.ReportError("dial", errors.New("boom"))
+	c.Flush(10 * time.Millisecond)
+}
+
+func TestClientFlushWaitsForInFlightBeacons(t *testing.T) {
+	slow := &blockingTransport{release: make(chan struct{})}
+	c := Configure("slicc-cli", Options{Rate: "on", Transport: slow, RandomSource: fakeRandom(0)})
+	c.Sample(Enter, "prompt", "")
+
+	flushed := make(chan struct{})
+	go func() {
+		c.Flush(2 * time.Second)
+		close(flushed)
+	}()
+
+	select {
+	case <-flushed:
+		t.Fatal("Flush returned before the in-flight beacon was released")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(slow.release)
+	select {
+	case <-flushed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Flush did not return after the beacon was released")
+	}
+}
+
+func TestClientFlushTimesOutBoundedly(t *testing.T) {
+	slow := &blockingTransport{release: make(chan struct{})}
+	defer close(slow.release)
+	c := Configure("slicc-cli", Options{Rate: "on", Transport: slow, RandomSource: fakeRandom(0)})
+	c.Sample(Enter, "prompt", "")
+
+	start := time.Now()
+	c.Flush(50 * time.Millisecond)
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("Flush did not honor its timeout, took %s", elapsed)
+	}
+}
+
+// blockingTransport holds every Send's wg.Done() until release is closed,
+// simulating a slow network call for Flush timeout tests.
+type blockingTransport struct {
+	release chan struct{}
+}
+
+func (b *blockingTransport) Send(_ Event, _ string, wg *sync.WaitGroup) {
+	if wg != nil {
+		wg.Add(1)
+		go func() {
+			<-b.release
+			wg.Done()
+		}()
+	}
+}

--- a/packages/go-optel/env.go
+++ b/packages/go-optel/env.go
@@ -1,0 +1,52 @@
+package optel
+
+import (
+	"os"
+	"strings"
+)
+
+// EnvRateKey / EnvDebugKey are the environment variables honored uniformly
+// across every go-optel-based binary (same names as swift-optel's
+// OptelEnvConfig).
+const (
+	EnvRateKey  = "OPTEL_RATE"
+	EnvDebugKey = "OPTEL_DEBUG"
+)
+
+// ResolveRate resolves the effective sampling rate string. environment, when
+// non-nil, is consulted instead of the process environment (tests only);
+// production callers pass nil. The env override wins when set and
+// non-empty; otherwise explicit is returned unchanged (which may itself be
+// "", yielding DefaultWeight downstream in NewSamplingConfig).
+func ResolveRate(explicit string, environment map[string]string) string {
+	if v, ok := lookupEnv(EnvRateKey, environment); ok && v != "" {
+		return v
+	}
+	return explicit
+}
+
+// ResolveDebug resolves the debug-logging flag from the environment.
+// Truthy values are 1/true/on/yes (case-insensitive); anything else
+// (including 0/false/off/no, empty, or missing) is false.
+func ResolveDebug(environment map[string]string) bool {
+	v, ok := lookupEnv(EnvDebugKey, environment)
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "on", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+// lookupEnv reads key from environment when non-nil (tests), else from the
+// process environment.
+func lookupEnv(key string, environment map[string]string) (string, bool) {
+	if environment != nil {
+		v, ok := environment[key]
+		return v, ok
+	}
+	return os.LookupEnv(key)
+}

--- a/packages/go-optel/env_test.go
+++ b/packages/go-optel/env_test.go
@@ -1,0 +1,47 @@
+package optel
+
+import "testing"
+
+func TestResolveRatePrefersEnvOverride(t *testing.T) {
+	env := map[string]string{EnvRateKey: "on"}
+	if got := ResolveRate("high", env); got != "on" {
+		t.Fatalf("ResolveRate = %q, want %q", got, "on")
+	}
+}
+
+func TestResolveRateFallsBackToExplicit(t *testing.T) {
+	env := map[string]string{}
+	if got := ResolveRate("high", env); got != "high" {
+		t.Fatalf("ResolveRate = %q, want %q", got, "high")
+	}
+}
+
+func TestResolveRateEmptyEnvValueDoesNotOverride(t *testing.T) {
+	env := map[string]string{EnvRateKey: ""}
+	if got := ResolveRate("low", env); got != "low" {
+		t.Fatalf("ResolveRate = %q, want %q", got, "low")
+	}
+}
+
+func TestResolveDebug(t *testing.T) {
+	cases := map[string]bool{
+		"1":     true,
+		"true":  true,
+		"TRUE":  true,
+		"on":    true,
+		"yes":   true,
+		"0":     false,
+		"false": false,
+		"off":   false,
+		"":      false,
+	}
+	for value, want := range cases {
+		env := map[string]string{EnvDebugKey: value}
+		if got := ResolveDebug(env); got != want {
+			t.Errorf("ResolveDebug(%q) = %v, want %v", value, got, want)
+		}
+	}
+	if got := ResolveDebug(map[string]string{}); got != false {
+		t.Fatalf("ResolveDebug(missing) = %v, want false", got)
+	}
+}

--- a/packages/go-optel/event.go
+++ b/packages/go-optel/event.go
@@ -1,0 +1,20 @@
+package optel
+
+// Event is one RUM beacon ready to be POSTed to the collector. The JSON
+// encoding is byte-compatible with helix-rum-js `sampleRUM.sendPing` and
+// with swift-optel's RUMEvent:
+//
+//	{ "weight": 100, "id": "abc123def", "referer": "https://slicc-cli/",
+//	  "checkpoint": "enter", "t": 0, "source": "prompt" }
+//
+// Source and Target are omitted from the wire payload when empty — go-optel
+// never sends an explicit `null`, matching the other two implementations.
+type Event struct {
+	Weight     int        `json:"weight"`
+	ID         string     `json:"id"`
+	Referer    string     `json:"referer"`
+	Checkpoint Checkpoint `json:"checkpoint"`
+	T          int        `json:"t"`
+	Source     string     `json:"source,omitempty"`
+	Target     string     `json:"target,omitempty"`
+}

--- a/packages/go-optel/event_test.go
+++ b/packages/go-optel/event_test.go
@@ -1,0 +1,44 @@
+package optel
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestEventEncodingOmitsEmptySourceAndTarget(t *testing.T) {
+	event := Event{Weight: 100, ID: "abc123456", Referer: "https://slicc-cli/", Checkpoint: Enter, T: 0}
+	b, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	for _, key := range []string{"source", "target"} {
+		if _, present := decoded[key]; present {
+			t.Errorf("expected %q to be omitted, got %v", key, decoded[key])
+		}
+	}
+	if decoded["checkpoint"] != "enter" {
+		t.Errorf("checkpoint = %v, want %q", decoded["checkpoint"], "enter")
+	}
+}
+
+func TestEventEncodingIncludesSourceAndTarget(t *testing.T) {
+	event := Event{
+		Weight: 100, ID: "abc123456", Referer: "https://slicc-cli/",
+		Checkpoint: Error, T: 12, Source: "dial", Target: "connection refused",
+	}
+	b, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if decoded["source"] != "dial" || decoded["target"] != "connection refused" {
+		t.Errorf("unexpected source/target: %v/%v", decoded["source"], decoded["target"])
+	}
+}

--- a/packages/go-optel/go.mod
+++ b/packages/go-optel/go.mod
@@ -1,0 +1,3 @@
+module github.com/ai-ecoverse/go-optel
+
+go 1.26.5

--- a/packages/go-optel/referer.go
+++ b/packages/go-optel/referer.go
@@ -1,0 +1,30 @@
+package optel
+
+import "strings"
+
+// DefaultCollectBaseURL matches helix-rum-js (https://rum.hlx.page/).
+const DefaultCollectBaseURL = "https://rum.hlx.page/"
+
+// BuildReferer constructs the helix-rum-js `referer` string from an app id
+// and a view path.
+//
+// In helix-rum-js, referer = window.location.origin + window.location.pathname.
+// A headless CLI has no URL, so — exactly like swift-optel's RUMReferer — the
+// app id substitutes for the hostname:
+//
+//	https://{appID}{viewPath}
+//
+// viewPath is normalized to always begin with "/" so the result mirrors a
+// browser origin+pathname value even when callers pass "" or a relative path.
+func BuildReferer(appID, viewPath string) string {
+	var normalized string
+	switch {
+	case viewPath == "":
+		normalized = "/"
+	case strings.HasPrefix(viewPath, "/"):
+		normalized = viewPath
+	default:
+		normalized = "/" + viewPath
+	}
+	return "https://" + appID + normalized
+}

--- a/packages/go-optel/referer_test.go
+++ b/packages/go-optel/referer_test.go
@@ -1,0 +1,21 @@
+package optel
+
+import "testing"
+
+func TestBuildReferer(t *testing.T) {
+	cases := []struct {
+		appID    string
+		viewPath string
+		want     string
+	}{
+		{"slicc-cli", "", "https://slicc-cli/"},
+		{"slicc-cli", "/", "https://slicc-cli/"},
+		{"slicc-cli", "/prompt", "https://slicc-cli/prompt"},
+		{"slicc-cli", "prompt", "https://slicc-cli/prompt"},
+	}
+	for _, c := range cases {
+		if got := BuildReferer(c.appID, c.viewPath); got != c.want {
+			t.Errorf("BuildReferer(%q, %q) = %q, want %q", c.appID, c.viewPath, got, c.want)
+		}
+	}
+}

--- a/packages/go-optel/sampling.go
+++ b/packages/go-optel/sampling.go
@@ -1,0 +1,90 @@
+package optel
+
+import "math/rand/v2"
+
+// SamplingConfig is the resolved sampling weight that drives the
+// once-per-process selection coin flip.
+//
+// Mirrors helix-rum-js and swift-optel's SamplingConfig exactly: only the
+// on/off/high/low rate aliases map to a specific weight; anything else
+// (including numeric strings, "", and unset) falls back to the default
+// weight of 100.
+type SamplingConfig struct {
+	Weight int
+}
+
+// DefaultWeight is the helix-rum-js default weight used when no rate is
+// supplied.
+const DefaultWeight = 100
+
+// NewSamplingConfig builds a SamplingConfig from a rate string.
+func NewSamplingConfig(rate string) SamplingConfig {
+	return SamplingConfig{Weight: ParseWeight(rate)}
+}
+
+// ParseWeight resolves a rate string to its integer weight, matching the
+// helix-rum-js `rateValue` table.
+func ParseWeight(rate string) int {
+	switch rate {
+	case "on":
+		return 1
+	case "off":
+		return 0
+	case "high":
+		return 10
+	case "low":
+		return 1000
+	default:
+		return DefaultWeight
+	}
+}
+
+// RandomSource supplies the uniform [0,1) draw used to resolve the
+// once-per-session selection decision. Injectable so tests can pin the
+// outcome; production code uses DefaultRandomSource.
+type RandomSource interface {
+	Float64() float64
+}
+
+type systemRandomSource struct{}
+
+func (systemRandomSource) Float64() float64 { return rand.Float64() }
+
+// DefaultRandomSource is the production RandomSource, backed by
+// math/rand/v2's auto-seeded top-level generator (no manual seeding
+// required since Go 1.22).
+var DefaultRandomSource RandomSource = systemRandomSource{}
+
+// Session is the per-process sampling state: the stable session id, the
+// resolved weight, and the cached selection decision.
+//
+// Mirrors swift-optel's SamplingSession: Selected is computed once, from a
+// single coin flip, and reused for every beacon this process emits — one
+// decision per launch, never per event.
+type Session struct {
+	ID       string
+	Weight   int
+	Selected bool
+}
+
+// NewSession constructs a Session, computing Selected exactly once from the
+// supplied RandomSource. A nil random falls back to DefaultRandomSource.
+func NewSession(id string, config SamplingConfig, random RandomSource) Session {
+	if random == nil {
+		random = DefaultRandomSource
+	}
+	return Session{
+		ID:       id,
+		Weight:   config.Weight,
+		Selected: computeSelected(config.Weight, random),
+	}
+}
+
+// computeSelected is the pure selection predicate matching helix-rum-js:
+// weight > 0 && random * weight < 1.
+func computeSelected(weight int, random RandomSource) bool {
+	if weight <= 0 {
+		return false
+	}
+	return random.Float64()*float64(weight) < 1.0
+}

--- a/packages/go-optel/sampling_test.go
+++ b/packages/go-optel/sampling_test.go
@@ -1,0 +1,64 @@
+package optel
+
+import "testing"
+
+func TestParseWeight(t *testing.T) {
+	cases := map[string]int{
+		"on":     1,
+		"off":    0,
+		"high":   10,
+		"low":    1000,
+		"":       DefaultWeight,
+		"100":    DefaultWeight, // numeric strings fall back, matching helix-rum-js
+		"banana": DefaultWeight,
+	}
+	for rate, want := range cases {
+		if got := ParseWeight(rate); got != want {
+			t.Errorf("ParseWeight(%q) = %d, want %d", rate, got, want)
+		}
+	}
+}
+
+// fakeRandom returns a fixed draw regardless of how many times it is called.
+type fakeRandom float64
+
+func (f fakeRandom) Float64() float64 { return float64(f) }
+
+func TestNewSessionSelection(t *testing.T) {
+	// weight=1 (rate "on"): 1/1 always selects regardless of the draw.
+	s := NewSession("abc123456", SamplingConfig{Weight: 1}, fakeRandom(0.999999))
+	if !s.Selected {
+		t.Fatal("weight=1 must always select")
+	}
+
+	// weight=0 (rate "off"): never selects, even with the smallest possible draw.
+	s = NewSession("abc123456", SamplingConfig{Weight: 0}, fakeRandom(0))
+	if s.Selected {
+		t.Fatal("weight=0 must never select")
+	}
+
+	// weight=10: draw*weight < 1 selects.
+	s = NewSession("abc123456", SamplingConfig{Weight: 10}, fakeRandom(0.05))
+	if !s.Selected {
+		t.Fatal("draw=0.05, weight=10 (0.5 < 1) should select")
+	}
+	s = NewSession("abc123456", SamplingConfig{Weight: 10}, fakeRandom(0.5))
+	if s.Selected {
+		t.Fatal("draw=0.5, weight=10 (5 < 1 is false) should not select")
+	}
+}
+
+func TestNewSessionNilRandomUsesDefault(t *testing.T) {
+	// Must not panic, and must be deterministic in structure even though the
+	// draw is real randomness.
+	s := NewSession("abc123456", SamplingConfig{Weight: 100}, nil)
+	if s.ID != "abc123456" || s.Weight != 100 {
+		t.Fatalf("unexpected session: %+v", s)
+	}
+}
+
+func TestNewSamplingConfig(t *testing.T) {
+	if got := NewSamplingConfig("high").Weight; got != 10 {
+		t.Fatalf("NewSamplingConfig(high).Weight = %d, want 10", got)
+	}
+}

--- a/packages/go-optel/sanitize.go
+++ b/packages/go-optel/sanitize.go
@@ -1,0 +1,83 @@
+package optel
+
+import (
+	"net/url"
+	"regexp"
+)
+
+// MaxMessageLength caps a sanitized error message, matching telemetry.ts's
+// 200-character truncation for the webapp/extension `error` checkpoint.
+const MaxMessageLength = 200
+
+// urlPattern finds absolute http(s) URLs embedded in an error string.
+var urlPattern = regexp.MustCompile(`https?://[^\s"'` + "`" + `)]+`)
+
+// posixPathPattern collapses a multi-segment POSIX path to its first
+// segment, mirroring telemetry.ts's `/(\/[a-z]+)(?:\/[^\s/]+)+/gi` ->
+// "$1/.../" collapse (case-insensitive, so /Users/... and /home/... both
+// hide everything past the first segment, including a username).
+var posixPathPattern = regexp.MustCompile(`(?i)(/[a-zA-Z][a-zA-Z0-9_.-]*)(?:/[^\s/]+)+`)
+
+// windowsPathPattern collapses a drive-rooted Windows path to its drive
+// letter, e.g. `C:\Users\lars\secrets.txt` -> `C:\...`.
+var windowsPathPattern = regexp.MustCompile(`(?i)[A-Z]:\\[^\s"']+`)
+
+// Sanitize reduces an error message to a privacy-safe form before it is
+// allowed anywhere near a Sample()/ReportError() call.
+//
+// This CLI is a WebRTC follower that dials a leader join URL carrying a
+// bearer token in its path (https://…/join/<token>) and executes
+// leader-issued shell commands on the user's machine (`follow`). Go's
+// net/http and net/url error types routinely embed the full request URL —
+// including that token — in their Error() string (e.g. `Get
+// "https://.../join/<token>": dial tcp: ...`), and OS-level errors just as
+// routinely embed the user's home directory (which, on most platforms,
+// contains their login name). Both are effectively credentials or PII for
+// this CLI's threat model, which is why the redaction order below is
+// URLs-and-paths-first, truncate-last: a URL or path is stripped in full
+// before any truncation could leave a partial (still-sensitive) fragment
+// on the wire.
+//
+//  1. Every absolute http(s) URL is reduced to just its scheme+host — the
+//     entire path/query/fragment (where a join-URL token lives) is
+//     dropped, never partially truncated.
+//  2. Absolute POSIX and Windows paths are collapsed to their first
+//     segment / drive letter, matching telemetry.ts's `/<root>/.../`
+//     convention.
+//  3. The result is truncated to MaxMessageLength runes.
+func Sanitize(msg string) string {
+	redacted := urlPattern.ReplaceAllStringFunc(msg, redactURL)
+	redacted = posixPathPattern.ReplaceAllString(redacted, "$1/...")
+	redacted = windowsPathPattern.ReplaceAllStringFunc(redacted, redactWindowsPath)
+	return truncate(redacted, MaxMessageLength)
+}
+
+// redactURL keeps only scheme://host from a matched URL, dropping path,
+// query, and fragment entirely (where a join-URL bearer token lives). An
+// unparseable match (should not happen given the pattern) is redacted
+// wholesale.
+func redactURL(match string) string {
+	parsed, err := url.Parse(match)
+	if err != nil || parsed.Host == "" {
+		return "<url>"
+	}
+	return parsed.Scheme + "://" + parsed.Host + "/..."
+}
+
+// redactWindowsPath keeps only the drive letter from a matched Windows
+// path.
+func redactWindowsPath(match string) string {
+	if len(match) < 2 {
+		return `<path>`
+	}
+	return match[:2] + `\...`
+}
+
+// truncate caps s to limit runes (never splitting a multi-byte rune).
+func truncate(s string, limit int) string {
+	r := []rune(s)
+	if len(r) <= limit {
+		return s
+	}
+	return string(r[:limit])
+}

--- a/packages/go-optel/sanitize_test.go
+++ b/packages/go-optel/sanitize_test.go
@@ -1,0 +1,89 @@
+package optel
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeRedactsJoinURLToken(t *testing.T) {
+	// The exact shape net/url's *url.Error produces on a dial failure — the
+	// case this whole package exists to defend against: the join URL's
+	// bearer token must never survive into a beacon.
+	msg := `Get "https://sliccy.ai/join/super-secret-token-abc123": dial tcp: lookup sliccy.ai: no such host`
+	got := Sanitize(msg)
+	if strings.Contains(got, "super-secret-token-abc123") {
+		t.Fatalf("Sanitize leaked the join token: %q", got)
+	}
+	if strings.Contains(got, "/join/") {
+		t.Fatalf("Sanitize leaked the URL path: %q", got)
+	}
+	if !strings.Contains(got, "sliccy.ai") {
+		t.Fatalf("expected the host to survive redaction, got %q", got)
+	}
+}
+
+func TestSanitizeRedactsMultipleURLs(t *testing.T) {
+	msg := "primary https://a.example.com/join/tok1 failed, retrying https://b.example.com/join/tok2"
+	got := Sanitize(msg)
+	if strings.Contains(got, "tok1") || strings.Contains(got, "tok2") {
+		t.Fatalf("Sanitize leaked a token from a multi-URL message: %q", got)
+	}
+}
+
+func TestSanitizeCollapsesPosixPath(t *testing.T) {
+	msg := "open /Users/lars/.slicc/logs/slicc-2026-07-28.log: permission denied"
+	got := Sanitize(msg)
+	if strings.Contains(got, "lars") {
+		t.Fatalf("Sanitize leaked the username segment: %q", got)
+	}
+	if !strings.Contains(got, "/Users/...") {
+		t.Fatalf("expected the first path segment to survive, got %q", got)
+	}
+}
+
+func TestSanitizeCollapsesWindowsPath(t *testing.T) {
+	msg := `open C:\Users\lars\AppData\slicc\state.json: access is denied`
+	got := Sanitize(msg)
+	if strings.Contains(got, "lars") {
+		t.Fatalf("Sanitize leaked the username segment: %q", got)
+	}
+	if !strings.Contains(got, `C:\...`) {
+		t.Fatalf("expected the drive letter to survive, got %q", got)
+	}
+}
+
+func TestSanitizeTruncates(t *testing.T) {
+	got := Sanitize(strings.Repeat("a", 500))
+	if len([]rune(got)) != MaxMessageLength {
+		t.Fatalf("expected truncation to %d runes, got %d", MaxMessageLength, len([]rune(got)))
+	}
+}
+
+func TestSanitizeNeverGrowsAURLPastTruncationBoundary(t *testing.T) {
+	// A long path before a URL must not push the URL redaction past the
+	// truncation boundary and leave a partial token on the wire: URL
+	// redaction must run on the FULL message, before truncation.
+	prefix := strings.Repeat("x", 190)
+	msg := prefix + " https://sliccy.ai/join/leaked-token-should-not-appear"
+	got := Sanitize(msg)
+	if strings.Contains(got, "leaked-token-should-not-appear") {
+		t.Fatalf("Sanitize leaked a token that should have been redacted before truncation: %q", got)
+	}
+}
+
+func TestSanitizeLeavesOrdinaryMessagesAlone(t *testing.T) {
+	msg := "connection refused"
+	if got := Sanitize(msg); got != msg {
+		t.Fatalf("expected %q unchanged, got %q", msg, got)
+	}
+}
+
+func TestSanitizeHandlesRealNetURLError(t *testing.T) {
+	// Exercise the actual net/url.Error shape, not just a hand-written string.
+	err := errors.New(`Post "https://sliccy.ai/join/abcdef0123456789": context deadline exceeded`)
+	got := Sanitize(err.Error())
+	if strings.Contains(got, "abcdef0123456789") {
+		t.Fatalf("Sanitize leaked a token from a net/url-shaped error: %q", got)
+	}
+}

--- a/packages/go-optel/session.go
+++ b/packages/go-optel/session.go
@@ -1,0 +1,22 @@
+package optel
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// GenerateSessionID returns a fresh 9-character session id, matching the
+// helix-rum-js / swift-optel derivation: a random v4 UUID formatted as the
+// canonical dashed lowercase string, then the last 9 characters (entirely
+// within the trailing 12-hex-digit group, so none of the dashes survive).
+func GenerateSessionID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	uuid := fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+	if len(uuid) <= 9 {
+		return uuid
+	}
+	return uuid[len(uuid)-9:]
+}

--- a/packages/go-optel/session_test.go
+++ b/packages/go-optel/session_test.go
@@ -1,0 +1,18 @@
+package optel
+
+import "testing"
+
+func TestGenerateSessionIDLength(t *testing.T) {
+	id := GenerateSessionID()
+	if len([]rune(id)) != 9 {
+		t.Fatalf("GenerateSessionID() = %q, want 9 runes, got %d", id, len([]rune(id)))
+	}
+}
+
+func TestGenerateSessionIDVaries(t *testing.T) {
+	a := GenerateSessionID()
+	b := GenerateSessionID()
+	if a == b {
+		t.Fatalf("two consecutive session ids collided: %q", a)
+	}
+}

--- a/packages/go-optel/transport.go
+++ b/packages/go-optel/transport.go
@@ -1,0 +1,122 @@
+package optel
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// DefaultTimeout is the per-request timeout used when HTTPTransport.Timeout
+// is zero.
+const DefaultTimeout = 10 * time.Second
+
+// Transport sends a single Event to the collector. Implementations must
+// never block the caller for the network round trip — this is the Go
+// analogue of navigator.sendBeacon / swift-optel's OptelTransport.
+type Transport interface {
+	// Send enqueues the event for delivery. When wg is non-nil, Send must
+	// call wg.Add(1) before returning and wg.Done() once the underlying
+	// network attempt (success or failure) completes, so Client.Flush can
+	// bound how long it waits for in-flight beacons at process exit.
+	Send(event Event, collectBaseURL string, wg *sync.WaitGroup)
+}
+
+// HTTPTransport is the default Transport, backed by net/http. Mirrors
+// swift-optel's URLSessionOptelTransport:
+//   - POST {collectBaseURL}.rum/{weight} with Content-Type: application/json
+//   - the request runs in its own goroutine so Send never blocks the caller
+//   - a short per-request timeout bounds a stuck collector
+//   - every error is swallowed; nothing is retried
+type HTTPTransport struct {
+	Client  *http.Client
+	Timeout time.Duration
+	// Debug, when non-nil, receives one line per beacon attempt (URL, byte
+	// count, and — on completion — status code or error). Off by default;
+	// wired from OPTEL_DEBUG / Options.Debug.
+	Debug func(format string, args ...any)
+}
+
+// NewHTTPTransport builds a production HTTPTransport. debug installs a
+// log.Printf-based Debug sink; false leaves it nil (no logging, no
+// behavior change).
+func NewHTTPTransport(debug bool) *HTTPTransport {
+	t := &HTTPTransport{
+		Client:  &http.Client{Timeout: DefaultTimeout},
+		Timeout: DefaultTimeout,
+	}
+	if debug {
+		t.Debug = log.Printf
+	}
+	return t
+}
+
+// Send implements Transport.
+func (t *HTTPTransport) Send(event Event, collectBaseURL string, wg *sync.WaitGroup) {
+	body, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+	reqURL, err := buildBeaconURL(collectBaseURL, event.Weight)
+	if err != nil {
+		return
+	}
+	client := t.Client
+	if client == nil {
+		client = &http.Client{Timeout: DefaultTimeout}
+	}
+	timeout := t.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	debug := t.Debug
+	if wg != nil {
+		wg.Add(1)
+	}
+	go func() {
+		if wg != nil {
+			defer wg.Done()
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
+		if reqErr != nil {
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if debug != nil {
+			debug("optel beacon -> %s (%d bytes)", reqURL, len(body))
+		}
+		res, doErr := client.Do(req)
+		if doErr != nil {
+			if debug != nil {
+				debug("optel beacon error: %s", doErr)
+			}
+			return
+		}
+		defer func() { _ = res.Body.Close() }()
+		if debug != nil {
+			debug("optel beacon <- %s status=%d", reqURL, res.StatusCode)
+		}
+	}()
+}
+
+// buildBeaconURL resolves ".rum/<weight>" relative to collectBaseURL,
+// matching `new URL('.rum/' + weight, collectBaseURL)` in helix-rum-js and
+// `URL(string:relativeTo:)` in swift-optel.
+func buildBeaconURL(collectBaseURL string, weight int) (string, error) {
+	base, err := url.Parse(collectBaseURL)
+	if err != nil {
+		return "", err
+	}
+	rel, err := url.Parse(fmt.Sprintf(".rum/%d", weight))
+	if err != nil {
+		return "", err
+	}
+	return base.ResolveReference(rel).String(), nil
+}

--- a/packages/go-optel/transport_test.go
+++ b/packages/go-optel/transport_test.go
@@ -1,0 +1,126 @@
+package optel
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBuildBeaconURL(t *testing.T) {
+	cases := []struct {
+		base   string
+		weight int
+		want   string
+	}{
+		{"https://rum.hlx.page/", 100, "https://rum.hlx.page/.rum/100"},
+		{"https://rum.hlx.page", 10, "https://rum.hlx.page/.rum/10"},
+	}
+	for _, c := range cases {
+		got, err := buildBeaconURL(c.base, c.weight)
+		if err != nil {
+			t.Fatalf("buildBeaconURL(%q, %d): %v", c.base, c.weight, err)
+		}
+		if got != c.want {
+			t.Errorf("buildBeaconURL(%q, %d) = %q, want %q", c.base, c.weight, got, c.want)
+		}
+	}
+}
+
+func TestHTTPTransportSendPostsExpectedShape(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		gotPath     string
+		gotMethod   string
+		gotContent  string
+		gotEvent    Event
+		requestSeen bool
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotContent = r.Header.Get("Content-Type")
+		_ = json.NewDecoder(r.Body).Decode(&gotEvent)
+		requestSeen = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	transport := NewHTTPTransport(false)
+	event := Event{Weight: 100, ID: "abc123456", Referer: "https://slicc-cli/", Checkpoint: Enter, T: 0, Source: "prompt"}
+	var wg sync.WaitGroup
+	transport.Send(event, srv.URL+"/", &wg)
+
+	waitWithTimeout(t, &wg, 2*time.Second)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !requestSeen {
+		t.Fatal("server never received a request")
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/.rum/100" {
+		t.Errorf("path = %q, want /.rum/100", gotPath)
+	}
+	if gotContent != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContent)
+	}
+	if gotEvent.Checkpoint != Enter || gotEvent.Source != "prompt" {
+		t.Errorf("decoded event = %+v", gotEvent)
+	}
+}
+
+func TestHTTPTransportSendNeverBlocksCaller(t *testing.T) {
+	// A server that never responds must not make Send itself block — only
+	// Flush (via the WaitGroup) should ever wait on the network.
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-block
+	}))
+	defer func() {
+		close(block)
+		srv.Close()
+	}()
+
+	transport := &HTTPTransport{Client: &http.Client{Timeout: 200 * time.Millisecond}, Timeout: 200 * time.Millisecond}
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+	go func() {
+		transport.Send(Event{Weight: 100, ID: "abc123456", Referer: "https://x/", Checkpoint: Enter}, srv.URL+"/", &wg)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Send blocked the caller")
+	}
+}
+
+func TestHTTPTransportSendSwallowsErrors(t *testing.T) {
+	transport := NewHTTPTransport(false)
+	var wg sync.WaitGroup
+	// An unroutable host: the goroutine's client.Do will fail; Send itself
+	// must not panic or return an error value (it has none to return).
+	transport.Send(Event{Weight: 100, ID: "abc123456", Referer: "https://x/", Checkpoint: Enter}, "http://127.0.0.1:1", &wg)
+	waitWithTimeout(t, &wg, 2*time.Second)
+}
+
+func waitWithTimeout(t *testing.T, wg *sync.WaitGroup, timeout time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for the WaitGroup")
+	}
+}

--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -52,6 +52,7 @@ with `CGO_ENABLED=0` (see the `dist` target). No native toolchain required.
 | `internal/tray/`      | pion peer + `tray-control` data channel + follower state machine (hello, ping/pong, dispatch)                                               |
 | `internal/execrun/`   | Cross-platform OS command runner backing `follow` (streams stdout/stderr, forwards signals) + `EvalSession` (persistent-REPL `--eval` mode) |
 | `update.go`           | `cmdUpdate` (`slicc update [--check]`) + the on-launch update-notice hook                                                                   |
+| `telemetry.go`        | `initTelemetry`/`reportRuntimeError` — launch + error RUM beacons via `@ai-ecoverse/go-optel`                                               |
 | `internal/update/`    | Release discovery (sparse-release scan), self-update apply, once-a-day cached notice                                                        |
 | `internal/logging/`   | `log/slog` structured diagnostic logger (text/JSON handler, env-driven level) + the `Logf` adapter the `tray` seam consumes                 |
 
@@ -145,6 +146,30 @@ and for any non-release-stamped version (`dev`, `git describe` output) —
 `IsReleaseVersion` gates both the notice and the self-replace, so `slicc
 update` refuses to clobber a local build that is ahead of the latest tag.
 `SLICC_UPDATE_API_BASE` overrides the API base (tests/mirrors).
+
+## Telemetry
+
+`telemetry.go` wires `packages/go-optel` (`github.com/ai-ecoverse/go-optel`, a
+sibling Go module pulled in via a local `replace` directive — this monorepo has
+no `go.work`) into two checkpoints only: `enter` on launch
+(`initTelemetry(sub)`, deferred right after `initTelemetry(sub)()` executes
+immediately in `main.go`'s `run()`) and `error` on an operational failure
+(`reportRuntimeError(source, err)`, called from the dial-error branches in
+`commands.go` and the update-check/apply error branches in `update.go`).
+`source` for `error` beacons is always one of a small fixed set (`dial`,
+`watch`, `follow`, `update`) — never user-typed input (join URL, exec/prompt
+text) — and `classifySubcommand` applies the same allowlist-not-passthrough
+treatment to the `enter` beacon's subcommand name.
+
+Gated the same way as the update notifier: `SLICC_NO_TELEMETRY=1` opts out
+outright, and `update.IsReleaseVersion(version)` means a `dev`/git-describe
+local build never configures a client at all (no env var needed for that
+case). Sampling is one coin flip per process (weight 100 by default,
+`OPTEL_RATE`/`OPTEL_DEBUG` env override), not per checkpoint. See
+`packages/go-optel/CLAUDE.md` for why `Sanitize()` (URL/path redaction before
+truncation) is mandatory here rather than a nice-to-have — this CLI's error
+strings can embed a leader's bearer-token join URL — and
+`docs/operational-telemetry.md` ("CLI Telemetry") for the cross-float design.
 
 ## Build / test
 

--- a/packages/slicc-cli/commands.go
+++ b/packages/slicc-cli/commands.go
@@ -78,6 +78,7 @@ func cmdPrompt(ctx context.Context, joinURL, text string) int {
 	conn, err := tray.Dial(ctx, joinURL, tray.Options{OnMessage: handler, Logf: debugLogf})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "slicc prompt: %s\n", err)
+		reportRuntimeError("dial", err)
 		return 1
 	}
 	defer conn.Close()
@@ -144,6 +145,7 @@ func cmdExec(ctx context.Context, joinURL, command string) int {
 	conn, err := tray.Dial(ctx, joinURL, tray.Options{OnMessage: handler, Logf: debugLogf})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "slicc exec: %s\n", err)
+		reportRuntimeError("dial", err)
 		return 1
 	}
 	defer conn.Close()
@@ -203,6 +205,7 @@ func cmdWatch(ctx context.Context, joinURL, scoopJid string) int {
 			failures++
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "slicc watch: %s\n", err)
+				reportRuntimeError("watch", err)
 			}
 			if failures >= 20 {
 				fmt.Fprintln(os.Stderr, "slicc watch: giving up after 20 failed attempts")
@@ -350,6 +353,7 @@ func cmdFollow(ctx context.Context, joinURL string, fa followArgs) int {
 			failures++
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "slicc follow: %s\n", err)
+				reportRuntimeError("follow", err)
 			}
 			if failures >= 20 {
 				fmt.Fprintln(os.Stderr, "slicc follow: giving up after 20 failed attempts")

--- a/packages/slicc-cli/go.mod
+++ b/packages/slicc-cli/go.mod
@@ -3,9 +3,14 @@ module github.com/ai-ecoverse/slicc-cli
 go 1.26.5
 
 require (
+	github.com/ai-ecoverse/go-optel v0.0.0
 	github.com/pion/ice/v4 v4.3.0
 	github.com/pion/webrtc/v4 v4.2.17
 )
+
+// go-optel is a sibling package in this monorepo (no go.work file), so the
+// module is resolved from the local tree rather than a published version.
+replace github.com/ai-ecoverse/go-optel => ../go-optel
 
 require (
 	github.com/google/uuid v1.6.0 // indirect

--- a/packages/slicc-cli/main.go
+++ b/packages/slicc-cli/main.go
@@ -45,6 +45,7 @@ func run(args []string) int {
 	case "update":
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
+		defer initTelemetry("update")()
 		return cmdUpdate(ctx, args[1:])
 	}
 
@@ -63,6 +64,11 @@ func run(args []string) int {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+
+	// Launch telemetry (Enter checkpoint only; see telemetry.go) — one
+	// sampling decision per process, opt-out via SLICC_NO_TELEMETRY=1,
+	// silent by construction on non-release builds.
+	defer initTelemetry(sub)()
 
 	// Once-a-day cached upgrade notice (stderr), refreshed in the background;
 	// the deferred flush lets a short-lived verb persist the refresh result.

--- a/packages/slicc-cli/telemetry.go
+++ b/packages/slicc-cli/telemetry.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	optel "github.com/ai-ecoverse/go-optel"
+	"github.com/ai-ecoverse/slicc-cli/internal/update"
+)
+
+// telemetryAppID is the beacon `referer` hostname — a fixed, non-identifying
+// label, never a per-machine or per-user value. See docs/operational-telemetry.md.
+const telemetryAppID = "slicc-cli"
+
+// knownSubcommands allowlists the subcommand names that may travel as a
+// launch beacon's `source`. sub is user-typed (a mistyped subcommand is
+// still whatever the user typed), so anything outside this fixed
+// vocabulary is folded into "unknown" rather than echoed verbatim — the
+// same allowlist-not-passthrough posture telemetry.ts uses for the
+// webapp's `fill` (shell command name) checkpoint.
+var knownSubcommands = map[string]bool{
+	"prompt": true, "exec": true, "watch": true, "follow": true, "update": true,
+}
+
+func classifySubcommand(sub string) string {
+	if knownSubcommands[sub] {
+		return sub
+	}
+	return "unknown"
+}
+
+// telemetryClient is the process-wide go-optel client. nil whenever
+// telemetry is disabled (opt-out env var or a non-release build) or before
+// initTelemetry has run; every *optel.Client method is a safe no-op on a
+// nil receiver, so call sites never need to guard this.
+var telemetryClient *optel.Client
+
+// initTelemetry configures telemetry — one launch, one sampling decision,
+// matching go-optel's per-process (not per-event) sampling model — and
+// fires the Enter checkpoint for sub. Returns a bounded flush func to
+// defer: Go has no `navigator.sendBeacon` guarantee that an in-flight
+// beacon goroutine survives past main() returning.
+//
+// Opt-out: SLICC_NO_TELEMETRY=1. Gated to stamped release builds only,
+// mirroring the update notifier's update.IsReleaseVersion gate — a `dev` /
+// git-describe local build never phones home, by construction, so local
+// development is always silent without needing the env var at all.
+func initTelemetry(sub string) func() {
+	noop := func() {}
+	if !telemetryEnabled(version, os.Getenv("SLICC_NO_TELEMETRY")) {
+		return noop
+	}
+	telemetryClient = optel.Configure(telemetryAppID, optel.Options{})
+	telemetryClient.Sample(optel.Enter, classifySubcommand(sub), "")
+	return func() { telemetryClient.Flush(2 * time.Second) }
+}
+
+// telemetryEnabled is the pure decision initTelemetry acts on, factored out
+// so it can be exhaustively unit-tested without ever calling
+// optel.Configure (and therefore without any risk of a test triggering a
+// real network call).
+func telemetryEnabled(ver, noTelemetryEnv string) bool {
+	if noTelemetryEnv != "" {
+		return false
+	}
+	return update.IsReleaseVersion(ver)
+}
+
+// reportRuntimeError fires an Error checkpoint for an operational failure
+// (connectivity, self-update). source must be a fixed, caller-chosen label
+// — never user-typed input (join URLs, exec/prompt text, or file paths).
+// The message itself is sanitized inside optel.Client.ReportError: URLs
+// (which may embed a join-URL bearer token) and filesystem paths are
+// redacted before any truncation runs. No-op when err is nil or telemetry
+// is disabled/unconfigured (nil telemetryClient).
+func reportRuntimeError(source string, err error) {
+	telemetryClient.ReportError(source, err)
+}

--- a/packages/slicc-cli/telemetry_test.go
+++ b/packages/slicc-cli/telemetry_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestClassifySubcommand(t *testing.T) {
+	cases := map[string]string{
+		"prompt": "prompt",
+		"exec":   "exec",
+		"watch":  "watch",
+		"follow": "follow",
+		"update": "update",
+		"bogus":  "unknown",
+		"":       "unknown",
+	}
+	for sub, want := range cases {
+		if got := classifySubcommand(sub); got != want {
+			t.Errorf("classifySubcommand(%q) = %q, want %q", sub, got, want)
+		}
+	}
+}
+
+func TestTelemetryEnabled(t *testing.T) {
+	cases := []struct {
+		name        string
+		version     string
+		noTelemetry string
+		want        bool
+	}{
+		{"dev build", "dev", "", false},
+		{"git-describe build", "v5.71.1-4-gabc123", "", false},
+		{"release, no opt-out", "v5.71.1", "", true},
+		{"release, opted out", "v5.71.1", "1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := telemetryEnabled(tc.version, tc.noTelemetry); got != tc.want {
+				t.Errorf("telemetryEnabled(%q, %q) = %v, want %v", tc.version, tc.noTelemetry, got, tc.want)
+			}
+		})
+	}
+}
+
+// withTelemetryGlobals saves/restores the two package-level globals
+// initTelemetry / reportRuntimeError mutate, so these tests can't leak
+// state into main_test.go's TestRunArgDispatch or each other.
+func withTelemetryGlobals(t *testing.T) {
+	t.Helper()
+	origVersion, origClient := version, telemetryClient
+	t.Cleanup(func() { version, telemetryClient = origVersion, origClient })
+}
+
+func TestInitTelemetryNoopWhenDisabled(t *testing.T) {
+	withTelemetryGlobals(t)
+	version = "dev"
+	telemetryClient = nil
+
+	flush := initTelemetry("prompt")
+	flush() // must not panic even though telemetryClient stays nil
+	if telemetryClient != nil {
+		t.Fatal("expected telemetryClient to stay nil for a dev build")
+	}
+}
+
+func TestInitTelemetryOptOutEvenOnReleaseBuild(t *testing.T) {
+	withTelemetryGlobals(t)
+	t.Setenv("SLICC_NO_TELEMETRY", "1")
+	version = "v5.71.1"
+	telemetryClient = nil
+
+	initTelemetry("prompt")()
+	if telemetryClient != nil {
+		t.Fatal("expected telemetryClient to stay nil when SLICC_NO_TELEMETRY is set")
+	}
+}
+
+func TestInitTelemetryConfiguresOnReleaseBuildWithoutNetworkCall(t *testing.T) {
+	withTelemetryGlobals(t)
+	// Force weight=0 so Sample() is a guaranteed no-op: this proves the
+	// wiring configures a client and fires Enter without ever risking a
+	// real network call — hermetic by construction, matching this
+	// module's "no network in tests" rule.
+	t.Setenv("OPTEL_RATE", "off")
+	version = "v5.71.1"
+	telemetryClient = nil
+
+	flush := initTelemetry("prompt")
+	if telemetryClient == nil {
+		t.Fatal("expected a configured telemetryClient for a release build")
+	}
+	flush()
+}
+
+func TestReportRuntimeErrorNilSafety(t *testing.T) {
+	withTelemetryGlobals(t)
+	telemetryClient = nil
+
+	// Neither of these may panic: nil client, and nil error on a nil client.
+	reportRuntimeError("dial", nil)
+	reportRuntimeError("dial", errors.New("boom"))
+}

--- a/packages/slicc-cli/update.go
+++ b/packages/slicc-cli/update.go
@@ -32,6 +32,7 @@ func cmdUpdate(ctx context.Context, args []string) int {
 	release, err := checker.LatestCLIRelease(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "slicc update: %s\n", err)
+		reportRuntimeError("update", err)
 		return 1
 	}
 	// A git-describe / dev build is not comparable to release tags (its
@@ -62,6 +63,7 @@ func cmdUpdate(ctx context.Context, args []string) int {
 	fmt.Printf("updating slicc %s → %s ...\n", version, release.Version)
 	if err := checker.Apply(ctx, release, exePath); err != nil {
 		fmt.Fprintf(os.Stderr, "slicc update: %s\n", err)
+		reportRuntimeError("update", err)
 		return 1
 	}
 	fmt.Printf("updated %s to slicc %s\n", exePath, release.Version)


### PR DESCRIPTION
<!-- Linked issue: none. Follow-up to the RUM instrumentation-gap review. -->

## Summary

Adds a new dependency-free Go RUM client (`packages/go-optel`) and wires it into `slicc-cli` for launch (`enter`) and error (`error`) beacons only. Also fixes a documentation-drift bug in `docs/operational-telemetry.md`: the scoop lifecycle checkpoints (`enter`/`convert`/`leave`) have been wired since 2026-06-14, but the doc still described them as unwired.

## Why

Reviewing RUM coverage surfaced two gaps: `docs/operational-telemetry.md` was stale (claimed no scoop-lifecycle checkpoints exist, when `scoop-telemetry-hook.ts` has wired `enter`/`convert`/`leave` since 2026-06-14 — verified via `git log`/`git show` on both the feature commit and the doc's last edit), and `slicc-cli` had zero telemetry of any kind, unlike every other float. This PR closes the doc gap and gives the CLI a minimal, privacy-conscious launch/error signal, mirroring the existing `packages/swift-optel` design for native binaries.

## Approach / Implementation notes

- `packages/go-optel` mirrors `packages/swift-optel`'s architecture (checkpoint/event/session/sampling/transport/env) in idiomatic Go, but the intended surface is deliberately narrower: `Enter` and `Error` only — a headless CLI has no UI to click or navigate, so there is no `Click`/`Navigate`/CWV equivalent.
- No third-party dependencies (stdlib only: `net/http`, `math/rand/v2`, `regexp`, `crypto/rand`). Consumed by `slicc-cli` via a local `replace` directive in `go.mod` (this monorepo has no `go.work`, so cross-module deps are wired per-module).
- Privacy/security is the load-bearing design constraint, not a nicety: Go's `net/http`/`net/url` errors embed the full request URL in `Error()` — `slicc-cli` dials a leader's `https://…/join/<token>` URL, so a raw dial-error string is a bearer-token leak, not just a PII nit. OS file errors likewise embed the user's home directory. `sanitize.go`'s `Sanitize()` is the only sanctioned path from an `error.Error()` string to a beacon field, and `Client.ReportError` is the only sanctioned caller — redaction (URL → `scheme://host/...`, path → first segment/drive letter) happens **before** the 200-char truncation, so a partial token can't survive truncation ordering.
- Sampling is one coin flip per process (weight 100, decided once inside `Configure`), not per event — matching how the webapp/swift-optel decide once per pageview/session.
- Gating: `SLICC_NO_TELEMETRY=1` opts out outright; telemetry only configures on stamped release builds (`update.IsReleaseVersion`, same gate the update notifier uses), so local/dev builds never phone home even without the env var.
- `main.go` uses the same `defer f()()` idiom already used for `startUpdateNotice()`: `initTelemetry(sub)` runs immediately (configuring the client + firing `Enter`), and only the returned bounded-flush closure is deferred.

## Cross-cutting impact

- **Floats exercised**: `slicc-cli` only. No changes to the webapp, extension, Electron, or Sliccstart floats.
- **Other callers checked**: `reportRuntimeError` is net-new and only called from the specific error sites added in this PR (`commands.go` dial errors, `update.go` fetch/apply errors, `commands.go` watch/follow retry-loop errors) — no existing call sites changed shape.
- **Security**: see "Approach" above — this PR's central concern is precisely the bearer-token/home-directory leak vector, and `sanitize_test.go` has explicit regression tests for both (`TestSanitizeRedactsJoinURLToken`, `TestSanitizeCollapsesPosixPath`/`...WindowsPath`, plus an order-of-operations test proving redaction happens before truncation).
- **CI**: added a dedicated `go-optel` job (path-filtered), extended `slicc-cli`'s path filter to also trigger on `go-optel` changes (it's a build dependency via local `replace`), and added `go-optel` to the final `ci` gate's `needs` list.

## Test plan

This is a Go-only change (`packages/go-optel`, `packages/slicc-cli`); the npm-workspace checklist items below don't apply.

- [ ] `npx prettier --write <changed-files>` — N/A, no TS/JS files changed
- [ ] `npm run typecheck` — N/A
- [ ] `npm run test` — N/A
- [ ] `npm run build` — N/A
- [ ] `npm run build -w @slicc/chrome-extension` — N/A
- [x] **New / changed behavior is covered by a unit test**, Go equivalent: verified locally with a freshly installed Go 1.26 toolchain + golangci-lint 2.12.2 (pinned to match CI, neither was available in this environment beforehand):
  - `packages/go-optel`: `go build ./...`, `go vet ./...`, `golangci-lint run` → 0 issues, `go test ./...` → all pass, `make check` → 88.4% coverage (floor 80%).
  - `packages/slicc-cli`: `go build ./...`, `go vet ./...`, `golangci-lint run` → 0 issues, `go test ./...` → all pass (including new `telemetry_test.go`: subcommand classification, opt-out/release-gating logic, nil-safety, hermetic client configuration with zero real network calls), `make check` → 61.5% coverage (floor 58%).
  - `go.mod`/`go.sum` tidy-check passes for both modules; no stray `go.sum` entry needed for the local `replace` dependency.
- [ ] Manual smoke (CLI) — not run; covered by the automated Go suite above plus manual code review of the beacon shape against `packages/swift-optel`'s wire format.
- [ ] Manual smoke (extension / Electron / Sliccstart / worker) — N/A, not touched
- [ ] **UI change?** — N/A, no UI changes
- [x] N/A — explained above

**Pre-existing failures**: none observed; both Go modules build/vet/lint/test cleanly from a fresh toolchain install.

## Documentation

- [ ] `README.md` — N/A, no top-level user-facing behavior change (opt-out env var is documented in `packages/go-optel/README.md` and `docs/operational-telemetry.md` instead)
- [x] Relevant `CLAUDE.md` — added `packages/go-optel/CLAUDE.md` (new package) and updated `packages/slicc-cli/CLAUDE.md` (new "Telemetry" section + layout table row)
- [x] `docs/` — updated `docs/operational-telemetry.md`: fixed the scoop-lifecycle drift, added a new "CLI Telemetry" section, updated the checkpoint mapping table, wiring status, deploy-impact table, and the `slicc-cli` gap subsection
- [ ] `packages/vfs-root/shared/CLAUDE.md` or workspace skills — N/A, no agent-facing shell command changes
- [ ] No documentation changes needed

## Risk & rollback

- Blast radius if this regresses: `slicc-cli` only, and narrowly — worst case is a beacon firing with an unexpected field or the sampling/gating logic misbehaving (e.g. telemetry firing on a dev build). No persisted state, no data migration.
- Kill switch: `SLICC_NO_TELEMETRY=1` disables it outright without a code change; non-release builds are already silent by construction.
- Rollback: revert this PR cleanly — it's additive (new package + new file + a handful of call sites), no schema/migration to undo.
- Nothing here requires real network access to verify; `go-optel`'s and `slicc-cli`'s test suites are both hermetic (no real HTTP calls), so CI failures should be fully reproducible locally.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff (incl. logs, fixtures, `.env*`, snapshots) — reviewed diff for these patterns before committing
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [ ] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths — N/A, `slicc-cli`'s telemetry client is entirely local to that binary and touches no shared wire protocol
