### PR TITLE
fix(webapp): infer cost for Adobe proxy models unknown to pi-ai

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -1082,7 +1082,15 @@ When Anthropic ships a new Claude model that isn't in the pinned pi-ai:
    testable) and is wired as a fallback strictly below any reported cost in
    both `buildAdobeModel` and `getProviderModels`'s unknown-model branch.
    Verify the inherited costs are reasonable. Once pi-ai is bumped, the real
-   costs take over.
+   costs take over. **Cross-provider guard:** the `getProviderModels` branch is
+   shared by _every_ provider that defines `getModelIds` (github, openrouter,
+   xai-grok, cerebras, local-llm, azure-openai, …), so inheritance is gated to
+   Anthropic-API-routed models (`pm.api !== 'openai'`). Adobe's Claude models
+   are anthropic-routed and still inherit; OpenAI-routed providers keep
+   `buildProviderRoutedModel`'s $0 default even for a Claude-style id — this
+   stops a local or free model literally named like a Claude family id (e.g. a
+   `local-llm` model called `claude-sonnet-6`) from inheriting real Anthropic
+   pricing. Reported cost (layer 2/3) still wins over the fallback either way.
 
 ## Thinking effort pipeline
 

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -1054,7 +1054,12 @@ When Anthropic ships a new Claude model that isn't in the pinned pi-ai:
    metadata and features silently break (thinking off, cost counter $0.00).
    Fields to check: `reasoning`, `input`, `cost`. See
    `providers/adobe.ts:getModelIds` and
-   `src/providers/adobe-model-metadata.ts:enrichAdobeModel`.
+   `src/providers/adobe-model-metadata.ts:enrichAdobeModel`. The forwarded
+   `cost` only sticks if `applyModelMetadata` (`src/providers/account-store.ts`)
+   has a branch that layers it onto both `model.cost` (the object pi-ai's
+   `calculateCost()` reads) and the flat `inputCost`/`outputCost`/`cacheReadCost`/
+   `cacheWriteCost` mirrors — without it a proxy-reported price is silently
+   discarded and the counter still reads $0.00.
 
 3. **Verify `parseClaudeVersion` handles the new ID format.** pi-ai may use
    IDs without a minor version (e.g. `claude-sonnet-5` instead of
@@ -1072,9 +1077,12 @@ When Anthropic ships a new Claude model that isn't in the pinned pi-ai:
    pattern as the Sonnet 5 and Haiku compat workarounds).
 
 5. **Verify `findFamilyCost`.** For models pi-ai doesn't know, this inherits
-   costs from the closest known model in the same family. Verify the
-   inherited costs are reasonable. Once pi-ai is bumped, the real costs
-   take over.
+   costs from the closest known model in the same family. It now lives in
+   `src/providers/family-cost.ts` (extracted from `adobe.ts` so it is unit-
+   testable) and is wired as a fallback strictly below any reported cost in
+   both `buildAdobeModel` and `getProviderModels`'s unknown-model branch.
+   Verify the inherited costs are reasonable. Once pi-ai is bumped, the real
+   costs take over.
 
 ## Thinking effort pipeline
 

--- a/docs/review-patterns.md
+++ b/docs/review-patterns.md
@@ -150,6 +150,12 @@ is denied.
   predicates (`claude-model-version.ts`).
 - Changes to `buildAdobeModel`, `enrichAdobeModel`, or `getModelIds` that add or rename
   model fields without checking all three are in sync.
+- Changes to the shared cost-fallback path (`findFamilyCost` in
+  `src/providers/family-cost.ts`, the `getProviderModels` unknown-model branch, or the
+  `applyModelMetadata` cost branch in `account-store.ts`) — these run for every provider with
+  `getModelIds`, not just Adobe. `findFamilyCost` inheritance is gated to Anthropic-API-routed
+  models (`pm.api !== 'openai'`) so OpenAI-routed providers (local-llm, azure-openai) don't
+  inherit Anthropic pricing for a Claude-style id; check that guard survives refactors.
 - A pi-ai bump that adds new models — check if the new model's `thinkingLevelMap`, `cost`,
   and `reasoning` are correct. Also check for breaking API changes (e.g. function signature
   changes like `buildBaseOptions`).

--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -47,7 +47,7 @@ import {
   enrichAdobeModel,
 } from '../src/providers/adobe-model-metadata.js';
 import { buildAdobeOAuthState } from '../src/providers/adobe-oauth-state.js';
-import { parseClaudeVersion } from '../src/providers/claude-model-version.js';
+import { findFamilyCost } from '../src/providers/family-cost.js';
 import { getOAuthPageOrigin } from '../src/providers/oauth-service.js';
 import { createSilentRenewBackoff } from '../src/providers/silent-renew-backoff.js';
 import { withSupportedTemperature } from '../src/providers/temperature-support.js';
@@ -992,26 +992,6 @@ function buildPiAiModelMap(): Map<string, Model<Api>> {
 }
 
 /** Construct an Adobe-tagged Model from a proxy entry, reusing pi-ai metadata when present. */
-/**
- * Find the closest known model in the same family to inherit costs from.
- * Searches for e.g. "sonnet-4-6" when the proxy returns "sonnet-5-0" that
- * pi-ai doesn't know yet. Returns the cost object or a zero fallback.
- */
-function findFamilyCost(modelId: string, modelMap: Map<string, Model<Api>>): Model<Api>['cost'] {
-  const zeroCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
-  const target = parseClaudeVersion(modelId);
-  if (!target) return zeroCost;
-  let best: { major: number; minor: number; cost: Model<Api>['cost'] } | undefined;
-  for (const m of modelMap.values()) {
-    const v = parseClaudeVersion(m.id);
-    if (!v || v.family !== target.family) continue;
-    if (!best || v.major > best.major || (v.major === best.major && v.minor > best.minor)) {
-      best = { major: v.major, minor: v.minor, cost: m.cost };
-    }
-  }
-  return best?.cost ?? zeroCost;
-}
-
 function buildAdobeModel(
   pm: RawProxyModel,
   endpoint: string,

--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -393,12 +393,20 @@ export function getProviderModels(providerId: string): Model<Api>[] {
           // pi-ai's registry doesn't know yet (e.g. claude-opus-5) still prices
           // instead of degrading to $0. Mirror buildAdobeModel(): set both the
           // cost object pi-ai's calculateCost() reads and the flat mirrors.
-          const familyCost = findFamilyCost(pm.id, modelMap);
-          model.cost = familyCost;
-          model.inputCost = familyCost.input;
-          model.outputCost = familyCost.output;
-          model.cacheReadCost = familyCost.cacheRead;
-          model.cacheWriteCost = familyCost.cacheWrite;
+          // Gate on the Anthropic API route: family-cost inheritance is
+          // Claude-specific and only meaningful for models billed through
+          // Anthropic's API (e.g. the Adobe proxy). OpenAI-routed providers
+          // (local-llm, azure-openai) may expose Claude-style IDs for local or
+          // free models, so they keep the synthesized $0 default instead of
+          // inheriting real Anthropic pricing.
+          if (apiType === 'anthropic') {
+            const familyCost = findFamilyCost(pm.id, modelMap);
+            model.cost = familyCost;
+            model.inputCost = familyCost.input;
+            model.outputCost = familyCost.output;
+            model.cacheReadCost = familyCost.cacheRead;
+            model.cacheWriteCost = familyCost.cacheWrite;
+          }
         }
 
         // Apply modelOverrides (layer 2) then getModelIds metadata (layer 3).

--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -282,6 +282,7 @@ function applyModelMetadata(
     max_tokens?: number;
     reasoning?: boolean;
     input?: string[];
+    cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
     compat?: CompatOverrides;
     thinkingLevelMap?: Record<string, string | null>;
   }
@@ -290,6 +291,18 @@ function applyModelMetadata(
   if (metadata.max_tokens !== undefined) model.maxTokens = metadata.max_tokens;
   if (metadata.reasoning !== undefined) model.reasoning = metadata.reasoning;
   if (metadata.input !== undefined) model.input = metadata.input;
+  // pi-ai's calculateCost() prices usage from model.cost (the object), so a
+  // provider's getModelIds() (layer 3) can report pricing for a model pi-ai's
+  // registry doesn't know — otherwise it inherits buildProviderRoutedModel()'s
+  // $0 default. Set both the cost object pi-ai reads and the flat mirrors
+  // buildAdobeModel() emits so the two model-construction paths stay aligned.
+  if (metadata.cost !== undefined) {
+    model.cost = metadata.cost;
+    model.inputCost = metadata.cost.input;
+    model.outputCost = metadata.cost.output;
+    model.cacheReadCost = metadata.cost.cacheRead;
+    model.cacheWriteCost = metadata.cost.cacheWrite;
+  }
   // Merge compat onto whatever pi-ai's base model already declared (or any
   // compat from a prior modelOverrides layer). Each successive layer can
   // override individual flags without clobbering siblings. Cast to a generic

--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -22,6 +22,7 @@ import { callSecretsBridge } from '../core/secrets-bridge-client.js';
 import { getPanelRpcClient, hasLocalDom } from '../kernel/panel-rpc.js';
 import { apiHeaders, resolveApiUrl } from '../shell/proxied-fetch.js';
 import { bedrockCampRegionFromBaseUrl, isBedrockCampCompatible } from './built-in/bedrock-camp.js';
+import { findFamilyCost } from './family-cost.js';
 import {
   getRegisteredProviderConfig,
   getRegisteredProviderIds,
@@ -385,6 +386,19 @@ export function getProviderModels(providerId: string): Model<Api>[] {
             unknown
           >;
           if (pm.name) model.name = pm.name; // proxy display name; else keep the id
+          // Fallback strictly BELOW an explicitly reported cost (applied via
+          // applyModelMetadata from modelOverrides/getModelIds just below) but
+          // above buildProviderRoutedModel's $0 default: inherit pricing from
+          // the closest known model in the same Claude family so a proxy model
+          // pi-ai's registry doesn't know yet (e.g. claude-opus-5) still prices
+          // instead of degrading to $0. Mirror buildAdobeModel(): set both the
+          // cost object pi-ai's calculateCost() reads and the flat mirrors.
+          const familyCost = findFamilyCost(pm.id, modelMap);
+          model.cost = familyCost;
+          model.inputCost = familyCost.input;
+          model.outputCost = familyCost.output;
+          model.cacheReadCost = familyCost.cacheRead;
+          model.cacheWriteCost = familyCost.cacheWrite;
         }
 
         // Apply modelOverrides (layer 2) then getModelIds metadata (layer 3).

--- a/packages/webapp/src/providers/family-cost.ts
+++ b/packages/webapp/src/providers/family-cost.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure family-cost inheritance helper.
+ *
+ * Extracted from `providers/adobe.ts:findFamilyCost()` so it has zero DOM /
+ * `chrome` / `import.meta.glob` dependencies and can be unit-tested directly
+ * (adobe.ts itself cannot be imported under vitest). It depends only on
+ * `parseClaudeVersion` from `claude-model-version.ts`, following the same
+ * extraction pattern as `adobe-model-metadata.ts`.
+ *
+ * When a proxy reports a Claude model pi-ai's registry doesn't know yet (e.g.
+ * `claude-opus-5`), the synthesized model would otherwise price at $0. This
+ * helper inherits pricing from the highest known version in the same Claude
+ * family so the session cost counter degrades gracefully instead of to zero.
+ * Both `buildAdobeModel()` (adobe.ts) and `getProviderModels()`'s unknown-model
+ * branch (account-store.ts) route through it to keep the two model-construction
+ * paths aligned.
+ */
+
+import { parseClaudeVersion } from './claude-model-version.js';
+
+/** Per-token cost structure (values in $ per million tokens); matches pi-ai's `ModelCostRates`. */
+export interface FamilyCost {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+/**
+ * Find the closest known model in the same Claude family to inherit costs from.
+ * Searches for e.g. `opus-4-8` when the proxy returns `opus-5-0` that pi-ai
+ * doesn't know yet, picking the highest known version in the family. Returns a
+ * zero-cost fallback when the id is non-Claude or no family member is known.
+ */
+export function findFamilyCost<T extends { id: string; cost: FamilyCost }>(
+  modelId: string,
+  modelMap: Map<string, T>
+): FamilyCost {
+  const zeroCost: FamilyCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  const target = parseClaudeVersion(modelId);
+  if (!target) return zeroCost;
+  let best: { major: number; minor: number; cost: FamilyCost } | undefined;
+  for (const m of modelMap.values()) {
+    const v = parseClaudeVersion(m.id);
+    if (!v || v.family !== target.family) continue;
+    if (!best || v.major > best.major || (v.major === best.major && v.minor > best.minor)) {
+      best = { major: v.major, minor: v.minor, cost: m.cost };
+    }
+  }
+  return best?.cost ?? zeroCost;
+}

--- a/packages/webapp/src/providers/types.ts
+++ b/packages/webapp/src/providers/types.ts
@@ -184,6 +184,15 @@ export interface ModelMetadata {
   /** Supported input modalities (e.g., ['text', 'image']). */
   input?: string[];
   /**
+   * Per-token pricing in US dollars per million tokens; matches pi-ai's
+   * `Model.cost`. Providers whose `getModelIds()` reports pricing for models
+   * pi-ai's registry doesn't know yet (e.g. Adobe's `claude-opus-5`) set this
+   * so the resolved model prices correctly instead of inheriting the $0
+   * default synthesized by `buildProviderRoutedModel()`. Merged as a whole
+   * object over the base model's cost by applyModelMetadata().
+   */
+  cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
+  /**
    * Per-model API compatibility overrides; matches pi-ai's `Model.compat`
    * field. Used to opt models out of provider features the upstream backend
    * rejects — e.g. Adobe sets `{ supportsEagerToolInputStreaming: false }`

--- a/packages/webapp/tests/providers/family-cost.test.ts
+++ b/packages/webapp/tests/providers/family-cost.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit coverage for the pure family-cost inheritance helper.
+ *
+ * This is the fallback `getProviderModels()` (account-store.ts) and
+ * `buildAdobeModel()` (adobe.ts) run for a proxy-reported Claude model that
+ * pi-ai's registry doesn't know yet. It is extracted into
+ * `src/providers/family-cost.ts` (no DOM / chrome / import.meta.glob deps) so
+ * it can be tested against the real implementation rather than a mirror —
+ * unlike adobe.ts itself.
+ */
+import { describe, expect, it } from 'vitest';
+import { type FamilyCost, findFamilyCost } from '../../src/providers/family-cost.js';
+
+type KnownModel = { id: string; cost: FamilyCost };
+
+const zero: FamilyCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+function mapOf(models: KnownModel[]): Map<string, KnownModel> {
+  return new Map(models.map((m) => [m.id, m]));
+}
+
+describe('findFamilyCost', () => {
+  it('inherits pricing from a known model in the same family', () => {
+    const opusCost: FamilyCost = { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 };
+    const map = mapOf([
+      { id: 'claude-opus-4-8', cost: opusCost },
+      { id: 'claude-sonnet-4-6', cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 } },
+    ]);
+    // opus-5 unknown to pi-ai → inherit the opus family's cost.
+    expect(findFamilyCost('claude-opus-5', map)).toEqual(opusCost);
+  });
+
+  it('returns zeros when no model in the family is known', () => {
+    const map = mapOf([
+      { id: 'claude-sonnet-4-6', cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 } },
+    ]);
+    // No opus in the map → nothing to inherit from.
+    expect(findFamilyCost('claude-opus-5', map)).toEqual(zero);
+  });
+
+  it('picks the highest known version in the family', () => {
+    const highCost: FamilyCost = { input: 9, output: 45, cacheRead: 0.9, cacheWrite: 11.25 };
+    const map = mapOf([
+      { id: 'claude-opus-4-6', cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 } },
+      { id: 'claude-opus-4-8', cost: highCost },
+      { id: 'claude-opus-4-7', cost: { input: 4, output: 8, cacheRead: 0, cacheWrite: 0 } },
+    ]);
+    // opus-5 inherits from the highest known opus (4.8), not the first seen.
+    expect(findFamilyCost('claude-opus-5', map)).toEqual(highCost);
+  });
+
+  it('compares minor versions when the major matches', () => {
+    const map = mapOf([
+      { id: 'claude-sonnet-4-5', cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 } },
+      { id: 'claude-sonnet-4-6', cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 } },
+    ]);
+    expect(findFamilyCost('claude-sonnet-4-9', map)).toEqual({
+      input: 3,
+      output: 15,
+      cacheRead: 0.3,
+      cacheWrite: 3.75,
+    });
+  });
+
+  it('returns zeros for a non-Claude model id', () => {
+    const map = mapOf([
+      { id: 'claude-opus-4-8', cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 } },
+    ]);
+    expect(findFamilyCost('gpt-5', map)).toEqual(zero);
+  });
+
+  it('returns zeros for an empty model map', () => {
+    expect(findFamilyCost('claude-opus-5', mapOf([]))).toEqual(zero);
+  });
+});

--- a/packages/webapp/tests/ui/provider-settings.test.ts
+++ b/packages/webapp/tests/ui/provider-settings.test.ts
@@ -1920,6 +1920,89 @@ describe('model metadata overrides', () => {
     expect(models[0].contextWindow).toBe(1000000);
   });
 
+  it('propagates cost from getModelIds for a model id unknown to pi-ai (fixes $0 pricing)', () => {
+    // Regression: an Adobe-style proxy reports pricing for a model pi-ai's
+    // registry doesn't know (e.g. claude-opus-5). Without a cost branch in
+    // applyModelMetadata the synthesized model kept buildProviderRoutedModel's
+    // $0 default and the session cost counter read $0. pi-ai's calculateCost()
+    // prices usage from model.cost, so the object must survive resolution.
+    const providerConfigs = new Map(
+      mockGetRegisteredProviderIds().map((id: string) => [id, mockGetRegisteredProviderConfig(id)])
+    );
+    providerConfigs.set('test-proxy', {
+      id: 'test-proxy',
+      name: 'Test Proxy',
+      description: '',
+      requiresApiKey: false,
+      requiresBaseUrl: false,
+      getModelIds: () => [
+        {
+          id: 'claude-opus-5',
+          name: 'Claude Opus 5',
+          cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+        },
+      ],
+    });
+    mockGetRegisteredProviderConfig.mockImplementation((id: string) => providerConfigs.get(id));
+
+    const models = getProviderModels('test-proxy');
+    expect(models).toHaveLength(1);
+    const model = models[0] as unknown as Record<string, unknown>;
+    expect(model.cost).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 });
+    // Flat mirrors match the shape buildAdobeModel() emits.
+    expect(model.inputCost).toBe(5);
+    expect(model.outputCost).toBe(25);
+    expect(model.cacheReadCost).toBe(0.5);
+    expect(model.cacheWriteCost).toBe(6.25);
+  });
+
+  it('leaves cost at the synthesized zero default when getModelIds reports none', () => {
+    const providerConfigs = new Map(
+      mockGetRegisteredProviderIds().map((id: string) => [id, mockGetRegisteredProviderConfig(id)])
+    );
+    providerConfigs.set('test-proxy', {
+      id: 'test-proxy',
+      name: 'Test Proxy',
+      description: '',
+      requiresApiKey: false,
+      requiresBaseUrl: false,
+      getModelIds: () => [{ id: 'claude-opus-5', name: 'Claude Opus 5' }],
+    });
+    mockGetRegisteredProviderConfig.mockImplementation((id: string) => providerConfigs.get(id));
+
+    const models = getProviderModels('test-proxy');
+    const model = models[0] as unknown as Record<string, unknown>;
+    expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+  });
+
+  it('getModelIds cost takes priority over modelOverrides cost (layer 3 > layer 2)', () => {
+    const providerConfigs = new Map(
+      mockGetRegisteredProviderIds().map((id: string) => [id, mockGetRegisteredProviderConfig(id)])
+    );
+    providerConfigs.set('test-proxy', {
+      id: 'test-proxy',
+      name: 'Test Proxy',
+      description: '',
+      requiresApiKey: false,
+      requiresBaseUrl: false,
+      modelOverrides: {
+        'claude-opus-5': { cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 } },
+      },
+      getModelIds: () => [
+        {
+          id: 'claude-opus-5',
+          name: 'Claude Opus 5',
+          cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+        },
+      ],
+    });
+    mockGetRegisteredProviderConfig.mockImplementation((id: string) => providerConfigs.get(id));
+
+    const models = getProviderModels('test-proxy');
+    const model = models[0] as unknown as Record<string, unknown>;
+    expect(model.cost).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 });
+  });
+
   it('compat from modelOverrides and getModelIds merges across the three layers', () => {
     // Verifies applyModelMetadata's merge behavior: each successive layer
     // (pi-ai base → modelOverrides → getModelIds) can override individual

--- a/packages/webapp/tests/ui/provider-settings.test.ts
+++ b/packages/webapp/tests/ui/provider-settings.test.ts
@@ -2003,6 +2003,72 @@ describe('model metadata overrides', () => {
     expect(model.cost).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 });
   });
 
+  it('cost precedence: reported cost > family-inherited cost > zeros', () => {
+    // Wave 2: a proxy reports two Claude models pi-ai's registry doesn't know.
+    // A known opus in the same family carries pricing, so the unknown-model
+    // branch inherits it as a fallback — unless getModelIds reports a cost,
+    // which must win. The chain proves reported > family-inherited > zeros.
+    const knownOpusCost = { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 };
+    const reportedCost = { input: 9, output: 45, cacheRead: 0.9, cacheWrite: 11.25 };
+    mockGetModels.mockImplementation(((providerId: string) => {
+      if (providerId === 'anthropic') {
+        return [
+          {
+            id: 'claude-opus-4-8',
+            name: 'Claude Opus 4.8',
+            contextWindow: 200000,
+            maxTokens: 16384,
+            reasoning: true,
+            cost: knownOpusCost,
+          },
+        ];
+      }
+      return [];
+    }) as unknown as (providerId: string) => { id: string; name: string; reasoning: boolean }[]);
+
+    const providerConfigs = new Map(
+      mockGetRegisteredProviderIds().map((id: string) => [id, mockGetRegisteredProviderConfig(id)])
+    );
+    providerConfigs.set('test-proxy', {
+      id: 'test-proxy',
+      name: 'Test Proxy',
+      description: '',
+      requiresApiKey: false,
+      requiresBaseUrl: false,
+      getModelIds: () => [
+        // Unknown opus WITHOUT a cost → inherits the known opus family cost.
+        { id: 'claude-opus-5', name: 'Claude Opus 5' },
+        // Unknown opus WITH a reported cost → reported wins over the family.
+        { id: 'claude-opus-5-1', name: 'Claude Opus 5.1', cost: reportedCost },
+        // Non-Claude unknown model → no family to inherit → stays at zeros.
+        { id: 'mystery-1', name: 'Mystery 1' },
+      ],
+    });
+    mockGetRegisteredProviderConfig.mockImplementation((id: string) => providerConfigs.get(id));
+
+    const models = getProviderModels('test-proxy');
+    const inherited = models.find((m) => m.id === 'claude-opus-5') as unknown as Record<
+      string,
+      unknown
+    >;
+    const reported = models.find((m) => m.id === 'claude-opus-5-1') as unknown as Record<
+      string,
+      unknown
+    >;
+    const mystery = models.find((m) => m.id === 'mystery-1') as unknown as Record<string, unknown>;
+
+    // Family-inherited cost (no reported cost) — object + flat mirrors.
+    expect(inherited.cost).toEqual(knownOpusCost);
+    expect(inherited.inputCost).toBe(5);
+    expect(inherited.outputCost).toBe(25);
+    // Reported cost wins over the family-inherited fallback.
+    expect(reported.cost).toEqual(reportedCost);
+    expect(reported.inputCost).toBe(9);
+    expect(reported.outputCost).toBe(45);
+    // No family match and no reported cost → zeros.
+    expect(mystery.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+  });
+
   it('compat from modelOverrides and getModelIds merges across the three layers', () => {
     // Verifies applyModelMetadata's merge behavior: each successive layer
     // (pi-ai base → modelOverrides → getModelIds) can override individual

--- a/packages/webapp/tests/ui/provider-settings.test.ts
+++ b/packages/webapp/tests/ui/provider-settings.test.ts
@@ -2069,6 +2069,55 @@ describe('model metadata overrides', () => {
     expect(mystery.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
   });
 
+  it('does not inherit Claude family cost for OpenAI-routed models (local-llm/azure)', () => {
+    // Regression for the Codex P2 finding: a local-llm or azure-openai account
+    // can expose a Claude-style id (e.g. claude-sonnet-6) that pi-ai's registry
+    // doesn't know. Those models route through the OpenAI API (api: 'openai')
+    // and run on the user's own/free server, so they must NOT inherit real
+    // Anthropic pricing from the global model map — they keep the $0 default.
+    const knownOpusCost = { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 };
+    mockGetModels.mockImplementation(((providerId: string) => {
+      if (providerId === 'anthropic') {
+        return [
+          {
+            id: 'claude-opus-4-8',
+            name: 'Claude Opus 4.8',
+            contextWindow: 200000,
+            maxTokens: 16384,
+            reasoning: true,
+            cost: knownOpusCost,
+          },
+        ];
+      }
+      return [];
+    }) as unknown as (providerId: string) => { id: string; name: string; reasoning: boolean }[]);
+
+    const providerConfigs = new Map(
+      mockGetRegisteredProviderIds().map((id: string) => [id, mockGetRegisteredProviderConfig(id)])
+    );
+    providerConfigs.set('test-proxy', {
+      id: 'test-proxy',
+      name: 'Test Proxy',
+      description: '',
+      requiresApiKey: false,
+      requiresBaseUrl: false,
+      getModelIds: () => [
+        // OpenAI-routed unknown Claude-family id → must stay at the $0 default.
+        { id: 'claude-opus-5', name: 'Claude Opus 5', api: 'openai' as const },
+      ],
+    });
+    mockGetRegisteredProviderConfig.mockImplementation((id: string) => providerConfigs.get(id));
+
+    const models = getProviderModels('test-proxy');
+    const model = models.find((m) => m.id === 'claude-opus-5') as unknown as Record<
+      string,
+      unknown
+    >;
+    // Must NOT have inherited the known Anthropic opus pricing.
+    expect(model.cost).not.toEqual(knownOpusCost);
+    expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+  });
+
   it('compat from modelOverrides and getModelIds merges across the three layers', () => {
     // Verifies applyModelMetadata's merge behavior: each successive layer
     // (pi-ai base → modelOverrides → getModelIds) can override individual


### PR DESCRIPTION
## Symptom

On `claude-opus-5` (an Adobe-proxy model pi-ai's registry doesn't know yet), the
session cost counter read **$0.00** across 87 turns / 4.07M tokens, while
`claude-opus-4-8` on the same proxy correctly reported **$1.63**. The Adobe proxy
*does* report pricing for the unknown model, so the counter should not have been
zero.

## Root cause

`applyModelMetadata()` in `src/providers/account-store.ts` forwarded
`reasoning`, `input`, `compat`, and `thinkingLevelMap` from the proxy's
`getModelIds()` metadata — but had **no `cost` branch**. pi-ai's
`calculateCost()` prices usage from `model.cost` (the object), so any
proxy-reported pricing was silently discarded and the model fell back to
`buildProviderRoutedModel()`'s $0 default.

## Fix

Two waves:

- **Wave 1** — added an optional `cost` field to `ModelMetadata`
  (`src/providers/types.ts`) and a branch in `applyModelMetadata()` that layers
  `model.cost` (the object pi-ai actually reads) plus the flat
  `inputCost`/`outputCost`/`cacheReadCost`/`cacheWriteCost` mirrors, keeping the
  two model-construction paths aligned.
- **Wave 2** — extracted `findFamilyCost` out of `providers/adobe.ts` into a
  DOM-free, unit-testable `src/providers/family-cost.ts` and wired it as a
  fallback in `getProviderModels()`'s unknown-model branch. For a model pi-ai
  doesn't know, it inherits pricing from the highest known version in the same
  Claude family instead of degrading to $0.

### Precedence chain

1. **Reported cost** — `getModelIds()` (layer 3) over `modelOverrides` (layer 2),
   applied via `applyModelMetadata`.
2. **Family-inherited cost** — `findFamilyCost` fallback, strictly below any
   reported cost but above the default.
3. **Zeros** — `buildProviderRoutedModel()` default when the id is non-Claude or
   no family member is known.

## Tests added

- `tests/providers/family-cost.test.ts` — 6 tests for `findFamilyCost`
  (family match, highest-version selection, non-Claude and unknown-family
  zero fallbacks).
- `tests/ui/provider-settings.test.ts` — 3 tests for the `applyModelMetadata`
  cost branch and 1 test for the `getProviderModels` family-fallback wiring.

## Verification

All gates pass on the branch:

- `npm run lint` — ok
- `npm run typecheck` — ok
- `npm run test:coverage:webapp` — ok (above floors)
- `npm run build` — ok
- `node packages/dev-tools/tools/check-touched-exemptions.mjs` — ok (0 on debt lists)
- `packages/dev-tools/tools/check-linear-history.sh` — ok (linear, no merge commits)
