### PR TITLE
fix(webcomponents): cut cone glass animation speed by 75%

### DIFF
--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -15,7 +15,7 @@ import { h, sheet } from '../internal/dom.js';
  * @attr mode - `cone` (default) | `scoop` | `freezer`
  * @attr tint - CSS color washed into the scoop field / event glow (the active accent)
  * @attr coverage - 0..1 freezer frost growth / cone glass density and geometry
- * @attr speed - 0..2 cone glass animation rate multiplier (default 0.25)
+ * @attr speed - 0..2 cone glass animation rate multiplier (default 0.0625)
  * @attr scroll - chat scroll offset in CSS px; pans the field with the content
  * @attr intensity - multiplier for coverage (freezer)
  * @attr no-webgl - reflected when WebGL is unavailable (CSS fallback)
@@ -206,7 +206,7 @@ export const SUGAR_GLASS_PRESETS = {
     noise: 0.025,
     blur: 0.14,
     coverage: 0.28,
-    speed: 0.25,
+    speed: 0.0625,
   },
   'caramel-soft': {
     mode: 'cone',
@@ -525,7 +525,7 @@ export class SliccShader extends HTMLElement {
     this.setAttribute('blur', String(value));
   }
 
-  /** Cone glass animation rate multiplier (0 = paused, Caramel default = 0.25). */
+  /** Cone glass animation rate multiplier (0 = paused, Caramel default = 0.0625). */
   get speed(): number {
     return clampNum(
       Number.parseFloat(this.getAttribute('speed') ?? ''),

--- a/packages/webcomponents/tests/freezer/slicc-shader.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-shader.test.ts
@@ -118,18 +118,18 @@ describe('slicc-shader', () => {
     expect(el.blurAmount).toBeCloseTo(0.14, 5);
   });
 
-  it('reflects and clamps the cone glass animation speed (Caramel default 0.25)', () => {
+  it('reflects and clamps the cone glass animation speed (Caramel default 0.0625)', () => {
     const el = mount();
-    expect(el.speed).toBe(0.25);
-    el.speed = 0.25;
-    expect(el.getAttribute('speed')).toBe('0.25');
-    expect(el.speed).toBe(0.25);
+    expect(el.speed).toBe(0.0625);
+    el.speed = 0.0625;
+    expect(el.getAttribute('speed')).toBe('0.0625');
+    expect(el.speed).toBe(0.0625);
     el.setAttribute('speed', '-1');
     expect(el.speed).toBe(0);
     el.setAttribute('speed', '99');
     expect(el.speed).toBe(2);
     el.setAttribute('speed', 'nope');
-    expect(el.speed).toBe(0.25);
+    expect(el.speed).toBe(0.0625);
   });
 
   it('keeps the cone glass render loop healthy when speed is zero', async () => {
@@ -444,7 +444,7 @@ describe('cone Sugar Glass field colors', () => {
         noise: 0.025,
         blur: 0.14,
         coverage: 0.28,
-        speed: 0.25,
+        speed: 0.0625,
       },
       'caramel-soft': {
         mode: 'cone',


### PR DESCRIPTION
## Problem

The cone (Sugar Glass) background field still reads as moving too fast. The shipped app mounts `<n mode="cone">` in `packages/webapp/src/ui/wc/wc-shell.ts` with no `speed` attribute, so it falls back to `SUGAR_GLASS_PRESETS.caramel.speed` — the single value that scales the shader's only time term.

## Change

`SUGAR_GLASS_PRESETS.caramel.speed`: `0.25` → `0.0625` (a 75% reduction, 4x slower). Both JSDoc comments that quote the default were updated to match.

Deliberately untouched:

- The other presets (`caramel-soft`, `frosted`, `brittle`, `waffle-glass`) — Storybook/storyboard variants, not the shipped default
- The `0..2` attribute clamp range
- The GLSL source, including the parallax term and the `sign(u_speed)` zero-speed freeze

## Tests

`packages/webcomponents/tests/freezer/slicc-shader.test.ts` — updated the speed default assertion, the invalid-input fallback, the test name, and the preset table entry.

## Verification

- `npm run verify` — all 7 checks pass
- `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK, 0 touched files on any debt list
- `npm run typecheck` — clean
- `npm run test` — 13,025 pass / 46 skipped
- `npm run test:coverage` — floors met
- `npm run build` + `npm run build -w @slicc/chrome-extension` — clean
- `npm run bundle-size` — all budgets under limit

## Follow-up

0.0625 is slow enough that the field may read as effectively static. If that overshoots, `0.1` is a one-value adjustment.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author