### PR TITLE
feat(webapp): agentic memory curation behind feature flag

### DIFF
--- a/packages/cloudflare-worker/wrangler.jsonc
+++ b/packages/cloudflare-worker/wrangler.jsonc
@@ -44,7 +44,11 @@
     "CONE_CAP_PAUSED": "5",
     // Feature flag config: base string map plus per-float string-map overlays.
     "FEATURE_FLAGS": {
-      "base": { "experimental-settings": "on", "panel-layouts": "off" },
+      "base": {
+        "experimental-settings": "on",
+        "panel-layouts": "off",
+        "agentic-memory": "off"
+      },
       "floats": {
         "standalone": {},
         "cherry": { "experimental-settings": "off" }
@@ -114,7 +118,11 @@
         "CONE_CAP_PAUSED": "5",
         // Feature flag config: base string map plus per-float string-map overlays.
         "FEATURE_FLAGS": {
-          "base": { "experimental-settings": "on", "panel-layouts": "off" },
+          "base": {
+            "experimental-settings": "on",
+            "panel-layouts": "off",
+            "agentic-memory": "off"
+          },
           "floats": {
             "standalone": {},
             "cherry": { "experimental-settings": "off" }

--- a/packages/vfs-root/CLAUDE.md
+++ b/packages/vfs-root/CLAUDE.md
@@ -25,6 +25,9 @@ This file covers the default virtual filesystem payload in `packages/vfs-root/`.
 - `shared/MEMORY.md` is the single source for the runner's build-time fallback and the seeded
   `/shared/MEMORY.md` file.
 - The file is seeded only when absent, so user and skill customizations survive later boots.
+- `MEMORY.md` is user-edited only; the curator intentionally cannot rewrite its own instructions.
+- Frontmatter uses a strict YAML subset: block-array items may have `#` comment tails; inline
+  entries containing commas must be quoted. A bare `/` is rejected from `writablePaths`.
 
 ### Skills
 

--- a/packages/vfs-root/CLAUDE.md
+++ b/packages/vfs-root/CLAUDE.md
@@ -22,8 +22,8 @@ This file covers the default virtual filesystem payload in `packages/vfs-root/`.
 
 ### Memory curator
 
-- Keep `shared/MEMORY.md` byte-for-byte aligned with the exported default in
-  `packages/webapp/src/scoops/agentic-memory.ts`; the drift test enforces this.
+- `shared/MEMORY.md` is the single source for the runner's build-time fallback and the seeded
+  `/shared/MEMORY.md` file.
 - The file is seeded only when absent, so user and skill customizations survive later boots.
 
 ### Skills

--- a/packages/vfs-root/CLAUDE.md
+++ b/packages/vfs-root/CLAUDE.md
@@ -13,11 +13,18 @@ This file covers the default virtual filesystem payload in `packages/vfs-root/`.
 | `packages/vfs-root/shared/`           | Shared content that becomes `/shared/` in the VFS                  |
 | `packages/vfs-root/workspace/`        | Default workspace content that becomes `/workspace/` in the VFS    |
 | `packages/vfs-root/shared/CLAUDE.md`  | Agent-facing runtime instructions bundled into `/shared/CLAUDE.md` |
+| `packages/vfs-root/shared/MEMORY.md`  | User-editable memory curator config bundled as `/shared/MEMORY.md` |
 | `packages/vfs-root/shared/sprinkles/` | Built-in sprinkle UIs                                              |
 | `packages/vfs-root/shared/sounds/`    | Shared notification sounds                                         |
 | `packages/vfs-root/workspace/skills/` | Default installable workspace skills                               |
 
 ## Adding Default Content
+
+### Memory curator
+
+- Keep `shared/MEMORY.md` byte-for-byte aligned with the exported default in
+  `packages/webapp/src/scoops/agentic-memory.ts`; the drift test enforces this.
+- The file is seeded only when absent, so user and skill customizations survive later boots.
 
 ### Skills
 

--- a/packages/vfs-root/shared/MEMORY.md
+++ b/packages/vfs-root/shared/MEMORY.md
@@ -1,0 +1,40 @@
+---
+writablePaths:
+  - /workspace/
+visiblePaths:
+  - /sessions/
+  - /shared/
+allowedCommands:
+  - cat
+  - find
+  - grep
+  - head
+  - ls
+  - mkdir
+  - mv
+  - sed
+  - tail
+  - touch
+  - wc
+timeoutSeconds: 120
+---
+
+# Memory curator
+
+Curate the durable memory for session {{SESSION_COUNT}}.
+
+Read the current memory at {{MEMORY_PATH}} if it exists, then read the archived session at {{SESSION_ARCHIVE_PATH}}. Rewrite {{MEMORY_PATH}} with the durable information worth carrying into future sessions.
+
+Rules:
+
+- Preserve the user-authored header before the first `## Auto-extracted` heading verbatim.
+- Keep durable preferences, stable project facts, validated approaches, and named resources.
+- Organize retained information into concise per-topic sections such as `## Preferences`, `## Context`, and per-project `##` sections rather than one flat list.
+- Drop ephemera, duplicates, and superseded facts.
+- Preserve concrete identifiers such as file paths, URLs, IDs, and names verbatim.
+- Keep the complete file at or below {{BUDGET_CHARS}} characters.
+- Write the result to {{MEMORY_PATH}}; do not merely return it in your response.
+
+<!-- How to customize
+Add curator instructions here, for example: also update the knowledge base at /path following its WIKI.md. Extend visiblePaths or writablePaths above to grant access to extra stores, and adjust timeoutSeconds when needed.
+-->

--- a/packages/vfs-root/shared/MEMORY.md
+++ b/packages/vfs-root/shared/MEMORY.md
@@ -37,4 +37,8 @@ Rules:
 
 <!-- How to customize
 Add curator instructions here, for example: also update the knowledge base at /path following its WIKI.md. Extend visiblePaths or writablePaths above to grant access to extra stores, and adjust timeoutSeconds when needed.
+
+MEMORY.md is user-edited only: the curator intentionally has read-only access to /shared/ and cannot rewrite its own instructions. A bare / is rejected in writablePaths.
+
+Frontmatter supports a strict YAML subset. Arrays may use the block form above (with optional # comment tails) or inline form such as [cat, grep]. Inline entries containing commas must be quoted, for example ["/knowledge/lars,rebecca/"].
 -->

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -211,7 +211,8 @@ See docs/architecture.md "Multi-Browser Sync (Tray) Architecture".
 - Path: `ui/session-freezer.ts`, `ui/new-session.ts`.
 - **Save**, **Skip memory**, and **Erase** clear cone chat and non-mount `/tmp`, not scoops.
 - Archives: `/sessions/<timestamp>-<slug>.md` plus `index.json`. `agentic-memory` writes full
-  archives before its kernel `MEMORY.md` curator; failure/quick/enrichment use legacy.
+  archives before its kernel `MEMORY.md` curator. Finished failures use legacy extraction;
+  timeouts skip it to avoid racing the still-running curator. Quick/enrichment stay legacy.
 - Cone-only `OffscreenClient.clearAllMessages()` awaits `clear-chat-ack` before panel reload.
 
 ### UI

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -209,11 +209,9 @@ See docs/architecture.md "Multi-Browser Sync (Tray) Architecture".
 ### Frozen Sessions ("New session" flow)
 
 - Path: `ui/session-freezer.ts`, `ui/new-session.ts`.
-- Actions: **Save & start new** (enriched archive), **New chat — skip memory** (quick archive),
-  and **Erase & start new** (none). Each clears cone chat and `/tmp` except mount roots; scoops
-  survive, and reload/restart/scoop creation do not clear `/tmp`.
-- Archive format: `/sessions/<timestamp>-<slug>.md` (YAML frontmatter +
-  `slicc:session-data` + body); prepended index: `/sessions/index.json`.
+- **Save**, **Skip memory**, and **Erase** clear cone chat and non-mount `/tmp`, not scoops.
+- Archives: `/sessions/<timestamp>-<slug>.md` plus `index.json`. `agentic-memory` writes full
+  archives before its kernel `MEMORY.md` curator; failure/quick/enrichment use legacy.
 - Cone-only `OffscreenClient.clearAllMessages()` awaits `clear-chat-ack` before panel reload.
 
 ### UI

--- a/packages/webapp/src/core/feature-flags.ts
+++ b/packages/webapp/src/core/feature-flags.ts
@@ -8,7 +8,7 @@ export type FeatureFlagFloat =
   | 'cherry'
   | 'follower';
 
-export type FeatureFlagId = 'experimental-settings' | 'panel-layouts';
+export type FeatureFlagId = 'experimental-settings' | 'panel-layouts' | 'agentic-memory';
 export type FeatureFlagValues = Partial<Record<FeatureFlagId, string>>;
 
 export interface FeatureFlagDefinition {
@@ -39,6 +39,14 @@ const FEATURE_FLAGS: readonly FeatureFlagDefinition[] = Object.freeze([
     // Off everywhere while the dock-tree is still the shipping layout. No
     // `floatDefaults`: the gate is uniform across floats, including a Cherry embed
     // pushing its own layout, so there is one answer to "are panels on here".
+    defaultValue: 'off',
+    userToggleable: true,
+  }),
+  Object.freeze({
+    id: 'agentic-memory',
+    label: 'Agentic memory',
+    description:
+      'Curate session memory with a background agent instead of a one-shot extraction call.',
     defaultValue: 'off',
     userToggleable: true,
   }),

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -12,6 +12,7 @@ import type { BrowserAPI } from '../cdp/index.js';
 import type { AgentEvent } from '../core/agent-types.js';
 import type { MessageAttachment } from '../core/attachments.js';
 import { createLogger } from '../core/logger.js';
+import { AGENT_BRIDGE_GLOBAL_KEY, type AgentBridge } from '../scoops/agent-bridge.js';
 import { SessionStore } from '../scoops/chat-session-store.js';
 import type { ChatMessage } from '../scoops/chat-types.js';
 import { HIDDEN_TOOL_NAMES } from '../scoops/hidden-tools.js';
@@ -30,6 +31,7 @@ import type { ChannelMessage, RegisteredScoop, ScoopTabState } from '../scoops/t
 import { TOOL_UI_MOUNTED_ACTION, toolUIRegistry } from '../tools/tool-ui.js';
 import type {
   AgentEventMsg,
+  AgentSpawnResultMsg,
   ErrorMsg,
   ExtensionMessage,
   ForwardedLickEvent,
@@ -1552,6 +1554,11 @@ export class Bridge implements KernelFacade {
         break;
       }
 
+      case 'agent-spawn-request': {
+        await this.handleAgentSpawn(msg);
+        break;
+      }
+
       case 'clear-filesystem':
         await this.orchestrator
           .resetFilesystem()
@@ -1643,6 +1650,34 @@ export class Bridge implements KernelFacade {
         this.applyLocalStorageOp(msg.type, (s) => s.clear());
         break;
       }
+    }
+  }
+
+  private async handleAgentSpawn(
+    msg: Extract<PanelToOffscreenMessage, { type: 'agent-spawn-request' }>
+  ): Promise<void> {
+    const agentBridge = (globalThis as Record<string, unknown>)[AGENT_BRIDGE_GLOBAL_KEY] as
+      | AgentBridge
+      | undefined;
+    if (!agentBridge || typeof agentBridge.spawn !== 'function') {
+      this.emit({
+        type: 'agent-spawn-result',
+        requestId: msg.requestId,
+        ok: false,
+        error: 'AgentBridge unavailable',
+      } satisfies AgentSpawnResultMsg);
+      return;
+    }
+    try {
+      const result = await agentBridge.spawn(msg.options);
+      this.emit({ type: 'agent-spawn-result', requestId: msg.requestId, ok: true, result });
+    } catch (err) {
+      this.emit({
+        type: 'agent-spawn-result',
+        requestId: msg.requestId,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      } satisfies AgentSpawnResultMsg);
     }
   }
 

--- a/packages/webapp/src/kernel/messages.ts
+++ b/packages/webapp/src/kernel/messages.ts
@@ -9,6 +9,7 @@
  */
 
 import type { MessageAttachment } from '../core/attachments.js';
+import type { AgentSpawnOptions, AgentSpawnResult } from '../scoops/agent-bridge.js';
 import type { ChatMessage } from '../scoops/chat-types.js';
 import type { ScoopTabState } from '../scoops/types.js';
 import type { TerminalControlMsg, TerminalEventMsg } from '../shell/terminal-protocol.js';
@@ -216,6 +217,18 @@ export interface ClearChatAckMsg {
   type: 'clear-chat-ack';
   requestId: string;
 }
+
+/** Page → kernel request to spawn an isolated agent through the worker-owned AgentBridge. */
+export interface AgentSpawnRequestMsg {
+  type: 'agent-spawn-request';
+  requestId: string;
+  options: AgentSpawnOptions;
+}
+
+/** Correlated kernel → page reply for {@link AgentSpawnRequestMsg}. */
+export type AgentSpawnResultMsg =
+  | { type: 'agent-spawn-result'; requestId: string; ok: true; result: AgentSpawnResult }
+  | { type: 'agent-spawn-result'; requestId: string; ok: false; error: string };
 
 export interface ClearFilesystemMsg {
   type: 'clear-filesystem';
@@ -739,6 +752,7 @@ export type PanelToOffscreenMessage =
   | RequestScoopChatMessagesMsg
   | RequestSessionStatsMsg
   | ClearChatMsg
+  | AgentSpawnRequestMsg
   | ClearFilesystemMsg
   | RefreshModelMsg
   | SetThinkingLevelMsg
@@ -1114,6 +1128,7 @@ export type OffscreenToPanelMessage =
   | OAuthResultMsg
   | TrayRuntimeStatusMsg
   | ClearChatAckMsg
+  | AgentSpawnResultMsg
   | SetThinkingLevelAckMsg
   | FollowerSprinklesListMsg
   | FollowerSprinkleUpdateMsg

--- a/packages/webapp/src/kernel/types.ts
+++ b/packages/webapp/src/kernel/types.ts
@@ -18,6 +18,7 @@
 
 import type { BrowserAPI } from '../cdp/browser-api.js';
 import type { AgentHandle, AgentEvent as UIAgentEvent } from '../core/agent-types.js';
+import type { AgentSpawnOptions, AgentSpawnResult } from '../scoops/agent-bridge.js';
 import type { ChatMessage } from '../scoops/chat-types.js';
 import type { Orchestrator } from '../scoops/orchestrator.js';
 import type { FollowerSyncManager } from '../scoops/tray-follower-sync.js';
@@ -237,6 +238,7 @@ export interface KernelClientFacade {
    * extension mode the offscreen document survives the panel reload).
    */
   clearAllMessages(): Promise<void>;
+  spawnAgent(options: AgentSpawnOptions): Promise<AgentSpawnResult>;
   clearFilesystem(): void;
   requestState(): void;
   sendSprinkleLick(

--- a/packages/webapp/src/scoops/agent-bridge.ts
+++ b/packages/webapp/src/scoops/agent-bridge.ts
@@ -49,6 +49,13 @@ const log = createLogger('agent-bridge');
 export interface AgentSpawnOptions {
   /** Absolute VFS path that becomes a read-write prefix for the spawned scoop. */
   cwd: string;
+  /**
+   * Optional writable VFS roots. Pure replace semantics for caller-provided
+   * roots; bridge-owned scratch and `/tmp/` remain available. When omitted,
+   * the historical `[cwd, '/shared/']` roots are used. Invalid non-absolute
+   * entries also fall back to those historical defaults.
+   */
+  writablePaths?: string[];
   /** Bash command allow-list. Omitted / wildcard means "unrestricted." */
   allowedCommands: string[];
   /** Prompt forwarded verbatim to the spawned scoop's agent loop. */
@@ -261,7 +268,8 @@ function buildScoopConfig(
 ): NonNullable<RegisteredScoop['config']> {
   const cwdPrefix = normalizeRwPrefix(options.cwd);
   const visiblePaths = resolveVisiblePaths(options);
-  const writablePaths = dedupePrefixes([cwdPrefix, '/shared/', `${scratchFolder}/`, '/tmp/']);
+  const configuredWritable = resolveWritablePaths(options.writablePaths, cwdPrefix);
+  const writablePaths = dedupePrefixes([...configuredWritable, `${scratchFolder}/`, '/tmp/']);
 
   const scoopConfig: NonNullable<RegisteredScoop['config']> = {
     visiblePaths,
@@ -658,6 +666,17 @@ export function defaultResolveModel(modelId: string): string | null {
 function normalizeRwPrefix(path: string): string {
   const normalized = normalizePath(path);
   return normalized.endsWith('/') ? normalized : `${normalized}/`;
+}
+
+function resolveWritablePaths(paths: string[] | undefined, cwdPrefix: string): string[] {
+  const defaults = [cwdPrefix, '/shared/'];
+  if (paths === undefined) return defaults;
+  if (
+    paths.some((path) => typeof path !== 'string' || !path.startsWith('/') || path.includes('\0'))
+  ) {
+    return defaults;
+  }
+  return paths.map(normalizeRwPrefix);
 }
 
 /**

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -47,10 +47,9 @@ export interface RunAgenticMemoryPassOptions {
   signal?: AbortSignal;
 }
 
-export interface AgenticMemoryPassResult {
-  ok: boolean;
-  reason?: string;
-}
+export type AgenticMemoryPassResult =
+  | { ok: true }
+  | { ok: false; reason: string; legacyFallbackSafe: boolean };
 
 type FrontmatterValue = string | string[];
 type WaitOutcome =
@@ -63,7 +62,9 @@ export async function runAgenticMemoryPass(
   opts: RunAgenticMemoryPassOptions
 ): Promise<AgenticMemoryPassResult> {
   try {
-    if (opts.signal?.aborted) return { ok: false, reason: 'aborted' };
+    if (opts.signal?.aborted) {
+      return { ok: false, reason: 'aborted', legacyFallbackSafe: false };
+    }
     const config = await loadMemoryConfig(opts.vfs);
     const prompt = substitutePlaceholders(config.promptTemplate, {
       MEMORY_PATH: CONE_MEMORY_PATH,
@@ -74,16 +75,26 @@ export async function runAgenticMemoryPass(
     const spawnOptions = buildSpawnOptions(config, prompt);
     const spawnPromise = Promise.resolve().then(() => opts.spawn(spawnOptions));
     const outcome = await waitForSpawn(spawnPromise, config.timeoutSeconds * 1000, opts.signal);
-    if (outcome.type === 'timeout') return { ok: false, reason: 'timeout' };
-    if (outcome.type === 'aborted') return { ok: false, reason: 'aborted' };
-    if (outcome.type === 'error') return { ok: false, reason: errorText(outcome.error) };
+    if (outcome.type === 'timeout') {
+      return { ok: false, reason: 'timeout', legacyFallbackSafe: false };
+    }
+    if (outcome.type === 'aborted') {
+      return { ok: false, reason: 'aborted', legacyFallbackSafe: false };
+    }
+    if (outcome.type === 'error') {
+      return { ok: false, reason: errorText(outcome.error), legacyFallbackSafe: true };
+    }
     if (outcome.result.exitCode !== 0) {
-      return { ok: false, reason: outcome.result.finalText || `exit-${outcome.result.exitCode}` };
+      return {
+        ok: false,
+        reason: outcome.result.finalText || `exit-${outcome.result.exitCode}`,
+        legacyFallbackSafe: true,
+      };
     }
     return { ok: true };
   } catch (error) {
     log.warn('Agentic memory pass failed', { error: errorText(error) });
-    return { ok: false, reason: errorText(error) };
+    return { ok: false, reason: errorText(error), legacyFallbackSafe: false };
   }
 }
 

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -165,7 +165,7 @@ function parseArrayValue(
     if (!value.startsWith('[') || !value.endsWith(']')) throw new Error('Expected an array');
     const inner = value.slice(1, -1).trim();
     return {
-      value: inner ? inner.split(',').map(parseScalar) : [],
+      value: inner ? splitInlineArray(inner) : [],
       lastIndex: keyIndex,
     };
   }
@@ -174,10 +174,41 @@ function parseArrayValue(
   for (let index = keyIndex + 1; index < lines.length; index += 1) {
     const item = lines[index].match(/^\s+-\s+(.+)$/);
     if (!item) break;
-    value.push(parseScalar(item[1]));
+    value.push(parseScalar(stripBlockArrayComment(item[1])));
     lastIndex = index;
   }
   return { value, lastIndex };
+}
+
+function splitInlineArray(inner: string): string[] {
+  const items: string[] = [];
+  let start = 0;
+  let quote: '"' | "'" | undefined;
+  for (let index = 0; index < inner.length; index += 1) {
+    const char = inner[index];
+    if (char === '"' || char === "'") {
+      quote = quote === char ? undefined : (quote ?? char);
+    } else if (char === ',' && !quote) {
+      items.push(parseScalar(inner.slice(start, index)));
+      start = index + 1;
+    }
+  }
+  if (quote) throw new Error('Unclosed quoted value');
+  items.push(parseScalar(inner.slice(start)));
+  return items;
+}
+
+function stripBlockArrayComment(raw: string): string {
+  let quote: '"' | "'" | undefined;
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (char === '"' || char === "'") {
+      quote = quote === char ? undefined : (quote ?? char);
+    } else if (char === '#' && !quote && (index === 0 || /\s/.test(raw[index - 1]))) {
+      return raw.slice(0, index).trimEnd();
+    }
+  }
+  return raw;
 }
 
 function parseScalar(raw: string): string {
@@ -215,7 +246,12 @@ function readTimeout(value: FrontmatterValue | undefined): number {
 }
 
 function validatePaths(paths: string[], key: string): void {
-  if (paths.some((path) => !path.startsWith('/') || path.includes('\0'))) {
+  if (
+    paths.some(
+      (path) =>
+        !path.startsWith('/') || path.includes('\0') || (key === 'writablePaths' && path === '/')
+    )
+  ) {
     throw new Error(`${key} must contain absolute VFS paths`);
   }
 }

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -1,0 +1,297 @@
+import { createLogger } from '../core/logger.js';
+import type { LocalVfsClient } from '../kernel/local-vfs-client.js';
+import type { AgentBridge, AgentSpawnOptions, AgentSpawnResult } from './agent-bridge.js';
+import { CONE_MEMORY_PATH, computeBudget } from './cone-memory-budget.js';
+
+const log = createLogger('agentic-memory');
+
+export const MEMORY_INSTRUCTIONS_PATH = '/shared/MEMORY.md';
+export const DEFAULT_MEMORY_TIMEOUT_SECONDS = 120;
+export const MAX_MEMORY_TIMEOUT_SECONDS = 600;
+
+export const DEFAULT_MEMORY_MD = `---
+writablePaths:
+  - /workspace/
+visiblePaths:
+  - /sessions/
+  - /shared/
+allowedCommands:
+  - cat
+  - find
+  - grep
+  - head
+  - ls
+  - mkdir
+  - mv
+  - sed
+  - tail
+  - touch
+  - wc
+timeoutSeconds: 120
+---
+
+# Memory curator
+
+Curate the durable memory for session {{SESSION_COUNT}}.
+
+Read the current memory at {{MEMORY_PATH}} if it exists, then read the archived session at {{SESSION_ARCHIVE_PATH}}. Rewrite {{MEMORY_PATH}} with the durable information worth carrying into future sessions.
+
+Rules:
+
+- Preserve the user-authored header before the first \`## Auto-extracted\` heading verbatim.
+- Keep durable preferences, stable project facts, validated approaches, and named resources.
+- Organize retained information into concise per-topic sections such as \`## Preferences\`, \`## Context\`, and per-project \`##\` sections rather than one flat list.
+- Drop ephemera, duplicates, and superseded facts.
+- Preserve concrete identifiers such as file paths, URLs, IDs, and names verbatim.
+- Keep the complete file at or below {{BUDGET_CHARS}} characters.
+- Write the result to {{MEMORY_PATH}}; do not merely return it in your response.
+
+<!-- How to customize
+Add curator instructions here, for example: also update the knowledge base at /path following its WIKI.md. Extend visiblePaths or writablePaths above to grant access to extra stores, and adjust timeoutSeconds when needed.
+-->
+`;
+
+const DEFAULT_WRITABLE_PATHS = ['/workspace/'];
+const DEFAULT_VISIBLE_PATHS = ['/sessions/', '/shared/'];
+const DEFAULT_ALLOWED_COMMANDS = [
+  'cat',
+  'find',
+  'grep',
+  'head',
+  'ls',
+  'mkdir',
+  'mv',
+  'sed',
+  'tail',
+  'touch',
+  'wc',
+];
+const ARRAY_KEYS = new Set(['writablePaths', 'visiblePaths', 'allowedCommands']);
+const SCALAR_KEYS = new Set(['model', 'timeoutSeconds']);
+
+interface MemoryConfig {
+  writablePaths: string[];
+  visiblePaths: string[];
+  allowedCommands: string[];
+  model?: string;
+  timeoutSeconds: number;
+  promptTemplate: string;
+}
+
+export interface RunAgenticMemoryPassOptions {
+  spawn: AgentBridge['spawn'];
+  vfs: Pick<LocalVfsClient, 'readFile'>;
+  sessionArchivePath: string;
+  sessionCount: number;
+  signal?: AbortSignal;
+}
+
+export interface AgenticMemoryPassResult {
+  ok: boolean;
+  reason?: string;
+}
+
+type FrontmatterValue = string | string[];
+type WaitOutcome =
+  | { type: 'result'; result: AgentSpawnResult }
+  | { type: 'error'; error: unknown }
+  | { type: 'timeout' }
+  | { type: 'aborted' };
+
+export async function runAgenticMemoryPass(
+  opts: RunAgenticMemoryPassOptions
+): Promise<AgenticMemoryPassResult> {
+  try {
+    if (opts.signal?.aborted) return { ok: false, reason: 'aborted' };
+    const config = await loadMemoryConfig(opts.vfs);
+    const prompt = substitutePlaceholders(config.promptTemplate, {
+      MEMORY_PATH: CONE_MEMORY_PATH,
+      SESSION_ARCHIVE_PATH: opts.sessionArchivePath,
+      SESSION_COUNT: String(opts.sessionCount),
+      BUDGET_CHARS: String(computeBudget(opts.sessionCount)),
+    });
+    const spawnOptions = buildSpawnOptions(config, prompt);
+    const spawnPromise = Promise.resolve().then(() => opts.spawn(spawnOptions));
+    const outcome = await waitForSpawn(spawnPromise, config.timeoutSeconds * 1000, opts.signal);
+    if (outcome.type === 'timeout') return { ok: false, reason: 'timeout' };
+    if (outcome.type === 'aborted') return { ok: false, reason: 'aborted' };
+    if (outcome.type === 'error') return { ok: false, reason: errorText(outcome.error) };
+    if (outcome.result.exitCode !== 0) {
+      return { ok: false, reason: outcome.result.finalText || `exit-${outcome.result.exitCode}` };
+    }
+    return { ok: true };
+  } catch (error) {
+    log.warn('Agentic memory pass failed', { error: errorText(error) });
+    return { ok: false, reason: errorText(error) };
+  }
+}
+
+async function loadMemoryConfig(vfs: Pick<LocalVfsClient, 'readFile'>): Promise<MemoryConfig> {
+  try {
+    const raw = await vfs.readFile(MEMORY_INSTRUCTIONS_PATH, { encoding: 'utf-8' });
+    const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+    return parseMemoryDocument(text);
+  } catch (error) {
+    log.warn('Could not load valid MEMORY.md; using built-in default', {
+      error: errorText(error),
+    });
+    return parseMemoryDocument(DEFAULT_MEMORY_MD);
+  }
+}
+
+function parseMemoryDocument(content: string): MemoryConfig {
+  const normalized = content.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n');
+  const match = normalized.match(/^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/);
+  if (!match?.[2].trim()) throw new Error('MEMORY.md requires frontmatter and a prompt');
+  const values = parseFrontmatter(match[1]);
+  const writablePaths = readArray(values, 'writablePaths', DEFAULT_WRITABLE_PATHS);
+  if (writablePaths.length === 0) throw new Error('writablePaths must not be empty');
+  validatePaths(writablePaths, 'writablePaths');
+  const visiblePaths = readArray(values, 'visiblePaths', DEFAULT_VISIBLE_PATHS);
+  validatePaths(visiblePaths, 'visiblePaths');
+  const timeoutSeconds = readTimeout(values.timeoutSeconds);
+  const model = readOptionalString(values.model, 'model');
+  return {
+    writablePaths,
+    visiblePaths,
+    allowedCommands: readArray(values, 'allowedCommands', DEFAULT_ALLOWED_COMMANDS),
+    ...(model ? { model } : {}),
+    timeoutSeconds,
+    promptTemplate: match[2].trim(),
+  };
+}
+
+function parseFrontmatter(frontmatter: string): Record<string, FrontmatterValue> {
+  const result: Record<string, FrontmatterValue> = {};
+  const lines = frontmatter.split('\n');
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line.trim() || line.trimStart().startsWith('#')) continue;
+    const keyMatch = line.match(/^([A-Za-z][A-Za-z0-9]*):\s*(.*)$/);
+    if (!keyMatch) throw new Error(`Invalid frontmatter line: ${line}`);
+    const [, key, rest] = keyMatch;
+    if (ARRAY_KEYS.has(key)) {
+      const parsed = parseArrayValue(lines, index, rest);
+      result[key] = parsed.value;
+      index = parsed.lastIndex;
+    } else if (SCALAR_KEYS.has(key) && rest.trim()) {
+      result[key] = parseScalar(rest);
+    } else {
+      throw new Error(`Unsupported or empty frontmatter field: ${key}`);
+    }
+  }
+  return result;
+}
+
+function parseArrayValue(
+  lines: string[],
+  keyIndex: number,
+  inline: string
+): { value: string[]; lastIndex: number } {
+  if (inline.trim()) {
+    const value = inline.trim();
+    if (!value.startsWith('[') || !value.endsWith(']')) throw new Error('Expected an array');
+    const inner = value.slice(1, -1).trim();
+    return {
+      value: inner ? inner.split(',').map(parseScalar) : [],
+      lastIndex: keyIndex,
+    };
+  }
+  const value: string[] = [];
+  let lastIndex = keyIndex;
+  for (let index = keyIndex + 1; index < lines.length; index += 1) {
+    const item = lines[index].match(/^\s+-\s+(.+)$/);
+    if (!item) break;
+    value.push(parseScalar(item[1]));
+    lastIndex = index;
+  }
+  return { value, lastIndex };
+}
+
+function parseScalar(raw: string): string {
+  const value = raw.trim();
+  if (!value) throw new Error('Empty frontmatter value');
+  const quote = value[0];
+  if ((quote === '"' || quote === "'") && value.at(-1) === quote) return value.slice(1, -1);
+  if (quote === '"' || quote === "'") throw new Error('Unclosed quoted value');
+  return value;
+}
+
+function readArray(
+  values: Record<string, FrontmatterValue>,
+  key: string,
+  fallback: string[]
+): string[] {
+  const value = values[key];
+  if (value === undefined) return [...fallback];
+  if (!Array.isArray(value) || value.some((item) => !item)) throw new Error(`${key} is invalid`);
+  return [...value];
+}
+
+function readOptionalString(value: FrontmatterValue | undefined, key: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !value) throw new Error(`${key} is invalid`);
+  return value;
+}
+
+function readTimeout(value: FrontmatterValue | undefined): number {
+  if (value === undefined) return DEFAULT_MEMORY_TIMEOUT_SECONDS;
+  if (typeof value !== 'string') throw new Error('timeoutSeconds is invalid');
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) throw new Error('timeoutSeconds must be positive');
+  return Math.min(parsed, MAX_MEMORY_TIMEOUT_SECONDS);
+}
+
+function validatePaths(paths: string[], key: string): void {
+  if (paths.some((path) => !path.startsWith('/') || path.includes('\0'))) {
+    throw new Error(`${key} must contain absolute VFS paths`);
+  }
+}
+
+function buildSpawnOptions(config: MemoryConfig, prompt: string): AgentSpawnOptions {
+  const inheritedModel = config.model === 'parent' || config.model === 'cone';
+  return {
+    cwd: config.writablePaths[0].replace(/\/+$/, '') || '/',
+    writablePaths: config.writablePaths,
+    visiblePaths: config.visiblePaths,
+    allowedCommands: config.allowedCommands,
+    prompt,
+    ...(!inheritedModel && config.model ? { modelId: config.model } : {}),
+  };
+}
+
+function substitutePlaceholders(template: string, values: Record<string, string>): string {
+  let prompt = template;
+  for (const [name, value] of Object.entries(values)) {
+    prompt = prompt.replaceAll(`{{${name}}}`, value);
+  }
+  return prompt;
+}
+
+function waitForSpawn(
+  spawnPromise: Promise<AgentSpawnResult>,
+  timeoutMs: number,
+  signal?: AbortSignal
+): Promise<WaitOutcome> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (outcome: WaitOutcome): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      resolve(outcome);
+    };
+    const onAbort = (): void => finish({ type: 'aborted' });
+    const timer = setTimeout(() => finish({ type: 'timeout' }), timeoutMs);
+    signal?.addEventListener('abort', onAbort, { once: true });
+    spawnPromise.then(
+      (result) => finish({ type: 'result', result }),
+      (error: unknown) => finish({ type: 'error', error })
+    );
+  });
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -1,55 +1,16 @@
+import DEFAULT_MEMORY_MD from '../../../vfs-root/shared/MEMORY.md?raw';
 import { createLogger } from '../core/logger.js';
 import type { LocalVfsClient } from '../kernel/local-vfs-client.js';
 import type { AgentBridge, AgentSpawnOptions, AgentSpawnResult } from './agent-bridge.js';
 import { CONE_MEMORY_PATH, computeBudget } from './cone-memory-budget.js';
+
+export { DEFAULT_MEMORY_MD };
 
 const log = createLogger('agentic-memory');
 
 export const MEMORY_INSTRUCTIONS_PATH = '/shared/MEMORY.md';
 export const DEFAULT_MEMORY_TIMEOUT_SECONDS = 120;
 export const MAX_MEMORY_TIMEOUT_SECONDS = 600;
-
-export const DEFAULT_MEMORY_MD = `---
-writablePaths:
-  - /workspace/
-visiblePaths:
-  - /sessions/
-  - /shared/
-allowedCommands:
-  - cat
-  - find
-  - grep
-  - head
-  - ls
-  - mkdir
-  - mv
-  - sed
-  - tail
-  - touch
-  - wc
-timeoutSeconds: 120
----
-
-# Memory curator
-
-Curate the durable memory for session {{SESSION_COUNT}}.
-
-Read the current memory at {{MEMORY_PATH}} if it exists, then read the archived session at {{SESSION_ARCHIVE_PATH}}. Rewrite {{MEMORY_PATH}} with the durable information worth carrying into future sessions.
-
-Rules:
-
-- Preserve the user-authored header before the first \`## Auto-extracted\` heading verbatim.
-- Keep durable preferences, stable project facts, validated approaches, and named resources.
-- Organize retained information into concise per-topic sections such as \`## Preferences\`, \`## Context\`, and per-project \`##\` sections rather than one flat list.
-- Drop ephemera, duplicates, and superseded facts.
-- Preserve concrete identifiers such as file paths, URLs, IDs, and names verbatim.
-- Keep the complete file at or below {{BUDGET_CHARS}} characters.
-- Write the result to {{MEMORY_PATH}}; do not merely return it in your response.
-
-<!-- How to customize
-Add curator instructions here, for example: also update the knowledge base at /path following its WIKI.md. Extend visiblePaths or writablePaths above to grant access to extra stores, and adjust timeoutSeconds when needed.
--->
-`;
 
 const DEFAULT_WRITABLE_PATHS = ['/workspace/'];
 const DEFAULT_VISIBLE_PATHS = ['/sessions/', '/shared/'];

--- a/packages/webapp/src/ui/new-session.ts
+++ b/packages/webapp/src/ui/new-session.ts
@@ -8,9 +8,11 @@
  */
 
 import type { Api, Model } from '@earendil-works/pi-ai';
+import { isFeatureEnabled } from '../core/feature-flags.js';
 import { createLogger } from '../core/logger.js';
 import type { DirEntry } from '../fs/types.js';
 import type { WritableVfsClient } from '../kernel/writable-vfs-client.js';
+import type { AgentBridge } from '../scoops/agent-bridge.js';
 import { SessionStore } from '../scoops/chat-session-store.js';
 import { getDailyAdobeUuid } from '../scoops/llm-session-id.js';
 import { getApiKey, resolveCurrentModel } from './provider-settings.js';
@@ -43,6 +45,54 @@ const DEFAULT_ENRICHMENT_RACE_MS = 20_000;
 /** How often the race timer reports progress (ms) to drive the spinner ring. */
 const ENRICHMENT_PROGRESS_TICK_MS = 250;
 
+function resolveAgenticMemorySpawn(
+  opts: RunNewSessionFreezeOptions
+): AgentBridge['spawn'] | undefined {
+  if (!isFeatureEnabled('agentic-memory')) return undefined;
+  if (!opts.agenticMemorySpawn) {
+    log.info('Agentic memory enabled but agent bridge unavailable — using legacy enrichment');
+    return undefined;
+  }
+  return opts.agenticMemorySpawn;
+}
+
+async function runAgenticMemoryFreeze(
+  opts: RunNewSessionFreezeOptions,
+  sessionStore: SessionStore,
+  model: Model<Api>,
+  apiKey: string,
+  headers: Record<string, string> | undefined,
+  spawn: AgentBridge['spawn']
+): Promise<FrozenSession | null> {
+  const frozen = await freezeConeSession({
+    sessionStore,
+    vfs: opts.vfs,
+    mode: 'full',
+    model,
+    apiKey,
+    headers,
+    agenticMemorySpawn: spawn,
+    pickIcon: (iconOpts) =>
+      import('../providers/quick-llm.js').then(({ pickLucideIcon }) => pickLucideIcon(iconOpts)),
+  });
+  if (!frozen) return null;
+  if (opts.captureCompleteSnapshot) {
+    try {
+      await opts.captureCompleteSnapshot(frozen);
+    } catch (err) {
+      const code = (err as { code?: string } | null)?.code ?? 'unknown';
+      log.warn('captureCompleteSnapshot failed', { code });
+      frozen.completeSnapshotUnavailable = true;
+      try {
+        await markSnapshotUnavailable(opts.vfs, frozen.filename);
+      } catch {
+        // Best-effort — the Markdown archive is still present.
+      }
+    }
+  }
+  return frozen;
+}
+
 export interface RunNewSessionFreezeOptions {
   /**
    * Writable VFS handle. Under `slicc_opfs_vfs === 'opfs'` AND on the
@@ -52,6 +102,8 @@ export interface RunNewSessionFreezeOptions {
    * the same shape structurally.
    */
   vfs: WritableVfsClient;
+  /** Page→kernel spawn seam. Omit it to preserve the legacy enrichment path. */
+  agenticMemorySpawn?: AgentBridge['spawn'];
   /**
    * Race window in ms: how long to wait for LLM enrichment before resolving
    * (so the caller can clear the chat) and continuing enrichment in the
@@ -174,6 +226,18 @@ export async function runNewSessionFreeze(
       error: err instanceof Error ? err.message : String(err),
     });
     return null;
+  }
+
+  const agenticMemorySpawn = apiKey && model ? resolveAgenticMemorySpawn(opts) : undefined;
+  if (agenticMemorySpawn) {
+    return await runAgenticMemoryFreeze(
+      opts,
+      sessionStore,
+      model!,
+      apiKey!,
+      headers,
+      agenticMemorySpawn
+    );
   }
 
   // 1. WRITE FIRST — durable archive on disk before any LLM call.

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -13,6 +13,7 @@ import { createLogger } from '../core/logger.js';
 import type { LocalVfsClient } from '../kernel/local-vfs-client.js';
 import type {
   AgentEventMsg,
+  AgentSpawnResultMsg,
   ErrorMsg,
   ExtensionMessage,
   ForwardedLickEvent,
@@ -36,6 +37,7 @@ import type {
 } from '../kernel/messages.js';
 import { createPanelChromeRuntimeTransport } from '../kernel/transport-chrome-runtime.js';
 import type { KernelClientFacade, KernelTransport } from '../kernel/types.js';
+import type { AgentSpawnOptions, AgentSpawnResult } from '../scoops/agent-bridge.js';
 import type { LickEvent } from '../scoops/lick-manager.js';
 import { setFollowerTrayRuntimeStatus } from '../scoops/tray-follower-status.js';
 import { setLeaderTrayRuntimeStatus } from '../scoops/tray-leader.js';
@@ -144,6 +146,10 @@ export class OffscreenClient implements KernelClientFacade {
    * `requestId`; resolved when a `clear-chat-ack` envelope arrives.
    */
   private pendingClearAcks = new Map<string, () => void>();
+  private pendingAgentSpawnRequests = new Map<
+    string,
+    { resolve: (result: AgentSpawnResult) => void; reject: (error: Error) => void }
+  >();
   /** Pending thinking updates, resolved only after the worker has applied and persisted them. */
   private pendingThinkingAcks = new Map<string, (applied: boolean) => void>();
   /**
@@ -438,6 +444,16 @@ export class OffscreenClient implements KernelClientFacade {
     this.pendingClearAcks.delete(requestId);
   }
 
+  /** Spawn an isolated agent in the kernel realm through the typed transport. */
+  spawnAgent(options: AgentSpawnOptions): Promise<AgentSpawnResult> {
+    const requestId = `agent-${uid()}`;
+    const result = new Promise<AgentSpawnResult>((resolve, reject) => {
+      this.pendingAgentSpawnRequests.set(requestId, { resolve, reject });
+    });
+    this.send({ type: 'agent-spawn-request', requestId, options });
+    return result;
+  }
+
   clearFilesystem(): void {
     this.send({ type: 'clear-filesystem' });
   }
@@ -717,6 +733,11 @@ export class OffscreenClient implements KernelClientFacade {
         break;
       }
 
+      case 'agent-spawn-result': {
+        this.handleAgentSpawnResult(msg);
+        break;
+      }
+
       case 'set-thinking-level-ack':
         this.handleThinkingLevelAck(msg);
         break;
@@ -825,6 +846,14 @@ export class OffscreenClient implements KernelClientFacade {
         break;
       }
     }
+  }
+
+  private handleAgentSpawnResult(msg: AgentSpawnResultMsg): void {
+    const pending = this.pendingAgentSpawnRequests.get(msg.requestId);
+    if (!pending) return;
+    this.pendingAgentSpawnRequests.delete(msg.requestId);
+    if (msg.ok) pending.resolve(msg.result);
+    else pending.reject(new Error(msg.error));
   }
 
   // -------------------------------------------------------------------------

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -6,14 +6,10 @@
  *   1. Load `session-cone` from the UI SessionStore.
  *   2. If the session is short (< MIN_MESSAGES_TO_FREEZE), skip everything
  *      and return null — nothing meaningful to extract or archive.
- *   3. Run two LLM calls over the message list with a shared system prompt
- *      (Anthropic prompt cache hits on the prefix for the second call):
- *        - Memory extraction → append bullets to /workspace/CLAUDE.md.
- *        - Title generation → 3-6 word label used to name the archive.
- *      Either call may fail independently; failures fall through to safe
- *      defaults (no memory append, heuristic title).
- *   4. Write the session JSON to `/sessions/<timestamp>-<slug>.json` and
- *      prepend the entry to `/sessions/index.json`.
+ *   3. Generate a title and icon, falling back to a heuristic title.
+ *   4. Legacy mode extracts memory before writing the archive. Agentic mode
+ *      writes the archive first, then lets a curator scoop rewrite memory;
+ *      curator failure falls back to legacy extraction.
  *
  * Scoops are intentionally untouched — they survive a "New session" reset
  * so the fresh cone inherits the existing scoop roster and decides what
@@ -32,8 +28,10 @@ import { createLogger } from '../core/logger.js';
 import { FsError } from '../fs/types.js';
 import type { LocalVfsClient } from '../kernel/local-vfs-client.js';
 import type { WritableVfsClient } from '../kernel/writable-vfs-client.js';
+import type { AgentBridge } from '../scoops/agent-bridge.js';
+import { runAgenticMemoryPass } from '../scoops/agentic-memory.js';
 import type { SessionStore } from '../scoops/chat-session-store.js';
-import { applyConeMemoryBudget } from '../scoops/cone-memory-budget.js';
+import { applyConeMemoryBudget, readSessionCount } from '../scoops/cone-memory-budget.js';
 import type {
   FrozenSessionArchive,
   FrozenSessionCost,
@@ -127,6 +125,12 @@ export interface FreezeConeSessionOptions {
    * calls are enabled (`mode: 'full'` with model + apiKey).
    */
   pickIcon?: (opts: { subject: string }) => Promise<string | null>;
+  /**
+   * Agent spawn seam supplied only when agentic memory is enabled. Its
+   * presence selects the write-first curator path for an LLM-enabled full
+   * freeze; quick mode and credential-less freezes remain legacy.
+   */
+  agenticMemorySpawn?: AgentBridge['spawn'];
 }
 
 /**
@@ -152,12 +156,46 @@ export async function freezeConeSession(
   // but additionally marks the index entry as needing later enrichment.
   const llmEnabled = mode === 'full' && Boolean(opts.apiKey && opts.model);
 
-  await extractMemoriesBestEffort(opts, agentMessages, llmEnabled);
+  if (!llmEnabled || !opts.agenticMemorySpawn) {
+    await extractMemoriesBestEffort(opts, agentMessages, llmEnabled);
+  }
   const title =
     (await generateTitleBestEffort(opts, agentMessages, llmEnabled)) ||
     heuristicTitle(session.messages);
   const icon = llmEnabled ? await pickIconBestEffort(opts, title) : undefined;
-  return await writeFrozenArchive(opts, session, title, mode, icon);
+  const frozen = await writeFrozenArchive(opts, session, title, mode, icon);
+  if (frozen && llmEnabled && opts.agenticMemorySpawn) {
+    await curateMemoriesBestEffort(opts, frozen, agentMessages);
+  }
+  return frozen;
+}
+
+/** Run the write-first curator, falling back to legacy extraction on failure. */
+async function curateMemoriesBestEffort(
+  opts: FreezeConeSessionOptions,
+  frozen: FrozenSession,
+  agentMessages: AgentMessage[]
+): Promise<void> {
+  let result: Awaited<ReturnType<typeof runAgenticMemoryPass>>;
+  try {
+    result = await runAgenticMemoryPass({
+      spawn: opts.agenticMemorySpawn!,
+      vfs: opts.vfs,
+      sessionArchivePath: frozenSessionPath(frozen),
+      sessionCount: await readSessionCount(opts.vfs),
+    });
+  } catch (err) {
+    result = { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+  if (result.ok) {
+    log.info('Agentic memory pass completed', { filename: frozen.filename });
+    return;
+  }
+  log.warn('Agentic memory pass failed — falling back to legacy extraction', {
+    filename: frozen.filename,
+    reason: result.reason ?? 'unknown',
+  });
+  await extractMemoriesBestEffort(opts, agentMessages, true);
 }
 
 /**

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -185,15 +185,26 @@ async function curateMemoriesBestEffort(
       sessionCount: await readSessionCount(opts.vfs),
     });
   } catch (err) {
-    result = { ok: false, reason: err instanceof Error ? err.message : String(err) };
+    result = {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+      legacyFallbackSafe: false,
+    };
   }
   if (result.ok) {
     log.info('Agentic memory pass completed', { filename: frozen.filename });
     return;
   }
-  log.warn('Agentic memory pass failed — falling back to legacy extraction', {
+  if (!result.legacyFallbackSafe) {
+    log.warn('Agentic memory pass unfinished — archive retained; skipping legacy extraction', {
+      filename: frozen.filename,
+      reason: result.reason,
+    });
+    return;
+  }
+  log.warn('Agentic memory pass failed after finishing — falling back to legacy extraction', {
     filename: frozen.filename,
-    reason: result.reason ?? 'unknown',
+    reason: result.reason,
   });
   await extractMemoriesBestEffort(opts, agentMessages, true);
 }

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -589,6 +589,7 @@ function wireFreezerRail(deps: FreezerRailDeps): FreezerRailHandles {
             // refreshes the rail when the late rename/icon land.
             await runNewSessionFreeze({
               vfs: writer,
+              agenticMemorySpawn: (options) => client.spawnAgent(options),
               captureCompleteSnapshot,
               onProgress: (fraction) => {
                 const el = freezerNew();

--- a/packages/webapp/tests/core/feature-flags.test.ts
+++ b/packages/webapp/tests/core/feature-flags.test.ts
@@ -52,8 +52,17 @@ describe('feature flag registry', () => {
         defaultValue: 'off',
         userToggleable: true,
       }),
+      expect.objectContaining({
+        id: 'agentic-memory',
+        label: 'Agentic memory',
+        description:
+          'Curate session memory with a background agent instead of a one-shot extraction call.',
+        defaultValue: 'off',
+        userToggleable: true,
+      }),
     ]);
     expect(listFlags()[0]).not.toHaveProperty('overridableFloats');
+    expect(listFlags()[2]).not.toHaveProperty('floatDefaults');
   });
 
   it('gates panel layouts OFF by default on every float', () => {
@@ -72,6 +81,26 @@ describe('feature flag registry', () => {
 
   it('lets the USER turn panel layouts on — it is toggleable, unlike the settings gate', () => {
     expect(resolveFlagValue('panel-layouts', 'standalone', { 'panel-layouts': 'on' })).toBe('on');
+  });
+
+  it('gates agentic memory off on every float and accepts a local override', () => {
+    for (const float of [
+      'standalone',
+      'extension',
+      'electron-overlay',
+      'extension-detached',
+      'hosted-leader',
+      'connect',
+      'cherry',
+      'follower',
+    ] as const) {
+      initFeatureFlags(float);
+      expect(isFeatureEnabled('agentic-memory')).toBe(false);
+    }
+
+    initFeatureFlags('standalone');
+    setFeatureFlagOverride('agentic-memory', 'on');
+    expect(isFeatureEnabled('agentic-memory')).toBe(true);
   });
 
   it('uses float-aware bundled defaults', () => {
@@ -111,6 +140,7 @@ describe('feature flag registry', () => {
     expect(resolveFlags('standalone', { 'experimental-settings': 'off' })).toEqual({
       'experimental-settings': 'off',
       'panel-layouts': 'off',
+      'agentic-memory': 'off',
     });
     expect(
       resolveFlags(
@@ -118,7 +148,11 @@ describe('feature flag registry', () => {
         { 'experimental-settings': 'off' },
         { 'experimental-settings': 'on' }
       )
-    ).toEqual({ 'experimental-settings': 'off', 'panel-layouts': 'off' });
+    ).toEqual({
+      'experimental-settings': 'off',
+      'panel-layouts': 'off',
+      'agentic-memory': 'off',
+    });
   });
 
   it('round-trips string overrides through one localStorage key', () => {

--- a/packages/webapp/tests/kernel/kernel-agent-bridge-topology.test.ts
+++ b/packages/webapp/tests/kernel/kernel-agent-bridge-topology.test.ts
@@ -1,0 +1,43 @@
+/** Regression guards for agent-spawn availability in every leader float. */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = (path: string): string =>
+  readFileSync(join(here, '..', '..', 'src', ...path.split('/')), 'utf8');
+
+const liveSource = source('ui/wc/wc-live.ts');
+const preludeSource = source('ui/boot/setup-standalone-prelude.ts');
+const workerSource = source('kernel/kernel-worker.ts');
+const hostSource = source('kernel/host.ts');
+
+describe('kernel AgentBridge topology', () => {
+  it('routes the extension leader through the shared kernel-worker boot', () => {
+    expect(preludeSource).toContain('extLeader && hasChromeRuntimeConnect()');
+    expect(preludeSource).toContain('extensionDelegateId = extLeader.extensionId');
+    const prelude = liveSource.indexOf('await setupStandalonePrelude(');
+    const spawn = liveSource.indexOf('spawnKernelWorker({');
+    expect(prelude).toBeGreaterThan(-1);
+    expect(spawn).toBeGreaterThan(prelude);
+  });
+
+  it('constructs Bridge and passes it to the shared kernel host', () => {
+    const bridge = workerSource.indexOf('const bridge = new Bridge(bridgeTransport)');
+    const host = workerSource.indexOf('await createKernelHost({');
+    expect(bridge).toBeGreaterThan(-1);
+    expect(host).toBeGreaterThan(bridge);
+    expect(workerSource.slice(host, host + 500)).toContain('bridge,');
+  });
+
+  it('publishes AgentBridge during host boot before returning the host', () => {
+    const boot = hostSource.indexOf('await bootOrchestrator(');
+    const publish = hostSource.indexOf('publishAgentBridge(orchestrator, sharedFs');
+    const ready = hostSource.indexOf('return {', publish);
+    expect(boot).toBeGreaterThan(-1);
+    expect(publish).toBeGreaterThan(boot);
+    expect(ready).toBeGreaterThan(publish);
+  });
+});

--- a/packages/webapp/tests/kernel/transport-message-channel.test.ts
+++ b/packages/webapp/tests/kernel/transport-message-channel.test.ts
@@ -10,7 +10,9 @@
  *  - multiple subscribers each get every message
  */
 
-import { describe, expect, it } from 'vitest';
+import 'fake-indexeddb/auto';
+import { describe, expect, it, vi } from 'vitest';
+import { Bridge } from '../../src/kernel/facade.js';
 import type {
   ExtensionMessage,
   OffscreenToPanelMessage,
@@ -21,6 +23,8 @@ import {
   createMessageChannelTransport,
   createPanelMessageChannelTransport,
 } from '../../src/kernel/transport-message-channel.js';
+import { runAgenticMemoryPass } from '../../src/scoops/agentic-memory.js';
+import { OffscreenClient } from '../../src/ui/offscreen-client.js';
 
 interface UpMsg {
   type: 'up';
@@ -163,6 +167,46 @@ describe('createBridgeMessageChannelTransport / createPanelMessageChannelTranspo
 
     channel.port1.close();
     channel.port2.close();
+  });
+
+  it('round-trips an agent spawn through the real OffscreenClient and Bridge seam', async () => {
+    const channel = new MessageChannel();
+    const panelTransport = createPanelMessageChannelTransport(channel.port1);
+    const bridgeTransport = createBridgeMessageChannelTransport(channel.port2);
+    const bridge = new Bridge(bridgeTransport);
+    await bridge.bind({} as never);
+
+    const spawn = vi.fn(async () => ({ finalText: 'curated', exitCode: 0 }));
+    (globalThis as Record<string, unknown>).__slicc_agent = { spawn };
+    const client = new OffscreenClient(
+      {
+        onStatusChange: vi.fn(),
+        onScoopCreated: vi.fn(),
+        onScoopListUpdate: vi.fn(),
+        onIncomingMessage: vi.fn(),
+      },
+      panelTransport
+    );
+    const result = await runAgenticMemoryPass({
+      spawn: (options) => client.spawnAgent(options),
+      vfs: { readFile: async () => Promise.reject(new Error('MEMORY.md absent')) },
+      sessionArchivePath: '/sessions/frozen.md',
+      sessionCount: 1,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(spawn).toHaveBeenCalledOnce();
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: '/workspace',
+        writablePaths: ['/workspace/'],
+        visiblePaths: ['/sessions/', '/shared/'],
+      })
+    );
+
+    channel.port1.close();
+    channel.port2.close();
+    delete (globalThis as Record<string, unknown>).__slicc_agent;
   });
 
   it('bridge→panel: bridge-side send wraps payload with source: offscreen', async () => {

--- a/packages/webapp/tests/scoops/agent-bridge.test.ts
+++ b/packages/webapp/tests/scoops/agent-bridge.test.ts
@@ -204,6 +204,63 @@ describe('createAgentBridge — config construction', () => {
     expect(registerCalls[0].config?.writablePaths?.[0]).toBe('/scoops/some-scoop/');
   });
 
+  it('uses explicit writablePaths with pure-replace semantics', async () => {
+    const { orchestrator, registerCalls, scripts } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'jolly-mint',
+    });
+    scripts.set('agent_jolly_mint', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn({
+      ...BASE_OPTS,
+      writablePaths: ['/workspace', '/knowledge/'],
+    });
+
+    expect(registerCalls[0].config?.writablePaths).toEqual([
+      '/workspace/',
+      '/knowledge/',
+      '/scoops/agent-jolly-mint/',
+      '/tmp/',
+    ]);
+  });
+
+  it('keeps historical cwd and /shared roots when writablePaths is omitted', async () => {
+    const { orchestrator, registerCalls, scripts } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'jolly-mint',
+    });
+    scripts.set('agent_jolly_mint', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn({ ...BASE_OPTS, cwd: '/scoops/caller' });
+
+    expect(registerCalls[0].config?.writablePaths).toEqual([
+      '/scoops/caller/',
+      '/shared/',
+      '/scoops/agent-jolly-mint/',
+      '/tmp/',
+    ]);
+  });
+
+  it('falls back to historical writable roots for a non-absolute override', async () => {
+    const { orchestrator, registerCalls, scripts } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'jolly-mint',
+    });
+    scripts.set('agent_jolly_mint', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn({ ...BASE_OPTS, writablePaths: ['/knowledge/', 'relative'] });
+
+    expect(registerCalls[0].config?.writablePaths).toEqual([
+      '/workspace/',
+      '/shared/',
+      '/scoops/agent-jolly-mint/',
+      '/tmp/',
+    ]);
+  });
+
   it('forwards allowedCommands verbatim', async () => {
     const { orchestrator, registerCalls, scripts } = makeMockOrchestrator();
     const { fs } = makeMockSharedFs();

--- a/packages/webapp/tests/scoops/agentic-memory-default.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory-default.test.ts
@@ -1,14 +1,7 @@
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { VirtualFS } from '../../src/fs/virtual-fs.js';
-import { DEFAULT_MEMORY_MD } from '../../src/scoops/agentic-memory.js';
+import { DEFAULT_MEMORY_MD, runAgenticMemoryPass } from '../../src/scoops/agentic-memory.js';
 import { createDefaultSharedFiles } from '../../src/scoops/skills.js';
-
-const here = dirname(fileURLToPath(import.meta.url));
-const repoRoot = resolve(here, '..', '..', '..', '..');
-const bundledMemory = readFileSync(resolve(repoRoot, 'packages/vfs-root/shared/MEMORY.md'), 'utf8');
 
 let dbCounter = 0;
 let vfs: VirtualFS | undefined;
@@ -19,8 +12,18 @@ afterEach(async () => {
 });
 
 describe('bundled MEMORY.md', () => {
-  it('matches the runner fallback exactly', () => {
-    expect(bundledMemory).toBe(DEFAULT_MEMORY_MD);
+  it('parses as the runner fallback', async () => {
+    const spawn = vi.fn(async () => ({ finalText: 'done', exitCode: 0 }));
+
+    await expect(
+      runAgenticMemoryPass({
+        spawn,
+        vfs: { readFile: async () => DEFAULT_MEMORY_MD },
+        sessionArchivePath: '/sessions/frozen.md',
+        sessionCount: 1,
+      })
+    ).resolves.toEqual({ ok: true });
+    expect(spawn).toHaveBeenCalledOnce();
   });
 
   it('is seeded on a fresh VFS without overwriting user edits', async () => {

--- a/packages/webapp/tests/scoops/agentic-memory-default.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory-default.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { DEFAULT_MEMORY_MD } from '../../src/scoops/agentic-memory.js';
+import { createDefaultSharedFiles } from '../../src/scoops/skills.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..', '..', '..');
+const bundledMemory = readFileSync(resolve(repoRoot, 'packages/vfs-root/shared/MEMORY.md'), 'utf8');
+
+let dbCounter = 0;
+let vfs: VirtualFS | undefined;
+
+afterEach(async () => {
+  await vfs?.dispose();
+  vfs = undefined;
+});
+
+describe('bundled MEMORY.md', () => {
+  it('matches the runner fallback exactly', () => {
+    expect(bundledMemory).toBe(DEFAULT_MEMORY_MD);
+  });
+
+  it('is seeded on a fresh VFS without overwriting user edits', async () => {
+    vfs = await VirtualFS.create({ dbName: `memory-default-${dbCounter++}`, wipe: true });
+
+    await createDefaultSharedFiles(vfs);
+    expect(await vfs.readFile('/shared/MEMORY.md', { encoding: 'utf-8' })).toBe(DEFAULT_MEMORY_MD);
+
+    await vfs.writeFile('/shared/MEMORY.md', 'custom memory curator');
+    await createDefaultSharedFiles(vfs);
+    expect(await vfs.readFile('/shared/MEMORY.md', { encoding: 'utf-8' })).toBe(
+      'custom memory curator'
+    );
+  });
+});

--- a/packages/webapp/tests/scoops/agentic-memory.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetLoggerDedupForTests } from '../../src/core/logger.js';
+import type { LocalVfsClient } from '../../src/kernel/local-vfs-client.js';
+import type { AgentSpawnOptions, AgentSpawnResult } from '../../src/scoops/agent-bridge.js';
+import { DEFAULT_MEMORY_MD, runAgenticMemoryPass } from '../../src/scoops/agentic-memory.js';
+import { CONE_MEMORY_PATH, computeBudget } from '../../src/scoops/cone-memory-budget.js';
+
+const ARCHIVE_PATH = '/sessions/2026-08-05-memory.md';
+
+function fakeVfs(content: string | Error): Pick<LocalVfsClient, 'readFile'> {
+  return {
+    readFile: vi.fn(async () => {
+      if (content instanceof Error) throw content;
+      return content;
+    }),
+  };
+}
+
+function successSpawn() {
+  return vi.fn(async (_options: AgentSpawnOptions): Promise<AgentSpawnResult> => {
+    return { finalText: 'done', exitCode: 0 };
+  });
+}
+
+describe('runAgenticMemoryPass', () => {
+  beforeEach(() => resetLoggerDedupForTests());
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('loads custom MEMORY.md parameters and substitutes known placeholders', async () => {
+    const memoryMd = `---
+writablePaths: [/workspace/, /knowledge/]
+visiblePaths:
+  - /sessions/
+  - /shared/
+  - /knowledge/
+allowedCommands: [cat, grep, wc]
+model: claude-sonnet-4-6
+timeoutSeconds: 45
+---
+Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} budget={{BUDGET_CHARS}} unknown={{KEEP_ME}}`;
+    const spawn = successSpawn();
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(memoryMd),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 30,
+    });
+
+    expect(result).toEqual({ ok: true });
+    const options = spawn.mock.calls[0][0];
+    expect(options).toMatchObject({
+      cwd: '/workspace',
+      writablePaths: ['/workspace/', '/knowledge/'],
+      visiblePaths: ['/sessions/', '/shared/', '/knowledge/'],
+      allowedCommands: ['cat', 'grep', 'wc'],
+      modelId: 'claude-sonnet-4-6',
+    });
+    expect(options.prompt).toBe(
+      `Memory=${CONE_MEMORY_PATH} archive=${ARCHIVE_PATH} count=30 budget=${computeBudget(30)} unknown={{KEEP_ME}}`
+    );
+  });
+
+  it('uses the built-in default and warns when MEMORY.md is missing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const spawn = successSpawn();
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(new Error('ENOENT')),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 2,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(warn).toHaveBeenCalled();
+    expect(spawn.mock.calls[0][0]).toMatchObject({
+      cwd: '/workspace',
+      writablePaths: ['/workspace/'],
+      visiblePaths: ['/sessions/', '/shared/'],
+    });
+    expect(spawn.mock.calls[0][0].prompt).toContain(
+      'Organize retained information into concise per-topic'
+    );
+  });
+
+  it.each([
+    ['malformed frontmatter', '---\nwritablePaths: [relative]\n---\nbroken'],
+    ['empty template', '---\ntimeoutSeconds: 5\n---\n'],
+  ])('falls back for %s', async (_name, content) => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const spawn = successSpawn();
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(content),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(warn).toHaveBeenCalled();
+    expect(spawn.mock.calls[0][0].prompt).toContain(CONE_MEMORY_PATH);
+  });
+
+  it('returns ok:false when spawn throws', async () => {
+    const spawn = vi.fn(async (_options: AgentSpawnOptions): Promise<AgentSpawnResult> => {
+      throw new Error('bridge unavailable');
+    });
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(DEFAULT_MEMORY_MD),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'bridge unavailable' });
+  });
+
+  it('returns ok:false for a non-zero agent exit', async () => {
+    const spawn = vi.fn(async (_options: AgentSpawnOptions): Promise<AgentSpawnResult> => {
+      return { finalText: 'curation failed', exitCode: 1 };
+    });
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(DEFAULT_MEMORY_MD),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'curation failed' });
+  });
+
+  it('returns ok:false when the configured timeout elapses', async () => {
+    vi.useFakeTimers();
+    const memoryMd = `---\ntimeoutSeconds: 1\n---\nCurate {{MEMORY_PATH}}.`;
+    const spawn = vi.fn(
+      (_options: AgentSpawnOptions) => new Promise<AgentSpawnResult>(() => undefined)
+    );
+
+    const pass = runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(memoryMd),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await expect(pass).resolves.toEqual({ ok: false, reason: 'timeout' });
+  });
+
+  it('clamps timeoutSeconds to the 600-second maximum', async () => {
+    vi.useFakeTimers();
+    const memoryMd = `---\ntimeoutSeconds: 9999\n---\nCurate {{MEMORY_PATH}}.`;
+    const spawn = vi.fn(
+      (_options: AgentSpawnOptions) => new Promise<AgentSpawnResult>(() => undefined)
+    );
+
+    const pass = runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(memoryMd),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+    await vi.advanceTimersByTimeAsync(599_999);
+    let settled = false;
+    void pass.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(pass).resolves.toEqual({ ok: false, reason: 'timeout' });
+  });
+});

--- a/packages/webapp/tests/scoops/agentic-memory.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory.test.ts
@@ -65,6 +65,52 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
     );
   });
 
+  it('strips block-array comments and preserves quoted inline commas', async () => {
+    const memoryMd = `---
+writablePaths: [/workspace/, "/knowledge/lars,rebecca/"]
+visiblePaths:
+  - /sessions/ # durable archives
+  - "/shared/#reference"
+allowedCommands:
+  - cat # read files
+---
+Curate {{MEMORY_PATH}}.`;
+    const spawn = successSpawn();
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(memoryMd),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(spawn.mock.calls[0][0]).toMatchObject({
+      writablePaths: ['/workspace/', '/knowledge/lars,rebecca/'],
+      visiblePaths: ['/sessions/', '/shared/#reference'],
+      allowedCommands: ['cat'],
+    });
+  });
+
+  it.each([
+    ['an unquoted comma in an inline path', 'writablePaths: [/workspace/, /home/lars,rebecca/]'],
+    ['a bare root writable path', 'writablePaths: [/]'],
+  ])('falls back safely for %s', async (_name, frontmatter) => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const spawn = successSpawn();
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(`---\n${frontmatter}\n---\nCurate {{MEMORY_PATH}}.`),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(warn).toHaveBeenCalled();
+    expect(spawn.mock.calls[0][0].writablePaths).toEqual(['/workspace/']);
+  });
+
   it('uses the built-in default and warns when MEMORY.md is missing', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const spawn = successSpawn();

--- a/packages/webapp/tests/scoops/agentic-memory.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory.test.ts
@@ -119,7 +119,11 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
       sessionCount: 1,
     });
 
-    expect(result).toEqual({ ok: false, reason: 'bridge unavailable' });
+    expect(result).toEqual({
+      ok: false,
+      reason: 'bridge unavailable',
+      legacyFallbackSafe: true,
+    });
   });
 
   it('returns ok:false for a non-zero agent exit', async () => {
@@ -134,7 +138,7 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
       sessionCount: 1,
     });
 
-    expect(result).toEqual({ ok: false, reason: 'curation failed' });
+    expect(result).toEqual({ ok: false, reason: 'curation failed', legacyFallbackSafe: true });
   });
 
   it('returns ok:false when the configured timeout elapses', async () => {
@@ -152,7 +156,11 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
     });
     await vi.advanceTimersByTimeAsync(1000);
 
-    await expect(pass).resolves.toEqual({ ok: false, reason: 'timeout' });
+    await expect(pass).resolves.toEqual({
+      ok: false,
+      reason: 'timeout',
+      legacyFallbackSafe: false,
+    });
   });
 
   it('clamps timeoutSeconds to the 600-second maximum', async () => {
@@ -177,6 +185,10 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
     expect(settled).toBe(false);
     await vi.advanceTimersByTimeAsync(1);
 
-    await expect(pass).resolves.toEqual({ ok: false, reason: 'timeout' });
+    await expect(pass).resolves.toEqual({
+      ok: false,
+      reason: 'timeout',
+      legacyFallbackSafe: false,
+    });
   });
 });

--- a/packages/webapp/tests/ui/new-session.test.ts
+++ b/packages/webapp/tests/ui/new-session.test.ts
@@ -14,6 +14,11 @@ vi.mock('../../src/ui/provider-settings.js', () => ({
   resolveCurrentModel: () => mockResolveCurrentModel(),
 }));
 
+const mockIsFeatureEnabled = vi.fn();
+vi.mock('../../src/core/feature-flags.js', () => ({
+  isFeatureEnabled: (...args: unknown[]) => mockIsFeatureEnabled(...args),
+}));
+
 vi.mock('../../src/scoops/llm-session-id.js', () => ({ getDailyAdobeUuid: () => 'uuid-x' }));
 
 const mockInit = vi.fn(async () => {});
@@ -110,6 +115,10 @@ const enriched: FrozenSessionIndexEntry = {
   icon: 'wrench',
 };
 
+beforeEach(() => {
+  mockIsFeatureEnabled.mockReset().mockReturnValue(false);
+});
+
 describe('runNewSessionFreeze — write-first + race', () => {
   beforeEach(() => {
     mockGetApiKey.mockReset().mockReturnValue('k');
@@ -131,6 +140,41 @@ describe('runNewSessionFreeze — write-first + race', () => {
     );
     // A hung/failing provider never loses the archive — the pending entry is returned.
     expect(result).not.toBeNull();
+  });
+
+  it('flag on with an agent bridge requests a full agentic freeze and skips enrichment', async () => {
+    mockIsFeatureEnabled.mockReturnValue(true);
+    const spawn = vi.fn(async () => ({ finalText: 'done', exitCode: 0 }));
+    mockFreezeConeSession.mockResolvedValue({
+      ...pending,
+      filename: '2026-06-16-agentic-memory.md',
+      pendingEnrichment: undefined,
+    });
+
+    const result = await runNewSessionFreeze({
+      vfs: {} as never,
+      enrichmentRaceMs: 10,
+      agenticMemorySpawn: spawn,
+    });
+
+    expect(mockIsFeatureEnabled).toHaveBeenCalledWith('agentic-memory');
+    expect(mockFreezeConeSession).toHaveBeenCalledOnce();
+    const freezeOptions = mockFreezeConeSession.mock.calls[0][0];
+    expect(freezeOptions).toMatchObject({ mode: 'full', model: fakeModel, apiKey: 'k' });
+    await freezeOptions.agenticMemorySpawn({} as never);
+    expect(spawn).toHaveBeenCalledOnce();
+    expect(mockEnrichPendingSession).not.toHaveBeenCalled();
+    expect(result?.pendingEnrichment).toBeUndefined();
+  });
+
+  it('flag on without an agent bridge keeps the legacy quick enrichment flow', async () => {
+    mockIsFeatureEnabled.mockReturnValue(true);
+    mockEnrichPendingSession.mockResolvedValue(enriched);
+
+    await runNewSessionFreeze({ vfs: {} as never, enrichmentRaceMs: 10_000 });
+
+    expect(mockFreezeConeSession.mock.calls[0][0].mode).toBe('quick');
+    expect(mockEnrichPendingSession).toHaveBeenCalledOnce();
   });
 
   it('timer wins → returns pending entry, enrichment finishes in the background', async () => {

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -14,6 +14,11 @@ vi.mock('../../src/core/context-compaction.js', () => ({
   runOneOffCompactionCall: (...args: unknown[]) => mockRunOneOffCompactionCall(...args),
 }));
 
+const mockRunAgenticMemoryPass = vi.fn();
+vi.mock('../../src/scoops/agentic-memory.js', () => ({
+  runAgenticMemoryPass: (...args: unknown[]) => mockRunAgenticMemoryPass(...args),
+}));
+
 // Mock the budget sink so tests can assert the freezer routes through it
 // (i.e. the post-append budget step actually runs with the credentials the
 // caller passed in). `vi.hoisted` guarantees the spy is initialized BEFORE
@@ -21,14 +26,16 @@ vi.mock('../../src/core/context-compaction.js', () => ({
 // cone-memory-budget). Default impl returns a no-op result; individual tests
 // override via `mockResolvedValue` / `mockRejectedValueOnce` to inspect
 // arguments or simulate throws.
-const { mockApplyConeMemoryBudget } = vi.hoisted(() => ({
+const { mockApplyConeMemoryBudget, mockReadSessionCount } = vi.hoisted(() => ({
   mockApplyConeMemoryBudget: vi.fn(async (..._args: unknown[]) => ({
     restructured: false,
     reason: 'no-llm' as const,
   })),
+  mockReadSessionCount: vi.fn(async (..._args: unknown[]) => 1),
 }));
 vi.mock('../../src/scoops/cone-memory-budget.js', () => ({
   applyConeMemoryBudget: (...args: unknown[]) => mockApplyConeMemoryBudget(...args),
+  readSessionCount: (...args: unknown[]) => mockReadSessionCount(...args),
 }));
 
 // chat-panel imports a wide chunk (incl. SessionStore via indexeddb shims) at
@@ -145,7 +152,9 @@ const fakeModel = { id: 'test-model', provider: 'anthropic' } as unknown as Para
 describe('freezeConeSession', () => {
   beforeEach(() => {
     mockRunOneOffCompactionCall.mockReset();
+    mockRunAgenticMemoryPass.mockReset();
     mockApplyConeMemoryBudget.mockReset();
+    mockReadSessionCount.mockReset().mockResolvedValue(1);
     mockApplyConeMemoryBudget.mockResolvedValue({
       restructured: false,
       reason: 'no-llm',
@@ -229,6 +238,80 @@ describe('freezeConeSession', () => {
     expect(memoryDoc).toContain('user prefers vim');
     // /shared/CLAUDE.md is not touched by the freezer anymore.
     expect(vfs.files.get('/shared/CLAUDE.md')).toBeUndefined();
+  });
+
+  it('writes the full archive before the agentic pass and skips legacy memory on success', async () => {
+    mockRunOneOffCompactionCall.mockResolvedValueOnce('Agentic memory session');
+    const vfs = makeFakeVfs();
+    const spawn = vi.fn(async () => ({ finalText: 'done', exitCode: 0 }));
+    mockRunAgenticMemoryPass.mockImplementationOnce(async (options) => {
+      expect(vfs.files.has(options.sessionArchivePath)).toBe(true);
+      expect(options.sessionCount).toBe(1);
+      await options.spawn({} as never);
+      return { ok: true };
+    });
+
+    const frozen = await freezeConeSession({
+      sessionStore: makeFakeStore({
+        id: 'session-cone',
+        messages: [
+          userMessage('q'),
+          assistantMessage('a'),
+          userMessage('r'),
+          assistantMessage('b'),
+        ],
+        createdAt: 0,
+        updatedAt: 1,
+      }),
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+      pickIcon: async () => null,
+      agenticMemorySpawn: spawn,
+    });
+
+    expect(frozen).not.toBeNull();
+    expect(mockRunAgenticMemoryPass).toHaveBeenCalledOnce();
+    expect(spawn).toHaveBeenCalledOnce();
+    expect(mockRunOneOffCompactionCall).toHaveBeenCalledOnce();
+    expect(mockRunOneOffCompactionCall.mock.calls[0][0].instruction).toBe('TITLE');
+    expect(mockApplyConeMemoryBudget).not.toHaveBeenCalled();
+    expect(vfs.files.get('/workspace/CLAUDE.md')).toBeUndefined();
+  });
+
+  it('falls back to legacy extraction and budgeting when the agentic pass fails', async () => {
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('Agentic fallback session')
+      .mockResolvedValueOnce('- durable fallback memory');
+    mockRunAgenticMemoryPass.mockResolvedValueOnce({ ok: false, reason: 'spawn failed' });
+    const vfs = makeFakeVfs();
+
+    const frozen = await freezeConeSession({
+      sessionStore: makeFakeStore({
+        id: 'session-cone',
+        messages: [
+          userMessage('q'),
+          assistantMessage('a'),
+          userMessage('r'),
+          assistantMessage('b'),
+        ],
+        createdAt: 0,
+        updatedAt: 1,
+      }),
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+      pickIcon: async () => null,
+      agenticMemorySpawn: vi.fn(),
+    });
+
+    expect(frozen).not.toBeNull();
+    expect(mockRunOneOffCompactionCall.mock.calls.map(([arg]) => arg.instruction)).toEqual([
+      'TITLE',
+      'MEMORY',
+    ]);
+    expect(vfs.files.get('/workspace/CLAUDE.md')).toContain('durable fallback memory');
+    expect(mockApplyConeMemoryBudget).toHaveBeenCalledOnce();
   });
 
   it('round-trips aggregate cost and per-model usage through the index and archive', async () => {
@@ -1174,7 +1257,9 @@ describe('parseFrozenArchive', () => {
 describe('freezeConeSession quick mode', () => {
   beforeEach(() => {
     mockRunOneOffCompactionCall.mockReset();
+    mockRunAgenticMemoryPass.mockReset();
     mockApplyConeMemoryBudget.mockReset();
+    mockReadSessionCount.mockReset().mockResolvedValue(1);
     mockApplyConeMemoryBudget.mockResolvedValue({
       restructured: false,
       reason: 'no-llm',
@@ -1201,10 +1286,12 @@ describe('freezeConeSession quick mode', () => {
       model: fakeModel,
       apiKey: 'k',
       mode: 'quick',
+      agenticMemorySpawn: vi.fn(),
     });
 
     expect(result).not.toBeNull();
     expect(mockRunOneOffCompactionCall).not.toHaveBeenCalled();
+    expect(mockRunAgenticMemoryPass).not.toHaveBeenCalled();
     expect(result!.pendingEnrichment).toBe(true);
     // Synthetic filename — `pending-<short-id>.md` shape.
     expect(result!.filename).toMatch(/^pending-[a-z0-9-]+\.md$/);

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -283,7 +283,11 @@ describe('freezeConeSession', () => {
     mockRunOneOffCompactionCall
       .mockResolvedValueOnce('Agentic fallback session')
       .mockResolvedValueOnce('- durable fallback memory');
-    mockRunAgenticMemoryPass.mockResolvedValueOnce({ ok: false, reason: 'spawn failed' });
+    mockRunAgenticMemoryPass.mockResolvedValueOnce({
+      ok: false,
+      reason: 'spawn failed',
+      legacyFallbackSafe: true,
+    });
     const vfs = makeFakeVfs();
 
     const frozen = await freezeConeSession({
@@ -312,6 +316,40 @@ describe('freezeConeSession', () => {
     ]);
     expect(vfs.files.get('/workspace/CLAUDE.md')).toContain('durable fallback memory');
     expect(mockApplyConeMemoryBudget).toHaveBeenCalledOnce();
+  });
+
+  it('skips legacy extraction when the agentic pass times out', async () => {
+    mockRunOneOffCompactionCall.mockResolvedValueOnce('Timed out agentic session');
+    mockRunAgenticMemoryPass.mockResolvedValueOnce({
+      ok: false,
+      reason: 'timeout',
+      legacyFallbackSafe: false,
+    });
+    const vfs = makeFakeVfs();
+
+    const frozen = await freezeConeSession({
+      sessionStore: makeFakeStore({
+        id: 'session-cone',
+        messages: [
+          userMessage('q'),
+          assistantMessage('a'),
+          userMessage('r'),
+          assistantMessage('b'),
+        ],
+        createdAt: 0,
+        updatedAt: 1,
+      }),
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+      pickIcon: async () => null,
+      agenticMemorySpawn: vi.fn(),
+    });
+
+    expect(frozen).not.toBeNull();
+    expect(mockRunOneOffCompactionCall).toHaveBeenCalledOnce();
+    expect(vfs.files.get('/workspace/CLAUDE.md')).toBeUndefined();
+    expect(mockApplyConeMemoryBudget).not.toHaveBeenCalled();
   });
 
   it('round-trips aggregate cost and per-model usage through the index and archive', async () => {

--- a/packages/webapp/tests/ui/wc/wc-settings.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-settings.test.ts
@@ -52,6 +52,10 @@ function findPanelLayoutsToggle(dialog: HTMLElement): HTMLInputElement | null {
   return dialog.querySelector('#wcset-feature-panel-layouts');
 }
 
+function findAgenticMemoryToggle(dialog: HTMLElement): HTMLInputElement | null {
+  return dialog.querySelector('#wcset-feature-agentic-memory');
+}
+
 const log = { error: vi.fn() };
 
 function seedAccounts(accounts: unknown[]): void {
@@ -268,6 +272,11 @@ describe('showExperimentalSettings', () => {
     // `listFlags()`, with no per-flag UI code.
     expect(findPanelLayoutsToggle(dialog)).not.toBeNull();
     expect(dialog.textContent).toContain('Panel layouts');
+    expect(findAgenticMemoryToggle(dialog)).not.toBeNull();
+    expect(dialog.textContent).toContain('Agentic memory');
+    expect(dialog.textContent).toContain(
+      'Curate session memory with a background agent instead of a one-shot extraction call.'
+    );
     // `experimental-settings` gates this dialog and is NOT toggleable, so it must
     // never offer a switch that would let a user lock themselves out of it.
     expect(findExperimentalToggle(dialog)).toBeNull();
@@ -287,6 +296,21 @@ describe('showExperimentalSettings', () => {
     toggle.dispatchEvent(new Event('change'));
 
     expect(isFeatureEnabled('panel-layouts')).toBe(true);
+    clickDone(dialog);
+    await result;
+  });
+
+  it('persists an agentic-memory toggle', async () => {
+    initFeatureFlags('standalone', { 'experimental-settings': 'on' });
+    const result = showExperimentalSettings(log);
+    const dialog = await openDialog();
+    const toggle = findAgenticMemoryToggle(dialog) as HTMLInputElement;
+
+    expect(toggle.checked).toBe(false);
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change'));
+
+    expect(isFeatureEnabled('agentic-memory')).toBe(true);
     clickDone(dialog);
     await result;
   });


### PR DESCRIPTION
## Summary

Adds agent-driven durable memory curation when a full session is frozen. The behavior is gated behind the default-off `agentic-memory` experimental feature flag.

## Why

The legacy one-shot extraction appends isolated bullets and cannot reliably maintain a bounded, topical long-lived memory file. A curator agent can read the previous memory and archived session, then rewrite durable memory coherently within the configured budget.

## Approach / Implementation notes

- Added the feature flag, default-off worker configuration, and experimental-settings toggle.
- Added the curator runner with safe `/shared/MEMORY.md` parsing and fallback, placeholder substitution, configurable sandbox paths and timeout, plus AgentBridge `writablePaths` support.
- Added the default VFS-root `/shared/MEMORY.md` template and drift, fresh-VFS seeding, and edit-preservation tests.
- Runs curation after archive creation, skips legacy extraction on success, and falls back to the legacy path when disabled, unavailable, failed, timed out, quick-mode, or pending enrichment.

## Cross-cutting impact

- Standalone and extension-leader paths use a typed page-to-kernel spawn RPC through the shared kernel topology.
- MessageChannel and topology tests cover the cross-runtime contract.
- Existing AgentBridge callers retain their prior writable-path defaults when the new option is omitted.
- No persisted-state migration or dependency change.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 799 files and 13,740 tests passed after rebase
- [x] `npm run verify` — all seven strict checks passed, including resolved `deadcode-prod`
- [x] `npm run test:coverage:webapp` — all configured coverage floors passed
- [x] `npm run build -w @slicc/webapp`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] New and changed behavior has mirrored unit and transport regression coverage
- [x] N/A — no new UI component; the flag uses the existing experimental-settings list and defaults off

**Pre-existing failures:** None in the final verification. The coverage run needed one retry for a load-sensitive ESM timing test, which was green on the successful run.

## Documentation

- [x] Relevant `CLAUDE.md` files document the curator, template, and freeze flow
- [x] `README.md` unchanged because the experimental flag defaults off
- [x] No shell-command or agent-skill documentation change required

## Risk & rollback

The flag defaults off. Disabling it restores the legacy freeze behavior without a data migration; the durable memory file remains Markdown with its user-authored header preserved.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API changes are intentional and documented
- [x] CLI, extension-leader, kernel, offscreen, and fallback paths were checked
