### PR TITLE
fix(webapp): handle initial sprinkle bridge calls

### DIFF
--- a/packages/webapp/src/ui/sprinkle-follower-controller.ts
+++ b/packages/webapp/src/ui/sprinkle-follower-controller.ts
@@ -247,6 +247,8 @@ export class SprinkleFollowerController {
     }
 
     entry.renderer = renderer;
+    renderer.activateBridgeLifecycle();
+    if (!this.open.has(sprinkleName)) return;
     log.info('Sprinkle reloaded in place', { sprinkleName });
   }
 
@@ -362,6 +364,8 @@ export class SprinkleFollowerController {
     // interleaving the buffered replay against them.
     this.open.set(name, { renderer, container });
     this.opening.delete(name);
+    renderer.activateBridgeLifecycle();
+    if (!this.open.has(name)) return;
     const buffered = this.pendingUpdates.get(name);
     if (buffered !== undefined) {
       this.pendingUpdates.delete(name);

--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -516,6 +516,8 @@ export class SprinkleManager implements SprinkleManagerHandle {
       return;
     }
     entry.renderer = renderer;
+    renderer.activateBridgeLifecycle();
+    if (!this.openSprinkles.has(name)) return;
 
     log.info('Sprinkle reloaded', { name });
     this.notifyChange();
@@ -951,7 +953,14 @@ export class SprinkleManager implements SprinkleManagerHandle {
     const renderer = new SprinkleRenderer(container, api);
     await renderer.render(content, name);
 
-    this.openSprinkles.get(name)!.renderer = renderer;
+    const entry = this.openSprinkles.get(name);
+    if (!entry) {
+      renderer.dispose();
+      return;
+    }
+    entry.renderer = renderer;
+    renderer.activateBridgeLifecycle();
+    if (!this.openSprinkles.has(name)) return;
     this.persistOpenSprinkles();
     trackSprinkleView(name);
     log.info('Sprinkle opened', { name, title: sprinkle.title });

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -613,6 +613,14 @@ export class SprinkleRenderer {
     iframe.srcdoc = modified;
     this.iframe = iframe;
 
+    // Install the parent listener before appending: srcdoc scripts can post
+    // bridge calls synchronously while appendChild() is still loading the iframe.
+    this.messageHandler = createIframeMessageListener(
+      iframe,
+      createSharedBridgeHandlers(this.bridge)
+    );
+    window.addEventListener('message', this.messageHandler);
+
     // Wait for iframe to load
     await new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -645,16 +653,6 @@ export class SprinkleRenderer {
       );
       this.container.appendChild(iframe);
     });
-
-    // Listen for messages from the iframe — the full-doc bridge script only
-    // sends the shared VFS/exec/device/lifecycle messages (no localStorage
-    // proxying, `sprinkle-open`, or `sprinkle-fetch-script` — those are
-    // sandbox-only, injected via extension-runtime-only script tags).
-    this.messageHandler = createIframeMessageListener(
-      iframe,
-      createSharedBridgeHandlers(this.bridge)
-    );
-    window.addEventListener('message', this.messageHandler);
 
     // The sprinkle's `<slicc-surface>` host stays mounted and toggles
     // `display:none`/`display:flex` on tab switches instead of destroying the

--- a/packages/webapp/src/ui/sprinkle-renderer.ts
+++ b/packages/webapp/src/ui/sprinkle-renderer.ts
@@ -296,6 +296,8 @@ export class SprinkleRenderer {
   private iframe: HTMLIFrameElement | null = null;
   private messageHandler: ((event: MessageEvent) => void) | null = null;
   private visibilityObserver: IntersectionObserver | null = null;
+  private bridgeLifecycleReady = false;
+  private pendingBridgeLifecycle: Array<() => void> = [];
 
   constructor(container: HTMLElement, bridge: SprinkleBridgeAPI) {
     this.container = container;
@@ -307,9 +309,22 @@ export class SprinkleRenderer {
     this.dispose();
 
     if (isFullDocument(content)) {
-      await this.renderFullDoc(content, sprinkleName);
+      try {
+        await this.renderFullDoc(content, sprinkleName);
+      } catch (err) {
+        this.dispose();
+        throw err;
+      }
     } else {
       this.renderInline(content, sprinkleName);
+    }
+  }
+
+  /** Release lifecycle calls once the owner has registered this renderer. */
+  activateBridgeLifecycle(): void {
+    this.bridgeLifecycleReady = true;
+    while (this.bridgeLifecycleReady && this.pendingBridgeLifecycle.length > 0) {
+      this.pendingBridgeLifecycle.shift()!();
     }
   }
 
@@ -615,10 +630,18 @@ export class SprinkleRenderer {
 
     // Install the parent listener before appending: srcdoc scripts can post
     // bridge calls synchronously while appendChild() is still loading the iframe.
-    this.messageHandler = createIframeMessageListener(
-      iframe,
-      createSharedBridgeHandlers(this.bridge)
-    );
+    const handlers = createSharedBridgeHandlers(this.bridge);
+    for (const type of ['sprinkle-close', 'sprinkle-minimize']) {
+      const handler = handlers[type];
+      handlers[type] = (target, msg) => {
+        if (!this.bridgeLifecycleReady) {
+          this.pendingBridgeLifecycle.push(() => handler(target, msg));
+          return;
+        }
+        handler(target, msg);
+      };
+    }
+    this.messageHandler = createIframeMessageListener(iframe, handlers);
     window.addEventListener('message', this.messageHandler);
 
     // Wait for iframe to load
@@ -724,6 +747,8 @@ export class SprinkleRenderer {
 
   /** Clean up scripts and content. */
   dispose(): void {
+    this.bridgeLifecycleReady = false;
+    this.pendingBridgeLifecycle = [];
     if (this.visibilityObserver) {
       this.visibilityObserver.disconnect();
       this.visibilityObserver = null;

--- a/packages/webapp/tests/ui/sprinkle-follower-controller.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-follower-controller.test.ts
@@ -23,6 +23,7 @@ vi.mock('../../src/ui/sprinkle-renderer.js', () => {
     rendered = '';
     disposed = false;
     pushed: unknown[] = [];
+    sprinkleName = '';
 
     constructor(container: HTMLElement, api: unknown) {
       this.container = container;
@@ -31,6 +32,7 @@ vi.mock('../../src/ui/sprinkle-renderer.js', () => {
     }
     async render(content: string, sprinkleName?: string): Promise<void> {
       this.rendered = content;
+      this.sprinkleName = sprinkleName ?? '';
       const gate = sprinkleName ? manualRenderGate.get(sprinkleName) : undefined;
       if (gate) {
         manualRenderGate.delete(sprinkleName!);
@@ -43,14 +45,21 @@ vi.mock('../../src/ui/sprinkle-renderer.js', () => {
     dispose(): void {
       this.disposed = true;
     }
+    activateBridgeLifecycle(): void {
+      if (FakeRenderer.closeOnActivate.delete(this.sprinkleName)) {
+        (this.api as { close(): void }).close();
+      }
+    }
     pushUpdate(data: unknown): void {
       this.pushed.push(data);
     }
 
     static instances: FakeRenderer[] = [];
+    static closeOnActivate = new Set<string>();
     static reset(): void {
       FakeRenderer.instances = [];
       manualRenderGate.clear();
+      FakeRenderer.closeOnActivate.clear();
     }
     static installManualRender(name: string): {
       resolve: () => void;
@@ -62,6 +71,9 @@ vi.mock('../../src/ui/sprinkle-renderer.js', () => {
       };
       manualRenderGate.set(name, handle);
       return handle;
+    }
+    static installCloseOnActivate(name: string): void {
+      FakeRenderer.closeOnActivate.add(name);
     }
   }
   return { SprinkleRenderer: FakeRenderer };
@@ -85,6 +97,7 @@ const FakeRenderer = SprinkleRenderer as unknown as {
   }>;
   reset(): void;
   installManualRender(name: string): { resolve: () => void; reject: (err: Error) => void };
+  installCloseOnActivate(name: string): void;
 };
 
 function makeSprinkle(name: string, opts: Partial<SprinkleSummary> = {}): SprinkleSummary {
@@ -350,6 +363,16 @@ describe('SprinkleFollowerController', () => {
       await controller.updateAvailable([makeSprinkle('welcome', { open: true })]);
 
       FakeRenderer.instances[0].api.close();
+
+      expect(removeSprinkle).toHaveBeenCalledWith('welcome');
+      expect(FakeRenderer.instances[0].disposed).toBe(true);
+    });
+
+    it('publishes the renderer before releasing a queued close lifecycle call', async () => {
+      sync.contentByName.set('welcome', '<p>hi</p>');
+      FakeRenderer.installCloseOnActivate('welcome');
+
+      await controller.updateAvailable([makeSprinkle('welcome', { open: true })]);
 
       expect(removeSprinkle).toHaveBeenCalledWith('welcome');
       expect(FakeRenderer.instances[0].disposed).toBe(true);

--- a/packages/webapp/tests/ui/sprinkle-manager.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-manager.test.ts
@@ -13,10 +13,18 @@ import {
   writeOpenSprinklesToUrl,
 } from '../../src/ui/sprinkle-manager.js';
 
+const rendererState = vi.hoisted(() => ({ closeOnActivate: false }));
+
 vi.mock('../../src/ui/sprinkle-renderer.js', () => ({
   SprinkleRenderer: class {
-    constructor(_c: unknown, _api: unknown) {}
+    constructor(
+      _c: unknown,
+      private readonly api: { close(): void }
+    ) {}
     async render() {}
+    activateBridgeLifecycle() {
+      if (rendererState.closeOnActivate) this.api.close();
+    }
     dispose() {}
     pushUpdate() {}
   },
@@ -75,6 +83,7 @@ describe('SprinkleManager', () => {
   let mgr: SprinkleManager;
 
   beforeEach(async () => {
+    rendererState.closeOnActivate = false;
     vi.stubGlobal('localStorage', makeMemoryStorage());
     vi.stubGlobal('document', makeFakeDocument());
     // Reset the URL to a known state so URL-persistence tests start
@@ -534,6 +543,17 @@ describe('SprinkleManager', () => {
       await Promise.resolve();
       expect(calls.length).toBe(1);
     });
+  });
+
+  it('handles a close lifecycle call released immediately after renderer registration', async () => {
+    await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>hi</div>');
+    await mgr.refresh();
+    rendererState.closeOnActivate = true;
+
+    await expect(mgr.open('dash')).resolves.toBeUndefined();
+
+    expect(mgr.opened()).not.toContain('dash');
+    expect(closeSprinkleContent).toHaveBeenCalledWith('dash');
   });
 
   describe('one-shot auto-open consumption ledger (slicc-autoopened-once)', () => {

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -303,6 +303,52 @@ describe('full document rendering', () => {
     expect(bridge.readFile).toHaveBeenCalledWith('/shared/state.json');
   });
 
+  it('defers lifecycle calls until the owner registers the renderer', async () => {
+    const bridge = makeBridge('full-doc');
+    const renderer = new SprinkleRenderer(container, bridge);
+    const appendChild = container.appendChild.bind(container);
+    vi.spyOn(container, 'appendChild').mockImplementation((node) => {
+      const result = appendChild(node);
+      const iframe = node as HTMLIFrameElement;
+      dom.window.dispatchEvent(
+        new dom.window.MessageEvent('message', {
+          data: { type: 'sprinkle-close' },
+          source: iframe.contentWindow,
+        })
+      );
+      return result;
+    });
+
+    await renderer.render('<!DOCTYPE html><html><head></head><body></body></html>', 'full-doc');
+    expect(bridge.close).not.toHaveBeenCalled();
+
+    renderer.activateBridgeLifecycle();
+    expect(bridge.close).toHaveBeenCalledOnce();
+  });
+
+  it('cleans up the early listener when iframe loading fails', async () => {
+    const bridge = makeBridge('full-doc');
+    const renderer = new SprinkleRenderer(container, bridge);
+    let iframe: HTMLIFrameElement | undefined;
+    vi.spyOn(container, 'appendChild').mockImplementation((node) => {
+      iframe = node as HTMLIFrameElement;
+      iframe.dispatchEvent(new dom.window.Event('error'));
+      return node;
+    });
+
+    await expect(
+      renderer.render('<!DOCTYPE html><html><head></head><body></body></html>', 'full-doc')
+    ).rejects.toThrow('full-doc iframe failed to load');
+
+    dom.window.dispatchEvent(
+      new dom.window.MessageEvent('message', {
+        data: { type: 'sprinkle-readfile', id: 'late-read', path: '/shared/state.json' },
+        source: iframe!.contentWindow,
+      })
+    );
+    expect(bridge.readFile).not.toHaveBeenCalled();
+  });
+
   it('dispose removes full-doc iframe', async () => {
     const bridge = makeBridge('full-doc');
     const renderer = new SprinkleRenderer(container, bridge);

--- a/packages/webapp/tests/ui/sprinkle-renderer.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-renderer.test.ts
@@ -281,6 +281,28 @@ describe('full document rendering', () => {
     expect(srcdoc).toContain('sprinkle-agent');
   });
 
+  it('handles bridge calls posted while the iframe is being appended', async () => {
+    const bridge = makeBridge('full-doc');
+    (bridge.readFile as ReturnType<typeof vi.fn>).mockResolvedValue('hydrated');
+    const renderer = new SprinkleRenderer(container, bridge);
+    const appendChild = container.appendChild.bind(container);
+    vi.spyOn(container, 'appendChild').mockImplementation((node) => {
+      const result = appendChild(node);
+      const iframe = node as HTMLIFrameElement;
+      dom.window.dispatchEvent(
+        new dom.window.MessageEvent('message', {
+          data: { type: 'sprinkle-readfile', id: 'early-read', path: '/shared/state.json' },
+          source: iframe.contentWindow,
+        })
+      );
+      return result;
+    });
+
+    await renderer.render('<!DOCTYPE html><html><head></head><body></body></html>', 'full-doc');
+
+    expect(bridge.readFile).toHaveBeenCalledWith('/shared/state.json');
+  });
+
   it('dispose removes full-doc iframe', async () => {
     const bridge = makeBridge('full-doc');
     const renderer = new SprinkleRenderer(container, bridge);


### PR DESCRIPTION
Closes #1811

## Solution
Install the parent `postMessage` listener before attaching the `srcdoc` iframe, so synchronous hydration calls cannot fall into the pre-load gap.

## Misc
The browser builds pass; the all-workspace build stops at native packages because this VM has no Swift toolchain.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KZ0QFXW14245PAV1664FNRM4&panel=chat)