### PR TITLE
feat(ios-app): monitor and memory surfaces — two fewer placeholders

### DIFF
--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		3A9E122F6A6C4C0F6258C5C6 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A069AA812629AC5FE70AC9 /* SettingsView.swift */; };
 		3EDEBD047CEC3F24BC3ED785 /* SliccFollowerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D4AD0E32B059DB9EABFF3E /* SliccFollowerApp.swift */; };
 		41FD9C8701A419C994CF2704 /* PttUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075FA82F3967B4E37A76C59A /* PttUITests.swift */; };
+		4656B51B0C5284B961957745 /* MemoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8232EF6923F57C710FF97AB /* MemoryView.swift */; };
 		472BB1BEB4E248916156C9EE /* tray-sync-corpus.json in Resources */ = {isa = PBXBuildFile; fileRef = FD6CEFD575FD21C28BEC39F5 /* tray-sync-corpus.json */; };
 		4874F8858460397F336DE469 /* WebRTC in Frameworks */ = {isa = PBXBuildFile; productRef = CEF104FB1C3EDA0B98BC5FFF /* WebRTC */; };
 		487756D13ED6B5D4FB9FF6A0 /* TrayFollowerConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93EE217FAA3F9F7DD3A0B07F /* TrayFollowerConnector.swift */; };
@@ -42,10 +43,12 @@
 		5B5741496E7C7EA37979CFF2 /* AttachmentChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E089FCA5BF8861469F73C4 /* AttachmentChips.swift */; };
 		5DBC389110F337A40762C4E1 /* MessageListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E727142147B0FB449F418D1 /* MessageListView.swift */; };
 		5E23C33D85A8DFC1772AD1FE /* FrozenSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508DFA2D4CC9FD26DCC66AD4 /* FrozenSessions.swift */; };
+		5FC455760C1E661897C898AE /* MemoryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB564AB9C945606419D0AB48 /* MemoryStoreTests.swift */; };
 		67305E9A6D6B198A43EF5148 /* ThemePalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE6D707649AD21C5912013 /* ThemePalette.swift */; };
 		67EC4D5BDDC4014A965FF5B4 /* ConnectionRouteUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */; };
 		686CFEC54F95406972A1A1D6 /* WorkbenchHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED01F56391DE9865C1405BAF /* WorkbenchHost.swift */; };
 		68FA70C9EC1A7C1137CC277D /* PttOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C4F68634F8E70BBC83002C /* PttOverlayView.swift */; };
+		700D14780F6676C4B9895576 /* MonitorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00BEA2C51D7D0E72D0ED176 /* MonitorUITests.swift */; };
 		73CD8FDB68D950291A923BCD /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B186EDFDE184DC8B3215C4 /* ChatView.swift */; };
 		7517352B67786422613418E5 /* DockUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27B23D49C2C36F1A276CF23 /* DockUITests.swift */; };
 		7AFB535E78304FCE5CE7058A /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523A4A068180D7EE98435885 /* MarkdownText.swift */; };
@@ -57,6 +60,7 @@
 		88FE04B67265180C58A84F82 /* ImageAttachmentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B13A2CF7B24036FE27F65975 /* ImageAttachmentBuilder.swift */; };
 		8A4DC8067E31936EA9C475BC /* TrayTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDB6F858D918DBBE06D4702 /* TrayTypes.swift */; };
 		8EEACE6ED76E43E36FC9F0AB /* ChatFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA9A527E2D4BBCE1BDFA89C /* ChatFixture.swift */; };
+		91B4DBF9FB2F5B25B099607C /* MonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F98508E6A01545988D9D42 /* MonitorView.swift */; };
 		9494D2F9E9EFAB61FFC71886 /* AppStateTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A88993C99745347AF830860 /* AppStateTheme.swift */; };
 		977007CC44BE2B53361DF256 /* Keepalive.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA931BF1BE121985E2FB3EE /* Keepalive.swift */; };
 		9AD8326007279D3F37D57C9C /* ICloudSessionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D158A5ACE0AC9C2CE6FEFCD3 /* ICloudSessionList.swift */; };
@@ -69,12 +73,14 @@
 		A14D3D308AFA24D467ECDE96 /* NewSessionDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29562677500C7380445B16B9 /* NewSessionDialog.swift */; };
 		A2488147A916BDDB57B9A41C /* CDPTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6B46ECEC5C79FA6D986F9 /* CDPTarget.swift */; };
 		A50239DCBBAD6235AC7C296A /* MessageBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF78C09597C5D63A373EB126 /* MessageBubble.swift */; };
+		A510DB540628EEEFC588B834 /* MemoryUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AADA76C8F5B9002C98EBFC6 /* MemoryUITests.swift */; };
 		A5A215E64B167C5F918EA6FA /* ICloudSessionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FC22E5B3D4B0DA205C7F62 /* ICloudSessionsUITests.swift */; };
 		A9C0449A188D09A99F506FFE /* InlineSprinkleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2EECDCB4AF899D3071D13C /* InlineSprinkleView.swift */; };
 		B4A19D759C5C4CDDFFA1FC35 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8BFCDA8C3F71C0A853D573 /* ContentView.swift */; };
 		B8033DFD106285BDC91FBEC4 /* FsClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0835A30393CEF046BA90DB16 /* FsClientTests.swift */; };
 		BAEB06EC85F8242C542D4782 /* LickEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62B1B7433B4D853B17578E82 /* LickEnvelopeTests.swift */; };
 		BD662161506DEE603F8854EF /* ConnectionStateUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37492C8E3201CB2A14C6BD12 /* ConnectionStateUITests.swift */; };
+		BE805A88112FF5627440F9A2 /* MemoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A73EE3E38934A8DE13AF2BD /* MemoryStore.swift */; };
 		C1CC6CC22FA5B076B8FF0A7F /* ThemePaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507969DA6DFEA7E053C53F32 /* ThemePaletteTests.swift */; };
 		C43F5710585B9C800CAAA0A2 /* ConnectionStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 940DB17683937E3DAE6E914C /* ConnectionStatusView.swift */; };
 		C5E734A68251BBE47EBE506D /* NewSessionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7EF3911627A88E5691B3949 /* NewSessionUITests.swift */; };
@@ -114,6 +120,7 @@
 
 /* Begin PBXFileReference section */
 		04F4A75BA9D14DA689D0E9F4 /* Dictation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dictation.swift; sourceTree = "<group>"; };
+		05F98508E6A01545988D9D42 /* MonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorView.swift; sourceTree = "<group>"; };
 		066BAF2F283227600FB92506 /* SteerMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteerMessageTests.swift; sourceTree = "<group>"; };
 		075FA82F3967B4E37A76C59A /* PttUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PttUITests.swift; sourceTree = "<group>"; };
 		0835A30393CEF046BA90DB16 /* FsClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FsClientTests.swift; sourceTree = "<group>"; };
@@ -165,6 +172,8 @@
 		93EE217FAA3F9F7DD3A0B07F /* TrayFollowerConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayFollowerConnector.swift; sourceTree = "<group>"; };
 		940DB17683937E3DAE6E914C /* ConnectionStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStatusView.swift; sourceTree = "<group>"; };
 		9572AB87A7ACEC6740682685 /* FrozenSessionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrozenSessionsTests.swift; sourceTree = "<group>"; };
+		9A73EE3E38934A8DE13AF2BD /* MemoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStore.swift; sourceTree = "<group>"; };
+		9AADA76C8F5B9002C98EBFC6 /* MemoryUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryUITests.swift; sourceTree = "<group>"; };
 		9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncProtocolCorpusTests.swift; sourceTree = "<group>"; };
 		A16A253ACC35EEB12798224E /* NewSessionMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionMessageTests.swift; sourceTree = "<group>"; };
 		A5FA307998C15DDB13AC2852 /* FixtureConversationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixtureConversationUITests.swift; sourceTree = "<group>"; };
@@ -185,15 +194,18 @@
 		C81245702943C2EE38D8FD5E /* HandoffLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandoffLink.swift; sourceTree = "<group>"; };
 		C9AF8A8A50FCC9C2DBECA0CF /* WebRTCManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebRTCManager.swift; sourceTree = "<group>"; };
 		C9C3A976D441E4BB628F2183 /* SprinkleWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SprinkleWebView.swift; sourceTree = "<group>"; };
+		CB564AB9C945606419D0AB48 /* MemoryStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryStoreTests.swift; sourceTree = "<group>"; };
 		CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBar.swift; sourceTree = "<group>"; };
 		CFEC70BAB27CC325BCD99C01 /* SliccFollowerTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SliccFollowerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D158A5ACE0AC9C2CE6FEFCD3 /* ICloudSessionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudSessionList.swift; sourceTree = "<group>"; };
+		D8232EF6923F57C710FF97AB /* MemoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryView.swift; sourceTree = "<group>"; };
 		DD1308398CD972FF297E2C75 /* UITestHooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestHooks.swift; sourceTree = "<group>"; };
 		DFC4F75EC6A6C1D71314A24D /* TrayFs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayFs.swift; sourceTree = "<group>"; };
 		E7EF3911627A88E5691B3949 /* NewSessionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionUITests.swift; sourceTree = "<group>"; };
 		E9FC22E5B3D4B0DA205C7F62 /* ICloudSessionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudSessionsUITests.swift; sourceTree = "<group>"; };
 		ECF8476768958BC66533E58F /* FrozenSessionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrozenSessionsUITests.swift; sourceTree = "<group>"; };
 		ED01F56391DE9865C1405BAF /* WorkbenchHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkbenchHost.swift; sourceTree = "<group>"; };
+		F00BEA2C51D7D0E72D0ED176 /* MonitorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorUITests.swift; sourceTree = "<group>"; };
 		F0425579D2C460F993D259DB /* ToolUIPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolUIPlaceholderTests.swift; sourceTree = "<group>"; };
 		F0583BDF50B1A1B9CE68AE67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F0A069AA812629AC5FE70AC9 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -231,6 +243,7 @@
 				8D76B8F603084A6021B6DD6B /* KeepaliveTests.swift */,
 				62B1B7433B4D853B17578E82 /* LickEnvelopeTests.swift */,
 				747034EA0B5B45B56875A5DD /* LinkHeaderCorpusTests.swift */,
+				CB564AB9C945606419D0AB48 /* MemoryStoreTests.swift */,
 				A16A253ACC35EEB12798224E /* NewSessionMessageTests.swift */,
 				8551D5DAD74B9BFB7CC2B76D /* PttControllerTests.swift */,
 				066BAF2F283227600FB92506 /* SteerMessageTests.swift */,
@@ -276,6 +289,7 @@
 				D158A5ACE0AC9C2CE6FEFCD3 /* ICloudSessionList.swift */,
 				B13A2CF7B24036FE27F65975 /* ImageAttachmentBuilder.swift */,
 				5AF41895CF5F76A1CD2B671E /* LickEvent.swift */,
+				9A73EE3E38934A8DE13AF2BD /* MemoryStore.swift */,
 				5F779D2634D4AED6D1AEDA07 /* PttController.swift */,
 				618555E73F15FDB4DB0CAA6F /* SyncProtocol.swift */,
 				1572105F0B5819E4CC07BD84 /* ThemeEngine.swift */,
@@ -319,6 +333,8 @@
 				A5FA307998C15DDB13AC2852 /* FixtureConversationUITests.swift */,
 				ECF8476768958BC66533E58F /* FrozenSessionsUITests.swift */,
 				E9FC22E5B3D4B0DA205C7F62 /* ICloudSessionsUITests.swift */,
+				9AADA76C8F5B9002C98EBFC6 /* MemoryUITests.swift */,
+				F00BEA2C51D7D0E72D0ED176 /* MonitorUITests.swift */,
 				E7EF3911627A88E5691B3949 /* NewSessionUITests.swift */,
 				075FA82F3967B4E37A76C59A /* PttUITests.swift */,
 				26D6B6B896CB48304A39DAB8 /* SteerUITests.swift */,
@@ -342,8 +358,10 @@
 				1F2EECDCB4AF899D3071D13C /* InlineSprinkleView.swift */,
 				CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */,
 				523A4A068180D7EE98435885 /* MarkdownText.swift */,
+				D8232EF6923F57C710FF97AB /* MemoryView.swift */,
 				AF78C09597C5D63A373EB126 /* MessageBubble.swift */,
 				7E727142147B0FB449F418D1 /* MessageListView.swift */,
+				05F98508E6A01545988D9D42 /* MonitorView.swift */,
 				29562677500C7380445B16B9 /* NewSessionDialog.swift */,
 				37C4F68634F8E70BBC83002C /* PttOverlayView.swift */,
 				F0A069AA812629AC5FE70AC9 /* SettingsView.swift */,
@@ -590,8 +608,11 @@
 				F5B6044724F8133C934A5143 /* LickEvent.swift in Sources */,
 				EDCEBDF62330D1775F1B4EE2 /* LinkHeader.swift in Sources */,
 				7AFB535E78304FCE5CE7058A /* MarkdownText.swift in Sources */,
+				BE805A88112FF5627440F9A2 /* MemoryStore.swift in Sources */,
+				4656B51B0C5284B961957745 /* MemoryView.swift in Sources */,
 				A50239DCBBAD6235AC7C296A /* MessageBubble.swift in Sources */,
 				5DBC389110F337A40762C4E1 /* MessageListView.swift in Sources */,
+				91B4DBF9FB2F5B25B099607C /* MonitorView.swift in Sources */,
 				A14D3D308AFA24D467ECDE96 /* NewSessionDialog.swift in Sources */,
 				11F604368853A3A60AC0B10F /* PttController.swift in Sources */,
 				68FA70C9EC1A7C1137CC277D /* PttOverlayView.swift in Sources */,
@@ -627,6 +648,8 @@
 				4A9B912F64233A5C73E57DB4 /* FixtureConversationUITests.swift in Sources */,
 				1939D37EEDBD284DC9F6A9DC /* FrozenSessionsUITests.swift in Sources */,
 				A5A215E64B167C5F918EA6FA /* ICloudSessionsUITests.swift in Sources */,
+				A510DB540628EEEFC588B834 /* MemoryUITests.swift in Sources */,
+				700D14780F6676C4B9895576 /* MonitorUITests.swift in Sources */,
 				C5E734A68251BBE47EBE506D /* NewSessionUITests.swift in Sources */,
 				41FD9C8701A419C994CF2704 /* PttUITests.swift in Sources */,
 				D3441201E520337FA883076A /* SteerUITests.swift in Sources */,
@@ -646,6 +669,7 @@
 				54B15E202D059EA1DBB4ED44 /* KeepaliveTests.swift in Sources */,
 				BAEB06EC85F8242C542D4782 /* LickEnvelopeTests.swift in Sources */,
 				CA14A8C5DE0A027197214AEF /* LinkHeaderCorpusTests.swift in Sources */,
+				5FC455760C1E661897C898AE /* MemoryStoreTests.swift in Sources */,
 				FBC5D9F3A8263FCAE3C6C6C5 /* NewSessionMessageTests.swift in Sources */,
 				9C28D445499995ADA861D75F /* PttControllerTests.swift in Sources */,
 				9ECC362CC8EBA3629542A6E7 /* SteerMessageTests.swift in Sources */,

--- a/packages/ios-app/SliccFollower/App/UITestHooks.swift
+++ b/packages/ios-app/SliccFollower/App/UITestHooks.swift
@@ -143,6 +143,26 @@ import UIKit
                 permission: permission, grantOutcome: grant, script: script)
         }
 
+        /// Canned memory markdown (`-uiTestMemoryFixture YES`) so the
+        /// memory surface renders rows without a leader.
+        static func memoryFixtureMarkdown() -> String? {
+            guard UserDefaults.standard.bool(forKey: "uiTestMemoryFixture") else { return nil }
+            return """
+                ## User Preferences
+
+                - Prefers concise answers with code examples over prose.
+                - Dark mode always; reduce motion enabled on the phone.
+
+                ## Feedback & Corrections
+
+                - Never auto-merge UI PRs; wait for a visual sign-off first.
+
+                ## Project: iOS parity
+
+                - The dock rail mirrors slicc-dock.ts order; tap-active collapses.
+                """
+        }
+
         /// Open a workbench surface on launch
         /// (`-uiTestOpenDockSurface term|files|memory|monitor|browser|new`)
         /// so screenshots and UI tests reach the dock overlay without taps.

--- a/packages/ios-app/SliccFollower/Models/MemoryStore.swift
+++ b/packages/ios-app/SliccFollower/Models/MemoryStore.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// One memory bullet from the cone's `/workspace/CLAUDE.md`, mirroring the
+/// web memory surface's row model (`wc-memory.ts`): section headings carry
+/// into the row, the first clause becomes the title, and the section name
+/// classifies the row (user / feedback / project).
+struct MemoryRow: Identifiable, Equatable {
+    enum Tag: String {
+        case user, feedback, project
+    }
+
+    let id: Int
+    let section: String
+    let title: String
+    let body: String
+    let tag: Tag?
+}
+
+/// Parser for the memory markdown — sections (`##`/`###` headings) holding
+/// `-` bullets with hanging continuations. Pure and synchronous so the
+/// row model is unit-testable without a leader.
+enum MemoryStore {
+    static let memoryPath = "/workspace/CLAUDE.md"
+    /// `TITLE_TARGET` (`wc-memory.ts`) — aim the title split near here.
+    static let titleTarget = 64
+    /// `MEMORY_TITLE_MAX` — lossless hard cap on the title clause.
+    static let titleMax = 96
+
+    private static let feedbackSection = try! NSRegularExpression(
+        pattern: "\\b(feedback|reviews?|corrections?|learnings?|observations?|testing|verification)\\b",
+        options: [.caseInsensitive])
+    private static let userSection = try! NSRegularExpression(
+        pattern:
+            "\\b(user|preferences?|identit(?:y|ies)|accounts?|personal|interface|working rhythm|keyboard|accessibility)\\b",
+        options: [.caseInsensitive])
+
+    static func tag(forSection section: String) -> MemoryRow.Tag? {
+        let range = NSRange(section.startIndex..., in: section)
+        if feedbackSection.firstMatch(in: section, range: range) != nil { return .feedback }
+        if userSection.firstMatch(in: section, range: range) != nil { return .user }
+        if section.isEmpty { return nil }
+        return .project
+    }
+
+    /// Split a bullet into title + rest: prefer a clause boundary (`.`,
+    /// `;`, ` — `) near the target, fall back to a word boundary under the
+    /// hard cap (web parity in spirit — the exact clause heuristics stay
+    /// with the richer web renderer).
+    static func splitTitle(_ text: String) -> (title: String, rest: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > titleMax else { return (trimmed, "") }
+        let candidates: [Character] = [".", ";", ":"]
+        let prefix = String(trimmed.prefix(titleMax))
+        var cut: String.Index?
+        for (offset, char) in prefix.enumerated() where candidates.contains(char) {
+            if offset >= 12 { cut = prefix.index(prefix.startIndex, offsetBy: offset) }
+        }
+        if cut == nil {
+            cut = prefix.lastIndex(of: " ")
+        }
+        guard let cutIndex = cut else { return (prefix, String(trimmed.dropFirst(titleMax))) }
+        let title = String(prefix[..<cutIndex]).trimmingCharacters(in: .whitespaces)
+        let rest = String(trimmed[cutIndex...]).trimmingCharacters(
+            in: CharacterSet(charactersIn: " .;:"))
+        return (title, rest)
+    }
+
+    /// Parse the whole memory file into rows, dropping heading-only noise.
+    static func parse(_ markdown: String) -> [MemoryRow] {
+        var rows: [MemoryRow] = []
+        var section = ""
+        var pending: [String] = []
+
+        func flush() {
+            guard !pending.isEmpty else { return }
+            let body = pending.joined(separator: "\n")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            pending = []
+            guard !body.isEmpty else { return }
+            let (title, _) = splitTitle(body)
+            rows.append(
+                MemoryRow(
+                    id: rows.count, section: section, title: title, body: body,
+                    tag: tag(forSection: section)))
+        }
+
+        for rawLine in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine)
+            let stripped = line.trimmingCharacters(in: .whitespaces)
+            if stripped.hasPrefix("#") {
+                flush()
+                section = stripped.drop(while: { $0 == "#" })
+                    .trimmingCharacters(in: .whitespaces)
+                continue
+            }
+            if stripped.hasPrefix("- ") || stripped.hasPrefix("* ") {
+                flush()
+                pending = [String(stripped.dropFirst(2))]
+                continue
+            }
+            if !pending.isEmpty {
+                if stripped.isEmpty {
+                    flush()
+                } else {
+                    // Hanging continuation of the open bullet.
+                    pending.append(stripped)
+                }
+            }
+        }
+        flush()
+        return rows
+    }
+}

--- a/packages/ios-app/SliccFollower/Models/MemoryStore.swift
+++ b/packages/ios-app/SliccFollower/Models/MemoryStore.swift
@@ -33,12 +33,22 @@ enum MemoryStore {
         pattern:
             "\\b(user|preferences?|identit(?:y|ies)|accounts?|personal|interface|working rhythm|keyboard|accessibility)\\b",
         options: [.caseInsensitive])
+    /// The session freezer files everything under a generic
+    /// `Auto-extracted (…)` heading — classification must then look at the
+    /// bullet's own content, not the heading (web parity: `tagFor` builds
+    /// its evidence the same way).
+    private static let autoExtractedSection = try! NSRegularExpression(
+        pattern: "^Auto-extracted \\(", options: [])
 
-    static func tag(forSection section: String) -> MemoryRow.Tag? {
-        let range = NSRange(section.startIndex..., in: section)
-        if feedbackSection.firstMatch(in: section, range: range) != nil { return .feedback }
-        if userSection.firstMatch(in: section, range: range) != nil { return .user }
-        if section.isEmpty { return nil }
+    static func tag(forSection section: String, content: String = "") -> MemoryRow.Tag? {
+        let sectionRange = NSRange(section.startIndex..., in: section)
+        let autoExtracted =
+            autoExtractedSection.firstMatch(in: section, range: sectionRange) != nil
+        let evidence = autoExtracted ? content : "\(section) \(content)"
+        let range = NSRange(evidence.startIndex..., in: evidence)
+        if feedbackSection.firstMatch(in: evidence, range: range) != nil { return .feedback }
+        if userSection.firstMatch(in: evidence, range: range) != nil { return .user }
+        if autoExtracted || section.isEmpty { return nil }
         return .project
     }
 
@@ -81,7 +91,7 @@ enum MemoryStore {
             rows.append(
                 MemoryRow(
                     id: rows.count, section: section, title: title, body: body,
-                    tag: tag(forSection: section)))
+                    tag: tag(forSection: section, content: body)))
         }
 
         for rawLine in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
@@ -108,6 +118,24 @@ enum MemoryStore {
             }
         }
         flush()
+        if rows.isEmpty {
+            // A memory file with prose but no bullets is still memory: the
+            // web parser folds a bullet-less document into a single row
+            // rather than claiming it is empty.
+            let prose =
+                markdown
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.hasPrefix("#") && !$0.isEmpty }
+                .joined(separator: "\n")
+            if !prose.isEmpty {
+                let (title, _) = splitTitle(prose)
+                rows.append(
+                    MemoryRow(
+                        id: 0, section: section, title: title, body: prose,
+                        tag: tag(forSection: section, content: prose)))
+            }
+        }
         return rows
     }
 }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/DockModelTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/DockModelTests.swift
@@ -28,12 +28,15 @@ final class DockModelTests: XCTestCase {
     }
 
     func testLeaderOnlySurfacesExplainThemselves() {
-        for surface in [DockSurface.files, .term, .memory, .monitor, .newSprinkle] {
+        for surface in [DockSurface.files, .term, .newSprinkle] {
             XCTAssertNotNil(
                 DockModel.placeholderText(for: surface),
                 "\(surface) has no native view — it must say why, not render empty")
         }
+        // Real views carry no placeholder: browser, sprinkles, monitor (#1868).
         XCTAssertNil(DockModel.placeholderText(for: .browser))
         XCTAssertNil(DockModel.placeholderText(for: .sprinkle(name: "x")))
+        XCTAssertNil(DockModel.placeholderText(for: .monitor))
+        XCTAssertNil(DockModel.placeholderText(for: .memory))
     }
 }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/MemoryStoreTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/MemoryStoreTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+@testable import SliccFollower
+
+/// The memory parser (#1867) — sections, tags, and title splitting over
+/// the cone's `/workspace/CLAUDE.md`, mirroring `wc-memory.ts`.
+final class MemoryStoreTests: XCTestCase {
+
+    func testParsesSectionsAndBullets() {
+        let rows = MemoryStore.parse(
+            """
+            # Memory
+
+            ## User Preferences
+
+            - Prefers dark mode.
+            - Uses a left-handed dock.
+
+            ## Project: parity
+
+            - The dock mirrors the web order,
+              with tools pinned at the bottom.
+            """)
+        XCTAssertEqual(rows.count, 3)
+        XCTAssertEqual(rows[0].section, "User Preferences")
+        XCTAssertEqual(rows[0].tag, .user)
+        XCTAssertEqual(rows[2].section, "Project: parity")
+        XCTAssertEqual(rows[2].tag, .project)
+        XCTAssertTrue(
+            rows[2].body.contains("pinned at the bottom"),
+            "hanging continuations belong to the open bullet")
+    }
+
+    func testFeedbackSectionsTagAsFeedback() {
+        let rows = MemoryStore.parse(
+            """
+            ## Corrections & learnings
+
+            - Never auto-merge UI PRs.
+            """)
+        XCTAssertEqual(rows.first?.tag, .feedback)
+    }
+
+    func testUnsectionedBulletsCarryNoTag() {
+        let rows = MemoryStore.parse("- floating fact with no heading")
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertNil(rows[0].tag)
+        XCTAssertEqual(rows[0].section, "")
+    }
+
+    func testLongBulletsSplitNearTheCap() {
+        let long = String(repeating: "word ", count: 40)
+        let (title, rest) = MemoryStore.splitTitle(long)
+        XCTAssertLessThanOrEqual(title.count, MemoryStore.titleMax)
+        XCTAssertFalse(title.isEmpty)
+        XCTAssertFalse(rest.isEmpty, "the split is lossless — the tail survives")
+    }
+
+    func testShortBulletsKeepTheirWholeTextAsTitle() {
+        let (title, rest) = MemoryStore.splitTitle("Short and sweet.")
+        XCTAssertEqual(title, "Short and sweet.")
+        XCTAssertEqual(rest, "")
+    }
+
+    func testHeadingOnlyDocumentYieldsNoRows() {
+        XCTAssertTrue(MemoryStore.parse("## Empty\n\n### Also empty").isEmpty)
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/MemoryStoreTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/MemoryStoreTests.swift
@@ -65,4 +65,32 @@ final class MemoryStoreTests: XCTestCase {
     func testHeadingOnlyDocumentYieldsNoRows() {
         XCTAssertTrue(MemoryStore.parse("## Empty\n\n### Also empty").isEmpty)
     }
+
+    func testAutoExtractedSectionsClassifyByContent() {
+        let rows = MemoryStore.parse(
+            """
+            ## Auto-extracted (2026-08-02)
+
+            - User prefers concise answers with keyboard-first workflows.
+            - Correction: never auto-merge UI PRs without review.
+            - The tray hub worker deploys manually.
+            """)
+        XCTAssertEqual(rows.count, 3)
+        XCTAssertEqual(rows[0].tag, .user, "content evidence, not the generic heading")
+        XCTAssertEqual(rows[1].tag, .feedback)
+        XCTAssertNil(rows[2].tag, "auto-extracted without signals stays untagged")
+    }
+
+    func testProseOnlyDocumentBecomesOneRow() {
+        let rows = MemoryStore.parse(
+            """
+            # Memory
+
+            The user works from Berlin and prefers espresso-length reviews.
+            Deploys happen manually on Fridays.
+            """)
+        XCTAssertEqual(rows.count, 1, "a bullet-less memory file is not empty")
+        XCTAssertTrue(rows[0].body.contains("espresso-length"))
+        XCTAssertTrue(rows[0].body.contains("Fridays"))
+    }
 }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/MemoryUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/MemoryUITests.swift
@@ -1,0 +1,28 @@
+import XCTest
+
+/// The dock's memory surface (#1867) against the canned fixture.
+final class MemoryUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testMemoryRendersTaggedRows() {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-joinUrl", "", "-uiTestConnectionState", "connected",
+            "-uiTestOpenDockSurface", "memory",
+            "-uiTestMemoryFixture", "YES",
+        ]
+        app.launch()
+
+        XCTAssertTrue(
+            app.staticTexts["Prefers concise answers with code examples over prose."]
+                .waitForExistence(timeout: 60),
+            "memory bullets render as rows")
+        XCTAssertTrue(
+            app.staticTexts["feedback"].exists,
+            "section names classify rows (feedback tag from Corrections)")
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/MonitorUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/MonitorUITests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+/// The dock's monitor surface (#1868): session vitals from tray state.
+final class MonitorUITests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testMonitorShowsConnectionAndCost() {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-joinUrl", "", "-uiTestConnectionState", "connected",
+            "-uiTestOpenDockSurface", "monitor",
+        ]
+        app.launch()
+
+        XCTAssertTrue(
+            app.staticTexts["Participants"].waitForExistence(timeout: 60),
+            "the monitor renders connection vitals, not a placeholder")
+        XCTAssertTrue(
+            app.staticTexts["monitor-cost-total"].exists,
+            "session cost is summed from message usage")
+    }
+}

--- a/packages/ios-app/SliccFollower/Views/DockModel.swift
+++ b/packages/ios-app/SliccFollower/Views/DockModel.swift
@@ -60,7 +60,7 @@ enum DockModel {
     /// that have a real view.
     static func placeholderText(for surface: DockSurface) -> String? {
         switch surface {
-        case .sprinkle, .browser:
+        case .sprinkle, .browser, .monitor, .memory:
             return nil
         case .newSprinkle:
             return "Sprinkles are authored on the leader. Ask the cone to scoop one up — it appears here when the leader registers it."
@@ -68,10 +68,6 @@ enum DockModel {
             return "Files live on the leader. A follower mirrors the leader's chat, sprinkles, and browser tabs - not its filesystem."
         case .term:
             return "The shell runs on the leader. A follower has no local terminal - drive the session through chat."
-        case .memory:
-            return "Memory lives on the leader. A follower has no local memory store."
-        case .monitor:
-            return "Monitor reads the leader's kernel state. A follower has no local kernel."
         }
     }
 }

--- a/packages/ios-app/SliccFollower/Views/InputBar.swift
+++ b/packages/ios-app/SliccFollower/Views/InputBar.swift
@@ -35,11 +35,14 @@ struct InputBar: View {
     @State private var photoItems: [PhotosPickerItem] = []
     @State private var showPhotoPicker = false
     @State private var showCamera = false
-    /// `UIPasteboard.general.hasImages` is not SwiftUI-observable — read
-    /// once, then track pasteboard changes and foreground returns (an image
-    /// copied in another app must surface Paste on the next menu open).
-    /// `hasImages` is a metadata check, so it never trips the paste banner.
-    @State private var pasteboardHasImage = UIPasteboard.general.hasImages
+    /// `UIPasteboard.general.hasImages` is not SwiftUI-observable — track
+    /// pasteboard changes and foreground returns (an image copied in
+    /// another app must surface Paste on the next menu open). Read lazily
+    /// in onAppear, NOT at struct init: the initial read is a synchronous
+    /// XPC to the pasteboard daemon, and on a contended simulator it can
+    /// stall the main thread through app launch. `hasImages` is a metadata
+    /// check, so none of this trips the paste banner.
+    @State private var pasteboardHasImage = false
 
     private var canSend: Bool {
         // Sending during a running turn queues on the leader (browser
@@ -107,6 +110,11 @@ struct InputBar: View {
                     stage(UITestHooks.attachmentFixtureImage(), name: "fixture.jpg")
                 }
             #endif
+            // Deferred first pasteboard read (see pasteboardHasImage) — off
+            // the launch-critical path, still ahead of any menu open.
+            DispatchQueue.main.async {
+                pasteboardHasImage = UIPasteboard.general.hasImages
+            }
         }
         // Handled from `.onChange` — NOT a callback stored at `onAppear` —
         // so the handler sees current props: an appear-time closure captures

--- a/packages/ios-app/SliccFollower/Views/MemoryView.swift
+++ b/packages/ios-app/SliccFollower/Views/MemoryView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+/// The dock's `memory` surface (#1867): the cone's `/workspace/CLAUDE.md`
+/// read over the tray (`fs.request` → leader VFS, the same two-method
+/// proxy the sprinkle path uses) and rendered as tagged rows — the same
+/// model as the web memory surface (`wc-memory.ts`), read-only like every
+/// follower surface.
+struct MemoryView: View {
+    @EnvironmentObject var appState: AppState
+    @Environment(\.palette) private var palette
+
+    private enum LoadState: Equatable {
+        case loading
+        case loaded([MemoryRow])
+        case failed(String)
+    }
+
+    @State private var state: LoadState = .loading
+
+    var body: some View {
+        Group {
+            switch state {
+            case .loading:
+                ProgressView("Reading the leader's memory…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .failed(let reason):
+                VStack(spacing: 12) {
+                    Image(systemName: "brain")
+                        .font(.system(size: 32))
+                        .foregroundStyle(palette.inkTertiary)
+                    Text(reason)
+                        .font(.system(size: 14))
+                        .foregroundStyle(palette.inkSecondary)
+                        .multilineTextAlignment(.center)
+                        .accessibilityIdentifier("memory-error")
+                }
+                .padding(.horizontal, 40)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .loaded(let rows):
+                if rows.isEmpty {
+                    Text("The leader's memory is empty.")
+                        .foregroundStyle(palette.inkSecondary)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .accessibilityIdentifier("memory-empty")
+                } else {
+                    rowList(rows)
+                }
+            }
+        }
+        .background(palette.canvas)
+        .task { await load() }
+    }
+
+    private func rowList(_ rows: [MemoryRow]) -> some View {
+        List {
+            ForEach(groupedSections(rows), id: \.section) { group in
+                Section(group.section.isEmpty ? "Memory" : group.section) {
+                    ForEach(group.rows) { row in
+                        DisclosureGroup {
+                            MarkdownText(content: row.body)
+                                .padding(.vertical, 4)
+                        } label: {
+                            HStack(spacing: 8) {
+                                if let tag = row.tag {
+                                    Text(tag.rawValue)
+                                        .font(.caption2.weight(.semibold))
+                                        .padding(.horizontal, 6)
+                                        .padding(.vertical, 2)
+                                        .background(tagColor(tag).opacity(0.18))
+                                        .foregroundStyle(tagColor(tag))
+                                        .clipShape(Capsule())
+                                }
+                                Text(row.title)
+                                    .font(.system(size: 14))
+                                    .lineLimit(2)
+                            }
+                        }
+                        .accessibilityIdentifier("memory-row-\(row.id)")
+                    }
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+    }
+
+    private func groupedSections(_ rows: [MemoryRow]) -> [(section: String, rows: [MemoryRow])] {
+        var order: [String] = []
+        var bySection: [String: [MemoryRow]] = [:]
+        for row in rows {
+            if bySection[row.section] == nil { order.append(row.section) }
+            bySection[row.section, default: []].append(row)
+        }
+        return order.map { ($0, bySection[$0] ?? []) }
+    }
+
+    private func tagColor(_ tag: MemoryRow.Tag) -> Color {
+        switch tag {
+        case .user: return .blue
+        case .feedback: return .orange
+        case .project: return palette.accent
+        }
+    }
+
+    private func load() async {
+        #if DEBUG
+            if let fixture = UITestHooks.memoryFixtureMarkdown() {
+                state = .loaded(MemoryStore.parse(fixture))
+                return
+            }
+        #endif
+        guard appState.connectionState == .connected else {
+            state = .failed("Memory lives on the leader — connect to a session to read it.")
+            return
+        }
+        do {
+            let markdown = try await appState.fsClient.readFile(MemoryStore.memoryPath)
+            state = .loaded(MemoryStore.parse(markdown))
+        } catch {
+            state = .failed(
+                "Could not read \(MemoryStore.memoryPath) from the leader: \(error.localizedDescription)")
+        }
+    }
+}

--- a/packages/ios-app/SliccFollower/Views/MonitorView.swift
+++ b/packages/ios-app/SliccFollower/Views/MonitorView.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+/// The dock's `monitor` surface (#1868): the session vitals a follower can
+/// honestly report. The web monitor is kernel-backed (processes, cron,
+/// webhooks, mounts) — none of that exists on a phone, so this renders
+/// what the tray already carries instead of a placeholder: connection
+/// health, scoops, session cost summed from message usage, and the
+/// follower-hosted surface counts. Anything deeper needs a leader-side
+/// summary feed (tracked on the issue).
+struct MonitorView: View {
+    @EnvironmentObject var appState: AppState
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        List {
+            connectionSection
+            scoopsSection
+            costSection
+            surfacesSection
+        }
+        .scrollContentBackground(.hidden)
+        .background(palette.canvas)
+    }
+
+    // MARK: Connection
+
+    private var connectionSection: some View {
+        Section("Connection") {
+            row("State", appState.connectionState.rawValue)
+            if appState.isLeaderStalled {
+                row("Leader", "stalled — not answering pings")
+            }
+            if let since = appState.connectedSince {
+                row("Connected", since.formatted(date: .omitted, time: .standard))
+            }
+            row("Participants", "\(appState.participantCount)")
+            if appState.reconnectAttempt > 0 {
+                row("Reconnect attempt", "\(appState.reconnectAttempt)")
+            }
+            if let error = appState.leaderError {
+                row("Leader error", error)
+            }
+        }
+    }
+
+    // MARK: Scoops
+
+    private var scoopsSection: some View {
+        Section("Scoops") {
+            if appState.scoops.isEmpty {
+                Text("No scoops reported yet")
+                    .foregroundStyle(palette.inkSecondary)
+            }
+            ForEach(appState.scoops) { scoop in
+                HStack {
+                    Image(systemName: scoop.isCone ? "crown" : "cup.and.saucer")
+                        .foregroundStyle(palette.inkSecondary)
+                    VStack(alignment: .leading) {
+                        Text(scoop.name)
+                        if let state = scoop.state {
+                            Text(state)
+                                .font(.caption)
+                                .foregroundStyle(palette.inkSecondary)
+                        }
+                    }
+                    Spacer()
+                    if scoop.jid == appState.leaderActiveScoopJid {
+                        Text("active")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(palette.accent)
+                    }
+                }
+                .accessibilityIdentifier("monitor-scoop-\(scoop.jid)")
+            }
+        }
+    }
+
+    // MARK: Cost
+
+    /// Sum of the usage the leader attached to assistant turns in the
+    /// transcript this follower holds. A snapshot-truncated transcript
+    /// undercounts, so it is labeled as visible-session cost, not billing.
+    private var visibleCost: (total: Double, turns: Int) {
+        var total = 0.0
+        var turns = 0
+        for message in appState.messages {
+            guard let usage = message.usage else { continue }
+            total += usage.cost.total
+            turns += 1
+        }
+        return (total, turns)
+    }
+
+    private var costSection: some View {
+        let cost = visibleCost
+        return Section("Session cost (visible transcript)") {
+            row("Metered turns", "\(cost.turns)")
+            row("Total", String(format: "$%.4f", cost.total))
+                .accessibilityIdentifier("monitor-cost-total")
+        }
+    }
+
+    // MARK: Surfaces
+
+    private var surfacesSection: some View {
+        Section("Surfaces") {
+            row("Sprinkles", "\(appState.sprinkles.count)")
+            row("Browser tabs", "\(appState.cdpTargets.count)")
+            row("Messages held", "\(appState.messages.count)")
+        }
+    }
+
+    private func row(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label)
+            Spacer()
+            Text(value)
+                .foregroundStyle(palette.inkSecondary)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+}

--- a/packages/ios-app/SliccFollower/Views/WorkbenchHost.swift
+++ b/packages/ios-app/SliccFollower/Views/WorkbenchHost.swift
@@ -24,7 +24,11 @@ struct WorkbenchHost: View {
                     // The leader unregistered it while open.
                     placeholder("This sprinkle is no longer registered on the leader.")
                 }
-            case .newSprinkle, .files, .term, .memory, .monitor:
+            case .monitor:
+                MonitorView()
+            case .memory:
+                MemoryView()
+            case .newSprinkle, .files, .term:
                 placeholder(DockModel.placeholderText(for: surface) ?? "")
             }
         }

--- a/packages/ios-app/screenshot-screens.json
+++ b/packages/ios-app/screenshot-screens.json
@@ -177,6 +177,28 @@
       ]
     },
     {
+      "name": "dock-memory",
+      "description": "Memory surface: the cone's workspace CLAUDE.md as tagged rows",
+      "args": [
+        "-uiTestConnectionState",
+        "connected",
+        "-uiTestOpenDockSurface",
+        "memory",
+        "-uiTestMemoryFixture",
+        "YES"
+      ]
+    },
+    {
+      "name": "dock-monitor",
+      "description": "Monitor surface: connection vitals, scoops, visible-session cost",
+      "args": [
+        "-uiTestConnectionState",
+        "connected",
+        "-uiTestOpenDockSurface",
+        "monitor"
+      ]
+    },
+    {
       "name": "frozen-empty",
       "description": "Past Sessions sheet with no archived sessions",
       "args": [


### PR DESCRIPTION
Closes #1868, closes #1867 — the dock's monitor and memory items open real surfaces instead of explaining their absence.

**Stacked on #1870**; collapses to the tip commit once it merges.

| monitor | memory |
| --- | --- |
| <img src="https://raw.githubusercontent.com/ai-ecoverse/slicc/screenshots/pr-1861/docs/screenshots/1868-monitor.png" width="280"> | <img src="https://raw.githubusercontent.com/ai-ecoverse/slicc/screenshots/pr-1861/docs/screenshots/1867-memory.png" width="280"> |

## Monitor (#1868)

The session vitals a follower can honestly report from tray state it already holds: connection health (state/stall/participants/reconnect/leader errors), the scoop roster with the active one marked, **session cost summed from the usage the leader attaches to assistant turns** (labeled visible-transcript cost — a snapshot-truncated transcript undercounts), and surface counts. The web monitor's kernel-backed rows (processes, cron, webhooks, mounts) need a leader-side summary feed — deliberately out of scope here.

## Memory (#1867)

Reads the cone's `/workspace/CLAUDE.md` over the tray (the same `fs.request` → leader-VFS path sprinkles use) and renders the web memory surface's row model (`wc-memory.ts`): section headings carry into rows, first clause becomes the title, section names classify rows **user / feedback / project**. Read-only; disconnected and unreadable states say why. The parser is pure Swift with 6 unit tests.

## Also

The Paste Image gate's initial `UIPasteboard` read moves out of struct init into a deferred onAppear read — the synchronous pasteboard XPC could stall the main thread through app launch on a contended simulator (this is what made the settings-sheet launch test fail twice under parallel clones).

Full suite: **196 tests green**, coverage 63.21 % (floor 59 %). New screens `dock-monitor` / `dock-memory` in the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2m3i5QmGvGFehU4Uoi1k3