### PR TITLE
chore(deps): bump @biomejs/biome to 2.5.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "slicc": "dist/node-server/index.js"
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.5",
+        "@biomejs/biome": "2.5.6",
         "@playwright/test": "^1.58.2",
         "@semantic-release/exec": "7.1.0",
         "@semantic-release/git": "10.0.1",
@@ -726,9 +726,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.5.tgz",
-      "integrity": "sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.6.tgz",
+      "integrity": "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -742,20 +742,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.5",
-        "@biomejs/cli-darwin-x64": "2.5.5",
-        "@biomejs/cli-linux-arm64": "2.5.5",
-        "@biomejs/cli-linux-arm64-musl": "2.5.5",
-        "@biomejs/cli-linux-x64": "2.5.5",
-        "@biomejs/cli-linux-x64-musl": "2.5.5",
-        "@biomejs/cli-win32-arm64": "2.5.5",
-        "@biomejs/cli-win32-x64": "2.5.5"
+        "@biomejs/cli-darwin-arm64": "2.5.6",
+        "@biomejs/cli-darwin-x64": "2.5.6",
+        "@biomejs/cli-linux-arm64": "2.5.6",
+        "@biomejs/cli-linux-arm64-musl": "2.5.6",
+        "@biomejs/cli-linux-x64": "2.5.6",
+        "@biomejs/cli-linux-x64-musl": "2.5.6",
+        "@biomejs/cli-win32-arm64": "2.5.6",
+        "@biomejs/cli-win32-x64": "2.5.6"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.5.tgz",
-      "integrity": "sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==",
       "cpu": [
         "arm64"
       ],
@@ -770,9 +770,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.5.tgz",
-      "integrity": "sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==",
       "cpu": [
         "x64"
       ],
@@ -787,9 +787,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.5.tgz",
-      "integrity": "sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.6.tgz",
+      "integrity": "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==",
       "cpu": [
         "arm64"
       ],
@@ -807,9 +807,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.5.tgz",
-      "integrity": "sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==",
       "cpu": [
         "arm64"
       ],
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.5.tgz",
-      "integrity": "sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.6.tgz",
+      "integrity": "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==",
       "cpu": [
         "x64"
       ],
@@ -847,9 +847,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.5.tgz",
-      "integrity": "sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==",
       "cpu": [
         "x64"
       ],
@@ -867,9 +867,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.5.tgz",
-      "integrity": "sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==",
       "cpu": [
         "arm64"
       ],
@@ -884,9 +884,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.5.tgz",
-      "integrity": "sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.5",
+    "@biomejs/biome": "2.5.6",
     "@playwright/test": "^1.58.2",
     "@semantic-release/exec": "7.1.0",
     "@semantic-release/git": "10.0.1",

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -1721,7 +1721,7 @@ export class Bridge implements KernelFacade {
       ...(msg.steer ? { steer: true as const } : {}),
     };
     await this.orchestrator?.handleMessage(channelMsg);
-    this.orchestrator?.createScoopTab(msg.scoopJid);
+    await this.orchestrator?.createScoopTab(msg.scoopJid);
   }
 
   /**

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -941,7 +941,7 @@ export class ScoopContext {
       if (this.disposed || abortSignal.aborted) return null;
 
       const recovery = this.overflowRecoveryPromise;
-      if (recovery) {
+      if (recovery !== null) {
         await recovery;
         if (this.overflowRecoveryPromise === recovery) this.overflowRecoveryPromise = null;
         if (this.disposed || abortSignal.aborted) return null;

--- a/packages/webapp/src/shell/almost-bash-shell-headless.ts
+++ b/packages/webapp/src/shell/almost-bash-shell-headless.ts
@@ -504,7 +504,7 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
    * custom commands. Idempotent; in-flight calls coalesce.
    */
   async syncJshCommands(): Promise<void> {
-    if (this.jshSyncInflight) {
+    if (this.jshSyncInflight !== null) {
       this.jshSyncDirty = true;
       return this.jshSyncInflight;
     }

--- a/packages/webapp/tests/scoops/scoop-message-router.test.ts
+++ b/packages/webapp/tests/scoops/scoop-message-router.test.ts
@@ -221,6 +221,7 @@ describe('ScoopMessageRouter re-entrancy guard', () => {
     });
 
     await expect(harness.router.handleMessage(makeMessage('cone', 0))).rejects.toThrow('boom');
+    // biome-ignore lint/nursery/noFloatingPromises: already awaited; biome 2.5.6 mis-infers the `??=` assignment as a nested promise and suggests `await await`
     await coalesced;
 
     expect(harness.sends.some((p) => p.includes('MSG_001'))).toBe(true);


### PR DESCRIPTION
## Why

`biome check .` went from ~67s to ~640s in CI when the nursery async rules landed in #1874. The cause is upstream: [`noMisusedPromises` is a lot slower since 2.5.4](https://github.com/biomejs/biome/issues/11096). We were pinned at 2.5.5, inside that window.

CI `lint` step, median of the runs either side of the #1874 merge (2026-08-02 15:23Z):

| | median |
| --- | --- |
| before merge (14:55–15:19Z) | **67s** |
| after merge (18:31–20:08Z) | **640s** |

Biome says it plainly in the job log: `Checked 2021 files in 388s`. Prettier in the same step is 4s, so biome was ~78% of the job.

Attribution between the two rules, measured locally on 668 files (two passes, machine under load so read the ratios not the absolutes):

| config | time |
| --- | --- |
| both rules off | 2–3s |
| only `noFloatingPromises` | 5–6s |
| only `noMisusedPromises` | 44–53s |

## What this changes

Bumps `@biomejs/biome` 2.5.5 → 2.5.6. `biome check .` over 2039 files now takes **~2s** locally, and the full `lint:ci` chain runs in **61s** on a machine at load 400+.

2.5.6 also has better inference, which surfaces four findings 2.5.5 missed. One is a real bug:

- **`kernel/facade.ts`** — genuine floating promise. `Orchestrator.createScoopTab` returns `Promise<void>`, the line above it already awaits `handleMessage`, and every other call site (`orchestrator.ts:424`, `scoop-message-router.ts:237`) awaits it. Now awaited.

The other three are false positives on nullable-promise unions, where biome's autofix would be actively wrong:

- **`scoop-context.ts`**, **`almost-bash-shell-headless.ts`** — `if (promiseOrNull)` on `Promise<void> | null` fields is a null check. Biome suggests `if (await ...)`, which would await the promise and test the resolved `void` — inverting the in-flight coalescing. Rewritten as explicit `!== null`, which is behaviour-identical and satisfies the rule.
- **`scoop-message-router.test.ts`** — flagged on an already-awaited expression; the suggested fix is `await await coalesced`. Suppressed with a `biome-ignore` naming the reason.

## Verification

- `biome check .` — clean (26 pre-existing warnings, unchanged)
- `npm run typecheck` — pass
- `npm run lint:ci` — pass, 61s
- `check-touched-exemptions` — OK, 6 changed files, 0 on any debt list
- Tests covering the touched code (scoops, kernel, shell) — pass

One caveat worth stating: a wide test run showed failures in `tests/shell/ipk/`, all 5s timeouts. They are load flakes on this machine, not from this change — two identical wide runs failed *different* counts (7, then 13), and the same narrow scope passes 441/441 both with and without these edits.

## Follow-up, not in this PR

[`perf(noFloatingPromises)`](https://github.com/biomejs/biome/pull/11160) merged upstream 2026-08-01, after 2.5.6 shipped, so a further improvement should arrive in 2.5.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxheYZjwGqrKxTsytgZTkH
