### PR TITLE
Coalesce and defer burst licks per scoop

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -652,11 +652,21 @@ Cone executes feed_scoop tool
 ```
 External webhook POST / scheduled cron task / fswatch change fires
   → LickManager receives event in IndexedDB
-    → dispatch() routes to target scoop
-      → ScoopContext processes lick
-        → Agent reacts to event
-        → No human in the loop
+    → dispatch() routes the external lick channel to ScoopMessageRouter
+      → Per-scoop coalescing window (1 s trailing debounce, capped at 3 s)
+        → Router drains all messages since the persisted watermark as one batch
+          ├─ Scoop busy + pure-lick batch
+          │    → Keep queue and watermark unchanged
+          │    → flushOnIdle() probes IndexedDB on the next ready transition
+          │    → createTab() fallback starts the same probe fire-and-forget
+          │    → After 60 s deferred, emit one log warning + onError notification
+          └─ Scoop idle, or batch contains a user message
+               → ScoopContext processes one formatted prompt
+                 → Agent reacts to the batched events
+                 → No human in the loop
 ```
+
+Only external lick channels use the coalescing window. User-typed `web` messages remain immediate, awaited, and error-propagating; one arriving during an open window drains the accumulated licks with it, and a batch containing one is never busy-deferred. The unchanged 2 s poll remains an in-memory safety net for ready scoops, but skips JIDs with an active coalescing window so it cannot split a burst. Idle probes query IndexedDB even when the in-memory queue is empty, preserving deferred delivery across reloads. The `createTab()` fallback does not block startup: it starts the probe fire-and-forget and catches a rejection for logging.
 
 **Topology note:** Lick legs (webhook, crontask, the `/licks-ws` bridge) are `node-rest`-only (standalone thin-bridge, electron, hosted/cloud). Extension-delegate leaders run `crontask` on the in-tab worker `LickManager` (tab-lifetime) and get `webhook` URLs from the connected tray worker. Followers forward `navigate` licks (including SLICC handoffs) to the leader instead of handling them locally. Float discriminator: `resolveFloatTopology()` in `packages/webapp/src/core/float-topology.ts`.
 

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -57,18 +57,19 @@ Deep reference: `docs/kernel/process-model.md`.
 ### Orchestrator
 
 - Path: `packages/webapp/src/scoops/`
-- `orchestrator.ts` creates/destroys scoops, routes messages, manages shared runtime state.
-  `observeScoop(jid, handler)` exposes per-scoop event taps; observers dropped by both
-  `unregisterScoop` and `destroyScoopTab`. `unregisterScoop` fires `onScoopUnregistered`
-  with the pre-removal snapshot for every teardown path — stateful consumers (e.g. the kernel
-  bridge) use it to evict per-scoop chat buffers.
+- `orchestrator.ts` owns scoop lifecycle, routing, shared state, observer teardown, and
+  pre-removal `onScoopUnregistered` snapshots.
+- `scoop-message-router.ts`: licks use `SCOOP_QUEUE_DEBOUNCE_MS` (1 s), bounded by
+  `SCOOP_QUEUE_MAX_COALESCE_MS` (3 s). Pure-lick batches defer while `ScoopContext.isBusy`
+  without queue or watermark loss; `SCOOP_DEFERRAL_STARVATION_MS` warns once at 60 s. User
+  `web` bypasses the window, stays immediate/awaited, and prevents deferral. The 2 s safety
+  poll skips active windows.
 - `scoop-context.ts` owns per-scoop prompt execution and filesystem/tool isolation.
-- `agent-bridge.ts` — `globalThis.__slicc_agent` surface for the `agent` shell command.
-  Sandbox defaults: `writablePaths = [cwd, /shared/, <scratch>/, /tmp/]`,
-  `visiblePaths = [/workspace/, invokingCwd]`; `--read-only` is pure-replace.
-- `transcript-limits.ts` — 64 KB caps for the chat-TRANSCRIPT boundary (bridge buffers,
-  emitted agent events). The canonical agent history (`agent-sessions` DB, compaction input)
-  must **never** route through these helpers.
+- `agent-bridge.ts` exposes `globalThis.__slicc_agent`. Defaults: writable
+  `[cwd, /shared/, <scratch>/, /tmp/]`, visible `[/workspace/, invokingCwd]`; `--read-only`
+  replaces them.
+- `transcript-limits.ts` caps bridge/event transcripts at 64 KB, never canonical
+  `agent-sessions` history or compaction input.
 
 ### VirtualFS
 

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -294,6 +294,7 @@ export class Orchestrator implements ConeApprovalRouter {
       messageRouter: {
         ensureQueue: (jid) => this.messageRouter.ensureQueue(jid),
         forgetScoop: (jid) => this.messageRouter.forgetScoop(jid),
+        flushOnIdle: (jid) => this.messageRouter.flushOnIdle(jid),
       },
       costTracker: { snapshot: (jid) => this.costTracker.snapshot(jid) },
       approvalRouter: { failScoop: (jid) => this.approvalRouter.failScoop(jid) },

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -365,6 +365,11 @@ export class ScoopContext {
     return { captured: this.structuredOutputCaptured, value: this.structuredOutputValue };
   }
 
+  /** Whether a prompt is active or the underlying agent is still streaming. */
+  get isBusy(): boolean {
+    return this.isProcessing || (this.agent?.state?.isStreaming ?? false);
+  }
+
   /**
    * Assemble the sudo enforcement surface for this scoop: the `SudoFS` broker
    * + policy getter + default disposition, plus a matching `ShellSudoConfig`.

--- a/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
+++ b/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
@@ -118,6 +118,7 @@ export interface ScoopLifecycleDeps {
   messageRouter: {
     ensureQueue(jid: string): void;
     forgetScoop(jid: string): void;
+    flushOnIdle(jid: string): Promise<void>;
   };
   /** Cost-tracker snapshot taken before destroying a scoop's context. */
   costTracker: { snapshot(jid: string): void };
@@ -335,6 +336,16 @@ export class ScoopLifecycleManager {
       this.tabs.set(jid, initTab);
       this.deps.callbacks.onStatusChange(jid, 'ready');
       this.dispatch(jid, 'onStatusChange', 'ready');
+      // Probe persisted messages when context init did not emit its own ready
+      // callback (for example, a rehydrated idle scoop).
+      void Promise.resolve()
+        .then(() => this.deps.messageRouter.flushOnIdle(jid))
+        .catch((err) => {
+          log.warn('Initial idle queue probe failed', {
+            jid,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
     }
 
     const scoopForTimer = this.deps.getScoops().get(jid);
@@ -747,6 +758,10 @@ export class ScoopLifecycleManager {
         }
         callbacks.onStatusChange(jid, status);
         this.dispatch(jid, 'onStatusChange', status);
+
+        if (status === 'ready') {
+          void this.deps.messageRouter.flushOnIdle(jid);
+        }
 
         // When a non-cone scoop finishes, route its response to the cone
         // with a VFS path + preview so the cone can decide how to follow up.

--- a/packages/webapp/src/scoops/scoop-message-router.ts
+++ b/packages/webapp/src/scoops/scoop-message-router.ts
@@ -208,22 +208,13 @@ export class ScoopMessageRouter {
       return;
     }
 
-    // Check trigger requirement using the scoop's own trigger
-    // Bypass trigger check for lick messages — they're explicitly routed to this scoop
-    const isLick =
-      message.channel === 'webhook' ||
-      message.channel === 'cron' ||
-      message.channel === 'fswatch' ||
-      message.channel === 'sprinkle';
-    if (!scoop.isCone && scoop.requiresTrigger && scoop.trigger && !isLick) {
-      if (!message.content.includes(scoop.trigger)) {
-        log.info('routeToScoop: trigger not found in content', {
-          chatJid: message.chatJid,
-          trigger: scoop.trigger,
-          contentPreview: message.content.slice(0, 80),
-        });
-        return;
-      }
+    if (!this.passesTriggerGate(scoop, message)) {
+      log.info('routeToScoop: trigger not found in content', {
+        chatJid: message.chatJid,
+        trigger: scoop.trigger,
+        contentPreview: message.content.slice(0, 80),
+      });
+      return;
     }
 
     const queue = this.messageQueues.get(message.chatJid) ?? [];
@@ -254,6 +245,22 @@ export class ScoopMessageRouter {
     }
 
     await this.flushScoopQueue(message.chatJid);
+  }
+
+  private passesTriggerGate(scoop: RegisteredScoop | undefined, message: ChannelMessage): boolean {
+    const isLick =
+      message.channel === 'webhook' ||
+      message.channel === 'cron' ||
+      message.channel === 'fswatch' ||
+      message.channel === 'sprinkle';
+    return (
+      !scoop ||
+      scoop.isCone ||
+      !scoop.requiresTrigger ||
+      !scoop.trigger ||
+      isLick ||
+      message.content.includes(scoop.trigger)
+    );
   }
 
   /** Restart one scoop's trailing window, capped so sustained licks cannot starve. */
@@ -457,6 +464,7 @@ export class ScoopMessageRouter {
     const excludeName = scoop?.assistantLabel ?? jid;
     const since = this.lastAgentTimestamp.get(jid) ?? '';
     const messages = await this.deps.db.getMessagesSince(jid, since, excludeName);
+    const eligibleMessages = messages.filter((message) => this.passesTriggerGate(scoop, message));
 
     log.debug('processScoopQueue: DB query', {
       jid,
@@ -464,6 +472,7 @@ export class ScoopMessageRouter {
       excludeName,
       since,
       dbMessageCount: messages.length,
+      eligibleMessageCount: eligibleMessages.length,
       queueLength: queue.length,
     });
 
@@ -474,13 +483,25 @@ export class ScoopMessageRouter {
       return;
     }
 
-    const isPureLickBatch = messages.every((message) =>
+    if (eligibleMessages.length === 0) {
+      log.debug('processScoopQueue: no messages passed trigger gate, clearing queue', { jid });
+      this.messageQueues.set(jid, []);
+      this.busyDeferrals.delete(jid);
+      const nextWatermark = serializeMessageWatermark(
+        advanceMessageWatermark(parseMessageWatermark(since), messages)
+      );
+      this.lastAgentTimestamp.set(jid, nextWatermark);
+      await this.deps.db.setState(`lastAgentTs_${jid}`, nextWatermark);
+      return;
+    }
+
+    const isPureLickBatch = eligibleMessages.every((message) =>
       this.deps.isExternalLickChannel(message.channel)
     );
     if (isPureLickBatch && this.deps.getContexts().get(jid)?.isBusy) {
       log.debug('processScoopQueue: deferring lick batch while scoop is busy', {
         jid,
-        messageCount: messages.length,
+        messageCount: eligibleMessages.length,
       });
       this.recordBusyDeferral(jid);
       return;
@@ -488,7 +509,7 @@ export class ScoopMessageRouter {
 
     this.busyDeferrals.delete(jid);
 
-    const formatted = messages
+    const formatted = eligibleMessages
       .map((m) => {
         const date = new Date(m.timestamp);
         const time = date.toLocaleString('en-US', {
@@ -501,11 +522,11 @@ export class ScoopMessageRouter {
         return `[${time}] ${m.senderName}: ${formatPromptWithAttachments(m.content, m.attachments)}`;
       })
       .join('\n');
-    const images = messages.flatMap((m) => imageContentFromAttachments(m.attachments));
+    const images = eligibleMessages.flatMap((m) => imageContentFromAttachments(m.attachments));
 
     this.messageQueues.set(jid, []);
 
-    const lastMsg = messages[messages.length - 1];
+    const lastMsg = eligibleMessages[eligibleMessages.length - 1];
     // Advance the high-water mark by the composite (timestamp, id) cursor so a
     // batch that shares one millisecond is consumed exactly once: the id set
     // accumulated at the max ms lets a later pass skip already-delivered rows
@@ -519,7 +540,7 @@ export class ScoopMessageRouter {
     // One steering send anywhere in the batch steers the whole batch — the
     // batch is delivered as a single prompt, so it cannot be split into a
     // steered and a queued half.
-    const steer = messages.some((m) => m.steer);
+    const steer = eligibleMessages.some((m) => m.steer);
 
     await this.deps.sendPrompt(jid, formatted, lastMsg.senderId, lastMsg.senderName, images, {
       steer,

--- a/packages/webapp/src/scoops/scoop-message-router.ts
+++ b/packages/webapp/src/scoops/scoop-message-router.ts
@@ -22,6 +22,7 @@ import type { ChannelMessage, RegisteredScoop, ScoopTabState } from './types.js'
 const log = createLogger('scoop-message-router');
 export const SCOOP_QUEUE_DEBOUNCE_MS = 1000;
 export const SCOOP_QUEUE_MAX_COALESCE_MS = 3000;
+export const SCOOP_DEFERRAL_STARVATION_MS = 60_000;
 
 interface DebounceWaiter {
   messageId: string;
@@ -33,6 +34,16 @@ interface DebounceState {
   startedAt: number;
   timer?: ReturnType<typeof setTimeout>;
   waiters: DebounceWaiter[];
+}
+
+interface ProcessingState {
+  rerun: boolean;
+  done: Promise<void>;
+}
+
+interface BusyDeferralState {
+  startedAt: number;
+  reported: boolean;
 }
 
 export interface ScoopMessageRouterDeps {
@@ -89,7 +100,8 @@ export class ScoopMessageRouter {
    * finishes, so a coalesced caller can await the turn its message lands in.
    * Keyed by jid so distinct scoops still process in parallel.
    */
-  private processing: Map<string, { rerun: boolean; done: Promise<void> }> = new Map();
+  private processing: Map<string, ProcessingState> = new Map();
+  private busyDeferrals: Map<string, BusyDeferralState> = new Map();
 
   constructor(private deps: ScoopMessageRouterDeps) {}
 
@@ -110,6 +122,7 @@ export class ScoopMessageRouter {
     this.cancelDebounce(jid);
     this.messageQueues.delete(jid);
     this.lastAgentTimestamp.delete(jid);
+    this.busyDeferrals.delete(jid);
   }
 
   /** Handle incoming message from a channel. */
@@ -233,7 +246,7 @@ export class ScoopMessageRouter {
         log.warn('routeToScoop: retry init failed', { chatJid: message.chatJid });
       }
     }
-    if (tab?.status !== 'ready') return;
+    if (tab?.status !== 'ready' && tab?.status !== 'processing') return;
 
     if (this.deps.isExternalLickChannel(message.channel)) {
       await this.scheduleScoopQueue(message.chatJid, message.id);
@@ -274,12 +287,56 @@ export class ScoopMessageRouter {
   /** Drain now and settle every debounced caller whose batch was consumed. */
   private async flushScoopQueue(jid: string): Promise<void> {
     const state = this.takeDebounce(jid);
+    if (state && this.processing.has(jid) && this.shouldDeferQueuedLicks(jid)) {
+      for (const waiter of state.waiters) waiter.resolve();
+      this.recordBusyDeferral(jid);
+      return;
+    }
     try {
       await this.processScoopQueue(jid);
       for (const waiter of state?.waiters ?? []) waiter.resolve();
     } catch (err) {
       for (const waiter of state?.waiters ?? []) waiter.reject(err);
       throw err;
+    }
+  }
+
+  /** Flush work retained while a scoop was busy, using the normal serialized drain path. */
+  async flushOnIdle(jid: string): Promise<void> {
+    if (!this.messageQueues.has(jid)) return;
+    try {
+      await this.flushScoopQueue(jid);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error('Idle message queue processing failed', { jid, error: message });
+      this.deps.onError(jid, `Queue processing failed: ${message}`);
+    }
+  }
+
+  private shouldDeferQueuedLicks(jid: string): boolean {
+    const queue = this.messageQueues.get(jid);
+    return (
+      queue !== undefined &&
+      queue.length > 0 &&
+      queue.every((message) => this.deps.isExternalLickChannel(message.channel))
+    );
+  }
+
+  private recordBusyDeferral(jid: string): void {
+    const state = this.busyDeferrals.get(jid) ?? { startedAt: Date.now(), reported: false };
+    this.busyDeferrals.set(jid, state);
+    if (state.reported || Date.now() - state.startedAt < SCOOP_DEFERRAL_STARVATION_MS) return;
+
+    state.reported = true;
+    const error = `Lick queue remained deferred while scoop was busy for ${SCOOP_DEFERRAL_STARVATION_MS / 1000}s`;
+    log.warn('Busy lick queue may be starved', { jid, error });
+    try {
+      this.deps.onError(jid, error);
+    } catch (err) {
+      log.warn('Busy lick queue error callback failed', {
+        jid,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 
@@ -337,7 +394,10 @@ export class ScoopMessageRouter {
       return;
     }
 
-    const state = { rerun: false, done: Promise.resolve() };
+    const state: ProcessingState = {
+      rerun: false,
+      done: Promise.resolve(),
+    };
     this.processing.set(jid, state);
     state.done = this.drainScoopQueue(jid, state);
     return state.done;
@@ -355,7 +415,7 @@ export class ScoopMessageRouter {
    * caller. The `finally` releases the guard even on that path so a failed turn
    * cannot wedge the queue.
    */
-  private async drainScoopQueue(jid: string, state: { rerun: boolean }): Promise<void> {
+  private async drainScoopQueue(jid: string, state: ProcessingState): Promise<void> {
     let failed = false;
     let firstError: unknown;
     try {
@@ -379,13 +439,13 @@ export class ScoopMessageRouter {
   /** Drain one turn of a scoop's queue. Callers must go through {@link processScoopQueue}. */
   private async runScoopQueue(jid: string): Promise<void> {
     const queue = this.messageQueues.get(jid);
-    if (!queue || queue.length === 0) {
-      log.debug('processScoopQueue: empty queue', { jid });
+    if (!queue) {
+      log.debug('processScoopQueue: queue not registered', { jid });
       return;
     }
 
     const tab = this.deps.getTabs().get(jid);
-    if (tab?.status !== 'ready') {
+    if (tab?.status !== 'ready' && tab?.status !== 'processing') {
       log.debug('processScoopQueue: tab not ready', { jid, status: tab?.status ?? 'no-tab' });
       return;
     }
@@ -410,8 +470,23 @@ export class ScoopMessageRouter {
     if (messages.length === 0) {
       log.debug('processScoopQueue: no messages from DB, clearing queue', { jid });
       this.messageQueues.set(jid, []);
+      this.busyDeferrals.delete(jid);
       return;
     }
+
+    const isPureLickBatch = messages.every((message) =>
+      this.deps.isExternalLickChannel(message.channel)
+    );
+    if (isPureLickBatch && this.deps.getContexts().get(jid)?.isBusy) {
+      log.debug('processScoopQueue: deferring lick batch while scoop is busy', {
+        jid,
+        messageCount: messages.length,
+      });
+      this.recordBusyDeferral(jid);
+      return;
+    }
+
+    this.busyDeferrals.delete(jid);
 
     const formatted = messages
       .map((m) => {
@@ -461,7 +536,9 @@ export class ScoopMessageRouter {
     this.pollInterval = setInterval(() => {
       for (const jid of this.deps.getScoops().keys()) {
         const tab = this.deps.getTabs().get(jid);
-        if (tab?.status === 'ready' && !this.debounceStates.has(jid)) {
+        this.recordBusyDeferralIfPresent(jid);
+        const queueHasMessages = (this.messageQueues.get(jid)?.length ?? 0) > 0;
+        if (tab?.status === 'ready' && queueHasMessages && !this.debounceStates.has(jid)) {
           this.processScoopQueue(jid).catch((err) => {
             const message = err instanceof Error ? err.message : String(err);
             log.error('Message queue processing failed', { jid, error: message });
@@ -470,6 +547,10 @@ export class ScoopMessageRouter {
         }
       }
     }, 2000);
+  }
+
+  private recordBusyDeferralIfPresent(jid: string): void {
+    if (this.busyDeferrals.has(jid)) this.recordBusyDeferral(jid);
   }
 
   /** Stop the message polling loop. */
@@ -510,6 +591,7 @@ export class ScoopMessageRouter {
     });
     this.lastAgentTimestamp.delete(jid);
     this.messageQueues.set(jid, []);
+    this.busyDeferrals.delete(jid);
     log.info('Scoop messages cleared', { jid });
   }
 
@@ -529,6 +611,7 @@ export class ScoopMessageRouter {
       ctx.clearMessages();
     }
     this.lastAgentTimestamp.clear();
+    this.busyDeferrals.clear();
     for (const jid of this.deps.getScoops().keys()) {
       this.messageQueues.set(jid, []);
     }
@@ -539,13 +622,17 @@ export class ScoopMessageRouter {
   /** Clear all queued messages for a scoop (removes from both IndexedDB and in-memory queue). */
   async clearQueuedMessages(jid: string): Promise<void> {
     this.cancelDebounce(jid);
-    const queue = this.messageQueues.get(jid);
-    if (queue && queue.length > 0) {
-      for (const msg of queue) {
-        await this.deps.db.deleteMessage(msg.id);
-      }
-      this.messageQueues.set(jid, []);
+    const queue = this.messageQueues.get(jid) ?? [];
+    const scoop = this.deps.getScoops().get(jid);
+    const excludeName = scoop?.assistantLabel ?? jid;
+    const since = this.lastAgentTimestamp.get(jid) ?? '';
+    const persisted = await this.deps.db.getMessagesSince(jid, since, excludeName);
+    const ids = new Set([...queue, ...persisted].map((message) => message.id));
+    for (const id of ids) {
+      await this.deps.db.deleteMessage(id);
     }
+    this.messageQueues.set(jid, []);
+    this.busyDeferrals.delete(jid);
   }
 
   /** Delete a queued message by ID (removes from both IndexedDB and in-memory queue). */
@@ -554,6 +641,7 @@ export class ScoopMessageRouter {
     if (queue) {
       const idx = queue.findIndex((m) => m.id === messageId);
       if (idx !== -1) queue.splice(idx, 1);
+      if (queue.length === 0) this.busyDeferrals.delete(jid);
     }
     this.cancelDebounceWaiter(jid, messageId);
     await this.deps.db.deleteMessage(messageId);

--- a/packages/webapp/src/scoops/scoop-message-router.ts
+++ b/packages/webapp/src/scoops/scoop-message-router.ts
@@ -20,6 +20,20 @@ import { emitScoopLifecycle } from './scoop-telemetry-hook.js';
 import type { ChannelMessage, RegisteredScoop, ScoopTabState } from './types.js';
 
 const log = createLogger('scoop-message-router');
+export const SCOOP_QUEUE_DEBOUNCE_MS = 1000;
+export const SCOOP_QUEUE_MAX_COALESCE_MS = 3000;
+
+interface DebounceWaiter {
+  messageId: string;
+  resolve(): void;
+  reject(error: unknown): void;
+}
+
+interface DebounceState {
+  startedAt: number;
+  timer?: ReturnType<typeof setTimeout>;
+  waiters: DebounceWaiter[];
+}
 
 export interface ScoopMessageRouterDeps {
   /** Live snapshot of registered scoops; the router reads `isCone`, `assistantLabel`, `folder`, `name`, `trigger`, `requiresTrigger`. */
@@ -64,6 +78,7 @@ export class ScoopMessageRouter {
   private messageQueues: Map<string, ChannelMessage[]> = new Map();
   private lastAgentTimestamp: Map<string, string> = new Map();
   private pollInterval: ReturnType<typeof setInterval> | null = null;
+  private debounceStates: Map<string, DebounceState> = new Map();
   /**
    * Per-jid re-entrancy guard for {@link processScoopQueue}. While a run is in
    * flight for a jid, its entry lives here; a re-entrant call sets `rerun` so
@@ -92,6 +107,7 @@ export class ScoopMessageRouter {
 
   /** Drop all per-scoop state on unregister. */
   forgetScoop(jid: string): void {
+    this.cancelDebounce(jid);
     this.messageQueues.delete(jid);
     this.lastAgentTimestamp.delete(jid);
   }
@@ -217,9 +233,82 @@ export class ScoopMessageRouter {
         log.warn('routeToScoop: retry init failed', { chatJid: message.chatJid });
       }
     }
-    if (tab?.status === 'ready') {
-      await this.processScoopQueue(message.chatJid);
+    if (tab?.status !== 'ready') return;
+
+    if (this.deps.isExternalLickChannel(message.channel)) {
+      await this.scheduleScoopQueue(message.chatJid, message.id);
+      return;
     }
+
+    await this.flushScoopQueue(message.chatJid);
+  }
+
+  /** Restart one scoop's trailing window, capped so sustained licks cannot starve. */
+  private scheduleScoopQueue(jid: string, messageId: string): Promise<void> {
+    const state = this.debounceStates.get(jid) ?? {
+      startedAt: Date.now(),
+      waiters: [],
+    };
+    if (state.timer !== undefined) clearTimeout(state.timer);
+
+    const done = new Promise<void>((resolve, reject) => {
+      state.waiters.push({ messageId, resolve, reject });
+    });
+    const remainingMaxWait = Math.max(
+      0,
+      SCOOP_QUEUE_MAX_COALESCE_MS - (Date.now() - state.startedAt)
+    );
+    const delay = Math.min(SCOOP_QUEUE_DEBOUNCE_MS, remainingMaxWait);
+    state.timer = setTimeout(() => {
+      state.timer = undefined;
+      this.flushScoopQueue(jid).catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        log.error('Debounced message queue processing failed', { jid, error: message });
+        this.deps.onError(jid, `Queue processing failed: ${message}`);
+      });
+    }, delay);
+    this.debounceStates.set(jid, state);
+    return done;
+  }
+
+  /** Drain now and settle every debounced caller whose batch was consumed. */
+  private async flushScoopQueue(jid: string): Promise<void> {
+    const state = this.takeDebounce(jid);
+    try {
+      await this.processScoopQueue(jid);
+      for (const waiter of state?.waiters ?? []) waiter.resolve();
+    } catch (err) {
+      for (const waiter of state?.waiters ?? []) waiter.reject(err);
+      throw err;
+    }
+  }
+
+  private takeDebounce(jid: string): DebounceState | undefined {
+    const state = this.debounceStates.get(jid);
+    if (state?.timer !== undefined) clearTimeout(state.timer);
+    this.debounceStates.delete(jid);
+    return state;
+  }
+
+  private cancelDebounce(jid: string): void {
+    const state = this.takeDebounce(jid);
+    for (const waiter of state?.waiters ?? []) waiter.resolve();
+  }
+
+  private cancelDebounces(): void {
+    for (const jid of this.debounceStates.keys()) this.cancelDebounce(jid);
+  }
+
+  private cancelDebounceWaiter(jid: string, messageId: string): void {
+    const state = this.debounceStates.get(jid);
+    if (!state) return;
+    const remaining: DebounceWaiter[] = [];
+    for (const waiter of state.waiters) {
+      if (waiter.messageId === messageId) waiter.resolve();
+      else remaining.push(waiter);
+    }
+    state.waiters = remaining;
+    if (remaining.length === 0) this.cancelDebounce(jid);
   }
 
   /**
@@ -372,7 +461,7 @@ export class ScoopMessageRouter {
     this.pollInterval = setInterval(() => {
       for (const jid of this.deps.getScoops().keys()) {
         const tab = this.deps.getTabs().get(jid);
-        if (tab?.status === 'ready') {
+        if (tab?.status === 'ready' && !this.debounceStates.has(jid)) {
           this.processScoopQueue(jid).catch((err) => {
             const message = err instanceof Error ? err.message : String(err);
             log.error('Message queue processing failed', { jid, error: message });
@@ -385,6 +474,7 @@ export class ScoopMessageRouter {
 
   /** Stop the message polling loop. */
   stopMessageLoop(): void {
+    this.cancelDebounces();
     if (this.pollInterval) {
       clearInterval(this.pollInterval);
       this.pollInterval = null;
@@ -398,6 +488,7 @@ export class ScoopMessageRouter {
    * cleared too.
    */
   async clearScoopMessages(jid: string, context: ScoopContext | undefined): Promise<void> {
+    this.cancelDebounce(jid);
     if (context) {
       context.clearMessages();
       const sessionStore = this.deps.getSessionStore();
@@ -424,6 +515,7 @@ export class ScoopMessageRouter {
 
   /** Clear all messages from the orchestrator DB, agent sessions, and live agent contexts. */
   async clearAllMessages(): Promise<void> {
+    this.cancelDebounces();
     await this.deps.db.clearAllMessages();
     const sessionStore = this.deps.getSessionStore();
     if (sessionStore) {
@@ -446,6 +538,7 @@ export class ScoopMessageRouter {
 
   /** Clear all queued messages for a scoop (removes from both IndexedDB and in-memory queue). */
   async clearQueuedMessages(jid: string): Promise<void> {
+    this.cancelDebounce(jid);
     const queue = this.messageQueues.get(jid);
     if (queue && queue.length > 0) {
       for (const msg of queue) {
@@ -462,6 +555,7 @@ export class ScoopMessageRouter {
       const idx = queue.findIndex((m) => m.id === messageId);
       if (idx !== -1) queue.splice(idx, 1);
     }
+    this.cancelDebounceWaiter(jid, messageId);
     await this.deps.db.deleteMessage(messageId);
   }
 }

--- a/packages/webapp/tests/scoops/scoop-context.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.test.ts
@@ -328,6 +328,17 @@ describe('ScoopContext prompt queueing', () => {
     expect(statusCalls[statusCalls.length - 1][0]).toBe('ready');
   });
 
+  it('reports busy state from prompt processing or agent streaming', () => {
+    injectMockAgent(ctx, async () => {});
+
+    expect(ctx.isBusy).toBe(false);
+    (ctx as any).isProcessing = true;
+    expect(ctx.isBusy).toBe(true);
+    (ctx as any).isProcessing = false;
+    (ctx as any).agent.state.isStreaming = true;
+    expect(ctx.isBusy).toBe(true);
+  });
+
   it('queues prompts via followUp when already processing', async () => {
     const prompts: string[] = [];
     let resolveFirst: () => void;

--- a/packages/webapp/tests/scoops/scoop-lifecycle-manager.test.ts
+++ b/packages/webapp/tests/scoops/scoop-lifecycle-manager.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type ScoopLifecycleDeps,
+  ScoopLifecycleManager,
+} from '../../src/scoops/scoop-lifecycle-manager.js';
+import type { RegisteredScoop } from '../../src/scoops/types.js';
+
+vi.mock('../../src/scoops/scoop-context.js', () => ({
+  ScoopContext: class {
+    async init(): Promise<void> {}
+  },
+}));
+
+const scoop: RegisteredScoop = {
+  jid: 'cone',
+  name: 'Main',
+  folder: 'main',
+  isCone: true,
+  type: 'cone',
+  requiresTrigger: false,
+  assistantLabel: 'sliccy',
+  addedAt: new Date().toISOString(),
+};
+
+function makeManager(flushOnIdle: (jid: string) => Promise<void>): ScoopLifecycleManager {
+  return new ScoopLifecycleManager({
+    getScoops: () => new Map([[scoop.jid, scoop]]),
+    getSharedFs: () => ({}),
+    getSessionStore: () => null,
+    getProcessManager: () => null,
+    getSudoManager: () => null,
+    callbacks: { onStatusChange: vi.fn() },
+    idleTimers: { start: vi.fn(), clear: vi.fn() },
+    messageRouter: {
+      ensureQueue: vi.fn(),
+      forgetScoop: vi.fn(),
+      flushOnIdle,
+    },
+  } as unknown as ScoopLifecycleDeps);
+}
+
+describe('ScoopLifecycleManager', () => {
+  it('probes persisted messages when a constructed tab first becomes ready', async () => {
+    const flushOnIdle = vi.fn(async () => {});
+    const manager = makeManager(flushOnIdle);
+
+    await manager.createTab(scoop.jid);
+
+    expect(manager.getTab(scoop.jid)?.status).toBe('ready');
+    expect(flushOnIdle).toHaveBeenCalledOnce();
+    expect(flushOnIdle).toHaveBeenCalledWith(scoop.jid);
+  });
+
+  it('does not wait for a slow first-ready probe', async () => {
+    const flushOnIdle = vi.fn(() => new Promise<void>(() => {}));
+    const manager = makeManager(flushOnIdle);
+    const timeout = new Promise<never>((_resolve, reject) => {
+      setTimeout(() => reject(new Error('createTab remained pending')), 50);
+    });
+
+    await expect(Promise.race([manager.createTab(scoop.jid), timeout])).resolves.toBeUndefined();
+    expect(flushOnIdle).toHaveBeenCalledOnce();
+  });
+
+  it('contains a rejected first-ready probe', async () => {
+    const flushOnIdle = vi.fn(async () => {
+      throw new Error('probe failed');
+    });
+    const manager = makeManager(flushOnIdle);
+
+    await expect(manager.createTab(scoop.jid)).resolves.toBeUndefined();
+    expect(flushOnIdle).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/webapp/tests/scoops/scoop-message-router.test.ts
+++ b/packages/webapp/tests/scoops/scoop-message-router.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isAfterMessageWatermark, parseMessageWatermark } from '../../src/scoops/db.js';
 import type { ScoopMessageRouterDeps } from '../../src/scoops/scoop-message-router.js';
-import { ScoopMessageRouter } from '../../src/scoops/scoop-message-router.js';
+import {
+  SCOOP_QUEUE_DEBOUNCE_MS,
+  SCOOP_QUEUE_MAX_COALESCE_MS,
+  ScoopMessageRouter,
+} from '../../src/scoops/scoop-message-router.js';
 import type { ChannelMessage, RegisteredScoop, ScoopTabState } from '../../src/scoops/types.js';
 
 /** Yield to the microtask/timer queue so concurrent turns genuinely interleave. */
@@ -20,7 +24,7 @@ function makeScoop(jid: string): RegisteredScoop {
   };
 }
 
-function makeMessage(jid: string, i: number): ChannelMessage {
+function makeMessage(jid: string, i: number, channel = 'chat'): ChannelMessage {
   return {
     id: `id-${jid}-${i}`,
     chatJid: jid,
@@ -29,7 +33,7 @@ function makeMessage(jid: string, i: number): ChannelMessage {
     content: `MSG_${String(i).padStart(3, '0')}`,
     timestamp: new Date(Date.UTC(2026, 0, 1) + i).toISOString(),
     fromAssistant: false,
-    channel: 'chat',
+    channel,
   };
 }
 
@@ -41,6 +45,7 @@ interface Harness {
 
 function makeHarness(opts?: {
   failFirstSend?: boolean;
+  immediateIO?: boolean;
   jids?: string[];
   onSend?: () => Promise<void>;
 }): Harness {
@@ -57,6 +62,7 @@ function makeHarness(opts?: {
   const probe = { max: 0 };
   let active = 0;
   let sendCount = 0;
+  const pause = opts?.immediateIO ? async () => {} : tick;
 
   const deps: ScoopMessageRouterDeps = {
     getScoops: () => scoops,
@@ -64,7 +70,7 @@ function makeHarness(opts?: {
     getContexts: () => new Map(),
     createScoopTab: async () => {},
     sendPrompt: async (_jid, text) => {
-      await tick();
+      await pause();
       if (opts?.onSend) await opts.onSend();
       if (opts?.failFirstSend && sendCount++ === 0) throw new Error('boom');
       sends.push(text);
@@ -75,7 +81,7 @@ function makeHarness(opts?: {
     resetCostTracker: () => {},
     db: {
       saveMessage: async (msg) => {
-        await tick();
+        await pause();
         store.push(msg);
       },
       deleteMessage: async () => {},
@@ -84,7 +90,7 @@ function makeHarness(opts?: {
       getMessagesSince: async (jid, since, excludeName) => {
         active += 1;
         probe.max = Math.max(probe.max, active);
-        await tick();
+        await pause();
         const wm = parseMessageWatermark(since);
         const result = store
           .filter(
@@ -97,7 +103,7 @@ function makeHarness(opts?: {
       },
       setState: async () => {},
     },
-    isExternalLickChannel: () => false,
+    isExternalLickChannel: (channel) => channel === 'webhook',
   };
 
   const router = new ScoopMessageRouter(deps);
@@ -196,5 +202,191 @@ describe('ScoopMessageRouter same-millisecond high-water mark', () => {
       const count = sends.filter((p) => p.includes(token)).length;
       expect(count, `${token} appeared in ${count} payloads`).toBe(1);
     }
+  });
+});
+
+describe('ScoopMessageRouter debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  async function queueLicks(router: ScoopMessageRouter, messages: ChannelMessage[]) {
+    const pending = Promise.all(messages.map((message) => router.handleMessage(message)));
+    await vi.advanceTimersByTimeAsync(0);
+    return { done: pending };
+  }
+
+  async function flushDebounce(): Promise<void> {
+    await vi.advanceTimersByTimeAsync(SCOOP_QUEUE_DEBOUNCE_MS);
+  }
+
+  it('coalesces a burst into one trailing prompt', async () => {
+    const { router, sends } = makeHarness({ immediateIO: true });
+    const messages = Array.from({ length: 10 }, (_, i) => makeMessage('cone', i, 'webhook'));
+
+    const { done } = await queueLicks(router, messages);
+    expect(sends).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(SCOOP_QUEUE_DEBOUNCE_MS - 1);
+    expect(sends).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1);
+    await done;
+
+    expect(sends).toHaveLength(1);
+    for (let i = 0; i < messages.length; i += 1) {
+      expect(sends[0]).toContain(`MSG_${String(i).padStart(3, '0')}`);
+    }
+  });
+
+  it('dispatches an isolated message after one window', async () => {
+    const { router, sends } = makeHarness({ immediateIO: true });
+
+    const { done } = await queueLicks(router, [makeMessage('cone', 0, 'webhook')]);
+    await flushDebounce();
+    await done;
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toContain('MSG_000');
+  });
+
+  it('keeps trailing windows isolated per scoop', async () => {
+    const { router, sends } = makeHarness({ immediateIO: true, jids: ['coneA', 'coneB'] });
+
+    const first = await queueLicks(router, [makeMessage('coneA', 0, 'webhook')]);
+    await vi.advanceTimersByTimeAsync(500);
+    const second = await queueLicks(router, [makeMessage('coneB', 1, 'webhook')]);
+    await vi.advanceTimersByTimeAsync(400);
+    const third = await queueLicks(router, [makeMessage('coneA', 2, 'webhook')]);
+    await vi.advanceTimersByTimeAsync(600);
+    await second.done;
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toContain('MSG_001');
+    await vi.advanceTimersByTimeAsync(400);
+    await Promise.all([first.done, third.done]);
+    expect(sends).toHaveLength(2);
+    expect(sends[1]).toContain('MSG_000');
+    expect(sends[1]).toContain('MSG_002');
+  });
+
+  it('does not let the poll split an active trailing window', async () => {
+    const { router, sends } = makeHarness({ immediateIO: true });
+    router.startMessageLoop();
+    await vi.advanceTimersByTimeAsync(1500);
+    const first = await queueLicks(router, [makeMessage('cone', 0, 'webhook')]);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(sends).toEqual([]);
+    await vi.advanceTimersByTimeAsync(200);
+    const second = await queueLicks(router, [makeMessage('cone', 1, 'webhook')]);
+    await vi.advanceTimersByTimeAsync(SCOOP_QUEUE_DEBOUNCE_MS);
+    await Promise.all([first.done, second.done]);
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toContain('MSG_000');
+    expect(sends[0]).toContain('MSG_001');
+    router.stopMessageLoop();
+  });
+
+  it('bounds a sustained lick stream by the max-wait deadline', async () => {
+    const { router, sends } = makeHarness({ immediateIO: true });
+    router.startMessageLoop();
+    const pending = [await queueLicks(router, [makeMessage('cone', 0, 'webhook')])];
+    await vi.advanceTimersByTimeAsync(800);
+    pending.push(await queueLicks(router, [makeMessage('cone', 1, 'webhook')]));
+    await vi.advanceTimersByTimeAsync(800);
+    pending.push(await queueLicks(router, [makeMessage('cone', 2, 'webhook')]));
+    await vi.advanceTimersByTimeAsync(800);
+    pending.push(await queueLicks(router, [makeMessage('cone', 3, 'webhook')]));
+
+    await vi.advanceTimersByTimeAsync(SCOOP_QUEUE_MAX_COALESCE_MS - 2401);
+    expect(sends).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.all(pending.map(({ done }) => done));
+
+    expect(sends).toHaveLength(1);
+    router.stopMessageLoop();
+  });
+
+  it('delivers web messages immediately without a debounce timer', async () => {
+    const { router, sends } = makeHarness({ immediateIO: true });
+
+    await router.handleMessage(makeMessage('cone', 0, 'web'));
+
+    expect(sends).toHaveLength(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('lets an immediate web message flush a pending lick batch', async () => {
+    const { router, sends } = makeHarness({ immediateIO: true });
+    const lick = await queueLicks(router, [makeMessage('cone', 0, 'webhook')]);
+    await vi.advanceTimersByTimeAsync(500);
+
+    await router.handleMessage(makeMessage('cone', 1, 'web'));
+    await lick.done;
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toContain('MSG_000');
+    expect(sends[0]).toContain('MSG_001');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('propagates immediate web-message send failures', async () => {
+    const { router } = makeHarness({ failFirstSend: true, immediateIO: true });
+
+    await expect(router.handleMessage(makeMessage('cone', 0, 'web'))).rejects.toThrow('boom');
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('keeps debounced delivery awaitable and propagates send failures', async () => {
+    const { router } = makeHarness({ failFirstSend: true, immediateIO: true });
+    const { done } = await queueLicks(router, [makeMessage('cone', 0, 'webhook')]);
+    const rejected = expect(done).rejects.toThrow('boom');
+
+    await flushDebounce();
+
+    await rejected;
+  });
+
+  const cleanupCases: Array<[string, (router: ScoopMessageRouter) => void | Promise<void>]> = [
+    ['forgetScoop', (router) => router.forgetScoop('cone')],
+    ['clearScoopMessages', (router) => router.clearScoopMessages('cone', undefined)],
+    ['clearAllMessages', (router) => router.clearAllMessages()],
+    ['clearQueuedMessages', (router) => router.clearQueuedMessages('cone')],
+    ['stopMessageLoop', (router) => router.stopMessageLoop()],
+  ];
+
+  it.each(cleanupCases)('cancels pending dispatch on %s', async (_name, cleanup) => {
+    const { router, sends } = makeHarness({ immediateIO: true });
+    const { done } = await queueLicks(router, [makeMessage('cone', 0, 'webhook')]);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await cleanup(router);
+    expect(vi.getTimerCount()).toBe(0);
+    await done;
+    await flushDebounce();
+
+    expect(sends).toEqual([]);
+  });
+
+  it('cancels pending dispatch when the final queued message is deleted', async () => {
+    const { router, sends } = makeHarness({ immediateIO: true });
+    const message = makeMessage('cone', 0, 'webhook');
+    const { done } = await queueLicks(router, [message]);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await router.deleteQueuedMessage('cone', message.id);
+    expect(vi.getTimerCount()).toBe(0);
+    await done;
+    await flushDebounce();
+
+    expect(sends).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/packages/webapp/tests/scoops/scoop-message-router.test.ts
+++ b/packages/webapp/tests/scoops/scoop-message-router.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isAfterMessageWatermark, parseMessageWatermark } from '../../src/scoops/db.js';
+import type { ScoopContext } from '../../src/scoops/scoop-context.js';
 import type { ScoopMessageRouterDeps } from '../../src/scoops/scoop-message-router.js';
 import {
+  SCOOP_DEFERRAL_STARVATION_MS,
   SCOOP_QUEUE_DEBOUNCE_MS,
   SCOOP_QUEUE_MAX_COALESCE_MS,
   ScoopMessageRouter,
@@ -41,6 +43,9 @@ interface Harness {
   router: ScoopMessageRouter;
   sends: string[];
   probe: { max: number };
+  stateWrites: string[];
+  store: ChannelMessage[];
+  errors: string[];
 }
 
 function makeHarness(opts?: {
@@ -48,17 +53,24 @@ function makeHarness(opts?: {
   immediateIO?: boolean;
   jids?: string[];
   onSend?: () => Promise<void>;
+  busy?: { value: boolean };
+  tabStatus?: ScoopTabState['status'];
+  store?: ChannelMessage[];
+  lastAgentTimestamp?: string;
+  onError?: (jid: string, error: string) => void;
 }): Harness {
   const jids = opts?.jids ?? ['cone'];
   const scoops = new Map<string, RegisteredScoop>();
   const tabs = new Map<string, ScoopTabState>();
   for (const jid of jids) {
     scoops.set(jid, makeScoop(jid));
-    tabs.set(jid, { jid, contextId: jid, status: 'ready', lastActivity: '' });
+    tabs.set(jid, { jid, contextId: jid, status: opts?.tabStatus ?? 'ready', lastActivity: '' });
   }
 
-  const store: ChannelMessage[] = [];
+  const store = opts?.store ?? [];
   const sends: string[] = [];
+  const stateWrites: string[] = [];
+  const errors: string[] = [];
   const probe = { max: 0 };
   let active = 0;
   let sendCount = 0;
@@ -67,7 +79,18 @@ function makeHarness(opts?: {
   const deps: ScoopMessageRouterDeps = {
     getScoops: () => scoops,
     getTabs: () => tabs,
-    getContexts: () => new Map(),
+    getContexts: () =>
+      new Map(
+        jids.map((jid) => [
+          jid,
+          {
+            get isBusy() {
+              return opts?.busy?.value ?? false;
+            },
+            clearMessages() {},
+          } as ScoopContext,
+        ])
+      ),
     createScoopTab: async () => {},
     sendPrompt: async (_jid, text) => {
       await pause();
@@ -76,7 +99,10 @@ function makeHarness(opts?: {
       sends.push(text);
     },
     notifyIncomingMessage: () => {},
-    onError: () => {},
+    onError: (jid, error) => {
+      errors.push(error);
+      opts?.onError?.(jid, error);
+    },
     getSessionStore: () => null,
     resetCostTracker: () => {},
     db: {
@@ -84,9 +110,18 @@ function makeHarness(opts?: {
         await pause();
         store.push(msg);
       },
-      deleteMessage: async () => {},
-      clearMessagesForScoop: async () => {},
-      clearAllMessages: async () => {},
+      deleteMessage: async (id) => {
+        const index = store.findIndex((message) => message.id === id);
+        if (index !== -1) store.splice(index, 1);
+      },
+      clearMessagesForScoop: async (jid) => {
+        for (let index = store.length - 1; index >= 0; index -= 1) {
+          if (store[index].chatJid === jid) store.splice(index, 1);
+        }
+      },
+      clearAllMessages: async () => {
+        store.length = 0;
+      },
       getMessagesSince: async (jid, since, excludeName) => {
         active += 1;
         probe.max = Math.max(probe.max, active);
@@ -101,14 +136,17 @@ function makeHarness(opts?: {
         active -= 1;
         return result;
       },
-      setState: async () => {},
+      setState: async (_key, value) => {
+        stateWrites.push(value);
+      },
     },
     isExternalLickChannel: (channel) => channel === 'webhook',
   };
 
   const router = new ScoopMessageRouter(deps);
   for (const jid of jids) router.ensureQueue(jid);
-  return { router, sends, probe };
+  if (opts?.lastAgentTimestamp) router.setLastAgentTimestamp(jids[0], opts.lastAgentTimestamp);
+  return { router, sends, probe, stateWrites, store, errors };
 }
 
 describe('ScoopMessageRouter re-entrancy guard', () => {
@@ -352,6 +390,283 @@ describe('ScoopMessageRouter debounce', () => {
     await flushDebounce();
 
     await rejected;
+  });
+
+  it('defers a pure lick batch while busy without advancing its watermark', async () => {
+    const busy = { value: true };
+    const { router, sends, stateWrites } = makeHarness({
+      immediateIO: true,
+      busy,
+      tabStatus: 'processing',
+    });
+    const queued = await queueLicks(router, [
+      makeMessage('cone', 0, 'webhook'),
+      makeMessage('cone', 1, 'webhook'),
+    ]);
+
+    await flushDebounce();
+    await expect(queued.done).resolves.toEqual([undefined, undefined]);
+    expect(sends).toEqual([]);
+    expect(stateWrites).toEqual([]);
+
+    busy.value = false;
+    await router.flushOnIdle('cone');
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toContain('MSG_000');
+    expect(sends[0]).toContain('MSG_001');
+    expect(stateWrites).toHaveLength(1);
+  });
+
+  it('dispatches a mixed web-and-lick batch immediately while busy', async () => {
+    const busy = { value: true };
+    const { router, sends } = makeHarness({ immediateIO: true, busy, tabStatus: 'processing' });
+    const lick = await queueLicks(router, [makeMessage('cone', 0, 'webhook')]);
+
+    await router.handleMessage(makeMessage('cone', 1, 'web'));
+    await lick.done;
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toContain('MSG_000');
+    expect(sends[0]).toContain('MSG_001');
+  });
+
+  it('preserves baseline guard ordering for an active-turn mixed batch', async () => {
+    const busy = { value: false };
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let releaseTurn!: () => void;
+    const turnDone = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    let sendCount = 0;
+    const { router, sends } = makeHarness({
+      immediateIO: true,
+      busy,
+      onSend: async () => {
+        sendCount += 1;
+        if (sendCount !== 1) return;
+        busy.value = true;
+        markStarted();
+        await turnDone;
+        busy.value = false;
+      },
+    });
+    const activeTurn = router.handleMessage(makeMessage('cone', 0, 'web'));
+    await started;
+    const lick = await queueLicks(router, [makeMessage('cone', 1, 'webhook')]);
+    let webSettled = false;
+
+    const web = router.handleMessage(makeMessage('cone', 2, 'web')).then(() => {
+      webSettled = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(webSettled).toBe(false);
+    expect(sends).toEqual([]);
+
+    releaseTurn();
+    await Promise.all([activeTurn, web, lick.done]);
+    expect(sends).toHaveLength(2);
+    for (const token of ['MSG_000', 'MSG_001', 'MSG_002']) {
+      expect(sends.filter((prompt) => prompt.includes(token))).toHaveLength(1);
+    }
+  });
+
+  it('settles lick waiters while an earlier queue drain is still mid-turn', async () => {
+    const busy = { value: false };
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let releaseTurn!: () => void;
+    const turnDone = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    let sendCount = 0;
+    const { router, sends } = makeHarness({
+      immediateIO: true,
+      busy,
+      onSend: async () => {
+        sendCount += 1;
+        if (sendCount !== 1) return;
+        busy.value = true;
+        markStarted();
+        await turnDone;
+        busy.value = false;
+      },
+    });
+    const activeTurn = router.handleMessage(makeMessage('cone', 0, 'web'));
+    await started;
+    const lick = await queueLicks(router, [makeMessage('cone', 1, 'webhook')]);
+
+    await flushDebounce();
+    await expect(lick.done).resolves.toEqual([undefined]);
+    expect(sends).toEqual([]);
+
+    releaseTurn();
+    await activeTurn;
+    await router.flushOnIdle('cone');
+    expect(sends).toHaveLength(2);
+    expect(sends[1]).toContain('MSG_001');
+  });
+
+  it('settles a starved lick waiter when the error callback throws during an active drain', async () => {
+    const busy = { value: false };
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    let releaseTurn!: () => void;
+    const turnDone = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    const { router, errors } = makeHarness({
+      immediateIO: true,
+      busy,
+      onError: () => {
+        throw new Error('error callback failed');
+      },
+      onSend: async () => {
+        busy.value = true;
+        markStarted();
+        await turnDone;
+        busy.value = false;
+      },
+    });
+    const activeTurn = router.handleMessage(makeMessage('cone', 0, 'web'));
+    await started;
+    const first = await queueLicks(router, [makeMessage('cone', 1, 'webhook')]);
+    await flushDebounce();
+    await first.done;
+    await vi.advanceTimersByTimeAsync(SCOOP_DEFERRAL_STARVATION_MS);
+    const starved = await queueLicks(router, [makeMessage('cone', 2, 'webhook')]);
+
+    await flushDebounce();
+    await expect(starved.done).resolves.toEqual([undefined]);
+    expect(errors).toHaveLength(1);
+
+    releaseTurn();
+    await activeTurn;
+  });
+
+  it('recovers deferred IDB messages through idle flush after router reconstruction', async () => {
+    const busy = { value: false };
+    const first = makeHarness({ immediateIO: true, busy });
+    await first.router.handleMessage(makeMessage('cone', 0, 'web'));
+    const restoredWatermark = first.stateWrites.at(-1);
+    busy.value = true;
+    const lick = await queueLicks(first.router, [makeMessage('cone', 1, 'webhook')]);
+    await flushDebounce();
+    await lick.done;
+
+    const restored = makeHarness({
+      immediateIO: true,
+      store: first.store,
+      lastAgentTimestamp: restoredWatermark,
+    });
+    await restored.router.flushOnIdle('cone');
+
+    expect(restored.sends).toHaveLength(1);
+    expect(restored.sends[0]).not.toContain('MSG_000');
+    expect(restored.sends[0]).toContain('MSG_001');
+  });
+
+  it('delivers a reconstructed deferred row once across concurrent startup probes', async () => {
+    const message = makeMessage('cone', 0, 'webhook');
+    const restored = makeHarness({ immediateIO: true, store: [message] });
+
+    await Promise.all([restored.router.flushOnIdle('cone'), restored.router.flushOnIdle('cone')]);
+
+    expect(restored.sends).toHaveLength(1);
+    expect(restored.sends[0]).toContain('MSG_000');
+  });
+
+  it('uses the poll loop as a safety-net flush after busy deferral', async () => {
+    const busy = { value: true };
+    const { router, sends } = makeHarness({ immediateIO: true, busy });
+    router.startMessageLoop();
+    const lick = await queueLicks(router, [makeMessage('cone', 0, 'webhook')]);
+    await flushDebounce();
+    await lick.done;
+
+    busy.value = false;
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toContain('MSG_000');
+    router.stopMessageLoop();
+  });
+
+  it('clears deferred IDB messages after router reconstruction', async () => {
+    const busy = { value: true };
+    const first = makeHarness({ immediateIO: true, busy });
+    const lick = await queueLicks(first.router, [makeMessage('cone', 0, 'webhook')]);
+    await flushDebounce();
+    await lick.done;
+
+    const restored = makeHarness({ immediateIO: true, store: first.store });
+    await restored.router.clearQueuedMessages('cone');
+    restored.router.startMessageLoop();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(restored.store).toEqual([]);
+    expect(restored.sends).toEqual([]);
+    restored.router.stopMessageLoop();
+  });
+
+  it('preserves protected IDB rows when clearing a reconstructed deferred queue', async () => {
+    const busy = { value: false };
+    const first = makeHarness({ immediateIO: true, busy });
+    const processed = makeMessage('cone', 0, 'web');
+    await first.router.handleMessage(processed);
+    const restoredWatermark = first.stateWrites.at(-1);
+    busy.value = true;
+    const deferred = makeMessage('cone', 1, 'webhook');
+    const lick = await queueLicks(first.router, [deferred]);
+    await flushDebounce();
+    await lick.done;
+    const assistant = { ...makeMessage('cone', 2), senderName: 'sliccy', fromAssistant: true };
+    const otherScoop = makeMessage('other', 3, 'webhook');
+    first.store.push(assistant, otherScoop);
+
+    const restored = makeHarness({
+      immediateIO: true,
+      jids: ['cone', 'other'],
+      store: first.store,
+      lastAgentTimestamp: restoredWatermark,
+    });
+    await restored.router.clearQueuedMessages('cone');
+
+    expect(restored.store.map((message) => message.id)).toEqual([
+      processed.id,
+      assistant.id,
+      otherScoop.id,
+    ]);
+  });
+
+  it('reports a permanently busy deferred queue once without dispatching it', async () => {
+    const busy = { value: true };
+    const { router, sends, errors } = makeHarness({
+      immediateIO: true,
+      busy,
+      tabStatus: 'processing',
+    });
+    router.startMessageLoop();
+    const lick = await queueLicks(router, [makeMessage('cone', 0, 'webhook')]);
+    await flushDebounce();
+    await lick.done;
+
+    await vi.advanceTimersByTimeAsync(SCOOP_DEFERRAL_STARVATION_MS + 2000);
+
+    expect(sends).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('remained deferred');
+    await vi.advanceTimersByTimeAsync(SCOOP_DEFERRAL_STARVATION_MS);
+    expect(errors).toHaveLength(1);
+    router.stopMessageLoop();
   });
 
   const cleanupCases: Array<[string, (router: ScoopMessageRouter) => void | Promise<void>]> = [

--- a/packages/webapp/tests/scoops/scoop-message-router.test.ts
+++ b/packages/webapp/tests/scoops/scoop-message-router.test.ts
@@ -42,6 +42,7 @@ function makeMessage(jid: string, i: number, channel = 'chat'): ChannelMessage {
 interface Harness {
   router: ScoopMessageRouter;
   sends: string[];
+  senders: string[];
   probe: { max: number };
   stateWrites: string[];
   store: ChannelMessage[];
@@ -58,17 +59,19 @@ function makeHarness(opts?: {
   store?: ChannelMessage[];
   lastAgentTimestamp?: string;
   onError?: (jid: string, error: string) => void;
+  scoop?: Partial<RegisteredScoop>;
 }): Harness {
   const jids = opts?.jids ?? ['cone'];
   const scoops = new Map<string, RegisteredScoop>();
   const tabs = new Map<string, ScoopTabState>();
   for (const jid of jids) {
-    scoops.set(jid, makeScoop(jid));
+    scoops.set(jid, { ...makeScoop(jid), ...opts?.scoop });
     tabs.set(jid, { jid, contextId: jid, status: opts?.tabStatus ?? 'ready', lastActivity: '' });
   }
 
   const store = opts?.store ?? [];
   const sends: string[] = [];
+  const senders: string[] = [];
   const stateWrites: string[] = [];
   const errors: string[] = [];
   const probe = { max: 0 };
@@ -92,11 +95,12 @@ function makeHarness(opts?: {
         ])
       ),
     createScoopTab: async () => {},
-    sendPrompt: async (_jid, text) => {
+    sendPrompt: async (_jid, text, senderId, senderName) => {
       await pause();
       if (opts?.onSend) await opts.onSend();
       if (opts?.failFirstSend && sendCount++ === 0) throw new Error('boom');
       sends.push(text);
+      senders.push(`${senderId}:${senderName}`);
     },
     notifyIncomingMessage: () => {},
     onError: (jid, error) => {
@@ -140,13 +144,20 @@ function makeHarness(opts?: {
         stateWrites.push(value);
       },
     },
-    isExternalLickChannel: (channel) => channel === 'webhook',
+    isExternalLickChannel: (channel) =>
+      new Set<ChannelMessage['channel']>([
+        'webhook',
+        'cron',
+        'fswatch',
+        'sprinkle',
+        'navigate',
+      ]).has(channel),
   };
 
   const router = new ScoopMessageRouter(deps);
   for (const jid of jids) router.ensureQueue(jid);
   if (opts?.lastAgentTimestamp) router.setLastAgentTimestamp(jids[0], opts.lastAgentTimestamp);
-  return { router, sends, probe, stateWrites, store, errors };
+  return { router, sends, senders, probe, stateWrites, store, errors };
 }
 
 describe('ScoopMessageRouter re-entrancy guard', () => {
@@ -240,6 +251,89 @@ describe('ScoopMessageRouter same-millisecond high-water mark', () => {
       const count = sends.filter((p) => p.includes(token)).length;
       expect(count, `${token} appeared in ${count} payloads`).toBe(1);
     }
+  });
+});
+
+describe('ScoopMessageRouter trigger gate', () => {
+  const triggerScoop: Partial<RegisteredScoop> = {
+    isCone: false,
+    requiresTrigger: true,
+    trigger: '@scoop',
+  };
+
+  it('advances past a persisted rejected row without deferring or replaying it', async () => {
+    const busy = { value: true };
+    const { router, sends, stateWrites } = makeHarness({
+      busy,
+      jids: ['scoop'],
+      scoop: triggerScoop,
+      tabStatus: 'processing',
+    });
+    const rejected = { ...makeMessage('scoop', 0, 'navigate'), content: 'not for this scoop' };
+
+    await router.handleMessage(rejected);
+    await router.flushOnIdle('scoop');
+    await router.flushOnIdle('scoop');
+
+    expect(sends).toEqual([]);
+    expect(stateWrites).toHaveLength(1);
+  });
+
+  it('delivers only eligible rows and uses the last eligible sender', async () => {
+    const eligible = {
+      ...makeMessage('scoop', 0),
+      content: 'hello @scoop',
+      senderId: 'eligible-id',
+      senderName: 'eligible-name',
+    };
+    const rejected = {
+      ...makeMessage('scoop', 1),
+      content: 'not for this scoop',
+      senderId: 'rejected-id',
+      senderName: 'rejected-name',
+    };
+    const { router, sends, senders } = makeHarness({
+      jids: ['scoop'],
+      scoop: triggerScoop,
+      store: [eligible, rejected],
+    });
+
+    await router.flushOnIdle('scoop');
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toContain('hello @scoop');
+    expect(sends[0]).not.toContain('not for this scoop');
+    expect(senders).toEqual(['eligible-id:eligible-name']);
+  });
+
+  it.each<ChannelMessage['channel']>(['webhook', 'cron', 'fswatch', 'sprinkle'])(
+    'lets %s rows bypass the trigger gate',
+    async (channel) => {
+      const message = { ...makeMessage('scoop', 0, channel), content: 'no trigger' };
+      const { router, sends } = makeHarness({
+        jids: ['scoop'],
+        scoop: triggerScoop,
+        store: [message],
+      });
+
+      await router.flushOnIdle('scoop');
+
+      expect(sends).toHaveLength(1);
+      expect(sends[0]).toContain('no trigger');
+    }
+  );
+
+  it('never gates a cone', async () => {
+    const message = { ...makeMessage('cone', 0), content: 'no trigger' };
+    const { router, sends } = makeHarness({
+      scoop: { requiresTrigger: true, trigger: '@cone' },
+      store: [message],
+    });
+
+    await router.flushOnIdle('cone');
+
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toContain('no trigger');
   });
 });
 


### PR DESCRIPTION
A rapid burst of licks (navigation/discovery events) each triggered its own agent turn. A single page load emitting several `navigate` licks in a few hundred milliseconds would wake the cone repeatedly with near-identical context, burning tokens and interleaving partial turns.

Builds on the per-jid serialization and composite watermark from #1738.

## Changes

### 1. Coalesce burst licks per scoop

- **File**: `packages/webapp/src/scoops/scoop-message-router.ts`
- **Change**: Lick channels get a trailing debounce, `SCOOP_QUEUE_DEBOUNCE_MS` (1000 ms), capped by `SCOOP_QUEUE_MAX_COALESCE_MS` (3000 ms) so a sustained stream still lands. User-typed `'web'` messages bypass the window entirely and stay immediate and awaited. Callers get a waiter promise so they can await delivery confirmation rather than fire-and-forget.
- **Tests**: `packages/webapp/tests/scoops/scoop-message-router.test.ts` — burst collapsing, the 3000 ms clamp, waiter settlement on cleanup, and user chat bypassing the window.

### 2. Defer lick batches while the scoop is busy

- **Files**: `packages/webapp/src/scoops/scoop-message-router.ts`, `scoop-context.ts`, `orchestrator.ts`
- **Change**: New `ScoopContext.isBusy` (aggregating `isProcessing` and `agent.state.isStreaming`). A batch containing *only* licks holds while the scoop is busy; a mixed batch containing user chat dispatches immediately. The watermark advances only after a successful `sendPrompt`, so a deferred batch stays durable in IndexedDB. Deferral settles waiters rather than leaving callers hanging for the length of a turn — deferral is not a delivery failure.
- **Tests**: `packages/webapp/tests/scoops/scoop-context.test.ts`, `scoop-message-router.test.ts` — pure-lick deferral, mixed-batch immediacy, watermark non-advancement, waiter settlement.

### 3. Recovery and starvation surfacing

- **Files**: `packages/webapp/src/scoops/scoop-message-router.ts`, `scoop-lifecycle-manager.ts`
- **Change**: `flushOnIdle` probes IndexedDB directly instead of gating on the in-memory queue, so a batch deferred before a reload still lands (after a reload the in-memory queue is empty while the watermark is restored, which would otherwise strand the rows). `createTab()` fires that probe fire-and-forget with a caught rejection, so a slow or failing read cannot stall or break tab creation. The 2 s poll remains the safety net. A scoop stuck busy for `SCOOP_DEFERRAL_STARVATION_MS` (60 s) emits a one-shot `log.warn` plus `onError` instead of deferring silently forever.
- **Tests**: `packages/webapp/tests/scoops/scoop-lifecycle-manager.test.ts`, `scoop-message-router.test.ts` — reload recovery, slow and rejected first-ready probes, concurrent startup probes delivering exactly once, poll-loop fallback, starvation warning fires once.

## Known, out of scope

A user-typed `'web'` message arriving mid-turn joins the coalescing rerun and waits out the per-jid guard. This was measured directly against the pre-branch baseline: it is pre-existing #1738 behaviour, not a regression introduced here. Changing it is a separate behaviour change.

## Verification

Run post-rebase onto `main`, all passing:

- lint
- typecheck
- test
- test:coverage:webapp
- build
- build -w @slicc/chrome-extension
- check-touched-exemptions (9 changed files, 0 debt-list hits)
- check-doc-sizes (`packages/webapp/CLAUDE.md` 19,847/20,000 chars)

Rebased cleanly onto `main` with no conflicts; three commits, linear history, no merge commits.

## Docs

- `docs/architecture.md` — the "Lick (Event) Flow" section now describes the coalescing window, busy deferral, and the poll safety net.
- `packages/webapp/CLAUDE.md` — router timing contract and the three constant names.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author