### PR TITLE
Fix chat scroll pinning, live position, and elastic overscroll

### DIFF
--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -117,8 +117,9 @@ export interface WcShellRefs {
 const STYLE_ID = 'slicc-wcui-style';
 const CSS = [
   // The shell owns the page: kill the UA body margin (the legacy reset died
-  // with base.css) so the frame sits flush against the window edges.
-  'html,body{margin:0;padding:0;height:100%;}',
+  // with base.css) and suppress the manually verified root-viewport elastic
+  // overscroll (not scroll chaining) so the frame stays flush to the window.
+  'html,body{margin:0;padding:0;height:100%;overscroll-behavior:none;}',
   '.wcui-frame{position:relative;transform:translateZ(0);width:100%;height:100vh;',
   'overflow:hidden;background:var(--bg);font-family:var(--ui);}',
   '.wcui-shader{position:absolute;inset:0;z-index:0;}',

--- a/packages/webapp/tests/ui/wc/wc-shell.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-shell.test.ts
@@ -35,6 +35,13 @@ describe('mountWcUiPreview', () => {
     expect(document.querySelectorAll('#slicc-wcui-style').length).toBe(1);
   });
 
+  it('suppresses root-viewport elastic overscroll in the shell document', () => {
+    mount();
+    const css = document.getElementById('slicc-wcui-style')?.textContent ?? '';
+    const rootRule = css.match(/html,body\{([^}]*)\}/)?.[1] ?? '';
+    expect(rootRule).toContain('overscroll-behavior:none;');
+  });
+
   it('replaces prior root content (idempotent mount)', () => {
     const root = mount();
     mountWcUiPreview(root);

--- a/packages/webcomponents/src/chat/slicc-chat-thread.ts
+++ b/packages/webcomponents/src/chat/slicc-chat-thread.ts
@@ -21,7 +21,6 @@ slicc-chat-thread {
   flex: 1 1 auto;
   display: block;
   overflow-y: auto;
-  overscroll-behavior-y: contain;
   min-height: 0;
   /* Always reserve the scrollbar gutter so the reading column's width — and
      therefore its aspect ratio — stays fixed when a context swap changes the

--- a/packages/webcomponents/src/chat/slicc-chat-thread.ts
+++ b/packages/webcomponents/src/chat/slicc-chat-thread.ts
@@ -175,6 +175,15 @@ export class SliccChatThread extends HTMLElement {
   #pendingScrollRestore: string | null = null;
   /** URL `ctx` value captured at connect — the context the restore belongs to. */
   #bootCtx: string | null = null;
+  /** Whether the viewer intends to stay pinned to the newest content. */
+  #following = false;
+  /** Guards scroll events emitted by this component's own scrollTop writes. */
+  #writingScroll = false;
+  #scrollWriteTarget = 0;
+  #scrollWriteFrame: number | null = null;
+  #scrollGuardTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Persistent observer that follows every source of inner-column growth. */
+  #growthObserver: ResizeObserver | null = null;
   #scrollWriteTimer: ReturnType<typeof setTimeout> | null = null;
   #onScrollPersist = (): void => {
     if (!this.urlState) return;
@@ -206,16 +215,6 @@ export class SliccChatThread extends HTMLElement {
   #follow: HTMLElement | null = null;
 
   /**
-   * Re-anchor state for the rail (`open`) toggle. Opening / closing the
-   * workbench rail animates the chat pane's width over ~380ms (see the shell's
-   * transition), which reflows the reading column and moves its bottom. A
-   * viewer pinned to the bottom before the toggle is kept pinned across the
-   * whole animation; a viewer scrolled up keeps their position untouched.
-   */
-  #reanchorObserver: ResizeObserver | null = null;
-  #reanchorTimer: ReturnType<typeof setTimeout> | null = null;
-
-  /**
    * Per-context snapshots of the inner column content, keyed by context id.
    * Each snapshot is a detached fragment of cloned child nodes (no HTML string);
    * restoring re-clones it so the swapped-in nodes are fresh and inert — the
@@ -228,6 +227,7 @@ export class SliccChatThread extends HTMLElement {
     ensureThreadStyle(this.ownerDocument);
     this.#build();
     this.#applyAccent();
+    this.#startGrowthObserver();
     this.scrollToBottom();
     if (this.urlState) {
       this.#pendingScrollRestore = readUrlState('at');
@@ -248,22 +248,15 @@ export class SliccChatThread extends HTMLElement {
       clearTimeout(this.#scrollWriteTimer);
       this.#scrollWriteTimer = null;
     }
-    this.#stopReanchor();
+    this.#growthObserver?.disconnect();
+    this.#growthObserver = null;
+    this.#clearScrollWriteGuard();
   }
 
   attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void {
     if (oldValue === newValue) return;
     if (name === 'accent' && this.#built) this.#applyAccent();
-    // Toggling the rail (`open`) tightens/loosens the column padding instantly
-    // AND animates the parent pane's width — both reflow the column and move its
-    // bottom. Keep a bottom-pinned viewer pinned across the transition. Guarded
-    // to connected + built so pre-mount setup sets don't trip the observer. The
-    // direction matters: CLOSE (`open` removed → newValue null) loosens the
-    // padding and grows the column, so the re-anchor tolerance must absorb that
-    // growth.
-    if (name === 'open' && this.#built && this.isConnected) {
-      this.#reanchorOnRailToggle(newValue === null);
-    }
+    if (name === 'open' && this.#built && this.isConnected) this.#followColumnResize();
     // The thread owns the `ctx` URL param: context switches are user-level
     // navigations, so they PUSH (back button walks contexts). The helper
     // skips no-op writes, so applying a URL-restored context never re-pushes.
@@ -374,44 +367,34 @@ export class SliccChatThread extends HTMLElement {
   /** Pixels from the bottom within which the view still counts as following. */
   static readonly FOLLOW_SLACK = 80;
 
-  /**
-   * Vertical padding the reading column GAINS when the rail closes on a wide
-   * viewport: the normal `56px` top+bottom (112) minus the rail-open `24px`
-   * (48) from the STYLE block above. Closing loosens the padding instantly, so
-   * `scrollHeight` grows by this much before the width animation even starts —
-   * and because the `open` attribute is already applied by the time
-   * {@link attributeChangedCallback} runs, the first layout read already
-   * reflects the loosened (grown) column. A viewer who was within
-   * {@link FOLLOW_SLACK} of the bottom therefore reads up to this much further
-   * away, which is what stranded the newest message ~one padding-delta below
-   * the fold on CLOSE. The re-anchor widens its tolerance by this on close only
-   * (OPEN tightens the padding, so no widening is needed). At ≤560px both rail
-   * states share `16px` padding, so the growth is zero (guarded by matchMedia).
-   */
-  static readonly RAIL_CLOSE_PADDING_GROWTH = 112 - 48;
-
   #nearBottom(): boolean {
     return this.scrollHeight - this.scrollTop - this.clientHeight <= SliccChatThread.FOLLOW_SLACK;
   }
 
   /**
-   * Follow new content politely: scroll to the bottom when the viewer is
-   * already (near) there, otherwise surface the sticky "new messages" chip —
-   * clicking it (or scrolling down manually) jumps/clears.
+   * Follow new content politely: obey the explicit follow mode without
+   * re-measuring post-mutation geometry. Otherwise surface the sticky "new
+   * messages" chip — clicking it (or scrolling down manually) re-arms.
    */
   requestFollow(): void {
     this.#build();
-    if (this.#nearBottom()) {
-      this.scrollToBottom();
+    if (this.#following) {
+      this.#writeScrollTop(this.scrollHeight);
       this.removeAttribute('has-new');
     } else {
       this.setAttribute('has-new', '');
     }
   }
 
-  /** Hide the chip once the viewer is back at the bottom. */
+  /** Update follow mode only from a scroll not emitted by our own write. */
   #onFollowScroll = (): void => {
-    if (this.hasAttribute('has-new') && this.#nearBottom()) this.removeAttribute('has-new');
+    if (this.#writingScroll && Math.abs(this.scrollTop - this.#scrollWriteTarget) <= 1) {
+      this.#clearScrollWriteGuard();
+      return;
+    }
+    this.#clearScrollWriteGuard();
+    this.#following = this.#nearBottom();
+    if (this.#following) this.removeAttribute('has-new');
   };
 
   /**
@@ -434,70 +417,58 @@ export class SliccChatThread extends HTMLElement {
     if (restore != null && nodes.length > 0) {
       requestAnimationFrame(() => {
         if (this.#pendingScrollRestore !== restore) return;
-        this.scrollTop = Number.parseInt(restore, 10) || 0;
+        this.#following = false;
+        this.#writeScrollTop(Number.parseInt(restore, 10) || 0);
+        this.#following = this.#nearBottom();
       });
     }
   }
 
   /** Scroll the thread wrapper to the bottom (latest message). */
   scrollToBottom(): void {
-    this.scrollTop = this.scrollHeight;
+    this.#following = true;
+    this.removeAttribute('has-new');
+    this.#writeScrollTop(this.scrollHeight);
   }
 
-  /**
-   * Keep a bottom-pinned viewer pinned while the rail toggle reflows the
-   * reading column. Decides "was the viewer near the bottom?" then re-pins —
-   * instantly for the synchronous padding change, then on every reflow frame (a
-   * `ResizeObserver` on the column) while the parent pane's width animates,
-   * torn down once the ~380ms transition settles. A viewer who had scrolled up
-   * installs no observer, so their position is left alone.
-   *
-   * The near-bottom check can't be snapshotted before the reflow — the `open`
-   * attribute is already applied when {@link attributeChangedCallback} runs, so
-   * the first layout read reflects the new padding. On CLOSE (`loosening`) that
-   * padding grew the column by {@link RAIL_CLOSE_PADDING_GROWTH}, pushing a
-   * once-pinned viewer's measured distance up by that much; widen the tolerance
-   * by the same amount so they still count as near-bottom and re-anchor (this
-   * is the CLOSE-case gap the OPEN path never had). OPEN tightens the padding,
-   * so its tolerance stays {@link FOLLOW_SLACK}. A genuinely scrolled-up viewer
-   * is still well past the widened tolerance, so they are not yanked either way.
-   */
-  #reanchorOnRailToggle(loosening: boolean): void {
-    const growth =
-      loosening && !this.#isNarrowRail() ? SliccChatThread.RAIL_CLOSE_PADDING_GROWTH : 0;
-    const slack = SliccChatThread.FOLLOW_SLACK + growth;
-    const wasNearBottom = this.scrollHeight - this.scrollTop - this.clientHeight <= slack;
-    this.#stopReanchor();
-    if (!wasNearBottom) return;
-    this.scrollToBottom();
+  /** Observe the inner column for every growth source, not only append call sites. */
+  #startGrowthObserver(): void {
+    this.#growthObserver?.disconnect();
     if (typeof ResizeObserver !== 'function') return;
-    this.#reanchorObserver = new ResizeObserver(() => {
-      if (this.scrollHeight - this.scrollTop - this.clientHeight <= slack) this.scrollToBottom();
-    });
-    this.#reanchorObserver.observe(this.#inner);
-    this.#reanchorTimer = setTimeout(() => this.#stopReanchor(), 450);
+    this.#growthObserver = new ResizeObserver(() => this.#followColumnResize());
+    this.#growthObserver.observe(this.#inner);
   }
 
-  /**
-   * Whether the viewport is in the narrow / extension-sidebar regime where both
-   * rail states share the same column padding (STYLE `@media (max-width:560px)`)
-   * — so closing the rail grows nothing and the re-anchor must NOT widen its
-   * tolerance (that would yank a slightly scrolled-up viewer to the bottom).
-   */
-  #isNarrowRail(): boolean {
-    return typeof matchMedia === 'function' && matchMedia('(max-width: 560px)').matches;
+  /** Follow a column resize without deriving the mode from post-resize geometry. */
+  #followColumnResize(): void {
+    if (!this.#following) return;
+    const pendingUpwardScroll = this.#scrollWriteTarget - this.scrollTop;
+    if (this.#writingScroll && pendingUpwardScroll > SliccChatThread.FOLLOW_SLACK) return;
+    this.#writeScrollTop(this.scrollHeight);
   }
 
-  /** Stop any in-flight rail-toggle re-anchor (observer + timer). */
-  #stopReanchor(): void {
-    if (this.#reanchorObserver) {
-      this.#reanchorObserver.disconnect();
-      this.#reanchorObserver = null;
+  /** Write scrollTop without letting the resulting event masquerade as user intent. */
+  #writeScrollTop(value: number): void {
+    this.#writingScroll = true;
+    this.scrollTop = value;
+    this.#scrollWriteTarget = this.scrollTop;
+    if (this.#scrollWriteFrame != null) cancelAnimationFrame(this.#scrollWriteFrame);
+    if (this.#scrollGuardTimer != null) clearTimeout(this.#scrollGuardTimer);
+    const supportsScrollEnd = 'onscrollend' in HTMLElement.prototype;
+    if (supportsScrollEnd) {
+      this.#scrollGuardTimer = setTimeout(() => this.#clearScrollWriteGuard(), 100);
+    } else {
+      this.#scrollWriteFrame = requestAnimationFrame(() => this.#clearScrollWriteGuard());
     }
-    if (this.#reanchorTimer != null) {
-      clearTimeout(this.#reanchorTimer);
-      this.#reanchorTimer = null;
-    }
+  }
+
+  /** Clear the component-write guard after scrolling settles. */
+  #clearScrollWriteGuard(): void {
+    this.#writingScroll = false;
+    if (this.#scrollWriteFrame != null) cancelAnimationFrame(this.#scrollWriteFrame);
+    this.#scrollWriteFrame = null;
+    if (this.#scrollGuardTimer != null) clearTimeout(this.#scrollGuardTimer);
+    this.#scrollGuardTimer = null;
   }
 
   /**
@@ -551,11 +522,11 @@ export class SliccChatThread extends HTMLElement {
     followBtn.append('New messages', chevron);
     followBtn.addEventListener('click', () => {
       this.scrollToBottom();
-      this.removeAttribute('has-new');
     });
     this.#follow.append(followBtn);
     this.appendChild(this.#follow);
     this.addEventListener('scroll', this.#onFollowScroll, { passive: true });
+    this.addEventListener('scrollend', () => this.#clearScrollWriteGuard(), { passive: true });
 
     this.#onClick = (ev: MouseEvent) => {
       const target = ev.target;

--- a/packages/webcomponents/src/chat/slicc-chat-thread.ts
+++ b/packages/webcomponents/src/chat/slicc-chat-thread.ts
@@ -21,6 +21,7 @@ slicc-chat-thread {
   flex: 1 1 auto;
   display: block;
   overflow-y: auto;
+  overscroll-behavior-y: contain;
   min-height: 0;
   /* Always reserve the scrollbar gutter so the reading column's width — and
      therefore its aspect ratio — stays fixed when a context swap changes the
@@ -117,6 +118,7 @@ slicc-chat-thread[open] > .slicc-thread__inner {
 `;
 
 const STYLE_ID = 'slicc-chat-thread-style';
+const SCROLL_PERSIST_INTERVAL_MS = 120;
 
 /** Inject the scoped thread stylesheet into a document once (idempotent). */
 function ensureThreadStyle(doc: Document): void {
@@ -153,7 +155,7 @@ function ensureThreadStyle(doc: Document): void {
  * @slot - default; message / day-label / card children, rendered in DOM order
  * @attr url-state - boolean; the thread persists its own URL params — `ctx`
  *   (context, pushed as a history entry) and `at` (scroll position, replaced,
- *   debounced). On `popstate` it re-applies `at` itself and asks the host to
+ *   throttled). On `popstate` it re-applies `at` itself and asks the host to
  *   route `ctx` via `slicc-url-context` (selection is app state).
  * @fires slicc-url-context - composed + bubbling; `detail.context` when a
  *   popstate carries a different context than the current one
@@ -185,13 +187,29 @@ export class SliccChatThread extends HTMLElement {
   /** Persistent observer that follows every source of inner-column growth. */
   #growthObserver: ResizeObserver | null = null;
   #scrollWriteTimer: ReturnType<typeof setTimeout> | null = null;
+  #lastScrollWriteAt: number | null = null;
+  #persistScrollPosition = (): void => {
+    this.#scrollWriteTimer = null;
+    this.#lastScrollWriteAt = performance.now();
+    writeUrlState('at', String(Math.round(this.scrollTop)));
+  };
   #onScrollPersist = (): void => {
     if (!this.urlState) return;
-    if (this.#scrollWriteTimer != null) clearTimeout(this.#scrollWriteTimer);
-    this.#scrollWriteTimer = setTimeout(() => {
-      this.#scrollWriteTimer = null;
-      writeUrlState('at', String(Math.round(this.scrollTop)));
-    }, 300);
+    const elapsed =
+      this.#lastScrollWriteAt == null
+        ? SCROLL_PERSIST_INTERVAL_MS
+        : performance.now() - this.#lastScrollWriteAt;
+    if (elapsed >= SCROLL_PERSIST_INTERVAL_MS) {
+      if (this.#scrollWriteTimer != null) clearTimeout(this.#scrollWriteTimer);
+      this.#persistScrollPosition();
+      return;
+    }
+    if (this.#scrollWriteTimer == null) {
+      this.#scrollWriteTimer = setTimeout(
+        this.#persistScrollPosition,
+        SCROLL_PERSIST_INTERVAL_MS - elapsed
+      );
+    }
   };
   #onPopState = (): void => {
     if (!this.urlState) return;
@@ -248,6 +266,7 @@ export class SliccChatThread extends HTMLElement {
       clearTimeout(this.#scrollWriteTimer);
       this.#scrollWriteTimer = null;
     }
+    this.#lastScrollWriteAt = null;
     this.#growthObserver?.disconnect();
     this.#growthObserver = null;
     this.#clearScrollWriteGuard();

--- a/packages/webcomponents/tests/chat/slicc-chat-thread.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-chat-thread.test.ts
@@ -181,11 +181,6 @@ describe('slicc-chat-thread', () => {
       expect(getComputedStyle(el).overflowY).toBe('auto');
     });
 
-    it('contains vertical overscroll at the thread boundary', () => {
-      const el = mount();
-      expect(getComputedStyle(el).overscrollBehaviorY).toBe('contain');
-    });
-
     it('reserves a stable scrollbar gutter so context swaps do not shift the column', () => {
       const el = mount();
       expect(getComputedStyle(el).scrollbarGutter).toBe('stable');

--- a/packages/webcomponents/tests/chat/slicc-chat-thread.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-chat-thread.test.ts
@@ -16,6 +16,12 @@ function inner(el: SliccChatThread): HTMLElement {
   return el.querySelector('.slicc-thread__inner') as HTMLElement;
 }
 
+/** Wait for layout and its ResizeObserver delivery. */
+async function settleResize(): Promise<void> {
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+}
+
 describe('slicc-chat-thread', () => {
   beforeEach(() => {
     ensureGlobalTokens();
@@ -300,6 +306,69 @@ describe('slicc-chat-thread', () => {
       expect(wrapper.childNodes.length).toBe(0);
     });
 
+    it('keeps an at= restore authoritative over same-frame column growth', async () => {
+      const originalUrl = window.location.href;
+      const restoreUrl = new URL(originalUrl);
+      restoreUrl.searchParams.set('at', '240');
+      const RealResizeObserver = globalThis.ResizeObserver;
+      let capturedCb: ResizeObserverCallback | undefined;
+      class FakeResizeObserver {
+        constructor(cb: ResizeObserverCallback) {
+          capturedCb = cb;
+        }
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+      }
+      history.replaceState(null, '', restoreUrl);
+      globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver;
+      let el: SliccChatThread | null = null;
+      try {
+        el = mount((thread) => {
+          thread.urlState = true;
+          thread.style.cssText = 'display:block;height:120px;overflow-y:auto;';
+        });
+        const tall = document.createElement('div');
+        tall.style.height = '1200px';
+        el.replaceContent(tall);
+
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+        expect(el.scrollTop).toBe(240);
+        capturedCb?.([], {} as ResizeObserver);
+        expect(el.scrollTop).toBe(240);
+      } finally {
+        el?.remove();
+        globalThis.ResizeObserver = RealResizeObserver;
+        history.replaceState(null, '', originalUrl);
+      }
+    });
+
+    it('keeps following when an at= restore resolves to the bottom', async () => {
+      const originalUrl = window.location.href;
+      const restoreUrl = new URL(originalUrl);
+      restoreUrl.searchParams.set('at', '99999');
+      history.replaceState(null, '', restoreUrl);
+      let el: SliccChatThread | null = null;
+      try {
+        el = mount((thread) => {
+          thread.urlState = true;
+          thread.style.cssText = 'display:block;height:120px;overflow-y:auto;';
+        });
+        const tall = document.createElement('div');
+        tall.style.height = '1200px';
+        el.replaceContent(tall);
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+        expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(1);
+
+        tall.style.height = '1600px';
+        await settleResize();
+        expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(1);
+      } finally {
+        el?.remove();
+        history.replaceState(null, '', originalUrl);
+      }
+    });
+
     it('re-emits child clicks as a delegated slicc-thread-action', async () => {
       const el = mount();
       const btn = document.createElement('button');
@@ -393,6 +462,7 @@ describe('slicc-chat-thread', () => {
     it('requestFollow raises the chip instead of yanking a scrolled-away viewer', () => {
       const el = mountScrollable();
       el.scrollTop = 0;
+      el.dispatchEvent(new Event('scroll'));
       el.requestFollow();
       expect(el.scrollTop).toBe(0);
       expect(el.hasAttribute('has-new')).toBe(true);
@@ -401,6 +471,7 @@ describe('slicc-chat-thread', () => {
     it('append() routes through requestFollow (chip when scrolled away)', () => {
       const el = mountScrollable();
       el.scrollTop = 0;
+      el.dispatchEvent(new Event('scroll'));
       const m = document.createElement('div');
       m.textContent = 'new arrival';
       el.append(m);
@@ -411,6 +482,7 @@ describe('slicc-chat-thread', () => {
     it('clicking the chip scrolls to the bottom and clears has-new', () => {
       const el = mountScrollable();
       el.scrollTop = 0;
+      el.dispatchEvent(new Event('scroll'));
       el.requestFollow();
       chip(el).click();
       expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(1);
@@ -420,6 +492,7 @@ describe('slicc-chat-thread', () => {
     it('scrolling back near the bottom clears has-new without a click', () => {
       const el = mountScrollable();
       el.scrollTop = 0;
+      el.dispatchEvent(new Event('scroll'));
       el.requestFollow();
       el.scrollTop = el.scrollHeight; // user scrolls down themselves
       el.dispatchEvent(new Event('scroll'));
@@ -429,9 +502,88 @@ describe('slicc-chat-thread', () => {
     it('replaceContent clears a stale chip', () => {
       const el = mountScrollable();
       el.scrollTop = 0;
+      el.dispatchEvent(new Event('scroll'));
       el.requestFollow();
       expect(el.hasAttribute('has-new')).toBe(true);
       el.replaceContent(document.createElement('div'));
+      expect(el.hasAttribute('has-new')).toBe(false);
+    });
+
+    it('keeps a bottom-pinned viewer pinned after one large append', async () => {
+      const el = mountScrollable();
+      el.scrollToBottom();
+      const arrival = document.createElement('div');
+      arrival.style.height = `${SliccChatThread.FOLLOW_SLACK + 220}px`;
+      el.append(arrival);
+
+      await settleResize();
+
+      expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(1);
+      expect(el.hasAttribute('has-new')).toBe(false);
+    });
+
+    it('stays pinned through consecutive large appends', async () => {
+      const el = mountScrollable();
+      el.scrollToBottom();
+      for (let i = 0; i < 3; i += 1) {
+        const arrival = document.createElement('div');
+        arrival.style.height = `${SliccChatThread.FOLLOW_SLACK + 120}px`;
+        el.append(arrival);
+        await settleResize();
+        expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(1);
+      }
+      expect(el.hasAttribute('has-new')).toBe(false);
+    });
+
+    it('does not yank a deliberately scrolled-up viewer after a large append', async () => {
+      const el = mountScrollable();
+      const pinnedArrival = document.createElement('div');
+      pinnedArrival.style.height = `${SliccChatThread.FOLLOW_SLACK + 220}px`;
+      el.append(pinnedArrival);
+      await settleResize();
+      expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(1);
+
+      el.scrollTop = 0;
+      el.dispatchEvent(new Event('scroll'));
+      const arrival = document.createElement('div');
+      arrival.style.height = `${SliccChatThread.FOLLOW_SLACK + 220}px`;
+      el.append(arrival);
+
+      await settleResize();
+
+      expect(el.scrollTop).toBe(0);
+      expect(el.hasAttribute('has-new')).toBe(true);
+    });
+
+    it('re-arms following from the chip for subsequent large appends', async () => {
+      const el = mountScrollable();
+      el.scrollTop = 0;
+      el.dispatchEvent(new Event('scroll'));
+      el.append(Object.assign(document.createElement('div'), { textContent: 'first arrival' }));
+      expect(el.hasAttribute('has-new')).toBe(true);
+
+      chip(el).click();
+      const arrival = document.createElement('div');
+      arrival.style.height = `${SliccChatThread.FOLLOW_SLACK + 220}px`;
+      el.append(arrival);
+      await settleResize();
+
+      expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(1);
+      expect(el.hasAttribute('has-new')).toBe(false);
+    });
+
+    it('stays pinned when existing content grows without requestFollow', async () => {
+      const el = mountScrollable();
+      const lateContent = document.createElement('div');
+      lateContent.style.height = '24px';
+      el.append(lateContent);
+      await settleResize();
+      el.scrollToBottom();
+
+      lateContent.style.height = `${SliccChatThread.FOLLOW_SLACK + 320}px`;
+      await settleResize();
+
+      expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(1);
       expect(el.hasAttribute('has-new')).toBe(false);
     });
   });
@@ -466,16 +618,16 @@ describe('slicc-chat-thread', () => {
     it('leaves a scrolled-up viewer where they are when the rail toggles', () => {
       const el = mountScrollable();
       el.scrollTop = 0;
-      // Not near the bottom → no re-anchor; the reading position is respected.
+      // A viewer parked in history is not following, so rail changes respect their position.
       el.open = true;
       expect(el.scrollTop).toBe(0);
     });
 
     it('re-anchors on CLOSE even when the viewer was near (not pixel-pinned to) the bottom', () => {
-      // Regression: the CLOSE loosen (24/32 → 56/72) grows the column by
-      // RAIL_CLOSE_PADDING_GROWTH, so a viewer sitting within FOLLOW_SLACK of
-      // the bottom — but not exactly on it — read as "past FOLLOW_SLACK" once
-      // the padding loosened and was stranded ~a padding-delta below the fold.
+      // Regression: the CLOSE loosen (24/32 → 56/72) grows the column after the
+      // viewer has already chosen to follow. The growth follow path must retain
+      // that intent instead of re-measuring after the padding change and leaving
+      // the newest message stranded below the fold.
       const el = mountScrollable();
       el.open = true; // rail open → tight padding
       el.scrollToBottom();
@@ -485,13 +637,13 @@ describe('slicc-chat-thread', () => {
         SliccChatThread.FOLLOW_SLACK
       );
       el.open = false; // CLOSE → padding loosens, column grows
-      // The widened close tolerance keeps them pinned: newest message stays in view.
+      // Column growth keeps a following viewer pinned: newest message stays in view.
       expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(1);
     });
 
     it('does NOT re-anchor on CLOSE when the viewer is scrolled up in history', () => {
-      // The close-only widening must not become a blanket "jump to bottom": a
-      // reader parked in history stays put through a CLOSE just like an OPEN.
+      // A reader parked in history is not following, so CLOSE-driven column
+      // growth does not scroll them; their reading position stays fixed.
       const el = mountScrollable();
       el.open = true;
       el.scrollTop = 0;
@@ -500,10 +652,10 @@ describe('slicc-chat-thread', () => {
     });
 
     it('lets an intentional upward scroll mid-animation break the re-anchor pin', () => {
-      // The observer that keeps a pinned viewer glued to the bottom across the
-      // ~380ms width transition must re-check the near-bottom condition on each
-      // reflow tick: a viewer who deliberately scrolls up beyond the slack is
-      // no longer following, so the tick must NOT yank them back down.
+      // The persistent column-growth observer checks the explicit follow mode on
+      // each delivery instead of re-measuring near-bottom geometry. If an upward
+      // gesture lands during a guarded component write, the guard must preserve it
+      // until the scroll event disarms following rather than yank the viewer down.
       const RealResizeObserver = globalThis.ResizeObserver;
       let capturedCb: ResizeObserverCallback | undefined;
       class FakeResizeObserver {
@@ -519,11 +671,11 @@ describe('slicc-chat-thread', () => {
         const el = mountScrollable();
         el.open = true; // rail open → tight padding
         el.scrollToBottom();
-        el.open = false; // CLOSE while pinned → installs the guarded observer
+        el.open = false; // CLOSE while pinned → guarded synchronous follow write
         expect(capturedCb).toBeTypeOf('function');
-        // The viewer deliberately scrolls up past the (widened) tolerance.
+        // The viewer deliberately scrolls up past FOLLOW_SLACK.
         el.scrollTop = 0;
-        // A reflow tick fires: the guard must see they are no longer following.
+        // A resize delivery arrives before the scroll event; preserve the upward gesture.
         capturedCb?.([], {} as ResizeObserver);
         expect(el.scrollTop).toBe(0);
       } finally {

--- a/packages/webcomponents/tests/chat/slicc-chat-thread.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-chat-thread.test.ts
@@ -181,6 +181,11 @@ describe('slicc-chat-thread', () => {
       expect(getComputedStyle(el).overflowY).toBe('auto');
     });
 
+    it('contains vertical overscroll at the thread boundary', () => {
+      const el = mount();
+      expect(getComputedStyle(el).overscrollBehaviorY).toBe('contain');
+    });
+
     it('reserves a stable scrollbar gutter so context swaps do not shift the column', () => {
       const el = mount();
       expect(getComputedStyle(el).scrollbarGutter).toBe('stable');
@@ -417,6 +422,47 @@ describe('slicc-chat-thread', () => {
       // Allow for sub-pixel rounding at the scroll extent.
       expect(el.scrollTop).toBeGreaterThan(0);
       expect(el.scrollHeight - el.scrollTop - el.clientHeight).toBeLessThanOrEqual(1);
+    });
+
+    it('persists rounded at= positions during a continuous scroll without adding history', async () => {
+      const originalUrl = window.location.href;
+      const cleanUrl = new URL(originalUrl);
+      cleanUrl.search = '';
+      history.replaceState(null, '', cleanUrl);
+      const historyDepth = history.length;
+      let scrollTimer: number | undefined;
+      let el: SliccChatThread | null = null;
+      try {
+        el = mount((thread) => {
+          thread.urlState = true;
+          thread.style.cssText = 'display:block;height:120px;overflow-y:auto;';
+        });
+        const thread = el;
+        const tall = document.createElement('div');
+        tall.style.height = '1200px';
+        thread.replaceContent(tall);
+        let position = 160.4;
+        thread.scrollTop = position;
+        thread.dispatchEvent(new Event('scroll'));
+        expect(new URLSearchParams(window.location.search).get('at')).toBe('160');
+
+        scrollTimer = window.setInterval(() => {
+          position += 80.4;
+          thread.scrollTop = position;
+          thread.dispatchEvent(new Event('scroll'));
+        }, 40);
+
+        await new Promise((resolve) => setTimeout(resolve, 190));
+
+        const liveAt = Number(new URLSearchParams(window.location.search).get('at'));
+        expect(liveAt).toBeGreaterThan(Math.round(160.4));
+        expect(Number.isInteger(liveAt)).toBe(true);
+        expect(history.length).toBe(historyDepth);
+      } finally {
+        if (scrollTimer != null) clearInterval(scrollTimer);
+        el?.remove();
+        history.replaceState(null, '', originalUrl);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

This fixes three independent chat scrolling defects in three semantic commits.

1. **Keep a bottom-pinned thread following streamed content.** The old implementation inferred follow mode from geometry after content had already changed that geometry. Starting at `fromBottom: 0`, appending a 300 px node produced a measured 306 px gap, displayed the new-message chip, and permanently latched following off. Follow intent is now explicit, user-controlled state; guarded synchronous writes handle known append paths, while a persistent `ResizeObserver` covers other growth sources without moving readers who deliberately scroll up.

2. **Persist the live scroll position in `at=`.** The previous 300 ms trailing debounce left the URL stale throughout a gesture: across six wheel events, `scrollTop` moved 9720 → 8720 while `at` remained 9920, then updated only after scrolling stopped. A 120 ms leading/trailing throttle now keeps rounded `at` values moving during the gesture, performs a final trailing write, uses `replaceState`, and cleans up on disconnect.

3. **Suppress root-viewport elastic overscroll without disabling local thread elasticity.** Manual trackpad diagnosis showed the full-UI white-gap bounce still occurred while the thread, body, and document were all non-scrollable, ruling out scroll chaining. Applying `overscroll-behavior: none` to the shell's `html, body` rule removed the bounce, so the earlier component-level containment was removed atomically with the shell fix. The thread remains locally elastic while the root viewport no longer rubber-bands the whole UI.

## Verification

- Linear-history gate: pass
- Lint: pass
- Typecheck: pass
- Root tests: pass
- Focused chat-thread tests: 45/45 pass
- Focused webapp shell tests: 22/22 pass
- Touched-file complexity gate: pass
- Webapp coverage: pass with `--testTimeout=15000 --maxWorkers=4`
- Webcomponents coverage: the canonical run reproduces only the accepted pre-existing clipboard paste failure in `slicc-input-card.test.ts` (1,735/1,736); excluding that unrelated file gives 1,682/1,682 and 92.52% statements / 80.15% branches / 95.17% functions / 95.37% lines, above the unchanged 91/80/95/95 floors
- Full build: pass
- Chrome extension build: pass
- Bundle-size budgets: pass
- Each intermediate semantic commit independently builds `@slicc/webcomponents`

## Manual overscroll evidence

The overscroll fix was verified with a human macOS trackpad gesture. Synthetic CDP wheel input cannot reproduce macOS elastic overscroll: a differential automated run produced identical no-motion traces with containment enabled and disabled, so it cannot validate this behavior. After moving suppression to the root shell and removing the probe, `html` and `body` computed to `none`, the thread computed to `auto`, and the human trackpad re-check confirmed the full-UI bounce was gone.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author