### PR TITLE
feat(cherry): let a Cherry host push feature-flag overrides

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -31,6 +31,15 @@ The panel system is gated by the **`panel-layouts` feature flag**, which ships
    needs no release, but takes effect on the next page load: flag hydration is
    read once at boot and has no live refresh.
 3. **Bundled default** — `defaultValue: 'off'` in the flag definition.
+4. **Per embed, by the host page** — `mountSlicc({ flags: { 'panel-layouts': 'on' } })`.
+   The only way to reach this flag from inside a Cherry embed: the "Experimental
+   features…" dialog that would otherwise let a user flip it is itself hidden
+   there (Cherry sets `experimental-settings: off`). Applied once at boot,
+   session-only — never written to the follower's `localStorage` — and gated
+   through the exact same `userToggleable`-and-float check a local user
+   override must pass, so an embedder can only reach flags this registry
+   already marked safe for outside control. See "Cherry: pushing a layout
+   into an embed" below.
 
 There is deliberately **no URL parameter**. An earlier `?panels=1` was removed when
 the flag landed: two switches for one boolean meant a bookmarked URL could
@@ -38,8 +47,8 @@ contradict the user's own setting, with nothing in the UI to explain why.
 
 The gate is uniform across every float, including a Cherry embed that pushes its
 own `LayoutDocument` — one answer to "are panels on here". A host pushing a layout
-while the flag is off gets the default shell and a logged warning, not a partial
-application.
+while the flag is off (and not turning it on itself via `flags`) gets the default
+shell and a logged warning, not a partial application.
 
 ---
 
@@ -342,6 +351,7 @@ sibling. This is what a Cherry embedder sets.
 
 ```ts
 mountSlicc({
+  flags: { 'panel-layouts': 'on' }, // the panel-layouts flag ships off; push it on for this embed
   layout: {
     version: 1,
     id: 'embed',
@@ -358,10 +368,19 @@ mountSlicc({
 });
 ```
 
-Serialized into `handshake.welcome.layout` and applied once at boot — static, like
-`theme`. The follower accepts **either** shape: a `LayoutDocument` (has `base`) or
-the older `DockTreeSpec` (has `zones`), since embedders vendor the SDK and upgrade
-on their own schedule.
+`layout` is serialized into `handshake.welcome.layout` and applied once at boot —
+static, like `theme`. The follower accepts **either** shape: a `LayoutDocument` (has
+`base`) or the older `DockTreeSpec` (has `zones`), since embedders vendor the SDK
+and upgrade on their own schedule.
+
+`flags` is serialized into `handshake.welcome.flags` and applied session-only
+(never persisted) before the `panel-layouts` gate is checked — this is how a
+pushed `LayoutDocument` can turn the flag on for itself rather than depending on
+the target deployment's worker-level `FEATURE_FLAGS`. Only ids the flag registry
+marks `userToggleable`-and-allowed for the `cherry` float take effect; anything
+else is silently dropped, the same gate a local end-user override must pass. A
+vendored SDK too old to send `flags` at all simply doesn't — the field is
+additive, so the handshake still completes.
 
 A pushed layout is applied **without a filesystem**, so it can never be persisted
 or drifted client-side, and `layout save` inside an embed reports that it needs one

--- a/packages/cherry/CLAUDE.md
+++ b/packages/cherry/CLAUDE.md
@@ -59,6 +59,7 @@ mountSlicc({
   features, // { terminal?, files?, memory?, browser?, modelPicker?, history?, nav?, newSprinkle?, monitor? } — all default true
   theme, // SliccTheme object — optional brand theme applied inside the follower (serialized in handshake welcome)
   layout, // DockTreeSpec-shaped object — optional pushed layout, typically with locked: true (serialized in handshake welcome)
+  flags, // { [flagId]: value } — optional feature-flag overrides for this embed, e.g. panel-layouts
   hooks, // { onOpenUrl?, onSliccEvent?, onPermissionRequest?, onHandshakeComplete? }
   joinToken, // REQUIRED: existing tray join URL the host (or its backend) provisioned
   uiOnly, // Opt-in: append `ui-only=1` AFTER `cherry=1` (follower renders UI but advertises no CDP target)
@@ -88,11 +89,12 @@ mountSlicc({
   at mount time and sent in `handshake.welcome`; there is no runtime toggle.
   Separate from `capabilities` (which gates agent _powers_ over the host page);
   features gate _UI surfaces_ shown to the user.
-- **Feature flags are separate:** the `?cherry=1` webapp boot uses the shared registry in
-  `packages/webapp/src/core/feature-flags.ts` with Cherry defaults (`experimental-settings`
-  is off). This is not `SIDE_PANEL_FEATURES` in
-  `packages/chrome-extension/src/cherry-panel-protocol.ts`: that constant is host-provided,
-  mount-time `CherryFeatures` panel visibility sent in `handshake.welcome`, not remote flag config.
+- **Feature flags are separate** from `CherryFeatures`: the `?cherry=1` boot uses the shared
+  registry in `feature-flags.ts` (Cherry default: `experimental-settings` off, hiding the
+  dialog that would toggle these). `flags` on `mountSlicc` is the host's session-only bridge
+  into that registry — same `userToggleable`-and-float gate a local override must pass; see
+  `docs/layouts.md`. Not `SIDE_PANEL_FEATURES` in `cherry-panel-protocol.ts` (extension), which
+  is mount-time `CherryFeatures` panel visibility, not a registry flag.
 - `theme` accepts a `SliccTheme` object (`{ id, name, base, tokens, css?,
 disableShader?, components? }`) that the SDK serializes as JSON in the
   handshake welcome. The follower applies it on boot via `applyCherryTheme`,
@@ -127,7 +129,7 @@ save` in an embed reports it needs one rather than writing your arrangement into
   channelId is pinned (synchronous, single-shot per hello).
 - `hooks.onPermissionRequest(domain)` gates each synthetic CDP domain the leader
   tries to use (return `false` to deny — the SDK answers `-32601`).
-- `hooks.onSliccEvent(name, detail)` observes `slicc.event` envelopes (telemetry, plus the host's `open-url` convenience path) — the **cone → host** direction. The follower also emits two transport-layer (not cone-routed) sentinels: `slicc.follower.ready` when the WebRTC channel to the leader connects, and `slicc.follower.disconnected` on transient drops AND on terminal `onGaveUp` (so the host always gets an authoritative "stop emitting" signal — see `wc-follower.ts:onConnectionChange` and `onGaveUp`). Hosts should defer `emitHostEvent` calls until `ready` arrives, since `emitHostEvent` calls that reach the follower before the tray channel is open are silently dropped.
+- `hooks.onSliccEvent(name, detail)` observes `slicc.event` envelopes (telemetry, plus the host's `open-url` convenience path) — the **cone → host** direction. The follower also emits two transport-layer sentinels: `slicc.follower.ready` (WebRTC channel connected) and `slicc.follower.disconnected` (transient drop or terminal `onGaveUp`) — see `wc-follower.ts:onConnectionChange`. Defer `emitHostEvent` until `ready`: calls before the tray channel opens are silently dropped.
 - `SliccHandle.emitHostEvent(name, detail?)` is the **host → cone** direction: the host page emits a named event that posts a `host.event` envelope to the follower, which forwards it over the tray channel as `cherry.host_event`; the leader turns it into a `cherry` lick (labeled **Cherry Event**) on the cone. No-ops with a warning before the handshake completes (no `channelId` to pin it to).
 
 ## Host-SDK ↔ iframe synthetic-CDP boundary
@@ -282,15 +284,14 @@ the repo's `node_modules` — the same file a bundler would resolve. **Serve fro
 the repo root** (`npx http-server . -p 8080`) so both relative map paths resolve.
 
 **Screenshots:** set the **screenshot** dropdown to `html2canvas` (it defaults to
-`none`) _before_ Mount — capabilities are fixed at mount time, so changing it
-afterward does nothing. The SDK is built with `tsc` (no bundling), so the
-screenshot path keeps a bare `await import('html2canvas-pro')` (resolved per the
-import map above). The renderer is the maintained **`html2canvas-pro`** fork —
-the original `html2canvas@1.4.1` throws on CSS Color 4 syntax (`color()`,
-`oklch`, …), which is common on real host pages; the capability value stays
-`'html2canvas'` (the strategy), only the implementation lib differs. Cherry's
-screenshot is a best-effort DOM raster of `document.body`, not a pixel-level CDP
-capture.
+`none`) _before_ Mount — capabilities are fixed at mount time. The SDK is built
+with `tsc` (no bundling), so the screenshot path keeps a bare
+`await import('html2canvas-pro')` (resolved per the import map above). The
+renderer is the maintained **`html2canvas-pro`** fork — the original
+`html2canvas@1.4.1` throws on CSS Color 4 syntax (`color()`, `oklch`, …); the
+capability value stays `'html2canvas'`, only the implementation lib differs.
+Cherry's screenshot is a best-effort DOM raster of `document.body`, not a
+pixel-level CDP capture.
 
 ## Transcript export
 

--- a/packages/cherry/src/index.ts
+++ b/packages/cherry/src/index.ts
@@ -156,6 +156,30 @@ export interface MountSliccOptions {
    * cost/quality tradeoff; the end user cannot override it.
    */
   effortLevel?: EffortLevel;
+  /**
+   * Feature-flag overrides to apply for this embed, e.g.
+   * `{ 'panel-layouts': 'on' }`. Serialized as JSON in the handshake welcome
+   * and applied once at boot — session-only, like `theme`/`layout`; never
+   * persisted to the follower's localStorage.
+   *
+   * Only takes effect for flags the follower's registry marks
+   * `userToggleable` and allows for the `cherry` float — the same gate a
+   * local end-user override must pass. An embedder is not a trusted operator
+   * of the SLICC deployment it's pointed at, so it cannot flip a flag nobody
+   * decided was safe for outside control; an id that fails the gate (or isn't
+   * recognized) is silently dropped rather than applied partially.
+   *
+   * `panel-layouts` is the flag this exists for today: it ships `off` by
+   * default and, inside a Cherry embed, the "Experimental features…" dialog
+   * that would otherwise let a user flip it is itself hidden (Cherry sets
+   * `experimental-settings: off`) — so pushing it here is the only way to
+   * turn panels on for an embed without changing the target deployment's
+   * worker-level `FEATURE_FLAGS`. See `docs/layouts.md`.
+   *
+   * @example
+   * mountSlicc({ flags: { 'panel-layouts': 'on' }, layout: { ... } });
+   */
+  flags?: Record<string, string>;
 }
 
 export interface SliccHandle {

--- a/packages/cherry/src/mount.ts
+++ b/packages/cherry/src/mount.ts
@@ -77,6 +77,14 @@ function buildWelcomeEnvelope(
       console.warn('[cherry] options.layout is not JSON-serializable — sending no layout', err);
     }
   }
+  let flagsJson: string | undefined;
+  if (options.flags) {
+    try {
+      flagsJson = JSON.stringify(options.flags);
+    } catch (err) {
+      console.warn('[cherry] options.flags is not JSON-serializable — sending no flags', err);
+    }
+  }
   return {
     cherry: CHERRY_PROTOCOL_VERSION,
     channelId: newChannelId,
@@ -86,6 +94,7 @@ function buildWelcomeEnvelope(
     ...(themeJson ? { theme: themeJson } : {}),
     ...(layoutJson ? { layout: layoutJson } : {}),
     ...(options.effortLevel ? { effortLevel: options.effortLevel } : {}),
+    ...(flagsJson ? { flags: flagsJson } : {}),
   };
 }
 

--- a/packages/cherry/src/protocol.ts
+++ b/packages/cherry/src/protocol.ts
@@ -70,6 +70,15 @@ export interface CherryHandshakeWelcome {
   layout?: string;
   /** Locked effort level. When set, the thinking-level picker is hidden. */
   effortLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+  /**
+   * JSON-serialized feature-flag overrides (e.g. `{"panel-layouts":"on"}`) the
+   * host wants applied for this embed. Applied once, at boot, session-only —
+   * never written to localStorage. Only takes effect for flags that are
+   * `userToggleable` and allowed for the `cherry` float (the same gate a local
+   * user override must pass); an embedder is not a trusted operator of this
+   * deployment, so it cannot flip a flag nobody marked safe for outside control.
+   */
+  flags?: string;
 }
 
 /**

--- a/packages/cherry/tests/mount.test.ts
+++ b/packages/cherry/tests/mount.test.ts
@@ -321,6 +321,48 @@ describe('mountSliccImpl', () => {
     handle.destroy();
   });
 
+  it('serializes options.flags as JSON in the handshake.welcome envelope', async () => {
+    const container = document.createElement('div');
+    const posted: { kind?: string; flags?: string }[] = [];
+    const flags = { 'panel-layouts': 'on' };
+    const handle = mountSliccImpl({
+      container,
+      sliccOrigin: 'https://app.example',
+      capabilities: { navigate: true, screenshot: 'none', openUrl: true },
+      joinToken: 'https://app.example/join?t=X',
+      flags,
+      __test_post: (env) => posted.push(env as never),
+    });
+    await handle.testReceive({
+      cherry: 2,
+      channelId: 'ch-flags',
+      kind: 'handshake.hello',
+    } as never);
+    const welcome = posted.find((e) => e.kind === 'handshake.welcome');
+    expect(welcome?.flags).toBe(JSON.stringify(flags));
+    handle.destroy();
+  });
+
+  it('omits flags from the welcome envelope when options.flags is undefined', async () => {
+    const container = document.createElement('div');
+    const posted: { kind?: string; flags?: string }[] = [];
+    const handle = mountSliccImpl({
+      container,
+      sliccOrigin: 'https://app.example',
+      capabilities: { navigate: true, screenshot: 'none', openUrl: true },
+      joinToken: 'https://app.example/join?t=X',
+      __test_post: (env) => posted.push(env as never),
+    });
+    await handle.testReceive({
+      cherry: 2,
+      channelId: 'ch-no-flags',
+      kind: 'handshake.hello',
+    } as never);
+    const welcome = posted.find((e) => e.kind === 'handshake.welcome');
+    expect(welcome?.flags).toBeUndefined();
+    handle.destroy();
+  });
+
   it('normalizes a trailing-slash sliccOrigin to the bare origin for postMessage targeting', async () => {
     const container = document.createElement('div');
     const posted: { kind?: string; channelId?: string }[] = [];

--- a/packages/webapp/src/cdp/cherry-host-protocol.ts
+++ b/packages/webapp/src/cdp/cherry-host-protocol.ts
@@ -60,6 +60,15 @@ export interface CherryHandshakeWelcome {
   layout?: string;
   /** Locked effort level. When set, the thinking-level picker is hidden. */
   effortLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+  /**
+   * JSON-serialized feature-flag overrides (e.g. `{"panel-layouts":"on"}`) the
+   * host wants applied for this embed. Applied once, at boot, session-only —
+   * never written to localStorage. Only takes effect for flags that are
+   * `userToggleable` and allowed for the `cherry` float (the same gate a local
+   * user override must pass); an embedder is not a trusted operator of this
+   * deployment, so it cannot flip a flag nobody marked safe for outside control.
+   */
+  flags?: string;
 }
 
 /**

--- a/packages/webapp/src/cdp/cherry-host-transport.ts
+++ b/packages/webapp/src/cdp/cherry-host-transport.ts
@@ -74,6 +74,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
   private _theme: string | null = null;
   private _layout: string | null = null;
   private _effortLevel: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | null = null;
+  private _flags: string | null = null;
   /**
    * Wire version negotiated with the host SDK. connect() posts one hello per
    * SUPPORTED_CHERRY_PROTOCOL_VERSIONS entry; the version of the welcome the
@@ -201,6 +202,14 @@ export class CherryHostTransport extends SyntheticCdpTransport {
    */
   get effortLevel(): 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | null {
     return this._effortLevel;
+  }
+
+  /**
+   * JSON-serialized feature-flag overrides from the host SDK's
+   * handshake.welcome. Null when the host did not supply any.
+   */
+  get flags(): string | null {
+    return this._flags;
   }
 
   /** The wire version negotiated at handshake (own version until connected). */
@@ -483,6 +492,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
     this._theme = env.theme ?? null;
     this._layout = env.layout ?? null;
     this._effortLevel = env.effortLevel ?? null;
+    this._flags = env.flags ?? null;
     this._features = env.features ?? {
       terminal: true,
       files: true,

--- a/packages/webapp/src/core/feature-flags.ts
+++ b/packages/webapp/src/core/feature-flags.ts
@@ -49,6 +49,13 @@ const ENABLED_VALUES = new Set(['1', 'on', 'true']);
 
 let activeFloat: FeatureFlagFloat = 'standalone';
 let remoteValues: FeatureFlagValues = {};
+/**
+ * Session-only overrides pushed by a Cherry host in `handshake.welcome.flags`
+ * (or any other embedder-supplied source). Never written to `localStorage` —
+ * like a pushed `theme`/`layout`, this must not persist or drift on the
+ * shared origin. Reset on every `initFeatureFlags` call (i.e. every boot).
+ */
+let hostValues: FeatureFlagValues = {};
 
 interface FeatureFlagStorage {
   getItem(key: string): string | null;
@@ -68,10 +75,12 @@ export function resolveFlagValue(
   if (!definition) return undefined;
   const override = overrides[id];
   if (typeof override === 'string' && canOverride(definition, float)) return override;
+  const hostValue = hostValues[id];
+  if (typeof hostValue === 'string' && canOverride(definition, float)) return hostValue;
   return getBundledDefault(definition, float);
 }
 
-/** Resolve every registered flag using local override → remote value → bundled default. */
+/** Resolve every registered flag using local override → host-pushed value → remote value → bundled default. */
 export function resolveFlags(
   float: FeatureFlagFloat,
   centralValues: Readonly<FeatureFlagValues> = {},
@@ -82,6 +91,11 @@ export function resolveFlags(
     const override = overrides[definition.id];
     if (typeof override === 'string' && canOverride(definition, float)) {
       resolved[definition.id] = override;
+      continue;
+    }
+    const hostValue = hostValues[definition.id];
+    if (typeof hostValue === 'string' && canOverride(definition, float)) {
+      resolved[definition.id] = hostValue;
       continue;
     }
     const centralValue = centralValues[definition.id];
@@ -124,6 +138,33 @@ export function initFeatureFlags(
 ): void {
   activeFloat = float;
   remoteValues = sanitizeValues(centralValues);
+  hostValues = {};
+}
+
+/**
+ * Apply session-only flag overrides pushed by an embedder (a Cherry host's
+ * `handshake.welcome.flags`). Silently drops any id that isn't a known flag
+ * or isn't `userToggleable`-and-allowed for the active float — the same gate
+ * a local user override must pass via `canOverride`. This is what keeps a
+ * host page from flipping a flag nobody decided was safe for it to touch;
+ * unlike the worker's own `centralValues`, an embedder is not a trusted
+ * operator of this deployment.
+ *
+ * Returns the subset that was actually applied, so a caller can warn about
+ * anything dropped. Never touches `localStorage` — reset on every
+ * `initFeatureFlags` call, exactly like a pushed `theme`/`layout`.
+ */
+export function applyHostFlagOverrides(
+  values: Readonly<Record<string, unknown>>
+): FeatureFlagValues {
+  const applied: FeatureFlagValues = {};
+  for (const [id, value] of Object.entries(values)) {
+    const definition = FEATURE_FLAGS_BY_ID.get(id as FeatureFlagId);
+    if (!definition || typeof value !== 'string' || !canOverride(definition, activeFloat)) continue;
+    applied[definition.id] = value;
+  }
+  hostValues = { ...hostValues, ...applied };
+  return applied;
 }
 
 export function getFeatureValue(id: FeatureFlagId): string | undefined {

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -1,6 +1,6 @@
 import type { TranscriptExportSelector } from '@slicc/shared-ts';
 import { TranscriptExportError } from '@slicc/shared-ts';
-import { isFeatureEnabled } from '../../core/feature-flags.js';
+import { applyHostFlagOverrides, isFeatureEnabled } from '../../core/feature-flags.js';
 import { createLogger } from '../../core/logger.js';
 import {
   FOLLOWER_STATUS_STORAGE_KEY,
@@ -345,6 +345,20 @@ export async function mountWcUiFollower(
   // synchronous with no flash.
   if (isCherry && prelude.cherryTransport?.theme) {
     applyCherryTheme(prelude.cherryTransport.theme);
+  }
+  // Apply host-pushed feature-flag overrides BEFORE the panel-layouts gate
+  // check below — this is what lets a host's own pushed layout turn the flag
+  // on for itself, rather than depending on this deployment's worker-level
+  // FEATURE_FLAGS. Session-only (see applyHostFlagOverrides): never persisted.
+  if (isCherry && prelude.cherryTransport?.flags) {
+    try {
+      const pushedFlags = JSON.parse(prelude.cherryTransport.flags);
+      if (pushedFlags && typeof pushedFlags === 'object' && !Array.isArray(pushedFlags)) {
+        applyHostFlagOverrides(pushedFlags);
+      }
+    } catch (err) {
+      log.warn('follower: host-pushed flags were not valid JSON — ignoring', err);
+    }
   }
   // A host-pushed layout replaces `mountWcShell`'s chat-only default
   // wholesale. Applied directly, like theme — never through

--- a/packages/webapp/tests/cdp/cherry-host-transport-features.test.ts
+++ b/packages/webapp/tests/cdp/cherry-host-transport-features.test.ts
@@ -128,4 +128,39 @@ describe('CherryHostTransport features', () => {
     await connectPromise;
     expect(h.transport.theme).toBeNull();
   });
+
+  it('exposes flags from handshake welcome', async () => {
+    const h = makeTransport();
+    const connectPromise = h.transport.connect({ timeout: 5000 } as CDPConnectOptions);
+    const hello = h.posted.find((m) => m.kind === 'handshake.hello');
+
+    const flagsJson = JSON.stringify({ 'panel-layouts': 'on' });
+
+    h.inbound({
+      cherry: CHERRY_PROTOCOL_VERSION,
+      channelId: hello.channelId,
+      kind: 'handshake.welcome',
+      joinUrl: 'https://host.example/join?t=X',
+      flags: flagsJson,
+    });
+
+    await connectPromise;
+    expect(h.transport.flags).toBe(flagsJson);
+  });
+
+  it('flags defaults to null when welcome has no flags field', async () => {
+    const h = makeTransport();
+    const connectPromise = h.transport.connect({ timeout: 5000 } as CDPConnectOptions);
+    const hello = h.posted.find((m) => m.kind === 'handshake.hello');
+
+    h.inbound({
+      cherry: CHERRY_PROTOCOL_VERSION,
+      channelId: hello.channelId,
+      kind: 'handshake.welcome',
+      joinUrl: 'https://host.example/join?t=X',
+    });
+
+    await connectPromise;
+    expect(h.transport.flags).toBeNull();
+  });
 });

--- a/packages/webapp/tests/core/feature-flags.test.ts
+++ b/packages/webapp/tests/core/feature-flags.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  applyHostFlagOverrides,
   coerceFeatureFlagValue,
   FEATURE_FLAG_STORAGE_KEY,
   getFeatureValue,
@@ -176,5 +177,52 @@ describe('feature flag registry', () => {
     const unknownId = 'not-registered' as 'experimental-settings';
     expect(resolveFlagValue(unknownId, 'standalone')).toBeUndefined();
     expect(isFeatureEnabled(unknownId)).toBe(false);
+  });
+});
+
+describe('applyHostFlagOverrides (Cherry-pushed session flags)', () => {
+  it('applies a userToggleable flag for the active float', () => {
+    initFeatureFlags('cherry');
+    expect(applyHostFlagOverrides({ 'panel-layouts': 'on' })).toEqual({ 'panel-layouts': 'on' });
+    expect(getFeatureValue('panel-layouts')).toBe('on');
+  });
+
+  it('drops a flag that is not userToggleable, even though the worker trusts centralValues for it', () => {
+    initFeatureFlags('cherry');
+    expect(applyHostFlagOverrides({ 'experimental-settings': 'on' })).toEqual({});
+    expect(getFeatureValue('experimental-settings')).toBe('off');
+  });
+
+  it('drops an unrecognized id and a non-string value without throwing', () => {
+    initFeatureFlags('cherry');
+    expect(
+      applyHostFlagOverrides({
+        'not-a-real-flag': 'on',
+        'panel-layouts': true as unknown as string,
+      })
+    ).toEqual({});
+  });
+
+  it('never persists to localStorage — session-only, like a pushed theme/layout', () => {
+    initFeatureFlags('cherry');
+    applyHostFlagOverrides({ 'panel-layouts': 'on' });
+    expect(readFeatureFlagOverrides()).toEqual({});
+  });
+
+  it('is reset on the next initFeatureFlags call (next boot)', () => {
+    initFeatureFlags('cherry');
+    applyHostFlagOverrides({ 'panel-layouts': 'on' });
+    expect(getFeatureValue('panel-layouts')).toBe('on');
+
+    initFeatureFlags('cherry');
+    expect(getFeatureValue('panel-layouts')).toBe('off');
+  });
+
+  it('a local user override still wins over a host-pushed value', () => {
+    initFeatureFlags('cherry');
+    applyHostFlagOverrides({ 'panel-layouts': 'on' });
+    expect(resolveFlags('cherry', {}, { 'panel-layouts': 'off' })).toEqual(
+      expect.objectContaining({ 'panel-layouts': 'off' })
+    );
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-follower.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-follower.test.ts
@@ -1016,6 +1016,71 @@ describe('mountWcUiFollower', () => {
     expect(app.querySelector('slicc-dock-tree')).not.toBeNull();
   });
 
+  it('cherry: a host-pushed flags override turns panel-layouts on for its own pushed layout — no worker-level FEATURE_FLAGS needed', async () => {
+    const pushedDoc = {
+      version: 1,
+      id: 'embed',
+      locked: true,
+      base: { center: { panel: 'chat' } },
+    };
+    vi.doMock('../../../src/ui/boot/setup-standalone-prelude.js', () => ({
+      setupStandalonePrelude: vi.fn(async () => ({
+        browser: { getTransport: () => ({}), listPages: async () => [] },
+        realCdpTransport: {},
+        cherryJoinUrl: 'https://www.sliccy.ai/join/tray-c.cap',
+        cherryTransport: {
+          emitSliccEventToHost: vi.fn(),
+          onHostEvent: null,
+          flags: JSON.stringify({ 'panel-layouts': 'on' }),
+          layout: JSON.stringify(pushedDoc),
+          features: ALL_CHERRY_FEATURES,
+        },
+        instanceId: 'i',
+      })),
+    }));
+    vi.resetModules();
+    // Deliberately NO initFeatureFlags('cherry', { 'panel-layouts': 'on' }) call —
+    // the flag must come from the host-pushed `flags`, not the test harness.
+    const { mountWcUiFollower } = await import('../../../src/ui/wc/wc-follower.js');
+    const app = document.getElementById('app')!;
+    await mountWcUiFollower(app, { stage: () => {} } as never, 'cherry');
+
+    const layout = app.querySelector('slicc-layout') as HTMLElement & {
+      getLayout(): { id: string };
+    };
+    expect(layout).not.toBeNull();
+    expect(layout.getLayout().id).toBe('embed');
+  });
+
+  it('cherry: ignores host-pushed flags that are not valid JSON, keeping the flag off (and the default layout)', async () => {
+    vi.doMock('../../../src/ui/boot/setup-standalone-prelude.js', () => ({
+      setupStandalonePrelude: vi.fn(async () => ({
+        browser: { getTransport: () => ({}), listPages: async () => [] },
+        realCdpTransport: {},
+        cherryJoinUrl: 'https://www.sliccy.ai/join/tray-c.cap',
+        cherryTransport: {
+          emitSliccEventToHost: vi.fn(),
+          onHostEvent: null,
+          flags: '{not json',
+          layout: JSON.stringify({
+            version: 1,
+            id: 'embed',
+            base: { center: { panel: 'chat' } },
+          }),
+          features: ALL_CHERRY_FEATURES,
+        },
+        instanceId: 'i',
+      })),
+    }));
+    vi.resetModules();
+    const { mountWcUiFollower } = await import('../../../src/ui/wc/wc-follower.js');
+    const app = document.getElementById('app')!;
+    await mountWcUiFollower(app, { stage: () => {} } as never, 'cherry');
+
+    expect(app.querySelector('slicc-layout')).toBeNull();
+    expect(app.querySelector('slicc-dock-tree')).not.toBeNull();
+  });
+
   it('cherry: ignores a pushed document that fails schema validation, keeping the default', async () => {
     // `base` present (so it takes the document path) but no id/version — must
     // degrade rather than render a half-broken arrangement.


### PR DESCRIPTION
## Summary
- Adds `flags` to `mountSlicc` — a Cherry host can now push feature-flag overrides (e.g. `{ 'panel-layouts': 'on' }`), serialized in `handshake.welcome.flags` and applied session-only (never persisted to `localStorage`).
- Applied before the `panel-layouts` gate check in `wc-follower.ts`, so a host's own pushed `layout` can turn the flag on for itself, rather than depending on the target deployment's worker-level `FEATURE_FLAGS`.
- Gated through the same `userToggleable`-and-float check a local user override must pass — an embedder can only reach flags this registry already marked safe for outside control.
- Additive `handshake.welcome.flags` field, no protocol version bump (per the 2026-07-27 labs-incident lesson in `packages/cherry/CLAUDE.md`).

## Why
Inside a Cherry embed, the "Experimental features…" dialog that would let a user flip `panel-layouts` is itself hidden (`experimental-settings: off` for the `cherry` float). Before this change the only lever was the worker's per-env `FEATURE_FLAGS`, which flips the flag for every embed on that deployment at once. This gives an individual embedder its own switch.

## Test plan
- [x] `npm run lint` / `npm run typecheck` / `npm run test` (13701 tests) / both builds — all green
- [x] New unit tests: `feature-flags.test.ts` (host override tier + gate), `mount.test.ts` (welcome serialization), `cherry-host-transport-features.test.ts` (getter), `wc-follower.test.ts` (host-pushed flags enabling panel-layouts for its own layout; invalid-JSON flags ignored)
- [x] Docs: `docs/layouts.md`, `packages/cherry/CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)