### PR TITLE
feat: recency-weighted floatbar burn rate

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -860,7 +860,7 @@ See [docs/secrets.md](secrets.md) for user-facing setup instructions.
 | Change preview service worker          | `packages/webapp/src/ui/preview-sw.ts`                                                       |
 | Change provider/model selection        | `packages/webapp/src/ui/provider-settings.ts`                                                |
 | Change theme handling                  | `packages/webapp/src/ui/theme.ts`                                                            |
-| Change session storage                 | `packages/webapp/src/ui/session-store.ts`                                                    |
+| Change session storage                 | `packages/webapp/src/scoops/chat-session-store.ts`                                           |
 
 ### CLI Server
 

--- a/packages/dev-tools/tools/ui-back-edge-baseline.json
+++ b/packages/dev-tools/tools/ui-back-edge-baseline.json
@@ -1,5 +1,4 @@
 {
-  "packages/webapp/src/kernel/facade.ts": 1,
   "packages/webapp/src/kernel/host.ts": 1,
   "packages/webapp/src/kernel/kernel-worker.ts": 1,
   "packages/webapp/src/kernel/remote-terminal-view.ts": 2,
@@ -9,7 +8,6 @@
   "packages/webapp/src/providers/oauth-service.ts": 1,
   "packages/webapp/src/scoops/agent-message-to-chat.ts": 1,
   "packages/webapp/src/scoops/lick-ws-bridge.ts": 1,
-  "packages/webapp/src/scoops/orchestrator.ts": 2,
   "packages/webapp/src/scoops/sprinkle-bridge-channel.ts": 2,
   "packages/webapp/src/scoops/sprinkle-manager-proxy.ts": 1,
   "packages/webapp/src/scoops/tray-follower-sync.ts": 1,

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -12,6 +12,7 @@ import type { BrowserAPI } from '../cdp/index.js';
 import type { AgentEvent } from '../core/agent-types.js';
 import type { MessageAttachment } from '../core/attachments.js';
 import { createLogger } from '../core/logger.js';
+import { SessionStore } from '../scoops/chat-session-store.js';
 import type { ChatMessage } from '../scoops/chat-types.js';
 import { HIDDEN_TOOL_NAMES } from '../scoops/hidden-tools.js';
 import { formatLickEventForCone } from '../scoops/lick-formatting.js';
@@ -27,7 +28,6 @@ import type { FollowerSyncManager } from '../scoops/tray-follower-sync.js';
 import { getLeaderTrayRuntimeStatus } from '../scoops/tray-leader.js';
 import type { ChannelMessage, RegisteredScoop, ScoopTabState } from '../scoops/types.js';
 import { TOOL_UI_MOUNTED_ACTION, toolUIRegistry } from '../tools/tool-ui.js';
-import { SessionStore } from '../ui/session-store.js';
 import type {
   AgentEventMsg,
   ErrorMsg,

--- a/packages/webapp/src/kernel/messages.ts
+++ b/packages/webapp/src/kernel/messages.ts
@@ -187,7 +187,7 @@ export interface SessionStatsMsg {
   requestId: string;
   /** Total session cost (USD) across all scoops, dropped ones included. */
   totalCost: number;
-  /** Active-session spend over the trailing window, extrapolated to USD/hour. */
+  /** Blended 15-minute, 60-minute, and full-session spend rate in USD/hour. */
   burnRate: number;
   /** Per-scoop context-window fill, 0..1 (last assistant turn's usage). */
   fills: Array<{ jid: string; fill: number }>;

--- a/packages/webapp/src/scoops/chat-session-store.ts
+++ b/packages/webapp/src/scoops/chat-session-store.ts
@@ -1,8 +1,8 @@
 /**
- * Session persistence — save/restore conversations to IndexedDB.
+ * Chat session persistence — save/restore rendered conversations in IndexedDB.
  */
 
-import type { ChatMessage, Session } from './types.js';
+import type { ChatMessage, Session } from './chat-types.js';
 
 const DB_NAME = 'browser-coding-agent';
 const DB_VERSION = 1;

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -36,7 +36,7 @@ import { registerTranscriptExportService } from '../transcript/export-provider.j
 import { DefaultTranscriptExportService } from '../transcript/export-service.js';
 import { readSnapshot, writeSnapshot } from '../transcript/snapshot-store.js';
 import { getStrictKnownSecretRedactor } from '../transcript/strict-secret-client.js';
-import { SessionStore as UiSessionStore } from '../ui/session-store.js';
+import { SessionStore as UiSessionStore } from './chat-session-store.js';
 import { ConeMemoryStore } from './cone-memory-store.js';
 import * as db from './db.js';
 import { isExternalLickChannel } from './lick-formatting.js';
@@ -1006,7 +1006,7 @@ export class Orchestrator implements ConeApprovalRouter {
   async getSessionCostsForCommand(scope: SessionCostScope): Promise<ScoopCostData[]> {
     const costs = this.getSessionCosts({ includeDropped: scope === 'all' });
     if (scope === 'live' || !this.sharedFs) return costs;
-    const { readSessionsIndex } = await import('../ui/session-freezer.js');
+    const { readSessionsIndex } = await import('../transcript/frozen-archive-format.js');
     const frozenSessions = await readSessionsIndex(this.sharedFs);
     return [...costs, ...frozenSessions.map(frozenSessionToCostData)];
   }
@@ -1018,7 +1018,7 @@ export class Orchestrator implements ConeApprovalRouter {
     return this.costTracker.getModelCosts(options);
   }
 
-  /** Active-session spend over the trailing window, extrapolated to dollars per hour. */
+  /** Recency-weighted active-session USD/hour blend, floored at the full-session average. */
   getBurnRate(nowMs?: number): ReturnType<ScoopCostTracker['getBurnRate']> {
     return this.costTracker.getBurnRate(nowMs);
   }

--- a/packages/webapp/src/scoops/scoop-cost-tracker.ts
+++ b/packages/webapp/src/scoops/scoop-cost-tracker.ts
@@ -17,7 +17,14 @@ import type { ScoopContext } from './scoop-context.js';
 import type { RegisteredScoop } from './types.js';
 
 const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
-const BURN_RATE_WINDOW_HOURS = 0.25;
+const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
+
+export const BURN_RATE_RECENT_WINDOW_MS = FIFTEEN_MINUTES_MS;
+export const BURN_RATE_MEDIUM_WINDOW_MS = 60 * 60 * 1000;
+export const BURN_RATE_MIN_SESSION_DURATION_MS = 60 * 1000;
+export const BURN_RATE_RECENT_WEIGHT = 0.5;
+export const BURN_RATE_MEDIUM_WEIGHT = 0.3;
+export const BURN_RATE_SESSION_WEIGHT = 0.2;
 
 export interface ModelCostData {
   model: string;
@@ -155,18 +162,47 @@ export class ScoopCostTracker {
     return results;
   }
 
-  /** Active-session cost in the trailing 15-minute window, extrapolated to dollars per hour. */
+  /**
+   * Weighted USD/hour blend of trailing 15-minute, trailing 60-minute, and
+   * full-session spend, floored at the full-session average.
+   */
   getBurnRate(nowMs = Date.now()): number {
-    const cutoff = nowMs - FIFTEEN_MINUTES_MS;
-    let windowCost = 0;
+    const assistantMessages = this.droppedMessages.flat();
     for (const context of this.deps.getContexts().values()) {
       for (const message of context.getAgentMessages()) {
-        if (message.role === 'assistant' && message.timestamp >= cutoff) {
-          windowCost += message.usage.cost.total;
-        }
+        if (message.role === 'assistant') assistantMessages.push(message);
       }
     }
-    return windowCost / BURN_RATE_WINDOW_HOURS;
+    if (assistantMessages.length === 0) return 0;
+
+    let sessionStartMs = assistantMessages[0].timestamp;
+    for (const message of assistantMessages) {
+      sessionStartMs = Math.min(sessionStartMs, message.timestamp);
+    }
+    const sessionDurationMs = Math.max(nowMs - sessionStartMs, BURN_RATE_MIN_SESSION_DURATION_MS);
+    const recentDurationMs = Math.min(BURN_RATE_RECENT_WINDOW_MS, sessionDurationMs);
+    const mediumDurationMs = Math.min(BURN_RATE_MEDIUM_WINDOW_MS, sessionDurationMs);
+    const recentCutoffMs = nowMs - recentDurationMs;
+    const mediumCutoffMs = nowMs - mediumDurationMs;
+
+    let recentCost = 0;
+    let mediumCost = 0;
+    let sessionCost = 0;
+    for (const message of assistantMessages) {
+      const cost = message.usage.cost.total;
+      sessionCost += cost;
+      if (message.timestamp >= recentCutoffMs) recentCost += cost;
+      if (message.timestamp >= mediumCutoffMs) mediumCost += cost;
+    }
+
+    const recentRate = (recentCost * MILLISECONDS_PER_HOUR) / recentDurationMs;
+    const mediumRate = (mediumCost * MILLISECONDS_PER_HOUR) / mediumDurationMs;
+    const sessionRate = (sessionCost * MILLISECONDS_PER_HOUR) / sessionDurationMs;
+    const blendedRate =
+      recentRate * BURN_RATE_RECENT_WEIGHT +
+      mediumRate * BURN_RATE_MEDIUM_WEIGHT +
+      sessionRate * BURN_RATE_SESSION_WEIGHT;
+    return Math.max(blendedRate, sessionRate);
   }
 
   /**

--- a/packages/webapp/src/scoops/welcome-detection.ts
+++ b/packages/webapp/src/scoops/welcome-detection.ts
@@ -29,7 +29,7 @@ const WELCOMED_MARKER_PATH = '/shared/.welcomed';
 
 /**
  * IndexedDB layer that holds the chat-panel's persisted conversations.
- * Mirrors `ui/session-store.ts` literally — DB name + store + the
+ * Mirrors `scoops/chat-session-store.ts` literally — DB name + store + the
  * `session-cone` key the chat panel uses for the cone scoop. We avoid
  * importing the UI `SessionStore` so this module stays inside the
  * scoops layer (which `main.ts` imports from both CLI and extension

--- a/packages/webapp/src/ui/new-session.ts
+++ b/packages/webapp/src/ui/new-session.ts
@@ -11,6 +11,7 @@ import type { Api, Model } from '@earendil-works/pi-ai';
 import { createLogger } from '../core/logger.js';
 import type { DirEntry } from '../fs/types.js';
 import type { WritableVfsClient } from '../kernel/writable-vfs-client.js';
+import { SessionStore } from '../scoops/chat-session-store.js';
 import { getDailyAdobeUuid } from '../scoops/llm-session-id.js';
 import { getApiKey, resolveCurrentModel } from './provider-settings.js';
 import {
@@ -20,7 +21,6 @@ import {
   freezeConeSession,
   markSnapshotUnavailable,
 } from './session-freezer.js';
-import { SessionStore } from './session-store.js';
 
 const log = createLogger('new-session');
 

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -59,7 +59,7 @@ void _assertLickWireCarrier;
 export interface SessionStats {
   /** Total session cost (USD) across all scoops, dropped ones included. */
   totalCost: number;
-  /** Active-session spend over the trailing window, extrapolated to USD/hour. */
+  /** Blended 15-minute, 60-minute, and full-session spend rate in USD/hour. */
   burnRate: number;
   /** Per-scoop context-window fill, 0..1 (last assistant turn's usage). */
   fills: Array<{ jid: string; fill: number }>;

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -32,6 +32,7 @@ import { createLogger } from '../core/logger.js';
 import { FsError } from '../fs/types.js';
 import type { LocalVfsClient } from '../kernel/local-vfs-client.js';
 import type { WritableVfsClient } from '../kernel/writable-vfs-client.js';
+import type { SessionStore } from '../scoops/chat-session-store.js';
 import { applyConeMemoryBudget } from '../scoops/cone-memory-budget.js';
 import type {
   FrozenSessionArchive,
@@ -47,7 +48,6 @@ import {
   SESSIONS_INDEX_PATH,
 } from '../transcript/frozen-archive-format.js';
 import { formatChatForClipboard } from './chat-clipboard.js';
-import type { SessionStore } from './session-store.js';
 import type { ChatMessage, Session } from './types.js';
 
 export type {

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -25,6 +25,7 @@ import {
   resolveCurrentModel,
   resolveModelById,
 } from '../../providers/account-store.js';
+import { SessionStore as UiSessionStore } from '../../scoops/chat-session-store.js';
 import type { LickEvent } from '../../scoops/lick-manager.js';
 import { hasStoredTrayJoinUrl } from '../../scoops/tray-runtime-config.js';
 import type { RegisteredScoop, ThinkingLevel } from '../../scoops/types.js';
@@ -42,7 +43,6 @@ import { type DipInstance, disposeDips, hydrateDips } from '../dip.js';
 import { isLickChannel } from '../lick-channels.js';
 import type { OffscreenClient, OffscreenClientCallbacks } from '../offscreen-client.js';
 import type { UiRuntimeMode } from '../runtime-mode.js';
-import { SessionStore as UiSessionStore } from '../session-store.js';
 import type { ChatMessage } from '../types.js';
 import {
   LEADER_BROADCAST_SNAPSHOT_EVENT,
@@ -1031,7 +1031,7 @@ function wireWcComposer(deps: {
   void (async () => {
     try {
       if (shouldSkipSessionHydration(boot.wiring.pendingUrlContext, window)) return;
-      const { SessionStore } = await import('../session-store.js');
+      const { SessionStore } = await import('../../scoops/chat-session-store.js');
       const store = new SessionStore();
       await store.init();
       const session = await store.load('session-cone');

--- a/packages/webapp/tests/kernel/bridge.test.ts
+++ b/packages/webapp/tests/kernel/bridge.test.ts
@@ -46,7 +46,7 @@ const { mockSessionStore, mockHandleAction } = vi.hoisted(() => ({
   mockHandleAction: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('../../src/ui/session-store.js', () => ({
+vi.mock('../../src/scoops/chat-session-store.js', () => ({
   SessionStore: mockSessionStore,
 }));
 
@@ -60,7 +60,7 @@ vi.mock('../../src/tools/tool-ui.js', () => ({
 }));
 
 const { Bridge } = await import('../../src/kernel/facade.js');
-const { SessionStore } = await import('../../src/ui/session-store.js');
+const { SessionStore } = await import('../../src/scoops/chat-session-store.js');
 
 describe('Bridge createCallbacks', () => {
   let bridge: InstanceType<typeof Bridge>;

--- a/packages/webapp/tests/kernel/facade.test.ts
+++ b/packages/webapp/tests/kernel/facade.test.ts
@@ -81,7 +81,7 @@ const { mockSessionStore, mockHandleAction, mockHandleSprinkleOpResponse } = vi.
   mockHandleSprinkleOpResponse: vi.fn(),
 }));
 
-vi.mock('../../src/ui/session-store.js', () => ({
+vi.mock('../../src/scoops/chat-session-store.js', () => ({
   SessionStore: mockSessionStore,
 }));
 

--- a/packages/webapp/tests/scoops/scoop-cost-tracker.test.ts
+++ b/packages/webapp/tests/scoops/scoop-cost-tracker.test.ts
@@ -1,8 +1,19 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { AssistantMessage } from '../../src/core/types.js';
 import type { ScoopContext } from '../../src/scoops/scoop-context.js';
-import { ScoopCostTracker } from '../../src/scoops/scoop-cost-tracker.js';
+import {
+  BURN_RATE_MEDIUM_WEIGHT,
+  BURN_RATE_MEDIUM_WINDOW_MS,
+  BURN_RATE_MIN_SESSION_DURATION_MS,
+  BURN_RATE_RECENT_WEIGHT,
+  BURN_RATE_RECENT_WINDOW_MS,
+  BURN_RATE_SESSION_WEIGHT,
+  ScoopCostTracker,
+} from '../../src/scoops/scoop-cost-tracker.js';
 import type { RegisteredScoop } from '../../src/scoops/types.js';
+
+const MINUTE_MS = 60 * 1000;
+const NOW_MS = 2_000_000_000_000;
 
 describe('ScoopCostTracker', () => {
   function createMockScoop(jid: string, label: string, isCone = false): RegisteredScoop {
@@ -30,7 +41,7 @@ describe('ScoopCostTracker', () => {
     outputCost = 0,
     cacheReadCost = 0,
     cacheWriteCost = 0,
-    timestamp = Date.now()
+    timestamp = NOW_MS
   ): AssistantMessage {
     const totalCost = inputCost + outputCost + cacheReadCost + cacheWriteCost;
     return {
@@ -66,6 +77,15 @@ describe('ScoopCostTracker', () => {
       getContexts: () => contextsMap,
     });
   });
+
+  function createCostMessage(cost: number, timestamp: number): AssistantMessage {
+    return createAssistantMessage('model', 100, 50, 0, 0, cost, 0, 0, 0, timestamp);
+  }
+
+  function addLiveMessages(jid: string, messages: AssistantMessage[]): void {
+    scoopsMap.set(jid, createMockScoop(jid, jid));
+    contextsMap.set(jid, createMockContext(messages));
+  }
 
   it('returns live session costs by default and includes dropped costs on request', () => {
     const liveScoop = createMockScoop('live', 'Live Scoop');
@@ -112,43 +132,78 @@ describe('ScoopCostTracker', () => {
     expect(cost.models).toEqual(['model-expensive', 'model-frequent']);
   });
 
-  it('returns zero burn rate when the trailing window is empty', () => {
-    const nowMs = 2_000_000_000_000;
-    const scoop = createMockScoop('idle', 'Idle Scoop');
-    scoopsMap.set('idle', scoop);
-    contextsMap.set(
-      'idle',
-      createMockContext([
-        createAssistantMessage('model', 100, 50, 0, 0, 0.1, 0, 0, 0, nowMs - 15 * 60 * 1000 - 1),
-      ])
-    );
+  describe('burn rate', () => {
+    it('exports the configured windows, floor, and weights', () => {
+      expect(BURN_RATE_RECENT_WINDOW_MS).toBe(15 * MINUTE_MS);
+      expect(BURN_RATE_MEDIUM_WINDOW_MS).toBe(60 * MINUTE_MS);
+      expect(BURN_RATE_MIN_SESSION_DURATION_MS).toBe(MINUTE_MS);
+      expect(BURN_RATE_RECENT_WEIGHT).toBe(0.5);
+      expect(BURN_RATE_MEDIUM_WEIGHT).toBe(0.3);
+      expect(BURN_RATE_SESSION_WEIGHT).toBe(0.2);
+    });
 
-    expect(tracker.getBurnRate(nowMs)).toBe(0);
-  });
+    it('returns zero for an empty session', () => {
+      addLiveMessages('empty', []);
 
-  it('computes burn rate from live messages inside the deterministic trailing window', () => {
-    const nowMs = 2_000_000_000_000;
-    const liveScoop = createMockScoop('live', 'Live Scoop');
-    const droppedScoop = createMockScoop('dropped', 'Dropped Scoop');
-    scoopsMap.set('live', liveScoop);
-    scoopsMap.set('dropped', droppedScoop);
-    contextsMap.set(
-      'live',
-      createMockContext([
-        createAssistantMessage('model', 100, 50, 0, 0, 0.1, 0, 0, 0, nowMs - 5 * 60 * 1000),
-        createAssistantMessage('model', 100, 50, 0, 0, 0.2, 0, 0, 0, nowMs - 15 * 60 * 1000),
-        createAssistantMessage('model', 100, 50, 0, 0, 0.3, 0, 0, 0, nowMs - 15 * 60 * 1000 - 1),
-      ])
-    );
-    contextsMap.set(
-      'dropped',
-      createMockContext([createAssistantMessage('model', 100, 50, 0, 0, 0.5, 0, 0, 0, nowMs - 1)])
-    );
-    tracker.snapshot('dropped');
-    scoopsMap.delete('dropped');
-    contextsMap.delete('dropped');
+      expect(tracker.getBurnRate(NOW_MS)).toBe(0);
+    });
 
-    expect(tracker.getBurnRate(nowMs)).toBeCloseTo(1.2, 10);
+    it('reports the true hourly average for steady spend', () => {
+      const messages = Array.from({ length: 120 }, (_, index) =>
+        createCostMessage(0.01, NOW_MS - (120 - index) * MINUTE_MS)
+      );
+      addLiveMessages('steady', messages);
+
+      expect(tracker.getBurnRate(NOW_MS)).toBeCloseTo(0.6, 10);
+    });
+
+    it('uses the one-minute floor for a single early turn', () => {
+      addLiveMessages('early', [createCostMessage(0.01, NOW_MS)]);
+
+      expect(tracker.getBurnRate(NOW_MS)).toBeCloseTo(0.6, 10);
+    });
+
+    it('stops at the session average after 20 minutes idle', () => {
+      addLiveMessages('idle', [
+        createCostMessage(1, NOW_MS - 40 * MINUTE_MS),
+        createCostMessage(1, NOW_MS - 20 * MINUTE_MS),
+      ]);
+
+      expect(tracker.getBurnRate(NOW_MS)).toBeCloseTo(3, 10);
+    });
+
+    it('never drops below the session average after a burst then idle period', () => {
+      addLiveMessages('burst', [
+        createCostMessage(0.1, NOW_MS - 120 * MINUTE_MS),
+        createCostMessage(10, NOW_MS - 16 * MINUTE_MS),
+      ]);
+      const sessionRate = 10.1 / 2;
+      const rate = tracker.getBurnRate(NOW_MS);
+
+      expect(rate).toBeGreaterThanOrEqual(sessionRate);
+      expect(rate).toBeCloseTo(sessionRate, 10);
+    });
+
+    it('includes dropped-scoop messages in every component', () => {
+      addLiveMessages('dropped', [
+        createCostMessage(1, NOW_MS - 120 * MINUTE_MS),
+        createCostMessage(1, NOW_MS - 5 * MINUTE_MS),
+      ]);
+      tracker.snapshot('dropped');
+      scoopsMap.delete('dropped');
+      contextsMap.delete('dropped');
+
+      expect(tracker.getBurnRate(NOW_MS)).toBeCloseTo(2.5, 10);
+    });
+
+    it('clamps trailing windows to the elapsed session duration', () => {
+      addLiveMessages('clamped', [
+        createCostMessage(0.05, NOW_MS - 5 * MINUTE_MS),
+        createCostMessage(0.05, NOW_MS - MINUTE_MS),
+      ]);
+
+      expect(tracker.getBurnRate(NOW_MS)).toBeCloseTo(1.2, 10);
+    });
   });
 
   it('aggregates costs by model across all live scoops', () => {

--- a/packages/webapp/tests/ui/new-session.test.ts
+++ b/packages/webapp/tests/ui/new-session.test.ts
@@ -17,7 +17,7 @@ vi.mock('../../src/ui/provider-settings.js', () => ({
 vi.mock('../../src/scoops/llm-session-id.js', () => ({ getDailyAdobeUuid: () => 'uuid-x' }));
 
 const mockInit = vi.fn(async () => {});
-vi.mock('../../src/ui/session-store.js', () => ({
+vi.mock('../../src/scoops/chat-session-store.js', () => ({
   SessionStore: class {
     init = mockInit;
   },

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -42,6 +42,7 @@ vi.mock('../../src/ui/chat-panel.js', () => ({
       .join(''),
 }));
 
+import type { SessionStore } from '../../src/scoops/chat-session-store.js';
 import { applyDictationMarkers } from '../../src/speech/dictation-priming.js';
 import {
   enrichPendingSession,
@@ -51,7 +52,6 @@ import {
   parseFrozenArchive,
   readSessionsIndex,
 } from '../../src/ui/session-freezer.js';
-import type { SessionStore } from '../../src/ui/session-store.js';
 
 /**
  * Minimal VirtualFS double — just the subset the freezer touches. Backed by

--- a/packages/webapp/tests/ui/session-store.test.ts
+++ b/packages/webapp/tests/ui/session-store.test.ts
@@ -4,7 +4,7 @@
 
 import { beforeEach, describe, expect, it } from 'vitest';
 import 'fake-indexeddb/auto';
-import { SessionStore } from '../../src/ui/session-store.js';
+import { SessionStore } from '../../src/scoops/chat-session-store.js';
 import type { ChatMessage, Session } from '../../src/ui/types.js';
 
 describe('SessionStore', () => {

--- a/packages/webcomponents/src/primitives/slicc-floatbar.ts
+++ b/packages/webcomponents/src/primitives/slicc-floatbar.ts
@@ -91,7 +91,7 @@ const STYLE = `
   height: 12px;
 }
 
-/* Hover/focus tip surfacing the collapsed label + spend + connection state.
+/* Hover/focus tip surfacing the collapsed label + rate + connection state.
    Hidden in the wide pill (the full label already shows everything); only the
    narrow square badge reveals it, mirroring slicc-pill's dark .tip convention.
    Decorative (aria-hidden); the accessible name rides the host title attribute. */
@@ -272,12 +272,14 @@ export class SliccFloatbar extends HTMLElement {
 
   /**
    * The tooltip text for the narrow square badge — the label, the formatted
-   * hourly rate and connection state, joined with the same ` · `
+   * hourly rate, its recency-weighted session context, and connection state,
+   * joined with the same ` · `
    * separator the verbose label uses, so the collapsed badge stays legible.
    */
   #tipText(): string {
     const parts: string[] = [this.label];
     parts.push(formatRate(this.rate));
+    parts.push('recency-weighted session avg');
     parts.push(this.online ? 'online' : 'offline');
     return parts.join(' · ');
   }

--- a/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
+++ b/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
@@ -321,7 +321,7 @@ describe('slicc-floatbar', () => {
           dispatchEvent: () => false,
         }) as unknown as MediaQueryList;
 
-    it('renders a decorative tip part derived from the label, spend, and state', () => {
+    it('renders a decorative tip part derived from the label, rate context, and state', () => {
       const el = document.createElement('slicc-floatbar');
       el.label = 'CLI · tray · 1 follower';
       el.online = true;
@@ -333,14 +333,16 @@ describe('slicc-floatbar', () => {
       expect(tip.getAttribute('part')).toBe('tip');
       // decorative — the accessible name rides the host title, not the tip node
       expect(tip.getAttribute('aria-hidden')).toBe('true');
-      expect(tip.textContent).toBe('CLI · tray · 1 follower · $2.41/h · online');
+      expect(tip.textContent).toBe(
+        'CLI · tray · 1 follower · $2.41/h · recency-weighted session avg · online'
+      );
     });
 
     it('reflects the offline state and the zero rate when unset', () => {
       const el = document.createElement('slicc-floatbar');
       document.body.appendChild(el);
       expect(el.shadowRoot?.querySelector('.tip')?.textContent).toBe(
-        'CLI float · $0.00/h · offline'
+        'CLI float · $0.00/h · recency-weighted session avg · offline'
       );
     });
 
@@ -374,7 +376,9 @@ describe('slicc-floatbar', () => {
         el.online = true;
         el.rate = '2.41';
         document.body.appendChild(el);
-        expect(el.getAttribute('title')).toBe('CLI float · $2.41/h · online');
+        expect(el.getAttribute('title')).toBe(
+          'CLI float · $2.41/h · recency-weighted session avg · online'
+        );
       } finally {
         window.matchMedia = original;
       }


### PR DESCRIPTION
## Problem

The $/h pill extrapolated only the trailing 15 minutes, so one expensive turn spiked it while idle time decayed it toward $0.00/h.

## Solution

The rate now blends the trailing 15 minutes (0.5), trailing 60 minutes (0.3), and full session (0.2). Each window is clamped to elapsed session time, and the result is floored at the full-session average, so bursts can raise the rate but idle time cannot pull it below the true average. Dropped scoops are included so the rate agrees with the cumulative spent total.

## Layering

This retires two ui-back-edge-baseline.json entries: orchestrator.ts and kernel/facade.ts.

## Compatibility

**Reviewer sanity-check:** the IndexedDB database name, store name, and key schema are unchanged, so existing saved sessions are unaffected. This is the main compatibility risk to verify.
