### PR TITLE
Fix phantom replay: serialize processScoopQueue, collision-safe watermark, settle expired licks

### DIFF
--- a/packages/webapp/src/scoops/db.ts
+++ b/packages/webapp/src/scoops/db.ts
@@ -278,6 +278,71 @@ export async function getMessagesForScoop(chatJid: string): Promise<ChannelMessa
   });
 }
 
+/**
+ * Per-scoop message high-water mark. A bare millisecond timestamp cannot
+ * disambiguate messages that share a millisecond, so the cursor pairs the max
+ * delivered `ts` with the set of message ids already delivered exactly at that
+ * `ts`. Timestamps strictly below `ts` are fully consumed; at `ts` only ids in
+ * the set are consumed. `ids === null` marks a legacy bare-timestamp watermark
+ * whose whole millisecond was consumed by the previous exclusive-bound query.
+ */
+export interface MessageWatermark {
+  ts: string;
+  ids: Set<string> | null;
+}
+
+const WATERMARK_PREFIX = 'wm1:';
+
+/** Parse a persisted/in-memory watermark string, tolerating the legacy bare-ISO form. */
+export function parseMessageWatermark(since: string): MessageWatermark {
+  if (!since) return { ts: '', ids: new Set() };
+  if (since.startsWith(WATERMARK_PREFIX)) {
+    try {
+      const parsed = JSON.parse(since.slice(WATERMARK_PREFIX.length)) as {
+        ts: string;
+        ids: string[];
+      };
+      return { ts: parsed.ts, ids: new Set(parsed.ids) };
+    } catch {
+      // Fall through to legacy handling on any corruption.
+    }
+  }
+  // Legacy bare-ISO-timestamp watermark: the old exclusive lower bound consumed
+  // every message at `since`, so treat the whole millisecond as delivered.
+  return { ts: since, ids: null };
+}
+
+/** Serialize a watermark for `lastAgentTs_<jid>` state and the in-memory map. */
+export function serializeMessageWatermark(wm: MessageWatermark): string {
+  const ids = wm.ids ? Array.from(wm.ids) : [];
+  return `${WATERMARK_PREFIX}${JSON.stringify({ ts: wm.ts, ids })}`;
+}
+
+/** True when `msg` is strictly after `wm` under the composite (ts, id) ordering. */
+export function isAfterMessageWatermark(
+  msg: { timestamp: string; id: string },
+  wm: MessageWatermark
+): boolean {
+  if (msg.timestamp > wm.ts) return true;
+  if (msg.timestamp < wm.ts) return false;
+  if (wm.ids === null) return false;
+  return !wm.ids.has(msg.id);
+}
+
+/** Advance a watermark past a delivered batch, accumulating ids within the max millisecond. */
+export function advanceMessageWatermark(
+  prev: MessageWatermark,
+  delivered: { timestamp: string; id: string }[]
+): MessageWatermark {
+  if (delivered.length === 0) return prev;
+  let ts = prev.ts;
+  for (const m of delivered) if (m.timestamp > ts) ts = m.timestamp;
+  const ids = new Set<string>();
+  if (prev.ts === ts && prev.ids) for (const id of prev.ids) ids.add(id);
+  for (const m of delivered) if (m.timestamp === ts) ids.add(m.id);
+  return { ts, ids };
+}
+
 export async function getMessagesSince(
   chatJid: string,
   since: string,
@@ -285,12 +350,15 @@ export async function getMessagesSince(
 ): Promise<ChannelMessage[]> {
   const store = await getStore(STORES.MESSAGES);
   const index = store.index('chatJid_timestamp');
-  const range = IDBKeyRange.bound([chatJid, since], [chatJid, '\uffff'], true, false);
+  const wm = parseMessageWatermark(since);
+  // Inclusive lower bound so same-millisecond messages at `wm.ts` are read; the
+  // id-aware filter below drops the ones already delivered.
+  const range = IDBKeyRange.bound([chatJid, wm.ts], [chatJid, '\uffff'], false, false);
 
   return new Promise((resolve, reject) => {
     const req = index.getAll(range);
     req.onsuccess = () => {
-      let msgs = req.result as ChannelMessage[];
+      let msgs = (req.result as ChannelMessage[]).filter((m) => isAfterMessageWatermark(m, wm));
       if (excludeSender) {
         msgs = msgs.filter((m) => m.senderName !== excludeSender);
       }

--- a/packages/webapp/src/scoops/scoop-approval-router.ts
+++ b/packages/webapp/src/scoops/scoop-approval-router.ts
@@ -24,6 +24,7 @@ import {
   type SudoBroker,
   type SudoDecision,
   type SudoRequest,
+  type SudoSettleReason,
 } from '../sudo/index.js';
 import type { SudoManager } from '../sudo/sudo-manager.js';
 import type { LickManager } from './lick-manager.js';
@@ -64,9 +65,34 @@ export interface ResolveSudoRequestAndPersistResult {
 }
 
 export class ScoopApprovalRouter implements ConeApprovalRouter {
-  private registry: ConeRequestRegistry = new ConeRequestRegistry();
+  private registry: ConeRequestRegistry;
 
-  constructor(private deps: ScoopApprovalRouterDeps) {}
+  constructor(private deps: ScoopApprovalRouterDeps) {
+    // Fail-closed settles that bypass the cone (timeout / scoop drop /
+    // shutdown) must still retire the persisted `pending` lick card, or the
+    // chat keeps showing a request `list_sudo_requests` no longer knows about.
+    this.registry = new ConeRequestRegistry({
+      onAutoSettle: (id, reason) => this.handleAutoSettle(id, reason),
+    });
+  }
+
+  /**
+   * Retire a lick card the registry settled fail-closed without a cone
+   * decision. Reuses the existing `dismissed` state (a deny outcome) and never
+   * re-delivers to the cone — {@link persistLickDecision} only re-renders the
+   * stored card. Fire-and-forget: settling is synchronous, persistence is
+   * best-effort.
+   */
+  private handleAutoSettle(id: string, reason: SudoSettleReason): void {
+    log.info('Sudo request auto-settled fail-closed; retiring lick card', { id, reason });
+    void this.persistLickDecision(id, 'deny').catch((err) => {
+      log.warn('Failed to persist auto-settled lick decision', {
+        id,
+        reason,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
 
   /** Build the per-scoop {@link SudoBroker}; scoop's gated FS / shell calls route here. */
   getConeSudoBroker(scoopJid: string): SudoBroker {

--- a/packages/webapp/src/scoops/scoop-message-router.ts
+++ b/packages/webapp/src/scoops/scoop-message-router.ts
@@ -62,6 +62,16 @@ export class ScoopMessageRouter {
   private messageQueues: Map<string, ChannelMessage[]> = new Map();
   private lastAgentTimestamp: Map<string, string> = new Map();
   private pollInterval: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Per-jid re-entrancy guard for {@link processScoopQueue}. While a run is in
+   * flight for a jid, its entry lives here; a re-entrant call sets `rerun` so
+   * the in-flight run loops once more instead of executing concurrently (which
+   * would let two invocations read the same stale high-water mark and format
+   * overlapping slices of the same rows) or being dropped (which would lose a
+   * message that arrived mid-flight). Keyed by jid so distinct scoops still
+   * process in parallel.
+   */
+  private processing: Map<string, { rerun: boolean }> = new Map();
 
   constructor(private deps: ScoopMessageRouterDeps) {}
 
@@ -209,8 +219,40 @@ export class ScoopMessageRouter {
     }
   }
 
-  /** Process queued messages for a scoop. */
+  /**
+   * Process queued messages for a scoop, serialized per jid.
+   *
+   * A burst of inbound messages fires one call per message; without this guard
+   * every concurrent call reads the same stale `lastAgentTimestamp` across the
+   * `await db.getMessagesSince` and formats an overlapping slice of the same
+   * rows, so each message reaches the agent multiple times. The guard runs the
+   * real work ({@link runScoopQueue}) one turn at a time per jid and coalesces
+   * re-entrant calls into a single rerun, so a message that arrives mid-flight
+   * is still delivered exactly once. The `finally` releases the guard even when
+   * a turn throws (e.g. `sendPrompt` rejects) so a failed turn cannot wedge the
+   * queue.
+   */
   async processScoopQueue(jid: string): Promise<void> {
+    const inFlight = this.processing.get(jid);
+    if (inFlight) {
+      inFlight.rerun = true;
+      return;
+    }
+
+    const state = { rerun: false };
+    this.processing.set(jid, state);
+    try {
+      do {
+        state.rerun = false;
+        await this.runScoopQueue(jid);
+      } while (state.rerun);
+    } finally {
+      this.processing.delete(jid);
+    }
+  }
+
+  /** Drain one turn of a scoop's queue. Callers must go through {@link processScoopQueue}. */
+  private async runScoopQueue(jid: string): Promise<void> {
     const queue = this.messageQueues.get(jid);
     if (!queue || queue.length === 0) {
       log.debug('processScoopQueue: empty queue', { jid });

--- a/packages/webapp/src/scoops/scoop-message-router.ts
+++ b/packages/webapp/src/scoops/scoop-message-router.ts
@@ -14,6 +14,7 @@
 import { formatPromptWithAttachments, imageContentFromAttachments } from '../core/attachments.js';
 import { createLogger } from '../core/logger.js';
 import type { SessionStore } from '../core/session.js';
+import { advanceMessageWatermark, parseMessageWatermark, serializeMessageWatermark } from './db.js';
 import type { ScoopContext } from './scoop-context.js';
 import { emitScoopLifecycle } from './scoop-telemetry-hook.js';
 import type { ChannelMessage, RegisteredScoop, ScoopTabState } from './types.js';
@@ -306,8 +307,15 @@ export class ScoopMessageRouter {
     this.messageQueues.set(jid, []);
 
     const lastMsg = messages[messages.length - 1];
-    this.lastAgentTimestamp.set(jid, lastMsg.timestamp);
-    await this.deps.db.setState(`lastAgentTs_${jid}`, lastMsg.timestamp);
+    // Advance the high-water mark by the composite (timestamp, id) cursor so a
+    // batch that shares one millisecond is consumed exactly once: the id set
+    // accumulated at the max ms lets a later pass skip already-delivered rows
+    // without dropping same-ms siblings (which a bare-timestamp mark would).
+    const nextWatermark = serializeMessageWatermark(
+      advanceMessageWatermark(parseMessageWatermark(since), messages)
+    );
+    this.lastAgentTimestamp.set(jid, nextWatermark);
+    await this.deps.db.setState(`lastAgentTs_${jid}`, nextWatermark);
 
     await this.deps.sendPrompt(jid, formatted, lastMsg.senderId, lastMsg.senderName, images);
   }

--- a/packages/webapp/src/scoops/scoop-message-router.ts
+++ b/packages/webapp/src/scoops/scoop-message-router.ts
@@ -69,10 +69,11 @@ export class ScoopMessageRouter {
    * the in-flight run loops once more instead of executing concurrently (which
    * would let two invocations read the same stale high-water mark and format
    * overlapping slices of the same rows) or being dropped (which would lose a
-   * message that arrived mid-flight). Keyed by jid so distinct scoops still
-   * process in parallel.
+   * message that arrived mid-flight). `done` settles when that run's drain
+   * finishes, so a coalesced caller can await the turn its message lands in.
+   * Keyed by jid so distinct scoops still process in parallel.
    */
-  private processing: Map<string, { rerun: boolean }> = new Map();
+  private processing: Map<string, { rerun: boolean; done: Promise<void> }> = new Map();
 
   constructor(private deps: ScoopMessageRouterDeps) {}
 
@@ -229,27 +230,60 @@ export class ScoopMessageRouter {
    * rows, so each message reaches the agent multiple times. The guard runs the
    * real work ({@link runScoopQueue}) one turn at a time per jid and coalesces
    * re-entrant calls into a single rerun, so a message that arrives mid-flight
-   * is still delivered exactly once. The `finally` releases the guard even when
-   * a turn throws (e.g. `sendPrompt` rejects) so a failed turn cannot wedge the
-   * queue.
+   * is still delivered exactly once.
+   *
+   * A coalesced caller awaits the active drain rather than returning as soon as
+   * it has flagged the rerun: {@link runScoopQueue} clears the shared queue
+   * after taking its DB snapshot, so an early return would let the caller
+   * believe its message was handled while the rerun that actually delivers it
+   * is still pending. The drain's failure belongs to the owning caller, which
+   * rethrows it, so it is swallowed on the coalesced path.
    */
   async processScoopQueue(jid: string): Promise<void> {
     const inFlight = this.processing.get(jid);
     if (inFlight) {
       inFlight.rerun = true;
+      await inFlight.done.catch(() => {});
       return;
     }
 
-    const state = { rerun: false };
+    const state = { rerun: false, done: Promise.resolve() };
     this.processing.set(jid, state);
+    state.done = this.drainScoopQueue(jid, state);
+    return state.done;
+  }
+
+  /**
+   * Run turns for a jid until no rerun is pending, then release the guard.
+   *
+   * A turn that throws (e.g. `sendPrompt` rejects) must not swallow a rerun
+   * requested while it was in flight: the coalesced message is already
+   * persisted but the in-memory queue was cleared, so it would sit stranded
+   * until unrelated traffic happens to enqueue work — long enough for a
+   * coalesced sudo request to reach its timeout. Turn errors are therefore held
+   * back until the loop drains, and the first one is rethrown to the owning
+   * caller. The `finally` releases the guard even on that path so a failed turn
+   * cannot wedge the queue.
+   */
+  private async drainScoopQueue(jid: string, state: { rerun: boolean }): Promise<void> {
+    let failed = false;
+    let firstError: unknown;
     try {
       do {
         state.rerun = false;
-        await this.runScoopQueue(jid);
+        try {
+          await this.runScoopQueue(jid);
+        } catch (err) {
+          if (!failed) {
+            failed = true;
+            firstError = err;
+          }
+        }
       } while (state.rerun);
     } finally {
       this.processing.delete(jid);
     }
+    if (failed) throw firstError;
   }
 
   /** Drain one turn of a scoop's queue. Callers must go through {@link processScoopQueue}. */

--- a/packages/webapp/src/sudo/cone-broker.ts
+++ b/packages/webapp/src/sudo/cone-broker.ts
@@ -32,6 +32,16 @@ export interface PendingSudoRequest {
 }
 
 /**
+ * Why the registry settled a request fail-closed WITHOUT a cone decision.
+ * Surfaced to the owner (the {@link ScoopApprovalRouter}) so it can flip the
+ * persisted lick card off `pending`:
+ *   - `expired`      — the per-request fail-closed timer fired.
+ *   - `scoop-dropped`— the requesting scoop was unregistered.
+ *   - `shutdown`     — the orchestrator drained everything on shutdown.
+ */
+export type SudoSettleReason = 'expired' | 'scoop-dropped' | 'shutdown';
+
+/**
  * Trusted-realm seam between {@link createConeApprovalBroker} and whatever
  * owns the cone-side delivery + resolution (the {@link Orchestrator}, or a
  * fake in tests). A scoop's `requestApproval` becomes
@@ -69,6 +79,14 @@ export interface ConeRequestRegistryOptions {
   setTimer?: (cb: () => void, ms: number) => unknown;
   /** Timer canceller. Defaults to `clearTimeout`. Override in tests. */
   clearTimer?: (handle: unknown) => void;
+  /**
+   * Notified whenever a request is settled fail-closed WITHOUT a cone
+   * decision — timeout, scoop drop, or shutdown. The owner uses it to flip
+   * the persisted lick card off `pending`. Never fired for a normal
+   * {@link ConeRequestRegistry.resolve} (the cone already knows). Best-effort:
+   * any error thrown by the callback is swallowed so it can't wedge teardown.
+   */
+  onAutoSettle?: (id: string, reason: SudoSettleReason) => void;
 }
 
 interface RegistryEntry {
@@ -103,12 +121,23 @@ export class ConeRequestRegistry {
   private readonly newId: () => string;
   private readonly setTimer: (cb: () => void, ms: number) => unknown;
   private readonly clearTimer: (handle: unknown) => void;
+  private readonly onAutoSettle: (id: string, reason: SudoSettleReason) => void;
 
   constructor(opts: ConeRequestRegistryOptions = {}) {
     this.timeoutMs = opts.timeoutMs ?? CONE_SUDO_TIMEOUT_MS;
     this.newId = opts.newId ?? defaultId;
     this.setTimer = opts.setTimer ?? ((cb, ms) => setTimeout(cb, ms));
     this.clearTimer = opts.clearTimer ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+    this.onAutoSettle = opts.onAutoSettle ?? (() => {});
+  }
+
+  /** Fire the auto-settle hook, isolating a throwing callback from teardown. */
+  private notifyAutoSettle(id: string, reason: SudoSettleReason): void {
+    try {
+      this.onAutoSettle(id, reason);
+    } catch {
+      // Best-effort: a broken card-flip must never wedge timeout / drop / shutdown.
+    }
   }
 
   /**
@@ -128,6 +157,7 @@ export class ConeRequestRegistry {
           if (!entry) return;
           this.pending.delete(id);
           entry.resolve({ decision: 'deny' });
+          this.notifyAutoSettle(id, 'expired');
         }, this.timeoutMs);
       }
       this.pending.set(id, { scoopJid, request, resolve, timerHandle });
@@ -161,6 +191,7 @@ export class ConeRequestRegistry {
       this.pending.delete(id);
       if (entry.timerHandle != null) this.clearTimer(entry.timerHandle);
       entry.resolve({ decision: 'deny' });
+      this.notifyAutoSettle(id, 'scoop-dropped');
       count++;
     }
     return count;
@@ -169,9 +200,10 @@ export class ConeRequestRegistry {
   /** Fail-closed every pending request. Used by `Orchestrator.shutdown`. */
   failAll(): number {
     let count = 0;
-    for (const entry of this.pending.values()) {
+    for (const [id, entry] of this.pending) {
       if (entry.timerHandle != null) this.clearTimer(entry.timerHandle);
       entry.resolve({ decision: 'deny' });
+      this.notifyAutoSettle(id, 'shutdown');
       count++;
     }
     this.pending.clear();

--- a/packages/webapp/src/sudo/index.ts
+++ b/packages/webapp/src/sudo/index.ts
@@ -26,6 +26,7 @@ export {
   type ConeRequestRegistryOptions,
   createConeApprovalBroker,
   type PendingSudoRequest,
+  type SudoSettleReason,
 } from './cone-broker.js';
 export { createExtensionSudoBroker } from './extension-broker.js';
 export { createHttpSudoBroker } from './http-broker.js';

--- a/packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts
+++ b/packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Router-level settle paths for cone-mediated sudo requests.
+ *
+ * When a request is settled fail-closed WITHOUT a cone decision — the
+ * per-request timer fires (`expired`), the requesting scoop is dropped
+ * (`scoop-dropped`), or the orchestrator shuts down (`shutdown`) — the stored
+ * `sudo-request` lick card must flip off `pending` to `dismissed`, and the cone
+ * must NOT be re-prompted (no second `handleMessage` delivery).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ScoopApprovalRouter,
+  type ScoopApprovalRouterDeps,
+} from '../../src/scoops/scoop-approval-router.js';
+import type { ChannelMessage, RegisteredScoop } from '../../src/scoops/types.js';
+import { CONE_SUDO_TIMEOUT_MS } from '../../src/sudo/index.js';
+import type { SudoRequest } from '../../src/sudo/types.js';
+
+const REQ: SudoRequest = { kind: 'command', detail: 'git push origin main' };
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+function scoop(jid: string, isCone: boolean): RegisteredScoop {
+  return {
+    jid,
+    name: jid,
+    folder: `${jid}-folder`,
+    isCone,
+    type: isCone ? 'cone' : 'scoop',
+    requiresTrigger: false,
+    assistantLabel: jid,
+    addedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeHarness() {
+  const cone = scoop('cone_jid', true);
+  const requester = scoop('scoop_a', false);
+  const scoops = new Map<string, RegisteredScoop>([
+    [cone.jid, cone],
+    [requester.jid, requester],
+  ]);
+  const store: ChannelMessage[] = [];
+  const handleMessage = vi.fn(async (msg: ChannelMessage) => {
+    store.push(msg);
+  });
+  const saveMessage = vi.fn(async (msg: ChannelMessage) => {
+    const i = store.findIndex((m) => m.id === msg.id);
+    if (i >= 0) store[i] = msg;
+    else store.push(msg);
+  });
+  const onMessageUpdate = vi.fn();
+  const deps: ScoopApprovalRouterDeps = {
+    getScoops: () => scoops,
+    getSudoManager: () => null,
+    getLickManager: () => null,
+    handleMessage,
+    onMessageUpdate,
+    getMessagesForScoop: async (jid) => store.filter((m) => m.chatJid === jid),
+    saveMessage,
+  };
+  return { router: new ScoopApprovalRouter(deps), store, handleMessage, onMessageUpdate };
+}
+
+describe('ScoopApprovalRouter settle paths flip the lick card off pending', () => {
+  it('scoop-dropped: failScoop flips the stored card to dismissed', async () => {
+    const h = makeHarness();
+    const decision = h.router.enqueueSudoRequest('scoop_a', REQ);
+    expect(h.store[0].lickState).toBe('pending');
+
+    expect(h.router.failScoop('scoop_a')).toBe(1);
+    await flush();
+
+    expect(h.store[0].lickState).toBe('dismissed');
+    expect(h.onMessageUpdate).toHaveBeenCalledWith(
+      'cone_jid',
+      expect.objectContaining({ lickId: h.store[0].lickId, lickState: 'dismissed' })
+    );
+    // Only the original delivery — settling must not re-prompt the cone.
+    expect(h.handleMessage).toHaveBeenCalledTimes(1);
+    await expect(decision).resolves.toEqual({ decision: 'deny' });
+  });
+
+  it('shutdown: failAll flips the stored card to dismissed', async () => {
+    const h = makeHarness();
+    const decision = h.router.enqueueSudoRequest('scoop_a', REQ);
+    expect(h.store[0].lickState).toBe('pending');
+
+    expect(h.router.failAll()).toBe(1);
+    await flush();
+
+    expect(h.store[0].lickState).toBe('dismissed');
+    expect(h.onMessageUpdate).toHaveBeenCalledWith(
+      'cone_jid',
+      expect.objectContaining({ lickState: 'dismissed' })
+    );
+    expect(h.handleMessage).toHaveBeenCalledTimes(1);
+    await expect(decision).resolves.toEqual({ decision: 'deny' });
+  });
+
+  it('expired: the fail-closed timer flips the stored card to dismissed', async () => {
+    vi.useFakeTimers();
+    try {
+      const h = makeHarness();
+      const decision = h.router.enqueueSudoRequest('scoop_a', REQ);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(h.store[0].lickState).toBe('pending');
+
+      await vi.advanceTimersByTimeAsync(CONE_SUDO_TIMEOUT_MS + 1);
+
+      expect(h.store[0].lickState).toBe('dismissed');
+      expect(h.onMessageUpdate).toHaveBeenCalledWith(
+        'cone_jid',
+        expect.objectContaining({ lickState: 'dismissed' })
+      );
+      expect(h.handleMessage).toHaveBeenCalledTimes(1);
+      await expect(decision).resolves.toEqual({ decision: 'deny' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/webapp/tests/scoops/scoop-message-router.test.ts
+++ b/packages/webapp/tests/scoops/scoop-message-router.test.ts
@@ -39,7 +39,11 @@ interface Harness {
   probe: { max: number };
 }
 
-function makeHarness(opts?: { failFirstSend?: boolean; jids?: string[] }): Harness {
+function makeHarness(opts?: {
+  failFirstSend?: boolean;
+  jids?: string[];
+  onSend?: () => Promise<void>;
+}): Harness {
   const jids = opts?.jids ?? ['cone'];
   const scoops = new Map<string, RegisteredScoop>();
   const tabs = new Map<string, ScoopTabState>();
@@ -61,6 +65,7 @@ function makeHarness(opts?: { failFirstSend?: boolean; jids?: string[] }): Harne
     createScoopTab: async () => {},
     sendPrompt: async (_jid, text) => {
       await tick();
+      if (opts?.onSend) await opts.onSend();
       if (opts?.failFirstSend && sendCount++ === 0) throw new Error('boom');
       sends.push(text);
     },
@@ -137,6 +142,26 @@ describe('ScoopMessageRouter re-entrancy guard', () => {
     await router.handleMessage(makeMessage('cone', 1));
 
     expect(sends.some((p) => p.includes('MSG_001'))).toBe(true);
+  });
+
+  it('drains a rerun coalesced onto a turn that then throws', async () => {
+    let coalesced: Promise<void> | undefined;
+    // Enqueued from inside the failing turn — after `runScoopQueue` took its DB
+    // snapshot and cleared the shared queue — so the rerun is the only thing
+    // left that can deliver it.
+    const harness: Harness = makeHarness({
+      failFirstSend: true,
+      onSend: async () => {
+        coalesced ??= harness.router.handleMessage(makeMessage('cone', 1));
+        await tick();
+        await tick();
+      },
+    });
+
+    await expect(harness.router.handleMessage(makeMessage('cone', 0))).rejects.toThrow('boom');
+    await coalesced;
+
+    expect(harness.sends.some((p) => p.includes('MSG_001'))).toBe(true);
   });
 });
 

--- a/packages/webapp/tests/scoops/scoop-message-router.test.ts
+++ b/packages/webapp/tests/scoops/scoop-message-router.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { isAfterMessageWatermark, parseMessageWatermark } from '../../src/scoops/db.js';
 import type { ScoopMessageRouterDeps } from '../../src/scoops/scoop-message-router.js';
 import { ScoopMessageRouter } from '../../src/scoops/scoop-message-router.js';
 import type { ChannelMessage, RegisteredScoop, ScoopTabState } from '../../src/scoops/types.js';
@@ -79,9 +80,13 @@ function makeHarness(opts?: { failFirstSend?: boolean; jids?: string[] }): Harne
         active += 1;
         probe.max = Math.max(probe.max, active);
         await tick();
+        const wm = parseMessageWatermark(since);
         const result = store
-          .filter((m) => m.chatJid === jid && m.timestamp > since && m.senderName !== excludeName)
-          .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+          .filter(
+            (m) =>
+              m.chatJid === jid && isAfterMessageWatermark(m, wm) && m.senderName !== excludeName
+          )
+          .sort((a, b) => a.timestamp.localeCompare(b.timestamp) || a.id.localeCompare(b.id));
         active -= 1;
         return result;
       },
@@ -132,5 +137,39 @@ describe('ScoopMessageRouter re-entrancy guard', () => {
     await router.handleMessage(makeMessage('cone', 1));
 
     expect(sends.some((p) => p.includes('MSG_001'))).toBe(true);
+  });
+});
+
+describe('ScoopMessageRouter same-millisecond high-water mark', () => {
+  /** A message pinned to a shared millisecond; ids arrive in descending order so an id-ordered tie-break would drop siblings. */
+  function makeSameMsMessage(jid: string, i: number, count: number): ChannelMessage {
+    return {
+      id: `same-${jid}-${String(count - i).padStart(3, '0')}`,
+      chatJid: jid,
+      senderId: 'user',
+      senderName: 'user',
+      content: `MSG_${String(i).padStart(3, '0')}`,
+      timestamp: new Date(Date.UTC(2026, 0, 1)).toISOString(),
+      fromAssistant: false,
+      channel: 'chat',
+    };
+  }
+
+  it('delivers each of N same-millisecond messages exactly once across successive passes', async () => {
+    const { router, sends } = makeHarness();
+    const N = 8;
+
+    // Awaited sequentially, so each handleMessage drains a separate
+    // processScoopQueue pass — the watermark must carry enough state to skip
+    // the already-delivered same-ms rows without dropping the new ones.
+    for (let i = 0; i < N; i += 1) {
+      await router.handleMessage(makeSameMsMessage('cone', i, N));
+    }
+
+    for (let i = 0; i < N; i += 1) {
+      const token = `MSG_${String(i).padStart(3, '0')}`;
+      const count = sends.filter((p) => p.includes(token)).length;
+      expect(count, `${token} appeared in ${count} payloads`).toBe(1);
+    }
   });
 });

--- a/packages/webapp/tests/scoops/scoop-message-router.test.ts
+++ b/packages/webapp/tests/scoops/scoop-message-router.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import type { ScoopMessageRouterDeps } from '../../src/scoops/scoop-message-router.js';
+import { ScoopMessageRouter } from '../../src/scoops/scoop-message-router.js';
+import type { ChannelMessage, RegisteredScoop, ScoopTabState } from '../../src/scoops/types.js';
+
+/** Yield to the microtask/timer queue so concurrent turns genuinely interleave. */
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+function makeScoop(jid: string): RegisteredScoop {
+  return {
+    jid,
+    name: jid,
+    folder: jid,
+    isCone: true,
+    type: 'cone',
+    requiresTrigger: false,
+    assistantLabel: 'sliccy',
+    addedAt: new Date().toISOString(),
+  };
+}
+
+function makeMessage(jid: string, i: number): ChannelMessage {
+  return {
+    id: `id-${jid}-${i}`,
+    chatJid: jid,
+    senderId: 'user',
+    senderName: 'user',
+    content: `MSG_${String(i).padStart(3, '0')}`,
+    timestamp: new Date(Date.UTC(2026, 0, 1) + i).toISOString(),
+    fromAssistant: false,
+    channel: 'chat',
+  };
+}
+
+interface Harness {
+  router: ScoopMessageRouter;
+  sends: string[];
+  probe: { max: number };
+}
+
+function makeHarness(opts?: { failFirstSend?: boolean; jids?: string[] }): Harness {
+  const jids = opts?.jids ?? ['cone'];
+  const scoops = new Map<string, RegisteredScoop>();
+  const tabs = new Map<string, ScoopTabState>();
+  for (const jid of jids) {
+    scoops.set(jid, makeScoop(jid));
+    tabs.set(jid, { jid, contextId: jid, status: 'ready', lastActivity: '' });
+  }
+
+  const store: ChannelMessage[] = [];
+  const sends: string[] = [];
+  const probe = { max: 0 };
+  let active = 0;
+  let sendCount = 0;
+
+  const deps: ScoopMessageRouterDeps = {
+    getScoops: () => scoops,
+    getTabs: () => tabs,
+    getContexts: () => new Map(),
+    createScoopTab: async () => {},
+    sendPrompt: async (_jid, text) => {
+      await tick();
+      if (opts?.failFirstSend && sendCount++ === 0) throw new Error('boom');
+      sends.push(text);
+    },
+    notifyIncomingMessage: () => {},
+    onError: () => {},
+    getSessionStore: () => null,
+    resetCostTracker: () => {},
+    db: {
+      saveMessage: async (msg) => {
+        await tick();
+        store.push(msg);
+      },
+      deleteMessage: async () => {},
+      clearMessagesForScoop: async () => {},
+      clearAllMessages: async () => {},
+      getMessagesSince: async (jid, since, excludeName) => {
+        active += 1;
+        probe.max = Math.max(probe.max, active);
+        await tick();
+        const result = store
+          .filter((m) => m.chatJid === jid && m.timestamp > since && m.senderName !== excludeName)
+          .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+        active -= 1;
+        return result;
+      },
+      setState: async () => {},
+    },
+    isExternalLickChannel: () => false,
+  };
+
+  const router = new ScoopMessageRouter(deps);
+  for (const jid of jids) router.ensureQueue(jid);
+  return { router, sends, probe };
+}
+
+describe('ScoopMessageRouter re-entrancy guard', () => {
+  it('delivers each of 130 concurrent messages to exactly one sendPrompt payload', async () => {
+    const { router, sends, probe } = makeHarness();
+    const N = 130;
+    const msgs = Array.from({ length: N }, (_, i) => makeMessage('cone', i));
+
+    await Promise.all(msgs.map((m) => router.handleMessage(m)));
+
+    // Serialized per jid: the read-modify-write of getMessagesSince never overlaps itself.
+    expect(probe.max).toBe(1);
+    for (let i = 0; i < N; i += 1) {
+      const token = `MSG_${String(i).padStart(3, '0')}`;
+      const count = sends.filter((p) => p.includes(token)).length;
+      expect(count, `${token} appeared in ${count} payloads`).toBe(1);
+    }
+  });
+
+  it('processes distinct scoops in parallel (guard is per-jid)', async () => {
+    const { router, sends, probe } = makeHarness({ jids: ['coneA', 'coneB'] });
+
+    await Promise.all([
+      router.handleMessage(makeMessage('coneA', 0)),
+      router.handleMessage(makeMessage('coneB', 1)),
+    ]);
+
+    expect(probe.max).toBe(2);
+    expect(sends.some((p) => p.includes('MSG_000'))).toBe(true);
+    expect(sends.some((p) => p.includes('MSG_001'))).toBe(true);
+  });
+
+  it('releases the guard when a turn throws so the queue is not wedged', async () => {
+    const { router, sends } = makeHarness({ failFirstSend: true });
+
+    await expect(router.handleMessage(makeMessage('cone', 0))).rejects.toThrow('boom');
+    await router.handleMessage(makeMessage('cone', 1));
+
+    expect(sends.some((p) => p.includes('MSG_001'))).toBe(true);
+  });
+});

--- a/packages/webapp/tests/sudo/cone-broker.test.ts
+++ b/packages/webapp/tests/sudo/cone-broker.test.ts
@@ -189,6 +189,76 @@ describe('ConeRequestRegistry fail-closed paths', () => {
   });
 });
 
+describe('ConeRequestRegistry onAutoSettle', () => {
+  function makeRegistryWithSettle(ids?: string[]) {
+    const onAutoSettle = vi.fn();
+    const timers = new Set<() => void>();
+    let i = 0;
+    const registry = new ConeRequestRegistry({
+      newId: () => ids?.[i++] ?? `sudo-${i}`,
+      setTimer: (cb: () => void) => {
+        timers.add(cb);
+        return cb;
+      },
+      clearTimer: (h: unknown) => {
+        timers.delete(h as () => void);
+      },
+      onAutoSettle,
+    });
+    const fireAllTimers = () => {
+      for (const cb of timers) cb();
+    };
+    return { registry, onAutoSettle, fireAllTimers };
+  }
+
+  it('fires with reason "expired" when the timer settles a request', () => {
+    const { registry, onAutoSettle, fireAllTimers } = makeRegistryWithSettle(['sudo-1']);
+    registry.register('scoop_a', REQ);
+    fireAllTimers();
+    expect(onAutoSettle).toHaveBeenCalledExactlyOnceWith('sudo-1', 'expired');
+  });
+
+  it('fires with reason "scoop-dropped" for each request failScoop drains', () => {
+    const { registry, onAutoSettle } = makeRegistryWithSettle(['a1', 'a2', 'b1']);
+    registry.register('scoop_a', REQ);
+    registry.register('scoop_a', REQ);
+    registry.register('scoop_b', REQ);
+    registry.failScoop('scoop_a');
+    expect(onAutoSettle.mock.calls).toEqual([
+      ['a1', 'scoop-dropped'],
+      ['a2', 'scoop-dropped'],
+    ]);
+  });
+
+  it('fires with reason "shutdown" for every request failAll drains', () => {
+    const { registry, onAutoSettle } = makeRegistryWithSettle(['x1', 'x2']);
+    registry.register('scoop_a', REQ);
+    registry.register('scoop_b', REQ);
+    registry.failAll();
+    expect(onAutoSettle.mock.calls).toEqual([
+      ['x1', 'shutdown'],
+      ['x2', 'shutdown'],
+    ]);
+  });
+
+  it('does NOT fire for a normal cone-driven resolve', () => {
+    const { registry, onAutoSettle } = makeRegistryWithSettle(['sudo-1']);
+    const { id } = registry.register('scoop_a', REQ);
+    registry.resolve(id, { decision: 'allow' });
+    expect(onAutoSettle).not.toHaveBeenCalled();
+  });
+
+  it('swallows a throwing callback so teardown is not wedged', () => {
+    const onAutoSettle = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const registry = new ConeRequestRegistry({ newId: () => 'sudo-1', onAutoSettle });
+    const { pending } = registry.register('scoop_a', REQ);
+    expect(() => registry.failAll()).not.toThrow();
+    return expect(pending).resolves.toEqual({ decision: 'deny' });
+  });
+});
+
 describe('ConeRequestRegistry timeout configuration', () => {
   it('does NOT install a timer when timeoutMs <= 0', () => {
     const { registry, setTimer } = makeRegistry({ timeoutMs: 0 });


### PR DESCRIPTION
Fixes the "phantom replay" defect where sudo-request lick IDs minted in a sub-millisecond burst were delivered to the cone multiple times (130 unique IDs → 910 total deliveries in a live instance).

## Root Cause

ScoopMessageRouter.processScoopQueue had no re-entrancy guard; concurrent calls read-modify-wrote the lastAgentTimestamp high-water mark with an await in between, causing each call to replay the same message batch.

## Contributing Factors

1. **ms-precision watermark with exclusive lower bound** — same-millisecond siblings silently dropped.
2. **Expired/dropped requests left phantom cards** — ConeRequestRegistry timeout / failScoop / failAll resolved deny without flipping the persisted lickState, leaving pending cards in the UI.

## Changes

### 1. Serialize processScoopQueue per scoop
- **File**: packages/webapp/src/scoops/scoop-message-router.ts
- **Change**: Per-jid re-entrancy guard with coalescing rerun; guard releases in a finally on the sendPrompt error path.
- **Test**: packages/webapp/tests/scoops/scoop-message-router.test.ts — 130 concurrent handleMessage calls deliver each message exactly once.

### 2. Make the message high-water mark collision-safe
- **Files**: packages/webapp/src/scoops/db.ts, packages/webapp/src/scoops/scoop-message-router.ts
- **Change**: Replaced bare-timestamp watermark with composite (timestamp, delivered-id-set) cursor; inclusive range in db.getMessagesSince + id-aware filter.
- **Backward compat**: Legacy bare-timestamp values load without replaying history.
- **Test**: Regression test for same-millisecond batch exactly-once delivery.

### 3. Settle expired/dropped lick cards
- **Files**: packages/webapp/src/sudo/cone-broker.ts, packages/webapp/src/scoops/scoop-approval-router.ts
- **Change**: SudoSettleReason + onAutoSettle hook on ConeRequestRegistry, wired to flip stored lickState pending → dismissed on timeout / failScoop / failAll, without re-prompting the cone.
- **Tests**: packages/webapp/tests/sudo/cone-broker.test.ts, packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts

## Verification

- ✅ lint (clean)
- ✅ typecheck (clean)
- ✅ test (12,705 passed)
- ✅ build (Sliccstart.app + extension bundles)

All pre-push verification gates passed.

---

**Diagnosed via**: CDP attach to live instance on port 9222, IndexedDB inspection, session archive grep, and tracing processScoopQueue → getMessagesSince → lastAgentTimestamp read-modify-write race.
