### PR TITLE
feat(swift-launcher): iCloud tray-session sync and Sliccstart list redesign

### DIFF
--- a/packages/swift-launcher/CLAUDE.md
+++ b/packages/swift-launcher/CLAUDE.md
@@ -98,24 +98,34 @@ Mac can be joined from another device without hand-copying its join URL. The
 data model is Foundation-only and platform-agnostic so the iOS follower
 (`packages/ios-app`) can reuse it verbatim when it gains sync.
 
-- `Models/SyncedTraySession.swift` — one advertised session: `id` (derived
-  from the join URL so republish upserts and two devices observing the same
-  tray collapse to one entry), `joinUrl`, `label`, `deviceName`, `createdAt`,
-  `lastSeenAt`, plus `isStale(ttl:now:)`. No AppKit/UIKit import.
+- `Models/SyncedTraySession.swift` — one advertised session: `id` (the
+  **SHA-256 of the join URL** — stable for upsert/dedup but opaque, so it is
+  safe in accessibility identifiers / telemetry `source`; the raw `joinUrl`
+  carries the secret and is never surfaced to telemetry), `joinUrl`, `label`,
+  `deviceId` (stable per-device UUID for ownership), `deviceName` (display
+  only), `createdAt`, `lastSeenAt`, plus `isStale(ttl:now:)`. `CryptoKit` +
+  Foundation only; no AppKit/UIKit. Legacy payloads without `deviceId` decode
+  (empty).
 - `Models/TraySessionSyncStore.swift` — `@Observable` store over a
   `KeyValueSyncBackend`. Default backend is `UbiquitousKeyValueBackend`
   (`NSUbiquitousKeyValueStore`); tests inject `InMemoryKeyValueBackend` so no
-  unit test touches iCloud. Publishes/withdraws this device's session, prunes
-  stale entries by `defaultTTL` (12h) on every load, caps at `maxSessions`
+  unit test touches iCloud. **Each device writes its own sessions under a
+  per-device key `storageKeyPrefix + deviceId` and reads the union of all such
+  keys** (`keys(withPrefix:)`), so two devices publishing at once never
+  clobber each other's advertisement and same-host-name Macs stay distinct.
+  Ownership (local vs remote) keys on `deviceId`, not host name;
+  `withdrawLocalSessions()` clears only this device's key. Prunes stale entries
+  by `defaultTTL` (12h) on every load, caps the merged view at `maxSessions`
   (64, newest first), and registers a `didChangeExternallyNotification`
   observer so the UI redraws when another device pushes a change. Pure logic
   (`active(from:)`, `upsert(_:into:)`) is static and unit-tested.
 - **Producer** — `SliccstartApp` publishes on `sliccProcess.leaderJoinUrl`
   becoming non-nil (label = `SliccProcess.leaderTargetName`) and withdraws
-  when it clears. `SliccstartAppDelegate.applicationWillTerminate` withdraws
-  local sessions on the clean-quit path but **not** on the update/detach path
-  (the browser survives, so the relaunched Sliccstart republishes after
-  reattach).
+  when it clears. A 4-hour timer re-publishes a still-running leader so it
+  never ages out of the 12h TTL. `SliccstartAppDelegate.applicationWillTerminate`
+  withdraws local sessions on the clean-quit path but **not** on the
+  update/detach path (the browser survives, so the relaunched Sliccstart
+  republishes after reattach).
 - **Consumer** — `AppListView`'s "iCloud Sessions" section lists remote
   sessions (device + age) with three actions: Copy-join-URL,
   Attach-a-browser-as-follower, and Follow-in-Terminal. This device's own
@@ -162,7 +172,7 @@ data model is Foundation-only and platform-agnostic so the iOS follower
 ### iCloud provisioning (Developer ID app)
 
 The code above runs today but **does not sync** until the app is signed with an
-iCloud KVS entitlement backed by an *embedded* provisioning profile. Sliccstart
+iCloud KVS entitlement backed by an _embedded_ provisioning profile. Sliccstart
 is Developer ID-signed and notarized (team `S8LB56P782`), distributed outside
 the App Store, so Developer ID signing alone does not authorize iCloud.
 

--- a/packages/swift-launcher/CLAUDE.md
+++ b/packages/swift-launcher/CLAUDE.md
@@ -93,129 +93,85 @@ Terminal.app and iTerm2 launch through Apple Events. `assemble-app.mjs` supplies
 
 ## iCloud Sync (Tray Sessions)
 
-Cross-device discovery of active tray join URLs, so a leader started on one
-Mac can be joined from another device without hand-copying its join URL. The
-data model is Foundation-only and platform-agnostic so the iOS follower
-(`packages/ios-app`) can reuse it verbatim when it gains sync.
+Cross-device discovery of active tray join URLs so a leader on one Mac can be
+joined from another without hand-copying. The model is Foundation-only so the
+iOS follower (`packages/ios-app`) can reuse it.
 
-- `Models/SyncedTraySession.swift` — one advertised session: `id` (the
-  **SHA-256 of the join URL** — stable for upsert/dedup but opaque, so it is
-  safe in accessibility identifiers / telemetry `source`; the raw `joinUrl`
-  carries the secret and is never surfaced to telemetry), `joinUrl`, `label`,
-  `deviceId` (stable per-device UUID for ownership), `deviceName` (display
-  only), `createdAt`, `lastSeenAt`, plus `isStale(ttl:now:)`. `CryptoKit` +
-  Foundation only; no AppKit/UIKit. Legacy payloads without `deviceId` decode
-  (empty).
+- `Models/SyncedTraySession.swift` — one session: `id` (**SHA-256 of the join
+  URL** — stable for upsert/dedup but opaque, so it is safe in accessibility
+  identifiers / telemetry; the raw `joinUrl` carries the secret and is never
+  surfaced), `joinUrl`, `label`, `deviceId` (per-device UUID for ownership),
+  `deviceName` (display), `createdAt`, `lastSeenAt`, `isStale(ttl:now:)`.
+  `CryptoKit` + Foundation only. Legacy payloads without `deviceId` decode empty.
 - `Models/TraySessionSyncStore.swift` — `@Observable` store over a
-  `KeyValueSyncBackend`. Default backend is `UbiquitousKeyValueBackend`
-  (`NSUbiquitousKeyValueStore`); tests inject `InMemoryKeyValueBackend` so no
-  unit test touches iCloud. **Each device writes its own sessions under a
-  per-device key `storageKeyPrefix + deviceId` and reads the union of all such
-  keys** (`keys(withPrefix:)`), so two devices publishing at once never
-  clobber each other's advertisement and same-host-name Macs stay distinct.
-  Ownership (local vs remote) keys on `deviceId`, not host name;
-  `withdrawLocalSessions()` clears only this device's key. Prunes stale entries
-  by `defaultTTL` (12h) on every load, caps the merged view at `maxSessions`
-  (64, newest first), and registers a `didChangeExternallyNotification`
-  observer so the UI redraws when another device pushes a change. Pure logic
-  (`active(from:)`, `upsert(_:into:)`) is static and unit-tested.
-- **Producer** — `SliccstartApp` publishes on `sliccProcess.leaderJoinUrl`
-  becoming non-nil (label = `SliccProcess.leaderTargetName`) and withdraws
-  when it clears. A 4-hour timer re-publishes a still-running leader so it
-  never ages out of the 12h TTL. `SliccstartAppDelegate.applicationWillTerminate`
-  withdraws local sessions on the clean-quit path but **not** on the
-  update/detach path (the browser survives, so the relaunched Sliccstart
-  republishes after reattach).
-- **Consumer** — `AppListView`'s "iCloud Sessions" section lists remote
-  sessions (device + age) with three actions: Copy-join-URL,
-  Attach-a-browser-as-follower, and Follow-in-Terminal. This device's own
-  sessions are read-only (copy only). Each row's icon overlays the matching
-  local browser's icon (matched by `label`/name) over an `icloud` badge when
-  that browser is installed. Follow reuses the terminal follower flow via
-  `SliccProcess.launchTerminalFollower(_:joinURLOverride:)`, which skips the
-  local-leader readiness gate when an override is supplied so it can attach to
-  a **remote** leader. Attach-browser launches the **top** browser via
-  `SliccProcess.launchBrowserFollower(_:joinUrl:)`.
+  `KeyValueSyncBackend` (default `UbiquitousKeyValueBackend`; tests inject
+  `InMemoryKeyValueBackend`). **Each device writes its own sessions under a
+  per-device key `storageKeyPrefix + deviceId` and reads the union**, so
+  concurrent publishes never clobber and same-host-name Macs stay distinct;
+  ownership keys on `deviceId`, and `withdrawLocalSessions()` clears only this
+  device's key. Prunes stale by `defaultTTL` (12h) on load,
+  caps the merged view at `maxSessions` (64), and observes
+  `didChangeExternallyNotification`. Pure `active(from:)`/`upsert(_:into:)` are
+  static and unit-tested.
+- **Producer** — `SliccstartApp` publishes when `leaderJoinUrl` becomes non-nil
+  (label = `leaderTargetName`) and withdraws when it clears; a 4-hour timer
+  re-publishes a live leader so it never ages out of the TTL.
+  `applicationWillTerminate` withdraws on clean quit but **not** on
+  update/detach (the browser survives; the relaunched app republishes).
+- **Consumer** — `AppListView`'s "iCloud Sessions" section lists remote sessions
+  (device + age) with Copy, Attach-browser, Follow-in-Terminal; own sessions are
+  copy-only. A row's icon overlays the matching local browser icon on an
+  `icloud` badge. Follow reuses `launchTerminalFollower(_:joinURLOverride:)`
+  (override skips the local-leader gate → attaches to a **remote** leader);
+  Attach-browser launches the **top** browser via `launchBrowserFollower`.
+- **Security** — join URLs carry the session secret and sync only through the
+  user's own (encrypted, same-Apple-ID) iCloud KVS. Tests:
+  `TraySessionSyncTests`.
 
 ## App Ordering, Browser Followers, and Startup
 
-- `Models/AppOrdering.swift` — pure ordering for the Browsers and Terminals
-  lists: `browserBundlePriority` (market share, Chrome first) and
-  `terminalBundlePriority` (power-user terminals before Terminal.app) supply
-  the defaults; a user drag-reorder is persisted by `AppOrderStore` (UserDefaults
-  keys `browserOrder`/`terminalOrder`, bundle-id arrays) and wins over the
-  default. `AppTarget.bundleId` is the ordering/matching key (populated by
-  `AppScanner` for known browsers/terminals/electron apps; `nil` for
-  CDP-sniffed electron apps). `AppListView` drag-reorders via the
-  `ReorderableRow` modifier (`.onDrag`/`.onDrop`, live reorder on hover).
-- **Browser as follower** — `SliccProcess.browserFollowerArgs(cdpPort:joinUrl:)`
-  passes `--join=<url>` (vs standalone's `--lead`) so swift-server opens the
-  browser attached to a **remote** tray. `launchBrowserFollower` flags the
-  `LaunchRecord` `isFollower = true`, which excludes it from `isLeaderReady`,
-  `leaderTargetName`, leader-URL clearing, and the smooth-update reattach
-  snapshot (a follower is not this device's leader). Clicking a browser row
-  with remote sessions present opens a confirmation dialog (lead vs attach);
-  with none it launches standalone (unchanged single-Mac flow).
-- **Startup** — `Models/StartupPreference.swift` replaces the per-browser
-  auto-launch picker with the `launchBrowserAtStartup` boolean (Settings >
-  Startup checkbox). `resolveEnabled(defaults:)` migrates the legacy
-  `autoLaunchAppId` (non-empty == enabled) once. On launch the app starts the
-  **top** browser of the ordered Browsers list.
-- Tests: `AppOrderingTests`, `StartupPreferenceTests`,
-  `SliccProcessLaunchArgsTests` (browser-follower args), and
-  `SliccProcessLeaderGatingTests` (follower does not gate as leader).
-- **Security** — join URLs carry the session secret. They sync through the
-  user's own iCloud key-value store (encrypted, same-Apple-ID devices only),
-  which the user has accepted for this feature.
-- Tests: `SliccstartTests/TraySessionSyncTests.swift`.
+- `Models/AppOrdering.swift` — pure default ordering (`browserBundlePriority`
+  market-share, `terminalBundlePriority` power-user-first); a user drag-reorder
+  persists via `AppOrderStore` (UserDefaults `browserOrder`/`terminalOrder`,
+  bundle-id arrays) and wins. `AppTarget.bundleId` (populated by `AppScanner`;
+  `nil` for CDP-sniffed electron apps) is the ordering/matching key.
+  `AppListView` drag-reorders via the `ReorderableRow` modifier
+  (`.onDrag`/`.onDrop`), keyed off the on-screen order so newly installed apps
+  are draggable too.
+- **Browser as follower** — `browserFollowerArgs(cdpPort:joinUrl:)` passes
+  `--join=<url>` (vs `--lead`). `launchBrowserFollower` flags the record
+  `isFollower`, excluding it from `isLeaderReady`, `leaderTargetName`,
+  leader-URL clearing, and reattach. Clicking a browser with remote sessions
+  opens a lead-vs-attach dialog; with none it launches standalone.
+- **Startup** — `Models/StartupPreference.swift`: the `launchBrowserAtStartup`
+  checkbox replaces the per-browser picker; `resolveEnabled(defaults:)` migrates
+  legacy `autoLaunchAppId` once; launch starts the **top** ordered browser.
+- Tests: `AppOrderingTests`, `StartupPreferenceTests`, `SliccProcessLaunchArgsTests`.
 
 ### iCloud provisioning (Developer ID app)
 
-The code above runs today but **does not sync** until the app is signed with an
-iCloud KVS entitlement backed by an _embedded_ provisioning profile. Sliccstart
-is Developer ID-signed and notarized (team `S8LB56P782`), distributed outside
-the App Store, so Developer ID signing alone does not authorize iCloud.
+Sync stays dark until the app is signed with an iCloud KVS entitlement backed
+by an _embedded_ provisioning profile (Developer ID signing alone does not
+authorize iCloud). `sign-and-package.sh` gates this on optional
+**`PROVISION_PROFILE`**: **unset** (default, incl. CI) signs against
+`Sliccstart.entitlements` only and `NSUbiquitousKeyValueStore` degrades to a
+local cache; **set** embeds the profile at `Contents/embedded.provisionprofile`
+and signs against a merged entitlements file (base + `ubiquity-kvstore-identifier`,
+base never mutated).
 
-`sign-and-package.sh` handles this via the optional **`PROVISION_PROFILE`** env
-var (path to the downloaded `.provisionprofile`):
+The KVS bucket (`ubiquity-kvstore-identifier`) defaults to
+`${APPLE_TEAM_ID}.com.slicc.sliccstart`, overridable via **`KVSTORE_IDENTIFIER`**
+(the iOS follower must match it; a brand-neutral `S8LB56P782.ai.sliccy.trays` is
+preferable, but a custom value fails the outer `codesign` unless the embedded
+profile authorizes it). The iCloud **container** is separate (CloudKit-only,
+unused), so any `iCloud.<reverse-dns>` you own works.
 
-- **unset** (default, incl. current CI): signs against `Sliccstart.entitlements`
-  only. No iCloud; `NSUbiquitousKeyValueStore` degrades to a local cache, so
-  builds stay valid.
-- **set**: embeds the profile at `Contents/embedded.provisionprofile` and signs
-  against a merged entitlements file (base + `com.apple.developer.ubiquity-kvstore-identifier`).
-  The base entitlements file is never mutated.
-
-The KVS bucket namespace (`ubiquity-kvstore-identifier`) defaults to
-`${APPLE_TEAM_ID}.com.slicc.sliccstart` and is overridable via the
-**`KVSTORE_IDENTIFIER`** env var. This is the value the code actually keys the
-sync bucket on and the value the future iOS follower must match to share it, so
-a brand-neutral value like `S8LB56P782.ai.sliccy.trays` is preferable — but the
-auto-generated Developer ID profile pins the bundle-id form, so a custom value
-must be verified at sign time (the outer `codesign` fails if the embedded
-profile does not authorize it). The **iCloud container** is separate: it only
-matters for CloudKit (unused here), so it can be any `iCloud.<reverse-dns>` you
-own (e.g. `iCloud.ai.sliccy`) with no code impact.
-
-One-time portal setup:
-
-1. Enable **iCloud** on the `com.slicc.sliccstart` App ID (attach an iCloud
-   container, e.g. `iCloud.ai.sliccy`; key-value storage rides along).
-2. Create a **Developer ID** distribution **provisioning profile** (App
-   variant) for that App ID + the Developer ID Application cert; download it.
-
-Local signed build with sync:
-
-```bash
-APPLE_TEAM_ID=S8LB56P782 APPLE_ID=... APPLE_APP_SPECIFIC_PASSWORD=... \
-  PROVISION_PROFILE=/path/to/Sliccstart_DeveloperID_iCloud.provisionprofile \
-  ./sign-and-package.sh
-```
-
-Then verify sync between two devices on the same Apple ID (both signed into
-iCloud). To enable in CI, add the profile as a base64 secret, decode it to a
-file in the release job, and export `PROVISION_PROFILE` before the script runs.
-Signing contract is covered by `macos-permissions.test.mjs`.
+One-time portal setup: enable iCloud on the `com.slicc.sliccstart` App ID
+(attach a container; KVS rides along), then create a Developer ID **provisioning
+profile** (App variant) for it. Local signed build passes `PROVISION_PROFILE=...`
+to `./sign-and-package.sh` with the usual `APPLE_*` env. For CI, add the profile
+as a base64 secret and decode it before exporting `PROVISION_PROFILE`. Signing
+contract: `macos-permissions.test.mjs`.
 
 ## Debug Build Creation
 

--- a/packages/swift-launcher/CLAUDE.md
+++ b/packages/swift-launcher/CLAUDE.md
@@ -91,6 +91,122 @@ Release Darwin binaries are Developer ID-signed with hardened runtime and notari
 
 Terminal.app and iTerm2 launch through Apple Events. `assemble-app.mjs` supplies the user-facing usage description, and `sign-and-package.sh` signs the outer app with `Sliccstart.entitlements`, including `com.apple.security.automation.apple-events`. A TCC denial is surfaced with a direct path to the Sliccstart controls in System Settings → Privacy & Security → Automation.
 
+## iCloud Sync (Tray Sessions)
+
+Cross-device discovery of active tray join URLs, so a leader started on one
+Mac can be joined from another device without hand-copying its join URL. The
+data model is Foundation-only and platform-agnostic so the iOS follower
+(`packages/ios-app`) can reuse it verbatim when it gains sync.
+
+- `Models/SyncedTraySession.swift` — one advertised session: `id` (derived
+  from the join URL so republish upserts and two devices observing the same
+  tray collapse to one entry), `joinUrl`, `label`, `deviceName`, `createdAt`,
+  `lastSeenAt`, plus `isStale(ttl:now:)`. No AppKit/UIKit import.
+- `Models/TraySessionSyncStore.swift` — `@Observable` store over a
+  `KeyValueSyncBackend`. Default backend is `UbiquitousKeyValueBackend`
+  (`NSUbiquitousKeyValueStore`); tests inject `InMemoryKeyValueBackend` so no
+  unit test touches iCloud. Publishes/withdraws this device's session, prunes
+  stale entries by `defaultTTL` (12h) on every load, caps at `maxSessions`
+  (64, newest first), and registers a `didChangeExternallyNotification`
+  observer so the UI redraws when another device pushes a change. Pure logic
+  (`active(from:)`, `upsert(_:into:)`) is static and unit-tested.
+- **Producer** — `SliccstartApp` publishes on `sliccProcess.leaderJoinUrl`
+  becoming non-nil (label = `SliccProcess.leaderTargetName`) and withdraws
+  when it clears. `SliccstartAppDelegate.applicationWillTerminate` withdraws
+  local sessions on the clean-quit path but **not** on the update/detach path
+  (the browser survives, so the relaunched Sliccstart republishes after
+  reattach).
+- **Consumer** — `AppListView`'s "iCloud Sessions" section lists remote
+  sessions (device + age) with three actions: Copy-join-URL,
+  Attach-a-browser-as-follower, and Follow-in-Terminal. This device's own
+  sessions are read-only (copy only). Each row's icon overlays the matching
+  local browser's icon (matched by `label`/name) over an `icloud` badge when
+  that browser is installed. Follow reuses the terminal follower flow via
+  `SliccProcess.launchTerminalFollower(_:joinURLOverride:)`, which skips the
+  local-leader readiness gate when an override is supplied so it can attach to
+  a **remote** leader. Attach-browser launches the **top** browser via
+  `SliccProcess.launchBrowserFollower(_:joinUrl:)`.
+
+## App Ordering, Browser Followers, and Startup
+
+- `Models/AppOrdering.swift` — pure ordering for the Browsers and Terminals
+  lists: `browserBundlePriority` (market share, Chrome first) and
+  `terminalBundlePriority` (power-user terminals before Terminal.app) supply
+  the defaults; a user drag-reorder is persisted by `AppOrderStore` (UserDefaults
+  keys `browserOrder`/`terminalOrder`, bundle-id arrays) and wins over the
+  default. `AppTarget.bundleId` is the ordering/matching key (populated by
+  `AppScanner` for known browsers/terminals/electron apps; `nil` for
+  CDP-sniffed electron apps). `AppListView` drag-reorders via the
+  `ReorderableRow` modifier (`.onDrag`/`.onDrop`, live reorder on hover).
+- **Browser as follower** — `SliccProcess.browserFollowerArgs(cdpPort:joinUrl:)`
+  passes `--join=<url>` (vs standalone's `--lead`) so swift-server opens the
+  browser attached to a **remote** tray. `launchBrowserFollower` flags the
+  `LaunchRecord` `isFollower = true`, which excludes it from `isLeaderReady`,
+  `leaderTargetName`, leader-URL clearing, and the smooth-update reattach
+  snapshot (a follower is not this device's leader). Clicking a browser row
+  with remote sessions present opens a confirmation dialog (lead vs attach);
+  with none it launches standalone (unchanged single-Mac flow).
+- **Startup** — `Models/StartupPreference.swift` replaces the per-browser
+  auto-launch picker with the `launchBrowserAtStartup` boolean (Settings >
+  Startup checkbox). `resolveEnabled(defaults:)` migrates the legacy
+  `autoLaunchAppId` (non-empty == enabled) once. On launch the app starts the
+  **top** browser of the ordered Browsers list.
+- Tests: `AppOrderingTests`, `StartupPreferenceTests`,
+  `SliccProcessLaunchArgsTests` (browser-follower args), and
+  `SliccProcessLeaderGatingTests` (follower does not gate as leader).
+- **Security** — join URLs carry the session secret. They sync through the
+  user's own iCloud key-value store (encrypted, same-Apple-ID devices only),
+  which the user has accepted for this feature.
+- Tests: `SliccstartTests/TraySessionSyncTests.swift`.
+
+### iCloud provisioning (Developer ID app)
+
+The code above runs today but **does not sync** until the app is signed with an
+iCloud KVS entitlement backed by an *embedded* provisioning profile. Sliccstart
+is Developer ID-signed and notarized (team `S8LB56P782`), distributed outside
+the App Store, so Developer ID signing alone does not authorize iCloud.
+
+`sign-and-package.sh` handles this via the optional **`PROVISION_PROFILE`** env
+var (path to the downloaded `.provisionprofile`):
+
+- **unset** (default, incl. current CI): signs against `Sliccstart.entitlements`
+  only. No iCloud; `NSUbiquitousKeyValueStore` degrades to a local cache, so
+  builds stay valid.
+- **set**: embeds the profile at `Contents/embedded.provisionprofile` and signs
+  against a merged entitlements file (base + `com.apple.developer.ubiquity-kvstore-identifier`).
+  The base entitlements file is never mutated.
+
+The KVS bucket namespace (`ubiquity-kvstore-identifier`) defaults to
+`${APPLE_TEAM_ID}.com.slicc.sliccstart` and is overridable via the
+**`KVSTORE_IDENTIFIER`** env var. This is the value the code actually keys the
+sync bucket on and the value the future iOS follower must match to share it, so
+a brand-neutral value like `S8LB56P782.ai.sliccy.trays` is preferable — but the
+auto-generated Developer ID profile pins the bundle-id form, so a custom value
+must be verified at sign time (the outer `codesign` fails if the embedded
+profile does not authorize it). The **iCloud container** is separate: it only
+matters for CloudKit (unused here), so it can be any `iCloud.<reverse-dns>` you
+own (e.g. `iCloud.ai.sliccy`) with no code impact.
+
+One-time portal setup:
+
+1. Enable **iCloud** on the `com.slicc.sliccstart` App ID (attach an iCloud
+   container, e.g. `iCloud.ai.sliccy`; key-value storage rides along).
+2. Create a **Developer ID** distribution **provisioning profile** (App
+   variant) for that App ID + the Developer ID Application cert; download it.
+
+Local signed build with sync:
+
+```bash
+APPLE_TEAM_ID=S8LB56P782 APPLE_ID=... APPLE_APP_SPECIFIC_PASSWORD=... \
+  PROVISION_PROFILE=/path/to/Sliccstart_DeveloperID_iCloud.provisionprofile \
+  ./sign-and-package.sh
+```
+
+Then verify sync between two devices on the same Apple ID (both signed into
+iCloud). To enable in CI, add the profile as a base64 secret, decode it to a
+file in the release job, and export `PROVISION_PROFILE` before the script runs.
+Signing contract is covered by `macos-permissions.test.mjs`.
+
 ## Debug Build Creation
 
 `Models/DebugBuildCreator.swift` creates Electron debug builds by:

--- a/packages/swift-launcher/Sliccstart/Models/AppOrdering.swift
+++ b/packages/swift-launcher/Sliccstart/Models/AppOrdering.swift
@@ -81,6 +81,34 @@ enum AppOrdering {
     static func persistableOrder(from reordered: [AppTarget]) -> [String] {
         reordered.compactMap { $0.bundleId }
     }
+
+    /// Move `moving` to the current position of `over` within `ids`. Returns
+    /// `ids` unchanged when the two match or either id is absent — the pure
+    /// core of the drag-reorder drop delegate, so it is unit-testable without
+    /// SwiftUI drag events.
+    static func reorder(_ ids: [String], moving: String, over: String) -> [String] {
+        guard moving != over,
+            let from = ids.firstIndex(of: moving),
+            let to = ids.firstIndex(of: over)
+        else { return ids }
+        var next = ids
+        next.insert(next.remove(at: from), at: to)
+        return next
+    }
+}
+
+/// Whether clicking a browser row should launch it standalone or offer the
+/// lead-vs-attach dialog. Split out so the choice is unit-testable without the
+/// view. A running browser (re-focus/restart) or the absence of any remote
+/// iCloud session both go straight to standalone — the dialog only helps when
+/// there is a remote tray to attach to.
+enum BrowserLaunchAction: Equatable {
+    case standalone
+    case chooseLeadOrAttach
+
+    static func resolve(isRunning: Bool, hasRemoteSessions: Bool) -> BrowserLaunchAction {
+        (isRunning || !hasRemoteSessions) ? .standalone : .chooseLeadOrAttach
+    }
 }
 
 /// UserDefaults-backed persistence for custom Browsers/Terminals ordering.

--- a/packages/swift-launcher/Sliccstart/Models/AppOrdering.swift
+++ b/packages/swift-launcher/Sliccstart/Models/AppOrdering.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Default ordering for the Browsers and Terminals lists, plus a persisted
+/// user-defined override (drag-to-reorder). Pure logic so it is unit-testable
+/// without UserDefaults or SwiftUI.
+enum AppOrdering {
+    /// Browsers, most common first (market share). The top entry is the
+    /// default leader and the browser attached to a session by the
+    /// session-row shortcut.
+    static let browserBundlePriority: [String] = [
+        "com.google.Chrome",
+        "com.microsoft.edgemac",
+        "com.brave.Browser",
+        "com.operasoftware.Opera",
+        "com.vivaldi.Vivaldi",
+        "company.thebrowser.Browser",  // Arc
+        "com.openai.atlas",  // ChatGPT Atlas
+        "company.thebrowser.dia",  // Dia
+        "com.google.Chrome.beta",
+        "com.google.Chrome.dev",
+        "com.google.Chrome.canary",
+        "com.brave.Browser.beta",
+        "com.brave.Browser.nightly",
+        "com.microsoft.edgemac.Beta",
+        "com.microsoft.edgemac.Dev",
+        "com.microsoft.edgemac.Canary",
+        "com.vivaldi.Vivaldi.snapshot",
+        "com.google.chrome.for.testing",
+        "org.chromium.Chromium",
+    ]
+
+    /// Terminals, least common first: a deliberately installed power-user
+    /// terminal (Alacritty, kitty, …) outranks the ubiquitous Terminal.app,
+    /// so the default top pick is the one the user most likely prefers.
+    static let terminalBundlePriority: [String] = [
+        "org.alacritty",
+        "net.kovidgoyal.kitty",
+        "com.github.wez.wezterm",
+        "com.mitchellh.ghostty",
+        "com.googlecode.iterm2",
+        "com.apple.Terminal",
+    ]
+
+    /// Order `targets` by: the user's saved order first (in that order),
+    /// then any remaining known apps by `defaultPriority`, then unknown apps
+    /// alphabetically. Stable for equal ranks.
+    static func ordered(
+        _ targets: [AppTarget],
+        savedOrder: [String],
+        defaultPriority: [String]
+    ) -> [AppTarget] {
+        func rank(_ target: AppTarget) -> Int {
+            guard let bundleId = target.bundleId else {
+                return savedOrder.count + defaultPriority.count
+            }
+            if let saved = savedOrder.firstIndex(of: bundleId) {
+                return saved
+            }
+            if let def = defaultPriority.firstIndex(of: bundleId) {
+                return savedOrder.count + def
+            }
+            return savedOrder.count + defaultPriority.count
+        }
+        return
+            targets
+            .enumerated()
+            .sorted { lhs, rhs in
+                let a = rank(lhs.element)
+                let b = rank(rhs.element)
+                if a != b { return a < b }
+                let byName = lhs.element.name.localizedCaseInsensitiveCompare(rhs.element.name)
+                if byName != .orderedSame { return byName == .orderedAscending }
+                return lhs.offset < rhs.offset
+            }
+            .map { $0.element }
+    }
+
+    /// The bundle-id order to persist after a drag reorder produced
+    /// `reordered`. Targets without a bundle id are skipped (they can't be
+    /// keyed), so their relative position is governed by default priority.
+    static func persistableOrder(from reordered: [AppTarget]) -> [String] {
+        reordered.compactMap { $0.bundleId }
+    }
+}
+
+/// UserDefaults-backed persistence for custom Browsers/Terminals ordering.
+struct AppOrderStore {
+    static let browserKey = "browserOrder"
+    static let terminalKey = "terminalOrder"
+
+    let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func load(_ key: String) -> [String] {
+        defaults.stringArray(forKey: key) ?? []
+    }
+
+    func save(_ bundleIds: [String], forKey key: String) {
+        defaults.set(bundleIds, forKey: key)
+    }
+}

--- a/packages/swift-launcher/Sliccstart/Models/AppScanner.swift
+++ b/packages/swift-launcher/Sliccstart/Models/AppScanner.swift
@@ -51,7 +51,8 @@ final class AppScanner {
                     type: .chromiumBrowser, icon: icon,
                     debugSupport: .supported,
                     isDebugBuild: false,
-                    originalAppPath: nil
+                    originalAppPath: nil,
+                    bundleId: bundleId
                 ))
         }
 
@@ -75,7 +76,8 @@ final class AppScanner {
                     type: .terminal, icon: icon,
                     debugSupport: .unknown,
                     isDebugBuild: false,
-                    originalAppPath: nil
+                    originalAppPath: nil,
+                    bundleId: bundleId
                 ))
         }
 
@@ -101,7 +103,8 @@ final class AppScanner {
                         type: .electronApp, icon: icon,
                         debugSupport: .unknown,
                         isDebugBuild: false,
-                        originalAppPath: nil
+                        originalAppPath: nil,
+                        bundleId: bundleId
                     ))
             }
             targets.append(contentsOf: debugBuilds.values)

--- a/packages/swift-launcher/Sliccstart/Models/AppTarget.swift
+++ b/packages/swift-launcher/Sliccstart/Models/AppTarget.swift
@@ -23,6 +23,12 @@ struct AppTarget: Identifiable {
     let debugSupport: ElectronDebugSupport
     let isDebugBuild: Bool  // True if this is a patched debug build
     let originalAppPath: String?  // For debug builds, path to original app
+    /// Bundle identifier for known browsers/terminals/electron apps. Used
+    /// for default-priority ordering and for matching an iCloud session's
+    /// browser against a locally installed one. `nil` for scanned Electron
+    /// apps discovered purely by CDP framework presence.
+    // swiftlint:disable:next redundant_optional_initialization
+    var bundleId: String? = nil  // explicit default keeps the memberwise init optional
 
     static let knownChromiumBrowsers: [(bundleId: String, name: String)] = [
         ("com.google.Chrome", "Google Chrome"),

--- a/packages/swift-launcher/Sliccstart/Models/SliccBootstrapper.swift
+++ b/packages/swift-launcher/Sliccstart/Models/SliccBootstrapper.swift
@@ -185,7 +185,7 @@ final class SliccBootstrapper {
 
     /// Ensure PATH includes common tool locations (Homebrew, nvm, etc.)
     /// Finder-launched apps get a minimal PATH that may miss these.
-    private static var enrichedEnvironment: [String: String] {
+    static var enrichedEnvironment: [String: String] {
         var env = ProcessInfo.processInfo.environment
         let extraPaths = [
             "/opt/homebrew/bin",

--- a/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
+++ b/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
@@ -103,6 +103,11 @@ final class SliccProcess {
         /// still-booting browser (slow Keychain prompt, cold start) whose
         /// CDP port has not come up yet is never prematurely reaped.
         var observedCdpListening: Bool = false
+        /// True for a chromium browser launched with `--join` to attach to a
+        /// *remote* tray as a follower. Such a record is not a local leader,
+        /// so it is excluded from `isLeaderReady`, leader-URL clearing, and
+        /// the smooth-update reattach snapshot.
+        var isFollower: Bool = false
     }
 
     /// SLICC helper/server processes keyed by AppTarget.id.
@@ -230,7 +235,13 @@ final class SliccProcess {
     /// and a stale join URL (no live browser) would route to a dead leader.
     func isLeaderReady() -> Bool {
         guard let url = leaderJoinUrl, !url.isEmpty else { return false }
-        return launchRecords.values.contains { $0.targetType == .chromiumBrowser }
+        return launchRecords.values.contains { $0.targetType == .chromiumBrowser && !$0.isFollower }
+    }
+
+    /// Display name of the running chromium leader, if any. Used to label
+    /// this device's session when it is advertised for cross-device sync.
+    var leaderTargetName: String? {
+        launchRecords.values.first { $0.targetType == .chromiumBrowser && !$0.isFollower }?.targetName
     }
 
     func refreshRuntimeStates(for targets: [AppTarget]) {
@@ -279,6 +290,46 @@ final class SliccProcess {
         // Desktop App rows disabled rather than wiring followers to a
         // dead URL.
         startLeaderProbe(servePort: Self.browserPort)
+    }
+
+    // MARK: - Browser follower mode (attach a browser to a remote tray)
+
+    /// Launch a chromium browser as a *follower* attached to a remote tray
+    /// discovered via iCloud sync. Uses `--join=<url>` and its own port pair
+    /// so it can coexist with a local leader; the record is flagged
+    /// `isFollower` so it never counts as this device's leader.
+    func launchBrowserFollower(_ browser: AppTarget, joinUrl: String) throws {
+        guard browser.type == .chromiumBrowser else { throw LaunchError.invalidTerminalTarget }
+        guard !joinUrl.isEmpty else { throw LaunchError.leaderUnavailable }
+        refreshRuntimeState(for: browser)
+        if isRunning(browser) {
+            log.info("launchBrowserFollower: \(browser.name) already running")
+            return
+        }
+        startFailures.removeValue(forKey: browser.id)
+        let (port, cdpPort) = nextElectronPorts()
+        guard !Self.isPortInUse(port) else { throw LaunchError.portInUse(port) }
+        log.info("launchBrowserFollower: \(browser.name, privacy: .public) on port \(port), cdp \(cdpPort) (join)")
+        do {
+            try spawn(
+                target: browser,
+                extraArgs: Self.browserFollowerArgs(cdpPort: cdpPort, joinUrl: joinUrl),
+                env: Self.standaloneBrowserEnv(
+                    executablePath: browser.executablePath,
+                    servePort: port,
+                    inheritedEnv: ProcessInfo.processInfo.environment
+                ),
+                cdpPort: cdpPort,
+                servePort: port,
+                electronAppPath: nil,
+                joinUrl: joinUrl,
+                bridgeToken: Self.standaloneBridgeToken,
+                isFollower: true
+            )
+        } catch {
+            recordStartFailure(for: browser, message: error.localizedDescription)
+            throw error
+        }
     }
 
     // MARK: - Electron mode (each app gets its own port)
@@ -334,12 +385,22 @@ final class SliccProcess {
         terminalFollowerLaunchService.isCliAvailable()
     }
 
+    /// Attach a terminal follower to a leader. With no `joinURLOverride`
+    /// the local leader's `leaderJoinUrl` is used (the existing single-Mac
+    /// flow). A non-empty override attaches to a *remote* leader discovered
+    /// via iCloud sync, so the local-leader readiness gate is skipped.
     @MainActor
-    func launchTerminalFollower(_ target: AppTarget) async throws {
+    func launchTerminalFollower(_ target: AppTarget, joinURLOverride: String? = nil) async throws {
         guard target.type == .terminal else { throw LaunchError.invalidTerminalTarget }
         guard !isLaunchingTerminalFollower else { return }
-        guard isLeaderReady(), let joinURL = leaderJoinUrl, !joinURL.isEmpty else {
-            throw LaunchError.leaderUnavailable
+        let joinURL: String
+        if let joinURLOverride, !joinURLOverride.isEmpty {
+            joinURL = joinURLOverride
+        } else {
+            guard isLeaderReady(), let local = leaderJoinUrl, !local.isEmpty else {
+                throw LaunchError.leaderUnavailable
+            }
+            joinURL = local
         }
 
         startFailures.removeValue(forKey: target.id)
@@ -377,6 +438,13 @@ final class SliccProcess {
     /// scheme/host shape on the CLI.
     static func standaloneBrowserArgs(cdpPort: UInt16) -> [String] {
         ["--cdp-port=\(cdpPort)", "--lead"]
+    }
+
+    /// Browser-follower extra args: `--join=<url>` instead of `--lead`, so
+    /// swift-server hands the join URL to the webapp and the browser attaches
+    /// to a remote tray as a follower rather than minting its own.
+    static func browserFollowerArgs(cdpPort: UInt16, joinUrl: String) -> [String] {
+        ["--cdp-port=\(cdpPort)", "--join=\(joinUrl)"]
     }
 
     /// Environment for the browser launch. Preserves user-supplied
@@ -609,7 +677,7 @@ final class SliccProcess {
     /// keeping the Desktop App rows accurately gated when the user closes
     /// the leader. Safe to call after any path that removes a record.
     private func clearLeaderIfNoBrowserRunning() {
-        let hasBrowser = launchRecords.values.contains { $0.targetType == .chromiumBrowser }
+        let hasBrowser = launchRecords.values.contains { $0.targetType == .chromiumBrowser && !$0.isFollower }
         if !hasBrowser {
             leaderJoinUrl = nil
         }
@@ -637,7 +705,8 @@ final class SliccProcess {
         joinUrl: String? = nil,
         bridgeToken: String? = nil,
         startedAt: Date = Date(),
-        observedCdpListening: Bool = false
+        observedCdpListening: Bool = false,
+        isFollower: Bool = false
     ) {
         launchRecords[id] = LaunchRecord(
             process: process,
@@ -651,7 +720,8 @@ final class SliccProcess {
             observedAppPID: nil,
             joinUrl: joinUrl,
             bridgeToken: bridgeToken,
-            observedCdpListening: observedCdpListening
+            observedCdpListening: observedCdpListening,
+            isFollower: isFollower
         )
     }
 
@@ -668,6 +738,10 @@ final class SliccProcess {
         hasDetached = true
         let snapshot = launchRecords.compactMap { id, record -> PersistedLaunchRecord? in
             guard record.process.isRunning else { return nil }
+            // Follower browsers survive the detach signal but are not
+            // reattached: `reattachArgs` re-leads a chromiumBrowser, which
+            // would wrongly re-spawn a follower as its own leader.
+            guard !record.isFollower else { return nil }
             return PersistedLaunchRecord(
                 targetId: id,
                 targetName: record.targetName,
@@ -849,7 +923,8 @@ final class SliccProcess {
         servePort: UInt16,
         electronAppPath: String?,
         joinUrl: String? = nil,
-        bridgeToken: String? = nil
+        bridgeToken: String? = nil,
+        isFollower: Bool = false
     ) throws {
         let launchConfig = try Self.resolveLaunchConfiguration(sliccDir: sliccDir, extraArgs: extraArgs)
         let loggedArguments = Self.redactedSpawnArguments(launchConfig.arguments).joined(separator: " ")
@@ -919,7 +994,8 @@ final class SliccProcess {
             startedAt: Date(),
             observedAppPID: nil,
             joinUrl: joinUrl,
-            bridgeToken: bridgeToken
+            bridgeToken: bridgeToken,
+            isFollower: isFollower
         )
     }
 

--- a/packages/swift-launcher/Sliccstart/Models/StartupPreference.swift
+++ b/packages/swift-launcher/Sliccstart/Models/StartupPreference.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Whether Sliccstart auto-launches a browser leader at startup. Replaces the
+/// legacy per-browser `autoLaunchAppId` picker: the browser to launch is now
+/// the top of the (reorderable) Browsers list, so this is a single boolean.
+enum StartupPreference {
+    static let enabledKey = "launchBrowserAtStartup"
+
+    /// Resolve the boolean, migrating the legacy `autoLaunchAppId` (a
+    /// non-empty bundle path meant "auto-launch this browser") into the new
+    /// key the first time, then persisting so the Settings checkbox reflects
+    /// it. Idempotent: once the boolean exists it wins.
+    @discardableResult
+    static func resolveEnabled(defaults: UserDefaults) -> Bool {
+        if defaults.object(forKey: enabledKey) != nil {
+            return defaults.bool(forKey: enabledKey)
+        }
+        let legacy = defaults.string(forKey: autoLaunchAppIdKey) ?? ""
+        let enabled = !legacy.isEmpty
+        defaults.set(enabled, forKey: enabledKey)
+        return enabled
+    }
+}

--- a/packages/swift-launcher/Sliccstart/Models/SyncedTraySession.swift
+++ b/packages/swift-launcher/Sliccstart/Models/SyncedTraySession.swift
@@ -1,21 +1,32 @@
+import CryptoKit
 import Foundation
 
 /// One tray session advertised for cross-device discovery.
 ///
 /// Foundation-only and platform-agnostic on purpose: the iOS follower
 /// (`packages/ios-app`) is expected to reuse this type verbatim once it
-/// gains iCloud sync, so nothing here may import AppKit/UIKit.
+/// gains iCloud sync, so nothing here may import AppKit/UIKit. (CryptoKit is
+/// available on both macOS and iOS.)
 struct SyncedTraySession: Codable, Equatable, Identifiable {
-    /// Stable identifier. Derived from the join URL so a republish (fresh
-    /// `lastSeenAt`) upserts in place, and two devices that observe the
-    /// same tray collapse to a single entry rather than duplicating.
+    /// Stable, opaque identifier: the SHA-256 of the join URL. Derived from
+    /// the join URL so a republish (fresh `lastSeenAt`) upserts in place and
+    /// two devices observing the same tray collapse to one entry — but it is
+    /// a one-way hash, so it can be used in accessibility identifiers /
+    /// telemetry `source` strings without leaking the session secret the raw
+    /// join URL carries.
     let id: String
     /// Full leader join URL (carries the session secret). Threaded into a
-    /// follower via `--join=<url>`.
+    /// follower via `--join=<url>`. Never surfaced to telemetry.
     var joinUrl: String
     /// Human-facing label, e.g. "Chrome on Lars's MacBook".
     var label: String
-    /// Name of the device that published the session.
+    /// Stable per-device identity (a persisted UUID) of the publisher. Used
+    /// for ownership (local vs remote) so two Macs sharing a host name do not
+    /// collide. Empty only for legacy payloads decoded before this field
+    /// existed.
+    var deviceId: String
+    /// Human-facing name of the device that published the session (display
+    /// only — ownership keys on `deviceId`).
     var deviceName: String
     var createdAt: Date
     var lastSeenAt: Date
@@ -23,6 +34,7 @@ struct SyncedTraySession: Codable, Equatable, Identifiable {
     init(
         joinUrl: String,
         label: String,
+        deviceId: String,
         deviceName: String,
         createdAt: Date,
         lastSeenAt: Date
@@ -30,16 +42,34 @@ struct SyncedTraySession: Codable, Equatable, Identifiable {
         self.id = SyncedTraySession.identifier(forJoinUrl: joinUrl)
         self.joinUrl = joinUrl
         self.label = label
+        self.deviceId = deviceId
         self.deviceName = deviceName
         self.createdAt = createdAt
         self.lastSeenAt = lastSeenAt
     }
 
-    /// The join URL is globally unique per tray session, so it doubles as
-    /// the identity key. Kept behind a function so the derivation can
-    /// change (e.g. to a hash) without touching call sites.
+    private enum CodingKeys: String, CodingKey {
+        case id, joinUrl, label, deviceId, deviceName, createdAt, lastSeenAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        joinUrl = try container.decode(String.self, forKey: .joinUrl)
+        label = try container.decode(String.self, forKey: .label)
+        // Tolerate payloads published before `deviceId` existed.
+        deviceId = try container.decodeIfPresent(String.self, forKey: .deviceId) ?? ""
+        deviceName = try container.decode(String.self, forKey: .deviceName)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        lastSeenAt = try container.decode(Date.self, forKey: .lastSeenAt)
+    }
+
+    /// SHA-256 hex of the join URL. Kept behind a function so the derivation
+    /// stays in one place and every call site agrees on the identity key.
     static func identifier(forJoinUrl joinUrl: String) -> String {
-        joinUrl
+        SHA256.hash(data: Data(joinUrl.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 
     func isStale(ttl: TimeInterval, now: Date) -> Bool {

--- a/packages/swift-launcher/Sliccstart/Models/SyncedTraySession.swift
+++ b/packages/swift-launcher/Sliccstart/Models/SyncedTraySession.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// One tray session advertised for cross-device discovery.
+///
+/// Foundation-only and platform-agnostic on purpose: the iOS follower
+/// (`packages/ios-app`) is expected to reuse this type verbatim once it
+/// gains iCloud sync, so nothing here may import AppKit/UIKit.
+struct SyncedTraySession: Codable, Equatable, Identifiable {
+    /// Stable identifier. Derived from the join URL so a republish (fresh
+    /// `lastSeenAt`) upserts in place, and two devices that observe the
+    /// same tray collapse to a single entry rather than duplicating.
+    let id: String
+    /// Full leader join URL (carries the session secret). Threaded into a
+    /// follower via `--join=<url>`.
+    var joinUrl: String
+    /// Human-facing label, e.g. "Chrome on Lars's MacBook".
+    var label: String
+    /// Name of the device that published the session.
+    var deviceName: String
+    var createdAt: Date
+    var lastSeenAt: Date
+
+    init(
+        joinUrl: String,
+        label: String,
+        deviceName: String,
+        createdAt: Date,
+        lastSeenAt: Date
+    ) {
+        self.id = SyncedTraySession.identifier(forJoinUrl: joinUrl)
+        self.joinUrl = joinUrl
+        self.label = label
+        self.deviceName = deviceName
+        self.createdAt = createdAt
+        self.lastSeenAt = lastSeenAt
+    }
+
+    /// The join URL is globally unique per tray session, so it doubles as
+    /// the identity key. Kept behind a function so the derivation can
+    /// change (e.g. to a hash) without touching call sites.
+    static func identifier(forJoinUrl joinUrl: String) -> String {
+        joinUrl
+    }
+
+    func isStale(ttl: TimeInterval, now: Date) -> Bool {
+        now.timeIntervalSince(lastSeenAt) > ttl
+    }
+}

--- a/packages/swift-launcher/Sliccstart/Models/TraySessionSyncStore.swift
+++ b/packages/swift-launcher/Sliccstart/Models/TraySessionSyncStore.swift
@@ -10,6 +10,9 @@ private let log = Logger(subsystem: "com.slicc.sliccstart", category: "TraySessi
 protocol KeyValueSyncBackend: AnyObject {
     func data(forKey key: String) -> Data?
     func setData(_ data: Data?, forKey key: String)
+    /// Every currently-stored key beginning with `prefix`. Used to merge each
+    /// device's own per-device session key into the combined view.
+    func keys(withPrefix prefix: String) -> [String]
     @discardableResult func synchronize() -> Bool
     /// When non-nil, the store registers a NotificationCenter observer for
     /// `name`/`object` and reloads when the backend reports an external
@@ -41,6 +44,10 @@ final class UbiquitousKeyValueBackend: KeyValueSyncBackend {
         }
     }
 
+    func keys(withPrefix prefix: String) -> [String] {
+        store.dictionaryRepresentation.keys.filter { $0.hasPrefix(prefix) }
+    }
+
     @discardableResult
     func synchronize() -> Bool {
         store.synchronize()
@@ -57,6 +64,9 @@ final class InMemoryKeyValueBackend: KeyValueSyncBackend {
 
     func data(forKey key: String) -> Data? { storage[key] }
     func setData(_ data: Data?, forKey key: String) { storage[key] = data }
+    func keys(withPrefix prefix: String) -> [String] {
+        storage.keys.filter { $0.hasPrefix(prefix) }
+    }
     @discardableResult func synchronize() -> Bool { true }
     var externalChange: (name: Notification.Name, object: AnyObject?)? { nil }
 }
@@ -72,7 +82,13 @@ final class InMemoryKeyValueBackend: KeyValueSyncBackend {
 /// backend.
 @Observable
 final class TraySessionSyncStore {
-    static let storageKey = "activeTraySessions.v1"
+    /// Each device writes its own sessions under `storageKeyPrefix + deviceId`
+    /// and reads the union of every such key. Per-device keys mean two devices
+    /// publishing at once never overwrite each other's advertisement (each
+    /// only ever writes its own key), which a single shared array could not
+    /// guarantee.
+    static let storageKeyPrefix = "traySessions.v2."
+    static let deviceIdDefaultsKey = "traySyncDeviceId"
     static let defaultTTL: TimeInterval = 12 * 60 * 60
     static let maxSessions = 64
 
@@ -82,16 +98,21 @@ final class TraySessionSyncStore {
     @ObservationIgnored private let backend: KeyValueSyncBackend
     @ObservationIgnored private let ttl: TimeInterval
     @ObservationIgnored private let clock: () -> Date
+    @ObservationIgnored let deviceId: String
     @ObservationIgnored let deviceName: String
     @ObservationIgnored private var observer: NSObjectProtocol?
 
+    private var ownKey: String { Self.storageKeyPrefix + deviceId }
+
     init(
         backend: KeyValueSyncBackend = UbiquitousKeyValueBackend(),
+        deviceId: String = TraySessionSyncStore.currentDeviceId(),
         deviceName: String = TraySessionSyncStore.currentDeviceName(),
         ttl: TimeInterval = TraySessionSyncStore.defaultTTL,
         clock: @escaping () -> Date = Date.init
     ) {
         self.backend = backend
+        self.deviceId = deviceId
         self.deviceName = deviceName
         self.ttl = ttl
         self.clock = clock
@@ -110,48 +131,54 @@ final class TraySessionSyncStore {
 
     /// Sessions published by other devices — the ones worth acting on here.
     var remoteSessions: [SyncedTraySession] {
-        sessions.filter { $0.deviceName != deviceName }
+        sessions.filter { $0.deviceId != deviceId }
     }
 
     /// Sessions this device published (shown read-only so the user can see
     /// their own leader is being advertised).
     var localSessions: [SyncedTraySession] {
-        sessions.filter { $0.deviceName == deviceName }
+        sessions.filter { $0.deviceId == deviceId }
     }
 
     func reload() {
-        sessions = TraySessionSyncStore.active(from: decodeRaw(), ttl: ttl, now: clock())
+        sessions = TraySessionSyncStore.active(from: decodeAll(), ttl: ttl, now: clock())
     }
 
     // MARK: - Write
 
-    /// Advertise (or refresh) a session originating from this device.
+    /// Advertise (or refresh) a session originating from this device. Only
+    /// ever writes this device's own key, so a concurrent publish on another
+    /// device cannot clobber it.
     func publish(joinUrl: String, label: String) {
         guard !joinUrl.isEmpty else { return }
         let now = clock()
-        var raw = decodeRaw()
-        let existing = raw.first { $0.id == SyncedTraySession.identifier(forJoinUrl: joinUrl) }
+        var own = decodeOwn()
+        let existing = own.first { $0.id == SyncedTraySession.identifier(forJoinUrl: joinUrl) }
         let session = SyncedTraySession(
             joinUrl: joinUrl,
             label: label,
+            deviceId: deviceId,
             deviceName: deviceName,
             createdAt: existing?.createdAt ?? now,
             lastSeenAt: now
         )
-        raw = TraySessionSyncStore.upsert(session, into: raw)
-        persist(TraySessionSyncStore.active(from: raw, ttl: ttl, now: now))
+        own = TraySessionSyncStore.upsert(session, into: own)
+        persistOwn(TraySessionSyncStore.active(from: own, ttl: ttl, now: now))
     }
 
-    /// Remove a single session by its join URL.
+    /// Remove a single session by its join URL (from this device's own key).
     func withdraw(joinUrl: String) {
         let id = SyncedTraySession.identifier(forJoinUrl: joinUrl)
-        persist(TraySessionSyncStore.active(from: decodeRaw().filter { $0.id != id }, ttl: ttl, now: clock()))
+        persistOwn(TraySessionSyncStore.active(from: decodeOwn().filter { $0.id != id }, ttl: ttl, now: clock()))
     }
 
-    /// Remove every session this device published. Called on a clean quit
-    /// so a dead leader stops being advertised to other devices.
+    /// Remove every session this device published by clearing its own key.
+    /// Called on a clean quit so a dead leader stops being advertised. Never
+    /// touches another device's key, even if two devices share a host name.
     func withdrawLocalSessions() {
-        persist(TraySessionSyncStore.active(from: decodeRaw().filter { $0.deviceName != deviceName }, ttl: ttl, now: clock()))
+        backend.setData(nil, forKey: ownKey)
+        _ = backend.synchronize()
+        reload()
     }
 
     // MARK: - Pure helpers (unit-testable without a backend)
@@ -175,27 +202,49 @@ final class TraySessionSyncStore {
         return name.isEmpty ? "This device" : name
     }
 
+    /// A stable per-device UUID persisted in `UserDefaults`, minted once.
+    /// Used as the ownership key so two devices with the same host name stay
+    /// distinct.
+    static func currentDeviceId(defaults: UserDefaults = .standard) -> String {
+        if let existing = defaults.string(forKey: deviceIdDefaultsKey), !existing.isEmpty {
+            return existing
+        }
+        let fresh = UUID().uuidString
+        defaults.set(fresh, forKey: deviceIdDefaultsKey)
+        return fresh
+    }
+
     // MARK: - Backend plumbing
 
-    private func decodeRaw() -> [SyncedTraySession] {
-        guard let data = backend.data(forKey: Self.storageKey) else { return [] }
+    /// This device's own advertised sessions.
+    private func decodeOwn() -> [SyncedTraySession] {
+        decode(key: ownKey)
+    }
+
+    /// The union of every device's advertised sessions.
+    private func decodeAll() -> [SyncedTraySession] {
+        backend.keys(withPrefix: Self.storageKeyPrefix).flatMap { decode(key: $0) }
+    }
+
+    private func decode(key: String) -> [SyncedTraySession] {
+        guard let data = backend.data(forKey: key) else { return [] }
         do {
             return try JSONDecoder().decode([SyncedTraySession].self, from: data)
         } catch {
-            log.error("decodeRaw: failed to decode payload: \(error.localizedDescription, privacy: .public)")
+            log.error("decode: failed to decode payload: \(error.localizedDescription, privacy: .public)")
             return []
         }
     }
 
-    private func persist(_ list: [SyncedTraySession]) {
+    private func persistOwn(_ list: [SyncedTraySession]) {
         do {
             let data = try JSONEncoder().encode(list)
-            backend.setData(data, forKey: Self.storageKey)
+            backend.setData(data, forKey: ownKey)
             _ = backend.synchronize()
         } catch {
-            log.error("persist: failed to encode payload: \(error.localizedDescription, privacy: .public)")
+            log.error("persistOwn: failed to encode payload: \(error.localizedDescription, privacy: .public)")
         }
-        sessions = TraySessionSyncStore.active(from: list, ttl: ttl, now: clock())
+        reload()
     }
 
     private func registerExternalObserver() {

--- a/packages/swift-launcher/Sliccstart/Models/TraySessionSyncStore.swift
+++ b/packages/swift-launcher/Sliccstart/Models/TraySessionSyncStore.swift
@@ -1,0 +1,211 @@
+import Foundation
+import Observation
+import os
+
+private let log = Logger(subsystem: "com.slicc.sliccstart", category: "TraySessionSyncStore")
+
+/// Minimal key/value transport the sync store persists through. The default
+/// implementation is iCloud (`NSUbiquitousKeyValueStore`); tests inject an
+/// in-memory backend so no unit test touches iCloud.
+protocol KeyValueSyncBackend: AnyObject {
+    func data(forKey key: String) -> Data?
+    func setData(_ data: Data?, forKey key: String)
+    @discardableResult func synchronize() -> Bool
+    /// When non-nil, the store registers a NotificationCenter observer for
+    /// `name`/`object` and reloads when the backend reports an external
+    /// (other-device) change. iCloud supplies this; the in-memory backend
+    /// returns nil.
+    var externalChange: (name: Notification.Name, object: AnyObject?)? { get }
+}
+
+/// iCloud key-value backend. Degrades gracefully to a local cache when the
+/// app is not (yet) provisioned for iCloud — reads/writes still succeed,
+/// they just do not sync — so the launcher never crashes on a build that
+/// lacks the `com.apple.developer.ubiquity-kvstore-identifier` entitlement.
+final class UbiquitousKeyValueBackend: KeyValueSyncBackend {
+    private let store: NSUbiquitousKeyValueStore
+
+    init(store: NSUbiquitousKeyValueStore = .default) {
+        self.store = store
+    }
+
+    func data(forKey key: String) -> Data? {
+        store.data(forKey: key)
+    }
+
+    func setData(_ data: Data?, forKey key: String) {
+        if let data {
+            store.set(data, forKey: key)
+        } else {
+            store.removeObject(forKey: key)
+        }
+    }
+
+    @discardableResult
+    func synchronize() -> Bool {
+        store.synchronize()
+    }
+
+    var externalChange: (name: Notification.Name, object: AnyObject?)? {
+        (NSUbiquitousKeyValueStore.didChangeExternallyNotification, store)
+    }
+}
+
+/// In-memory backend for tests and for platforms/builds without iCloud.
+final class InMemoryKeyValueBackend: KeyValueSyncBackend {
+    private var storage: [String: Data] = [:]
+
+    func data(forKey key: String) -> Data? { storage[key] }
+    func setData(_ data: Data?, forKey key: String) { storage[key] = data }
+    @discardableResult func synchronize() -> Bool { true }
+    var externalChange: (name: Notification.Name, object: AnyObject?)? { nil }
+}
+
+/// Cross-device store of active tray join URLs, backed by iCloud key-value
+/// sync. The macOS launcher publishes its leader session here so the same
+/// user's other devices (and, later, the iOS follower) can discover and
+/// join it without hand-copying a join URL.
+///
+/// `@Observable` so a SwiftUI list redraws the moment iCloud pushes an
+/// external change. All persistence logic lives in the pure static helpers
+/// (`active(from:)`, `upsert(_:into:)`) so it can be unit-tested without a
+/// backend.
+@Observable
+final class TraySessionSyncStore {
+    static let storageKey = "activeTraySessions.v1"
+    static let defaultTTL: TimeInterval = 12 * 60 * 60
+    static let maxSessions = 64
+
+    /// Non-stale sessions, newest first. Observable.
+    private(set) var sessions: [SyncedTraySession] = []
+
+    @ObservationIgnored private let backend: KeyValueSyncBackend
+    @ObservationIgnored private let ttl: TimeInterval
+    @ObservationIgnored private let clock: () -> Date
+    @ObservationIgnored let deviceName: String
+    @ObservationIgnored private var observer: NSObjectProtocol?
+
+    init(
+        backend: KeyValueSyncBackend = UbiquitousKeyValueBackend(),
+        deviceName: String = TraySessionSyncStore.currentDeviceName(),
+        ttl: TimeInterval = TraySessionSyncStore.defaultTTL,
+        clock: @escaping () -> Date = Date.init
+    ) {
+        self.backend = backend
+        self.deviceName = deviceName
+        self.ttl = ttl
+        self.clock = clock
+        registerExternalObserver()
+        _ = backend.synchronize()
+        reload()
+    }
+
+    deinit {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    // MARK: - Read
+
+    /// Sessions published by other devices — the ones worth acting on here.
+    var remoteSessions: [SyncedTraySession] {
+        sessions.filter { $0.deviceName != deviceName }
+    }
+
+    /// Sessions this device published (shown read-only so the user can see
+    /// their own leader is being advertised).
+    var localSessions: [SyncedTraySession] {
+        sessions.filter { $0.deviceName == deviceName }
+    }
+
+    func reload() {
+        sessions = TraySessionSyncStore.active(from: decodeRaw(), ttl: ttl, now: clock())
+    }
+
+    // MARK: - Write
+
+    /// Advertise (or refresh) a session originating from this device.
+    func publish(joinUrl: String, label: String) {
+        guard !joinUrl.isEmpty else { return }
+        let now = clock()
+        var raw = decodeRaw()
+        let existing = raw.first { $0.id == SyncedTraySession.identifier(forJoinUrl: joinUrl) }
+        let session = SyncedTraySession(
+            joinUrl: joinUrl,
+            label: label,
+            deviceName: deviceName,
+            createdAt: existing?.createdAt ?? now,
+            lastSeenAt: now
+        )
+        raw = TraySessionSyncStore.upsert(session, into: raw)
+        persist(TraySessionSyncStore.active(from: raw, ttl: ttl, now: now))
+    }
+
+    /// Remove a single session by its join URL.
+    func withdraw(joinUrl: String) {
+        let id = SyncedTraySession.identifier(forJoinUrl: joinUrl)
+        persist(TraySessionSyncStore.active(from: decodeRaw().filter { $0.id != id }, ttl: ttl, now: clock()))
+    }
+
+    /// Remove every session this device published. Called on a clean quit
+    /// so a dead leader stops being advertised to other devices.
+    func withdrawLocalSessions() {
+        persist(TraySessionSyncStore.active(from: decodeRaw().filter { $0.deviceName != deviceName }, ttl: ttl, now: clock()))
+    }
+
+    // MARK: - Pure helpers (unit-testable without a backend)
+
+    static func upsert(_ session: SyncedTraySession, into list: [SyncedTraySession]) -> [SyncedTraySession] {
+        var next = list.filter { $0.id != session.id }
+        next.append(session)
+        return next
+    }
+
+    static func active(from raw: [SyncedTraySession], ttl: TimeInterval, now: Date) -> [SyncedTraySession] {
+        raw
+            .filter { !$0.isStale(ttl: ttl, now: now) }
+            .sorted { $0.lastSeenAt > $1.lastSeenAt }
+            .prefix(maxSessions)
+            .map { $0 }
+    }
+
+    static func currentDeviceName() -> String {
+        let name = Host.current().localizedName ?? ""
+        return name.isEmpty ? "This device" : name
+    }
+
+    // MARK: - Backend plumbing
+
+    private func decodeRaw() -> [SyncedTraySession] {
+        guard let data = backend.data(forKey: Self.storageKey) else { return [] }
+        do {
+            return try JSONDecoder().decode([SyncedTraySession].self, from: data)
+        } catch {
+            log.error("decodeRaw: failed to decode payload: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
+    }
+
+    private func persist(_ list: [SyncedTraySession]) {
+        do {
+            let data = try JSONEncoder().encode(list)
+            backend.setData(data, forKey: Self.storageKey)
+            _ = backend.synchronize()
+        } catch {
+            log.error("persist: failed to encode payload: \(error.localizedDescription, privacy: .public)")
+        }
+        sessions = TraySessionSyncStore.active(from: list, ttl: ttl, now: clock())
+    }
+
+    private func registerExternalObserver() {
+        guard let external = backend.externalChange else { return }
+        observer = NotificationCenter.default.addObserver(
+            forName: external.name,
+            object: external.object,
+            queue: .main
+        ) { [weak self] _ in
+            self?.reload()
+        }
+    }
+}

--- a/packages/swift-launcher/Sliccstart/SliccstartApp.swift
+++ b/packages/swift-launcher/Sliccstart/SliccstartApp.swift
@@ -60,6 +60,9 @@ struct SliccstartApp: App {
         )
     )
     private let runtimeRefreshTimer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
+    // Re-advertise a still-running leader well inside the sync store's 12h TTL
+    // so a continuously-open leader is never pruned from other devices.
+    private let sessionRepublishTimer = Timer.publish(every: 4 * 60 * 60, on: .main, in: .common).autoconnect()
 
     private let optelAppID = Bundle.main.bundleIdentifier ?? "unknown.app"
 
@@ -176,6 +179,12 @@ struct SliccstartApp: App {
                 } else {
                     sessionStore.withdrawLocalSessions()
                 }
+            }
+            .onReceive(sessionRepublishTimer) { _ in
+                // Refresh lastSeenAt on a live leader so it never ages out of
+                // the sync store's TTL while it is still running.
+                guard isReady, let joinUrl = sliccProcess.leaderJoinUrl, !joinUrl.isEmpty else { return }
+                sessionStore.publish(joinUrl: joinUrl, label: sliccProcess.leaderTargetName ?? "SLICC")
             }
             .onChange(of: appManagementPermission.isGranted) {
                 // Re-scan when permission is granted so Electron apps appear

--- a/packages/swift-launcher/Sliccstart/SliccstartApp.swift
+++ b/packages/swift-launcher/Sliccstart/SliccstartApp.swift
@@ -16,15 +16,21 @@ private let log = Logger(subsystem: "com.slicc.sliccstart", category: "App")
 /// Sliccstart reattaches on next launch in `SliccstartApp.initialize()`.
 final class SliccstartAppDelegate: NSObject, NSApplicationDelegate {
     let sliccProcess = SliccProcess()
+    let sessionStore = TraySessionSyncStore()
 
     func applicationWillTerminate(_ notification: Notification) {
         if sliccProcess.isPreparingForUpdate {
+            // Browsers survive the update and the tray stays live, so leave
+            // this device's session advertised — the relaunched Sliccstart
+            // republishes it after reattach.
             log.info("applicationWillTerminate: detaching for update")
             sliccProcess.detachAll()
             return
         }
         log.info("applicationWillTerminate: stopping all processes")
         sliccProcess.stopAll()
+        // The leader is going away, so stop advertising it to other devices.
+        sessionStore.withdrawLocalSessions()
     }
 }
 
@@ -63,6 +69,7 @@ struct SliccstartApp: App {
     }
 
     private var sliccProcess: SliccProcess { appDelegate.sliccProcess }
+    private var sessionStore: TraySessionSyncStore { appDelegate.sessionStore }
 
     var body: some Scene {
         WindowGroup {
@@ -85,6 +92,7 @@ struct SliccstartApp: App {
                     AppListView(
                         targets: targets,
                         sliccProcess: sliccProcess,
+                        sessionStore: sessionStore,
                         appManagementPermission: appManagementPermission,
                         appUpdater: appUpdater,
                         updateCheckStatus: updateCheckStatus,
@@ -95,6 +103,16 @@ struct SliccstartApp: App {
                                 try sliccProcess.launchStandalone(target)
                             } catch {
                                 log.error("onLaunchStandalone failed: \(error.localizedDescription, privacy: .public)")
+                                LauncherErrorReport.report(.launchStandalone, error)
+                                showError(error.localizedDescription)
+                            }
+                        },
+                        onLaunchBrowserFollower: { target, joinUrl in
+                            log.info("onLaunchBrowserFollower: \(target.name, privacy: .public)")
+                            do {
+                                try sliccProcess.launchBrowserFollower(target, joinUrl: joinUrl)
+                            } catch {
+                                log.error("onLaunchBrowserFollower failed: \(error.localizedDescription, privacy: .public)")
                                 LauncherErrorReport.report(.launchStandalone, error)
                                 showError(error.localizedDescription)
                             }
@@ -148,6 +166,16 @@ struct SliccstartApp: App {
             .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
                 guard isReady else { return }
                 sliccProcess.refreshRuntimeStates(for: targets)
+            }
+            .onChange(of: sliccProcess.leaderJoinUrl) { _, newValue in
+                // Advertise this device's leader session over iCloud when it
+                // becomes ready, and withdraw it when the leader goes away.
+                if let joinUrl = newValue, !joinUrl.isEmpty {
+                    let label = sliccProcess.leaderTargetName ?? "SLICC"
+                    sessionStore.publish(joinUrl: joinUrl, label: label)
+                } else {
+                    sessionStore.withdrawLocalSessions()
+                }
             }
             .onChange(of: appManagementPermission.isGranted) {
                 // Re-scan when permission is granted so Electron apps appear
@@ -284,14 +312,18 @@ struct SliccstartApp: App {
         )
     }
 
-    /// Launch the browser the user picked in Settings > Startup, if any.
-    /// Stored as the `AppTarget.id` (bundle path) under
-    /// `autoLaunchAppIdKey`. Failures are logged but never block startup.
+    /// Launch the top browser at startup when the Settings > Startup checkbox
+    /// is enabled. The browser is the head of the (reorderable) Browsers list.
+    /// Failures are logged but never block startup.
     private func autoLaunchConfiguredBrowser() {
-        let savedId = UserDefaults.standard.string(forKey: autoLaunchAppIdKey) ?? ""
-        guard !savedId.isEmpty else { return }
-        guard let target = targets.first(where: { $0.id == savedId && $0.type == .chromiumBrowser }) else {
-            log.info("autoLaunch: no matching browser found for id=\(savedId, privacy: .public)")
+        guard StartupPreference.resolveEnabled(defaults: .standard) else { return }
+        let browsers = AppOrdering.ordered(
+            targets.filter { $0.type == .chromiumBrowser },
+            savedOrder: AppOrderStore().load(AppOrderStore.browserKey),
+            defaultPriority: AppOrdering.browserBundlePriority
+        )
+        guard let target = browsers.first else {
+            log.info("autoLaunch: no browser available to launch")
             return
         }
         log.info("autoLaunch: launching \(target.name, privacy: .public)")

--- a/packages/swift-launcher/Sliccstart/Views/AppListView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/AppListView.swift
@@ -274,12 +274,13 @@ struct AppListView: View {
     }
 
     private func handleBrowserLaunch(_ target: AppTarget) {
-        // A running browser just re-focuses/restarts via the standalone path.
-        // Otherwise, when remote iCloud sessions exist, offer lead-vs-attach;
-        // with none, launch standalone directly (unchanged single-Mac flow).
-        if sliccProcess.runtimeState(for: target).isRunning || sessionStore.remoteSessions.isEmpty {
+        switch BrowserLaunchAction.resolve(
+            isRunning: sliccProcess.runtimeState(for: target).isRunning,
+            hasRemoteSessions: !sessionStore.remoteSessions.isEmpty
+        ) {
+        case .standalone:
             onLaunchStandalone(target)
-        } else {
+        case .chooseLeadOrAttach:
             browserDialogTarget = target
         }
     }
@@ -624,6 +625,20 @@ struct AppRow: View {
     }
 
     private var statusDot: AppRowStatusDot? {
+        AppRow.statusDot(for: runtimeState)
+    }
+
+    private var subtitle: String? {
+        AppRow.subtitle(
+            for: runtimeState,
+            override: subtitleOverride,
+            isDebugBuild: target.isDebugBuild
+        )
+    }
+
+    // Pure state → display mappings, split out from the computed view
+    // properties so every branch is unit-testable without rendering the row.
+    static func statusDot(for runtimeState: AppRuntimeState) -> AppRowStatusDot? {
         switch runtimeState {
         case .notRunning:
             return nil
@@ -642,11 +657,15 @@ struct AppRow: View {
         }
     }
 
-    private var subtitle: String? {
-        if let subtitleOverride { return subtitleOverride }
+    static func subtitle(
+        for runtimeState: AppRuntimeState,
+        override: String?,
+        isDebugBuild: Bool
+    ) -> String? {
+        if let override { return override }
         switch runtimeState {
         case .notRunning:
-            return target.isDebugBuild ? "Debug Build" : nil
+            return isDebugBuild ? "Debug Build" : nil
         case .runningWithoutDebug:
             return "Running without SLICC"
         case .runningWithDebug(let cdpPort):
@@ -747,16 +766,9 @@ private struct ReorderDropDelegate: DropDelegate {
     }
 
     func dropEntered(info: DropInfo) {
-        guard let dragging,
-            let over = target.bundleId,
-            dragging != over
-        else { return }
-        var ids = currentIds
-        guard let from = ids.firstIndex(of: dragging),
-            let to = ids.firstIndex(of: over)
-        else { return }
-        let moved = ids.remove(at: from)
-        ids.insert(moved, at: to)
+        guard let dragging, let over = target.bundleId else { return }
+        let ids = AppOrdering.reorder(currentIds, moving: dragging, over: over)
+        guard ids != currentIds else { return }
         order = ids
         onCommit(ids)
     }

--- a/packages/swift-launcher/Sliccstart/Views/AppListView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/AppListView.swift
@@ -506,8 +506,21 @@ struct TraySessionRow: View {
     }
 
     private var subtitle: String {
-        let origin = isLocal ? "This device" : session.deviceName
-        return "\(origin) · \(TraySessionRow.age(of: session.lastSeenAt))"
+        TraySessionRow.subtitle(
+            isLocal: isLocal,
+            deviceName: session.deviceName,
+            lastSeenAt: session.lastSeenAt
+        )
+    }
+
+    static func subtitle(
+        isLocal: Bool,
+        deviceName: String,
+        lastSeenAt: Date,
+        now: Date = Date()
+    ) -> String {
+        let origin = isLocal ? "This device" : deviceName
+        return "\(origin) · \(age(of: lastSeenAt, now: now))"
     }
 
     static func age(of date: Date, now: Date = Date()) -> String {
@@ -568,6 +581,10 @@ struct AppRow: View {
     }
 
     private var isDisabled: Bool {
+        AppRow.isDisabled(runtimeState: runtimeState, interactionDisabled: interactionDisabled)
+    }
+
+    static func isDisabled(runtimeState: AppRuntimeState, interactionDisabled: Bool) -> Bool {
         runtimeState == .cannotStart(.needsLeader) || interactionDisabled
     }
 

--- a/packages/swift-launcher/Sliccstart/Views/AppListView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/AppListView.swift
@@ -734,8 +734,12 @@ private struct ReorderDropDelegate: DropDelegate {
     @Binding var dragging: String?
     let onCommit: ([String]) -> Void
 
+    // The on-screen order already merges the saved order with any app
+    // installed after it was saved (AppOrdering appends the newcomers), so
+    // keying off `displayed` — not the raw saved `order` — lets a freshly
+    // installed browser/terminal be dragged too.
     private var currentIds: [String] {
-        order.isEmpty ? displayed.compactMap { $0.bundleId } : order
+        displayed.compactMap { $0.bundleId }
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {

--- a/packages/swift-launcher/Sliccstart/Views/AppListView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/AppListView.swift
@@ -739,7 +739,7 @@ private struct ReorderDropDelegate: DropDelegate {
     // keying off `displayed` — not the raw saved `order` — lets a freshly
     // installed browser/terminal be dragged too.
     private var currentIds: [String] {
-        displayed.compactMap { $0.bundleId }
+        AppOrdering.persistableOrder(from: displayed)
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {

--- a/packages/swift-launcher/Sliccstart/Views/AppListView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/AppListView.swift
@@ -1,14 +1,17 @@
 import AppUpdater
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct AppListView: View {
     let targets: [AppTarget]
     @Bindable var sliccProcess: SliccProcess
+    let sessionStore: TraySessionSyncStore
     @Bindable var appManagementPermission: AppManagementPermission
     @ObservedObject var appUpdater: AppUpdater
     let updateCheckStatus: UpdateCheckStatus
     let onCheckForUpdates: () -> Void
     let onLaunchStandalone: (AppTarget) -> Void
+    let onLaunchBrowserFollower: (AppTarget, String) -> Void
     let onLaunchElectron: (AppTarget) -> Void
     let onCreateDebugBuild: (AppTarget) -> Void
     let onUpdate: () -> Void
@@ -17,16 +20,45 @@ struct AppListView: View {
 
     @AppStorage(suppressTerminalWarningKey) private var suppressTerminalWarning = false
     @State private var pendingTerminalTarget: AppTarget?
+    @State private var pendingJoinURLOverride: String?
     @State private var showTerminalWarning = false
     @State private var suppressWarningAfterApproval = false
     @State private var showTerminalDownloadPrompt = false
     @State private var terminalLaunchError: String?
+    @State private var browserOrder: [String] = []
+    @State private var terminalOrder: [String] = []
+    @State private var draggingBundleId: String?
+    @State private var browserDialogTarget: AppTarget?
+
+    private let orderStore = AppOrderStore()
+
+    private var orderedBrowsers: [AppTarget] {
+        AppOrdering.ordered(
+            targets.filter { $0.type == .chromiumBrowser },
+            savedOrder: browserOrder,
+            defaultPriority: AppOrdering.browserBundlePriority
+        )
+    }
+
+    private var orderedTerminals: [AppTarget] {
+        AppOrdering.ordered(
+            targets.filter { $0.type == .terminal },
+            savedOrder: terminalOrder,
+            defaultPriority: AppOrdering.terminalBundlePriority
+        )
+    }
+
+    private var electronApps: [AppTarget] {
+        targets.filter { $0.type == .electronApp }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             ForEach(AppListSection.visibleSections(for: targets), id: \.self) { section in
                 sectionContent(section)
             }
+
+            sessionsSection
 
             Spacer(minLength: 0)
 
@@ -44,6 +76,10 @@ struct AppListView: View {
                     .accessibilityIdentifier("rescan")
             }
             .padding(.horizontal, 12).padding(.vertical, 6)
+        }
+        .onAppear {
+            browserOrder = orderStore.load(AppOrderStore.browserKey)
+            terminalOrder = orderStore.load(AppOrderStore.terminalKey)
         }
         .alert("Allow terminal access?", isPresented: $showTerminalWarning) {
             Toggle("Don't show this again", isOn: $suppressWarningAfterApproval)
@@ -69,21 +105,36 @@ struct AppListView: View {
         } message: {
             Text(terminalLaunchError ?? "")
         }
+        .confirmationDialog(
+            browserDialogTarget.map { "Launch \($0.name)" } ?? "Launch browser",
+            isPresented: Binding(
+                get: { browserDialogTarget != nil },
+                set: { if !$0 { browserDialogTarget = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: browserDialogTarget
+        ) { target in
+            Button("Launch standalone") {
+                onLaunchStandalone(target)
+                browserDialogTarget = nil
+            }
+            ForEach(sessionStore.remoteSessions) { session in
+                Button("Attach to \(session.label) on \(session.deviceName)") {
+                    onLaunchBrowserFollower(target, session.joinUrl)
+                    browserDialogTarget = nil
+                }
+            }
+            Button("Cancel", role: .cancel) { browserDialogTarget = nil }
+        } message: { target in
+            Text("Launch \(target.name) as its own session, or attach it to a running iCloud session as a follower.")
+        }
     }
 
     @ViewBuilder
     private func sectionContent(_ section: AppListSection) -> some View {
         switch section {
         case .browsers:
-            SectionHeader("Browsers")
-            ForEach(targets.filter { $0.type == .chromiumBrowser }) { target in
-                AppRow(
-                    target: target,
-                    runtimeState: sliccProcess.runtimeState(for: target),
-                    onLaunch: { onLaunchStandalone(target) },
-                    onCreateDebugBuild: nil
-                )
-            }
+            browsersSection
         case .desktopApps:
             desktopAppsSection
         case .terminals:
@@ -94,9 +145,31 @@ struct AppListView: View {
     }
 
     @ViewBuilder
+    private var browsersSection: some View {
+        SectionHeader("Browsers")
+        ForEach(orderedBrowsers) { target in
+            AppRow(
+                target: target,
+                runtimeState: sliccProcess.runtimeState(for: target),
+                onLaunch: { handleBrowserLaunch(target) },
+                onCreateDebugBuild: nil
+            )
+            .modifier(
+                ReorderableRow(
+                    target: target,
+                    order: $browserOrder,
+                    displayed: orderedBrowsers,
+                    dragging: $draggingBundleId,
+                    onCommit: { orderStore.save($0, forKey: AppOrderStore.browserKey) }
+                )
+            )
+        }
+    }
+
+    @ViewBuilder
     private var desktopAppsSection: some View {
         SectionHeader("Desktop Apps")
-        ForEach(targets.filter { $0.type == .electronApp }) { target in
+        ForEach(electronApps) { target in
             let runtimeState = sliccProcess.runtimeState(
                 for: target,
                 hasAppManagementPermission: appManagementPermission.isGranted
@@ -113,7 +186,7 @@ struct AppListView: View {
     @ViewBuilder
     private var terminalsSection: some View {
         SectionHeader("Terminals")
-        ForEach(targets.filter { $0.type == .terminal }) { target in
+        ForEach(orderedTerminals) { target in
             let runtimeState = sliccProcess.runtimeState(for: target)
             AppRow(
                 target: target,
@@ -122,6 +195,15 @@ struct AppListView: View {
                 onCreateDebugBuild: nil,
                 subtitleOverride: terminalSubtitle(runtimeState: runtimeState),
                 interactionDisabled: sliccProcess.isLaunchingTerminalFollower
+            )
+            .modifier(
+                ReorderableRow(
+                    target: target,
+                    order: $terminalOrder,
+                    displayed: orderedTerminals,
+                    dragging: $draggingBundleId,
+                    onCommit: { orderStore.save($0, forKey: AppOrderStore.terminalKey) }
+                )
             )
         }
     }
@@ -154,6 +236,73 @@ struct AppListView: View {
         .accessibilityLabel("Get Extension")
     }
 
+    @ViewBuilder
+    private var sessionsSection: some View {
+        let remote = sessionStore.remoteSessions
+        let local = sessionStore.localSessions
+        if !remote.isEmpty || !local.isEmpty {
+            SectionHeader("iCloud Sessions")
+            ForEach(remote) { session in
+                TraySessionRow(
+                    session: session,
+                    isLocal: false,
+                    localBrowserIcon: localBrowserIcon(for: session),
+                    canAttachBrowser: orderedBrowsers.first != nil,
+                    canFollow: !orderedTerminals.isEmpty,
+                    onCopy: { copyJoinURL(session) },
+                    onAttachBrowser: { attachBrowser(to: session) },
+                    onFollow: { beginRemoteFollow(session) }
+                )
+            }
+            ForEach(local) { session in
+                TraySessionRow(
+                    session: session,
+                    isLocal: true,
+                    localBrowserIcon: localBrowserIcon(for: session),
+                    canAttachBrowser: false,
+                    canFollow: false,
+                    onCopy: { copyJoinURL(session) },
+                    onAttachBrowser: {},
+                    onFollow: {}
+                )
+            }
+        }
+    }
+
+    private func localBrowserIcon(for session: SyncedTraySession) -> NSImage? {
+        orderedBrowsers.first(where: { $0.name == session.label })?.icon
+    }
+
+    private func handleBrowserLaunch(_ target: AppTarget) {
+        // A running browser just re-focuses/restarts via the standalone path.
+        // Otherwise, when remote iCloud sessions exist, offer lead-vs-attach;
+        // with none, launch standalone directly (unchanged single-Mac flow).
+        if sliccProcess.runtimeState(for: target).isRunning || sessionStore.remoteSessions.isEmpty {
+            onLaunchStandalone(target)
+        } else {
+            browserDialogTarget = target
+        }
+    }
+
+    private func attachBrowser(to session: SyncedTraySession) {
+        guard let top = orderedBrowsers.first else { return }
+        onLaunchBrowserFollower(top, session.joinUrl)
+    }
+
+    private func copyJoinURL(_ session: SyncedTraySession) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(session.joinUrl, forType: .string)
+    }
+
+    private func beginRemoteFollow(_ session: SyncedTraySession) {
+        guard let terminal = orderedTerminals.first else {
+            terminalLaunchError = "Install a supported terminal to follow this session."
+            return
+        }
+        pendingJoinURLOverride = session.joinUrl
+        beginTerminalLaunch(terminal)
+    }
+
     private func handleElectronRow(_ target: AppTarget, runtimeState: AppRuntimeState) {
         if runtimeState == .cannotStart(.needsDebugBuild) {
             onCreateDebugBuild(target)
@@ -175,8 +324,11 @@ struct AppListView: View {
     }
 
     private func beginTerminalLaunch(_ target: AppTarget, warningAcknowledged: Bool = false) {
+        // A remote (iCloud) session supplies its own join URL, so the local
+        // leader-readiness gate does not apply when an override is pending.
+        let leaderReady = sliccProcess.isLeaderReady() || pendingJoinURLOverride != nil
         let nextStep = TerminalLaunchDecision.nextStep(
-            leaderReady: sliccProcess.isLeaderReady(),
+            leaderReady: leaderReady,
             warningSuppressed: suppressTerminalWarning,
             warningAcknowledged: warningAcknowledged,
             cliAvailable: sliccProcess.isTerminalCliAvailable()
@@ -203,9 +355,10 @@ struct AppListView: View {
 
     private func launchPendingTerminal() {
         guard let target = pendingTerminalTarget else { return }
+        let override = pendingJoinURLOverride
         Task { @MainActor in
             do {
-                try await sliccProcess.launchTerminalFollower(target)
+                try await sliccProcess.launchTerminalFollower(target, joinURLOverride: override)
                 clearPendingTerminalLaunch()
             } catch {
                 LauncherErrorReport.report(.terminalFollower, error)
@@ -217,6 +370,7 @@ struct AppListView: View {
 
     private func clearPendingTerminalLaunch(keepError: Bool = false) {
         pendingTerminalTarget = nil
+        pendingJoinURLOverride = nil
         suppressWarningAfterApproval = false
         if !keepError { terminalLaunchError = nil }
     }
@@ -278,6 +432,89 @@ struct AppListView: View {
         case .failed:
             return AnyShapeStyle(Color.red)
         }
+    }
+}
+
+struct TraySessionRow: View {
+    let session: SyncedTraySession
+    let isLocal: Bool
+    let localBrowserIcon: NSImage?
+    let canAttachBrowser: Bool
+    let canFollow: Bool
+    let onCopy: () -> Void
+    let onAttachBrowser: () -> Void
+    let onFollow: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            icon
+            VStack(alignment: .leading, spacing: 1) {
+                Text(session.label).font(.system(size: 13))
+                Text(subtitle)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button(action: onCopy) {
+                Image(systemName: "doc.on.doc")
+            }
+            .buttonStyle(.borderless)
+            .help("Copy join URL")
+            .accessibilityIdentifier("session-copy-\(session.id)")
+            if !isLocal {
+                Button(action: onAttachBrowser) {
+                    Image(systemName: "globe")
+                }
+                .buttonStyle(.borderless)
+                .disabled(!canAttachBrowser)
+                .help(canAttachBrowser ? "Attach a browser to this session" : "Install a supported browser to attach")
+                .accessibilityIdentifier("session-attach-browser-\(session.id)")
+                Button(action: onFollow) {
+                    Image(systemName: "terminal")
+                }
+                .buttonStyle(.borderless)
+                .disabled(!canFollow)
+                .help(canFollow ? "Follow in a terminal" : "Install a supported terminal to follow")
+                .accessibilityIdentifier("session-follow-\(session.id)")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private var icon: some View {
+        if let localBrowserIcon {
+            ZStack(alignment: .bottomTrailing) {
+                Image(nsImage: localBrowserIcon)
+                    .resizable()
+                    .frame(width: 28, height: 28)
+                Image(systemName: "icloud.fill")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.white)
+                    .padding(1)
+                    .background(Circle().fill(.blue))
+                    .offset(x: 2, y: 2)
+            }
+        } else {
+            Image(systemName: "icloud")
+                .font(.system(size: 15))
+                .frame(width: 28, height: 28)
+                .foregroundStyle(.blue)
+        }
+    }
+
+    private var subtitle: String {
+        let origin = isLocal ? "This device" : session.deviceName
+        return "\(origin) · \(TraySessionRow.age(of: session.lastSeenAt))"
+    }
+
+    static func age(of date: Date, now: Date = Date()) -> String {
+        let seconds = max(0, now.timeIntervalSince(date))
+        if seconds < 60 { return "just now" }
+        if seconds < 3600 { return "\(Int(seconds / 60))m ago" }
+        if seconds < 86400 { return "\(Int(seconds / 3600))h ago" }
+        return "\(Int(seconds / 86400))d ago"
     }
 }
 
@@ -458,5 +695,70 @@ extension AppRowStatusDot {
         case .failed:
             return "The last start attempt failed. Click to retry."
         }
+    }
+}
+
+/// Makes a row draggable to reorder its list. Live-reorders as the drag hovers
+/// over sibling rows and persists the new bundle-id order via `onCommit`.
+struct ReorderableRow: ViewModifier {
+    let target: AppTarget
+    @Binding var order: [String]
+    let displayed: [AppTarget]
+    @Binding var dragging: String?
+    let onCommit: ([String]) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(dragging == target.bundleId ? 0.5 : 1)
+            .onDrag {
+                dragging = target.bundleId
+                return NSItemProvider(object: (target.bundleId ?? target.id) as NSString)
+            }
+            .onDrop(
+                of: [.text],
+                delegate: ReorderDropDelegate(
+                    target: target,
+                    order: $order,
+                    displayed: displayed,
+                    dragging: $dragging,
+                    onCommit: onCommit
+                )
+            )
+    }
+}
+
+private struct ReorderDropDelegate: DropDelegate {
+    let target: AppTarget
+    @Binding var order: [String]
+    let displayed: [AppTarget]
+    @Binding var dragging: String?
+    let onCommit: ([String]) -> Void
+
+    private var currentIds: [String] {
+        order.isEmpty ? displayed.compactMap { $0.bundleId } : order
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+
+    func dropEntered(info: DropInfo) {
+        guard let dragging,
+            let over = target.bundleId,
+            dragging != over
+        else { return }
+        var ids = currentIds
+        guard let from = ids.firstIndex(of: dragging),
+            let to = ids.firstIndex(of: over)
+        else { return }
+        let moved = ids.remove(at: from)
+        ids.insert(moved, at: to)
+        order = ids
+        onCommit(ids)
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        dragging = nil
+        return true
     }
 }

--- a/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
@@ -60,30 +60,35 @@ struct SettingsView: View {
 // MARK: - Startup tab
 
 struct StartupSettingsView: View {
-    @AppStorage(autoLaunchAppIdKey) private var autoLaunchAppId: String = ""
-    @State private var browsers: [AppTarget] = []
+    @AppStorage(StartupPreference.enabledKey) private var launchAtStartup = false
+    @State private var topBrowserName: String?
 
     var body: some View {
         Form {
-            Picker(selection: $autoLaunchAppId) {
-                Text("None").tag("")
-                if !browsers.isEmpty {
-                    Divider()
-                    ForEach(browsers) { browser in
-                        Text(browser.name).tag(browser.id)
-                    }
+            Toggle(isOn: $launchAtStartup) {
+                if let topBrowserName {
+                    Text("Launch \(topBrowserName) on startup")
+                } else {
+                    Text("Launch top browser on startup")
                 }
-            } label: {
-                Text("Launch on startup:")
             }
-            .pickerStyle(.menu)
+            Text("Launches the browser at the top of your Browsers list. Drag to reorder that list in the main window to change which one starts.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
         .padding(20)
         .frame(width: 460)
         .fixedSize()
         .onAppear {
-            browsers = AppScanner.scan(hasAppManagementPermission: false)
+            StartupPreference.resolveEnabled(defaults: .standard)
+            let browsers = AppScanner.scan(hasAppManagementPermission: false)
                 .filter { $0.type == .chromiumBrowser }
+            topBrowserName =
+                AppOrdering.ordered(
+                    browsers,
+                    savedOrder: AppOrderStore().load(AppOrderStore.browserKey),
+                    defaultPriority: AppOrdering.browserBundlePriority
+                ).first?.name
         }
     }
 }

--- a/packages/swift-launcher/SliccstartTests/AppOrderingTests.swift
+++ b/packages/swift-launcher/SliccstartTests/AppOrderingTests.swift
@@ -1,0 +1,99 @@
+import AppKit
+import XCTest
+
+@testable import Sliccstart
+
+/// Ordering rules for the Browsers and Terminals lists: default priority,
+/// saved user overrides, and the drag-reorder persistence helper.
+final class AppOrderingTests: XCTestCase {
+
+    private func target(_ name: String, _ bundleId: String?, _ type: AppTargetType) -> AppTarget {
+        let path = "/Applications/\(name).app"
+        return AppTarget(
+            id: path,
+            name: name,
+            path: path,
+            executablePath: "\(path)/Contents/MacOS/\(name)",
+            type: type,
+            icon: NSImage(size: NSSize(width: 1, height: 1)),
+            debugSupport: .supported,
+            isDebugBuild: false,
+            originalAppPath: nil,
+            bundleId: bundleId
+        )
+    }
+
+    private func browser(_ name: String, _ bundleId: String?) -> AppTarget {
+        target(name, bundleId, .chromiumBrowser)
+    }
+
+    private func terminal(_ name: String, _ bundleId: String?) -> AppTarget {
+        target(name, bundleId, .terminal)
+    }
+
+    func testBrowsersOrderByMarketSharePriorityByDefault() {
+        let targets = [
+            browser("Brave", "com.brave.Browser"),
+            browser("Chrome", "com.google.Chrome"),
+            browser("Edge", "com.microsoft.edgemac"),
+        ]
+        let ordered = AppOrdering.ordered(
+            targets,
+            savedOrder: [],
+            defaultPriority: AppOrdering.browserBundlePriority
+        )
+        XCTAssertEqual(ordered.map(\.name), ["Chrome", "Edge", "Brave"])
+    }
+
+    func testTerminalsPreferPowerUserAppOverTerminalApp() {
+        let targets = [
+            terminal("Terminal", "com.apple.Terminal"),
+            terminal("Alacritty", "org.alacritty"),
+        ]
+        let ordered = AppOrdering.ordered(
+            targets,
+            savedOrder: [],
+            defaultPriority: AppOrdering.terminalBundlePriority
+        )
+        XCTAssertEqual(ordered.map(\.name), ["Alacritty", "Terminal"])
+    }
+
+    func testSavedOrderWinsOverDefaultPriority() {
+        let targets = [
+            browser("Chrome", "com.google.Chrome"),
+            browser("Brave", "com.brave.Browser"),
+        ]
+        let ordered = AppOrdering.ordered(
+            targets,
+            savedOrder: ["com.brave.Browser", "com.google.Chrome"],
+            defaultPriority: AppOrdering.browserBundlePriority
+        )
+        XCTAssertEqual(ordered.map(\.name), ["Brave", "Chrome"])
+    }
+
+    func testUnknownBundleIdsSortAlphabeticallyAfterKnown() {
+        let targets = [
+            browser("Zeta", "com.example.zeta"),
+            browser("Chrome", "com.google.Chrome"),
+            browser("Alpha", "com.example.alpha"),
+        ]
+        let ordered = AppOrdering.ordered(
+            targets,
+            savedOrder: [],
+            defaultPriority: AppOrdering.browserBundlePriority
+        )
+        XCTAssertEqual(ordered.map(\.name), ["Chrome", "Alpha", "Zeta"])
+    }
+
+    func testPersistableOrderSkipsTargetsWithoutBundleId() {
+        let reordered = [
+            browser("Chrome", "com.google.Chrome"),
+            browser("Mystery", nil),
+            browser("Brave", "com.brave.Browser"),
+        ]
+        XCTAssertEqual(
+            AppOrdering.persistableOrder(from: reordered),
+            ["com.google.Chrome", "com.brave.Browser"]
+        )
+    }
+}

--- a/packages/swift-launcher/SliccstartTests/AppOrderingTests.swift
+++ b/packages/swift-launcher/SliccstartTests/AppOrderingTests.swift
@@ -96,4 +96,39 @@ final class AppOrderingTests: XCTestCase {
             ["com.google.Chrome", "com.brave.Browser"]
         )
     }
+
+    func testReorderMovesItemDown() {
+        XCTAssertEqual(
+            AppOrdering.reorder(["a", "b", "c"], moving: "a", over: "c"),
+            ["b", "c", "a"]
+        )
+    }
+
+    func testReorderMovesItemUp() {
+        XCTAssertEqual(
+            AppOrdering.reorder(["a", "b", "c"], moving: "c", over: "a"),
+            ["c", "a", "b"]
+        )
+    }
+
+    func testReorderIsNoOpWhenIdsMatchOrAbsent() {
+        XCTAssertEqual(AppOrdering.reorder(["a", "b"], moving: "a", over: "a"), ["a", "b"])
+        XCTAssertEqual(AppOrdering.reorder(["a", "b"], moving: "z", over: "a"), ["a", "b"])
+        XCTAssertEqual(AppOrdering.reorder(["a", "b"], moving: "a", over: "z"), ["a", "b"])
+    }
+
+    func testBrowserLaunchActionResolves() {
+        XCTAssertEqual(
+            BrowserLaunchAction.resolve(isRunning: false, hasRemoteSessions: true),
+            .chooseLeadOrAttach
+        )
+        XCTAssertEqual(
+            BrowserLaunchAction.resolve(isRunning: true, hasRemoteSessions: true),
+            .standalone
+        )
+        XCTAssertEqual(
+            BrowserLaunchAction.resolve(isRunning: false, hasRemoteSessions: false),
+            .standalone
+        )
+    }
 }

--- a/packages/swift-launcher/SliccstartTests/AppRowDisplayTests.swift
+++ b/packages/swift-launcher/SliccstartTests/AppRowDisplayTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import Sliccstart
+
+final class AppRowDisplayTests: XCTestCase {
+    func testStatusDotForEachRuntimeState() {
+        XCTAssertNil(AppRow.statusDot(for: .notRunning))
+        XCTAssertEqual(AppRow.statusDot(for: .runningWithoutDebug), .runningWithoutDebug)
+        XCTAssertEqual(AppRow.statusDot(for: .runningWithDebug(cdpPort: 9222)), .runningWithDebug)
+        XCTAssertEqual(AppRow.statusDot(for: .startFailed(message: "boom")), .failed)
+        XCTAssertEqual(AppRow.statusDot(for: .cannotStart(.needsDebugBuild)), .needsDebugBuild)
+        XCTAssertEqual(AppRow.statusDot(for: .cannotStart(.needsPermission)), .needsPermission)
+        XCTAssertEqual(AppRow.statusDot(for: .cannotStart(.needsLeader)), .needsLeader)
+    }
+
+    func testSubtitleOverrideWins() {
+        XCTAssertEqual(
+            AppRow.subtitle(for: .runningWithoutDebug, override: "Custom", isDebugBuild: false),
+            "Custom"
+        )
+    }
+
+    func testSubtitleForEachRuntimeState() {
+        XCTAssertNil(AppRow.subtitle(for: .notRunning, override: nil, isDebugBuild: false))
+        XCTAssertEqual(
+            AppRow.subtitle(for: .notRunning, override: nil, isDebugBuild: true),
+            "Debug Build"
+        )
+        XCTAssertEqual(
+            AppRow.subtitle(for: .runningWithoutDebug, override: nil, isDebugBuild: false),
+            "Running without SLICC"
+        )
+        XCTAssertEqual(
+            AppRow.subtitle(for: .runningWithDebug(cdpPort: 9222), override: nil, isDebugBuild: false),
+            "Running with SLICC on 9222"
+        )
+        XCTAssertEqual(
+            AppRow.subtitle(for: .runningWithDebug(cdpPort: nil), override: nil, isDebugBuild: false),
+            "Running with SLICC"
+        )
+        XCTAssertEqual(
+            AppRow.subtitle(for: .startFailed(message: "x"), override: nil, isDebugBuild: false),
+            "Start failed"
+        )
+        XCTAssertEqual(
+            AppRow.subtitle(for: .cannotStart(.needsDebugBuild), override: nil, isDebugBuild: false),
+            "Needs Debug Build"
+        )
+        XCTAssertEqual(
+            AppRow.subtitle(for: .cannotStart(.needsPermission), override: nil, isDebugBuild: false),
+            "Needs Permission"
+        )
+        XCTAssertEqual(
+            AppRow.subtitle(for: .cannotStart(.needsLeader), override: nil, isDebugBuild: false),
+            "Start a browser first"
+        )
+    }
+}

--- a/packages/swift-launcher/SliccstartTests/AppRowDisplayTests.swift
+++ b/packages/swift-launcher/SliccstartTests/AppRowDisplayTests.swift
@@ -13,6 +13,21 @@ final class AppRowDisplayTests: XCTestCase {
         XCTAssertEqual(AppRow.statusDot(for: .cannotStart(.needsLeader)), .needsLeader)
     }
 
+    func testStatusDotColorAndHelpForEachCase() {
+        let all: [AppRowStatusDot] = [
+            .runningWithDebug,
+            .runningWithoutDebug,
+            .needsPermission,
+            .needsDebugBuild,
+            .needsLeader,
+            .failed,
+        ]
+        for dot in all {
+            _ = dot.color
+            XCTAssertFalse(dot.help.isEmpty)
+        }
+    }
+
     func testSubtitleOverrideWins() {
         XCTAssertEqual(
             AppRow.subtitle(for: .runningWithoutDebug, override: "Custom", isDebugBuild: false),

--- a/packages/swift-launcher/SliccstartTests/AppRowDisplayTests.swift
+++ b/packages/swift-launcher/SliccstartTests/AppRowDisplayTests.swift
@@ -22,10 +22,31 @@ final class AppRowDisplayTests: XCTestCase {
             .needsLeader,
             .failed,
         ]
+        var colors: Set<String> = []
         for dot in all {
-            _ = dot.color
+            colors.insert(String(describing: dot.color))
             XCTAssertFalse(dot.help.isEmpty)
         }
+        XCTAssertEqual(colors.count, 4)
+        XCTAssertEqual(AppRowStatusDot.needsLeader.help, "Start a browser first to enable this app.")
+    }
+
+    func testIsDisabledOnlyForNeedsLeaderOrExplicitFlag() {
+        XCTAssertTrue(
+            AppRow.isDisabled(runtimeState: .cannotStart(.needsLeader), interactionDisabled: false)
+        )
+        XCTAssertTrue(
+            AppRow.isDisabled(runtimeState: .notRunning, interactionDisabled: true)
+        )
+        XCTAssertFalse(
+            AppRow.isDisabled(runtimeState: .notRunning, interactionDisabled: false)
+        )
+        XCTAssertFalse(
+            AppRow.isDisabled(
+                runtimeState: .cannotStart(.needsPermission),
+                interactionDisabled: false
+            )
+        )
     }
 
     func testSubtitleOverrideWins() {

--- a/packages/swift-launcher/SliccstartTests/SliccBootstrapperTests.swift
+++ b/packages/swift-launcher/SliccstartTests/SliccBootstrapperTests.swift
@@ -93,6 +93,15 @@ final class SliccBootstrapperTests: XCTestCase {
         }
     }
 
+    func testEnrichedEnvironmentAddsToolPathsAndDedupes() {
+        let env = SliccBootstrapper.enrichedEnvironment
+        let entries = (env["PATH"] ?? "").split(separator: ":").map(String.init)
+        XCTAssertTrue(entries.contains("/opt/homebrew/bin"))
+        XCTAssertTrue(entries.contains("/usr/local/bin"))
+        XCTAssertTrue(entries.contains("/usr/bin"))
+        XCTAssertEqual(Set(entries).count, entries.count)
+    }
+
     private func createFile(at url: URL) throws {
         try FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(),

--- a/packages/swift-launcher/SliccstartTests/SliccProcessLaunchArgsTests.swift
+++ b/packages/swift-launcher/SliccstartTests/SliccProcessLaunchArgsTests.swift
@@ -15,6 +15,15 @@ final class SliccProcessLaunchArgsTests: XCTestCase {
         XCTAssertEqual(args, ["--cdp-port=9222", "--lead"])
     }
 
+    func testBrowserFollowerArgsJoinInsteadOfLead() {
+        let args = SliccProcess.browserFollowerArgs(
+            cdpPort: 9222,
+            joinUrl: "https://example.test/join/abc.def"
+        )
+        XCTAssertEqual(args, ["--cdp-port=9222", "--join=https://example.test/join/abc.def"])
+        XCTAssertFalse(args.contains("--lead"))
+    }
+
     // MARK: - Browser launch env
 
     func testStandaloneBrowserEnvDefaultsWorkerBaseUrl() {

--- a/packages/swift-launcher/SliccstartTests/SliccProcessLeaderGatingTests.swift
+++ b/packages/swift-launcher/SliccstartTests/SliccProcessLeaderGatingTests.swift
@@ -105,7 +105,82 @@ final class SliccProcessLeaderGatingTests: XCTestCase {
         XCTAssertFalse(proc.isLeaderReady())
     }
 
+    func testLaunchBrowserFollowerRejectsNonBrowserTarget() {
+        let proc = SliccProcess()
+        XCTAssertThrowsError(
+            try proc.launchBrowserFollower(makeElectron(), joinUrl: "https://x.test/join/a.b")
+        )
+    }
+
+    func testLaunchBrowserFollowerRejectsEmptyJoinURL() {
+        let proc = SliccProcess()
+        XCTAssertThrowsError(try proc.launchBrowserFollower(makeBrowser(), joinUrl: ""))
+    }
+
+    func testLaunchBrowserFollowerNoOpsWhenBrowserAlreadyRunning() throws {
+        let proc = SliccProcess()
+        let browser = makeBrowser()
+        let helper = try launchSleeper()
+        addTeardownBlock { if helper.isRunning { helper.terminate() } }
+        proc._testing_seedLaunchRecord(
+            id: browser.id,
+            process: helper,
+            targetType: .chromiumBrowser,
+            cdpPort: 39321,
+            servePort: 35821,
+            targetName: browser.name
+        )
+        XCTAssertTrue(proc.isRunning(browser))
+        // Already running → early return, never reaches the (test-unavailable)
+        // slicc-server spawn.
+        XCTAssertNoThrow(try proc.launchBrowserFollower(browser, joinUrl: "https://x.test/join/a.b"))
+    }
+
+    func testLeaderTargetNameIgnoresFollowerRecords() throws {
+        let proc = SliccProcess()
+        let follower = try launchSleeper()
+        addTeardownBlock { if follower.isRunning { follower.terminate() } }
+        proc._testing_seedLaunchRecord(
+            id: "follower",
+            process: follower,
+            targetType: .chromiumBrowser,
+            cdpPort: 39331,
+            servePort: 35831,
+            targetName: "FollowerBrowser",
+            isFollower: true
+        )
+        XCTAssertNil(proc.leaderTargetName)
+
+        let leader = try launchSleeper()
+        addTeardownBlock { if leader.isRunning { leader.terminate() } }
+        proc._testing_seedLaunchRecord(
+            id: "leader",
+            process: leader,
+            targetType: .chromiumBrowser,
+            cdpPort: 39332,
+            servePort: 35832,
+            targetName: "LeaderBrowser"
+        )
+        XCTAssertEqual(proc.leaderTargetName, "LeaderBrowser")
+    }
+
     // MARK: - Helpers
+
+    private func makeBrowser() -> AppTarget {
+        let path = "/Applications/Sliccstart-Test-Browser-\(UUID().uuidString).app"
+        return AppTarget(
+            id: path,
+            name: "TestBrowser",
+            path: path,
+            executablePath: "\(path)/Contents/MacOS/TestBrowser",
+            type: .chromiumBrowser,
+            icon: NSImage(size: NSSize(width: 1, height: 1)),
+            debugSupport: .unknown,
+            isDebugBuild: false,
+            originalAppPath: nil,
+            bundleId: "com.test.browser"
+        )
+    }
 
     private func makeElectron() -> AppTarget {
         // Synthetic path that won't match any installed app — keeps

--- a/packages/swift-launcher/SliccstartTests/SliccProcessLeaderGatingTests.swift
+++ b/packages/swift-launcher/SliccstartTests/SliccProcessLeaderGatingTests.swift
@@ -62,6 +62,28 @@ final class SliccProcessLeaderGatingTests: XCTestCase {
         )
     }
 
+    func testFollowerBrowserDoesNotCountAsLeader() throws {
+        let proc = SliccProcess()
+        let helper = try launchSleeper()
+        addTeardownBlock { if helper.isRunning { helper.terminate() } }
+        proc._testing_seedLaunchRecord(
+            id: "follower-1",
+            process: helper,
+            targetType: .chromiumBrowser,
+            cdpPort: 39222,
+            servePort: 35710,
+            targetName: "FollowerBrowser",
+            isFollower: true
+        )
+        proc.leaderJoinUrl = nil
+
+        XCTAssertFalse(proc.isLeaderReady(), "a --join follower browser must not gate as this device's leader")
+        XCTAssertEqual(
+            proc.runtimeState(for: makeElectron(), hasAppManagementPermission: true),
+            .cannotStart(.needsLeader)
+        )
+    }
+
     func testStopAllClearsLeaderJoinUrl() throws {
         let proc = SliccProcess()
         let helper = try launchSleeper()

--- a/packages/swift-launcher/SliccstartTests/StartupPreferenceTests.swift
+++ b/packages/swift-launcher/SliccstartTests/StartupPreferenceTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+@testable import Sliccstart
+
+/// Migration of the legacy per-browser `autoLaunchAppId` picker into the new
+/// `launchBrowserAtStartup` boolean checkbox.
+final class StartupPreferenceTests: XCTestCase {
+
+    private func makeDefaults() -> UserDefaults {
+        let suite = "StartupPreferenceTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    func testDefaultsToDisabledWithNoLegacyValue() {
+        let defaults = makeDefaults()
+        XCTAssertFalse(StartupPreference.resolveEnabled(defaults: defaults))
+        XCTAssertFalse(defaults.bool(forKey: StartupPreference.enabledKey))
+    }
+
+    func testMigratesNonEmptyLegacyIdToEnabled() {
+        let defaults = makeDefaults()
+        defaults.set("/Applications/Google Chrome.app", forKey: autoLaunchAppIdKey)
+        XCTAssertTrue(StartupPreference.resolveEnabled(defaults: defaults))
+        XCTAssertTrue(defaults.bool(forKey: StartupPreference.enabledKey))
+    }
+
+    func testMigratesEmptyLegacyIdToDisabled() {
+        let defaults = makeDefaults()
+        defaults.set("", forKey: autoLaunchAppIdKey)
+        XCTAssertFalse(StartupPreference.resolveEnabled(defaults: defaults))
+    }
+
+    func testExistingBooleanWinsOverLegacy() {
+        let defaults = makeDefaults()
+        defaults.set("/Applications/Google Chrome.app", forKey: autoLaunchAppIdKey)
+        defaults.set(false, forKey: StartupPreference.enabledKey)
+        XCTAssertFalse(StartupPreference.resolveEnabled(defaults: defaults))
+    }
+}

--- a/packages/swift-launcher/SliccstartTests/TraySessionSyncTests.swift
+++ b/packages/swift-launcher/SliccstartTests/TraySessionSyncTests.swift
@@ -171,6 +171,28 @@ final class TraySessionSyncTests: XCTestCase {
         XCTAssertFalse(TraySessionSyncStore.currentDeviceName().isEmpty)
     }
 
+    func testTraySessionRowSubtitle() {
+        let now = Date()
+        XCTAssertEqual(
+            TraySessionRow.subtitle(
+                isLocal: true,
+                deviceName: "Ignored",
+                lastSeenAt: now,
+                now: now
+            ),
+            "This device · just now"
+        )
+        XCTAssertEqual(
+            TraySessionRow.subtitle(
+                isLocal: false,
+                deviceName: "MacBook",
+                lastSeenAt: now.addingTimeInterval(-120),
+                now: now
+            ),
+            "MacBook · 2m ago"
+        )
+    }
+
     func testPublishIgnoresEmptyJoinURL() {
         let store = makeStore(deviceName: "MacA")
         store.publish(joinUrl: "", label: "Chrome")
@@ -182,6 +204,56 @@ final class TraySessionSyncTests: XCTestCase {
         store.publish(joinUrl: "https://slicc.test/join/a.secret", label: "Chrome")
         store.withdraw(joinUrl: "https://slicc.test/join/does-not-exist.secret")
         XCTAssertEqual(store.sessions.count, 1)
+    }
+
+    func testReloadIgnoresCorruptPayload() {
+        let backend = InMemoryKeyValueBackend()
+        backend.setData(
+            Data("not-json".utf8),
+            forKey: TraySessionSyncStore.storageKeyPrefix + "corrupt"
+        )
+        let store = TraySessionSyncStore(backend: backend, deviceId: "MacA", deviceName: "MacA")
+        XCTAssertTrue(store.sessions.isEmpty)
+    }
+
+    func testCurrentDeviceIdMintsOnceAndPersists() {
+        let suite = UserDefaults(suiteName: "SliccstartTest-\(UUID().uuidString)")!
+        let first = TraySessionSyncStore.currentDeviceId(defaults: suite)
+        XCTAssertFalse(first.isEmpty)
+        // Second call reads the persisted value rather than minting a new one.
+        XCTAssertEqual(TraySessionSyncStore.currentDeviceId(defaults: suite), first)
+    }
+
+    func testStoreReloadsOnExternalChangeThenTearsDownObserver() throws {
+        let backend = ObservableTestBackend()
+        var store: TraySessionSyncStore? = TraySessionSyncStore(
+            backend: backend,
+            deviceId: "devLocal",
+            deviceName: "MacLocal"
+        )
+        XCTAssertEqual(store?.remoteSessions.count, 0)
+
+        let remote = SyncedTraySession(
+            joinUrl: "https://slicc.test/join/r.secret",
+            label: "Chrome",
+            deviceId: "devRemote",
+            deviceName: "MacRemote",
+            createdAt: Date(),
+            lastSeenAt: Date()
+        )
+        backend.setData(
+            try JSONEncoder().encode([remote]),
+            forKey: TraySessionSyncStore.storageKeyPrefix + "devRemote"
+        )
+
+        NotificationCenter.default.post(name: ObservableTestBackend.changeName, object: nil)
+        // The observer reloads on the main queue; pump the run loop so it runs.
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+        XCTAssertEqual(store?.remoteSessions.count, 1)
+
+        // Dropping the last reference runs `deinit`, removing the observer.
+        store = nil
+        XCTAssertNil(store)
     }
 
     // MARK: - Age formatting
@@ -267,5 +339,23 @@ final class TraySessionSyncTests: XCTestCase {
             isDebugBuild: false,
             originalAppPath: nil
         )
+    }
+}
+
+/// In-memory backend that also advertises an `externalChange` notification, so
+/// the store's observer registration/teardown path (which the iCloud backend
+/// drives in production) is exercisable without touching iCloud.
+private final class ObservableTestBackend: KeyValueSyncBackend {
+    static let changeName = Notification.Name("SliccstartTest.kvChanged")
+    private var storage: [String: Data] = [:]
+
+    func data(forKey key: String) -> Data? { storage[key] }
+    func setData(_ data: Data?, forKey key: String) { storage[key] = data }
+    func keys(withPrefix prefix: String) -> [String] {
+        storage.keys.filter { $0.hasPrefix(prefix) }
+    }
+    @discardableResult func synchronize() -> Bool { true }
+    var externalChange: (name: Notification.Name, object: AnyObject?)? {
+        (Self.changeName, nil)
     }
 }

--- a/packages/swift-launcher/SliccstartTests/TraySessionSyncTests.swift
+++ b/packages/swift-launcher/SliccstartTests/TraySessionSyncTests.swift
@@ -1,0 +1,192 @@
+import AppKit
+import XCTest
+
+@testable import Sliccstart
+
+@MainActor
+final class TraySessionSyncTests: XCTestCase {
+    // MARK: - Model
+
+    func testSessionDerivesIdentityFromJoinURL() {
+        let session = makeSession(joinUrl: "https://slicc.test/join/abc.secret")
+        XCTAssertEqual(session.id, "https://slicc.test/join/abc.secret")
+        XCTAssertEqual(SyncedTraySession.identifier(forJoinUrl: session.joinUrl), session.id)
+    }
+
+    func testSessionCodableRoundTrip() throws {
+        let session = makeSession(joinUrl: "https://slicc.test/join/x.secret")
+        let data = try JSONEncoder().encode(session)
+        let decoded = try JSONDecoder().decode(SyncedTraySession.self, from: data)
+        XCTAssertEqual(decoded, session)
+    }
+
+    func testIsStaleUsesTTLAgainstLastSeen() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let session = makeSession(joinUrl: "https://slicc.test/join/x.secret", lastSeenAt: now)
+        XCTAssertFalse(session.isStale(ttl: 60, now: now.addingTimeInterval(59)))
+        XCTAssertTrue(session.isStale(ttl: 60, now: now.addingTimeInterval(61)))
+    }
+
+    // MARK: - Store
+
+    func testPublishAddsLocalSession() {
+        let store = makeStore(deviceName: "MacA")
+        store.publish(joinUrl: "https://slicc.test/join/a.secret", label: "Chrome")
+
+        XCTAssertEqual(store.sessions.count, 1)
+        XCTAssertEqual(store.localSessions.map(\.label), ["Chrome"])
+        XCTAssertEqual(store.localSessions.first?.deviceName, "MacA")
+        XCTAssertTrue(store.remoteSessions.isEmpty)
+    }
+
+    func testRepublishUpsertsAndPreservesCreatedAt() {
+        var now = Date(timeIntervalSince1970: 1_000)
+        let store = makeStore(deviceName: "MacA", clock: { now })
+        store.publish(joinUrl: "https://slicc.test/join/a.secret", label: "Chrome")
+        let created = store.localSessions.first?.createdAt
+
+        now = now.addingTimeInterval(120)
+        store.publish(joinUrl: "https://slicc.test/join/a.secret", label: "Chrome (renamed)")
+
+        XCTAssertEqual(store.sessions.count, 1)
+        XCTAssertEqual(store.localSessions.first?.label, "Chrome (renamed)")
+        XCTAssertEqual(store.localSessions.first?.createdAt, created)
+        XCTAssertEqual(store.localSessions.first?.lastSeenAt, now)
+    }
+
+    func testWithdrawRemovesSession() {
+        let store = makeStore(deviceName: "MacA")
+        store.publish(joinUrl: "https://slicc.test/join/a.secret", label: "Chrome")
+        store.withdraw(joinUrl: "https://slicc.test/join/a.secret")
+        XCTAssertTrue(store.sessions.isEmpty)
+    }
+
+    func testWithdrawLocalSessionsLeavesRemoteIntact() {
+        let backend = InMemoryKeyValueBackend()
+        let deviceA = makeStore(deviceName: "MacA", backend: backend)
+        deviceA.publish(joinUrl: "https://slicc.test/join/a.secret", label: "Chrome")
+
+        let deviceB = makeStore(deviceName: "MacB", backend: backend)
+        deviceB.publish(joinUrl: "https://slicc.test/join/b.secret", label: "Edge")
+
+        deviceB.withdrawLocalSessions()
+        deviceB.reload()
+
+        XCTAssertEqual(deviceB.localSessions.count, 0)
+        XCTAssertEqual(deviceB.remoteSessions.map(\.label), ["Chrome"])
+    }
+
+    func testOtherDeviceSessionSurfacesAsRemote() {
+        let backend = InMemoryKeyValueBackend()
+        let deviceA = makeStore(deviceName: "MacA", backend: backend)
+        deviceA.publish(joinUrl: "https://slicc.test/join/a.secret", label: "Chrome")
+
+        let deviceB = makeStore(deviceName: "MacB", backend: backend)
+        deviceB.reload()
+
+        XCTAssertEqual(deviceB.remoteSessions.map(\.deviceName), ["MacA"])
+        XCTAssertTrue(deviceB.localSessions.isEmpty)
+    }
+
+    func testStaleSessionsArePrunedOnReload() {
+        var now = Date(timeIntervalSince1970: 1_000)
+        let store = makeStore(deviceName: "MacA", ttl: 60, clock: { now })
+        store.publish(joinUrl: "https://slicc.test/join/a.secret", label: "Chrome")
+        XCTAssertEqual(store.sessions.count, 1)
+
+        now = now.addingTimeInterval(61)
+        store.reload()
+        XCTAssertTrue(store.sessions.isEmpty)
+    }
+
+    func testActiveSortsNewestFirstAndCaps() {
+        let base = Date(timeIntervalSince1970: 1_000_000)
+        let raw = (0..<(TraySessionSyncStore.maxSessions + 5)).map { index in
+            makeSession(
+                joinUrl: "https://slicc.test/join/\(index).secret",
+                lastSeenAt: base.addingTimeInterval(TimeInterval(index))
+            )
+        }
+        let now = base.addingTimeInterval(TimeInterval(raw.count))
+        let capped = TraySessionSyncStore.active(from: raw, ttl: .greatestFiniteMagnitude, now: now)
+
+        XCTAssertEqual(capped.count, TraySessionSyncStore.maxSessions)
+        XCTAssertGreaterThan(capped[0].lastSeenAt, capped[1].lastSeenAt)
+    }
+
+    // MARK: - Age formatting
+
+    func testAgeFormatting() {
+        let now = Date(timeIntervalSince1970: 100_000)
+        XCTAssertEqual(TraySessionRow.age(of: now, now: now), "just now")
+        XCTAssertEqual(TraySessionRow.age(of: now.addingTimeInterval(-120), now: now), "2m ago")
+        XCTAssertEqual(TraySessionRow.age(of: now.addingTimeInterval(-7200), now: now), "2h ago")
+        XCTAssertEqual(TraySessionRow.age(of: now.addingTimeInterval(-172_800), now: now), "2d ago")
+    }
+
+    // MARK: - Remote follow override
+
+    func testTerminalFollowerUsesOverrideWithoutLocalLeader() async throws {
+        var launchedCommand: String?
+        let service = TerminalFollowerLaunchService(
+            findCliBinary: { "/usr/local/bin/slicc" },
+            downloadCli: { _ in URL(fileURLWithPath: "/unused") },
+            resolveLoginShell: { "/bin/zsh" },
+            loadTemplate: { FollowCommandTemplate.defaultTemplate },
+            launchTerminal: { _, command in launchedCommand = command }
+        )
+        let process = SliccProcess(terminalFollowerLaunchService: service)
+        // No leader seeded and leaderJoinUrl is nil — the override must still
+        // drive a follower attaching to the remote leader.
+        XCTAssertFalse(process.isLeaderReady())
+
+        try await process.launchTerminalFollower(
+            terminalTarget(),
+            joinURLOverride: "https://remote.test/join/token.secret"
+        )
+
+        XCTAssertEqual(
+            launchedCommand,
+            "/usr/local/bin/slicc https://remote.test/join/token.secret follow /bin/zsh -c"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeStore(
+        deviceName: String,
+        backend: KeyValueSyncBackend = InMemoryKeyValueBackend(),
+        ttl: TimeInterval = TraySessionSyncStore.defaultTTL,
+        clock: @escaping () -> Date = Date.init
+    ) -> TraySessionSyncStore {
+        TraySessionSyncStore(backend: backend, deviceName: deviceName, ttl: ttl, clock: clock)
+    }
+
+    private func makeSession(
+        joinUrl: String,
+        deviceName: String = "MacA",
+        lastSeenAt: Date = Date(timeIntervalSince1970: 0)
+    ) -> SyncedTraySession {
+        SyncedTraySession(
+            joinUrl: joinUrl,
+            label: "Chrome",
+            deviceName: deviceName,
+            createdAt: lastSeenAt,
+            lastSeenAt: lastSeenAt
+        )
+    }
+
+    private func terminalTarget() -> AppTarget {
+        AppTarget(
+            id: UUID().uuidString,
+            name: "Terminal",
+            path: "/Applications/Terminal.app",
+            executablePath: "/Applications/Terminal.app/Contents/MacOS/Terminal",
+            type: .terminal,
+            icon: NSImage(),
+            debugSupport: .unknown,
+            isDebugBuild: false,
+            originalAppPath: nil
+        )
+    }
+}

--- a/packages/swift-launcher/SliccstartTests/TraySessionSyncTests.swift
+++ b/packages/swift-launcher/SliccstartTests/TraySessionSyncTests.swift
@@ -167,6 +167,23 @@ final class TraySessionSyncTests: XCTestCase {
         XCTAssertEqual(decoded.deviceName, "MacA")
     }
 
+    func testCurrentDeviceNameIsNonEmpty() {
+        XCTAssertFalse(TraySessionSyncStore.currentDeviceName().isEmpty)
+    }
+
+    func testPublishIgnoresEmptyJoinURL() {
+        let store = makeStore(deviceName: "MacA")
+        store.publish(joinUrl: "", label: "Chrome")
+        XCTAssertTrue(store.sessions.isEmpty)
+    }
+
+    func testWithdrawUnknownJoinURLIsNoOp() {
+        let store = makeStore(deviceName: "MacA")
+        store.publish(joinUrl: "https://slicc.test/join/a.secret", label: "Chrome")
+        store.withdraw(joinUrl: "https://slicc.test/join/does-not-exist.secret")
+        XCTAssertEqual(store.sessions.count, 1)
+    }
+
     // MARK: - Age formatting
 
     func testAgeFormatting() {

--- a/packages/swift-launcher/SliccstartTests/TraySessionSyncTests.swift
+++ b/packages/swift-launcher/SliccstartTests/TraySessionSyncTests.swift
@@ -7,10 +7,15 @@ import XCTest
 final class TraySessionSyncTests: XCTestCase {
     // MARK: - Model
 
-    func testSessionDerivesIdentityFromJoinURL() {
-        let session = makeSession(joinUrl: "https://slicc.test/join/abc.secret")
-        XCTAssertEqual(session.id, "https://slicc.test/join/abc.secret")
-        XCTAssertEqual(SyncedTraySession.identifier(forJoinUrl: session.joinUrl), session.id)
+    func testSessionIdentityIsAnOpaqueHashOfJoinURL() {
+        let joinUrl = "https://slicc.test/join/abc.secret"
+        let session = makeSession(joinUrl: joinUrl)
+        // Stable, derived from the join URL, but not the join URL itself — so
+        // it is safe to use in accessibility identifiers / telemetry.
+        XCTAssertEqual(session.id, SyncedTraySession.identifier(forJoinUrl: joinUrl))
+        XCTAssertNotEqual(session.id, joinUrl)
+        XCTAssertFalse(session.id.contains("secret"))
+        XCTAssertEqual(session.id.count, 64)  // SHA-256 hex
     }
 
     func testSessionCodableRoundTrip() throws {
@@ -114,6 +119,54 @@ final class TraySessionSyncTests: XCTestCase {
         XCTAssertGreaterThan(capped[0].lastSeenAt, capped[1].lastSeenAt)
     }
 
+    func testSameHostNameDevicesStayDistinctByDeviceId() {
+        let backend = InMemoryKeyValueBackend()
+        // Two Macs both named "MacBook Pro" but with distinct persisted UUIDs.
+        let deviceA = makeStore(deviceName: "MacBook Pro", deviceId: "uuid-a", backend: backend)
+        deviceA.publish(joinUrl: "https://slicc.test/join/a.secret", label: "Chrome")
+        let deviceB = makeStore(deviceName: "MacBook Pro", deviceId: "uuid-b", backend: backend)
+        deviceB.publish(joinUrl: "https://slicc.test/join/b.secret", label: "Edge")
+
+        deviceB.reload()
+        XCTAssertEqual(deviceB.localSessions.map(\.label), ["Edge"])
+        XCTAssertEqual(deviceB.remoteSessions.map(\.label), ["Chrome"])
+
+        // Withdrawing on B must not delete A's advertisement.
+        deviceB.withdrawLocalSessions()
+        deviceA.reload()
+        XCTAssertEqual(deviceA.localSessions.map(\.label), ["Chrome"])
+    }
+
+    func testConcurrentPublishDoesNotClobber() {
+        let backend = InMemoryKeyValueBackend()
+        let deviceA = makeStore(deviceName: "MacA", backend: backend)
+        let deviceB = makeStore(deviceName: "MacB", backend: backend)
+
+        deviceA.publish(joinUrl: "https://slicc.test/join/a.secret", label: "Chrome")
+        deviceB.publish(joinUrl: "https://slicc.test/join/b.secret", label: "Edge")
+
+        deviceA.reload()
+        XCTAssertEqual(Set(deviceA.sessions.map(\.label)), ["Chrome", "Edge"])
+    }
+
+    func testCurrentDeviceIdIsMintedOnceAndStable() {
+        let defaults = UserDefaults(suiteName: "TraySyncDeviceId-\(UUID().uuidString)")!
+        let first = TraySessionSyncStore.currentDeviceId(defaults: defaults)
+        let second = TraySessionSyncStore.currentDeviceId(defaults: defaults)
+        XCTAssertFalse(first.isEmpty)
+        XCTAssertEqual(first, second)
+    }
+
+    func testLegacyPayloadWithoutDeviceIdDecodes() throws {
+        let legacy = """
+            {"id":"abc","joinUrl":"https://slicc.test/join/x.secret","label":"Chrome",\
+            "deviceName":"MacA","createdAt":0,"lastSeenAt":0}
+            """
+        let decoded = try JSONDecoder().decode(SyncedTraySession.self, from: Data(legacy.utf8))
+        XCTAssertEqual(decoded.deviceId, "")
+        XCTAssertEqual(decoded.deviceName, "MacA")
+    }
+
     // MARK: - Age formatting
 
     func testAgeFormatting() {
@@ -155,21 +208,30 @@ final class TraySessionSyncTests: XCTestCase {
 
     private func makeStore(
         deviceName: String,
+        deviceId: String? = nil,
         backend: KeyValueSyncBackend = InMemoryKeyValueBackend(),
         ttl: TimeInterval = TraySessionSyncStore.defaultTTL,
         clock: @escaping () -> Date = Date.init
     ) -> TraySessionSyncStore {
-        TraySessionSyncStore(backend: backend, deviceName: deviceName, ttl: ttl, clock: clock)
+        TraySessionSyncStore(
+            backend: backend,
+            deviceId: deviceId ?? deviceName,
+            deviceName: deviceName,
+            ttl: ttl,
+            clock: clock
+        )
     }
 
     private func makeSession(
         joinUrl: String,
+        deviceId: String = "MacA",
         deviceName: String = "MacA",
         lastSeenAt: Date = Date(timeIntervalSince1970: 0)
     ) -> SyncedTraySession {
         SyncedTraySession(
             joinUrl: joinUrl,
             label: "Chrome",
+            deviceId: deviceId,
             deviceName: deviceName,
             createdAt: lastSeenAt,
             lastSeenAt: lastSeenAt

--- a/packages/swift-launcher/macos-permissions.test.mjs
+++ b/packages/swift-launcher/macos-permissions.test.mjs
@@ -21,3 +21,23 @@ describe('Sliccstart Apple Events packaging', () => {
     expect(signingScript).toContain('ENTITLEMENTS="$SCRIPT_DIR/Sliccstart.entitlements"');
   });
 });
+
+describe('Sliccstart iCloud sync packaging', () => {
+  it('embeds the provisioning profile only when PROVISION_PROFILE is supplied', () => {
+    expect(signingScript).toContain('if [ -n "${PROVISION_PROFILE:-}" ]; then');
+    expect(signingScript).toContain('Contents/embedded.provisionprofile');
+  });
+
+  it('defaults the kvstore identifier to the team-prefixed bundle id, overridable via KVSTORE_IDENTIFIER', () => {
+    expect(signingScript).toContain(
+      'KVSTORE_IDENTIFIER="${KVSTORE_IDENTIFIER:-${APPLE_TEAM_ID}.com.slicc.sliccstart}"'
+    );
+    expect(signingScript).toContain(
+      'com.apple.developer.ubiquity-kvstore-identifier string ${KVSTORE_IDENTIFIER}'
+    );
+  });
+
+  it('fails fast when PROVISION_PROFILE points at a missing file', () => {
+    expect(signingScript).toContain('ERROR: PROVISION_PROFILE set but file not found');
+  });
+});

--- a/packages/swift-launcher/sign-and-package.sh
+++ b/packages/swift-launcher/sign-and-package.sh
@@ -24,6 +24,38 @@ if [ -n "${APPLE_TEAM_ID:-}" ]; then
   # Sign nested executables first, then the outer app
   codesign --force --options runtime --sign "$IDENTITY" --timestamp \
     "$APP_DIR/Contents/Resources/slicc-server"
+
+  # iCloud key-value sync (cross-device tray sessions) needs an embedded
+  # Developer ID provisioning profile that authorizes the ubiquity-kvstore
+  # entitlement. When PROVISION_PROFILE points at that profile we embed it and
+  # sign against a merged entitlements file (base + iCloud KVS). Without it we
+  # sign against the base entitlements only, and the app degrades to a local
+  # key-value cache (no sync) — so CI stays green until the profile secret
+  # exists.
+  if [ -n "${PROVISION_PROFILE:-}" ]; then
+    if [ ! -f "$PROVISION_PROFILE" ]; then
+      echo "ERROR: PROVISION_PROFILE set but file not found: $PROVISION_PROFILE" >&2
+      exit 1
+    fi
+    echo "Embedding provisioning profile for iCloud sync..."
+    cp "$PROVISION_PROFILE" "$APP_DIR/Contents/embedded.provisionprofile"
+    # The key-value sync bucket namespace. Defaults to the team-prefixed
+    # bundle id (what the auto-generated profile pins). Override with
+    # KVSTORE_IDENTIFIER to use a brand-neutral, cross-app value the iOS
+    # follower can share (e.g. S8LB56P782.ai.sliccy.trays) — the outer
+    # codesign will fail fast if the embedded profile does not authorize it.
+    KVSTORE_IDENTIFIER="${KVSTORE_IDENTIFIER:-${APPLE_TEAM_ID}.com.slicc.sliccstart}"
+    MERGED_ENTITLEMENTS="$SCRIPT_DIR/build/Sliccstart.icloud.entitlements"
+    cp "$ENTITLEMENTS" "$MERGED_ENTITLEMENTS"
+    /usr/libexec/PlistBuddy -c \
+      "Add :com.apple.developer.ubiquity-kvstore-identifier string ${KVSTORE_IDENTIFIER}" \
+      "$MERGED_ENTITLEMENTS" 2>/dev/null \
+      || /usr/libexec/PlistBuddy -c \
+        "Set :com.apple.developer.ubiquity-kvstore-identifier ${KVSTORE_IDENTIFIER}" \
+        "$MERGED_ENTITLEMENTS"
+    ENTITLEMENTS="$MERGED_ENTITLEMENTS"
+  fi
+
   codesign --force --options runtime --entitlements "$ENTITLEMENTS" \
     --sign "$IDENTITY" --timestamp "$APP_DIR"
 


### PR DESCRIPTION
## Summary

Sliccstart now syncs active tray join URLs across a user's devices over iCloud, so a leader started on one Mac appears on another without hand-copying the join URL. Also redesigns the launcher list: default ordering + drag-reorder, browser-as-follower, and an enriched iCloud Sessions section.

## Why

Adding a SLICC instance to a tray on a second machine meant manually copying a secret-bearing join URL. Syncing the active session list removes that friction. The data model is Foundation-only so the iOS follower can reuse it later.

## Approach / Implementation notes

- **Sync store**: `NSUbiquitousKeyValueStore` behind an injectable `KeyValueSyncBackend` protocol so tests never touch iCloud (`InMemoryKeyValueBackend`). `TraySessionSyncStore` prunes stale entries (12h TTL), caps at 64 sessions, and observes `didChangeExternallyNotification`. `SyncedTraySession.id` is derived from the join URL so republish upserts and two devices watching one tray collapse to a single entry.
- **Producer/consumer**: `SliccstartApp` publishes on `leaderJoinUrl` becoming non-nil and withdraws when it clears; `AppListView` lists remote/local sessions.
- **Signing (non-breaking)**: `sign-and-package.sh` embeds a provisioning profile + merged entitlements only when `PROVISION_PROFILE` is set; the KVS bucket namespace is overridable via `KVSTORE_IDENTIFIER`. Unset (incl. current CI) signs base entitlements only and degrades to a local cache, so CI stays green until the profile secret exists.
- **List redesign**: `AppOrdering` supplies market-share browser / power-user terminal defaults; `AppOrderStore` persists a drag-reorder. Browser-as-follower launches via `--join` and flags the `LaunchRecord` `isFollower` so it never counts as this device's leader (excluded from `isLeaderReady`, leader-URL clearing, reattach). Clicking a browser with remote sessions opens a lead-vs-attach dialog. Startup tab is now a checkbox launching the top browser, migrating the legacy `autoLaunchAppId` picker.

## Cross-cutting impact

- **Floats exercised**: Sliccstart (macOS launcher) only. The browser-follower path reuses swift-server's existing `--join` launch URL (same as the Electron/terminal follower contract); no server changes.
- **Persisted state**: adds UserDefaults keys `browserOrder`, `terminalOrder`, `launchBrowserAtStartup`; migrates legacy `autoLaunchAppId`. New iCloud KVS bucket keyed by `KVSTORE_IDENTIFIER`.
- **Security**: join URLs carry the session secret and sync only through the user's own (encrypted, same-Apple-ID) iCloud KVS; error reporting already redacts URLs.

## Test plan

- [x] `cd packages/swift-launcher && swift build` — clean
- [x] `swift test` — 291 passing, no new failures (adds `AppOrderingTests`, `StartupPreferenceTests`, `TraySessionSyncTests`, browser-follower args + follower-gating coverage)
- [x] `npm run lint -w @slicc/swift-launcher` — 0 serious violations
- [x] `npm run lint:format -w @slicc/swift-launcher` — clean
- [x] `npx vitest run packages/swift-launcher/macos-permissions.test.mjs` — signing contract covered
- [ ] Manual two-device iCloud smoke — verified previously against a signed+notarized build (`KVSTORE_IDENTIFIER=S8LB56P782.ai.sliccy.trays`); session appeared and join URL was copyable on the second Mac.

## Documentation

- [x] Relevant `CLAUDE.md` (`packages/swift-launcher/CLAUDE.md`)

## Risk & rollback

- Blast radius: single float (Sliccstart). Revert this PR cleanly; no data migration to undo beyond harmless new UserDefaults keys. Without the provisioning-profile secret the sync silently degrades to a local cache, so an unsigned/CI build is unaffected.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets or credentials in the diff (team id `S8LB56P782` is a public identifier already in the repo)
- [x] Follower wiring checked (browser follower reuses the existing `--join` contract; `isFollower` keeps leader gating correct)