### PR TITLE
fix(ios-app): pass File Provider secrets into TestFlight release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,13 @@ jobs:
           APPLE_DISTRIBUTION_CERT_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERT_BASE64 }}
           APPLE_DISTRIBUTION_CERT_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERT_PASSWORD }}
           APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+          APPLE_PROVISIONING_PROFILE_NAME: ${{ secrets.APPLE_PROVISIONING_PROFILE_NAME }}
+          # File Provider appex ships inside SliccFollower.ipa; without these
+          # the package script soft-skips the entire TestFlight upload (see
+          # packages/ios-app/scripts/package-and-upload-testflight.sh).
+          APPLE_FILEPROVIDER_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_FILEPROVIDER_PROVISIONING_PROFILE_BASE64 }}
+          APPLE_FILEPROVIDER_PROVISIONING_PROFILE_NAME: ${{ secrets.APPLE_FILEPROVIDER_PROVISIONING_PROFILE_NAME }}
+          APPLE_FILEPROVIDER_BUNDLE_ID: ${{ secrets.APPLE_FILEPROVIDER_BUNDLE_ID }}
           # Repo variable, not a secret: set to 1 to archive the iOS build
           # WITHOUT the iCloud KVS entitlement while the App Store profile
           # lacks the iCloud capability (see package-and-upload-testflight.sh).

--- a/packages/ios-app/scripts/package-and-upload-testflight.sh
+++ b/packages/ios-app/scripts/package-and-upload-testflight.sh
@@ -22,10 +22,15 @@
 #   APPLE_PROVISIONING_PROFILE_NAME    defaults to "Slicc Follower App Store"
 #   APPLE_FILEPROVIDER_PROVISIONING_PROFILE_BASE64
 #                                      base64 of the File Provider appex App Store profile
+#                                      (required — missing/"-" soft-skips the whole upload)
 #   APPLE_FILEPROVIDER_PROVISIONING_PROFILE_NAME
 #                                      defaults to "Slicc Follower File Provider App Store"
 #   APPLE_FILEPROVIDER_BUNDLE_ID       defaults to com.sliccy.follower.fileprovider
 #   APPLE_TEAM_ID                      defaults to S8LB56P782
+#
+# Release wiring: .github/workflows/release.yml must pass every APPLE_* secret
+# above into the Publish release step env. Repo secrets alone are not enough —
+# an unset workflow env makes the File Provider check soft-skip TestFlight.
 #   KEYCHAIN_PATH                      reuse a keychain set up by an
 #                                       earlier workflow step; if unset
 #                                       and APPLE_DISTRIBUTION_CERT_BASE64


### PR DESCRIPTION
## Summary
v6.17.0 shipped from #1901 but **skipped the iOS TestFlight upload**:

```
TestFlight secret $APPLE_FILEPROVIDER_PROVISIONING_PROFILE_BASE64 is missing or set to "-" — skipping iOS upload.
```

The dual-profile secrets exist on the repo, but `.github/workflows/release.yml` never exported `APPLE_FILEPROVIDER_*` (or the profile name vars) into the Publish step env. The package script treats an empty env as unusable and soft-skips.

## Fix
- Wire `APPLE_PROVISIONING_PROFILE_NAME`, `APPLE_FILEPROVIDER_PROVISIONING_PROFILE_BASE64`, `APPLE_FILEPROVIDER_PROVISIONING_PROFILE_NAME`, and `APPLE_FILEPROVIDER_BUNDLE_ID` into the release Publish env.
- Document the release-env requirement on `package-and-upload-testflight.sh` (and touch `packages/ios-app/` so the next release re-runs the iOS packaging gate).

## Expected after merge
Next release should log both:
- `installed app provisioning profile …`
- `installed fileprovider provisioning profile …`

and upload the IPA to TestFlight instead of soft-skipping.

## Test plan
- [x] Secrets present on repo (`gh secret list`)
- [ ] CI green on this PR
- [ ] Merge → Release run publishes and TestFlight step no longer skips on missing File Provider secret
- [ ] Confirm archive/export succeeds for app + appex