### PR TITLE
fix(webcomponents): make agent tab frame hug its tabs

### DIFF
--- a/packages/webcomponents/src/switcher/slicc-agent-tabs.stories.ts
+++ b/packages/webcomponents/src/switcher/slicc-agent-tabs.stories.ts
@@ -130,6 +130,10 @@ const meta: Meta<AgentTabsArgs> = {
 export default meta;
 type Story = StoryObj<AgentTabsArgs>;
 
+export const SingleCone: Story = {
+  args: { scoops: [BASE_ROSTER[0]], active: 'cone', width: 720 },
+};
+
 export const Default: Story = { args: { scoops: BASE_ROSTER, active: 'cone', width: 720 } };
 
 export const ConeMostRecent: Story = {

--- a/packages/webcomponents/src/switcher/slicc-agent-tabs.ts
+++ b/packages/webcomponents/src/switcher/slicc-agent-tabs.ts
@@ -55,7 +55,7 @@ const STYLE = `
 .slicc-agent-tabs{display:flex;align-items:center;gap:${HOST_GAP}px;min-width:0;overflow:visible;color:var(--ink);font-family:var(--ui);}
 .slicc-agent-tabs *{box-sizing:border-box;}
 .slicc-agent-tabs__focus-avatar{display:block;flex:0 0 ${AVATAR_WIDTH}px;width:${AVATAR_WIDTH}px;height:${AVATAR_WIDTH}px;pointer-events:none;}
-.slicc-agent-tabs__track-frame{position:relative;flex:1 1 auto;min-width:0;height:var(--ctl-h,30px);overflow:visible;border:1px solid var(--line);border-radius:9px;background:var(--ghost);}
+.slicc-agent-tabs__track-frame{position:relative;flex:0 1 auto;min-width:0;height:var(--ctl-h,30px);overflow:visible;border:1px solid var(--line);border-radius:9px;background:var(--ghost);}
 .slicc-agent-tabs__track{display:flex;align-items:center;min-width:0;height:100%;padding:2px 41px 2px 2px;overflow:hidden;}
 .slicc-agent-tabs__segment{position:relative;display:inline-flex;flex:0 1 auto;align-items:center;justify-content:center;gap:${SEGMENT_GAP}px;width:max-content;min-width:var(--slicc-agent-tabs-segment-floor,${SEGMENT_FLOOR_FALLBACK}px);max-width:160px;height:24px;padding:0 8px;overflow:hidden;color:var(--txt-2);font:500 11px/1 var(--ui);white-space:nowrap;border:0;border-radius:6px;background:transparent;cursor:pointer;}
 .slicc-agent-tabs__segment:hover{color:var(--ink);}

--- a/packages/webcomponents/tests/switcher/slicc-agent-tabs.test.ts
+++ b/packages/webcomponents/tests/switcher/slicc-agent-tabs.test.ts
@@ -711,6 +711,25 @@ describe('slicc-agent-tabs', () => {
   });
 
   describe('overflow reflow', () => {
+    it('sizes a one-tab frame to its tab and permanently reserved overflow footprint', () => {
+      const element = mount(rosterOf(1), 720);
+      element.reflow();
+      const frame = element.querySelector('.slicc-agent-tabs__track-frame') as HTMLElement;
+      const track = element.querySelector('.slicc-agent-tabs__track') as HTMLElement;
+      const tabWidth = segment(element, 'cone').getBoundingClientRect().width;
+      const trackStyle = getComputedStyle(track);
+      const frameStyle = getComputedStyle(frame);
+      const expectedWidth =
+        tabWidth +
+        Number.parseFloat(trackStyle.paddingLeft) +
+        Number.parseFloat(trackStyle.paddingRight) +
+        Number.parseFloat(frameStyle.borderLeftWidth) +
+        Number.parseFloat(frameStyle.borderRightWidth);
+
+      expect(frame.getBoundingClientRect().width).toBeCloseTo(expectedWidth, 1);
+      expect(frame.getBoundingClientRect().width).toBeLessThan(element.clientWidth / 2);
+    });
+
     it.each([1, 2, 6, 12])(
       'reaches the same overflow fixed point across forced reflows for %i scoops',
       (count) => {
@@ -793,11 +812,20 @@ describe('slicc-agent-tabs', () => {
         const sliccy = segment(element, 'cone');
         const label = sliccy.querySelector('.slicc-agent-tabs__label') as HTMLElement;
         const frame = element.querySelector('.slicc-agent-tabs__track-frame') as HTMLElement;
+        const focusedAvatar = avatar(element) as HTMLElement;
         const trigger = overflow(element).shadowRoot?.querySelector('[part="more"]') as HTMLElement;
         const sliccyRect = sliccy.getBoundingClientRect();
         const frameRect = frame.getBoundingClientRect();
         const triggerRect = trigger.getBoundingClientRect();
         expect(element.clientWidth).toBe(360);
+        expect(frameRect.width).toBeCloseTo(
+          element.clientWidth -
+            focusedAvatar.getBoundingClientRect().width -
+            Number.parseFloat(getComputedStyle(element).columnGap),
+          1
+        );
+        expect(triggerRect.width).toBeCloseTo(39, 1);
+        expect(triggerRect.height).toBeCloseTo(24, 1);
         expect(label.scrollWidth).toBeLessThanOrEqual(label.clientWidth);
         expect(sliccyRect.right).toBeLessThanOrEqual(triggerRect.left);
         expect(triggerRect.right).toBeLessThanOrEqual(frameRect.right);
@@ -882,6 +910,12 @@ describe('slicc-agent-tabs', () => {
   describe('ResizeObserver lifecycle', () => {
     const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
+    async function waitForObserverReflow(): Promise<void> {
+      await nextFrame();
+      await nextFrame();
+      await nextFrame();
+    }
+
     function stubResizeObserver(): {
       callback: { current: ResizeObserverCallback | null };
       restore: () => void;
@@ -914,6 +948,28 @@ describe('slicc-agent-tabs', () => {
       } finally {
         restore();
       }
+    });
+
+    it('settles after crossing the fit/overflow boundary instead of oscillating', async () => {
+      const element = mount(rosterOf(6), 220);
+      await waitForObserverReflow();
+      const reflow = vi.spyOn(element, 'reflow');
+      const states: boolean[] = [];
+
+      for (const width of [220, 320, 420, 520, 420, 320, 220]) {
+        const before = reflow.mock.calls.length;
+        element.style.width = `${width}px`;
+        element.getBoundingClientRect();
+        await waitForObserverReflow();
+        const settled = reflow.mock.calls.length;
+        states.push(element.classList.contains('has-overflow'));
+        expect(settled - before).toBeLessThanOrEqual(2);
+        await waitForObserverReflow();
+        expect(reflow).toHaveBeenCalledTimes(settled);
+      }
+
+      expect(states).toContain(true);
+      expect(states).toContain(false);
     });
 
     it('cancels a pending observer reflow on disconnect', async () => {


### PR DESCRIPTION
## Summary

- stop the agent-tab track frame from flex-growing across empty toolbar space
- retain flex shrink and the permanent 41px overflow-trigger reservation
- add one-tab and many-tab geometry coverage plus a single-cone Storybook state

## Oscillation-stability evidence

The regression test spies on the public `reflow()` method and drives the connected host through `220 → 320 → 420 → 520 → 420 → 320 → 220px`, crossing between overflow and fit in both directions. At each width it waits three animation frames for ResizeObserver delivery and the scheduled reflow, requires no more than two reflow calls, then waits three additional frames and requires the call count to remain unchanged. It also verifies that the sweep observed both overflow and non-overflow states.

That is bounded-settling evidence from local macOS Chromium for this exercised width sweep. It is not Linux-CI proof, and CI has not run on this PR yet.

The frame-width assertion was falsified separately: temporarily restoring `flex: 1 1 auto` produced a 686px frame against 115px of tab plus reserved chrome, so the new assertion failed; restoring `flex: 0 1 auto` made it pass. This falsifies the width fix, not the oscillation test.

## Live harness

Using the isolated `:5715` / `:8787` harness (without touching production `:5710` or `:9222`):

- one tab: 110px frame inside a 525.75px host
- four tabs: 321.21px frame, no overflow
- 30 tabs: 873.5px frame, 12 visible / 18 hidden, 39×24 overflow trigger

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run test -w @slicc/webcomponents` — 1,781 passed
- `npm run test` — 13,335 passed, 46 skipped
- `npm run test:coverage:webcomponents` — 93.36% statements, 82.28% branches, 95.65% functions, 96.22% lines
- `node packages/dev-tools/tools/check-touched-exemptions.mjs` — 3 changed files, 0 debt-listed
- `npm run build`
- `npm run build -w @slicc/chrome-extension`
- `npm run build-storybook -w @slicc/webcomponents`
- `npm run bundle-size`
- `npm run verify`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author