### PR TITLE
fix(slicc-cli): make reassembly eviction deterministic under coarse clocks

### DIFF
--- a/packages/slicc-cli/internal/tray/conn.go
+++ b/packages/slicc-cli/internal/tray/conn.go
@@ -521,14 +521,18 @@ func (c *Conn) acceptChunkFrame(data []byte) {
 // pending count is over budget. Caller must hold reassemblyMu.
 func (c *Conn) evictOldestReassemblyLocked() {
 	for len(c.reassembly) > maxPendingReassemblies {
+		// Selection is tracked with an explicit flag: the empty string is a
+		// syntactically valid chunkId, so it cannot double as "none selected".
 		var oldestID string
 		var oldest uint64
+		found := false
 		for id, entry := range c.reassembly {
-			if oldestID == "" || entry.seq < oldest {
+			if !found || entry.seq < oldest {
 				oldestID, oldest = id, entry.seq
+				found = true
 			}
 		}
-		if oldestID == "" {
+		if !found {
 			return
 		}
 		delete(c.reassembly, oldestID)

--- a/packages/slicc-cli/internal/tray/conn.go
+++ b/packages/slicc-cli/internal/tray/conn.go
@@ -94,8 +94,9 @@ type Conn struct {
 
 	// reassemblyMu guards reassembly; dispatch runs on the data-channel read
 	// goroutine, so inbound frames arrive serially, but Close may race it.
-	reassemblyMu sync.Mutex
-	reassembly   map[string]*chunkReassembly
+	reassemblyMu  sync.Mutex
+	reassembly    map[string]*chunkReassembly
+	reassemblySeq uint64
 
 	connected chan struct{}
 	done      chan struct{}
@@ -412,7 +413,10 @@ type chunkReassembly struct {
 	seen     []bool
 	received int
 	bytes    int
-	started  time.Time
+	// seq orders entries by insertion for oldest-first eviction. Not wall
+	// time: time.Now() is coarse enough on Windows that entries started in
+	// the same tick tie, and map iteration then evicts an arbitrary one.
+	seq uint64
 }
 
 // dispatch decodes the discriminant and routes inbound messages.
@@ -479,10 +483,11 @@ func (c *Conn) acceptChunkFrame(data []byte) {
 		return
 	}
 	if !ok {
+		c.reassemblySeq++
 		entry = &chunkReassembly{
-			chunks:  make([]string, frame.TotalChunks),
-			seen:    make([]bool, frame.TotalChunks),
-			started: time.Now(),
+			chunks: make([]string, frame.TotalChunks),
+			seen:   make([]bool, frame.TotalChunks),
+			seq:    c.reassemblySeq,
 		}
 		c.reassembly[frame.ChunkID] = entry
 		c.evictOldestReassemblyLocked()
@@ -517,10 +522,10 @@ func (c *Conn) acceptChunkFrame(data []byte) {
 func (c *Conn) evictOldestReassemblyLocked() {
 	for len(c.reassembly) > maxPendingReassemblies {
 		var oldestID string
-		var oldest time.Time
+		var oldest uint64
 		for id, entry := range c.reassembly {
-			if oldestID == "" || entry.started.Before(oldest) {
-				oldestID, oldest = id, entry.started
+			if oldestID == "" || entry.seq < oldest {
+				oldestID, oldest = id, entry.seq
 			}
 		}
 		if oldestID == "" {

--- a/packages/slicc-cli/internal/tray/conn_test.go
+++ b/packages/slicc-cli/internal/tray/conn_test.go
@@ -319,6 +319,34 @@ func TestDispatchEvictsOldestIncompleteReassembly(t *testing.T) {
 	}
 }
 
+// The empty string is a syntactically valid chunkId, so it must be evictable
+// like any other id — a sentinel-based selection would skip it (or let a later
+// map entry steal the selection) and the pending-entry bound would not hold.
+func TestDispatchEvictsOldestEvenWithEmptyChunkID(t *testing.T) {
+	calls := 0
+	c := newConnForDispatch(func(_ string, _ []byte) { calls++ })
+
+	original := `{"type":"user_message_echo","text":"` + strings.Repeat("x", 200_000) + `"}`
+	oldest := frameChunks(original, "")
+	encoded, _ := json.Marshal(oldest[0])
+	c.dispatch(encoded)
+	for i := 0; i < maxPendingReassemblies+1; i++ {
+		frames := frameChunks(original, string(rune('a'+i)))
+		encoded, _ := json.Marshal(frames[0])
+		c.dispatch(encoded)
+	}
+
+	// The empty-id reassembly was the oldest, so completing it emits nothing.
+	for _, frame := range oldest[1:] {
+		encoded, _ := json.Marshal(frame)
+		c.dispatch(encoded)
+	}
+
+	if calls != 0 {
+		t.Errorf("handler ran %d times for an evicted empty-id reassembly", calls)
+	}
+}
+
 func TestDispatchPassesSmallMessagesThrough(t *testing.T) {
 	var gotType string
 	c := newConnForDispatch(func(msgType string, _ []byte) { gotType = msgType })


### PR DESCRIPTION
## Summary

`TestDispatchEvictsOldestIncompleteReassembly` flaked on `windows-latest` in [CI run 30709000754](https://github.com/ai-ecoverse/slicc/actions/runs/30709000754) (on PR #1838, which doesn't touch Go at all): `handler ran 1 times for an evicted reassembly`. This makes the eviction order deterministic so the flake class is gone rather than retried — this module deliberately has no test-retry wrapper.

## Why

`evictOldestReassemblyLocked` ordered entries by a `time.Now()` captured per insert. Windows' wall clock is coarse (~1–15 ms ticks), so reassemblies started in a tight loop tie on `started`, and with a strict `Before` comparison the survivor among ties is whatever Go's randomized map iteration visits first — occasionally the entry the test (and the security property: a peer starting many large messages and finishing none must not pin memory) expects evicted.

"Oldest" always meant insertion order, so the fix orders eviction by a monotonic per-connection insertion sequence (`seq`, incremented under `reassemblyMu`) and drops the timestamp the entry no longer needs. Deterministic on every platform, no behavior change on ties' non-degenerate cases.

## Verification

- `go test -race -count=20 ./internal/tray/` — green (previously the tie + unlucky map order reproduced within similar counts on Windows; on macOS the clock is fine-grained enough that this mostly asserts no regression)
- `make check` — gofmt, tidy-check, vet, golangci-lint, race tests, coverage 61.0% vs 58% floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2m3i5QmGvGFehU4Uoi1k3
