### PR TITLE
test(e2e): stabilize CDP browser across retries

### DIFF
--- a/packages/webapp/tests/e2e/cdp-browser.ts
+++ b/packages/webapp/tests/e2e/cdp-browser.ts
@@ -1,0 +1,33 @@
+import { chromium } from '@playwright/test';
+
+const DEFAULT_CDP_PORT = 9222;
+
+function resolveCdpPort(): number {
+  const value = Number.parseInt(process.env['SLICC_E2E_CDP_PORT'] ?? '', 10);
+  return Number.isInteger(value) && value > 0 && value <= 65_535 ? value : DEFAULT_CDP_PORT;
+}
+
+const cdpPort = resolveCdpPort();
+const browser = await chromium.launch({
+  headless: true,
+  args: [`--remote-debugging-port=${cdpPort}`],
+});
+
+console.log(`[e2e-cdp-browser] listening on ${cdpPort}`);
+
+let stopping = false;
+async function stop(): Promise<void> {
+  if (stopping) return;
+  stopping = true;
+  await browser.close();
+}
+
+process.once('SIGINT', () => void stop());
+process.once('SIGTERM', () => void stop());
+
+await new Promise<void>((resolve, reject) => {
+  browser.once('disconnected', () => {
+    if (stopping) resolve();
+    else reject(new Error('Dedicated E2E CDP browser disconnected unexpectedly'));
+  });
+});

--- a/packages/webapp/tests/e2e/fake-llm-helpers.ts
+++ b/packages/webapp/tests/e2e/fake-llm-helpers.ts
@@ -317,3 +317,28 @@ export async function readCdpPageState(
   }
   return targets;
 }
+
+/**
+ * Close matching Chrome targets through the HTTP CDP discovery API and wait
+ * until they disappear. The dedicated E2E CDP browser outlives Playwright test
+ * workers, so scenario-owned tabs must be cleared explicitly between retries.
+ */
+export async function closeCdpPageTargets(options: ReadCdpPageStateOptions = {}): Promise<void> {
+  const base = (options.cdpEndpoint ?? 'http://127.0.0.1:9222').replace(/\/+$/, '');
+  const targets = await readCdpPageState(options);
+  await Promise.all(
+    targets.map(async (target) => {
+      const res = await fetch(`${base}/json/close/${encodeURIComponent(target.id)}`);
+      if (!res.ok) {
+        throw new Error(`Failed to close CDP target ${target.id}: HTTP ${res.status}`);
+      }
+    })
+  );
+
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if ((await readCdpPageState(options)).length === 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error('Timed out waiting for CDP targets to close');
+}

--- a/packages/webapp/tests/e2e/playwright.config.ts
+++ b/packages/webapp/tests/e2e/playwright.config.ts
@@ -21,8 +21,8 @@ export const FAKE_LLM_PORT = resolvePort('SLICC_E2E_FAKE_LLM_PORT', 5781);
  * webapp is served by `wrangler dev` from `dist/ui` on {@link WRANGLER_PORT}
  * (the leader origin / `baseURL`) and dials back to the node-server thin-bridge
  * on {@link BRIDGE_PORT} for CDP + cross-origin `/api`. The CDP proxy's outbound
- * target stays {@link CDP_PORT}, matching the `--remote-debugging-port` the
- * CDP-binding scenarios launch Playwright Chrome with.
+ * target stays {@link CDP_PORT}, matching the dedicated Chrome process the
+ * harness keeps alive across Playwright worker restarts and CI retries.
  */
 export const WRANGLER_PORT = resolvePort('SLICC_E2E_WRANGLER_PORT', 8787);
 export const BRIDGE_PORT = resolvePort('SLICC_E2E_BRIDGE_PORT', 5710);
@@ -68,6 +68,18 @@ export default defineConfig({
   testDir: '.',
   webServer: [
     {
+      // Keep the agent-driven CDP target outside Playwright's test-worker
+      // browser lifecycle. A failed attempt restarts its worker browser; when
+      // that browser also owned port 9222, node-server retained its now-stale
+      // /devtools/browser/<id> URL and every retry failed with HTTP 404.
+      command: `npx tsx ${resolve(repoRoot, 'packages/webapp/tests/e2e/cdp-browser.ts')}`,
+      port: CDP_PORT,
+      reuseExistingServer: !process.env['CI'],
+      env: {
+        SLICC_E2E_CDP_PORT: String(CDP_PORT),
+      },
+    },
+    {
       // wrangler serves `dist/ui` (the leader/UI origin) with SPA fallback,
       // exactly as the production worker does. The webapp must be built
       // (`npm run build -w @slicc/webapp` → `dist/ui/index.html`) first; the
@@ -82,9 +94,8 @@ export default defineConfig({
     {
       // Thin /cdp bridge + `/api` surface only — no UI. `--cdp-port=9222` pins
       // the proxy's outbound CDP target so the agent's `playwright-cli` and the
-      // harness's `readCdpPageState` both speak to the same Chrome (see
-      // `reference-scenario.test.ts`, which launches Playwright Chrome with
-      // `--remote-debugging-port=9222`). `SLICC_BRIDGE_TOKEN` arms the `/cdp`
+      // harness's `readCdpPageState` both speak to the dedicated Chrome above.
+      // `SLICC_BRIDGE_TOKEN` arms the `/cdp`
       // upgrade gate + cross-origin `/api` token check; `BRIDGE_DEV_ALLOWED_ORIGINS`
       // allowlists the wrangler leader origin so its cross-origin requests pass.
       command: `node ${resolve(repoRoot, 'dist/node-server/index.js')} --serve-only --cdp-port=${CDP_PORT}`,
@@ -115,11 +126,9 @@ export default defineConfig({
   use: {
     baseURL: LEADER_ORIGIN,
   },
-  // Single-worker by construction: the node-server CDP proxy points at one
-  // Chrome on port 9222, and every CDP-binding scenario (reference-scenario,
-  // preview-serve) launches Playwright Chrome with `--remote-debugging-port=9222`.
-  // Running them in parallel would collide on the port and on the proxy's
-  // outbound target.
+  // Keep one worker because fake-LLM fixture state and browser-driven scenarios
+  // are process-global. The agent-driven Chrome itself is a dedicated webServer
+  // process, so retries can restart Playwright's worker without replacing CDP.
   workers: 1,
   fullyParallel: true,
   timeout: 30_000,

--- a/packages/webapp/tests/e2e/reference-scenario.test.ts
+++ b/packages/webapp/tests/e2e/reference-scenario.test.ts
@@ -18,8 +18,8 @@
  *      completing, so a silent "turn never started" failure mode
  *      surfaces as a timeout, not a false green.
  *
- *   3. CDP port matches the harness default — Playwright launches
- *      Chrome with `--remote-debugging-port=9222` for this file,
+ *   3. CDP port matches the harness default — the dedicated E2E Chrome
+ *      process listens on `--remote-debugging-port=9222`, while
  *      `node-server --serve-only --cdp-port=9222` (from
  *      `playwright.config.ts`) proxies to the same port, and
  *      {@link readCdpPageState} probes it by default. The per-phase
@@ -35,6 +35,7 @@
 
 import { expect, test } from '@playwright/test';
 import {
+  closeCdpPageTargets,
   FAKE_LLM_BASE_URL,
   readCdpPageState,
   resetFakeLlm,
@@ -66,26 +67,26 @@ const PAGE_C_URL = `data:text/html,${PAGE_C_HTML}`;
 const ALL_TITLES_SORTED = [PAGE_A_TITLE, PAGE_B_TITLE, PAGE_C_TITLE].slice().sort();
 const PHASE2_TITLES_SORTED = [PAGE_B_TITLE, PAGE_C_TITLE].slice().sort();
 
-// Bind 9222 on the Playwright-launched Chrome so:
+// The dedicated E2E Chrome process binds 9222 so:
 //   - the `node-server --serve-only` CDP proxy (`--cdp-port=9222`)
 //     connects to a real Chrome
 //   - the agent's `playwright-cli tab-new` opens a CDP-driven tab there
 //   - {@link readCdpPageState} sees the same target at its default port
-// Project-level `workers: 1` in `playwright.config.ts` already
-// serializes every CDP-binding scenario (preview-serve.test.ts also
-// claims 9222), so no per-file `mode: 'serial'` is needed here.
-test.use({
-  launchOptions: { args: ['--remote-debugging-port=9222'] },
-});
+// It stays alive when Playwright replaces a failed test worker for a retry,
+// avoiding stale `/devtools/browser/<id>` URLs in the long-lived CDP proxy.
 
 test.describe('fake-llm reference scenario', () => {
   // The fake LLM is a long-lived `webServer` with a per-process turn
   // cursor. Playwright retries reuse that server, so rewind the cursor
-  // before every attempt — otherwise a retry resumes mid-fixture and
-  // fails deterministically with `fixture_overflow` (runs before the
-  // first attempt too, where it's a harmless no-op).
+  // and clear scenario-owned CDP targets before every attempt — otherwise a
+  // retry resumes mid-fixture or counts tabs left by its predecessor.
   test.beforeEach(async () => {
     await resetFakeLlm();
+    await closeCdpPageTargets({
+      filter: (target) =>
+        target.type === 'page' &&
+        (target.url === PAGE_A_URL || target.url === PAGE_B_URL || target.url === PAGE_C_URL),
+    });
   });
 
   test('multi-phase scripted tool calls drive multiple CDP navigations', async ({ page }) => {


### PR DESCRIPTION
**Problem**
Playwright retries could restart the browser behind the long-lived CDP proxy, leaving a stale DevTools endpoint and repeatedly evicting PRs such as #1762 from the merge queue.

**Solution**
Keep a dedicated CDP browser alive for the E2E run and clear scenario-owned tabs between attempts.

**Testing**
- Reference scenario passed 5 consecutive CI-mode runs.
- Full E2E suite passed: 13 passed, 1 skipped.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KYQFZP4SSC1GD7VF9RME6W4R&panel=chat)