### PR TITLE
feat(ios-app): render the payload fields the follower already decodes

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -145,9 +145,9 @@
       "regions": 79
     },
     "ios-app": {
-      "lines": 47,
-      "functions": 32,
-      "regions": 37
+      "lines": 50,
+      "functions": 34,
+      "regions": 39
     }
   }
 }

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -32,7 +32,7 @@ This package is NOT an npm workspace. It is a Swift Package Manager project (`Pa
 
 - Federated `fs.request` / `fs.response` in both directions.
 - Follower-originated `cdp.request` and `tab.open` (iOS only _responds_ to leader-initiated requests — `CDPBridge.swift` sends `cdp.response` / `cdp.event` / `tab.opened` back, but never originates). The same applies to the unified preview's `preview.open` leader→follower message: iOS decodes it in `LeaderToFollowerMessage` and routes through `CDPBridge.handleTabOpen` (the URL is the worker-hosted preview URL minted by the leader's `serve`), then acks with `tab.opened`.
-- The leader→follower reply path for follower-originated CDP/tab.open requests (`cdp.response` / `cdp.event` / `tab.opened` / `tab.open.error` received by a follower that asked for it). Since iOS doesn't originate, it never has to consume the reply.
+- The leader→follower reply path for those requests — iOS never originates, so it never consumes a reply.
 - `tab.open.error` send-side — iOS embeds CDP errors in `cdp.response.error` and always sends `.tabOpened` for `tab.open`.
 - Transcript export in both directions, including the v4 delegated-approval pair
   (`transcript.export.approve.request` / `transcript.export.approve.response`). iOS never
@@ -43,8 +43,8 @@ This package is NOT an npm workspace. It is a Swift Package Manager project (`Pa
 
 iOS mirrors the cherry-target wire surface even though it cannot _host_ a cherry page:
 
-- `Models/SyncProtocol.swift` defines `CherryCapabilities { navigate, network, screenshot }` and `RemoteTargetInfo.kind` / `.capabilities`, mirroring `RemoteTargetInfo` from `tray-sync-protocol.ts`. The `network` capability gates whether the leader may drive `Network.*` against the target (distinct from the host-page `openUrl` capability); for a cherry target it is always `false`. A target advertised with `"kind":"cherry"` decodes into these fields (see `Tests/SliccFollowerTests/SyncProtocolTests.swift`).
-- `LeaderToFollowerMessage` includes `cherry.slicc_event` (decoded as `.cherrySliccEvent(targetId, name, detail)`). iOS has **no cherry page surface**, so `AppState.handleDataChannelMessage` handles it as a **documented no-op**: it logs and ignores the event. The case exists to keep the decode switch exhaustive and to leave a seam for a future cherry-on-iOS path.
+- `Models/SyncProtocol.swift` defines `CherryCapabilities { navigate, network, screenshot }` and `RemoteTargetInfo.kind` / `.capabilities`, mirroring `RemoteTargetInfo` from `tray-sync-protocol.ts`. The `network` capability gates whether the leader may drive `Network.*` against the target; for a cherry target it is always `false`. A `"kind":"cherry"` target decodes into these fields (see `Tests/SliccFollowerTests/SyncProtocolTests.swift`).
+- `cherry.slicc_event` decodes to `.cherrySliccEvent(targetId, name, detail)`. iOS has **no cherry page surface**, so `AppState.handleDataChannelMessage` logs and ignores it — a **documented no-op** that keeps the decode switch exhaustive.
 
 The doc-comment headers above the `LeaderToFollowerMessage` and `FollowerToLeaderMessage` enum declarations in `SyncProtocol.swift` declare the omission explicitly — `// MARK: -` boundaries are the stable anchors; line numbers shift whenever the headers expand.
 
@@ -74,7 +74,7 @@ Skipping the iOS update now fails `SyncProtocolCorpusTests` in CI instead of qui
 
 ## What this app supports vs the browser follower
 
-Both followers now implement sprinkle rendering (the TS implementation landed in this branch and matches the iOS surface). iOS remains the longer-deployed reference; when adding a follower-side feature on the TS side, model the behavior on `AppState`:
+Both followers implement sprinkle rendering. iOS is the longer-deployed reference; when adding a follower-side feature on the TS side, model it on `AppState`:
 
 - Connection lifecycle: `connect()` / `disconnect()` / `dataChannelOpened()` / `handleDisconnect(reason:)`
 - Message dispatch: `handleDataChannelMessage(_ data: Data)` switch
@@ -84,7 +84,15 @@ Both followers now implement sprinkle rendering (the TS implementation landed in
 
 ### Lick Forwarding (leader-side origin stamping)
 
-The native iOS follower's sprinkle licks now display their origin label in the leader's cone via leader-side origin stamping (no iOS change was required). The leader's `onSprinkleLick` callback gained a 4th `originLabel` parameter and routes sprinkle lick content through the shared `formatLickEventForCone`, so follower sprinkle licks (including from iOS) display their origin. Migrating iOS from the legacy `sprinkle.lick` envelope to the generic `lick` follower→leader message (for `navigate` / handoff licks) remains a documented follow-up.
+iOS sprinkle licks show their origin label in the leader's cone via leader-side stamping — no iOS change was needed. Migrating iOS from the legacy `sprinkle.lick` envelope to the generic `lick` message remains a follow-up.
+
+### Message rendering parity
+
+Payload fields decode _and_ render. Deliberate divergences from the web:
+
+- Attachment chips: thumbnail (inline base64) or kind glyph plus filename, user messages only. No size/MIME line — the web's chat mapper drops those too. A content-less attachment message renders no bubble.
+- The error card omits the web's CTAs (`Try again`, `Open Settings`): each acts on leader state with no follower→leader equivalent, so the button would silently no-op.
+- `tool_ui` renders a read-only card keyed by `requestId`, title extracted from the leader's HTML minus badge and meta (the meta carries the mount path). `tool_ui_done` removes it; a `snapshot` clears all cards.
 
 ## Build
 
@@ -99,9 +107,9 @@ swiftlint lint                                   # SwiftLint (config inherits re
 ## Test + coverage
 
 Plain `swift test` cannot run on a macOS host (iOS-only WebRTC binary), so the
-suite runs through `xcodebuild test` on a simulator. Use the shared coverage
-gate: it picks a simulator, enables coverage + parallel testing + on-failure
-retries, and enforces the `ios-app` floors in `coverage-thresholds.json`.
+suite runs through `xcodebuild test` on a simulator. The shared coverage gate
+picks a simulator, enables coverage and on-failure retries, and enforces the
+`ios-app` floors in `coverage-thresholds.json`.
 
 ```bash
 ./packages/dev-tools/tools/swift-coverage-check.sh \
@@ -112,18 +120,18 @@ Outputs land in `.build/coverage/` (`summary.json`, `lcov.info`,
 `ios-app.xcresult` with per-test durations). Tests run `parallelizable` with
 `randomExecutionOrder`, so a new test must not depend on another test's side
 effects. Coverage is measured against
-`SliccFollower.app/SliccFollower.debug.dylib`, not the same-named launcher stub
-beside it — debug builds put the code, and the coverage mapping, in the dylib.
+`SliccFollower.app/SliccFollower.debug.dylib`, not the launcher stub beside it —
+debug builds put the code and the coverage mapping in the dylib.
 
 ## Simulator QA path
 
-Running the app by hand — the only way to check the SwiftUI surfaces, which the
-unit tests (protocol decoder only) do not touch.
+Running the app by hand, for exploratory checks the UI tests do not cover.
 
 **Prerequisites.** `brew install xcodegen`, plus a simulator runtime matching the
-Xcode SDK. If `xcodebuild -showdestinations …` lists no `platform:iOS Simulator`
-entries and only `iOS <x> is not installed` errors, install the platform with
-`xcodebuild -downloadPlatform iOS` (~8.5 GB, tens of minutes).
+Xcode SDK. If `xcodebuild -showdestinations …` lists only `iOS <x> is not
+installed`, run `xcodebuild -downloadPlatform iOS` (~8.5 GB, tens of minutes).
+Pick the newest installed iPhone runtime: an older one can fail at launch with a
+missing `libswiftWebKit.dylib`.
 
 **Boot, build, install, launch.**
 
@@ -188,14 +196,17 @@ leader: the `-uiTestFixtureRoute YES` launch argument reaches the leaderless
 **UI Fixture** route (`FixtureConversationView`) without a tap. `UITestHooks`
 (`App/UITestHooks.swift`) reads it and is `#if DEBUG` only — a shipped binary
 must not carry a flag that skips the connection path. The failure-state test
-dials `http://127.0.0.1:1/…`, refused without DNS or egress, so
-`Connection Failed` arrives in seconds instead of depending on CI networking.
+dials `http://127.0.0.1:1/…` — refused without DNS or egress, so
+`Connection Failed` arrives in seconds.
 
 - **Put accessibility identifiers on leaves.** SwiftUI pushes one onto a
   container's leaves instead of minting a container, so an identifier on a
   `VStack` yields tagged leaves and no `otherElements` match — and
   `.accessibilityElement(children: .contain)` suppresses that propagation rather
   than fixing it. Every leaf in a message row carries `message-<id>`.
+- **Row ids alone are blind.** Because every leaf carries `message-<id>`, a row
+  still matches when its specialized renderer is gone. A new fixture variant
+  also needs a `variantMarkers` string only that renderer can emit.
 - **The transcript is pinned to the newest message**, so a walk over every
   variant scrolls bottom-to-top and must be bounded.
 - **The bundle is `parallelizable: false`** — cloning simulators for a UI bundle
@@ -203,25 +214,24 @@ dials `http://127.0.0.1:1/…`, refused without DNS or egress, so
 
 ## Linting
 
-`packages/ios-app/.swiftlint.yml` inherits the shared rule set from the
-repo-root `.swiftlint.yml` (via `parent_config`) and excludes this package's
-`.build`/`SliccFollower.xcodeproj`. Warnings surface code-quality issues; only
-`error`-severity violations fail CI. Use `swiftlint --fix` to auto-correct
-fixable violations.
+`packages/ios-app/.swiftlint.yml` inherits the repo-root rule set via
+`parent_config` and excludes `.build`/`SliccFollower.xcodeproj`. Only
+`error`-severity violations fail CI. `swiftlint --fix` auto-corrects, but
+rewrites every file it scans — run it on a clean tree.
 
 ## Formatting
 
-SwiftLint lints; `swift format` (Swift 6+ toolchain) formats, against the single
-repo-root `.swift-format` it finds by walking up from each input file. No
+SwiftLint lints; `swift format` (Swift 6+ toolchain) formats, against the
+repo-root `.swift-format` found by walking up from each input file. No
 `package.json` here, so invoke it directly — or use the repo-root
-`npm run lint:swift:format` / `npm run format:swift`, which include this package:
+`npm run lint:swift:format` / `npm run format:swift`, which cover this package:
 
 ```bash
 swift format lint --strict --parallel --recursive SliccFollower Package.swift   # CI gate
 swift format --in-place --parallel --recursive SliccFollower Package.swift
 ```
 
-TestFlight automation lives in `scripts/package-and-upload-testflight.sh` (consumes secrets via `setup-testflight-secrets.sh`).
+TestFlight automation: `scripts/package-and-upload-testflight.sh` (secrets via `setup-testflight-secrets.sh`).
 
 ## Related Guides
 

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		09FE7E5B6F63D6850F2EBFBE /* UITestHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1308398CD972FF297E2C75 /* UITestHooks.swift */; };
 		0CAAEE94D02D4006193FA4BB /* InputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */; };
 		15CF4C85551B4FE239D55E94 /* SliccIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438577405ABBCA33F117862C /* SliccIcons.swift */; };
+		21BD049697833AC4E3316A58 /* ToolUIPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0425579D2C460F993D259DB /* ToolUIPlaceholderTests.swift */; };
 		238295F68E3669C0968C9934 /* WebRTCManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AF8A8A50FCC9C2DBECA0CF /* WebRTCManager.swift */; };
 		2401C7FE702795E1066A7C9F /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB646EF0D0006D1A43F527D /* ChatMessage.swift */; };
 		2CE789AA836BB0713F1250D7 /* CDPBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE0A7D88487F7712E451646 /* CDPBridge.swift */; };
@@ -24,6 +25,7 @@
 		541C36C1FB80D6EDBA337FE6 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A69E83B7BB267C230C892A29 /* PrivacyInfo.xcprivacy */; };
 		58AACC678F1000C41BC7AA1A /* TabsCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39ADD0645C7DD3B30664E997 /* TabsCarouselView.swift */; };
 		5A678420A08BBB43297E1D8D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F0583BDF50B1A1B9CE68AE67 /* Assets.xcassets */; };
+		5B5741496E7C7EA37979CFF2 /* AttachmentChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E089FCA5BF8861469F73C4 /* AttachmentChips.swift */; };
 		5DBC389110F337A40762C4E1 /* MessageListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E727142147B0FB449F418D1 /* MessageListView.swift */; };
 		67EC4D5BDDC4014A965FF5B4 /* ConnectionRouteUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */; };
 		73CD8FDB68D950291A923BCD /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B186EDFDE184DC8B3215C4 /* ChatView.swift */; };
@@ -33,6 +35,7 @@
 		8A4DC8067E31936EA9C475BC /* TrayTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDB6F858D918DBBE06D4702 /* TrayTypes.swift */; };
 		8EEACE6ED76E43E36FC9F0AB /* ChatFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA9A527E2D4BBCE1BDFA89C /* ChatFixture.swift */; };
 		977007CC44BE2B53361DF256 /* Keepalive.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA931BF1BE121985E2FB3EE /* Keepalive.swift */; };
+		9FC130913A6643DA7276FFFA /* ToolUICard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD3AFC2F2EB348C5A74AEA3 /* ToolUICard.swift */; };
 		A2488147A916BDDB57B9A41C /* CDPTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6B46ECEC5C79FA6D986F9 /* CDPTarget.swift */; };
 		A50239DCBBAD6235AC7C296A /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF78C09597C5D63A373EB126 /* MessageBubble.swift */; };
 		A9C0449A188D09A99F506FFE /* InlineSprinkleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2EECDCB4AF899D3071D13C /* InlineSprinkleView.swift */; };
@@ -69,6 +72,7 @@
 		1F2EECDCB4AF899D3071D13C /* InlineSprinkleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineSprinkleView.swift; sourceTree = "<group>"; };
 		1F8BFCDA8C3F71C0A853D573 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		2EDB6F858D918DBBE06D4702 /* TrayTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayTypes.swift; sourceTree = "<group>"; };
+		31E089FCA5BF8861469F73C4 /* AttachmentChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentChips.swift; sourceTree = "<group>"; };
 		356386D299A1933A39CB972B /* TrayChunkFraming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayChunkFraming.swift; sourceTree = "<group>"; };
 		39ADD0645C7DD3B30664E997 /* TabsCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsCarouselView.swift; sourceTree = "<group>"; };
 		3BA9A527E2D4BBCE1BDFA89C /* ChatFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFixture.swift; sourceTree = "<group>"; };
@@ -77,6 +81,7 @@
 		407939337779F91986E8DAB3 /* SprinkleSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SprinkleSidebarView.swift; sourceTree = "<group>"; };
 		434BBAD25E91BD0B7D626821 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		438577405ABBCA33F117862C /* SliccIcons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliccIcons.swift; sourceTree = "<group>"; };
+		4AD3AFC2F2EB348C5A74AEA3 /* ToolUICard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolUICard.swift; sourceTree = "<group>"; };
 		4E70132BA0E6C4BC99D8CB73 /* TraySignaling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraySignaling.swift; sourceTree = "<group>"; };
 		4E99369A8A6B1A9B8EBE996E /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		523A4A068180D7EE98435885 /* MarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownText.swift; sourceTree = "<group>"; };
@@ -101,6 +106,7 @@
 		CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBar.swift; sourceTree = "<group>"; };
 		CFEC70BAB27CC325BCD99C01 /* SliccFollowerTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SliccFollowerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD1308398CD972FF297E2C75 /* UITestHooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestHooks.swift; sourceTree = "<group>"; };
+		F0425579D2C460F993D259DB /* ToolUIPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolUIPlaceholderTests.swift; sourceTree = "<group>"; };
 		F0583BDF50B1A1B9CE68AE67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F0A069AA812629AC5FE70AC9 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRouteUITests.swift; sourceTree = "<group>"; };
@@ -127,6 +133,7 @@
 				639AB6CC8494FCE4C252F00B /* ChunkFramingTests.swift */,
 				9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */,
 				3BBC1002CE4D3E1D940352F4 /* SyncProtocolTests.swift */,
+				F0425579D2C460F993D259DB /* ToolUIPlaceholderTests.swift */,
 				52A9B6A8BE5EE73A5DF4470C /* Fixtures */,
 			);
 			name = SliccFollowerTests;
@@ -196,6 +203,7 @@
 		8004F77F534D7D3B9F54E8C3 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				31E089FCA5BF8861469F73C4 /* AttachmentChips.swift */,
 				3BA9A527E2D4BBCE1BDFA89C /* ChatFixture.swift */,
 				11B186EDFDE184DC8B3215C4 /* ChatView.swift */,
 				940DB17683937E3DAE6E914C /* ConnectionStatusView.swift */,
@@ -210,6 +218,7 @@
 				407939337779F91986E8DAB3 /* SprinkleSidebarView.swift */,
 				C9C3A976D441E4BB628F2183 /* SprinkleWebView.swift */,
 				39ADD0645C7DD3B30664E997 /* TabsCarouselView.swift */,
+				4AD3AFC2F2EB348C5A74AEA3 /* ToolUICard.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -397,6 +406,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				02019B8CFDC4B36D610933B8 /* AppState.swift in Sources */,
+				5B5741496E7C7EA37979CFF2 /* AttachmentChips.swift in Sources */,
 				2CE789AA836BB0713F1250D7 /* CDPBridge.swift in Sources */,
 				A2488147A916BDDB57B9A41C /* CDPTarget.swift in Sources */,
 				8EEACE6ED76E43E36FC9F0AB /* ChatFixture.swift in Sources */,
@@ -417,6 +427,7 @@
 				F5AC500C53CC1A9251A5718B /* SprinkleWebView.swift in Sources */,
 				7BEE859F6C68FEAFD63D1FBB /* SyncProtocol.swift in Sources */,
 				58AACC678F1000C41BC7AA1A /* TabsCarouselView.swift in Sources */,
+				9FC130913A6643DA7276FFFA /* ToolUICard.swift in Sources */,
 				E60E295D09FF005492A64FB5 /* TrayChunkFraming.swift in Sources */,
 				487756D13ED6B5D4FB9FF6A0 /* TrayFollowerConnector.swift in Sources */,
 				D2A85DC611A43443DEC75989 /* TraySignaling.swift in Sources */,
@@ -442,6 +453,7 @@
 				8017E9416AEB3D7756ADEB3A /* ChunkFramingTests.swift in Sources */,
 				F908DA74A70E1C7F16EC6AD8 /* SyncProtocolCorpusTests.swift in Sources */,
 				CB6A8F9EEAD1D4DAA552E0EC /* SyncProtocolTests.swift in Sources */,
+				21BD049697833AC4E3316A58 /* ToolUIPlaceholderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -40,6 +40,10 @@ class AppState: ObservableObject {
     @Published var joinUrl: String = ""
     @Published var trayId: String?
     @Published var messages: [ChatMessage] = []
+    /// Pending `tool_ui` approvals, oldest first. These live outside the
+    /// transcript because the leader mounts them outside the message list too,
+    /// so a streaming re-render cannot wipe them.
+    @Published var toolUICards: [ToolUIPlaceholder] = []
     @Published var isStreaming: Bool = false
 
     // Multi-scoop awareness
@@ -808,6 +812,11 @@ class AppState: ObservableObject {
     /// refresh `messages` if it matches the currently-viewed scoop.
     private func ingestSnapshot(messages chatMessages: [ChatMessage], scoopJid: String) {
         messagesByScoop[scoopJid] = chatMessages
+        // A snapshot is the leader re-describing the world. Any approval
+        // placeholder we are still holding predates it and can no longer be
+        // confirmed, so it would otherwise hang around forever — the leader
+        // only ever clears one via the matching `tool_ui_done`.
+        toolUICards.removeAll()
         if selectedScoopJid == nil { selectedScoopJid = scoopJid }
         if scoopJid == selectedScoopJid {
             messages = chatMessages
@@ -910,31 +919,39 @@ class AppState: ObservableObject {
             logger.error("Agent event: error — \(error)")
             if isVisible { lastError = error }
 
-        // Events that decode but mutate no transcript state. Kept as a single
-        // arm so the switch stays exhaustive — a new protocol case is then a
-        // compile error rather than a silent drop — without charging this
-        // dispatcher's complexity budget once per case.
+        // Events that mutate no transcript state. Kept as a single arm so the
+        // switch stays exhaustive — a new protocol case is then a compile error
+        // rather than a silent drop — without charging this dispatcher's
+        // complexity budget once per case.
         case .toolUI, .toolUIDone, .screenshot, .terminalOutput, .unknown:
-            logNonRenderingAgentEvent(event)
+            handleNonTranscriptAgentEvent(event)
         }
     }
 
-    /// Agent events the follower decodes but does not render.
+    /// Agent events that never touch `messages`.
     ///
-    /// `tool_ui` / `tool_ui_done` are approval cards the leader owns; a
-    /// follower has no permissions surface, so the browser follower degrades
-    /// them to a read-only placeholder (`buildReadOnlyToolUiHtml` in
-    /// `wc-chat-controller.ts`) and iOS shows nothing yet. `screenshot` and
+    /// `tool_ui` / `tool_ui_done` drive the read-only approval placeholder,
+    /// which lives beside the transcript rather than in it. `screenshot` and
     /// `terminal_output` are deliberate no-ops on every follower — the webapp
     /// chat thread names both explicitly for the same reason.
-    private func logNonRenderingAgentEvent(_ event: AgentEvent) {
+    private func handleNonTranscriptAgentEvent(_ event: AgentEvent) {
         switch event {
-        case .toolUI(let messageId, let toolName, let requestId, _):
+        case .toolUI(let messageId, let toolName, let requestId, let html):
             logger.debug(
-                "Agent event: tool_ui id=\(messageId) tool=\(toolName) request=\(requestId) — not rendered"
+                "Agent event: tool_ui id=\(messageId) tool=\(toolName) request=\(requestId)"
             )
+            let card = ToolUIPlaceholder(requestId: requestId, html: html)
+            // A re-broadcast of the same request must not stack a duplicate.
+            if let existing = toolUICards.firstIndex(where: { $0.id == requestId }) {
+                toolUICards[existing] = card
+            } else {
+                toolUICards.append(card)
+            }
         case .toolUIDone(let messageId, let requestId):
             logger.debug("Agent event: tool_ui_done id=\(messageId) request=\(requestId)")
+            // The leader removes the card outright — there is no terminal
+            // "approved"/"denied" state to show.
+            toolUICards.removeAll { $0.id == requestId }
         case .screenshot, .terminalOutput:
             break
         default:

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/ToolUIPlaceholderTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/ToolUIPlaceholderTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import XCTest
+
+@testable import SliccFollower
+
+/// Title extraction for the read-only `tool_ui` placeholder (#1792).
+///
+/// The leader ships the approval card as rendered HTML. A follower cannot act
+/// on it, so it shows only the title — which means pulling that title back out
+/// of the markup. Mirrors `extractToolUiTitle` in `wc-chat-controller.ts`.
+final class ToolUIPlaceholderTests: XCTestCase {
+
+    private func title(_ html: String) -> String {
+        ToolUIPlaceholder(requestId: "req-1", html: html).title
+    }
+
+    func testExtractsHeaderTextAndDropsBadgeAndMeta() {
+        let html = """
+            <div class="sprinkle-action-card">
+              <div class="sprinkle-action-card__header">
+                <span class="sprinkle-badge">sudo</span>
+                Allow <code>npm publish</code>?
+                <div class="sprinkle-action-card__meta">/workspace/package.json</div>
+              </div>
+            </div>
+            """
+        // No space before the `?`: tags are dropped with no separator, the way
+        // `textContent` reads them on the web.
+        XCTAssertEqual(title(html), "Allow npm publish?")
+    }
+
+    /// The meta line carries the mount target path. Followers are deliberately
+    /// never shown it, so a regression that leaks it into the title is a
+    /// disclosure bug rather than a cosmetic one.
+    func testMetaPathNeverReachesTheTitle() {
+        let html = """
+            <div class="sprinkle-action-card__header">
+              Approve write
+              <div class="sprinkle-action-card__meta">/Users/someone/secrets/.env</div>
+            </div>
+            """
+        XCTAssertEqual(title(html), "Approve write")
+        XCTAssertFalse(title(html).contains("secrets"))
+    }
+
+    func testFallsBackWhenThereIsNoHeader() {
+        XCTAssertEqual(
+            title("<div class=\"sprinkle-action-card\">no header here</div>"),
+            ToolUIPlaceholder.fallbackTitle)
+        XCTAssertEqual(title(""), ToolUIPlaceholder.fallbackTitle)
+    }
+
+    /// A header holding only a badge and a meta line strips to nothing, which
+    /// must fall back rather than render an empty title.
+    func testFallsBackWhenTheHeaderStripsToNothing() {
+        let html = """
+            <div class="sprinkle-action-card__header">
+              <span class="sprinkle-badge">sudo</span>
+              <div class="sprinkle-action-card__meta">/workspace</div>
+            </div>
+            """
+        XCTAssertEqual(title(html), ToolUIPlaceholder.fallbackTitle)
+    }
+
+    /// The header contains nested elements of the same tag, so a naive scan for
+    /// the next `</div>` would cut the title short.
+    func testHandlesNestedElementsOfTheSameTag() {
+        let html = """
+            <div class="sprinkle-action-card__header">
+              <div><strong>Run</strong> migration</div>
+            </div>
+            """
+        XCTAssertEqual(title(html), "Run migration")
+    }
+
+    func testDecodesEntitiesAndCollapsesWhitespace() {
+        let html = """
+            <div class="sprinkle-action-card__header">
+              Allow    &lt;script&gt;   &amp;   more&hellip;
+            </div>
+            """
+        XCTAssertEqual(title(html), "Allow <script> & more…")
+    }
+
+    func testIdentifierIsTheRequestIdSoToolUIDoneCanMatchIt() {
+        let card = ToolUIPlaceholder(requestId: "req-42", html: "")
+        XCTAssertEqual(card.id, "req-42")
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
@@ -31,6 +31,12 @@ final class FixtureConversationUITests: XCTestCase {
         "fx-lick-fswatch",
         "fx-lick-navigate",
         "fx-lick-upgrade",
+        "fx-lick-collated",
+        "fx-lick-confirmed",
+        "fx-lick-dismissed",
+        "fx-user-attachments",
+        "fx-user-attachment-only",
+        "fx-assistant-error",
         "fx-queued-1",
         "fx-assistant-streaming",
     ]
@@ -57,6 +63,12 @@ final class FixtureConversationUITests: XCTestCase {
         "0.4.1→0.5.0",  // lick pill, upgrade channel
         "Instructions from sliccy",  // delegation-sourced user message
         "npm run test",  // running tool under the streaming message
+        "deploy-status \u{00D7}3",  // collated lick pill, count suffix
+        "SOMETHING WENT WRONG",  // error card header, uppercased
+        "screenshot.png",  // attachment chip beside a user bubble
+        "diagram.png",  // attachment chip on a bubble-less message
+        "Allow npm publish?",  // tool_ui title, badge and meta stripped
+        "Waiting for approval on the leader",  // tool_ui read-only body
     ]
 
     override func setUp() {
@@ -132,6 +144,39 @@ final class FixtureConversationUITests: XCTestCase {
             missingMarkers(in: seenLabels), [],
             "Variant renderers produced no output; the row can still carry its "
                 + "id while its specialized subview is gone")
+    }
+
+    /// A settled lick shows its decision glyph. This is asserted by identifier
+    /// because the glyph is an SF Symbol with no text of its own, so the
+    /// variant-marker walk above cannot see it.
+    func testSettledLicksShowTheirDecisionGlyph() {
+        let app = launchFixtureApp()
+        XCTAssertTrue(
+            app.staticTexts["fixture-header"].waitForExistence(timeout: 60),
+            "The fixture route should render before scrolling")
+        XCTAssertTrue(
+            waitForAnyMessageRow(in: app),
+            "Rows should be on screen before the walk starts")
+
+        var seen = visibleStateIdentifiers(in: app)
+        for _ in 0..<40 where !seen.isSuperset(of: ["lick-state-confirmed", "lick-state-dismissed"]) {
+            app.swipeDown()
+            let before = seen.count
+            seen.formUnion(visibleStateIdentifiers(in: app))
+            if seen.count == before && seen.count > 0 { break }
+        }
+
+        XCTAssertTrue(
+            seen.contains("lick-state-confirmed"),
+            "A confirmed lick should render its decision glyph")
+        XCTAssertTrue(
+            seen.contains("lick-state-dismissed"),
+            "A dismissed lick should render its decision glyph")
+        // `pending` is the default state and deliberately has no glyph on the
+        // web either, so a stray one here would be a divergence.
+        XCTAssertFalse(
+            seen.contains("lick-state-pending"),
+            "A pending lick should render no decision glyph")
     }
 
     func testReloadRebuildsTheTranscript() {
@@ -225,6 +270,13 @@ final class FixtureConversationUITests: XCTestCase {
         labels.formUnion(app.staticTexts.allElementsBoundByAccessibilityElement.map(\.label))
         labels.formUnion(app.buttons.allElementsBoundByAccessibilityElement.map(\.label))
         return labels
+    }
+
+    /// Lick decision-glyph identifiers currently in the tree.
+    private func visibleStateIdentifiers(in app: XCUIApplication) -> Set<String> {
+        let rows = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier BEGINSWITH %@", "lick-state-"))
+        return Set(rows.allElementsBoundByAccessibilityElement.map(\.identifier))
     }
 
     private func missingMarkers(in labels: Set<String>) -> [String] {

--- a/packages/ios-app/SliccFollower/Views/AttachmentChips.swift
+++ b/packages/ios-app/SliccFollower/Views/AttachmentChips.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+/// Attachment chips shown above a user bubble.
+///
+/// Mirrors `slicc-user-message.ts`: an image with inline base64 renders as a
+/// thumbnail, everything else falls back to a kind glyph, and the chip carries
+/// only the filename beside it.
+///
+/// The webapp's chat path deliberately shows no size or MIME meta line — its
+/// mapper (`toUserAttachment` in `wc-message-view.ts`) drops `mimeType`,
+/// `size`, `path` and `error` before the component ever sees them, so a chip
+/// there is a visual plus a name. This mirrors that rather than inventing a
+/// richer treatment the browser follower does not have.
+struct AttachmentChips: View {
+    let attachments: [MessageAttachment]
+
+    private let chipBackground = Color.white.opacity(0.07)
+    private let borderColor = Color.white.opacity(0.10)
+
+    var body: some View {
+        // `flex-wrap: wrap` on the web. A horizontal scroller is the closest
+        // native equivalent that never truncates a long attachment list.
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                Spacer(minLength: 0)
+                ForEach(attachments) { attachment in
+                    chip(attachment)
+                }
+            }
+            .padding(.horizontal, 4)
+        }
+        .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+
+    private func chip(_ attachment: MessageAttachment) -> some View {
+        HStack(spacing: 6) {
+            visual(attachment)
+            Text(attachment.name)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.white.opacity(0.85))
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 6)
+        .background(chipBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(borderColor, lineWidth: 0.5)
+        )
+        .frame(maxWidth: 240)
+        .accessibilityIdentifier("attachment-\(attachment.id)")
+    }
+
+    @ViewBuilder
+    private func visual(_ attachment: MessageAttachment) -> some View {
+        if attachment.kind == .image, let image = decodedImage(attachment) {
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 30, height: 30)
+                .clipShape(RoundedRectangle(cornerRadius: 7))
+        } else {
+            // Covers a `path`-only attachment too: the leader strips oversize
+            // payloads to a VFS path, leaving no bytes to draw.
+            Image(systemName: SliccIcons.attachment(attachment.kind))
+                .font(.system(size: 16))
+                .foregroundStyle(.white.opacity(0.6))
+                .frame(width: 30, height: 30)
+        }
+    }
+
+    private func decodedImage(_ attachment: MessageAttachment) -> UIImage? {
+        guard let data = attachment.data,
+            let bytes = Data(base64Encoded: data)
+        else { return nil }
+        return UIImage(data: bytes)
+    }
+}
+
+// MARK: - ErrorCard
+
+/// A cone error, rendered as a card instead of an ordinary assistant bubble.
+///
+/// Mirrors `slicc-error-card.ts`: a red-tinted card with an uppercase
+/// "Something went wrong" header over the raw error text.
+///
+/// The web card also offers a contextual action (`Try again`, `Open Settings`,
+/// `Change model`, `Log in again`). Those are omitted here for the same reason
+/// the follower's `tool_ui` card is read-only: every one of them acts on
+/// leader-side state, the follower→leader protocol carries no equivalent
+/// message, and a button that silently does nothing is worse than no button.
+struct ErrorCard: View {
+    let message: ChatMessage
+
+    private let cardBackground = Color(red: 0x3A / 255, green: 0x14 / 255, blue: 0x18 / 255)
+    private let borderColor = Color(red: 0xDC / 255, green: 0x26 / 255, blue: 0x26 / 255)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 7) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 11))
+                Text("Something went wrong".uppercased())
+                    .font(.system(size: 10.5, weight: .semibold))
+                    .kerning(0.2)
+            }
+            .foregroundStyle(Color(red: 0xF8 / 255, green: 0x71 / 255, blue: 0x71 / 255))
+
+            Text(message.content)
+                .font(.system(size: 12.5))
+                .foregroundStyle(.white.opacity(0.9))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(borderColor.opacity(0.4), lineWidth: 0.5)
+        )
+        .padding(.horizontal, 4)
+        .accessibilityIdentifier("error-card")
+    }
+}

--- a/packages/ios-app/SliccFollower/Views/ChatFixture.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatFixture.swift
@@ -256,6 +256,85 @@ enum ChatFixture {
                 at: 17
             ))
 
+        // 6b. Collated and settled licks — count pill, folded parts, decisions
+        out.append(
+            lick(
+                id: "fx-lick-collated",
+                channel: "webhook",
+                header: "[Webhook Event: deploy-status]",
+                json: ["run": 1],
+                at: 17.2,
+                count: 3,
+                parts: (1...3).map {
+                    lickContent(header: "[Webhook Event: deploy-status]", json: ["run": $0])
+                }
+            ))
+        out.append(
+            lick(
+                id: "fx-lick-confirmed",
+                channel: "sudo-request",
+                header: "[Sudo Request: npm publish]",
+                json: ["command": "npm publish --access public"],
+                at: 17.4,
+                state: .confirmed
+            ))
+        out.append(
+            lick(
+                id: "fx-lick-dismissed",
+                channel: "sudo-request",
+                header: "[Sudo Request: rm -rf node_modules]",
+                json: ["command": "rm -rf node_modules"],
+                at: 17.6,
+                state: .dismissed
+            ))
+
+        // 6c. Attachments and a cone error
+        out.append(
+            ChatMessage(
+                id: "fx-user-attachments", role: .user,
+                content: "Here's the failing screen and the log.",
+                timestamp: ts(17.7),
+                attachments: [
+                    MessageAttachment(
+                        id: "fx-att-image", name: "screenshot.png",
+                        mimeType: "image/png", size: 2048, kind: .image,
+                        data: onePixelPNG
+                    ),
+                    MessageAttachment(
+                        id: "fx-att-text", name: "build.log",
+                        mimeType: "text/plain", size: 812, kind: .text,
+                        text: "error TS2345: Argument of type 'string'…"
+                    ),
+                    MessageAttachment(
+                        id: "fx-att-file", name: "heap-profile.cpuprofile",
+                        mimeType: "application/octet-stream", size: 9_400_000, kind: .file,
+                        path: "/workspace/uploads/heap-profile.cpuprofile",
+                        error: "File too large to inline"
+                    ),
+                ]
+            ))
+        // A pure-attachment message renders no bubble at all.
+        out.append(
+            ChatMessage(
+                id: "fx-user-attachment-only", role: .user,
+                content: "",
+                timestamp: ts(17.8),
+                attachments: [
+                    MessageAttachment(
+                        id: "fx-att-solo", name: "diagram.png",
+                        mimeType: "image/png", size: 1024, kind: .image,
+                        data: onePixelPNG
+                    )
+                ]
+            ))
+        out.append(
+            ChatMessage(
+                id: "fx-assistant-error", role: .assistant,
+                content: "Provider returned 429: rate limit exceeded. Retry after 30s.",
+                timestamp: ts(17.9),
+                error: true
+            ))
+
         // 7. Queued messages + streaming tail
         out.append(
             ChatMessage(
@@ -288,21 +367,50 @@ enum ChatFixture {
         channel: String,
         header: String,
         json: Any,
-        at minutes: Double
+        at minutes: Double,
+        count: Int? = nil,
+        parts: [String]? = nil,
+        state: LickState? = nil
     ) -> ChatMessage {
+        let content = lickContent(header: header, json: json)
+        return ChatMessage(
+            id: id, role: .user,
+            content: content,
+            timestamp: ts(minutes),
+            source: "lick",
+            channel: channel,
+            lickCount: count,
+            lickParts: parts,
+            lickState: state
+        )
+    }
+
+    /// Smallest valid PNG, so an attachment chip can exercise the real
+    /// base64 → `UIImage` thumbnail path without carrying a binary asset.
+    private static let onePixelPNG =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+    /// A leader-shaped `tool_ui` payload: the header carries a badge and a meta
+    /// line that the follower must strip before showing the title.
+    static let toolUIHtml = """
+        <div class="sprinkle-action-card">
+          <div class="sprinkle-action-card__header">
+            <span class="sprinkle-badge">sudo</span>
+            Allow <code>npm publish</code>?
+            <div class="sprinkle-action-card__meta">/workspace/package.json</div>
+          </div>
+          <button>Approve</button>
+        </div>
+        """
+
+    /// `[Header]\n```json …``` ` — the shape the leader sends for a lick body.
+    private static func lickContent(header: String, json: Any) -> String {
         let bodyData =
             (try? JSONSerialization.data(
                 withJSONObject: json,
                 options: [.prettyPrinted, .sortedKeys]
             )) ?? Data()
         let body = String(data: bodyData, encoding: .utf8) ?? "{}"
-        let content = "\(header)\n```json\n\(body)\n```"
-        return ChatMessage(
-            id: id, role: .user,
-            content: content,
-            timestamp: ts(minutes),
-            source: "lick",
-            channel: channel
-        )
+        return "\(header)\n```json\n\(body)\n```"
     }
 }

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -86,6 +86,7 @@ struct ConversationView: View {
             MessageListView(
                 messages: appState.messages,
                 isStreaming: appState.isStreaming,
+                toolUICards: appState.toolUICards,
                 onInlineSprinkleLick: { body, target in
                     appState.sendSprinkleLick("inline", body: body, targetScoop: target)
                 }
@@ -183,6 +184,9 @@ struct FixtureConversationView: View {
             MessageListView(
                 messages: messages,
                 isStreaming: messages.last?.isStreaming == true,
+                toolUICards: [
+                    ToolUIPlaceholder(requestId: "fx-tool-ui-1", html: ChatFixture.toolUIHtml)
+                ],
                 onInlineSprinkleLick: { body, target in
                     let summary = describeLick(body: body, target: target)
                     Self.log.info("sprinkle lick: \(summary)")

--- a/packages/ios-app/SliccFollower/Views/MessageBubble.swift
+++ b/packages/ios-app/SliccFollower/Views/MessageBubble.swift
@@ -21,19 +21,31 @@ struct MessageBubble: View {
     }
 
     var body: some View {
+        // Precedence mirrors `messageEls` in wc-message-view.ts: a lick wins
+        // over everything, then delegation, then `error`, then role.
         if isLick {
             LickRow(message: message)
                 .padding(.horizontal, 4)
+        } else if message.error == true {
+            ErrorCard(message: message)
         } else if message.role == .user {
-            HStack {
-                Spacer(minLength: UIScreen.main.bounds.width * 0.2)
-                userBubbleText
-                    .font(.system(size: 15))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 10)
-                    .background(userBubbleColor)
-                    .cornerRadius(18)
+            VStack(alignment: .trailing, spacing: 6) {
+                if let attachments = message.attachments, !attachments.isEmpty {
+                    AttachmentChips(attachments: attachments)
+                }
+                // A pure-attachment message has no bubble on the web either.
+                if !message.content.isEmpty {
+                    HStack {
+                        Spacer(minLength: UIScreen.main.bounds.width * 0.2)
+                        userBubbleText
+                            .font(.system(size: 15))
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 10)
+                            .background(userBubbleColor)
+                            .cornerRadius(18)
+                    }
+                }
             }
         } else {
             VStack(alignment: .leading, spacing: 6) {
@@ -465,6 +477,39 @@ struct LickRow: View {
         LickRow.parseLickContent(message.content)
     }
 
+    /// Event label with the collation multiplicity appended, matching the
+    /// web pill's `"<event-label> ×<count>"`.
+    private var previewLabel: String {
+        let count = message.lickCount ?? 1
+        guard count > 1 else { return parsed.preview }
+        return parsed.preview.isEmpty ? "×\(count)" : "\(parsed.preview) ×\(count)"
+    }
+
+    /// Bodies of the licks folded into this row, each with its own `[...]`
+    /// header stripped. Without `lickParts` the collapsed bodies are
+    /// unrecoverable, which is what made a collated row lossy on iOS.
+    private var bodies: [String] {
+        guard let parts = message.lickParts, parts.count > 1 else {
+            return parsed.body.isEmpty ? [] : [parsed.body]
+        }
+        return parts.map { LickRow.parseLickContent($0).body }
+            .filter { !$0.isEmpty }
+    }
+
+    /// A dismissed card mutes on the web (`opacity: .62`); confirmed keeps
+    /// full strength.
+    private var contentOpacity: Double {
+        message.lickState == .dismissed ? 0.62 : 1
+    }
+
+    private func stateColor(_ state: LickState) -> Color {
+        switch state {
+        case .confirmed: return Color(red: 0x4A / 255, green: 0xDE / 255, blue: 0x80 / 255)
+        case .dismissed: return Color(red: 0xF8 / 255, green: 0x71 / 255, blue: 0x71 / 255)
+        case .pending: return .white.opacity(0.5)
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
@@ -474,14 +519,22 @@ struct LickRow: View {
                     Text(label)
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(.white.opacity(0.85))
-                    if !parsed.preview.isEmpty {
-                        Text(parsed.preview)
+                    if !previewLabel.isEmpty {
+                        Text(previewLabel)
                             .font(.system(size: 13))
                             .foregroundStyle(.white.opacity(0.55))
                             .lineLimit(1)
                             .truncationMode(.tail)
                     }
                     Spacer(minLength: 6)
+                    if let state = message.lickState,
+                        let glyph = SliccIcons.lickState(state)
+                    {
+                        Image(systemName: glyph)
+                            .font(.system(size: 13))
+                            .foregroundStyle(stateColor(state))
+                            .accessibilityIdentifier("lick-state-\(state.rawValue)")
+                    }
                     Image(systemName: iconName)
                         .font(.system(size: 13))
                         .foregroundStyle(.white.opacity(0.5))
@@ -498,24 +551,30 @@ struct LickRow: View {
             }
             .buttonStyle(.plain)
 
-            if isExpanded, !parsed.body.isEmpty {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    Text(parsed.body)
-                        .font(.system(size: 12, design: .monospaced))
-                        .foregroundStyle(.white.opacity(0.75))
-                        .textSelection(.enabled)
-                        .padding(12)
+            if isExpanded, !bodies.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(Array(bodies.enumerated()), id: \.offset) { index, body in
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            Text(body)
+                                .font(.system(size: 12, design: .monospaced))
+                                .foregroundStyle(.white.opacity(0.75))
+                                .textSelection(.enabled)
+                                .padding(12)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(bodyBackground)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .strokeBorder(borderColor, lineWidth: 0.5)
+                        )
+                        .accessibilityIdentifier("lick-part-\(index)")
+                    }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(bodyBackground)
-                .clipShape(RoundedRectangle(cornerRadius: 10))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .strokeBorder(borderColor, lineWidth: 0.5)
-                )
                 .padding(.top, 4)
             }
         }
+        .opacity(contentOpacity)
     }
 
     // MARK: Header parsing — mirrors lick-view.ts parseLickContent

--- a/packages/ios-app/SliccFollower/Views/MessageListView.swift
+++ b/packages/ios-app/SliccFollower/Views/MessageListView.swift
@@ -6,6 +6,8 @@ import SwiftUI
 struct MessageListView: View {
     let messages: [ChatMessage]
     let isStreaming: Bool
+    /// Pending read-only approval placeholders, pinned below the transcript.
+    var toolUICards: [ToolUIPlaceholder] = []
     /// Forwarded to inline sprinkle bubbles for `sprinkle.lick` events.
     var onInlineSprinkleLick: ((AnyCodable?, String?) -> Void)?
 
@@ -13,7 +15,7 @@ struct MessageListView: View {
 
     var body: some View {
         Group {
-            if messages.isEmpty {
+            if messages.isEmpty && toolUICards.isEmpty {
                 emptyState
             } else {
                 messageList
@@ -67,6 +69,13 @@ struct MessageListView: View {
                         }
                     }
 
+                    // Approval placeholders sit after the transcript, matching
+                    // the leader mounting them outside the message list.
+                    ForEach(toolUICards) { card in
+                        ToolUICardView(card: card)
+                            .padding(.horizontal, 12)
+                    }
+
                     // Invisible anchor at bottom
                     Color.clear
                         .frame(height: 1)
@@ -75,6 +84,9 @@ struct MessageListView: View {
                 .padding(.vertical, 8)
             }
             .onChange(of: messages.count) { _ in
+                scrollToBottom(proxy: proxy)
+            }
+            .onChange(of: toolUICards.count) { _ in
                 scrollToBottom(proxy: proxy)
             }
             .onChange(of: messages.last?.content) { _ in

--- a/packages/ios-app/SliccFollower/Views/SliccIcons.swift
+++ b/packages/ios-app/SliccFollower/Views/SliccIcons.swift
@@ -123,6 +123,29 @@ enum SliccIcons {
         return "circle.grid.2x2"
     }
 
+    // MARK: - Attachments (mirror ATTACHMENT_ICON in slicc-user-message.ts)
+
+    /// SF Symbol for an attachment chip that has no inline image to show.
+    static func attachment(_ kind: MessageAttachmentKind) -> String {
+        switch kind {
+        case .image: return "photo"  // lucide image
+        case .text: return "doc.text"  // lucide file-text
+        case .file: return "doc"  // lucide file
+        }
+    }
+
+    // MARK: - Lick State (mirror STATE_ICON in slicc-lick-card.ts)
+
+    /// SF Symbol for a settled lick decision. `pending` has no glyph on the
+    /// web either — the card simply stays in its default form.
+    static func lickState(_ state: LickState) -> String? {
+        switch state {
+        case .pending: return nil
+        case .confirmed: return "checkmark.circle"  // lucide circle-check
+        case .dismissed: return "xmark.circle"  // lucide circle-x
+        }
+    }
+
     /// Color for tool status (mirrors the web UI's running/success/error tinting).
     static func toolStatusColor(_ tc: ToolCall) -> Color {
         if tc.result == nil { return .yellow.opacity(0.8) }

--- a/packages/ios-app/SliccFollower/Views/ToolUICard.swift
+++ b/packages/ios-app/SliccFollower/Views/ToolUICard.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+
+/// A pending `tool_ui` approval, shown read-only.
+///
+/// The leader mounts an interactive card (Deny / Select directory / ...). A
+/// follower has no permissions surface and no wiring to answer, so the browser
+/// follower degrades the same event to static status text via
+/// `buildReadOnlyToolUiHtml` in `wc-chat-controller.ts`. This mirrors that
+/// output rather than rendering buttons that would silently no-op.
+struct ToolUIPlaceholder: Identifiable, Equatable {
+    /// Matches the `tool_ui_done` that tears this card down.
+    let id: String
+    let title: String
+
+    /// Fallback when the leader's HTML has no usable header, mirroring
+    /// `extractToolUiTitle`.
+    static let fallbackTitle = "Approval requested"
+
+    init(requestId: String, html: String) {
+        self.id = requestId
+        self.title = Self.extractTitle(from: html)
+    }
+
+    /// Pull the card title out of the leader's HTML.
+    ///
+    /// Mirrors `extractToolUiTitle`: read `.sprinkle-action-card__header`, drop
+    /// the nested `.sprinkle-badge` and `.sprinkle-action-card__meta`, and take
+    /// what is left. Dropping the meta line matters — it carries the mount
+    /// target path, which the follower is deliberately never shown.
+    static func extractTitle(from html: String) -> String {
+        guard let header = firstElementContent(in: html, className: "sprinkle-action-card__header")
+        else { return fallbackTitle }
+        let stripped = stripTags(removeNestedElements(from: header))
+        let title = stripped.trimmingCharacters(in: .whitespacesAndNewlines)
+        return title.isEmpty ? fallbackTitle : title
+    }
+
+    /// Inner HTML of the first element carrying `className`.
+    ///
+    /// Scans for the matching open tag and then walks tag by tag to find its
+    /// close, so a nested element of the same type does not end the match
+    /// early — the header contains nested spans and divs.
+    private static func firstElementContent(in html: String, className: String) -> String? {
+        guard let classRange = html.range(of: "class=\"\(className)\"") else { return nil }
+        guard let openStart = html.range(of: "<", options: .backwards, range: html.startIndex..<classRange.lowerBound)
+        else { return nil }
+        let tagName = html[html.index(after: openStart.lowerBound)...]
+            .prefix { $0.isLetter || $0.isNumber }
+        guard !tagName.isEmpty else { return nil }
+        guard let openEnd = html.range(of: ">", range: classRange.upperBound..<html.endIndex)
+        else { return nil }
+
+        var depth = 1
+        var cursor = openEnd.upperBound
+        let contentStart = cursor
+        while cursor < html.endIndex {
+            guard let next = html.range(of: "<", range: cursor..<html.endIndex) else { break }
+            let rest = html[next.upperBound...]
+            if rest.hasPrefix("/\(tagName)") {
+                depth -= 1
+                if depth == 0 { return String(html[contentStart..<next.lowerBound]) }
+            } else if rest.hasPrefix(tagName) {
+                depth += 1
+            }
+            guard let close = html.range(of: ">", range: next.upperBound..<html.endIndex) else { break }
+            cursor = close.upperBound
+        }
+        return nil
+    }
+
+    /// Remove `.sprinkle-badge` and `.sprinkle-action-card__meta` subtrees.
+    private static func removeNestedElements(from html: String) -> String {
+        var result = html
+        for className in ["sprinkle-badge", "sprinkle-action-card__meta"] {
+            while let inner = firstElementContent(in: result, className: className),
+                let range = result.range(of: inner)
+            {
+                // Drop the subtree along with the tags bracketing it.
+                guard
+                    let openStart = result.range(
+                        of: "<", options: .backwards, range: result.startIndex..<range.lowerBound),
+                    let closeEnd = result.range(of: ">", range: range.upperBound..<result.endIndex)
+                else { break }
+                result.removeSubrange(openStart.lowerBound..<closeEnd.upperBound)
+            }
+        }
+        return result
+    }
+
+    private static func stripTags(_ html: String) -> String {
+        // Dropped with no separator, matching `textContent` — the web reads the
+        // title the same way, so `Allow <code>npm publish</code>?` has to come
+        // back as `Allow npm publish?` and not gain a space before the `?`.
+        let withoutTags = html.replacingOccurrences(
+            of: "<[^>]+>", with: "", options: .regularExpression)
+        return
+            withoutTags
+            .replacingOccurrences(of: "&hellip;", with: "…")
+            .replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+    }
+}
+
+// MARK: - View
+
+struct ToolUICardView: View {
+    let card: ToolUIPlaceholder
+
+    private let cardBackground = Color(red: 0x1B / 255, green: 0x1B / 255, blue: 0x2A / 255)
+    private let borderColor = Color.white.opacity(0.10)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 7) {
+                Text(card.title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.85))
+                Text("pending")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.white.opacity(0.75))
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 1)
+                    .background(Capsule().fill(Color.white.opacity(0.12)))
+            }
+            Text("Waiting for approval on the leader…")
+                .font(.system(size: 12.5))
+                .foregroundStyle(.white.opacity(0.6))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(borderColor, lineWidth: 0.5)
+        )
+        .padding(.horizontal, 4)
+        .accessibilityIdentifier("tool-ui-\(card.id)")
+    }
+}


### PR DESCRIPTION
Closes #1792. Stacked on #1813, which is still in the merge queue. Targeting `main` so CI runs; until #1813 lands this PR also shows its two commits, and the diff shrinks to the single top commit once it merges. **Review only `feat(ios-app): render the payload fields the follower already decodes`.**

#1808 landed the wire half: iOS stopped dropping the fields below the type tag. But decoding a field and showing it are different things, and #1792's acceptance names four surfaces by name. This is the rendering half.

## What renders now

| Surface | Behavior |
| --- | --- |
| `attachments` | Chips above the user bubble — inline base64 becomes a 30×30 thumbnail, anything else a kind glyph, plus the filename. A message with empty `content` renders no bubble. |
| `error` | An error card instead of a plain assistant bubble, ranked below lick so a lick still wins. |
| `lickCount` / `lickParts` / `lickState` | Count suffix on the pill, the folded bodies (previously unrecoverable), and the confirmed/dismissed glyph with the dismissed card muted. |
| `tool_ui` / `tool_ui_done` | A read-only "waiting on the leader" card keyed by `requestId`, torn down by `tool_ui_done`. |

Each mirrors the browser follower rather than inventing an iOS treatment.

## Three deliberate divergences

All three come from the same fact: **a follower cannot act on leader state.**

- **The error card has no CTAs.** The web offers `Try again` / `Open Settings` / `Change model` / `Log in again`. Every one acts on leader-side state and the follower→leader union carries no equivalent message, so the button would silently no-op — worse than no button. Same reasoning #1792 already applies to `tool_ui`.
- **Attachment chips carry no size or MIME line.** Not an omission: the web's own chat mapper (`toUserAttachment`) drops `mimeType`, `size`, `path` and `error` before the component sees them. A chip there is a visual plus a name, so that is what a chip is here.
- **The `tool_ui` title strips the meta line.** It carries the mount target path, which followers are deliberately never shown. `ToolUIPlaceholderTests.testMetaPathNeverReachesTheTitle` guards it as a disclosure bug, not a cosmetic one.

A `snapshot` clears pending cards — it is the leader re-describing the world, so any placeholder predating it can never be confirmed, and the leader only ever clears one via the matching `tool_ui_done`.

## Complexity

`tool_ui` handling stays inside the single non-transcript `switch` arm and dispatches in the helper, so `handleAgentEvent` does not regain the complexity #1808 paid down. SwiftLint stays at the baseline 14 violations.

## Verification

The fixture gains 6 variants (collated lick, confirmed, dismissed, attachments, attachment-only, error) and the UI walk gains 6 markers plus a decision-glyph test, since the glyph is an SF Symbol with no text for the marker walk to see.

**The mutation that matters.** Gating all five renderers off — attachments, error card, count suffix, state glyph, tool_ui — fails **exactly** the 6 new markers and **none** of the 9 existing ones, plus the glyph test:

```
XCTAssertEqual failed: (["deploy-status ×3", "SOMETHING WENT WRONG",
  "screenshot.png", "diagram.png", "Allow npm publish?",
  "Waiting for approval on the leader"]) is not equal to ([])
XCTAssertTrue failed - A confirmed lick should render its decision glyph
```

The **row-id assertion stayed silent** through all of it. That is the #1813 Codex finding reproducing on new code: ids propagate to every leaf, so the markers are what actually hold this down.

`ToolUIPlaceholderTests` covers the HTML title extractor directly — badge/meta stripping, same-tag nesting, entity decoding, and both fallback paths.

## Gates

`npm run verify` (7/7), `check-touched-exemptions`, `typecheck`, targeted vitest (552), `lint:swift` (14 = baseline), `lint:swift:format`, full `xcodebuild test` via the coverage gate.

Coverage **47.64 → 50.68** lines, 33.25 → 35.39 functions, 37.57 → 39.51 regions. Floors raised to 50/34/39, which is exactly `Math.floor(actual − 0.5)` — what the nightly ratchet would compute.

## Note

`packages/ios-app/CLAUDE.md` was at 19,987/20,000 chars, so the new rendering-parity section is paid for by condensing prose that duplicated `docs/architecture.md`. Two now-stale claims were corrected in passing: the QA section still said manual running was the only way to check SwiftUI surfaces (the UI tests changed that), and the simulator prerequisites now warn about the `libswiftWebKit.dylib` launch failure on a runtime older than the Xcode SDK, which cost time here.
