### PR TITLE
fix(swift-launcher): activate iCloud KVS entitlement in signed releases

### DIFF
--- a/packages/swift-launcher/sign-and-package.sh
+++ b/packages/swift-launcher/sign-and-package.sh
@@ -39,8 +39,6 @@ if [ -n "${APPLE_TEAM_ID:-}" ]; then
   # PROVISION_PROFILE + KVSTORE_IDENTIFIER for this script, so published macOS
   # builds ship the iCloud KVS entitlement. (That is a distinct secret from the
   # iOS App Store APPLE_PROVISIONING_PROFILE_BASE64 used by TestFlight.)
-  # The macOS Developer ID profile secret is configured, so release builds embed
-  # the profile and cross-device tray sync is active in shipped builds.
   if [ -n "${PROVISION_PROFILE:-}" ]; then
     if [ ! -f "$PROVISION_PROFILE" ]; then
       echo "ERROR: PROVISION_PROFILE set but file not found: $PROVISION_PROFILE" >&2
@@ -63,6 +61,8 @@ if [ -n "${APPLE_TEAM_ID:-}" ]; then
         "Set :com.apple.developer.ubiquity-kvstore-identifier ${KVSTORE_IDENTIFIER}" \
         "$MERGED_ENTITLEMENTS"
     ENTITLEMENTS="$MERGED_ENTITLEMENTS"
+  else
+    echo "No provisioning profile — signing base entitlements only (tray sessions stay local, no cross-device sync)."
   fi
 
   codesign --force --options runtime --entitlements "$ENTITLEMENTS" \

--- a/packages/swift-launcher/sign-and-package.sh
+++ b/packages/swift-launcher/sign-and-package.sh
@@ -39,6 +39,8 @@ if [ -n "${APPLE_TEAM_ID:-}" ]; then
   # PROVISION_PROFILE + KVSTORE_IDENTIFIER for this script, so published macOS
   # builds ship the iCloud KVS entitlement. (That is a distinct secret from the
   # iOS App Store APPLE_PROVISIONING_PROFILE_BASE64 used by TestFlight.)
+  # The macOS Developer ID profile secret is configured, so release builds embed
+  # the profile and cross-device tray sync is active in shipped builds.
   if [ -n "${PROVISION_PROFILE:-}" ]; then
     if [ ! -f "$PROVISION_PROFILE" ]; then
       echo "ERROR: PROVISION_PROFILE set but file not found: $PROVISION_PROFILE" >&2


### PR DESCRIPTION
## Summary

Now that the `APPLE_MACOS_PROVISIONING_PROFILE_BASE64` repo secret is configured (the macOS Developer ID profile that authorizes `S8LB56P782.ai.sliccy.trays`), this cuts a release that rebuilds and re-signs `Sliccstart.app` so the shipped build finally carries the `com.apple.developer.ubiquity-kvstore-identifier` entitlement and cross-device iCloud tray sync is active for users.

## Why

Follow-up to #1763. That PR wired the release workflow to consume the macOS profile secret, but the secret didn't exist when v5.88.1 was built, so the shipped app still had base entitlements (local-only). The secret is now set. A release only rebuilds the macOS app when a `packages/swift-launcher/**` file changes since the last tag (the `release-native.mjs` macOS gate), so this `fix:` touches `sign-and-package.sh` to both cut a release and trip that gate.

## Approach / Implementation notes

- Adds an explicit `else`-branch log line in `packages/swift-launcher/sign-and-package.sh` for the no-profile path (release logs now state when the app is signed with base entitlements only / local sessions). This is a genuine observability improvement rather than PR-scoped state, and it keeps the swift-launcher diff that trips the macOS gate. The signing logic (embed profile + merged entitlements) already landed in #1763.
- `fix:` commit → semantic-release cuts a patch; the swift-launcher path change → `release-native.mjs` rebuilds + re-signs the macOS app, which now embeds the decoded profile.

## Cross-cutting impact

- **Floats exercised**: Sliccstart (macOS) only. No app/webapp/extension/worker code changes. iOS TestFlight untouched.

## Test plan

- [x] `bash -n packages/swift-launcher/sign-and-package.sh` — syntax OK.
- [ ] Post-merge release verification: the release log should now print `macOS provisioning profile decoded …` then `Embedding provisioning profile for iCloud sync...`, and the notarized app should carry the `ubiquity-kvstore` entitlement (`codesign -d --entitlements - Sliccstart.app`).

## Documentation

- [x] Inline comment in `sign-and-package.sh`.
- [ ] No other documentation changes needed

## Risk & rollback

- Blast radius: macOS release signing only. If the profile is somehow invalid, `codesign` fails fast and the release job errors — no partially-signed artifact ships. Roll back by reverting; the workflow's absent-secret branch still degrades to base-entitlement signing.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
