### PR TITLE
Conditionally reserve agent tab overflow space

### DIFF
--- a/packages/webcomponents/src/switcher/slicc-agent-tabs.ts
+++ b/packages/webcomponents/src/switcher/slicc-agent-tabs.ts
@@ -56,7 +56,8 @@ const STYLE = `
 .slicc-agent-tabs *{box-sizing:border-box;}
 .slicc-agent-tabs__focus-avatar{display:block;flex:0 0 ${AVATAR_WIDTH}px;width:${AVATAR_WIDTH}px;height:${AVATAR_WIDTH}px;pointer-events:none;}
 .slicc-agent-tabs__track-frame{position:relative;flex:0 1 auto;min-width:0;height:var(--ctl-h,30px);overflow:visible;border:1px solid var(--line);border-radius:9px;background:var(--ghost);}
-.slicc-agent-tabs__track{display:flex;align-items:center;min-width:0;height:100%;padding:2px 41px 2px 2px;overflow:hidden;}
+.slicc-agent-tabs__track{display:flex;align-items:center;min-width:0;height:100%;padding:2px;overflow:hidden;}
+.slicc-agent-tabs.has-overflow .slicc-agent-tabs__track{padding-right:${MORE_RESERVE + 2}px;}
 .slicc-agent-tabs__segment{position:relative;display:inline-flex;flex:0 1 auto;align-items:center;justify-content:center;gap:${SEGMENT_GAP}px;width:max-content;min-width:var(--slicc-agent-tabs-segment-floor,${SEGMENT_FLOOR_FALLBACK}px);max-width:160px;height:24px;padding:0 8px;overflow:hidden;color:var(--txt-2);font:500 11px/1 var(--ui);white-space:nowrap;border:0;border-radius:6px;background:transparent;cursor:pointer;}
 .slicc-agent-tabs__segment:hover{color:var(--ink);}
 .slicc-agent-tabs__segment[aria-selected='true']{color:var(--ink);background:var(--canvas);box-shadow:0 1px 3px color-mix(in srgb,var(--ink) 12%,transparent);}
@@ -332,11 +333,15 @@ export class SliccAgentTabs extends HTMLElement {
       });
       return;
     }
-    const widths = segments.map((segment) => segment.offsetWidth);
     const segmentSpace = Math.max(0, available - AVATAR_WIDTH - HOST_GAP - TRACK_CHROME);
-    const total = widths.reduce((sum, width) => sum + width, 0);
-    const budget = Math.max(0, segmentSpace - MORE_RESERVE);
-    if (total <= budget + 1) {
+    this.classList.remove('has-overflow');
+    const widthsWithoutReserve = segments.map((segment) => segment.offsetWidth);
+    const totalWithoutReserve = widthsWithoutReserve.reduce((sum, width) => sum + width, 0);
+    const reserve = totalWithoutReserve > segmentSpace + 1;
+    this.classList.toggle('has-overflow', reserve);
+    const widths = reserve ? segments.map((segment) => segment.offsetWidth) : widthsWithoutReserve;
+    const budget = Math.max(0, segmentSpace - (reserve ? MORE_RESERVE : 0));
+    if (!reserve) {
       this.#feedOverflow([]);
       return;
     }

--- a/packages/webcomponents/src/switcher/slicc-agent-tabs.ts
+++ b/packages/webcomponents/src/switcher/slicc-agent-tabs.ts
@@ -317,6 +317,7 @@ export class SliccAgentTabs extends HTMLElement {
   #reflowOnce(): void {
     const segments = [...this.querySelectorAll<HTMLButtonElement>(`.${PREFIX}__segment`)];
     for (const segment of segments) segment.classList.remove('hide');
+    this.classList.remove('has-overflow');
     if (segments.length === 0) {
       this.#feedOverflow([]);
       return;
@@ -334,10 +335,9 @@ export class SliccAgentTabs extends HTMLElement {
       return;
     }
     const segmentSpace = Math.max(0, available - AVATAR_WIDTH - HOST_GAP - TRACK_CHROME);
-    this.classList.remove('has-overflow');
     const widthsWithoutReserve = segments.map((segment) => segment.offsetWidth);
     const totalWithoutReserve = widthsWithoutReserve.reduce((sum, width) => sum + width, 0);
-    const reserve = totalWithoutReserve > segmentSpace + 1;
+    const reserve = segments.length > 1 && totalWithoutReserve > segmentSpace + 1;
     this.classList.toggle('has-overflow', reserve);
     const widths = reserve ? segments.map((segment) => segment.offsetWidth) : widthsWithoutReserve;
     const budget = Math.max(0, segmentSpace - (reserve ? MORE_RESERVE : 0));
@@ -526,7 +526,6 @@ export class SliccAgentTabs extends HTMLElement {
       }
     );
     this.#overflow.items = items;
-    this.classList.toggle('has-overflow', items.length > 0);
   }
 
   #handleClick(event: Event): void {

--- a/packages/webcomponents/tests/switcher/slicc-agent-tabs.test.ts
+++ b/packages/webcomponents/tests/switcher/slicc-agent-tabs.test.ts
@@ -711,7 +711,7 @@ describe('slicc-agent-tabs', () => {
   });
 
   describe('overflow reflow', () => {
-    it('sizes a one-tab frame to its tab and permanently reserved overflow footprint', () => {
+    it('sizes a one-tab frame to its tab without reserving an overflow footprint', () => {
       const element = mount(rosterOf(1), 720);
       element.reflow();
       const frame = element.querySelector('.slicc-agent-tabs__track-frame') as HTMLElement;
@@ -727,6 +727,7 @@ describe('slicc-agent-tabs', () => {
         Number.parseFloat(frameStyle.borderRightWidth);
 
       expect(frame.getBoundingClientRect().width).toBeCloseTo(expectedWidth, 1);
+      expect(trackStyle.paddingRight).toBe('2px');
       expect(frame.getBoundingClientRect().width).toBeLessThan(element.clientWidth / 2);
     });
 
@@ -747,17 +748,53 @@ describe('slicc-agent-tabs', () => {
       }
     );
 
-    it('reserves the overflow footprint without changing track padding after reflow', () => {
+    it('keeps the DOM and arithmetic overflow reserves in the same state', () => {
       const element = mount(rosterOf(1), 220);
       const track = element.querySelector('.slicc-agent-tabs__track') as HTMLElement;
       element.reflow();
-      const withoutOverflow = getComputedStyle(track).paddingRight;
-      expect(withoutOverflow).toBe('41px');
+      expect(element.classList.contains('has-overflow')).toBe(false);
+      expect(getComputedStyle(track).paddingRight).toBe('2px');
 
       element.scoops = rosterOf(12);
       element.reflow();
       expect(element.classList.contains('has-overflow')).toBe(true);
-      expect(getComputedStyle(track).paddingRight).toBe(withoutOverflow);
+      expect(getComputedStyle(track).paddingRight).toBe('41px');
+    });
+
+    it('settles at every pixel across the fit boundary and keeps tabs clear of the trigger', () => {
+      const element = mount(rosterOf(6), 200);
+      const track = element.querySelector('.slicc-agent-tabs__track') as HTMLElement;
+      const trigger = overflow(element).shadowRoot?.querySelector('[part="more"]') as HTMLElement;
+      const visited = new Set<boolean>();
+
+      for (let width = 200; width <= 560; width += 1) {
+        element.style.width = `${width}px`;
+        const states = Array.from({ length: 4 }, () => {
+          element.reflow();
+          return {
+            overflow: element.classList.contains('has-overflow'),
+            hidden: segments(element)
+              .filter((item) => item.classList.contains('hide'))
+              .map((item) => item.dataset.k),
+            paddingRight: getComputedStyle(track).paddingRight,
+          };
+        });
+        expect(states.slice(1), `reflow alternated at ${width}px`).toEqual([
+          states[0],
+          states[0],
+          states[0],
+        ]);
+        visited.add(states[0].overflow);
+        expect(states[0].paddingRight).toBe(states[0].overflow ? '41px' : '2px');
+        if (states[0].overflow) {
+          const visible = segments(element).filter((item) => !item.classList.contains('hide'));
+          expect(visible.at(-1)?.getBoundingClientRect().right).toBeLessThanOrEqual(
+            trigger.getBoundingClientRect().left
+          );
+        }
+      }
+
+      expect(visited).toEqual(new Set([true, false]));
     });
 
     it('uses the rendered sliccy width as its floor and ellipsizes long labels at the ceiling', () => {

--- a/packages/webcomponents/tests/switcher/slicc-agent-tabs.test.ts
+++ b/packages/webcomponents/tests/switcher/slicc-agent-tabs.test.ts
@@ -761,6 +761,20 @@ describe('slicc-agent-tabs', () => {
       expect(getComputedStyle(track).paddingRight).toBe('41px');
     });
 
+    it('never reserves overflow space when the non-hideable first tab is the only tab', () => {
+      const element = mount(rosterOf(1), 40);
+      const track = element.querySelector('.slicc-agent-tabs__track') as HTMLElement;
+      const toggle = vi.spyOn(element.classList, 'toggle');
+
+      element.reflow();
+
+      expect(toggle).not.toHaveBeenCalledWith('has-overflow', true);
+      expect(element.classList.contains('has-overflow')).toBe(false);
+      expect(overflow(element).items).toHaveLength(0);
+      expect(getComputedStyle(track).paddingRight).toBe('2px');
+      toggle.mockRestore();
+    });
+
     it('settles at every pixel across the fit boundary and keeps tabs clear of the trigger', () => {
       const element = mount(rosterOf(6), 200);
       const track = element.querySelector('.slicc-agent-tabs__track') as HTMLElement;
@@ -776,6 +790,7 @@ describe('slicc-agent-tabs', () => {
             hidden: segments(element)
               .filter((item) => item.classList.contains('hide'))
               .map((item) => item.dataset.k),
+            items: overflow(element).items.length,
             paddingRight: getComputedStyle(track).paddingRight,
           };
         });
@@ -785,6 +800,7 @@ describe('slicc-agent-tabs', () => {
           states[0],
         ]);
         visited.add(states[0].overflow);
+        expect(states[0].items > 0).toBe(states[0].overflow);
         expect(states[0].paddingRight).toBe(states[0].overflow ? '41px' : '2px');
         if (states[0].overflow) {
           const visible = segments(element).filter((item) => !item.classList.contains('hide'));


### PR DESCRIPTION
## Summary
- remove the 41px right-side reserve when all agent tabs fit
- apply the overflow CSS padding and JavaScript budget subtraction from the same reserve decision, so there is no path where only one reserve applies
- preserve the 39×24 overflow trigger footprint when tabs need to hide

## Verification
- reproduced the padding-only oscillation with two scoops at 220px
- added a 1px sweep from 200–560px and confirmed it visits both states and settles at every width
- falsified the sweep by reverting only the arithmetic half; it failed at 498px
- visually checked one-tab, several-tab, and overflow Storybook states
- `npm run lint`
- `npm run typecheck`
- `npm run test -w @slicc/webcomponents` (1,782 passed)
- `npm run test` (13,344 passed, 46 skipped)
- `npm run test:coverage:webcomponents`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- `npm run build`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author