### PR TITLE
fix(sw): authorize proxy config publishers

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -593,9 +593,9 @@ chrome.runtime.onConnect.addListener((port) => {
 
 See `packages/chrome-extension/src/fetch-proxy-shared.ts:handleFetchProxyConnectionAsync` for the production pattern. Regression test: `packages/chrome-extension/tests/fetch-proxy-shared.test.ts` — "handleFetchProxyConnectionAsync — synchronous listener attach".
 
-### Service-worker configuration messages require a top-level window source
+### Service-worker proxy configuration requires a top-level window source
 
-Treat service-worker `message` payload validation and sender authorization as separate checks. A worker or nested/auxiliary window can construct the same `bridge-config` or `extension-delegate` payload as the leader, so the listener must also require `event.source.type === 'window'` and `frameType === 'top-level'` before updating proxy configuration. Keep this gate aligned with the sync-fs channel-nonce gate in `llm-proxy-sw-config.ts`.
+Treat service-worker payload validation and client authorization as separate checks. A worker or nested/auxiliary window can publish `bridge-config` / `extension-delegate` messages or encode equivalent parameters in its URL, so both message handling and URL fallback/delegate selection must require `type === 'window'` and `frameType === 'top-level'`. Keep this gate aligned with the sync-fs channel-nonce gate in `llm-proxy-sw-config.ts`.
 
 ## Hosted Leader Tab Cannot Reach `chrome.storage`
 

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -593,6 +593,10 @@ chrome.runtime.onConnect.addListener((port) => {
 
 See `packages/chrome-extension/src/fetch-proxy-shared.ts:handleFetchProxyConnectionAsync` for the production pattern. Regression test: `packages/chrome-extension/tests/fetch-proxy-shared.test.ts` — "handleFetchProxyConnectionAsync — synchronous listener attach".
 
+### Service-worker configuration messages require a top-level window source
+
+Treat service-worker `message` payload validation and sender authorization as separate checks. A worker or nested/auxiliary window can construct the same `bridge-config` or `extension-delegate` payload as the leader, so the listener must also require `event.source.type === 'window'` and `frameType === 'top-level'` before updating proxy configuration. Keep this gate aligned with the sync-fs channel-nonce gate in `llm-proxy-sw-config.ts`.
+
 ## Hosted Leader Tab Cannot Reach `chrome.storage`
 
 **The Problem**

--- a/packages/webapp/src/ui/llm-proxy-sw-config.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw-config.ts
@@ -462,6 +462,11 @@ export function maySetProxyConfig(source: unknown): boolean {
   return maySetSyncFsNonce(source);
 }
 
+/** Remove clients that must not supply proxy URL fallbacks or receive delegated fetches. */
+export function filterAuthorizedProxyClients<T>(clients: readonly T[]): T[] {
+  return clients.filter(maySetProxyConfig);
+}
+
 /** A one-shot notifier the SW's cold-op path awaits until a nonce (re)arrives. */
 export interface NonceWaiter {
   /** Resolve every pending `wait()` — called when a nonce is registered. */

--- a/packages/webapp/src/ui/llm-proxy-sw-config.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw-config.ts
@@ -457,6 +457,11 @@ export function maySetSyncFsNonce(source: unknown): boolean {
   return c?.type === 'window' && c.frameType === 'top-level';
 }
 
+/** Only the top-level leader page may publish bridge or extension-delegate config. */
+export function maySetProxyConfig(source: unknown): boolean {
+  return maySetSyncFsNonce(source);
+}
+
 /** A one-shot notifier the SW's cold-op path awaits until a nonce (re)arrives. */
 export interface NonceWaiter {
   /** Resolve every pending `wait()` — called when a nonce is registered. */

--- a/packages/webapp/src/ui/llm-proxy-sw.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw.ts
@@ -52,6 +52,7 @@ import {
   createNonceWaiter,
   ExtensionDelegateCache,
   type ExtensionFetchDelegateRequest,
+  filterAuthorizedProxyClients,
   isBridgeConfigMessage,
   isBridgeLocalApiUrl,
   isExtensionDelegateMessage,
@@ -409,7 +410,7 @@ async function readClientUrl(clientId: string | null): Promise<string | null> {
   if (!clientId) return null;
   try {
     const client = await self.clients.get(clientId);
-    return client?.url ?? null;
+    return filterAuthorizedProxyClients(client ? [client] : [])[0]?.url ?? null;
   } catch {
     return null;
   }
@@ -428,7 +429,9 @@ async function readWindowClientUrls(): Promise<string[]> {
       type: 'window',
       includeUncontrolled: true,
     });
-    return clients.map((c) => c.url).filter((u): u is string => !!u);
+    return filterAuthorizedProxyClients(clients)
+      .map((c) => c.url)
+      .filter((u): u is string => !!u);
   } catch {
     return [];
   }
@@ -442,7 +445,9 @@ async function readWindowClientUrls(): Promise<string[]> {
  */
 async function pickDelegateWindowClient(): Promise<Client | null> {
   try {
-    const clients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    const clients = filterAuthorizedProxyClients(
+      await self.clients.matchAll({ type: 'window', includeUncontrolled: true })
+    );
     if (clients.length === 0) return null;
     const leader = clients.find((c) => parseExtensionDelegateFromClientUrl(c.url) !== null);
     return leader ?? clients[0];

--- a/packages/webapp/src/ui/llm-proxy-sw.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw.ts
@@ -56,6 +56,7 @@ import {
   isBridgeLocalApiUrl,
   isExtensionDelegateMessage,
   isPassthroughDestination,
+  maySetProxyConfig,
   maySetSyncFsNonce,
   parseExtensionDelegateFromClientUrl,
   type ResolvedExtensionDelegate,
@@ -141,14 +142,14 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
   // clients, so a non-Client sender is either an unrelated message or
   // a future channel we haven't wired up yet.
   if (!source || !('id' in source) || typeof source.id !== 'string') return;
-  if (isBridgeConfigMessage(event.data)) {
+  if (isBridgeConfigMessage(event.data) && maySetProxyConfig(source)) {
     bridgeConfigCache.set(source.id, {
       apiBaseUrl: event.data.apiBaseUrl,
       token: event.data.token,
     });
     return;
   }
-  if (isExtensionDelegateMessage(event.data)) {
+  if (isExtensionDelegateMessage(event.data) && maySetProxyConfig(source)) {
     extensionDelegateCache.set(source.id, { extensionId: event.data.extensionId });
     return;
   }

--- a/packages/webapp/tests/ui/llm-proxy-sw-config.test.ts
+++ b/packages/webapp/tests/ui/llm-proxy-sw-config.test.ts
@@ -15,6 +15,7 @@ import {
   BridgeConfigCache,
   createNonceWaiter,
   ExtensionDelegateCache,
+  filterAuthorizedProxyClients,
   isBridgeConfigMessage,
   isBridgeFetchProxyUrl,
   isBridgeLocalApiUrl,
@@ -547,6 +548,18 @@ describe('maySetProxyConfig (bridge-config security gate)', () => {
     expect(maySetProxyConfig({ type: 'window', frameType: 'nested', id: 'sprinkle' })).toBe(false);
     expect(maySetProxyConfig({ type: 'window', frameType: 'auxiliary', id: 'popup' })).toBe(false);
     expect(maySetProxyConfig(null)).toBe(false);
+  });
+
+  it('filters URL fallbacks and delegate candidates to top-level windows', () => {
+    const leader = { type: 'window', frameType: 'top-level', url: 'https://leader.test/' };
+    const clients = [
+      leader,
+      { type: 'window', frameType: 'nested', url: 'https://nested.test/?bridge=evil' },
+      { type: 'window', frameType: 'auxiliary', url: 'https://popup.test/?ext=evil' },
+      { type: 'worker', frameType: 'none', url: 'https://worker.test/' },
+    ];
+
+    expect(filterAuthorizedProxyClients(clients)).toEqual([leader]);
   });
 });
 

--- a/packages/webapp/tests/ui/llm-proxy-sw-config.test.ts
+++ b/packages/webapp/tests/ui/llm-proxy-sw-config.test.ts
@@ -21,6 +21,7 @@ import {
   isExtensionDelegateMessage,
   isExtensionFetchDelegateRequest,
   isPassthroughDestination,
+  maySetProxyConfig,
   maySetSyncFsNonce,
   parseExtensionDelegateFromClientUrl,
   resolveBridgeConfig,
@@ -536,6 +537,16 @@ describe('maySetSyncFsNonce (sync-fs channel-nonce security gate)', () => {
     expect(maySetSyncFsNonce(undefined)).toBe(false);
     expect(maySetSyncFsNonce({ id: 'x' })).toBe(false); // no type
     expect(maySetSyncFsNonce({ type: 'window' })).toBe(false); // no frameType
+  });
+});
+
+describe('maySetProxyConfig (bridge-config security gate)', () => {
+  it('accepts only the top-level leader window', () => {
+    expect(maySetProxyConfig({ type: 'window', frameType: 'top-level', id: 'leader' })).toBe(true);
+    expect(maySetProxyConfig({ type: 'worker', id: 'realm' })).toBe(false);
+    expect(maySetProxyConfig({ type: 'window', frameType: 'nested', id: 'sprinkle' })).toBe(false);
+    expect(maySetProxyConfig({ type: 'window', frameType: 'auxiliary', id: 'popup' })).toBe(false);
+    expect(maySetProxyConfig(null)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #1522.

**Solution**
Only top-level window clients may publish bridge or extension-delegate configuration; worker fetches retain the existing top-level URL fallback.

**Testing**
Traced both bootstrap publishers and verified the service-worker config regression suite.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KYM7TWC02G52BMPTZEZZXS77&panel=chat)