### PR TITLE
test(e2e): stabilize text-only turn synchronization

### DIFF
--- a/packages/webapp/tests/e2e/reference-scenario.test.ts
+++ b/packages/webapp/tests/e2e/reference-scenario.test.ts
@@ -168,10 +168,20 @@ test.describe('fake-llm reference scenario', () => {
     // only (no tool call) — proves both the regex path and a
     // text-only terminal turn.
     await submitUserMessage(page, 'give me a summary');
-    await waitForTurnComplete(page);
-
     await expect(page.locator('slicc-chat-thread')).toContainText(
-      'Summary: opened three CDP targets'
+      'Summary: opened three CDP targets',
+      { timeout: 20_000 }
+    );
+    // A text-only fake response can rise and fall between processing-state
+    // polls. Synchronize on its terminal text first, then the level-triggered
+    // idle state so a missed transient edge cannot consume the test budget.
+    await page.waitForFunction(
+      () => {
+        const frame = document.querySelector('.wcui-frame');
+        return frame !== null && !frame.hasAttribute('data-processing');
+      },
+      undefined,
+      { timeout: 20_000 }
     );
 
     await expect


### PR DESCRIPTION
**Problem**
PR #1762 exposed a race where a fast text-only turn completed before the E2E harness observed the transient processing edge.

**Solution**
Wait for terminal transcript text, then the level-triggered idle state, avoiding an unnecessary 8-second rise timeout.

**Testing**
- CI-mode reference scenario repeated 5× (5/5 passed)

**Misc**
- Full unit/coverage runs hit two unrelated IPK 5-second timeouts; JS builds passed, while the aggregate build stopped at the unavailable Swift toolchain.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KYQFZP4SSC1GD7VF9RME6W4R&panel=chat)