### PR TITLE
fix(dev-tools): protect standalone harness ports

### DIFF
--- a/.agents/skills/cdp-smoke-test/SKILL.md
+++ b/.agents/skills/cdp-smoke-test/SKILL.md
@@ -19,20 +19,38 @@ and work through the two test tiers. All driving goes through
 
 ## Setup
 
+**Production safety boundary:** `:5710` (bridge) and `:9222` (Chrome CDP)
+belong to the developer's production SLICC. Never bind, reap, or kill either
+port. The smoke-test lane uses bridge `:5715`; its Chrome CDP port is
+auto-resolved.
+
 ```bash
-# 1. Build the latest code (cherry regenerates worker bridge assets)
+# 1. Record production listeners before doing anything else.
+PROD_BRIDGE_PIDS=$(lsof -nP -tiTCP:5710 -sTCP:LISTEN 2>/dev/null | sort -n | paste -sd, -)
+PROD_CDP_PIDS=$(lsof -nP -tiTCP:9222 -sTCP:LISTEN 2>/dev/null | sort -n | paste -sd, -)
+printf 'production preflight: :5710=%s :9222=%s\n' "${PROD_BRIDGE_PIDS:-none}" "${PROD_CDP_PIDS:-none}"
+
+# 2. Build the latest code (cherry regenerates worker bridge assets).
 npm install
 npm run build -w @ai-ecoverse/cherry -w @slicc/webapp -w @slicc/node-server
 
-# 2. Launch — local wrangler UI on :8787, bridge on :5710, ephemeral profile.
+# 3. Launch — wrangler :8787, isolated bridge :5715, ephemeral profile.
 #    CHROME_PATH is optional; default is a labeled Chrome for Testing clone.
+export SLICC_HARNESS_LOG=/tmp/slicc-dev-harness-5715.log
 CHROME_PATH="/Applications/Google Chrome Canary.app" \
-  nohup npm run dev:standalone:fresh > /tmp/slicc-dev-harness.log 2>&1 &
+  PORT=5715 WRANGLER_PORT=8787 \
+  nohup npm run dev:standalone:fresh > "$SLICC_HARNESS_LOG" 2>&1 &
 
-# 3. Wait for boot, then confirm CDP is reachable (port is auto-resolved,
-#    NOT 9222 — slicc-cdp greps it from the harness log automatically)
-sleep 20 && grep "Chrome CDP listening" /tmp/slicc-dev-harness.log
+# 4. Wait for boot and export the auto-resolved CDP port from this lane's log.
+sleep 20 && grep "Chrome CDP listening" "$SLICC_HARNESS_LOG"
+export SLICC_CDP_PORT=$(sed -nE 's/.*Chrome CDP listening on port ([0-9]+).*/\1/p' "$SLICC_HARNESS_LOG" | tail -1)
+test -n "$SLICC_CDP_PORT"
 .agents/skills/cdp-smoke-test/scripts/slicc-cdp targets
+
+# 5. Pass criterion: production listeners are exactly the preflight PIDs.
+POST_BRIDGE_PIDS=$(lsof -nP -tiTCP:5710 -sTCP:LISTEN 2>/dev/null | sort -n | paste -sd, -)
+POST_CDP_PIDS=$(lsof -nP -tiTCP:9222 -sTCP:LISTEN 2>/dev/null | sort -n | paste -sd, -)
+test "$POST_BRIDGE_PIDS" = "$PROD_BRIDGE_PIDS" && test "$POST_CDP_PIDS" = "$PROD_CDP_PIDS"
 ```
 
 Attach the console watcher before testing — a clean log at the end is part
@@ -66,6 +84,13 @@ anomalies, and the total session cost from the header counter.
 
 ## Pitfalls
 
+- Never use `pkill` or `killall` on Chrome, node, or wrangler. Never `kill` a
+  PID resolved from `:5710` or `:9222`. If any chosen harness port is
+  occupied, select another isolated port instead of clearing it.
+- The standalone guard fails fast, exits non-zero, and reports the PID and
+  command holding the selected bridge port. `SLICC_FRESH_REAP=1` opts into
+  reaping only a stale harness on a non-production bridge port that you have
+  verified you own; never use it with `PORT=5710`. Chrome CDP is never reaped.
 - **Closed the leader tab?** The harness survives. **Diagnostic-only, do
   not automate**: the harness log redacts `bridgeToken` deliberately — the
   token is a capability. As a manual last resort during an interactive
@@ -74,5 +99,6 @@ anomalies, and the total session cost from the header counter.
 url like '%bridgeToken%'"`) and the URL reopened via `location.href` or
   `/json/new`; prefer restarting the harness when nothing valuable would be
   lost. Never print the token into transcripts or scripts.
-- Second instance alongside: `PORT=5720 npm run dev:standalone:fresh`
-  (ports and profile auto-isolate).
+- Additional instance alongside: choose another unused bridge port, for
+  example `PORT=5716 WRANGLER_PORT=8787 npm run dev:standalone:fresh`.
+  Profiles and Chrome CDP ports auto-isolate; an occupied bridge fails fast.

--- a/.agents/skills/cdp-smoke-test/SKILL.md
+++ b/.agents/skills/cdp-smoke-test/SKILL.md
@@ -90,7 +90,8 @@ anomalies, and the total session cost from the header counter.
 - The standalone guard fails fast, exits non-zero, and reports the PID and
   command holding the selected bridge port. `SLICC_FRESH_REAP=1` opts into
   reaping only a stale harness on a non-production bridge port that you have
-  verified you own; never use it with `PORT=5710`. Chrome CDP is never reaped.
+  verified you own. Forced reaping of `:5710` is refused; choose another port
+  or stop your own `:5710` process manually. Chrome CDP is never reaped.
 - **Closed the leader tab?** The harness survives. **Diagnostic-only, do
   not automate**: the harness log redacts `bridgeToken` deliberately — the
   token is a capability. As a manual last resort during an interactive

--- a/.agents/skills/cdp-smoke-test/scripts/slicc-cdp
+++ b/.agents/skills/cdp-smoke-test/scripts/slicc-cdp
@@ -3,7 +3,8 @@
  * slicc-cdp — zero-dependency CDP driver for a running SLICC dev harness.
  *
  * Attaches to the Chrome the harness launched (port auto-detected from
- * /tmp/slicc-dev-harness.log, or pass --port / SLICC_CDP_PORT) and drives
+ * SLICC_HARNESS_LOG, default /tmp/slicc-dev-harness.log, or pass --port /
+ * SLICC_CDP_PORT) and drives
  * the leader tab (matched on the wrangler UI origin — default
  * http://localhost:8787, override with SLICC_UI_ORIGIN for a
  * WRANGLER_PORT-overridden harness). Node 22+ (built-in WebSocket).
@@ -32,14 +33,18 @@ const [cmd, ...rest] = args;
 
 async function detectPort() {
   const { readFileSync } = await import('node:fs');
+  const logPath = process.env.SLICC_HARNESS_LOG ?? '/tmp/slicc-dev-harness.log';
   try {
-    const log = readFileSync('/tmp/slicc-dev-harness.log', 'utf8');
+    const log = readFileSync(logPath, 'utf8');
     // Last occurrence wins: a restarted harness appends a fresh
     // "listening" line, so the first match may be a dead port.
     const m = [...log.matchAll(/Chrome CDP listening on port (\d+)/g)].pop();
     if (m) return Number(m[1]);
   } catch {}
-  console.error('Cannot detect CDP port — pass --port or set SLICC_CDP_PORT');
+  console.error(
+    `Cannot detect CDP port from ${logPath} — pass --port, set SLICC_CDP_PORT, ` +
+      'or set SLICC_HARNESS_LOG'
+  );
   process.exit(1);
 }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -157,31 +157,33 @@ or the wrong provider/feature code may be served.
 npm run build -w @slicc/webapp
 npm run build -w @slicc/node-server
 
-# Then launch a fresh local instance (wrangler UI + node-server thin-bridge)
-npm run dev:standalone:fresh
+# Then launch an isolated local instance (wrangler UI + node-server thin-bridge)
+PORT=5715 WRANGLER_PORT=8787 npm run dev:standalone:fresh
 ```
 
 Or rebuild everything in one shot (slower, ~2–3 min, but catches all packages):
 
 ```bash
-npm run build && npm run dev:standalone:fresh
+npm run build && PORT=5715 WRANGLER_PORT=8787 npm run dev:standalone:fresh
 ```
 
 What `dev:standalone:fresh` does:
 
 1. Starts wrangler serving `dist/ui/` on `http://localhost:8787`.
-2. Starts node-server on port 5710, pointing Chrome at the wrangler origin.
+2. Starts node-server on the selected `PORT` (`5715` above), pointing Chrome
+   at the wrangler origin.
 3. Opens a labeled Chrome clone (`SLICC-Node`) with an ephemeral profile — no
    production profile is touched, and parallel instances stay isolated.
 
 To run a second instance alongside (e.g. for A/B testing two builds):
 
 ```bash
-PORT=5720 npm run dev:standalone:fresh
+PORT=5716 WRANGLER_PORT=8787 npm run dev:standalone:fresh
 ```
 
-Each instance gets its own Chrome profile and CDP port auto-resolved from its
-bridge port.
+Each instance gets its own Chrome profile. Node-server independently requests
+CDP port `0`, so Chrome selects an available OS-assigned port; `slicc-cdp` reads
+the selected port from the harness log.
 
 ### Fresh Dev Harness Details
 
@@ -191,10 +193,6 @@ profile collisions.
 
 **Shared behavior across all harnesses:**
 
-- **Port-scoped reaping**: before binding, each harness resolves the PID
-  bound to its own bridge/CDP port via `lsof -t` and kills it (TERM, then
-  KILL if still bound). It **never** blanket-kills by process name, so
-  concurrent harnesses survive.
 - **Wrangler reuse-or-start**: an already-listening `:8787` is reused as-is;
   otherwise the harness starts one and gates cleanup behind
   `STARTED_WRANGLER`. A `kill -0 "$WRANGLER_PID"` liveness guard in the
@@ -206,11 +204,18 @@ profile collisions.
   the label with `CHROME_LABEL=…`; falls back to the unlabeled bundle on
   failure or non-darwin.
 
-**Standalone** (`dev-standalone-fresh.sh`, bridge `:5710`, CDP `:9222`,
+**Standalone** (`dev-standalone-fresh.sh`, bridge `:$PORT`, OS-assigned CDP,
 label `SLICC-Node`):
 The primary two-service harness (wrangler UI/leader origin on `:8787` +
 node-server thin-bridge). Self-builds the leader UI
 (`npm run build -w @slicc/webapp`) when `dist/ui/index.html` is missing.
+Use an isolated bridge such as `PORT=5715`; `:5710` and `:9222` may belong to
+a production instance and must not be cleared. If the selected bridge is
+occupied, the harness exits non-zero and reports the holding PID and command.
+Only `SLICC_FRESH_REAP=1` opts into reaping that selected bridge, and only for
+a confirmed stale harness you own. The standalone harness never reaps a Chrome
+CDP port. Other fresh harnesses retain their documented port-scoped cleanup;
+none should blanket-kill by process name.
 On exit, SIGTERMs only the node-server it foregrounds (which closes the
 Chrome it launched), then removes the ephemeral profile.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -213,8 +213,10 @@ Use an isolated bridge such as `PORT=5715`; `:5710` and `:9222` may belong to
 a production instance and must not be cleared. If the selected bridge is
 occupied, the harness exits non-zero and reports the holding PID and command.
 Only `SLICC_FRESH_REAP=1` opts into reaping that selected bridge, and only for
-a confirmed stale harness you own. The standalone harness never reaps a Chrome
-CDP port. Other fresh harnesses retain their documented port-scoped cleanup;
+a confirmed stale harness you own. Forced reaping of the documented production
+bridge `:5710` is refused; choose another port or stop your own `:5710` process
+manually. The standalone harness never reaps a Chrome CDP port. Other fresh
+harnesses retain their documented port-scoped cleanup;
 none should blanket-kill by process name.
 On exit, SIGTERMs only the node-server it foregrounds (which closes the
 Chrome it launched), then removes the ephemeral profile.

--- a/packages/dev-tools/CLAUDE.md
+++ b/packages/dev-tools/CLAUDE.md
@@ -46,17 +46,17 @@ This file covers the repo's developer-tooling surface.
 
 ### Fresh Dev Harnesses
 
-Five harness scripts bring up isolated dev environments on distinct ports so they can run concurrently. Each harness reaps stale processes **strictly port-scoped** (never blanket-kills by name) and uses a labeled Chrome bundle clone (`clone-labeled-chrome.sh`) for distinct ⌘-Tab entries.
+Five harness scripts bring up isolated dev environments on distinct ports so they can run concurrently. The standalone harness fails if its selected bridge is occupied unless `SLICC_FRESH_REAP=1` explicitly opts into reaping a confirmed stale harness; it never reaps Chrome CDP. Other harness cleanup remains strictly port-scoped, never by process name. Labeled Chrome bundle clones (`clone-labeled-chrome.sh`) provide distinct ⌘-Tab entries.
 
-| Harness        | Script                        | Bridge  | CDP     | Chrome Label  | Notes                                                                          |
-| -------------- | ----------------------------- | ------- | ------- | ------------- | ------------------------------------------------------------------------------ |
-| Standalone     | `dev-standalone-fresh.sh`     | `:5710` | `:9222` | `SLICC-Node`  | Primary node-server harness; self-builds leader UI                             |
-| Swift          | `dev-swift-fresh.sh`          | `:5720` | `:9224` | `SLICC-Swift` | Native `swift-server` bridge; auto-signs with stable dev cert                  |
-| Extension      | `dev-extension-fresh.sh`      | (SW)    | `:9333` | `SLICC-Ext`   | MV3 extension IS the bridge; self-builds leader UI; uses LaunchServices launch |
-| Electron-Node  | `dev-electron-node-fresh.sh`  | `:5730` | `:9225` | —             | Attaches to external Electron app (default: Slack)                             |
-| Electron-Swift | `dev-electron-swift-fresh.sh` | `:5740` | `:9226` | —             | Swift backend attaching to external Electron app                               |
+| Harness        | Script                        | Bridge                 | CDP     | Chrome Label  | Notes                                                                          |
+| -------------- | ----------------------------- | ---------------------- | ------- | ------------- | ------------------------------------------------------------------------------ |
+| Standalone     | `dev-standalone-fresh.sh`     | `:$PORT` (use `:5715`) | auto    | `SLICC-Node`  | Fails on occupied bridge by default; self-builds leader UI                     |
+| Swift          | `dev-swift-fresh.sh`          | `:5720`                | `:9224` | `SLICC-Swift` | Native `swift-server` bridge; auto-signs with stable dev cert                  |
+| Extension      | `dev-extension-fresh.sh`      | (SW)                   | `:9333` | `SLICC-Ext`   | MV3 extension IS the bridge; self-builds leader UI; uses LaunchServices launch |
+| Electron-Node  | `dev-electron-node-fresh.sh`  | `:5730`                | `:9225` | —             | Attaches to external Electron app (default: Slack)                             |
+| Electron-Swift | `dev-electron-swift-fresh.sh` | `:5740`                | `:9226` | —             | Swift backend attaching to external Electron app                               |
 
-Run via `npm run dev:standalone:fresh`, `npm run dev:swift:fresh`, `npm run dev:extension:fresh`, `npm run dev:electron:node:fresh`, `npm run dev:electron:swift:fresh`. Override bridge port with `PORT=…`, target app with positional arg or `ELECTRON_APP=…`. All pair with `slicc-debug.mjs` for verification. For detailed lifecycle, port resolution, reaping, LaunchServices, and wrangler reuse behavior, see [`docs/development.md`](../../docs/development.md) § "Fresh Dev Harness Details".
+Run standalone in an isolated lane with `PORT=5715 WRANGLER_PORT=8787 npm run dev:standalone:fresh`; never use or clear production bridge `:5710` or Chrome CDP `:9222`. Other entry points are `npm run dev:swift:fresh`, `npm run dev:extension:fresh`, `npm run dev:electron:node:fresh`, and `npm run dev:electron:swift:fresh`. Override bridge port with `PORT=…`, target app with positional arg or `ELECTRON_APP=…`. All pair with `slicc-debug.mjs` for verification. For detailed lifecycle, port resolution, reaping, LaunchServices, and wrangler reuse behavior, see [`docs/development.md`](../../docs/development.md) § "Fresh Dev Harness Details".
 
 ### Supporting Utilities
 

--- a/packages/dev-tools/CLAUDE.md
+++ b/packages/dev-tools/CLAUDE.md
@@ -46,7 +46,7 @@ This file covers the repo's developer-tooling surface.
 
 ### Fresh Dev Harnesses
 
-Five harness scripts bring up isolated dev environments on distinct ports so they can run concurrently. The standalone harness fails if its selected bridge is occupied unless `SLICC_FRESH_REAP=1` explicitly opts into reaping a confirmed stale harness; it never reaps Chrome CDP. Other harness cleanup remains strictly port-scoped, never by process name. Labeled Chrome bundle clones (`clone-labeled-chrome.sh`) provide distinct ⌘-Tab entries.
+Five harness scripts bring up isolated dev environments on distinct ports so they can run concurrently. The standalone harness fails if its selected bridge is occupied unless `SLICC_FRESH_REAP=1` explicitly opts into reaping a confirmed stale harness; forced reaping of the documented production bridge `:5710` is refused, and it never reaps Chrome CDP. Other harness cleanup remains strictly port-scoped, never by process name. Labeled Chrome bundle clones (`clone-labeled-chrome.sh`) provide distinct ⌘-Tab entries.
 
 | Harness        | Script                        | Bridge                 | CDP     | Chrome Label  | Notes                                                                          |
 | -------------- | ----------------------------- | ---------------------- | ------- | ------------- | ------------------------------------------------------------------------------ |

--- a/packages/dev-tools/tools/dev-standalone-fresh.sh
+++ b/packages/dev-tools/tools/dev-standalone-fresh.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # dev:standalone:fresh — launch the two-service standalone harness
 # (wrangler UI + node-server thin-bridge) with a brand-new Chrome for
-# Testing profile.  Reaps stale processes on its OWN ports (bridge +
-# Chrome CDP) and uses an ephemeral profile so the session starts clean
-# without disturbing concurrent harnesses.
+# Testing profile. Fails fast when its bridge port is occupied and uses an
+# ephemeral profile so the session starts clean without disturbing concurrent
+# harnesses. Set SLICC_FRESH_REAP=1 to explicitly reap the bridge holder.
 #
 # Usage:
 #   npm run dev:standalone:fresh
@@ -17,14 +17,111 @@
 #   - npx playwright install chromium
 set -euo pipefail
 
+canonicalize_port() {
+	local port="${1:-}"
+	case "$port" in
+	"" | *[!0-9]*) return 1 ;;
+	0 | 0*) return 1 ;;
+	esac
+	[ "${#port}" -le 5 ] || return 1
+	[ "$port" -le 65535 ] || return 1
+	printf '%s\n' "$port"
+}
+
+is_protected_port() {
+	case "${1:-}" in
+	9222 | 9223) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+bridge_port_guard_action() {
+	local port="${1:-}" holders="${2:-}" force_reap="${3:-0}"
+	if ! port="$(canonicalize_port "$port")"; then
+		echo "invalid"
+		return 0
+	fi
+	if is_protected_port "$port"; then
+		echo "protected"
+	elif [ -z "$holders" ]; then
+		echo "proceed"
+	elif [ "$force_reap" = "1" ]; then
+		echo "reap"
+	else
+		echo "fail-fast"
+	fi
+}
+
+reap_port() {
+	local requested_port="$1" port label="$2" pids pid
+	if ! port="$(canonicalize_port "$requested_port")"; then
+		echo "❌  Refusing to reap invalid port: $requested_port" >&2
+		return 1
+	fi
+	if is_protected_port "$port"; then
+		echo "❌  Refusing to reap protected Chrome/Electron CDP port :$port" >&2
+		return 1
+	fi
+	pids="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null || true)"
+	[ -z "$pids" ] && return 0
+	for pid in $pids; do
+		echo "♻️   Reaping stale pid $pid on :$port ($label) — TERM"
+		kill -TERM "$pid" 2>/dev/null || true
+	done
+	sleep 2
+	pids="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null || true)"
+	[ -z "$pids" ] && return 0
+	for pid in $pids; do
+		echo "♻️   pid $pid still bound to :$port — KILL"
+		kill -KILL "$pid" 2>/dev/null || true
+	done
+	sleep 1
+}
+
+# Allow Vitest to source and exercise the guard and protected-port refusal
+# without running browser discovery, builds, port checks, or harness processes.
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+	return 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
-BRIDGE_PORT="${PORT:-5710}"
-CDP_PORT="${CDP_PORT:-9222}"
+BRIDGE_PORT_INPUT="${PORT:-5710}"
+if ! BRIDGE_PORT="$(canonicalize_port "$BRIDGE_PORT_INPUT")"; then
+	echo "❌  PORT must be one decimal port from 1 to 65535: $BRIDGE_PORT_INPUT" >&2
+	exit 1
+fi
 WRANGLER_PORT="${WRANGLER_PORT:-8787}"
 
-# ── 1. Resolve the browser binary ────────────────────────────────────
+# ── 1. Guard the bridge port ─────────────────────────────────────────
+if is_protected_port "$BRIDGE_PORT"; then
+	echo "❌  Bridge port :$BRIDGE_PORT is reserved for Chrome/Electron CDP and cannot be reaped" >&2
+	exit 1
+fi
+
+BRIDGE_HOLDERS="$(lsof -nP -iTCP:"$BRIDGE_PORT" -sTCP:LISTEN 2>/dev/null || true)"
+case "$(bridge_port_guard_action "$BRIDGE_PORT" "$BRIDGE_HOLDERS" "${SLICC_FRESH_REAP:-0}")" in
+proceed) ;;
+reap) reap_port "$BRIDGE_PORT" "bridge" ;;
+invalid)
+	echo "❌  Refusing invalid bridge port: $BRIDGE_PORT" >&2
+	exit 1
+	;;
+fail-fast)
+	echo "❌  Bridge port :$BRIDGE_PORT is already in use:" >&2
+	printf '%s\n' "$BRIDGE_HOLDERS" >&2
+	echo "    Re-run with a different port, for example: PORT=5715 npm run dev:standalone:fresh" >&2
+	echo "    Or explicitly opt into reaping the bridge holder: SLICC_FRESH_REAP=1 npm run dev:standalone:fresh" >&2
+	exit 1
+	;;
+esac
+
+# Standalone node-server launches Chrome with requestedCdpPort = 0, so Chrome
+# self-selects its CDP port and slicc-cdp greps that port from the harness log.
+# Any process listening on :9222 is therefore foreign and must not be touched.
+
+# ── 2. Resolve the browser binary ────────────────────────────────────
 # Default: the newest Chrome for Testing from the Playwright cache, cloned
 # under a labeled bundle for ⌘-Tab distinguishability. Override by exporting
 # CHROME_PATH (a .app bundle or the inner binary) to launch your own browser
@@ -79,32 +176,6 @@ else
 		fi
 	fi
 fi
-
-# ── 2. Reap stale processes on OUR OWN ports (strictly port-scoped) ──
-# A prior hung run can leave a node-server holding :$BRIDGE_PORT or the
-# Chrome it launched holding CDP :$CDP_PORT.  Resolve the PID from the
-# specific listening port and kill ONLY that PID.  NEVER blanket-kill
-# "Google Chrome for Testing" by name — a concurrent swift (:5720/:9224)
-# / extension (:9333) / electron harness must survive.
-reap_port() {
-	local port="$1" label="$2" pids pid
-	pids="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null || true)"
-	[ -z "$pids" ] && return 0
-	for pid in $pids; do
-		echo "♻️   Reaping stale pid $pid on :$port ($label) — TERM"
-		kill -TERM "$pid" 2>/dev/null || true
-	done
-	sleep 2
-	pids="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null || true)"
-	[ -z "$pids" ] && return 0
-	for pid in $pids; do
-		echo "♻️   pid $pid still bound to :$port — KILL"
-		kill -KILL "$pid" 2>/dev/null || true
-	done
-	sleep 1
-}
-reap_port "$BRIDGE_PORT" "bridge"
-reap_port "$CDP_PORT" "Chrome CDP"
 
 # ── 3. Create an ephemeral profile (no production profiles touched) ──
 FRESH_PROFILE="$(mktemp -d)"

--- a/packages/dev-tools/tools/dev-standalone-fresh.sh
+++ b/packages/dev-tools/tools/dev-standalone-fresh.sh
@@ -17,6 +17,9 @@
 #   - npx playwright install chromium
 set -euo pipefail
 
+# Documented production bridge: valid when free, never eligible for automated reaping.
+PRODUCTION_BRIDGE_PORT=5710
+
 canonicalize_port() {
 	local port="${1:-}"
 	case "$port" in
@@ -45,6 +48,8 @@ bridge_port_guard_action() {
 		echo "protected"
 	elif [ -z "$holders" ]; then
 		echo "proceed"
+	elif [ "$force_reap" = "1" ] && [ "$port" = "$PRODUCTION_BRIDGE_PORT" ]; then
+		echo "production-protected"
 	elif [ "$force_reap" = "1" ]; then
 		echo "reap"
 	else
@@ -62,6 +67,10 @@ reap_port() {
 		echo "❌  Refusing to reap protected Chrome/Electron CDP port :$port" >&2
 		return 1
 	fi
+	if [ "$port" = "$PRODUCTION_BRIDGE_PORT" ]; then
+		echo "❌  Refusing to reap documented production bridge :$port. Choose a different port, or stop your own :$port process manually." >&2
+		return 1
+	fi
 	pids="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null || true)"
 	[ -z "$pids" ] && return 0
 	for pid in $pids; do
@@ -76,6 +85,20 @@ reap_port() {
 		kill -KILL "$pid" 2>/dev/null || true
 	done
 	sleep 1
+}
+
+print_bridge_port_suggestions() {
+	local requested_port="$1" port
+	if ! port="$(canonicalize_port "$requested_port")"; then
+		echo "    Choose a different unused bridge port." >&2
+		return 0
+	fi
+	echo "    Re-run with a different unused port: PORT=<unused-port> npm run dev:standalone:fresh" >&2
+	if [ "$port" = "$PRODUCTION_BRIDGE_PORT" ]; then
+		echo "    Automated reaping of :$port is disabled; stop your own :$port process manually instead." >&2
+	else
+		echo "    Or explicitly opt into reaping the bridge holder: SLICC_FRESH_REAP=1 PORT=$port npm run dev:standalone:fresh" >&2
+	fi
 }
 
 # Allow Vitest to source and exercise the guard and protected-port refusal
@@ -104,6 +127,10 @@ BRIDGE_HOLDERS="$(lsof -nP -iTCP:"$BRIDGE_PORT" -sTCP:LISTEN 2>/dev/null || true
 case "$(bridge_port_guard_action "$BRIDGE_PORT" "$BRIDGE_HOLDERS" "${SLICC_FRESH_REAP:-0}")" in
 proceed) ;;
 reap) reap_port "$BRIDGE_PORT" "bridge" ;;
+production-protected)
+	echo "❌  Refusing to reap documented production bridge :$BRIDGE_PORT. Choose a different port, or stop your own :$BRIDGE_PORT process manually." >&2
+	exit 1
+	;;
 invalid)
 	echo "❌  Refusing invalid bridge port: $BRIDGE_PORT" >&2
 	exit 1
@@ -111,8 +138,7 @@ invalid)
 fail-fast)
 	echo "❌  Bridge port :$BRIDGE_PORT is already in use:" >&2
 	printf '%s\n' "$BRIDGE_HOLDERS" >&2
-	echo "    Re-run with a different port, for example: PORT=5715 npm run dev:standalone:fresh" >&2
-	echo "    Or explicitly opt into reaping the bridge holder: SLICC_FRESH_REAP=1 npm run dev:standalone:fresh" >&2
+	print_bridge_port_suggestions "$BRIDGE_PORT"
 	exit 1
 	;;
 esac

--- a/packages/dev-tools/tools/dev-standalone-fresh.test.mjs
+++ b/packages/dev-tools/tools/dev-standalone-fresh.test.mjs
@@ -1,0 +1,99 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const scriptPath = resolve(dirname(fileURLToPath(import.meta.url)), 'dev-standalone-fresh.sh');
+
+function guardDecision(holders, forceReap = '0', port = '5715') {
+  return execFileSync(
+    'bash',
+    [
+      '-c',
+      'lsof() { :; }; kill() { :; }; source "$1"; bridge_port_guard_action "$2" "$3" "$4"',
+      'bash',
+      scriptPath,
+      port,
+      holders,
+      forceReap,
+    ],
+    { encoding: 'utf8' }
+  ).trim();
+}
+
+function canonicalPort(port) {
+  return execFileSync(
+    'bash',
+    ['-c', 'source "$1"; canonicalize_port "$2"', 'bash', scriptPath, port],
+    { encoding: 'utf8' }
+  ).trim();
+}
+
+function reapPort(port) {
+  return spawnSync(
+    'bash',
+    [
+      '-c',
+      'lsof() { :; }; kill() { :; }; source "$1"; reap_port "$2" test',
+      'bash',
+      scriptPath,
+      port,
+    ],
+    { encoding: 'utf8' }
+  );
+}
+
+describe('dev-standalone-fresh bridge port guard', () => {
+  it('proceeds when the bridge port has no listener', () => {
+    expect(guardDecision('')).toBe('proceed');
+  });
+
+  it('fails fast when the bridge port is occupied by default', () => {
+    expect(guardDecision('slicc-server 123 user')).toBe('fail-fast');
+  });
+
+  it('reaps an occupied bridge port only with the explicit opt-in', () => {
+    expect(guardDecision('node 456 user', '1')).toBe('reap');
+  });
+
+  it.each(['1', '5715', '65535'])('accepts canonical decimal port %s', (port) => {
+    expect(canonicalPort(port)).toBe(port);
+  });
+
+  it.each(['9222', '9223'])('refuses protected CDP port %s at both guard layers', (port) => {
+    expect(guardDecision('', '0', port)).toBe('protected');
+    expect(guardDecision('chrome 789 user', '1', port)).toBe('protected');
+
+    const result = reapPort(port);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(`protected Chrome/Electron CDP port :${port}`);
+  });
+
+  it.each([
+    '09222',
+    '0009222',
+    ' 9222',
+    '9222 ',
+    '+9222',
+    '\t9222',
+    '-9222',
+    '0x2406',
+    '022026',
+    '9222\n',
+    '$(printf 9222)',
+    '*',
+    '9222-9222',
+    '9222,9223',
+    '9222,5710',
+    'not-a-port',
+    '',
+    '0',
+    '65536',
+  ])('rejects invalid port encoding %j before any reap decision', (port) => {
+    expect(guardDecision('chrome 789 user', '1', port)).toBe('invalid');
+
+    const result = reapPort(port);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Refusing to reap invalid port:');
+  });
+});

--- a/packages/dev-tools/tools/dev-standalone-fresh.test.mjs
+++ b/packages/dev-tools/tools/dev-standalone-fresh.test.mjs
@@ -43,6 +43,20 @@ function reapPort(port) {
   );
 }
 
+function bridgeSuggestions(port) {
+  return execFileSync(
+    'bash',
+    [
+      '-c',
+      'lsof() { :; }; kill() { :; }; source "$1"; print_bridge_port_suggestions "$2" 2>&1',
+      'bash',
+      scriptPath,
+      port,
+    ],
+    { encoding: 'utf8' }
+  );
+}
+
 describe('dev-standalone-fresh bridge port guard', () => {
   it('proceeds when the bridge port has no listener', () => {
     expect(guardDecision('')).toBe('proceed');
@@ -54,6 +68,37 @@ describe('dev-standalone-fresh bridge port guard', () => {
 
   it('reaps an occupied bridge port only with the explicit opt-in', () => {
     expect(guardDecision('node 456 user', '1')).toBe('reap');
+  });
+
+  it('keeps the production bridge usable when it is free', () => {
+    expect(guardDecision('', '0', '5710')).toBe('proceed');
+    expect(guardDecision('', '1', '5710')).toBe('proceed');
+  });
+
+  it('refuses forced reaping of the production bridge at both guard layers', () => {
+    expect(guardDecision('slicc-server 123 user', '1', '5710')).toBe('production-protected');
+
+    const result = reapPort('5710');
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Choose a different port');
+    expect(result.stderr).toContain('stop your own :5710 process manually');
+  });
+
+  it.each(['05710', '5710-5710'])(
+    'rejects alternate production-port spelling %j at both guard layers',
+    (port) => {
+      expect(guardDecision('slicc-server 123 user', '1', port)).toBe('invalid');
+
+      const result = reapPort(port);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain('Refusing to reap invalid port:');
+    }
+  );
+
+  it('carries the resolved bridge port into the forced-reap retry suggestion', () => {
+    const output = bridgeSuggestions('5715');
+    expect(output).toContain('SLICC_FRESH_REAP=1 PORT=5715 npm run dev:standalone:fresh');
+    expect(output).toContain('PORT=<unused-port> npm run dev:standalone:fresh');
   });
 
   it.each(['1', '5715', '65535'])('accepts canonical decimal port %s', (port) => {


### PR DESCRIPTION
## Summary

Prevents the standalone fresh-development harness from killing a foreign SLICC bridge or Chrome/Electron CDP listener. The smoke-test runbook now uses an isolated bridge lane on port 5715, preserves the production listeners on ports 5710 and 9222, and uses the same SLICC_HARNESS_LOG path as the slicc-cdp helper.

## Why

The harness previously reaped whatever occupied its default ports. The bridge defaulted to 5710, which is also the production SLICC bridge, and the cleanup path targeted 9222 even though standalone node-server requests CDP port 0 and lets Chrome select an available port. In standalone mode, reaping 9222 was therefore purely destructive: it could only terminate a foreign browser.

## Approach / Implementation notes

- Fail fast when the selected bridge port is occupied, reporting its holder. Reaping requires the explicit SLICC_FRESH_REAP=1 opt-in.
- Refuse ports 9222 and 9223 unconditionally at both the guard-decision layer and the reap function.
- Accept only canonical decimal ports from 1 through 65535. This is deliberate: alternate spellings are rejected rather than normalized before lsof is called.
- Add regression coverage for protected ports and 19 invalid/rejection spellings. The test helpers stub lsof and kill, so the suite cannot signal a real process even if the guard regresses.
- Update the smoke-test instructions to use PORT=5715 with production PID preflight/postflight checks.
- Align SLICC_HARNESS_LOG between the runbook and slicc-cdp so CDP auto-detection reads the correct lane-specific log.

### Verification history

Three review rounds closed successive bypasses:

1. Added the missing occupied-port and protected-CDP safeguards.
2. Removed a string-versus-lsof mismatch that allowed spellings such as 09222 and 9222-9222 to reach the reap path.
3. Expanded regression coverage to include all identified alternate spellings at both guard layers.

### Live verification on an isolated lane

The port-0 claim above was confirmed empirically, not just by reading the code. Two independent harness runs on an isolated `PORT=5715` lane, one on this branch's overlay against PR #1767 and one against `origin/main`:

| Run | Explicit `CDP_PORT` | Actual CDP listener |
| --- | --- | --- |
| PR #1767 worktree | 9230 | 57939 |
| `origin/main` worktree | unset | 61385 |

In both runs the harness ignored the requested CDP port and Chrome self-selected a high ephemeral port. Neither run bound 9222 or 9223. This is the direct evidence that the previous unconditional `reap_port "$CDP_PORT"` on 9222 could never have cleaned up after a standalone run, and could only ever have terminated an unrelated browser.

No guard refusal fired during either legitimate run, so the added protections do not block ordinary isolated-lane use.

Teardown finding folded into the runbook: stopping the harness through the script manager removes both lane listeners without signalling any PID, which is preferable to resolving and terminating lane PIDs by hand.

## Cross-cutting impact

This changes only the standalone developer harness and its developer/smoke-test guidance. It does not change production runtime behavior, node-server port allocation, the Chrome extension, Electron, Swift, or follower wiring.

Scoped follow-up: dev-swift-fresh.sh, dev-extension-fresh.sh, dev-electron-node-fresh.sh, and dev-electron-swift-fresh.sh have not yet been audited for equivalent unguarded reaping. They are intentionally not changed in this PR.

## Test plan

Coordinator-verified before push:

- [x] Focused dev-tools suite: 27/27 passing
- [x] npm run lint
- [x] npm run typecheck
- [x] check-touched-exemptions.mjs origin/main: 6 changed files, 0 debt-list matches
- [x] Guard call paths reviewed; test lsof/kill helpers confirmed non-signaling
- [x] Production slicc-server on 5710 and Chrome on 9222 remained alive and untouched throughout verification
- [x] Two isolated-lane harness runs on PORT=5715 completed with production 5710/9222 PIDs verified unchanged at preflight and postflight
- [x] Confirmed no guard refusal fires on a legitimate isolated lane

CI will run the remaining repository-wide gates.

## Documentation

- [x] Relevant package CLAUDE.md
- [x] docs/development.md
- [x] Developer smoke-test skill and slicc-cdp helper guidance

## Risk & rollback

The blast radius is limited to the standalone fresh-development harness. The main compatibility risk is an intentional behavior change for users who previously relied on automatic bridge reaping; they must now select a free bridge or explicitly opt in for a confirmed stale harness they own. Rollback is a clean revert of this PR; there is no persisted state or migration.

## Checklist

- [x] Commit is focused and conventional
- [x] No files under dist were edited
- [x] No secrets or credentials were added
- [x] The changed harness contract is reflected in developer and agent guidance


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author