### PR TITLE
fix(webapp): resync git-token bridge on every getValidAccessToken() call

### DIFF
--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -396,6 +396,26 @@ export async function syncGitIdentityFromGitHub(profile: GitHubUserProfile): Pro
 
 const silentRenewBackoff = createSilentRenewBackoff();
 
+/**
+ * Mirror the account store's current masked token into the git-token VFS
+ * bridge file. Called on every `getValidAccessToken()` resolution (not just
+ * renewals) so a token injected out-of-band — e.g. a cone resume's
+ * `coneConfigDelta.upsert.accounts`, applied via the generic
+ * `applyHostedAccounts`/`saveOAuthAccount` path, which never calls
+ * `writeGitToken` itself — still reaches isomorphic-git. Without this, a
+ * fresh long-lived token bypasses the renewal branch entirely (its expiry is
+ * far off) and `/workspace/.git/github-token` keeps serving the token from
+ * before resume.
+ */
+async function syncGitTokenFromAccount(): Promise<void> {
+  const masked = getOAuthAccountInfo('github')?.maskedValue;
+  if (masked) {
+    await writeGitToken(masked);
+  } else {
+    await clearGitToken();
+  }
+}
+
 async function renewGitHubToken(): Promise<string | null> {
   try {
     const account = getGitHubAccount();
@@ -416,12 +436,7 @@ async function renewGitHubToken(): Promise<string | null> {
       userAvatar: account.userAvatar,
     });
 
-    const masked = getOAuthAccountInfo('github')?.maskedValue;
-    if (masked) {
-      await writeGitToken(masked);
-    } else {
-      await clearGitToken();
-    }
+    await syncGitTokenFromAccount();
     return tokenResult.access_token;
   } catch (err) {
     console.warn(
@@ -437,7 +452,10 @@ async function getValidAccessToken(): Promise<string> {
   if (!account?.accessToken) throw new Error('Not logged in to GitHub — please log in first');
 
   const expiresIn = (account.tokenExpiresAt ?? Number.POSITIVE_INFINITY) - Date.now();
-  if (expiresIn > 60000) return account.accessToken;
+  if (expiresIn > 60000) {
+    await syncGitTokenFromAccount();
+    return account.accessToken;
+  }
 
   const newToken = await silentRenewBackoff.run(() => renewGitHubToken());
   if (newToken) return newToken;

--- a/packages/webapp/tests/providers/github-token-renewal.test.ts
+++ b/packages/webapp/tests/providers/github-token-renewal.test.ts
@@ -200,4 +200,32 @@ describe('GitHub token renewal', () => {
 
     await expect(getValidAccessToken()).resolves.toBe('ghp_new_access');
   });
+
+  it('resyncs the git-token bridge to a fresh long-lived account without renewing', async () => {
+    // Simulates a cone-resume `coneConfigDelta.upsert.accounts` injection: the
+    // account store already holds a fresh, long-lived token + updated masked
+    // value (written by `applyHostedAccounts`/`saveOAuthAccount`, which never
+    // touches the VFS bridge file itself) while the git-token file on disk
+    // still holds the masked value from before resume. `getValidAccessToken()`
+    // must re-mirror the current masked value into the bridge file even
+    // though the token is far from expiry and the renewal branch never runs.
+    const { VirtualFS } = await import('../../src/fs/index.js');
+    const { GLOBAL_FS_DB_NAME } = await import('../../src/fs/global-db.js');
+    const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+    await fs.writeFile('/workspace/.git/github-token', 'ghp_masked_stale');
+
+    seedGitHubAccount({
+      accessToken: 'ghp_resumed_fresh',
+      tokenExpiresAt: Date.now() + 3_600_000,
+      maskedValue: 'ghp_masked_resumed',
+    });
+    globalThis.fetch = vi.fn() as typeof fetch;
+    const { getValidAccessToken } = await import('../../providers/github.js');
+
+    await expect(getValidAccessToken()).resolves.toBe('ghp_resumed_fresh');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    await expect(fs.readFile('/workspace/.git/github-token', { encoding: 'utf-8' })).resolves.toBe(
+      'ghp_masked_resumed'
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes a bug where the git credential bridge kept serving a stale GitHub token after an OF1 Labs cone resume/restart, even though the secret store and account store both showed the fresh token.
- Root cause: cone resume injects a fresh GitHub OAuth account via `coneConfigDelta.upsert.accounts`, which flows through the generic `applyHostedAccounts` → `saveOAuthAccount` path. That path updates the account store's masked value but never rewrites `/workspace/.git/github-token` — the VFS file `GitCommands` treats as the highest-priority credential source for every git invocation. The one hook meant to keep that file in sync, `getValidAccessToken()`, only rewrote it inside the token-renewal branch, which a freshly-injected long-lived token never reaches (its expiry is far off) — so the bridge file kept serving the pre-resume token indefinitely and `git push`/`git clone` 401'd.
- Fix: `getValidAccessToken()` now resyncs the bridge file to the account store's current masked value on every resolution, not just on renewal.

## Test plan

- [x] Added a regression test simulating the cone-resume scenario (fresh long-lived account + updated masked value, stale bridge file on disk) — verifies `getValidAccessToken()` rewrites the bridge file without going through renewal.
- [x] `npm run verify` (lint gate — ran automatically via pre-push hook)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` (12,750 passed)
- [x] `npm run test:coverage` (thresholds pass)
- [x] `npm run build` + `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size`

🤖 Generated with [Claude Code](https://claude.com/claude-code)