### PR TITLE
fix(ext): reload discarded/unloaded leader tab on adoption

### DIFF
--- a/docs/extension-thin-bridge.md
+++ b/docs/extension-thin-bridge.md
@@ -65,6 +65,16 @@ connection:
   by `leaderTabLock` and shared by the cherry-panel connect and
   cherry-recovery. This also heals any pre-fix pile: the next icon click
   collapses it to one.
+- **Unloaded tabs are reloaded on adoption.** Chrome's memory saver can
+  discard the pinned background leader, and lazy session restore restores it
+  without loading it (`discarded` / `status: 'unloaded'`). Such a tab runs no
+  JS, so it can never dial the bridge Port or deliver `leader.join-url` —
+  adopting it as-is strands the side panel on "Disconnected — reopen to
+  retry" (the panel's 20s boot watchdog fires, and reopening re-adopts the
+  same dead tab). `adoptSingleLeaderTab` therefore prefers a live match over
+  an unloaded duplicate when deduping and `chrome.tabs.reload`s an unloaded
+  keeper (skipped when the `ext=` stamp already navigated — and thereby
+  loaded — it).
 
 Net: a restart can never duplicate the tab (nothing creates on startup), and
 the restored tab stays fully functional (self-adopt re-pins its bridge).

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -68,8 +68,11 @@ stale stored id. `ensureLeaderTab()` (adopt-or-create + dedup) runs **on
 demand** when the icon is clicked or a cherry-panel Port connects. After
 restart, the restored leader re-pins itself via **self-adopt**: when no leader
 id is stored, a top-frame connection from an allowlisted origin carrying
-`?slicc=leader` is accepted and persisted. See
-`docs/extension-thin-bridge.md` "Leader-Tab Lifecycle" for the full rationale.
+`?slicc=leader` is accepted and persisted. Adoption reloads a
+discarded/unloaded leader tab (memory saver, lazy session restore) — it runs
+no JS and could never deliver `leader.join-url` to the side panel otherwise.
+See `docs/extension-thin-bridge.md` "Leader-Tab Lifecycle" for the full
+rationale.
 
 ### Tray leader / multi-browser sync
 

--- a/packages/chrome-extension/src/chrome.d.ts
+++ b/packages/chrome-extension/src/chrome.d.ts
@@ -45,6 +45,10 @@ interface ChromeTab {
   url?: string;
   windowId?: number;
   pinned?: boolean;
+  /** True when Chrome discarded the tab (memory saver); it runs no JS until reloaded. */
+  discarded?: boolean;
+  /** 'unloaded' = restored-but-never-loaded (lazy session restore); runs no JS either. */
+  status?: 'unloaded' | 'loading' | 'complete';
 }
 
 interface ChromeTabChangeInfo {

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -256,10 +256,22 @@ async function createLeaderTab(): Promise<void> {
   if (created.id !== undefined) await writeStoredLeaderTabId(created.id);
 }
 
-/** Keep the first leader tab (stamp `ext=` + pin if needed, store its id) and
- *  close every duplicate. `matches` must be non-empty. */
+/** True when the tab exists but runs no JS: discarded by Chrome's memory saver,
+ *  or restored-but-never-loaded by lazy session restore. Such a tab can never
+ *  dial the bridge Port or deliver `leader.join-url`, so adopting it as-is
+ *  strands the side panel on "Disconnected — reopen to retry" (its 20s boot
+ *  watchdog fires with no joinUrl, and reopening re-adopts the same dead tab). */
+function isUnloadedTab(tab: ChromeTab): boolean {
+  return tab.discarded === true || tab.status === 'unloaded';
+}
+
+/** Keep the first LIVE leader tab (stamp `ext=` + pin if needed, store its id,
+ *  reload it when Chrome unloaded it) and close every duplicate. Preferring a
+ *  live match over an unloaded one avoids closing a working leader in favor of
+ *  a dead duplicate. `matches` must be non-empty. */
 async function adoptSingleLeaderTab(matches: ChromeTab[]): Promise<void> {
-  const [keep, ...extras] = matches;
+  const keep = matches.find((t) => !isUnloadedTab(t)) ?? matches[0];
+  const extras = matches.filter((t) => t !== keep);
   if (keep.id === undefined) return;
 
   for (const extra of extras) {
@@ -281,6 +293,17 @@ async function adoptSingleLeaderTab(matches: ChromeTab[]): Promise<void> {
     const props: { pinned: true; url?: string } = { pinned: true };
     if (extIdUrl !== undefined) props.url = extIdUrl;
     await chrome.tabs.update(keep.id, props);
+  }
+  // A discarded/unloaded leader runs no JS, so it can never deliver the tray
+  // joinUrl — reload it (loads without focusing) unless the ext= stamp above
+  // already navigated it. Without this the panel loops booting → disconnected
+  // until the user happens to activate the tab manually.
+  if (extIdUrl === undefined && isUnloadedTab(keep)) {
+    try {
+      await chrome.tabs.reload(keep.id);
+    } catch (err) {
+      console.error('[slicc-sw] failed to reload unloaded leader tab', err);
+    }
   }
   await writeStoredLeaderTabId(keep.id);
 }

--- a/packages/chrome-extension/tests/service-worker-leader-tab.test.ts
+++ b/packages/chrome-extension/tests/service-worker-leader-tab.test.ts
@@ -18,7 +18,14 @@ import { CHERRY_PANEL_PORT_NAME } from '../src/cherry-panel-protocol.js';
 const sessionStorage = new Map<string, unknown>();
 const tabsStore = new Map<
   number,
-  { id: number; windowId?: number; url?: string; pinned?: boolean }
+  {
+    id: number;
+    windowId?: number;
+    url?: string;
+    pinned?: boolean;
+    discarded?: boolean;
+    status?: 'unloaded' | 'loading' | 'complete';
+  }
 >();
 const tabsRemoved: number[] = [];
 
@@ -408,7 +415,120 @@ describe('leader tab — ensure on demand (icon click), never on startup', () =>
 
     expect(mockChrome.tabs.create).not.toHaveBeenCalled();
     expect(mockChrome.tabs.update).not.toHaveBeenCalled();
+    expect(mockChrome.tabs.reload).not.toHaveBeenCalled();
     expect(sessionStorage.get(LEADER_KEY)).toBe(9);
+  });
+
+  it('reloads an adopted leader tab that Chrome discarded (memory saver)', async () => {
+    // A discarded tab keeps its URL but runs no JS — it can never dial the
+    // bridge Port or deliver leader.join-url. Adopting it without a reload
+    // strands the side panel on "Disconnected — reopen to retry" forever.
+    tabsStore.set(21, {
+      id: 21,
+      windowId: 100,
+      url: LEADER_URL_WITH_EXT,
+      pinned: true,
+      discarded: true,
+      status: 'unloaded',
+    });
+    await loadSw();
+    mockChrome.tabs.create.mockClear();
+    await fireIconClick();
+
+    expect(mockChrome.tabs.create).not.toHaveBeenCalled();
+    expect(mockChrome.tabs.reload).toHaveBeenCalledWith(21);
+    expect(sessionStorage.get(LEADER_KEY)).toBe(21);
+  });
+
+  it('reloads an adopted leader tab restored lazily by session restore (status unloaded)', async () => {
+    tabsStore.set(22, {
+      id: 22,
+      windowId: 100,
+      url: LEADER_URL_WITH_EXT,
+      pinned: true,
+      status: 'unloaded',
+    });
+    await loadSw();
+    await fireIconClick();
+
+    expect(mockChrome.tabs.reload).toHaveBeenCalledWith(22);
+    expect(sessionStorage.get(LEADER_KEY)).toBe(22);
+  });
+
+  it('does NOT double-load a discarded leader whose adoption already navigates it (ext= stamp)', async () => {
+    // The ext= stamp goes through tabs.update({url}), which itself loads a
+    // discarded tab — a reload on top would boot the page twice.
+    tabsStore.set(23, {
+      id: 23,
+      windowId: 100,
+      url: LEADER_URL,
+      pinned: true,
+      discarded: true,
+      status: 'unloaded',
+    });
+    await loadSw();
+    await fireIconClick();
+
+    expect(mockChrome.tabs.update).toHaveBeenCalledWith(23, {
+      pinned: true,
+      url: LEADER_URL_WITH_EXT,
+    });
+    expect(mockChrome.tabs.reload).not.toHaveBeenCalled();
+    expect(sessionStorage.get(LEADER_KEY)).toBe(23);
+  });
+
+  it('prefers a live leader tab over a discarded duplicate when deduping', async () => {
+    // matches[0] is the dead one — keeping it (and closing the live tab) would
+    // trade a working leader for one that cannot serve the panel.
+    tabsStore.set(31, {
+      id: 31,
+      windowId: 100,
+      url: LEADER_URL_WITH_EXT,
+      pinned: true,
+      discarded: true,
+      status: 'unloaded',
+    });
+    tabsStore.set(32, {
+      id: 32,
+      windowId: 100,
+      url: LEADER_URL_WITH_EXT,
+      pinned: true,
+      status: 'complete',
+    });
+    await loadSw();
+    mockChrome.tabs.create.mockClear();
+    await fireIconClick();
+
+    expect(mockChrome.tabs.create).not.toHaveBeenCalled();
+    expect(mockChrome.tabs.remove).toHaveBeenCalledWith(31);
+    expect(mockChrome.tabs.remove).not.toHaveBeenCalledWith(32);
+    expect(mockChrome.tabs.reload).not.toHaveBeenCalled();
+    expect(sessionStorage.get(LEADER_KEY)).toBe(32);
+  });
+
+  it('still adopts (and reloads) when every leader duplicate is unloaded', async () => {
+    tabsStore.set(41, {
+      id: 41,
+      windowId: 100,
+      url: LEADER_URL_WITH_EXT,
+      pinned: true,
+      discarded: true,
+      status: 'unloaded',
+    });
+    tabsStore.set(42, {
+      id: 42,
+      windowId: 100,
+      url: LEADER_URL_WITH_EXT,
+      pinned: true,
+      discarded: true,
+      status: 'unloaded',
+    });
+    await loadSw();
+    await fireIconClick();
+
+    expect(mockChrome.tabs.remove).toHaveBeenCalledWith(42);
+    expect(mockChrome.tabs.reload).toHaveBeenCalledWith(41);
+    expect(sessionStorage.get(LEADER_KEY)).toBe(41);
   });
 
   it('re-creates the leader tab on icon click after the user closed it', async () => {


### PR DESCRIPTION
## Problem

Users (and locally reproducible) saw the extension side panel stuck on **"Disconnected — reopen to retry"** even though the Slicc leader tab was visibly working. Reopening the panel did not recover it.

**Root cause:** Chrome's memory saver can *discard* the pinned background leader tab, and lazy session restore can leave it *unloaded* (`status: 'unloaded'`). In both cases the tab URL is intact but no JavaScript runs — the tab can never dial the bridge Port or deliver `leader.join-url` to the service worker.

`ensureLeaderTab` / `adoptSingleLeaderTab` had no awareness of tab load state. It accepted the dead tab as a valid leader, stored its id, and returned. The panel's 20 s boot watchdog then fired (no joinUrl ever arrived) → "Disconnected — reopen to retry". Reopening re-adopted the same dead tab and looped.

The leader appeared "working" because *clicking* it triggered a transparent memory-saver reload, but by then the panel had already cycled to disconnected.

**Reproduced** end-to-end via CDP instrumentation:
1. Discard the leader tab + stop the SW (simulates memory-saver + browser restart).
2. Open the panel → stuck in `starting` → `disconnected` loop, leader stays `{discarded: true, status: 'unloaded'}`.
3. Activate the leader tab → it loads → panel becomes `live` within ~5 s. ✅

## Fix

- Add `isUnloadedTab()` predicate (`discarded === true || status === 'unloaded'`).
- When deduping multiple leader tabs, **prefer a live match as the keeper** over a discarded one — avoids closing a working leader in favour of a dead duplicate.
- After adoption, if the kept tab is still unloaded (and the `ext=` URL stamp didn't already navigate+load it), `chrome.tabs.reload()` it — loads without focusing, so the tab boots silently, dials the bridge, and delivers the joinUrl.
- Extend `ChromeTab` type declaration with `discarded` and `status` fields.

## Tests

6 new cases in `service-worker-leader-tab.test.ts`:

| Case | Asserts |
|---|---|
| `discarded: true` tab | `reload()` called |
| `status: 'unloaded'` tab | `reload()` called |
| Live tab (`status: 'complete'`) | `reload()` **not** called |
| Ext= stamp already navigated it | `reload()` **not** called (no double-load) |
| Live + discarded duplicate | live tab kept, discarded closed, no reload |
| All duplicates unloaded | first kept + reloaded, second closed |

Mutation-tested: disabling the reload branch or the live-preference sort each independently fails the right subset.

## Checklist

- [x] `npm run verify` ✅
- [x] `check-touched-exemptions.mjs` ✅ (0 debt-listed files touched)
- [x] `npm run typecheck` ✅
- [x] `npm run test` — 12 942 passed ✅
- [x] `npm run test:coverage` ✅
- [x] `npm run build` ✅
- [x] `npm run build -w @slicc/chrome-extension` ✅
- [x] `npm run bundle-size` ✅
