### PR TITLE
feat(extension): add "Bring leader to front" to the side-panel avatar menu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,12 @@ jobs:
         run: npm run build -w @slicc/webapp
       - name: Build extension
         run: npm run build -w @slicc/chrome-extension
+      - name: Upload unpacked extension build
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: chrome-extension-unpacked
+          path: dist/extension/
+          if-no-files-found: error
       - name: Check bundle for forbidden CDN URL literals (MV3 RHC guard)
         run: bash packages/dev-tools/tools/check-extension-rhc.sh
       - name: Check bundle for Node-only APIs

--- a/docs/extension-thin-bridge.md
+++ b/docs/extension-thin-bridge.md
@@ -187,11 +187,20 @@ The side panel is opened on demand by the toolbar icon. Full flow:
    SLICC tab" card (`showSignInRedirect`). A general cherry embed in a
    third-party page keeps its own onboarding untouched. In both card cases the
    follower emits `slicc.open-leader-tab`; `sidepanel-entry`'s `onSliccEvent`
-   hook relays it to the SW as a `cherry-panel` `focus-leader` message, and
-   `cherry-panel-sw` both `focusLeaderTab()`s (focus/create the leader tab)
-   and `postOpenSettingsToWelcomedLeaderPorts()`s (bridge
+   hook relays it to the SW as a `cherry-panel`
+   `{ kind:'focus-leader', openSettings: true }` message, and `cherry-panel-sw`
+   both `focusLeaderTab()`s (focus/create the leader tab) and
+   `postOpenSettingsToWelcomedLeaderPorts()`s (bridge
    `extension.open-settings` → leader opens its Settings dialog) so the user
    lands on the login UI, not a bare focused tab.
+7. **Focus-leader button**: the panel chrome renders a "⌂ Leader tab" button
+   above the follower iframe (`#focus-leader` in `sidepanel.html`). The leader
+   is pinned in exactly one window, so a panel open in any other window has no
+   other way back to it — and the follower iframe cannot reach `chrome.tabs`
+   itself. The click sends the same `focus-leader` message with
+   `openSettings: false`: focus only, leaving the leader on whatever view it is
+   showing. An omitted `openSettings` still means "open Settings", so a panel
+   document from before an extension update keeps the sign-in behaviour.
 
 **Tri-state panel UI:**
 

--- a/docs/extension-thin-bridge.md
+++ b/docs/extension-thin-bridge.md
@@ -193,14 +193,15 @@ The side panel is opened on demand by the toolbar icon. Full flow:
    `postOpenSettingsToWelcomedLeaderPorts()`s (bridge
    `extension.open-settings` → leader opens its Settings dialog) so the user
    lands on the login UI, not a bare focused tab.
-7. **Focus-leader button**: the panel chrome renders a "⌂ Leader tab" button
-   above the follower iframe (`#focus-leader` in `sidepanel.html`). The leader
-   is pinned in exactly one window, so a panel open in any other window has no
-   other way back to it — and the follower iframe cannot reach `chrome.tabs`
-   itself. The click sends the same `focus-leader` message with
-   `openSettings: false`: focus only, leaving the leader on whatever view it is
-   showing. An omitted `openSettings` still means "open Settings", so a panel
-   document from before an extension update keeps the sign-in behaviour.
+7. **"Bring leader to front"**: the follower's avatar menu carries this item in
+   the side panel only. The leader is pinned in exactly one window, so a panel
+   open in any other window has no other way back to it — and the follower
+   iframe cannot reach `chrome.tabs` itself. Selecting it emits
+   `slicc.focus-leader-tab`, which `sidepanel-entry` relays as the same
+   `focus-leader` message with `openSettings: false`: focus only, leaving the
+   leader on whatever view it is showing. An omitted `openSettings` still means
+   "open Settings", so a panel document from before an extension update keeps
+   the sign-in behaviour.
 
 **Tri-state panel UI:**
 

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -54,7 +54,9 @@ toast dedup, QA scenarios, and dev-watch details.
   on-demand `chrome.sidePanel` surface that iframes the hosted ui-only cherry
   follower (`?cherry=1&ui-only=1`) and runs the tri-state
   (booting → ready → disconnected) controller over a `cherry-panel` Port to
-  the service worker.
+  the service worker. Its panel chrome carries a "Leader tab" button that
+  sends `focus-leader` with `openSettings: false` — the follower iframe has no
+  `chrome.tabs` access, and the pinned leader lives in one window only.
 - **Secrets options page** (`secrets.html` + `src/secrets-entry.ts`): user-
   facing CRUD over `chrome.storage.local` credentials consumed by the SW's
   fetch-proxy and sign-and-forward backends.

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -54,9 +54,10 @@ toast dedup, QA scenarios, and dev-watch details.
   on-demand `chrome.sidePanel` surface that iframes the hosted ui-only cherry
   follower (`?cherry=1&ui-only=1`) and runs the tri-state
   (booting → ready → disconnected) controller over a `cherry-panel` Port to
-  the service worker. Its panel chrome carries a "Leader tab" button that
-  sends `focus-leader` with `openSettings: false` — the follower iframe has no
-  `chrome.tabs` access, and the pinned leader lives in one window only.
+  the service worker. It relays the follower avatar menu's "Bring leader to
+  front" (`slicc.focus-leader-tab`) as `focus-leader` with
+  `openSettings: false` — the follower iframe has no `chrome.tabs` access, and
+  the pinned leader lives in one window only.
 - **Secrets options page** (`secrets.html` + `src/secrets-entry.ts`): user-
   facing CRUD over `chrome.storage.local` credentials consumed by the SW's
   fetch-proxy and sign-and-forward backends.

--- a/packages/chrome-extension/sidepanel.html
+++ b/packages/chrome-extension/sidepanel.html
@@ -10,40 +10,15 @@
         height: 100%;
         background: #1e1e1e;
       }
-      body {
-        display: flex;
-        flex-direction: column;
-      }
-      /* Panel chrome: extension-only actions the follower iframe cannot perform
-         itself (it has no access to chrome.tabs). */
-      #panel-toolbar {
-        flex: 0 0 auto;
-        display: flex;
-        justify-content: flex-end;
-        padding: 2px 4px;
-      }
-      #focus-leader {
-        background: transparent;
-        border: 0;
-        border-radius: 4px;
-        color: #aaa;
-        cursor: pointer;
-        font: 12px system-ui;
-        padding: 2px 6px;
-      }
-      #focus-leader:hover {
-        background: #2f2f2f;
-        color: #ddd;
-      }
       #cherry-follower {
         border: 0;
         width: 100%;
-        flex: 1 1 auto;
+        height: 100%;
         display: block;
       }
       #cherry-status {
         position: absolute;
-        inset: 24px 0 0;
+        inset: 0;
         display: none;
         align-items: center;
         justify-content: center;
@@ -57,13 +32,6 @@
     </style>
   </head>
   <body>
-    <!-- The leader tab is pinned in exactly one window; from any other window
-         this button is the only way back to it. -->
-    <div id="panel-toolbar">
-      <button id="focus-leader" type="button" title="Focus the SLICC leader tab">
-        ⌂ Leader tab
-      </button>
-    </div>
     <div id="cherry-status" data-state="starting">Starting SLICC…</div>
     <!--
       Permissions-Policy delegation to the cross-origin follower iframe. The

--- a/packages/chrome-extension/sidepanel.html
+++ b/packages/chrome-extension/sidepanel.html
@@ -10,15 +10,40 @@
         height: 100%;
         background: #1e1e1e;
       }
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      /* Panel chrome: extension-only actions the follower iframe cannot perform
+         itself (it has no access to chrome.tabs). */
+      #panel-toolbar {
+        flex: 0 0 auto;
+        display: flex;
+        justify-content: flex-end;
+        padding: 2px 4px;
+      }
+      #focus-leader {
+        background: transparent;
+        border: 0;
+        border-radius: 4px;
+        color: #aaa;
+        cursor: pointer;
+        font: 12px system-ui;
+        padding: 2px 6px;
+      }
+      #focus-leader:hover {
+        background: #2f2f2f;
+        color: #ddd;
+      }
       #cherry-follower {
         border: 0;
         width: 100%;
-        height: 100%;
+        flex: 1 1 auto;
         display: block;
       }
       #cherry-status {
         position: absolute;
-        inset: 0;
+        inset: 24px 0 0;
         display: none;
         align-items: center;
         justify-content: center;
@@ -32,6 +57,13 @@
     </style>
   </head>
   <body>
+    <!-- The leader tab is pinned in exactly one window; from any other window
+         this button is the only way back to it. -->
+    <div id="panel-toolbar">
+      <button id="focus-leader" type="button" title="Focus the SLICC leader tab">
+        ⌂ Leader tab
+      </button>
+    </div>
     <div id="cherry-status" data-state="starting">Starting SLICC…</div>
     <!--
       Permissions-Policy delegation to the cross-origin follower iframe. The

--- a/packages/chrome-extension/src/cherry-panel-protocol.ts
+++ b/packages/chrome-extension/src/cherry-panel-protocol.ts
@@ -20,8 +20,8 @@ export interface PanelHelloMessage {
  * Panel → SW: focus (or create) the pinned SLICC leader tab. Sent when the
  * follower asks to sign in — provider login (OAuth / device-code / settings)
  * can't complete in the cross-origin side-panel iframe, so the panel hands the
- * user off to the leader tab where the real login UI runs — and by the panel's
- * own "Leader tab" button, which is a plain focus with nothing to sign in to.
+ * user off to the leader tab where the real login UI runs — and by the follower
+ * avatar menu's "Bring leader to front", a plain focus with nothing to sign in to.
  */
 export interface PanelFocusLeaderMessage {
   kind: 'focus-leader';

--- a/packages/chrome-extension/src/cherry-panel-protocol.ts
+++ b/packages/chrome-extension/src/cherry-panel-protocol.ts
@@ -20,10 +20,14 @@ export interface PanelHelloMessage {
  * Panel → SW: focus (or create) the pinned SLICC leader tab. Sent when the
  * follower asks to sign in — provider login (OAuth / device-code / settings)
  * can't complete in the cross-origin side-panel iframe, so the panel hands the
- * user off to the leader tab where the real login UI runs.
+ * user off to the leader tab where the real login UI runs — and by the panel's
+ * own "Leader tab" button, which is a plain focus with nothing to sign in to.
  */
 export interface PanelFocusLeaderMessage {
   kind: 'focus-leader';
+  /** Also open the leader's Settings dialog (the sign-in hand-off). Defaults to
+   *  true so an omitted field keeps the sign-in behaviour. */
+  openSettings?: boolean;
 }
 export type PanelToSwMessage = PanelHelloMessage | PanelFocusLeaderMessage;
 

--- a/packages/chrome-extension/src/cherry-panel-sw.ts
+++ b/packages/chrome-extension/src/cherry-panel-sw.ts
@@ -155,14 +155,15 @@ export async function handleCherryPanelConnect(
   port.onMessage.addListener((raw) => {
     const msg = raw as PanelToSwMessage;
     if (msg?.kind === 'focus-leader') {
-      // The follower asked to sign in — focus/create the leader tab where the
-      // real login UI runs AND tell it to open Settings so the user lands on the
-      // login UI. Fire-and-forget; the panel's card already told the user, so a
-      // focus failure isn't fatal. Focus first (may create the tab), then post
-      // open-settings over the bridge (a just-created leader's bridge Port is not
-      // welcomed yet, so the follower card remains the fallback).
+      // Focus/create the leader tab. Fire-and-forget; the panel's card already
+      // told the user, so a focus failure isn't fatal. For the sign-in hand-off
+      // also tell the leader to open Settings so the user lands on the login UI:
+      // focus first (may create the tab), then post open-settings over the bridge
+      // (a just-created leader's bridge Port is not welcomed yet, so the follower
+      // card remains the fallback). The panel's own "Leader tab" button sends
+      // `openSettings: false` — it is a plain focus with nothing to sign in to.
       void deps.focusLeaderTab?.().catch(() => {});
-      deps.openSettingsOnLeader?.();
+      if (msg.openSettings !== false) deps.openSettingsOnLeader?.();
       return;
     }
     if (msg?.kind !== 'hello') return;

--- a/packages/chrome-extension/src/cherry-panel-sw.ts
+++ b/packages/chrome-extension/src/cherry-panel-sw.ts
@@ -160,8 +160,8 @@ export async function handleCherryPanelConnect(
       // also tell the leader to open Settings so the user lands on the login UI:
       // focus first (may create the tab), then post open-settings over the bridge
       // (a just-created leader's bridge Port is not welcomed yet, so the follower
-      // card remains the fallback). The panel's own "Leader tab" button sends
-      // `openSettings: false` — it is a plain focus with nothing to sign in to.
+      // card remains the fallback). The avatar menu's "Bring leader to front"
+      // sends `openSettings: false` — a plain focus with nothing to sign in to.
       void deps.focusLeaderTab?.().catch(() => {});
       if (msg.openSettings !== false) deps.openSettingsOnLeader?.();
       return;

--- a/packages/chrome-extension/src/sidepanel-entry.ts
+++ b/packages/chrome-extension/src/sidepanel-entry.ts
@@ -36,9 +36,6 @@ export interface SidePanelDeps {
   iframe: HTMLIFrameElement;
   setStatus: (s: PanelStatus) => void;
   sliccOrigin: string;
-  /** Panel-chrome button that focuses the pinned leader tab. Optional so tests
-   *  (and a panel document without the toolbar) need not provide it. */
-  focusLeaderButton?: HTMLElement;
 }
 
 export function createSidePanelController(deps: SidePanelDeps): { dispose(): void } {
@@ -105,11 +102,6 @@ export function createSidePanelController(deps: SidePanelDeps): { dispose(): voi
     }
   };
 
-  // Panel chrome: the leader tab is pinned in one window only, so a user with
-  // the panel open in another window has no way back to it from the follower.
-  const onFocusLeaderClick = () => requestLeaderFocus(false);
-  deps.focusLeaderButton?.addEventListener('click', onFocusLeaderClick);
-
   const onMessage = (raw: unknown) => {
     const msg = raw as SwToPanelMessage;
     if (msg?.kind !== 'join-url') return;
@@ -166,8 +158,11 @@ export function createSidePanelController(deps: SidePanelDeps): { dispose(): voi
         // The follower asks to sign in — provider login can't complete in the
         // panel iframe, so focus/open the SLICC leader tab where the real login
         // UI runs. Route it through the SW (which owns the leader tab).
+        // `slicc.focus-leader-tab` is the follower avatar menu's "Bring leader
+        // to front" — a plain focus, with nothing to sign in to.
         onSliccEvent: (name) => {
           if (name === 'slicc.open-leader-tab') requestLeaderFocus(true);
+          if (name === 'slicc.focus-leader-tab') requestLeaderFocus(false);
         },
       },
     });
@@ -210,7 +205,6 @@ export function createSidePanelController(deps: SidePanelDeps): { dispose(): voi
       disposed = true;
       teardown();
       deps.iframe.removeEventListener('load', onIframeLoad);
-      deps.focusLeaderButton?.removeEventListener('click', onFocusLeaderClick);
       try {
         port?.disconnect();
       } catch {
@@ -236,6 +230,5 @@ if (typeof chrome !== 'undefined' && chrome?.runtime?.id) {
     iframe,
     setStatus,
     sliccOrigin: sliccOriginDefault,
-    focusLeaderButton: document.getElementById('focus-leader') ?? undefined,
   });
 }

--- a/packages/chrome-extension/src/sidepanel-entry.ts
+++ b/packages/chrome-extension/src/sidepanel-entry.ts
@@ -36,6 +36,9 @@ export interface SidePanelDeps {
   iframe: HTMLIFrameElement;
   setStatus: (s: PanelStatus) => void;
   sliccOrigin: string;
+  /** Panel-chrome button that focuses the pinned leader tab. Optional so tests
+   *  (and a panel document without the toolbar) need not provide it. */
+  focusLeaderButton?: HTMLElement;
 }
 
 export function createSidePanelController(deps: SidePanelDeps): { dispose(): void } {
@@ -89,6 +92,23 @@ export function createSidePanelController(deps: SidePanelDeps): { dispose(): voi
   deps.iframe.addEventListener('error', () => {
     if (!disposed && handle) goDisconnected();
   });
+
+  // Only the SW can touch chrome.tabs, so every leader-tab focus goes over the
+  // Port. `openSettings` distinguishes the sign-in hand-off (land the user on
+  // the login UI) from a plain focus.
+  const requestLeaderFocus = (openSettings: boolean) => {
+    try {
+      port?.postMessage({ kind: 'focus-leader', openSettings });
+    } catch {
+      // Port died (SW evicted / context invalidated) — the follower's card still
+      // tells the user to open the SLICC tab manually.
+    }
+  };
+
+  // Panel chrome: the leader tab is pinned in one window only, so a user with
+  // the panel open in another window has no way back to it from the follower.
+  const onFocusLeaderClick = () => requestLeaderFocus(false);
+  deps.focusLeaderButton?.addEventListener('click', onFocusLeaderClick);
 
   const onMessage = (raw: unknown) => {
     const msg = raw as SwToPanelMessage;
@@ -147,14 +167,7 @@ export function createSidePanelController(deps: SidePanelDeps): { dispose(): voi
         // panel iframe, so focus/open the SLICC leader tab where the real login
         // UI runs. Route it through the SW (which owns the leader tab).
         onSliccEvent: (name) => {
-          if (name === 'slicc.open-leader-tab') {
-            try {
-              port?.postMessage({ kind: 'focus-leader' });
-            } catch {
-              // Port died (SW evicted / context invalidated) — the follower's
-              // card still tells the user to open the SLICC tab manually.
-            }
-          }
+          if (name === 'slicc.open-leader-tab') requestLeaderFocus(true);
         },
       },
     });
@@ -197,6 +210,7 @@ export function createSidePanelController(deps: SidePanelDeps): { dispose(): voi
       disposed = true;
       teardown();
       deps.iframe.removeEventListener('load', onIframeLoad);
+      deps.focusLeaderButton?.removeEventListener('click', onFocusLeaderClick);
       try {
         port?.disconnect();
       } catch {
@@ -222,5 +236,6 @@ if (typeof chrome !== 'undefined' && chrome?.runtime?.id) {
     iframe,
     setStatus,
     sliccOrigin: sliccOriginDefault,
+    focusLeaderButton: document.getElementById('focus-leader') ?? undefined,
   });
 }

--- a/packages/chrome-extension/tests/cherry-panel-sw.test.ts
+++ b/packages/chrome-extension/tests/cherry-panel-sw.test.ts
@@ -72,6 +72,21 @@ describe('cherry-panel-sw', () => {
     expect(p._sent).toEqual([]);
   });
 
+  it('a focus-leader message with openSettings:false focuses WITHOUT opening Settings', async () => {
+    const focusLeaderTab = vi.fn(async () => {});
+    const openSettingsOnLeader = vi.fn();
+    const p = fakePort();
+    await handleCherryPanelConnect(p as never, {
+      ensureLeaderTab: vi.fn(async () => {}),
+      focusLeaderTab,
+      openSettingsOnLeader,
+    });
+    // The panel's own "Leader tab" button — the user just wants the tab, not login.
+    p._rx({ kind: 'focus-leader', openSettings: false });
+    expect(focusLeaderTab).toHaveBeenCalledTimes(1);
+    expect(openSettingsOnLeader).not.toHaveBeenCalled();
+  });
+
   it('a focus-leader message with no openSettingsOnLeader dep still focuses (no throw)', async () => {
     const focusLeaderTab = vi.fn(async () => {});
     const p = fakePort();

--- a/packages/chrome-extension/tests/cherry-panel-sw.test.ts
+++ b/packages/chrome-extension/tests/cherry-panel-sw.test.ts
@@ -81,7 +81,7 @@ describe('cherry-panel-sw', () => {
       focusLeaderTab,
       openSettingsOnLeader,
     });
-    // The panel's own "Leader tab" button — the user just wants the tab, not login.
+    // The avatar menu's "Bring leader to front" — just the tab, not login.
     p._rx({ kind: 'focus-leader', openSettings: false });
     expect(focusLeaderTab).toHaveBeenCalledTimes(1);
     expect(openSettingsOnLeader).not.toHaveBeenCalled();

--- a/packages/chrome-extension/tests/sidepanel-entry.test.ts
+++ b/packages/chrome-extension/tests/sidepanel-entry.test.ts
@@ -102,14 +102,53 @@ describe('sidepanel-entry controller', () => {
     const opts = mountSlicc.mock.calls[0]![0] as {
       hooks?: { onSliccEvent?: (name: string, detail?: unknown) => void };
     };
-    // The follower asks to sign in → the panel hands it off to the leader tab.
+    // The follower asks to sign in → hand off to the leader tab AND its Settings.
     opts.hooks?.onSliccEvent?.('slicc.open-leader-tab');
-    expect(port.postMessage).toHaveBeenCalledWith({ kind: 'focus-leader' });
+    expect(port.postMessage).toHaveBeenCalledWith({ kind: 'focus-leader', openSettings: true });
 
     // An unrelated follower event is NOT relayed as a focus-leader command.
     port.postMessage.mockClear();
     opts.hooks?.onSliccEvent?.('slicc.follower.ready');
-    expect(port.postMessage).not.toHaveBeenCalledWith({ kind: 'focus-leader' });
+    expect(port.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'focus-leader' })
+    );
+  });
+
+  it('the panel-chrome button focuses the leader tab WITHOUT opening Settings', () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    createSidePanelController({
+      connect: () => port as never,
+      mountSlicc: mountSlicc as never,
+      iframe,
+      setStatus: (s) => statuses.push(s),
+      sliccOrigin: 'https://www.sliccy.ai',
+      focusLeaderButton: button,
+    });
+    button.click();
+    // Nothing to sign in to — a plain focus, so the leader keeps its current view.
+    expect(port.postMessage).toHaveBeenCalledWith({ kind: 'focus-leader', openSettings: false });
+  });
+
+  it('the focus-leader button survives a dead port and stops working after dispose', () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    const controller = createSidePanelController({
+      connect: () => port as never,
+      mountSlicc: mountSlicc as never,
+      iframe,
+      setStatus: (s) => statuses.push(s),
+      sliccOrigin: 'https://www.sliccy.ai',
+      focusLeaderButton: button,
+    });
+    port.postMessage.mockImplementation(() => {
+      throw new Error('Attempting to use a disconnected port object');
+    });
+    expect(() => button.click()).not.toThrow();
+    port.postMessage.mockReset();
+    controller.dispose();
+    button.click();
+    expect(port.postMessage).not.toHaveBeenCalled();
   });
 
   it('ready → status live (overlay hidden so the follower owns its own sub-status)', () => {

--- a/packages/chrome-extension/tests/sidepanel-entry.test.ts
+++ b/packages/chrome-extension/tests/sidepanel-entry.test.ts
@@ -114,41 +114,28 @@ describe('sidepanel-entry controller', () => {
     );
   });
 
-  it('the panel-chrome button focuses the leader tab WITHOUT opening Settings', () => {
-    const button = document.createElement('button');
-    document.body.appendChild(button);
-    createSidePanelController({
-      connect: () => port as never,
-      mountSlicc: mountSlicc as never,
-      iframe,
-      setStatus: (s) => statuses.push(s),
-      sliccOrigin: 'https://www.sliccy.ai',
-      focusLeaderButton: button,
-    });
-    button.click();
-    // Nothing to sign in to — a plain focus, so the leader keeps its current view.
+  it('follower "slicc.focus-leader-tab" event focuses the leader tab WITHOUT opening Settings', () => {
+    make();
+    port._emit({ kind: 'join-url', state: 'ready', joinUrl: 'https://tray/join/t.s' });
+    const opts = mountSlicc.mock.calls[0]![0] as {
+      hooks?: { onSliccEvent?: (name: string, detail?: unknown) => void };
+    };
+    // The avatar menu's "Bring leader to front" — nothing to sign in to, so the
+    // leader keeps its current view.
+    opts.hooks?.onSliccEvent?.('slicc.focus-leader-tab');
     expect(port.postMessage).toHaveBeenCalledWith({ kind: 'focus-leader', openSettings: false });
   });
 
-  it('the focus-leader button survives a dead port and stops working after dispose', () => {
-    const button = document.createElement('button');
-    document.body.appendChild(button);
-    const controller = createSidePanelController({
-      connect: () => port as never,
-      mountSlicc: mountSlicc as never,
-      iframe,
-      setStatus: (s) => statuses.push(s),
-      sliccOrigin: 'https://www.sliccy.ai',
-      focusLeaderButton: button,
-    });
+  it('a leader-focus request survives a dead port', () => {
+    make();
+    port._emit({ kind: 'join-url', state: 'ready', joinUrl: 'https://tray/join/t.s' });
+    const opts = mountSlicc.mock.calls[0]![0] as {
+      hooks?: { onSliccEvent?: (name: string, detail?: unknown) => void };
+    };
     port.postMessage.mockImplementation(() => {
       throw new Error('Attempting to use a disconnected port object');
     });
-    expect(() => button.click()).not.toThrow();
-    port.postMessage.mockReset();
-    controller.dispose();
-    button.click();
-    expect(port.postMessage).not.toHaveBeenCalled();
+    expect(() => opts.hooks?.onSliccEvent?.('slicc.focus-leader-tab')).not.toThrow();
   });
 
   it('ready → status live (overlay hidden so the follower owns its own sub-status)', () => {

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -793,10 +793,16 @@ export async function mountWcUiFollower(
   // Task 8: add "Export transcript" to the follower avatar menu.
   // Experimental features are deliberately excluded: the centrally gated
   // dialog currently has no user-toggleable flags, so this menu stays minimal.
+  // "Bring leader to front" is extension-side-panel-only: the pinned leader tab
+  // lives in exactly one window, and only that host can focus it (see
+  // `isExtensionSidePanel`).
   let exportInFlight = false;
   const syncFollowerMenuItems = (): void => {
     boot.refs.avatarMenu.items = [
       { kind: 'separator' },
+      ...(isExtensionSidePanel
+        ? [{ id: 'focus-leader-tab', label: 'Bring leader to front', icon: 'external-link' }]
+        : []),
       {
         id: 'export-transcript',
         label: exportInFlight ? 'Exporting…' : 'Export transcript',
@@ -810,6 +816,10 @@ export async function mountWcUiFollower(
 
   boot.refs.avatarMenu.addEventListener('slicc-avatar-action', (event) => {
     const id = (event as CustomEvent<{ id?: string }>).detail?.id;
+    if (id === 'focus-leader-tab') {
+      prelude.cherryTransport?.emitSliccEventToHost('slicc.focus-leader-tab');
+      return;
+    }
     if (id === 'tray-stop') {
       window.dispatchEvent(
         new CustomEvent('slicc:tray-leave', { detail: { workerBaseUrl: null } })

--- a/packages/webapp/tests/ui/wc/wc-follower.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-follower.test.ts
@@ -721,6 +721,43 @@ describe('mountWcUiFollower', () => {
     expect(app.querySelector('.wc-signin-redirect')).toBeTruthy();
   });
 
+  it('extension side panel: the avatar menu offers "Bring leader to front" and focuses the tab', async () => {
+    const emit = vi.fn();
+    mockCherryPrelude(emit);
+    vi.resetModules();
+    setCherryLocation('chrome-extension://abcdef');
+    const { mountWcUiFollower } = await import('../../../src/ui/wc/wc-follower.js');
+    const app = document.getElementById('app')!;
+    await mountWcUiFollower(app, { stage: () => {} } as never, 'cherry');
+
+    const avatarMenu = app.querySelector('slicc-avatar-menu') as HTMLElement & {
+      items?: Array<{ id?: string; label?: string }>;
+    };
+    expect(avatarMenu.items?.some((i) => i.id === 'focus-leader-tab')).toBe(true);
+
+    // A plain focus — the panel host relays it as focus-leader WITHOUT Settings.
+    avatarMenu.dispatchEvent(
+      new CustomEvent('slicc-avatar-action', { detail: { id: 'focus-leader-tab' } })
+    );
+    expect(emit).toHaveBeenCalledWith('slicc.focus-leader-tab');
+  });
+
+  it('general cherry embed (NOT side panel): no "Bring leader to front" item', async () => {
+    const emit = vi.fn();
+    mockCherryPrelude(emit);
+    vi.resetModules();
+    setCherryLocation('https://third-party.example');
+    const { mountWcUiFollower } = await import('../../../src/ui/wc/wc-follower.js');
+    const app = document.getElementById('app')!;
+    await mountWcUiFollower(app, { stage: () => {} } as never, 'cherry');
+
+    const avatarMenu = app.querySelector('slicc-avatar-menu') as HTMLElement & {
+      items?: Array<{ id?: string }>;
+    };
+    // No pinned leader tab to focus outside the extension side panel.
+    expect(avatarMenu.items?.some((i) => i.id === 'focus-leader-tab')).toBe(false);
+  });
+
   it('general cherry embed (NOT side panel): does NOT route the error-card CTA to a leader tab', async () => {
     const emit = vi.fn();
     mockCherryPrelude(emit);


### PR DESCRIPTION
**Problem** — the pinned leader tab lives in exactly one window, so a side panel opened in any other window has no way back to it, and the follower iframe can't reach `chrome.tabs` itself.

**Solution** — the follower's avatar menu gains a **Bring leader to front** item (side panel only). It emits `slicc.focus-leader-tab`, which `sidepanel-entry` relays as the existing `focus-leader` message with a new `openSettings: false` (plain focus; the sign-in hand-off keeps `openSettings: true`). An omitted field still means "open Settings", so a panel document from before an extension update keeps its behaviour.

**Testing** — side-loaded a local build into a disposable Chrome 151 profile (xvfb + CDP): the menu item renders and selecting it switches the active tab to the pinned leader without opening Settings. Screenshot in the thread.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KZCD7B6HQH772YZ3F6J3JST9&panel=chat)