### PR TITLE
fix(ios-app): keep TestFlight group attach when beta review is deferred

### DIFF
--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -161,7 +161,7 @@ swift format --in-place --parallel --recursive SliccFollower Package.swift
 
 Releases run `scripts/package-and-upload-testflight.sh` (secrets via `setup-testflight-secrets.sh`), path-gated by `release-native.mjs`. The script **soft-skips with exit 0** when `SLICC_SKIP_TESTFLIGHT=1`, an Apple secret is missing/`-`, or default Xcode is below 26. A green release is not proof an ipa shipped.
 
-After upload, `scripts/testflight-distribute.mjs` (gated on the `SLICC_TF_EXTERNAL_GROUP` repo variable; unset = upload-only) waits for processing, sets What to Test notes (appending `SLICC_TF_DEMO_JOIN_URL` when set), submits Beta App Review idempotently, and attaches the build to that tester group.
+After upload, `scripts/testflight-distribute.mjs` (gated on `SLICC_TF_EXTERNAL_GROUP`; unset = upload-only) waits for processing, sets What to Test notes (appending `SLICC_TF_DEMO_JOIN_URL`), submits Beta App Review, and attaches the build to that group. **Submission and attach are independent** — only a `fatal` submit aborts; `deferred` (Apple's review quota) warns and still attaches, so the build ships once review clears. Tests: `scripts/testflight-distribute.test.mjs`.
 
 ## Related Guides
 

--- a/packages/ios-app/scripts/testflight-distribute.mjs
+++ b/packages/ios-app/scripts/testflight-distribute.mjs
@@ -11,6 +11,14 @@
 //      submitted/approved build is not an error)
 //   4. attach the build to the named tester group
 //
+// Steps 3 and 4 are INDEPENDENT. Beta App Review runs against a version
+// string; group membership is a property of the build. A build can sit in a
+// group waiting for its review to clear, which is exactly the state we want
+// when review is deferred — so step 4 always runs, even when step 3 could
+// not submit. Aborting between them (the pre-2026-08-06 behavior) stranded
+// the build in no group at all, so it could never flow to testers even
+// after review capacity returned. See `classifySubmitOutcome`.
+//
 // Inputs (env):
 //   APPLE_API_KEY_ID            App Store Connect API key id (required)
 //   APPLE_API_KEY_ISSUER_ID     API key issuer id (required)
@@ -27,47 +35,83 @@
 // The soft-skip mirrors package-and-upload-testflight.sh: distribution is
 // opt-in per repo, and a missing group name must not fail the release.
 
-import { readFileSync } from 'node:fs';
 import { createPrivateKey, randomUUID, sign } from 'node:crypto';
+import { readFileSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 const API = 'https://api.appstoreconnect.apple.com/v1';
 
-const keyId = process.env.APPLE_API_KEY_ID ?? '';
-const issuerId = process.env.APPLE_API_KEY_ISSUER_ID ?? '';
-const p8Path = process.env.APPLE_API_KEY_P8_PATH ?? '';
-const buildNumber = process.env.SLICC_TF_BUILD_NUMBER ?? '';
-const bundleId = process.env.SLICC_TF_BUNDLE_ID || 'com.sliccy.follower';
-const groupName = process.env.SLICC_TF_EXTERNAL_GROUP ?? '';
-// A typo'd value must degrade to the default, not to NaN: a NaN deadline
-// never compares true and would turn the processing poll into an infinite
-// loop with only the CI job timeout as a backstop.
-const parsedTimeout = Number(process.env.SLICC_TF_PROCESSING_TIMEOUT_MINUTES || '30');
-const timeoutMinutes = Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : 30;
+/**
+ * A step that failed in a way that should fail the release. Thrown instead of
+ * calling process.exit inline so the orchestration is testable and so a
+ * failure can never bypass the steps that are still worth attempting.
+ */
+export class DistributionError extends Error {}
 
-if (!groupName) {
-  console.log('SLICC_TF_EXTERNAL_GROUP not set — skipping TestFlight distribution.');
-  process.exit(0);
-}
-for (const [name, value] of [
-  ['APPLE_API_KEY_ID', keyId],
-  ['APPLE_API_KEY_ISSUER_ID', issuerId],
-  ['APPLE_API_KEY_P8_PATH', p8Path],
-  ['SLICC_TF_BUILD_NUMBER', buildNumber],
-]) {
-  if (!value) {
-    console.error(`error: ${name} is required for TestFlight distribution`);
-    process.exit(1);
-  }
+// --- Outcome classification (pure) ----------------------------------------
+
+/**
+ * Error codes that mean "this build is already past this step". Benign on
+ * re-runs and for internal-only groups: the desired end state already holds.
+ */
+export const IDEMPOTENT_ERROR_CODES = new Set(['STATE_ERROR']);
+
+/**
+ * Apple caps how many Beta App Review submissions an app may make in a
+ * rolling window. Because semantic-release stamps a NEW marketing version on
+ * every merge, and Apple requires a fresh review per version string, this
+ * pipeline spends one submission per merge and periodically exhausts the
+ * quota. That is a capacity condition, not a broken release: the build is
+ * uploaded, valid, and already live for internal testers. Treat it as
+ * deferred so the release stays green, the group attach still happens, and a
+ * later run (or the backfill job) can submit once capacity returns.
+ */
+export function isSubmissionCapacityError({ status, code }) {
+  if (status === 429) return true;
+  // Match on the distinctive suffix rather than the full dotted code so an
+  // Apple-side prefix change (ENTITY_UNPROCESSABLE.*) does not silently
+  // reclassify a capacity condition as a fatal release failure.
+  return typeof code === 'string' && code.includes('SUBMISSION_LIMIT_REACHED');
 }
 
-function defaultWhatsNew() {
+/**
+ * Classify the POST /betaAppReviewSubmissions response.
+ *
+ *   'submitted' - accepted; review is now pending
+ *   'skipped'   - already submitted/approved, or review not required
+ *   'deferred'  - Apple has no review capacity right now; retry later
+ *   'fatal'     - anything else; the release should surface this
+ */
+export function classifySubmitOutcome({ status, code }) {
+  if (status < 400) return 'submitted';
+  if (isSubmissionCapacityError({ status, code })) return 'deferred';
+  if (IDEMPOTENT_ERROR_CODES.has(code) || status === 409) return 'skipped';
+  return 'fatal';
+}
+
+/**
+ * Classify the POST /betaGroups/{id}/relationships/builds response. Same
+ * idempotency contract as the review submission: a build already in the
+ * group is a no-op on re-runs, not a failed release.
+ */
+export function classifyAttachOutcome({ status, code }) {
+  if (status < 400) return 'attached';
+  if (IDEMPOTENT_ERROR_CODES.has(code) || status === 409) return 'already-present';
+  return 'fatal';
+}
+
+export function firstErrorCode(payload) {
+  return payload?.errors?.[0]?.code ?? '';
+}
+
+export function defaultWhatsNew(env = process.env) {
   const lines = [
     'Chat with a live SLICC agent session from your iPhone or iPad.',
     '',
     'Getting a session to join:',
     '- macOS: download https://www.sliccy.ai/download/slicc.dmg, drag Sliccstart into Applications, and launch it. With the same iCloud account on both devices the session appears under Settings automatically; otherwise paste the join link.',
   ];
-  const demoUrl = process.env.SLICC_TF_DEMO_JOIN_URL ?? '';
+  const demoUrl = env.SLICC_TF_DEMO_JOIN_URL ?? '';
   if (demoUrl) {
     lines.push(`- No Mac handy? Join the hosted demo session: ${demoUrl}`);
   }
@@ -82,206 +126,294 @@ function base64url(input) {
   return Buffer.from(input).toString('base64url');
 }
 
-function makeToken() {
-  const key = createPrivateKey(readFileSync(p8Path, 'utf8'));
-  const now = Math.floor(Date.now() / 1000);
-  const header = base64url(JSON.stringify({ alg: 'ES256', kid: keyId, typ: 'JWT' }));
-  const payload = base64url(
-    JSON.stringify({
-      iss: issuerId,
-      iat: now,
-      exp: now + 19 * 60,
-      aud: 'appstoreconnect-v1',
-      jti: randomUUID(),
-    })
-  );
-  const signature = sign('sha256', Buffer.from(`${header}.${payload}`), {
-    key,
-    dsaEncoding: 'ieee-p1363',
-  }).toString('base64url');
-  return `${header}.${payload}.${signature}`;
-}
-
-// Token minting is cheap; re-mint when within a minute of expiry so long
-// processing waits never present a stale token.
-let token = makeToken();
-let tokenBornAt = Date.now();
-function freshToken() {
-  if (Date.now() - tokenBornAt > 18 * 60 * 1000) {
-    token = makeToken();
-    tokenBornAt = Date.now();
+export function createAscClient({ keyId, issuerId, p8Path, fetchImpl = fetch }) {
+  function makeToken() {
+    const key = createPrivateKey(readFileSync(p8Path, 'utf8'));
+    const now = Math.floor(Date.now() / 1000);
+    const header = base64url(JSON.stringify({ alg: 'ES256', kid: keyId, typ: 'JWT' }));
+    const payload = base64url(
+      JSON.stringify({
+        iss: issuerId,
+        iat: now,
+        exp: now + 19 * 60,
+        aud: 'appstoreconnect-v1',
+        jti: randomUUID(),
+      })
+    );
+    const signature = sign('sha256', Buffer.from(`${header}.${payload}`), {
+      key,
+      dsaEncoding: 'ieee-p1363',
+    }).toString('base64url');
+    return `${header}.${payload}.${signature}`;
   }
-  return token;
+
+  // Token minting is cheap; re-mint when within a minute of expiry so long
+  // processing waits never present a stale token.
+  let token = makeToken();
+  let tokenBornAt = Date.now();
+  function freshToken() {
+    if (Date.now() - tokenBornAt > 18 * 60 * 1000) {
+      token = makeToken();
+      tokenBornAt = Date.now();
+    }
+    return token;
+  }
+
+  return async function asc(method, path, body) {
+    const response = await fetchImpl(`${API}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${freshToken()}`,
+        'Content-Type': 'application/json',
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await response.text();
+    let json = null;
+    if (text) {
+      try {
+        json = JSON.parse(text);
+      } catch {
+        // non-JSON error body; keep raw text for the error message
+      }
+    }
+    return { status: response.status, json, text };
+  };
 }
 
-async function asc(method, path, body) {
-  const response = await fetch(`${API}${path}`, {
-    method,
-    headers: {
-      Authorization: `Bearer ${freshToken()}`,
-      'Content-Type': 'application/json',
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Steps 1-4. Returns { submit, attach } outcome labels so the caller owns
+ * the exit-code policy. Throws DistributionError for conditions that should
+ * fail the release.
+ */
+export async function distribute({
+  asc,
+  bundleId,
+  buildNumber,
+  groupName,
+  whatsNew,
+  timeoutMinutes = 30,
+  sleep = defaultSleep,
+  log = console,
+  now = () => Date.now(),
+}) {
+  async function must(method, path, body, what) {
+    const result = await asc(method, path, body);
+    if (result.status >= 400) {
+      throw new DistributionError(
+        `${what} failed (HTTP ${result.status}): ${result.text.slice(0, 500)}`
+      );
+    }
+    return result.json;
+  }
+
+  // --- 1. Resolve app and wait for the build --------------------------------
+  const apps = await must(
+    'GET',
+    `/apps?filter[bundleId]=${encodeURIComponent(bundleId)}&fields[apps]=bundleId`,
+    undefined,
+    'app lookup'
+  );
+  const app = apps?.data?.[0];
+  if (!app) {
+    throw new DistributionError(`no App Store Connect app with bundle id ${bundleId}`);
+  }
+
+  log.log(`Waiting for build ${buildNumber} of ${bundleId} to finish processing...`);
+  const deadline = now() + timeoutMinutes * 60 * 1000;
+  let build = null;
+  for (;;) {
+    const builds = await must(
+      'GET',
+      `/builds?filter[app]=${app.id}&filter[version]=${encodeURIComponent(buildNumber)}` +
+        '&fields[builds]=processingState,version&limit=5',
+      undefined,
+      'build lookup'
+    );
+    build = builds?.data?.[0] ?? null;
+    const state = build?.attributes?.processingState ?? 'NOT_VISIBLE_YET';
+    if (state === 'VALID') {
+      break;
+    }
+    if (state === 'FAILED' || state === 'INVALID') {
+      throw new DistributionError(`build ${buildNumber} processing ended in ${state}`);
+    }
+    if (now() > deadline) {
+      throw new DistributionError(
+        `build ${buildNumber} still ${state} after ${timeoutMinutes} minutes — ` +
+          'raise SLICC_TF_PROCESSING_TIMEOUT_MINUTES or distribute manually'
+      );
+    }
+    log.log(`  ${state}; retrying in 60s`);
+    await sleep(60 * 1000);
+  }
+  log.log(`Build processed: ${build.id}`);
+
+  // --- 2. What to Test -------------------------------------------------------
+  const localizations = await must(
+    'GET',
+    `/builds/${build.id}/betaBuildLocalizations?fields[betaBuildLocalizations]=locale`,
+    undefined,
+    'localization lookup'
+  );
+  const enUS = localizations?.data?.find((l) => l.attributes?.locale === 'en-US');
+  if (enUS) {
+    await must(
+      'PATCH',
+      `/betaBuildLocalizations/${enUS.id}`,
+      {
+        data: {
+          id: enUS.id,
+          type: 'betaBuildLocalizations',
+          attributes: { whatsNew },
+        },
+      },
+      'What to Test update'
+    );
+  } else {
+    await must(
+      'POST',
+      '/betaBuildLocalizations',
+      {
+        data: {
+          type: 'betaBuildLocalizations',
+          attributes: { locale: 'en-US', whatsNew },
+          relationships: { build: { data: { id: build.id, type: 'builds' } } },
+        },
+      },
+      'What to Test creation'
+    );
+  }
+  log.log('What to Test notes set.');
+
+  // --- 3. Beta App Review (idempotent, never aborts) -------------------------
+  // A failure here must not skip step 4: see the header note on why the two
+  // steps are independent.
+  const submission = await asc('POST', '/betaAppReviewSubmissions', {
+    data: {
+      type: 'betaAppReviewSubmissions',
+      relationships: { build: { data: { id: build.id, type: 'builds' } } },
     },
-    body: body === undefined ? undefined : JSON.stringify(body),
   });
-  const text = await response.text();
-  let json = null;
-  if (text) {
-    try {
-      json = JSON.parse(text);
-    } catch {
-      // non-JSON error body; keep raw text for the error message
+  const submitOutcome = classifySubmitOutcome({
+    status: submission.status,
+    code: firstErrorCode(submission.json),
+  });
+  if (submitOutcome === 'submitted') {
+    log.log('Submitted for Beta App Review.');
+  } else if (submitOutcome === 'skipped') {
+    log.log(`Beta App Review submission skipped (${submission.text.slice(0, 200)})`);
+  } else if (submitOutcome === 'deferred') {
+    log.log(
+      `::warning title=TestFlight beta review deferred::Build ${buildNumber} could not be ` +
+        'submitted for Beta App Review — Apple reports no review capacity right now ' +
+        `(HTTP ${submission.status}). The build is uploaded and live for internal testers; ` +
+        'it will reach external testers once a later run resubmits it.'
+    );
+  } else {
+    throw new DistributionError(
+      `Beta App Review submission failed (HTTP ${submission.status}): ${submission.text.slice(0, 500)}`
+    );
+  }
+
+  // --- 4. Attach to the tester group -----------------------------------------
+  const groups = await must(
+    'GET',
+    `/betaGroups?filter[app]=${app.id}&filter[name]=${encodeURIComponent(groupName)}` +
+      '&fields[betaGroups]=name,isInternalGroup',
+    undefined,
+    'tester group lookup'
+  );
+  const group = groups?.data?.find((g) => g.attributes?.name === groupName);
+  if (!group) {
+    throw new DistributionError(`no tester group named "${groupName}" for ${bundleId}`);
+  }
+  const attach = await asc('POST', `/betaGroups/${group.id}/relationships/builds`, {
+    data: [{ id: build.id, type: 'builds' }],
+  });
+  const attachOutcome = classifyAttachOutcome({
+    status: attach.status,
+    code: firstErrorCode(attach.json),
+  });
+  if (attachOutcome === 'attached') {
+    log.log(`Build ${buildNumber} attached to tester group "${groupName}".`);
+  } else if (attachOutcome === 'already-present') {
+    log.log(`Build ${buildNumber} already in "${groupName}" (${attach.text.slice(0, 200)})`);
+  } else {
+    throw new DistributionError(
+      `attaching build to "${groupName}" failed (HTTP ${attach.status}): ${attach.text.slice(0, 500)}`
+    );
+  }
+
+  return { submit: submitOutcome, attach: attachOutcome };
+}
+
+export async function main(env = process.env, log = console) {
+  const keyId = env.APPLE_API_KEY_ID ?? '';
+  const issuerId = env.APPLE_API_KEY_ISSUER_ID ?? '';
+  const p8Path = env.APPLE_API_KEY_P8_PATH ?? '';
+  const buildNumber = env.SLICC_TF_BUILD_NUMBER ?? '';
+  const bundleId = env.SLICC_TF_BUNDLE_ID || 'com.sliccy.follower';
+  const groupName = env.SLICC_TF_EXTERNAL_GROUP ?? '';
+  // A typo'd value must degrade to the default, not to NaN: a NaN deadline
+  // never compares true and would turn the processing poll into an infinite
+  // loop with only the CI job timeout as a backstop.
+  const parsedTimeout = Number(env.SLICC_TF_PROCESSING_TIMEOUT_MINUTES || '30');
+  const timeoutMinutes = Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : 30;
+
+  if (!groupName) {
+    log.log('SLICC_TF_EXTERNAL_GROUP not set — skipping TestFlight distribution.');
+    return 0;
+  }
+  for (const [name, value] of [
+    ['APPLE_API_KEY_ID', keyId],
+    ['APPLE_API_KEY_ISSUER_ID', issuerId],
+    ['APPLE_API_KEY_P8_PATH', p8Path],
+    ['SLICC_TF_BUILD_NUMBER', buildNumber],
+  ]) {
+    if (!value) {
+      log.error(`error: ${name} is required for TestFlight distribution`);
+      return 1;
     }
   }
-  return { status: response.status, json, text };
-}
 
-function firstErrorCode(payload) {
-  return payload?.errors?.[0]?.code ?? '';
-}
+  // Code-point-safe truncation: a plain .slice counts UTF-16 units and can
+  // split a surrogate pair (emoji) at the 4000-char ASC limit.
+  const whatsNew = [...(env.SLICC_TF_WHATS_NEW || defaultWhatsNew(env))].slice(0, 4000).join('');
 
-async function must(method, path, body, what) {
-  const result = await asc(method, path, body);
-  if (result.status >= 400) {
-    console.error(`error: ${what} failed (HTTP ${result.status}): ${result.text.slice(0, 500)}`);
-    process.exit(1);
+  try {
+    const result = await distribute({
+      asc: createAscClient({ keyId, issuerId, p8Path }),
+      bundleId,
+      buildNumber,
+      groupName,
+      whatsNew,
+      timeoutMinutes,
+      log,
+    });
+    // A deferred review is a degraded outcome, not a failed release: the ipa
+    // shipped and internal testers have it. Exit 0 so a capacity condition
+    // does not read as a broken pipeline, and rely on the ::warning:: above
+    // for visibility.
+    if (result.submit === 'deferred') {
+      log.log(
+        `TestFlight distribution degraded: build ${buildNumber} is in "${groupName}" but is ` +
+          'not yet approved for external testing.'
+      );
+    }
+    return 0;
+  } catch (err) {
+    if (err instanceof DistributionError) {
+      log.error(`error: ${err.message}`);
+      return 1;
+    }
+    throw err;
   }
-  return result.json;
 }
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-// --- 1. Resolve app and wait for the build --------------------------------
-const apps = await must(
-  'GET',
-  `/apps?filter[bundleId]=${encodeURIComponent(bundleId)}&fields[apps]=bundleId`,
-  undefined,
-  'app lookup'
-);
-const app = apps?.data?.[0];
-if (!app) {
-  console.error(`error: no App Store Connect app with bundle id ${bundleId}`);
-  process.exit(1);
-}
-
-console.log(`Waiting for build ${buildNumber} of ${bundleId} to finish processing...`);
-const deadline = Date.now() + timeoutMinutes * 60 * 1000;
-let build = null;
-for (;;) {
-  const builds = await must(
-    'GET',
-    `/builds?filter[app]=${app.id}&filter[version]=${encodeURIComponent(buildNumber)}` +
-      '&fields[builds]=processingState,version&limit=5',
-    undefined,
-    'build lookup'
-  );
-  build = builds?.data?.[0] ?? null;
-  const state = build?.attributes?.processingState ?? 'NOT_VISIBLE_YET';
-  if (state === 'VALID') {
-    break;
-  }
-  if (state === 'FAILED' || state === 'INVALID') {
-    console.error(`error: build ${buildNumber} processing ended in ${state}`);
-    process.exit(1);
-  }
-  if (Date.now() > deadline) {
-    console.error(
-      `error: build ${buildNumber} still ${state} after ${timeoutMinutes} minutes — ` +
-        'raise SLICC_TF_PROCESSING_TIMEOUT_MINUTES or distribute manually'
-    );
-    process.exit(1);
-  }
-  console.log(`  ${state}; retrying in 60s`);
-  await sleep(60 * 1000);
-}
-console.log(`Build processed: ${build.id}`);
-
-// --- 2. What to Test -------------------------------------------------------
-// Code-point-safe truncation: a plain .slice counts UTF-16 units and can
-// split a surrogate pair (emoji) at the 4000-char ASC limit.
-const whatsNew = [...(process.env.SLICC_TF_WHATS_NEW || defaultWhatsNew())]
-  .slice(0, 4000)
-  .join('');
-const localizations = await must(
-  'GET',
-  `/builds/${build.id}/betaBuildLocalizations?fields[betaBuildLocalizations]=locale`,
-  undefined,
-  'localization lookup'
-);
-const enUS = localizations?.data?.find((l) => l.attributes?.locale === 'en-US');
-if (enUS) {
-  await must(
-    'PATCH',
-    `/betaBuildLocalizations/${enUS.id}`,
-    {
-      data: {
-        id: enUS.id,
-        type: 'betaBuildLocalizations',
-        attributes: { whatsNew },
-      },
-    },
-    'What to Test update'
-  );
-} else {
-  await must(
-    'POST',
-    '/betaBuildLocalizations',
-    {
-      data: {
-        type: 'betaBuildLocalizations',
-        attributes: { locale: 'en-US', whatsNew },
-        relationships: { build: { data: { id: build.id, type: 'builds' } } },
-      },
-    },
-    'What to Test creation'
-  );
-}
-console.log('What to Test notes set.');
-
-// --- 3. Beta App Review (idempotent) ---------------------------------------
-const submission = await asc('POST', '/betaAppReviewSubmissions', {
-  data: {
-    type: 'betaAppReviewSubmissions',
-    relationships: { build: { data: { id: build.id, type: 'builds' } } },
-  },
-});
-if (submission.status < 400) {
-  console.log('Submitted for Beta App Review.');
-} else if (firstErrorCode(submission.json) === 'STATE_ERROR' || submission.status === 409) {
-  // Already submitted, already approved, or review not required for this
-  // build — all fine for re-runs and internal-only groups.
-  console.log(`Beta App Review submission skipped (${submission.text.slice(0, 200)})`);
-} else {
-  console.error(
-    `error: Beta App Review submission failed (HTTP ${submission.status}): ${submission.text.slice(0, 500)}`
-  );
-  process.exit(1);
-}
-
-// --- 4. Attach to the tester group -----------------------------------------
-const groups = await must(
-  'GET',
-  `/betaGroups?filter[app]=${app.id}&filter[name]=${encodeURIComponent(groupName)}` +
-    '&fields[betaGroups]=name,isInternalGroup',
-  undefined,
-  'tester group lookup'
-);
-const group = groups?.data?.find((g) => g.attributes?.name === groupName);
-if (!group) {
-  console.error(`error: no tester group named "${groupName}" for ${bundleId}`);
-  process.exit(1);
-}
-const attach = await asc('POST', `/betaGroups/${group.id}/relationships/builds`, {
-  data: [{ id: build.id, type: 'builds' }],
-});
-if (attach.status < 400) {
-  console.log(`Build ${buildNumber} attached to tester group "${groupName}".`);
-} else if (firstErrorCode(attach.json) === 'STATE_ERROR' || attach.status === 409) {
-  // Same idempotency contract as the review submission: a build already in
-  // the group is a no-op on re-runs, not a failed release.
-  console.log(`Build ${buildNumber} already in "${groupName}" (${attach.text.slice(0, 200)})`);
-} else {
-  console.error(
-    `error: attaching build to "${groupName}" failed (HTTP ${attach.status}): ${attach.text.slice(0, 500)}`
-  );
-  process.exit(1);
+const isMain = process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  process.exit(await main());
 }

--- a/packages/ios-app/scripts/testflight-distribute.test.mjs
+++ b/packages/ios-app/scripts/testflight-distribute.test.mjs
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  classifyAttachOutcome,
+  classifySubmitOutcome,
+  defaultWhatsNew,
+  distribute,
+  DistributionError,
+  firstErrorCode,
+  isSubmissionCapacityError,
+  main,
+} from './testflight-distribute.mjs';
+
+const SUBMISSION_LIMIT = 'ENTITY_UNPROCESSABLE.SUBMISSION_LIMIT_REACHED';
+
+describe('isSubmissionCapacityError', () => {
+  it('recognizes the dotted App Store Connect submission-limit code', () => {
+    expect(isSubmissionCapacityError({ status: 422, code: SUBMISSION_LIMIT })).toBe(true);
+  });
+
+  it('recognizes a bare or re-prefixed submission-limit code', () => {
+    // Apple has moved these codes between prefixes before; matching the
+    // suffix keeps a capacity condition from reclassifying as fatal.
+    expect(isSubmissionCapacityError({ status: 422, code: 'SUBMISSION_LIMIT_REACHED' })).toBe(true);
+    expect(
+      isSubmissionCapacityError({ status: 422, code: 'SOMETHING.SUBMISSION_LIMIT_REACHED' })
+    ).toBe(true);
+  });
+
+  it('treats HTTP 429 as capacity regardless of code', () => {
+    expect(isSubmissionCapacityError({ status: 429, code: '' })).toBe(true);
+  });
+
+  it('does not treat unrelated errors as capacity', () => {
+    expect(isSubmissionCapacityError({ status: 422, code: 'ENTITY_ERROR.ATTRIBUTE_INVALID' })).toBe(
+      false
+    );
+    expect(isSubmissionCapacityError({ status: 403, code: undefined })).toBe(false);
+  });
+});
+
+describe('classifySubmitOutcome', () => {
+  it('reports success as submitted', () => {
+    expect(classifySubmitOutcome({ status: 201, code: '' })).toBe('submitted');
+  });
+
+  it('reports the submission limit as deferred, not fatal', () => {
+    expect(classifySubmitOutcome({ status: 422, code: SUBMISSION_LIMIT })).toBe('deferred');
+  });
+
+  it('reports already-submitted states as skipped', () => {
+    expect(classifySubmitOutcome({ status: 409, code: '' })).toBe('skipped');
+    expect(classifySubmitOutcome({ status: 422, code: 'STATE_ERROR' })).toBe('skipped');
+  });
+
+  it('reports anything else as fatal', () => {
+    expect(classifySubmitOutcome({ status: 401, code: 'NOT_AUTHORIZED' })).toBe('fatal');
+    expect(classifySubmitOutcome({ status: 500, code: '' })).toBe('fatal');
+  });
+
+  it('prefers deferred over skipped when a 409 also carries a capacity code', () => {
+    expect(classifySubmitOutcome({ status: 409, code: SUBMISSION_LIMIT })).toBe('deferred');
+  });
+});
+
+describe('classifyAttachOutcome', () => {
+  it('classifies success, idempotent repeats, and real failures', () => {
+    expect(classifyAttachOutcome({ status: 204, code: '' })).toBe('attached');
+    expect(classifyAttachOutcome({ status: 409, code: '' })).toBe('already-present');
+    expect(classifyAttachOutcome({ status: 422, code: 'STATE_ERROR' })).toBe('already-present');
+    expect(classifyAttachOutcome({ status: 403, code: 'FORBIDDEN' })).toBe('fatal');
+  });
+});
+
+describe('firstErrorCode', () => {
+  it('extracts the first error code and tolerates missing shapes', () => {
+    expect(firstErrorCode({ errors: [{ code: 'STATE_ERROR' }] })).toBe('STATE_ERROR');
+    expect(firstErrorCode({ errors: [] })).toBe('');
+    expect(firstErrorCode(null)).toBe('');
+  });
+});
+
+describe('defaultWhatsNew', () => {
+  it('omits the demo line when no join url is configured', () => {
+    expect(defaultWhatsNew({})).not.toContain('hosted demo session');
+  });
+
+  it('appends the demo join url when set', () => {
+    expect(defaultWhatsNew({ SLICC_TF_DEMO_JOIN_URL: 'https://example.test/join' })).toContain(
+      'https://example.test/join'
+    );
+  });
+});
+
+// --- distribute() orchestration -------------------------------------------
+
+const silentLog = { log: () => {}, error: () => {} };
+
+/**
+ * Minimal ASC stub. `overrides` maps "METHOD /path-prefix" to a response.
+ */
+function makeAsc(overrides = {}) {
+  const calls = [];
+  const asc = async (method, path, body) => {
+    calls.push({ method, path, body });
+    for (const [key, response] of Object.entries(overrides)) {
+      const [m, prefix] = key.split(' ');
+      if (m === method && path.startsWith(prefix)) {
+        return { status: 200, json: null, text: '', ...response };
+      }
+    }
+    if (method === 'GET' && path.startsWith('/apps')) {
+      return { status: 200, json: { data: [{ id: 'app-1' }] }, text: '{}' };
+    }
+    if (method === 'GET' && path.startsWith('/builds?')) {
+      return {
+        status: 200,
+        json: { data: [{ id: 'build-1', attributes: { processingState: 'VALID' } }] },
+        text: '{}',
+      };
+    }
+    if (method === 'GET' && path.includes('/betaBuildLocalizations')) {
+      return {
+        status: 200,
+        json: { data: [{ id: 'loc-1', attributes: { locale: 'en-US' } }] },
+        text: '{}',
+      };
+    }
+    if (method === 'PATCH' && path.startsWith('/betaBuildLocalizations')) {
+      return { status: 200, json: {}, text: '{}' };
+    }
+    if (method === 'POST' && path === '/betaAppReviewSubmissions') {
+      return { status: 201, json: {}, text: '{}' };
+    }
+    if (method === 'GET' && path.startsWith('/betaGroups')) {
+      return {
+        status: 200,
+        json: { data: [{ id: 'group-1', attributes: { name: 'External Testers' } }] },
+        text: '{}',
+      };
+    }
+    if (method === 'POST' && path.includes('/relationships/builds')) {
+      return { status: 204, json: null, text: '' };
+    }
+    throw new Error(`unstubbed ASC call: ${method} ${path}`);
+  };
+  return { asc, calls };
+}
+
+const baseArgs = {
+  bundleId: 'com.sliccy.follower',
+  buildNumber: '1314',
+  groupName: 'External Testers',
+  whatsNew: 'notes',
+  sleep: async () => {},
+  log: silentLog,
+};
+
+describe('distribute', () => {
+  it('submits and attaches on the happy path', async () => {
+    const { asc, calls } = makeAsc();
+    const result = await distribute({ ...baseArgs, asc });
+
+    expect(result).toEqual({ submit: 'submitted', attach: 'attached' });
+    expect(calls.some((c) => c.path === '/betaAppReviewSubmissions')).toBe(true);
+    expect(calls.some((c) => c.path.includes('/relationships/builds'))).toBe(true);
+  });
+
+  // The regression this whole change exists for: build 1314 (2026-08-06) hit
+  // the submission limit, the script exited, and the build was left in no
+  // tester group at all — so it could not flow to testers even after review
+  // capacity returned.
+  it('still attaches the build to the group when review submission is deferred', async () => {
+    const { asc, calls } = makeAsc({
+      'POST /betaAppReviewSubmissions': {
+        status: 422,
+        json: { errors: [{ code: SUBMISSION_LIMIT }] },
+        text: '{"errors":[{"code":"ENTITY_UNPROCESSABLE.SUBMISSION_LIMIT_REACHED"}]}',
+      },
+    });
+
+    const result = await distribute({ ...baseArgs, asc });
+
+    expect(result).toEqual({ submit: 'deferred', attach: 'attached' });
+    expect(calls.some((c) => c.path.includes('/relationships/builds'))).toBe(true);
+  });
+
+  it('emits a warning annotation when review is deferred', async () => {
+    const log = { log: vi.fn(), error: vi.fn() };
+    const { asc } = makeAsc({
+      'POST /betaAppReviewSubmissions': {
+        status: 422,
+        json: { errors: [{ code: SUBMISSION_LIMIT }] },
+        text: 'limit',
+      },
+    });
+
+    await distribute({ ...baseArgs, asc, log });
+
+    const warning = log.log.mock.calls.flat().find((line) => String(line).includes('::warning'));
+    expect(warning).toBeDefined();
+    expect(warning).toContain('1314');
+  });
+
+  it('still attaches when the build was already submitted for review', async () => {
+    const { asc } = makeAsc({
+      'POST /betaAppReviewSubmissions': {
+        status: 409,
+        json: { errors: [{ code: 'STATE_ERROR' }] },
+        text: 'already',
+      },
+    });
+
+    const result = await distribute({ ...baseArgs, asc });
+    expect(result).toEqual({ submit: 'skipped', attach: 'attached' });
+  });
+
+  it('throws on a genuinely failed review submission', async () => {
+    const { asc } = makeAsc({
+      'POST /betaAppReviewSubmissions': {
+        status: 401,
+        json: { errors: [{ code: 'NOT_AUTHORIZED' }] },
+        text: 'nope',
+      },
+    });
+
+    await expect(distribute({ ...baseArgs, asc })).rejects.toThrow(DistributionError);
+  });
+
+  it('throws when the named tester group does not exist', async () => {
+    const { asc } = makeAsc({
+      'GET /betaGroups': { status: 200, json: { data: [] }, text: '{}' },
+    });
+
+    await expect(distribute({ ...baseArgs, asc })).rejects.toThrow(/no tester group named/);
+  });
+
+  it('throws when the build fails processing', async () => {
+    const { asc } = makeAsc({
+      'GET /builds?': {
+        status: 200,
+        json: { data: [{ id: 'b', attributes: { processingState: 'INVALID' } }] },
+        text: '{}',
+      },
+    });
+
+    await expect(distribute({ ...baseArgs, asc })).rejects.toThrow(/ended in INVALID/);
+  });
+
+  it('gives up once the processing deadline passes', async () => {
+    const { asc } = makeAsc({
+      'GET /builds?': {
+        status: 200,
+        json: { data: [{ id: 'b', attributes: { processingState: 'PROCESSING' } }] },
+        text: '{}',
+      },
+    });
+    let clock = 0;
+    const now = () => {
+      clock += 60_000;
+      return clock;
+    };
+
+    await expect(
+      distribute({ ...baseArgs, asc, timeoutMinutes: 1, now })
+    ).rejects.toThrow(/still PROCESSING/);
+  });
+});
+
+describe('main', () => {
+  it('soft-skips with exit 0 when no tester group is configured', async () => {
+    expect(await main({}, silentLog)).toBe(0);
+  });
+
+  it('fails when a required credential is missing', async () => {
+    const code = await main({ SLICC_TF_EXTERNAL_GROUP: 'External Testers' }, silentLog);
+    expect(code).toBe(1);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -232,6 +232,18 @@ export default defineConfig({
         },
       },
       {
+        // ios-app is an SPM package, not an npm workspace; its Swift code is
+        // covered by the xcodebuild gate. The release-side .mjs scripts
+        // (testflight-distribute.mjs) have no Swift coverage, so co-located
+        // *.test.mjs run under this dedicated project — same shape as
+        // swift-launcher above.
+        extends: true,
+        test: {
+          name: 'ios-app',
+          include: ['packages/ios-app/scripts/*.test.mjs'],
+        },
+      },
+      {
         // Claude Code hook scripts in .claude/hooks/ are plain .mjs, not a
         // workspace. Co-located *.test.mjs so `npm test` covers them.
         extends: true,


### PR DESCRIPTION
## Summary

Beta App Review submission and tester-group attach are independent steps, but `testflight-distribute.mjs` aborted between them. When build 1314 hit Apple's Beta App Review submission limit on 2026-08-06, the script exited at step 3 and the build was left in **no tester group at all** — so it could not reach external testers even once Apple's review capacity returned. It now classifies the submission response, treats capacity exhaustion as a deferral rather than a failure, and always performs the group attach.

## Why

Investigating why external TestFlight was stuck at build 1313 surfaced this in the release log for [run 31059138240](https://github.com/ai-ecoverse/slicc/actions/runs/31059138240):

```
What to Test notes set.
error: Beta App Review submission failed (HTTP 422):
  "code" : "ENTITY_UNPROCESSABLE.SUBMISSION_LIMIT_REACHED",
```

Two separate problems in one line:

1. **Ordering.** Review runs against a *version string*; group membership is a property of the *build*. A build sitting in its group waiting for review is exactly the state we want when review is deferred — it ships the moment approval lands, with no further run. Exiting first strands it.
2. **Classification.** The submission quota is a capacity condition, not a broken release. The ipa uploaded, is `VALID`, and is already live for internal testers. Failing the step made a normal condition read as a pipeline break.

Root cause of the exhaustion itself is out of scope here: semantic-release stamps a new marketing version on every merge and Apple requires a fresh review per version string, so the pipeline spends one submission per merge. Measured on this app, six submissions were accepted in 9.4 h and the seventh was refused 40 min later — that is the app's entire submission history, so the quota looks like ~6 per rolling 24 h. Pacing that cadence is a follow-up; we're watching it for a few more days before picking an interval.

## Approach / Implementation notes

- `classifySubmitOutcome` returns `submitted` / `skipped` / `deferred` / `fatal`. Only `fatal` aborts. `deferred` emits a `::warning::` and exits 0.
- Capacity is matched on the distinctive `SUBMISSION_LIMIT_REACHED` **suffix** plus HTTP 429, not the full dotted code — Apple has moved codes between prefixes before, and a prefix change silently reclassifying capacity as fatal would reintroduce exactly this bug.
- The group attach now always runs. Attaching an unapproved build is safe: the pre-existing idempotency contract (`STATE_ERROR` / 409 → benign) already covers the case where Apple rejects it.
- Restructured for testability — `distribute()` takes an injectable ASC client, `must()` throws `DistributionError` instead of calling `process.exit` inline, and a `main()` + `isMain` guard mirrors the existing pattern in `release-native.mjs`. **The CLI contract is unchanged**: soft-skip exit 0 with no group, exit 1 on missing credentials (both smoke-tested directly).
- Added an `ios-app` vitest project. `packages/ios-app` is an SPM package whose Swift is covered by the xcodebuild gate; this mirrors the existing `swift-launcher` project, which covers that package's plain `.mjs` helpers the same way.

## Cross-cutting impact

- **Floats exercised**: none at runtime — this is release tooling, invoked only from `package-and-upload-testflight.sh` during `semantic-release`. No webapp/extension/worker/Electron code path touches it.
- **Other callers**: `testflight-distribute.mjs` has exactly one caller (`package-and-upload-testflight.sh:513`), which invokes it as a subprocess and relies only on its exit code. Exit-code semantics are preserved for every pre-existing case; `deferred` is a new outcome that maps to the previously-unreachable "warn but succeed" state.
- **Release-pipeline behavior**: a deferred submission no longer trips `runNonGatingStep`'s catch in `release-native.mjs`, so the release log stops showing `iOS (TestFlight ipa) FAILED` for what is a normal capacity condition. Genuine failures still surface exactly as before.
- **Bundle size**: unaffected — nothing here is bundled.
- **Not addressed here** (deliberately): the release still only annotates rather than pages on a degraded TestFlight outcome, and there is no backfill for builds left un-submitted. Build 1314 still needs a manual resubmission.

## Test plan

- [x] `npm run verify` — all 7 checks pass
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK, 0 files on any debt list
- [x] `npm run typecheck`
- [x] `npm run test` — 13,768 passing, no new failures
- [x] `npm run test:coverage`
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — extension total JS 97.61 kB / 105 kB
- [x] **New behavior covered by unit tests** — `npx vitest run --project ios-app`, 23 tests, including a named regression case asserting the group attach still happens when the submission is deferred
- [x] CLI smoke: script run directly with no group (exit 0, soft-skip) and with a group but no credentials (exit 1)

Pre-existing / environmental, not from this change:

- `packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts > iframe integration` flakes with `Chrome exited with code null before reporting CDP port` under the full parallel `test:coverage` run on a loaded machine. It passes in isolation (282 tests) and `npm run test:coverage:webapp` gives an identical `622 passed, exit 0` both with and without this change (verified by stashing).
- A stale `node_modules` pinned `@biomejs/wasm-web` at 2.5.5 vs 2.5.6 in `package.json`, failing `biome-command.test.ts`. Resolved by `npm install`; unrelated to this change.

No UI change, so no screencast.

## Follow-ups

Not in this PR, listed so they aren't lost:

1. Pace external submissions to stay under the ~6/24 h quota (root cause).
2. Escalate degraded native/TestFlight outcomes — today `runNonGatingStep` emits a `::error` annotation but the run still concludes green and `Alert on red release` is `if: failure()`, so nobody is notified.
3. A backfill job that resubmits the newest `READY_FOR_BETA_SUBMISSION` build, which would make this self-healing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SajxiRaNArMun27ysBZHUV
