### PR TITLE
fix(mcp): repair `mcp add` mojibake and negotiate the 2026-07-28 protocol revision

### DIFF
--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -68,6 +68,7 @@ Sandbox lifecycle logic lives in `@slicc/cloud-core`; worker `src/cloud/` is ada
 | `WS __slicc/bridge`                   | Preview bridge WS (`slicc.preview-bridge.v1.<connId>`); relays CDP + attributed `emit` between tabs and leader; hibernated via `setWebSocketAutoResponse` |
 | `POST __slicc/emit`                   | Fallback beacon relay for `window.slicc.emit` on page unload                                                                                              |
 | `GET /auth/callback`                  | OAuth callback relay; also a capture hop for the cloud dashboard (no `state` → `postMessage` to `window.opener`)                                          |
+| `GET /auth/mcp-callback`              | MCP OAuth capture hop; preserves opaque `state` and posts the untouched callback URL to the same-origin opener                                            |
 | `GET /api/flags`                      | Resolve `{ float, flags }` string values for `?float=<float>`; unknown/invalid profiles fall back to `base`                                               |
 
 **Routes-mirror rule:** every new route must appear in three places:

--- a/packages/cloudflare-worker/src/api-catalog.ts
+++ b/packages/cloudflare-worker/src/api-catalog.ts
@@ -54,6 +54,11 @@ const ENTRIES: CatalogEntry[] = [
     description: 'OAuth callback relay; redirects to the localhost runtime.',
   },
   {
+    anchor: '/auth/mcp-callback',
+    methods: ['GET'],
+    description: 'MCP OAuth callback capture; preserves opaque state for the opener.',
+  },
+  {
     anchor: '/oauth/token',
     methods: ['POST', 'OPTIONS'],
     description: 'Generic OAuth authorization-code grant exchange.',

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -374,15 +374,13 @@ try {
     )
   );
 
-// Capture page for the OAuth relay's final hop. After the relay bounces a
-// provider response back to the dashboard's own origin (code present, state
-// consumed), this page hands the full URL (which carries the OAuth `code`) to
-// the opener via postMessage — the signal the webapp's `launchOAuthCli` waits
-// for — then closes. Used by the webapp-served-by-worker (connect/cloud)
-// context, where there's no node-server callback page.
+// Capture page for OAuth callbacks that must be handed to the opener without
+// interpreting their parameters. This serves both the structured relay's final
+// hop (where state was consumed) and the dedicated MCP callback (where opaque
+// state must be preserved).
 //
-// The relay only ever bounces back to the dashboard's OWN origin, so the
-// legitimate opener is same-origin: scope the postMessage `targetOrigin` to
+// Both capture paths run on the dashboard's OWN origin, so the legitimate
+// opener is same-origin: scope the postMessage `targetOrigin` to
 // `location.origin` (NOT '*') so the code can't be delivered to a cross-origin
 // window that managed to become our opener. The receiver also re-checks
 // `event.origin`, but the sender must scope delivery too.
@@ -573,6 +571,7 @@ const ROUTES_INDEX_BODY = {
     'GET /api/tray/:trayId/previews',
     'POST /api/tray/:trayId/supersede',
     'GET /auth/callback',
+    'GET /auth/mcp-callback',
     'POST /oauth/token',
     'POST /oauth/revoke',
     'GET /api/runtime-config',
@@ -676,6 +675,15 @@ async function tryHandleOAuthRoutes(
   env: WorkerEnv,
   fetchImpl: typeof fetch
 ): Promise<Response | null> {
+  // MCP authorization servers return an opaque CSRF state. Keep this path
+  // separate from the structured SLICC relay so the value survives unchanged.
+  if (url.pathname === '/auth/mcp-callback') {
+    return new Response(OAUTH_CAPTURE_HTML, {
+      status: 200,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  }
+
   // OAuth callback relay — serves a static HTML page that reads the OAuth state
   // parameter and redirects to the correct localhost port. Provider-agnostic.
   if (url.pathname === '/auth/callback') {

--- a/packages/cloudflare-worker/tests/auth-relay.test.ts
+++ b/packages/cloudflare-worker/tests/auth-relay.test.ts
@@ -15,6 +15,10 @@ function relayRequest(query: string): Request {
   return new Request(`https://www.sliccy.ai/auth/callback${query}`);
 }
 
+function mcpCallbackRequest(query: string): Request {
+  return new Request(`https://www.sliccy.ai/auth/mcp-callback${query}`);
+}
+
 async function fetchRelayBody(query: string): Promise<string> {
   const res = await handleWorkerRequest(relayRequest(query), env);
   return res.text();
@@ -30,7 +34,7 @@ function runRelay(
   html: string,
   search: string,
   hash = '',
-  opts: { origin?: string; hasOpener?: boolean } = {}
+  opts: { origin?: string; hasOpener?: boolean; path?: string } = {}
 ): { replaced?: string; error?: string; postedMessage?: any; postedTarget?: string } {
   const match = html.match(/<script>([\s\S]*?)<\/script>/);
   if (!match) throw new Error('No <script> in relay HTML');
@@ -43,7 +47,7 @@ function runRelay(
     search,
     hash,
     origin,
-    href: `${origin}/auth/callback${search}${hash}`,
+    href: `${origin}${opts.path ?? '/auth/callback'}${search}${hash}`,
     replace: (url: string) => {
       replaced = url;
     },
@@ -131,6 +135,29 @@ describe('OAuth callback relay — page response', () => {
     const res = await handleWorkerRequest(trayReq, env);
     const body = await res.text();
     expect(body).not.toContain('Redirecting to SLICC');
+  });
+});
+
+describe('MCP OAuth callback — opaque state', () => {
+  it('posts the callback to the opener without decoding opaque state', async () => {
+    const opaqueState = 'mcp-state_opaque~value-123';
+    const search = `?code=abc&state=${encodeURIComponent(opaqueState)}`;
+    const res = await handleWorkerRequest(mcpCallbackRequest(search), env);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).not.toContain('atob(');
+    const { postedMessage, postedTarget, error } = runRelay(html, search, '', {
+      path: '/auth/mcp-callback',
+    });
+
+    expect(error).toBeUndefined();
+    expect(postedTarget).toBe('https://www.sliccy.ai');
+    expect(postedMessage?.type).toBe('oauth-callback');
+    const redirect = new URL(postedMessage?.redirectUrl);
+    expect(redirect.pathname).toBe('/auth/mcp-callback');
+    expect(redirect.searchParams.get('code')).toBe('abc');
+    expect(redirect.searchParams.get('state')).toBe(opaqueState);
   });
 });
 

--- a/packages/cloudflare-worker/tests/deployed.test.ts
+++ b/packages/cloudflare-worker/tests/deployed.test.ts
@@ -45,6 +45,7 @@ describeIfConfigured('deployed tray worker', () => {
         'GET /api/tray/:trayId/previews',
         'POST /api/tray/:trayId/supersede',
         'GET /auth/callback',
+        'GET /auth/mcp-callback',
         'POST /oauth/token',
         'POST /oauth/revoke',
         'GET /api/runtime-config',

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -1223,6 +1223,7 @@ describe('tray worker skeleton', () => {
         'GET /api/tray/:trayId/previews',
         'POST /api/tray/:trayId/supersede',
         'GET /auth/callback',
+        'GET /auth/mcp-callback',
         'POST /oauth/token',
         'POST /oauth/revoke',
         'GET /api/runtime-config',

--- a/packages/node-server/src/bridge-security.ts
+++ b/packages/node-server/src/bridge-security.ts
@@ -122,9 +122,11 @@ const CORS_BASE_ALLOW_HEADERS = [
  * Response headers the browser is allowed to read after a cross-origin
  * /api call — must include the proxy's infrastructure-error marker
  * (`isProxyError` reads `X-Proxy-Error`) and the forbidden-response
- * bridge (`decodeForbiddenResponseHeaders` reads `X-Proxy-Set-Cookie`).
+ * bridge (`decodeForbiddenResponseHeaders` reads `X-Proxy-Set-Cookie`). MCP
+ * clients also read protocol negotiation/session headers from proxy responses.
  */
-const CORS_EXPOSE_HEADERS = 'Link, X-Proxy-Error, X-Proxy-Set-Cookie';
+const CORS_EXPOSE_HEADERS =
+  'Link, X-Proxy-Error, X-Proxy-Set-Cookie, Mcp-Session-Id, MCP-Protocol-Version';
 
 /**
  * Methods exposed to the hosted leader. Must cover the FULL `/api/fetch-proxy`

--- a/packages/node-server/tests/bridge-security.test.ts
+++ b/packages/node-server/tests/bridge-security.test.ts
@@ -224,6 +224,8 @@ describe('buildCorsHeaders', () => {
     expect(headers!['Access-Control-Allow-Headers']).toContain('X-Proxy-Cookie');
     expect(headers!['Access-Control-Expose-Headers']).toContain('X-Proxy-Error');
     expect(headers!['Access-Control-Expose-Headers']).toContain('X-Proxy-Set-Cookie');
+    expect(headers!['Access-Control-Expose-Headers']).toContain('Mcp-Session-Id');
+    expect(headers!['Access-Control-Expose-Headers']).toContain('MCP-Protocol-Version');
     expect(headers!.Vary).toBe('Origin, Access-Control-Request-Headers');
   });
 

--- a/packages/swift-server/Sources/Server/BridgeSecurity.swift
+++ b/packages/swift-server/Sources/Server/BridgeSecurity.swift
@@ -105,8 +105,10 @@ enum BridgeSecurity {
     /// Response headers the browser is allowed to read after a cross-origin
     /// `/api` call — must include the proxy's infrastructure-error marker
     /// (`isProxyError` reads `X-Proxy-Error`) and the forbidden-response
-    /// bridge (`decodeForbiddenResponseHeaders` reads `X-Proxy-Set-Cookie`).
-    static let corsExposeHeaders = "Link, X-Proxy-Error, X-Proxy-Set-Cookie"
+    /// bridge (`decodeForbiddenResponseHeaders` reads `X-Proxy-Set-Cookie`). MCP
+    /// clients also read protocol negotiation/session headers from proxy responses.
+    static let corsExposeHeaders =
+        "Link, X-Proxy-Error, X-Proxy-Set-Cookie, Mcp-Session-Id, MCP-Protocol-Version"
 
     /// Methods exposed to the hosted leader. Must cover the FULL
     /// `/api/fetch-proxy` verb set (`fetchProxyMethods` in `APIRoutes.swift`):

--- a/packages/swift-server/Tests/BridgeSecurityTests.swift
+++ b/packages/swift-server/Tests/BridgeSecurityTests.swift
@@ -163,13 +163,12 @@ final class BridgeSecurityTests: XCTestCase {
     }
 
     func testBuildCorsHeadersExposesProxyResponseMarkers() {
-        // Clients read X-Proxy-Error (isProxyError) and X-Proxy-Set-Cookie
-        // (decodeForbiddenResponseHeaders) from the response, so both must be
-        // listed in Access-Control-Expose-Headers.
+        // Clients read proxy markers and MCP negotiation/session headers from
+        // the response, so all must be listed in Access-Control-Expose-Headers.
         let headers = BridgeSecurity.buildCorsHeaders(origin: "https://www.sliccy.ai")
         XCTAssertEqual(
             headers?[HTTPField.Name("Access-Control-Expose-Headers")!],
-            "Link, X-Proxy-Error, X-Proxy-Set-Cookie"
+            "Link, X-Proxy-Error, X-Proxy-Set-Cookie, Mcp-Session-Id, MCP-Protocol-Version"
         )
     }
 

--- a/packages/webapp/src/shell/mcp/client.ts
+++ b/packages/webapp/src/shell/mcp/client.ts
@@ -187,7 +187,9 @@ function rpcErrorFromFrame(
   frame: JsonRpcResponseFrame,
   expectedId: number
 ): McpRpcError | undefined {
-  if (frame.jsonrpc !== '2.0' || frame.id !== expectedId) return undefined;
+  if (frame.jsonrpc !== '2.0' || frame.id !== expectedId || Object.hasOwn(frame, 'result')) {
+    return undefined;
+  }
   const error = frame.error;
   return error && typeof error.code === 'number' && typeof error.message === 'string'
     ? error

--- a/packages/webapp/src/shell/mcp/client.ts
+++ b/packages/webapp/src/shell/mcp/client.ts
@@ -43,6 +43,16 @@ export class McpAuthRequiredError extends Error {
   }
 }
 
+class McpRpcFailure extends Error {
+  readonly rpcError: McpRpcError;
+
+  constructor(error: McpRpcError) {
+    super(`MCP RPC error ${error.code}: ${error.message}`);
+    this.name = 'McpRpcFailure';
+    this.rpcError = error;
+  }
+}
+
 /**
  * Thrown when a JSON-RPC request exceeds its per-request timeout. The
  * `mcp` shell command maps this to exit code 124 (matching GNU
@@ -165,26 +175,29 @@ function headerLookup(headers: Record<string, string>, name: string): string | u
 
 function rpcErrorFrom(error: unknown): McpRpcError | undefined {
   if (error instanceof McpHttpError) return error.rpcError;
-  if (!(error instanceof Error)) return undefined;
-  return (error as Error & { rpcError?: McpRpcError }).rpcError;
+  if (error instanceof McpRpcFailure) return error.rpcError;
+  return undefined;
 }
 
 function rpcFailure(error: McpRpcError): Error {
-  const failure = new Error(`MCP RPC error ${error.code}: ${error.message}`) as Error & {
-    rpcError: McpRpcError;
-  };
-  failure.rpcError = error;
-  return failure;
+  return new McpRpcFailure(error);
+}
+
+function rpcErrorFromFrame(
+  frame: JsonRpcResponseFrame,
+  expectedId: number
+): McpRpcError | undefined {
+  if (frame.jsonrpc !== '2.0' || frame.id !== expectedId) return undefined;
+  const error = frame.error;
+  return error && typeof error.code === 'number' && typeof error.message === 'string'
+    ? error
+    : undefined;
 }
 
 function parseRpcError(text: string, expectedId: number): McpRpcError | undefined {
   try {
     const frame = JSON.parse(text) as JsonRpcResponseFrame;
-    if (frame.jsonrpc !== '2.0' || frame.id !== expectedId) return undefined;
-    const error = frame.error;
-    return error && typeof error.code === 'number' && typeof error.message === 'string'
-      ? error
-      : undefined;
+    return rpcErrorFromFrame(frame, expectedId);
   } catch {
     return undefined;
   }
@@ -272,7 +285,10 @@ export class McpClient {
         }
         return this.discoverModern(retryVersion);
       }
-      if (err instanceof McpHttpError && err.status === 400 && rpcError?.code === -32601) {
+      const isValidatedLegacySignal =
+        rpcError?.code === -32601 &&
+        ((err instanceof McpHttpError && err.status === 400) || err instanceof McpRpcFailure);
+      if (isValidatedLegacySignal) {
         log.debug('server/discover identified a legacy server; using initialize', {
           error: err.message,
         });
@@ -416,7 +432,11 @@ export class McpClient {
       : (JSON.parse(new TextDecoder('utf-8').decode(res.body)) as JsonRpcResponseFrame);
 
     if (frame.error) {
-      throw rpcFailure(frame.error);
+      const rpcError = rpcErrorFromFrame(frame, id);
+      if (!rpcError) {
+        throw new Error(`MCP invalid JSON-RPC error response for request id ${String(id)}`);
+      }
+      throw rpcFailure(rpcError);
     }
     return frame.result;
   }

--- a/packages/webapp/src/shell/mcp/client.ts
+++ b/packages/webapp/src/shell/mcp/client.ts
@@ -19,8 +19,11 @@ const log = createLogger('mcp-client');
 /** Default per-request timeout (ms). */
 export const DEFAULT_TIMEOUT_MS = 60_000;
 
-/** Streamable-HTTP spec version negotiated on `initialize`. */
-const MCP_PROTOCOL_VERSION = '2025-06-18';
+/** Protocol revisions supported by this client, in preference order. */
+export const MCP_SUPPORTED_PROTOCOL_VERSIONS = ['2026-07-28', '2025-06-18'] as const;
+
+const MODERN_PROTOCOL_VERSION = MCP_SUPPORTED_PROTOCOL_VERSIONS[0];
+const LEGACY_PROTOCOL_VERSION = MCP_SUPPORTED_PROTOCOL_VERSIONS[1];
 
 /**
  * Thrown when the server returns HTTP 401. Carries the parsed
@@ -56,13 +59,33 @@ export class McpTimeoutError extends Error {
   }
 }
 
+class McpHttpError extends Error {
+  readonly status: number;
+  readonly rpcError: McpRpcError | undefined;
+
+  constructor(opts: {
+    status: number;
+    statusText: string;
+    method: string;
+    snippet: string;
+    rpcError?: McpRpcError;
+  }) {
+    super(
+      `MCP HTTP ${opts.status} ${opts.statusText} for ${opts.method}: ${opts.snippet || '(empty body)'}`
+    );
+    this.name = 'McpHttpError';
+    this.status = opts.status;
+    this.rpcError = opts.rpcError;
+  }
+}
+
 /** Constructor options for {@link McpClient}. */
 export interface McpClientOptions {
   /** Full server endpoint URL. */
   url: string;
   /** Static headers merged into every request (lowest precedence). */
   headers?: Record<string, string>;
-  /** Pre-existing session id to echo on the first request. */
+  /** Pre-existing session id to echo after a legacy handshake. */
   sessionId?: string;
   /** Per-request timeout in milliseconds (default 60s). */
   timeoutMs?: number;
@@ -74,7 +97,7 @@ export interface McpClientOptions {
    * sends the request without an `Authorization` header.
    */
   getAuthHeader?: () => Promise<string | null>;
-  /** Override the protocol version sent on `initialize`. */
+  /** Override the preferred protocol version used by the discovery probe. */
   protocolVersion?: string;
   /** Client identity sent on `initialize`. */
   clientInfo?: { name: string; version: string };
@@ -140,6 +163,41 @@ function headerLookup(headers: Record<string, string>, name: string): string | u
   return undefined;
 }
 
+function rpcErrorFrom(error: unknown): McpRpcError | undefined {
+  if (error instanceof McpHttpError) return error.rpcError;
+  if (!(error instanceof Error)) return undefined;
+  return (error as Error & { rpcError?: McpRpcError }).rpcError;
+}
+
+function rpcFailure(error: McpRpcError): Error {
+  const failure = new Error(`MCP RPC error ${error.code}: ${error.message}`) as Error & {
+    rpcError: McpRpcError;
+  };
+  failure.rpcError = error;
+  return failure;
+}
+
+function parseRpcError(text: string, expectedId: number): McpRpcError | undefined {
+  try {
+    const frame = JSON.parse(text) as JsonRpcResponseFrame;
+    if (frame.jsonrpc !== '2.0' || frame.id !== expectedId) return undefined;
+    const error = frame.error;
+    return error && typeof error.code === 'number' && typeof error.message === 'string'
+      ? error
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function advertisedVersions(error: McpRpcError): string[] {
+  if (!error.data || typeof error.data !== 'object') return [];
+  const supported = (error.data as { supported?: unknown }).supported;
+  return Array.isArray(supported)
+    ? supported.filter((version): version is string => typeof version === 'string')
+    : [];
+}
+
 async function defaultFetchImpl(): Promise<McpFetchLike> {
   const { createProxiedFetch } = await import('../proxied-fetch.js');
   const fn = createProxiedFetch();
@@ -164,11 +222,12 @@ export class McpClient {
   private readonly staticHeaders: Record<string, string>;
   private readonly timeoutMs: number;
   private readonly getAuthHeader?: () => Promise<string | null>;
-  private readonly protocolVersion: string;
+  private readonly preferredProtocolVersion: string;
   private readonly clientInfo: { name: string; version: string };
   private fetchImpl: McpFetchLike | null;
   private fetchImplLoader: Promise<McpFetchLike> | null = null;
   private sessionId: string | undefined;
+  private negotiatedProtocolVersion: string | undefined;
   private nextId = 1;
 
   constructor(opts: McpClientOptions) {
@@ -176,7 +235,7 @@ export class McpClient {
     this.staticHeaders = opts.headers ?? {};
     this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.getAuthHeader = opts.getAuthHeader;
-    this.protocolVersion = opts.protocolVersion ?? MCP_PROTOCOL_VERSION;
+    this.preferredProtocolVersion = opts.protocolVersion ?? MODERN_PROTOCOL_VERSION;
     this.clientInfo = opts.clientInfo ?? { name: 'SLICC', version: '0.0.0' };
     this.fetchImpl = opts.fetchImpl ?? null;
     this.sessionId = opts.sessionId;
@@ -187,13 +246,60 @@ export class McpClient {
     return this.sessionId;
   }
 
-  /** MCP `initialize` — also captures the session id from the response. */
+  /** The protocol revision selected by the discovery/initialize negotiation. */
+  getNegotiatedProtocolVersion(): string | undefined {
+    return this.negotiatedProtocolVersion;
+  }
+
+  /** Prefer stateless discovery, falling back to the legacy initialize handshake. */
   async initialize(): Promise<unknown> {
-    return this.request('initialize', {
-      protocolVersion: this.protocolVersion,
-      capabilities: {},
-      clientInfo: this.clientInfo,
-    });
+    if (this.preferredProtocolVersion === LEGACY_PROTOCOL_VERSION) {
+      return this.initializeLegacy();
+    }
+    try {
+      return await this.discoverModern(this.preferredProtocolVersion);
+    } catch (err) {
+      const rpcError = rpcErrorFrom(err);
+      if (rpcError?.code === -32022) {
+        const supported = advertisedVersions(rpcError);
+        const retryVersion = MCP_SUPPORTED_PROTOCOL_VERSIONS.find(
+          (version) => version !== LEGACY_PROTOCOL_VERSION && supported.includes(version)
+        );
+        if (!retryVersion) {
+          throw new Error(
+            `MCP server does not support a compatible modern protocol version (supported: ${supported.join(', ') || 'none'})`
+          );
+        }
+        return this.discoverModern(retryVersion);
+      }
+      if (err instanceof McpHttpError && err.status === 400 && rpcError?.code === -32601) {
+        log.debug('server/discover identified a legacy server; using initialize', {
+          error: err.message,
+        });
+        return this.initializeLegacy();
+      }
+      throw err;
+    }
+  }
+
+  private async discoverModern(protocolVersion: string): Promise<unknown> {
+    const result = (await this.request('server/discover', { protocolVersion })) as {
+      supportedVersions?: unknown;
+    } | null;
+    const supportedVersions = Array.isArray(result?.supportedVersions)
+      ? result.supportedVersions.filter((version): version is string => typeof version === 'string')
+      : [];
+    const selected = MCP_SUPPORTED_PROTOCOL_VERSIONS.find(
+      (version) => version !== LEGACY_PROTOCOL_VERSION && supportedVersions.includes(version)
+    );
+    if (!selected) {
+      throw new Error(
+        `MCP server discovery did not advertise a compatible modern protocol version (advertised: ${supportedVersions.join(', ') || 'none'})`
+      );
+    }
+    this.negotiatedProtocolVersion = selected;
+    this.sessionId = undefined;
+    return result;
   }
 
   /** MCP `tools/list` — returns the `tools` array (empty if absent). */
@@ -233,7 +339,11 @@ export class McpClient {
     // Per the MCP Streamable-HTTP spec the session id is established BY the
     // server's response to `initialize`; sending one in is a protocol
     // violation. All subsequent methods echo the captured id.
-    if (this.sessionId && method !== 'initialize') {
+    if (
+      this.negotiatedProtocolVersion === LEGACY_PROTOCOL_VERSION &&
+      this.sessionId &&
+      method !== 'initialize'
+    ) {
       headers['Mcp-Session-Id'] = this.sessionId;
     }
     if (this.getAuthHeader) {
@@ -284,14 +394,20 @@ export class McpClient {
       });
     }
 
-    const sid = headerLookup(res.headers, 'mcp-session-id');
-    if (sid) this.sessionId = sid;
+    if (this.negotiatedProtocolVersion === LEGACY_PROTOCOL_VERSION) {
+      const sid = headerLookup(res.headers, 'mcp-session-id');
+      if (sid) this.sessionId = sid;
+    }
 
     if (res.status >= 400) {
-      const snippet = new TextDecoder('utf-8').decode(res.body).slice(0, 512);
-      throw new Error(
-        `MCP HTTP ${res.status} ${res.statusText} for ${method}: ${snippet || '(empty body)'}`
-      );
+      const text = new TextDecoder('utf-8').decode(res.body);
+      throw new McpHttpError({
+        status: res.status,
+        statusText: res.statusText,
+        method,
+        snippet: text.slice(0, 512),
+        rpcError: parseRpcError(text, id),
+      });
     }
 
     const ct = headerLookup(res.headers, 'content-type') ?? '';
@@ -300,12 +416,7 @@ export class McpClient {
       : (JSON.parse(new TextDecoder('utf-8').decode(res.body)) as JsonRpcResponseFrame);
 
     if (frame.error) {
-      const err = frame.error;
-      const e = new Error(`MCP RPC error ${err.code}: ${err.message}`) as Error & {
-        rpcError: McpRpcError;
-      };
-      e.rpcError = err;
-      throw e;
+      throw rpcFailure(frame.error);
     }
     return frame.result;
   }
@@ -319,5 +430,14 @@ export class McpClient {
       });
     }
     return this.fetchImplLoader;
+  }
+
+  private async initializeLegacy(): Promise<unknown> {
+    this.negotiatedProtocolVersion = LEGACY_PROTOCOL_VERSION;
+    return this.request('initialize', {
+      protocolVersion: LEGACY_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: this.clientInfo,
+    });
   }
 }

--- a/packages/webapp/src/shell/mcp/provider.ts
+++ b/packages/webapp/src/shell/mcp/provider.ts
@@ -10,7 +10,6 @@
  */
 
 import { createLogger } from '../../core/logger.js';
-import { isExtensionRealm } from '../../core/runtime-env.js';
 import {
   getAccounts,
   getOAuthAccountInfo,
@@ -30,6 +29,7 @@ import {
   runAuthFlow,
 } from './oauth.js';
 import { type McpAuthEntry, readMcpAuthEntry } from './provider-store-access.js';
+import { resolveMcpRedirectUri } from './redirect-uri.js';
 
 const log = createLogger('mcp-provider');
 
@@ -78,27 +78,6 @@ const discoveryCache = new Map<string, DiscoveredAuth>();
 
 /** Track which providers we've already registered in this page session. */
 const registeredInSession = new Set<string>();
-
-async function defaultRedirectUri(): Promise<string> {
-  // Extension offscreen runtime: chrome.identity.launchWebAuthFlow only
-  // completes against the deterministic `<extension-id>.chromiumapp.org`
-  // redirect, so the URI registered at DCR time must match.
-  if (isExtensionRealm()) {
-    const chromeApi = chrome as unknown as {
-      identity?: { getRedirectURL?: (path?: string) => string };
-      runtime?: { id?: string };
-    };
-    return (
-      chromeApi.identity?.getRedirectURL?.('mcp-callback') ??
-      `https://${chromeApi.runtime?.id ?? ''}.chromiumapp.org/mcp-callback`
-    );
-  }
-  // CLI / standalone: the popup→postMessage + /api/oauth-result polling
-  // path captures the redirect on the page origin.
-  const { getOAuthPageOrigin } = await import('../../providers/oauth-service.js');
-  const { origin } = await getOAuthPageOrigin();
-  return `${origin}/auth/callback`;
-}
 
 async function resolveFetchImpl(override?: FetchLike): Promise<FetchLike> {
   if (override) return override;
@@ -163,7 +142,7 @@ function buildProviderConfig(opts: RegisterMcpProviderOptions): ProviderConfig {
         asMetadata,
         clientId: opts.auth.clientId,
         scope: opts.auth.scope,
-        redirectUri: await defaultRedirectUri(),
+        redirectUri: opts.auth.redirectUri ?? (await resolveMcpRedirectUri()),
         launcher: effectiveLauncher,
         fetchImpl,
       });
@@ -244,13 +223,16 @@ export function registerMcpProvider(opts: RegisterMcpProviderOptions): void {
  * (now) registered, false if there is no matching server entry or it has
  * no `auth` block yet (e.g. `mcp add` failed before persisting auth).
  */
-export async function ensureMcpProviderRegistered(name: string): Promise<boolean> {
+export async function ensureMcpProviderRegistered(
+  name: string,
+  overrides: Pick<RegisterMcpProviderOptions, 'fetchImpl' | 'launcher'> = {}
+): Promise<boolean> {
   const id = mcpProviderId(name);
   if (registeredInSession.has(id) && getRegisteredProviderConfig(id)) return true;
   if (!hasIndexedDB()) return false;
   const entry = await readMcpAuthEntry(name);
   if (!entry) return false;
-  registerMcpProvider({ name, serverUrl: entry.serverUrl, auth: entry.auth });
+  registerMcpProvider({ name, serverUrl: entry.serverUrl, auth: entry.auth, ...overrides });
   return true;
 }
 

--- a/packages/webapp/src/shell/mcp/redirect-uri.ts
+++ b/packages/webapp/src/shell/mcp/redirect-uri.ts
@@ -1,0 +1,29 @@
+import { resolveFloatTopology } from '../../core/float-topology.js';
+
+/** Hosted callback that treats MCP OAuth `state` as an opaque value. */
+export const MCP_HOSTED_CALLBACK_PATH = '/auth/mcp-callback';
+
+/** Resolve the redirect URI shared by MCP DCR and subsequent OAuth flows. */
+export async function resolveMcpRedirectUri(): Promise<string> {
+  const topology = resolveFloatTopology();
+  if (topology === 'extension-direct') {
+    const chromeApi = chrome as unknown as {
+      identity?: { getRedirectURL?: (path?: string) => string };
+      runtime?: { id?: string };
+    };
+    return (
+      chromeApi.identity?.getRedirectURL?.('mcp-callback') ??
+      `https://${chromeApi.runtime?.id ?? ''}.chromiumapp.org/mcp-callback`
+    );
+  }
+
+  if (topology === 'node-rest') {
+    const { getLocalApiBaseUrl } = await import('../proxied-fetch.js');
+    const localApiOrigin = getLocalApiBaseUrl();
+    if (localApiOrigin) return `${localApiOrigin}/auth/callback`;
+  }
+
+  const { getOAuthPageOrigin } = await import('../../providers/oauth-service.js');
+  const { origin } = await getOAuthPageOrigin();
+  return `${origin}${topology === 'extension-delegate' ? MCP_HOSTED_CALLBACK_PATH : '/auth/callback'}`;
+}

--- a/packages/webapp/src/shell/mcp/store.ts
+++ b/packages/webapp/src/shell/mcp/store.ts
@@ -58,6 +58,14 @@ function emptyFile(): McpServersFile {
   return { version: CURRENT_VERSION, servers: {} };
 }
 
+function normalizeEntry(raw: unknown): McpServerEntry | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const entry = { ...(raw as Record<string, unknown>) };
+  if (typeof entry.url !== 'string') return null;
+  delete entry.sessionId;
+  return entry as unknown as McpServerEntry;
+}
+
 function normalize(raw: unknown): McpServersFile {
   if (!raw || typeof raw !== 'object') return emptyFile();
   const obj = raw as Partial<McpServersFile> & { servers?: unknown };
@@ -65,10 +73,8 @@ function normalize(raw: unknown): McpServersFile {
   const servers: Record<string, McpServerEntry> = {};
   if (obj.servers && typeof obj.servers === 'object') {
     for (const [name, entry] of Object.entries(obj.servers as Record<string, unknown>)) {
-      if (!entry || typeof entry !== 'object') continue;
-      const e = entry as McpServerEntry & Record<string, unknown>;
-      if (typeof e.url !== 'string') continue;
-      servers[name] = e;
+      const normalized = normalizeEntry(entry);
+      if (normalized) servers[name] = normalized;
     }
   }
   return { version, servers };
@@ -103,10 +109,10 @@ export async function writeServersFile(
 ): Promise<void> {
   const fs = await openFs(injectedFs);
   await fs.mkdir(MCP_DIR, { recursive: true });
-  const payload: McpServersFile = {
+  const payload = normalize({
     version: file.version || CURRENT_VERSION,
     servers: file.servers ?? {},
-  };
+  });
   await fs.writeFile(MCP_STORE_PATH, JSON.stringify(payload, null, 2));
 }
 
@@ -126,7 +132,8 @@ export async function setServer(
   injectedFs?: MinimalFs | null
 ): Promise<McpServerEntry> {
   const file = await readServersFile(injectedFs);
-  const merged: McpServerEntry = { ...file.servers[name], ...entry };
+  const merged = normalizeEntry({ ...file.servers[name], ...entry });
+  if (!merged) throw new Error('MCP server entry requires a URL');
   file.servers[name] = merged;
   await writeServersFile(file, injectedFs);
   return merged;

--- a/packages/webapp/src/shell/mcp/types.ts
+++ b/packages/webapp/src/shell/mcp/types.ts
@@ -30,6 +30,8 @@ export interface McpAuthEntry {
   providerId: string;
   authorizationServer: string;
   clientId: string;
+  /** Exact redirect URI registered with the authorization server. */
+  redirectUri?: string;
   scope?: string;
   registrationClientUri?: string;
 }

--- a/packages/webapp/src/shell/mcp/types.ts
+++ b/packages/webapp/src/shell/mcp/types.ts
@@ -44,8 +44,8 @@ export interface McpServerAuthRecord {
 /** Full persisted entry for one server in `servers.json`. */
 export interface McpServerEntry {
   url: string;
+  protocolVersion?: string;
   headers?: Record<string, string>;
-  sessionId?: string;
   tools?: McpToolDef[];
   apps?: McpAppDef[];
   addedAt?: string;

--- a/packages/webapp/src/shell/supplemental-commands/mcp-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/mcp-command.ts
@@ -19,11 +19,11 @@
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import { createLogger } from '../../core/logger.js';
-import { isExtensionRealm } from '../../core/runtime-env.js';
 import type { VirtualFS } from '../../fs/index.js';
 import type { OAuthLauncher } from '../../providers/types.js';
 import { McpTimeoutError } from '../mcp/client.js';
 import type { FetchLike } from '../mcp/oauth.js';
+import { resolveMcpRedirectUri } from '../mcp/redirect-uri.js';
 import type { McpAppDef, McpFetchLike, McpServerEntry, McpToolDef } from '../mcp/types.js';
 import type { ScriptCatalog } from '../script-catalog.js';
 
@@ -247,7 +247,7 @@ async function runOAuthForAdd(
     discoveryPath: asMetadata.discoveryPath,
     issuer: asMetadata.issuer,
   });
-  const redirectUri = await defaultRedirectUri();
+  const redirectUri = await resolveMcpRedirectUri();
   const dcr = await dynamicRegister(asMetadata, redirectUri, fetchImpl);
   const scope =
     asMetadata.supportedScopes && asMetadata.supportedScopes.length > 0
@@ -276,6 +276,7 @@ async function runOAuthForAdd(
     providerId,
     authorizationServer: asMetadata.issuer,
     clientId: dcr.clientId,
+    redirectUri,
     scope: token.scope ?? scope,
     registrationClientUri: dcr.registrationClientUri,
   };
@@ -887,7 +888,10 @@ Options:
   }
 
   const { ensureMcpProviderRegistered } = await import('../mcp/provider.js');
-  const registered = await ensureMcpProviderRegistered(name);
+  const registered = await ensureMcpProviderRegistered(name, {
+    fetchImpl: deps.oauthFetchImpl,
+    launcher: deps.oauthLauncher,
+  });
 
   const { getServer } = await import('../mcp/store.js');
   const entry = await getServer(name, deps.fs);
@@ -996,36 +1000,6 @@ async function getMcpBearerHeader(name: string): Promise<string | null> {
 async function defaultLauncher(): Promise<OAuthLauncher> {
   const { createOAuthLauncher } = await import('../../providers/oauth-service.js');
   return createOAuthLauncher();
-}
-
-async function defaultRedirectUri(): Promise<string> {
-  // Extension offscreen runtime: the OAuth launcher routes through
-  // `chrome.identity.launchWebAuthFlow`, which only captures redirects
-  // matching the deterministic `<extension-id>.chromiumapp.org` URL.
-  // Both the authorize URL and the token-exchange redirect_uri must use
-  // the same value (RFC 6749 §10.6).
-  if (isExtensionRealm()) {
-    const chromeApi = chrome as unknown as {
-      identity?: { getRedirectURL?: (path?: string) => string };
-      runtime?: { id?: string };
-    };
-    return (
-      chromeApi.identity?.getRedirectURL?.('mcp-callback') ??
-      `https://${chromeApi.runtime?.id ?? ''}.chromiumapp.org/mcp-callback`
-    );
-  }
-  // Thin-bridge standalone: register the local node-server callback, not the
-  // hosted UI origin. The worker's /auth/callback route consumes a structured
-  // relay state, while MCP OAuth uses its own opaque CSRF state.
-  const { getLocalApiBaseUrl } = await import('../proxied-fetch.js');
-  const localApiOrigin = getLocalApiBaseUrl();
-  if (localApiOrigin) return `${localApiOrigin}/auth/callback`;
-
-  // Same-origin webapp: the popup→postMessage path captures the redirect on
-  // the page origin.
-  const { getOAuthPageOrigin } = await import('../../providers/oauth-service.js');
-  const { origin } = await getOAuthPageOrigin();
-  return `${origin}/auth/callback`;
 }
 
 async function resolveOAuthFetchImpl(override?: FetchLike): Promise<FetchLike> {

--- a/packages/webapp/src/shell/supplemental-commands/mcp-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/mcp-command.ts
@@ -199,6 +199,7 @@ short name resolves on the PATH.
   // id on the next `initialize` is a Streamable-HTTP protocol violation.
   const entry: McpServerEntry = {
     url,
+    protocolVersion: client.getNegotiatedProtocolVersion(),
     tools,
     apps,
     addedAt: now,
@@ -842,13 +843,9 @@ OAuth tokens — for OAuth token refresh use \`mcp auth <name>\`.
   }
   const tools = await client.toolsList();
   const apps = await client.appsList();
-  // Drop any previously persisted `sessionId` — it's per-process state on
-  // the server and unsafe to re-send on the next `initialize`. Setting it
-  // to `undefined` ensures JSON.stringify in `writeServersFile` drops it
-  // even though `setServer` shallow-merges with the existing record.
   const merged: McpServerEntry = {
     ...entry,
-    sessionId: undefined,
+    protocolVersion: client.getNegotiatedProtocolVersion(),
     tools,
     apps,
     lastRefreshedAt: new Date().toISOString(),

--- a/packages/webapp/src/shell/supplemental-commands/mcp-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/mcp-command.ts
@@ -1017,8 +1017,15 @@ async function defaultRedirectUri(): Promise<string> {
       `https://${chromeApi.runtime?.id ?? ''}.chromiumapp.org/mcp-callback`
     );
   }
-  // CLI / standalone webapp: the popup→postMessage + /api/oauth-result
-  // polling path captures the redirect on the page origin.
+  // Thin-bridge standalone: register the local node-server callback, not the
+  // hosted UI origin. The worker's /auth/callback route consumes a structured
+  // relay state, while MCP OAuth uses its own opaque CSRF state.
+  const { getLocalApiBaseUrl } = await import('../proxied-fetch.js');
+  const localApiOrigin = getLocalApiBaseUrl();
+  if (localApiOrigin) return `${localApiOrigin}/auth/callback`;
+
+  // Same-origin webapp: the popup→postMessage path captures the redirect on
+  // the page origin.
   const { getOAuthPageOrigin } = await import('../../providers/oauth-service.js');
   const { origin } = await getOAuthPageOrigin();
   return `${origin}/auth/callback`;

--- a/packages/webapp/tests/shell/mcp/client.test.ts
+++ b/packages/webapp/tests/shell/mcp/client.test.ts
@@ -214,6 +214,28 @@ describe('McpClient: protocol negotiation', () => {
     expect(c.getSessionId()).toBe('legacy-session');
   });
 
+  it('falls back on a validated HTTP 200 method-not-found response', async () => {
+    const { fetchImpl, calls } = stubFetch((_url, init) => {
+      const sent = JSON.parse(init?.body ?? '{}') as { id: number; method: string };
+      return sent.method === 'server/discover'
+        ? { body: jsonRpcError(sent.id, -32601, 'Method not found') }
+        : {
+            headers: { 'content-type': 'application/json', 'Mcp-Session-Id': 'legacy-session' },
+            body: jsonRpc(sent.id, { protocolVersion: '2025-06-18' }),
+          };
+    });
+    const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
+
+    await c.initialize();
+
+    expect(calls.map((call) => JSON.parse(call.init!.body!).method)).toEqual([
+      'server/discover',
+      'initialize',
+    ]);
+    expect(c.getNegotiatedProtocolVersion()).toBe('2025-06-18');
+    expect(c.getSessionId()).toBe('legacy-session');
+  });
+
   it('retries a mutually supported modern version when discovery returns -32022', async () => {
     const { fetchImpl, calls } = stubFetch((_url, init) => {
       const sent = JSON.parse(init?.body ?? '{}') as {
@@ -311,6 +333,28 @@ describe('McpClient: protocol negotiation', () => {
     const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
 
     await expect(c.initialize()).rejects.toThrow(/MCP HTTP 400/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it.each([
+    ['mismatched request id', (id: number) => jsonRpcError(id + 1, -32601, 'Method not found')],
+    [
+      'invalid JSON-RPC envelope',
+      (id: number) =>
+        JSON.stringify({
+          jsonrpc: '1.0',
+          id,
+          error: { code: -32601, message: 'Method not found' },
+        }),
+    ],
+  ])('does not fall back on an HTTP 200 %s', async (_label, responseBody) => {
+    const { fetchImpl, calls } = stubFetch((_url, init) => {
+      const sent = JSON.parse(init?.body ?? '{}') as { id: number };
+      return { body: responseBody(sent.id) };
+    });
+    const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
+
+    await expect(c.initialize()).rejects.toThrow(/invalid JSON-RPC error response/);
     expect(calls).toHaveLength(1);
   });
 

--- a/packages/webapp/tests/shell/mcp/client.test.ts
+++ b/packages/webapp/tests/shell/mcp/client.test.ts
@@ -339,6 +339,16 @@ describe('McpClient: protocol negotiation', () => {
   it.each([
     ['mismatched request id', (id: number) => jsonRpcError(id + 1, -32601, 'Method not found')],
     [
+      'result and error fields',
+      (id: number) =>
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id,
+          result: {},
+          error: { code: -32601, message: 'Method not found' },
+        }),
+    ],
+    [
       'invalid JSON-RPC envelope',
       (id: number) =>
         JSON.stringify({

--- a/packages/webapp/tests/shell/mcp/client.test.ts
+++ b/packages/webapp/tests/shell/mcp/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_TIMEOUT_MS,
+  MCP_SUPPORTED_PROTOCOL_VERSIONS,
   McpAuthRequiredError,
   McpClient,
   McpTimeoutError,
@@ -44,6 +45,14 @@ function stubFetch(responder: (url: string, init: Parameters<McpFetchLike>[1]) =
 
 function jsonRpc(id: number, result: unknown): string {
   return JSON.stringify({ jsonrpc: '2.0', id, result });
+}
+
+function jsonRpcError(id: number, code: number, message: string, data?: unknown): string {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id,
+    error: { code, message, ...(data === undefined ? {} : { data }) },
+  });
 }
 
 function sseFrames(frames: string[]): string {
@@ -94,15 +103,23 @@ describe('selectSseResponseFrame', () => {
 
 describe('McpClient: JSON response path', () => {
   it('POSTs JSON-RPC and returns the result on a plain JSON response', async () => {
-    const { fetchImpl, calls } = stubFetch(() => ({
-      headers: { 'content-type': 'application/json' },
-      body: jsonRpc(1, { protocolVersion: '2025-06-18' }),
-    }));
+    const { fetchImpl, calls } = stubFetch((_url, init) => {
+      const sent = JSON.parse(init?.body ?? '{}') as { id: number; method: string };
+      return {
+        status: sent.method === 'server/discover' ? 400 : 200,
+        statusText: sent.method === 'server/discover' ? 'Bad Request' : 'OK',
+        headers: { 'content-type': 'application/json' },
+        body:
+          sent.method === 'server/discover'
+            ? jsonRpcError(sent.id, -32601, 'Method not found')
+            : jsonRpc(sent.id, { protocolVersion: '2025-06-18' }),
+      };
+    });
     const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
     const result = await c.initialize();
     expect(result).toEqual({ protocolVersion: '2025-06-18' });
-    expect(calls).toHaveLength(1);
-    const init = calls[0].init!;
+    expect(calls).toHaveLength(2);
+    const init = calls[1].init!;
     expect(init.method).toBe('POST');
     expect(init.headers!['Content-Type']).toBe('application/json');
     expect(init.headers!['Accept']).toContain('application/json');
@@ -110,11 +127,13 @@ describe('McpClient: JSON response path', () => {
     const sent = JSON.parse(init.body!);
     expect(sent.jsonrpc).toBe('2.0');
     expect(sent.method).toBe('initialize');
-    expect(sent.id).toBe(1);
+    expect(sent.id).toBe(2);
   });
 
   it('threads getAuthHeader into the Authorization header', async () => {
-    const { fetchImpl, calls } = stubFetch(() => ({ body: jsonRpc(1, {}) }));
+    const { fetchImpl, calls } = stubFetch(() => ({
+      body: jsonRpc(1, { supportedVersions: ['2026-07-28'] }),
+    }));
     const c = new McpClient({
       url: 'https://mcp.example/rpc',
       fetchImpl,
@@ -134,6 +153,202 @@ describe('McpClient: JSON response path', () => {
     }));
     const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
     await expect(c.toolsList()).rejects.toThrow(/-32601/);
+  });
+});
+
+describe('McpClient: protocol negotiation', () => {
+  it('exports supported revisions in preference order', () => {
+    expect(MCP_SUPPORTED_PROTOCOL_VERSIONS).toEqual(['2026-07-28', '2025-06-18']);
+  });
+
+  it('selects 2026-07-28 from server/discover without a legacy initialize', async () => {
+    const { fetchImpl, calls } = stubFetch((_url, init) => {
+      const sent = JSON.parse(init?.body ?? '{}') as { id: number; method: string };
+      return sent.method === 'server/discover'
+        ? {
+            headers: { 'content-type': 'application/json', 'Mcp-Session-Id': 'must-ignore' },
+            body: jsonRpc(sent.id, { supportedVersions: ['2026-07-28', '2025-06-18'] }),
+          }
+        : {
+            headers: { 'content-type': 'application/json', 'Mcp-Session-Id': 'also-ignore' },
+            body: jsonRpc(sent.id, { tools: [] }),
+          };
+    });
+    const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
+
+    await c.initialize();
+
+    await c.toolsList();
+
+    expect(calls).toHaveLength(2);
+    expect(JSON.parse(calls[0].init!.body!).method).toBe('server/discover');
+    expect(calls[1].init!.headers!['Mcp-Session-Id']).toBeUndefined();
+    expect(c.getNegotiatedProtocolVersion()).toBe('2026-07-28');
+    expect(c.getSessionId()).toBeUndefined();
+  });
+
+  it('falls back to the legacy initialize handshake when discovery is unsupported', async () => {
+    const { fetchImpl, calls } = stubFetch((_url, init) => {
+      const sent = JSON.parse(init?.body ?? '{}') as { id: number; method: string };
+      return sent.method === 'server/discover'
+        ? {
+            status: 400,
+            statusText: 'Bad Request',
+            body: jsonRpcError(sent.id, -32601, 'Method not found'),
+          }
+        : {
+            headers: { 'content-type': 'application/json', 'Mcp-Session-Id': 'legacy-session' },
+            body: jsonRpc(sent.id, { protocolVersion: '2025-06-18' }),
+          };
+    });
+    const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
+
+    await c.initialize();
+
+    expect(calls.map((call) => JSON.parse(call.init!.body!).method)).toEqual([
+      'server/discover',
+      'initialize',
+    ]);
+    expect(JSON.parse(calls[1].init!.body!).params.protocolVersion).toBe('2025-06-18');
+    expect(c.getNegotiatedProtocolVersion()).toBe('2025-06-18');
+    expect(c.getSessionId()).toBe('legacy-session');
+  });
+
+  it('retries a mutually supported modern version when discovery returns -32022', async () => {
+    const { fetchImpl, calls } = stubFetch((_url, init) => {
+      const sent = JSON.parse(init?.body ?? '{}') as {
+        id: number;
+        params: { protocolVersion: string };
+      };
+      return sent.params.protocolVersion === '2099-01-01'
+        ? {
+            status: 400,
+            statusText: 'Bad Request',
+            body: jsonRpcError(sent.id, -32022, 'Unsupported protocol version', {
+              supported: ['2026-07-28', '2025-06-18'],
+              requested: '2099-01-01',
+            }),
+          }
+        : { body: jsonRpc(sent.id, { supportedVersions: ['2026-07-28'] }) };
+    });
+    const c = new McpClient({
+      url: 'https://mcp.example/rpc',
+      fetchImpl,
+      protocolVersion: '2099-01-01',
+    });
+
+    await c.initialize();
+
+    expect(calls).toHaveLength(2);
+    expect(calls.map((call) => JSON.parse(call.init!.body!).method)).toEqual([
+      'server/discover',
+      'server/discover',
+    ]);
+    expect(JSON.parse(calls[1].init!.body!).params.protocolVersion).toBe('2026-07-28');
+    expect(c.getNegotiatedProtocolVersion()).toBe('2026-07-28');
+  });
+
+  it('does not fall back when -32022 advertises no compatible modern version', async () => {
+    const { fetchImpl, calls } = stubFetch((_url, init) => {
+      const sent = JSON.parse(init?.body ?? '{}') as { id: number };
+      return {
+        status: 400,
+        statusText: 'Bad Request',
+        body: jsonRpcError(sent.id, -32022, 'Unsupported protocol version', {
+          supported: ['2025-06-18'],
+        }),
+      };
+    });
+    const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
+
+    await expect(c.initialize()).rejects.toThrow(/compatible modern protocol version/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('does not fall back on transport or HTTP 5xx failures', async () => {
+    const network = stubFetch(() => {
+      throw new TypeError('network unavailable');
+    });
+    await expect(
+      new McpClient({ url: 'https://mcp.example/rpc', fetchImpl: network.fetchImpl }).initialize()
+    ).rejects.toThrow('network unavailable');
+    expect(network.calls).toHaveLength(1);
+
+    const unavailable = stubFetch(() => ({
+      status: 503,
+      statusText: 'Service Unavailable',
+      body: 'temporarily unavailable',
+    }));
+    await expect(
+      new McpClient({
+        url: 'https://mcp.example/rpc',
+        fetchImpl: unavailable.fetchImpl,
+      }).initialize()
+    ).rejects.toThrow(/MCP HTTP 503/);
+    expect(unavailable.calls).toHaveLength(1);
+  });
+
+  it('does not fall back on a malformed successful discovery response', async () => {
+    const { fetchImpl, calls } = stubFetch(() => ({ body: 'not-json' }));
+    const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
+
+    await expect(c.initialize()).rejects.toThrow();
+    expect(calls).toHaveLength(1);
+  });
+
+  it.each([
+    ['unparseable', 'not-json'],
+    [
+      'invalid JSON-RPC envelope',
+      JSON.stringify({ error: { code: -32601, message: 'Method not found' } }),
+    ],
+  ])('does not fall back on an %s HTTP 400 response', async (_label, body) => {
+    const { fetchImpl, calls } = stubFetch(() => ({
+      status: 400,
+      statusText: 'Bad Request',
+      body,
+    }));
+    const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
+
+    await expect(c.initialize()).rejects.toThrow(/MCP HTTP 400/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it.each([-32020, -32021, -32602])('does not fall back on JSON-RPC error %i', async (code) => {
+    const { fetchImpl, calls } = stubFetch((_url, init) => {
+      const sent = JSON.parse(init?.body ?? '{}') as { id: number };
+      return {
+        status: 400,
+        statusText: 'Bad Request',
+        body: jsonRpcError(sent.id, code, 'Not a legacy-era signal'),
+      };
+    });
+    const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
+
+    await expect(c.initialize()).rejects.toThrow(/MCP HTTP 400/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('does not fall back when discovery times out', async () => {
+    vi.useFakeTimers();
+    try {
+      let callCount = 0;
+      const fetchImpl: McpFetchLike = (_url, init) => {
+        callCount++;
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        });
+      };
+      const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl, timeoutMs: 50 });
+      const pending = c.initialize();
+      const assertion = expect(pending).rejects.toBeInstanceOf(McpTimeoutError);
+
+      await vi.advanceTimersByTimeAsync(60);
+      await assertion;
+      expect(callCount).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -163,32 +378,48 @@ describe('McpClient: Mcp-Session-Id round-trip', () => {
       callCount++;
       if (callCount === 1) {
         return {
-          headers: { 'content-type': 'application/json', 'Mcp-Session-Id': 'sess-1' },
-          body: jsonRpc(1, {}),
+          status: 400,
+          statusText: 'Bad Request',
+          body: jsonRpcError(1, -32601, 'Method not found'),
         };
       }
-      return { body: jsonRpc(2, { tools: [] }) };
+      if (callCount === 2) {
+        return {
+          headers: { 'content-type': 'application/json', 'Mcp-Session-Id': 'sess-1' },
+          body: jsonRpc(2, {}),
+        };
+      }
+      return { body: jsonRpc(3, { tools: [] }) };
     });
     const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
     await c.initialize();
     expect(c.getSessionId()).toBe('sess-1');
     await c.toolsList();
-    expect(calls[1].init!.headers!['Mcp-Session-Id']).toBe('sess-1');
+    expect(calls[2].init!.headers!['Mcp-Session-Id']).toBe('sess-1');
   });
 
   it('does NOT attach Mcp-Session-Id on the initialize request even when constructor was given a stale id', async () => {
-    const { fetchImpl, calls } = stubFetch(() => ({
-      headers: { 'content-type': 'application/json', 'Mcp-Session-Id': 'srv-fresh' },
-      body: jsonRpc(1, {}),
-    }));
+    const { fetchImpl, calls } = stubFetch((_url, init) => {
+      const sent = JSON.parse(init?.body ?? '{}') as { id: number; method: string };
+      return sent.method === 'server/discover'
+        ? {
+            status: 400,
+            statusText: 'Bad Request',
+            body: jsonRpcError(sent.id, -32601, 'Method not found'),
+          }
+        : {
+            headers: { 'content-type': 'application/json', 'Mcp-Session-Id': 'srv-fresh' },
+            body: jsonRpc(sent.id, {}),
+          };
+    });
     const c = new McpClient({
       url: 'https://mcp.example/rpc',
       fetchImpl,
       sessionId: 'stale-123',
     });
     await c.initialize();
-    expect(calls).toHaveLength(1);
-    expect(calls[0].init!.headers!['Mcp-Session-Id']).toBeUndefined();
+    expect(calls).toHaveLength(2);
+    expect(calls[1].init!.headers!['Mcp-Session-Id']).toBeUndefined();
     // The response-provided session id wins over the stale constructor value.
     expect(c.getSessionId()).toBe('srv-fresh');
   });
@@ -199,20 +430,27 @@ describe('McpClient: Mcp-Session-Id round-trip', () => {
       callCount++;
       if (callCount === 1) {
         return {
+          status: 400,
+          statusText: 'Bad Request',
+          body: jsonRpcError(1, -32601, 'Method not found'),
+        };
+      }
+      if (callCount === 2) {
+        return {
           headers: { 'content-type': 'application/json', 'Mcp-Session-Id': 'srv-abc' },
-          body: jsonRpc(1, {}),
+          body: jsonRpc(2, {}),
         };
       }
       return {
-        body: jsonRpc(2, { content: [{ type: 'text', text: 'ok' }] }),
+        body: jsonRpc(3, { content: [{ type: 'text', text: 'ok' }] }),
       };
     });
     const c = new McpClient({ url: 'https://mcp.example/rpc', fetchImpl });
     await c.initialize();
     await c.toolsCall('echo', { msg: 'hi' });
-    expect(calls).toHaveLength(2);
+    expect(calls).toHaveLength(3);
     expect(calls[0].init!.headers!['Mcp-Session-Id']).toBeUndefined();
-    expect(calls[1].init!.headers!['Mcp-Session-Id']).toBe('srv-abc');
+    expect(calls[2].init!.headers!['Mcp-Session-Id']).toBe('srv-abc');
   });
 });
 

--- a/packages/webapp/tests/shell/mcp/store.test.ts
+++ b/packages/webapp/tests/shell/mcp/store.test.ts
@@ -39,7 +39,6 @@ describe('mcp store', () => {
   it('round-trips writeServersFile → readServersFile', async () => {
     const entry: McpServerEntry = {
       url: 'https://mcp.example.com',
-      sessionId: 'sess-1',
       tools: [{ name: 'echo', description: 'Echo a string' }],
       apps: [{ name: 'demo', title: 'Demo' }],
       addedAt: '2026-05-20T00:00:00.000Z',
@@ -103,11 +102,51 @@ describe('mcp store', () => {
   it('setServer + getServer + deleteServer behave as expected', async () => {
     await setServer('demo', { url: 'https://a.example' });
     expect((await getServer('demo'))?.url).toBe('https://a.example');
-    await setServer('demo', { url: 'https://a.example', sessionId: 'sid-1' });
-    expect((await getServer('demo'))?.sessionId).toBe('sid-1');
+    await setServer('demo', { url: 'https://a.example', tools: [{ name: 'echo' }] });
+    expect((await getServer('demo'))?.tools).toEqual([{ name: 'echo' }]);
     expect(await deleteServer('demo')).toBe(true);
     expect(await deleteServer('demo')).toBe(false);
     expect(await getServer('demo')).toBeNull();
+  });
+
+  it('tolerates legacy sessionId fields but scrubs them from reads and writes', async () => {
+    const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+    await fs.mkdir('/workspace/.mcp', { recursive: true });
+    const legacyEntry = {
+      url: 'https://mcp.example.com',
+      sessionId: 'stale-session',
+      unknownField: 'preserved',
+    };
+    await fs.writeFile(
+      MCP_STORE_PATH,
+      JSON.stringify({ version: 1, servers: { demo: legacyEntry } })
+    );
+
+    const loaded = await readServersFile();
+    expect((loaded.servers.demo as unknown as Record<string, unknown>).sessionId).toBeUndefined();
+    expect((loaded.servers.demo as unknown as Record<string, unknown>).unknownField).toBe(
+      'preserved'
+    );
+
+    await writeServersFile({
+      version: 1,
+      servers: { demo: legacyEntry as unknown as McpServerEntry },
+    });
+    let raw = JSON.parse((await fs.readFile(MCP_STORE_PATH, { encoding: 'utf-8' })) as string) as {
+      servers: Record<string, Record<string, unknown>>;
+    };
+    expect(raw.servers.demo.sessionId).toBeUndefined();
+
+    await fs.writeFile(
+      MCP_STORE_PATH,
+      JSON.stringify({ version: 1, servers: { demo: legacyEntry } })
+    );
+    await setServer('demo', { url: legacyEntry.url, tools: [{ name: 'echo' }] });
+    raw = JSON.parse((await fs.readFile(MCP_STORE_PATH, { encoding: 'utf-8' })) as string) as {
+      servers: Record<string, Record<string, unknown>>;
+    };
+    expect(raw.servers.demo.sessionId).toBeUndefined();
+    expect(raw.servers.demo.unknownField).toBe('preserved');
   });
 
   it('listServers returns every entry', async () => {

--- a/packages/webapp/tests/shell/supplemental-commands/mcp-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/mcp-command.test.ts
@@ -45,6 +45,7 @@ import {
 } from '../../../src/shell/mcp/provider.js';
 import {
   testOnlyResetStoreCache as _testOnly_resetStoreCache,
+  MCP_STORE_PATH,
   readServersFile,
   setServer,
 } from '../../../src/shell/mcp/store.js';
@@ -84,9 +85,21 @@ interface MockServerOptions {
 
 function makeMockMcpFetch(opts: MockServerOptions): {
   fetch: McpFetchLike;
-  calls: Array<{ url: string; method: string; body?: RpcBody; auth?: string }>;
+  calls: Array<{
+    url: string;
+    method: string;
+    body?: RpcBody;
+    auth?: string;
+    sessionId?: string;
+  }>;
 } {
-  const calls: Array<{ url: string; method: string; body?: RpcBody; auth?: string }> = [];
+  const calls: Array<{
+    url: string;
+    method: string;
+    body?: RpcBody;
+    auth?: string;
+    sessionId?: string;
+  }> = [];
   const encode = (obj: unknown): Uint8Array =>
     new TextEncoder().encode(typeof obj === 'string' ? obj : JSON.stringify(obj));
 
@@ -100,11 +113,13 @@ function makeMockMcpFetch(opts: MockServerOptions): {
         /* ignore non-JSON */
       }
     }
-    const auth =
+    const requestHeaders =
       init?.headers && typeof init.headers === 'object'
-        ? (init.headers as Record<string, string>)['Authorization']
-        : undefined;
-    calls.push({ url, method, body, auth });
+        ? (init.headers as Record<string, string>)
+        : {};
+    const auth = requestHeaders['Authorization'];
+    const sessionId = requestHeaders['Mcp-Session-Id'];
+    calls.push({ url, method, body, auth, sessionId });
 
     const id = body?.id ?? 1;
     if (opts.authRequired) {
@@ -121,6 +136,24 @@ function makeMockMcpFetch(opts: MockServerOptions): {
       }
     }
 
+    if (
+      opts.sessionId &&
+      body?.method !== 'server/discover' &&
+      body?.method !== 'initialize' &&
+      sessionId !== opts.sessionId
+    ) {
+      return {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: { 'content-type': 'application/json' },
+        body: encode({
+          jsonrpc: '2.0',
+          id: body?.id ?? 1,
+          error: { code: -32000, message: 'Bad Request: Mcp-Session-Id header is required' },
+        }),
+      };
+    }
+
     const respond = (result: unknown): MockResponse => ({
       status: 200,
       statusText: 'OK',
@@ -133,6 +166,18 @@ function makeMockMcpFetch(opts: MockServerOptions): {
 
     let resp: MockResponse;
     switch (body?.method) {
+      case 'server/discover':
+        resp = {
+          status: 400,
+          statusText: 'Bad Request',
+          headers: { 'content-type': 'application/json' },
+          body: {
+            jsonrpc: '2.0',
+            id,
+            error: { code: -32601, message: 'Method not found' },
+          },
+        };
+        break;
       case 'initialize':
         resp = respond({ protocolVersion: '2025-06-18', capabilities: {} });
         break;
@@ -413,10 +458,11 @@ describe('mcp add / list / delete / invoke / refresh (integration)', () => {
 
     const file = await readServersFile();
     expect(file.servers.demo.url).toBe('https://server.test/sse');
+    expect(file.servers.demo.protocolVersion).toBe('2025-06-18');
     // `sessionId` MUST NOT be persisted — sessions are per-process on the
     // server and re-sending one on the next `initialize` is a protocol
     // violation (MCP Streamable-HTTP).
-    expect(file.servers.demo.sessionId).toBeUndefined();
+    expect((file.servers.demo as unknown as Record<string, unknown>).sessionId).toBeUndefined();
     expect(file.servers.demo.tools).toEqual([
       {
         name: 'echo',
@@ -742,24 +788,34 @@ describe('mcp invoke / delete / refresh', () => {
     expect(r.stderr).toContain('unknown server "ghost"');
   });
 
-  it('invoke does NOT pass a stale persisted sessionId to McpClient (initialize must be Mcp-Session-Id-free)', async () => {
-    // Seed an entry with a stale sessionId — historically `cmdInvoke` would
-    // thread this into the McpClient constructor, which then sent it on the
-    // `initialize` request and triggered a protocol violation.
-    await setServer('demo', {
-      url: 'https://server.test/sse',
-      sessionId: 'stale-from-old-version',
-      tools: [
-        {
-          name: 'echo',
-          inputSchema: {
-            type: 'object',
-            properties: { msg: { type: 'string' } },
-            required: ['msg'],
+  it('invoke re-negotiates stale persisted protocol/session state', async () => {
+    // Persisted protocol/session state is informational and may be stale.
+    // Invocation must probe again rather than seed the client from either.
+    const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+    await fs.mkdir('/workspace/.mcp', { recursive: true });
+    await fs.writeFile(
+      MCP_STORE_PATH,
+      JSON.stringify({
+        version: 1,
+        servers: {
+          demo: {
+            url: 'https://server.test/sse',
+            protocolVersion: '2025-06-18',
+            sessionId: 'stale-from-old-version',
+            tools: [
+              {
+                name: 'echo',
+                inputSchema: {
+                  type: 'object',
+                  properties: { msg: { type: 'string' } },
+                  required: ['msg'],
+                },
+              },
+            ],
           },
         },
-      ],
-    });
+      })
+    );
 
     const calls: Array<{
       method?: string;
@@ -775,6 +831,20 @@ describe('mcp invoke / delete / refresh', () => {
       const headers = (init?.headers ?? {}) as Record<string, string>;
       calls.push({ method: body?.method, mcpSessionId: headers['Mcp-Session-Id'] });
       const id = body?.id ?? 1;
+      if (body?.method === 'server/discover') {
+        return {
+          status: 400,
+          statusText: 'Bad Request',
+          headers: { 'content-type': 'application/json' },
+          body: new TextEncoder().encode(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id,
+              error: { code: -32601, message: 'Method not found' },
+            })
+          ),
+        };
+      }
       const result =
         body?.method === 'tools/call'
           ? { content: [{ type: 'text', text: 'pong' }] }
@@ -796,6 +866,7 @@ describe('mcp invoke / delete / refresh', () => {
     const r = await runCmd(['invoke', 'demo', 'echo', '--msg', 'hi'], { fetchImpl });
     expect(r.exitCode).toBe(0);
 
+    expect(calls[0]?.method).toBe('server/discover');
     const initCall = calls.find((c) => c.method === 'initialize');
     const toolCall = calls.find((c) => c.method === 'tools/call');
     expect(initCall?.mcpSessionId).toBeUndefined();
@@ -825,12 +896,23 @@ describe('mcp invoke / delete / refresh', () => {
   });
 
   it('refresh re-fetches tools/apps and updates lastRefreshedAt', async () => {
-    await setServer('demo', {
-      url: 'https://server.test/sse',
-      tools: [],
-      apps: [],
-      lastRefreshedAt: '2020-01-01T00:00:00.000Z',
-    });
+    const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+    await fs.mkdir('/workspace/.mcp', { recursive: true });
+    await fs.writeFile(
+      MCP_STORE_PATH,
+      JSON.stringify({
+        version: 1,
+        servers: {
+          demo: {
+            url: 'https://server.test/sse',
+            sessionId: 'legacy-session-must-be-removed',
+            tools: [],
+            apps: [],
+            lastRefreshedAt: '2020-01-01T00:00:00.000Z',
+          },
+        },
+      })
+    );
     const { fetch } = makeMockMcpFetch({
       tools: [{ name: 'a' }, { name: 'b' }],
       apps: [{ name: 'x' }],
@@ -841,7 +923,12 @@ describe('mcp invoke / delete / refresh', () => {
     expect(r.stdout).toContain('apps: 1');
     const file = await readServersFile();
     expect(file.servers.demo.tools?.length).toBe(2);
+    expect(file.servers.demo.protocolVersion).toBe('2025-06-18');
     expect(file.servers.demo.lastRefreshedAt).not.toBe('2020-01-01T00:00:00.000Z');
+    const persisted = JSON.parse(
+      (await fs.readFile(MCP_STORE_PATH, { encoding: 'utf-8' })) as string
+    ) as { servers: Record<string, Record<string, unknown>> };
+    expect(persisted.servers.demo.sessionId).toBeUndefined();
   });
 
   it('delete: cleans server, alias, sprinkles, account, provider', async () => {
@@ -1400,10 +1487,26 @@ describe('mcp invoke --timeout flag (integration)', () => {
     // Fetch that never resolves — the only way the call returns is via the
     // McpClient timeout firing. If --timeout 1 wasn't threaded through, the
     // default (60s) would prevent the abort from firing within 1500ms.
-    const fetchImpl: McpFetchLike = (_url, init) =>
-      new Promise((_resolve, reject) => {
+    const fetchImpl: McpFetchLike = (_url, init) => {
+      const body = JSON.parse(init?.body ?? '{}') as RpcBody;
+      if (body.method === 'server/discover') {
+        return Promise.resolve({
+          status: 200,
+          statusText: 'OK',
+          headers: { 'content-type': 'application/json' },
+          body: new TextEncoder().encode(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: body.id,
+              result: { supportedVersions: ['2026-07-28', '2025-06-18'] },
+            })
+          ),
+        });
+      }
+      return new Promise((_resolve, reject) => {
         init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
       });
+    };
 
     vi.useFakeTimers();
     try {
@@ -1454,6 +1557,18 @@ describe('mcp invoke --timeout flag (integration)', () => {
         ? (JSON.parse(init.body as string) as { id: number; method: string })
         : { id: 1, method: 'initialize' };
       const encode = (obj: unknown) => new TextEncoder().encode(JSON.stringify(obj));
+      if (body.method === 'server/discover') {
+        return {
+          status: 400,
+          statusText: 'Bad Request',
+          headers: { 'content-type': 'application/json' },
+          body: encode({
+            jsonrpc: '2.0',
+            id: body.id,
+            error: { code: -32601, message: 'Method not found' },
+          }),
+        };
+      }
       if (body.method === 'tools/call') {
         return {
           status: 200,

--- a/packages/webapp/tests/shell/supplemental-commands/mcp-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/mcp-command.test.ts
@@ -50,7 +50,7 @@ import {
   setServer,
 } from '../../../src/shell/mcp/store.js';
 import type { McpFetchLike } from '../../../src/shell/mcp/types.js';
-import { setLocalApiBaseUrl } from '../../../src/shell/proxied-fetch.js';
+import { setExtensionDelegateId, setLocalApiBaseUrl } from '../../../src/shell/proxied-fetch.js';
 import {
   aliasContent,
   coerceArgsBySchema,
@@ -210,7 +210,12 @@ function makeMockMcpFetch(opts: MockServerOptions): {
   return { fetch, calls };
 }
 
-function makeMockOAuthFetch(): FetchLike {
+interface OAuthRequestCapture {
+  registrationRedirectUris: string[];
+  tokenRedirectUris: string[];
+}
+
+function makeMockOAuthFetch(capture?: OAuthRequestCapture): FetchLike {
   return async (url, init) => {
     const json = (payload: unknown) => ({
       ok: true,
@@ -237,10 +242,14 @@ function makeMockOAuthFetch(): FetchLike {
       });
     }
     if (url === 'https://auth.test/register') {
+      const body = JSON.parse(init?.body ?? '{}') as { redirect_uris?: string[] };
+      capture?.registrationRedirectUris.push(...(body.redirect_uris ?? []));
       return json({ client_id: 'test-client-abc' });
     }
     if (url === 'https://auth.test/token') {
       const params = new URLSearchParams(init?.body ?? '');
+      const redirectUri = params.get('redirect_uri');
+      if (redirectUri) capture?.tokenRedirectUris.push(redirectUri);
       if (params.get('grant_type') === 'refresh_token') {
         return json({
           access_token: 'rotated-token',
@@ -416,6 +425,8 @@ describe('mcp add / list / delete / invoke / refresh (integration)', () => {
     unregisterProviderConfig(mcpProviderId('demo'));
     await wipeGlobalFs();
     localStorage.clear();
+    setExtensionDelegateId(null);
+    setLocalApiBaseUrl(null);
     // Default: mimic the in-page path so the OAuth-required tests keep
     // resolving a valid redirect URI without needing a panel-RPC bridge.
     mockGetOAuthPageOrigin.mockReset();
@@ -428,6 +439,8 @@ describe('mcp add / list / delete / invoke / refresh (integration)', () => {
   afterEach(async () => {
     _testOnly_resetMcpProviderState();
     unregisterProviderConfig(mcpProviderId('demo'));
+    setExtensionDelegateId(null);
+    setLocalApiBaseUrl(null);
     // Let LightningFS finish its debounced superblock write.
     await new Promise((r) => setTimeout(r, 600));
     _testOnly_resetStoreCache();
@@ -523,6 +536,7 @@ describe('mcp add / list / delete / invoke / refresh (integration)', () => {
 
     const file = await readServersFile();
     expect(file.servers.demo.auth?.clientId).toBe('test-client-abc');
+    expect(file.servers.demo.auth?.redirectUri).toBe(`${window.location.origin}/auth/callback`);
     expect(file.servers.demo.auth?.providerId).toBe('mcp:demo');
     expect(file.servers.demo.auth?.authorizationServer).toBe('https://auth.test');
     expect(file.servers.demo.auth?.scope).toBe('mcp:tools');
@@ -591,6 +605,89 @@ describe('mcp add / list / delete / invoke / refresh (integration)', () => {
       const redirect = new URL(capturedAuthorizeUrl).searchParams.get('redirect_uri');
       expect(redirect).toBe('http://localhost:63905/auth/callback');
       expect(mockGetOAuthPageOrigin).not.toHaveBeenCalled();
+    } finally {
+      setLocalApiBaseUrl(null);
+    }
+  });
+
+  it('add: uses the opaque-state callback for an extension-delegate leader', async () => {
+    setExtensionDelegateId('abcdefghijklmnopabcdefghijklmnop');
+    try {
+      const { fetch } = makeMockMcpFetch({
+        authRequired: true,
+        expectedToken: 'mcp-access-token',
+        tools: [{ name: 'foo' }],
+      });
+      let capturedAuthorizeUrl = '';
+      const captureLauncher = async (authorizeUrl: string): Promise<string | null> => {
+        capturedAuthorizeUrl = authorizeUrl;
+        const u = new URL(authorizeUrl);
+        return `${u.searchParams.get('redirect_uri')}?code=test-code&state=${u.searchParams.get('state')}`;
+      };
+
+      const r = await runCmd(['add', 'https://server.test/sse', 'demo'], {
+        fetchImpl: fetch,
+        oauthFetchImpl: makeMockOAuthFetch(),
+        oauthLauncher: captureLauncher,
+      });
+
+      expect(r.exitCode).toBe(0);
+      const redirect = new URL(capturedAuthorizeUrl).searchParams.get('redirect_uri');
+      expect(redirect).toBe(`${window.location.origin}/auth/mcp-callback`);
+      expect(mockGetOAuthPageOrigin).toHaveBeenCalledOnce();
+    } finally {
+      setExtensionDelegateId(null);
+    }
+  });
+
+  it('reuses the registered thin-node redirect URI after reload', async () => {
+    setLocalApiBaseUrl('http://localhost:63905');
+    const capture: OAuthRequestCapture = {
+      registrationRedirectUris: [],
+      tokenRedirectUris: [],
+    };
+    const authorizeRedirectUris: string[] = [];
+    const oauthFetch = makeMockOAuthFetch(capture);
+    const captureLauncher = async (authorizeUrl: string): Promise<string | null> => {
+      const url = new URL(authorizeUrl);
+      const redirectUri = url.searchParams.get('redirect_uri') ?? '';
+      authorizeRedirectUris.push(redirectUri);
+      return `${redirectUri}?code=test-code&state=${url.searchParams.get('state')}`;
+    };
+    const { fetch } = makeMockMcpFetch({
+      authRequired: true,
+      expectedToken: 'mcp-access-token',
+      tools: [{ name: 'foo' }],
+    });
+
+    try {
+      const added = await runCmd(['add', 'https://server.test/sse', 'demo'], {
+        fetchImpl: fetch,
+        oauthFetchImpl: oauthFetch,
+        oauthLauncher: captureLauncher,
+      });
+      expect(added.exitCode).toBe(0);
+      expect((await readServersFile()).servers.demo.auth?.redirectUri).toBe(
+        'http://localhost:63905/auth/callback'
+      );
+
+      _testOnly_resetMcpProviderState();
+      unregisterProviderConfig(mcpProviderId('demo'));
+
+      const authenticated = await runCmd(['auth', 'demo', '--interactive'], {
+        oauthFetchImpl: oauthFetch,
+        oauthLauncher: captureLauncher,
+      });
+      expect(authenticated.exitCode).toBe(0);
+      expect(capture.registrationRedirectUris).toEqual(['http://localhost:63905/auth/callback']);
+      expect(authorizeRedirectUris).toEqual([
+        'http://localhost:63905/auth/callback',
+        'http://localhost:63905/auth/callback',
+      ]);
+      expect(capture.tokenRedirectUris).toEqual([
+        'http://localhost:63905/auth/callback',
+        'http://localhost:63905/auth/callback',
+      ]);
     } finally {
       setLocalApiBaseUrl(null);
     }

--- a/packages/webapp/tests/shell/supplemental-commands/mcp-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/mcp-command.test.ts
@@ -49,6 +49,7 @@ import {
   setServer,
 } from '../../../src/shell/mcp/store.js';
 import type { McpFetchLike } from '../../../src/shell/mcp/types.js';
+import { setLocalApiBaseUrl } from '../../../src/shell/proxied-fetch.js';
 import {
   aliasContent,
   coerceArgsBySchema,
@@ -492,10 +493,9 @@ describe('mcp add / list / delete / invoke / refresh (integration)', () => {
     expect(acct.scopes).toBe('mcp:tools');
   });
 
-  it('add: uses page-origin redirect URI when not running as a Chrome extension', async () => {
-    // CLI / standalone webapp path — the launcher captures the redirect
-    // on the page origin, so the URI registered with the AS must be
-    // `<origin>/auth/callback`.
+  it('add: uses page-origin redirect URI without a thin-bridge API base', async () => {
+    // Same-origin webapp path — the launcher captures the redirect on the page
+    // origin, so the URI registered with the AS must be `<origin>/auth/callback`.
     const { fetch } = makeMockMcpFetch({
       authRequired: true,
       expectedToken: 'mcp-access-token',
@@ -518,6 +518,36 @@ describe('mcp add / list / delete / invoke / refresh (integration)', () => {
     const redirect = new URL(capturedAuthorizeUrl).searchParams.get('redirect_uri');
     expect(redirect).toBe(`${window.location.origin}/auth/callback`);
     expect(redirect).not.toMatch(/chromiumapp\.org/);
+  });
+
+  it('add: uses the local API callback in thin-bridge mode', async () => {
+    setLocalApiBaseUrl('http://localhost:63905');
+    try {
+      const { fetch } = makeMockMcpFetch({
+        authRequired: true,
+        expectedToken: 'mcp-access-token',
+        tools: [{ name: 'foo' }],
+      });
+      let capturedAuthorizeUrl = '';
+      const captureLauncher = async (authorizeUrl: string): Promise<string | null> => {
+        capturedAuthorizeUrl = authorizeUrl;
+        const u = new URL(authorizeUrl);
+        return `${u.searchParams.get('redirect_uri')}?code=test-code&state=${u.searchParams.get('state')}`;
+      };
+
+      const r = await runCmd(['add', 'https://server.test/sse', 'demo'], {
+        fetchImpl: fetch,
+        oauthFetchImpl: makeMockOAuthFetch(),
+        oauthLauncher: captureLauncher,
+      });
+
+      expect(r.exitCode).toBe(0);
+      const redirect = new URL(capturedAuthorizeUrl).searchParams.get('redirect_uri');
+      expect(redirect).toBe('http://localhost:63905/auth/callback');
+      expect(mockGetOAuthPageOrigin).not.toHaveBeenCalled();
+    } finally {
+      setLocalApiBaseUrl(null);
+    }
   });
 
   it('add: uses chromiumapp.org redirect URI when running as a Chrome extension', async () => {


### PR DESCRIPTION
Fixes `mcp add` against a real MCP server and teaches the client to negotiate MCP `2026-07-28` while keeping `2025-06-18` servers working.

This is **Wave 1 of a staged migration**. The remaining 2026-07-28 work (`_meta` and `Mcp-*` headers, `resultType`/MRTR and renumbered error codes, OAuth hardening, cacheable list results, docs/skills) is deliberately out of scope here and lands in follow-ups. Wave 1 is independently useful: it makes `mcp add` work.

## What was broken

**1. Mojibake on `mcp add`.** The hosted OAuth callback parsed MCP's `state` parameter as a SLICC relay envelope. `state` is opaque to the relay — MCP servers put their own structure in it — so decoding it corrupted the value and produced garbled output. Thin-bridge OAuth now uses the local node-server callback, leaving `state` untouched.

**2. No protocol negotiation.** The client only spoke `2025-06-18`.

**3. `Mcp-Session-Id` invisible to the browser.** The server sent it, but it was absent from `Access-Control-Expose-Headers`, so the browser hid it from `Response.headers`. Every post-`initialize` request then went out without the session ID and was rejected. This is the failure a 1,228-test green suite missed, because the stubs handed the client an already-visible header map.

## What changed

- **Negotiation** — prefer `server/discover` at `2026-07-28`. Downgrade to `2025-06-18` **only** on a request-matching JSON-RPC 2.0 HTTP 400 `-32601`. Malformed or unparseable 400s, timeouts, network errors, 5xx, and `-32020`/`-32021`/`-32602` do **not** downgrade — a transient failure must never permanently pin a modern server to the legacy revision. `-32022` stays modern and retries using `error.data.supported`.
- **Session lifecycle** — legacy-only and per-process. `sessionId` is scrubbed at every persistence boundary and no longer exists on `McpServerEntry`. Files written by earlier builds remain readable and are rewritten without it. Persisted protocol revisions are re-negotiated rather than trusted.
- **CORS parity** — `Mcp-Session-Id` and `MCP-Protocol-Version` added to the expose lists in node-server and swift-server. cloudflare-worker and the Chrome extension were checked and are genuinely not applicable: the worker returns 404 for `/api/fetch-proxy`, and the extension serialises the upstream header map over `chrome.runtime.Port` with no CORS boundary in between.

## Verification

**Live, against the real server** — `mcp add` returned `tools: 5, auth: oauth` (so an authenticated `tools/list` succeeded), `mcp list` confirmed the entry, `mcp invoke` reached upstream, and `servers.json` validated as UTF-8 and JSON with a byte-exact round-trip. Both original bugs are closed against production behaviour, not just against stubs.

**Gates on this head** — lint:ci, typecheck, touched-file debt gate, full webapp suite (597 files, 10,683 tests passed / 36 skipped), coverage with thresholds, root build, and extension build all pass. Coverage needs `maxWorkers=4`; at the default worker count an unrelated iframe suite intermittently fails on Chrome startup under load. That flake is outside this diff and is being tracked separately.

## Note on test quality

This change produced two bugs that a green suite missed, both because fixtures did not model reality. The tests were tightened accordingly: the legacy mock now rejects post-`initialize` requests lacking the issued `Mcp-Session-Id` with the same `-32000` the live server returns, and the persistence tests assert against raw persisted JSON rather than typed reads, so a scrubbed field cannot be merely hidden by its type. Browser CORS header hiding is deliberately **not** simulated in the fetch stubs — that would be theatre, since stubs receive an already-visible header map. The bridge expose-list tests are the real guard.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author