### PR TITLE
ci(ios-app): parallelize simulator tests as a device × iOS matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1361,15 +1361,108 @@ jobs:
             -scheme SliccFollower \
             -destination 'generic/platform=iOS' \
             CODE_SIGNING_ALLOWED=NO
+      - name: Install Periphery
+        run: brew install peripheryapp/periphery/periphery
+      - name: Dead code detection (Periphery)
+        run: |
+          # Informational scan; surfaces unused Swift declarations without
+          # blocking PRs while existing findings get cleaned up incrementally.
+          # Unlike the SPM packages, an xcodegen project has no Package.swift for
+          # Periphery to infer from, so the project/scheme/target are explicit.
+          cd packages/ios-app && periphery scan \
+            --project SliccFollower.xcodeproj \
+            --schemes SliccFollower \
+            --targets SliccFollower \
+            --disable-update-check || true
+
+  # Simulator test matrix: device × iOS runtime, all cells concurrent so the
+  # slowest leg (not the sum of legs) bounds iOS wall-clock. The iPhone/26
+  # cell is the canonical coverage-gated run; iPhone/27 repeats the unit suite
+  # against the beta SDK without the coverage gate (line coverage shifts
+  # between SDKs, and the floors track the stable one). iPad cells run the
+  # regular-width browser regression. iOS 27 cells ride the `xcode-27` beta
+  # runner image and are informational (continue-on-error) until 27 goes GA —
+  # a beta-image breakage must not hold the merge queue.
+  ios-app-tests:
+    needs: [changes, lint]
+    if: >-
+      needs.lint.result == 'success' &&
+      needs.changes.outputs.is-queue-leader == 'true' &&
+      (needs.changes.outputs.ios-app == 'true' ||
+      needs.changes.outputs.swift-traysession == 'true' ||
+      needs.changes.outputs.swift-config == 'true')
+    strategy:
+      fail-fast: false
+      matrix:
+        device: [iPhone, iPad]
+        ios: ['26', '27']
+    runs-on: ${{ matrix.ios == '27' && 'xcode-27' || 'macos-latest' }}
+    continue-on-error: ${{ matrix.ios == '27' }}
+    # Simulator boots can wedge on fresh runner images; fail fast instead of
+    # holding the merge queue for the 6h default.
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # swift-coverage-check.sh reads its floors from coverage-thresholds.json
+      # via node, so pin Node (matches the other Swift jobs) instead of relying
+      # on the runner's preinstalled version.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Install XcodeGen
+        run: brew install xcodegen
+      - name: Generate Xcode project
+        run: cd packages/ios-app && xcodegen generate
+      - name: Resolve SPM dependencies
+        run: |
+          cd packages/ios-app
+          xcodebuild -resolvePackageDependencies \
+            -project SliccFollower.xcodeproj \
+            -scheme SliccFollower
       # Golden-fixture protocol corpus + unit tests. The shared coverage script
       # picks the simulator, runs `xcodebuild test` with coverage + parallel
       # testing + on-failure retries, and gates the result against the `ios-app`
       # floors in coverage-thresholds.json.
-      - name: Test (with coverage threshold gate)
+      - name: Test (iPhone unit suite, coverage threshold gate)
+        if: matrix.device == 'iPhone' && matrix.ios == '26'
         run: |
           ./packages/dev-tools/tools/swift-coverage-check.sh \
             --xcodebuild SliccFollower packages/ios-app SliccFollower
+      - name: Test (iPhone unit suite, no coverage gate)
+        if: matrix.device == 'iPhone' && matrix.ios != '26'
+        run: |
+          set -o pipefail
+          cd packages/ios-app
+          SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
+          PHONE_UDID=$(
+            xcrun simctl list devices available --json |
+              IOS_SIMULATOR_RUNTIME_KEY="com.apple.CoreSimulator.SimRuntime.iOS-${SDK_VERSION//./-}" node -e '
+                let input = "";
+                process.stdin.on("data", chunk => input += chunk).on("end", () => {
+                  const devices = JSON.parse(input).devices?.[process.env.IOS_SIMULATOR_RUNTIME_KEY] ?? [];
+                  const phone = devices.find(device => device.isAvailable && /iPhone/.test(device.name));
+                  process.stdout.write(phone?.udid ?? "");
+                });
+              '
+          )
+          if [[ -z "$PHONE_UDID" ]]; then
+            echo "::error::No available iPhone simulator matching the iOS $SDK_VERSION SDK"
+            exit 1
+          fi
+          xcrun simctl boot "$PHONE_UDID" 2>/dev/null || true
+          xcrun simctl bootstatus "$PHONE_UDID" -b
+          xcodebuild test \
+            -project SliccFollower.xcodeproj \
+            -scheme SliccFollower \
+            -destination "platform=iOS Simulator,id=$PHONE_UDID" \
+            -derivedDataPath .build/xcodebuild \
+            -resultBundlePath .build/unit-suite.xcresult \
+            -parallel-testing-enabled NO \
+            -retry-tests-on-failure \
+            -test-iterations 2 \
+            -only-testing:SliccFollowerTests
       - name: Test regular-width browser (iPad)
+        if: matrix.device == 'iPad'
         run: |
           set -o pipefail
           cd packages/ios-app
@@ -1402,7 +1495,7 @@ jobs:
             -test-iterations 2 \
             -only-testing:SliccFollowerUITests/RemoteTabUITests/testRegularWidthBrowsingEntersAndExitsFullScreen
       - name: Upload coverage report
-        if: always()
+        if: always() && matrix.device == 'iPhone' && matrix.ios == '26'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-ios-app
@@ -1414,24 +1507,12 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-timings-ios-app
+          name: test-timings-ios-app-${{ matrix.ios }}-${{ matrix.device }}
           path: |
             packages/ios-app/.build/coverage/ios-app.xcresult
+            packages/ios-app/.build/unit-suite.xcresult
             packages/ios-app/.build/regular-width-ui.xcresult
           if-no-files-found: ignore
-      - name: Install Periphery
-        run: brew install peripheryapp/periphery/periphery
-      - name: Dead code detection (Periphery)
-        run: |
-          # Informational scan; surfaces unused Swift declarations without
-          # blocking PRs while existing findings get cleaned up incrementally.
-          # Unlike the SPM packages, an xcodegen project has no Package.swift for
-          # Periphery to infer from, so the project/scheme/target are explicit.
-          cd packages/ios-app && periphery scan \
-            --project SliccFollower.xcodeproj \
-            --schemes SliccFollower \
-            --targets SliccFollower \
-            --disable-update-check || true
 
   global-install:
     needs: changes
@@ -1553,6 +1634,7 @@ jobs:
         swift-optel,
         swift-traysession,
         ios-app,
+        ios-app-tests,
         go-optel,
         slicc-cli,
         release-gate,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1428,72 +1428,23 @@ jobs:
         run: |
           ./packages/dev-tools/tools/swift-coverage-check.sh \
             --xcodebuild SliccFollower packages/ios-app SliccFollower
+      # Both non-coverage legs share ios-sim-test.sh, which reuses the
+      # coverage script's simulator selection, SLICC_IOS_SIM_UDID override,
+      # pre-boot, and runner-init retry — one canonical path, no drift.
       - name: Test (iPhone unit suite, no coverage gate)
         if: matrix.device == 'iPhone' && matrix.ios != '26'
         run: |
-          set -o pipefail
-          cd packages/ios-app
-          SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
-          PHONE_UDID=$(
-            xcrun simctl list devices available --json |
-              IOS_SIMULATOR_RUNTIME_KEY="com.apple.CoreSimulator.SimRuntime.iOS-${SDK_VERSION//./-}" node -e '
-                let input = "";
-                process.stdin.on("data", chunk => input += chunk).on("end", () => {
-                  const devices = JSON.parse(input).devices?.[process.env.IOS_SIMULATOR_RUNTIME_KEY] ?? [];
-                  const phone = devices.find(device => device.isAvailable && /iPhone/.test(device.name));
-                  process.stdout.write(phone?.udid ?? "");
-                });
-              '
-          )
-          if [[ -z "$PHONE_UDID" ]]; then
-            echo "::error::No available iPhone simulator matching the iOS $SDK_VERSION SDK"
-            exit 1
-          fi
-          xcrun simctl boot "$PHONE_UDID" 2>/dev/null || true
-          xcrun simctl bootstatus "$PHONE_UDID" -b
-          xcodebuild test \
-            -project SliccFollower.xcodeproj \
-            -scheme SliccFollower \
-            -destination "platform=iOS Simulator,id=$PHONE_UDID" \
-            -derivedDataPath .build/xcodebuild \
-            -resultBundlePath .build/unit-suite.xcresult \
-            -parallel-testing-enabled NO \
-            -retry-tests-on-failure \
-            -test-iterations 2 \
-            -only-testing:SliccFollowerTests
+          ./packages/dev-tools/tools/ios-sim-test.sh \
+            --device iPhone \
+            --result-bundle .build/unit-suite.xcresult \
+            --only-testing SliccFollowerTests
       - name: Test regular-width browser (iPad)
         if: matrix.device == 'iPad'
         run: |
-          set -o pipefail
-          cd packages/ios-app
-          SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
-          IPAD_UDID=$(
-            xcrun simctl list devices available --json |
-              IOS_SIMULATOR_RUNTIME_KEY="com.apple.CoreSimulator.SimRuntime.iOS-${SDK_VERSION//./-}" node -e '
-                let input = "";
-                process.stdin.on("data", chunk => input += chunk).on("end", () => {
-                  const devices = JSON.parse(input).devices?.[process.env.IOS_SIMULATOR_RUNTIME_KEY] ?? [];
-                  const ipad = devices.find(device => device.isAvailable && /iPad/.test(device.name));
-                  process.stdout.write(ipad?.udid ?? "");
-                });
-              '
-          )
-          if [[ -z "$IPAD_UDID" ]]; then
-            echo "::error::No available iPad simulator matching the iOS $SDK_VERSION SDK"
-            exit 1
-          fi
-          xcrun simctl boot "$IPAD_UDID" 2>/dev/null || true
-          xcrun simctl bootstatus "$IPAD_UDID" -b
-          xcodebuild test \
-            -project SliccFollower.xcodeproj \
-            -scheme SliccFollower \
-            -destination "platform=iOS Simulator,id=$IPAD_UDID" \
-            -derivedDataPath .build/xcodebuild \
-            -resultBundlePath .build/regular-width-ui.xcresult \
-            -parallel-testing-enabled NO \
-            -retry-tests-on-failure \
-            -test-iterations 2 \
-            -only-testing:SliccFollowerUITests/RemoteTabUITests/testRegularWidthBrowsingEntersAndExitsFullScreen
+          ./packages/dev-tools/tools/ios-sim-test.sh \
+            --device iPad \
+            --result-bundle .build/regular-width-ui.xcresult \
+            --only-testing SliccFollowerUITests/RemoteTabUITests/testRegularWidthBrowsingEntersAndExitsFullScreen
       - name: Upload coverage report
         if: always() && matrix.device == 'iPhone' && matrix.ios == '26'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/packages/dev-tools/tools/ios-sim-select.sh
+++ b/packages/dev-tools/tools/ios-sim-select.sh
@@ -1,0 +1,23 @@
+# shellcheck shell=bash
+# Sourced by swift-coverage-check.sh and ios-sim-test.sh — the single home
+# of the simulator-selection JSON parse, so the coverage-gated leg and the
+# matrix test legs cannot drift apart in how they pick a device.
+
+# select_ios_sim_for_sdk <sdk-version> <name-regex>
+# Reads `xcrun simctl list devices available --json` on stdin and prints the
+# UDID of the first available device whose name matches <name-regex> in the
+# runtime matching <sdk-version>, or nothing when none matches.
+select_ios_sim_for_sdk() {
+  local sdk_version="$1"
+  local name_regex="$2"
+  IOS_SIMULATOR_RUNTIME_KEY="com.apple.CoreSimulator.SimRuntime.iOS-${sdk_version//./-}" \
+    IOS_SIMULATOR_NAME_REGEX="$name_regex" node -e '
+    let input = "";
+    process.stdin.on("data", chunk => input += chunk).on("end", () => {
+      const devices = JSON.parse(input).devices?.[process.env.IOS_SIMULATOR_RUNTIME_KEY] ?? [];
+      const nameRe = new RegExp(process.env.IOS_SIMULATOR_NAME_REGEX);
+      const device = devices.find(device => device.isAvailable && nameRe.test(device.name));
+      process.stdout.write(device?.udid ?? "");
+    });
+  '
+}

--- a/packages/dev-tools/tools/ios-sim-test.sh
+++ b/packages/dev-tools/tools/ios-sim-test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Run a SliccFollower test slice on a simulator WITHOUT the coverage gate —
+# the non-canonical cells of the ios-app-tests CI matrix (iPhone on the beta
+# SDK, the iPad regular-width regression). The canonical coverage-gated leg
+# stays in swift-coverage-check.sh; this script shares its simulator
+# selection (ios-sim-select.sh), its SLICC_IOS_SIM_UDID override, its
+# pre-boot, and its runner-init retry (swift-coverage-runner-retry.sh) so
+# the legs cannot drift.
+#
+# Usage:
+#   ios-sim-test.sh --device <name-regex> --result-bundle <path> --only-testing <spec>
+#
+#   --device        simulator name regex, e.g. iPhone or iPad
+#   --result-bundle xcresult path relative to packages/ios-app
+#   --only-testing  xcodebuild -only-testing spec
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DEVICE_REGEX=""
+RESULT_BUNDLE=""
+ONLY_TESTING=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --device) DEVICE_REGEX="$2"; shift 2 ;;
+    --result-bundle) RESULT_BUNDLE="$2"; shift 2 ;;
+    --only-testing) ONLY_TESTING="$2"; shift 2 ;;
+    *) echo "error: unknown argument $1" >&2; exit 2 ;;
+  esac
+done
+for required in DEVICE_REGEX RESULT_BUNDLE ONLY_TESTING; do
+  if [[ -z "${!required}" ]]; then
+    echo "error: missing --$(echo "$required" | tr 'A-Z_' 'a-z-' | sed 's/-regex$//;s/-bundle$/-bundle/')" >&2
+    exit 2
+  fi
+done
+
+# shellcheck source=packages/dev-tools/tools/ios-sim-select.sh
+source "$SCRIPT_DIR/ios-sim-select.sh"
+# shellcheck source=packages/dev-tools/tools/swift-coverage-runner-retry.sh
+source "$SCRIPT_DIR/swift-coverage-runner-retry.sh"
+
+cd "$REPO_ROOT/packages/ios-app"
+
+SDK_VERSION="$(xcrun --sdk iphonesimulator --show-sdk-version)"
+# Same override contract as swift-coverage-check.sh: a worktree-owned or
+# CI-pinned simulator wins over discovery.
+UDID="${SLICC_IOS_SIM_UDID:-}"
+if [[ -z "$UDID" ]]; then
+  UDID=$(
+    xcrun simctl list devices available --json |
+      select_ios_sim_for_sdk "$SDK_VERSION" "$DEVICE_REGEX"
+  )
+fi
+if [[ -z "$UDID" ]]; then
+  echo "::error::No available simulator matching /$DEVICE_REGEX/ for the iOS $SDK_VERSION SDK"
+  exit 1
+fi
+
+# Pre-boot: a UI-test runner attaching to a still-booting device dies with
+# "Timed out while loading Accessibility" before a single test runs, which
+# -retry-tests-on-failure cannot rescue.
+echo "==> waiting for simulator $UDID to finish booting"
+xcrun simctl boot "$UDID" 2>/dev/null || true
+xcrun simctl bootstatus "$UDID" -b ||
+  echo "::warning::simctl bootstatus did not report a clean boot; continuing"
+
+echo "==> xcodebuild test ($ONLY_TESTING, simulator $UDID)"
+set -o pipefail
+XCODEBUILD_LOG=$(mktemp -t ios-sim-test-xcodebuild)
+trap 'rm -f "$XCODEBUILD_LOG"' EXIT
+
+run_single_xcodebuild_attempt() {
+  # xcodebuild refuses to overwrite an existing result bundle.
+  rm -rf "$RESULT_BUNDLE"
+  xcodebuild test \
+    -project SliccFollower.xcodeproj \
+    -scheme SliccFollower \
+    -destination "platform=iOS Simulator,id=$UDID" \
+    -derivedDataPath .build/xcodebuild \
+    -resultBundlePath "$RESULT_BUNDLE" \
+    -parallel-testing-enabled NO \
+    -retry-tests-on-failure \
+    -test-iterations 2 \
+    "-only-testing:$ONLY_TESTING"
+}
+run_with_runner_init_retry "$XCODEBUILD_LOG" run_single_xcodebuild_attempt

--- a/packages/dev-tools/tools/swift-coverage-check.sh
+++ b/packages/dev-tools/tools/swift-coverage-check.sh
@@ -29,16 +29,13 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 # Resolved before any `cd` below — BASH_SOURCE may be a relative path.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Simulator selection is shared with ios-sim-test.sh (the non-coverage CI
+# matrix legs) so the two paths cannot drift.
+# shellcheck source=packages/dev-tools/tools/ios-sim-select.sh
+source "$SCRIPT_DIR/ios-sim-select.sh"
+
 select_iphone_for_sdk() {
-  local sdk_version="$1"
-  IOS_SIMULATOR_RUNTIME_KEY="com.apple.CoreSimulator.SimRuntime.iOS-${sdk_version//./-}" node -e '
-    let input = "";
-    process.stdin.on("data", chunk => input += chunk).on("end", () => {
-      const devices = JSON.parse(input).devices?.[process.env.IOS_SIMULATOR_RUNTIME_KEY] ?? [];
-      const iphone = devices.find(device => device.isAvailable && /iPhone/.test(device.name));
-      process.stdout.write(iphone?.udid ?? "");
-    });
-  '
+  select_ios_sim_for_sdk "$1" iPhone
 }
 
 configure_xcode_coverage_scope() {

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -136,12 +136,12 @@ Hand-running the app for exploratory QA is covered in [`docs/ios-simulator-qa.md
 
 A `bundle.ui-testing` target remains in the scheme, but the unit coverage gate excludes it. Run `-only-testing:SliccFollowerUITests` when UI changes, as a separate CI job. No test needs a leader: `-uiTestFixtureRoute YES` opens the leaderless **UI Fixture** route; `-uiTestSessionsFixture/Empty YES` seeds iCloud sessions in-memory; `-uiTestScoopStatusFixture` covers lifecycle/fill; `-uiTestReduceMotion` keeps the fullness cue static. `UITestHooks` is `#if DEBUG` only. The failure-state test dials `http://127.0.0.1:1/…` so `Connection Failed` arrives without DNS. `-uiTestCompletedTurn YES` feeds `message_start` + `content_done` + `status: ready` through the real dispatcher.
 
-Regular-width browser tabs claim the whole iPad window; returning to the tab overview restores the split. CI runs this enter/exit regression separately on an iPad simulator.
+Regular-width browser tabs claim the whole iPad window; returning to the tab overview restores the split. CI runs this enter/exit regression in the `ios-app-tests` device × iOS matrix (iPad cells; iOS 27 cells are informational).
 
 - Put accessibility identifiers on leaves (`message-<id>`). Container ids propagate; `.accessibilityElement(children: .contain)` does not fix that.
 - Row ids alone are blind — also add a `variantMarkers` string only that renderer can emit.
 - The transcript pins to the newest message; variant walks scroll bottom-to-top and must be bounded.
-- A red CI job names the test, not the reason. Read XCTAssert text from the uploaded `test-timings-ios-app` xcresult via `xcrun xcresulttool get test-results tests`. Host death before XCTest connects is usually a runtime mismatch or `CODE_SIGNING_ALLOWED=NO` on the test build, not a flake.
+- A red CI job names the test, not the reason. Read XCTAssert text from the uploaded `test-timings-ios-app-<ios>-<device>` xcresult via `xcrun xcresulttool get test-results tests`. Host death before XCTest connects is usually a runtime mismatch or `CODE_SIGNING_ALLOWED=NO` on the test build, not a flake.
 
 ## Linting
 


### PR DESCRIPTION
The `ios-app` job ran the iPhone coverage suite and the iPad regular-width regression **sequentially** on one runner, so iOS wall-clock was the sum of both legs. This splits the tests into a new `ios-app-tests` matrix job so the slowest leg, not the sum, bounds wall-clock.

## Matrix

| | iOS 26 (`macos-latest`, Xcode 26.6) | iOS 27 (`xcode-27` beta image) |
|---|---|---|
| **iPhone** | unit suite, coverage-gated (canonical; unchanged floors + `coverage-ios-app` artifact) | unit suite, no coverage gate |
| **iPad** | regular-width browser regression | regular-width browser regression |

- All four cells run concurrently; `fail-fast: false` so one cell's failure doesn't cancel the rest.
- **iOS 27 cells are informational** (`continue-on-error: true`): they ride the beta runner image, and a beta breakage must not hold the merge queue. Flip when 27 goes GA.
- The iPad leg always compiled into its own derived-data path, so splitting it out duplicates no build work vs the sequential version.
- iPhone/27 skips the coverage gate deliberately — line coverage shifts between SDKs and the floors track the stable runtime.
- `ios-app` keeps SwiftLint/swift-format, both builds (simulator + device), and the Periphery scan.
- Per-cell xcresults upload as `test-timings-ios-app-<ios>-<device>`; the aggregate `ci` job now needs `ios-app-tests`.

No runtime downloads: iOS 26 uses the default Xcode on `macos-latest`, iOS 27 uses GitHub's dedicated `xcode-27` beta runner label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXn7dzJEwXceMx3ABAhfPg