### PR TITLE
feat(sliccstart): list iCloud tray sessions via CLI, with reveal consent

### DIFF
--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -12,6 +12,8 @@ slicc <join-url> watch [scoop]                  Tail the leader's live agent out
 slicc <join-url> follow [--no-banner] [runner]  Stay connected; run leader-issued commands via <runner>
 slicc <join-url> follow --eval [repl]           Same, into ONE persistent REPL (state persists; see README)
 slicc update [--check]                          Self-update to the newest released CLI binary
+slicc list-sessions [--json]                    List iCloud-synced tray sessions (macOS only; no join URLs)
+slicc <verb>-cloud [--index N|--session <id>]   Resolve a session's join URL from iCloud, then run <verb>
 ```
 
 `watch` is a passive `tail -f` on the agent that mirrors the browser thread: it
@@ -34,6 +36,31 @@ to (command appended as the final arg): `follow bash -c`, `follow sh -c`,
 `follow docker exec -i sandbox sh -c`, a multiplexer, `flatpak-spawn --host …`, etc.
 With no runner, `follow` connects as a plain follower and refuses every command.
 
+## iCloud tray sessions (`list-sessions`, `<verb>-cloud`)
+
+macOS only. iCloud key-value storage is an Apple API readable only by the signed,
+iCloud-entitled `Sliccstart` launcher, so `internal/cloud` **shells out** to
+`Sliccstart --list-sessions` rather than reading iCloud from Go (which would need
+cgo + entitlement/profile signing and break the `CGO_ENABLED=0` cross-compile).
+`LocateExecutable` finds the app via `$SLICCSTART_APP` → `mdfind` (bundle id
+`com.slicc.sliccstart`) → `/Applications` → `~/Applications`. Off macOS the reader
+returns `ErrUnsupported` and every verb reports it.
+
+- `list-sessions [--json]` prints **metadata only** (opaque id, label, device,
+  age) — never a join URL — so it is safe to pipe and log.
+- `<verb>-cloud` (`follow`/`prompt`/`exec`/`watch`) resolves a session's **join
+  URL** with `--reveal-urls`, which prompts for consent on the Mac (denied over
+  SSH until granted once from the screen), then dispatches to the plain verb. The
+  URL is never printed. Selection defaults to the newest session; `--index N` /
+  `--session <id-prefix>` (leading options, consumed by `ParseSelector`) pick
+  another, and the remaining argv passes through verbatim (runner argv / text).
+
+Pure logic (`ParseSessions`, `ParseSelector`, `Select`, `FormatTable`) is
+platform-independent and unit-tested; the exec/locate glue lives in the
+darwin-only `resolve_darwin.go` (not counted by the Linux coverage gate). The
+`cloudList` seam in `cloud.go` is overridden in tests so dispatch is exercised
+without a real launcher.
+
 ## Why Go + pion
 
 The follower must speak real WebRTC (SCTP data channel) and interoperate with
@@ -50,6 +77,8 @@ with `CGO_ENABLED=0` (see the `dist` target). No native toolchain required.
 | `internal/protocol/`  | Wire structs mirroring `packages/shared-ts/src/tray-sync-protocol.ts` (the subset the CLI uses)                                             |
 | `internal/signaling/` | HTTP follower client for `tray-signaling.ts` (attach → poll/answer/ice/retry), ported from the iOS connector                                |
 | `internal/tray/`      | pion peer + `tray-control` data channel + follower state machine (hello, ping/pong, dispatch)                                               |
+| `internal/cloud/`     | iCloud tray-session discovery: parse/select/format (pure) + a darwin-only reader that shells out to `Sliccstart --list-sessions`            |
+| `cloud.go`            | `list-sessions` + the `<verb>-cloud` family (resolve a session's join URL from iCloud, then hand off to the plain verb)                     |
 | `internal/execrun/`   | Cross-platform OS command runner backing `follow` (streams stdout/stderr, forwards signals) + `EvalSession` (persistent-REPL `--eval` mode) |
 | `update.go`           | `cmdUpdate` (`slicc update [--check]`) + the on-launch update-notice hook                                                                   |
 | `telemetry.go`        | `initTelemetry`/`reportRuntimeError` — launch + error RUM beacons via `@ai-ecoverse/go-optel`                                               |

--- a/packages/slicc-cli/cloud.go
+++ b/packages/slicc-cli/cloud.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/ai-ecoverse/slicc-cli/internal/cloud"
+)
+
+// cloudList is the seam through which the cloud verbs read iCloud tray sessions.
+// It defaults to the real (platform-specific) reader and is overridden in tests.
+var cloudList = cloud.List
+
+// cmdListSessions prints the active iCloud tray sessions (metadata only — join
+// URLs are never shown here, so the output is safe to pipe and log).
+func cmdListSessions(args []string) int {
+	jsonOut := false
+	for _, a := range args {
+		switch a {
+		case "--json":
+			jsonOut = true
+		case "-h", "--help":
+			usage(os.Stdout)
+			return 0
+		default:
+			fmt.Fprintf(os.Stderr, "slicc list-sessions: unknown option %q\n", a)
+			return 2
+		}
+	}
+
+	sessions, err := cloudList(false)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "slicc list-sessions: %s\n", err)
+		return 1
+	}
+
+	if jsonOut {
+		encoded, err := json.MarshalIndent(sessions, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "slicc list-sessions: %s\n", err)
+			return 1
+		}
+		fmt.Println(string(encoded))
+		return 0
+	}
+
+	fmt.Print(cloud.FormatTable(sessions, time.Now()))
+	return 0
+}
+
+// resolveCloudSession lists sessions (revealing join URLs when reveal is set)
+// and applies the selector. Injecting the lister keeps it testable off macOS.
+func resolveCloudSession(reveal bool, sel cloud.Selector, list func(bool) ([]cloud.Session, error)) (cloud.Session, error) {
+	sessions, err := list(reveal)
+	if err != nil {
+		return cloud.Session{}, err
+	}
+	return cloud.Select(sessions, sel)
+}
+
+// cmdCloud implements the `<verb>-cloud` family: resolve a session's join URL
+// from iCloud (which prompts for reveal consent on the Mac), then hand off to
+// the matching plain verb. The join URL is never printed.
+func cmdCloud(ctx context.Context, verb string, args []string) int {
+	sel, rest, err := cloud.ParseSelector(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "slicc %s: %s\n", verb, err)
+		return 2
+	}
+
+	session, err := resolveCloudSession(true, sel, cloudList)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "slicc %s: %s\n", verb, err)
+		return 1
+	}
+	if session.JoinURL == "" {
+		fmt.Fprintf(os.Stderr, "slicc %s: resolved session has no join URL (reveal denied?)\n", verb)
+		return 1
+	}
+
+	switch verb {
+	case "follow-cloud":
+		fa := parseFollowArgs(rest)
+		if fa.help {
+			usage(os.Stdout)
+			return 0
+		}
+		return cmdFollow(ctx, session.JoinURL, fa)
+	case "prompt-cloud":
+		if len(rest) == 0 {
+			fmt.Fprintln(os.Stderr, "slicc prompt-cloud: missing prompt text")
+			return 2
+		}
+		text, err := readTextArg(rest, os.Stdin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "slicc prompt-cloud: %s\n", err)
+			return 1
+		}
+		return cmdPrompt(ctx, session.JoinURL, text)
+	case "exec-cloud":
+		if len(rest) == 0 {
+			fmt.Fprintln(os.Stderr, "slicc exec-cloud: missing command")
+			return 2
+		}
+		command, err := readTextArg(rest, os.Stdin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "slicc exec-cloud: %s\n", err)
+			return 1
+		}
+		return cmdExec(ctx, session.JoinURL, command)
+	case "watch-cloud":
+		scoopJid := ""
+		if len(rest) > 0 {
+			scoopJid = rest[0]
+		}
+		return cmdWatch(ctx, session.JoinURL, scoopJid)
+	default:
+		fmt.Fprintf(os.Stderr, "slicc: unknown cloud verb %q\n", verb)
+		return 2
+	}
+}

--- a/packages/slicc-cli/cloud_test.go
+++ b/packages/slicc-cli/cloud_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ai-ecoverse/slicc-cli/internal/cloud"
+)
+
+// withCloudList swaps the cloud lister seam for the duration of a test.
+func withCloudList(t *testing.T, fake func(bool) ([]cloud.Session, error)) {
+	t.Helper()
+	prev := cloudList
+	cloudList = fake
+	t.Cleanup(func() { cloudList = prev })
+}
+
+// captureStdout runs fn with os.Stdout redirected and returns what it wrote.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	prev := os.Stdout
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = prev
+	return <-done
+}
+
+func sample() []cloud.Session {
+	return []cloud.Session{
+		{ID: "aaa11122233", Label: "Chrome", DeviceName: "MacA", LastSeenAt: time.Now().Add(-2 * time.Minute), JoinURL: "https://slicc.test/join/a.secret"},
+		{ID: "bbb44455566", Label: "Edge", DeviceName: "MacB", LastSeenAt: time.Now().Add(-30 * time.Minute), JoinURL: "https://slicc.test/join/b.secret"},
+	}
+}
+
+func TestCmdListSessionsTable(t *testing.T) {
+	withCloudList(t, func(reveal bool) ([]cloud.Session, error) {
+		if reveal {
+			t.Error("list-sessions must not request reveal")
+		}
+		return sample(), nil
+	})
+	out := captureStdout(t, func() {
+		if code := cmdListSessions(nil); code != 0 {
+			t.Errorf("exit code = %d", code)
+		}
+	})
+	if !strings.Contains(out, "Chrome") || !strings.Contains(out, "MacB") {
+		t.Errorf("table missing rows: %q", out)
+	}
+	if strings.Contains(out, "secret") {
+		t.Errorf("join URL leaked into table: %q", out)
+	}
+}
+
+func TestCmdListSessionsJSON(t *testing.T) {
+	withCloudList(t, func(bool) ([]cloud.Session, error) { return sample(), nil })
+	out := captureStdout(t, func() {
+		if code := cmdListSessions([]string{"--json"}); code != 0 {
+			t.Errorf("exit code = %d", code)
+		}
+	})
+	if !strings.Contains(out, `"label": "Chrome"`) {
+		t.Errorf("json output unexpected: %q", out)
+	}
+}
+
+func TestCmdListSessionsError(t *testing.T) {
+	withCloudList(t, func(bool) ([]cloud.Session, error) { return nil, cloud.ErrUnsupported })
+	if code := cmdListSessions(nil); code != 1 {
+		t.Errorf("exit code = %d, want 1", code)
+	}
+}
+
+func TestCmdListSessionsUnknownOption(t *testing.T) {
+	if code := cmdListSessions([]string{"--nope"}); code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+}
+
+func TestResolveCloudSession(t *testing.T) {
+	got, err := resolveCloudSession(true, cloud.Selector{Index: 0}, func(reveal bool) ([]cloud.Session, error) {
+		if !reveal {
+			t.Error("cloud verbs must request reveal")
+		}
+		return sample(), nil
+	})
+	if err != nil {
+		t.Fatalf("resolveCloudSession: %v", err)
+	}
+	if got.ID != "aaa11122233" {
+		t.Errorf("expected newest session, got %q", got.ID)
+	}
+}
+
+func TestResolveCloudSessionListError(t *testing.T) {
+	_, err := resolveCloudSession(true, cloud.Selector{}, func(bool) ([]cloud.Session, error) {
+		return nil, errors.New("boom")
+	})
+	if err == nil {
+		t.Fatal("expected list error to propagate")
+	}
+}
+
+func TestCmdCloudListErrorShortCircuits(t *testing.T) {
+	// A list error must return before any WebRTC dial is attempted.
+	withCloudList(t, func(bool) ([]cloud.Session, error) { return nil, cloud.ErrUnsupported })
+	if code := cmdCloud(context.Background(), "follow-cloud", nil); code != 1 {
+		t.Errorf("exit code = %d, want 1", code)
+	}
+}
+
+func TestCmdCloudBadSelector(t *testing.T) {
+	if code := cmdCloud(context.Background(), "follow-cloud", []string{"--index", "notnum"}); code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+}
+
+func TestCmdCloudMissingJoinURL(t *testing.T) {
+	withCloudList(t, func(bool) ([]cloud.Session, error) {
+		return []cloud.Session{{ID: "x", LastSeenAt: time.Now()}}, nil // no JoinURL (reveal denied)
+	})
+	if code := cmdCloud(context.Background(), "prompt-cloud", []string{"hello"}); code != 1 {
+		t.Errorf("exit code = %d, want 1", code)
+	}
+}
+
+func TestCmdCloudPromptMissingText(t *testing.T) {
+	withCloudList(t, func(bool) ([]cloud.Session, error) { return sample(), nil })
+	if code := cmdCloud(context.Background(), "prompt-cloud", nil); code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+}
+
+func TestCmdCloudExecMissingCommand(t *testing.T) {
+	withCloudList(t, func(bool) ([]cloud.Session, error) { return sample(), nil })
+	if code := cmdCloud(context.Background(), "exec-cloud", nil); code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+}
+
+func TestCmdCloudUnknownVerb(t *testing.T) {
+	withCloudList(t, func(bool) ([]cloud.Session, error) { return sample(), nil })
+	if code := cmdCloud(context.Background(), "bogus-cloud", nil); code != 2 {
+		t.Errorf("exit code = %d, want 2", code)
+	}
+}

--- a/packages/slicc-cli/internal/cloud/cloud.go
+++ b/packages/slicc-cli/internal/cloud/cloud.go
@@ -85,6 +85,10 @@ func ParseSelector(args []string) (Selector, []string, error) {
 		case strings.HasPrefix(args[0], "--session="):
 			sel.IDPrefix = strings.TrimPrefix(args[0], "--session=")
 			args = args[1:]
+		case args[0] == "--index" || args[0] == "--session":
+			// A bare selector flag with no value must not be silently treated
+			// as verb argument (e.g. runner argv or prompt text).
+			return sel, nil, fmt.Errorf("missing value for %s", args[0])
 		default:
 			return sel, args, nil
 		}
@@ -157,14 +161,17 @@ func shortID(id string) string {
 	return id[:12]
 }
 
+// truncate shortens s to at most width runes (not bytes), so multibyte labels
+// and device names are never cut mid-UTF-8-sequence.
 func truncate(s string, width int) string {
-	if len(s) <= width {
+	runes := []rune(s)
+	if len(runes) <= width {
 		return s
 	}
 	if width <= 1 {
-		return s[:width]
+		return string(runes[:width])
 	}
-	return s[:width-1] + "…"
+	return string(runes[:width-1]) + "…"
 }
 
 // formatAge renders a coarse "time since last seen" label.

--- a/packages/slicc-cli/internal/cloud/cloud.go
+++ b/packages/slicc-cli/internal/cloud/cloud.go
@@ -1,0 +1,182 @@
+// Package cloud reads active SLICC tray sessions that the macOS launcher
+// (Sliccstart) advertises over the user's iCloud key-value store, so the
+// headless CLI can join a leader by discovery instead of a hand-copied join
+// URL.
+//
+// iCloud KVS is an Apple-only API and the store is readable only by the signed,
+// iCloud-entitled Sliccstart binary, so this package shells out to
+// `Sliccstart --list-sessions` (see resolve_darwin.go) rather than reading
+// iCloud directly. The join URL is a bearer secret, so Sliccstart redacts it
+// unless `--reveal-urls` is passed and the user approves. Everything in this
+// file is pure (parsing, selection, formatting) and platform-independent.
+package cloud
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ErrUnsupported is returned by List/LocateExecutable on non-macOS platforms.
+var ErrUnsupported = errors.New("iCloud tray sessions are only available on macOS")
+
+// Session mirrors the JSON `Sliccstart --list-sessions` emits (see
+// TraySessionCLI.SessionDTO in packages/swift-launcher). JoinURL is present only
+// when the session was listed with --reveal-urls and the user approved.
+type Session struct {
+	ID         string    `json:"id"`
+	Label      string    `json:"label"`
+	DeviceID   string    `json:"deviceId"`
+	DeviceName string    `json:"deviceName"`
+	CreatedAt  time.Time `json:"createdAt"`
+	LastSeenAt time.Time `json:"lastSeenAt"`
+	JoinURL    string    `json:"joinUrl,omitempty"`
+}
+
+// ParseSessions decodes the launcher's JSON array.
+func ParseSessions(data []byte) ([]Session, error) {
+	var sessions []Session
+	if err := json.Unmarshal(data, &sessions); err != nil {
+		return nil, fmt.Errorf("parsing session list: %w", err)
+	}
+	return sessions, nil
+}
+
+// Selector picks one session from the list. IDPrefix (a leading substring of
+// the opaque session id) wins when set; otherwise Index selects into the
+// newest-first ordering (0 = most recently seen).
+type Selector struct {
+	Index    int
+	IDPrefix string
+}
+
+// ParseSelector consumes leading `--index N` / `--session <id-prefix>` options
+// (and their `=` forms, plus a `--` terminator) and returns the remaining args
+// verbatim, so verb-specific arguments (runner argv, prompt text) pass through
+// untouched.
+func ParseSelector(args []string) (Selector, []string, error) {
+	sel := Selector{}
+	for len(args) > 0 {
+		switch {
+		case args[0] == "--":
+			return sel, args[1:], nil
+		case args[0] == "--index" && len(args) > 1:
+			n, err := strconv.Atoi(args[1])
+			if err != nil {
+				return sel, nil, fmt.Errorf("invalid --index %q: %w", args[1], err)
+			}
+			sel.Index = n
+			args = args[2:]
+		case strings.HasPrefix(args[0], "--index="):
+			raw := strings.TrimPrefix(args[0], "--index=")
+			n, err := strconv.Atoi(raw)
+			if err != nil {
+				return sel, nil, fmt.Errorf("invalid --index %q: %w", raw, err)
+			}
+			sel.Index = n
+			args = args[1:]
+		case args[0] == "--session" && len(args) > 1:
+			sel.IDPrefix = args[1]
+			args = args[2:]
+		case strings.HasPrefix(args[0], "--session="):
+			sel.IDPrefix = strings.TrimPrefix(args[0], "--session=")
+			args = args[1:]
+		default:
+			return sel, args, nil
+		}
+	}
+	return sel, args, nil
+}
+
+// Select applies a Selector to the sessions, newest first. It sorts defensively
+// so index semantics hold regardless of input order.
+func Select(sessions []Session, sel Selector) (Session, error) {
+	if len(sessions) == 0 {
+		return Session{}, errors.New("no active tray sessions found in iCloud")
+	}
+
+	ordered := make([]Session, len(sessions))
+	copy(ordered, sessions)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].LastSeenAt.After(ordered[j].LastSeenAt)
+	})
+
+	if sel.IDPrefix != "" {
+		var matches []Session
+		for _, s := range ordered {
+			if strings.HasPrefix(s.ID, sel.IDPrefix) {
+				matches = append(matches, s)
+			}
+		}
+		switch len(matches) {
+		case 0:
+			return Session{}, fmt.Errorf("no session matches id prefix %q", sel.IDPrefix)
+		case 1:
+			return matches[0], nil
+		default:
+			return Session{}, fmt.Errorf("id prefix %q matches %d sessions; use a longer prefix", sel.IDPrefix, len(matches))
+		}
+	}
+
+	if sel.Index < 0 || sel.Index >= len(ordered) {
+		return Session{}, fmt.Errorf("session index %d out of range (%d session(s) available)", sel.Index, len(ordered))
+	}
+	return ordered[sel.Index], nil
+}
+
+// FormatTable renders the sessions as a human-readable table (join URLs are
+// never shown here). now is passed in so the age column is deterministic.
+func FormatTable(sessions []Session, now time.Time) string {
+	if len(sessions) == 0 {
+		return "No active tray sessions found in iCloud.\n"
+	}
+
+	ordered := make([]Session, len(sessions))
+	copy(ordered, sessions)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].LastSeenAt.After(ordered[j].LastSeenAt)
+	})
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%-3s  %-12s  %-24s  %-20s  %s\n", "#", "ID", "LABEL", "DEVICE", "AGE")
+	for i, s := range ordered {
+		fmt.Fprintf(&b, "%-3d  %-12s  %-24s  %-20s  %s\n",
+			i, shortID(s.ID), truncate(s.Label, 24), truncate(s.DeviceName, 20), formatAge(now.Sub(s.LastSeenAt)))
+	}
+	return b.String()
+}
+
+func shortID(id string) string {
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:12]
+}
+
+func truncate(s string, width int) string {
+	if len(s) <= width {
+		return s
+	}
+	if width <= 1 {
+		return s[:width]
+	}
+	return s[:width-1] + "…"
+}
+
+// formatAge renders a coarse "time since last seen" label.
+func formatAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}

--- a/packages/slicc-cli/internal/cloud/cloud_test.go
+++ b/packages/slicc-cli/internal/cloud/cloud_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func mustTime(t *testing.T, rfc string) time.Time {
@@ -83,6 +84,17 @@ func TestParseSelectorErrors(t *testing.T) {
 	}
 	if _, _, err := ParseSelector([]string{"--index=xyz"}); err == nil {
 		t.Error("expected error for non-numeric --index=")
+	}
+}
+
+func TestParseSelectorMissingValue(t *testing.T) {
+	// A bare selector flag as the final arg must error, not fall through as a
+	// verb argument (else `prompt-cloud --index` would send "--index" verbatim).
+	if _, _, err := ParseSelector([]string{"--index"}); err == nil {
+		t.Error("expected error for --index with no value")
+	}
+	if _, _, err := ParseSelector([]string{"--session"}); err == nil {
+		t.Error("expected error for --session with no value")
 	}
 }
 
@@ -206,5 +218,14 @@ func TestTruncateAndShortID(t *testing.T) {
 	}
 	if got := truncate("abcdefghij", 5); got != "abcd…" {
 		t.Errorf("truncate = %q", got)
+	}
+	// Multibyte input must be cut on rune boundaries, never mid-UTF-8, and the
+	// result must stay valid UTF-8.
+	got := truncate("日本語のデバイス名", 4)
+	if got != "日本語…" {
+		t.Errorf("multibyte truncate = %q, want 日本語…", got)
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("truncate produced invalid UTF-8: %q", got)
 	}
 }

--- a/packages/slicc-cli/internal/cloud/cloud_test.go
+++ b/packages/slicc-cli/internal/cloud/cloud_test.go
@@ -1,0 +1,210 @@
+package cloud
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func mustTime(t *testing.T, rfc string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, rfc)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", rfc, err)
+	}
+	return parsed
+}
+
+func TestParseSessions(t *testing.T) {
+	data := []byte(`[{"id":"abc123","label":"Chrome","deviceId":"d1","deviceName":"MacA","createdAt":"2026-07-30T10:00:00Z","lastSeenAt":"2026-07-30T11:00:00Z","joinUrl":"https://slicc.test/join/x.secret"}]`)
+	sessions, err := ParseSessions(data)
+	if err != nil {
+		t.Fatalf("ParseSessions: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("want 1 session, got %d", len(sessions))
+	}
+	s := sessions[0]
+	if s.ID != "abc123" || s.Label != "Chrome" || s.DeviceName != "MacA" {
+		t.Errorf("unexpected metadata: %+v", s)
+	}
+	if s.JoinURL != "https://slicc.test/join/x.secret" {
+		t.Errorf("join URL not parsed: %q", s.JoinURL)
+	}
+	if !s.LastSeenAt.Equal(mustTime(t, "2026-07-30T11:00:00Z")) {
+		t.Errorf("lastSeenAt not parsed as RFC3339: %v", s.LastSeenAt)
+	}
+}
+
+func TestParseSessionsEmptyAndInvalid(t *testing.T) {
+	empty, err := ParseSessions([]byte(`[]`))
+	if err != nil || len(empty) != 0 {
+		t.Fatalf("empty array: got %v, %v", empty, err)
+	}
+	if _, err := ParseSessions([]byte(`not json`)); err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestParseSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantSel  Selector
+		wantRest []string
+	}{
+		{"none", []string{"bash", "-c"}, Selector{}, []string{"bash", "-c"}},
+		{"index space", []string{"--index", "2", "bash"}, Selector{Index: 2}, []string{"bash"}},
+		{"index equals", []string{"--index=3"}, Selector{Index: 3}, nil},
+		{"session space", []string{"--session", "abc", "sh"}, Selector{IDPrefix: "abc"}, []string{"sh"}},
+		{"session equals", []string{"--session=def"}, Selector{IDPrefix: "def"}, nil},
+		{"terminator", []string{"--", "--index", "9"}, Selector{}, []string{"--index", "9"}},
+		{"stops at non-flag", []string{"bash", "--index", "1"}, Selector{}, []string{"bash", "--index", "1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sel, rest, err := ParseSelector(tt.args)
+			if err != nil {
+				t.Fatalf("ParseSelector: %v", err)
+			}
+			if sel != tt.wantSel {
+				t.Errorf("selector: got %+v want %+v", sel, tt.wantSel)
+			}
+			if strings.Join(rest, ",") != strings.Join(tt.wantRest, ",") {
+				t.Errorf("rest: got %v want %v", rest, tt.wantRest)
+			}
+		})
+	}
+}
+
+func TestParseSelectorErrors(t *testing.T) {
+	if _, _, err := ParseSelector([]string{"--index", "abc"}); err == nil {
+		t.Error("expected error for non-numeric --index")
+	}
+	if _, _, err := ParseSelector([]string{"--index=xyz"}); err == nil {
+		t.Error("expected error for non-numeric --index=")
+	}
+}
+
+func sampleSessions(t *testing.T) []Session {
+	t.Helper()
+	return []Session{
+		{ID: "old00000", Label: "Old", LastSeenAt: mustTime(t, "2026-07-30T09:00:00Z"), JoinURL: "u-old"},
+		{ID: "new11111", Label: "New", LastSeenAt: mustTime(t, "2026-07-30T12:00:00Z"), JoinURL: "u-new"},
+		{ID: "mid22222", Label: "Mid", LastSeenAt: mustTime(t, "2026-07-30T10:30:00Z"), JoinURL: "u-mid"},
+	}
+}
+
+func TestSelectNewestFirst(t *testing.T) {
+	got, err := Select(sampleSessions(t), Selector{Index: 0})
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if got.ID != "new11111" {
+		t.Errorf("index 0 should be newest, got %q", got.ID)
+	}
+}
+
+func TestSelectByIndex(t *testing.T) {
+	got, err := Select(sampleSessions(t), Selector{Index: 2})
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if got.ID != "old00000" {
+		t.Errorf("index 2 should be oldest, got %q", got.ID)
+	}
+}
+
+func TestSelectIndexOutOfRange(t *testing.T) {
+	if _, err := Select(sampleSessions(t), Selector{Index: 9}); err == nil {
+		t.Error("expected out-of-range error")
+	}
+	if _, err := Select(sampleSessions(t), Selector{Index: -1}); err == nil {
+		t.Error("expected out-of-range error for negative index")
+	}
+}
+
+func TestSelectByIDPrefix(t *testing.T) {
+	got, err := Select(sampleSessions(t), Selector{IDPrefix: "mid"})
+	if err != nil {
+		t.Fatalf("Select: %v", err)
+	}
+	if got.ID != "mid22222" {
+		t.Errorf("prefix mid should select mid, got %q", got.ID)
+	}
+}
+
+func TestSelectIDPrefixNoMatchAndAmbiguous(t *testing.T) {
+	if _, err := Select(sampleSessions(t), Selector{IDPrefix: "zzz"}); err == nil {
+		t.Error("expected no-match error")
+	}
+	dup := []Session{
+		{ID: "dupe1", LastSeenAt: mustTime(t, "2026-07-30T09:00:00Z")},
+		{ID: "dupe2", LastSeenAt: mustTime(t, "2026-07-30T10:00:00Z")},
+	}
+	if _, err := Select(dup, Selector{IDPrefix: "dup"}); err == nil {
+		t.Error("expected ambiguous-prefix error")
+	}
+}
+
+func TestSelectEmpty(t *testing.T) {
+	if _, err := Select(nil, Selector{}); err == nil {
+		t.Error("expected error for empty session list")
+	}
+}
+
+func TestFormatTable(t *testing.T) {
+	now := mustTime(t, "2026-07-30T12:05:00Z")
+	out := FormatTable(sampleSessions(t), now)
+	if !strings.Contains(out, "LABEL") || !strings.Contains(out, "AGE") {
+		t.Errorf("missing header: %q", out)
+	}
+	// Newest first, and no join URL ever leaks into the table.
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if !strings.Contains(lines[1], "New") {
+		t.Errorf("first row should be newest: %q", lines[1])
+	}
+	if strings.Contains(out, "u-new") || strings.Contains(out, "u-old") {
+		t.Errorf("table must not contain join URLs: %q", out)
+	}
+	if strings.Contains(out, "just now") {
+		// 5m after last seen for the newest → "5m ago"
+		t.Errorf("expected minute-granular age, got %q", out)
+	}
+}
+
+func TestFormatTableEmpty(t *testing.T) {
+	out := FormatTable(nil, time.Now())
+	if !strings.Contains(out, "No active tray sessions") {
+		t.Errorf("unexpected empty output: %q", out)
+	}
+}
+
+func TestFormatAge(t *testing.T) {
+	cases := map[time.Duration]string{
+		30 * time.Second: "just now",
+		5 * time.Minute:  "5m ago",
+		3 * time.Hour:    "3h ago",
+		50 * time.Hour:   "2d ago",
+	}
+	for d, want := range cases {
+		if got := formatAge(d); got != want {
+			t.Errorf("formatAge(%v) = %q, want %q", d, got, want)
+		}
+	}
+}
+
+func TestTruncateAndShortID(t *testing.T) {
+	if shortID("0123456789abcdef") != "0123456789ab" {
+		t.Errorf("shortID truncation wrong: %q", shortID("0123456789abcdef"))
+	}
+	if shortID("short") != "short" {
+		t.Errorf("shortID should pass through short ids")
+	}
+	if truncate("hello", 10) != "hello" {
+		t.Error("truncate should pass short strings")
+	}
+	if got := truncate("abcdefghij", 5); got != "abcd…" {
+		t.Errorf("truncate = %q", got)
+	}
+}

--- a/packages/slicc-cli/internal/cloud/resolve_darwin.go
+++ b/packages/slicc-cli/internal/cloud/resolve_darwin.go
@@ -1,0 +1,99 @@
+//go:build darwin
+
+package cloud
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// bundleID is Sliccstart's macOS bundle identifier, used to locate the app.
+const bundleID = "com.slicc.sliccstart"
+
+// executableRelPath is where the launcher binary lives inside the .app bundle.
+const executableRelPath = "Contents/MacOS/Sliccstart"
+
+// LocateExecutable resolves the Sliccstart launcher binary that can read the
+// iCloud store (it holds the KVS entitlement). Resolution order: the
+// SLICCSTART_APP override, Spotlight (mdfind by bundle id), then the standard
+// install locations.
+func LocateExecutable() (string, error) {
+	if override := os.Getenv("SLICCSTART_APP"); override != "" {
+		return executableIn(override)
+	}
+	if app := mdfindApp(); app != "" {
+		if exe, err := executableIn(app); err == nil {
+			return exe, nil
+		}
+	}
+	candidates := []string{"/Applications/Sliccstart.app"}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, "Applications", "Sliccstart.app"))
+	}
+	for _, app := range candidates {
+		if exe, err := executableIn(app); err == nil {
+			return exe, nil
+		}
+	}
+	return "", fmt.Errorf("cannot find Sliccstart.app (install it, or set SLICCSTART_APP to the app or its executable)")
+}
+
+// executableIn maps an .app path (or a direct executable path) to the launcher
+// binary and verifies it exists.
+func executableIn(path string) (string, error) {
+	exe := path
+	if strings.HasSuffix(path, ".app") {
+		exe = filepath.Join(path, executableRelPath)
+	}
+	info, err := os.Stat(exe)
+	if err != nil {
+		return "", fmt.Errorf("no Sliccstart executable at %q: %w", exe, err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("%q is a directory, not the Sliccstart executable", exe)
+	}
+	return exe, nil
+}
+
+func mdfindApp() string {
+	out, err := exec.Command("mdfind", fmt.Sprintf("kMDItemCFBundleIdentifier == %q", bundleID)).Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasSuffix(line, ".app") {
+			return line
+		}
+	}
+	return ""
+}
+
+// List runs `Sliccstart --list-sessions [--reveal-urls]` and parses the JSON it
+// prints. A non-zero exit (e.g. reveal consent denied) surfaces the launcher's
+// stderr guidance verbatim.
+func List(reveal bool) ([]Session, error) {
+	exe, err := LocateExecutable()
+	if err != nil {
+		return nil, err
+	}
+	args := []string{"--list-sessions"}
+	if reveal {
+		args = append(args, "--reveal-urls")
+	}
+	cmd := exec.Command(exe, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return nil, fmt.Errorf("%s", msg)
+		}
+		return nil, fmt.Errorf("running Sliccstart --list-sessions: %w", err)
+	}
+	return ParseSessions(stdout.Bytes())
+}

--- a/packages/slicc-cli/internal/cloud/resolve_darwin.go
+++ b/packages/slicc-cli/internal/cloud/resolve_darwin.go
@@ -4,11 +4,13 @@ package cloud
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // bundleID is Sliccstart's macOS bundle identifier, used to locate the app.
@@ -73,23 +75,42 @@ func mdfindApp() string {
 	return ""
 }
 
+// listTimeout / revealTimeout bound the launcher subprocess so a Sliccstart
+// too old to recognize --list-sessions (which would boot its GUI and never
+// exit) cannot hang the CLI forever. The reveal path waits longer because it
+// blocks on the user's consent dialog.
+const (
+	listTimeout   = 20 * time.Second
+	revealTimeout = 2 * time.Minute
+)
+
 // List runs `Sliccstart --list-sessions [--reveal-urls]` and parses the JSON it
 // prints. A non-zero exit (e.g. reveal consent denied) surfaces the launcher's
-// stderr guidance verbatim.
+// stderr guidance verbatim; a timeout means the launcher is too old to support
+// the flag.
 func List(reveal bool) ([]Session, error) {
 	exe, err := LocateExecutable()
 	if err != nil {
 		return nil, err
 	}
 	args := []string{"--list-sessions"}
+	timeout := listTimeout
 	if reveal {
 		args = append(args, "--reveal-urls")
+		timeout = revealTimeout
 	}
-	cmd := exec.Command(exe, args...)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, exe, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("timed out after %s waiting for Sliccstart --list-sessions; update Sliccstart to a version that supports it", timeout)
+		}
 		if msg := strings.TrimSpace(stderr.String()); msg != "" {
 			return nil, fmt.Errorf("%s", msg)
 		}

--- a/packages/slicc-cli/internal/cloud/resolve_other.go
+++ b/packages/slicc-cli/internal/cloud/resolve_other.go
@@ -1,0 +1,15 @@
+//go:build !darwin
+
+package cloud
+
+// iCloud key-value storage is an Apple-only API, so tray-session discovery is
+// unavailable off macOS. The verbs still compile and dispatch everywhere; they
+// just report ErrUnsupported.
+
+func LocateExecutable() (string, error) {
+	return "", ErrUnsupported
+}
+
+func List(_ bool) ([]Session, error) {
+	return nil, ErrUnsupported
+}

--- a/packages/slicc-cli/internal/cloud/resolve_other.go
+++ b/packages/slicc-cli/internal/cloud/resolve_other.go
@@ -6,10 +6,13 @@ package cloud
 // unavailable off macOS. The verbs still compile and dispatch everywhere; they
 // just report ErrUnsupported.
 
+// LocateExecutable reports that iCloud tray-session discovery is unavailable off
+// macOS.
 func LocateExecutable() (string, error) {
 	return "", ErrUnsupported
 }
 
+// List reports that iCloud tray-session discovery is unavailable off macOS.
 func List(_ bool) ([]Session, error) {
 	return nil, ErrUnsupported
 }

--- a/packages/slicc-cli/internal/cloud/resolve_other_test.go
+++ b/packages/slicc-cli/internal/cloud/resolve_other_test.go
@@ -1,0 +1,17 @@
+//go:build !darwin
+
+package cloud
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestUnsupportedOffMacOS(t *testing.T) {
+	if _, err := LocateExecutable(); !errors.Is(err, ErrUnsupported) {
+		t.Errorf("LocateExecutable off macOS: got %v, want ErrUnsupported", err)
+	}
+	if _, err := List(true); !errors.Is(err, ErrUnsupported) {
+		t.Errorf("List off macOS: got %v, want ErrUnsupported", err)
+	}
+}

--- a/packages/slicc-cli/main.go
+++ b/packages/slicc-cli/main.go
@@ -47,6 +47,14 @@ func run(args []string) int {
 		defer stop()
 		defer initTelemetry("update")()
 		return cmdUpdate(ctx, args[1:])
+	case "list-sessions":
+		return cmdListSessions(args[1:])
+	case "follow-cloud", "prompt-cloud", "exec-cloud", "watch-cloud":
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		defer initTelemetry(args[0])()
+		defer startUpdateNotice()()
+		return cmdCloud(ctx, args[0], args[1:])
 	}
 
 	joinURL := args[0]
@@ -74,6 +82,11 @@ func run(args []string) int {
 	// the deferred flush lets a short-lived verb persist the refresh result.
 	defer startUpdateNotice()()
 
+	return dispatchJoinVerb(ctx, joinURL, sub, rest)
+}
+
+// dispatchJoinVerb runs a subcommand against an explicit join URL.
+func dispatchJoinVerb(ctx context.Context, joinURL, sub string, rest []string) int {
 	switch sub {
 	case "prompt":
 		if len(rest) == 0 {
@@ -153,6 +166,23 @@ Usage:
   slicc update [--check]              Self-update to the newest released CLI binary
                                       (--check only reports; SLICC_NO_UPDATE_CHECK=1
                                       disables the once-a-day launch check)
+
+iCloud tray sessions (macOS only — read from the signed Sliccstart launcher):
+  slicc list-sessions [--json]        List active tray sessions synced from your
+                                      other devices (metadata only; no join URLs)
+  slicc <verb>-cloud [--index N | --session <id-prefix>] [args...]
+                                      Resolve a session's join URL from iCloud
+                                      (newest by default) and run <verb>, where
+                                      <verb> is follow | prompt | exec | watch.
+                                      Revealing the URL prompts for approval on
+                                      the Mac; over SSH it is denied until you
+                                      grant it once from the screen.
+                                        slicc follow-cloud bash -c
+                                        slicc prompt-cloud "summarize the diff"
+                                        slicc exec-cloud "git status"
+                                        slicc watch-cloud
+                                        slicc follow-cloud --index 1 sh -c
+
   slicc --version
   slicc --help
 

--- a/packages/slicc-cli/telemetry.go
+++ b/packages/slicc-cli/telemetry.go
@@ -20,6 +20,8 @@ const telemetryAppID = "slicc-cli"
 // webapp's `fill` (shell command name) checkpoint.
 var knownSubcommands = map[string]bool{
 	"prompt": true, "exec": true, "watch": true, "follow": true, "update": true,
+	"list-sessions": true, "follow-cloud": true, "prompt-cloud": true,
+	"exec-cloud": true, "watch-cloud": true,
 }
 
 func classifySubcommand(sub string) string {

--- a/packages/swift-launcher/CLAUDE.md
+++ b/packages/swift-launcher/CLAUDE.md
@@ -98,35 +98,44 @@ joined from another without hand-copying. The model is Foundation-only so the
 iOS follower (`packages/ios-app`) can reuse it.
 
 - `Models/SyncedTraySession.swift` — one session: `id` (**SHA-256 of the join
-  URL** — stable for upsert/dedup but opaque, so it is safe in accessibility
-  identifiers / telemetry; the raw `joinUrl` carries the secret and is never
-  surfaced), `joinUrl`, `label`, `deviceId` (per-device UUID for ownership),
-  `deviceName` (display), `createdAt`, `lastSeenAt`, `isStale(ttl:now:)`.
-  `CryptoKit` + Foundation only. Legacy payloads without `deviceId` decode empty.
+  URL**: opaque, so safe in accessibility ids / telemetry; the raw `joinUrl`
+  carries the secret and is never surfaced), `joinUrl`, `label`, `deviceId`
+  (per-device UUID for ownership), `deviceName`, `createdAt`, `lastSeenAt`,
+  `isStale(ttl:now:)`. `CryptoKit` + Foundation only; legacy payloads without
+  `deviceId` decode empty.
 - `Models/TraySessionSyncStore.swift` — `@Observable` store over a
   `KeyValueSyncBackend` (default `UbiquitousKeyValueBackend`; tests inject
-  `InMemoryKeyValueBackend`). **Each device writes its own sessions under a
-  per-device key `storageKeyPrefix + deviceId` and reads the union**, so
-  concurrent publishes never clobber and same-host-name Macs stay distinct;
-  ownership keys on `deviceId`, and `withdrawLocalSessions()` clears only this
-  device's key. Prunes stale by `defaultTTL` (12h) on load,
-  caps the merged view at `maxSessions` (64), and observes
-  `didChangeExternallyNotification`. Pure `active(from:)`/`upsert(_:into:)` are
-  static and unit-tested.
+  `InMemoryKeyValueBackend`). **Each device writes its own key
+  `storageKeyPrefix + deviceId` and reads the union**, so concurrent publishes
+  never clobber and same-host-name Macs stay distinct; `withdrawLocalSessions()`
+  clears only this device's key. Prunes stale by `defaultTTL` (12h), caps the
+  view at `maxSessions` (64), observes `didChangeExternallyNotification`. Pure
+  `active(from:)`/`upsert(_:into:)` are static and unit-tested.
 - **Producer** — `SliccstartApp` publishes when `leaderJoinUrl` becomes non-nil
-  (label = `leaderTargetName`) and withdraws when it clears; a 4-hour timer
-  re-publishes a live leader so it never ages out of the TTL.
-  `applicationWillTerminate` withdraws on clean quit but **not** on
-  update/detach (the browser survives; the relaunched app republishes).
+  and withdraws when it clears; a 4-hour timer re-publishes a live leader so it
+  never ages out of the TTL. `applicationWillTerminate` withdraws on clean quit
+  but **not** on update/detach (the browser survives; the relaunch republishes).
 - **Consumer** — `AppListView`'s "iCloud Sessions" section lists remote sessions
-  (device + age) with Copy, Attach-browser, Follow-in-Terminal; own sessions are
-  copy-only. A row's icon overlays the matching local browser icon on an
-  `icloud` badge. Follow reuses `launchTerminalFollower(_:joinURLOverride:)`
-  (override skips the local-leader gate → attaches to a **remote** leader);
-  Attach-browser launches the **top** browser via `launchBrowserFollower`.
+  with Copy, Attach-browser, Follow-in-Terminal (own sessions are copy-only).
+  Follow reuses `launchTerminalFollower(_:joinURLOverride:)` (override attaches
+  to a **remote** leader); Attach-browser uses `launchBrowserFollower`.
 - **Security** — join URLs carry the session secret and sync only through the
-  user's own (encrypted, same-Apple-ID) iCloud KVS. Tests:
-  `TraySessionSyncTests`.
+  user's own (encrypted, same-Apple-ID) iCloud KVS. Tests: `TraySessionSyncTests`.
+
+### Headless CLI (`Sliccstart --list-sessions`)
+
+The iCloud store is readable only by this signed, iCloud-entitled binary, so the
+Go `slicc` CLI shells out to a subcommand parsed in `main.swift` **before** the
+SwiftUI app boots (`TraySessionCLI.parse` returns `nil` for a normal launch).
+`--list-sessions` prints active sessions as JSON, **metadata only** (`joinUrl`
+redacted). `--reveal-urls` adds `joinUrl` behind a **consent gate**: a remembered
+"Always" (`UserDefaults`, keyed by caller code-signing id / path) wins; else an
+`NSAlert` (Deny / Allow Once / Always Allow / Always Deny) shows in a GUI session
+and a headless/SSH caller is **denied** (exit 3). Pure logic in
+`Models/TraySessionCLI.swift` is unit-tested (`TraySessionCLITests`); untestable
+glue (NSAlert, `getppid`/`proc_pidpath`/`SecCode`, store read) sits in
+`TraySessionCLIRunner`. Caller identity is spoofable, so redaction-by-default is
+the real control and the dialog a speed bump.
 
 ## App Ordering, Browser Followers, and Startup
 
@@ -150,28 +159,15 @@ iOS follower (`packages/ios-app`) can reuse it.
 
 ### iCloud provisioning (Developer ID app)
 
-Sync stays dark until the app is signed with an iCloud KVS entitlement backed
-by an _embedded_ provisioning profile (Developer ID signing alone does not
-authorize iCloud). `sign-and-package.sh` gates this on optional
-**`PROVISION_PROFILE`**: **unset** (default, incl. CI) signs against
+Sync needs an iCloud KVS entitlement backed by an _embedded_ provisioning
+profile (Developer ID signing alone does not authorize iCloud).
+`sign-and-package.sh` gates on optional **`PROVISION_PROFILE`**: **unset** signs
 `Sliccstart.entitlements` only and `NSUbiquitousKeyValueStore` degrades to a
-local cache; **set** embeds the profile at `Contents/embedded.provisionprofile`
-and signs against a merged entitlements file (base + `ubiquity-kvstore-identifier`,
-base never mutated).
-
-The KVS bucket (`ubiquity-kvstore-identifier`) defaults to
-`${APPLE_TEAM_ID}.com.slicc.sliccstart`, overridable via **`KVSTORE_IDENTIFIER`**
-(the iOS follower must match it; a brand-neutral `S8LB56P782.ai.sliccy.trays` is
-preferable, but a custom value fails the outer `codesign` unless the embedded
-profile authorizes it). The iCloud **container** is separate (CloudKit-only,
-unused), so any `iCloud.<reverse-dns>` you own works.
-
-One-time portal setup: enable iCloud on the `com.slicc.sliccstart` App ID
-(attach a container; KVS rides along), then create a Developer ID **provisioning
-profile** (App variant) for it. Local signed build passes `PROVISION_PROFILE=...`
-to `./sign-and-package.sh` with the usual `APPLE_*` env. For CI, add the profile
-as a base64 secret and decode it before exporting `PROVISION_PROFILE`. Signing
-contract: `macos-permissions.test.mjs`.
+local cache; **set** embeds the profile and signs a merged file (base +
+`ubiquity-kvstore-identifier`). CI decodes `APPLE_MACOS_PROVISIONING_PROFILE_BASE64`
+and exports `PROVISION_PROFILE` and `KVSTORE_IDENTIFIER` (default
+`${APPLE_TEAM_ID}.com.slicc.sliccstart`; releases ship `S8LB56P782.ai.sliccy.trays`,
+which the iOS follower must match). Signing contract: `macos-permissions.test.mjs`.
 
 ## Debug Build Creation
 

--- a/packages/swift-launcher/Sliccstart/Models/TraySessionCLI.swift
+++ b/packages/swift-launcher/Sliccstart/Models/TraySessionCLI.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+/// Headless `Sliccstart --list-sessions` support.
+///
+/// The launcher's iCloud key-value store holds active tray *join URLs*, which
+/// are bearer secrets: whoever holds one can attach as a follower and run
+/// commands on the leader. Listing the sessions is therefore split in two:
+///
+/// - **metadata** (opaque `id`, `label`, device, timestamps) is the user's own
+///   non-secret data and prints freely, so `slicc list-sessions` and pipelines
+///   never leak a token by accident;
+/// - the raw **join URL** is emitted only with `--reveal-urls`, behind a consent
+///   gate (see `TraySessionCLIRunner`).
+///
+/// Everything here is pure so it is unit-tested without touching iCloud, AppKit,
+/// or `UserDefaults`; the untestable glue (NSAlert, caller identity, the real
+/// store read) lives in `TraySessionCLIRunner`.
+enum TraySessionCLI {
+    /// A parsed headless invocation. `parse` returns `nil` for a normal GUI
+    /// launch so `main` falls through to the SwiftUI app.
+    struct Request: Equatable {
+        var reveal: Bool
+    }
+
+    static let listFlag = "--list-sessions"
+    static let revealFlag = "--reveal-urls"
+
+    /// Recognise `--list-sessions [--reveal-urls]` anywhere in the process
+    /// arguments (argv[0] is the executable path). Any other launch returns nil.
+    static func parse(_ argv: [String]) -> Request? {
+        let args = argv.dropFirst()
+        guard args.contains(listFlag) else { return nil }
+        return Request(reveal: args.contains(revealFlag))
+    }
+
+    /// Wire shape shared with the Go CLI (`internal/cloud`). `joinUrl` is present
+    /// only when revealed; ISO-8601 dates keep it trivially parseable in Go.
+    struct SessionDTO: Codable, Equatable {
+        let id: String
+        let label: String
+        let deviceId: String
+        let deviceName: String
+        let createdAt: Date
+        let lastSeenAt: Date
+        let joinUrl: String?
+    }
+
+    static func payload(from sessions: [SyncedTraySession], reveal: Bool) -> [SessionDTO] {
+        sessions.map {
+            SessionDTO(
+                id: $0.id,
+                label: $0.label,
+                deviceId: $0.deviceId,
+                deviceName: $0.deviceName,
+                createdAt: $0.createdAt,
+                lastSeenAt: $0.lastSeenAt,
+                joinUrl: reveal ? $0.joinUrl : nil
+            )
+        }
+    }
+
+    static func encode(_ sessions: [SyncedTraySession], reveal: Bool) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(payload(from: sessions, reveal: reveal))
+    }
+
+    // MARK: - Reveal consent
+
+    /// A persisted "always" decision for a given caller identity.
+    enum StoredConsent: String {
+        case allow
+        case deny
+    }
+
+    /// What to do for a reveal request before any interactive prompt.
+    enum Outcome: Equatable {
+        case allow
+        case deny
+        case prompt
+    }
+
+    /// Non-interactive resolution: a remembered "always" wins; otherwise prompt
+    /// when a GUI session exists, and deny outright when it does not (so a
+    /// headless/SSH caller cannot silently harvest tokens — the user must grant
+    /// once from the Mac's screen).
+    static func outcome(stored: StoredConsent?, guiAvailable: Bool) -> Outcome {
+        switch stored {
+        case .allow: return .allow
+        case .deny: return .deny
+        case nil: return guiAvailable ? .prompt : .deny
+        }
+    }
+
+    /// The four consent-dialog buttons, in presentation order.
+    enum PromptResult: Equatable {
+        case denyOnce
+        case allowOnce
+        case alwaysAllow
+        case alwaysDeny
+    }
+
+    static let buttonTitles = ["Deny", "Allow Once", "Always Allow", "Always Deny"]
+
+    /// Map an `NSAlert.runModal()` response to a decision. The first button is
+    /// `alertFirstButtonReturn` (1000) and each subsequent button increments.
+    static func promptResult(forButtonIndex index: Int) -> PromptResult {
+        switch index {
+        case 1001: return .allowOnce
+        case 1002: return .alwaysAllow
+        case 1003: return .alwaysDeny
+        default: return .denyOnce
+        }
+    }
+
+    /// Whether the request is allowed now, and any "always" decision to persist.
+    static func effect(of result: PromptResult) -> (allow: Bool, persist: StoredConsent?) {
+        switch result {
+        case .allowOnce: return (true, nil)
+        case .denyOnce: return (false, nil)
+        case .alwaysAllow: return (true, .allow)
+        case .alwaysDeny: return (false, .deny)
+        }
+    }
+
+    /// Persistence/identity key for a caller. A code-signing identifier is
+    /// stable across paths and hard to forge, so it is preferred; the
+    /// executable path is a best-effort fallback. Both are spoofable by code
+    /// already running as the user, so this keys "always" decisions rather than
+    /// forming a real trust boundary.
+    static func consentKey(signingIdentifier: String?, executablePath: String?) -> String {
+        if let signing = signingIdentifier, !signing.isEmpty { return "id:" + signing }
+        if let path = executablePath, !path.isEmpty { return "path:" + path }
+        return "unknown"
+    }
+
+    /// Human-facing description of the requesting process for the dialog.
+    static func describeCaller(name: String?, pid: Int32, signingIdentifier: String?) -> String {
+        let label = (name?.isEmpty == false) ? name! : "An unidentified process"
+        var description = "\(label) (pid \(pid))"
+        if let signing = signingIdentifier, !signing.isEmpty {
+            description += ", signed by \(signing)"
+        }
+        return description
+    }
+
+    static func deniedMessage(guiAvailable: Bool) -> String {
+        if guiAvailable {
+            return "Revealing session join URLs was denied.\n"
+        }
+        return """
+            Revealing session join URLs requires approval, which cannot be shown over \
+            a headless/SSH session. Run `Sliccstart --list-sessions --reveal-urls` once \
+            from the Mac's screen and choose "Always Allow" to grant access.
+
+            """
+    }
+}
+
+/// `UserDefaults`-backed record of "Always Allow"/"Always Deny" reveal
+/// decisions, keyed by caller identity. Small enough to unit-test with an
+/// injected suite.
+struct RevealConsentStore {
+    static let keyPrefix = "traySessionRevealConsent."
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func load(forConsentKey consentKey: String) -> TraySessionCLI.StoredConsent? {
+        guard let raw = defaults.string(forKey: Self.keyPrefix + consentKey) else { return nil }
+        return TraySessionCLI.StoredConsent(rawValue: raw)
+    }
+
+    func save(_ consent: TraySessionCLI.StoredConsent, forConsentKey consentKey: String) {
+        defaults.set(consent.rawValue, forKey: Self.keyPrefix + consentKey)
+    }
+}

--- a/packages/swift-launcher/Sliccstart/Models/TraySessionCLI.swift
+++ b/packages/swift-launcher/Sliccstart/Models/TraySessionCLI.swift
@@ -149,10 +149,14 @@ enum TraySessionCLI {
         if guiAvailable {
             return "Revealing session join URLs was denied.\n"
         }
+        // The remembered "Always Allow" is keyed to the requesting caller, so the
+        // grant must be made by re-running the SAME command from the Mac's screen
+        // (not by launching Sliccstart directly, which is a different caller and
+        // would not authorize this one).
         return """
             Revealing session join URLs requires approval, which cannot be shown over \
-            a headless/SSH session. Run `Sliccstart --list-sessions --reveal-urls` once \
-            from the Mac's screen and choose "Always Allow" to grant access.
+            a headless/SSH session. Re-run this same command from the Mac's screen \
+            (e.g. in Terminal.app on the Mac itself) and choose "Always Allow".
 
             """
     }

--- a/packages/swift-launcher/Sliccstart/Models/TraySessionCLIRunner.swift
+++ b/packages/swift-launcher/Sliccstart/Models/TraySessionCLIRunner.swift
@@ -1,0 +1,142 @@
+import AppKit
+import Darwin
+import Security
+import os
+
+private let log = Logger(subsystem: "com.slicc.sliccstart", category: "TraySessionCLI")
+
+/// Thin, side-effecting glue for `Sliccstart --list-sessions`. Reads the real
+/// iCloud store, runs the reveal-consent dialog, and writes JSON to stdout. All
+/// decision logic lives in the pure `TraySessionCLI`; this file is deliberately
+/// small because it cannot be unit-tested (AppKit, Security, iCloud, TTY).
+enum TraySessionCLIRunner {
+    static func run(_ request: TraySessionCLI.Request) -> Int32 {
+        let sessions = TraySessionSyncStore().sessions
+
+        if request.reveal, !authorizeReveal() {
+            return 3
+        }
+
+        do {
+            var data = try TraySessionCLI.encode(sessions, reveal: request.reveal)
+            data.append(0x0A)
+            FileHandle.standardOutput.write(data)
+            return 0
+        } catch {
+            log.error("encode failed: \(error.localizedDescription, privacy: .public)")
+            FileHandle.standardError.write(Data("Sliccstart: failed to encode sessions\n".utf8))
+            return 1
+        }
+    }
+
+    /// Resolve reveal consent: a remembered "always" wins; otherwise prompt when
+    /// a GUI session exists, else deny with guidance.
+    private static func authorizeReveal() -> Bool {
+        let caller = callerIdentity()
+        let key = TraySessionCLI.consentKey(
+            signingIdentifier: caller.signingIdentifier,
+            executablePath: caller.executablePath
+        )
+        let consentStore = RevealConsentStore()
+        let gui = guiSessionAvailable()
+
+        switch TraySessionCLI.outcome(stored: consentStore.load(forConsentKey: key), guiAvailable: gui) {
+        case .allow:
+            return true
+        case .deny:
+            FileHandle.standardError.write(Data(TraySessionCLI.deniedMessage(guiAvailable: gui).utf8))
+            return false
+        case .prompt:
+            let (allow, persist) = TraySessionCLI.effect(of: promptForReveal(caller: caller))
+            if let persist {
+                consentStore.save(persist, forConsentKey: key)
+            }
+            if !allow {
+                FileHandle.standardError.write(Data(TraySessionCLI.deniedMessage(guiAvailable: gui).utf8))
+            }
+            return allow
+        }
+    }
+
+    private static func promptForReveal(caller: CallerIdentity) -> TraySessionCLI.PromptResult {
+        NSApplication.shared.setActivationPolicy(.accessory)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+
+        let requester = TraySessionCLI.describeCaller(
+            name: caller.name,
+            pid: caller.pid,
+            signingIdentifier: caller.signingIdentifier
+        )
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = "Reveal SLICC session join URLs?"
+        alert.informativeText = """
+            \(requester) is requesting the secret join URLs for your active SLICC sessions.
+
+            A join URL lets its holder attach as a follower and run commands on the \
+            leader. Only allow this if you started the request.
+            """
+        for title in TraySessionCLI.buttonTitles {
+            alert.addButton(withTitle: title)
+        }
+        return TraySessionCLI.promptResult(forButtonIndex: alert.runModal().rawValue)
+    }
+
+    // MARK: - Best-effort caller identity
+
+    private struct CallerIdentity {
+        let pid: Int32
+        let name: String?
+        let executablePath: String?
+        let signingIdentifier: String?
+    }
+
+    private static func callerIdentity() -> CallerIdentity {
+        let ppid = getppid()
+        let path = executablePath(forPid: ppid)
+        let name = path.map { ($0 as NSString).lastPathComponent }
+        return CallerIdentity(
+            pid: ppid,
+            name: name,
+            executablePath: path,
+            signingIdentifier: signingIdentifier(forPid: ppid)
+        )
+    }
+
+    private static func executablePath(forPid pid: pid_t) -> String? {
+        // PROC_PIDPATHINFO_MAXSIZE (4 * MAXPATHLEN) is a C macro Swift cannot
+        // import from this SDK; inline its value.
+        let maxSize = 4 * 1024
+        var buffer = [CChar](repeating: 0, count: maxSize)
+        let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+        return length > 0 ? String(cString: buffer) : nil
+    }
+
+    private static func signingIdentifier(forPid pid: pid_t) -> String? {
+        let attributes = [kSecGuestAttributePid: pid] as CFDictionary
+        var code: SecCode?
+        guard SecCodeCopyGuestWithAttributes(nil, attributes, [], &code) == errSecSuccess,
+            let guest = code
+        else { return nil }
+
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(guest, [], &staticCode) == errSecSuccess,
+            let resolved = staticCode
+        else { return nil }
+
+        var infoRef: CFDictionary?
+        guard
+            SecCodeCopySigningInformation(resolved, SecCSFlags(rawValue: kSecCSSigningInformation), &infoRef)
+                == errSecSuccess,
+            let info = infoRef as? [String: Any]
+        else { return nil }
+
+        return info[kSecCodeInfoIdentifier as String] as? String
+    }
+
+    /// A GUI (Aqua) login session can present a modal; a headless/SSH session
+    /// returns nil here, so reveal falls back to deny-with-guidance.
+    private static func guiSessionAvailable() -> Bool {
+        CGSessionCopyCurrentDictionary() != nil
+    }
+}

--- a/packages/swift-launcher/Sliccstart/SliccstartApp.swift
+++ b/packages/swift-launcher/Sliccstart/SliccstartApp.swift
@@ -34,7 +34,6 @@ final class SliccstartAppDelegate: NSObject, NSApplicationDelegate {
     }
 }
 
-@main
 struct SliccstartApp: App {
     @NSApplicationDelegateAdaptor private var appDelegate: SliccstartAppDelegate
     @State private var bootstrapper = SliccBootstrapper()

--- a/packages/swift-launcher/Sliccstart/main.swift
+++ b/packages/swift-launcher/Sliccstart/main.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+// Headless `Sliccstart --list-sessions [--reveal-urls]` short-circuits before
+// the SwiftUI app boots so the `slicc` CLI can read iCloud tray sessions from
+// the signed, iCloud-entitled launcher binary. Any other launch falls through
+// to the normal GUI app.
+if let request = TraySessionCLI.parse(CommandLine.arguments) {
+    exit(TraySessionCLIRunner.run(request))
+}
+
+SliccstartApp.main()

--- a/packages/swift-launcher/SliccstartTests/TraySessionCLITests.swift
+++ b/packages/swift-launcher/SliccstartTests/TraySessionCLITests.swift
@@ -1,0 +1,171 @@
+import XCTest
+
+@testable import Sliccstart
+
+/// Pure-logic coverage for the headless `Sliccstart --list-sessions` path:
+/// argument parsing, redacted-vs-full encoding, and the reveal-consent gate.
+final class TraySessionCLITests: XCTestCase {
+
+    // MARK: - Argument parsing
+
+    func testParseReturnsNilForNormalLaunch() {
+        XCTAssertNil(TraySessionCLI.parse(["/Applications/Sliccstart.app/Contents/MacOS/Sliccstart"]))
+        XCTAssertNil(TraySessionCLI.parse(["Sliccstart", "--update-host=https://example.test"]))
+    }
+
+    func testParseListSessionsWithoutReveal() {
+        let request = TraySessionCLI.parse(["Sliccstart", "--list-sessions"])
+        XCTAssertEqual(request, TraySessionCLI.Request(reveal: false))
+    }
+
+    func testParseListSessionsWithReveal() {
+        let request = TraySessionCLI.parse(["Sliccstart", "--list-sessions", "--reveal-urls"])
+        XCTAssertEqual(request, TraySessionCLI.Request(reveal: true))
+    }
+
+    func testRevealFlagAloneWithoutListIsNotHeadless() {
+        XCTAssertNil(TraySessionCLI.parse(["Sliccstart", "--reveal-urls"]))
+    }
+
+    // MARK: - Encoding / redaction
+
+    func testEncodeRedactsJoinURLByDefault() throws {
+        let sessions = [makeSession(joinUrl: "https://slicc.test/join/a.secret")]
+        let data = try TraySessionCLI.encode(sessions, reveal: false)
+        let object = try decodeArray(data)
+
+        XCTAssertEqual(object.count, 1)
+        XCTAssertNil(object[0]["joinUrl"], "join URL must never appear without --reveal-urls")
+        XCTAssertEqual(object[0]["id"] as? String, sessions[0].id)
+        XCTAssertEqual(object[0]["label"] as? String, "Chrome")
+        XCTAssertEqual(object[0]["deviceName"] as? String, "MacA")
+        let raw = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertFalse(raw.contains("secret"))
+    }
+
+    func testEncodeIncludesJoinURLWhenRevealed() throws {
+        let sessions = [makeSession(joinUrl: "https://slicc.test/join/a.secret")]
+        let data = try TraySessionCLI.encode(sessions, reveal: true)
+        let object = try decodeArray(data)
+        XCTAssertEqual(object[0]["joinUrl"] as? String, "https://slicc.test/join/a.secret")
+    }
+
+    func testEncodeUsesISO8601Dates() throws {
+        let when = Date(timeIntervalSince1970: 1_700_000_000)
+        let sessions = [makeSession(joinUrl: "https://slicc.test/join/a.secret", lastSeenAt: when)]
+        let raw = String(data: try TraySessionCLI.encode(sessions, reveal: false), encoding: .utf8) ?? ""
+        // ISO-8601 (not a raw Double) so the Go CLI can parse it as RFC3339.
+        XCTAssertTrue(raw.contains("2023-11-14T"), "expected ISO-8601 timestamp, got \(raw)")
+    }
+
+    func testPayloadMappingPreservesMetadata() {
+        let session = makeSession(joinUrl: "https://slicc.test/join/a.secret")
+        let dto = TraySessionCLI.payload(from: [session], reveal: false)[0]
+        XCTAssertEqual(dto.id, session.id)
+        XCTAssertEqual(dto.deviceId, session.deviceId)
+        XCTAssertNil(dto.joinUrl)
+    }
+
+    // MARK: - Consent outcome
+
+    func testStoredAlwaysDecisionsWinOverGUI() {
+        XCTAssertEqual(TraySessionCLI.outcome(stored: .allow, guiAvailable: false), .allow)
+        XCTAssertEqual(TraySessionCLI.outcome(stored: .deny, guiAvailable: true), .deny)
+    }
+
+    func testNoStoredDecisionPromptsWithGUIAndDeniesHeadless() {
+        XCTAssertEqual(TraySessionCLI.outcome(stored: nil, guiAvailable: true), .prompt)
+        XCTAssertEqual(TraySessionCLI.outcome(stored: nil, guiAvailable: false), .deny)
+    }
+
+    // MARK: - Dialog button mapping
+
+    func testPromptResultMapping() {
+        XCTAssertEqual(TraySessionCLI.promptResult(forButtonIndex: 1000), .denyOnce)
+        XCTAssertEqual(TraySessionCLI.promptResult(forButtonIndex: 1001), .allowOnce)
+        XCTAssertEqual(TraySessionCLI.promptResult(forButtonIndex: 1002), .alwaysAllow)
+        XCTAssertEqual(TraySessionCLI.promptResult(forButtonIndex: 1003), .alwaysDeny)
+        XCTAssertEqual(TraySessionCLI.promptResult(forButtonIndex: 42), .denyOnce)
+    }
+
+    func testEffectOfPromptResult() {
+        XCTAssertEqual(TraySessionCLI.effect(of: .allowOnce).allow, true)
+        XCTAssertNil(TraySessionCLI.effect(of: .allowOnce).persist)
+        XCTAssertEqual(TraySessionCLI.effect(of: .denyOnce).allow, false)
+        XCTAssertNil(TraySessionCLI.effect(of: .denyOnce).persist)
+        XCTAssertEqual(TraySessionCLI.effect(of: .alwaysAllow).persist, .allow)
+        XCTAssertEqual(TraySessionCLI.effect(of: .alwaysDeny).persist, .deny)
+        XCTAssertFalse(TraySessionCLI.effect(of: .alwaysDeny).allow)
+    }
+
+    // MARK: - Consent key / caller description
+
+    func testConsentKeyPrefersSigningIdentifier() {
+        XCTAssertEqual(
+            TraySessionCLI.consentKey(signingIdentifier: "com.slicc.slicc-cli", executablePath: "/usr/bin/x"),
+            "id:com.slicc.slicc-cli"
+        )
+        XCTAssertEqual(
+            TraySessionCLI.consentKey(signingIdentifier: nil, executablePath: "/usr/local/bin/slicc"),
+            "path:/usr/local/bin/slicc"
+        )
+        XCTAssertEqual(TraySessionCLI.consentKey(signingIdentifier: "", executablePath: ""), "unknown")
+    }
+
+    func testDescribeCaller() {
+        XCTAssertEqual(
+            TraySessionCLI.describeCaller(name: "slicc", pid: 42, signingIdentifier: "com.slicc.slicc-cli"),
+            "slicc (pid 42), signed by com.slicc.slicc-cli"
+        )
+        XCTAssertEqual(
+            TraySessionCLI.describeCaller(name: "bash", pid: 7, signingIdentifier: nil),
+            "bash (pid 7)"
+        )
+        XCTAssertEqual(
+            TraySessionCLI.describeCaller(name: nil, pid: 9, signingIdentifier: nil),
+            "An unidentified process (pid 9)"
+        )
+    }
+
+    func testDeniedMessageDiffersForHeadless() {
+        XCTAssertTrue(TraySessionCLI.deniedMessage(guiAvailable: false).contains("SSH"))
+        XCTAssertFalse(TraySessionCLI.deniedMessage(guiAvailable: true).contains("SSH"))
+    }
+
+    // MARK: - Persistence
+
+    func testRevealConsentStoreRoundTrip() {
+        let suite = "TraySessionCLITests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = RevealConsentStore(defaults: defaults)
+
+        XCTAssertNil(store.load(forConsentKey: "id:x"))
+        store.save(.allow, forConsentKey: "id:x")
+        XCTAssertEqual(store.load(forConsentKey: "id:x"), .allow)
+        store.save(.deny, forConsentKey: "id:x")
+        XCTAssertEqual(store.load(forConsentKey: "id:x"), .deny)
+        XCTAssertNil(store.load(forConsentKey: "id:other"))
+    }
+
+    // MARK: - Helpers
+
+    private func decodeArray(_ data: Data) throws -> [[String: Any]] {
+        let json = try JSONSerialization.jsonObject(with: data)
+        return try XCTUnwrap(json as? [[String: Any]])
+    }
+
+    private func makeSession(
+        joinUrl: String,
+        lastSeenAt: Date = Date(timeIntervalSince1970: 0)
+    ) -> SyncedTraySession {
+        SyncedTraySession(
+            joinUrl: joinUrl,
+            label: "Chrome",
+            deviceId: "device-A",
+            deviceName: "MacA",
+            createdAt: lastSeenAt,
+            lastSeenAt: lastSeenAt
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Adds a way to see and use the iCloud-synced tray sessions from the command line. The macOS launcher gains a headless `Sliccstart --list-sessions [--reveal-urls]` subcommand, and the Go `slicc` CLI gains `list-sessions` plus a `<verb>-cloud` family (`follow`/`prompt`/`exec`/`watch`) that resolves a session's join URL from iCloud and runs the verb — so you never hand-copy a join URL.

## Why

Follow-up to the iCloud tray-session sync (v5.88.x). The sessions synced across a user's devices were only reachable through the launcher's SwiftUI list. This exposes them to the headless follower CLI. iCloud KVS is an Apple-only API readable only by the signed, iCloud-entitled `Sliccstart` binary, so putting it in the cross-platform Go CLI directly would need cgo + entitlement/profile signing and break the `CGO_ENABLED=0` cross-compile; instead the Go CLI shells out to the launcher.

## Approach / Implementation notes

**Swift (`packages/swift-launcher`)**
- `main.swift` parses `--list-sessions` **before** the SwiftUI app boots (`@main` moved off the struct); a normal launch still shows the GUI.
- `Models/TraySessionCLI.swift` (pure, unit-tested): arg parse, redacted-vs-full `SessionDTO` encoding (ISO-8601 dates for Go), consent outcome, dialog-button mapping, `consentKey`/`describeCaller`, `RevealConsentStore`.
- `Models/TraySessionCLIRunner.swift` (thin, untestable glue): reads the real store, the `NSAlert`, and best-effort caller identity (`getppid`/`proc_pidpath`/`SecCode`).

**Go (`packages/slicc-cli`)**
- `internal/cloud/cloud.go` (pure): `ParseSessions`, `ParseSelector` (`--index N` / `--session <id-prefix>`), `Select` (newest-first), `FormatTable`.
- `internal/cloud/resolve_darwin.go`: locates `Sliccstart.app` (`$SLICCSTART_APP` → `mdfind` → `/Applications` → `~/Applications`) and shells out. `resolve_other.go` returns `ErrUnsupported` off macOS.
- `cloud.go`: `cmdListSessions` + `cmdCloud`; a `cloudList` seam makes dispatch testable without a launcher. Verbs wired into `main.go`; telemetry allowlist updated.

## Security

Join URLs are **bearer secrets** (holder can attach as a follower and run commands on the leader), so:
- **Redaction by default** — `list-sessions` prints metadata only (opaque id, label, device, age); safe to pipe/log.
- **Consent gate on `--reveal-urls`** — a remembered "Always" (UserDefaults, keyed by caller code-signing id / path) wins; otherwise an `NSAlert` (Deny / Allow Once / Always Allow / Always Deny) naming the requesting process shows in a GUI session, and a **headless/SSH** caller is denied (exit 3) with guidance to grant once from the screen.
- Caller identity is spoofable by same-user code, so redaction-by-default is the real control and the dialog is a speed bump — called out in the docs, not oversold.

## Cross-cutting impact

- **Floats exercised**: Sliccstart (macOS) + slicc-cli (Go follower). Off macOS the cloud verbs report "macOS only".
- No change to the WebRTC follower path itself — the `-cloud` verbs resolve a URL then reuse the existing `cmdFollow`/`cmdPrompt`/`cmdExec`/`cmdWatch`.

## Test plan

- [x] Swift: `swift build`; full suite `swift test` (332 tests, 0 failures); coverage gate `swift-coverage-check.sh` (Lines 40.28 / Functions 44.20 / Regions 51.08, all above floor); SwiftLint (0 serious); `swift format lint --strict` clean.
- [x] Go: `go build ./...`; `make check` (gofmt, tidy, vet, golangci-lint clean, coverage 61.2% ≥ 58%).
- [x] Docs: doc-size gate (swift-launcher 19883/20000), Prettier, and doc-refs all pass.
- [x] Smoke: `Sliccstart --list-sessions` on the local build prints `[]` and exits 0 without launching the GUI.
- [ ] Not covered by CI: the real reveal dialog + a live cross-device session (needs a signed, iCloud-entitled build on a Mac with sessions).

## Documentation

- [x] `packages/swift-launcher/CLAUDE.md` (Headless CLI section; provisioning section refreshed) and `packages/slicc-cli/CLAUDE.md` (verbs, `internal/cloud`).

## Risk & rollback

- Blast radius: a new headless code path (guarded by an explicit flag) + new opt-in CLI verbs; the GUI launch path is unchanged. Revert the PR to remove both. Worst case for the reveal path is a denied request (no token disclosed).

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff (test fixtures use `slicc.test` placeholders)
- [x] Cross-runtime contract checked (Swift emits the JSON `internal/cloud` parses; iOS follower reuse of `SyncedTraySession` unaffected)
