### PR TITLE
fix(webapp): restore leader tab focus and keepalive

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -334,7 +334,6 @@
       "includes": [
         "packages/chrome-extension/capture-popup.js",
         "packages/chrome-extension/src/secrets-entry.ts",
-        "packages/chrome-extension/src/service-worker.ts",
         "packages/cloudflare-worker/scripts/upload-assets-to-r2.mjs",
         "packages/node-server/src/index.ts",
         "packages/webapp/cloud/app.js",
@@ -377,7 +376,6 @@
     {
       "includes": [
         "packages/chrome-extension/src/fetch-proxy-shared.ts",
-        "packages/chrome-extension/src/service-worker.ts",
         "packages/webapp/providers/adobe.ts",
         "packages/webapp/src/cdp/browser-api.ts",
         "packages/webapp/src/cdp/synthetic-cdp-transport.ts",

--- a/docs/extension-thin-bridge.md
+++ b/docs/extension-thin-bridge.md
@@ -61,6 +61,14 @@ reference counts keep that session and its debugger attachment alive until the
 last matching detach. Port disconnect and target close remain authoritative:
 they release the tab immediately regardless of its outstanding count.
 
+Debugger ownership is explicit across service-worker consumers. The attach
+dependency reports whether the bridge actually performed the underlying
+`chrome.debugger.attach`; a port records the tab as owned only in that case. If
+the legacy compatibility path already tracks the tab, the bridge can use that
+attachment but its detach, disconnect, and target-close cleanup never detach it.
+The compatibility message handler remains in the service worker, although no
+shipped extension context currently emits its `cdp-command` messages.
+
 ## Leader-Tab Lifecycle (Why No Startup Create)
 
 `chrome.storage.session` is wiped on browser restart, and the startup

--- a/docs/extension-thin-bridge.md
+++ b/docs/extension-thin-bridge.md
@@ -66,9 +66,12 @@ The first consumer to perform the underlying `chrome.debugger.attach` owns its
 matching detach. The other consumer may borrow the attachment, but releasing
 that borrowed reference never detaches the owner's session. This rule applies
 identically whether the bridge or legacy compatibility path attaches first;
-external detach and target close clear ownership authoritatively. The
-compatibility message handler remains in the service worker, although no shipped
-extension context currently emits its `cdp-command` messages.
+external detach and target close clear ownership authoritatively. An external
+detach also invalidates every live bridge Port's owned-tab, reference-count, and
+synthetic-session state, so the next attach performs a real
+`chrome.debugger.attach`. The compatibility message handler remains in the
+service worker, although no shipped extension context currently emits its
+`cdp-command` messages.
 
 ## Leader-Tab Lifecycle (Why No Startup Create)
 

--- a/docs/extension-thin-bridge.md
+++ b/docs/extension-thin-bridge.md
@@ -61,13 +61,14 @@ reference counts keep that session and its debugger attachment alive until the
 last matching detach. Port disconnect and target close remain authoritative:
 they release the tab immediately regardless of its outstanding count.
 
-Debugger ownership is explicit across service-worker consumers. The attach
-dependency reports whether the bridge actually performed the underlying
-`chrome.debugger.attach`; a port records the tab as owned only in that case. If
-the legacy compatibility path already tracks the tab, the bridge can use that
-attachment but its detach, disconnect, and target-close cleanup never detach it.
-The compatibility message handler remains in the service worker, although no
-shipped extension context currently emits its `cdp-command` messages.
+Debugger ownership is explicit and symmetric across service-worker consumers.
+The first consumer to perform the underlying `chrome.debugger.attach` owns its
+matching detach. The other consumer may borrow the attachment, but releasing
+that borrowed reference never detaches the owner's session. This rule applies
+identically whether the bridge or legacy compatibility path attaches first;
+external detach and target close clear ownership authoritatively. The
+compatibility message handler remains in the service worker, although no shipped
+extension context currently emits its `cdp-command` messages.
 
 ## Leader-Tab Lifecycle (Why No Startup Create)
 

--- a/docs/extension-thin-bridge.md
+++ b/docs/extension-thin-bridge.md
@@ -43,13 +43,17 @@ is consumed by the webapp's kernel-worker or its crontask / webhook commands.
 ### Temporary Focus for Follower Previews
 
 `chrome.debugger`'s `Page.bringToFront` wakes a background renderer but does
-not select its Chrome tab, so `bridge-sw.ts` also calls `activateTab`. For
-follower-driven previews this is a temporary borrow: the bridge captures the
-active tab before the first activation, coalesces a burst behind a 150 ms
-settle window, and restores the original through `activateTab` once the burst
-ends. It skips restoration when the user selected another tab or the original
-tab closed. Per-Port generation guards ignore stale async completions, restore
-errors stay contained, and disconnect clears the pending timer.
+not select its Chrome tab, so `bridge-sw.ts` calls `activateTab` before
+forwarding every such command. The bridge Port carries all leader CDP traffic,
+including permanent foregrounding, and therefore does not classify or restore
+focus itself.
+
+The webapp's `CDPRouter` is the single owner of temporary follower-preview
+focus. It recognizes follower-originated requests, reads the original target
+from `Target.getTargets` (whose extension shim marks the active tab), coalesces
+the preview burst, and restores by sending `Target.attachToTarget` followed by
+`Page.bringToFront` over the same bridge transport. The bridge activates that
+original tab exactly as it activated the preview tab.
 
 ## Leader-Tab Lifecycle (Why No Startup Create)
 

--- a/docs/extension-thin-bridge.md
+++ b/docs/extension-thin-bridge.md
@@ -40,6 +40,17 @@ The kernel bridge and its proxies now live entirely in the webapp package
 `packages/webapp/src/scoops/lick-manager-proxy.ts`); no code in this package
 is consumed by the webapp's kernel-worker or its crontask / webhook commands.
 
+### Temporary Focus for Follower Previews
+
+`chrome.debugger`'s `Page.bringToFront` wakes a background renderer but does
+not select its Chrome tab, so `bridge-sw.ts` also calls `activateTab`. For
+follower-driven previews this is a temporary borrow: the bridge captures the
+active tab before the first activation, coalesces a burst behind a 150 ms
+settle window, and restores the original through `activateTab` once the burst
+ends. It skips restoration when the user selected another tab or the original
+tab closed. Per-Port generation guards ignore stale async completions, restore
+errors stay contained, and disconnect clears the pending timer.
+
 ## Leader-Tab Lifecycle (Why No Startup Create)
 
 `chrome.storage.session` is wiped on browser restart, and the startup

--- a/docs/extension-thin-bridge.md
+++ b/docs/extension-thin-bridge.md
@@ -55,6 +55,12 @@ the preview burst, and restores by sending `Target.attachToTarget` followed by
 `Page.bringToFront` over the same bridge transport. The bridge activates that
 original tab exactly as it activated the preview tab.
 
+The bridge preserves its `sessionId === targetId` correlation convention, so
+multiple logical attachments to one tab share a synthetic session. Per-tab
+reference counts keep that session and its debugger attachment alive until the
+last matching detach. Port disconnect and target close remain authoritative:
+they release the tab immediately regardless of its outstanding count.
+
 ## Leader-Tab Lifecycle (Why No Startup Create)
 
 `chrome.storage.session` is wiped on browser restart, and the startup

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -111,9 +111,10 @@ six-step flow and tri-state UI details.
   every `Page.bringToFront` by activating the target tab and forwarding the
   command, without trying to classify its origin. Synthetic sessions keep the
   `sessionId === targetId` convention and ref-count duplicate tab attachments;
-  disconnect and target close force-release them. A port claims debugger
-  ownership only when its dependency actually performs `chrome.debugger.attach`,
-  so cleanup cannot detach a pre-existing compatibility-path session.
+  disconnect and target close force-release them. Debugger ownership is shared
+  symmetrically with the legacy compatibility path: whichever consumer performs
+  `chrome.debugger.attach` owns the matching detach, while the borrowing consumer's
+  detach is a no-op. External detach and target close clear ownership authoritatively.
 - `src/sidepanel-entry.ts` — side-panel host controller (bundled to
   `dist/extension/sidepanel.js`): mounts the ui-only cherry follower iframe
   and drives the tri-state UI over a `cherry-panel` Port.

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -106,10 +106,10 @@ six-step flow and tri-state UI details.
 - `src/bridge-sw.ts` — `externally_connectable` Port handler that
   pass-through-proxies CDP to `chrome.debugger`. `cdpGetTargets` marks the
   `lastFocusedWindow` active tab so `playwright list-tabs` shows `(active)`
-  and cherry prompts can resolve 'this page'. Follower-preview
-  `Page.bringToFront` calls temporarily activate the target tab, coalesce for
-  150 ms, then restore the previously active tab unless the user switched tabs
-  or the original tab disappeared; Port teardown cancels pending restoration.
+  and cherry prompts can resolve 'this page'. The webapp's `CDPRouter` alone
+  owns temporary follower-preview focus and restoration; the bridge applies
+  every `Page.bringToFront` by activating the target tab and forwarding the
+  command, without trying to classify its origin.
 - `src/sidepanel-entry.ts` — side-panel host controller (bundled to
   `dist/extension/sidepanel.js`): mounts the ui-only cherry follower iframe
   and drives the tri-state UI over a `cherry-panel` Port.

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -109,7 +109,11 @@ six-step flow and tri-state UI details.
   and cherry prompts can resolve 'this page'. The webapp's `CDPRouter` alone
   owns temporary follower-preview focus and restoration; the bridge applies
   every `Page.bringToFront` by activating the target tab and forwarding the
-  command, without trying to classify its origin.
+  command, without trying to classify its origin. Synthetic sessions keep the
+  `sessionId === targetId` convention and ref-count duplicate tab attachments;
+  disconnect and target close force-release them. A port claims debugger
+  ownership only when its dependency actually performs `chrome.debugger.attach`,
+  so cleanup cannot detach a pre-existing compatibility-path session.
 - `src/sidepanel-entry.ts` — side-panel host controller (bundled to
   `dist/extension/sidepanel.js`): mounts the ui-only cherry follower iframe
   and drives the tri-state UI over a `cherry-panel` Port.

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -114,7 +114,9 @@ six-step flow and tri-state UI details.
   disconnect and target close force-release them. Debugger ownership is shared
   symmetrically with the legacy compatibility path: whichever consumer performs
   `chrome.debugger.attach` owns the matching detach, while the borrowing consumer's
-  detach is a no-op. External detach and target close clear ownership authoritatively.
+  detach is a no-op. External detach clears every live bridge Port's tab, session,
+  and ref-count state so a later attach reacquires the debugger; target close also
+  clears ownership authoritatively.
 - `src/sidepanel-entry.ts` — side-panel host controller (bundled to
   `dist/extension/sidepanel.js`): mounts the ui-only cherry follower iframe
   and drives the tri-state UI over a `cherry-panel` Port.

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -115,8 +115,8 @@ six-step flow and tri-state UI details.
   symmetrically with the legacy compatibility path: whichever consumer performs
   `chrome.debugger.attach` owns the matching detach, while the borrowing consumer's
   detach is a no-op. External detach clears every live bridge Port's tab, session,
-  and ref-count state so a later attach reacquires the debugger; target close also
-  clears ownership authoritatively.
+  and ref-count state and emits `Target.detachedFromTarget` so the hosted leader
+  invalidates its cached session before reattaching; target close also clears ownership.
 - `src/sidepanel-entry.ts` — side-panel host controller (bundled to
   `dist/extension/sidepanel.js`): mounts the ui-only cherry follower iframe
   and drives the tri-state UI over a `cherry-panel` Port.

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -106,7 +106,10 @@ six-step flow and tri-state UI details.
 - `src/bridge-sw.ts` — `externally_connectable` Port handler that
   pass-through-proxies CDP to `chrome.debugger`. `cdpGetTargets` marks the
   `lastFocusedWindow` active tab so `playwright list-tabs` shows `(active)`
-  and cherry prompts can resolve 'this page'.
+  and cherry prompts can resolve 'this page'. Follower-preview
+  `Page.bringToFront` calls temporarily activate the target tab, coalesce for
+  150 ms, then restore the previously active tab unless the user switched tabs
+  or the original tab disappeared; Port teardown cancels pending restoration.
 - `src/sidepanel-entry.ts` — side-panel host controller (bundled to
   `dist/extension/sidepanel.js`): mounts the ui-only cherry follower iframe
   and drives the tri-state UI over a `cherry-panel` Port.

--- a/packages/chrome-extension/src/bridge-sw.ts
+++ b/packages/chrome-extension/src/bridge-sw.ts
@@ -216,10 +216,27 @@ function invalidatePortDebuggerAttachment(state: PortState, tabId: number): void
   }
 }
 
-/** Drop stale per-port state after chrome reports an external debugger detach. */
+/** Drop stale per-port state and notify clients after an external debugger detach. */
 export function notifyBridgeDebuggerDetached(tabId: number): void {
-  for (const state of liveBridgePortStates.values()) {
+  for (const [port, state] of liveBridgePortStates) {
+    const detachedSessionIds = [...state.sessionToTab]
+      .filter(([, attachedTabId]) => attachedTabId === tabId)
+      .map(([sessionId]) => sessionId);
     invalidatePortDebuggerAttachment(state, tabId);
+    if (state.channelId === null) continue;
+    for (const sessionId of detachedSessionIds) {
+      try {
+        port.postMessage({
+          bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+          channelId: state.channelId,
+          kind: 'cdp.event',
+          method: 'Target.detachedFromTarget',
+          params: { sessionId, targetId: String(tabId) },
+        } satisfies ExtensionBridgeEnvelope);
+      } catch {
+        /* port disconnected; its onDisconnect will evict it */
+      }
+    }
   }
 }
 

--- a/packages/chrome-extension/src/bridge-sw.ts
+++ b/packages/chrome-extension/src/bridge-sw.ts
@@ -41,6 +41,8 @@ import {
 /** Storage key the sibling leader-tab task writes after pinning the leader. */
 const LEADER_TAB_ID_KEY = 'slicc_leader_tab_id';
 
+const FOLLOWER_PREVIEW_SETTLE_MS = 150;
+
 /** Origin allowlist for the bridge Port. Externally_connectable also gates
  *  this at the manifest level, but enforcing in code is defense-in-depth and
  *  makes test injection straightforward. Hosted origin comes from
@@ -190,6 +192,13 @@ interface PortState {
   ownedTabs: Set<number>;
   /** Unsubscribe from chrome.debugger.onEvent when the port closes. */
   unsubscribeEvents: (() => void) | null;
+  previewOriginalTab: Promise<number | undefined> | null;
+  previewLastTabId: number | null;
+  previewGeneration: number;
+  previewSequence: number;
+  previewLatestSuccessfulSequence: number;
+  previewRequestsInFlight: number;
+  previewRestoreTimer: ReturnType<typeof setTimeout> | null;
 }
 
 /**
@@ -395,6 +404,13 @@ export async function handleBridgePortConnect(
     sessionToTab: new Map(),
     ownedTabs: new Set(),
     unsubscribeEvents: null,
+    previewOriginalTab: null,
+    previewLastTabId: null,
+    previewGeneration: 0,
+    previewSequence: 0,
+    previewLatestSuccessfulSequence: 0,
+    previewRequestsInFlight: 0,
+    previewRestoreTimer: null,
   };
 
   // The leader-side ExtensionBridgeTransport posts its `handshake.hello`
@@ -426,6 +442,7 @@ export async function handleBridgePortConnect(
   });
 
   port.onDisconnect.addListener(() => {
+    resetPreviewFocus(state);
     // Evict from the welcomed-port registry so we never post a lick to a dead
     // Port (no-op if the port never reached the welcome step).
     welcomedLeaderPorts.delete(port);
@@ -628,10 +645,116 @@ async function dispatchCdpCommand(
   // silent no-op in the extension). Select + focus the tab explicitly, then still
   // forward the command so renderer-wake parity is preserved.
   if (method === 'Page.bringToFront') {
-    await deps.activateTab(tabId);
+    return executeFollowerBringToFront(tabId, params, state, deps);
   }
   const effectiveParams = await deps.maybeUnmaskCdpFrame(tabId, method, params);
   return deps.sendDebuggerCommand(tabId, method, effectiveParams);
+}
+
+async function executeFollowerBringToFront(
+  tabId: number,
+  params: Record<string, unknown> | undefined,
+  state: PortState,
+  deps: BridgeSwDeps
+): Promise<Record<string, unknown>> {
+  const generation = state.previewGeneration;
+  const sequence = ++state.previewSequence;
+  state.previewRequestsInFlight++;
+  cancelPreviewRestore(state);
+  state.previewOriginalTab ??= deps.queryActiveTabId().catch(() => undefined);
+
+  try {
+    await state.previewOriginalTab;
+    await deps.activateTab(tabId);
+    if (
+      generation === state.previewGeneration &&
+      sequence > state.previewLatestSuccessfulSequence
+    ) {
+      state.previewLatestSuccessfulSequence = sequence;
+      state.previewLastTabId = tabId;
+    }
+    const effectiveParams = await deps.maybeUnmaskCdpFrame(tabId, 'Page.bringToFront', params);
+    return await deps.sendDebuggerCommand(tabId, 'Page.bringToFront', effectiveParams);
+  } finally {
+    if (generation === state.previewGeneration) {
+      state.previewRequestsInFlight--;
+      if (state.previewRequestsInFlight === 0 && state.previewLastTabId === null) {
+        state.previewOriginalTab = null;
+        state.previewLatestSuccessfulSequence = 0;
+      } else {
+        schedulePreviewRestore(state, deps);
+      }
+    }
+  }
+}
+
+function resetPreviewFocus(state: PortState): void {
+  cancelPreviewRestore(state);
+  state.previewGeneration++;
+  state.previewOriginalTab = null;
+  state.previewLastTabId = null;
+  state.previewLatestSuccessfulSequence = 0;
+  state.previewRequestsInFlight = 0;
+}
+
+function cancelPreviewRestore(state: PortState): void {
+  if (state.previewRestoreTimer === null) return;
+  clearTimeout(state.previewRestoreTimer);
+  state.previewRestoreTimer = null;
+}
+
+function schedulePreviewRestore(state: PortState, deps: BridgeSwDeps): void {
+  if (state.previewRequestsInFlight !== 0 || state.previewLastTabId === null) return;
+  cancelPreviewRestore(state);
+  state.previewRestoreTimer = setTimeout(() => {
+    state.previewRestoreTimer = null;
+    void restorePreviewFocus(state, deps);
+  }, FOLLOWER_PREVIEW_SETTLE_MS);
+}
+
+async function restorePreviewFocus(state: PortState, deps: BridgeSwDeps): Promise<void> {
+  const sequence = state.previewLatestSuccessfulSequence;
+  const originalTabId = await state.previewOriginalTab;
+  const previewTabId = state.previewLastTabId;
+  if (!originalTabId || !previewTabId || originalTabId === previewTabId) {
+    finishPreviewBurst(state, sequence);
+    return;
+  }
+
+  const [originalTab, activeTabId] = await Promise.all([
+    deps.getTab(originalTabId).catch(() => undefined),
+    deps.queryActiveTabId().catch(() => undefined),
+  ]);
+  if (!previewRestoreIsCurrent(state, sequence)) {
+    schedulePreviewRestore(state, deps);
+    return;
+  }
+  if (!originalTab || activeTabId !== previewTabId) {
+    finishPreviewBurst(state, sequence);
+    return;
+  }
+
+  try {
+    await deps.activateTab(originalTabId);
+  } catch (err) {
+    console.debug('[slicc-bridge-sw] follower preview focus restore skipped', {
+      tabId: originalTabId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  finishPreviewBurst(state, sequence);
+}
+
+function previewRestoreIsCurrent(state: PortState, sequence: number): boolean {
+  return sequence === state.previewLatestSuccessfulSequence && state.previewRequestsInFlight === 0;
+}
+
+function finishPreviewBurst(state: PortState, sequence: number): void {
+  if (!previewRestoreIsCurrent(state, sequence)) return;
+  cancelPreviewRestore(state);
+  state.previewOriginalTab = null;
+  state.previewLastTabId = null;
+  state.previewLatestSuccessfulSequence = 0;
 }
 
 async function cdpGetTargets(

--- a/packages/chrome-extension/src/bridge-sw.ts
+++ b/packages/chrome-extension/src/bridge-sw.ts
@@ -41,8 +41,6 @@ import {
 /** Storage key the sibling leader-tab task writes after pinning the leader. */
 const LEADER_TAB_ID_KEY = 'slicc_leader_tab_id';
 
-const FOLLOWER_PREVIEW_SETTLE_MS = 150;
-
 /** Origin allowlist for the bridge Port. Externally_connectable also gates
  *  this at the manifest level, but enforcing in code is defense-in-depth and
  *  makes test injection straightforward. Hosted origin comes from
@@ -192,13 +190,6 @@ interface PortState {
   ownedTabs: Set<number>;
   /** Unsubscribe from chrome.debugger.onEvent when the port closes. */
   unsubscribeEvents: (() => void) | null;
-  previewOriginalTab: Promise<number | undefined> | null;
-  previewLastTabId: number | null;
-  previewGeneration: number;
-  previewSequence: number;
-  previewLatestSuccessfulSequence: number;
-  previewRequestsInFlight: number;
-  previewRestoreTimer: ReturnType<typeof setTimeout> | null;
 }
 
 /**
@@ -404,13 +395,6 @@ export async function handleBridgePortConnect(
     sessionToTab: new Map(),
     ownedTabs: new Set(),
     unsubscribeEvents: null,
-    previewOriginalTab: null,
-    previewLastTabId: null,
-    previewGeneration: 0,
-    previewSequence: 0,
-    previewLatestSuccessfulSequence: 0,
-    previewRequestsInFlight: 0,
-    previewRestoreTimer: null,
   };
 
   // The leader-side ExtensionBridgeTransport posts its `handshake.hello`
@@ -442,7 +426,6 @@ export async function handleBridgePortConnect(
   });
 
   port.onDisconnect.addListener(() => {
-    resetPreviewFocus(state);
     // Evict from the welcomed-port registry so we never post a lick to a dead
     // Port (no-op if the port never reached the welcome step).
     welcomedLeaderPorts.delete(port);
@@ -645,116 +628,10 @@ async function dispatchCdpCommand(
   // silent no-op in the extension). Select + focus the tab explicitly, then still
   // forward the command so renderer-wake parity is preserved.
   if (method === 'Page.bringToFront') {
-    return executeFollowerBringToFront(tabId, params, state, deps);
+    await deps.activateTab(tabId);
   }
   const effectiveParams = await deps.maybeUnmaskCdpFrame(tabId, method, params);
   return deps.sendDebuggerCommand(tabId, method, effectiveParams);
-}
-
-async function executeFollowerBringToFront(
-  tabId: number,
-  params: Record<string, unknown> | undefined,
-  state: PortState,
-  deps: BridgeSwDeps
-): Promise<Record<string, unknown>> {
-  const generation = state.previewGeneration;
-  const sequence = ++state.previewSequence;
-  state.previewRequestsInFlight++;
-  cancelPreviewRestore(state);
-  state.previewOriginalTab ??= deps.queryActiveTabId().catch(() => undefined);
-
-  try {
-    await state.previewOriginalTab;
-    await deps.activateTab(tabId);
-    if (
-      generation === state.previewGeneration &&
-      sequence > state.previewLatestSuccessfulSequence
-    ) {
-      state.previewLatestSuccessfulSequence = sequence;
-      state.previewLastTabId = tabId;
-    }
-    const effectiveParams = await deps.maybeUnmaskCdpFrame(tabId, 'Page.bringToFront', params);
-    return await deps.sendDebuggerCommand(tabId, 'Page.bringToFront', effectiveParams);
-  } finally {
-    if (generation === state.previewGeneration) {
-      state.previewRequestsInFlight--;
-      if (state.previewRequestsInFlight === 0 && state.previewLastTabId === null) {
-        state.previewOriginalTab = null;
-        state.previewLatestSuccessfulSequence = 0;
-      } else {
-        schedulePreviewRestore(state, deps);
-      }
-    }
-  }
-}
-
-function resetPreviewFocus(state: PortState): void {
-  cancelPreviewRestore(state);
-  state.previewGeneration++;
-  state.previewOriginalTab = null;
-  state.previewLastTabId = null;
-  state.previewLatestSuccessfulSequence = 0;
-  state.previewRequestsInFlight = 0;
-}
-
-function cancelPreviewRestore(state: PortState): void {
-  if (state.previewRestoreTimer === null) return;
-  clearTimeout(state.previewRestoreTimer);
-  state.previewRestoreTimer = null;
-}
-
-function schedulePreviewRestore(state: PortState, deps: BridgeSwDeps): void {
-  if (state.previewRequestsInFlight !== 0 || state.previewLastTabId === null) return;
-  cancelPreviewRestore(state);
-  state.previewRestoreTimer = setTimeout(() => {
-    state.previewRestoreTimer = null;
-    void restorePreviewFocus(state, deps);
-  }, FOLLOWER_PREVIEW_SETTLE_MS);
-}
-
-async function restorePreviewFocus(state: PortState, deps: BridgeSwDeps): Promise<void> {
-  const sequence = state.previewLatestSuccessfulSequence;
-  const originalTabId = await state.previewOriginalTab;
-  const previewTabId = state.previewLastTabId;
-  if (!originalTabId || !previewTabId || originalTabId === previewTabId) {
-    finishPreviewBurst(state, sequence);
-    return;
-  }
-
-  const [originalTab, activeTabId] = await Promise.all([
-    deps.getTab(originalTabId).catch(() => undefined),
-    deps.queryActiveTabId().catch(() => undefined),
-  ]);
-  if (!previewRestoreIsCurrent(state, sequence)) {
-    schedulePreviewRestore(state, deps);
-    return;
-  }
-  if (!originalTab || activeTabId !== previewTabId) {
-    finishPreviewBurst(state, sequence);
-    return;
-  }
-
-  try {
-    await deps.activateTab(originalTabId);
-  } catch (err) {
-    console.debug('[slicc-bridge-sw] follower preview focus restore skipped', {
-      tabId: originalTabId,
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
-  finishPreviewBurst(state, sequence);
-}
-
-function previewRestoreIsCurrent(state: PortState, sequence: number): boolean {
-  return sequence === state.previewLatestSuccessfulSequence && state.previewRequestsInFlight === 0;
-}
-
-function finishPreviewBurst(state: PortState, sequence: number): void {
-  if (!previewRestoreIsCurrent(state, sequence)) return;
-  cancelPreviewRestore(state);
-  state.previewOriginalTab = null;
-  state.previewLastTabId = null;
-  state.previewLatestSuccessfulSequence = 0;
 }
 
 async function cdpGetTargets(

--- a/packages/chrome-extension/src/bridge-sw.ts
+++ b/packages/chrome-extension/src/bridge-sw.ts
@@ -185,6 +185,8 @@ interface PortState {
   channelId: string | null;
   /** Synthetic sessionId → real chrome tab id. */
   sessionToTab: Map<string, number>;
+  /** Number of logical CDP attachments sharing each tab's synthetic session. */
+  attachRefCounts: Map<number, number>;
   /** Tabs we attached the debugger to from THIS port. Used so disconnect
    *  detaches only what we attached (other code paths may also attach). */
   ownedTabs: Set<number>;
@@ -393,6 +395,7 @@ export async function handleBridgePortConnect(
   const state: PortState = {
     channelId: null,
     sessionToTab: new Map(),
+    attachRefCounts: new Map(),
     ownedTabs: new Set(),
     unsubscribeEvents: null,
   };
@@ -442,6 +445,7 @@ export async function handleBridgePortConnect(
     }
     state.ownedTabs.clear();
     state.sessionToTab.clear();
+    state.attachRefCounts.clear();
   });
 
   const pin = await validateBridgePin(port.sender, deps);
@@ -670,6 +674,7 @@ async function cdpAttachToTarget(
   // round-trip (matches the existing offscreen CDP proxy's convention).
   const sessionId = targetId;
   state.sessionToTab.set(sessionId, tabId);
+  state.attachRefCounts.set(tabId, (state.attachRefCounts.get(tabId) ?? 0) + 1);
   return { sessionId };
 }
 
@@ -681,9 +686,18 @@ async function cdpDetachFromTarget(
   const sessionId = params['sessionId'] as string;
   const tabId = state.sessionToTab.get(sessionId);
   if (tabId === undefined) return {};
-  state.sessionToTab.delete(sessionId);
-  const stillReferenced = [...state.sessionToTab.values()].includes(tabId);
-  if (!stillReferenced && state.ownedTabs.has(tabId)) {
+
+  const nextRefCount = (state.attachRefCounts.get(tabId) ?? 1) - 1;
+  if (nextRefCount > 0) {
+    state.attachRefCounts.set(tabId, nextRefCount);
+    return {};
+  }
+
+  state.attachRefCounts.delete(tabId);
+  for (const [sid, attachedTabId] of state.sessionToTab) {
+    if (attachedTabId === tabId) state.sessionToTab.delete(sid);
+  }
+  if (state.ownedTabs.has(tabId)) {
     state.ownedTabs.delete(tabId);
     await deps.detachDebugger(tabId);
   }
@@ -712,6 +726,7 @@ async function cdpCloseTarget(
   for (const [sid, tid] of state.sessionToTab) {
     if (tid === tabId) state.sessionToTab.delete(sid);
   }
+  state.attachRefCounts.delete(tabId);
   if (state.ownedTabs.has(tabId)) {
     state.ownedTabs.delete(tabId);
     await deps.detachDebugger(tabId);

--- a/packages/chrome-extension/src/bridge-sw.ts
+++ b/packages/chrome-extension/src/bridge-sw.ts
@@ -73,8 +73,9 @@ export interface BridgeSwDeps {
     method: string,
     params: Record<string, unknown> | undefined
   ) => Promise<Record<string, unknown> | undefined>;
-  /** Attach the chrome.debugger to a tab, idempotent. */
-  attachDebugger: (tabId: number) => Promise<void>;
+  /** Attach chrome.debugger to a tab. Returns true only when this caller
+   *  performed the underlying attach and therefore owns the matching detach. */
+  attachDebugger: (tabId: number) => Promise<boolean>;
   /** Detach the chrome.debugger from a tab if attached. */
   detachDebugger: (tabId: number) => Promise<void>;
   /** chrome.debugger.sendCommand bound to `{ tabId }`. */
@@ -324,6 +325,7 @@ export function buildDefaultBridgeSwDeps(overrides?: Partial<BridgeSwDeps>): Bri
     maybeUnmaskCdpFrame: async (_tabId, _method, params) => params,
     attachDebugger: async (tabId) => {
       await chrome.debugger.attach({ tabId }, '1.3');
+      return true;
     },
     detachDebugger: async (tabId) => {
       await chrome.debugger.detach({ tabId }).catch(() => {
@@ -436,10 +438,8 @@ export async function handleBridgePortConnect(
       state.unsubscribeEvents();
       state.unsubscribeEvents = null;
     }
-    // Detach debugger from tabs we own. Other paths in service-worker.ts
-    // own their own attachedTabs set; the SW deps' detachDebugger is wired
-    // to coordinate with that set so we never detach a tab still in use
-    // by the offscreen CDP proxy.
+    // Detach only tabs whose underlying debugger attachment this port created.
+    // A shared pre-existing attachment is usable by this port but never owned.
     for (const tabId of state.ownedTabs) {
       deps.detachDebugger(tabId).catch(() => {});
     }
@@ -667,8 +667,8 @@ async function cdpAttachToTarget(
     throw new Error(`Invalid targetId: ${targetId}`);
   }
   if (!state.ownedTabs.has(tabId)) {
-    await deps.attachDebugger(tabId);
-    state.ownedTabs.add(tabId);
+    const attachedByThisPort = await deps.attachDebugger(tabId);
+    if (attachedByThisPort) state.ownedTabs.add(tabId);
   }
   // sessionId === targetId so the leader can correlate without an extra
   // round-trip (matches the existing offscreen CDP proxy's convention).

--- a/packages/chrome-extension/src/bridge-sw.ts
+++ b/packages/chrome-extension/src/bridge-sw.ts
@@ -205,6 +205,23 @@ interface PortState {
  * broadcast (the leader has no in-page listener for that in thin mode).
  */
 const welcomedLeaderPorts = new Map<ChromeRuntimePort, string>();
+/** Per-port CDP state for live, welcomed leader connections. */
+const liveBridgePortStates = new Map<ChromeRuntimePort, PortState>();
+
+function invalidatePortDebuggerAttachment(state: PortState, tabId: number): void {
+  state.ownedTabs.delete(tabId);
+  state.attachRefCounts.delete(tabId);
+  for (const [sessionId, attachedTabId] of state.sessionToTab) {
+    if (attachedTabId === tabId) state.sessionToTab.delete(sessionId);
+  }
+}
+
+/** Drop stale per-port state after chrome reports an external debugger detach. */
+export function notifyBridgeDebuggerDetached(tabId: number): void {
+  for (const state of liveBridgePortStates.values()) {
+    invalidatePortDebuggerAttachment(state, tabId);
+  }
+}
 
 /**
  * Post an `extension.lick` envelope to every welcomed leader Port, each
@@ -288,6 +305,7 @@ export function postDiscoveryToWelcomedLeaderPorts(
 /** Test-only: clear the welcomed-port registry between cases. */
 export function __clearWelcomedLeaderPortsForTest(): void {
   welcomedLeaderPorts.clear();
+  liveBridgePortStates.clear();
 }
 
 /**
@@ -434,6 +452,7 @@ export async function handleBridgePortConnect(
     // Evict from the welcomed-port registry so we never post a lick to a dead
     // Port (no-op if the port never reached the welcome step).
     welcomedLeaderPorts.delete(port);
+    liveBridgePortStates.delete(port);
     if (state.unsubscribeEvents) {
       state.unsubscribeEvents();
       state.unsubscribeEvents = null;
@@ -530,6 +549,7 @@ async function handleBridgeMessage(
       return;
     }
     state.channelId = env.channelId;
+    liveBridgePortStates.set(port, state);
     // Start forwarding chrome.debugger events. Filter by tab id against
     // the per-port sessionToTab so we don't leak events from tabs another
     // port (or the offscreen path) is attached to.

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -847,10 +847,40 @@ chrome.webRequest.onHeadersReceived.addListener(
 
 /** Maps synthetic sessionId → Chrome tab ID. */
 const sessionToTab = new Map<string, number>();
-/** Tracks which tab IDs we've attached the debugger to. */
-const attachedTabs = new Set<number>();
+type DebuggerAttachmentOwner = 'bridge' | 'legacy';
+/** Tracks which consumer performed each underlying debugger attachment. */
+const debuggerAttachmentOwners = new Map<number, DebuggerAttachmentOwner>();
 /** Tracks leader tray WebSockets opened on behalf of the offscreen document. */
 const traySockets = new Map<number, WebSocket>();
+
+async function acquireDebuggerAttachment(
+  tabId: number,
+  owner: DebuggerAttachmentOwner
+): Promise<boolean> {
+  if (debuggerAttachmentOwners.has(tabId)) return false;
+  await chrome.debugger.attach({ tabId }, '1.3');
+  debuggerAttachmentOwners.set(tabId, owner);
+  return true;
+}
+
+async function releaseDebuggerAttachment(
+  tabId: number,
+  owner: DebuggerAttachmentOwner
+): Promise<void> {
+  if (debuggerAttachmentOwners.get(tabId) !== owner) return;
+  debuggerAttachmentOwners.delete(tabId);
+  await chrome.debugger.detach({ tabId }).catch(() => {
+    // Tab may already be closed
+  });
+}
+
+async function forceReleaseDebuggerAttachment(tabId: number): Promise<void> {
+  if (!debuggerAttachmentOwners.has(tabId)) return;
+  debuggerAttachmentOwners.delete(tabId);
+  await chrome.debugger.detach({ tabId }).catch(() => {
+    // Tab may already be closed
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Message relay
@@ -1176,7 +1206,7 @@ async function cdpGetTargets(): Promise<Record<string, unknown>> {
       type: 'page',
       title: tab.title ?? '',
       url: tab.url ?? '',
-      attached: attachedTabs.has(tab.id),
+      attached: debuggerAttachmentOwners.has(tab.id),
       active: activeTabIds.has(tab.id),
     }));
   return { targetInfos };
@@ -1191,10 +1221,7 @@ async function cdpAttachToTarget(
     throw new Error(`Invalid targetId: ${targetId}`);
   }
 
-  if (!attachedTabs.has(tabId)) {
-    await chrome.debugger.attach({ tabId }, '1.3');
-    attachedTabs.add(tabId);
-  }
+  await acquireDebuggerAttachment(tabId, 'legacy');
 
   const sessionId = targetId;
   sessionToTab.set(sessionId, tabId);
@@ -1211,10 +1238,7 @@ async function cdpDetachFromTarget(
     sessionToTab.delete(sessionId);
     const stillReferenced = [...sessionToTab.values()].includes(tabId);
     if (!stillReferenced) {
-      attachedTabs.delete(tabId);
-      await chrome.debugger.detach({ tabId }).catch(() => {
-        // Tab may already be closed
-      });
+      await releaseDebuggerAttachment(tabId, 'legacy');
     }
   }
 
@@ -1239,12 +1263,7 @@ async function cdpCloseTarget(params: Record<string, unknown>): Promise<Record<s
   for (const [sid, tid] of sessionToTab) {
     if (tid === tabId) sessionToTab.delete(sid);
   }
-  if (attachedTabs.has(tabId)) {
-    attachedTabs.delete(tabId);
-    await chrome.debugger.detach({ tabId }).catch(() => {
-      // Tab may already be closed
-    });
-  }
+  await forceReleaseDebuggerAttachment(tabId);
 
   await chrome.tabs.remove(tabId);
   return { success: true };
@@ -1323,7 +1342,7 @@ async function cdpSendCommand(
 
 chrome.debugger.onEvent.addListener(
   (source: { tabId: number }, method: string, params?: Record<string, unknown>) => {
-    if (!attachedTabs.has(source.tabId)) return;
+    if (!debuggerAttachmentOwners.has(source.tabId)) return;
 
     // Find sessionId for this tabId
     let sessionId: string | undefined;
@@ -1391,7 +1410,7 @@ async function handleOAuthRequest(msg: OAuthRequestMsg): Promise<OAuthResultMsg>
 }
 
 chrome.debugger.onDetach.addListener((source: { tabId: number }, _reason: string) => {
-  attachedTabs.delete(source.tabId);
+  debuggerAttachmentOwners.delete(source.tabId);
   for (const [sessionId, tabId] of sessionToTab) {
     if (tabId === source.tabId) {
       sessionToTab.delete(sessionId);
@@ -1439,19 +1458,8 @@ async function buildSecretsPipeline(): Promise<SecretsPipeline> {
 // ---------------------------------------------------------------------------
 
 const bridgeSwDeps = buildDefaultBridgeSwDeps({
-  attachDebugger: async (tabId) => {
-    if (attachedTabs.has(tabId)) return false;
-    await chrome.debugger.attach({ tabId }, '1.3');
-    attachedTabs.add(tabId);
-    return true;
-  },
-  detachDebugger: async (tabId) => {
-    if (!attachedTabs.has(tabId)) return;
-    attachedTabs.delete(tabId);
-    await chrome.debugger.detach({ tabId }).catch(() => {
-      /* tab may already be closed */
-    });
-  },
+  attachDebugger: (tabId) => acquireDebuggerAttachment(tabId, 'bridge'),
+  detachDebugger: (tabId) => releaseDebuggerAttachment(tabId, 'bridge'),
   sendDebuggerCommand: async (tabId, method, params) => {
     const result = await chrome.debugger.sendCommand({ tabId }, method, params);
     return result ?? {};

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -309,7 +309,7 @@ async function adoptSingleLeaderTab(matches: ChromeTab[]): Promise<void> {
 }
 
 async function ensureLeaderTab(): Promise<void> {
-  if (leaderTabLock) return leaderTabLock;
+  if (leaderTabLock !== null) return leaderTabLock;
   leaderTabLock = (async () => {
     try {
       const matches = await queryLeaderTabs();
@@ -1432,18 +1432,18 @@ async function buildSecretsPipeline(): Promise<SecretsPipeline> {
 // three-factor pin enforced inside `handleBridgePortConnect` (origin
 // allowlist + sender.tab.id === storedLeaderTabId + sender.frameId === 0).
 // `slicc_leader_tab_id` is owned by the sibling leader-tab task; absent →
-// pin fails closed. The deps here delegate attach/detach to the existing
-// `attachedTabs` accounting so the bridge and the offscreen CDP proxy never
-// trample each other, and route outbound commands through `maybeUnmaskCdpFrame`
+// pin fails closed. The deps here report whether the bridge actually performed
+// an attach, so it never claims or detaches a session already tracked by the
+// legacy offscreen compatibility path. Outbound commands route through `maybeUnmaskCdpFrame`
 // so raw CDP secrets MUST NEVER reach the leader tab.
 // ---------------------------------------------------------------------------
 
 const bridgeSwDeps = buildDefaultBridgeSwDeps({
   attachDebugger: async (tabId) => {
-    if (!attachedTabs.has(tabId)) {
-      await chrome.debugger.attach({ tabId }, '1.3');
-      attachedTabs.add(tabId);
-    }
+    if (attachedTabs.has(tabId)) return false;
+    await chrome.debugger.attach({ tabId }, '1.3');
+    attachedTabs.add(tabId);
+    return true;
   },
   detachDebugger: async (tabId) => {
     if (!attachedTabs.has(tabId)) return;
@@ -1655,7 +1655,7 @@ function errMsg(err: unknown): string {
 }
 
 function runSecretsListMaskedEntries(_msg: unknown, sendResponse: SendResponse): boolean {
-  (async () => {
+  void (async () => {
     try {
       const pipeline = await buildSecretsPipeline();
       await pipeline.reload();
@@ -1680,7 +1680,7 @@ function runSecretsListMaskedEntries(_msg: unknown, sendResponse: SendResponse):
 function runSecretsScrubToolResult(msg: unknown, sendResponse: SendResponse): boolean {
   const text = getStringField(msg, 'text');
   if (text === undefined) return false;
-  (async () => {
+  void (async () => {
     try {
       const pipeline = await buildSecretsPipeline();
       await pipeline.reload();
@@ -1700,7 +1700,7 @@ function runSecretsScrubToolResult(msg: unknown, sendResponse: SendResponse): bo
 // `buildSecretsPipeline()` above so the offscreen's pipeline produces the
 // same masked values as the SW fetch-proxy pipeline.
 function runSecretsListWithValuesForPipeline(_msg: unknown, sendResponse: SendResponse): boolean {
-  (async () => {
+  void (async () => {
     try {
       const sessionId = await readOrCreateSwSessionId();
       const persisted = await listSecretsWithValues(storageLocal);
@@ -1721,7 +1721,7 @@ function runSecretsListWithValuesForPipeline(_msg: unknown, sendResponse: SendRe
 // the manifest grants it (MV3 quirk). Route the management ops through
 // the SW, which DOES have chrome.storage.
 function runSecretsList(_msg: unknown, sendResponse: SendResponse): boolean {
-  (async () => {
+  void (async () => {
     try {
       const entries = await listSecrets(storageLocal);
       sendResponse({ entries });
@@ -1738,7 +1738,7 @@ function runSecretsSet(msg: unknown, sendResponse: SendResponse): boolean {
   const value = getStringField(msg, 'value');
   const domains = getStringArrayField(msg, 'domains');
   if (name === undefined || value === undefined || domains === undefined) return false;
-  (async () => {
+  void (async () => {
     try {
       await setSecret(storageLocal, name, value, domains);
       sendResponse({ ok: true });
@@ -1753,7 +1753,7 @@ function runSecretsSet(msg: unknown, sendResponse: SendResponse): boolean {
 function runSecretsDelete(msg: unknown, sendResponse: SendResponse): boolean {
   const name = getStringField(msg, 'name');
   if (name === undefined) return false;
-  (async () => {
+  void (async () => {
     try {
       // Session secrets win over persisted on name collision (mirrors the
       // node-server endpoint), so they are also checked first on delete.
@@ -1798,7 +1798,7 @@ function runSecretsSessionList(_msg: unknown, sendResponse: SendResponse): boole
 function runSecretsPeek(msg: unknown, sendResponse: SendResponse): boolean {
   const name = getStringField(msg, 'name');
   if (name === undefined) return false;
-  (async () => {
+  void (async () => {
     try {
       const sessionRec = sessionSecretStore.getRecord(name);
       if (sessionRec) {
@@ -1832,7 +1832,7 @@ function runSecretsSetDomains(msg: unknown, sendResponse: SendResponse): boolean
   const name = getStringField(msg, 'name');
   const domains = getStringArrayField(msg, 'domains');
   if (name === undefined || domains === undefined) return false;
-  (async () => {
+  void (async () => {
     try {
       if (sessionSecretStore.has(name)) {
         sessionSecretStore.setDomains(name, domains);
@@ -1882,7 +1882,7 @@ function runSecretsMaskOauthToken(msg: unknown, sendResponse: SendResponse): boo
   if (providerId === undefined) return false;
   const accessToken = getStringField(msg, 'accessToken');
   const domains = getStringField(msg, 'domains');
-  (async () => {
+  void (async () => {
     try {
       const maskedValue = await runMaskOauthTokenWrite(providerId, accessToken, domains);
       // We just wrote the secret above, so a missing entry here is NOT a
@@ -1913,7 +1913,7 @@ function runSecretsMaskOauthToken(msg: unknown, sendResponse: SendResponse): boo
 function runSecretsRedactExport(msg: unknown, sendResponse: SendResponse): boolean {
   const texts = getStringArrayField(msg, 'texts');
   if (texts === undefined) return false;
-  (async () => {
+  void (async () => {
     try {
       const pipeline = await buildSecretsPipeline();
       await pipeline.reload();

--- a/packages/chrome-extension/src/service-worker.ts
+++ b/packages/chrome-extension/src/service-worker.ts
@@ -52,6 +52,7 @@ import {
   BRIDGE_DEV_ORIGINS,
   buildDefaultBridgeSwDeps,
   handleBridgePortConnect,
+  notifyBridgeDebuggerDetached,
   postDiscoveryToWelcomedLeaderPorts,
   postLickToWelcomedLeaderPorts,
   postOpenSettingsToWelcomedLeaderPorts,
@@ -1416,6 +1417,7 @@ chrome.debugger.onDetach.addListener((source: { tabId: number }, _reason: string
       sessionToTab.delete(sessionId);
     }
   }
+  notifyBridgeDebuggerDetached(source.tabId);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/chrome-extension/tests/bridge-sw.test.ts
+++ b/packages/chrome-extension/tests/bridge-sw.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   EXTENSION_BRIDGE_PORT_NAME,
   EXTENSION_BRIDGE_PROTOCOL_VERSION,
@@ -100,6 +100,36 @@ const goodSender: FakeSender = {
   tab: { id: 42 },
   frameId: 0,
 };
+
+async function connectWithAttachedTabs(deps: BridgeSwDeps, tabIds: number[]): Promise<FakePort> {
+  const port = makePort(EXTENSION_BRIDGE_PORT_NAME, goodSender);
+  await handleBridgePortConnect(port as never, deps);
+  port.receive({ bridge: 1, channelId: 'c', kind: 'handshake.hello' });
+  for (const [index, tabId] of tabIds.entries()) {
+    port.receive({
+      bridge: 1,
+      channelId: 'c',
+      kind: 'cdp.request',
+      id: index + 1,
+      method: 'Target.attachToTarget',
+      params: { targetId: String(tabId) },
+    });
+  }
+  await flushMicrotasks();
+  return port;
+}
+
+async function bringToFront(port: FakePort, tabId: number, id: number): Promise<void> {
+  port.receive({
+    bridge: 1,
+    channelId: 'c',
+    kind: 'cdp.request',
+    id,
+    method: 'Page.bringToFront',
+    sessionId: String(tabId),
+  });
+  await flushMicrotasks();
+}
 
 describe('validateBridgePin', () => {
   it('passes for an origin in the allowlist on the stored leader tab top frame', async () => {
@@ -282,6 +312,10 @@ describe('handleBridgePortConnect — pin gating', () => {
 });
 
 describe('handleBridgePortConnect — CDP pass-through', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('attaches a tab on Target.attachToTarget and pipes commands through chrome.debugger', async () => {
     const port = makePort(EXTENSION_BRIDGE_PORT_NAME, goodSender);
     const deps = makeDeps();
@@ -327,6 +361,7 @@ describe('handleBridgePortConnect — CDP pass-through', () => {
   });
 
   it('Page.bringToFront selects + focuses the tab AND still forwards to chrome.debugger', async () => {
+    vi.useFakeTimers();
     const port = makePort(EXTENSION_BRIDGE_PORT_NAME, goodSender);
     const deps = makeDeps();
     await handleBridgePortConnect(port as never, deps);
@@ -343,7 +378,7 @@ describe('handleBridgePortConnect — CDP pass-through', () => {
       method: 'Target.attachToTarget',
       params: { targetId: '43' },
     });
-    await flush();
+    await flushMicrotasks();
 
     port.receive({
       bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
@@ -353,13 +388,171 @@ describe('handleBridgePortConnect — CDP pass-through', () => {
       method: 'Page.bringToFront',
       sessionId: '43',
     });
-    await flush();
+    await flushMicrotasks();
 
     // The real foregrounding: chrome.debugger's bringToFront can't switch the
     // active tab, so the bridge selects + focuses it explicitly.
     expect(deps.activateTab).toHaveBeenCalledWith(43);
     // …and the command is still forwarded (renderer-wake parity with standalone).
     expect(deps.sendDebuggerCommand).toHaveBeenCalledWith(43, 'Page.bringToFront', undefined);
+  });
+
+  it('borrows the preview tab then restores the previously active tab', async () => {
+    vi.useFakeTimers();
+    let activeTabId = 42;
+    const deps = makeDeps({
+      queryActiveTabId: vi.fn(async () => activeTabId),
+      activateTab: vi.fn(async (tabId) => {
+        activeTabId = tabId;
+      }),
+    });
+    const port = await connectWithAttachedTabs(deps, [43]);
+
+    await bringToFront(port, 43, 2);
+    expect(activeTabId).toBe(43);
+
+    await vi.advanceTimersByTimeAsync(150);
+    expect(activeTabId).toBe(42);
+    expect(deps.activateTab).toHaveBeenNthCalledWith(1, 43);
+    expect(deps.activateTab).toHaveBeenNthCalledWith(2, 42);
+  });
+
+  it('coalesces a preview burst into one restoration', async () => {
+    vi.useFakeTimers();
+    let activeTabId = 42;
+    const deps = makeDeps({
+      queryActiveTabId: async () => activeTabId,
+      activateTab: vi.fn(async (tabId) => {
+        activeTabId = tabId;
+      }),
+    });
+    const port = await connectWithAttachedTabs(deps, [43, 44]);
+
+    await bringToFront(port, 43, 3);
+    await vi.advanceTimersByTimeAsync(100);
+    await bringToFront(port, 44, 4);
+    await vi.advanceTimersByTimeAsync(149);
+    expect(activeTabId).toBe(44);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(activeTabId).toBe(42);
+    expect(deps.activateTab).toHaveBeenCalledTimes(3);
+    expect(deps.activateTab).toHaveBeenLastCalledWith(42);
+  });
+
+  it('does not restore when the user switches tabs during the settle window', async () => {
+    vi.useFakeTimers();
+    let activeTabId = 42;
+    const deps = makeDeps({
+      queryActiveTabId: async () => activeTabId,
+      activateTab: vi.fn(async (tabId) => {
+        activeTabId = tabId;
+      }),
+    });
+    const port = await connectWithAttachedTabs(deps, [43]);
+
+    await bringToFront(port, 43, 2);
+    activeTabId = 44;
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(activeTabId).toBe(44);
+    expect(deps.activateTab).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not restore when the previously active tab vanished', async () => {
+    vi.useFakeTimers();
+    let activeTabId = 42;
+    const existingTabs = new Set([42, 43]);
+    const deps = makeDeps({
+      queryActiveTabId: async () => activeTabId,
+      getTab: async (tabId) =>
+        existingTabs.has(tabId) ? { id: tabId, title: 't', url: 'https://example.com' } : undefined,
+      activateTab: vi.fn(async (tabId) => {
+        activeTabId = tabId;
+      }),
+    });
+    const port = await connectWithAttachedTabs(deps, [43]);
+
+    await bringToFront(port, 43, 2);
+    existingTabs.delete(42);
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(activeTabId).toBe(43);
+    expect(deps.activateTab).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels a pending restoration when the bridge port disconnects', async () => {
+    vi.useFakeTimers();
+    let activeTabId = 42;
+    const deps = makeDeps({
+      queryActiveTabId: async () => activeTabId,
+      activateTab: vi.fn(async (tabId) => {
+        activeTabId = tabId;
+      }),
+    });
+    const port = await connectWithAttachedTabs(deps, [43]);
+
+    await bringToFront(port, 43, 2);
+    port.triggerDisconnect();
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(activeTabId).toBe(43);
+    expect(deps.activateTab).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores an in-flight preview completion after the bridge port disconnects', async () => {
+    vi.useFakeTimers();
+    let resolveOriginal: ((tabId: number) => void) | undefined;
+    const originalTab = new Promise<number>((resolve) => {
+      resolveOriginal = resolve;
+    });
+    let activeTabId = 42;
+    const deps = makeDeps({
+      queryActiveTabId: vi.fn(() => originalTab),
+      activateTab: vi.fn(async (tabId) => {
+        activeTabId = tabId;
+      }),
+    });
+    const port = await connectWithAttachedTabs(deps, [43]);
+
+    const bringPromise = bringToFront(port, 43, 2);
+    port.triggerDisconnect();
+    resolveOriginal?.(42);
+    await bringPromise;
+    await vi.runAllTimersAsync();
+
+    expect(activeTabId).toBe(43);
+    expect(deps.activateTab).toHaveBeenCalledTimes(1);
+  });
+
+  it('contains a failed restoration and remains reusable for the next burst', async () => {
+    vi.useFakeTimers();
+    let activeTabId = 42;
+    let failRestore = true;
+    const deps = makeDeps({
+      queryActiveTabId: async () => activeTabId,
+      activateTab: vi.fn(async (tabId) => {
+        if (tabId === 42 && failRestore) throw new Error('tab activation failed');
+        activeTabId = tabId;
+      }),
+    });
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const port = await connectWithAttachedTabs(deps, [43]);
+
+    await bringToFront(port, 43, 2);
+    await vi.advanceTimersByTimeAsync(150);
+    expect(activeTabId).toBe(43);
+    expect(debugSpy).toHaveBeenCalledWith(
+      '[slicc-bridge-sw] follower preview focus restore skipped',
+      expect.objectContaining({ tabId: 42, error: 'tab activation failed' })
+    );
+
+    activeTabId = 42;
+    failRestore = false;
+    await bringToFront(port, 43, 3);
+    await vi.advanceTimersByTimeAsync(150);
+    expect(activeTabId).toBe(42);
+    debugSpy.mockRestore();
   });
 
   it('routes outbound CDP through maybeUnmaskCdpFrame (secrets stay SW-side)', async () => {
@@ -975,4 +1168,8 @@ describe('handleBridgePortConnect — leader.join-url message', () => {
 
 function flush(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
 }

--- a/packages/chrome-extension/tests/bridge-sw.test.ts
+++ b/packages/chrome-extension/tests/bridge-sw.test.ts
@@ -131,6 +131,18 @@ async function bringToFront(port: FakePort, tabId: number, id: number): Promise<
   await flushMicrotasks();
 }
 
+async function sendCdpRequest(
+  port: FakePort,
+  id: number,
+  method: string,
+  params?: Record<string, unknown>,
+  sessionId?: string
+): Promise<unknown> {
+  port.receive({ bridge: 1, channelId: 'c', kind: 'cdp.request', id, method, params, sessionId });
+  await flush();
+  return port.posted.find((message) => (message as { id?: number }).id === id);
+}
+
 describe('validateBridgePin', () => {
   it('passes for an origin in the allowlist on the stored leader tab top frame', async () => {
     const r = await validateBridgePin(goodSender as never, {
@@ -360,6 +372,55 @@ describe('handleBridgePortConnect — CDP pass-through', () => {
     });
   });
 
+  it('preserves a live session when one of two attachments detaches', async () => {
+    const deps = makeDeps();
+    const port = await connectWithAttachedTabs(deps, [42]);
+
+    await sendCdpRequest(port, 2, 'Target.attachToTarget', {
+      targetId: '42',
+      flatten: true,
+    });
+    await sendCdpRequest(port, 3, 'Target.detachFromTarget', { sessionId: '42' });
+    const commandResponse = await sendCdpRequest(
+      port,
+      4,
+      'Runtime.evaluate',
+      { expression: '1 + 1' },
+      '42'
+    );
+    expect(commandResponse).toMatchObject({ result: { ok: true, tabId: 42 } });
+    expect(deps.detachDebugger).not.toHaveBeenCalled();
+  });
+
+  it('detaches exactly once when duplicate attachments are balanced to zero', async () => {
+    const deps = makeDeps();
+    const port = await connectWithAttachedTabs(deps, [42]);
+    await sendCdpRequest(port, 2, 'Target.attachToTarget', { targetId: '42' });
+
+    await sendCdpRequest(port, 3, 'Target.detachFromTarget', { sessionId: '42' });
+    expect(deps.detachDebugger).not.toHaveBeenCalled();
+    await sendCdpRequest(port, 4, 'Target.detachFromTarget', { sessionId: '42' });
+    expect(deps.detachDebugger).toHaveBeenCalledTimes(1);
+    expect(deps.detachDebugger).toHaveBeenCalledWith(42);
+
+    const releasedResponse = await sendCdpRequest(port, 5, 'Target.detachFromTarget', {
+      sessionId: '42',
+    });
+    expect(releasedResponse).toMatchObject({ result: {} });
+    expect(deps.detachDebugger).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats an unknown session detach as a no-op', async () => {
+    const deps = makeDeps();
+    const port = await connectWithAttachedTabs(deps, []);
+
+    const response = await sendCdpRequest(port, 1, 'Target.detachFromTarget', {
+      sessionId: 'unknown',
+    });
+    expect(response).toMatchObject({ result: {} });
+    expect(deps.detachDebugger).not.toHaveBeenCalled();
+  });
+
   it('keeps a leader-originated Page.bringToFront permanently focused', async () => {
     vi.useFakeTimers();
     let activeTabId = 42;
@@ -551,23 +612,30 @@ describe('handleBridgePortConnect — CDP pass-through', () => {
     expect(resp).toMatchObject({ error: expect.stringContaining('No tab attached') });
   });
 
-  it('detaches owned tabs and unsubscribes events on port disconnect', async () => {
+  it('detaches a multiply-referenced owned tab once on port disconnect', async () => {
     const deps = makeDeps();
-    const port = makePort(EXTENSION_BRIDGE_PORT_NAME, goodSender);
-    await handleBridgePortConnect(port as never, deps);
-    port.receive({ bridge: 1, channelId: 'c', kind: 'handshake.hello' });
-    port.receive({
-      bridge: 1,
-      channelId: 'c',
-      kind: 'cdp.request',
-      id: 1,
-      method: 'Target.attachToTarget',
-      params: { targetId: '43' },
-    });
-    await flush();
+    const port = await connectWithAttachedTabs(deps, [43]);
+    await sendCdpRequest(port, 2, 'Target.attachToTarget', { targetId: '43' });
     port.triggerDisconnect();
     await flush();
     expect(deps.detachDebugger).toHaveBeenCalledWith(43);
+    expect(deps.detachDebugger).toHaveBeenCalledTimes(1);
+  });
+
+  it('force-releases a multiply-referenced tab when the target closes', async () => {
+    const removeTab = vi.fn(async () => undefined);
+    const deps = makeDeps({ removeTab });
+    const port = await connectWithAttachedTabs(deps, [43]);
+    await sendCdpRequest(port, 2, 'Target.attachToTarget', { targetId: '43' });
+
+    const response = await sendCdpRequest(port, 3, 'Target.closeTarget', { targetId: '43' });
+    expect(response).toMatchObject({ result: { success: true } });
+    expect(deps.detachDebugger).toHaveBeenCalledTimes(1);
+    expect(deps.detachDebugger).toHaveBeenCalledWith(43);
+    expect(removeTab).toHaveBeenCalledWith(43);
+
+    await sendCdpRequest(port, 4, 'Target.detachFromTarget', { sessionId: '43' });
+    expect(deps.detachDebugger).toHaveBeenCalledTimes(1);
   });
 
   it('Target.getTargets returns a CDP-shaped target list', async () => {

--- a/packages/chrome-extension/tests/bridge-sw.test.ts
+++ b/packages/chrome-extension/tests/bridge-sw.test.ts
@@ -360,48 +360,29 @@ describe('handleBridgePortConnect — CDP pass-through', () => {
     });
   });
 
-  it('Page.bringToFront selects + focuses the tab AND still forwards to chrome.debugger', async () => {
-    vi.useFakeTimers();
-    const port = makePort(EXTENSION_BRIDGE_PORT_NAME, goodSender);
-    const deps = makeDeps();
-    await handleBridgePortConnect(port as never, deps);
-    port.receive({
-      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
-      channelId: 'bridge-abc',
-      kind: 'handshake.hello',
-    });
-    port.receive({
-      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
-      channelId: 'bridge-abc',
-      kind: 'cdp.request',
-      id: 1,
-      method: 'Target.attachToTarget',
-      params: { targetId: '43' },
-    });
-    await flushMicrotasks();
-
-    port.receive({
-      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
-      channelId: 'bridge-abc',
-      kind: 'cdp.request',
-      id: 2,
-      method: 'Page.bringToFront',
-      sessionId: '43',
-    });
-    await flushMicrotasks();
-
-    // The real foregrounding: chrome.debugger's bringToFront can't switch the
-    // active tab, so the bridge selects + focuses it explicitly.
-    expect(deps.activateTab).toHaveBeenCalledWith(43);
-    // …and the command is still forwarded (renderer-wake parity with standalone).
-    expect(deps.sendDebuggerCommand).toHaveBeenCalledWith(43, 'Page.bringToFront', undefined);
-  });
-
-  it('borrows the preview tab then restores the previously active tab', async () => {
+  it('keeps a leader-originated Page.bringToFront permanently focused', async () => {
     vi.useFakeTimers();
     let activeTabId = 42;
     const deps = makeDeps({
-      queryActiveTabId: vi.fn(async () => activeTabId),
+      activateTab: vi.fn(async (tabId) => {
+        activeTabId = tabId;
+      }),
+    });
+    const port = await connectWithAttachedTabs(deps, [43]);
+
+    await bringToFront(port, 43, 2);
+
+    expect(activeTabId).toBe(43);
+    expect(deps.activateTab).toHaveBeenCalledWith(43);
+    expect(deps.sendDebuggerCommand).toHaveBeenCalledWith(43, 'Page.bringToFront', undefined);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(activeTabId).toBe(43);
+    expect(deps.activateTab).toHaveBeenCalledTimes(1);
+  });
+
+  it('activates the original tab for CDPRouter attach + bringToFront restoration', async () => {
+    let activeTabId = 42;
+    const deps = makeDeps({
       activateTab: vi.fn(async (tabId) => {
         activeTabId = tabId;
       }),
@@ -411,148 +392,20 @@ describe('handleBridgePortConnect — CDP pass-through', () => {
     await bringToFront(port, 43, 2);
     expect(activeTabId).toBe(43);
 
-    await vi.advanceTimersByTimeAsync(150);
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: 'c',
+      kind: 'cdp.request',
+      id: 3,
+      method: 'Target.attachToTarget',
+      params: { targetId: '42', flatten: true },
+    });
+    await flushMicrotasks();
+    await bringToFront(port, 42, 4);
+
     expect(activeTabId).toBe(42);
     expect(deps.activateTab).toHaveBeenNthCalledWith(1, 43);
     expect(deps.activateTab).toHaveBeenNthCalledWith(2, 42);
-  });
-
-  it('coalesces a preview burst into one restoration', async () => {
-    vi.useFakeTimers();
-    let activeTabId = 42;
-    const deps = makeDeps({
-      queryActiveTabId: async () => activeTabId,
-      activateTab: vi.fn(async (tabId) => {
-        activeTabId = tabId;
-      }),
-    });
-    const port = await connectWithAttachedTabs(deps, [43, 44]);
-
-    await bringToFront(port, 43, 3);
-    await vi.advanceTimersByTimeAsync(100);
-    await bringToFront(port, 44, 4);
-    await vi.advanceTimersByTimeAsync(149);
-    expect(activeTabId).toBe(44);
-
-    await vi.advanceTimersByTimeAsync(1);
-    expect(activeTabId).toBe(42);
-    expect(deps.activateTab).toHaveBeenCalledTimes(3);
-    expect(deps.activateTab).toHaveBeenLastCalledWith(42);
-  });
-
-  it('does not restore when the user switches tabs during the settle window', async () => {
-    vi.useFakeTimers();
-    let activeTabId = 42;
-    const deps = makeDeps({
-      queryActiveTabId: async () => activeTabId,
-      activateTab: vi.fn(async (tabId) => {
-        activeTabId = tabId;
-      }),
-    });
-    const port = await connectWithAttachedTabs(deps, [43]);
-
-    await bringToFront(port, 43, 2);
-    activeTabId = 44;
-    await vi.advanceTimersByTimeAsync(150);
-
-    expect(activeTabId).toBe(44);
-    expect(deps.activateTab).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not restore when the previously active tab vanished', async () => {
-    vi.useFakeTimers();
-    let activeTabId = 42;
-    const existingTabs = new Set([42, 43]);
-    const deps = makeDeps({
-      queryActiveTabId: async () => activeTabId,
-      getTab: async (tabId) =>
-        existingTabs.has(tabId) ? { id: tabId, title: 't', url: 'https://example.com' } : undefined,
-      activateTab: vi.fn(async (tabId) => {
-        activeTabId = tabId;
-      }),
-    });
-    const port = await connectWithAttachedTabs(deps, [43]);
-
-    await bringToFront(port, 43, 2);
-    existingTabs.delete(42);
-    await vi.advanceTimersByTimeAsync(150);
-
-    expect(activeTabId).toBe(43);
-    expect(deps.activateTab).toHaveBeenCalledTimes(1);
-  });
-
-  it('cancels a pending restoration when the bridge port disconnects', async () => {
-    vi.useFakeTimers();
-    let activeTabId = 42;
-    const deps = makeDeps({
-      queryActiveTabId: async () => activeTabId,
-      activateTab: vi.fn(async (tabId) => {
-        activeTabId = tabId;
-      }),
-    });
-    const port = await connectWithAttachedTabs(deps, [43]);
-
-    await bringToFront(port, 43, 2);
-    port.triggerDisconnect();
-    await vi.advanceTimersByTimeAsync(150);
-
-    expect(activeTabId).toBe(43);
-    expect(deps.activateTab).toHaveBeenCalledTimes(1);
-  });
-
-  it('ignores an in-flight preview completion after the bridge port disconnects', async () => {
-    vi.useFakeTimers();
-    let resolveOriginal: ((tabId: number) => void) | undefined;
-    const originalTab = new Promise<number>((resolve) => {
-      resolveOriginal = resolve;
-    });
-    let activeTabId = 42;
-    const deps = makeDeps({
-      queryActiveTabId: vi.fn(() => originalTab),
-      activateTab: vi.fn(async (tabId) => {
-        activeTabId = tabId;
-      }),
-    });
-    const port = await connectWithAttachedTabs(deps, [43]);
-
-    const bringPromise = bringToFront(port, 43, 2);
-    port.triggerDisconnect();
-    resolveOriginal?.(42);
-    await bringPromise;
-    await vi.runAllTimersAsync();
-
-    expect(activeTabId).toBe(43);
-    expect(deps.activateTab).toHaveBeenCalledTimes(1);
-  });
-
-  it('contains a failed restoration and remains reusable for the next burst', async () => {
-    vi.useFakeTimers();
-    let activeTabId = 42;
-    let failRestore = true;
-    const deps = makeDeps({
-      queryActiveTabId: async () => activeTabId,
-      activateTab: vi.fn(async (tabId) => {
-        if (tabId === 42 && failRestore) throw new Error('tab activation failed');
-        activeTabId = tabId;
-      }),
-    });
-    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
-    const port = await connectWithAttachedTabs(deps, [43]);
-
-    await bringToFront(port, 43, 2);
-    await vi.advanceTimersByTimeAsync(150);
-    expect(activeTabId).toBe(43);
-    expect(debugSpy).toHaveBeenCalledWith(
-      '[slicc-bridge-sw] follower preview focus restore skipped',
-      expect.objectContaining({ tabId: 42, error: 'tab activation failed' })
-    );
-
-    activeTabId = 42;
-    failRestore = false;
-    await bringToFront(port, 43, 3);
-    await vi.advanceTimersByTimeAsync(150);
-    expect(activeTabId).toBe(42);
-    debugSpy.mockRestore();
   });
 
   it('routes outbound CDP through maybeUnmaskCdpFrame (secrets stay SW-side)', async () => {

--- a/packages/chrome-extension/tests/bridge-sw.test.ts
+++ b/packages/chrome-extension/tests/bridge-sw.test.ts
@@ -8,6 +8,7 @@ import {
   BRIDGE_ALLOWED_ORIGINS,
   type BridgeSwDeps,
   handleBridgePortConnect,
+  notifyBridgeDebuggerDetached,
   postDiscoveryToWelcomedLeaderPorts,
   postLickToWelcomedLeaderPorts,
   postOpenSettingsToWelcomedLeaderPorts,
@@ -610,6 +611,21 @@ describe('handleBridgePortConnect — CDP pass-through', () => {
         (m as { id?: number }).id === 1
     );
     expect(resp).toMatchObject({ error: expect.stringContaining('No tab attached') });
+  });
+
+  it('notifies the leader when an external debugger detach invalidates its session', async () => {
+    const deps = makeDeps();
+    const port = await connectWithAttachedTabs(deps, [43]);
+
+    notifyBridgeDebuggerDetached(43);
+
+    expect(port.posted).toContainEqual({
+      bridge: 1,
+      channelId: 'c',
+      kind: 'cdp.event',
+      method: 'Target.detachedFromTarget',
+      params: { sessionId: '43', targetId: '43' },
+    });
   });
 
   it('detaches a multiply-referenced owned tab once on port disconnect', async () => {

--- a/packages/chrome-extension/tests/bridge-sw.test.ts
+++ b/packages/chrome-extension/tests/bridge-sw.test.ts
@@ -65,7 +65,7 @@ function makeDeps(overrides: Partial<BridgeSwDeps> = {}): BridgeSwDeps {
   const base: BridgeSwDeps = {
     readStoredLeaderTabId: async () => 42,
     maybeUnmaskCdpFrame: async (_tabId, _method, params) => params,
-    attachDebugger: vi.fn(async () => undefined),
+    attachDebugger: vi.fn(async () => true),
     detachDebugger: vi.fn(async () => undefined),
     sendDebuggerCommand: vi.fn(async (tabId, method, params) => {
       sent.push({ tabId, method, params });

--- a/packages/chrome-extension/tests/service-worker-cdp-unmask.test.ts
+++ b/packages/chrome-extension/tests/service-worker-cdp-unmask.test.ts
@@ -1,7 +1,41 @@
 import { mask } from '@slicc/shared-ts';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  EXTENSION_BRIDGE_PORT_NAME,
+  EXTENSION_BRIDGE_PROTOCOL_VERSION,
+} from '../../webapp/src/cdp/extension-bridge-protocol.js';
 
 type MessageListener = (msg: any, sender: any, sendResponse: (r: any) => void) => boolean | void;
+
+interface FakePort {
+  name: string;
+  sender: { origin: string; tab: { id: number }; frameId: number; url: string };
+  postMessage: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  onMessage: { addListener: (listener: (message: unknown) => void) => void };
+  onDisconnect: { addListener: (listener: () => void) => void };
+  receive: (message: unknown) => void;
+}
+
+function makeBridgePort(): FakePort {
+  const messageListeners: Array<(message: unknown) => void> = [];
+  return {
+    name: EXTENSION_BRIDGE_PORT_NAME,
+    sender: {
+      origin: 'https://www.sliccy.ai',
+      tab: { id: 7 },
+      frameId: 0,
+      url: 'https://www.sliccy.ai/?slicc=leader',
+    },
+    postMessage: vi.fn(),
+    disconnect: vi.fn(),
+    onMessage: { addListener: (listener) => messageListeners.push(listener) },
+    onDisconnect: { addListener: vi.fn() },
+    receive: (message) => {
+      for (const listener of messageListeners) listener(message);
+    },
+  };
+}
 
 describe('service-worker CDP outgoing unmask', () => {
   let messageListeners: MessageListener[];
@@ -10,6 +44,8 @@ describe('service-worker CDP outgoing unmask', () => {
   let tabsMap: Record<number, { id: number; url: string }>;
   let debuggerSendCommand: ReturnType<typeof vi.fn>;
   let tabsGet: ReturnType<typeof vi.fn>;
+  let connectExternalListeners: Array<(port: FakePort) => void>;
+  let debuggerAttached: boolean;
 
   const SESSION_ID = '11111111-2222-3333-4444-555555555555';
   const TAB_ID = 42;
@@ -17,6 +53,8 @@ describe('service-worker CDP outgoing unmask', () => {
   beforeEach(() => {
     messageListeners = [];
     runtimeSentMessages = [];
+    connectExternalListeners = [];
+    debuggerAttached = false;
     storageMap = {
       '_session.id': SESSION_ID,
       GITHUB_TOKEN: 'ghp_realtoken',
@@ -33,7 +71,10 @@ describe('service-worker CDP outgoing unmask', () => {
     (globalThis as any).chrome = {
       runtime: {
         onConnect: { addListener: vi.fn() },
-        onConnectExternal: { addListener: vi.fn() },
+        onConnectExternal: {
+          addListener: (listener: (port: FakePort) => void) =>
+            connectExternalListeners.push(listener),
+        },
         onMessage: { addListener: (fn: MessageListener) => messageListeners.push(fn) },
         onInstalled: { addListener: vi.fn() },
         onStartup: { addListener: vi.fn() },
@@ -91,8 +132,12 @@ describe('service-worker CDP outgoing unmask', () => {
       },
       tabGroups: { update: vi.fn() },
       debugger: {
-        attach: vi.fn(async () => undefined),
-        detach: vi.fn(async () => undefined),
+        attach: vi.fn(async () => {
+          debuggerAttached = true;
+        }),
+        detach: vi.fn(async () => {
+          debuggerAttached = false;
+        }),
         sendCommand: debuggerSendCommand,
         onEvent: { addListener: vi.fn() },
         onDetach: { addListener: vi.fn() },
@@ -206,5 +251,43 @@ describe('service-worker CDP outgoing unmask', () => {
     expect(tabsGet).not.toHaveBeenCalled();
     const calls = debuggerSendCommand.mock.calls.filter((c) => c[1] === 'Page.reload');
     expect(calls).toHaveLength(1);
+  });
+
+  it('does not detach a legacy-owned debugger session when the bridge releases it', async () => {
+    await import('../src/service-worker.js');
+    await attach();
+    expect(debuggerAttached).toBe(true);
+    expect(chrome.debugger.attach).toHaveBeenCalledTimes(1);
+
+    const port = makeBridgePort();
+    for (const listener of connectExternalListeners) listener(port);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: 'ownership-test',
+      kind: 'handshake.hello',
+    });
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: 'ownership-test',
+      kind: 'cdp.request',
+      id: 2,
+      method: 'Target.attachToTarget',
+      params: { targetId: String(TAB_ID) },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: 'ownership-test',
+      kind: 'cdp.request',
+      id: 3,
+      method: 'Target.detachFromTarget',
+      params: { sessionId: String(TAB_ID) },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(chrome.debugger.attach).toHaveBeenCalledTimes(1);
+    expect(chrome.debugger.detach).not.toHaveBeenCalled();
+    expect(debuggerAttached).toBe(true);
   });
 });

--- a/packages/chrome-extension/tests/service-worker-cdp-unmask.test.ts
+++ b/packages/chrome-extension/tests/service-worker-cdp-unmask.test.ts
@@ -289,5 +289,61 @@ describe('service-worker CDP outgoing unmask', () => {
     expect(chrome.debugger.attach).toHaveBeenCalledTimes(1);
     expect(chrome.debugger.detach).not.toHaveBeenCalled();
     expect(debuggerAttached).toBe(true);
+
+    await dispatchOffscreen({
+      type: 'cdp-command',
+      id: 4,
+      method: 'Target.detachFromTarget',
+      params: { sessionId: String(TAB_ID) },
+    });
+    expect(chrome.debugger.detach).toHaveBeenCalledTimes(1);
+    expect(debuggerAttached).toBe(false);
+  });
+
+  it('does not detach a bridge-owned debugger session when the legacy path releases it', async () => {
+    await import('../src/service-worker.js');
+    const port = makeBridgePort();
+    for (const listener of connectExternalListeners) listener(port);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: 'inverse-ownership-test',
+      kind: 'handshake.hello',
+    });
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: 'inverse-ownership-test',
+      kind: 'cdp.request',
+      id: 2,
+      method: 'Target.attachToTarget',
+      params: { targetId: String(TAB_ID) },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(debuggerAttached).toBe(true);
+    expect(chrome.debugger.attach).toHaveBeenCalledTimes(1);
+
+    await attach();
+    await dispatchOffscreen({
+      type: 'cdp-command',
+      id: 3,
+      method: 'Target.detachFromTarget',
+      params: { sessionId: String(TAB_ID) },
+    });
+
+    expect(chrome.debugger.attach).toHaveBeenCalledTimes(1);
+    expect(chrome.debugger.detach).not.toHaveBeenCalled();
+    expect(debuggerAttached).toBe(true);
+
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: 'inverse-ownership-test',
+      kind: 'cdp.request',
+      id: 4,
+      method: 'Target.detachFromTarget',
+      params: { sessionId: String(TAB_ID) },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(chrome.debugger.detach).toHaveBeenCalledTimes(1);
+    expect(debuggerAttached).toBe(false);
   });
 });

--- a/packages/chrome-extension/tests/service-worker-cdp-unmask.test.ts
+++ b/packages/chrome-extension/tests/service-worker-cdp-unmask.test.ts
@@ -45,6 +45,7 @@ describe('service-worker CDP outgoing unmask', () => {
   let debuggerSendCommand: ReturnType<typeof vi.fn>;
   let tabsGet: ReturnType<typeof vi.fn>;
   let connectExternalListeners: Array<(port: FakePort) => void>;
+  let debuggerDetachListeners: Array<(source: { tabId: number }, reason: string) => void>;
   let debuggerAttached: boolean;
 
   const SESSION_ID = '11111111-2222-3333-4444-555555555555';
@@ -54,6 +55,7 @@ describe('service-worker CDP outgoing unmask', () => {
     messageListeners = [];
     runtimeSentMessages = [];
     connectExternalListeners = [];
+    debuggerDetachListeners = [];
     debuggerAttached = false;
     storageMap = {
       '_session.id': SESSION_ID,
@@ -140,7 +142,10 @@ describe('service-worker CDP outgoing unmask', () => {
         }),
         sendCommand: debuggerSendCommand,
         onEvent: { addListener: vi.fn() },
-        onDetach: { addListener: vi.fn() },
+        onDetach: {
+          addListener: (listener: (source: { tabId: number }, reason: string) => void) =>
+            debuggerDetachListeners.push(listener),
+        },
       },
       identity: { launchWebAuthFlow: vi.fn(), getRedirectURL: vi.fn() },
       notifications: { create: vi.fn(), onClicked: { addListener: vi.fn() } },
@@ -337,6 +342,72 @@ describe('service-worker CDP outgoing unmask', () => {
     port.receive({
       bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
       channelId: 'inverse-ownership-test',
+      kind: 'cdp.request',
+      id: 4,
+      method: 'Target.detachFromTarget',
+      params: { sessionId: String(TAB_ID) },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(chrome.debugger.detach).toHaveBeenCalledTimes(1);
+    expect(debuggerAttached).toBe(false);
+  });
+
+  it('reacquires a bridge debugger attachment after an external detach', async () => {
+    await import('../src/service-worker.js');
+    const port = makeBridgePort();
+    for (const listener of connectExternalListeners) listener(port);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: 'external-detach-test',
+      kind: 'handshake.hello',
+    });
+
+    const attachThroughBridge = (id: number): void => {
+      port.receive({
+        bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+        channelId: 'external-detach-test',
+        kind: 'cdp.request',
+        id,
+        method: 'Target.attachToTarget',
+        params: { targetId: String(TAB_ID) },
+      });
+    };
+
+    attachThroughBridge(1);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(chrome.debugger.attach).toHaveBeenCalledTimes(1);
+
+    debuggerAttached = false;
+    for (const listener of debuggerDetachListeners) {
+      listener({ tabId: TAB_ID }, 'canceled_by_user');
+    }
+
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: 'external-detach-test',
+      kind: 'cdp.request',
+      id: 2,
+      method: 'Runtime.evaluate',
+      params: { expression: '1 + 1' },
+      sessionId: String(TAB_ID),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(port.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 2,
+        error: expect.stringContaining('No tab attached'),
+      })
+    );
+
+    attachThroughBridge(3);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(chrome.debugger.attach).toHaveBeenCalledTimes(2);
+    expect(debuggerAttached).toBe(true);
+
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: 'external-detach-test',
       kind: 'cdp.request',
       id: 4,
       method: 'Target.detachFromTarget',

--- a/packages/webapp/src/cdp/extension-bridge-transport.ts
+++ b/packages/webapp/src/cdp/extension-bridge-transport.ts
@@ -279,6 +279,12 @@ export class ExtensionBridgeTransport extends CdpTransportBridge {
       this.cleanupHandshake();
       return;
     }
+    if (env.kind === 'cdp.event' && env.method === 'Target.detachedFromTarget') {
+      // The service worker lost chrome.debugger ownership. Dropping the Port
+      // makes BrowserAPI's existing reconnect path invalidate its cached session.
+      this.disconnect();
+      return;
+    }
     if (env.kind === 'extension.lick') {
       this.bridgeOpts.onLick?.(env);
     }

--- a/packages/webapp/src/scoops/tab-persistence-guard.ts
+++ b/packages/webapp/src/scoops/tab-persistence-guard.ts
@@ -1,0 +1,205 @@
+/**
+ * Prevents the host browser tab from being discarded by Chrome's memory
+ * pressure heuristics while followers are attached to a tray leader.
+ *
+ * Chrome considers tabs with active inaudible audio playback, held Web Locks,
+ * and registered `beforeunload` handlers as "important" and rarely discards
+ * them. We combine all three to maximize the chance the leader stays
+ * resident while followers are connected.
+ *
+ * The guard is a no-op in environments where AudioContext / navigator.locks
+ * are unavailable (e.g. node tests, restricted iframes); failures are logged
+ * but never propagated.
+ */
+
+import { createLogger } from '../core/logger.js';
+
+const log = createLogger('tab-persistence-guard');
+
+export interface TabPersistenceGuardOptions {
+  audioContextFactory?: () => AudioContextLike | null;
+  lockManager?: LockManagerLike | null;
+  windowRef?: WindowLike | null;
+}
+
+export interface AudioContextLike {
+  state: string;
+  resume(): Promise<void>;
+  close(): Promise<void>;
+  createOscillator(): { connect(node: unknown): void; start(): void; stop(): void };
+  createGain(): { connect(node: unknown): void; gain: { value: number } };
+  readonly destination: unknown;
+}
+
+export interface LockManagerLike {
+  request(
+    name: string,
+    options: { mode?: 'shared' | 'exclusive'; signal?: AbortSignal },
+    callback: () => Promise<unknown>
+  ): Promise<unknown>;
+}
+
+export interface WindowLike {
+  addEventListener(type: 'beforeunload', listener: () => void): void;
+  removeEventListener(type: 'beforeunload', listener: () => void): void;
+}
+
+const LOCK_NAME = 'slicc-tray-leader-active';
+
+export class TabPersistenceGuard {
+  private active = false;
+  private audioCtx: AudioContextLike | null = null;
+  private oscillator: { stop(): void } | null = null;
+  private lockController: AbortController | null = null;
+  private beforeUnloadHandler: (() => void) | null = null;
+
+  constructor(private readonly options: TabPersistenceGuardOptions = {}) {}
+
+  activate(): void {
+    if (this.active) return;
+    this.active = true;
+    this.startSilentAudio();
+    this.acquireWebLock();
+    this.installBeforeUnload();
+    log.info('Tab persistence guard activated');
+  }
+
+  deactivate(): void {
+    if (!this.active) return;
+    this.active = false;
+    this.stopSilentAudio();
+    this.releaseWebLock();
+    this.removeBeforeUnload();
+    log.info('Tab persistence guard deactivated');
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  private startSilentAudio(): void {
+    try {
+      const factory =
+        this.options.audioContextFactory ??
+        (() => {
+          const Ctor =
+            typeof globalThis !== 'undefined'
+              ? ((globalThis as { AudioContext?: { new (): AudioContextLike } }).AudioContext ??
+                (globalThis as { webkitAudioContext?: { new (): AudioContextLike } })
+                  .webkitAudioContext)
+              : undefined;
+          return Ctor ? new Ctor() : null;
+        });
+      const ctx = factory();
+      if (!ctx) {
+        log.warn('AudioContext unavailable — discard prevention via silent audio disabled');
+        return;
+      }
+      void ctx.resume?.().catch(() => {});
+      const oscillator = ctx.createOscillator();
+      const gain = ctx.createGain();
+      gain.gain.value = 0;
+      oscillator.connect(gain);
+      gain.connect(ctx.destination);
+      oscillator.start();
+      this.audioCtx = ctx;
+      this.oscillator = oscillator;
+    } catch (error) {
+      log.warn('Failed to start silent audio guard', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private stopSilentAudio(): void {
+    try {
+      this.oscillator?.stop();
+    } catch {
+      // Already stopped.
+    }
+    this.oscillator = null;
+    if (this.audioCtx) {
+      void this.audioCtx.close?.().catch(() => {});
+      this.audioCtx = null;
+    }
+  }
+
+  private acquireWebLock(): void {
+    try {
+      const manager =
+        this.options.lockManager ??
+        (typeof navigator !== 'undefined' && 'locks' in navigator
+          ? (navigator as unknown as { locks: LockManagerLike }).locks
+          : null);
+      if (!manager) {
+        log.warn('navigator.locks unavailable — discard prevention via Web Lock disabled');
+        return;
+      }
+      const controller = new AbortController();
+      this.lockController = controller;
+      manager
+        .request(LOCK_NAME, { mode: 'exclusive', signal: controller.signal }, () => {
+          return new Promise<void>((resolve) => {
+            if (controller.signal.aborted) {
+              resolve();
+              return;
+            }
+            const onAbort = () => {
+              controller.signal.removeEventListener('abort', onAbort);
+              resolve();
+            };
+            controller.signal.addEventListener('abort', onAbort, { once: true });
+          });
+        })
+        .catch((error: unknown) => {
+          const name = (error as { name?: string } | null)?.name;
+          if (name !== 'AbortError') {
+            log.warn('Web Lock request rejected', {
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        });
+    } catch (error) {
+      log.warn('Failed to acquire Web Lock', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private releaseWebLock(): void {
+    try {
+      this.lockController?.abort();
+    } catch {
+      // Ignore.
+    }
+    this.lockController = null;
+  }
+
+  private installBeforeUnload(): void {
+    try {
+      const win =
+        this.options.windowRef ??
+        (typeof window !== 'undefined' ? (window as unknown as WindowLike) : null);
+      if (!win) return;
+      const handler = () => {};
+      win.addEventListener('beforeunload', handler);
+      this.beforeUnloadHandler = handler;
+    } catch {
+      // Ignore.
+    }
+  }
+
+  private removeBeforeUnload(): void {
+    try {
+      const win =
+        this.options.windowRef ??
+        (typeof window !== 'undefined' ? (window as unknown as WindowLike) : null);
+      if (win && this.beforeUnloadHandler) {
+        win.removeEventListener('beforeunload', this.beforeUnloadHandler);
+      }
+    } catch {
+      // Ignore.
+    }
+    this.beforeUnloadHandler = null;
+  }
+}

--- a/packages/webapp/src/scoops/tray-leader-sync.ts
+++ b/packages/webapp/src/scoops/tray-leader-sync.ts
@@ -387,6 +387,7 @@ export class LeaderSyncManager {
   }
 
   stop(): void {
+    this.cdpRouter.resetPreviewFocus();
     for (const bootstrapId of [...this.followers.keys()]) {
       this.removeFollower(bootstrapId);
     }

--- a/packages/webapp/src/scoops/tray-leader/cdp-router.ts
+++ b/packages/webapp/src/scoops/tray-leader/cdp-router.ts
@@ -36,6 +36,7 @@ export class CDPRouter {
   private readonly remoteTransports = new Map<string, RemoteCDPTransport>();
   private previewOriginalTarget: Promise<string | null> | null = null;
   private previewLastTargetId: string | null = null;
+  private previewGeneration = 0;
   private previewSequence = 0;
   private previewLatestSuccessfulSequence = 0;
   private previewRequestsInFlight = 0;
@@ -114,6 +115,7 @@ export class CDPRouter {
     params: Record<string, unknown> | undefined,
     sessionId: string | undefined
   ): Promise<Record<string, unknown>> {
+    const generation = this.previewGeneration;
     const sequence = ++this.previewSequence;
     this.previewRequestsInFlight++;
     this.cancelPreviewRestore();
@@ -122,20 +124,35 @@ export class CDPRouter {
     try {
       await this.previewOriginalTarget;
       const result = await transport.send('Page.bringToFront', params, sessionId);
-      if (sequence > this.previewLatestSuccessfulSequence) {
+      if (
+        generation === this.previewGeneration &&
+        sequence > this.previewLatestSuccessfulSequence
+      ) {
         this.previewLatestSuccessfulSequence = sequence;
         this.previewLastTargetId = localTargetId;
       }
       return result;
     } finally {
-      this.previewRequestsInFlight--;
-      if (this.previewRequestsInFlight === 0 && this.previewLastTargetId === null) {
-        this.previewOriginalTarget = null;
-        this.previewLatestSuccessfulSequence = 0;
-      } else {
-        this.schedulePreviewRestore(transport);
+      if (generation === this.previewGeneration) {
+        this.previewRequestsInFlight--;
+        if (this.previewRequestsInFlight === 0 && this.previewLastTargetId === null) {
+          this.previewOriginalTarget = null;
+          this.previewLatestSuccessfulSequence = 0;
+        } else {
+          this.schedulePreviewRestore(transport);
+        }
       }
     }
+  }
+
+  /** Cancel pending follower-preview restoration without disabling future previews. */
+  resetPreviewFocus(): void {
+    this.cancelPreviewRestore();
+    this.previewGeneration++;
+    this.previewOriginalTarget = null;
+    this.previewLastTargetId = null;
+    this.previewLatestSuccessfulSequence = 0;
+    this.previewRequestsInFlight = 0;
   }
 
   private cancelPreviewRestore(): void {

--- a/packages/webapp/src/scoops/tray-leader/cdp-router.ts
+++ b/packages/webapp/src/scoops/tray-leader/cdp-router.ts
@@ -4,6 +4,14 @@ import type { FollowerToLeaderMessage } from '../tray-sync-protocol.js';
 import { reassembleCDPResponse, sendCDPResponse } from '../tray-sync-protocol.js';
 import type { LeaderSyncContext } from './context.js';
 
+const FOLLOWER_PREVIEW_SETTLE_MS = 150;
+
+interface FocusTargetInfo {
+  targetId?: unknown;
+  type?: unknown;
+  active?: unknown;
+}
+
 /** Tracks a CDP request being routed through the leader. */
 export interface PendingCDPRoute {
   /** bootstrapId of the follower that originated the request */
@@ -26,6 +34,12 @@ export class CDPRouter {
   >();
   /** Active transports for the leader's BrowserAPI, keyed by runtimeId:localTargetId. */
   private readonly remoteTransports = new Map<string, RemoteCDPTransport>();
+  private previewOriginalTarget: Promise<string | null> | null = null;
+  private previewLastTargetId: string | null = null;
+  private previewSequence = 0;
+  private previewLatestSuccessfulSequence = 0;
+  private previewRequestsInFlight = 0;
+  private previewRestoreTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     private readonly context: LeaderSyncContext,
@@ -80,7 +94,10 @@ export class CDPRouter {
     }
 
     try {
-      const result = await transport.send(method, params, sessionId);
+      const result =
+        method === 'Page.bringToFront'
+          ? await this.executeFollowerBringToFront(transport, localTargetId, params, sessionId)
+          : await transport.send(method, params, sessionId);
       sendCDPResponse(follower.sync, requestId, result);
     } catch (err) {
       follower.sync.send({
@@ -88,6 +105,183 @@ export class CDPRouter {
         requestId,
         error: err instanceof Error ? err.message : String(err),
       });
+    }
+  }
+
+  private async executeFollowerBringToFront(
+    transport: CDPTransport,
+    localTargetId: string,
+    params: Record<string, unknown> | undefined,
+    sessionId: string | undefined
+  ): Promise<Record<string, unknown>> {
+    const sequence = ++this.previewSequence;
+    this.previewRequestsInFlight++;
+    this.cancelPreviewRestore();
+    this.previewOriginalTarget ??= this.findFocusedTargetId(transport, localTargetId, sessionId);
+
+    try {
+      await this.previewOriginalTarget;
+      const result = await transport.send('Page.bringToFront', params, sessionId);
+      if (sequence > this.previewLatestSuccessfulSequence) {
+        this.previewLatestSuccessfulSequence = sequence;
+        this.previewLastTargetId = localTargetId;
+      }
+      return result;
+    } finally {
+      this.previewRequestsInFlight--;
+      if (this.previewRequestsInFlight === 0 && this.previewLastTargetId === null) {
+        this.previewOriginalTarget = null;
+        this.previewLatestSuccessfulSequence = 0;
+      } else {
+        this.schedulePreviewRestore(transport);
+      }
+    }
+  }
+
+  private cancelPreviewRestore(): void {
+    if (this.previewRestoreTimer === null) return;
+    clearTimeout(this.previewRestoreTimer);
+    this.previewRestoreTimer = null;
+  }
+
+  private schedulePreviewRestore(transport: CDPTransport): void {
+    if (this.previewRequestsInFlight !== 0 || this.previewLastTargetId === null) return;
+    this.cancelPreviewRestore();
+    this.previewRestoreTimer = setTimeout(() => {
+      this.previewRestoreTimer = null;
+      void this.restorePreviewFocus(transport);
+    }, FOLLOWER_PREVIEW_SETTLE_MS);
+  }
+
+  private async restorePreviewFocus(transport: CDPTransport): Promise<void> {
+    const sequence = this.previewLatestSuccessfulSequence;
+    const originalTargetId = await this.previewOriginalTarget;
+    const previewTargetId = this.previewLastTargetId;
+    if (!originalTargetId || !previewTargetId || originalTargetId === previewTargetId) {
+      this.finishPreviewBurst(sequence);
+      return;
+    }
+
+    const focusedTargetId = await this.findFocusedTargetId(transport);
+    if (!this.previewRestoreIsCurrent(sequence)) {
+      this.schedulePreviewRestore(transport);
+      return;
+    }
+    if (focusedTargetId !== previewTargetId) {
+      this.finishPreviewBurst(sequence);
+      return;
+    }
+
+    try {
+      await this.bringTargetToFront(transport, originalTargetId, sequence);
+    } catch (err) {
+      this.context.log.debug('Follower preview focus restore skipped', {
+        targetId: originalTargetId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    this.finishPreviewBurst(sequence);
+  }
+
+  private previewRestoreIsCurrent(sequence: number): boolean {
+    return sequence === this.previewLatestSuccessfulSequence && this.previewRequestsInFlight === 0;
+  }
+
+  private finishPreviewBurst(sequence: number): void {
+    if (!this.previewRestoreIsCurrent(sequence)) return;
+    this.cancelPreviewRestore();
+    this.previewOriginalTarget = null;
+    this.previewLastTargetId = null;
+    this.previewLatestSuccessfulSequence = 0;
+  }
+
+  private async bringTargetToFront(
+    transport: CDPTransport,
+    targetId: string,
+    sequence: number
+  ): Promise<void> {
+    const attached = await transport.send('Target.attachToTarget', {
+      targetId,
+      flatten: true,
+    });
+    const sessionId = attached['sessionId'];
+    if (typeof sessionId !== 'string') return;
+    try {
+      if (!this.previewRestoreIsCurrent(sequence)) return;
+      await transport.send('Page.bringToFront', {}, sessionId);
+    } finally {
+      try {
+        await transport.send('Target.detachFromTarget', { sessionId });
+      } catch {
+        // The target may close while focus is being restored.
+      }
+    }
+  }
+
+  private async findFocusedTargetId(
+    transport: CDPTransport,
+    reusableTargetId?: string,
+    reusableSessionId?: string
+  ): Promise<string | null> {
+    let targetInfos: FocusTargetInfo[];
+    try {
+      const result = await transport.send('Target.getTargets');
+      targetInfos = Array.isArray(result['targetInfos'])
+        ? (result['targetInfos'] as FocusTargetInfo[])
+        : [];
+    } catch {
+      return null;
+    }
+
+    const pages = targetInfos.filter(
+      (target): target is FocusTargetInfo & { targetId: string } =>
+        target.type === 'page' && typeof target.targetId === 'string'
+    );
+    const activeTarget = pages.find((target) => target.active === true);
+    if (activeTarget) return activeTarget.targetId;
+
+    for (const target of pages) {
+      const sessionId = target.targetId === reusableTargetId ? reusableSessionId : undefined;
+      if (await this.targetHasFocus(transport, target.targetId, sessionId)) {
+        return target.targetId;
+      }
+    }
+    return null;
+  }
+
+  private async targetHasFocus(
+    transport: CDPTransport,
+    targetId: string,
+    reusableSessionId?: string
+  ): Promise<boolean> {
+    let sessionId = reusableSessionId;
+    let detach = false;
+    try {
+      if (!sessionId) {
+        const attached = await transport.send('Target.attachToTarget', {
+          targetId,
+          flatten: true,
+        });
+        sessionId = typeof attached['sessionId'] === 'string' ? attached['sessionId'] : undefined;
+        detach = !!sessionId;
+      }
+      if (!sessionId) return false;
+      const evaluated = await transport.send(
+        'Runtime.evaluate',
+        { expression: 'document.hasFocus()', returnByValue: true },
+        sessionId
+      );
+      return (evaluated['result'] as { value?: unknown } | undefined)?.value === true;
+    } catch {
+      return false;
+    } finally {
+      if (detach && sessionId) {
+        try {
+          await transport.send('Target.detachFromTarget', { sessionId });
+        } catch {
+          // The target may disappear during the focus probe.
+        }
+      }
     }
   }
 

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -10,6 +10,7 @@
 import type { BrowserAPI, CDPTransport } from '../../cdp/index.js';
 import { type PanelRpcPushMsg, panelRpcChannelName } from '../../kernel/panel-rpc.js';
 import type { LickEvent } from '../../scoops/lick-manager.js';
+import { TabPersistenceGuard } from '../../scoops/tab-persistence-guard.js';
 import {
   FOLLOWER_STATUS_STORAGE_KEY,
   getFollowerTrayRuntimeStatus,
@@ -101,6 +102,7 @@ export interface WcTrayHandle {
 interface TrayRoleState {
   leader: PageLeaderTrayHandle | null;
   follower: PageFollowerTrayHandle | null;
+  persistenceGuard: TabPersistenceGuard;
   /** Release function for the current leader lock (null when no lock held). */
   lockRelease: (() => void) | null;
 }
@@ -159,6 +161,11 @@ export function createLeaderOptionsFactory(
   const refreshFollowerPresentation = (fallbackCount = 0): void => {
     const followers = state.leader ? getLeaderConnectedFollowers(state.leader) : [];
     const count = fallbackCount;
+    if (count > 0) {
+      state.persistenceGuard.activate();
+    } else {
+      state.persistenceGuard.deactivate();
+    }
     refs.floatbar.setAttribute(
       'label',
       count > 0
@@ -450,6 +457,7 @@ function installRoleSwitchListeners(
     const lockRelease = state.lockRelease;
     state.leader = null;
     state.lockRelease = null;
+    state.persistenceGuard.deactivate();
     clearLeaderHooks();
     const previousFollower = state.follower;
     state.follower = null;
@@ -480,6 +488,7 @@ function installRoleSwitchListeners(
   win.addEventListener(
     'beforeunload',
     () => {
+      state.persistenceGuard.deactivate();
       state.leader?.stop();
       state.follower?.stop();
       state.lockRelease?.();
@@ -498,7 +507,12 @@ export async function wireWcTray(deps: WcTrayDeps): Promise<WcTrayHandle> {
   await loadSprinkleStyles();
 
   const { client, instanceId, window: win, log } = deps;
-  const state: TrayRoleState = { leader: null, follower: null, lockRelease: null };
+  const state: TrayRoleState = {
+    leader: null,
+    follower: null,
+    persistenceGuard: new TabPersistenceGuard(),
+    lockRelease: null,
+  };
   const lockManager = getDefaultLockManager();
 
   const remoteCdpPushChannel =
@@ -552,6 +566,7 @@ export async function wireWcTray(deps: WcTrayDeps): Promise<WcTrayHandle> {
         getLeader: () => state.leader,
         setLeader: (h) => {
           state.leader = h;
+          if (!h) state.persistenceGuard.deactivate();
         },
         getFollower: () => state.follower,
         setFollower: (h) => {

--- a/packages/webapp/tests/cdp/browser-api.test.ts
+++ b/packages/webapp/tests/cdp/browser-api.test.ts
@@ -593,6 +593,22 @@ describe('BrowserAPI', () => {
     });
   });
 
+  describe('bringToFront', () => {
+    it('keeps user-initiated foregrounding permanent', async () => {
+      (mockClient.send as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        sessionId: 'sess-1',
+      });
+      await api.attachToPage('target-1');
+      (mockClient.send as ReturnType<typeof vi.fn>).mockClear();
+
+      await api.bringToFront();
+
+      expect(mockClient.send).toHaveBeenCalledTimes(1);
+      expect(mockClient.send).toHaveBeenCalledWith('Page.bringToFront', {}, 'sess-1');
+      expect(mockClient.send).not.toHaveBeenCalledWith('Target.getTargets');
+    });
+  });
+
   describe('screenshot', () => {
     beforeEach(async () => {
       (mockClient.send as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ sessionId: 'sess-1' });

--- a/packages/webapp/tests/cdp/extension-bridge-transport.test.ts
+++ b/packages/webapp/tests/cdp/extension-bridge-transport.test.ts
@@ -236,6 +236,21 @@ describe('ExtensionBridgeTransport', () => {
     expect(received).toEqual([{ timestamp: 123, sessionId: 'sess-9' }]);
   });
 
+  it('disconnects after an external debugger detach so the client reacquires its session', async () => {
+    const channelId = await connect(transport, port);
+
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId,
+      kind: 'cdp.event',
+      method: 'Target.detachedFromTarget',
+      params: { sessionId: 'sess-9', targetId: '9' },
+    });
+
+    expect(port.disconnected).toBe(true);
+    expect(transport.state).toBe('disconnected');
+  });
+
   it('ignores envelopes whose channelId does not match', async () => {
     await connect(transport, port);
     const received: Array<Record<string, unknown>> = [];

--- a/packages/webapp/tests/cdp/extension-bridge-transport.test.ts
+++ b/packages/webapp/tests/cdp/extension-bridge-transport.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BrowserAPI } from '../../src/cdp/browser-api.js';
 import {
   EXTENSION_BRIDGE_PORT_NAME,
   EXTENSION_BRIDGE_PROTOCOL_VERSION,
@@ -249,6 +250,46 @@ describe('ExtensionBridgeTransport', () => {
 
     expect(port.disconnected).toBe(true);
     expect(transport.state).toBe('disconnected');
+  });
+
+  it('makes BrowserAPI reacquire the same target session after external debugger detach', async () => {
+    const api = new BrowserAPI(transport);
+    const firstAttach = api.attachToPage('9');
+    await Promise.resolve();
+    const firstChannelId = lastChannelId(port);
+    port.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: firstChannelId,
+      kind: 'handshake.welcome',
+    });
+    await replyToCdpRequest(port, 'Target.attachToTarget', { sessionId: '9' });
+    await replyToCdpRequest(port, 'Page.enable', {});
+    await expect(firstAttach).resolves.toBe('9');
+
+    const firstPort = port;
+    firstPort.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: firstChannelId,
+      kind: 'cdp.event',
+      method: 'Target.detachedFromTarget',
+      params: { sessionId: '9', targetId: '9' },
+    });
+
+    const secondPort = nextPort();
+    const secondAttach = api.attachToPage('9');
+    await Promise.resolve();
+    const secondChannelId = lastChannelId(secondPort);
+    secondPort.receive({
+      bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+      channelId: secondChannelId,
+      kind: 'handshake.welcome',
+    });
+    await replyToCdpRequest(secondPort, 'Target.attachToTarget', { sessionId: '9' });
+    await replyToCdpRequest(secondPort, 'Page.enable', {});
+
+    await expect(secondAttach).resolves.toBe('9');
+    expect(cdpRequests(firstPort, 'Target.attachToTarget')).toHaveLength(1);
+    expect(cdpRequests(secondPort, 'Target.attachToTarget')).toHaveLength(1);
   });
 
   it('ignores envelopes whose channelId does not match', async () => {
@@ -517,4 +558,30 @@ async function connect(t: ExtensionBridgeTransport, port: FakePort): Promise<str
   });
   await p;
   return channelId;
+}
+
+function cdpRequests(port: FakePort, method: string): Array<{ id: number }> {
+  return port.posted.filter(
+    (message): message is { id: number } & Record<string, unknown> =>
+      typeof message === 'object' &&
+      message !== null &&
+      (message as { kind?: string }).kind === 'cdp.request' &&
+      (message as { method?: string }).method === method
+  );
+}
+
+async function replyToCdpRequest(
+  port: FakePort,
+  method: string,
+  result: Record<string, unknown>
+): Promise<void> {
+  await vi.waitFor(() => expect(cdpRequests(port, method)).toHaveLength(1));
+  const request = cdpRequests(port, method)[0];
+  port.receive({
+    bridge: EXTENSION_BRIDGE_PROTOCOL_VERSION,
+    channelId: lastChannelId(port),
+    kind: 'cdp.response',
+    id: request.id,
+    result,
+  });
 }

--- a/packages/webapp/tests/scoops/tab-persistence-guard.test.ts
+++ b/packages/webapp/tests/scoops/tab-persistence-guard.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type AudioContextLike,
+  type LockManagerLike,
+  TabPersistenceGuard,
+  type WindowLike,
+} from '../../src/scoops/tab-persistence-guard.js';
+
+function createFakeAudioContext() {
+  const oscillator = { connect: vi.fn(), start: vi.fn(), stop: vi.fn() };
+  const gain = { connect: vi.fn(), gain: { value: 1 } };
+  const ctx: AudioContextLike & { closed: boolean } = {
+    state: 'running',
+    closed: false,
+    resume: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockImplementation(async function (this: typeof ctx) {
+      this.closed = true;
+    }),
+    createOscillator: () => oscillator,
+    createGain: () => gain,
+    destination: {},
+  };
+  return { ctx, oscillator, gain };
+}
+
+function createFakeLockManager() {
+  const requests: Array<{ name: string; signal?: AbortSignal; resolved: boolean }> = [];
+  const manager: LockManagerLike = {
+    request: vi.fn().mockImplementation(async (name, options, callback) => {
+      const entry = { name, signal: options.signal, resolved: false };
+      requests.push(entry);
+      try {
+        await callback();
+      } finally {
+        entry.resolved = true;
+      }
+    }),
+  };
+  return { manager, requests };
+}
+
+function createFakeWindow(): WindowLike & { listeners: Array<() => void> } {
+  const listeners: Array<() => void> = [];
+  return {
+    listeners,
+    addEventListener: (_type, listener) => listeners.push(listener),
+    removeEventListener: (_type, listener) => {
+      const idx = listeners.indexOf(listener);
+      if (idx >= 0) listeners.splice(idx, 1);
+    },
+  };
+}
+
+describe('TabPersistenceGuard', () => {
+  it('starts silent audio, holds a Web Lock, and registers beforeunload on activate', () => {
+    const { ctx, oscillator, gain } = createFakeAudioContext();
+    const { manager, requests } = createFakeLockManager();
+    const win = createFakeWindow();
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => ctx,
+      lockManager: manager,
+      windowRef: win,
+    });
+
+    guard.activate();
+
+    expect(guard.isActive()).toBe(true);
+    expect(oscillator.start).toHaveBeenCalledTimes(1);
+    expect(gain.gain.value).toBe(0);
+    expect(oscillator.connect).toHaveBeenCalledWith(gain);
+    expect(gain.connect).toHaveBeenCalledWith(ctx.destination);
+    expect(requests).toHaveLength(1);
+    expect(requests[0].name).toBe('slicc-tray-leader-active');
+    expect(win.listeners).toHaveLength(1);
+  });
+
+  it('is idempotent — calling activate twice does not double up resources', () => {
+    const { ctx, oscillator } = createFakeAudioContext();
+    const { manager, requests } = createFakeLockManager();
+    const win = createFakeWindow();
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => ctx,
+      lockManager: manager,
+      windowRef: win,
+    });
+
+    guard.activate();
+    guard.activate();
+
+    expect(oscillator.start).toHaveBeenCalledTimes(1);
+    expect(requests).toHaveLength(1);
+    expect(win.listeners).toHaveLength(1);
+  });
+
+  it('releases all resources on deactivate', async () => {
+    const { ctx, oscillator } = createFakeAudioContext();
+    const { manager, requests } = createFakeLockManager();
+    const win = createFakeWindow();
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => ctx,
+      lockManager: manager,
+      windowRef: win,
+    });
+
+    guard.activate();
+    guard.deactivate();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(guard.isActive()).toBe(false);
+    expect(oscillator.stop).toHaveBeenCalledTimes(1);
+    expect(ctx.close).toHaveBeenCalledTimes(1);
+    expect(win.listeners).toHaveLength(0);
+    expect(requests[0].signal?.aborted).toBe(true);
+  });
+
+  it('logs a warning and continues if AudioContext is unavailable', () => {
+    const { manager } = createFakeLockManager();
+    const win = createFakeWindow();
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => null,
+      lockManager: manager,
+      windowRef: win,
+    });
+
+    expect(() => guard.activate()).not.toThrow();
+    expect(guard.isActive()).toBe(true);
+    expect(win.listeners).toHaveLength(1);
+  });
+
+  it('continues to function if Web Lock manager is unavailable', () => {
+    const { ctx } = createFakeAudioContext();
+    const win = createFakeWindow();
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => ctx,
+      lockManager: null,
+      windowRef: win,
+    });
+
+    expect(() => guard.activate()).not.toThrow();
+    expect(guard.isActive()).toBe(true);
+    expect(win.listeners).toHaveLength(1);
+  });
+
+  it('deactivate() is safe when never activated', () => {
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => null,
+      lockManager: null,
+      windowRef: null,
+    });
+    expect(() => guard.deactivate()).not.toThrow();
+    expect(guard.isActive()).toBe(false);
+  });
+
+  it('releases the Web Lock immediately if already aborted when the callback runs', async () => {
+    const { ctx } = createFakeAudioContext();
+    const callbackInvoked = vi.fn();
+    let callbackResolved = false;
+    const manager: LockManagerLike = {
+      request: async (_name, _options, callback) => {
+        await Promise.resolve();
+        callbackInvoked();
+        await callback();
+        callbackResolved = true;
+      },
+    };
+    const guard = new TabPersistenceGuard({
+      audioContextFactory: () => ctx,
+      lockManager: manager,
+      windowRef: createFakeWindow(),
+    });
+
+    guard.activate();
+    guard.deactivate();
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+
+    expect(callbackInvoked).toHaveBeenCalledTimes(1);
+    expect(callbackResolved).toBe(true);
+  });
+});

--- a/packages/webapp/tests/scoops/tray-leader-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader-sync.test.ts
@@ -4,6 +4,7 @@ import type { AgentEvent } from '../../src/core/agent-types.js';
 import { resetLoggerDedupForTests } from '../../src/core/logger.js';
 import { VirtualFS } from '../../src/fs/virtual-fs.js';
 import type { ChatMessage } from '../../src/scoops/chat-types.js';
+import { CDPRouter } from '../../src/scoops/tray-leader/cdp-router.js';
 import {
   isCherryTarget,
   LeaderSyncManager,
@@ -500,6 +501,7 @@ describe('LeaderSyncManager', () => {
   });
 
   it('stop removes all followers', () => {
+    const resetPreviewFocus = vi.spyOn(CDPRouter.prototype, 'resetPreviewFocus');
     const { manager } = createManager();
     const ch1 = new FakeChannel();
     const ch2 = new FakeChannel();
@@ -511,6 +513,8 @@ describe('LeaderSyncManager', () => {
     expect(ch1.readyState).toBe('closed');
     expect(ch2.readyState).toBe('closed');
     expect(manager.hasFollowers).toBe(false);
+    expect(resetPreviewFocus).toHaveBeenCalledOnce();
+    resetPreviewFocus.mockRestore();
   });
 
   it('broadcasts user_message_echo to all followers', () => {

--- a/packages/webapp/tests/scoops/tray-leader/cdp-router.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader/cdp-router.test.ts
@@ -47,7 +47,7 @@ function createHarness(overrides: Partial<LeaderSyncManagerOptions> = {}) {
     sendControl: options.sendControl,
   };
   const router = new CDPRouter(context, { getBridgeTransport: () => undefined });
-  return { followers, router };
+  return { followers, router, log };
 }
 
 function createFocusTransport(
@@ -59,6 +59,7 @@ function createFocusTransport(
   const sessionTargets = new Map<string, string>();
   const bringCalls: string[] = [];
   let focusedTargetId = initialFocus;
+  let failingBringTargetId: string | null = null;
   let sessionCounter = 0;
   const send = vi.fn(
     async (
@@ -101,6 +102,10 @@ function createFocusTransport(
         return { result: { value: targetId === focusedTargetId } };
       }
       if (method === 'Page.bringToFront') {
+        if (targetId === failingBringTargetId) {
+          failingBringTargetId = null;
+          throw new Error('Focus restore failed');
+        }
         focusedTargetId = targetId;
         bringCalls.push(targetId);
         return {};
@@ -122,6 +127,9 @@ function createFocusTransport(
     getFocusedTarget: () => focusedTargetId,
     setFocusedTarget: (targetId: string) => {
       focusedTargetId = targetId;
+    },
+    failNextBringToFront: (targetId: string) => {
+      failingBringTargetId = targetId;
     },
     removeTarget: (targetId: string) => {
       targets.delete(targetId);
@@ -203,6 +211,43 @@ describe('CDPRouter', () => {
 
     expect(focus.getFocusedTarget()).toBe('preview');
     expect(focus.bringCalls).toEqual(['preview']);
+  });
+
+  it('cancels teardown restoration and remains reusable after reset', async () => {
+    vi.useFakeTimers();
+    const focus = createFocusTransport(['leader', 'preview'], 'leader');
+    const { followers, router } = createHarness({ browserTransport: focus.transport });
+    addFollower(followers, 'requester');
+
+    await executePreview(router, 'preview-before-stop', 'preview');
+    router.resetPreviewFocus();
+    await vi.runAllTimersAsync();
+    expect(focus.bringCalls).toEqual(['preview']);
+
+    focus.setFocusedTarget('leader');
+    await executePreview(router, 'preview-after-reset', 'preview');
+    await vi.runAllTimersAsync();
+    expect(focus.bringCalls).toEqual(['preview', 'preview', 'leader']);
+  });
+
+  it('contains a thrown restore without breaking later preview bursts', async () => {
+    vi.useFakeTimers();
+    const focus = createFocusTransport(['leader', 'preview'], 'leader');
+    const { followers, router, log } = createHarness({ browserTransport: focus.transport });
+    addFollower(followers, 'requester');
+
+    await executePreview(router, 'preview-failed-restore', 'preview');
+    focus.failNextBringToFront('leader');
+    await vi.runAllTimersAsync();
+    expect(log.debug).toHaveBeenCalledWith(
+      'Follower preview focus restore skipped',
+      expect.objectContaining({ targetId: 'leader', error: 'Focus restore failed' })
+    );
+
+    focus.setFocusedTarget('leader');
+    await executePreview(router, 'preview-after-failure', 'preview');
+    await vi.runAllTimersAsync();
+    expect(focus.bringCalls).toEqual(['preview', 'preview', 'leader']);
   });
 
   it('reassembles out-of-order chunked responses before forwarding them', () => {

--- a/packages/webapp/tests/scoops/tray-leader/cdp-router.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader/cdp-router.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { CDPTransport } from '../../../src/cdp/transport.js';
 import type { Logger } from '../../../src/core/logger.js';
 import { CDPRouter } from '../../../src/scoops/tray-leader/cdp-router.js';
 import type { LeaderSyncContext } from '../../../src/scoops/tray-leader/context.js';
@@ -49,7 +50,161 @@ function createHarness(overrides: Partial<LeaderSyncManagerOptions> = {}) {
   return { followers, router };
 }
 
+function createFocusTransport(
+  targetIds: string[],
+  initialFocus: string | null,
+  exposeActive = true
+) {
+  const targets = new Set(targetIds);
+  const sessionTargets = new Map<string, string>();
+  const bringCalls: string[] = [];
+  let focusedTargetId = initialFocus;
+  let sessionCounter = 0;
+  const send = vi.fn(
+    async (
+      method: string,
+      params?: Record<string, unknown>,
+      sessionId?: string
+    ): Promise<Record<string, unknown>> => {
+      if (method === 'Target.getTargets') {
+        return {
+          targetInfos: [...targets].map((targetId) => ({
+            targetId,
+            type: 'page',
+            title: targetId,
+            url: `https://${targetId}.example.com`,
+            attached: false,
+            ...(exposeActive ? { active: targetId === focusedTargetId } : {}),
+          })),
+        };
+      }
+      if (method === 'Target.attachToTarget') {
+        const targetId = params?.['targetId'];
+        if (typeof targetId !== 'string' || !targets.has(targetId)) {
+          throw new Error('No target with given id');
+        }
+        const attachedSessionId = `temporary-${targetId}-${++sessionCounter}`;
+        sessionTargets.set(attachedSessionId, targetId);
+        return { sessionId: attachedSessionId };
+      }
+      if (method === 'Target.detachFromTarget') {
+        const detachedSessionId = params?.['sessionId'];
+        if (typeof detachedSessionId === 'string') sessionTargets.delete(detachedSessionId);
+        return {};
+      }
+
+      const targetId =
+        (sessionId ? sessionTargets.get(sessionId) : undefined) ??
+        (sessionId?.startsWith('session-') ? sessionId.slice('session-'.length) : undefined);
+      if (!targetId || !targets.has(targetId)) throw new Error('Session target is gone');
+      if (method === 'Runtime.evaluate') {
+        return { result: { value: targetId === focusedTargetId } };
+      }
+      if (method === 'Page.bringToFront') {
+        focusedTargetId = targetId;
+        bringCalls.push(targetId);
+        return {};
+      }
+      return {};
+    }
+  );
+  return {
+    transport: {
+      state: 'connected',
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      send,
+      on: vi.fn(),
+      off: vi.fn(),
+      once: vi.fn(),
+    } as unknown as CDPTransport,
+    bringCalls,
+    getFocusedTarget: () => focusedTargetId,
+    setFocusedTarget: (targetId: string) => {
+      focusedTargetId = targetId;
+    },
+    removeTarget: (targetId: string) => {
+      targets.delete(targetId);
+    },
+  };
+}
+
+function executePreview(router: CDPRouter, requestId: string, targetId: string): Promise<void> {
+  return router.executeLocalCDP(
+    requestId,
+    targetId,
+    'Page.bringToFront',
+    {},
+    `session-${targetId}`,
+    'requester'
+  );
+}
+
 describe('CDPRouter', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('restores focus once after a burst of follower previews', async () => {
+    vi.useFakeTimers();
+    const focus = createFocusTransport(['leader', 'tab-1', 'tab-2', 'tab-3'], 'leader', false);
+    const { followers, router } = createHarness({ browserTransport: focus.transport });
+    addFollower(followers, 'requester');
+
+    await Promise.all([
+      executePreview(router, 'preview-1', 'tab-1'),
+      executePreview(router, 'preview-2', 'tab-2'),
+      executePreview(router, 'preview-3', 'tab-3'),
+    ]);
+    expect(focus.getFocusedTarget()).toBe('tab-3');
+
+    await vi.runAllTimersAsync();
+
+    expect(focus.getFocusedTarget()).toBe('leader');
+    expect(focus.bringCalls).toEqual(['tab-1', 'tab-2', 'tab-3', 'leader']);
+  });
+
+  it('does not restore when the user switches tabs during the settle window', async () => {
+    vi.useFakeTimers();
+    const focus = createFocusTransport(['leader', 'preview', 'user-choice'], 'leader');
+    const { followers, router } = createHarness({ browserTransport: focus.transport });
+    addFollower(followers, 'requester');
+
+    await executePreview(router, 'preview-1', 'preview');
+    focus.setFocusedTarget('user-choice');
+    await vi.runAllTimersAsync();
+
+    expect(focus.getFocusedTarget()).toBe('user-choice');
+    expect(focus.bringCalls).toEqual(['preview']);
+  });
+
+  it('does not restore when the previously focused target is gone', async () => {
+    vi.useFakeTimers();
+    const focus = createFocusTransport(['leader', 'preview'], 'leader');
+    const { followers, router } = createHarness({ browserTransport: focus.transport });
+    addFollower(followers, 'requester');
+
+    await executePreview(router, 'preview-1', 'preview');
+    focus.removeTarget('leader');
+    await vi.runAllTimersAsync();
+
+    expect(focus.getFocusedTarget()).toBe('preview');
+    expect(focus.bringCalls).toEqual(['preview']);
+  });
+
+  it('does not restore when no focused target can be determined', async () => {
+    vi.useFakeTimers();
+    const focus = createFocusTransport(['preview'], null, false);
+    const { followers, router } = createHarness({ browserTransport: focus.transport });
+    addFollower(followers, 'requester');
+
+    await executePreview(router, 'preview-1', 'preview');
+    await vi.runAllTimersAsync();
+
+    expect(focus.getFocusedTarget()).toBe('preview');
+    expect(focus.bringCalls).toEqual(['preview']);
+  });
+
   it('reassembles out-of-order chunked responses before forwarding them', () => {
     const { followers, router } = createHarness();
     const requester = addFollower(followers, 'requester');

--- a/packages/webapp/tests/ui/wc/wc-tray-followers.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-tray-followers.test.ts
@@ -192,8 +192,12 @@ describe('WC tray connected follower mapping', () => {
     const state = {
       leader: handle,
       follower: null,
+      persistenceGuard: {
+        activate: vi.fn(),
+        deactivate: vi.fn(),
+      },
       lockRelease: null,
-    } as Parameters<typeof createLeaderOptionsFactory>[1];
+    } as unknown as Parameters<typeof createLeaderOptionsFactory>[1];
     const options = createLeaderOptionsFactory(
       deps,
       state,

--- a/packages/webapp/tests/ui/wc/wc-tray.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-tray.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "https://www.sliccy.ai/" }
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const guardMocks = vi.hoisted(() => ({
+  instances: [] as Array<{
+    activate: ReturnType<typeof vi.fn>;
+    deactivate: ReturnType<typeof vi.fn>;
+  }>,
+}));
+const trayMocks = vi.hoisted(() => ({
+  options: null as Record<string, unknown> | null,
+  stop: vi.fn(),
+}));
+
+vi.mock('../../../src/scoops/tab-persistence-guard.js', () => ({
+  TabPersistenceGuard: class {
+    activate = vi.fn();
+    deactivate = vi.fn();
+
+    constructor() {
+      guardMocks.instances.push(this);
+    }
+  },
+}));
+
+vi.mock('../../../src/ui/page-leader-tray.js', () => ({
+  getLeaderFollowerStates: () => [],
+  startPageLeaderTray: (options: Record<string, unknown>) => {
+    trayMocks.options = options;
+    return {
+      ready: Promise.resolve(),
+      stop: trayMocks.stop,
+      reset: vi.fn(),
+      scheduleScoopsListBroadcast: vi.fn(),
+      peers: { getPeers: () => [] },
+      sync: {
+        broadcastSnapshot: vi.fn(),
+        broadcastSprinkleUpdate: vi.fn(),
+        broadcastSprinkleReloaded: vi.fn(),
+        broadcastUserMessage: vi.fn(),
+        broadcastStatus: vi.fn(),
+        broadcastTheme: vi.fn(),
+        getExecCapableBootstrapIds: () => new Set(),
+        getBrowserCapableBootstrapIds: () => new Set(),
+        getFollowerMotds: () => new Map(),
+      },
+    };
+  },
+}));
+
+vi.mock('../../../src/ui/page-follower-tray.js', () => ({
+  startPageFollowerTray: vi.fn(),
+}));
+vi.mock('../../../src/ui/legacy-styles.js', () => ({
+  loadSprinkleStyles: vi.fn(async () => {}),
+}));
+vi.mock('../../../src/ui/boot/setup-standalone-panel-rpc.js', () => ({
+  setupStandalonePanelRpc: vi.fn(async () => {}),
+}));
+vi.mock('../../../src/ui/boot/setup-standalone-tray-init-hosted.js', () => ({
+  runHostedBootstrap: vi.fn(async () => {}),
+}));
+vi.mock('../../../src/ui/remote-cdp-page-bridge.js', () => ({
+  createRemoteCdpPageBridge: () => ({
+    cleanupRuntime: vi.fn(),
+    disposeAll: vi.fn(),
+  }),
+}));
+vi.mock('../../../src/ui/tray-leader-lock.js', () => ({
+  acquireLeaderRole: vi.fn(),
+  getDefaultLockManager: () => null,
+  requestLeaderLock: vi.fn(),
+}));
+vi.mock('../../../src/ui/wc/wc-floatbar-online.js', () => ({
+  installFloatbarOnline: vi.fn(),
+}));
+vi.mock('../../../src/shell/supplemental-commands/host-command.js', () => ({
+  getConnectedFollowers: () => [],
+  setConnectedFollowersGetter: vi.fn(),
+  setTrayResetter: vi.fn(),
+  writeConnectedFollowersToShim: vi.fn(),
+}));
+vi.mock('../../../src/scoops/tray-leader.js', () => ({
+  getLeaderTrayRuntimeStatus: () => ({ state: 'inactive' }),
+  subscribeToLeaderTrayRuntimeStatus: vi.fn(),
+}));
+vi.mock('../../../src/scoops/tray-follower-status.js', () => ({
+  FOLLOWER_STATUS_STORAGE_KEY: 'slicc.followerTrayStatus',
+  getFollowerTrayRuntimeStatus: () => ({ state: 'inactive' }),
+  subscribeToFollowerTrayRuntimeStatus: vi.fn(),
+}));
+vi.mock('../../../src/ui/theme-engine.js', () => ({
+  getActiveThemeId: () => 'default',
+  getActiveThemeJson: () => ({}),
+  setThemeChangeListener: vi.fn(),
+}));
+
+import { TRAY_WORKER_STORAGE_KEY } from '../../../src/scoops/tray-runtime-config.js';
+import { wireWcTray } from '../../../src/ui/wc/wc-tray.js';
+
+function makeDeps() {
+  const floatbar = document.createElement('div');
+  const data = new Map([[TRAY_WORKER_STORAGE_KEY, 'https://tray.example.com']]);
+  const testWindow = Object.assign(new EventTarget(), {
+    localStorage: {
+      getItem: (key: string) => data.get(key) ?? null,
+      setItem: (key: string, value: string) => data.set(key, value),
+      removeItem: (key: string) => data.delete(key),
+    },
+  });
+  const deps = {
+    refs: { floatbar, switcher: { scoops: [] } },
+    client: {
+      setForwardLickHandler: vi.fn(),
+      getScoops: () => [],
+    },
+    browser: {},
+    realCdpTransport: {},
+    instanceId: 'test-instance',
+    runtimeMode: 'hosted-leader',
+    sprinkleManager: {
+      opened: () => [],
+      available: () => [],
+      setSendToSprinkleHook: vi.fn(),
+      setReloadHook: vi.fn(),
+    },
+    addSprinkle: vi.fn(),
+    removeSprinkle: vi.fn(),
+    getController: () => null,
+    getSelectedJid: () => 'cone',
+    agentHandle: { sendMessage: vi.fn(), stop: vi.fn(), onEvent: vi.fn() },
+    openFs: vi.fn(),
+    openWriter: vi.fn(),
+    window: testWindow,
+    log: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), stage: vi.fn() },
+  };
+  return { deps, testWindow };
+}
+
+describe('wireWcTray tab persistence guard', () => {
+  beforeEach(() => {
+    guardMocks.instances.length = 0;
+    trayMocks.options = null;
+    trayMocks.stop.mockClear();
+  });
+
+  it('uses one guard for follower transitions and deactivates it when the leader stops', async () => {
+    const { deps, testWindow } = makeDeps();
+    await wireWcTray(deps as never);
+
+    expect(guardMocks.instances).toHaveLength(1);
+    const guard = guardMocks.instances[0];
+    const onFollowerCountChanged = trayMocks.options?.onFollowerCountChanged as (
+      count: number
+    ) => void;
+
+    onFollowerCountChanged(1);
+    expect(guard.activate).toHaveBeenCalledTimes(1);
+    onFollowerCountChanged(0);
+    expect(guard.deactivate).toHaveBeenCalledTimes(1);
+
+    onFollowerCountChanged(1);
+    testWindow.dispatchEvent(new Event('beforeunload'));
+    expect(guard.deactivate).toHaveBeenCalledTimes(2);
+    expect(trayMocks.stop).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Follower-driven tab previews now restore the SLICC leader tab instead of permanently stealing focus. Leader keepalive is also restored while followers are attached, and the Chrome extension bridge recovers safely across debugger detach events.

## Why

Follower previews must briefly foreground a target before capture, but the previous flow could leave that target active. The resulting leader throttling or discard could drop the tray connection. Separately, the leader's silent-audio, Web Lock, and beforeunload keepalive wiring had been lost.

## Approach / Implementation notes

- CDPRouter owns follower-preview focus restoration, with burst coalescing and manual-switch detection.
- TabPersistenceGuard is restored and wired across leader paths.
- The extension bridge remains a thin proxy for Page.bringToFront for hosted and extension parity.
- Debugger-attachment ownership is symmetric in service-worker.ts, so only the attaching consumer can detach.
- External debugger detach invalidates bridge PortState so reattachment works after DevTools closes.

## Cross-cutting impact

The hosted/standalone leader and Chrome extension float use the same CDPRouter focus policy. The extension adds only the visible-tab activation required by chrome.debugger parity. No iOS, Go follower, Electron, or cloud protocol changes are required.

## Test plan

- [x] Pre-push verification passed: 7/7 checks
- [x] Typecheck passed
- [x] Chrome extension tests passed: 20/20 files, 350/350 tests
- [x] Webapp CDP tests passed: 75/75 suites, 288/288 tests
- [x] Chrome extension coverage passed: 84.61% statements, 73.44% branches, 76.89% functions, 85.66% lines
- [x] Root webapp build passed
- [x] Chrome extension build passed
- [x] Bundle-size passed for webapp and extension outputs
- [x] Touched-file debt gate passed: 18 changed files, 0 on any debt list
- [x] New and changed behavior is covered by mirrored unit tests

**Pre-existing failures**: None in the scoped verification.

## Documentation

- [x] Relevant CLAUDE.md files
- [x] docs/ agent reference
- [ ] README.md
- [ ] Agent-facing runtime skill documentation

## Risk & rollback

The main risk is real-Chrome focus timing across preview bursts and debugger lifecycle events. The commits are isolated and can be reverted independently to remove focus restoration, keepalive, or attachment-ownership behavior.

## Known limitations

The cross-consumer lease count for the legacy offscreen CDP handlers is deferred. No shipped code path currently reaches those handlers, and deleting them in a follow-up is a cleaner solution than expanding dead compatibility code in this fix.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under dist
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Cross-float focus and debugger ownership paths were checked
