### PR TITLE
Fix JS realm stream lifecycle shims

### DIFF
--- a/docs/node-compat-shims.md
+++ b/docs/node-compat-shims.md
@@ -184,8 +184,9 @@ Static/hardcoded values: `tmpdir()` → `/tmp`, `homedir()` → `/home/user`,
 ### `stream`
 
 Minimal stubs: `Readable`, `Writable`, `Transform`, `PassThrough`, `Stream`.
-Basic event emission and `pipe()` work. These are NOT full Node streams —
-no backpressure, no flowing/paused modes, no proper pipe chaining.
+Basic event emission, `data`/`end` forwarding through `pipe()`, and `close` on
+`destroy()` work. These are NOT full Node streams — there is no backpressure,
+flowing/paused mode, `unpipe()`, or error propagation.
 
 ### `tty`
 

--- a/docs/node-compat-shims.md
+++ b/docs/node-compat-shims.md
@@ -140,7 +140,8 @@ they throw an error naming the async escape hatch instead.
 
 `env`, `cwd()`, `exit(code?)` (throws `NodeExitError` to unwind the stack),
 `stdout`, `stderr`, `stdin`, and `argv` (with a non-enumerable
-`argv.parseFlags()` helper).
+`argv.parseFlags()` helper). `stdout` and `stderr` accept `write()` and a no-op
+`end()`, so they can be used as stream pipe destinations.
 
 **Not available:** `platform`, `arch`, `version`, `pid`, `on()`,
 `nextTick()`, `hrtime`. (Source: `createProcessShim` in

--- a/packages/webapp/src/kernel/realm/helpers/node-stream.ts
+++ b/packages/webapp/src/kernel/realm/helpers/node-stream.ts
@@ -1,7 +1,13 @@
 type StreamListener = (...args: unknown[]) => void;
 
+interface PipeDestination {
+  write(chunk: unknown): unknown;
+  end(): unknown;
+}
+
 class StreamBase {
   private _events: Map<string, StreamListener[]> = new Map();
+  private closeScheduled = false;
   writable = true;
   readable = true;
 
@@ -36,8 +42,17 @@ class StreamBase {
     return true;
   }
 
-  pipe(dest: StreamBase): StreamBase {
+  pipe<T extends PipeDestination>(dest: T): T {
+    this.on('data', (chunk) => dest.write(chunk));
+    this.once('end', () => dest.end());
     return dest;
+  }
+
+  protected closeOnDestroy(): this {
+    if (this.closeScheduled) return this;
+    this.closeScheduled = true;
+    queueMicrotask(() => this.emit('close'));
+    return this;
   }
 
   removeListener(event: string, fn: StreamListener): this {
@@ -55,7 +70,7 @@ export class Readable extends StreamBase {
     return null;
   }
   destroy(): this {
-    return this;
+    return this.closeOnDestroy();
   }
 }
 
@@ -69,7 +84,7 @@ class Writable extends StreamBase {
     return this;
   }
   destroy(): this {
-    return this;
+    return this.closeOnDestroy();
   }
 }
 
@@ -86,7 +101,7 @@ class Transform extends StreamBase {
     return null;
   }
   destroy(): this {
-    return this;
+    return this.closeOnDestroy();
   }
 }
 

--- a/packages/webapp/src/kernel/realm/realm-node-shims.ts
+++ b/packages/webapp/src/kernel/realm/realm-node-shims.ts
@@ -74,6 +74,8 @@ export function createProcessShim(
   // uncaught error).
   const stdinShim = createStdinShim(init.stdin ?? '', recordExit);
   const argvWithParseFlags = attachArgvParseFlags(init.argv);
+  const stdout = { write: writeStdout, end: () => undefined, isTTY: !noColor };
+  const stderr = { write: writeStderr, end: () => undefined, isTTY: !noColor };
   const processShim = {
     argv: argvWithParseFlags,
     env: init.env,
@@ -84,8 +86,8 @@ export function createProcessShim(
       throw new NodeExitError(normalized);
     },
     stdin: stdinShim,
-    stdout: { write: writeStdout, isTTY: !noColor },
-    stderr: { write: writeStderr, isTTY: !noColor },
+    stdout,
+    stderr,
   };
   return {
     processShim,

--- a/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
+++ b/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
@@ -583,6 +583,21 @@ describe('node:stream shim', () => {
     expect(out.stdout.trim()).toBe('true\nended a,b');
   });
 
+  it('pipes to process.stdout without throwing when the source ends', async () => {
+    const ctx = makeCtx();
+    const out = await runCode(
+      `const { Readable } = require('node:stream');
+       const r = new Readable();
+       r.pipe(process.stdout);
+       r.emit('data', 'piped');
+       r.emit('end');`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stderr).toBe('');
+    expect(out.stdout).toBe('piped');
+  });
+
   it('destroy emits close once for each stream type', async () => {
     const ctx = makeCtx();
     const out = await runCode(

--- a/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
+++ b/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
@@ -564,17 +564,47 @@ describe('node:stream shim', () => {
     expect(out.stdout.trim()).toBe('true true function function');
   });
 
-  it('pipe returns destination', async () => {
+  it('pipe returns the destination, forwards data, and ends it', async () => {
     const ctx = makeCtx();
     const out = await runCode(
       `const { Readable, Writable } = require('node:stream');
        const r = new Readable();
        const w = new Writable();
-       console.log(r.pipe(w) === w);`,
+       const chunks = [];
+       w.write = (chunk) => { chunks.push(chunk); return true; };
+       w.end = () => { console.log('ended', chunks.join(',')); return w; };
+       console.log(r.pipe(w) === w);
+       r.emit('data', 'a');
+       r.emit('data', 'b');
+       r.emit('end');`,
       ctx
     );
     expect(out.exitCode).toBe(0);
-    expect(out.stdout.trim()).toBe('true');
+    expect(out.stdout.trim()).toBe('true\nended a,b');
+  });
+
+  it('destroy emits close once for each stream type', async () => {
+    const ctx = makeCtx();
+    const out = await runCode(
+      `const { Readable, Writable, Transform, PassThrough } = require('stream');
+       const events = [];
+       const streams = [
+         ['readable', new Readable()],
+         ['writable', new Writable()],
+         ['transform', new Transform()],
+         ['pass-through', new PassThrough()],
+       ];
+       for (const [name, stream] of streams) {
+         stream.on('close', () => events.push(name));
+         stream.destroy();
+         stream.destroy();
+       }
+       await Promise.resolve();
+       console.log(events.join(','));`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.trim()).toBe('readable,writable,transform,pass-through');
   });
 
   it('on/emit event wiring works', async () => {


### PR DESCRIPTION
## Problem
Follow-up to #1890: realm streams did not forward `data`/`end` through `pipe()` or emit `close` from `destroy()`.

## Solution
Add the minimal lifecycle wiring with regression coverage; this PR is stacked on #1890 and targets `main`.

## Misc
Full test and coverage runs hit the pre-existing fake-LLM SSE ordering failure documented on #1890; lint, typecheck, focused tests, browser builds, and bundle budgets pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KZ3J8MT9VWY4FEB64Q7AZ34R&panel=chat)