### PR TITLE
feat(webapp): enrich the monitor with tray and followers sections

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -351,7 +351,6 @@
         "packages/webapp/src/shell/almost-bash-shell.ts",
         "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts",
         "packages/webapp/src/ui/wc/wc-nav.ts",
-        "packages/webapp/src/ui/wc/wc-tray.ts",
         "packages/webapp/tests/cdp/cdp-client.test.ts",
         "packages/webapp/tests/cdp/preview-bridge-cdp-transport.test.ts",
         "packages/webapp/tests/fs/internal-mount.test.ts",

--- a/packages/webapp/src/scoops/tray-leader-sync.ts
+++ b/packages/webapp/src/scoops/tray-leader-sync.ts
@@ -28,7 +28,9 @@ import type { LeaderSyncContext } from './tray-leader/context.js';
 import { FollowerDispatch } from './tray-leader/follower-dispatch.js';
 import {
   type ConnectedFollower,
+  deriveFloatType,
   type FloatType,
+  type FollowerDetails,
   FollowerRegistry,
   labelForFollower,
 } from './tray-leader/follower-registry.js';
@@ -52,7 +54,7 @@ import type { TrayDataChannelLike } from './tray-webrtc.js';
 const log = createLogger('tray-leader-sync');
 
 export type { FloatType, RemoteExecResult };
-export { isCherryTarget, labelForFollower, selectTeleportPool };
+export { deriveFloatType, isCherryTarget, labelForFollower, selectTeleportPool };
 
 export interface LeaderSyncManagerOptions {
   /** Get current chat messages for the active scoop. */
@@ -336,6 +338,10 @@ export class LeaderSyncManager {
 
   getFollowerMotds(): Map<string, string> {
     return this.followerRegistry.getFollowerMotds();
+  }
+
+  getFollowerDetails(): FollowerDetails[] {
+    return this.followerRegistry.getFollowerDetails();
   }
 
   setLocalTargets(targets: RemoteTargetInfo[]): void {

--- a/packages/webapp/src/scoops/tray-leader/follower-registry.ts
+++ b/packages/webapp/src/scoops/tray-leader/follower-registry.ts
@@ -73,6 +73,17 @@ export interface ConnectedFollowerInfo {
   floatType?: FloatType;
 }
 
+export interface FollowerDetails {
+  bootstrapId: string;
+  runtime?: string;
+  connectedAt?: string;
+  lastActivity: number;
+  floatType: FloatType;
+  hostOrigin?: string;
+  selectedScoopJid?: string;
+  health: 'live' | 'stalled';
+}
+
 const BROADCAST_ERROR_THROTTLE_MS = 60_000;
 
 export class FollowerRegistry {
@@ -205,6 +216,19 @@ export class FollowerRegistry {
 
   getBrowserCapableBootstrapIds(): Set<string> {
     return new Set(this.runtimeToBootstrap.values());
+  }
+
+  getFollowerDetails(): FollowerDetails[] {
+    return [...this.followers.values()].map((follower) => ({
+      bootstrapId: follower.bootstrapId,
+      runtime: follower.runtime,
+      connectedAt: follower.connectedAt,
+      lastActivity: follower.lastActivity,
+      floatType: follower.floatType,
+      hostOrigin: follower.hostOrigin,
+      selectedScoopJid: follower.selectedScoopJid,
+      health: follower.keepalive.isStalled ? 'stalled' : 'live',
+    }));
   }
 
   getConnectedFollowers(): ConnectedFollowerInfo[] {

--- a/packages/webapp/src/scoops/tray-webrtc.ts
+++ b/packages/webapp/src/scoops/tray-webrtc.ts
@@ -96,6 +96,8 @@ export interface LeaderTrayPeerManagerOptions {
   sendControlMessage: (message: LeaderToWorkerControlMessage) => void;
   peerConnectionFactory?: TrayPeerConnectionFactory;
   dataChannelLabel?: string;
+  /** Called whenever the visible peer set or a peer's connecting/connected state changes. */
+  onPeersChanged?: () => void;
   onPeerConnected?: (peer: LeaderTrayPeerState, channel: TrayDataChannelLike) => void;
   /** Called when an established peer connection transitions to 'disconnected' or 'failed'. */
   onPeerDisconnected?: (bootstrapId: string, reason: string) => void;
@@ -187,6 +189,7 @@ export class LeaderTrayPeerManager {
       active.peer.close();
     }
     this.peers.clear();
+    this.options.onPeersChanged?.();
   }
 
   private async handleJoinRequested(message: FollowerJoinRequestedMessage): Promise<void> {
@@ -202,6 +205,7 @@ export class LeaderTrayPeerManager {
     };
     const channel = bindSctpLimit(peer.createDataChannel(this.dataChannelLabel), peer);
     this.peers.set(message.bootstrapId, { state, peer, channel });
+    this.options.onPeersChanged?.();
 
     peer.addEventListener('icecandidate', ({ candidate }) => {
       const normalized = normalizeIceCandidate(candidate);
@@ -242,6 +246,7 @@ export class LeaderTrayPeerManager {
       active.state.state = 'connected';
       active.state.connectedAt = new Date().toISOString();
       this.options.onPeerConnected?.({ ...active.state }, active.channel);
+      this.options.onPeersChanged?.();
     });
     channel.addEventListener('close', () => {
       const active = this.peers.get(message.bootstrapId);
@@ -292,6 +297,7 @@ export class LeaderTrayPeerManager {
     if (!active) return;
     active.peer.close();
     this.peers.delete(message.bootstrapId);
+    this.options.onPeersChanged?.();
     try {
       this.options.sendControlMessage({
         type: 'bootstrap.failed',

--- a/packages/webapp/src/shell/supplemental-commands/host-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/host-command.ts
@@ -7,6 +7,7 @@ import {
   getFollowerTrayRuntimeStatus,
 } from '../../scoops/tray-follower-status.js';
 import { joinTray as defaultJoinTray } from '../../scoops/tray-join.js';
+import type { FloatType } from '../../scoops/tray-leader/follower-registry.js';
 import {
   getLeaderStatusWithFallback,
   type LeaderTrayRuntimeStatus,
@@ -21,6 +22,11 @@ export interface ConnectedFollowerInfo {
   runtimeId: string;
   runtime?: string;
   connectedAt?: string;
+  floatType?: FloatType;
+  hostOrigin?: string;
+  selectedScoopJid?: string;
+  health?: 'live' | 'stalled';
+  peerState?: 'connecting' | 'connected';
   /** True when the follower advertised `exec` capability (a `slicc … follow` CLI) — reach it with `ssh`. */
   exec?: boolean;
   /** True when the follower advertised browser targets — reach its tabs with `playwright-cli`. */

--- a/packages/webapp/src/ui/page-leader-tray.ts
+++ b/packages/webapp/src/ui/page-leader-tray.ts
@@ -41,7 +41,7 @@ import {
   type LeaderTrayRuntimeStatus,
 } from '../scoops/tray-leader.js';
 import type { LeaderSyncManagerOptions } from '../scoops/tray-leader-sync.js';
-import { LeaderSyncManager } from '../scoops/tray-leader-sync.js';
+import { deriveFloatType, type FloatType, LeaderSyncManager } from '../scoops/tray-leader-sync.js';
 import { buildTrayLaunchUrl } from '../scoops/tray-runtime-config.js';
 import type {
   RemoteTargetInfo,
@@ -178,10 +178,51 @@ export interface PageLeaderTrayHandle {
   readonly currentLeaderSync: LeaderSyncManager | null;
 }
 
+export interface PageLeaderFollowerState {
+  bootstrapId: string;
+  runtime?: string;
+  connectedAt?: string;
+  floatType?: FloatType;
+  hostOrigin?: string;
+  selectedScoopJid?: string;
+  health?: 'live' | 'stalled';
+  peerState: 'connecting' | 'connected';
+}
+
+export function getLeaderFollowerStates(
+  peers: Pick<LeaderTrayPeerManager, 'getPeers'>,
+  sync: Pick<LeaderSyncManager, 'getFollowerDetails'>
+): PageLeaderFollowerState[] {
+  const details = new Map(
+    sync.getFollowerDetails().map((follower) => [follower.bootstrapId, follower])
+  );
+  const states: PageLeaderFollowerState[] = [];
+  for (const peer of peers.getPeers()) {
+    const follower = details.get(peer.bootstrapId);
+    if (peer.state === 'connected' && !follower) continue;
+    states.push({
+      bootstrapId: peer.bootstrapId,
+      runtime: follower?.runtime ?? peer.runtime,
+      connectedAt: follower?.connectedAt ?? peer.connectedAt ?? undefined,
+      floatType: follower?.floatType ?? deriveFloatType(peer.runtime),
+      hostOrigin: follower?.hostOrigin,
+      selectedScoopJid: follower?.selectedScoopJid,
+      health: follower?.health,
+      peerState: peer.state,
+    });
+    details.delete(peer.bootstrapId);
+  }
+  for (const follower of details.values()) {
+    states.push({ ...follower, peerState: 'connected' });
+  }
+  return states;
+}
+
 /** --- Sync manager (top of the dependency chain — peers feeds it) --- */
 function buildSyncManager(
   options: StartPageLeaderTrayOptions,
-  getLeader: () => LeaderTrayManager
+  getLeader: () => LeaderTrayManager,
+  onFollowerCountChanged: () => void
 ): LeaderSyncManager {
   const syncOptions: LeaderSyncManagerOptions = {
     sendControl: (msg) => getLeader().sendControlMessage(msg),
@@ -196,7 +237,7 @@ function buildSyncManager(
     onFollowerMessage: options.onFollowerMessage,
     onFollowerAbort: options.onFollowerAbort,
     onFollowerNewSession: options.onFollowerNewSession,
-    onFollowerCountChanged: options.onFollowerCountChanged,
+    onFollowerCountChanged,
     onRemoteTransportsCleaned: options.onRemoteTransportsCleaned,
     execInShell: options.execInShell,
     onCherryHostEvent: options.onCherryHostEvent,
@@ -223,10 +264,12 @@ function buildSyncManager(
  */
 function buildPeerManager(
   getLeader: () => LeaderTrayManager,
-  sync: LeaderSyncManager
+  sync: LeaderSyncManager,
+  onPeersChanged: () => void
 ): LeaderTrayPeerManager {
   return new LeaderTrayPeerManager({
     sendControlMessage: (message) => getLeader().sendControlMessage(message),
+    onPeersChanged,
     onPeerConnected: (peer, channel) => {
       log.info('Tray follower data channel opened', {
         controllerId: peer.controllerId,
@@ -471,12 +514,20 @@ export function startPageLeaderTray(options: StartPageLeaderTrayOptions): PageLe
   // Forward declaration so the peer manager can call `leader.sendControlMessage`
   // through the getter closure; the leader is constructed bottom-up after peers.
   let leader!: LeaderTrayManager;
+  let peers!: LeaderTrayPeerManager;
+  let sync!: LeaderSyncManager;
   const updateUrlBar = createUpdateUrlBar(options);
+  const notifyFollowerCountChanged = (): void => {
+    const count = getLeaderFollowerStates(peers, sync).filter(
+      (follower) => follower.peerState === 'connected'
+    ).length;
+    options.onFollowerCountChanged?.(count);
+  };
 
   // Forward declaration so sync can call leader.sendControlMessage through the getter
-  const sync = buildSyncManager(options, () => leader);
+  sync = buildSyncManager(options, () => leader, notifyFollowerCountChanged);
   options.browserAPI.setTrayTargetProvider(sync);
-  const peers = buildPeerManager(() => leader, sync);
+  peers = buildPeerManager(() => leader, sync, notifyFollowerCountChanged);
   leader = buildLeaderManager(options, peers, sync, fetchImpl, updateUrlBar, () => leader);
 
   // --- Agent event tap → broadcast to all followers. The helper owns

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -27,8 +27,16 @@ import {
 } from '../../providers/account-store.js';
 import { SessionStore as UiSessionStore } from '../../scoops/chat-session-store.js';
 import type { LickEvent } from '../../scoops/lick-manager.js';
-import { hasStoredTrayJoinUrl } from '../../scoops/tray-runtime-config.js';
+import { getFollowerTrayRuntimeStatus } from '../../scoops/tray-follower-status.js';
+import { getLeaderTrayRuntimeStatus } from '../../scoops/tray-leader.js';
+import {
+  hasStoredTrayJoinUrl,
+  normalizeTrayWorkerBaseUrl,
+  parseTrayJoinUrlValue,
+  TRAY_WORKER_STORAGE_KEY,
+} from '../../scoops/tray-runtime-config.js';
 import type { RegisteredScoop, ThinkingLevel } from '../../scoops/types.js';
+import { getConnectedFollowers } from '../../shell/supplemental-commands/host-command.js';
 import { registerTranscriptExportService } from '../../transcript/export-provider.js';
 import { DefaultTranscriptExportService } from '../../transcript/export-service.js';
 import { readSnapshot, writeSnapshot } from '../../transcript/snapshot-store.js';
@@ -50,6 +58,7 @@ import {
   type LeaderRunNewSessionDetail,
 } from './leader-session-events.js';
 import { WcChatController } from './wc-chat-controller.js';
+import type { MonitorTrayInfo } from './wc-monitor.js';
 import { scoopColor } from './wc-scoop-color.js';
 
 export { scoopColor } from './wc-scoop-color.js';
@@ -138,6 +147,39 @@ const PROC_STATE_LETTER_TO_WORD: Record<string, string> = {
 export function parseProcStatLine(statLine: string): string {
   const stateLetter = statLine.trim().split(' ')[2] ?? '';
   return PROC_STATE_LETTER_TO_WORD[stateLetter] ?? 'unknown';
+}
+
+function getTrayMonitorInfo(storage: Pick<Storage, 'getItem'>): MonitorTrayInfo {
+  const follower = getFollowerTrayRuntimeStatus();
+  if (follower.state !== 'inactive') {
+    return {
+      role: 'follower',
+      state: follower.state,
+      joinUrl: follower.joinUrl,
+      sessionId: follower.trayId,
+      workerBaseUrl: parseTrayJoinUrlValue(follower.joinUrl)?.workerBaseUrl ?? null,
+      stalled: follower.stalled,
+    };
+  }
+
+  const leader = getLeaderTrayRuntimeStatus();
+  if (leader.state !== 'inactive') {
+    return {
+      role: 'leader',
+      state: leader.state,
+      joinUrl: leader.session?.joinUrl,
+      sessionId: leader.session?.trayId,
+      workerBaseUrl: leader.session?.workerBaseUrl,
+    };
+  }
+
+  let workerBaseUrl: string | null = null;
+  try {
+    workerBaseUrl = normalizeTrayWorkerBaseUrl(storage.getItem(TRAY_WORKER_STORAGE_KEY));
+  } catch {
+    // Storage can be unavailable in a sandboxed page; inactive tray display remains usable.
+  }
+  return { role: 'standalone', state: 'inactive', workerBaseUrl };
 }
 
 /**
@@ -1728,6 +1770,8 @@ export function attachWcClient(
             return [];
           }
         },
+        getTrayInfo: () => getTrayMonitorInfo(window.localStorage),
+        getConnectedFollowers,
       }),
       mountTerminal: (container) => mountWorkbenchTerminal(boot, client, container),
       insertReference: (path: string) => {

--- a/packages/webapp/src/ui/wc/wc-monitor.ts
+++ b/packages/webapp/src/ui/wc/wc-monitor.ts
@@ -1,13 +1,14 @@
 /**
  * Monitor surface for the WC workbench: read-only dashboard of all resources
- * managed by SLICC — scoops, cron tasks, webhooks, mounts, MCP servers,
- * and OAuth accounts.
+ * managed by SLICC — tray connections, followers, scoops, cron tasks,
+ * webhooks, mounts, MCP servers, and OAuth accounts.
  */
 
 import type { MonitorSection } from '@slicc/webcomponents';
 import type { MountTableEntry } from '../../fs/mount-table-store.js';
 import type { CronTaskEntry, WebhookEntry } from '../../scoops/lick-manager.js';
 import type { RegisteredScoop } from '../../scoops/types.js';
+import type { ConnectedFollowerInfo } from '../../shell/supplemental-commands/host-command.js';
 
 /**
  * A persisted mount entry, augmented with the permission state as of the
@@ -40,6 +41,15 @@ export interface OAuthProviderEntry {
   valid?: boolean;
 }
 
+export interface MonitorTrayInfo {
+  role: 'leader' | 'follower' | 'standalone';
+  state: 'inactive' | 'connecting' | 'connected' | 'leader' | 'reconnecting' | 'error';
+  joinUrl?: string | null;
+  sessionId?: string | null;
+  workerBaseUrl?: string | null;
+  stalled?: boolean;
+}
+
 export interface MonitorDeps {
   getScoops(): RegisteredScoop[];
   isProcessing(jid: string): boolean;
@@ -54,6 +64,122 @@ export interface MonitorDeps {
     scoops: { name: string; cost: number }[];
   } | null>;
   getProcesses(): Promise<{ pid: number; argv: string; status: string }[]>;
+  getTrayInfo(): MonitorTrayInfo;
+  getConnectedFollowers(): ConnectedFollowerInfo[];
+}
+
+function shortId(runtimeId: string): string {
+  const unprefixed = runtimeId.replace(/^follower-/, '');
+  return unprefixed.length > 12 ? `${unprefixed.slice(0, 8)}…` : unprefixed;
+}
+
+function followerTypeLabel(follower: ConnectedFollowerInfo): string {
+  if (follower.floatType === 'ios') return 'iOS';
+  if (follower.floatType === 'electron') return 'Electron';
+  if (follower.floatType === 'extension') return 'Extension';
+  if (follower.floatType === 'standalone') return 'Standalone';
+  return follower.runtime?.includes('cli') ? 'CLI' : 'Follower';
+}
+
+function followerIcon(follower: ConnectedFollowerInfo): string {
+  if (follower.floatType === 'ios') return 'smartphone';
+  if (follower.floatType === 'electron' || follower.floatType === 'standalone') return 'monitor';
+  if (follower.floatType === 'extension') return 'blocks';
+  return follower.runtime?.includes('cli') ? 'terminal' : 'radio';
+}
+
+function elapsedSince(connectedAt?: string): string | null {
+  if (!connectedAt) return null;
+  const timestamp = new Date(connectedAt).getTime();
+  if (!Number.isFinite(timestamp)) return null;
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86_400)}d`;
+}
+
+function followerStatus(follower: ConnectedFollowerInfo): 'active' | 'warn' | 'idle' {
+  if (follower.health === 'stalled') return 'warn';
+  if (follower.peerState === 'connecting') return 'idle';
+  if (follower.peerState === 'connected' && follower.health === 'live') return 'active';
+  return 'idle';
+}
+
+function followerMeta(follower: ConnectedFollowerInfo): string {
+  const state =
+    follower.health === 'stalled'
+      ? 'stalled'
+      : follower.peerState === 'connecting'
+        ? 'connecting'
+        : 'connected';
+  const age = elapsedSince(follower.connectedAt);
+  return age ? `${state} ${age}` : state;
+}
+
+export function buildFollowersSection(followers: ConnectedFollowerInfo[]): MonitorSection {
+  const stalled = followers.filter((follower) => follower.health === 'stalled').length;
+  const connecting = followers.filter(
+    (follower) => follower.health !== 'stalled' && follower.peerState === 'connecting'
+  ).length;
+  const connected = followers.length - stalled - connecting;
+  const summary = [
+    connected > 0 ? `${connected} connected` : '',
+    connecting > 0 ? `${connecting} connecting` : '',
+    stalled > 0 ? `${stalled} stalled` : '',
+  ].filter(Boolean);
+  return {
+    id: 'followers',
+    label: 'Followers',
+    count: followers.filter((follower) => follower.peerState === 'connected').length,
+    meta: summary.join(' · ') || undefined,
+    accent: 'cyan',
+    emptyText: 'No followers connected yet. Pair a phone, tablet, or CLI follower to this tray.',
+    rows: followers.map((follower) => {
+      const detail = follower.motd ?? follower.runtime ?? 'Connected follower';
+      const sublabel = follower.hostOrigin ? `${detail} · ${follower.hostOrigin}` : detail;
+      const badges = [follower.exec ? 'ssh' : '', follower.cdp ? 'playwright' : ''].filter(Boolean);
+      return {
+        name: `${followerTypeLabel(follower)} · ${shortId(follower.runtimeId)}`,
+        sublabel,
+        meta: followerMeta(follower),
+        icon: followerIcon(follower),
+        badges,
+        status: followerStatus(follower),
+      };
+    }),
+  };
+}
+
+function buildTraySection(tray: MonitorTrayInfo): MonitorSection {
+  const state = tray.stalled ? 'stalled' : tray.state === 'leader' ? 'connected' : tray.state;
+  const status =
+    tray.stalled || tray.state === 'reconnecting'
+      ? 'warn'
+      : tray.state === 'error'
+        ? 'error'
+        : tray.state === 'leader' || tray.state === 'connected'
+          ? 'active'
+          : 'idle';
+  const session = tray.sessionId ? `Session ${shortId(tray.sessionId)}` : null;
+  const worker = tray.workerBaseUrl ? `Worker · ${tray.workerBaseUrl}` : null;
+  return {
+    id: 'tray',
+    label: 'Tray',
+    count: 1,
+    meta: `${tray.role} · ${state}`,
+    accent: 'waffle',
+    rows: [
+      {
+        name: tray.role[0].toUpperCase() + tray.role.slice(1),
+        sublabel: [session, worker].filter(Boolean).join(' · ') || 'No tray session',
+        meta: state,
+        icon: tray.role === 'follower' ? 'radio' : 'cloud',
+        badges: tray.joinUrl ? ['join URL'] : [],
+        status,
+      },
+    ],
+  };
 }
 
 /**
@@ -62,6 +188,8 @@ export interface MonitorDeps {
  */
 export async function fetchMonitorData(deps: MonitorDeps): Promise<MonitorSection[]> {
   const scoops = deps.getScoops();
+  const tray = deps.getTrayInfo();
+  const followers = deps.getConnectedFollowers();
   const [cronTasks, webhooks, mounts, mcpServers, sessionStats, processes] = await Promise.all([
     deps.getCronTasks().catch(() => [] as CronTaskEntry[]),
     deps.getWebhooks().catch(() => [] as WebhookEntry[]),
@@ -74,6 +202,8 @@ export async function fetchMonitorData(deps: MonitorDeps): Promise<MonitorSectio
   const mcpEntries = Object.entries(mcpServers);
 
   const sections: MonitorSection[] = [
+    buildTraySection(tray),
+    buildFollowersSection(followers),
     {
       id: 'cost',
       label: 'Cost',

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -26,6 +26,7 @@ import {
 } from '../../scoops/tray-runtime-config.js';
 import { apiHeaders, resolveApiUrl } from '../../shell/proxied-fetch.js';
 import {
+  type ConnectedFollowerInfo,
   getConnectedFollowers,
   setConnectedFollowersGetter,
   setTrayResetter,
@@ -38,6 +39,7 @@ import { runLeaderExecInShell } from '../leader-exec-runner.js';
 import type { OffscreenClient } from '../offscreen-client.js';
 import { type PageFollowerTrayHandle, startPageFollowerTray } from '../page-follower-tray.js';
 import {
+  getLeaderFollowerStates,
   type PageLeaderTrayHandle,
   type StartPageLeaderTrayOptions,
   startPageLeaderTray,
@@ -103,6 +105,27 @@ interface TrayRoleState {
   lockRelease: (() => void) | null;
 }
 
+export function getLeaderConnectedFollowers(handle: PageLeaderTrayHandle): ConnectedFollowerInfo[] {
+  const execIds = handle.sync.getExecCapableBootstrapIds();
+  const cdpIds = handle.sync.getBrowserCapableBootstrapIds();
+  const motds = handle.sync.getFollowerMotds();
+  return getLeaderFollowerStates(handle.peers, handle.sync).map((follower) => {
+    return {
+      runtimeId: canonicalRuntimeId(follower.bootstrapId),
+      runtime: follower.runtime,
+      connectedAt: follower.connectedAt,
+      floatType: follower.floatType,
+      hostOrigin: follower.hostOrigin,
+      selectedScoopJid: follower.selectedScoopJid,
+      health: follower.health,
+      peerState: follower.peerState,
+      exec: execIds.has(follower.bootstrapId),
+      cdp: cdpIds.has(follower.bootstrapId),
+      motd: motds.get(follower.bootstrapId),
+    };
+  });
+}
+
 function buildFollowerOptions(
   deps: WcTrayDeps,
   joinUrl: string
@@ -127,12 +150,23 @@ function buildFollowerOptions(
 }
 
 /** Leader option factory — the WC equivalent of `buildLeaderTrayOptions`. */
-function createLeaderOptionsFactory(
+export function createLeaderOptionsFactory(
   deps: WcTrayDeps,
   state: TrayRoleState,
   remoteCdpBridge: RemoteCdpPageBridge
 ): (workerBaseUrl: string) => StartPageLeaderTrayOptions {
   const { client, refs } = deps;
+  const refreshFollowerPresentation = (fallbackCount = 0): void => {
+    const followers = state.leader ? getLeaderConnectedFollowers(state.leader) : [];
+    const count = fallbackCount;
+    refs.floatbar.setAttribute(
+      'label',
+      count > 0
+        ? `tray · ${count} follower${count === 1 ? '' : 's'}`
+        : (deps.baseFloatLabel ?? 'standalone · live')
+    );
+    writeConnectedFollowersToShim(followers);
+  };
   return (workerBaseUrl) => ({
     workerBaseUrl,
     getMessages: () => deps.getController()?.getMessages() ?? [],
@@ -180,17 +214,7 @@ function createLeaderOptionsFactory(
         })
       );
     },
-    onFollowerCountChanged: (count) => {
-      refs.floatbar.setAttribute(
-        'label',
-        count > 0
-          ? `tray · ${count} follower${count === 1 ? '' : 's'}`
-          : (deps.baseFloatLabel ?? 'standalone · live')
-      );
-      // Mirror the live follower list into the shim so the standalone
-      // worker-side `host` command (no live getter) reflects it.
-      writeConnectedFollowersToShim(getConnectedFollowers());
-    },
+    onFollowerCountChanged: refreshFollowerPresentation,
     onRemoteTransportsCleaned: (runtimeId) => remoteCdpBridge.cleanupRuntime(runtimeId),
     onForwardedLick: (event) => client.sendForwardedLick(event),
     onCherryHostEvent: (runtimeId, name, detail) =>
@@ -257,19 +281,7 @@ function createLeaderHookSetup(
 ): { wireLeaderHooks(handle: PageLeaderTrayHandle): void; clearLeaderHooks(): void } {
   return {
     wireLeaderHooks: (handle) => {
-      setConnectedFollowersGetter(() => {
-        const execIds = handle.sync.getExecCapableBootstrapIds();
-        const cdpIds = handle.sync.getBrowserCapableBootstrapIds();
-        const motds = handle.sync.getFollowerMotds();
-        return handle.peers.getPeers().map((p) => ({
-          runtimeId: canonicalRuntimeId(p.bootstrapId),
-          runtime: p.runtime,
-          connectedAt: p.connectedAt ?? undefined,
-          exec: execIds.has(p.bootstrapId),
-          cdp: cdpIds.has(p.bootstrapId),
-          motd: motds.get(p.bootstrapId),
-        }));
-      });
+      setConnectedFollowersGetter(() => getLeaderConnectedFollowers(handle));
       setTrayResetter(() => handle.reset());
       deps.sprinkleManager.setSendToSprinkleHook((name, data) =>
         handle.sync.broadcastSprinkleUpdate(name, data)
@@ -289,8 +301,8 @@ function createLeaderHookSetup(
         ?.setOnLocalProcessingChange((processing) =>
           handle.sync.broadcastStatus(processing ? 'processing' : 'ready')
         );
-      import('../theme-engine.js').then(
-        ({ setThemeChangeListener, getActiveThemeId, getActiveThemeJson }) => {
+      void import('../theme-engine.js')
+        .then(({ setThemeChangeListener, getActiveThemeId, getActiveThemeJson }) => {
           let debounceTimer: ReturnType<typeof setTimeout> | undefined;
           setThemeChangeListener((themeJson) => {
             if (getActiveThemeId() === '__preview') return;
@@ -301,8 +313,8 @@ function createLeaderHookSetup(
           // fires on the next change, but a follower joining a leader that
           // booted themed must receive the palette at bootstrap.
           handle.sync.broadcastTheme(getActiveThemeJson());
-        }
-      );
+        })
+        .catch((err) => deps.log.error('failed to install tray theme sync', err));
     },
     clearLeaderHooks: () => {
       setConnectedFollowersGetter(null);
@@ -313,9 +325,11 @@ function createLeaderHookSetup(
       deps.sprinkleManager.setSendToSprinkleHook(undefined);
       deps.sprinkleManager.setReloadHook(undefined);
       remoteCdpBridge.disposeAll();
-      import('../theme-engine.js').then(({ setThemeChangeListener }) => {
-        setThemeChangeListener(null);
-      });
+      void import('../theme-engine.js')
+        .then(({ setThemeChangeListener }) => {
+          setThemeChangeListener(null);
+        })
+        .catch((err) => deps.log.error('failed to clear tray theme sync', err));
     },
   };
 }

--- a/packages/webapp/tests/scoops/tray-leader/follower-registry.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader/follower-registry.test.ts
@@ -118,6 +118,35 @@ describe('FollowerRegistry', () => {
     registry.removeFollower('browser');
   });
 
+  it('exposes follower metadata and live keepalive health through a read snapshot', () => {
+    const registry = createRegistry();
+    const follower = registry.addFollower('b1', new FakeChannel(), {
+      runtime: 'slicc-electron',
+      connectedAt: '2026-08-03T08:00:00.000Z',
+    });
+    follower.hostOrigin = 'https://host.example';
+    follower.selectedScoopJid = 'research';
+
+    expect(registry.getFollowerDetails()).toEqual([
+      expect.objectContaining({
+        bootstrapId: 'b1',
+        runtime: 'slicc-electron',
+        connectedAt: '2026-08-03T08:00:00.000Z',
+        floatType: 'electron',
+        hostOrigin: 'https://host.example',
+        selectedScoopJid: 'research',
+        health: 'live',
+      }),
+    ]);
+
+    vi.advanceTimersByTime(40_000);
+    expect(registry.getFollowerDetails()[0].health).toBe('stalled');
+
+    follower.keepalive.receivePong();
+    expect(registry.getFollowerDetails()[0].health).toBe('live');
+    registry.removeFollower('b1');
+  });
+
   it('throttles repeated broadcast send-error logs per follower', () => {
     const log = createLog();
     const registry = createRegistry({ log });

--- a/packages/webapp/tests/ui/wc/wc-monitor.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-monitor.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import 'fake-indexeddb/auto';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { installWcDomStubs } from './wc-dom-stubs.js';
 
 installWcDomStubs();
@@ -18,14 +18,125 @@ function makeDeps(overrides: Partial<MonitorDeps> = {}): MonitorDeps {
     getOAuthProviders: () => [],
     getSessionStats: async () => null,
     getProcesses: async () => [],
+    getTrayInfo: () => ({ role: 'standalone', state: 'inactive' }),
+    getConnectedFollowers: () => [],
     ...overrides,
   };
 }
 
 describe('fetchMonitorData', () => {
-  it('returns all nine sections', async () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns all eleven sections', async () => {
     const sections = await fetchMonitorData(makeDeps());
-    expect(sections).toHaveLength(9);
+    expect(sections).toHaveLength(11);
+  });
+
+  it('shows standalone tray state and a clear followers empty state', async () => {
+    const sections = await fetchMonitorData(makeDeps());
+    const tray = sections.find((section) => section.id === 'tray')!;
+    const followers = sections.find((section) => section.id === 'followers')!;
+
+    expect(tray.rows[0]).toMatchObject({ name: 'Standalone', meta: 'inactive', status: 'idle' });
+    expect(followers).toMatchObject({ count: 0, rows: [], accent: 'cyan' });
+    expect(followers.emptyText).toContain('No followers connected yet');
+  });
+
+  it('shows exec and stalled followers with approved detail fields', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-03T10:10:00.000Z').getTime());
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getTrayInfo: () => ({
+          role: 'leader',
+          state: 'leader',
+          joinUrl: 'https://tray.example/join/token',
+          sessionId: 'tray-123456789',
+          workerBaseUrl: 'https://tray.example',
+        }),
+        getConnectedFollowers: () => [
+          {
+            runtimeId: 'follower-cli-1',
+            runtime: 'slicc-cli',
+            connectedAt: '2026-08-03T10:00:00.000Z',
+            floatType: 'unknown',
+            health: 'live',
+            peerState: 'connected',
+            exec: true,
+            motd: 'Remote build host',
+          },
+          {
+            runtimeId: 'follower-browser-1',
+            runtime: 'slicc-extension-offscreen',
+            connectedAt: '2026-08-03T10:05:00.000Z',
+            floatType: 'extension',
+            hostOrigin: 'https://host.example',
+            health: 'stalled',
+            peerState: 'connected',
+            cdp: true,
+          },
+        ],
+      })
+    );
+    const tray = sections.find((section) => section.id === 'tray')!;
+    const followers = sections.find((section) => section.id === 'followers')!;
+
+    expect(tray.rows[0]).toMatchObject({ name: 'Leader', status: 'active' });
+    expect(tray.rows[0].badges).toEqual(['join URL']);
+    expect(followers.meta).toBe('1 connected · 1 stalled');
+    expect(followers.rows[0]).toMatchObject({
+      name: 'CLI · cli-1',
+      sublabel: 'Remote build host',
+      badges: ['ssh'],
+      meta: 'connected 10m',
+      status: 'active',
+    });
+    expect(followers.rows[1]).toMatchObject({
+      name: 'Extension · browser-1',
+      sublabel: 'slicc-extension-offscreen · https://host.example',
+      badges: ['playwright'],
+      meta: 'stalled 5m',
+      status: 'warn',
+    });
+  });
+
+  it('shows connecting followers as idle', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getConnectedFollowers: () => [
+          {
+            runtimeId: 'follower-ios-1',
+            floatType: 'ios',
+            health: 'live',
+            peerState: 'connecting',
+          },
+        ],
+      })
+    );
+    const followers = sections.find((section) => section.id === 'followers')!;
+    expect(followers.count).toBe(0);
+    expect(followers.meta).toBe('1 connecting');
+    expect(followers.rows[0]).toMatchObject({
+      name: 'iOS · ios-1',
+      meta: 'connecting',
+      status: 'idle',
+    });
+  });
+
+  it('represents follower tray connection state without changing the follower placeholder', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getTrayInfo: () => ({
+          role: 'follower',
+          state: 'connected',
+          joinUrl: 'https://tray.example/join/token',
+          sessionId: 'tray-follower',
+          workerBaseUrl: 'https://tray.example',
+        }),
+      })
+    );
+    const tray = sections.find((section) => section.id === 'tray')!;
+    expect(tray.meta).toBe('follower · connected');
+    expect(tray.rows[0]).toMatchObject({ name: 'Follower', meta: 'connected', status: 'active' });
   });
 
   it('shows scoop rows with status', async () => {
@@ -68,9 +179,9 @@ describe('fetchMonitorData', () => {
     expect(cronSection.rows[0].meta).toContain('0 9 * * *');
   });
 
-  it('shows empty sections with count 0', async () => {
+  it('shows empty resource sections with count 0', async () => {
     const sections = await fetchMonitorData(makeDeps());
-    for (const section of sections) {
+    for (const section of sections.filter((section) => section.id !== 'tray')) {
       expect(section.count).toBe(0);
     }
   });

--- a/packages/webapp/tests/ui/wc/wc-tray-followers.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-tray-followers.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LeaderSyncManager } from '../../../src/scoops/tray-leader-sync.js';
+import type { TrayDataChannelLike } from '../../../src/scoops/tray-webrtc.js';
+import type { PageLeaderTrayHandle } from '../../../src/ui/page-leader-tray.js';
+import { buildFollowersSection } from '../../../src/ui/wc/wc-monitor.js';
+import {
+  createLeaderOptionsFactory,
+  getLeaderConnectedFollowers,
+} from '../../../src/ui/wc/wc-tray.js';
+
+class FakeChannel implements TrayDataChannelLike {
+  readyState = 'open';
+  addEventListener(): void {}
+  send(): void {}
+  close(): void {
+    this.readyState = 'closed';
+  }
+}
+
+describe('WC tray connected follower mapping', () => {
+  beforeEach(() => vi.useFakeTimers());
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('maps stalled metadata and a capability-less transient CLI', () => {
+    const handle = {
+      sync: {
+        getExecCapableBootstrapIds: () => new Set(['browser-1']),
+        getBrowserCapableBootstrapIds: () => new Set(['browser-1']),
+        getFollowerMotds: () => new Map([['browser-1', 'remote browser']]),
+        getFollowerDetails: () => [
+          {
+            bootstrapId: 'browser-1',
+            runtime: 'slicc-extension-offscreen',
+            connectedAt: '2026-08-03T08:00:00.000Z',
+            lastActivity: 1,
+            floatType: 'extension' as const,
+            hostOrigin: 'https://host.example',
+            selectedScoopJid: 'research',
+            health: 'stalled' as const,
+          },
+          {
+            bootstrapId: 'cli-1',
+            runtime: 'slicc-cli',
+            connectedAt: '2026-08-03T08:01:00.000Z',
+            lastActivity: 2,
+            floatType: 'unknown' as const,
+            health: 'live' as const,
+          },
+        ],
+      },
+      peers: {
+        getPeers: () => [
+          {
+            controllerId: 'controller-browser',
+            bootstrapId: 'browser-1',
+            attempt: 1,
+            state: 'connected' as const,
+            connectedAt: '2026-08-03T08:00:00.000Z',
+            runtime: 'slicc-extension-offscreen',
+          },
+          {
+            controllerId: 'controller-cli',
+            bootstrapId: 'cli-1',
+            attempt: 1,
+            state: 'connected' as const,
+            connectedAt: '2026-08-03T08:01:00.000Z',
+            runtime: 'slicc-cli',
+          },
+        ],
+      },
+    } as unknown as PageLeaderTrayHandle;
+
+    expect(getLeaderConnectedFollowers(handle)).toEqual([
+      {
+        runtimeId: 'follower-browser-1',
+        runtime: 'slicc-extension-offscreen',
+        connectedAt: '2026-08-03T08:00:00.000Z',
+        floatType: 'extension',
+        hostOrigin: 'https://host.example',
+        selectedScoopJid: 'research',
+        health: 'stalled',
+        peerState: 'connected',
+        exec: true,
+        cdp: true,
+        motd: 'remote browser',
+      },
+      {
+        runtimeId: 'follower-cli-1',
+        runtime: 'slicc-cli',
+        connectedAt: '2026-08-03T08:01:00.000Z',
+        floatType: 'unknown',
+        hostOrigin: undefined,
+        selectedScoopJid: undefined,
+        health: 'live',
+        peerState: 'connected',
+        exec: false,
+        cdp: false,
+        motd: undefined,
+      },
+    ]);
+  });
+
+  it('keeps connecting rows uncounted through connect and death', () => {
+    let floatbarCount = 0;
+    let peerState: 'connecting' | 'connected' = 'connecting';
+    const sync = new LeaderSyncManager({
+      sendControl: vi.fn(),
+      getMessages: () => [],
+      getScoopJid: () => 'cone',
+      onFollowerMessage: vi.fn(),
+      onFollowerAbort: vi.fn(),
+      onFollowerCountChanged: (count) => {
+        floatbarCount = count;
+      },
+    });
+    const channel = new FakeChannel();
+    const handle = {
+      sync,
+      peers: {
+        getPeers: () => [
+          {
+            bootstrapId: 'follower-1',
+            state: peerState,
+            runtime: 'slicc-cli',
+          },
+        ],
+      },
+    } as unknown as PageLeaderTrayHandle;
+
+    let followers = getLeaderConnectedFollowers(handle);
+    let section = buildFollowersSection(followers);
+    expect(followers).toHaveLength(1);
+    expect(followers[0].peerState).toBe('connecting');
+    expect(section.rows[0].status).toBe('idle');
+    expect(section.count).toBe(floatbarCount);
+    expect(floatbarCount).toBe(0);
+
+    peerState = 'connected';
+    sync.addFollower('follower-1', channel, { runtime: 'slicc-cli' });
+    followers = getLeaderConnectedFollowers(handle);
+    section = buildFollowersSection(followers);
+    expect(followers).toHaveLength(1);
+    expect(followers[0]).toMatchObject({
+      runtimeId: 'follower-1',
+      health: 'live',
+      peerState: 'connected',
+    });
+    expect(section.rows[0].status).toBe('active');
+    expect(section.count).toBe(floatbarCount);
+    expect(floatbarCount).toBe(1);
+
+    channel.readyState = 'closed';
+    vi.advanceTimersByTime(40_000);
+    followers = getLeaderConnectedFollowers(handle);
+    section = buildFollowersSection(followers);
+    expect(followers).toHaveLength(0);
+    expect(section.count).toBe(floatbarCount);
+    expect(floatbarCount).toBe(0);
+  });
+
+  it('uses the registry count for the floatbar while mirroring connecting rows', () => {
+    const floatbar = { setAttribute: vi.fn() };
+    const storage = { setItem: vi.fn() };
+    vi.stubGlobal('localStorage', storage);
+    const handle = {
+      sync: {
+        getExecCapableBootstrapIds: () => new Set(),
+        getBrowserCapableBootstrapIds: () => new Set(),
+        getFollowerMotds: () => new Map(),
+        getFollowerDetails: () => [],
+      },
+      peers: {
+        getPeers: () => [
+          {
+            bootstrapId: 'pending-peer',
+            state: 'connecting' as const,
+            runtime: 'slicc-cli',
+          },
+        ],
+      },
+    } as unknown as PageLeaderTrayHandle;
+    const deps = {
+      refs: { floatbar },
+      client: {},
+      baseFloatLabel: 'standalone · live',
+    } as unknown as Parameters<typeof createLeaderOptionsFactory>[0];
+    const state = {
+      leader: handle,
+      follower: null,
+      lockRelease: null,
+    } as Parameters<typeof createLeaderOptionsFactory>[1];
+    const options = createLeaderOptionsFactory(
+      deps,
+      state,
+      {} as Parameters<typeof createLeaderOptionsFactory>[2]
+    )('https://tray.example');
+
+    options.onFollowerCountChanged?.(0);
+
+    expect(floatbar.setAttribute).toHaveBeenCalledWith('label', 'standalone · live');
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'slicc.leaderTrayFollowers',
+      expect.stringContaining('"peerState":"connecting"')
+    );
+  });
+});

--- a/packages/webcomponents/src/index.ts
+++ b/packages/webcomponents/src/index.ts
@@ -160,7 +160,13 @@ export { SliccTheme } from './theme/slicc-theme.js';
 export { SliccThemeToggle } from './theme/slicc-theme-toggle.js';
 export * from './theme/tokens.js';
 export { SliccFileTree } from './workbench/slicc-file-tree.js';
-export { type MonitorRow, type MonitorSection, SliccMonitor } from './workbench/slicc-monitor.js';
+export {
+  type MonitorAccent,
+  type MonitorRow,
+  type MonitorSection,
+  type MonitorStatus,
+  SliccMonitor,
+} from './workbench/slicc-monitor.js';
 export { SliccSurface } from './workbench/slicc-surface.js';
 export { SliccTab } from './workbench/slicc-tab.js';
 export { SliccTabBar } from './workbench/slicc-tab-bar.js';

--- a/packages/webcomponents/src/workbench/slicc-monitor.stories.ts
+++ b/packages/webcomponents/src/workbench/slicc-monitor.stories.ts
@@ -6,161 +6,409 @@ interface MonitorArgs {
   sections?: MonitorSection[];
 }
 
-const MOCK_SECTIONS_POPULATED: MonitorSection[] = [
+const FULLY_POPULATED: MonitorSection[] = [
   {
-    id: 'cost',
-    label: 'Cost',
-    count: 2,
-    meta: '$1.23',
+    id: 'followers',
+    label: 'Followers',
+    count: 3,
+    meta: '2 connected · 1 stalled',
+    accent: 'cyan',
     rows: [
-      { name: 'claude-opus-4-6', meta: '$0.87', active: true },
-      { name: 'claude-sonnet-4-6', meta: '$0.36', active: false },
+      {
+        name: 'Lars’s iPhone',
+        sublabel: 'iOS 19 · SliccFollower 1.8',
+        meta: 'connected 8m',
+        icon: 'smartphone',
+        badges: ['browser', 'files', 'camera'],
+        status: 'active',
+      },
+      {
+        name: 'Studio display',
+        sublabel: 'macOS 16 · Slicc CLI',
+        meta: 'connected 42m',
+        icon: 'monitor',
+        badges: ['browser', 'shell', 'clipboard'],
+        status: 'active',
+      },
+      {
+        name: 'QA iPad',
+        sublabel: 'iPadOS 19 · SliccFollower 1.7',
+        meta: 'stalled 2m',
+        icon: 'tablet',
+        badges: ['browser', 'camera'],
+        status: 'warn',
+      },
     ],
   },
   {
     id: 'scoops',
     label: 'Scoops',
-    count: 2,
+    count: 3,
+    meta: '1 working',
+    accent: 'violet',
     rows: [
-      { name: 'sliccy (cone)', meta: 'processing', active: true },
-      { name: 'researcher', meta: 'idle' },
+      {
+        name: 'Sliccy',
+        sublabel: 'Cone · primary workspace agent',
+        meta: '12m 18s',
+        icon: 'bot',
+        badges: ['browser', 'shell', 'memory'],
+        status: 'active',
+      },
+      {
+        name: 'Researcher',
+        sublabel: 'Scoop · source gathering',
+        meta: 'idle 4m',
+        icon: 'search',
+        badges: ['web', 'files'],
+        status: 'idle',
+      },
+      {
+        name: 'Verifier',
+        sublabel: 'Scoop · regression review',
+        meta: 'idle 11m',
+        icon: 'shield-check',
+        badges: ['shell', 'tests'],
+        status: 'idle',
+      },
     ],
   },
   {
     id: 'processes',
     label: 'Processes',
     count: 3,
+    meta: '2 running',
+    accent: 'green',
     rows: [
-      { name: '1024', meta: 'scoop:cone — running', active: true },
-      { name: '1025', meta: 'shell:ls — done' },
-      { name: '1026', meta: 'js:workflow — running', active: true },
+      {
+        name: 'Storybook',
+        sublabel: 'storybook dev · port 6006',
+        meta: 'running 18m',
+        icon: 'panels-top-left',
+        badges: ['service'],
+        status: 'active',
+      },
+      {
+        name: 'Browser tests',
+        sublabel: 'vitest · Chromium',
+        meta: 'running 36s',
+        icon: 'flask-conical',
+        badges: ['test'],
+        status: 'active',
+      },
+      {
+        name: 'Build #1842',
+        sublabel: 'webcomponents · completed',
+        meta: '2m ago',
+        icon: 'package-check',
+        badges: ['build'],
+        status: 'idle',
+      },
     ],
   },
   {
-    id: 'cron',
-    label: 'Cron Tasks',
+    id: 'automations',
+    label: 'Automations',
     count: 2,
+    meta: 'next in 3m',
+    accent: 'amber',
     rows: [
-      { name: 'daily-backup', meta: '0 3 * * *', active: true },
-      { name: 'health-check', meta: '*/5 * * * *', active: true },
+      {
+        name: 'Health sweep',
+        sublabel: 'Every 5 minutes · cone',
+        meta: 'in 3m',
+        icon: 'heart-pulse',
+        badges: ['cron'],
+        status: 'active',
+      },
+      {
+        name: 'Daily archive',
+        sublabel: 'At 03:00 · workspace',
+        meta: 'in 9h',
+        icon: 'archive',
+        badges: ['cron', 'files'],
+        status: 'idle',
+      },
     ],
   },
   {
-    id: 'webhooks',
-    label: 'Webhooks',
-    count: 1,
-    rows: [{ name: 'github-push', meta: '→ cone' }],
-  },
-  {
-    id: 'workflows',
-    label: 'Workflows',
-    count: 0,
-    rows: [],
-  },
-  {
-    id: 'mounts',
-    label: 'Mounts',
-    count: 1,
-    rows: [{ name: '/workspace/project', meta: 'local' }],
-  },
-  {
-    id: 'mcp',
-    label: 'MCP Servers',
-    count: 2,
+    id: 'integrations',
+    label: 'Integrations',
+    count: 3,
+    meta: '12 capabilities',
+    accent: 'waffle',
     rows: [
-      { name: 'github', meta: '3 tools' },
-      { name: 'slack', meta: '5 tools' },
+      {
+        name: 'GitHub',
+        sublabel: 'MCP server · repository access',
+        meta: '6 tools',
+        icon: 'github',
+        badges: ['issues', 'pulls', 'actions'],
+        status: 'active',
+      },
+      {
+        name: 'Workspace',
+        sublabel: 'MCP server · Intent space',
+        meta: '4 tools',
+        icon: 'blocks',
+        badges: ['notes', 'agents'],
+        status: 'active',
+      },
+      {
+        name: 'Cloudflare',
+        sublabel: 'OAuth · tray worker',
+        meta: '2 tools',
+        icon: 'cloud',
+        badges: ['deploy', 'logs'],
+        status: 'idle',
+      },
     ],
   },
   {
-    id: 'oauth',
-    label: 'OAuth',
+    id: 'cost',
+    label: 'Cost',
     count: 2,
+    meta: '$1.23 this session',
+    accent: 'rose',
     rows: [
-      { name: 'adobe', meta: '' },
-      { name: 'github', meta: '' },
+      {
+        name: 'claude-opus-4-6',
+        sublabel: '3.8M input · 92K output',
+        meta: '$0.87',
+        icon: 'sparkles',
+        badges: ['reasoning'],
+        status: 'active',
+      },
+      {
+        name: 'claude-sonnet-4-6',
+        sublabel: '1.1M input · 48K output',
+        meta: '$0.36',
+        icon: 'zap',
+        badges: ['fast'],
+        status: 'idle',
+      },
     ],
   },
 ];
 
-const MOCK_SECTIONS_EMPTY: MonitorSection[] = [
-  { id: 'cost', label: 'Cost', count: 0, rows: [] },
-  { id: 'scoops', label: 'Scoops', count: 0, rows: [] },
-  { id: 'processes', label: 'Processes', count: 0, rows: [] },
-  { id: 'cron', label: 'Cron Tasks', count: 0, rows: [] },
-  { id: 'webhooks', label: 'Webhooks', count: 0, rows: [] },
-  { id: 'workflows', label: 'Workflows', count: 0, rows: [] },
-  { id: 'mounts', label: 'Mounts', count: 0, rows: [] },
-  { id: 'mcp', label: 'MCP Servers', count: 0, rows: [] },
-  { id: 'oauth', label: 'OAuth', count: 0, rows: [] },
+const ALL_EMPTY: MonitorSection[] = [
+  {
+    id: 'followers',
+    label: 'Followers',
+    count: 0,
+    rows: [],
+    accent: 'cyan',
+    emptyText: 'Pair a phone, tablet, or CLI follower to lend the cone new capabilities.',
+  },
+  {
+    id: 'scoops',
+    label: 'Scoops',
+    count: 0,
+    rows: [],
+    accent: 'violet',
+    emptyText: 'Delegate a focused task and its scoop will show up here.',
+  },
+  {
+    id: 'processes',
+    label: 'Processes',
+    count: 0,
+    rows: [],
+    accent: 'green',
+    emptyText: 'Commands and background services will appear as they start.',
+  },
+  {
+    id: 'automations',
+    label: 'Automations',
+    count: 0,
+    rows: [],
+    accent: 'amber',
+    emptyText: 'Scheduled tasks and webhook-driven licks will appear here.',
+  },
+  {
+    id: 'integrations',
+    label: 'Integrations',
+    count: 0,
+    rows: [],
+    accent: 'waffle',
+    emptyText: 'Connect an MCP server or account to extend the workspace.',
+  },
+  {
+    id: 'cost',
+    label: 'Cost',
+    count: 0,
+    rows: [],
+    accent: 'rose',
+    emptyText: 'Model usage will be summarized after the first turn.',
+  },
+];
+
+const ERROR_HEAVY: MonitorSection[] = [
+  {
+    id: 'followers',
+    label: 'Followers',
+    count: 3,
+    meta: '0 connected · 3 need attention',
+    accent: 'cyan',
+    rows: [
+      {
+        name: 'Lars’s iPhone',
+        sublabel: 'iOS 19 · heartbeat timed out',
+        meta: 'lost 4m ago',
+        icon: 'smartphone',
+        badges: ['browser', 'camera'],
+        status: 'error',
+      },
+      {
+        name: 'Studio display',
+        sublabel: 'macOS 16 · reconnecting',
+        meta: 'retry 3 of 5',
+        icon: 'monitor',
+        badges: ['browser', 'shell', 'clipboard'],
+        status: 'warn',
+      },
+      {
+        name: 'QA iPad',
+        sublabel: 'iPadOS 19 · capability sync stalled',
+        meta: 'stalled 12m',
+        icon: 'tablet',
+        badges: ['browser', 'camera'],
+        status: 'warn',
+      },
+    ],
+  },
+  {
+    id: 'processes',
+    label: 'Processes',
+    count: 3,
+    meta: '2 failed · 1 stalled',
+    accent: 'rose',
+    rows: [
+      {
+        name: 'Browser tests',
+        sublabel: 'vitest · Chromium could not launch',
+        meta: 'exit 1',
+        icon: 'flask-conical',
+        badges: ['test'],
+        status: 'error',
+      },
+      {
+        name: 'Tray sync',
+        sublabel: 'worker · request timeout',
+        meta: 'failed 48s ago',
+        icon: 'cloud-off',
+        badges: ['service', 'network'],
+        status: 'error',
+      },
+      {
+        name: 'Storybook',
+        sublabel: 'storybook dev · unresponsive',
+        meta: 'stalled 3m',
+        icon: 'panels-top-left',
+        badges: ['service'],
+        status: 'warn',
+      },
+    ],
+  },
+  {
+    id: 'integrations',
+    label: 'Integrations',
+    count: 2,
+    meta: 'authentication required',
+    accent: 'amber',
+    rows: [
+      {
+        name: 'GitHub',
+        sublabel: 'OAuth session expired',
+        meta: '401',
+        icon: 'github',
+        badges: ['issues', 'pulls'],
+        status: 'error',
+      },
+      {
+        name: 'Cloudflare',
+        sublabel: 'MCP handshake is taking longer than expected',
+        meta: 'retrying',
+        icon: 'cloud',
+        badges: ['deploy', 'logs'],
+        status: 'warn',
+      },
+    ],
+  },
+  {
+    id: 'automations',
+    label: 'Automations',
+    count: 2,
+    meta: 'last sweep incomplete',
+    accent: 'violet',
+    rows: [
+      {
+        name: 'Health sweep',
+        sublabel: 'Last run exceeded its 30 second limit',
+        meta: 'timed out',
+        icon: 'heart-pulse',
+        badges: ['cron'],
+        status: 'error',
+      },
+      {
+        name: 'Daily archive',
+        sublabel: 'Waiting for workspace mount',
+        meta: 'delayed 9m',
+        icon: 'archive',
+        badges: ['cron', 'files'],
+        status: 'warn',
+      },
+    ],
+  },
 ];
 
 /**
  * Mount the monitor in a workbench-sized container so the scrollable dashboard
  * reads in its real context (the workbench surface).
  */
-function buildMonitor({ sections = MOCK_SECTIONS_POPULATED }: MonitorArgs): HTMLElement {
+function buildMonitor({ sections = FULLY_POPULATED }: MonitorArgs): HTMLElement {
+  const stage = document.createElement('main');
+  stage.style.cssText =
+    'width:100%;min-height:100vh;padding:24px;box-sizing:border-box;background:var(--bg);';
+
   const container = document.createElement('div');
   container.style.cssText =
-    'width:100%;height:600px;background:var(--canvas);' +
-    'border:1px solid var(--line);border-radius:8px;overflow:hidden;' +
-    'box-shadow:var(--shadow-pane);box-sizing:border-box;';
+    'width:min(1040px,100%);height:820px;margin:0 auto;border:1px solid var(--line);' +
+    'border-radius:16px;overflow:hidden;box-shadow:var(--shadow-pane);box-sizing:border-box;';
 
   const monitor = document.createElement('slicc-monitor') as SliccMonitor;
+  monitor.style.height = '100%';
   monitor.sections = sections;
 
   container.appendChild(monitor);
-  return container;
+  stage.appendChild(container);
+  return stage;
 }
 
 const meta: Meta<MonitorArgs> = {
   title: 'Workbench/Monitor',
+  component: 'slicc-monitor',
   tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
   render: buildMonitor,
 };
 
 export default meta;
 type Story = StoryObj<MonitorArgs>;
 
-/** The full monitor dashboard with all sections populated. */
-export const Populated: Story = {
-  args: { sections: MOCK_SECTIONS_POPULATED },
+/**
+ * Review target: a complete two-column dashboard. The Followers card includes
+ * connection-age metadata, capability chips, device details, and a stalled row.
+ */
+export const FullyPopulated: Story = {
+  args: { sections: FULLY_POPULATED },
 };
 
-/** All sections at count 0 (empty state). */
-export const Empty: Story = {
-  args: { sections: MOCK_SECTIONS_EMPTY },
+/** Every section uses its own friendly, actionable empty-state message. */
+export const AllEmpty: Story = {
+  args: { sections: ALL_EMPTY },
 };
 
-/** A mix of populated and empty sections showing the dimmed empty-state styling. */
-export const MixedStates: Story = {
-  args: {
-    sections: [
-      MOCK_SECTIONS_POPULATED[0], // cost
-      MOCK_SECTIONS_POPULATED[1], // scoops
-      MOCK_SECTIONS_EMPTY[2], // processes (empty)
-      MOCK_SECTIONS_POPULATED[3], // cron
-      MOCK_SECTIONS_EMPTY[4], // webhooks (empty)
-      MOCK_SECTIONS_POPULATED[7], // mcp
-    ],
-  },
-};
-
-/** A section with an error row (red status dot). */
-export const WithErrors: Story = {
-  args: {
-    sections: [
-      {
-        id: 'processes',
-        label: 'Processes',
-        count: 3,
-        rows: [
-          { name: '1024', meta: 'scoop:cone — running', active: true },
-          { name: '1025', meta: 'shell:command — failed', error: true },
-          { name: '1026', meta: 'js:workflow — running', active: true },
-        ],
-      },
-      MOCK_SECTIONS_POPULATED[1], // scoops
-    ],
-  },
+/** Dense warning and failure coverage with explicit, readable state labels. */
+export const ErrorHeavy: Story = {
+  args: { sections: ERROR_HEAVY },
 };

--- a/packages/webcomponents/src/workbench/slicc-monitor.ts
+++ b/packages/webcomponents/src/workbench/slicc-monitor.ts
@@ -1,5 +1,9 @@
 import { define } from '../internal/define.js';
 import { append, h } from '../internal/dom.js';
+import { iconEl } from '../internal/icons.js';
+
+export type MonitorStatus = 'active' | 'error' | 'warn' | 'idle';
+export type MonitorAccent = 'rose' | 'cyan' | 'violet' | 'amber' | 'waffle' | 'green';
 
 /**
  * A row in the monitor: a resource with status, name, and metadata.
@@ -9,6 +13,10 @@ export interface MonitorRow {
   meta: string;
   active?: boolean;
   error?: boolean;
+  icon?: string;
+  sublabel?: string;
+  badges?: string[];
+  status?: MonitorStatus;
 }
 
 /**
@@ -20,6 +28,8 @@ export interface MonitorSection {
   count: number;
   rows: MonitorRow[];
   meta?: string;
+  accent?: MonitorAccent;
+  emptyText?: string;
 }
 
 const COLLAPSE_KEY = 'slicc_monitor_collapsed';
@@ -54,127 +64,418 @@ function setCollapsed(collapsed: Set<string>): void {
 const STYLE = `
 slicc-monitor {
   display: block;
+  box-sizing: border-box;
   font-family: var(--ui);
   font-size: 13px;
   color: var(--ink);
+  background: var(--bg);
   overflow: auto;
-  padding: 12px;
+  padding: 16px;
+  container: monitor / inline-size;
+  --monitor-border: color-mix(in srgb, var(--line) 55%, var(--ink));
 }
-.monitor-toolbar {
+.monitor-summary {
+  display: grid;
+  gap: 16px;
+  padding: 16px;
+  margin: -16px -16px 16px;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--canvas) 94%, var(--ctx));
+  box-shadow: var(--shadow-pane);
+  position: sticky;
+  top: -16px;
+  z-index: 2;
+}
+.monitor-summary__topline {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--line);
-  margin: -12px -12px 12px;
-  background: var(--canvas);
-  position: sticky;
-  top: -12px;
-  z-index: 1;
+  gap: 12px;
 }
-.monitor-toolbar__refresh {
+.monitor-summary__mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  border-radius: 12px;
+  color: color-mix(in srgb, var(--ctx) 35%, var(--ink));
+  background: color-mix(in srgb, var(--ctx) 14%, var(--canvas));
+  border: 1px solid color-mix(in srgb, var(--ctx) 28%, var(--monitor-border));
+}
+.monitor-summary__copy {
+  min-width: 0;
+}
+.monitor-summary__title {
+  margin: 0;
+  color: var(--ink);
+  font-size: 16px;
+  line-height: 1.25;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.monitor-summary__subtitle {
+  margin: 2px 0 0;
+  color: var(--txt-2);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.monitor-summary__refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 40px;
+  margin-left: auto;
   font-family: var(--ui);
   font-size: 12px;
-  padding: 4px 12px;
-  border: 1px solid var(--line);
-  border-radius: 6px;
+  font-weight: 600;
+  padding: 0 12px;
+  border: 1px solid var(--monitor-border);
+  border-radius: 8px;
   background: var(--canvas);
   color: var(--ink);
   cursor: pointer;
-  transition: background 0.1s ease;
+  transition: background-color 120ms ease, border-color 120ms ease;
 }
-.monitor-toolbar__refresh:hover {
+.monitor-summary__refresh:hover {
   background: var(--ghost);
 }
-.monitor-toolbar__refresh:active {
-  opacity: 0.6;
+.monitor-summary__refresh:active {
+  transform: translateY(1px);
+}
+.monitor-summary__refresh:focus-visible,
+.monitor-section__header:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
+}
+.monitor-summary__refresh:disabled,
+.monitor-section__header:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.monitor-summary__metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+}
+.monitor-summary__metric {
+  min-width: 0;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--ink) 4%, var(--canvas));
+  border: 1px solid var(--line);
+}
+.monitor-summary__metric dt {
+  color: var(--txt-2);
+  font-size: 10px;
+  line-height: 1.4;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.monitor-summary__metric dd {
+  margin: 2px 0 0;
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 15px;
+  line-height: 1.3;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.monitor-sections {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+  align-items: start;
+  gap: 16px;
 }
 .monitor-section {
-  margin-bottom: 16px;
+  --monitor-accent: var(--ctx);
+  overflow: hidden;
+  border: 1px solid var(--monitor-border);
+  border-radius: 12px;
+  background: var(--canvas);
+  box-shadow: var(--shadow-pane);
 }
-.monitor-section--empty {
-  opacity: 0.5;
+.monitor-section[data-accent='rose'] { --monitor-accent: var(--rose); }
+.monitor-section[data-accent='cyan'] { --monitor-accent: var(--cyan); }
+.monitor-section[data-accent='violet'] { --monitor-accent: var(--violet); }
+.monitor-section[data-accent='amber'] { --monitor-accent: var(--amber); }
+.monitor-section[data-accent='waffle'] { --monitor-accent: var(--waffle); }
+.monitor-section[data-accent='green'] { --monitor-accent: var(--green); }
+.monitor-section--empty .monitor-section__count {
+  background: var(--canvas);
 }
 .monitor-section__header {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
   width: 100%;
-  padding: 8px 12px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--canvas);
+  min-height: 48px;
+  padding: 8px 12px 8px 16px;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  background: color-mix(in srgb, var(--monitor-accent) 8%, var(--canvas));
   cursor: pointer;
   font-family: var(--ui);
   font-size: 13px;
   color: var(--ink);
-  transition: background 0.1s ease;
+  transition: background-color 120ms ease;
   text-align: left;
 }
+.monitor-section__header::before {
+  content: '';
+  position: absolute;
+  inset: 8px auto 8px 0;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: var(--monitor-accent);
+}
 .monitor-section__header:hover {
-  background: var(--ghost);
+  background: color-mix(in srgb, var(--monitor-accent) 13%, var(--canvas));
 }
 .monitor-section__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
   color: var(--txt-3);
-  font-size: 10px;
   flex-shrink: 0;
+}
+.monitor-section__heading {
+  display: grid;
+  min-width: 0;
+  gap: 1px;
 }
 .monitor-section__title {
   font-weight: 600;
 }
 .monitor-section__meta {
-  margin-left: auto;
-  color: var(--txt-3);
+  color: var(--txt-2);
   font-size: 11px;
 }
 .monitor-section__count {
+  margin-left: auto;
   flex-shrink: 0;
-  background: color-mix(in srgb, var(--ctx) 12%, var(--canvas));
-  border: 1px solid var(--line);
+  min-width: 24px;
+  background: color-mix(in srgb, var(--monitor-accent) 13%, var(--canvas));
+  border: 1px solid color-mix(in srgb, var(--monitor-accent) 28%, var(--line));
   border-radius: 12px;
-  padding: 2px 8px;
+  padding: 2px 7px;
   font-size: 11px;
   font-weight: 600;
-  color: var(--txt-2);
+  color: color-mix(in srgb, var(--monitor-accent) 35%, var(--ink));
+  text-align: center;
 }
 .monitor-section__body {
-  padding: 8px 0 0;
+  padding: 8px;
 }
 .monitor-section__body[hidden] {
   display: none;
 }
+.monitor-section__list {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
 .monitor-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
-  border-radius: 6px;
-  transition: background 0.1s ease;
+  gap: 12px;
+  min-height: 56px;
+  padding: 8px;
+  border-radius: 8px;
+  transition: background-color 120ms ease;
 }
 .monitor-row:hover {
-  background: var(--ghost);
+  background: color-mix(in srgb, var(--monitor-accent) 5%, var(--ghost));
 }
-.monitor-row__dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--txt-3);
-  flex-shrink: 0;
+.monitor-row__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  border-radius: 8px;
+  color: color-mix(in srgb, var(--monitor-accent) 35%, var(--ink));
+  background: color-mix(in srgb, var(--monitor-accent) 10%, var(--canvas));
+  border: 1px solid color-mix(in srgb, var(--monitor-accent) 20%, var(--line));
 }
-.monitor-row__dot--active {
-  background: #10b981;
+.monitor-row__content {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
 }
-.monitor-row__dot--error {
-  background: var(--rose);
+.monitor-row__headline {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 .monitor-row__name {
-  font-weight: 500;
+  min-width: 0;
+  overflow: hidden;
   color: var(--ink);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.monitor-row__sublabel {
+  overflow: hidden;
+  color: var(--txt-2);
+  font-size: 11px;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.monitor-row__badges {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.monitor-row__badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  padding: 1px 6px;
+  border: 1px solid color-mix(in srgb, var(--monitor-accent) 24%, var(--line));
+  border-radius: 9px;
+  color: color-mix(in srgb, var(--monitor-accent) 30%, var(--ink));
+  background: color-mix(in srgb, var(--monitor-accent) 8%, var(--canvas));
+  font-size: 10px;
+  line-height: 1.3;
+  font-weight: 600;
+}
+.monitor-row__aside {
+  display: grid;
+  justify-items: end;
+  min-width: 88px;
+  gap: 3px;
+  text-align: right;
 }
 .monitor-row__meta {
-  margin-left: auto;
-  color: var(--txt-3);
+  color: var(--txt-2);
   font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+.monitor-row__state {
+  --monitor-status: var(--txt-2);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--monitor-status);
+  font-size: 10px;
+  line-height: 1.4;
+  font-weight: 700;
+}
+.monitor-row__state--active {
+  --monitor-status: color-mix(in srgb, var(--green) 35%, var(--ink));
+}
+.monitor-row__state--error {
+  --monitor-status: color-mix(in srgb, var(--red) 35%, var(--ink));
+}
+.monitor-row__state--warn {
+  --monitor-status: color-mix(in srgb, var(--amber) 35%, var(--ink));
+}
+.monitor-row__dot {
+  position: relative;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+.monitor-row__state--active .monitor-row__dot::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  animation: monitor-pulse 2s ease-out infinite;
+}
+.monitor-row__state--error .monitor-row__dot {
+  border-radius: 2px;
+  transform: rotate(45deg);
+}
+.monitor-row__state--warn .monitor-row__dot {
+  width: 8px;
+  height: 8px;
+  border: 2px solid currentColor;
+  background: transparent;
+}
+.monitor-empty {
+  display: grid;
+  justify-items: center;
+  gap: 4px;
+  padding: 24px 16px;
+  color: var(--txt-2);
+  text-align: center;
+}
+.monitor-empty__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  margin-bottom: 4px;
+  border-radius: 12px;
+  color: color-mix(in srgb, var(--monitor-accent) 30%, var(--ink));
+  background: color-mix(in srgb, var(--monitor-accent) 9%, var(--canvas));
+}
+.monitor-empty__title {
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 700;
+}
+.monitor-empty__text {
+  max-width: 32ch;
+  font-size: 11px;
+  line-height: 1.5;
+}
+@keyframes monitor-pulse {
+  from { opacity: 0.55; transform: scale(0.55); }
+  to { opacity: 0; transform: scale(1.25); }
+}
+@container monitor (max-width: 560px) {
+  .monitor-summary__metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .monitor-sections {
+    grid-template-columns: 1fr;
+  }
+  .monitor-row {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+  .monitor-row__aside {
+    grid-column: 2;
+    grid-template-columns: 1fr auto;
+    justify-items: start;
+    min-width: 0;
+    width: 100%;
+    text-align: left;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .monitor-row__state--active .monitor-row__dot::after {
+    animation: none;
+  }
+  .monitor-summary__refresh,
+  .monitor-section__header,
+  .monitor-row {
+    transition-duration: 0.01ms;
+  }
 }
 `;
 
@@ -189,39 +490,95 @@ function ensureMonitorStyle(doc: Document): void {
   (doc.head ?? doc.documentElement).appendChild(style);
 }
 
+function resolveStatus(row: MonitorRow): MonitorStatus {
+  if (row.status) return row.status;
+  if (row.error) return 'error';
+  if (row.active) return 'active';
+  return 'idle';
+}
+
+function statusLabel(status: MonitorStatus): string {
+  if (status === 'active') return 'Active';
+  if (status === 'error') return 'Error';
+  if (status === 'warn') return 'Warning';
+  return 'Idle';
+}
+
 function createRow(row: MonitorRow): HTMLElement {
-  const dotClass = row.error
-    ? 'monitor-row__dot monitor-row__dot--error'
-    : row.active
-      ? 'monitor-row__dot monitor-row__dot--active'
-      : 'monitor-row__dot';
+  const status = resolveStatus(row);
+  const badges = h('span', { class: 'monitor-row__badges' });
+  for (const badge of row.badges ?? []) {
+    badges.appendChild(h('span', { class: 'monitor-row__badge' }, badge));
+  }
+
+  const headline = h(
+    'span',
+    { class: 'monitor-row__headline' },
+    h('span', { class: 'monitor-row__name' }, row.name)
+  );
+  if (badges.childElementCount > 0) headline.appendChild(badges);
+
+  const content = h('span', { class: 'monitor-row__content' }, headline);
+  if (row.sublabel) {
+    content.appendChild(h('span', { class: 'monitor-row__sublabel' }, row.sublabel));
+  }
 
   return h(
+    'li',
+    { class: 'monitor-row', 'data-status': status },
+    h('span', { class: 'monitor-row__icon' }, iconEl(row.icon ?? 'box', { size: 16 })),
+    content,
+    h(
+      'span',
+      { class: 'monitor-row__aside' },
+      h('span', { class: 'monitor-row__meta' }, row.meta),
+      h(
+        'span',
+        { class: `monitor-row__state monitor-row__state--${status}` },
+        h('span', { class: 'monitor-row__dot', 'aria-hidden': 'true' }),
+        statusLabel(status)
+      )
+    )
+  );
+}
+
+function createEmptyState(section: MonitorSection): HTMLElement {
+  return h(
     'div',
-    { class: 'monitor-row' },
-    h('span', { class: dotClass }),
-    h('span', { class: 'monitor-row__name' }, row.name),
-    h('span', { class: 'monitor-row__meta' }, row.meta)
+    { class: 'monitor-empty', role: 'status' },
+    h('span', { class: 'monitor-empty__icon' }, iconEl('inbox', { size: 18 })),
+    h('span', { class: 'monitor-empty__title' }, `No ${section.label.toLocaleLowerCase()} yet`),
+    h(
+      'span',
+      { class: 'monitor-empty__text' },
+      section.emptyText ?? `${section.label} will appear here when available.`
+    )
   );
 }
 
 function createSection(
   section: MonitorSection,
   collapsed: Set<string>,
-  onToggle: (id: string) => void
+  onToggle: (id: string) => void,
+  bodyId: string
 ): HTMLElement {
   const isCollapsed = collapsed.has(section.id);
   const sectionClass =
     section.count === 0 ? 'monitor-section monitor-section--empty' : 'monitor-section';
 
   const headerChildren: (string | HTMLElement)[] = [
-    h('span', { class: 'monitor-section__toggle' }, isCollapsed ? '▸' : '▾'),
-    h('span', { class: 'monitor-section__title' }, section.label),
+    h(
+      'span',
+      { class: 'monitor-section__toggle', 'aria-hidden': 'true' },
+      iconEl(isCollapsed ? 'chevron-right' : 'chevron-down', { size: 15 })
+    ),
+    h(
+      'span',
+      { class: 'monitor-section__heading' },
+      h('span', { class: 'monitor-section__title' }, section.label),
+      section.meta ? h('span', { class: 'monitor-section__meta' }, section.meta) : null
+    ),
   ];
-
-  if (section.meta) {
-    headerChildren.push(h('span', { class: 'monitor-section__meta' }, section.meta));
-  }
 
   headerChildren.push(h('span', { class: 'monitor-section__count' }, String(section.count)));
 
@@ -231,17 +588,87 @@ function createSection(
     ...headerChildren
   );
   header.setAttribute('aria-expanded', String(!isCollapsed));
+  header.setAttribute('aria-controls', bodyId);
   header.addEventListener('click', () => onToggle(section.id));
 
-  const body = h('div', { class: 'monitor-section__body' });
+  const body = h('div', { class: 'monitor-section__body', id: bodyId });
   if (isCollapsed) body.setAttribute('hidden', '');
 
-  for (const row of section.rows) {
-    body.appendChild(createRow(row));
+  if (section.rows.length === 0) {
+    body.appendChild(createEmptyState(section));
+  } else {
+    const list = h('ul', { class: 'monitor-section__list' });
+    for (const row of section.rows) list.appendChild(createRow(row));
+    body.appendChild(list);
   }
 
-  return h('div', { class: sectionClass, 'data-section': section.id }, header, body);
+  return h(
+    'section',
+    { class: sectionClass, 'data-section': section.id, 'data-accent': section.accent ?? 'neutral' },
+    header,
+    body
+  );
 }
+
+function createMetric(label: string, value: string): HTMLElement {
+  return h('div', { class: 'monitor-summary__metric' }, h('dt', null, label), h('dd', null, value));
+}
+
+function createSummary(sections: MonitorSection[], onRefresh: () => void): HTMLElement {
+  const rows = sections.flatMap((section) => section.rows);
+  const active = rows.filter((row) => resolveStatus(row) === 'active').length;
+  const attention = rows.filter((row) => ['warn', 'error'].includes(resolveStatus(row))).length;
+  const tracked = sections.reduce(
+    (total, section) => total + (section.id === 'cost' ? 0 : section.count),
+    0
+  );
+  const cost = sections.find((section) => section.id === 'cost')?.meta ?? '—';
+  const refresh = h(
+    'button',
+    { class: 'monitor-summary__refresh', type: 'button', 'aria-label': 'Refresh monitor data' },
+    iconEl('refresh-cw', { size: 15 }),
+    h('span', null, 'Refresh')
+  );
+  refresh.addEventListener('click', onRefresh);
+
+  return h(
+    'header',
+    { class: 'monitor-summary' },
+    h(
+      'div',
+      { class: 'monitor-summary__topline' },
+      h('span', { class: 'monitor-summary__mark' }, iconEl('activity', { size: 19 })),
+      h(
+        'div',
+        { class: 'monitor-summary__copy' },
+        h('h2', { class: 'monitor-summary__title' }, 'Live monitor'),
+        h(
+          'p',
+          { class: 'monitor-summary__subtitle' },
+          'System activity and connections at a glance'
+        )
+      ),
+      refresh
+    ),
+    h(
+      'dl',
+      { class: 'monitor-summary__metrics' },
+      createMetric('Tracked', String(tracked)),
+      createMetric('Active', String(active)),
+      createMetric('Attention', String(attention)),
+      createMetric('Session cost', cost)
+    )
+  );
+}
+
+function cloneSection(section: MonitorSection): MonitorSection {
+  return {
+    ...section,
+    rows: section.rows.map((row) => ({ ...row, badges: row.badges?.slice() })),
+  };
+}
+
+let monitorInstance = 0;
 
 /**
  * `<slicc-monitor>` — the monitor dashboard from the workbench. A scrollable
@@ -261,6 +688,7 @@ export class SliccMonitor extends HTMLElement {
   #sections: MonitorSection[] = [];
   #collapsed = new Set<string>();
   #initialized = false;
+  readonly #instanceId = ++monitorInstance;
 
   connectedCallback(): void {
     ensureMonitorStyle(this.ownerDocument);
@@ -273,48 +701,44 @@ export class SliccMonitor extends HTMLElement {
 
   /** The monitor sections (returns a copy). */
   get sections(): MonitorSection[] {
-    return this.#sections.map((s) => ({ ...s, rows: s.rows.slice() }));
+    return this.#sections.map(cloneSection);
   }
 
   set sections(value: MonitorSection[]) {
-    this.#sections = Array.isArray(value) ? value.map((s) => ({ ...s, rows: s.rows.slice() })) : [];
+    this.#sections = Array.isArray(value) ? value.map(cloneSection) : [];
     if (this.isConnected) this.#render();
   }
 
   #render(): void {
-    const toolbar = h(
-      'div',
-      { class: 'monitor-toolbar' },
-      h('button', { class: 'monitor-toolbar__refresh', type: 'button' }, '↻ Refresh')
-    );
-
-    const refreshBtn = toolbar.querySelector('.monitor-toolbar__refresh');
-    if (refreshBtn) {
-      refreshBtn.addEventListener('click', () => {
-        this.dispatchEvent(
-          new CustomEvent('slicc-monitor-refresh', {
-            bubbles: true,
-            composed: true,
-          })
-        );
-      });
-    }
-
-    const nodes: Node[] = [toolbar];
+    const summary = createSummary(this.#sections, () => {
+      this.dispatchEvent(
+        new CustomEvent('slicc-monitor-refresh', {
+          bubbles: true,
+          composed: true,
+        })
+      );
+    });
+    const sections = h('div', { class: 'monitor-sections' });
 
     for (const section of this.#sections) {
-      nodes.push(
-        createSection(section, this.#collapsed, (id: string) => {
-          if (this.#collapsed.has(id)) this.#collapsed.delete(id);
-          else this.#collapsed.add(id);
-          setCollapsed(this.#collapsed);
-          this.#render();
-        })
+      const safeId = section.id.replace(/[^a-z0-9_-]/gi, '-');
+      sections.appendChild(
+        createSection(
+          section,
+          this.#collapsed,
+          (id: string) => {
+            if (this.#collapsed.has(id)) this.#collapsed.delete(id);
+            else this.#collapsed.add(id);
+            setCollapsed(this.#collapsed);
+            this.#render();
+          },
+          `monitor-${this.#instanceId}-${safeId}`
+        )
       );
     }
 
     this.replaceChildren();
-    append(this, nodes);
+    append(this, [summary, sections]);
   }
 }
 

--- a/packages/webcomponents/tests/workbench/slicc-monitor.test.ts
+++ b/packages/webcomponents/tests/workbench/slicc-monitor.test.ts
@@ -14,8 +14,17 @@ const SAMPLE_SECTIONS: MonitorSection[] = [
     id: 'scoops',
     label: 'Scoops',
     count: 2,
+    meta: '1 working',
+    accent: 'violet',
     rows: [
-      { name: 'sliccy (cone)', meta: 'processing', active: true },
+      {
+        name: 'sliccy (cone)',
+        meta: 'processing',
+        active: true,
+        icon: 'bot',
+        sublabel: 'Cone · primary workspace agent',
+        badges: ['browser', 'shell'],
+      },
       { name: 'researcher', meta: 'idle' },
     ],
   },
@@ -25,7 +34,13 @@ const SAMPLE_SECTIONS: MonitorSection[] = [
     count: 1,
     rows: [{ name: 'daily-backup', meta: '0 3 * * *', active: true }],
   },
-  { id: 'webhooks', label: 'Webhooks', count: 0, rows: [] },
+  {
+    id: 'webhooks',
+    label: 'Webhooks',
+    count: 0,
+    rows: [],
+    emptyText: 'Connect a webhook to receive external events.',
+  },
 ];
 
 describe('slicc-monitor', () => {
@@ -63,11 +78,26 @@ describe('slicc-monitor', () => {
     expect(rows[1].querySelector('.monitor-row__name')!.textContent).toBe('researcher');
   });
 
+  it('renders rich row icons, sublabels, and capability badges', () => {
+    const el = mount(SAMPLE_SECTIONS);
+    const row = el.querySelector('[data-section="scoops"] .monitor-row')!;
+    expect(row.tagName).toBe('LI');
+    expect(row.querySelector('.monitor-row__icon svg')).not.toBeNull();
+    expect(row.querySelector('.monitor-row__sublabel')!.textContent).toBe(
+      'Cone · primary workspace agent'
+    );
+    expect(
+      [...row.querySelectorAll('.monitor-row__badge')].map((badge) => badge.textContent)
+    ).toEqual(['browser', 'shell']);
+  });
+
   it('applies active dot class for active rows', () => {
     const el = mount(SAMPLE_SECTIONS);
-    const dots = el.querySelectorAll('[data-section="scoops"] .monitor-row__dot');
-    expect(dots[0].classList.contains('monitor-row__dot--active')).toBe(true);
-    expect(dots[1].classList.contains('monitor-row__dot--active')).toBe(false);
+    const states = el.querySelectorAll('[data-section="scoops"] .monitor-row__state');
+    expect(states[0].classList.contains('monitor-row__state--active')).toBe(true);
+    expect(states[0].textContent).toContain('Active');
+    expect(states[1].classList.contains('monitor-row__state--idle')).toBe(true);
+    expect(states[1].textContent).toContain('Idle');
   });
 
   it('applies error dot class for error rows', () => {
@@ -79,8 +109,23 @@ describe('slicc-monitor', () => {
         rows: [{ name: 'broken', meta: 'err', error: true }],
       },
     ]);
-    const dot = el.querySelector('.monitor-row__dot--error');
-    expect(dot).not.toBeNull();
+    const state = el.querySelector('.monitor-row__state--error');
+    expect(state).not.toBeNull();
+    expect(state!.textContent).toContain('Error');
+  });
+
+  it('renders explicit warning status ahead of legacy booleans', () => {
+    const el = mount([
+      {
+        id: 'warn',
+        label: 'Warnings',
+        count: 1,
+        rows: [{ name: 'stalled', meta: '2m', active: true, status: 'warn' }],
+      },
+    ]);
+    const row = el.querySelector('.monitor-row')!;
+    expect(row.getAttribute('data-status')).toBe('warn');
+    expect(row.querySelector('.monitor-row__state--warn')!.textContent).toContain('Warning');
   });
 
   it('marks empty sections with --empty modifier', () => {
@@ -89,6 +134,21 @@ describe('slicc-monitor', () => {
     expect(empty!.classList.contains('monitor-section--empty')).toBe(true);
     const notEmpty = el.querySelector('[data-section="scoops"]');
     expect(notEmpty!.classList.contains('monitor-section--empty')).toBe(false);
+  });
+
+  it('renders custom friendly empty-state copy', () => {
+    const el = mount(SAMPLE_SECTIONS);
+    const empty = el.querySelector('[data-section="webhooks"] .monitor-empty')!;
+    expect(empty.getAttribute('role')).toBe('status');
+    expect(empty.querySelector('.monitor-empty__title')!.textContent).toBe('No webhooks yet');
+    expect(empty.querySelector('.monitor-empty__text')!.textContent).toBe(
+      'Connect a webhook to receive external events.'
+    );
+  });
+
+  it('applies the section accent hook', () => {
+    const el = mount(SAMPLE_SECTIONS);
+    expect(el.querySelector('[data-section="scoops"]')!.getAttribute('data-accent')).toBe('violet');
   });
 
   it('shows count badges', () => {
@@ -101,18 +161,48 @@ describe('slicc-monitor', () => {
 
   it('renders a refresh button in toolbar', () => {
     const el = mount(SAMPLE_SECTIONS);
-    const btn = el.querySelector('.monitor-toolbar__refresh');
+    const btn = el.querySelector('.monitor-summary__refresh');
     expect(btn).not.toBeNull();
     expect(btn!.textContent).toContain('Refresh');
+    expect(btn!.getAttribute('aria-label')).toBe('Refresh monitor data');
   });
 
   it('dispatches slicc-monitor-refresh on refresh click', () => {
     const el = mount(SAMPLE_SECTIONS);
     const handler = vi.fn();
     el.addEventListener('slicc-monitor-refresh', handler);
-    const btn = el.querySelector<HTMLButtonElement>('.monitor-toolbar__refresh')!;
+    const btn = el.querySelector<HTMLButtonElement>('.monitor-summary__refresh')!;
     btn.click();
     expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('summarizes tracked, active, attention, and cost values', () => {
+    const el = mount([
+      ...SAMPLE_SECTIONS,
+      {
+        id: 'alerts',
+        label: 'Alerts',
+        count: 1,
+        rows: [{ name: 'stalled', meta: '2m', status: 'warn' }],
+      },
+      {
+        id: 'cost',
+        label: 'Cost',
+        count: 1,
+        meta: '$1.23 this session',
+        rows: [{ name: 'model', meta: '$1.23' }],
+      },
+    ]);
+    const metrics = [...el.querySelectorAll('.monitor-summary__metric')].map((metric) => ({
+      label: metric.querySelector('dt')!.textContent,
+      value: metric.querySelector('dd')!.textContent,
+    }));
+    expect(metrics).toEqual([
+      { label: 'Tracked', value: '4' },
+      { label: 'Active', value: '2' },
+      { label: 'Attention', value: '1' },
+      { label: 'Session cost', value: '$1.23 this session' },
+    ]);
   });
 
   it('collapses a section on header click and persists state', () => {
@@ -128,6 +218,7 @@ describe('slicc-monitor', () => {
     )!;
     expect(body!.hasAttribute('hidden')).toBe(true);
     expect(updatedHeader.getAttribute('aria-expanded')).toBe('false');
+    expect(updatedHeader.getAttribute('aria-controls')).toBe(body!.id);
     const stored = JSON.parse(localStorage.getItem('slicc_monitor_collapsed')!);
     expect(stored).toContain('scoops');
   });
@@ -166,6 +257,8 @@ describe('slicc-monitor', () => {
     const el = mount(SAMPLE_SECTIONS);
     const copy = el.sections;
     copy.push({ id: 'extra', label: 'X', count: 0, rows: [] });
+    copy[0].rows[0].badges!.push('mutated');
     expect(el.sections).toHaveLength(3);
+    expect(el.sections[0].rows[0].badges).toEqual(['browser', 'shell']);
   });
 });


### PR DESCRIPTION
## What changed

- Exposes leader follower details, connection state, capabilities, age, and keepalive health to the UI.
- Adds Tray and Followers sections to the Monitor.
- Redesigns the Monitor with a summary strip, section accents, icons, two-line rows, badges, and empty states for light and dark themes.
- Keeps `host` command rendering unchanged; its interface only gains optional follower metadata fields.
- Removes `wc-tray.ts` from the `noFloatingPromises` debt override after handling its dynamic imports explicitly.

## Count semantics

The Followers badge counts registry-confirmed connected followers only, matching the float bar's count. Peers still handshaking appear as additional `connecting` rows but are not included in the badge; the section meta calls them out separately, for example `2 connected · 1 connecting`.

## Verification

| Command | Result |
| --- | --- |
| `npm install` | PASS; Biome 2.5.6 installed |
| `npm run lint` | PASS; 2040 files checked in 6s, no fixes, 26 pre-existing warnings |
| `npm run typecheck` | PASS; all 9 TypeScript projects |
| `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` | PASS; 22 changed files, 0 on any debt list |
| Focused webapp suites | PASS; 6 files, 116 tests |
| `npm run test -w @slicc/webcomponents` | PASS; 76 files, 1788 tests |
| `npm run test:coverage:webapp` | PASS post-rebase; 79.18% statements / 70.11% branches / 79.36% functions / 81.27% lines, all floors met, zero timeouts |
| `npm run build` | PASS |
| `npm run build -w @slicc/chrome-extension` | PASS; built in 85ms |
| Linear-history gate | PASS; no merge commits |

Earlier coverage attempts on this machine hit exact-5000ms timeout storms at system load up to 954, caused by concurrent unrelated workloads rather than by this change. Re-running the gate alone with `--testTimeout=60000` produced a clean pass with zero timeouts, confirming the failures were load contention.

## Stack note

This branch is stacked on #1895 to include the Biome 2.5.6 lint performance fix. The three feature commits are linear on top of #1895's head (`9baac95c5`).