### PR TITLE
fix(ios-app): settle streaming turns without turn_end

### DIFF
--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -181,14 +181,11 @@ picks a simulator, enables coverage and on-failure retries, and enforces the
   --xcodebuild SliccFollower packages/ios-app SliccFollower
 ```
 
-Outputs land in `.build/coverage/` (`summary.json`, `lcov.info`,
-`ios-app.xcresult` with per-test durations). Neither bundle is `parallelizable`: the unit tests total
-~7s, so cloning simulators only raced the UI runner, which then fails preflight
-with `Busy` or dies on `Timed out while loading Accessibility`.
-`randomExecutionOrder` still holds, so no test may depend on another's side
-effects. Coverage is measured against
-`SliccFollower.app/SliccFollower.debug.dylib`, not the launcher stub beside it —
-debug builds put the code and the coverage mapping in the dylib.
+Outputs land in `.build/coverage/` (`summary.json`, `lcov.info`, and the timed
+`ios-app.xcresult`). Neither bundle is `parallelizable`: simulator clones race
+the UI runner into `Busy` or accessibility timeouts. Tests still run in random
+order, so they cannot share state. Coverage reads
+`SliccFollower.app/SliccFollower.debug.dylib`, where debug code and mappings live.
 
 ## Simulator QA path
 
@@ -208,8 +205,8 @@ in-memory backend (fixture URLs dial `127.0.0.1:1`, failing hermetically). `UITe
 must not carry a flag that skips the connection path. The failure-state test
 dials `http://127.0.0.1:1/…` — refused without DNS or egress, so
 `Connection Failed` arrives in seconds.
-`-uiTestCompletedTurn YES` feeds `message_start` + `content_done` through the
-real data-channel dispatcher, proving the composer settles without `turn_end`.
+`-uiTestCompletedTurn YES` feeds `message_start` + `content_done` + `status:
+ready` through the real dispatcher, proving settlement without `turn_end`.
 
 - **Put accessibility identifiers on leaves.** SwiftUI pushes one onto a
   container's leaves instead of minting a container, so an identifier on a
@@ -264,7 +261,7 @@ the skip message.
 
 ## Related Guides
 
-- `packages/shared-ts/src/tray-sync-protocol.ts` — canonical protocol (the file this app's `SyncProtocol.swift` partially mirrors); payload types in `packages/shared-ts/src/agent-wire-types.ts`
+- `packages/shared-ts/src/tray-sync-protocol.ts` — canonical protocol; payload types in `agent-wire-types.ts`
 - `packages/webapp/src/scoops/tray-leader-sync.ts` — leader-side broadcast/respond logic
 - `packages/webapp/src/scoops/tray-follower-sync.ts` — browser follower
 - `packages/webapp/src/ui/sprinkle-follower-controller.ts` — browser follower's page-side sprinkle renderer (mirrors `SprinkleWebView` behavior)

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -208,6 +208,8 @@ in-memory backend (fixture URLs dial `127.0.0.1:1`, failing hermetically). `UITe
 must not carry a flag that skips the connection path. The failure-state test
 dials `http://127.0.0.1:1/…` — refused without DNS or egress, so
 `Connection Failed` arrives in seconds.
+`-uiTestCompletedTurn YES` feeds `message_start` + `content_done` through the
+real data-channel dispatcher, proving the composer settles without `turn_end`.
 
 - **Put accessibility identifiers on leaves.** SwiftUI pushes one onto a
   container's leaves instead of minting a container, so an identifier on a

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		02019B8CFDC4B36D610933B8 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434BBAD25E91BD0B7D626821 /* AppState.swift */; };
 		07FB78A21C6B4886CF4FEA74 /* AppStateFrozenSessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE98FF01376D2519FAC3A05 /* AppStateFrozenSessions.swift */; };
 		09FE7E5B6F63D6850F2EBFBE /* UITestHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1308398CD972FF297E2C75 /* UITestHooks.swift */; };
+		0A2E0E32557303EF81B1F3A1 /* AppStateStreamingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC17E730D500B3482A2952ED /* AppStateStreamingTests.swift */; };
 		0CAAEE94D02D4006193FA4BB /* InputBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */; };
 		11F604368853A3A60AC0B10F /* PttController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F779D2634D4AED6D1AEDA07 /* PttController.swift */; };
 		15CF4C85551B4FE239D55E94 /* SliccIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438577405ABBCA33F117862C /* SliccIcons.swift */; };
@@ -276,6 +277,7 @@
 		F8E6A8B63717540E230B11C9 /* TerminalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalViewModel.swift; sourceTree = "<group>"; };
 		F9555BBF8AC72C74630432D1 /* theme-vectors.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "theme-vectors.json"; sourceTree = "<group>"; };
 		FA2246D17E400D5616AD36E0 /* SliccAgentAvatarTilt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliccAgentAvatarTilt.swift; sourceTree = "<group>"; };
+		FC17E730D500B3482A2952ED /* AppStateStreamingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateStreamingTests.swift; sourceTree = "<group>"; };
 		FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRouteUITests.swift; sourceTree = "<group>"; };
 		FD6CEFD575FD21C28BEC39F5 /* tray-sync-corpus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tray-sync-corpus.json"; sourceTree = "<group>"; };
 		FDB1EE73D7F0AA0AE4B8BC83 /* AppStateDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateDelivery.swift; sourceTree = "<group>"; };
@@ -301,6 +303,7 @@
 		32BEF7BC73FC1288DC470211 /* SliccFollowerTests */ = {
 			isa = PBXGroup;
 			children = (
+				FC17E730D500B3482A2952ED /* AppStateStreamingTests.swift */,
 				787E06CD88652B51BA32D519 /* AttachmentMessageTests.swift */,
 				2D69F96CFDFB32CC8A815552 /* BrowserTargetsTests.swift */,
 				496510BE3FA550EC3F1CF325 /* CdpPreviewClientTests.swift */,
@@ -782,6 +785,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A2E0E32557303EF81B1F3A1 /* AppStateStreamingTests.swift in Sources */,
 				581EB92FA65132178CAE334E /* AttachmentMessageTests.swift in Sources */,
 				80CAC841902FCED56E805928 /* BrowserTargetsTests.swift in Sources */,
 				E568114F9C5022800E90127F /* CdpPreviewClientTests.swift in Sources */,

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -1203,6 +1203,9 @@ class AppState: ObservableObject {
             logger.debug("Agent event: content_done id=\(messageId)")
             if let idx = buffer.firstIndex(where: { $0.id == messageId }) {
                 buffer[idx].isStreaming = false
+                // Match WcChatController: content_done finalizes only this message.
+                // Turn-level busy state falls on turn_end or status: ready so tools
+                // that follow remain stoppable and steerable.
                 // Retained for cost attribution, as the webapp does. Neither
                 // surface renders these in the thread.
                 if let model { buffer[idx].model = model }
@@ -1212,7 +1215,6 @@ class AppState: ObservableObject {
                     cancelPendingMessagesFlush()
                     messages = buffer
                 }
-                settleTurn(messageId: messageId, isVisible: isVisible)
                 speakIfDictated(buffer[idx], scoopJid: scoopJid, isVisible: isVisible)
             }
 

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -209,7 +209,7 @@ class AppState: ObservableObject {
     private var chunkReassembler = TrayChunkReassembler()
 
     /// ID of the message currently being streamed.
-    private var streamingMessageId: String?
+    private(set) var streamingMessageId: String?
 
     /// Coalesces high-frequency `messages` republishes during streaming so a
     /// burst of contentDeltas doesn't peg the SwiftUI render loop and starve
@@ -875,7 +875,8 @@ class AppState: ObservableObject {
         case .status(let scoopStatus):
             logger.debug("Status update: \(scoopStatus)")
             let wasStreaming = isStreaming
-            isStreaming = (scoopStatus == "streaming" || scoopStatus == "running")
+            // The leader emits processing/ready; streaming/running remain accepted busy aliases.
+            isStreaming = ["processing", "streaming", "running"].contains(scoopStatus)
             if wasStreaming && !isStreaming {
                 streamingMessageId = nil
             }
@@ -1211,6 +1212,7 @@ class AppState: ObservableObject {
                     cancelPendingMessagesFlush()
                     messages = buffer
                 }
+                settleTurn(messageId: messageId, isVisible: isVisible)
                 speakIfDictated(buffer[idx], scoopJid: scoopJid, isVisible: isVisible)
             }
 
@@ -1260,6 +1262,7 @@ class AppState: ObservableObject {
         case .error(let error):
             logger.error("Agent event: error — \(error)")
             if isVisible { leaderError = error }
+            settleTurn(messageId: nil, isVisible: isVisible)
 
         // Events that mutate no transcript state. Kept as a single arm so the
         // switch stays exhaustive — a new protocol case is then a compile error
@@ -1268,6 +1271,14 @@ class AppState: ObservableObject {
         case .toolUI, .toolUIDone, .screenshot, .terminalOutput, .unknown:
             handleNonTranscriptAgentEvent(event)
         }
+    }
+
+    /// Settle only the visible turn that the terminal event belongs to.
+    private func settleTurn(messageId: String?, isVisible: Bool) {
+        guard isVisible, let activeMessageId = streamingMessageId else { return }
+        guard messageId == nil || messageId == activeMessageId else { return }
+        isStreaming = false
+        streamingMessageId = nil
     }
 
     /// Agent events that never touch `messages`.

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -1263,6 +1263,14 @@ class AppState: ObservableObject {
 
         case .error(let error):
             logger.error("Agent event: error — \(error)")
+            if let idx = buffer.lastIndex(where: { $0.isStreaming == true }) {
+                buffer[idx].isStreaming = false
+                messagesByScoop[scoopJid] = buffer
+                if isVisible {
+                    cancelPendingMessagesFlush()
+                    messages = buffer
+                }
+            }
             if isVisible { leaderError = error }
             settleTurn(messageId: nil, isVisible: isVisible)
 

--- a/packages/ios-app/SliccFollower/App/UITestHooks.swift
+++ b/packages/ios-app/SliccFollower/App/UITestHooks.swift
@@ -39,6 +39,30 @@ import UIKit
             UserDefaults.standard.string(forKey: "uiTestConnectionState")
         }
 
+        /// Stage a completed visible turn without a leader
+        /// (`-uiTestCompletedTurn YES`). Both events enter through the real
+        /// data-channel decoder and agent-event dispatcher; the missing
+        /// `turn_end` is deliberate so the composer settlement can regress.
+        @MainActor
+        static func scriptCompletedTurn(into appState: AppState) -> Bool {
+            guard UserDefaults.standard.bool(forKey: "uiTestCompletedTurn") else { return false }
+            let scoopJid = "ui-test-cone"
+            let messageId = "ui-test-reply"
+            appState.connectionState = .connected
+            appState.selectedScoopJid = scoopJid
+            let events: [AgentEvent] = [
+                .messageStart(messageId: messageId),
+                .contentDone(messageId: messageId, model: nil, usage: nil),
+            ]
+            for event in events {
+                let message = LeaderToFollowerMessage.agentEvent(
+                    event: event, scoopJid: scoopJid)
+                guard let data = try? JSONEncoder().encode(message) else { return false }
+                appState.handleDataChannelMessage(data)
+            }
+            return true
+        }
+
         /// Seed the iCloud sessions list without touching iCloud:
         /// `-uiTestSessionsFixture YES` yields two devices' worth of fixture
         /// sessions, `-uiTestSessionsEmpty YES` a deterministic empty store.

--- a/packages/ios-app/SliccFollower/App/UITestHooks.swift
+++ b/packages/ios-app/SliccFollower/App/UITestHooks.swift
@@ -40,9 +40,9 @@ import UIKit
         }
 
         /// Stage a completed visible turn without a leader
-        /// (`-uiTestCompletedTurn YES`). Both events enter through the real
-        /// data-channel decoder and agent-event dispatcher; the missing
-        /// `turn_end` is deliberate so the composer settlement can regress.
+        /// (`-uiTestCompletedTurn YES`). All messages enter through the real
+        /// data-channel decoder; status: ready settles the turn because the
+        /// missing `turn_end` is deliberate.
         @MainActor
         static func scriptCompletedTurn(into appState: AppState) -> Bool {
             guard UserDefaults.standard.bool(forKey: "uiTestCompletedTurn") else { return false }
@@ -50,13 +50,14 @@ import UIKit
             let messageId = "ui-test-reply"
             appState.connectionState = .connected
             appState.selectedScoopJid = scoopJid
-            let events: [AgentEvent] = [
-                .messageStart(messageId: messageId),
-                .contentDone(messageId: messageId, model: nil, usage: nil),
+            let messages: [LeaderToFollowerMessage] = [
+                .agentEvent(event: .messageStart(messageId: messageId), scoopJid: scoopJid),
+                .agentEvent(
+                    event: .contentDone(messageId: messageId, model: nil, usage: nil),
+                    scoopJid: scoopJid),
+                .status(scoopStatus: "ready"),
             ]
-            for event in events {
-                let message = LeaderToFollowerMessage.agentEvent(
-                    event: event, scoopJid: scoopJid)
+            for message in messages {
                 guard let data = try? JSONEncoder().encode(message) else { return false }
                 appState.handleDataChannelMessage(data)
             }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/AppStateStreamingTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/AppStateStreamingTests.swift
@@ -11,7 +11,7 @@ final class AppStateStreamingTests: XCTestCase {
     }
 
     @MainActor
-    func testContentDoneSettlesMatchingVisibleTurnWithoutTurnEnd() throws {
+    func testContentDoneThenToolUseKeepsStopSteerAvailable() throws {
         let state = AppState()
         state.selectedScoopJid = "cone"
 
@@ -19,32 +19,18 @@ final class AppStateStreamingTests: XCTestCase {
         try send(
             .contentDone(messageId: "reply", model: nil, usage: nil),
             scoopJid: "cone", to: state)
-
-        XCTAssertFalse(state.isStreaming)
-        XCTAssertNil(state.streamingMessageId)
-        XCTAssertEqual(try XCTUnwrap(state.messages.last).isStreaming, false)
-    }
-
-    @MainActor
-    func testLateContentDoneDoesNotSettleNewerVisibleTurn() throws {
-        let state = AppState()
-        state.selectedScoopJid = "cone"
-        try send(.messageStart(messageId: "earlier"), scoopJid: "cone", to: state)
         try send(
-            .contentDone(messageId: "earlier", model: nil, usage: nil),
-            scoopJid: "cone", to: state)
-        try send(.messageStart(messageId: "current"), scoopJid: "cone", to: state)
-
-        try send(
-            .contentDone(messageId: "earlier", model: nil, usage: nil),
+            .toolUseStart(messageId: "reply", toolName: "bash", toolInput: nil),
             scoopJid: "cone", to: state)
 
         XCTAssertTrue(state.isStreaming)
-        XCTAssertEqual(state.streamingMessageId, "current")
+        XCTAssertEqual(state.streamingMessageId, "reply")
+        XCTAssertEqual(try XCTUnwrap(state.messages.last).isStreaming, false)
+        XCTAssertEqual(state.messages.last?.toolCalls?.last?.name, "bash")
     }
 
     @MainActor
-    func testTurnEndAfterContentDoneRemainsIdempotent() throws {
+    func testTurnEndSettlesAfterContentDone() throws {
         let state = AppState()
         state.selectedScoopJid = "cone"
         try send(.messageStart(messageId: "reply"), scoopJid: "cone", to: state)
@@ -88,16 +74,24 @@ final class AppStateStreamingTests: XCTestCase {
     }
 
     @MainActor
-    func testProcessingAndReadyStatusesMapToStreamingState() throws {
+    func testReadyStatusSettlesCompletedMessageWithoutTurnEnd() throws {
         let state = AppState()
+        state.selectedScoopJid = "cone"
 
         state.handleDataChannelMessage(
             try JSONEncoder().encode(LeaderToFollowerMessage.status(scoopStatus: "processing")))
         XCTAssertTrue(state.isStreaming)
+        try send(.messageStart(messageId: "reply"), scoopJid: "cone", to: state)
+        try send(
+            .contentDone(messageId: "reply", model: nil, usage: nil),
+            scoopJid: "cone", to: state)
+        XCTAssertTrue(state.isStreaming)
+        XCTAssertEqual(state.streamingMessageId, "reply")
 
         state.handleDataChannelMessage(
             try JSONEncoder().encode(LeaderToFollowerMessage.status(scoopStatus: "ready")))
         XCTAssertFalse(state.isStreaming)
         XCTAssertNil(state.streamingMessageId)
+        XCTAssertEqual(try XCTUnwrap(state.messages.last).isStreaming, false)
     }
 }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/AppStateStreamingTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/AppStateStreamingTests.swift
@@ -56,6 +56,36 @@ final class AppStateStreamingTests: XCTestCase {
         XCTAssertFalse(state.isStreaming)
         XCTAssertNil(state.streamingMessageId)
         XCTAssertEqual(state.leaderError, "boom")
+        XCTAssertEqual(try XCTUnwrap(state.messages.last).isStreaming, false)
+        XCTAssertEqual(try XCTUnwrap(state.messagesByScoop["cone"]?.last).isStreaming, false)
+    }
+
+    @MainActor
+    func testBackgroundAgentErrorDoesNotRelatchWhenSelected() throws {
+        let state = AppState()
+        state.scoops = [
+            ScoopSummary(
+                jid: "cone", name: "cone", folder: "/workspace", isCone: true,
+                assistantLabel: "sliccy", trigger: nil, state: nil, fill: nil),
+            ScoopSummary(
+                jid: "scoop", name: "scoop", folder: "/scoops/scoop", isCone: false,
+                assistantLabel: "scoop", trigger: nil, state: nil, fill: nil),
+        ]
+        state.selectedScoopJid = "cone"
+        try send(.messageStart(messageId: "cone-reply"), scoopJid: "cone", to: state)
+        try send(.messageStart(messageId: "scoop-reply"), scoopJid: "scoop", to: state)
+
+        try send(.error(error: "boom"), scoopJid: "scoop", to: state)
+
+        XCTAssertTrue(state.isStreaming)
+        XCTAssertEqual(state.streamingMessageId, "cone-reply")
+        XCTAssertEqual(try XCTUnwrap(state.messagesByScoop["scoop"]?.last).isStreaming, false)
+
+        state.selectScoop(jid: "scoop")
+
+        XCTAssertFalse(state.isStreaming)
+        XCTAssertNil(state.streamingMessageId)
+        XCTAssertEqual(try XCTUnwrap(state.messages.last).isStreaming, false)
     }
 
     @MainActor

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/AppStateStreamingTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/AppStateStreamingTests.swift
@@ -76,15 +76,15 @@ final class AppStateStreamingTests: XCTestCase {
     func testBackgroundContentDoneDoesNotSettleVisibleTurn() throws {
         let state = AppState()
         state.selectedScoopJid = "cone"
-        try send(.messageStart(messageId: "visible"), scoopJid: "cone", to: state)
-        try send(.messageStart(messageId: "background"), scoopJid: "scoop", to: state)
+        try send(.messageStart(messageId: "reply"), scoopJid: "cone", to: state)
+        try send(.messageStart(messageId: "reply"), scoopJid: "scoop", to: state)
 
         try send(
-            .contentDone(messageId: "background", model: nil, usage: nil),
+            .contentDone(messageId: "reply", model: nil, usage: nil),
             scoopJid: "scoop", to: state)
 
         XCTAssertTrue(state.isStreaming)
-        XCTAssertEqual(state.streamingMessageId, "visible")
+        XCTAssertEqual(state.streamingMessageId, "reply")
     }
 
     @MainActor

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/AppStateStreamingTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/AppStateStreamingTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import XCTest
+
+@testable import SliccFollower
+
+final class AppStateStreamingTests: XCTestCase {
+    @MainActor
+    private func send(_ event: AgentEvent, scoopJid: String, to state: AppState) throws {
+        let message = LeaderToFollowerMessage.agentEvent(event: event, scoopJid: scoopJid)
+        state.handleDataChannelMessage(try JSONEncoder().encode(message))
+    }
+
+    @MainActor
+    func testContentDoneSettlesMatchingVisibleTurnWithoutTurnEnd() throws {
+        let state = AppState()
+        state.selectedScoopJid = "cone"
+
+        try send(.messageStart(messageId: "reply"), scoopJid: "cone", to: state)
+        try send(
+            .contentDone(messageId: "reply", model: nil, usage: nil),
+            scoopJid: "cone", to: state)
+
+        XCTAssertFalse(state.isStreaming)
+        XCTAssertNil(state.streamingMessageId)
+        XCTAssertEqual(try XCTUnwrap(state.messages.last).isStreaming, false)
+    }
+
+    @MainActor
+    func testLateContentDoneDoesNotSettleNewerVisibleTurn() throws {
+        let state = AppState()
+        state.selectedScoopJid = "cone"
+        try send(.messageStart(messageId: "earlier"), scoopJid: "cone", to: state)
+        try send(
+            .contentDone(messageId: "earlier", model: nil, usage: nil),
+            scoopJid: "cone", to: state)
+        try send(.messageStart(messageId: "current"), scoopJid: "cone", to: state)
+
+        try send(
+            .contentDone(messageId: "earlier", model: nil, usage: nil),
+            scoopJid: "cone", to: state)
+
+        XCTAssertTrue(state.isStreaming)
+        XCTAssertEqual(state.streamingMessageId, "current")
+    }
+
+    @MainActor
+    func testTurnEndAfterContentDoneRemainsIdempotent() throws {
+        let state = AppState()
+        state.selectedScoopJid = "cone"
+        try send(.messageStart(messageId: "reply"), scoopJid: "cone", to: state)
+        try send(
+            .contentDone(messageId: "reply", model: nil, usage: nil),
+            scoopJid: "cone", to: state)
+
+        try send(.turnEnd(messageId: "reply"), scoopJid: "cone", to: state)
+
+        XCTAssertFalse(state.isStreaming)
+        XCTAssertNil(state.streamingMessageId)
+        XCTAssertEqual(try XCTUnwrap(state.messages.last).isStreaming, false)
+    }
+
+    @MainActor
+    func testAgentErrorSettlesVisibleTrackedTurn() throws {
+        let state = AppState()
+        state.selectedScoopJid = "cone"
+        try send(.messageStart(messageId: "reply"), scoopJid: "cone", to: state)
+
+        try send(.error(error: "boom"), scoopJid: "cone", to: state)
+
+        XCTAssertFalse(state.isStreaming)
+        XCTAssertNil(state.streamingMessageId)
+        XCTAssertEqual(state.leaderError, "boom")
+    }
+
+    @MainActor
+    func testBackgroundContentDoneDoesNotSettleVisibleTurn() throws {
+        let state = AppState()
+        state.selectedScoopJid = "cone"
+        try send(.messageStart(messageId: "visible"), scoopJid: "cone", to: state)
+        try send(.messageStart(messageId: "background"), scoopJid: "scoop", to: state)
+
+        try send(
+            .contentDone(messageId: "background", model: nil, usage: nil),
+            scoopJid: "scoop", to: state)
+
+        XCTAssertTrue(state.isStreaming)
+        XCTAssertEqual(state.streamingMessageId, "visible")
+    }
+
+    @MainActor
+    func testProcessingAndReadyStatusesMapToStreamingState() throws {
+        let state = AppState()
+
+        state.handleDataChannelMessage(
+            try JSONEncoder().encode(LeaderToFollowerMessage.status(scoopStatus: "processing")))
+        XCTAssertTrue(state.isStreaming)
+
+        state.handleDataChannelMessage(
+            try JSONEncoder().encode(LeaderToFollowerMessage.status(scoopStatus: "ready")))
+        XCTAssertFalse(state.isStreaming)
+        XCTAssertNil(state.streamingMessageId)
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/SteerUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/SteerUITests.swift
@@ -58,7 +58,7 @@ final class SteerUITests: XCTestCase {
             "The streaming send affordance must not exist while idle")
     }
 
-    func testContentDoneRestoresIdleComposerWithoutTurnEnd() {
+    func testReadyStatusRestoresIdleComposerWithoutTurnEnd() {
         let app = XCUIApplication()
         app.launchArguments += [
             "-joinUrl", "", "-uiTestCompletedTurn", "YES",
@@ -70,9 +70,9 @@ final class SteerUITests: XCTestCase {
         let idleSend = app.buttons["composer-send"]
         XCTAssertTrue(
             idleSend.waitForExistence(timeout: 10),
-            "content_done should restore the idle send control without turn_end")
+            "status: ready should restore the idle send control without turn_end")
         XCTAssertFalse(
             app.buttons["send-while-streaming"].exists,
-            "A completed turn must not retain the streaming send affordance")
+            "A ready turn must not retain the streaming send affordance")
     }
 }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/SteerUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/SteerUITests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 /// The send-while-streaming affordance: absent when no turn runs, present
 /// (with the "Interrupt & send" long-press menu) while one does. Driven by
-/// the `-uiTestConnectionState streaming` hook — no leader involved.
+/// DEBUG launch hooks — no leader involved.
 final class SteerUITests: XCTestCase {
 
     override func setUp() {
@@ -56,5 +56,23 @@ final class SteerUITests: XCTestCase {
         XCTAssertFalse(
             app.buttons["send-while-streaming"].exists,
             "The streaming send affordance must not exist while idle")
+    }
+
+    func testContentDoneRestoresIdleComposerWithoutTurnEnd() {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-joinUrl", "", "-uiTestCompletedTurn", "YES",
+            "-uiTestComposerText", "follow up",
+        ]
+        app.launch()
+
+        XCTAssertTrue(app.textViews.firstMatch.waitForExistence(timeout: 60))
+        let idleSend = app.buttons["composer-send"]
+        XCTAssertTrue(
+            idleSend.waitForExistence(timeout: 10),
+            "content_done should restore the idle send control without turn_end")
+        XCTAssertFalse(
+            app.buttons["send-while-streaming"].exists,
+            "A completed turn must not retain the streaming send affordance")
     }
 }

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -92,6 +92,9 @@ struct ChatView: View {
                 if let targets = UITestHooks.remoteTargetsFixture() {
                     appState.remoteTargets = targets
                 }
+                if UITestHooks.scriptCompletedTurn(into: appState) {
+                    return
+                }
                 if let forced = UITestHooks.forcedConnectionState {
                     applyForcedConnectionState(forced)
                     return


### PR DESCRIPTION
## Bug

When the live leader omits `turn_end`, the iOS follower could remain latched in streaming mode. Settling on `content_done` would fix that latch but regress tool-using turns by removing stop/steer before tools finish.

## Fix

- Match the web controller precedent: `content_done` finalizes only the assistant message.
- Keep turn-level streaming active until `turn_end`, `status: ready`, or a mid-stream error.
- Map the leader's `processing`/`ready` status lifecycle while retaining existing busy aliases.
- Script the no-`turn_end` UI fixture as `message_start` → `content_done` → `status: ready`.
- Trim the iOS package guide below the 20,000-character CI limit.

The leader prerequisite is satisfied: `ScoopContext` transitions to `ready` only after the full agent/tool loop, and leader hooks broadcast that state to followers even on the live-float path that omits follower `turn_end`.

## Test coverage

- `testContentDoneThenToolUseKeepsStopSteerAvailable` proves stop/steer survives `content_done` when a tool follows.
- Tests cover settlement on `turn_end`, `status: ready`, and mid-stream error.
- `testReadyStatusRestoresIdleComposerWithoutTurnEnd` covers the complete UI path.
- Negative controls fail when settlement is restored to `content_done` and when `status: ready` is removed from the UI fixture.

## Verification

- Repository lint, touched-file debt, typecheck, and ordinary test suite: passed.
- Webapp and Chrome-extension coverage gates: passed in isolation; the all-package coverage command remains load-flaky with unrelated 5-second timeouts/races.
- Full production build, extension build, and bundle-size budgets: passed.
- SwiftLint and strict Swift formatting: passed (warning-only pre-existing debt remains).
- iOS generic simulator build: passed.
- iOS unit/UI coverage: passed — lines 68.01% (floor 59%), functions 59.59% (floor 46%), regions 60.84% (floor 50%).
- Doc-size gate: passed; `packages/ios-app/CLAUDE.md` is below 20,000 characters.

Follow-up: #1909 tracks adding scoop identity to the currently unscoped status broadcast.

Closes #1891