### PR TITLE
fix(webapp): restore one-panel-at-a-time layout and working minimize for sprinkles

### DIFF
--- a/packages/webapp/src/ui/sprinkle-manager.ts
+++ b/packages/webapp/src/ui/sprinkle-manager.ts
@@ -985,16 +985,18 @@ export class SprinkleManager implements SprinkleManagerHandle {
    * Route a rail-icon click to the right action based on current
    * state. When the sprinkle was surfaced in attention mode, promote
    * it to user-opened (`markActivated`). When it has a registered
-   * rail icon but no content yet, open it. Already-open user-driven
-   * entries get no extra work — the rail-zone toggle has already
-   * shown the panel.
+   * rail icon but no content yet, open it. An already-open sprinkle
+   * re-runs `addSprinkle` on its existing (already-rendered) container —
+   * idempotent when it's already shown, and the layout's re-place if it
+   * was minimized/parked.
    */
   async activate(name: string, zone?: string): Promise<void> {
     if (this.attentionOnly.has(name)) {
       this.markActivated(name);
       return;
     }
-    if (!this.openSprinkles.has(name)) {
+    const entry = this.openSprinkles.get(name);
+    if (!entry) {
       try {
         await this.open(name, zone);
       } catch (err) {
@@ -1003,7 +1005,12 @@ export class SprinkleManager implements SprinkleManagerHandle {
           error: err instanceof Error ? err.message : String(err),
         });
       }
+      return;
     }
+    const sprinkle = this.availableSprinkles.get(name);
+    this.callbacks.addSprinkle(name, sprinkle?.title ?? name, entry.container, zone, {
+      icon: sprinkle?.icon,
+    });
   }
 
   /** Close a sprinkle by name. */

--- a/packages/webapp/src/ui/wc/wc-sprinkles.ts
+++ b/packages/webapp/src/ui/wc/wc-sprinkles.ts
@@ -231,12 +231,26 @@ export class WcSprinkleZone {
 
   /**
    * Explicit placement (dock-rail click, `layout open`/agent-driven): place a
-   * surface into a zone. Fires `onToolPanelActivate` for a fixed tool-panel
-   * id — its own lazy-mount/poller lifecycle, distinct from the dock-tree
-   * placement itself — regardless of which caller placed it.
+   * surface into a zone. In the classic (non-panelized) dock-tree, only one
+   * non-chat surface is ever visible at a time — mirrors the pre-panels
+   * "one panel open" model, where opening anything replaced whatever was
+   * already showing. Panelized shells (a `hostSprinkleSurface` hook) run
+   * their own model and skip the collapse. Fires `onToolPanelActivate` for a
+   * fixed tool-panel id — its own lazy-mount/poller lifecycle, distinct from
+   * the dock-tree placement itself — regardless of which caller placed it.
    */
   placeSurface(zone: DockZoneName, surfaceId: string): void {
-    this.#dockTreeApi()?.placeSurface(surfaceId, zone);
+    const dockTree = this.#dockTreeApi();
+    if (dockTree && !this.#toolPanelHooks.hostSprinkleSurface) {
+      for (const other of dockTree.getSurfaceIds()) {
+        if (other !== surfaceId && other !== CHAT_SURFACE_ID) this.removeSurface(other);
+      }
+    }
+    dockTree?.placeSurface(surfaceId, zone);
+    if (!this.#toolPanelHooks.hostSprinkleSurface) {
+      const dock = this.#refs.dock as unknown as { active: string | null } | undefined;
+      if (dock) dock.active = surfaceId;
+    }
     if (isToolPanelId(surfaceId)) this.#toolPanelHooks.onToolPanelActivate?.(surfaceId);
   }
 
@@ -354,13 +368,16 @@ export class WcSprinkleZone {
       if (isNew) host(id, surface);
       return;
     }
+    // Passive attention-pulse or background session-restore adds must not
+    // steal the one visible slot — mirrors the pre-panels `#activate` skip
+    // for these two modes (see `AddSprinkleOptions`). The dock item above
+    // still registers so the rail icon is clickable; a later user click
+    // (`activate`) or `ws`-driven restore does the actual placement.
+    if (options?.attention || options?.background) return;
     // A new leaf lands in the default zone unless a drag or a restored/
     // persisted tree already placed it (`placeSurface` no-ops on a
     // duplicate surfaceId).
-    (this.#refs.dockTree as unknown as DockTreeLike | undefined)?.placeSurface(
-      id,
-      DEFAULT_TREE_ZONE
-    );
+    this.placeSurface(DEFAULT_TREE_ZONE, id);
   }
 
   #remove(name: string, opts: { keepDockItem: boolean }): void {
@@ -379,13 +396,18 @@ export class WcSprinkleZone {
   }
 
   /**
-   * Minimize just clears the dock rail's active indicator — the sprinkle's
-   * surface stays exactly where it is in the tree (every leaf is always
-   * visible now; there's no show-one state to collapse).
+   * Minimize (collapse) a sprinkle: detach its leaf from the dock-tree,
+   * parking it offstage (state preserved, not destroyed — dock-tree parking
+   * hides via `display:none` rather than unmounting) so the rail icon can
+   * reopen it later. Mirrors the pre-panels behavior, where minimizing
+   * closed the single shared "workbench body" pane. Panelized shells (a
+   * `hostSprinkleSurface` hook) manage their own hide affordance and are
+   * left untouched here.
    */
   #minimize(name: string): void {
-    void name;
     this.#refs.dock.removeAttribute('active');
+    if (this.#toolPanelHooks.hostSprinkleSurface) return;
+    this.removeSurface(sprinkleSurfaceId(name));
   }
 
   /**

--- a/packages/webapp/src/ui/wc/wc-sprinkles.ts
+++ b/packages/webapp/src/ui/wc/wc-sprinkles.ts
@@ -121,9 +121,6 @@ interface DockTreeLike {
  */
 export const CHAT_SURFACE_ID = 'chat';
 
-/** Zone a newly opened sprinkle (no drag gesture) lands in. */
-const DEFAULT_TREE_ZONE: DockZoneName = 'middle';
-
 /**
  * Dock-rail ids of the fixed tool panels — each an independent, permanently
  * mounted `<slicc-surface>` composed directly into the dock-tree (see
@@ -134,6 +131,9 @@ const TOOL_PANEL_IDS: ReadonlySet<string> = new Set(['files', 'term', 'memory', 
 
 /** Zone a tool panel lands in the first time it's opened (each one independent — no shared leaf). */
 export const DEFAULT_TOOL_ZONE: DockZoneName = 'right';
+
+/** Zone a newly opened sprinkle (no drag gesture) lands in — same zone as the tool panels, so sprinkles tab alongside VFS/terminal instead of claiming their own column. */
+const DEFAULT_TREE_ZONE: DockZoneName = DEFAULT_TOOL_ZONE;
 
 /** Whether a dock-rail id is one of the fixed tool panels (not a sprinkle). */
 export function isToolPanelId(id: string): boolean {

--- a/packages/webapp/src/ui/wc/wc-sprinkles.ts
+++ b/packages/webapp/src/ui/wc/wc-sprinkles.ts
@@ -583,13 +583,18 @@ export async function wireWcSprinkles(deps: WireWcSprinklesDeps): Promise<WcSpri
     }
   });
   // Clicking the ACTIVE dock item emits collapse (not a second select).
-  // `detail.id` gates it to tool-panel collapses so a sprinkle collapse
-  // never touches a tool panel's leaf.
+  // Tool panels detach their leaf directly; a sprinkle routes through
+  // `manager.minimize` so it goes through the same path as its own in-panel
+  // minimize button (bookkeeping stays, only the leaf gets parked).
   refs.dock.addEventListener('slicc-dock-collapse', (event) => {
     const id = (event as CustomEvent<{ id?: string }>).detail?.id;
-    if (id && isToolPanelId(id)) {
+    if (!id) return;
+    if (isToolPanelId(id)) {
       zone.removeSurface(id);
+      return;
     }
+    const name = sprinkleNameFromId(id);
+    if (name) manager.minimize(name);
   });
 
   let enriching = false;

--- a/packages/webapp/tests/ui/sprinkle-manager.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-manager.test.ts
@@ -1141,7 +1141,7 @@ describe('SprinkleManager', () => {
       expect(JSON.parse(localStorage.getItem('slicc-open-sprinkles') ?? '[]')).toEqual(['q']);
     });
 
-    it('activate is a no-op when the sprinkle is already user-opened', async () => {
+    it('activate re-places an already user-opened sprinkle (reopen after minimize)', async () => {
       await vfs.writeFile('/shared/sprinkles/dash/dash.shtml', '<title>Dash</title><div>hi</div>');
       await mgr.refresh();
       await mgr.open('dash');
@@ -1149,7 +1149,11 @@ describe('SprinkleManager', () => {
 
       await mgr.activate('dash');
 
-      expect(addSprinkle).not.toHaveBeenCalled();
+      // Re-runs addSprinkle on the SAME container (no re-fetch/re-render) so a
+      // minimized/parked sprinkle's leaf gets placed back into the layout;
+      // idempotent when it was already shown.
+      expect(addSprinkle).toHaveBeenCalledTimes(1);
+      expect(addSprinkle.mock.calls[0]?.[0]).toBe('dash');
     });
   });
 

--- a/packages/webapp/tests/ui/wc/wc-sprinkles.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-sprinkles.test.ts
@@ -624,14 +624,14 @@ describe('WcSprinkleZone / wireWcSprinkles tool panels (independent leaves)', ()
     expect(treeSpies(refs).setSurfaceSize).toHaveBeenCalledWith('files', { widthPercent: 40 });
   });
 
-  it('a sprinkle collapse does not touch the dock-tree (isToolPanelId gate)', async () => {
+  it("clicking an open sprinkle's active dock icon minimizes it (collapse routes to manager.minimize)", async () => {
     const refs = makeRefs();
     const fs = {
-      exists: async () => false,
+      exists: async () => true,
       async *walk(): AsyncGenerator<string> {
-        /* empty */
+        yield '/shared/sprinkles/hero/hero.shtml';
       },
-      readFile: async () => '',
+      readFile: async () => '<title>Hero</title><div>hi</div>',
     } as unknown as VirtualFS;
     const client = {
       sendSprinkleLick: () => {},
@@ -639,12 +639,15 @@ describe('WcSprinkleZone / wireWcSprinkles tool panels (independent leaves)', ()
       stopScoop: () => {},
     } as unknown as OffscreenClient;
     const log = { info() {}, warn() {}, error() {}, debug() {} } as unknown as BootStageLogger;
-    await wireWcSprinkles({ refs, client, fs, log });
+    const { manager } = await wireWcSprinkles({ refs, client, fs, log });
+    await manager.open('hero');
+    treeSpies(refs).removeSurface.mockClear();
 
     refs.dock.dispatchEvent(
       new CustomEvent('slicc-dock-collapse', { detail: { id: 'sprinkle:hero' }, bubbles: true })
     );
 
-    expect(treeSpies(refs).removeSurface).not.toHaveBeenCalled();
+    expect(treeSpies(refs).removeSurface).toHaveBeenCalledWith('sprinkle:hero');
+    expect(manager.opened()).toContain('hero');
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-sprinkles.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-sprinkles.test.ts
@@ -181,7 +181,7 @@ describe('WcSprinkleZone', () => {
       );
       expect(surface?.contains(element)).toBe(true);
       expect(dockIds(refs)).toContain('sprinkle:hero');
-      expect(treeSpies(refs).placeSurface).toHaveBeenCalledWith('sprinkle:hero', 'middle');
+      expect(treeSpies(refs).placeSurface).toHaveBeenCalledWith('sprinkle:hero', DEFAULT_TOOL_ZONE);
       expect(zone.isOpen('hero')).toBe(true);
     }
   );
@@ -386,7 +386,7 @@ describe('WcSprinkleZone applyLayout / placeSurface / moveSurfaceToZone', () => 
     zone.applyLayout(LAYOUT_PRESETS.focus.tree);
 
     expect(treeSpies(refs).setTree).toHaveBeenCalledWith(LAYOUT_PRESETS.focus.tree);
-    expect(treeSpies(refs).placeSurface).toHaveBeenCalledWith('sprinkle:hero', 'middle');
+    expect(treeSpies(refs).placeSurface).toHaveBeenCalledWith('sprinkle:hero', DEFAULT_TOOL_ZONE);
   });
 
   it('placeSurface forwards to the dock-tree with (surfaceId, zone) order', () => {

--- a/packages/webapp/tests/ui/wc/wc-sprinkles.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-sprinkles.test.ts
@@ -279,7 +279,7 @@ describe('WcSprinkleZone', () => {
     expect(dockIds(refs)).toContain('sprinkle:hero');
   });
 
-  it('minimize clears the dock rail active indicator without moving the surface', () => {
+  it('minimize clears the dock rail active indicator and parks the surface off the tree', () => {
     const refs = makeRefs();
     refs.dock.setAttribute('active', 'sprinkle:hero');
     const zone = new WcSprinkleZone(refs);
@@ -289,10 +289,81 @@ describe('WcSprinkleZone', () => {
     callbacks.minimizeSprinkle('hero');
 
     expect(refs.dock.hasAttribute('active')).toBe(false);
-    // The surface stays exactly where it is — no show-one state to collapse.
-    expect(
-      (refs.dockTree as unknown as HTMLElement).querySelector('[surface-id="sprinkle:hero"]')
-    ).not.toBeNull();
+    // Detached from the tree (mirrors the pre-panels "close the workbench
+    // body" behavior) but NOT destroyed or dropped from bookkeeping — the
+    // rail icon can still reopen it.
+    expect(treeSpies(refs).removeSurface).toHaveBeenCalledWith('sprinkle:hero');
+    expect(zone.isOpen('hero')).toBe(true);
+    expect(dockIds(refs)).toContain('sprinkle:hero');
+  });
+
+  it('minimize is a no-op on the dock-tree for a panelized shell (host owns hiding)', () => {
+    const refs = makeRefs();
+    const hostSprinkleSurface = vi.fn();
+    const zone = new WcSprinkleZone(refs, { hostSprinkleSurface });
+    const callbacks = zone.callbacks();
+    callbacks.addSprinkle('hero', 'Hero', document.createElement('div'));
+    treeSpies(refs).removeSurface.mockClear();
+
+    callbacks.minimizeSprinkle('hero');
+
+    expect(treeSpies(refs).removeSurface).not.toHaveBeenCalled();
+  });
+
+  it('placeSurface collapses every other non-chat surface first (one panel at a time, classic mode)', () => {
+    const refs = makeRefs();
+    treeSpies(refs).getSurfaceIds.mockReturnValue(['chat', 'files', 'sprinkle:hero']);
+    const zone = new WcSprinkleZone(refs);
+
+    zone.placeSurface('right', 'term');
+
+    expect(treeSpies(refs).removeSurface).toHaveBeenCalledWith('files');
+    expect(treeSpies(refs).removeSurface).toHaveBeenCalledWith('sprinkle:hero');
+    expect(treeSpies(refs).removeSurface).not.toHaveBeenCalledWith('chat');
+    expect(treeSpies(refs).placeSurface).toHaveBeenCalledWith('term', 'right');
+    expect((refs.dock as unknown as { active: string | null }).active).toBe('term');
+  });
+
+  it('opening a new sprinkle collapses whatever tool panel/sprinkle was showing', () => {
+    const refs = makeRefs();
+    treeSpies(refs).getSurfaceIds.mockReturnValue(['chat', 'files']);
+    const zone = new WcSprinkleZone(refs);
+    const callbacks = zone.callbacks();
+
+    callbacks.addSprinkle('hero', 'Hero', document.createElement('div'));
+
+    expect(treeSpies(refs).removeSurface).toHaveBeenCalledWith('files');
+    expect(treeSpies(refs).removeSurface).not.toHaveBeenCalledWith('chat');
+    expect(treeSpies(refs).placeSurface).toHaveBeenCalledWith('sprinkle:hero', DEFAULT_TOOL_ZONE);
+  });
+
+  it('does not collapse other surfaces in a panelized shell', () => {
+    const refs = makeRefs();
+    treeSpies(refs).getSurfaceIds.mockReturnValue(['chat', 'files']);
+    const hostSprinkleSurface = vi.fn();
+    const zone = new WcSprinkleZone(refs, { hostSprinkleSurface });
+
+    zone.placeSurface('right', 'term');
+
+    expect(treeSpies(refs).removeSurface).not.toHaveBeenCalled();
+  });
+
+  it('attention adds do not place a surface (must not steal the visible slot)', () => {
+    const refs = makeRefs();
+    const zone = new WcSprinkleZone(refs);
+    zone.callbacks().addSprinkle('hero', 'Hero', document.createElement('div'), undefined, {
+      attention: true,
+    });
+    expect(treeSpies(refs).placeSurface).not.toHaveBeenCalled();
+  });
+
+  it('background (session-restore) adds do not place a surface either', () => {
+    const refs = makeRefs();
+    const zone = new WcSprinkleZone(refs);
+    zone.callbacks().addSprinkle('pomodoro', 'Pomodoro', document.createElement('div'), undefined, {
+      background: true,
+    });
+    expect(treeSpies(refs).placeSurface).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Sprinkles were landing in an unused `middle` dock-tree zone while tool panels (VFS/terminal/memory/monitor) shared `right`, so a newly opened sprinkle always claimed its own column instead of tabbing alongside them.
- The dock-tree-collapse refactor (`58040db62`) deleted the old show-one "workbench body" without replacing its behavior: every tool panel/sprinkle became a permanently-visible independent leaf, and minimize was left clearing a dock-rail attribute with nothing left to hide.
- Clicking an already-open sprinkle's rail icon fires the dock's `collapse` event, but the handler only handled tool-panel ids, so nothing happened.

This restores, for the classic (`panel-layouts` flag off) dock-tree only:
- Sprinkles default to the same zone as tool panels (`right`), not a separate `middle` zone.
- `placeSurface` detaches every other non-chat surface before placing the new one, and syncs the rail's active indicator — one panel visible at a time, matching the pre-panels model.
- `#minimize` actually parks the sprinkle's leaf (`dockTree.removeSurface`, which hides via `display:none` rather than destroying it) instead of no-op'ing.
- `SprinkleManager.activate()` re-runs `addSprinkle` on an already-open sprinkle's existing container so a minimized/parked one re-places on rail click.
- Attention-pulse and background session-restore adds skip placement entirely (must not steal the one visible slot), matching the pre-refactor `#activate` skip for those modes.
- Clicking an open sprinkle's rail icon now routes to `manager.minimize`, the same path its own in-panel minimize button uses.
- Paid down `sprinkle-manager.ts`'s `noMisusedPromises` debt-list entry (an inline suppression on the one flagged line — a null-check dedupe guard, not a missed `await`) since this PR touches the file.

Panelized shells (`panel-layouts` on, a `hostSprinkleSurface` hook) are untouched — they own their own show/hide model.

## Test plan
- [x] `npm run verify` (lint gate, 7/7 checks)
- [x] `npm run typecheck`
- [x] `npm run test` (13797 passed)
- [x] `npm run test:coverage` (thresholds met)
- [x] `npm run build` + `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` (within budget)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] New/updated unit tests for show-one collapse, minimize parking, panelized-mode no-op, and rail-collapse-to-minimize routing
- [ ] Manual verification in a running dev instance (sprinkle opens alongside VFS in the right zone, minimize hides it, rail click reopens it, one panel at a time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)