### PR TITLE
fix(release): gate the @ai-ecoverse/biome-jsh npm publish on source changes

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,18 +12,10 @@
       }
     ],
     [
-      "@semantic-release/npm",
-      {
-        "npmPublish": true,
-        "provenance": true,
-        "pkgRoot": "packages/dev-tools/biome-jsh"
-      }
-    ],
-    [
       "@semantic-release/exec",
       {
-        "prepareCmd": "SLICC_RELEASED_AT=\"$(date -u +'%Y-%m-%dT%H:%M:%SZ')\" npm run build && npm run package:release && node packages/dev-tools/tools/release-native.mjs --last='${lastRelease.gitTag}' --next='${nextRelease.version}'",
-        "publishCmd": "SLICC_LAST_RELEASE_TAG='${lastRelease.gitTag}' npm run publish:worker && node packages/dev-tools/tools/release-native.mjs --gate=chrome --last='${lastRelease.gitTag}'"
+        "prepareCmd": "SLICC_RELEASED_AT=\"$(date -u +'%Y-%m-%dT%H:%M:%SZ')\" npm run build && npm run package:release && node packages/dev-tools/tools/release-native.mjs --last='${lastRelease.gitTag}' --next='${nextRelease.version}' && node packages/dev-tools/tools/release-native.mjs --gate=biome-jsh-version --last='${lastRelease.gitTag}' --next='${nextRelease.version}'",
+        "publishCmd": "SLICC_LAST_RELEASE_TAG='${lastRelease.gitTag}' npm run publish:worker && node packages/dev-tools/tools/release-native.mjs --gate=chrome --last='${lastRelease.gitTag}' && node packages/dev-tools/tools/release-native.mjs --gate=biome-jsh --last='${lastRelease.gitTag}'"
       }
     ],
     [

--- a/docs/development.md
+++ b/docs/development.md
@@ -57,6 +57,8 @@ The **Chrome Web Store publish** (`npm run publish:chrome`) is gated the same wa
 - CLI entrypoint: `slicc`
 - Node requirement: `>=22`
 
+`@ai-ecoverse/biome-jsh` (`packages/dev-tools/biome-jsh/`) is published **conditionally**, not on every release: `packages/dev-tools/tools/release-native.mjs --gate=biome-jsh-version` stamps the release version into its `package.json` during `prepareCmd` (committed by `@semantic-release/git`) and `--gate=biome-jsh` runs `npm publish` during `publishCmd`, both only when `packages/dev-tools/biome-jsh/` changed since the previous tag (or on a first release). Otherwise the package stays at its last published version instead of republishing an identical tarball.
+
 ### Required repo configuration
 
 - Release branch: semantic-release is configured for `main` only.

--- a/packages/dev-tools/CLAUDE.md
+++ b/packages/dev-tools/CLAUDE.md
@@ -34,7 +34,7 @@ This file covers the repo's developer-tooling surface.
 - **Optional-binary guard**: `packages/dev-tools/tools/run-if-installed.mjs <binary> [args...]` — runs a command only when its binary resolves on `PATH`, otherwise warns and exits 0. Used by the root `lint-staged` Swift/Go globs so a missing `swiftlint`/`gofmt` cannot break `git commit`.
 - **Cross-impl mask vectors**: `packages/dev-tools/tools/gen-mask-vectors.mjs` — regenerate pinned mask vectors for TS/Swift parity tests after intentional masking changes.
 - **Preflight deps check**: `packages/dev-tools/tools/preflight-deps.mjs` — fast `npm ci` staleness check wired via `pretypecheck` and `pretest` scripts.
-- **Release gating**: `packages/dev-tools/tools/release-native.mjs` — gates native macOS/iOS packaging, the signed + notarized `slicc` Go CLI binaries (`packages/slicc-cli/sign-and-package.sh`), and Chrome Web Store/worker publish steps on whether relevant source changed since the last tag.
+- **Release gating**: `packages/dev-tools/tools/release-native.mjs` — gates native macOS/iOS packaging, the signed + notarized `slicc` Go CLI binaries (`packages/slicc-cli/sign-and-package.sh`), Chrome Web Store/worker publish steps, and the `@ai-ecoverse/biome-jsh` npm release (`--gate=biome-jsh-version` in prepare, `--gate=biome-jsh` in publish) on whether relevant source changed since the last tag.
 
 ### SLICC CDP Debug Toolkit
 

--- a/packages/dev-tools/biome-jsh/README.md
+++ b/packages/dev-tools/biome-jsh/README.md
@@ -74,11 +74,13 @@ Any already-installed Biome is reused, so no fresh install is required.
 
 ## Published package
 
-Published to npm as **`@ai-ecoverse/biome-jsh`** (public), released **in lockstep
-with SLICC** via slicc's semantic-release pipeline — its version tracks the
-`sliccy` release version (see the second `@semantic-release/npm` target with
-`pkgRoot: packages/dev-tools/biome-jsh` in `.releaserc.json`). Downstream repos
-consume it as a dev dependency:
+Published to npm as **`@ai-ecoverse/biome-jsh`** (public) by slicc's
+semantic-release pipeline, but only on releases that actually change this
+directory — the `--gate=biome-jsh-version` / `--gate=biome-jsh` steps in
+`.releaserc.json` (see `packages/dev-tools/tools/release-native.mjs`) skip the
+version stamp and the publish otherwise, so unchanged code is never republished.
+Published versions are still SLICC release versions, just not every one of them.
+Downstream repos consume it as a dev dependency:
 
 ```sh
 npm i -D @ai-ecoverse/biome-jsh

--- a/packages/dev-tools/tools/release-native.mjs
+++ b/packages/dev-tools/tools/release-native.mjs
@@ -82,6 +82,11 @@ export const WORKER_PATH_PREFIXES = [
 // under a new version number.
 export const BIOME_JSH_PATH_PREFIXES = ['packages/dev-tools/biome-jsh/'];
 
+// Files inside the package that never reach the tarball (the `files` array ships
+// only biome-jsh.mjs, lib.mjs, jsh-biome-source.mjs and README.md), so a change
+// confined to them would publish a byte-identical tarball.
+export const BIOME_JSH_IGNORED_PATTERN = /\.test\.mjs$/;
+
 // Command strings preserve the current .releaserc.json fail-fast behavior
 // (chmod then run; a non-zero exit throws out of execSync).
 export const MACOS_SCRIPT_CMD =
@@ -181,7 +186,9 @@ export function decideBiomeJshGating({ lastTag, changedFiles = [] } = {}) {
     return { biomeJsh: true, firstRelease: true };
   }
   return {
-    biomeJsh: changedFiles.some((f) => matchesAnyPrefix(f, BIOME_JSH_PATH_PREFIXES)),
+    biomeJsh: changedFiles
+      .filter((f) => !BIOME_JSH_IGNORED_PATTERN.test(f))
+      .some((f) => matchesAnyPrefix(f, BIOME_JSH_PATH_PREFIXES)),
     firstRelease: false,
   };
 }

--- a/packages/dev-tools/tools/release-native.mjs
+++ b/packages/dev-tools/tools/release-native.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 // Gate the native macOS (Sliccstart DMG + update ZIP) and iOS (TestFlight)
 // packaging steps of the semantic-release prepareCmd — and the Chrome Web Store
-// publish steps of the publishCmd (`--gate=chrome` / `--gate=worker`) — on whether
-// their relevant source changed since the previous release tag. The always-run
-// build/package steps stay in .releaserc.json; only gated steps are decided here.
+// publish steps of the publishCmd (`--gate=chrome` / `--gate=worker`) — plus the
+// `@ai-ecoverse/biome-jsh` npm release (`--gate=biome-jsh-version` in prepare,
+// `--gate=biome-jsh` in publish) — on whether their relevant source changed since
+// the previous release tag. The always-run build/package steps stay in
+// .releaserc.json; only gated steps are decided here.
 //
 // The pure decision helpers (no IO) are unit-tested by the `dev-tools` vitest
 // project via the co-located release-native.test.mjs. Only main() touches git
@@ -73,6 +75,13 @@ export const WORKER_PATH_PREFIXES = [
   'package-lock.json',
 ];
 
+// APPROVED relevant path set for the standalone `@ai-ecoverse/biome-jsh` npm
+// package. It ships only its own directory (see its package.json `files`) and
+// resolves the Biome binary at runtime, so it has no other build inputs — a
+// SLICC release that touches nothing here would publish a byte-identical tarball
+// under a new version number.
+export const BIOME_JSH_PATH_PREFIXES = ['packages/dev-tools/biome-jsh/'];
+
 // Command strings preserve the current .releaserc.json fail-fast behavior
 // (chmod then run; a non-zero exit throws out of execSync).
 export const MACOS_SCRIPT_CMD =
@@ -87,6 +96,11 @@ export const IOS_SCRIPT_CMD =
 export const SLICC_CLI_SCRIPT = 'packages/slicc-cli/sign-and-package.sh';
 // A failing publish must fail the release (fail-fast preserved via execSync).
 export const CHROME_PUBLISH_CMD = 'npm run publish:chrome';
+// biome-jsh is published from its own directory (it is not an npm workspace of
+// the root package). `--provenance` / `--access public` mirror the settings the
+// former second @semantic-release/npm target used.
+export const BIOME_JSH_PUBLISH_CMD =
+  'npm publish packages/dev-tools/biome-jsh --provenance --access public';
 
 // An empty / unset / placeholder tag means "first release" — build both.
 export function isFirstRelease(lastTag) {
@@ -154,6 +168,20 @@ export function decideWorkerGating({ lastTag, changedFiles = [] } = {}) {
   }
   return {
     worker: changedFiles.some((f) => matchesAnyPrefix(f, WORKER_PATH_PREFIXES)),
+    firstRelease: false,
+  };
+}
+
+// Core gating decision for the @ai-ecoverse/biome-jsh npm release. The same
+// decision drives both phases — the prepare-phase version bump and the
+// publish-phase `npm publish` — so a published version always matches the
+// version committed back by @semantic-release/git.
+export function decideBiomeJshGating({ lastTag, changedFiles = [] } = {}) {
+  if (isFirstRelease(lastTag)) {
+    return { biomeJsh: true, firstRelease: true };
+  }
+  return {
+    biomeJsh: changedFiles.some((f) => matchesAnyPrefix(f, BIOME_JSH_PATH_PREFIXES)),
     firstRelease: false,
   };
 }
@@ -237,22 +265,53 @@ function writeKnownGoodPointer(version, targetPath = KNOWN_GOOD_MACOS_PATH) {
   return pointer;
 }
 
-const HELP = `release-native — gate native packaging, worker deploy, and Chrome publish on source changes
+// Repo path of the biome-jsh package manifest, resolved relative to this script
+// so it works from any cwd.
+export const BIOME_JSH_PKG_JSON_PATH = fileURLToPath(
+  new URL('../biome-jsh/package.json', import.meta.url)
+);
+
+// Pure helper (no IO): the biome-jsh manifest with `version` set to the release
+// version. Trims a leading `v` (git-tag style). Throws on empty so the caller
+// must decide whether to skip.
+export function buildBiomeJshManifest(manifest, version) {
+  const v = (typeof version === 'string' ? version : '').trim().replace(/^v/, '');
+  if (!v) throw new Error('buildBiomeJshManifest: a non-empty version is required');
+  return { ...manifest, version: v };
+}
+
+// Small IO wrapper: stamp the release version into the biome-jsh manifest,
+// preserving the checked-in 2-space + trailing-newline format.
+function writeBiomeJshVersion(version, targetPath = BIOME_JSH_PKG_JSON_PATH) {
+  const current = JSON.parse(readFileSync(targetPath, 'utf8'));
+  const manifest = buildBiomeJshManifest(current, version);
+  writeFileSync(targetPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+const HELP = `release-native — gate native packaging, worker deploy, Chrome publish, and the biome-jsh npm release on source changes
 
 Usage:
-  node packages/dev-tools/tools/release-native.mjs --last=<tag> [--gate=chrome|worker] [--dry-run]
+  node packages/dev-tools/tools/release-native.mjs --last=<tag> [--gate=chrome|worker|biome-jsh|biome-jsh-version] [--dry-run]
 
 Options:
   --last=<tag>   Previous release git tag. Empty => first release => run ALL gated steps.
                  In .releaserc.json use --last='\${lastRelease.gitTag}'.
   --next=<ver>   Next release version. When the macOS gate is open and its packaging
                  step succeeds (non-dry-run), record it in the committed known-good
-                 macOS pointer. Empty => skip the pointer update (never fails the release).
+                 macOS pointer. Also the version stamped into the biome-jsh manifest by
+                 --gate=biome-jsh-version. Empty => skip the pointer update / version
+                 stamp (never fails the release).
                  In .releaserc.json use --next='\${nextRelease.version}'.
   --gate=chrome  Gate the Chrome Web Store publish (\`${CHROME_PUBLISH_CMD}\`) instead of
                  the default native macOS/iOS packaging.
   --gate=worker  Print "deploy" when the production worker/UI should deploy, otherwise
                  print "skip". This decision mode never runs the deploy itself.
+  --gate=biome-jsh-version
+                 Prepare phase: stamp --next into packages/dev-tools/biome-jsh/package.json
+                 (committed by @semantic-release/git) only when the biome-jsh gate is open.
+  --gate=biome-jsh
+                 Publish phase: run \`${BIOME_JSH_PUBLISH_CMD}\` only when the gate is open.
   --classify-deploy-log=<path>
                  Read a captured \`wrangler deploy\` log and print "routes-only" when the
                  ONLY failure was route reconciliation (the script + assets deployed and
@@ -271,6 +330,9 @@ Behavior:
     ${EXTENSION_PATH_PREFIXES.join(', ')} changed.
   - --gate=worker: use the same resolved diff ref and print deploy only if one of
     ${WORKER_PATH_PREFIXES.join(', ')} changed.
+  - --gate=biome-jsh[-version]: use the same resolved diff ref and bump / publish
+    @ai-ecoverse/biome-jsh only if ${BIOME_JSH_PATH_PREFIXES.join(', ')} changed, so the
+    package is not republished unchanged on every SLICC release.
   - A failing packaging / publish script fails the release (fail-fast preserved).`;
 
 export function getChangedFiles(lastTag) {
@@ -360,6 +422,50 @@ function runNativeGate(args, changedFiles) {
   }
 }
 
+// biome-jsh gate. Two phases share one decision: `--gate=biome-jsh-version`
+// stamps the release version into the manifest during prepare (so
+// @semantic-release/git commits it), `--gate=biome-jsh` publishes during publish.
+// A closed gate leaves the manifest at the last published version.
+function runBiomeJshGate(args, changedFiles) {
+  const publishPhase = args.gate === 'biome-jsh';
+  const decision = decideBiomeJshGating({ lastTag: args.last, changedFiles });
+
+  if (!decision.biomeJsh) {
+    console.log(
+      `[release-native] Skipping @ai-ecoverse/biome-jsh ${publishPhase ? 'npm publish' : 'version stamp'} (no packages/dev-tools/biome-jsh changes).`
+    );
+    return;
+  }
+
+  if (publishPhase) {
+    runStep(
+      '@ai-ecoverse/biome-jsh (npm)',
+      BIOME_JSH_PUBLISH_CMD,
+      args.dryRun,
+      'Publishing',
+      'publish'
+    );
+    return;
+  }
+
+  if (args.dryRun) {
+    console.log(
+      `[release-native] (dry-run) would stamp @ai-ecoverse/biome-jsh version ${args.next}.`
+    );
+    return;
+  }
+
+  if (!args.next.trim()) {
+    console.warn(
+      '[release-native] --next is empty; skipping the @ai-ecoverse/biome-jsh version stamp.'
+    );
+    return;
+  }
+
+  const manifest = writeBiomeJshVersion(args.next);
+  console.log(`[release-native] Stamped @ai-ecoverse/biome-jsh version → ${manifest.version}.`);
+}
+
 export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   if (args.help) {
@@ -377,6 +483,11 @@ export function main(argv = process.argv.slice(2)) {
   if (args.gate === 'worker') {
     const decision = decideWorkerGating({ lastTag: args.last, changedFiles });
     console.log(decision.worker ? 'deploy' : 'skip');
+    return 0;
+  }
+
+  if (args.gate === 'biome-jsh' || args.gate === 'biome-jsh-version') {
+    runBiomeJshGate(args, changedFiles);
     return 0;
   }
 

--- a/packages/dev-tools/tools/release-native.mjs
+++ b/packages/dev-tools/tools/release-native.mjs
@@ -288,7 +288,9 @@ export function buildBiomeJshManifest(manifest, version) {
 }
 
 // Small IO wrapper: stamp the release version into the biome-jsh manifest,
-// preserving the checked-in 2-space + trailing-newline format.
+// preserving the checked-in 2-space + trailing-newline format. The re-serialize
+// is intentionally opinionated — any other formatting in the manifest gets
+// canonicalized to that shape (matching root package.json / `npm init`).
 function writeBiomeJshVersion(version, targetPath = BIOME_JSH_PKG_JSON_PATH) {
   const current = JSON.parse(readFileSync(targetPath, 'utf8'));
   const manifest = buildBiomeJshManifest(current, version);

--- a/packages/dev-tools/tools/release-native.test.mjs
+++ b/packages/dev-tools/tools/release-native.test.mjs
@@ -488,6 +488,39 @@ describe('decideBiomeJshGating', () => {
       })
     ).toEqual({ biomeJsh: false, firstRelease: false });
   });
+
+  it('skips a test-only change inside the package (not in the tarball)', () => {
+    expect(
+      decideBiomeJshGating({
+        lastTag: 'v5.91.1',
+        changedFiles: [
+          'packages/dev-tools/biome-jsh/lib.test.mjs',
+          'packages/dev-tools/biome-jsh/biome-jsh.test.mjs',
+        ],
+      })
+    ).toEqual({ biomeJsh: false, firstRelease: false });
+  });
+
+  it('publishes when a shipped file changes alongside its test', () => {
+    expect(
+      decideBiomeJshGating({
+        lastTag: 'v5.91.1',
+        changedFiles: [
+          'packages/dev-tools/biome-jsh/lib.test.mjs',
+          'packages/dev-tools/biome-jsh/lib.mjs',
+        ],
+      })
+    ).toEqual({ biomeJsh: true, firstRelease: false });
+  });
+
+  it('publishes for a README change (README.md ships in the tarball)', () => {
+    expect(
+      decideBiomeJshGating({
+        lastTag: 'v5.91.1',
+        changedFiles: ['packages/dev-tools/biome-jsh/README.md'],
+      })
+    ).toEqual({ biomeJsh: true, firstRelease: false });
+  });
 });
 
 describe('buildBiomeJshManifest', () => {

--- a/packages/dev-tools/tools/release-native.test.mjs
+++ b/packages/dev-tools/tools/release-native.test.mjs
@@ -15,7 +15,10 @@ vi.mock('node:child_process', async (importActual) => {
 import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import {
+  BIOME_JSH_PATH_PREFIXES,
+  buildBiomeJshManifest,
   buildKnownGoodPointer,
+  decideBiomeJshGating,
   decideChromeGating,
   decideGating,
   decideSliccCliGating,
@@ -455,6 +458,61 @@ describe('decideWorkerGating', () => {
   });
 });
 
+describe('decideBiomeJshGating', () => {
+  it('publishes on first release with an empty last tag', () => {
+    expect(decideBiomeJshGating({ lastTag: '', changedFiles: [] })).toEqual({
+      biomeJsh: true,
+      firstRelease: true,
+    });
+  });
+
+  it('publishes for a change inside the package', () => {
+    expect(BIOME_JSH_PATH_PREFIXES).toContain('packages/dev-tools/biome-jsh/');
+    expect(
+      decideBiomeJshGating({
+        lastTag: 'v5.91.1',
+        changedFiles: ['packages/dev-tools/biome-jsh/lib.mjs'],
+      })
+    ).toEqual({ biomeJsh: true, firstRelease: false });
+  });
+
+  it('skips a SLICC release that touched nothing in the package', () => {
+    expect(
+      decideBiomeJshGating({
+        lastTag: 'v5.91.1',
+        changedFiles: [
+          'packages/webapp/src/main.ts',
+          'packages/dev-tools/tools/release-native.mjs',
+          'docs/development.md',
+        ],
+      })
+    ).toEqual({ biomeJsh: false, firstRelease: false });
+  });
+});
+
+describe('buildBiomeJshManifest', () => {
+  const manifest = { name: '@ai-ecoverse/biome-jsh', version: '5.85.2', main: './lib.mjs' };
+
+  it('sets the version and preserves the other fields and their order', () => {
+    expect(buildBiomeJshManifest(manifest, '5.92.0')).toEqual({
+      name: '@ai-ecoverse/biome-jsh',
+      version: '5.92.0',
+      main: './lib.mjs',
+    });
+    expect(Object.keys(buildBiomeJshManifest(manifest, '5.92.0'))).toEqual(Object.keys(manifest));
+  });
+
+  it('trims a leading v (git-tag style) and surrounding whitespace', () => {
+    expect(buildBiomeJshManifest(manifest, ' v5.92.0 ').version).toBe('5.92.0');
+  });
+
+  it('throws on empty / whitespace / non-string input', () => {
+    expect(() => buildBiomeJshManifest(manifest, '')).toThrow();
+    expect(() => buildBiomeJshManifest(manifest, '   ')).toThrow();
+    expect(() => buildBiomeJshManifest(manifest, undefined)).toThrow();
+  });
+});
+
 describe('parseArgs', () => {
   it('parses --last= inline form (as passed by the release template)', () => {
     expect(parseArgs(['--last=v1.2.3'])).toEqual({
@@ -592,6 +650,32 @@ describe('main native gate — dry-run', () => {
     } finally {
       logSpy.mockRestore();
       warnSpy.mockRestore();
+    }
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('main biome-jsh gate', () => {
+  it('does not stamp the manifest when nothing in the package changed', () => {
+    // execFileSync is mocked, so getChangedFiles resolves to an empty file list
+    // => the gate is closed and the version stamp must be skipped.
+    writeFileSync.mockClear();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      expect(main(['--gate=biome-jsh-version', '--last=v5.91.1', '--next=5.92.0'])).toBe(0);
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('does not stamp the manifest on a dry-run with the gate open', () => {
+    writeFileSync.mockClear();
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      expect(main(['--gate=biome-jsh-version', '--last=', '--next=5.92.0', '--dry-run'])).toBe(0);
+    } finally {
+      logSpy.mockRestore();
     }
     expect(writeFileSync).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Problem

`@ai-ecoverse/biome-jsh` was a second `@semantic-release/npm` target in `.releaserc.json`, so every SLICC release republished a byte-identical tarball under a new version number.

## Solution

Move both the version stamp (prepare) and the `npm publish` (publish) into `release-native.mjs` behind the same changed-files gate the native/Chrome/worker steps already use — the two phases share one decision (`decideBiomeJshGating`) so a published version always matches what `@semantic-release/git` commits back. A closed gate leaves the manifest at its last published version.

## Testing

Unit tests for the gating decision, the manifest builder, and the `main()` dry-run/closed-gate paths (74 pass). Biome + `lint:docs` clean.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KYSKGHZTWEK6CF780VQQRDW5&panel=chat)