### PR TITLE
fix(ios-app): treat a busy leader as stalled, not dead

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -146,8 +146,8 @@
     },
     "ios-app": {
       "lines": 50,
-      "functions": 34,
-      "regions": 39
+      "functions": 36,
+      "regions": 40
     }
   }
 }

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -14,7 +14,7 @@ This package is NOT an npm workspace. It is a Swift Package Manager project (`Pa
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `SliccFollower/App/SliccFollowerApp.swift`, `App/AppState.swift`                                                                                                                              | App entry + central `@MainActor AppState` (connection lifecycle, per-scoop message buffers, sprinkle state, CDP bridge wiring)                                                                                    |
 | `SliccFollower/Models/SyncProtocol.swift`                                                                                                                                                     | `Codable` mirror (partial — see "Protocol Mirror Invariant" below) of `packages/shared-ts/src/tray-sync-protocol.ts`                                                                                              |
-| `SliccFollower/Models/ChatMessage.swift`, `Models/TrayTypes.swift`, `Models/TrayChunkFraming.swift`                                                                                           | Chat + signaling data types. `TrayChunkFraming` holds the `__chunk` transport frame + `TrayChunkReassembler`: below both unions, so no corpus fixture / `ios` expectation. See `docs/architecture.md`             |
+| `SliccFollower/Models/ChatMessage.swift`, `Models/TrayTypes.swift`, `Models/TrayChunkFraming.swift`                                                                                           | Chat + signaling data types. `TrayChunkFraming` holds the `__chunk` transport frame + `TrayChunkReassembler`: below both unions, so no corpus fixture. See `docs/architecture.md`                                 |
 | `SliccFollower/Sync/Keepalive.swift`                                                                                                                                                          | `DataChannelKeepalive` ping/pong actor (used by `AppState`)                                                                                                                                                       |
 | `SliccFollower/Networking/TraySignaling.swift`, `TrayFollowerConnector.swift`, `WebRTCManager.swift`                                                                                          | Signaling client + WebRTC peer/data-channel setup                                                                                                                                                                 |
 | `SliccFollower/CDP/CDPBridge.swift`, `CDPTarget.swift`                                                                                                                                        | Hosts WKWebViews as CDP targets the leader can drive remotely                                                                                                                                                     |
@@ -34,19 +34,18 @@ This package is NOT an npm workspace. It is a Swift Package Manager project (`Pa
 - Follower-originated `cdp.request` and `tab.open` (iOS only _responds_ to leader-initiated requests — `CDPBridge.swift` sends `cdp.response` / `cdp.event` / `tab.opened` back, but never originates). The same applies to the unified preview's `preview.open` leader→follower message: iOS decodes it in `LeaderToFollowerMessage` and routes through `CDPBridge.handleTabOpen` (the URL is the worker-hosted preview URL minted by the leader's `serve`), then acks with `tab.opened`.
 - The leader→follower reply path for those requests — iOS never originates, so it never consumes a reply.
 - `tab.open.error` send-side — iOS embeds CDP errors in `cdp.response.error` and always sends `.tabOpened` for `tab.open`.
-- Transcript export in both directions, including the v4 delegated-approval pair
-  (`transcript.export.approve.request` / `transcript.export.approve.response`). iOS never
-  originates an export, so it is never asked to approve one; the leader→follower prompt decodes
-  to `.unknown` and the follower→leader reply is `undecodable` in the corpus.
+- Transcript export both ways, including the v4 delegated-approval pair. iOS never
+  originates an export, so it is never asked to approve one: the leader→follower
+  prompt decodes to `.unknown`, the reply is `undecodable` in the corpus.
 
 ### Cherry (embedded follower) mirror
 
 iOS mirrors the cherry-target wire surface even though it cannot _host_ a cherry page:
 
-- `Models/SyncProtocol.swift` defines `CherryCapabilities { navigate, network, screenshot }` and `RemoteTargetInfo.kind` / `.capabilities`, mirroring `RemoteTargetInfo` from `tray-sync-protocol.ts`. The `network` capability gates whether the leader may drive `Network.*` against the target; for a cherry target it is always `false`. A `"kind":"cherry"` target decodes into these fields (see `Tests/SliccFollowerTests/SyncProtocolTests.swift`).
+- `Models/SyncProtocol.swift` defines `CherryCapabilities { navigate, network, screenshot }` and `RemoteTargetInfo.kind` / `.capabilities`, mirroring `RemoteTargetInfo` from `tray-sync-protocol.ts`. `network` gates whether the leader may drive `Network.*`; for a cherry target it is always `false`. A `"kind":"cherry"` target decodes into these fields (see `Tests/SliccFollowerTests/SyncProtocolTests.swift`).
 - `cherry.slicc_event` decodes to `.cherrySliccEvent(targetId, name, detail)`. iOS has **no cherry page surface**, so `AppState.handleDataChannelMessage` logs and ignores it — a **documented no-op** that keeps the decode switch exhaustive.
 
-The doc-comment headers above the `LeaderToFollowerMessage` and `FollowerToLeaderMessage` enum declarations in `SyncProtocol.swift` declare the omission explicitly — `// MARK: -` boundaries are the stable anchors; line numbers shift whenever the headers expand.
+The doc-comment headers above the `LeaderToFollowerMessage` and `FollowerToLeaderMessage` declarations in `SyncProtocol.swift` state the omission explicitly; `// MARK: -` boundaries are the stable anchors, line numbers are not.
 
 **Mechanical enforcement (golden-fixture corpus):** every variant of both TS
 unions has a fixture and an explicit iOS expectation in
@@ -77,9 +76,13 @@ Skipping the iOS update now fails `SyncProtocolCorpusTests` in CI instead of qui
 Both followers implement sprinkle rendering. iOS is the longer-deployed reference; when adding a follower-side feature on the TS side, model it on `AppState`:
 
 - Connection lifecycle: `connect()` / `disconnect()` / `dataChannelOpened()` / `handleDisconnect(reason:)`
+- Connection health: `Sync/Keepalive.swift` splits **stalled** (reachable, keep
+  probing, composer disabled) from **dead**; collapsing them tore down healthy
+  connections. `handleDisconnect` backs off to `.gaveUp`; `lastError` is
+  transport-only, `leaderError` the cone's.
 - Message dispatch: `handleDataChannelMessage(_ data: Data)` switch
-- Sprinkles: `refreshSprinkles()`, `fetchSprinkleContent(_:)` with chunk reassembly + waiter dedup, `sendSprinkleLick(_:body:targetScoop:)`, `handleSprinkleContent(...)`
-- Multi-scoop: `selectScoop`, `swipeToNextScoop` / `swipeToPreviousScoop`, per-scoop `messagesByScoop` buffer + scheduled flush throttling
+- Sprinkles: `refreshSprinkles()`, `fetchSprinkleContent(_:)` (chunk reassembly + waiter dedup), `sendSprinkleLick(_:body:targetScoop:)`, `handleSprinkleContent(...)`
+- Multi-scoop: `selectScoop`, `swipeToNextScoop` / `swipeToPreviousScoop`, per-scoop `messagesByScoop` buffer + flush throttling
 - Agent events: `handleAgentEvent(_:scoopJid:)` with the same scoop-targeted buffer update + per-render-loop throttle
 
 ### Lick Forwarding (leader-side origin stamping)
@@ -152,11 +155,10 @@ xcrun simctl launch "$UDID" com.sliccy.follower
 xcrun simctl io "$UDID" screenshot /tmp/slicc-ios-launch.png
 ```
 
-With no stored `joinUrl`, `ChatView.onAppear` opens the Settings sheet — the
+With no stored `joinUrl`, `ChatView.onAppear` opens the Settings sheet, so the
 screenshot should show **Settings → Connection → Join URL** with
-`Status: Disconnected`. The uninstall matters: a `joinUrl` from an earlier run
-persists in the app container, and the app then boots straight into the
-conversation and auto-connects.
+`Status: Disconnected`. The uninstall matters: a stored `joinUrl` boots the app
+straight into the conversation and auto-connects.
 
 **Driving an interaction without tapping.** `simctl` cannot synthesize taps, but
 `UserDefaults` reads the argument domain, so launch arguments seed
@@ -194,8 +196,8 @@ dials `http://127.0.0.1:1/…` — refused without DNS or egress, so
 - **Row ids alone are blind.** Because every leaf carries `message-<id>`, a row
   still matches when its specialized renderer is gone. A new fixture variant
   also needs a `variantMarkers` string only that renderer can emit.
-- **The transcript is pinned to the newest message**, so a walk over every
-  variant scrolls bottom-to-top and must be bounded.
+- **The transcript is pinned to the newest message**, so a variant walk scrolls
+  bottom-to-top and must be bounded.
 - **The bundle is `parallelizable: false`** — cloning simulators for a UI bundle
   races the runner install and the loser fails preflight with `Busy`.
 - **A red CI job names the test, not the reason.** The XCTAssert text lives only

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -94,8 +94,8 @@ iOS sprinkle licks show their origin label in the leader's cone via leader-side 
 Payload fields decode _and_ render. Deliberate divergences from the web:
 
 - Attachment chips: thumbnail (inline base64) or kind glyph plus filename, user messages only. No size/MIME line — the web's chat mapper drops those too. A content-less attachment message renders no bubble.
-- The error card omits the web's CTAs (`Try again`, `Open Settings`): each acts on leader state with no follower→leader equivalent, so the button would silently no-op.
-- `tool_ui` renders a read-only card keyed by `requestId`, title extracted from the leader's HTML minus badge and meta (the meta carries the mount path). `tool_ui_done` removes it; a `snapshot` clears all cards.
+- The error card omits the web's CTAs (`Try again`, `Open Settings`): each acts on leader state with no follower→leader equivalent, so it would silently no-op.
+- `tool_ui` renders a read-only card keyed by `requestId`, title extracted from the leader's HTML minus badge and meta (which carries the mount path). `tool_ui_done` removes it; a `snapshot` clears all cards.
 
 ## Build
 
@@ -120,8 +120,10 @@ picks a simulator, enables coverage and on-failure retries, and enforces the
 ```
 
 Outputs land in `.build/coverage/` (`summary.json`, `lcov.info`,
-`ios-app.xcresult` with per-test durations). Tests run `parallelizable` with
-`randomExecutionOrder`, so a new test must not depend on another test's side
+`ios-app.xcresult` with per-test durations). Neither bundle is `parallelizable`: the unit tests total
+~7s, so cloning simulators only raced the UI runner, which then fails preflight
+with `Busy` or dies on `Timed out while loading Accessibility`.
+`randomExecutionOrder` still holds, so no test may depend on another's side
 effects. Coverage is measured against
 `SliccFollower.app/SliccFollower.debug.dylib`, not the launcher stub beside it —
 debug builds put the code and the coverage mapping in the dylib.
@@ -198,8 +200,6 @@ dials `http://127.0.0.1:1/…` — refused without DNS or egress, so
   also needs a `variantMarkers` string only that renderer can emit.
 - **The transcript is pinned to the newest message**, so a variant walk scrolls
   bottom-to-top and must be bounded.
-- **The bundle is `parallelizable: false`** — cloning simulators for a UI bundle
-  races the runner install and the loser fails preflight with `Busy`.
 - **A red CI job names the test, not the reason.** The XCTAssert text lives only
   in the `test-timings-ios-app` xcresult the job uploads — read it with
   `xcrun xcresulttool get test-results tests` before theorizing. These failures

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		4A9B912F64233A5C73E57DB4 /* FixtureConversationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FA307998C15DDB13AC2852 /* FixtureConversationUITests.swift */; };
 		532EBF4FC79CF40ABCD366F0 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E99369A8A6B1A9B8EBE996E /* WebKit.framework */; };
 		541C36C1FB80D6EDBA337FE6 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A69E83B7BB267C230C892A29 /* PrivacyInfo.xcprivacy */; };
+		54B15E202D059EA1DBB4ED44 /* KeepaliveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D76B8F603084A6021B6DD6B /* KeepaliveTests.swift */; };
 		58AACC678F1000C41BC7AA1A /* TabsCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39ADD0645C7DD3B30664E997 /* TabsCarouselView.swift */; };
 		5A678420A08BBB43297E1D8D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F0583BDF50B1A1B9CE68AE67 /* Assets.xcassets */; };
 		5B5741496E7C7EA37979CFF2 /* AttachmentChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E089FCA5BF8861469F73C4 /* AttachmentChips.swift */; };
@@ -41,6 +42,7 @@
 		A9C0449A188D09A99F506FFE /* InlineSprinkleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2EECDCB4AF899D3071D13C /* InlineSprinkleView.swift */; };
 		B4A19D759C5C4CDDFFA1FC35 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8BFCDA8C3F71C0A853D573 /* ContentView.swift */; };
 		BBF4C5A147E77FE534564A87 /* SprinkleSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407939337779F91986E8DAB3 /* SprinkleSidebarView.swift */; };
+		BD662161506DEE603F8854EF /* ConnectionStateUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37492C8E3201CB2A14C6BD12 /* ConnectionStateUITests.swift */; };
 		C43F5710585B9C800CAAA0A2 /* ConnectionStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 940DB17683937E3DAE6E914C /* ConnectionStatusView.swift */; };
 		CB6A8F9EEAD1D4DAA552E0EC /* SyncProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BBC1002CE4D3E1D940352F4 /* SyncProtocolTests.swift */; };
 		D2A85DC611A43443DEC75989 /* TraySignaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E70132BA0E6C4BC99D8CB73 /* TraySignaling.swift */; };
@@ -74,6 +76,7 @@
 		2EDB6F858D918DBBE06D4702 /* TrayTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayTypes.swift; sourceTree = "<group>"; };
 		31E089FCA5BF8861469F73C4 /* AttachmentChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentChips.swift; sourceTree = "<group>"; };
 		356386D299A1933A39CB972B /* TrayChunkFraming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayChunkFraming.swift; sourceTree = "<group>"; };
+		37492C8E3201CB2A14C6BD12 /* ConnectionStateUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStateUITests.swift; sourceTree = "<group>"; };
 		39ADD0645C7DD3B30664E997 /* TabsCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsCarouselView.swift; sourceTree = "<group>"; };
 		3BA9A527E2D4BBCE1BDFA89C /* ChatFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFixture.swift; sourceTree = "<group>"; };
 		3BBC1002CE4D3E1D940352F4 /* SyncProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncProtocolTests.swift; sourceTree = "<group>"; };
@@ -89,6 +92,7 @@
 		639AB6CC8494FCE4C252F00B /* ChunkFramingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkFramingTests.swift; sourceTree = "<group>"; };
 		7E727142147B0FB449F418D1 /* MessageListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListView.swift; sourceTree = "<group>"; };
 		88219CD0B963530C38CE40FB /* SliccFollowerUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SliccFollowerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		8D76B8F603084A6021B6DD6B /* KeepaliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeepaliveTests.swift; sourceTree = "<group>"; };
 		93EE217FAA3F9F7DD3A0B07F /* TrayFollowerConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayFollowerConnector.swift; sourceTree = "<group>"; };
 		940DB17683937E3DAE6E914C /* ConnectionStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatusView.swift; sourceTree = "<group>"; };
 		9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncProtocolCorpusTests.swift; sourceTree = "<group>"; };
@@ -131,6 +135,7 @@
 			isa = PBXGroup;
 			children = (
 				639AB6CC8494FCE4C252F00B /* ChunkFramingTests.swift */,
+				8D76B8F603084A6021B6DD6B /* KeepaliveTests.swift */,
 				9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */,
 				3BBC1002CE4D3E1D940352F4 /* SyncProtocolTests.swift */,
 				F0425579D2C460F993D259DB /* ToolUIPlaceholderTests.swift */,
@@ -194,6 +199,7 @@
 			isa = PBXGroup;
 			children = (
 				FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */,
+				37492C8E3201CB2A14C6BD12 /* ConnectionStateUITests.swift */,
 				A5FA307998C15DDB13AC2852 /* FixtureConversationUITests.swift */,
 			);
 			name = SliccFollowerUITests;
@@ -442,6 +448,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				67EC4D5BDDC4014A965FF5B4 /* ConnectionRouteUITests.swift in Sources */,
+				BD662161506DEE603F8854EF /* ConnectionStateUITests.swift in Sources */,
 				4A9B912F64233A5C73E57DB4 /* FixtureConversationUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -451,6 +458,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8017E9416AEB3D7756ADEB3A /* ChunkFramingTests.swift in Sources */,
+				54B15E202D059EA1DBB4ED44 /* KeepaliveTests.swift in Sources */,
 				F908DA74A70E1C7F16EC6AD8 /* SyncProtocolCorpusTests.swift in Sources */,
 				CB6A8F9EEAD1D4DAA552E0EC /* SyncProtocolTests.swift in Sources */,
 				21BD049697833AC4E3316A58 /* ToolUIPlaceholderTests.swift in Sources */,

--- a/packages/ios-app/SliccFollower.xcodeproj/xcshareddata/xcschemes/SliccFollower.xcscheme
+++ b/packages/ios-app/SliccFollower.xcodeproj/xcshareddata/xcschemes/SliccFollower.xcscheme
@@ -70,7 +70,7 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES"
+            parallelizable = "NO"
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -11,6 +11,26 @@ enum ConnectionState: String {
     case connected
     case reconnecting
     case failed
+    /// Bounded reconnect ran out of attempts. Terminal and actionable — unlike
+    /// `reconnecting`, nothing further happens without the user, and unlike
+    /// `failed`, we know the leader was unreachable across the whole backoff.
+    case gaveUp
+}
+
+/// Bounded exponential backoff for reconnects, mirroring the TS defaults in
+/// `startFollowerWithAutoReconnect` (`packages/webapp/src/scoops/tray-webrtc.ts`).
+enum ReconnectBackoff {
+    static let baseDelay: TimeInterval = 1
+    static let multiplier: Double = 2
+    static let maxDelay: TimeInterval = 30
+    static let maxAttempts = 10
+
+    /// Delay before attempt `attempt` (1-based), capped at `maxDelay`.
+    static func delay(forAttempt attempt: Int) -> TimeInterval {
+        guard attempt > 1 else { return baseDelay }
+        let grown = baseDelay * pow(multiplier, Double(attempt - 1))
+        return min(grown, maxDelay)
+    }
 }
 
 // ChatMessage is defined in Models/ChatMessage.swift
@@ -80,8 +100,23 @@ class AppState: ObservableObject {
     // Join URL history (last 5)
     @Published var joinUrlHistory: [String] = []
 
-    /// Last connection error, surfaced to the UI.
+    /// Last *transport* error, surfaced to the UI. A dropped channel, a refused
+    /// signaling attempt, an exhausted reconnect. Kept apart from `leaderError`
+    /// so a network blip and a cone failure do not read identically.
     @Published var lastError: String?
+
+    /// Last error reported *by the leader's agent*. A cone problem, not a
+    /// transport problem: reconnecting cannot fix it and the UI must not offer
+    /// that as the remedy.
+    @Published var leaderError: String?
+
+    /// The leader stopped answering pings while its channel stayed open. The
+    /// connection is intact and probing continues; the peer is just busy. The
+    /// composer disables itself so a message typed now cannot be lost.
+    @Published var isLeaderStalled: Bool = false
+
+    /// Which reconnect attempt is in flight, 1-based. Zero when not reconnecting.
+    @Published var reconnectAttempt: Int = 0
 
     /// Buffer for chunked sprinkle.content responses.
     private struct SprinkleFetchBuffer {
@@ -106,6 +141,10 @@ class AppState: ObservableObject {
     private var webRTCDelegate: WebRTCBridge?
     private var keepalive: DataChannelKeepalive?
     private var connectTask: Task<Void, Never>?
+    /// Owns the bounded reconnect budget. Separate from `connectTask`, which
+    /// `tearDown()` cancels on every attempt — cancelling the loop from inside
+    /// its own retry would end the budget after one try.
+    private var reconnectTask: Task<Void, Never>?
     fileprivate var controllerId: String = UUID().uuidString
     fileprivate var currentBootstrapId: String?
 
@@ -167,6 +206,12 @@ class AppState: ObservableObject {
     /// Disconnect from the current tray session. Unlike a transient WebRTC
     /// drop this is user-initiated, so we also drop any open CDP tabs.
     func disconnect() {
+        // A user-initiated disconnect ends the reconnect budget; otherwise the
+        // loop would keep dialing a leader the user just walked away from.
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        reconnectAttempt = 0
+        isLeaderStalled = false
         tearDown()
         resetCDPState()
         connectionState = .disconnected
@@ -543,6 +588,16 @@ class AppState: ObservableObject {
                 Task { @MainActor [weak self] in
                     self?.handleDisconnect(reason: "Keepalive timeout")
                 }
+            },
+            // A leader that stops answering but keeps its channel open is busy,
+            // not gone. Without this gate the follower tore down a healthy
+            // transport after ~30s and forced a full renegotiation.
+            isTransportOpen: { [weak rtc] in rtc?.isConnected ?? false },
+            onStalled: { [weak self] in
+                Task { @MainActor [weak self] in self?.isLeaderStalled = true }
+            },
+            onRecovered: { [weak self] in
+                Task { @MainActor [weak self] in self?.isLeaderStalled = false }
             }
         )
         Task { await keepalive?.start() }
@@ -640,7 +695,7 @@ class AppState: ObservableObject {
 
         case .error(let error):
             logger.error("Leader error: \(error)")
-            lastError = error
+            leaderError = error
 
         case .scoopsList(let scoops, let activeScoopJid):
             logger.info("Scoops list received: \(scoops.count) scoops, active=\(activeScoopJid)")
@@ -917,7 +972,7 @@ class AppState: ObservableObject {
 
         case .error(let error):
             logger.error("Agent event: error — \(error)")
-            if isVisible { lastError = error }
+            if isVisible { leaderError = error }
 
         // Events that mutate no transcript state. Kept as a single arm so the
         // switch stays exhaustive — a new protocol case is then a compile error
@@ -996,6 +1051,13 @@ class AppState: ObservableObject {
             logger.error("Refusing to send oversize message (\(data.count) bytes)")
             return false
         }
+        // Only chunked sends are gated: a congested channel must still carry
+        // keepalive ping/pong, or a busy peer reads as a dead one.
+        let queued = webRTCManager?.bufferedAmount ?? 0
+        guard queued < UInt64(TrayChunkLimits.sendHighWaterBytes) else {
+            logger.error("Refusing chunked send — channel congested (\(queued) bytes queued)")
+            return false
+        }
         let frames = TrayChunkFraming.frameChunks(text)
         for frame in frames {
             guard let encoded = try? JSONEncoder().encode(frame),
@@ -1047,20 +1109,60 @@ class AppState: ObservableObject {
     func handleDisconnect(reason: String) {
         guard connectionState == .connected || connectionState == .reconnecting else { return }
 
-        if autoReconnect {
-            connectionState = .reconnecting
-            streamingMessageId = nil
-            // TODO: Implement reconnect with exponential backoff.
-            // For now, attempt a fresh connect after a delay.
-            Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: 3_000_000_000)
-                guard let self, self.connectionState == .reconnecting else { return }
-                self.connect()
-            }
-        } else {
+        // A stall that ends in a real disconnect must not leave the composer
+        // wedged: the stall is over, the connection is what is broken now.
+        isLeaderStalled = false
+
+        guard autoReconnect else {
             connectionState = .failed
             lastError = reason
+            return
         }
+
+        connectionState = .reconnecting
+        streamingMessageId = nil
+        reconnectTask?.cancel()
+        reconnectTask = Task { @MainActor [weak self] in
+            await self?.runReconnectLoop(initialReason: reason)
+        }
+    }
+
+    /// Bounded exponential backoff, mirroring `startFollowerWithAutoReconnect`.
+    ///
+    /// A transient drop deliberately does not render as a permanent error: the
+    /// state stays `.reconnecting` with a visible attempt count, and only an
+    /// exhausted budget reaches the terminal `.gaveUp`.
+    private func runReconnectLoop(initialReason: String) async {
+        for attempt in 1...ReconnectBackoff.maxAttempts {
+            reconnectAttempt = attempt
+            connectionState = .reconnecting
+
+            let delay = ReconnectBackoff.delay(forAttempt: attempt)
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            if Task.isCancelled { return }
+            // A user-initiated disconnect (or a connect that already landed)
+            // moves us out of `.reconnecting`; abandon the budget silently.
+            guard connectionState == .reconnecting else { return }
+
+            connect()
+
+            // `connect()` drives its own async signaling; wait for it to settle
+            // before deciding whether this attempt earned another.
+            await connectTask?.value
+            if Task.isCancelled { return }
+            if connectionState == .connected {
+                reconnectAttempt = 0
+                lastError = nil
+                return
+            }
+        }
+
+        guard !Task.isCancelled else { return }
+        connectionState = .gaveUp
+        lastError =
+            "Couldn't reach the leader after \(ReconnectBackoff.maxAttempts) attempts "
+            + "(\(initialReason)). Reload to retry."
+        reconnectAttempt = 0
     }
 
     // MARK: - Private: Teardown

--- a/packages/ios-app/SliccFollower/App/UITestHooks.swift
+++ b/packages/ios-app/SliccFollower/App/UITestHooks.swift
@@ -18,5 +18,16 @@ import Foundation
         static var routesToFixture: Bool {
             UserDefaults.standard.bool(forKey: "uiTestFixtureRoute")
         }
+
+        /// Force the connection banner into a given state. The stalled and
+        /// gave-up states are otherwise only reachable by starving a real
+        /// leader of pings or exhausting a real reconnect budget, neither of
+        /// which a hermetic UI test can stage.
+        ///
+        /// Accepts a `ConnectionState` raw value; `stalled` additionally means
+        /// "connected, but the leader stopped answering".
+        static var forcedConnectionState: String? {
+            UserDefaults.standard.string(forKey: "uiTestConnectionState")
+        }
     }
 #endif

--- a/packages/ios-app/SliccFollower/Models/TrayChunkFraming.swift
+++ b/packages/ios-app/SliccFollower/Models/TrayChunkFraming.swift
@@ -28,6 +28,14 @@ enum TrayChunkLimits {
     static let maxChunkBytes = 32 * 1024
     /// Hard ceiling on one reassembled message.
     static let maxTotalBytes = 8 * 1024 * 1024
+    /// Queued-bytes ceiling above which a *chunked* send is refused: the next
+    /// write is heading for a full send queue, and hundreds of frames would
+    /// wedge the channel for everything behind them.
+    ///
+    /// Deliberately not applied to small messages, so a congested channel still
+    /// passes keepalive ping/pong and a merely busy peer is not mistaken for a
+    /// dead one. Mirrors `TRAY_SEND_HIGH_WATER_BYTES`.
+    static let sendHighWaterBytes = 8 * 1024 * 1024
     /// Concurrent in-flight reassemblies before the oldest is evicted.
     static let maxPending = 8
     /// Max frames one message may claim. Bounds the buffer allocated from a

--- a/packages/ios-app/SliccFollower/Networking/WebRTCManager.swift
+++ b/packages/ios-app/SliccFollower/Networking/WebRTCManager.swift
@@ -26,6 +26,12 @@ class WebRTCManager: NSObject {
         dataChannel?.readyState == .open
     }
 
+    /// Bytes queued on the data channel but not yet sent. Zero when there is no
+    /// channel, so a caller with nothing to send never reads as congested.
+    var bufferedAmount: UInt64 {
+        dataChannel?.bufferedAmount ?? 0
+    }
+
     override init() {
         RTCInitializeSSL()
         let encoderFactory = RTCDefaultVideoEncoderFactory()

--- a/packages/ios-app/SliccFollower/Sync/Keepalive.swift
+++ b/packages/ios-app/SliccFollower/Sync/Keepalive.swift
@@ -2,43 +2,96 @@ import Foundation
 
 /// Manages ping/pong keepalive over a tray data channel.
 ///
-/// Sends periodic pings and declares the connection dead if no pong (or ping)
-/// is received within `maxMissed` consecutive intervals.
+/// Missing `maxMissed` consecutive pongs means the peer is not *answering*,
+/// which is not the same thing as the peer being gone. Both ends of the tray
+/// sync channel run this timer on the same thread that serves the agent, so a
+/// peer that is merely CPU-starved (the hosted-leader float shares one small
+/// sandbox between Chromium, the kernel worker, and node-server) stops
+/// answering pings long before its transport dies. Treating that as death tore
+/// down a healthy connection and forced a full ICE/DTLS renegotiation — the
+/// disconnect was self-inflicted.
+///
+/// So the state machine has two thresholds:
+///
+/// - `maxMissed` consecutive misses → **stalled**. Reported once via
+///   `onStalled`; the timer keeps probing and `onRecovered` fires when the peer
+///   answers again. No teardown.
+/// - `hardMaxMissed` consecutive misses → **dead**. `onDead` fires and the
+///   keepalive stops, exactly as before.
+///
+/// The stall state only applies while `isTransportOpen` says the underlying
+/// channel is still usable. It defaults to `{ false }`, so a caller that does
+/// not pass it keeps the original "dead at `maxMissed`" behavior.
 ///
 /// Port of `DataChannelKeepalive` from
 /// `packages/webapp/src/scoops/data-channel-keepalive.ts`.
 actor DataChannelKeepalive {
     private let sendPing: @Sendable () -> Void
     private let onDead: @Sendable () -> Void
+    private let isTransportOpen: @Sendable () -> Bool
+    private let onStalled: (@Sendable () -> Void)?
+    private let onRecovered: (@Sendable () -> Void)?
 
     /// Ping interval in seconds (TS default: 10_000 ms → 10 s).
     private let pingInterval: TimeInterval
 
-    /// Number of consecutive missed pongs before declaring dead (TS default: 3).
+    /// Number of consecutive missed pongs before reporting a stall (TS default: 3).
     private let maxMissed: Int
+
+    /// Consecutive missed pongs before declaring the peer dead even though its
+    /// transport still looks open (TS default: 30 — five minutes at the default
+    /// interval). Only consulted while `isTransportOpen` returns true; a closed
+    /// transport still dies at `maxMissed`.
+    private let hardMaxMissed: Int
 
     private var pingTask: Task<Void, Never>?
     private var missedPongs: Int = 0
     private var awaitingPong: Bool = false
     private var stopped: Bool = false
+    private var stalled: Bool = false
 
     /// Creates a new keepalive timer.
     ///
     /// - Parameters:
     ///   - sendPing: Closure that sends a `ping` message over the data channel.
     ///   - onDead: Closure called when the remote side is considered dead.
+    ///   - isTransportOpen: Whether the channel still looks usable. While this
+    ///     returns true, crossing `maxMissed` reports a stall instead of death.
+    ///   - onStalled: Called once when the peer crosses `maxMissed` with the
+    ///     transport still open.
+    ///   - onRecovered: Called once when a stalled peer answers again.
     ///   - pingInterval: Seconds between pings (default 10, matching the TS 10 000 ms).
-    ///   - maxMissed: Consecutive missed pongs before declaring dead (default 3).
+    ///   - maxMissed: Consecutive missed pongs before reporting a stall (default 3).
+    ///   - hardMaxMissed: Consecutive missed pongs before declaring death (default 30).
     init(
         sendPing: @escaping @Sendable () -> Void,
         onDead: @escaping @Sendable () -> Void,
+        isTransportOpen: @escaping @Sendable () -> Bool = { false },
+        onStalled: (@Sendable () -> Void)? = nil,
+        onRecovered: (@Sendable () -> Void)? = nil,
         pingInterval: TimeInterval = 10,
-        maxMissed: Int = 3
+        maxMissed: Int = 3,
+        hardMaxMissed: Int = 30
     ) {
+        precondition(pingInterval > 0, "pingInterval must be positive; got \(pingInterval)")
+        precondition(maxMissed >= 1, "maxMissed must be a positive integer; got \(maxMissed)")
+        // `tick` only consults the hard deadline after `maxMissed` is crossed, so
+        // a hard deadline below the soft one would silently never apply — death
+        // would land at `maxMissed` instead, later than the configured hard
+        // deadline promises. Reject the contradiction rather than surprising the
+        // caller with a threshold that quietly does nothing.
+        precondition(
+            hardMaxMissed >= maxMissed,
+            "hardMaxMissed (\(hardMaxMissed)) must be >= maxMissed (\(maxMissed))")
+
         self.sendPing = sendPing
         self.onDead = onDead
+        self.isTransportOpen = isTransportOpen
+        self.onStalled = onStalled
+        self.onRecovered = onRecovered
         self.pingInterval = pingInterval
         self.maxMissed = maxMissed
+        self.hardMaxMissed = hardMaxMissed
     }
 
     /// Start the keepalive interval. Safe to call multiple times.
@@ -55,16 +108,22 @@ actor DataChannelKeepalive {
     }
 
     /// Stop the keepalive. Once stopped it cannot be restarted.
+    ///
+    /// Terminal: any stall is cleared without notifying, so a late pong cannot
+    /// report a recovery for a state machine that has already given up.
     func stop() {
         stopped = true
+        stalled = false
         pingTask?.cancel()
         pingTask = nil
     }
 
     /// Call when a pong is received from the remote side — resets the missed counter.
     func receivedPong() {
+        guard !stopped else { return }
         awaitingPong = false
         missedPongs = 0
+        clearStall()
     }
 
     /// Call when a ping is received from the remote side.
@@ -72,28 +131,54 @@ actor DataChannelKeepalive {
     /// Receiving a ping also proves the channel is alive, so counters are reset.
     /// The caller is responsible for sending a pong back.
     func receivedPing() {
+        guard !stopped else { return }
         missedPongs = 0
         awaitingPong = false
+        clearStall()
     }
 
     /// The current number of consecutive missed pongs (exposed for testing).
     var missed: Int { missedPongs }
 
-    // MARK: - Private
+    /// Whether the peer is currently past `maxMissed` but still reachable.
+    var isStalled: Bool { stalled }
 
-    private func tick() {
+    /// One keepalive interval. Internal rather than private so tests can drive
+    /// the state machine deterministically instead of waiting on wall clock.
+    func tick() {
         guard !stopped else { return }
 
         if awaitingPong {
             missedPongs += 1
-            if missedPongs >= maxMissed {
-                stop()
-                onDead()
-                return
-            }
+            if missedPongs >= maxMissed && declareUnreachable() { return }
         }
 
         awaitingPong = true
         sendPing()
+    }
+
+    // MARK: - Private
+
+    private func clearStall() {
+        guard stalled else { return }
+        stalled = false
+        onRecovered?()
+    }
+
+    /// Decide what crossing `maxMissed` means. Returns true when the keepalive
+    /// has died and `tick` must not send another ping.
+    private func declareUnreachable() -> Bool {
+        // A peer we can still reach is busy, not gone — keep probing until the
+        // hard deadline rather than tearing down a working transport.
+        if missedPongs < hardMaxMissed && isTransportOpen() {
+            if !stalled {
+                stalled = true
+                onStalled?()
+            }
+            return false
+        }
+        stop()
+        onDead()
+        return true
     }
 }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/KeepaliveTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/KeepaliveTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import XCTest
+
+@testable import SliccFollower
+
+/// Stall/recover/dead transitions for `DataChannelKeepalive` (#1793).
+///
+/// Every test drives `tick()` directly rather than waiting on the ping timer,
+/// so the state machine is exercised deterministically and no test needs a live
+/// peer or a wall-clock delay.
+final class KeepaliveTests: XCTestCase {
+    /// Thread-safe tally for the actor's `@Sendable` callbacks.
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var counts: [String: Int] = [:]
+
+        func record(_ event: String) {
+            lock.lock()
+            defer { lock.unlock() }
+            counts[event, default: 0] += 1
+        }
+
+        func count(_ event: String) -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return counts[event] ?? 0
+        }
+    }
+
+    /// `tick` only counts a miss when it is already awaiting a pong, so the
+    /// first tick just sends. Crossing `maxMissed` therefore takes
+    /// `maxMissed + 1` ticks.
+    private func makeKeepalive(
+        recorder: Recorder,
+        transportOpen: Bool,
+        maxMissed: Int = 2,
+        hardMaxMissed: Int = 4
+    ) -> DataChannelKeepalive {
+        DataChannelKeepalive(
+            sendPing: { recorder.record("ping") },
+            onDead: { recorder.record("dead") },
+            isTransportOpen: { transportOpen },
+            onStalled: { recorder.record("stalled") },
+            onRecovered: { recorder.record("recovered") },
+            pingInterval: 10,
+            maxMissed: maxMissed,
+            hardMaxMissed: hardMaxMissed
+        )
+    }
+
+    func testAnOpenTransportStallsInsteadOfDying() async {
+        let recorder = Recorder()
+        let keepalive = makeKeepalive(recorder: recorder, transportOpen: true)
+
+        for _ in 0..<3 { await keepalive.tick() }
+
+        XCTAssertEqual(recorder.count("stalled"), 1, "Crossing maxMissed should report a stall")
+        XCTAssertEqual(recorder.count("dead"), 0, "A reachable peer must not be declared dead")
+        let stalled = await keepalive.isStalled
+        XCTAssertTrue(stalled)
+    }
+
+    func testAStalledKeepaliveKeepsProbing() async {
+        let recorder = Recorder()
+        let keepalive = makeKeepalive(recorder: recorder, transportOpen: true)
+
+        for _ in 0..<3 { await keepalive.tick() }
+        let pingsAtStall = recorder.count("ping")
+        await keepalive.tick()
+
+        XCTAssertGreaterThan(
+            recorder.count("ping"), pingsAtStall,
+            "A stall must not stop the timer — recovery is only observable by probing")
+        XCTAssertEqual(recorder.count("stalled"), 1, "The stall is reported once, not per tick")
+    }
+
+    func testAPongAfterAStallReportsRecovery() async {
+        let recorder = Recorder()
+        let keepalive = makeKeepalive(recorder: recorder, transportOpen: true)
+
+        for _ in 0..<3 { await keepalive.tick() }
+        await keepalive.receivedPong()
+
+        XCTAssertEqual(recorder.count("recovered"), 1)
+        XCTAssertEqual(recorder.count("dead"), 0, "Recovery must not require renegotiation")
+        let stalled = await keepalive.isStalled
+        XCTAssertFalse(stalled)
+        let missed = await keepalive.missed
+        XCTAssertEqual(missed, 0)
+    }
+
+    /// A peer that pings us has proved liveness just as well as one that pongs.
+    func testAnInboundPingAlsoClearsAStall() async {
+        let recorder = Recorder()
+        let keepalive = makeKeepalive(recorder: recorder, transportOpen: true)
+
+        for _ in 0..<3 { await keepalive.tick() }
+        await keepalive.receivedPing()
+
+        XCTAssertEqual(recorder.count("recovered"), 1)
+        let stalled = await keepalive.isStalled
+        XCTAssertFalse(stalled)
+    }
+
+    func testTheHardDeadlineStillKillsAStalledPeer() async {
+        let recorder = Recorder()
+        let keepalive = makeKeepalive(recorder: recorder, transportOpen: true)
+
+        for _ in 0..<5 { await keepalive.tick() }
+
+        XCTAssertEqual(recorder.count("stalled"), 1)
+        XCTAssertEqual(
+            recorder.count("dead"), 1,
+            "hardMaxMissed must still terminate a peer that never answers")
+    }
+
+    /// Callers that omit `isTransportOpen` keep the pre-stall semantics.
+    func testAClosedTransportDiesAtMaxMissed() async {
+        let recorder = Recorder()
+        let keepalive = makeKeepalive(recorder: recorder, transportOpen: false)
+
+        for _ in 0..<3 { await keepalive.tick() }
+
+        XCTAssertEqual(recorder.count("dead"), 1, "A closed transport dies at maxMissed")
+        XCTAssertEqual(recorder.count("stalled"), 0, "A closed transport cannot be merely stalled")
+    }
+
+    func testTheDefaultTransportGatePreservesTheOldBehavior() async {
+        let recorder = Recorder()
+        let keepalive = DataChannelKeepalive(
+            sendPing: { recorder.record("ping") },
+            onDead: { recorder.record("dead") },
+            pingInterval: 10,
+            maxMissed: 2
+        )
+
+        for _ in 0..<3 { await keepalive.tick() }
+
+        XCTAssertEqual(recorder.count("dead"), 1)
+    }
+
+    /// The boundary the initializer permits: equal thresholds mean the hard
+    /// deadline lands exactly on the soft one, so there is no stall window.
+    func testEqualThresholdsLeaveNoStallWindow() async {
+        let recorder = Recorder()
+        let keepalive = makeKeepalive(
+            recorder: recorder, transportOpen: true, maxMissed: 2, hardMaxMissed: 2)
+
+        for _ in 0..<3 { await keepalive.tick() }
+
+        XCTAssertEqual(recorder.count("dead"), 1)
+        XCTAssertEqual(recorder.count("stalled"), 0)
+    }
+
+    /// Stopping is terminal, so a late pong must not announce a recovery for a
+    /// state machine that has already given up.
+    func testStopSuppressesALateRecovery() async {
+        let recorder = Recorder()
+        let keepalive = makeKeepalive(recorder: recorder, transportOpen: true)
+
+        for _ in 0..<3 { await keepalive.tick() }
+        await keepalive.stop()
+        await keepalive.receivedPong()
+
+        XCTAssertEqual(recorder.count("recovered"), 0)
+        let stalled = await keepalive.isStalled
+        XCTAssertFalse(stalled)
+    }
+
+    func testTickAfterStopDoesNothing() async {
+        let recorder = Recorder()
+        let keepalive = makeKeepalive(recorder: recorder, transportOpen: true)
+
+        await keepalive.stop()
+        await keepalive.tick()
+
+        XCTAssertEqual(recorder.count("ping"), 0)
+        XCTAssertEqual(recorder.count("dead"), 0)
+    }
+}
+
+/// Backoff schedule for the bounded reconnect (#1793).
+final class ReconnectBackoffTests: XCTestCase {
+    func testDelaysGrowGeometricallyThenCap() {
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 1), 1)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 2), 2)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 3), 4)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 4), 8)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 5), 16)
+    }
+
+    func testDelayIsCappedAtMaxDelay() {
+        XCTAssertEqual(
+            ReconnectBackoff.delay(forAttempt: 6), ReconnectBackoff.maxDelay,
+            "32s would exceed the cap and must clamp")
+        XCTAssertEqual(
+            ReconnectBackoff.delay(forAttempt: ReconnectBackoff.maxAttempts),
+            ReconnectBackoff.maxDelay)
+    }
+
+    /// A non-positive attempt is not a real attempt; it must not produce a
+    /// negative or fractional delay via `pow`.
+    func testNonPositiveAttemptsFallBackToTheBaseDelay() {
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: 0), ReconnectBackoff.baseDelay)
+        XCTAssertEqual(ReconnectBackoff.delay(forAttempt: -3), ReconnectBackoff.baseDelay)
+    }
+
+    /// The whole budget must stay bounded — a follower that retries forever is
+    /// the bug this replaces, just slower.
+    func testTheTotalBudgetIsBounded() {
+        let total = (1...ReconnectBackoff.maxAttempts)
+            .map { ReconnectBackoff.delay(forAttempt: $0) }
+            .reduce(0, +)
+        XCTAssertLessThan(total, 300, "Ten attempts should settle well inside five minutes")
+        XCTAssertGreaterThan(total, 30, "…but still spread out enough to outlast a blip")
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/ConnectionStateUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/ConnectionStateUITests.swift
@@ -1,0 +1,84 @@
+import XCTest
+
+/// The connection banner and composer states introduced with stall detection
+/// and bounded reconnect (#1793).
+///
+/// The stalled and gave-up states cannot be staged against a real leader in a
+/// hermetic test — one needs a peer that stops answering pings while keeping
+/// its channel open, the other needs a whole reconnect budget to expire — so
+/// `-uiTestConnectionState` pins the state directly. See `UITestHooks`.
+final class ConnectionStateUITests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    /// A busy leader must read as busy, not as a disconnect. This is the whole
+    /// point of the stall state: the connection is fine.
+    func testAStalledLeaderSaysSoInsteadOfClaimingDisconnection() {
+        let app = launchApp(forcing: "stalled")
+
+        let banner = app.staticTexts["connection-status"]
+        XCTAssertTrue(banner.waitForExistence(timeout: 60), "A stall should raise the banner")
+        XCTAssertTrue(
+            banner.label.contains("busy"),
+            "The banner should name the leader as busy, got \(banner.label)")
+        XCTAssertFalse(
+            banner.label.contains("Disconnected"),
+            "A stall is not a disconnect and must not read as one")
+    }
+
+    /// The composer has to refuse input during a stall, or a typed message is
+    /// accepted into a channel that cannot deliver it.
+    func testTheComposerRefusesInputDuringAStall() {
+        let app = launchApp(forcing: "stalled")
+
+        let placeholder = app.staticTexts["composer-placeholder"]
+        XCTAssertTrue(placeholder.waitForExistence(timeout: 60))
+        XCTAssertTrue(
+            placeholder.label.contains("busy"),
+            "The composer should explain the block, got \(placeholder.label)")
+    }
+
+    /// A transient reconnect must show progress, so it does not read as a hang.
+    func testReconnectingShowsWhichAttemptIsInFlight() {
+        let app = launchApp(forcing: "reconnecting")
+
+        let banner = app.staticTexts["connection-status"]
+        XCTAssertTrue(banner.waitForExistence(timeout: 60))
+        XCTAssertTrue(
+            banner.label.contains("Reconnecting"),
+            "Expected a reconnecting banner, got \(banner.label)")
+        XCTAssertTrue(
+            banner.label.contains("3"),
+            "The attempt count is what distinguishes a retry from a hang, got \(banner.label)")
+    }
+
+    /// Exhausting the budget is terminal and must say what the user can do.
+    func testGivingUpIsTerminalAndActionable() {
+        let app = launchApp(forcing: "gaveUp")
+
+        let banner = app.staticTexts["connection-status"]
+        XCTAssertTrue(banner.waitForExistence(timeout: 60))
+        XCTAssertTrue(
+            banner.label.contains("Couldn't reach the leader"),
+            "Expected the terminal copy, got \(banner.label)")
+        XCTAssertFalse(
+            banner.label.contains("Reconnecting"),
+            "Giving up must not still claim to be retrying")
+    }
+
+    // MARK: - Helpers
+
+    /// `joinUrl` is passed explicitly and empty so a value persisted by another
+    /// test cannot start a real connection underneath the forced state.
+    private func launchApp(forcing state: String) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-uiTestConnectionState", state,
+            "-joinUrl", "",
+        ]
+        app.launch()
+        return app
+    }
+}

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -40,6 +40,10 @@ struct ChatView: View {
             guard !hasAppeared else { return }
             hasAppeared = true
             #if DEBUG
+                if let forced = UITestHooks.forcedConnectionState {
+                    applyForcedConnectionState(forced)
+                    return
+                }
                 if UITestHooks.routesToFixture {
                     route = .fixture
                     return
@@ -54,6 +58,23 @@ struct ChatView: View {
             }
         }
     }
+
+    #if DEBUG
+        /// Pin the banner to one state for a UI test. `stalled` is a connected
+        /// leader that stopped answering, so it sets both fields.
+        private func applyForcedConnectionState(_ raw: String) {
+            if raw == "stalled" {
+                appState.connectionState = .connected
+                appState.isLeaderStalled = true
+                return
+            }
+            guard let state = ConnectionState(rawValue: raw) else { return }
+            appState.connectionState = state
+            if state == .reconnecting {
+                appState.reconnectAttempt = 3
+            }
+        }
+    #endif
 }
 
 // MARK: - ConversationView
@@ -72,9 +93,12 @@ struct ConversationView: View {
             // Connection status bar
             ConnectionStatusView(
                 state: appState.connectionState,
+                reconnectAttempt: appState.reconnectAttempt,
+                isStalled: appState.isLeaderStalled,
                 onTapDisconnected: { showSettings = true }
             )
             .animation(.easeInOut(duration: 0.3), value: appState.connectionState)
+            .animation(.easeInOut(duration: 0.3), value: appState.isLeaderStalled)
 
             // Scoop indicator + tap-to-cycle.
             if appState.scoops.count > 1 {
@@ -99,6 +123,10 @@ struct ConversationView: View {
                 text: $inputText,
                 isStreaming: appState.isStreaming,
                 isConnected: appState.connectionState == .connected,
+                // A message typed during a stall would be accepted into the
+                // composer and lost, so block sending — but say why, rather
+                // than claiming the follower is disconnected.
+                isStalled: appState.isLeaderStalled,
                 onSend: { text in
                     appState.sendMessage(text)
                     inputText = ""

--- a/packages/ios-app/SliccFollower/Views/ConnectionStatusView.swift
+++ b/packages/ios-app/SliccFollower/Views/ConnectionStatusView.swift
@@ -2,29 +2,45 @@ import SwiftUI
 
 struct ConnectionStatusView: View {
     let state: ConnectionState
+    /// In-flight reconnect attempt, 1-based. Zero renders no attempt count.
+    var reconnectAttempt: Int = 0
+    /// Leader stopped answering pings but its channel is still open.
+    var isStalled: Bool = false
     var onTapDisconnected: (() -> Void)?
 
+    /// A stall is only meaningful on an otherwise healthy connection; once the
+    /// state itself is degraded, that state is the more specific news.
+    private var showsStall: Bool { isStalled && state == .connected }
+
     private var dotColor: Color {
+        if showsStall { return .orange }
         switch state {
-        case .connected: .green
-        case .connecting: .yellow
-        case .reconnecting: .orange
-        case .disconnected, .failed: .red
+        case .connected: return .green
+        case .connecting: return .yellow
+        case .reconnecting: return .orange
+        case .disconnected, .failed, .gaveUp: return .red
         }
     }
 
     private var statusText: String? {
+        if showsStall { return "The leader is busy — hang on…" }
         switch state {
-        case .connected: nil
-        case .connecting: "Connecting…"
-        case .reconnecting: "Reconnecting…"
-        case .disconnected: "Disconnected"
-        case .failed: "Connection Failed"
+        case .connected: return nil
+        case .connecting: return "Connecting…"
+        case .reconnecting:
+            // Attempt feedback distinguishes a transient blip that is actively
+            // being retried from a connection that is merely hung.
+            return reconnectAttempt > 0
+                ? "Reconnecting… (\(reconnectAttempt)/\(ReconnectBackoff.maxAttempts))"
+                : "Reconnecting…"
+        case .disconnected: return "Disconnected"
+        case .failed: return "Connection Failed"
+        case .gaveUp: return "Couldn't reach the leader. Reload to retry."
         }
     }
 
     private var showBanner: Bool {
-        state != .connected
+        state != .connected || showsStall
     }
 
     var body: some View {
@@ -64,7 +80,8 @@ struct ConnectionStatusView: View {
                 value: state == .connecting
             )
             .onTapGesture {
-                if state == .disconnected || state == .failed {
+                // `.gaveUp` is terminal but actionable — tapping is the retry.
+                if state == .disconnected || state == .failed || state == .gaveUp {
                     onTapDisconnected?()
                 }
             }

--- a/packages/ios-app/SliccFollower/Views/InputBar.swift
+++ b/packages/ios-app/SliccFollower/Views/InputBar.swift
@@ -4,6 +4,9 @@ struct InputBar: View {
     @Binding var text: String
     let isStreaming: Bool
     let isConnected: Bool
+    /// Leader stopped answering pings while its channel stayed open. Sending is
+    /// blocked, but this is not a disconnect and must not read as one.
+    var isStalled: Bool = false
     let onSend: (String) -> Void
     let onAbort: () -> Void
 
@@ -15,11 +18,16 @@ struct InputBar: View {
     private let separatorColor = Color(white: 1, opacity: 0.1)
 
     private var canSend: Bool {
-        isConnected && !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isStreaming
+        isComposable && !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !isStreaming
     }
 
+    /// Whether a message can be handed to the leader at all.
+    private var isComposable: Bool { isConnected && !isStalled }
+
     private var placeholderText: String {
-        isConnected ? "Message..." : "Disconnected"
+        if isStalled { return "The leader is busy — hang on…" }
+        return isConnected ? "Message..." : "Disconnected"
     }
 
     var body: some View {
@@ -39,8 +47,8 @@ struct InputBar: View {
             .padding(.vertical, 8)
         }
         .background(barBackground)
-        .opacity(isConnected ? 1.0 : 0.5)
-        .disabled(!isConnected)
+        .opacity(isComposable ? 1.0 : 0.5)
+        .disabled(!isComposable)
         .animation(.easeInOut(duration: 0.2), value: isStreaming)
     }
 
@@ -57,6 +65,7 @@ struct InputBar: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 10)
                     .allowsHitTesting(false)
+                    .accessibilityIdentifier("composer-placeholder")
             }
 
             TextEditor(text: $text)
@@ -108,7 +117,7 @@ struct InputBar: View {
 
     private func sendIfPossible() {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, isConnected, !isStreaming else { return }
+        guard !trimmed.isEmpty, isComposable, !isStreaming else { return }
         onSend(trimmed)
         text = ""
     }

--- a/packages/ios-app/SliccFollower/Views/SettingsView.swift
+++ b/packages/ios-app/SliccFollower/Views/SettingsView.swift
@@ -157,7 +157,7 @@ struct SettingsView: View {
 
     private var connectionDotColor: Color {
         switch appState.connectionState {
-        case .disconnected, .failed: .red
+        case .disconnected, .failed, .gaveUp: .red
         case .connecting: .yellow
         case .connected: .green
         case .reconnecting: .orange
@@ -171,6 +171,7 @@ struct SettingsView: View {
         case .connected: "Connected"
         case .reconnecting: "Reconnecting…"
         case .failed: "Failed"
+        case .gaveUp: "Gave up"
         }
     }
 

--- a/packages/ios-app/project.yml
+++ b/packages/ios-app/project.yml
@@ -70,8 +70,13 @@ schemes:
       coverageTargets:
         - SliccFollower
       targets:
+        # Also serial, for the UI bundle's sake rather than its own. The 47
+        # unit tests total ~7s, so parallelizing them saves seconds, while the
+        # simulator clones it spawns compete with the UI runner's startup and
+        # leave it dying on "Timed out while loading Accessibility". Random
+        # order still holds, so test independence stays enforced.
         - name: SliccFollowerTests
-          parallelizable: true
+          parallelizable: false
           randomExecutionOrder: true
         # Serial on purpose. Each UI test is independent — it launches its own
         # app process with its own launch arguments — but cloning simulators


### PR DESCRIPTION
Closes #1793.

## Problem 1 — iOS killed healthy connections

`DataChannelKeepalive` went straight from `maxMissed` to `onDead`. A leader
that was merely CPU-starved — routinely the hosted-leader float, where the
agent and the sandbox share one small box — stopped answering pings long
before its transport died, so iOS tore down a working channel after ~30s and
paid for a full ICE/DTLS renegotiation. The disconnect was self-inflicted.

The TS follower fixed exactly this in `1d8c3d3d6` and `2e783cd1f`; this ports
the semantics:

| Condition | Result |
| --- | --- |
| `maxMissed` (3) reached, transport open | **stalled** — report once, keep probing, recover on the next answer |
| `hardMaxMissed` (30) reached | **dead** |
| `maxMissed` reached, transport closed | **dead** (unchanged) |

`isTransportOpen` defaults to `{ false }`, so any caller that omits it keeps
the old behavior.

## Problem 2 — one failed retry was terminal

Reconnect was a flat 3-second retry behind a `// TODO: Implement reconnect
with exponential backoff`. If that single attempt failed, the connection went
to `.failed` permanently. It is now bounded exponential backoff (1s, ×2, 30s
cap, 10 attempts) ending in a distinct `.gaveUp`, so a transient blip no
longer renders as a permanent error.

## Problem 3 — a blip and a cone error looked identical

`lastError` carried both. Cone errors now land in `leaderError`; `lastError`
is transport-only. The two render differently, which is the acceptance
criterion.

## UI

The composer refuses input while stalled and says *the leader is busy*
instead of claiming a disconnect, mirroring the web's `LEADER_BUSY`. It is a
separate `isStalled` input rather than folding the stall into `isConnected`,
so the placeholder does not lie. The banner shows which attempt is in flight,
so a retry does not read as a hang, and `.gaveUp` is tappable to retry.

## Also in scope

Adds the missing `TRAY_SEND_HIGH_WATER_BYTES` guard. Applied to **chunked
sends only** — gating small messages would starve keepalive ping/pong on a
congested channel and recreate the exact bug above (#1696).

## Tests

- **10 keepalive tests** driving `tick()` directly rather than the wall clock,
  covering stall, keep-probing, recover-by-pong, recover-by-ping, hard
  deadline, closed-transport death, the default gate, the equal-threshold
  boundary, and stop-suppresses-late-recovery.
- **4 backoff tests** for the schedule, the cap, non-positive attempts, and a
  bounded total budget.
- **4 UI tests** via a new `-uiTestConnectionState` hook, because neither a
  stall nor an exhausted budget can be staged against a real leader.

**Mutation-verified.** Disabling the stall branch fails exactly the five stall
tests and leaves the five death-asserting ones green. Mutating both stall UI
surfaces fails exactly the two stall UI tests and spares reconnecting and
gave-up.

## Verification

- `swift format lint --strict` clean; SwiftLint 0 errors (the two `force_try`
  warnings predate this branch, from release 3.42.1)
- Coverage 50.78/36.85/40.55 against floors raised to **50/36/40**
- `check-touched-exemptions` OK; `check-doc-sizes` 19,981/20,000
