### PR TITLE
feat(webcomponents)!: replace waffle shader with Sugar Glass

### DIFF
--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -351,8 +351,8 @@ export function createWcLiveCallbacks(wiring: WcLiveWiring): OffscreenClientCall
 async function applyThreadContext(refs: WcShellRefs, scoop: RegisteredScoop): Promise<void> {
   refs.thread.setAttribute('context', scoop.isCone ? 'cone' : `scoop:${scoop.name}`);
   refs.thread.setAttribute('accent', scoopColor(scoop));
-  // The whole frame changes mood with the selection: waffle lattice + warm
-  // amber for the cone, swirling pastels + the scoop's accent for scoops.
+  // The whole frame changes mood with the selection: Caramel Sugar Glass for
+  // the cone, swirling pastels + the scoop's accent for scoops.
   applyShellContext(
     refs,
     scoop.isCone ? { kind: 'cone' } : { kind: 'scoop', accent: scoopColor(scoop) }

--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -366,7 +366,7 @@ export function mountWcShell(root: HTMLElement, options: WcShellOptions): WcShel
   ensureSystemTheme();
 
   const frame = el('div', { class: 'wcui-frame' });
-  const shader = el('slicc-shader', { mode: 'cone', tint: 'var(--waffle)', class: 'wcui-shader' });
+  const shader = el('slicc-shader', { mode: 'cone', class: 'wcui-shader' });
 
   const freezer = el('slicc-freezer');
   freezer.append(el('slicc-freezer-new'));
@@ -452,8 +452,8 @@ export type ShellContext =
   | { kind: 'freezer' };
 
 /**
- * Flip the whole frame between its three moods: cone (waffle lattice, warm
- * amber), scoop (swirling ice-cream pastels, the scoop's accent), freezer
+ * Flip the whole frame between its three moods: cone (Caramel Sugar Glass),
+ * scoop (swirling ice-cream pastels, the scoop's accent), freezer
  * (frost crystallizing, ice blue). Swaps the WebGL program via the shader's
  * `mode`, washes its `tint`, and drives the inherited `--ctx` context accent
  * so every token-driven surface (freezer chrome, composer band, badges)
@@ -462,8 +462,8 @@ export type ShellContext =
 export function applyShellContext(refs: WcShellRefs, context: ShellContext): void {
   const { shader, frame, freezer } = refs;
   if (context.kind === 'cone') {
+    shader.removeAttribute('tint');
     shader.setAttribute('mode', 'cone');
-    shader.setAttribute('tint', 'var(--waffle)');
     frame.style.removeProperty('--ctx');
     freezer.removeAttribute('ctx');
   } else if (context.kind === 'scoop') {

--- a/packages/webapp/tests/ui/wc/wc-shell.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-shell.test.ts
@@ -336,8 +336,9 @@ describe('mountWcUiPreview', () => {
       placeholder: 'p',
     });
 
-    // Cone (boot default): waffle lattice, warm amber, no --ctx override.
+    // Cone (boot default): Caramel Sugar Glass, default tint, no --ctx override.
     expect(refs.shader.getAttribute('mode')).toBe('cone');
+    expect(refs.shader.getAttribute('tint')).toBeNull();
 
     applyShellContext(refs, { kind: 'scoop', accent: '#06b6d4' });
     expect(refs.shader.getAttribute('mode')).toBe('scoop');
@@ -353,7 +354,7 @@ describe('mountWcUiPreview', () => {
 
     applyShellContext(refs, { kind: 'cone' });
     expect(refs.shader.getAttribute('mode')).toBe('cone');
-    expect(refs.shader.getAttribute('tint')).toBe('var(--waffle)');
+    expect(refs.shader.getAttribute('tint')).toBeNull();
     expect(refs.frame.style.getPropertyValue('--ctx')).toBe('');
     expect(refs.freezer.hasAttribute('ctx')).toBe(false);
   });

--- a/packages/webcomponents/src/freezer/slicc-shader.stories.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.stories.ts
@@ -12,20 +12,9 @@ interface ShaderArgs {
   speed: number;
 }
 
-const WAFFLE_CURRENT = {
-  mode: 'cone',
-  tint: '#b07823',
-  coverage: 0.66,
-  brightness: 1.2,
-  contrast: 0.75,
-  noise: 0.04,
-  blur: 0.09,
-  speed: 1,
-} as const satisfies Readonly<ShaderArgs>;
-
 const PRESET_LABELS: Readonly<Record<SugarGlassPresetName, string>> = {
   caramel: 'Caramel',
-  'caramel-waffle': 'Caramel-waffle-tone',
+  'caramel-soft': 'Caramel — soft tone',
   frosted: 'Frosted',
   brittle: 'Brittle',
   'waffle-glass': 'Waffle-glass',
@@ -211,7 +200,6 @@ function createStoryboard(interactive = false): HTMLElement {
   `;
   const grid = document.createElement('main');
   grid.className = 'storyboard-grid';
-  grid.appendChild(createStoryboardPanel('Waffle (current)', WAFFLE_CURRENT, interactive));
   for (const [name, preset] of Object.entries(SUGAR_GLASS_PRESETS)) {
     grid.appendChild(
       createStoryboardPanel(PRESET_LABELS[name as SugarGlassPresetName], preset, interactive)
@@ -226,7 +214,7 @@ const meta: Meta<ShaderArgs> = {
   component: 'slicc-shader',
   tags: ['autodocs'],
   argTypes: {
-    mode: { control: 'inline-radio', options: ['cone', 'scoop', 'freezer', 'sugar'] },
+    mode: { control: 'inline-radio', options: ['cone', 'scoop', 'freezer'] },
     tint: { control: 'color' },
     coverage: { control: { type: 'range', min: 0, max: 1, step: 0.05 } },
     brightness: { control: { type: 'range', min: 0.5, max: 1.5, step: 0.01 } },
@@ -254,16 +242,16 @@ export const Storyboard: Story = {
   render: () => createStoryboard(),
 };
 
-/** Six-up live comparison: every candidate owns an isolated control set. */
+/** Five-up live comparison: every retained preset owns an isolated control set. */
 export const Playground: Story = {
   name: 'PLAYGROUND',
   parameters: { layout: 'fullscreen', controls: { disable: true } },
   render: () => createStoryboard(true),
 };
 
-/** Cone — the sheared waffle lattice behind the cone/chat context. */
+/** Cone — the default Caramel Sugar Glass field behind the cone/chat context. */
 export const Cone: Story = {
-  args: { ...WAFFLE_CURRENT },
+  args: { mode: 'cone' },
 };
 /** Scoop — the flowing ice-cream swirl, tinted to the active scoop accent. */
 export const Scoop: Story = {
@@ -292,10 +280,8 @@ export const Freezer: Story = {
   },
 };
 
-/** Sugar Glass — warm amber cells and visible crack light. */
-export const Caramel: Story = { args: { ...SUGAR_GLASS_PRESETS.caramel } };
-/** Sugar Glass — Caramel color and texture with the current Waffle tone. */
-export const CaramelWaffle: Story = { args: { ...SUGAR_GLASS_PRESETS['caramel-waffle'] } };
+/** Sugar Glass — Caramel color and texture with a softer tone. */
+export const CaramelSoft: Story = { args: { ...SUGAR_GLASS_PRESETS['caramel-soft'] } };
 /** Sugar Glass — broad quiet seams tuned for prose legibility. */
 export const Frosted: Story = { args: { ...SUGAR_GLASS_PRESETS.frosted } };
 /** Sugar Glass — dense sharp fractures with low glass fill. */

--- a/packages/webcomponents/src/freezer/slicc-shader.stories.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import './slicc-shader.js';
+import { type ShaderMode, SUGAR_GLASS_PRESETS, type SugarGlassPresetName } from './slicc-shader.js';
 
 interface ShaderArgs {
-  mode: 'cone' | 'scoop' | 'freezer';
+  mode: ShaderMode;
   tint: string;
   coverage: number;
   brightness: number;
@@ -11,12 +11,105 @@ interface ShaderArgs {
   blur: number;
 }
 
+const WAFFLE_CURRENT = {
+  mode: 'cone',
+  tint: '#b07823',
+  coverage: 0.66,
+  brightness: 1.2,
+  contrast: 0.75,
+  noise: 0.04,
+  blur: 0.09,
+} as const satisfies Readonly<ShaderArgs>;
+
+const PRESET_LABELS: Readonly<Record<SugarGlassPresetName, string>> = {
+  caramel: 'Caramel',
+  frosted: 'Frosted',
+  brittle: 'Brittle',
+  'waffle-glass': 'Waffle-glass',
+};
+
+const CHAT_HEADING = 'Reviewing the assistant’s plan';
+const CHAT_PARAGRAPHS = [
+  'I traced the request through the current shell and found the smallest safe change. The existing conversation layout can stay in place while the background treatment is reviewed.',
+  'Next I would verify the result in both themes, read the final diff, and call out any remaining risk before asking you to choose a direction.',
+] as const;
+
+function applyShaderAttributes(shader: HTMLElement, args: Readonly<ShaderArgs>): void {
+  for (const [name, value] of Object.entries(args)) shader.setAttribute(name, String(value));
+}
+
+function createShader(args: Readonly<ShaderArgs>): HTMLElement {
+  const shader = document.createElement('slicc-shader');
+  shader.style.cssText = 'position:absolute;inset:0;';
+  applyShaderAttributes(shader, args);
+  return shader;
+}
+
+function attributeCaption(args: Readonly<ShaderArgs>): string {
+  return Object.entries(args)
+    .map(([name, value]) => `${name}=${value}`)
+    .join(' · ');
+}
+
+function createStoryboardPanel(label: string, args: Readonly<ShaderArgs>): HTMLElement {
+  const panel = document.createElement('article');
+  panel.className = 'storyboard-panel';
+  panel.appendChild(createShader(args));
+
+  const caption = document.createElement('header');
+  caption.className = 'storyboard-caption';
+  const title = document.createElement('h3');
+  title.textContent = label;
+  const attributes = document.createElement('p');
+  attributes.textContent = attributeCaption(args);
+  caption.append(title, attributes);
+
+  const prose = document.createElement('section');
+  prose.className = 'storyboard-prose';
+  const heading = document.createElement('h4');
+  heading.textContent = CHAT_HEADING;
+  prose.appendChild(heading);
+  for (const copy of CHAT_PARAGRAPHS) {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = copy;
+    prose.appendChild(paragraph);
+  }
+  panel.append(caption, prose);
+  return panel;
+}
+
+function createStoryboard(): HTMLElement {
+  const root = document.createElement('div');
+  root.className = 'storyboard-root';
+  const style = document.createElement('style');
+  style.textContent = `
+    .storyboard-root { width: 100%; min-width: 1276px; min-height: 608px; background: var(--canvas); color: var(--ink); }
+    .storyboard-grid { display: grid; grid-template-columns: repeat(3, minmax(420px, 1fr)); gap: 8px; }
+    .storyboard-panel { position: relative; box-sizing: border-box; min-width: 420px; height: 300px; overflow: hidden; border: 1px solid var(--line); background: var(--bg); color: var(--ink); }
+    .storyboard-caption, .storyboard-prose { position: relative; z-index: 1; }
+    .storyboard-caption { padding: 12px 16px 0; }
+    .storyboard-caption h3 { margin: 0 0 4px; font: 700 15px/1.25 system-ui, sans-serif; letter-spacing: 0.01em; }
+    .storyboard-caption p { margin: 0; color: var(--txt-2); font: 500 11px/1.35 ui-monospace, monospace; overflow-wrap: anywhere; }
+    .storyboard-prose { max-width: 48ch; padding: 15px 20px 18px; font: 400 15px/1.45 system-ui, sans-serif; }
+    .storyboard-prose h4 { margin: 0 0 8px; font: 700 17px/1.3 system-ui, sans-serif; }
+    .storyboard-prose p { margin: 0 0 8px; }
+  `;
+  const grid = document.createElement('main');
+  grid.className = 'storyboard-grid';
+  grid.appendChild(createStoryboardPanel('Waffle (current)', WAFFLE_CURRENT));
+  for (const [name, preset] of Object.entries(SUGAR_GLASS_PRESETS)) {
+    grid.appendChild(createStoryboardPanel(PRESET_LABELS[name as SugarGlassPresetName], preset));
+  }
+  root.append(style, grid);
+  return root;
+}
+
 const meta: Meta<ShaderArgs> = {
   title: 'Freezer/Shader',
   component: 'slicc-shader',
   tags: ['autodocs'],
   argTypes: {
-    mode: { control: 'inline-radio', options: ['cone', 'scoop', 'freezer'] },
+    mode: { control: 'inline-radio', options: ['cone', 'scoop', 'freezer', 'sugar'] },
     tint: { control: 'color' },
     coverage: { control: { type: 'range', min: 0, max: 1, step: 0.05 } },
     brightness: { control: { type: 'range', min: 0.5, max: 1.5, step: 0.01 } },
@@ -24,20 +117,11 @@ const meta: Meta<ShaderArgs> = {
     noise: { control: { type: 'range', min: 0, max: 0.3, step: 0.01 } },
     blur: { control: { type: 'range', min: 0, max: 1, step: 0.01 } },
   },
-  render: ({ mode, tint, coverage, brightness, contrast, noise, blur }) => {
+  render: (args) => {
     const box = document.createElement('div');
     box.style.cssText =
       'position:relative;width:520px;height:320px;border-radius:14px;overflow:hidden;border:1px solid var(--line);background:var(--bg);';
-    const s = document.createElement('slicc-shader');
-    s.style.cssText = 'position:absolute;inset:0;';
-    s.setAttribute('mode', mode);
-    if (tint) s.setAttribute('tint', tint);
-    if (coverage != null) s.setAttribute('coverage', String(coverage));
-    if (brightness != null) s.setAttribute('brightness', String(brightness));
-    if (contrast != null) s.setAttribute('contrast', String(contrast));
-    if (noise != null) s.setAttribute('noise', String(noise));
-    if (blur != null) s.setAttribute('blur', String(blur));
-    box.appendChild(s);
+    box.appendChild(createShader(args));
     return box;
   },
 };
@@ -45,17 +129,16 @@ const meta: Meta<ShaderArgs> = {
 export default meta;
 type Story = StoryObj<ShaderArgs>;
 
+/** Five-up comparison board with real chat prose over every candidate field. */
+export const Storyboard: Story = {
+  name: 'STORYBOARD',
+  parameters: { layout: 'fullscreen', controls: { disable: true } },
+  render: () => createStoryboard(),
+};
+
 /** Cone — the sheared waffle lattice behind the cone/chat context. */
 export const Cone: Story = {
-  args: {
-    mode: 'cone',
-    tint: '#b07823',
-    coverage: 0.66,
-    brightness: 1.2,
-    contrast: 0.75,
-    noise: 0.04,
-    blur: 0.09,
-  },
+  args: { ...WAFFLE_CURRENT },
 };
 /** Scoop — the flowing ice-cream swirl, tinted to the active scoop accent. */
 export const Scoop: Story = {
@@ -81,3 +164,12 @@ export const Freezer: Story = {
     blur: 0,
   },
 };
+
+/** Sugar Glass — warm amber cells and visible crack light. */
+export const Caramel: Story = { args: { ...SUGAR_GLASS_PRESETS.caramel } };
+/** Sugar Glass — broad quiet seams tuned for prose legibility. */
+export const Frosted: Story = { args: { ...SUGAR_GLASS_PRESETS.frosted } };
+/** Sugar Glass — dense sharp fractures with low glass fill. */
+export const Brittle: Story = { args: { ...SUGAR_GLASS_PRESETS.brittle } };
+/** Sugar Glass — the sugar treatment over the familiar waffle geometry. */
+export const WaffleGlass: Story = { args: { ...SUGAR_GLASS_PRESETS['waffle-glass'] } };

--- a/packages/webcomponents/src/freezer/slicc-shader.stories.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.stories.ts
@@ -9,6 +9,7 @@ interface ShaderArgs {
   contrast: number;
   noise: number;
   blur: number;
+  speed: number;
 }
 
 const WAFFLE_CURRENT = {
@@ -19,10 +20,12 @@ const WAFFLE_CURRENT = {
   contrast: 0.75,
   noise: 0.04,
   blur: 0.09,
+  speed: 1,
 } as const satisfies Readonly<ShaderArgs>;
 
 const PRESET_LABELS: Readonly<Record<SugarGlassPresetName, string>> = {
   caramel: 'Caramel',
+  'caramel-waffle': 'Caramel-waffle-tone',
   frosted: 'Frosted',
   brittle: 'Brittle',
   'waffle-glass': 'Waffle-glass',
@@ -33,6 +36,24 @@ const CHAT_PARAGRAPHS = [
   'I traced the request through the current shell and found the smallest safe change. The existing conversation layout can stay in place while the background treatment is reviewed.',
   'Next I would verify the result in both themes, read the final diff, and call out any remaining risk before asking you to choose a direction.',
 ] as const;
+
+type NumericShaderAttribute = Exclude<keyof ShaderArgs, 'mode' | 'tint'>;
+type ControlAttribute = NumericShaderAttribute | 'tint';
+
+const NUMERIC_CONTROLS: ReadonlyArray<{
+  name: NumericShaderAttribute;
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+}> = [
+  { name: 'coverage', label: 'Coverage', min: 0, max: 1, step: 0.01 },
+  { name: 'brightness', label: 'Brightness', min: 0.5, max: 1.5, step: 0.01 },
+  { name: 'contrast', label: 'Contrast', min: 0.5, max: 2, step: 0.01 },
+  { name: 'noise', label: 'Noise', min: 0, max: 0.3, step: 0.005 },
+  { name: 'blur', label: 'Blur', min: 0, max: 1, step: 0.01 },
+  { name: 'speed', label: 'Speed', min: 0, max: 2, step: 0.05 },
+];
 
 function applyShaderAttributes(shader: HTMLElement, args: Readonly<ShaderArgs>): void {
   for (const [name, value] of Object.entries(args)) shader.setAttribute(name, String(value));
@@ -51,10 +72,36 @@ function attributeCaption(args: Readonly<ShaderArgs>): string {
     .join(' · ');
 }
 
-function createStoryboardPanel(label: string, args: Readonly<ShaderArgs>): HTMLElement {
+function formatControlValue(name: ControlAttribute, value: string | number): string {
+  if (name === 'tint') return String(value).toUpperCase();
+  return Number(value).toFixed(name === 'noise' ? 3 : 2);
+}
+
+function createControlRow(
+  panelLabel: string,
+  label: string,
+  input: HTMLInputElement,
+  output: HTMLOutputElement
+): HTMLElement {
+  const row = document.createElement('label');
+  row.className = 'storyboard-control';
+  const text = document.createElement('span');
+  text.textContent = label;
+  input.setAttribute('aria-label', `${panelLabel} ${label}`);
+  row.append(text, input, output);
+  return row;
+}
+
+function createStoryboardPanel(
+  label: string,
+  args: Readonly<ShaderArgs>,
+  interactive = false
+): HTMLElement {
   const panel = document.createElement('article');
   panel.className = 'storyboard-panel';
-  panel.appendChild(createShader(args));
+  if (interactive) panel.classList.add('playground-panel');
+  const shader = createShader(args);
+  panel.appendChild(shader);
 
   const caption = document.createElement('header');
   caption.className = 'storyboard-caption';
@@ -75,12 +122,72 @@ function createStoryboardPanel(label: string, args: Readonly<ShaderArgs>): HTMLE
     prose.appendChild(paragraph);
   }
   panel.append(caption, prose);
+  if (interactive) {
+    const current: ShaderArgs = { ...args };
+    const inputs = new Map<ControlAttribute, HTMLInputElement>();
+    const outputs = new Map<ControlAttribute, HTMLOutputElement>();
+    const controls = document.createElement('form');
+    controls.className = 'storyboard-controls';
+    controls.addEventListener('submit', (event) => event.preventDefault());
+
+    const addControl = (
+      name: ControlAttribute,
+      controlLabel: string,
+      input: HTMLInputElement
+    ): void => {
+      const output = document.createElement('output');
+      const update = (): void => {
+        const value = name === 'tint' ? input.value : Number(input.value);
+        Object.assign(current, { [name]: value });
+        shader.setAttribute(name, String(value));
+        output.textContent = formatControlValue(name, value);
+        attributes.textContent = attributeCaption(current);
+      };
+      input.addEventListener('input', update);
+      output.textContent = formatControlValue(name, current[name]);
+      inputs.set(name, input);
+      outputs.set(name, output);
+      controls.appendChild(createControlRow(label, controlLabel, input, output));
+    };
+
+    const tint = document.createElement('input');
+    tint.type = 'color';
+    tint.value = args.tint;
+    addControl('tint', 'Tint', tint);
+    for (const spec of NUMERIC_CONTROLS) {
+      const input = document.createElement('input');
+      input.type = 'range';
+      input.min = String(spec.min);
+      input.max = String(spec.max);
+      input.step = String(spec.step);
+      input.value = String(args[spec.name]);
+      addControl(spec.name, spec.label, input);
+    }
+
+    const reset = document.createElement('button');
+    reset.type = 'button';
+    reset.className = 'storyboard-reset';
+    reset.textContent = 'Reset to preset';
+    reset.addEventListener('click', () => {
+      Object.assign(current, args);
+      applyShaderAttributes(shader, args);
+      for (const [name, input] of inputs) {
+        input.value = String(args[name]);
+        const output = outputs.get(name);
+        if (output) output.textContent = formatControlValue(name, args[name]);
+      }
+      attributes.textContent = attributeCaption(current);
+    });
+    controls.appendChild(reset);
+    panel.appendChild(controls);
+  }
   return panel;
 }
 
-function createStoryboard(): HTMLElement {
+function createStoryboard(interactive = false): HTMLElement {
   const root = document.createElement('div');
   root.className = 'storyboard-root';
+  if (interactive) root.classList.add('playground-root');
   const style = document.createElement('style');
   style.textContent = `
     .storyboard-root { width: 100%; min-width: 1276px; min-height: 608px; background: var(--canvas); color: var(--ink); }
@@ -93,12 +200,22 @@ function createStoryboard(): HTMLElement {
     .storyboard-prose { max-width: 48ch; padding: 15px 20px 18px; font: 400 15px/1.45 system-ui, sans-serif; }
     .storyboard-prose h4 { margin: 0 0 8px; font: 700 17px/1.3 system-ui, sans-serif; }
     .storyboard-prose p { margin: 0 0 8px; }
+    .playground-panel { height: 488px; }
+    .storyboard-controls { position: relative; z-index: 1; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 9px 14px; margin: 0 16px 12px; padding: 10px 12px; border: 1px solid var(--line); border-radius: 10px; background: color-mix(in srgb, var(--bg) 88%, transparent); box-shadow: var(--shadow-pane); }
+    .storyboard-control { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 4px 6px; min-width: 0; color: var(--txt-2); font: 600 10px/1.2 system-ui, sans-serif; }
+    .storyboard-control input { grid-column: 1 / -1; width: 100%; min-width: 0; accent-color: var(--ctx); }
+    .storyboard-control input[type='color'] { box-sizing: border-box; width: 100%; height: 22px; padding: 2px; border: 1px solid var(--line); border-radius: 5px; background: var(--canvas); }
+    .storyboard-control output { grid-column: 2; grid-row: 1; color: var(--ink); font: 600 10px/1.2 ui-monospace, monospace; text-align: right; }
+    .storyboard-reset { grid-column: 1 / -1; min-height: var(--ctl-h); border: 1px solid var(--line); border-radius: 7px; background: var(--ghost); color: var(--ink); font: 650 11px/1 system-ui, sans-serif; cursor: pointer; }
+    .storyboard-reset:hover { background: var(--desk); }
   `;
   const grid = document.createElement('main');
   grid.className = 'storyboard-grid';
-  grid.appendChild(createStoryboardPanel('Waffle (current)', WAFFLE_CURRENT));
+  grid.appendChild(createStoryboardPanel('Waffle (current)', WAFFLE_CURRENT, interactive));
   for (const [name, preset] of Object.entries(SUGAR_GLASS_PRESETS)) {
-    grid.appendChild(createStoryboardPanel(PRESET_LABELS[name as SugarGlassPresetName], preset));
+    grid.appendChild(
+      createStoryboardPanel(PRESET_LABELS[name as SugarGlassPresetName], preset, interactive)
+    );
   }
   root.append(style, grid);
   return root;
@@ -116,6 +233,7 @@ const meta: Meta<ShaderArgs> = {
     contrast: { control: { type: 'range', min: 0.5, max: 2, step: 0.01 } },
     noise: { control: { type: 'range', min: 0, max: 0.3, step: 0.01 } },
     blur: { control: { type: 'range', min: 0, max: 1, step: 0.01 } },
+    speed: { control: { type: 'range', min: 0, max: 2, step: 0.05 } },
   },
   render: (args) => {
     const box = document.createElement('div');
@@ -129,11 +247,18 @@ const meta: Meta<ShaderArgs> = {
 export default meta;
 type Story = StoryObj<ShaderArgs>;
 
-/** Five-up comparison board with real chat prose over every candidate field. */
+/** Static comparison board with real chat prose over every candidate field. */
 export const Storyboard: Story = {
   name: 'STORYBOARD',
   parameters: { layout: 'fullscreen', controls: { disable: true } },
   render: () => createStoryboard(),
+};
+
+/** Six-up live comparison: every candidate owns an isolated control set. */
+export const Playground: Story = {
+  name: 'PLAYGROUND',
+  parameters: { layout: 'fullscreen', controls: { disable: true } },
+  render: () => createStoryboard(true),
 };
 
 /** Cone — the sheared waffle lattice behind the cone/chat context. */
@@ -150,6 +275,7 @@ export const Scoop: Story = {
     contrast: 1,
     noise: 0,
     blur: 0,
+    speed: 1,
   },
 };
 /** Freezer — frost crystallizing from the corner. */
@@ -162,11 +288,14 @@ export const Freezer: Story = {
     contrast: 1,
     noise: 0,
     blur: 0,
+    speed: 1,
   },
 };
 
 /** Sugar Glass — warm amber cells and visible crack light. */
 export const Caramel: Story = { args: { ...SUGAR_GLASS_PRESETS.caramel } };
+/** Sugar Glass — Caramel color and texture with the current Waffle tone. */
+export const CaramelWaffle: Story = { args: { ...SUGAR_GLASS_PRESETS['caramel-waffle'] } };
 /** Sugar Glass — broad quiet seams tuned for prose legibility. */
 export const Frosted: Story = { args: { ...SUGAR_GLASS_PRESETS.frosted } };
 /** Sugar Glass — dense sharp fractures with low glass fill. */

--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -18,7 +18,7 @@ import { h, sheet } from '../internal/dom.js';
  *
  * @attr mode - `cone` (default) | `scoop` | `freezer` | `sugar`
  * @attr tint - CSS color washed into the scoop field / event glow (the active accent)
- * @attr coverage - 0..1 freezer frost growth (feeds `u_freeze`)
+ * @attr coverage - 0..1 freezer frost growth / sugar cell density and geometry
  * @attr scroll - chat scroll offset in CSS px; pans the field with the content
  * @attr intensity - multiplier for coverage (freezer)
  * @attr no-webgl - reflected when WebGL is unavailable (CSS fallback)
@@ -174,17 +174,32 @@ float sugarEdge(vec2 p,float t){
     if(dot(delta,delta)>0.001) edge=min(edge,dot(0.5*(nearPt+d),normalize(delta))); } }
   return edge;
 }
+vec3 sugarLattice(vec2 p,float scale){
+  float ca=cos(0.7853981634), sa=sin(0.7853981634);
+  vec2 pr=mat2(ca,-sa,sa,ca)*p; vec2 g=pr*scale; g.x+=g.y*0.5;
+  vec2 id=floor(g), f=fract(g)-0.5;
+  float edge=min(0.5-abs(f.x),0.5-abs(f.y));
+  return vec3(length(f)*0.70710678,edge,hash21(id));
+}
 void main(){
   vec2 uv=gl_FragCoord.xy/u_res; float aspect=u_res.x/u_res.y;
   vec2 p=(gl_FragCoord.xy-u_res*0.5)/min(u_res.x,u_res.y); p.y-=u_scroll;
   vec2 parallax=-(u_center-0.5)*0.15; float t=u_time*(u_life+0.15);
   p+=vec2(sin(p.y*12.0+t*2.3),cos(p.x*10.0+t*1.7))*0.003;
-  float scale=3.25+u_density*0.85; vec3 macro=sugarVoronoi((p+parallax)*scale+0.5,t);
+  float sugarCoverage=clamp(u_freeze/2.2,0.0,1.0);
+  float waffleMask=step(0.82,sugarCoverage);
+  float scale=mix(2.9,6.6,smoothstep(0.0,0.75,sugarCoverage));
+  vec3 voronoiMacro=sugarVoronoi((p+parallax)*scale+0.5,t);
+  vec3 latticeMacro=sugarLattice(p+parallax,8.0);
+  vec3 macro=mix(voronoiMacro,latticeMacro,waffleMask);
   float microEdge=sugarEdge((p+parallax*2.5)*9.0+vec2(3.7,1.2),t*0.7);
   float crackPulse=0.5+0.3*sin(t*1.5)+0.2*sin(t*2.7+1.0);
-  float macroWidth=0.04*crackPulse, microWidth=0.025*crackPulse;
-  float macroCrack=1.0-smoothstep(0.0,macroWidth,macro.y);
-  float microCrack=1.0-smoothstep(0.0,microWidth,microEdge);
+  float softness=clamp(u_blur,0.0,1.0);
+  float macroWidth=mix(0.025,0.085,softness)*crackPulse;
+  float microWidth=mix(0.015,0.055,softness)*crackPulse;
+  float seamStrength=mix(1.0,0.28,softness);
+  float macroCrack=(1.0-smoothstep(0.0,macroWidth,macro.y))*seamStrength;
+  float microCrack=(1.0-smoothstep(0.0,microWidth,microEdge))*seamStrength;
   float crack=clamp(macroCrack+microCrack*0.4,0.0,1.0);
   float macroGlow=1.0-smoothstep(0.0,macroWidth*4.0,macro.y);
   float microGlow=1.0-smoothstep(0.0,microWidth*3.0,microEdge);
@@ -198,6 +213,8 @@ void main(){
   vec3 rose=mix(vec3(0.90,0.65,0.60),vec3(0.42,0.19,0.10),u_dark);
   glass=mix(glass,rose,glow*(0.3+0.2*sin(macro.z*12.0+t*0.8))*0.25);
   glass=mix(glass,u_tint,0.06);
+  float fill=mix(1.0,0.35,smoothstep(0.45,0.75,sugarCoverage));
+  fill=mix(fill,0.75,waffleMask); glass=mix(themeBg(),glass,fill);
   vec3 crackLight=mix(vec3(1.0,0.91,0.75),vec3(0.74,0.38,0.10),u_dark);
   vec3 crackBright=mix(vec3(1.0,0.96,0.90),vec3(0.90,0.52,0.16),u_dark);
   vec3 lightCol=mix(crackLight,crackBright,crack); float bleed=clamp(0.55+u_falloff*1.5,0.4,1.3);
@@ -209,10 +226,69 @@ void main(){
   vec3 bg=themeBg(); col=mix(bg,clamp(col,0.0,1.0),0.20);
   float noiseFreq=mix(80.0,4.0,clamp(u_blur,0.0,1.0)); float grain=fbm(uv*noiseFreq)-0.5;
   col+=u_noise*grain; col=(col-0.5)*u_contrast+0.5; col*=u_brightness; col=clamp(col,0.0,1.0);
+  col=clamp(col,max(bg-vec3(0.20),vec3(0.0)),min(bg+vec3(0.20),vec3(1.0)));
   gl_FragColor=vec4(col,1.0);
 }`;
 
 export type ShaderMode = 'cone' | 'scoop' | 'freezer' | 'sugar';
+export interface SugarGlassPreset {
+  readonly mode: 'sugar';
+  readonly tint: string;
+  readonly brightness: number;
+  readonly contrast: number;
+  readonly noise: number;
+  readonly blur: number;
+  readonly coverage: number;
+}
+
+/**
+ * Tuned Sugar Glass storyboard presets (all remain within the 20% background budget):
+ * - Caramel — Radiant-like warm amber cells with visible crack light.
+ * - Frosted — broad, quiet seams and restrained contrast for maximum prose legibility.
+ * - Brittle — dense small cells, sharp bright fractures, and low glass fill.
+ * - Waffle-glass — sugar rendering over Cone's 45-degree, half-sheared lattice geometry.
+ * Sugar uses `coverage` for cell scale; values >= 0.82 select the lattice geometry.
+ */
+export const SUGAR_GLASS_PRESETS = {
+  caramel: {
+    mode: 'sugar',
+    tint: '#d08a3c',
+    brightness: 1,
+    contrast: 1,
+    noise: 0.025,
+    blur: 0.14,
+    coverage: 0.28,
+  },
+  frosted: {
+    mode: 'sugar',
+    tint: '#ead9bd',
+    brightness: 1,
+    contrast: 0.55,
+    noise: 0.005,
+    blur: 0.9,
+    coverage: 0.08,
+  },
+  brittle: {
+    mode: 'sugar',
+    tint: '#ffd089',
+    brightness: 0.96,
+    contrast: 1.2,
+    noise: 0.055,
+    blur: 0.02,
+    coverage: 0.68,
+  },
+  'waffle-glass': {
+    mode: 'sugar',
+    tint: '#d3a15f',
+    brightness: 1,
+    contrast: 0.9,
+    noise: 0.02,
+    blur: 0.08,
+    coverage: 0.9,
+  },
+} as const satisfies Readonly<Record<string, SugarGlassPreset>>;
+export type SugarGlassPresetName = keyof typeof SUGAR_GLASS_PRESETS;
+
 const PROGRAMS: Record<ShaderMode, string> = {
   cone: FRAG_CONE,
   scoop: FRAG_SCOOP,
@@ -406,7 +482,7 @@ export class SliccShader extends HTMLElement {
     this.setAttribute('mode', value);
   }
 
-  /** Freezer frost growth 0..1. */
+  /** Freezer frost growth / Sugar cell density and geometry 0..1. */
   get coverage(): number {
     return clampNum(Number.parseFloat(this.getAttribute('coverage') ?? ''), 0, 1, 0.66);
   }

--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -2,24 +2,20 @@ import { define } from '../internal/define.js';
 import { h, sheet } from '../internal/dom.js';
 
 /**
- * The SLICC background field — a single WebGL element with four program modes,
- * lifted from the prototype's shared `#bg-canvas` (proto/StellarRubySwift.html,
- * `__sliccShaders`): `cone` (a sheared waffle lattice that behaves like a
- * probabilistic Game of Life near a floating focal point), `scoop` (a lush
- * flowing ice-cream gradient that swirls and breathes), and `freezer` (water
- * crystallizing into ice from the corner), and `sugar` (caramelized glass with
- * Voronoi fractures). One canvas, one program swapped by
- * the `mode` attribute — exactly as the prototype swaps `FRAG_CONE` / `FRAG_SCOOP`
- * / `FRAG_FREEZER` / `FRAG_SUGAR`.
+ * The SLICC background field — a single WebGL element with three program modes:
+ * `cone` (caramelized glass with Voronoi fractures), `scoop` (a lush flowing
+ * ice-cream gradient that swirls and breathes), and `freezer` (water
+ * crystallizing into ice from the corner). One canvas, one program swapped by
+ * the `mode` attribute.
  *
  * Sits behind the app (`position: fixed; inset: 0; z-index: 0; pointer-events:
  * none`). Honors `prefers-reduced-motion` (one static frame), pauses on
  * disconnect, and falls back to a per-mode CSS gradient when WebGL is absent.
  *
- * @attr mode - `cone` (default) | `scoop` | `freezer` | `sugar`
+ * @attr mode - `cone` (default) | `scoop` | `freezer`
  * @attr tint - CSS color washed into the scoop field / event glow (the active accent)
- * @attr coverage - 0..1 freezer frost growth / sugar cell density and geometry
- * @attr speed - 0..2 sugar animation rate multiplier (default 1)
+ * @attr coverage - 0..1 freezer frost growth / cone glass density and geometry
+ * @attr speed - 0..2 cone glass animation rate multiplier (default 0.25)
  * @attr scroll - chat scroll offset in CSS px; pans the field with the content
  * @attr intensity - multiplier for coverage (freezer)
  * @attr no-webgl - reflected when WebGL is unavailable (CSS fallback)
@@ -28,14 +24,12 @@ import { h, sheet } from '../internal/dom.js';
 
 const VERT = 'attribute vec2 a_pos; void main(){ gl_Position = vec4(a_pos,0.0,1.0); }';
 
-// Full uniform header + fbm noise — the prototype's HEAD + NOISE. Every program
-// declares the full set so a single render path can feed them; unused uniforms
-// are harmless.
+// Shared uniform header + fbm noise. Every declared uniform is read by at least
+// one program so the common render path contains no dead uniform plumbing.
 const HEAD = `precision highp float;
 uniform vec2 u_res; uniform float u_time; uniform float u_energy;
 uniform vec2 u_center; uniform vec3 u_evt; uniform float u_freeze; uniform float u_dark;
-uniform float u_density; uniform float u_falloff; uniform float u_life;
-uniform float u_blink; uniform float u_thick; uniform vec3 u_tint; uniform float u_scroll;
+uniform float u_falloff; uniform float u_life; uniform vec3 u_tint; uniform float u_scroll;
 uniform float u_brightness; uniform float u_contrast; uniform float u_noise; uniform float u_blur;
 vec3 themeBg(){ return mix(vec3(0.97,0.95,0.89), vec3(0.09,0.08,0.06), u_dark); }`;
 
@@ -46,56 +40,6 @@ float vnoise(vec2 p){ vec2 i=floor(p),f=fract(p);
   vec2 u=f*f*(3.-2.*f); return mix(mix(a,b,u.x),mix(c,d,u.x),u.y); }
 float fbm(vec2 p){ float v=0.,a=0.5; for(int i=0;i<5;i++){ v+=a*vnoise(p); p=p*2.02+vec2(7.1,3.7); a*=0.5;} return v; }
 vec2 warp(vec2 p, float t){ float a=fbm(p+vec2(0.0,1.7)+t*0.10); float b=fbm(p+vec2(5.2,1.3)-t*0.08); return p+0.85*vec2(a,b); }`;
-
-const FRAG_CONE = `${HEAD}${NOISE}
-float cellCycle(vec2 q){ float s=hash21(q+11.7);
-  return 0.5+0.32*sin(u_time*u_blink+s*6.2831)+0.18*sin(u_time*0.6*u_blink+s*19.0); }
-void main(){
-  vec2 uv=gl_FragCoord.xy/u_res; float aspect=u_res.x/u_res.y;
-  vec2 p=uv-0.5; p.x*=aspect; vec2 c=u_center-0.5; c.x*=aspect;
-  vec3 bg=themeBg(); float dist=length(p-c);
-  /* Chat scroll pans the (periodic) lattice with the content. */
-  p.y-=u_scroll;
-  float ca=cos(0.7853981634), sa=sin(0.7853981634);
-  vec2 pr=mat2(ca,-sa,sa,ca)*p; float cells=12.0; vec2 g=pr*cells; g.x+=g.y*0.5;
-  vec2 id=floor(g); vec2 f=fract(g)-0.5;
-  float dia=mix(length(f),abs(f.x)+abs(f.y),0.82);
-  float ph=hash21(id)*6.2831; float radius=0.42+0.05*sin(u_time*0.5+ph);
-  float aa=2.2/cells; float outline=smoothstep(u_thick+aa,u_thick,abs(dia-radius));
-  float seedDen=clamp(u_density+u_energy*0.20*exp(-dist*2.0),0.0,1.0);
-  float selfCyc=cellCycle(id); float selfSoft=smoothstep(-0.05,0.05,seedDen-selfCyc);
-  float selfHard=step(selfCyc,seedDen); float nbs=0.0;
-  for(int j=-1;j<=1;j++){ for(int i=-1;i<=1;i++){ if(i==0&&j==0) continue;
-    vec2 nb=id+vec2(float(i),float(j)); nbs+=step(cellCycle(nb),seedDen); } }
-  float survive=smoothstep(1.5,1.9,nbs)-smoothstep(3.1,3.5,nbs);
-  float birth=smoothstep(2.6,3.0,nbs)-smoothstep(3.0,3.4,nbs);
-  float gol=clamp(selfHard*survive+(1.0-selfHard)*birth,0.0,1.0);
-  float golMix=1.0-smoothstep(0.0,max(u_life,0.001),dist);
-  float onState=mix(selfSoft,gol,golMix);
-  float falloff=clamp(1.0-u_falloff*max(dist-0.12,0.0),0.0,1.0);
-  falloff=clamp(falloff+u_energy*0.30*exp(-dist*2.0),0.0,1.0); onState*=falloff;
-  float bevel=clamp(0.5-(f.x-f.y)*0.9,0.0,1.0);
-  vec3 lineCol=mix(vec3(0.78,0.55,0.30),vec3(0.86,0.62,0.36),u_dark);
-  vec3 hiCol=mix(vec3(0.90,0.72,0.46),vec3(0.92,0.74,0.48),u_dark);
-  vec3 tint=mix(lineCol,hiCol,bevel*0.6); float stroke=outline*onState;
-  // Low-contrast lattice: chat prose sits DIRECTLY on this field (the frosted
-  // reading card is gone), so strokes stay close to the base color — toward
-  // the light bg in light mode, toward the dark bg in dark mode.
-  vec3 col=mix(bg,tint,clamp(stroke*0.20,0.0,0.20));
-  col+=u_evt*u_energy*stroke*exp(-dist*dist*4.0)*0.18;
-  /* Cone-only post: a noise/grain layer whose sample frequency is driven by
-     u_blur (high blur => low frequency / soft, low blur => sharp grain), then
-     contrast around 0.5 and brightness as a multiplier. The JS getters bake in
-     tuned defaults (brightness=1.2, contrast=0.75, noise=0.04, blur=0.09); at
-     the shader level the identity is still u_noise=0, u_contrast=1, u_brightness=1. */
-  float noiseFreq=mix(80.0,4.0,clamp(u_blur,0.0,1.0));
-  float grain=fbm(uv*noiseFreq)-0.5;
-  col+=u_noise*grain;
-  col=(col-0.5)*u_contrast+0.5;
-  col*=u_brightness;
-  col=clamp(col,0.0,1.0);
-  gl_FragColor=vec4(col,1.0);
-}`;
 
 const FRAG_SCOOP = `${HEAD}${NOISE}
 vec3 pal(float t){ vec3 strawberry=vec3(1.0,0.45,0.62); vec3 vanilla=vec3(1.0,0.95,0.82);
@@ -142,7 +86,7 @@ void main(){
   float rim=smoothstep(0.05,0.0,abs(edge))*0.6; col+=rim*iceCol;
   /* The field is a BACKGROUND: chat prose sits directly on it, so the final
      wash pins the whole pattern close to the icy ground — the same ~20%
-     deviation budget the cone lattice uses (strokes at 0.20 toward tint). */
+     deviation budget the cone glass uses. */
   col=mix(freezerBg(),col,0.22);
   gl_FragColor=vec4(col,1.0);
 }`;
@@ -232,9 +176,9 @@ void main(){
   gl_FragColor=vec4(col,1.0);
 }`;
 
-export type ShaderMode = 'cone' | 'scoop' | 'freezer' | 'sugar';
+export type ShaderMode = 'cone' | 'scoop' | 'freezer';
 export interface SugarGlassPreset {
-  readonly mode: 'sugar';
+  readonly mode: 'cone';
   readonly tint: string;
   readonly brightness: number;
   readonly contrast: number;
@@ -247,15 +191,15 @@ export interface SugarGlassPreset {
 /**
  * Tuned Sugar Glass storyboard presets (all remain within the 20% background budget):
  * - Caramel — Radiant-like warm amber cells with visible crack light.
- * - Caramel-waffle — Caramel's field with the current Cone brightness and contrast.
+ * - Caramel-soft — Caramel's field with a softer brightness and contrast treatment.
  * - Frosted — broad, quiet seams and restrained contrast for maximum prose legibility.
  * - Brittle — dense small cells, sharp bright fractures, and low glass fill.
  * - Waffle-glass — sugar rendering over Cone's 45-degree, half-sheared lattice geometry.
- * Sugar uses `coverage` for cell scale; values >= 0.82 select the lattice geometry.
+ * Cone glass uses `coverage` for cell scale; values >= 0.82 select the lattice geometry.
  */
 export const SUGAR_GLASS_PRESETS = {
   caramel: {
-    mode: 'sugar',
+    mode: 'cone',
     tint: '#d08a3c',
     brightness: 1.1,
     contrast: 1.1,
@@ -264,8 +208,8 @@ export const SUGAR_GLASS_PRESETS = {
     coverage: 0.28,
     speed: 0.25,
   },
-  'caramel-waffle': {
-    mode: 'sugar',
+  'caramel-soft': {
+    mode: 'cone',
     tint: '#d08a3c',
     brightness: 1.2,
     contrast: 0.75,
@@ -275,7 +219,7 @@ export const SUGAR_GLASS_PRESETS = {
     speed: 1,
   },
   frosted: {
-    mode: 'sugar',
+    mode: 'cone',
     tint: '#ead9bd',
     brightness: 1,
     contrast: 0.55,
@@ -285,7 +229,7 @@ export const SUGAR_GLASS_PRESETS = {
     speed: 1,
   },
   brittle: {
-    mode: 'sugar',
+    mode: 'cone',
     tint: '#ffd089',
     brightness: 0.96,
     contrast: 1.2,
@@ -295,7 +239,7 @@ export const SUGAR_GLASS_PRESETS = {
     speed: 1,
   },
   'waffle-glass': {
-    mode: 'sugar',
+    mode: 'cone',
     tint: '#d3a15f',
     brightness: 1,
     contrast: 0.9,
@@ -308,23 +252,20 @@ export const SUGAR_GLASS_PRESETS = {
 export type SugarGlassPresetName = keyof typeof SUGAR_GLASS_PRESETS;
 
 const PROGRAMS: Record<ShaderMode, string> = {
-  cone: FRAG_CONE,
+  cone: FRAG_SUGAR,
   scoop: FRAG_SCOOP,
   freezer: FRAG_FREEZER,
-  sugar: FRAG_SUGAR,
 };
 /** Fragment sources, exposed so tests can compile and pixel-probe the fields. */
 export const SHADER_FRAGMENTS: Readonly<Record<ShaderMode, string>> = PROGRAMS;
-const MODES = new Set<ShaderMode>(['cone', 'scoop', 'freezer', 'sugar']);
+const MODES = new Set<ShaderMode>(['cone', 'scoop', 'freezer']);
 
 const FALLBACK: Record<ShaderMode, string> = {
-  cone: 'radial-gradient(120% 120% at 35% 45%, color-mix(in srgb,#e0a866 40%,var(--bg)) 0%, var(--bg) 60%)',
+  cone: 'radial-gradient(120% 120% at 35% 45%, color-mix(in srgb,#d08a3c 20%,var(--bg)) 0%, var(--bg) 70%)',
   scoop:
     'radial-gradient(120% 120% at 40% 50%, color-mix(in srgb,#ff9bc0 40%,var(--bg)) 0%, var(--bg) 62%)',
   freezer:
     'radial-gradient(120% 120% at 0% 100%, color-mix(in srgb,#7fb0e6 55%,var(--bg)) 0%, var(--bg) 70%)',
-  sugar:
-    'radial-gradient(120% 120% at 35% 45%, color-mix(in srgb,#c8956c 20%,var(--bg)) 0%, var(--bg) 70%)',
 };
 
 const STYLE = `
@@ -348,11 +289,8 @@ const UNIFORMS = [
   'u_evt',
   'u_freeze',
   'u_dark',
-  'u_density',
   'u_falloff',
   'u_life',
-  'u_blink',
-  'u_thick',
   'u_tint',
   'u_brightness',
   'u_contrast',
@@ -421,7 +359,7 @@ export class SliccShader extends HTMLElement {
   // change — NEVER per frame: resolving them calls getComputedStyle and (via
   // colorToVec3) appends a probe to document.body, which forces a full-document
   // style recalc. Doing that every animation frame was the flicker's cause.
-  #tintVec: [number, number, number] = [0.545, 0.361, 0.965];
+  #tintVec: [number, number, number] = [0.816, 0.541, 0.235];
   #evtVec: [number, number, number] = [0.957, 0.247, 0.369];
   #darkVal = 0;
   #themeObserver: MutationObserver | null = null;
@@ -477,9 +415,9 @@ export class SliccShader extends HTMLElement {
 
   attributeChangedCallback(name: string): void {
     if (!this.isConnected) return;
-    // `tint` drives the tint + event-tint uniforms — re-resolve the cache before
-    // any repaint below. (`mode` only swaps the GL program, not the colors.)
-    if (name === 'tint') this.#refreshColorUniforms();
+    // `tint` drives the tint + event-tint uniforms. A mode change also refreshes
+    // the cache because a tint-less cone uses the Caramel default.
+    if (name === 'tint' || name === 'mode') this.#refreshColorUniforms();
     if (name === 'mode' && this.#gl && this.mode !== this.#builtMode) {
       // Switch to the (cached) program and repaint synchronously so the
       // previous mode's frame does not linger for a rAF — the blue flicker.
@@ -502,9 +440,10 @@ export class SliccShader extends HTMLElement {
     this.setAttribute('mode', value);
   }
 
-  /** Freezer frost growth / Sugar cell density and geometry 0..1. */
+  /** Freezer frost growth / cone glass cell density and geometry 0..1. */
   get coverage(): number {
-    return clampNum(Number.parseFloat(this.getAttribute('coverage') ?? ''), 0, 1, 0.66);
+    const fallback = this.mode === 'cone' ? SUGAR_GLASS_PRESETS.caramel.coverage : 0.66;
+    return clampNum(Number.parseFloat(this.getAttribute('coverage') ?? ''), 0, 1, fallback);
   }
   set coverage(value: number) {
     this.setAttribute('coverage', String(value));
@@ -530,45 +469,70 @@ export class SliccShader extends HTMLElement {
     this.setAttribute('scroll', String(value));
   }
 
-  /** Cone-mode multiplier on final color (tuned default = 1.2). */
+  /** Cone glass multiplier on final color (Caramel default = 1.1). */
   get brightness(): number {
-    return clampNum(Number.parseFloat(this.getAttribute('brightness') ?? ''), 0.5, 1.5, 1.2);
+    return clampNum(
+      Number.parseFloat(this.getAttribute('brightness') ?? ''),
+      0.5,
+      1.5,
+      SUGAR_GLASS_PRESETS.caramel.brightness
+    );
   }
   set brightness(value: number) {
     this.setAttribute('brightness', String(value));
   }
 
-  /** Cone-mode contrast around a 0.5 pivot (tuned default = 0.75). */
+  /** Cone glass contrast around a 0.5 pivot (Caramel default = 1.1). */
   get contrast(): number {
-    return clampNum(Number.parseFloat(this.getAttribute('contrast') ?? ''), 0.5, 2, 0.75);
+    return clampNum(
+      Number.parseFloat(this.getAttribute('contrast') ?? ''),
+      0.5,
+      2,
+      SUGAR_GLASS_PRESETS.caramel.contrast
+    );
   }
   set contrast(value: number) {
     this.setAttribute('contrast', String(value));
   }
 
-  /** Cone-mode grain amount added to the final color (tuned default = 0.04). */
+  /** Cone glass grain amount added to the final color (Caramel default = 0.025). */
   get noise(): number {
-    return clampNum(Number.parseFloat(this.getAttribute('noise') ?? ''), 0, 0.3, 0.04);
+    return clampNum(
+      Number.parseFloat(this.getAttribute('noise') ?? ''),
+      0,
+      0.3,
+      SUGAR_GLASS_PRESETS.caramel.noise
+    );
   }
   set noise(value: number) {
     this.setAttribute('noise', String(value));
   }
 
   /**
-   * Cone-mode blur of the noise layer only (0 = sharp grain, 1 = soft).
+   * Cone glass blur of the noise layer only (0 = sharp grain, 1 = soft).
    * Reflects the `blur` attribute; named `blurAmount` because `HTMLElement`
-   * already defines a `blur()` method. Tuned default = 0.09.
+   * already defines a `blur()` method. Caramel default = 0.14.
    */
   get blurAmount(): number {
-    return clampNum(Number.parseFloat(this.getAttribute('blur') ?? ''), 0, 1, 0.09);
+    return clampNum(
+      Number.parseFloat(this.getAttribute('blur') ?? ''),
+      0,
+      1,
+      SUGAR_GLASS_PRESETS.caramel.blur
+    );
   }
   set blurAmount(value: number) {
     this.setAttribute('blur', String(value));
   }
 
-  /** Sugar-mode animation rate multiplier (0 = paused, 1 = current rate). */
+  /** Cone glass animation rate multiplier (0 = paused, Caramel default = 0.25). */
   get speed(): number {
-    return clampNum(Number.parseFloat(this.getAttribute('speed') ?? ''), 0, 2, 1);
+    return clampNum(
+      Number.parseFloat(this.getAttribute('speed') ?? ''),
+      0,
+      2,
+      SUGAR_GLASS_PRESETS.caramel.speed
+    );
   }
   set speed(value: number) {
     this.setAttribute('speed', String(value));
@@ -596,13 +560,14 @@ export class SliccShader extends HTMLElement {
   }
 
   /** Resolve + cache the CSS-derived uniforms (tint, event tint, dark mode).
-   *  Called on connect, on a `tint` change, and on a theme change — NEVER per
+   *  Called on connect, on a `mode`/`tint` change, and on a theme change — NEVER per
    *  frame. Each call uses getComputedStyle and (via colorToVec3) a one-shot
    *  probe appended to document.body, so running it every animation frame
    *  forced a full-document style recalc — the flicker. The values only change
    *  on a theme/tint switch, so caching them is safe. */
   #refreshColorUniforms(): void {
-    const tintAttr = this.getAttribute('tint') ?? '';
+    const tintAttr =
+      this.getAttribute('tint') ?? (this.mode === 'cone' ? SUGAR_GLASS_PRESETS.caramel.tint : '');
     this.#tintVec = colorToVec3(tintAttr, [0.545, 0.361, 0.965]);
     this.#evtVec = colorToVec3(tintAttr, [0.957, 0.247, 0.369]);
     this.#darkVal = this.#darkUniform();
@@ -840,13 +805,8 @@ export class SliccShader extends HTMLElement {
       u.u_scroll ?? null,
       (this.scrollOffset * SCROLL_PARALLAX) / Math.max(1, cv.clientHeight || cv.height)
     );
-    // Cone-mode knobs — pulled verbatim from the prototype's frame loop. u_blink
-    // in particular is 0.05 (NOT 1.0): the Game-of-Life cells breathe slowly.
-    gl.uniform1f(u.u_density ?? null, 0.29);
     gl.uniform1f(u.u_falloff ?? null, 0.3);
     gl.uniform1f(u.u_life ?? null, 0.35);
-    gl.uniform1f(u.u_blink ?? null, 0.05);
-    gl.uniform1f(u.u_thick ?? null, 0.02);
     gl.uniform3f(u.u_tint ?? null, tint[0], tint[1], tint[2]);
     gl.uniform1f(u.u_brightness ?? null, this.brightness);
     gl.uniform1f(u.u_contrast ?? null, this.contrast);

--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -683,22 +683,21 @@ export class SliccShader extends HTMLElement {
     if (!gl) return false;
     this.#gl = gl;
     this.#installContextHandlers(cv);
-    return this.#setupGlResources();
+    if (this.#setupGlResources()) return true;
+    // Resource setup can fail after acquiring a context and compiling a program
+    // (for example when buffer allocation is exhausted). Keep #gl alive until
+    // disposal so the partial program and the context are actually released.
+    this.#dispose();
+    return false;
   }
 
   /** Link the active mode and (re)build the fullscreen-triangle buffer. */
   #setupGlResources(): boolean {
     const gl = this.#gl;
     if (!gl) return false;
-    if (!this.#linkMode()) {
-      this.#gl = null;
-      return false;
-    }
+    if (!this.#linkMode()) return false;
     const buf = gl.createBuffer();
-    if (!buf) {
-      this.#gl = null;
-      return false;
-    }
+    if (!buf) return false;
     this.#buffer = buf;
     gl.bindBuffer(gl.ARRAY_BUFFER, buf);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);

--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -19,6 +19,7 @@ import { h, sheet } from '../internal/dom.js';
  * @attr mode - `cone` (default) | `scoop` | `freezer` | `sugar`
  * @attr tint - CSS color washed into the scoop field / event glow (the active accent)
  * @attr coverage - 0..1 freezer frost growth / sugar cell density and geometry
+ * @attr speed - 0..2 sugar animation rate multiplier (default 1)
  * @attr scroll - chat scroll offset in CSS px; pans the field with the content
  * @attr intensity - multiplier for coverage (freezer)
  * @attr no-webgl - reflected when WebGL is unavailable (CSS fallback)
@@ -147,10 +148,11 @@ void main(){
 }`;
 
 // Sugar Glass adapted from pbakaus/radiant (MIT), static/sugar-glass.html.
-// Uniform mapping: u_time*(u_life+0.15) is crack speed; u_falloff is light
+// Uniform mapping: u_time*(u_life+0.15)*u_speed is crack speed; u_falloff is light
 // bleed; u_center replaces mouse parallax; u_scroll pans the field; u_tint
 // washes the glass; u_energy/u_evt pulse at u_center; u_dark selects palette.
 const FRAG_SUGAR = `${HEAD}${NOISE}
+uniform float u_speed;
 vec2 sugarHash(vec2 p){ p=vec2(dot(p,vec2(127.1,311.7)),dot(p,vec2(269.5,183.3))); return fract(sin(p)*43758.5453123); }
 vec3 sugarVoronoi(vec2 p,float t){
   vec2 n=floor(p),f=fract(p),nearPt=vec2(0.0),nearCell=vec2(0.0); float minDist=8.0;
@@ -184,7 +186,7 @@ vec3 sugarLattice(vec2 p,float scale){
 void main(){
   vec2 uv=gl_FragCoord.xy/u_res; float aspect=u_res.x/u_res.y;
   vec2 p=(gl_FragCoord.xy-u_res*0.5)/min(u_res.x,u_res.y); p.y-=u_scroll;
-  vec2 parallax=-(u_center-0.5)*0.15; float t=u_time*(u_life+0.15);
+  vec2 parallax=-(u_center-0.5)*0.15; float t=u_time*(u_life+0.15)*u_speed;
   p+=vec2(sin(p.y*12.0+t*2.3),cos(p.x*10.0+t*1.7))*0.003;
   float sugarCoverage=clamp(u_freeze/2.2,0.0,1.0);
   float waffleMask=step(0.82,sugarCoverage);
@@ -239,11 +241,13 @@ export interface SugarGlassPreset {
   readonly noise: number;
   readonly blur: number;
   readonly coverage: number;
+  readonly speed: number;
 }
 
 /**
  * Tuned Sugar Glass storyboard presets (all remain within the 20% background budget):
  * - Caramel — Radiant-like warm amber cells with visible crack light.
+ * - Caramel-waffle — Caramel's field with the current Cone brightness and contrast.
  * - Frosted — broad, quiet seams and restrained contrast for maximum prose legibility.
  * - Brittle — dense small cells, sharp bright fractures, and low glass fill.
  * - Waffle-glass — sugar rendering over Cone's 45-degree, half-sheared lattice geometry.
@@ -253,11 +257,22 @@ export const SUGAR_GLASS_PRESETS = {
   caramel: {
     mode: 'sugar',
     tint: '#d08a3c',
-    brightness: 1,
-    contrast: 1,
+    brightness: 1.1,
+    contrast: 1.1,
     noise: 0.025,
     blur: 0.14,
     coverage: 0.28,
+    speed: 0.25,
+  },
+  'caramel-waffle': {
+    mode: 'sugar',
+    tint: '#d08a3c',
+    brightness: 1.2,
+    contrast: 0.75,
+    noise: 0.025,
+    blur: 0.14,
+    coverage: 0.28,
+    speed: 1,
   },
   frosted: {
     mode: 'sugar',
@@ -267,6 +282,7 @@ export const SUGAR_GLASS_PRESETS = {
     noise: 0.005,
     blur: 0.9,
     coverage: 0.08,
+    speed: 1,
   },
   brittle: {
     mode: 'sugar',
@@ -276,6 +292,7 @@ export const SUGAR_GLASS_PRESETS = {
     noise: 0.055,
     blur: 0.02,
     coverage: 0.68,
+    speed: 1,
   },
   'waffle-glass': {
     mode: 'sugar',
@@ -285,6 +302,7 @@ export const SUGAR_GLASS_PRESETS = {
     noise: 0.02,
     blur: 0.08,
     coverage: 0.9,
+    speed: 1,
   },
 } as const satisfies Readonly<Record<string, SugarGlassPreset>>;
 export type SugarGlassPresetName = keyof typeof SUGAR_GLASS_PRESETS;
@@ -340,6 +358,7 @@ const UNIFORMS = [
   'u_contrast',
   'u_noise',
   'u_blur',
+  'u_speed',
 ] as const;
 type UniformName = (typeof UNIFORMS)[number];
 
@@ -381,6 +400,7 @@ export class SliccShader extends HTMLElement {
     'contrast',
     'noise',
     'blur',
+    'speed',
   ];
 
   readonly #root: ShadowRoot;
@@ -544,6 +564,14 @@ export class SliccShader extends HTMLElement {
   }
   set blurAmount(value: number) {
     this.setAttribute('blur', String(value));
+  }
+
+  /** Sugar-mode animation rate multiplier (0 = paused, 1 = current rate). */
+  get speed(): number {
+    return clampNum(Number.parseFloat(this.getAttribute('speed') ?? ''), 0, 2, 1);
+  }
+  set speed(value: number) {
+    this.setAttribute('speed', String(value));
   }
 
   get noWebgl(): boolean {
@@ -824,6 +852,7 @@ export class SliccShader extends HTMLElement {
     gl.uniform1f(u.u_contrast ?? null, this.contrast);
     gl.uniform1f(u.u_noise ?? null, this.noise);
     gl.uniform1f(u.u_blur ?? null, this.blurAmount);
+    gl.uniform1f(u.u_speed ?? null, this.speed);
     gl.drawArrays(gl.TRIANGLES, 0, 3);
     // Energy decays toward rest.
     this.#energy *= 0.95;

--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -2,20 +2,21 @@ import { define } from '../internal/define.js';
 import { h, sheet } from '../internal/dom.js';
 
 /**
- * The SLICC background field — a single WebGL element with THREE program modes,
+ * The SLICC background field — a single WebGL element with four program modes,
  * lifted from the prototype's shared `#bg-canvas` (proto/StellarRubySwift.html,
  * `__sliccShaders`): `cone` (a sheared waffle lattice that behaves like a
  * probabilistic Game of Life near a floating focal point), `scoop` (a lush
  * flowing ice-cream gradient that swirls and breathes), and `freezer` (water
- * crystallizing into ice from the corner). One canvas, one program swapped by
+ * crystallizing into ice from the corner), and `sugar` (caramelized glass with
+ * Voronoi fractures). One canvas, one program swapped by
  * the `mode` attribute — exactly as the prototype swaps `FRAG_CONE` / `FRAG_SCOOP`
- * / `FRAG_FREEZER`.
+ * / `FRAG_FREEZER` / `FRAG_SUGAR`.
  *
  * Sits behind the app (`position: fixed; inset: 0; z-index: 0; pointer-events:
  * none`). Honors `prefers-reduced-motion` (one static frame), pauses on
  * disconnect, and falls back to a per-mode CSS gradient when WebGL is absent.
  *
- * @attr mode - `cone` (default) | `scoop` | `freezer`
+ * @attr mode - `cone` (default) | `scoop` | `freezer` | `sugar`
  * @attr tint - CSS color washed into the scoop field / event glow (the active accent)
  * @attr coverage - 0..1 freezer frost growth (feeds `u_freeze`)
  * @attr scroll - chat scroll offset in CSS px; pans the field with the content
@@ -145,15 +146,82 @@ void main(){
   gl_FragColor=vec4(col,1.0);
 }`;
 
-export type ShaderMode = 'cone' | 'scoop' | 'freezer';
+// Sugar Glass adapted from pbakaus/radiant (MIT), static/sugar-glass.html.
+// Uniform mapping: u_time*(u_life+0.15) is crack speed; u_falloff is light
+// bleed; u_center replaces mouse parallax; u_scroll pans the field; u_tint
+// washes the glass; u_energy/u_evt pulse at u_center; u_dark selects palette.
+const FRAG_SUGAR = `${HEAD}${NOISE}
+vec2 sugarHash(vec2 p){ p=vec2(dot(p,vec2(127.1,311.7)),dot(p,vec2(269.5,183.3))); return fract(sin(p)*43758.5453123); }
+vec3 sugarVoronoi(vec2 p,float t){
+  vec2 n=floor(p),f=fract(p),nearPt=vec2(0.0),nearCell=vec2(0.0); float minDist=8.0;
+  for(int j=-1;j<=1;j++){ for(int i=-1;i<=1;i++){ vec2 g=vec2(float(i),float(j));
+    vec2 o=sugarHash(n+g)*0.5+0.25; o=0.5+0.4*sin(t*0.3+6.2831*o); vec2 d=g+o-f; float dd=dot(d,d);
+    if(dd<minDist){ minDist=dd; nearPt=d; nearCell=n+g; } } }
+  float edge=8.0;
+  for(int j=-1;j<=1;j++){ for(int i=-1;i<=1;i++){ vec2 g=vec2(float(i),float(j));
+    vec2 o=sugarHash(n+g)*0.5+0.25; o=0.5+0.4*sin(t*0.3+6.2831*o); vec2 d=g+o-f; vec2 delta=d-nearPt;
+    if(dot(delta,delta)>0.001) edge=min(edge,dot(0.5*(nearPt+d),normalize(delta))); } }
+  return vec3(sqrt(minDist),edge,hash21(nearCell));
+}
+float sugarEdge(vec2 p,float t){
+  vec2 n=floor(p),f=fract(p),nearPt=vec2(0.0); float minDist=8.0;
+  for(int j=-1;j<=1;j++){ for(int i=-1;i<=1;i++){ vec2 g=vec2(float(i),float(j));
+    vec2 o=sugarHash(n+g); o=0.5+0.35*sin(t*0.5+6.2831*o); vec2 d=g+o-f; float dd=dot(d,d);
+    if(dd<minDist){ minDist=dd; nearPt=d; } } }
+  float edge=8.0;
+  for(int j=-1;j<=1;j++){ for(int i=-1;i<=1;i++){ vec2 g=vec2(float(i),float(j));
+    vec2 o=sugarHash(n+g); o=0.5+0.35*sin(t*0.5+6.2831*o); vec2 d=g+o-f; vec2 delta=d-nearPt;
+    if(dot(delta,delta)>0.001) edge=min(edge,dot(0.5*(nearPt+d),normalize(delta))); } }
+  return edge;
+}
+void main(){
+  vec2 uv=gl_FragCoord.xy/u_res; float aspect=u_res.x/u_res.y;
+  vec2 p=(gl_FragCoord.xy-u_res*0.5)/min(u_res.x,u_res.y); p.y-=u_scroll;
+  vec2 parallax=-(u_center-0.5)*0.15; float t=u_time*(u_life+0.15);
+  p+=vec2(sin(p.y*12.0+t*2.3),cos(p.x*10.0+t*1.7))*0.003;
+  float scale=3.25+u_density*0.85; vec3 macro=sugarVoronoi((p+parallax)*scale+0.5,t);
+  float microEdge=sugarEdge((p+parallax*2.5)*9.0+vec2(3.7,1.2),t*0.7);
+  float crackPulse=0.5+0.3*sin(t*1.5)+0.2*sin(t*2.7+1.0);
+  float macroWidth=0.04*crackPulse, microWidth=0.025*crackPulse;
+  float macroCrack=1.0-smoothstep(0.0,macroWidth,macro.y);
+  float microCrack=1.0-smoothstep(0.0,microWidth,microEdge);
+  float crack=clamp(macroCrack+microCrack*0.4,0.0,1.0);
+  float macroGlow=1.0-smoothstep(0.0,macroWidth*4.0,macro.y);
+  float microGlow=1.0-smoothstep(0.0,microWidth*3.0,microEdge);
+  float glow=macroGlow*0.7+microGlow*0.3;
+  float thickness=0.6+0.4*macro.z, hue=macro.z*0.3;
+  vec3 amber=mix(vec3(0.78,0.585,0.424),vec3(0.34,0.16,0.035),u_dark);
+  vec3 caramel=mix(vec3(0.831,0.647,0.455),vec3(0.46,0.22,0.045),u_dark);
+  vec3 deepAmber=mix(vec3(0.29,0.125,0.0),vec3(0.10,0.035,0.0),u_dark);
+  vec3 glass=mix(deepAmber,mix(amber,caramel,hue),thickness);
+  glass=mix(glass*1.1,glass*0.85,smoothstep(0.0,0.5,macro.x));
+  vec3 rose=mix(vec3(0.90,0.65,0.60),vec3(0.42,0.19,0.10),u_dark);
+  glass=mix(glass,rose,glow*(0.3+0.2*sin(macro.z*12.0+t*0.8))*0.25);
+  glass=mix(glass,u_tint,0.06);
+  vec3 crackLight=mix(vec3(1.0,0.91,0.75),vec3(0.74,0.38,0.10),u_dark);
+  vec3 crackBright=mix(vec3(1.0,0.96,0.90),vec3(0.90,0.52,0.16),u_dark);
+  vec3 lightCol=mix(crackLight,crackBright,crack); float bleed=clamp(0.55+u_falloff*1.5,0.4,1.3);
+  vec3 col=mix(glass,lightCol*0.8,glow*bleed*0.5); col=mix(col,lightCol,crack*bleed);
+  float sss=0.5+0.5*sin(p.x*3.0+t*0.5)*sin(p.y*2.5+t*0.3); col+=vec3(0.05,0.03,0.01)*sss*thickness;
+  float vig=smoothstep(0.0,1.0,1.0-dot(p*0.8,p*0.8)); col*=0.6+0.4*vig; col=pow(col,vec3(0.95));
+  float focus=length(vec2((uv.x-u_center.x)*aspect,uv.y-u_center.y)); col+=u_evt*u_energy*exp(-focus*focus*10.0)*0.12;
+  /* Background budget: clamp the hero treatment, then expose at most 20%. */
+  vec3 bg=themeBg(); col=mix(bg,clamp(col,0.0,1.0),0.20);
+  float noiseFreq=mix(80.0,4.0,clamp(u_blur,0.0,1.0)); float grain=fbm(uv*noiseFreq)-0.5;
+  col+=u_noise*grain; col=(col-0.5)*u_contrast+0.5; col*=u_brightness; col=clamp(col,0.0,1.0);
+  gl_FragColor=vec4(col,1.0);
+}`;
+
+export type ShaderMode = 'cone' | 'scoop' | 'freezer' | 'sugar';
 const PROGRAMS: Record<ShaderMode, string> = {
   cone: FRAG_CONE,
   scoop: FRAG_SCOOP,
   freezer: FRAG_FREEZER,
+  sugar: FRAG_SUGAR,
 };
 /** Fragment sources, exposed so tests can compile and pixel-probe the fields. */
 export const SHADER_FRAGMENTS: Readonly<Record<ShaderMode, string>> = PROGRAMS;
-const MODES = new Set<ShaderMode>(['cone', 'scoop', 'freezer']);
+const MODES = new Set<ShaderMode>(['cone', 'scoop', 'freezer', 'sugar']);
 
 const FALLBACK: Record<ShaderMode, string> = {
   cone: 'radial-gradient(120% 120% at 35% 45%, color-mix(in srgb,#e0a866 40%,var(--bg)) 0%, var(--bg) 60%)',
@@ -161,6 +229,8 @@ const FALLBACK: Record<ShaderMode, string> = {
     'radial-gradient(120% 120% at 40% 50%, color-mix(in srgb,#ff9bc0 40%,var(--bg)) 0%, var(--bg) 62%)',
   freezer:
     'radial-gradient(120% 120% at 0% 100%, color-mix(in srgb,#7fb0e6 55%,var(--bg)) 0%, var(--bg) 70%)',
+  sugar:
+    'radial-gradient(120% 120% at 35% 45%, color-mix(in srgb,#c8956c 20%,var(--bg)) 0%, var(--bg) 70%)',
 };
 
 const STYLE = `

--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -130,7 +130,7 @@ vec3 sugarLattice(vec2 p,float scale){
 void main(){
   vec2 uv=gl_FragCoord.xy/u_res; float aspect=u_res.x/u_res.y;
   vec2 p=(gl_FragCoord.xy-u_res*0.5)/min(u_res.x,u_res.y); p.y-=u_scroll;
-  vec2 parallax=-(u_center-0.5)*0.15; float t=u_time*(u_life+0.15)*u_speed;
+  vec2 parallax=-(u_center-0.5)*0.15*sign(u_speed); float t=u_time*(u_life+0.15)*u_speed;
   p+=vec2(sin(p.y*12.0+t*2.3),cos(p.x*10.0+t*1.7))*0.003;
   float sugarCoverage=clamp(u_freeze/2.2,0.0,1.0);
   float waffleMask=step(0.82,sugarCoverage);

--- a/packages/webcomponents/src/showcase/app.stories.ts
+++ b/packages/webcomponents/src/showcase/app.stories.ts
@@ -359,8 +359,8 @@ function app(opts: AppOpts): HTMLElement {
     'position:relative;transform:translateZ(0);width:100%;height:100vh;overflow:hidden;' +
     'background:var(--bg);font-family:var(--ui);';
 
-  // The cone background field (the chat context's animated waffle lattice).
-  const shader = el('slicc-shader', { mode: 'cone', tint: 'var(--waffle)' });
+  // The cone background field (the chat context's Caramel Sugar Glass).
+  const shader = el('slicc-shader', { mode: 'cone' });
   shader.style.cssText = 'position:absolute;inset:0;z-index:0;';
   frame.append(shader);
 

--- a/packages/webcomponents/tests/freezer/slicc-shader.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-shader.test.ts
@@ -178,6 +178,30 @@ describe('slicc-shader', () => {
     await frame();
     expect(() => el.remove()).not.toThrow();
   });
+
+  it('releases partial GL resources when initialization fails', () => {
+    const createBufferSpy = vi
+      .spyOn(WebGLRenderingContext.prototype, 'createBuffer')
+      .mockImplementation(() => null as unknown as WebGLBuffer);
+    const deleteProgramSpy = vi.spyOn(WebGLRenderingContext.prototype, 'deleteProgram');
+    const deleteShaderSpy = vi.spyOn(WebGLRenderingContext.prototype, 'deleteShader');
+    const getExtensionSpy = vi.spyOn(WebGLRenderingContext.prototype, 'getExtension');
+    try {
+      const el = mount();
+      if (createBufferSpy.mock.calls.length === 0) return;
+      expect(el.noWebgl).toBe(true);
+      expect(deleteProgramSpy).toHaveBeenCalledOnce();
+      expect(deleteShaderSpy).toHaveBeenCalledTimes(2);
+      expect(getExtensionSpy).toHaveBeenCalledWith('WEBGL_lose_context');
+      const canvas = el.shadowRoot?.querySelector('canvas') as HTMLCanvasElement;
+      expect(canvas.getContext('webgl')?.isContextLost()).toBe(true);
+    } finally {
+      createBufferSpy.mockRestore();
+      deleteProgramSpy.mockRestore();
+      deleteShaderSpy.mockRestore();
+      getExtensionSpy.mockRestore();
+    }
+  });
 });
 
 describe('slicc-shader program cache + immediate repaint (anti-flicker)', () => {

--- a/packages/webcomponents/tests/freezer/slicc-shader.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-shader.test.ts
@@ -488,6 +488,34 @@ describe('cone Sugar Glass field colors', () => {
     expect(cone).toContain('float waffleMask=step(0.82,sugarCoverage);');
   });
 
+  it('freezes all cone motion at speed zero while keeping positive-speed parallax', () => {
+    const pausedStart = renderFragment(SHADER_FRAGMENTS.cone, {
+      ...CONE_UNIFORMS,
+      u_time: 0,
+      u_center: [0.2, 0.3],
+      u_speed: 0,
+    });
+    const pausedLater = renderFragment(SHADER_FRAGMENTS.cone, {
+      ...CONE_UNIFORMS,
+      u_time: 120,
+      u_center: [0.8, 0.7],
+      u_speed: 0,
+    });
+    if (!pausedStart || !pausedLater) return;
+    expect(pausedLater).toEqual(pausedStart);
+
+    const movingStart = renderFragment(SHADER_FRAGMENTS.cone, {
+      ...CONE_UNIFORMS,
+      u_center: [0.2, 0.3],
+    });
+    const movingLater = renderFragment(SHADER_FRAGMENTS.cone, {
+      ...CONE_UNIFORMS,
+      u_center: [0.8, 0.7],
+    });
+    if (!movingStart || !movingLater) return;
+    expect(movingLater).not.toEqual(movingStart);
+  });
+
   it.each([
     ['light', 0, [0.97, 0.95, 0.89]],
     ['dark', 1, [0.09, 0.08, 0.06]],

--- a/packages/webcomponents/tests/freezer/slicc-shader.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-shader.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { SHADER_FRAGMENTS, SliccShader } from '../../src/freezer/slicc-shader.js';
+import {
+  SHADER_FRAGMENTS,
+  SliccShader,
+  SUGAR_GLASS_PRESETS,
+} from '../../src/freezer/slicc-shader.js';
 import { ensureGlobalTokens } from '../../src/theme/tokens.js';
 
 function mount(attrs: Record<string, string> = {}): SliccShader {
@@ -25,7 +29,7 @@ describe('slicc-shader', () => {
     expect(el.shadowRoot?.querySelector('[part="fallback"]')).not.toBeNull();
   });
 
-  it('defaults to cone mode and accepts cone/scoop/freezer', () => {
+  it('defaults to cone mode and accepts the three distinct programs', () => {
     expect(mount().mode).toBe('cone');
     expect(mount({ mode: 'scoop' }).mode).toBe('scoop');
     expect(mount({ mode: 'freezer' }).mode).toBe('freezer');
@@ -66,16 +70,25 @@ describe('slicc-shader', () => {
     expect(() => el.pulse()).not.toThrow();
   });
 
-  it('reflects cone-mode brightness/contrast/noise/blur knobs (tuned defaults)', () => {
+  it('uses the complete Caramel preset for an attribute-less cone', () => {
     const el = mount();
-    // Tuned defaults baked in so the cone field renders with the Storybook
-    // texture everywhere with no attributes required.
+    expect(el.getAttribute('tint')).toBeNull();
+    expect(el.coverage).toBe(SUGAR_GLASS_PRESETS.caramel.coverage);
+    expect(el.brightness).toBe(SUGAR_GLASS_PRESETS.caramel.brightness);
+    expect(el.contrast).toBe(SUGAR_GLASS_PRESETS.caramel.contrast);
+    expect(el.noise).toBe(SUGAR_GLASS_PRESETS.caramel.noise);
+    expect(el.blurAmount).toBe(SUGAR_GLASS_PRESETS.caramel.blur);
+    expect(el.speed).toBe(SUGAR_GLASS_PRESETS.caramel.speed);
+  });
+
+  it('reflects cone glass brightness/contrast/noise/blur knobs', () => {
+    const el = mount();
     // The blur attribute reflects to `blurAmount` because HTMLElement already
     // defines a `blur()` method — same renaming dance as `scroll`/`scrollOffset`.
-    expect(el.brightness).toBe(1.2);
-    expect(el.contrast).toBe(0.75);
-    expect(el.noise).toBeCloseTo(0.04, 5);
-    expect(el.blurAmount).toBeCloseTo(0.09, 5);
+    expect(el.brightness).toBe(1.1);
+    expect(el.contrast).toBe(1.1);
+    expect(el.noise).toBeCloseTo(0.025, 5);
+    expect(el.blurAmount).toBeCloseTo(0.14, 5);
     // Property → attribute round-trip.
     el.brightness = 1.25;
     el.contrast = 1.5;
@@ -99,10 +112,33 @@ describe('slicc-shader', () => {
     el.setAttribute('contrast', 'nope');
     el.setAttribute('noise', 'nope');
     el.setAttribute('blur', 'nope');
-    expect(el.brightness).toBe(1.2);
-    expect(el.contrast).toBe(0.75);
-    expect(el.noise).toBeCloseTo(0.04, 5);
-    expect(el.blurAmount).toBeCloseTo(0.09, 5);
+    expect(el.brightness).toBe(1.1);
+    expect(el.contrast).toBe(1.1);
+    expect(el.noise).toBeCloseTo(0.025, 5);
+    expect(el.blurAmount).toBeCloseTo(0.14, 5);
+  });
+
+  it('reflects and clamps the cone glass animation speed (Caramel default 0.25)', () => {
+    const el = mount();
+    expect(el.speed).toBe(0.25);
+    el.speed = 0.25;
+    expect(el.getAttribute('speed')).toBe('0.25');
+    expect(el.speed).toBe(0.25);
+    el.setAttribute('speed', '-1');
+    expect(el.speed).toBe(0);
+    el.setAttribute('speed', '99');
+    expect(el.speed).toBe(2);
+    el.setAttribute('speed', 'nope');
+    expect(el.speed).toBe(0.25);
+  });
+
+  it('keeps the cone glass render loop healthy when speed is zero', async () => {
+    const el = mount({ speed: '0' });
+    await frame();
+    await frame();
+    expect(el.speed).toBe(0);
+    const canvas = el.shadowRoot?.querySelector('canvas') as HTMLCanvasElement;
+    expect(el.noWebgl || canvas.width > 0).toBe(true);
   });
 
   it('cone fragment program references the new brightness/contrast/noise/blur uniforms', () => {
@@ -116,6 +152,22 @@ describe('slicc-shader', () => {
     expect(cone).toContain('u_contrast');
     expect(cone).toContain('u_noise');
     expect(cone).toContain('u_blur');
+  });
+
+  it('leaves every declared uniform read by a program', () => {
+    const sources = Object.values(SHADER_FRAGMENTS);
+    const declarations = new Set(
+      sources.flatMap((source) =>
+        [...source.matchAll(/uniform\s+\w+\s+(u_\w+)/g)].map((match) => match[1])
+      )
+    );
+    for (const name of declarations) {
+      const declaration = new RegExp(`uniform\\s+\\w+\\s+${name};`, 'g');
+      expect(
+        sources.some((source) => source.replace(declaration, '').includes(name)),
+        `${name} is declared but unread`
+      ).toBe(true);
+    }
   });
 
   it('keeps the canvas pointer-transparent and disposes cleanly', async () => {
@@ -328,6 +380,173 @@ describe('freezer field colors (inside-of-a-freezer, not sand)', () => {
     // And no animated term reads the raw clock directly anymore.
     const body = SHADER_FRAGMENTS.freezer.split('float t=u_time*0.08;')[1] ?? '';
     expect(body).not.toContain('u_time');
+  });
+});
+
+describe('cone Sugar Glass field colors', () => {
+  const CONE_UNIFORMS = {
+    u_res: [64, 64],
+    u_time: 2,
+    u_energy: 0,
+    u_center: [0.35, 0.55],
+    u_evt: [0.95, 0.25, 0.37],
+    u_falloff: 0.3,
+    u_life: 0.35,
+    u_freeze: SUGAR_GLASS_PRESETS.caramel.coverage * 2.2,
+    u_tint: tintVec(SUGAR_GLASS_PRESETS.caramel.tint),
+    u_scroll: 0,
+    u_brightness: SUGAR_GLASS_PRESETS.caramel.brightness,
+    u_contrast: SUGAR_GLASS_PRESETS.caramel.contrast,
+    u_noise: SUGAR_GLASS_PRESETS.caramel.noise,
+    u_blur: SUGAR_GLASS_PRESETS.caramel.blur,
+    u_speed: SUGAR_GLASS_PRESETS.caramel.speed,
+  };
+
+  function tintVec(tint: string): [number, number, number] {
+    return [1, 3, 5].map((start) => Number.parseInt(tint.slice(start, start + 2), 16) / 255) as [
+      number,
+      number,
+      number,
+    ];
+  }
+
+  it('exports five exact, reachable storyboard presets', () => {
+    expect(SUGAR_GLASS_PRESETS).toEqual({
+      caramel: {
+        mode: 'cone',
+        tint: '#d08a3c',
+        brightness: 1.1,
+        contrast: 1.1,
+        noise: 0.025,
+        blur: 0.14,
+        coverage: 0.28,
+        speed: 0.25,
+      },
+      'caramel-soft': {
+        mode: 'cone',
+        tint: '#d08a3c',
+        brightness: 1.2,
+        contrast: 0.75,
+        noise: 0.025,
+        blur: 0.14,
+        coverage: 0.28,
+        speed: 1,
+      },
+      frosted: {
+        mode: 'cone',
+        tint: '#ead9bd',
+        brightness: 1,
+        contrast: 0.55,
+        noise: 0.005,
+        blur: 0.9,
+        coverage: 0.08,
+        speed: 1,
+      },
+      brittle: {
+        mode: 'cone',
+        tint: '#ffd089',
+        brightness: 0.96,
+        contrast: 1.2,
+        noise: 0.055,
+        blur: 0.02,
+        coverage: 0.68,
+        speed: 1,
+      },
+      'waffle-glass': {
+        mode: 'cone',
+        tint: '#d3a15f',
+        brightness: 1,
+        contrast: 0.9,
+        noise: 0.02,
+        blur: 0.08,
+        coverage: 0.9,
+        speed: 1,
+      },
+    });
+
+    for (const preset of Object.values(SUGAR_GLASS_PRESETS)) {
+      const attrs = Object.fromEntries(
+        Object.entries(preset).map(([name, value]) => [name, String(value)])
+      );
+      const el = mount(attrs);
+      expect(el.mode).toBe('cone');
+      expect(el.getAttribute('tint')).toBe(preset.tint);
+      expect(el.brightness).toBe(preset.brightness);
+      expect(el.contrast).toBe(preset.contrast);
+      expect(el.noise).toBe(preset.noise);
+      expect(el.blurAmount).toBe(preset.blur);
+      expect(el.coverage).toBe(preset.coverage);
+      expect(el.speed).toBe(preset.speed);
+      el.remove();
+    }
+  });
+
+  it('keeps Cone sheared-lattice geometry in the Waffle-glass branch', () => {
+    const cone = SHADER_FRAGMENTS.cone;
+    expect(cone).toContain('cos(0.7853981634)');
+    expect(cone).toContain('g.x+=g.y*0.5');
+    expect(cone).toContain('float waffleMask=step(0.82,sugarCoverage);');
+  });
+
+  it.each([
+    ['light', 0, [0.97, 0.95, 0.89]],
+    ['dark', 1, [0.09, 0.08, 0.06]],
+  ] as const)(
+    'default cone stays inside the 20%% background wash budget in %s',
+    (_name, uDark, bg) => {
+      const px = renderFragment(SHADER_FRAGMENTS.cone, { ...CONE_UNIFORMS, u_dark: uDark });
+      if (!px) return;
+      for (let i = 0; i < px.length; i += 4) {
+        expect(Math.abs(px[i] - bg[0] * 255)).toBeLessThanOrEqual(52);
+        expect(Math.abs(px[i + 1] - bg[1] * 255)).toBeLessThanOrEqual(52);
+        expect(Math.abs(px[i + 2] - bg[2] * 255)).toBeLessThanOrEqual(52);
+      }
+    }
+  );
+
+  it.each([
+    ['light', 0, [0.97, 0.95, 0.89]],
+    ['dark', 1, [0.09, 0.08, 0.06]],
+  ] as const)('keeps every preset inside the 20%% budget in %s mode', (_name, uDark, bg) => {
+    for (const preset of Object.values(SUGAR_GLASS_PRESETS)) {
+      const px = renderFragment(SHADER_FRAGMENTS.cone, {
+        ...CONE_UNIFORMS,
+        u_dark: uDark,
+        u_tint: tintVec(preset.tint),
+        u_brightness: preset.brightness,
+        u_contrast: preset.contrast,
+        u_noise: preset.noise,
+        u_blur: preset.blur,
+        u_freeze: preset.coverage * 2.2,
+        u_speed: preset.speed,
+      });
+      if (!px) continue;
+      for (let i = 0; i < px.length; i += 4) {
+        expect(Math.abs(px[i] - bg[0] * 255)).toBeLessThanOrEqual(52);
+        expect(Math.abs(px[i + 1] - bg[1] * 255)).toBeLessThanOrEqual(52);
+        expect(Math.abs(px[i + 2] - bg[2] * 255)).toBeLessThanOrEqual(52);
+      }
+    }
+  });
+
+  it('renders warm glass in both themes and carries the shared post chain', () => {
+    for (const uDark of [0, 1]) {
+      const px = renderFragment(SHADER_FRAGMENTS.cone, { ...CONE_UNIFORMS, u_dark: uDark });
+      if (!px) continue;
+      const { r, b } = meanRgb(px);
+      expect(r).toBeGreaterThan(b);
+    }
+    const cone = SHADER_FRAGMENTS.cone;
+    expect(cone).toContain('vec3 bg=themeBg(); col=mix(bg,clamp(col,0.0,1.0),0.20);');
+    expect(cone).toContain('u_time*(u_life+0.15)*u_speed');
+    expect(cone).toContain('u_center');
+    expect(cone).toContain('p.y-=u_scroll');
+    expect(cone).toContain('u_falloff');
+    expect(cone).toContain('u_tint');
+    expect(cone).toContain('u_evt*u_energy');
+    expect(cone).toContain('u_noise*grain');
+    expect(cone).toContain('u_contrast');
+    expect(cone).toContain('u_brightness');
   });
 });
 


### PR DESCRIPTION
## Summary

- Port Radiant's Sugar Glass shader into slicc-shader with four tuned presets and a light/dark Storybook storyboard with live per-panel controls.
- Add a reflected speed attribute, clamped from 0 to 2; the cone default is 0.25.
- Make tuned Caramel Sugar Glass the cone background while preserving the waffle-glass preset as a lattice variation.
- Add regression coverage for shader compilation, uniforms, speed, theme legibility, lifecycle behavior, and preset rendering.

## Why

Storyboard review selected the tuned Caramel treatment as the replacement for the old cone background. This makes that reviewed choice the production cone field and removes the obsolete parallel shader path.

## Approach / Implementation notes

- The Sugar Glass program is adapted from pbakaus/radiant, static/sugar-glass.html, under the MIT license. Attribution remains beside the ported shader source.
- Sugar Glass presets share one program and expose tuning through component attributes.
- The original waffle / Game-of-Life cone shader program is deleted, not deprecated or retained behind a flag.
- The exported ShaderMode type no longer includes sugar. Its public modes are cone, scoop, and freezer; cone now renders Sugar Glass.

## Cross-cutting impact

- Webcomponents owns the shader, presets, Storybook surface, and browser tests.
- Webapp cone call sites were updated to use the new cone defaults; CLI and extension both consume that same webapp path.
- Scoop and freezer shader programs, the unrelated cone context type, and the --waffle theme token are unchanged.
- No persisted state, server behavior, dependencies, or native floats change.

## Screenshots

### Storyboard — light

![Sugar Glass shader storyboard in light mode](https://pub-e4170b327f03406f9831a6f393b96e05.r2.dev/manual/sugar-glass/2d5ae8d1c/storyboard-light.png)

### Storyboard — dark

![Sugar Glass shader storyboard in dark mode](https://pub-e4170b327f03406f9831a6f393b96e05.r2.dev/manual/sugar-glass/2d5ae8d1c/storyboard-dark.png)

### Final Caramel cone — light

![Final Caramel cone background in light mode](https://pub-e4170b327f03406f9831a6f393b96e05.r2.dev/manual/sugar-glass/2d5ae8d1c/cone-light.jpg)

### Final Caramel cone — dark

![Final Caramel cone background in dark mode](https://pub-e4170b327f03406f9831a6f393b96e05.r2.dev/manual/sugar-glass/2d5ae8d1c/cone-dark.jpg)

## Test plan

- [x] npm run verify
- [x] node packages/dev-tools/tools/check-touched-exemptions.mjs
- [x] npm run typecheck
- [x] npm run test
- [x] npm run test:coverage
- [x] npm run build
- [x] npm run build -w @slicc/chrome-extension
- [x] npm run bundle-size
- [x] npm run build-storybook -w @slicc/webcomponents
- [x] New shader behavior is covered in packages/webcomponents/tests/freezer/slicc-shader.test.ts
- [x] UI evidence attached above for Storyboard and final cone in light and dark

**Pre-existing failures** (verified against the merge base, unrelated to this PR):

slicc-input-card > preserves the line breaks of pasted multi-line text fails identically on the merge base. It is the sole failure in the webcomponents browser run: 1766 passed and 1 failed. Please do not attribute it to this shader change.

## Documentation

- [x] No standalone documentation changes needed. Component API documentation, Storybook controls, and stories were updated with the implementation.

## Risk & rollback

The blast radius is the cone background in every float that renders the shared webapp component. Theme-budget regression tests cover light and dark readability. Rollback requires reverting this PR, which restores the deleted waffle program and the prior ShaderMode contract; there is no data migration or persisted state to unwind.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under dist
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API changes are intentional and reflected in component documentation and the breaking commit footer
- [x] Shared webapp callers used by CLI and extension were checked
