### PR TITLE
refactor(webapp): use shared base64 helpers in image-processor

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -297,7 +297,6 @@
         "packages/cloud-core/src/operations/list.ts",
         "packages/cloud-core/src/operations/start.ts",
         "packages/cloudflare-worker/src/cloud/auth.ts",
-        "packages/webapp/src/core/image-processor.ts",
         "packages/webapp/src/core/tool-adapter.ts",
         "packages/webapp/src/fs/mount-recovery.ts",
         "packages/webapp/src/git/git-config.ts",

--- a/packages/webapp/src/core/image-processor.ts
+++ b/packages/webapp/src/core/image-processor.ts
@@ -21,10 +21,11 @@ export const SUPPORTED_MIMES = new Set(['image/jpeg', 'image/png', 'image/gif', 
 
 /** Estimate decoded byte size from base64 without full decode. */
 export function getImageByteSize(base64: string): number {
+  const data = normalizeBase64(base64);
   let padding = 0;
-  if (base64.endsWith('==')) padding = 2;
-  else if (base64.endsWith('=')) padding = 1;
-  return Math.ceil((base64.length * 3) / 4) - padding;
+  if (data.endsWith('==')) padding = 2;
+  else if (data.endsWith('=')) padding = 1;
+  return Math.ceil((data.length * 3) / 4) - padding;
 }
 
 export function isSupportedImageFormat(mimeType: string): boolean {
@@ -33,9 +34,22 @@ export function isSupportedImageFormat(mimeType: string): boolean {
 
 type Dimensions = { width: number; height: number };
 
+/**
+ * Restore the tolerance `atob` had before the strict shared decoder: tool
+ * output often arrives line-wrapped or with the trailing padding omitted, and
+ * `base64ToUint8` rejects both wherever the Node `Buffer` fast-path is active.
+ */
+function normalizeBase64(base64: string): string {
+  const compact = base64.replace(/[\t\n\f\r ]/g, '');
+  const remainder = compact.length % 4;
+  if (remainder === 2) return `${compact}==`;
+  if (remainder === 3) return `${compact}=`;
+  return compact;
+}
+
 /** Decode a base64 prefix and expose it as a byte view plus a `DataView`. */
 function readHeader(base64: string, chars: number): DataView {
-  const raw = base64ToUint8(base64.slice(0, chars));
+  const raw = base64ToUint8(normalizeBase64(base64.slice(0, chars)));
   return new DataView(raw.buffer, raw.byteOffset, raw.byteLength);
 }
 
@@ -78,9 +92,12 @@ function jpegDimensions(base64: string): Dimensions | null {
  */
 export function getImageDimensions(base64: string, mimeType: string): Dimensions | null {
   try {
-    if (mimeType === 'image/png') return pngDimensions(base64);
-    if (mimeType === 'image/gif') return gifDimensions(base64);
-    if (mimeType === 'image/jpeg') return jpegDimensions(base64);
+    // Strip whitespace up front so the fixed prefix lengths below still cover
+    // the header bytes when the input arrives line-wrapped.
+    const data = normalizeBase64(base64);
+    if (mimeType === 'image/png') return pngDimensions(data);
+    if (mimeType === 'image/gif') return gifDimensions(data);
+    if (mimeType === 'image/jpeg') return jpegDimensions(data);
   } catch {
     // Corrupt header — can't determine dimensions
   }
@@ -159,7 +176,7 @@ export async function processImageContent(
 
   // Step 2: Decode and process
   try {
-    const bytes = base64ToUint8(image.data);
+    const bytes = base64ToUint8(normalizeBase64(image.data));
 
     const output: { data: Uint8Array | null; mime: string } = { data: null, mime: image.mimeType };
 

--- a/packages/webapp/src/core/image-processor.ts
+++ b/packages/webapp/src/core/image-processor.ts
@@ -6,6 +6,7 @@
  * if the image is unrecoverable (corrupt, unsupported format).
  */
 
+import { base64ToUint8, uint8ToBase64 } from '@slicc/shared-ts';
 import { createLogger } from './logger.js';
 import type { ImageContent, TextContent } from './types.js';
 
@@ -30,57 +31,56 @@ export function isSupportedImageFormat(mimeType: string): boolean {
   return SUPPORTED_MIMES.has(mimeType);
 }
 
+type Dimensions = { width: number; height: number };
+
+/** Decode a base64 prefix and expose it as a byte view plus a `DataView`. */
+function readHeader(base64: string, chars: number): DataView {
+  const raw = base64ToUint8(base64.slice(0, chars));
+  return new DataView(raw.buffer, raw.byteOffset, raw.byteLength);
+}
+
+function nonZero(width: number, height: number): Dimensions | null {
+  return width > 0 && height > 0 ? { width, height } : null;
+}
+
+function pngDimensions(base64: string): Dimensions | null {
+  // PNG IHDR: width @ bytes 16-19, height @ bytes 20-23 (big-endian uint32)
+  // Need first 24 raw bytes = 32 base64 chars
+  if (base64.length < 32) return null;
+  const dv = readHeader(base64, 32);
+  return nonZero(dv.getUint32(16, false), dv.getUint32(20, false));
+}
+
+function gifDimensions(base64: string): Dimensions | null {
+  // GIF: width @ bytes 6-7, height @ bytes 8-9 (little-endian uint16)
+  if (base64.length < 16) return null;
+  const dv = readHeader(base64, 16);
+  return nonZero(dv.getUint16(6, true), dv.getUint16(8, true));
+}
+
+function jpegDimensions(base64: string): Dimensions | null {
+  // JPEG: scan for SOF0 (0xFFC0) or SOF2 (0xFFC2) marker in first 64KB
+  const scanChars = Math.min(Math.ceil(65536 / 3) * 4, base64.length);
+  const dv = readHeader(base64, scanChars);
+  for (let i = 0; i < dv.byteLength - 8; i++) {
+    if (dv.getUint8(i) !== 0xff) continue;
+    const marker = dv.getUint8(i + 1);
+    if (marker === 0xc0 || marker === 0xc2) {
+      return nonZero(dv.getUint16(i + 7, false), dv.getUint16(i + 5, false));
+    }
+  }
+  return null;
+}
+
 /**
  * Extract image dimensions from base64 data by parsing format headers.
  * Returns null if dimensions can't be determined (unknown format, corrupt header).
  */
-export function getImageDimensions(
-  base64: string,
-  mimeType: string
-): { width: number; height: number } | null {
+export function getImageDimensions(base64: string, mimeType: string): Dimensions | null {
   try {
-    if (mimeType === 'image/png') {
-      // PNG IHDR: width @ bytes 16-19, height @ bytes 20-23 (big-endian uint32)
-      // Need first 24 raw bytes = 32 base64 chars
-      if (base64.length < 32) return null;
-      const raw = atob(base64.slice(0, 32));
-      const w =
-        (raw.charCodeAt(16) << 24) |
-        (raw.charCodeAt(17) << 16) |
-        (raw.charCodeAt(18) << 8) |
-        raw.charCodeAt(19);
-      const h =
-        (raw.charCodeAt(20) << 24) |
-        (raw.charCodeAt(21) << 16) |
-        (raw.charCodeAt(22) << 8) |
-        raw.charCodeAt(23);
-      return w > 0 && h > 0 ? { width: w, height: h } : null;
-    }
-
-    if (mimeType === 'image/gif') {
-      // GIF: width @ bytes 6-7, height @ bytes 8-9 (little-endian uint16)
-      if (base64.length < 16) return null;
-      const raw = atob(base64.slice(0, 16));
-      const w = raw.charCodeAt(6) | (raw.charCodeAt(7) << 8);
-      const h = raw.charCodeAt(8) | (raw.charCodeAt(9) << 8);
-      return w > 0 && h > 0 ? { width: w, height: h } : null;
-    }
-
-    if (mimeType === 'image/jpeg') {
-      // JPEG: scan for SOF0 (0xFFC0) or SOF2 (0xFFC2) marker in first 64KB
-      const scanBytes = Math.min(Math.ceil(65536 / 3) * 4, base64.length);
-      const raw = atob(base64.slice(0, scanBytes));
-      for (let i = 0; i < raw.length - 8; i++) {
-        if (raw.charCodeAt(i) === 0xff) {
-          const marker = raw.charCodeAt(i + 1);
-          if (marker === 0xc0 || marker === 0xc2) {
-            const h = (raw.charCodeAt(i + 5) << 8) | raw.charCodeAt(i + 6);
-            const w = (raw.charCodeAt(i + 7) << 8) | raw.charCodeAt(i + 8);
-            return w > 0 && h > 0 ? { width: w, height: h } : null;
-          }
-        }
-      }
-    }
+    if (mimeType === 'image/png') return pngDimensions(base64);
+    if (mimeType === 'image/gif') return gifDimensions(base64);
+    if (mimeType === 'image/jpeg') return jpegDimensions(base64);
   } catch {
     // Corrupt header — can't determine dimensions
   }
@@ -159,11 +159,7 @@ export async function processImageContent(
 
   // Step 2: Decode and process
   try {
-    const binaryString = atob(image.data);
-    const bytes = new Uint8Array(binaryString.length);
-    for (let i = 0; i < binaryString.length; i++) {
-      bytes[i] = binaryString.charCodeAt(i);
-    }
+    const bytes = base64ToUint8(image.data);
 
     const output: { data: Uint8Array | null; mime: string } = { data: null, mime: image.mimeType };
 
@@ -223,11 +219,7 @@ export async function processImageContent(
     }
 
     // Encode back to base64
-    let binary = '';
-    for (let i = 0; i < output.data.length; i++) {
-      binary += String.fromCharCode(output.data[i]);
-    }
-    const newBase64 = btoa(binary);
+    const newBase64 = uint8ToBase64(output.data);
 
     log.info('Image processed successfully', {
       originalBase64: base64Size,

--- a/packages/webapp/tests/core/image-processor.test.ts
+++ b/packages/webapp/tests/core/image-processor.test.ts
@@ -201,6 +201,41 @@ describe('getImageDimensions', () => {
     expect(getImageDimensions(makeBase64(jpeg), 'image/jpeg')).toEqual({ width: 800, height: 600 });
   });
 
+  it('extracts JPEG dimensions from an SOF marker after a leading APP0 segment', () => {
+    const jpeg = [
+      0xff,
+      0xd8, // SOI
+      0xff,
+      0xe0, // APP0
+      0x00,
+      0x10, // APP0 length
+      0x4a,
+      0x46,
+      0x49,
+      0x46,
+      0x00,
+      0x01,
+      0x01,
+      0x00,
+      0x00,
+      0x01,
+      0x00,
+      0x01,
+      0x00,
+      0x00,
+      0xff,
+      0xc0, // SOF0
+      0x00,
+      0x11,
+      0x08,
+      0x02,
+      0x58, // height = 600
+      0x03,
+      0x20, // width = 800
+    ];
+    expect(getImageDimensions(makeBase64(jpeg), 'image/jpeg')).toEqual({ width: 800, height: 600 });
+  });
+
   it('returns null for JPEG with no SOF marker', () => {
     const jpeg = [
       0xff,

--- a/packages/webapp/tests/core/image-processor.test.ts
+++ b/packages/webapp/tests/core/image-processor.test.ts
@@ -29,6 +29,10 @@ describe('getImageByteSize', () => {
     expect(getImageByteSize('')).toBe(0);
   });
 
+  it('ignores line-wrapping whitespace', () => {
+    expect(getImageByteSize('SGVs\nbG8=')).toBe(5);
+  });
+
   it('estimates large base64 correctly', () => {
     // 1MB of data would be ~1,398,101 base64 chars
     const oneMB = 1024 * 1024;
@@ -280,6 +284,24 @@ describe('getImageDimensions', () => {
       0x58, // height = 600
     ];
     expect(getImageDimensions(makeBase64(png), 'image/png')).toBeNull();
+  });
+
+  it('extracts PNG dimensions when padding is omitted', () => {
+    const png = [
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+      0x52, 0x00, 0x00, 0x03, 0x20, 0x00, 0x00, 0x02, 0x58, 0x00,
+    ];
+    const unpadded = makeBase64(png).replace(/=+$/, '');
+    expect(getImageDimensions(unpadded, 'image/png')).toEqual({ width: 800, height: 600 });
+  });
+
+  it('extracts PNG dimensions when the base64 is line-wrapped', () => {
+    const png = [
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+      0x52, 0x00, 0x00, 0x03, 0x20, 0x00, 0x00, 0x02, 0x58,
+    ];
+    const wrapped = makeBase64(png).replace(/(.{8})/g, '$1\n');
+    expect(getImageDimensions(wrapped, 'image/png')).toEqual({ width: 800, height: 600 });
   });
 
   it('returns null for too-short base64', () => {


### PR DESCRIPTION
## Problem

Closes #1749.

## Solution

The five hand-rolled `atob`/`btoa` loops collapse to `base64ToUint8` / `uint8ToBase64` from `@slicc/shared-ts`; the encode path gains the Node `Buffer` fast-path and browser chunking that the unchunked `String.fromCharCode` loop lacked. `getImageDimensions` is split into per-format helpers so the file could come off the cognitive-complexity debt list in `biome.json`, which the touched-file gate requires.

## Testing

`npm run lint`, `npm run typecheck`, and the `image-processor` suite (33 tests) pass. Added a JPEG case where the SOF marker follows a leading APP0 segment, exercising the offset scan rather than a marker at index 2.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KYPHEM8J8QHC5NBF0GFFNSQB&panel=chat)