### PR TITLE
feat(realm): implement child_process sync forms over the sync-XHR bridge

### DIFF
--- a/docs/kernel/process-model.md
+++ b/docs/kernel/process-model.md
@@ -186,14 +186,21 @@ after; neither await exists here. Instead the sync bridge flushes pending
 `SyncFsCache` mutations over the blocking fs channel (which is why the fs route
 also carries live `mkdir` / `rm`), then **invalidates** the cache after the
 command rather than re-snapshotting — every sync read already falls through to
-the live bridge on a miss, so invalidation is correct and far cheaper.
+the live bridge on a miss, so invalidation is correct and far cheaper. That
+fall-through covers the removals too (`rmSync` / `rmdirSync` / `unlinkSync` /
+`renameSync`): after an invalidate a cache miss is not proof of absence, so a
+miss deletes through the live bridge and tombstones the path. `renameSync` of a
+live-only **directory** is the one gap — a recursive live walk over a blocking
+XHR is too expensive, so it raises `EISDIR`.
 
 **No bridge → throw**: without a controlling SW there is no way to block on a
 host round-trip, so the sync forms throw a message naming `promisify(exec)`.
 `spawnSync` reports it on `.error` instead (it never throws).
 
 **Not killable mid-call**: a blocked `execSync` cannot be SIGINT'd; only realm
-`worker.terminate()` (SIGKILL, exit 137) reaches it.
+`worker.terminate()` (SIGKILL, exit 137) reaches it. Realm disposal then revokes
+the sync token, which aborts the in-flight `ctx.exec` too (`trackSyncExec`), so
+a killed realm cannot strand a running command.
 
 ## Wiring map
 

--- a/docs/kernel/process-model.md
+++ b/docs/kernel/process-model.md
@@ -153,6 +153,48 @@ model). `accessSync`/`chmodSync` are existence-gated no-ops. `appendFileSync`,
 write-through, so an over-cap or post-snapshot source copies its real bytes
 (never a silent 0-byte).
 
+## Synchronous exec bridge
+
+`child_process.execSync` / `execFileSync` / `spawnSync` ride the same
+transport. `realm/sync-xhr.ts` (`synchronify`) holds the blocking round-trip
+both channels share — marker gate, errno recovery, fail-closed transport — so
+the fs and exec channels differ only in route and payload.
+
+**Route**: `POST /__slicc/exec-sync` with a JSON command envelope (the command
+never has to survive URL encoding). The kernel-worker responder resolves the
+same per-realm token and dispatches through the realm's own **`ctx.exec`** —
+the handle the async `exec` RPC uses — so the sudo command guard, path ACLs,
+and secret masking are inherited unchanged. The token entry widened from
+`{ fs, cwd }` to `{ fs, exec, cwd }`; one token covers both channels because
+they share a mint site, a lifetime, and a revocation, and a realm that can
+drive `ctx.exec` can already reach the filesystem through the shell.
+
+**Sudo while blocked**: the realm worker is blocked on the XHR, but the sudo
+brokers live in the kernel worker (HTTP) and the page (panel-RPC), so an
+approval prompt still renders and resolves — the blocked thread is never on the
+approval path.
+
+**Timeout**: a file read finishes in milliseconds, a build command does not, so
+the exec channel derives its budget from Node's `timeout` option (default 2
+minutes, capped at 10). The responder aborts the in-flight `ctx.exec` at the
+budget, and its dedupe TTL is derived from the larger of the two channel
+budgets so a late SW re-post replays the cached result instead of re-running
+the command.
+
+**Cache coherence**: the async exec bridge does flush-before / re-snapshot-
+after; neither await exists here. Instead the sync bridge flushes pending
+`SyncFsCache` mutations over the blocking fs channel (which is why the fs route
+also carries live `mkdir` / `rm`), then **invalidates** the cache after the
+command rather than re-snapshotting — every sync read already falls through to
+the live bridge on a miss, so invalidation is correct and far cheaper.
+
+**No bridge → throw**: without a controlling SW there is no way to block on a
+host round-trip, so the sync forms throw a message naming `promisify(exec)`.
+`spawnSync` reports it on `.error` instead (it never throws).
+
+**Not killable mid-call**: a blocked `execSync` cannot be SIGINT'd; only realm
+`worker.terminate()` (SIGKILL, exit 137) reaches it.
+
 ## Wiring map
 
 `createKernelHost` builds the manager and threads it explicitly through:

--- a/docs/node-compat-shims.md
+++ b/docs/node-compat-shims.md
@@ -116,7 +116,25 @@ Async forms (backed by shell exec RPC):
 (Readable), `.stdin` (writable), `.pid`, `.exitCode`, `.kill(signal?)`,
 and `exit`/`close`/`error` events.
 
-**Not available (throws):** `execSync`, `spawnSync`, `execFileSync`, `fork`.
+Sync forms (backed by the blocking sync-XHR bridge — see
+[`architecture.md`](architecture.md)):
+
+| Method                             | Notes                                               |
+| ---------------------------------- | --------------------------------------------------- |
+| `execSync(cmd, opts?)`             | Returns stdout (Buffer, or string with `encoding`)  |
+| `execFileSync(file, args?, opts?)` | Shell-free argv form                                |
+| `spawnSync(cmd, args?, opts?)`     | Returns `{ status, stdout, stderr, signal, error }` |
+
+`execSync` / `execFileSync` throw on a non-zero exit with Node's
+`.status` / `.stdout` / `.stderr` / `.signal` fields; `spawnSync` never throws
+and reports on `.status` / `.error`. `opts.timeout` bounds the command (capped
+at 10 minutes); `opts.input` supplies stdin.
+
+These need a controlling Service Worker to block the realm worker on a host
+round-trip. On a float without one (extension follower, boot before SW control)
+they throw an error naming the async escape hatch instead.
+
+**Not available (throws):** `fork`.
 
 ### `process`
 

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -1058,9 +1058,12 @@ const { stdout } = await h.done;
 realm) resolves to a shim over `exec.start`: `exec` / `execFile` / `spawn`
 return a `ChildProcess` EventEmitter (`'exit'` / `'close'`, Readable
 `.stdout` / `.stderr`); `exec` / `execFile` carry `util.promisify.custom`. The
-sync forms (`execSync` / `spawnSync` / `execFileSync`) and `fork` throw — no
-synchronous or long-lived process model. `.bsh` scripts run in the target page
-(no shell bridge), so `child_process` is unavailable there.
+sync forms (`execSync` / `execFileSync` / `spawnSync`) run on the blocking
+sync-XHR bridge and follow Node's return/throw contracts; they need a
+controlling Service Worker, so on a float without one they throw an error
+naming the async escape hatch. `fork` always throws — no long-lived process
+model. `.bsh` scripts run in the target page (no shell bridge), so
+`child_process` is unavailable there.
 
 #### require / module / exports
 
@@ -1559,15 +1562,15 @@ Packages are fetched from [esm.sh](https://esm.sh) and cached for the session. V
 
 Some Node.js built-in modules are available via `require()`:
 
-| Module                                           | Status                                                                                            |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `fs`                                             | ✅ VFS bridge (readFile, writeFile, readDir, exists, stat, mkdir, rm)                             |
-| `process`                                        | ✅ Shim (argv, env, cwd, exit, stdout, stderr)                                                    |
-| `buffer`                                         | ✅ Browser polyfill                                                                               |
-| `path`                                           | ✅ Via esm.sh (browser polyfill)                                                                  |
-| `url`, `querystring`, `util`, `events`, `assert` | ✅ Via esm.sh                                                                                     |
-| `child_process`                                  | ✅ Realm shim over the `exec.start` bridge (`exec`/`execFile`/`spawn`; sync forms + `fork` throw) |
-| `http`, `https`, `crypto`, `net`, etc.           | ❌ Not available in browser                                                                       |
+| Module                                           | Status                                                                                                                     |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `fs`                                             | ✅ VFS bridge (readFile, writeFile, readDir, exists, stat, mkdir, rm)                                                      |
+| `process`                                        | ✅ Shim (argv, env, cwd, exit, stdout, stderr)                                                                             |
+| `buffer`                                         | ✅ Browser polyfill                                                                                                        |
+| `path`                                           | ✅ Via esm.sh (browser polyfill)                                                                                           |
+| `url`, `querystring`, `util`, `events`, `assert` | ✅ Via esm.sh                                                                                                              |
+| `child_process`                                  | ✅ Realm shim over the `exec.start` bridge (`exec`/`execFile`/`spawn`); sync forms over the sync-XHR bridge; `fork` throws |
+| `http`, `https`, `crypto`, `net`, etc.           | ❌ Not available in browser                                                                                                |
 
 The `node:` prefix is supported: `require('node:path')` works the same as `require('path')`.
 

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -47,10 +47,11 @@ User → ChatPanel → Orchestrator → ScoopContext.prompt() → pi-agent-core 
   run in the kernel worker via `createJsWorkerRealm()` → `js-realm-shared.ts`, in every
   float.** Kernel-side `realm-host` proxies `vfs` / `exec` / `fetch` RPC. The extension
   iframe realm path (`createIframeRealm`) is fully removed.
-- `realm/sync-fs-*.ts` + `ui/sync-fs-sw-handler.ts` — synchronous `readFileSync`/
-  `writeFileSync` for realm scripts via bounded snapshot + SW BroadcastChannel XHR fallback;
-  capability-token-scoped to the calling realm's `RestrictedFS`.
-  See `docs/kernel/process-model.md` for method surface and cold-start behavior.
+- `realm/sync-{xhr,fs-*,exec-*}.ts` + `ui/sync-fs-sw-handler.ts` — synchronous
+  `readFileSync`/`writeFileSync` and `child_process.execSync`/`execFileSync`/`spawnSync`
+  for realm scripts, over one blocking sync-XHR transport (`synchronify`) and one
+  capability token scoped to the calling realm's `ctx.fs` / `ctx.exec`.
+  See `docs/kernel/process-model.md` for method surface, coherence, and cold-start.
 
 Deep reference: `docs/kernel/process-model.md`.
 

--- a/packages/webapp/src/kernel/realm/js-realm-helpers.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-helpers.ts
@@ -1709,9 +1709,12 @@ export const nodeStream = {
 // exec pipeline. `spawn`'s `.stdout` / `.stderr` are the `nodeStream` Readable
 // stubs, each emitting a single `'data'` chunk then `'end'`; the `ChildProcess`
 // is an EventEmitter that fires `'exit'` / `'close'`. The sync forms
-// (`execSync` / `spawnSync` / `execFileSync`) and `fork` throw — just-bash has
-// no synchronous or long-lived process model. Because the shim needs the
-// per-realm `exec` bridge it is a FACTORY (unlike the static `node*` shims);
+// (`execSync` / `execFileSync` / `spawnSync`) run on the SEPARATE synchronous
+// exec bridge (blocking sync-XHR → SW → kernel responder), which is available
+// only when the realm has one — a float with no controlling Service Worker gets
+// a throw naming the async escape hatch instead. `fork` always throws:
+// just-bash has no long-lived process model. Because the shim needs the
+// per-realm bridges it is a FACTORY (unlike the static `node*` shims);
 // `js-realm-shared.ts` builds one instance per realm and `realm-module-system.ts`
 // serves it from `resolveServedBuiltin`.
 // ---------------------------------------------------------------------------
@@ -1741,14 +1744,41 @@ export interface CpExecBridge {
   start(commandOrArgv: string | string[], opts?: CpExecStartOptions): CpExecHandle;
 }
 
+/**
+ * Structural slice of the SYNCHRONOUS exec bridge (`sync-exec-xhr-bridge.ts`)
+ * the sync forms need. Present only when the realm's SW sync bridge is enabled;
+ * absent → the sync forms throw with an actionable message.
+ */
+export interface CpSyncExecBridge {
+  run(
+    command: string | string[],
+    opts?: { args?: string[]; input?: string; timeout?: number }
+  ): CpExecResult;
+}
+
 interface CpOptions {
   encoding?: string | null;
   input?: string | ArrayBufferView;
   shell?: boolean | string;
+  /** Milliseconds before the command is aborted (sync forms). */
+  timeout?: number;
+  /** `spawnSync`-family: `pipe` (default) or `inherit`-alike; unused, accepted for parity. */
+  stdio?: unknown;
 }
 
 type CpChunk = string | Buffer;
 type CpExecCallback = (error: Error | null, stdout: CpChunk, stderr: CpChunk) => void;
+
+/** `spawnSync`'s never-throws return shape. */
+export interface CpSpawnSyncResult {
+  pid: number;
+  status: number | null;
+  signal: string | null;
+  stdout: CpChunk;
+  stderr: CpChunk;
+  output: Array<CpChunk | null>;
+  error?: Error;
+}
 
 export interface NodeChildProcess {
   exec(
@@ -1763,9 +1793,9 @@ export interface NodeChildProcess {
     callback?: CpExecCallback
   ): ChildProcess;
   spawn(command: string, args?: string[] | CpOptions, options?: CpOptions): ChildProcess;
-  execSync(...args: unknown[]): never;
-  spawnSync(...args: unknown[]): never;
-  execFileSync(...args: unknown[]): never;
+  execSync(command: string, options?: CpOptions): CpChunk;
+  execFileSync(file: string, args?: string[] | CpOptions, options?: CpOptions): CpChunk;
+  spawnSync(command: string, args?: string[] | CpOptions, options?: CpOptions): CpSpawnSyncResult;
   fork(...args: unknown[]): never;
   ChildProcess: typeof ChildProcess;
 }
@@ -1876,6 +1906,137 @@ class ChildProcess extends EventEmitter {
 }
 
 /**
+ * Build the three synchronous forms over the blocking exec bridge. Kept out of
+ * {@link createNodeChildProcess} because the two families share nothing but the
+ * bridge: the async forms are callback/stream-shaped, these are blocking and
+ * follow Node's per-form return/throw contracts.
+ *
+ * Node defaults the sync forms to Buffer output (unlike `exec`, whose callback
+ * defaults to utf8), and splits the failure contract: `execSync` /
+ * `execFileSync` throw on a non-zero exit, `spawnSync` never throws and reports
+ * on `.status` / `.error`.
+ */
+function createCpSyncForms(
+  syncExec: CpSyncExecBridge | undefined
+): Pick<NodeChildProcess, 'execSync' | 'execFileSync' | 'spawnSync'> {
+  /**
+   * Run one command, or throw the no-bridge error. The sync forms need the SW
+   * sync bridge (a page-confirmed Service Worker controller); on a float that
+   * has none — an extension follower, an in-process test, or a boot before SW
+   * control — there is no way to block a realm worker on a host round-trip, so
+   * they fail with a message that names the async escape hatch.
+   */
+  const runSync = (
+    name: string,
+    command: string | string[],
+    opts: { input?: string; timeout?: number }
+  ): CpExecResult => {
+    if (!syncExec) {
+      throw new Error(
+        `child_process.${name} is not available in this browser realm ` +
+          '(no synchronous bridge — the page has no controlling Service Worker). ' +
+          `Use the async form instead: await promisify(${name.replace(/Sync$/, '')})(…).`
+      );
+    }
+    return syncExec.run(command, opts);
+  };
+
+  const runOptions = (options: CpOptions): { input?: string; timeout?: number } => ({
+    ...(options.input !== undefined ? { input: cpChunkToString(options.input) } : {}),
+    ...(options.timeout !== undefined ? { timeout: options.timeout } : {}),
+  });
+
+  /** The shared `execSync` / `execFileSync` throw-on-non-zero-exit contract. */
+  const throwingSync = (
+    name: string,
+    command: string | string[],
+    label: string,
+    options: CpOptions
+  ): CpChunk => {
+    const encoding = options.encoding === undefined ? 'buffer' : options.encoding;
+    const result = runSync(name, command, runOptions(options));
+    const stdout = cpEncodeChunk(result.stdout, encoding);
+    const stderr = cpEncodeChunk(result.stderr, encoding);
+    if (result.exitCode === 0) return stdout;
+    throw Object.assign(new Error(`Command failed: ${label}\n${result.stderr}`), {
+      status: result.exitCode,
+      signal: null,
+      stdout,
+      stderr,
+      output: [null, stdout, stderr],
+      pid: nextCpPid++,
+    });
+  };
+
+  /** `(file, args?, options?)` / `(command, args?, options?)` normalization. */
+  const splitArgs = (
+    argsOrOptions?: string[] | CpOptions,
+    maybeOptions?: CpOptions
+  ): { args: string[]; options: CpOptions } => ({
+    args: Array.isArray(argsOrOptions) ? argsOrOptions : [],
+    options: (Array.isArray(argsOrOptions) ? maybeOptions : argsOrOptions) ?? {},
+  });
+
+  return {
+    execSync: (command: string, options: CpOptions = {}): CpChunk =>
+      throwingSync('execSync', command, command, options),
+
+    execFileSync: (
+      file: string,
+      argsOrOptions?: string[] | CpOptions,
+      maybeOptions?: CpOptions
+    ): CpChunk => {
+      const { args, options } = splitArgs(argsOrOptions, maybeOptions);
+      // Shell-free argv form — matches `execFile`'s no-shell semantics.
+      const argv = [file, ...args];
+      return throwingSync('execFileSync', argv, argv.join(' '), options);
+    },
+
+    spawnSync: (
+      command: string,
+      argsOrOptions?: string[] | CpOptions,
+      maybeOptions?: CpOptions
+    ): CpSpawnSyncResult => {
+      const { args, options } = splitArgs(argsOrOptions, maybeOptions);
+      const encoding = options.encoding === undefined ? 'buffer' : options.encoding;
+      const pid = nextCpPid++;
+      // Default is shell-free (argv form); `shell:true` runs the joined string —
+      // mirrors the async `spawn`.
+      const commandOrArgv: string | string[] = options.shell
+        ? `${command}${args.length ? ` ${args.join(' ')}` : ''}`
+        : [command, ...args];
+      let result: CpExecResult;
+      try {
+        result = runSync('spawnSync', commandOrArgv, runOptions(options));
+      } catch (err) {
+        // spawnSync NEVER throws — a transport / no-bridge failure surfaces on
+        // `.error` with a null status, exactly as it does for ENOENT in Node.
+        const empty = cpEncodeChunk('', encoding);
+        return {
+          pid,
+          status: null,
+          signal: null,
+          stdout: empty,
+          stderr: empty,
+          output: [null, empty, empty],
+          error: err instanceof Error ? err : new Error(String(err)),
+        };
+      }
+      const stdout = cpEncodeChunk(result.stdout, encoding);
+      const stderr = cpEncodeChunk(result.stderr, encoding);
+      return {
+        pid,
+        status: result.exitCode,
+        signal: null,
+        stdout,
+        stderr,
+        output: [null, stdout, stderr],
+      };
+    },
+  };
+}
+
+/**
  * Build a per-realm `child_process` shim over the supplied `exec` bridge. Each
  * of `exec` / `execFile` / `spawn` allocates one `exec.start` handle and
  * auto-launches it on the next microtask so synchronous `stdin.write` / `.end`
@@ -1883,7 +2044,10 @@ class ChildProcess extends EventEmitter {
  * no-op once the caller ended stdin). `exec` / `execFile` also carry a
  * `util.promisify.custom` implementation resolving `{ stdout, stderr }`.
  */
-export function createNodeChildProcess(exec: CpExecBridge): NodeChildProcess {
+export function createNodeChildProcess(
+  exec: CpExecBridge,
+  syncExec?: CpSyncExecBridge
+): NodeChildProcess {
   const launch = (
     commandOrArgv: string | string[],
     options: CpOptions,
@@ -2035,6 +2199,8 @@ export function createNodeChildProcess(exec: CpExecBridge): NodeChildProcess {
     throw new Error(`child_process.${name} is not available in the browser realm`);
   };
 
+  const sync = createCpSyncForms(syncExec);
+
   const attachPromisify = (fn: object, impl: Function): void => {
     Object.defineProperty(fn, UTIL_PROMISIFY_CUSTOM, {
       value: impl,
@@ -2049,9 +2215,9 @@ export function createNodeChildProcess(exec: CpExecBridge): NodeChildProcess {
     exec: execImpl,
     execFile: execFileImpl,
     spawn: spawnImpl,
-    execSync: cpUnavailable('execSync'),
-    spawnSync: cpUnavailable('spawnSync'),
-    execFileSync: cpUnavailable('execFileSync'),
+    execSync: sync.execSync,
+    spawnSync: sync.spawnSync,
+    execFileSync: sync.execFileSync,
     fork: cpUnavailable('fork'),
     ChildProcess,
   };

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -44,8 +44,9 @@ import { createSerialBridge, type RealmSerialApi } from './realm-serial-bridge.j
 import type { RealmDoneMsg, RealmInitMsg, SerializedFetchResponse } from './realm-types.js';
 import { createUsbBridge, type RealmUsbApi } from './realm-usb-bridge.js';
 import { createSkillGlobal, type SkillFsBridge } from './skill-global.js';
+import { createSyncExecXhrBridge, type SyncExecXhrBridge } from './sync-exec-xhr-bridge.js';
 import { SyncFsCache, type SyncFsSnapshot } from './sync-fs-cache.js';
-import { createSyncFsXhrBridge, type SyncFsXhrBridge } from './sync-fs-xhr-bridge.js';
+import { createSyncFsXhrBridge, type SyncFsXhrMutatingBridge } from './sync-fs-xhr-bridge.js';
 
 /**
  * Request the `vfs.snapshot` RPC and build the {@link SyncFsCache} it backs.
@@ -98,8 +99,30 @@ function syncFsSnapshotErrorSink(
  * absent (default / in-process tests / boot-before-control) → `undefined` →
  * the bounded snapshot fallback. See `sync-fs-xhr-bridge.ts` + the plan.
  */
-function resolveSyncFsBridge(init: RealmInitMsg): SyncFsXhrBridge | undefined {
+function resolveSyncFsBridge(init: RealmInitMsg): SyncFsXhrMutatingBridge | undefined {
   return init.syncFsToken ? createSyncFsXhrBridge(init.syncFsToken) : undefined;
+}
+
+/**
+ * Install both synchronous bridges, built off the ONE per-realm capability
+ * token. The sync `fs` shim is merged into `fsBridge`; the `child_process` sync
+ * forms ride their own blocking channel but share the fs bridge and the cache,
+ * so they can flush pending sync-fs mutations to the live VFS before a command
+ * runs and invalidate the cache after it. Returns the exec bridge (`undefined`
+ * on a realm with no token — the sync `child_process` forms then throw).
+ */
+function installSyncBridges(
+  init: RealmInitMsg,
+  syncFs: SyncFsCache,
+  fsBridge: object
+): SyncExecXhrBridge | undefined {
+  const syncFsXhr = resolveSyncFsBridge(init);
+  Object.assign(fsBridge, createSyncFsBridge(syncFs, init.cwd, syncFsXhr));
+  if (!init.syncFsToken) return undefined;
+  return createSyncExecXhrBridge(init.syncFsToken, {
+    syncFs,
+    ...(syncFsXhr ? { fsBridge: syncFsXhr } : {}),
+  });
 }
 
 /**
@@ -166,7 +189,7 @@ export async function runJsRealm(init: RealmInitMsg, port: RealmPortLike): Promi
   const fsBridge = createFsBridge(rpc, realmFetch);
 
   const syncFs = await initSyncFsCache(rpc, init.cwd, syncFsSnapshotErrorSink(init, writeStderr));
-  Object.assign(fsBridge, createSyncFsBridge(syncFs, init.cwd, resolveSyncFsBridge(init)));
+  const syncExecBridge = installSyncBridges(init, syncFs, fsBridge);
 
   const execBridge = createExecBridge(rpc, syncFs, init.cwd, writeStderr);
   const agentModule = createSliccyAgentModule(execBridge, { cwd: init.cwd });
@@ -240,7 +263,7 @@ export async function runJsRealm(init: RealmInitMsg, port: RealmPortLike): Promi
     graph,
     fsBridge,
     processShim: proc.processShim,
-    childProcess: createNodeChildProcess(execBridge), // per-realm `child_process` shim over `exec`
+    childProcess: createNodeChildProcess(execBridge, syncExecBridge), // per-realm `child_process` shim over `exec`
     nodeConsole,
     sliccyModules,
     shimmedPackages: buildShimmedPackages(rpc),

--- a/packages/webapp/src/kernel/realm/realm-fs-bridge.ts
+++ b/packages/webapp/src/kernel/realm/realm-fs-bridge.ts
@@ -6,7 +6,7 @@
  */
 import type { RealmRpcClient } from './realm-rpc.js';
 import { normalizePath, type SyncFsCache } from './sync-fs-cache.js';
-import type { SyncFsXhrBridge } from './sync-fs-xhr-bridge.js';
+import type { SyncFsXhrBridge, SyncFsXhrMutatingBridge } from './sync-fs-xhr-bridge.js';
 
 /** RPC-backed `fs` bridge (the realm's `require('fs')` / `fs` global). */
 export function createFsBridge(
@@ -185,6 +185,114 @@ function syncFsErr(code: string, resolved: string, verb = ''): Error & { code: s
   });
 }
 
+/**
+ * Cache-first removal with a live-bridge fallback; `false` → genuinely absent,
+ * so the caller can raise Node's `ENOENT`.
+ *
+ * A cache miss is not proof of absence once `execSync` has invalidated the
+ * cache (`sync-exec-xhr-bridge`) or the file post-dates the boot snapshot — the
+ * live VFS may still hold it, and a cache-only delete would leave it behind
+ * while `unlinkSync` reported `ENOENT`. On a miss this deletes live, then
+ * tombstones so later reads don't resurrect it through the bridge.
+ *
+ * Module-level rather than a closure inside `createSyncFsBridge` only to keep
+ * that factory under the function-length lint gate.
+ */
+function removeWithBridgeFallback(
+  syncFs: SyncFsCache,
+  bridge: SyncFsXhrBridge | undefined,
+  resolved: string,
+  opts: { recursive?: boolean; requireFile?: boolean } = {}
+): boolean {
+  const recursive = opts.recursive === true;
+  try {
+    if (opts.requireFile) syncFs.unlink(resolved);
+    else syncFs.rm(resolved, recursive);
+    return true;
+  } catch (err) {
+    // Only a genuine miss falls through — EISDIR / ENOTEMPTY are real Node
+    // errors the caller must see.
+    if ((err as { code?: string })?.code !== 'ENOENT') throw err;
+  }
+  const mutating = bridge as SyncFsXhrMutatingBridge | undefined;
+  if (!mutating?.rm || syncFs.isTombstoned(resolved)) return false;
+  try {
+    if (!mutating.exists(resolved)) return false;
+  } catch {
+    return false;
+  }
+  mutating.rm(resolved);
+  syncFs.markRemoved(resolved, recursive);
+  return true;
+}
+
+/** The `createSyncFsBridge` internals the removal ops need. See {@link createRemovalOps}. */
+interface RemovalDeps {
+  syncFs: SyncFsCache;
+  bridge: SyncFsXhrBridge | undefined;
+  resolve: (p: string) => string;
+  existsResolved: (resolved: string) => boolean;
+  statResolved: (resolved: string) => { isFile: boolean; isDirectory: boolean; size: number };
+  readBytes: (resolved: string) => Uint8Array;
+  writeThrough: (resolved: string, bytes: Uint8Array) => void;
+}
+
+/**
+ * The four removal ops, split out of `createSyncFsBridge` purely to keep that
+ * factory under the function-length lint gate. All of them go through
+ * {@link removeWithBridgeFallback} so a live-only path is really deleted.
+ */
+function createRemovalOps(deps: RemovalDeps) {
+  const { syncFs, bridge, resolve, existsResolved, statResolved, readBytes, writeThrough } = deps;
+  const remove = (resolved: string, opts?: { recursive?: boolean; requireFile?: boolean }) =>
+    removeWithBridgeFallback(syncFs, bridge, resolved, opts);
+  return {
+    rmSync(path: string, opts?: { recursive?: boolean; force?: boolean }): void {
+      const resolved = resolve(path);
+      // `existsResolved` (not `syncFs.exists`): with `force`, a live-only path
+      // must still be removed rather than treated as already gone.
+      if (opts?.force && !existsResolved(resolved)) return;
+      if (!remove(resolved, { recursive: opts?.recursive === true }) && !opts?.force) {
+        throw syncFsErr('ENOENT', resolved, 'rm');
+      }
+    },
+    rmdirSync(path: string, opts?: { recursive?: boolean }): void {
+      const resolved = resolve(path);
+      // Node's rmdirSync throws ENOTDIR on a non-directory (rmSync does not, and
+      // SyncFsCache.rm has no isDirectory guard — it would silently unlink a file).
+      if (existsResolved(resolved) && !statResolved(resolved).isDirectory) {
+        throw syncFsErr('ENOTDIR', resolved, 'rmdir');
+      }
+      if (!remove(resolved, { recursive: opts?.recursive === true })) {
+        throw syncFsErr('ENOENT', resolved, 'rmdir');
+      }
+    },
+    unlinkSync(path: string): void {
+      const resolved = resolve(path);
+      if (!remove(resolved, { requireFile: true })) throw syncFsErr('ENOENT', resolved, 'unlink');
+    },
+    renameSync(oldPath: string, newPath: string): void {
+      const src = resolve(oldPath);
+      const dest = resolve(newPath);
+      try {
+        syncFs.rename(src, dest);
+        return;
+      } catch (err) {
+        if ((err as { code?: string })?.code !== 'ENOENT') throw err;
+      }
+      // Cache miss on the source: it may still be live (post-`execSync`
+      // invalidate, or created after the snapshot). Copy-then-remove over the
+      // bridge — the sync surface has no live `rename` op, and a cache-only
+      // rename would lose the file. Directories are out of scope: a recursive
+      // live walk on a blocking XHR is prohibitively expensive.
+      if (!bridge || syncFs.isTombstoned(src)) throw syncFsErr('ENOENT', src, 'rename');
+      if (statResolved(src).isDirectory) throw syncFsErr('EISDIR', src, 'rename');
+      writeThrough(dest, readBytes(src));
+      if (!remove(src, { requireFile: true })) throw syncFsErr('ENOENT', src, 'rename');
+    },
+  };
+}
+
 /** Coerce a `writeFileSync`/`appendFileSync` data arg to bytes (string | typed array). */
 function toBytes(data: unknown): Uint8Array {
   if (typeof data === 'string') return new TextEncoder().encode(data);
@@ -215,9 +323,13 @@ function toBytes(data: unknown): Uint8Array {
  * (commitWrite advances the mutation baseline so it is not double-flushed).
  * The snapshot cache stays a best-effort fast path for the hot working set;
  * reads served from a cache hit skip the bridge round-trip.
- * Mutating metadata ops (mkdir/rm/rename) stay cache-backed — the exec
+ * Mutating metadata ops (mkdir/rm/rename) are cache-backed on a hit — the exec
  * bridge's flush-before-exec pushes their pending cache mutations to `ctx.fs`
- * so a subprocess sees them. Read-only metadata ops (stat/exists/readdir)
+ * so a subprocess sees them — but the REMOVALS (`rmSync` / `rmdirSync` /
+ * `unlinkSync` / `renameSync`) fall through to the live bridge on a miss. A
+ * miss is not proof of absence once `execSync` has invalidated the cache or the
+ * file post-dates the snapshot; a cache-only delete would leave the live file
+ * behind while reporting `ENOENT`. Read-only metadata ops (stat/exists/readdir)
  * fall through to `bridge` on a cache miss (phase-2), so a file created after
  * the boot snapshot or beyond the entry cap is discovered live rather than
  * silently reported absent. A path deleted in-script keeps its tombstone: the
@@ -318,6 +430,15 @@ export function createSyncFsBridge(syncFs: SyncFsCache, cwd: string, bridge?: Sy
   }
 
   return {
+    ...createRemovalOps({
+      syncFs,
+      bridge,
+      resolve,
+      existsResolved,
+      statResolved,
+      readBytes,
+      writeThrough,
+    }),
     readFileSync(path: string, opts?: string | { encoding?: string | null } | null): unknown {
       const encoding = typeof opts === 'string' ? opts : opts?.encoding;
       const bytes = readBytes(resolve(path));
@@ -382,20 +503,6 @@ export function createSyncFsBridge(syncFs: SyncFsCache, cwd: string, bridge?: Sy
     readdirSync(path: string): string[] {
       return readdirResolved(resolve(path));
     },
-    rmSync(path: string, opts?: { recursive?: boolean; force?: boolean }): void {
-      const resolved = resolve(path);
-      if (opts?.force && !syncFs.exists(resolved)) return;
-      syncFs.rm(resolved, opts?.recursive);
-    },
-    rmdirSync(path: string, opts?: { recursive?: boolean }): void {
-      const resolved = resolve(path);
-      // Node's rmdirSync throws ENOTDIR on a non-directory (rmSync does not, and
-      // SyncFsCache.rm has no isDirectory guard — it would silently unlink a file).
-      if (existsResolved(resolved) && !statResolved(resolved).isDirectory) {
-        throw syncFsErr('ENOTDIR', resolved, 'rmdir');
-      }
-      syncFs.rm(resolved, opts?.recursive);
-    },
     copyFileSync(src: string, dest: string): void {
       // Bridge-aware copy (see copyTree): reading via `readBytes` + `writeThrough`
       // copies an over-cap or live-only (post-snapshot) source correctly, instead
@@ -412,12 +519,6 @@ export function createSyncFsBridge(syncFs: SyncFsCache, cwd: string, bridge?: Sy
     },
     mkdtempSync(prefix: string): string {
       return syncFs.mkdtemp(resolve(prefix));
-    },
-    unlinkSync(path: string): void {
-      syncFs.unlink(resolve(path));
-    },
-    renameSync(oldPath: string, newPath: string): void {
-      syncFs.rename(resolve(oldPath), resolve(newPath));
     },
   };
 }

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -155,11 +155,13 @@ export function attachRealmHost(
   // page-side `inputreport` listener (DOD: "no leaked subscriptions
   // on realm teardown").
   const hidSubscriptions = new Map<string, () => void | Promise<void>>();
-  // Mint a per-realm sync-fs capability token only when the bridge is enabled
+  // Mint a per-realm sync capability token only when the bridge is enabled
   // (see RealmHostOptions.syncFsBridgeEnabled). Bound to this realm's gated
-  // fs + cwd; revoked in dispose() so a dead realm's scope can't be reused.
+  // fs + exec + cwd; revoked in dispose() so a dead realm's scope can't be
+  // reused. `exec` backs the synchronous `child_process` channel and carries
+  // the same sudo command guard as the async `exec` RPC.
   const syncFsToken = opts.syncFsBridgeEnabled
-    ? mintSyncFsToken({ fs: ctx.fs, cwd: ctx.cwd })
+    ? mintSyncFsToken({ fs: ctx.fs, ...(ctx.exec ? { exec: ctx.exec } : {}), cwd: ctx.cwd })
     : undefined;
   let disposed = false;
   const pushEvent = (msg: RealmEventMsg, transfer: Transferable[] = []): void => {

--- a/packages/webapp/src/kernel/realm/sync-exec-dispatch.ts
+++ b/packages/webapp/src/kernel/realm/sync-exec-dispatch.ts
@@ -20,7 +20,7 @@
  */
 
 import { type SyncFsRequest, type SyncFsResult, toErrno } from './sync-fs-dispatch.js';
-import { resolveSyncFsToken } from './sync-fs-token-registry.js';
+import { resolveSyncFsToken, trackSyncExec } from './sync-fs-token-registry.js';
 import { SYNC_EXEC_MAX_TIMEOUT_MS } from './sync-fs-wire.js';
 
 /** Discriminator distinguishing an exec request from an fs one on the wire. */
@@ -115,10 +115,17 @@ export async function dispatchSyncExec(req: SyncExecRequest): Promise<SyncFsResu
   // Abort the in-flight `ctx.exec` at the budget so the command cannot outlive
   // the realm's blocked XHR and keep running with no consumer for its result.
   const controller = new AbortController();
+  let timedOut = false;
   const timer = setTimeout(
-    () => controller.abort(),
+    () => {
+      timedOut = true;
+      controller.abort();
+    },
     clampSyncExecTimeout(req.timeoutMs, SYNC_EXEC_MAX_TIMEOUT_MS)
   );
+  // Register with the token so realm disposal (SIGKILL and friends) aborts the
+  // command too — a sync exec has no `spawnId` for the host to track.
+  const untrack = trackSyncExec(req.token, controller);
   try {
     const result = await entry.exec(normalized.cmd, {
       cwd: entry.cwd,
@@ -138,14 +145,21 @@ export async function dispatchSyncExec(req: SyncExecRequest): Promise<SyncFsResu
   } catch (err) {
     // An aborted exec is a timeout, not a shell failure — surface it as
     // ETIMEDOUT so the shim can throw the Node-shaped timeout error.
-    if (controller.signal.aborted) {
+    if (timedOut) {
       const message = err instanceof Error ? err.message : String(err);
       return { ok: false, errno: 'ETIMEDOUT', message: `sync-exec: timed out — ${message}` };
+    }
+    // Aborted without the timer firing = the realm was disposed mid-command.
+    // ECANCELED, not ETIMEDOUT: nothing is left to receive it either way, but
+    // the errno should not claim the budget elapsed.
+    if (controller.signal.aborted) {
+      return { ok: false, errno: 'ECANCELED', message: 'sync-exec: realm disposed' };
     }
     // Shared with the fs channel so a sudo denial's EACCES survives rather than
     // being flattened to a generic EIO.
     return toErrno(err);
   } finally {
     clearTimeout(timer);
+    untrack();
   }
 }

--- a/packages/webapp/src/kernel/realm/sync-exec-dispatch.ts
+++ b/packages/webapp/src/kernel/realm/sync-exec-dispatch.ts
@@ -1,0 +1,151 @@
+/**
+ * Token-scoped synchronous-exec dispatch.
+ *
+ * The kernel-worker responder resolves a per-realm capability token (see
+ * `sync-fs-token-registry.ts`) to that realm's `{ exec, cwd }` and runs the
+ * requested command HERE — through the realm's own `ctx.exec`, the same handle
+ * the async `exec.run` / `exec.spawn` RPC uses (`realm-host.ts` `dispatchExec`).
+ * Routing through it is what makes the synchronous bridge inherit the exact
+ * same sudo command guard, path ACLs, and secret masking the async path has.
+ *
+ * The realm worker is blocked on a synchronous XHR while this runs, but the
+ * sudo brokers live in the kernel worker (HTTP) or the page (panel-RPC), so an
+ * approval prompt still renders and resolves normally — the blocked thread is
+ * never on the approval path.
+ *
+ * The result crosses back as JSON (`{ stdout, stderr, exitCode }`) rather than
+ * an errno: a non-zero exit is a normal outcome for `spawnSync`, not a
+ * transport failure. Only a genuine failure (no `ctx.exec`, a malformed
+ * request, an unknown token, a throwing shell) becomes an errno result.
+ */
+
+import { type SyncFsRequest, type SyncFsResult, toErrno } from './sync-fs-dispatch.js';
+import { resolveSyncFsToken } from './sync-fs-token-registry.js';
+import { SYNC_EXEC_MAX_TIMEOUT_MS } from './sync-fs-wire.js';
+
+/** Discriminator distinguishing an exec request from an fs one on the wire. */
+export const SYNC_EXEC_CHANNEL = 'exec';
+
+/** POST body the realm bridge sends on the `exec` route. */
+export interface SyncExecRequestPayload {
+  /** Command string (shell form) or argv (shell-free form, argv[0] = program). */
+  command: string | string[];
+  /** Shell-free argv tail for the string form — mirrors `exec.spawn`'s `args`. */
+  args?: string[];
+  /** Buffered stdin for the one-shot command. */
+  stdin?: string;
+  /** Caller budget in ms, clamped to {@link SYNC_EXEC_MAX_TIMEOUT_MS}. */
+  timeoutMs?: number;
+}
+
+/** SW → responder envelope for one synchronous exec. */
+export interface SyncExecRequest extends SyncExecRequestPayload {
+  token: string;
+  channel: typeof SYNC_EXEC_CHANNEL;
+}
+
+/** Buffered outcome of a synchronous exec, JSON-encoded back to the realm. */
+export interface SyncExecResultPayload {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Narrow a wire request to the exec channel. */
+export function isSyncExecRequest(req: SyncFsRequest | SyncExecRequest): req is SyncExecRequest {
+  return (req as SyncExecRequest).channel === SYNC_EXEC_CHANNEL;
+}
+
+/**
+ * Validate the request envelope. Returns the normalized `{ cmd, argv }` pair or
+ * an errno result — a malformed payload must never reach `ctx.exec`.
+ */
+function normalizeCommand(
+  req: SyncExecRequest
+): { cmd: string; args?: string[] } | { errno: string; message: string } {
+  const { command } = req;
+  if (Array.isArray(command)) {
+    if (command.length === 0 || !command.every((a) => typeof a === 'string')) {
+      return { errno: 'EINVAL', message: 'sync-exec: argv must be a non-empty string[]' };
+    }
+    const [cmd, ...rest] = command;
+    return { cmd: cmd!, args: rest };
+  }
+  if (typeof command !== 'string' || command.length === 0) {
+    return { errno: 'EINVAL', message: 'sync-exec: command must be a non-empty string' };
+  }
+  if (req.args !== undefined) {
+    if (!Array.isArray(req.args) || !req.args.every((a) => typeof a === 'string')) {
+      return { errno: 'EINVAL', message: 'sync-exec: args must be a string[]' };
+    }
+    return { cmd: command, args: req.args };
+  }
+  return { cmd: command };
+}
+
+/**
+ * Clamp the caller's budget into `(0, SYNC_EXEC_MAX_TIMEOUT_MS]`. A blocked
+ * realm worker cannot be interrupted, so an unbounded or absent budget would
+ * make a runaway command unkillable short of terminating the realm.
+ */
+export function clampSyncExecTimeout(timeoutMs: number | undefined, fallbackMs: number): number {
+  if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return Math.min(fallbackMs, SYNC_EXEC_MAX_TIMEOUT_MS);
+  }
+  return Math.min(timeoutMs, SYNC_EXEC_MAX_TIMEOUT_MS);
+}
+
+/**
+ * Run one synchronous exec against the token's realm. Resolves to a JSON
+ * `{ stdout, stderr, exitCode }` payload, or an errno result. An unknown /
+ * revoked token fails closed with `EACCES` — never the ambient shell.
+ */
+export async function dispatchSyncExec(req: SyncExecRequest): Promise<SyncFsResult> {
+  const entry = resolveSyncFsToken(req.token);
+  if (!entry) {
+    return { ok: false, errno: 'EACCES', message: 'sync-exec: unknown or revoked token' };
+  }
+  if (!entry.exec) {
+    return { ok: false, errno: 'ENOSYS', message: 'sync-exec: exec is not available' };
+  }
+  const normalized = normalizeCommand(req);
+  if ('errno' in normalized) {
+    return { ok: false, errno: normalized.errno, message: normalized.message };
+  }
+  // Abort the in-flight `ctx.exec` at the budget so the command cannot outlive
+  // the realm's blocked XHR and keep running with no consumer for its result.
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    clampSyncExecTimeout(req.timeoutMs, SYNC_EXEC_MAX_TIMEOUT_MS)
+  );
+  try {
+    const result = await entry.exec(normalized.cmd, {
+      cwd: entry.cwd,
+      signal: controller.signal,
+      ...(normalized.args !== undefined ? { args: normalized.args } : {}),
+      ...(req.stdin !== undefined ? { stdin: req.stdin } : {}),
+    });
+    return {
+      ok: true,
+      kind: 'json',
+      json: {
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exitCode: result.exitCode,
+      } satisfies SyncExecResultPayload,
+    };
+  } catch (err) {
+    // An aborted exec is a timeout, not a shell failure — surface it as
+    // ETIMEDOUT so the shim can throw the Node-shaped timeout error.
+    if (controller.signal.aborted) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, errno: 'ETIMEDOUT', message: `sync-exec: timed out — ${message}` };
+    }
+    // Shared with the fs channel so a sudo denial's EACCES survives rather than
+    // being flattened to a generic EIO.
+    return toErrno(err);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/webapp/src/kernel/realm/sync-exec-xhr-bridge.ts
+++ b/packages/webapp/src/kernel/realm/sync-exec-xhr-bridge.ts
@@ -1,0 +1,124 @@
+/**
+ * Realm-side client for the synchronous-exec bridge — the substrate under
+ * `child_process.execSync` / `execFileSync` / `spawnSync`.
+ *
+ * Issues one blocking round-trip (see `sync-xhr.ts`) to `/__slicc/exec-sync`
+ * carrying a JSON command envelope; the controlling Service Worker forwards it
+ * to the kernel-worker responder, which runs the command through the CALLING
+ * realm's own `ctx.exec` — same sudo command guard, path ACLs, and secret
+ * masking as the async `exec` RPC. The realm worker blocks meanwhile; the sudo
+ * brokers live in the kernel worker / page, so an approval prompt still renders
+ * and resolves while it does.
+ *
+ * **Coherence with the sync fs cache.** The async exec bridge does
+ * flush-before / re-snapshot-after (`realm-exec-bridge.ts`). Neither await is
+ * available here, so this bridge instead:
+ *
+ *   1. FLUSHES pending {@link SyncFsCache} mutations over the *fs* bridge
+ *      (blocking writes / mkdir / rm), so the command sees them, then rebases
+ *      the cache's mutation baseline so the end-of-script flush doesn't
+ *      re-apply them.
+ *   2. runs the command.
+ *   3. INVALIDATES the cache rather than re-snapshotting: a fresh snapshot
+ *      cannot be pulled through a blocking XHR cheaply, and every sync read
+ *      already falls through to the live fs bridge on a cache miss — so
+ *      dropping the stale entries is both correct and far cheaper.
+ *
+ * Both steps are skipped entirely unless the script has actually touched
+ * sync-fs (`wasUsed()`), matching the async bridge's perf gate.
+ */
+
+import { SYNC_EXEC_CHANNEL, type SyncExecResultPayload } from './sync-exec-dispatch.js';
+import type { SyncFsCache } from './sync-fs-cache.js';
+import { SYNC_EXEC_DEFAULT_TIMEOUT_MS, SYNC_EXEC_ROUTE } from './sync-fs-wire.js';
+import type { SyncFsXhrMutatingBridge } from './sync-fs-xhr-bridge.js';
+import { synchronifyJson, syncXhrError } from './sync-xhr.js';
+
+/** Options accepted by one synchronous exec. */
+export interface SyncExecOptions {
+  /** Shell-free argv tail for the string command form. */
+  args?: string[];
+  /** Buffered stdin for the one-shot command. */
+  input?: string;
+  /** Caller budget in ms; clamped server-side to the wire ceiling. */
+  timeout?: number;
+}
+
+export interface SyncExecXhrBridge {
+  run(command: string | string[], opts?: SyncExecOptions): SyncExecResultPayload;
+}
+
+/**
+ * Push the cache's pending mutations to the live VFS over the blocking fs
+ * bridge, then rebase the baseline so the end-of-script flush doesn't reapply
+ * them. Mirrors `createExecBridge`'s `flushBeforeExec`, minus the `await`.
+ */
+function flushBeforeSyncExec(syncFs: SyncFsCache, fsBridge: SyncFsXhrMutatingBridge): void {
+  const mutations = syncFs.getMutations();
+  // Order matches `applySyncFsMutations`: a path deleted then recreated with a
+  // different type must tear the old node down before the new one is written.
+  for (const path of mutations.deleted) fsBridge.rm(path);
+  for (const entry of mutations.created) {
+    if (entry.isDirectory) fsBridge.mkdir(entry.path);
+    else fsBridge.writeFile(entry.path, entry.content);
+  }
+  for (const entry of mutations.modified) fsBridge.writeFile(entry.path, entry.content);
+  syncFs.resetBaseline();
+}
+
+/**
+ * Build the synchronous exec bridge. `syncFs` + `fsBridge` are the coherence
+ * pair — both must be present for the flush/invalidate dance; without them the
+ * bridge still runs commands (an exec-only script needs no coherence).
+ */
+export function createSyncExecXhrBridge(
+  token: string,
+  opts: { syncFs?: SyncFsCache; fsBridge?: SyncFsXhrMutatingBridge; timeoutMs?: number } = {}
+): SyncExecXhrBridge {
+  const defaultTimeoutMs = opts.timeoutMs ?? SYNC_EXEC_DEFAULT_TIMEOUT_MS;
+  const { syncFs, fsBridge } = opts;
+
+  return {
+    run(command: string | string[], runOpts: SyncExecOptions = {}): SyncExecResultPayload {
+      const coherent = syncFs?.wasUsed() === true && fsBridge !== undefined;
+      if (coherent) flushBeforeSyncExec(syncFs!, fsBridge!);
+      const label = `sync-exec bridge, '${Array.isArray(command) ? command.join(' ') : command}'`;
+      const timeoutMs = runOpts.timeout ?? defaultTimeoutMs;
+      const payload = {
+        command,
+        ...(runOpts.args !== undefined ? { args: runOpts.args } : {}),
+        ...(runOpts.input !== undefined ? { stdin: runOpts.input } : {}),
+        timeoutMs,
+        channel: SYNC_EXEC_CHANNEL,
+      };
+      try {
+        const json = synchronifyJson({
+          method: 'POST',
+          url: SYNC_EXEC_ROUTE,
+          token,
+          body: new TextEncoder().encode(JSON.stringify(payload)),
+          // Give the transport a margin over the command budget so the SW's
+          // authoritative errno wins the race with the bare XHR-timeout EIO —
+          // same ordering the fs channel relies on.
+          timeoutMs: timeoutMs + 5_000,
+          label,
+        }) as Partial<SyncExecResultPayload> | null;
+        if (
+          !json ||
+          typeof json.stdout !== 'string' ||
+          typeof json.stderr !== 'string' ||
+          typeof json.exitCode !== 'number'
+        ) {
+          throw syncXhrError('EIO', label);
+        }
+        return { stdout: json.stdout, stderr: json.stderr, exitCode: json.exitCode };
+      } finally {
+        // INVALIDATE (not re-snapshot): the command may have changed anything
+        // under the cache, and every sync read falls through to the live fs
+        // bridge on a miss. Runs even when the exec threw — a failed command
+        // can still have written before it died.
+        if (coherent) syncFs!.invalidate();
+      }
+    },
+  };
+}

--- a/packages/webapp/src/kernel/realm/sync-exec-xhr-bridge.ts
+++ b/packages/webapp/src/kernel/realm/sync-exec-xhr-bridge.ts
@@ -30,7 +30,11 @@
 
 import { SYNC_EXEC_CHANNEL, type SyncExecResultPayload } from './sync-exec-dispatch.js';
 import type { SyncFsCache } from './sync-fs-cache.js';
-import { SYNC_EXEC_DEFAULT_TIMEOUT_MS, SYNC_EXEC_ROUTE } from './sync-fs-wire.js';
+import {
+  SYNC_EXEC_DEFAULT_TIMEOUT_MS,
+  SYNC_EXEC_ROUTE,
+  SYNC_EXEC_XHR_MARGIN_MS,
+} from './sync-fs-wire.js';
 import type { SyncFsXhrMutatingBridge } from './sync-fs-xhr-bridge.js';
 import { synchronifyJson, syncXhrError } from './sync-xhr.js';
 
@@ -100,7 +104,7 @@ export function createSyncExecXhrBridge(
           // Give the transport a margin over the command budget so the SW's
           // authoritative errno wins the race with the bare XHR-timeout EIO —
           // same ordering the fs channel relies on.
-          timeoutMs: timeoutMs + 5_000,
+          timeoutMs: timeoutMs + SYNC_EXEC_XHR_MARGIN_MS,
           label,
         }) as Partial<SyncExecResultPayload> | null;
         if (

--- a/packages/webapp/src/kernel/realm/sync-exec-xhr-bridge.ts
+++ b/packages/webapp/src/kernel/realm/sync-exec-xhr-bridge.ts
@@ -28,7 +28,11 @@
  * sync-fs (`wasUsed()`), matching the async bridge's perf gate.
  */
 
-import { SYNC_EXEC_CHANNEL, type SyncExecResultPayload } from './sync-exec-dispatch.js';
+import {
+  clampSyncExecTimeout,
+  SYNC_EXEC_CHANNEL,
+  type SyncExecResultPayload,
+} from './sync-exec-dispatch.js';
 import type { SyncFsCache } from './sync-fs-cache.js';
 import {
   SYNC_EXEC_DEFAULT_TIMEOUT_MS,
@@ -87,7 +91,13 @@ export function createSyncExecXhrBridge(
       const coherent = syncFs?.wasUsed() === true && fsBridge !== undefined;
       if (coherent) flushBeforeSyncExec(syncFs!, fsBridge!);
       const label = `sync-exec bridge, '${Array.isArray(command) ? command.join(' ') : command}'`;
-      const timeoutMs = runOpts.timeout ?? defaultTimeoutMs;
+      // Clamp HERE, not just server-side: the transport budget below derives
+      // from this value, so an unclamped one desyncs the two. Node's
+      // `{ timeout: 0 }` means "no timeout" and must become the default budget
+      // (the SW's own fallback) rather than a 0 that makes the XHR give up in
+      // SYNC_EXEC_XHR_MARGIN_MS; an oversized one must hit the wire ceiling
+      // here too, or the XHR waits long past the command the SW already killed.
+      const timeoutMs = clampSyncExecTimeout(runOpts.timeout, defaultTimeoutMs);
       const payload = {
         command,
         ...(runOpts.args !== undefined ? { args: runOpts.args } : {}),

--- a/packages/webapp/src/kernel/realm/sync-fs-cache.ts
+++ b/packages/webapp/src/kernel/realm/sync-fs-cache.ts
@@ -514,6 +514,22 @@ export class SyncFsCache {
   }
 
   /**
+   * Tombstone a path the shim has ALREADY deleted from the live VFS over the
+   * fs bridge — the cache-miss counterpart to {@link rm} / {@link unlink}.
+   * Needed because a post-`execSync` {@link invalidate} empties the tree, so a
+   * subsequent `unlinkSync` / `rmSync` of a still-live file finds no entry to
+   * remove. No mutation is recorded (the path was never in the baseline, and
+   * the live delete already happened) — only the tombstone, so later reads see
+   * `ENOENT` instead of resurrecting the file through the bridge.
+   */
+  markRemoved(path: string, recursive = false): void {
+    this.touched = true;
+    const normalized = normalizePath(path);
+    this.tombstones.add(normalized);
+    if (recursive) this.removedDirs.add(normalized);
+  }
+
+  /**
    * True if `path` was deleted in-script (exact tombstone) or lies under a
    * recursively-removed directory. The `readFileSync` bridge fallback consults
    * this so a cache-miss on a deleted path throws `ENOENT` rather than

--- a/packages/webapp/src/kernel/realm/sync-fs-cache.ts
+++ b/packages/webapp/src/kernel/realm/sync-fs-cache.ts
@@ -248,6 +248,21 @@ export class SyncFsCache {
   }
 
   /**
+   * Drop every cached entry, leaving an empty (but still-usable) cache. Called
+   * by the SYNCHRONOUS exec bridge after a blocking `execSync`, where the async
+   * bridge's re-snapshot is unavailable: a fresh snapshot cannot be pulled
+   * through a blocking XHR cheaply, and every sync read already falls through
+   * to the live fs bridge on a cache miss — so dropping the (now possibly
+   * stale) entries is correct and far cheaper. Tombstones are cleared for the
+   * same reason {@link loadSnapshot} clears them: the pending deletes were
+   * flushed before the exec, so the live fs answers `ENOENT` on its own.
+   * {@link touched} is preserved — the script stays on the coherent path.
+   */
+  invalidate(): void {
+    this.loadSnapshot({ entries: [] });
+  }
+
+  /**
    * Snapshot the CURRENT tree as the new mutation baseline. Called by the exec
    * bridge right AFTER a mid-script flush so those already-flushed mutations
    * are not re-applied by a later flush (the next exec, or the end-of-script

--- a/packages/webapp/src/kernel/realm/sync-fs-dispatch.ts
+++ b/packages/webapp/src/kernel/realm/sync-fs-dispatch.ts
@@ -16,8 +16,9 @@
  *
  * NOTE: this module is pure (no BroadcastChannel / SW). Phase-2 routes
  * `stat` / `readdir` / `exists` through the SW wire in addition to the
- * phase-1 `read` / `write`; the rest of the op set is kept for the responder's
- * completeness but is not reachable from the SW handler today.
+ * phase-1 `read` / `write`, and the sync-exec flush-before path adds
+ * `mkdir` / `rm`. `rename` is kept for the responder's completeness but is
+ * not reachable from the SW handler today.
  */
 
 import { resolveSyncFsToken } from './sync-fs-token-registry.js';
@@ -48,8 +49,12 @@ export type SyncFsResult =
   | { ok: true; kind: 'void' }
   | { ok: false; errno: string; message: string };
 
-/** Map any thrown error to a POSIX errno result. */
-function toErrno(err: unknown): SyncFsResult {
+/**
+ * Map any thrown error to a POSIX errno result. Shared with the exec channel
+ * (`sync-exec-dispatch.ts`) so a sudo denial's `EACCES` survives on BOTH paths
+ * rather than being flattened to a generic `EIO`.
+ */
+export function toErrno(err: unknown): SyncFsResult {
   const message = err instanceof Error ? err.message : String(err);
   // Validate the errno shape for EVERY error (FsError, sync-fs-cache errors, or
   // anything else with a `.code`). A malformed `.code` would otherwise become an
@@ -107,8 +112,8 @@ export async function dispatchSyncFs(req: SyncFsRequest): Promise<SyncFsResult> 
         // Extends realm-host.ts dispatchVfs (which probes only `rename`):
         // production ctx.fs (VfsAdapter, possibly sudo-wrapped) exposes `mv`,
         // not `rename`, so probe `mv` too, then fall back to copy+remove when
-        // neither is present. (Phase-2 only — the phase-1 SW wire is
-        // read/write; the responder keeps this for completeness.)
+        // neither is present. (Not reachable from the SW handler — the
+        // responder keeps this for completeness.)
         const dest = fs.resolvePath(cwd, req.arg2 ?? '');
         const maybe = fs as {
           rename?: (a: string, b: string) => Promise<void>;

--- a/packages/webapp/src/kernel/realm/sync-fs-responder.ts
+++ b/packages/webapp/src/kernel/realm/sync-fs-responder.ts
@@ -1,14 +1,14 @@
 /**
- * Kernel-worker responder for the synchronous-fs bridge.
+ * Kernel-worker responder for the synchronous bridges (fs + exec).
  *
  * The realm's synchronous XHR is intercepted by the controlling Service
  * Worker, which round-trips the request over the per-session
  * (nonce-named — see `sync-fs-wire.ts`) BroadcastChannel to THIS responder.
  * The responder runs in the kernel worker — co-located with the token registry
- * and every realm's `ctx.fs` — so it can answer from the calling realm's own
- * (ACL + sudo enforced) filesystem via `dispatchSyncFs`, and there is no page
- * hop and no deadlock (the blocked realm worker is a different thread from this
- * one).
+ * and every realm's `ctx.fs` / `ctx.exec` — so it can answer from the calling
+ * realm's own (ACL + sudo enforced) handles via `dispatchSyncFs` /
+ * `dispatchSyncExec`, and there is no page hop and no deadlock (the blocked
+ * realm worker is a different thread from this one).
  *
  * Wire protocol (see `sync-fs-wire.ts`, the shared contract):
  *   SW → responder:  { type: 'sync-fs-req', id, ...SyncFsRequest }
@@ -37,9 +37,11 @@
  * (EIO), which is the correct outcome for the abuse path (not the hot path).
  */
 
+import { dispatchSyncExec, isSyncExecRequest } from './sync-exec-dispatch.js';
 import { dispatchSyncFs, type SyncFsResult } from './sync-fs-dispatch.js';
 import { resolveSyncFsToken } from './sync-fs-token-registry.js';
 import {
+  SYNC_EXEC_MAX_TIMEOUT_MS,
   SYNC_FS_ACK_MSG,
   SYNC_FS_REQ_MSG,
   SYNC_FS_REQUEST_TIMEOUT_MS,
@@ -56,9 +58,11 @@ import {
  * >= the SW handler's round-trip budget: the SW can re-post the same id until
  * that budget elapses, and a re-post arriving after eviction would be treated
  * as first-seen and RE-DISPATCHED — the double-write the dedupe exists to
- * prevent. Derive it (+5s margin) so the two can't drift apart.
+ * prevent. Derive it from the LARGER of the two channel budgets (+5s margin) so
+ * the exec channel's much longer round-trip can't outlive its dedupe entry and
+ * re-run a command.
  */
-const DEDUPE_TTL_MS = SYNC_FS_REQUEST_TIMEOUT_MS + 5_000;
+const DEDUPE_TTL_MS = Math.max(SYNC_FS_REQUEST_TIMEOUT_MS, SYNC_EXEC_MAX_TIMEOUT_MS) + 5_000;
 
 /** Structural subset of `BroadcastChannel` so tests can inject a fake. */
 export interface SyncFsChannelLike {
@@ -134,19 +138,18 @@ export function installSyncFsResponder(
       entry.timer = setTimeout(() => seen.delete(req.id), DEDUPE_TTL_MS);
       post({ type: SYNC_FS_RES_MSG, id: req.id, ...result });
     };
-    // dispatchSyncFs is written not to reject, but a future ctx.fs could throw
+    // dispatchSync* is written not to reject, but a future ctx.fs could throw
     // synchronously (e.g. in resolvePath). Catch it and post a terminal errno
     // so the blocked realm worker never waits out the SW handler's full
     // timeout — fail closed, not hang.
-    void dispatchSyncFs(req)
-      .then(settle)
-      .catch((err) =>
-        settle({
-          ok: false,
-          errno: 'EIO',
-          message: err instanceof Error ? err.message : String(err),
-        })
-      );
+    const dispatched = isSyncExecRequest(req) ? dispatchSyncExec(req) : dispatchSyncFs(req);
+    void dispatched.then(settle).catch((err) =>
+      settle({
+        ok: false,
+        errno: 'EIO',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    );
   };
 
   ch.addEventListener('message', listener);

--- a/packages/webapp/src/kernel/realm/sync-fs-token-registry.ts
+++ b/packages/webapp/src/kernel/realm/sync-fs-token-registry.ts
@@ -41,6 +41,16 @@ export interface SyncFsTokenEntry {
 
 const registry = new Map<string, SyncFsTokenEntry>();
 
+/**
+ * In-flight synchronous execs per token. A sync exec runs entirely inside one
+ * `dispatchSyncExec` call, so — unlike `exec.start` — it has no `spawnId` the
+ * realm host could track. Without this, killing a realm that is blocked in
+ * `execSync` (SIGINT / SIGTERM / SIGKILL) reports the realm as exited while the
+ * already-started `ctx.exec` keeps running, and producing side effects, for the
+ * rest of its budget. {@link revokeSyncFsToken} aborts them on realm dispose.
+ */
+const inFlightExecs = new Map<string, Set<AbortController>>();
+
 /** Mint an unguessable token bound to a realm's fs + exec handles and cwd. */
 export function mintSyncFsToken(entry: SyncFsTokenEntry): SyncFsToken {
   // The one place a raw random string becomes a capability token. The registry
@@ -56,7 +66,41 @@ export function resolveSyncFsToken(token: string): SyncFsTokenEntry | null {
   return registry.get(token) ?? null;
 }
 
-/** Revoke on realm dispose so a dead realm's token can never be reused. */
+/**
+ * Register an in-flight synchronous exec against its realm's token. Returns the
+ * disposer the dispatcher must call once the command settles; a token already
+ * revoked (the realm died between resolve and dispatch) aborts immediately so a
+ * late command cannot outlive its realm.
+ */
+export function trackSyncExec(token: string, controller: AbortController): () => void {
+  if (!registry.has(token)) {
+    controller.abort();
+    return () => {};
+  }
+  let set = inFlightExecs.get(token);
+  if (!set) {
+    set = new Set();
+    inFlightExecs.set(token, set);
+  }
+  set.add(controller);
+  return () => {
+    const live = inFlightExecs.get(token);
+    if (!live) return;
+    live.delete(controller);
+    if (live.size === 0) inFlightExecs.delete(token);
+  };
+}
+
+/**
+ * Revoke on realm dispose so a dead realm's token can never be reused, and
+ * abort anything it still has running — see {@link inFlightExecs}.
+ */
 export function revokeSyncFsToken(token: string): void {
   registry.delete(token);
+  const live = inFlightExecs.get(token);
+  if (!live) return;
+  inFlightExecs.delete(token);
+  for (const controller of live) {
+    if (!controller.signal.aborted) controller.abort();
+  }
 }

--- a/packages/webapp/src/kernel/realm/sync-fs-token-registry.ts
+++ b/packages/webapp/src/kernel/realm/sync-fs-token-registry.ts
@@ -1,16 +1,22 @@
 /**
- * Per-realm capability tokens for the synchronous-fs bridge.
+ * Per-realm capability tokens for the synchronous bridges (fs + exec).
  *
- * A realm's sync fs bridge (sync XHR → controlling SW → kernel-worker
- * responder) must resolve reads/writes against the CALLING realm's own
- * filesystem handle — the same `ctx.fs` the async `vfs` RPC uses, which for a
- * scoop is a `RestrictedFS` wrapped by the sudo-fs `Proxy`. An origin-scoped
- * SW route cannot know which realm issued a request, so each realm is minted
- * an unguessable token (bound to `{ fs, cwd }`) at `attachRealmHost` time and
- * carries it on every sync-fs request; the kernel-worker responder maps the
- * token back to that realm's `ctx` before dispatching. The token is revoked
- * when the realm is disposed so a dead realm's scope can never be reused or
- * forged by another realm.
+ * A realm's sync bridge (sync XHR → controlling SW → kernel-worker responder)
+ * must resolve reads/writes/commands against the CALLING realm's own handles —
+ * the same `ctx.fs` / `ctx.exec` the async `vfs` / `exec` RPCs use, which for a
+ * scoop is a `RestrictedFS` wrapped by the sudo-fs `Proxy` and a command-guarded
+ * shell. An origin-scoped SW route cannot know which realm issued a request, so
+ * each realm is minted an unguessable token (bound to `{ fs, exec, cwd }`) at
+ * `attachRealmHost` time and carries it on every sync request; the kernel-worker
+ * responder maps the token back to that realm's `ctx` before dispatching. The
+ * token is revoked when the realm is disposed so a dead realm's scope can never
+ * be reused or forged by another realm.
+ *
+ * ONE token covers both channels rather than two independently-granted ones:
+ * the two capabilities have the same mint site, the same lifetime, and the same
+ * revocation, and a realm that can drive `ctx.exec` can already reach the whole
+ * filesystem through the shell — so splitting them would add a second secret to
+ * protect without narrowing what a leak grants.
  *
  * The registry is a module-level map in the kernel worker (where realm hosts
  * live and where the responder runs). It never crosses the worker boundary —
@@ -23,13 +29,19 @@ import type { SyncFsToken } from './sync-fs-wire.js';
 export interface SyncFsTokenEntry {
   /** The realm's gated filesystem handle (RestrictedFS + sudo-fs for scoops). */
   fs: CommandContext['fs'];
-  /** The realm's working directory — relative sync-fs paths resolve against it. */
+  /**
+   * The realm's gated shell handle, backing the synchronous `exec` channel.
+   * Absent when the runtime provides no shell (`ctx.exec` is optional) — the
+   * dispatch then fails closed with `ENOSYS`.
+   */
+  exec?: CommandContext['exec'];
+  /** The realm's working directory — relative sync paths and execs resolve against it. */
   cwd: string;
 }
 
 const registry = new Map<string, SyncFsTokenEntry>();
 
-/** Mint an unguessable token bound to a realm's fs handle + cwd. */
+/** Mint an unguessable token bound to a realm's fs + exec handles and cwd. */
 export function mintSyncFsToken(entry: SyncFsTokenEntry): SyncFsToken {
   // The one place a raw random string becomes a capability token. The registry
   // map + resolve/revoke stay keyed by plain `string` (the wire delivers the

--- a/packages/webapp/src/kernel/realm/sync-fs-wire.ts
+++ b/packages/webapp/src/kernel/realm/sync-fs-wire.ts
@@ -1,15 +1,18 @@
 /**
- * Single source of truth for the synchronous-fs bridge wire contract.
+ * Single source of truth for the synchronous-bridge wire contract — both the
+ * `fs` channel (`/__slicc/fs-sync/*`) and the `exec` channel
+ * (`/__slicc/exec-sync`) that backs `child_process.execSync` & friends.
  *
  * The bridge spans three bundles that can't share a runtime import cheaply —
- * the realm worker (`sync-fs-xhr-bridge.ts`), the kernel-worker responder
- * (`sync-fs-responder.ts`), and the Service Worker (`ui/sync-fs-sw-handler.ts`
- * bundled into `llm-proxy-sw`). This module is **dependency-free** (only string
- * constants + wire types) so every side can import it without dragging logic
- * across bundle boundaries, and a rename can't silently desync the two ends
- * (which would fail at runtime, not compile time).
+ * the realm worker (`sync-fs-xhr-bridge.ts` / `sync-exec-xhr-bridge.ts`), the
+ * kernel-worker responder (`sync-fs-responder.ts`), and the Service Worker
+ * (`ui/sync-fs-sw-handler.ts` bundled into `llm-proxy-sw`). This module is
+ * **dependency-free** (only string constants + wire types) so every side can
+ * import it without dragging logic across bundle boundaries, and a rename can't
+ * silently desync the two ends (which would fail at runtime, not compile time).
  */
 
+import type { SyncExecRequest } from './sync-exec-dispatch.js';
 import type { SyncFsRequest, SyncFsResult } from './sync-fs-dispatch.js';
 
 /**
@@ -68,6 +71,12 @@ export interface SyncFsNeedNonceMsg {
 export const SYNC_FS_ROUTE_PREFIX = '/__slicc/fs-sync/';
 /** Same route without the trailing slash — the bridge joins the abs path onto it. */
 export const SYNC_FS_ROUTE_BASE = '/__slicc/fs-sync';
+/**
+ * Route for the synchronous `exec` channel. Unlike the fs routes it carries no
+ * path — the command rides in the POST body (see {@link SyncExecRequestPayload})
+ * so a command string never has to survive URL encoding.
+ */
+export const SYNC_EXEC_ROUTE = '/__slicc/exec-sync';
 
 /** Per-realm capability token header (realm → SW). */
 export const SYNC_FS_TOKEN_HEADER = 'x-slicc-fs-token';
@@ -91,8 +100,11 @@ export const SYNC_FS_REQ_MSG = 'sync-fs-req';
 export const SYNC_FS_ACK_MSG = 'sync-fs-ack';
 export const SYNC_FS_RES_MSG = 'sync-fs-res';
 
-/** SW → responder: a request to run one fs op against the token's realm. */
-export type SyncFsReqMsg = SyncFsRequest & { type: typeof SYNC_FS_REQ_MSG; id: string };
+/** SW → responder: a request to run one op against the token's realm. */
+export type SyncFsReqMsg = (SyncFsRequest | SyncExecRequest) & {
+  type: typeof SYNC_FS_REQ_MSG;
+  id: string;
+};
 /** responder → SW: receipt, posted synchronously before the async dispatch. */
 export type SyncFsAckMsg = { type: typeof SYNC_FS_ACK_MSG; id: string };
 /** responder → SW: the dispatch result. */
@@ -121,3 +133,19 @@ export const SYNC_FS_REQUEST_TIMEOUT_MS = 25_000;
  * The WARM path (a channel already exists) never waits.
  */
 export const SYNC_FS_NONCE_WAIT_MS = 2_000;
+
+/**
+ * Default round-trip budget for the `exec` channel when the caller supplies no
+ * `timeout`. A file read finishes in milliseconds; a build command does not, so
+ * the fs budget ({@link SYNC_FS_REQUEST_TIMEOUT_MS}) is far too tight here.
+ */
+export const SYNC_EXEC_DEFAULT_TIMEOUT_MS = 120_000;
+
+/**
+ * Ceiling on a caller-supplied `execSync(cmd, { timeout })`. A blocked realm
+ * worker cannot be interrupted, so an unbounded budget would make a runaway
+ * command unkillable short of terminating the realm. The responder retains a
+ * settled `id` for at least this long (plus a margin) so a late SW re-post
+ * replays the cached result instead of re-running the command.
+ */
+export const SYNC_EXEC_MAX_TIMEOUT_MS = 600_000;

--- a/packages/webapp/src/kernel/realm/sync-fs-wire.ts
+++ b/packages/webapp/src/kernel/realm/sync-fs-wire.ts
@@ -149,3 +149,23 @@ export const SYNC_EXEC_DEFAULT_TIMEOUT_MS = 120_000;
  * replays the cached result instead of re-running the command.
  */
 export const SYNC_EXEC_MAX_TIMEOUT_MS = 600_000;
+
+/**
+ * Margin the SW handler adds on top of the command budget before failing an
+ * exec closed. The dispatcher aborts `ctx.exec` exactly at the budget and then
+ * still has to build the `ETIMEDOUT` (or a just-in-time success) result,
+ * structured-clone it onto the channel, and have the SW turn it into a
+ * `Response`. Without this the two deadlines coincide and the SW's generic
+ * `EIO` races — usually wins — against the specific answer the responder is
+ * already producing. Kept BELOW the realm bridge's own XHR margin
+ * ({@link SYNC_EXEC_XHR_MARGIN_MS}) so the SW response still lands first.
+ */
+export const SYNC_EXEC_RESPONSE_MARGIN_MS = 2_000;
+
+/**
+ * Margin the realm bridge adds on top of the command budget for the blocking
+ * XHR's own `timeout`. Larger than {@link SYNC_EXEC_RESPONSE_MARGIN_MS} so the
+ * SW's authoritative errno wins the race with the bare XHR-timeout `EIO`; the
+ * XHR timeout stays the backstop for a dead SW that never answers at all.
+ */
+export const SYNC_EXEC_XHR_MARGIN_MS = 5_000;

--- a/packages/webapp/src/kernel/realm/sync-fs-xhr-bridge.ts
+++ b/packages/webapp/src/kernel/realm/sync-fs-xhr-bridge.ts
@@ -4,15 +4,10 @@
  * Runs INSIDE the realm's DedicatedWorker. Each op issues a **synchronous**
  * `XMLHttpRequest` to `/__slicc/fs-sync/<path>` — the controlling Service
  * Worker intercepts it (`llm-proxy-sw.ts`), round-trips to the kernel-worker
- * responder, and answers from the calling realm's own `ctx.fs`. The XHR blocks
- * the realm worker (a different thread from the VFS owner, so no deadlock)
- * until bytes come back.
- *
- * Synchronous XHR with `responseType='arraybuffer'` + a `timeout` is only
- * permitted OFF the main thread — which is exactly where realm code runs. On
- * any transport failure (timeout / no controlling SW / network error) the op
- * throws an `Error` whose `.code` is a POSIX errno, so it fails closed instead
- * of hanging, and ported Node code's `catch (e) { e.code === '…' }` still works.
+ * responder, and answers from the calling realm's own `ctx.fs`. The blocking
+ * round-trip itself (marker gate, errno recovery, fail-closed transport) lives
+ * in `sync-xhr.ts` and is shared with the exec channel; this module owns only
+ * the fs route shape and the per-op payload contracts.
  *
  * Phase-2 extends this to the metadata ops (`stat` / `readdir` / `exists`)
  * so the shim can fall back to the live filesystem on a cache miss — a file
@@ -21,18 +16,8 @@
  * param and return a JSON body; the read/write wire is unchanged.
  */
 
-// Wire contract shared with the SW handler + responder (single source of
-// truth — see sync-fs-wire.ts, a dependency-free module). The MARKER header
-// is load-bearing: its ABSENCE on a 2xx means the request was NOT answered by
-// our SW handler (a stale/absent SW let it hit the network → SPA fallback
-// `200` + `index.html`), so we reject it as EIO rather than reading HTML as
-// file bytes.
-import {
-  SYNC_FS_ERRNO_HEADER as ERRNO_HEADER,
-  SYNC_FS_MARKER_HEADER as MARKER_HEADER,
-  SYNC_FS_ROUTE_BASE,
-  SYNC_FS_TOKEN_HEADER as TOKEN_HEADER,
-} from './sync-fs-wire.js';
+import { SYNC_FS_ROUTE_BASE } from './sync-fs-wire.js';
+import { type SyncXhrRequest, synchronify, synchronifyJson, syncXhrError } from './sync-xhr.js';
 
 const DEFAULT_TIMEOUT_MS = 30000;
 
@@ -43,6 +28,7 @@ export interface SyncFsBridgeStat {
   size: number;
 }
 
+/** What the `fs` shim consumes — read/write plus read-only metadata. */
 export interface SyncFsXhrBridge {
   readFile(path: string): Uint8Array;
   writeFile(path: string, bytes: Uint8Array): void;
@@ -51,12 +37,28 @@ export interface SyncFsXhrBridge {
   exists(path: string): boolean;
 }
 
-/** An `Error` carrying a POSIX `.code`, matching sync-fs-cache's errors. */
-function errnoError(code: string, path: string): Error & { code: string } {
-  return Object.assign(new Error(`${code}: sync-fs bridge, '${path}'`), { code });
+/**
+ * The full bridge {@link createSyncFsXhrBridge} returns. The two mutating ops
+ * are kept OFF {@link SyncFsXhrBridge} because the `fs` shim deliberately keeps
+ * mkdir/rm cache-backed; only the sync-exec flush-before path drives them live,
+ * so the narrower type documents (and enforces) that split.
+ */
+export interface SyncFsXhrMutatingBridge extends SyncFsXhrBridge {
+  /** Live `mkdir -p`. */
+  mkdir(path: string): void;
+  /** Live recursive `rm`. */
+  rm(path: string): void;
 }
 
-function routeUrl(path: string, op?: 'stat' | 'readdir' | 'exists'): string {
+/** Ops the route carries as an `?op=` query param (bare read/write carry none). */
+type SyncFsRouteOp = 'stat' | 'readdir' | 'exists' | 'mkdir' | 'rm';
+
+/** An `Error` carrying a POSIX `.code`, matching sync-fs-cache's errors. */
+function errnoError(code: string, path: string): Error & { code: string } {
+  return syncXhrError(code, `sync-fs bridge, '${path}'`);
+}
+
+function routeUrl(path: string, op?: SyncFsRouteOp): string {
   const abs = path.startsWith('/') ? path : `/${path}`;
   // Encode PER SEGMENT: encodeURIComponent escapes `#`, `?`, `%`, space, and
   // unicode (which whole-string encodeURI leaves raw → dropped fragment/query
@@ -73,69 +75,28 @@ function routeUrl(path: string, op?: 'stat' | 'readdir' | 'exists'): string {
 export function createSyncFsXhrBridge(
   token: string,
   opts: { timeoutMs?: number } = {}
-): SyncFsXhrBridge {
+): SyncFsXhrMutatingBridge {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-  function send(
+  function request(
     method: 'GET' | 'POST',
     path: string,
     body?: Uint8Array,
-    op?: 'stat' | 'readdir' | 'exists'
-  ): XMLHttpRequest {
-    const xhr = new XMLHttpRequest();
-    try {
-      xhr.open(method, routeUrl(path, op), false); // synchronous — realm worker only
-      xhr.responseType = 'arraybuffer'; // permitted for sync XHR off the main thread
-      xhr.timeout = timeoutMs; // bounds a no-controller network hang
-      xhr.setRequestHeader(TOKEN_HEADER, token);
-      if (body) xhr.send(new Uint8Array(body));
-      else xhr.send();
-    } catch {
-      // ANY failure fails closed as EIO — a sync XHR throws on timeout /
-      // network error / no controlling SW, and open/responseType/timeout could
-      // in principle reject. Never let a raw error (missing `.code`) escape,
-      // and never leave the realm hung.
-      throw errnoError('EIO', path);
-    }
-    return xhr;
-  }
-
-  /**
-   * Parse the JSON body of a genuine metadata response. Bytes → text → JSON
-   * so we can reuse the `arraybuffer` response type used by read/write (a sync
-   * XHR can only set one `responseType` per request). A malformed JSON body
-   * from an otherwise-genuine handler fails closed as EIO rather than
-   * surfacing SyntaxError with no `.code`.
-   */
-  function readJson(xhr: XMLHttpRequest, path: string): unknown {
-    try {
-      const bytes = new Uint8Array(xhr.response as ArrayBuffer);
-      return JSON.parse(new TextDecoder().decode(bytes));
-    } catch {
-      throw errnoError('EIO', path);
-    }
-  }
-
-  function fail(xhr: XMLHttpRequest, path: string): never {
-    // Only trust the errno header when OUR handler stamped the marker — symmetric
-    // with the 2xx marker gate. A non-2xx lacking the marker isn't ours (a
-    // foreign/injected response), so fall back to EIO rather than reading an
-    // attacker-supplied x-slicc-fs-errno as authoritative.
-    const trusted = xhr.getResponseHeader(MARKER_HEADER) === '1';
-    throw errnoError((trusted && xhr.getResponseHeader(ERRNO_HEADER)) || 'EIO', path);
-  }
-  /** A 2xx is only trustworthy if our handler stamped the marker. */
-  function isGenuine(xhr: XMLHttpRequest): boolean {
-    return xhr.status >= 200 && xhr.status < 300 && xhr.getResponseHeader(MARKER_HEADER) === '1';
+    op?: SyncFsRouteOp
+  ): SyncXhrRequest {
+    return {
+      method,
+      url: routeUrl(path, op),
+      token,
+      ...(body ? { body } : {}),
+      timeoutMs,
+      label: `sync-fs bridge, '${path}'`,
+    };
   }
 
   return {
     readFile(path: string): Uint8Array {
-      const xhr = send('GET', path);
-      if (isGenuine(xhr)) return new Uint8Array(xhr.response as ArrayBuffer);
-      // 2xx without the marker = SPA fallback / stale SW → not our bytes.
-      if (xhr.status >= 200 && xhr.status < 300) throw errnoError('EIO', path);
-      fail(xhr, path);
+      return synchronify(request('GET', path));
     },
     writeFile(path: string, bytes: Uint8Array): void {
       // AT-LEAST-ONCE (see spec §11): a thrown error here means the outcome is
@@ -143,39 +104,28 @@ export function createSyncFsXhrBridge(
       // fire AFTER the responder already committed the bytes to the live VFS.
       // The caller must re-read to confirm rather than trust the throw; the
       // shim only advances its cache/baseline (`commitWrite`) on a clean return.
-      const xhr = send('POST', path, bytes);
-      if (isGenuine(xhr)) return;
-      if (xhr.status >= 200 && xhr.status < 300) throw errnoError('EIO', path);
-      fail(xhr, path);
+      synchronify(request('POST', path, bytes));
     },
     stat(path: string): SyncFsBridgeStat {
-      const xhr = send('GET', path, undefined, 'stat');
-      if (isGenuine(xhr)) {
-        const json = readJson(xhr, path) as Partial<SyncFsBridgeStat> | null;
-        if (
-          !json ||
-          typeof json.isFile !== 'boolean' ||
-          typeof json.isDirectory !== 'boolean' ||
-          typeof json.size !== 'number'
-        ) {
-          throw errnoError('EIO', path);
-        }
-        return { isFile: json.isFile, isDirectory: json.isDirectory, size: json.size };
+      const json = synchronifyJson(
+        request('GET', path, undefined, 'stat')
+      ) as Partial<SyncFsBridgeStat> | null;
+      if (
+        !json ||
+        typeof json.isFile !== 'boolean' ||
+        typeof json.isDirectory !== 'boolean' ||
+        typeof json.size !== 'number'
+      ) {
+        throw errnoError('EIO', path);
       }
-      if (xhr.status >= 200 && xhr.status < 300) throw errnoError('EIO', path);
-      fail(xhr, path);
+      return { isFile: json.isFile, isDirectory: json.isDirectory, size: json.size };
     },
     readdir(path: string): string[] {
-      const xhr = send('GET', path, undefined, 'readdir');
-      if (isGenuine(xhr)) {
-        const json = readJson(xhr, path);
-        if (!Array.isArray(json) || !json.every((s) => typeof s === 'string')) {
-          throw errnoError('EIO', path);
-        }
-        return json as string[];
+      const json = synchronifyJson(request('GET', path, undefined, 'readdir'));
+      if (!Array.isArray(json) || !json.every((s) => typeof s === 'string')) {
+        throw errnoError('EIO', path);
       }
-      if (xhr.status >= 200 && xhr.status < 300) throw errnoError('EIO', path);
-      fail(xhr, path);
+      return json as string[];
     },
     exists(path: string): boolean {
       // A genuine `exists` returns a JSON boolean (never throws ENOENT — the
@@ -183,14 +133,15 @@ export function createSyncFsXhrBridge(
       // an out-of-sandbox path, EIO on transport failure) does propagate; the
       // shim wraps this in a try/catch so `existsSync` matches Node's
       // never-throws contract.
-      const xhr = send('GET', path, undefined, 'exists');
-      if (isGenuine(xhr)) {
-        const json = readJson(xhr, path);
-        if (typeof json !== 'boolean') throw errnoError('EIO', path);
-        return json;
-      }
-      if (xhr.status >= 200 && xhr.status < 300) throw errnoError('EIO', path);
-      fail(xhr, path);
+      const json = synchronifyJson(request('GET', path, undefined, 'exists'));
+      if (typeof json !== 'boolean') throw errnoError('EIO', path);
+      return json;
+    },
+    mkdir(path: string): void {
+      synchronify(request('POST', path, undefined, 'mkdir'));
+    },
+    rm(path: string): void {
+      synchronify(request('POST', path, undefined, 'rm'));
     },
   };
 }

--- a/packages/webapp/src/kernel/realm/sync-xhr.ts
+++ b/packages/webapp/src/kernel/realm/sync-xhr.ts
@@ -1,0 +1,117 @@
+/**
+ * `synchronify` — the channel-agnostic blocking round-trip the realm's
+ * synchronous bridges are built on.
+ *
+ * Runs INSIDE the realm's DedicatedWorker. A **synchronous** `XMLHttpRequest`
+ * to a `/__slicc/*` route is intercepted by the controlling Service Worker
+ * (`llm-proxy-sw.ts`), round-tripped to the kernel-worker responder, and
+ * answered from the calling realm's own capability-token scope. The XHR blocks
+ * the realm worker (a different thread from the VFS / shell owner, so no
+ * deadlock) until the reply comes back.
+ *
+ * Synchronous XHR with `responseType='arraybuffer'` + a `timeout` is only
+ * permitted OFF the main thread — which is exactly where realm code runs. On
+ * any transport failure (timeout / no controlling SW / network error) the call
+ * throws an `Error` whose `.code` is a POSIX errno, so it fails closed instead
+ * of hanging, and ported Node code's `catch (e) { e.code === '…' }` still works.
+ *
+ * Extracted from `sync-fs-xhr-bridge.ts` so the fs channel and the exec channel
+ * (`sync-exec-xhr-bridge.ts`) share one transport rather than duplicating the
+ * marker/errno gates — the security-critical part of this bridge.
+ */
+
+// Wire contract shared with the SW handler + responder (single source of
+// truth — see sync-fs-wire.ts, a dependency-free module). The MARKER header
+// is load-bearing: its ABSENCE on a 2xx means the request was NOT answered by
+// our SW handler (a stale/absent SW let it hit the network → SPA fallback
+// `200` + `index.html`), so we reject it as EIO rather than reading HTML as
+// a genuine payload.
+import {
+  SYNC_FS_ERRNO_HEADER as ERRNO_HEADER,
+  SYNC_FS_MARKER_HEADER as MARKER_HEADER,
+  SYNC_FS_TOKEN_HEADER as TOKEN_HEADER,
+} from './sync-fs-wire.js';
+
+/** An `Error` carrying a POSIX `.code`, matching sync-fs-cache's error shape. */
+export function syncXhrError(code: string, label: string): Error & { code: string } {
+  return Object.assign(new Error(`${code}: ${label}`), { code });
+}
+
+export interface SyncXhrRequest {
+  method: 'GET' | 'POST';
+  /** Same-origin route the controlling SW intercepts. */
+  url: string;
+  /** Per-realm capability token addressing the caller's scope server-side. */
+  token: string;
+  /** Raw request body (POST only). */
+  body?: Uint8Array;
+  /**
+   * Hard bound on the blocking wait. The SW handler fails the op closed a
+   * margin BEFORE this (so its authoritative errno wins the race with the bare
+   * XHR-timeout `EIO`); this is the backstop for a dead SW that never runs the
+   * handler at all.
+   */
+  timeoutMs: number;
+  /** Trailing half of the thrown message — e.g. `sync-fs bridge, '/a.txt'`. */
+  label: string;
+}
+
+/**
+ * Issue one blocking round-trip and return the raw response bytes. Throws an
+ * errno `Error` on any non-genuine or non-2xx reply.
+ */
+export function synchronify(req: SyncXhrRequest): Uint8Array {
+  const xhr = send(req);
+  if (isGenuine(xhr)) return new Uint8Array(xhr.response as ArrayBuffer);
+  // 2xx without the marker = SPA fallback / stale SW → not our bytes.
+  if (xhr.status >= 200 && xhr.status < 300) throw syncXhrError('EIO', req.label);
+  fail(xhr, req.label);
+}
+
+/**
+ * Same round-trip, parsing the response as JSON. Bytes → text → JSON so the
+ * one `responseType` a sync XHR allows (`arraybuffer`) serves both payload
+ * shapes. A malformed body from an otherwise-genuine handler fails closed as
+ * `EIO` rather than surfacing a `SyntaxError` with no `.code`.
+ */
+export function synchronifyJson(req: SyncXhrRequest): unknown {
+  const bytes = synchronify(req);
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    throw syncXhrError('EIO', req.label);
+  }
+}
+
+function send(req: SyncXhrRequest): XMLHttpRequest {
+  const xhr = new XMLHttpRequest();
+  try {
+    xhr.open(req.method, req.url, false); // synchronous — realm worker only
+    xhr.responseType = 'arraybuffer'; // permitted for sync XHR off the main thread
+    xhr.timeout = req.timeoutMs; // bounds a no-controller network hang
+    xhr.setRequestHeader(TOKEN_HEADER, req.token);
+    if (req.body) xhr.send(new Uint8Array(req.body));
+    else xhr.send();
+  } catch {
+    // ANY failure fails closed as EIO — a sync XHR throws on timeout /
+    // network error / no controlling SW, and open/responseType/timeout could
+    // in principle reject. Never let a raw error (missing `.code`) escape,
+    // and never leave the realm hung.
+    throw syncXhrError('EIO', req.label);
+  }
+  return xhr;
+}
+
+/** A 2xx is only trustworthy if our handler stamped the marker. */
+function isGenuine(xhr: XMLHttpRequest): boolean {
+  return xhr.status >= 200 && xhr.status < 300 && xhr.getResponseHeader(MARKER_HEADER) === '1';
+}
+
+function fail(xhr: XMLHttpRequest, label: string): never {
+  // Only trust the errno header when OUR handler stamped the marker — symmetric
+  // with the 2xx marker gate. A non-2xx lacking the marker isn't ours (a
+  // foreign/injected response), so fall back to EIO rather than reading an
+  // attacker-supplied x-slicc-fs-errno as authoritative.
+  const trusted = xhr.getResponseHeader(MARKER_HEADER) === '1';
+  throw syncXhrError((trusted && xhr.getResponseHeader(ERRNO_HEADER)) || 'EIO', label);
+}

--- a/packages/webapp/src/ui/llm-proxy-sw.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw.ts
@@ -69,6 +69,7 @@ import {
 import {
   handleSyncFsRequest,
   parseSyncFsRequest,
+  SYNC_EXEC_ROUTE,
   SYNC_FS_ERRNO_HEADER,
   SYNC_FS_MARKER_HEADER,
   SYNC_FS_ROUTE_PREFIX,
@@ -192,15 +193,15 @@ self.addEventListener('fetch', (event: FetchEvent) => {
 });
 
 // ---------------------------------------------------------------------------
-// Synchronous-fs bridge route (`/__slicc/fs-sync/*`).
+// Synchronous bridge routes (`/__slicc/fs-sync/*`, `/__slicc/exec-sync`).
 //
-// The proxy listener above ignores same-origin fetches, so the sync-fs route
-// needs its OWN respondWith'ing listener (first respondWith wins, so this
-// coexists with the proxy listener and the importScripts'd preview-sw). A
-// realm's synchronous XHR is answered here by round-tripping over the
-// per-session nonce-named BroadcastChannel(s) (`slicc-sync-fs-<nonce>`) to the
+// The proxy listener above ignores same-origin fetches, so these routes need
+// their OWN respondWith'ing listener (first respondWith wins, so this coexists
+// with the proxy listener and the importScripts'd preview-sw). A realm's
+// synchronous XHR is answered here by round-tripping over the per-session
+// nonce-named BroadcastChannel(s) (`slicc-sync-fs-<nonce>`) to the
 // kernel-worker responder (`sync-fs-responder.ts`), which reads/writes the
-// CALLING realm's own ctx.fs.
+// CALLING realm's own ctx.fs or runs a command through its own ctx.exec.
 // ---------------------------------------------------------------------------
 // Per-session nonces naming the sync-fs channels — each same-origin leader tab
 // mints its own and delivers it over `postMessage` (never on a realm-observable
@@ -242,15 +243,16 @@ async function requestSyncFsNonce(): Promise<void> {
 self.addEventListener('fetch', (event: FetchEvent) => {
   const url = new URL(event.request.url);
   if (url.origin !== self.location.origin) return;
-  if (!url.pathname.startsWith(SYNC_FS_ROUTE_PREFIX)) return;
+  if (!url.pathname.startsWith(SYNC_FS_ROUTE_PREFIX) && url.pathname !== SYNC_EXEC_ROUTE) return;
   event.respondWith(
     (async () => {
       const req = await parseSyncFsRequest(event.request);
-      // Prefix already matched above, so a null parse means a malformed path
-      // (bad percent-encoding from an untrusted caller) → fail closed EINVAL,
-      // never a network fallthrough that could return SPA HTML.
+      // Prefix already matched above, so a null parse means a malformed
+      // request (bad percent-encoding on the fs route, or a malformed /
+      // non-POST envelope on the exec route) → fail closed EINVAL, never a
+      // network fallthrough that could return SPA HTML.
       if (!req) {
-        return new Response('sync-fs bridge: malformed path', {
+        return new Response('sync bridge: malformed request', {
           status: 400,
           headers: { [SYNC_FS_ERRNO_HEADER]: 'EINVAL', [SYNC_FS_MARKER_HEADER]: '1' },
         });

--- a/packages/webapp/src/ui/sync-fs-sw-handler.ts
+++ b/packages/webapp/src/ui/sync-fs-sw-handler.ts
@@ -1,13 +1,13 @@
 /**
- * Pure Service-Worker handler half of the synchronous-fs bridge.
+ * Pure Service-Worker handler half of the synchronous bridges (fs + exec).
  *
  * A realm issues a synchronous XHR to `/__slicc/fs-sync/<vfs-path>` (GET =
- * read, POST = write). The controlling SW's fetch listener calls
- * `handleSyncFsRequest`, which round-trips the request over the per-session
- * nonce-named BroadcastChannel(s) (`slicc-sync-fs-<nonce>` — never the fixed
- * name `slicc-sync-fs`, which a realm could join; see `sync-fs-wire.ts`) to the
- * kernel-worker responder (`sync-fs-responder.ts`) and turns the reply into a
- * `Response`:
+ * read, POST = write) or to `/__slicc/exec-sync` (POST, JSON command envelope).
+ * The controlling SW's fetch listener calls `handleSyncFsRequest`, which
+ * round-trips the request over the per-session nonce-named BroadcastChannel(s)
+ * (`slicc-sync-fs-<nonce>` — never the fixed name `slicc-sync-fs`, which a realm
+ * could join; see `sync-fs-wire.ts`) to the kernel-worker responder
+ * (`sync-fs-responder.ts`) and turns the reply into a `Response`:
  *
  *   - ok read  → 200, raw bytes body
  *   - ok write → 200, empty body
@@ -25,6 +25,8 @@
 // of truth). Re-exported so `llm-proxy-sw` can keep importing the route prefix
 // from this handler.
 import {
+  SYNC_EXEC_DEFAULT_TIMEOUT_MS,
+  SYNC_EXEC_ROUTE,
   SYNC_FS_ACK_MSG,
   SYNC_FS_ERRNO_HEADER,
   SYNC_FS_MARKER_HEADER,
@@ -35,8 +37,19 @@ import {
   SYNC_FS_TOKEN_HEADER,
 } from '../kernel/realm/sync-fs-wire.js';
 
-export { SYNC_FS_ERRNO_HEADER, SYNC_FS_MARKER_HEADER, SYNC_FS_ROUTE_PREFIX, SYNC_FS_TOKEN_HEADER };
+export {
+  SYNC_EXEC_ROUTE,
+  SYNC_FS_ERRNO_HEADER,
+  SYNC_FS_MARKER_HEADER,
+  SYNC_FS_ROUTE_PREFIX,
+  SYNC_FS_TOKEN_HEADER,
+};
 
+import {
+  clampSyncExecTimeout,
+  SYNC_EXEC_CHANNEL,
+  type SyncExecRequest,
+} from '../kernel/realm/sync-exec-dispatch.js';
 import type { SyncFsAckMsg, SyncFsResMsg } from '../kernel/realm/sync-fs-wire.js';
 
 /**
@@ -59,15 +72,45 @@ export interface SyncFsSwChannelLike {
   removeEventListener(type: 'message', listener: (ev: MessageEvent) => void): void;
 }
 
-export interface SyncFsHandlerRequest {
+export interface SyncFsHandlerFsRequest {
   token: string;
-  op: 'read' | 'write' | 'stat' | 'readdir' | 'exists';
+  op: 'read' | 'write' | 'stat' | 'readdir' | 'exists' | 'mkdir' | 'rm';
   path: string;
   body?: Uint8Array;
 }
 
-/** Metadata ops the SW parses off a GET `?op=` query param. */
+/**
+ * Either channel's wire request — the responder discriminates on `channel`.
+ * The exec arm's `op` / `path` / `body` are pinned absent so a consumer that
+ * reads them off the union gets `undefined` rather than a type error.
+ */
+export type SyncFsHandlerRequest =
+  | SyncFsHandlerFsRequest
+  | (SyncExecRequest & { op?: undefined; path?: undefined; body?: undefined });
+
+/** Read-only metadata ops the SW parses off a GET `?op=` query param. */
 const METADATA_OPS = new Set(['stat', 'readdir', 'exists']);
+/**
+ * Mutating metadata ops, parsed off a POST `?op=`. Only the sync-exec
+ * flush-before path issues these — the `fs` shim keeps mkdir/rm cache-backed —
+ * so a script's pending directory creations and deletions reach the live VFS
+ * before an `execSync` subprocess looks for them.
+ */
+const MUTATING_OPS = new Set(['mkdir', 'rm']);
+
+/**
+ * Per-request round-trip budget. The fs channel's budget is a fixed constant
+ * sized for a file read; the exec channel derives its own from the caller's
+ * `timeout` (clamped), because a build command legitimately runs for minutes.
+ */
+function budgetFor(req: SyncFsHandlerRequest): number {
+  if (!isExecHandlerRequest(req)) return DEFAULT_TIMEOUT_MS;
+  return clampSyncExecTimeout(req.timeoutMs, SYNC_EXEC_DEFAULT_TIMEOUT_MS);
+}
+
+function isExecHandlerRequest(req: SyncFsHandlerRequest): req is SyncExecRequest {
+  return (req as { channel?: unknown }).channel === SYNC_EXEC_CHANNEL;
+}
 
 /**
  * Map a POSIX errno to an HTTP status for the fail response. The realm bridge
@@ -94,9 +137,49 @@ export function errnoToStatus(errno: string): number {
 }
 
 /**
- * Parse a same-origin `/__slicc/fs-sync/*` request into a handler request.
- * GET → read, POST → write (body). Token comes from the `x-slicc-fs-token`
- * header. Returns `null` when the path is not a sync-fs route.
+ * Parse a same-origin `/__slicc/exec-sync` request into an exec handler
+ * request. Always a POST whose body is the JSON command envelope (a command
+ * string never has to survive URL encoding). Returns `null` for a malformed
+ * body so the caller fails it closed rather than forwarding an unvalidated
+ * shape to `ctx.exec`.
+ */
+async function parseSyncExecRequest(request: {
+  method: string;
+  headers: { get(name: string): string | null };
+  arrayBuffer(): Promise<ArrayBuffer>;
+}): Promise<SyncExecRequest | null> {
+  if (request.method !== 'POST') return null;
+  let payload: unknown;
+  try {
+    const buf = await request.arrayBuffer();
+    payload = JSON.parse(new TextDecoder().decode(new Uint8Array(buf)));
+  } catch {
+    return null;
+  }
+  if (!payload || typeof payload !== 'object') return null;
+  const p = payload as Record<string, unknown>;
+  const command = p.command;
+  const commandOk =
+    typeof command === 'string' ||
+    (Array.isArray(command) && command.every((a) => typeof a === 'string'));
+  if (!commandOk) return null;
+  return {
+    token: request.headers.get(SYNC_FS_TOKEN_HEADER) ?? '',
+    channel: SYNC_EXEC_CHANNEL,
+    command: command as string | string[],
+    ...(Array.isArray(p.args) && p.args.every((a) => typeof a === 'string')
+      ? { args: p.args as string[] }
+      : {}),
+    ...(typeof p.stdin === 'string' ? { stdin: p.stdin } : {}),
+    ...(typeof p.timeoutMs === 'number' ? { timeoutMs: p.timeoutMs } : {}),
+  };
+}
+
+/**
+ * Parse a same-origin `/__slicc/fs-sync/*` or `/__slicc/exec-sync` request into
+ * a handler request. On the fs route GET → read, POST → write (body); the exec
+ * route is POST-only with a JSON envelope. Token comes from the
+ * `x-slicc-fs-token` header. Returns `null` when the path is neither route.
  */
 export async function parseSyncFsRequest(request: {
   url: string;
@@ -105,6 +188,7 @@ export async function parseSyncFsRequest(request: {
   arrayBuffer(): Promise<ArrayBuffer>;
 }): Promise<SyncFsHandlerRequest | null> {
   const url = new URL(request.url);
+  if (url.pathname === SYNC_EXEC_ROUTE) return parseSyncExecRequest(request);
   if (!url.pathname.startsWith(SYNC_FS_ROUTE_PREFIX)) return null;
   // Decode PER SEGMENT — the symmetric partner of the bridge's per-segment
   // `encodeURIComponent` (see sync-fs-xhr-bridge.ts `routeUrl`): decode each
@@ -121,7 +205,12 @@ export async function parseSyncFsRequest(request: {
     return null;
   }
   const token = request.headers.get(SYNC_FS_TOKEN_HEADER) ?? '';
+  const opParam = url.searchParams.get('op');
   if (request.method === 'POST') {
+    // Mutating metadata ops carry no body; a plain POST is still a write.
+    if (opParam && MUTATING_OPS.has(opParam)) {
+      return { token, op: opParam as 'mkdir' | 'rm', path };
+    }
     const buf = await request.arrayBuffer();
     return { token, op: 'write', path, body: new Uint8Array(buf) };
   }
@@ -130,7 +219,6 @@ export async function parseSyncFsRequest(request: {
   // `op` value falls through to `read` rather than being accepted verbatim,
   // so a typo can't traverse the discriminated union with an untyped op
   // string (the responder / route would fail closed EINVAL anyway).
-  const opParam = url.searchParams.get('op');
   if (opParam && METADATA_OPS.has(opParam)) {
     return { token, op: opParam as 'stat' | 'readdir' | 'exists', path };
   }
@@ -145,10 +233,10 @@ function buildResponse(res: SyncFsResMsg): Response {
       headers: { [SYNC_FS_ERRNO_HEADER]: errno, [SYNC_FS_MARKER_HEADER]: '1' },
     });
   }
-  // Phase-2 metadata result (stat/readdir/exists). Phase-1 never routes these
-  // over the SW (`SyncFsHandlerRequest.op` is read|write), but the discriminated
+  // A metadata result (stat/readdir/exists) or an exec result
+  // (`{stdout,stderr,exitCode}`) — both ride a JSON body. The discriminated
   // union forces us to handle it so it can't be silently dropped as an empty
-  // body when phase-2 wires metadata through.
+  // body.
   if (res.kind === 'json') {
     return new Response(JSON.stringify(res.json ?? null), {
       status: 200,
@@ -167,7 +255,7 @@ function buildResponse(res: SyncFsResMsg): Response {
 }
 
 /**
- * Round-trip a sync-fs request over the channel(s) and resolve a `Response`.
+ * Round-trip a sync request over the channel(s) and resolve a `Response`.
  * Always resolves (never rejects): a timeout / absent responder yields a
  * fail-closed 503 + `EIO` so the blocked realm worker unblocks.
  *
@@ -182,7 +270,7 @@ export function handleSyncFsRequest(
   req: SyncFsHandlerRequest,
   opts: { timeoutMs?: number; retryIntervalMs?: number } = {}
 ): Promise<Response> {
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timeoutMs = opts.timeoutMs ?? budgetFor(req);
   const retryIntervalMs = opts.retryIntervalMs ?? DEFAULT_RETRY_INTERVAL_MS;
   const id = crypto.randomUUID();
 

--- a/packages/webapp/src/ui/sync-fs-sw-handler.ts
+++ b/packages/webapp/src/ui/sync-fs-sw-handler.ts
@@ -26,6 +26,7 @@
 // from this handler.
 import {
   SYNC_EXEC_DEFAULT_TIMEOUT_MS,
+  SYNC_EXEC_RESPONSE_MARGIN_MS,
   SYNC_EXEC_ROUTE,
   SYNC_FS_ACK_MSG,
   SYNC_FS_ERRNO_HEADER,
@@ -102,10 +103,18 @@ const MUTATING_OPS = new Set(['mkdir', 'rm']);
  * Per-request round-trip budget. The fs channel's budget is a fixed constant
  * sized for a file read; the exec channel derives its own from the caller's
  * `timeout` (clamped), because a build command legitimately runs for minutes.
+ *
+ * The exec budget gets {@link SYNC_EXEC_RESPONSE_MARGIN_MS} on top: the
+ * dispatcher aborts `ctx.exec` AT the command budget and then still has to
+ * serialize the result across the channel. Without the margin the two
+ * deadlines coincide and this handler's generic `EIO` races the responder's
+ * specific `ETIMEDOUT` (or a result that landed just in time).
  */
 function budgetFor(req: SyncFsHandlerRequest): number {
   if (!isExecHandlerRequest(req)) return DEFAULT_TIMEOUT_MS;
-  return clampSyncExecTimeout(req.timeoutMs, SYNC_EXEC_DEFAULT_TIMEOUT_MS);
+  return (
+    clampSyncExecTimeout(req.timeoutMs, SYNC_EXEC_DEFAULT_TIMEOUT_MS) + SYNC_EXEC_RESPONSE_MARGIN_MS
+  );
 }
 
 function isExecHandlerRequest(req: SyncFsHandlerRequest): req is SyncExecRequest {

--- a/packages/webapp/tests/kernel/realm/child_process.test.ts
+++ b/packages/webapp/tests/kernel/realm/child_process.test.ts
@@ -196,18 +196,35 @@ describe('child_process: spawn', () => {
   });
 });
 
-describe('child_process: sync forms are unavailable', () => {
-  it('execSync / spawnSync / execFileSync / fork throw a clear browser-realm error', async () => {
+describe('child_process: sync forms without a bridge', () => {
+  it('execSync / execFileSync / fork throw a message naming the async escape hatch', async () => {
+    // An in-process realm has no controlling Service Worker, so it gets no sync
+    // bridge and the sync forms fail — but with an actionable message rather
+    // than the old flat "not available". `spawnSync` is excluded: it never
+    // throws (Node contract) and reports the failure on `.error` instead.
     const out = await runCode(
       `const cp = require('child_process');
-       for (const name of ['execSync', 'spawnSync', 'execFileSync', 'fork']) {
+       for (const name of ['execSync', 'execFileSync']) {
          try { cp[name]('x'); console.log(name, 'NO-THROW'); }
-         catch (e) { console.log(name, e.message.includes('not available in the browser realm')); }
-       }`,
+         catch (e) { console.log(name, e.message.includes('no synchronous bridge')); }
+       }
+       try { cp.fork('x'); console.log('fork', 'NO-THROW'); }
+       catch (e) { console.log('fork', e.message.includes('not available in the browser realm')); }`,
       makeExecCtx()
     );
     expect(out.exitCode).toBe(0);
-    expect(out.stdout.trim()).toBe('execSync true\nspawnSync true\nexecFileSync true\nfork true');
+    expect(out.stdout.trim()).toBe('execSync true\nexecFileSync true\nfork true');
+  });
+
+  it('spawnSync reports the missing bridge on .error and never throws', async () => {
+    const out = await runCode(
+      `const cp = require('child_process');
+       const r = cp.spawnSync('echo', ['hi']);
+       console.log(r.status, r.signal, !!r.error, r.error.message.includes('no synchronous bridge'));`,
+      makeExecCtx()
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.trim()).toBe('null null true true');
   });
 });
 
@@ -285,12 +302,103 @@ describe('child_process unit: command shapes', () => {
     expect(typeof (cp.execFile as unknown as Record<symbol, unknown>)[sym]).toBe('function');
   });
 
-  it('execSync / spawnSync / execFileSync / fork throw', () => {
+  it('without a sync bridge, execSync/execFileSync throw and fork throws', () => {
     const cp = createNodeChildProcess(makeFakeBridge());
-    expect(() => cp.execSync('x')).toThrow('not available in the browser realm');
-    expect(() => cp.spawnSync('x')).toThrow('not available in the browser realm');
-    expect(() => cp.execFileSync('x')).toThrow('not available in the browser realm');
+    expect(() => cp.execSync('x')).toThrow('no synchronous bridge');
+    expect(() => cp.execFileSync('x')).toThrow('no synchronous bridge');
     expect(() => cp.fork('x')).toThrow('not available in the browser realm');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sync forms over a fake synchronous exec bridge. Node's contracts differ per
+// form: execSync/execFileSync return stdout and THROW on a non-zero exit;
+// spawnSync returns a result object and never throws.
+// ---------------------------------------------------------------------------
+
+type SyncCall = { command: string | string[]; opts: Record<string, unknown> };
+
+function makeFakeSyncBridge(result: CpExecResult, calls: SyncCall[] = []) {
+  return {
+    calls,
+    run(command: string | string[], opts: Record<string, unknown> = {}): CpExecResult {
+      calls.push({ command, opts });
+      return result;
+    },
+  };
+}
+
+describe('child_process unit: sync forms', () => {
+  const ok: CpExecResult = { stdout: 'out\n', stderr: 'warn\n', exitCode: 0 };
+  const failed: CpExecResult = { stdout: 'partial', stderr: 'boom', exitCode: 3 };
+
+  it('execSync returns a Buffer by default and a string with an encoding', () => {
+    const cp = createNodeChildProcess(makeFakeBridge(), makeFakeSyncBridge(ok));
+    const buf = cp.execSync('echo out');
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect((buf as Buffer).toString()).toBe('out\n');
+    expect(cp.execSync('echo out', { encoding: 'utf8' })).toBe('out\n');
+  });
+
+  it('execSync throws on a non-zero exit with Node status/stdout/stderr fields', () => {
+    const cp = createNodeChildProcess(makeFakeBridge(), makeFakeSyncBridge(failed));
+    try {
+      cp.execSync('false', { encoding: 'utf8' });
+      expect.unreachable('execSync must throw on a non-zero exit');
+    } catch (err) {
+      const e = err as Error & { status: number; stdout: string; stderr: string; signal: null };
+      expect(e.message).toContain('Command failed: false');
+      expect(e.status).toBe(3);
+      expect(e.stdout).toBe('partial');
+      expect(e.stderr).toBe('boom');
+      expect(e.signal).toBeNull();
+    }
+  });
+
+  it('execSync forwards input and timeout to the bridge', () => {
+    const bridge = makeFakeSyncBridge(ok);
+    const cp = createNodeChildProcess(makeFakeBridge(), bridge);
+    cp.execSync('cat', { input: 'piped', timeout: 500 });
+    expect(bridge.calls[0]?.opts).toMatchObject({ input: 'piped', timeout: 500 });
+  });
+
+  it('execFileSync runs the shell-free argv form', () => {
+    const bridge = makeFakeSyncBridge(ok);
+    const cp = createNodeChildProcess(makeFakeBridge(), bridge);
+    cp.execFileSync('ls', ['-la']);
+    expect(bridge.calls[0]?.command).toEqual(['ls', '-la']);
+  });
+
+  it('spawnSync returns a result object and NEVER throws on a non-zero exit', () => {
+    const cp = createNodeChildProcess(makeFakeBridge(), makeFakeSyncBridge(failed));
+    const r = cp.spawnSync('false', [], { encoding: 'utf8' });
+    expect(r.status).toBe(3);
+    expect(r.stdout).toBe('partial');
+    expect(r.stderr).toBe('boom');
+    expect(r.signal).toBeNull();
+    expect(r.error).toBeUndefined();
+    expect(r.output).toEqual([null, 'partial', 'boom']);
+  });
+
+  it('spawnSync surfaces a bridge failure on .error instead of throwing', () => {
+    const throwing = {
+      run(): CpExecResult {
+        throw Object.assign(new Error('EIO: sync-exec bridge'), { code: 'EIO' });
+      },
+    };
+    const cp = createNodeChildProcess(makeFakeBridge(), throwing);
+    const r = cp.spawnSync('ls');
+    expect(r.status).toBeNull();
+    expect(r.error?.message).toContain('EIO');
+  });
+
+  it('spawnSync defaults to argv and joins into a string when shell:true', () => {
+    const bridge = makeFakeSyncBridge(ok);
+    const cp = createNodeChildProcess(makeFakeBridge(), bridge);
+    cp.spawnSync('echo', ['a', 'b']);
+    expect(bridge.calls[0]?.command).toEqual(['echo', 'a', 'b']);
+    cp.spawnSync('echo', ['a', 'b'], { shell: true });
+    expect(bridge.calls[1]?.command).toBe('echo a b');
   });
 });
 

--- a/packages/webapp/tests/kernel/realm/sync-exec-dispatch.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-exec-dispatch.test.ts
@@ -1,0 +1,152 @@
+import type { CommandContext } from 'just-bash';
+import { expect, test, vi } from 'vitest';
+import {
+  clampSyncExecTimeout,
+  dispatchSyncExec,
+  isSyncExecRequest,
+  SYNC_EXEC_CHANNEL,
+} from '../../../src/kernel/realm/sync-exec-dispatch.js';
+import { mintSyncFsToken } from '../../../src/kernel/realm/sync-fs-token-registry.js';
+import { SYNC_EXEC_MAX_TIMEOUT_MS } from '../../../src/kernel/realm/sync-fs-wire.js';
+
+type ExecCall = { cmd: string; opts: Record<string, unknown> };
+
+/** Mint a token whose `exec` records its calls and answers with a fixed result. */
+function execToken(
+  result: { stdout: string; stderr: string; exitCode: number } | Error,
+  calls: ExecCall[] = []
+): { token: string; calls: ExecCall[] } {
+  const exec = (async (cmd: string, opts: Record<string, unknown>) => {
+    calls.push({ cmd, opts });
+    if (result instanceof Error) throw result;
+    return result;
+  }) as unknown as CommandContext['exec'];
+  const fs = {} as CommandContext['fs'];
+  return { token: mintSyncFsToken({ fs, exec, cwd: '/workspace' }), calls };
+}
+
+test('runs a string command through ctx.exec and returns the buffered result', async () => {
+  const { token, calls } = execToken({ stdout: 'hi\n', stderr: '', exitCode: 0 });
+  const r = await dispatchSyncExec({ token, channel: SYNC_EXEC_CHANNEL, command: 'echo hi' });
+  expect(r.ok).toBe(true);
+  if (r.ok && r.kind === 'json') {
+    expect(r.json).toEqual({ stdout: 'hi\n', stderr: '', exitCode: 0 });
+  }
+  expect(calls[0]?.cmd).toBe('echo hi');
+  expect(calls[0]?.opts.cwd).toBe('/workspace');
+});
+
+test('a non-zero exit is a SUCCESSFUL dispatch (not an errno)', async () => {
+  // spawnSync must be able to observe a failing command; only a transport /
+  // capability failure is an errno.
+  const { token } = execToken({ stdout: '', stderr: 'boom', exitCode: 3 });
+  const r = await dispatchSyncExec({ token, channel: SYNC_EXEC_CHANNEL, command: 'false' });
+  expect(r.ok).toBe(true);
+  if (r.ok && r.kind === 'json') expect((r.json as { exitCode: number }).exitCode).toBe(3);
+});
+
+test('argv form splits argv[0] from the shell-free tail', async () => {
+  const { token, calls } = execToken({ stdout: '', stderr: '', exitCode: 0 });
+  await dispatchSyncExec({
+    token,
+    channel: SYNC_EXEC_CHANNEL,
+    command: ['ls', '-la', '/tmp'],
+  });
+  expect(calls[0]?.cmd).toBe('ls');
+  expect(calls[0]?.opts.args).toEqual(['-la', '/tmp']);
+});
+
+test('stdin rides through to ctx.exec', async () => {
+  const { token, calls } = execToken({ stdout: '', stderr: '', exitCode: 0 });
+  await dispatchSyncExec({ token, channel: SYNC_EXEC_CHANNEL, command: 'cat', stdin: 'piped' });
+  expect(calls[0]?.opts.stdin).toBe('piped');
+});
+
+test('ESCALATION GUARD: an unknown / revoked token fails closed with EACCES', async () => {
+  const r = await dispatchSyncExec({
+    token: 'forged',
+    channel: SYNC_EXEC_CHANNEL,
+    command: 'whoami',
+  });
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.errno).toBe('EACCES');
+});
+
+test('a token minted without an exec handle fails closed with ENOSYS', async () => {
+  const token = mintSyncFsToken({ fs: {} as CommandContext['fs'], cwd: '/workspace' });
+  const r = await dispatchSyncExec({ token, channel: SYNC_EXEC_CHANNEL, command: 'ls' });
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.errno).toBe('ENOSYS');
+});
+
+test.each([
+  ['empty string', ''],
+  ['empty argv', []],
+  ['non-string argv member', [1]],
+  ['wrong type', 42],
+])('a malformed command (%s) fails closed with EINVAL before reaching exec', async (_l, cmd) => {
+  const { token, calls } = execToken({ stdout: '', stderr: '', exitCode: 0 });
+  const r = await dispatchSyncExec({
+    token,
+    channel: SYNC_EXEC_CHANNEL,
+    command: cmd as string | string[],
+  });
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.errno).toBe('EINVAL');
+  expect(calls).toHaveLength(0);
+});
+
+test('a malformed args array fails closed with EINVAL', async () => {
+  const { token } = execToken({ stdout: '', stderr: '', exitCode: 0 });
+  const r = await dispatchSyncExec({
+    token,
+    channel: SYNC_EXEC_CHANNEL,
+    command: 'ls',
+    args: [1] as unknown as string[],
+  });
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.errno).toBe('EINVAL');
+});
+
+test('a throwing shell becomes an EIO result (never a rejected promise)', async () => {
+  const { token } = execToken(new Error('shell exploded'));
+  const r = await dispatchSyncExec({ token, channel: SYNC_EXEC_CHANNEL, command: 'boom' });
+  expect(r.ok).toBe(false);
+  if (!r.ok) {
+    expect(r.errno).toBe('EIO');
+    expect(r.message).toContain('shell exploded');
+  }
+});
+
+test('the budget aborts a hung command and reports ETIMEDOUT', async () => {
+  const exec = (async (_cmd: string, opts: { signal: AbortSignal }) =>
+    new Promise((_resolve, reject) => {
+      opts.signal.addEventListener('abort', () => reject(new Error('aborted')));
+    })) as unknown as CommandContext['exec'];
+  const token = mintSyncFsToken({ fs: {} as CommandContext['fs'], exec, cwd: '/workspace' });
+  vi.useFakeTimers();
+  const pending = dispatchSyncExec({
+    token,
+    channel: SYNC_EXEC_CHANNEL,
+    command: 'sleep 999',
+    timeoutMs: 50,
+  });
+  await vi.advanceTimersByTimeAsync(60);
+  const r = await pending;
+  vi.useRealTimers();
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.errno).toBe('ETIMEDOUT');
+});
+
+test('clampSyncExecTimeout bounds the caller budget and falls back on garbage', () => {
+  expect(clampSyncExecTimeout(1_000, 5_000)).toBe(1_000);
+  expect(clampSyncExecTimeout(undefined, 5_000)).toBe(5_000);
+  expect(clampSyncExecTimeout(-1, 5_000)).toBe(5_000);
+  expect(clampSyncExecTimeout(Number.NaN, 5_000)).toBe(5_000);
+  expect(clampSyncExecTimeout(1e12, 5_000)).toBe(SYNC_EXEC_MAX_TIMEOUT_MS);
+});
+
+test('isSyncExecRequest discriminates the two channels', () => {
+  expect(isSyncExecRequest({ token: 't', channel: SYNC_EXEC_CHANNEL, command: 'ls' })).toBe(true);
+  expect(isSyncExecRequest({ token: 't', op: 'read', path: '/a' })).toBe(false);
+});

--- a/packages/webapp/tests/kernel/realm/sync-exec-dispatch.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-exec-dispatch.test.ts
@@ -6,7 +6,10 @@ import {
   isSyncExecRequest,
   SYNC_EXEC_CHANNEL,
 } from '../../../src/kernel/realm/sync-exec-dispatch.js';
-import { mintSyncFsToken } from '../../../src/kernel/realm/sync-fs-token-registry.js';
+import {
+  mintSyncFsToken,
+  revokeSyncFsToken,
+} from '../../../src/kernel/realm/sync-fs-token-registry.js';
 import { SYNC_EXEC_MAX_TIMEOUT_MS } from '../../../src/kernel/realm/sync-fs-wire.js';
 
 type ExecCall = { cmd: string; opts: Record<string, unknown> };
@@ -136,6 +139,34 @@ test('the budget aborts a hung command and reports ETIMEDOUT', async () => {
   vi.useRealTimers();
   expect(r.ok).toBe(false);
   if (!r.ok) expect(r.errno).toBe('ETIMEDOUT');
+});
+
+test('revoking the token aborts an in-flight command (realm killed mid-execSync)', async () => {
+  // A sync exec has no spawnId the realm host can track, so without the
+  // registry hook a SIGKILL'd realm left its ctx.exec running — and producing
+  // side effects — for the rest of its budget.
+  let aborted = false;
+  const exec = (async (_cmd: string, opts: { signal: AbortSignal }) =>
+    new Promise((_resolve, reject) => {
+      opts.signal.addEventListener('abort', () => {
+        aborted = true;
+        reject(new Error('aborted'));
+      });
+    })) as unknown as CommandContext['exec'];
+  const token = mintSyncFsToken({ fs: {} as CommandContext['fs'], exec, cwd: '/workspace' });
+  const pending = dispatchSyncExec({
+    token,
+    channel: SYNC_EXEC_CHANNEL,
+    command: 'sleep 999',
+    timeoutMs: 600_000,
+  });
+  await Promise.resolve(); // let the dispatch reach ctx.exec
+  revokeSyncFsToken(token);
+  const r = await pending;
+  expect(aborted).toBe(true);
+  expect(r.ok).toBe(false);
+  // Not ETIMEDOUT — the budget never elapsed.
+  if (!r.ok) expect(r.errno).toBe('ECANCELED');
 });
 
 test('clampSyncExecTimeout bounds the caller budget and falls back on garbage', () => {

--- a/packages/webapp/tests/kernel/realm/sync-exec-xhr-bridge.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-exec-xhr-bridge.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, expect, test, vi } from 'vitest';
+import { createSyncExecXhrBridge } from '../../../src/kernel/realm/sync-exec-xhr-bridge.js';
+import { SyncFsCache } from '../../../src/kernel/realm/sync-fs-cache.js';
+import type { SyncFsXhrMutatingBridge } from '../../../src/kernel/realm/sync-fs-xhr-bridge.js';
+
+interface FakeReply {
+  status: number;
+  body?: Uint8Array;
+  errno?: string;
+  noMarker?: boolean;
+}
+
+interface SentRecord {
+  method: string;
+  url: string;
+  token: string | null;
+  body: string;
+}
+
+let reply: FakeReply = { status: 200 };
+let lastSent: SentRecord | null = null;
+
+/** Minimal synchronous-XHR stand-in (node has no XMLHttpRequest). */
+class FakeXHR {
+  method = '';
+  url = '';
+  responseType = '';
+  timeout = 0;
+  status = 0;
+  response: ArrayBuffer = new ArrayBuffer(0);
+  private headers: Record<string, string> = {};
+
+  open(method: string, url: string): void {
+    this.method = method;
+    this.url = url;
+  }
+  setRequestHeader(k: string, v: string): void {
+    this.headers[k.toLowerCase()] = v;
+  }
+  send(body?: Uint8Array): void {
+    lastSent = {
+      method: this.method,
+      url: this.url,
+      token: this.headers['x-slicc-fs-token'] ?? null,
+      body: body ? new TextDecoder().decode(body) : '',
+    };
+    this.status = reply.status;
+    if (reply.body) {
+      const b = reply.body;
+      this.response = b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength) as ArrayBuffer;
+    }
+  }
+  getResponseHeader(name: string): string | null {
+    const n = name.toLowerCase();
+    if (n === 'x-slicc-fs-errno') return reply.errno ?? null;
+    if (n === 'x-slicc-fs') return reply.noMarker ? null : '1';
+    return null;
+  }
+}
+
+function okReply(value: unknown): FakeReply {
+  return { status: 200, body: new TextEncoder().encode(JSON.stringify(value)) };
+}
+
+function installFakeXhr(): void {
+  vi.stubGlobal('XMLHttpRequest', FakeXHR as unknown as typeof XMLHttpRequest);
+}
+
+/** Records every live fs op the flush-before path drives. */
+function recordingFsBridge(log: string[]): SyncFsXhrMutatingBridge {
+  return {
+    readFile: () => new Uint8Array(0),
+    writeFile: (p) => log.push(`write ${p}`),
+    stat: () => ({ isFile: true, isDirectory: false, size: 0 }),
+    readdir: () => [],
+    exists: () => true,
+    mkdir: (p) => log.push(`mkdir ${p}`),
+    rm: (p) => log.push(`rm ${p}`),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  reply = { status: 200 };
+  lastSent = null;
+});
+
+test('run POSTs the JSON envelope to the exec route with the token', () => {
+  installFakeXhr();
+  reply = okReply({ stdout: 'hi\n', stderr: '', exitCode: 0 });
+  const bridge = createSyncExecXhrBridge('tok-exec');
+  expect(bridge.run('echo hi')).toEqual({ stdout: 'hi\n', stderr: '', exitCode: 0 });
+  expect(lastSent?.method).toBe('POST');
+  expect(lastSent?.url).toBe('/__slicc/exec-sync');
+  expect(lastSent?.token).toBe('tok-exec');
+  expect(JSON.parse(lastSent!.body)).toMatchObject({ command: 'echo hi', channel: 'exec' });
+});
+
+test('argv, stdin and timeout ride the envelope', () => {
+  installFakeXhr();
+  reply = okReply({ stdout: '', stderr: '', exitCode: 0 });
+  createSyncExecXhrBridge('t').run(['cat'], { input: 'piped', timeout: 1234 });
+  expect(JSON.parse(lastSent!.body)).toMatchObject({
+    command: ['cat'],
+    stdin: 'piped',
+    timeoutMs: 1234,
+  });
+});
+
+test('an errno reply throws an Error carrying .code', () => {
+  installFakeXhr();
+  reply = { status: 403, errno: 'EACCES' };
+  expect(() => createSyncExecXhrBridge('t').run('sudo rm -rf /')).toThrow(
+    expect.objectContaining({ code: 'EACCES' })
+  );
+});
+
+test('a 2xx without the marker header fails closed as EIO (SPA fallback)', () => {
+  installFakeXhr();
+  reply = { ...okReply({ stdout: '', stderr: '', exitCode: 0 }), noMarker: true };
+  expect(() => createSyncExecXhrBridge('t').run('ls')).toThrow(
+    expect.objectContaining({ code: 'EIO' })
+  );
+});
+
+test('a malformed result payload fails closed as EIO', () => {
+  installFakeXhr();
+  reply = okReply({ stdout: 'x' }); // missing stderr / exitCode
+  expect(() => createSyncExecXhrBridge('t').run('ls')).toThrow(
+    expect.objectContaining({ code: 'EIO' })
+  );
+});
+
+test('COHERENCE: pending cache mutations are flushed live before the command runs', () => {
+  installFakeXhr();
+  reply = okReply({ stdout: '', stderr: '', exitCode: 0 });
+  const syncFs = new SyncFsCache({
+    entries: [{ path: '/workspace/old.txt', content: new Uint8Array(1), isDirectory: false }],
+  });
+  syncFs.writeFile('/workspace/new.txt', new TextEncoder().encode('fresh'));
+  syncFs.mkdir('/workspace/d', true);
+  syncFs.rm('/workspace/old.txt');
+  const log: string[] = [];
+  const bridge = createSyncExecXhrBridge('t', { syncFs, fsBridge: recordingFsBridge(log) });
+
+  bridge.run('build');
+
+  // Deletes first, then creates — matching applySyncFsMutations' ordering.
+  expect(log[0]).toBe('rm /workspace/old.txt');
+  expect(log).toContain('mkdir /workspace/d');
+  expect(log).toContain('write /workspace/new.txt');
+  // Baseline rebased, so the end-of-script flush won't re-apply them.
+  const m = syncFs.getMutations();
+  expect(m.created.length + m.modified.length + m.deleted.length).toBe(0);
+});
+
+test('COHERENCE: the cache is invalidated after the command, even when it throws', () => {
+  installFakeXhr();
+  const syncFs = new SyncFsCache({
+    entries: [{ path: '/workspace/a.txt', content: new Uint8Array(1), isDirectory: false }],
+  });
+  syncFs.readFile('/workspace/a.txt'); // marks the cache as used
+  const bridge = createSyncExecXhrBridge('t', { syncFs, fsBridge: recordingFsBridge([]) });
+
+  reply = { status: 503, errno: 'EIO' };
+  expect(() => bridge.run('boom')).toThrow();
+  // Invalidated → the entry is gone, so a later read falls through to the live
+  // fs bridge instead of returning stale post-exec bytes.
+  expect(syncFs.exists('/workspace/a.txt')).toBe(false);
+});
+
+test('an untouched sync cache skips the coherence dance entirely', () => {
+  installFakeXhr();
+  reply = okReply({ stdout: '', stderr: '', exitCode: 0 });
+  const syncFs = new SyncFsCache({ entries: [] });
+  const log: string[] = [];
+  createSyncExecXhrBridge('t', { syncFs, fsBridge: recordingFsBridge(log) }).run('ls');
+  expect(log).toEqual([]);
+});

--- a/packages/webapp/tests/kernel/realm/sync-exec-xhr-bridge.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-exec-xhr-bridge.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, expect, test, vi } from 'vitest';
 import { createSyncExecXhrBridge } from '../../../src/kernel/realm/sync-exec-xhr-bridge.js';
 import { SyncFsCache } from '../../../src/kernel/realm/sync-fs-cache.js';
+import { SYNC_EXEC_MAX_TIMEOUT_MS } from '../../../src/kernel/realm/sync-fs-wire.js';
 import type { SyncFsXhrMutatingBridge } from '../../../src/kernel/realm/sync-fs-xhr-bridge.js';
 
 interface FakeReply {
@@ -105,6 +106,23 @@ test('argv, stdin and timeout ride the envelope', () => {
     stdin: 'piped',
     timeoutMs: 1234,
   });
+});
+
+test("Node's `{ timeout: 0 }` becomes the default budget, not a 0 transport budget", () => {
+  // 0 means "no timeout" in Node. Sending it verbatim made the SW use its
+  // 120s fallback while the XHR gave up after only the margin, so any command
+  // slower than the margin failed early with EIO.
+  installFakeXhr();
+  reply = okReply({ stdout: '', stderr: '', exitCode: 0 });
+  createSyncExecXhrBridge('t', { timeoutMs: 60_000 }).run('slow', { timeout: 0 });
+  expect(JSON.parse(lastSent!.body).timeoutMs).toBe(60_000);
+});
+
+test('a caller budget above the wire ceiling is clamped before it reaches the XHR', () => {
+  installFakeXhr();
+  reply = okReply({ stdout: '', stderr: '', exitCode: 0 });
+  createSyncExecXhrBridge('t').run('forever', { timeout: Number.MAX_SAFE_INTEGER });
+  expect(JSON.parse(lastSent!.body).timeoutMs).toBe(SYNC_EXEC_MAX_TIMEOUT_MS);
 });
 
 test('an errno reply throws an Error carrying .code', () => {

--- a/packages/webapp/tests/kernel/realm/sync-fs-acceptance.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-fs-acceptance.test.ts
@@ -1,16 +1,17 @@
 /**
- * Phase-1 acceptance gates for the sync-fs bridge (node-testable layer).
+ * Acceptance gates for the sync bridges (node-testable layer).
  *
  * The ACL escape guard is proven in sync-fs-dispatch.test.ts (out-of-sandbox
- * read/write/`../` denied). Here we lock in the other two security properties
- * that are exercisable in node at the dispatch layer:
- *   - sudo inheritance: a sudo-gated write through dispatchSyncFs consults the
- *     broker and fails closed with EACCES on deny (the sync path inherits the
- *     same createSudoFs gate the async vfs path has).
+ * read/write/`../` denied). Here we lock in the other security properties
+ * that are exercisable in node at the dispatch layer, for BOTH channels:
+ *   - sudo inheritance: a sudo-gated write through dispatchSyncFs, and a
+ *     sudo-denied command through dispatchSyncExec, both fail closed with
+ *     EACCES (the sync paths inherit the same gates the async vfs / exec
+ *     paths have).
  *   - token isolation: one realm's token cannot reach another realm's scope,
- *     and a revoked token fails closed.
+ *     and a revoked token fails closed for reads AND for commands.
  *
- * The TRUE sudo-under-synchronous-write REENTRANCY (page services the sync-fs
+ * The TRUE sudo-under-synchronous-write REENTRANCY (page services the sync
  * request while the sudo modal is pending; broker-timeout → EACCES, never a
  * hang) and cross-float smoke are browser-only (real SW + DedicatedWorker) and
  * are documented as manual smokes in the plan (Task 8 step 2/4 / Task 9 docs) —
@@ -23,6 +24,10 @@ import { expect, test } from 'vitest';
 import { RestrictedFS } from '../../../src/fs/restricted-fs.js';
 import { createSudoFs } from '../../../src/fs/sudo-fs.js';
 import { VirtualFS } from '../../../src/fs/virtual-fs.js';
+import {
+  dispatchSyncExec,
+  SYNC_EXEC_CHANNEL,
+} from '../../../src/kernel/realm/sync-exec-dispatch.js';
 import { dispatchSyncFs } from '../../../src/kernel/realm/sync-fs-dispatch.js';
 import {
   mintSyncFsToken,
@@ -129,4 +134,58 @@ test('GATE: token isolation — one realm cannot read another realm scope; revok
   const revoked = await dispatchSyncFs({ token: tokenA, op: 'read', path: 'anything' });
   expect(revoked.ok).toBe(false);
   if (!revoked.ok) expect(revoked.errno).toBe('EACCES');
+});
+
+// ---------------------------------------------------------------------------
+// Exec channel. Same three properties, now that the token also carries the
+// realm's gated `ctx.exec`: the sudo COMMAND guard must fire on the sync path,
+// the command must run in the realm's own cwd, and revocation must fail closed.
+// ---------------------------------------------------------------------------
+
+test('GATE: the sync-exec channel runs through the realm own gated ctx.exec, in its cwd', async () => {
+  const seen: Array<{ cmd: string; cwd: unknown }> = [];
+  const exec = (async (cmd: string, opts: { cwd?: string }) => {
+    seen.push({ cmd, cwd: opts.cwd });
+    return { stdout: 'ok', stderr: '', exitCode: 0 };
+  }) as unknown as CommandContext['exec'];
+  const token = mintSyncFsToken({ fs: {} as CommandContext['fs'], exec, cwd: '/scoops/a' });
+
+  const r = await dispatchSyncExec({ token, channel: SYNC_EXEC_CHANNEL, command: 'ls' });
+
+  expect(r.ok).toBe(true);
+  // Not the ambient shell and not the global cwd — the realm's own handle/scope.
+  expect(seen).toEqual([{ cmd: 'ls', cwd: '/scoops/a' }]);
+});
+
+test('GATE: a sudo-denying ctx.exec propagates EACCES through the sync-exec channel', async () => {
+  // The command guard lives inside ctx.exec (same handle the async exec RPC
+  // uses), so a denial must surface as an errno rather than being swallowed.
+  const exec = (async () => {
+    throw Object.assign(new Error('sudo: command denied'), { code: 'EACCES' });
+  }) as unknown as CommandContext['exec'];
+  const token = mintSyncFsToken({ fs: {} as CommandContext['fs'], exec, cwd: '/workspace' });
+
+  const r = await dispatchSyncExec({
+    token,
+    channel: SYNC_EXEC_CHANNEL,
+    command: 'rm -rf /',
+  });
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.errno).toBe('EACCES');
+});
+
+test('GATE: a revoked token cannot run a command (exec capability dies with the realm)', async () => {
+  let ran = false;
+  const exec = (async () => {
+    ran = true;
+    return { stdout: '', stderr: '', exitCode: 0 };
+  }) as unknown as CommandContext['exec'];
+  const token = mintSyncFsToken({ fs: {} as CommandContext['fs'], exec, cwd: '/workspace' });
+
+  revokeSyncFsToken(token);
+  const r = await dispatchSyncExec({ token, channel: SYNC_EXEC_CHANNEL, command: 'whoami' });
+
+  expect(r.ok).toBe(false);
+  if (!r.ok) expect(r.errno).toBe('EACCES');
+  expect(ran).toBe(false);
 });

--- a/packages/webapp/tests/kernel/realm/sync-fs-responder.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-fs-responder.test.ts
@@ -66,6 +66,42 @@ test('responds to a sync-fs-req: acks immediately, then posts res with bytes', a
   handle.dispose();
 });
 
+test('routes an exec-channel request to the exec dispatch, not the fs one', async () => {
+  const { a, b } = makeChannelPair();
+  const received: Array<Record<string, unknown>> = [];
+  a.addEventListener('message', (e) => received.push(e.data as Record<string, unknown>));
+  const handle = installSyncFsResponder({ channel: b });
+  const exec = (async () => ({
+    stdout: 'ran\n',
+    stderr: '',
+    exitCode: 0,
+  })) as unknown as CommandContext['exec'];
+  const token = mintSyncFsToken({ fs: {} as CommandContext['fs'], exec, cwd: '/workspace' });
+
+  a.postMessage({ type: 'sync-fs-req', id: 'e1', token, channel: 'exec', command: 'echo ran' });
+
+  await vi.waitFor(() => expect(received.some((m) => m.type === 'sync-fs-res')).toBe(true));
+  const res = received.find((m) => m.type === 'sync-fs-res') as Record<string, unknown>;
+  expect(res.ok).toBe(true);
+  expect(res.json).toEqual({ stdout: 'ran\n', stderr: '', exitCode: 0 });
+  handle.dispose();
+});
+
+test('an unowned token gets NO response on the exec channel either', async () => {
+  // Same fail-silent contract as the fs channel: a non-owning worker must not
+  // answer, or a forged token could be served by whichever worker replies first.
+  const { a, b } = makeChannelPair();
+  const received: Array<Record<string, unknown>> = [];
+  a.addEventListener('message', (e) => received.push(e.data as Record<string, unknown>));
+  const handle = installSyncFsResponder({ channel: b });
+
+  a.postMessage({ type: 'sync-fs-req', id: 'e2', token: 'forged', channel: 'exec', command: 'ls' });
+
+  await new Promise((r) => setTimeout(r, 20));
+  expect(received).toEqual([]);
+  handle.dispose();
+});
+
 test('an unowned token gets NO response (stays silent — owner/timeout answers)', async () => {
   // Origin-scoped channel: a token this worker doesn't own (another worker's,
   // or forged/revoked) must NOT be answered here, so we can't win a race with

--- a/packages/webapp/tests/kernel/realm/sync-fs-shim-bridge.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-fs-shim-bridge.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from 'vitest';
 import { createSyncFsBridge } from '../../../src/kernel/realm/realm-fs-bridge.js';
 import { SyncFsCache, type SyncFsSnapshot } from '../../../src/kernel/realm/sync-fs-cache.js';
-import type { SyncFsXhrBridge } from '../../../src/kernel/realm/sync-fs-xhr-bridge.js';
+import type {
+  SyncFsXhrBridge,
+  SyncFsXhrMutatingBridge,
+} from '../../../src/kernel/realm/sync-fs-xhr-bridge.js';
 
 function fakeBridge(
   store: Map<string, Uint8Array>,
@@ -448,6 +451,70 @@ test('chmodSync is a no-op for an existing path, ENOENT for a missing one', () =
   const shim = createSyncFsBridge(cache([textEntry('/workspace/m.txt', 'x')]), '/workspace');
   expect(() => shim.chmodSync('/workspace/m.txt')).not.toThrow();
   expect(() => shim.chmodSync('/workspace/gone.txt')).toThrow(/ENOENT/);
+});
+
+/** A `fakeBridge` widened with the live mkdir/rm the removal fallback needs. */
+function mutatingBridge(
+  store: Map<string, Uint8Array>,
+  dirs: Set<string> = new Set(['/workspace'])
+): SyncFsXhrMutatingBridge {
+  return {
+    ...fakeBridge(store, dirs),
+    mkdir: (p: string) => {
+      dirs.add(p);
+    },
+    rm: (p: string) => {
+      store.delete(p);
+      dirs.delete(p);
+      for (const k of [...store.keys()]) if (k.startsWith(`${p}/`)) store.delete(k);
+    },
+  };
+}
+
+test('unlinkSync removes a live file the (post-execSync) empty cache does not hold', () => {
+  // execSync invalidates the cache, so a miss is not proof of absence — a
+  // cache-only unlink would throw ENOENT and leave the live file behind.
+  const store = new Map([['/workspace/live.txt', new TextEncoder().encode('L')]]);
+  const shim = createSyncFsBridge(cache(), '/workspace', mutatingBridge(store));
+  expect(() => shim.unlinkSync('/workspace/live.txt')).not.toThrow();
+  expect(store.has('/workspace/live.txt')).toBe(false);
+  expect(shim.existsSync('/workspace/live.txt')).toBe(false);
+});
+
+test('unlinkSync still throws ENOENT when the path is absent live too', () => {
+  const shim = createSyncFsBridge(cache(), '/workspace', mutatingBridge(new Map()));
+  expect(() => shim.unlinkSync('/workspace/nope.txt')).toThrow(/ENOENT/);
+});
+
+test('rmSync removes a live-only path; force stays silent on a real miss', () => {
+  const store = new Map([['/workspace/live.txt', new TextEncoder().encode('L')]]);
+  const shim = createSyncFsBridge(cache(), '/workspace', mutatingBridge(store));
+  shim.rmSync('/workspace/live.txt');
+  expect(store.has('/workspace/live.txt')).toBe(false);
+  expect(() => shim.rmSync('/workspace/gone.txt', { force: true })).not.toThrow();
+});
+
+test('rmSync without force throws ENOENT on a path absent from cache AND live', () => {
+  const shim = createSyncFsBridge(cache(), '/workspace', mutatingBridge(new Map()));
+  expect(() => shim.rmSync('/workspace/gone.txt')).toThrow(/ENOENT/);
+});
+
+test('renameSync moves a live-only file via copy-then-remove', () => {
+  const store = new Map([['/workspace/src.txt', new TextEncoder().encode('BODY')]]);
+  const shim = createSyncFsBridge(cache(), '/workspace', mutatingBridge(store));
+  shim.renameSync('/workspace/src.txt', '/workspace/dst.txt');
+  expect(shim.readFileSync('/workspace/dst.txt', 'utf8')).toBe('BODY');
+  expect(shim.existsSync('/workspace/src.txt')).toBe(false);
+  expect(store.has('/workspace/src.txt')).toBe(false);
+});
+
+test('a removal fallback does NOT resurrect a tombstoned path via the bridge', () => {
+  const store = new Map([['/workspace/del.txt', new TextEncoder().encode('LIVE')]]);
+  const syncFs = cache([textEntry('/workspace/del.txt', 'LIVE')]);
+  const shim = createSyncFsBridge(syncFs, '/workspace', mutatingBridge(store));
+  shim.unlinkSync('/workspace/del.txt'); // cache hit → tombstone, live delete deferred
+  // The second unlink must be ENOENT from the tombstone, not a live re-delete.
+  expect(() => shim.unlinkSync('/workspace/del.txt')).toThrow(/ENOENT/);
 });
 
 test('appendFileSync does NOT resurrect a tombstoned (deleted-in-script) path', () => {

--- a/packages/webapp/tests/kernel/realm/sync-fs-token-registry.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-fs-token-registry.test.ts
@@ -6,6 +6,7 @@ import {
   mintSyncFsToken,
   resolveSyncFsToken,
   revokeSyncFsToken,
+  trackSyncExec,
 } from '../../../src/kernel/realm/sync-fs-token-registry.js';
 
 const fakeFs = {} as never;
@@ -43,6 +44,42 @@ test('two mints are distinct and isolated', () => {
 
 test('revoking an unknown token is a no-op (no throw)', () => {
   expect(() => revokeSyncFsToken('does-not-exist')).not.toThrow();
+});
+
+test('trackSyncExec: revoke aborts every in-flight command for that token', () => {
+  const token = mintSyncFsToken({ fs: fakeFs, cwd: '/' });
+  const a = new AbortController();
+  const b = new AbortController();
+  trackSyncExec(token, a);
+  trackSyncExec(token, b);
+  revokeSyncFsToken(token);
+  expect(a.signal.aborted).toBe(true);
+  expect(b.signal.aborted).toBe(true);
+});
+
+test('trackSyncExec: an untracked (settled) command is not aborted by a later revoke', () => {
+  const token = mintSyncFsToken({ fs: fakeFs, cwd: '/' });
+  const controller = new AbortController();
+  trackSyncExec(token, controller)();
+  revokeSyncFsToken(token);
+  expect(controller.signal.aborted).toBe(false);
+});
+
+test('trackSyncExec: an already-revoked token aborts immediately (resolve/revoke race)', () => {
+  const token = mintSyncFsToken({ fs: fakeFs, cwd: '/' });
+  revokeSyncFsToken(token);
+  const controller = new AbortController();
+  trackSyncExec(token, controller);
+  expect(controller.signal.aborted).toBe(true);
+});
+
+test('trackSyncExec: one realm\u2019s revoke leaves another realm\u2019s command running', () => {
+  const mine = mintSyncFsToken({ fs: fakeFs, cwd: '/a' });
+  const theirs = mintSyncFsToken({ fs: fakeFs, cwd: '/b' });
+  const controller = new AbortController();
+  trackSyncExec(theirs, controller);
+  revokeSyncFsToken(mine);
+  expect(controller.signal.aborted).toBe(false);
 });
 
 test('attachRealmHost mints a resolvable token when the bridge is enabled', () => {

--- a/packages/webapp/tests/ui/sync-fs-sw-handler.test.ts
+++ b/packages/webapp/tests/ui/sync-fs-sw-handler.test.ts
@@ -1,4 +1,5 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
+import { SYNC_EXEC_MAX_TIMEOUT_MS } from '../../src/kernel/realm/sync-fs-wire.js';
 import {
   errnoToStatus,
   handleSyncFsRequest,
@@ -181,6 +182,114 @@ test('parseSyncFsRequest: GET ?op=exists → exists op', async () => {
     arrayBuffer: async () => new ArrayBuffer(0),
   });
   expect(parsed?.op).toBe('exists');
+});
+
+test.each(['mkdir', 'rm'])(
+  'parseSyncFsRequest: POST ?op=%s → mutating op with no body',
+  async (op) => {
+    // The sync-exec flush-before path is the only caller — it needs live
+    // mkdir/rm so a subprocess sees the script's pending directory mutations.
+    const parsed = await parseSyncFsRequest({
+      url: `https://www.sliccy.ai/__slicc/fs-sync/workspace/d?op=${op}`,
+      method: 'POST',
+      headers: { get: () => 'tok' },
+      arrayBuffer: async () => new ArrayBuffer(0),
+    });
+    expect(parsed).toEqual({ token: 'tok', op, path: '/workspace/d' });
+  }
+);
+
+test('parseSyncFsRequest: exec route → exec channel request off the JSON envelope', async () => {
+  const body = new TextEncoder().encode(
+    JSON.stringify({ command: 'echo hi', stdin: 'in', timeoutMs: 900 })
+  );
+  const parsed = await parseSyncFsRequest({
+    url: 'https://www.sliccy.ai/__slicc/exec-sync',
+    method: 'POST',
+    headers: { get: (n) => (n === 'x-slicc-fs-token' ? 'tok' : null) },
+    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+  });
+  expect(parsed).toEqual({
+    token: 'tok',
+    channel: 'exec',
+    command: 'echo hi',
+    stdin: 'in',
+    timeoutMs: 900,
+  });
+});
+
+test('parseSyncFsRequest: exec route rejects a GET (POST-only envelope)', async () => {
+  const parsed = await parseSyncFsRequest({
+    url: 'https://www.sliccy.ai/__slicc/exec-sync',
+    method: 'GET',
+    headers: { get: () => 'tok' },
+    arrayBuffer: async () => new ArrayBuffer(0),
+  });
+  expect(parsed).toBeNull();
+});
+
+test.each([
+  ['not JSON', 'not json at all'],
+  ['no command', '{"stdin":"x"}'],
+  ['command of the wrong type', '{"command":42}'],
+  ['argv with a non-string member', '{"command":[1,2]}'],
+])('parseSyncFsRequest: exec route fails closed on a malformed envelope (%s)', async (_l, raw) => {
+  // A null parse makes the SW answer EINVAL rather than forwarding an
+  // unvalidated shape toward ctx.exec.
+  const body = new TextEncoder().encode(raw);
+  const parsed = await parseSyncFsRequest({
+    url: 'https://www.sliccy.ai/__slicc/exec-sync',
+    method: 'POST',
+    headers: { get: () => 'tok' },
+    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+  });
+  expect(parsed).toBeNull();
+});
+
+test('an exec request waits on the exec budget, not the fs one', async () => {
+  // A build command legitimately outruns the fs channel's fixed 25s budget; the
+  // handler must derive its wait from the (clamped) caller timeout instead. The
+  // responder acks but never answers, so only the budget ends the wait.
+  vi.useFakeTimers();
+  try {
+    const ch = respondingChannel(() => null);
+    const pending = handleSyncFsRequest([ch], {
+      token: 't',
+      channel: 'exec',
+      command: 'build',
+      timeoutMs: 300_000,
+    });
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(60_000); // well past the fs budget
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(250_000); // past the exec budget
+    const res = await pending;
+    expect(res.status).toBe(503);
+    expect(res.headers.get('x-slicc-fs-errno')).toBe('EIO');
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('a caller budget above the ceiling is clamped, not honored verbatim', async () => {
+  vi.useFakeTimers();
+  try {
+    const ch = respondingChannel(() => null);
+    const pending = handleSyncFsRequest([ch], {
+      token: 't',
+      channel: 'exec',
+      command: 'forever',
+      timeoutMs: Number.MAX_SAFE_INTEGER,
+    });
+    // SYNC_EXEC_MAX_TIMEOUT_MS is 10 minutes; a hair past it must settle.
+    await vi.advanceTimersByTimeAsync(SYNC_EXEC_MAX_TIMEOUT_MS + 1_000);
+    expect((await pending).status).toBe(503);
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test('parseSyncFsRequest: GET with an UNKNOWN ?op= falls back to read (typo → bytes route)', async () => {

--- a/packages/webapp/tests/ui/sync-fs-sw-handler.test.ts
+++ b/packages/webapp/tests/ui/sync-fs-sw-handler.test.ts
@@ -1,5 +1,8 @@
 import { expect, test, vi } from 'vitest';
-import { SYNC_EXEC_MAX_TIMEOUT_MS } from '../../src/kernel/realm/sync-fs-wire.js';
+import {
+  SYNC_EXEC_MAX_TIMEOUT_MS,
+  SYNC_EXEC_RESPONSE_MARGIN_MS,
+} from '../../src/kernel/realm/sync-fs-wire.js';
 import {
   errnoToStatus,
   handleSyncFsRequest,
@@ -32,6 +35,32 @@ function respondingChannel(
       queueMicrotask(() => emit({ type: 'sync-fs-ack', id: req.id }));
       const result = responder(req);
       if (result) queueMicrotask(() => emit({ type: 'sync-fs-res', id: req.id, ...result }));
+    },
+    addEventListener: (_t, l) => {
+      listeners.add(l);
+    },
+    removeEventListener: (_t, l) => {
+      listeners.delete(l);
+    },
+  };
+}
+
+/**
+ * Like {@link respondingChannel}, but the result lands `delayMs` after the
+ * request — modelling the responder that aborts at the command budget and then
+ * needs a moment to serialize its answer.
+ */
+function deferredChannel(delayMs: number, result: FakeResult): SyncFsSwChannelLike {
+  const listeners = new Set<(e: MessageEvent) => void>();
+  const emit = (data: unknown): void => {
+    for (const l of [...listeners]) l({ data } as MessageEvent);
+  };
+  return {
+    postMessage: (data: unknown) => {
+      const req = data as Record<string, unknown>;
+      if (req?.type !== 'sync-fs-req') return;
+      queueMicrotask(() => emit({ type: 'sync-fs-ack', id: req.id }));
+      setTimeout(() => emit({ type: 'sync-fs-res', id: req.id, ...result }), delayMs);
     },
     addEventListener: (_t, l) => {
       listeners.add(l);
@@ -284,9 +313,38 @@ test('a caller budget above the ceiling is clamped, not honored verbatim', async
       command: 'forever',
       timeoutMs: Number.MAX_SAFE_INTEGER,
     });
-    // SYNC_EXEC_MAX_TIMEOUT_MS is 10 minutes; a hair past it must settle.
-    await vi.advanceTimersByTimeAsync(SYNC_EXEC_MAX_TIMEOUT_MS + 1_000);
+    // SYNC_EXEC_MAX_TIMEOUT_MS is 10 minutes; a hair past it (plus the
+    // response margin) must settle.
+    await vi.advanceTimersByTimeAsync(
+      SYNC_EXEC_MAX_TIMEOUT_MS + SYNC_EXEC_RESPONSE_MARGIN_MS + 1_000
+    );
     expect((await pending).status).toBe(503);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("the SW waits past the command budget so the responder's ETIMEDOUT wins", async () => {
+  // The dispatcher aborts ctx.exec AT the budget, then still has to serialize
+  // the result. If the SW deadline coincided with the command budget, its
+  // generic EIO would race — and usually beat — that specific errno.
+  vi.useFakeTimers();
+  try {
+    const budgetMs = 10_000;
+    const ch = deferredChannel(budgetMs + 500, {
+      ok: false,
+      errno: 'ETIMEDOUT',
+      message: 'sync-exec: timed out',
+    });
+    const pending = handleSyncFsRequest([ch], {
+      token: 't',
+      channel: 'exec',
+      command: 'sleep 99',
+      timeoutMs: budgetMs,
+    });
+    await vi.advanceTimersByTimeAsync(budgetMs + 1_000);
+    const res = await pending;
+    expect(res.headers.get('x-slicc-fs-errno')).toBe('ETIMEDOUT');
   } finally {
     vi.useRealTimers();
   }


### PR DESCRIPTION
## Problem

Closes #1748 — `execSync` / `execFileSync` / `spawnSync` were enumerable functions that always threw, so every Node feature-detection pattern took the sync branch and failed.

## Solution

The issue proposed hiding them; this implements them instead, on the blocking sync-XHR bridge that already backs `readFileSync`. Two decisions worth a look:

- **One capability token, not two.** The exec channel reuses the sync-fs token (widened to carry `ctx.exec`) rather than minting an exec-scoped one — same mint site, lifetime, and revocation, and a realm that can drive `ctx.exec` can already reach the filesystem through the shell, so a second secret would add exposure without narrowing what a leak grants. Dispatch goes through the realm's own gated `ctx.exec`, inheriting the sudo command guard, path ACLs, and secret masking from the async path.
- **Invalidate the sync-fs cache instead of re-snapshotting.** The async exec bridge does flush-before / re-snapshot-after; `execSync` can await neither. It flushes pending mutations over the blocking fs channel, then drops the cache — every sync read already falls through to the live bridge on a miss, so invalidation is correct and far cheaper than pulling a snapshot through a blocking XHR.

Sudo is safe while blocked: the brokers live in the kernel worker and the page, so the approval prompt still renders while the realm worker waits. The exec channel gets its own budget (default 2 min, capped at 10) since the fs channel's 25 s is sized for a file read.

Spec: [realm-sync-child-process.md](https://cosmos.augmentcode.com/files/realm-sync-child-process-dbd0457eec6a4aa6aaee6e930e36f2a2?view=focus)

## Testing

Full suite green (12,826 tests), plus new coverage at each seam: exec dispatch against a fake `ctx.exec`, the realm bridge against a fake XHR (including both coherence paths), the shim against Node's documented return/throw contracts, and three security gates in the acceptance suite (sudo denial propagates `EACCES`, commands run in the realm's own cwd, a revoked token cannot run anything). One real bug caught in review-by-test: the exec dispatch was flattening a sudo denial's `EACCES` to `EIO`.

Not yet verified in a real browser float — the in-process harness can't drive a synchronous XHR without deadlocking, so the issue's `node -e` repro against a live SW is still a manual smoke.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KYPHJMZ7674FYP052CJT280N&panel=chat)