### PR TITLE
fix(webapp): sync git-shim token on fresh externally-injected GitHub accounts

### DIFF
--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -346,6 +346,23 @@ async function clearGitToken(): Promise<void> {
   }
 }
 
+/**
+ * Sync the current account's masked value into the git-shim bridge file.
+ * Shared by the interactive login/renewal flows AND `getValidAccessToken`
+ * (called by `ensureFreshGithubToken` before every network git op) so a
+ * token injected via `saveOAuthAccount` — e.g. a hosted cone's
+ * `coneConfigDelta` upsert of a GitHub App installation token — reaches
+ * the file isomorphic-git actually reads, not just the account store.
+ */
+async function syncGitToken(): Promise<void> {
+  const masked = getOAuthAccountInfo('github')?.maskedValue;
+  if (masked) {
+    await writeGitToken(masked);
+  } else {
+    await clearGitToken();
+  }
+}
+
 // ── Git identity bridge ────────────────────────────────────────────
 
 /**
@@ -416,12 +433,7 @@ async function renewGitHubToken(): Promise<string | null> {
       userAvatar: account.userAvatar,
     });
 
-    const masked = getOAuthAccountInfo('github')?.maskedValue;
-    if (masked) {
-      await writeGitToken(masked);
-    } else {
-      await clearGitToken();
-    }
+    await syncGitToken();
     return tokenResult.access_token;
   } catch (err) {
     console.warn(
@@ -437,7 +449,15 @@ async function getValidAccessToken(): Promise<string> {
   if (!account?.accessToken) throw new Error('Not logged in to GitHub — please log in first');
 
   const expiresIn = (account.tokenExpiresAt ?? Number.POSITIVE_INFINITY) - Date.now();
-  if (expiresIn > 60000) return account.accessToken;
+  if (expiresIn > 60000) {
+    // Re-sync the git-shim bridge file even when the account's own token is
+    // still fresh: a hosted cone's `coneConfigDelta` upsert (GitHub App
+    // installation token, no refresh token) writes straight to the account
+    // store via `saveOAuthAccount` and never goes through the interactive
+    // login/renewal paths that normally call `writeGitToken`.
+    await syncGitToken();
+    return account.accessToken;
+  }
 
   const newToken = await silentRenewBackoff.run(() => renewGitHubToken());
   if (newToken) return newToken;
@@ -566,13 +586,7 @@ export const config: ProviderConfig = {
     });
 
     // Bridge token to isomorphic-git — use the masked value, not the real token
-    const info = getOAuthAccountInfo('github');
-    const masked = info?.maskedValue;
-    if (masked) {
-      await writeGitToken(masked);
-    } else {
-      await clearGitToken();
-    }
+    await syncGitToken();
 
     // Seed git user.name / user.email so commits are attributed to the
     // authenticated GitHub identity instead of the placeholder

--- a/packages/webapp/tests/providers/github-token-renewal.test.ts
+++ b/packages/webapp/tests/providers/github-token-renewal.test.ts
@@ -200,4 +200,28 @@ describe('GitHub token renewal', () => {
 
     await expect(getValidAccessToken()).resolves.toBe('ghp_new_access');
   });
+
+  it('syncs the git-token bridge for a fresh externally-injected token with no refresh token', async () => {
+    // Mirrors a hosted cone's coneConfigDelta upsert: a GitHub App
+    // installation token landed via saveOAuthAccount with a full fresh
+    // expiry and no refreshToken, bypassing the interactive login/renewal
+    // paths that normally call writeGitToken.
+    seedGitHubAccount({
+      accessToken: 'ghs_installation_token',
+      tokenExpiresAt: Date.now() + 3_600_000,
+      maskedValue: 'ghs_masked_installation',
+    });
+    globalThis.fetch = vi.fn() as typeof fetch;
+    const { getValidAccessToken } = await import('../../providers/github.js');
+    const { VirtualFS } = await import('../../src/fs/index.js');
+    const { GLOBAL_FS_DB_NAME } = await import('../../src/fs/global-db.js');
+
+    await expect(getValidAccessToken()).resolves.toBe('ghs_installation_token');
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+
+    const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+    await expect(fs.readFile('/workspace/.git/github-token', { encoding: 'utf-8' })).resolves.toBe(
+      'ghs_masked_installation'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- `getValidAccessToken`'s early-return branch (token not yet near expiry) never wrote `/workspace/.git/github-token`, so a GitHub account injected directly into the account store via `saveOAuthAccount` — e.g. a hosted cone's `coneConfigDelta` upsert of a GitHub App installation token on cone start/resume — never reached the file the git shim's `onAuth` actually reads for `git clone/fetch/pull/push`. Only the interactive OAuth login and refresh-token renewal paths called `writeGitToken`.
- Factored the masked-value sync into a shared `syncGitToken()` helper in `providers/github.ts` and call it from the login flow, the refresh-token renewal flow, and now also `getValidAccessToken`'s fresh-token early return — so `ensureFreshGithubToken()` (invoked before every network git op) keeps the bridge file in sync regardless of how the token got into the account store.

## Test plan
- [x] `npm run test -w @slicc/webapp -- packages/webapp/tests/providers/github-token-renewal.test.ts packages/webapp/tests/providers/github-provider.test.ts` — added a regression test seeding a fresh externally-injected token (mirroring a `ghs_*` installation token with no `refreshToken`) and asserting `getValidAccessToken()` writes it to the bridge file without any network call.
- [x] `npm run test -w @slicc/webapp` — full webapp suite (10,376 tests) passes.
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)