### PR TITLE
fix(ios): fullscreen browser at regular width

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1369,6 +1369,38 @@ jobs:
         run: |
           ./packages/dev-tools/tools/swift-coverage-check.sh \
             --xcodebuild SliccFollower packages/ios-app SliccFollower
+      - name: Test regular-width browser (iPad)
+        run: |
+          set -o pipefail
+          cd packages/ios-app
+          SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
+          IPAD_UDID=$(
+            xcrun simctl list devices available --json |
+              IOS_SIMULATOR_RUNTIME_KEY="com.apple.CoreSimulator.SimRuntime.iOS-${SDK_VERSION//./-}" node -e '
+                let input = "";
+                process.stdin.on("data", chunk => input += chunk).on("end", () => {
+                  const devices = JSON.parse(input).devices?.[process.env.IOS_SIMULATOR_RUNTIME_KEY] ?? [];
+                  const ipad = devices.find(device => device.isAvailable && /iPad/.test(device.name));
+                  process.stdout.write(ipad?.udid ?? "");
+                });
+              '
+          )
+          if [[ -z "$IPAD_UDID" ]]; then
+            echo "::error::No available iPad simulator matching the iOS $SDK_VERSION SDK"
+            exit 1
+          fi
+          xcrun simctl boot "$IPAD_UDID" 2>/dev/null || true
+          xcrun simctl bootstatus "$IPAD_UDID" -b
+          xcodebuild test \
+            -project SliccFollower.xcodeproj \
+            -scheme SliccFollower \
+            -destination "platform=iOS Simulator,id=$IPAD_UDID" \
+            -derivedDataPath .build/xcodebuild \
+            -resultBundlePath .build/regular-width-ui.xcresult \
+            -parallel-testing-enabled NO \
+            -retry-tests-on-failure \
+            -test-iterations 2 \
+            -only-testing:SliccFollowerUITests/RemoteTabUITests/testRegularWidthBrowsingEntersAndExitsFullScreen
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1383,7 +1415,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-timings-ios-app
-          path: packages/ios-app/.build/coverage/ios-app.xcresult
+          path: |
+            packages/ios-app/.build/coverage/ios-app.xcresult
+            packages/ios-app/.build/regular-width-ui.xcresult
           if-no-files-found: ignore
       - name: Install Periphery
         run: brew install peripheryapp/periphery/periphery

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -135,6 +135,8 @@ Hand-running the app for exploratory QA is covered in [`docs/ios-simulator-qa.md
 
 A `bundle.ui-testing` target remains in the scheme, but the unit coverage gate excludes it. Run `-only-testing:SliccFollowerUITests` when UI changes, as a separate CI job. No test needs a leader: `-uiTestFixtureRoute YES` opens the leaderless **UI Fixture** route; `-uiTestSessionsFixture/Empty YES` seeds iCloud sessions in-memory; `-uiTestScoopStatusFixture` covers lifecycle/fill; `-uiTestReduceMotion` keeps the fullness cue static. `UITestHooks` is `#if DEBUG` only. The failure-state test dials `http://127.0.0.1:1/…` so `Connection Failed` arrives without DNS. `-uiTestCompletedTurn YES` feeds `message_start` + `content_done` + `status: ready` through the real dispatcher.
 
+Regular-width browser tabs claim the whole iPad window; returning to the tab overview restores the split. CI runs this enter/exit regression separately on an iPad simulator.
+
 - Put accessibility identifiers on leaves (`message-<id>`). Container ids propagate; `.accessibilityElement(children: .contain)` does not fix that.
 - Row ids alone are blind — also add a `variantMarkers` string only that renderer can emit.
 - The transcript pins to the newest message; variant walks scroll bottom-to-top and must be bounded.

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/RemoteTabUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/RemoteTabUITests.swift
@@ -1,3 +1,4 @@
+import UIKit
 import XCTest
 
 /// Federated remote-tab preview cards on the browser surface (#1865).
@@ -105,5 +106,38 @@ final class RemoteTabUITests: XCTestCase {
         XCTAssertFalse(
             app.buttons["dock-browser"].exists,
             "full-screen browsing hides the dock rail")
+    }
+
+    /// Run on an iPad simulator: regular-width browsing must claim the whole
+    /// window, then restore the conversation + rail when tabs are shown.
+    func testRegularWidthBrowsingEntersAndExitsFullScreen() throws {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-joinUrl", "", "-uiTestConnectionState", "connected",
+            "-uiTestOpenDockSurface", "browser",
+            "-uiTestRemoteTargetsFixture", "YES",
+        ]
+        app.launch()
+
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: 10))
+        guard UIDevice.current.userInterfaceIdiom == .pad, window.frame.width > 560 else {
+            throw XCTSkip("Requires a regular-width iPad simulator destination")
+        }
+        let remoteCard = app.staticTexts["SLICC docs — architecture"].firstMatch
+        XCTAssertTrue(remoteCard.waitForExistence(timeout: 60))
+        XCTAssertTrue(app.buttons["settings-button"].exists, "the split starts with chat visible")
+        XCTAssertTrue(app.buttons["dock-browser"].exists, "the split starts with its rail visible")
+
+        remoteCard.tap()
+        XCTAssertTrue(app.buttons["browser-address-display"].firstMatch.waitForExistence(timeout: 10))
+        XCTAssertFalse(app.buttons["settings-button"].exists, "full screen hides the conversation")
+        XCTAssertFalse(app.buttons["dock-browser"].exists, "full screen hides the rail")
+
+        app.buttons["browser-show-tabs"].firstMatch.tap()
+
+        XCTAssertTrue(remoteCard.waitForExistence(timeout: 10), "the tabs button restores the overview")
+        XCTAssertTrue(app.buttons["settings-button"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["dock-browser"].waitForExistence(timeout: 10))
     }
 }

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -6,7 +6,7 @@ import os
 /// Top-level adaptive shell. Compact width preserves the webapp's narrow IA:
 /// chat is the app, workbench surfaces overlay it full-bleed, and only the
 /// 48pt dock stays tappable. Regular width keeps chat visible beside the
-/// selected workbench surface.
+/// selected workbench surface, except while a browser tab claims the window.
 struct ChatView: View {
     @EnvironmentObject var appState: AppState
     @Environment(\.colorScheme) private var systemScheme
@@ -97,7 +97,7 @@ struct ChatView: View {
     }
 
     /// Full-screen browsing: a foregrounded local tab claims the whole
-    /// phone — no rail, no navigation bar (Safari-shaped). The way back is
+    /// window — no rail, no navigation bar (Safari-shaped). The way back is
     /// the tab-overview button in the browser's own bottom bar.
     private var isBrowserFullScreen: Bool {
         presentation.activeSurface == .browser && appState.browserViewingTabId != nil
@@ -163,19 +163,30 @@ struct ChatView: View {
 
     /// Regular width mirrors the dock and its workbench around a persistent
     /// conversation column. With no selected surface, conversation fills the
-    /// space beside the rail.
+    /// space beside the rail. A foregrounded browser tab expands the same
+    /// workbench to fill the window, keeping its stacked terminal alive.
     private var regularShell: some View {
         HStack(spacing: 0) {
             if leftHandedDock {
-                dockRail
+                if !isBrowserFullScreen {
+                    dockRail
+                }
                 regularWorkbench
             }
 
             conversation
+                .frame(maxWidth: isBrowserFullScreen ? 0 : .infinity)
+                .toolbar(isBrowserFullScreen ? .hidden : .automatic, for: .navigationBar)
+                .opacity(isBrowserFullScreen ? 0 : 1)
+                .allowsHitTesting(!isBrowserFullScreen)
+                .accessibilityHidden(isBrowserFullScreen)
+                .clipped()
 
             if !leftHandedDock {
                 regularWorkbench
-                dockRail
+                if !isBrowserFullScreen {
+                    dockRail
+                }
             }
         }
     }
@@ -203,9 +214,13 @@ struct ChatView: View {
         if presentation.activeSurface != nil {
             if leftHandedDock {
                 workbench
-                Divider()
+                if !isBrowserFullScreen {
+                    Divider()
+                }
             } else {
-                Divider()
+                if !isBrowserFullScreen {
+                    Divider()
+                }
                 workbench
             }
         }


### PR DESCRIPTION
Closes #1931

## Solution
Foregrounded browser tabs reuse the regular-width workbench while hiding the conversation and rail; returning to the overview restores the split.

## Testing
Dedicated enter/exit UI regression runs on an iPad simulator in CI; Xcode was unavailable locally.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KZ8Q12NZ00YABHSC1RZCG5NF&panel=chat)