### PR TITLE
feat(ios-app): render scoop lifecycle state and context fullness

### DIFF
--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -14,6 +14,7 @@ This file covers the iOS follower app in `packages/ios-app/`.
 | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `SliccFollower/App/SliccFollowerApp.swift`, `App/AppState.swift`                                     | App entry + central `@MainActor AppState`                                                                               |
 | `SliccFollower/Models/SyncProtocol.swift`                                                            | Partial `Codable` mirror of `packages/shared-ts/src/tray-sync-protocol.ts`                                              |
+| `SliccFollower/Models/ScoopStatus.swift`                                                             | View-independent scoop lifecycle and context-fullness presentation model                                                |
 | `SliccFollower/Models/ChatMessage.swift`, `Models/TrayTypes.swift`, `Models/TrayChunkFraming.swift`  | Chat/signaling types and transport chunk reassembly                                                                     |
 | `SliccFollower/Sync/Keepalive.swift`                                                                 | `DataChannelKeepalive` ping/pong actor (used by `AppState`)                                                             |
 | `SliccFollower/Sync/TerminalClient.swift`                                                            | Single-flight `exec.*` client for the leader shell, byte output, cancellation, and disconnect handling                  |
@@ -201,19 +202,18 @@ scheme, so `swift-coverage-check.sh --xcodebuild` picks up both. No test needs a
 leader: the `-uiTestFixtureRoute YES` launch argument reaches the leaderless
 **UI Fixture** route (`FixtureConversationView`) without a tap, and
 `-uiTestSessionsFixture/Empty YES` seed the iCloud sessions list from an
-in-memory backend (fixture URLs dial `127.0.0.1:1`, failing hermetically). `UITestHooks`
-(`App/UITestHooks.swift`) reads it and is `#if DEBUG` only — a shipped binary
+in-memory backend. `-uiTestScoopStatusFixture` covers every lifecycle plus
+low/near-limit/absent fill; `-uiTestReduceMotion` keeps the fullness cue static.
+`UITestHooks` (`App/UITestHooks.swift`) reads them and is `#if DEBUG` only — a shipped binary
 must not carry a flag that skips the connection path. The failure-state test
 dials `http://127.0.0.1:1/…` — refused without DNS or egress, so
 `Connection Failed` arrives in seconds.
 `-uiTestCompletedTurn YES` feeds `message_start` + `content_done` + `status:
 ready` through the real dispatcher, proving settlement without `turn_end`.
 
-- **Put accessibility identifiers on leaves.** SwiftUI pushes one onto a
-  container's leaves instead of minting a container, so an identifier on a
-  `VStack` yields tagged leaves and no `otherElements` match — and
-  `.accessibilityElement(children: .contain)` suppresses that propagation rather
-  than fixing it. Every leaf in a message row carries `message-<id>`.
+- **Put accessibility identifiers on leaves.** SwiftUI propagates a container id
+  to leaves; `.accessibilityElement(children: .contain)` suppresses rather than
+  fixes that behavior. Every message-row leaf carries `message-<id>`.
 - **Row ids alone are blind.** Because every leaf carries `message-<id>`, a row
   still matches when its specialized renderer is gone. A new fixture variant
   also needs a `variantMarkers` string only that renderer can emit.

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		E8F341988A6006B0132BFD61 /* ChatPresentationStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 072D67E727EF4751A1F46665 /* ChatPresentationStateTests.swift */; };
 		EDCEBDF62330D1775F1B4EE2 /* LinkHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB9ADA61005F3F96BE8CDE2 /* LinkHeader.swift */; };
 		F13E566C40F05F6F3ED297BD /* SliccAgentAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80C9AA05D0F49F7E284BEC5 /* SliccAgentAvatarView.swift */; };
+		F266887FC83BB1D23A4D0441 /* ScoopStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD1AA2BFCF961C6F3372B78 /* ScoopStatus.swift */; };
 		F5AC500C53CC1A9251A5718B /* SprinkleWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C3A976D441E4BB628F2183 /* SprinkleWebView.swift */; };
 		F5B6044724F8133C934A5143 /* LickEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF41895CF5F76A1CD2B671E /* LickEvent.swift */; };
 		F908DA74A70E1C7F16EC6AD8 /* SyncProtocolCorpusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */; };
@@ -286,6 +287,7 @@
 		F9555BBF8AC72C74630432D1 /* theme-vectors.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "theme-vectors.json"; sourceTree = "<group>"; };
 		FA2246D17E400D5616AD36E0 /* SliccAgentAvatarTilt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliccAgentAvatarTilt.swift; sourceTree = "<group>"; };
 		FC17E730D500B3482A2952ED /* AppStateStreamingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateStreamingTests.swift; sourceTree = "<group>"; };
+		FAD1AA2BFCF961C6F3372B78 /* ScoopStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoopStatus.swift; sourceTree = "<group>"; };
 		FD162F974FA1F7C5C51E1727 /* ConnectionRouteUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionRouteUITests.swift; sourceTree = "<group>"; };
 		FD6CEFD575FD21C28BEC39F5 /* tray-sync-corpus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tray-sync-corpus.json"; sourceTree = "<group>"; };
 		FDB1EE73D7F0AA0AE4B8BC83 /* AppStateDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateDelivery.swift; sourceTree = "<group>"; };
@@ -386,6 +388,7 @@
 				2D75B552EEAA18730A8843B9 /* MarkdownBlock.swift */,
 				9A73EE3E38934A8DE13AF2BD /* MemoryStore.swift */,
 				5F779D2634D4AED6D1AEDA07 /* PttController.swift */,
+				FAD1AA2BFCF961C6F3372B78 /* ScoopStatus.swift */,
 				9EF40B2C78468173C75F958F /* SliccAgentAvatarGeometry.swift */,
 				FA2246D17E400D5616AD36E0 /* SliccAgentAvatarTilt.swift */,
 				0A51DB1BA99DAE89F21CF736 /* SVGPath.swift */,
@@ -743,6 +746,7 @@
 				68FA70C9EC1A7C1137CC277D /* PttOverlayView.swift in Sources */,
 				1C51604116AA20BE57F33B46 /* RemoteTabCard.swift in Sources */,
 				1B1D78732EE937BE2DBF2C05 /* SVGPath.swift in Sources */,
+				F266887FC83BB1D23A4D0441 /* ScoopStatus.swift in Sources */,
 				3A9E122F6A6C4C0F6258C5C6 /* SettingsView.swift in Sources */,
 				E6AE9D960C36AC71ED33D18E /* ShellLayout.swift in Sources */,
 				47960F08DC8B7DD9E31F586B /* SliccAgentAvatarGeometry.swift in Sources */,

--- a/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.pbxproj
@@ -130,10 +130,12 @@
 		EDCEBDF62330D1775F1B4EE2 /* LinkHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB9ADA61005F3F96BE8CDE2 /* LinkHeader.swift */; };
 		F13E566C40F05F6F3ED297BD /* SliccAgentAvatarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80C9AA05D0F49F7E284BEC5 /* SliccAgentAvatarView.swift */; };
 		F266887FC83BB1D23A4D0441 /* ScoopStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD1AA2BFCF961C6F3372B78 /* ScoopStatus.swift */; };
+		F2C8373CBF5775D4189C7B82 /* ScoopStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E209029F63F2427997E161 /* ScoopStatusTests.swift */; };
 		F5AC500C53CC1A9251A5718B /* SprinkleWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C3A976D441E4BB628F2183 /* SprinkleWebView.swift */; };
 		F5B6044724F8133C934A5143 /* LickEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF41895CF5F76A1CD2B671E /* LickEvent.swift */; };
 		F908DA74A70E1C7F16EC6AD8 /* SyncProtocolCorpusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C81AE341D6F9E262EEA65EF /* SyncProtocolCorpusTests.swift */; };
 		FA28410D2D764BBA8EF08E0E /* ShellLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B99AEB1D5213A4F05B3D1D0 /* ShellLayoutTests.swift */; };
+		F95870EFC1D01FEEBA2FA80F /* ScoopStatusUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7B6364A38EB8C2C30749907 /* ScoopStatusUITests.swift */; };
 		FA619188A03965E77BE27A09 /* FilesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83613696C70A0EF218A19B6D /* FilesUITests.swift */; };
 		FAC7347D5CB648E85CEACBCF /* TerminalUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2510ED24DEED53DF7825A362 /* TerminalUITests.swift */; };
 		FBC5D9F3A8263FCAE3C6C6C5 /* NewSessionMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16A253ACC35EEB12798224E /* NewSessionMessageTests.swift */; };
@@ -168,6 +170,7 @@
 		0A51DB1BA99DAE89F21CF736 /* SVGPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SVGPath.swift; sourceTree = "<group>"; };
 		11B186EDFDE184DC8B3215C4 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		12FDDE8F74ACEEEACDA73346 /* FsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FsClient.swift; sourceTree = "<group>"; };
+		13E209029F63F2427997E161 /* ScoopStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoopStatusTests.swift; sourceTree = "<group>"; };
 		1572105F0B5819E4CC07BD84 /* ThemeEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEngine.swift; sourceTree = "<group>"; };
 		18BF55CBA000161C54E4770C /* CdpPreviewClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CdpPreviewClient.swift; sourceTree = "<group>"; };
 		1F2EECDCB4AF899D3071D13C /* InlineSprinkleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineSprinkleView.swift; sourceTree = "<group>"; };
@@ -249,6 +252,7 @@
 		B3BE6D707649AD21C5912013 /* ThemePalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemePalette.swift; sourceTree = "<group>"; };
 		B4C27643E1CF51B1F1B38003 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		B6BD423A10DF2C2C310F3689 /* RemoteTabUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTabUITests.swift; sourceTree = "<group>"; };
+		B7B6364A38EB8C2C30749907 /* ScoopStatusUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoopStatusUITests.swift; sourceTree = "<group>"; };
 		BBB646EF0D0006D1A43F527D /* ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessage.swift; sourceTree = "<group>"; };
 		BBE0A7D88487F7712E451646 /* CDPBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDPBridge.swift; sourceTree = "<group>"; };
 		BDA931BF1BE121985E2FB3EE /* Keepalive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keepalive.swift; sourceTree = "<group>"; };
@@ -332,6 +336,7 @@
 				A16A253ACC35EEB12798224E /* NewSessionMessageTests.swift */,
 				8551D5DAD74B9BFB7CC2B76D /* PttControllerTests.swift */,
 				8B99AEB1D5213A4F05B3D1D0 /* ShellLayoutTests.swift */,
+				13E209029F63F2427997E161 /* ScoopStatusTests.swift */,
 				5A30A613A67EAAAA1298638B /* SliccAgentAvatarGeometryTests.swift */,
 				066BAF2F283227600FB92506 /* SteerMessageTests.swift */,
 				695356CA7F082C3287CFB228 /* SVGPathTests.swift */,
@@ -442,6 +447,7 @@
 				E7EF3911627A88E5691B3949 /* NewSessionUITests.swift */,
 				075FA82F3967B4E37A76C59A /* PttUITests.swift */,
 				B6BD423A10DF2C2C310F3689 /* RemoteTabUITests.swift */,
+				B7B6364A38EB8C2C30749907 /* ScoopStatusUITests.swift */,
 				26D6B6B896CB48304A39DAB8 /* SteerUITests.swift */,
 				2510ED24DEED53DF7825A362 /* TerminalUITests.swift */,
 			);
@@ -794,6 +800,7 @@
 				C5E734A68251BBE47EBE506D /* NewSessionUITests.swift in Sources */,
 				41FD9C8701A419C994CF2704 /* PttUITests.swift in Sources */,
 				726B3A4A70B54A313E5BF3A1 /* RemoteTabUITests.swift in Sources */,
+				F95870EFC1D01FEEBA2FA80F /* ScoopStatusUITests.swift in Sources */,
 				D3441201E520337FA883076A /* SteerUITests.swift in Sources */,
 				FAC7347D5CB648E85CEACBCF /* TerminalUITests.swift in Sources */,
 			);
@@ -823,6 +830,7 @@
 				9C28D445499995ADA861D75F /* PttControllerTests.swift in Sources */,
 				7782C370E6882C97EB6FC236 /* SVGPathTests.swift in Sources */,
 				FA28410D2D764BBA8EF08E0E /* ShellLayoutTests.swift in Sources */,
+				F2C8373CBF5775D4189C7B82 /* ScoopStatusTests.swift in Sources */,
 				941662107E886C9BA55F2658 /* SliccAgentAvatarGeometryTests.swift in Sources */,
 				9ECC362CC8EBA3629542A6E7 /* SteerMessageTests.swift in Sources */,
 				F908DA74A70E1C7F16EC6AD8 /* SyncProtocolCorpusTests.swift in Sources */,

--- a/packages/ios-app/SliccFollower/App/AppState.swift
+++ b/packages/ios-app/SliccFollower/App/AppState.swift
@@ -185,6 +185,13 @@ class AppState: ObservableObject {
         if let history = UserDefaults.standard.stringArray(forKey: "joinUrlHistory") {
             joinUrlHistory = history
         }
+        #if DEBUG
+            if let fixtureScoops = UITestHooks.scoopStatusFixture() {
+                scoops = fixtureScoops
+                selectedScoopJid = fixtureScoops.first?.jid
+                leaderActiveScoopJid = fixtureScoops.first?.jid
+            }
+        #endif
     }
 
     // MARK: - Private Networking / Sync

--- a/packages/ios-app/SliccFollower/App/UITestHooks.swift
+++ b/packages/ios-app/SliccFollower/App/UITestHooks.swift
@@ -28,6 +28,42 @@ import UIKit
             UserDefaults.standard.string(forKey: "uiTestAvatarFixture")
         }
 
+        /// Seed the scoop switcher with every lifecycle treatment plus low,
+        /// near-limit, and fully absent status values. The fixture is consumed
+        /// by `AppState` before the first view renders, so no leader is needed.
+        static func scoopStatusFixture() -> [ScoopSummary]? {
+            guard UserDefaults.standard.bool(forKey: "uiTestScoopStatusFixture") else {
+                return nil
+            }
+            return [
+                scoop(jid: "fixture-working", label: "Working Scoop", state: "working", fill: 64),
+                scoop(jid: "fixture-broken", label: "Broken Scoop", state: "broken", fill: 82),
+                scoop(
+                    jid: "fixture-initializing", label: "Initializing Scoop",
+                    state: "initializing", fill: 12),
+                scoop(jid: "fixture-idle", label: "Idle Scoop", state: "idle", fill: 0),
+                scoop(
+                    jid: "fixture-near-limit", label: "Near Limit Scoop", state: "idle",
+                    fill: 95),
+                scoop(jid: "fixture-low-fill", label: "Low Fill Scoop", state: "idle", fill: 5),
+                scoop(jid: "fixture-unknown", label: "Unknown Scoop", state: nil, fill: nil),
+            ]
+        }
+
+        /// Deterministically expose the system Reduce Motion environment to UI
+        /// tests without changing a shared simulator's persistent settings.
+        static var reducesMotion: Bool {
+            UserDefaults.standard.bool(forKey: "uiTestReduceMotion")
+        }
+
+        private static func scoop(
+            jid: String, label: String, state: String?, fill: Double?
+        ) -> ScoopSummary {
+            ScoopSummary(
+                jid: jid, name: jid, folder: "/scoops/\(jid)", isCone: false,
+                assistantLabel: label, trigger: nil, state: state, fill: fill)
+        }
+
         /// Force the connection banner into a given state. The stalled and
         /// gave-up states are otherwise only reachable by starving a real
         /// leader of pings or exhausting a real reconnect budget, neither of

--- a/packages/ios-app/SliccFollower/Models/ScoopStatus.swift
+++ b/packages/ios-app/SliccFollower/Models/ScoopStatus.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+enum ScoopLifecycle: String, CaseIterable, Equatable, Sendable {
+    case working
+    case broken
+    case initializing
+    case idle
+    case unknown
+
+    init(state: String?) {
+        self = state.flatMap(Self.init(rawValue:)) ?? .unknown
+    }
+}
+
+struct ScoopStatus: Equatable, Sendable {
+    static let nearLimitThreshold = 75.0
+
+    let lifecycle: ScoopLifecycle
+    let fullness: Double?
+
+    init(state: String?, fill: Double?) {
+        lifecycle = ScoopLifecycle(state: state)
+        fullness = fill.map { value in
+            value.isFinite ? min(100, max(0, value)) : 0
+        }
+    }
+
+    var isNearLimit: Bool {
+        fullness.map { $0 >= Self.nearLimitThreshold } ?? false
+    }
+
+    func accessibilityPhrase(label: String) -> String {
+        let fillPhrase =
+            fullness.map { "\(Int($0.rounded()))% context fill" }
+            ?? "context fill unknown"
+        return "\(label): \(lifecycle.rawValue), \(fillPhrase)"
+    }
+}
+
+extension ScoopSummary {
+    var status: ScoopStatus {
+        ScoopStatus(state: state, fill: fill)
+    }
+}

--- a/packages/ios-app/SliccFollower/Models/SliccAgentAvatarGeometry.swift
+++ b/packages/ios-app/SliccFollower/Models/SliccAgentAvatarGeometry.swift
@@ -22,18 +22,18 @@ struct SliccAgentAvatarGeometry: Equatable, Sendable {
     let type: AvatarType
     let color: String
     let eyes: EyeState
-    let fill: Double
+    let fill: Double?
     let blink: Bool
     let sideLength: Double
 
     init(
-        type: AvatarType, color: String, eyes: EyeState = .open, fill: Double = 0,
+        type: AvatarType, color: String, eyes: EyeState = .open, fill: Double? = nil,
         blink: Bool = false, sideLength: Double = 26
     ) {
         self.type = type
         self.color = color
         self.eyes = eyes
-        self.fill = min(100, max(0, fill))
+        self.fill = fill.map { min(100, max(0, $0)) }
         self.blink = blink
         self.sideLength = max(0, sideLength)
     }
@@ -69,7 +69,8 @@ struct SliccAgentAvatarGeometry: Equatable, Sendable {
         return Point(x: proposed.x * scale, y: proposed.y * scale)
     }
 
-    static func fillScale(for fill: Double) -> Double {
+    static func fillScale(for fill: Double?) -> Double {
+        guard let fill else { return 1 }
         let clampedFill = min(100, max(0, fill))
         if clampedFill <= 50 { return 1 }
         if clampedFill >= 85 { return 2.2 }
@@ -97,16 +98,17 @@ struct SliccAgentAvatarGeometry: Equatable, Sendable {
 extension ScoopSummary {
     func avatarGeometry(sideLength: Double = 26) -> SliccAgentAvatarGeometry {
         let type: SliccAgentAvatarGeometry.AvatarType = isCone ? .cone : .scoop
-        let state = state ?? "idle"
-        let eyes: SliccAgentAvatarGeometry.EyeState
-        switch state {
-        case "broken": eyes = .dead
-        case "initializing": eyes = .none
-        default: eyes = .open
-        }
+        let scoopStatus = status
+        let eyes: SliccAgentAvatarGeometry.EyeState =
+            switch scoopStatus.lifecycle {
+            case .broken: .dead
+            case .initializing: .none
+            case .working, .idle, .unknown: .open
+            }
         return .init(
-            type: type, color: avatarColor, eyes: eyes, fill: fill ?? 0,
-            blink: state == "working", sideLength: sideLength)
+            type: type, color: avatarColor, eyes: eyes, fill: scoopStatus.fullness,
+            blink: scoopStatus.lifecycle == .working,
+            sideLength: sideLength)
     }
 
     /// Mirrors `scoopColor`: JS iterates scalars, while `charCodeAt(0)` deliberately

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/ScoopStatusTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/ScoopStatusTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+@testable import SliccFollower
+
+final class ScoopStatusTests: XCTestCase {
+    func testLifecycleMapsEveryWireValueAndUnknowns() {
+        XCTAssertEqual(ScoopLifecycle(state: "working"), .working)
+        XCTAssertEqual(ScoopLifecycle(state: "broken"), .broken)
+        XCTAssertEqual(ScoopLifecycle(state: "initializing"), .initializing)
+        XCTAssertEqual(ScoopLifecycle(state: "idle"), .idle)
+        XCTAssertEqual(ScoopLifecycle(state: nil), .unknown)
+        XCTAssertEqual(ScoopLifecycle(state: "future-state"), .unknown)
+    }
+
+    func testFullnessPreservesAbsenceAndClampsPresentValues() {
+        XCTAssertNil(ScoopStatus(state: "idle", fill: nil).fullness)
+        XCTAssertEqual(ScoopStatus(state: "idle", fill: -1).fullness, 0)
+        XCTAssertEqual(ScoopStatus(state: "idle", fill: 42).fullness, 42)
+        XCTAssertEqual(ScoopStatus(state: "idle", fill: 101).fullness, 100)
+    }
+
+    func testNearLimitBoundaryMatchesWeb() {
+        XCTAssertFalse(ScoopStatus(state: "working", fill: nil).isNearLimit)
+        XCTAssertFalse(ScoopStatus(state: "working", fill: 74.999).isNearLimit)
+        XCTAssertTrue(ScoopStatus(state: "working", fill: 75).isNearLimit)
+        XCTAssertTrue(ScoopStatus(state: "working", fill: 100).isNearLimit)
+    }
+
+    func testAccessibilityPhraseWithStateAndFill() {
+        let status = ScoopStatus(state: "broken", fill: 82)
+
+        XCTAssertEqual(
+            status.accessibilityPhrase(label: "Reviewer"),
+            "Reviewer: broken, 82% context fill")
+    }
+
+    func testAccessibilityPhraseWithUnknownState() {
+        let status = ScoopStatus(state: nil, fill: 64)
+
+        XCTAssertEqual(
+            status.accessibilityPhrase(label: "Reviewer"),
+            "Reviewer: unknown, 64% context fill")
+    }
+
+    func testAccessibilityPhraseWithUnknownFill() {
+        let status = ScoopStatus(state: "working", fill: nil)
+
+        XCTAssertEqual(
+            status.accessibilityPhrase(label: "Reviewer"),
+            "Reviewer: working, context fill unknown")
+    }
+
+    func testAccessibilityPhraseWithUnknownStateAndFill() {
+        let status = ScoopStatus(state: nil, fill: nil)
+
+        XCTAssertEqual(
+            status.accessibilityPhrase(label: "Reviewer"),
+            "Reviewer: unknown, context fill unknown")
+    }
+
+    func testScoopSummaryBuildsStatusPresentationValue() {
+        let summary = ScoopSummary(
+            jid: "reviewer", name: "reviewer", folder: "/scoops/reviewer", isCone: false,
+            assistantLabel: "Reviewer", trigger: nil, state: "broken", fill: 82)
+
+        XCTAssertEqual(summary.status, ScoopStatus(state: "broken", fill: 82))
+    }
+}

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SliccAgentAvatarGeometryTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/SliccAgentAvatarGeometryTests.swift
@@ -117,11 +117,25 @@ final class SliccAgentAvatarGeometryTests: XCTestCase {
         }
     }
 
-    func testScoopSummaryNilFillMapsToZero() {
-        let geometry = scoopSummary(isCone: false, fill: nil).avatarGeometry()
+    func testScoopSummaryAbsentFillStaysAbsent() {
+        let geometry = scoopSummary(isCone: false, state: nil, fill: nil).avatarGeometry()
 
-        XCTAssertEqual(geometry.fill, 0)
-        XCTAssertFalse(geometry.fill.isNaN)
+        XCTAssertNil(geometry.fill)
+        XCTAssertEqual(geometry.pupilRadius, 0.167 * 26, accuracy: accuracy)
+    }
+
+    func testScoopSummaryMapsLifecycleToWebEyeStates() {
+        XCTAssertEqual(
+            scoopSummary(isCone: false, state: "broken", fill: 20).avatarGeometry().eyes,
+            .dead)
+        XCTAssertEqual(
+            scoopSummary(isCone: false, state: "initializing", fill: 20).avatarGeometry().eyes,
+            .none)
+        for state in ["working", "idle", nil] as [String?] {
+            XCTAssertEqual(
+                scoopSummary(isCone: false, state: state, fill: 20).avatarGeometry().eyes,
+                .open)
+        }
     }
 
     func testZeroTiltCentersPupils() {

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/ScoopStatusUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/ScoopStatusUITests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+/// Lifecycle and context-fullness coverage for the leaderless scoop fixture.
+final class ScoopStatusUITests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testLifecycleTreatmentsIncludeWorkingAndHonestUnknown() {
+        let app = launchFixtureApp()
+
+        assertSelection(
+            jid: "fixture-working", label: "Working Scoop: working, 64% context fill",
+            treatment: "scoop-lifecycle-working", in: app)
+        assertSelection(
+            jid: "fixture-broken", label: "Broken Scoop: broken, 82% context fill",
+            treatment: "scoop-lifecycle-broken", in: app)
+        assertSelection(
+            jid: "fixture-initializing",
+            label: "Initializing Scoop: initializing, 12% context fill",
+            treatment: "scoop-lifecycle-initializing", in: app)
+        assertSelection(
+            jid: "fixture-idle", label: "Idle Scoop: idle, 0% context fill",
+            treatment: "scoop-lifecycle-idle", in: app)
+        assertSelection(
+            jid: "fixture-unknown", label: "Unknown Scoop: unknown, context fill unknown",
+            treatment: "scoop-lifecycle-unknown", in: app)
+
+        let switcher = app.buttons["scoop-switcher"]
+        XCTAssertFalse(switcher.label.contains("idle"), "Absent state must not read as idle")
+        XCTAssertFalse(switcher.label.contains("0%"), "Absent fill must not read as zero")
+        XCTAssertTrue(app.descendants(matching: .any)["scoop-fullness-unknown"].exists)
+    }
+
+    func testNearLimitFullnessIsDistinctFromLowFill() {
+        let app = launchFixtureApp()
+
+        select(jid: "fixture-near-limit", in: app)
+        XCTAssertTrue(
+            app.descendants(matching: .any)["scoop-fullness-near-limit"].waitForExistence(
+                timeout: 10))
+        XCTAssertEqual(app.buttons["scoop-switcher"].label, "Near Limit Scoop: idle, 95% context fill")
+
+        select(jid: "fixture-low-fill", in: app)
+        XCTAssertTrue(
+            app.descendants(matching: .any)["scoop-fullness-normal"].waitForExistence(timeout: 10))
+        XCTAssertEqual(app.buttons["scoop-switcher"].label, "Low Fill Scoop: idle, 5% context fill")
+    }
+
+    func testReducedMotionKeepsFullnessReadingPresent() {
+        let app = launchFixtureApp(reduceMotion: true)
+
+        select(jid: "fixture-working", in: app)
+        XCTAssertTrue(
+            app.descendants(matching: .any)["scoop-fullness-normal"].waitForExistence(timeout: 10))
+        XCTAssertEqual(app.buttons["scoop-switcher"].label, "Working Scoop: working, 64% context fill")
+    }
+
+    private func launchFixtureApp(reduceMotion: Bool = false) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-joinUrl", "", "-uiTestConnectionState", "connected",
+            "-uiTestScoopStatusFixture", "YES",
+            "-uiTestReduceMotion", reduceMotion ? "YES" : "NO",
+        ]
+        app.launch()
+        XCTAssertTrue(app.buttons["scoop-switcher"].waitForExistence(timeout: 60))
+        return app
+    }
+
+    private func assertSelection(
+        jid: String, label: String, treatment: String, in app: XCUIApplication
+    ) {
+        select(jid: jid, in: app)
+        XCTAssertEqual(app.buttons["scoop-switcher"].label, label)
+        XCTAssertTrue(app.descendants(matching: .any)[treatment].waitForExistence(timeout: 10))
+    }
+
+    private func select(jid: String, in app: XCUIApplication) {
+        let switcher = app.buttons["scoop-switcher"]
+        switcher.tap()
+        let option = app.buttons["scoop-switch-\(jid)"]
+        XCTAssertTrue(option.waitForExistence(timeout: 10), "Fixture scoop \(jid) should be selectable")
+        option.tap()
+    }
+}

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -621,15 +621,18 @@ struct ScoopSwitcher: View {
                             systemImage: scoop.jid == appState.selectedScoopJid
                                 ? "checkmark" : "circle")
                     }
+                    .accessibilityLabel(menuTitle(for: scoop))
                     .accessibilityIdentifier("scoop-switch-\(scoop.jid)")
                 }
             } label: {
                 identityLabel
             }
-            .accessibilityLabel("Switch scoop")
+            .accessibilityLabel(selectedAccessibilityLabel)
+            .accessibilityHint("Switch scoop")
             .accessibilityIdentifier("scoop-switcher")
         } else {
             identityLabel
+                .accessibilityLabel(selectedAccessibilityLabel)
                 .accessibilityIdentifier("scoop-switcher")
         }
     }
@@ -639,8 +642,7 @@ struct ScoopSwitcher: View {
     /// pushing the action cluster off the other edge.
     private var identityLabel: some View {
         HStack(spacing: 5) {
-            SliccAgentAvatarView(avatar: selectedAvatar)
-                .accessibilityHidden(true)
+            ScoopStatusAvatar(avatar: selectedAvatar, status: selectedStatus)
             Text(appState.selectedScoop?.assistantLabel ?? "SLICC")
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(palette.ink)
@@ -668,13 +670,131 @@ struct ScoopSwitcher: View {
             ?? .init(type: .cone, color: "#D2691E", sideLength: 20)
     }
 
+    private var selectedStatus: ScoopStatus {
+        appState.selectedScoop?.status ?? ScoopStatus(state: nil, fill: nil)
+    }
+
+    private var selectedAccessibilityLabel: String {
+        selectedStatus.accessibilityPhrase(
+            label: appState.selectedScoop?.assistantLabel ?? "SLICC")
+    }
+
     /// The leader's active scoop is marked in the menu too — the dot on the
-    /// closed control only speaks about the one you are looking at.
+    /// closed control only speaks about the one you are looking at. State and
+    /// fullness stay textual because native Menu rows cannot host the ring.
     private func menuTitle(for scoop: ScoopSummary) -> String {
         let kind = scoop.isCone ? "cone" : "scoop"
+        let status = scoop.status.accessibilityPhrase(label: scoop.assistantLabel)
         return scoop.jid == appState.leaderActiveScoopJid
-            ? "\(scoop.assistantLabel) · \(kind) · active"
-            : "\(scoop.assistantLabel) · \(kind)"
+            ? "\(status) · \(kind) · active"
+            : "\(status) · \(kind)"
+    }
+}
+
+/// The closed switcher uses a native circular Gauge around the existing avatar
+/// plus an SF Symbol lifecycle badge. This deliberately adapts, rather than
+/// copies, the web glyph + eyes treatment: a ring preserves the numeric context
+/// reading at nav-bar scale and follows platform conventions, while the badge
+/// keeps lifecycle recognizable without asking color or motion to carry meaning.
+private struct ScoopStatusAvatar: View {
+    let avatar: SliccAgentAvatarGeometry
+    let status: ScoopStatus
+
+    @Environment(\.palette) private var palette
+    @Environment(\.accessibilityReduceMotion) private var systemReduceMotion
+
+    private var reduceMotion: Bool {
+        #if DEBUG
+            systemReduceMotion || UITestHooks.reducesMotion
+        #else
+            systemReduceMotion
+        #endif
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            fullnessTreatment
+            SliccAgentAvatarView(avatar: avatar)
+                .accessibilityHidden(true)
+                .frame(width: 20, height: 20)
+                .position(x: 14, y: 14)
+            lifecycleTreatment
+                .offset(x: 2, y: 2)
+        }
+        .frame(width: 30, height: 30)
+    }
+
+    @ViewBuilder
+    private var fullnessTreatment: some View {
+        if let fullness = status.fullness {
+            Gauge(value: fullness, in: 0...100) {
+                Text("Context fullness")
+            }
+            .gaugeStyle(.accessoryCircularCapacity)
+            .tint(status.isNearLimit ? palette.accent : palette.inkSecondary)
+            .labelsHidden()
+            .frame(width: 28, height: 28)
+            .accessibilityLabel("Context fullness")
+            .accessibilityValue("\(Int(fullness.rounded())) percent")
+            .accessibilityIdentifier(
+                status.isNearLimit ? "scoop-fullness-near-limit" : "scoop-fullness-normal")
+        } else {
+            Circle()
+                .stroke(
+                    palette.inkTertiary,
+                    style: StrokeStyle(lineWidth: 1.5, lineCap: .round, dash: [2, 2])
+                )
+                .frame(width: 28, height: 28)
+                .accessibilityLabel("Context fullness unknown")
+                .accessibilityIdentifier("scoop-fullness-unknown")
+        }
+    }
+
+    @ViewBuilder
+    private var lifecycleTreatment: some View {
+        if status.lifecycle == .working || status.lifecycle == .initializing {
+            TimelineView(
+                .animation(minimumInterval: 1.0 / 12.0, paused: reduceMotion)
+            ) { context in
+                lifecycleBadge
+                    .opacity(reduceMotion ? 1 : pulseOpacity(at: context.date))
+            }
+        } else {
+            lifecycleBadge
+        }
+    }
+
+    private var lifecycleBadge: some View {
+        Image(systemName: lifecycleSymbol)
+            .font(.system(size: 7, weight: .bold))
+            .foregroundStyle(lifecycleColor)
+            .frame(width: 12, height: 12)
+            .background(Circle().fill(palette.surface))
+            .accessibilityLabel("Lifecycle \(status.lifecycle.rawValue)")
+            .accessibilityIdentifier("scoop-lifecycle-\(status.lifecycle.rawValue)")
+    }
+
+    private var lifecycleSymbol: String {
+        switch status.lifecycle {
+        case .working: "bolt.fill"
+        case .broken: "exclamationmark.triangle.fill"
+        case .initializing: "ellipsis"
+        case .idle: "pause.fill"
+        case .unknown: "questionmark"
+        }
+    }
+
+    private var lifecycleColor: Color {
+        switch status.lifecycle {
+        case .working, .initializing: palette.accent
+        case .broken: palette.ink
+        case .idle, .unknown: palette.inkTertiary
+        }
+    }
+
+    private func pulseOpacity(at date: Date) -> Double {
+        let phase = date.timeIntervalSinceReferenceDate.truncatingRemainder(dividingBy: 1.2)
+        return 0.65 + 0.35 * abs(cos(phase * .pi / 1.2))
     }
 }
 
@@ -684,4 +804,37 @@ struct ScoopSwitcher: View {
     ChatView()
         .preferredColorScheme(.dark)
         .environmentObject(AppState())
+}
+
+#Preview("Scoop status treatments") {
+    ScoopStatusTreatmentPreview()
+        .preferredColorScheme(.dark)
+}
+
+private struct ScoopStatusTreatmentPreview: View {
+    var body: some View {
+        HStack(spacing: 14) {
+            ForEach(ScoopLifecycle.allCases, id: \.rawValue) { lifecycle in
+                VStack(spacing: 5) {
+                    ScoopStatusAvatar(
+                        avatar: .init(type: .scoop, color: "#FFB6C1", sideLength: 20),
+                        status: previewStatus(for: lifecycle)
+                    )
+                    Text(lifecycle.rawValue)
+                        .font(.caption2)
+                }
+            }
+        }
+        .padding()
+    }
+
+    private func previewStatus(for lifecycle: ScoopLifecycle) -> ScoopStatus {
+        switch lifecycle {
+        case .working: ScoopStatus(state: lifecycle.rawValue, fill: 42)
+        case .broken: ScoopStatus(state: lifecycle.rawValue, fill: 82)
+        case .initializing: ScoopStatus(state: lifecycle.rawValue, fill: 12)
+        case .idle: ScoopStatus(state: lifecycle.rawValue, fill: 0)
+        case .unknown: ScoopStatus(state: nil, fill: nil)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- model scoop lifecycle and context fullness without coercing absent fields
- render lifecycle badges and a determinate context ring in the existing iOS scoop switcher
- add leaderless XCUITest fixtures, reduced-motion coverage, and package documentation

## Why

The iOS follower previously treated missing scoop status as a confident `idle` at 0%, so a working or nearly full scoop looked calm on the phone. This closes that false-idle bug: absent values now receive an honest unknown treatment, while transmitted lifecycle and fullness values remain visible and accessible.

The switcher uses a native SwiftUI circular `Gauge` around the existing avatar plus SF Symbol lifecycle badges rather than copying the web glyph/eyes SVG treatment. This keeps both signals legible at navigation-bar scale and follows platform conventions. Working and initializing badges may pulse, but reduced motion pauses that animation without removing the fullness ring or its accessibility value.

## Verification

- `npm run lint`
- `npm run verify`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- `npm run typecheck`
- `npm run test`
- `npm run test:coverage`
- `npm run build`
- `npm run build -w @slicc/chrome-extension`
- `npm run bundle-size`
- `npm run lint:swift`
- `npm run lint:swift:format`
- `swift format lint --strict --parallel --recursive SliccFollower Package.swift`
- `./packages/dev-tools/tools/swift-coverage-check.sh --xcodebuild SliccFollower packages/ios-app SliccFollower`

Closes #1826

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author