### PR TITLE
fix(ios-app): restore a visible escape on the new-chat dialog

### DIFF
--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/NewSessionUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/NewSessionUITests.swift
@@ -1,24 +1,53 @@
 import XCTest
 
-/// The Past Sessions sheet's New button: three clearly labeled dispositions,
-/// with erase double-confirming before anything fires. Driven leaderless via
-/// the frozen fixture + `-uiTestOpenNewSession`.
+/// The shared New Session dialog from both Past Sessions and the chat toolbar:
+/// three clearly labeled dispositions, a visible Cancel below Erase, and erase
+/// double-confirming before anything fires. Driven leaderless via UI fixtures.
 final class NewSessionUITests: XCTestCase {
+
+    private enum EntryPoint {
+        case chat
+        case pastSessions
+    }
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
     }
 
+    func testFirstDialogCancelDismissesWithoutRequestingANewSession() {
+        let app = launchApp(opening: .pastSessions)
+        let cancel = assertCancelableDialog(in: app)
+
+        cancel.tap()
+
+        XCTAssertFalse(app.buttons["Save & start new"].waitForExistence(timeout: 3))
+        let caller = app.buttons["new-session-button"]
+        XCTAssertTrue(
+            caller.waitForExistence(timeout: 10),
+            "Cancel must leave the Past Sessions caller intact instead of requesting a new session")
+        XCTAssertTrue(caller.isEnabled)
+    }
+
+    func testChatToolbarCancelDismissesWithoutRequestingANewSession() {
+        let app = launchApp(opening: .chat)
+        let caller = app.buttons["new-chat-button"]
+        XCTAssertTrue(caller.waitForExistence(timeout: 60))
+        XCTAssertTrue(caller.isHittable)
+
+        caller.tap()
+        let cancel = assertCancelableDialog(in: app)
+        cancel.tap()
+
+        XCTAssertFalse(app.buttons["Save & start new"].waitForExistence(timeout: 3))
+        XCTAssertTrue(
+            caller.waitForExistence(timeout: 10),
+            "Cancel must leave the chat toolbar caller intact instead of requesting a new session")
+        XCTAssertTrue(caller.isEnabled, "Cancel must not put a new-session request in flight")
+    }
+
     func testDialogOffersThreeActionsAndEraseDoubleConfirms() {
-        let app = XCUIApplication()
-        app.launchArguments += [
-            "-joinUrl", "http://127.0.0.1:1/join/new-session-ui-test",
-            "-uiTestFrozenFixture", "YES",
-            "-uiTestOpenFrozenRail", "YES",
-            "-uiTestOpenNewSession", "YES",
-        ]
-        app.launch()
+        let app = launchApp(opening: .pastSessions)
 
         // The auto-opened dialog carries all three dispositions.
         let save = app.buttons["Save & start new"]
@@ -35,5 +64,36 @@ final class NewSessionUITests: XCTestCase {
 
         // Cancelling leaves the sheet intact — nothing was sent or dismissed.
         XCTAssertTrue(app.buttons["new-session-button"].waitForExistence(timeout: 10))
+    }
+
+    private func launchApp(opening entryPoint: EntryPoint) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-joinUrl", "http://127.0.0.1:1/join/new-session-ui-test",
+        ]
+        switch entryPoint {
+        case .chat:
+            app.launchArguments += ["-uiTestConnectionState", "connected"]
+        case .pastSessions:
+            app.launchArguments += [
+                "-uiTestFrozenFixture", "YES",
+                "-uiTestOpenFrozenRail", "YES",
+                "-uiTestOpenNewSession", "YES",
+            ]
+        }
+        app.launch()
+        return app
+    }
+
+    private func assertCancelableDialog(in app: XCUIApplication) -> XCUIElement {
+        let erase = app.buttons["Erase & start new"]
+        XCTAssertTrue(erase.waitForExistence(timeout: 60))
+        let cancel = app.buttons["Cancel"]
+        XCTAssertTrue(cancel.exists, "The first dialog must expose a visible dismiss control")
+        XCTAssertTrue(cancel.isHittable, "The first dialog's dismiss control must be tappable")
+        XCTAssertGreaterThan(
+            cancel.frame.midY, erase.frame.midY,
+            "Erase & start new must not be the bottom-most control")
+        return cancel
     }
 }

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import os
 
 /// Top-level container view with a NavigationSplitView whose sidebar lists
@@ -199,7 +200,6 @@ struct ConversationView: View {
             FrozenSessionsView()
                 .environmentObject(appState)
         }
-        .modifier(NewSessionDialog(isPresented: $showNewSessionDialog))
         .onAppear {
             #if DEBUG
                 if UITestHooks.opensFrozenRail { showFrozenSessions = true }
@@ -268,6 +268,9 @@ struct ConversationView: View {
 
     private var newChatButton: some View {
         Button {
+            UIApplication.shared.sendAction(
+                #selector(UIResponder.resignFirstResponder),
+                to: nil, from: nil, for: nil)
             showNewSessionDialog = true
         } label: {
             if appState.newSessionInFlight {
@@ -287,6 +290,7 @@ struct ConversationView: View {
         )
         .accessibilityLabel("New chat")
         .accessibilityIdentifier("new-chat-button")
+        .modifier(NewSessionDialog(isPresented: $showNewSessionDialog))
     }
 
     private var settingsButton: some View {

--- a/packages/ios-app/SliccFollower/Views/FrozenSessionsView.swift
+++ b/packages/ios-app/SliccFollower/Views/FrozenSessionsView.swift
@@ -54,15 +54,15 @@ struct FrozenSessionsView: View {
                     .disabled(appState.newSessionInFlight)
                     .accessibilityLabel("New session")
                     .accessibilityIdentifier("new-session-button")
+                    .modifier(
+                        NewSessionDialog(
+                            isPresented: $showNewSessionDialog,
+                            onRequested: { dismiss() }))
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { dismiss() }
                 }
             }
-            .modifier(
-                NewSessionDialog(
-                    isPresented: $showNewSessionDialog,
-                    onRequested: { dismiss() }))
         }
         .onAppear { appState.loadFrozenSessions() }
         .onChange(of: appState.openFrozen?.entry.id) { _, opened in

--- a/packages/ios-app/SliccFollower/Views/NewSessionDialog.swift
+++ b/packages/ios-app/SliccFollower/Views/NewSessionDialog.swift
@@ -3,7 +3,9 @@ import SwiftUI
 /// The `new_session` disposition dialog (#1799), shared by every entry
 /// point — the Past Sessions sheet's `New +` and the chat's top-control
 /// New chat button — so the save/skip/erase contract and the erase
-/// double-confirm stay single-sourced.
+/// double-confirm stay single-sourced. The first dialog's Cancel intentionally
+/// has no `.cancel` role: anchored popovers omit role-cancel actions, while a
+/// plain final action remains visible in every presentation style.
 struct NewSessionDialog: ViewModifier {
     @Binding var isPresented: Bool
     @EnvironmentObject var appState: AppState
@@ -31,7 +33,7 @@ struct NewSessionDialog: ViewModifier {
                     // destructive action from a slippable dialog.
                     confirmErase = true
                 }
-                Button("Cancel", role: .cancel) {}
+                Button("Cancel") { isPresented = false }
             } message: {
                 Text("The current session is archived on the leader; Save also extracts memory.")
             }


### PR DESCRIPTION
<!-- WIP: stacked on #1885; merge that PR first. -->

## Summary

WIP stacked on #1885. This restores a visible dismiss affordance for the new-chat dialog, keeps the destructive action away from the dismiss position, lowers the keyboard before presentation, and anchors the dialog to the button that opened it.

## Why

The popover presentation drops role-cancel, leaving no visible escape. Erase & start new then occupies the dismiss position, the focused composer keeps the keyboard up, and the dialog is anchored to the surrounding view rather than the New chat button.

## Test plan

- [x] iPad Pro 11-inch / iOS 26.5: NewSessionUITests 3/3 and DockUITests 3/3.
- [x] iPhone 17 Pro / iOS 26.5: NewSessionUITests 2/2 and DockUITests 3/3.
- [x] No tests rerun during this Git-only rebase task; results above were already obtained.

**Pre-existing failure:** iOS 26.4 has an unrelated UIAccessibility / NSMachError -308 runner defect.

## Documentation

- [x] No documentation changes needed

## Risk & rollback

Limited to the iOS follower new-chat dialog and its UI regression coverage. Roll back by reverting these two commits.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under dist/
- [x] No secrets or credentials in the diff
- [x] No cross-float contract changes
