### PR TITLE
fix(scoops): reject unresolvable model ids instead of falling back

### DIFF
--- a/packages/vfs-root/workspace/skills/delegation/SKILL.md
+++ b/packages/vfs-root/workspace/skills/delegation/SKILL.md
@@ -87,7 +87,7 @@ agent <cwd> <allowed-commands> <prompt> [--model <id>] [--read-only <paths>]
 - `<cwd>` — sole writable prefix (plus `/shared/`, the scoop's scratch folder, and `/tmp/`). Relative paths resolve against the caller's cwd.
 - `<allowed-commands>` — comma-separated allow-list; `*` for unrestricted.
 - `<prompt>` — forwarded verbatim. The spawned scoop has no access to the caller's history; pack context into the prompt.
-- `--model` — defaults to the parent scoop's model (or the cone's, when invoked from the terminal).
+- `--model` — defaults to the parent scoop's model (or the cone's, when invoked from the terminal). Accepts an exact id or a shorthand (`haiku`, `sonnet`, `claude-haiku-4-5`), resolved against the selected provider's catalog. An id that cannot be resolved is a hard error (exit 1) — it never silently falls back to the parent's model.
 - `--read-only` — pure-replace list of read-only paths. Default: `/workspace/` plus the invoking shell's cwd.
 
 **Critical property: no handoff.** Ephemeral scoops do NOT notify the cone on completion. Running `agent` from a non-cone shell does not trigger an unsolicited cone turn. The caller gets the result on stdout, nothing else. This makes `agent` the right choice for cheap, predictable interactions inside dips and sprinkles where you don't want the cone or owning scoop woken up.
@@ -225,7 +225,7 @@ scoop_unmute({ scoop_names: ["scraper"] })
 
 ## Model selection for scoops
 
-**Always run `models` to verify available models before specifying one.** Model availability depends on the configured provider and API key. Specifying a non-existent model fails immediately with an unrecoverable error.
+**Always run `models` to verify available models before specifying one.** Model availability depends on the configured provider and API key. `model` accepts an exact id or a shorthand (`haiku`, `sonnet`, `claude-haiku-4-5`), resolved against the selected provider's catalog. An id that cannot be resolved is rejected outright — it never silently falls back to the cone's model.
 
 Use `models --json` to compare. Intelligence, speed, and cost are independent dimensions:
 

--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -1648,6 +1648,15 @@ function bestShorthandMatch(keyword: string, providerIds: string[]): string | nu
  *
  * Callers MUST treat null as a hard error rather than spawning without a
  * model id (which inherits the parent's, reintroducing the same overrun).
+ *
+ * The equality check alone is not sufficient for OAuth/custom providers:
+ * `resolveModelById()` synthesizes a provider-routed model that echoes ANY
+ * requested id (so an unknown-but-real proxy model still routes through the
+ * provider instead of leaking the token to api.anthropic.com), which would
+ * accept a typo verbatim. Candidates are therefore also checked against the
+ * selected provider's catalogue — skipped when that catalogue is empty (a
+ * cold/failed model list), where rejecting everything would be worse than
+ * deferring the error to the provider API.
  */
 export function resolveModelIdForScoop(input: string): string | null {
   if (!input) return null;
@@ -1655,7 +1664,15 @@ export function resolveModelIdForScoop(input: string): string | null {
   const alias = resolveModelByShorthand(input);
   if (alias !== null && alias !== input) candidates.push(alias);
 
+  let catalogue: Model<Api>[] = [];
+  try {
+    catalogue = getProviderModels(getSelectedProvider());
+  } catch {
+    /* storage fault — fall back to the resolver check alone */
+  }
+
   for (const candidate of candidates) {
+    if (catalogue.length > 0 && !catalogue.some((m) => m.id === candidate)) continue;
     try {
       if (resolveModelById(candidate).id === candidate) return candidate;
     } catch (err) {

--- a/packages/webapp/src/providers/account-store.ts
+++ b/packages/webapp/src/providers/account-store.ts
@@ -1576,17 +1576,46 @@ export function resolveCurrentModel(): Model<Api> {
  * The match is intentionally loose (any id/name containing the keyword
  * wins) so it works across providers without a hardcoded family list.
  *
+ * The SELECTED provider's catalog is searched first and wins outright when
+ * it has any match — `resolveModelById()` resolves against that provider,
+ * so an id borrowed from a different account would not resolve there and
+ * would degrade to the selected model instead (see
+ * {@link resolveModelIdForScoop}).
+ *
  * Returns the concrete model id, or null if no model matches.
  */
 export function resolveModelByShorthand(input: string): string | null {
   const keyword = input.toLowerCase();
   if (!keyword) return null;
 
+  let selectedProvider: string | null = null;
+  try {
+    selectedProvider = getSelectedProvider();
+  } catch {
+    /* storage fault — fall back to scanning every account */
+  }
+
+  if (selectedProvider !== null) {
+    const preferred = bestShorthandMatch(keyword, [selectedProvider]);
+    if (preferred !== null) return preferred;
+  }
+  return bestShorthandMatch(
+    keyword,
+    getAccounts().map((a) => a.providerId)
+  );
+}
+
+/**
+ * Best keyword match across the given providers. Shared by both passes of
+ * {@link resolveModelByShorthand} so the ranking rule (largest context
+ * window, numeric version tiebreak) is defined once.
+ */
+function bestShorthandMatch(keyword: string, providerIds: string[]): string | null {
   let bestId: string | null = null;
   let bestContextWindow = -1;
 
-  for (const account of getAccounts()) {
-    for (const model of getProviderModels(account.providerId)) {
+  for (const providerId of providerIds) {
+    for (const model of getProviderModels(providerId)) {
       const idLower = model.id.toLowerCase();
       const nameLower = (model.name ?? '').toLowerCase();
       if (!idLower.includes(keyword) && !nameLower.includes(keyword)) continue;
@@ -1603,6 +1632,41 @@ export function resolveModelByShorthand(input: string): string | null {
   }
 
   return bestId;
+}
+
+/**
+ * Canonicalize a caller-supplied model id (exact id or shorthand alias) into
+ * the id a spawned scoop will actually run as, or null when nothing matches.
+ *
+ * The invariant every candidate must satisfy is `resolveModelById(id).id ===
+ * id`: `ScoopContext.init()` resolves `config.modelId` through
+ * `resolveModelById()`, which resolves against the SELECTED provider and
+ * silently degrades to `resolveCurrentModel()` (the cone's own model) for an
+ * id that provider doesn't offer. Validating with a looser notion of "known"
+ * than the spawn path uses is what let `--model claude-haiku-4-5` exit 0 and
+ * then run as the cone's Opus — a ~5x cost overrun with no warning.
+ *
+ * Callers MUST treat null as a hard error rather than spawning without a
+ * model id (which inherits the parent's, reintroducing the same overrun).
+ */
+export function resolveModelIdForScoop(input: string): string | null {
+  if (!input) return null;
+  const candidates = [input];
+  const alias = resolveModelByShorthand(input);
+  if (alias !== null && alias !== input) candidates.push(alias);
+
+  for (const candidate of candidates) {
+    try {
+      if (resolveModelById(candidate).id === candidate) return candidate;
+    } catch (err) {
+      log.debug('resolveModelIdForScoop: candidate did not resolve', {
+        input,
+        candidate,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return null;
 }
 
 /**

--- a/packages/webapp/src/scoops/agent-bridge.ts
+++ b/packages/webapp/src/scoops/agent-bridge.ts
@@ -33,11 +33,7 @@ import { createLogger } from '../core/logger.js';
 import type { SessionStore } from '../core/session.js';
 import type { VirtualFS } from '../fs/index.js';
 import { normalizePath } from '../fs/path-utils.js';
-import {
-  getAccounts,
-  getProviderModels,
-  resolveModelByShorthand,
-} from '../providers/account-store.js';
+import { resolveModelIdForScoop } from '../providers/account-store.js';
 import type { Orchestrator } from './orchestrator.js';
 import {
   CURRENT_SCOOP_CONFIG_VERSION,
@@ -627,26 +623,25 @@ function tokenToJid(token: string): string {
 }
 
 /**
- * Default model resolver. Returns the input id if any configured provider's
- * FULL model list advertises it; otherwise null. Validates against
- * `getProviderModels()` (the unfiltered per-provider list), NOT
- * `getAllAvailableModels()` — the latter is picker-filtered
- * (`PICKER_HIDDEN_MODEL_PATTERNS`, e.g. `/haiku/i`), so a model hidden from the
- * cone picker would be wrongly rejected here as "unknown". A picker-hidden
- * model is still a legitimate explicit sub-agent target (the very "haiku scoop
- * for cheap throwaway work" the picker hides it to avoid as a *cone* default).
+ * Default model resolver. Returns the canonical id the spawned scoop will
+ * actually run as, or null when the requested id resolves to nothing.
+ *
+ * Delegates to `resolveModelIdForScoop()`, which validates every candidate
+ * (the id verbatim, then its shorthand expansion) through the SAME
+ * `resolveModelById()` the spawn path uses. Validating against a looser
+ * notion of "known" — e.g. any account's `getProviderModels()` list — let a
+ * bare alias like `claude-haiku-4-5` pass while the scoop silently ran as the
+ * cone's model. The picker filter (`PICKER_HIDDEN_MODEL_PATTERNS`, e.g.
+ * `/haiku/i`) is deliberately NOT consulted: a picker-hidden model is still a
+ * legitimate explicit sub-agent target (the very "haiku scoop for cheap
+ * throwaway work" the picker hides it to avoid as a *cone* default).
+ *
  * Tests can replace this via `deps.resolveModel` without touching
  * provider-settings state.
  */
 export function defaultResolveModel(modelId: string): string | null {
   try {
-    for (const account of getAccounts()) {
-      if (getProviderModels(account.providerId).some((m) => m.id === modelId)) return modelId;
-    }
-    // Try shorthand alias: keyword match against available model ids/names
-    const alias = resolveModelByShorthand(modelId);
-    if (alias) return alias;
-    return null;
+    return resolveModelIdForScoop(modelId);
   } catch (err) {
     // getAccounts/getProviderModels normally return [] (and self-log) on a provider/parse
     // failure; the only throws that reach here are residual storage/environment faults

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -43,6 +43,7 @@ import {
   getSelectedProvider,
   resolveCurrentModel,
   resolveModelById,
+  resolveModelIdForScoop,
 } from '../providers/account-store.js';
 import { AlmostBashShell } from '../shell/index.js';
 import type { SudoManager } from '../sudo/sudo-manager.js';
@@ -485,6 +486,7 @@ export class ScoopContext {
       getScoopTabState: this.callbacks.getScoopTabState,
       onFeedScoop: this.callbacks.onFeedScoop,
       onScoopScoop: this.callbacks.onScoopScoop,
+      resolveModelId: resolveModelIdForScoop,
       onDropScoop: this.callbacks.onDropScoop,
       onMuteScoops: this.callbacks.onMuteScoops,
       onUnmuteScoops: this.callbacks.onUnmuteScoops,
@@ -653,11 +655,23 @@ export class ScoopContext {
         return;
       }
 
-      const model = this.scoop.config?.modelId
-        ? resolveModelById(this.scoop.config.modelId)
-        : resolveCurrentModel();
+      const configuredModelId = this.scoop.config?.modelId;
+      const model = configuredModelId ? resolveModelById(configuredModelId) : resolveCurrentModel();
       const label = this.scoop.isCone ? 'Cone' : `Scoop "${this.scoop.name}"`;
       console.log(`[model] ${label} using model: ${model.id} (provider: ${model.provider})`);
+      // `resolveModelById` degrades to the *selected* model for an id the
+      // selected provider doesn't offer (e.g. a scoop persisted before a
+      // provider switch). Spawn-time callers reject that up front via
+      // `resolveModelIdForScoop`, but a stored config can still drift — and a
+      // silent drift from a cheap model to the cone's Opus is a real cost
+      // overrun, so leave a breadcrumb rather than only the info line above.
+      if (configuredModelId && model.id !== configuredModelId) {
+        log.warn('Configured scoop model did not resolve; using resolved model instead', {
+          folder: this.scoop.folder,
+          configuredModelId,
+          resolvedModelId: model.id,
+        });
+      }
 
       const systemPrompt = this.buildSystemPrompt(globalMemory, scoopMemory, skills);
       const restoredMessages = await this.restoreSession();

--- a/packages/webapp/src/scoops/scoop-management-tools.ts
+++ b/packages/webapp/src/scoops/scoop-management-tools.ts
@@ -27,6 +27,14 @@ export interface ScoopManagementToolsConfig {
   /** Get tab state for a scoop by JID (status, lastActivity). */
   getScoopTabState?: (jid: string) => import('./types.js').ScoopTabState | undefined;
   onScoopScoop?: (scoop: Omit<RegisteredScoop, 'jid'>) => Promise<RegisteredScoop>;
+  /**
+   * Canonicalize `scoop_scoop`'s `model` argument into the id the new scoop
+   * will actually run as, or null when it resolves to nothing. Wired to
+   * `resolveModelIdForScoop` by `ScoopContext`. Without it an unresolvable id
+   * lands in `config.modelId` and `ScoopContext.init()` silently degrades to
+   * the cone's own (typically far more expensive) model.
+   */
+  resolveModelId?: (modelId: string) => string | null;
   onDropScoop?: (scoopJid: string) => Promise<void>;
   onSetGlobalMemory?: (content: string) => Promise<void>;
   getGlobalMemory?: () => Promise<string>;
@@ -125,6 +133,28 @@ function parseThinkingLevel(
     };
   }
   return { ok: true, level: thinking };
+}
+
+/**
+ * Canonicalize `scoop_scoop`'s `model` argument, or return an error result.
+ * Omitting the model is fine (the scoop inherits the cone's), but an id that
+ * cannot be resolved MUST be rejected rather than silently inherited — see
+ * `resolveModelId` on {@link ScoopManagementToolsConfig}.
+ */
+function parseModelId(
+  model: string | undefined,
+  resolveModelId: ScoopManagementToolsConfig['resolveModelId']
+): { ok: true; modelId?: string } | { ok: false; content: string; isError: true } {
+  if (model === undefined || !resolveModelId) return { ok: true, modelId: model };
+  const resolved = resolveModelId(model);
+  if (resolved === null) {
+    return {
+      ok: false,
+      content: `Unknown model "${model}". Run the "models" shell command to list available model IDs.`,
+      isError: true,
+    };
+  }
+  return { ok: true, modelId: resolved };
 }
 
 /** Render a "scoop not found" error including the available list. */
@@ -344,12 +374,15 @@ async function executeScoopScoop(
   const parsed = parseThinkingLevel(thinking);
   if (!parsed.ok) return { content: parsed.content, isError: parsed.isError };
 
+  const parsedModel = parseModelId(model, config.resolveModelId);
+  if (!parsedModel.ok) return { content: parsedModel.content, isError: parsedModel.isError };
+
   const folder = folderFromDisplayName(name);
   try {
     const record = buildScoopRecord(
       name,
       folder,
-      model,
+      parsedModel.modelId,
       visiblePaths,
       writablePaths,
       allowedCommands,

--- a/packages/webapp/src/shell/supplemental-commands/agent-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/agent-command.ts
@@ -76,7 +76,12 @@ Default sandbox:
 
 Options:
   --model <id>            Override the model id used by the spawned scoop.
-                          Defaults to inheriting the parent's model.
+                          Accepts an exact id or a shorthand ('haiku',
+                          'sonnet', 'claude-haiku-4-5'), resolved against the
+                          selected provider's catalog. An id that cannot be
+                          resolved exits 1 — it never falls back to the
+                          parent's model. Defaults to inheriting the parent's
+                          model.
   --thinking <level>      Reasoning / thinking level for the spawned scoop.
                           One of: off, minimal, low, medium, high, xhigh.
                           Defaults to inheriting the parent's level (or 'off'

--- a/packages/webapp/tests/providers/model-alias-resolution.test.ts
+++ b/packages/webapp/tests/providers/model-alias-resolution.test.ts
@@ -11,7 +11,7 @@
  * Runs against the REAL pi-ai model catalogue (no mocked model lists) so a
  * catalogue change that breaks alias resolution fails here.
  */
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const storage = new Map<string, string>();
 const storageStub = {
@@ -115,6 +115,53 @@ describe('resolveModelIdForScoop (bedrock-camp selected)', () => {
     // the bare id would degrade to Opus at `resolveModelById` time.
     expect(resolved).toMatch(/anthropic\.claude-haiku-4-5/);
     expect(resolveModelById(resolved!).id).toBe(resolved);
+  });
+});
+
+describe('resolveModelIdForScoop (OAuth provider selected)', () => {
+  const PROVIDER_ID = 'test-oauth-proxy';
+
+  beforeEach(async () => {
+    storage.clear();
+    const { registerProviderConfig } = await import('../../src/providers/index.js');
+    registerProviderConfig({
+      id: PROVIDER_ID,
+      name: 'Test OAuth Proxy',
+      description: 'test',
+      requiresApiKey: false,
+      requiresBaseUrl: false,
+      isOAuth: true,
+      getModelIds: () => [{ id: 'claude-sonnet-4-6', name: 'Sonnet 4.6' }],
+    });
+    storage.set('slicc_accounts', JSON.stringify([{ providerId: PROVIDER_ID, accessToken: 'x' }]));
+    storage.set('selected-model', `${PROVIDER_ID}:claude-sonnet-4-6`);
+  });
+
+  afterEach(async () => {
+    const { unregisterProviderConfig } = await import('../../src/providers/index.js');
+    unregisterProviderConfig(PROVIDER_ID);
+  });
+
+  it('accepts an id the proxy actually offers', async () => {
+    const { resolveModelIdForScoop } = await import('../../src/providers/account-store.js');
+    expect(resolveModelIdForScoop('claude-sonnet-4-6')).toBe('claude-sonnet-4-6');
+  });
+
+  it('rejects a bogus id instead of accepting the synthesized fallback', async () => {
+    // `resolveModelById` synthesizes a provider-routed model echoing ANY id for
+    // OAuth providers, so the round-trip check alone would accept this.
+    const { resolveModelById, resolveModelIdForScoop } = await import(
+      '../../src/providers/account-store.js'
+    );
+    expect(resolveModelById('this-model-does-not-exist-xyz').id).toBe(
+      'this-model-does-not-exist-xyz'
+    );
+    expect(resolveModelIdForScoop('this-model-does-not-exist-xyz')).toBeNull();
+  });
+
+  it('rejects an id the proxy does not offer even when pi-ai knows it', async () => {
+    const { resolveModelIdForScoop } = await import('../../src/providers/account-store.js');
+    expect(resolveModelIdForScoop('claude-haiku-4-5')).toBeNull();
   });
 });
 

--- a/packages/webapp/tests/providers/model-alias-resolution.test.ts
+++ b/packages/webapp/tests/providers/model-alias-resolution.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression coverage for issue #1752 — `agent --model claude-haiku-4-5`
+ * validated (exit 0) but the spawned scoop silently ran as the cone's Opus.
+ *
+ * Validation used a looser notion of "known" (any account's
+ * `getProviderModels()` list, plus a cross-provider shorthand scan) than the
+ * spawn path, which resolves `config.modelId` through `resolveModelById()`
+ * against the SELECTED provider only. `resolveModelIdForScoop` closes the gap
+ * by requiring `resolveModelById(id).id === id`.
+ *
+ * Runs against the REAL pi-ai model catalogue (no mocked model lists) so a
+ * catalogue change that breaks alias resolution fails here.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const storage = new Map<string, string>();
+const storageStub = {
+  getItem: (k: string) => storage.get(k) ?? null,
+  setItem: (k: string, v: string) => {
+    storage.set(k, v);
+  },
+  removeItem: (k: string) => {
+    storage.delete(k);
+  },
+  get length() {
+    return storage.size;
+  },
+  key: (i: number) => [...storage.keys()][i] ?? null,
+  clear: () => {
+    storage.clear();
+  },
+};
+Object.defineProperty(globalThis, 'localStorage', {
+  value: storageStub,
+  configurable: true,
+  writable: true,
+});
+
+const BEDROCK_BASE_URL = 'https://bedrock-runtime.us-west-2.amazonaws.com';
+
+/** Seed a bedrock-camp account selected on Opus 4.8 (the issue's setup). */
+function seedBedrockCampOnOpus(): void {
+  storage.set(
+    'slicc_accounts',
+    JSON.stringify([{ providerId: 'bedrock-camp', apiKey: 'ABSK-x', baseUrl: BEDROCK_BASE_URL }])
+  );
+  storage.set('selected-model', 'bedrock-camp:us.anthropic.claude-opus-4-8');
+}
+
+describe('resolveModelIdForScoop (bedrock-camp selected)', () => {
+  beforeEach(() => {
+    storage.clear();
+    seedBedrockCampOnOpus();
+  });
+
+  it('expands a bare haiku alias to a real bedrock haiku profile', async () => {
+    const { resolveModelIdForScoop } = await import('../../src/providers/account-store.js');
+    const resolved = resolveModelIdForScoop('claude-haiku-4-5');
+    expect(resolved).toMatch(/anthropic\.claude-haiku-4-5/);
+  });
+
+  it('expands a bare sonnet alias (the id that already worked)', async () => {
+    const { resolveModelIdForScoop } = await import('../../src/providers/account-store.js');
+    const resolved = resolveModelIdForScoop('claude-sonnet-4-6');
+    expect(resolved).toMatch(/anthropic\.claude-sonnet-4-6/);
+  });
+
+  it('never resolves to the selected (parent) model for a haiku request', async () => {
+    const { resolveModelIdForScoop } = await import('../../src/providers/account-store.js');
+    expect(resolveModelIdForScoop('claude-haiku-4-5')).not.toBe('us.anthropic.claude-opus-4-8');
+  });
+
+  it('passes a fully-qualified id through unchanged', async () => {
+    const { resolveModelIdForScoop } = await import('../../src/providers/account-store.js');
+    const id = 'us.anthropic.claude-haiku-4-5-20251001-v1:0';
+    expect(resolveModelIdForScoop(id)).toBe(id);
+  });
+
+  it('rejects a bogus id', async () => {
+    const { resolveModelIdForScoop } = await import('../../src/providers/account-store.js');
+    expect(resolveModelIdForScoop('this-model-does-not-exist-xyz')).toBeNull();
+  });
+
+  it('rejects an empty id', async () => {
+    const { resolveModelIdForScoop } = await import('../../src/providers/account-store.js');
+    expect(resolveModelIdForScoop('')).toBeNull();
+  });
+
+  it('every resolved id round-trips through resolveModelById', async () => {
+    const { resolveModelById, resolveModelIdForScoop } = await import(
+      '../../src/providers/account-store.js'
+    );
+    for (const input of ['claude-haiku-4-5', 'claude-sonnet-4-6', 'haiku', 'opus']) {
+      const resolved = resolveModelIdForScoop(input);
+      expect(resolved, input).not.toBeNull();
+      // The invariant the spawn path depends on: what we validate is what runs.
+      expect(resolveModelById(resolved!).id, input).toBe(resolved);
+    }
+  });
+
+  it('prefers the selected provider over another account offering the alias', async () => {
+    storage.set(
+      'slicc_accounts',
+      JSON.stringify([
+        { providerId: 'anthropic', apiKey: 'sk-ant-x' },
+        { providerId: 'bedrock-camp', apiKey: 'ABSK-x', baseUrl: BEDROCK_BASE_URL },
+      ])
+    );
+    storage.set('selected-model', 'bedrock-camp:us.anthropic.claude-opus-4-8');
+    const { resolveModelById, resolveModelIdForScoop } = await import(
+      '../../src/providers/account-store.js'
+    );
+    const resolved = resolveModelIdForScoop('claude-haiku-4-5');
+    // `anthropic` offers the bare id, but bedrock-camp is selected — picking
+    // the bare id would degrade to Opus at `resolveModelById` time.
+    expect(resolved).toMatch(/anthropic\.claude-haiku-4-5/);
+    expect(resolveModelById(resolved!).id).toBe(resolved);
+  });
+});
+
+describe('resolveModelIdForScoop (native anthropic selected)', () => {
+  beforeEach(() => {
+    storage.clear();
+    storage.set(
+      'slicc_accounts',
+      JSON.stringify([{ providerId: 'anthropic', apiKey: 'sk-ant-x' }])
+    );
+    storage.set('selected-model', 'anthropic:claude-opus-4-8');
+  });
+
+  it('keeps the bare pi-ai alias when the selected provider offers it', async () => {
+    const { resolveModelIdForScoop } = await import('../../src/providers/account-store.js');
+    expect(resolveModelIdForScoop('claude-haiku-4-5')).toBe('claude-haiku-4-5');
+  });
+
+  it('rejects a bedrock-only inference-profile id', async () => {
+    const { resolveModelIdForScoop } = await import('../../src/providers/account-store.js');
+    expect(resolveModelIdForScoop('us.anthropic.claude-haiku-4-5-20251001-v1:0')).toBeNull();
+  });
+});

--- a/packages/webapp/tests/scoops/agent-bridge.test.ts
+++ b/packages/webapp/tests/scoops/agent-bridge.test.ts
@@ -17,71 +17,48 @@ import {
   publishAgentBridge,
 } from '../../src/scoops/agent-bridge.js';
 
-// Mock only the two model-list accessors defaultResolveModel uses; keep every other
-// provider-settings export real so the rest of the suite is unaffected. The full
-// adobe list here includes claude-haiku-4-5 (which the real picker hides via
-// PICKER_HIDDEN_MODEL_PATTERNS) — the regression: a picker-hidden model must still
-// validate for an explicit sub-agent target.
-const MOCK_ACCOUNTS = [
-  { providerId: 'adobe', accessToken: 'x' },
-  { providerId: 'openai', accessToken: 'y' },
+// `defaultResolveModel` is a thin delegate over account-store's
+// `resolveModelIdForScoop`; mock just that seam and keep every other
+// provider-settings export real so the rest of the suite is unaffected. The
+// resolver's own alias/provider-scoping semantics are covered against the real
+// pi-ai catalogue in tests/providers/model-alias-resolution.test.ts.
+//
+// The mock stands in for a single selected provider offering these ids. It
+// includes claude-haiku-4-5, which the real picker hides via
+// PICKER_HIDDEN_MODEL_PATTERNS — the regression: a picker-hidden model must
+// still validate for an explicit sub-agent target.
+const MOCK_MODELS = [
+  { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', contextWindow: 200000 },
+  { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', contextWindow: 200000 },
+  { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', contextWindow: 1000000 },
+  { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', contextWindow: 1000000 },
+  { id: 'gpt-4o', name: 'GPT-4o', contextWindow: 128000 },
+  { id: 'gpt-5', name: 'GPT-5', contextWindow: 1000000 },
+  { id: 'o3', name: 'o3', contextWindow: 200000 },
 ];
 
-function mockGetProviderModels(providerId: string) {
-  if (providerId === 'adobe')
-    return [
-      { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', contextWindow: 200000 },
-      { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', contextWindow: 200000 },
-      { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', contextWindow: 1000000 },
-      { id: 'claude-opus-4-6', name: 'Claude Opus 4.6', contextWindow: 1000000 },
-    ];
-  if (providerId === 'openai')
-    return [
-      { id: 'gpt-4o', name: 'GPT-4o', contextWindow: 128000 },
-      { id: 'gpt-5', name: 'GPT-5', contextWindow: 1000000 },
-      { id: 'o3', name: 'o3', contextWindow: 200000 },
-    ];
-  return [];
+/** Exact id, else the keyword match with the largest context window. */
+function mockResolveModelIdForScoop(input: string): string | null {
+  if (!input) return null;
+  if (MOCK_MODELS.some((m) => m.id === input)) return input;
+  const keyword = input.toLowerCase();
+  const matches = MOCK_MODELS.filter(
+    (m) => m.id.toLowerCase().includes(keyword) || m.name.toLowerCase().includes(keyword)
+  );
+  if (matches.length === 0) return null;
+  return matches.reduce((best, m) =>
+    m.contextWindow > best.contextWindow ||
+    (m.contextWindow === best.contextWindow && m.id > best.id)
+      ? m
+      : best
+  ).id;
 }
 
 vi.mock('../../src/providers/account-store.js', async (importActual) => {
   const actual = await importActual<typeof import('../../src/providers/account-store.js')>();
   return {
     ...actual,
-    getAccounts: () => MOCK_ACCOUNTS,
-    getProviderModels: mockGetProviderModels,
-    resolveModelByShorthand: (input: string) => {
-      const keyword = input.toLowerCase();
-      if (!keyword) return null;
-      let bestId: string | null = null;
-      let bestContextWindow = -1;
-      for (const account of MOCK_ACCOUNTS) {
-        for (const model of mockGetProviderModels(account.providerId)) {
-          const idLower = model.id.toLowerCase();
-          const nameLower = (model.name ?? '').toLowerCase();
-          if (!idLower.includes(keyword) && !nameLower.includes(keyword)) continue;
-          const contextWindow = model.contextWindow ?? 0;
-          const segsA = model.id.match(/\d+/g)?.map(Number) ?? [];
-          const segsB = (bestId ?? '').match(/\d+/g)?.map(Number) ?? [];
-          let cmp = 0;
-          for (let i = 0; i < Math.max(segsA.length, segsB.length); i++) {
-            const diff = (segsA[i] ?? 0) - (segsB[i] ?? 0);
-            if (diff !== 0) {
-              cmp = diff;
-              break;
-            }
-          }
-          if (
-            contextWindow > bestContextWindow ||
-            (contextWindow === bestContextWindow && cmp > 0)
-          ) {
-            bestContextWindow = contextWindow;
-            bestId = model.id;
-          }
-        }
-      }
-      return bestId;
-    },
+    resolveModelIdForScoop: mockResolveModelIdForScoop,
   };
 });
 
@@ -593,6 +570,64 @@ describe('createAgentBridge — model resolution', () => {
     await bridge.spawn({ ...BASE_OPTS, parentJid: 'scoop_parent' });
 
     expect(registerCalls[0].config?.modelId).toBe('claude-opus-4-7');
+  });
+
+  // Regression (#1752): an explicit --model must never be quietly replaced by
+  // the parent's (typically far more expensive) model. Either the resolved id
+  // lands on the config, or the spawn fails — never a silent inheritance.
+  it('never falls back to the parent model when an explicit modelId resolves', async () => {
+    const { orchestrator, registerCalls, scripts, knownScoops } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    knownScoops.push({
+      jid: 'cone_1',
+      name: 'Cone',
+      folder: 'cone',
+      isCone: true,
+      type: 'cone',
+      requiresTrigger: false,
+      assistantLabel: 'sliccy',
+      addedAt: '2026-04-19T00:00:00Z',
+      config: { modelId: 'claude-opus-4-8' },
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    });
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'jolly-mint',
+    });
+    scripts.set('agent_jolly_mint', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn({ ...BASE_OPTS, modelId: 'claude-haiku-4-5', parentJid: 'cone_1' });
+
+    expect(registerCalls[0].config?.modelId).toBe('claude-haiku-4-5');
+  });
+
+  it('rejects the spawn rather than inheriting the parent when the model is unknown', async () => {
+    const { orchestrator, registerCalls, knownScoops } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    knownScoops.push({
+      jid: 'cone_1',
+      name: 'Cone',
+      folder: 'cone',
+      isCone: true,
+      type: 'cone',
+      requiresTrigger: false,
+      assistantLabel: 'sliccy',
+      addedAt: '2026-04-19T00:00:00Z',
+      config: { modelId: 'claude-opus-4-8' },
+      configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
+    });
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'jolly-mint',
+    });
+
+    const result = await bridge.spawn({
+      ...BASE_OPTS,
+      modelId: 'this-model-does-not-exist-xyz',
+      parentJid: 'cone_1',
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.finalText).toContain('unknown model');
+    expect(registerCalls).toHaveLength(0);
   });
 
   it('leaves modelId unset when neither explicit nor parent has one', async () => {

--- a/packages/webapp/tests/scoops/scoop-context.compaction-window.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.compaction-window.test.ts
@@ -73,6 +73,7 @@ vi.mock('../../src/providers/account-store.js', () => ({
   getSelectedProvider: () => 'adobe',
   resolveCurrentModel: mocks.resolveCurrentModel,
   resolveModelById: () => ({ id: 'test-model', provider: 'adobe' }),
+  resolveModelIdForScoop: (id: string) => id,
 }));
 
 vi.mock('../../src/scoops/skills.js', () => ({

--- a/packages/webapp/tests/scoops/scoop-context.restore-orphans.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.restore-orphans.test.ts
@@ -71,6 +71,7 @@ vi.mock('../../src/providers/account-store.js', () => ({
   getSelectedProvider: () => 'anthropic',
   resolveCurrentModel: () => ({ id: 'test-model', provider: 'anthropic' }),
   resolveModelById: () => ({ id: 'test-model', provider: 'anthropic' }),
+  resolveModelIdForScoop: (id: string) => id,
 }));
 
 vi.mock('../../src/scoops/skills.js', () => ({

--- a/packages/webapp/tests/scoops/scoop-context.session-id.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.session-id.test.ts
@@ -94,6 +94,7 @@ vi.mock('../../src/providers/account-store.js', () => ({
   getSelectedProvider: () => 'anthropic',
   resolveCurrentModel: mocks.resolveCurrentModel,
   resolveModelById: () => ({ id: 'test-model', provider: 'anthropic' }),
+  resolveModelIdForScoop: (id: string) => id,
 }));
 
 vi.mock('../../src/scoops/skills.js', () => ({

--- a/packages/webapp/tests/scoops/scoop-context.tools.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.tools.test.ts
@@ -32,6 +32,7 @@ const mocks = vi.hoisted(() => {
     getSelectedProvider: vi.fn(() => 'anthropic'),
     resolveCurrentModel: vi.fn(() => ({ id: 'test-model' })),
     resolveModelById: vi.fn(() => ({ id: 'test-model' })),
+    resolveModelIdForScoop: vi.fn((id: string) => id),
     createDefaultSkills: vi.fn(async () => {}),
     loadSkills: vi.fn(async () => []),
     formatSkillsForPrompt: vi.fn(() => ''),
@@ -58,6 +59,7 @@ vi.mock('../../src/providers/account-store.js', () => ({
   getSelectedProvider: mocks.getSelectedProvider,
   resolveCurrentModel: mocks.resolveCurrentModel,
   resolveModelById: mocks.resolveModelById,
+  resolveModelIdForScoop: mocks.resolveModelIdForScoop,
 }));
 
 vi.mock('../../src/scoops/skills.js', () => ({

--- a/packages/webapp/tests/scoops/scoop-management-tools.test.ts
+++ b/packages/webapp/tests/scoops/scoop-management-tools.test.ts
@@ -20,7 +20,7 @@ const cone: RegisteredScoop = {
   addedAt: new Date().toISOString(),
 };
 
-function findScoopScoopTool() {
+function findScoopScoopTool(resolveModelId?: (id: string) => string | null) {
   const onScoopScoop = vi.fn(
     async (scoop: Omit<RegisteredScoop, 'jid'>): Promise<RegisteredScoop> => ({
       ...scoop,
@@ -33,6 +33,7 @@ function findScoopScoopTool() {
     onSendMessage: vi.fn(),
     getScoops: () => [cone],
     onScoopScoop,
+    ...(resolveModelId ? { resolveModelId } : {}),
   });
 
   const tool = tools.find((t) => t.name === 'scoop_scoop');
@@ -106,6 +107,37 @@ describe('scoop_scoop tool — config defaults', () => {
     const created = onScoopScoop.mock.calls[0][0];
     expect(created.config?.visiblePaths).toEqual(['/workspace/']);
     expect(created.config?.modelId).toBe('claude-sonnet-4-6');
+  });
+
+  // Regression (#1752): an unresolvable model must be rejected, not written
+  // into config.modelId where ScoopContext.init() silently degrades it to the
+  // cone's own (typically far more expensive) model.
+  it('rejects a model the resolver cannot resolve', async () => {
+    const { tool, onScoopScoop } = findScoopScoopTool(() => null);
+    const result = await tool.execute({ name: 'hero-block', model: 'claude-haiku-4-5' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Unknown model "claude-haiku-4-5"');
+    expect(onScoopScoop).not.toHaveBeenCalled();
+  });
+
+  it('stores the resolver-canonicalized id, not the caller-supplied alias', async () => {
+    const { tool, onScoopScoop } = findScoopScoopTool(
+      () => 'us.anthropic.claude-haiku-4-5-20251001-v1:0'
+    );
+    await tool.execute({ name: 'hero-block', model: 'claude-haiku-4-5' });
+
+    const created = onScoopScoop.mock.calls[0][0];
+    expect(created.config?.modelId).toBe('us.anthropic.claude-haiku-4-5-20251001-v1:0');
+  });
+
+  it('does not consult the resolver when no model is specified', async () => {
+    const resolveModelId = vi.fn(() => null);
+    const { tool, onScoopScoop } = findScoopScoopTool(resolveModelId);
+    await tool.execute({ name: 'hero-block' });
+
+    expect(resolveModelId).not.toHaveBeenCalled();
+    expect(onScoopScoop.mock.calls[0][0].config?.modelId).toBeUndefined();
   });
 
   it('injects writablePaths scoped to the new scoop folder plus /shared/', async () => {


### PR DESCRIPTION
## Problem

Fixes #1752.

## Solution

Validation and spawning used different notions of "known", so they could disagree. Validation accepted an id offered by *any* account's `getProviderModels()`; the spawn path resolves `config.modelId` via `resolveModelById()`, which resolves against the **selected** provider only and silently degrades to `resolveCurrentModel()` for anything it doesn't offer.

Reproduced against the real pi-ai catalogue with bedrock-camp selected on Opus 4.8:

| `--model` | validated as | actually ran as |
|---|---|---|
| `claude-haiku-4-5` | `claude-haiku-4-5` | **`us.anthropic.claude-opus-4-8`** |
| `claude-sonnet-4-6` | `global.anthropic.claude-sonnet-4-6` | `global.anthropic.claude-sonnet-4-6` OK |

Sonnet worked by luck: `claude-sonnet-4-6` isn't a bare id in the bedrock registry, so shorthand expansion kicked in and produced a real profile id. `claude-haiku-4-5` *is* a bare id in the `anthropic` registry, so it passed validation verbatim and never got expanded — then failed to resolve at spawn time and fell back to the cone's Opus. Roughly a 5x cost overrun, exit code 0, no warning.

New `resolveModelIdForScoop()` enforces the invariant the spawn path depends on — `resolveModelById(id).id === id` — so what is validated is what runs, and scopes shorthand expansion to the selected provider first.

Two other surfaces had the same latent bug and are fixed alongside `agent --model`:
- **`scoop_scoop`'s `model` arg** wrote straight to `config.modelId` with no validation at all.
- **A persisted `config.modelId`** can still drift (e.g. a provider switch after the scoop was created). Can't be rejected at spawn time, so it now logs a warning instead of degrading silently.

Deliberately *not* consulting the picker filter (`PICKER_HIDDEN_MODEL_PATTERNS`, e.g. `/haiku/i`): a picker-hidden model is a legitimate explicit sub-agent target — that's the whole point of a cheap haiku scoop.

## Testing

New `tests/providers/model-alias-resolution.test.ts` runs against the **real** pi-ai catalogue (no mocked model lists), so a catalogue change that breaks alias resolution fails the suite. Full pass locally: lint, typecheck, tests, coverage (above all four webapp floors), build, and the boy-scout complexity gate.

One pre-existing unrelated failure in `fake-llm/server.test.ts` — verified it fails identically on a clean checkout of `main`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KYPQCNYWEMW5SVQMVC8JNE8B&panel=chat)