### PR TITLE
ci: gate expensive workflows by affected changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1271,6 +1271,7 @@ jobs:
     needs: [changes, lint]
     if: >-
       needs.lint.result == 'success' &&
+      needs.changes.outputs.is-queue-leader == 'true' &&
       (needs.changes.outputs.ios-app == 'true' ||
       needs.changes.outputs.swift-traysession == 'true' ||
       needs.changes.outputs.swift-config == 'true')

--- a/.github/workflows/ios-screenshots.yml
+++ b/.github/workflows/ios-screenshots.yml
@@ -21,6 +21,11 @@ name: iOS Screenshots
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'packages/ios-app/**'
+      - 'packages/swift-traysession/**'
+      - 'packages/dev-tools/tools/ios-screenshots*'
+      - '.github/workflows/ios-screenshots.yml'
 
 concurrency:
   group: ios-screenshots-${{ github.event.pull_request.number }}
@@ -31,25 +36,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      ios: ${{ steps.filter.outputs.ios }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
-        id: filter
-        with:
-          filters: |
-            ios:
-              - 'packages/ios-app/**'
-              - 'packages/swift-traysession/**'
-              - 'packages/dev-tools/tools/ios-screenshots*'
-              - '.github/workflows/ios-screenshots.yml'
-
   screenshots:
-    needs: changes
-    if: needs.changes.outputs.ios == 'true'
     runs-on: macos-latest
     timeout-minutes: 40
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      release_required: ${{ steps.release.outputs.required }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci --ignore-scripts
+
+      # Analyze commits with semantic-release's real default analyzer, but omit
+      # every prepare/publish plugin. Non-release pushes stop on this cheap Linux
+      # runner before reserving macOS or rebuilding the repository.
+      - name: Plan release
+        id: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          LOG="$RUNNER_TEMP/semantic-release-analyze.log"
+          npx semantic-release --dry-run --no-ci \
+            --plugins @semantic-release/commit-analyzer 2>&1 | tee "$LOG"
+
+          if grep -q 'The next release version is' "$LOG"; then
+            echo "required=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "required=false" >> "$GITHUB_OUTPUT"
+          fi
+
   release:
+    needs: analyze
+    if: needs.analyze.outputs.release_required == 'true'
     # macos-26 GA'd 2026-02-26 and is the image that ships Xcode 26
     # by default. Apple now rejects App Store submissions built with
     # anything older: "Validation failed (409) SDK version issue.
@@ -49,7 +87,6 @@ jobs:
       - run: npm ci
       - run: npm run typecheck
       - run: npm run test
-      - run: npm run build
 
       - name: Import Apple certificates
         if: env.APPLE_CERTIFICATE_BASE64 != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,24 +30,21 @@ jobs:
 
       - run: npm ci --ignore-scripts
 
-      # Analyze commits with semantic-release's real default analyzer, but omit
-      # every prepare/publish plugin. Non-release pushes stop on this cheap Linux
-      # runner before reserving macOS or rebuilding the repository.
+      # Call semantic-release's default commit analyzer directly, avoiding the
+      # CLI's repository push-access verification. Non-release pushes stop on
+      # this read-only Linux runner before reserving macOS or rebuilding.
       - name: Plan release
         id: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          LOG="$RUNNER_TEMP/semantic-release-analyze.log"
-          npx semantic-release --dry-run --no-ci \
-            --plugins @semantic-release/commit-analyzer 2>&1 | tee "$LOG"
+          RELEASE_TYPE="$(node packages/dev-tools/tools/release-plan.mjs)"
 
-          if grep -q 'The next release version is' "$LOG"; then
+          if [ "$RELEASE_TYPE" != 'none' ]; then
             echo "required=true" >> "$GITHUB_OUTPUT"
           else
             echo "required=false" >> "$GITHUB_OUTPUT"
           fi
+          echo "release_type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
 
   release:
     needs: analyze

--- a/.github/workflows/storybook-screenshots.yml
+++ b/.github/workflows/storybook-screenshots.yml
@@ -18,6 +18,10 @@ name: Storybook Screenshots
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'packages/webcomponents/**'
+      - 'packages/dev-tools/tools/storybook-affected-*'
+      - '.github/workflows/storybook-screenshots.yml'
 
 concurrency:
   group: storybook-screenshots-${{ github.event.pull_request.number }}
@@ -28,22 +32,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      webcomponents: ${{ steps.filter.outputs.webcomponents }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
-        id: filter
-        with:
-          filters: |
-            webcomponents:
-              - 'packages/webcomponents/**'
-
   screenshots:
-    needs: changes
-    if: needs.changes.outputs.webcomponents == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,7 +33,7 @@ Releases are automated with semantic-release. Maintainers do not cut version tag
 ### End-to-end flow
 
 1. Merge or push conventional-commit changes onto `main`, or manually dispatch `.github/workflows/release.yml` against `main`.
-2. A lightweight Linux preflight runs semantic-release's commit analyzer. Pushes with no releasable commits stop before reserving the `macos-26` release runner.
+2. A lightweight, read-only Linux preflight invokes semantic-release's commit analyzer directly. Pushes with no releasable commits stop before reserving the `macos-26` release runner.
 3. `.releaserc.json` limits publishing to `main`, so the semantic-release run exits without publishing when invoked from other refs.
 4. During the semantic-release `prepare` step, `@semantic-release/npm` updates `package.json` to the computed release version, `node dist/node-server/sync-release-version.js <version>` updates the extension `manifest.json`, and `npm run build -w @slicc/chrome-extension && npm run package:release` regenerate versioned release assets in `artifacts/release/`.
 5. During publish, semantic-release publishes the `sliccy` npm package via GitHub Actions OIDC trusted publishing. Worker and Chrome deploy scripts independently skip their release operations when their dependent sources did not change, and GitHub Release creation attaches the generated artifacts.

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,10 +33,10 @@ Releases are automated with semantic-release. Maintainers do not cut version tag
 ### End-to-end flow
 
 1. Merge or push conventional-commit changes onto `main`, or manually dispatch `.github/workflows/release.yml` against `main`.
-2. The release workflow runs `npm ci`, `npm run typecheck`, `npm run test`, and `npm run build` before calling `npx semantic-release`.
+2. A lightweight Linux preflight runs semantic-release's commit analyzer. Pushes with no releasable commits stop before reserving the `macos-26` release runner.
 3. `.releaserc.json` limits publishing to `main`, so the semantic-release run exits without publishing when invoked from other refs.
 4. During the semantic-release `prepare` step, `@semantic-release/npm` updates `package.json` to the computed release version, `node dist/node-server/sync-release-version.js <version>` updates the extension `manifest.json`, and `npm run build -w @slicc/chrome-extension && npm run package:release` regenerate versioned release assets in `artifacts/release/`.
-5. During publish, semantic-release publishes the `sliccy` npm package via GitHub Actions OIDC trusted publishing, runs `npm run publish:worker` unconditionally and then `npm run publish:chrome` **only when extension-relevant sources changed** (gated by `packages/dev-tools/tools/release-native.mjs --gate=chrome`), and finally creates a GitHub Release with generated release notes plus the packaged assets from `artifacts/release/`.
+5. During publish, semantic-release publishes the `sliccy` npm package via GitHub Actions OIDC trusted publishing. Worker and Chrome deploy scripts independently skip their release operations when their dependent sources did not change, and GitHub Release creation attaches the generated artifacts.
 
 ### GitHub Release outputs
 
@@ -47,7 +47,7 @@ Each published GitHub Release includes semantic-release generated release notes 
 - `release-artifacts.json` — stable manifest describing the generated artifact paths
 - `sliccstart-v<version>.dmg` — **conditional**: the macOS Sliccstart DMG (plus the `Sliccstart-<version>.zip` update archive) is only built and attached when macOS-relevant sources changed since the previous release tag (`packages/swift-launcher/`, `packages/swift-server/`, `packages/swift-optel/`, `packages/spoon/`, `packages/assets/`); the iOS TestFlight upload is likewise gated on `packages/ios-app/`. A first release (no previous tag) builds both. Gating is driven by `packages/dev-tools/tools/release-native.mjs`, invoked from the semantic-release `prepareCmd`; `npm run build` and `npm run package:release` always run.
 
-The **Chrome Web Store publish** (`npm run publish:chrome`) is gated the same way, but in the semantic-release `publishCmd` via `packages/dev-tools/tools/release-native.mjs --gate=chrome`: it only runs when extension-relevant sources changed since the previous tag (`packages/chrome-extension/`, `packages/webapp/`, `packages/webcomponents/`, `packages/shared-ts/`, `packages/cherry/`, `packages/spoon/`, `packages/cloud-core/`, `packages/assets/`), or on a first release. `npm run publish:worker` runs first and unconditionally.
+The **Chrome Web Store publish** (`npm run publish:chrome`) is gated the same way, but in the semantic-release `publishCmd` via `packages/dev-tools/tools/release-native.mjs --gate=chrome`: it only runs when extension-relevant sources changed since the previous tag (`packages/chrome-extension/`, `packages/webapp/`, `packages/webcomponents/`, `packages/shared-ts/`, `packages/cherry/`, `packages/spoon/`, `packages/cloud-core/`, `packages/assets/`), or on a first release. `npm run publish:worker` runs first, but its internal worker/UI gate skips template builds, secret writes, deploys, and smoke tests for unrelated releases while retaining the required R2 asset refresh.
 
 ### What gets published to npm
 

--- a/packages/dev-tools/CLAUDE.md
+++ b/packages/dev-tools/CLAUDE.md
@@ -37,7 +37,7 @@ This file covers the repo's developer-tooling surface.
 - **Cross-impl mask vectors**: `packages/dev-tools/tools/gen-mask-vectors.mjs` — regenerate pinned mask vectors for TS/Swift parity tests after intentional masking changes.
 - **Cross-impl theme vectors**: `packages/dev-tools/tools/gen-theme-vectors.mjs` (run via `npx tsx`) — regenerate pinned theme-derivation vectors after intentional `theme-engine.ts` changes; asserted by `packages/webapp/tests/ui/theme-vectors.test.ts` and `ThemeEngineTests.swift` against the same fixture.
 - **Preflight deps check**: `packages/dev-tools/tools/preflight-deps.mjs` — fast `npm ci` staleness check wired via `pretypecheck` and `pretest` scripts.
-- **Release gating**: `packages/dev-tools/tools/release-native.mjs` — gates native macOS/iOS packaging, the signed + notarized `slicc` Go CLI binaries (`packages/slicc-cli/sign-and-package.sh`), Chrome Web Store/worker publish steps, and the `@ai-ecoverse/biome-jsh` npm release (`--gate=biome-jsh-version` in prepare, `--gate=biome-jsh` in publish) on whether relevant source changed since the last tag.
+- **Release gating**: `packages/dev-tools/tools/release-plan.mjs` invokes semantic-release's commit analyzer directly for the read-only Linux preflight. `release-native.mjs` gates native macOS/iOS packaging, the signed + notarized `slicc` Go CLI binaries (`packages/slicc-cli/sign-and-package.sh`), Chrome Web Store/worker publish steps, and the `@ai-ecoverse/biome-jsh` npm release (`--gate=biome-jsh-version` in prepare, `--gate=biome-jsh` in publish) on whether relevant source changed since the last tag.
 
 ### SLICC CDP Debug Toolkit
 

--- a/packages/dev-tools/tools/release-plan.mjs
+++ b/packages/dev-tools/tools/release-plan.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { analyzeCommits } from '@semantic-release/commit-analyzer';
+
+const LOG_FORMAT = '%H%x1f%B%x1e';
+
+export function parseGitLog(output) {
+  return String(output ?? '')
+    .split('\x1e')
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map((record) => {
+      const separator = record.indexOf('\x1f');
+      if (separator < 0) throw new Error('Malformed git log record');
+      return {
+        hash: record.slice(0, separator).trim(),
+        message: record.slice(separator + 1).trim(),
+      };
+    });
+}
+
+export function getLastReleaseTag() {
+  try {
+    return execFileSync('git', ['describe', '--tags', '--match', 'v[0-9]*', '--abbrev=0'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+export function getCommitsSince(lastTag) {
+  const range = lastTag ? `${lastTag}..HEAD` : 'HEAD';
+  return parseGitLog(
+    execFileSync('git', ['log', `--format=${LOG_FORMAT}`, range], { encoding: 'utf8' })
+  );
+}
+
+export async function determineReleaseType(commits, cwd = process.cwd()) {
+  return analyzeCommits(
+    {},
+    {
+      commits,
+      cwd,
+      logger: { log() {} },
+    }
+  );
+}
+
+export async function main() {
+  const lastTag = getLastReleaseTag();
+  const releaseType = await determineReleaseType(getCommitsSince(lastTag));
+  console.log(releaseType ?? 'none');
+}
+
+const isMain =
+  process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+if (isMain) await main();

--- a/packages/dev-tools/tools/release-plan.test.mjs
+++ b/packages/dev-tools/tools/release-plan.test.mjs
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { determineReleaseType, parseGitLog } from './release-plan.mjs';
+
+describe('parseGitLog', () => {
+  it('maps delimited git records to semantic-release commits', () => {
+    expect(parseGitLog('abc\x1ffeat: add gating\n\x1e\ndef\x1fchore: docs\n\x1e')).toEqual([
+      { hash: 'abc', message: 'feat: add gating' },
+      { hash: 'def', message: 'chore: docs' },
+    ]);
+  });
+
+  it('rejects malformed records', () => {
+    expect(() => parseGitLog('missing separator\x1e')).toThrow('Malformed git log record');
+  });
+});
+
+describe('determineReleaseType', () => {
+  it('uses semantic-release default rules without repository authentication', async () => {
+    await expect(determineReleaseType([{ hash: 'a', message: 'feat: add gating' }])).resolves.toBe(
+      'minor'
+    );
+    await expect(
+      determineReleaseType([{ hash: 'b', message: 'fix: repair gating' }])
+    ).resolves.toBe('patch');
+    await expect(
+      determineReleaseType([{ hash: 'c', message: 'chore: update docs' }])
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/webcomponents/CLAUDE.md
+++ b/packages/webcomponents/CLAUDE.md
@@ -106,9 +106,9 @@ with light + dark Storybook screenshots of the **affected** stories. Driven by
 `.github/workflows/storybook-screenshots.yml`; the capture script and resolver
 live under `packages/dev-tools/tools/` (see that package's `CLAUDE.md`).
 
-**Trigger:** any path under `packages/webcomponents/**` on a `pull_request` to
-`main` (`dorny/paths-filter` `webcomponents` flag). PRs that don't touch the
-package don't run the job.
+**Trigger:** the workflow is event-filtered to `packages/webcomponents/**`, its
+screenshot tooling, and the workflow definition on a `pull_request` to `main`.
+Unrelated PRs do not start the workflow.
 
 **Affected-story heuristic** (directory-level, intentionally coarse — easy to
 reason about, no module-graph plumbing):


### PR DESCRIPTION
**Problem**
Long screenshot and release workflows reserve runners for changes that cannot affect their outputs.

**Solution**
Gate screenshot workflows at dispatch, limit merge-queue iOS validation to the queue leader, and stop non-release pushes in a lightweight semantic-release preflight.

**Testing**
Semantic-release dry-run, workflow YAML parsing, full repository verification, coverage, browser builds, and bundle-size gates passed.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KZ1MP28N5DTQ8X98KHX4TNT5&panel=chat)