### PR TITLE
fix(ios-app): mirror the follower scoop mapping and rotate tilt axes

### DIFF
--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -153,11 +153,12 @@ output are unsupported.
 
 `SliccAgentAvatarView` follows `webcomponents/src/switcher/slicc-agent-avatar.ts`;
 `Models/SliccAgentAvatarGeometry.swift` is its parity contract. `ScoopSwitcher`
-maps the selected `ScoopSummary` to web defaults and renders a 20pt nav-bar avatar;
+maps the selected `ScoopSummary` like `toFollowerSwitcherScoops` into a 20pt avatar;
 menu rows stay textual because custom shapes do not render there. The decorative
 avatar is accessibility-hidden beside its label. `Models/SliccAgentAvatarTilt.swift`
-seams CoreMotion; disappearance, reduce-motion, unavailable hardware, and closed
-eyes stop updates and center pupils. `-uiTestAvatarFixture` renders screenshots.
+seams CoreMotion with orientation-aware screen axes; disappearance, reduce-motion,
+unavailable hardware, and closed eyes stop updates and center pupils.
+`-uiTestAvatarFixture` renders screenshots.
 
 ## Build
 

--- a/packages/ios-app/SliccFollower/Models/SliccAgentAvatarGeometry.swift
+++ b/packages/ios-app/SliccFollower/Models/SliccAgentAvatarGeometry.swift
@@ -97,9 +97,25 @@ struct SliccAgentAvatarGeometry: Equatable, Sendable {
 extension ScoopSummary {
     func avatarGeometry(sideLength: Double = 26) -> SliccAgentAvatarGeometry {
         let type: SliccAgentAvatarGeometry.AvatarType = isCone ? .cone : .scoop
-        // Mirrors DEFAULT_COLOR in slicc-agent-avatar.ts; ScoopSummary carries no color.
-        let color = isCone ? "#D2691E" : "#FFB6C1"
+        let state = state ?? "idle"
+        let eyes: SliccAgentAvatarGeometry.EyeState
+        switch state {
+        case "broken": eyes = .dead
+        case "initializing": eyes = .none
+        default: eyes = .open
+        }
         return .init(
-            type: type, color: color, eyes: .open, fill: fill ?? 0, sideLength: sideLength)
+            type: type, color: avatarColor, eyes: eyes, fill: fill ?? 0,
+            blink: state == "working", sideLength: sideLength)
+    }
+
+    /// Mirrors `scoopColor`: UInt32 wrapping over the name's UTF-16 code units.
+    private var avatarColor: String {
+        if isCone { return "#b07823" }
+        let palette = ["#06b6d4", "#8b5cf6", "#f59e0b", "#10b981", "#3b82f6", "#ef4444"]
+        let hash = name.utf16.reduce(UInt32.zero) { hash, codeUnit in
+            hash &* 31 &+ UInt32(codeUnit)
+        }
+        return palette[Int(hash % UInt32(palette.count))]
     }
 }

--- a/packages/ios-app/SliccFollower/Models/SliccAgentAvatarGeometry.swift
+++ b/packages/ios-app/SliccFollower/Models/SliccAgentAvatarGeometry.swift
@@ -109,12 +109,17 @@ extension ScoopSummary {
             blink: state == "working", sideLength: sideLength)
     }
 
-    /// Mirrors `scoopColor`: UInt32 wrapping over the name's UTF-16 code units.
+    /// Mirrors `scoopColor`: JS iterates scalars, while `charCodeAt(0)` deliberately
+    /// hashes only each scalar's first UTF-16 unit (dropping an astral low surrogate).
     private var avatarColor: String {
         if isCone { return "#b07823" }
         let palette = ["#06b6d4", "#8b5cf6", "#f59e0b", "#10b981", "#3b82f6", "#ef4444"]
-        let hash = name.utf16.reduce(UInt32.zero) { hash, codeUnit in
-            hash &* 31 &+ UInt32(codeUnit)
+        let hash = name.unicodeScalars.reduce(UInt32.zero) { hash, scalar in
+            let firstCodeUnit: UInt32 =
+                scalar.value <= 0xFFFF
+                ? scalar.value
+                : 0xD800 + ((scalar.value - 0x10000) >> 10)
+            return hash &* 31 &+ firstCodeUnit
         }
         return palette[Int(hash % UInt32(palette.count))]
     }

--- a/packages/ios-app/SliccFollower/Models/SliccAgentAvatarTilt.swift
+++ b/packages/ios-app/SliccFollower/Models/SliccAgentAvatarTilt.swift
@@ -1,12 +1,20 @@
 import Combine
 import CoreMotion
 import Foundation
+import UIKit
 
 struct SliccAgentAvatarAttitude: Equatable, Sendable {
     static let zero = Self(roll: 0, pitch: 0)
 
     let roll: Double
     let pitch: Double
+}
+
+enum SliccAgentAvatarInterfaceOrientation: Equatable, Sendable {
+    case portrait
+    case portraitUpsideDown
+    case landscapeLeft
+    case landscapeRight
 }
 
 /// Lifecycle seam for deterministic previews/tests and the CoreMotion implementation.
@@ -90,14 +98,31 @@ struct SliccAgentAvatarTiltMapping: Sendable {
         for attitude: SliccAgentAvatarAttitude,
         geometry: SliccAgentAvatarGeometry,
         reduceMotion: Bool,
-        isDeviceMotionAvailable: Bool
+        isDeviceMotionAvailable: Bool,
+        orientation: SliccAgentAvatarInterfaceOrientation = .portrait
     ) -> SliccAgentAvatarGeometry.Point {
         guard !reduceMotion, isDeviceMotionAvailable, fullTravelTilt > 0 else {
             return .init(x: 0, y: 0)
         }
         let scale = geometry.maxPupilTravel / fullTravelTilt
-        return geometry.clampedPupilOffset(
-            .init(x: attitude.roll * scale, y: -attitude.pitch * scale))
+        let screenAxes = screenAxes(for: attitude, orientation: orientation)
+        return geometry.clampedPupilOffset(.init(x: screenAxes.x * scale, y: screenAxes.y * scale))
+    }
+
+    private func screenAxes(
+        for attitude: SliccAgentAvatarAttitude,
+        orientation: SliccAgentAvatarInterfaceOrientation
+    ) -> SliccAgentAvatarGeometry.Point {
+        switch orientation {
+        case .portrait:
+            .init(x: attitude.roll, y: -attitude.pitch)
+        case .portraitUpsideDown:
+            .init(x: -attitude.roll, y: attitude.pitch)
+        case .landscapeLeft:
+            .init(x: -attitude.pitch, y: -attitude.roll)
+        case .landscapeRight:
+            .init(x: attitude.pitch, y: attitude.roll)
+        }
     }
 
     func smoothedOffset(
@@ -118,16 +143,21 @@ final class SliccAgentAvatarTiltController: ObservableObject {
 
     private let source: any SliccAgentAvatarTiltSource
     private let mapping: SliccAgentAvatarTiltMapping
+    private let interfaceOrientation: @MainActor () -> SliccAgentAvatarInterfaceOrientation
     private var geometry: SliccAgentAvatarGeometry?
     private var motionDisabled = false
     private var isUpdating = false
 
     init(
         source: any SliccAgentAvatarTiltSource,
-        mapping: SliccAgentAvatarTiltMapping = .init()
+        mapping: SliccAgentAvatarTiltMapping = .init(),
+        interfaceOrientation: @escaping @MainActor () -> SliccAgentAvatarInterfaceOrientation = {
+            SliccAgentAvatarTiltController.currentInterfaceOrientation
+        }
     ) {
         self.source = source
         self.mapping = mapping
+        self.interfaceOrientation = interfaceOrientation
     }
 
     func update(geometry: SliccAgentAvatarGeometry, motionDisabled: Bool) {
@@ -154,7 +184,21 @@ final class SliccAgentAvatarTiltController: ObservableObject {
         guard let geometry else { return }
         let target = mapping.pupilOffset(
             for: attitude, geometry: geometry, reduceMotion: motionDisabled,
-            isDeviceMotionAvailable: source.isDeviceMotionAvailable)
+            isDeviceMotionAvailable: source.isDeviceMotionAvailable,
+            orientation: interfaceOrientation())
         pupilOffset = mapping.smoothedOffset(from: pupilOffset, toward: target)
+    }
+
+    private static var currentInterfaceOrientation: SliccAgentAvatarInterfaceOrientation {
+        let orientation = UIApplication.shared.connectedScenes.lazy
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }?
+            .interfaceOrientation
+        switch orientation {
+        case .portraitUpsideDown: return .portraitUpsideDown
+        case .landscapeLeft: return .landscapeLeft
+        case .landscapeRight: return .landscapeRight
+        default: return .portrait
+        }
     }
 }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SliccAgentAvatarGeometryTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SliccAgentAvatarGeometryTests.swift
@@ -83,7 +83,8 @@ final class SliccAgentAvatarGeometryTests: XCTestCase {
         let reviewer = scoopSummary(isCone: false, name: "reviewer", fill: 82).avatarGeometry(
             sideLength: 24)
         let coder = scoopSummary(isCone: false, name: "coder", fill: 64).avatarGeometry()
-        let astralScalar = scoopSummary(isCone: false, name: "🚀", fill: 12).avatarGeometry()
+        let rocket = scoopSummary(isCone: false, name: "🚀", fill: 12).avatarGeometry()
+        let pileOfPoo = scoopSummary(isCone: false, name: "💩", fill: 12).avatarGeometry()
 
         XCTAssertEqual(cone.type, .cone)
         XCTAssertEqual(cone.color, "#b07823")
@@ -95,7 +96,8 @@ final class SliccAgentAvatarGeometryTests: XCTestCase {
         XCTAssertEqual(reviewer.fill, 82)
         XCTAssertEqual(reviewer.sideLength, 24)
         XCTAssertEqual(coder.color, "#10b981")
-        XCTAssertEqual(astralScalar.color, "#8b5cf6")
+        XCTAssertEqual(rocket.color, "#8b5cf6")
+        XCTAssertEqual(pileOfPoo.color, "#8b5cf6")
         XCTAssertNotEqual(reviewer.color, coder.color)
     }
 

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SliccAgentAvatarGeometryTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SliccAgentAvatarGeometryTests.swift
@@ -58,20 +58,41 @@ final class SliccAgentAvatarGeometryTests: XCTestCase {
         XCTAssertEqual(geometry.sideLength, 0)
     }
 
-    func testScoopSummaryMapsTypeFillEyesAndWebDefaultColors() {
+    func testScoopSummaryMapsTypeFillAndBrowserPaletteColors() {
         let cone = scoopSummary(isCone: true, fill: 42).avatarGeometry(sideLength: 22)
-        let scoop = scoopSummary(isCone: false, fill: 82).avatarGeometry(sideLength: 24)
+        let reviewer = scoopSummary(isCone: false, name: "reviewer", fill: 82).avatarGeometry(
+            sideLength: 24)
+        let coder = scoopSummary(isCone: false, name: "coder", fill: 64).avatarGeometry()
+        let unicode = scoopSummary(isCone: false, name: "🍨", fill: 12).avatarGeometry()
 
         XCTAssertEqual(cone.type, .cone)
-        XCTAssertEqual(cone.color, "#D2691E")
+        XCTAssertEqual(cone.color, "#b07823")
         XCTAssertEqual(cone.eyes, .open)
         XCTAssertEqual(cone.fill, 42)
         XCTAssertEqual(cone.sideLength, 22)
-        XCTAssertEqual(scoop.type, .scoop)
-        XCTAssertEqual(scoop.color, "#FFB6C1")
-        XCTAssertEqual(scoop.eyes, .open)
-        XCTAssertEqual(scoop.fill, 82)
-        XCTAssertEqual(scoop.sideLength, 24)
+        XCTAssertEqual(reviewer.type, .scoop)
+        XCTAssertEqual(reviewer.color, "#ef4444")
+        XCTAssertEqual(reviewer.fill, 82)
+        XCTAssertEqual(reviewer.sideLength, 24)
+        XCTAssertEqual(coder.color, "#10b981")
+        XCTAssertEqual(unicode.color, "#06b6d4")
+        XCTAssertNotEqual(reviewer.color, coder.color)
+    }
+
+    func testScoopSummaryMapsEveryLifecycleState() {
+        let cases: [(String?, SliccAgentAvatarGeometry.EyeState, Bool)] = [
+            (nil, .open, false),
+            ("idle", .open, false),
+            ("working", .open, true),
+            ("broken", .dead, false),
+            ("initializing", .none, false),
+        ]
+
+        for (state, eyes, blink) in cases {
+            let geometry = scoopSummary(isCone: false, state: state, fill: 50).avatarGeometry()
+            XCTAssertEqual(geometry.eyes, eyes, "Unexpected eyes for state \(state ?? "absent")")
+            XCTAssertEqual(geometry.blink, blink, "Unexpected blink for state \(state ?? "absent")")
+        }
     }
 
     func testScoopSummaryNilFillMapsToZero() {
@@ -98,13 +119,32 @@ final class SliccAgentAvatarGeometryTests: XCTestCase {
             hypot(offset.x, offset.y), tiltGeometry.maxPupilTravel, accuracy: accuracy)
     }
 
-    func testTiltDirectionSignsMatchScreenCoordinates() {
+    func testPortraitTiltOutputPreservesScreenCoordinateMapping() {
         let offset = tiltMapping.pupilOffset(
             for: .init(roll: 0.1, pitch: 0.2), geometry: tiltGeometry,
             reduceMotion: false, isDeviceMotionAvailable: true)
+        let scale = tiltGeometry.maxPupilTravel / SliccAgentAvatarTiltMapping.defaultFullTravelTilt
 
-        XCTAssertGreaterThan(offset.x, 0)
-        XCTAssertLessThan(offset.y, 0)
+        XCTAssertEqual(offset.x, 0.1 * scale, accuracy: accuracy)
+        XCTAssertEqual(offset.y, -0.2 * scale, accuracy: accuracy)
+    }
+
+    func testLandscapeOrientationsSwapAxesWithOppositeSigns() {
+        let attitude = SliccAgentAvatarAttitude(roll: 0.1, pitch: 0.2)
+        let portrait = tiltMapping.pupilOffset(
+            for: attitude, geometry: tiltGeometry, reduceMotion: false,
+            isDeviceMotionAvailable: true, orientation: .portrait)
+        let landscapeLeft = tiltMapping.pupilOffset(
+            for: attitude, geometry: tiltGeometry, reduceMotion: false,
+            isDeviceMotionAvailable: true, orientation: .landscapeLeft)
+        let landscapeRight = tiltMapping.pupilOffset(
+            for: attitude, geometry: tiltGeometry, reduceMotion: false,
+            isDeviceMotionAvailable: true, orientation: .landscapeRight)
+
+        XCTAssertEqual(landscapeLeft.x, portrait.y, accuracy: accuracy)
+        XCTAssertEqual(landscapeLeft.y, -portrait.x, accuracy: accuracy)
+        XCTAssertEqual(landscapeRight.x, -portrait.y, accuracy: accuracy)
+        XCTAssertEqual(landscapeRight.y, portrait.x, accuracy: accuracy)
     }
 
     func testReducedMotionAndUnavailableMotionCenterPupils() {
@@ -201,11 +241,14 @@ final class SliccAgentAvatarGeometryTests: XCTestCase {
         .init()
     }
 
-    private func scoopSummary(isCone: Bool, fill: Double?) -> ScoopSummary {
-        .init(
-            jid: isCone ? "cone" : "reviewer", name: isCone ? "sliccy" : "reviewer",
-            folder: isCone ? "/workspace" : "/scoops/reviewer", isCone: isCone,
-            assistantLabel: isCone ? "Sliccy" : "Reviewer", trigger: nil, state: nil,
+    private func scoopSummary(
+        isCone: Bool, name: String? = nil, state: String? = nil, fill: Double?
+    ) -> ScoopSummary {
+        let scoopName = name ?? (isCone ? "sliccy" : "reviewer")
+        return .init(
+            jid: isCone ? "cone" : scoopName, name: scoopName,
+            folder: isCone ? "/workspace" : "/scoops/\(scoopName)", isCone: isCone,
+            assistantLabel: isCone ? "Sliccy" : "Reviewer", trigger: nil, state: state,
             fill: fill)
     }
 }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SliccAgentAvatarGeometryTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SliccAgentAvatarGeometryTests.swift
@@ -3,6 +3,26 @@ import XCTest
 @testable import SliccFollower
 
 @MainActor
+private final class ManuallyEmittingAvatarTiltSource: SliccAgentAvatarTiltSource {
+    var isDeviceMotionAvailable = true
+    private var handler: (@MainActor (SliccAgentAvatarAttitude) -> Void)?
+
+    func startDeviceMotionUpdates(
+        _ handler: @escaping @MainActor (SliccAgentAvatarAttitude) -> Void
+    ) {
+        self.handler = handler
+    }
+
+    func stopDeviceMotionUpdates() {
+        handler = nil
+    }
+
+    func emit(_ attitude: SliccAgentAvatarAttitude) {
+        handler?(attitude)
+    }
+}
+
+@MainActor
 final class SliccAgentAvatarGeometryTests: XCTestCase {
     private let accuracy = 0.000_001
 
@@ -63,7 +83,7 @@ final class SliccAgentAvatarGeometryTests: XCTestCase {
         let reviewer = scoopSummary(isCone: false, name: "reviewer", fill: 82).avatarGeometry(
             sideLength: 24)
         let coder = scoopSummary(isCone: false, name: "coder", fill: 64).avatarGeometry()
-        let unicode = scoopSummary(isCone: false, name: "🍨", fill: 12).avatarGeometry()
+        let astralScalar = scoopSummary(isCone: false, name: "🚀", fill: 12).avatarGeometry()
 
         XCTAssertEqual(cone.type, .cone)
         XCTAssertEqual(cone.color, "#b07823")
@@ -75,7 +95,7 @@ final class SliccAgentAvatarGeometryTests: XCTestCase {
         XCTAssertEqual(reviewer.fill, 82)
         XCTAssertEqual(reviewer.sideLength, 24)
         XCTAssertEqual(coder.color, "#10b981")
-        XCTAssertEqual(unicode.color, "#06b6d4")
+        XCTAssertEqual(astralScalar.color, "#8b5cf6")
         XCTAssertNotEqual(reviewer.color, coder.color)
     }
 
@@ -182,6 +202,39 @@ final class SliccAgentAvatarGeometryTests: XCTestCase {
         controller.update(geometry: tiltGeometry, motionDisabled: false)
 
         XCTAssertEqual(source.startCallCount, 1)
+    }
+
+    func testTiltControllerReadsInjectedOrientationForEveryMotionSample() {
+        let source = ManuallyEmittingAvatarTiltSource()
+        var orientation = SliccAgentAvatarInterfaceOrientation.portrait
+        var orientationReadCount = 0
+        let controller = SliccAgentAvatarTiltController(
+            source: source,
+            interfaceOrientation: {
+                orientationReadCount += 1
+                return orientation
+            })
+        let attitude = SliccAgentAvatarAttitude(roll: 0.1, pitch: 0.2)
+        controller.update(geometry: tiltGeometry, motionDisabled: false)
+
+        source.emit(attitude)
+        let portraitTarget = tiltMapping.pupilOffset(
+            for: attitude, geometry: tiltGeometry, reduceMotion: false,
+            isDeviceMotionAvailable: true, orientation: .portrait)
+        let portraitOffset = tiltMapping.smoothedOffset(
+            from: .init(x: 0, y: 0), toward: portraitTarget)
+        XCTAssertEqual(controller.pupilOffset, portraitOffset)
+        XCTAssertEqual(orientationReadCount, 1)
+
+        orientation = .landscapeRight
+        source.emit(attitude)
+        let landscapeTarget = tiltMapping.pupilOffset(
+            for: attitude, geometry: tiltGeometry, reduceMotion: false,
+            isDeviceMotionAvailable: true, orientation: .landscapeRight)
+        let landscapeOffset = tiltMapping.smoothedOffset(
+            from: portraitOffset, toward: landscapeTarget)
+        XCTAssertEqual(controller.pupilOffset, landscapeOffset)
+        XCTAssertEqual(orientationReadCount, 2)
     }
 
     func testTiltControllerMotionDisabledStopsAndCenters() {


### PR DESCRIPTION
## Summary

- mirror the browser follower's scoop color and lifecycle mapping in `ScoopSummary.avatarGeometry`
- rotate Core Motion roll/pitch into current interface-orientation screen axes
- add regression coverage for UTF-16/UInt32 palette hashing, every lifecycle state, unchanged portrait output, and both landscape orientations
- update the iOS agent-avatar guide while staying below its size limit

## Codex follow-up from #1903

This closes the three actionable findings:

- lifecycle-specific eyes/blink: https://github.com/ai-ecoverse/slicc/pull/1903#discussion_r3706372967
- stable hashed scoop colors: https://github.com/ai-ecoverse/slicc/pull/1903#discussion_r3706372982
- landscape motion coordinates: https://github.com/ai-ecoverse/slicc/pull/1903#discussion_r3706372988

The P1 `NSMotionUsageDescription` finding is a false positive: Apple DTS states that the key does not gate `CMMotionManager` (it applies to `CMPedometer`, `CMMotionActivityManager`, and `CMSensorRecorder`), so no privacy-key change is included. The cone/scoop SVG glyph port is deferred to separate work; this PR deliberately leaves the existing `Ellipse` renderer unchanged.

## Verification

- `npm run lint` — passed
- `node packages/dev-tools/tools/check-touched-exemptions.mjs` — passed (4 changed files, 0 debt-list entries)
- `swiftlint lint` — passed (0 serious violations)
- `swift format lint --strict --parallel --recursive SliccFollower Package.swift` — passed
- focused avatar suite — 19 tests, 0 failures
- `swift-coverage-check.sh --xcodebuild` — passed: lines 66.09% (floor 59%), functions 57.00% (floor 46%), regions 57.37% (floor 50%)

`coverage-thresholds.json` is untouched.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author