### PR TITLE
feat(ios-app): push-to-talk dictation by holding the empty composer

### DIFF
--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -25,7 +25,7 @@ This package is NOT an npm workspace. It is a Swift Package Manager project (`Pa
 | Other views (`ChatFixture.swift`, `ConnectionStatusView.swift`, `ContentView.swift`, `InputBar.swift`, `MarkdownText.swift`, `MessageBubble.swift`, `SettingsView.swift`, `SliccIcons.swift`) | Top-level shell + smaller UI fragments — not exhaustive                                                                                                                                                           |
 | `SliccFollower/Resources/Assets.xcassets`                                                                                                                                                     | App icon + asset catalog                                                                                                                                                                                          |
 
-Plain SPM commands do nothing useful on a macOS host: `swift build` fails (`no such module 'UIKit'` — the sources import iOS-only frameworks) and `Package.swift` declares no test target, so `swift test` has nothing to run. Build and test both go through the XcodeGen project with a simulator destination. The two test bundles — `SliccFollowerTests` and `SliccFollowerUITests` — are defined in `project.yml`, wired into the scheme with coverage, and run in CI via `xcodebuild test` (see "Test + coverage").
+Plain SPM commands do nothing useful on a macOS host (`swift build` hits iOS-only frameworks; `Package.swift` declares no test target). Build and test go through the XcodeGen project on a simulator (see "Test + coverage").
 
 ## Protocol Mirror Invariant
 
@@ -111,6 +111,15 @@ parser (`slicc:session-data` block + heading fallback). `FrozenSessionsView`
 lists past sessions; opening one swaps the transcript read-only and the
 ice-blue banner replaces the composer. Hooks: `-uiTestFrozenFixture/Empty`.
 
+## Push to Talk
+
+Holding the EMPTY composer dictates a `user_message` (no protocol change).
+`Models/PttController.swift` ports `<slicc-composer>`'s gesture;
+`Models/Dictation.swift` seams the engine (`SFSpeechRecognizer`, on-device
+when the locale supports it). Hooks: `-uiTestSpeechPermission`/
+`-uiTestSpeechScript` script the engine; `-uiTestPttStage` pins the
+overlay for screenshots.
+
 ## Build
 
 ```bash
@@ -124,8 +133,7 @@ swiftlint lint                                   # SwiftLint (config inherits re
 
 ## Test + coverage
 
-Plain `swift test` cannot run on a macOS host (iOS-only WebRTC binary), so the
-suite runs through `xcodebuild test` on a simulator. The shared coverage gate
+The suite runs through `xcodebuild test` on a simulator. The shared coverage gate
 picks a simulator, enables coverage and on-failure retries, and enforces the
 `ios-app` floors in `coverage-thresholds.json`.
 
@@ -145,9 +153,8 @@ debug builds put the code and the coverage mapping in the dylib.
 
 ## Simulator QA path
 
-Hand-running the app for exploratory checks the UI tests do not cover — boot /
-build / install / launch commands, seeding `@AppStorage` state via launch
-arguments, and getting a real Join URL — is covered in
+Hand-running the app for exploratory QA (boot/build/install/launch, seeding
+`@AppStorage` via launch arguments, getting a real Join URL) is covered in
 [`docs/ios-simulator-qa.md`](../../docs/ios-simulator-qa.md).
 
 ## UI tests (`SliccFollowerUITests`)

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -10,17 +10,20 @@
 		02019B8CFDC4B36D610933B8 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434BBAD25E91BD0B7D626821 /* AppState.swift */; };
 		09FE7E5B6F63D6850F2EBFBE /* UITestHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1308398CD972FF297E2C75 /* UITestHooks.swift */; };
 		0CAAEE94D02D4006193FA4BB /* InputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */; };
+		11F604368853A3A60AC0B10F /* PttController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F779D2634D4AED6D1AEDA07 /* PttController.swift */; };
 		15CF4C85551B4FE239D55E94 /* SliccIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438577405ABBCA33F117862C /* SliccIcons.swift */; };
 		1939D37EEDBD284DC9F6A9DC /* FrozenSessionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF8476768958BC66533E58F /* FrozenSessionsUITests.swift */; };
 		21BD049697833AC4E3316A58 /* ToolUIPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0425579D2C460F993D259DB /* ToolUIPlaceholderTests.swift */; };
 		238295F68E3669C0968C9934 /* WebRTCManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AF8A8A50FCC9C2DBECA0CF /* WebRTCManager.swift */; };
 		2401C7FE702795E1066A7C9F /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB646EF0D0006D1A43F527D /* ChatMessage.swift */; };
+		2A750B8B02200270E97C8D6E /* Dictation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4A75BA9D14DA689D0E9F4 /* Dictation.swift */; };
 		2CE789AA836BB0713F1250D7 /* CDPBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE0A7D88487F7712E451646 /* CDPBridge.swift */; };
 		306C9DAD5071D0E813194FC5 /* ICloudSessionListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D53BAF8B8E31F0EC06B69E /* ICloudSessionListTests.swift */; };
 		319F6B893CA643B51BE218BB /* FrozenSessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3425D0B50BD57E03FFF47A45 /* FrozenSessionsView.swift */; };
 		372183DEB63D89EC6E10C140 /* FrozenSessionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9572AB87A7ACEC6740682685 /* FrozenSessionsTests.swift */; };
 		3A9E122F6A6C4C0F6258C5C6 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A069AA812629AC5FE70AC9 /* SettingsView.swift */; };
 		3EDEBD047CEC3F24BC3ED785 /* SliccFollowerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D4AD0E32B059DB9EABFF3E /* SliccFollowerApp.swift */; };
+		41FD9C8701A419C994CF2704 /* PttUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075FA82F3967B4E37A76C59A /* PttUITests.swift */; };
 		472BB1BEB4E248916156C9EE /* tray-sync-corpus.json in Resources */ = {isa = PBXBuildFile; fileRef = FD6CEFD575FD21C28BEC39F5 /* tray-sync-corpus.json */; };
 		4874F8858460397F336DE469 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = CEF104FB1C3EDA0B98BC5FFF /* WebRTC */; };
 		487756D13ED6B5D4FB9FF6A0 /* TrayFollowerConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93EE217FAA3F9F7DD3A0B07F /* TrayFollowerConnector.swift */; };
@@ -36,6 +39,7 @@
 		5DBC389110F337A40762C4E1 /* MessageListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E727142147B0FB449F418D1 /* MessageListView.swift */; };
 		5E23C33D85A8DFC1772AD1FE /* FrozenSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508DFA2D4CC9FD26DCC66AD4 /* FrozenSessions.swift */; };
 		67EC4D5BDDC4014A965FF5B4 /* ConnectionRouteUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */; };
+		68FA70C9EC1A7C1137CC277D /* PttOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C4F68634F8E70BBC83002C /* PttOverlayView.swift */; };
 		73CD8FDB68D950291A923BCD /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B186EDFDE184DC8B3215C4 /* ChatView.swift */; };
 		7AFB535E78304FCE5CE7058A /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523A4A068180D7EE98435885 /* MarkdownText.swift */; };
 		7BEE859F6C68FEAFD63D1FBB /* SyncProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618555E73F15FDB4DB0CAA6F /* SyncProtocol.swift */; };
@@ -46,6 +50,7 @@
 		8EEACE6ED76E43E36FC9F0AB /* ChatFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA9A527E2D4BBCE1BDFA89C /* ChatFixture.swift */; };
 		977007CC44BE2B53361DF256 /* Keepalive.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA931BF1BE121985E2FB3EE /* Keepalive.swift */; };
 		9AD8326007279D3F37D57C9C /* ICloudSessionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D158A5ACE0AC9C2CE6FEFCD3 /* ICloudSessionList.swift */; };
+		9C28D445499995ADA861D75F /* PttControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8551D5DAD74B9BFB7CC2B76D /* PttControllerTests.swift */; };
 		9DF8A1F02E02C3662AC7E44E /* ThemeEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3C704861C906098707C875 /* ThemeEngineTests.swift */; };
 		9ECC362CC8EBA3629542A6E7 /* SteerMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066BAF2F283227600FB92506 /* SteerMessageTests.swift */; };
 		9FA93426F018C3EE0C94E8E5 /* theme-vectors.json in Resources */ = {isa = PBXBuildFile; fileRef = F9555BBF8AC72C74630432D1 /* theme-vectors.json */; };
@@ -94,7 +99,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		04F4A75BA9D14DA689D0E9F4 /* Dictation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dictation.swift; sourceTree = "<group>"; };
 		066BAF2F283227600FB92506 /* SteerMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteerMessageTests.swift; sourceTree = "<group>"; };
+		075FA82F3967B4E37A76C59A /* PttUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PttUITests.swift; sourceTree = "<group>"; };
 		0835A30393CEF046BA90DB16 /* FsClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FsClientTests.swift; sourceTree = "<group>"; };
 		11B186EDFDE184DC8B3215C4 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		12FDDE8F74ACEEEACDA73346 /* FsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FsClient.swift; sourceTree = "<group>"; };
@@ -108,6 +115,7 @@
 		3425D0B50BD57E03FFF47A45 /* FrozenSessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrozenSessionsView.swift; sourceTree = "<group>"; };
 		356386D299A1933A39CB972B /* TrayChunkFraming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayChunkFraming.swift; sourceTree = "<group>"; };
 		37492C8E3201CB2A14C6BD12 /* ConnectionStateUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStateUITests.swift; sourceTree = "<group>"; };
+		37C4F68634F8E70BBC83002C /* PttOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PttOverlayView.swift; sourceTree = "<group>"; };
 		39ADD0645C7DD3B30664E997 /* TabsCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabsCarouselView.swift; sourceTree = "<group>"; };
 		3BA9A527E2D4BBCE1BDFA89C /* ChatFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatFixture.swift; sourceTree = "<group>"; };
 		3BBC1002CE4D3E1D940352F4 /* SyncProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncProtocolTests.swift; sourceTree = "<group>"; };
@@ -123,6 +131,7 @@
 		55D53BAF8B8E31F0EC06B69E /* ICloudSessionListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudSessionListTests.swift; sourceTree = "<group>"; };
 		5AF41895CF5F76A1CD2B671E /* LickEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LickEvent.swift; sourceTree = "<group>"; };
 		5EB9ADA61005F3F96BE8CDE2 /* LinkHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHeader.swift; sourceTree = "<group>"; };
+		5F779D2634D4AED6D1AEDA07 /* PttController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PttController.swift; sourceTree = "<group>"; };
 		610460E1CC7B9EBB1F34EC0E /* SliccFollower.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SliccFollower.entitlements; sourceTree = "<group>"; };
 		618555E73F15FDB4DB0CAA6F /* SyncProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncProtocol.swift; sourceTree = "<group>"; };
 		62B1B7433B4D853B17578E82 /* LickEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LickEnvelopeTests.swift; sourceTree = "<group>"; };
@@ -130,6 +139,7 @@
 		740A6B3BC797CFC901E08521 /* swift-traysession */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "swift-traysession"; path = "../swift-traysession"; sourceTree = SOURCE_ROOT; };
 		747034EA0B5B45B56875A5DD /* LinkHeaderCorpusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHeaderCorpusTests.swift; sourceTree = "<group>"; };
 		7E727142147B0FB449F418D1 /* MessageListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListView.swift; sourceTree = "<group>"; };
+		8551D5DAD74B9BFB7CC2B76D /* PttControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PttControllerTests.swift; sourceTree = "<group>"; };
 		88219CD0B963530C38CE40FB /* SliccFollowerUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SliccFollowerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D76B8F603084A6021B6DD6B /* KeepaliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeepaliveTests.swift; sourceTree = "<group>"; };
 		93EE217FAA3F9F7DD3A0B07F /* TrayFollowerConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayFollowerConnector.swift; sourceTree = "<group>"; };
@@ -192,6 +202,7 @@
 				62B1B7433B4D853B17578E82 /* LickEnvelopeTests.swift */,
 				747034EA0B5B45B56875A5DD /* LinkHeaderCorpusTests.swift */,
 				A16A253ACC35EEB12798224E /* NewSessionMessageTests.swift */,
+				8551D5DAD74B9BFB7CC2B76D /* PttControllerTests.swift */,
 				066BAF2F283227600FB92506 /* SteerMessageTests.swift */,
 				9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */,
 				3BBC1002CE4D3E1D940352F4 /* SyncProtocolTests.swift */,
@@ -227,9 +238,11 @@
 			isa = PBXGroup;
 			children = (
 				BBB646EF0D0006D1A43F527D /* ChatMessage.swift */,
+				04F4A75BA9D14DA689D0E9F4 /* Dictation.swift */,
 				508DFA2D4CC9FD26DCC66AD4 /* FrozenSessions.swift */,
 				D158A5ACE0AC9C2CE6FEFCD3 /* ICloudSessionList.swift */,
 				5AF41895CF5F76A1CD2B671E /* LickEvent.swift */,
+				5F779D2634D4AED6D1AEDA07 /* PttController.swift */,
 				618555E73F15FDB4DB0CAA6F /* SyncProtocol.swift */,
 				1572105F0B5819E4CC07BD84 /* ThemeEngine.swift */,
 				356386D299A1933A39CB972B /* TrayChunkFraming.swift */,
@@ -270,6 +283,7 @@
 				ECF8476768958BC66533E58F /* FrozenSessionsUITests.swift */,
 				E9FC22E5B3D4B0DA205C7F62 /* ICloudSessionsUITests.swift */,
 				E7EF3911627A88E5691B3949 /* NewSessionUITests.swift */,
+				075FA82F3967B4E37A76C59A /* PttUITests.swift */,
 				26D6B6B896CB48304A39DAB8 /* SteerUITests.swift */,
 			);
 			name = SliccFollowerUITests;
@@ -290,6 +304,7 @@
 				523A4A068180D7EE98435885 /* MarkdownText.swift */,
 				AF78C09597C5D63A373EB126 /* MessageBubble.swift */,
 				7E727142147B0FB449F418D1 /* MessageListView.swift */,
+				37C4F68634F8E70BBC83002C /* PttOverlayView.swift */,
 				F0A069AA812629AC5FE70AC9 /* SettingsView.swift */,
 				438577405ABBCA33F117862C /* SliccIcons.swift */,
 				407939337779F91986E8DAB3 /* SprinkleSidebarView.swift */,
@@ -515,6 +530,7 @@
 				73CD8FDB68D950291A923BCD /* ChatView.swift in Sources */,
 				C43F5710585B9C800CAAA0A2 /* ConnectionStatusView.swift in Sources */,
 				B4A19D759C5C4CDDFFA1FC35 /* ContentView.swift in Sources */,
+				2A750B8B02200270E97C8D6E /* Dictation.swift in Sources */,
 				5E23C33D85A8DFC1772AD1FE /* FrozenSessions.swift in Sources */,
 				319F6B893CA643B51BE218BB /* FrozenSessionsView.swift in Sources */,
 				D493553CF88D9F88586D7E93 /* FsClient.swift in Sources */,
@@ -528,6 +544,8 @@
 				7AFB535E78304FCE5CE7058A /* MarkdownText.swift in Sources */,
 				A50239DCBBAD6235AC7C296A /* MessageBubble.swift in Sources */,
 				5DBC389110F337A40762C4E1 /* MessageListView.swift in Sources */,
+				11F604368853A3A60AC0B10F /* PttController.swift in Sources */,
+				68FA70C9EC1A7C1137CC277D /* PttOverlayView.swift in Sources */,
 				3A9E122F6A6C4C0F6258C5C6 /* SettingsView.swift in Sources */,
 				3EDEBD047CEC3F24BC3ED785 /* SliccFollowerApp.swift in Sources */,
 				15CF4C85551B4FE239D55E94 /* SliccIcons.swift in Sources */,
@@ -557,6 +575,7 @@
 				1939D37EEDBD284DC9F6A9DC /* FrozenSessionsUITests.swift in Sources */,
 				A5A215E64B167C5F918EA6FA /* ICloudSessionsUITests.swift in Sources */,
 				C5E734A68251BBE47EBE506D /* NewSessionUITests.swift in Sources */,
+				41FD9C8701A419C994CF2704 /* PttUITests.swift in Sources */,
 				D3441201E520337FA883076A /* SteerUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -573,6 +592,7 @@
 				BAEB06EC85F8242C542D4782 /* LickEnvelopeTests.swift in Sources */,
 				CA14A8C5DE0A027197214AEF /* LinkHeaderCorpusTests.swift in Sources */,
 				FBC5D9F3A8263FCAE3C6C6C5 /* NewSessionMessageTests.swift in Sources */,
+				9C28D445499995ADA861D75F /* PttControllerTests.swift in Sources */,
 				9ECC362CC8EBA3629542A6E7 /* SteerMessageTests.swift in Sources */,
 				F908DA74A70E1C7F16EC6AD8 /* SyncProtocolCorpusTests.swift in Sources */,
 				CB6A8F9EEAD1D4DAA552E0EC /* SyncProtocolTests.swift in Sources */,
@@ -605,6 +625,8 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app does not access the camera. This entry is required because the bundled WebRTC framework references camera APIs.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Hold the message field to dictate a message with your voice.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Dictated audio is transcribed on this device when possible to fill the message field.";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -731,6 +753,8 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app does not access the camera. This entry is required because the bundled WebRTC framework references camera APIs.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Hold the message field to dictate a message with your voice.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Dictated audio is transcribed on this device when possible to fill the message field.";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/packages/ios-app/SliccFollower/App/UITestHooks.swift
+++ b/packages/ios-app/SliccFollower/App/UITestHooks.swift
@@ -124,6 +124,56 @@ import SliccTraySession
             ]
         }
 
+        /// A scripted dictation engine so push-to-talk UI tests never depend
+        /// on a simulator microphone or the system permission prompts.
+        /// `-uiTestSpeechPermission granted|undetermined|denied|restricted`
+        /// selects the starting permission; `-uiTestSpeechScript "…"` is the
+        /// transcript the fake session streams word by word;
+        /// `-uiTestSpeechGrant denied` makes the in-app prompt resolve to a
+        /// refusal (default: granted).
+        static func speechEngine() -> DictationEngine? {
+            guard let raw = UserDefaults.standard.string(forKey: "uiTestSpeechPermission"),
+                let permission = parsePermission(raw)
+            else { return nil }
+            let script = UserDefaults.standard.string(forKey: "uiTestSpeechScript") ?? ""
+            let grantRaw = UserDefaults.standard.string(forKey: "uiTestSpeechGrant") ?? "granted"
+            let grant = parsePermission(grantRaw) ?? .granted
+            return ScriptedDictationEngine(
+                permission: permission, grantOutcome: grant, script: script)
+        }
+
+        /// Pin the push-to-talk overlay to a stage on launch
+        /// (`-uiTestPttStage enable|prompting|denied|restricted|recording|finalizing`,
+        /// with `-uiTestPttCaption` filling the recording caption line). The
+        /// overlay otherwise exists only while a finger holds the composer,
+        /// which a screenshot run cannot stage.
+        static func pttStage() -> (stage: PttStage, caption: String)? {
+            guard let raw = UserDefaults.standard.string(forKey: "uiTestPttStage") else {
+                return nil
+            }
+            let caption = UserDefaults.standard.string(forKey: "uiTestPttCaption") ?? ""
+            switch raw {
+            case "enable": return (.enable, caption)
+            case "prompting": return (.prompting, caption)
+            case "denied": return (.denied(message: nil), caption)
+            case "restricted":
+                return (.denied(message: PttController.restrictedMessage), caption)
+            case "recording": return (.recording, caption)
+            case "finalizing": return (.finalizing, caption)
+            default: return nil
+            }
+        }
+
+        private static func parsePermission(_ raw: String) -> DictationPermission? {
+            switch raw {
+            case "granted": return .granted
+            case "undetermined": return .undetermined
+            case "denied": return .denied
+            case "restricted": return .restricted
+            default: return nil
+            }
+        }
+
         /// The archive body backing the fixture entries — a modern archive
         /// with an intact `slicc:session-data` block.
         static func frozenArchiveFixture(for entry: FrozenSessionIndexEntry) -> String? {
@@ -149,6 +199,65 @@ import SliccTraySession
 
                 The freezer rail, read-only on your phone.
                 """
+        }
+    }
+
+    /// DEBUG-only dictation engine behind `-uiTestSpeechPermission`: the
+    /// scripted transcript streams word by word as partials (like a real
+    /// recognizer refining its interim result) and returns whole from
+    /// `stop()`, so a UI test can hold, watch the caption, release, and
+    /// assert the committed message — no microphone involved.
+    final class ScriptedDictationEngine: DictationEngine {
+        private(set) var permission: DictationPermission
+        private let grantOutcome: DictationPermission
+        private let script: String
+
+        init(permission: DictationPermission, grantOutcome: DictationPermission, script: String) {
+            self.permission = permission
+            self.grantOutcome = grantOutcome
+            self.script = script
+        }
+
+        var statusLine: String { "Scripted test engine" }
+
+        func requestPermission() async -> DictationPermission {
+            permission = grantOutcome
+            return grantOutcome
+        }
+
+        func start(
+            onPartial: @escaping @MainActor @Sendable (String) -> Void,
+            onError: @escaping @MainActor @Sendable (String) -> Void
+        ) async throws -> DictationSession {
+            ScriptedDictationSession(script: script, onPartial: onPartial)
+        }
+    }
+
+    final class ScriptedDictationSession: DictationSession {
+        private let script: String
+        private let streamTask: Task<Void, Never>
+
+        init(script: String, onPartial: @escaping @MainActor @Sendable (String) -> Void) {
+            self.script = script
+            let words = script.split(separator: " ").map(String.init)
+            streamTask = Task { @MainActor in
+                var heard: [String] = []
+                for word in words {
+                    try? await Task.sleep(nanoseconds: 120_000_000)
+                    guard !Task.isCancelled else { return }
+                    heard.append(word)
+                    onPartial(heard.joined(separator: " "))
+                }
+            }
+        }
+
+        func stop() async -> String {
+            streamTask.cancel()
+            return script
+        }
+
+        func cancel() {
+            streamTask.cancel()
         }
     }
 #endif

--- a/packages/ios-app/SliccFollower/Models/Dictation.swift
+++ b/packages/ios-app/SliccFollower/Models/Dictation.swift
@@ -170,6 +170,10 @@ private final class AppleDictationSessionBox: DictationSession, @unchecked Senda
                 let isFinal = result.isFinal
                 self.lock.lock()
                 self.latestTranscript = text
+                // A final result is terminal even when no stop() is waiting
+                // yet: mark finished so a later stop() takes the fast path
+                // instead of installing a continuation nothing will resume.
+                if isFinal { self.finished = true }
                 let continuation = isFinal ? self.takeContinuationLocked() : nil
                 self.lock.unlock()
                 if let continuation {
@@ -181,27 +185,30 @@ private final class AppleDictationSessionBox: DictationSession, @unchecked Senda
             if let error {
                 self.lock.lock()
                 let transcript = self.latestTranscript
+                let wasFinished = self.finished
+                // An error ends the recognition task — terminal like a
+                // final result, whatever the ordering.
+                self.finished = true
                 let continuation = self.takeContinuationLocked()
-                let midSession = continuation == nil && !self.finished
                 self.lock.unlock()
                 // A stop() in flight settles with whatever was heard — an
                 // error after endAudio() (e.g. "no speech detected") is a
                 // normal empty finish, not something to surface.
                 if let continuation {
                     continuation.resume(returning: transcript)
-                } else if midSession {
+                } else if !wasFinished {
                     Task { @MainActor in onError(error.localizedDescription) }
                 }
             }
         }
     }
 
-    /// Must be called with `lock` held. Marks the session finished and hands
-    /// out the continuation exactly once.
+    /// Must be called with `lock` held. Hands out the continuation exactly
+    /// once; callers mark `finished` themselves (a terminal callback is
+    /// terminal whether or not a stop() was already waiting).
     private func takeContinuationLocked() -> CheckedContinuation<String, Never>? {
         guard let continuation = finalContinuation else { return nil }
         finalContinuation = nil
-        finished = true
         return continuation
     }
 

--- a/packages/ios-app/SliccFollower/Models/Dictation.swift
+++ b/packages/ios-app/SliccFollower/Models/Dictation.swift
@@ -1,0 +1,242 @@
+import AVFoundation
+import Foundation
+import Speech
+
+// MARK: - Permission
+
+/// Microphone + speech-recognition permission, collapsed to what the
+/// push-to-talk gesture needs. iOS has two independent grants (mic capture
+/// and speech recognition); the gesture only cares about the combined state.
+/// `restricted` (Screen Time / a management profile) is distinct from
+/// `denied` because the fix is different: there is no Settings toggle for the
+/// user to flip, so the overlay must not send them hunting for one.
+enum DictationPermission: Equatable {
+    case granted
+    case undetermined
+    case denied
+    case restricted
+}
+
+// MARK: - Engine contract
+
+/// A live dictation session: exactly one of `stop`/`cancel` ends it.
+/// Mirrors `SpeechSession` in `packages/webcomponents/src/composer/speech.ts`.
+protocol DictationSession {
+    /// Stop listening and resolve the final transcript ("" when nothing).
+    func stop() async -> String
+    /// Abort without a transcript (gesture cancelled, teardown).
+    func cancel()
+}
+
+/// The audio stack behind the composer's push-to-talk gesture, mirroring the
+/// web's `ComposerSpeech` contract: the gesture (hold-to-enable, captions)
+/// lives in `PttController`, the recognizer behind this protocol. DEBUG
+/// builds swap in a scripted fake (see `UITestHooks.speechEngine()`) so UI
+/// tests never depend on a simulator microphone.
+protocol DictationEngine {
+    /// Current combined permission. Synchronous on iOS — both authorization
+    /// statuses are cached by the system, unlike the web's async query.
+    var permission: DictationPermission { get }
+    /// Human-readable note for the recording overlay's engine status line —
+    /// the privacy-relevant "where does my audio go" disclosure.
+    var statusLine: String { get }
+    /// Trigger the system permission prompts (speech recognition first, then
+    /// microphone). Resolves to the resulting combined permission.
+    func requestPermission() async -> DictationPermission
+    /// Begin one dictation session. Partials stream the interim transcript
+    /// for the closed-caption line; errors are non-fatal session notes.
+    func start(
+        onPartial: @escaping @MainActor @Sendable (String) -> Void,
+        onError: @escaping @MainActor @Sendable (String) -> Void
+    ) async throws -> DictationSession
+}
+
+// MARK: - Apple engine
+
+/// `SFSpeechRecognizer` + `AVAudioEngine`. On-device recognition is the
+/// default whenever the current locale's model supports it — the natural
+/// analogue of the web's "enhanced" whisper engine, minus the 150 MB
+/// download. Server-based recognition is the deliberate fallback, and the
+/// status line discloses which one is active.
+final class AppleDictationEngine: DictationEngine {
+    var permission: DictationPermission {
+        let speech = SFSpeechRecognizer.authorizationStatus()
+        let mic = AVAudioApplication.shared.recordPermission
+        if speech == .denied || mic == .denied { return .denied }
+        if speech == .restricted { return .restricted }
+        if speech == .authorized && mic == .granted { return .granted }
+        return .undetermined
+    }
+
+    var statusLine: String {
+        guard let recognizer = SFSpeechRecognizer() else {
+            return "Speech recognition is unavailable for this language"
+        }
+        return recognizer.supportsOnDeviceRecognition
+            ? "Transcribed on this device"
+            : "Audio is sent to Apple for transcription"
+    }
+
+    func requestPermission() async -> DictationPermission {
+        let speech = await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+        switch speech {
+        case .denied: return .denied
+        case .restricted: return .restricted
+        case .notDetermined: return .undetermined
+        case .authorized: break
+        @unknown default: return .denied
+        }
+        let micGranted = await AVAudioApplication.requestRecordPermission()
+        return micGranted ? .granted : .denied
+    }
+
+    func start(
+        onPartial: @escaping @MainActor @Sendable (String) -> Void,
+        onError: @escaping @MainActor @Sendable (String) -> Void
+    ) async throws -> DictationSession {
+        guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
+            throw DictationError.recognizerUnavailable
+        }
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        // Privacy default: keep audio on the device whenever the locale's
+        // model allows it; only then fall back to Apple's servers (which the
+        // status line discloses).
+        request.requiresOnDeviceRecognition = recognizer.supportsOnDeviceRecognition
+
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+
+        let audioEngine = AVAudioEngine()
+        let input = audioEngine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        input.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            request.append(buffer)
+        }
+        audioEngine.prepare()
+        try audioEngine.start()
+
+        return AppleDictationSessionBox(
+            audioEngine: audioEngine,
+            request: request,
+            recognizer: recognizer,
+            onPartial: onPartial,
+            onError: onError
+        )
+    }
+}
+
+enum DictationError: Error, LocalizedError {
+    case recognizerUnavailable
+
+    var errorDescription: String? {
+        "Speech recognition is unavailable right now"
+    }
+}
+
+/// One live `SFSpeechRecognizer` session. `stop()` ends audio capture and
+/// waits for the recognizer's final result; `cancel()` tears everything down
+/// without one. The recognition callback arrives on an arbitrary queue, so
+/// all shared state lives behind a lock-free single-owner pattern: the
+/// recognition task is the only writer of `latestTranscript` after `stop()`
+/// hands ownership to the continuation.
+private final class AppleDictationSessionBox: DictationSession, @unchecked Sendable {
+    private let audioEngine: AVAudioEngine
+    private let request: SFSpeechAudioBufferRecognitionRequest
+    private var task: SFSpeechRecognitionTask?
+    private let lock = NSLock()
+    private var latestTranscript = ""
+    private var finished = false
+    private var finalContinuation: CheckedContinuation<String, Never>?
+
+    init(
+        audioEngine: AVAudioEngine,
+        request: SFSpeechAudioBufferRecognitionRequest,
+        recognizer: SFSpeechRecognizer,
+        onPartial: @escaping @MainActor @Sendable (String) -> Void,
+        onError: @escaping @MainActor @Sendable (String) -> Void
+    ) {
+        self.audioEngine = audioEngine
+        self.request = request
+        task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            guard let self else { return }
+            if let result {
+                let text = result.bestTranscription.formattedString
+                let isFinal = result.isFinal
+                self.lock.lock()
+                self.latestTranscript = text
+                let continuation = isFinal ? self.takeContinuationLocked() : nil
+                self.lock.unlock()
+                if let continuation {
+                    continuation.resume(returning: text)
+                } else if !isFinal {
+                    Task { @MainActor in onPartial(text) }
+                }
+            }
+            if let error {
+                self.lock.lock()
+                let transcript = self.latestTranscript
+                let continuation = self.takeContinuationLocked()
+                let midSession = continuation == nil && !self.finished
+                self.lock.unlock()
+                // A stop() in flight settles with whatever was heard — an
+                // error after endAudio() (e.g. "no speech detected") is a
+                // normal empty finish, not something to surface.
+                if let continuation {
+                    continuation.resume(returning: transcript)
+                } else if midSession {
+                    Task { @MainActor in onError(error.localizedDescription) }
+                }
+            }
+        }
+    }
+
+    /// Must be called with `lock` held. Marks the session finished and hands
+    /// out the continuation exactly once.
+    private func takeContinuationLocked() -> CheckedContinuation<String, Never>? {
+        guard let continuation = finalContinuation else { return nil }
+        finalContinuation = nil
+        finished = true
+        return continuation
+    }
+
+    func stop() async -> String {
+        stopAudio()
+        return await withCheckedContinuation { continuation in
+            lock.lock()
+            if finished {
+                let transcript = latestTranscript
+                lock.unlock()
+                continuation.resume(returning: transcript)
+                return
+            }
+            finalContinuation = continuation
+            lock.unlock()
+            request.endAudio()
+        }
+    }
+
+    func cancel() {
+        stopAudio()
+        lock.lock()
+        finished = true
+        let continuation = finalContinuation
+        finalContinuation = nil
+        lock.unlock()
+        continuation?.resume(returning: "")
+        task?.cancel()
+        task = nil
+    }
+
+    private func stopAudio() {
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        try? AVAudioSession.sharedInstance().setActive(
+            false, options: .notifyOthersOnDeactivation)
+    }
+}

--- a/packages/ios-app/SliccFollower/Models/PttController.swift
+++ b/packages/ios-app/SliccFollower/Models/PttController.swift
@@ -383,20 +383,45 @@ final class PttController: ObservableObject {
 
     /// Race `operation` against a deadline; `fallback` when the deadline
     /// wins. Non-throwing analogue of the web's `withTimeout`.
+    ///
+    /// Deliberately NOT a task group: a group only exits once every child
+    /// has completed, and cancellation is cooperative — an operation
+    /// suspended in a checked continuation (a permission callback that
+    /// never fires, a recognizer that never finalizes) would keep the
+    /// group, and therefore the overlay, stuck past the advertised
+    /// deadline. Here the loser is simply abandoned: both racers funnel
+    /// into a resume-once gate, and a stalled operation parks harmlessly
+    /// while the UI recovers.
     private static func withTimeout<T: Sendable>(
         ms: Int,
         fallback: T,
         operation: @escaping @MainActor @Sendable () async -> T
     ) async -> T {
-        await withTaskGroup(of: T?.self) { group in
-            group.addTask { await operation() }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: UInt64(ms) * 1_000_000)
-                return nil
+        await withCheckedContinuation { (continuation: CheckedContinuation<T, Never>) in
+            let gate = ResumeOnceGate(continuation)
+            Task { @MainActor in
+                gate.resume(await operation())
             }
-            let first = await group.next()
-            group.cancelAll()
-            return first ?? fallback
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: UInt64(ms) * 1_000_000)
+                gate.resume(fallback)
+            }
+        }
+    }
+
+    /// First racer through wins; later resumes are no-ops. MainActor-bound,
+    /// so no lock is needed.
+    @MainActor
+    private final class ResumeOnceGate<T: Sendable> {
+        private var continuation: CheckedContinuation<T, Never>?
+
+        init(_ continuation: CheckedContinuation<T, Never>) {
+            self.continuation = continuation
+        }
+
+        func resume(_ value: T) {
+            continuation?.resume(returning: value)
+            continuation = nil
         }
     }
 }

--- a/packages/ios-app/SliccFollower/Models/PttController.swift
+++ b/packages/ios-app/SliccFollower/Models/PttController.swift
@@ -1,0 +1,402 @@
+import Foundation
+
+// MARK: - Stage
+
+/// One gesture outcome. `id` makes consecutive identical outcomes distinct
+/// so `.onChange` fires for each (two quick taps in a row must both focus).
+struct PttEvent: Equatable {
+    enum Kind: Equatable {
+        /// Final non-empty transcript, trimmed — append + submit it.
+        case commit(String)
+        /// The press ended as a plain tap (or nothing was heard) — restore
+        /// the native behavior the surface intercepted: focus the field.
+        case quickTap
+    }
+
+    let id: UUID
+    let kind: Kind
+
+    init(_ kind: Kind) {
+        id = UUID()
+        self.kind = kind
+    }
+}
+
+/// Where an active push-to-talk press is in its lifecycle. `idle` means no
+/// overlay is mounted. Mirrors `PttStage` in
+/// `packages/webcomponents/src/composer/slicc-composer.ts`, minus `picking`:
+/// iOS routes the active microphone at the system level (AirPods and wired
+/// mics take over automatically), so there is deliberately no device picker.
+enum PttStage: Equatable {
+    case idle
+    /// Hold-to-enable bar sweeping; completing the hold requests permission.
+    case enable
+    /// The system permission prompt is up (or the request is in flight).
+    case prompting
+    /// Blocked. The associated message overrides the default "flip it in
+    /// Settings" instructions when the block has a different fix (restricted
+    /// devices, a stalled request).
+    case denied(message: String?)
+    case recording
+    /// Released — waiting for the recognizer's final transcript.
+    case finalizing
+}
+
+// MARK: - Scheduling seam
+
+/// Timer seam so unit tests drive the engage/enable delays by hand instead
+/// of sleeping through them. Returns a cancel closure.
+protocol PttScheduling {
+    func schedule(afterMs: Int, _ work: @escaping @MainActor () -> Void) -> () -> Void
+}
+
+struct MainQueuePttScheduler: PttScheduling {
+    func schedule(afterMs: Int, _ work: @escaping @MainActor () -> Void) -> () -> Void {
+        let item = DispatchWorkItem {
+            Task { @MainActor in work() }
+        }
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(afterMs), execute: item)
+        return { item.cancel() }
+    }
+}
+
+// MARK: - Controller
+
+/// The push-to-talk state machine, ported from `<slicc-composer>`'s gesture
+/// (`packages/webcomponents/src/composer/slicc-composer.ts`). The view owns
+/// touches (down / up / system-cancel); this controller owns every timer and
+/// transition, so the whole lifecycle is unit-testable with a fake engine
+/// and a hand-cranked scheduler.
+///
+/// Web timings are kept verbatim: a plain tap (released inside the 400 ms
+/// engage window) never flashes the overlay, and the 1 s hold-to-enable gate
+/// stands between an undetermined permission and the system prompt.
+@MainActor
+final class PttController: ObservableObject {
+    /// Delay between touch-down and arming the lifecycle (`PTT_ENGAGE_MS`).
+    static let engageMs = 400
+    /// Hold length before the permission request fires (`HOLD_TO_ENABLE_MS`).
+    static let holdToEnableMs = 1000
+    /// The caption line keeps only the trailing words (`CAPTION_MAX_WORDS`).
+    static let captionMaxWords = 8
+
+    @Published private(set) var stage: PttStage = .idle
+    /// The closed-caption line while recording (trailing words of the interim
+    /// transcript), or an error note when `captionIsError`.
+    @Published private(set) var caption = ""
+    @Published private(set) var captionIsError = false
+    /// The gesture's outcome, published as an event rather than delivered
+    /// through a stored callback: a SwiftUI view must handle it from
+    /// `.onChange` (re-registered every render) so the handler sees CURRENT
+    /// view state — a closure stored once at `onAppear` captures the value
+    /// snapshot from before e.g. the connection state settled, and a commit
+    /// routed through it silently fails the composer's guards.
+    @Published private(set) var event: PttEvent?
+
+    var engineStatusLine: String { engine.statusLine }
+
+    private let engine: DictationEngine
+    private let scheduler: PttScheduling
+    /// Bounds `requestPermission` (`PERMISSION_REQUEST_TIMEOUT_MS`): a grant
+    /// flow that never settles must not freeze the overlay at "prompting".
+    private let permissionTimeoutMs: Int
+    /// Bounds the release → stop() → commit chain (`FINALIZE_TIMEOUT_MS`).
+    private let finalizeTimeoutMs: Int
+
+    private var pressed = false
+    /// Monotonic press counter — async continuations from a stale press bail.
+    private var token = 0
+    private var cancelEngage: (() -> Void)?
+    private var cancelEnable: (() -> Void)?
+    private var session: DictationSession?
+    /// An in-flight `engine.start()`. Whoever nulls this slot owns the
+    /// eventual session (web parity with `#startingSession`): a release that
+    /// lands before start() resolves awaits it so captured audio is
+    /// transcribed, not dropped; a cancel awaits it to tear the session
+    /// down; the resolve continuation adopts it only while the slot still
+    /// holds its own handle.
+    private var startHandle: StartHandle?
+
+    /// Reference wrapper so continuations can check slot ownership by
+    /// identity (`Task` itself is a value type).
+    private final class StartHandle {
+        let task: Task<DictationSession?, Never>
+        init(_ task: Task<DictationSession?, Never>) { self.task = task }
+    }
+
+    init(
+        engine: DictationEngine,
+        scheduler: PttScheduling = MainQueuePttScheduler(),
+        permissionTimeoutMs: Int = 10_000,
+        finalizeTimeoutMs: Int = 45_000
+    ) {
+        self.engine = engine
+        self.scheduler = scheduler
+        self.permissionTimeoutMs = permissionTimeoutMs
+        self.finalizeTimeoutMs = finalizeTimeoutMs
+    }
+
+    // MARK: Touch input
+
+    func pressDown() {
+        guard !pressed, stage == .idle else { return }
+        pressed = true
+        token += 1
+        let t = token
+        cancelEngage = scheduler.schedule(afterMs: Self.engageMs) { [weak self] in
+            guard let self else { return }
+            self.cancelEngage = nil
+            self.engaged(t)
+        }
+    }
+
+    func pressUp() {
+        guard pressed else { return }
+        pressed = false
+        if let cancel = cancelEngage {
+            // Released inside the engage window: a plain tap. The overlay
+            // never flashed and the engine was never touched.
+            cancel()
+            cancelEngage = nil
+            token += 1
+            event = PttEvent(.quickTap)
+            return
+        }
+        switch stage {
+        case .enable:
+            cancelEnable?()
+            cancelEnable = nil
+            reset()
+        case .prompting:
+            // The system prompt steals the touch, so a release here is
+            // expected — the permission continuation owns teardown.
+            break
+        case .recording:
+            finalize()
+        default:
+            reset()
+        }
+    }
+
+    /// The system cancelled the touch mid-press (incoming call, control
+    /// center swipe). Tear down without inserting.
+    func pressCancelled() {
+        guard pressed else { return }
+        pressed = false
+        cancelEngage?()
+        cancelEngage = nil
+        cancelEnable?()
+        cancelEnable = nil
+        session?.cancel()
+        session = nil
+        cancelPendingStart()
+        if case .prompting = stage { return }
+        reset()
+    }
+
+    // MARK: Lifecycle
+
+    private func engaged(_ t: Int) {
+        guard pressed, t == token else { return }
+        switch engine.permission {
+        case .granted:
+            startRecording(t)
+        case .denied:
+            stage = .denied(message: nil)
+        case .restricted:
+            stage = .denied(message: Self.restrictedMessage)
+        case .undetermined:
+            stage = .enable
+            cancelEnable = scheduler.schedule(afterMs: Self.holdToEnableMs) { [weak self] in
+                guard let self else { return }
+                self.cancelEnable = nil
+                self.holdComplete(t)
+            }
+        }
+    }
+
+    private func holdComplete(_ t: Int) {
+        guard pressed, t == token, stage == .enable else { return }
+        stage = .prompting
+        let timeoutMs = permissionTimeoutMs
+        Task { @MainActor [weak self] in
+            guard let engine = self?.engine else { return }
+            let outcome: DictationPermission? = await Self.withTimeout(
+                ms: timeoutMs, fallback: nil
+            ) {
+                await engine.requestPermission()
+            }
+            guard let self, t == self.token else { return }
+            switch outcome {
+            case .granted:
+                if self.pressed {
+                    self.startRecording(t)
+                } else {
+                    // Released while the native prompt was up — granted and
+                    // armed for the next hold.
+                    self.reset()
+                }
+            case .restricted:
+                if self.pressed {
+                    self.stage = .denied(message: Self.restrictedMessage)
+                } else {
+                    self.reset()
+                }
+            case .denied, .undetermined:
+                if self.pressed {
+                    self.stage = .denied(message: nil)
+                } else {
+                    self.reset()
+                }
+            case nil:
+                // The request stalled past the timeout — surface why instead
+                // of freezing at "prompting" forever.
+                if self.pressed {
+                    self.stage = .denied(
+                        message: "The microphone didn't respond. Check Settings, then hold again.")
+                } else {
+                    self.reset()
+                }
+            }
+        }
+    }
+
+    private func startRecording(_ t: Int) {
+        stage = .recording
+        caption = ""
+        captionIsError = false
+        let engine = engine
+        let task = Task<DictationSession?, Never> { @MainActor [weak self] in
+            do {
+                return try await engine.start(
+                    onPartial: { [weak self] text in
+                        guard let self, t == self.token else { return }
+                        self.caption = Self.trailingWords(text)
+                        self.captionIsError = false
+                    },
+                    onError: { [weak self] message in
+                        guard let self, t == self.token else { return }
+                        self.caption = message
+                        self.captionIsError = true
+                    })
+            } catch {
+                if let self, t == self.token {
+                    self.caption = error.localizedDescription
+                    self.captionIsError = true
+                }
+                return nil
+            }
+        }
+        let handle = StartHandle(task)
+        startHandle = handle
+        Task { @MainActor [weak self] in
+            let session = await task.value
+            guard let self else {
+                session?.cancel()
+                return
+            }
+            // A finalize/cancel that landed first took the slot and owns the
+            // session — bail so we neither double-handle nor cancel a session
+            // the user wants transcribed.
+            guard self.startHandle === handle else { return }
+            self.startHandle = nil
+            guard t == self.token, self.stage == .recording else {
+                session?.cancel()
+                return
+            }
+            self.session = session
+        }
+    }
+
+    private func finalize() {
+        let t = token
+        let live = session
+        session = nil
+        let pending = startHandle
+        startHandle = nil
+        guard live != nil || pending != nil else {
+            // The engine never came up — keep the press a plain focus.
+            reset()
+            event = PttEvent(.quickTap)
+            return
+        }
+        stage = .finalizing
+        caption = "Transcribing…"
+        captionIsError = false
+        let timeoutMs = finalizeTimeoutMs
+        Task { @MainActor [weak self] in
+            let text = await Self.withTimeout(ms: timeoutMs, fallback: "") {
+                if let live { return await live.stop() }
+                guard let session = await pending?.task.value else { return "" }
+                return await session.stop()
+            }
+            guard let self, t == self.token else { return }
+            self.reset()
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                // Nothing heard — leave the press as a plain focus.
+                self.event = PttEvent(.quickTap)
+            } else {
+                self.event = PttEvent(.commit(trimmed))
+            }
+        }
+    }
+
+    private func cancelPendingStart() {
+        guard let pending = startHandle else { return }
+        startHandle = nil
+        Task { @MainActor in
+            (await pending.task.value)?.cancel()
+        }
+    }
+
+    private func reset() {
+        stage = .idle
+        caption = ""
+        captionIsError = false
+        token += 1
+    }
+
+    #if DEBUG
+        /// Screenshot seam (`-uiTestPttStage`): pin the overlay to a stage
+        /// without a touch. The overlay only exists mid-hold, so the PR
+        /// screenshots job could not reach it otherwise. DEBUG-only — a
+        /// shipped binary must not carry a flag that fakes recording UI.
+        func forceStage(_ stage: PttStage, caption: String = "") {
+            self.stage = stage
+            self.caption = caption
+        }
+    #endif
+
+    // MARK: Helpers
+
+    static let restrictedMessage =
+        "Speech recognition is restricted on this device (Screen Time or a profile), "
+        + "so push to talk is unavailable."
+
+    /// Keep only the trailing words, like movie closed captions.
+    static func trailingWords(_ text: String) -> String {
+        let words = text.split(whereSeparator: \.isWhitespace)
+        return words.suffix(captionMaxWords).joined(separator: " ")
+    }
+
+    /// Race `operation` against a deadline; `fallback` when the deadline
+    /// wins. Non-throwing analogue of the web's `withTimeout`.
+    private static func withTimeout<T: Sendable>(
+        ms: Int,
+        fallback: T,
+        operation: @escaping @MainActor @Sendable () async -> T
+    ) async -> T {
+        await withTaskGroup(of: T?.self) { group in
+            group.addTask { await operation() }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(ms) * 1_000_000)
+                return nil
+            }
+            let first = await group.next()
+            group.cancelAll()
+            return first ?? fallback
+        }
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/PttControllerTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/PttControllerTests.swift
@@ -1,0 +1,355 @@
+import Combine
+import XCTest
+
+@testable import SliccFollower
+
+/// The push-to-talk state machine, driven synchronously via a hand-cranked
+/// scheduler and a controllable fake engine. Timings and transitions mirror
+/// the web composer's gesture (`slicc-composer.ts`) — the tests assert the
+/// ported semantics, not SwiftUI rendering.
+@MainActor
+final class PttControllerTests: XCTestCase {
+
+    // MARK: Fakes
+
+    /// Records scheduled timers; the test fires them by hand.
+    final class FakeScheduler: PttScheduling {
+        final class Entry {
+            let afterMs: Int
+            let work: @MainActor () -> Void
+            var cancelled = false
+
+            init(afterMs: Int, work: @escaping @MainActor () -> Void) {
+                self.afterMs = afterMs
+                self.work = work
+            }
+        }
+
+        private(set) var entries: [Entry] = []
+
+        func schedule(afterMs: Int, _ work: @escaping @MainActor () -> Void) -> () -> Void {
+            let entry = Entry(afterMs: afterMs, work: work)
+            entries.append(entry)
+            return { entry.cancelled = true }
+        }
+
+        /// Fire the next pending (uncancelled) timer.
+        @MainActor
+        func fireNext() {
+            guard let index = entries.firstIndex(where: { !$0.cancelled }) else {
+                XCTFail("no pending timer to fire")
+                return
+            }
+            let entry = entries.remove(at: index)
+            entry.work()
+        }
+
+        var pendingCount: Int { entries.filter { !$0.cancelled }.count }
+    }
+
+    final class FakeSession: DictationSession {
+        let transcript: String
+        private(set) var stopped = false
+        private(set) var cancelled = false
+
+        init(transcript: String) { self.transcript = transcript }
+
+        func stop() async -> String {
+            stopped = true
+            return transcript
+        }
+
+        func cancel() { cancelled = true }
+    }
+
+    final class FakeEngine: DictationEngine {
+        var permission: DictationPermission
+        var grantOutcome: DictationPermission = .granted
+        var transcript = ""
+        var statusLine = "Fake engine"
+        private(set) var permissionRequests = 0
+        private(set) var startCount = 0
+        private(set) var lastSession: FakeSession?
+        var lastPartial: (@MainActor @Sendable (String) -> Void)?
+        /// When set, `requestPermission` never resolves (timeout path).
+        var stallPermission = false
+
+        init(permission: DictationPermission) { self.permission = permission }
+
+        func requestPermission() async -> DictationPermission {
+            permissionRequests += 1
+            if stallPermission {
+                // Far beyond any test's timeout budget.
+                try? await Task.sleep(nanoseconds: 60_000_000_000)
+            }
+            permission = grantOutcome
+            return grantOutcome
+        }
+
+        func start(
+            onPartial: @escaping @MainActor @Sendable (String) -> Void,
+            onError: @escaping @MainActor @Sendable (String) -> Void
+        ) async throws -> DictationSession {
+            startCount += 1
+            lastPartial = onPartial
+            let session = FakeSession(transcript: transcript)
+            lastSession = session
+            return session
+        }
+    }
+
+    // MARK: Helpers
+
+    private func makeController(
+        engine: FakeEngine,
+        scheduler: FakeScheduler,
+        permissionTimeoutMs: Int = 10_000
+    ) -> (PttController, Committed) {
+        let controller = PttController(
+            engine: engine,
+            scheduler: scheduler,
+            permissionTimeoutMs: permissionTimeoutMs,
+            finalizeTimeoutMs: 5000
+        )
+        let committed = Committed()
+        committed.cancellable = controller.$event
+            .compactMap { $0 }
+            .sink { event in
+                switch event.kind {
+                case .commit(let transcript): committed.transcripts.append(transcript)
+                case .quickTap: committed.quickTaps += 1
+                }
+            }
+        return (controller, committed)
+    }
+
+    /// Collects the controller's published outcome events (the view consumes
+    /// them via `.onChange`; tests via a sink).
+    final class Committed {
+        var transcripts: [String] = []
+        var quickTaps = 0
+        var cancellable: AnyCancellable?
+    }
+
+    /// Pump the main actor until `condition` holds (the controller settles
+    /// its async continuations in a few hops).
+    private func waitUntil(
+        _ condition: @autoclosure @MainActor () -> Bool,
+        timeout: TimeInterval = 2
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    // MARK: Tests
+
+    func testQuickTapNeverTouchesTheEngine() {
+        let engine = FakeEngine(permission: .granted)
+        let scheduler = FakeScheduler()
+        let (controller, committed) = makeController(engine: engine, scheduler: scheduler)
+
+        controller.pressDown()
+        XCTAssertEqual(controller.stage, .idle, "the engage window must not flash the overlay")
+        controller.pressUp()
+
+        XCTAssertEqual(controller.stage, .idle)
+        XCTAssertEqual(committed.quickTaps, 1, "a quick tap restores focus")
+        XCTAssertEqual(engine.startCount, 0)
+        XCTAssertEqual(scheduler.pendingCount, 0, "the engage timer was cancelled")
+    }
+
+    func testGrantedHoldRecordsAndCommitsOnRelease() async {
+        let engine = FakeEngine(permission: .granted)
+        engine.transcript = "hello from dictation"
+        let scheduler = FakeScheduler()
+        let (controller, committed) = makeController(engine: engine, scheduler: scheduler)
+
+        controller.pressDown()
+        scheduler.fireNext()  // engage → permission already granted → recording
+        XCTAssertEqual(controller.stage, .recording)
+
+        await waitUntil(engine.startCount == 1)
+        engine.lastPartial?("one two three")
+        XCTAssertEqual(controller.caption, "one two three")
+
+        controller.pressUp()
+        XCTAssertEqual(controller.stage, .finalizing)
+        await waitUntil(committed.transcripts.count == 1)
+        XCTAssertEqual(committed.transcripts, ["hello from dictation"])
+        XCTAssertEqual(controller.stage, .idle)
+        XCTAssertEqual(engine.lastSession?.stopped, true)
+    }
+
+    func testCaptionKeepsOnlyTrailingWords() async {
+        let engine = FakeEngine(permission: .granted)
+        let scheduler = FakeScheduler()
+        let (controller, _) = makeController(engine: engine, scheduler: scheduler)
+
+        controller.pressDown()
+        scheduler.fireNext()
+        await waitUntil(engine.startCount == 1)
+
+        engine.lastPartial?("one two three four five six seven eight nine ten")
+        XCTAssertEqual(
+            controller.caption, "three four five six seven eight nine ten",
+            "the caption keeps the trailing \(PttController.captionMaxWords) words")
+    }
+
+    func testUndeterminedRunsTheEnableGateThenPrompts() async {
+        let engine = FakeEngine(permission: .undetermined)
+        let scheduler = FakeScheduler()
+        let (controller, _) = makeController(engine: engine, scheduler: scheduler)
+
+        controller.pressDown()
+        scheduler.fireNext()  // engage
+        XCTAssertEqual(controller.stage, .enable)
+        XCTAssertEqual(engine.permissionRequests, 0, "the 1s gate stands before the prompt")
+
+        scheduler.fireNext()  // hold-to-enable complete
+        XCTAssertEqual(controller.stage, .prompting)
+        await waitUntil(engine.permissionRequests == 1)
+        // Grant resolved while still pressed → straight into recording.
+        await waitUntil(controller.stage == .recording)
+        XCTAssertEqual(engine.startCount, 1)
+    }
+
+    func testReleaseDuringEnableNeverPrompts() {
+        let engine = FakeEngine(permission: .undetermined)
+        let scheduler = FakeScheduler()
+        let (controller, committed) = makeController(engine: engine, scheduler: scheduler)
+
+        controller.pressDown()
+        scheduler.fireNext()  // engage → enable
+        controller.pressUp()
+
+        XCTAssertEqual(controller.stage, .idle)
+        XCTAssertEqual(engine.permissionRequests, 0)
+        XCTAssertEqual(committed.quickTaps, 0, "an aborted enable is not a tap")
+        XCTAssertEqual(scheduler.pendingCount, 0, "the enable timer was cancelled")
+    }
+
+    func testDeniedShowsInstructionsAndReleaseDismisses() {
+        let engine = FakeEngine(permission: .denied)
+        let scheduler = FakeScheduler()
+        let (controller, _) = makeController(engine: engine, scheduler: scheduler)
+
+        controller.pressDown()
+        scheduler.fireNext()
+        XCTAssertEqual(controller.stage, .denied(message: nil))
+        controller.pressUp()
+        XCTAssertEqual(controller.stage, .idle)
+        XCTAssertEqual(engine.startCount, 0)
+    }
+
+    func testRestrictedGetsItsOwnMessage() {
+        let engine = FakeEngine(permission: .restricted)
+        let scheduler = FakeScheduler()
+        let (controller, _) = makeController(engine: engine, scheduler: scheduler)
+
+        controller.pressDown()
+        scheduler.fireNext()
+        XCTAssertEqual(
+            controller.stage, .denied(message: PttController.restrictedMessage),
+            "restricted has no Settings toggle — the fix is different, so is the text")
+    }
+
+    func testGrantAfterReleaseArmsWithoutRecording() async {
+        let engine = FakeEngine(permission: .undetermined)
+        let scheduler = FakeScheduler()
+        let (controller, _) = makeController(engine: engine, scheduler: scheduler)
+
+        controller.pressDown()
+        scheduler.fireNext()  // engage → enable
+        scheduler.fireNext()  // → prompting (the system prompt steals the touch)
+        controller.pressUp()
+        XCTAssertEqual(controller.stage, .prompting, "the continuation owns teardown")
+
+        await waitUntil(controller.stage == .idle)
+        XCTAssertEqual(engine.permission, .granted, "granted and armed for the next hold")
+        XCTAssertEqual(engine.startCount, 0, "released — never records")
+    }
+
+    func testDenialWhilePressedShowsBlocked() async {
+        let engine = FakeEngine(permission: .undetermined)
+        engine.grantOutcome = .denied
+        let scheduler = FakeScheduler()
+        let (controller, _) = makeController(engine: engine, scheduler: scheduler)
+
+        controller.pressDown()
+        scheduler.fireNext()
+        scheduler.fireNext()
+        await waitUntil(controller.stage == .denied(message: nil))
+        XCTAssertEqual(controller.stage, .denied(message: nil))
+    }
+
+    func testStalledPermissionRequestRecoversWithAMessage() async {
+        let engine = FakeEngine(permission: .undetermined)
+        engine.stallPermission = true
+        let scheduler = FakeScheduler()
+        let (controller, _) = makeController(
+            engine: engine, scheduler: scheduler, permissionTimeoutMs: 50)
+
+        controller.pressDown()
+        scheduler.fireNext()
+        scheduler.fireNext()
+        XCTAssertEqual(controller.stage, .prompting)
+        await waitUntil(
+            {
+                if case .denied(let message) = controller.stage { return message != nil }
+                return false
+            }())
+        guard case .denied(let message) = controller.stage else {
+            return XCTFail("a stalled request must surface, not freeze the overlay")
+        }
+        XCTAssertNotNil(message)
+    }
+
+    func testEmptyTranscriptFallsBackToFocus() async {
+        let engine = FakeEngine(permission: .granted)
+        engine.transcript = "   "
+        let scheduler = FakeScheduler()
+        let (controller, committed) = makeController(engine: engine, scheduler: scheduler)
+
+        controller.pressDown()
+        scheduler.fireNext()
+        await waitUntil(engine.startCount == 1)
+        controller.pressUp()
+
+        await waitUntil(committed.quickTaps == 1)
+        XCTAssertTrue(committed.transcripts.isEmpty, "nothing heard — nothing submitted")
+        XCTAssertEqual(controller.stage, .idle)
+    }
+
+    func testSystemCancelTearsDownWithoutInserting() async {
+        let engine = FakeEngine(permission: .granted)
+        engine.transcript = "should never appear"
+        let scheduler = FakeScheduler()
+        let (controller, committed) = makeController(engine: engine, scheduler: scheduler)
+
+        controller.pressDown()
+        scheduler.fireNext()
+        await waitUntil(engine.startCount == 1)
+        // Let the start continuation adopt the session before cancelling.
+        await waitUntil(engine.lastSession != nil)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        controller.pressCancelled()
+        XCTAssertEqual(controller.stage, .idle)
+        await waitUntil(engine.lastSession?.cancelled == true)
+        XCTAssertEqual(engine.lastSession?.cancelled, true)
+        XCTAssertTrue(committed.transcripts.isEmpty)
+        XCTAssertEqual(committed.quickTaps, 0)
+    }
+
+    func testSecondPressDownWhileActiveIsIgnored() {
+        let engine = FakeEngine(permission: .granted)
+        let scheduler = FakeScheduler()
+        let (controller, _) = makeController(engine: engine, scheduler: scheduler)
+
+        controller.pressDown()
+        controller.pressDown()
+        XCTAssertEqual(scheduler.pendingCount, 1, "a second finger must not stack a press")
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/PttControllerTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/PttControllerTests.swift
@@ -49,13 +49,20 @@ final class PttControllerTests: XCTestCase {
 
     final class FakeSession: DictationSession {
         let transcript: String
+        let stallStop: Bool
         private(set) var stopped = false
         private(set) var cancelled = false
 
-        init(transcript: String) { self.transcript = transcript }
+        init(transcript: String, stallStop: Bool = false) {
+            self.transcript = transcript
+            self.stallStop = stallStop
+        }
 
         func stop() async -> String {
             stopped = true
+            if stallStop {
+                await FakeEngine.parkForever()
+            }
             return transcript
         }
 
@@ -71,19 +78,30 @@ final class PttControllerTests: XCTestCase {
         private(set) var startCount = 0
         private(set) var lastSession: FakeSession?
         var lastPartial: (@MainActor @Sendable (String) -> Void)?
-        /// When set, `requestPermission` never resolves (timeout path).
+        /// When set, `requestPermission` never resolves (timeout path). The
+        /// stall deliberately ignores task cancellation — the failure mode
+        /// is a system permission callback that simply never fires, and the
+        /// controller's deadline must recover from exactly that.
         var stallPermission = false
+        /// When set, sessions' `stop()` never resolves (finalize-timeout
+        /// path), again immune to cancellation like a hung recognizer.
+        var stallStop = false
 
         init(permission: DictationPermission) { self.permission = permission }
 
         func requestPermission() async -> DictationPermission {
             permissionRequests += 1
             if stallPermission {
-                // Far beyond any test's timeout budget.
-                try? await Task.sleep(nanoseconds: 60_000_000_000)
+                await Self.parkForever()
             }
             permission = grantOutcome
             return grantOutcome
+        }
+
+        /// Suspend forever, ignoring cancellation (unsafe continuation is
+        /// never resumed — no checked-continuation leak warning).
+        static func parkForever() async {
+            await withUnsafeContinuation { (_: UnsafeContinuation<Void, Never>) in }
         }
 
         func start(
@@ -92,7 +110,7 @@ final class PttControllerTests: XCTestCase {
         ) async throws -> DictationSession {
             startCount += 1
             lastPartial = onPartial
-            let session = FakeSession(transcript: transcript)
+            let session = FakeSession(transcript: transcript, stallStop: stallStop)
             lastSession = session
             return session
         }
@@ -304,6 +322,42 @@ final class PttControllerTests: XCTestCase {
             return XCTFail("a stalled request must surface, not freeze the overlay")
         }
         XCTAssertNotNil(message)
+    }
+
+    func testHungStopRecoversViaFinalizeTimeout() async {
+        let engine = FakeEngine(permission: .granted)
+        engine.transcript = "never delivered"
+        engine.stallStop = true
+        let scheduler = FakeScheduler()
+        let controller = PttController(
+            engine: engine,
+            scheduler: scheduler,
+            permissionTimeoutMs: 10_000,
+            finalizeTimeoutMs: 50
+        )
+        let committed = Committed()
+        committed.cancellable = controller.$event
+            .compactMap { $0 }
+            .sink { event in
+                switch event.kind {
+                case .commit(let transcript): committed.transcripts.append(transcript)
+                case .quickTap: committed.quickTaps += 1
+                }
+            }
+
+        controller.pressDown()
+        scheduler.fireNext()
+        await waitUntil(engine.startCount == 1)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        controller.pressUp()
+        XCTAssertEqual(controller.stage, .finalizing)
+
+        // A stop() that never settles (and ignores cancellation, like a
+        // hung recognizer) must not pin the overlay at "Transcribing…" —
+        // the deadline abandons it and the gesture recovers to idle.
+        await waitUntil(controller.stage == .idle)
+        XCTAssertEqual(controller.stage, .idle)
+        XCTAssertTrue(committed.transcripts.isEmpty)
     }
 
     func testEmptyTranscriptFallsBackToFocus() async {

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/PttUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/PttUITests.swift
@@ -1,0 +1,84 @@
+import XCTest
+
+/// Push-to-talk end to end against the scripted DEBUG engine
+/// (`-uiTestSpeechPermission` / `-uiTestSpeechScript`) — no microphone, no
+/// system permission prompt, no leader.
+final class PttUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testHoldDictatesAndSubmitsTheTranscript() {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-joinUrl", "",
+            "-uiTestConnectionState", "connected",
+            "-uiTestSpeechPermission", "granted",
+            "-uiTestSpeechScript", "hello from dictation",
+        ]
+        app.launch()
+
+        let surface = app.otherElements["ptt-surface"]
+        XCTAssertTrue(surface.waitForExistence(timeout: 60))
+
+        // Hold well past the 400 ms engage window; the scripted engine
+        // streams the transcript while held, release commits + submits it.
+        surface.press(forDuration: 1.5)
+
+        XCTAssertTrue(
+            app.staticTexts["hello from dictation"].waitForExistence(timeout: 10),
+            "the dictated transcript should submit as a user message")
+    }
+
+    func testBlockedPermissionNeverSubmits() {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-joinUrl", "",
+            "-uiTestConnectionState", "connected",
+            "-uiTestSpeechPermission", "denied",
+            "-uiTestSpeechScript", "should never appear",
+        ]
+        app.launch()
+
+        let surface = app.otherElements["ptt-surface"]
+        XCTAssertTrue(surface.waitForExistence(timeout: 60))
+
+        surface.press(forDuration: 1.5)
+
+        // The hold surfaced the blocked overlay (not observable after
+        // release) — what matters is that nothing was heard or sent.
+        XCTAssertFalse(
+            app.staticTexts["should never appear"].waitForExistence(timeout: 3),
+            "a blocked microphone must never produce a message")
+        XCTAssertTrue(surface.exists, "the composer stays empty and armed")
+    }
+
+    func testQuickTapStillFocusesTheComposer() {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-joinUrl", "",
+            "-uiTestConnectionState", "connected",
+            "-uiTestSpeechPermission", "granted",
+            "-uiTestSpeechScript", "should never appear",
+        ]
+        app.launch()
+
+        let composer = app.textViews.firstMatch
+        XCTAssertTrue(composer.waitForExistence(timeout: 60))
+
+        // A plain tap lands on the press surface (it overlays the empty
+        // composer) and must forward to focus — the pre-PTT behavior every
+        // other composer test relies on.
+        composer.tap()
+        composer.typeText("typed, not spoken")
+
+        // typeText itself fails without focus, and the value proves the tap
+        // forwarded to the editor instead of arming dictation.
+        XCTAssertTrue((composer.value as? String)?.contains("typed, not spoken") == true)
+        XCTAssertFalse(
+            app.staticTexts["should never appear"].exists,
+            "a quick tap must never trigger dictation")
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/SteerUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/SteerUITests.swift
@@ -31,8 +31,13 @@ final class SteerUITests: XCTestCase {
             "A non-empty composer during a running turn should offer send")
 
         // Long-press reveals the interrupt option (Menu primaryAction keeps
-        // plain tap as the queueing send).
+        // plain tap as the queueing send). Under CI load a context menu can
+        // eat the first press without opening (load-dependent, seen only on
+        // busy simulator clones), so give it one more before judging.
         send.press(forDuration: 1.0)
+        if !app.buttons["Interrupt & send"].waitForExistence(timeout: 10) {
+            send.press(forDuration: 1.2)
+        }
         XCTAssertTrue(
             app.buttons["Interrupt & send"].waitForExistence(timeout: 10),
             "The long-press menu should offer the steer action")

--- a/packages/ios-app/SliccFollower/Views/InputBar.swift
+++ b/packages/ios-app/SliccFollower/Views/InputBar.swift
@@ -19,6 +19,12 @@ struct InputBar: View {
     var onSteer: (String) -> Void = { _ in }
 
     @FocusState private var isFocused: Bool
+    @Environment(\.scenePhase) private var scenePhase
+
+    /// Push-to-talk: holding the EMPTY composer dictates a message
+    /// (`PttController` owns the state machine; the engine is swappable so
+    /// UI tests script it via `-uiTestSpeechPermission`).
+    @StateObject private var ptt = PttController(engine: InputBar.makeDictationEngine())
 
     private let accentPurple = Color(red: 0x71 / 255, green: 0x55 / 255, blue: 0xFA / 255)
     private let barBackground = Color(red: 0x1C / 255, green: 0x1C / 255, blue: 0x2E / 255)
@@ -59,6 +65,51 @@ struct InputBar: View {
         .opacity(isComposable ? 1.0 : 0.5)
         .disabled(!isComposable)
         .animation(.easeInOut(duration: 0.2), value: isStreaming)
+        .overlay {
+            // The walkie-talkie overlay while a hold is active. Covers the
+            // whole band so the held finger has nothing else to hit.
+            if ptt.stage != .idle {
+                PttOverlayView(
+                    stage: ptt.stage,
+                    caption: ptt.caption,
+                    captionIsError: ptt.captionIsError,
+                    statusLine: ptt.engineStatusLine
+                )
+            }
+        }
+        .onAppear {
+            #if DEBUG
+                if let forced = UITestHooks.pttStage() {
+                    ptt.forceStage(forced.stage, caption: forced.caption)
+                }
+            #endif
+        }
+        // Handled from `.onChange` — NOT a callback stored at `onAppear` —
+        // so the handler sees current props: an appear-time closure captures
+        // the view value from before the connection state settled, and a
+        // commit routed through that snapshot fails `isComposable` silently.
+        .onChange(of: ptt.event) { _, event in
+            guard let event else { return }
+            switch event.kind {
+            case .commit(let transcript):
+                // The gesture only arms on an empty composer, so the
+                // transcript IS the message — reuse the exact send path.
+                text = transcript
+                sendIfPossible()
+            case .quickTap:
+                // Restore the native behavior the surface intercepted: a
+                // plain tap places the caret.
+                isFocused = true
+            }
+        }
+        .onChange(of: scenePhase) { _, phase in
+            // SwiftUI's DragGesture has no touch-cancel callback; a system
+            // interrupt (incoming call, app switcher) surfaces as a scene
+            // phase change instead, and a press must not outlive it.
+            if phase != .active {
+                ptt.pressCancelled()
+            }
+        }
     }
 
     // MARK: - Text Field
@@ -89,6 +140,14 @@ struct InputBar: View {
                 .onSubmit {
                     sendIfPossible()
                 }
+                // While push-to-talk is armed the UIKit text view must not
+                // swallow touches: UITextView sits above any sibling overlay
+                // in UIKit z-order no matter what SwiftUI declares, so the
+                // press surface only ever hears a touch if the editor is
+                // hit-disabled. There is nothing to lose — the composer is
+                // empty (no caret to place, no text to select) and a quick
+                // tap restores focus through the `quickTap` event.
+                .allowsHitTesting(!pttArmed)
         }
         .background(fieldBackground)
         .clipShape(RoundedRectangle(cornerRadius: 18))
@@ -96,6 +155,31 @@ struct InputBar: View {
             RoundedRectangle(cornerRadius: 18)
                 .stroke(Color.white.opacity(0.12), lineWidth: 0.5)
         )
+        .overlay {
+            // Hold-to-talk arms ONLY from an empty composer (web parity:
+            // once text is present a press is editing it, so the surface
+            // unmounts and selection/caret placement stay native). A quick
+            // tap forwards to focus via the `quickTap` event.
+            if pttArmed {
+                PttPressSurface(
+                    onDown: { ptt.pressDown() },
+                    onUp: { ptt.pressUp() }
+                )
+            }
+        }
+    }
+
+    /// The press surface mounts (and the editor yields its touches) only on
+    /// an empty, usable composer.
+    private var pttArmed: Bool { text.isEmpty && isComposable }
+
+    /// The recognizer behind push-to-talk: a UI test's scripted fake when
+    /// the launch arguments ask for one, Apple's on-device engine otherwise.
+    private static func makeDictationEngine() -> DictationEngine {
+        #if DEBUG
+            if let scripted = UITestHooks.speechEngine() { return scripted }
+        #endif
+        return AppleDictationEngine()
     }
 
     // MARK: - Action Button

--- a/packages/ios-app/SliccFollower/Views/PttOverlayView.swift
+++ b/packages/ios-app/SliccFollower/Views/PttOverlayView.swift
@@ -1,0 +1,244 @@
+import SwiftUI
+import UIKit
+
+// MARK: - Overlay
+
+/// The push-to-talk overlay that turns the composer band into one big
+/// walkie-talkie button while a hold is active. Renders whatever stage the
+/// `PttController` is in; it never owns state. Ported from the
+/// `.slicc-composer__ptt` overlay stages (web parity), minus the mic picker
+/// — iOS routes the input device at the system level.
+struct PttOverlayView: View {
+    let stage: PttStage
+    let caption: String
+    let captionIsError: Bool
+    /// The engine's "where does my audio go" disclosure line.
+    let statusLine: String
+
+    private let accentPurple = Color(red: 0x71 / 255, green: 0x55 / 255, blue: 0xFA / 255)
+    private let barBackground = Color(red: 0x1C / 255, green: 0x1C / 255, blue: 0x2E / 255)
+
+    var body: some View {
+        VStack(spacing: 6) {
+            switch stage {
+            case .idle:
+                EmptyView()
+            case .enable:
+                micIcon(pulse: false)
+                Text("Hold to enable push to talk")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.white)
+                sweepBar
+                Text("Requesting microphone access when the bar fills")
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.6))
+            case .prompting:
+                micIcon(pulse: false)
+                Text("Allow microphone access")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.white)
+                Text("Waiting for permission…")
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.6))
+            case .denied(let message):
+                Image(systemName: "mic.slash.fill")
+                    .font(.system(size: 24))
+                    .foregroundStyle(.red)
+                Text(message == nil ? "Microphone access is blocked" : "Push to talk unavailable")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.white)
+                Text(
+                    message
+                        ?? "Enable the microphone and speech recognition for SLICC in Settings, then hold again."
+                )
+                .font(.caption2)
+                .foregroundStyle(.white.opacity(0.7))
+                .multilineTextAlignment(.center)
+                .accessibilityIdentifier("ptt-denied")
+            case .recording:
+                micIcon(pulse: true)
+                Text(caption.isEmpty ? "Listening…" : caption)
+                    .font(.subheadline)
+                    .foregroundStyle(captionIsError ? .red : .white)
+                    .lineLimit(1)
+                    .truncationMode(.head)
+                    .accessibilityIdentifier("ptt-caption")
+                Text(statusLine)
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.6))
+                    .accessibilityIdentifier("ptt-status")
+            case .finalizing:
+                ProgressView()
+                    .tint(accentPurple)
+                Text("Transcribing…")
+                    .font(.subheadline)
+                    .foregroundStyle(.white)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(barBackground)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(accentPurple.opacity(0.6))
+                .frame(height: 1)
+        }
+        // No container-level identifier: SwiftUI stamps one onto every leaf,
+        // clobbering the per-leaf ids (`ptt-caption`, `ptt-denied`) tests
+        // key on — the repo's documented put-ids-on-leaves gotcha.
+    }
+
+    @ViewBuilder
+    private func micIcon(pulse: Bool) -> some View {
+        PulsingMic(active: pulse, tint: accentPurple)
+    }
+
+    @ViewBuilder
+    private var sweepBar: some View {
+        EnableSweepBar(tint: accentPurple)
+    }
+}
+
+/// The recording mic. Owns its pulse so the animation restarts whenever the
+/// stage branch (re)mounts it. Reduce Motion keeps it lit but still (web
+/// parity with `prefers-reduced-motion`).
+private struct PulsingMic: View {
+    let active: Bool
+    let tint: Color
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var up = false
+
+    var body: some View {
+        Image(systemName: "mic.fill")
+            .font(.system(size: 24))
+            .foregroundStyle(tint)
+            .scaleEffect(active && up && !reduceMotion ? 1.25 : 1.0)
+            .onAppear {
+                guard active, !reduceMotion else { return }
+                withAnimation(.easeInOut(duration: 0.7).repeatForever(autoreverses: true)) {
+                    up = true
+                }
+            }
+    }
+}
+
+/// The hold-to-enable progress bar, sweeping over
+/// `PttController.holdToEnableMs` in step with the permission gate. Reduce
+/// Motion renders it full immediately — the label carries the meaning.
+private struct EnableSweepBar: View {
+    let tint: Color
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var filled = false
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.white.opacity(0.15))
+                Capsule()
+                    .fill(tint)
+                    .frame(width: filled ? proxy.size.width : 0)
+            }
+        }
+        .frame(height: 4)
+        .padding(.horizontal, 32)
+        .onAppear {
+            guard !reduceMotion else {
+                filled = true
+                return
+            }
+            withAnimation(.linear(duration: Double(PttController.holdToEnableMs) / 1000)) {
+                filled = true
+            }
+        }
+    }
+}
+
+// MARK: - Press surface
+
+/// Transparent touch surface laid over the empty composer field. SwiftUI
+/// hit-testing is the only layer that can reliably sit above `TextEditor`'s
+/// backing `UITextView` (a UIKit sibling always wins UIKit hit-testing, no
+/// matter what order SwiftUI declares — which is also why the editor is
+/// hit-disabled while this surface is armed). A zero-distance `DragGesture`
+/// reports touch down/up; SwiftUI has no first-class touch-cancel, so the
+/// host view cancels the press on scene-phase changes (the system-interrupt
+/// case that would otherwise strand a recording).
+struct PttPressSurface: View {
+    let onDown: () -> Void
+    let onUp: () -> Void
+
+    @State private var pressing = false
+
+    var body: some View {
+        Color.clear
+            .contentShape(Rectangle())
+            .accessibilityIdentifier("ptt-surface")
+            .accessibilityLabel("Message field — hold to talk")
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        guard !pressing else { return }
+                        pressing = true
+                        onDown()
+                    }
+                    .onEnded { _ in
+                        pressing = false
+                        onUp()
+                    }
+            )
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Recording") {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        VStack {
+            Spacer()
+            PttOverlayView(
+                stage: .recording,
+                caption: "the quick brown fox jumps over",
+                captionIsError: false,
+                statusLine: "Transcribed on this device"
+            )
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Enable") {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        VStack {
+            Spacer()
+            PttOverlayView(
+                stage: .enable,
+                caption: "",
+                captionIsError: false,
+                statusLine: ""
+            )
+        }
+    }
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Denied") {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        VStack {
+            Spacer()
+            PttOverlayView(
+                stage: .denied(message: nil),
+                caption: "",
+                captionIsError: false,
+                statusLine: ""
+            )
+        }
+    }
+    .preferredColorScheme(.dark)
+}

--- a/packages/ios-app/project.yml
+++ b/packages/ios-app/project.yml
@@ -32,6 +32,8 @@ targets:
         SUPPORTED_PLATFORMS: 'iphoneos iphonesimulator'
         SUPPORTS_MACCATALYST: NO
         INFOPLIST_KEY_NSCameraUsageDescription: 'This app does not access the camera. This entry is required because the bundled WebRTC framework references camera APIs.'
+        INFOPLIST_KEY_NSMicrophoneUsageDescription: 'Hold the message field to dictate a message with your voice.'
+        INFOPLIST_KEY_NSSpeechRecognitionUsageDescription: 'Dictated audio is transcribed on this device when possible to fill the message field.'
         INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO
         # iCloud KVS for tray-session discovery. The App Store provisioning
         # profile must carry the iCloud capability; dev/simulator builds

--- a/packages/ios-app/screenshot-screens.json
+++ b/packages/ios-app/screenshot-screens.json
@@ -62,6 +62,28 @@
       ]
     },
     {
+      "name": "ptt-recording",
+      "description": "Push-to-talk mid-hold: pulsing mic, streaming caption, engine line",
+      "args": [
+        "-uiTestConnectionState",
+        "connected",
+        "-uiTestPttStage",
+        "recording",
+        "-uiTestPttCaption",
+        "the quick brown fox jumps over"
+      ]
+    },
+    {
+      "name": "ptt-enable",
+      "description": "Hold-to-enable gate before the first permission prompt",
+      "args": ["-uiTestConnectionState", "connected", "-uiTestPttStage", "enable"]
+    },
+    {
+      "name": "ptt-denied",
+      "description": "Microphone blocked: instructions instead of a recorder",
+      "args": ["-uiTestConnectionState", "connected", "-uiTestPttStage", "denied"]
+    },
+    {
       "name": "frozen-empty",
       "description": "Past Sessions sheet with no archived sessions",
       "args": [


### PR DESCRIPTION
Closes #1796.

Holding the **empty** composer records a dictated message: a closed-caption line streams the interim transcript while the finger is down, and release appends the final transcript and submits it as an ordinary `user_message` — no protocol work, exactly as the tracking issue prescribed.

## What's ported (web parity)

- The `<slicc-composer>` gesture timings verbatim: **400 ms engage window** (a plain tap never flashes the overlay — it forwards to caret focus), **1 s hold-to-enable gate** before the first permission prompt, trailing-8-word captions, bounded permission (10 s) and finalize (45 s) chains so no stage can freeze the overlay.
- Stages: `enable` (sweeping bar) → `prompting` → `recording` (pulsing mic + caption + engine line) → `finalizing`, plus `denied`.
- **Reduce Motion** kills the sweep and the pulse (`prefers-reduced-motion` parity).
- Deliberate divergence: **no mic picker** — iOS routes the input device at the system level (AirPods / wired mics take over automatically).

## Engine

`SFSpeechRecognizer` + `AVAudioEngine` behind a `DictationEngine` seam. On-device recognition is the default whenever the locale's model supports it (the natural analogue of the web's whisper engine, minus the 150 MB download); the overlay's status line discloses when audio is sent to Apple instead. Permission states are handled distinctly: undetermined runs the enable gate, denied renders Settings instructions, **restricted** (Screen Time / profile) gets its own message because there is no toggle to flip, and a stalled request times out into an explanation.

## Two SwiftUI traps worth reviewer attention

1. `TextEditor`'s backing `UITextView` wins UIKit hit-testing over ANY sibling overlay regardless of SwiftUI declaration order. The press surface is therefore a SwiftUI-native zero-distance `DragGesture`, and the editor is hit-disabled while the composer is empty (nothing to select or caret-place there).
2. Gesture outcomes surface as a `@Published` `PttEvent` consumed from `.onChange` — NOT a callback stored at `onAppear`, whose stale view-value capture (connection state from before the forced state settled) silently failed the composer guards. Found the hard way; documented in the code.

## Tests

- 12 `PttControllerTests` drive the state machine synchronously via a hand-cranked scheduler seam + fake engine: quick tap, granted/denied/restricted, release-during-enable, grant-after-release, stalled-prompt recovery, empty transcript, system cancel, caption trimming, double-press.
- 3 `PttUITests` run end to end against a scripted DEBUG engine (`-uiTestSpeechPermission` / `-uiTestSpeechScript`): hold → transcript submits as a message; denied → nothing ever submits; quick tap still focuses + types.
- Full suite: **157 tests green**, coverage 60.68 % lines (floor 53 %).

## Screenshots

Three new screens in the PR screenshots manifest (`ptt-recording`, `ptt-enable`, `ptt-denied`, via the `-uiTestPttStage` seam) — the **iOS screenshots job comments below** with the rendered overlays. The recording overlay: pulsing mic over the composer band, caption line, "Transcribed on this device" disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2m3i5QmGvGFehU4Uoi1k3