### PR TITLE
fix(e2e): gate wrangler webServer readiness on /status HTTP 200, capture logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,40 @@ jobs:
         run: |
           npx playwright install chromium
           npm run test:e2e
+        env:
+          # Surface wrangler's own diagnostics so a crash during workerd
+          # cold-start doesn't reduce to an empty `X [ERROR]` in the Playwright
+          # webServer log. Combined with the `/status` readiness gate in the
+          # Playwright config, this makes a startup race actually debuggable.
+          WRANGLER_LOG: debug
+      - name: Upload Playwright artifacts
+        # Playwright's report + trace + screenshots are the primary post-mortem
+        # surface when the E2E job flakes. Without them a failure reduces to a
+        # single log line and a rerun; with them, the failing spec's trace
+        # zip is one download away. Runs on failure and success — a green run
+        # with a captured trace makes it easy to diff against a red one.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report-webapp
+          path: |
+            packages/webapp/playwright-report/
+            packages/webapp/test-results/
+            packages/webapp/tests/e2e/test-results/
+          if-no-files-found: ignore
+      - name: Upload wrangler logs
+        # wrangler writes structured startup + request logs to
+        # ~/.config/.wrangler/logs/wrangler-YYYY-MM-DD_HH-MM-SS.log even when
+        # its stderr is captured by another process; that file is where the
+        # real workerd bring-up stack ends up when the process crashes during
+        # the tail of `wrangler dev` startup. Uploading it turns an otherwise
+        # empty `X [ERROR]` in the Playwright surface into a full stack.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wrangler-logs-webapp
+          path: ~/.config/.wrangler/logs/
+          if-no-files-found: ignore
 
   # Real `say -o` Kokoro synthesis through the worker→page→worker
   # synthesize-to-wav bridge, validating the produced WAV file. Split

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,10 +375,15 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report-webapp
+          # Playwright resolves both the HTML reporter's `outputFolder` and the
+          # per-test `outputDir` against the nearest package root walked up from
+          # the config file, i.e. `packages/webapp/` (the config sits at
+          # `packages/webapp/tests/e2e/`). That is where `playwright-report/`
+          # (HTML index + trace zips) and `test-results/` (screenshots, videos,
+          # per-test artifacts) land — verified locally.
           path: |
             packages/webapp/playwright-report/
             packages/webapp/test-results/
-            packages/webapp/tests/e2e/test-results/
           if-no-files-found: ignore
       - name: Upload wrangler logs
         # wrangler writes structured startup + request logs to

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -817,6 +817,12 @@ async function tryHandleInfoRoutes(
   }
 
   if (url.pathname === '/status' && (request.method === 'GET' || request.method === 'HEAD')) {
+    // Also load-bearing for the E2E suite: `packages/webapp/tests/e2e/playwright.config.ts`
+    // gates the wrangler `webServer` readiness on a 200 from this handler
+    // (see the `url:` comment there). A future refactor must preserve both
+    // the 200 status and the `no-store` header, and must keep this route
+    // reachable by the worker's `fetch` (i.e. must not move it behind an
+    // asset/SPA intercept — see `wrangler.jsonc` `run_worker_first: true`).
     return jsonResponse(
       {
         status: 'ok',

--- a/packages/cloudflare-worker/wrangler.jsonc
+++ b/packages/cloudflare-worker/wrangler.jsonc
@@ -8,6 +8,12 @@
   "assets": {
     "directory": "../../dist/ui/",
     "binding": "ASSETS",
+    // `run_worker_first: true` routes every request through the worker's
+    // `fetch` before the ASSETS binding. Load-bearing for the E2E readiness
+    // probe: `packages/webapp/tests/e2e/playwright.config.ts` gates the
+    // wrangler `webServer` on a 200 from `/status`, which is a worker route.
+    // Flipping this to `false` (or the equivalent default) would let assets
+    // intercept `/status` and regress the gate back to bind-time semantics.
     "run_worker_first": true,
     "not_found_handling": "single-page-application"
   },

--- a/packages/webapp/tests/e2e/playwright.config.ts
+++ b/packages/webapp/tests/e2e/playwright.config.ts
@@ -131,7 +131,17 @@ export default defineConfig({
   ],
   use: {
     baseURL: LEADER_ORIGIN,
+    // Record traces on the retried attempt so the CI `Upload Playwright
+    // artifacts` step has something to hand a reviewer. `on-first-retry`
+    // matches `retries: 2` below: the initial attempt runs bare (no perf
+    // cost on a green run) and any retry writes a full trace + screenshots.
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
   },
+  // HTML reporter feeds the `playwright-report/` upload path; `list` keeps
+  // the CI stdout log readable. Without an HTML reporter the report dir is
+  // never written and the CI artifact would be empty.
+  reporter: process.env['CI'] ? [['html', { open: 'never' }], ['list']] : [['list']],
   // Keep one worker because fake-LLM fixture state and browser-driven scenarios
   // are process-global. The agent-driven Chrome itself is a dedicated webServer
   // process, so retries can restart Playwright's worker without replacing CDP.

--- a/packages/webapp/tests/e2e/playwright.config.ts
+++ b/packages/webapp/tests/e2e/playwright.config.ts
@@ -85,7 +85,13 @@ export default defineConfig({
       // (`npm run build -w @slicc/webapp` → `dist/ui/index.html`) first; the
       // CI `webapp` job builds it before the E2E step.
       command: `npx wrangler dev --config ${resolve(repoRoot, 'packages/cloudflare-worker/wrangler.jsonc')} --port ${WRANGLER_PORT} --ip 127.0.0.1`,
-      port: WRANGLER_PORT,
+      // Gate readiness on a real HTTP 200 from `/status`, NOT a bare TCP probe.
+      // workerd's `dev` process binds the listen socket well before the worker
+      // module + DO stubs finish loading; a `port:` probe passes during that
+      // tail, then the first Playwright navigate hits `ERR_CONNECTION_REFUSED`
+      // if any of the tail steps crash or drop the listener. `/status` runs the
+      // worker's `fetch` handler, so a 200 proves workerd is fully warm.
+      url: `${LEADER_ORIGIN}/status`,
       reuseExistingServer: !process.env['CI'],
       // wrangler's first cold start (workerd bring-up) can exceed Playwright's
       // 60s default in CI.

--- a/packages/webapp/tests/e2e/playwright.config.ts
+++ b/packages/webapp/tests/e2e/playwright.config.ts
@@ -91,6 +91,16 @@ export default defineConfig({
       // tail, then the first Playwright navigate hits `ERR_CONNECTION_REFUSED`
       // if any of the tail steps crash or drop the listener. `/status` runs the
       // worker's `fetch` handler, so a 200 proves workerd is fully warm.
+      //
+      // Two invariants this probe depends on — a future refactor that breaks
+      // either will silently regress the gate back to bind-time semantics:
+      //   1. `packages/cloudflare-worker/wrangler.jsonc` sets
+      //      `assets.run_worker_first: true` so `/status` reaches the worker's
+      //      `fetch` handler and is not intercepted by the ASSETS binding or
+      //      the SPA fallback.
+      //   2. `packages/cloudflare-worker/src/index.ts` `/status` handler
+      //      returns `200` with `Cache-Control: no-store`, so Playwright's
+      //      `url:` probe never gets a cached response mid-startup.
       url: `${LEADER_ORIGIN}/status`,
       reuseExistingServer: !process.env['CI'],
       // wrangler's first cold start (workerd bring-up) can exceed Playwright's


### PR DESCRIPTION
## Problem

The `CI / webapp` job's E2E suite flaked on 3 distinct commits in the last 7 days — same SHA, attempt 1 red, attempt 2 green on unchanged code:

- 8918b7bb: https://github.com/ai-ecoverse/slicc/actions/runs/30477639299
- 5744b8c4: https://github.com/ai-ecoverse/slicc/actions/runs/30641696399
- 55d4d75c: (linked in the launch brief)

Failure signature: every failing spec hit `net::ERR_CONNECTION_REFUSED` on `http://localhost:8787` moments after `wrangler dev` "started", accompanied by a bare `X [ERROR]` line from workerd with no stack.

Root cause: the Playwright `webServer` entry for wrangler gated readiness on `port: WRANGLER_PORT`. That probe passes as soon as workerd's TCP listener binds — well before the worker module + Durable Object stubs finish loading. When the tail of that cold-start crashed, the port was momentarily open and then dropped, so Playwright raced ahead and every navigate hit a dead socket.

## Solution

Gate readiness on a real HTTP 200 from the worker's own `/status` handler instead of a bare TCP probe. `/status` runs through the worker's `fetch` handler, so a 200 proves workerd is fully warm — a TCP-open probe cannot pass during the crashing tail.

Paired with matching CI observability so the next flake is actually debuggable:

- `WRANGLER_LOG=debug` on the E2E step, so wrangler's own diagnostics reach the Playwright webServer log surface.
- Upload the Playwright report + traces (`playwright-report-webapp`) — the webapp job did not previously capture them.
- Upload `~/.config/.wrangler/logs/` (`wrangler-logs-webapp`), so the real workerd stack survives even when its stderr is captured elsewhere.

No retries, no sleeps, no `test.retry` — per `.agents/skills/writing-slicc-tests/SKILL.md`.

## Testing

Ran `CI=1 npm run test:e2e` **10 consecutive iterations** on a Linux runner in a clean checkout:

| iter | result | tests |
|------|--------|-------|
| 1–10 | pass (exit 0) | 13 passed, 1 skipped |

Zero `ERR_CONNECTION_REFUSED`, zero retries triggered. Total wall clock ≈11 min for the 10-run loop.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KZ3443TBDVFZ1JSGZ436C0BD&panel=chat)