### PR TITLE
Harden the agentic memory curator: allowlist, background pass, catch-up, dated sections

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -358,7 +358,6 @@
         "packages/webapp/tests/shell/di/di.test.ts",
         "packages/webapp/tests/shell/supplemental-commands/esbuild-command.test.ts",
         "packages/webapp/tests/shell/supplemental-commands/v86-command.test.ts",
-        "packages/webapp/tests/sudo/sudo-manager.test.ts",
         "packages/webapp/tests/ui/provider-settings.test.ts",
         "packages/webcomponents/src/primitives/slicc-image-preview.stories.ts"
       ],

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -214,6 +214,15 @@ on `/scoops/<folder>/etc/sudoers`). `kind: 'secret'` cannot be persisted because
 there is no matching sudoers directive — the cone tool surfaces this as
 "approved but not persisted" so the agent retries the request next time.
 
+An "always" grant is only as durable as the folder it lands in. One-shot agents
+spawned through `AgentBridge` get a random `agent-<adjective>-<flavor>` folder
+that is dropped when the run ends, so a grant persisted into
+`/scoops/agent-<name>/etc/sudoers` dies with it and the next run starts from
+zero under a name the cone has never seen. For a recurring unattended agent such
+as the memory curator, that makes escalation a permanent interruption rather
+than a one-time cost: configure its `allowedCommands` to cover the work up
+front instead of relying on the cone to grant its way out.
+
 #### Unified enforcement (sudo is the single surface)
 
 The per-scoop sudo policy is the **single enforcement surface** for non-cone

--- a/packages/vfs-root/CLAUDE.md
+++ b/packages/vfs-root/CLAUDE.md
@@ -32,8 +32,9 @@ This file covers the default virtual filesystem payload in `packages/vfs-root/`.
   replace or remove base commands.
 - The curator may rewrite the entire `/workspace/CLAUDE.md`, and the hard character budget
   applies to the entire file with no protected region.
-- Every `##`/`###` memory section ends with a `YYYY-MM-DD` last-verified date. Each pass
-  re-verifies the oldest sections first; undated sections are maximally stale.
+- Every `##`/`###` memory section ends with a `YYYY-MM-DD` last-verified date, in UTC to match
+  archive timestamps. Each pass re-verifies the oldest sections first; undated sections are
+  maximally stale.
 
 ### Skills
 

--- a/packages/vfs-root/CLAUDE.md
+++ b/packages/vfs-root/CLAUDE.md
@@ -28,6 +28,8 @@ This file covers the default virtual filesystem payload in `packages/vfs-root/`.
 - `MEMORY.md` is user-edited only; the curator intentionally cannot rewrite its own instructions.
 - Frontmatter uses a strict YAML subset: block-array items may have `#` comment tails; inline
   entries containing commas must be quoted. A bare `/` is rejected from `writablePaths`.
+- Frontmatter `allowedCommands` entries extend the curator's built-in base set; they do not
+  replace or remove base commands.
 
 ### Skills
 

--- a/packages/vfs-root/CLAUDE.md
+++ b/packages/vfs-root/CLAUDE.md
@@ -35,6 +35,13 @@ This file covers the default virtual filesystem payload in `packages/vfs-root/`.
 - Every `##`/`###` memory section ends with a `YYYY-MM-DD` last-verified date, in UTC to match
   archive timestamps. Each pass re-verifies the oldest sections first; undated sections are
   maximally stale.
+- The curator's write grant is `/workspace/CLAUDE.md` alone, not `/workspace/`. It can run `upskill`
+  to look up a skill for a pitfall it found, and a directory-wide grant would also let it install
+  into `/workspace/skills/`. Reads still cover `/workspace/`. Single-file entries in
+  `writablePaths` work because `generateScoopSudoers` emits both the bare path and the `/**` form.
+- The pass is detached, so it spawns with `notifyOnComplete`. Its closing message reaches the cone
+  on the `scoop-notify` channel; that is where a skill suggestion lands. Without it the report is
+  discarded and the cone never learns the pass ran.
 - Turn count is what a pass costs, because every turn re-reads the whole context as a cache read.
   Two things keep it down, and both belong to the prompt rather than the runtime: `thinkingLevel`
   (default `medium`; spawned agents otherwise resolve to `off`) so the curator plans the cut

--- a/packages/vfs-root/CLAUDE.md
+++ b/packages/vfs-root/CLAUDE.md
@@ -35,6 +35,11 @@ This file covers the default virtual filesystem payload in `packages/vfs-root/`.
 - Every `##`/`###` memory section ends with a `YYYY-MM-DD` last-verified date, in UTC to match
   archive timestamps. Each pass re-verifies the oldest sections first; undated sections are
   maximally stale.
+- Turn count is what a pass costs, because every turn re-reads the whole context as a cache read.
+  Two things keep it down, and both belong to the prompt rather than the runtime: `thinkingLevel`
+  (default `medium`; spawned agents otherwise resolve to `off`) so the curator plans the cut
+  instead of converging by trial and error, and the archive reading recipes so it never `cat`s a
+  multi-megabyte archive whose `slicc:session-data` block is a single line holding half the file.
 
 ### Skills
 

--- a/packages/vfs-root/CLAUDE.md
+++ b/packages/vfs-root/CLAUDE.md
@@ -30,6 +30,10 @@ This file covers the default virtual filesystem payload in `packages/vfs-root/`.
   entries containing commas must be quoted. A bare `/` is rejected from `writablePaths`.
 - Frontmatter `allowedCommands` entries extend the curator's built-in base set; they do not
   replace or remove base commands.
+- The curator may rewrite the entire `/workspace/CLAUDE.md`, and the hard character budget
+  applies to the entire file with no protected region.
+- Every `##`/`###` memory section ends with a `YYYY-MM-DD` last-verified date. Each pass
+  re-verifies the oldest sections first; undated sections are maximally stale.
 
 ### Skills
 

--- a/packages/vfs-root/shared/MEMORY.md
+++ b/packages/vfs-root/shared/MEMORY.md
@@ -5,16 +5,25 @@ visiblePaths:
   - /sessions/
   - /shared/
 allowedCommands:
+  - awk
   - cat
+  - cut
+  - date
+  - diff
+  - echo
   - find
   - grep
   - head
   - ls
   - mkdir
   - mv
+  - printf
   - sed
+  - sort
   - tail
   - touch
+  - tr
+  - uniq
   - wc
 timeoutSeconds: 120
 ---
@@ -40,5 +49,5 @@ Add curator instructions here, for example: also update the knowledge base at /p
 
 MEMORY.md is user-edited only: the curator intentionally has read-only access to /shared/ and cannot rewrite its own instructions. A bare / is rejected in writablePaths.
 
-Frontmatter supports a strict YAML subset. Arrays may use the block form above (with optional # comment tails) or inline form such as [cat, grep]. Inline entries containing commas must be quoted, for example ["/knowledge/lars,rebecca/"].
+Frontmatter supports a strict YAML subset. Arrays may use the block form above (with optional # comment tails) or inline form such as [cat, grep]. `allowedCommands` is additive: listed commands extend the built-in base set without replacing it. Inline entries containing commas must be quoted, for example ["/knowledge/lars,rebecca/"].
 -->

--- a/packages/vfs-root/shared/MEMORY.md
+++ b/packages/vfs-root/shared/MEMORY.md
@@ -38,7 +38,7 @@ Rules:
 
 - Keep durable preferences, stable project facts, validated approaches, and named resources.
 - Organize retained information into concise per-topic sections rather than one flat list.
-- End every `##` and `###` section heading with its last-verified date in `YYYY-MM-DD` form, for example `## Deployment pipeline (2026-08-06)`.
+- End every `##` and `###` section heading with its last-verified date in `YYYY-MM-DD` form, for example `## Deployment pipeline (2026-08-06)`. Dates are UTC, matching the session archive timestamps, so a late-evening freeze west of UTC stamps the next day.
 - Stamp sections you write or confirm with today's date, {{TODAY}}.
 - Prioritize re-verifying the oldest-dated sections. Treat undated headings as maximally stale and date them on this pass.
 - Drop ephemera and duplicates. Delete or merge sections that are stale, superseded, or unverifiable.

--- a/packages/vfs-root/shared/MEMORY.md
+++ b/packages/vfs-root/shared/MEMORY.md
@@ -30,18 +30,20 @@ timeoutSeconds: 120
 
 # Memory curator
 
-Curate the durable memory for session {{SESSION_COUNT}}.
+Curate the durable memory for session {{SESSION_COUNT}}. Today's date is {{TODAY}}.
 
-Read the current memory at {{MEMORY_PATH}} if it exists, then read the archived session at {{SESSION_ARCHIVE_PATH}}. Rewrite {{MEMORY_PATH}} with the durable information worth carrying into future sessions.
+Read the entire current memory at {{MEMORY_PATH}} if it exists, then read the archived session at {{SESSION_ARCHIVE_PATH}}. Rewrite the entire {{MEMORY_PATH}} file with the durable information worth carrying into future sessions. Every part of the file is editable and counts toward the budget.
 
 Rules:
 
-- Preserve the user-authored header before the first `## Auto-extracted` heading verbatim.
 - Keep durable preferences, stable project facts, validated approaches, and named resources.
-- Organize retained information into concise per-topic sections such as `## Preferences`, `## Context`, and per-project `##` sections rather than one flat list.
-- Drop ephemera, duplicates, and superseded facts.
+- Organize retained information into concise per-topic sections rather than one flat list.
+- End every `##` and `###` section heading with its last-verified date in `YYYY-MM-DD` form, for example `## Deployment pipeline (2026-08-06)`.
+- Stamp sections you write or confirm with today's date, {{TODAY}}.
+- Prioritize re-verifying the oldest-dated sections. Treat undated headings as maximally stale and date them on this pass.
+- Drop ephemera and duplicates. Delete or merge sections that are stale, superseded, or unverifiable.
 - Preserve concrete identifiers such as file paths, URLs, IDs, and names verbatim.
-- Keep the complete file at or below {{BUDGET_CHARS}} characters.
+- Keep the entire file at or below the hard budget of {{BUDGET_CHARS}} characters, with no exempt region. When over budget, compact or remove the oldest-dated sections first.
 - Write the result to {{MEMORY_PATH}}; do not merely return it in your response.
 
 <!-- How to customize

--- a/packages/vfs-root/shared/MEMORY.md
+++ b/packages/vfs-root/shared/MEMORY.md
@@ -1,9 +1,10 @@
 ---
 writablePaths:
-  - /workspace/
+  - /workspace/CLAUDE.md
 visiblePaths:
   - /sessions/
   - /shared/
+  - /workspace/
 allowedCommands:
   - awk
   - cat
@@ -25,6 +26,7 @@ allowedCommands:
   - touch
   - tr
   - uniq
+  - upskill
   - wc
 timeoutSeconds: 120
 thinkingLevel: medium
@@ -36,30 +38,54 @@ Curate the durable memory for session {{SESSION_COUNT}}. Today's date is {{TODAY
 
 Read the entire current memory at {{MEMORY_PATH}} if it exists. Then mine the archived session at {{SESSION_ARCHIVE_PATH}} using the reading recipes below. Rewrite the entire {{MEMORY_PATH}} file with the durable information worth carrying into future sessions. Every part of the file is editable and counts toward the budget.
 
+## What to look for
+
+Three things carry across sessions, and each has its own place in the archive:
+
+| Look for        | Where it lives                                                         |
+| --------------- | ---------------------------------------------------------------------- |
+| **Preferences** | the user's own messages — how they want things done, and what to avoid |
+| **Projects**    | tool-call arguments — the paths, repos and files actually worked on    |
+| **Pitfalls**    | failed tool calls — what broke, and the error that proves it           |
+
+Pitfalls are the highest-value and most-often-lost category: a failure that cost half an hour is worth one line next time. Keep the error text that identifies it, not the stack trace.
+
 ## Reading the session archive
 
-**Never `cat` the archive and never `head` it.** Archives reach several megabytes, and the machine-readable `<!-- slicc:session-data ... -->` block is a _single line_ holding the whole session as JSON — roughly half the file. Reading it costs a fortune and tells you nothing the prose below it does not.
+**Never `cat` the archive and never `head` it.** Archives reach several megabytes, and the machine-readable `<!-- slicc:session-data ... -->` block is a _single line_ holding the whole session as JSON — roughly half the file. Reading it costs a fortune and tells you nothing the prose below it does not. Whole `### Tool` result bodies are the other half and are equally not worth reading.
 
-Check the size first, then extract only what you need:
+Check the size first, then pull the three signals separately. Together they run about 1% of the archive, so these work on a 2.5 MB file as happily as on a small one.
 
 ```bash
 wc -c {{SESSION_ARCHIVE_PATH}}
-```
 
-The prose transcript uses `## User`, `## Assistant` and `### Tool` headings. Tool blocks are the overwhelming bulk of the bytes and almost never hold durable memory, so drop them.
-
-```bash
-# 1. Orient: metadata and what the user actually asked. Usually well under 1%
-#    of the file — start here, on any archive, however large.
+# Preferences — what the user asked for, in their words.
 sed '/^<!-- slicc:session-data$/,/^-->$/d' {{SESSION_ARCHIVE_PATH}} \
   | awk '/^## User/{p=1;next} /^## (Assistant|Summary)/{p=0} /^### Tool/{p=0} p'
 
-# 2. Read the full conversation without tool output. Usually 2-4% of the file.
+# Projects — the paths touched most, which name the work.
 sed '/^<!-- slicc:session-data$/,/^-->$/d' {{SESSION_ARCHIVE_PATH}} \
-  | awk '/^### Tool/{p=0;next} /^## (User|Assistant)/{p=1} p'
+  | grep -o '/[A-Za-z0-9_][A-Za-z0-9_./-]\{3,\}' \
+  | sort | uniq -c | sort -rn | head -40
+
+# Pitfalls — failed calls with the input that caused them.
+sed '/^<!-- slicc:session-data$/,/^-->$/d' {{SESSION_ARCHIVE_PATH}} \
+  | grep -B6 '^Result:.*\(rror\|not found\|failed\|denied\|ENOENT\|fatal\)' \
+  | cut -c1-200
 ```
 
-Recipe 1 on a 2.5 MB archive returns about 5 KB; recipe 2 returns about 96 KB. Reach into a specific tool block with `grep -n` plus a bounded `sed -n 'START,ENDp'` only when a detail you need is genuinely missing from recipe 2.
+Only if something is still missing, reach into one specific block with `grep -n` plus a bounded `sed -n 'START,ENDp'`. Never widen these to the whole file.
+
+## Suggesting a skill
+
+A recurring pitfall is often a missing skill. Once you know what broke and what the work was, spend **one** lookup on it — no more, and skip it entirely when the session had no failures:
+
+```bash
+upskill search <a few words from the pitfall>
+upskill list                      # what is already installed — never suggest a duplicate
+```
+
+`upskill ai-ecoverse/skills` and `upskill adobe/skills` list a repo's skills without installing anything. **Never install.** You have no write access outside {{MEMORY_PATH}}, so an install attempt will fail or interrupt the user for approval; recommending is your job, deciding is theirs. Put any suggestion in your closing message, with the pitfall it addresses — that message is delivered to the main agent.
 
 ## Working within the budget
 
@@ -72,8 +98,9 @@ Measure, decide, then write once. Do not converge on the budget by trial and err
 
 Rules:
 
-- Keep durable preferences, stable project facts, validated approaches, and named resources.
-- Organize retained information into concise per-topic sections rather than one flat list.
+- Keep durable preferences, stable project facts, validated approaches, named resources, and the pitfalls worth not repeating.
+- Organize retained information into concise per-topic sections rather than one flat list. Let the topic lead the heading; preferences, projects and pitfalls are what to look for, not a required table of contents.
+- Write the memory file only. Do not create backups or scratch copies next to it — the file is versioned, and you have no write access anywhere else.
 - End every `##` and `###` section heading with its last-verified date in `YYYY-MM-DD` form, for example `## Deployment pipeline (2026-08-06)`. Dates are UTC, matching the session archive timestamps, so a late-evening freeze west of UTC stamps the next day.
 - Stamp sections you write or confirm with today's date, {{TODAY}}.
 - Prioritize re-verifying the oldest-dated sections. Treat undated headings as maximally stale and date them on this pass.
@@ -84,6 +111,8 @@ Rules:
 
 <!-- How to customize
 Add curator instructions here, for example: also update the knowledge base at /path following its WIKI.md. Extend visiblePaths or writablePaths above to grant access to extra stores, and adjust timeoutSeconds when needed.
+
+writablePaths defaults to the memory file alone rather than /workspace/, because the curator can run upskill and a directory-wide grant would also let it install skills into /workspace/skills. Widen it only as far as a task genuinely needs; a single file is a valid entry, not just a directory.
 
 thinkingLevel accepts off, minimal, low, medium, high, or xhigh. Curation is cheaper with reasoning than without: an unreasoned pass converges on the budget by trial and error, and because every turn re-reads the whole context, turn count is what the pass costs. Lower it to off only if you also shrink the prompt to a single mechanical instruction.
 

--- a/packages/vfs-root/shared/MEMORY.md
+++ b/packages/vfs-root/shared/MEMORY.md
@@ -27,13 +27,48 @@ allowedCommands:
   - uniq
   - wc
 timeoutSeconds: 120
+thinkingLevel: medium
 ---
 
 # Memory curator
 
 Curate the durable memory for session {{SESSION_COUNT}}. Today's date is {{TODAY}}.
 
-Read the entire current memory at {{MEMORY_PATH}} if it exists, then read the archived session at {{SESSION_ARCHIVE_PATH}}. Rewrite the entire {{MEMORY_PATH}} file with the durable information worth carrying into future sessions. Every part of the file is editable and counts toward the budget.
+Read the entire current memory at {{MEMORY_PATH}} if it exists. Then mine the archived session at {{SESSION_ARCHIVE_PATH}} using the reading recipes below. Rewrite the entire {{MEMORY_PATH}} file with the durable information worth carrying into future sessions. Every part of the file is editable and counts toward the budget.
+
+## Reading the session archive
+
+**Never `cat` the archive and never `head` it.** Archives reach several megabytes, and the machine-readable `<!-- slicc:session-data ... -->` block is a _single line_ holding the whole session as JSON — roughly half the file. Reading it costs a fortune and tells you nothing the prose below it does not.
+
+Check the size first, then extract only what you need:
+
+```bash
+wc -c {{SESSION_ARCHIVE_PATH}}
+```
+
+The prose transcript uses `## User`, `## Assistant` and `### Tool` headings. Tool blocks are the overwhelming bulk of the bytes and almost never hold durable memory, so drop them.
+
+```bash
+# 1. Orient: metadata and what the user actually asked. Usually well under 1%
+#    of the file — start here, on any archive, however large.
+sed '/^<!-- slicc:session-data$/,/^-->$/d' {{SESSION_ARCHIVE_PATH}} \
+  | awk '/^## User/{p=1;next} /^## (Assistant|Summary)/{p=0} /^### Tool/{p=0} p'
+
+# 2. Read the full conversation without tool output. Usually 2-4% of the file.
+sed '/^<!-- slicc:session-data$/,/^-->$/d' {{SESSION_ARCHIVE_PATH}} \
+  | awk '/^### Tool/{p=0;next} /^## (User|Assistant)/{p=1} p'
+```
+
+Recipe 1 on a 2.5 MB archive returns about 5 KB; recipe 2 returns about 96 KB. Reach into a specific tool block with `grep -n` plus a bounded `sed -n 'START,ENDp'` only when a detail you need is genuinely missing from recipe 2.
+
+## Working within the budget
+
+Measure, decide, then write once. Do not converge on the budget by trial and error — each attempt re-reads your whole context and is billed accordingly.
+
+1. `wc -c {{MEMORY_PATH}}` to get the current size, and subtract {{BUDGET_CHARS}} to get the exact surplus.
+2. Decide up front which sections absorb that surplus, oldest-dated first, and roughly what each one costs. Budget the whole cut before editing anything.
+3. Write the complete file once.
+4. `wc -c {{MEMORY_PATH}}` to confirm. If you are still over, cut a whole section rather than shaving a few characters at a time.
 
 Rules:
 
@@ -49,6 +84,8 @@ Rules:
 
 <!-- How to customize
 Add curator instructions here, for example: also update the knowledge base at /path following its WIKI.md. Extend visiblePaths or writablePaths above to grant access to extra stores, and adjust timeoutSeconds when needed.
+
+thinkingLevel accepts off, minimal, low, medium, high, or xhigh. Curation is cheaper with reasoning than without: an unreasoned pass converges on the budget by trial and error, and because every turn re-reads the whole context, turn count is what the pass costs. Lower it to off only if you also shrink the prompt to a single mechanical instruction.
 
 MEMORY.md is user-edited only: the curator intentionally has read-only access to /shared/ and cannot rewrite its own instructions. A bare / is rejected in writablePaths.
 

--- a/packages/vfs-root/shared/MEMORY.md
+++ b/packages/vfs-root/shared/MEMORY.md
@@ -7,6 +7,7 @@ visiblePaths:
 allowedCommands:
   - awk
   - cat
+  - cp
   - cut
   - date
   - diff

--- a/packages/vfs-root/workspace/skills/upgrade/SKILL.md
+++ b/packages/vfs-root/workspace/skills/upgrade/SKILL.md
@@ -60,7 +60,7 @@ Show the conventional-commit messages grouped by type (`feat`, `fix`, `chore`, .
 upgrade apply --from="${FROM_VERSION}" --to="${TO_VERSION}"
 ```
 
-The command discovers bundled files at both release refs under `/workspace/skills`, `/shared/sprinkles`, and `/shared/sounds`; prefetches and preflights every path; then applies safe updates with `VirtualFS` and the built-in three-way merge. Its JSON output classifies every bundled path as `auto-applied`, `merged-clean`, `kept-local`, `needs-review`, `unchanged`, or `added-new`.
+The command discovers bundled files at both release refs under `/workspace/skills`, `/shared/sprinkles`, and `/shared/sounds`, plus the single file `/shared/MEMORY.md` (the memory-curator contract, seeded only when absent — this merge is the only way a curator-rule change reaches an existing workspace); prefetches and preflights every path; then applies safe updates with `VirtualFS` and the built-in three-way merge. Its JSON output classifies every bundled path as `auto-applied`, `merged-clean`, `kept-local`, `needs-review`, `unchanged`, or `added-new`.
 
 An exit code of `1` means discovery/fetch failed or at least one path needs review. Conflicts are written to the reported collision-safe sidecar while the live file remains unchanged. Show the JSON summary and sidecar paths to the user; never copy conflict markers into the live file automatically. The command never deletes local-only files.
 
@@ -70,5 +70,5 @@ The command can also be run directly with explicit release versions for manual r
 
 - Do not run `upgrade apply` before the user confirms. Confirmation runs it automatically; dismissal runs nothing.
 - Do not delete files that no longer exist in the new release — many users name-collide their own scripts with bundled ones; deletion is too dangerous to automate.
-- Do not modify files outside `/workspace/skills/`, `/shared/sprinkles/`, and `/shared/sounds/` without the user explicitly extending the scope.
+- Do not modify files outside `/workspace/skills/`, `/shared/sprinkles/`, `/shared/sounds/`, and `/shared/MEMORY.md` without the user explicitly extending the scope.
 - Do not advance the bundled version marker yourself. The runtime advances it automatically once this lick has been routed; if the user dismisses, the lick will not fire again until the next upgrade.

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -203,15 +203,16 @@ See docs/architecture.md "Multi-Browser Sync (Tray) Architecture".
 - Path: `packages/webapp/src/core/context-compaction.ts`
 - `scoop-context.ts` passes `model.contextWindow`; compaction fires at window minus reserve,
   falling back to 200K when absent/zero.
-- Cone memory appends to `/workspace/CLAUDE.md`; agentic budget covers the whole file, while
-  legacy restructuring covers only `## Auto-extracted`.
+- Cone memory appends to `/workspace/CLAUDE.md`; the agentic budget covers the whole file, legacy
+  restructuring only `## Auto-extracted`.
 
 ### Frozen Sessions ("New session" flow)
 
 - Path: `ui/session-freezer.ts`, `ui/new-session.ts`.
 - **Save**, **Skip memory**, and **Erase** clear cone chat and non-mount `/tmp`, not scoops.
-- Archives use `/sessions/<timestamp>-<slug>.md` plus `index.json`. Idle live-kernel boot retries
-  both pending markers serially up to three times (curator flag on, legacy off).
+- Archives use `/sessions/<timestamp>-<slug>.md` plus `index.json`. Idle boot recovers both
+  pending markers serially, up to three times, through the bounded legacy enrichment call —
+  never the curator, whose unbounded multi-turn run `timeoutSeconds` cannot stop.
 - Cone-only `OffscreenClient.clearAllMessages()` awaits `clear-chat-ack` before panel reload.
 
 ### UI

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -211,8 +211,9 @@ See docs/architecture.md "Multi-Browser Sync (Tray) Architecture".
 - Path: `ui/session-freezer.ts`, `ui/new-session.ts`.
 - **Save**, **Skip memory**, and **Erase** clear cone chat and non-mount `/tmp`, not scoops.
 - Archives: `/sessions/<timestamp>-<slug>.md` plus `index.json`. `agentic-memory` writes full
-  archives before its kernel `MEMORY.md` curator. Finished failures use legacy extraction;
-  timeouts skip it to avoid racing the still-running curator. Quick/enrichment stay legacy.
+  archives with `memoryPending` before starting its kernel `MEMORY.md` curator behind the UI's
+  bounded progress race. Success clears the marker; finished failures use legacy extraction,
+  while timeouts leave it set and skip fallback. Quick/enrichment stay legacy.
 - Cone-only `OffscreenClient.clearAllMessages()` awaits `clear-chat-ack` before panel reload.
 
 ### UI

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -203,17 +203,15 @@ See docs/architecture.md "Multi-Browser Sync (Tray) Architecture".
 - Path: `packages/webapp/src/core/context-compaction.ts`
 - `scoop-context.ts` passes `model.contextWindow`; compaction fires at window minus reserve,
   falling back to 200K when absent/zero.
-- Cone memory extraction is best-effort and appends to `/workspace/CLAUDE.md`.
-  `cone-memory-budget.ts` bounds it; overflow restructures only `## Auto-extracted`.
+- Cone memory appends to `/workspace/CLAUDE.md`; agentic budget covers the whole file, while
+  legacy restructuring covers only `## Auto-extracted`.
 
 ### Frozen Sessions ("New session" flow)
 
 - Path: `ui/session-freezer.ts`, `ui/new-session.ts`.
 - **Save**, **Skip memory**, and **Erase** clear cone chat and non-mount `/tmp`, not scoops.
-- Archives: `/sessions/<timestamp>-<slug>.md` plus `index.json`. `agentic-memory` writes full
-  archives with `memoryPending` before starting its kernel `MEMORY.md` curator behind the UI's
-  bounded progress race. Success clears the marker; finished failures use legacy extraction,
-  while timeouts leave it set and skip fallback. Quick/enrichment stay legacy.
+- Archives use `/sessions/<timestamp>-<slug>.md` plus `index.json`. Idle live-kernel boot retries
+  both pending markers serially up to three times (curator flag on, legacy off).
 - Cone-only `OffscreenClient.clearAllMessages()` awaits `clear-chat-ack` before panel reload.
 
 ### UI

--- a/packages/webapp/src/scoops/agent-bridge.ts
+++ b/packages/webapp/src/scoops/agent-bridge.ts
@@ -117,6 +117,15 @@ export interface AgentSpawnOptions {
    * result in the specified schema shape.
    */
   structuredOutputSchema?: Record<string, unknown>;
+  /**
+   * Announce completion to the cone on the `scoop-notify` lick channel.
+   * Defaults to `false`: a one-shot `agent` call is synchronous for its
+   * caller, which already has the result, so notifying would duplicate it.
+   * Set this when the spawn is detached and nobody is waiting for the
+   * return value — a background pass whose report would otherwise be
+   * dropped, leaving the cone with no idea it ran.
+   */
+  notifyOnComplete?: boolean;
 }
 
 /** Result returned by {@link AgentBridge.spawn}. */
@@ -456,7 +465,7 @@ export function createAgentBridge(
       addedAt: new Date().toISOString(),
       config: scoopConfig,
       configSchemaVersion: CURRENT_SCOOP_CONFIG_VERSION,
-      notifyOnComplete: false,
+      notifyOnComplete: options.notifyOnComplete === true,
       // Propagate the invoking scoop's JID for delegation-chain reconstruction.
       // Only set when AgentSpawnOptions.parentJid is provided; never inferred.
       ...(options.parentJid !== undefined ? { parentJid: options.parentJid } : {}),

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -53,6 +53,8 @@ export interface RunAgenticMemoryPassOptions {
   vfs: Pick<LocalVfsClient, 'readFile'>;
   sessionArchivePath: string;
   sessionCount: number;
+  /** UTC date override for deterministic tests; defaults to today's date. */
+  today?: string;
   signal?: AbortSignal;
 }
 
@@ -80,6 +82,7 @@ export async function runAgenticMemoryPass(
       SESSION_ARCHIVE_PATH: opts.sessionArchivePath,
       SESSION_COUNT: String(opts.sessionCount),
       BUDGET_CHARS: String(computeBudget(opts.sessionCount)),
+      TODAY: opts.today ?? new Date().toISOString().slice(0, 10),
     });
     const spawnOptions = buildSpawnOptions(config, prompt);
     const spawnPromise = Promise.resolve().then(() => opts.spawn(spawnOptions));

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -14,9 +14,19 @@ export const MAX_MEMORY_TIMEOUT_SECONDS = 600;
 
 const DEFAULT_WRITABLE_PATHS = ['/workspace/'];
 const DEFAULT_VISIBLE_PATHS = ['/sessions/', '/shared/'];
+/**
+ * Commands the curator may run without escalating. Non-cone scoops run under
+ * `defaultDisposition: 'require-approval'`, so a command missing here does not
+ * fail — it raises a sudo request against the cone mid-conversation. The
+ * curator runs unattended and its scoop folder (and any "always" grant the
+ * cone persists into it) is destroyed when the run ends, so every gap becomes
+ * a recurring interruption that can never be granted away. Keep this list
+ * ahead of what the prompt in `vfs-root/shared/MEMORY.md` asks for.
+ */
 const DEFAULT_ALLOWED_COMMANDS = [
   'awk',
   'cat',
+  'cp',
   'cut',
   'date',
   'diff',

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -3,6 +3,7 @@ import { createLogger } from '../core/logger.js';
 import type { LocalVfsClient } from '../kernel/local-vfs-client.js';
 import type { AgentBridge, AgentSpawnOptions, AgentSpawnResult } from './agent-bridge.js';
 import { CONE_MEMORY_PATH, computeBudget } from './cone-memory-budget.js';
+import { isThinkingLevel, THINKING_LEVELS, type ThinkingLevel } from './types.js';
 
 export { DEFAULT_MEMORY_MD };
 
@@ -47,13 +48,23 @@ const DEFAULT_ALLOWED_COMMANDS = [
   'wc',
 ];
 const ARRAY_KEYS = new Set(['writablePaths', 'visiblePaths', 'allowedCommands']);
-const SCALAR_KEYS = new Set(['model', 'timeoutSeconds']);
+const SCALAR_KEYS = new Set(['model', 'timeoutSeconds', 'thinkingLevel']);
+
+/**
+ * Spawned agents resolve an absent thinking level to `'off'`. That is wrong for
+ * curation: without reasoning the curator converges on the budget by trial and
+ * error, and because every turn re-reads the whole context as a cache read, turn
+ * count is what the pass actually costs. Paying for reasoning once is cheaper
+ * than paying for the turns it removes.
+ */
+const DEFAULT_MEMORY_THINKING_LEVEL: ThinkingLevel = 'medium';
 
 interface MemoryConfig {
   writablePaths: string[];
   visiblePaths: string[];
   allowedCommands: string[];
   model?: string;
+  thinkingLevel: ThinkingLevel;
   timeoutSeconds: number;
   promptTemplate: string;
 }
@@ -152,9 +163,18 @@ function parseMemoryDocument(content: string): MemoryConfig {
       ...new Set([...DEFAULT_ALLOWED_COMMANDS, ...readArray(values, 'allowedCommands', [])]),
     ],
     ...(model ? { model } : {}),
+    thinkingLevel: readThinkingLevel(values.thinkingLevel),
     timeoutSeconds,
     promptTemplate: match[2].trim(),
   };
+}
+
+function readThinkingLevel(value: FrontmatterValue | undefined): ThinkingLevel {
+  if (value === undefined) return DEFAULT_MEMORY_THINKING_LEVEL;
+  if (typeof value !== 'string' || !isThinkingLevel(value)) {
+    throw new Error(`thinkingLevel must be one of ${THINKING_LEVELS.join(', ')}`);
+  }
+  return value;
 }
 
 function parseFrontmatter(frontmatter: string): Record<string, FrontmatterValue> {
@@ -288,6 +308,7 @@ function buildSpawnOptions(config: MemoryConfig, prompt: string): AgentSpawnOpti
     visiblePaths: config.visiblePaths,
     allowedCommands: config.allowedCommands,
     prompt,
+    thinkingLevel: config.thinkingLevel,
     ...(!inheritedModel && config.model ? { modelId: config.model } : {}),
   };
 }
@@ -300,6 +321,13 @@ function substitutePlaceholders(template: string, values: Record<string, string>
   return prompt;
 }
 
+/**
+ * Stops *waiting* on the spawn; it cannot stop the agent. `AgentSpawnOptions`
+ * carries no turn bound, deadline or signal, so a timed-out pass keeps taking
+ * turns and billing — one measured run overran its 120s timeout by 14.9x and
+ * cost $53.81. Tracked in ai-ecoverse/slicc#1972; until that lands, treat a
+ * `timeout` outcome as "still running", never as "stopped".
+ */
 function waitForSpawn(
   spawnPromise: Promise<AgentSpawnResult>,
   timeoutMs: number,

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -15,16 +15,25 @@ export const MAX_MEMORY_TIMEOUT_SECONDS = 600;
 const DEFAULT_WRITABLE_PATHS = ['/workspace/'];
 const DEFAULT_VISIBLE_PATHS = ['/sessions/', '/shared/'];
 const DEFAULT_ALLOWED_COMMANDS = [
+  'awk',
   'cat',
+  'cut',
+  'date',
+  'diff',
+  'echo',
   'find',
   'grep',
   'head',
   'ls',
   'mkdir',
   'mv',
+  'printf',
   'sed',
+  'sort',
   'tail',
   'touch',
+  'tr',
+  'uniq',
   'wc',
 ];
 const ARRAY_KEYS = new Set(['writablePaths', 'visiblePaths', 'allowedCommands']);
@@ -126,7 +135,9 @@ function parseMemoryDocument(content: string): MemoryConfig {
   return {
     writablePaths,
     visiblePaths,
-    allowedCommands: readArray(values, 'allowedCommands', DEFAULT_ALLOWED_COMMANDS),
+    allowedCommands: [
+      ...new Set([...DEFAULT_ALLOWED_COMMANDS, ...readArray(values, 'allowedCommands', [])]),
+    ],
     ...(model ? { model } : {}),
     timeoutSeconds,
     promptTemplate: match[2].trim(),

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -13,8 +13,18 @@ export const MEMORY_INSTRUCTIONS_PATH = '/shared/MEMORY.md';
 export const DEFAULT_MEMORY_TIMEOUT_SECONDS = 120;
 export const MAX_MEMORY_TIMEOUT_SECONDS = 600;
 
-const DEFAULT_WRITABLE_PATHS = ['/workspace/'];
-const DEFAULT_VISIBLE_PATHS = ['/sessions/', '/shared/'];
+/**
+ * Exactly the memory file, not `/workspace/`. The curator is given `upskill` so
+ * it can look up skills, and `upskill <owner>/<repo> --all` installs into
+ * `/workspace/skills/`, which a `/workspace/` root would have permitted. A
+ * single-file root grants the one write the curator actually needs and turns
+ * any other write — an install, a stray backup — into a cone escalation.
+ */
+const DEFAULT_WRITABLE_PATHS = [CONE_MEMORY_PATH];
+/** `/workspace/` is readable so the curator can still orient; only writes narrow. */
+const DEFAULT_VISIBLE_PATHS = ['/sessions/', '/shared/', '/workspace/'];
+/** Directory the curator starts in; `writablePaths` may be a bare file. */
+const CURATOR_CWD = '/workspace';
 /**
  * Commands the curator may run without escalating. Non-cone scoops run under
  * `defaultDisposition: 'require-approval'`, so a command missing here does not
@@ -45,6 +55,10 @@ const DEFAULT_ALLOWED_COMMANDS = [
   'touch',
   'tr',
   'uniq',
+  // Read-only skill discovery for the pitfalls it finds. Installing is not
+  // reachable: `writablePaths` grants the memory file alone, so a write into
+  // `/workspace/skills/` matches no grant and escalates instead of landing.
+  'upskill',
   'wc',
 ];
 const ARRAY_KEYS = new Set(['writablePaths', 'visiblePaths', 'allowedCommands']);
@@ -80,8 +94,12 @@ export interface RunAgenticMemoryPassOptions {
 }
 
 export type AgenticMemoryPassResult =
-  | { ok: true }
-  | { ok: false; reason: string; legacyFallbackSafe: boolean };
+  /**
+   * `report` is the curator's closing message — what it curated and any skill
+   * it found worth suggesting. The cone receives it directly over
+   * `scoop-notify`; it is surfaced here too so callers can log it.
+   */
+  { ok: true; report: string } | { ok: false; reason: string; legacyFallbackSafe: boolean };
 
 type FrontmatterValue = string | string[];
 type WaitOutcome =
@@ -124,7 +142,7 @@ export async function runAgenticMemoryPass(
         legacyFallbackSafe: true,
       };
     }
-    return { ok: true };
+    return { ok: true, report: outcome.result.finalText };
   } catch (error) {
     log.warn('Agentic memory pass failed', { error: errorText(error) });
     return { ok: false, reason: errorText(error), legacyFallbackSafe: false };
@@ -303,12 +321,16 @@ function validatePaths(paths: string[], key: string): void {
 function buildSpawnOptions(config: MemoryConfig, prompt: string): AgentSpawnOptions {
   const inheritedModel = config.model === 'parent' || config.model === 'cone';
   return {
-    cwd: config.writablePaths[0].replace(/\/+$/, '') || '/',
+    cwd: CURATOR_CWD,
     writablePaths: config.writablePaths,
     visiblePaths: config.visiblePaths,
     allowedCommands: config.allowedCommands,
     prompt,
     thinkingLevel: config.thinkingLevel,
+    // The pass is detached, so the caller's return value goes nowhere. Without
+    // this the curator's report — including any skill it found — is discarded
+    // and the cone never learns the pass happened at all.
+    notifyOnComplete: true,
     ...(!inheritedModel && config.model ? { modelId: config.model } : {}),
   };
 }

--- a/packages/webapp/src/scoops/cone-memory-budget.ts
+++ b/packages/webapp/src/scoops/cone-memory-budget.ts
@@ -1,10 +1,11 @@
 /**
  * Cone memory budget — bound the size of `/workspace/CLAUDE.md` against a
  * logarithmic budget derived from the session count, and run an LLM-driven
- * restructure pass over the auto-extracted tail when an append overshoots.
+ * legacy restructure pass over the auto-extracted tail when an append
+ * overshoots.
  *
- * The header above the first `## Auto-extracted` heading is user-authored
- * and preserved verbatim. Only the auto-extracted tail is consolidated.
+ * Agentic memory curation does not use this split: it can rewrite the entire
+ * file, and the entire file counts against the same budget.
  */
 
 import type { Api, Model, UserMessage } from '@earendil-works/pi-ai';
@@ -47,9 +48,9 @@ export function computeBudget(sessionCount: number): number {
 }
 
 /**
- * Split cone-memory content at the first `## Auto-extracted` heading. The
- * header (everything before that heading) is user-authored and preserved
- * verbatim. The tail is the entire auto-extracted region we may restructure.
+ * Split cone-memory content for the legacy append-only consolidator. That
+ * path rewrites only the auto-extracted tail and leaves the preceding content
+ * outside its narrowly scoped LLM call.
  */
 export function splitConeMemory(content: string): { header: string; autoExtracted: string } {
   const match = AUTO_EXTRACTED_HEADING_RE.exec(content);
@@ -71,7 +72,7 @@ export async function readSessionCount(vfs: LocalVfsClient): Promise<number> {
 }
 
 export interface RestructureConeMemoryOptions {
-  /** Current full file content (header + auto-extracted tail). */
+  /** Current full file content (legacy header + auto-extracted tail). */
   currentContent: string;
   /** Computed budget; only used as advisory context in the system prompt. */
   budget: number;
@@ -82,8 +83,8 @@ export interface RestructureConeMemoryOptions {
 }
 
 /**
- * Run the LLM consolidation pass over the auto-extracted tail. Returns the
- * new full file content (header preserved verbatim + consolidated tail).
+ * Run the legacy LLM consolidation pass over the auto-extracted tail. Returns
+ * the new full file content (unchanged prefix + consolidated tail).
  * Throws on LLM error or when the response is empty — callers should treat
  * any failure as best-effort and keep the unrestructured content in place.
  */

--- a/packages/webapp/src/shell/supplemental-commands/upgrade-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upgrade-command.ts
@@ -8,10 +8,15 @@ import { getFetchBodyBytes, parseFetchJson } from '../fetch-body.js';
 const REPO = 'ai-ecoverse/slicc';
 const BUNDLED_PREFIX = 'packages/vfs-root';
 const FETCH_TIMEOUT_MS = 30_000;
+// Directory prefixes plus one single-file scope. `MEMORY.md` is seeded only
+// when absent, so a curator-contract change would otherwise never reach an
+// existing workspace; the three-way merge is what makes that safe to ship,
+// since the file is meant to be user-edited.
 const SCOPES = [
   `${BUNDLED_PREFIX}/workspace/skills/`,
   `${BUNDLED_PREFIX}/shared/sprinkles/`,
   `${BUNDLED_PREFIX}/shared/sounds/`,
+  `${BUNDLED_PREFIX}/shared/MEMORY.md`,
 ] as const;
 const CLASSIFICATIONS = [
   'auto-applied',

--- a/packages/webapp/src/sudo/sudo-manager.ts
+++ b/packages/webapp/src/sudo/sudo-manager.ts
@@ -117,14 +117,26 @@ export function generateScoopSudoers(config?: ScoopConfig | null): string {
     }
   }
 
+  // Each root grants the subtree AND the bare path. Without the bare form a
+  // single-file root (e.g. `/workspace/CLAUDE.md`) would emit only
+  // `…/CLAUDE.md/**`, which never matches the file itself, so the write would
+  // escalate despite being configured. Emitting both is what lets a sandbox
+  // grant exactly one file — the way to keep a scoop out of sibling paths it
+  // must not touch, such as `/workspace/skills/`.
   for (const raw of config?.writablePaths ?? []) {
     const safe = sanitizeGrantPattern(raw);
-    if (safe) lines.push(`NOPASSWD Write ${trimTrailingSlash(safe)}/**`);
+    if (safe) {
+      lines.push(`NOPASSWD Write ${trimTrailingSlash(safe)}`);
+      lines.push(`NOPASSWD Write ${trimTrailingSlash(safe)}/**`);
+    }
   }
 
   for (const raw of config?.visiblePaths ?? []) {
     const safe = sanitizeGrantPattern(raw);
-    if (safe) lines.push(`NOPASSWD Read ${trimTrailingSlash(safe)}/**`);
+    if (safe) {
+      lines.push(`NOPASSWD Read ${trimTrailingSlash(safe)}`);
+      lines.push(`NOPASSWD Read ${trimTrailingSlash(safe)}/**`);
+    }
   }
 
   return `${lines.join('\n')}\n`;

--- a/packages/webapp/src/transcript/frozen-archive-format.ts
+++ b/packages/webapp/src/transcript/frozen-archive-format.ts
@@ -68,6 +68,12 @@ export interface FrozenSessionIndexEntry {
    */
   pendingEnrichment?: boolean;
   /**
+   * Agentic-memory marker. Set when the archive is written before its curator
+   * pass starts, then removed only after that pass succeeds. A later boot may
+   * recover entries that still carry the marker.
+   */
+  memoryPending?: true;
+  /**
    * Set to `true` when the `captureCompleteSnapshot` hook failed during
    * freeze. The Markdown archive is still present; only the full sanitized
    * transcript bundle was not produced.

--- a/packages/webapp/src/transcript/frozen-archive-format.ts
+++ b/packages/webapp/src/transcript/frozen-archive-format.ts
@@ -69,8 +69,9 @@ export interface FrozenSessionIndexEntry {
   pendingEnrichment?: boolean;
   /**
    * Agentic-memory marker. Set when the archive is written before its curator
-   * pass starts, then removed only after that pass succeeds. A later boot may
-   * recover entries that still carry the marker.
+   * pass starts, then removed only after that pass succeeds. A later boot
+   * recovers surviving entries through the bounded legacy enrichment call — it
+   * never re-runs the curator, which has no working timeout.
    */
   memoryPending?: true;
   /**

--- a/packages/webapp/src/transcript/frozen-archive-format.ts
+++ b/packages/webapp/src/transcript/frozen-archive-format.ts
@@ -74,6 +74,11 @@ export interface FrozenSessionIndexEntry {
    */
   memoryPending?: true;
   /**
+   * Number of boot-time catch-up attempts already started for either pending
+   * marker. Persisted before the LLM call; entries at the retry cap are skipped.
+   */
+  pendingAttemptCount?: number;
+  /**
    * Set to `true` when the `captureCompleteSnapshot` hook failed during
    * freeze. The Markdown archive is still present; only the full sanitized
    * transcript bundle was not produced.

--- a/packages/webapp/src/ui/new-session.ts
+++ b/packages/webapp/src/ui/new-session.ts
@@ -23,6 +23,7 @@ import {
   type FrozenSessionIndexEntry,
   freezeConeSession,
   markSnapshotUnavailable,
+  processPendingSessions,
 } from './session-freezer.js';
 
 const log = createLogger('new-session');
@@ -45,6 +46,60 @@ const DEFAULT_ENRICHMENT_RACE_MS = 20_000;
 
 /** How often the race timer reports progress (ms) to drive the spinner ring. */
 const ENRICHMENT_PROGRESS_TICK_MS = 250;
+
+export interface PendingSessionCatchupOptions {
+  openVfs: () => Promise<WritableVfsClient>;
+  agenticMemorySpawn?: AgentBridge['spawn'];
+  onComplete?: () => void;
+  schedule?: (callback: () => void) => void;
+}
+
+/** Run the boot catch-up with the current feature flag and provider credentials. */
+export async function runPendingSessionCatchup(opts: PendingSessionCatchupOptions): Promise<void> {
+  try {
+    const vfs = await opts.openVfs();
+    if (isFeatureEnabled('agentic-memory') && opts.agenticMemorySpawn) {
+      await processPendingSessions({ vfs, agenticMemorySpawn: opts.agenticMemorySpawn });
+      opts.onComplete?.();
+      return;
+    }
+
+    const apiKey = getApiKey() ?? undefined;
+    if (!apiKey) return;
+    let model: Model<Api>;
+    try {
+      model = resolveCurrentModel();
+    } catch {
+      return;
+    }
+    const headers =
+      model.provider === 'adobe'
+        ? { 'X-Session-Id': getDailyAdobeUuid(FREEZER_SESSION_ANCHOR) }
+        : undefined;
+    await processPendingSessions({ vfs, model, apiKey, headers });
+    opts.onComplete?.();
+  } catch (err) {
+    log.warn('Pending session catch-up failed (boot continues)', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/** Schedule catch-up after first paint without returning a boot-blocking promise. */
+export function schedulePendingSessionCatchup(opts: PendingSessionCatchupOptions): void {
+  const schedule = opts.schedule ?? scheduleIdle;
+  schedule(() => {
+    void runPendingSessionCatchup(opts);
+  });
+}
+
+function scheduleIdle(callback: () => void): void {
+  if (typeof globalThis.requestIdleCallback === 'function') {
+    globalThis.requestIdleCallback(callback, { timeout: 5_000 });
+    return;
+  }
+  setTimeout(callback, 0);
+}
 
 function resolveAgenticMemorySpawn(
   opts: RunNewSessionFreezeOptions

--- a/packages/webapp/src/ui/new-session.ts
+++ b/packages/webapp/src/ui/new-session.ts
@@ -49,21 +49,23 @@ const ENRICHMENT_PROGRESS_TICK_MS = 250;
 
 export interface PendingSessionCatchupOptions {
   openVfs: () => Promise<WritableVfsClient>;
-  agenticMemorySpawn?: AgentBridge['spawn'];
   onComplete?: () => void;
   schedule?: (callback: () => void) => void;
 }
 
-/** Run the boot catch-up with the current feature flag and provider credentials. */
+/**
+ * Run the boot catch-up for archives whose inline enrichment never finished.
+ *
+ * Deliberately drives only the legacy single-call enrichment. A curator pass is
+ * an unbounded multi-turn agent run — one measured pass billed $53.81 over 163
+ * turns and 30 minutes, and `timeoutSeconds` cannot stop it because
+ * `AgentSpawnOptions` has no cancellation path. Retrying that automatically on
+ * every boot multiplies the bill, so `memoryPending` archives are left for the
+ * next freeze to pick up instead.
+ */
 export async function runPendingSessionCatchup(opts: PendingSessionCatchupOptions): Promise<void> {
   try {
     const vfs = await opts.openVfs();
-    if (isFeatureEnabled('agentic-memory') && opts.agenticMemorySpawn) {
-      await processPendingSessions({ vfs, agenticMemorySpawn: opts.agenticMemorySpawn });
-      opts.onComplete?.();
-      return;
-    }
-
     const apiKey = getApiKey() ?? undefined;
     if (!apiKey) return;
     let model: Model<Api>;

--- a/packages/webapp/src/ui/new-session.ts
+++ b/packages/webapp/src/ui/new-session.ts
@@ -17,6 +17,7 @@ import { SessionStore } from '../scoops/chat-session-store.js';
 import { getDailyAdobeUuid } from '../scoops/llm-session-id.js';
 import { getApiKey, resolveCurrentModel } from './provider-settings.js';
 import {
+  curateFrozenSessionMemories,
   enrichPendingSession,
   type FrozenSession,
   type FrozenSessionIndexEntry,
@@ -90,6 +91,39 @@ async function runAgenticMemoryFreeze(
       }
     }
   }
+  const curator = curateFrozenSessionMemories(
+    {
+      sessionStore,
+      vfs: opts.vfs,
+      mode: 'full',
+      model,
+      apiKey,
+      headers,
+      agenticMemorySpawn: spawn,
+    },
+    frozen
+  ).catch((err) => {
+    log.warn('Agentic memory curator threw (entry stays pending)', {
+      filename: frozen.filename,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  });
+  const winner = await raceEnrichmentAgainstTimer(
+    curator,
+    opts.enrichmentRaceMs ?? DEFAULT_ENRICHMENT_RACE_MS,
+    opts.onProgress
+  );
+  if (winner.kind === 'llm') {
+    return winner.updated ? { ...winner.updated, archive: frozen.archive } : frozen;
+  }
+  void curator.then((updated) => {
+    log.info('Background agentic memory curator resolved after race window', {
+      filename: frozen.filename,
+      memoryPending: updated ? updated.memoryPending === true : true,
+    });
+    opts.onBackgroundEnriched?.(updated);
+  });
   return frozen;
 }
 

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -77,6 +77,9 @@ const MEMORY_MAX_TOKENS = 2048;
 /** Max output tokens for the title call — a short label. */
 const TITLE_MAX_TOKENS = 40;
 
+/** Permanently skip a pending archive after this many boot-time attempts. */
+export const PENDING_SESSION_ATTEMPT_LIMIT = 3;
+
 /** Where per-freeze attachments land beneath the sessions dir. */
 const SESSION_ATTACHMENTS_DIR = `${SESSIONS_DIR}/attachments`;
 
@@ -199,7 +202,7 @@ export async function curateFrozenSessionMemories(
     };
   }
   if (result.ok) {
-    const updated = await clearMemoryPending(opts.vfs, frozen.filename);
+    const updated = await clearPendingMarkers(opts.vfs, frozen.filename);
     if (!updated) {
       log.warn('Agentic memory pass completed but pending marker could not be cleared', {
         filename: frozen.filename,
@@ -763,16 +766,99 @@ async function updateSessionsIndex(
 }
 
 /**
- * Subset of the sessions index that still needs the LLM-driven enrichment
- * pass (memory extraction + title rewrite). Returns `[]` when the index
- * is missing, empty, or malformed — never throws. Read-only, so typed
- * against `LocalVfsClient`.
+ * Subset of the sessions index that still needs either legacy enrichment or
+ * agentic-memory curation. Entries at the retry cap are permanently skipped.
+ * Returns `[]` when the index is missing, empty, or malformed — never throws.
  */
 export async function listPendingEnrichments(
   vfs: LocalVfsClient
 ): Promise<FrozenSessionIndexEntry[]> {
   const all = await readSessionsIndex(vfs);
-  return all.filter((e) => e.pendingEnrichment === true);
+  return all.filter(
+    (entry) =>
+      (entry.pendingEnrichment === true || entry.memoryPending === true) &&
+      pendingAttemptCount(entry) < PENDING_SESSION_ATTEMPT_LIMIT
+  );
+}
+
+export interface ProcessPendingSessionsOptions {
+  vfs: WritableVfsClient;
+  model?: Model<Api>;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  /** Presence selects the agentic-memory curator path. */
+  agenticMemorySpawn?: AgentBridge['spawn'];
+}
+
+export interface PendingSessionProcessingResult {
+  attempted: number;
+  completed: number;
+}
+
+/**
+ * Process every eligible pending archive serially. Attempts are persisted
+ * before work starts so reloads and permanently failing archives cannot cause
+ * an unbounded LLM call on every boot. Best-effort: this function never throws.
+ */
+export async function processPendingSessions(
+  opts: ProcessPendingSessionsOptions
+): Promise<PendingSessionProcessingResult> {
+  const result = { attempted: 0, completed: 0 };
+  if (!opts.agenticMemorySpawn && (!opts.model || !opts.apiKey)) return result;
+  try {
+    const entries = await listPendingEnrichments(opts.vfs);
+    for (const listedEntry of entries) {
+      try {
+        const entry = await recordPendingAttempt(opts.vfs, listedEntry.filename);
+        if (!entry) continue;
+        result.attempted += 1;
+        const updated = opts.agenticMemorySpawn
+          ? await runPendingAgenticMemoryPass(opts.vfs, entry, opts.agenticMemorySpawn)
+          : await enrichPendingSession(opts.vfs, entry, {
+              model: opts.model!,
+              apiKey: opts.apiKey!,
+              headers: opts.headers,
+            });
+        if (updated) result.completed += 1;
+      } catch (err) {
+        log.warn('Pending session catch-up attempt failed', {
+          filename: listedEntry.filename,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  } catch (err) {
+    log.warn('Pending session catch-up failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  return result;
+}
+
+async function runPendingAgenticMemoryPass(
+  vfs: WritableVfsClient,
+  entry: FrozenSessionIndexEntry,
+  spawn: AgentBridge['spawn']
+): Promise<FrozenSessionIndexEntry | null> {
+  const result = await runAgenticMemoryPass({
+    spawn,
+    vfs,
+    sessionArchivePath: frozenSessionPath(entry),
+    sessionCount: await readSessionCount(vfs),
+  });
+  if (!result.ok) {
+    log.warn('Pending agentic memory pass failed (entry stays pending)', {
+      filename: entry.filename,
+      reason: result.reason,
+    });
+    return null;
+  }
+  return clearPendingMarkers(vfs, entry.filename);
+}
+
+function pendingAttemptCount(entry: FrozenSessionIndexEntry): number {
+  const count = entry.pendingAttemptCount;
+  return typeof count === 'number' && Number.isInteger(count) && count > 0 ? count : 0;
 }
 
 export interface EnrichPendingSessionOptions {
@@ -813,7 +899,7 @@ export async function enrichPendingSession(
   opts: EnrichPendingSessionOptions
 ): Promise<FrozenSessionIndexEntry | null> {
   // 1. Idempotency guard — entry no longer pending, nothing to do.
-  if (!entry.pendingEnrichment) {
+  if (!entry.pendingEnrichment && !entry.memoryPending) {
     return null;
   }
   const archiveContent = await readPendingArchive(vfs, entry);
@@ -1028,6 +1114,7 @@ async function commitEnrichedArchive(
     ...(entry.models ? { models: entry.models } : {}),
     ...(entry.sessionId ? { sessionId: entry.sessionId } : {}),
     ...(resolvedIcon ? { icon: resolvedIcon } : {}),
+    ...(entry.completeSnapshotUnavailable ? { completeSnapshotUnavailable: true } : {}),
   };
   try {
     await replaceIndexEntry(vfs, entry.filename, updatedEntry);
@@ -1092,8 +1179,8 @@ function rewriteArchiveTitle(content: string, newTitle: string): string {
  */
 let indexWriteChain: Promise<void> = Promise.resolve();
 
-/** Clear the agentic-memory marker without racing other index mutations. */
-async function clearMemoryPending(
+/** Clear every catch-up marker and its attempt counter after successful work. */
+async function clearPendingMarkers(
   vfs: WritableVfsClient,
   filename: string
 ): Promise<FrozenSessionIndexEntry | null> {
@@ -1102,7 +1189,12 @@ async function clearMemoryPending(
     const existing = await readSessionsIndex(vfs);
     const index = existing.findIndex((entry) => entry.filename === filename);
     if (index === -1) return;
-    const { memoryPending: _pending, ...updatedEntry } = existing[index];
+    const {
+      memoryPending: _memoryPending,
+      pendingEnrichment: _pendingEnrichment,
+      pendingAttemptCount: _pendingAttemptCount,
+      ...updatedEntry
+    } = existing[index];
     const updated = existing.slice();
     updated[index] = updatedEntry;
     await vfs.writeFile(SESSIONS_INDEX_PATH, JSON.stringify(updated, null, 2));
@@ -1123,6 +1215,35 @@ async function clearMemoryPending(
     });
   }
   return cleared;
+}
+
+/** Persist one attempt before its LLM call, serialized with every index mutation. */
+async function recordPendingAttempt(
+  vfs: WritableVfsClient,
+  filename: string
+): Promise<FrozenSessionIndexEntry | null> {
+  let attempted: FrozenSessionIndexEntry | null = null;
+  const run = async (): Promise<void> => {
+    const existing = await readSessionsIndex(vfs);
+    const index = existing.findIndex((entry) => entry.filename === filename);
+    if (index === -1) return;
+    const current = existing[index];
+    if (!current.pendingEnrichment && !current.memoryPending) return;
+    const attempts = pendingAttemptCount(current);
+    if (attempts >= PENDING_SESSION_ATTEMPT_LIMIT) return;
+    attempted = { ...current, pendingAttemptCount: attempts + 1 };
+    const updated = existing.slice();
+    updated[index] = attempted;
+    await vfs.writeFile(SESSIONS_INDEX_PATH, JSON.stringify(updated, null, 2));
+    await vfs.flush();
+  };
+  const next = indexWriteChain.then(run, run);
+  indexWriteChain = next.then(
+    () => undefined,
+    () => undefined
+  );
+  await next;
+  return attempted;
 }
 
 /**

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -778,9 +778,9 @@ async function updateSessionsIndex(
 }
 
 /**
- * Subset of the sessions index that still needs either legacy enrichment or
- * agentic-memory curation. Entries at the retry cap are permanently skipped.
- * Returns `[]` when the index is missing, empty, or malformed — never throws.
+ * Subset of the sessions index that still needs recovery, under either pending
+ * marker. Entries at the retry cap are permanently skipped. Returns `[]` when
+ * the index is missing, empty, or malformed — never throws.
  */
 export async function listPendingEnrichments(
   vfs: LocalVfsClient
@@ -798,8 +798,6 @@ export interface ProcessPendingSessionsOptions {
   model?: Model<Api>;
   apiKey?: string;
   headers?: Record<string, string>;
-  /** Presence selects the agentic-memory curator path. */
-  agenticMemorySpawn?: AgentBridge['spawn'];
 }
 
 export interface PendingSessionProcessingResult {
@@ -808,15 +806,21 @@ export interface PendingSessionProcessingResult {
 }
 
 /**
- * Process every eligible pending archive serially. Attempts are persisted
- * before work starts so reloads and permanently failing archives cannot cause
- * an unbounded LLM call on every boot. Best-effort: this function never throws.
+ * Process every eligible pending archive serially, always through the legacy
+ * single-call enrichment — never by re-running the curator. A curator pass is an
+ * unbounded multi-turn agent run (one measured pass billed $53.81 over 163 turns
+ * and 30 minutes) and `AgentSpawnOptions` has no cancellation path, so
+ * `timeoutSeconds` cannot stop it. Recovering a `memoryPending` archive with one
+ * bounded call is the cheap substitute for re-driving that agent.
+ *
+ * Attempts are persisted before work starts so reloads and permanently failing
+ * archives cannot cause an LLM call on every boot. Best-effort: never throws.
  */
 export async function processPendingSessions(
   opts: ProcessPendingSessionsOptions
 ): Promise<PendingSessionProcessingResult> {
   const result = { attempted: 0, completed: 0 };
-  if (!opts.agenticMemorySpawn && (!opts.model || !opts.apiKey)) return result;
+  if (!opts.model || !opts.apiKey) return result;
   try {
     const entries = await listPendingEnrichments(opts.vfs);
     for (const listedEntry of entries) {
@@ -824,13 +828,11 @@ export async function processPendingSessions(
         const entry = await recordPendingAttempt(opts.vfs, listedEntry.filename);
         if (!entry) continue;
         result.attempted += 1;
-        const updated = opts.agenticMemorySpawn
-          ? await runPendingAgenticMemoryPass(opts.vfs, entry, opts.agenticMemorySpawn)
-          : await enrichPendingSession(opts.vfs, entry, {
-              model: opts.model!,
-              apiKey: opts.apiKey!,
-              headers: opts.headers,
-            });
+        const updated = await enrichPendingSession(opts.vfs, entry, {
+          model: opts.model,
+          apiKey: opts.apiKey,
+          headers: opts.headers,
+        });
         if (updated) result.completed += 1;
       } catch (err) {
         log.warn('Pending session catch-up attempt failed', {
@@ -845,27 +847,6 @@ export async function processPendingSessions(
     });
   }
   return result;
-}
-
-async function runPendingAgenticMemoryPass(
-  vfs: WritableVfsClient,
-  entry: FrozenSessionIndexEntry,
-  spawn: AgentBridge['spawn']
-): Promise<FrozenSessionIndexEntry | null> {
-  const result = await runAgenticMemoryPass({
-    spawn,
-    vfs,
-    sessionArchivePath: frozenSessionPath(entry),
-    sessionCount: await readSessionCount(vfs),
-  });
-  if (!result.ok) {
-    log.warn('Pending agentic memory pass failed (entry stays pending)', {
-      filename: entry.filename,
-      reason: result.reason,
-    });
-    return null;
-  }
-  return clearPendingMarkers(vfs, entry.filename);
 }
 
 function pendingAttemptCount(entry: FrozenSessionIndexEntry): number {

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -204,7 +204,9 @@ export async function curateFrozenSessionMemories(
   if (result.ok) {
     const updated = await clearPendingMarkers(opts.vfs, frozen.filename);
     if (!updated) {
-      log.warn('Agentic memory pass completed but pending marker could not be cleared', {
+      // The curated memory is already on disk; only the index bookkeeping
+      // missed, so there is no work left for a retry to redo.
+      log.info('Agentic memory pass completed; index entry already gone', {
         filename: frozen.filename,
       });
       return null;
@@ -214,9 +216,10 @@ export async function curateFrozenSessionMemories(
     return updated;
   }
   if (!result.legacyFallbackSafe) {
-    log.warn('Agentic memory pass unfinished — archive retained; skipping legacy extraction', {
+    log.warn('Agentic memory pass unfinished — entry stays pending for boot catch-up', {
       filename: frozen.filename,
       reason: result.reason,
+      attemptLimit: PENDING_SESSION_ATTEMPT_LIMIT,
     });
     return null;
   }
@@ -679,6 +682,15 @@ function pendingShortId(): string {
   return `${time}-${rand}`;
 }
 
+/**
+ * Whether a filename is a quick-mode draft name (and so safe to rename once
+ * the real title is known). Canonical `<timestamp>-<slug>.md` names are final:
+ * the rail, deep links, and snapshot lookups all key off them.
+ */
+function isPendingDraftFilename(filename: string): boolean {
+  return filename.startsWith('pending-');
+}
+
 async function ensureDir(vfs: WritableVfsClient, path: string): Promise<void> {
   try {
     await vfs.mkdir(path, { recursive: true });
@@ -1086,18 +1098,28 @@ async function commitEnrichedArchive(
   icon?: string
 ): Promise<FrozenSessionIndexEntry | null> {
   const oldPath = frozenSessionPath(entry);
-  const newContent = rewriteArchiveTitle(archiveContent, newTitle);
-  const newFilename = `${entry.frozenAt.replace(/[:.]/g, '-')}-${slugify(newTitle)}.md`;
+  // Only a quick-mode `pending-…md` draft carries a placeholder title and a
+  // throwaway name. A curator archive is written straight to its canonical
+  // name, so when the legacy fallback picks one up (agentic-memory toggled off
+  // before catch-up ran) retitling it would rename the file out from under
+  // deep links that already point at it.
+  const isDraft = isPendingDraftFilename(entry.filename);
+  const resolvedTitle = isDraft ? newTitle : entry.title;
+  const newFilename = isDraft
+    ? `${entry.frozenAt.replace(/[:.]/g, '-')}-${slugify(newTitle)}.md`
+    : entry.filename;
   const newPath = `${SESSIONS_DIR}/${newFilename}`;
-  try {
-    await ensureDir(vfs, SESSIONS_DIR);
-    await vfs.writeFile(newPath, newContent);
-  } catch (err) {
-    log.warn('Enrichment write failed (entry stays pending)', {
-      filename: entry.filename,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return null;
+  if (isDraft) {
+    try {
+      await ensureDir(vfs, SESSIONS_DIR);
+      await vfs.writeFile(newPath, rewriteArchiveTitle(archiveContent, resolvedTitle));
+    } catch (err) {
+      log.warn('Enrichment write failed (entry stays pending)', {
+        filename: entry.filename,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
   }
 
   // Carry a freshly-picked icon (single-click "save" path) or preserve an
@@ -1107,7 +1129,7 @@ async function commitEnrichedArchive(
   const resolvedIcon = icon ?? entry.icon;
   const updatedEntry: FrozenSessionIndexEntry = {
     filename: newFilename,
-    title: newTitle,
+    title: resolvedTitle,
     frozenAt: entry.frozenAt,
     messageCount: entry.messageCount,
     ...(entry.cost ? { cost: entry.cost } : {}),
@@ -1144,7 +1166,7 @@ async function commitEnrichedArchive(
   log.info('Pending session enriched', {
     oldFilename: entry.filename,
     newFilename,
-    title: newTitle,
+    title: resolvedTitle,
   });
   return updatedEntry;
 }

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -8,8 +8,8 @@
  *      and return null — nothing meaningful to extract or archive.
  *   3. Generate a title and icon, falling back to a heuristic title.
  *   4. Legacy mode extracts memory before writing the archive. Agentic mode
- *      writes the archive first, then lets a curator scoop rewrite memory;
- *      curator failure falls back to legacy extraction.
+ *      writes the archive with a durable pending marker; its caller starts the
+ *      curator after this function returns.
  *
  * Scoops are intentionally untouched — they survive a "New session" reset
  * so the fresh cone inherits the existing scoop roster and decides what
@@ -163,19 +163,26 @@ export async function freezeConeSession(
     (await generateTitleBestEffort(opts, agentMessages, llmEnabled)) ||
     heuristicTitle(session.messages);
   const icon = llmEnabled ? await pickIconBestEffort(opts, title) : undefined;
-  const frozen = await writeFrozenArchive(opts, session, title, mode, icon);
-  if (frozen && llmEnabled && opts.agenticMemorySpawn) {
-    await curateMemoriesBestEffort(opts, frozen, agentMessages);
-  }
-  return frozen;
+  return await writeFrozenArchive(
+    opts,
+    session,
+    title,
+    mode,
+    icon,
+    llmEnabled && Boolean(opts.agenticMemorySpawn)
+  );
 }
 
-/** Run the write-first curator, falling back to legacy extraction on failure. */
-async function curateMemoriesBestEffort(
+/**
+ * Run the curator for an already-durable archive. Success clears the durable
+ * pending marker; failure leaves it for a later recovery pass. A failure that
+ * is known to have finished retains the existing legacy-extraction fallback.
+ */
+export async function curateFrozenSessionMemories(
   opts: FreezeConeSessionOptions,
-  frozen: FrozenSession,
-  agentMessages: AgentMessage[]
-): Promise<void> {
+  frozen: FrozenSession
+): Promise<FrozenSessionIndexEntry | null> {
+  const agentMessages = toAgentMessages(frozen.archive.messages);
   let result: Awaited<ReturnType<typeof runAgenticMemoryPass>>;
   try {
     result = await runAgenticMemoryPass({
@@ -192,21 +199,30 @@ async function curateMemoriesBestEffort(
     };
   }
   if (result.ok) {
+    const updated = await clearMemoryPending(opts.vfs, frozen.filename);
+    if (!updated) {
+      log.warn('Agentic memory pass completed but pending marker could not be cleared', {
+        filename: frozen.filename,
+      });
+      return null;
+    }
+    delete frozen.memoryPending;
     log.info('Agentic memory pass completed', { filename: frozen.filename });
-    return;
+    return updated;
   }
   if (!result.legacyFallbackSafe) {
     log.warn('Agentic memory pass unfinished — archive retained; skipping legacy extraction', {
       filename: frozen.filename,
       reason: result.reason,
     });
-    return;
+    return null;
   }
   log.warn('Agentic memory pass failed after finishing — falling back to legacy extraction', {
     filename: frozen.filename,
     reason: result.reason,
   });
   await extractMemoriesBestEffort(opts, agentMessages, true);
+  return null;
 }
 
 /**
@@ -322,7 +338,8 @@ async function writeFrozenArchive(
   session: Session,
   title: string,
   mode: 'full' | 'quick',
-  icon?: string
+  icon?: string,
+  memoryPending = false
 ): Promise<FrozenSession | null> {
   const frozenAt = new Date().toISOString();
   // sessionId is generated BEFORE the filename so it is stable across
@@ -342,6 +359,7 @@ async function writeFrozenArchive(
     ...(usageSummary ?? {}),
     ...(icon ? { icon } : {}),
     ...(mode === 'quick' ? { pendingEnrichment: true } : {}),
+    ...(memoryPending ? { memoryPending: true } : {}),
   };
   try {
     await ensureDir(opts.vfs, SESSIONS_DIR);
@@ -1073,6 +1091,39 @@ function rewriteArchiveTitle(content: string, newTitle: string): string {
  * single context.
  */
 let indexWriteChain: Promise<void> = Promise.resolve();
+
+/** Clear the agentic-memory marker without racing other index mutations. */
+async function clearMemoryPending(
+  vfs: WritableVfsClient,
+  filename: string
+): Promise<FrozenSessionIndexEntry | null> {
+  let cleared: FrozenSessionIndexEntry | null = null;
+  const run = async (): Promise<void> => {
+    const existing = await readSessionsIndex(vfs);
+    const index = existing.findIndex((entry) => entry.filename === filename);
+    if (index === -1) return;
+    const { memoryPending: _pending, ...updatedEntry } = existing[index];
+    const updated = existing.slice();
+    updated[index] = updatedEntry;
+    await vfs.writeFile(SESSIONS_INDEX_PATH, JSON.stringify(updated, null, 2));
+    await vfs.flush();
+    cleared = updatedEntry;
+  };
+  const next = indexWriteChain.then(run, run);
+  indexWriteChain = next.then(
+    () => undefined,
+    () => undefined
+  );
+  try {
+    await next;
+  } catch (err) {
+    log.warn('Failed to clear agentic memory pending marker', {
+      filename,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+  return cleared;
+}
 
 /**
  * Swap one entry in the sessions index by filename. Used by the

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -2128,7 +2128,6 @@ export function attachWcClient(
       .then(({ schedulePendingSessionCatchup }) =>
         schedulePendingSessionCatchup({
           openVfs: async () => (await openVfs()).writer,
-          agenticMemorySpawn: (spawnOptions) => client.spawnAgent(spawnOptions),
           onComplete: refreshFreezer,
         })
       )

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -1652,7 +1652,7 @@ export function attachWcClient(
   client: OffscreenClient,
   log: BootStageLogger,
   options: AttachWcClientOptions = {}
-): void {
+): (() => void) | undefined {
   // Apply persisted timestamp visibility preference (both standalone + extension).
   void import('../timestamp-preference.js')
     .then(({ initTimestampPreference }) => initTimestampPreference())
@@ -2121,6 +2121,19 @@ export function attachWcClient(
   void import('../../speech/speak.js')
     .then(({ setSpeakAssetsInstanceId }) => setSpeakAssetsInstanceId(options.instanceId))
     .catch((err) => log.error('WC say warmup wiring failed', err));
+
+  if (!options.standalone) return undefined;
+  return () => {
+    void import('../new-session.js')
+      .then(({ schedulePendingSessionCatchup }) =>
+        schedulePendingSessionCatchup({
+          openVfs: async () => (await openVfs()).writer,
+          agenticMemorySpawn: (spawnOptions) => client.spawnAgent(spawnOptions),
+          onComplete: refreshFreezer,
+        })
+      )
+      .catch((err) => log.warn('Pending session catch-up scheduling failed', err));
+  };
 }
 
 /** Boot the standalone live WC shell: prelude → kernel spawn → attach. */
@@ -2221,7 +2234,7 @@ export async function mountWcUiLive(
   // extension-bridge `onLick` handler so forwarded handoff/upskill licks reach
   // the worker `LickManager`. No-op on every other CDP path.
   attachLickForwardingClient?.(host.client);
-  attachWcClient(boot, host.client, log, {
+  const schedulePendingCatchup = attachWcClient(boot, host.client, log, {
     instanceId,
     standalone: {
       browser,
@@ -2241,6 +2254,7 @@ export async function mountWcUiLive(
   // into nobody. Re-notify so boot reads (freezer rail) finally land.
   boot.wiring.notifyReady?.();
   log.info('WC live shell ready', { scoops: host.client.getScoops().length });
+  schedulePendingCatchup?.();
 
   // Auto-submit: `node-server --prompt "..."` appends `?prompt=<text>` to
   // the launch URL. Consume it exactly once now that the kernel + controller

--- a/packages/webapp/tests/kernel/transport-message-channel.test.ts
+++ b/packages/webapp/tests/kernel/transport-message-channel.test.ts
@@ -194,13 +194,14 @@ describe('createBridgeMessageChannelTransport / createPanelMessageChannelTranspo
       sessionCount: 1,
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({ ok: true, report: 'curated' });
     expect(spawn).toHaveBeenCalledOnce();
     expect(spawn).toHaveBeenCalledWith(
       expect.objectContaining({
         cwd: '/workspace',
-        writablePaths: ['/workspace/'],
-        visiblePaths: ['/sessions/', '/shared/'],
+        writablePaths: ['/workspace/CLAUDE.md'],
+        visiblePaths: ['/sessions/', '/shared/', '/workspace/'],
+        notifyOnComplete: true,
       })
     );
 

--- a/packages/webapp/tests/scoops/agentic-memory-default.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory-default.test.ts
@@ -22,7 +22,7 @@ describe('bundled MEMORY.md', () => {
         sessionArchivePath: '/sessions/frozen.md',
         sessionCount: 1,
       })
-    ).resolves.toEqual({ ok: true });
+    ).resolves.toEqual({ ok: true, report: 'done' });
     expect(spawn).toHaveBeenCalledOnce();
   });
 

--- a/packages/webapp/tests/scoops/agentic-memory.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory.test.ts
@@ -27,6 +27,7 @@ const BASE_ALLOWED_COMMANDS = [
   'touch',
   'tr',
   'uniq',
+  'upskill',
   'wc',
 ];
 
@@ -75,7 +76,7 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
       today: '2026-08-06',
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({ ok: true, report: 'done' });
     const options = spawn.mock.calls[0][0];
     expect(options).toMatchObject({
       cwd: '/workspace',
@@ -100,7 +101,7 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
       today: '2026-08-06',
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({ ok: true, report: 'done' });
     const prompt = spawn.mock.calls[0][0].prompt;
     expect(prompt).toContain("Today's date is 2026-08-06");
     expect(prompt).toContain('Every part of the file is editable and counts toward the budget');
@@ -131,7 +132,7 @@ Curate {{MEMORY_PATH}} on {{TODAY}}.`;
       today: '2026-08-06',
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({ ok: true, report: 'done' });
     expect(spawn.mock.calls[0][0].prompt).toContain('## Existing instructions');
     expect(spawn.mock.calls[0][0].prompt).toContain('Curate /workspace/CLAUDE.md on 2026-08-06.');
   });
@@ -155,7 +156,7 @@ Curate {{MEMORY_PATH}}.`;
       sessionCount: 1,
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({ ok: true, report: 'done' });
     expect(spawn.mock.calls[0][0]).toMatchObject({
       writablePaths: ['/workspace/', '/knowledge/lars,rebecca/'],
       visiblePaths: ['/sessions/', '/shared/#reference'],
@@ -177,7 +178,7 @@ Curate {{MEMORY_PATH}}.`;
       sessionCount: 1,
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({ ok: true, report: 'done' });
     expect(spawn.mock.calls[0][0].allowedCommands).toEqual(BASE_ALLOWED_COMMANDS);
   });
 
@@ -275,9 +276,9 @@ Curate {{MEMORY_PATH}}.`;
       sessionCount: 1,
     });
 
-    expect(result).toEqual({ ok: true });
+    expect(result).toEqual({ ok: true, report: 'done' });
     expect(warn).toHaveBeenCalled();
-    expect(spawn.mock.calls[0][0].writablePaths).toEqual(['/workspace/']);
+    expect(spawn.mock.calls[0][0].writablePaths).toEqual(['/workspace/CLAUDE.md']);
   });
 
   it('uses the built-in default and warns when MEMORY.md is missing', async () => {
@@ -293,10 +294,14 @@ Curate {{MEMORY_PATH}}.`;
 
     expect(result.ok).toBe(true);
     expect(warn).toHaveBeenCalled();
+    // The write grant is the memory file alone: the curator can run `upskill`,
+    // and a `/workspace/` root would also let it install into
+    // `/workspace/skills/`. `/workspace/` stays readable so it can orient.
     expect(spawn.mock.calls[0][0]).toMatchObject({
       cwd: '/workspace',
-      writablePaths: ['/workspace/'],
-      visiblePaths: ['/sessions/', '/shared/'],
+      writablePaths: ['/workspace/CLAUDE.md'],
+      visiblePaths: ['/sessions/', '/shared/', '/workspace/'],
+      notifyOnComplete: true,
     });
     expect(spawn.mock.calls[0][0].prompt).toContain(
       'Organize retained information into concise per-topic'

--- a/packages/webapp/tests/scoops/agentic-memory.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory.test.ts
@@ -201,6 +201,55 @@ Curate {{MEMORY_PATH}}.`;
     }
   );
 
+  // Spawned agents resolve an absent level to 'off'. Reasoning is what keeps the
+  // turn count (and therefore the bill) down, so the curator must never inherit
+  // that default silently.
+  it('spawns with a reasoning level by default', async () => {
+    const spawn = successSpawn();
+
+    await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs('---\nallowedCommands: [cat]\n---\nCurate {{MEMORY_PATH}}.'),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+
+    expect(spawn.mock.calls[0][0].thinkingLevel).toBe('medium');
+  });
+
+  it('honours a frontmatter thinkingLevel override', async () => {
+    const spawn = successSpawn();
+
+    await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs('---\nthinkingLevel: high\n---\nCurate {{MEMORY_PATH}}.'),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+
+    expect(spawn.mock.calls[0][0].thinkingLevel).toBe('high');
+  });
+
+  it('rejects an unknown thinkingLevel and falls back to the built-in default', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const spawn = successSpawn();
+
+    await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs('---\nthinkingLevel: turbo\n---\nCurate {{MEMORY_PATH}}.'),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+
+    expect(spawn.mock.calls[0][0].thinkingLevel).toBe('medium');
+    warn.mockRestore();
+  });
+
+  it('tells the curator not to read the archive whole', () => {
+    expect(DEFAULT_MEMORY_MD).toMatch(/Never `cat` the archive/);
+    expect(DEFAULT_MEMORY_MD).toContain('slicc:session-data');
+  });
+
   it('grants every command the seeded curator prompt is configured to use', async () => {
     const seeded = DEFAULT_MEMORY_MD.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
     const seededCommands = seeded

--- a/packages/webapp/tests/scoops/agentic-memory.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory.test.ts
@@ -9,6 +9,7 @@ const ARCHIVE_PATH = '/sessions/2026-08-05-memory.md';
 const BASE_ALLOWED_COMMANDS = [
   'awk',
   'cat',
+  'cp',
   'cut',
   'date',
   'diff',
@@ -178,6 +179,37 @@ Curate {{MEMORY_PATH}}.`;
 
     expect(result).toEqual({ ok: true });
     expect(spawn.mock.calls[0][0].allowedCommands).toEqual(BASE_ALLOWED_COMMANDS);
+  });
+
+  // Observed live: a stale workspace whose seeded MEMORY.md predates the wider
+  // list still escalated `awk`, `sort` and `echo` to the cone, which killed the
+  // run. Missing commands do not fail — they raise a sudo request — so the base
+  // set must cover them from code, independent of the on-disk frontmatter.
+  it.each(['awk', 'cp', 'echo', 'printf', 'sort'])(
+    'grants %s from the base set even when frontmatter omits it',
+    async (command) => {
+      const spawn = successSpawn();
+
+      await runAgenticMemoryPass({
+        spawn,
+        vfs: fakeVfs(`---\nallowedCommands: [cat]\n---\nCurate {{MEMORY_PATH}}.`),
+        sessionArchivePath: ARCHIVE_PATH,
+        sessionCount: 1,
+      });
+
+      expect(spawn.mock.calls[0][0].allowedCommands).toContain(command);
+    }
+  );
+
+  it('grants every command the seeded curator prompt is configured to use', async () => {
+    const seeded = DEFAULT_MEMORY_MD.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
+    const seededCommands = seeded
+      .match(/allowedCommands:\n((?:\s+-\s+\S+\n)+)/)?.[1]
+      .split('\n')
+      .map((line) => line.replace(/^\s*-\s*/, '').trim())
+      .filter(Boolean);
+    expect(seededCommands?.length).toBeGreaterThan(0);
+    expect(BASE_ALLOWED_COMMANDS).toEqual(expect.arrayContaining(seededCommands ?? []));
   });
 
   it.each([

--- a/packages/webapp/tests/scoops/agentic-memory.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory.test.ts
@@ -63,7 +63,7 @@ allowedCommands: [cat, grep, wc, custom-text]
 model: claude-sonnet-4-6
 timeoutSeconds: 45
 ---
-Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} budget={{BUDGET_CHARS}} unknown={{KEEP_ME}}`;
+Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} budget={{BUDGET_CHARS}} today={{TODAY}} unknown={{KEEP_ME}}`;
     const spawn = successSpawn();
 
     const result = await runAgenticMemoryPass({
@@ -71,6 +71,7 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
       vfs: fakeVfs(memoryMd),
       sessionArchivePath: ARCHIVE_PATH,
       sessionCount: 30,
+      today: '2026-08-06',
     });
 
     expect(result).toEqual({ ok: true });
@@ -83,8 +84,55 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
       modelId: 'claude-sonnet-4-6',
     });
     expect(options.prompt).toBe(
-      `Memory=${CONE_MEMORY_PATH} archive=${ARCHIVE_PATH} count=30 budget=${computeBudget(30)} unknown={{KEEP_ME}}`
+      `Memory=${CONE_MEMORY_PATH} archive=${ARCHIVE_PATH} count=30 budget=${computeBudget(30)} today=2026-08-06 unknown={{KEEP_ME}}`
     );
+  });
+
+  it('passes whole-file budget and freshness rules to the curator', async () => {
+    const spawn = successSpawn();
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(DEFAULT_MEMORY_MD),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 4,
+      today: '2026-08-06',
+    });
+
+    expect(result).toEqual({ ok: true });
+    const prompt = spawn.mock.calls[0][0].prompt;
+    expect(prompt).toContain("Today's date is 2026-08-06");
+    expect(prompt).toContain('Every part of the file is editable and counts toward the budget');
+    expect(prompt).toContain(
+      `hard budget of ${computeBudget(4)} characters, with no exempt region`
+    );
+    expect(prompt).toContain('Prioritize re-verifying the oldest-dated sections');
+    expect(prompt).toContain('Treat undated headings as maximally stale');
+    expect(prompt).not.toContain('Preserve the user-authored header');
+  });
+
+  it('accepts undated headings in a custom curator prompt', async () => {
+    const spawn = successSpawn();
+    const memoryMd = `---
+timeoutSeconds: 5
+---
+# Curator
+
+## Existing instructions
+
+Curate {{MEMORY_PATH}} on {{TODAY}}.`;
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(memoryMd),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+      today: '2026-08-06',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(spawn.mock.calls[0][0].prompt).toContain('## Existing instructions');
+    expect(spawn.mock.calls[0][0].prompt).toContain('Curate /workspace/CLAUDE.md on 2026-08-06.');
   });
 
   it('strips block-array comments and preserves quoted inline commas', async () => {

--- a/packages/webapp/tests/scoops/agentic-memory.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory.test.ts
@@ -6,6 +6,28 @@ import { DEFAULT_MEMORY_MD, runAgenticMemoryPass } from '../../src/scoops/agenti
 import { CONE_MEMORY_PATH, computeBudget } from '../../src/scoops/cone-memory-budget.js';
 
 const ARCHIVE_PATH = '/sessions/2026-08-05-memory.md';
+const BASE_ALLOWED_COMMANDS = [
+  'awk',
+  'cat',
+  'cut',
+  'date',
+  'diff',
+  'echo',
+  'find',
+  'grep',
+  'head',
+  'ls',
+  'mkdir',
+  'mv',
+  'printf',
+  'sed',
+  'sort',
+  'tail',
+  'touch',
+  'tr',
+  'uniq',
+  'wc',
+];
 
 function fakeVfs(content: string | Error): Pick<LocalVfsClient, 'readFile'> {
   return {
@@ -37,7 +59,7 @@ visiblePaths:
   - /sessions/
   - /shared/
   - /knowledge/
-allowedCommands: [cat, grep, wc]
+allowedCommands: [cat, grep, wc, custom-text]
 model: claude-sonnet-4-6
 timeoutSeconds: 45
 ---
@@ -57,7 +79,7 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
       cwd: '/workspace',
       writablePaths: ['/workspace/', '/knowledge/'],
       visiblePaths: ['/sessions/', '/shared/', '/knowledge/'],
-      allowedCommands: ['cat', 'grep', 'wc'],
+      allowedCommands: [...BASE_ALLOWED_COMMANDS, 'custom-text'],
       modelId: 'claude-sonnet-4-6',
     });
     expect(options.prompt).toBe(
@@ -88,8 +110,26 @@ Curate {{MEMORY_PATH}}.`;
     expect(spawn.mock.calls[0][0]).toMatchObject({
       writablePaths: ['/workspace/', '/knowledge/lars,rebecca/'],
       visiblePaths: ['/sessions/', '/shared/#reference'],
-      allowedCommands: ['cat'],
+      allowedCommands: BASE_ALLOWED_COMMANDS,
     });
+  });
+
+  it('preserves the base command set when frontmatter lists only a subset', async () => {
+    const memoryMd = `---
+allowedCommands: [cat, grep]
+---
+Curate {{MEMORY_PATH}}.`;
+    const spawn = successSpawn();
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(memoryMd),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(spawn.mock.calls[0][0].allowedCommands).toEqual(BASE_ALLOWED_COMMANDS);
   });
 
   it.each([

--- a/packages/webapp/tests/scoops/cone-memory-budget.test.ts
+++ b/packages/webapp/tests/scoops/cone-memory-budget.test.ts
@@ -93,7 +93,7 @@ describe('computeBudget', () => {
 });
 
 describe('splitConeMemory', () => {
-  it('returns the whole content as header when no auto-extracted block exists', () => {
+  it('returns the whole content as the legacy header when no auto-extracted block exists', () => {
     const content = '# User memory\n\nHand-curated notes.\n';
     expect(splitConeMemory(content)).toEqual({ header: content, autoExtracted: '' });
   });
@@ -107,7 +107,7 @@ describe('splitConeMemory', () => {
     expect(t).toBe(tail);
   });
 
-  it('emits an empty header when the file starts with the auto-extracted heading', () => {
+  it('emits an empty legacy header when the file starts with the auto-extracted heading', () => {
     const tail = '## Auto-extracted (2024-01-01)\n\n- foo\n';
     expect(splitConeMemory(tail)).toEqual({ header: '', autoExtracted: tail });
   });
@@ -144,7 +144,7 @@ describe('restructureConeMemory', () => {
     mockCompleteSimple.mockReset();
   });
 
-  it('preserves the header verbatim and replaces the auto-extracted tail with the LLM output', async () => {
+  it('leaves the prefix unchanged and replaces the auto-extracted tail with the LLM output', async () => {
     mockCompleteSimple.mockResolvedValueOnce(
       llmResponse('## Auto-extracted (consolidated)\n\n- merged fact')
     );

--- a/packages/webapp/tests/shell/supplemental-commands/upgrade-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/upgrade-command.test.ts
@@ -191,6 +191,39 @@ describe('upgrade apply', () => {
     expect(await fs.readFile(second)).toBe('second base\n');
   });
 
+  // `/shared/MEMORY.md` is the memory-curator contract. It is seeded only when
+  // absent, so this merge is the only route by which a curator-rule change
+  // reaches a workspace that already has one.
+  it('merges the curator contract at /shared/MEMORY.md while keeping local edits', async () => {
+    const path = '/shared/MEMORY.md';
+    await fs.writeFile(path, 'intro\nlocal rule\noutro\n');
+
+    const { result, json } = await run(
+      fs,
+      makeFetch({
+        'v1.0.0': { [path]: 'intro\nbase rule\noutro\n' },
+        'v2.0.0': { [path]: 'intro\nbase rule\noutro\nupstream rule\n' },
+      })
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(json.results).toEqual([{ path, status: 'merged-clean' }]);
+    expect(await fs.readFile(path)).toBe('intro\nlocal rule\noutro\nupstream rule\n');
+  });
+
+  it('ignores bundled files outside the upgrade scopes', async () => {
+    const path = '/shared/CLAUDE.md';
+    await fs.writeFile(path, 'local\n');
+
+    const { json } = await run(
+      fs,
+      makeFetch({ 'v1.0.0': { [path]: 'base\n' }, 'v2.0.0': { [path]: 'upstream\n' } })
+    );
+
+    expect(json.results).toEqual([]);
+    expect(await fs.readFile(path)).toBe('local\n');
+  });
+
   it('returns JSON and a nonzero exit for discovery errors', async () => {
     const { result, json } = await run(fs, makeFetch({ 'v1.0.0': {} }));
     expect(result.exitCode).toBe(1);

--- a/packages/webapp/tests/sudo/sudo-manager.test.ts
+++ b/packages/webapp/tests/sudo/sudo-manager.test.ts
@@ -38,8 +38,8 @@ describe('SudoManager', () => {
     watcher = new FsWatcher();
     vfs.setWatcher(watcher);
   });
-  afterEach(() => {
-    vfs.dispose?.();
+  afterEach(async () => {
+    await vfs.dispose?.();
   });
 
   it('seeds the default /etc/sudoers template and gates nothing by default', async () => {
@@ -193,6 +193,29 @@ describe('generateScoopSudoers', () => {
     expect(matchCommand(policy, 'catnap')).toBe('no-match');
   });
 
+  // A single-file writable root is how a sandbox grants one file without its
+  // siblings — the memory curator writes /workspace/CLAUDE.md but must not be
+  // able to install into /workspace/skills/. Emitting only the `/**` form made
+  // that impossible to express, since it never matches the file itself.
+  it('grants a single-file writable root without granting its directory', () => {
+    const policy = parseSudoers(
+      generateScoopSudoers({ writablePaths: ['/workspace/CLAUDE.md'], allowedCommands: ['cat'] })
+    );
+
+    expect(matchPath(policy, 'write', '/workspace/CLAUDE.md')).toBe('nopasswd-allow');
+    expect(matchPath(policy, 'write', '/workspace/skills/evil/SKILL.md')).toBe('no-match');
+    expect(matchPath(policy, 'write', '/workspace/other.md')).toBe('no-match');
+  });
+
+  it('still grants the whole subtree for a directory writable root', () => {
+    const policy = parseSudoers(
+      generateScoopSudoers({ writablePaths: ['/workspace/'], allowedCommands: ['cat'] })
+    );
+
+    expect(matchPath(policy, 'write', '/workspace')).toBe('nopasswd-allow');
+    expect(matchPath(policy, 'write', '/workspace/skills/ok/SKILL.md')).toBe('nopasswd-allow');
+  });
+
   it('emits no Cmnd grants for an explicit empty allowedCommands list', () => {
     const text = generateScoopSudoers({ allowedCommands: [] });
     expect(text).not.toMatch(/^NOPASSWD Cmnd /m);
@@ -253,8 +276,8 @@ describe('SudoManager per-scoop policy view', () => {
     watcher = new FsWatcher();
     vfs.setWatcher(watcher);
   });
-  afterEach(() => {
-    vfs.dispose?.();
+  afterEach(async () => {
+    await vfs.dispose?.();
   });
 
   it('getPolicyForScoop returns the global policy when no scoop file has been seeded', async () => {

--- a/packages/webapp/tests/ui/new-session.test.ts
+++ b/packages/webapp/tests/ui/new-session.test.ts
@@ -153,7 +153,6 @@ describe('pending session boot catch-up', () => {
     expect(() =>
       schedulePendingSessionCatchup({
         openVfs,
-        agenticMemorySpawn: vi.fn(),
         schedule: (callback) => scheduled.push(callback),
       })
     ).not.toThrow();

--- a/packages/webapp/tests/ui/new-session.test.ts
+++ b/packages/webapp/tests/ui/new-session.test.ts
@@ -29,10 +29,12 @@ vi.mock('../../src/scoops/chat-session-store.js', () => ({
 }));
 
 const mockFreezeConeSession = vi.fn();
+const mockCurateFrozenSessionMemories = vi.fn();
 const mockEnrichPendingSession = vi.fn();
 const mockMarkSnapshotUnavailable = vi.fn<(...args: unknown[]) => Promise<void>>(async () => {});
 vi.mock('../../src/ui/session-freezer.js', () => ({
   freezeConeSession: (...a: unknown[]) => mockFreezeConeSession(...a),
+  curateFrozenSessionMemories: (...a: unknown[]) => mockCurateFrozenSessionMemories(...a),
   enrichPendingSession: (...a: unknown[]) => mockEnrichPendingSession(...a),
   markSnapshotUnavailable: (...a: unknown[]) => mockMarkSnapshotUnavailable(...a),
 }));
@@ -125,6 +127,7 @@ describe('runNewSessionFreeze — write-first + race', () => {
     mockResolveCurrentModel.mockReset().mockReturnValue(fakeModel);
     mockInit.mockReset().mockResolvedValue(undefined);
     mockFreezeConeSession.mockReset().mockResolvedValue(pending);
+    mockCurateFrozenSessionMemories.mockReset();
     mockEnrichPendingSession.mockReset();
     mockPickLucideIcon.mockClear();
   });
@@ -142,13 +145,18 @@ describe('runNewSessionFreeze — write-first + race', () => {
     expect(result).not.toBeNull();
   });
 
-  it('flag on with an agent bridge requests a full agentic freeze and skips enrichment', async () => {
+  it('flag on races one curator pass after the full archive write', async () => {
     mockIsFeatureEnabled.mockReturnValue(true);
     const spawn = vi.fn(async () => ({ finalText: 'done', exitCode: 0 }));
     mockFreezeConeSession.mockResolvedValue({
       ...pending,
       filename: '2026-06-16-agentic-memory.md',
       pendingEnrichment: undefined,
+      memoryPending: true,
+    });
+    mockCurateFrozenSessionMemories.mockResolvedValue({
+      ...enriched,
+      filename: '2026-06-16-agentic-memory.md',
     });
 
     const result = await runNewSessionFreeze({
@@ -163,8 +171,40 @@ describe('runNewSessionFreeze — write-first + race', () => {
     expect(freezeOptions).toMatchObject({ mode: 'full', model: fakeModel, apiKey: 'k' });
     await freezeOptions.agenticMemorySpawn({} as never);
     expect(spawn).toHaveBeenCalledOnce();
+    expect(mockCurateFrozenSessionMemories).toHaveBeenCalledOnce();
+    expect(mockFreezeConeSession.mock.invocationCallOrder[0]).toBeLessThan(
+      mockCurateFrozenSessionMemories.mock.invocationCallOrder[0]
+    );
     expect(mockEnrichPendingSession).not.toHaveBeenCalled();
-    expect(result?.pendingEnrichment).toBeUndefined();
+    expect(result?.memoryPending).toBeUndefined();
+  });
+
+  it('agentic timer leaves the marker while one curator pass finishes in the background', async () => {
+    mockIsFeatureEnabled.mockReturnValue(true);
+    const frozen = {
+      ...pending,
+      filename: '2026-06-16-agentic-memory.md',
+      pendingEnrichment: undefined,
+      memoryPending: true as const,
+    };
+    mockFreezeConeSession.mockResolvedValue(frozen);
+    const deferredCurator = deferred<FrozenSessionIndexEntry | null>();
+    mockCurateFrozenSessionMemories.mockReturnValue(deferredCurator.promise);
+    const onBackgroundEnriched = vi.fn();
+
+    const result = await runNewSessionFreeze({
+      vfs: {} as never,
+      enrichmentRaceMs: 10,
+      agenticMemorySpawn: vi.fn(),
+      onBackgroundEnriched,
+    });
+
+    expect(result?.memoryPending).toBe(true);
+    expect(mockCurateFrozenSessionMemories).toHaveBeenCalledOnce();
+    deferredCurator.resolve({ ...enriched, filename: frozen.filename });
+    await flush();
+    expect(mockCurateFrozenSessionMemories).toHaveBeenCalledOnce();
+    expect(onBackgroundEnriched).toHaveBeenCalledOnce();
   });
 
   it('flag on without an agent bridge keeps the legacy quick enrichment flow', async () => {

--- a/packages/webapp/tests/ui/new-session.test.ts
+++ b/packages/webapp/tests/ui/new-session.test.ts
@@ -31,11 +31,13 @@ vi.mock('../../src/scoops/chat-session-store.js', () => ({
 const mockFreezeConeSession = vi.fn();
 const mockCurateFrozenSessionMemories = vi.fn();
 const mockEnrichPendingSession = vi.fn();
+const mockProcessPendingSessions = vi.fn();
 const mockMarkSnapshotUnavailable = vi.fn<(...args: unknown[]) => Promise<void>>(async () => {});
 vi.mock('../../src/ui/session-freezer.js', () => ({
   freezeConeSession: (...a: unknown[]) => mockFreezeConeSession(...a),
   curateFrozenSessionMemories: (...a: unknown[]) => mockCurateFrozenSessionMemories(...a),
   enrichPendingSession: (...a: unknown[]) => mockEnrichPendingSession(...a),
+  processPendingSessions: (...a: unknown[]) => mockProcessPendingSessions(...a),
   markSnapshotUnavailable: (...a: unknown[]) => mockMarkSnapshotUnavailable(...a),
 }));
 
@@ -46,6 +48,8 @@ import {
   resetNewSessionTmp,
   runNewSessionFreeze,
   runNewSessionFreezeQuick,
+  runPendingSessionCatchup,
+  schedulePendingSessionCatchup,
 } from '../../src/ui/new-session.js';
 
 function deferred<T>() {
@@ -119,6 +123,47 @@ const enriched: FrozenSessionIndexEntry = {
 
 beforeEach(() => {
   mockIsFeatureEnabled.mockReset().mockReturnValue(false);
+  mockProcessPendingSessions.mockReset().mockResolvedValue({ attempted: 0, completed: 0 });
+});
+
+describe('pending session boot catch-up', () => {
+  it('uses the flag-off legacy path with current provider credentials', async () => {
+    const vfs = {} as never;
+    mockGetApiKey.mockReturnValue('k');
+    mockResolveCurrentModel.mockReturnValue(fakeModel);
+    const onComplete = vi.fn();
+
+    await runPendingSessionCatchup({ openVfs: async () => vfs, onComplete });
+
+    expect(mockProcessPendingSessions).toHaveBeenCalledWith({
+      vfs,
+      model: fakeModel,
+      apiKey: 'k',
+      headers: undefined,
+    });
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it('runs only after the idle callback and never surfaces catch-up failures', async () => {
+    mockIsFeatureEnabled.mockReturnValue(true);
+    mockProcessPendingSessions.mockRejectedValue(new Error('index write failed'));
+    const openVfs = vi.fn(async () => ({}) as never);
+    const scheduled: Array<() => void> = [];
+
+    expect(() =>
+      schedulePendingSessionCatchup({
+        openVfs,
+        agenticMemorySpawn: vi.fn(),
+        schedule: (callback) => scheduled.push(callback),
+      })
+    ).not.toThrow();
+    expect(openVfs).not.toHaveBeenCalled();
+
+    scheduled[0]();
+    await flush();
+    expect(openVfs).toHaveBeenCalledOnce();
+    expect(mockProcessPendingSessions).toHaveBeenCalledOnce();
+  });
 });
 
 describe('runNewSessionFreeze — write-first + race', () => {

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -1584,6 +1584,51 @@ describe('processPendingSessions', () => {
     expect(updated.pendingAttemptCount).toBeUndefined();
   });
 
+  it('keeps a canonical curator archive at its name when legacy enrichment runs', async () => {
+    const vfs = makeFakeVfs();
+    const frozen = await freezeConeSession({
+      sessionStore: makeFakeStore({
+        id: 'session-cone',
+        messages: [
+          userMessage('q'),
+          assistantMessage('a'),
+          userMessage('r'),
+          assistantMessage('b'),
+        ],
+        createdAt: 0,
+        updatedAt: 1,
+      }),
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      mode: 'full',
+    });
+    const canonicalName = frozen!.filename;
+    expect(canonicalName.startsWith('pending-')).toBe(false);
+    const { archive: _archive, ...index } = {
+      ...frozen!,
+      pendingEnrichment: undefined,
+      memoryPending: true as const,
+    };
+    vfs.files.set('/sessions/index.json', JSON.stringify([index]));
+    // A legacy title call still runs, but its output must not rename the file.
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('NONE')
+      .mockResolvedValueOnce('A slightly different title');
+
+    const result = await processPendingSessions({
+      vfs: vfs as unknown as Parameters<typeof processPendingSessions>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+    });
+
+    expect(result).toEqual({ attempted: 1, completed: 1 });
+    const [updated] = await readSessionsIndex(vfs as never);
+    expect(updated.filename).toBe(canonicalName);
+    expect(updated.title).toBe(frozen!.title);
+    expect(updated.memoryPending).toBeUndefined();
+    expect(updated.pendingAttemptCount).toBeUndefined();
+    expect(vfs.files.has(`/sessions/${canonicalName}`)).toBe(true);
+  });
+
   it('persists the third failed attempt and skips the archive thereafter', async () => {
     const vfs = makeFakeVfs();
     vfs.files.set(

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -1507,42 +1507,29 @@ describe('processPendingSessions', () => {
     });
   });
 
-  it('serially processes all pending marker types in one agentic catch-up pass', async () => {
+  // The boot catch-up must never re-drive a curator pass: it is an unbounded
+  // multi-turn agent run that `timeoutSeconds` cannot stop, and one measured
+  // pass billed $53.81 over 163 turns. Recovery still happens, through the
+  // single bounded legacy call.
+  it('recovers every pending marker serially without ever running the curator', async () => {
     const vfs = makeFakeVfs();
-    const entries = [
-      indexEntry('pending-one.md', { pendingEnrichment: true }),
-      indexEntry('pending-two.md', { memoryPending: true }),
-      indexEntry('pending-three.md', { pendingEnrichment: true, memoryPending: true }),
-    ];
-    vfs.files.set('/sessions/index.json', JSON.stringify(entries));
-    let active = 0;
-    let maxActive = 0;
-    mockRunAgenticMemoryPass.mockImplementation(async () => {
-      active += 1;
-      maxActive = Math.max(maxActive, active);
-      await Promise.resolve();
-      active -= 1;
-      return { ok: true };
-    });
+    vfs.files.set(
+      '/sessions/index.json',
+      JSON.stringify([
+        indexEntry('pending-one.md', { pendingEnrichment: true }),
+        indexEntry('pending-two.md', { memoryPending: true }),
+        indexEntry('pending-three.md', { pendingEnrichment: true, memoryPending: true }),
+      ])
+    );
 
     const result = await processPendingSessions({
       vfs: vfs as unknown as Parameters<typeof processPendingSessions>[0]['vfs'],
-      agenticMemorySpawn: vi.fn(),
+      model: {} as never,
+      apiKey: 'k',
     });
 
-    expect(result).toEqual({ attempted: 3, completed: 3 });
-    expect(maxActive).toBe(1);
-    expect(mockRunAgenticMemoryPass).toHaveBeenCalledTimes(3);
-    const index = await readSessionsIndex(vfs as never);
-    expect(index).toHaveLength(3);
-    expect(
-      index.every(
-        (entry) =>
-          entry.pendingEnrichment === undefined &&
-          entry.memoryPending === undefined &&
-          entry.pendingAttemptCount === undefined
-      )
-    ).toBe(true);
+    expect(result.attempted).toBe(3);
+    expect(mockRunAgenticMemoryPass).not.toHaveBeenCalled();
   });
 
   it('uses legacy enrichment for a memoryPending archive when no curator is supplied', async () => {
@@ -1637,19 +1624,16 @@ describe('processPendingSessions', () => {
         { ...indexEntry('always-fails.md', { memoryPending: true }), pendingAttemptCount: 2 },
       ])
     );
-    mockRunAgenticMemoryPass.mockResolvedValue({
-      ok: false,
-      reason: 'provider unavailable',
-      legacyFallbackSafe: false,
-    });
+    mockRunOneOffCompactionCall.mockRejectedValue(new Error('provider unavailable'));
     const opts = {
       vfs: vfs as unknown as Parameters<typeof processPendingSessions>[0]['vfs'],
-      agenticMemorySpawn: vi.fn(),
+      model: fakeModel,
+      apiKey: 'k',
     };
 
     expect(await processPendingSessions(opts)).toEqual({ attempted: 1, completed: 0 });
     expect(await processPendingSessions(opts)).toEqual({ attempted: 0, completed: 0 });
-    expect(mockRunAgenticMemoryPass).toHaveBeenCalledOnce();
+    expect(mockRunAgenticMemoryPass).not.toHaveBeenCalled();
     const [failed] = await readSessionsIndex(vfs as never);
     expect(failed).toMatchObject({ memoryPending: true, pendingAttemptCount: 3 });
     expect(await listPendingEnrichments(vfs as never)).toEqual([]);

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -54,10 +54,12 @@ import { applyDictationMarkers } from '../../src/speech/dictation-priming.js';
 import {
   curateFrozenSessionMemories,
   enrichPendingSession,
+  type FrozenSessionIndexEntry,
   freezeConeSession,
   listPendingEnrichments,
   markSnapshotUnavailable,
   parseFrozenArchive,
+  processPendingSessions,
   readSessionsIndex,
 } from '../../src/ui/session-freezer.js';
 
@@ -1441,7 +1443,7 @@ describe('listPendingEnrichments', () => {
     expect(out).toEqual([]);
   });
 
-  it('returns only the pendingEnrichment=true subset of the index', async () => {
+  it('returns both pending marker types below the retry cap', async () => {
     const vfs = makeFakeVfs();
     vfs.files.set(
       '/sessions/index.json',
@@ -1454,6 +1456,21 @@ describe('listPendingEnrichments', () => {
           pendingEnrichment: true,
         },
         {
+          filename: 'memory-pending.md',
+          title: 'memory pending',
+          frozenAt: '2026-05-13T18:00:00.000Z',
+          messageCount: 5,
+          memoryPending: true,
+        },
+        {
+          filename: 'retry-capped.md',
+          title: 'capped',
+          frozenAt: '2026-05-13T17:00:00.000Z',
+          messageCount: 5,
+          memoryPending: true,
+          pendingAttemptCount: 3,
+        },
+        {
           filename: '2026-05-12T10-00-00-000Z-done.md',
           title: 'done',
           frozenAt: '2026-05-12T10:00:00.000Z',
@@ -1464,9 +1481,133 @@ describe('listPendingEnrichments', () => {
     const out = await listPendingEnrichments(
       vfs as unknown as Parameters<typeof listPendingEnrichments>[0]
     );
-    expect(out).toHaveLength(1);
-    expect(out[0].filename).toBe('pending-abc.md');
-    expect(out[0].pendingEnrichment).toBe(true);
+    expect(out.map((entry) => entry.filename)).toEqual(['pending-abc.md', 'memory-pending.md']);
+  });
+});
+
+describe('processPendingSessions', () => {
+  const indexEntry = (
+    filename: string,
+    pending: Partial<Pick<FrozenSessionIndexEntry, 'pendingEnrichment' | 'memoryPending'>>
+  ): FrozenSessionIndexEntry => ({
+    filename,
+    title: filename,
+    frozenAt: '2026-08-06T12:00:00.000Z',
+    messageCount: 4,
+    ...pending,
+  });
+
+  beforeEach(() => {
+    mockRunAgenticMemoryPass.mockReset();
+    mockRunOneOffCompactionCall.mockReset();
+    mockReadSessionCount.mockReset().mockResolvedValue(3);
+    mockApplyConeMemoryBudget.mockReset().mockResolvedValue({
+      restructured: false,
+      reason: 'no-llm',
+    });
+  });
+
+  it('serially processes all pending marker types in one agentic catch-up pass', async () => {
+    const vfs = makeFakeVfs();
+    const entries = [
+      indexEntry('pending-one.md', { pendingEnrichment: true }),
+      indexEntry('pending-two.md', { memoryPending: true }),
+      indexEntry('pending-three.md', { pendingEnrichment: true, memoryPending: true }),
+    ];
+    vfs.files.set('/sessions/index.json', JSON.stringify(entries));
+    let active = 0;
+    let maxActive = 0;
+    mockRunAgenticMemoryPass.mockImplementation(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+      return { ok: true };
+    });
+
+    const result = await processPendingSessions({
+      vfs: vfs as unknown as Parameters<typeof processPendingSessions>[0]['vfs'],
+      agenticMemorySpawn: vi.fn(),
+    });
+
+    expect(result).toEqual({ attempted: 3, completed: 3 });
+    expect(maxActive).toBe(1);
+    expect(mockRunAgenticMemoryPass).toHaveBeenCalledTimes(3);
+    const index = await readSessionsIndex(vfs as never);
+    expect(index).toHaveLength(3);
+    expect(
+      index.every(
+        (entry) =>
+          entry.pendingEnrichment === undefined &&
+          entry.memoryPending === undefined &&
+          entry.pendingAttemptCount === undefined
+      )
+    ).toBe(true);
+  });
+
+  it('uses legacy enrichment for a memoryPending archive when no curator is supplied', async () => {
+    const vfs = makeFakeVfs();
+    const frozen = await freezeConeSession({
+      sessionStore: makeFakeStore({
+        id: 'session-cone',
+        messages: [
+          userMessage('q'),
+          assistantMessage('a'),
+          userMessage('r'),
+          assistantMessage('b'),
+        ],
+        createdAt: 0,
+        updatedAt: 1,
+      }),
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      mode: 'quick',
+    });
+    const entry = { ...frozen!, pendingEnrichment: undefined, memoryPending: true as const };
+    const { archive: _archive, ...index } = entry;
+    vfs.files.set('/sessions/index.json', JSON.stringify([index]));
+    mockRunOneOffCompactionCall
+      .mockResolvedValueOnce('NONE')
+      .mockResolvedValueOnce('Recovered archive');
+
+    const result = await processPendingSessions({
+      vfs: vfs as unknown as Parameters<typeof processPendingSessions>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+    });
+
+    expect(result).toEqual({ attempted: 1, completed: 1 });
+    expect(mockRunAgenticMemoryPass).not.toHaveBeenCalled();
+    expect(mockRunOneOffCompactionCall).toHaveBeenCalledTimes(2);
+    const [updated] = await readSessionsIndex(vfs as never);
+    expect(updated.title).toBe('Recovered archive');
+    expect(updated.memoryPending).toBeUndefined();
+    expect(updated.pendingAttemptCount).toBeUndefined();
+  });
+
+  it('persists the third failed attempt and skips the archive thereafter', async () => {
+    const vfs = makeFakeVfs();
+    vfs.files.set(
+      '/sessions/index.json',
+      JSON.stringify([
+        { ...indexEntry('always-fails.md', { memoryPending: true }), pendingAttemptCount: 2 },
+      ])
+    );
+    mockRunAgenticMemoryPass.mockResolvedValue({
+      ok: false,
+      reason: 'provider unavailable',
+      legacyFallbackSafe: false,
+    });
+    const opts = {
+      vfs: vfs as unknown as Parameters<typeof processPendingSessions>[0]['vfs'],
+      agenticMemorySpawn: vi.fn(),
+    };
+
+    expect(await processPendingSessions(opts)).toEqual({ attempted: 1, completed: 0 });
+    expect(await processPendingSessions(opts)).toEqual({ attempted: 0, completed: 0 });
+    expect(mockRunAgenticMemoryPass).toHaveBeenCalledOnce();
+    const [failed] = await readSessionsIndex(vfs as never);
+    expect(failed).toMatchObject({ memoryPending: true, pendingAttemptCount: 3 });
+    expect(await listPendingEnrichments(vfs as never)).toEqual([]);
   });
 });
 

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../src/ui/chat-panel.js', () => ({
 import type { SessionStore } from '../../src/scoops/chat-session-store.js';
 import { applyDictationMarkers } from '../../src/speech/dictation-priming.js';
 import {
+  curateFrozenSessionMemories,
   enrichPendingSession,
   freezeConeSession,
   listPendingEnrichments,
@@ -240,7 +241,7 @@ describe('freezeConeSession', () => {
     expect(vfs.files.get('/shared/CLAUDE.md')).toBeUndefined();
   });
 
-  it('writes the full archive before the agentic pass and skips legacy memory on success', async () => {
+  it('writes memoryPending before the agentic pass and clears it on success', async () => {
     mockRunOneOffCompactionCall.mockResolvedValueOnce('Agentic memory session');
     const vfs = makeFakeVfs();
     const spawn = vi.fn(async () => ({ finalText: 'done', exitCode: 0 }));
@@ -251,7 +252,7 @@ describe('freezeConeSession', () => {
       return { ok: true };
     });
 
-    const frozen = await freezeConeSession({
+    const options = {
       sessionStore: makeFakeStore({
         id: 'session-cone',
         messages: [
@@ -268,9 +269,19 @@ describe('freezeConeSession', () => {
       apiKey: 'k',
       pickIcon: async () => null,
       agenticMemorySpawn: spawn,
-    });
+    };
+    const frozen = await freezeConeSession(options);
 
     expect(frozen).not.toBeNull();
+    expect(frozen?.memoryPending).toBe(true);
+    expect(mockRunAgenticMemoryPass).not.toHaveBeenCalled();
+    expect((await readSessionsIndex(vfs as never))[0].memoryPending).toBe(true);
+
+    const updated = await curateFrozenSessionMemories(options, frozen!);
+
+    expect(updated?.memoryPending).toBeUndefined();
+    expect(frozen?.memoryPending).toBeUndefined();
+    expect((await readSessionsIndex(vfs as never))[0].memoryPending).toBeUndefined();
     expect(mockRunAgenticMemoryPass).toHaveBeenCalledOnce();
     expect(spawn).toHaveBeenCalledOnce();
     expect(mockRunOneOffCompactionCall).toHaveBeenCalledOnce();
@@ -290,6 +301,41 @@ describe('freezeConeSession', () => {
     });
     const vfs = makeFakeVfs();
 
+    const options = {
+      sessionStore: makeFakeStore({
+        id: 'session-cone',
+        messages: [
+          userMessage('q'),
+          assistantMessage('a'),
+          userMessage('r'),
+          assistantMessage('b'),
+        ],
+        createdAt: 0,
+        updatedAt: 1,
+      }),
+      vfs: vfs as unknown as Parameters<typeof freezeConeSession>[0]['vfs'],
+      model: fakeModel,
+      apiKey: 'k',
+      pickIcon: async () => null,
+      agenticMemorySpawn: vi.fn(),
+    };
+    const frozen = await freezeConeSession(options);
+    await curateFrozenSessionMemories(options, frozen!);
+
+    expect(frozen).not.toBeNull();
+    expect(mockRunOneOffCompactionCall.mock.calls.map(([arg]) => arg.instruction)).toEqual([
+      'TITLE',
+      'MEMORY',
+    ]);
+    expect(vfs.files.get('/workspace/CLAUDE.md')).toContain('durable fallback memory');
+    expect(mockApplyConeMemoryBudget).toHaveBeenCalledOnce();
+    expect(frozen?.memoryPending).toBe(true);
+    expect((await readSessionsIndex(vfs as never))[0].memoryPending).toBe(true);
+  });
+
+  it('retains persisted memoryPending when reload interrupts before curation', async () => {
+    mockRunOneOffCompactionCall.mockResolvedValueOnce('Interrupted agentic session');
+    const vfs = makeFakeVfs();
     const frozen = await freezeConeSession({
       sessionStore: makeFakeStore({
         id: 'session-cone',
@@ -309,13 +355,13 @@ describe('freezeConeSession', () => {
       agenticMemorySpawn: vi.fn(),
     });
 
-    expect(frozen).not.toBeNull();
-    expect(mockRunOneOffCompactionCall.mock.calls.map(([arg]) => arg.instruction)).toEqual([
-      'TITLE',
-      'MEMORY',
-    ]);
-    expect(vfs.files.get('/workspace/CLAUDE.md')).toContain('durable fallback memory');
-    expect(mockApplyConeMemoryBudget).toHaveBeenCalledOnce();
+    const filename = frozen!.filename;
+    delete frozen!.memoryPending;
+    const [reloaded] = await readSessionsIndex(vfs as never);
+
+    expect(reloaded).not.toBe(frozen);
+    expect(reloaded).toMatchObject({ filename, memoryPending: true });
+    expect(mockRunAgenticMemoryPass).not.toHaveBeenCalled();
   });
 
   it('skips legacy extraction when the agentic pass times out', async () => {
@@ -327,7 +373,7 @@ describe('freezeConeSession', () => {
     });
     const vfs = makeFakeVfs();
 
-    const frozen = await freezeConeSession({
+    const options = {
       sessionStore: makeFakeStore({
         id: 'session-cone',
         messages: [
@@ -344,9 +390,13 @@ describe('freezeConeSession', () => {
       apiKey: 'k',
       pickIcon: async () => null,
       agenticMemorySpawn: vi.fn(),
-    });
+    };
+    const frozen = await freezeConeSession(options);
+    await curateFrozenSessionMemories(options, frozen!);
 
     expect(frozen).not.toBeNull();
+    expect(frozen?.memoryPending).toBe(true);
+    expect((await readSessionsIndex(vfs as never))[0].memoryPending).toBe(true);
     expect(mockRunOneOffCompactionCall).toHaveBeenCalledOnce();
     expect(vfs.files.get('/workspace/CLAUDE.md')).toBeUndefined();
     expect(mockApplyConeMemoryBudget).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Hardens the agentic memory curator against four failure modes observed in real runs: it was blocked on safe commands, never picked up sessions whose enrichment had failed, ran inline and blocked the cone, and worked against a "do not edit above this line" header that does not scale. It also fixes the delivery gap that would have kept all of that from reaching anyone who already has a workspace.

Before: a curator pass could stall the cone for minutes, silently skip every `pending-*.md` archive it had already failed once, and interrupt the user with approval prompts for `awk` and `echo`. After: it runs in the background, recovers pending archives on idle boot, maintains dated re-verifiable sections under a whole-file budget, and runs its analysis commands without escalating.

Cost measurement on a live instance then reshaped the last round of this PR. A single curator pass billed **$53.81** over 163 turns and 30 minutes, so the work turned to bringing the turn count down and to making sure nothing re-runs a pass automatically.

## Why

The four problems came out of a real on-call session (311 messages, $51.61) whose memory was never extracted. I then attached to a live instance over CDP to check the fixes against actual runs, which corrected three assumptions in the original draft:

1. **Three archives had been stuck for up to 17 days**, all flagged `pendingEnrichment`, including that on-call session. Nothing retried them. → `feat(webapp): retry pending session archives on idle boot`
2. **The curator rewrote the "protected" region anyway** despite the `preserve verbatim` instruction, and grew the file 31.8% in one pass. The live file measured 133.5% of its own budget with no enforcement, because `applyConeMemoryBudget` is only reachable from the legacy append paths and never runs after a curator pass. → dated sections + whole-file budget
3. **Two curator runs escalated six shell commands to the cone** (`awk` ×2, `echo` ×3, `sort` ×1), all read-only introspection, and the cone killed one run rather than grant shell access to an agent it did not recognise. → see below.
4. **`/shared/MEMORY.md` is seeded only when absent**, so every prompt change in this PR reached only brand-new workspaces. The live instance was still running the original prompt and the narrow 11-command allowlist. → `feat(shell): merge the curator contract into existing workspaces on upgrade`
5. **One curator pass cost $53.81** — 90% of what the entire 245-turn, 18-hour cone session that spawned it cost ($59.69), for one 30-minute sub-agent run. → `perf(scoops)` + `fix(webapp): never re-run the memory curator from the boot catch-up`

| | Curator, 1 pass | Cone, 245 turns / 18 h |
| --- | --- | --- |
| Cost | **$53.81** | $59.69 |
| Turns | 163 | 245 |
| Cache reads | 94,990,089 tok ($47.50, 88%) | 38,066,411 tok |
| Cache writes | 627,925 tok | 5,909,688 tok |

627,925 written against 94,990,089 read is one large context re-read ~151 times. **Turn count is the cost**, near-linearly.

## Approach / Implementation notes

**Why the allowlist has to be complete up front.** Non-cone scoops run with `defaultDisposition: 'require-approval'`, and `AlmostBashShell` deliberately skips its registration filter in that mode so an unlisted command escalates instead of dying as "command not found". For an unattended agent that inverts the intent: every gap becomes an approval prompt in the user's live conversation. Worse, the cone cannot grant its way out. It tried, reasoning *"I should approve these operations and set reads to always-allow so it doesn't keep prompting me"*, and the grant was persisted to `/scoops/agent-dapper-strawberry/etc/sudoers` — a folder named after a random per-run `agent-<adjective>-<flavor>` pair that is dropped when the run ends. The next run arrives under a name the cone has never seen. So the base set is code (`DEFAULT_ALLOWED_COMMANDS`), unioned with the user's frontmatter rather than replaced by it, so it reaches existing installs.

Rejected: widening the sandbox or giving the curator a non-escalating disposition. The `RestrictedFS` boundary is the real control, but changing the disposition would alter the security posture for every spawned agent, which is far more than this problem needs.

**Why the upgrade path, not an overwrite.** `MEMORY.md` is meant to be user-edited, so seeding over it would destroy local rules. `upgrade apply` already does a three-way merge against the bundled file at both release refs and classifies each path; adding `MEMORY.md` as a single-file scope alongside the three directory prefixes inherits `merged-clean` / `kept-local` / sidecar-on-conflict for free. This is a deliberate scope extension, and the skill doc is updated in both places that enumerate the scopes.

**Background pass.** The curator is spawned without awaiting it, so freeze no longer blocks on curation.

**Why the cost fixes live in the prompt.** Both turn-count drivers were instructions, not runtime:

- Spawned agents resolve an absent `thinkingLevel` to `'off'`, so the curator reasoned not at all and converged on the budget by trial and error, exactly as you saw: "cut 2000 more characters", then a turn that cut 200. It now defaults to `'medium'` (overridable per workspace) and is told to measure the surplus, budget the whole cut, then write once.
- The prompt said "read the archived session". Archives reach 2.5 MB, and the `slicc:session-data` block is a **single line** holding the whole session as JSON — about half the file. The new recipes strip that block and then drop `### Tool` sections, which are the bulk of the remaining bytes and hold no durable memory. Verified against three real archives: on the 2.5 MB one, orientation returns ~5 KB (0.22%) and the full conversation without tool output ~96 KB (3.9%). One session had 34 `## User` turns against 780 `### Tool` blocks.

**Why nothing retries a pass.** `timeoutSeconds` does not work and cannot be made to work from the caller. `waitForSpawn` resolves `{type: 'timeout'}` and abandons the promise; `AgentSpawnOptions` has no turn bound, deadline or `AbortSignal`, and `spawn()` returns only a promise, so there is no handle to cancel with. The measured run overran its 120s timeout by 14.9x. The boot catch-up therefore recovers pending archives only through the bounded single-call legacy enrichment, never by re-driving the agent. Real bounds on `agent` are filed as #1972.

Rejected: pinning the curator to a cheaper model. Cache reads dominate, but the fix for that is fewer turns over less context, and curation quality matters more than the per-token rate.

## Cross-cutting impact

- **Floats exercised**: logic is in `packages/webapp` (scoops + shell), so it is shared by CLI, extension, Electron and cloud alike. No float-specific wiring.
- **Other callers of the changed contract**: `upgrade apply`'s `SCOPES` is consumed only by `runtimePath()`, which returns `null` for out-of-scope paths; a new test pins that `/shared/CLAUDE.md` stays out of scope so the addition is not read as "all of `/shared/`".
- **Persisted state**: no schema change. `MEMORY.md` gains a frontmatter entry; the whole-file budget changes what the curator writes into `/workspace/CLAUDE.md`, not how it is stored.
- **Security**: the allowlist addition is `cp`, and the commands added are read-only text utilities. Nothing widens `writablePaths` (`/workspace/` only) or `visiblePaths` (`/sessions/`, `/shared/`). The self-protection on `/etc/sudoers*` is untouched.
- **Bundle size**: no new dependencies; all 6 budgets pass.

## Test plan

- [x] `npm run verify` — 7/7 checks pass (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK, 0 changed files on any debt list
- [x] `npm run typecheck` — clean across all 9 projects
- [x] `npm run test` — 13,781 passing, no new failures
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — 6/6 budgets under limit
- [x] **New / changed behavior is covered by unit tests**: `npx vitest run packages/webapp/tests/scoops/agentic-memory.test.ts packages/webapp/tests/shell/supplemental-commands/upgrade-command.test.ts` — 29 passing. Covers each command granted from the base set when frontmatter omits it, the base set covering everything the seeded prompt is configured to use, the `MEMORY.md` three-way merge preserving local edits, and out-of-scope paths staying untouched.
- [x] Verified against a live instance over CDP: read the VFS archive index, the per-agent sudoers, and the cone's session history to confirm the diagnosis. I did **not** trigger a curator run — it costs real money and would rewrite the user's live memory file.
- [ ] N/A — no UI change, so no screencast.

**Pre-existing failures** (unrelated to this PR, now resolved upstream):

- `speech-e2e` was failing here and on every branch that triggered it since 2026-08-06. **Fixed on `main` by #1970**, now merged, and this branch is rebased onto it. Root cause was a race in `kokoro-js`'s vendored `phonemizer`: its emscripten build registers espeak's dictionaries asynchronously but publishes the instance without waiting, so a loaded-but-empty filesystem made `list_voices()` return `[]` and the one-shot language registry cached that emptiness for the page's lifetime. Load-sensitive, hence the unrelated branches. For the record, my earlier note on this PR blamed the `QuotaExceededError` in the log; #1970 disproved that with 4 GB of headroom.
- `packages/webapp/tests/speech/kokoro-voices.test.ts` fails locally only: `onnxruntime-node` ships no `darwin/arm64` `libonnxruntime.1.21.0.dylib` in this checkout. Environmental, passes in CI.
- Local coverage could not be run for the same reason, so `npm run test:coverage` is left to CI.

## Documentation

- [x] `docs/approvals.md` — documents that an "always" grant dies with an ephemeral agent's folder, so a recurring unattended agent must be configured up front rather than granted its way out
- [x] `packages/vfs-root/CLAUDE.md` — frontmatter `allowedCommands` extends the built-in base set rather than replacing it
- [x] `packages/vfs-root/workspace/skills/upgrade/SKILL.md` — `/shared/MEMORY.md` added to the documented scopes, in both the apply section and the "Do not" list
- [x] `packages/vfs-root/shared/MEMORY.md` — the curator contract itself

## Risk & rollback

- **Blast radius**: the curator runs on session freeze in every float. A bad prompt change shows up as a poor edit to `/workspace/CLAUDE.md`, not as data loss — the file is versioned in the VFS and the curator's own pass is what would be wrong.
- **Rollback**: revert cleanly. No persisted-state migration. The `upgrade` scope addition is inert until a user confirms an upgrade lick, and even then a conflict goes to a sidecar rather than the live file.
- **Worth a human check**: whether extending `upgrade apply` to a single file outside the three directory prefixes is the contract you want. The skill doc explicitly said not to modify files outside those prefixes "without the user explicitly extending the scope", and this PR is that extension.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats, I checked the followers/leader/offscreen paths

---

### Review round 1 (Claude PR Review — LGTM, 3 🔵 minor)

| Finding | Resolution |
| --- | --- |
| Log wording went stale after the retry loop was added | Reworded to match post-retry behavior |
| `TODAY` is UTC-only, so section dates can be a day off locally | Documented as UTC in `packages/vfs-root/CLAUDE.md` |
| Flag-toggle rename edge case in the legacy catch-up path | Fixed to keep canonical archive names; regression test added |

### Review round 2 (live CDP diagnosis)

| Finding | Resolution |
| --- | --- |
| Curator escalated `awk` / `echo` / `sort` to the cone, which killed a run | Base allowlist already covers all three; added `cp` and documented why the list must lead the prompt |
| "Always" grants die with the agent's random per-run scoop folder | Documented in `docs/approvals.md`; the fix is a complete allowlist, not runtime grants |
| Prompt changes reached no existing workspace | `/shared/MEMORY.md` added to the `upgrade apply` scopes |

### Review round 3 (cost measurement on a live instance)

| Finding | Resolution |
| --- | --- |
| One pass billed $53.81; 88% of it cache reads, i.e. turn count | `thinkingLevel: medium` default so it plans instead of iterating |
| Prompt told it to read a 2.5 MB archive whose data block is one line | Verified reading recipes; orientation returns 0.22% of the file |
| `timeoutSeconds` is advisory — the run overran it 14.9x and kept billing | Boot catch-up no longer re-drives the curator; bounds filed as #1972 |

### Review round 4 (what memory is actually for)

The async curator told the cone nothing: `spawn` hardcoded `notifyOnComplete: false` and the pass discarded `finalText`, so a completed curation left only a log line.

| Finding | Resolution |
| --- | --- |
| Cone never learns a background pass ran | `notifyOnComplete` opt-in on `AgentSpawnOptions`, reusing the existing `scoop-notify` channel |
| Round 3's recipes dropped all `### Tool` blocks, discarding projects *and* pitfalls | Three targeted extractions instead, ~1% of the archive |
| Curator could install skills, since `/workspace/` was its writable root | Write grant narrowed to the memory file; `generateScoopSudoers` now emits the bare path so a single-file root works at all |

Memory now targets **preferences** (user turns), **projects** (top paths by frequency) and **pitfalls** (failed calls), and spends one `upskill search` on a pitfall when the session had failures, reporting any match in the message the cone now receives.


