### PR TITLE
feat(ios-app): device-QA polish — markdown blocks, sprinkle icons, compact scoop switcher

### DIFF
--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -19,9 +19,9 @@ This package is NOT an npm workspace. It is a Swift Package Manager project (`Pa
 | `SliccFollower/Models/ICloudSessionList.swift`, `SliccFollower.entitlements`                         | iCloud tray-session discovery: presentation logic over `SliccTraySession` (see "iCloud Sessions") + the KVS entitlement                                                                                           |
 | `SliccFollower/Networking/TraySignaling.swift`, `TrayFollowerConnector.swift`, `WebRTCManager.swift` | Signaling client + WebRTC peer/data-channel setup                                                                                                                                                                 |
 | `SliccFollower/CDP/CDPBridge.swift`, `CDPTarget.swift`                                               | Hosts WKWebViews as CDP targets the leader can drive remotely                                                                                                                                                     |
-| `SliccFollower/Views/ChatView.swift`, `MessageListView.swift`                                        | SwiftUI chat surface. `MessageListView` is the active renderer                                                                                                                                                    |
+| `SliccFollower/Views/ChatView.swift`, `MessageListView.swift`, `MarkdownText.swift`                  | SwiftUI chat surface (`MessageListView` renders). `Models/MarkdownBlock.swift` parses fences, lists and GFM pipe tables for the bubbles                                                                           |
 | `SliccFollower/Views/SprinkleWebView.swift`, `InlineSprinkleView.swift`, `SprinkleDetailView.swift`  | Renders `.shtml` sprinkle content received from the leader via `sprinkle.content`. Bridge calls (`lick`, `setState`, etc.) intercepted via `WKScriptMessageHandler` — VFS APIs are stubbed (graceful degradation) |
-| `SliccFollower/Views/DockModel.swift`, `DockRail.swift`, `WorkbenchHost.swift`                       | Phone IA (#1802): chat + 48pt dock rail (web order, tap-active collapses); workbench overlays chat, leader-only surfaces get honest placeholders. No sidebar                                                      |
+| `SliccFollower/Views/DockModel.swift`, `DockRail.swift`, `WorkbenchHost.swift`, `LucideIcon.swift`   | Phone IA (#1802): chat + 48pt dock rail (web order, tap-active collapses); workbench overlays chat. Icons are lucide `d` strings parsed by `Models/SVGPath.swift` — SF Symbols has no cone                        |
 | `SliccFollower/Views/TabsCarouselView.swift`                                                         | Carousel of locally hosted CDP target WKWebViews                                                                                                                                                                  |
 | Other views (`ChatView.swift`, `InputBar.swift`, `MessageBubble.swift`, `SettingsView.swift`, …)     | Top-level shell + smaller UI fragments — not exhaustive                                                                                                                                                           |
 | `SliccFollower/Resources/Assets.xcassets`                                                            | App icon + asset catalog                                                                                                                                                                                          |
@@ -120,6 +120,20 @@ Holding the EMPTY composer dictates a `user_message` (no protocol change).
 when the locale supports it). Hooks: `-uiTestSpeechPermission`/
 `-uiTestSpeechScript` script the engine; `-uiTestPttStage` pins the
 overlay for screenshots.
+
+Release submits the transcript directly (`InputBar.submit(_:dictated:)`),
+never by writing the composer binding and re-reading it; an unsendable one
+stays in the composer as a draft rather than vanishing.
+
+Dictated turns speak their reply back, porting
+`webapp/src/speech/{dictation-priming,voice-reply}.ts`.
+`Models/DictationPriming.swift` appends the AI-only markers the model sees
+(🎙️ per turn, plus a one-time `◁…▷` note per session asking for speakable
+prose and a hidden `<!--lang:xx-->` marker); bubbles strip them at render
+time. `Models/VoiceReply.swift` counts dictated submissions — a count, not a
+flag, so queued turns stay balanced — and speaks that reply via
+`AVSpeechSynthesizer` behind the `SpeechSpeaking` seam. Typed turns stay
+silent, as does a reply whose declared language has no voice.
 
 ## Build
 

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -9,20 +9,24 @@
 /* Begin PBXBuildFile section */
 		016FBAD73E8220037360A213 /* CdpPreviewClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18BF55CBA000161C54E4770C /* CdpPreviewClient.swift */; };
 		02019B8CFDC4B36D610933B8 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434BBAD25E91BD0B7D626821 /* AppState.swift */; };
+		07FB78A21C6B4886CF4FEA74 /* AppStateFrozenSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE98FF01376D2519FAC3A05 /* AppStateFrozenSessions.swift */; };
 		09FE7E5B6F63D6850F2EBFBE /* UITestHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1308398CD972FF297E2C75 /* UITestHooks.swift */; };
 		0CAAEE94D02D4006193FA4BB /* InputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */; };
 		11F604368853A3A60AC0B10F /* PttController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F779D2634D4AED6D1AEDA07 /* PttController.swift */; };
 		15CF4C85551B4FE239D55E94 /* SliccIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438577405ABBCA33F117862C /* SliccIcons.swift */; };
 		1939D37EEDBD284DC9F6A9DC /* FrozenSessionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF8476768958BC66533E58F /* FrozenSessionsUITests.swift */; };
+		1B1D78732EE937BE2DBF2C05 /* SVGPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A51DB1BA99DAE89F21CF736 /* SVGPath.swift */; };
 		1C51604116AA20BE57F33B46 /* RemoteTabCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 841A713C553168F264F8D4DE /* RemoteTabCard.swift */; };
 		1CA565FA67F1B5B7CCFE08D9 /* DockModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FF5A8AF177D5B78AFD87FD /* DockModel.swift */; };
 		21BD049697833AC4E3316A58 /* ToolUIPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0425579D2C460F993D259DB /* ToolUIPlaceholderTests.swift */; };
 		238295F68E3669C0968C9934 /* WebRTCManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AF8A8A50FCC9C2DBECA0CF /* WebRTCManager.swift */; };
 		2401C7FE702795E1066A7C9F /* ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB646EF0D0006D1A43F527D /* ChatMessage.swift */; };
+		295A3C0E98C58AB966726AB9 /* VoiceReply.swift in Sources */ = {isa = PBXBuildFile; fileRef = E326D34AE874B17953C8895E /* VoiceReply.swift */; };
 		2A750B8B02200270E97C8D6E /* Dictation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4A75BA9D14DA689D0E9F4 /* Dictation.swift */; };
 		2AB3075DAEAC8AC08789EF37 /* AppStateDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB1EE73D7F0AA0AE4B8BC83 /* AppStateDelivery.swift */; };
 		2CE789AA836BB0713F1250D7 /* CDPBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE0A7D88487F7712E451646 /* CDPBridge.swift */; };
 		306C9DAD5071D0E813194FC5 /* ICloudSessionListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D53BAF8B8E31F0EC06B69E /* ICloudSessionListTests.swift */; };
+		3154CC4D9E37E6D8031FCC3F /* DictationPriming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5194158BDF37CEDBD7AE9308 /* DictationPriming.swift */; };
 		319F6B893CA643B51BE218BB /* FrozenSessionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3425D0B50BD57E03FFF47A45 /* FrozenSessionsView.swift */; };
 		372183DEB63D89EC6E10C140 /* FrozenSessionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9572AB87A7ACEC6740682685 /* FrozenSessionsTests.swift */; };
 		3A9E122F6A6C4C0F6258C5C6 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A069AA812629AC5FE70AC9 /* SettingsView.swift */; };
@@ -57,6 +61,8 @@
 		731FD0C4926AE9E5998970A3 /* MarkdownBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D75B552EEAA18730A8843B9 /* MarkdownBlock.swift */; };
 		73CD8FDB68D950291A923BCD /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B186EDFDE184DC8B3215C4 /* ChatView.swift */; };
 		7517352B67786422613418E5 /* DockUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27B23D49C2C36F1A276CF23 /* DockUITests.swift */; };
+		7782C370E6882C97EB6FC236 /* SVGPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 695356CA7F082C3287CFB228 /* SVGPathTests.swift */; };
+		77F6BA1A2BAEC5433F12CD0E /* LucideIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B8EC8680591A3A1A9BD392 /* LucideIcon.swift */; };
 		7AFB535E78304FCE5CE7058A /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523A4A068180D7EE98435885 /* MarkdownText.swift */; };
 		7BEE859F6C68FEAFD63D1FBB /* SyncProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 618555E73F15FDB4DB0CAA6F /* SyncProtocol.swift */; };
 		7D0637CA64748935A98A60D8 /* TrayFs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFC4F75EC6A6C1D71314A24D /* TrayFs.swift */; };
@@ -68,6 +74,7 @@
 		8A4DC8067E31936EA9C475BC /* TrayTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDB6F858D918DBBE06D4702 /* TrayTypes.swift */; };
 		8EEACE6ED76E43E36FC9F0AB /* ChatFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA9A527E2D4BBCE1BDFA89C /* ChatFixture.swift */; };
 		91B4DBF9FB2F5B25B099607C /* MonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F98508E6A01545988D9D42 /* MonitorView.swift */; };
+		92BBD6EFB95893D4B3566905 /* VoiceReplyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60DB85370008030F231AAD3 /* VoiceReplyTests.swift */; };
 		9494D2F9E9EFAB61FFC71886 /* AppStateTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A88993C99745347AF830860 /* AppStateTheme.swift */; };
 		977007CC44BE2B53361DF256 /* Keepalive.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDA931BF1BE121985E2FB3EE /* Keepalive.swift */; };
 		9AD8326007279D3F37D57C9C /* ICloudSessionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D158A5ACE0AC9C2CE6FEFCD3 /* ICloudSessionList.swift */; };
@@ -134,6 +141,7 @@
 		066BAF2F283227600FB92506 /* SteerMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteerMessageTests.swift; sourceTree = "<group>"; };
 		075FA82F3967B4E37A76C59A /* PttUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PttUITests.swift; sourceTree = "<group>"; };
 		0835A30393CEF046BA90DB16 /* FsClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FsClientTests.swift; sourceTree = "<group>"; };
+		0A51DB1BA99DAE89F21CF736 /* SVGPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SVGPath.swift; sourceTree = "<group>"; };
 		11B186EDFDE184DC8B3215C4 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		12FDDE8F74ACEEEACDA73346 /* FsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FsClient.swift; sourceTree = "<group>"; };
 		1572105F0B5819E4CC07BD84 /* ThemeEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEngine.swift; sourceTree = "<group>"; };
@@ -163,6 +171,7 @@
 		4E99369A8A6B1A9B8EBE996E /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		507969DA6DFEA7E053C53F32 /* ThemePaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemePaletteTests.swift; sourceTree = "<group>"; };
 		508DFA2D4CC9FD26DCC66AD4 /* FrozenSessions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrozenSessions.swift; sourceTree = "<group>"; };
+		5194158BDF37CEDBD7AE9308 /* DictationPriming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationPriming.swift; sourceTree = "<group>"; };
 		523A4A068180D7EE98435885 /* MarkdownText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownText.swift; sourceTree = "<group>"; };
 		55D53BAF8B8E31F0EC06B69E /* ICloudSessionListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudSessionListTests.swift; sourceTree = "<group>"; };
 		58899461D44B42F512AD0645 /* DockRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockRail.swift; sourceTree = "<group>"; };
@@ -174,12 +183,14 @@
 		62B1B7433B4D853B17578E82 /* LickEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LickEnvelopeTests.swift; sourceTree = "<group>"; };
 		639AB6CC8494FCE4C252F00B /* ChunkFramingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkFramingTests.swift; sourceTree = "<group>"; };
 		686D36BA22DBC2F94CEA8448 /* BrowserTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserTargets.swift; sourceTree = "<group>"; };
+		695356CA7F082C3287CFB228 /* SVGPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SVGPathTests.swift; sourceTree = "<group>"; };
 		6A88993C99745347AF830860 /* AppStateTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTheme.swift; sourceTree = "<group>"; };
 		740A6B3BC797CFC901E08521 /* swift-traysession */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "swift-traysession"; path = "../swift-traysession"; sourceTree = SOURCE_ROOT; };
 		747034EA0B5B45B56875A5DD /* LinkHeaderCorpusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHeaderCorpusTests.swift; sourceTree = "<group>"; };
 		787E06CD88652B51BA32D519 /* AttachmentMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMessageTests.swift; sourceTree = "<group>"; };
 		7BF55967F5396E597EE34125 /* SprinkleDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SprinkleDetailView.swift; sourceTree = "<group>"; };
 		7E727142147B0FB449F418D1 /* MessageListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageListView.swift; sourceTree = "<group>"; };
+		81B8EC8680591A3A1A9BD392 /* LucideIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LucideIcon.swift; sourceTree = "<group>"; };
 		83613696C70A0EF218A19B6D /* FilesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesUITests.swift; sourceTree = "<group>"; };
 		841A713C553168F264F8D4DE /* RemoteTabCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabCard.swift; sourceTree = "<group>"; };
 		844647F0DBCA8CC0C840D09A /* AttachmentStaging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentStaging.swift; sourceTree = "<group>"; };
@@ -218,7 +229,9 @@
 		D158A5ACE0AC9C2CE6FEFCD3 /* ICloudSessionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudSessionList.swift; sourceTree = "<group>"; };
 		D8232EF6923F57C710FF97AB /* MemoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryView.swift; sourceTree = "<group>"; };
 		DD1308398CD972FF297E2C75 /* UITestHooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestHooks.swift; sourceTree = "<group>"; };
+		DDE98FF01376D2519FAC3A05 /* AppStateFrozenSessions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateFrozenSessions.swift; sourceTree = "<group>"; };
 		DFC4F75EC6A6C1D71314A24D /* TrayFs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayFs.swift; sourceTree = "<group>"; };
+		E326D34AE874B17953C8895E /* VoiceReply.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceReply.swift; sourceTree = "<group>"; };
 		E7EF3911627A88E5691B3949 /* NewSessionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionUITests.swift; sourceTree = "<group>"; };
 		E92410F3BA05462ECDEB20A1 /* FilesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesView.swift; sourceTree = "<group>"; };
 		E9FC22E5B3D4B0DA205C7F62 /* ICloudSessionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudSessionsUITests.swift; sourceTree = "<group>"; };
@@ -230,6 +243,7 @@
 		F0583BDF50B1A1B9CE68AE67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F0A069AA812629AC5FE70AC9 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		F507FDBA9C3FD19BCC67FB3B /* DockModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockModelTests.swift; sourceTree = "<group>"; };
+		F60DB85370008030F231AAD3 /* VoiceReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceReplyTests.swift; sourceTree = "<group>"; };
 		F9555BBF8AC72C74630432D1 /* theme-vectors.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "theme-vectors.json"; sourceTree = "<group>"; };
 		FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRouteUITests.swift; sourceTree = "<group>"; };
 		FD6CEFD575FD21C28BEC39F5 /* tray-sync-corpus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tray-sync-corpus.json"; sourceTree = "<group>"; };
@@ -270,11 +284,13 @@
 				A16A253ACC35EEB12798224E /* NewSessionMessageTests.swift */,
 				8551D5DAD74B9BFB7CC2B76D /* PttControllerTests.swift */,
 				066BAF2F283227600FB92506 /* SteerMessageTests.swift */,
+				695356CA7F082C3287CFB228 /* SVGPathTests.swift */,
 				9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */,
 				3BBC1002CE4D3E1D940352F4 /* SyncProtocolTests.swift */,
 				BF3C704861C906098707C875 /* ThemeEngineTests.swift */,
 				507969DA6DFEA7E053C53F32 /* ThemePaletteTests.swift */,
 				F0425579D2C460F993D259DB /* ToolUIPlaceholderTests.swift */,
+				F60DB85370008030F231AAD3 /* VoiceReplyTests.swift */,
 				52A9B6A8BE5EE73A5DF4470C /* Fixtures */,
 			);
 			name = SliccFollowerTests;
@@ -286,6 +302,7 @@
 			children = (
 				434BBAD25E91BD0B7D626821 /* AppState.swift */,
 				FDB1EE73D7F0AA0AE4B8BC83 /* AppStateDelivery.swift */,
+				DDE98FF01376D2519FAC3A05 /* AppStateFrozenSessions.swift */,
 				6A88993C99745347AF830860 /* AppStateTheme.swift */,
 				C7D4AD0E32B059DB9EABFF3E /* SliccFollowerApp.swift */,
 				DD1308398CD972FF297E2C75 /* UITestHooks.swift */,
@@ -309,6 +326,7 @@
 				686D36BA22DBC2F94CEA8448 /* BrowserTargets.swift */,
 				BBB646EF0D0006D1A43F527D /* ChatMessage.swift */,
 				04F4A75BA9D14DA689D0E9F4 /* Dictation.swift */,
+				5194158BDF37CEDBD7AE9308 /* DictationPriming.swift */,
 				508DFA2D4CC9FD26DCC66AD4 /* FrozenSessions.swift */,
 				D158A5ACE0AC9C2CE6FEFCD3 /* ICloudSessionList.swift */,
 				B13A2CF7B24036FE27F65975 /* ImageAttachmentBuilder.swift */,
@@ -316,12 +334,14 @@
 				2D75B552EEAA18730A8843B9 /* MarkdownBlock.swift */,
 				9A73EE3E38934A8DE13AF2BD /* MemoryStore.swift */,
 				5F779D2634D4AED6D1AEDA07 /* PttController.swift */,
+				0A51DB1BA99DAE89F21CF736 /* SVGPath.swift */,
 				618555E73F15FDB4DB0CAA6F /* SyncProtocol.swift */,
 				1572105F0B5819E4CC07BD84 /* ThemeEngine.swift */,
 				B3BE6D707649AD21C5912013 /* ThemePalette.swift */,
 				356386D299A1933A39CB972B /* TrayChunkFraming.swift */,
 				DFC4F75EC6A6C1D71314A24D /* TrayFs.swift */,
 				2EDB6F858D918DBBE06D4702 /* TrayTypes.swift */,
+				E326D34AE874B17953C8895E /* VoiceReply.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -385,6 +405,7 @@
 				3425D0B50BD57E03FFF47A45 /* FrozenSessionsView.swift */,
 				1F2EECDCB4AF899D3071D13C /* InlineSprinkleView.swift */,
 				CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */,
+				81B8EC8680591A3A1A9BD392 /* LucideIcon.swift */,
 				523A4A068180D7EE98435885 /* MarkdownText.swift */,
 				D8232EF6923F57C710FF97AB /* MemoryView.swift */,
 				AF78C09597C5D63A373EB126 /* MessageBubble.swift */,
@@ -613,6 +634,7 @@
 			files = (
 				02019B8CFDC4B36D610933B8 /* AppState.swift in Sources */,
 				2AB3075DAEAC8AC08789EF37 /* AppStateDelivery.swift in Sources */,
+				07FB78A21C6B4886CF4FEA74 /* AppStateFrozenSessions.swift in Sources */,
 				9494D2F9E9EFAB61FFC71886 /* AppStateTheme.swift in Sources */,
 				5B5741496E7C7EA37979CFF2 /* AttachmentChips.swift in Sources */,
 				A0327A6785996F45F4FED08A /* AttachmentStaging.swift in Sources */,
@@ -626,6 +648,7 @@
 				C43F5710585B9C800CAAA0A2 /* ConnectionStatusView.swift in Sources */,
 				B4A19D759C5C4CDDFFA1FC35 /* ContentView.swift in Sources */,
 				2A750B8B02200270E97C8D6E /* Dictation.swift in Sources */,
+				3154CC4D9E37E6D8031FCC3F /* DictationPriming.swift in Sources */,
 				1CA565FA67F1B5B7CCFE08D9 /* DockModel.swift in Sources */,
 				C9148ED833EA104C5F60800B /* DockRail.swift in Sources */,
 				B2C8B3A408D6696046BFA08C /* FilesView.swift in Sources */,
@@ -640,6 +663,7 @@
 				977007CC44BE2B53361DF256 /* Keepalive.swift in Sources */,
 				F5B6044724F8133C934A5143 /* LickEvent.swift in Sources */,
 				EDCEBDF62330D1775F1B4EE2 /* LinkHeader.swift in Sources */,
+				77F6BA1A2BAEC5433F12CD0E /* LucideIcon.swift in Sources */,
 				731FD0C4926AE9E5998970A3 /* MarkdownBlock.swift in Sources */,
 				7AFB535E78304FCE5CE7058A /* MarkdownText.swift in Sources */,
 				BE805A88112FF5627440F9A2 /* MemoryStore.swift in Sources */,
@@ -651,6 +675,7 @@
 				11F604368853A3A60AC0B10F /* PttController.swift in Sources */,
 				68FA70C9EC1A7C1137CC277D /* PttOverlayView.swift in Sources */,
 				1C51604116AA20BE57F33B46 /* RemoteTabCard.swift in Sources */,
+				1B1D78732EE937BE2DBF2C05 /* SVGPath.swift in Sources */,
 				3A9E122F6A6C4C0F6258C5C6 /* SettingsView.swift in Sources */,
 				3EDEBD047CEC3F24BC3ED785 /* SliccFollowerApp.swift in Sources */,
 				15CF4C85551B4FE239D55E94 /* SliccIcons.swift in Sources */,
@@ -667,6 +692,7 @@
 				D2A85DC611A43443DEC75989 /* TraySignaling.swift in Sources */,
 				8A4DC8067E31936EA9C475BC /* TrayTypes.swift in Sources */,
 				09FE7E5B6F63D6850F2EBFBE /* UITestHooks.swift in Sources */,
+				295A3C0E98C58AB966726AB9 /* VoiceReply.swift in Sources */,
 				238295F68E3669C0968C9934 /* WebRTCManager.swift in Sources */,
 				686CFEC54F95406972A1A1D6 /* WorkbenchHost.swift in Sources */,
 			);
@@ -712,12 +738,14 @@
 				5FC455760C1E661897C898AE /* MemoryStoreTests.swift in Sources */,
 				FBC5D9F3A8263FCAE3C6C6C5 /* NewSessionMessageTests.swift in Sources */,
 				9C28D445499995ADA861D75F /* PttControllerTests.swift in Sources */,
+				7782C370E6882C97EB6FC236 /* SVGPathTests.swift in Sources */,
 				9ECC362CC8EBA3629542A6E7 /* SteerMessageTests.swift in Sources */,
 				F908DA74A70E1C7F16EC6AD8 /* SyncProtocolCorpusTests.swift in Sources */,
 				CB6A8F9EEAD1D4DAA552E0EC /* SyncProtocolTests.swift in Sources */,
 				9DF8A1F02E02C3662AC7E44E /* ThemeEngineTests.swift in Sources */,
 				C1CC6CC22FA5B076B8FF0A7F /* ThemePaletteTests.swift in Sources */,
 				21BD049697833AC4E3316A58 /* ToolUIPlaceholderTests.swift in Sources */,
+				92BBD6EFB95893D4B3566905 /* VoiceReplyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		5A678420A08BBB43297E1D8D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F0583BDF50B1A1B9CE68AE67 /* Assets.xcassets */; };
 		5B5741496E7C7EA37979CFF2 /* AttachmentChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E089FCA5BF8861469F73C4 /* AttachmentChips.swift */; };
 		5DBC389110F337A40762C4E1 /* MessageListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E727142147B0FB449F418D1 /* MessageListView.swift */; };
+		5E20209A4C1455BBC0160856 /* BrowserTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686D36BA22DBC2F94CEA8448 /* BrowserTargets.swift */; };
 		5E23C33D85A8DFC1772AD1FE /* FrozenSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 508DFA2D4CC9FD26DCC66AD4 /* FrozenSessions.swift */; };
 		5FC455760C1E661897C898AE /* MemoryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB564AB9C945606419D0AB48 /* MemoryStoreTests.swift */; };
 		67305E9A6D6B198A43EF5148 /* ThemePalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE6D707649AD21C5912013 /* ThemePalette.swift */; };
@@ -51,7 +52,9 @@
 		686CFEC54F95406972A1A1D6 /* WorkbenchHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED01F56391DE9865C1405BAF /* WorkbenchHost.swift */; };
 		68FA70C9EC1A7C1137CC277D /* PttOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C4F68634F8E70BBC83002C /* PttOverlayView.swift */; };
 		700D14780F6676C4B9895576 /* MonitorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00BEA2C51D7D0E72D0ED176 /* MonitorUITests.swift */; };
+		705EDE718FE98C367B68B122 /* MarkdownBlockParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEA8DFDB483EE57CB725982 /* MarkdownBlockParserTests.swift */; };
 		726B3A4A70B54A313E5BF3A1 /* RemoteTabUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6BD423A10DF2C2C310F3689 /* RemoteTabUITests.swift */; };
+		731FD0C4926AE9E5998970A3 /* MarkdownBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D75B552EEAA18730A8843B9 /* MarkdownBlock.swift */; };
 		73CD8FDB68D950291A923BCD /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B186EDFDE184DC8B3215C4 /* ChatView.swift */; };
 		7517352B67786422613418E5 /* DockUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27B23D49C2C36F1A276CF23 /* DockUITests.swift */; };
 		7AFB535E78304FCE5CE7058A /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523A4A068180D7EE98435885 /* MarkdownText.swift */; };
@@ -59,6 +62,7 @@
 		7D0637CA64748935A98A60D8 /* TrayFs.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFC4F75EC6A6C1D71314A24D /* TrayFs.swift */; };
 		7F933D63693873A7B8955085 /* link-header-corpus.json in Resources */ = {isa = PBXBuildFile; fileRef = 224A81FCF4ECFA8EA4157E42 /* link-header-corpus.json */; };
 		8017E9416AEB3D7756ADEB3A /* ChunkFramingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639AB6CC8494FCE4C252F00B /* ChunkFramingTests.swift */; };
+		80CAC841902FCED56E805928 /* BrowserTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D69F96CFDFB32CC8A815552 /* BrowserTargetsTests.swift */; };
 		889CE05A1D2AFDFC669EC987 /* DockModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F507FDBA9C3FD19BCC67FB3B /* DockModelTests.swift */; };
 		88FE04B67265180C58A84F82 /* ImageAttachmentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B13A2CF7B24036FE27F65975 /* ImageAttachmentBuilder.swift */; };
 		8A4DC8067E31936EA9C475BC /* TrayTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EDB6F858D918DBBE06D4702 /* TrayTypes.swift */; };
@@ -139,6 +143,8 @@
 		224A81FCF4ECFA8EA4157E42 /* link-header-corpus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "link-header-corpus.json"; sourceTree = "<group>"; };
 		26D6B6B896CB48304A39DAB8 /* SteerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteerUITests.swift; sourceTree = "<group>"; };
 		29562677500C7380445B16B9 /* NewSessionDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionDialog.swift; sourceTree = "<group>"; };
+		2D69F96CFDFB32CC8A815552 /* BrowserTargetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserTargetsTests.swift; sourceTree = "<group>"; };
+		2D75B552EEAA18730A8843B9 /* MarkdownBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownBlock.swift; sourceTree = "<group>"; };
 		2EDB6F858D918DBBE06D4702 /* TrayTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayTypes.swift; sourceTree = "<group>"; };
 		31E089FCA5BF8861469F73C4 /* AttachmentChips.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentChips.swift; sourceTree = "<group>"; };
 		3425D0B50BD57E03FFF47A45 /* FrozenSessionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrozenSessionsView.swift; sourceTree = "<group>"; };
@@ -167,6 +173,7 @@
 		618555E73F15FDB4DB0CAA6F /* SyncProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncProtocol.swift; sourceTree = "<group>"; };
 		62B1B7433B4D853B17578E82 /* LickEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LickEnvelopeTests.swift; sourceTree = "<group>"; };
 		639AB6CC8494FCE4C252F00B /* ChunkFramingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkFramingTests.swift; sourceTree = "<group>"; };
+		686D36BA22DBC2F94CEA8448 /* BrowserTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserTargets.swift; sourceTree = "<group>"; };
 		6A88993C99745347AF830860 /* AppStateTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTheme.swift; sourceTree = "<group>"; };
 		740A6B3BC797CFC901E08521 /* swift-traysession */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "swift-traysession"; path = "../swift-traysession"; sourceTree = SOURCE_ROOT; };
 		747034EA0B5B45B56875A5DD /* LinkHeaderCorpusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkHeaderCorpusTests.swift; sourceTree = "<group>"; };
@@ -217,6 +224,7 @@
 		E9FC22E5B3D4B0DA205C7F62 /* ICloudSessionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ICloudSessionsUITests.swift; sourceTree = "<group>"; };
 		ECF8476768958BC66533E58F /* FrozenSessionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrozenSessionsUITests.swift; sourceTree = "<group>"; };
 		ED01F56391DE9865C1405BAF /* WorkbenchHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkbenchHost.swift; sourceTree = "<group>"; };
+		EFEA8DFDB483EE57CB725982 /* MarkdownBlockParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownBlockParserTests.swift; sourceTree = "<group>"; };
 		F00BEA2C51D7D0E72D0ED176 /* MonitorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorUITests.swift; sourceTree = "<group>"; };
 		F0425579D2C460F993D259DB /* ToolUIPlaceholderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolUIPlaceholderTests.swift; sourceTree = "<group>"; };
 		F0583BDF50B1A1B9CE68AE67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -247,6 +255,7 @@
 			isa = PBXGroup;
 			children = (
 				787E06CD88652B51BA32D519 /* AttachmentMessageTests.swift */,
+				2D69F96CFDFB32CC8A815552 /* BrowserTargetsTests.swift */,
 				496510BE3FA550EC3F1CF325 /* CdpPreviewClientTests.swift */,
 				639AB6CC8494FCE4C252F00B /* ChunkFramingTests.swift */,
 				F507FDBA9C3FD19BCC67FB3B /* DockModelTests.swift */,
@@ -256,6 +265,7 @@
 				8D76B8F603084A6021B6DD6B /* KeepaliveTests.swift */,
 				62B1B7433B4D853B17578E82 /* LickEnvelopeTests.swift */,
 				747034EA0B5B45B56875A5DD /* LinkHeaderCorpusTests.swift */,
+				EFEA8DFDB483EE57CB725982 /* MarkdownBlockParserTests.swift */,
 				CB564AB9C945606419D0AB48 /* MemoryStoreTests.swift */,
 				A16A253ACC35EEB12798224E /* NewSessionMessageTests.swift */,
 				8551D5DAD74B9BFB7CC2B76D /* PttControllerTests.swift */,
@@ -296,12 +306,14 @@
 		51886095A534C38E3C7A30E7 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				686D36BA22DBC2F94CEA8448 /* BrowserTargets.swift */,
 				BBB646EF0D0006D1A43F527D /* ChatMessage.swift */,
 				04F4A75BA9D14DA689D0E9F4 /* Dictation.swift */,
 				508DFA2D4CC9FD26DCC66AD4 /* FrozenSessions.swift */,
 				D158A5ACE0AC9C2CE6FEFCD3 /* ICloudSessionList.swift */,
 				B13A2CF7B24036FE27F65975 /* ImageAttachmentBuilder.swift */,
 				5AF41895CF5F76A1CD2B671E /* LickEvent.swift */,
+				2D75B552EEAA18730A8843B9 /* MarkdownBlock.swift */,
 				9A73EE3E38934A8DE13AF2BD /* MemoryStore.swift */,
 				5F779D2634D4AED6D1AEDA07 /* PttController.swift */,
 				618555E73F15FDB4DB0CAA6F /* SyncProtocol.swift */,
@@ -604,6 +616,7 @@
 				9494D2F9E9EFAB61FFC71886 /* AppStateTheme.swift in Sources */,
 				5B5741496E7C7EA37979CFF2 /* AttachmentChips.swift in Sources */,
 				A0327A6785996F45F4FED08A /* AttachmentStaging.swift in Sources */,
+				5E20209A4C1455BBC0160856 /* BrowserTargets.swift in Sources */,
 				2CE789AA836BB0713F1250D7 /* CDPBridge.swift in Sources */,
 				A2488147A916BDDB57B9A41C /* CDPTarget.swift in Sources */,
 				016FBAD73E8220037360A213 /* CdpPreviewClient.swift in Sources */,
@@ -627,6 +640,7 @@
 				977007CC44BE2B53361DF256 /* Keepalive.swift in Sources */,
 				F5B6044724F8133C934A5143 /* LickEvent.swift in Sources */,
 				EDCEBDF62330D1775F1B4EE2 /* LinkHeader.swift in Sources */,
+				731FD0C4926AE9E5998970A3 /* MarkdownBlock.swift in Sources */,
 				7AFB535E78304FCE5CE7058A /* MarkdownText.swift in Sources */,
 				BE805A88112FF5627440F9A2 /* MemoryStore.swift in Sources */,
 				4656B51B0C5284B961957745 /* MemoryView.swift in Sources */,
@@ -684,6 +698,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				581EB92FA65132178CAE334E /* AttachmentMessageTests.swift in Sources */,
+				80CAC841902FCED56E805928 /* BrowserTargetsTests.swift in Sources */,
 				E568114F9C5022800E90127F /* CdpPreviewClientTests.swift in Sources */,
 				8017E9416AEB3D7756ADEB3A /* ChunkFramingTests.swift in Sources */,
 				889CE05A1D2AFDFC669EC987 /* DockModelTests.swift in Sources */,
@@ -693,6 +708,7 @@
 				54B15E202D059EA1DBB4ED44 /* KeepaliveTests.swift in Sources */,
 				BAEB06EC85F8242C542D4782 /* LickEnvelopeTests.swift in Sources */,
 				CA14A8C5DE0A027197214AEF /* LinkHeaderCorpusTests.swift in Sources */,
+				705EDE718FE98C367B68B122 /* MarkdownBlockParserTests.swift in Sources */,
 				5FC455760C1E661897C898AE /* MemoryStoreTests.swift in Sources */,
 				FBC5D9F3A8263FCAE3C6C6C5 /* NewSessionMessageTests.swift in Sources */,
 				9C28D445499995ADA861D75F /* PttControllerTests.swift in Sources */,

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -391,12 +391,17 @@ class AppState: ObservableObject {
         // with no caption); only an entirely empty send is dropped.
         guard !trimmed.isEmpty || attached != nil else { return }
 
+        // The dictation scoop is resolved up front: the mark has to name the
+        // scoop the message goes to, and the same value is used to undo it.
+        let dictationScoop = selectedScoopJid ?? ""
         if dictated {
             // Markers are stored AND sent, as the webapp does, so replay and
             // compaction keep the context; bubbles strip them at render time.
+            // The first-turn flag is only PEEKED here — a send that never
+            // reaches the leader must not burn the one-time priming note.
             trimmed = DictationPriming.applyMarkers(
-                trimmed, isFirst: DictationPriming.consumeFirst())
-            VoiceReply.shared.markSubmission()
+                trimmed, isFirst: DictationPriming.isFirstPending)
+            VoiceReply.shared.markSubmission(scoopJid: dictationScoop)
         }
 
         let messageId = UUID().uuidString
@@ -425,6 +430,13 @@ class AppState: ObservableObject {
         #endif
         if !sendToLeader(msg), !hermeticallyConnected {
             markUndelivered(messageId)
+            // Nothing left, so nothing will answer: retire the mark and keep
+            // the priming note armed. Otherwise a reconnect (which runs
+            // `handleDisconnect`, not the user-only `disconnect()`) would
+            // carry the stale mark forward and speak an unrelated reply.
+            if dictated { VoiceReply.shared.rollbackSubmission(scoopJid: dictationScoop) }
+        } else if dictated {
+            DictationPriming.commitFirst()
         }
     }
 
@@ -965,8 +977,12 @@ class AppState: ObservableObject {
             // the browser surface renders them as preview cards (#1865).
             // Our own advertised targets and the leader's own SLICC page are
             // excluded — see `BrowserTargets`.
+            // `activeJoinUrl`, not `joinUrl`: an iCloud session dials a URL
+            // that never lands in the published field, and matching on the
+            // empty/stale one leaves the leader's own SLICC page in the cards.
             remoteTargets = BrowserTargets.visible(
-                targets, ownRuntimeId: controllerId, joinUrl: joinUrl)
+                targets, ownRuntimeId: controllerId,
+                joinUrl: activeJoinUrl.isEmpty ? joinUrl : activeJoinUrl)
 
         case .cdpResponse(
             let requestId, let result, let error, let chunkData, let chunkIndex,
@@ -1038,10 +1054,15 @@ class AppState: ObservableObject {
     /// double hook safe: whichever event lands first is the only one that
     /// speaks. The consume happens even for a background scoop so marks and
     /// turns stay balanced; only a visible reply is read aloud.
-    private func speakIfDictated(_ content: String, isVisible: Bool) {
-        guard VoiceReply.shared.consumeSubmission(), isVisible else { return }
+    private func speakIfDictated(
+        _ message: ChatMessage, scoopJid: String, isVisible: Bool
+    ) {
+        guard
+            VoiceReply.shared.consumeSubmission(scoopJid: scoopJid, messageId: message.id),
+            isVisible
+        else { return }
         logger.notice("speaking the reply to a dictated turn")
-        VoiceReply.shared.speakReply(markdown: content)
+        VoiceReply.shared.speakReply(markdown: message.content)
     }
 
     // MARK: - CDP advertise timer
@@ -1111,6 +1132,11 @@ class AppState: ObservableObject {
         if newSessionInFlight && chatMessages.isEmpty {
             newSessionInFlight = false
             newSessionTimeout?.cancel()
+            // A new session in place keeps the connection but starts a new
+            // conversation, so it re-arms the one-time priming note and drops
+            // marks whose replies belong to the transcript just cleared.
+            VoiceReply.shared.reset()
+            DictationPriming.reset()
         }
         messagesByScoop[scoopJid] = chatMessages
         // A snapshot is the leader re-describing the world. Any approval
@@ -1134,6 +1160,9 @@ class AppState: ObservableObject {
         switch event {
         case .messageStart(let messageId):
             logger.info("Agent event: message_start id=\(messageId) scoop=\(scoopJid)")
+            // The first message this scoop opens after a dictated submission
+            // is that submission's answer — bind before any reply completes.
+            VoiceReply.shared.bindReply(scoopJid: scoopJid, messageId: messageId)
             let newMsg = ChatMessage(
                 id: messageId,
                 role: .assistant,
@@ -1172,7 +1201,7 @@ class AppState: ObservableObject {
                     cancelPendingMessagesFlush()
                     messages = buffer
                 }
-                speakIfDictated(buffer[idx].content, isVisible: isVisible)
+                speakIfDictated(buffer[idx], scoopJid: scoopJid, isVisible: isVisible)
             }
 
         case .toolUseStart(let messageId, let toolName, let toolInput):
@@ -1215,7 +1244,7 @@ class AppState: ObservableObject {
                     isStreaming = false
                     streamingMessageId = nil
                 }
-                speakIfDictated(buffer[idx].content, isVisible: isVisible)
+                speakIfDictated(buffer[idx], scoopJid: scoopJid, isVisible: isVisible)
             }
 
         case .error(let error):

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -1029,6 +1029,21 @@ class AppState: ObservableObject {
         }
     }
 
+    /// Speak a finished assistant reply when the turn it answers was dictated.
+    ///
+    /// Hooked to BOTH completion events because leaders disagree about which
+    /// they send — a plain text turn from the browser leader arrives as
+    /// `content_done` with no `turn_end` at all, which is why the first cut
+    /// of this never made a sound. Consuming the mark is what makes the
+    /// double hook safe: whichever event lands first is the only one that
+    /// speaks. The consume happens even for a background scoop so marks and
+    /// turns stay balanced; only a visible reply is read aloud.
+    private func speakIfDictated(_ content: String, isVisible: Bool) {
+        guard VoiceReply.shared.consumeSubmission(), isVisible else { return }
+        logger.notice("speaking the reply to a dictated turn")
+        VoiceReply.shared.speakReply(markdown: content)
+    }
+
     // MARK: - CDP advertise timer
 
     private func startTargetsAdvertiseTimer() {
@@ -1157,6 +1172,7 @@ class AppState: ObservableObject {
                     cancelPendingMessagesFlush()
                     messages = buffer
                 }
+                speakIfDictated(buffer[idx].content, isVisible: isVisible)
             }
 
         case .toolUseStart(let messageId, let toolName, let toolInput):
@@ -1199,11 +1215,7 @@ class AppState: ObservableObject {
                     isStreaming = false
                     streamingMessageId = nil
                 }
-                // Consume unconditionally, even for a background scoop, so
-                // marks and turns stay balanced; only speak what is on screen.
-                if VoiceReply.shared.consumeSubmission(), isVisible {
-                    VoiceReply.shared.speakReply(markdown: buffer[idx].content)
-                }
+                speakIfDictated(buffer[idx].content, isVisible: isVisible)
             }
 
         case .error(let error):

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -242,21 +242,6 @@ class AppState: ObservableObject {
 
     // MARK: - Frozen sessions (freezer rail)
 
-    /// How the frozen-session list was (or failed to be) produced.
-    enum FrozenListState: Equatable {
-        case idle
-        case loading
-        /// `rebuilt` means /sessions/index.json was corrupt and the list came
-        /// from a /sessions directory scan instead.
-        case loaded(rebuilt: Bool)
-        case failed(String)
-    }
-
-    struct OpenFrozenSession {
-        let entry: FrozenSessionIndexEntry
-        let archive: ParsedFrozenArchive
-    }
-
     /// Single-flight guard for `new_session`: the leader runs its own
     /// guard, but the phone must not queue a second request while a save
     /// (the slow, LLM-enriched path) is in flight. Cleared when the
@@ -274,91 +259,6 @@ class AppState: ObservableObject {
     /// replaced by the frozen banner for the duration.
     @Published var openFrozen: OpenFrozenSession?
     @Published var frozenOpenError: String?
-
-    /// Load `/sessions/index.json` from the leader's VFS. A corrupt index
-    /// self-heals from a `/sessions` directory scan; a missing sessions dir
-    /// is an empty rail, not an error.
-    func loadFrozenSessions() {
-        #if DEBUG
-            if let fixture = UITestHooks.frozenFixture() {
-                frozenSessions = fixture
-                frozenListState = .loaded(rebuilt: false)
-                return
-            }
-        #endif
-        guard connectionState == .connected else {
-            // The snowflake is always reachable; a stale list from a previous
-            // leader — or an eternal spinner from `.idle` — must not be.
-            frozenSessions = []
-            frozenListState = .failed("Connect to a leader to browse its past sessions.")
-            return
-        }
-        frozenListState = .loading
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            do {
-                let raw = try await self.fsClient.readFile(FrozenSessionIndex.indexPath)
-                if let entries = FrozenSessionIndex.parse(indexJson: raw) {
-                    self.frozenSessions = entries
-                    self.frozenListState = .loaded(rebuilt: false)
-                    return
-                }
-                // Corrupt or partially written index — rebuild from a scan.
-                try await self.rebuildFrozenList()
-            } catch {
-                // Missing index but present archives is the same self-heal
-                // path; a missing directory degrades to an empty rail.
-                do {
-                    try await self.rebuildFrozenList()
-                } catch {
-                    self.frozenSessions = []
-                    self.frozenListState = .loaded(rebuilt: false)
-                }
-            }
-        }
-    }
-
-    private func rebuildFrozenList() async throws {
-        let entries = try await fsClient.readDir(FrozenSessionIndex.sessionsDir)
-        frozenSessions = FrozenSessionIndex.rebuild(from: entries)
-        frozenListState = .loaded(rebuilt: true)
-    }
-
-    /// Open one archive read-only. Never logs the content; parse failures
-    /// surface on `frozenOpenError`.
-    func openFrozenSession(_ entry: FrozenSessionIndexEntry) {
-        frozenOpenError = nil
-        #if DEBUG
-            if let markdown = UITestHooks.frozenArchiveFixture(for: entry) {
-                openFrozen = OpenFrozenSession(
-                    entry: entry,
-                    archive: FrozenArchiveParser.withFallbackTimestamps(
-                        FrozenArchiveParser.parse(markdown: markdown),
-                        frozenAt: entry.frozenDate))
-                return
-            }
-        #endif
-        frozenOpeningId = entry.id
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            defer { self.frozenOpeningId = nil }
-            do {
-                let markdown = try await self.fsClient.readFile(entry.path)
-                self.openFrozen = OpenFrozenSession(
-                    entry: entry,
-                    archive: FrozenArchiveParser.withFallbackTimestamps(
-                        FrozenArchiveParser.parse(markdown: markdown),
-                        frozenAt: entry.frozenDate))
-            } catch {
-                self.frozenOpenError =
-                    "Could not read “\(entry.title)” — it may have been removed on the leader."
-            }
-        }
-    }
-
-    func closeFrozenSession() {
-        openFrozen = nil
-    }
 
     /// Ask the leader to start a new chat. The phone never clears
     /// optimistically — the leader broadcasts the cleared snapshot and
@@ -427,6 +327,11 @@ class AppState: ObservableObject {
         connectedSince = nil
         isStreaming = false
         streamingMessageId = nil
+        // A reply that never arrived must not leave a mark behind to speak
+        // the first turn of whatever session comes next; the fresh session
+        // also re-arms the one-time dictation priming note.
+        VoiceReply.shared.reset()
+        DictationPriming.reset()
         scoops = []
         selectedScoopJid = nil
         leaderActiveScoopJid = nil
@@ -477,13 +382,22 @@ class AppState: ObservableObject {
     /// queueing behind it — the phone's equivalent of the desktop's
     /// Cmd+Enter.
     func sendMessage(
-        _ text: String, steer: Bool = false, attachments: [MessageAttachment]? = nil
+        _ text: String, steer: Bool = false, attachments: [MessageAttachment]? = nil,
+        dictated: Bool = false
     ) {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        var trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         let attached = (attachments?.isEmpty == false) ? attachments : nil
         // A pure-attachment message is legal (the web composer sends photos
         // with no caption); only an entirely empty send is dropped.
         guard !trimmed.isEmpty || attached != nil else { return }
+
+        if dictated {
+            // Markers are stored AND sent, as the webapp does, so replay and
+            // compaction keep the context; bubbles strip them at render time.
+            trimmed = DictationPriming.applyMarkers(
+                trimmed, isFirst: DictationPriming.consumeFirst())
+            VoiceReply.shared.markSubmission()
+        }
 
         let messageId = UUID().uuidString
         let message = ChatMessage(
@@ -1284,6 +1198,11 @@ class AppState: ObservableObject {
                     messages = buffer
                     isStreaming = false
                     streamingMessageId = nil
+                }
+                // Consume unconditionally, even for a background scoop, so
+                // marks and turns stay balanced; only speak what is on screen.
+                if VoiceReply.shared.consumeSubmission(), isVisible {
+                    VoiceReply.shared.speakReply(markdown: buffer[idx].content)
                 }
             }
 

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -1049,9 +1049,10 @@ class AppState: ObservableObject {
         case .targetsRegistry(let targets):
             // Tabs the tray federates elsewhere (leader + other followers);
             // the browser surface renders them as preview cards (#1865).
-            // Our own advertised targets are excluded — they are the live
-            // local carousel.
-            remoteTargets = targets.filter { $0.runtimeId != controllerId }
+            // Our own advertised targets and the leader's own SLICC page are
+            // excluded — see `BrowserTargets`.
+            remoteTargets = BrowserTargets.visible(
+                targets, ownRuntimeId: controllerId, joinUrl: joinUrl)
 
         case .cdpResponse(
             let requestId, let result, let error, let chunkData, let chunkIndex,

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -977,12 +977,14 @@ class AppState: ObservableObject {
             // the browser surface renders them as preview cards (#1865).
             // Our own advertised targets and the leader's own SLICC page are
             // excluded — see `BrowserTargets`.
-            // `activeJoinUrl`, not `joinUrl`: an iCloud session dials a URL
-            // that never lands in the published field, and matching on the
-            // empty/stale one leaves the leader's own SLICC page in the cards.
+            // `activeJoinUrl`, never `joinUrl`: an iCloud session deliberately
+            // keeps its URL out of the published field (it carries the session
+            // secret), so matching on `joinUrl` left a launcher-published
+            // leader at 127.0.0.1 unrecognised and put its own SLICC page back
+            // in the cards. Falling back to `joinUrl` would be worse than
+            // nothing — a stale typed URL is not the one we dialled.
             remoteTargets = BrowserTargets.visible(
-                targets, ownRuntimeId: controllerId,
-                joinUrl: activeJoinUrl.isEmpty ? joinUrl : activeJoinUrl)
+                targets, ownRuntimeId: controllerId, joinUrl: activeJoinUrl)
 
         case .cdpResponse(
             let requestId, let result, let error, let chunkData, let chunkIndex,

--- a/packages/ios-app/SliccFollower/App/AppStateFrozenSessions.swift
+++ b/packages/ios-app/SliccFollower/App/AppStateFrozenSessions.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// The freezer rail: browsing and opening the leader's saved (frozen)
+/// sessions read-only.
+///
+/// Split out of `AppState` because the class had grown past its size budget
+/// and this is its most self-contained subsystem — it talks only to the VFS
+/// client and its own published state, never to the transport.
+extension AppState {
+
+    /// How the frozen-session list was (or failed to be) produced.
+    enum FrozenListState: Equatable {
+        case idle
+        case loading
+        /// `rebuilt` means /sessions/index.json was corrupt and the list came
+        /// from a /sessions directory scan instead.
+        case loaded(rebuilt: Bool)
+        case failed(String)
+    }
+
+    struct OpenFrozenSession {
+        let entry: FrozenSessionIndexEntry
+        let archive: ParsedFrozenArchive
+    }
+
+    /// Load `/sessions/index.json` from the leader's VFS. A corrupt index
+    /// self-heals from a `/sessions` directory scan; a missing sessions dir
+    /// is an empty rail, not an error.
+    func loadFrozenSessions() {
+        #if DEBUG
+            if let fixture = UITestHooks.frozenFixture() {
+                frozenSessions = fixture
+                frozenListState = .loaded(rebuilt: false)
+                return
+            }
+        #endif
+        guard connectionState == .connected else {
+            // The snowflake is always reachable; a stale list from a previous
+            // leader — or an eternal spinner from `.idle` — must not be.
+            frozenSessions = []
+            frozenListState = .failed("Connect to a leader to browse its past sessions.")
+            return
+        }
+        frozenListState = .loading
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let raw = try await self.fsClient.readFile(FrozenSessionIndex.indexPath)
+                if let entries = FrozenSessionIndex.parse(indexJson: raw) {
+                    self.frozenSessions = entries
+                    self.frozenListState = .loaded(rebuilt: false)
+                    return
+                }
+                // Corrupt or partially written index — rebuild from a scan.
+                try await self.rebuildFrozenList()
+            } catch {
+                // Missing index but present archives is the same self-heal
+                // path; a missing directory degrades to an empty rail.
+                do {
+                    try await self.rebuildFrozenList()
+                } catch {
+                    self.frozenSessions = []
+                    self.frozenListState = .loaded(rebuilt: false)
+                }
+            }
+        }
+    }
+
+    private func rebuildFrozenList() async throws {
+        let entries = try await fsClient.readDir(FrozenSessionIndex.sessionsDir)
+        frozenSessions = FrozenSessionIndex.rebuild(from: entries)
+        frozenListState = .loaded(rebuilt: true)
+    }
+
+    /// Open one archive read-only. Never logs the content; parse failures
+    /// surface on `frozenOpenError`.
+    func openFrozenSession(_ entry: FrozenSessionIndexEntry) {
+        frozenOpenError = nil
+        #if DEBUG
+            if let markdown = UITestHooks.frozenArchiveFixture(for: entry) {
+                openFrozen = OpenFrozenSession(
+                    entry: entry,
+                    archive: FrozenArchiveParser.withFallbackTimestamps(
+                        FrozenArchiveParser.parse(markdown: markdown),
+                        frozenAt: entry.frozenDate))
+                return
+            }
+        #endif
+        frozenOpeningId = entry.id
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.frozenOpeningId = nil }
+            do {
+                let markdown = try await self.fsClient.readFile(entry.path)
+                self.openFrozen = OpenFrozenSession(
+                    entry: entry,
+                    archive: FrozenArchiveParser.withFallbackTimestamps(
+                        FrozenArchiveParser.parse(markdown: markdown),
+                        frozenAt: entry.frozenDate))
+            } catch {
+                self.frozenOpenError =
+                    "Could not read “\(entry.title)” — it may have been removed on the leader."
+            }
+        }
+    }
+
+    func closeFrozenSession() {
+        openFrozen = nil
+    }
+}

--- a/packages/ios-app/SliccFollower/App/UITestHooks.swift
+++ b/packages/ios-app/SliccFollower/App/UITestHooks.swift
@@ -222,7 +222,7 @@ import UIKit
         }
 
         /// Open a workbench surface on launch
-        /// (`-uiTestOpenDockSurface term|files|memory|monitor|browser|new`)
+        /// (`-uiTestOpenDockSurface term|files|memory|monitor|browser`)
         /// so screenshots and UI tests reach the dock overlay without taps.
         static func opensDockSurface() -> DockSurface? {
             switch UserDefaults.standard.string(forKey: "uiTestOpenDockSurface") {
@@ -231,7 +231,6 @@ import UIKit
             case "term": return .term
             case "memory": return .memory
             case "monitor": return .monitor
-            case "new": return .newSprinkle
             default: return nil
             }
         }

--- a/packages/ios-app/SliccFollower/Models/BrowserTargets.swift
+++ b/packages/ios-app/SliccFollower/Models/BrowserTargets.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Which federated tabs the browser surface should list.
+///
+/// Pure so the rules are unit-testable without a leader (same reason
+/// `DockModel` is a pure builder).
+enum BrowserTargets {
+
+    /// Tabs worth showing as preview cards: everything the tray federates,
+    /// minus our own advertised targets (those are the live local carousel)
+    /// and minus the leader's own SLICC page.
+    static func visible(
+        _ targets: [TrayTargetEntry],
+        ownRuntimeId: String,
+        joinUrl: String
+    ) -> [TrayTargetEntry] {
+        targets.filter { target in
+            target.runtimeId != ownRuntimeId && !isSliccAppPage(target.url, joinUrl: joinUrl)
+        }
+    }
+
+    /// True for the page the leader itself runs in.
+    ///
+    /// It is federated like any other tab — the leader enumerates its whole
+    /// browser — but it is the app this follower is already attached to, not
+    /// something to browse. Matching is on scheme + host + path so the
+    /// per-session `?ws=…#tray=…` on the join URL never defeats it, and so a
+    /// genuine `sliccy.ai/docs/...` tab still lists.
+    static func isSliccAppPage(_ url: String, joinUrl: String) -> Bool {
+        guard let candidate = appIdentity(of: url) else { return false }
+        if let leader = appIdentity(of: joinUrl), candidate == leader { return true }
+        // A follower can dial in from a saved session whose join URL has since
+        // been cleared, so fall back to the hosted origin's app shell.
+        return hostedAppShells.contains(candidate)
+    }
+
+    /// `scheme://host[:port]/path` with the query, fragment, trailing slash
+    /// and an explicit `index.html` removed.
+    private static func appIdentity(of raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let components = URLComponents(string: trimmed),
+            let host = components.host?.lowercased(), !host.isEmpty
+        else { return nil }
+        let scheme = (components.scheme ?? "https").lowercased()
+        var authority = host
+        if let port = components.port { authority += ":\(port)" }
+        var path = components.path.lowercased()
+        if path.hasSuffix("/index.html") { path.removeLast("index.html".count) }
+        while path.hasSuffix("/") { path.removeLast() }
+        return "\(scheme)://\(authority)\(path)"
+    }
+
+    /// The hosted leader's app shell, in the forms the origin serves it.
+    private static let hostedAppShells: Set<String> = [
+        "https://sliccy.ai",
+        "https://www.sliccy.ai",
+    ]
+}

--- a/packages/ios-app/SliccFollower/Models/DictationPriming.swift
+++ b/packages/ios-app/SliccFollower/Models/DictationPriming.swift
@@ -42,7 +42,7 @@ enum DictationPriming {
         options: .caseInsensitive)
 
     /// Append the dictation markers. Pure — callers drive the "is first?"
-    /// decision via ``consumeFirst()`` so this stays unit-testable.
+    /// decision via ``isFirstPending`` so this stays unit-testable.
     static func applyMarkers(_ text: String, isFirst: Bool) -> String {
         let base = text.hasSuffix(" ") ? text : "\(text) "
         return isFirst ? "\(base)\(micGlyph)\(primingNote)" : "\(base)\(micGlyph)"
@@ -78,12 +78,16 @@ enum DictationPriming {
 
     private static var firstPending = true
 
-    /// One-shot "is this the first dictated turn?" check. True ONCE per
-    /// session (until the next reset); every later dictated turn gets false.
-    static func consumeFirst() -> Bool {
-        guard firstPending else { return false }
+    /// Whether the next dictated turn still owes the priming note. Read-only
+    /// so a caller can build the marked text BEFORE it knows the send will
+    /// succeed; `commitFirst()` is what actually spends the flag.
+    static var isFirstPending: Bool { firstPending }
+
+    /// Spend the one-time flag. Called only once a dictated message has
+    /// actually reached the leader — a failed send must leave the note armed
+    /// for the next attempt, or the session silently loses its priming.
+    static func commitFirst() {
         firstPending = false
-        return true
     }
 
     /// Re-arm the flag so a fresh session sends the priming note again.

--- a/packages/ios-app/SliccFollower/Models/DictationPriming.swift
+++ b/packages/ios-app/SliccFollower/Models/DictationPriming.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Per-session dictation priming — the Swift twin of
+/// `packages/webapp/src/speech/dictation-priming.ts`.
+///
+/// A turn submitted by push-to-talk carries AI-only markers so the model
+/// tolerates transcription noise and answers in a speakable way, without
+/// polluting the user-visible transcript:
+///
+/// - 🎙️ on EVERY dictated message.
+/// - `◁ … ▷` wrapping a one-time priming note on the FIRST dictated turn of
+///   a session.
+///
+/// The marked text is what gets stored AND sent, so replay and compaction
+/// keep the context; the UI strips markers at render time.
+enum DictationPriming {
+
+    /// The one-time note, wrapped in ◁ … ▷ on the first dictated turn. Kept
+    /// character-for-character in sync with the webapp so the phone and the
+    /// browser prime the same model the same way.
+    static let primingNote =
+        "◁This message has been sent through text to speech, consider possible "
+        + "phonetic alternatives and transcription errors. Future dictated messages "
+        + "will have the 🎙️ emoji appended. Your responses to dictated messages "
+        + "will be read out loud, avoid urls, acronyms, numbers, formatting. Begin "
+        + "every reply with the language you are replying in as a hidden HTML "
+        + "comment, e.g. <!--lang:en--> for English or <!--lang:de--> for German; "
+        + "it stays hidden from the user and selects a matching voice▷"
+
+    static let micGlyph = "\u{1F399}\u{FE0F}"
+
+    /// Any ◁ … ▷ region (non-greedy, newline tolerant).
+    private static let noteRegex = try? NSRegularExpression(
+        pattern: "\u{25C1}[\\s\\S]*?\u{25B7}")
+    /// Microphone glyph, with or without the VS16 variation selector.
+    private static let micRegex = try? NSRegularExpression(
+        pattern: "\u{1F399}\u{FE0F}?")
+    /// The hidden reply-language marker, e.g. `<!--lang:de-->`; group 1 is
+    /// the BCP-47 tag.
+    private static let replyLangRegex = try? NSRegularExpression(
+        pattern: "<!--\\s*lang:\\s*([A-Za-z]{2,3}(?:-[A-Za-z0-9]{1,8})*)\\s*-->",
+        options: .caseInsensitive)
+
+    /// Append the dictation markers. Pure — callers drive the "is first?"
+    /// decision via ``consumeFirst()`` so this stays unit-testable.
+    static func applyMarkers(_ text: String, isFirst: Bool) -> String {
+        let base = text.hasSuffix(" ") ? text : "\(text) "
+        return isFirst ? "\(base)\(micGlyph)\(primingNote)" : "\(base)\(micGlyph)"
+    }
+
+    /// Remove every dictation marker and trailing whitespace. Defensive: a
+    /// message that is only markers yields the empty string.
+    static func stripMarkers(_ text: String) -> String {
+        var out = replaceAll(noteRegex, in: text, with: "")
+        out = replaceAll(micRegex, in: out, with: "")
+        while let last = out.last, last == " " || last == "\t" || last.isNewline {
+            out.removeLast()
+        }
+        return out
+    }
+
+    /// The agent's declared reply language, or nil when it emitted none.
+    static func replyLang(_ text: String) -> String? {
+        guard let regex = replyLangRegex else { return nil }
+        let range = NSRange(text.startIndex..., in: text)
+        guard let match = regex.firstMatch(in: text, range: range),
+            let tagRange = Range(match.range(at: 1), in: text)
+        else { return nil }
+        return String(text[tagRange])
+    }
+
+    /// Remove every `<!--lang:xx-->` marker so it never reaches a bubble.
+    static func stripReplyLangMarker(_ text: String) -> String {
+        replaceAll(replyLangRegex, in: text, with: "")
+    }
+
+    // MARK: - Per-session first-turn flag
+
+    private static var firstPending = true
+
+    /// One-shot "is this the first dictated turn?" check. True ONCE per
+    /// session (until the next reset); every later dictated turn gets false.
+    static func consumeFirst() -> Bool {
+        guard firstPending else { return false }
+        firstPending = false
+        return true
+    }
+
+    /// Re-arm the flag so a fresh session sends the priming note again.
+    static func reset() {
+        firstPending = true
+    }
+
+    private static func replaceAll(
+        _ regex: NSRegularExpression?, in text: String, with template: String
+    ) -> String {
+        guard let regex else { return text }
+        return regex.stringByReplacingMatches(
+            in: text, range: NSRange(text.startIndex..., in: text), withTemplate: template)
+    }
+}

--- a/packages/ios-app/SliccFollower/Models/MarkdownBlock.swift
+++ b/packages/ios-app/SliccFollower/Models/MarkdownBlock.swift
@@ -1,0 +1,433 @@
+import Foundation
+
+// MARK: - Block model
+
+/// One rendered block of leader markdown. `MarkdownText` owns the SwiftUI
+/// side; the split keeps the block grammar unit-testable without a view
+/// host (same reason `DockModel` is a pure builder).
+enum MarkdownBlock: Equatable {
+    case paragraph(String)
+    case heading(level: Int, text: String)
+    case blockquote(String)
+    case codeBlock(language: String?, code: String)
+    case list(MarkdownList)
+    case table(MarkdownTable)
+    case thematicBreak
+}
+
+/// A bullet or ordered list. Loose nesting only: every item carries its own
+/// depth rather than owning children, which is enough for the flat
+/// indent-and-marker rendering the transcript needs and avoids a recursive
+/// parse the leader's output never exercises.
+struct MarkdownList: Equatable {
+    struct Item: Equatable {
+        /// 0-based nesting level (two spaces or one tab per level).
+        let depth: Int
+        /// Rendered bullet/number, already resolved (`•`, `◦`, `1.`).
+        let marker: String
+        /// Inline markdown for the item body.
+        let text: String
+    }
+
+    let ordered: Bool
+    let items: [Item]
+}
+
+/// A GitHub-flavored pipe table.
+struct MarkdownTable: Equatable {
+    enum Alignment: Equatable {
+        case leading
+        case center
+        case trailing
+    }
+
+    let header: [String]
+    let alignments: [Alignment]
+    let rows: [[String]]
+
+    var columnCount: Int { header.count }
+}
+
+// MARK: - Parser
+
+/// Block-level markdown grammar for the transcript.
+///
+/// `AttributedString(markdown:)` is inline-only in the configuration we use
+/// (`.inlineOnlyPreservingWhitespace`), so every block construct has to be
+/// recognised here or it reaches the screen as its literal source — which is
+/// how comparison tables arrived as raw `| … | … |` rows.
+enum MarkdownBlockParser {
+
+    static func parse(_ content: String) -> [MarkdownBlock] {
+        var blocks: [MarkdownBlock] = []
+        let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+
+        var paragraph: [String] = []
+        var quote: [String] = []
+        var listBuffer: [MarkdownList.Item] = []
+        var listOrdered = false
+        var index = 0
+
+        func flushParagraph() {
+            let joined = paragraph.joined(separator: "\n").trimmingCharacters(
+                in: .whitespacesAndNewlines)
+            if !joined.isEmpty { blocks.append(.paragraph(joined)) }
+            paragraph = []
+        }
+        func flushQuote() {
+            guard !quote.isEmpty else { return }
+            let body = quote.map(stripQuoteMarker).joined(separator: "\n")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !body.isEmpty { blocks.append(.blockquote(body)) }
+            quote = []
+        }
+        func flushList() {
+            guard !listBuffer.isEmpty else { return }
+            blocks.append(.list(MarkdownList(ordered: listOrdered, items: listBuffer)))
+            listBuffer = []
+        }
+        func flushAll() {
+            flushQuote()
+            flushList()
+            flushParagraph()
+        }
+
+        while index < lines.count {
+            let line = lines[index]
+
+            if isFence(line) {
+                flushAll()
+                let language = fenceLanguage(line)
+                var code: [String] = []
+                index += 1
+                while index < lines.count, !isFence(lines[index]) {
+                    code.append(lines[index])
+                    index += 1
+                }
+                // An unclosed fence still renders as code — better than
+                // spilling the rest of the turn as prose.
+                blocks.append(.codeBlock(language: language, code: code.joined(separator: "\n")))
+                index += 1
+                continue
+            }
+
+            if isThematicBreak(line) {
+                flushAll()
+                blocks.append(.thematicBreak)
+                index += 1
+                continue
+            }
+
+            if let heading = parseAtxHeading(line) {
+                flushAll()
+                blocks.append(.heading(level: heading.level, text: heading.text))
+                index += 1
+                continue
+            }
+
+            if let table = parseTable(lines, startingAt: index), table.consumed > 0 {
+                flushAll()
+                blocks.append(.table(table.table))
+                index += table.consumed
+                continue
+            }
+
+            if line.trimmingCharacters(in: .whitespaces).hasPrefix(">") {
+                flushList()
+                flushParagraph()
+                quote.append(line)
+                index += 1
+                continue
+            }
+
+            if let item = parseListItem(line) {
+                flushQuote()
+                flushParagraph()
+                // A bullet list interrupting an ordered one (or vice versa)
+                // is a new list, not a continuation.
+                if !listBuffer.isEmpty && listOrdered != item.ordered { flushList() }
+                listOrdered = item.ordered
+                listBuffer.append(item.item)
+                index += 1
+                continue
+            }
+
+            flushQuote()
+            if !listBuffer.isEmpty {
+                // A blank line inside a list keeps the list open; anything
+                // else ends it.
+                if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                    index += 1
+                    continue
+                }
+                flushList()
+            }
+            paragraph.append(line)
+            index += 1
+        }
+
+        flushAll()
+        return blocks
+    }
+
+    // MARK: - Fences
+
+    private static func isFence(_ line: String) -> Bool {
+        line.trimmingCharacters(in: .whitespaces).hasPrefix("```")
+    }
+
+    /// The info string of an opening fence (```` ```swift ````), `nil` for a
+    /// bare fence.
+    private static func fenceLanguage(_ line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        let language = String(trimmed.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+        return language.isEmpty ? nil : language
+    }
+
+    // MARK: - Thematic break
+
+    /// `---`, `***`, `___` (3+ of one marker, spaces allowed between). Must
+    /// not swallow a table delimiter row, which always carries a pipe.
+    static func isThematicBreak(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.count >= 3, !trimmed.contains("|") else { return false }
+        guard let marker = trimmed.first, marker == "-" || marker == "*" || marker == "_" else {
+            return false
+        }
+        var count = 0
+        for char in trimmed {
+            if char == marker {
+                count += 1
+            } else if char != " " {
+                return false
+            }
+        }
+        return count >= 3
+    }
+
+    // MARK: - Blockquote
+
+    private static func stripQuoteMarker(_ line: String) -> String {
+        var body = line.trimmingCharacters(in: .whitespaces)
+        if body.hasPrefix(">") { body.removeFirst() }
+        if body.hasPrefix(" ") { body.removeFirst() }
+        return body
+    }
+
+    // MARK: - Lists
+
+    /// `- item`, `* item`, `+ item`, `1. item`, `1) item`, with two spaces (or
+    /// one tab) per nesting level.
+    static func parseListItem(_ line: String) -> (item: MarkdownList.Item, ordered: Bool)? {
+        var indent = 0
+        var cursor = line.startIndex
+        while cursor < line.endIndex, line[cursor] == " " || line[cursor] == "\t" {
+            indent += line[cursor] == "\t" ? 4 : 1
+            cursor = line.index(after: cursor)
+        }
+        guard cursor < line.endIndex else { return nil }
+        let depth = min(indent / 2, 3)
+
+        // Bullet: exactly one marker char followed by a space.
+        if line[cursor] == "-" || line[cursor] == "*" || line[cursor] == "+" {
+            let afterMarker = line.index(after: cursor)
+            guard afterMarker < line.endIndex, line[afterMarker] == " " else { return nil }
+            let body = String(line[line.index(after: afterMarker)...]).trimmingCharacters(
+                in: .whitespaces)
+            guard !body.isEmpty else { return nil }
+            return (
+                MarkdownList.Item(depth: depth, marker: bullet(for: depth), text: body),
+                false
+            )
+        }
+
+        // Ordered: up to 9 digits, then `.` or `)`, then a space.
+        var digits = ""
+        var scan = cursor
+        while scan < line.endIndex, line[scan].isNumber, digits.count < 9 {
+            digits.append(line[scan])
+            scan = line.index(after: scan)
+        }
+        guard !digits.isEmpty, scan < line.endIndex, line[scan] == "." || line[scan] == ")" else {
+            return nil
+        }
+        let afterDelimiter = line.index(after: scan)
+        guard afterDelimiter < line.endIndex, line[afterDelimiter] == " " else { return nil }
+        let body = String(line[line.index(after: afterDelimiter)...]).trimmingCharacters(
+            in: .whitespaces)
+        guard !body.isEmpty else { return nil }
+        // The author's own numbering wins: a list that starts at 3 renders
+        // as 3, matching every other markdown surface in the tray.
+        return (
+            MarkdownList.Item(depth: depth, marker: "\(digits).", text: body),
+            true
+        )
+    }
+
+    private static func bullet(for depth: Int) -> String {
+        switch depth {
+        case 0: return "•"
+        case 1: return "◦"
+        default: return "▪"
+        }
+    }
+
+    // MARK: - Tables
+
+    /// Parse a GFM pipe table starting at `start`. Returns `nil` when the two
+    /// lines there are not a header + delimiter pair.
+    static func parseTable(_ lines: [String], startingAt start: Int)
+        -> (table: MarkdownTable, consumed: Int)?
+    {
+        guard start + 1 < lines.count else { return nil }
+        let headerLine = lines[start]
+        let delimiterLine = lines[start + 1]
+        guard headerLine.contains("|"), let alignments = parseDelimiterRow(delimiterLine) else {
+            return nil
+        }
+        let header = splitRow(headerLine)
+        guard !header.isEmpty, header.count == alignments.count else { return nil }
+
+        var rows: [[String]] = []
+        var cursor = start + 2
+        while cursor < lines.count {
+            let line = lines[cursor]
+            guard line.contains("|"), !line.trimmingCharacters(in: .whitespaces).isEmpty else {
+                break
+            }
+            // A second delimiter row is not a body row.
+            if parseDelimiterRow(line) != nil { break }
+            var cells = splitRow(line)
+            if cells.count < header.count {
+                cells.append(contentsOf: Array(repeating: "", count: header.count - cells.count))
+            } else if cells.count > header.count {
+                cells = Array(cells.prefix(header.count))
+            }
+            rows.append(cells)
+            cursor += 1
+        }
+
+        return (
+            MarkdownTable(header: header, alignments: alignments, rows: rows),
+            cursor - start
+        )
+    }
+
+    /// `|---|:--:|---:|` → per-column alignment. `nil` when any cell is not a
+    /// dash run, which is what separates a table from a paragraph of pipes.
+    private static func parseDelimiterRow(_ line: String) -> [MarkdownTable.Alignment]? {
+        guard line.contains("|"), line.contains("-") else { return nil }
+        let cells = splitRow(line)
+        guard !cells.isEmpty else { return nil }
+        var alignments: [MarkdownTable.Alignment] = []
+        for cell in cells {
+            let trimmed = cell.trimmingCharacters(in: .whitespaces)
+            let leadingColon = trimmed.hasPrefix(":")
+            let trailingColon = trimmed.hasSuffix(":") && trimmed.count > 1
+            var dashes = trimmed
+            if leadingColon { dashes.removeFirst() }
+            if trailingColon { dashes.removeLast() }
+            guard !dashes.isEmpty, dashes.allSatisfy({ $0 == "-" }) else { return nil }
+            if leadingColon && trailingColon {
+                alignments.append(.center)
+            } else if trailingColon {
+                alignments.append(.trailing)
+            } else {
+                alignments.append(.leading)
+            }
+        }
+        return alignments
+    }
+
+    /// Split one table row into trimmed cells, honoring `\|` escapes and
+    /// dropping the optional outer pipes.
+    static func splitRow(_ line: String) -> [String] {
+        var cells: [String] = []
+        var current = ""
+        var escaped = false
+        for char in line.trimmingCharacters(in: .whitespaces) {
+            if escaped {
+                current.append(char == "|" ? "|" : "\\\(char)")
+                escaped = false
+                continue
+            }
+            if char == "\\" {
+                escaped = true
+                continue
+            }
+            if char == "|" {
+                cells.append(current)
+                current = ""
+                continue
+            }
+            current.append(char)
+        }
+        if escaped { current.append("\\") }
+        cells.append(current)
+        // Outer pipes produce empty edge cells; a genuinely empty first or
+        // last column would have been written as `| |`.
+        if let first = cells.first, first.trimmingCharacters(in: .whitespaces).isEmpty {
+            cells.removeFirst()
+        }
+        if let last = cells.last, last.trimmingCharacters(in: .whitespaces).isEmpty {
+            cells.removeLast()
+        }
+        return cells.map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    // MARK: - Headings
+
+    /// Parse a leading `# … ######` ATX heading. Returns nil for lines that
+    /// aren't headings (so callers fall through to plain text).
+    ///
+    /// Follows CommonMark's ATX-heading rules:
+    /// - 0-3 leading spaces are allowed (4+ → indented code block, not heading).
+    /// - The opening `#` run must be followed by whitespace or end-of-line.
+    /// - A trailing `#` run is only treated as a closing sequence when it's
+    ///   preceded by whitespace; e.g. `# C#` keeps the `#` as part of the
+    ///   title, while `# Heading ##` strips the closing `##`.
+    static func parseAtxHeading(_ line: String) -> (level: Int, text: String)? {
+        var leadingSpaces = 0
+        var cursor = line.startIndex
+        while cursor < line.endIndex, line[cursor] == " ", leadingSpaces < 4 {
+            leadingSpaces += 1
+            cursor = line.index(after: cursor)
+        }
+        guard leadingSpaces < 4 else { return nil }
+        let trimmed = line[cursor...]
+        guard trimmed.first == "#" else { return nil }
+        var level = 0
+        var index = trimmed.startIndex
+        while index < trimmed.endIndex, trimmed[index] == "#", level < 6 {
+            level += 1
+            index = trimmed.index(after: index)
+        }
+        guard level >= 1 else { return nil }
+        if index == trimmed.endIndex { return (level, "") }
+        guard trimmed[index] == " " || trimmed[index] == "\t" else { return nil }
+        let rawText = String(trimmed[index...])
+        var endIndex = rawText.endIndex
+        while endIndex > rawText.startIndex,
+            rawText[rawText.index(before: endIndex)] == " "
+                || rawText[rawText.index(before: endIndex)] == "\t"
+        {
+            endIndex = rawText.index(before: endIndex)
+        }
+        var hashStart = endIndex
+        while hashStart > rawText.startIndex, rawText[rawText.index(before: hashStart)] == "#" {
+            hashStart = rawText.index(before: hashStart)
+        }
+        let hadTrailingHashes = hashStart < endIndex
+        let bodyEnd: String.Index
+        if hadTrailingHashes,
+            hashStart == rawText.startIndex
+                || rawText[rawText.index(before: hashStart)] == " "
+                || rawText[rawText.index(before: hashStart)] == "\t"
+        {
+            bodyEnd = hashStart
+        } else {
+            bodyEnd = endIndex
+        }
+        return (level, String(rawText[rawText.startIndex..<bodyEnd]).trimmingCharacters(in: .whitespaces))
+    }
+}

--- a/packages/ios-app/SliccFollower/Models/SVGPath.swift
+++ b/packages/ios-app/SliccFollower/Models/SVGPath.swift
@@ -1,0 +1,403 @@
+import CoreGraphics
+import Foundation
+
+/// Minimal SVG path-data parser (`d` attribute) → `CGPath`.
+///
+/// Exists so lucide glyphs can be ported into the app as their literal
+/// upstream path strings instead of being re-approximated by whichever SF
+/// Symbol looks closest. The web UI renders lucide for every glyph
+/// (`packages/webcomponents/src/internal/icons.ts`), and SF Symbols has no
+/// ice cream cone at all — the cone, the product's central metaphor, was
+/// standing in as a teacup.
+///
+/// Supports the command set lucide actually emits: `M m L l H h V v C c S s
+/// Q q T t A a Z z`. Unknown commands abort the parse and yield whatever was
+/// built so far, so a bad glyph is a missing glyph, never a crash.
+enum SVGPath {
+
+    /// Parse `d` and scale the result from `viewBox`×`viewBox` into `rect`,
+    /// preserving aspect ratio and centering the remainder.
+    static func path(from data: String, viewBox: CGFloat = 24, in rect: CGRect) -> CGPath {
+        fitted(parse(data), viewBox: viewBox, in: rect)
+    }
+
+    /// Scale an already-parsed path from `viewBox`×`viewBox` into `rect`.
+    /// Split out because `Shape.path(in:)` runs on every layout pass, so
+    /// glyph parsing has to happen once and only the transform per frame.
+    static func fitted(_ path: CGPath, viewBox: CGFloat = 24, in rect: CGRect) -> CGPath {
+        let scale = min(rect.width, rect.height) / viewBox
+        var transform = CGAffineTransform(
+            translationX: rect.minX + (rect.width - viewBox * scale) / 2,
+            y: rect.minY + (rect.height - viewBox * scale) / 2
+        )
+        .scaledBy(x: scale, y: scale)
+        return path.copy(using: &transform) ?? path
+    }
+
+    /// Parse `d` in its own coordinate space.
+    static func parse(_ data: String) -> CGPath {
+        let path = CGMutablePath()
+        var tokens = Tokenizer(data)
+        var pen = Pen()
+        var command: Character?
+        while let cmd = nextCommand(&tokens, after: command) {
+            command = cmd
+            guard apply(cmd, &tokens, &pen, to: path) else { break }
+            if tokens.atEnd { break }
+        }
+        return path
+    }
+
+    /// The pen state threaded through every command.
+    private struct Pen {
+        var current = CGPoint.zero
+        var subpathStart = CGPoint.zero
+        /// Reflection anchors for smooth curves (`S`/`T`); nil means the
+        /// reflection collapses to the current point, per the SVG spec.
+        var lastCubicControl: CGPoint?
+        var lastQuadControl: CGPoint?
+
+        func point(_ x: CGFloat, _ y: CGFloat, relative: Bool) -> CGPoint {
+            relative ? CGPoint(x: current.x + x, y: current.y + y) : CGPoint(x: x, y: y)
+        }
+
+        /// Every command except `S`/`T` clears the smooth-curve anchors.
+        mutating func clearReflections() {
+            lastCubicControl = nil
+            lastQuadControl = nil
+        }
+    }
+
+    /// Which command the next operands belong to: an explicit letter, or the
+    /// implicit repeat of the previous one (`M 0 0 4 0 4 4` is a moveto plus
+    /// two linetos).
+    private static func nextCommand(
+        _ tokens: inout Tokenizer, after previous: Character?
+    ) -> Character? {
+        if let next = tokens.peekCommand() {
+            tokens.advanceCommand()
+            return next
+        }
+        guard !tokens.atEnd, let previous else { return nil }
+        switch previous {
+        case "M": return "L"
+        case "m": return "l"
+        // `Z` consumes no operands, so repeating it would spin forever.
+        case "Z", "z": return nil
+        default: return previous
+        }
+    }
+
+    /// Returns false when the operands ran out or the command is unknown —
+    /// a malformed glyph then renders as far as it parsed.
+    private static func apply(
+        _ cmd: Character, _ tokens: inout Tokenizer, _ pen: inout Pen, to path: CGMutablePath
+    ) -> Bool {
+        switch cmd {
+        case "M", "m", "L", "l", "H", "h", "V", "v":
+            return applyStraight(cmd, &tokens, &pen, to: path)
+        case "C", "c", "S", "s", "Q", "q", "T", "t":
+            return applyCurve(cmd, &tokens, &pen, to: path)
+        case "A", "a":
+            return applyArc(cmd, &tokens, &pen, to: path)
+        case "Z", "z":
+            if !path.isEmpty { path.closeSubpath() }
+            pen.current = pen.subpathStart
+            pen.clearReflections()
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func applyStraight(
+        _ cmd: Character, _ tokens: inout Tokenizer, _ pen: inout Pen, to path: CGMutablePath
+    ) -> Bool {
+        let relative = cmd.isLowercase
+        switch cmd {
+        case "H", "h":
+            guard let x = tokens.number() else { return false }
+            pen.current = CGPoint(x: relative ? pen.current.x + x : x, y: pen.current.y)
+        case "V", "v":
+            guard let y = tokens.number() else { return false }
+            pen.current = CGPoint(x: pen.current.x, y: relative ? pen.current.y + y : y)
+        default:
+            guard let x = tokens.number(), let y = tokens.number() else { return false }
+            pen.current = pen.point(x, y, relative: relative)
+        }
+        if cmd == "M" || cmd == "m" {
+            pen.subpathStart = pen.current
+            path.move(to: pen.current)
+        } else {
+            path.addLine(to: pen.current)
+        }
+        pen.clearReflections()
+        return true
+    }
+
+    private static func applyCurve(
+        _ cmd: Character, _ tokens: inout Tokenizer, _ pen: inout Pen, to path: CGMutablePath
+    ) -> Bool {
+        let relative = cmd.isLowercase
+        switch cmd {
+        case "C", "c":
+            guard let x1 = tokens.number(), let y1 = tokens.number(),
+                let x2 = tokens.number(), let y2 = tokens.number(),
+                let x = tokens.number(), let y = tokens.number()
+            else { return false }
+            addCubic(
+                pen.point(x1, y1, relative: relative), pen.point(x2, y2, relative: relative),
+                pen.point(x, y, relative: relative), &pen, to: path)
+        case "S", "s":
+            guard let x2 = tokens.number(), let y2 = tokens.number(),
+                let x = tokens.number(), let y = tokens.number()
+            else { return false }
+            addCubic(
+                reflect(pen.lastCubicControl, about: pen.current),
+                pen.point(x2, y2, relative: relative),
+                pen.point(x, y, relative: relative), &pen, to: path)
+        case "Q", "q":
+            guard let x1 = tokens.number(), let y1 = tokens.number(),
+                let x = tokens.number(), let y = tokens.number()
+            else { return false }
+            addQuad(
+                pen.point(x1, y1, relative: relative),
+                pen.point(x, y, relative: relative), &pen, to: path)
+        default:
+            guard let x = tokens.number(), let y = tokens.number() else { return false }
+            addQuad(
+                reflect(pen.lastQuadControl, about: pen.current),
+                pen.point(x, y, relative: relative), &pen, to: path)
+        }
+        return true
+    }
+
+    private static func addCubic(
+        _ control1: CGPoint, _ control2: CGPoint, _ end: CGPoint, _ pen: inout Pen,
+        to path: CGMutablePath
+    ) {
+        pen.current = end
+        path.addCurve(to: end, control1: control1, control2: control2)
+        pen.clearReflections()
+        pen.lastCubicControl = control2
+    }
+
+    private static func addQuad(
+        _ control: CGPoint, _ end: CGPoint, _ pen: inout Pen, to path: CGMutablePath
+    ) {
+        pen.current = end
+        path.addQuadCurve(to: end, control: control)
+        pen.clearReflections()
+        pen.lastQuadControl = control
+    }
+
+    private static func applyArc(
+        _ cmd: Character, _ tokens: inout Tokenizer, _ pen: inout Pen, to path: CGMutablePath
+    ) -> Bool {
+        guard let rx = tokens.number(), let ry = tokens.number(),
+            let rotation = tokens.number(), let largeArc = tokens.flag(),
+            let sweep = tokens.flag(), let x = tokens.number(), let y = tokens.number()
+        else { return false }
+        let end = pen.point(x, y, relative: cmd.isLowercase)
+        appendArc(
+            to: path, from: pen.current, to: end, rx: rx, ry: ry,
+            xRotationDegrees: rotation, largeArc: largeArc, sweep: sweep)
+        pen.current = end
+        pen.clearReflections()
+        return true
+    }
+
+    private static func reflect(_ control: CGPoint?, about current: CGPoint) -> CGPoint {
+        guard let control else { return current }
+        return CGPoint(x: 2 * current.x - control.x, y: 2 * current.y - control.y)
+    }
+
+    // MARK: - Elliptical arcs
+
+    /// Endpoint → center parameterization (SVG spec F.6.5), then one cubic
+    /// per ≤90° slice. Hand-converting lucide's arcs was the alternative;
+    /// this keeps the upstream `d` strings pasteable verbatim.
+    private static func appendArc(
+        to path: CGMutablePath,
+        from start: CGPoint,
+        to end: CGPoint,
+        rx: CGFloat,
+        ry: CGFloat,
+        xRotationDegrees: CGFloat,
+        largeArc: Bool,
+        sweep: Bool
+    ) {
+        // Degenerate radii mean a straight line, per the spec.
+        var rx = abs(rx)
+        var ry = abs(ry)
+        guard rx > 0, ry > 0, start != end else {
+            path.addLine(to: end)
+            return
+        }
+        // `addCurve` needs a current point; an arc that opens a subpath is
+        // malformed but must not trap.
+        if path.isEmpty { path.move(to: start) }
+
+        let phi = xRotationDegrees * .pi / 180
+        let cosPhi = cos(phi)
+        let sinPhi = sin(phi)
+
+        let dx2 = (start.x - end.x) / 2
+        let dy2 = (start.y - end.y) / 2
+        let x1p = cosPhi * dx2 + sinPhi * dy2
+        let y1p = -sinPhi * dx2 + cosPhi * dy2
+
+        // Scale up radii that are too small to span the chord (F.6.6).
+        let lambda = (x1p * x1p) / (rx * rx) + (y1p * y1p) / (ry * ry)
+        if lambda > 1 {
+            let scale = sqrt(lambda)
+            rx *= scale
+            ry *= scale
+        }
+
+        let sign: CGFloat = largeArc == sweep ? -1 : 1
+        let numerator = max(
+            0, rx * rx * ry * ry - rx * rx * y1p * y1p - ry * ry * x1p * x1p)
+        let denominator = rx * rx * y1p * y1p + ry * ry * x1p * x1p
+        let coefficient = denominator == 0 ? 0 : sign * sqrt(numerator / denominator)
+        let cxp = coefficient * rx * y1p / ry
+        let cyp = -coefficient * ry * x1p / rx
+
+        let cx = cosPhi * cxp - sinPhi * cyp + (start.x + end.x) / 2
+        let cy = sinPhi * cxp + cosPhi * cyp + (start.y + end.y) / 2
+
+        func angle(_ ux: CGFloat, _ uy: CGFloat, _ vx: CGFloat, _ vy: CGFloat) -> CGFloat {
+            let dot = ux * vx + uy * vy
+            let len = sqrt(ux * ux + uy * uy) * sqrt(vx * vx + vy * vy)
+            guard len > 0 else { return 0 }
+            let value = min(1, max(-1, dot / len))
+            let result = acos(value)
+            return (ux * vy - uy * vx) < 0 ? -result : result
+        }
+
+        let startVectorX = (x1p - cxp) / rx
+        let startVectorY = (y1p - cyp) / ry
+        let endVectorX = (-x1p - cxp) / rx
+        let endVectorY = (-y1p - cyp) / ry
+        let theta1 = angle(1, 0, startVectorX, startVectorY)
+        var delta = angle(startVectorX, startVectorY, endVectorX, endVectorY)
+        if !sweep, delta > 0 {
+            delta -= 2 * .pi
+        } else if sweep, delta < 0 {
+            delta += 2 * .pi
+        }
+
+        let segments = max(1, Int(ceil(abs(delta) / (.pi / 2))))
+        let step = delta / CGFloat(segments)
+        // Standard cubic approximation constant for a circular arc slice.
+        let alpha = 4.0 / 3.0 * tan(step / 4)
+
+        var theta = theta1
+        for _ in 0..<segments {
+            let cosTheta1 = cos(theta)
+            let sinTheta1 = sin(theta)
+            let theta2 = theta + step
+            let cosTheta2 = cos(theta2)
+            let sinTheta2 = sin(theta2)
+
+            func map(_ x: CGFloat, _ y: CGFloat) -> CGPoint {
+                CGPoint(
+                    x: cx + cosPhi * rx * x - sinPhi * ry * y,
+                    y: cy + sinPhi * rx * x + cosPhi * ry * y)
+            }
+
+            let point2 = map(cosTheta2, sinTheta2)
+            let control1 = map(
+                cosTheta1 - alpha * sinTheta1, sinTheta1 + alpha * cosTheta1)
+            let control2 = map(
+                cosTheta2 + alpha * sinTheta2, sinTheta2 - alpha * cosTheta2)
+            path.addCurve(to: point2, control1: control1, control2: control2)
+            theta = theta2
+        }
+    }
+
+    // MARK: - Tokenizer
+
+    /// Scans a `d` string. SVG path data allows commas, arbitrary whitespace,
+    /// implicit `+`/`-` separators and exponent notation, so hand-splitting
+    /// on whitespace is not enough.
+    private struct Tokenizer {
+        private let scalars: [Character]
+        private var index: Int = 0
+
+        init(_ data: String) {
+            scalars = Array(data)
+        }
+
+        var atEnd: Bool {
+            var probe = index
+            while probe < scalars.count, isSeparator(scalars[probe]) { probe += 1 }
+            return probe >= scalars.count
+        }
+
+        private func isSeparator(_ char: Character) -> Bool {
+            char == " " || char == "," || char == "\n" || char == "\t" || char == "\r"
+        }
+
+        private mutating func skipSeparators() {
+            while index < scalars.count, isSeparator(scalars[index]) { index += 1 }
+        }
+
+        mutating func peekCommand() -> Character? {
+            skipSeparators()
+            guard index < scalars.count else { return nil }
+            let char = scalars[index]
+            return "MmLlHhVvCcSsQqTtAaZz".contains(char) ? char : nil
+        }
+
+        mutating func advanceCommand() {
+            index += 1
+        }
+
+        /// Arc flags are single characters and may be written unseparated
+        /// (`a1 1 0 1 1 …` and `a1 1 0 11 …` are both legal).
+        mutating func flag() -> Bool? {
+            skipSeparators()
+            guard index < scalars.count else { return nil }
+            let char = scalars[index]
+            guard char == "0" || char == "1" else { return nil }
+            index += 1
+            return char == "1"
+        }
+
+        mutating func number() -> CGFloat? {
+            skipSeparators()
+            guard index < scalars.count else { return nil }
+            var text = ""
+            if scalars[index] == "-" || scalars[index] == "+" {
+                text.append(scalars[index])
+                index += 1
+            }
+            var sawDigit = false
+            var sawDot = false
+            while index < scalars.count {
+                let char = scalars[index]
+                if char.isNumber {
+                    sawDigit = true
+                } else if char == ".", !sawDot {
+                    sawDot = true
+                } else if char == "e" || char == "E", sawDigit {
+                    // Exponent: consume it plus an optional sign.
+                    text.append(char)
+                    index += 1
+                    if index < scalars.count, scalars[index] == "-" || scalars[index] == "+" {
+                        text.append(scalars[index])
+                        index += 1
+                    }
+                    continue
+                } else {
+                    break
+                }
+                text.append(char)
+                index += 1
+            }
+            guard sawDigit, let value = Double(text) else { return nil }
+            return CGFloat(value)
+        }
+    }
+}

--- a/packages/ios-app/SliccFollower/Models/VoiceReply.swift
+++ b/packages/ios-app/SliccFollower/Models/VoiceReply.swift
@@ -20,10 +20,26 @@ final class VoiceReply {
     private let logger = Logger(subsystem: "com.sliccy.follower", category: "voice-reply")
     private let speaker: SpeechSpeaking
 
-    /// Tracked as a COUNT, not a flag: queued dictated turns each mark a
-    /// submission before any of them complete, and every completion must
-    /// balance its own mark so a later typed turn is not read aloud.
-    private var pendingCount = 0
+    /// One dictated submission awaiting its answer.
+    ///
+    /// The web tracks a bare count because a browser turn is strictly
+    /// sequential. The phone is not: scoops stream concurrently, and a
+    /// dictated turn can be queued while a TYPED turn is still streaming.
+    /// A count would then let the wrong reply consume the mark — the typed
+    /// answer gets read aloud and the dictated one stays silent. Each mark
+    /// therefore names the scoop it was sent to, and binds to a specific
+    /// assistant message as soon as that scoop opens its next one.
+    private struct PendingReply {
+        let scoopJid: String
+        /// nil until the answering `message_start` arrives.
+        var messageId: String?
+    }
+
+    private var pending: [PendingReply] = []
+
+    /// A runaway leader that never completes a turn must not grow this
+    /// without bound; the oldest mark is dropped rather than retained.
+    private static let maxPending = 8
 
     /// The engine is injectable so the coordination is testable without a
     /// live audio session; it defaults lazily because `AVSpeechSpeaker` is
@@ -32,23 +48,54 @@ final class VoiceReply {
         self.speaker = speaker ?? AVSpeechSpeaker()
     }
 
-    /// A dictated submission just went out — the next reply should be spoken.
-    func markSubmission() {
-        pendingCount += 1
-        logger.notice("dictated turn marked (\(self.pendingCount, privacy: .public) pending)")
+    /// A dictated submission just went out to `scoopJid` — its answer should
+    /// be spoken.
+    func markSubmission(scoopJid: String) {
+        pending.append(PendingReply(scoopJid: scoopJid, messageId: nil))
+        if pending.count > Self.maxPending { pending.removeFirst() }
+        logger.notice("dictated turn marked (\(self.pending.count, privacy: .public) pending)")
     }
 
-    /// Whether the completing turn was voice-initiated, decrementing when so.
-    func consumeSubmission() -> Bool {
-        guard pendingCount > 0 else { return false }
-        pendingCount -= 1
+    /// Bind the oldest unbound mark for `scoopJid` to the assistant message
+    /// that just opened. The first message a scoop starts after a dictated
+    /// submission IS its answer, which is what separates it from a typed
+    /// turn that was already streaming when the dictation went out.
+    func bindReply(scoopJid: String, messageId: String) {
+        guard
+            let idx = pending.firstIndex(where: {
+                $0.scoopJid == scoopJid && $0.messageId == nil
+            })
+        else { return }
+        pending[idx].messageId = messageId
+    }
+
+    /// Whether the completing message answers a dictated turn, retiring the
+    /// mark when it does. Only a BOUND mark matches, so a reply that was
+    /// already in flight when the user dictated can never claim it.
+    func consumeSubmission(scoopJid: String, messageId: String) -> Bool {
+        guard
+            let idx = pending.firstIndex(where: {
+                $0.scoopJid == scoopJid && $0.messageId == messageId
+            })
+        else { return false }
+        pending.remove(at: idx)
         return true
+    }
+
+    /// Drop the most recent mark — the send it was armed for never left.
+    func rollbackSubmission(scoopJid: String) {
+        guard
+            let idx = pending.lastIndex(where: {
+                $0.scoopJid == scoopJid && $0.messageId == nil
+            })
+        else { return }
+        pending.remove(at: idx)
     }
 
     /// Drop every pending mark — a disconnect or a new session must not let
     /// a stale mark speak the first reply of the next conversation.
     func reset() {
-        pendingCount = 0
+        pending.removeAll()
         speaker.stop()
     }
 

--- a/packages/ios-app/SliccFollower/Models/VoiceReply.swift
+++ b/packages/ios-app/SliccFollower/Models/VoiceReply.swift
@@ -35,6 +35,7 @@ final class VoiceReply {
     /// A dictated submission just went out — the next reply should be spoken.
     func markSubmission() {
         pendingCount += 1
+        logger.notice("dictated turn marked (\(self.pendingCount, privacy: .public) pending)")
     }
 
     /// Whether the completing turn was voice-initiated, decrementing when so.
@@ -65,7 +66,10 @@ final class VoiceReply {
         }
         let text = Self.speechText(
             fromMarkdown: DictationPriming.stripReplyLangMarker(markdown))
-        guard !text.isEmpty else { return }
+        guard !text.isEmpty else {
+            logger.info("spoken reply skipped: nothing speakable in the reply")
+            return
+        }
         speaker.speak(text, lang: lang)
     }
 
@@ -157,8 +161,12 @@ protocol SpeechSpeaking {
 }
 
 /// `AVSpeechSynthesizer` behind the seam.
+///
+/// `NSObject` because `AVSpeechSynthesizerDelegate` requires it — the
+/// delegate is how we learn the reply finished and can hand the audio route
+/// back to whatever was playing before.
 @MainActor
-final class AVSpeechSpeaker: SpeechSpeaking {
+final class AVSpeechSpeaker: NSObject, SpeechSpeaking, AVSpeechSynthesizerDelegate {
     /// Created on the first spoken reply, never at launch. Constructing a
     /// synthesizer wakes the system speech services on the main actor, and
     /// most sessions never dictate at all.
@@ -166,18 +174,20 @@ final class AVSpeechSpeaker: SpeechSpeaking {
     private let logger = Logger(subsystem: "com.sliccy.follower", category: "voice-reply")
 
     func speak(_ text: String, lang: String?) {
-        configureSession()
+        guard activateSession() else { return }
         let utterance = AVSpeechUtterance(string: text)
         if let lang, let voice = Self.voice(for: lang) {
             utterance.voice = voice
         }
-        let synthesizer = synthesizer ?? AVSpeechSynthesizer()
-        self.synthesizer = synthesizer
+        let synthesizer = self.synthesizer ?? makeSynthesizer()
         // Barge-in: a new reply replaces the one still playing rather than
         // queueing behind it.
         if synthesizer.isSpeaking {
             synthesizer.stopSpeaking(at: .immediate)
         }
+        logger.notice(
+            "speaking reply: \(text.count, privacy: .public) chars, lang \(lang ?? "default", privacy: .public)"
+        )
         synthesizer.speak(utterance)
     }
 
@@ -190,6 +200,13 @@ final class AVSpeechSpeaker: SpeechSpeaking {
         Self.voice(for: lang) != nil
     }
 
+    private func makeSynthesizer() -> AVSpeechSynthesizer {
+        let created = AVSpeechSynthesizer()
+        created.delegate = self
+        synthesizer = created
+        return created
+    }
+
     /// An exact BCP-47 match first, then any voice sharing the base subtag —
     /// a `de` reply should still speak in `de-DE`.
     private static func voice(for lang: String) -> AVSpeechSynthesisVoice? {
@@ -200,18 +217,44 @@ final class AVSpeechSpeaker: SpeechSpeaking {
         }
     }
 
-    /// Push-to-talk leaves the session in a record-oriented mode; playback
-    /// needs `.duckOthers` so the reply is audible over other audio and does
-    /// not stop it outright.
-    private func configureSession() {
+    /// Sliccy answering is MEDIA, not a notification: `.playback` so the reply
+    /// is heard with the ring switch flipped and routes to the speaker on its
+    /// own. Dictation leaves the session on `.record` and deactivated, so the
+    /// category has to be reclaimed for every reply — and taking `.playback`
+    /// rather than `.playAndRecord` also drops the microphone, which nothing
+    /// needs while the phone is the one talking.
+    private func activateSession() -> Bool {
         let session = AVAudioSession.sharedInstance()
         do {
-            try session.setCategory(
-                .playAndRecord, mode: .spokenAudio,
-                options: [.duckOthers, .defaultToSpeaker, .allowBluetooth])
+            try session.setCategory(.playback, mode: .spokenAudio, options: [.duckOthers])
             try session.setActive(true, options: [])
+            return true
         } catch {
-            logger.warning("audio session for spoken reply failed: \(error.localizedDescription)")
+            logger.error("spoken reply audio session failed: \(error.localizedDescription)")
+            return false
         }
+    }
+
+    /// Hand the route back so ducked audio returns to full volume and the
+    /// next push-to-talk hold can claim the microphone.
+    private func releaseSession() {
+        do {
+            try AVAudioSession.sharedInstance().setActive(
+                false, options: .notifyOthersOnDeactivation)
+        } catch {
+            logger.warning("releasing audio session failed: \(error.localizedDescription)")
+        }
+    }
+
+    nonisolated func speechSynthesizer(
+        _ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance
+    ) {
+        MainActor.assumeIsolated { releaseSession() }
+    }
+
+    nonisolated func speechSynthesizer(
+        _ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance
+    ) {
+        MainActor.assumeIsolated { releaseSession() }
     }
 }

--- a/packages/ios-app/SliccFollower/Models/VoiceReply.swift
+++ b/packages/ios-app/SliccFollower/Models/VoiceReply.swift
@@ -1,0 +1,217 @@
+import AVFoundation
+import Foundation
+import OSLog
+
+/// The spoken-reply loop — the Swift twin of
+/// `packages/webapp/src/speech/voice-reply.ts`.
+///
+/// A turn submitted by DICTATION gets its assistant reply read aloud; typed
+/// turns stay silent. "Speak to it, it speaks back." The phone had the
+/// listening half (push-to-talk) but not the answering half, so a hands-free
+/// exchange still ended with the user having to look at the screen.
+///
+/// The web routes through Kokoro or Web Speech; iOS has one always-present
+/// engine, `AVSpeechSynthesizer`, so the engine-selection layer collapses and
+/// only the coordination survives.
+@MainActor
+final class VoiceReply {
+    static let shared = VoiceReply()
+
+    private let logger = Logger(subsystem: "com.sliccy.follower", category: "voice-reply")
+    private let speaker: SpeechSpeaking
+
+    /// Tracked as a COUNT, not a flag: queued dictated turns each mark a
+    /// submission before any of them complete, and every completion must
+    /// balance its own mark so a later typed turn is not read aloud.
+    private var pendingCount = 0
+
+    /// The engine is injectable so the coordination is testable without a
+    /// live audio session; it defaults lazily because `AVSpeechSpeaker` is
+    /// itself main-actor isolated.
+    init(speaker: SpeechSpeaking? = nil) {
+        self.speaker = speaker ?? AVSpeechSpeaker()
+    }
+
+    /// A dictated submission just went out — the next reply should be spoken.
+    func markSubmission() {
+        pendingCount += 1
+    }
+
+    /// Whether the completing turn was voice-initiated, decrementing when so.
+    func consumeSubmission() -> Bool {
+        guard pendingCount > 0 else { return false }
+        pendingCount -= 1
+        return true
+    }
+
+    /// Drop every pending mark — a disconnect or a new session must not let
+    /// a stale mark speak the first reply of the next conversation.
+    func reset() {
+        pendingCount = 0
+        speaker.stop()
+    }
+
+    /// Read an assistant reply aloud, markdown reduced to speakable prose.
+    /// Best-effort: a failure never disturbs the chat flow.
+    ///
+    /// When the agent declared its reply language via `<!--lang:xx-->`, the
+    /// reply is spoken ONLY if a voice exists for it — better silence than
+    /// English prose mangled by the locale-default German voice.
+    func speakReply(markdown: String) {
+        let lang = DictationPriming.replyLang(markdown)
+        if let lang, !speaker.hasVoice(for: lang) {
+            logger.info("skipping spoken reply: no voice for \(lang, privacy: .public)")
+            return
+        }
+        let text = Self.speechText(
+            fromMarkdown: DictationPriming.stripReplyLangMarker(markdown))
+        guard !text.isEmpty else { return }
+        speaker.speak(text, lang: lang)
+    }
+
+    /// Stop any in-flight utterance (the user tapping to type, or aborting).
+    func stopSpeaking() {
+        speaker.stop()
+    }
+
+    // MARK: - Markdown → speech
+
+    /// Spoken replies stay bounded; the cap only exists to keep runaway prose
+    /// from monologuing.
+    static let maxSpeechCharacters = 20000
+    /// Inline code longer than this is a path or a blob, not a word.
+    static let maxSpokenInlineCodeCharacters = 40
+
+    /// Reduce markdown to speakable prose — the port of
+    /// `speechTextFromMarkdown` in `speak.ts`. Order matters: fences go
+    /// before inline code so a fence body is never mistaken for a span.
+    static func speechText(fromMarkdown markdown: String) -> String {
+        var text = markdown
+        text = replace(#"```[\s\S]*?```"#, in: text, with: " ")
+        text = replace(#"~~~[\s\S]*?~~~"#, in: text, with: " ")
+        // An unterminated fence (a truncated reply) would otherwise leak its
+        // whole body into speech — drop everything from the dangling opener.
+        text = replace(#"(?:```|~~~)[\s\S]*$"#, in: text, with: " ")
+        text = replace(#"!\[([^\]]*)\]\([^)]*\)"#, in: text, with: "$1")
+        text = replace(#"\[([^\]]+)\]\([^)]*\)"#, in: text, with: "$1")
+        text = replaceInlineCode(in: text)
+        text = replace(#"<[^>\n]+>"#, in: text, with: " ")
+        text = replace(#"^[ \t]{0,3}#{1,6}[ \t]+"#, in: text, with: "", multiline: true)
+        text = replace(#"^[ \t]*>[ \t]?"#, in: text, with: "", multiline: true)
+        text = replace(
+            #"^[ \t]*(?:[-*+]|\d+[.)])[ \t]+"#, in: text, with: "", multiline: true)
+        text = replace(#"[*_~]{1,3}([^*_~]+)[*_~]{1,3}"#, in: text, with: "$1")
+        text = replace(#"\s+"#, in: text, with: " ")
+        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.count > maxSpeechCharacters {
+            var clipped = String(text.prefix(maxSpeechCharacters))
+            // Never end mid-word.
+            if let lastSpace = clipped.lastIndex(of: " ") {
+                clipped = String(clipped[clipped.startIndex..<lastSpace])
+            }
+            text = clipped + "…"
+        }
+        return text
+    }
+
+    /// Short inline code is spoken as its content; a long span is dropped.
+    private static func replaceInlineCode(in text: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: "`([^`]*)`") else { return text }
+        let full = NSRange(text.startIndex..., in: text)
+        var result = ""
+        var cursor = text.startIndex
+        for match in regex.matches(in: text, range: full) {
+            guard let matchRange = Range(match.range, in: text),
+                let codeRange = Range(match.range(at: 1), in: text)
+            else { continue }
+            result += text[cursor..<matchRange.lowerBound]
+            let code = String(text[codeRange])
+            result += code.count > maxSpokenInlineCodeCharacters ? " " : code
+            cursor = matchRange.upperBound
+        }
+        result += text[cursor...]
+        return result
+    }
+
+    private static func replace(
+        _ pattern: String, in text: String, with template: String, multiline: Bool = false
+    ) -> String {
+        let options: NSRegularExpression.Options = multiline ? [.anchorsMatchLines] : []
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else {
+            return text
+        }
+        return regex.stringByReplacingMatches(
+            in: text, range: NSRange(text.startIndex..., in: text), withTemplate: template)
+    }
+}
+
+// MARK: - Speech engine
+
+/// The speaking seam. A protocol so the coordination above is testable
+/// without a live audio session.
+@MainActor
+protocol SpeechSpeaking {
+    func speak(_ text: String, lang: String?)
+    func stop()
+    func hasVoice(for lang: String) -> Bool
+}
+
+/// `AVSpeechSynthesizer` behind the seam.
+@MainActor
+final class AVSpeechSpeaker: SpeechSpeaking {
+    /// Created on the first spoken reply, never at launch. Constructing a
+    /// synthesizer wakes the system speech services on the main actor, and
+    /// most sessions never dictate at all.
+    private var synthesizer: AVSpeechSynthesizer?
+    private let logger = Logger(subsystem: "com.sliccy.follower", category: "voice-reply")
+
+    func speak(_ text: String, lang: String?) {
+        configureSession()
+        let utterance = AVSpeechUtterance(string: text)
+        if let lang, let voice = Self.voice(for: lang) {
+            utterance.voice = voice
+        }
+        let synthesizer = synthesizer ?? AVSpeechSynthesizer()
+        self.synthesizer = synthesizer
+        // Barge-in: a new reply replaces the one still playing rather than
+        // queueing behind it.
+        if synthesizer.isSpeaking {
+            synthesizer.stopSpeaking(at: .immediate)
+        }
+        synthesizer.speak(utterance)
+    }
+
+    func stop() {
+        guard let synthesizer, synthesizer.isSpeaking else { return }
+        synthesizer.stopSpeaking(at: .immediate)
+    }
+
+    func hasVoice(for lang: String) -> Bool {
+        Self.voice(for: lang) != nil
+    }
+
+    /// An exact BCP-47 match first, then any voice sharing the base subtag —
+    /// a `de` reply should still speak in `de-DE`.
+    private static func voice(for lang: String) -> AVSpeechSynthesisVoice? {
+        if let exact = AVSpeechSynthesisVoice(language: lang) { return exact }
+        let base = lang.split(separator: "-").first.map(String.init)?.lowercased() ?? lang
+        return AVSpeechSynthesisVoice.speechVoices().first {
+            $0.language.lowercased().split(separator: "-").first.map(String.init) == base
+        }
+    }
+
+    /// Push-to-talk leaves the session in a record-oriented mode; playback
+    /// needs `.duckOthers` so the reply is audible over other audio and does
+    /// not stop it outright.
+    private func configureSession() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(
+                .playAndRecord, mode: .spokenAudio,
+                options: [.duckOthers, .defaultToSpeaker, .allowBluetooth])
+            try session.setActive(true, options: [])
+        } catch {
+            logger.warning("audio session for spoken reply failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/BrowserTargetsTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/BrowserTargetsTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+
+@testable import SliccFollower
+
+/// Which federated tabs reach the browser surface. The leader enumerates its
+/// whole browser, so its own SLICC page arrives in the registry like any
+/// other tab — listing it invites the user to "browse" the app they are
+/// already attached to.
+final class BrowserTargetsTests: XCTestCase {
+
+    private func target(
+        _ id: String, runtime: String = "leader", url: String
+    ) -> TrayTargetEntry {
+        TrayTargetEntry(
+            targetId: "\(runtime):\(id)", localTargetId: id, runtimeId: runtime,
+            title: id, url: url, isLocal: false)
+    }
+
+    private let joinUrl = "https://www.sliccy.ai/?ws=wss%3A%2F%2Fhub#tray=abc123"
+
+    func testDropsOurOwnAdvertisedTargets() {
+        let targets = [
+            target("mine", runtime: "ios-me", url: "https://example.com/a"),
+            target("theirs", url: "https://example.com/b"),
+        ]
+        let visible = BrowserTargets.visible(targets, ownRuntimeId: "ios-me", joinUrl: joinUrl)
+        XCTAssertEqual(
+            visible.map(\.localTargetId), ["theirs"],
+            "our own tabs are the live local carousel, not preview cards")
+    }
+
+    func testDropsTheLeadersOwnSliccPage() {
+        let targets = [
+            target("app", url: joinUrl),
+            target("docs", url: "https://www.sliccy.ai/docs/architecture"),
+        ]
+        let visible = BrowserTargets.visible(targets, ownRuntimeId: "ios-me", joinUrl: joinUrl)
+        XCTAssertEqual(
+            visible.map(\.localTargetId), ["docs"],
+            "the app page goes; a real page on the same host stays")
+    }
+
+    func testSessionQueryAndFragmentDoNotDefeatTheMatch() {
+        // The leader's own tab has advanced its `#tray=` fragment since the
+        // follower dialed; scheme+host+path still identify it.
+        XCTAssertTrue(
+            BrowserTargets.isSliccAppPage(
+                "https://www.sliccy.ai/?ws=wss%3A%2F%2Fother#tray=zzz", joinUrl: joinUrl))
+        XCTAssertTrue(
+            BrowserTargets.isSliccAppPage("https://www.sliccy.ai/index.html", joinUrl: joinUrl))
+        XCTAssertTrue(
+            BrowserTargets.isSliccAppPage("https://WWW.Sliccy.AI/", joinUrl: joinUrl))
+    }
+
+    func testLocalLeaderIsMatchedThroughTheJoinUrlNotAHardcodedHost() {
+        let localJoin = "http://localhost:5710/?ws=ws%3A%2F%2Flocalhost%3A5710"
+        XCTAssertTrue(
+            BrowserTargets.isSliccAppPage("http://localhost:5710/", joinUrl: localJoin),
+            "a CLI float's leader page is the app page too")
+        XCTAssertFalse(
+            BrowserTargets.isSliccAppPage("http://localhost:5710/preview/index.html", joinUrl: localJoin),
+            "a served preview on the same origin is a real page")
+    }
+
+    func testHostedAppShellIsDroppedEvenWithoutAJoinUrl() {
+        XCTAssertTrue(BrowserTargets.isSliccAppPage("https://sliccy.ai/", joinUrl: ""))
+        XCTAssertFalse(
+            BrowserTargets.isSliccAppPage("https://sliccy.ai/cloud", joinUrl: ""),
+            "the dashboard is a page you may legitimately want to see")
+    }
+
+    func testNonHttpTargetsAreNeverMistakenForTheApp() {
+        for url in ["about:blank", "", "data:text/html,<p>hi</p>"] {
+            XCTAssertFalse(BrowserTargets.isSliccAppPage(url, joinUrl: joinUrl), url)
+        }
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/DockModelTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/DockModelTests.swift
@@ -6,18 +6,41 @@ import XCTest
 /// mirroring `slicc-dock.ts`.
 final class DockModelTests: XCTestCase {
 
-    private func sprinkle(_ name: String) -> SprinkleSummary {
+    private func sprinkle(_ name: String, icon: String? = nil) -> SprinkleSummary {
         SprinkleSummary(
             name: name, title: name.capitalized, path: "/sprinkles/\(name).shtml",
-            open: false, autoOpen: false, icon: nil)
+            open: false, autoOpen: false, icon: icon)
     }
 
-    func testSprinkleItemsKeepLeaderOrderAndEndWithNew() {
+    func testSprinkleItemsKeepLeaderOrder() {
         let items = DockModel.sprinkleItems([sprinkle("alpha"), sprinkle("beta")])
         XCTAssertEqual(
-            items.map(\.id), ["sprinkle-alpha", "sprinkle-beta", "new"],
-            "launchers in leader order, New + always last")
-        XCTAssertEqual(items.last?.surface, .newSprinkle)
+            items.map(\.id), ["sprinkle-alpha", "sprinkle-beta"],
+            "launchers in leader order")
+    }
+
+    func testRailCarriesNoNewSprinkleLauncher() {
+        let items = DockModel.sprinkleItems([sprinkle("alpha")])
+        XCTAssertFalse(
+            items.contains { $0.id == "new" },
+            "sprinkles are authored on the leader — a `+` here could only open a placeholder")
+    }
+
+    func testSprinkleItemsCarryTheLeaderDeclaredIcon() {
+        let items = DockModel.sprinkleItems([
+            sprinkle("pomodoro", icon: "timer"),
+            sprinkle("plain"),
+            sprinkle("pathy", icon: "/workspace/icon.svg"),
+            sprinkle("obscure", icon: "not-a-real-lucide-name"),
+        ])
+        XCTAssertEqual(items[0].systemImage, "timer", "declared lucide name maps to its SF Symbol")
+        XCTAssertEqual(items[1].systemImage, "sparkles", "no icon declared → generic sparkle")
+        XCTAssertEqual(
+            items[2].systemImage, "sparkles",
+            "VFS paths render in other surfaces, not the rail (isLucideIconSpec parity)")
+        XCTAssertEqual(
+            items[3].systemImage, "sparkles",
+            "an unmapped lucide name degrades to the sparkle, never a missing glyph")
     }
 
     func testToolOrderMirrorsTheWebDock() {
@@ -28,11 +51,9 @@ final class DockModelTests: XCTestCase {
     }
 
     func testLeaderOnlySurfacesExplainThemselves() {
-        for surface in [DockSurface.term, .newSprinkle] {
-            XCTAssertNotNil(
-                DockModel.placeholderText(for: surface),
-                "\(surface) has no native view — it must say why, not render empty")
-        }
+        XCTAssertNotNil(
+            DockModel.placeholderText(for: .term),
+            "the terminal has no native view — it must say why, not render empty")
         // Real views carry no placeholder: browser, sprinkles, monitor (#1868).
         XCTAssertNil(DockModel.placeholderText(for: .browser))
         XCTAssertNil(DockModel.placeholderText(for: .sprinkle(name: "x")))

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/MarkdownBlockParserTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/MarkdownBlockParserTests.swift
@@ -1,0 +1,236 @@
+import XCTest
+
+@testable import SliccFollower
+
+/// The block grammar behind `MarkdownText`. `AttributedString(markdown:)` is
+/// inline-only in the configuration the view uses, so anything this parser
+/// misses reaches the transcript as its literal source — which is how the
+/// leader's comparison tables arrived as raw `| … |` rows.
+final class MarkdownBlockParserTests: XCTestCase {
+
+    // MARK: - Tables
+
+    func testParsesPipeTableWithAlignments() {
+        let blocks = MarkdownBlockParser.parse(
+            """
+            | Lens | Reach | Price |
+            |------|:-----:|------:|
+            | Leica 100-400 | 800mm-eq | €750 |
+            | OM 100-400 | 800mm-eq | €650 |
+            """)
+
+        guard case .table(let table)? = blocks.first, blocks.count == 1 else {
+            return XCTFail("expected one table block, got \(blocks)")
+        }
+        XCTAssertEqual(table.header, ["Lens", "Reach", "Price"])
+        XCTAssertEqual(table.alignments, [.leading, .center, .trailing])
+        XCTAssertEqual(table.rows.count, 2)
+        XCTAssertEqual(table.rows[0], ["Leica 100-400", "800mm-eq", "€750"])
+    }
+
+    func testTableWithoutOuterPipesStillParses() {
+        let blocks = MarkdownBlockParser.parse(
+            """
+            a | b
+            --- | ---
+            1 | 2
+            """)
+        guard case .table(let table)? = blocks.first else {
+            return XCTFail("expected a table, got \(blocks)")
+        }
+        XCTAssertEqual(table.header, ["a", "b"])
+        XCTAssertEqual(table.rows, [["1", "2"]])
+    }
+
+    func testRaggedRowsArePaddedAndTruncatedToTheHeader() {
+        let blocks = MarkdownBlockParser.parse(
+            """
+            | a | b |
+            |---|---|
+            | 1 |
+            | 1 | 2 | 3 |
+            """)
+        guard case .table(let table)? = blocks.first else {
+            return XCTFail("expected a table, got \(blocks)")
+        }
+        XCTAssertEqual(
+            table.rows, [["1", ""], ["1", "2"]],
+            "a ragged row must not desync the grid or index out of bounds")
+    }
+
+    func testEscapedPipeStaysInsideItsCell() {
+        XCTAssertEqual(MarkdownBlockParser.splitRow(#"| a \| b | c |"#), ["a | b", "c"])
+    }
+
+    func testProseFullOfPipesIsNotATable() {
+        let blocks = MarkdownBlockParser.parse(
+            """
+            Run `a | b | c` and then
+            pipe it | somewhere else
+            """)
+        XCTAssertEqual(blocks.count, 1)
+        guard case .paragraph? = blocks.first else {
+            return XCTFail("pipes without a delimiter row are prose, got \(blocks)")
+        }
+    }
+
+    func testTableTerminatesAtTheFirstNonRow() {
+        let blocks = MarkdownBlockParser.parse(
+            """
+            | a |
+            |---|
+            | 1 |
+
+            After the table.
+            """)
+        XCTAssertEqual(blocks.count, 2)
+        guard case .table(let table)? = blocks.first, case .paragraph(let text) = blocks[1] else {
+            return XCTFail("expected table then paragraph, got \(blocks)")
+        }
+        XCTAssertEqual(table.rows, [["1"]])
+        XCTAssertEqual(text, "After the table.")
+    }
+
+    // MARK: - Lists
+
+    func testBulletListItemsCarryDepthAndMarker() {
+        let blocks = MarkdownBlockParser.parse(
+            """
+            - Leica SL 100-400 L-mount
+            - Hood-only listings
+              - nested note
+            """)
+        guard case .list(let list)? = blocks.first else {
+            return XCTFail("expected a list, got \(blocks)")
+        }
+        XCTAssertFalse(list.ordered)
+        XCTAssertEqual(list.items.map(\.depth), [0, 0, 1])
+        XCTAssertEqual(list.items.map(\.marker), ["•", "•", "◦"])
+        XCTAssertEqual(list.items[0].text, "Leica SL 100-400 L-mount")
+    }
+
+    func testOrderedListKeepsTheAuthorsNumbering() {
+        let blocks = MarkdownBlockParser.parse(
+            """
+            3. €750 Dinslaken
+            4. €805 Senden
+            """)
+        guard case .list(let list)? = blocks.first else {
+            return XCTFail("expected a list, got \(blocks)")
+        }
+        XCTAssertTrue(list.ordered)
+        XCTAssertEqual(list.items.map(\.marker), ["3.", "4."])
+    }
+
+    func testSwitchingMarkerKindStartsANewList() {
+        let blocks = MarkdownBlockParser.parse(
+            """
+            - bullet
+            1. number
+            """)
+        XCTAssertEqual(blocks.count, 2)
+        guard case .list(let bullets)? = blocks.first, case .list(let numbers) = blocks[1] else {
+            return XCTFail("expected two lists, got \(blocks)")
+        }
+        XCTAssertFalse(bullets.ordered)
+        XCTAssertTrue(numbers.ordered)
+    }
+
+    func testHyphenatedProseIsNotAListItem() {
+        let blocks = MarkdownBlockParser.parse("-not a bullet")
+        guard case .paragraph(let text)? = blocks.first else {
+            return XCTFail("a marker needs a trailing space, got \(blocks)")
+        }
+        XCTAssertEqual(text, "-not a bullet")
+    }
+
+    // MARK: - Thematic breaks
+
+    func testThematicBreakVariants() {
+        for line in ["---", "***", "___", "- - -", "  ----"] {
+            XCTAssertTrue(MarkdownBlockParser.isThematicBreak(line), "\(line) is a rule")
+        }
+        for line in ["--", "-- text", "|---|---|", "-"] {
+            XCTAssertFalse(MarkdownBlockParser.isThematicBreak(line), "\(line) is not a rule")
+        }
+    }
+
+    func testTableDelimiterRowIsNotEatenAsAThematicBreak() {
+        let blocks = MarkdownBlockParser.parse(
+            """
+            | a | b |
+            | --- | --- |
+            | 1 | 2 |
+            """)
+        guard case .table? = blocks.first, blocks.count == 1 else {
+            return XCTFail("delimiter rows carry pipes and belong to the table, got \(blocks)")
+        }
+    }
+
+    // MARK: - Blocks that already worked
+
+    func testHeadingsCodeAndQuotesSurviveTheRewrite() {
+        let blocks = MarkdownBlockParser.parse(
+            """
+            # Title
+
+            > quoted
+
+            ```swift
+            let x = 1
+            ```
+
+            tail
+            """)
+        XCTAssertEqual(blocks.count, 4)
+        guard case .heading(let level, let title)? = blocks.first else {
+            return XCTFail("expected a heading, got \(blocks)")
+        }
+        XCTAssertEqual(level, 1)
+        XCTAssertEqual(title, "Title")
+        XCTAssertEqual(blocks[1], .blockquote("quoted"))
+        XCTAssertEqual(blocks[2], .codeBlock(language: "swift", code: "let x = 1"))
+        XCTAssertEqual(blocks[3], .paragraph("tail"))
+    }
+
+    func testUnclosedFenceStillRendersAsCode() {
+        let blocks = MarkdownBlockParser.parse(
+            """
+            ```
+            still code
+            """)
+        XCTAssertEqual(blocks, [.codeBlock(language: nil, code: "still code")])
+    }
+
+    func testFencedContentIsNeverReinterpreted() {
+        let blocks = MarkdownBlockParser.parse(
+            """
+            ```
+            | a | b |
+            |---|---|
+            - not a bullet
+            ---
+            ```
+            """)
+        XCTAssertEqual(blocks.count, 1)
+        guard case .codeBlock(_, let code)? = blocks.first else {
+            return XCTFail("expected one code block, got \(blocks)")
+        }
+        XCTAssertTrue(code.contains("| a | b |"))
+        XCTAssertTrue(code.contains("- not a bullet"))
+    }
+
+    func testHashInTitleSurvivesButClosingSequenceDoesNot() {
+        XCTAssertEqual(MarkdownBlockParser.parseAtxHeading("# C#")?.text, "C#")
+        XCTAssertEqual(MarkdownBlockParser.parseAtxHeading("# Heading ##")?.text, "Heading")
+        XCTAssertNil(MarkdownBlockParser.parseAtxHeading("#NoSpace"))
+        XCTAssertNil(
+            MarkdownBlockParser.parseAtxHeading("    # indented"),
+            "4+ leading spaces is an indented code block, not a heading")
+    }
+
+    func testEmptyContentProducesNoBlocks() {
+        XCTAssertEqual(MarkdownBlockParser.parse(""), [])
+        XCTAssertEqual(MarkdownBlockParser.parse("\n\n  \n"), [])
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SVGPathTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SVGPathTests.swift
@@ -1,0 +1,148 @@
+import CoreGraphics
+import XCTest
+
+@testable import SliccFollower
+
+/// The parser that lets lucide's `d` strings ship verbatim. Correctness here
+/// is what keeps a ported glyph from silently becoming a smear, so the tests
+/// assert on the geometry the commands are supposed to produce rather than
+/// on "did it parse".
+final class SVGPathTests: XCTestCase {
+
+    /// Sampling the bounding box is the cheapest ground truth for "the pen
+    /// went where the command said".
+    private func bounds(_ data: String) -> CGRect {
+        SVGPath.parse(data).boundingBoxOfPath
+    }
+
+    func testAbsoluteMoveAndLine() {
+        let box = bounds("M 2 4 L 10 16")
+        XCTAssertEqual(box.minX, 2, accuracy: 0.001)
+        XCTAssertEqual(box.minY, 4, accuracy: 0.001)
+        XCTAssertEqual(box.maxX, 10, accuracy: 0.001)
+        XCTAssertEqual(box.maxY, 16, accuracy: 0.001)
+    }
+
+    func testRelativeCommandsAccumulate() {
+        let box = bounds("m 1 1 l 2 2 l 2 2")
+        XCTAssertEqual(box.maxX, 5, accuracy: 0.001, "relative segments must chain, not reset")
+        XCTAssertEqual(box.maxY, 5, accuracy: 0.001)
+    }
+
+    func testRepeatedPairsAfterMovetoAreImplicitLinetos() {
+        // Per the SVG spec; lucide relies on it, e.g. `m7 11 4.08 10.35 …`.
+        XCTAssertEqual(bounds("M 0 0 4 0 4 4"), bounds("M 0 0 L 4 0 L 4 4"))
+    }
+
+    func testHorizontalAndVerticalShorthand() {
+        let box = bounds("M 0 0 H 8 V 6")
+        XCTAssertEqual(box.width, 8, accuracy: 0.001)
+        XCTAssertEqual(box.height, 6, accuracy: 0.001)
+    }
+
+    func testNegativeNumbersNeedNoSeparator() {
+        // `4-3` is two numbers in path data — splitting on whitespace loses this.
+        XCTAssertEqual(bounds("M0 0L4-3"), bounds("M 0 0 L 4 -3"))
+    }
+
+    func testDecimalsPackedWithoutSeparators() {
+        XCTAssertEqual(bounds("M.5.5L1.5 2.5"), bounds("M 0.5 0.5 L 1.5 2.5"))
+    }
+
+    func testSemicircleArcSpansItsDiameter() {
+        // A half-circle of radius 5 from (0,0) to (10,0). SVG's y axis points
+        // down, so sweep=1 (positive angle direction) bulges to NEGATIVE y.
+        let box = bounds("M 0 0 A 5 5 0 0 1 10 0")
+        XCTAssertEqual(box.minX, 0, accuracy: 0.01)
+        XCTAssertEqual(box.maxX, 10, accuracy: 0.01)
+        XCTAssertEqual(box.minY, -5, accuracy: 0.05, "sweep=1 must curve to -y")
+        XCTAssertEqual(box.maxY, 0, accuracy: 0.05)
+    }
+
+    func testArcSweepFlagFlipsTheBulge() {
+        let box = bounds("M 0 0 A 5 5 0 0 0 10 0")
+        XCTAssertEqual(box.maxY, 5, accuracy: 0.05, "sweep=0 must curve to +y")
+        XCTAssertEqual(box.minY, 0, accuracy: 0.05)
+    }
+
+    func testUndersizedArcRadiiAreScaledUpToReachTheEndpoint() {
+        // Radius 1 cannot span a chord of 10; the spec says scale, not fail.
+        let box = bounds("M 0 0 A 1 1 0 0 1 10 0")
+        XCTAssertEqual(box.maxX, 10, accuracy: 0.01)
+        XCTAssertEqual(box.minY, -5, accuracy: 0.1)
+    }
+
+    func testZeroRadiusArcDegradesToALine() {
+        XCTAssertEqual(bounds("M 0 0 A 0 0 0 0 1 6 8"), bounds("M 0 0 L 6 8"))
+    }
+
+    func testArcFlagsMayBeWrittenUnseparated() {
+        // Lucide emits `a3.5 3.5 0 1 1 6.71 0`, but `011` is equally legal.
+        XCTAssertEqual(bounds("M0 0a5 5 0 116 0"), bounds("M 0 0 a 5 5 0 1 1 6 0"))
+    }
+
+    func testSmoothCubicReflectsThePreviousControlPoint() {
+        let reflected = bounds("M 0 0 C 0 4 4 4 4 0 S 8 -4 8 0")
+        let explicit = bounds("M 0 0 C 0 4 4 4 4 0 C 4 -4 8 -4 8 0")
+        XCTAssertEqual(reflected.minY, explicit.minY, accuracy: 0.001)
+        XCTAssertEqual(reflected.maxY, explicit.maxY, accuracy: 0.001)
+    }
+
+    func testClosePathReturnsToTheSubpathStart() {
+        let box = bounds("M 2 2 L 6 2 L 6 6 Z")
+        XCTAssertEqual(box.minX, 2, accuracy: 0.001)
+        XCTAssertEqual(box.minY, 2, accuracy: 0.001)
+    }
+
+    func testTrailingCloseWithoutACommandTerminates() {
+        // A malformed repeat would spin forever: `Z` consumes no operands.
+        XCTAssertFalse(bounds("M 0 0 L 4 4 Z 1 2").isNull)
+    }
+
+    func testGarbageYieldsAnEmptyPathInsteadOfCrashing() {
+        XCTAssertTrue(SVGPath.parse("wat").isEmpty)
+        XCTAssertTrue(SVGPath.parse("").isEmpty)
+        XCTAssertTrue(SVGPath.parse("M").isEmpty, "a moveto with no operands draws nothing")
+    }
+
+    // MARK: - Framing
+
+    func testGlyphIsScaledAndCenteredInTheTargetRect() {
+        // The full 24-unit box mapped into a 48pt square doubles in size.
+        let rect = CGRect(x: 0, y: 0, width: 48, height: 48)
+        let box = SVGPath.path(from: "M 0 0 L 24 24", in: rect).boundingBoxOfPath
+        XCTAssertEqual(box.minX, 0, accuracy: 0.001)
+        XCTAssertEqual(box.maxX, 48, accuracy: 0.001)
+    }
+
+    func testNonSquareRectPreservesAspectAndCenters() {
+        let rect = CGRect(x: 0, y: 0, width: 100, height: 50)
+        let box = SVGPath.path(from: "M 0 0 L 24 24", in: rect).boundingBoxOfPath
+        XCTAssertEqual(box.width, 50, accuracy: 0.001, "scaled by the short side")
+        XCTAssertEqual(box.minX, 25, accuracy: 0.001, "centered on the long side")
+    }
+
+    // MARK: - The shipped glyphs
+
+    func testEveryPortedLucideGlyphParsesAndFillsItsBox() {
+        for glyph in LucideGlyph.allCases {
+            var combined = CGRect.null
+            for data in glyph.pathData {
+                let box = SVGPath.parse(data).boundingBoxOfPath
+                XCTAssertFalse(
+                    box.isNull || box.isEmpty, "\(glyph.rawValue) has an unparsed subpath")
+                combined = combined.union(box)
+            }
+            // Lucide draws to a 24x24 box with ~2 units of padding; a glyph
+            // that came out tiny means the parser dropped commands.
+            XCTAssertGreaterThan(
+                combined.width, 10, "\(glyph.rawValue) is too narrow to be intact")
+            XCTAssertGreaterThan(
+                combined.height, 10, "\(glyph.rawValue) is too short to be intact")
+            XCTAssertGreaterThanOrEqual(combined.minX, -0.5, "\(glyph.rawValue) overflows left")
+            XCTAssertLessThanOrEqual(combined.maxX, 24.5, "\(glyph.rawValue) overflows right")
+            XCTAssertGreaterThanOrEqual(combined.minY, -0.5, "\(glyph.rawValue) overflows top")
+            XCTAssertLessThanOrEqual(combined.maxY, 24.5, "\(glyph.rawValue) overflows bottom")
+        }
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/VoiceReplyTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/VoiceReplyTests.swift
@@ -64,10 +64,20 @@ final class VoiceReplyTests: XCTestCase {
     }
 
     func testFirstFlagIsOneShotUntilReset() {
-        XCTAssertTrue(DictationPriming.consumeFirst())
-        XCTAssertFalse(DictationPriming.consumeFirst())
+        XCTAssertTrue(DictationPriming.isFirstPending)
+        DictationPriming.commitFirst()
+        XCTAssertFalse(DictationPriming.isFirstPending)
         DictationPriming.reset()
-        XCTAssertTrue(DictationPriming.consumeFirst(), "a fresh session re-arms the note")
+        XCTAssertTrue(DictationPriming.isFirstPending, "a fresh session re-arms the note")
+    }
+
+    func testPeekingTheFirstFlagDoesNotSpendIt() {
+        // A dictated send builds its marked text before it knows the send
+        // succeeded; only a delivered message may spend the priming note.
+        XCTAssertTrue(DictationPriming.isFirstPending)
+        XCTAssertTrue(DictationPriming.isFirstPending)
+        DictationPriming.commitFirst()
+        XCTAssertFalse(DictationPriming.isFirstPending)
     }
 
     // MARK: - Reply language marker
@@ -144,32 +154,89 @@ final class VoiceReplyTests: XCTestCase {
 
     // MARK: - The loop
 
-    func testOnlyDictatedTurnsAreSpoken() {
-        let speaker = FakeSpeaker()
-        let reply = VoiceReply(speaker: speaker)
+    /// Mark, bind and consume in the order the transport delivers them.
+    private func answer(
+        _ reply: VoiceReply, scoop: String, messageId: String
+    ) -> Bool {
+        reply.bindReply(scoopJid: scoop, messageId: messageId)
+        return reply.consumeSubmission(scoopJid: scoop, messageId: messageId)
+    }
 
-        XCTAssertFalse(reply.consumeSubmission(), "a typed turn is never voice-initiated")
-        reply.markSubmission()
-        XCTAssertTrue(reply.consumeSubmission())
-        XCTAssertFalse(reply.consumeSubmission(), "one mark answers exactly one turn")
+    func testOnlyDictatedTurnsAreSpoken() {
+        let reply = VoiceReply(speaker: FakeSpeaker())
+
+        XCTAssertFalse(
+            answer(reply, scoop: "cone", messageId: "m1"),
+            "a typed turn is never voice-initiated")
+        reply.markSubmission(scoopJid: "cone")
+        XCTAssertTrue(answer(reply, scoop: "cone", messageId: "m2"))
+        XCTAssertFalse(
+            answer(reply, scoop: "cone", messageId: "m3"),
+            "one mark answers exactly one turn")
     }
 
     func testQueuedDictatedTurnsStayBalanced() {
         let reply = VoiceReply(speaker: FakeSpeaker())
-        reply.markSubmission()
-        reply.markSubmission()
-        XCTAssertTrue(reply.consumeSubmission())
-        XCTAssertTrue(reply.consumeSubmission())
-        XCTAssertFalse(reply.consumeSubmission())
+        reply.markSubmission(scoopJid: "cone")
+        reply.markSubmission(scoopJid: "cone")
+        XCTAssertTrue(answer(reply, scoop: "cone", messageId: "m1"))
+        XCTAssertTrue(answer(reply, scoop: "cone", messageId: "m2"))
+        XCTAssertFalse(answer(reply, scoop: "cone", messageId: "m3"))
+    }
+
+    func testAReplyAlreadyStreamingCannotClaimALaterMark() {
+        // The typed turn opened its message BEFORE the user dictated, so its
+        // completion must not consume the dictated mark and read the wrong
+        // answer aloud while the dictated one stays silent.
+        let reply = VoiceReply(speaker: FakeSpeaker())
+        reply.bindReply(scoopJid: "cone", messageId: "typed")
+        reply.markSubmission(scoopJid: "cone")
+
+        XCTAssertFalse(
+            reply.consumeSubmission(scoopJid: "cone", messageId: "typed"),
+            "the in-flight typed reply predates the mark")
+        XCTAssertTrue(
+            answer(reply, scoop: "cone", messageId: "dictated"),
+            "the next message the scoop opens is the dictated answer")
+    }
+
+    func testAnotherScoopFinishingFirstDoesNotStealTheMark() {
+        let reply = VoiceReply(speaker: FakeSpeaker())
+        reply.markSubmission(scoopJid: "cone")
+
+        XCTAssertFalse(
+            answer(reply, scoop: "scoop-a", messageId: "m1"),
+            "a concurrent scoop's reply answers nothing the user dictated")
+        XCTAssertTrue(answer(reply, scoop: "cone", messageId: "m2"))
+    }
+
+    func testRollbackRetiresAMarkWhoseSendNeverLeft() {
+        let reply = VoiceReply(speaker: FakeSpeaker())
+        reply.markSubmission(scoopJid: "cone")
+        reply.rollbackSubmission(scoopJid: "cone")
+        XCTAssertFalse(
+            answer(reply, scoop: "cone", messageId: "m1"),
+            "an undelivered message will never be answered")
+    }
+
+    func testRollbackLeavesAnAlreadyBoundMarkAlone() {
+        // A failed send must retire ITS mark, not one already matched to a
+        // reply that is on its way.
+        let reply = VoiceReply(speaker: FakeSpeaker())
+        reply.markSubmission(scoopJid: "cone")
+        reply.bindReply(scoopJid: "cone", messageId: "inflight")
+        reply.rollbackSubmission(scoopJid: "cone")
+        XCTAssertTrue(reply.consumeSubmission(scoopJid: "cone", messageId: "inflight"))
     }
 
     func testResetDropsPendingMarksAndSilencesTheEngine() {
         let speaker = FakeSpeaker()
         let reply = VoiceReply(speaker: speaker)
-        reply.markSubmission()
+        reply.markSubmission(scoopJid: "cone")
         reply.reset()
         XCTAssertFalse(
-            reply.consumeSubmission(), "a stale mark must not speak the next session's reply")
+            answer(reply, scoop: "cone", messageId: "m1"),
+            "a stale mark must not speak the next session's reply")
         XCTAssertEqual(speaker.stops, 1)
     }
 

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/VoiceReplyTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/VoiceReplyTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+
+@testable import SliccFollower
+
+/// The dictation markers and the spoken-reply loop. Both are ports of
+/// `packages/webapp/src/speech/{dictation-priming,voice-reply}.ts`, so the
+/// cases mirror the web's contract: markers reach the model but never the
+/// bubble, and only dictated turns get read back.
+@MainActor
+final class VoiceReplyTests: XCTestCase {
+
+    /// Records what would have been spoken.
+    private final class FakeSpeaker: SpeechSpeaking {
+        var spoken: [(text: String, lang: String?)] = []
+        var stops = 0
+        var availableLanguages: Set<String> = ["en", "de"]
+
+        func speak(_ text: String, lang: String?) { spoken.append((text, lang)) }
+        func stop() { stops += 1 }
+        func hasVoice(for lang: String) -> Bool {
+            availableLanguages.contains(lang.split(separator: "-").first.map(String.init) ?? lang)
+        }
+    }
+
+    override func setUp() {
+        super.setUp()
+        DictationPriming.reset()
+    }
+
+    // MARK: - Dictation markers
+
+    func testFirstDictatedTurnCarriesThePrimingNote() {
+        let marked = DictationPriming.applyMarkers("hello there", isFirst: true)
+        XCTAssertTrue(marked.hasPrefix("hello there "))
+        XCTAssertTrue(marked.contains(DictationPriming.micGlyph))
+        XCTAssertTrue(marked.contains(DictationPriming.primingNote))
+    }
+
+    func testLaterDictatedTurnsCarryOnlyTheMicrophone() {
+        let marked = DictationPriming.applyMarkers("again", isFirst: false)
+        XCTAssertTrue(marked.contains(DictationPriming.micGlyph))
+        XCTAssertFalse(marked.contains(DictationPriming.primingNote))
+    }
+
+    func testMarkersAreNotDoubleSpaced() {
+        XCTAssertEqual(
+            DictationPriming.applyMarkers("trailing ", isFirst: false),
+            "trailing \(DictationPriming.micGlyph)")
+    }
+
+    func testStripMarkersRestoresWhatTheUserSaid() {
+        let marked = DictationPriming.applyMarkers("what is the weather", isFirst: true)
+        XCTAssertEqual(DictationPriming.stripMarkers(marked), "what is the weather")
+    }
+
+    func testStripMarkersHandlesAMessageThatIsOnlyMarkers() {
+        let marked = DictationPriming.applyMarkers("", isFirst: true)
+        XCTAssertEqual(DictationPriming.stripMarkers(marked), "")
+    }
+
+    func testStripMarkersLeavesTypedTextUntouched() {
+        let typed = "a normal message with ◁ nothing to strip"
+        XCTAssertEqual(DictationPriming.stripMarkers(typed), typed)
+    }
+
+    func testFirstFlagIsOneShotUntilReset() {
+        XCTAssertTrue(DictationPriming.consumeFirst())
+        XCTAssertFalse(DictationPriming.consumeFirst())
+        DictationPriming.reset()
+        XCTAssertTrue(DictationPriming.consumeFirst(), "a fresh session re-arms the note")
+    }
+
+    // MARK: - Reply language marker
+
+    func testReplyLangIsParsedAndStripped() {
+        let reply = "<!--lang:de-->Guten Tag."
+        XCTAssertEqual(DictationPriming.replyLang(reply), "de")
+        XCTAssertEqual(DictationPriming.stripReplyLangMarker(reply), "Guten Tag.")
+    }
+
+    func testReplyLangToleratesWhitespaceRegionsAndCasing() {
+        XCTAssertEqual(DictationPriming.replyLang("<!-- LANG: pt-BR -->oi"), "pt-BR")
+    }
+
+    func testReplyWithoutAMarkerHasNoLanguage() {
+        XCTAssertNil(DictationPriming.replyLang("just prose"))
+    }
+
+    // MARK: - Markdown to speech
+
+    func testFencedCodeIsNotReadAloud() {
+        let text = VoiceReply.speechText(
+            fromMarkdown: "Here you go:\n\n```sh\nrm -rf /\n```\n\nDone.")
+        XCTAssertFalse(text.contains("rm -rf"))
+        XCTAssertTrue(text.contains("Here you go"))
+        XCTAssertTrue(text.contains("Done"))
+    }
+
+    func testUnterminatedFenceDoesNotLeakItsBody() {
+        // A truncated reply would otherwise monologue its whole code block.
+        let text = VoiceReply.speechText(fromMarkdown: "Sure:\n\n```js\nconst x = 1;\nconst y")
+        XCTAssertEqual(text, "Sure:")
+    }
+
+    func testLinksAreSpokenAsTheirLabel() {
+        XCTAssertEqual(
+            VoiceReply.speechText(fromMarkdown: "See [the docs](https://example.com/a/b)."),
+            "See the docs.")
+    }
+
+    func testImagesAreSpokenAsTheirAltText() {
+        XCTAssertEqual(
+            VoiceReply.speechText(fromMarkdown: "![a red cone](x.png)"), "a red cone")
+    }
+
+    func testShortInlineCodeIsSpokenAndLongSpansAreDropped() {
+        XCTAssertEqual(VoiceReply.speechText(fromMarkdown: "Run `ls` now."), "Run ls now.")
+        let long = String(repeating: "x", count: VoiceReply.maxSpokenInlineCodeCharacters + 1)
+        XCTAssertEqual(VoiceReply.speechText(fromMarkdown: "Try `\(long)` ok"), "Try ok")
+    }
+
+    func testStructuralMarkupIsRemoved() {
+        let markdown = """
+            # Heading
+
+            > quoted
+
+            - one
+            - two
+
+            **bold** and *italic*
+            """
+        let text = VoiceReply.speechText(fromMarkdown: markdown)
+        XCTAssertEqual(text, "Heading quoted one two bold and italic")
+    }
+
+    func testRunawayProseIsCappedOnAWordBoundary() {
+        let markdown = String(repeating: "word ", count: VoiceReply.maxSpeechCharacters)
+        let text = VoiceReply.speechText(fromMarkdown: markdown)
+        XCTAssertLessThanOrEqual(text.count, VoiceReply.maxSpeechCharacters + 1)
+        XCTAssertTrue(text.hasSuffix("…"))
+        XCTAssertFalse(text.hasSuffix("wor…"), "the cap must not split a word")
+    }
+
+    // MARK: - The loop
+
+    func testOnlyDictatedTurnsAreSpoken() {
+        let speaker = FakeSpeaker()
+        let reply = VoiceReply(speaker: speaker)
+
+        XCTAssertFalse(reply.consumeSubmission(), "a typed turn is never voice-initiated")
+        reply.markSubmission()
+        XCTAssertTrue(reply.consumeSubmission())
+        XCTAssertFalse(reply.consumeSubmission(), "one mark answers exactly one turn")
+    }
+
+    func testQueuedDictatedTurnsStayBalanced() {
+        let reply = VoiceReply(speaker: FakeSpeaker())
+        reply.markSubmission()
+        reply.markSubmission()
+        XCTAssertTrue(reply.consumeSubmission())
+        XCTAssertTrue(reply.consumeSubmission())
+        XCTAssertFalse(reply.consumeSubmission())
+    }
+
+    func testResetDropsPendingMarksAndSilencesTheEngine() {
+        let speaker = FakeSpeaker()
+        let reply = VoiceReply(speaker: speaker)
+        reply.markSubmission()
+        reply.reset()
+        XCTAssertFalse(
+            reply.consumeSubmission(), "a stale mark must not speak the next session's reply")
+        XCTAssertEqual(speaker.stops, 1)
+    }
+
+    func testSpokenReplyUsesTheDeclaredLanguage() {
+        let speaker = FakeSpeaker()
+        VoiceReply(speaker: speaker).speakReply(markdown: "<!--lang:de-->Guten **Tag**.")
+        XCTAssertEqual(speaker.spoken.count, 1)
+        XCTAssertEqual(speaker.spoken.first?.text, "Guten Tag.")
+        XCTAssertEqual(speaker.spoken.first?.lang, "de")
+    }
+
+    func testReplyStaysSilentWhenNoVoiceExistsForItsLanguage() {
+        let speaker = FakeSpeaker()
+        speaker.availableLanguages = ["en"]
+        VoiceReply(speaker: speaker).speakReply(markdown: "<!--lang:ja-->こんにちは")
+        XCTAssertTrue(
+            speaker.spoken.isEmpty, "better silent than Japanese read in an English voice")
+    }
+
+    func testReplyWithoutALanguageMarkerStillSpeaks() {
+        let speaker = FakeSpeaker()
+        VoiceReply(speaker: speaker).speakReply(markdown: "All done.")
+        XCTAssertEqual(speaker.spoken.first?.text, "All done.")
+        XCTAssertNil(speaker.spoken.first?.lang)
+    }
+
+    func testAReplyThatReducesToNothingIsNotSpoken() {
+        let speaker = FakeSpeaker()
+        VoiceReply(speaker: speaker).speakReply(markdown: "```\njust code\n```")
+        XCTAssertTrue(speaker.spoken.isEmpty)
+    }
+}

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -150,6 +150,9 @@ struct ConversationView: View {
     @Binding var showFrozenSessions: Bool
     @State private var inputText = ChatView.seededComposerText()
     @State private var showNewSessionDialog = false
+    /// Mirrors `ChatView` so the nav-bar clusters follow the rail to the
+    /// reachable edge.
+    @AppStorage("leftHandedDock") private var leftHandedDock = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -162,13 +165,6 @@ struct ConversationView: View {
             )
             .animation(.easeInOut(duration: 0.3), value: appState.connectionState)
             .animation(.easeInOut(duration: 0.3), value: appState.isLeaderStalled)
-
-            // Scoop indicator + tap-to-cycle.
-            if appState.scoops.count > 1 {
-                ScoopHeaderView()
-                    .padding(.vertical, 6)
-                    .background(palette.canvas.opacity(0.85))
-            }
 
             if let frozen = appState.openFrozen {
                 // Read-only view of an archived session. The live transcript
@@ -188,67 +184,16 @@ struct ConversationView: View {
             }
         }
         .background(palette.canvas)
-        .navigationTitle(
-            appState.openFrozen?.entry.title
-                ?? appState.selectedScoop?.assistantLabel ?? "SLICC"
-        )
+        // The live session identifies itself through the compact switcher in
+        // the corner, not through a nav title — two copies of the same scoop
+        // label stacked on top of each other is what the full-width scoop
+        // header used to cost.
+        .navigationTitle(appState.openFrozen?.entry.title ?? "")
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(appState.openFrozen != nil)
         .toolbar {
-            // While frozen, the top-left Back returns to the LIVE session —
-            // the system back (which pops to the sidebar) is hidden so there
-            // is exactly one back affordance and it does what it looks like.
-            if appState.openFrozen != nil {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: { appState.closeFrozenSession() }) {
-                        Image(systemName: "chevron.backward")
-                            .foregroundStyle(palette.ink.opacity(0.7))
-                    }
-                    .accessibilityLabel("Back to live session")
-                    .accessibilityIdentifier("frozen-back")
-                }
-            }
-            // The rail button hides while a frozen session is open — the
-            // snowflake would only offer more of what is already on screen.
-            if appState.openFrozen == nil {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    // New chat lives beside the snowflake and gear (the
-                    // top control cluster owns session-level actions; the
-                    // dock rail owns workbench surfaces).
-                    Button(action: { showNewSessionDialog = true }) {
-                        if appState.newSessionInFlight {
-                            ProgressView()
-                        } else {
-                            Image(systemName: "square.and.pencil")
-                                .foregroundStyle(palette.ink.opacity(0.7))
-                        }
-                    }
-                    // Gated like the composer: with no usable leader the
-                    // request would silently vanish (requestNewSession
-                    // returns when the channel cannot be written).
-                    .disabled(
-                        appState.newSessionInFlight
-                            || appState.connectionState != .connected
-                            || appState.isLeaderStalled
-                    )
-                    .accessibilityLabel("New chat")
-                    .accessibilityIdentifier("new-chat-button")
-                }
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: { showFrozenSessions = true }) {
-                        Image(systemName: "snowflake")
-                            .foregroundStyle(palette.ink.opacity(0.7))
-                    }
-                    .accessibilityLabel("Past Sessions")
-                    .accessibilityIdentifier("frozen-rail-button")
-                }
-            }
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: { showSettings = true }) {
-                    Image(systemName: "gearshape")
-                        .foregroundStyle(palette.ink.opacity(0.7))
-                }
-            }
+            identityGroup
+            sessionControls
         }
         .sheet(isPresented: $showFrozenSessions) {
             FrozenSessionsView()
@@ -265,6 +210,105 @@ struct ConversationView: View {
                 }
             #endif
         }
+    }
+
+    // MARK: - Toolbar
+
+    /// The rail's edge is the reachable one, so both nav-bar clusters follow
+    /// it: identity opposite the rail, session actions on the rail's side.
+    private var identityPlacement: ToolbarItemPlacement {
+        leftHandedDock ? .topBarTrailing : .topBarLeading
+    }
+    private var controlsPlacement: ToolbarItemPlacement {
+        leftHandedDock ? .topBarLeading : .topBarTrailing
+    }
+
+    /// Who you are talking to: the frozen back button, or the compact
+    /// cone/scoop switcher that replaced the full-width header row.
+    @ToolbarContentBuilder
+    private var identityGroup: some ToolbarContent {
+        ToolbarItem(placement: identityPlacement) {
+            if appState.openFrozen != nil {
+                // While frozen, Back returns to the LIVE session — the system
+                // back (which pops to the sidebar) is hidden so there is
+                // exactly one back affordance and it does what it looks like.
+                Button {
+                    appState.closeFrozenSession()
+                } label: {
+                    Image(systemName: "chevron.backward")
+                        .foregroundStyle(palette.ink.opacity(0.7))
+                }
+                .accessibilityLabel("Back to live session")
+                .accessibilityIdentifier("frozen-back")
+            } else {
+                ScoopSwitcher()
+            }
+        }
+    }
+
+    /// Session-level actions. `settings` sits in the middle of the cluster in
+    /// both handedness modes; the outer two mirror so New chat — the most
+    /// frequent of the three — stays nearest the holding hand's edge.
+    @ToolbarContentBuilder
+    private var sessionControls: some ToolbarContent {
+        ToolbarItemGroup(placement: controlsPlacement) {
+            if appState.openFrozen != nil {
+                settingsButton
+            } else if leftHandedDock {
+                newChatButton
+                settingsButton
+                frozenSessionsButton
+            } else {
+                frozenSessionsButton
+                settingsButton
+                newChatButton
+            }
+        }
+    }
+
+    private var newChatButton: some View {
+        Button {
+            showNewSessionDialog = true
+        } label: {
+            if appState.newSessionInFlight {
+                ProgressView()
+            } else {
+                Image(systemName: "square.and.pencil")
+                    .foregroundStyle(palette.ink.opacity(0.7))
+            }
+        }
+        // Gated like the composer: with no usable leader the request would
+        // silently vanish (requestNewSession returns when the channel cannot
+        // be written).
+        .disabled(
+            appState.newSessionInFlight
+                || appState.connectionState != .connected
+                || appState.isLeaderStalled
+        )
+        .accessibilityLabel("New chat")
+        .accessibilityIdentifier("new-chat-button")
+    }
+
+    private var settingsButton: some View {
+        Button {
+            showSettings = true
+        } label: {
+            Image(systemName: "gearshape")
+                .foregroundStyle(palette.ink.opacity(0.7))
+        }
+        .accessibilityLabel("Settings")
+        .accessibilityIdentifier("settings-button")
+    }
+
+    private var frozenSessionsButton: some View {
+        Button {
+            showFrozenSessions = true
+        } label: {
+            Image(systemName: "snowflake")
+                .foregroundStyle(palette.ink.opacity(0.7))
+        }
+        .accessibilityLabel("Past Sessions")
+        .accessibilityIdentifier("frozen-rail-button")
     }
 
     @ViewBuilder
@@ -413,60 +457,81 @@ struct FixtureConversationView: View {
     }
 }
 
-// MARK: - ScoopHeaderView
+// MARK: - ScoopSwitcher
 
-/// Slim header showing the currently-viewed scoop with chevron buttons for
-/// manual prev/next switching (in addition to swipe gestures).
-struct ScoopHeaderView: View {
+/// The nav-bar cone/scoop switcher. Replaces the old full-width header row:
+/// the same identity (glyph + label + leader-active dot) in a nav-bar-sized
+/// control, and a menu that jumps straight to a scoop instead of cycling
+/// one chevron tap at a time. Swipe still cycles.
+struct ScoopSwitcher: View {
     @EnvironmentObject var appState: AppState
     @Environment(\.palette) private var palette
 
     var body: some View {
-        HStack(spacing: 12) {
-            Button {
-                appState.swipeToPreviousScoop()
-            } label: {
-                Image(systemName: "chevron.left")
-                    .font(.system(size: 14, weight: .semibold))
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .foregroundStyle(palette.ink.opacity(0.6))
-            }
-
-            Spacer()
-
-            HStack(spacing: 6) {
-                Image(
-                    systemName: appState.selectedScoop?.isCone == true
-                        ? "cup.and.saucer.fill"
-                        : "circle.grid.2x2"
-                )
-                .foregroundStyle(.purple)
-                Text(appState.selectedScoop?.assistantLabel ?? "—")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(palette.ink)
-                if let active = appState.leaderActiveScoopJid,
-                    active == appState.selectedScoopJid
-                {
-                    Circle()
-                        .fill(Color.green)
-                        .frame(width: 6, height: 6)
+        if appState.scoops.count > 1 {
+            Menu {
+                ForEach(appState.scoops) { scoop in
+                    Button {
+                        appState.selectScoop(jid: scoop.jid)
+                    } label: {
+                        Label(
+                            menuTitle(for: scoop),
+                            systemImage: scoop.jid == appState.selectedScoopJid
+                                ? "checkmark" : Self.glyph(isCone: scoop.isCone))
+                    }
+                    .accessibilityIdentifier("scoop-switch-\(scoop.jid)")
                 }
-            }
-
-            Spacer()
-
-            Button {
-                appState.swipeToNextScoop()
             } label: {
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 14, weight: .semibold))
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .foregroundStyle(palette.ink.opacity(0.6))
+                identityLabel
+            }
+            .accessibilityLabel("Switch scoop")
+            .accessibilityIdentifier("scoop-switcher")
+        } else {
+            identityLabel
+                .accessibilityIdentifier("scoop-switcher")
+        }
+    }
+
+    /// Glyph + label + leader-active dot, sized to sit inside the nav bar.
+    /// `.lineLimit(1)` plus a cap keeps a chatty `assistantLabel` from
+    /// pushing the action cluster off the other edge.
+    private var identityLabel: some View {
+        HStack(spacing: 5) {
+            Image(systemName: Self.glyph(isCone: appState.selectedScoop?.isCone ?? true))
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(palette.accent)
+            Text(appState.selectedScoop?.assistantLabel ?? "SLICC")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(palette.ink)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: 140, alignment: .leading)
+            if appState.leaderActiveScoopJid != nil,
+                appState.leaderActiveScoopJid == appState.selectedScoopJid
+            {
+                Circle()
+                    .fill(Color.green)
+                    .frame(width: 6, height: 6)
+            }
+            if appState.scoops.count > 1 {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(palette.ink.opacity(0.5))
             }
         }
-        .padding(.horizontal, 14)
+        .fixedSize()
+    }
+
+    /// The leader's active scoop is marked in the menu too — the dot on the
+    /// closed control only speaks about the one you are looking at.
+    private func menuTitle(for scoop: ScoopSummary) -> String {
+        scoop.jid == appState.leaderActiveScoopJid
+            ? "\(scoop.assistantLabel) · active"
+            : scoop.assistantLabel
+    }
+
+    private static func glyph(isCone: Bool) -> String {
+        isCone ? "cup.and.saucer.fill" : "circle.grid.2x2"
     }
 }
 

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -335,8 +335,9 @@ struct ConversationView: View {
                 // than claiming the follower is disconnected.
                 isStalled: appState.isLeaderStalled,
                 steersActiveScoop: appState.composerTargetsLeaderActiveScoop,
-                onSend: { text, attachments in
-                    appState.sendMessage(text, attachments: attachments)
+                onSend: { text, attachments, dictated in
+                    appState.sendMessage(
+                        text, attachments: attachments, dictated: dictated)
                     inputText = ""
                 },
                 onAbort: {
@@ -474,10 +475,13 @@ struct ScoopSwitcher: View {
                     Button {
                         appState.selectScoop(jid: scoop.jid)
                     } label: {
+                        // A menu row can only draw `Image`/`Text`, never a
+                        // custom Shape, so the lucide cone cannot appear
+                        // here — the row says cone or scoop in words instead.
                         Label(
                             menuTitle(for: scoop),
                             systemImage: scoop.jid == appState.selectedScoopJid
-                                ? "checkmark" : Self.glyph(isCone: scoop.isCone))
+                                ? "checkmark" : "circle")
                     }
                     .accessibilityIdentifier("scoop-switch-\(scoop.jid)")
                 }
@@ -497,8 +501,7 @@ struct ScoopSwitcher: View {
     /// pushing the action cluster off the other edge.
     private var identityLabel: some View {
         HStack(spacing: 5) {
-            Image(systemName: Self.glyph(isCone: appState.selectedScoop?.isCone ?? true))
-                .font(.system(size: 13, weight: .semibold))
+            ConeScoopGlyph(isCone: appState.selectedScoop?.isCone ?? true, size: 17)
                 .foregroundStyle(palette.accent)
             Text(appState.selectedScoop?.assistantLabel ?? "SLICC")
                 .font(.system(size: 15, weight: .semibold))
@@ -525,13 +528,10 @@ struct ScoopSwitcher: View {
     /// The leader's active scoop is marked in the menu too — the dot on the
     /// closed control only speaks about the one you are looking at.
     private func menuTitle(for scoop: ScoopSummary) -> String {
-        scoop.jid == appState.leaderActiveScoopJid
-            ? "\(scoop.assistantLabel) · active"
-            : scoop.assistantLabel
-    }
-
-    private static func glyph(isCone: Bool) -> String {
-        isCone ? "cup.and.saucer.fill" : "circle.grid.2x2"
+        let kind = scoop.isCone ? "cone" : "scoop"
+        return scoop.jid == appState.leaderActiveScoopJid
+            ? "\(scoop.assistantLabel) · \(kind) · active"
+            : "\(scoop.assistantLabel) · \(kind)"
     }
 }
 

--- a/packages/ios-app/SliccFollower/Views/DockModel.swift
+++ b/packages/ios-app/SliccFollower/Views/DockModel.swift
@@ -5,9 +5,6 @@ import Foundation
 /// plus the pinned system tools, in prototype order.
 enum DockSurface: Hashable {
     case sprinkle(name: String)
-    /// The always-present `New +` launcher. Sprinkles are authored on the
-    /// leader, so on a follower this opens an honest placeholder.
-    case newSprinkle
     case browser
     case files
     case term
@@ -25,22 +22,22 @@ struct DockItem: Identifiable, Hashable {
 }
 
 /// Pure builders so the rail's order is unit-testable: sprinkle launchers
-/// at the top, then `New +`; the pinned tools anchor the bottom after a
-/// spacer + divider (the view owns those two).
+/// at the top; the pinned tools anchor the bottom after a spacer + divider
+/// (the view owns those two).
+///
+/// There is no `New +` launcher: sprinkles are authored on the leader, so
+/// the button could only ever open a placeholder — a rail entry that does
+/// nothing costs a tap target and teaches the wrong affordance.
 enum DockModel {
     static func sprinkleItems(_ sprinkles: [SprinkleSummary]) -> [DockItem] {
         sprinkles.map { sprinkle in
             DockItem(
                 id: "sprinkle-\(sprinkle.name)",
                 surface: .sprinkle(name: sprinkle.name),
-                systemImage: "sparkles",
+                systemImage: SliccIcons.sprinkle(iconSpec: sprinkle.icon),
                 label: sprinkle.title
             )
-        } + [
-            DockItem(
-                id: "new", surface: .newSprinkle, systemImage: "plus",
-                label: "New sprinkle")
-        ]
+        }
     }
 
     /// The pinned system tools, in the web dock's exact order.
@@ -62,8 +59,6 @@ enum DockModel {
         switch surface {
         case .sprinkle, .browser, .monitor, .memory, .files:
             return nil
-        case .newSprinkle:
-            return "Sprinkles are authored on the leader. Ask the cone to scoop one up — it appears here when the leader registers it."
         case .term:
             return "The shell runs on the leader. A follower has no local terminal - drive the session through chat."
         }

--- a/packages/ios-app/SliccFollower/Views/InputBar.swift
+++ b/packages/ios-app/SliccFollower/Views/InputBar.swift
@@ -1,6 +1,9 @@
+import OSLog
 import PhotosUI
 import SwiftUI
 import UIKit
+
+private let logger = Logger(subsystem: "com.sliccy.follower", category: "composer")
 
 struct InputBar: View {
     @Binding var text: String
@@ -14,8 +17,9 @@ struct InputBar: View {
     /// steer affordance hides so an interrupt cannot hit the wrong turn.
     var steersActiveScoop: Bool = true
     /// Send the composed message: trimmed text + any staged attachments
-    /// (nil rather than an empty array, matching the wire shape).
-    let onSend: (String, [MessageAttachment]?) -> Void
+    /// (nil rather than an empty array, matching the wire shape) + whether
+    /// the turn was dictated, which arms the spoken reply.
+    let onSend: (String, [MessageAttachment]?, Bool) -> Void
     let onAbort: () -> Void
     /// Send interrupting the running turn (`user_message.steer`). Only
     /// reachable while streaming, via the long-press menu on send.
@@ -125,9 +129,16 @@ struct InputBar: View {
             switch event.kind {
             case .commit(let transcript):
                 // The gesture only arms on an empty composer, so the
-                // transcript IS the message — reuse the exact send path.
-                text = transcript
-                sendIfPossible()
+                // transcript IS the message — submit it directly instead of
+                // writing `text` and re-reading it through the binding, which
+                // made the send depend on when SwiftUI published the write.
+                // If the leader turned unsendable mid-hold, fall back to
+                // leaving the words in the composer: dictation that cannot
+                // be delivered must not evaporate.
+                if !submit(transcript, dictated: true) {
+                    logger.notice("dictation not sent — composer unavailable; kept as draft")
+                    text = transcript
+                }
             case .quickTap:
                 // Restore the native behavior the surface intercepted: a
                 // plain tap places the caret.
@@ -357,7 +368,9 @@ struct InputBar: View {
             .transition(.scale.combined(with: .opacity))
             .padding(.bottom, 2)
         } else {
-            Button(action: { sendIfPossible() }) {
+            Button {
+                sendIfPossible()
+            } label: {
                 Image(systemName: "arrow.up.circle.fill")
                     .font(.system(size: 30))
                     .foregroundStyle(canSend ? palette.accent : palette.inkTertiary.opacity(0.6))
@@ -372,11 +385,21 @@ struct InputBar: View {
     // MARK: - Actions
 
     private func sendIfPossible() {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard canSend else { return }
-        onSend(trimmed, stagedAttachments.isEmpty ? nil : stagedAttachments)
+        _ = submit(text, dictated: false)
+    }
+
+    /// The one send path. Takes the body explicitly so push-to-talk can
+    /// submit a transcript the composer binding has not published yet, and
+    /// reports whether the message actually went out so a caller holding the
+    /// only copy of it can decide what to do when it did not.
+    @discardableResult
+    private func submit(_ body: String, dictated: Bool) -> Bool {
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isComposable, !trimmed.isEmpty || !stagedAttachments.isEmpty else { return false }
+        onSend(trimmed, stagedAttachments.isEmpty ? nil : stagedAttachments, dictated)
         text = ""
         stagedAttachments = []
+        return true
     }
 
     private func steerIfPossible() {
@@ -401,7 +424,7 @@ struct InputBar: View {
                 text: .constant(""),
                 isStreaming: false,
                 isConnected: true,
-                onSend: { _, _ in },
+                onSend: { _, _, _ in },
                 onAbort: {}
             )
         }
@@ -418,7 +441,7 @@ struct InputBar: View {
                 text: .constant("Hello world"),
                 isStreaming: true,
                 isConnected: true,
-                onSend: { _, _ in },
+                onSend: { _, _, _ in },
                 onAbort: {}
             )
         }
@@ -435,7 +458,7 @@ struct InputBar: View {
                 text: .constant(""),
                 isStreaming: false,
                 isConnected: false,
-                onSend: { _, _ in },
+                onSend: { _, _, _ in },
                 onAbort: {}
             )
         }

--- a/packages/ios-app/SliccFollower/Views/LucideIcon.swift
+++ b/packages/ios-app/SliccFollower/Views/LucideIcon.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+// MARK: - Glyph registry
+
+/// Lucide glyphs ported as their literal upstream path data.
+///
+/// The web UI renders every icon from lucide
+/// (`packages/webcomponents/src/internal/icons.ts` — "NOT emoji or bespoke
+/// glyphs"), and the phone approximated them with SF Symbols. That works for
+/// generic nouns, but SF Symbols has no ice cream cone, so the cone — the
+/// product's central metaphor — was rendering as a teacup, and scoops as a
+/// 2x2 grid. Neither reads as SLICC.
+///
+/// Only the glyphs the phone actually needs are ported; adding one means
+/// pasting its `d` string from `node_modules/lucide/dist/esm/icons/<name>.js`.
+/// Icons are lucide v1.8.0, ISC licensed (Copyright Lucide Icons and
+/// Contributors), on a 24x24 viewBox with 2px round-capped strokes.
+enum LucideGlyph: String, CaseIterable {
+    case iceCreamCone = "ice-cream-cone"
+    case iceCreamBowl = "ice-cream-bowl"
+
+    /// The `d` strings of the glyph's `<path>` children, verbatim.
+    var pathData: [String] {
+        switch self {
+        case .iceCreamCone:
+            return [
+                "m7 11 4.08 10.35a1 1 0 0 0 1.84 0L17 11",
+                "M17 7A5 5 0 0 0 7 7",
+                "M17 7a2 2 0 0 1 0 4H7a2 2 0 0 1 0-4",
+            ]
+        case .iceCreamBowl:
+            return [
+                "M12 17c5 0 8-2.69 8-6H4c0 3.31 3 6 8 6m-4 4h8m-4-3v3M5.14 11a3.5 3.5 0 1 1 6.71 0",
+                "M12.14 11a3.5 3.5 0 1 1 6.71 0",
+                "M15.5 6.5a3.5 3.5 0 1 0-7 0",
+            ]
+        }
+    }
+}
+
+extension LucideGlyph {
+    /// The glyph parsed once, in its own 24-unit space.
+    ///
+    /// `Shape.path(in:)` is called on every layout pass, and re-parsing
+    /// arc-heavy path data per frame is expensive enough to make a screen
+    /// full of glyphs visibly slow. The set is tiny and immutable, so it is
+    /// parsed eagerly on first use and reused forever after.
+    var unitPath: CGPath {
+        Self.unitPaths[self] ?? CGMutablePath()
+    }
+
+    private static let unitPaths: [LucideGlyph: CGPath] = {
+        var built: [LucideGlyph: CGPath] = [:]
+        for glyph in LucideGlyph.allCases {
+            let combined = CGMutablePath()
+            for data in glyph.pathData {
+                combined.addPath(SVGPath.parse(data))
+            }
+            built[glyph] = combined
+        }
+        return built
+    }()
+}
+
+// MARK: - Shape
+
+/// The glyph's outline in a given rect. Separate from the view so it can be
+/// stroked, animated or masked like any other `Shape`.
+struct LucideShape: Shape {
+    let glyph: LucideGlyph
+
+    func path(in rect: CGRect) -> Path {
+        Path(SVGPath.fitted(glyph.unitPath, in: rect))
+    }
+}
+
+// MARK: - View
+
+/// A lucide glyph rendered at `size`, tinted by the surrounding
+/// `foregroundStyle` like an SF Symbol.
+///
+/// Stroke width scales with the glyph so a 13pt cone keeps lucide's optical
+/// weight rather than turning into a smudge — the web sets `stroke-width: 2`
+/// against a fixed 24px box, so the equivalent here is proportional.
+struct LucideIcon: View {
+    let glyph: LucideGlyph
+    var size: CGFloat = 16
+    /// Stroke width in the glyph's own 24-unit space (lucide's default is 2).
+    var strokeWidth: CGFloat = 2
+
+    var body: some View {
+        LucideShape(glyph: glyph)
+            .stroke(
+                style: StrokeStyle(
+                    lineWidth: strokeWidth * size / 24,
+                    lineCap: .round,
+                    lineJoin: .round)
+            )
+            // Lucide glyphs touch the edge of the 24-unit box, so the stroke
+            // straddles it. Inset by half a stroke BEFORE sizing, so the
+            // caller still gets exactly `size` points and nothing clips.
+            .padding(strokeWidth * size / 48)
+            .frame(width: size, height: size)
+            .accessibilityHidden(true)
+    }
+}
+
+// MARK: - Cone / scoop identity
+
+/// The cone-vs-scoop glyph, in one place so the switcher, the transcript and
+/// the monitor cannot drift apart. The cone is the session's main agent; a
+/// scoop is a sandboxed sub-agent.
+struct ConeScoopGlyph: View {
+    let isCone: Bool
+    var size: CGFloat = 16
+
+    var body: some View {
+        LucideIcon(glyph: isCone ? .iceCreamCone : .iceCreamBowl, size: size)
+            .accessibilityLabel(isCone ? "Cone" : "Scoop")
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(spacing: 24) {
+        HStack(spacing: 20) {
+            ConeScoopGlyph(isCone: true, size: 13)
+            ConeScoopGlyph(isCone: true, size: 24)
+            ConeScoopGlyph(isCone: true, size: 48)
+        }
+        .foregroundStyle(.purple)
+        HStack(spacing: 20) {
+            ConeScoopGlyph(isCone: false, size: 13)
+            ConeScoopGlyph(isCone: false, size: 24)
+            ConeScoopGlyph(isCone: false, size: 48)
+        }
+        .foregroundStyle(.teal)
+    }
+    .padding()
+}

--- a/packages/ios-app/SliccFollower/Views/MarkdownText.swift
+++ b/packages/ios-app/SliccFollower/Views/MarkdownText.swift
@@ -3,7 +3,11 @@ import SwiftUI
 // MARK: - MarkdownText
 
 /// Renders markdown content as styled SwiftUI views.
-/// Handles fenced code blocks specially since AttributedString(markdown:) doesn't support them well.
+///
+/// The block grammar lives in `MarkdownBlockParser`; this view only paints
+/// it. `AttributedString(markdown:)` is used for inline spans only — it
+/// cannot render fenced code, tables or lists, which is why those are
+/// recognised as blocks first.
 struct MarkdownText: View {
     @Environment(\.palette) private var palette
 
@@ -11,9 +15,9 @@ struct MarkdownText: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            ForEach(Array(segments.enumerated()), id: \.offset) { _, segment in
-                switch segment {
-                case .text(let text):
+            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                switch block {
+                case .paragraph(let text):
                     markdownTextView(text)
                 case .heading(let level, let text):
                     headingView(level: level, text: text)
@@ -21,169 +25,44 @@ struct MarkdownText: View {
                     blockquoteView(text: text)
                 case .codeBlock(let lang, let code):
                     codeBlockView(language: lang, code: code)
+                case .list(let list):
+                    listView(list)
+                case .table(let table):
+                    tableView(table)
+                case .thematicBreak:
+                    Rectangle()
+                        .fill(palette.line)
+                        .frame(height: 1)
+                        .padding(.vertical, 2)
                 }
             }
         }
     }
 
-    // MARK: - Segment Parsing
+    private var blocks: [MarkdownBlock] { MarkdownBlockParser.parse(content) }
 
-    private enum Segment {
-        case text(String)
-        case heading(level: Int, text: String)
-        case blockquote(String)
-        case codeBlock(language: String?, code: String)
+    // MARK: - Inline Text Rendering
+
+    /// The one place inline markdown is parsed. Everything block-level hands
+    /// its body through here so **bold**, `code` and links behave the same
+    /// in a paragraph, a heading, a list item and a table cell.
+    private func inlineText(_ text: String) -> Text {
+        guard
+            let attributed = try? AttributedString(
+                markdown: text,
+                options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace))
+        else {
+            return Text(text)
+        }
+        return Text(styledForInlineCode(attributed))
     }
-
-    private var segments: [Segment] {
-        var result: [Segment] = []
-        let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        var currentText: [String] = []
-        var inCodeBlock = false
-        var codeLines: [String] = []
-        var codeLang: String?
-        var quoteLines: [String] = []
-
-        func flushText() {
-            let joined = currentText.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-            if !joined.isEmpty { result.append(.text(joined)) }
-            currentText = []
-        }
-        func flushQuote() {
-            guard !quoteLines.isEmpty else { return }
-            // Strip the leading `>` (and optional single space) from each line.
-            let body = quoteLines.map { line -> String in
-                var s = line
-                if s.hasPrefix(">") { s.removeFirst() }
-                if s.hasPrefix(" ") { s.removeFirst() }
-                return s
-            }.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-            if !body.isEmpty { result.append(.blockquote(body)) }
-            quoteLines = []
-        }
-
-        for line in lines {
-            if !inCodeBlock && line.hasPrefix("```") {
-                flushQuote()
-                flushText()
-                inCodeBlock = true
-                let langStr = String(line.dropFirst(3)).trimmingCharacters(in: .whitespaces)
-                codeLang = langStr.isEmpty ? nil : langStr
-                codeLines = []
-            } else if inCodeBlock && line.hasPrefix("```") {
-                result.append(.codeBlock(language: codeLang, code: codeLines.joined(separator: "\n")))
-                inCodeBlock = false
-                codeLines = []
-                codeLang = nil
-            } else if inCodeBlock {
-                codeLines.append(line)
-            } else if let heading = parseAtxHeading(line) {
-                flushQuote()
-                flushText()
-                result.append(.heading(level: heading.level, text: heading.text))
-            } else if line.hasPrefix(">") {
-                flushText()
-                quoteLines.append(line)
-            } else {
-                flushQuote()
-                currentText.append(line)
-            }
-        }
-
-        // Flush remaining
-        if inCodeBlock {
-            // Unclosed code block — render as code anyway
-            result.append(.codeBlock(language: codeLang, code: codeLines.joined(separator: "\n")))
-        } else {
-            flushQuote()
-            flushText()
-        }
-
-        return result
-    }
-
-    /// Parse a leading `# … ######` ATX heading. Returns nil for lines that
-    /// aren't headings (so callers fall through to plain text).
-    ///
-    /// Follows CommonMark's ATX-heading rules:
-    /// - 0-3 leading spaces are allowed (4+ → indented code block, not heading).
-    /// - The opening `#` run must be followed by whitespace or end-of-line.
-    /// - A trailing `#` run is only treated as a closing sequence when it's
-    ///   preceded by whitespace; e.g. `# C#` keeps the `#` as part of the
-    ///   title, while `# Heading ##` strips the closing `##`.
-    private func parseAtxHeading(_ line: String) -> (level: Int, text: String)? {
-        // Allow up to 3 leading spaces. 4+ leading spaces is an indented
-        // code block in CommonMark, never a heading.
-        var leadingSpaces = 0
-        var cursor = line.startIndex
-        while cursor < line.endIndex, line[cursor] == " ", leadingSpaces < 4 {
-            leadingSpaces += 1
-            cursor = line.index(after: cursor)
-        }
-        guard leadingSpaces < 4 else { return nil }
-        let trimmed = line[cursor...]
-        guard trimmed.first == "#" else { return nil }
-        var level = 0
-        var i = trimmed.startIndex
-        while i < trimmed.endIndex, trimmed[i] == "#", level < 6 {
-            level += 1
-            i = trimmed.index(after: i)
-        }
-        // Must be followed by whitespace or end-of-line for it to be a heading.
-        guard level >= 1 else { return nil }
-        if i == trimmed.endIndex { return (level, "") }
-        guard trimmed[i] == " " || trimmed[i] == "\t" else { return nil }
-        let rawText = String(trimmed[i...])
-        // Strip trailing whitespace first.
-        var endIdx = rawText.endIndex
-        while endIdx > rawText.startIndex,
-            rawText[rawText.index(before: endIdx)] == " "
-                || rawText[rawText.index(before: endIdx)] == "\t"
-        {
-            endIdx = rawText.index(before: endIdx)
-        }
-        // Walk back over a trailing run of `#`. Only treat it as a closing
-        // sequence if the character before the run is whitespace (or the
-        // entire body is hashes). Otherwise keep them — `# C#` should not
-        // become `# C`.
-        var hashStart = endIdx
-        while hashStart > rawText.startIndex,
-            rawText[rawText.index(before: hashStart)] == "#"
-        {
-            hashStart = rawText.index(before: hashStart)
-        }
-        let hadTrailingHashes = hashStart < endIdx
-        let bodyEnd: String.Index
-        if hadTrailingHashes,
-            hashStart == rawText.startIndex
-                || rawText[rawText.index(before: hashStart)] == " "
-                || rawText[rawText.index(before: hashStart)] == "\t"
-        {
-            bodyEnd = hashStart
-        } else {
-            bodyEnd = endIdx
-        }
-        let final = String(rawText[rawText.startIndex..<bodyEnd]).trimmingCharacters(in: .whitespaces)
-        return (level, final)
-    }
-
-    // MARK: - Text Rendering
 
     @ViewBuilder
     private func markdownTextView(_ text: String) -> some View {
-        if let attributed = try? AttributedString(
-            markdown: text,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        ) {
-            Text(styledForInlineCode(attributed))
-                .font(.system(size: 15))
-                .foregroundStyle(palette.ink.opacity(0.9))
-                .tint(palette.accent)
-        } else {
-            Text(text)
-                .font(.system(size: 15))
-                .foregroundStyle(palette.ink.opacity(0.9))
-        }
+        inlineText(text)
+            .font(.system(size: 15))
+            .foregroundStyle(palette.ink.opacity(0.9))
+            .tint(palette.accent)
     }
 
     /// Apply the assistant-bubble inline-code style: white@10 background,
@@ -214,18 +93,9 @@ struct MarkdownText: View {
             }
         }()
         let weight: Font.Weight = level <= 2 ? .bold : .semibold
-        if let attributed = try? AttributedString(
-            markdown: text,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        ) {
-            Text(styledForInlineCode(attributed))
-                .font(.system(size: size, weight: weight))
-                .foregroundStyle(palette.ink)
-        } else {
-            Text(text)
-                .font(.system(size: size, weight: weight))
-                .foregroundStyle(palette.ink)
-        }
+        inlineText(text)
+            .font(.system(size: size, weight: weight))
+            .foregroundStyle(palette.ink)
     }
 
     // MARK: - Blockquote Rendering
@@ -238,21 +108,91 @@ struct MarkdownText: View {
             RoundedRectangle(cornerRadius: 1.5)
                 .fill(palette.ink.opacity(0.20))
                 .frame(width: 3)
-            Group {
-                if let attributed = try? AttributedString(
-                    markdown: text,
-                    options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-                ) {
-                    Text(styledForInlineCode(attributed))
-                } else {
-                    Text(text)
-                }
-            }
-            .font(.system(size: 15))
-            .foregroundStyle(palette.ink.opacity(0.65))
-            .italic()
+            inlineText(text)
+                .font(.system(size: 15))
+                .foregroundStyle(palette.ink.opacity(0.65))
+                .italic()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - List Rendering
+
+    /// Bullets and numbers get their own gutter so wrapped lines hang under
+    /// the text, not under the marker. Nesting indents by depth.
+    private func listView(_ list: MarkdownList) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(Array(list.items.enumerated()), id: \.offset) { _, item in
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(item.marker)
+                        .font(
+                            .system(
+                                size: 15, weight: list.ordered ? .medium : .regular)
+                        )
+                        .monospacedDigit()
+                        .foregroundStyle(palette.ink.opacity(0.55))
+                        .frame(minWidth: list.ordered ? 22 : 12, alignment: .trailing)
+                    inlineText(item.text)
+                        .font(.system(size: 15))
+                        .foregroundStyle(palette.ink.opacity(0.9))
+                        .tint(palette.accent)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .padding(.leading, CGFloat(item.depth) * 16)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Table Rendering
+
+    /// Pipe tables scroll horizontally rather than compressing: a 4-column
+    /// comparison squeezed into a phone's width is unreadable, and the
+    /// leader emits those routinely.
+    private func tableView(_ table: MarkdownTable) -> some View {
+        ScrollView(.horizontal, showsIndicators: true) {
+            Grid(alignment: .topLeading, horizontalSpacing: 0, verticalSpacing: 0) {
+                GridRow {
+                    ForEach(Array(table.header.enumerated()), id: \.offset) { column, cell in
+                        tableCell(
+                            cell, alignment: table.alignments[safe: column] ?? .leading,
+                            isHeader: true, zebra: false)
+                    }
+                }
+                Rectangle()
+                    .fill(palette.line)
+                    .frame(height: 1)
+                    .gridCellColumns(max(table.columnCount, 1))
+                ForEach(Array(table.rows.enumerated()), id: \.offset) { rowIndex, row in
+                    GridRow {
+                        ForEach(Array(row.enumerated()), id: \.offset) { column, cell in
+                            tableCell(
+                                cell, alignment: table.alignments[safe: column] ?? .leading,
+                                isHeader: false, zebra: !rowIndex.isMultiple(of: 2))
+                        }
+                    }
+                }
+            }
+        }
+        .background(palette.field)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(palette.line, lineWidth: 1)
+        )
+    }
+
+    private func tableCell(
+        _ text: String, alignment: MarkdownTable.Alignment, isHeader: Bool, zebra: Bool
+    ) -> some View {
+        inlineText(text)
+            .font(.system(size: 13, weight: isHeader ? .semibold : .regular))
+            .foregroundStyle(palette.ink.opacity(isHeader ? 1.0 : 0.85))
+            .multilineTextAlignment(alignment.textAlignment)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .frame(minWidth: 56, maxWidth: 220, alignment: alignment.frameAlignment)
+            .background(zebra ? palette.ink.opacity(0.04) : .clear)
     }
 
     // MARK: - Code Block Rendering
@@ -280,6 +220,35 @@ struct MarkdownText: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(palette.field)
         .cornerRadius(8)
+    }
+}
+
+// MARK: - Alignment bridging
+
+extension MarkdownTable.Alignment {
+    var textAlignment: TextAlignment {
+        switch self {
+        case .leading: return .leading
+        case .center: return .center
+        case .trailing: return .trailing
+        }
+    }
+
+    var frameAlignment: Alignment {
+        switch self {
+        case .leading: return .leading
+        case .center: return .center
+        case .trailing: return .trailing
+        }
+    }
+}
+
+extension Array {
+    /// Bounds-checked subscript. A malformed table can carry more cells than
+    /// the delimiter row declared alignments for; a crash there would take
+    /// the whole transcript down.
+    fileprivate subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }
 
@@ -319,6 +288,11 @@ func styledInlineCode(
 
                 This is **bold** and *italic* and `inline code`.
 
+                | Lens | Reach | Price |
+                |------|:-----:|------:|
+                | Leica 100-400 | 800mm-eq | €750-1.010 |
+                | OM 100-400 | 800mm-eq | €650-850 |
+
                 ```swift
                 func hello() {
                     print("Hello, world!")
@@ -327,7 +301,11 @@ func styledInlineCode(
 
                 - Item one
                 - Item two
-                - Item three
+                  - Nested item
+                1. First
+                2. Second
+
+                ---
 
                 Some more text with a [link](https://example.com).
                 """

--- a/packages/ios-app/SliccFollower/Views/MessageBubble.swift
+++ b/packages/ios-app/SliccFollower/Views/MessageBubble.swift
@@ -61,8 +61,15 @@ struct MessageBubble: View {
             VStack(alignment: .leading, spacing: 6) {
                 if let source = message.source, source != "cone" {
                     HStack(spacing: 4) {
-                        Image(systemName: SliccIcons.messageSource(message))
-                            .font(.system(size: 10))
+                        // A lick carries its channel glyph; anything else
+                        // attributed to a non-cone source is a scoop, which
+                        // gets the lucide bowl the web rail uses.
+                        if message.channel?.isEmpty == false {
+                            Image(systemName: SliccIcons.messageSource(message))
+                                .font(.system(size: 10))
+                        } else {
+                            ConeScoopGlyph(isCone: false, size: 11)
+                        }
                         Text(source)
                             .font(.system(size: 11, weight: .medium))
                     }
@@ -82,14 +89,18 @@ struct MessageBubble: View {
     /// doesn't accidentally become a heading inside a chat bubble.
     @ViewBuilder
     private var userBubbleText: some View {
+        // Dictated turns carry AI-only markers (🎙️ and the one-time ◁…▷
+        // priming note) in the stored text; the bubble is the one place
+        // that hides them again.
+        let body = DictationPriming.stripMarkers(message.content)
         if let attributed = try? AttributedString(
-            markdown: message.content,
+            markdown: body,
             options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
         ) {
             Text(styleUserBubbleCode(attributed))
                 .tint(palette.bubbleText)
         } else {
-            Text(message.content)
+            Text(body)
         }
     }
 
@@ -109,7 +120,10 @@ struct MessageBubble: View {
 
     @ViewBuilder
     private var assistantBody: some View {
-        let extracted = extractInlineSprinkles(from: message.content)
+        // The agent declares its reply language in a hidden HTML comment so
+        // the spoken reply can pick a voice; it must never reach the bubble.
+        let extracted = extractInlineSprinkles(
+            from: DictationPriming.stripReplyLangMarker(message.content))
         VStack(alignment: .leading, spacing: 8) {
             if !extracted.cleaned.isEmpty || extracted.fragments.isEmpty {
                 renderInlineContent(cleaned: extracted.cleaned, fragments: extracted.fragments)

--- a/packages/ios-app/SliccFollower/Views/MonitorView.swift
+++ b/packages/ios-app/SliccFollower/Views/MonitorView.swift
@@ -53,7 +53,7 @@ struct MonitorView: View {
             }
             ForEach(appState.scoops) { scoop in
                 HStack {
-                    Image(systemName: scoop.isCone ? "crown" : "cup.and.saucer")
+                    ConeScoopGlyph(isCone: scoop.isCone, size: 17)
                         .foregroundStyle(palette.inkSecondary)
                     VStack(alignment: .leading) {
                         Text(scoop.name)

--- a/packages/ios-app/SliccFollower/Views/RemoteTabCard.swift
+++ b/packages/ios-app/SliccFollower/Views/RemoteTabCard.swift
@@ -19,19 +19,13 @@ struct RemoteTabCard: View {
     @State private var preview: PreviewState = .loading
 
     var body: some View {
-        ZStack(alignment: .bottomLeading) {
+        ZStack(alignment: .bottom) {
             thumbnail
-            // A scrim, not a caption bar: the label reads over the darkest
-            // part of the shot instead of stealing a strip of it, and the
-            // gradient guarantees contrast whatever the page looks like.
-            LinearGradient(
-                colors: [.black.opacity(0), .black.opacity(0.55), .black.opacity(0.82)],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-            .frame(height: 72)
-            .frame(maxHeight: .infinity, alignment: .bottom)
-            .allowsHitTesting(false)
+            // A material bar, not a gradient scrim. A translucent scrim's
+            // contrast is whatever the page underneath happens to be, and a
+            // screenshot of a light page swallowed the caption entirely.
+            // Material stays legible over any backdrop and still shows the
+            // shot through it.
             caption
         }
         .frame(height: 156)
@@ -65,8 +59,8 @@ struct RemoteTabCard: View {
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 8)
                 }
-                // Above the scrim's darkest band, so the reason stays legible.
-                .padding(.bottom, 56)
+                // Clear of the caption bar, so the reason stays readable.
+                .padding(.bottom, 48)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -75,29 +69,34 @@ struct RemoteTabCard: View {
 
     /// Title + origin only. The full URL was the noisiest thing on the card
     /// and never fit; the host is what identifies a tab at a glance.
+    ///
+    /// `.primary` / `.secondary` over material are vibrant styles — the
+    /// system keeps them legible against whatever the blurred screenshot
+    /// behind them looks like, which a hand-picked white never could.
     private var caption: some View {
-        VStack(alignment: .leading, spacing: 3) {
+        VStack(alignment: .leading, spacing: 2) {
             Text(target.title.isEmpty ? "Untitled tab" : target.title)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.white)
+                .foregroundStyle(.primary)
                 .lineLimit(1)
             HStack(spacing: 5) {
                 Text(target.runtimeId == "leader" ? "leader" : target.runtimeId)
                     .font(.caption2.weight(.semibold))
                     .padding(.horizontal, 5)
                     .padding(.vertical, 1)
-                    .background(.white.opacity(0.22))
-                    .foregroundStyle(.white)
-                    .clipShape(Capsule())
+                    .background(.quaternary, in: Capsule())
+                    .foregroundStyle(.secondary)
                 Text(Self.displayHost(target.url))
                     .font(.caption2)
-                    .foregroundStyle(.white.opacity(0.75))
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 10)
-        .padding(.bottom, 9)
+        .padding(.vertical, 7)
+        .background(.regularMaterial)
     }
 
     /// Host without the `www.` noise; falls back to the raw string for

--- a/packages/ios-app/SliccFollower/Views/RemoteTabCard.swift
+++ b/packages/ios-app/SliccFollower/Views/RemoteTabCard.swift
@@ -19,58 +19,92 @@ struct RemoteTabCard: View {
     @State private var preview: PreviewState = .loading
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(palette.field)
-                switch preview {
-                case .loading:
-                    ProgressView()
-                case .image(let image):
-                    Image(uiImage: image)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
-                        .accessibilityIdentifier("remote-preview-\(target.targetId)")
-                case .unavailable(let reason):
-                    VStack(spacing: 6) {
-                        Image(systemName: "rectangle.on.rectangle.slash")
-                            .foregroundStyle(palette.inkTertiary)
-                        Text(reason)
-                            .font(.caption2)
-                            .foregroundStyle(palette.inkSecondary)
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal, 8)
-                    }
-                }
-            }
-            .frame(height: 140)
+        ZStack(alignment: .bottomLeading) {
+            thumbnail
+            // A scrim, not a caption bar: the label reads over the darkest
+            // part of the shot instead of stealing a strip of it, and the
+            // gradient guarantees contrast whatever the page looks like.
+            LinearGradient(
+                colors: [.black.opacity(0), .black.opacity(0.55), .black.opacity(0.82)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: 72)
+            .frame(maxHeight: .infinity, alignment: .bottom)
+            .allowsHitTesting(false)
+            caption
+        }
+        .frame(height: 156)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(palette.line, lineWidth: 0.5)
+        )
+        .task(id: target.targetId) { await capture() }
+    }
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(target.title.isEmpty ? "Untitled tab" : target.title)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(palette.ink)
-                    .lineLimit(1)
-                HStack(spacing: 4) {
-                    Text(target.runtimeId == "leader" ? "leader" : target.runtimeId)
-                        .font(.caption2.weight(.semibold))
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 1)
-                        .background(palette.accent.opacity(0.15))
-                        .foregroundStyle(palette.accent)
-                        .clipShape(Capsule())
-                    Text(target.url)
+    @ViewBuilder
+    private var thumbnail: some View {
+        ZStack {
+            Rectangle().fill(palette.field)
+            switch preview {
+            case .loading:
+                ProgressView()
+            case .image(let image):
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .accessibilityIdentifier("remote-preview-\(target.targetId)")
+            case .unavailable(let reason):
+                VStack(spacing: 6) {
+                    Image(systemName: "rectangle.on.rectangle.slash")
+                        .foregroundStyle(palette.inkTertiary)
+                    Text(reason)
                         .font(.caption2)
                         .foregroundStyle(palette.inkSecondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 8)
                 }
+                // Above the scrim's darkest band, so the reason stays legible.
+                .padding(.bottom, 56)
             }
         }
-        .padding(10)
-        .background(palette.surface)
-        .clipShape(RoundedRectangle(cornerRadius: 14))
-        .task(id: target.targetId) { await capture() }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .clipped()
+    }
+
+    /// Title + origin only. The full URL was the noisiest thing on the card
+    /// and never fit; the host is what identifies a tab at a glance.
+    private var caption: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(target.title.isEmpty ? "Untitled tab" : target.title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+            HStack(spacing: 5) {
+                Text(target.runtimeId == "leader" ? "leader" : target.runtimeId)
+                    .font(.caption2.weight(.semibold))
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(.white.opacity(0.22))
+                    .foregroundStyle(.white)
+                    .clipShape(Capsule())
+                Text(Self.displayHost(target.url))
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.75))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.bottom, 9)
+    }
+
+    /// Host without the `www.` noise; falls back to the raw string for
+    /// `about:blank` and friends, which have no host at all.
+    static func displayHost(_ url: String) -> String {
+        guard let host = URLComponents(string: url)?.host, !host.isEmpty else { return url }
+        return host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
     }
 
     private func capture() async {

--- a/packages/ios-app/SliccFollower/Views/SettingsView.swift
+++ b/packages/ios-app/SliccFollower/Views/SettingsView.swift
@@ -10,6 +10,10 @@ struct SettingsView: View {
     /// without it, `Date()` in `body` is only sampled on unrelated redraws and
     /// a row crossing the 12h TTL would stay enabled indefinitely.
     @State private var now = Date()
+    /// Set when the user asks THIS sheet to connect, so the auto-dismiss only
+    /// fires for a connection they just started here. Opening Settings while
+    /// a background reconnect happens to land must not yank the sheet away.
+    @State private var awaitingConnect = false
     private let staleTicker = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
 
     var body: some View {
@@ -39,6 +43,19 @@ struct SettingsView: View {
             .onChange(of: appState.joinUrl) { _, newValue in
                 storedJoinUrl = newValue
             }
+            // Connecting is the reason the sheet was opened; once it lands,
+            // the settings form is in the way of the conversation.
+            .onChange(of: appState.connectionState) { _, state in
+                guard awaitingConnect else { return }
+                if state == .connected {
+                    awaitingConnect = false
+                    dismiss()
+                } else if state == .disconnected || state == .failed || state == .gaveUp {
+                    // The attempt resolved without connecting — stay put so
+                    // the error is readable and the URL can be corrected.
+                    awaitingConnect = false
+                }
+            }
         }
     }
 
@@ -64,7 +81,9 @@ struct SettingsView: View {
             Text("iCloud Sessions")
         } footer: {
             Text(
-                "Leaders started with Sliccstart on this Apple ID appear here automatically. Others (cloud, another Apple ID) still join via a pasted Join URL below."
+                "Leaders started with Sliccstart on this Apple ID appear here "
+                    + "automatically. Others (cloud, another Apple ID) still join via a "
+                    + "pasted Join URL below."
             )
         }
         .onAppear {
@@ -82,6 +101,7 @@ struct SettingsView: View {
                 appState.sessionStore.reload()
                 return
             }
+            awaitingConnect = true
             appState.connectToDiscoveredSession(joinUrl: session.joinUrl)
         } label: {
             HStack {
@@ -215,6 +235,7 @@ struct SettingsView: View {
                 }
             } else {
                 Button {
+                    awaitingConnect = true
                     appState.connect()
                 } label: {
                     HStack {

--- a/packages/ios-app/SliccFollower/Views/SettingsView.swift
+++ b/packages/ios-app/SliccFollower/Views/SettingsView.swift
@@ -14,6 +14,13 @@ struct SettingsView: View {
     /// fires for a connection they just started here. Opening Settings while
     /// a background reconnect happens to land must not yank the sheet away.
     @State private var awaitingConnect = false
+    /// Whether this device has an iCloud identity, or nil while unknown.
+    ///
+    /// `FileManager.ubiquityIdentityToken` reaches the iCloud daemon and can
+    /// block; reading it inside `body` put that call on the main thread on
+    /// every single layout pass of the sheet. It is sampled once, off the
+    /// main actor, and the answer cannot change while the sheet is open.
+    @State private var hasICloudIdentity: Bool?
     private let staleTicker = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
 
     var body: some View {
@@ -39,6 +46,9 @@ struct SettingsView: View {
                 if let history = UserDefaults.standard.stringArray(forKey: "joinUrlHistory") {
                     appState.joinUrlHistory = history
                 }
+            }
+            .task {
+                hasICloudIdentity = await Self.probeICloudIdentity()
             }
             .onChange(of: appState.joinUrl) { _, newValue in
                 storedJoinUrl = newValue
@@ -126,8 +136,11 @@ struct SettingsView: View {
     }
 
     private var sessionsEmptyState: some View {
+        // `hasICloudIdentity` is sampled off the main actor (see its
+        // declaration); until it answers, assume iCloud is fine so the row
+        // cannot flash "iCloud is unavailable" at someone who is signed in.
         let reason = ICloudSessionList.emptyReason(
-            hasICloudIdentity: FileManager.default.ubiquityIdentityToken != nil
+            hasICloudIdentity: hasICloudIdentity ?? true
         )
         return HStack(spacing: 10) {
             Image(systemName: reason == .iCloudUnavailable ? "icloud.slash" : "icloud")
@@ -141,6 +154,14 @@ struct SettingsView: View {
             .foregroundStyle(.secondary)
         }
         .accessibilityIdentifier("icloud-sessions-empty")
+    }
+
+    /// Off the main actor: the token read can block on the iCloud daemon,
+    /// and nothing about the sheet needs it synchronously.
+    private static func probeICloudIdentity() async -> Bool {
+        await Task.detached(priority: .userInitiated) {
+            FileManager.default.ubiquityIdentityToken != nil
+        }.value
     }
 
     // MARK: - Connection Section

--- a/packages/ios-app/SliccFollower/Views/SliccIcons.swift
+++ b/packages/ios-app/SliccFollower/Views/SliccIcons.swift
@@ -94,6 +94,195 @@ enum SliccIcons {
         "welcome": "door.right.hand.open"
     ]
 
+    // MARK: - Sprinkle Rail Icons
+
+    /// SF Symbol for a sprinkle's declared icon spec (`SprinkleSummary.icon`,
+    /// sourced from `data-sprinkle-icon` / `<link rel="icon">` on the leader).
+    ///
+    /// The web rail renders lucide kebab names directly; the phone maps the
+    /// ones lucide and SF Symbols agree on and falls back to the generic
+    /// sparkle otherwise. Non-lucide specs (VFS paths, inline `<svg>`,
+    /// `data:` URLs) also fall back — the web dock item skips those too
+    /// (`isLucideIconSpec` in `wc-sprinkles.ts`).
+    static func sprinkle(iconSpec: String?) -> String {
+        guard let spec = iconSpec?.trimmingCharacters(in: .whitespacesAndNewlines),
+            isLucideName(spec)
+        else { return "sparkles" }
+        return lucideToSFSymbol[spec] ?? "sparkles"
+    }
+
+    /// Mirrors `isLucideIconSpec` in `wc-sprinkles.ts`: lowercase kebab only.
+    /// Anything else is a path, inline SVG or data URL.
+    static func isLucideName(_ spec: String) -> Bool {
+        guard !spec.isEmpty else { return false }
+        var previousWasDash = true
+        for char in spec {
+            if char == "-" {
+                if previousWasDash { return false }
+                previousWasDash = true
+                continue
+            }
+            guard char.isASCII, char.isLowercase || char.isNumber else { return false }
+            previousWasDash = false
+        }
+        return !previousWasDash
+    }
+
+    /// Lucide kebab name → SF Symbol. Covers the icons sprinkles in the
+    /// tray actually declare plus the ones the leader's LLM enrichment
+    /// reaches for; unmapped names degrade to `sparkles` rather than to a
+    /// missing-glyph box.
+    private static let lucideToSFSymbol: [String: String] = [
+        "activity": "waveform.path.ecg",
+        "alarm-clock": "alarm",
+        "album": "square.stack",
+        "atom": "atom",
+        "award": "rosette",
+        "banknote": "banknote",
+        "bar-chart": "chart.bar",
+        "bar-chart-3": "chart.bar",
+        "battery": "battery.100",
+        "bell": "bell",
+        "book": "book",
+        "book-open": "book",
+        "bookmark": "bookmark",
+        "bot": "cpu",
+        "brain": "brain",
+        "briefcase": "briefcase",
+        "bug": "ladybug",
+        "calculator": "plus.forwardslash.minus",
+        "calendar": "calendar",
+        "calendar-clock": "calendar.badge.clock",
+        "camera": "camera",
+        "check": "checkmark",
+        "check-circle": "checkmark.circle",
+        "chef-hat": "fork.knife",
+        "circle-check": "checkmark.circle",
+        "clipboard": "list.clipboard",
+        "clipboard-list": "list.clipboard",
+        "clock": "clock",
+        "cloud": "cloud",
+        "code": "chevron.left.forwardslash.chevron.right",
+        "code-2": "chevron.left.forwardslash.chevron.right",
+        "coffee": "cup.and.saucer",
+        "compass": "safari",
+        "cpu": "cpu",
+        "credit-card": "creditcard",
+        "database": "cylinder.split.1x2",
+        "dice-5": "die.face.5",
+        "dollar-sign": "dollarsign.circle",
+        "download": "arrow.down.circle",
+        "droplet": "drop",
+        "dumbbell": "dumbbell",
+        "eye": "eye",
+        "file": "doc",
+        "file-text": "doc.text",
+        "film": "film",
+        "flag": "flag",
+        "flame": "flame",
+        "flask-conical": "testtube.2",
+        "folder": "folder",
+        "gamepad-2": "gamecontroller",
+        "gauge": "gauge.with.dots.needle.bottom.50percent",
+        "gift": "gift",
+        "git-branch": "arrow.triangle.branch",
+        "github": "chevron.left.forwardslash.chevron.right",
+        "globe": "globe",
+        "graduation-cap": "graduationcap",
+        "hammer": "hammer",
+        "hash": "number",
+        "headphones": "headphones",
+        "heart": "heart",
+        "home": "house",
+        "house": "house",
+        "image": "photo",
+        "inbox": "tray",
+        "info": "info.circle",
+        "key": "key",
+        "keyboard": "keyboard",
+        "lamp": "lamp.desk",
+        "layers": "square.3.layers.3d",
+        "leaf": "leaf",
+        "library": "books.vertical",
+        "lightbulb": "lightbulb",
+        "link": "link",
+        "list": "list.bullet",
+        "list-checks": "checklist",
+        "list-todo": "checklist",
+        "lock": "lock",
+        "mail": "envelope",
+        "map": "map",
+        "map-pin": "mappin.and.ellipse",
+        "megaphone": "megaphone",
+        "message-circle": "message",
+        "message-square": "bubble.left",
+        "mic": "mic",
+        "monitor": "display",
+        "moon": "moon",
+        "music": "music.note",
+        "newspaper": "newspaper",
+        "notebook": "book.closed",
+        "package": "shippingbox",
+        "palette": "paintpalette",
+        "paperclip": "paperclip",
+        "pen": "pencil",
+        "pencil": "pencil",
+        "phone": "phone",
+        "pie-chart": "chart.pie",
+        "pin": "pin",
+        "plane": "airplane",
+        "play": "play",
+        "plug": "powerplug",
+        "printer": "printer",
+        "puzzle": "puzzlepiece",
+        "quote": "quote.opening",
+        "radio": "dot.radiowaves.left.and.right",
+        "receipt": "receipt",
+        "refresh-cw": "arrow.clockwise",
+        "rocket": "paperplane",
+        "rss": "dot.radiowaves.up.forward",
+        "ruler": "ruler",
+        "search": "magnifyingglass",
+        "send": "paperplane.fill",
+        "server": "server.rack",
+        "settings": "gearshape",
+        "shield": "shield",
+        "shopping-bag": "bag",
+        "shopping-cart": "cart",
+        "shuffle": "shuffle",
+        "sliders": "slider.horizontal.3",
+        "smile": "face.smiling",
+        "sparkles": "sparkles",
+        "star": "star",
+        "sticky-note": "note.text",
+        "sun": "sun.max",
+        "table": "tablecells",
+        "tag": "tag",
+        "target": "target",
+        "terminal": "terminal",
+        "thermometer": "thermometer.medium",
+        "timer": "timer",
+        "trash-2": "trash",
+        "trending-up": "chart.line.uptrend.xyaxis",
+        "trophy": "trophy",
+        "truck": "truck.box",
+        "tv": "tv",
+        "umbrella": "umbrella",
+        "upload": "arrow.up.circle",
+        "user": "person",
+        "users": "person.2",
+        "utensils": "fork.knife",
+        "video": "video",
+        "wallet": "wallet.bifold",
+        "wand-2": "wand.and.stars",
+        "watch": "applewatch",
+        "waves": "water.waves",
+        "webhook": "bolt.horizontal.fill",
+        "wifi": "wifi",
+        "wrench": "wrench.adjustable",
+        "zap": "bolt",
+    ]
+
     /// Lowercase noun label for a lick channel — keeps the chat row reading
     /// like a tool-call row ("webhook github-push", "cron daily-digest", …).
     static func lickLabel(_ channel: String) -> String {

--- a/packages/ios-app/SliccFollower/Views/TabsCarouselView.swift
+++ b/packages/ios-app/SliccFollower/Views/TabsCarouselView.swift
@@ -210,15 +210,18 @@ struct TabsCarouselView: View {
         HStack(spacing: 8) {
             Image(systemName: "globe")
                 .foregroundStyle(.blue)
+            // Title over origin, not title over full URL: a phone-width
+            // header cannot show a real URL and the truncated middle of one
+            // is unreadable noise.
             VStack(alignment: .leading, spacing: 1) {
                 Text(target.title.isEmpty ? "Untitled" : target.title)
                     .font(.system(size: 13, weight: .semibold))
                     .lineLimit(1)
-                Text(target.url)
-                    .font(.system(size: 11, design: .monospaced))
+                Text(RemoteTabCard.displayHost(target.url))
+                    .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
-                    .truncationMode(.middle)
+                    .truncationMode(.tail)
             }
             Spacer()
             Button {

--- a/packages/ios-app/SliccFollower/Views/WorkbenchHost.swift
+++ b/packages/ios-app/SliccFollower/Views/WorkbenchHost.swift
@@ -30,7 +30,7 @@ struct WorkbenchHost: View {
                 MemoryView()
             case .files:
                 FilesView()
-            case .newSprinkle, .term:
+            case .term:
                 placeholder(DockModel.placeholderText(for: surface) ?? "")
             }
         }


### PR DESCRIPTION
Refs #1785. Draft — more device-QA fixes are landing on this branch.

## Summary

Seven fixes found QA-ing a Debug device build on a physical iPhone (iPhone Air, iOS 26.5.2) against a live leader.

Before: the leader's comparison tables rendered as raw `| … |` pipe rows, all seven sprinkles in the dock rail drew the same sparkle glyph with no labels, the scoop label was drawn twice (nav title + a full-width header row), a non-functional `+` sat in the rail, remote-tab captions collided with their thumbnails, and the leader's own SLICC page was listed as a browsable tab.

After: tables and lists render as tables and lists, sprinkles carry their declared icons, the scoop identity appears once in a compact nav-bar switcher, the `+` is gone, tab previews use a gradient scrim, and the leader's own page is filtered out.

## Why

All seven are user-visible defects observed on-device, not speculative cleanup. The markdown one is the sharpest: the leader routinely emits comparison tables and the phone showed them as unreadable pipe soup, including the `|---|` delimiter row.

Two of the seven are latent-feature activation rather than bugs:

- `SprinkleSummary.icon` has been on the wire since the rail shipped, with a doc comment reading *"iOS sidebar rendering doesn't consume this yet"*. It does now.
- The duplicate scoop label was structural — `navigationTitle` and `ScoopHeaderView` both read `selectedScoop?.assistantLabel`, so with 2+ scoops connected the same string rendered stacked.

## Approach / Implementation notes

- **Layering.** The two non-trivial behaviors are pure models, not view code, so they are unit-testable without a view host — the same reason `DockModel` is a pure builder. `Models/MarkdownBlock.swift` owns the block grammar; `MarkdownText` only paints it. `Models/BrowserTargets.swift` owns the tab-visibility rules; `AppState` just calls it.
- **Why a parser at all.** `AttributedString(markdown:)` is used with `.inlineOnlyPreservingWhitespace`, which by design parses *no* block constructs. Switching to `.full` was the rejected alternative: it still cannot render tables, and it would have changed how existing headings, quotes and fenced code are laid out. Recognising blocks first and keeping the inline parser for spans preserves the existing look.
- **Lucide → SF Symbols is a mapping, not a registry.** The web rail renders lucide names directly. Importing an icon registry into the app was rejected on size; instead ~170 names map to SF Symbols and everything unmapped degrades to `sparkles`. `SliccIcons.isLucideName` mirrors `isLucideIconSpec` in `wc-sprinkles.ts` so both followers agree on which specs are rail-renderable.
- **Matching the leader's own page.** Comparing full URLs fails because the join URL carries a per-session `?ws=…#tray=…`. `BrowserTargets` normalises to scheme+host+path, so the leader page matches whatever its fragment has advanced to, while `sliccy.ai/docs/*` still lists. Falls back to the hosted app shell when `joinUrl` is empty (iCloud-session joins don't populate it).
- **Deleted, not hidden.** `DockSurface.newSprinkle` is removed from the enum along with its placeholder text and its `UITestHooks` route, rather than left as dead code for Periphery to flag.

## Cross-cutting impact

- **Floats exercised**: iOS follower only. No TypeScript, no protocol change, no wire-format change — `SprinkleSummary.icon` was already being sent and decoded; this only starts *rendering* it.
- **Browser-follower parity**: `SliccIcons.isLucideName` is a deliberate port of `isLucideIconSpec` (`wc-sprinkles.ts`). If that predicate changes on the web, this needs the same change. The terminal placeholder string stays word-for-word identical to `wc-follower.ts`.
- **Bundle size**: N/A — SF Symbols ship with the OS; no icon registry is bundled.
- **Persisted state**: none. `leftHandedDock` is the only `@AppStorage` key read by the new toolbar code and it already existed.
- **Removed accessibility surface**: `dock-new` no longer exists. No test referenced it. `settings-button` and `scoop-switcher` identifiers are new.

## Test plan

- [x] `npm run verify` — all 7 checks passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK (11 changed files, 0 on any debt list)
- [x] `npm run lint:swift` — 0 serious violations
- [x] `swift format lint --strict` on `packages/ios-app` — clean (exit 0)
- [x] `./packages/dev-tools/tools/swift-coverage-check.sh --xcodebuild SliccFollower packages/ios-app SliccFollower` — suite green; lines 65.19% (floor 59%), functions 55.27% (floor 46%), regions 55.73% (floor 50%)
- [x] **New behavior is covered by unit tests**: `MarkdownBlockParserTests` (18 cases — tables incl. ragged rows and escaped pipes, lists, thematic breaks, fenced content never reinterpreted), `BrowserTargetsTests` (6 cases), `DockModelTests` extended for declared icons and the absent launcher
- [x] Manual smoke on a physical iPhone: Debug build installed via `devicectl`, launched against a live leader
- [ ] **Screencast** — pending; will attach before/after device captures before marking ready
- [ ] `npm run typecheck` / `npm run test` / `npm run build` — N/A, no TypeScript changed

**Pre-existing failures** (unrelated to this PR): `npm run lint:swift:format` fails on `packages/swift-launcher/Sliccstart/Generated/WebKitManifest.swift` (`[TrailingComma]`). That file is generated, untracked, and in a package this PR does not touch. `packages/ios-app` passes the same gate cleanly.

## Documentation

- [ ] `packages/ios-app/CLAUDE.md` — pending on this branch: the Layout table still describes `MarkdownText` without the block parser, and the dock row still mentions the `New +` launcher.

## Risk & rollback

Blast radius is the iOS follower's view layer only. No protocol, no persisted state, no migration. Reverting the commit restores the previous rendering exactly; nothing written to disk needs undoing.

The one behavioral risk worth a reviewer's eye is `BrowserTargets.isSliccAppPage` false-positiving and hiding a tab the user wanted. The hosted-shell fallback is deliberately narrow (exact origin + empty path); `sliccy.ai/cloud` and `sliccy.ai/docs/*` are covered by tests as *must-still-list*.
