### PR TITLE
fix(ios): stop transcript horizontal scrolling from switching scoops

### DIFF
--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -63,9 +63,10 @@ the drag pulls away from (right at leading, left at trailing). Freeze edge state
 at drag start. Capture must tolerate either inner/outer callback order, and an
 unknown context in a guarded region fails closed. Edge math uses the effective
 viewport, including both 8pt expansions from negative horizontal padding.
-The transcript observer is a UIKit pan recognizer that explicitly permits
-simultaneous recognition; iOS 26 no longer makes a descendant SwiftUI gesture
-simultaneous with an ancestor gesture. The inner gesture still snapshots edges.
+On iOS 18+, the transcript observer uses `UIGestureRecognizerRepresentable` to
+explicitly permit simultaneous recognition; iOS 26 no longer makes a descendant
+SwiftUI gesture simultaneous with an ancestor gesture. iOS 17 keeps the SwiftUI
+fallback, and the inner gesture still snapshots edges.
 Ordinary transcript navigation and vertical scrolling stay unchanged. Because
 the target is iOS 17, use preference/geometry APIs, not iOS 18 scroll APIs.
 

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -63,10 +63,10 @@ the drag pulls away from (right at leading, left at trailing). Freeze edge state
 at drag start. Capture must tolerate either inner/outer callback order, and an
 unknown context in a guarded region fails closed. Edge math uses the effective
 viewport, including both 8pt expansions from negative horizontal padding.
-On iOS 18+, the transcript observer uses `UIGestureRecognizerRepresentable` to
-explicitly permit simultaneous recognition; iOS 26 no longer makes a descendant
-SwiftUI gesture simultaneous with an ancestor gesture. iOS 17 keeps the SwiftUI
-fallback, and the inner gesture still snapshots edges.
+On iOS 18+, each guarded scroller uses `UIGestureRecognizerRepresentable` to
+resolve its own handoff; iOS 26 no longer makes a descendant SwiftUI gesture
+simultaneous with an ancestor gesture. The parent handles ordinary content and
+iOS 17 keeps the SwiftUI arbitration path.
 Ordinary transcript navigation and vertical scrolling stay unchanged. Because
 the target is iOS 17, use preference/geometry APIs, not iOS 18 scroll APIs.
 

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -55,6 +55,14 @@ Model TS follower features on `AppState`:
 - `hello` sends `exec: false` + device `motd`
 - Multi-scoop buffers, model/thinking controls, agent events
 
+### Transcript swipe arbitration
+
+Nested horizontal transcript content owns a drag while it can still scroll in
+that direction; scoop navigation (and frozen-session dismissal) takes over only
+at the edge the drag pulls away from. Sample the edge at drag start, before the
+inner scroller moves. A `simultaneousGesture` preserves vertical scrolling but
+does not choose a horizontal winner, so it is not sufficient by itself.
+
 ### Licks
 
 `sprinkle.lick` is its own message (`sprinkle` is not `FORWARDABLE_TO_LEADER`). `LickEvent` mirrors only `navigate` and `discovery`. `navigate` handoffs come from `WKNavigationResponse` Link headers (main frame only).

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -64,9 +64,10 @@ at drag start. Capture must tolerate either inner/outer callback order, and an
 unknown context in a guarded region fails closed. Edge math uses the effective
 viewport, including both 8pt expansions from negative horizontal padding.
 On iOS 18+, content inside each guarded scroller uses
-`UIGestureRecognizerRepresentable` to resolve its own handoff; iOS 26 no longer makes a descendant SwiftUI gesture
-simultaneous with an ancestor gesture. The parent handles ordinary content and
-iOS 17 keeps the SwiftUI arbitration path.
+`UIGestureRecognizerRepresentable` to resolve its own handoff; iOS 26 no longer
+makes a descendant SwiftUI gesture simultaneous with an ancestor gesture. The
+recognizer snapshots live backing-`UIScrollView` metrics at touch-down. The
+parent handles ordinary content and iOS 17 keeps the SwiftUI geometry path.
 Ordinary transcript navigation and vertical scrolling stay unchanged. Because
 the target is iOS 17, use preference/geometry APIs, not iOS 18 scroll APIs.
 

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -63,8 +63,8 @@ the drag pulls away from (right at leading, left at trailing). Freeze edge state
 at drag start. Capture must tolerate either inner/outer callback order, and an
 unknown context in a guarded region fails closed. Edge math uses the effective
 viewport, including both 8pt expansions from negative horizontal padding.
-On iOS 18+, each guarded scroller uses `UIGestureRecognizerRepresentable` to
-resolve its own handoff; iOS 26 no longer makes a descendant SwiftUI gesture
+On iOS 18+, content inside each guarded scroller uses
+`UIGestureRecognizerRepresentable` to resolve its own handoff; iOS 26 no longer makes a descendant SwiftUI gesture
 simultaneous with an ancestor gesture. The parent handles ordinary content and
 iOS 17 keeps the SwiftUI arbitration path.
 Ordinary transcript navigation and vertical scrolling stay unchanged. Because

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -63,9 +63,9 @@ the drag pulls away from (right at leading, left at trailing). Freeze edge state
 at drag start. Capture must tolerate either inner/outer callback order, and an
 unknown context in a guarded region fails closed. Edge math uses the effective
 viewport, including both 8pt expansions from negative horizontal padding.
-Guarded scrollers resolve handoff on their own gesture; iOS 26 no longer makes a
-descendant gesture simultaneous with an ancestor gesture. The ancestor handles
-ordinary transcript drags only, avoiding duplicate navigation on older iOS.
+The transcript observer is a UIKit pan recognizer that explicitly permits
+simultaneous recognition; iOS 26 no longer makes a descendant SwiftUI gesture
+simultaneous with an ancestor gesture. The inner gesture still snapshots edges.
 Ordinary transcript navigation and vertical scrolling stay unchanged. Because
 the target is iOS 17, use preference/geometry APIs, not iOS 18 scroll APIs.
 

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -63,6 +63,9 @@ the drag pulls away from (right at leading, left at trailing). Freeze edge state
 at drag start. Capture must tolerate either inner/outer callback order, and an
 unknown context in a guarded region fails closed. Edge math uses the effective
 viewport, including both 8pt expansions from negative horizontal padding.
+Guarded scrollers resolve handoff on their own gesture; iOS 26 no longer makes a
+descendant gesture simultaneous with an ancestor gesture. The ancestor handles
+ordinary transcript drags only, avoiding duplicate navigation on older iOS.
 Ordinary transcript navigation and vertical scrolling stay unchanged. Because
 the target is iOS 17, use preference/geometry APIs, not iOS 18 scroll APIs.
 

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -58,10 +58,13 @@ Model TS follower features on `AppState`:
 ### Transcript swipe arbitration
 
 Nested horizontal transcript content owns a drag while it can still scroll in
-that direction; scoop navigation (and frozen-session dismissal) takes over only
-at the edge the drag pulls away from. Sample the edge at drag start, before the
-inner scroller moves. A `simultaneousGesture` preserves vertical scrolling but
-does not choose a horizontal winner, so it is not sufficient by itself.
+that direction; scoop navigation or frozen dismissal takes over only at the edge
+the drag pulls away from (right at leading, left at trailing). Freeze edge state
+at drag start. Capture must tolerate either inner/outer callback order, and an
+unknown context in a guarded region fails closed. Edge math uses the effective
+viewport, including both 8pt expansions from negative horizontal padding.
+Ordinary transcript navigation and vertical scrolling stay unchanged. Because
+the target is iOS 17, use preference/geometry APIs, not iOS 18 scroll APIs.
 
 ### Licks
 

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		1EB817519D7626900D17BDE8 /* AvatarIsolationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F5E877CC67E8790899B164 /* AvatarIsolationView.swift */; };
 		21BD049697833AC4E3316A58 /* ToolUIPlaceholderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0425579D2C460F993D259DB /* ToolUIPlaceholderTests.swift */; };
 		295A3C0E98C58AB966726AB9 /* VoiceReply.swift in Sources */ = {isa = PBXBuildFile; fileRef = E326D34AE874B17953C8895E /* VoiceReply.swift */; };
+		2974D035AD2B5E1D2190C1B3 /* SwipeArbiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 682FAEF60C107C79F698B89C /* SwipeArbiter.swift */; };
 		2A750B8B02200270E97C8D6E /* Dictation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4A75BA9D14DA689D0E9F4 /* Dictation.swift */; };
 		2AB3075DAEAC8AC08789EF37 /* AppStateDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB1EE73D7F0AA0AE4B8BC83 /* AppStateDelivery.swift */; };
 		2CE789AA836BB0713F1250D7 /* CDPBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE0A7D88487F7712E451646 /* CDPBridge.swift */; };
@@ -67,6 +68,7 @@
 		619F0ADB89A5C9A18B6FD70E /* TrayFollowerDeviceMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F938D1C465382409AA3100 /* TrayFollowerDeviceMetadata.swift */; };
 		66685F6C8C714A97799BBCED /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0214511F398565EAE7893B54 /* CoreMotion.framework */; };
 		67305E9A6D6B198A43EF5148 /* ThemePalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE6D707649AD21C5912013 /* ThemePalette.swift */; };
+		67554B5BF8BA0434704207EF /* HorizontalScrollGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07F6E666E203541FA44FA52 /* HorizontalScrollGuard.swift */; };
 		67EC4D5BDDC4014A965FF5B4 /* ConnectionRouteUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */; };
 		686CFEC54F95406972A1A1D6 /* WorkbenchHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED01F56391DE9865C1405BAF /* WorkbenchHost.swift */; };
 		68FA70C9EC1A7C1137CC277D /* PttOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C4F68634F8E70BBC83002C /* PttOverlayView.swift */; };
@@ -139,6 +141,7 @@
 		D64746441155B8987B3861BF /* TerminalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E6A8B63717540E230B11C9 /* TerminalViewModel.swift */; };
 		DE768243B6F093DD9C0AE32B /* FileProviderDomainLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4BA4F974367F5D6E64E1CE /* FileProviderDomainLifecycleTests.swift */; };
 		DFF9C499295115804C6CE6C1 /* SliccAgentAvatarTilt.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2246D17E400D5616AD36E0 /* SliccAgentAvatarTilt.swift */; };
+		E2AF3C60CE619B7C31EB6798 /* SwipeArbiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8858EA60330219165C3BE9D /* SwipeArbiterTests.swift */; };
 		E4A27A22FBA5A5F89454165D /* TrayFollowerConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874A883BDEF9351B647F4EE0 /* TrayFollowerConnector.swift */; };
 		E568114F9C5022800E90127F /* CdpPreviewClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496510BE3FA550EC3F1CF325 /* CdpPreviewClientTests.swift */; };
 		E6AE9D960C36AC71ED33D18E /* ShellLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28D0D10C06C0CEBBC57634AA /* ShellLayout.swift */; };
@@ -301,6 +304,7 @@
 		639AB6CC8494FCE4C252F00B /* ChunkFramingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkFramingTests.swift; sourceTree = "<group>"; };
 		63CFFB3D55CD74B43CC70771 /* LeaderVFSProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderVFSProviderTests.swift; sourceTree = "<group>"; };
 		65F5E877CC67E8790899B164 /* AvatarIsolationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarIsolationView.swift; sourceTree = "<group>"; };
+		682FAEF60C107C79F698B89C /* SwipeArbiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeArbiter.swift; sourceTree = "<group>"; };
 		686D36BA22DBC2F94CEA8448 /* BrowserTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserTargets.swift; sourceTree = "<group>"; };
 		695356CA7F082C3287CFB228 /* SVGPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SVGPathTests.swift; sourceTree = "<group>"; };
 		6A88993C99745347AF830860 /* AppStateTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateTheme.swift; sourceTree = "<group>"; };
@@ -344,6 +348,7 @@
 		AF78C09597C5D63A373EB126 /* MessageBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubble.swift; sourceTree = "<group>"; };
 		AFCAA64AD099330D7C84B889 /* AttachmentUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentUITests.swift; sourceTree = "<group>"; };
 		B00A795E28FE6238268A196E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		B07F6E666E203541FA44FA52 /* HorizontalScrollGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalScrollGuard.swift; sourceTree = "<group>"; };
 		B13A2CF7B24036FE27F65975 /* ImageAttachmentBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAttachmentBuilder.swift; sourceTree = "<group>"; };
 		B3BE6D707649AD21C5912013 /* ThemePalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemePalette.swift; sourceTree = "<group>"; };
 		B4B50958D7C0526D4C5A926D /* TrayChunkFraming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayChunkFraming.swift; sourceTree = "<group>"; };
@@ -386,6 +391,7 @@
 		F0A069AA812629AC5FE70AC9 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		F507FDBA9C3FD19BCC67FB3B /* DockModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockModelTests.swift; sourceTree = "<group>"; };
 		F60DB85370008030F231AAD3 /* VoiceReplyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceReplyTests.swift; sourceTree = "<group>"; };
+		F8858EA60330219165C3BE9D /* SwipeArbiterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeArbiterTests.swift; sourceTree = "<group>"; };
 		F8E6A8B63717540E230B11C9 /* TerminalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalViewModel.swift; sourceTree = "<group>"; };
 		F8F938D1C465382409AA3100 /* TrayFollowerDeviceMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrayFollowerDeviceMetadata.swift; sourceTree = "<group>"; };
 		F9555BBF8AC72C74630432D1 /* theme-vectors.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "theme-vectors.json"; sourceTree = "<group>"; };
@@ -482,6 +488,7 @@
 				5A30A613A67EAAAA1298638B /* SliccAgentAvatarGeometryTests.swift */,
 				066BAF2F283227600FB92506 /* SteerMessageTests.swift */,
 				695356CA7F082C3287CFB228 /* SVGPathTests.swift */,
+				F8858EA60330219165C3BE9D /* SwipeArbiterTests.swift */,
 				9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */,
 				3BBC1002CE4D3E1D940352F4 /* SyncProtocolTests.swift */,
 				D8BE50108EF2BB5BE17D889C /* TerminalClientTests.swift */,
@@ -565,6 +572,7 @@
 				9EF40B2C78468173C75F958F /* SliccAgentAvatarGeometry.swift */,
 				FA2246D17E400D5616AD36E0 /* SliccAgentAvatarTilt.swift */,
 				0A51DB1BA99DAE89F21CF736 /* SVGPath.swift */,
+				682FAEF60C107C79F698B89C /* SwipeArbiter.swift */,
 				955A92ECF3F67770059EF5A5 /* TerminalLineEndings.swift */,
 				1572105F0B5819E4CC07BD84 /* ThemeEngine.swift */,
 				B3BE6D707649AD21C5912013 /* ThemePalette.swift */,
@@ -645,6 +653,7 @@
 				58899461D44B42F512AD0645 /* DockRail.swift */,
 				E92410F3BA05462ECDEB20A1 /* FilesView.swift */,
 				3425D0B50BD57E03FFF47A45 /* FrozenSessionsView.swift */,
+				B07F6E666E203541FA44FA52 /* HorizontalScrollGuard.swift */,
 				1F2EECDCB4AF899D3071D13C /* InlineSprinkleView.swift */,
 				CCCB2F32F2BEEC4DE1D526DB /* InputBar.swift */,
 				81B8EC8680591A3A1A9BD392 /* LucideIcon.swift */,
@@ -966,6 +975,7 @@
 				5E23C33D85A8DFC1772AD1FE /* FrozenSessions.swift in Sources */,
 				319F6B893CA643B51BE218BB /* FrozenSessionsView.swift in Sources */,
 				CCD45A2DC9CD2D58A5CBCA0F /* HandoffLink.swift in Sources */,
+				67554B5BF8BA0434704207EF /* HorizontalScrollGuard.swift in Sources */,
 				9AD8326007279D3F37D57C9C /* ICloudSessionList.swift in Sources */,
 				88FE04B67265180C58A84F82 /* ImageAttachmentBuilder.swift in Sources */,
 				A9C0449A188D09A99F506FFE /* InlineSprinkleView.swift in Sources */,
@@ -996,6 +1006,7 @@
 				15CF4C85551B4FE239D55E94 /* SliccIcons.swift in Sources */,
 				4BA825D2547CA8864F3E6C13 /* SprinkleDetailView.swift in Sources */,
 				F5AC500C53CC1A9251A5718B /* SprinkleWebView.swift in Sources */,
+				2974D035AD2B5E1D2190C1B3 /* SwipeArbiter.swift in Sources */,
 				58AACC678F1000C41BC7AA1A /* TabsCarouselView.swift in Sources */,
 				1865AE8BBF943F8EB482B9F1 /* TerminalClient.swift in Sources */,
 				CB3927786EA8B1A8C504469D /* TerminalLineEndings.swift in Sources */,
@@ -1071,6 +1082,7 @@
 				FA28410D2D764BBA8EF08E0E /* ShellLayoutTests.swift in Sources */,
 				941662107E886C9BA55F2658 /* SliccAgentAvatarGeometryTests.swift in Sources */,
 				9ECC362CC8EBA3629542A6E7 /* SteerMessageTests.swift in Sources */,
+				E2AF3C60CE619B7C31EB6798 /* SwipeArbiterTests.swift in Sources */,
 				F908DA74A70E1C7F16EC6AD8 /* SyncProtocolCorpusTests.swift in Sources */,
 				CB6A8F9EEAD1D4DAA552E0EC /* SyncProtocolTests.swift in Sources */,
 				8BC74CD5BEE3E940EE3EF2DD /* TerminalClientTests.swift in Sources */,

--- a/packages/ios-app/SliccFollower/Models/SwipeArbiter.swift
+++ b/packages/ios-app/SliccFollower/Models/SwipeArbiter.swift
@@ -1,0 +1,74 @@
+import CoreGraphics
+
+/// Decides whether a completed transcript drag navigates between scoops.
+struct SwipeArbiter {
+    enum Action: Equatable {
+        case next
+        case previous
+        case none
+    }
+
+    struct ScrollContext: Equatable {
+        let atLeadingEdge: Bool
+        let atTrailingEdge: Bool
+
+        init(atLeadingEdge: Bool, atTrailingEdge: Bool) {
+            self.atLeadingEdge = atLeadingEdge
+            self.atTrailingEdge = atTrailingEdge
+        }
+
+        init(
+            offset: CGFloat,
+            contentWidth: CGFloat,
+            viewportWidth: CGFloat,
+            tolerance: CGFloat = 1
+        ) {
+            guard contentWidth > 0, viewportWidth > 0 else {
+                atLeadingEdge = false
+                atTrailingEdge = false
+                return
+            }
+            let maximumOffset = max(contentWidth - viewportWidth, 0)
+            if maximumOffset <= tolerance {
+                atLeadingEdge = true
+                atTrailingEdge = true
+            } else {
+                atLeadingEdge = offset <= tolerance
+                atTrailingEdge = offset >= maximumOffset - tolerance
+            }
+        }
+    }
+
+    enum DragOrigin: Equatable {
+        case ordinaryContent
+        case guardedContent(ScrollContext)
+        case unknown
+    }
+
+    static let gestureMinimumDistance: CGFloat = 40
+    private static let actionThreshold: CGFloat = 60
+    private static let horizontalDominance: CGFloat = 1.5
+
+    static func action(
+        for translation: CGSize,
+        origin: DragOrigin
+    ) -> Action {
+        let horizontal = translation.width
+        let vertical = translation.height
+        guard abs(horizontal) > actionThreshold,
+            abs(horizontal) > abs(vertical) * horizontalDominance
+        else { return .none }
+
+        guard origin != .unknown else { return .none }
+        guard case .guardedContent(let scrollContext) = origin else {
+            return horizontal < 0 ? .next : .previous
+        }
+
+        if horizontal < 0 {
+            guard scrollContext.atTrailingEdge else { return .none }
+            return .next
+        }
+        guard scrollContext.atLeadingEdge else { return .none }
+        return .previous
+    }
+}

--- a/packages/ios-app/SliccFollower/Models/SwipeArbiter.swift
+++ b/packages/ios-app/SliccFollower/Models/SwipeArbiter.swift
@@ -72,4 +72,14 @@ struct SwipeArbiter {
         return .previous
     }
 
+    /// On iOS 18+, guarded descendants resolve their own handoff through a
+    /// UIKit recognizer. The transcript observer handles ordinary content only.
+    static func outerAction(
+        for translation: CGSize,
+        origin: DragOrigin
+    ) -> Action {
+        guard origin == .ordinaryContent else { return .none }
+        return action(for: translation, origin: origin)
+    }
+
 }

--- a/packages/ios-app/SliccFollower/Models/SwipeArbiter.swift
+++ b/packages/ios-app/SliccFollower/Models/SwipeArbiter.swift
@@ -72,13 +72,4 @@ struct SwipeArbiter {
         return .previous
     }
 
-    /// Guarded descendants resolve their own handoff because iOS 26 no longer
-    /// makes descendant gestures simultaneous with ancestor gestures.
-    static func outerAction(
-        for translation: CGSize,
-        origin: DragOrigin
-    ) -> Action {
-        guard origin == .ordinaryContent else { return .none }
-        return action(for: translation, origin: origin)
-    }
 }

--- a/packages/ios-app/SliccFollower/Models/SwipeArbiter.swift
+++ b/packages/ios-app/SliccFollower/Models/SwipeArbiter.swift
@@ -71,4 +71,14 @@ struct SwipeArbiter {
         guard scrollContext.atLeadingEdge else { return .none }
         return .previous
     }
+
+    /// Guarded descendants resolve their own handoff because iOS 26 no longer
+    /// makes descendant gestures simultaneous with ancestor gestures.
+    static func outerAction(
+        for translation: CGSize,
+        origin: DragOrigin
+    ) -> Action {
+        guard origin == .ordinaryContent else { return .none }
+        return action(for: translation, origin: origin)
+    }
 }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SwipeArbiterTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SwipeArbiterTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+
+@testable import SliccFollower
+
+final class SwipeArbiterTests: XCTestCase {
+    private let leading = SwipeArbiter.ScrollContext(
+        atLeadingEdge: true, atTrailingEdge: false)
+    private let middle = SwipeArbiter.ScrollContext(
+        atLeadingEdge: false, atTrailingEdge: false)
+    private let trailing = SwipeArbiter.ScrollContext(
+        atLeadingEdge: false, atTrailingEdge: true)
+    private let nonOverflowing = SwipeArbiter.ScrollContext(
+        atLeadingEdge: true, atTrailingEdge: true)
+
+    func testOrdinaryContentNavigatesInBothDirections() {
+        XCTAssertEqual(action(horizontal: -100), .next)
+        XCTAssertEqual(action(horizontal: 100), .previous)
+    }
+
+    func testUnknownOriginFailsClosedInBothDirections() {
+        XCTAssertEqual(action(horizontal: -100, origin: .unknown), .none)
+        XCTAssertEqual(action(horizontal: 100, origin: .unknown), .none)
+    }
+
+    func testVerticalAndDiagonalDragsDoNotNavigate() {
+        XCTAssertEqual(action(horizontal: 100, vertical: 100), .none)
+        XCTAssertEqual(action(horizontal: 100, vertical: 70), .none)
+    }
+
+    func testDragBelowActionThresholdDoesNotNavigate() {
+        XCTAssertEqual(action(horizontal: -59), .none)
+        XCTAssertEqual(action(horizontal: 59), .none)
+    }
+
+    func testLeftDragRequiresTrailingEdge() {
+        XCTAssertEqual(action(horizontal: -100, origin: .guardedContent(middle)), .none)
+        XCTAssertEqual(action(horizontal: -100, origin: .guardedContent(leading)), .none)
+        XCTAssertEqual(action(horizontal: -100, origin: .guardedContent(trailing)), .next)
+    }
+
+    func testRightDragRequiresLeadingEdge() {
+        XCTAssertEqual(action(horizontal: 100, origin: .guardedContent(middle)), .none)
+        XCTAssertEqual(action(horizontal: 100, origin: .guardedContent(trailing)), .none)
+        XCTAssertEqual(action(horizontal: 100, origin: .guardedContent(leading)), .previous)
+    }
+
+    func testNonOverflowingScrollerDoesNotBlockNavigation() {
+        XCTAssertEqual(
+            action(horizontal: -100, origin: .guardedContent(nonOverflowing)), .next)
+        XCTAssertEqual(
+            action(horizontal: 100, origin: .guardedContent(nonOverflowing)), .previous)
+    }
+
+    func testMeasuredEdgesIncludeToleranceBounceAndNonOverflowingContent() {
+        let nearLeading = SwipeArbiter.ScrollContext(
+            offset: 0.5, contentWidth: 200, viewportWidth: 100)
+        let leadingBounce = SwipeArbiter.ScrollContext(
+            offset: -5, contentWidth: 200, viewportWidth: 100)
+        let trailingBounce = SwipeArbiter.ScrollContext(
+            offset: 105, contentWidth: 200, viewportWidth: 100)
+        let shortContent = SwipeArbiter.ScrollContext(
+            offset: 0, contentWidth: 80, viewportWidth: 100)
+
+        XCTAssertTrue(nearLeading.atLeadingEdge)
+        XCTAssertTrue(leadingBounce.atLeadingEdge)
+        XCTAssertTrue(trailingBounce.atTrailingEdge)
+        XCTAssertEqual(shortContent, nonOverflowing)
+    }
+
+    func testOuterGestureKeepsTouchDownSnapshotAfterInnerGestureEnds() {
+        let state = HorizontalScrollGestureState()
+        state.beginInnerGesture(context: middle)
+        state.beginOuterGesture(at: .zero)
+        state.endInnerGesture()
+
+        XCTAssertEqual(state.endOuterGesture(), .guardedContent(middle))
+
+        state.beginOuterGesture(at: .zero)
+        XCTAssertEqual(
+            state.endOuterGesture(), .ordinaryContent,
+            "completed inner drags must not leak context")
+    }
+
+    func testOuterFirstInnerCallbackLateFillsUnknownCapture() {
+        let state = HorizontalScrollGestureState()
+        let regionID = UUID()
+        state.updateRegion(
+            id: regionID,
+            frame: CGRect(x: 10, y: 20, width: 100, height: 40),
+            context: nil)
+
+        state.beginOuterGesture(at: CGPoint(x: 20, y: 30))
+        state.beginInnerGesture(context: middle)
+        state.endInnerGesture()
+
+        XCTAssertEqual(state.endOuterGesture(), .guardedContent(middle))
+    }
+
+    func testStartLocationLookupCapturesRegionAndTouchDownEdge() {
+        let state = HorizontalScrollGestureState()
+        let regionID = UUID()
+        let frame = CGRect(x: 10, y: 20, width: 100, height: 40)
+        state.updateRegion(id: regionID, frame: frame, context: leading)
+
+        XCTAssertEqual(
+            state.dragOrigin(at: CGPoint(x: 20, y: 30)), .guardedContent(leading))
+        XCTAssertEqual(
+            state.dragOrigin(at: CGPoint(x: 114, y: 30)), .guardedContent(leading),
+            "the visible code-block hit area may extend slightly beyond its viewport")
+        XCTAssertEqual(state.dragOrigin(at: CGPoint(x: 200, y: 30)), .ordinaryContent)
+
+        state.beginOuterGesture(at: CGPoint(x: 20, y: 30))
+        state.updateRegion(id: regionID, frame: frame, context: trailing)
+        XCTAssertEqual(
+            state.endOuterGesture(), .guardedContent(leading),
+            "the region edge must be captured before the inner scroller moves")
+
+        state.updateRegion(id: regionID, frame: frame, context: nil)
+        XCTAssertEqual(state.dragOrigin(at: CGPoint(x: 20, y: 30)), .unknown)
+    }
+
+    private func action(
+        horizontal: CGFloat,
+        vertical: CGFloat = 0,
+        origin: SwipeArbiter.DragOrigin = .ordinaryContent
+    ) -> SwipeArbiter.Action {
+        SwipeArbiter.action(
+            for: CGSize(width: horizontal, height: vertical),
+            origin: origin)
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SwipeArbiterTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SwipeArbiterTests.swift
@@ -51,19 +51,6 @@ final class SwipeArbiterTests: XCTestCase {
             action(horizontal: 100, origin: .guardedContent(nonOverflowing)), .previous)
     }
 
-    func testOuterGestureDefersGuardedContentToScroller() {
-        XCTAssertEqual(
-            SwipeArbiter.outerAction(
-                for: CGSize(width: -100, height: 4),
-                origin: .guardedContent(trailing)),
-            .none)
-        XCTAssertEqual(
-            SwipeArbiter.outerAction(
-                for: CGSize(width: -100, height: 4),
-                origin: .ordinaryContent),
-            .next)
-    }
-
     func testMeasuredEdgesIncludeToleranceBounceAndNonOverflowingContent() {
         let nearLeading = SwipeArbiter.ScrollContext(
             offset: 0.5, contentWidth: 200, viewportWidth: 100)

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SwipeArbiterTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SwipeArbiterTests.swift
@@ -51,6 +51,19 @@ final class SwipeArbiterTests: XCTestCase {
             action(horizontal: 100, origin: .guardedContent(nonOverflowing)), .previous)
     }
 
+    func testOuterGestureDefersGuardedContentToScroller() {
+        XCTAssertEqual(
+            SwipeArbiter.outerAction(
+                for: CGSize(width: -100, height: 4),
+                origin: .guardedContent(trailing)),
+            .none)
+        XCTAssertEqual(
+            SwipeArbiter.outerAction(
+                for: CGSize(width: -100, height: 4),
+                origin: .ordinaryContent),
+            .next)
+    }
+
     func testMeasuredEdgesIncludeToleranceBounceAndNonOverflowingContent() {
         let nearLeading = SwipeArbiter.ScrollContext(
             offset: 0.5, contentWidth: 200, viewportWidth: 100)

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
@@ -241,7 +241,8 @@ final class FixtureConversationUITests: XCTestCase {
         }
         XCTAssertTrue(
             waitForLabel("Fixture scoop 2", on: selection),
-            "At the trailing edge the same drag must hand off to scoop navigation")
+            "At the trailing edge the same drag must hand off to scoop navigation; "
+                + "gesture diagnostic: \(String(describing: selection.value))")
 
         dragLeft(across: ordinaryText, in: app)
         XCTAssertTrue(

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
@@ -233,7 +233,12 @@ final class FixtureConversationUITests: XCTestCase {
             codeBlock.frame.minX, leadingEdgeX - 20,
             "The guarded drag must still scroll the code block")
 
-        dragLeft(across: codeBlock, in: app)
+        // A single physical flick does not guarantee that every simulator
+        // width traverses the remaining content. Keep pulling through the
+        // bounded scroll range until one drag starts at the trailing edge.
+        for _ in 0..<3 where selection.label == "Fixture scoop 1" {
+            dragLeft(across: codeBlock, in: app)
+        }
         XCTAssertTrue(
             waitForLabel("Fixture scoop 2", on: selection),
             "At the trailing edge the same drag must hand off to scoop navigation")

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/FixtureConversationUITests.swift
@@ -69,6 +69,7 @@ final class FixtureConversationUITests: XCTestCase {
         "diagram.png",  // attachment chip on a bubble-less message
         "Allow npm publish?",  // tool_ui title, badge and meta stripped
         "Waiting for approval on the leader",  // tool_ui read-only body
+        "SWIPE_ARBITRATION_CODE_BLOCK_TRAILING_EDGE_MARKER",  // overflowing code block
     ]
 
     override func setUp() {
@@ -198,6 +199,51 @@ final class FixtureConversationUITests: XCTestCase {
             "Reload should rebuild the fixture transcript")
     }
 
+    func testCodeBlockScrollUsesRubberBandScoopHandoff() {
+        let app = launchFixtureApp()
+        let selection = app.staticTexts["fixture-scoop-selection"]
+        XCTAssertTrue(selection.waitForExistence(timeout: 60))
+        XCTAssertEqual(selection.label, "Fixture scoop 1")
+        XCTAssertTrue(waitForListToSettleAtBottom(in: app))
+
+        let codeBlock = app.staticTexts.matching(
+            NSPredicate(
+                format: "label CONTAINS %@",
+                "SWIPE_ARBITRATION_CODE_BLOCK_TRAILING_EDGE_MARKER")
+        ).firstMatch
+        let ordinaryText = app.staticTexts.matching(
+            NSPredicate(format: "label == %@", "A fenced code block:")
+        ).firstMatch
+
+        // The fixture starts at the newest message, so walk upward with a hard
+        // bound until both drag targets in the markdown message are hittable.
+        for _ in 0..<12 where !(codeBlock.isHittable && ordinaryText.isHittable) {
+            app.swipeDown()
+        }
+        XCTAssertTrue(codeBlock.isHittable, "The overflowing code-block renderer should appear")
+        XCTAssertTrue(ordinaryText.isHittable, "The ordinary-text control should appear")
+
+        let leadingEdgeX = codeBlock.frame.minX
+        dragLeft(across: codeBlock, in: app)
+
+        XCTAssertEqual(
+            selection.label, "Fixture scoop 1",
+            "A code block with room to scroll must keep the current scoop")
+        XCTAssertLessThan(
+            codeBlock.frame.minX, leadingEdgeX - 20,
+            "The guarded drag must still scroll the code block")
+
+        dragLeft(across: codeBlock, in: app)
+        XCTAssertTrue(
+            waitForLabel("Fixture scoop 2", on: selection),
+            "At the trailing edge the same drag must hand off to scoop navigation")
+
+        dragLeft(across: ordinaryText, in: app)
+        XCTAssertTrue(
+            waitForLabel("Fixture scoop 3", on: selection),
+            "Ordinary transcript text must not suppress scoop navigation")
+    }
+
     // MARK: - Helpers
 
     /// Launch straight into the fixture route.
@@ -287,5 +333,34 @@ final class FixtureConversationUITests: XCTestCase {
 
     private func isComplete(ids: Set<String>, labels: Set<String>) -> Bool {
         ids == Self.expectedMessageIds && missingMarkers(in: labels).isEmpty
+    }
+
+    private func dragLeft(across element: XCUIElement, in app: XCUIApplication) {
+        let visibleFrame = element.frame.intersection(app.frame)
+        XCTAssertGreaterThan(visibleFrame.width, 100, "Drag target must expose a horizontal span")
+        // The trailing 48pt dock is outside the chat gesture surface even when
+        // a wide text leaf reports an accessibility frame beneath it.
+        let chatTrailingEdge = app.frame.maxX - 48
+        let origin = app.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+        let start = origin.withOffset(
+            CGVector(dx: min(visibleFrame.maxX, chatTrailingEdge) - 12, dy: visibleFrame.midY))
+        let end = origin.withOffset(
+            CGVector(dx: visibleFrame.minX + 12, dy: visibleFrame.midY))
+        start.press(forDuration: 0.05, thenDragTo: end)
+    }
+
+    private func waitForLabel(
+        _ label: String,
+        on element: XCUIElement,
+        timeout: TimeInterval = 5
+    ) -> Bool {
+        XCTWaiter.wait(
+            for: [
+                XCTNSPredicateExpectation(
+                    predicate: NSPredicate(format: "label == %@", label),
+                    object: element)
+            ],
+            timeout: timeout
+        ) == .completed
     }
 }

--- a/packages/ios-app/SliccFollower/Views/AttachmentChips.swift
+++ b/packages/ios-app/SliccFollower/Views/AttachmentChips.swift
@@ -23,15 +23,14 @@ struct AttachmentChips: View {
     var body: some View {
         // `flex-wrap: wrap` on the web. A horizontal scroller is the closest
         // native equivalent that never truncates a long attachment list.
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 6) {
-                Spacer(minLength: 0)
-                ForEach(attachments) { attachment in
-                    chip(attachment)
-                }
+        HStack(spacing: 6) {
+            Spacer(minLength: 0)
+            ForEach(attachments) { attachment in
+                chip(attachment)
             }
-            .padding(.horizontal, 4)
         }
+        .padding(.horizontal, 4)
+        .horizontalScrollGuard(showsIndicators: false)
         .frame(maxWidth: .infinity, alignment: .trailing)
     }
 

--- a/packages/ios-app/SliccFollower/Views/ChatFixture.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatFixture.swift
@@ -78,9 +78,7 @@ enum ChatFixture {
                     A fenced code block:
 
                     ```swift
-                    func loadFixture() -> [ChatMessage] {
-                        return ChatFixture.makeMessages()
-                    }
+                    let SWIPE_ARBITRATION_CODE_BLOCK_TRAILING_EDGE_MARKER = ChatFixture.makeMessages()
                     ```
 
                     > Blockquotes should feel quieter than regular text.

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -276,6 +276,7 @@ struct ConversationView: View {
     @Binding var transcriptPosition: ScrollPosition
     @ObservedObject var ptt: PttController
     @State private var showNewSessionDialog = false
+    @StateObject private var horizontalScrollGestureState = HorizontalScrollGestureState()
     /// Mirrors `ChatView` so the nav-bar clusters follow the rail to the
     /// reachable edge.
     @AppStorage("leftHandedDock") private var leftHandedDock = false
@@ -310,6 +311,8 @@ struct ConversationView: View {
                 liveConversation
             }
         }
+        .environment(\.horizontalScrollGestureState, horizontalScrollGestureState)
+        .coordinateSpace(name: horizontalScrollGestureState.coordinateSpaceName)
         .background(palette.canvas)
         // The live session identifies itself through the compact switcher in
         // the corner, not through a nav title — two copies of the same scoop
@@ -488,32 +491,25 @@ struct ConversationView: View {
     /// the same filter as the scoop swipe (mostly-horizontal flicks only) so
     /// vertical scrolling stays untouched.
     private var frozenDismissGesture: some Gesture {
-        DragGesture(minimumDistance: 40, coordinateSpace: .local)
-            .onEnded { value in
-                let horizontal = value.translation.width
-                let vertical = value.translation.height
-                guard abs(horizontal) > abs(vertical) * 1.5 else { return }
-                if horizontal > 60 {
-                    appState.closeFrozenSession()
-                }
+        arbitratedScoopSwipeGesture(state: horizontalScrollGestureState) { action in
+            if action == .previous {
+                appState.closeFrozenSession()
             }
+        }
     }
 
     /// Horizontal drag gesture that routes to AppState's swipe handlers.
     private var swipeGesture: some Gesture {
-        DragGesture(minimumDistance: 40, coordinateSpace: .local)
-            .onEnded { value in
-                let horizontal = value.translation.width
-                let vertical = value.translation.height
-                guard abs(horizontal) > abs(vertical) * 1.5 else { return }
-                if horizontal < -60 {
-                    // Swipe left → next scoop
-                    appState.swipeToNextScoop()
-                } else if horizontal > 60 {
-                    // Swipe right → previous scoop (cone fallback)
-                    appState.swipeToPreviousScoop()
-                }
+        arbitratedScoopSwipeGesture(state: horizontalScrollGestureState) { action in
+            switch action {
+            case .next:
+                appState.swipeToNextScoop()
+            case .previous:
+                appState.swipeToPreviousScoop()
+            case .none:
+                break
             }
+        }
     }
 }
 
@@ -528,6 +524,8 @@ struct FixtureConversationView: View {
     @Binding var transcriptPosition: ScrollPosition
     @State private var messages: [ChatMessage] = ChatFixture.makeMessages()
     @State private var lastLick: String?
+    @State private var selectedFixtureScoop = 1
+    @StateObject private var horizontalScrollGestureState = HorizontalScrollGestureState()
     private static let log = Logger(subsystem: "com.slicc.follower", category: "Fixture")
 
     var body: some View {
@@ -542,15 +540,22 @@ struct FixtureConversationView: View {
                         .lineLimit(1)
                         .truncationMode(.middle)
                 } else {
-                    Text("UI Fixture — synthetic session")
-                        .font(.caption)
-                        .foregroundStyle(palette.ink.opacity(0.7))
-                        .accessibilityIdentifier("fixture-header")
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("UI Fixture — synthetic session")
+                            .font(.caption)
+                            .foregroundStyle(palette.ink.opacity(0.7))
+                            .accessibilityIdentifier("fixture-header")
+                        Text("Fixture scoop \(selectedFixtureScoop)")
+                            .font(.caption2.monospaced())
+                            .foregroundStyle(palette.ink.opacity(0.55))
+                            .accessibilityIdentifier("fixture-scoop-selection")
+                    }
                 }
                 Spacer()
                 Button("Reload") {
                     messages = ChatFixture.makeMessages()
                     lastLick = nil
+                    selectedFixtureScoop = 1
                 }
                 .font(.caption)
                 .buttonStyle(.bordered)
@@ -573,7 +578,10 @@ struct FixtureConversationView: View {
                 },
                 scrollPosition: $transcriptPosition
             )
+            .simultaneousGesture(fixtureSwipeGesture)
         }
+        .environment(\.horizontalScrollGestureState, horizontalScrollGestureState)
+        .coordinateSpace(name: horizontalScrollGestureState.coordinateSpaceName)
         .background(palette.canvas)
         .navigationTitle("UI Fixture")
         .navigationBarTitleDisplayMode(.inline)
@@ -591,6 +599,50 @@ struct FixtureConversationView: View {
         if let target { return "\(action) (→\(target))" }
         return action
     }
+
+    private var fixtureSwipeGesture: some Gesture {
+        arbitratedScoopSwipeGesture(state: horizontalScrollGestureState) { action in
+            switch action {
+            case .next:
+                selectedFixtureScoop = min(selectedFixtureScoop + 1, 3)
+            case .previous:
+                selectedFixtureScoop = max(selectedFixtureScoop - 1, 1)
+            case .none:
+                break
+            }
+        }
+    }
+}
+
+/// The live conversation and leaderless fixture share this exact arbitration path.
+private func arbitratedScoopSwipeGesture(
+    state: HorizontalScrollGestureState,
+    onAction: @escaping (SwipeArbiter.Action) -> Void
+) -> some Gesture {
+    let touchDownGesture = DragGesture(
+        minimumDistance: 0,
+        coordinateSpace: .named(state.coordinateSpaceName)
+    )
+    .onChanged { value in
+        state.beginOuterGesture(at: value.startLocation)
+    }
+    .onEnded { _ in
+        state.endTouchGesture()
+    }
+
+    let actionGesture = DragGesture(
+        minimumDistance: SwipeArbiter.gestureMinimumDistance,
+        coordinateSpace: .named(state.coordinateSpaceName)
+    )
+    .onChanged { value in
+        state.beginOuterGesture(at: value.startLocation)
+    }
+    .onEnded { value in
+        let origin = state.endOuterGesture()
+        onAction(SwipeArbiter.action(for: value.translation, origin: origin))
+    }
+
+    return actionGesture.simultaneously(with: touchDownGesture)
 }
 
 // MARK: - ScoopSwitcher

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -314,6 +314,7 @@ struct ConversationView: View {
             }
         }
         .environment(\.horizontalScrollGestureState, horizontalScrollGestureState)
+        .environment(\.horizontalScrollAction, handleTranscriptSwipe)
         .background(palette.canvas)
         // The live session identifies itself through the compact switcher in
         // the corner, not through a nav title — two copies of the same scoop
@@ -574,6 +575,7 @@ struct FixtureConversationView: View {
                 onAction: handleFixtureSwipe)
         }
         .environment(\.horizontalScrollGestureState, horizontalScrollGestureState)
+        .environment(\.horizontalScrollAction, handleFixtureSwipe)
         .background(palette.canvas)
         .navigationTitle("UI Fixture")
         .navigationBarTitleDisplayMode(.inline)
@@ -610,19 +612,14 @@ extension View {
         state: HorizontalScrollGestureState,
         onAction: @escaping (SwipeArbiter.Action) -> Void
     ) -> some View {
-        let transcript = coordinateSpace(name: state.coordinateSpaceName)
-        if #available(iOS 18.0, *) {
-            transcript.gesture(
-                TranscriptSwipeGesture(gestureState: state, onAction: onAction))
-        } else {
-            transcript.simultaneousGesture(
+        coordinateSpace(name: state.coordinateSpaceName)
+            .simultaneousGesture(
                 arbitratedScoopSwipeGesture(state: state, onAction: onAction))
-        }
     }
 }
 
-/// iOS 17 fallback; iOS 18+ uses `TranscriptSwipeGesture` so nested scroll
-/// gestures can opt into simultaneous recognition through UIKit's delegate.
+/// Parent observer for ordinary transcript content. On iOS 18+, guarded
+/// descendants resolve their own handoff through UIKit's delegate.
 private func arbitratedScoopSwipeGesture(
     state: HorizontalScrollGestureState,
     onAction: @escaping (SwipeArbiter.Action) -> Void
@@ -636,7 +633,11 @@ private func arbitratedScoopSwipeGesture(
     }
     .onEnded { value in
         let origin = state.endOuterGesture()
-        onAction(SwipeArbiter.action(for: value.translation, origin: origin))
+        if #available(iOS 18.0, *) {
+            onAction(SwipeArbiter.outerAction(for: value.translation, origin: origin))
+        } else {
+            onAction(SwipeArbiter.action(for: value.translation, origin: origin))
+        }
     }
 }
 

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -305,12 +305,9 @@ struct ConversationView: View {
                     onInlineSprinkleLick: { _, _ in },
                     scrollPosition: $transcriptPosition
                 )
-                .coordinateSpace(name: horizontalScrollGestureState.coordinateSpaceName)
-                .background {
-                    TranscriptSwipeGestureBridge(
-                        gestureState: horizontalScrollGestureState,
-                        onAction: handleTranscriptSwipe)
-                }
+                .transcriptSwipeGesture(
+                    state: horizontalScrollGestureState,
+                    onAction: handleTranscriptSwipe)
                 FrozenSessionBanner()
             } else {
                 liveConversation
@@ -460,12 +457,9 @@ struct ConversationView: View {
                 },
                 scrollPosition: $transcriptPosition
             )
-            .coordinateSpace(name: horizontalScrollGestureState.coordinateSpaceName)
-            .background {
-                TranscriptSwipeGestureBridge(
-                    gestureState: horizontalScrollGestureState,
-                    onAction: handleTranscriptSwipe)
-            }
+            .transcriptSwipeGesture(
+                state: horizontalScrollGestureState,
+                onAction: handleTranscriptSwipe)
 
             InputBar(
                 text: $inputText,
@@ -575,12 +569,9 @@ struct FixtureConversationView: View {
                 },
                 scrollPosition: $transcriptPosition
             )
-            .coordinateSpace(name: horizontalScrollGestureState.coordinateSpaceName)
-            .background {
-                TranscriptSwipeGestureBridge(
-                    gestureState: horizontalScrollGestureState,
-                    onAction: handleFixtureSwipe)
-            }
+            .transcriptSwipeGesture(
+                state: horizontalScrollGestureState,
+                onAction: handleFixtureSwipe)
         }
         .environment(\.horizontalScrollGestureState, horizontalScrollGestureState)
         .background(palette.canvas)
@@ -610,6 +601,42 @@ struct FixtureConversationView: View {
         case .none:
             break
         }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func transcriptSwipeGesture(
+        state: HorizontalScrollGestureState,
+        onAction: @escaping (SwipeArbiter.Action) -> Void
+    ) -> some View {
+        let transcript = coordinateSpace(name: state.coordinateSpaceName)
+        if #available(iOS 18.0, *) {
+            transcript.gesture(
+                TranscriptSwipeGesture(gestureState: state, onAction: onAction))
+        } else {
+            transcript.simultaneousGesture(
+                arbitratedScoopSwipeGesture(state: state, onAction: onAction))
+        }
+    }
+}
+
+/// iOS 17 fallback; iOS 18+ uses `TranscriptSwipeGesture` so nested scroll
+/// gestures can opt into simultaneous recognition through UIKit's delegate.
+private func arbitratedScoopSwipeGesture(
+    state: HorizontalScrollGestureState,
+    onAction: @escaping (SwipeArbiter.Action) -> Void
+) -> some Gesture {
+    DragGesture(
+        minimumDistance: SwipeArbiter.gestureMinimumDistance,
+        coordinateSpace: .named(state.coordinateSpaceName)
+    )
+    .onChanged { value in
+        state.beginOuterGesture(at: value.startLocation)
+    }
+    .onEnded { value in
+        let origin = state.endOuterGesture()
+        onAction(SwipeArbiter.action(for: value.translation, origin: origin))
     }
 }
 

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -541,6 +541,7 @@ struct FixtureConversationView: View {
                             .font(.caption2.monospaced())
                             .foregroundStyle(palette.ink.opacity(0.55))
                             .accessibilityIdentifier("fixture-scoop-selection")
+                            .accessibilityValue(horizontalScrollGestureState.swipeDiagnostic)
                     }
                 }
                 Spacer()

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -305,15 +305,18 @@ struct ConversationView: View {
                     onInlineSprinkleLick: { _, _ in },
                     scrollPosition: $transcriptPosition
                 )
-                .simultaneousGesture(frozenDismissGesture)
+                .coordinateSpace(name: horizontalScrollGestureState.coordinateSpaceName)
+                .background {
+                    TranscriptSwipeGestureBridge(
+                        gestureState: horizontalScrollGestureState,
+                        onAction: handleTranscriptSwipe)
+                }
                 FrozenSessionBanner()
             } else {
                 liveConversation
             }
         }
         .environment(\.horizontalScrollGestureState, horizontalScrollGestureState)
-        .environment(\.horizontalScrollAction, handleTranscriptSwipe)
-        .coordinateSpace(name: horizontalScrollGestureState.coordinateSpaceName)
         .background(palette.canvas)
         // The live session identifies itself through the compact switcher in
         // the corner, not through a nav title — two copies of the same scoop
@@ -457,9 +460,12 @@ struct ConversationView: View {
                 },
                 scrollPosition: $transcriptPosition
             )
-            // simultaneousGesture so the inner ScrollView keeps vertical scrolling;
-            // we only react to mostly-horizontal flicks (filtered in onEnded).
-            .simultaneousGesture(swipeGesture)
+            .coordinateSpace(name: horizontalScrollGestureState.coordinateSpaceName)
+            .background {
+                TranscriptSwipeGestureBridge(
+                    gestureState: horizontalScrollGestureState,
+                    onAction: handleTranscriptSwipe)
+            }
 
             InputBar(
                 text: $inputText,
@@ -485,22 +491,6 @@ struct ConversationView: View {
                 },
                 stagedAttachments: $stagedAttachments
             )
-        }
-    }
-
-    /// Right swipe anywhere on a frozen transcript dismisses back to live —
-    /// the same filter as the scoop swipe (mostly-horizontal flicks only) so
-    /// vertical scrolling stays untouched.
-    private var frozenDismissGesture: some Gesture {
-        arbitratedScoopSwipeGesture(state: horizontalScrollGestureState) { action in
-            handleTranscriptSwipe(action)
-        }
-    }
-
-    /// Horizontal drag gesture that routes to AppState's swipe handlers.
-    private var swipeGesture: some Gesture {
-        arbitratedScoopSwipeGesture(state: horizontalScrollGestureState) { action in
-            handleTranscriptSwipe(action)
         }
     }
 
@@ -585,11 +575,14 @@ struct FixtureConversationView: View {
                 },
                 scrollPosition: $transcriptPosition
             )
-            .simultaneousGesture(fixtureSwipeGesture)
+            .coordinateSpace(name: horizontalScrollGestureState.coordinateSpaceName)
+            .background {
+                TranscriptSwipeGestureBridge(
+                    gestureState: horizontalScrollGestureState,
+                    onAction: handleFixtureSwipe)
+            }
         }
         .environment(\.horizontalScrollGestureState, horizontalScrollGestureState)
-        .environment(\.horizontalScrollAction, handleFixtureSwipe)
-        .coordinateSpace(name: horizontalScrollGestureState.coordinateSpaceName)
         .background(palette.canvas)
         .navigationTitle("UI Fixture")
         .navigationBarTitleDisplayMode(.inline)
@@ -608,12 +601,6 @@ struct FixtureConversationView: View {
         return action
     }
 
-    private var fixtureSwipeGesture: some Gesture {
-        arbitratedScoopSwipeGesture(state: horizontalScrollGestureState) { action in
-            handleFixtureSwipe(action)
-        }
-    }
-
     private func handleFixtureSwipe(_ action: SwipeArbiter.Action) {
         switch action {
         case .next:
@@ -624,37 +611,6 @@ struct FixtureConversationView: View {
             break
         }
     }
-}
-
-/// The live conversation and leaderless fixture share this exact arbitration path.
-private func arbitratedScoopSwipeGesture(
-    state: HorizontalScrollGestureState,
-    onAction: @escaping (SwipeArbiter.Action) -> Void
-) -> some Gesture {
-    let touchDownGesture = DragGesture(
-        minimumDistance: 0,
-        coordinateSpace: .named(state.coordinateSpaceName)
-    )
-    .onChanged { value in
-        state.beginOuterGesture(at: value.startLocation)
-    }
-    .onEnded { _ in
-        state.endTouchGesture()
-    }
-
-    let actionGesture = DragGesture(
-        minimumDistance: SwipeArbiter.gestureMinimumDistance,
-        coordinateSpace: .named(state.coordinateSpaceName)
-    )
-    .onChanged { value in
-        state.beginOuterGesture(at: value.startLocation)
-    }
-    .onEnded { value in
-        let origin = state.endOuterGesture()
-        onAction(SwipeArbiter.outerAction(for: value.translation, origin: origin))
-    }
-
-    return actionGesture.simultaneously(with: touchDownGesture)
 }
 
 // MARK: - ScoopSwitcher

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -312,6 +312,7 @@ struct ConversationView: View {
             }
         }
         .environment(\.horizontalScrollGestureState, horizontalScrollGestureState)
+        .environment(\.horizontalScrollAction, handleTranscriptSwipe)
         .coordinateSpace(name: horizontalScrollGestureState.coordinateSpaceName)
         .background(palette.canvas)
         // The live session identifies itself through the compact switcher in
@@ -492,23 +493,29 @@ struct ConversationView: View {
     /// vertical scrolling stays untouched.
     private var frozenDismissGesture: some Gesture {
         arbitratedScoopSwipeGesture(state: horizontalScrollGestureState) { action in
-            if action == .previous {
-                appState.closeFrozenSession()
-            }
+            handleTranscriptSwipe(action)
         }
     }
 
     /// Horizontal drag gesture that routes to AppState's swipe handlers.
     private var swipeGesture: some Gesture {
         arbitratedScoopSwipeGesture(state: horizontalScrollGestureState) { action in
-            switch action {
-            case .next:
-                appState.swipeToNextScoop()
-            case .previous:
-                appState.swipeToPreviousScoop()
-            case .none:
-                break
-            }
+            handleTranscriptSwipe(action)
+        }
+    }
+
+    private func handleTranscriptSwipe(_ action: SwipeArbiter.Action) {
+        if appState.openFrozen != nil {
+            if action == .previous { appState.closeFrozenSession() }
+            return
+        }
+        switch action {
+        case .next:
+            appState.swipeToNextScoop()
+        case .previous:
+            appState.swipeToPreviousScoop()
+        case .none:
+            break
         }
     }
 }
@@ -581,6 +588,7 @@ struct FixtureConversationView: View {
             .simultaneousGesture(fixtureSwipeGesture)
         }
         .environment(\.horizontalScrollGestureState, horizontalScrollGestureState)
+        .environment(\.horizontalScrollAction, handleFixtureSwipe)
         .coordinateSpace(name: horizontalScrollGestureState.coordinateSpaceName)
         .background(palette.canvas)
         .navigationTitle("UI Fixture")
@@ -602,14 +610,18 @@ struct FixtureConversationView: View {
 
     private var fixtureSwipeGesture: some Gesture {
         arbitratedScoopSwipeGesture(state: horizontalScrollGestureState) { action in
-            switch action {
-            case .next:
-                selectedFixtureScoop = min(selectedFixtureScoop + 1, 3)
-            case .previous:
-                selectedFixtureScoop = max(selectedFixtureScoop - 1, 1)
-            case .none:
-                break
-            }
+            handleFixtureSwipe(action)
+        }
+    }
+
+    private func handleFixtureSwipe(_ action: SwipeArbiter.Action) {
+        switch action {
+        case .next:
+            selectedFixtureScoop = min(selectedFixtureScoop + 1, 3)
+        case .previous:
+            selectedFixtureScoop = max(selectedFixtureScoop - 1, 1)
+        case .none:
+            break
         }
     }
 }
@@ -639,7 +651,7 @@ private func arbitratedScoopSwipeGesture(
     }
     .onEnded { value in
         let origin = state.endOuterGesture()
-        onAction(SwipeArbiter.action(for: value.translation, origin: origin))
+        onAction(SwipeArbiter.outerAction(for: value.translation, origin: origin))
     }
 
     return actionGesture.simultaneously(with: touchDownGesture)

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -604,9 +604,9 @@ struct FixtureConversationView: View {
     }
 }
 
-private extension View {
+extension View {
     @ViewBuilder
-    func transcriptSwipeGesture(
+    fileprivate func transcriptSwipeGesture(
         state: HorizontalScrollGestureState,
         onAction: @escaping (SwipeArbiter.Action) -> Void
     ) -> some View {

--- a/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
+++ b/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
@@ -1,5 +1,6 @@
 import Combine
 import SwiftUI
+import UIKit
 
 /// Resolves transcript touch-down locations against guarded horizontal scrollers.
 final class HorizontalScrollGestureState: ObservableObject {
@@ -15,7 +16,6 @@ final class HorizontalScrollGestureState: ObservableObject {
     private var innerContext: SwipeArbiter.ScrollContext?
     private var capturedOrigin: SwipeArbiter.DragOrigin?
     private var outerGestureActive = false
-    private var touchActive = false
 
     func beginInnerGesture(context: SwipeArbiter.ScrollContext) {
         innerContext = context
@@ -56,22 +56,17 @@ final class HorizontalScrollGestureState: ObservableObject {
     }
 
     func beginOuterGesture(at startLocation: CGPoint) {
-        guard !touchActive else { return }
-        touchActive = true
+        guard !outerGestureActive else { return }
         outerGestureActive = true
         capturedOrigin =
             innerContext.map(SwipeArbiter.DragOrigin.guardedContent)
             ?? dragOrigin(at: startLocation)
     }
 
-    func endTouchGesture() {
-        touchActive = false
-    }
-
     func endOuterGesture() -> SwipeArbiter.DragOrigin {
         defer {
             outerGestureActive = false
-            touchActive = false
+            innerContext = nil
             capturedOrigin = nil
         }
         return capturedOrigin ?? .unknown
@@ -97,19 +92,10 @@ private struct HorizontalScrollGestureStateKey: EnvironmentKey {
     static let defaultValue = HorizontalScrollGestureState()
 }
 
-private struct HorizontalScrollActionKey: EnvironmentKey {
-    static let defaultValue: (SwipeArbiter.Action) -> Void = { _ in }
-}
-
 extension EnvironmentValues {
     var horizontalScrollGestureState: HorizontalScrollGestureState {
         get { self[HorizontalScrollGestureStateKey.self] }
         set { self[HorizontalScrollGestureStateKey.self] = newValue }
-    }
-
-    var horizontalScrollAction: (SwipeArbiter.Action) -> Void {
-        get { self[HorizontalScrollActionKey.self] }
-        set { self[HorizontalScrollActionKey.self] = newValue }
     }
 }
 
@@ -141,14 +127,12 @@ private struct HorizontalScrollGuardModifier: ViewModifier {
     let showsIndicators: Bool
 
     @Environment(\.horizontalScrollGestureState) private var gestureState
-    @Environment(\.horizontalScrollAction) private var horizontalScrollAction
     @State private var scrollCoordinateSpaceName = UUID()
     @State private var regionID = UUID()
     @State private var metrics = HorizontalScrollMetrics()
     @State private var viewportWidth: CGFloat = 0
     @State private var regionFrame = CGRect.null
     @State private var touchActive = false
-    @State private var capturedOrigin: SwipeArbiter.DragOrigin?
 
     func body(content: Content) -> some View {
         ScrollView(.horizontal, showsIndicators: showsIndicators) {
@@ -203,16 +187,11 @@ private struct HorizontalScrollGuardModifier: ViewModifier {
                     offset: metrics.offset,
                     contentWidth: metrics.contentWidth,
                     viewportWidth: effectiveViewportWidth(viewportWidth))
-                capturedOrigin = .guardedContent(context)
                 gestureState.beginInnerGesture(context: context)
             }
-            .onEnded { value in
-                let origin = capturedOrigin ?? .unknown
+            .onEnded { _ in
                 touchActive = false
-                capturedOrigin = nil
                 gestureState.endInnerGesture()
-                horizontalScrollAction(
-                    SwipeArbiter.action(for: value.translation, origin: origin))
             }
     }
 
@@ -235,6 +214,128 @@ private struct HorizontalScrollGuardModifier: ViewModifier {
 
     private func effectiveViewportWidth(_ measuredWidth: CGFloat) -> CGFloat {
         measuredWidth + HorizontalScrollGestureState.horizontalTouchSlop * 2
+    }
+}
+
+/// UIKit observer used because iOS 26 no longer makes a descendant SwiftUI
+/// gesture simultaneous with an ancestor gesture. The recognizer is installed
+/// on the hosting ancestor and explicitly cooperates with nested scroll views.
+struct TranscriptSwipeGestureBridge: UIViewRepresentable {
+    let gestureState: HorizontalScrollGestureState
+    let onAction: (SwipeArbiter.Action) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(gestureState: gestureState, onAction: onAction)
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.isUserInteractionEnabled = false
+        context.coordinator.update(
+            markerView: view, gestureState: gestureState, onAction: onAction)
+        DispatchQueue.main.async { context.coordinator.installIfPossible() }
+        return view
+    }
+
+    func updateUIView(_ view: UIView, context: Context) {
+        context.coordinator.update(
+            markerView: view, gestureState: gestureState, onAction: onAction)
+        DispatchQueue.main.async { context.coordinator.installIfPossible() }
+    }
+
+    static func dismantleUIView(_ view: UIView, coordinator: Coordinator) {
+        coordinator.uninstall()
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        private weak var markerView: UIView?
+        private weak var installedView: UIView?
+        private var gestureState: HorizontalScrollGestureState
+        private var onAction: (SwipeArbiter.Action) -> Void
+        private var panGesture: UIPanGestureRecognizer?
+        private var tracksCurrentGesture = false
+
+        init(
+            gestureState: HorizontalScrollGestureState,
+            onAction: @escaping (SwipeArbiter.Action) -> Void
+        ) {
+            self.gestureState = gestureState
+            self.onAction = onAction
+        }
+
+        func update(
+            markerView: UIView,
+            gestureState: HorizontalScrollGestureState,
+            onAction: @escaping (SwipeArbiter.Action) -> Void
+        ) {
+            self.markerView = markerView
+            self.gestureState = gestureState
+            self.onAction = onAction
+        }
+
+        func installIfPossible() {
+            guard let markerView, let target = hostingAncestor(of: markerView) else { return }
+            guard installedView !== target else { return }
+            uninstall()
+            let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+            pan.cancelsTouchesInView = false
+            pan.delegate = self
+            target.addGestureRecognizer(pan)
+            installedView = target
+            panGesture = pan
+        }
+
+        func uninstall() {
+            if let panGesture { installedView?.removeGestureRecognizer(panGesture) }
+            panGesture = nil
+            installedView = nil
+            tracksCurrentGesture = false
+        }
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard let markerView else { return false }
+            return markerView.bounds.contains(gestureRecognizer.location(in: markerView))
+        }
+
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            true
+        }
+
+        @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+            guard let markerView else { return }
+            switch gesture.state {
+            case .began:
+                tracksCurrentGesture = true
+                gestureState.beginOuterGesture(at: gesture.location(in: markerView))
+            case .ended:
+                guard tracksCurrentGesture else { return }
+                tracksCurrentGesture = false
+                let point = gesture.translation(in: markerView)
+                let origin = gestureState.endOuterGesture()
+                onAction(
+                    SwipeArbiter.action(
+                        for: CGSize(width: point.x, height: point.y),
+                        origin: origin))
+            case .cancelled, .failed:
+                guard tracksCurrentGesture else { return }
+                tracksCurrentGesture = false
+                _ = gestureState.endOuterGesture()
+            default:
+                break
+            }
+        }
+
+        private func hostingAncestor(of view: UIView) -> UIView? {
+            var candidate = view.superview
+            while let parent = candidate?.superview, !(parent is UIWindow) {
+                candidate = parent
+            }
+            return candidate
+        }
     }
 }
 

--- a/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
+++ b/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
@@ -218,43 +218,46 @@ private struct HorizontalScrollGuardModifier: ViewModifier {
 }
 
 /// UIKit observer used because iOS 26 no longer makes a descendant SwiftUI
-/// gesture simultaneous with an ancestor gesture. The recognizer is installed
-/// on the hosting ancestor and explicitly cooperates with nested scroll views.
-struct TranscriptSwipeGestureBridge: UIViewRepresentable {
+/// gesture simultaneous with an ancestor gesture. SwiftUI installs this
+/// recognizer in its own gesture graph, where the delegate can explicitly
+/// cooperate with nested scroll views.
+@available(iOS 18.0, *)
+struct TranscriptSwipeGesture: UIGestureRecognizerRepresentable {
     let gestureState: HorizontalScrollGestureState
     let onAction: (SwipeArbiter.Action) -> Void
 
-    func makeCoordinator() -> Coordinator {
+    func makeCoordinator(converter: CoordinateSpaceConverter) -> Coordinator {
         Coordinator(gestureState: gestureState, onAction: onAction)
     }
 
-    func makeUIView(context: Context) -> UIView {
-        let view = UIView()
-        view.backgroundColor = .clear
-        view.isUserInteractionEnabled = false
-        context.coordinator.update(
-            markerView: view, gestureState: gestureState, onAction: onAction)
-        DispatchQueue.main.async { context.coordinator.installIfPossible() }
-        return view
+    func makeUIGestureRecognizer(context: Context) -> UILongPressGestureRecognizer {
+        let gesture = UILongPressGestureRecognizer()
+        gesture.minimumPressDuration = 0
+        gesture.allowableMovement = .greatestFiniteMagnitude
+        gesture.cancelsTouchesInView = false
+        gesture.delegate = context.coordinator
+        return gesture
     }
 
-    func updateUIView(_ view: UIView, context: Context) {
+    func updateUIGestureRecognizer(
+        _ gestureRecognizer: UILongPressGestureRecognizer,
+        context: Context
+    ) {
         context.coordinator.update(
-            markerView: view, gestureState: gestureState, onAction: onAction)
-        DispatchQueue.main.async { context.coordinator.installIfPossible() }
+            gestureState: gestureState, onAction: onAction)
     }
 
-    static func dismantleUIView(_ view: UIView, coordinator: Coordinator) {
-        coordinator.uninstall()
+    func handleUIGestureRecognizerAction(
+        _ gestureRecognizer: UILongPressGestureRecognizer,
+        context: Context
+    ) {
+        context.coordinator.handle(gestureRecognizer)
     }
 
     final class Coordinator: NSObject, UIGestureRecognizerDelegate {
-        private weak var markerView: UIView?
-        private weak var installedView: UIView?
         private var gestureState: HorizontalScrollGestureState
         private var onAction: (SwipeArbiter.Action) -> Void
-        private var panGesture: UIPanGestureRecognizer?
-        private var tracksCurrentGesture = false
+        private var startLocation: CGPoint?
 
         init(
             gestureState: HorizontalScrollGestureState,
@@ -265,37 +268,11 @@ struct TranscriptSwipeGestureBridge: UIViewRepresentable {
         }
 
         func update(
-            markerView: UIView,
             gestureState: HorizontalScrollGestureState,
             onAction: @escaping (SwipeArbiter.Action) -> Void
         ) {
-            self.markerView = markerView
             self.gestureState = gestureState
             self.onAction = onAction
-        }
-
-        func installIfPossible() {
-            guard let markerView, let target = hostingAncestor(of: markerView) else { return }
-            guard installedView !== target else { return }
-            uninstall()
-            let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
-            pan.cancelsTouchesInView = false
-            pan.delegate = self
-            target.addGestureRecognizer(pan)
-            installedView = target
-            panGesture = pan
-        }
-
-        func uninstall() {
-            if let panGesture { installedView?.removeGestureRecognizer(panGesture) }
-            panGesture = nil
-            installedView = nil
-            tracksCurrentGesture = false
-        }
-
-        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-            guard let markerView else { return false }
-            return markerView.bounds.contains(gestureRecognizer.location(in: markerView))
         }
 
         func gestureRecognizer(
@@ -305,36 +282,30 @@ struct TranscriptSwipeGestureBridge: UIViewRepresentable {
             true
         }
 
-        @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
-            guard let markerView else { return }
+        func handle(_ gesture: UILongPressGestureRecognizer) {
+            guard let view = gesture.view else { return }
+            let location = gesture.location(in: view)
             switch gesture.state {
             case .began:
-                tracksCurrentGesture = true
-                gestureState.beginOuterGesture(at: gesture.location(in: markerView))
+                startLocation = location
+                gestureState.beginOuterGesture(at: location)
             case .ended:
-                guard tracksCurrentGesture else { return }
-                tracksCurrentGesture = false
-                let point = gesture.translation(in: markerView)
+                guard let startLocation else { return }
+                self.startLocation = nil
                 let origin = gestureState.endOuterGesture()
                 onAction(
                     SwipeArbiter.action(
-                        for: CGSize(width: point.x, height: point.y),
+                        for: CGSize(
+                            width: location.x - startLocation.x,
+                            height: location.y - startLocation.y),
                         origin: origin))
             case .cancelled, .failed:
-                guard tracksCurrentGesture else { return }
-                tracksCurrentGesture = false
+                guard startLocation != nil else { return }
+                startLocation = nil
                 _ = gestureState.endOuterGesture()
             default:
                 break
             }
-        }
-
-        private func hostingAncestor(of view: UIView) -> UIView? {
-            var candidate = view.superview
-            while let parent = candidate?.superview, !(parent is UIWindow) {
-                candidate = parent
-            }
-            return candidate
         }
     }
 }

--- a/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
+++ b/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
@@ -97,10 +97,19 @@ private struct HorizontalScrollGestureStateKey: EnvironmentKey {
     static let defaultValue = HorizontalScrollGestureState()
 }
 
+private struct HorizontalScrollActionKey: EnvironmentKey {
+    static let defaultValue: (SwipeArbiter.Action) -> Void = { _ in }
+}
+
 extension EnvironmentValues {
     var horizontalScrollGestureState: HorizontalScrollGestureState {
         get { self[HorizontalScrollGestureStateKey.self] }
         set { self[HorizontalScrollGestureStateKey.self] = newValue }
+    }
+
+    var horizontalScrollAction: (SwipeArbiter.Action) -> Void {
+        get { self[HorizontalScrollActionKey.self] }
+        set { self[HorizontalScrollActionKey.self] = newValue }
     }
 }
 
@@ -132,12 +141,14 @@ private struct HorizontalScrollGuardModifier: ViewModifier {
     let showsIndicators: Bool
 
     @Environment(\.horizontalScrollGestureState) private var gestureState
+    @Environment(\.horizontalScrollAction) private var horizontalScrollAction
     @State private var scrollCoordinateSpaceName = UUID()
     @State private var regionID = UUID()
     @State private var metrics = HorizontalScrollMetrics()
     @State private var viewportWidth: CGFloat = 0
     @State private var regionFrame = CGRect.null
     @State private var touchActive = false
+    @State private var capturedOrigin: SwipeArbiter.DragOrigin?
 
     func body(content: Content) -> some View {
         ScrollView(.horizontal, showsIndicators: showsIndicators) {
@@ -188,15 +199,20 @@ private struct HorizontalScrollGuardModifier: ViewModifier {
             .onChanged { _ in
                 guard !touchActive else { return }
                 touchActive = true
-                gestureState.beginInnerGesture(
-                    context: SwipeArbiter.ScrollContext(
-                        offset: metrics.offset,
-                        contentWidth: metrics.contentWidth,
-                        viewportWidth: effectiveViewportWidth(viewportWidth)))
+                let context = SwipeArbiter.ScrollContext(
+                    offset: metrics.offset,
+                    contentWidth: metrics.contentWidth,
+                    viewportWidth: effectiveViewportWidth(viewportWidth))
+                capturedOrigin = .guardedContent(context)
+                gestureState.beginInnerGesture(context: context)
             }
-            .onEnded { _ in
+            .onEnded { value in
+                let origin = capturedOrigin ?? .unknown
                 touchActive = false
+                capturedOrigin = nil
                 gestureState.endInnerGesture()
+                horizontalScrollAction(
+                    SwipeArbiter.action(for: value.translation, origin: origin))
             }
     }
 

--- a/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
+++ b/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
@@ -320,8 +320,10 @@ private struct GuardedScrollSwipeGesture: UIGestureRecognizerRepresentable {
         }
 
         func handle(_ gesture: UILongPressGestureRecognizer) {
-            guard let view = gesture.view else { return }
-            let location = gesture.location(in: view)
+            guard let window = gesture.view?.window else { return }
+            // The recognizer's SwiftUI host can move with scroll content.
+            // Window coordinates preserve the finger's full translation.
+            let location = gesture.location(in: window)
             switch gesture.state {
             case .began:
                 startLocation = location

--- a/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
+++ b/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
@@ -92,10 +92,19 @@ private struct HorizontalScrollGestureStateKey: EnvironmentKey {
     static let defaultValue = HorizontalScrollGestureState()
 }
 
+private struct HorizontalScrollActionKey: EnvironmentKey {
+    static let defaultValue: (SwipeArbiter.Action) -> Void = { _ in }
+}
+
 extension EnvironmentValues {
     var horizontalScrollGestureState: HorizontalScrollGestureState {
         get { self[HorizontalScrollGestureStateKey.self] }
         set { self[HorizontalScrollGestureStateKey.self] = newValue }
+    }
+
+    var horizontalScrollAction: (SwipeArbiter.Action) -> Void {
+        get { self[HorizontalScrollActionKey.self] }
+        set { self[HorizontalScrollActionKey.self] = newValue }
     }
 }
 
@@ -127,6 +136,7 @@ private struct HorizontalScrollGuardModifier: ViewModifier {
     let showsIndicators: Bool
 
     @Environment(\.horizontalScrollGestureState) private var gestureState
+    @Environment(\.horizontalScrollAction) private var horizontalScrollAction
     @State private var scrollCoordinateSpaceName = UUID()
     @State private var regionID = UUID()
     @State private var metrics = HorizontalScrollMetrics()
@@ -134,8 +144,9 @@ private struct HorizontalScrollGuardModifier: ViewModifier {
     @State private var regionFrame = CGRect.null
     @State private var touchActive = false
 
+    @ViewBuilder
     func body(content: Content) -> some View {
-        ScrollView(.horizontal, showsIndicators: showsIndicators) {
+        let scroller = ScrollView(.horizontal, showsIndicators: showsIndicators) {
             content.background {
                 GeometryReader { proxy in
                     Color.clear.preference(
@@ -174,8 +185,17 @@ private struct HorizontalScrollGuardModifier: ViewModifier {
             regionFrame = newFrame
             publishRegion(metrics: metrics, viewportWidth: viewportWidth, frame: newFrame)
         }
-        .simultaneousGesture(touchDownGesture)
         .onDisappear { gestureState.removeRegion(id: regionID) }
+
+        if #available(iOS 18.0, *) {
+            scroller.gesture(
+                GuardedScrollSwipeGesture(
+                    gestureState: gestureState,
+                    scrollContext: scrollContext,
+                    onAction: horizontalScrollAction))
+        } else {
+            scroller.simultaneousGesture(touchDownGesture)
+        }
     }
 
     private var touchDownGesture: some Gesture {
@@ -215,19 +235,28 @@ private struct HorizontalScrollGuardModifier: ViewModifier {
     private func effectiveViewportWidth(_ measuredWidth: CGFloat) -> CGFloat {
         measuredWidth + HorizontalScrollGestureState.horizontalTouchSlop * 2
     }
+
+    private var scrollContext: SwipeArbiter.ScrollContext {
+        SwipeArbiter.ScrollContext(
+            offset: metrics.offset,
+            contentWidth: metrics.contentWidth,
+            viewportWidth: effectiveViewportWidth(viewportWidth))
+    }
 }
 
-/// UIKit observer used because iOS 26 no longer makes a descendant SwiftUI
-/// gesture simultaneous with an ancestor gesture. SwiftUI installs this
-/// recognizer in its own gesture graph, where the delegate can explicitly
-/// cooperate with nested scroll views.
+/// UIKit observer installed directly on guarded scrollers because iOS 26 no
+/// longer makes their SwiftUI gestures simultaneous with ancestor gestures.
 @available(iOS 18.0, *)
-struct TranscriptSwipeGesture: UIGestureRecognizerRepresentable {
+private struct GuardedScrollSwipeGesture: UIGestureRecognizerRepresentable {
     let gestureState: HorizontalScrollGestureState
+    let scrollContext: SwipeArbiter.ScrollContext
     let onAction: (SwipeArbiter.Action) -> Void
 
     func makeCoordinator(converter: CoordinateSpaceConverter) -> Coordinator {
-        Coordinator(gestureState: gestureState, onAction: onAction)
+        Coordinator(
+            gestureState: gestureState,
+            scrollContext: scrollContext,
+            onAction: onAction)
     }
 
     func makeUIGestureRecognizer(context: Context) -> UILongPressGestureRecognizer {
@@ -244,7 +273,9 @@ struct TranscriptSwipeGesture: UIGestureRecognizerRepresentable {
         context: Context
     ) {
         context.coordinator.update(
-            gestureState: gestureState, onAction: onAction)
+            gestureState: gestureState,
+            scrollContext: scrollContext,
+            onAction: onAction)
     }
 
     func handleUIGestureRecognizerAction(
@@ -256,22 +287,28 @@ struct TranscriptSwipeGesture: UIGestureRecognizerRepresentable {
 
     final class Coordinator: NSObject, UIGestureRecognizerDelegate {
         private var gestureState: HorizontalScrollGestureState
+        private var scrollContext: SwipeArbiter.ScrollContext
         private var onAction: (SwipeArbiter.Action) -> Void
         private var startLocation: CGPoint?
+        private var capturedContext: SwipeArbiter.ScrollContext?
 
         init(
             gestureState: HorizontalScrollGestureState,
+            scrollContext: SwipeArbiter.ScrollContext,
             onAction: @escaping (SwipeArbiter.Action) -> Void
         ) {
             self.gestureState = gestureState
+            self.scrollContext = scrollContext
             self.onAction = onAction
         }
 
         func update(
             gestureState: HorizontalScrollGestureState,
+            scrollContext: SwipeArbiter.ScrollContext,
             onAction: @escaping (SwipeArbiter.Action) -> Void
         ) {
             self.gestureState = gestureState
+            self.scrollContext = scrollContext
             self.onAction = onAction
         }
 
@@ -288,21 +325,24 @@ struct TranscriptSwipeGesture: UIGestureRecognizerRepresentable {
             switch gesture.state {
             case .began:
                 startLocation = location
-                gestureState.beginOuterGesture(at: location)
+                capturedContext = scrollContext
+                gestureState.beginInnerGesture(context: scrollContext)
             case .ended:
-                guard let startLocation else { return }
+                guard let startLocation, let capturedContext else { return }
                 self.startLocation = nil
-                let origin = gestureState.endOuterGesture()
+                self.capturedContext = nil
+                gestureState.endInnerGesture()
                 onAction(
                     SwipeArbiter.action(
                         for: CGSize(
                             width: location.x - startLocation.x,
                             height: location.y - startLocation.y),
-                        origin: origin))
+                        origin: .guardedContent(capturedContext)))
             case .cancelled, .failed:
                 guard startLocation != nil else { return }
                 startLocation = nil
-                _ = gestureState.endOuterGesture()
+                capturedContext = nil
+                gestureState.endInnerGesture()
             default:
                 break
             }

--- a/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
+++ b/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
@@ -340,11 +340,12 @@ private struct GuardedScrollSwipeGesture: UIGestureRecognizerRepresentable {
             let location = gesture.location(in: window)
             switch gesture.state {
             case .began:
+                let context = liveScrollContext(for: gesture)
                 startLocation = location
-                capturedContext = scrollContext
-                gestureState.beginInnerGesture(context: scrollContext)
+                capturedContext = context
+                gestureState.beginInnerGesture(context: context)
                 gestureState.recordSwipeDiagnostic(
-                    "began leading=\(scrollContext.atLeadingEdge) trailing=\(scrollContext.atTrailingEdge)")
+                    "began leading=\(context.atLeadingEdge) trailing=\(context.atTrailingEdge)")
             case .changed:
                 guard let startLocation else { return }
                 gestureState.recordSwipeDiagnostic(
@@ -378,6 +379,29 @@ private struct GuardedScrollSwipeGesture: UIGestureRecognizerRepresentable {
             default:
                 break
             }
+        }
+
+        private func liveScrollContext(
+            for gesture: UIGestureRecognizer
+        ) -> SwipeArbiter.ScrollContext {
+            var view = gesture.view
+            while let currentView = view {
+                if let scrollView = currentView as? UIScrollView {
+                    let insets = scrollView.adjustedContentInset
+                    let contentWidth =
+                        scrollView.contentSize.width + insets.left + insets.right
+                    guard contentWidth > scrollView.bounds.width + 1 else {
+                        view = currentView.superview
+                        continue
+                    }
+                    return SwipeArbiter.ScrollContext(
+                        offset: scrollView.contentOffset.x + insets.left,
+                        contentWidth: contentWidth,
+                        viewportWidth: scrollView.bounds.width)
+                }
+                view = currentView.superview
+            }
+            return scrollContext
         }
     }
 }

--- a/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
+++ b/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
@@ -1,0 +1,230 @@
+import Combine
+import SwiftUI
+
+/// Resolves transcript touch-down locations against guarded horizontal scrollers.
+final class HorizontalScrollGestureState: ObservableObject {
+    let coordinateSpaceName = UUID()
+    fileprivate static let horizontalTouchSlop: CGFloat = 8
+
+    private struct Region {
+        let frame: CGRect
+        let context: SwipeArbiter.ScrollContext?
+    }
+
+    private var regions: [UUID: Region] = [:]
+    private var innerContext: SwipeArbiter.ScrollContext?
+    private var capturedOrigin: SwipeArbiter.DragOrigin?
+    private var outerGestureActive = false
+    private var touchActive = false
+
+    func beginInnerGesture(context: SwipeArbiter.ScrollContext) {
+        innerContext = context
+        guard outerGestureActive else { return }
+        if case .some(.guardedContent) = capturedOrigin { return }
+        capturedOrigin = .guardedContent(context)
+    }
+
+    func endInnerGesture() {
+        innerContext = nil
+    }
+
+    func updateRegion(
+        id: UUID,
+        frame: CGRect,
+        context: SwipeArbiter.ScrollContext?
+    ) {
+        guard !frame.isNull, frame.width > 0, frame.height > 0 else {
+            regions[id] = nil
+            return
+        }
+        regions[id] = Region(frame: frame, context: context)
+    }
+
+    func removeRegion(id: UUID) {
+        regions[id] = nil
+    }
+
+    func dragOrigin(at location: CGPoint) -> SwipeArbiter.DragOrigin {
+        let region = regions.values
+            .filter {
+                $0.frame.insetBy(dx: -Self.horizontalTouchSlop, dy: 0).contains(location)
+            }
+            .min { area(of: $0.frame) < area(of: $1.frame) }
+        guard let region else { return .ordinaryContent }
+        guard let context = region.context else { return .unknown }
+        return .guardedContent(context)
+    }
+
+    func beginOuterGesture(at startLocation: CGPoint) {
+        guard !touchActive else { return }
+        touchActive = true
+        outerGestureActive = true
+        capturedOrigin =
+            innerContext.map(SwipeArbiter.DragOrigin.guardedContent)
+            ?? dragOrigin(at: startLocation)
+    }
+
+    func endTouchGesture() {
+        touchActive = false
+    }
+
+    func endOuterGesture() -> SwipeArbiter.DragOrigin {
+        defer {
+            outerGestureActive = false
+            touchActive = false
+            capturedOrigin = nil
+        }
+        return capturedOrigin ?? .unknown
+    }
+
+    private func area(of frame: CGRect) -> CGFloat {
+        frame.width * frame.height
+    }
+}
+
+private struct HorizontalScrollRegionFrameKey: PreferenceKey {
+    static let defaultValue = CGRect.null
+
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        let next = nextValue()
+        if !next.isNull {
+            value = next
+        }
+    }
+}
+
+private struct HorizontalScrollGestureStateKey: EnvironmentKey {
+    static let defaultValue = HorizontalScrollGestureState()
+}
+
+extension EnvironmentValues {
+    var horizontalScrollGestureState: HorizontalScrollGestureState {
+        get { self[HorizontalScrollGestureStateKey.self] }
+        set { self[HorizontalScrollGestureStateKey.self] = newValue }
+    }
+}
+
+private struct HorizontalScrollMetrics: Equatable {
+    var contentWidth: CGFloat = 0
+    var offset: CGFloat = 0
+}
+
+private struct HorizontalScrollMetricsKey: PreferenceKey {
+    static let defaultValue = HorizontalScrollMetrics()
+
+    static func reduce(
+        value: inout HorizontalScrollMetrics,
+        nextValue: () -> HorizontalScrollMetrics
+    ) {
+        value = nextValue()
+    }
+}
+
+private struct HorizontalScrollViewportWidthKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+private struct HorizontalScrollGuardModifier: ViewModifier {
+    let showsIndicators: Bool
+
+    @Environment(\.horizontalScrollGestureState) private var gestureState
+    @State private var scrollCoordinateSpaceName = UUID()
+    @State private var regionID = UUID()
+    @State private var metrics = HorizontalScrollMetrics()
+    @State private var viewportWidth: CGFloat = 0
+    @State private var regionFrame = CGRect.null
+    @State private var touchActive = false
+
+    func body(content: Content) -> some View {
+        ScrollView(.horizontal, showsIndicators: showsIndicators) {
+            content.background {
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: HorizontalScrollMetricsKey.self,
+                        value: HorizontalScrollMetrics(
+                            contentWidth: proxy.size.width,
+                            offset: -proxy.frame(in: .named(scrollCoordinateSpaceName)).minX
+                        ))
+                }
+            }
+        }
+        .coordinateSpace(name: scrollCoordinateSpaceName)
+        .padding(.horizontal, -HorizontalScrollGestureState.horizontalTouchSlop)
+        .background {
+            GeometryReader { proxy in
+                Color.clear
+                    .preference(
+                        key: HorizontalScrollViewportWidthKey.self,
+                        value: proxy.size.width
+                    )
+                    .preference(
+                        key: HorizontalScrollRegionFrameKey.self,
+                        value: proxy.frame(in: .named(gestureState.coordinateSpaceName))
+                    )
+            }
+        }
+        .onPreferenceChange(HorizontalScrollMetricsKey.self) { newMetrics in
+            metrics = newMetrics
+            publishRegion(metrics: newMetrics, viewportWidth: viewportWidth, frame: regionFrame)
+        }
+        .onPreferenceChange(HorizontalScrollViewportWidthKey.self) { newWidth in
+            viewportWidth = newWidth
+            publishRegion(metrics: metrics, viewportWidth: newWidth, frame: regionFrame)
+        }
+        .onPreferenceChange(HorizontalScrollRegionFrameKey.self) { newFrame in
+            regionFrame = newFrame
+            publishRegion(metrics: metrics, viewportWidth: viewportWidth, frame: newFrame)
+        }
+        .simultaneousGesture(touchDownGesture)
+        .onDisappear { gestureState.removeRegion(id: regionID) }
+    }
+
+    private var touchDownGesture: some Gesture {
+        DragGesture(minimumDistance: 0, coordinateSpace: .local)
+            .onChanged { _ in
+                guard !touchActive else { return }
+                touchActive = true
+                gestureState.beginInnerGesture(
+                    context: SwipeArbiter.ScrollContext(
+                        offset: metrics.offset,
+                        contentWidth: metrics.contentWidth,
+                        viewportWidth: effectiveViewportWidth(viewportWidth)))
+            }
+            .onEnded { _ in
+                touchActive = false
+                gestureState.endInnerGesture()
+            }
+    }
+
+    private func publishRegion(
+        metrics: HorizontalScrollMetrics,
+        viewportWidth: CGFloat,
+        frame: CGRect
+    ) {
+        let context: SwipeArbiter.ScrollContext? =
+            if metrics.contentWidth > 0, viewportWidth > 0 {
+                SwipeArbiter.ScrollContext(
+                    offset: metrics.offset,
+                    contentWidth: metrics.contentWidth,
+                    viewportWidth: effectiveViewportWidth(viewportWidth))
+            } else {
+                nil
+            }
+        gestureState.updateRegion(id: regionID, frame: frame, context: context)
+    }
+
+    private func effectiveViewportWidth(_ measuredWidth: CGFloat) -> CGFloat {
+        measuredWidth + HorizontalScrollGestureState.horizontalTouchSlop * 2
+    }
+}
+
+extension View {
+    /// Wraps content in an iOS 17 horizontal scroller that arbitrates parent swipes.
+    func horizontalScrollGuard(showsIndicators: Bool = true) -> some View {
+        modifier(HorizontalScrollGuardModifier(showsIndicators: showsIndicators))
+    }
+}

--- a/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
+++ b/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
@@ -6,6 +6,7 @@ import UIKit
 final class HorizontalScrollGestureState: ObservableObject {
     let coordinateSpaceName = UUID()
     fileprivate static let horizontalTouchSlop: CGFloat = 8
+    @Published private(set) var swipeDiagnostic = "idle"
 
     private struct Region {
         let frame: CGRect
@@ -26,6 +27,10 @@ final class HorizontalScrollGestureState: ObservableObject {
 
     func endInnerGesture() {
         innerContext = nil
+    }
+
+    func recordSwipeDiagnostic(_ diagnostic: String) {
+        swipeDiagnostic = diagnostic
     }
 
     func updateRegion(
@@ -338,22 +343,38 @@ private struct GuardedScrollSwipeGesture: UIGestureRecognizerRepresentable {
                 startLocation = location
                 capturedContext = scrollContext
                 gestureState.beginInnerGesture(context: scrollContext)
+                gestureState.recordSwipeDiagnostic(
+                    "began leading=\(scrollContext.atLeadingEdge) trailing=\(scrollContext.atTrailingEdge)")
+            case .changed:
+                guard let startLocation else { return }
+                gestureState.recordSwipeDiagnostic(
+                    "changed dx=\(Int(location.x - startLocation.x)) dy=\(Int(location.y - startLocation.y))")
             case .ended:
                 guard let startLocation, let capturedContext else { return }
                 self.startLocation = nil
                 self.capturedContext = nil
                 gestureState.endInnerGesture()
-                onAction(
-                    SwipeArbiter.action(
-                        for: CGSize(
-                            width: location.x - startLocation.x,
-                            height: location.y - startLocation.y),
-                        origin: .guardedContent(capturedContext)))
+                let translation = CGSize(
+                    width: location.x - startLocation.x,
+                    height: location.y - startLocation.y)
+                let action = SwipeArbiter.action(
+                    for: translation,
+                    origin: .guardedContent(capturedContext))
+                let diagnostic =
+                    "ended dx=\(Int(translation.width)) dy=\(Int(translation.height)) "
+                    + "leading=\(capturedContext.atLeadingEdge) "
+                    + "trailing=\(capturedContext.atTrailingEdge) "
+                    + "action=\(String(describing: action))"
+                gestureState.recordSwipeDiagnostic(
+                    diagnostic)
+                onAction(action)
             case .cancelled, .failed:
                 guard startLocation != nil else { return }
                 startLocation = nil
                 capturedContext = nil
                 gestureState.endInnerGesture()
+                gestureState.recordSwipeDiagnostic(
+                    gesture.state == .cancelled ? "cancelled" : "failed")
             default:
                 break
             }

--- a/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
+++ b/packages/ios-app/SliccFollower/Views/HorizontalScrollGuard.swift
@@ -147,15 +147,15 @@ private struct HorizontalScrollGuardModifier: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
         let scroller = ScrollView(.horizontal, showsIndicators: showsIndicators) {
-            content.background {
-                GeometryReader { proxy in
-                    Color.clear.preference(
-                        key: HorizontalScrollMetricsKey.self,
-                        value: HorizontalScrollMetrics(
-                            contentWidth: proxy.size.width,
-                            offset: -proxy.frame(in: .named(scrollCoordinateSpaceName)).minX
-                        ))
-                }
+            if #available(iOS 18.0, *) {
+                measuredContent(content)
+                    .gesture(
+                        GuardedScrollSwipeGesture(
+                            gestureState: gestureState,
+                            scrollContext: scrollContext,
+                            onAction: horizontalScrollAction))
+            } else {
+                measuredContent(content)
             }
         }
         .coordinateSpace(name: scrollCoordinateSpaceName)
@@ -188,13 +188,22 @@ private struct HorizontalScrollGuardModifier: ViewModifier {
         .onDisappear { gestureState.removeRegion(id: regionID) }
 
         if #available(iOS 18.0, *) {
-            scroller.gesture(
-                GuardedScrollSwipeGesture(
-                    gestureState: gestureState,
-                    scrollContext: scrollContext,
-                    onAction: horizontalScrollAction))
+            scroller
         } else {
             scroller.simultaneousGesture(touchDownGesture)
+        }
+    }
+
+    private func measuredContent(_ content: Content) -> some View {
+        content.background {
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: HorizontalScrollMetricsKey.self,
+                    value: HorizontalScrollMetrics(
+                        contentWidth: proxy.size.width,
+                        offset: -proxy.frame(in: .named(scrollCoordinateSpaceName)).minX
+                    ))
+            }
         }
     }
 

--- a/packages/ios-app/SliccFollower/Views/MarkdownText.swift
+++ b/packages/ios-app/SliccFollower/Views/MarkdownText.swift
@@ -150,30 +150,29 @@ struct MarkdownText: View {
     /// comparison squeezed into a phone's width is unreadable, and the
     /// leader emits those routinely.
     private func tableView(_ table: MarkdownTable) -> some View {
-        ScrollView(.horizontal, showsIndicators: true) {
-            Grid(alignment: .topLeading, horizontalSpacing: 0, verticalSpacing: 0) {
+        Grid(alignment: .topLeading, horizontalSpacing: 0, verticalSpacing: 0) {
+            GridRow {
+                ForEach(Array(table.header.enumerated()), id: \.offset) { column, cell in
+                    tableCell(
+                        cell, alignment: table.alignments[safe: column] ?? .leading,
+                        isHeader: true, zebra: false)
+                }
+            }
+            Rectangle()
+                .fill(palette.line)
+                .frame(height: 1)
+                .gridCellColumns(max(table.columnCount, 1))
+            ForEach(Array(table.rows.enumerated()), id: \.offset) { rowIndex, row in
                 GridRow {
-                    ForEach(Array(table.header.enumerated()), id: \.offset) { column, cell in
+                    ForEach(Array(row.enumerated()), id: \.offset) { column, cell in
                         tableCell(
                             cell, alignment: table.alignments[safe: column] ?? .leading,
-                            isHeader: true, zebra: false)
-                    }
-                }
-                Rectangle()
-                    .fill(palette.line)
-                    .frame(height: 1)
-                    .gridCellColumns(max(table.columnCount, 1))
-                ForEach(Array(table.rows.enumerated()), id: \.offset) { rowIndex, row in
-                    GridRow {
-                        ForEach(Array(row.enumerated()), id: \.offset) { column, cell in
-                            tableCell(
-                                cell, alignment: table.alignments[safe: column] ?? .leading,
-                                isHeader: false, zebra: !rowIndex.isMultiple(of: 2))
-                        }
+                            isHeader: false, zebra: !rowIndex.isMultiple(of: 2))
                     }
                 }
             }
         }
+        .horizontalScrollGuard()
         .background(palette.field)
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .overlay(
@@ -207,15 +206,14 @@ struct MarkdownText: View {
                     .padding(.top, 8)
                     .padding(.bottom, 4)
             }
-            ScrollView(.horizontal, showsIndicators: true) {
-                Text(code)
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(palette.ink.opacity(0.85))
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, language != nil ? 4 : 12)
-                    .padding(.bottom, 8)
-                    .textSelection(.enabled)
-            }
+            Text(code)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(palette.ink.opacity(0.85))
+                .padding(.horizontal, 12)
+                .padding(.vertical, language != nil ? 4 : 12)
+                .padding(.bottom, 8)
+                .textSelection(.enabled)
+                .horizontalScrollGuard()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(palette.field)

--- a/packages/ios-app/SliccFollower/Views/MessageBubble.swift
+++ b/packages/ios-app/SliccFollower/Views/MessageBubble.swift
@@ -581,21 +581,20 @@ struct LickRow: View {
             if isExpanded, !bodies.isEmpty {
                 VStack(alignment: .leading, spacing: 4) {
                     ForEach(Array(bodies.enumerated()), id: \.offset) { index, body in
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            Text(body)
-                                .font(.system(size: 12, design: .monospaced))
-                                .foregroundStyle(palette.ink.opacity(0.75))
-                                .textSelection(.enabled)
-                                .padding(12)
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(bodyBackground)
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .strokeBorder(borderColor, lineWidth: 0.5)
-                        )
-                        .accessibilityIdentifier("lick-part-\(index)")
+                        Text(body)
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundStyle(palette.ink.opacity(0.75))
+                            .textSelection(.enabled)
+                            .padding(12)
+                            .horizontalScrollGuard(showsIndicators: false)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(bodyBackground)
+                            .clipShape(RoundedRectangle(cornerRadius: 10))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .strokeBorder(borderColor, lineWidth: 0.5)
+                            )
+                            .accessibilityIdentifier("lick-part-\(index)")
                     }
                 }
                 .padding(.top, 4)


### PR DESCRIPTION
Closes #1892

## Problem

`ChatView.liveConversation` attaches the scoop-switch drag as a `.simultaneousGesture` over the whole transcript. Because it is *simultaneous*, a horizontal drag that a nested `ScrollView(.horizontal)` consumes for scrolling **also** reaches the outer gesture and fires `swipeToNextScoop()` / `swipeToPreviousScoop()`. Scrolling a wide code block sideways silently switched scoops.

Affected nested scrollers: fenced code blocks and GFM tables (`MarkdownText`), expanded tool bodies (`MessageBubble`), and the attachment chip strip (`AttachmentChips`).

## Approach

A rubber-band handoff. The inner scroller owns the drag until it is pinned at the edge the drag pulls away from; only then does scoop navigation take over. Drag right hands off only at the leading edge, drag left only at the trailing edge. A non-overflowing scroller is at both edges, so it never blocks.

Edge state is sampled at drag **start**, before the inner scroller moves — sampling at drag end would read the post-scroll position and get the wrong answer.

- `Models/SwipeArbiter.swift` — the pure rule, unit-testable with no view hierarchy.
- `Views/HorizontalScrollGuard.swift` — the `horizontalScrollGuard()` modifier that publishes each scroller's frame and scroll metrics and resolves a drag's origin against them.

Deployment target is iOS 17, so the iOS 18 scroll APIs (`onScrollPhaseChange`, `onGeometryChange`) were unavailable; the modifier uses preference keys and a named coordinate space instead.

## Three non-obvious defects found while verifying

The pure-logic unit tests passed while the fix still failed on a live fixture. Instrumented repro on the simulator surfaced three separate issues, all now fixed and covered:

1. **Callback order is parent-first.** SwiftUI does not guarantee the order of `onChanged` for simultaneous gestures, and empirically the outer 40pt `DragGesture` fires *before* the inner zero-distance one (outer at 08:15:24.044, inner at 08:15:24.045). The outer gesture therefore captured `nil` context for the entire drag. Capture is now order-independent: the inner gesture late-fills the origin when the outer is already active.
2. **Unknown context failed open.** `nil` context and "ordinary content" were indistinguishable, and both allowed the swipe — which is why the plumbing gap became a user-visible bug rather than a no-op. Unknown origin inside a guarded region now fails **closed**.
3. **Edge math used the wrong width.** The modifier applies `-8pt` horizontal padding, so the physical viewport is 16pt wider than measured. A scroller at offset 294.33 with a 338pt effective viewport was at its trailing max but reported as "middle". Edge math now uses the effective viewport.

## Testing

- `SwipeArbiterTests` covers the rule plus both gesture orderings and the fail-closed case.
- `FixtureConversationUITests.testCodeBlockScrollUsesRubberBandScoopHandoff` covers the code-block path end to end on the leaderless fixture route.
- SwiftLint, strict `swift format lint`, and the full iOS build/test/coverage gate pass. Coverage rose to 67.99% lines / 59.65% functions / 60.59% regions.

## Known gaps (non-blocking)

No end-to-end UI coverage yet for the table, tool-body, or attachment guards, frozen-session dismissal, the rightward leading-edge handoff, or the fail-closed unknown-metrics state. The arbiter logic and the code-block path are covered.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author