### PR TITLE
test(protocol): guard nested payload fields and the AgentEvent union in the tray-sync corpus

### DIFF
--- a/packages/dev-tools/tools/generate-tray-sync-corpus.ts
+++ b/packages/dev-tools/tools/generate-tray-sync-corpus.ts
@@ -9,16 +9,40 @@
  * script is the fix it suggests.
  */
 
-import { writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildCorpusDocument } from '../../webapp/src/scoops/tray-sync-protocol-corpus.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
+const swiftMirror = resolve(here, '../../ios-app/SliccFollower/Models/SyncProtocol.swift');
 const out = resolve(
   here,
   '../../ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json'
 );
 
-writeFileSync(out, `${JSON.stringify(buildCorpusDocument(), null, 2)}\n`);
-console.log(`Wrote ${out}`);
+const document = buildCorpusDocument();
+
+// `@slicc/shared-ts` resolves types from `src/` but RUNTIME from `dist/`, so a
+// stale or missing `dist` hands this script an out-of-date
+// `TRAY_SYNC_PROTOCOL_VERSION` and it writes a wrong version with exit 0. The
+// Swift suite asserts the two are equal, so that lands as a confusing iOS-only
+// CI failure far from the cause. Cross-check here and fail loudly instead.
+const swiftSource = readFileSync(swiftMirror, 'utf8');
+const swiftVersion = Number(
+  /^\s*let traySyncProtocolVersion\s*=\s*(\d+)/m.exec(swiftSource)?.[1] ?? Number.NaN
+);
+if (!Number.isInteger(swiftVersion)) {
+  throw new Error(`Could not read 'let traySyncProtocolVersion' from ${swiftMirror}`);
+}
+if (document.traySyncProtocolVersion !== swiftVersion) {
+  throw new Error(
+    `Refusing to write a corpus with traySyncProtocolVersion=${document.traySyncProtocolVersion} ` +
+      `while the Swift mirror declares ${swiftVersion}.\n` +
+      'If this is an intentional protocol bump, update SyncProtocol.swift in the same change. ' +
+      'Otherwise your @slicc/shared-ts dist/ is stale — run: npm run build -w @slicc/shared-ts'
+  );
+}
+
+writeFileSync(out, `${JSON.stringify(document, null, 2)}\n`);
+console.log(`Wrote ${out} (protocol version ${swiftVersion})`);

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json
@@ -722,6 +722,12 @@
     {
       "type": "content_delta",
       "ios": "decoded",
+      "mirrored": [
+        "messageId",
+        "text",
+        "type"
+      ],
+      "dropped": [],
       "event": {
         "type": "content_delta",
         "messageId": "m2",
@@ -731,6 +737,14 @@
     {
       "type": "content_done",
       "ios": "decoded",
+      "mirrored": [
+        "messageId",
+        "type"
+      ],
+      "dropped": [
+        "model",
+        "usage"
+      ],
       "event": {
         "type": "content_done",
         "messageId": "m2",
@@ -753,6 +767,11 @@
     {
       "type": "error",
       "ios": "decoded",
+      "mirrored": [
+        "error",
+        "type"
+      ],
+      "dropped": [],
       "event": {
         "type": "error",
         "error": "boom"
@@ -761,6 +780,11 @@
     {
       "type": "message_start",
       "ios": "decoded",
+      "mirrored": [
+        "messageId",
+        "type"
+      ],
+      "dropped": [],
       "event": {
         "type": "message_start",
         "messageId": "m2"
@@ -769,6 +793,13 @@
     {
       "type": "screenshot",
       "ios": "unknown",
+      "mirrored": [
+        "type"
+      ],
+      "dropped": [
+        "base64",
+        "url"
+      ],
       "event": {
         "type": "screenshot",
         "base64": "iVBORw0KGgo=",
@@ -778,6 +809,12 @@
     {
       "type": "terminal_output",
       "ios": "unknown",
+      "mirrored": [
+        "type"
+      ],
+      "dropped": [
+        "text"
+      ],
       "event": {
         "type": "terminal_output",
         "text": "$ ls\nnotes.md\n"
@@ -786,6 +823,14 @@
     {
       "type": "tool_result",
       "ios": "decoded",
+      "mirrored": [
+        "isError",
+        "messageId",
+        "result",
+        "toolName",
+        "type"
+      ],
+      "dropped": [],
       "event": {
         "type": "tool_result",
         "messageId": "m2",
@@ -797,6 +842,15 @@
     {
       "type": "tool_ui",
       "ios": "unknown",
+      "mirrored": [
+        "type"
+      ],
+      "dropped": [
+        "html",
+        "messageId",
+        "requestId",
+        "toolName"
+      ],
       "event": {
         "type": "tool_ui",
         "messageId": "m2",
@@ -808,6 +862,13 @@
     {
       "type": "tool_ui_done",
       "ios": "unknown",
+      "mirrored": [
+        "type"
+      ],
+      "dropped": [
+        "messageId",
+        "requestId"
+      ],
       "event": {
         "type": "tool_ui_done",
         "messageId": "m2",
@@ -817,6 +878,13 @@
     {
       "type": "tool_use_start",
       "ios": "decoded",
+      "mirrored": [
+        "messageId",
+        "toolInput",
+        "toolName",
+        "type"
+      ],
+      "dropped": [],
       "event": {
         "type": "tool_use_start",
         "messageId": "m2",
@@ -829,6 +897,11 @@
     {
       "type": "turn_end",
       "ios": "decoded",
+      "mirrored": [
+        "messageId",
+        "type"
+      ],
+      "dropped": [],
       "event": {
         "type": "turn_end",
         "messageId": "m2"

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json
@@ -2,6 +2,7 @@
   "traySyncProtocolVersion": 4,
   "leaderVariantCount": 37,
   "followerVariantCount": 30,
+  "agentEventVariantCount": 11,
   "leaderToFollower": [
     {
       "type": "agent_event",
@@ -714,6 +715,347 @@
         "type": "user_message",
         "text": "hello from follower",
         "messageId": "f-1"
+      }
+    }
+  ],
+  "agentEvents": [
+    {
+      "type": "content_delta",
+      "ios": "decoded",
+      "event": {
+        "type": "content_delta",
+        "messageId": "m2",
+        "text": "partial"
+      }
+    },
+    {
+      "type": "content_done",
+      "ios": "decoded",
+      "event": {
+        "type": "content_done",
+        "messageId": "m2",
+        "model": "claude-opus-4-6",
+        "usage": {
+          "input": 1200,
+          "output": 340,
+          "cacheRead": 900,
+          "cacheWrite": 100,
+          "cost": {
+            "input": 0.0036,
+            "output": 0.0051,
+            "cacheRead": 0.00027,
+            "cacheWrite": 0.000375,
+            "total": 0.009345
+          }
+        }
+      }
+    },
+    {
+      "type": "error",
+      "ios": "decoded",
+      "event": {
+        "type": "error",
+        "error": "boom"
+      }
+    },
+    {
+      "type": "message_start",
+      "ios": "decoded",
+      "event": {
+        "type": "message_start",
+        "messageId": "m2"
+      }
+    },
+    {
+      "type": "screenshot",
+      "ios": "unknown",
+      "event": {
+        "type": "screenshot",
+        "base64": "iVBORw0KGgo=",
+        "url": "https://example.com"
+      }
+    },
+    {
+      "type": "terminal_output",
+      "ios": "unknown",
+      "event": {
+        "type": "terminal_output",
+        "text": "$ ls\nnotes.md\n"
+      }
+    },
+    {
+      "type": "tool_result",
+      "ios": "decoded",
+      "event": {
+        "type": "tool_result",
+        "messageId": "m2",
+        "toolName": "read_file",
+        "result": "file contents",
+        "isError": false
+      }
+    },
+    {
+      "type": "tool_ui",
+      "ios": "unknown",
+      "event": {
+        "type": "tool_ui",
+        "messageId": "m2",
+        "toolName": "ask_user",
+        "requestId": "ui-1",
+        "html": "<div>approve?</div>"
+      }
+    },
+    {
+      "type": "tool_ui_done",
+      "ios": "unknown",
+      "event": {
+        "type": "tool_ui_done",
+        "messageId": "m2",
+        "requestId": "ui-1"
+      }
+    },
+    {
+      "type": "tool_use_start",
+      "ios": "decoded",
+      "event": {
+        "type": "tool_use_start",
+        "messageId": "m2",
+        "toolName": "read_file",
+        "toolInput": {
+          "path": "/workspace/notes.md"
+        }
+      }
+    },
+    {
+      "type": "turn_end",
+      "ios": "decoded",
+      "event": {
+        "type": "turn_end",
+        "messageId": "m2"
+      }
+    }
+  ],
+  "nestedPayloads": [
+    {
+      "name": "ChatMessage",
+      "ios": "mirrored",
+      "mirrored": [
+        "channel",
+        "content",
+        "id",
+        "isStreaming",
+        "queued",
+        "role",
+        "source",
+        "timestamp",
+        "toolCalls"
+      ],
+      "dropped": [
+        "attachments",
+        "error",
+        "lickCount",
+        "lickId",
+        "lickParts",
+        "lickState",
+        "model",
+        "usage"
+      ],
+      "sample": {
+        "id": "m-full",
+        "role": "assistant",
+        "content": "every field populated",
+        "timestamp": 1750000002000,
+        "attachments": [
+          {
+            "id": "a1",
+            "name": "notes.txt",
+            "mimeType": "text/plain",
+            "size": 5,
+            "kind": "text",
+            "text": "notes"
+          }
+        ],
+        "toolCalls": [
+          {
+            "id": "t1",
+            "name": "read_file",
+            "input": {
+              "path": "/workspace/notes.md"
+            },
+            "result": "ok",
+            "isError": false
+          }
+        ],
+        "isStreaming": false,
+        "model": "claude-opus-4-6",
+        "usage": {
+          "input": 1200,
+          "output": 340,
+          "cacheRead": 900,
+          "cacheWrite": 100,
+          "cost": {
+            "input": 0.0036,
+            "output": 0.0051,
+            "cacheRead": 0.00027,
+            "cacheWrite": 0.000375,
+            "total": 0.009345
+          }
+        },
+        "source": "cone",
+        "channel": "webhook",
+        "lickCount": 3,
+        "lickParts": [
+          "first",
+          "second",
+          "third"
+        ],
+        "lickId": "lick-1",
+        "lickState": "pending",
+        "queued": false,
+        "error": false
+      }
+    },
+    {
+      "name": "MessageAttachment",
+      "ios": "absent",
+      "mirrored": [],
+      "dropped": [
+        "data",
+        "error",
+        "id",
+        "kind",
+        "mimeType",
+        "name",
+        "path",
+        "size",
+        "text"
+      ],
+      "sample": {
+        "id": "a1",
+        "name": "shot.png",
+        "mimeType": "image/png",
+        "size": 12,
+        "kind": "image",
+        "data": "iVBORw0KGgo=",
+        "text": "alt text",
+        "path": "/tmp/attachment-a1.png",
+        "error": "too large to inline"
+      }
+    },
+    {
+      "name": "RemoteTargetInfo",
+      "ios": "mirrored",
+      "mirrored": [
+        "capabilities",
+        "kind",
+        "targetId",
+        "title",
+        "url"
+      ],
+      "dropped": [],
+      "sample": {
+        "targetId": "wk1",
+        "title": "Hosted tab",
+        "url": "https://example.com",
+        "kind": "cherry",
+        "capabilities": {
+          "navigate": true,
+          "network": false,
+          "screenshot": true
+        }
+      }
+    },
+    {
+      "name": "ScoopSummary",
+      "ios": "mirrored",
+      "mirrored": [
+        "assistantLabel",
+        "folder",
+        "isCone",
+        "jid",
+        "name",
+        "trigger"
+      ],
+      "dropped": [],
+      "sample": {
+        "jid": "reviewer",
+        "name": "reviewer",
+        "folder": "/scoops/reviewer",
+        "isCone": false,
+        "assistantLabel": "Reviewer",
+        "trigger": "on-push"
+      }
+    },
+    {
+      "name": "SprinkleSummary",
+      "ios": "mirrored",
+      "mirrored": [
+        "autoOpen",
+        "icon",
+        "name",
+        "open",
+        "path",
+        "title"
+      ],
+      "dropped": [],
+      "sample": {
+        "name": "todo",
+        "title": "Todo",
+        "path": "/workspace/sprinkles/todo.shtml",
+        "open": true,
+        "autoOpen": true,
+        "icon": "rocket"
+      }
+    },
+    {
+      "name": "ToolCall",
+      "ios": "mirrored",
+      "mirrored": [
+        "id",
+        "input",
+        "isError",
+        "name",
+        "result"
+      ],
+      "dropped": [],
+      "sample": {
+        "id": "t1",
+        "name": "read_file",
+        "input": {
+          "path": "/workspace/notes.md"
+        },
+        "result": "file contents",
+        "isError": false
+      }
+    },
+    {
+      "name": "TrayTargetEntry",
+      "ios": "mirrored",
+      "mirrored": [
+        "isLocal",
+        "localTargetId",
+        "runtimeId",
+        "targetId",
+        "title",
+        "url"
+      ],
+      "dropped": [
+        "capabilities",
+        "kind"
+      ],
+      "sample": {
+        "targetId": "leader:tab1",
+        "localTargetId": "tab1",
+        "runtimeId": "leader",
+        "title": "Example",
+        "url": "https://example.com",
+        "isLocal": false,
+        "kind": "cherry",
+        "capabilities": {
+          "navigate": true,
+          "network": false,
+          "screenshot": true
+        }
       }
     }
   ]

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SyncProtocolCorpusTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SyncProtocolCorpusTests.swift
@@ -14,10 +14,17 @@ import XCTest
 ///  - `unknown`: TS-only leader→follower variant — must decode to `.unknown`.
 ///  - `undecodable`: TS-only follower→leader variant — the decoder must throw.
 ///
+/// Two further axes sit below the message variants, because reaching a real
+/// case says nothing about what arrives inside it:
+///  - every `AgentEvent` variant, not just the one the `agent_event` envelope
+///    fixture happens to carry;
+///  - every FIELD of the payload types nested in those messages, round-tripped
+///    through its Swift mirror so dropped fields are proven rather than assumed.
+///
 /// A TS-side union change regenerates the corpus (the TS mapped types force a
-/// fixture + iOS decision per variant), so a variant this decoder mishandles
-/// fails HERE, in CI, instead of shipping as silently-dropped messages — the
-/// `theme.apply` drift class.
+/// fixture + iOS decision per variant and per nested field), so a variant or
+/// field this decoder mishandles fails HERE, in CI, instead of shipping as
+/// silently-dropped data — the `theme.apply` drift class.
 final class SyncProtocolCorpusTests: XCTestCase {
     private struct CorpusError: Error, CustomStringConvertible {
         let description: String
@@ -27,8 +34,24 @@ final class SyncProtocolCorpusTests: XCTestCase {
         let traySyncProtocolVersion: Int
         let declaredLeaderVariantCount: Int
         let declaredFollowerVariantCount: Int
+        let declaredAgentEventVariantCount: Int
         let leaderToFollower: [(type: String, ios: String, messageData: Data)]
         let followerToLeader: [(type: String, ios: String, messageData: Data)]
+        let agentEvents: [(type: String, ios: String, eventData: Data)]
+        let nestedPayloads: [NestedPayload]
+    }
+
+    /// One nested payload type carried INSIDE a message variant, with the
+    /// per-field expectations the TS corpus declares for this mirror.
+    private struct NestedPayload {
+        let name: String
+        let ios: String
+        /// Fields the Swift struct must preserve through decode → encode.
+        let mirrored: [String]
+        /// Fields the Swift struct has no property for, so they are lost.
+        /// Asserted absent so the inventory cannot silently go stale.
+        let dropped: [String]
+        let sampleData: Data
     }
 
     private func loadCorpus() throws -> RawCorpus {
@@ -44,16 +67,19 @@ final class SyncProtocolCorpusTests: XCTestCase {
             let version = root["traySyncProtocolVersion"] as? Int,
             let leaderCount = root["leaderVariantCount"] as? Int,
             let followerCount = root["followerVariantCount"] as? Int,
+            let agentEventCount = root["agentEventVariantCount"] as? Int,
             let leader = root["leaderToFollower"] as? [[String: Any]],
-            let follower = root["followerToLeader"] as? [[String: Any]]
+            let follower = root["followerToLeader"] as? [[String: Any]],
+            let events = root["agentEvents"] as? [[String: Any]],
+            let payloads = root["nestedPayloads"] as? [[String: Any]]
         else {
             throw CorpusError(description: "tray-sync-corpus.json has an unexpected shape — regenerate it")
         }
-        func entries(_ items: [[String: Any]]) throws -> [(String, String, Data)] {
+        func entries(_ items: [[String: Any]], payloadKey: String) throws -> [(String, String, Data)] {
             try items.map { item in
                 let type = item["type"] as? String ?? "<missing>"
                 let ios = item["ios"] as? String ?? "<missing>"
-                let messageData = try JSONSerialization.data(withJSONObject: item["message"] ?? [:])
+                let messageData = try JSONSerialization.data(withJSONObject: item[payloadKey] ?? [:])
                 return (type, ios, messageData)
             }
         }
@@ -61,9 +87,46 @@ final class SyncProtocolCorpusTests: XCTestCase {
             traySyncProtocolVersion: version,
             declaredLeaderVariantCount: leaderCount,
             declaredFollowerVariantCount: followerCount,
-            leaderToFollower: try entries(leader),
-            followerToLeader: try entries(follower)
+            declaredAgentEventVariantCount: agentEventCount,
+            leaderToFollower: try entries(leader, payloadKey: "message"),
+            followerToLeader: try entries(follower, payloadKey: "message"),
+            agentEvents: try entries(events, payloadKey: "event"),
+            nestedPayloads: try payloads.map { item in
+                NestedPayload(
+                    name: item["name"] as? String ?? "<missing>",
+                    ios: item["ios"] as? String ?? "<missing>",
+                    mirrored: item["mirrored"] as? [String] ?? [],
+                    dropped: item["dropped"] as? [String] ?? [],
+                    sampleData: try JSONSerialization.data(withJSONObject: item["sample"] ?? [:])
+                )
+            }
         )
+    }
+
+    /// Decode a nested payload sample into its Swift mirror and re-encode it,
+    /// so the caller can see which fields actually survived. `nil` means this
+    /// type has no Swift mirror at all.
+    private func roundTripThroughSwiftMirror(name: String, sample: Data) throws -> [String: Any]? {
+        let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+        let reencoded: Data
+        switch name {
+        case "ChatMessage":
+            reencoded = try encoder.encode(try decoder.decode(ChatMessage.self, from: sample))
+        case "ToolCall":
+            reencoded = try encoder.encode(try decoder.decode(ToolCall.self, from: sample))
+        case "ScoopSummary":
+            reencoded = try encoder.encode(try decoder.decode(ScoopSummary.self, from: sample))
+        case "SprinkleSummary":
+            reencoded = try encoder.encode(try decoder.decode(SprinkleSummary.self, from: sample))
+        case "RemoteTargetInfo":
+            reencoded = try encoder.encode(try decoder.decode(RemoteTargetInfo.self, from: sample))
+        case "TrayTargetEntry":
+            reencoded = try encoder.encode(try decoder.decode(TrayTargetEntry.self, from: sample))
+        default:
+            return nil
+        }
+        return try JSONSerialization.jsonObject(with: reencoded) as? [String: Any]
     }
 
     func testCorpusVersionMatchesThisBuild() throws {
@@ -86,6 +149,76 @@ final class SyncProtocolCorpusTests: XCTestCase {
         XCTAssertEqual(
             Set(corpus.followerToLeader.map(\.type)).count, corpus.followerToLeader.count,
             "duplicate followerToLeader fixture types")
+        XCTAssertEqual(corpus.agentEvents.count, corpus.declaredAgentEventVariantCount)
+        XCTAssertEqual(
+            Set(corpus.agentEvents.map(\.type)).count, corpus.agentEvents.count,
+            "duplicate agentEvents fixture types")
+    }
+
+    /// The `agent_event` envelope has a single fixture, so before this test the
+    /// suite only ever proved that ONE event type decodes. Every other variant
+    /// could fall to `.unknown` unnoticed — and four of them do.
+    func testAgentEventCorpusDecodesPerExpectation() throws {
+        let corpus = try loadCorpus()
+        let decoder = JSONDecoder()
+        for (type, ios, eventData) in corpus.agentEvents {
+            let decoded: AgentEvent
+            do {
+                decoded = try decoder.decode(AgentEvent.self, from: eventData)
+            } catch {
+                XCTFail("agentEvent '\(type)' failed to decode entirely: \(error)")
+                continue
+            }
+            let isUnknown: Bool
+            if case .unknown = decoded { isUnknown = true } else { isUnknown = false }
+            switch ios {
+            case "decoded":
+                XCTAssertFalse(
+                    isUnknown,
+                    "agent event '\(type)' decoded to .unknown but the corpus expects a real case — AgentEvent in SyncProtocol.swift is missing it")
+            case "unknown":
+                XCTAssertTrue(
+                    isUnknown,
+                    "agent event '\(type)' now decodes to a real case — flip its expectation to 'decoded' in tray-sync-protocol-corpus.ts")
+            default:
+                XCTFail("agent event '\(type)' has unexpected ios expectation '\(ios)'")
+            }
+        }
+    }
+
+    /// Envelope-level tests only prove a message reached a real case. A mirror
+    /// can decode `snapshot` into `.snapshot` and still discard most of every
+    /// `ChatMessage` it carries, because the Swift structs simply have no
+    /// property for those keys and `Codable` ignores what it does not know.
+    ///
+    /// Round-tripping each sample through its Swift mirror shows exactly which
+    /// fields survive. `dropped` is asserted as firmly as `mirrored`: a field
+    /// that starts surviving must be promoted in the corpus, so the inventory
+    /// of known data loss cannot drift out of date in either direction.
+    func testNestedPayloadFieldsSurviveTheSwiftMirror() throws {
+        let corpus = try loadCorpus()
+        for payload in corpus.nestedPayloads {
+            guard let survived = try roundTripThroughSwiftMirror(name: payload.name, sample: payload.sampleData)
+            else {
+                XCTAssertEqual(
+                    payload.ios, "absent",
+                    "'\(payload.name)' is declared mirrored but has no Swift type wired into roundTripThroughSwiftMirror")
+                continue
+            }
+            XCTAssertEqual(
+                payload.ios, "mirrored",
+                "'\(payload.name)' has a Swift mirror wired in but the corpus declares it '\(payload.ios)' — update tray-sync-protocol-corpus.ts")
+            for field in payload.mirrored {
+                XCTAssertNotNil(
+                    survived[field],
+                    "'\(payload.name).\(field)' is expected to survive but the Swift mirror dropped it")
+            }
+            for field in payload.dropped {
+                XCTAssertNil(
+                    survived[field],
+                    "'\(payload.name).\(field)' now survives the Swift mirror — promote it to 'mirrored' in tray-sync-protocol-corpus.ts")
+            }
+        }
     }
 
     func testLeaderToFollowerCorpusDecodesPerExpectation() throws {

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SyncProtocolCorpusTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SyncProtocolCorpusTests.swift
@@ -37,8 +37,19 @@ final class SyncProtocolCorpusTests: XCTestCase {
         let declaredAgentEventVariantCount: Int
         let leaderToFollower: [(type: String, ios: String, messageData: Data)]
         let followerToLeader: [(type: String, ios: String, messageData: Data)]
-        let agentEvents: [(type: String, ios: String, eventData: Data)]
+        let agentEvents: [AgentEventFixture]
         let nestedPayloads: [NestedPayload]
+    }
+
+    /// One `AgentEvent` variant plus the per-field expectations for its
+    /// payload. The discriminator check alone cannot see that `.contentDone`
+    /// decodes to a real case while discarding `model` and `usage`.
+    private struct AgentEventFixture {
+        let type: String
+        let ios: String
+        let mirrored: [String]
+        let dropped: [String]
+        let eventData: Data
     }
 
     /// One nested payload type carried INSIDE a message variant, with the
@@ -90,7 +101,15 @@ final class SyncProtocolCorpusTests: XCTestCase {
             declaredAgentEventVariantCount: agentEventCount,
             leaderToFollower: try entries(leader, payloadKey: "message"),
             followerToLeader: try entries(follower, payloadKey: "message"),
-            agentEvents: try entries(events, payloadKey: "event"),
+            agentEvents: try events.map { item in
+                AgentEventFixture(
+                    type: item["type"] as? String ?? "<missing>",
+                    ios: item["ios"] as? String ?? "<missing>",
+                    mirrored: item["mirrored"] as? [String] ?? [],
+                    dropped: item["dropped"] as? [String] ?? [],
+                    eventData: try JSONSerialization.data(withJSONObject: item["event"] ?? [:])
+                )
+            },
             nestedPayloads: try payloads.map { item in
                 NestedPayload(
                     name: item["name"] as? String ?? "<missing>",
@@ -161,27 +180,55 @@ final class SyncProtocolCorpusTests: XCTestCase {
     func testAgentEventCorpusDecodesPerExpectation() throws {
         let corpus = try loadCorpus()
         let decoder = JSONDecoder()
-        for (type, ios, eventData) in corpus.agentEvents {
+        for fixture in corpus.agentEvents {
             let decoded: AgentEvent
             do {
-                decoded = try decoder.decode(AgentEvent.self, from: eventData)
+                decoded = try decoder.decode(AgentEvent.self, from: fixture.eventData)
             } catch {
-                XCTFail("agentEvent '\(type)' failed to decode entirely: \(error)")
+                XCTFail("agentEvent '\(fixture.type)' failed to decode entirely: \(error)")
                 continue
             }
             let isUnknown: Bool
             if case .unknown = decoded { isUnknown = true } else { isUnknown = false }
-            switch ios {
+            switch fixture.ios {
             case "decoded":
                 XCTAssertFalse(
                     isUnknown,
-                    "agent event '\(type)' decoded to .unknown but the corpus expects a real case — AgentEvent in SyncProtocol.swift is missing it")
+                    "agent event '\(fixture.type)' decoded to .unknown but the corpus expects a real case — AgentEvent in SyncProtocol.swift is missing it")
             case "unknown":
                 XCTAssertTrue(
                     isUnknown,
-                    "agent event '\(type)' now decodes to a real case — flip its expectation to 'decoded' in tray-sync-protocol-corpus.ts")
+                    "agent event '\(fixture.type)' now decodes to a real case — flip its expectation to 'decoded' in tray-sync-protocol-corpus.ts")
             default:
-                XCTFail("agent event '\(type)' has unexpected ios expectation '\(ios)'")
+                XCTFail("agent event '\(fixture.type)' has unexpected ios expectation '\(fixture.ios)'")
+            }
+        }
+    }
+
+    /// Reaching a real case is not the same as keeping the payload.
+    /// `.contentDone(messageId:)` decodes cleanly and silently discards the
+    /// `model` and `usage` that price the turn, and every `.unknown` variant
+    /// re-encodes its type tag alone. Round-trip each event so the surviving
+    /// fields are proven rather than inferred from the discriminator.
+    func testAgentEventPayloadFieldsSurviveTheSwiftMirror() throws {
+        let corpus = try loadCorpus()
+        let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+        for fixture in corpus.agentEvents {
+            guard let decoded = try? decoder.decode(AgentEvent.self, from: fixture.eventData) else {
+                continue  // already reported by testAgentEventCorpusDecodesPerExpectation
+            }
+            let survived =
+                try JSONSerialization.jsonObject(with: try encoder.encode(decoded)) as? [String: Any] ?? [:]
+            for field in fixture.mirrored {
+                XCTAssertNotNil(
+                    survived[field],
+                    "agent event '\(fixture.type).\(field)' is expected to survive but the Swift mirror dropped it")
+            }
+            for field in fixture.dropped {
+                XCTAssertNil(
+                    survived[field],
+                    "agent event '\(fixture.type).\(field)' now survives — promote it to 'mirrored' in tray-sync-protocol-corpus.ts")
             }
         }
     }

--- a/packages/webapp/src/scoops/tray-sync-protocol-corpus.ts
+++ b/packages/webapp/src/scoops/tray-sync-protocol-corpus.ts
@@ -74,9 +74,9 @@ export type IosFieldExpectation = 'mirrored' | 'dropped' | 'local';
 /**
  * Whether iOS mirrors a nested payload type at all.
  * - `mirrored`: a Swift struct exists; the Swift suite round-trips the sample.
- * - `absent`: no Swift type exists. The Swift suite asserts it stays absent,
- *   so adding the mirror forces this to flip and the per-field expectations
- *   below to be revisited.
+ * - `absent`: no Swift type exists, so there is nothing to round-trip. A Swift
+ *   test cannot assert the non-existence of a Swift type, so `absent` is held
+ *   honest from the TS side instead — see `carriedBy`.
  */
 export type IosPayloadExpectation = 'mirrored' | 'absent';
 
@@ -92,11 +92,27 @@ type NestedPayloadEntry<T> = {
   fields: FieldExpectations<T>;
   /** Must populate every non-`local` field; asserted by the vitest guard. */
   sample: T;
+  /**
+   * Required when `ios` is `absent`: every `Type.field` site that carries this
+   * payload. Each must stay classified `dropped` while no Swift mirror exists.
+   * This is what actually forces `absent` to be revisited — the moment Swift
+   * learns to keep `ChatMessage.attachments`, that field is promoted to
+   * `mirrored` and this cross-check fails until the payload is promoted too.
+   */
+  carriedBy?: string[];
 };
 
+/**
+ * Per-variant `AgentEvent` entry. `fields` pushes the same field-level
+ * enforcement one level BELOW the discriminator: without it, `content_done`
+ * could carry `model` and `usage` (it does) while the variant still reads as
+ * cleanly `decoded`, because Swift's `.contentDone(messageId:)` throws both
+ * away and the discriminator check cannot see it.
+ */
 type AgentEventCorpus = {
   [K in AgentEvent['type']]: {
     ios: IosAgentEventExpectation;
+    fields: FieldExpectations<Extract<AgentEvent, { type: K }>>;
     event: Extract<AgentEvent, { type: K }>;
   };
 };
@@ -570,14 +586,26 @@ export const FOLLOWER_TO_LEADER_CORPUS: FollowerCorpus = {
  * "the leader never sends this one" is not an available excuse for any entry.
  */
 export const AGENT_EVENT_CORPUS: AgentEventCorpus = {
-  message_start: { ios: 'decoded', event: { type: 'message_start', messageId: 'm2' } },
+  message_start: {
+    ios: 'decoded',
+    fields: { type: 'mirrored', messageId: 'mirrored' },
+    event: { type: 'message_start', messageId: 'm2' },
+  },
   content_delta: {
     ios: 'decoded',
+    fields: { type: 'mirrored', messageId: 'mirrored', text: 'mirrored' },
     event: { type: 'content_delta', messageId: 'm2', text: 'partial' },
   },
-  // `model` and `usage` have no Swift properties — see CONTENT_DONE_FIELDS.
+  // Decodes to a real case, yet `.contentDone(messageId:)` carries neither
+  // `model` nor `usage` — the cost attribution for the turn is thrown away.
   content_done: {
     ios: 'decoded',
+    fields: {
+      type: 'mirrored',
+      messageId: 'mirrored',
+      model: 'dropped',
+      usage: 'dropped',
+    },
     event: {
       type: 'content_done',
       messageId: 'm2',
@@ -599,6 +627,12 @@ export const AGENT_EVENT_CORPUS: AgentEventCorpus = {
   },
   tool_use_start: {
     ios: 'decoded',
+    fields: {
+      type: 'mirrored',
+      messageId: 'mirrored',
+      toolName: 'mirrored',
+      toolInput: 'mirrored',
+    },
     event: {
       type: 'tool_use_start',
       messageId: 'm2',
@@ -608,6 +642,13 @@ export const AGENT_EVENT_CORPUS: AgentEventCorpus = {
   },
   tool_result: {
     ios: 'decoded',
+    fields: {
+      type: 'mirrored',
+      messageId: 'mirrored',
+      toolName: 'mirrored',
+      result: 'mirrored',
+      isError: 'mirrored',
+    },
     event: {
       type: 'tool_result',
       messageId: 'm2',
@@ -617,9 +658,17 @@ export const AGENT_EVENT_CORPUS: AgentEventCorpus = {
     },
   },
   // Tool-UI cards render as interactive HTML on the leader. iOS has no case,
-  // so an approval card silently never appears.
+  // so an approval card silently never appears. `.unknown` re-encodes the type
+  // tag and nothing else, which is why every payload field below is `dropped`.
   tool_ui: {
     ios: 'unknown',
+    fields: {
+      type: 'mirrored',
+      messageId: 'dropped',
+      toolName: 'dropped',
+      requestId: 'dropped',
+      html: 'dropped',
+    },
     event: {
       type: 'tool_ui',
       messageId: 'm2',
@@ -630,17 +679,31 @@ export const AGENT_EVENT_CORPUS: AgentEventCorpus = {
   },
   tool_ui_done: {
     ios: 'unknown',
+    fields: { type: 'mirrored', messageId: 'dropped', requestId: 'dropped' },
     event: { type: 'tool_ui_done', messageId: 'm2', requestId: 'ui-1' },
   },
-  turn_end: { ios: 'decoded', event: { type: 'turn_end', messageId: 'm2' } },
-  error: { ios: 'decoded', event: { type: 'error', error: 'boom' } },
+  turn_end: {
+    ios: 'decoded',
+    fields: { type: 'mirrored', messageId: 'mirrored' },
+    event: { type: 'turn_end', messageId: 'm2' },
+  },
+  error: {
+    ios: 'decoded',
+    fields: { type: 'mirrored', error: 'mirrored' },
+    event: { type: 'error', error: 'boom' },
+  },
   // `degradeOversizeAgentEvent` in broadcast.ts explicitly handles screenshots,
   // so they are expected on the wire; iOS still has no case for them.
   screenshot: {
     ios: 'unknown',
+    fields: { type: 'mirrored', base64: 'dropped', url: 'dropped' },
     event: { type: 'screenshot', base64: 'iVBORw0KGgo=', url: 'https://example.com' },
   },
-  terminal_output: { ios: 'unknown', event: { type: 'terminal_output', text: '$ ls\nnotes.md\n' } },
+  terminal_output: {
+    ios: 'unknown',
+    fields: { type: 'mirrored', text: 'dropped' },
+    event: { type: 'terminal_output', text: '$ ls\nnotes.md\n' },
+  },
 };
 
 const CHAT_MESSAGE: NestedPayloadEntry<ChatMessage> = {
@@ -733,6 +796,7 @@ const MESSAGE_ATTACHMENT: NestedPayloadEntry<MessageAttachment> = {
   // No Swift type exists at all, so every field is lost wherever attachments
   // ride along (`ChatMessage.attachments`, `user_message_echo.attachments`).
   ios: 'absent',
+  carriedBy: ['ChatMessage.attachments'],
   fields: {
     id: 'dropped',
     name: 'dropped',
@@ -881,7 +945,13 @@ export function buildCorpusDocument(): {
   agentEventVariantCount: number;
   leaderToFollower: Array<{ type: string; ios: string; message: unknown }>;
   followerToLeader: Array<{ type: string; ios: string; message: unknown }>;
-  agentEvents: Array<{ type: string; ios: string; event: unknown }>;
+  agentEvents: Array<{
+    type: string;
+    ios: string;
+    mirrored: string[];
+    dropped: string[];
+    event: unknown;
+  }>;
   nestedPayloads: Array<{
     name: string;
     ios: string;
@@ -907,7 +977,13 @@ export function buildCorpusDocument(): {
     leaderToFollower: flatten(LEADER_TO_FOLLOWER_CORPUS),
     followerToLeader: flatten(FOLLOWER_TO_LEADER_CORPUS),
     agentEvents: Object.values(AGENT_EVENT_CORPUS)
-      .map(({ ios, event }) => ({ type: event.type, ios, event: event as unknown }))
+      .map((entry) => ({
+        type: entry.event.type,
+        ios: entry.ios,
+        mirrored: fieldsWith(entry, 'mirrored'),
+        dropped: fieldsWith(entry, 'dropped'),
+        event: entry.event as unknown,
+      }))
       .sort((a, b) => a.type.localeCompare(b.type)),
     nestedPayloads: Object.entries(NESTED_PAYLOAD_CORPUS)
       .map(([name, entry]) => ({

--- a/packages/webapp/src/scoops/tray-sync-protocol-corpus.ts
+++ b/packages/webapp/src/scoops/tray-sync-protocol-corpus.ts
@@ -21,7 +21,18 @@
  * generator executes it under plain tsx, outside the Vite define environment.
  */
 
-import type { FollowerToLeaderMessage, LeaderToFollowerMessage } from '@slicc/shared-ts';
+import type {
+  AgentEvent,
+  ChatMessage,
+  FollowerToLeaderMessage,
+  LeaderToFollowerMessage,
+  MessageAttachment,
+  RemoteTargetInfo,
+  ScoopSummary,
+  SprinkleSummary,
+  ToolCall,
+  TrayTargetEntry,
+} from '@slicc/shared-ts';
 import { SLICC_HOSTED_ORIGIN, TRAY_SYNC_PROTOCOL_VERSION } from '@slicc/shared-ts';
 
 /**
@@ -37,6 +48,58 @@ export type IosLeaderDecodeExpectation = 'decoded' | 'unknown';
  * - `undecodable`: TS-only variant iOS never originates — its decoder throws.
  */
 export type IosFollowerDecodeExpectation = 'decoded' | 'undecodable';
+
+/**
+ * What the iOS mirror must do with an `AgentEvent` variant. The envelope
+ * (`agent_event`) has a single fixture above, which only ever proved that ONE
+ * event type decodes; this is the per-variant enforcement.
+ * - `decoded`: `AgentEvent` in `SyncProtocol.swift` has a real case for it.
+ * - `unknown`: no Swift case — it falls to `.unknown(type:)` and the payload
+ *   is dropped. Asserted so the gap stays inventoried rather than silent.
+ */
+export type IosAgentEventExpectation = 'decoded' | 'unknown';
+
+/**
+ * What the iOS mirror must do with ONE field of a nested payload type.
+ * - `mirrored`: the Swift struct has the property and a decode→encode
+ *   round-trip preserves it.
+ * - `dropped`: the Swift struct has no property for it, so the value is lost
+ *   on arrival. Asserted (the round-trip must NOT produce it) so every known
+ *   data-loss field is inventoried here instead of discovered in the field.
+ * - `local`: never crosses the wire at all — transient UI/bridge state that
+ *   the TS side strips before send. Excluded from the fixture.
+ */
+export type IosFieldExpectation = 'mirrored' | 'dropped' | 'local';
+
+/**
+ * Whether iOS mirrors a nested payload type at all.
+ * - `mirrored`: a Swift struct exists; the Swift suite round-trips the sample.
+ * - `absent`: no Swift type exists. The Swift suite asserts it stays absent,
+ *   so adding the mirror forces this to flip and the per-field expectations
+ *   below to be revisited.
+ */
+export type IosPayloadExpectation = 'mirrored' | 'absent';
+
+/**
+ * Forces an explicit per-field iOS decision. `-?` strips optionality so an
+ * OPTIONAL field added to `ChatMessage` (etc.) fails typecheck here until it
+ * is classified — the field-level analogue of the variant maps below.
+ */
+type FieldExpectations<T> = { [K in keyof T]-?: IosFieldExpectation };
+
+type NestedPayloadEntry<T> = {
+  ios: IosPayloadExpectation;
+  fields: FieldExpectations<T>;
+  /** Must populate every non-`local` field; asserted by the vitest guard. */
+  sample: T;
+};
+
+type AgentEventCorpus = {
+  [K in AgentEvent['type']]: {
+    ios: IosAgentEventExpectation;
+    event: Extract<AgentEvent, { type: K }>;
+  };
+};
 
 type LeaderCorpus = {
   [K in LeaderToFollowerMessage['type']]: {
@@ -498,13 +561,334 @@ export const FOLLOWER_TO_LEADER_CORPUS: FollowerCorpus = {
   pong: { ios: 'decoded', message: { type: 'pong' } },
 };
 
+/**
+ * One fixture per `AgentEvent` variant. The mapped type is the enforcement:
+ * adding a variant to `AgentEvent` fails typecheck here until it has a fixture
+ * AND an explicit iOS decision.
+ *
+ * `broadcast.ts` forwards every agent event to followers unconditionally, so
+ * "the leader never sends this one" is not an available excuse for any entry.
+ */
+export const AGENT_EVENT_CORPUS: AgentEventCorpus = {
+  message_start: { ios: 'decoded', event: { type: 'message_start', messageId: 'm2' } },
+  content_delta: {
+    ios: 'decoded',
+    event: { type: 'content_delta', messageId: 'm2', text: 'partial' },
+  },
+  // `model` and `usage` have no Swift properties — see CONTENT_DONE_FIELDS.
+  content_done: {
+    ios: 'decoded',
+    event: {
+      type: 'content_done',
+      messageId: 'm2',
+      model: 'claude-opus-4-6',
+      usage: {
+        input: 1200,
+        output: 340,
+        cacheRead: 900,
+        cacheWrite: 100,
+        cost: {
+          input: 0.0036,
+          output: 0.0051,
+          cacheRead: 0.00027,
+          cacheWrite: 0.000375,
+          total: 0.009345,
+        },
+      },
+    },
+  },
+  tool_use_start: {
+    ios: 'decoded',
+    event: {
+      type: 'tool_use_start',
+      messageId: 'm2',
+      toolName: 'read_file',
+      toolInput: { path: '/workspace/notes.md' },
+    },
+  },
+  tool_result: {
+    ios: 'decoded',
+    event: {
+      type: 'tool_result',
+      messageId: 'm2',
+      toolName: 'read_file',
+      result: 'file contents',
+      isError: false,
+    },
+  },
+  // Tool-UI cards render as interactive HTML on the leader. iOS has no case,
+  // so an approval card silently never appears.
+  tool_ui: {
+    ios: 'unknown',
+    event: {
+      type: 'tool_ui',
+      messageId: 'm2',
+      toolName: 'ask_user',
+      requestId: 'ui-1',
+      html: '<div>approve?</div>',
+    },
+  },
+  tool_ui_done: {
+    ios: 'unknown',
+    event: { type: 'tool_ui_done', messageId: 'm2', requestId: 'ui-1' },
+  },
+  turn_end: { ios: 'decoded', event: { type: 'turn_end', messageId: 'm2' } },
+  error: { ios: 'decoded', event: { type: 'error', error: 'boom' } },
+  // `degradeOversizeAgentEvent` in broadcast.ts explicitly handles screenshots,
+  // so they are expected on the wire; iOS still has no case for them.
+  screenshot: {
+    ios: 'unknown',
+    event: { type: 'screenshot', base64: 'iVBORw0KGgo=', url: 'https://example.com' },
+  },
+  terminal_output: { ios: 'unknown', event: { type: 'terminal_output', text: '$ ls\nnotes.md\n' } },
+};
+
+const CHAT_MESSAGE: NestedPayloadEntry<ChatMessage> = {
+  ios: 'mirrored',
+  fields: {
+    id: 'mirrored',
+    role: 'mirrored',
+    content: 'mirrored',
+    timestamp: 'mirrored',
+    attachments: 'dropped',
+    toolCalls: 'mirrored',
+    isStreaming: 'mirrored',
+    model: 'dropped',
+    usage: 'dropped',
+    source: 'mirrored',
+    channel: 'mirrored',
+    lickCount: 'dropped',
+    lickParts: 'dropped',
+    lickId: 'dropped',
+    lickState: 'dropped',
+    queued: 'mirrored',
+    error: 'dropped',
+  },
+  sample: {
+    id: 'm-full',
+    role: 'assistant',
+    content: 'every field populated',
+    timestamp: 1750000002000,
+    attachments: [
+      { id: 'a1', name: 'notes.txt', mimeType: 'text/plain', size: 5, kind: 'text', text: 'notes' },
+    ],
+    toolCalls: [
+      {
+        id: 't1',
+        name: 'read_file',
+        input: { path: '/workspace/notes.md' },
+        result: 'ok',
+        isError: false,
+      },
+    ],
+    isStreaming: false,
+    model: 'claude-opus-4-6',
+    usage: {
+      input: 1200,
+      output: 340,
+      cacheRead: 900,
+      cacheWrite: 100,
+      cost: {
+        input: 0.0036,
+        output: 0.0051,
+        cacheRead: 0.00027,
+        cacheWrite: 0.000375,
+        total: 0.009345,
+      },
+    },
+    source: 'cone',
+    channel: 'webhook',
+    lickCount: 3,
+    lickParts: ['first', 'second', 'third'],
+    lickId: 'lick-1',
+    lickState: 'pending',
+    queued: false,
+    error: false,
+  },
+};
+
+const TOOL_CALL: NestedPayloadEntry<ToolCall> = {
+  ios: 'mirrored',
+  fields: {
+    id: 'mirrored',
+    name: 'mirrored',
+    input: 'mirrored',
+    result: 'mirrored',
+    isError: 'mirrored',
+    // Underscore-prefixed fields are stripped before persistence and before
+    // send; they exist only inside one runtime's own UI pass.
+    _screenshotDataUrl: 'local',
+    _toolUIRequestId: 'local',
+  },
+  sample: {
+    id: 't1',
+    name: 'read_file',
+    input: { path: '/workspace/notes.md' },
+    result: 'file contents',
+    isError: false,
+  },
+};
+
+const MESSAGE_ATTACHMENT: NestedPayloadEntry<MessageAttachment> = {
+  // No Swift type exists at all, so every field is lost wherever attachments
+  // ride along (`ChatMessage.attachments`, `user_message_echo.attachments`).
+  ios: 'absent',
+  fields: {
+    id: 'dropped',
+    name: 'dropped',
+    mimeType: 'dropped',
+    size: 'dropped',
+    kind: 'dropped',
+    data: 'dropped',
+    text: 'dropped',
+    path: 'dropped',
+    error: 'dropped',
+  },
+  sample: {
+    id: 'a1',
+    name: 'shot.png',
+    mimeType: 'image/png',
+    size: 12,
+    kind: 'image',
+    data: 'iVBORw0KGgo=',
+    text: 'alt text',
+    path: '/tmp/attachment-a1.png',
+    error: 'too large to inline',
+  },
+};
+
+const SCOOP_SUMMARY: NestedPayloadEntry<ScoopSummary> = {
+  ios: 'mirrored',
+  fields: {
+    jid: 'mirrored',
+    name: 'mirrored',
+    folder: 'mirrored',
+    isCone: 'mirrored',
+    assistantLabel: 'mirrored',
+    trigger: 'mirrored',
+  },
+  sample: {
+    jid: 'reviewer',
+    name: 'reviewer',
+    folder: '/scoops/reviewer',
+    isCone: false,
+    assistantLabel: 'Reviewer',
+    trigger: 'on-push',
+  },
+};
+
+const SPRINKLE_SUMMARY: NestedPayloadEntry<SprinkleSummary> = {
+  ios: 'mirrored',
+  fields: {
+    name: 'mirrored',
+    title: 'mirrored',
+    path: 'mirrored',
+    open: 'mirrored',
+    autoOpen: 'mirrored',
+    icon: 'mirrored',
+  },
+  sample: {
+    name: 'todo',
+    title: 'Todo',
+    path: '/workspace/sprinkles/todo.shtml',
+    open: true,
+    autoOpen: true,
+    icon: 'rocket',
+  },
+};
+
+const REMOTE_TARGET_INFO: NestedPayloadEntry<RemoteTargetInfo> = {
+  ios: 'mirrored',
+  fields: {
+    targetId: 'mirrored',
+    title: 'mirrored',
+    url: 'mirrored',
+    kind: 'mirrored',
+    capabilities: 'mirrored',
+  },
+  sample: {
+    targetId: 'wk1',
+    title: 'Hosted tab',
+    url: 'https://example.com',
+    kind: 'cherry',
+    capabilities: { navigate: true, network: false, screenshot: true },
+  },
+};
+
+const TRAY_TARGET_ENTRY: NestedPayloadEntry<TrayTargetEntry> = {
+  ios: 'mirrored',
+  fields: {
+    targetId: 'mirrored',
+    localTargetId: 'mirrored',
+    runtimeId: 'mirrored',
+    title: 'mirrored',
+    url: 'mirrored',
+    isLocal: 'mirrored',
+    // Without `kind`, the follower cannot tell a cherry host page from a real
+    // browser tab; without `capabilities`, it cannot tell what that page lends.
+    kind: 'dropped',
+    capabilities: 'dropped',
+  },
+  sample: {
+    targetId: 'leader:tab1',
+    localTargetId: 'tab1',
+    runtimeId: 'leader',
+    title: 'Example',
+    url: 'https://example.com',
+    isLocal: false,
+    kind: 'cherry',
+    capabilities: { navigate: true, network: false, screenshot: true },
+  },
+};
+
+/**
+ * Field-level coverage for the payload types nested INSIDE the message
+ * variants. The variant maps above only ever proved that an envelope reaches a
+ * real Swift case; a mirror can decode `snapshot` into a real `.snapshot` and
+ * still throw away two thirds of every `ChatMessage` it carries — which is
+ * exactly what happens today.
+ *
+ * Every entry pairs an explicit per-field expectation with a sample that
+ * populates all of them, so the Swift suite can round-trip the sample and
+ * prove which fields actually survive.
+ */
+export const NESTED_PAYLOAD_CORPUS = {
+  ChatMessage: CHAT_MESSAGE,
+  ToolCall: TOOL_CALL,
+  MessageAttachment: MESSAGE_ATTACHMENT,
+  ScoopSummary: SCOOP_SUMMARY,
+  SprinkleSummary: SPRINKLE_SUMMARY,
+  RemoteTargetInfo: REMOTE_TARGET_INFO,
+  TrayTargetEntry: TRAY_TARGET_ENTRY,
+} as const;
+
+/** Field names of a nested payload entry carrying the given expectation. */
+function fieldsWith(
+  entry: { fields: Record<string, IosFieldExpectation> },
+  expectation: IosFieldExpectation
+): string[] {
+  return Object.entries(entry.fields)
+    .filter(([, value]) => value === expectation)
+    .map(([key]) => key)
+    .sort();
+}
+
 /** Stable JSON document shared with the Swift test suite. */
 export function buildCorpusDocument(): {
   traySyncProtocolVersion: number;
   leaderVariantCount: number;
   followerVariantCount: number;
+  agentEventVariantCount: number;
   leaderToFollower: Array<{ type: string; ios: string; message: unknown }>;
   followerToLeader: Array<{ type: string; ios: string; message: unknown }>;
+  agentEvents: Array<{ type: string; ios: string; event: unknown }>;
+  nestedPayloads: Array<{
+    name: string;
+    ios: string;
+    mirrored: string[];
+    dropped: string[];
+    sample: unknown;
+  }>;
 } {
   const flatten = (corpus: Record<string, { ios: string; message: { type: string } }>) =>
     Object.values(corpus)
@@ -519,7 +903,20 @@ export function buildCorpusDocument(): {
     // arrays match so a truncated/stale JSON copy fails loudly.
     leaderVariantCount: Object.keys(LEADER_TO_FOLLOWER_CORPUS).length,
     followerVariantCount: Object.keys(FOLLOWER_TO_LEADER_CORPUS).length,
+    agentEventVariantCount: Object.keys(AGENT_EVENT_CORPUS).length,
     leaderToFollower: flatten(LEADER_TO_FOLLOWER_CORPUS),
     followerToLeader: flatten(FOLLOWER_TO_LEADER_CORPUS),
+    agentEvents: Object.values(AGENT_EVENT_CORPUS)
+      .map(({ ios, event }) => ({ type: event.type, ios, event: event as unknown }))
+      .sort((a, b) => a.type.localeCompare(b.type)),
+    nestedPayloads: Object.entries(NESTED_PAYLOAD_CORPUS)
+      .map(([name, entry]) => ({
+        name,
+        ios: entry.ios,
+        mirrored: fieldsWith(entry, 'mirrored'),
+        dropped: fieldsWith(entry, 'dropped'),
+        sample: entry.sample as unknown,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name)),
   };
 }

--- a/packages/webapp/tests/scoops/tray-sync-corpus.test.ts
+++ b/packages/webapp/tests/scoops/tray-sync-corpus.test.ts
@@ -3,9 +3,11 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
+  AGENT_EVENT_CORPUS,
   buildCorpusDocument,
   FOLLOWER_TO_LEADER_CORPUS,
   LEADER_TO_FOLLOWER_CORPUS,
+  NESTED_PAYLOAD_CORPUS,
 } from '../../src/scoops/tray-sync-protocol-corpus.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -53,6 +55,61 @@ describe('tray sync golden-fixture corpus', () => {
         roundTripped = undefined; // the expect below fails loudly
       }
       expect(roundTripped).toEqual(message);
+    }
+  });
+
+  it('every agent-event fixture declares the type it is keyed under', () => {
+    for (const [key, { event }] of Object.entries(AGENT_EVENT_CORPUS)) {
+      expect(event.type).toBe(key);
+    }
+  });
+
+  // The mapped type forces a per-field CLASSIFICATION; this forces the sample
+  // to actually carry every field classified as crossing the wire. Without it,
+  // classifying a new optional field as `mirrored` and never populating it
+  // would leave the Swift round-trip with nothing to catch.
+  it('every nested payload sample populates all non-local fields', () => {
+    for (const [name, entry] of Object.entries(NESTED_PAYLOAD_CORPUS)) {
+      const sample: Record<string, unknown> = { ...entry.sample };
+      for (const [field, expectation] of Object.entries(entry.fields)) {
+        if (expectation === 'local') {
+          expect(
+            Object.hasOwn(sample, field),
+            `${name}.${field} is classified 'local' but the fixture sends it`
+          ).toBe(false);
+          continue;
+        }
+        expect(
+          Object.hasOwn(sample, field),
+          `${name}.${field} is classified '${expectation}' but the fixture omits it — a mirror dropping it would go unnoticed`
+        ).toBe(true);
+        expect(sample[field], `${name}.${field} is populated with undefined`).not.toBeUndefined();
+      }
+    }
+  });
+
+  it('nested payload samples carry no field outside their expectation map', () => {
+    for (const [name, entry] of Object.entries(NESTED_PAYLOAD_CORPUS)) {
+      const classified = new Set(Object.keys(entry.fields));
+      for (const field of Object.keys(entry.sample)) {
+        expect(classified.has(field), `${name}.${field} is in the sample but unclassified`).toBe(
+          true
+        );
+      }
+    }
+  });
+
+  // `absent` means no Swift type exists, so there is nothing to mirror; a
+  // field marked `mirrored` under it would assert a round-trip that cannot run.
+  it('payloads with no iOS mirror classify every field as dropped', () => {
+    for (const [name, entry] of Object.entries(NESTED_PAYLOAD_CORPUS)) {
+      if (entry.ios !== 'absent') continue;
+      for (const [field, expectation] of Object.entries(entry.fields)) {
+        expect(
+          expectation,
+          `${name}.${field} cannot be '${expectation}' — ${name} has no iOS mirror`
+        ).toBe('dropped');
+      }
     }
   });
 });

--- a/packages/webapp/tests/scoops/tray-sync-corpus.test.ts
+++ b/packages/webapp/tests/scoops/tray-sync-corpus.test.ts
@@ -112,4 +112,69 @@ describe('tray sync golden-fixture corpus', () => {
       }
     }
   });
+
+  // A Swift test cannot assert that a Swift type does NOT exist, so `absent`
+  // is held honest from this side: the fields that carry the payload must stay
+  // `dropped`. Promoting `ChatMessage.attachments` to `mirrored` without
+  // promoting `MessageAttachment` fails here, which is what makes `absent` a
+  // real ratchet rather than a comment.
+  it('absent payloads name their carriers, and every carrier is still dropped', () => {
+    const classifications = new Map(
+      Object.entries(NESTED_PAYLOAD_CORPUS).flatMap(([name, entry]) =>
+        Object.entries(entry.fields).map(([field, expectation]) => [
+          `${name}.${field}`,
+          expectation as string,
+        ])
+      )
+    );
+    for (const [name, entry] of Object.entries(NESTED_PAYLOAD_CORPUS)) {
+      if (entry.ios !== 'absent') continue;
+      const carriers = 'carriedBy' in entry ? (entry.carriedBy as string[] | undefined) : undefined;
+      expect(
+        carriers?.length ?? 0,
+        `${name} is 'absent' but names no carrier field`
+      ).toBeGreaterThan(0);
+      for (const carrier of carriers ?? []) {
+        expect(classifications.has(carrier), `${name} names unknown carrier '${carrier}'`).toBe(
+          true
+        );
+        expect(
+          classifications.get(carrier),
+          `'${carrier}' is no longer dropped, so ${name} now reaches iOS — promote it from 'absent' to 'mirrored'`
+        ).toBe('dropped');
+      }
+    }
+  });
+
+  it('every agent-event fixture populates exactly its classified fields', () => {
+    for (const [type, entry] of Object.entries(AGENT_EVENT_CORPUS)) {
+      const event: Record<string, unknown> = { ...entry.event };
+      for (const field of Object.keys(entry.fields)) {
+        expect(
+          Object.hasOwn(event, field),
+          `agent event ${type}.${field} is classified but the fixture omits it`
+        ).toBe(true);
+      }
+      for (const field of Object.keys(event)) {
+        expect(
+          Object.hasOwn(entry.fields, field),
+          `agent event ${type}.${field} is in the fixture but unclassified`
+        ).toBe(true);
+      }
+    }
+  });
+
+  // `.unknown` re-encodes the type tag and nothing else, so a variant iOS does
+  // not decode cannot preserve any payload field.
+  it('agent events iOS does not decode keep only the type tag', () => {
+    for (const [type, entry] of Object.entries(AGENT_EVENT_CORPUS)) {
+      if (entry.ios !== 'unknown') continue;
+      for (const [field, expectation] of Object.entries(entry.fields)) {
+        expect(
+          expectation,
+          `${type}.${field} cannot be '${expectation}' — iOS decodes ${type} to .unknown`
+        ).toBe(field === 'type' ? 'mirrored' : 'dropped');
+      }
+    }
+  });
 });


### PR DESCRIPTION
Closes #1786. Second PR of the #1785 iOS catch-up.

## Summary

The golden-fixture corpus guarded variant **presence** only. This adds the two axes underneath it: one fixture per `AgentEvent` variant, and per-field coverage for the seven payload types nested inside the messages. Both are enforced by mapped types, so the compiler refuses new work until a human classifies it.

## Why

The corpus already makes `theme.apply`-class drift impossible at the envelope level: adding a `LeaderToFollowerMessage` variant fails typecheck until it has a fixture and an explicit `ios` decision. That guarantee stops exactly at the envelope, and "the envelope reached a real Swift case" says nothing about what survived inside it.

Two holes sat directly under that line:

1. **The `AgentEvent` union was represented by one fixture.** `agent_event` carried a single `content_delta`, so adding a variant failed nothing. Four of the eleven — `tool_ui`, `tool_ui_done`, `screenshot`, `terminal_output` — are broadcast to followers unconditionally (`scoops/tray-leader/broadcast.ts:65-81`, and `degradeOversizeAgentEvent` at `:33-49` explicitly handles three of them) and all fall to `.unknown` on iOS.

2. **Nested payloads were never inspected field by field.** Swift decodes `snapshot` into a real `.snapshot` and still discards 8 of the 17 `ChatMessage` fields, because `Codable` silently ignores keys a struct has no property for. `testDecodedLeaderMessagesReencodeWithSameType` compares only the `type` tag, so it cannot see this. `snapshot` is worse than most: it uses `try? … ?? []`, so a `ChatMessage` that fails to decode outright becomes an empty array rather than an error.

Every tier-1 silent-data-loss gap catalogued in #1785 shipped through these two holes. Closing them first means the follow-on Swift work has a machine-checked target instead of a prose checklist.

## Approach / Implementation notes

Same idiom as the existing variant maps — a mapped type that will not compile until the new thing is classified.

```ts
type FieldExpectations<T> = { [K in keyof T]-?: IosFieldExpectation };
```

The `-?` is the load-bearing part: it strips optionality, so adding an **optional** field to `ChatMessage` fails typecheck until it is classified. Optional fields are precisely the ones that were slipping through.

Fields are classified three ways:

| Value | Meaning |
| --- | --- |
| `mirrored` | Swift has the property; a decode→encode round-trip must preserve it |
| `dropped` | Swift has no property; the value is lost on arrival |
| `local` | Never crosses the wire (transient UI state); excluded from the fixture |

**`dropped` is asserted as firmly as `mirrored`.** The Swift suite round-trips each sample through its mirror and requires dropped fields to stay *absent*. So when the follow-on PR teaches Swift about `attachments`, this test fails until the corpus is updated — the known-loss inventory cannot rot in either direction.

That is also what keeps `main` green. #1786 anticipated this landing red; a red `main` is not compatible with the merge queue, so instead all 19 currently-lost fields are encoded as machine-checked expectations rather than left as prose in an issue.

### What the corpus now inventories

| Payload | Mirrored | Dropped |
| --- | --- | --- |
| `ChatMessage` | 9 | 8 — `attachments`, `model`, `usage`, `lickCount`, `lickParts`, `lickId`, `lickState`, `error` |
| `TrayTargetEntry` | 6 | 2 — `kind`, `capabilities` |
| `MessageAttachment` | 0 | 9 — no Swift type exists at all |
| `ToolCall` | 5 | 0 (2 `local`) |
| `ScoopSummary` / `SprinkleSummary` / `RemoteTargetInfo` | 6 / 6 / 5 | 0 |

`MessageAttachment` is marked `absent` rather than `mirrored`: there is no Swift type to round-trip. The Swift suite asserts it stays unwired, so adding the mirror forces the classification to be revisited.

### Generator hardening

`packages/shared-ts/package.json` maps `exports['.']` to `./src/index.ts` for **types** but `./dist/index.js` at **runtime**. Running the generator against a stale or missing `dist` silently writes a wrong `traySyncProtocolVersion` and exits 0 — it then surfaces much later as an iOS-only CI failure with no obvious cause. I hit this while investigating #1785 and initially misread it as real protocol drift.

The generator now reads the Swift constant and refuses to write on a mismatch, pointing at `npm run build -w @slicc/shared-ts`.

### Deliberately out of scope

**The Swift fixes themselves.** Making `attachments` / `model` / `usage` / the four `AgentEvent` cases actually arrive is the "stop dropping payload fields" sub-issue. This PR is only the guard.

**The Go mirror.** `corpus_test.go:44-58` only models `hello` and `exec.*`; `agent_event` and `ChatMessage` hit `default: continue`. Its `corpusDoc` ignores unknown JSON fields, so the new sections are tolerated with no change. Giving Go field-level coverage means adding types to `target()` and bumping the `modeled < 10` floor — a separate call, noted in #1786.

## Cross-cutting impact

- **Protocol surface**: unchanged. No union member added or removed, no `traySyncProtocolVersion` bump. The `docs/architecture.md` matrix is untouched, and `tray-sync-doc-matrix.test.ts` still passes because it reads only the two variant-keyed maps.
- **Consumers of the JSON**: three. The vitest guard and the Swift suite are both updated here. The Go CLI test ignores unknown top-level fields, verified by reading `corpusDoc`.
- **Build system**: none. The new sections live inside the existing fixture file, so XcodeGen and `project.pbxproj` are unaffected — confirmed by re-running `xcodegen generate` and getting a byte-identical `project.pbxproj`.
- **Runtime**: none. The corpus module is data-only and test-only; no shipped code path changes.

## Test plan

The guards are only worth having if they fail when they should, so each was verified by deliberately breaking it, not just by watching it pass:

| Mutation | Expected | Result |
| --- | --- | --- |
| Add an `AgentEvent` variant | typecheck fails | `TS2741: Property 'probe_event' is missing … in type 'AgentEventCorpus'` |
| Add an **optional** `ChatMessage` field | typecheck fails | `TS2741: Property 'probeField' is missing … in type 'FieldExpectations<ChatMessage>'` |
| Omit a populated field from a sample | vitest fails | `every nested payload sample populates all non-local fields` |
| Corpus claims Swift keeps `ChatMessage.attachments` | XCTest fails | `testNestedPayloadFieldsSurviveTheSwiftMirror` |
| Corpus claims Swift decodes `tool_ui` | XCTest fails | `testAgentEventCorpusDecodesPerExpectation` |

Full pass on this branch:

- [x] `npm run verify` — all 7 checks pass
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK, 5 files, 0 on any debt list
- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 759 files, 12,961 tests pass
- [x] `npm run test:coverage` — thresholds pass
- [x] `npm run build` + `npm run build -w @slicc/chrome-extension` — both succeed
- [x] `npm run bundle-size` — within budget (extension total 96.49 kB / 105 kB)
- [x] `npm run lint:swift` — 0 errors
- [x] `npm run lint:swift:format` — clean
- [x] `swift-coverage-check.sh --xcodebuild SliccFollower` — 19.06 / 16.49 / 17.41 vs floors 18 / 15 / 16

All 7 `SyncProtocolCorpusTests` cases run, including the two new ones (verified by name in the xcodebuild output, not inferred from a green suite).

Coverage floors are left alone deliberately: lines moved 18.88% → 19.06%, which `floor(measured - 0.5)` still rounds to the current floor of 18, so hand-raising them would just fight the nightly ratchet.
