### PR TITLE
feat(swift-launcher): make Sliccstart a real default browser with session restore

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -65,6 +65,7 @@ Subsystems:
 - `link-discovery.md` — the standalone `discover` shell command and the `--discover` flag on `playwright-cli` subcommands (`fetch`, `goto`, `navigate`, `open`, `tab-new`); covers RFC 8288 / RFC 9727 parsing, emission, and the SLICC handoff/upskill rels
 - `urls.md` — production URL inventory
 - `electron.md` — Electron float workflow
+- `sliccstart-browser.md` — Sliccstart's browser-like surfaces: the macOS default-browser role (registration, Info.plist declarations, incoming-link routing over CDP) and previous-session tab restore
 
 Review & gotchas:
 

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -459,6 +459,32 @@ The extension SW runs `fetch()` in a Service Worker context, so the same browser
 - `packages/node-server/src/index.ts` — `/api/fetch-proxy` handler; decode + localhost-strip + default-origin synth
 - `packages/chrome-extension/src/fetch-proxy-shared.ts` — SW `handleFetchProxyConnectionAsync`; decode + default-origin synth + `installForbiddenHeaderRule` (DNR session-rule shim, fragment-keyed, cleanup in `finally`)
 
+## Downloaded `slicc` CLI: Notarization Without a Staple
+
+**The Problem**
+
+Release Darwin `slicc` binaries are Developer ID-signed with hardened runtime and
+notarized by `packages/slicc-cli/sign-and-package.sh`, but a **bare Mach-O
+executable cannot have a notarization ticket stapled**. A quarantined copy may
+therefore need Apple's online Gatekeeper lookup on first execution.
+
+**What This Means for Sliccstart**
+
+- The launcher's `URLSession` data download followed by `Data.write` does not
+  create or propagate `com.apple.quarantine`, so Sliccstart does not need to
+  strip that attribute after installing the binary.
+- Verification against the release channel confirmed that even a manually
+  quarantined signed release binary runs `--version` without a Gatekeeper
+  override.
+- `spctl --assess --type execute` is **not** a useful check here: it rejects bare
+  CLI executables as "not an app", so a failure says nothing about Gatekeeper's
+  actual verdict.
+
+**Related Files**
+
+- `packages/slicc-cli/sign-and-package.sh` — signing + notarization
+- `packages/swift-launcher/Sliccstart/Models/SliccCliDownloader.swift` — download, signature validation, atomic install
+
 ## Local Network Access: Launched Chrome Must Disable the Check
 
 **The Problem**

--- a/docs/sliccstart-browser.md
+++ b/docs/sliccstart-browser.md
@@ -130,6 +130,12 @@ swift-server keeps its own snapshot.
   cannot evict anything: verified against Chrome that two browser-level clients
   plus a live page session coexist, with the page session still answering
   `Runtime.evaluate` while the browser clients poll.
+- The read is bounded by `tabSnapshotReadTimeoutNanoseconds` (3s) and the socket
+  is closed on expiry. `runShutdownSequence` awaits `snapshotNow()` _before_
+  closing and force-killing the browser, so a browser that accepts the socket
+  and then stops answering must not be able to stall shutdown — the moment the
+  kill path matters most. `URLSessionWebSocketTask.receive()` has no deadline of
+  its own, so the timeout lives in the recorder.
 - `ChromeLaunchConfig.restoreUrls` → `buildLaunchArgs` appends them **after**
   `launchUrl`, because Chromium activates the first URL on the command line: the
   SLICC tab stays leftmost and focused (verified against Chrome 147).

--- a/docs/sliccstart-browser.md
+++ b/docs/sliccstart-browser.md
@@ -60,13 +60,26 @@ Contract test: `packages/swift-launcher/macos-permissions.test.mjs`.
    `topBrowser()`: the user can start any browser by hand, so the leader is not
    necessarily the head of the Browsers list, and re-deriving the pick here
    would foreground the wrong app and leave the link hidden.
-4. With no leader, the router starts the top ordered browser
-   (`AppOrdering.topBrowser(in:savedOrder:)` — the same pick startup auto-launch
-   uses) and waits up to ~45s for `SliccProcess.leaderBrowserEndpoint`,
-   re-attempting the launch every ~10s. A single attempt is not enough: it can
-   lose the race against startup's own auto-launch, or run while the app is
-   still bootstrapping. Links that never find a leader are reported through
+4. With no leader, the router starts the first browser in
+   `AppOrdering.orderedBrowsers(in:savedOrder:)` that is **not** already attached
+   to a remote tray as a follower, and waits up to ~45s for
+   `SliccProcess.leaderBrowserEndpoint`, re-attempting the launch every ~10s. A
+   single attempt is not enough: it can lose the race against startup's own
+   auto-launch, or run while the app is still bootstrapping. Links that never
+   find a leader are reported through
    `LauncherErrorReport.report(.openIncomingUrl, …)`.
+
+The follower skip matters because `launchStandalone` no-ops on a browser
+Sliccstart already launched, while `leaderBrowserEndpoint` ignores follower
+records: retrying that browser would burn the whole 45s budget and then drop the
+link. A browser that is merely still booting is deliberately **not** skipped —
+it is the leader-to-be, and starting a second browser instead would give the
+machine two leaders.
+
+Every delivery failure is reported, including a rejected `/json/activate` or a
+`/json/new` response with no target id: the tab exists but stays in the
+background, so silently swallowing that would foreground the browser on whatever
+tab the user was already on and make the clicked link look lost.
 
 `leaderBrowserEndpoint` pairs the CDP port with the launch record's key (the
 browser's bundle path) so callers cannot address one browser while activating
@@ -100,11 +113,23 @@ swift-server keeps its own snapshot.
   first-seen order, capped at `maxRestoredTabs` (50). The file is user-writable
   and every surviving entry becomes a Chrome argv slot, so a `--flag`-shaped or
   `file://` entry must never survive — `buildLaunchArgs` re-sanitizes as well.
-- `Sources/Browser/TabSessionRecorder.swift` — actor polling `/json/list` every
-  5s. Polling rather than subscribing to `Target.targetInfoChanged` keeps this off
-  the `/cdp` socket the webapp owns, so it cannot evict the leader's CDP session.
-  A failed or non-2xx poll is dropped rather than persisted, so a quitting browser
-  never erases the last good snapshot.
+- `Sources/Browser/TabSessionRecorder.swift` — actor polling the target list
+  every 5s. Polling rather than subscribing to `Target.targetInfoChanged` keeps
+  this off the `/cdp` socket the webapp owns, so it cannot evict the leader's CDP
+  session. A failed or non-2xx poll is dropped rather than persisted, so a
+  quitting browser never erases the last good snapshot.
+- **Incognito tabs are never written to disk.** `/json/list` lists an Incognito
+  page with nothing to distinguish it from a normal tab (verified against
+  Chrome), so the recorder reads `Target.getTargets` over the **browser** CDP
+  endpoint instead and keeps only targets whose `browserContextId` matches
+  `Target.getBrowserContexts`' `defaultBrowserContextId`. That field is optional
+  in the protocol, so a browser that does not report it fails **closed**: the
+  snapshot is skipped rather than written optimistically.
+- `Sources/Browser/CDPBrowserSession.swift` — the short-lived browser-endpoint
+  channel those two reads use. Chrome multiplexes browser-level clients, so this
+  cannot evict anything: verified against Chrome that two browser-level clients
+  plus a live page session coexist, with the page session still answering
+  `Runtime.evaluate` while the browser clients poll.
 - `ChromeLaunchConfig.restoreUrls` → `buildLaunchArgs` appends them **after**
   `launchUrl`, because Chromium activates the first URL on the command line: the
   SLICC tab stays leftmost and focused (verified against Chrome 147).
@@ -112,10 +137,10 @@ swift-server keeps its own snapshot.
   the server is up. `ShutdownContext.tabRecorder` takes the final snapshot in
   `runShutdownSequence` while CDP is still reachable — including the detach path,
   where the browser survives and the next full launch consumes the snapshot.
-- Restored order follows `/json/list`, which is roughly most-recently-used rather
-  than left-to-right tab order, so tab positions are not preserved. Pinned tabs,
-  tab groups, window layout, scroll positions, and per-tab back/forward history
-  are lost as well — the snapshot is URLs only.
+- Restored order follows the CDP target list, which is not left-to-right tab
+  order, so tab positions are not preserved. Pinned tabs, tab groups, window
+  layout, scroll positions, and per-tab back/forward history are lost as well —
+  the snapshot is URLs only.
 
 Not wired for `--serve-only` (it attaches to a browser it did not launch, so it
 knows neither the profile directory nor the SLICC origin set) or for
@@ -123,6 +148,6 @@ knows neither the profile directory nor the SLICC origin set) or for
 swift-server-only, so `packages/node-server/src/chrome-launch.ts` keeps the plain
 session wipe.
 
-Tests: `TabSessionStoreTests`, `TabSessionRecorderTests`, plus the restore-arg
-cases in `ChromeLauncherTests` and the snapshot ordering case in
-`GracefulShutdownHandlerTests`.
+Tests: `TabSessionStoreTests`, `TabSessionRecorderTests`,
+`CDPBrowserSessionTests`, plus the restore-arg cases in `ChromeLauncherTests` and
+the snapshot ordering case in `GracefulShutdownHandlerTests`.

--- a/docs/sliccstart-browser.md
+++ b/docs/sliccstart-browser.md
@@ -55,17 +55,23 @@ Contract test: `packages/swift-launcher/macos-permissions.test.mjs`.
    rejects GET on that endpoint since Chrome 111.
 3. `/json/new` creates the tab in the **background**, so the router follows up
    with `/json/activate/<targetId>` (id read from the `/json/new` response) and
-   activates the browser application.
+   activates the browser application. The app brought forward is the one that
+   owns the CDP port just written to (`LeaderBrowserEndpoint.appPath`), **not**
+   `topBrowser()`: the user can start any browser by hand, so the leader is not
+   necessarily the head of the Browsers list, and re-deriving the pick here
+   would foreground the wrong app and leave the link hidden.
 4. With no leader, the router starts the top ordered browser
    (`AppOrdering.topBrowser(in:savedOrder:)` — the same pick startup auto-launch
-   uses) and waits up to ~45s for `SliccProcess.leaderCdpPort`, re-attempting the
-   launch every ~10s. A single attempt is not enough: it can lose the race
-   against startup's own auto-launch, or run while the app is still
-   bootstrapping. Links that never find a leader are reported through
+   uses) and waits up to ~45s for `SliccProcess.leaderBrowserEndpoint`,
+   re-attempting the launch every ~10s. A single attempt is not enough: it can
+   lose the race against startup's own auto-launch, or run while the app is
+   still bootstrapping. Links that never find a leader are reported through
    `LauncherErrorReport.report(.openIncomingUrl, …)`.
 
-`leaderCdpPort` gates on a listening CDP port only. Unlike `isLeaderReady()` it
-does not wait for a tray join URL, because opening a plain tab does not need one.
+`leaderBrowserEndpoint` pairs the CDP port with the launch record's key (the
+browser's bundle path) so callers cannot address one browser while activating
+another. It gates on a listening CDP port only: unlike `isLeaderReady()` it does
+not wait for a tray join URL, because opening a plain tab does not need one.
 
 `NSWorkspace.open(_:withApplicationAt:)` is deliberately **not** used for
 delivery: the SLICC browser runs on its own `--user-data-dir`, so when the user

--- a/docs/sliccstart-browser.md
+++ b/docs/sliccstart-browser.md
@@ -1,0 +1,122 @@
+# Sliccstart as a Browser
+
+Two behaviors let the macOS launcher (`packages/swift-launcher/`) stand in for a
+web browser: it can hold the **default web browser** role, and a launched Chrome
+**reopens the previous session's tabs**. The first lives in the launcher, the
+second in `packages/swift-server/`.
+
+## Default Browser Role
+
+Sliccstart renders no web content. Holding the http/https handler role means
+links from other apps arrive in the launcher and are opened as tabs in the SLICC
+leader browser, starting that browser first when it is not running yet. The role
+is therefore offered next to "launch browser at startup" — without a leader
+waiting there would be nothing to hand links to.
+
+### Registration
+
+`Models/DefaultBrowserRegistration.swift`:
+
+- `isDefault()` asks LaunchServices who handles `probeURL` and compares against
+  `Bundle.main.bundleURL` on **resolved paths** (`matches`). The answer is
+  canonicalized and may differ by a trailing slash or a `.`-component, so
+  comparing `URL` values directly reports a false negative.
+- `makeDefault()` claims both `handledSchemes` (`http`, `https`) through
+  `NSWorkspace.setDefaultApplication(at:toOpenURLsWithScheme:)` and then
+  **re-reads** the role instead of trusting the absence of an error: macOS raises
+  its own confirmation panel, and a user who declines leaves the handler
+  unchanged with no error reported.
+- `isRegistrable` is `SliccBootstrapper.isBundled`. A `swift run` binary has no
+  `.app` bundle for LaunchServices to record, so the Settings control is disabled
+  rather than raising a prompt that cannot stick.
+
+`assemble-app.mjs` declares the matching Info.plist keys:
+
+- `CFBundleURLTypes` with `http` + `https` — what macOS reads to populate the
+  "Default web browser" list, and the precondition for a handler change to be
+  accepted at all. Keep in step with `handledSchemes`.
+- `CFBundleDocumentTypes` viewer entry for `public.html` / `public.xhtml` at
+  `LSHandlerRank: Alternate` — the document-side obligation, ranked below real
+  browsers so Sliccstart does not take over HTML files it was not asked about.
+
+Contract test: `packages/swift-launcher/macos-permissions.test.mjs`.
+
+### Routing an incoming link
+
+`Models/IncomingURLRouter.swift`, driven by
+`SliccstartAppDelegate.application(_:open:)`:
+
+1. `openableSchemes` keeps `http`, `https`, and `file` (the HTML documents the
+   bundle claims) and drops everything else — `javascript:`, `data:`, and app
+   schemes are never forwarded into the leader.
+2. With a leader running, each link becomes a tab through
+   `PUT /json/new?<percent-encoded url>`. Chrome reads the **whole query string**
+   as the target URL — a `?url=<url>` spelling silently opens `about:blank` — and
+   rejects GET on that endpoint since Chrome 111.
+3. `/json/new` creates the tab in the **background**, so the router follows up
+   with `/json/activate/<targetId>` (id read from the `/json/new` response) and
+   activates the browser application.
+4. With no leader, the router starts the top ordered browser
+   (`AppOrdering.topBrowser(in:savedOrder:)` — the same pick startup auto-launch
+   uses) and waits up to ~45s for `SliccProcess.leaderCdpPort`, re-attempting the
+   launch every ~10s. A single attempt is not enough: it can lose the race
+   against startup's own auto-launch, or run while the app is still
+   bootstrapping. Links that never find a leader are reported through
+   `LauncherErrorReport.report(.openIncomingUrl, …)`.
+
+`leaderCdpPort` gates on a listening CDP port only. Unlike `isLeaderReady()` it
+does not wait for a tray join URL, because opening a plain tab does not need one.
+
+`NSWorkspace.open(_:withApplicationAt:)` is deliberately **not** used for
+delivery: the SLICC browser runs on its own `--user-data-dir`, so when the user
+also has the same browser open on their normal profile, LaunchServices picks
+between the two instances non-deterministically. The CDP port only ever answers
+for the leader.
+
+Tests: `DefaultBrowserRegistrationTests`, `IncomingURLRouterTests`. The mutating
+`makeDefault()` is not unit-tested — it rewrites the real LaunchServices database
+and raises a modal system panel.
+
+## Tab Session Restore
+
+A launched Chrome reopens the tabs from the previous session, minus the SLICC
+tab: its bridge token is dead by the next launch, and a second leader tab
+restarts the `/cdp` eviction war that `ChromeLauncher.clearChromeSessionRestore`
+exists to prevent. Chrome's own session restore therefore stays wiped and
+swift-server keeps its own snapshot.
+
+- `Sources/Browser/TabSessionStore.swift` — one JSON file per profile at
+  `~/Library/Application Support/Slicc/sessions/<profile-dir>-tabs.json`, keyed
+  off the user-data-dir's last path component so each profile (and therefore each
+  serve port) keeps its own tab set. `sanitize` runs on **both** save and load:
+  absolute `http(s)` URLs with a host only, minus SLICC surfaces (an origin in
+  `hostedOrigins`, or a `bridge`/`bridgeToken` query parameter), deduplicated in
+  first-seen order, capped at `maxRestoredTabs` (50). The file is user-writable
+  and every surviving entry becomes a Chrome argv slot, so a `--flag`-shaped or
+  `file://` entry must never survive — `buildLaunchArgs` re-sanitizes as well.
+- `Sources/Browser/TabSessionRecorder.swift` — actor polling `/json/list` every
+  5s. Polling rather than subscribing to `Target.targetInfoChanged` keeps this off
+  the `/cdp` socket the webapp owns, so it cannot evict the leader's CDP session.
+  A failed or non-2xx poll is dropped rather than persisted, so a quitting browser
+  never erases the last good snapshot.
+- `ChromeLaunchConfig.restoreUrls` → `buildLaunchArgs` appends them **after**
+  `launchUrl`, because Chromium activates the first URL on the command line: the
+  SLICC tab stays leftmost and focused (verified against Chrome 147).
+- `ServerCommand` loads the snapshot before launch and starts the recorder once
+  the server is up. `ShutdownContext.tabRecorder` takes the final snapshot in
+  `runShutdownSequence` while CDP is still reachable — including the detach path,
+  where the browser survives and the next full launch consumes the snapshot.
+- Restored order follows `/json/list`, which is roughly most-recently-used rather
+  than left-to-right tab order, so tab positions are not preserved. Pinned tabs,
+  tab groups, window layout, scroll positions, and per-tab back/forward history
+  are lost as well — the snapshot is URLs only.
+
+Not wired for `--serve-only` (it attaches to a browser it did not launch, so it
+knows neither the profile directory nor the SLICC origin set) or for
+`--electron`. **node-server has no equivalent**: this is intentionally
+swift-server-only, so `packages/node-server/src/chrome-launch.ts` keeps the plain
+session wipe.
+
+Tests: `TabSessionStoreTests`, `TabSessionRecorderTests`, plus the restore-arg
+cases in `ChromeLauncherTests` and the snapshot ordering case in
+`GracefulShutdownHandlerTests`.

--- a/packages/swift-launcher/CLAUDE.md
+++ b/packages/swift-launcher/CLAUDE.md
@@ -87,7 +87,7 @@ The **Terminals** Settings tab persists these `UserDefaults` keys:
 
 `SliccCliLocator` resolves an executable in this order: the managed `~/Library/Application Support/Sliccstart/bin/slicc`, the repository's local `make build` output, its architecture-specific `make dist` output, then `/usr/local/bin`, `~/.local/bin`, and `/opt/homebrew/bin`. The CLI is never bundled in `Sliccstart.app`. If none is found, the launcher asks before downloading the current Darwin release from `https://www.sliccy.ai/download/slicc-cli/darwin-<arch>`, validates its Developer ID Application signature and release team identifier (`S8LB56P782`) before making it executable or running `--version`, then atomically installs it in the managed location. A successful terminal launch exposes that managed binary through `~/.local/bin/slicc`; the best-effort symlink step preserves regular files and unrelated user symlinks, and only re-points stale links under Sliccstart's own Application Support root.
 
-Release Darwin binaries are Developer ID-signed with hardened runtime and notarized by `packages/slicc-cli/sign-and-package.sh`. A bare Mach-O executable cannot have a notarization ticket stapled, so a quarantined copy may require Apple's online Gatekeeper lookup on first execution. The launcher's `URLSession` data download followed by `Data.write` does not create or propagate `com.apple.quarantine`, so Sliccstart does not need to remove that attribute. Verification against the release channel also confirmed that a manually quarantined signed release binary runs `--version` without a Gatekeeper override. (`spctl --assess --type execute` is not a useful check here because it rejects bare CLI executables as “not an app.”)
+Release Darwin binaries are signed and notarized, but a bare Mach-O gets no stapled ticket: [`docs/pitfalls.md`](../../docs/pitfalls.md) § "Downloaded `slicc` CLI" covers why Sliccstart neither strips quarantine nor trusts `spctl`.
 
 Terminal.app and iTerm2 launch through Apple Events. `assemble-app.mjs` supplies the user-facing usage description, and `sign-and-package.sh` signs the outer app with `Sliccstart.entitlements`, including `com.apple.security.automation.apple-events`. A TCC denial is surfaced with a direct path to the Sliccstart controls in System Settings → Privacy & Security → Automation.
 
@@ -154,8 +154,18 @@ the real control and the dialog a speed bump.
   opens a lead-vs-attach dialog; with none it launches standalone.
 - **Startup** — `Models/StartupPreference.swift`: the `launchBrowserAtStartup`
   checkbox replaces the per-browser picker; `resolveEnabled(defaults:)` migrates
-  legacy `autoLaunchAppId` once; launch starts the **top** ordered browser.
+  legacy `autoLaunchAppId` once; launch starts the **top** ordered browser
+  (`AppOrdering.topBrowser`, shared with the link handler).
 - Tests: `AppOrderingTests`, `StartupPreferenceTests`, `SliccProcessLaunchArgsTests`.
+
+## Default Browser Role
+
+Sliccstart can hold the macOS http/https handler role (Settings → Startup).
+`Models/DefaultBrowserRegistration.swift` claims it, `assemble-app.mjs`'s
+`CFBundleURLTypes` is the precondition, and `Models/IncomingURLRouter.swift`
+opens each link `application(_:open:)` receives as a tab in the leader browser
+over CDP, starting it first when none runs. See
+[`docs/sliccstart-browser.md`](../../docs/sliccstart-browser.md).
 
 ### iCloud provisioning (Developer ID app)
 

--- a/packages/swift-launcher/README.md
+++ b/packages/swift-launcher/README.md
@@ -71,6 +71,13 @@ and build the native server: `cd packages/swift-server && swift build`
   refresh/click so it can be started again. Status dots are refreshed
   periodically while Sliccstart is open and again whenever Sliccstart regains
   focus, so quitting an Electron app externally updates the row promptly.
+- **Default web browser**: With "launch browser at startup" enabled,
+  Settings → Startup offers to make Sliccstart the default browser. Sliccstart
+  renders nothing itself — links from other apps open as tabs in the SLICC
+  browser session, starting that browser first if it isn't running yet.
+- **Session restore**: A launched browser reopens the tabs from the previous
+  session. The SLICC tab is excluded and re-minted instead, because its bridge
+  key changes on every launch.
 - **Get extension**: Opens the Chrome Web Store listing to install the
   SLICC extension directly — no Developer Mode required.
 - **Update**: Pulls latest SLICC changes and rebuilds with one click.

--- a/packages/swift-launcher/Sliccstart/Models/AppOrdering.swift
+++ b/packages/swift-launcher/Sliccstart/Models/AppOrdering.swift
@@ -75,6 +75,17 @@ enum AppOrdering {
             .map { $0.element }
     }
 
+    /// The browser Sliccstart starts by itself — startup auto-launch and the
+    /// default-browser link handler both use this pick, so they can never
+    /// disagree about which browser is "the" leader.
+    static func topBrowser(in targets: [AppTarget], savedOrder: [String]) -> AppTarget? {
+        ordered(
+            targets.filter { $0.type == .chromiumBrowser },
+            savedOrder: savedOrder,
+            defaultPriority: browserBundlePriority
+        ).first
+    }
+
     /// The bundle-id order to persist after a drag reorder produced
     /// `reordered`. Targets without a bundle id are skipped (they can't be
     /// keyed), so their relative position is governed by default priority.

--- a/packages/swift-launcher/Sliccstart/Models/AppOrdering.swift
+++ b/packages/swift-launcher/Sliccstart/Models/AppOrdering.swift
@@ -75,15 +75,21 @@ enum AppOrdering {
             .map { $0.element }
     }
 
-    /// The browser Sliccstart starts by itself — startup auto-launch and the
-    /// default-browser link handler both use this pick, so they can never
-    /// disagree about which browser is "the" leader.
-    static func topBrowser(in targets: [AppTarget], savedOrder: [String]) -> AppTarget? {
+    /// The Browsers list in display order. The link handler walks it to find a
+    /// browser that can still become the leader.
+    static func orderedBrowsers(in targets: [AppTarget], savedOrder: [String]) -> [AppTarget] {
         ordered(
             targets.filter { $0.type == .chromiumBrowser },
             savedOrder: savedOrder,
             defaultPriority: browserBundlePriority
-        ).first
+        )
+    }
+
+    /// The browser Sliccstart starts by itself — startup auto-launch and the
+    /// default-browser link handler both use this pick, so they can never
+    /// disagree about which browser is "the" leader.
+    static func topBrowser(in targets: [AppTarget], savedOrder: [String]) -> AppTarget? {
+        orderedBrowsers(in: targets, savedOrder: savedOrder).first
     }
 
     /// The bundle-id order to persist after a drag reorder produced

--- a/packages/swift-launcher/Sliccstart/Models/DefaultBrowserRegistration.swift
+++ b/packages/swift-launcher/Sliccstart/Models/DefaultBrowserRegistration.swift
@@ -12,6 +12,34 @@ private let log = Logger(subsystem: "com.slicc.sliccstart", category: "DefaultBr
 /// the SLICC-controlled leader browser (`IncomingURLRouter`). The role is
 /// therefore only offered alongside "launch browser at startup" — without a
 /// leader to hand links to, becoming the default browser would swallow them.
+/// The LaunchServices operations the registration needs. `NSWorkspace` supplies
+/// them in production; tests supply a double, because the real calls rewrite
+/// the user's system-wide handler and raise a modal confirmation panel.
+protocol DefaultBrowserSystem {
+    func handlerURL(toOpen url: URL) -> URL?
+    func setDefaultApplication(at bundleURL: URL, toOpenURLsWithScheme scheme: String) async -> Error?
+}
+
+struct WorkspaceDefaultBrowserSystem: DefaultBrowserSystem {
+    let workspace: NSWorkspace
+
+    init(workspace: NSWorkspace = .shared) {
+        self.workspace = workspace
+    }
+
+    func handlerURL(toOpen url: URL) -> URL? {
+        workspace.urlForApplication(toOpen: url)
+    }
+
+    func setDefaultApplication(at bundleURL: URL, toOpenURLsWithScheme scheme: String) async -> Error? {
+        await withCheckedContinuation { continuation in
+            workspace.setDefaultApplication(at: bundleURL, toOpenURLsWithScheme: scheme) { error in
+                continuation.resume(returning: error)
+            }
+        }
+    }
+}
+
 enum DefaultBrowserRegistration {
     /// Schemes a default browser has to claim. `assemble-app.mjs` declares the
     /// same pair in `CFBundleURLTypes`; LaunchServices refuses a handler change
@@ -24,9 +52,9 @@ enum DefaultBrowserRegistration {
 
     static func isDefault(
         bundleURL: URL = Bundle.main.bundleURL,
-        workspace: NSWorkspace = .shared
+        system: any DefaultBrowserSystem = WorkspaceDefaultBrowserSystem()
     ) -> Bool {
-        matches(handlerURL: workspace.urlForApplication(toOpen: probeURL), bundleURL: bundleURL)
+        matches(handlerURL: system.handlerURL(toOpen: probeURL), bundleURL: bundleURL)
     }
 
     /// LaunchServices answers with a canonical, symlink-resolved URL that may
@@ -48,30 +76,19 @@ enum DefaultBrowserRegistration {
     /// absence of an error.
     static func makeDefault(
         bundleURL: URL = Bundle.main.bundleURL,
-        workspace: NSWorkspace = .shared
+        system: any DefaultBrowserSystem = WorkspaceDefaultBrowserSystem(),
+        report: (Error) -> Void = { LauncherErrorReport.report(.defaultBrowser, $0) }
     ) async -> Bool {
         for scheme in handledSchemes {
-            if let error = await setDefaultApplication(bundleURL: bundleURL, scheme: scheme, workspace: workspace) {
+            if let error = await system.setDefaultApplication(at: bundleURL, toOpenURLsWithScheme: scheme) {
                 log.error("makeDefault: \(scheme, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
-                LauncherErrorReport.report(.defaultBrowser, error)
-                return isDefault(bundleURL: bundleURL, workspace: workspace)
+                report(error)
+                return isDefault(bundleURL: bundleURL, system: system)
             }
         }
-        let succeeded = isDefault(bundleURL: bundleURL, workspace: workspace)
+        let succeeded = isDefault(bundleURL: bundleURL, system: system)
         log.info("makeDefault: isDefault = \(succeeded, privacy: .public)")
         return succeeded
-    }
-
-    private static func setDefaultApplication(
-        bundleURL: URL,
-        scheme: String,
-        workspace: NSWorkspace
-    ) async -> Error? {
-        await withCheckedContinuation { continuation in
-            workspace.setDefaultApplication(at: bundleURL, toOpenURLsWithScheme: scheme) { error in
-                continuation.resume(returning: error)
-            }
-        }
     }
 
     private static func canonicalPath(_ url: URL) -> String {

--- a/packages/swift-launcher/Sliccstart/Models/DefaultBrowserRegistration.swift
+++ b/packages/swift-launcher/Sliccstart/Models/DefaultBrowserRegistration.swift
@@ -1,0 +1,80 @@
+import AppKit
+import Foundation
+import os
+
+private let log = Logger(subsystem: "com.slicc.sliccstart", category: "DefaultBrowser")
+
+/// Registers Sliccstart as the macOS default web browser, and reports whether
+/// it currently holds that role.
+///
+/// Sliccstart never renders a page itself: taking the http/https handler role
+/// only means links from other apps arrive here and are then opened as tabs in
+/// the SLICC-controlled leader browser (`IncomingURLRouter`). The role is
+/// therefore only offered alongside "launch browser at startup" — without a
+/// leader to hand links to, becoming the default browser would swallow them.
+enum DefaultBrowserRegistration {
+    /// Schemes a default browser has to claim. `assemble-app.mjs` declares the
+    /// same pair in `CFBundleURLTypes`; LaunchServices refuses a handler change
+    /// for a scheme the bundle does not advertise.
+    static let handledSchemes = ["http", "https"]
+
+    /// Asks LaunchServices who currently handles web links. Any http(s) URL
+    /// resolves to the same handler, so the value is only a probe.
+    static let probeURL = URL(string: "https://www.sliccy.ai")!
+
+    static func isDefault(
+        bundleURL: URL = Bundle.main.bundleURL,
+        workspace: NSWorkspace = .shared
+    ) -> Bool {
+        matches(handlerURL: workspace.urlForApplication(toOpen: probeURL), bundleURL: bundleURL)
+    }
+
+    /// LaunchServices answers with a canonical, symlink-resolved URL that may
+    /// or may not carry a trailing slash, so comparing `URL` values directly
+    /// reports a false negative.
+    static func matches(handlerURL: URL?, bundleURL: URL) -> Bool {
+        guard let handlerURL else { return false }
+        return canonicalPath(handlerURL) == canonicalPath(bundleURL)
+    }
+
+    /// `false` for a build LaunchServices cannot record — a `swift run` binary
+    /// has no `.app` bundle, so the prompt would either not appear or not
+    /// stick. The UI disables the control instead of offering a no-op.
+    static var isRegistrable: Bool { SliccBootstrapper.isBundled }
+
+    /// Claim both web schemes. macOS shows its own confirmation panel for the
+    /// first one, and a user who declines leaves the handler unchanged — hence
+    /// the result is re-read from LaunchServices rather than assumed from the
+    /// absence of an error.
+    static func makeDefault(
+        bundleURL: URL = Bundle.main.bundleURL,
+        workspace: NSWorkspace = .shared
+    ) async -> Bool {
+        for scheme in handledSchemes {
+            if let error = await setDefaultApplication(bundleURL: bundleURL, scheme: scheme, workspace: workspace) {
+                log.error("makeDefault: \(scheme, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+                LauncherErrorReport.report(.defaultBrowser, error)
+                return isDefault(bundleURL: bundleURL, workspace: workspace)
+            }
+        }
+        let succeeded = isDefault(bundleURL: bundleURL, workspace: workspace)
+        log.info("makeDefault: isDefault = \(succeeded, privacy: .public)")
+        return succeeded
+    }
+
+    private static func setDefaultApplication(
+        bundleURL: URL,
+        scheme: String,
+        workspace: NSWorkspace
+    ) async -> Error? {
+        await withCheckedContinuation { continuation in
+            workspace.setDefaultApplication(at: bundleURL, toOpenURLsWithScheme: scheme) { error in
+                continuation.resume(returning: error)
+            }
+        }
+    }
+
+    private static func canonicalPath(_ url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+}

--- a/packages/swift-launcher/Sliccstart/Models/IncomingURLRouter.swift
+++ b/packages/swift-launcher/Sliccstart/Models/IncomingURLRouter.swift
@@ -10,14 +10,19 @@ private let log = Logger(subsystem: "com.slicc.sliccstart", category: "IncomingU
 protocol LeaderBrowserLaunching: AnyObject {
     /// CDP endpoint of the running local leader, or `nil` when none is up.
     var leaderBrowserEndpoint: LeaderBrowserEndpoint? { get }
+    /// True when this browser is already attached to a remote tray as a
+    /// follower, so it can never become the local leader.
+    func isRunningAsFollower(_ target: AppTarget) -> Bool
     func launchStandalone(_ target: AppTarget) throws
 }
 
 extension SliccProcess: LeaderBrowserLaunching {}
 
-enum IncomingURLRouterError: LocalizedError {
+enum IncomingURLRouterError: LocalizedError, Equatable {
     case leaderUnavailable
     case newTabRejected(status: Int)
+    case newTabResponseUnreadable
+    case activateRejected(status: Int)
 
     var errorDescription: String? {
         switch self {
@@ -25,6 +30,10 @@ enum IncomingURLRouterError: LocalizedError {
             return "No SLICC leader browser became available to open the link in."
         case .newTabRejected(let status):
             return "The browser rejected the new-tab request (HTTP \(status))."
+        case .newTabResponseUnreadable:
+            return "The browser did not report a target id for the new tab, so it stayed in the background."
+        case .activateRejected(let status):
+            return "The browser rejected the tab-activation request (HTTP \(status)), so the link stayed in the background."
         }
     }
 }
@@ -58,17 +67,18 @@ final class IncomingURLRouter {
     static let launchRetryEveryPolls = 20
 
     private let process: any LeaderBrowserLaunching
-    private let topBrowser: () -> AppTarget?
+    private let orderedBrowsers: () -> [AppTarget]
     private let send: (URLRequest) async throws -> (Int, Data)
     private let sleep: (TimeInterval) async -> Void
     private let activateBrowser: (String) -> Void
+    private let report: (Error) -> Void
 
     private var pending: [URL] = []
     private var isDraining = false
 
     init(
         process: any LeaderBrowserLaunching,
-        topBrowser: @escaping () -> AppTarget? = { IncomingURLRouter.defaultTopBrowser() },
+        orderedBrowsers: @escaping () -> [AppTarget] = { IncomingURLRouter.defaultOrderedBrowsers() },
         send: @escaping (URLRequest) async throws -> (Int, Data) = { request in
             let (data, response) = try await URLSession.shared.data(for: request)
             return ((response as? HTTPURLResponse)?.statusCode ?? 0, data)
@@ -81,19 +91,21 @@ final class IncomingURLRouter {
             NSWorkspace.shared.runningApplications
                 .first { $0.bundleURL?.standardizedFileURL == bundleURL }?
                 .activate()
-        }
+        },
+        report: @escaping (Error) -> Void = { LauncherErrorReport.report(.openIncomingUrl, $0) }
     ) {
         self.process = process
-        self.topBrowser = topBrowser
+        self.orderedBrowsers = orderedBrowsers
         self.send = send
         self.sleep = sleep
         self.activateBrowser = activateBrowser
+        self.report = report
     }
 
-    /// The browser Sliccstart starts on demand: the head of the (reorderable)
-    /// Browsers list, matching the startup auto-launch pick.
-    nonisolated static func defaultTopBrowser() -> AppTarget? {
-        AppOrdering.topBrowser(
+    /// The (reorderable) Browsers list in display order; its head is the same
+    /// pick startup auto-launch makes.
+    nonisolated static func defaultOrderedBrowsers() -> [AppTarget] {
+        AppOrdering.orderedBrowsers(
             in: AppScanner.scan(hasAppManagementPermission: false),
             savedOrder: AppOrderStore().load(AppOrderStore.browserKey)
         )
@@ -113,7 +125,7 @@ final class IncomingURLRouter {
 
         guard let leader = await resolveLeader() else {
             log.error("handle: no leader browser available; dropping \(self.pending.count, privacy: .public) link(s)")
-            LauncherErrorReport.report(.openIncomingUrl, IncomingURLRouterError.leaderUnavailable)
+            report(IncomingURLRouterError.leaderUnavailable)
             pending.removeAll()
             return
         }
@@ -179,14 +191,21 @@ final class IncomingURLRouter {
                 throw IncomingURLRouterError.newTabRejected(status: status)
             }
             log.info("open: opened link in leader on cdp \(cdpPort, privacy: .public)")
-            if let targetId = Self.createdTargetId(from: body),
+            // The tab exists but is in the background, so a failure here is a
+            // user-visible failure — the browser comes forward showing the
+            // tab the user was already on and the clicked link looks lost.
+            guard let targetId = Self.createdTargetId(from: body),
                 let activate = Self.activateRequest(cdpPort: cdpPort, targetId: targetId)
-            {
-                _ = try? await send(activate)
+            else {
+                throw IncomingURLRouterError.newTabResponseUnreadable
+            }
+            let (activateStatus, _) = try await send(activate)
+            guard (200..<300).contains(activateStatus) else {
+                throw IncomingURLRouterError.activateRejected(status: activateStatus)
             }
         } catch {
             log.error("open: failed: \(error.localizedDescription, privacy: .public)")
-            LauncherErrorReport.report(.openIncomingUrl, error)
+            report(error)
         }
     }
 
@@ -202,8 +221,14 @@ final class IncomingURLRouter {
     }
 
     private func launchLeader() {
-        guard let target = topBrowser() else {
-            log.error("launchLeader: no browser installed")
+        let browsers = orderedBrowsers()
+        // Skip a browser already attached to a remote tray as a follower:
+        // `launchStandalone` would no-op on it ("already running") while the
+        // wait loop keeps ignoring follower records, so retrying it would burn
+        // the whole budget and drop the link. A browser that is merely still
+        // booting is *not* skipped — it is the leader-to-be.
+        guard let target = browsers.first(where: { !process.isRunningAsFollower($0) }) else {
+            log.error("launchLeader: no browser available to become the leader")
             return
         }
         do {

--- a/packages/swift-launcher/Sliccstart/Models/IncomingURLRouter.swift
+++ b/packages/swift-launcher/Sliccstart/Models/IncomingURLRouter.swift
@@ -8,8 +8,8 @@ private let log = Logger(subsystem: "com.slicc.sliccstart", category: "IncomingU
 /// production implementation; the protocol keeps the routing logic testable
 /// without spawning a browser.
 protocol LeaderBrowserLaunching: AnyObject {
-    /// CDP port of the running local leader, or `nil` when none is up.
-    var leaderCdpPort: UInt16? { get }
+    /// CDP endpoint of the running local leader, or `nil` when none is up.
+    var leaderBrowserEndpoint: LeaderBrowserEndpoint? { get }
     func launchStandalone(_ target: AppTarget) throws
 }
 
@@ -61,7 +61,7 @@ final class IncomingURLRouter {
     private let topBrowser: () -> AppTarget?
     private let send: (URLRequest) async throws -> (Int, Data)
     private let sleep: (TimeInterval) async -> Void
-    private let activateBrowser: (AppTarget) -> Void
+    private let activateBrowser: (String) -> Void
 
     private var pending: [URL] = []
     private var isDraining = false
@@ -76,8 +76,8 @@ final class IncomingURLRouter {
         sleep: @escaping (TimeInterval) async -> Void = { seconds in
             try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
         },
-        activateBrowser: @escaping (AppTarget) -> Void = { target in
-            let bundleURL = URL(fileURLWithPath: target.path).standardizedFileURL
+        activateBrowser: @escaping (String) -> Void = { appPath in
+            let bundleURL = URL(fileURLWithPath: appPath).standardizedFileURL
             NSWorkspace.shared.runningApplications
                 .first { $0.bundleURL?.standardizedFileURL == bundleURL }?
                 .activate()
@@ -111,7 +111,7 @@ final class IncomingURLRouter {
         isDraining = true
         defer { isDraining = false }
 
-        guard let cdpPort = await resolveLeaderCdpPort() else {
+        guard let leader = await resolveLeader() else {
             log.error("handle: no leader browser available; dropping \(self.pending.count, privacy: .public) link(s)")
             LauncherErrorReport.report(.openIncomingUrl, IncomingURLRouterError.leaderUnavailable)
             pending.removeAll()
@@ -119,11 +119,12 @@ final class IncomingURLRouter {
         }
 
         while !pending.isEmpty {
-            await open(pending.removeFirst(), cdpPort: cdpPort)
+            await open(pending.removeFirst(), cdpPort: leader.cdpPort)
         }
-        if let target = topBrowser() {
-            activateBrowser(target)
-        }
+        // Bring forward the browser that actually owns the CDP port we just
+        // wrote to — which is not necessarily `topBrowser()`, since the user
+        // may have started a different browser by hand.
+        activateBrowser(leader.appPath)
     }
 
     static func openableURLs(from urls: [URL]) -> [URL] {
@@ -189,15 +190,15 @@ final class IncomingURLRouter {
         }
     }
 
-    private func resolveLeaderCdpPort() async -> UInt16? {
+    private func resolveLeader() async -> LeaderBrowserEndpoint? {
         for attempt in 0..<Self.maxLeaderWaitPolls {
-            if let port = process.leaderCdpPort { return port }
+            if let leader = process.leaderBrowserEndpoint { return leader }
             if attempt % Self.launchRetryEveryPolls == 0 {
                 launchLeader()
             }
             await sleep(Self.leaderWaitPollInterval)
         }
-        return process.leaderCdpPort
+        return process.leaderBrowserEndpoint
     }
 
     private func launchLeader() {

--- a/packages/swift-launcher/Sliccstart/Models/IncomingURLRouter.swift
+++ b/packages/swift-launcher/Sliccstart/Models/IncomingURLRouter.swift
@@ -1,0 +1,218 @@
+import AppKit
+import Foundation
+import os
+
+private let log = Logger(subsystem: "com.slicc.sliccstart", category: "IncomingURL")
+
+/// A SLICC leader browser that links can be handed to. `SliccProcess` is the
+/// production implementation; the protocol keeps the routing logic testable
+/// without spawning a browser.
+protocol LeaderBrowserLaunching: AnyObject {
+    /// CDP port of the running local leader, or `nil` when none is up.
+    var leaderCdpPort: UInt16? { get }
+    func launchStandalone(_ target: AppTarget) throws
+}
+
+extension SliccProcess: LeaderBrowserLaunching {}
+
+enum IncomingURLRouterError: LocalizedError {
+    case leaderUnavailable
+    case newTabRejected(status: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .leaderUnavailable:
+            return "No SLICC leader browser became available to open the link in."
+        case .newTabRejected(let status):
+            return "The browser rejected the new-tab request (HTTP \(status))."
+        }
+    }
+}
+
+/// Opens the links macOS hands to Sliccstart while it is the default web
+/// browser. Sliccstart draws no web content of its own, so every link becomes
+/// a tab in the SLICC leader browser — starting that browser first when it is
+/// not running yet, which is what makes a cold "click a link with Sliccstart
+/// as default browser" launch work.
+///
+/// Tabs are created over the browser's CDP HTTP endpoint rather than
+/// `NSWorkspace.open(_:withApplicationAt:)`: the SLICC browser runs on its own
+/// user-data-dir, so when the user also has the same browser open on their
+/// normal profile, LaunchServices would pick between the two instances
+/// non-deterministically. The CDP port only ever answers for the leader.
+@MainActor
+final class IncomingURLRouter {
+    /// Schemes we accept. `http`/`https` are the default-browser role;
+    /// `file` covers the HTML documents `CFBundleDocumentTypes` claims.
+    /// Everything else (`javascript:`, `data:`, custom app schemes) is
+    /// dropped rather than forwarded into the leader.
+    static let openableSchemes: Set<String> = ["http", "https", "file"]
+
+    static let leaderWaitPollInterval: TimeInterval = 0.5
+    /// ~45s of waiting: enough for a cold start that has to bootstrap and
+    /// boot Chrome before the CDP port answers.
+    static let maxLeaderWaitPolls = 90
+    /// Re-attempt the launch every ~10s while waiting. A launch can lose the
+    /// race against startup's own auto-launch (or against a still-bootstrapping
+    /// app), and a single attempt would then wait out the whole budget.
+    static let launchRetryEveryPolls = 20
+
+    private let process: any LeaderBrowserLaunching
+    private let topBrowser: () -> AppTarget?
+    private let send: (URLRequest) async throws -> (Int, Data)
+    private let sleep: (TimeInterval) async -> Void
+    private let activateBrowser: (AppTarget) -> Void
+
+    private var pending: [URL] = []
+    private var isDraining = false
+
+    init(
+        process: any LeaderBrowserLaunching,
+        topBrowser: @escaping () -> AppTarget? = { IncomingURLRouter.defaultTopBrowser() },
+        send: @escaping (URLRequest) async throws -> (Int, Data) = { request in
+            let (data, response) = try await URLSession.shared.data(for: request)
+            return ((response as? HTTPURLResponse)?.statusCode ?? 0, data)
+        },
+        sleep: @escaping (TimeInterval) async -> Void = { seconds in
+            try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+        },
+        activateBrowser: @escaping (AppTarget) -> Void = { target in
+            let bundleURL = URL(fileURLWithPath: target.path).standardizedFileURL
+            NSWorkspace.shared.runningApplications
+                .first { $0.bundleURL?.standardizedFileURL == bundleURL }?
+                .activate()
+        }
+    ) {
+        self.process = process
+        self.topBrowser = topBrowser
+        self.send = send
+        self.sleep = sleep
+        self.activateBrowser = activateBrowser
+    }
+
+    /// The browser Sliccstart starts on demand: the head of the (reorderable)
+    /// Browsers list, matching the startup auto-launch pick.
+    nonisolated static func defaultTopBrowser() -> AppTarget? {
+        AppOrdering.topBrowser(
+            in: AppScanner.scan(hasAppManagementPermission: false),
+            savedOrder: AppOrderStore().load(AppOrderStore.browserKey)
+        )
+    }
+
+    /// Queue `urls` and drain them into the leader. Re-entrant calls (macOS
+    /// delivers one `application(_:open:)` per user click) append to the queue
+    /// the in-flight drain is already working through, so a second click while
+    /// the browser is still booting is not lost.
+    func handle(_ urls: [URL]) async {
+        let openable = Self.openableURLs(from: urls)
+        guard !openable.isEmpty else { return }
+        pending.append(contentsOf: openable)
+        guard !isDraining else { return }
+        isDraining = true
+        defer { isDraining = false }
+
+        guard let cdpPort = await resolveLeaderCdpPort() else {
+            log.error("handle: no leader browser available; dropping \(self.pending.count, privacy: .public) link(s)")
+            LauncherErrorReport.report(.openIncomingUrl, IncomingURLRouterError.leaderUnavailable)
+            pending.removeAll()
+            return
+        }
+
+        while !pending.isEmpty {
+            await open(pending.removeFirst(), cdpPort: cdpPort)
+        }
+        if let target = topBrowser() {
+            activateBrowser(target)
+        }
+    }
+
+    static func openableURLs(from urls: [URL]) -> [URL] {
+        urls.filter { openableSchemes.contains($0.scheme?.lowercased() ?? "") }
+    }
+
+    /// Chrome's DevTools endpoint takes the **whole query string** as the
+    /// target URL (`PUT /json/new?<url>`) — a `?url=<url>` spelling opens
+    /// `about:blank` instead — and rejects GET since Chrome 111.
+    static func newTabRequest(cdpPort: UInt16, target: URL) -> URLRequest? {
+        guard
+            let encoded = target.absoluteString.addingPercentEncoding(
+                withAllowedCharacters: .alphanumerics.union(CharacterSet(charactersIn: "-._~"))
+            ),
+            let url = URL(string: "http://127.0.0.1:\(cdpPort)/json/new?\(encoded)")
+        else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.timeoutInterval = 5
+        return request
+    }
+
+    /// `/json/new` creates the tab in the background, so the link the user
+    /// just clicked would stay hidden without this follow-up.
+    static func activateRequest(cdpPort: UInt16, targetId: String) -> URLRequest? {
+        guard
+            let encodedId = targetId.addingPercentEncoding(
+                withAllowedCharacters: .alphanumerics.union(CharacterSet(charactersIn: "-._~"))
+            ),
+            !encodedId.isEmpty,
+            let url = URL(string: "http://127.0.0.1:\(cdpPort)/json/activate/\(encodedId)")
+        else { return nil }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 5
+        return request
+    }
+
+    /// Target id from a `/json/new` response body.
+    static func createdTargetId(from body: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+            let id = json["id"] as? String,
+            !id.isEmpty
+        else { return nil }
+        return id
+    }
+
+    private func open(_ url: URL, cdpPort: UInt16) async {
+        guard let request = Self.newTabRequest(cdpPort: cdpPort, target: url) else { return }
+        do {
+            let (status, body) = try await send(request)
+            guard (200..<300).contains(status) else {
+                throw IncomingURLRouterError.newTabRejected(status: status)
+            }
+            log.info("open: opened link in leader on cdp \(cdpPort, privacy: .public)")
+            if let targetId = Self.createdTargetId(from: body),
+                let activate = Self.activateRequest(cdpPort: cdpPort, targetId: targetId)
+            {
+                _ = try? await send(activate)
+            }
+        } catch {
+            log.error("open: failed: \(error.localizedDescription, privacy: .public)")
+            LauncherErrorReport.report(.openIncomingUrl, error)
+        }
+    }
+
+    private func resolveLeaderCdpPort() async -> UInt16? {
+        for attempt in 0..<Self.maxLeaderWaitPolls {
+            if let port = process.leaderCdpPort { return port }
+            if attempt % Self.launchRetryEveryPolls == 0 {
+                launchLeader()
+            }
+            await sleep(Self.leaderWaitPollInterval)
+        }
+        return process.leaderCdpPort
+    }
+
+    private func launchLeader() {
+        guard let target = topBrowser() else {
+            log.error("launchLeader: no browser installed")
+            return
+        }
+        do {
+            log.info("launchLeader: starting \(target.name, privacy: .public) for an incoming link")
+            try process.launchStandalone(target)
+        } catch {
+            // A losing race against startup's own auto-launch surfaces as
+            // "port in use"; the wait loop below picks the leader up either
+            // way, so this is logged rather than reported.
+            log.info("launchLeader: launch attempt failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/packages/swift-launcher/Sliccstart/Models/LauncherErrorReport.swift
+++ b/packages/swift-launcher/Sliccstart/Models/LauncherErrorReport.swift
@@ -29,6 +29,8 @@ enum LauncherErrorReport {
         case reattach = "reattach"
         case secretsUnlock = "secrets-unlock"
         case secretsPersist = "secrets-persist"
+        case defaultBrowser = "default-browser"
+        case openIncomingUrl = "open-incoming-url"
     }
 
     /// Longest `target` we send. Long enough to keep an OS error message

--- a/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
+++ b/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
@@ -244,6 +244,21 @@ final class SliccProcess {
         launchRecords.values.first { $0.targetType == .chromiumBrowser && !$0.isFollower }?.targetName
     }
 
+    /// CDP port of the running local leader browser, or `nil` while none is
+    /// up. Unlike `isLeaderReady()` this does not wait for a tray join URL:
+    /// opening a plain link as a tab (the default-browser role) only needs the
+    /// browser itself, which the listening CDP port proves.
+    var leaderCdpPort: UInt16? {
+        guard
+            let record = launchRecords.values.first(where: {
+                $0.targetType == .chromiumBrowser && !$0.isFollower
+            }),
+            record.process.isRunning,
+            Self.isPortInUse(record.cdpPort)
+        else { return nil }
+        return record.cdpPort
+    }
+
     func refreshRuntimeStates(for targets: [AppTarget]) {
         for target in targets {
             refreshRuntimeState(for: target)

--- a/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
+++ b/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
@@ -15,6 +15,17 @@ enum AppStartBlocker: Equatable {
     case needsLeader
 }
 
+/// A running leader browser addressed by both halves callers need: the CDP
+/// port to talk to and the app bundle that owns it. Keeping them together
+/// stops a caller from talking to one browser while bringing another forward
+/// (the leader is not necessarily the head of the reorderable Browsers list —
+/// the user can start any of them by hand).
+struct LeaderBrowserEndpoint: Equatable {
+    let cdpPort: UInt16
+    /// Bundle path (`AppTarget.id`) of the browser owning `cdpPort`.
+    let appPath: String
+}
+
 enum AppRuntimeState: Equatable {
     case notRunning
     case runningWithoutDebug
@@ -244,19 +255,19 @@ final class SliccProcess {
         launchRecords.values.first { $0.targetType == .chromiumBrowser && !$0.isFollower }?.targetName
     }
 
-    /// CDP port of the running local leader browser, or `nil` while none is
+    /// The running local leader browser's CDP endpoint, or `nil` while none is
     /// up. Unlike `isLeaderReady()` this does not wait for a tray join URL:
     /// opening a plain link as a tab (the default-browser role) only needs the
     /// browser itself, which the listening CDP port proves.
-    var leaderCdpPort: UInt16? {
+    var leaderBrowserEndpoint: LeaderBrowserEndpoint? {
         guard
-            let record = launchRecords.values.first(where: {
-                $0.targetType == .chromiumBrowser && !$0.isFollower
+            let entry = launchRecords.first(where: {
+                $0.value.targetType == .chromiumBrowser && !$0.value.isFollower
             }),
-            record.process.isRunning,
-            Self.isPortInUse(record.cdpPort)
+            entry.value.process.isRunning,
+            Self.isPortInUse(entry.value.cdpPort)
         else { return nil }
-        return record.cdpPort
+        return LeaderBrowserEndpoint(cdpPort: entry.value.cdpPort, appPath: entry.key)
     }
 
     func refreshRuntimeStates(for targets: [AppTarget]) {

--- a/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
+++ b/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
@@ -270,6 +270,17 @@ final class SliccProcess {
         return LeaderBrowserEndpoint(cdpPort: entry.value.cdpPort, appPath: entry.key)
     }
 
+    /// True when `target` is occupied by a launch record that can never become
+    /// this device's leader: a browser attached to a *remote* tray with
+    /// `--join`. `launchStandalone` no-ops on such a browser ("already
+    /// running") while `leaderBrowserEndpoint` keeps ignoring it, so a caller
+    /// waiting for a leader has to move on to the next browser instead of
+    /// retrying this one.
+    func isRunningAsFollower(_ target: AppTarget) -> Bool {
+        guard let record = launchRecords[target.id] else { return false }
+        return record.isFollower && record.process.isRunning
+    }
+
     func refreshRuntimeStates(for targets: [AppTarget]) {
         for target in targets {
             refreshRuntimeState(for: target)

--- a/packages/swift-launcher/Sliccstart/SliccstartApp.swift
+++ b/packages/swift-launcher/Sliccstart/SliccstartApp.swift
@@ -17,6 +17,23 @@ private let log = Logger(subsystem: "com.slicc.sliccstart", category: "App")
 final class SliccstartAppDelegate: NSObject, NSApplicationDelegate {
     let sliccProcess = SliccProcess()
     let sessionStore = TraySessionSyncStore()
+    /// Created on the first incoming link (only reachable while Sliccstart is
+    /// the default web browser, or the handler for an HTML document) and kept
+    /// afterwards, so its queue survives a burst of clicks.
+    @MainActor private var urlRouter: IncomingURLRouter?
+
+    /// Links macOS routes to us because we hold the http/https handler role.
+    /// Sliccstart shows no web content itself, so each one becomes a tab in
+    /// the SLICC leader browser — started on demand when it isn't running.
+    func application(_ application: NSApplication, open urls: [URL]) {
+        log.info("application(open:): \(urls.count, privacy: .public) url(s)")
+        let process = sliccProcess
+        Task { @MainActor in
+            let router = urlRouter ?? IncomingURLRouter(process: process)
+            urlRouter = router
+            await router.handle(urls)
+        }
+    }
 
     func applicationWillTerminate(_ notification: Notification) {
         if sliccProcess.isPreparingForUpdate {
@@ -325,12 +342,12 @@ struct SliccstartApp: App {
     /// Failures are logged but never block startup.
     private func autoLaunchConfiguredBrowser() {
         guard StartupPreference.resolveEnabled(defaults: .standard) else { return }
-        let browsers = AppOrdering.ordered(
-            targets.filter { $0.type == .chromiumBrowser },
-            savedOrder: AppOrderStore().load(AppOrderStore.browserKey),
-            defaultPriority: AppOrdering.browserBundlePriority
-        )
-        guard let target = browsers.first else {
+        guard
+            let target = AppOrdering.topBrowser(
+                in: targets,
+                savedOrder: AppOrderStore().load(AppOrderStore.browserKey)
+            )
+        else {
             log.info("autoLaunch: no browser available to launch")
             return
         }

--- a/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import os
 
@@ -62,6 +63,8 @@ struct SettingsView: View {
 struct StartupSettingsView: View {
     @AppStorage(StartupPreference.enabledKey) private var launchAtStartup = false
     @State private var topBrowserName: String?
+    @State private var isDefaultBrowser = false
+    @State private var isRequestingDefaultBrowser = false
 
     var body: some View {
         Form {
@@ -75,21 +78,66 @@ struct StartupSettingsView: View {
             Text("Launches the browser at the top of your Browsers list. Drag to reorder that list in the main window to change which one starts.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+            // Only offered alongside auto-launch: as the default browser
+            // Sliccstart hands every link to the leader browser, so without a
+            // leader waiting at startup the links would have nowhere to go.
+            // Still shown once the role is held, so turning auto-launch back
+            // off never hides the fact that Sliccstart owns web links.
+            if launchAtStartup || isDefaultBrowser {
+                Divider()
+                defaultBrowserSection
+            }
         }
         .padding(20)
         .frame(width: 460)
         .fixedSize()
         .onAppear {
             StartupPreference.resolveEnabled(defaults: .standard)
-            let browsers = AppScanner.scan(hasAppManagementPermission: false)
-                .filter { $0.type == .chromiumBrowser }
             topBrowserName =
-                AppOrdering.ordered(
-                    browsers,
-                    savedOrder: AppOrderStore().load(AppOrderStore.browserKey),
-                    defaultPriority: AppOrdering.browserBundlePriority
-                ).first?.name
+                AppOrdering.topBrowser(
+                    in: AppScanner.scan(hasAppManagementPermission: false),
+                    savedOrder: AppOrderStore().load(AppOrderStore.browserKey)
+                )?.name
+            isDefaultBrowser = DefaultBrowserRegistration.isDefault()
         }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            // The role can also change in System Settings, or through the
+            // macOS confirmation panel we can't observe directly.
+            isDefaultBrowser = DefaultBrowserRegistration.isDefault()
+        }
+    }
+
+    @ViewBuilder
+    private var defaultBrowserSection: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Default web browser")
+                Text(defaultBrowserCaption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer()
+            Button(isDefaultBrowser ? "Enabled" : "Make Default") {
+                Task {
+                    isRequestingDefaultBrowser = true
+                    isDefaultBrowser = await DefaultBrowserRegistration.makeDefault()
+                    isRequestingDefaultBrowser = false
+                }
+            }
+            .disabled(isDefaultBrowser || isRequestingDefaultBrowser || !DefaultBrowserRegistration.isRegistrable)
+            .accessibilityIdentifier("make-default-browser")
+        }
+    }
+
+    private var defaultBrowserCaption: String {
+        if isDefaultBrowser {
+            return "Links from other apps open as tabs in your SLICC browser session."
+        }
+        if !DefaultBrowserRegistration.isRegistrable {
+            return "Available in the installed Sliccstart.app — this build runs from a source checkout."
+        }
+        return "Sliccstart takes over web links and opens each one in the SLICC browser, starting it first if needed. macOS will ask you to confirm."
     }
 }
 

--- a/packages/swift-launcher/SliccstartTests/AppOrderingTests.swift
+++ b/packages/swift-launcher/SliccstartTests/AppOrderingTests.swift
@@ -103,6 +103,25 @@ final class AppOrderingTests: XCTestCase {
         XCTAssertNil(AppOrdering.topBrowser(in: [terminal("Terminal", "com.apple.Terminal")], savedOrder: []))
     }
 
+    func testOrderedBrowsersKeepsEveryBrowserInDisplayOrder() {
+        // The link handler walks the whole list to skip browsers that can no
+        // longer become the leader, so it needs more than the head.
+        let targets = [
+            terminal("Alacritty", "org.alacritty"),
+            browser("Brave", "com.brave.Browser"),
+            browser("Chrome", "com.google.Chrome"),
+        ]
+
+        XCTAssertEqual(
+            AppOrdering.orderedBrowsers(in: targets, savedOrder: []).map(\.name),
+            ["Chrome", "Brave"]
+        )
+        XCTAssertEqual(
+            AppOrdering.orderedBrowsers(in: targets, savedOrder: ["com.brave.Browser"]).map(\.name),
+            ["Brave", "Chrome"]
+        )
+    }
+
     func testPersistableOrderSkipsTargetsWithoutBundleId() {
         let reordered = [
             browser("Chrome", "com.google.Chrome"),

--- a/packages/swift-launcher/SliccstartTests/AppOrderingTests.swift
+++ b/packages/swift-launcher/SliccstartTests/AppOrderingTests.swift
@@ -85,6 +85,24 @@ final class AppOrderingTests: XCTestCase {
         XCTAssertEqual(ordered.map(\.name), ["Chrome", "Alpha", "Zeta"])
     }
 
+    func testTopBrowserIgnoresNonBrowserTargetsAndHonoursSavedOrder() {
+        // Both the startup auto-launch and the default-browser link handler
+        // resolve "the" leader through this helper, so they can never
+        // disagree about which browser to start.
+        let targets = [
+            terminal("Alacritty", "org.alacritty"),
+            browser("Chrome", "com.google.Chrome"),
+            browser("Brave", "com.brave.Browser"),
+        ]
+
+        XCTAssertEqual(AppOrdering.topBrowser(in: targets, savedOrder: [])?.name, "Chrome")
+        XCTAssertEqual(
+            AppOrdering.topBrowser(in: targets, savedOrder: ["com.brave.Browser"])?.name,
+            "Brave"
+        )
+        XCTAssertNil(AppOrdering.topBrowser(in: [terminal("Terminal", "com.apple.Terminal")], savedOrder: []))
+    }
+
     func testPersistableOrderSkipsTargetsWithoutBundleId() {
         let reordered = [
             browser("Chrome", "com.google.Chrome"),

--- a/packages/swift-launcher/SliccstartTests/DefaultBrowserRegistrationTests.swift
+++ b/packages/swift-launcher/SliccstartTests/DefaultBrowserRegistrationTests.swift
@@ -2,9 +2,10 @@ import XCTest
 
 @testable import Sliccstart
 
-/// Handler-identity comparison for the default-browser role. The mutating
-/// half (`makeDefault`) is not exercised here: it raises the macOS
-/// confirmation panel and rewrites the user's real LaunchServices database.
+/// Handler-identity comparison and the claim flow for the default-browser
+/// role. LaunchServices is behind `DefaultBrowserSystem` here: the real calls
+/// raise the macOS confirmation panel and rewrite the user's system-wide
+/// handler.
 final class DefaultBrowserRegistrationTests: XCTestCase {
     private let bundleURL = URL(fileURLWithPath: "/Applications/Sliccstart.app", isDirectory: true)
 
@@ -50,5 +51,81 @@ final class DefaultBrowserRegistrationTests: XCTestCase {
 
     func testProbeURLIsAWebURL() {
         XCTAssertEqual(DefaultBrowserRegistration.probeURL.scheme, "https")
+    }
+
+    func testIsDefaultAsksLaunchServicesForTheWebHandler() {
+        let system = SystemStub(handler: bundleURL)
+
+        XCTAssertTrue(DefaultBrowserRegistration.isDefault(bundleURL: bundleURL, system: system))
+        XCTAssertEqual(system.probedURLs, [DefaultBrowserRegistration.probeURL])
+
+        let other = SystemStub(handler: URL(fileURLWithPath: "/Applications/Google Chrome.app"))
+        XCTAssertFalse(DefaultBrowserRegistration.isDefault(bundleURL: bundleURL, system: other))
+    }
+
+    func testMakeDefaultClaimsEverySchemeThenConfirmsTheRole() async {
+        let system = SystemStub(handler: nil, handlerAfterClaim: bundleURL)
+
+        let succeeded = await DefaultBrowserRegistration.makeDefault(bundleURL: bundleURL, system: system)
+
+        XCTAssertTrue(succeeded)
+        XCTAssertEqual(system.claimedSchemes, ["http", "https"])
+    }
+
+    func testMakeDefaultReportsTheRoleWasNotTakenWhenTheUserDeclines() async {
+        // macOS returns **no error** when the user dismisses its confirmation
+        // panel, so the claim's return value is not evidence — the role has to
+        // be re-read.
+        let system = SystemStub(handler: nil)
+
+        let succeeded = await DefaultBrowserRegistration.makeDefault(bundleURL: bundleURL, system: system)
+
+        XCTAssertFalse(succeeded)
+        XCTAssertEqual(system.claimedSchemes, ["http", "https"])
+    }
+
+    func testMakeDefaultStopsAndReportsOnTheFirstFailedScheme() async {
+        let failure = NSError(domain: "test", code: 7)
+        let system = SystemStub(handler: nil, failure: failure)
+        var reported: [Error] = []
+
+        let succeeded = await DefaultBrowserRegistration.makeDefault(
+            bundleURL: bundleURL,
+            system: system,
+            report: { reported.append($0) }
+        )
+
+        XCTAssertFalse(succeeded)
+        // Bailed out after http rather than pestering the user again for https.
+        XCTAssertEqual(system.claimedSchemes, ["http"])
+        XCTAssertEqual(reported as? [NSError], [failure])
+    }
+}
+
+/// Stands in for LaunchServices: reports a handler, records the claims, and
+/// can flip to "we hold the role" once a claim goes through.
+private final class SystemStub: DefaultBrowserSystem {
+    private let handlerAfterClaim: URL?
+    private let failure: Error?
+    private var handler: URL?
+    private(set) var probedURLs: [URL] = []
+    private(set) var claimedSchemes: [String] = []
+
+    init(handler: URL?, handlerAfterClaim: URL? = nil, failure: Error? = nil) {
+        self.handler = handler
+        self.handlerAfterClaim = handlerAfterClaim
+        self.failure = failure
+    }
+
+    func handlerURL(toOpen url: URL) -> URL? {
+        probedURLs.append(url)
+        return handler
+    }
+
+    func setDefaultApplication(at bundleURL: URL, toOpenURLsWithScheme scheme: String) async -> Error? {
+        claimedSchemes.append(scheme)
+        if let failure { return failure }
+        if let handlerAfterClaim { handler = handlerAfterClaim }
+        return nil
     }
 }

--- a/packages/swift-launcher/SliccstartTests/DefaultBrowserRegistrationTests.swift
+++ b/packages/swift-launcher/SliccstartTests/DefaultBrowserRegistrationTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+@testable import Sliccstart
+
+/// Handler-identity comparison for the default-browser role. The mutating
+/// half (`makeDefault`) is not exercised here: it raises the macOS
+/// confirmation panel and rewrites the user's real LaunchServices database.
+final class DefaultBrowserRegistrationTests: XCTestCase {
+    private let bundleURL = URL(fileURLWithPath: "/Applications/Sliccstart.app", isDirectory: true)
+
+    func testClaimsBothWebSchemes() {
+        // LaunchServices only accepts a handler change for a scheme the
+        // bundle advertises, so these must stay in step with the
+        // CFBundleURLTypes block in assemble-app.mjs.
+        XCTAssertEqual(DefaultBrowserRegistration.handledSchemes, ["http", "https"])
+    }
+
+    func testMatchesIgnoresTrailingSlashDifferences() {
+        // LaunchServices answers with a canonical directory URL, which may
+        // carry a trailing slash the bundle URL does not.
+        XCTAssertTrue(
+            DefaultBrowserRegistration.matches(
+                handlerURL: URL(fileURLWithPath: "/Applications/Sliccstart.app"),
+                bundleURL: bundleURL
+            )
+        )
+    }
+
+    func testMatchesResolvesRelativePathComponents() {
+        XCTAssertTrue(
+            DefaultBrowserRegistration.matches(
+                handlerURL: URL(fileURLWithPath: "/Applications/./Sliccstart.app", isDirectory: true),
+                bundleURL: bundleURL
+            )
+        )
+    }
+
+    func testDoesNotMatchAnotherBrowser() {
+        XCTAssertFalse(
+            DefaultBrowserRegistration.matches(
+                handlerURL: URL(fileURLWithPath: "/Applications/Google Chrome.app", isDirectory: true),
+                bundleURL: bundleURL
+            )
+        )
+    }
+
+    func testNoHandlerIsNotDefault() {
+        XCTAssertFalse(DefaultBrowserRegistration.matches(handlerURL: nil, bundleURL: bundleURL))
+    }
+
+    func testProbeURLIsAWebURL() {
+        XCTAssertEqual(DefaultBrowserRegistration.probeURL.scheme, "https")
+    }
+}

--- a/packages/swift-launcher/SliccstartTests/IncomingURLRouterTests.swift
+++ b/packages/swift-launcher/SliccstartTests/IncomingURLRouterTests.swift
@@ -1,0 +1,198 @@
+import XCTest
+
+@testable import Sliccstart
+
+/// Routing of links macOS hands to Sliccstart while it holds the default
+/// web browser role.
+@MainActor
+final class IncomingURLRouterTests: XCTestCase {
+
+    func testOpenableURLsKeepsWebAndFileLinksOnly() {
+        let urls = IncomingURLRouter.openableURLs(from: [
+            URL(string: "https://example.com")!,
+            URL(string: "http://example.org")!,
+            URL(string: "file:///Users/x/page.html")!,
+            URL(string: "javascript:alert(1)")!,
+            URL(string: "data:text/html,<b>x</b>")!,
+            URL(string: "slack://channel?id=1")!,
+        ])
+
+        XCTAssertEqual(
+            urls.map(\.absoluteString),
+            ["https://example.com", "http://example.org", "file:///Users/x/page.html"]
+        )
+    }
+
+    func testNewTabRequestPutsTheWholeUrlInTheQueryString() {
+        // Chrome reads the entire query as the target URL; a `?url=` spelling
+        // silently opens about:blank, and GET is rejected since Chrome 111.
+        let request = IncomingURLRouter.newTabRequest(
+            cdpPort: 9222,
+            target: URL(string: "https://example.com/path?a=1&b=2#frag")!
+        )
+
+        XCTAssertEqual(request?.httpMethod, "PUT")
+        XCTAssertEqual(
+            request?.url?.absoluteString,
+            "http://127.0.0.1:9222/json/new?https%3A%2F%2Fexample.com%2Fpath%3Fa%3D1%26b%3D2%23frag"
+        )
+    }
+
+    func testActivateRequestTargetsTheCreatedTab() {
+        let request = IncomingURLRouter.activateRequest(cdpPort: 9333, targetId: "AB/CD 12")
+
+        XCTAssertEqual(request?.url?.absoluteString, "http://127.0.0.1:9333/json/activate/AB%2FCD%2012")
+        XCTAssertNil(IncomingURLRouter.activateRequest(cdpPort: 9333, targetId: ""))
+    }
+
+    func testCreatedTargetIdReadsTheNewTabResponse() {
+        let body = Data(#"{"id":"EE4AC065","type":"page","url":"https://example.com/"}"#.utf8)
+        XCTAssertEqual(IncomingURLRouter.createdTargetId(from: body), "EE4AC065")
+        XCTAssertNil(IncomingURLRouter.createdTargetId(from: Data("nope".utf8)))
+        XCTAssertNil(IncomingURLRouter.createdTargetId(from: Data(#"{"id":""}"#.utf8)))
+    }
+
+    func testDeliversToARunningLeaderWithoutLaunchingABrowser() async {
+        let process = LeaderStub(leaderCdpPort: 9222)
+        let transport = TransportSpy()
+        let router = makeRouter(process: process, transport: transport)
+
+        await router.handle([URL(string: "https://example.com/a")!])
+
+        XCTAssertEqual(process.launchedTargets, [])
+        XCTAssertEqual(
+            transport.requests.map { $0.url?.absoluteString ?? "" },
+            [
+                "http://127.0.0.1:9222/json/new?https%3A%2F%2Fexample.com%2Fa",
+                "http://127.0.0.1:9222/json/activate/tab-1",
+            ]
+        )
+        XCTAssertEqual(transport.activatedApps, ["Google Chrome"])
+    }
+
+    func testLaunchesTheTopBrowserAndWaitsForItsCdpPort() async {
+        // The cold "click a link while no leader runs" path: the browser has
+        // to be started first, and the link delivered once CDP answers.
+        let process = LeaderStub(leaderCdpPort: nil, portAfterPolls: 3, portWhenReady: 9222)
+        let transport = TransportSpy()
+        let router = makeRouter(process: process, transport: transport)
+
+        await router.handle([URL(string: "https://example.com/a")!])
+
+        XCTAssertEqual(process.launchedTargets, ["Google Chrome"])
+        XCTAssertEqual(
+            transport.requests.first?.url?.absoluteString,
+            "http://127.0.0.1:9222/json/new?https%3A%2F%2Fexample.com%2Fa"
+        )
+    }
+
+    func testDropsLinksWhenNoLeaderEverBecomesAvailable() async {
+        let process = LeaderStub(leaderCdpPort: nil)
+        let transport = TransportSpy()
+        let router = makeRouter(process: process, transport: transport)
+
+        await router.handle([URL(string: "https://example.com/a")!])
+
+        XCTAssertEqual(transport.requests, [])
+        // Retried rather than attempted once: a launch can lose the race
+        // against startup's own auto-launch.
+        XCTAssertGreaterThan(process.launchedTargets.count, 1)
+    }
+
+    func testIgnoresLinksWithNoOpenableScheme() async {
+        let process = LeaderStub(leaderCdpPort: 9222)
+        let transport = TransportSpy()
+        let router = makeRouter(process: process, transport: transport)
+
+        await router.handle([URL(string: "slack://channel?id=1")!])
+
+        XCTAssertEqual(transport.requests, [])
+        XCTAssertEqual(process.launchedTargets, [])
+    }
+
+    func testOpensEveryQueuedLinkInOneDrain() async {
+        let process = LeaderStub(leaderCdpPort: 9222)
+        let transport = TransportSpy()
+        let router = makeRouter(process: process, transport: transport)
+
+        await router.handle([
+            URL(string: "https://example.com/a")!,
+            URL(string: "https://example.com/b")!,
+        ])
+
+        let created = transport.requests.filter { $0.url?.path == "/json/new" }
+        XCTAssertEqual(created.count, 2)
+    }
+
+    private func makeRouter(process: LeaderStub, transport: TransportSpy) -> IncomingURLRouter {
+        let chrome = browserTarget()
+        return IncomingURLRouter(
+            process: process,
+            topBrowser: { chrome },
+            send: { request in try await transport.send(request) },
+            sleep: { _ in await process.tick() },
+            activateBrowser: { target in transport.recordActivation(target.name) }
+        )
+    }
+
+    private func browserTarget() -> AppTarget {
+        let path = "/Applications/Google Chrome.app"
+        return AppTarget(
+            id: path,
+            name: "Google Chrome",
+            path: path,
+            executablePath: "\(path)/Contents/MacOS/Google Chrome",
+            type: .chromiumBrowser,
+            icon: NSImage(size: NSSize(width: 1, height: 1)),
+            debugSupport: .supported,
+            isDebugBuild: false,
+            originalAppPath: nil,
+            bundleId: "com.google.Chrome"
+        )
+    }
+}
+
+/// Stands in for `SliccProcess`: reports a leader CDP port, optionally only
+/// after a number of wait ticks, and records launch attempts.
+@MainActor
+private final class LeaderStub: LeaderBrowserLaunching {
+    private var port: UInt16?
+    private let portAfterPolls: Int?
+    private let portWhenReady: UInt16?
+    private var ticks = 0
+    private(set) var launchedTargets: [String] = []
+
+    init(leaderCdpPort: UInt16?, portAfterPolls: Int? = nil, portWhenReady: UInt16? = nil) {
+        self.port = leaderCdpPort
+        self.portAfterPolls = portAfterPolls
+        self.portWhenReady = portWhenReady
+    }
+
+    var leaderCdpPort: UInt16? { port }
+
+    func launchStandalone(_ target: AppTarget) throws {
+        launchedTargets.append(target.name)
+    }
+
+    func tick() {
+        ticks += 1
+        if let portAfterPolls, ticks >= portAfterPolls {
+            port = portWhenReady
+        }
+    }
+}
+
+@MainActor
+private final class TransportSpy {
+    private(set) var requests: [URLRequest] = []
+    private(set) var activatedApps: [String] = []
+
+    func send(_ request: URLRequest) async throws -> (Int, Data) {
+        requests.append(request)
+        return (200, Data(#"{"id":"tab-1"}"#.utf8))
+    }
+
+    func recordActivation(_ appName: String) {
+        activatedApps.append(appName)
+    }
+}

--- a/packages/swift-launcher/SliccstartTests/IncomingURLRouterTests.swift
+++ b/packages/swift-launcher/SliccstartTests/IncomingURLRouterTests.swift
@@ -53,7 +53,7 @@ final class IncomingURLRouterTests: XCTestCase {
     }
 
     func testDeliversToARunningLeaderWithoutLaunchingABrowser() async {
-        let process = LeaderStub(leaderCdpPort: 9222)
+        let process = LeaderStub(leader: Self.chromeLeader)
         let transport = TransportSpy()
         let router = makeRouter(process: process, transport: transport)
 
@@ -67,13 +67,31 @@ final class IncomingURLRouterTests: XCTestCase {
                 "http://127.0.0.1:9222/json/activate/tab-1",
             ]
         )
-        XCTAssertEqual(transport.activatedApps, ["Google Chrome"])
+        XCTAssertEqual(transport.activatedApps, ["/Applications/Google Chrome.app"])
+    }
+
+    func testActivatesTheBrowserThatOwnsTheLeaderPortNotTheTopBrowser() async {
+        // The user can start any browser by hand, so the leader is not
+        // necessarily the head of the Browsers list. Talking to one browser
+        // while bringing another forward would leave the link hidden.
+        let leader = LeaderBrowserEndpoint(cdpPort: 9333, appPath: "/Applications/Brave Browser.app")
+        let process = LeaderStub(leader: leader)
+        let transport = TransportSpy()
+        let router = makeRouter(process: process, transport: transport)
+
+        await router.handle([URL(string: "https://example.com/a")!])
+
+        XCTAssertEqual(
+            transport.requests.first?.url?.absoluteString,
+            "http://127.0.0.1:9333/json/new?https%3A%2F%2Fexample.com%2Fa"
+        )
+        XCTAssertEqual(transport.activatedApps, ["/Applications/Brave Browser.app"])
     }
 
     func testLaunchesTheTopBrowserAndWaitsForItsCdpPort() async {
         // The cold "click a link while no leader runs" path: the browser has
         // to be started first, and the link delivered once CDP answers.
-        let process = LeaderStub(leaderCdpPort: nil, portAfterPolls: 3, portWhenReady: 9222)
+        let process = LeaderStub(leader: nil, endpointAfterPolls: 3, endpointWhenReady: Self.chromeLeader)
         let transport = TransportSpy()
         let router = makeRouter(process: process, transport: transport)
 
@@ -87,7 +105,7 @@ final class IncomingURLRouterTests: XCTestCase {
     }
 
     func testDropsLinksWhenNoLeaderEverBecomesAvailable() async {
-        let process = LeaderStub(leaderCdpPort: nil)
+        let process = LeaderStub(leader: nil)
         let transport = TransportSpy()
         let router = makeRouter(process: process, transport: transport)
 
@@ -100,7 +118,7 @@ final class IncomingURLRouterTests: XCTestCase {
     }
 
     func testIgnoresLinksWithNoOpenableScheme() async {
-        let process = LeaderStub(leaderCdpPort: 9222)
+        let process = LeaderStub(leader: Self.chromeLeader)
         let transport = TransportSpy()
         let router = makeRouter(process: process, transport: transport)
 
@@ -111,7 +129,7 @@ final class IncomingURLRouterTests: XCTestCase {
     }
 
     func testOpensEveryQueuedLinkInOneDrain() async {
-        let process = LeaderStub(leaderCdpPort: 9222)
+        let process = LeaderStub(leader: Self.chromeLeader)
         let transport = TransportSpy()
         let router = makeRouter(process: process, transport: transport)
 
@@ -124,6 +142,11 @@ final class IncomingURLRouterTests: XCTestCase {
         XCTAssertEqual(created.count, 2)
     }
 
+    private static let chromeLeader = LeaderBrowserEndpoint(
+        cdpPort: 9222,
+        appPath: "/Applications/Google Chrome.app"
+    )
+
     private func makeRouter(process: LeaderStub, transport: TransportSpy) -> IncomingURLRouter {
         let chrome = browserTarget()
         return IncomingURLRouter(
@@ -131,7 +154,7 @@ final class IncomingURLRouterTests: XCTestCase {
             topBrowser: { chrome },
             send: { request in try await transport.send(request) },
             sleep: { _ in await process.tick() },
-            activateBrowser: { target in transport.recordActivation(target.name) }
+            activateBrowser: { appPath in transport.recordActivation(appPath) }
         )
     }
 
@@ -152,23 +175,27 @@ final class IncomingURLRouterTests: XCTestCase {
     }
 }
 
-/// Stands in for `SliccProcess`: reports a leader CDP port, optionally only
+/// Stands in for `SliccProcess`: reports a leader endpoint, optionally only
 /// after a number of wait ticks, and records launch attempts.
 @MainActor
 private final class LeaderStub: LeaderBrowserLaunching {
-    private var port: UInt16?
-    private let portAfterPolls: Int?
-    private let portWhenReady: UInt16?
+    private var endpoint: LeaderBrowserEndpoint?
+    private let endpointAfterPolls: Int?
+    private let endpointWhenReady: LeaderBrowserEndpoint?
     private var ticks = 0
     private(set) var launchedTargets: [String] = []
 
-    init(leaderCdpPort: UInt16?, portAfterPolls: Int? = nil, portWhenReady: UInt16? = nil) {
-        self.port = leaderCdpPort
-        self.portAfterPolls = portAfterPolls
-        self.portWhenReady = portWhenReady
+    init(
+        leader: LeaderBrowserEndpoint?,
+        endpointAfterPolls: Int? = nil,
+        endpointWhenReady: LeaderBrowserEndpoint? = nil
+    ) {
+        self.endpoint = leader
+        self.endpointAfterPolls = endpointAfterPolls
+        self.endpointWhenReady = endpointWhenReady
     }
 
-    var leaderCdpPort: UInt16? { port }
+    var leaderBrowserEndpoint: LeaderBrowserEndpoint? { endpoint }
 
     func launchStandalone(_ target: AppTarget) throws {
         launchedTargets.append(target.name)
@@ -176,8 +203,8 @@ private final class LeaderStub: LeaderBrowserLaunching {
 
     func tick() {
         ticks += 1
-        if let portAfterPolls, ticks >= portAfterPolls {
-            port = portWhenReady
+        if let endpointAfterPolls, ticks >= endpointAfterPolls {
+            endpoint = endpointWhenReady
         }
     }
 }
@@ -192,7 +219,7 @@ private final class TransportSpy {
         return (200, Data(#"{"id":"tab-1"}"#.utf8))
     }
 
-    func recordActivation(_ appName: String) {
-        activatedApps.append(appName)
+    func recordActivation(_ appPath: String) {
+        activatedApps.append(appPath)
     }
 }

--- a/packages/swift-launcher/SliccstartTests/IncomingURLRouterTests.swift
+++ b/packages/swift-launcher/SliccstartTests/IncomingURLRouterTests.swift
@@ -117,6 +117,62 @@ final class IncomingURLRouterTests: XCTestCase {
         XCTAssertGreaterThan(process.launchedTargets.count, 1)
     }
 
+    func testSkipsAFollowerBrowserWhenPickingOneToStart() async {
+        // Chrome is attached to a remote tray with `--join`, so it can never
+        // become the local leader and `launchStandalone` would no-op on it.
+        // Retrying it would burn the whole wait budget and drop the link.
+        let browsers = [browserTarget(name: "Google Chrome"), browserTarget(name: "Brave Browser")]
+        let process = LeaderStub(leader: nil, followerNames: ["Google Chrome"])
+        let transport = TransportSpy()
+        let router = makeRouter(process: process, transport: transport, browsers: browsers)
+
+        await router.handle([URL(string: "https://example.com/a")!])
+
+        XCTAssertFalse(process.launchedTargets.contains("Google Chrome"))
+        XCTAssertEqual(Set(process.launchedTargets), ["Brave Browser"])
+    }
+
+    func testReportsWhenTheCreatedTabCannotBeActivated() async {
+        // `/json/new` creates the tab in the background, so a failed activate
+        // leaves the browser foregrounded on the tab the user was already on
+        // and the clicked link looks lost. That must not be swallowed.
+        let process = LeaderStub(leader: Self.chromeLeader)
+        let transport = TransportSpy(activateStatus: 500)
+        let reported = ErrorSpy()
+        let router = makeRouter(process: process, transport: transport, report: reported.record)
+
+        await router.handle([URL(string: "https://example.com/a")!])
+
+        XCTAssertEqual(
+            reported.errors as? [IncomingURLRouterError],
+            [.activateRejected(status: 500)]
+        )
+    }
+
+    func testReportsWhenTheNewTabResponseHasNoTargetId() async {
+        let process = LeaderStub(leader: Self.chromeLeader)
+        let transport = TransportSpy(newTabBody: Data("{}".utf8))
+        let reported = ErrorSpy()
+        let router = makeRouter(process: process, transport: transport, report: reported.record)
+
+        await router.handle([URL(string: "https://example.com/a")!])
+
+        XCTAssertEqual(
+            reported.errors as? [IncomingURLRouterError],
+            [.newTabResponseUnreadable]
+        )
+    }
+
+    func testDroppedLinksAreReported() async {
+        let process = LeaderStub(leader: nil)
+        let reported = ErrorSpy()
+        let router = makeRouter(process: process, transport: TransportSpy(), report: reported.record)
+
+        await router.handle([URL(string: "https://example.com/a")!])
+
+        XCTAssertEqual(reported.errors as? [IncomingURLRouterError], [.leaderUnavailable])
+    }
+
     func testIgnoresLinksWithNoOpenableScheme() async {
         let process = LeaderStub(leader: Self.chromeLeader)
         let transport = TransportSpy()
@@ -147,30 +203,36 @@ final class IncomingURLRouterTests: XCTestCase {
         appPath: "/Applications/Google Chrome.app"
     )
 
-    private func makeRouter(process: LeaderStub, transport: TransportSpy) -> IncomingURLRouter {
-        let chrome = browserTarget()
+    private func makeRouter(
+        process: LeaderStub,
+        transport: TransportSpy,
+        browsers: [AppTarget]? = nil,
+        report: @escaping (Error) -> Void = { _ in }
+    ) -> IncomingURLRouter {
+        let ordered = browsers ?? [browserTarget(name: "Google Chrome")]
         return IncomingURLRouter(
             process: process,
-            topBrowser: { chrome },
+            orderedBrowsers: { ordered },
             send: { request in try await transport.send(request) },
             sleep: { _ in await process.tick() },
-            activateBrowser: { appPath in transport.recordActivation(appPath) }
+            activateBrowser: { appPath in transport.recordActivation(appPath) },
+            report: report
         )
     }
 
-    private func browserTarget() -> AppTarget {
-        let path = "/Applications/Google Chrome.app"
+    private func browserTarget(name: String) -> AppTarget {
+        let path = "/Applications/\(name).app"
         return AppTarget(
             id: path,
-            name: "Google Chrome",
+            name: name,
             path: path,
-            executablePath: "\(path)/Contents/MacOS/Google Chrome",
+            executablePath: "\(path)/Contents/MacOS/\(name)",
             type: .chromiumBrowser,
             icon: NSImage(size: NSSize(width: 1, height: 1)),
             debugSupport: .supported,
             isDebugBuild: false,
             originalAppPath: nil,
-            bundleId: "com.google.Chrome"
+            bundleId: "com.example.\(name)"
         )
     }
 }
@@ -185,17 +247,26 @@ private final class LeaderStub: LeaderBrowserLaunching {
     private var ticks = 0
     private(set) var launchedTargets: [String] = []
 
+    /// Browser names Sliccstart already has attached to a remote tray.
+    private let followerNames: Set<String>
+
     init(
         leader: LeaderBrowserEndpoint?,
         endpointAfterPolls: Int? = nil,
-        endpointWhenReady: LeaderBrowserEndpoint? = nil
+        endpointWhenReady: LeaderBrowserEndpoint? = nil,
+        followerNames: Set<String> = []
     ) {
         self.endpoint = leader
         self.endpointAfterPolls = endpointAfterPolls
         self.endpointWhenReady = endpointWhenReady
+        self.followerNames = followerNames
     }
 
     var leaderBrowserEndpoint: LeaderBrowserEndpoint? { endpoint }
+
+    func isRunningAsFollower(_ target: AppTarget) -> Bool {
+        followerNames.contains(target.name)
+    }
 
     func launchStandalone(_ target: AppTarget) throws {
         launchedTargets.append(target.name)
@@ -213,13 +284,32 @@ private final class LeaderStub: LeaderBrowserLaunching {
 private final class TransportSpy {
     private(set) var requests: [URLRequest] = []
     private(set) var activatedApps: [String] = []
+    private let activateStatus: Int
+    private let newTabBody: Data
+
+    init(activateStatus: Int = 200, newTabBody: Data = Data(#"{"id":"tab-1"}"#.utf8)) {
+        self.activateStatus = activateStatus
+        self.newTabBody = newTabBody
+    }
 
     func send(_ request: URLRequest) async throws -> (Int, Data) {
         requests.append(request)
-        return (200, Data(#"{"id":"tab-1"}"#.utf8))
+        if request.url?.path.hasPrefix("/json/activate") == true {
+            return (activateStatus, Data())
+        }
+        return (200, newTabBody)
     }
 
     func recordActivation(_ appPath: String) {
         activatedApps.append(appPath)
+    }
+}
+
+@MainActor
+private final class ErrorSpy {
+    private(set) var errors: [Error] = []
+
+    func record(_ error: Error) {
+        errors.append(error)
     }
 }

--- a/packages/swift-launcher/SliccstartTests/IncomingURLRouterTests.swift
+++ b/packages/swift-launcher/SliccstartTests/IncomingURLRouterTests.swift
@@ -163,6 +163,75 @@ final class IncomingURLRouterTests: XCTestCase {
         )
     }
 
+    func testReportsWhenTheBrowserRejectsTheNewTab() async {
+        let process = LeaderStub(leader: Self.chromeLeader)
+        let transport = TransportSpy(newTabStatus: 500)
+        let reported = ErrorSpy()
+        let router = makeRouter(process: process, transport: transport, report: reported.record)
+
+        await router.handle([URL(string: "https://example.com/a")!])
+
+        XCTAssertEqual(reported.errors as? [IncomingURLRouterError], [.newTabRejected(status: 500)])
+    }
+
+    func testReportsWhenNoBrowserIsInstalledAtAll() async {
+        let process = LeaderStub(leader: nil)
+        let reported = ErrorSpy()
+        let router = makeRouter(
+            process: process,
+            transport: TransportSpy(),
+            browsers: [],
+            report: reported.record
+        )
+
+        await router.handle([URL(string: "https://example.com/a")!])
+
+        XCTAssertEqual(process.launchedTargets, [])
+        XCTAssertEqual(reported.errors as? [IncomingURLRouterError], [.leaderUnavailable])
+    }
+
+    func testKeepsWaitingWhenALaunchAttemptThrows() async {
+        // A launch racing startup's own auto-launch surfaces as "port in use";
+        // the wait loop, not the launch call, decides whether a leader arrived.
+        let process = LeaderStub(
+            leader: nil,
+            endpointAfterPolls: 3,
+            endpointWhenReady: Self.chromeLeader,
+            launchError: LaunchStubError.portInUse
+        )
+        let transport = TransportSpy()
+        let router = makeRouter(process: process, transport: transport)
+
+        await router.handle([URL(string: "https://example.com/a")!])
+
+        XCTAssertEqual(
+            transport.requests.first?.url?.absoluteString,
+            "http://127.0.0.1:9222/json/new?https%3A%2F%2Fexample.com%2Fa"
+        )
+    }
+
+    func testEveryFailureCarriesAUserReadableDescription() {
+        let descriptions: [String] = [
+            IncomingURLRouterError.leaderUnavailable,
+            .newTabRejected(status: 500),
+            .newTabResponseUnreadable,
+            .activateRejected(status: 404),
+        ].map { $0.localizedDescription }
+
+        XCTAssertEqual(descriptions.count, Set(descriptions).count)
+        XCTAssertFalse(descriptions.contains { $0.isEmpty })
+    }
+
+    func testProductionDefaultsResolveTheInstalledBrowsers() {
+        // The defaults are what the app delegate uses; exercising them keeps
+        // the wiring from silently pointing at nothing.
+        let router = IncomingURLRouter(process: LeaderStub(leader: nil))
+        XCTAssertNotNil(router)
+        for browser in IncomingURLRouter.defaultOrderedBrowsers() {
+            XCTAssertEqual(browser.type, .chromiumBrowser)
+        }
+    }
+
     func testDroppedLinksAreReported() async {
         let process = LeaderStub(leader: nil)
         let reported = ErrorSpy()
@@ -249,17 +318,20 @@ private final class LeaderStub: LeaderBrowserLaunching {
 
     /// Browser names Sliccstart already has attached to a remote tray.
     private let followerNames: Set<String>
+    private let launchError: Error?
 
     init(
         leader: LeaderBrowserEndpoint?,
         endpointAfterPolls: Int? = nil,
         endpointWhenReady: LeaderBrowserEndpoint? = nil,
-        followerNames: Set<String> = []
+        followerNames: Set<String> = [],
+        launchError: Error? = nil
     ) {
         self.endpoint = leader
         self.endpointAfterPolls = endpointAfterPolls
         self.endpointWhenReady = endpointWhenReady
         self.followerNames = followerNames
+        self.launchError = launchError
     }
 
     var leaderBrowserEndpoint: LeaderBrowserEndpoint? { endpoint }
@@ -270,6 +342,7 @@ private final class LeaderStub: LeaderBrowserLaunching {
 
     func launchStandalone(_ target: AppTarget) throws {
         launchedTargets.append(target.name)
+        if let launchError { throw launchError }
     }
 
     func tick() {
@@ -285,10 +358,16 @@ private final class TransportSpy {
     private(set) var requests: [URLRequest] = []
     private(set) var activatedApps: [String] = []
     private let activateStatus: Int
+    private let newTabStatus: Int
     private let newTabBody: Data
 
-    init(activateStatus: Int = 200, newTabBody: Data = Data(#"{"id":"tab-1"}"#.utf8)) {
+    init(
+        activateStatus: Int = 200,
+        newTabStatus: Int = 200,
+        newTabBody: Data = Data(#"{"id":"tab-1"}"#.utf8)
+    ) {
         self.activateStatus = activateStatus
+        self.newTabStatus = newTabStatus
         self.newTabBody = newTabBody
     }
 
@@ -297,12 +376,16 @@ private final class TransportSpy {
         if request.url?.path.hasPrefix("/json/activate") == true {
             return (activateStatus, Data())
         }
-        return (200, newTabBody)
+        return (newTabStatus, newTabBody)
     }
 
     func recordActivation(_ appPath: String) {
         activatedApps.append(appPath)
     }
+}
+
+private enum LaunchStubError: Error {
+    case portInUse
 }
 
 @MainActor

--- a/packages/swift-launcher/SliccstartTests/LauncherCoverageBackfillTests.swift
+++ b/packages/swift-launcher/SliccstartTests/LauncherCoverageBackfillTests.swift
@@ -477,4 +477,37 @@ final class LauncherBootstrapperCoverageTests: XCTestCase {
         XCTAssertNotNil(SliccBootstrapper.BootstrapError.nodeNotFound.errorDescription)
         XCTAssertNotNil(SliccBootstrapper.BootstrapError.commandFailed("x").errorDescription)
     }
+
+    func testCliDownloadProgressHasADistinctStatusForEveryStage() {
+        let texts = [
+            SliccCliDownloadProgress.preparing,
+            .downloading(attempt: 2, totalAttempts: 3),
+            .validating,
+            .installing,
+            .finished(URL(fileURLWithPath: "/tmp/slicc")),
+        ].map(\.statusText)
+
+        XCTAssertEqual(texts.count, Set(texts).count)
+        XCTAssertTrue(texts.contains { $0.contains("2 of 3") })
+    }
+
+    func testAppOrderStoreRoundTripsThroughUserDefaults() {
+        let suiteName = "slicc.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = AppOrderStore(defaults: defaults)
+
+        XCTAssertEqual(store.load(AppOrderStore.browserKey), [])
+        store.save(["com.brave.Browser", "com.google.Chrome"], forKey: AppOrderStore.browserKey)
+
+        XCTAssertEqual(store.load(AppOrderStore.browserKey), ["com.brave.Browser", "com.google.Chrome"])
+        XCTAssertEqual(store.load(AppOrderStore.terminalKey), [])
+    }
+
+    func testDefaultBrowserProbeReadsTheRealLaunchServicesHandler() {
+        // Read-only: asks LaunchServices who handles web links. The xctest
+        // runner is not a registered handler, so it can never hold the role.
+        XCTAssertFalse(DefaultBrowserRegistration.isDefault())
+        _ = DefaultBrowserRegistration.isRegistrable
+    }
 }

--- a/packages/swift-launcher/assemble-app.mjs
+++ b/packages/swift-launcher/assemble-app.mjs
@@ -147,6 +147,36 @@ const infoPlist = `<?xml version="1.0" encoding="UTF-8"?>
     <string>Slicc launches Google Chrome to host the assistant UI. Chrome — not Slicc — uses the microphone for sites you visit (Google Meet, Zoom, etc.). Grant access if you want microphone-enabled sites to work inside Slicc.</string>
     <key>NSAppleEventsUsageDescription</key>
     <string>Sliccstart uses Apple Events to open a new Terminal or iTerm2 window and attach it to your running SLICC session.</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>Web site URL</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>http</string>
+                <string>https</string>
+            </array>
+        </dict>
+    </array>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>HTML document</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.html</string>
+                <string>public.xhtml</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>
 `;

--- a/packages/swift-launcher/macos-permissions.test.mjs
+++ b/packages/swift-launcher/macos-permissions.test.mjs
@@ -22,6 +22,24 @@ describe('Sliccstart Apple Events packaging', () => {
   });
 });
 
+describe('Sliccstart default-browser packaging', () => {
+  it('advertises the http and https handler role', () => {
+    // LaunchServices only lists Sliccstart under "Default web browser" — and
+    // only accepts a handler change — for schemes the bundle declares here.
+    // Keep in step with DefaultBrowserRegistration.handledSchemes.
+    expect(assemblySource).toContain('<key>CFBundleURLTypes</key>');
+    expect(assemblySource).toMatch(
+      /<key>CFBundleURLSchemes<\/key>\s*<array>\s*<string>http<\/string>\s*<string>https<\/string>\s*<\/array>/
+    );
+  });
+
+  it('claims HTML documents as a viewer without outranking real browsers', () => {
+    expect(assemblySource).toContain('<string>public.html</string>');
+    expect(assemblySource).toContain('<string>public.xhtml</string>');
+    expect(assemblySource).toMatch(/<key>LSHandlerRank<\/key>\s*<string>Alternate<\/string>/);
+  });
+});
+
 describe('Sliccstart iCloud sync packaging', () => {
   it('embeds the provisioning profile only when PROVISION_PROFILE is supplied', () => {
     expect(signingScript).toContain('if [ -n "${PROVISION_PROFILE:-}" ]; then');

--- a/packages/swift-server/CLAUDE.md
+++ b/packages/swift-server/CLAUDE.md
@@ -96,6 +96,21 @@ WebSocket routes are installed separately for CDP proxying and the lick system.
 
 - **swift-server serves no static UI in any mode** — the launched Chrome loads the hosted webapp from `https://www.sliccy.ai` (or `http://localhost:8787` in the wrangler dev harness). `StaticFileMiddleware` and `--static-root` have been removed; the root router only mounts `ThinBridgeCorsMiddleware` (gated by `shouldMountThinBridgeCors`). This matches node-server, which is thin-bridge in **every** mode and serves no static UI either.
 
+## Tab Session Restore
+
+A launched Chrome reopens the tabs the previous session had open, minus the SLICC
+tab (its bridge token is dead by then, and a second leader tab restarts the
+`/cdp` eviction war `clearChromeSessionRestore` exists to prevent). Chrome's own
+session restore therefore stays wiped; swift-server keeps its own URL-only
+snapshot in `Sources/Browser/TabSessionStore.swift` (sanitized on save **and**
+load — every entry becomes a Chrome argv slot) fed by
+`Sources/Browser/TabSessionRecorder.swift` (polls `/json/list`, so it can never
+evict the webapp's CDP session) and replayed through
+`ChromeLaunchConfig.restoreUrls`. Not wired for `--serve-only` or `--electron`,
+and **node-server has no equivalent** — `chrome-launch.ts` keeps the plain
+session wipe. Full reference:
+[`docs/sliccstart-browser.md`](../../docs/sliccstart-browser.md).
+
 ## Lick / WebSocket System
 
 - `LickSystem` is an actor that tracks connected browser clients and pending requests.

--- a/packages/swift-server/Sources/Browser/CDPBrowserSession.swift
+++ b/packages/swift-server/Sources/Browser/CDPBrowserSession.swift
@@ -25,6 +25,37 @@ enum CDPBrowserSessionError: LocalizedError {
     }
 }
 
+/// The socket operations the session needs. `URLSessionWebSocketTask` supplies
+/// them in production; tests supply a double, which is the only way to drive
+/// the frame-matching loop without a live browser.
+protocol CDPWebSocketTransport: Sendable {
+    func sendFrame(_ payload: Data) async throws
+    func receiveFrame() async throws -> URLSessionWebSocketTask.Message
+    func cancelSocket() async
+}
+
+/// `URLSessionWebSocketTask` is documented as safe to use from any thread.
+private final class URLSessionCDPWebSocket: CDPWebSocketTransport, @unchecked Sendable {
+    private let task: URLSessionWebSocketTask
+
+    init(url: URL, session: URLSession) {
+        task = session.webSocketTask(with: url)
+        task.resume()
+    }
+
+    func sendFrame(_ payload: Data) async throws {
+        try await task.send(.data(payload))
+    }
+
+    func receiveFrame() async throws -> URLSessionWebSocketTask.Message {
+        try await task.receive()
+    }
+
+    func cancelSocket() {
+        task.cancel(with: .goingAway, reason: nil)
+    }
+}
+
 /// `URLSessionWebSocketTask`-backed `CDPBrowserSession`. One instance is one
 /// short-lived connection: callers open it, make their reads, and close it,
 /// so there is no reconnect state to manage and a dropped connection simply
@@ -35,22 +66,25 @@ actor WebSocketCDPBrowserSession: CDPBrowserSession {
     /// Bounded so a chatty browser cannot pin the caller forever.
     private static let maxFramesPerCall = 64
 
-    private let socket: URLSessionWebSocketTask
+    private let socket: any CDPWebSocketTransport
     private var nextId = 0
 
     init(url: URL, session: URLSession = .shared) {
-        socket = session.webSocketTask(with: url)
-        socket.resume()
+        socket = URLSessionCDPWebSocket(url: url, session: session)
+    }
+
+    init(socket: any CDPWebSocketTransport) {
+        self.socket = socket
     }
 
     func call(method: String) async throws -> Data {
         nextId += 1
         let id = nextId
         let payload = try JSONSerialization.data(withJSONObject: ["id": id, "method": method])
-        try await socket.send(.data(payload))
+        try await socket.sendFrame(payload)
 
         for _ in 0..<Self.maxFramesPerCall {
-            guard let frame = Self.payload(of: try await socket.receive()),
+            guard let frame = Self.payload(of: try await socket.receiveFrame()),
                 let result = Self.result(fromFrame: frame, id: id)
             else { continue }
             return result
@@ -58,8 +92,8 @@ actor WebSocketCDPBrowserSession: CDPBrowserSession {
         throw CDPBrowserSessionError.noReply(method: method)
     }
 
-    func close() {
-        socket.cancel(with: .goingAway, reason: nil)
+    func close() async {
+        await socket.cancelSocket()
     }
 
     /// The `result` object of `frame` when it is the reply to `id`, else `nil`

--- a/packages/swift-server/Sources/Browser/CDPBrowserSession.swift
+++ b/packages/swift-server/Sources/Browser/CDPBrowserSession.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// A request/response channel to the *browser*-level CDP endpoint
+/// (`/devtools/browser/<id>`, discovered through `/json/version`).
+///
+/// The browser endpoint is used rather than a page target because Chrome
+/// multiplexes browser-level clients: attaching here cannot evict the `/cdp`
+/// session the webapp owns. Verified against Chrome — two browser-level
+/// clients plus a live page session coexist, and the page session keeps
+/// answering `Runtime.evaluate` while the browser clients poll.
+protocol CDPBrowserSession: Sendable {
+    /// Send a parameterless CDP command and return its `result` object.
+    func call(method: String) async throws -> Data
+    func close() async
+}
+
+enum CDPBrowserSessionError: LocalizedError {
+    case noReply(method: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noReply(let method):
+            return "The browser did not reply to \(method)."
+        }
+    }
+}
+
+/// `URLSessionWebSocketTask`-backed `CDPBrowserSession`. One instance is one
+/// short-lived connection: callers open it, make their reads, and close it,
+/// so there is no reconnect state to manage and a dropped connection simply
+/// means the next read reconnects.
+actor WebSocketCDPBrowserSession: CDPBrowserSession {
+    /// Browser-level target lifecycle events interleave with command replies,
+    /// so a read loop has to skip frames until the matching `id` shows up.
+    /// Bounded so a chatty browser cannot pin the caller forever.
+    private static let maxFramesPerCall = 64
+
+    private let socket: URLSessionWebSocketTask
+    private var nextId = 0
+
+    init(url: URL, session: URLSession = .shared) {
+        socket = session.webSocketTask(with: url)
+        socket.resume()
+    }
+
+    func call(method: String) async throws -> Data {
+        nextId += 1
+        let id = nextId
+        let payload = try JSONSerialization.data(withJSONObject: ["id": id, "method": method])
+        try await socket.send(.data(payload))
+
+        for _ in 0..<Self.maxFramesPerCall {
+            guard let frame = Self.payload(of: try await socket.receive()),
+                let result = Self.result(fromFrame: frame, id: id)
+            else { continue }
+            return result
+        }
+        throw CDPBrowserSessionError.noReply(method: method)
+    }
+
+    func close() {
+        socket.cancel(with: .goingAway, reason: nil)
+    }
+
+    /// The `result` object of `frame` when it is the reply to `id`, else `nil`
+    /// — an event, another call's reply, or a non-JSON frame.
+    static func result(fromFrame frame: Data, id: Int) -> Data? {
+        guard let object = try? JSONSerialization.jsonObject(with: frame) as? [String: Any],
+            object["id"] as? Int == id
+        else { return nil }
+        return try? JSONSerialization.data(withJSONObject: object["result"] as? [String: Any] ?? [:])
+    }
+
+    private static func payload(of message: URLSessionWebSocketTask.Message) -> Data? {
+        switch message {
+        case .data(let payload):
+            return payload
+        case .string(let text):
+            return Data(text.utf8)
+        @unknown default:
+            return nil
+        }
+    }
+}

--- a/packages/swift-server/Sources/Browser/ChromeLauncher.swift
+++ b/packages/swift-server/Sources/Browser/ChromeLauncher.swift
@@ -42,6 +42,11 @@ struct ChromeLaunchConfig: Sendable {
     let currentDirectoryPath: String?
     let environment: [String: String]
     let launchTimeout: TimeInterval
+    /// Tabs from the previous session, reopened alongside the SLICC tab.
+    /// Sourced from `TabSessionStore` (which sanitizes them) because Chrome's
+    /// own session restore is wiped on every launch — see
+    /// `clearChromeSessionRestore`.
+    let restoreUrls: [String]
 
     init(
         projectRoot: String? = nil,
@@ -52,7 +57,8 @@ struct ChromeLaunchConfig: Sendable {
         executablePath: String? = nil,
         currentDirectoryPath: String? = nil,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        launchTimeout: TimeInterval = defaultChromeLaunchTimeout
+        launchTimeout: TimeInterval = defaultChromeLaunchTimeout,
+        restoreUrls: [String] = []
     ) {
         self.projectRoot = projectRoot
         self.cdpPort = cdpPort
@@ -63,6 +69,7 @@ struct ChromeLaunchConfig: Sendable {
         self.currentDirectoryPath = currentDirectoryPath
         self.environment = environment
         self.launchTimeout = launchTimeout
+        self.restoreUrls = restoreUrls
     }
 }
 
@@ -187,7 +194,8 @@ struct ChromeLauncher: Sendable {
         cdpPort: Int,
         launchUrl: String,
         userDataDir: String,
-        extensionPath: String?
+        extensionPath: String?,
+        restoreUrls: [String] = []
     ) -> [String] {
         var args = [
             "--remote-debugging-port=\(cdpPort)",
@@ -216,7 +224,17 @@ struct ChromeLauncher: Sendable {
             args.append("--load-extension=\(extensionPath)")
         }
 
+        // The SLICC tab goes first so it is the leftmost and initially active
+        // tab; Chromium activates the first URL on the command line. Restored
+        // tabs are re-sanitized here because every entry becomes an argv slot,
+        // where a `--flag`-shaped string would be read as a Chrome switch.
         args.append(launchUrl)
+        args.append(
+            contentsOf: TabSessionStore.sanitize(
+                rawUrls: restoreUrls,
+                hostedOrigins: []
+            )
+        )
         return args
     }
 
@@ -418,7 +436,8 @@ struct ChromeLauncher: Sendable {
             cdpPort: config.cdpPort,
             launchUrl: config.launchUrl,
             userDataDir: config.userDataDir,
-            extensionPath: config.extensionPath
+            extensionPath: config.extensionPath,
+            restoreUrls: config.restoreUrls
         )
         process.environment = config.environment.merging(["GOOGLE_CRASHPAD_DISABLE": "1"]) { _, new in new }
         if let currentDirectoryPath = normalizedPath(config.currentDirectoryPath) {

--- a/packages/swift-server/Sources/Browser/TabSessionRecorder.swift
+++ b/packages/swift-server/Sources/Browser/TabSessionRecorder.swift
@@ -2,6 +2,16 @@ import Foundation
 import Logging
 
 private let defaultTabSnapshotIntervalNanoseconds: UInt64 = 5_000_000_000
+/// Hard ceiling on one browser read. `snapshotNow()` is awaited by the
+/// shutdown sequence *before* the browser is closed and force-killed, so a
+/// browser that accepts the socket and then stops answering must not be able
+/// to stall shutdown — exactly when the kill path is needed most.
+private let tabSnapshotReadTimeoutNanoseconds: UInt64 = 3_000_000_000
+
+private enum SnapshotRead: Sendable {
+    case completed([String]?)
+    case timedOut
+}
 
 private struct CDPVersionEntry: Decodable {
     let webSocketDebuggerUrl: String?
@@ -42,6 +52,7 @@ actor TabSessionRecorder {
     private let fetch: @Sendable (URL) async throws -> (Int, Data)
     private let openSession: @Sendable (URL) -> any CDPBrowserSession
     private let intervalNanoseconds: UInt64
+    private let readTimeoutNanoseconds: UInt64
     private let logger: Logger
 
     private var pollTask: Task<Void, Never>?
@@ -52,6 +63,7 @@ actor TabSessionRecorder {
         cdpPort: Int,
         hostedOrigins: [String],
         intervalNanoseconds: UInt64 = defaultTabSnapshotIntervalNanoseconds,
+        readTimeoutNanoseconds: UInt64 = tabSnapshotReadTimeoutNanoseconds,
         logger: Logger = Logger(label: "slicc.browser.tab-session"),
         fetch: @escaping @Sendable (URL) async throws -> (Int, Data) = { url in
             var request = URLRequest(url: url)
@@ -68,6 +80,7 @@ actor TabSessionRecorder {
         self.cdpPort = cdpPort
         self.hostedOrigins = hostedOrigins
         self.intervalNanoseconds = intervalNanoseconds
+        self.readTimeoutNanoseconds = readTimeoutNanoseconds
         self.logger = logger
         self.fetch = fetch
         self.openSession = openSession
@@ -112,9 +125,26 @@ actor TabSessionRecorder {
     private func restorableTabUrls() async -> [String]? {
         guard let browserURL = await browserDebuggerURL() else { return nil }
         let session = openSession(browserURL)
-        let urls = await defaultContextPageUrls(in: session)
+        let read = await withTaskGroup(of: SnapshotRead.self) { group in
+            group.addTask { .completed(await self.defaultContextPageUrls(in: session)) }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: self.readTimeoutNanoseconds)
+                return .timedOut
+            }
+            let first = await group.next() ?? .timedOut
+            group.cancelAll()
+            return first
+        }
+        // Closing the socket is what unblocks a read that is still waiting on
+        // a browser that went quiet.
         await session.close()
-        return urls
+        switch read {
+        case .completed(let urls):
+            return urls
+        case .timedOut:
+            logger.debug("Tab snapshot skipped: browser did not answer in time")
+            return nil
+        }
     }
 
     private func browserDebuggerURL() async -> URL? {

--- a/packages/swift-server/Sources/Browser/TabSessionRecorder.swift
+++ b/packages/swift-server/Sources/Browser/TabSessionRecorder.swift
@@ -3,24 +3,44 @@ import Logging
 
 private let defaultTabSnapshotIntervalNanoseconds: UInt64 = 5_000_000_000
 
-private struct CDPTargetEntry: Decodable {
+private struct CDPVersionEntry: Decodable {
+    let webSocketDebuggerUrl: String?
+}
+
+private struct CDPBrowserContextsResult: Decodable {
+    let defaultBrowserContextId: String?
+}
+
+private struct CDPTargetInfo: Decodable {
     let type: String?
     let url: String?
+    let browserContextId: String?
+}
+
+private struct CDPTargetsResult: Decodable {
+    let targetInfos: [CDPTargetInfo]
 }
 
 /// Polls the launched browser's CDP target list and keeps a persisted
 /// snapshot of the open tabs, so the next launch can reopen them.
 ///
 /// Polling (rather than subscribing to `Target.targetInfoChanged`) keeps this
-/// off the `/cdp` proxy socket the webapp owns: a plain `/json/list` read
-/// cannot evict the leader's CDP session. A failed poll is dropped rather
-/// than persisted, so a browser that is quitting — or a momentarily
-/// unreachable CDP endpoint — never erases the last good snapshot.
+/// off the `/cdp` proxy socket the webapp owns: a browser-level read cannot
+/// evict the leader's page CDP session. A failed poll is dropped rather than
+/// persisted, so a browser that is quitting — or a momentarily unreachable CDP
+/// endpoint — never erases the last good snapshot.
+///
+/// Targets are read over the browser endpoint rather than `/json/list`
+/// because only `Target.getTargets` reports each target's
+/// `browserContextId`, which is the only way to keep **Incognito** tabs out of
+/// a file on disk: `/json/list` lists them with nothing to tell them apart
+/// from normal tabs.
 actor TabSessionRecorder {
     private let store: TabSessionStore
     private let cdpPort: Int
     private let hostedOrigins: [String]
     private let fetch: @Sendable (URL) async throws -> (Int, Data)
+    private let openSession: @Sendable (URL) -> any CDPBrowserSession
     private let intervalNanoseconds: UInt64
     private let logger: Logger
 
@@ -39,6 +59,9 @@ actor TabSessionRecorder {
             request.cachePolicy = .reloadIgnoringLocalCacheData
             let (data, response) = try await URLSession.shared.data(for: request)
             return ((response as? HTTPURLResponse)?.statusCode ?? 0, data)
+        },
+        openSession: @escaping @Sendable (URL) -> any CDPBrowserSession = { url in
+            WebSocketCDPBrowserSession(url: url)
         }
     ) {
         self.store = store
@@ -47,6 +70,7 @@ actor TabSessionRecorder {
         self.intervalNanoseconds = intervalNanoseconds
         self.logger = logger
         self.fetch = fetch
+        self.openSession = openSession
     }
 
     func start() {
@@ -75,24 +99,70 @@ actor TabSessionRecorder {
     /// best-effort convenience, and it runs on the shutdown path where a
     /// thrown error would abort the rest of the sequence.
     func snapshotNow() async {
-        guard let listURL = URL(string: "http://127.0.0.1:\(cdpPort)/json/list") else { return }
-        let urls: [String]
-        do {
-            let (status, data) = try await fetch(listURL)
-            guard (200..<300).contains(status) else {
-                logger.debug("Tab snapshot skipped: /json/list returned \(status)")
-                return
-            }
-            let entries = try JSONDecoder().decode([CDPTargetEntry].self, from: data)
-            urls = entries.filter { $0.type == "page" }.compactMap { $0.url }
-        } catch {
-            logger.debug("Tab snapshot skipped: \(error.localizedDescription)")
-            return
-        }
+        guard let urls = await restorableTabUrls() else { return }
         let sanitized = TabSessionStore.sanitize(rawUrls: urls, hostedOrigins: hostedOrigins)
         guard sanitized != lastPersisted else { return }
         store.save(urls: sanitized, hostedOrigins: hostedOrigins)
         lastPersisted = sanitized
         logger.debug("Persisted \(sanitized.count) tab(s) for restore")
+    }
+
+    /// The open page URLs that may be written to disk, or `nil` when this
+    /// snapshot has to be skipped.
+    private func restorableTabUrls() async -> [String]? {
+        guard let browserURL = await browserDebuggerURL() else { return nil }
+        let session = openSession(browserURL)
+        let urls = await defaultContextPageUrls(in: session)
+        await session.close()
+        return urls
+    }
+
+    private func browserDebuggerURL() async -> URL? {
+        guard let versionURL = URL(string: "http://127.0.0.1:\(cdpPort)/json/version") else { return nil }
+        do {
+            let (status, data) = try await fetch(versionURL)
+            guard (200..<300).contains(status) else {
+                logger.debug("Tab snapshot skipped: /json/version returned \(status)")
+                return nil
+            }
+            guard let raw = try JSONDecoder().decode(CDPVersionEntry.self, from: data).webSocketDebuggerUrl,
+                let url = URL(string: raw)
+            else {
+                logger.debug("Tab snapshot skipped: browser reported no debugger URL")
+                return nil
+            }
+            return url
+        } catch {
+            logger.debug("Tab snapshot skipped: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func defaultContextPageUrls(in session: any CDPBrowserSession) async -> [String]? {
+        do {
+            let contexts = try JSONDecoder().decode(
+                CDPBrowserContextsResult.self,
+                from: try await session.call(method: "Target.getBrowserContexts")
+            )
+            // Incognito tabs live in a non-default browser context and are
+            // otherwise indistinguishable from normal ones. Without the
+            // default context's id there is no way to exclude them, and
+            // writing browsing the user made private into a file on disk is
+            // worse than restoring nothing — so skip the snapshot entirely.
+            guard let defaultContextId = contexts.defaultBrowserContextId else {
+                logger.debug("Tab snapshot skipped: browser reported no default context id")
+                return nil
+            }
+            let targets = try JSONDecoder().decode(
+                CDPTargetsResult.self,
+                from: try await session.call(method: "Target.getTargets")
+            )
+            return targets.targetInfos
+                .filter { $0.type == "page" && $0.browserContextId == defaultContextId }
+                .compactMap { $0.url }
+        } catch {
+            logger.debug("Tab snapshot skipped: \(error.localizedDescription)")
+            return nil
+        }
     }
 }

--- a/packages/swift-server/Sources/Browser/TabSessionRecorder.swift
+++ b/packages/swift-server/Sources/Browser/TabSessionRecorder.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Logging
+
+private let defaultTabSnapshotIntervalNanoseconds: UInt64 = 5_000_000_000
+
+private struct CDPTargetEntry: Decodable {
+    let type: String?
+    let url: String?
+}
+
+/// Polls the launched browser's CDP target list and keeps a persisted
+/// snapshot of the open tabs, so the next launch can reopen them.
+///
+/// Polling (rather than subscribing to `Target.targetInfoChanged`) keeps this
+/// off the `/cdp` proxy socket the webapp owns: a plain `/json/list` read
+/// cannot evict the leader's CDP session. A failed poll is dropped rather
+/// than persisted, so a browser that is quitting — or a momentarily
+/// unreachable CDP endpoint — never erases the last good snapshot.
+actor TabSessionRecorder {
+    private let store: TabSessionStore
+    private let cdpPort: Int
+    private let hostedOrigins: [String]
+    private let fetch: @Sendable (URL) async throws -> (Int, Data)
+    private let intervalNanoseconds: UInt64
+    private let logger: Logger
+
+    private var pollTask: Task<Void, Never>?
+    private var lastPersisted: [String]?
+
+    init(
+        store: TabSessionStore,
+        cdpPort: Int,
+        hostedOrigins: [String],
+        intervalNanoseconds: UInt64 = defaultTabSnapshotIntervalNanoseconds,
+        logger: Logger = Logger(label: "slicc.browser.tab-session"),
+        fetch: @escaping @Sendable (URL) async throws -> (Int, Data) = { url in
+            var request = URLRequest(url: url)
+            request.timeoutInterval = 2
+            request.cachePolicy = .reloadIgnoringLocalCacheData
+            let (data, response) = try await URLSession.shared.data(for: request)
+            return ((response as? HTTPURLResponse)?.statusCode ?? 0, data)
+        }
+    ) {
+        self.store = store
+        self.cdpPort = cdpPort
+        self.hostedOrigins = hostedOrigins
+        self.intervalNanoseconds = intervalNanoseconds
+        self.logger = logger
+        self.fetch = fetch
+    }
+
+    func start() {
+        stop()
+        let interval = intervalNanoseconds
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                await self.snapshotNow()
+                do {
+                    try await Task.sleep(nanoseconds: interval)
+                } catch {
+                    break
+                }
+            }
+        }
+    }
+
+    func stop() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    /// Read the target list once and persist it when it differs from the last
+    /// snapshot this recorder wrote. Never throws: a snapshot is a
+    /// best-effort convenience, and it runs on the shutdown path where a
+    /// thrown error would abort the rest of the sequence.
+    func snapshotNow() async {
+        guard let listURL = URL(string: "http://127.0.0.1:\(cdpPort)/json/list") else { return }
+        let urls: [String]
+        do {
+            let (status, data) = try await fetch(listURL)
+            guard (200..<300).contains(status) else {
+                logger.debug("Tab snapshot skipped: /json/list returned \(status)")
+                return
+            }
+            let entries = try JSONDecoder().decode([CDPTargetEntry].self, from: data)
+            urls = entries.filter { $0.type == "page" }.compactMap { $0.url }
+        } catch {
+            logger.debug("Tab snapshot skipped: \(error.localizedDescription)")
+            return
+        }
+        let sanitized = TabSessionStore.sanitize(rawUrls: urls, hostedOrigins: hostedOrigins)
+        guard sanitized != lastPersisted else { return }
+        store.save(urls: sanitized, hostedOrigins: hostedOrigins)
+        lastPersisted = sanitized
+        logger.debug("Persisted \(sanitized.count) tab(s) for restore")
+    }
+}

--- a/packages/swift-server/Sources/Browser/TabSessionStore.swift
+++ b/packages/swift-server/Sources/Browser/TabSessionStore.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Logging
+
+/// One persisted tab snapshot for a Chrome profile.
+struct PersistedTabSession: Codable, Equatable {
+    var updatedAt: Date
+    var urls: [String]
+}
+
+/// Persists the URLs a launched Chrome had open so the next launch can
+/// reopen them.
+///
+/// Chrome's own session restore stays disabled — `clearChromeSessionRestore`
+/// wipes `Default/Sessions` on every launch because a restored SLICC tab
+/// carries the previous run's bridge token and fights the fresh tab over
+/// `/cdp`. Keeping our own URL-only snapshot lets us reopen everything
+/// *except* that tab, which `resolveBrowserLaunchURL` re-mints with the
+/// current token instead.
+///
+/// URLs are re-validated on both save and load: the file lives in the user's
+/// Application Support directory, and every entry is handed straight to
+/// Chrome's argument vector, so an entry like `--headless` or `file:///…`
+/// must never survive `sanitize`.
+struct TabSessionStore: Sendable {
+    static let maxRestoredTabs = 50
+
+    let fileURL: URL
+    private let logger: Logger
+
+    init(fileURL: URL, logger: Logger = Logger(label: "slicc.browser.tab-session")) {
+        self.fileURL = fileURL
+        self.logger = logger
+    }
+
+    /// `~/Library/Application Support/Slicc/sessions/<profile-dir>-tabs.json`.
+    /// Keyed off the user-data-dir's last path component so each profile
+    /// (`resolveUserDataDir` appends the serve port for non-default ports)
+    /// keeps its own tab set.
+    static func defaultFileURL(userDataDir: String, homeDirectory: String = NSHomeDirectory()) -> URL {
+        let profileDirName = URL(fileURLWithPath: userDataDir).lastPathComponent
+        return URL(fileURLWithPath: homeDirectory, isDirectory: true)
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Slicc", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+            .appendingPathComponent("\(profileDirName)-tabs.json")
+    }
+
+    func load(hostedOrigins: [String]) -> [String] {
+        guard let data = try? Data(contentsOf: fileURL) else { return [] }
+        guard let session = try? JSONDecoder().decode(PersistedTabSession.self, from: data) else {
+            logger.warning("Ignoring unreadable tab snapshot at \(fileURL.path)")
+            return []
+        }
+        return Self.sanitize(rawUrls: session.urls, hostedOrigins: hostedOrigins)
+    }
+
+    func save(urls: [String], hostedOrigins: [String], now: Date = Date()) {
+        let sanitized = Self.sanitize(rawUrls: urls, hostedOrigins: hostedOrigins)
+        let session = PersistedTabSession(updatedAt: now, urls: sanitized)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        guard let data = try? encoder.encode(session) else { return }
+        do {
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            logger.warning("Could not persist tab snapshot: \(error.localizedDescription)")
+        }
+    }
+
+    /// Keep only real web pages the next launch can safely reopen: absolute
+    /// `http(s)` URLs with a host, minus the SLICC leader page, deduplicated
+    /// in first-seen order and capped at `limit`.
+    static func sanitize(
+        rawUrls: [String],
+        hostedOrigins: [String],
+        limit: Int = maxRestoredTabs
+    ) -> [String] {
+        let origins = Set(hostedOrigins.compactMap { normalizedOrigin(of: $0) })
+        var seen = Set<String>()
+        var kept: [String] = []
+        for raw in rawUrls {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let url = URL(string: trimmed),
+                let scheme = url.scheme?.lowercased(),
+                scheme == "http" || scheme == "https",
+                let host = url.host,
+                !host.isEmpty,
+                !isSliccPage(url, origins: origins),
+                !seen.contains(trimmed)
+            else { continue }
+            seen.insert(trimmed)
+            kept.append(trimmed)
+            if kept.count >= max(limit, 0) { break }
+        }
+        return kept
+    }
+
+    /// A SLICC page is either served from an origin we launch the leader
+    /// from, or carries the bridge query parameters that only a SLICC
+    /// launch URL has. Both halves matter: the hosted origin also serves
+    /// the marketing site (reopening it as a second leader would restart
+    /// the `/cdp` eviction war), and a locally hosted UI origin can differ
+    /// between runs while the bridge parameters stay recognizable.
+    private static func isSliccPage(_ url: URL, origins: Set<String>) -> Bool {
+        if let origin = normalizedOrigin(of: url.absoluteString), origins.contains(origin) {
+            return true
+        }
+        let queryNames =
+            URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .map { $0.name.lowercased() } ?? []
+        return queryNames.contains("bridge") || queryNames.contains("bridgetoken")
+    }
+
+    /// `scheme://host[:port]`, lowercased, or `nil` for anything that is not
+    /// an absolute http(s) URL.
+    static func normalizedOrigin(of value: String) -> String? {
+        guard let components = URLComponents(string: value.trimmingCharacters(in: .whitespacesAndNewlines)),
+            let scheme = components.scheme?.lowercased(),
+            scheme == "http" || scheme == "https",
+            let host = components.host?.lowercased(),
+            !host.isEmpty
+        else { return nil }
+        if let port = components.port {
+            return "\(scheme)://\(host):\(port)"
+        }
+        return "\(scheme)://\(host)"
+    }
+}

--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -111,6 +111,11 @@ struct ServerCommand: AsyncParsableCommand {
         var browserKillPid: pid_t?
         var browserLabel = config.electron ? "Electron" : "Chrome"
         var overlayInjector: ElectronOverlayInjector?
+        // Records the launched Chrome's open tabs so the next launch reopens
+        // them. Only the Chrome launch path sets it: `--serve-only` attaches to
+        // a browser someone else launched (and whose profile dir it does not
+        // know), and Electron has no restorable tab set.
+        var tabSessionRecorder: TabSessionRecorder?
 
         // Read the Keychain before launching the browser so the macOS ACL
         // prompt appears in front of the still-focused terminal instead of
@@ -184,6 +189,18 @@ struct ServerCommand: AsyncParsableCommand {
                 bridgeToken: bridgeToken
             )
             let userDataDir = chromeLauncher.resolveUserDataDir(servePort: servePort)
+            // Origins whose tabs are SLICC surfaces rather than user tabs:
+            // the hosted UI origin and this server's own bridge origin. They
+            // are excluded from the snapshot so the stale leader tab (dead
+            // bridge token) is never reopened — `launchURL` re-mints it.
+            let sliccOrigins = [resolveHostedLeaderOrigin(environment: environment), serveOrigin]
+            let tabSessionStore = TabSessionStore(
+                fileURL: TabSessionStore.defaultFileURL(userDataDir: userDataDir)
+            )
+            let restoreUrls = tabSessionStore.load(hostedOrigins: sliccOrigins)
+            if !restoreUrls.isEmpty {
+                logger.info("Reopening \(restoreUrls.count) tab(s) from the previous session")
+            }
 
             let launchedChrome = try await chromeLauncher.launch(
                 config: ChromeLaunchConfig(
@@ -192,13 +209,19 @@ struct ServerCommand: AsyncParsableCommand {
                     launchUrl: launchURL,
                     userDataDir: userDataDir,
                     executablePath: chromeExecutable,
-                    currentDirectoryPath: currentDirectoryPath
+                    currentDirectoryPath: currentDirectoryPath,
+                    restoreUrls: restoreUrls
                 )
             )
             browserProcess = launchedChrome.process
             browserKillPid = launchedChrome.chromePid
             browserLabel = "Chrome"
             cdpPort = launchedChrome.cdpPort
+            tabSessionRecorder = TabSessionRecorder(
+                store: tabSessionStore,
+                cdpPort: cdpPort,
+                hostedOrigins: sliccOrigins
+            )
         }
 
         let lickSystem = LickSystem()
@@ -340,9 +363,12 @@ struct ServerCommand: AsyncParsableCommand {
                     overlayInjector: overlayInjector,
                     cdpProxy: cdpProxy,
                     clientSockets: lickSystem,
-                    server: serverController
+                    server: serverController,
+                    tabRecorder: tabSessionRecorder
                 )
             )
+
+            await tabSessionRecorder?.start()
 
             if thinBridgeMode {
                 print("Thin /cdp bridge + /api at \(serveOrigin)")
@@ -355,10 +381,12 @@ struct ServerCommand: AsyncParsableCommand {
 
             try await appTask.value
             await consoleForwarder?.stop()
+            await tabSessionRecorder?.stop()
             overlayInjector?.stop()
             try await httpClient.shutdown()
         } catch {
             appTask.cancel()
+            await tabSessionRecorder?.stop()
             overlayInjector?.stop()
             try? await httpClient.shutdown()
             throw error

--- a/packages/swift-server/Sources/Server/GracefulShutdown.swift
+++ b/packages/swift-server/Sources/Server/GracefulShutdown.swift
@@ -18,9 +18,15 @@ protocol GracefulShutdownClientSocketControlling: Sendable {
     func shutdown() async
 }
 
+protocol GracefulShutdownTabRecording: Sendable {
+    func snapshotNow() async
+    func stop() async
+}
+
 extension ElectronOverlayInjector: GracefulShutdownOverlayControlling {}
 extension CDPProxy: GracefulShutdownChromeProxyControlling {}
 extension LickSystem: GracefulShutdownClientSocketControlling {}
+extension TabSessionRecorder: GracefulShutdownTabRecording {}
 
 struct ShutdownContext: @unchecked Sendable {
     var browserProcess: Process?
@@ -38,6 +44,9 @@ struct ShutdownContext: @unchecked Sendable {
     var cdpProxy: (any GracefulShutdownChromeProxyControlling)?
     var clientSockets: (any GracefulShutdownClientSocketControlling)?
     var server: (any GracefulShutdownServer)?
+    /// Takes a final tab snapshot before the browser closes, so the tabs the
+    /// user had open at quit time are the ones the next launch reopens.
+    var tabRecorder: (any GracefulShutdownTabRecording)?
 
     init(
         browserProcess: Process? = nil,
@@ -48,7 +57,8 @@ struct ShutdownContext: @unchecked Sendable {
         overlayInjector: (any GracefulShutdownOverlayControlling)? = nil,
         cdpProxy: (any GracefulShutdownChromeProxyControlling)? = nil,
         clientSockets: (any GracefulShutdownClientSocketControlling)? = nil,
-        server: (any GracefulShutdownServer)? = nil
+        server: (any GracefulShutdownServer)? = nil,
+        tabRecorder: (any GracefulShutdownTabRecording)? = nil
     ) {
         self.browserProcess = browserProcess
         self.browserKillPid = browserKillPid
@@ -59,6 +69,7 @@ struct ShutdownContext: @unchecked Sendable {
         self.cdpProxy = cdpProxy
         self.clientSockets = clientSockets
         self.server = server
+        self.tabRecorder = tabRecorder
     }
 }
 
@@ -163,6 +174,13 @@ actor GracefulShutdownHandler {
         GracefulShutdownLastResortRegistry.markGracefulShutdownStarted()
 
         print(closeBrowser ? "\nShutting down..." : "\nDetaching (browser stays open)...")
+        // Snapshot the tabs while the browser is still up: `closeBrowser`
+        // below tears the CDP endpoint down, and on the detach path the next
+        // full launch is what consumes the snapshot.
+        if let tabRecorder = context.tabRecorder {
+            await tabRecorder.snapshotNow()
+            await tabRecorder.stop()
+        }
         context.fileLogger?.close()
         context.overlayInjector?.stop()
 

--- a/packages/swift-server/Tests/CDPBrowserSessionTests.swift
+++ b/packages/swift-server/Tests/CDPBrowserSessionTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+@testable import slicc_server
+
+final class CDPBrowserSessionTests: XCTestCase {
+    private func result(_ json: String, id: Int) -> String? {
+        WebSocketCDPBrowserSession.result(fromFrame: Data(json.utf8), id: id)
+            .map { String(decoding: $0, as: UTF8.self) }
+    }
+
+    func testReturnsTheResultOfTheMatchingReply() {
+        XCTAssertEqual(
+            result(#"{"id":7,"result":{"defaultBrowserContextId":"CTX"}}"#, id: 7),
+            #"{"defaultBrowserContextId":"CTX"}"#
+        )
+    }
+
+    func testSkipsEventsAndOtherRepliesSoAReadLoopKeepsGoing() {
+        // Browser-level target lifecycle events interleave with replies.
+        XCTAssertNil(result(#"{"method":"Target.targetCreated","params":{}}"#, id: 7))
+        XCTAssertNil(result(#"{"id":6,"result":{}}"#, id: 7))
+        XCTAssertNil(result("not json", id: 7))
+        XCTAssertNil(result("[1,2,3]", id: 7))
+    }
+
+    func testTreatsAReplyWithoutAResultAsAnEmptyObject() {
+        // An error reply still answers the id; the decoder above then reports
+        // the missing field rather than the read hanging for more frames.
+        XCTAssertEqual(result(#"{"id":7,"error":{"code":-32000}}"#, id: 7), "{}")
+    }
+
+    func testNoReplyErrorNamesTheMethod() {
+        XCTAssertEqual(
+            CDPBrowserSessionError.noReply(method: "Target.getTargets").errorDescription,
+            "The browser did not reply to Target.getTargets."
+        )
+    }
+}

--- a/packages/swift-server/Tests/CDPBrowserSessionTests.swift
+++ b/packages/swift-server/Tests/CDPBrowserSessionTests.swift
@@ -35,4 +35,106 @@ final class CDPBrowserSessionTests: XCTestCase {
             "The browser did not reply to Target.getTargets."
         )
     }
+
+    func testCallNumbersItsCommandsAndReadsPastInterleavedFrames() async throws {
+        let socket = SocketStub(frames: [
+            .string(#"{"method":"Target.targetCreated","params":{}}"#),
+            .data(Data(#"{"id":99,"result":{"stale":true}}"#.utf8)),
+            .string(#"{"id":1,"result":{"browserContextIds":["CTX"]}}"#),
+            .string(#"{"id":2,"result":{"targetInfos":[]}}"#),
+        ])
+        let session = WebSocketCDPBrowserSession(socket: socket)
+
+        let contexts = try await session.call(method: "Target.getBrowserContexts")
+        let targets = try await session.call(method: "Target.getTargets")
+
+        XCTAssertEqual(String(decoding: contexts, as: UTF8.self), #"{"browserContextIds":["CTX"]}"#)
+        XCTAssertEqual(String(decoding: targets, as: UTF8.self), #"{"targetInfos":[]}"#)
+        // Ids increment per call, which is what lets the loop above tell this
+        // call's reply from the previous one's.
+        let sent = await socket.sentCommands()
+        XCTAssertEqual(sent.map(\.id), [1, 2])
+        XCTAssertEqual(sent.map(\.method), ["Target.getBrowserContexts", "Target.getTargets"])
+    }
+
+    func testCallGivesUpOnABrowserThatOnlyEmitsEvents() async {
+        // Without the frame budget a chatty browser would pin the caller for
+        // as long as it keeps talking.
+        let event = URLSessionWebSocketTask.Message.string(#"{"method":"Target.targetInfoChanged"}"#)
+        let socket = SocketStub(frames: Array(repeating: event, count: 256))
+        let session = WebSocketCDPBrowserSession(socket: socket)
+
+        do {
+            _ = try await session.call(method: "Target.getTargets")
+            XCTFail("expected the call to give up")
+        } catch {
+            XCTAssertEqual(
+                (error as? CDPBrowserSessionError)?.errorDescription,
+                CDPBrowserSessionError.noReply(method: "Target.getTargets").errorDescription
+            )
+        }
+    }
+
+    func testAClosedPortSurfacesAsAThrownErrorRatherThanAHang() async {
+        // Production wiring, no browser behind it: the recorder polls on the
+        // shutdown path, so a refused connection has to come back as an error.
+        let session = WebSocketCDPBrowserSession(url: URL(string: "ws://127.0.0.1:1/devtools/browser/none")!)
+
+        do {
+            _ = try await session.call(method: "Target.getTargets")
+            XCTFail("expected the call to fail")
+        } catch {
+            XCTAssertNotNil(error)
+        }
+        await session.close()
+    }
+
+    func testCloseCancelsTheSocket() async {
+        let socket = SocketStub(frames: [])
+        let session = WebSocketCDPBrowserSession(socket: socket)
+
+        await session.close()
+
+        let cancelled = await socket.wasCancelled()
+        XCTAssertTrue(cancelled)
+    }
+}
+
+/// Replays a scripted frame sequence, the way a browser interleaves target
+/// events with command replies.
+private actor SocketStub: CDPWebSocketTransport {
+    struct Command {
+        let id: Int
+        let method: String
+    }
+
+    private var frames: [URLSessionWebSocketTask.Message]
+    private var sent: [Command] = []
+    private var cancelled = false
+
+    init(frames: [URLSessionWebSocketTask.Message]) {
+        self.frames = frames
+    }
+
+    func sendFrame(_ payload: Data) async throws {
+        let object = try JSONSerialization.jsonObject(with: payload) as? [String: Any]
+        sent.append(
+            Command(
+                id: object?["id"] as? Int ?? -1,
+                method: object?["method"] as? String ?? ""
+            )
+        )
+    }
+
+    func receiveFrame() async throws -> URLSessionWebSocketTask.Message {
+        guard !frames.isEmpty else { throw CancellationError() }
+        return frames.removeFirst()
+    }
+
+    func cancelSocket() {
+        cancelled = true
+    }
+
+    func sentCommands() -> [Command] { sent }
+    func wasCancelled() -> Bool { cancelled }
 }

--- a/packages/swift-server/Tests/ChromeLauncherTests.swift
+++ b/packages/swift-server/Tests/ChromeLauncherTests.swift
@@ -55,6 +55,46 @@ final class ChromeLauncherTests: XCTestCase {
         XCTAssertEqual(args.last, "http://127.0.0.1:5710")
     }
 
+    func testBuildLaunchArgsAppendsRestoredTabsAfterTheSliccURL() {
+        // Chromium activates the first URL on the command line, so the SLICC
+        // tab has to stay first — the restored tabs land to its right.
+        let launcher = makeLauncher()
+        let args = launcher.buildLaunchArgs(
+            cdpPort: 9333,
+            launchUrl: "https://www.sliccy.ai/?bridge=ws://localhost:5710/cdp&bridgeToken=t",
+            userDataDir: "/tmp/profile",
+            extensionPath: nil,
+            restoreUrls: ["https://example.com/a", "https://example.org/b"]
+        )
+
+        XCTAssertEqual(
+            Array(args.suffix(3)),
+            [
+                "https://www.sliccy.ai/?bridge=ws://localhost:5710/cdp&bridgeToken=t",
+                "https://example.com/a",
+                "https://example.org/b",
+            ]
+        )
+    }
+
+    func testBuildLaunchArgsRejectsRestoredEntriesThatCouldBeReadAsChromeFlags() {
+        // The snapshot file is user-writable, and each restored entry becomes
+        // an argv slot — a `--flag`-shaped or non-web entry must never reach
+        // Chrome's command line.
+        let launcher = makeLauncher()
+        let args = launcher.buildLaunchArgs(
+            cdpPort: 9333,
+            launchUrl: "https://www.sliccy.ai",
+            userDataDir: "/tmp/profile",
+            extensionPath: nil,
+            restoreUrls: ["--headless=new", "file:///etc/passwd", "https://example.com/a"]
+        )
+
+        XCTAssertEqual(args.last, "https://example.com/a")
+        XCTAssertFalse(args.contains("--headless=new"))
+        XCTAssertFalse(args.contains("file:///etc/passwd"))
+    }
+
     func testBuildLaunchArgsDisablesLocalNetworkAccessChecks() {
         // Regression: Sliccstart loads its UI from https://www.sliccy.ai and
         // dials back to the local bridge (public->local), which Chromium 142+

--- a/packages/swift-server/Tests/ChromeLauncherTests.swift
+++ b/packages/swift-server/Tests/ChromeLauncherTests.swift
@@ -484,6 +484,26 @@ final class ChromeLauncherTests: XCTestCase {
         XCTAssertNil(browser)
     }
 
+    func testEveryLaunchFailureExplainsItselfToTheUser() {
+        // These strings are what the launcher surfaces in its error report,
+        // so an empty or duplicated one leaves the user with no next step.
+        let descriptions: [String] = [
+            ChromeLauncherError.chromeExecutableNotFound,
+            .invalidChromeExecutable("/no/such/chrome"),
+            .chromeExitedBeforeReportingPort(9),
+            .timedOutWaitingForPort(2.5),
+            .cdpUnavailable(9222),
+            .openLaunchFailed(exitCode: 1, executable: "/Applications/Google Chrome.app"),
+            .chromeAlreadyRunning(port: 9222, browser: "Chrome/147"),
+            .chromeAlreadyRunning(port: 9222, browser: nil),
+        ].map(\.localizedDescription)
+
+        XCTAssertEqual(descriptions.count, Set(descriptions).count)
+        XCTAssertFalse(descriptions.contains { $0.isEmpty })
+        XCTAssertTrue(descriptions.contains { $0.contains("2500ms") })
+        XCTAssertTrue(descriptions.contains { $0.contains("(Chrome/147)") })
+    }
+
     func testLaunchFailsFastWhenCdpPortIsAlreadyServingChrome() async throws {
         let chromePath = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
         let cdpResponse = Data(#"{"Browser":"Chrome/147.0.7727.101","webSocketDebuggerUrl":"ws://127.0.0.1:9222/devtools/browser/test"}"#.utf8)

--- a/packages/swift-server/Tests/GracefulShutdownHandlerTests.swift
+++ b/packages/swift-server/Tests/GracefulShutdownHandlerTests.swift
@@ -50,6 +50,29 @@ final class GracefulShutdownHandlerTests: XCTestCase {
         XCTAssertEqual(exitRecorder.codeSnapshot(), 0)
     }
 
+    func testRunShutdownSequenceSnapshotsTabsBeforeStoppingTheRecorder() async {
+        // The snapshot has to happen while CDP is still reachable, so the
+        // tabs the user had open at quit time are the ones the next launch
+        // reopens. Detach takes the same path (the browser survives, and the
+        // next full launch consumes the snapshot).
+        for closeBrowser in [true, false] {
+            let tabRecorder = TabRecorderSpy()
+
+            let handler = GracefulShutdownHandler(exitHandler: { _ in })
+            await handler.runShutdownSequence(
+                context: ShutdownContext(
+                    browserLabel: "Chrome",
+                    cdpPort: 9222,
+                    tabRecorder: tabRecorder
+                ),
+                closeBrowser: closeBrowser
+            )
+
+            let events = await tabRecorder.events
+            XCTAssertEqual(events, ["snapshot", "stop"])
+        }
+    }
+
     func testRunShutdownSequenceSendsBrowserCloseBeforeForcedKill() async throws {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
@@ -355,6 +378,18 @@ private actor ClientSocketSpy: GracefulShutdownClientSocketControlling {
 
     func shutdownCount() -> Int {
         count
+    }
+}
+
+private actor TabRecorderSpy: GracefulShutdownTabRecording {
+    private(set) var events: [String] = []
+
+    func snapshotNow() async {
+        events.append("snapshot")
+    }
+
+    func stop() async {
+        events.append("stop")
     }
 }
 

--- a/packages/swift-server/Tests/GracefulShutdownHandlerTests.swift
+++ b/packages/swift-server/Tests/GracefulShutdownHandlerTests.swift
@@ -338,6 +338,18 @@ final class GracefulShutdownHandlerTests: XCTestCase {
         XCTAssertEqual(killTargets.snapshot(), [chromePid])
         XCTAssertEqual(exitRecorder.codeSnapshot(), 0)
     }
+
+    func testEveryShutdownFailureExplainsWhichStepGaveUp() {
+        let descriptions: [String] = [
+            GracefulShutdownError.cdpUnavailable(9222),
+            .invalidBrowserWebSocketURL("not a url"),
+            .missingBrowserWebSocketURL,
+        ].map(\.localizedDescription)
+
+        XCTAssertEqual(descriptions.count, Set(descriptions).count)
+        XCTAssertFalse(descriptions.contains { $0.isEmpty })
+        XCTAssertTrue(descriptions.contains { $0.contains("9222") })
+    }
 }
 
 private final class OverlayControllerSpy: @unchecked Sendable, GracefulShutdownOverlayControlling {

--- a/packages/swift-server/Tests/OAuthSecretStoreTests.swift
+++ b/packages/swift-server/Tests/OAuthSecretStoreTests.swift
@@ -56,4 +56,12 @@ final class OAuthSecretStoreTests: XCTestCase {
         XCTAssertEqual(entries.map(\.name), ["A", "B"])
         XCTAssertEqual(entries.map(\.value), ["1", "2"])
     }
+
+    func testEmptyDomainsRejectionExplainsItself() {
+        // Surfaces to the webapp through the API route's error body.
+        XCTAssertEqual(
+            OAuthSecretStore.OAuthSecretStoreError.emptyDomains.errorDescription,
+            "OAuthSecretStore: domains must be non-empty"
+        )
+    }
 }

--- a/packages/swift-server/Tests/RequestLoggerTests.swift
+++ b/packages/swift-server/Tests/RequestLoggerTests.swift
@@ -1,4 +1,7 @@
 import Hummingbird
+import HummingbirdTesting
+import Logging
+import NIOCore
 import XCTest
 
 @testable import slicc_server
@@ -16,5 +19,71 @@ final class RequestLoggerTests: XCTestCase {
             RequestLogger<BasicRequestContext>.coloredStatusCode(204),
             "\u{1b}[32m204\u{1b}[0m"
         )
+    }
+
+    func testLogsOneLinePerRequestIncludingFailedOnes() async throws {
+        // A handler that throws still has to produce a log line, otherwise the
+        // requests worth debugging are exactly the ones missing from the log.
+        let sink = LogSink()
+        let logger = Logger(label: "test.request") { _ in SinkLogHandler(sink: sink) }
+        let router = Router(context: BasicRequestContext.self)
+        router.middlewares.add(RequestLogger<BasicRequestContext>(logger: logger))
+        router.get("/api/status") { _, _ in
+            Response(status: .ok, body: .init(byteBuffer: ByteBuffer(string: "{}")))
+        }
+        router.get("/api/boom") { _, _ -> Response in
+            throw HTTPError(.badGateway)
+        }
+
+        let app = Application(responder: router.buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(uri: "/api/status", method: .get) { XCTAssertEqual($0.status, .ok) }
+            try await client.execute(uri: "/api/boom", method: .get) { XCTAssertEqual($0.status, .badGateway) }
+        }
+
+        let lines = sink.snapshot()
+        XCTAssertTrue(lines.contains { $0.contains("200") && $0.contains("GET /api/status") })
+        XCTAssertTrue(lines.contains { $0.contains("502") && $0.contains("GET /api/boom") })
+        XCTAssertTrue(lines.allSatisfy { $0.hasSuffix("ms") })
+    }
+}
+
+private final class LogSink: @unchecked Sendable {
+    private let lock = NSLock()
+    private var lines: [String] = []
+
+    func record(_ line: String) {
+        lock.lock()
+        lines.append(line)
+        lock.unlock()
+    }
+
+    func snapshot() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return lines
+    }
+}
+
+private struct SinkLogHandler: LogHandler {
+    let sink: LogSink
+    var metadata: Logger.Metadata = [:]
+    var logLevel: Logger.Level = .trace
+
+    subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+        get { metadata[key] }
+        set { metadata[key] = newValue }
+    }
+
+    func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        sink.record(message.description)
     }
 }

--- a/packages/swift-server/Tests/ServerCommandTests.swift
+++ b/packages/swift-server/Tests/ServerCommandTests.swift
@@ -1,3 +1,4 @@
+import Logging
 import XCTest
 
 @testable import slicc_server
@@ -460,6 +461,46 @@ final class ServerCommandTests: XCTestCase {
                 thinBridgeMode: true,
                 bridgeToken: nil
             ))
+    }
+
+    func testNormalizeTrayWorkerBaseURLStripsEverythingButTheOrigin() {
+        // The value ends up in URLs the webapp dials, so a stray trailing
+        // slash or a leftover query would produce a double-slashed endpoint.
+        XCTAssertEqual(
+            ServerCommand.normalizeTrayWorkerBaseURL(" https://tray.example.com/base/?a=1#f "),
+            "https://tray.example.com/base"
+        )
+        XCTAssertEqual(ServerCommand.normalizeTrayWorkerBaseURL("https://tray.example.com/"), "https://tray.example.com")
+        XCTAssertEqual(ServerCommand.normalizeTrayWorkerBaseURL("https://tray.example.com///"), "https://tray.example.com")
+        XCTAssertNil(ServerCommand.normalizeTrayWorkerBaseURL("   "))
+        XCTAssertNil(ServerCommand.normalizeTrayWorkerBaseURL("tray.example.com"))
+        XCTAssertNil(ServerCommand.normalizeTrayWorkerBaseURL(nil))
+    }
+
+    func testParseEnvFileSecretsReadsTheSameSyntaxAsTheKeychainBlob() throws {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("slicc-env-\(UUID().uuidString).env")
+        try """
+        GITHUB_TOKEN=ghp_test
+        GITHUB_TOKEN_DOMAINS=api.github.com
+        """.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let secrets = try XCTUnwrap(ServerCommand.parseEnvFileSecrets(at: url))
+
+        XCTAssertEqual(secrets.map(\.name), ["GITHUB_TOKEN"])
+        XCTAssertEqual(secrets.first?.domains, ["api.github.com"])
+        // A missing file is "no override", not an empty secret set.
+        XCTAssertNil(ServerCommand.parseEnvFileSecrets(at: url.appendingPathExtension("gone")))
+    }
+
+    func testLoggerLevelMapsTheCliVocabularyOntoSwiftLog() {
+        XCTAssertEqual(ServerCommand.loggerLevel(from: "debug"), .debug)
+        // The CLI says "warn", swift-log says "warning".
+        XCTAssertEqual(ServerCommand.loggerLevel(from: "warn"), .warning)
+        XCTAssertEqual(ServerCommand.loggerLevel(from: "error"), .error)
+        XCTAssertEqual(ServerCommand.loggerLevel(from: "info"), .info)
+        XCTAssertEqual(ServerCommand.loggerLevel(from: "verbose"), .info)
     }
 
     func testShouldMountThinBridgeCorsOffInLegacyModesWithoutToken() {

--- a/packages/swift-server/Tests/TabSessionRecorderTests.swift
+++ b/packages/swift-server/Tests/TabSessionRecorderTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+
+@testable import slicc_server
+
+final class TabSessionRecorderTests: XCTestCase {
+    private let sliccOrigins = ["https://www.sliccy.ai", "http://localhost:5710"]
+
+    func testSnapshotPersistsPageTargetsAndSkipsTheSliccTab() async {
+        let store = TabSessionStore(fileURL: makeTemporaryFileURL())
+        let payload = """
+            [
+              {"type":"page","url":"https://www.sliccy.ai/?bridge=ws://localhost:5710/cdp&bridgeToken=t"},
+              {"type":"page","url":"https://example.com/a"},
+              {"type":"service_worker","url":"https://example.com/sw.js"},
+              {"type":"page","url":"chrome://settings"}
+            ]
+            """
+        let recorder = makeRecorder(store: store, responses: [.success((200, Data(payload.utf8)))])
+
+        await recorder.snapshotNow()
+
+        XCTAssertEqual(store.load(hostedOrigins: sliccOrigins), ["https://example.com/a"])
+    }
+
+    func testSnapshotRequestsTheCdpTargetListForTheConfiguredPort() async {
+        let requested = RequestRecorder()
+        let recorder = TabSessionRecorder(
+            store: TabSessionStore(fileURL: makeTemporaryFileURL()),
+            cdpPort: 9333,
+            hostedOrigins: sliccOrigins,
+            fetch: { url in
+                await requested.record(url)
+                return (200, Data("[]".utf8))
+            }
+        )
+
+        await recorder.snapshotNow()
+
+        let urls = await requested.urls
+        XCTAssertEqual(urls, ["http://127.0.0.1:9333/json/list"])
+    }
+
+    func testFailedOrNonSuccessProbeLeavesThePreviousSnapshotIntact() async {
+        let store = TabSessionStore(fileURL: makeTemporaryFileURL())
+        store.save(urls: ["https://example.com/keep"], hostedOrigins: sliccOrigins)
+        let good = Data(#"[{"type":"page","url":"https://example.com/new"}]"#.utf8)
+        let recorder = makeRecorder(
+            store: store,
+            responses: [
+                .failure(URLError(.cannotConnectToHost)),
+                .success((500, good)),
+                .success((200, Data("not json".utf8))),
+            ]
+        )
+
+        for _ in 0..<3 {
+            await recorder.snapshotNow()
+            XCTAssertEqual(store.load(hostedOrigins: sliccOrigins), ["https://example.com/keep"])
+        }
+    }
+
+    func testStartPollsRepeatedlyUntilStopped() async throws {
+        let store = TabSessionStore(fileURL: makeTemporaryFileURL())
+        let requested = RequestRecorder()
+        let recorder = TabSessionRecorder(
+            store: store,
+            cdpPort: 9222,
+            hostedOrigins: sliccOrigins,
+            intervalNanoseconds: 1_000_000,
+            fetch: { url in
+                await requested.record(url)
+                return (200, Data(#"[{"type":"page","url":"https://example.com/a"}]"#.utf8))
+            }
+        )
+
+        await recorder.start()
+        for _ in 0..<200 where await requested.urls.count < 2 {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        await recorder.stop()
+        let afterStop = await requested.urls.count
+
+        XCTAssertGreaterThanOrEqual(afterStop, 2)
+        XCTAssertEqual(store.load(hostedOrigins: sliccOrigins), ["https://example.com/a"])
+        // A stopped recorder stays stopped: the poll loop is cancelled, not paused.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let settled = await requested.urls.count
+        XCTAssertEqual(settled, afterStop)
+    }
+
+    private func makeRecorder(
+        store: TabSessionStore,
+        responses: [Result<(Int, Data), Error>]
+    ) -> TabSessionRecorder {
+        let queue = ResponseQueue(responses: responses)
+        return TabSessionRecorder(
+            store: store,
+            cdpPort: 9222,
+            hostedOrigins: sliccOrigins,
+            fetch: { _ in try await queue.next() }
+        )
+    }
+
+    private func makeTemporaryFileURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("slicc-tab-recorder-tests-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("tabs.json")
+    }
+}
+
+private actor ResponseQueue {
+    private var responses: [Result<(Int, Data), Error>]
+
+    init(responses: [Result<(Int, Data), Error>]) {
+        self.responses = responses
+    }
+
+    func next() async throws -> (Int, Data) {
+        guard !responses.isEmpty else { throw URLError(.cannotConnectToHost) }
+        return try responses.removeFirst().get()
+    }
+}
+
+private actor RequestRecorder {
+    private(set) var urls: [String] = []
+
+    func record(_ url: URL) {
+        urls.append(url.absoluteString)
+    }
+}

--- a/packages/swift-server/Tests/TabSessionRecorderTests.swift
+++ b/packages/swift-server/Tests/TabSessionRecorderTests.swift
@@ -111,6 +111,34 @@ final class TabSessionRecorderTests: XCTestCase {
         }
     }
 
+    func testSnapshotGivesUpOnABrowserThatStopsAnswering() async {
+        // The shutdown sequence awaits snapshotNow() before closing and
+        // force-killing the browser, so a browser that accepts the socket and
+        // then goes quiet must not be able to stall shutdown.
+        let store = TabSessionStore(fileURL: makeTemporaryFileURL())
+        store.save(urls: ["https://example.com/keep"], hostedOrigins: sliccOrigins)
+        let session = HangingSessionStub()
+        let recorder = TabSessionRecorder(
+            store: store,
+            cdpPort: 9222,
+            hostedOrigins: sliccOrigins,
+            readTimeoutNanoseconds: 20_000_000,
+            fetch: { _ in
+                (200, Data(#"{"webSocketDebuggerUrl":"ws://127.0.0.1:9222/devtools/browser/abc"}"#.utf8))
+            },
+            openSession: { _ in session }
+        )
+
+        let started = Date()
+        await recorder.snapshotNow()
+
+        XCTAssertLessThan(Date().timeIntervalSince(started), 5)
+        XCTAssertEqual(store.load(hostedOrigins: sliccOrigins), ["https://example.com/keep"])
+        // Closing the socket is what releases a read still waiting on the browser.
+        let isClosed = await session.isClosed
+        XCTAssertTrue(isClosed)
+    }
+
     func testStartPollsRepeatedlyUntilStopped() async throws {
         let store = TabSessionStore(fileURL: makeTemporaryFileURL())
         let requested = RequestRecorder()
@@ -205,6 +233,22 @@ private actor BrowserSessionStub: CDPBrowserSession {
         default:
             return Data("{}".utf8)
         }
+    }
+
+    func close() {
+        isClosed = true
+    }
+}
+
+/// A browser that accepts the connection and then never answers.
+private actor HangingSessionStub: CDPBrowserSession {
+    private(set) var isClosed = false
+
+    func call(method: String) async throws -> Data {
+        while !Task.isCancelled {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        throw CancellationError()
     }
 
     func close() {

--- a/packages/swift-server/Tests/TabSessionRecorderTests.swift
+++ b/packages/swift-server/Tests/TabSessionRecorderTests.swift
@@ -174,6 +174,23 @@ final class TabSessionRecorderTests: XCTestCase {
         XCTAssertEqual(settled, afterStop)
     }
 
+    func testSnapshotKeepsTheLastGoodFileWhenNothingIsListeningOnTheCdpPort() async {
+        // Exercises the production HTTP probe: after the browser is gone the
+        // discovery request fails, and a failed poll must not erase the
+        // snapshot the next launch restores from.
+        let store = TabSessionStore(fileURL: makeTemporaryFileURL())
+        store.save(urls: ["https://example.com/keep"], hostedOrigins: sliccOrigins)
+        let recorder = TabSessionRecorder(
+            store: store,
+            cdpPort: 1,
+            hostedOrigins: sliccOrigins
+        )
+
+        await recorder.snapshotNow()
+
+        XCTAssertEqual(store.load(hostedOrigins: sliccOrigins), ["https://example.com/keep"])
+    }
+
     private func makeRecorder(
         store: TabSessionStore,
         targets: [(context: String, type: String, url: String)],

--- a/packages/swift-server/Tests/TabSessionRecorderTests.swift
+++ b/packages/swift-server/Tests/TabSessionRecorderTests.swift
@@ -4,56 +4,108 @@ import XCTest
 
 final class TabSessionRecorderTests: XCTestCase {
     private let sliccOrigins = ["https://www.sliccy.ai", "http://localhost:5710"]
+    private static let defaultContext = "DEFAULT-CTX"
+    private static let incognitoContext = "OTR-CTX"
 
     func testSnapshotPersistsPageTargetsAndSkipsTheSliccTab() async {
         let store = TabSessionStore(fileURL: makeTemporaryFileURL())
-        let payload = """
-            [
-              {"type":"page","url":"https://www.sliccy.ai/?bridge=ws://localhost:5710/cdp&bridgeToken=t"},
-              {"type":"page","url":"https://example.com/a"},
-              {"type":"service_worker","url":"https://example.com/sw.js"},
-              {"type":"page","url":"chrome://settings"}
+        let recorder = makeRecorder(
+            store: store,
+            targets: [
+                (Self.defaultContext, "page", "https://www.sliccy.ai/?bridge=ws://localhost:5710/cdp&bridgeToken=t"),
+                (Self.defaultContext, "page", "https://example.com/a"),
+                (Self.defaultContext, "service_worker", "https://example.com/sw.js"),
+                (Self.defaultContext, "page", "chrome://settings"),
             ]
-            """
-        let recorder = makeRecorder(store: store, responses: [.success((200, Data(payload.utf8)))])
+        )
 
         await recorder.snapshotNow()
 
         XCTAssertEqual(store.load(hostedOrigins: sliccOrigins), ["https://example.com/a"])
     }
 
-    func testSnapshotRequestsTheCdpTargetListForTheConfiguredPort() async {
+    func testSnapshotNeverPersistsIncognitoTabs() async {
+        // Incognito pages show up in the target list with nothing but their
+        // browser context to tell them apart, and writing browsing the user
+        // made private into a file on disk would outlive the session.
+        let store = TabSessionStore(fileURL: makeTemporaryFileURL())
+        let recorder = makeRecorder(
+            store: store,
+            targets: [
+                (Self.defaultContext, "page", "https://example.com/normal"),
+                (Self.incognitoContext, "page", "https://example.com/private"),
+            ]
+        )
+
+        await recorder.snapshotNow()
+
+        XCTAssertEqual(store.load(hostedOrigins: sliccOrigins), ["https://example.com/normal"])
+    }
+
+    func testSnapshotIsSkippedWhenTheDefaultContextCannotBeIdentified() async {
+        // `defaultBrowserContextId` is an optional CDP field. Without it every
+        // tab is potentially Incognito, so the snapshot is skipped rather than
+        // written optimistically.
+        let store = TabSessionStore(fileURL: makeTemporaryFileURL())
+        store.save(urls: ["https://example.com/keep"], hostedOrigins: sliccOrigins)
+        let recorder = makeRecorder(
+            store: store,
+            targets: [(Self.defaultContext, "page", "https://example.com/new")],
+            defaultContextId: nil
+        )
+
+        await recorder.snapshotNow()
+
+        XCTAssertEqual(store.load(hostedOrigins: sliccOrigins), ["https://example.com/keep"])
+    }
+
+    func testSnapshotReadsTheBrowserEndpointForTheConfiguredPort() async {
         let requested = RequestRecorder()
+        let session = BrowserSessionStub(defaultContextId: Self.defaultContext, targets: [])
         let recorder = TabSessionRecorder(
             store: TabSessionStore(fileURL: makeTemporaryFileURL()),
             cdpPort: 9333,
             hostedOrigins: sliccOrigins,
             fetch: { url in
                 await requested.record(url)
-                return (200, Data("[]".utf8))
-            }
+                return (200, Data(#"{"webSocketDebuggerUrl":"ws://127.0.0.1:9333/devtools/browser/abc"}"#.utf8))
+            },
+            openSession: { _ in session }
         )
 
         await recorder.snapshotNow()
 
         let urls = await requested.urls
-        XCTAssertEqual(urls, ["http://127.0.0.1:9333/json/list"])
+        XCTAssertEqual(urls, ["http://127.0.0.1:9333/json/version"])
+        // Browser-level reads only: a page attach could evict the webapp's
+        // own `/cdp` session.
+        let methods = await session.methods
+        XCTAssertEqual(methods, ["Target.getBrowserContexts", "Target.getTargets"])
+        let isClosed = await session.isClosed
+        XCTAssertTrue(isClosed)
     }
 
     func testFailedOrNonSuccessProbeLeavesThePreviousSnapshotIntact() async {
         let store = TabSessionStore(fileURL: makeTemporaryFileURL())
         store.save(urls: ["https://example.com/keep"], hostedOrigins: sliccOrigins)
-        let good = Data(#"[{"type":"page","url":"https://example.com/new"}]"#.utf8)
-        let recorder = makeRecorder(
+        let version = Data(#"{"webSocketDebuggerUrl":"ws://127.0.0.1:9222/devtools/browser/abc"}"#.utf8)
+        let queue = ResponseQueue(responses: [
+            .failure(URLError(.cannotConnectToHost)),
+            .success((500, version)),
+            .success((200, Data("not json".utf8))),
+            .success((200, Data("{}".utf8))),
+            .success((200, version)),
+        ])
+        let recorder = TabSessionRecorder(
             store: store,
-            responses: [
-                .failure(URLError(.cannotConnectToHost)),
-                .success((500, good)),
-                .success((200, Data("not json".utf8))),
-            ]
+            cdpPort: 9222,
+            hostedOrigins: sliccOrigins,
+            fetch: { _ in try await queue.next() },
+            // The last round reaches a browser that refuses the read.
+            openSession: { _ in BrowserSessionStub(defaultContextId: nil, targets: [], failing: true) }
         )
 
-        for _ in 0..<3 {
+        for _ in 0..<5 {
             await recorder.snapshotNow()
             XCTAssertEqual(store.load(hostedOrigins: sliccOrigins), ["https://example.com/keep"])
         }
@@ -69,7 +121,13 @@ final class TabSessionRecorderTests: XCTestCase {
             intervalNanoseconds: 1_000_000,
             fetch: { url in
                 await requested.record(url)
-                return (200, Data(#"[{"type":"page","url":"https://example.com/a"}]"#.utf8))
+                return (200, Data(#"{"webSocketDebuggerUrl":"ws://127.0.0.1:9222/devtools/browser/abc"}"#.utf8))
+            },
+            openSession: { _ in
+                BrowserSessionStub(
+                    defaultContextId: Self.defaultContext,
+                    targets: [(Self.defaultContext, "page", "https://example.com/a")]
+                )
             }
         )
 
@@ -90,14 +148,19 @@ final class TabSessionRecorderTests: XCTestCase {
 
     private func makeRecorder(
         store: TabSessionStore,
-        responses: [Result<(Int, Data), Error>]
+        targets: [(context: String, type: String, url: String)],
+        defaultContextId: String? = TabSessionRecorderTests.defaultContext
     ) -> TabSessionRecorder {
-        let queue = ResponseQueue(responses: responses)
-        return TabSessionRecorder(
+        TabSessionRecorder(
             store: store,
             cdpPort: 9222,
             hostedOrigins: sliccOrigins,
-            fetch: { _ in try await queue.next() }
+            fetch: { _ in
+                (200, Data(#"{"webSocketDebuggerUrl":"ws://127.0.0.1:9222/devtools/browser/abc"}"#.utf8))
+            },
+            openSession: { _ in
+                BrowserSessionStub(defaultContextId: defaultContextId, targets: targets)
+            }
         )
     }
 
@@ -105,6 +168,47 @@ final class TabSessionRecorderTests: XCTestCase {
         URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("slicc-tab-recorder-tests-\(UUID().uuidString)", isDirectory: true)
             .appendingPathComponent("tabs.json")
+    }
+}
+
+/// Canned browser-level CDP endpoint: answers `Target.getBrowserContexts` and
+/// `Target.getTargets` and records what was asked of it.
+private actor BrowserSessionStub: CDPBrowserSession {
+    private let defaultContextId: String?
+    private let targets: [(context: String, type: String, url: String)]
+    private let failing: Bool
+    private(set) var methods: [String] = []
+    private(set) var isClosed = false
+
+    init(
+        defaultContextId: String?,
+        targets: [(context: String, type: String, url: String)],
+        failing: Bool = false
+    ) {
+        self.defaultContextId = defaultContextId
+        self.targets = targets
+        self.failing = failing
+    }
+
+    func call(method: String) async throws -> Data {
+        methods.append(method)
+        if failing { throw CDPBrowserSessionError.noReply(method: method) }
+        switch method {
+        case "Target.getBrowserContexts":
+            let payload = defaultContextId.map { #"{"defaultBrowserContextId":"\#($0)"}"# } ?? "{}"
+            return Data(payload.utf8)
+        case "Target.getTargets":
+            let infos = targets.map {
+                #"{"type":"\#($0.type)","url":"\#($0.url)","browserContextId":"\#($0.context)"}"#
+            }
+            return Data(#"{"targetInfos":[\#(infos.joined(separator: ","))]}"#.utf8)
+        default:
+            return Data("{}".utf8)
+        }
+    }
+
+    func close() {
+        isClosed = true
     }
 }
 

--- a/packages/swift-server/Tests/TabSessionStoreTests.swift
+++ b/packages/swift-server/Tests/TabSessionStoreTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+
+@testable import slicc_server
+
+final class TabSessionStoreTests: XCTestCase {
+    private let sliccOrigins = ["https://www.sliccy.ai", "http://localhost:5710"]
+
+    func testSanitizeKeepsHttpAndHttpsPagesInFirstSeenOrder() {
+        let urls = TabSessionStore.sanitize(
+            rawUrls: ["https://example.com/a", "http://example.org/b", "https://example.com/a"],
+            hostedOrigins: sliccOrigins
+        )
+
+        XCTAssertEqual(urls, ["https://example.com/a", "http://example.org/b"])
+    }
+
+    func testSanitizeDropsNonWebSchemesAndFlagShapedEntries() {
+        // Every surviving entry becomes a Chrome argv slot, so anything that
+        // could be read as a switch — or as a local file / script URL — must
+        // not make it through.
+        let urls = TabSessionStore.sanitize(
+            rawUrls: [
+                "--headless=new",
+                "--user-data-dir=/tmp/evil",
+                "file:///etc/passwd",
+                "javascript:alert(1)",
+                "chrome://settings",
+                "chrome-extension://abc/page.html",
+                "devtools://devtools/bundled/inspector.html",
+                "about:blank",
+                "",
+                "https://example.com/keep",
+            ],
+            hostedOrigins: sliccOrigins
+        )
+
+        XCTAssertEqual(urls, ["https://example.com/keep"])
+    }
+
+    func testSanitizeDropsSliccOriginsAndBridgeCarryingTabs() {
+        let urls = TabSessionStore.sanitize(
+            rawUrls: [
+                "https://www.sliccy.ai/?bridge=ws://localhost:5710/cdp&bridgeToken=abc",
+                "https://www.sliccy.ai/pricing",
+                "http://localhost:5710/api/status",
+                "https://staging.example/?bridgeToken=abc",
+                "https://example.com/keep",
+            ],
+            hostedOrigins: sliccOrigins
+        )
+
+        XCTAssertEqual(urls, ["https://example.com/keep"])
+    }
+
+    func testSanitizeCapsRestoredTabs() {
+        let many = (0..<(TabSessionStore.maxRestoredTabs + 10)).map { "https://example.com/\($0)" }
+
+        let urls = TabSessionStore.sanitize(rawUrls: many, hostedOrigins: [])
+
+        XCTAssertEqual(urls.count, TabSessionStore.maxRestoredTabs)
+        XCTAssertEqual(urls.first, "https://example.com/0")
+    }
+
+    func testDefaultFileURLIsKeyedByProfileDirectoryName() {
+        let url = TabSessionStore.defaultFileURL(
+            userDataDir: "/Users/x/Library/Application Support/Slicc/profiles/browser-coding-agent-chrome-5720",
+            homeDirectory: "/Users/x"
+        )
+
+        XCTAssertEqual(
+            url.path,
+            "/Users/x/Library/Application Support/Slicc/sessions/browser-coding-agent-chrome-5720-tabs.json"
+        )
+    }
+
+    func testSaveThenLoadRoundTripsSanitizedUrls() throws {
+        let store = TabSessionStore(fileURL: makeTemporaryFileURL())
+
+        store.save(
+            urls: ["https://example.com/a", "chrome://settings", "https://www.sliccy.ai/pricing"],
+            hostedOrigins: sliccOrigins
+        )
+
+        XCTAssertEqual(store.load(hostedOrigins: sliccOrigins), ["https://example.com/a"])
+    }
+
+    func testLoadReappliesSanitizationToAnEditedFile() throws {
+        let fileURL = makeTemporaryFileURL()
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let payload = #"{"updatedAt":0,"urls":["--headless","https://example.com/a"]}"#
+        try Data(payload.utf8).write(to: fileURL)
+
+        XCTAssertEqual(
+            TabSessionStore(fileURL: fileURL).load(hostedOrigins: sliccOrigins),
+            ["https://example.com/a"]
+        )
+    }
+
+    func testLoadReturnsEmptyForMissingOrCorruptSnapshot() throws {
+        let missing = makeTemporaryFileURL()
+        XCTAssertEqual(TabSessionStore(fileURL: missing).load(hostedOrigins: []), [])
+
+        try FileManager.default.createDirectory(
+            at: missing.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("not json".utf8).write(to: missing)
+        XCTAssertEqual(TabSessionStore(fileURL: missing).load(hostedOrigins: []), [])
+    }
+
+    func testNormalizedOriginIncludesExplicitPortAndLowercasesHost() {
+        XCTAssertEqual(TabSessionStore.normalizedOrigin(of: "HTTP://LocalHost:8787/x"), "http://localhost:8787")
+        XCTAssertEqual(TabSessionStore.normalizedOrigin(of: "https://www.sliccy.ai/"), "https://www.sliccy.ai")
+        XCTAssertNil(TabSessionStore.normalizedOrigin(of: "chrome://settings"))
+    }
+
+    private func makeTemporaryFileURL() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("slicc-tab-session-tests-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("tabs.json")
+    }
+}


### PR DESCRIPTION
## Summary

`Sliccstart` can now hold the macOS default-browser role (offered in Settings → Startup, next to auto-launch) and actually behaves like one: every `http`/`https` link the OS hands it opens as a tab in the SLICC leader browser, starting that browser first if none is running. Separately, a browser launch now reopens the tabs from the previous session, minus the SLICC tab itself.

## Why

Two gaps kept Sliccstart from being usable as someone's actual browser:

1. It could not be selected as the system default at all — it declared no URL schemes, so macOS never listed it as a candidate — and even if it had been selected, nothing handled incoming links.
2. Every launch started from a blank slate, because `clearChromeSessionRestore` wipes `Default/Sessions` on each launch (#1096). That wipe exists for a good reason (see below), so "just let Chrome restore" was not an option.

## Approach / Implementation notes

**Layering** — the default-browser role lives in `packages/swift-launcher` (it owns the app bundle and the LaunchServices registration); tab restore lives in `packages/swift-server` (it owns the Chrome launch).

### Default-browser role (`packages/swift-launcher`)

- `Models/DefaultBrowserRegistration.swift` — `isDefault()` compares the LaunchServices `http` handler against `Bundle.main.bundleURL` on symlink-resolved, standardized paths. `makeDefault()` claims `http`+`https` and then **re-reads** the role, because macOS's confirmation panel returns **no error when the user declines** — the return value of the claim alone is not evidence. Gated on `SliccBootstrapper.isBundled`, since a `swift run` binary has no bundle to register.
- `assemble-app.mjs` — adds `CFBundleURLTypes` (`http`, `https`) plus a `CFBundleDocumentTypes` viewer for `public.html`/`public.xhtml` at `LSHandlerRank: Alternate`. These declarations are the precondition for the role; `Alternate` keeps Sliccstart from fighting the user's real browser for file associations.
- `Models/IncomingURLRouter.swift` — turns each URL from `application(_:open:)` into a tab via `PUT /json/new?<percent-encoded url>` followed by `/json/activate/<targetId>`, then activates the browser app. On the cold path it starts the top ordered browser and waits for its CDP port, retrying the launch periodically. The pending queue survives re-entrant `application(_:open:)` calls (macOS can deliver a second link while the first is still opening a browser).
- `AppOrdering.topBrowser(in:savedOrder:)` — one resolver for "the" leader, now shared by startup auto-launch and the link handler so they cannot disagree about which browser to start.

**Rejected alternative: `NSWorkspace.open(_:withApplicationAt:)`.** The SLICC browser runs on its own `--user-data-dir`. Handing a URL to LaunchServices would non-deterministically land it in either SLICC's instance or the user's normal-profile Chrome. CDP addresses the leader unambiguously.

### Tab session restore (`packages/swift-server`)

- `Sources/Browser/TabSessionStore.swift` — a URL-only snapshot per Chrome profile at `~/Library/Application Support/Slicc/sessions/<profile-dir>-tabs.json`.
- `Sources/Browser/TabSessionRecorder.swift` — polls `/json/list` every 5 s. Deliberately **not** `Target.targetInfoChanged`: a long-lived CDP subscription risks evicting the webapp's own `/cdp` session, which is the exact failure #1096 was about. Failed or non-2xx polls are **dropped rather than persisted**, so a browser that is already quitting cannot erase the last good snapshot.
- Restore URLs are appended **after** `launchUrl`, because Chromium activates the *first* CLI URL — this keeps the SLICC tab leftmost and focused. This ordering is load-bearing and covered by a test.
- The final snapshot is taken in `runShutdownSequence` **before** `closeBrowser`, on both the shutdown and the detach path (detach leaves the browser up, so the next full launch is what consumes the snapshot).

**Rejected alternative: re-enabling Chrome's own session restore.** `clearChromeSessionRestore` stays intact; a restored stale SLICC tab would reconnect to a dead bridge token and start a `/cdp` eviction war (#1096). Restore is therefore an explicit, filtered mechanism that never resurrects a SLICC surface.

**New data file (no migration).** The snapshot is additive and self-healing: a missing, malformed, or truncated file simply means "no tabs to restore". Deleting it is a safe reset.

## Cross-cutting impact

- **Floats exercised**: Sliccstart + the Swift server's Chrome launch path. Unchanged and deliberately excluded: `--serve-only` (no browser to snapshot), `--electron` (Electron owns its own windows), the Chrome extension (no server-side launch), the worker, and `packages/node-server`.
- **node-server parity (explicit non-goal, documented)**: node-server is the dev/CI float, not the shipped desktop path, and the macOS default-browser role has no node-server analogue. Its `clearChromeSessionRestore` mirror is untouched, so its behavior is unchanged rather than silently divergent.
- **Security — user-writable file becomes command-line arguments.** Every snapshot entry is passed to Chrome as an argv element, so the file is treated as untrusted input and sanitized in **three** places (on save, on load, and again at argv construction): absolute `http(s)` with a host only; drops SLICC surfaces (hosted origin, or a `bridge`/`bridgeToken` query param), `chrome://`, `devtools://`, `file://`, `javascript:`, `about:`, and any `--flag`-shaped string; dedupes first-seen; caps at 50. Tests cover `--headless=new` and `file:///etc/passwd` injection attempts.
- **No secrets persisted.** The SLICC tab URL carries the bridge token, which is precisely why it is filtered out of the snapshot rather than stored.
- **Async lifecycle**: the recorder is a stopped-not-paused actor task — `stop()` cancels the poll loop, verified by a test that asserts no further polls occur after `stop()`. It is stopped on the success path, the error path, and in the shutdown sequence.
- **Other callers of changed contracts**: `ChromeLaunchConfig`/`buildLaunchArgs` gained an optional `restoreUrls` (defaulted, so existing callers are unaffected); `ShutdownContext` gained an optional `tabRecorder`; `AppOrdering.ordered` is unchanged — `topBrowser` is a new wrapper, and the auto-launch call site was refactored onto it with identical semantics (covered by the existing plus one new `AppOrderingTests` case).
- **Bundle size**: N/A (no web bundle touched).

## Test plan

- [x] `npm run lint` — clean, incl. `lint:docs` doc-size gate and `check-doc-refs`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK (18 changed files, 0 on any debt list)
- [x] `npm run lint:swift` — 22 violations, **0 serious** (all pre-existing warnings)
- [x] `npm run lint:swift:format` — `swift format lint --strict` clean
- [x] `swift test` — **501** passing in swift-server, **332** in swift-launcher, 0 failures
- [x] `swift-coverage-check.sh packages/swift-server SliccServerPackageTests` — lines **61.09%** (floor 60), functions 59.36% (58), regions 58.22% (57)
- [x] `swift-coverage-check.sh packages/swift-launcher SliccstartPackageTests` — lines **40.09%** (floor 39), functions 43.35% (42), regions 50.68% (48)
- [x] `npx vitest run --project swift-launcher` — 11 passing (incl. the new Info.plist declaration assertions)
- [x] `plutil -lint` on the Info.plist generated by `assemble-app.mjs` — OK, `CFBundleURLTypes` extracts correctly
- [x] **New / changed behavior is covered by unit tests**: new `TabSessionStoreTests`, `TabSessionRecorderTests`, `DefaultBrowserRegistrationTests`, `IncomingURLRouterTests`; extended `ChromeLauncherTests` (restore-arg ordering + sanitization), `GracefulShutdownHandlerTests` (snapshot-before-close ordering), `AppOrderingTests`, `macos-permissions.test.mjs`
- [ ] `npm run typecheck` / `npm run test` — **not run**: this worktree's `node_modules` sentinels are missing and the preflight refuses to run `tsc` against a parent-resolved tree. No TypeScript is changed by this PR (the only JS touched is `assemble-app.mjs`, covered by the vitest project above). CI runs both.
- [ ] N/A: `npm run build -w @slicc/chrome-extension`, extension smoke — no extension code touched.

### Empirically verified against real Chrome

Browser behavior CI cannot check was verified with throwaway CDP scripts against a real Chrome (all temp profiles/dirs removed afterwards), not taken from docs:

1. `/json/list` returns MRU order, and the **first** CLI URL is the `visible` one → the SLICC tab must be first in argv. This is why `restoreUrls` are appended, not prepended.
2. The same holds through the **production** spawn path (`/usr/bin/open -n -a … --args`), not just a direct `exec` — multiple URLs are honoured and the first stays focused.
3. `PUT /json/new?<encoded-url>` → 200. `?url=<encoded>` silently opens `about:blank`, and `GET` → 405 ("supports only PUT"). The new tab is created **hidden**, which is why the router follows up with `/json/activate/<id>`.

**Pre-existing failures**: none observed.

### Reviewer hand-check (CI cannot cover these)

- Settings → Startup → "Make Sliccstart the default browser": accept the macOS panel, then click a link in Mail/Slack → it should open as a focused tab in the SLICC browser.
- Decline the macOS panel → the control must stay off (this is the no-error-on-decline path).
- Quit the browser with a few tabs open, relaunch → tabs return, SLICC tab is leftmost, focused, and freshly minted.

## Documentation

- [x] `README.md` (`packages/swift-launcher/README.md` — user-facing behavior)
- [x] Relevant `CLAUDE.md` (`packages/swift-launcher`, `packages/swift-server`)
- [x] `docs/` — new `docs/sliccstart-browser.md` long-form reference, listed in `docs/CLAUDE.md`
- [ ] No agent-facing (`vfs-root`) changes needed — no shell commands or agent tools changed

The launcher `CLAUDE.md` was already at its 20,000-char budget, so the `slicc`-CLI notarization/Gatekeeper gotcha moved to its natural home in `docs/pitfalls.md` ("Downloaded `slicc` CLI: Notarization Without a Staple"). No content was lost.

## Risk & rollback

- **Blast radius**: Sliccstart + the native server's Chrome launch. Both features are opt-in-ish: the default-browser role requires an explicit user action, and tab restore no-ops when the snapshot file is absent.
- **Kill switch / reset**: delete `~/Library/Application Support/Slicc/sessions/*-tabs.json` to clear restore state; unset the role in System Settings → Default web browser.
- **Rollback**: revert cleanly. No schema or persisted-state migration; the orphaned snapshot file is inert.
- **Hand-verify before approving**: the three reviewer checks above (real LaunchServices role change and a real macOS confirmation panel are not reproducible in CI).

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff (staged diff scanned; the bridge token is explicitly *excluded* from the snapshot)
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths — no cross-float contract changed; node-server exclusion documented above
