### PR TITLE
feat(ios-app): discover and join tray sessions from iCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1273,6 +1273,7 @@ jobs:
     if: >-
       needs.lint.result == 'success' &&
       (needs.changes.outputs.ios-app == 'true' ||
+      needs.changes.outputs.swift-traysession == 'true' ||
       needs.changes.outputs.swift-config == 'true')
     runs-on: macos-latest
     # Simulator boots can wedge on fresh runner images; fail fast instead of

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,6 +218,10 @@ jobs:
           APPLE_DISTRIBUTION_CERT_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERT_BASE64 }}
           APPLE_DISTRIBUTION_CERT_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERT_PASSWORD }}
           APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+          # Repo variable, not a secret: set to 1 to archive the iOS build
+          # WITHOUT the iCloud KVS entitlement while the App Store profile
+          # lacks the iCloud capability (see package-and-upload-testflight.sh).
+          SLICC_IOS_NO_ICLOUD: ${{ vars.SLICC_IOS_NO_ICLOUD }}
         run: npx semantic-release
 
       - name: Cleanup keychain

--- a/packages/dev-tools/tools/release-native.mjs
+++ b/packages/dev-tools/tools/release-native.mjs
@@ -27,7 +27,7 @@ export const MACOS_PATH_PREFIXES = [
   'packages/spoon/',
   'packages/assets/',
 ];
-export const IOS_PATH_PREFIXES = ['packages/ios-app/'];
+export const IOS_PATH_PREFIXES = ['packages/ios-app/', 'packages/swift-traysession/'];
 
 // APPROVED relevant path set for the `slicc` Go CLI binaries. The CLI vendors
 // its own copy of the wire protocol (internal/protocol), so that part of the

--- a/packages/dev-tools/tools/release-native.test.mjs
+++ b/packages/dev-tools/tools/release-native.test.mjs
@@ -132,6 +132,9 @@ describe('matchesAnyPrefix', () => {
       )
     ).toBe(true);
     expect(matchesAnyPrefix('packages/ios-app/scripts/x.sh', IOS_PATH_PREFIXES)).toBe(true);
+    expect(matchesAnyPrefix('packages/swift-traysession/Package.swift', IOS_PATH_PREFIXES)).toBe(
+      true
+    );
   });
 
   it('does not match unrelated files', () => {

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -95,7 +95,8 @@ Payload fields decode _and_ render. Deliberate divergences from the web:
 `AppState.sessionStore` is a read-only `TraySessionSyncStore` from
 **`packages/swift-traysession`** (the launcher publishes; the phone only
 joins). `SettingsView` lists sessions grouped by device (`ICloudSessionList`);
-a tap threads `joinUrl` into `connect()`; the empty state distinguishes
+a tap joins via `connectToDiscoveredSession` — never the Join URL field or
+visible history; the empty state distinguishes
 signed-out from no-published-sessions. The entitlement's KVS id
 (`S8LB56P782.ai.sliccy.trays`) MUST match macOS releases. Unprovisioned builds
 degrade to an empty local cache; `SLICC_IOS_NO_ICLOUD=1` archives TestFlight

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -16,6 +16,7 @@ This package is NOT an npm workspace. It is a Swift Package Manager project (`Pa
 | `SliccFollower/Models/SyncProtocol.swift`                                                                                                                                                     | `Codable` mirror (partial — see "Protocol Mirror Invariant" below) of `packages/shared-ts/src/tray-sync-protocol.ts`                                                                                              |
 | `SliccFollower/Models/ChatMessage.swift`, `Models/TrayTypes.swift`, `Models/TrayChunkFraming.swift`                                                                                           | Chat + signaling data types. `TrayChunkFraming` holds the `__chunk` transport frame + `TrayChunkReassembler`: below both unions, so no corpus fixture. See `docs/architecture.md`                                 |
 | `SliccFollower/Sync/Keepalive.swift`                                                                                                                                                          | `DataChannelKeepalive` ping/pong actor (used by `AppState`)                                                                                                                                                       |
+| `SliccFollower/Models/ICloudSessionList.swift`, `SliccFollower.entitlements`                                                                                                                  | iCloud tray-session discovery: presentation logic over `SliccTraySession` (see "iCloud Sessions") + the KVS entitlement                                                                                           |
 | `SliccFollower/Networking/TraySignaling.swift`, `TrayFollowerConnector.swift`, `WebRTCManager.swift`                                                                                          | Signaling client + WebRTC peer/data-channel setup                                                                                                                                                                 |
 | `SliccFollower/CDP/CDPBridge.swift`, `CDPTarget.swift`                                                                                                                                        | Hosts WKWebViews as CDP targets the leader can drive remotely                                                                                                                                                     |
 | `SliccFollower/Views/ChatView.swift`, `MessageListView.swift`                                                                                                                                 | SwiftUI chat surface. `MessageListView` is the active renderer                                                                                                                                                    |
@@ -89,6 +90,18 @@ Payload fields decode _and_ render. Deliberate divergences from the web:
 - The error card omits the web's CTAs (`Try again`, `Open Settings`): each acts on leader state with no follower→leader equivalent, so it would silently no-op.
 - `tool_ui` renders a read-only card keyed by `requestId`, title extracted from the leader's HTML minus badge and meta (which carries the mount path). `tool_ui_done` removes it; a `snapshot` clears all cards.
 
+## iCloud Sessions
+
+`AppState.sessionStore` is a read-only `TraySessionSyncStore` from
+**`packages/swift-traysession`** (the launcher publishes; the phone only
+joins). `SettingsView` lists sessions grouped by device (`ICloudSessionList`);
+a tap threads `joinUrl` into `connect()`; the empty state distinguishes
+signed-out from no-published-sessions. The entitlement's KVS id
+(`S8LB56P782.ai.sliccy.trays`) MUST match macOS releases. Unprovisioned builds
+degrade to an empty local cache; `SLICC_IOS_NO_ICLOUD=1` archives TestFlight
+without the entitlement. `joinUrl` carries the session secret — never log it
+or put it in telemetry/accessibility ids (rows use the one-way `session.id`).
+
 ## Build
 
 ```bash
@@ -133,7 +146,10 @@ arguments, and getting a real Join URL — is covered in
 A `bundle.ui-testing` target runs alongside the unit bundle in the `SliccFollower`
 scheme, so `swift-coverage-check.sh --xcodebuild` picks up both. No test needs a
 leader: the `-uiTestFixtureRoute YES` launch argument reaches the leaderless
-**UI Fixture** route (`FixtureConversationView`) without a tap. `UITestHooks`
+**UI Fixture** route (`FixtureConversationView`) without a tap, and
+`-uiTestSessionsFixture YES` / `-uiTestSessionsEmpty YES` seed the iCloud
+sessions list from an in-memory backend (fixture join URLs dial
+`127.0.0.1:1`, so a tapped row settles on Connection Failed hermetically). `UITestHooks`
 (`App/UITestHooks.swift`) reads it and is `#if DEBUG` only — a shipped binary
 must not carry a flag that skips the connection path. The failure-state test
 dials `http://127.0.0.1:1/…` — refused without DNS or egress, so

--- a/packages/ios-app/Package.swift
+++ b/packages/ios-app/Package.swift
@@ -13,13 +13,15 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/stasel/WebRTC.git", .upToNextMajor(from: "150.0.0"))
+        .package(url: "https://github.com/stasel/WebRTC.git", .upToNextMajor(from: "150.0.0")),
+        .package(path: "../swift-traysession"),
     ],
     targets: [
         .target(
             name: "SliccFollower",
             dependencies: [
-                .product(name: "WebRTC", package: "WebRTC")
+                .product(name: "WebRTC", package: "WebRTC"),
+                .product(name: "SliccTraySession", package: "swift-traysession"),
             ],
             path: "SliccFollower",
             resources: [

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -15,12 +15,14 @@
 		238295F68E3669C0968C9934 /* WebRTCManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AF8A8A50FCC9C2DBECA0CF /* WebRTCManager.swift */; };
 		2401C7FE702795E1066A7C9F /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB646EF0D0006D1A43F527D /* ChatMessage.swift */; };
 		2CE789AA836BB0713F1250D7 /* CDPBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE0A7D88487F7712E451646 /* CDPBridge.swift */; };
+		306C9DAD5071D0E813194FC5 /* ICloudSessionListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D53BAF8B8E31F0EC06B69E /* ICloudSessionListTests.swift */; };
 		3A9E122F6A6C4C0F6258C5C6 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A069AA812629AC5FE70AC9 /* SettingsView.swift */; };
 		3EDEBD047CEC3F24BC3ED785 /* SliccFollowerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D4AD0E32B059DB9EABFF3E /* SliccFollowerApp.swift */; };
 		472BB1BEB4E248916156C9EE /* tray-sync-corpus.json in Resources */ = {isa = PBXBuildFile; fileRef = FD6CEFD575FD21C28BEC39F5 /* tray-sync-corpus.json */; };
 		4874F8858460397F336DE469 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = CEF104FB1C3EDA0B98BC5FFF /* WebRTC */; };
 		487756D13ED6B5D4FB9FF6A0 /* TrayFollowerConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93EE217FAA3F9F7DD3A0B07F /* TrayFollowerConnector.swift */; };
 		4A9B912F64233A5C73E57DB4 /* FixtureConversationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FA307998C15DDB13AC2852 /* FixtureConversationUITests.swift */; };
+		4D82D5E38FB3BC4E9924A482 /* SliccTraySession in Frameworks */ = {isa = PBXBuildFile; productRef = 94A995EE85CB8B2E61D3B1C2 /* SliccTraySession */; };
 		532EBF4FC79CF40ABCD366F0 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E99369A8A6B1A9B8EBE996E /* WebKit.framework */; };
 		541C36C1FB80D6EDBA337FE6 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A69E83B7BB267C230C892A29 /* PrivacyInfo.xcprivacy */; };
 		54B15E202D059EA1DBB4ED44 /* KeepaliveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D76B8F603084A6021B6DD6B /* KeepaliveTests.swift */; };
@@ -38,9 +40,11 @@
 		8A4DC8067E31936EA9C475BC /* TrayTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDB6F858D918DBBE06D4702 /* TrayTypes.swift */; };
 		8EEACE6ED76E43E36FC9F0AB /* ChatFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA9A527E2D4BBCE1BDFA89C /* ChatFixture.swift */; };
 		977007CC44BE2B53361DF256 /* Keepalive.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA931BF1BE121985E2FB3EE /* Keepalive.swift */; };
+		9AD8326007279D3F37D57C9C /* ICloudSessionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D158A5ACE0AC9C2CE6FEFCD3 /* ICloudSessionList.swift */; };
 		9FC130913A6643DA7276FFFA /* ToolUICard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD3AFC2F2EB348C5A74AEA3 /* ToolUICard.swift */; };
 		A2488147A916BDDB57B9A41C /* CDPTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6B46ECEC5C79FA6D986F9 /* CDPTarget.swift */; };
 		A50239DCBBAD6235AC7C296A /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF78C09597C5D63A373EB126 /* MessageBubble.swift */; };
+		A5A215E64B167C5F918EA6FA /* ICloudSessionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FC22E5B3D4B0DA205C7F62 /* ICloudSessionsUITests.swift */; };
 		A9C0449A188D09A99F506FFE /* InlineSprinkleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2EECDCB4AF899D3071D13C /* InlineSprinkleView.swift */; };
 		B4A19D759C5C4CDDFFA1FC35 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8BFCDA8C3F71C0A853D573 /* ContentView.swift */; };
 		B8033DFD106285BDC91FBEC4 /* FsClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0835A30393CEF046BA90DB16 /* FsClientTests.swift */; };
@@ -100,11 +104,14 @@
 		4E70132BA0E6C4BC99D8CB73 /* TraySignaling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraySignaling.swift; sourceTree = "<group>"; };
 		4E99369A8A6B1A9B8EBE996E /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		523A4A068180D7EE98435885 /* MarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownText.swift; sourceTree = "<group>"; };
+		55D53BAF8B8E31F0EC06B69E /* ICloudSessionListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudSessionListTests.swift; sourceTree = "<group>"; };
 		5AF41895CF5F76A1CD2B671E /* LickEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LickEvent.swift; sourceTree = "<group>"; };
 		5EB9ADA61005F3F96BE8CDE2 /* LinkHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHeader.swift; sourceTree = "<group>"; };
+		610460E1CC7B9EBB1F34EC0E /* SliccFollower.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SliccFollower.entitlements; sourceTree = "<group>"; };
 		618555E73F15FDB4DB0CAA6F /* SyncProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncProtocol.swift; sourceTree = "<group>"; };
 		62B1B7433B4D853B17578E82 /* LickEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LickEnvelopeTests.swift; sourceTree = "<group>"; };
 		639AB6CC8494FCE4C252F00B /* ChunkFramingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkFramingTests.swift; sourceTree = "<group>"; };
+		740A6B3BC797CFC901E08521 /* swift-traysession */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "swift-traysession"; path = "../swift-traysession"; sourceTree = SOURCE_ROOT; };
 		747034EA0B5B45B56875A5DD /* LinkHeaderCorpusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHeaderCorpusTests.swift; sourceTree = "<group>"; };
 		7E727142147B0FB449F418D1 /* MessageListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListView.swift; sourceTree = "<group>"; };
 		88219CD0B963530C38CE40FB /* SliccFollowerUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SliccFollowerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -126,8 +133,10 @@
 		C9C3A976D441E4BB628F2183 /* SprinkleWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SprinkleWebView.swift; sourceTree = "<group>"; };
 		CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBar.swift; sourceTree = "<group>"; };
 		CFEC70BAB27CC325BCD99C01 /* SliccFollowerTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SliccFollowerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D158A5ACE0AC9C2CE6FEFCD3 /* ICloudSessionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudSessionList.swift; sourceTree = "<group>"; };
 		DD1308398CD972FF297E2C75 /* UITestHooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestHooks.swift; sourceTree = "<group>"; };
 		DFC4F75EC6A6C1D71314A24D /* TrayFs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayFs.swift; sourceTree = "<group>"; };
+		E9FC22E5B3D4B0DA205C7F62 /* ICloudSessionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudSessionsUITests.swift; sourceTree = "<group>"; };
 		F0425579D2C460F993D259DB /* ToolUIPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolUIPlaceholderTests.swift; sourceTree = "<group>"; };
 		F0583BDF50B1A1B9CE68AE67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F0A069AA812629AC5FE70AC9 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -141,6 +150,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4874F8858460397F336DE469 /* WebRTC in Frameworks */,
+				4D82D5E38FB3BC4E9924A482 /* SliccTraySession in Frameworks */,
 				532EBF4FC79CF40ABCD366F0 /* WebKit.framework in Frameworks */,
 				FBCB39B163E63ED4E5CA70C6 /* AVFoundation.framework in Frameworks */,
 			);
@@ -154,6 +164,7 @@
 			children = (
 				639AB6CC8494FCE4C252F00B /* ChunkFramingTests.swift */,
 				0835A30393CEF046BA90DB16 /* FsClientTests.swift */,
+				55D53BAF8B8E31F0EC06B69E /* ICloudSessionListTests.swift */,
 				8D76B8F603084A6021B6DD6B /* KeepaliveTests.swift */,
 				62B1B7433B4D853B17578E82 /* LickEnvelopeTests.swift */,
 				747034EA0B5B45B56875A5DD /* LinkHeaderCorpusTests.swift */,
@@ -190,6 +201,7 @@
 			isa = PBXGroup;
 			children = (
 				BBB646EF0D0006D1A43F527D /* ChatMessage.swift */,
+				D158A5ACE0AC9C2CE6FEFCD3 /* ICloudSessionList.swift */,
 				5AF41895CF5F76A1CD2B671E /* LickEvent.swift */,
 				618555E73F15FDB4DB0CAA6F /* SyncProtocol.swift */,
 				356386D299A1933A39CB972B /* TrayChunkFraming.swift */,
@@ -211,6 +223,7 @@
 		645B35912FE46A12B4225E91 = {
 			isa = PBXGroup;
 			children = (
+				9909FDE81B84636F9A79E359 /* Packages */,
 				BB5014359700AC04F578180A /* SliccFollower */,
 				32BEF7BC73FC1288DC470211 /* SliccFollowerTests */,
 				7F41C1476E661236B93AE3D7 /* SliccFollowerUITests */,
@@ -225,6 +238,7 @@
 				FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */,
 				37492C8E3201CB2A14C6BD12 /* ConnectionStateUITests.swift */,
 				A5FA307998C15DDB13AC2852 /* FixtureConversationUITests.swift */,
+				E9FC22E5B3D4B0DA205C7F62 /* ICloudSessionsUITests.swift */,
 			);
 			name = SliccFollowerUITests;
 			path = SliccFollower/Tests/SliccFollowerUITests;
@@ -263,6 +277,14 @@
 			path = Networking;
 			sourceTree = "<group>";
 		};
+		9909FDE81B84636F9A79E359 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				740A6B3BC797CFC901E08521 /* swift-traysession */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
 		9CFF76BF3998C901E0323030 /* Sync */ = {
 			isa = PBXGroup;
 			children = (
@@ -293,6 +315,7 @@
 		BB5014359700AC04F578180A /* SliccFollower */ = {
 			isa = PBXGroup;
 			children = (
+				610460E1CC7B9EBB1F34EC0E /* SliccFollower.entitlements */,
 				465A70583C8607C07D58E04D /* App */,
 				A80E98982729018ABE0252BF /* CDP */,
 				51886095A534C38E3C7A30E7 /* Models */,
@@ -341,6 +364,7 @@
 			name = SliccFollower;
 			packageProductDependencies = (
 				CEF104FB1C3EDA0B98BC5FFF /* WebRTC */,
+				94A995EE85CB8B2E61D3B1C2 /* SliccTraySession */,
 			);
 			productName = SliccFollower;
 			productReference = C00DD8A5F90DA65983AA6601 /* SliccFollower.app */;
@@ -408,6 +432,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				FFE71351C061C8F247B95AFA /* XCRemoteSwiftPackageReference "WebRTC" */,
+				8F70B47C71BDD8563EA8DCE6 /* XCLocalSwiftPackageReference "../swift-traysession" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 4F9716065FA89F76CAF30D9E /* Products */;
@@ -458,6 +483,7 @@
 				B4A19D759C5C4CDDFFA1FC35 /* ContentView.swift in Sources */,
 				D493553CF88D9F88586D7E93 /* FsClient.swift in Sources */,
 				CCD45A2DC9CD2D58A5CBCA0F /* HandoffLink.swift in Sources */,
+				9AD8326007279D3F37D57C9C /* ICloudSessionList.swift in Sources */,
 				A9C0449A188D09A99F506FFE /* InlineSprinkleView.swift in Sources */,
 				0CAAEE94D02D4006193FA4BB /* InputBar.swift in Sources */,
 				977007CC44BE2B53361DF256 /* Keepalive.swift in Sources */,
@@ -491,6 +517,7 @@
 				67EC4D5BDDC4014A965FF5B4 /* ConnectionRouteUITests.swift in Sources */,
 				BD662161506DEE603F8854EF /* ConnectionStateUITests.swift in Sources */,
 				4A9B912F64233A5C73E57DB4 /* FixtureConversationUITests.swift in Sources */,
+				A5A215E64B167C5F918EA6FA /* ICloudSessionsUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -500,6 +527,7 @@
 			files = (
 				8017E9416AEB3D7756ADEB3A /* ChunkFramingTests.swift in Sources */,
 				B8033DFD106285BDC91FBEC4 /* FsClientTests.swift in Sources */,
+				306C9DAD5071D0E813194FC5 /* ICloudSessionListTests.swift in Sources */,
 				54B15E202D059EA1DBB4ED44 /* KeepaliveTests.swift in Sources */,
 				BAEB06EC85F8242C542D4782 /* LickEnvelopeTests.swift in Sources */,
 				CA14A8C5DE0A027197214AEF /* LinkHeaderCorpusTests.swift in Sources */,
@@ -529,6 +557,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = SliccFollower/SliccFollower.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app does not access the camera. This entry is required because the bundled WebRTC framework references camera APIs.";
@@ -654,6 +683,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = SliccFollower/SliccFollower.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app does not access the camera. This entry is required because the bundled WebRTC framework references camera APIs.";
@@ -823,6 +853,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		8F70B47C71BDD8563EA8DCE6 /* XCLocalSwiftPackageReference "../swift-traysession" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../swift-traysession";
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		FFE71351C061C8F247B95AFA /* XCRemoteSwiftPackageReference "WebRTC" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -835,6 +872,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		94A995EE85CB8B2E61D3B1C2 /* SliccTraySession */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SliccTraySession;
+		};
 		CEF104FB1C3EDA0B98BC5FFF /* WebRTC */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = FFE71351C061C8F247B95AFA /* XCRemoteSwiftPackageReference "WebRTC" */;

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -209,15 +209,34 @@ class AppState: ObservableObject {
 
     // MARK: - Connection Lifecycle
 
+    /// The URL of the session currently being dialed. Manual connects copy it
+    /// from the Join URL field; discovered sessions set it directly so the
+    /// secret-bearing URL never surfaces in the field, the persisted setting,
+    /// or the visible history. Reconnects reuse it.
+    private var activeJoinUrl: String = ""
+
     /// Attempt to connect to the tray using the current joinUrl.
     func connect() {
-        let trimmed = joinUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        connect(to: joinUrl, rememberInHistory: true)
+    }
+
+    /// Join an iCloud-discovered session. The URL stays out of the Join URL
+    /// field, the `joinUrl` setting, and the Recent URLs list — a discovered
+    /// session is rediscoverable from iCloud, so nothing needs to remember
+    /// (or display) its secret.
+    func connectToDiscoveredSession(joinUrl url: String) {
+        connect(to: url, rememberInHistory: false)
+    }
+
+    private func connect(to rawUrl: String, rememberInHistory: Bool) {
+        let trimmed = rawUrl.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, let url = URL(string: trimmed) else { return }
         guard connectionState != .connecting else { return }
 
         connectionState = .connecting
         lastError = nil
-        addToHistory(joinUrl)
+        if rememberInHistory { addToHistory(trimmed) }
+        activeJoinUrl = trimmed
 
         // Tear down any previous connection first.
         tearDown()
@@ -1250,9 +1269,9 @@ class AppState: ObservableObject {
             // moves us out of `.reconnecting`; abandon the budget silently.
             guard connectionState == .reconnecting else { return }
 
-            connect()
+            connect(to: activeJoinUrl, rememberInHistory: false)
 
-            // `connect()` drives its own async signaling; wait for it to settle
+            // `connect(to:)` drives its own async signaling; wait for it to settle
             // before deciding whether this attempt earned another.
             await connectTask?.value
             if Task.isCancelled { return }

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SliccTraySession
 import SwiftUI
 import WebKit
 import WebRTC
@@ -140,10 +141,31 @@ class AppState: ObservableObject {
 
     // MARK: - Init
 
+    /// Tray sessions other devices published to iCloud KVS (the macOS
+    /// launcher is the producer). Read-only here: the phone joins sessions,
+    /// it never publishes one. `@Observable`, so SwiftUI views track it
+    /// directly; without iCloud provisioning it degrades to a local cache
+    /// and simply stays empty.
+    let sessionStore: TraySessionSyncStore
+
     init() {
+        sessionStore = AppState.makeSessionStore()
         if let history = UserDefaults.standard.stringArray(forKey: "joinUrlHistory") {
             joinUrlHistory = history
         }
+    }
+
+    private static func makeSessionStore() -> TraySessionSyncStore {
+        #if DEBUG
+            if let fixture = UITestHooks.sessionsFixtureBackend() {
+                return TraySessionSyncStore(
+                    backend: fixture,
+                    deviceId: "ios-under-test",
+                    deviceName: "iPhone Under Test"
+                )
+            }
+        #endif
+        return TraySessionSyncStore()
     }
 
     // MARK: - Private Networking / Sync

--- a/packages/ios-app/SliccFollower/App/UITestHooks.swift
+++ b/packages/ios-app/SliccFollower/App/UITestHooks.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SliccTraySession
 
 #if DEBUG
     /// Launch-argument seams that let XCUITest reach a deterministic screen
@@ -28,6 +29,66 @@ import Foundation
         /// "connected, but the leader stopped answering".
         static var forcedConnectionState: String? {
             UserDefaults.standard.string(forKey: "uiTestConnectionState")
+        }
+
+        /// Seed the iCloud sessions list without touching iCloud:
+        /// `-uiTestSessionsFixture YES` yields two devices' worth of fixture
+        /// sessions, `-uiTestSessionsEmpty YES` a deterministic empty store.
+        /// Join URLs dial 127.0.0.1:1 so a tap reaches Connection Failed
+        /// hermetically, like the existing failure-state test.
+        static func sessionsFixtureBackend() -> KeyValueSyncBackend? {
+            if UserDefaults.standard.bool(forKey: "uiTestSessionsEmpty") {
+                return InMemoryKeyValueBackend()
+            }
+            guard UserDefaults.standard.bool(forKey: "uiTestSessionsFixture") else { return nil }
+            let backend = InMemoryKeyValueBackend()
+            let now = Date()
+            seed(
+                backend,
+                deviceId: "fixture-macbook",
+                sessions: [
+                    SyncedTraySession(
+                        joinUrl: "http://127.0.0.1:1/join/fixture-chrome",
+                        label: "Chrome on Fixture MacBook",
+                        deviceId: "fixture-macbook",
+                        deviceName: "Fixture MacBook",
+                        createdAt: now.addingTimeInterval(-3600),
+                        lastSeenAt: now.addingTimeInterval(-60)
+                    ),
+                    SyncedTraySession(
+                        joinUrl: "http://127.0.0.1:1/join/fixture-edge",
+                        label: "Edge on Fixture MacBook",
+                        deviceId: "fixture-macbook",
+                        deviceName: "Fixture MacBook",
+                        createdAt: now.addingTimeInterval(-7200),
+                        lastSeenAt: now.addingTimeInterval(-7200)
+                    ),
+                ]
+            )
+            seed(
+                backend,
+                deviceId: "fixture-studio",
+                sessions: [
+                    SyncedTraySession(
+                        joinUrl: "http://127.0.0.1:1/join/fixture-studio",
+                        label: "Chrome on Fixture Studio",
+                        deviceId: "fixture-studio",
+                        deviceName: "Fixture Studio",
+                        createdAt: now.addingTimeInterval(-300),
+                        lastSeenAt: now.addingTimeInterval(-300)
+                    )
+                ]
+            )
+            return backend
+        }
+
+        private static func seed(
+            _ backend: KeyValueSyncBackend,
+            deviceId: String,
+            sessions: [SyncedTraySession]
+        ) {
+            guard let data = try? JSONEncoder().encode(sessions) else { return }
+            backend.setData(data, forKey: TraySessionSyncStore.storageKeyPrefix + deviceId)
         }
     }
 #endif

--- a/packages/ios-app/SliccFollower/Models/ICloudSessionList.swift
+++ b/packages/ios-app/SliccFollower/Models/ICloudSessionList.swift
@@ -1,0 +1,59 @@
+import Foundation
+import SliccTraySession
+
+/// Presentation logic for the Settings "iCloud Sessions" list, kept out of
+/// the view so grouping, ordering, and the empty-state decision are unit
+/// testable without SwiftUI or iCloud.
+enum ICloudSessionList {
+    /// One publishing device's sessions, newest-first. Grouping keys on
+    /// `deviceId` — two Macs may share a host name — while the header shows
+    /// `deviceName`.
+    struct DeviceGroup: Equatable, Identifiable {
+        let deviceId: String
+        let deviceName: String
+        let sessions: [SyncedTraySession]
+        var id: String { deviceId }
+    }
+
+    /// Groups the store's (already newest-first, already TTL-pruned) sessions
+    /// by publishing device. Devices keep the order of their newest session,
+    /// so the most recently active Mac sorts first.
+    static func groups(from sessions: [SyncedTraySession]) -> [DeviceGroup] {
+        var order: [String] = []
+        var byDevice: [String: [SyncedTraySession]] = [:]
+        for session in sessions {
+            if byDevice[session.deviceId] == nil { order.append(session.deviceId) }
+            byDevice[session.deviceId, default: []].append(session)
+        }
+        return order.compactMap { id in
+            guard let sessions = byDevice[id], let first = sessions.first else { return nil }
+            let name = first.deviceName.isEmpty ? "Unknown device" : first.deviceName
+            return DeviceGroup(deviceId: id, deviceName: name, sessions: sessions)
+        }
+    }
+
+    /// Why the list is empty — the two cases need different guidance. Signed
+    /// out of iCloud is user-fixable on the phone; "no sessions" means no Mac
+    /// on this Apple ID is currently advertising a leader. (An unprovisioned
+    /// dev build is indistinguishable from the latter at runtime: the KVS
+    /// degrades silently to an empty local cache.)
+    enum EmptyReason: Equatable {
+        case iCloudUnavailable
+        case noSessions
+    }
+
+    static func emptyReason(hasICloudIdentity: Bool) -> EmptyReason {
+        hasICloudIdentity ? .noSessions : .iCloudUnavailable
+    }
+
+    /// Compact relative age for a session row ("2m ago"). Mirrors the macOS
+    /// launcher's `TraySessionRow.age` thresholds so both platforms describe
+    /// the same session the same way.
+    static func age(of date: Date, now: Date) -> String {
+        let seconds = now.timeIntervalSince(date)
+        if seconds < 60 { return "just now" }
+        if seconds < 3600 { return "\(Int(seconds / 60))m ago" }
+        if seconds < 86_400 { return "\(Int(seconds / 3600))h ago" }
+        return "\(Int(seconds / 86_400))d ago"
+    }
+}

--- a/packages/ios-app/SliccFollower/SliccFollower.entitlements
+++ b/packages/ios-app/SliccFollower/SliccFollower.entitlements
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- iCloud key-value store for cross-device tray-session discovery.
+	     MUST match what macOS releases ship (packages/swift-launcher/CLAUDE.md
+	     "iCloud provisioning": S8LB56P782.ai.sliccy.trays) so both platforms
+	     read the same container. Unsigned/dev builds without a provisioning
+	     profile degrade to a local cache (UbiquitousKeyValueBackend). -->
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>S8LB56P782.ai.sliccy.trays</string>
+</dict>
+</plist>

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/ICloudSessionListTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/ICloudSessionListTests.swift
@@ -1,0 +1,109 @@
+import SliccTraySession
+import XCTest
+
+@testable import SliccFollower
+
+final class ICloudSessionListTests: XCTestCase {
+    // MARK: - Grouping
+
+    func testGroupsKeyOnDeviceIdAndKeepNewestFirstDeviceOrder() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        // Store order is newest-first; the Studio session is newest overall.
+        let sessions = [
+            makeSession(joinUrl: "https://t.test/join/s1.secret", label: "Chrome on Studio", deviceId: "studio", deviceName: "MacBook Pro", lastSeenAt: now),
+            makeSession(
+                joinUrl: "https://t.test/join/m1.secret", label: "Chrome on Book", deviceId: "book", deviceName: "MacBook Pro",
+                lastSeenAt: now.addingTimeInterval(-60)),
+            makeSession(
+                joinUrl: "https://t.test/join/m2.secret", label: "Edge on Book", deviceId: "book", deviceName: "MacBook Pro",
+                lastSeenAt: now.addingTimeInterval(-120)),
+        ]
+
+        let groups = ICloudSessionList.groups(from: sessions)
+
+        XCTAssertEqual(groups.map(\.deviceId), ["studio", "book"])
+        // Same host name on both Macs must NOT merge the groups.
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertEqual(groups[1].sessions.map(\.label), ["Chrome on Book", "Edge on Book"])
+    }
+
+    func testGroupsFallBackToPlaceholderForEmptyDeviceName() {
+        let sessions = [
+            makeSession(joinUrl: "https://t.test/join/x.secret", label: "Chrome", deviceId: "d1", deviceName: "", lastSeenAt: Date())
+        ]
+        XCTAssertEqual(ICloudSessionList.groups(from: sessions).first?.deviceName, "Unknown device")
+    }
+
+    func testGroupsOfNothingIsEmpty() {
+        XCTAssertTrue(ICloudSessionList.groups(from: []).isEmpty)
+    }
+
+    // MARK: - Empty state
+
+    func testEmptyReasonDistinguishesSignedOutFromNoSessions() {
+        XCTAssertEqual(ICloudSessionList.emptyReason(hasICloudIdentity: false), .iCloudUnavailable)
+        XCTAssertEqual(ICloudSessionList.emptyReason(hasICloudIdentity: true), .noSessions)
+    }
+
+    // MARK: - Age
+
+    func testAgeThresholdsMatchTheLauncher() {
+        let now = Date(timeIntervalSince1970: 100_000)
+        XCTAssertEqual(ICloudSessionList.age(of: now, now: now), "just now")
+        XCTAssertEqual(ICloudSessionList.age(of: now.addingTimeInterval(-120), now: now), "2m ago")
+        XCTAssertEqual(ICloudSessionList.age(of: now.addingTimeInterval(-7200), now: now), "2h ago")
+        XCTAssertEqual(ICloudSessionList.age(of: now.addingTimeInterval(-172_800), now: now), "2d ago")
+    }
+
+    // MARK: - UITest fixture seam
+
+    func testSessionsFixtureBackendSeedsTwoDevices() throws {
+        UserDefaults.standard.set(true, forKey: "uiTestSessionsFixture")
+        defer { UserDefaults.standard.removeObject(forKey: "uiTestSessionsFixture") }
+
+        let backend = try XCTUnwrap(UITestHooks.sessionsFixtureBackend())
+        let store = TraySessionSyncStore(
+            backend: backend, deviceId: "ios-under-test", deviceName: "iPhone Under Test"
+        )
+
+        let groups = ICloudSessionList.groups(from: store.sessions)
+        XCTAssertEqual(Set(groups.map(\.deviceName)), ["Fixture MacBook", "Fixture Studio"])
+        XCTAssertEqual(store.sessions.count, 3)
+        // Every fixture join URL is hermetic — no test may dial out.
+        XCTAssertTrue(store.sessions.allSatisfy { $0.joinUrl.hasPrefix("http://127.0.0.1:1/") })
+    }
+
+    func testSessionsEmptyBackendYieldsDeterministicEmptyStore() throws {
+        UserDefaults.standard.set(true, forKey: "uiTestSessionsEmpty")
+        defer { UserDefaults.standard.removeObject(forKey: "uiTestSessionsEmpty") }
+
+        let backend = try XCTUnwrap(UITestHooks.sessionsFixtureBackend())
+        let store = TraySessionSyncStore(
+            backend: backend, deviceId: "ios-under-test", deviceName: "iPhone Under Test"
+        )
+        XCTAssertTrue(store.sessions.isEmpty)
+    }
+
+    func testNoFixtureArgumentsMeansNoBackend() {
+        XCTAssertNil(UITestHooks.sessionsFixtureBackend())
+    }
+
+    // MARK: - Helpers
+
+    private func makeSession(
+        joinUrl: String,
+        label: String,
+        deviceId: String,
+        deviceName: String,
+        lastSeenAt: Date
+    ) -> SyncedTraySession {
+        SyncedTraySession(
+            joinUrl: joinUrl,
+            label: label,
+            deviceId: deviceId,
+            deviceName: deviceName,
+            createdAt: lastSeenAt,
+            lastSeenAt: lastSeenAt
+        )
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/ICloudSessionListTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/ICloudSessionListTests.swift
@@ -88,6 +88,25 @@ final class ICloudSessionListTests: XCTestCase {
         XCTAssertNil(UITestHooks.sessionsFixtureBackend())
     }
 
+    // MARK: - Discovered-session connect path
+
+    /// The security contract of tap-to-join: the secret-bearing URL must not
+    /// surface in the Join URL field or the visible Recent URLs history.
+    @MainActor
+    func testDiscoveredSessionConnectLeavesManualSurfacesUntouched() {
+        let state = AppState()
+        defer { state.disconnect() }
+        let secret = "http://127.0.0.1:1/join/discovered.secret"
+
+        state.connectToDiscoveredSession(joinUrl: secret)
+
+        XCTAssertEqual(state.connectionState, .connecting)
+        XCTAssertEqual(state.joinUrl, "", "The Join URL field must stay empty")
+        XCTAssertFalse(
+            state.joinUrlHistory.contains(secret),
+            "A discovered URL must not enter the visible history")
+    }
+
     // MARK: - Helpers
 
     private func makeSession(

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/ICloudSessionsUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/ICloudSessionsUITests.swift
@@ -1,0 +1,60 @@
+import XCTest
+
+/// UI coverage for the Settings "iCloud Sessions" list, seeded through the
+/// `-uiTestSessionsFixture` / `-uiTestSessionsEmpty` hooks so no test touches
+/// real iCloud. Fixture join URLs dial 127.0.0.1:1, the same hermetic
+/// unreachable endpoint the connection-route tests use.
+final class ICloudSessionsUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testFixtureSessionsListGroupedRowsAndTapConnects() {
+        let app = XCUIApplication()
+        app.launchArguments += ["-joinUrl", "", "-uiTestSessionsFixture", "YES"]
+        app.launch()
+
+        XCTAssertTrue(
+            app.navigationBars["Settings"].waitForExistence(timeout: 60),
+            "An empty join URL should open the Settings sheet on launch")
+
+        // Rows are identified by the one-way session id — never the join URL —
+        // so match on the stable prefix instead of hardcoding hashes.
+        let rows = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH %@", "icloud-session-"))
+        XCTAssertTrue(
+            rows.firstMatch.waitForExistence(timeout: 30),
+            "Seeded fixture sessions should render as rows")
+        XCTAssertEqual(rows.count, 3, "Both fixture devices' sessions should be listed")
+
+        // Device and label text surface from the fixture payloads.
+        XCTAssertTrue(app.staticTexts["Chrome on Fixture MacBook"].exists)
+        XCTAssertTrue(app.staticTexts["Chrome on Fixture Studio"].exists)
+
+        // Tapping a row threads its join URL into the real connect path. The
+        // fixture URL is refused instantly, so the settled state is Failed —
+        // which proves the tap connected rather than just closing the sheet.
+        rows.firstMatch.tap()
+        let pill = app.staticTexts["connection-status"]
+        XCTAssertTrue(pill.waitForExistence(timeout: 30))
+        let failed = NSPredicate(format: "label == %@", "Connection Failed")
+        expectation(for: failed, evaluatedWith: pill)
+        waitForExpectations(timeout: 60)
+    }
+
+    func testEmptyStateNamesTheReason() {
+        let app = XCUIApplication()
+        app.launchArguments += ["-joinUrl", "", "-uiTestSessionsEmpty", "YES"]
+        app.launch()
+
+        XCTAssertTrue(
+            app.navigationBars["Settings"].waitForExistence(timeout: 60),
+            "An empty join URL should open the Settings sheet on launch")
+        XCTAssertTrue(
+            app.otherElements["icloud-sessions-empty"].waitForExistence(timeout: 30)
+                || app.staticTexts["icloud-sessions-empty"].waitForExistence(timeout: 5),
+            "An empty session list should explain why it is empty")
+    }
+}

--- a/packages/ios-app/SliccFollower/Views/SettingsView.swift
+++ b/packages/ios-app/SliccFollower/Views/SettingsView.swift
@@ -1,3 +1,4 @@
+import SliccTraySession
 import SwiftUI
 
 struct SettingsView: View {
@@ -8,6 +9,7 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             Form {
+                iCloudSessionsSection
                 connectionSection
                 if appState.connectionState == .connected {
                     trayInfoSection
@@ -32,6 +34,78 @@ struct SettingsView: View {
                 storedJoinUrl = newValue
             }
         }
+    }
+
+    // MARK: - iCloud Sessions Section
+
+    /// Live leaders other devices on this Apple ID advertised to iCloud.
+    /// Tapping one threads its join URL into the normal connect path — the
+    /// URL carries the session secret, so it is never rendered, logged, or
+    /// used in an accessibility identifier (rows use the one-way session id).
+    private var iCloudSessionsSection: some View {
+        Section {
+            let groups = ICloudSessionList.groups(from: appState.sessionStore.sessions)
+            if groups.isEmpty {
+                sessionsEmptyState
+            } else {
+                ForEach(groups) { group in
+                    ForEach(group.sessions) { session in
+                        sessionRow(session, deviceName: group.deviceName)
+                    }
+                }
+            }
+        } header: {
+            Text("iCloud Sessions")
+        } footer: {
+            Text(
+                "Leaders started with Sliccstart on this Apple ID appear here automatically. Others (cloud, another Apple ID) still join via a pasted Join URL below."
+            )
+        }
+        .onAppear { appState.sessionStore.reload() }
+    }
+
+    private func sessionRow(_ session: SyncedTraySession, deviceName: String) -> some View {
+        Button {
+            appState.joinUrl = session.joinUrl
+            appState.connect()
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(session.label.isEmpty ? "SLICC session" : session.label)
+                        .foregroundStyle(.primary)
+                    Text("\(deviceName) · \(ICloudSessionList.age(of: session.lastSeenAt, now: Date()))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: "arrow.right.circle")
+                    .foregroundStyle(.tint)
+            }
+        }
+        // The one-way hash, deliberately — never the join URL.
+        .accessibilityIdentifier("icloud-session-\(session.id)")
+        .disabled(
+            session.isStale(ttl: TraySessionSyncStore.defaultTTL, now: Date())
+                || appState.connectionState == .connecting
+        )
+    }
+
+    private var sessionsEmptyState: some View {
+        let reason = ICloudSessionList.emptyReason(
+            hasICloudIdentity: FileManager.default.ubiquityIdentityToken != nil
+        )
+        return HStack(spacing: 10) {
+            Image(systemName: reason == .iCloudUnavailable ? "icloud.slash" : "icloud")
+                .foregroundStyle(.secondary)
+            Text(
+                reason == .iCloudUnavailable
+                    ? "iCloud is unavailable on this device. Sign in to iCloud, or paste a Join URL below."
+                    : "No active sessions. Start a leader with Sliccstart on a Mac using this Apple ID, or paste a Join URL below."
+            )
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
+        .accessibilityIdentifier("icloud-sessions-empty")
     }
 
     // MARK: - Connection Section

--- a/packages/ios-app/SliccFollower/Views/SettingsView.swift
+++ b/packages/ios-app/SliccFollower/Views/SettingsView.swift
@@ -5,6 +5,11 @@ struct SettingsView: View {
     @EnvironmentObject var appState: AppState
     @Environment(\.dismiss) var dismiss
     @AppStorage("joinUrl") private var storedJoinUrl: String = ""
+    /// Re-evaluates session staleness and ages while the sheet stays open —
+    /// without it, `Date()` in `body` is only sampled on unrelated redraws and
+    /// a row crossing the 12h TTL would stay enabled indefinitely.
+    @State private var now = Date()
+    private let staleTicker = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
 
     var body: some View {
         NavigationStack {
@@ -61,19 +66,28 @@ struct SettingsView: View {
                 "Leaders started with Sliccstart on this Apple ID appear here automatically. Others (cloud, another Apple ID) still join via a pasted Join URL below."
             )
         }
-        .onAppear { appState.sessionStore.reload() }
+        .onAppear {
+            appState.sessionStore.reload()
+            now = Date()
+        }
+        .onReceive(staleTicker) { now = $0 }
     }
 
     private func sessionRow(_ session: SyncedTraySession, deviceName: String) -> some View {
         Button {
-            appState.joinUrl = session.joinUrl
-            appState.connect()
+            // Revalidate at tap time: the row's disabled state was computed at
+            // render time, and a session can age out in between.
+            guard !session.isStale(ttl: TraySessionSyncStore.defaultTTL, now: Date()) else {
+                appState.sessionStore.reload()
+                return
+            }
+            appState.connectToDiscoveredSession(joinUrl: session.joinUrl)
         } label: {
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(session.label.isEmpty ? "SLICC session" : session.label)
                         .foregroundStyle(.primary)
-                    Text("\(deviceName) · \(ICloudSessionList.age(of: session.lastSeenAt, now: Date()))")
+                    Text("\(deviceName) · \(ICloudSessionList.age(of: session.lastSeenAt, now: now))")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -85,7 +99,7 @@ struct SettingsView: View {
         // The one-way hash, deliberately — never the join URL.
         .accessibilityIdentifier("icloud-session-\(session.id)")
         .disabled(
-            session.isStale(ttl: TraySessionSyncStore.defaultTTL, now: Date())
+            session.isStale(ttl: TraySessionSyncStore.defaultTTL, now: now)
                 || appState.connectionState == .connecting
         )
     }

--- a/packages/ios-app/project.yml
+++ b/packages/ios-app/project.yml
@@ -33,8 +33,13 @@ targets:
         SUPPORTS_MACCATALYST: NO
         INFOPLIST_KEY_NSCameraUsageDescription: 'This app does not access the camera. This entry is required because the bundled WebRTC framework references camera APIs.'
         INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO
+        # iCloud KVS for tray-session discovery. The App Store provisioning
+        # profile must carry the iCloud capability; dev/simulator builds
+        # without it still run — the store degrades to a local cache.
+        CODE_SIGN_ENTITLEMENTS: SliccFollower/SliccFollower.entitlements
     dependencies:
       - package: WebRTC
+      - package: SliccTraySession
       - sdk: WebKit.framework
       - sdk: AVFoundation.framework
   SliccFollowerTests:
@@ -90,3 +95,5 @@ packages:
   WebRTC:
     url: https://github.com/stasel/WebRTC.git
     exactVersion: 150.0.0
+  SliccTraySession:
+    path: ../swift-traysession

--- a/packages/ios-app/scripts/package-and-upload-testflight.sh
+++ b/packages/ios-app/scripts/package-and-upload-testflight.sh
@@ -27,7 +27,22 @@
 #                                       created and torn down on exit
 #   SLICC_SKIP_TESTFLIGHT=1            no-op; useful when the secrets
 #                                       aren't available
+#   SLICC_IOS_NO_ICLOUD=1              archive WITHOUT the iCloud KVS
+#                                       entitlement (mirrors the macOS
+#                                       PROVISION_PROFILE gate): use when the
+#                                       App Store profile does not yet carry
+#                                       the iCloud capability, so the release
+#                                       ships without session sync instead of
+#                                       failing codesign
 set -euo pipefail
+
+# iCloud KVS entitlement gate — see SLICC_IOS_NO_ICLOUD above. An empty
+# CODE_SIGN_ENTITLEMENTS override drops the project.yml entitlements file.
+ENTITLEMENTS_OVERRIDE=()
+if [ "${SLICC_IOS_NO_ICLOUD:-}" = "1" ]; then
+  echo "SLICC_IOS_NO_ICLOUD=1 — archiving without the iCloud KVS entitlement"
+  ENTITLEMENTS_OVERRIDE=(CODE_SIGN_ENTITLEMENTS=)
+fi
 
 if [ "${SLICC_SKIP_TESTFLIGHT:-}" = "1" ]; then
   echo "SLICC_SKIP_TESTFLIGHT=1 — skipping TestFlight upload"
@@ -281,6 +296,7 @@ xcodebuild \
   PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID" \
   MARKETING_VERSION="$VERSION" \
   CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
+  ${ENTITLEMENTS_OVERRIDE[@]+"${ENTITLEMENTS_OVERRIDE[@]}"} \
   archive >/tmp/slicc-archive.log 2>&1 \
   || { tail -50 /tmp/slicc-archive.log; exit 1; }
 echo "  archive ok"

--- a/packages/swift-traysession/CLAUDE.md
+++ b/packages/swift-traysession/CLAUDE.md
@@ -4,7 +4,7 @@ This file covers the shared tray-session sync library in `packages/swift-trayses
 
 ## Scope
 
-`SliccTraySession` is a Foundation-only SPM library for cross-device discovery of active tray join URLs over iCloud key-value sync. The macOS launcher (`packages/swift-launcher`) is the producer and today's only consumer; the iOS follower (`packages/ios-app`) is the intended second consumer for iCloud session discovery (#1791) and does not depend on it yet. Supports `.macOS(.v14)` and `.iOS(.v17)`; **nothing here may import AppKit or UIKit** — CI builds the package for the iOS Simulator to enforce that.
+`SliccTraySession` is a Foundation-only SPM library for cross-device discovery of active tray join URLs over iCloud key-value sync. The macOS launcher (`packages/swift-launcher`) is the producer; the iOS follower (`packages/ios-app`) consumes it read-only for iCloud session discovery (the phone joins sessions, it never publishes one). Supports `.macOS(.v14)` and `.iOS(.v17)`; **nothing here may import AppKit or UIKit** — CI builds the package for the iOS Simulator to enforce that.
 
 ## Contents
 


### PR DESCRIPTION
Closes #1791. Part of the iOS follower catch-up (#1785); consumes the `packages/swift-traysession` extraction (#1790/#1838). The single biggest UX win in the backlog: joining a leader from the phone no longer means hand-copying a join URL that carries the session secret.

## Summary

The Settings sheet gains an **iCloud Sessions** section above the manual paste flow: every leader a Mac on the same Apple ID advertises via Sliccstart appears live, grouped by device with `label` and age; tapping a row threads its `joinUrl` into the existing `connect()` path. Manual paste stays for cloud leaders and other Apple IDs.

_Simulator screenshots (sessions list + empty state) attached in a follow-up comment — pending the image-upload authorization._

## Entitlement and provisioning

- New `SliccFollower.entitlements` carries `com.apple.developer.ubiquity-kvstore-identifier` = `S8LB56P782.ai.sliccy.trays`, **matching what macOS releases ship** (`packages/swift-launcher/CLAUDE.md` § iCloud provisioning), wired via `CODE_SIGN_ENTITLEMENTS` in `project.yml`.
- Unprovisioned dev/simulator builds still run: `UbiquitousKeyValueBackend` degrades to an empty local cache by design.
- The TestFlight script gains the iOS analogue of the launcher's `PROVISION_PROFILE` gate: `SLICC_IOS_NO_ICLOUD=1` archives with an empty `CODE_SIGN_ENTITLEMENTS` override, so a release ships without session sync instead of failing codesign while the App Store profile lacks the iCloud capability. **Ops prerequisite:** the "Slicc Follower App Store" provisioning profile needs the iCloud capability added before a synced TestFlight build ships.

## UI

- `ICloudSessionList` (unit-tested, no SwiftUI import) owns grouping (keyed on `deviceId` so same-named Macs stay distinct, devices ordered by their newest session), the empty-state decision, and the launcher-matching age format.
- Stale rows render disabled (`isStale` against the store's 12h TTL); the store reloads on section appear and on iCloud's external-change notification — no polling.
- Empty state is honest about why: signed out of iCloud (`ubiquityIdentityToken == nil`) vs. no sessions published. An unprovisioned build is indistinguishable from the latter at runtime; the CLAUDE.md says so.

## Security

- `joinUrl` (carries the session secret) appears in no log line, no telemetry field, and no accessibility identifier — rows use the one-way SHA-256 `session.id`, same rule as macOS.
- Sync stays exclusively on the user's own encrypted same-Apple-ID iCloud KVS; no new transport.

## Testing

- `ICloudSessionListTests`: grouping, device ordering, placeholder names, empty-state reasons, age thresholds, and the DEBUG-only fixture seam (asserting every fixture URL is hermetic).
- `ICloudSessionsUITests`: `-uiTestSessionsFixture YES` seeds two devices' sessions through `InMemoryKeyValueBackend` — asserts grouped rows render and that tapping one settles on **Connection Failed** (fixture URLs dial `127.0.0.1:1`), proving the tap reached the real connect path; `-uiTestSessionsEmpty YES` asserts the empty state. No test touches real iCloud.
- Full simulator suite: **112/112 green**; coverage gate 55.3 / 42.8 / 47.4 vs floors 53 / 40 / 45.

## CI / release wiring

The app now links `SliccTraySession`, so the `ios-app` CI job and `IOS_PATH_PREFIXES` in `release-native.mjs` (+ test) also trigger on `packages/swift-traysession/**` — same treatment the `swift-launcher` job got in #1838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2m3i5QmGvGFehU4Uoi1k3
