### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -145,9 +145,9 @@
       "regions": 79
     },
     "ios-app": {
-      "lines": 13,
-      "functions": 11,
-      "regions": 14
+      "lines": 17,
+      "functions": 14,
+      "regions": 15
     }
   }
 }


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.