### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -2,10 +2,10 @@
   "$comment": "Single source of truth for per-package coverage floors. Edited automatically by the nightly coverage ratchet (packages/dev-tools/tools/coverage-ratchet.mjs), which only ever raises floors and keeps a ~0.5-1.5pp headroom below measured coverage (a half-point safety margin then floored to a whole percentage). Consumed by the CI gates via coverage-gate.mjs (TypeScript) and swift-coverage-check.sh (Swift). Do not hand-lower these values.",
   "typescript": {
     "cloudflare-worker": {
-      "lines": 86,
+      "lines": 87,
       "statements": 86,
-      "functions": 92,
-      "branches": 75,
+      "functions": 93,
+      "branches": 76,
       "coverageExclude": [
         "**/node_modules/**",
         "**/dist/**",
@@ -68,8 +68,8 @@
       ]
     },
     "webapp": {
-      "lines": 80,
-      "statements": 78,
+      "lines": 81,
+      "statements": 79,
       "functions": 79,
       "branches": 69,
       "coverageExclude": [


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.