### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -136,8 +136,8 @@
     },
     "swift-launcher": {
       "lines": 39,
-      "functions": 42,
-      "regions": 48
+      "functions": 43,
+      "regions": 50
     },
     "swift-optel": {
       "lines": 75,


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.