### PR TITLE
fix(dev-tools): retry guard also matches the preflight-Busy launch refusal

### DIFF
--- a/packages/dev-tools/tools/swift-coverage-runner-retry.sh
+++ b/packages/dev-tools/tools/swift-coverage-runner-retry.sh
@@ -3,13 +3,14 @@
 # swift-coverage-runner-retry.test.mjs.
 #
 # A UI-test runner that dies at initialization ("Timed out while loading
-# Accessibility" / "failed to initialize for UI testing") aborts the xcodebuild
-# session before a single test runs, so `-retry-tests-on-failure` never sees
-# it — that flag retries failed tests, not a runner that never started. This
-# guard retries exactly that infrastructure signature, once. A genuine test
-# failure does not match and fails on the first attempt, preserving its exit
-# status.
-RUNNER_INIT_RE='failed to initialize for UI testing|Timed out while loading Accessibility'
+# Accessibility", "failed to initialize for UI testing", or SpringBoard
+# refusing the launch with Busy / "Application failed preflight checks")
+# aborts the xcodebuild session before a single test runs, so
+# `-retry-tests-on-failure` never sees it — that flag retries failed tests,
+# not a runner that never started. This guard retries exactly those
+# infrastructure signatures, once. A genuine test failure does not match and
+# fails on the first attempt, preserving its exit status.
+RUNNER_INIT_RE='failed to initialize for UI testing|Timed out while loading Accessibility|Failed to install or launch the test runner|Application failed preflight checks'
 
 # run_with_runner_init_retry <logfile> <cmd...>
 # Runs <cmd...> (stdout+stderr teed to <logfile>) up to twice. Returns 0 on

--- a/packages/dev-tools/tools/swift-coverage-runner-retry.sh
+++ b/packages/dev-tools/tools/swift-coverage-runner-retry.sh
@@ -4,13 +4,16 @@
 #
 # A UI-test runner that dies at initialization ("Timed out while loading
 # Accessibility", "failed to initialize for UI testing", or SpringBoard
-# refusing the launch with Busy / "Application failed preflight checks")
+# refusing the launch with Busy / "Application failed preflight checks" —
+# deliberately NOT the generic "Failed to install or launch the test
+# runner" wrapper, which also wraps permanent failures like a bad bundle
+# or signature)
 # aborts the xcodebuild session before a single test runs, so
 # `-retry-tests-on-failure` never sees it — that flag retries failed tests,
 # not a runner that never started. This guard retries exactly those
 # infrastructure signatures, once. A genuine test failure does not match and
 # fails on the first attempt, preserving its exit status.
-RUNNER_INIT_RE='failed to initialize for UI testing|Timed out while loading Accessibility|Failed to install or launch the test runner|Application failed preflight checks'
+RUNNER_INIT_RE='failed to initialize for UI testing|Timed out while loading Accessibility|Application failed preflight checks'
 
 # run_with_runner_init_retry <logfile> <cmd...>
 # Runs <cmd...> (stdout+stderr teed to <logfile>) up to twice. Returns 0 on

--- a/packages/dev-tools/tools/swift-coverage-runner-retry.test.mjs
+++ b/packages/dev-tools/tools/swift-coverage-runner-retry.test.mjs
@@ -79,6 +79,21 @@ describe('run_with_runner_init_retry', () => {
     expect(calls()).toBe(2);
   });
 
+  it('also matches the SpringBoard preflight-Busy launch refusal', () => {
+    const { stub, calls } = makeStub([
+      {
+        output:
+          'SliccFollowerUITests-Runner encountered an error (Failed to install or launch the test runner. ' +
+          '(Underlying Error: The request was denied by service delegate (SBMainWorkspace) for reason: ' +
+          'Busy ("Application failed preflight checks").))',
+        exit: 65,
+      },
+      { output: 'ok', exit: 0 },
+    ]);
+    expect(run(stub).status).toBe(0);
+    expect(calls()).toBe(2);
+  });
+
   it('does not retry a genuine test failure and preserves its exit status', () => {
     const { stub, calls } = makeStub([{ output: "Test Case 'testSomething' failed", exit: 65 }]);
     const res = run(stub);

--- a/packages/dev-tools/tools/swift-coverage-runner-retry.test.mjs
+++ b/packages/dev-tools/tools/swift-coverage-runner-retry.test.mjs
@@ -94,6 +94,20 @@ describe('run_with_runner_init_retry', () => {
     expect(calls()).toBe(2);
   });
 
+  it('does not retry a permanent install failure (generic wrapper without Busy)', () => {
+    const { stub, calls } = makeStub([
+      {
+        output:
+          'Failed to install or launch the test runner. (Underlying Error: ' +
+          'The code signature is invalid.)',
+        exit: 65,
+      },
+    ]);
+    const res = run(stub);
+    expect(res.status).toBe(65);
+    expect(calls()).toBe(1);
+  });
+
   it('does not retry a genuine test failure and preserves its exit status', () => {
     const { stub, calls } = makeStub([{ output: "Test Case 'testSomething' failed", exit: 65 }]);
     const res = run(stub);


### PR DESCRIPTION
## Summary

Follow-up to #1842: a local ios-app suite run died with the **other** documented runner-init flake phrasing — `Failed to install or launch the test runner … denied by service delegate (SBMainWorkspace) for reason: Busy ("Application failed preflight checks")` — which the guard's regex didn't match, so the failure passed through unretried. The signature set now covers both phrasings from `packages/ios-app/CLAUDE.md`.

## Test plan

- `npx vitest run packages/dev-tools/tools/swift-coverage-runner-retry.test.mjs` — 6 tests, including a new case with the real SpringBoard error shape retrying exactly once
- `shellcheck -S warning` clean
- Full pass: `npm run verify` (7/7), `npm run typecheck`, `npm run test` (13,281), `check-touched-exemptions` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2m3i5QmGvGFehU4Uoi1k3
