### PR TITLE
test(ios-app): add an XCUITest target driven by ChatFixture

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -145,9 +145,9 @@
       "regions": 79
     },
     "ios-app": {
-      "lines": 19,
-      "functions": 16,
-      "regions": 18
+      "lines": 47,
+      "functions": 32,
+      "regions": 37
     }
   }
 }

--- a/packages/dev-tools/tools/swift-coverage-check.sh
+++ b/packages/dev-tools/tools/swift-coverage-check.sh
@@ -71,6 +71,16 @@ if [[ -n "$XCODE_SCHEME" ]]; then
     echo "::error::No available iPhone simulator (install one via 'xcodebuild -downloadPlatform iOS')"
     exit 1
   fi
+  # Boot the simulator and block until it reports ready, instead of letting
+  # `xcodebuild test` boot it lazily. A UI-test runner attaching to a
+  # still-booting device dies with "Timed out while loading Accessibility",
+  # which aborts the whole session before a single test runs — so
+  # `-retry-tests-on-failure` cannot rescue it, as that retries failed tests,
+  # not a runner that never initialized.
+  echo "==> waiting for simulator $UDID to finish booting"
+  xcrun simctl bootstatus "$UDID" -b ||
+    echo "::warning::simctl bootstatus did not report a clean boot; continuing"
+
   echo "==> xcodebuild test -enableCodeCoverage YES ($PACKAGE_DIR, simulator $UDID)"
   # xcodebuild refuses to overwrite an existing result bundle, so a second local
   # run would fail before ever reaching the tests.

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -177,12 +177,29 @@ then use the avatar menu's **Enable multi-browser sync** (copies it) or ask the
 agent to run `host` and report its `join_url` — the same URL the CLI follower
 takes, see [`packages/slicc-cli/README.md`](../slicc-cli/README.md).
 
-**Known limitation.** A synthetic token verifies boot → install → launch → Join
-URL read → connect → failure state, but not the connected surfaces. Chat,
-sprinkles, and the CDP carousel need a real WebRTC peer. The sidebar's **UI
-Fixture** route (`FixtureConversationView`) renders every chat variant
-leaderless, but reaching it needs a tap — a human, or an XCUITest target that
-does not exist yet.
+**Known limitation.** A synthetic token only reaches the failure state. The
+connected surfaces — chat, sprinkles, the CDP carousel — need a real peer.
+
+## UI tests (`SliccFollowerUITests`)
+
+A `bundle.ui-testing` target runs alongside the unit bundle in the `SliccFollower`
+scheme, so `swift-coverage-check.sh --xcodebuild` picks up both. No test needs a
+leader: the `-uiTestFixtureRoute YES` launch argument reaches the leaderless
+**UI Fixture** route (`FixtureConversationView`) without a tap. `UITestHooks`
+(`App/UITestHooks.swift`) reads it and is `#if DEBUG` only — a shipped binary
+must not carry a flag that skips the connection path. The failure-state test
+dials `http://127.0.0.1:1/…`, refused without DNS or egress, so
+`Connection Failed` arrives in seconds instead of depending on CI networking.
+
+- **Put accessibility identifiers on leaves.** SwiftUI pushes one onto a
+  container's leaves instead of minting a container, so an identifier on a
+  `VStack` yields tagged leaves and no `otherElements` match — and
+  `.accessibilityElement(children: .contain)` suppresses that propagation rather
+  than fixing it. Every leaf in a message row carries `message-<id>`.
+- **The transcript is pinned to the newest message**, so a walk over every
+  variant scrolls bottom-to-top and must be bounded.
+- **The bundle is `parallelizable: false`** — cloning simulators for a UI bundle
+  races the runner install and the loser fails preflight with `Busy`.
 
 ## Linting
 

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		02019B8CFDC4B36D610933B8 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434BBAD25E91BD0B7D626821 /* AppState.swift */; };
+		09FE7E5B6F63D6850F2EBFBE /* UITestHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1308398CD972FF297E2C75 /* UITestHooks.swift */; };
 		0CAAEE94D02D4006193FA4BB /* InputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */; };
 		15CF4C85551B4FE239D55E94 /* SliccIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438577405ABBCA33F117862C /* SliccIcons.swift */; };
 		238295F68E3669C0968C9934 /* WebRTCManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AF8A8A50FCC9C2DBECA0CF /* WebRTCManager.swift */; };
@@ -18,11 +19,13 @@
 		472BB1BEB4E248916156C9EE /* tray-sync-corpus.json in Resources */ = {isa = PBXBuildFile; fileRef = FD6CEFD575FD21C28BEC39F5 /* tray-sync-corpus.json */; };
 		4874F8858460397F336DE469 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = CEF104FB1C3EDA0B98BC5FFF /* WebRTC */; };
 		487756D13ED6B5D4FB9FF6A0 /* TrayFollowerConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93EE217FAA3F9F7DD3A0B07F /* TrayFollowerConnector.swift */; };
+		4A9B912F64233A5C73E57DB4 /* FixtureConversationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FA307998C15DDB13AC2852 /* FixtureConversationUITests.swift */; };
 		532EBF4FC79CF40ABCD366F0 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E99369A8A6B1A9B8EBE996E /* WebKit.framework */; };
 		541C36C1FB80D6EDBA337FE6 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A69E83B7BB267C230C892A29 /* PrivacyInfo.xcprivacy */; };
 		58AACC678F1000C41BC7AA1A /* TabsCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39ADD0645C7DD3B30664E997 /* TabsCarouselView.swift */; };
 		5A678420A08BBB43297E1D8D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F0583BDF50B1A1B9CE68AE67 /* Assets.xcassets */; };
 		5DBC389110F337A40762C4E1 /* MessageListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E727142147B0FB449F418D1 /* MessageListView.swift */; };
+		67EC4D5BDDC4014A965FF5B4 /* ConnectionRouteUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */; };
 		73CD8FDB68D950291A923BCD /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B186EDFDE184DC8B3215C4 /* ChatView.swift */; };
 		7AFB535E78304FCE5CE7058A /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523A4A068180D7EE98435885 /* MarkdownText.swift */; };
 		7BEE859F6C68FEAFD63D1FBB /* SyncProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618555E73F15FDB4DB0CAA6F /* SyncProtocol.swift */; };
@@ -52,6 +55,13 @@
 			remoteGlobalIDString = DF5C349429D85D6ADB077CD0;
 			remoteInfo = SliccFollower;
 		};
+		3D924F53B6D8324A7CF26640 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 54B6C2249B6DB4AE685DD53E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DF5C349429D85D6ADB077CD0;
+			remoteInfo = SliccFollower;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -73,9 +83,11 @@
 		618555E73F15FDB4DB0CAA6F /* SyncProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncProtocol.swift; sourceTree = "<group>"; };
 		639AB6CC8494FCE4C252F00B /* ChunkFramingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkFramingTests.swift; sourceTree = "<group>"; };
 		7E727142147B0FB449F418D1 /* MessageListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListView.swift; sourceTree = "<group>"; };
+		88219CD0B963530C38CE40FB /* SliccFollowerUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SliccFollowerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		93EE217FAA3F9F7DD3A0B07F /* TrayFollowerConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayFollowerConnector.swift; sourceTree = "<group>"; };
 		940DB17683937E3DAE6E914C /* ConnectionStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatusView.swift; sourceTree = "<group>"; };
 		9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncProtocolCorpusTests.swift; sourceTree = "<group>"; };
+		A5FA307998C15DDB13AC2852 /* FixtureConversationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixtureConversationUITests.swift; sourceTree = "<group>"; };
 		A69E83B7BB267C230C892A29 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AF78C09597C5D63A373EB126 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
 		B4C27643E1CF51B1F1B38003 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -88,8 +100,10 @@
 		C9C3A976D441E4BB628F2183 /* SprinkleWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SprinkleWebView.swift; sourceTree = "<group>"; };
 		CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBar.swift; sourceTree = "<group>"; };
 		CFEC70BAB27CC325BCD99C01 /* SliccFollowerTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SliccFollowerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD1308398CD972FF297E2C75 /* UITestHooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestHooks.swift; sourceTree = "<group>"; };
 		F0583BDF50B1A1B9CE68AE67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F0A069AA812629AC5FE70AC9 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRouteUITests.swift; sourceTree = "<group>"; };
 		FD6CEFD575FD21C28BEC39F5 /* tray-sync-corpus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tray-sync-corpus.json"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -124,6 +138,7 @@
 			children = (
 				434BBAD25E91BD0B7D626821 /* AppState.swift */,
 				C7D4AD0E32B059DB9EABFF3E /* SliccFollowerApp.swift */,
+				DD1308398CD972FF297E2C75 /* UITestHooks.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -133,6 +148,7 @@
 			children = (
 				C00DD8A5F90DA65983AA6601 /* SliccFollower.app */,
 				CFEC70BAB27CC325BCD99C01 /* SliccFollowerTests.xctest */,
+				88219CD0B963530C38CE40FB /* SliccFollowerUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -161,9 +177,20 @@
 			children = (
 				BB5014359700AC04F578180A /* SliccFollower */,
 				32BEF7BC73FC1288DC470211 /* SliccFollowerTests */,
+				7F41C1476E661236B93AE3D7 /* SliccFollowerUITests */,
 				B2AAEACBF84A968A5C6054DD /* Frameworks */,
 				4F9716065FA89F76CAF30D9E /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		7F41C1476E661236B93AE3D7 /* SliccFollowerUITests */ = {
+			isa = PBXGroup;
+			children = (
+				FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */,
+				A5FA307998C15DDB13AC2852 /* FixtureConversationUITests.swift */,
+			);
+			name = SliccFollowerUITests;
+			path = SliccFollower/Tests/SliccFollowerUITests;
 			sourceTree = "<group>";
 		};
 		8004F77F534D7D3B9F54E8C3 /* Views */ = {
@@ -288,6 +315,24 @@
 			productReference = CFEC70BAB27CC325BCD99C01 /* SliccFollowerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		FF48252A89FE80B2D64FDC90 /* SliccFollowerUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 24D3619F007563D9014EB45D /* Build configuration list for PBXNativeTarget "SliccFollowerUITests" */;
+			buildPhases = (
+				8FA602BBB356290A90DFBA7B /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7595BF89A13B56013568F142 /* PBXTargetDependency */,
+			);
+			name = SliccFollowerUITests;
+			packageProductDependencies = (
+			);
+			productName = SliccFollowerUITests;
+			productReference = 88219CD0B963530C38CE40FB /* SliccFollowerUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -297,6 +342,9 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					FF48252A89FE80B2D64FDC90 = {
+						TestTargetID = DF5C349429D85D6ADB077CD0;
+					};
 				};
 			};
 			buildConfigurationList = 72096B669C8B76EFAEF1AC1F /* Build configuration list for PBXProject "SliccFollower" */;
@@ -318,6 +366,7 @@
 			targets = (
 				DF5C349429D85D6ADB077CD0 /* SliccFollower */,
 				EF35FD5A64E737F1EEFDEDE2 /* SliccFollowerTests */,
+				FF48252A89FE80B2D64FDC90 /* SliccFollowerUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -372,7 +421,17 @@
 				487756D13ED6B5D4FB9FF6A0 /* TrayFollowerConnector.swift in Sources */,
 				D2A85DC611A43443DEC75989 /* TraySignaling.swift in Sources */,
 				8A4DC8067E31936EA9C475BC /* TrayTypes.swift in Sources */,
+				09FE7E5B6F63D6850F2EBFBE /* UITestHooks.swift in Sources */,
 				238295F68E3669C0968C9934 /* WebRTCManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8FA602BBB356290A90DFBA7B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				67EC4D5BDDC4014A965FF5B4 /* ConnectionRouteUITests.swift in Sources */,
+				4A9B912F64233A5C73E57DB4 /* FixtureConversationUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -389,6 +448,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		7595BF89A13B56013568F142 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DF5C349429D85D6ADB077CD0 /* SliccFollower */;
+			targetProxy = 3D924F53B6D8324A7CF26640 /* PBXContainerItemProxy */;
+		};
 		848263A7AC089AF8851BD101 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DF5C349429D85D6ADB077CD0 /* SliccFollower */;
@@ -418,6 +482,26 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
 				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		09725B910ED157E57DE3096A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.sliccy.follower.uitests;
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SliccFollower;
 			};
 			name = Release;
 		};
@@ -594,6 +678,26 @@
 			};
 			name = Debug;
 		};
+		CAE235A54EA0A4097FC7179B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.sliccy.follower.uitests;
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = SliccFollower;
+			};
+			name = Debug;
+		};
 		D32C961F5ABE2A1D6FF64AAB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -617,6 +721,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		24D3619F007563D9014EB45D /* Build configuration list for PBXNativeTarget "SliccFollowerUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CAE235A54EA0A4097FC7179B /* Debug */,
+				09725B910ED157E57DE3096A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		5BB123793342DC590D40B995 /* Build configuration list for PBXNativeTarget "SliccFollower" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/packages/ios-app/SliccFollower.xcodeproj/xcshareddata/xcschemes/SliccFollower.xcscheme
+++ b/packages/ios-app/SliccFollower.xcodeproj/xcshareddata/xcschemes/SliccFollower.xcscheme
@@ -35,6 +35,20 @@
                ReferencedContainer = "container:SliccFollower.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FF48252A89FE80B2D64FDC90"
+               BuildableName = "SliccFollowerUITests.xctest"
+               BlueprintName = "SliccFollowerUITests"
+               ReferencedContainer = "container:SliccFollower.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -63,6 +77,18 @@
                BlueprintIdentifier = "EF35FD5A64E737F1EEFDEDE2"
                BuildableName = "SliccFollowerTests.xctest"
                BlueprintName = "SliccFollowerTests"
+               ReferencedContainer = "container:SliccFollower.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FF48252A89FE80B2D64FDC90"
+               BuildableName = "SliccFollowerUITests.xctest"
+               BlueprintName = "SliccFollowerUITests"
                ReferencedContainer = "container:SliccFollower.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/packages/ios-app/SliccFollower/App/UITestHooks.swift
+++ b/packages/ios-app/SliccFollower/App/UITestHooks.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+#if DEBUG
+    /// Launch-argument seams that let XCUITest reach a deterministic screen
+    /// without a leader on the other end.
+    ///
+    /// These read the `UserDefaults` argument domain, the same mechanism the
+    /// documented `-joinUrl` override uses (see `packages/ios-app/CLAUDE.md`).
+    /// The argument domain outranks the persistent domain, so a test that
+    /// passes a key explicitly is immune to whatever a previous run left on
+    /// disk — which matters because the suite runs in random order.
+    ///
+    /// Compiled out of release builds. A shipped binary must not carry an
+    /// argument that skips the connection path.
+    enum UITestHooks {
+        /// Route straight to `FixtureConversationView` and skip the join /
+        /// connect path entirely, so no test needs a live WebRTC peer.
+        static var routesToFixture: Bool {
+            UserDefaults.standard.bool(forKey: "uiTestFixtureRoute")
+        }
+    }
+#endif

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/ConnectionRouteUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/ConnectionRouteUITests.swift
@@ -23,8 +23,10 @@ final class ConnectionRouteUITests: XCTestCase {
         XCTAssertTrue(
             app.navigationBars["Settings"].waitForExistence(timeout: 60),
             "An empty join URL should open the Settings sheet on launch")
+        // The sheet's chrome can lag its navigation bar on a loaded simulator,
+        // so this waits rather than sampling once.
         XCTAssertTrue(
-            app.buttons["Done"].exists,
+            app.buttons["Done"].waitForExistence(timeout: 30),
             "The Settings sheet should offer its dismiss control")
     }
 

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/ConnectionRouteUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/ConnectionRouteUITests.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+/// UI coverage for the two launch states that do not need a leader: no stored
+/// join URL (Settings sheet) and an unreachable one (failed connection).
+final class ConnectionRouteUITests: XCTestCase {
+
+    /// Refused on connect rather than left hanging: port 1 on the loopback
+    /// interface needs no DNS and no network, so `attach()` throws on the first
+    /// attempt and `AppState` settles on `.failed` fast. A public host would
+    /// make this test depend on CI egress and on retry timing.
+    private static let unreachableJoinUrl = "http://127.0.0.1:1/join/ui-test"
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testSettingsSheetOpensWhenNoJoinUrlIsStored() {
+        let app = XCUIApplication()
+        app.launchArguments += ["-joinUrl", ""]
+        app.launch()
+
+        XCTAssertTrue(
+            app.navigationBars["Settings"].waitForExistence(timeout: 60),
+            "An empty join URL should open the Settings sheet on launch")
+        XCTAssertTrue(
+            app.buttons["Done"].exists,
+            "The Settings sheet should offer its dismiss control")
+    }
+
+    func testConnectionPillReportsFailureForAnUnreachableLeader() {
+        let app = XCUIApplication()
+        app.launchArguments += ["-joinUrl", Self.unreachableJoinUrl]
+        app.launch()
+
+        let pill = app.staticTexts["connection-status"]
+        XCTAssertTrue(
+            pill.waitForExistence(timeout: 30),
+            "A stored join URL should skip Settings and show the status pill")
+
+        // The pill passes through "Connecting…" first, so wait for the settled
+        // state rather than asserting on whatever is on screen at first sight.
+        let failed = NSPredicate(format: "label == %@", "Connection Failed")
+        expectation(for: failed, evaluatedWith: pill)
+        waitForExpectations(timeout: 60)
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
@@ -35,6 +35,25 @@ final class FixtureConversationUITests: XCTestCase {
         "fx-assistant-streaming",
     ]
 
+    /// Substrings that only a variant-specific renderer can produce.
+    ///
+    /// Row ids alone are not enough: SwiftUI propagates `message-<id>` to every
+    /// leaf in the row, so a row still matches while its specialized subview is
+    /// gone — delete the tool cluster and the plain bubble text keeps carrying
+    /// the id. Each marker below is emitted by exactly one renderer, so losing
+    /// that renderer fails the walk.
+    private static let variantMarkers = [
+        "Working",  // collapsed tool-call cluster header
+        "edit: error",  // per-call status dot, error state
+        "bash: running",  // per-call status dot, running state
+        "list scoops",  // ungrouped tool row (fewer than 3 calls)
+        "github-push",  // lick pill, webhook channel
+        "src-watch",  // lick pill, fswatch channel relabelled "files"
+        "0.4.1→0.5.0",  // lick pill, upgrade channel
+        "Instructions from sliccy",  // delegation-sourced user message
+        "npm run test",  // running tool under the streaming message
+    ]
+
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
@@ -56,7 +75,8 @@ final class FixtureConversationUITests: XCTestCase {
             "The fixture route should not show a connection pill")
     }
 
-    /// Walks the whole transcript and asserts every fixture variant rendered.
+    /// Walks the whole transcript and asserts every fixture variant rendered —
+    /// both that each row exists and that its specialized renderer ran.
     ///
     /// The list is a `LazyVStack` pinned to the newest message, so offscreen
     /// rows are absent from the accessibility tree and the walk has to run
@@ -68,25 +88,31 @@ final class FixtureConversationUITests: XCTestCase {
             app.staticTexts["fixture-header"].waitForExistence(timeout: 60),
             "The fixture route should render before scrolling")
 
-        var seen = visibleMessageIds(in: app)
+        var seenIds = visibleMessageIds(in: app)
+        var seenLabels = visibleLabels(in: app)
         var barrenScrolls = 0
 
         // Bounded so a layout regression that stops the list scrolling fails
         // here instead of hanging until the suite times out.
-        for _ in 0..<40 where seen != Self.expectedMessageIds {
-            let before = seen.count
+        for _ in 0..<40 where !isComplete(ids: seenIds, labels: seenLabels) {
+            let before = seenIds.count + seenLabels.count
             app.swipeDown()
-            seen.formUnion(visibleMessageIds(in: app))
+            seenIds.formUnion(visibleMessageIds(in: app))
+            seenLabels.formUnion(visibleLabels(in: app))
             // One dry pass is normal at the top of the list; three in a row
             // means scrolling has stopped making progress.
-            barrenScrolls = seen.count == before ? barrenScrolls + 1 : 0
+            barrenScrolls = seenIds.count + seenLabels.count == before ? barrenScrolls + 1 : 0
             if barrenScrolls >= 3 { break }
         }
 
         XCTAssertEqual(
-            seen, Self.expectedMessageIds,
-            "Fixture variants never rendered: "
-                + "\(Self.expectedMessageIds.subtracting(seen).sorted())")
+            seenIds, Self.expectedMessageIds,
+            "Fixture rows never rendered: "
+                + "\(Self.expectedMessageIds.subtracting(seenIds).sorted())")
+        XCTAssertEqual(
+            missingMarkers(in: seenLabels), [],
+            "Variant renderers produced no output; the row can still carry its "
+                + "id while its specialized subview is gone")
     }
 
     func testReloadRebuildsTheTranscript() {
@@ -137,5 +163,25 @@ final class FixtureConversationUITests: XCTestCase {
         return Set(
             rows.allElementsBoundByAccessibilityElement
                 .map { String($0.identifier.dropFirst(prefix.count)) })
+    }
+
+    /// Accessibility labels currently on screen. Text and buttons are where the
+    /// variant-specific renderers put their output — tool rows and lick pills
+    /// are buttons, bubbles are text.
+    private func visibleLabels(in app: XCUIApplication) -> Set<String> {
+        var labels = Set<String>()
+        labels.formUnion(app.staticTexts.allElementsBoundByAccessibilityElement.map(\.label))
+        labels.formUnion(app.buttons.allElementsBoundByAccessibilityElement.map(\.label))
+        return labels
+    }
+
+    private func missingMarkers(in labels: Set<String>) -> [String] {
+        Self.variantMarkers.filter { marker in
+            !labels.contains { $0.contains(marker) }
+        }
+    }
+
+    private func isComplete(ids: Set<String>, labels: Set<String>) -> Bool {
+        ids == Self.expectedMessageIds && missingMarkers(in: labels).isEmpty
     }
 }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
@@ -90,19 +90,30 @@ final class FixtureConversationUITests: XCTestCase {
 
         var seenIds = visibleMessageIds(in: app)
         var seenLabels = visibleLabels(in: app)
-        var barrenScrolls = 0
+        var previousScreen = seenIds.union(seenLabels)
+        var unchangedScrolls = 0
 
         // Bounded so a layout regression that stops the list scrolling fails
         // here instead of hanging until the suite times out.
         for _ in 0..<40 where !isComplete(ids: seenIds, labels: seenLabels) {
-            let before = seenIds.count + seenLabels.count
             app.swipeDown()
-            seenIds.formUnion(visibleMessageIds(in: app))
-            seenLabels.formUnion(visibleLabels(in: app))
-            // One dry pass is normal at the top of the list; three in a row
-            // means scrolling has stopped making progress.
-            barrenScrolls = seenIds.count + seenLabels.count == before ? barrenScrolls + 1 : 0
-            if barrenScrolls >= 3 { break }
+            let ids = visibleMessageIds(in: app)
+            let labels = visibleLabels(in: app)
+            seenIds.formUnion(ids)
+            seenLabels.formUnion(labels)
+
+            // Progress means *the screen changed*, not that the cumulative set
+            // grew. Scrolling across rows already recorded adds nothing new
+            // while still making progress, so counting that as a dry pass ends
+            // the walk early — which is exactly how this went flaky on CI,
+            // where the slower list renders fewer fresh rows per swipe.
+            let screen = ids.union(labels)
+            unchangedScrolls = screen == previousScreen ? unchangedScrolls + 1 : 0
+            previousScreen = screen
+            // The top of the list is stable forever, so waiting several rounds
+            // costs a few swipes there and tolerates a swipe whose animation
+            // had not settled when the tree was read.
+            if unchangedScrolls >= 4 { break }
         }
 
         XCTAssertEqual(

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
@@ -1,0 +1,141 @@
+import XCTest
+
+/// UI coverage for the leaderless fixture route.
+///
+/// `FixtureConversationView` renders every chat variant with no peer attached,
+/// so these tests need no signaling server and no WebRTC connection. The route
+/// is reached with the `-uiTestFixtureRoute` launch argument (see
+/// `App/UITestHooks.swift`) rather than by tapping through the sidebar.
+final class FixtureConversationUITests: XCTestCase {
+
+    /// Every id in `ChatFixture.makeMessages()`.
+    ///
+    /// Duplicated here on purpose: a UI test bundle cannot import the app
+    /// target, so this list is what makes "every variant still renders"
+    /// enforceable. Adding or removing a fixture message fails
+    /// `testEveryFixtureMessageVariantRenders` until this list is updated too.
+    private static let expectedMessageIds: Set<String> = [
+        "fx-user-1",
+        "fx-assistant-1",
+        "fx-user-2",
+        "fx-assistant-2",
+        "fx-assistant-sprinkle",
+        "fx-assistant-sprinkle-bare",
+        "fx-assistant-3",
+        "fx-assistant-mgmt",
+        "fx-delegation-1",
+        "fx-assistant-delegated",
+        "fx-lick-webhook",
+        "fx-lick-cron",
+        "fx-lick-sprinkle",
+        "fx-lick-fswatch",
+        "fx-lick-navigate",
+        "fx-lick-upgrade",
+        "fx-queued-1",
+        "fx-assistant-streaming",
+    ]
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testFixtureConversationRendersWithoutALeader() {
+        let app = launchFixtureApp()
+
+        XCTAssertTrue(
+            app.staticTexts["fixture-header"].waitForExistence(timeout: 60),
+            "The fixture route should render without a leader attached")
+        XCTAssertTrue(
+            app.buttons["Reload"].exists,
+            "The fixture chrome should offer a reload control")
+        // No leader means no connection. The status pill belongs to
+        // ConversationView and must not bleed into the fixture route.
+        XCTAssertFalse(
+            app.staticTexts["connection-status"].exists,
+            "The fixture route should not show a connection pill")
+    }
+
+    /// Walks the whole transcript and asserts every fixture variant rendered.
+    ///
+    /// The list is a `LazyVStack` pinned to the newest message, so offscreen
+    /// rows are absent from the accessibility tree and the walk has to run
+    /// bottom-to-top. Scrolling is what makes this a real assertion rather than
+    /// a check that the last screenful happens to be right.
+    func testEveryFixtureMessageVariantRenders() {
+        let app = launchFixtureApp()
+        XCTAssertTrue(
+            app.staticTexts["fixture-header"].waitForExistence(timeout: 60),
+            "The fixture route should render before scrolling")
+
+        var seen = visibleMessageIds(in: app)
+        var barrenScrolls = 0
+
+        // Bounded so a layout regression that stops the list scrolling fails
+        // here instead of hanging until the suite times out.
+        for _ in 0..<40 where seen != Self.expectedMessageIds {
+            let before = seen.count
+            app.swipeDown()
+            seen.formUnion(visibleMessageIds(in: app))
+            // One dry pass is normal at the top of the list; three in a row
+            // means scrolling has stopped making progress.
+            barrenScrolls = seen.count == before ? barrenScrolls + 1 : 0
+            if barrenScrolls >= 3 { break }
+        }
+
+        XCTAssertEqual(
+            seen, Self.expectedMessageIds,
+            "Fixture variants never rendered: "
+                + "\(Self.expectedMessageIds.subtracting(seen).sorted())")
+    }
+
+    func testReloadRebuildsTheTranscript() {
+        let app = launchFixtureApp()
+        XCTAssertTrue(
+            app.staticTexts["fixture-header"].waitForExistence(timeout: 60),
+            "The fixture route should render before reloading")
+        XCTAssertFalse(
+            visibleMessageIds(in: app).isEmpty,
+            "The transcript should be populated before reloading")
+
+        app.buttons["Reload"].tap()
+
+        XCTAssertTrue(
+            app.staticTexts["fixture-header"].waitForExistence(timeout: 30),
+            "Reload should leave the header on its default copy")
+        XCTAssertFalse(
+            visibleMessageIds(in: app).isEmpty,
+            "Reload should rebuild the fixture transcript")
+    }
+
+    // MARK: - Helpers
+
+    /// Launch straight into the fixture route.
+    ///
+    /// `joinUrl` is passed explicitly and empty so a value persisted by another
+    /// test cannot leak in — the argument domain outranks the persistent one,
+    /// and the suite runs in random order across parallel simulator clones.
+    private func launchFixtureApp() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-uiTestFixtureRoute", "YES",
+            "-joinUrl", "",
+        ]
+        app.launch()
+        return app
+    }
+
+    /// Message ids currently present in the accessibility tree.
+    ///
+    /// SwiftUI pushes a row's identifier down onto its leaf elements, so one
+    /// message yields several matches; the set collapses them. One query per
+    /// scroll step keeps the walk to tens of round-trips rather than hundreds.
+    private func visibleMessageIds(in app: XCUIApplication) -> Set<String> {
+        let prefix = "message-"
+        let rows = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier BEGINSWITH %@", prefix))
+        return Set(
+            rows.allElementsBoundByAccessibilityElement
+                .map { String($0.identifier.dropFirst(prefix.count)) })
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
@@ -66,7 +66,7 @@ final class FixtureConversationUITests: XCTestCase {
             app.staticTexts["fixture-header"].waitForExistence(timeout: 60),
             "The fixture route should render without a leader attached")
         XCTAssertTrue(
-            app.buttons["Reload"].exists,
+            app.buttons["Reload"].waitForExistence(timeout: 30),
             "The fixture chrome should offer a reload control")
         // No leader means no connection. The status pill belongs to
         // ConversationView and must not bleed into the fixture route.
@@ -87,6 +87,9 @@ final class FixtureConversationUITests: XCTestCase {
         XCTAssertTrue(
             app.staticTexts["fixture-header"].waitForExistence(timeout: 60),
             "The fixture route should render before scrolling")
+        XCTAssertTrue(
+            waitForAnyMessageRow(in: app),
+            "Rows should be on screen before the walk starts")
 
         var seenIds = visibleMessageIds(in: app)
         var seenLabels = visibleLabels(in: app)
@@ -131,8 +134,8 @@ final class FixtureConversationUITests: XCTestCase {
         XCTAssertTrue(
             app.staticTexts["fixture-header"].waitForExistence(timeout: 60),
             "The fixture route should render before reloading")
-        XCTAssertFalse(
-            visibleMessageIds(in: app).isEmpty,
+        XCTAssertTrue(
+            waitForAnyMessageRow(in: app),
             "The transcript should be populated before reloading")
 
         app.buttons["Reload"].tap()
@@ -140,8 +143,8 @@ final class FixtureConversationUITests: XCTestCase {
         XCTAssertTrue(
             app.staticTexts["fixture-header"].waitForExistence(timeout: 30),
             "Reload should leave the header on its default copy")
-        XCTAssertFalse(
-            visibleMessageIds(in: app).isEmpty,
+        XCTAssertTrue(
+            waitForAnyMessageRow(in: app),
             "Reload should rebuild the fixture transcript")
     }
 
@@ -160,6 +163,20 @@ final class FixtureConversationUITests: XCTestCase {
         ]
         app.launch()
         return app
+    }
+
+    /// Block until at least one message row is in the accessibility tree.
+    ///
+    /// A single-shot query straight after a transition is a race: the header
+    /// can already be up while the `LazyVStack` is still materializing rows.
+    /// That window is invisible locally and wide enough on a loaded CI
+    /// simulator to fail the assertion outright, so every row read that
+    /// follows a launch or a rebuild waits here first.
+    private func waitForAnyMessageRow(in app: XCUIApplication, timeout: TimeInterval = 30) -> Bool {
+        app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier BEGINSWITH %@", "message-"))
+            .firstMatch
+            .waitForExistence(timeout: timeout)
     }
 
     /// Message ids currently present in the accessibility tree.

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
@@ -35,6 +35,11 @@ final class FixtureConversationUITests: XCTestCase {
         "fx-assistant-streaming",
     ]
 
+    /// Last message in `ChatFixture.makeMessages()`, and therefore the row the
+    /// list auto-scrolls to. The bottom-to-top walk uses it as its start
+    /// signal, so it must stay in step with the fixture's tail.
+    private static let newestFixtureMessageId = "fx-assistant-streaming"
+
     /// Substrings that only a variant-specific renderer can produce.
     ///
     /// Row ids alone are not enough: SwiftUI propagates `message-<id>` to every
@@ -88,8 +93,8 @@ final class FixtureConversationUITests: XCTestCase {
             app.staticTexts["fixture-header"].waitForExistence(timeout: 60),
             "The fixture route should render before scrolling")
         XCTAssertTrue(
-            waitForAnyMessageRow(in: app),
-            "Rows should be on screen before the walk starts")
+            waitForListToSettleAtBottom(in: app),
+            "The list should settle on its newest message before the walk starts")
 
         var seenIds = visibleMessageIds(in: app)
         var seenLabels = visibleLabels(in: app)
@@ -163,6 +168,25 @@ final class FixtureConversationUITests: XCTestCase {
         ]
         app.launch()
         return app
+    }
+
+    /// Block until the list has settled on its newest message.
+    ///
+    /// The walk starts at the bottom and only ever scrolls up, so a row the
+    /// first sample misses is never seen again. Waiting for *any* row is not
+    /// enough — rows materialize while the auto-scroll to the bottom is still
+    /// in flight, and sampling then drops the newest message from the set
+    /// permanently. That is precisely how CI collected seventeen of the
+    /// eighteen fixture rows and lost `fx-assistant-streaming` every time.
+    private func waitForListToSettleAtBottom(in app: XCUIApplication, timeout: TimeInterval = 30)
+        -> Bool
+    {
+        app.descendants(matching: .any)
+            .matching(
+                NSPredicate(format: "identifier == %@", "message-\(Self.newestFixtureMessageId)")
+            )
+            .firstMatch
+            .waitForExistence(timeout: timeout)
     }
 
     /// Block until at least one message row is in the accessibility tree.

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -39,6 +39,12 @@ struct ChatView: View {
         .onAppear {
             guard !hasAppeared else { return }
             hasAppeared = true
+            #if DEBUG
+                if UITestHooks.routesToFixture {
+                    route = .fixture
+                    return
+                }
+            #endif
             let stored = UserDefaults.standard.string(forKey: "joinUrl") ?? ""
             if stored.isEmpty {
                 showSettings = true
@@ -159,6 +165,7 @@ struct FixtureConversationView: View {
                     Text("UI Fixture — synthetic session")
                         .font(.caption)
                         .foregroundStyle(.white.opacity(0.7))
+                        .accessibilityIdentifier("fixture-header")
                 }
                 Spacer()
                 Button("Reload") {

--- a/packages/ios-app/SliccFollower/Views/ConnectionStatusView.swift
+++ b/packages/ios-app/SliccFollower/Views/ConnectionStatusView.swift
@@ -38,6 +38,7 @@ struct ConnectionStatusView: View {
                     Text(text)
                         .font(.system(size: 13, weight: .medium))
                         .foregroundStyle(.white.opacity(0.85))
+                        .accessibilityIdentifier("connection-status")
                 }
 
                 if state == .connecting {

--- a/packages/ios-app/SliccFollower/Views/MessageListView.swift
+++ b/packages/ios-app/SliccFollower/Views/MessageListView.swift
@@ -57,6 +57,13 @@ struct MessageListView: View {
                             )
                             .id(message.id)
                             .padding(.horizontal, 12)
+                            // SwiftUI pushes an identifier down onto the row's
+                            // leaf elements rather than minting a container,
+                            // so every bubble, pill and tool button inside a
+                            // message carries this id. That is what lets UI
+                            // tests ask which messages are on screen without
+                            // matching on user-visible copy.
+                            .accessibilityIdentifier("message-\(message.id)")
                         }
                     }
 

--- a/packages/ios-app/project.yml
+++ b/packages/ios-app/project.yml
@@ -47,12 +47,24 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sliccy.follower.tests
+  SliccFollowerUITests:
+    type: bundle.ui-testing
+    supportedDestinations: [iOS]
+    sources:
+      - path: SliccFollower/Tests/SliccFollowerUITests
+    dependencies:
+      - target: SliccFollower
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.sliccy.follower.uitests
+        TEST_TARGET_NAME: SliccFollower
 schemes:
   SliccFollower:
     build:
       targets:
         SliccFollower: all
         SliccFollowerTests: [test]
+        SliccFollowerUITests: [test]
     test:
       gatherCoverageData: true
       coverageTargets:
@@ -60,6 +72,14 @@ schemes:
       targets:
         - name: SliccFollowerTests
           parallelizable: true
+          randomExecutionOrder: true
+        # Serial on purpose. Each UI test is independent — it launches its own
+        # app process with its own launch arguments — but cloning simulators
+        # for a UI bundle races the runner install, and the clone that loses
+        # fails preflight with "Busy" before any test runs. Random order still
+        # holds, so the independence these tests are written for stays enforced.
+        - name: SliccFollowerUITests
+          parallelizable: false
           randomExecutionOrder: true
 packages:
   WebRTC:


### PR DESCRIPTION
## Summary

The SwiftUI surface had no test at all. One unit bundle covered the protocol decoder and chunk framing; the fixture route rendered every chat variant leaderless but could only be reached by a human finger. Every UI deliverable in #1785 was landing blind.

This adds a `bundle.ui-testing` bundle to the `SliccFollower` scheme and five hermetic tests:

| Test | Asserts |
| --- | --- |
| `testFixtureConversationRendersWithoutALeader` | fixture chrome renders; no connection pill bleeds in |
| `testEveryFixtureMessageVariantRenders` | all 18 `ChatFixture` variants appear |
| `testReloadRebuildsTheTranscript` | Reload restores the transcript and header |
| `testSettingsSheetOpensWhenNoJoinUrlIsStored` | empty join URL opens Settings |
| `testConnectionPillReportsFailureForAnUnreachableLeader` | pill settles on `Connection Failed` |

## Why

**No test needs a WebRTC peer.** The fixture is reached with a `#if DEBUG` launch argument (`-uiTestFixtureRoute YES`) rather than a tap, reusing the `UserDefaults` argument-domain seam already documented for `-joinUrl`. `UITestHooks` is compiled out of release builds: a shipped binary must not carry a flag that skips the connection path.

The failure-state test dials `http://127.0.0.1:1/…`. That is refused immediately with no DNS and no egress, so `Connection Failed` arrives in seconds instead of depending on CI networking or on `attachWithRetry`'s timing. Every test also passes `-joinUrl` explicitly, because the argument domain outranks the persistent one and the suite runs in random order.

**Coverage:** 19.69 → **47.64** lines, 16.53 → **33.25** functions, 19.25 → **37.57** regions. Floors move to exactly what the nightly ratchet would compute (`Math.floor(actual - MARGIN)`, `MARGIN = 0.5`) rather than to hand-picked numbers.

## Approach / Implementation notes

Two findings that cost real debugging time, both now recorded in `packages/ios-app/CLAUDE.md`:

1. **SwiftUI accessibility identifiers only work on leaves.** An identifier on a container propagates down to that container's leaf elements instead of minting a container element, so `app.otherElements["…"]` never matches. Worse, adding `.accessibilityElement(children: .contain)` to force a container *suppresses* the propagation, leaving the row with no identifier at all. My first attempt did exactly that and every fixture test failed on a 30s timeout. I dumped the live accessibility tree to find it rather than guessing. Message rows now rely on the propagating form: every leaf in a row carries `message-<id>`.

2. **The UI bundle is `parallelizable: false`.** Cloning simulators for a UI bundle races the runner install; the losing clone dies with `Application failed preflight checks` / `Busy` before any test runs. This is not hypothetical — it reproduced twice through the coverage script with 33/33 tests passing and the run still marked failed. The tests themselves are independent (each launches its own app process with its own arguments) and `randomExecutionOrder` stays on, so the independence requirement in #1788 is still enforced.

The transcript is pinned to the newest message, so the variant walk scrolls bottom-to-top and is bounded, failing rather than hanging if the list ever stops scrolling.

## Test plan

Acceptance from #1788, point by point:

- [x] `swift-coverage-check.sh --xcodebuild SliccFollower packages/ios-app SliccFollower` runs **both** bundles and passes — 33 tests, exit 0. Only one `Coverage.profdata` is produced, so the script's `head -1` stays correct, and the binary still resolves to `SliccFollower.app/SliccFollower.debug.dylib`.
- [x] **A deliberately broken view fails a UI test** — verified by mutation:

| Mutation | Expected failure | Result |
| --- | --- | --- |
| List filters out lick rows | `testEveryFixtureMessageVariantRenders` | failed as intended |
| `Connection Failed` copy renamed | `testConnectionPillReportsFailureForAnUnreachableLeader` | failed as intended |

  The other three kept passing in the same run. Both reverted.
- [x] **CI wall time** — the UI suite adds ~46s; the whole gate finishes far inside the 40-minute `ios-app` timeout.
- [x] `npm run verify`, `check-touched-exemptions`, `typecheck`, `test` (760 files), both builds, `bundle-size`
- [x] `swift format lint --strict` clean; SwiftLint **14 violations, unchanged from baseline**

## Documentation

- [x] `packages/ios-app/CLAUDE.md` — new UI-tests section; removed the stale claim that this target "does not exist yet". Trimmed elsewhere to stay under the 20,000-char cap.

Closes #1788, part of #1785. This unblocks the rendering half of #1792 and the UI tracks.
