### PR TITLE
feat: centrally-managed feature flag system with experimental settings pane

### DIFF
--- a/packages/cherry/CLAUDE.md
+++ b/packages/cherry/CLAUDE.md
@@ -87,6 +87,11 @@ mountSlicc({
   at mount time and sent in `handshake.welcome`; there is no runtime toggle.
   Separate from `capabilities` (which gates agent _powers_ over the host page);
   features gate _UI surfaces_ shown to the user.
+- **Feature flags are separate:** the `?cherry=1` webapp boot uses the shared registry in
+  `packages/webapp/src/core/feature-flags.ts` with Cherry defaults (`experimental-settings`
+  is off). This is not `SIDE_PANEL_FEATURES` in
+  `packages/chrome-extension/src/cherry-panel-protocol.ts`: that constant is host-provided,
+  mount-time `CherryFeatures` panel visibility sent in `handshake.welcome`, not remote flag config.
 - `theme` accepts a `SliccTheme` object (`{ id, name, base, tokens, css?,
 disableShader?, components? }`) that the SDK serializes as JSON in the
   handshake welcome. The follower applies it on boot via `applyCherryTheme`,

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -22,6 +22,7 @@ the built SLICC webapp as static assets to browser visitors.
 | `src/install-cli.ts`                                                                   | `/install-cli` POSIX installer script + `/download/slicc-cli/:target` release-asset resolver                        |
 | `src/llms-txt.ts`                                                                      | `/llms.txt` builder                                                                                                 |
 | `src/rel-docs.ts`                                                                      | `/rel/:name` — dereferenceable docs for SLICC custom rels                                                           |
+| `src/flags.ts`                                                                         | `/api/flags` string-map resolution, CORS, and per-float edge caching                                                |
 | `src/oauth-exchange.ts`, `src/oauth-registry.ts`                                       | OAuth callback relay (`/auth/callback`)                                                                             |
 | `src/auth/cloud-callback.ts`                                                           | `/auth/cloud-callback` IMS popup callback for the cloud dashboard                                                   |
 | `src/cloud/cloud-sessions-do.ts`                                                       | `CloudSessionsDurableObject` — per-user state for `/api/cloud/*`                                                    |
@@ -34,18 +35,14 @@ the built SLICC webapp as static assets to browser visitors.
 | `src/cloud/rate-limit.ts`                                                              | Per-user rate limiting on cloud endpoints                                                                           |
 | `wrangler.jsonc`                                                                       | Wrangler config, DO bindings (`TRAY_HUB`, `CLOUD_SESSIONS`), staging env, asset binding                             |
 
-This package depends on `@slicc/cloud-core` (see
-[`packages/cloud-core/CLAUDE.md`](../cloud-core/CLAUDE.md)) for sandbox lifecycle logic.
-The worker-local `src/cloud/` files are adapter glue — operation logic lives in
-cloud-core.
+Sandbox lifecycle logic lives in `@slicc/cloud-core`; worker `src/cloud/` is adapter glue.
 
 ## Tray Hub Architecture
 
 ### Durable Objects
 
-- Each tray maps to one `SessionTrayDurableObject` instance via the `TRAY_HUB` binding.
-- Tray state tracks issued capability tokens, leader attachment state, follower bootstrap
-  state, reconnect windows, and cached ICE servers.
+- `TRAY_HUB` maps each tray to one `SessionTrayDurableObject`, tracking capabilities,
+  leader/follower state, reconnect windows, and cached ICE servers.
 
 ### Public Routes
 
@@ -71,7 +68,7 @@ cloud-core.
 | `WS __slicc/bridge`                   | Preview bridge WS (`slicc.preview-bridge.v1.<connId>`); relays CDP + attributed `emit` between tabs and leader; hibernated via `setWebSocketAutoResponse` |
 | `POST __slicc/emit`                   | Fallback beacon relay for `window.slicc.emit` on page unload                                                                                              |
 | `GET /auth/callback`                  | OAuth callback relay; also a capture hop for the cloud dashboard (no `state` → `postMessage` to `window.opener`)                                          |
-| `GET /api/flags`                      | Resolve string flags for `?float=<float>`                                                                                                                 |
+| `GET /api/flags`                      | Resolve `{ float, flags }` string values for `?float=<float>`; unknown/invalid profiles fall back to `base`                                               |
 
 **Routes-mirror rule:** every new route must appear in three places:
 
@@ -83,9 +80,11 @@ Missing any of these causes CI failures.
 
 ### Feature Flag Configuration
 
-`FEATURE_FLAGS` is a JSON Wrangler var shaped as `{ base: string map, floats: per-float
-string maps }`. Float maps overlay `base`; invalid profiles use base.
-Deploy required; KV/R2 hot reload is future work.
+`FEATURE_FLAGS` in `wrangler.jsonc` is a JSON var shaped as
+`{ base: Record<string, string>, floats: Record<string, Record<string, string>> }`.
+Float maps overlay `base`; invalid profiles return `{ float: "default", flags: base }`.
+Keep production and `env.staging` aligned. Values cache for five minutes; config needs deploy.
+Keep `/api/flags` in the routes array and both routes-list assertions per the rule above.
 
 ### Signaling Model
 
@@ -134,15 +133,10 @@ for desktop trays — branched through `reclaimMsForTray(tray)` in `shared.ts`.
 
 ### R2 Asset Archive
 
-The `ASSET_ARCHIVE` R2 binding keeps content-hashed `/assets/*` chunks available across
-deploys so long-lived tabs don't 404 on lazy-loaded chunks from older builds.
-`serveAssetWithArchiveFallback` in `src/index.ts` serves from `ASSETS`; falls back to
-R2; degrades to the stale-asset reload if R2 also misses. 14-day bucket lifecycle GC.
-
-See the
-[`deploying-tray-worker` skill](../../.agents/skills/deploying-tray-worker/SKILL.md)
-for the full ops runbook: bucket creation, lifecycle rules, API token required
-permissions, upload gate mechanics, and the 2026-07-13 incident.
+`ASSET_ARCHIVE` retains hashed `/assets/*` across deploys. `serveAssetWithArchiveFallback`
+tries `ASSETS`, then R2, then stale-asset reload; bucket GC is 14 days. The
+[`deploying-tray-worker` skill](../../.agents/skills/deploying-tray-worker/SKILL.md) is the
+ops runbook for bucket setup, permissions, uploads, and the 2026-07-13 incident.
 
 ## Commands
 
@@ -166,12 +160,9 @@ npm run start:extension
 
 ## CI and Deployment
 
-The automated release gates production deployment with `release-native.mjs --gate=worker`.
-The hub (`wrangler.jsonc`) and preview worker (`wrangler-preview.jsonc`) **must deploy as
-a pair** — they share the same DO and preview URL token format. The R2 archive upload
-runs unconditionally before every deploy. Routes-only failures are non-fatal (script
-already live). Required secrets: `CLOUDFLARE_API_TOKEN` (Workers Edit + R2 R/W + Zone
-Routes Edit) and `CLOUDFLARE_ACCOUNT_ID`.
+`release-native.mjs --gate=worker` gates production. Hub and preview configs deploy as a pair
+(shared DO/token format); R2 uploads always precede deploy. Routes-only failures are non-fatal.
+Required: `CLOUDFLARE_API_TOKEN` (Workers Edit, R2 R/W, Zone Routes Edit) and account ID.
 
 See the
 [`deploying-tray-worker` skill](../../.agents/skills/deploying-tray-worker/SKILL.md)

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -71,6 +71,7 @@ cloud-core.
 | `WS __slicc/bridge`                   | Preview bridge WS (`slicc.preview-bridge.v1.<connId>`); relays CDP + attributed `emit` between tabs and leader; hibernated via `setWebSocketAutoResponse` |
 | `POST __slicc/emit`                   | Fallback beacon relay for `window.slicc.emit` on page unload                                                                                              |
 | `GET /auth/callback`                  | OAuth callback relay; also a capture hop for the cloud dashboard (no `state` → `postMessage` to `window.opener`)                                          |
+| `GET /api/flags`                      | Resolve string flags for `?float=<float>`                                                                                                                 |
 
 **Routes-mirror rule:** every new route must appear in three places:
 
@@ -79,6 +80,12 @@ cloud-core.
 3. `tests/deployed.test.ts` routes-list assertion
 
 Missing any of these causes CI failures.
+
+### Feature Flag Configuration
+
+`FEATURE_FLAGS` is a JSON Wrangler var shaped as `{ base: string map, floats: per-float
+string maps }`. Float maps overlay `base`; invalid profiles use base.
+Deploy required; KV/R2 hot reload is future work.
 
 ### Signaling Model
 

--- a/packages/cloudflare-worker/src/flags.ts
+++ b/packages/cloudflare-worker/src/flags.ts
@@ -1,0 +1,121 @@
+/**
+ * Centrally authored feature flags for SLICC floats.
+ *
+ * `FEATURE_FLAGS` is a Wrangler JSON var shaped as
+ * `{ base: Record<string, string>, floats: Record<string, Record<string, string>> }`.
+ * Per-float values overlay `base`. A future KV/R2 source can replace the config
+ * input without changing the response contract or resolution rules.
+ */
+
+import { SLICC_HOSTED_ORIGIN } from '@slicc/shared-ts';
+import { isAllowedOrigin } from './oauth-exchange.js';
+import { jsonResponse } from './shared.js';
+
+const FLAGS_CACHE_TTL_SECONDS = 300;
+const DEFAULT_FLOAT = 'default';
+const FALLBACK_BASE_FLAGS: Record<string, string> = {
+  'experimental-settings': 'on',
+};
+
+export interface ResolvedFlags {
+  float: string;
+  flags: Record<string, string>;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringRecord(value: unknown): Record<string, string> | null {
+  const record = objectRecord(value);
+  if (!record || Object.values(record).some((entry) => typeof entry !== 'string')) return null;
+  return record as Record<string, string>;
+}
+
+/** Resolve a requested float, falling back to the base profile on any invalid config. */
+export function resolveFlags(config: unknown, requestedFloat: string | null): ResolvedFlags {
+  const root = objectRecord(config);
+  const base = stringRecord(root?.base) ?? FALLBACK_BASE_FLAGS;
+  const floats = objectRecord(root?.floats);
+  if (!requestedFloat || !floats || !Object.hasOwn(floats, requestedFloat)) {
+    return { float: DEFAULT_FLOAT, flags: { ...base } };
+  }
+
+  const overlay = stringRecord(floats[requestedFloat]);
+  if (!overlay) return { float: DEFAULT_FLOAT, flags: { ...base } };
+  return { float: requestedFloat, flags: { ...base, ...overlay } };
+}
+
+function flagsCorsHeaders(request: Request): Record<string, string> {
+  const origin = request.headers.get('Origin');
+  const allowedOrigin = origin && isAllowedOrigin(origin) ? origin : SLICC_HOSTED_ORIGIN;
+  return {
+    'Access-Control-Allow-Origin': allowedOrigin,
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    Vary: 'Origin',
+  };
+}
+
+function withFlagsCors(response: Response, request: Request): Response {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(flagsCorsHeaders(request))) headers.set(key, value);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function flagsCacheKey(request: Request, float: string): Request {
+  const url = new URL(request.url);
+  url.search = '';
+  url.searchParams.set('float', float);
+  return new Request(url.toString(), { method: 'GET' });
+}
+
+async function readCachedFlags(key: Request): Promise<Response | null> {
+  const cachesGlobal = (globalThis as { caches?: CacheStorage }).caches;
+  if (!cachesGlobal) return null;
+  try {
+    return (await cachesGlobal.default.match(key)) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function cacheFlags(key: Request, response: Response): Promise<void> {
+  const cachesGlobal = (globalThis as { caches?: CacheStorage }).caches;
+  if (!cachesGlobal) return;
+  try {
+    await cachesGlobal.default.put(key, response.clone());
+  } catch {
+    // Cache failures must never make public configuration unavailable.
+  }
+}
+
+export async function handleFlagsRequest(request: Request, config: unknown): Promise<Response> {
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: flagsCorsHeaders(request) });
+  }
+  if (request.method !== 'GET') {
+    return jsonResponse({ error: 'method_not_allowed' }, 405, {
+      ...flagsCorsHeaders(request),
+      Allow: 'GET, OPTIONS',
+    });
+  }
+
+  const url = new URL(request.url);
+  const resolved = resolveFlags(config, url.searchParams.get('float'));
+  const cacheKey = flagsCacheKey(request, resolved.float);
+  const cached = await readCachedFlags(cacheKey);
+  if (cached) return withFlagsCors(cached, request);
+
+  const response = jsonResponse(resolved, 200, {
+    'Cache-Control': `public, max-age=${FLAGS_CACHE_TTL_SECONDS}`,
+  });
+  await cacheFlags(cacheKey, response);
+  return withFlagsCors(response, request);
+}

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -15,6 +15,7 @@ import {
   handleStart,
 } from './cloud/handlers.js';
 import { getProxyEndpoint } from './cloud/proxy-config.js';
+import { handleFlagsRequest } from './flags.js';
 import { buildHandoffResponse } from './handoff-page.js';
 import {
   buildInstallCliPowershellResponse,
@@ -68,6 +69,7 @@ export interface WorkerEnv {
   CONE_CAP_RUNNING?: string;
   CONE_CAP_PAUSED?: string;
   ALLOWED_CLOUD_DASHBOARD_ORIGINS?: string;
+  FEATURE_FLAGS?: unknown;
   /**
    * Space-separated origins permitted to frame the `?cherry=1` SPA. Empty/unset = deny.
    * A bare `*` token (alone or among origins) opens framing to arbitrary
@@ -574,6 +576,7 @@ const ROUTES_INDEX_BODY = {
     'POST /oauth/token',
     'POST /oauth/revoke',
     'GET /api/runtime-config',
+    'GET /api/flags',
     'ANY /api/fetch-proxy',
     'GET /api/cloud/config',
     'POST /api/cloud/start',
@@ -768,6 +771,10 @@ async function tryHandleInfoRoutes(
 ): Promise<Response | null> {
   if (url.pathname === '/api/runtime-config') {
     return handleRuntimeConfig(url, request, env);
+  }
+
+  if (url.pathname === '/api/flags') {
+    return handleFlagsRequest(request, env.FEATURE_FLAGS);
   }
 
   if (url.pathname === '/api/fetch-proxy') {

--- a/packages/cloudflare-worker/src/oauth-exchange.ts
+++ b/packages/cloudflare-worker/src/oauth-exchange.ts
@@ -19,7 +19,7 @@ const ALLOWED_ORIGINS = [
   /^http:\/\/localhost:\d+$/,
 ];
 
-function isAllowedOrigin(origin: string): boolean {
+export function isAllowedOrigin(origin: string): boolean {
   return ALLOWED_ORIGINS.some((allowed) =>
     typeof allowed === 'string' ? allowed === origin : allowed.test(origin)
   );

--- a/packages/cloudflare-worker/tests/deployed.test.ts
+++ b/packages/cloudflare-worker/tests/deployed.test.ts
@@ -48,6 +48,7 @@ describeIfConfigured('deployed tray worker', () => {
         'POST /oauth/token',
         'POST /oauth/revoke',
         'GET /api/runtime-config',
+        'GET /api/flags',
         'ANY /api/fetch-proxy',
         'GET /api/cloud/config',
         'POST /api/cloud/start',

--- a/packages/cloudflare-worker/tests/flags.test.ts
+++ b/packages/cloudflare-worker/tests/flags.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { handleWorkerRequest } from '../src/index.js';
+import { makeEnv } from './helpers/fake-env.js';
+
+const FEATURE_FLAGS = {
+  base: { 'experimental-settings': 'on', theme: 'stable' },
+  floats: {
+    standalone: {},
+    cherry: { 'experimental-settings': 'off' },
+  },
+};
+
+class FakeCache {
+  readonly keys: string[] = [];
+  private readonly responses = new Map<string, Response>();
+
+  async match(request: Request): Promise<Response | undefined> {
+    this.keys.push(request.url);
+    return this.responses.get(request.url)?.clone();
+  }
+
+  async put(request: Request, response: Response): Promise<void> {
+    this.keys.push(request.url);
+    this.responses.set(request.url, response.clone());
+  }
+}
+
+function request(float?: string, origin?: string): Request {
+  const url = new URL('https://www.sliccy.ai/api/flags');
+  if (float) url.searchParams.set('float', float);
+  return new Request(url, { headers: origin ? { Origin: origin } : undefined });
+}
+
+async function flags(float?: string, config: unknown = FEATURE_FLAGS): Promise<Response> {
+  return handleWorkerRequest(request(float), makeEnv({ FEATURE_FLAGS: config }));
+}
+
+describe('GET /api/flags', () => {
+  beforeEach(() => {
+    delete (globalThis as Record<string, unknown>).caches;
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).caches;
+  });
+
+  it('overlays per-float values on the base string map', async () => {
+    const standalone = await flags('standalone');
+    await expect(standalone.json()).resolves.toEqual({
+      float: 'standalone',
+      flags: { 'experimental-settings': 'on', theme: 'stable' },
+    });
+
+    const cherry = await flags('cherry');
+    await expect(cherry.json()).resolves.toEqual({
+      float: 'cherry',
+      flags: { 'experimental-settings': 'off', theme: 'stable' },
+    });
+  });
+
+  it('uses the default profile for missing and unknown floats', async () => {
+    await expect((await flags()).json()).resolves.toEqual({
+      float: 'default',
+      flags: { 'experimental-settings': 'on', theme: 'stable' },
+    });
+    await expect((await flags('unknown')).json()).resolves.toEqual({
+      float: 'default',
+      flags: { 'experimental-settings': 'on', theme: 'stable' },
+    });
+  });
+
+  it('falls back to the valid base map when a float overlay is malformed', async () => {
+    const response = await flags('cherry', {
+      base: { 'experimental-settings': 'on', cohort: 'base' },
+      floats: { cherry: { 'experimental-settings': false } },
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      float: 'default',
+      flags: { 'experimental-settings': 'on', cohort: 'base' },
+    });
+  });
+
+  it('never fails when the entire config is malformed', async () => {
+    const response = await flags('cherry', 'not-an-object');
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      float: 'default',
+      flags: { 'experimental-settings': 'on' },
+    });
+  });
+
+  it('mirrors OAuth CORS and caches independently by resolved float', async () => {
+    const cache = new FakeCache();
+    (globalThis as Record<string, unknown>).caches = { default: cache };
+    const env = makeEnv({ FEATURE_FLAGS });
+
+    const standalone = await handleWorkerRequest(
+      request('standalone', 'http://localhost:5710'),
+      env
+    );
+    expect(standalone.headers.get('access-control-allow-origin')).toBe('http://localhost:5710');
+    expect(standalone.headers.get('vary')).toBe('Origin');
+    expect(standalone.headers.get('cache-control')).toBe('public, max-age=300');
+
+    const cached = await handleWorkerRequest(request('standalone', 'http://localhost:5720'), env);
+    expect(cached.headers.get('access-control-allow-origin')).toBe('http://localhost:5720');
+    const cherry = await handleWorkerRequest(request('cherry'), env);
+    expect(cherry.status).toBe(200);
+
+    expect(cache.keys.some((key) => key.endsWith('/api/flags?float=standalone'))).toBe(true);
+    expect(cache.keys.some((key) => key.endsWith('/api/flags?float=cherry'))).toBe(true);
+  });
+});

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -1226,6 +1226,7 @@ describe('tray worker skeleton', () => {
         'POST /oauth/token',
         'POST /oauth/revoke',
         'GET /api/runtime-config',
+        'GET /api/flags',
         'ANY /api/fetch-proxy',
         'GET /api/cloud/config',
         'POST /api/cloud/start',

--- a/packages/cloudflare-worker/wrangler.jsonc
+++ b/packages/cloudflare-worker/wrangler.jsonc
@@ -33,6 +33,14 @@
     // Cloud cone concurrency caps
     "CONE_CAP_RUNNING": "1",
     "CONE_CAP_PAUSED": "5",
+    // Feature flag config: base string map plus per-float string-map overlays.
+    "FEATURE_FLAGS": {
+      "base": { "experimental-settings": "on" },
+      "floats": {
+        "standalone": {},
+        "cherry": { "experimental-settings": "off" }
+      }
+    },
     // OAuth relay allowlist for remote origins (staging/preview deploys)
     "ALLOWED_CLOUD_DASHBOARD_ORIGINS": "https://www.sliccy.ai,https://slicc-tray-hub-staging.minivelos.workers.dev",
     // Space-separated origins permitted to frame the ?cherry=1 SPA (empty = deny, "*" = any origin)
@@ -92,6 +100,14 @@
         // Cloud cone concurrency caps
         "CONE_CAP_RUNNING": "1",
         "CONE_CAP_PAUSED": "5",
+        // Feature flag config: base string map plus per-float string-map overlays.
+        "FEATURE_FLAGS": {
+          "base": { "experimental-settings": "on" },
+          "floats": {
+            "standalone": {},
+            "cherry": { "experimental-settings": "off" }
+          }
+        },
         // OAuth relay allowlist for remote origins (staging/preview deploys)
         "ALLOWED_CLOUD_DASHBOARD_ORIGINS": "https://slicc-tray-hub-staging.minivelos.workers.dev,https://www.sliccy.ai",
         // Space-separated origins permitted to frame the ?cherry=1 SPA (empty = deny, "*" = any origin)

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -196,32 +196,33 @@ See `docs/architecture.md` "Multi-Browser Sync (Tray) Architecture".
 - `tool-adapter.ts` bridges legacy tool definitions into the pi-compatible tool layer.
 - `session.ts` and UI session storage keep the browser runtime restorable.
 
+### Feature Flags
+
+- Add: extend `FeatureFlagId` + `FEATURE_FLAGS` in `core/feature-flags.ts`, then add the same
+  string values to production and staging `wrangler.jsonc` `FEATURE_FLAGS`; `listFlags()` drives UI.
+- Boolean consumers use `isFeatureEnabled`/`coerceFeatureFlagValue` (`on`/`true`/`1`, trimmed and
+  case-insensitive). Precedence where `overridableFloats` permits: local → remote → bundled
+  `floatDefaults`/`defaultValue`.
+- `setupFeatureFlagsForPage` selects the float, loads its isolated cache, then refreshes
+  `/api/flags?float=<float>` once. There is no live refresh; later config requires reload.
+
 ### Context Compaction
 
 - Path: `packages/webapp/src/core/context-compaction.ts`
-- **GC threshold is model-sized**: `scoop-context.ts` forwards `model.contextWindow` into
-  `createCompactContext`; fires at `contextWindow - reserveTokens`, not a hardcoded value.
-  A `0`/missing window falls back to 200K default.
-- **Memory extraction** (cone only): when `onMemoryUpdates` is wired, compaction makes a
-  second LLM call sharing the same system prompt (prompt-cache hit) and appends bullets to
-  `/workspace/CLAUDE.md` via `orchestrator.appendConeMemory`. Best-effort; never blocks
-  compaction.
-- `appendConeMemory` is size-bounded by `cone-memory-budget.ts` (log2-scaled per-session
-  budget). When an append exceeds budget × 1.25, an LLM restructure runs over only the
-  `## Auto-extracted` tail; the user-authored header is preserved verbatim.
+- `scoop-context.ts` passes `model.contextWindow`; compaction fires at window minus reserve,
+  falling back to 200K when absent/zero.
+- Cone memory extraction is best-effort and appends to `/workspace/CLAUDE.md`.
+  `cone-memory-budget.ts` bounds it; overflow restructures only `## Auto-extracted`.
 
 ### Frozen Sessions ("New session" flow)
 
 - Path: `ui/session-freezer.ts`, `ui/new-session.ts`.
-- Three explicit actions from the avatar popover: **Save & start new** (enrichment + memory
-  extraction), **New chat — skip memory** (quick archive), **Erase & start new** (no
-  archive). All reset VFS `/tmp` (preserving active mount roots) and clear the cone chat;
-  scoops survive. Page reload, app restart, and scoop creation do NOT clear `/tmp`.
+- Actions: **Save & start new** (enriched archive), **New chat — skip memory** (quick archive),
+  and **Erase & start new** (none). Each clears cone chat and `/tmp` except mount roots; scoops
+  survive, and reload/restart/scoop creation do not clear `/tmp`.
 - Archive format: `/sessions/<timestamp>-<slug>.md` (YAML frontmatter +
-  `slicc:session-data` HTML-comment block + human-readable body). Index at
-  `/sessions/index.json` (prepended).
-- `OffscreenClient.clearAllMessages()` is cone-only; awaits `clear-chat-ack` before
-  resolving to avoid racing the panel reload.
+  `slicc:session-data` + body); prepended index: `/sessions/index.json`.
+- Cone-only `OffscreenClient.clearAllMessages()` awaits `clear-chat-ack` before panel reload.
 
 ### UI
 
@@ -270,15 +271,9 @@ See `docs/architecture.md` "Multi-Browser Sync (Tray) Architecture".
 
 ### Stale-asset recovery (post-deploy)
 
-- Four triggers → one shared, `instanceId`-scoped, fail-closed, 60 s reload
-  (`ui/boot/setup-preload-error-reload.ts` + `core/stale-asset-channel.ts`): page
-  `vite:preloadError`; page `Worker` error (`spawn.ts`); worker `boot()` try/catch; worker
-  scoop-context classifier. Worker triggers broadcast over `BroadcastChannel` stamped with
-  `instanceId`; only the owning page reloads.
-- A dropped cone turn is auto-resubmitted once after recovery: the broadcast stamps
-  `replayTurn` (cone only), the page sets `sessionStorage slicc:stale-asset-replay`, and
-  `wc-chat-controller.loadMessages` replays the last unanswered user turn once via
-  `#handleErrorRetry`.
+- `setup-preload-error-reload.ts` + `stale-asset-channel.ts` funnel preload, page Worker,
+  worker boot, and scoop-classifier failures into an `instanceId`-scoped 60 s reload; only
+  the owning page reacts. A cone `replayTurn` marker replays one unanswered turn after recovery.
 
 ## Key Conventions
 

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -207,8 +207,9 @@ See `docs/architecture.md` "Multi-Browser Sync (Tray) Architecture".
   local → remote → bundled `floatDefaults`/`defaultValue`.
 - `experimental-settings` is worker-controlled (`userToggleable: false`): it independently gates
   both the avatar-menu item and exported dialog, and local override attempts are ignored.
-- `setupFeatureFlagsForPage` selects the float, loads its isolated cache, then refreshes
-  `/api/flags?float=<float>` once. There is no live refresh; later config requires reload.
+- `setupFeatureFlagsForPage` selects the float and loads its isolated cache synchronously, then
+  lazy-loads a non-blocking `/api/flags?float=<float>` refresh. There is no live refresh; later
+  config requires reload.
 
 ### Context Compaction
 

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -199,10 +199,14 @@ See `docs/architecture.md` "Multi-Browser Sync (Tray) Architecture".
 ### Feature Flags
 
 - Add: extend `FeatureFlagId` + `FEATURE_FLAGS` in `core/feature-flags.ts`, then add the same
-  string values to production and staging `wrangler.jsonc` `FEATURE_FLAGS`; `listFlags()` drives UI.
+  string values to production and staging `wrangler.jsonc` `FEATURE_FLAGS`. User-toggleable flags
+  appear in the standalone **Experimental features…** avatar-menu dialog driven by `listFlags()`;
+  they do not belong in Account settings.
 - Boolean consumers use `isFeatureEnabled`/`coerceFeatureFlagValue` (`on`/`true`/`1`, trimmed and
-  case-insensitive). Precedence where `overridableFloats` permits: local → remote → bundled
-  `floatDefaults`/`defaultValue`.
+  case-insensitive). For user-toggleable flags, precedence where `overridableFloats` permits is
+  local → remote → bundled `floatDefaults`/`defaultValue`.
+- `experimental-settings` is worker-controlled (`userToggleable: false`): it independently gates
+  both the avatar-menu item and exported dialog, and local override attempts are ignored.
 - `setupFeatureFlagsForPage` selects the float, loads its isolated cache, then refreshes
   `/api/flags?float=<float>` once. There is no live refresh; later config requires reload.
 

--- a/packages/webapp/src/core/feature-flags-cache.ts
+++ b/packages/webapp/src/core/feature-flags-cache.ts
@@ -1,0 +1,77 @@
+import {
+  type FeatureFlagFloat,
+  type FeatureFlagValues,
+  initFeatureFlags,
+} from './feature-flags.js';
+
+export const FEATURE_FLAGS_REMOTE_STORAGE_KEY = 'slicc_feature_flags_remote';
+
+export interface FeatureFlagsRemoteStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export function featureFlagsRemoteCacheKey(float: FeatureFlagFloat): string {
+  return `${FEATURE_FLAGS_REMOTE_STORAGE_KEY}:${float}`;
+}
+
+export function initFeatureFlagsFromRemoteCache(
+  float: FeatureFlagFloat,
+  storage?: FeatureFlagsRemoteStorage | null
+): void {
+  const resolvedStorage = resolveFeatureFlagsRemoteStorage(storage);
+  initFeatureFlags(float, readCachedFlags(resolvedStorage, float) ?? {});
+}
+
+export function writeFeatureFlagsRemoteCache(
+  storage: FeatureFlagsRemoteStorage | null | undefined,
+  float: FeatureFlagFloat,
+  flags: FeatureFlagValues
+): void {
+  try {
+    storage?.setItem(featureFlagsRemoteCacheKey(float), JSON.stringify(flags));
+  } catch {
+    // Storage is best-effort; the fetched values remain active in memory.
+  }
+}
+
+export function resolveFeatureFlagsRemoteStorage(
+  storage?: FeatureFlagsRemoteStorage | null
+): FeatureFlagsRemoteStorage | null | undefined {
+  if (storage !== undefined) return storage;
+  try {
+    const globalStorage = (globalThis as { localStorage?: Partial<FeatureFlagsRemoteStorage> })
+      .localStorage;
+    if (
+      typeof globalStorage?.getItem !== 'function' ||
+      typeof globalStorage.setItem !== 'function'
+    ) {
+      return undefined;
+    }
+    return globalStorage as FeatureFlagsRemoteStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function readCachedFlags(
+  storage: FeatureFlagsRemoteStorage | null | undefined,
+  float: FeatureFlagFloat
+): FeatureFlagValues | null {
+  try {
+    const raw = storage?.getItem(featureFlagsRemoteCacheKey(float));
+    return raw ? readFlagsRecord(JSON.parse(raw)) : null;
+  } catch {
+    return null;
+  }
+}
+
+function readFlagsRecord(value: unknown): FeatureFlagValues | null {
+  if (!isRecord(value)) return null;
+  if (Object.values(value).some((flagValue) => typeof flagValue !== 'string')) return null;
+  return value as FeatureFlagValues;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/webapp/src/core/feature-flags-remote.ts
+++ b/packages/webapp/src/core/feature-flags-remote.ts
@@ -3,24 +3,25 @@ import {
   type FeatureFlagValues,
   initFeatureFlags,
 } from './feature-flags.js';
+import {
+  type FeatureFlagsRemoteStorage,
+  initFeatureFlagsFromRemoteCache,
+  resolveFeatureFlagsRemoteStorage,
+  writeFeatureFlagsRemoteCache,
+} from './feature-flags-cache.js';
 
-export const FEATURE_FLAGS_REMOTE_STORAGE_KEY = 'slicc_feature_flags_remote';
+export {
+  FEATURE_FLAGS_REMOTE_STORAGE_KEY,
+  featureFlagsRemoteCacheKey,
+} from './feature-flags-cache.js';
+
 const DEFAULT_FETCH_TIMEOUT_MS = 3_000;
-
-interface FeatureFlagsRemoteStorage {
-  getItem(key: string): string | null;
-  setItem(key: string, value: string): void;
-}
 
 export interface FeatureFlagsRemoteOptions {
   workerBaseUrl: string;
   fetchImpl?: typeof fetch;
   storage?: FeatureFlagsRemoteStorage | null;
   timeoutMs?: number;
-}
-
-export function featureFlagsRemoteCacheKey(float: FeatureFlagFloat): string {
-  return `${FEATURE_FLAGS_REMOTE_STORAGE_KEY}:${float}`;
 }
 
 /**
@@ -32,16 +33,15 @@ export function hydrateFeatureFlagsFromRemote(
   float: FeatureFlagFloat,
   options: FeatureFlagsRemoteOptions
 ): Promise<void> {
-  const storage = options.storage === undefined ? getStorage() : options.storage;
-  initFeatureFlags(float, readCachedFlags(storage, float) ?? {});
-  return refreshFeatureFlags(float, options, storage);
+  initFeatureFlagsFromRemoteCache(float, options.storage);
+  return refreshFeatureFlagsFromRemote(float, options);
 }
 
-async function refreshFeatureFlags(
+export async function refreshFeatureFlagsFromRemote(
   float: FeatureFlagFloat,
-  options: FeatureFlagsRemoteOptions,
-  storage: FeatureFlagsRemoteStorage | null | undefined
+  options: FeatureFlagsRemoteOptions
 ): Promise<void> {
+  const storage = resolveFeatureFlagsRemoteStorage(options.storage);
   try {
     const url = new URL('/api/flags', `${options.workerBaseUrl.replace(/\/+$/, '')}/`);
     url.searchParams.set('float', float);
@@ -51,7 +51,7 @@ async function refreshFeatureFlags(
       options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS
     );
     if (!flags) return;
-    writeCachedFlags(storage, float, flags);
+    writeFeatureFlagsRemoteCache(storage, float, flags);
     // The response is an envelope. Its echoed `float` is informational and may
     // be "default"; the page's resolveUiRuntimeMode() result remains authoritative.
     initFeatureFlags(float, flags);
@@ -98,47 +98,6 @@ function readFlagsPayload(value: unknown): FeatureFlagValues | null {
   return value.flags as FeatureFlagValues;
 }
 
-function readCachedFlags(
-  storage: FeatureFlagsRemoteStorage | null | undefined,
-  float: FeatureFlagFloat
-): FeatureFlagValues | null {
-  try {
-    const raw = storage?.getItem(featureFlagsRemoteCacheKey(float));
-    return raw ? readFlagsRecord(JSON.parse(raw)) : null;
-  } catch {
-    return null;
-  }
-}
-
-function writeCachedFlags(
-  storage: FeatureFlagsRemoteStorage | null | undefined,
-  float: FeatureFlagFloat,
-  flags: FeatureFlagValues
-): void {
-  try {
-    storage?.setItem(featureFlagsRemoteCacheKey(float), JSON.stringify(flags));
-  } catch {
-    // Storage is best-effort; the fetched values remain active in memory.
-  }
-}
-
-function readFlagsRecord(value: unknown): FeatureFlagValues | null {
-  if (!isRecord(value)) return null;
-  if (Object.values(value).some((flagValue) => typeof flagValue !== 'string')) return null;
-  return value as FeatureFlagValues;
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function getStorage(): FeatureFlagsRemoteStorage | undefined {
-  try {
-    const storage = (globalThis as { localStorage?: Partial<FeatureFlagsRemoteStorage> })
-      .localStorage;
-    if (typeof storage?.getItem !== 'function' || typeof storage.setItem !== 'function') return;
-    return storage as FeatureFlagsRemoteStorage;
-  } catch {
-    return undefined;
-  }
 }

--- a/packages/webapp/src/core/feature-flags-remote.ts
+++ b/packages/webapp/src/core/feature-flags-remote.ts
@@ -1,0 +1,144 @@
+import {
+  type FeatureFlagFloat,
+  type FeatureFlagValues,
+  initFeatureFlags,
+} from './feature-flags.js';
+
+export const FEATURE_FLAGS_REMOTE_STORAGE_KEY = 'slicc_feature_flags_remote';
+const DEFAULT_FETCH_TIMEOUT_MS = 3_000;
+
+interface FeatureFlagsRemoteStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export interface FeatureFlagsRemoteOptions {
+  workerBaseUrl: string;
+  fetchImpl?: typeof fetch;
+  storage?: FeatureFlagsRemoteStorage | null;
+  timeoutMs?: number;
+}
+
+export function featureFlagsRemoteCacheKey(float: FeatureFlagFloat): string {
+  return `${FEATURE_FLAGS_REMOTE_STORAGE_KEY}:${float}`;
+}
+
+/**
+ * Resolve flags from the last-known-good cache synchronously, then refresh once
+ * in the background. The returned promise always fulfills, so boot may safely
+ * fire-and-forget it without creating an unhandled rejection.
+ */
+export function hydrateFeatureFlagsFromRemote(
+  float: FeatureFlagFloat,
+  options: FeatureFlagsRemoteOptions
+): Promise<void> {
+  const storage = options.storage === undefined ? getStorage() : options.storage;
+  initFeatureFlags(float, readCachedFlags(storage, float) ?? {});
+  return refreshFeatureFlags(float, options, storage);
+}
+
+async function refreshFeatureFlags(
+  float: FeatureFlagFloat,
+  options: FeatureFlagsRemoteOptions,
+  storage: FeatureFlagsRemoteStorage | null | undefined
+): Promise<void> {
+  try {
+    const url = new URL('/api/flags', `${options.workerBaseUrl.replace(/\/+$/, '')}/`);
+    url.searchParams.set('float', float);
+    const flags = await fetchFlags(
+      url.toString(),
+      options.fetchImpl ?? fetch,
+      options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS
+    );
+    if (!flags) return;
+    writeCachedFlags(storage, float, flags);
+    // The response is an envelope. Its echoed `float` is informational and may
+    // be "default"; the page's resolveUiRuntimeMode() result remains authoritative.
+    initFeatureFlags(float, flags);
+  } catch {
+    // Remote configuration is best-effort; cached values/defaults stay active.
+  }
+}
+
+async function fetchFlags(
+  url: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number
+): Promise<FeatureFlagValues | null> {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const timedOut = new Promise<null>((resolve) => {
+      timeoutId = setTimeout(() => {
+        controller.abort();
+        resolve(null);
+      }, timeoutMs);
+    });
+    const request = fetchImpl(url, {
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) return null;
+        return readFlagsPayload(await response.json());
+      })
+      .catch(() => null);
+    return await Promise.race([request, timedOut]);
+  } catch {
+    return null;
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}
+
+function readFlagsPayload(value: unknown): FeatureFlagValues | null {
+  if (!isRecord(value) || !isRecord(value.flags)) return null;
+  if (Object.values(value.flags).some((flagValue) => typeof flagValue !== 'string')) return null;
+  return value.flags as FeatureFlagValues;
+}
+
+function readCachedFlags(
+  storage: FeatureFlagsRemoteStorage | null | undefined,
+  float: FeatureFlagFloat
+): FeatureFlagValues | null {
+  try {
+    const raw = storage?.getItem(featureFlagsRemoteCacheKey(float));
+    return raw ? readFlagsRecord(JSON.parse(raw)) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedFlags(
+  storage: FeatureFlagsRemoteStorage | null | undefined,
+  float: FeatureFlagFloat,
+  flags: FeatureFlagValues
+): void {
+  try {
+    storage?.setItem(featureFlagsRemoteCacheKey(float), JSON.stringify(flags));
+  } catch {
+    // Storage is best-effort; the fetched values remain active in memory.
+  }
+}
+
+function readFlagsRecord(value: unknown): FeatureFlagValues | null {
+  if (!isRecord(value)) return null;
+  if (Object.values(value).some((flagValue) => typeof flagValue !== 'string')) return null;
+  return value as FeatureFlagValues;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getStorage(): FeatureFlagsRemoteStorage | undefined {
+  try {
+    const storage = (globalThis as { localStorage?: Partial<FeatureFlagsRemoteStorage> })
+      .localStorage;
+    if (typeof storage?.getItem !== 'function' || typeof storage.setItem !== 'function') return;
+    return storage as FeatureFlagsRemoteStorage;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/webapp/src/core/feature-flags.ts
+++ b/packages/webapp/src/core/feature-flags.ts
@@ -23,16 +23,6 @@ export interface FeatureFlagDefinition {
 
 export const FEATURE_FLAG_STORAGE_KEY = 'slicc_feature_flags';
 
-const WEB_UI_FLOATS: readonly FeatureFlagFloat[] = [
-  'standalone',
-  'extension',
-  'electron-overlay',
-  'extension-detached',
-  'hosted-leader',
-  'connect',
-  'follower',
-];
-
 const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = Object.freeze([
   Object.freeze({
     id: 'experimental-settings',
@@ -40,8 +30,7 @@ const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = Object.freeze([
     description: 'Show controls for experimental features.',
     defaultValue: 'on',
     floatDefaults: Object.freeze({ cherry: 'off' }),
-    userToggleable: true,
-    overridableFloats: WEB_UI_FLOATS,
+    userToggleable: false,
   }),
 ]);
 

--- a/packages/webapp/src/core/feature-flags.ts
+++ b/packages/webapp/src/core/feature-flags.ts
@@ -1,0 +1,173 @@
+export type FeatureFlagFloat =
+  | 'standalone'
+  | 'extension'
+  | 'electron-overlay'
+  | 'extension-detached'
+  | 'hosted-leader'
+  | 'connect'
+  | 'cherry'
+  | 'follower';
+
+export type FeatureFlagId = 'experimental-settings';
+export type FeatureFlagValues = Partial<Record<FeatureFlagId, string>>;
+
+export interface FeatureFlagDefinition {
+  readonly id: FeatureFlagId;
+  readonly label: string;
+  readonly description: string;
+  readonly defaultValue: string;
+  readonly floatDefaults?: Readonly<Partial<Record<FeatureFlagFloat, string>>>;
+  readonly userToggleable: boolean;
+  readonly overridableFloats?: readonly FeatureFlagFloat[];
+}
+
+export const FEATURE_FLAG_STORAGE_KEY = 'slicc_feature_flags';
+
+const WEB_UI_FLOATS: readonly FeatureFlagFloat[] = [
+  'standalone',
+  'extension',
+  'electron-overlay',
+  'extension-detached',
+  'hosted-leader',
+  'connect',
+  'follower',
+];
+
+const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = Object.freeze([
+  Object.freeze({
+    id: 'experimental-settings',
+    label: 'Experimental settings',
+    description: 'Show controls for experimental features.',
+    defaultValue: 'on',
+    floatDefaults: Object.freeze({ cherry: 'off' }),
+    userToggleable: true,
+    overridableFloats: WEB_UI_FLOATS,
+  }),
+]);
+
+const FEATURE_FLAGS_BY_ID = new Map(FEATURE_FLAGS.map((flag) => [flag.id, flag]));
+const ENABLED_VALUES = new Set(['1', 'on', 'true']);
+
+let activeFloat: FeatureFlagFloat = 'standalone';
+let remoteValues: FeatureFlagValues = {};
+
+interface FeatureFlagStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export function listFlags(): readonly FeatureFlagDefinition[] {
+  return FEATURE_FLAGS;
+}
+
+export function resolveFlagValue(
+  id: FeatureFlagId,
+  float: FeatureFlagFloat,
+  overrides: Readonly<FeatureFlagValues> = {}
+): string | undefined {
+  const definition = FEATURE_FLAGS_BY_ID.get(id);
+  if (!definition) return undefined;
+  const override = overrides[id];
+  if (typeof override === 'string' && canOverride(definition, float)) return override;
+  return getBundledDefault(definition, float);
+}
+
+/** Resolve every registered flag using local override → remote value → bundled default. */
+export function resolveFlags(
+  float: FeatureFlagFloat,
+  centralValues: Readonly<FeatureFlagValues> = {},
+  overrides: Readonly<FeatureFlagValues> = readFeatureFlagOverrides()
+): FeatureFlagValues {
+  const resolved: FeatureFlagValues = {};
+  for (const definition of FEATURE_FLAGS) {
+    const override = overrides[definition.id];
+    if (typeof override === 'string' && canOverride(definition, float)) {
+      resolved[definition.id] = override;
+      continue;
+    }
+    const centralValue = centralValues[definition.id];
+    resolved[definition.id] =
+      typeof centralValue === 'string' ? centralValue : getBundledDefault(definition, float);
+  }
+  return resolved;
+}
+
+export function readFeatureFlagOverrides(): FeatureFlagValues {
+  try {
+    const raw = getStorage()?.getItem(FEATURE_FLAG_STORAGE_KEY);
+    if (!raw) return {};
+    return sanitizeValues(JSON.parse(raw));
+  } catch {
+    return {};
+  }
+}
+
+export function writeFeatureFlagOverrides(overrides: Readonly<FeatureFlagValues>): void {
+  try {
+    getStorage()?.setItem(FEATURE_FLAG_STORAGE_KEY, JSON.stringify(sanitizeValues(overrides)));
+  } catch {
+    // Storage is best-effort; bundled and central values remain available without it.
+  }
+}
+
+export function setFeatureFlagOverride(id: FeatureFlagId, value: string | undefined): void {
+  const definition = FEATURE_FLAGS_BY_ID.get(id);
+  if (!definition || !canOverride(definition, activeFloat)) return;
+  const overrides = readFeatureFlagOverrides();
+  if (typeof value === 'string') overrides[id] = value;
+  else delete overrides[id];
+  writeFeatureFlagOverrides(overrides);
+}
+
+export function initFeatureFlags(
+  float: FeatureFlagFloat,
+  centralValues: Readonly<FeatureFlagValues> = {}
+): void {
+  activeFloat = float;
+  remoteValues = sanitizeValues(centralValues);
+}
+
+export function getFeatureValue(id: FeatureFlagId): string | undefined {
+  return resolveFlags(activeFloat, remoteValues)[id];
+}
+
+/** `on`, `true`, and `1` (case-insensitive, surrounding whitespace ignored) are enabled. */
+export function coerceFeatureFlagValue(value: string | undefined): boolean {
+  return typeof value === 'string' && ENABLED_VALUES.has(value.trim().toLowerCase());
+}
+
+export function isFeatureEnabled(id: FeatureFlagId): boolean {
+  return coerceFeatureFlagValue(getFeatureValue(id));
+}
+
+function getBundledDefault(definition: FeatureFlagDefinition, float: FeatureFlagFloat): string {
+  return definition.floatDefaults?.[float] ?? definition.defaultValue;
+}
+
+function canOverride(definition: FeatureFlagDefinition, float: FeatureFlagFloat): boolean {
+  return (
+    definition.userToggleable &&
+    (definition.overridableFloats === undefined || definition.overridableFloats.includes(float))
+  );
+}
+
+function sanitizeValues(value: unknown): FeatureFlagValues {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return {};
+  const candidate = value as Record<string, unknown>;
+  const sanitized: FeatureFlagValues = {};
+  for (const definition of FEATURE_FLAGS) {
+    const flagValue = candidate[definition.id];
+    if (typeof flagValue === 'string') sanitized[definition.id] = flagValue;
+  }
+  return sanitized;
+}
+
+function getStorage(): FeatureFlagStorage | undefined {
+  try {
+    const storage = (globalThis as { localStorage?: Partial<FeatureFlagStorage> }).localStorage;
+    if (typeof storage?.getItem !== 'function' || typeof storage.setItem !== 'function') return;
+    return storage as FeatureFlagStorage;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/webapp/src/ui/boot/setup-feature-flags-remote.ts
+++ b/packages/webapp/src/ui/boot/setup-feature-flags-remote.ts
@@ -1,0 +1,57 @@
+import type { FeatureFlagFloat } from '../../core/feature-flags.js';
+import { refreshFeatureFlagsFromRemote } from '../../core/feature-flags-remote.js';
+import {
+  DEFAULT_PRODUCTION_TRAY_WORKER_BASE_URL,
+  DEFAULT_STAGING_TRAY_WORKER_BASE_URL,
+  normalizeTrayWorkerBaseUrl,
+  type RuntimeConfigStorage,
+  TRAY_WORKER_STORAGE_KEY,
+} from '../../scoops/tray-runtime-config.js';
+import type { FeatureFlagsBootOptions } from './setup-feature-flags.js';
+
+/** Resolve and fetch worker flags after the synchronous cache-backed boot path. */
+export function refreshFeatureFlagsForPage(
+  float: FeatureFlagFloat,
+  options: FeatureFlagsBootOptions
+): Promise<void> {
+  return refreshFeatureFlagsFromRemote(float, {
+    workerBaseUrl: resolveFeatureFlagsWorkerBaseUrl(options),
+    storage: options.storage,
+  });
+}
+
+/**
+ * Resolve the public worker origin without resolveApiUrl(): that helper targets
+ * node-server in thin-bridge mode, while `/api/flags` exists only on the worker.
+ */
+export function resolveFeatureFlagsWorkerBaseUrl(options: FeatureFlagsBootOptions): string {
+  const stored = readStoredWorkerBaseUrl(options.storage);
+  const env = normalizeTrayWorkerBaseUrl(options.envBaseUrl ?? null);
+  if (stored) return stored;
+  if (env) return env;
+
+  // Vite development origins do not host the worker API. Built hosted pages
+  // (standalone thin bridge, hosted leader, follower, and Cherry) do, so their
+  // HTTP(S) origin is the most accurate fallback, including custom deployments.
+  if (!options.isDev) {
+    try {
+      const location = new URL(options.locationHref);
+      if (location.protocol === 'http:' || location.protocol === 'https:') {
+        return location.origin;
+      }
+    } catch {
+      // Fall through to the bundled production origin.
+    }
+  }
+  return options.isDev
+    ? DEFAULT_STAGING_TRAY_WORKER_BASE_URL
+    : DEFAULT_PRODUCTION_TRAY_WORKER_BASE_URL;
+}
+
+function readStoredWorkerBaseUrl(storage: RuntimeConfigStorage | null | undefined): string | null {
+  try {
+    return normalizeTrayWorkerBaseUrl(storage?.getItem(TRAY_WORKER_STORAGE_KEY) ?? null);
+  } catch {
+    return null;
+  }
+}

--- a/packages/webapp/src/ui/boot/setup-feature-flags.ts
+++ b/packages/webapp/src/ui/boot/setup-feature-flags.ts
@@ -1,15 +1,9 @@
 import type { FeatureFlagFloat } from '../../core/feature-flags.js';
-import { hydrateFeatureFlagsFromRemote } from '../../core/feature-flags-remote.js';
-import {
-  DEFAULT_PRODUCTION_TRAY_WORKER_BASE_URL,
-  DEFAULT_STAGING_TRAY_WORKER_BASE_URL,
-  normalizeTrayWorkerBaseUrl,
-  type RuntimeConfigStorage,
-  TRAY_WORKER_STORAGE_KEY,
-} from '../../scoops/tray-runtime-config.js';
+import { initFeatureFlagsFromRemoteCache } from '../../core/feature-flags-cache.js';
+import type { RuntimeConfigStorage } from '../../scoops/tray-runtime-config.js';
 import { resolveUiRuntimeMode, type UiRuntimeMode } from '../runtime-mode.js';
 
-interface FeatureFlagsBootOptions {
+export interface FeatureFlagsBootOptions {
   locationHref: string;
   storage?: RuntimeConfigStorage | null;
   envBaseUrl?: string | null;
@@ -20,40 +14,13 @@ interface FeatureFlagsPageBootOptions extends FeatureFlagsBootOptions {
   isExtension: boolean;
 }
 
-/**
- * Resolve the public worker origin without resolveApiUrl(): that helper targets
- * node-server in thin-bridge mode, while `/api/flags` exists only on the worker.
- */
-export function resolveFeatureFlagsWorkerBaseUrl(options: FeatureFlagsBootOptions): string {
-  const stored = readStoredWorkerBaseUrl(options.storage);
-  const env = normalizeTrayWorkerBaseUrl(options.envBaseUrl ?? null);
-  if (stored) return stored;
-  if (env) return env;
-
-  // Vite development origins do not host the worker API. Built hosted pages
-  // (standalone thin bridge, hosted leader, follower, and Cherry) do, so their
-  // HTTP(S) origin is the most accurate fallback, including custom deployments.
-  if (!options.isDev) {
-    try {
-      const location = new URL(options.locationHref);
-      if (location.protocol === 'http:' || location.protocol === 'https:') {
-        return location.origin;
-      }
-    } catch {
-      // Fall through to the bundled production origin.
-    }
-  }
-  return options.isDev
-    ? DEFAULT_STAGING_TRAY_WORKER_BASE_URL
-    : DEFAULT_PRODUCTION_TRAY_WORKER_BASE_URL;
-}
-
 export function setupFeatureFlags(float: FeatureFlagFloat, options: FeatureFlagsBootOptions): void {
-  const workerBaseUrl = resolveFeatureFlagsWorkerBaseUrl(options);
-  void hydrateFeatureFlagsFromRemote(float, {
-    workerBaseUrl,
-    storage: options.storage,
-  });
+  initFeatureFlagsFromRemoteCache(float, options.storage);
+  void import('./setup-feature-flags-remote.js')
+    .then(({ refreshFeatureFlagsForPage }) => refreshFeatureFlagsForPage(float, options))
+    .catch(() => {
+      // Remote hydration is best-effort; bundled defaults and the cache stay active.
+    });
 }
 
 export function setupFeatureFlagsForPage(options: FeatureFlagsPageBootOptions): UiRuntimeMode {
@@ -64,12 +31,4 @@ export function setupFeatureFlagsForPage(options: FeatureFlagsPageBootOptions): 
   );
   setupFeatureFlags(runtimeMode, options);
   return runtimeMode;
-}
-
-function readStoredWorkerBaseUrl(storage: RuntimeConfigStorage | null | undefined): string | null {
-  try {
-    return normalizeTrayWorkerBaseUrl(storage?.getItem(TRAY_WORKER_STORAGE_KEY) ?? null);
-  } catch {
-    return null;
-  }
 }

--- a/packages/webapp/src/ui/boot/setup-feature-flags.ts
+++ b/packages/webapp/src/ui/boot/setup-feature-flags.ts
@@ -7,12 +7,17 @@ import {
   type RuntimeConfigStorage,
   TRAY_WORKER_STORAGE_KEY,
 } from '../../scoops/tray-runtime-config.js';
+import { resolveUiRuntimeMode, type UiRuntimeMode } from '../runtime-mode.js';
 
 interface FeatureFlagsBootOptions {
   locationHref: string;
   storage?: RuntimeConfigStorage | null;
   envBaseUrl?: string | null;
   isDev: boolean;
+}
+
+interface FeatureFlagsPageBootOptions extends FeatureFlagsBootOptions {
+  isExtension: boolean;
 }
 
 /**
@@ -49,6 +54,16 @@ export function setupFeatureFlags(float: FeatureFlagFloat, options: FeatureFlags
     workerBaseUrl,
     storage: options.storage,
   });
+}
+
+export function setupFeatureFlagsForPage(options: FeatureFlagsPageBootOptions): UiRuntimeMode {
+  const runtimeMode = resolveUiRuntimeMode(
+    options.locationHref,
+    options.isExtension,
+    options.storage
+  );
+  setupFeatureFlags(runtimeMode, options);
+  return runtimeMode;
 }
 
 function readStoredWorkerBaseUrl(storage: RuntimeConfigStorage | null | undefined): string | null {

--- a/packages/webapp/src/ui/boot/setup-feature-flags.ts
+++ b/packages/webapp/src/ui/boot/setup-feature-flags.ts
@@ -1,0 +1,60 @@
+import type { FeatureFlagFloat } from '../../core/feature-flags.js';
+import { hydrateFeatureFlagsFromRemote } from '../../core/feature-flags-remote.js';
+import {
+  DEFAULT_PRODUCTION_TRAY_WORKER_BASE_URL,
+  DEFAULT_STAGING_TRAY_WORKER_BASE_URL,
+  normalizeTrayWorkerBaseUrl,
+  type RuntimeConfigStorage,
+  TRAY_WORKER_STORAGE_KEY,
+} from '../../scoops/tray-runtime-config.js';
+
+interface FeatureFlagsBootOptions {
+  locationHref: string;
+  storage?: RuntimeConfigStorage | null;
+  envBaseUrl?: string | null;
+  isDev: boolean;
+}
+
+/**
+ * Resolve the public worker origin without resolveApiUrl(): that helper targets
+ * node-server in thin-bridge mode, while `/api/flags` exists only on the worker.
+ */
+export function resolveFeatureFlagsWorkerBaseUrl(options: FeatureFlagsBootOptions): string {
+  const stored = readStoredWorkerBaseUrl(options.storage);
+  const env = normalizeTrayWorkerBaseUrl(options.envBaseUrl ?? null);
+  if (stored) return stored;
+  if (env) return env;
+
+  // Vite development origins do not host the worker API. Built hosted pages
+  // (standalone thin bridge, hosted leader, follower, and Cherry) do, so their
+  // HTTP(S) origin is the most accurate fallback, including custom deployments.
+  if (!options.isDev) {
+    try {
+      const location = new URL(options.locationHref);
+      if (location.protocol === 'http:' || location.protocol === 'https:') {
+        return location.origin;
+      }
+    } catch {
+      // Fall through to the bundled production origin.
+    }
+  }
+  return options.isDev
+    ? DEFAULT_STAGING_TRAY_WORKER_BASE_URL
+    : DEFAULT_PRODUCTION_TRAY_WORKER_BASE_URL;
+}
+
+export function setupFeatureFlags(float: FeatureFlagFloat, options: FeatureFlagsBootOptions): void {
+  const workerBaseUrl = resolveFeatureFlagsWorkerBaseUrl(options);
+  void hydrateFeatureFlagsFromRemote(float, {
+    workerBaseUrl,
+    storage: options.storage,
+  });
+}
+
+function readStoredWorkerBaseUrl(storage: RuntimeConfigStorage | null | undefined): string | null {
+  try {
+    return normalizeTrayWorkerBaseUrl(storage?.getItem(TRAY_WORKER_STORAGE_KEY) ?? null);
+  } catch {
+    return null;
+  }
+}

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -25,14 +25,13 @@ import { registerProviders } from '../providers/index.js';
 import { parseBridgeLaunchParams } from './boot/bridge-launch-params.js';
 import { renderBootRecoveryScreen } from './boot/recovery-screen.js';
 import { installExtensionFetchDelegate } from './boot/setup-extension-fetch-delegate.js';
-import { setupFeatureFlags } from './boot/setup-feature-flags.js';
+import { setupFeatureFlagsForPage } from './boot/setup-feature-flags.js';
 import { startFreezeWatchdog } from './boot/setup-freeze-watchdog.js';
 import { setupNukeReloadListener } from './boot/setup-nuke-reload-listener.js';
 import { setupPreloadErrorReload } from './boot/setup-preload-error-reload.js';
 import { parseExtensionLeaderParams } from './boot/setup-standalone-prelude.js';
 import { setupSwRegistration } from './boot/setup-sw-registration.js';
 import { applyProviderDefaults } from './provider-settings.js';
-import { resolveUiRuntimeMode } from './runtime-mode.js';
 import { initTelemetry } from './telemetry.js';
 
 const log = createLogger('main');
@@ -56,15 +55,14 @@ async function main(): Promise<void> {
   if (!app) throw new Error('#app element not found');
 
   const isExtension = isExtensionRealm();
-  // Storage arg omitted on purpose: resolveUiRuntimeMode falls back to ambient
-  // window.localStorage when it's undefined (main.ts always runs in the page),
-  // so a stored follower join URL is still detected here.
-  const runtimeMode = resolveUiRuntimeMode(window.location.href, isExtension);
-  setupFeatureFlags(runtimeMode, {
+  // Use one boot helper for runtime detection and flag hydration so the float
+  // sent to the worker and used for the local cache cannot diverge.
+  const runtimeMode = setupFeatureFlagsForPage({
     locationHref: window.location.href,
     storage: window.localStorage,
     envBaseUrl: import.meta.env.VITE_WORKER_BASE_URL ?? null,
     isDev: __DEV__,
+    isExtension,
   });
 
   // Design-time fixture: the WC shell over the synthetic chat session,

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -25,6 +25,7 @@ import { registerProviders } from '../providers/index.js';
 import { parseBridgeLaunchParams } from './boot/bridge-launch-params.js';
 import { renderBootRecoveryScreen } from './boot/recovery-screen.js';
 import { installExtensionFetchDelegate } from './boot/setup-extension-fetch-delegate.js';
+import { setupFeatureFlags } from './boot/setup-feature-flags.js';
 import { startFreezeWatchdog } from './boot/setup-freeze-watchdog.js';
 import { setupNukeReloadListener } from './boot/setup-nuke-reload-listener.js';
 import { setupPreloadErrorReload } from './boot/setup-preload-error-reload.js';
@@ -59,6 +60,12 @@ async function main(): Promise<void> {
   // window.localStorage when it's undefined (main.ts always runs in the page),
   // so a stored follower join URL is still detected here.
   const runtimeMode = resolveUiRuntimeMode(window.location.href, isExtension);
+  setupFeatureFlags(runtimeMode, {
+    locationHref: window.location.href,
+    storage: window.localStorage,
+    envBaseUrl: import.meta.env.VITE_WORKER_BASE_URL ?? null,
+    isDev: __DEV__,
+  });
 
   // Design-time fixture: the WC shell over the synthetic chat session,
   // no kernel, no providers — exits before any heavy boot work.

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -684,6 +684,8 @@ export async function mountWcUiFollower(
   // (wireWcNav needs a worker client; a follower has none, so we set the
   // menu items directly.)
   // Task 8: add "Export transcript" to the follower avatar menu.
+  // Experimental features are deliberately excluded: the centrally gated
+  // dialog currently has no user-toggleable flags, so this menu stays minimal.
   let exportInFlight = false;
   const syncFollowerMenuItems = (): void => {
     boot.refs.avatarMenu.items = [

--- a/packages/webapp/src/ui/wc/wc-nav.ts
+++ b/packages/webapp/src/ui/wc/wc-nav.ts
@@ -6,6 +6,7 @@
  * section (enable / copy join URL / stop / disconnect).
  */
 
+import { isFeatureEnabled } from '../../core/feature-flags.js';
 import { isExtensionRealm } from '../../core/runtime-env.js';
 import { getFollowerTrayRuntimeStatus } from '../../scoops/tray-follower-status.js';
 import { getLeaderTrayRuntimeStatus } from '../../scoops/tray-leader.js';
@@ -91,6 +92,29 @@ export interface WcNavDeps {
    * the export is in-flight and restore it once the export completes.
    */
   onExportTranscript?: () => Promise<void>;
+}
+
+function standardMenuItems(
+  exportInFlight: boolean
+): NonNullable<WcShellRefs['avatarMenu']['items']> {
+  const items: NonNullable<WcShellRefs['avatarMenu']['items']> = [
+    { id: 'settings', label: 'Account settings…', icon: 'settings' },
+    { id: 'theme', label: 'Theme settings…', icon: 'palette' },
+    {
+      id: 'export-transcript',
+      label: 'Export transcript',
+      icon: 'download',
+      disabled: exportInFlight || undefined,
+    },
+  ];
+  if (isFeatureEnabled('experimental-settings')) {
+    items.push({
+      id: 'experimental-settings',
+      label: 'Experimental features…',
+      icon: 'flask-conical',
+    });
+  }
+  return items;
 }
 
 export async function wireWcNav(deps: WcNavDeps): Promise<void> {
@@ -205,14 +229,7 @@ export async function wireWcNav(deps: WcNavDeps): Promise<void> {
   let exportInFlight = false;
   const syncMenuItems = (): void => {
     refs.avatarMenu.items = [
-      { id: 'settings', label: 'Account settings…', icon: 'settings' },
-      { id: 'theme', label: 'Theme settings…', icon: 'palette' },
-      {
-        id: 'export-transcript',
-        label: 'Export transcript',
-        icon: 'download',
-        disabled: exportInFlight || undefined,
-      },
+      ...standardMenuItems(exportInFlight),
       ...popoutItems(),
       ...trayMenuItems(),
     ];
@@ -226,6 +243,7 @@ export async function wireWcNav(deps: WcNavDeps): Promise<void> {
     client.updateModel()
   );
   const openTheme = buildOpenTheme(log);
+  const openExperimental = buildOpenExperimental(log);
 
   refs.avatarMenu.addEventListener('slicc-avatar-action', (event) => {
     const id = (event as CustomEvent<{ id?: string }>).detail?.id;
@@ -241,6 +259,7 @@ export async function wireWcNav(deps: WcNavDeps): Promise<void> {
     }
     if (id === 'settings') openSettings();
     if (id === 'theme') openTheme();
+    if (id === 'experimental-settings') openExperimental();
     if (id === 'export-transcript' && onExportTranscript) {
       exportInFlight = true;
       syncMenuItems();
@@ -298,6 +317,14 @@ function buildOpenTheme(log: BootStageLogger): () => void {
     import('./wc-settings.js')
       .then(({ showThemeSettings }) => showThemeSettings(log))
       .catch((err) => log.error('Theme settings dialog failed', err));
+  };
+}
+
+function buildOpenExperimental(log: BootStageLogger): () => void {
+  return () => {
+    import('./wc-settings.js')
+      .then(({ showExperimentalSettings }) => showExperimentalSettings(log))
+      .catch((err) => log.error('Experimental settings dialog failed', err));
   };
 }
 

--- a/packages/webapp/src/ui/wc/wc-settings.ts
+++ b/packages/webapp/src/ui/wc/wc-settings.ts
@@ -7,6 +7,7 @@
  * (tray-join, auto-join) stay on the legacy dialog via the connect surface.
  */
 
+import { isFeatureEnabled, listFlags, setFeatureFlagOverride } from '../../core/feature-flags.js';
 import { getDiscoveryEnabled, setDiscoveryEnabled } from '../discovery-preference.js';
 import type { Account, ProviderConfig } from '../provider-settings.js';
 import { applyTheme } from '../theme.js';
@@ -356,6 +357,31 @@ function buildBrowsingPreferencesSection(): HTMLElement {
   row.append(label, check);
   section.append(row);
   return section;
+}
+
+function buildExperimentalSection(): HTMLElement[] {
+  if (!isFeatureEnabled('experimental-settings')) return [];
+  const section = div('wcset__add');
+  section.append(div('wcset__section-label', 'Experimental'));
+  for (const flag of listFlags().filter((candidate) => candidate.userToggleable)) {
+    const row = div('wcset__toggle-row');
+    const info = div('wcset__info');
+    const label = document.createElement('label');
+    const check = document.createElement('input');
+    check.id = `wcset-feature-${flag.id}`;
+    check.type = 'checkbox';
+    check.checked = isFeatureEnabled(flag.id);
+    label.htmlFor = check.id;
+    label.textContent = flag.label;
+    info.append(label, div('wcset__detail', flag.description));
+    check.addEventListener('change', () => {
+      setFeatureFlagOverride(flag.id, check.checked ? 'on' : 'off');
+      check.checked = isFeatureEnabled(flag.id);
+    });
+    row.append(info, check);
+    section.append(row);
+  }
+  return [section];
 }
 
 function buildAppearanceSection(deps: ViewDeps): HTMLElement {
@@ -887,7 +913,7 @@ export async function showWcSettings(log: SettingsLogger): Promise<boolean> {
     };
     deps.renderList();
 
-    body.append(list, addSectionSlot, status);
+    body.append(list, addSectionSlot, ...buildExperimentalSection(), status);
     dialog.append(body);
 
     const done = button('wcset__btn wcset__btn--primary', 'Done', () => {

--- a/packages/webapp/src/ui/wc/wc-settings.ts
+++ b/packages/webapp/src/ui/wc/wc-settings.ts
@@ -359,11 +359,16 @@ function buildBrowsingPreferencesSection(): HTMLElement {
   return section;
 }
 
-function buildExperimentalSection(): HTMLElement[] {
-  if (!isFeatureEnabled('experimental-settings')) return [];
-  const section = div('wcset__add');
-  section.append(div('wcset__section-label', 'Experimental'));
-  for (const flag of listFlags().filter((candidate) => candidate.userToggleable)) {
+function buildExperimentalSection(deps: {
+  log: SettingsLogger;
+  setStatus(text: string, isError?: boolean): void;
+}): HTMLElement {
+  const section = div('wcset__list');
+  const flags = listFlags().filter((candidate) => candidate.userToggleable);
+  if (flags.length === 0) {
+    section.append(div('wcset__empty', 'No experimental features are available right now.'));
+  }
+  for (const flag of flags) {
     const row = div('wcset__toggle-row');
     const info = div('wcset__info');
     const label = document.createElement('label');
@@ -375,13 +380,19 @@ function buildExperimentalSection(): HTMLElement[] {
     label.textContent = flag.label;
     info.append(label, div('wcset__detail', flag.description));
     check.addEventListener('change', () => {
-      setFeatureFlagOverride(flag.id, check.checked ? 'on' : 'off');
-      check.checked = isFeatureEnabled(flag.id);
+      try {
+        setFeatureFlagOverride(flag.id, check.checked ? 'on' : 'off');
+        check.checked = isFeatureEnabled(flag.id);
+        deps.setStatus('Saved.');
+      } catch (err) {
+        deps.log.error('Experimental settings update failed', { flagId: flag.id, err });
+        deps.setStatus('Unable to save this feature setting.', true);
+      }
     });
     row.append(info, check);
     section.append(row);
   }
-  return [section];
+  return section;
 }
 
 function buildAppearanceSection(deps: ViewDeps): HTMLElement {
@@ -913,7 +924,7 @@ export async function showWcSettings(log: SettingsLogger): Promise<boolean> {
     };
     deps.renderList();
 
-    body.append(list, addSectionSlot, ...buildExperimentalSection(), status);
+    body.append(list, addSectionSlot, status);
     dialog.append(body);
 
     const done = button('wcset__btn wcset__btn--primary', 'Done', () => {
@@ -982,6 +993,41 @@ export async function showThemeSettings(log: SettingsLogger): Promise<void> {
         }
         applyTheme();
       }
+      dialog.remove();
+      resolve();
+    });
+
+    document.body.append(dialog);
+    (dialog as HTMLElement & { show?: () => void }).show?.();
+  });
+}
+
+/** Open the centrally gated standalone experimental-features dialog. */
+export async function showExperimentalSettings(log: SettingsLogger): Promise<void> {
+  if (!isFeatureEnabled('experimental-settings')) return;
+  ensureSettingsStyle(document);
+
+  return new Promise((resolve) => {
+    const dialog = document.createElement('slicc-dialog');
+    dialog.classList.add('wcset-dialog');
+    dialog.setAttribute('heading', 'Experimental');
+
+    const body = div('wcset');
+    const status = div('wcset__status');
+    const setStatus = (text: string, isError = false): void => {
+      status.textContent = text;
+      status.toggleAttribute('data-error', isError);
+    };
+    body.append(buildExperimentalSection({ log, setStatus }), status);
+    dialog.append(body);
+
+    const done = button('wcset__btn wcset__btn--primary', 'Done', () => {
+      (dialog as HTMLElement & { hide?: () => void }).hide?.();
+    });
+    done.setAttribute('slot', 'footer');
+    dialog.append(done);
+
+    dialog.addEventListener('slicc-dialog-close', () => {
       dialog.remove();
       resolve();
     });

--- a/packages/webapp/tests/core/feature-flags-remote.test.ts
+++ b/packages/webapp/tests/core/feature-flags-remote.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  FEATURE_FLAG_STORAGE_KEY,
+  getFeatureValue,
+  initFeatureFlags,
+} from '../../src/core/feature-flags.js';
+import {
+  featureFlagsRemoteCacheKey,
+  hydrateFeatureFlagsFromRemote,
+} from '../../src/core/feature-flags-remote.js';
+import { TRAY_WORKER_STORAGE_KEY } from '../../src/scoops/tray-runtime-config.js';
+import { resolveFeatureFlagsWorkerBaseUrl } from '../../src/ui/boot/setup-feature-flags.js';
+
+function makeMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => void values.set(key, String(value)),
+    removeItem: (key) => void values.delete(key),
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() {
+      return values.size;
+    },
+  } as Storage;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', makeMemoryStorage());
+  initFeatureFlags('standalone');
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('remote feature flag hydration', () => {
+  it('fetches the runtime float and initializes from payload.flags', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ float: 'default', flags: { 'experimental-settings': 'off' } })
+    );
+
+    await hydrateFeatureFlagsFromRemote('standalone', {
+      workerBaseUrl: 'https://flags.example',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://flags.example/api/flags?float=standalone',
+      expect.objectContaining({ cache: 'no-store', signal: expect.any(AbortSignal) })
+    );
+    expect(getFeatureValue('experimental-settings')).toBe('off');
+    expect(localStorage.getItem(featureFlagsRemoteCacheKey('standalone'))).toBe(
+      JSON.stringify({ 'experimental-settings': 'off' })
+    );
+  });
+
+  it('keeps bundled defaults after an HTTP 500', async () => {
+    await hydrateFeatureFlagsFromRemote('standalone', {
+      workerBaseUrl: 'https://flags.example',
+      fetchImpl: vi.fn(async () =>
+        jsonResponse({ error: 'failed' }, 500)
+      ) as unknown as typeof fetch,
+    });
+
+    expect(getFeatureValue('experimental-settings')).toBe('on');
+    expect(localStorage.getItem(featureFlagsRemoteCacheKey('standalone'))).toBeNull();
+  });
+
+  it('keeps bundled defaults after a network error', async () => {
+    await hydrateFeatureFlagsFromRemote('standalone', {
+      workerBaseUrl: 'https://flags.example',
+      fetchImpl: vi.fn(async () => {
+        throw new Error('offline');
+      }) as unknown as typeof fetch,
+    });
+
+    expect(getFeatureValue('experimental-settings')).toBe('on');
+  });
+
+  it('keeps bundled defaults after a malformed body', async () => {
+    await hydrateFeatureFlagsFromRemote('standalone', {
+      workerBaseUrl: 'https://flags.example',
+      fetchImpl: vi.fn(async () =>
+        jsonResponse({ float: 'standalone', flags: { 'experimental-settings': false } })
+      ) as unknown as typeof fetch,
+    });
+
+    expect(getFeatureValue('experimental-settings')).toBe('on');
+    expect(localStorage.getItem(featureFlagsRemoteCacheKey('standalone'))).toBeNull();
+  });
+
+  it('keeps bundled defaults after malformed JSON', async () => {
+    await hydrateFeatureFlagsFromRemote('standalone', {
+      workerBaseUrl: 'https://flags.example',
+      fetchImpl: vi.fn(
+        async () =>
+          new Response('{not-json', {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+      ) as unknown as typeof fetch,
+    });
+
+    expect(getFeatureValue('experimental-settings')).toBe('on');
+  });
+
+  it('times out silently and aborts the request', async () => {
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    const fetchImpl = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      signal = init?.signal ?? undefined;
+      return new Promise<Response>(() => {});
+    });
+    const hydration = hydrateFeatureFlagsFromRemote('standalone', {
+      workerBaseUrl: 'https://flags.example',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      timeoutMs: 25,
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+    await hydration;
+
+    expect(signal?.aborted).toBe(true);
+    expect(getFeatureValue('experimental-settings')).toBe('on');
+  });
+
+  it('hydrates from cache synchronously while offline', async () => {
+    localStorage.setItem(
+      featureFlagsRemoteCacheKey('standalone'),
+      JSON.stringify({ 'experimental-settings': 'off' })
+    );
+    const hydration = hydrateFeatureFlagsFromRemote('standalone', {
+      workerBaseUrl: 'https://flags.example',
+      fetchImpl: vi.fn(async () => {
+        throw new Error('offline');
+      }) as unknown as typeof fetch,
+    });
+
+    expect(getFeatureValue('experimental-settings')).toBe('off');
+    await hydration;
+    expect(getFeatureValue('experimental-settings')).toBe('off');
+  });
+
+  it('keeps the runtime Cherry float when the worker echoes default', async () => {
+    localStorage.setItem(
+      FEATURE_FLAG_STORAGE_KEY,
+      JSON.stringify({ 'experimental-settings': 'on' })
+    );
+
+    await hydrateFeatureFlagsFromRemote('cherry', {
+      workerBaseUrl: 'https://flags.example',
+      fetchImpl: vi.fn(async () =>
+        jsonResponse({ float: 'default', flags: { 'experimental-settings': 'off' } })
+      ) as unknown as typeof fetch,
+    });
+
+    expect(getFeatureValue('experimental-settings')).toBe('off');
+  });
+
+  it('resolves the worker origin without routing through the local API bridge', () => {
+    localStorage.setItem(TRAY_WORKER_STORAGE_KEY, 'https://configured-worker.example/');
+    expect(
+      resolveFeatureFlagsWorkerBaseUrl({
+        locationHref: 'https://www.sliccy.ai/?bridge=ws://localhost:5710/cdp',
+        storage: localStorage,
+        envBaseUrl: null,
+        isDev: false,
+      })
+    ).toBe('https://configured-worker.example');
+    localStorage.removeItem(TRAY_WORKER_STORAGE_KEY);
+    expect(
+      resolveFeatureFlagsWorkerBaseUrl({
+        locationHref: 'https://custom-worker.example/?cherry=1',
+        storage: localStorage,
+        envBaseUrl: null,
+        isDev: false,
+      })
+    ).toBe('https://custom-worker.example');
+  });
+});

--- a/packages/webapp/tests/core/feature-flags-remote.test.ts
+++ b/packages/webapp/tests/core/feature-flags-remote.test.ts
@@ -9,7 +9,7 @@ import {
   hydrateFeatureFlagsFromRemote,
 } from '../../src/core/feature-flags-remote.js';
 import { TRAY_WORKER_STORAGE_KEY } from '../../src/scoops/tray-runtime-config.js';
-import { resolveFeatureFlagsWorkerBaseUrl } from '../../src/ui/boot/setup-feature-flags.js';
+import { resolveFeatureFlagsWorkerBaseUrl } from '../../src/ui/boot/setup-feature-flags-remote.js';
 
 function makeMemoryStorage(): Storage {
   const values = new Map<string, string>();

--- a/packages/webapp/tests/core/feature-flags.test.ts
+++ b/packages/webapp/tests/core/feature-flags.test.ts
@@ -43,9 +43,10 @@ describe('feature flag registry', () => {
         id: 'experimental-settings',
         label: 'Experimental settings',
         defaultValue: 'on',
-        userToggleable: true,
+        userToggleable: false,
       }),
     ]);
+    expect(listFlags()[0]).not.toHaveProperty('overridableFloats');
   });
 
   it('uses float-aware bundled defaults', () => {
@@ -54,12 +55,12 @@ describe('feature flag registry', () => {
     expect(resolveFlagValue('experimental-settings', 'cherry')).toBe('off');
   });
 
-  it('applies a permitted string override', () => {
+  it('ignores a string override for the central-only flag', () => {
     expect(
       resolveFlagValue('experimental-settings', 'standalone', {
         'experimental-settings': 'variant-a',
       })
-    ).toBe('variant-a');
+    ).toBe('on');
   });
 
   it('ignores an override on a float where overrides are not permitted', () => {
@@ -70,27 +71,18 @@ describe('feature flag registry', () => {
     ).toBe('off');
   });
 
-  it('ignores a local override for a flag that is not user-toggleable', async () => {
-    vi.resetModules();
-    const freeze = vi
-      .spyOn(Object, 'freeze')
-      .mockImplementation(<T>(value: T): Readonly<T> => value);
-    const fixture = await import('../../src/core/feature-flags.js').finally(() => {
-      freeze.mockRestore();
-    });
-    const definition = fixture.listFlags()[0] as { userToggleable: boolean };
-    definition.userToggleable = false;
+  it('ignores a stored local override for the central-only flag', () => {
     localStorage.setItem(
-      fixture.FEATURE_FLAG_STORAGE_KEY,
+      FEATURE_FLAG_STORAGE_KEY,
       JSON.stringify({ 'experimental-settings': 'on' })
     );
 
-    fixture.initFeatureFlags('standalone', { 'experimental-settings': 'off' });
+    initFeatureFlags('standalone', { 'experimental-settings': 'off' });
 
-    expect(fixture.getFeatureValue('experimental-settings')).toBe('off');
+    expect(getFeatureValue('experimental-settings')).toBe('off');
   });
 
-  it('resolves local override before central value before bundled default', () => {
+  it('resolves central value before the bundled default', () => {
     expect(resolveFlags('standalone', { 'experimental-settings': 'off' })).toEqual({
       'experimental-settings': 'off',
     });
@@ -100,7 +92,7 @@ describe('feature flag registry', () => {
         { 'experimental-settings': 'off' },
         { 'experimental-settings': 'on' }
       )
-    ).toEqual({ 'experimental-settings': 'on' });
+    ).toEqual({ 'experimental-settings': 'off' });
   });
 
   it('round-trips string overrides through one localStorage key', () => {
@@ -111,10 +103,9 @@ describe('feature flag registry', () => {
     expect(readFeatureFlagOverrides()).toEqual({ 'experimental-settings': 'variant-b' });
   });
 
-  it('updates and clears the active float override', () => {
+  it('refuses to persist an override for the central-only flag', () => {
     setFeatureFlagOverride('experimental-settings', 'off');
-    expect(getFeatureValue('experimental-settings')).toBe('off');
-    setFeatureFlagOverride('experimental-settings', undefined);
+    expect(readFeatureFlagOverrides()).toEqual({});
     expect(getFeatureValue('experimental-settings')).toBe('on');
   });
 

--- a/packages/webapp/tests/core/feature-flags.test.ts
+++ b/packages/webapp/tests/core/feature-flags.test.ts
@@ -70,6 +70,26 @@ describe('feature flag registry', () => {
     ).toBe('off');
   });
 
+  it('ignores a local override for a flag that is not user-toggleable', async () => {
+    vi.resetModules();
+    const freeze = vi
+      .spyOn(Object, 'freeze')
+      .mockImplementation(<T>(value: T): Readonly<T> => value);
+    const fixture = await import('../../src/core/feature-flags.js').finally(() => {
+      freeze.mockRestore();
+    });
+    const definition = fixture.listFlags()[0] as { userToggleable: boolean };
+    definition.userToggleable = false;
+    localStorage.setItem(
+      fixture.FEATURE_FLAG_STORAGE_KEY,
+      JSON.stringify({ 'experimental-settings': 'on' })
+    );
+
+    fixture.initFeatureFlags('standalone', { 'experimental-settings': 'off' });
+
+    expect(fixture.getFeatureValue('experimental-settings')).toBe('off');
+  });
+
   it('resolves local override before central value before bundled default', () => {
     expect(resolveFlags('standalone', { 'experimental-settings': 'off' })).toEqual({
       'experimental-settings': 'off',

--- a/packages/webapp/tests/core/feature-flags.test.ts
+++ b/packages/webapp/tests/core/feature-flags.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  coerceFeatureFlagValue,
+  FEATURE_FLAG_STORAGE_KEY,
+  getFeatureValue,
+  initFeatureFlags,
+  isFeatureEnabled,
+  listFlags,
+  readFeatureFlagOverrides,
+  resolveFlags,
+  resolveFlagValue,
+  setFeatureFlagOverride,
+  writeFeatureFlagOverrides,
+} from '../../src/core/feature-flags.js';
+
+function makeMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => void values.set(key, String(value)),
+    removeItem: (key) => void values.delete(key),
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() {
+      return values.size;
+    },
+  } as Storage;
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', makeMemoryStorage());
+  initFeatureFlags('standalone');
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('feature flag registry', () => {
+  it('lists the experimental settings string flag', () => {
+    expect(listFlags()).toEqual([
+      expect.objectContaining({
+        id: 'experimental-settings',
+        label: 'Experimental settings',
+        defaultValue: 'on',
+        userToggleable: true,
+      }),
+    ]);
+  });
+
+  it('uses float-aware bundled defaults', () => {
+    expect(resolveFlagValue('experimental-settings', 'standalone')).toBe('on');
+    expect(resolveFlagValue('experimental-settings', 'extension')).toBe('on');
+    expect(resolveFlagValue('experimental-settings', 'cherry')).toBe('off');
+  });
+
+  it('applies a permitted string override', () => {
+    expect(
+      resolveFlagValue('experimental-settings', 'standalone', {
+        'experimental-settings': 'variant-a',
+      })
+    ).toBe('variant-a');
+  });
+
+  it('ignores an override on a float where overrides are not permitted', () => {
+    expect(
+      resolveFlagValue('experimental-settings', 'cherry', {
+        'experimental-settings': 'on',
+      })
+    ).toBe('off');
+  });
+
+  it('resolves local override before central value before bundled default', () => {
+    expect(resolveFlags('standalone', { 'experimental-settings': 'off' })).toEqual({
+      'experimental-settings': 'off',
+    });
+    expect(
+      resolveFlags(
+        'standalone',
+        { 'experimental-settings': 'off' },
+        { 'experimental-settings': 'on' }
+      )
+    ).toEqual({ 'experimental-settings': 'on' });
+  });
+
+  it('round-trips string overrides through one localStorage key', () => {
+    writeFeatureFlagOverrides({ 'experimental-settings': 'variant-b' });
+    expect(localStorage.getItem(FEATURE_FLAG_STORAGE_KEY)).toBe(
+      JSON.stringify({ 'experimental-settings': 'variant-b' })
+    );
+    expect(readFeatureFlagOverrides()).toEqual({ 'experimental-settings': 'variant-b' });
+  });
+
+  it('updates and clears the active float override', () => {
+    setFeatureFlagOverride('experimental-settings', 'off');
+    expect(getFeatureValue('experimental-settings')).toBe('off');
+    setFeatureFlagOverride('experimental-settings', undefined);
+    expect(getFeatureValue('experimental-settings')).toBe('on');
+  });
+
+  it('does not persist an override for cherry', () => {
+    initFeatureFlags('cherry');
+    setFeatureFlagOverride('experimental-settings', 'on');
+    expect(readFeatureFlagOverrides()).toEqual({});
+    expect(getFeatureValue('experimental-settings')).toBe('off');
+  });
+
+  it('falls back to defaults for corrupt or malformed storage', () => {
+    localStorage.setItem(FEATURE_FLAG_STORAGE_KEY, '{not-json');
+    expect(getFeatureValue('experimental-settings')).toBe('on');
+    localStorage.setItem(
+      FEATURE_FLAG_STORAGE_KEY,
+      JSON.stringify({
+        'experimental-settings': false,
+        unknown: 'on',
+      })
+    );
+    expect(readFeatureFlagOverrides()).toEqual({});
+  });
+
+  it('does not throw when localStorage is unavailable', () => {
+    vi.stubGlobal('localStorage', undefined);
+    expect(() => writeFeatureFlagOverrides({ 'experimental-settings': 'off' })).not.toThrow();
+    expect(readFeatureFlagOverrides()).toEqual({});
+    expect(getFeatureValue('experimental-settings')).toBe('on');
+  });
+
+  it('uses the documented boolean coercion', () => {
+    for (const value of ['on', 'ON', ' true ', '1']) {
+      expect(coerceFeatureFlagValue(value)).toBe(true);
+    }
+    for (const value of ['off', 'false', '0', 'variant-a', '', undefined]) {
+      expect(coerceFeatureFlagValue(value)).toBe(false);
+    }
+    initFeatureFlags('standalone', { 'experimental-settings': 'true' });
+    expect(isFeatureEnabled('experimental-settings')).toBe(true);
+  });
+
+  it('degrades an unknown runtime id without throwing', () => {
+    const unknownId = 'not-registered' as 'experimental-settings';
+    expect(resolveFlagValue(unknownId, 'standalone')).toBeUndefined();
+    expect(isFeatureEnabled(unknownId)).toBe(false);
+  });
+});

--- a/packages/webapp/tests/ui/boot/setup-feature-flags.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-feature-flags.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FEATURE_FLAG_STORAGE_KEY, isFeatureEnabled } from '../../../src/core/feature-flags.js';
+import {
+  FEATURE_FLAGS_REMOTE_STORAGE_KEY,
+  featureFlagsRemoteCacheKey,
+} from '../../../src/core/feature-flags-remote.js';
+import { setupFeatureFlagsForPage } from '../../../src/ui/boot/setup-feature-flags.js';
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => void values.set(key, String(value)),
+    removeItem: (key) => void values.delete(key),
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() {
+      return values.size;
+    },
+  } as Storage;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('feature flag page boot', () => {
+  it('boots ?cherry=1 with Cherry defaults and a float-isolated request/cache', () => {
+    const storage = memoryStorage();
+    const enabled = JSON.stringify({ 'experimental-settings': 'on' });
+    storage.setItem(FEATURE_FLAG_STORAGE_KEY, enabled);
+    storage.setItem(FEATURE_FLAGS_REMOTE_STORAGE_KEY, enabled);
+    storage.setItem(featureFlagsRemoteCacheKey('standalone'), enabled);
+    const fetchImpl = vi.fn(() => Promise.resolve(new Response(null, { status: 503 })));
+    vi.stubGlobal('fetch', fetchImpl);
+
+    const runtimeMode = setupFeatureFlagsForPage({
+      locationHref: 'https://app.example/?cherry=1',
+      storage,
+      envBaseUrl: null,
+      isDev: false,
+      isExtension: false,
+    });
+
+    expect(runtimeMode).toBe('cherry');
+    expect(isFeatureEnabled('experimental-settings')).toBe(false);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://app.example/api/flags?float=cherry',
+      expect.objectContaining({ cache: 'no-store' })
+    );
+    expect(storage.getItem(featureFlagsRemoteCacheKey('cherry'))).toBeNull();
+  });
+});

--- a/packages/webapp/tests/ui/boot/setup-feature-flags.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-feature-flags.test.ts
@@ -23,7 +23,29 @@ function memoryStorage(): Storage {
 afterEach(() => vi.unstubAllGlobals());
 
 describe('feature flag page boot', () => {
-  it('boots ?cherry=1 with Cherry defaults and a float-isolated request/cache', () => {
+  it('applies the last-known-good cache before the lazy refresh starts', async () => {
+    const storage = memoryStorage();
+    storage.setItem(
+      featureFlagsRemoteCacheKey('cherry'),
+      JSON.stringify({ 'experimental-settings': 'on' })
+    );
+    const fetchImpl = vi.fn(() => Promise.resolve(new Response(null, { status: 503 })));
+    vi.stubGlobal('fetch', fetchImpl);
+
+    setupFeatureFlagsForPage({
+      locationHref: 'https://app.example/?cherry=1',
+      storage,
+      envBaseUrl: null,
+      isDev: false,
+      isExtension: false,
+    });
+
+    expect(isFeatureEnabled('experimental-settings')).toBe(true);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledOnce());
+  });
+
+  it('boots ?cherry=1 synchronously and refreshes its float-isolated cache lazily', async () => {
     const storage = memoryStorage();
     const enabled = JSON.stringify({ 'experimental-settings': 'on' });
     storage.setItem(FEATURE_FLAG_STORAGE_KEY, enabled);
@@ -42,6 +64,8 @@ describe('feature flag page boot', () => {
 
     expect(runtimeMode).toBe('cherry');
     expect(isFeatureEnabled('experimental-settings')).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledOnce());
     expect(fetchImpl).toHaveBeenCalledWith(
       'https://app.example/api/flags?float=cherry',
       expect.objectContaining({ cache: 'no-store' })

--- a/packages/webapp/tests/ui/wc/wc-nav.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-nav.test.ts
@@ -4,7 +4,8 @@
  * and the live wiring against a fake client.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { hasIcon } from '@slicc/webcomponents';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { installWcDomStubs } from './wc-dom-stubs.js';
 
 installWcDomStubs();
@@ -13,7 +14,11 @@ installWcDomStubs();
 // `slicc-error-open-settings` event routes the user into the same surface
 // as the composer-meta `add-ai` action — without booting the real dialog.
 const showWcSettingsSpy = vi.fn(async () => undefined);
-vi.mock('../../../src/ui/wc/wc-settings.js', () => ({ showWcSettings: showWcSettingsSpy }));
+const showExperimentalSettingsSpy = vi.fn(async () => undefined);
+vi.mock('../../../src/ui/wc/wc-settings.js', () => ({
+  showExperimentalSettings: showExperimentalSettingsSpy,
+  showWcSettings: showWcSettingsSpy,
+}));
 
 // Stub the OAuth transport leaf so the real `reloginOAuthAccount` runs end to
 // end without booting the popup/CDP module graph: `createOAuthLauncher`
@@ -24,11 +29,22 @@ vi.mock('../../../src/providers/oauth-service.js', () => ({
   createInterceptingOAuthLauncherForCurrentRuntime: async () => null,
 }));
 
+import {
+  FEATURE_FLAG_STORAGE_KEY,
+  initFeatureFlags,
+  setFeatureFlagOverride,
+} from '../../../src/core/feature-flags.js';
 import { registerProviderConfig, unregisterProviderConfig } from '../../../src/providers/index.js';
 import type { OffscreenClient } from '../../../src/ui/offscreen-client.js';
 import type { GroupedModels } from '../../../src/ui/provider-settings.js';
 import { accountIdentity, modelListForMeta, wireWcNav } from '../../../src/ui/wc/wc-nav.js';
 import type { WcShellRefs } from '../../../src/ui/wc/wc-shell.js';
+
+afterEach(() => {
+  localStorage.removeItem(FEATURE_FLAG_STORAGE_KEY);
+  initFeatureFlags('standalone');
+  document.body.replaceChildren();
+});
 
 describe('modelListForMeta', () => {
   it('flattens provider groups into picker rows with provider-qualified ids', () => {
@@ -104,6 +120,54 @@ describe('wireWcNav', () => {
     // unchanged so `getSelectedProvider()` recovers the correct provider.
     expect(localStorage.getItem('selected-model')).toBe('adobe:claude-opus-4-8');
     expect(client.updateModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Experimental features immediately after Export transcript with a real icon', async () => {
+    initFeatureFlags('standalone', { 'experimental-settings': 'on' });
+    const refs = makeRefs();
+    const client = { updateModel: vi.fn() } as unknown as OffscreenClient;
+    await wireWcNav({ refs, client, log: { error: vi.fn() } as never });
+
+    const exportIndex = refs.avatarMenu.items.findIndex((item) => item.id === 'export-transcript');
+    const experimental = refs.avatarMenu.items[exportIndex + 1];
+    expect(experimental).toEqual({
+      id: 'experimental-settings',
+      label: 'Experimental features…',
+      icon: 'flask-conical',
+    });
+    expect(hasIcon(experimental?.icon ?? '')).toBe(true);
+  });
+
+  it('removes Experimental features on the next menu open when the worker turns it off', async () => {
+    initFeatureFlags('standalone', { 'experimental-settings': 'on' });
+    const refs = makeRefs();
+    const client = { updateModel: vi.fn() } as unknown as OffscreenClient;
+    await wireWcNav({ refs, client, log: { error: vi.fn() } as never });
+    expect(refs.avatarMenu.items.some((item) => item.id === 'experimental-settings')).toBe(true);
+
+    initFeatureFlags('standalone', { 'experimental-settings': 'off' });
+    setFeatureFlagOverride('experimental-settings', 'on');
+    refs.avatarMenu.dispatchEvent(
+      new CustomEvent('slicc-avatar-menu-toggle', { detail: { open: true } })
+    );
+
+    expect(refs.avatarMenu.items.some((item) => item.id === 'experimental-settings')).toBe(false);
+    expect(localStorage.getItem(FEATURE_FLAG_STORAGE_KEY)).toBeNull();
+  });
+
+  it('opens the standalone Experimental dialog from its avatar action', async () => {
+    initFeatureFlags('standalone', { 'experimental-settings': 'on' });
+    const refs = makeRefs();
+    const client = { updateModel: vi.fn() } as unknown as OffscreenClient;
+    await wireWcNav({ refs, client, log: { error: vi.fn() } as never });
+
+    showExperimentalSettingsSpy.mockClear();
+    refs.avatarMenu.dispatchEvent(
+      new CustomEvent('slicc-avatar-action', { detail: { id: 'experimental-settings' } })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(showExperimentalSettingsSpy).toHaveBeenCalledTimes(1);
   });
 
   it('clears the avatar identity when signed out (so the component shows ?)', async () => {

--- a/packages/webapp/tests/ui/wc/wc-settings.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-settings.test.ts
@@ -11,10 +11,15 @@ import { installWcDomStubs } from './wc-dom-stubs.js';
 
 installWcDomStubs();
 
-import { FEATURE_FLAG_STORAGE_KEY, initFeatureFlags } from '../../../src/core/feature-flags.js';
+import {
+  FEATURE_FLAG_STORAGE_KEY,
+  initFeatureFlags,
+  setFeatureFlagOverride,
+} from '../../../src/core/feature-flags.js';
 import {
   accountDetail,
   maskKey,
+  showExperimentalSettings,
   showThemeSettings,
   showWcSettings,
 } from '../../../src/ui/wc/wc-settings.js';
@@ -101,21 +106,8 @@ describe('accountDetail', () => {
 });
 
 describe('showWcSettings', () => {
-  it('shows user-toggleable experimental flags in a web UI float', async () => {
+  it('does not render experimental UI', async () => {
     initFeatureFlags('standalone');
-    const result = showWcSettings(log);
-    const dialog = await openDialog();
-
-    expect(dialog.textContent).toContain('Experimental');
-    expect(dialog.textContent).toContain('Show controls for experimental features.');
-    expect(findExperimentalToggle(dialog)?.checked).toBe(true);
-
-    clickDone(dialog);
-    await result;
-  });
-
-  it('omits the experimental section entirely in Cherry', async () => {
-    initFeatureFlags('cherry');
     const result = showWcSettings(log);
     const dialog = await openDialog();
 
@@ -124,70 +116,6 @@ describe('showWcSettings', () => {
 
     clickDone(dialog);
     await result;
-  });
-
-  it('round-trips experimental toggle changes as string overrides', async () => {
-    initFeatureFlags('standalone');
-    const result = showWcSettings(log);
-    const dialog = await openDialog();
-    const toggle = findExperimentalToggle(dialog);
-    expect(toggle).toBeTruthy();
-
-    toggle!.checked = false;
-    toggle!.dispatchEvent(new Event('change'));
-    expect(toggle!.checked).toBe(false);
-    expect(JSON.parse(localStorage.getItem(FEATURE_FLAG_STORAGE_KEY) ?? '{}')).toEqual({
-      'experimental-settings': 'off',
-    });
-
-    toggle!.checked = true;
-    toggle!.dispatchEvent(new Event('change'));
-    expect(toggle!.checked).toBe(true);
-    expect(JSON.parse(localStorage.getItem(FEATURE_FLAG_STORAGE_KEY) ?? '{}')).toEqual({
-      'experimental-settings': 'on',
-    });
-
-    clickDone(dialog);
-    await result;
-  });
-
-  it('persists the experimental override across dialog close and reopen', async () => {
-    initFeatureFlags('standalone');
-    const firstResult = showWcSettings(log);
-    const firstDialog = await openDialog();
-    const toggle = findExperimentalToggle(firstDialog);
-    expect(toggle).toBeTruthy();
-    toggle!.checked = false;
-    toggle!.dispatchEvent(new Event('change'));
-    clickDone(firstDialog);
-    await firstResult;
-
-    const reopenedResult = showWcSettings(log);
-    const reopenedDialog = await openDialog();
-    expect(reopenedDialog.textContent).not.toContain('Experimental');
-    expect(findExperimentalToggle(reopenedDialog)).toBeNull();
-    clickDone(reopenedDialog);
-    await reopenedResult;
-  });
-
-  it('restores the persisted override after reload-equivalent initialization', async () => {
-    initFeatureFlags('standalone');
-    const firstResult = showWcSettings(log);
-    const firstDialog = await openDialog();
-    const toggle = findExperimentalToggle(firstDialog);
-    expect(toggle).toBeTruthy();
-    toggle!.checked = false;
-    toggle!.dispatchEvent(new Event('change'));
-    clickDone(firstDialog);
-    await firstResult;
-
-    initFeatureFlags('standalone', { 'experimental-settings': 'on' });
-    const reloadedResult = showWcSettings(log);
-    const reloadedDialog = await openDialog();
-    expect(reloadedDialog.textContent).not.toContain('Experimental');
-    expect(findExperimentalToggle(reloadedDialog)).toBeNull();
-    clickDone(reloadedDialog);
-    await reloadedResult;
   });
 
   it('lists connected accounts and resolves false when nothing changed', async () => {
@@ -321,6 +249,69 @@ describe('showWcSettings', () => {
     } finally {
       window.removeEventListener('slicc:accounts-changed', onChange);
     }
+  });
+});
+
+describe('showExperimentalSettings', () => {
+  it('shows an honest empty state when no user-toggleable flags exist', async () => {
+    initFeatureFlags('standalone', { 'experimental-settings': 'on' });
+    const result = showExperimentalSettings(log);
+    const dialog = await openDialog();
+
+    expect(dialog.getAttribute('heading')).toBe('Experimental');
+    expect(dialog.textContent).toContain('No experimental features are available right now.');
+    expect(findExperimentalToggle(dialog)).toBeNull();
+
+    clickDone(dialog);
+    await result;
+  });
+
+  it('does not mount when called directly while the central flag is off', async () => {
+    initFeatureFlags('standalone', { 'experimental-settings': 'off' });
+
+    await expect(showExperimentalSettings(log)).resolves.toBeUndefined();
+    expect(document.querySelector('slicc-dialog')).toBeNull();
+  });
+
+  it('ignores a local attempt to turn on a worker-disabled dialog', async () => {
+    initFeatureFlags('standalone', { 'experimental-settings': 'off' });
+    setFeatureFlagOverride('experimental-settings', 'on');
+
+    expect(localStorage.getItem(FEATURE_FLAG_STORAGE_KEY)).toBeNull();
+    await showExperimentalSettings(log);
+    expect(document.querySelector('slicc-dialog')).toBeNull();
+  });
+
+  it('cannot be hidden locally and remains available after reopening', async () => {
+    initFeatureFlags('standalone', { 'experimental-settings': 'on' });
+    setFeatureFlagOverride('experimental-settings', 'off');
+
+    const firstResult = showExperimentalSettings(log);
+    const firstDialog = await openDialog();
+    clickDone(firstDialog);
+    await firstResult;
+
+    const reopenedResult = showExperimentalSettings(log);
+    const reopenedDialog = await openDialog();
+    expect(reopenedDialog.textContent).toContain(
+      'No experimental features are available right now.'
+    );
+    clickDone(reopenedDialog);
+    await reopenedResult;
+  });
+
+  it('ignores a stale persisted override after worker initialization', async () => {
+    localStorage.setItem(
+      FEATURE_FLAG_STORAGE_KEY,
+      JSON.stringify({ 'experimental-settings': 'off' })
+    );
+    initFeatureFlags('standalone', { 'experimental-settings': 'on' });
+
+    const result = showExperimentalSettings(log);
+    const dialog = await openDialog();
+    expect(dialog.getAttribute('heading')).toBe('Experimental');
+    clickDone(dialog);
+    await result;
   });
 });
 

--- a/packages/webapp/tests/ui/wc/wc-settings.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-settings.test.ts
@@ -11,6 +11,7 @@ import { installWcDomStubs } from './wc-dom-stubs.js';
 
 installWcDomStubs();
 
+import { FEATURE_FLAG_STORAGE_KEY, initFeatureFlags } from '../../../src/core/feature-flags.js';
 import {
   accountDetail,
   maskKey,
@@ -35,6 +36,10 @@ function findTimestampToggle(dialog: HTMLElement): HTMLInputElement | null {
   );
   const row = label?.parentElement;
   return (row?.querySelector('input[type="checkbox"]') as HTMLInputElement | null) ?? null;
+}
+
+function findExperimentalToggle(dialog: HTMLElement): HTMLInputElement | null {
+  return dialog.querySelector('#wcset-feature-experimental-settings');
 }
 
 const log = { error: vi.fn() };
@@ -64,6 +69,8 @@ function clickDone(dialog: HTMLElement): void {
 afterEach(() => {
   localStorage.removeItem('slicc_accounts');
   localStorage.removeItem('slicc_show_timestamps');
+  localStorage.removeItem(FEATURE_FLAG_STORAGE_KEY);
+  initFeatureFlags('standalone');
   document.body.replaceChildren();
 });
 
@@ -94,6 +101,95 @@ describe('accountDetail', () => {
 });
 
 describe('showWcSettings', () => {
+  it('shows user-toggleable experimental flags in a web UI float', async () => {
+    initFeatureFlags('standalone');
+    const result = showWcSettings(log);
+    const dialog = await openDialog();
+
+    expect(dialog.textContent).toContain('Experimental');
+    expect(dialog.textContent).toContain('Show controls for experimental features.');
+    expect(findExperimentalToggle(dialog)?.checked).toBe(true);
+
+    clickDone(dialog);
+    await result;
+  });
+
+  it('omits the experimental section entirely in Cherry', async () => {
+    initFeatureFlags('cherry');
+    const result = showWcSettings(log);
+    const dialog = await openDialog();
+
+    expect(dialog.textContent).not.toContain('Experimental');
+    expect(findExperimentalToggle(dialog)).toBeNull();
+
+    clickDone(dialog);
+    await result;
+  });
+
+  it('round-trips experimental toggle changes as string overrides', async () => {
+    initFeatureFlags('standalone');
+    const result = showWcSettings(log);
+    const dialog = await openDialog();
+    const toggle = findExperimentalToggle(dialog);
+    expect(toggle).toBeTruthy();
+
+    toggle!.checked = false;
+    toggle!.dispatchEvent(new Event('change'));
+    expect(toggle!.checked).toBe(false);
+    expect(JSON.parse(localStorage.getItem(FEATURE_FLAG_STORAGE_KEY) ?? '{}')).toEqual({
+      'experimental-settings': 'off',
+    });
+
+    toggle!.checked = true;
+    toggle!.dispatchEvent(new Event('change'));
+    expect(toggle!.checked).toBe(true);
+    expect(JSON.parse(localStorage.getItem(FEATURE_FLAG_STORAGE_KEY) ?? '{}')).toEqual({
+      'experimental-settings': 'on',
+    });
+
+    clickDone(dialog);
+    await result;
+  });
+
+  it('persists the experimental override across dialog close and reopen', async () => {
+    initFeatureFlags('standalone');
+    const firstResult = showWcSettings(log);
+    const firstDialog = await openDialog();
+    const toggle = findExperimentalToggle(firstDialog);
+    expect(toggle).toBeTruthy();
+    toggle!.checked = false;
+    toggle!.dispatchEvent(new Event('change'));
+    clickDone(firstDialog);
+    await firstResult;
+
+    const reopenedResult = showWcSettings(log);
+    const reopenedDialog = await openDialog();
+    expect(reopenedDialog.textContent).not.toContain('Experimental');
+    expect(findExperimentalToggle(reopenedDialog)).toBeNull();
+    clickDone(reopenedDialog);
+    await reopenedResult;
+  });
+
+  it('restores the persisted override after reload-equivalent initialization', async () => {
+    initFeatureFlags('standalone');
+    const firstResult = showWcSettings(log);
+    const firstDialog = await openDialog();
+    const toggle = findExperimentalToggle(firstDialog);
+    expect(toggle).toBeTruthy();
+    toggle!.checked = false;
+    toggle!.dispatchEvent(new Event('change'));
+    clickDone(firstDialog);
+    await firstResult;
+
+    initFeatureFlags('standalone', { 'experimental-settings': 'on' });
+    const reloadedResult = showWcSettings(log);
+    const reloadedDialog = await openDialog();
+    expect(reloadedDialog.textContent).not.toContain('Experimental');
+    expect(findExperimentalToggle(reloadedDialog)).toBeNull();
+    clickDone(reloadedDialog);
+    await reloadedResult;
+  });
+
   it('lists connected accounts and resolves false when nothing changed', async () => {
     seedAccounts([{ providerId: 'mystery-llm', apiKey: 'sk-abcdefghijklmnop' }]);
     const result = showWcSettings(log);


### PR DESCRIPTION
## Summary

Adds a runtime feature flag system shared by the web UI and Cherry, with flag values authored centrally in the Cloudflare worker and served from `GET /api/flags`. The first flag, `experimental-settings`, controls a standalone **Experimental features…** avatar-menu item and dialog — on for the web UI, off for Cherry. It is currently `userToggleable: false`, so the dialog honestly shows an empty state rather than a toggle.

## Why

There was no unified flag mechanism: user-facing toggles were scattered across independent localStorage modules (`discovery-preference.ts`, `soundscape.ts`, `theme.ts`, `timestamp-preference.ts`), each with its own key and defaults, and per-float capability gating lived inline (e.g. `SIDE_PANEL_FEATURES`). That made it impossible to ship a feature to one float but not another without a code change, and impossible to change a default without a webapp deploy.

Planned and reviewed in a workspace spec; implemented in three waves with a verifier pass between each.

## Approach / Implementation notes

- **String values, boolean-coerced.** Flag values are strings on the wire and in storage. `isFeatureEnabled(id)` applies one documented coercion rule; `getFeatureValue(id)` returns the raw string. Chosen over booleans so variant/experiment values can be added later without a schema change.
- **Three-level precedence** (highest wins): local user override → worker-served value → bundled registry default. The bundled default is what keeps behavior correct offline, on first paint, and when the worker is unreachable — the remote fetch is never on the critical path. Flags such as `experimental-settings` with `userToggleable: false` deliberately ignore local user overrides.
- **Registry in `core/`.** `packages/webapp/src/core/feature-flags.ts` holds flag ids, metadata and bundled per-float defaults. The float is passed in as an argument rather than resolved internally, so `core/` never imports `ui/` (keeps `lint:ui-back-edges` clean).
- **Worker as central config.** `GET /api/flags?float=<float>` resolves a base map with a per-float overlay, authored in `wrangler.jsonc`. Edge-cached ~5 min via the Cache API, keyed including the `float` param. CORS mirrors the `oauth-exchange.ts` allowlist with `Vary: Origin`, since the Cherry embed is a cross-origin iframe on third-party hosts. Bad config falls back to the base map rather than 500ing.
- **Origin routing.** Flags come from the worker, *not* the local node-server bridge, so `resolveApiUrl()` is deliberately not used — the hosted worker base URL is resolved instead. Relevant to review pattern #9.
- **Cherry is data, not code.** Cherry receives the full payload and simply has `experimental-settings` off. No `if (cherry)` branch in the UI. Deliberately kept separate from `SIDE_PANEL_FEATURES` in `cherry-panel-protocol.ts`, which is a mount-time hard gate rather than a user-visible flag; documented as such.
- **Lazy hydration.** Feature-flag hydration is dynamically imported after the boot-critical path, reducing the main entry from 25.71 kB to 23.59 kB and leaving about 410 B below the 24 kB budget without changing synchronous defaults/cache behavior.
- **New localStorage keys**: a single JSON override map plus a per-float last-known-good cache. Guarded so a missing or throwing `localStorage` (worker context) never throws.

## Cross-cutting impact

- **Floats exercised**: boot wiring goes through a single `setupFeatureFlagsForPage` entry point, verified across standalone, extension, extension-detached, electron-overlay, hosted-leader, connect, follower and cherry. This centralisation was added in the final wave specifically because the Cherry regression test — written to exercise the real boot path rather than calling the registry directly — surfaced a float-consistency gap. The follower's avatar menu deliberately omits **Experimental features…**; that exclusion is documented in code and follows review pattern #8.
- **Cache isolation**: the last-known-good cache is per-float, so a Cherry entry cannot leak into a web-UI float in the same browser profile. Explicitly probed in review.
- **Async lifecycle**: the worker refresh is timeout-bounded and non-blocking; timeout, non-2xx, network throw and malformed JSON all fall back silently with no unhandled rejection and no boot delay.
- **Flags resolve at boot.** A centrally changed value takes effect on next load, not mid-session. Documented.
- **Routes-mirror rule**: `ROUTES_INDEX_BODY`, `tests/index.test.ts` and `tests/deployed.test.ts` all updated.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] 224 focused tests across `packages/webapp/tests/` and `packages/cloudflare-worker/tests/`, mirroring the changed `src/` paths
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — main entry 23.59 kB / 24 kB
- [x] Touched-file debt gate (`check-touched-exemptions.mjs`)
- [x] New behavior covered by unit tests: per-float defaults, remote-over-default, override-over-remote, coercion table, corrupt storage, absent `localStorage`, non-user-toggleable override ignored, all four fetch failure modes, per-float cache isolation, standalone dialog empty state, avatar-menu visibility, deliberate follower omission, and Cherry parity through the real boot path
- [x] **UI change — [screencast attached](https://github.com/ai-ecoverse/slicc/pull/1817#issuecomment-5141286976).** It shows the standalone **Experimental features…** dialog and honest empty state, confirms Account settings has no Experimental section, and verifies the genuine Cherry follower omits the menu item.

**Post-rebase verification**: strict lint/format/custom-lint/complexity/manifest/dead-code gates, typecheck, the full test suite, coverage, full build, touched-file debt gate, and bundle-size gate all pass on the rebased head.

## Documentation

- [x] `packages/webapp/CLAUDE.md` — add-a-flag procedure, value/coercion rule, precedence, boot-time resolution caveat
- [x] `packages/cloudflare-worker/CLAUDE.md` — the `/api/flags` endpoint, where config is authored, routes-mirror reminder
- [x] `packages/cherry/CLAUDE.md` — pointer to the shared registry with Cherry's own central values
- [x] `README.md` — no change needed; no existing user-facing behavior changed

## Risk & rollback

- **Blast radius**: additive. With the worker unreachable every float falls back to bundled defaults, which reproduce today's behavior.
- **Kill switch**: central values can be neutralised by a worker-only deploy setting every flag to its bundled default — no webapp deploy required.
- **Rollback**: clean single-branch revert. No persisted data migration; clearing the override key restores resolved values.
- **Needs manual verification**: the Cherry path in a real cross-origin embed (CORS + `frame-ancestors` interaction) is not something CI covers.

## Checklist

- [x] No hand-edited files under `dist/`
- [x] No secrets or credentials in the diff
- [x] Public API and endpoint changes are intentional and reflected in docs
- [x] Contract used by other floats checked (worker → hydration → registry → UI traced end to end)
- [ ] Commits are focused and package-local where possible — **partially**: `7b39a10da` mixes the worker endpoint with two webapp registry files because two agents wrote concurrently. Content is correct; only the commit boundary is off.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author
