### PR TITLE
fix(release): embed iCloud KVS entitlement in signed macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
           APPLE_DISTRIBUTION_CERT_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERT_BASE64 }}
           APPLE_DISTRIBUTION_CERT_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERT_PASSWORD }}
+          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
 
@@ -166,6 +168,23 @@ jobs:
 
           # Store keychain path for later steps
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
+
+          # Decode the Developer ID provisioning profile that authorizes the
+          # iCloud ubiquity-kvstore entitlement and expose it (plus the KVS
+          # identifier) to the Publish step. semantic-release → release-native.mjs
+          # → packages/swift-launcher/sign-and-package.sh reads PROVISION_PROFILE
+          # (a file path) and KVSTORE_IDENTIFIER to embed the profile and sign the
+          # macOS app with cross-device tray sync enabled. Absent the secret the
+          # app still signs — it just degrades to local-only tray sessions.
+          if [ -n "${APPLE_PROVISIONING_PROFILE_BASE64:-}" ]; then
+            PROVISION_PROFILE_PATH="$RUNNER_TEMP/sliccstart.provisionprofile"
+            printf '%s' "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROVISION_PROFILE_PATH"
+            echo "PROVISION_PROFILE=$PROVISION_PROFILE_PATH" >> "$GITHUB_ENV"
+            echo "KVSTORE_IDENTIFIER=${APPLE_TEAM_ID}.ai.sliccy.trays" >> "$GITHUB_ENV"
+            echo "Provisioning profile decoded — macOS build will embed the iCloud KVS entitlement."
+          else
+            echo "No APPLE_PROVISIONING_PROFILE_BASE64 secret — signing without the iCloud KVS entitlement (local-only)."
+          fi
 
       - name: Publish release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,14 @@ jobs:
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
           APPLE_DISTRIBUTION_CERT_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERT_BASE64 }}
           APPLE_DISTRIBUTION_CERT_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERT_PASSWORD }}
-          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+          # macOS Developer ID provisioning profile for Sliccstart. This is a
+          # SEPARATE secret from APPLE_PROVISIONING_PROFILE_BASE64 (the iOS App
+          # Store profile for com.sliccy.follower, consumed by the TestFlight
+          # script) — reusing that one would embed a wrong-platform/bundle-id
+          # profile and codesign would fail fast. When this secret is unset the
+          # app signs with base entitlements only (tray sync degrades to
+          # local-only), so the release stays green until the profile is added.
+          APPLE_MACOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_MACOS_PROVISIONING_PROFILE_BASE64 }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
@@ -169,21 +176,21 @@ jobs:
           # Store keychain path for later steps
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
 
-          # Decode the Developer ID provisioning profile that authorizes the
-          # iCloud ubiquity-kvstore entitlement and expose it (plus the KVS
+          # Decode the macOS Developer ID provisioning profile that authorizes
+          # the iCloud ubiquity-kvstore entitlement and expose it (plus the KVS
           # identifier) to the Publish step. semantic-release → release-native.mjs
           # → packages/swift-launcher/sign-and-package.sh reads PROVISION_PROFILE
           # (a file path) and KVSTORE_IDENTIFIER to embed the profile and sign the
           # macOS app with cross-device tray sync enabled. Absent the secret the
           # app still signs — it just degrades to local-only tray sessions.
-          if [ -n "${APPLE_PROVISIONING_PROFILE_BASE64:-}" ]; then
+          if [ -n "${APPLE_MACOS_PROVISIONING_PROFILE_BASE64:-}" ]; then
             PROVISION_PROFILE_PATH="$RUNNER_TEMP/sliccstart.provisionprofile"
-            printf '%s' "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROVISION_PROFILE_PATH"
+            printf '%s' "$APPLE_MACOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROVISION_PROFILE_PATH"
             echo "PROVISION_PROFILE=$PROVISION_PROFILE_PATH" >> "$GITHUB_ENV"
             echo "KVSTORE_IDENTIFIER=${APPLE_TEAM_ID}.ai.sliccy.trays" >> "$GITHUB_ENV"
-            echo "Provisioning profile decoded — macOS build will embed the iCloud KVS entitlement."
+            echo "macOS provisioning profile decoded — build will embed the iCloud KVS entitlement."
           else
-            echo "No APPLE_PROVISIONING_PROFILE_BASE64 secret — signing without the iCloud KVS entitlement (local-only)."
+            echo "No APPLE_MACOS_PROVISIONING_PROFILE_BASE64 secret — signing without the iCloud KVS entitlement (local-only)."
           fi
 
       - name: Publish release

--- a/packages/swift-launcher/sign-and-package.sh
+++ b/packages/swift-launcher/sign-and-package.sh
@@ -34,9 +34,11 @@ if [ -n "${APPLE_TEAM_ID:-}" ]; then
   # exists.
   #
   # In CI, the release workflow (.github/workflows/release.yml, "Import Apple
-  # certificates" step) decodes the APPLE_PROVISIONING_PROFILE_BASE64 secret to
-  # a file and exports PROVISION_PROFILE + KVSTORE_IDENTIFIER for this script, so
-  # published macOS builds ship the iCloud KVS entitlement.
+  # certificates" step) decodes the macOS-specific
+  # APPLE_MACOS_PROVISIONING_PROFILE_BASE64 secret to a file and exports
+  # PROVISION_PROFILE + KVSTORE_IDENTIFIER for this script, so published macOS
+  # builds ship the iCloud KVS entitlement. (That is a distinct secret from the
+  # iOS App Store APPLE_PROVISIONING_PROFILE_BASE64 used by TestFlight.)
   if [ -n "${PROVISION_PROFILE:-}" ]; then
     if [ ! -f "$PROVISION_PROFILE" ]; then
       echo "ERROR: PROVISION_PROFILE set but file not found: $PROVISION_PROFILE" >&2

--- a/packages/swift-launcher/sign-and-package.sh
+++ b/packages/swift-launcher/sign-and-package.sh
@@ -32,6 +32,11 @@ if [ -n "${APPLE_TEAM_ID:-}" ]; then
   # sign against the base entitlements only, and the app degrades to a local
   # key-value cache (no sync) — so CI stays green until the profile secret
   # exists.
+  #
+  # In CI, the release workflow (.github/workflows/release.yml, "Import Apple
+  # certificates" step) decodes the APPLE_PROVISIONING_PROFILE_BASE64 secret to
+  # a file and exports PROVISION_PROFILE + KVSTORE_IDENTIFIER for this script, so
+  # published macOS builds ship the iCloud KVS entitlement.
   if [ -n "${PROVISION_PROFILE:-}" ]; then
     if [ ! -f "$PROVISION_PROFILE" ]; then
       echo "ERROR: PROVISION_PROFILE set but file not found: $PROVISION_PROFILE" >&2


### PR DESCRIPTION
## Summary

The release job signed `Sliccstart.app` with base entitlements only, so the cross-device iCloud tray sync shipped in #1760 / v5.88.0 was dormant in every published macOS build. This wires the iCloud `ubiquity-kvstore` entitlement into the signed release by decoding a **macOS-specific** provisioning profile and passing it to `sign-and-package.sh`.

## Why

Follow-up to #1760. v5.88.0 signed + notarized cleanly, but the release log's "Embedding provisioning profile for iCloud sync..." branch never fired (0 occurrences) because `PROVISION_PROFILE` (a file path) and `KVSTORE_IDENTIFIER` were never set. Users got a valid, notarized app whose tray sync silently degraded to local-only.

## Approach / Implementation notes

- `.github/workflows/release.yml` — in the "Import Apple certificates" step, decode a **new** `APPLE_MACOS_PROVISIONING_PROFILE_BASE64` secret to `$RUNNER_TEMP/sliccstart.provisionprofile` and export `PROVISION_PROFILE` + `KVSTORE_IDENTIFIER=${APPLE_TEAM_ID}.ai.sliccy.trays` via `$GITHUB_ENV`. semantic-release → `release-native.mjs` → `sign-and-package.sh` (which already consumes those two vars) then embeds the profile and signs with the iCloud KVS entitlement.
- **Dedicated secret (Codex P1 fix):** this is intentionally **not** the existing `APPLE_PROVISIONING_PROFILE_BASE64`, which is the iOS App Store profile for `com.sliccy.follower` consumed by `packages/ios-app/scripts/package-and-upload-testflight.sh`. Reusing that would embed a wrong-platform/bundle-id profile and make `codesign` fail fast (and repurposing it would break TestFlight).
- Non-breaking: if `APPLE_MACOS_PROVISIONING_PROFILE_BASE64` is unset, the step logs and skips, and the app signs with base entitlements exactly as today (local-only sessions). `codesign` fails fast if the embedded profile does not authorize the identifier.
- `packages/swift-launcher/sign-and-package.sh` gets a comment documenting the CI wiring. This also deliberately trips the macOS path gate in `release-native.mjs` (`MACOS_PATH_PREFIXES` = `packages/swift-launcher/`, …) so this fix's own release rebuilds + re-signs the app instead of skipping macOS packaging.

## Maintainer action required to activate sync in releases

Add a repo secret **`APPLE_MACOS_PROVISIONING_PROFILE_BASE64`** = base64 of a macOS **Developer ID** provisioning profile for Sliccstart that authorizes `com.apple.developer.ubiquity-kvstore-identifier = <TEAM_ID>.ai.sliccy.trays` (the bucket verified in manual two-device signing). Until then, releases keep shipping the app with local-only tray sessions (no regression).

## Cross-cutting impact

- **Floats exercised**: Sliccstart (macOS) only. No iOS TestFlight change — the iOS profile secret is untouched.
- **Security**: the profile is written to job-scoped `$RUNNER_TEMP` (cleaned with the keychain); only the decoded file *path* is exported, no secret value is echoed.

## Test plan

- [x] `actionlint .github/workflows/release.yml` — only the pre-existing `SC2086:info` at line 107 (`KEYCHAIN_PATH`, unchanged); new lines quote `"$GITHUB_ENV"`.
- [x] `bash -n packages/swift-launcher/sign-and-package.sh` — syntax OK.
- [x] `npx prettier --check .github/workflows/release.yml` — "All matched files use Prettier code style".
- [ ] Real verification is the post-merge release: once the secret is added, confirm the log prints "Embedding provisioning profile for iCloud sync..." and the notarized app carries the ubiquity-kvstore entitlement.

## Documentation

- [x] Inline docs in `release.yml` + `sign-and-package.sh` explain the secret contract.
- [ ] No other documentation changes needed

## Risk & rollback

- Blast radius: macOS release signing only. Worst case if the (future) profile secret is wrong/expired: `codesign` fails fast and the release job errors — no partially-signed artifact ships. Roll back by reverting this PR (returns to base-entitlement signing).
- Anything CI cannot catch: the entitlement embedding runs only in the real release job (needs the Apple secret), so it is verified on the post-merge release, not in PR CI.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] If this changes a contract used by other floats, I checked the relevant paths (iOS TestFlight secret left intact; `sign-and-package.sh` already reads `PROVISION_PROFILE`/`KVSTORE_IDENTIFIER`)
