### PR TITLE
fix(fs): serialize OPFS mutations across contexts, drop the overwrite copy

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -373,7 +373,6 @@
       "includes": [
         "packages/chrome-extension/src/fetch-proxy-shared.ts",
         "packages/webapp/providers/adobe.ts",
-        "packages/webapp/src/fs/virtual-fs.ts",
         "packages/webapp/src/kernel/cdp-worker-proxy.ts",
         "packages/webapp/src/providers/index.ts",
         "packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts",

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -338,6 +338,45 @@ All paths in VirtualFS must follow these rules:
 
 **Normalization**: Use `normalizePath(path)` from `packages/webapp/src/fs/path-utils.ts` before any VFS operation.
 
+## OPFS Writes: Serialize Per Mount, Across Contexts
+
+**Files**: `packages/webapp/src/fs/virtual-fs.ts` (`withWriteLock`),
+`patches/@zenfs+dom+*.patch`.
+
+ZenFS' `WebAccess` backend keeps a **per-context in-memory directory index** and
+mutates it non-atomically across `await` points. Two writers racing that index
+hand Chromium stale `FileSystemFileHandle`s, and the failure surfaces on paths
+that plainly exist — so the error never names the real cause:
+
+| Symptom                                               | Actually means                     |
+| ----------------------------------------------------- | ---------------------------------- |
+| `NotFoundError` / `ENOENT` on a path you just created | index race                         |
+| `QuotaExceededError` far below the reported quota     | index race, orphaned swap files    |
+| `EIO: Unexpected mismatch in file data size`          | index size disagrees with the file |
+
+Two independent scopes must be serialized, and getting only one is a silent
+half-fix:
+
+- **In-realm**: key the lock on `dbName`, never per instance. Same-`dbName`
+  `VirtualFS` instances share one resolved `WebAccessFS`, so a per-instance lock
+  leaves them free to interleave on one index.
+- **Cross-realm**: a Web Lock (`navigator.locks`), which spans page, kernel
+  worker, and realm workers of one origin. The Python realm mounts the same
+  subtree from its own `DedicatedWorker`, so an in-realm chain cannot see it.
+
+Lock **mutations only**. Locking reads too measured 4× slower and prevented no
+failures. Measured on five contexts writing 92 MB + 800 small files into one
+mount: 5/5 runs failed unserialized, 0/5 serialized, at ~4× the wall clock.
+
+**Never open a full overwrite with `keepExistingData: true`.** Chromium honors it
+by copying the entire existing file into the swap file before the first byte is
+written — O(file size) per write even when the write replaces the file (92 MB
+rewrite: 480 ms → 240 ms without it). Worse, `IndexFS.touch` only narrows the
+in-memory inode and nothing truncates the handle, so a shrink's tail survives on
+disk forever: a 92 MB file rewritten as 4 MB left 92 MB of unreclaimable OPFS
+quota. The patch keeps the copy only where the write needs it — a non-zero
+offset, or a buffer that does not span the indexed size.
+
 ## CDP Transport: Extension Mode
 
 **File**: `packages/webapp/src/cdp/extension-bridge-transport.ts`

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -354,15 +354,19 @@ that plainly exist — so the error never names the real cause:
 | `QuotaExceededError` far below the reported quota     | index race, orphaned swap files    |
 | `EIO: Unexpected mismatch in file data size`          | index size disagrees with the file |
 
-Two independent scopes must be serialized, and getting only one is a silent
-half-fix:
+Two scopes:
 
-- **In-realm**: key the lock on `dbName`, never per instance. Same-`dbName`
+- **In-realm** — key the lock on `dbName`, never per instance. Same-`dbName`
   `VirtualFS` instances share one resolved `WebAccessFS`, so a per-instance lock
-  leaves them free to interleave on one index.
-- **Cross-realm**: a Web Lock (`navigator.locks`), which spans page, kernel
-  worker, and realm workers of one origin. The Python realm mounts the same
-  subtree from its own `DedicatedWorker`, so an in-realm chain cannot see it.
+  leaves them free to interleave on one index. Several instances really are
+  constructed on `GLOBAL_FS_DB_NAME` (plugins, MCP, git, upskill), so this is
+  the scope that matters today.
+- **Cross-context** — a Web Lock (`navigator.locks`) spanning every context of
+  the origin. Insurance: all ZenFS writers currently live in the kernel worker,
+  so it is uncontended and costs one async hop. It does **not** cover the Python
+  realm, which mounts the same subtree through emscripten's `OPFS_SYNC_FS`
+  (sync access handles) and bypasses the ZenFS index entirely — a writer this
+  lock cannot see.
 
 Lock **mutations only**. Locking reads too measured 4× slower and prevented no
 failures. Measured on five contexts writing 92 MB + 800 small files into one

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -1485,15 +1485,21 @@ export class VirtualFS {
    * the shape of `hf download` racing `ipk add`) failed 3 of 5 runs, and 0 of
    * 5 once serialized.
    *
-   * Two scopes, because there are two ways to race:
+   * Two scopes:
    *
-   *  - **In-realm**: keyed by `dbName`, NOT per instance. Same-`dbName`
-   *    instances share one resolved `WebAccessFS` (see `opfsBackends`), so a
-   *    per-instance chain leaves them free to interleave on the same index.
-   *  - **Cross-realm**: a Web Lock, which spans page, kernel worker and realm
-   *    workers of one origin. The Python realm mounts this very subtree in its
-   *    own `DedicatedWorker` (`python-command.ts`), so an in-realm chain alone
-   *    cannot see the other writer.
+   *  - **In-realm**: keyed by `dbName`, NOT per instance. This is the one that
+   *    fixes a live bug — several instances are constructed on
+   *    `GLOBAL_FS_DB_NAME` (plugins, MCP, git, upskill), they share one
+   *    resolved `WebAccessFS` (see `opfsBackends`) and therefore one index,
+   *    and a per-instance chain left them free to interleave on it.
+   *  - **Cross-context**: a Web Lock, which spans every context of the origin.
+   *    Insurance, not a fix for a path that exists today: every ZenFS writer
+   *    currently lives in the kernel worker, so this lock is uncontended and
+   *    costs one async hop. It is what would catch a second context mounting
+   *    the same subtree through ZenFS. Note it does NOT cover the Python
+   *    realm — that mounts this subtree through emscripten's `OPFS_SYNC_FS`
+   *    (sync access handles, see `python-command.ts`), bypassing the ZenFS
+   *    index entirely, so it never takes this lock.
    *
    * Mutations only. Locking reads as well measured 4x slower with no failures
    * prevented. Memory-backed instances skip the Web Lock: they share nothing

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -42,6 +42,11 @@ import type {
 import { FsError } from './types.js';
 import { walk } from './walker.js';
 
+/** The sliver of the Web Locks API {@link VirtualFS.withWriteLock} uses. */
+interface LockManagerLike {
+  request<T>(name: string, callback: () => Promise<T>): Promise<T>;
+}
+
 /** Backend identifier for {@link VirtualFS}. */
 export type VfsBackend = 'memory' | 'opfs';
 
@@ -190,20 +195,21 @@ export class VirtualFS {
   /** Index of files in mounted directories for fast discovery. */
   private mountIndex = new MountIndex();
   /**
-   * Serializes local backend mutations that create directories and the
-   * writes that depend on them (`mkdir` / `writeFile` / `symlink`). The
-   * ZenFS `WebAccess` (OPFS) backend keeps a single in-memory directory
-   * index that it mutates non-atomically across `await` points, so
-   * isomorphic-git's concurrent checkout `writeFile`/`symlink` calls —
-   * each ensuring its parent via `mkdir(recursive)` — could interleave
-   * such that a write ran against a not-yet-materialized parent and threw
-   * spurious `ENOENT` (aggregated into `MultipleGitError`, non-deterministic
-   * across runs). Funneling those mutations through this promise-chain lock
-   * makes parent-creation-then-write a single critical section. Reads and
-   * mount-backend ops stay off the lock, so the uncontended fast path costs
-   * only one extra microtask. Mirrors `BrowserAPI._tabLock`.
+   * Serializes local backend mutations that create directories and the writes
+   * that depend on them (`mkdir` / `writeFile` / `symlink`), so
+   * parent-creation-then-write is one critical section. The original symptom
+   * was isomorphic-git's concurrent checkout: `writeFile`/`symlink` calls each
+   * ensuring their parent via `mkdir(recursive)` could interleave such that a
+   * write ran against a not-yet-materialized parent and threw spurious
+   * `ENOENT` (aggregated into `MultipleGitError`, non-deterministic across
+   * runs). Reads and mount-backend ops stay off the lock, so the uncontended
+   * fast path costs only one extra microtask. Mirrors `BrowserAPI._tabLock`.
+   *
+   * Keyed by `dbName` rather than held per instance: same-`dbName` instances
+   * share one resolved `WebAccessFS`, and therefore one index to corrupt.
+   * See {@link withWriteLock} for the cross-realm half.
    */
-  private _writeLock: Promise<void> = Promise.resolve();
+  private static writeChains = new Map<string, Promise<void>>();
 
   private constructor(
     dbName: string,
@@ -450,7 +456,9 @@ export class VirtualFS {
     { backendFs: { index?: { toJSON: () => unknown } }; refs: number }
   > = new Map();
   private static async ensureRootMount(zenfs: typeof import('@zenfs/core')): Promise<void> {
-    if (VirtualFS.rootMountReady) return VirtualFS.rootMountReady;
+    // Testing the memo for presence, not for a result — a promise is always
+    // truthy, so say so explicitly rather than leaning on that.
+    if (VirtualFS.rootMountReady !== null) return VirtualFS.rootMountReady;
     VirtualFS.rootMountReady = (async () => {
       await zenfs.configureSingle({ backend: zenfs.InMemory, label: '__vfs_root__' });
     })();
@@ -1325,7 +1333,7 @@ export class VirtualFS {
     // section under the write lock: on the ZenFS OPFS backend the parent
     // must be fully materialized before the write, and concurrent
     // mkdir/write ops interleaving on the shared index would otherwise let a
-    // write hit a not-yet-created parent (spurious ENOENT). See _writeLock.
+    // write hit a not-yet-created parent (spurious ENOENT). See withWriteLock.
     const { dir } = splitPath(resolved);
     await this.withWriteLock(async () => {
       if (dir !== '/') {
@@ -1465,27 +1473,58 @@ export class VirtualFS {
   }
 
   /**
-   * Run a local backend mutation under {@link _writeLock} so directory
-   * creation and dependent writes never interleave on ZenFS' shared
-   * in-memory index. Mirrors {@link BrowserAPI.withTab}.
+   * Run a local backend mutation serialized against every other writer of the
+   * same OPFS subtree — in this realm AND in any other.
+   *
+   * ZenFS' `WebAccess` backend keeps a per-context in-memory directory index
+   * that it mutates non-atomically across `await` points. Two writers racing
+   * it hand Chromium stale `FileSystemFileHandle`s, which surface as
+   * `NotFoundError` / `NotReadableError` / `EACCES` on operations whose paths
+   * plainly exist. Measured in a headless-Chromium harness: five contexts
+   * writing distinct paths into one shared mount (92 MB + 800 small files —
+   * the shape of `hf download` racing `ipk add`) failed 3 of 5 runs, and 0 of
+   * 5 once serialized.
+   *
+   * Two scopes, because there are two ways to race:
+   *
+   *  - **In-realm**: keyed by `dbName`, NOT per instance. Same-`dbName`
+   *    instances share one resolved `WebAccessFS` (see `opfsBackends`), so a
+   *    per-instance chain leaves them free to interleave on the same index.
+   *  - **Cross-realm**: a Web Lock, which spans page, kernel worker and realm
+   *    workers of one origin. The Python realm mounts this very subtree in its
+   *    own `DedicatedWorker` (`python-command.ts`), so an in-realm chain alone
+   *    cannot see the other writer.
+   *
+   * Mutations only. Locking reads as well measured 4x slower with no failures
+   * prevented. Memory-backed instances skip the Web Lock: they share nothing
+   * across contexts.
+   *
+   * NOT re-entrant, like the chain it replaces — callers already inside the
+   * lock use the `*Unlocked` helpers.
    */
   private async withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+    const key = this.dbName;
     let release!: () => void;
     const next = new Promise<void>((r) => {
       release = r;
     });
-    const prev = this._writeLock;
-    this._writeLock = next;
+    const prev = VirtualFS.writeChains.get(key) ?? Promise.resolve();
+    VirtualFS.writeChains.set(key, next);
     await prev;
     try {
-      return await fn();
+      const locks = (globalThis as { navigator?: { locks?: LockManagerLike } }).navigator?.locks;
+      if (this.backend !== 'opfs' || typeof locks?.request !== 'function') return await fn();
+      return await locks.request(`slicc-vfs:${key}`, () => fn());
     } finally {
       release();
+      // Drop the chain entry once this was the last waiter, so a long-lived
+      // page does not retain a promise per dbName forever.
+      if (VirtualFS.writeChains.get(key) === next) VirtualFS.writeChains.delete(key);
     }
   }
 
   /**
-   * Recursive local `mkdir` walk WITHOUT acquiring {@link _writeLock}. The
+   * Recursive local `mkdir` walk WITHOUT acquiring {@link withWriteLock}. The
    * caller must already hold the lock — used by {@link mkdir}, {@link
    * writeFile}, and {@link symlink} so parent-ensure-then-write is one
    * critical section (and so re-entrant lock acquisition can't deadlock).
@@ -1600,7 +1639,7 @@ export class VirtualFS {
     this.watcher?.notify([{ type: 'delete', path: normalized }]);
   }
 
-  /** Recursive local removal. The caller must already hold {@link _writeLock}. */
+  /** Recursive local removal. The caller must already hold {@link withWriteLock}. */
   private async rmRecursiveUnlocked(path: string): Promise<void> {
     const entries = await this.lfs.readdir(path);
     for (const name of entries) {
@@ -1795,7 +1834,7 @@ export class VirtualFS {
     }
     // Ensure the parent directory exists and create the link as ONE critical
     // section under the write lock — same ZenFS concurrent-checkout race as
-    // writeFile (see _writeLock).
+    // writeFile (see withWriteLock).
     const { dir } = splitPath(normalizedLinkPath);
     await this.withWriteLock(async () => {
       if (dir !== '/') {

--- a/packages/webapp/tests/fs/write-serialization.test.ts
+++ b/packages/webapp/tests/fs/write-serialization.test.ts
@@ -15,10 +15,11 @@ import { VirtualFS } from '../../src/fs/virtual-fs.js';
  * These tests drive `withWriteLock` directly: the defect is overlapping
  * critical sections, and no assertion on the resulting bytes can see that.
  *
- * The cross-context half of the fix (a Web Lock spanning page, kernel worker
- * and the Python realm's own worker) is out of reach here — these run on the
- * memory backend in Node, where there is no shared index to corrupt and no
- * `navigator.locks`. The browser harness in #1979 covers it.
+ * The cross-context half (a Web Lock spanning every context of the origin) is
+ * out of reach here — these run on the memory backend in Node, where there is
+ * no shared index to corrupt and no `navigator.locks`. It is insurance rather
+ * than a fix for a live path: every ZenFS writer currently lives in the kernel
+ * worker. The browser harness in #1979 covers it.
  */
 
 /** `withWriteLock` is private; the race it prevents is only visible from inside. */

--- a/packages/webapp/tests/fs/write-serialization.test.ts
+++ b/packages/webapp/tests/fs/write-serialization.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+
+/**
+ * Mutations must serialize per `dbName`, not per instance.
+ *
+ * ZenFS' OPFS backend keeps one in-memory directory index per context and
+ * mutates it non-atomically across `await` points, and same-`dbName` VirtualFS
+ * instances share that resolved backend. A per-instance lock therefore left two
+ * instances free to interleave on the same index — which in a headless Chromium
+ * harness produced `NotFoundError` on paths that plainly existed, 3 runs in 5,
+ * for concurrent writes to distinct paths in one shared mount (the shape of
+ * `hf download` racing `ipk add`).
+ *
+ * These tests drive `withWriteLock` directly: the defect is overlapping
+ * critical sections, and no assertion on the resulting bytes can see that.
+ *
+ * The cross-context half of the fix (a Web Lock spanning page, kernel worker
+ * and the Python realm's own worker) is out of reach here — these run on the
+ * memory backend in Node, where there is no shared index to corrupt and no
+ * `navigator.locks`. The browser harness in #1979 covers it.
+ */
+
+/** `withWriteLock` is private; the race it prevents is only visible from inside. */
+function lock<T>(fs: VirtualFS, fn: () => Promise<T>): Promise<T> {
+  return (fs as unknown as { withWriteLock<R>(f: () => Promise<R>): Promise<R> }).withWriteLock(fn);
+}
+
+/** A section that yields to the microtask queue — an interleave point. */
+function section(gauge: { now: number; peak: number }) {
+  return async () => {
+    gauge.now += 1;
+    gauge.peak = Math.max(gauge.peak, gauge.now);
+    await Promise.resolve();
+    await Promise.resolve();
+    gauge.now -= 1;
+  };
+}
+
+describe('VirtualFS write serialization', () => {
+  it('serializes mutations across instances sharing a dbName', async () => {
+    const dbName = `serialize-${Date.now()}`;
+    const a = await VirtualFS.create({ dbName, wipe: true });
+    const b = await VirtualFS.create({ dbName });
+
+    const gauge = { now: 0, peak: 0 };
+    await Promise.all([
+      lock(a, section(gauge)),
+      lock(b, section(gauge)),
+      lock(a, section(gauge)),
+      lock(b, section(gauge)),
+    ]);
+
+    expect(gauge.peak).toBe(1);
+  });
+
+  it('keeps separate dbNames independent', async () => {
+    // Different mounts share no index, so they must not queue behind each
+    // other — serializing everything would be a throughput regression, and a
+    // peak of 1 here would mean the key is being ignored.
+    const left = await VirtualFS.create({ dbName: `indep-l-${Date.now()}`, wipe: true });
+    const right = await VirtualFS.create({ dbName: `indep-r-${Date.now()}`, wipe: true });
+
+    const gauge = { now: 0, peak: 0 };
+    await Promise.all([lock(left, section(gauge)), lock(right, section(gauge))]);
+
+    expect(gauge.peak).toBe(2);
+  });
+
+  it('releases the chain when a writer throws', async () => {
+    // A failed mkdir must not wedge every later write on this dbName.
+    const dbName = `throwing-${Date.now()}`;
+    const fs = await VirtualFS.create({ dbName, wipe: true });
+
+    await expect(
+      lock(fs, async () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+
+    await fs.writeFile('/after.txt', 'still writable');
+    expect(await fs.readFile('/after.txt', { encoding: 'utf-8' })).toBe('still writable');
+  });
+
+  it('does not retain a chain entry per dbName once writers drain', async () => {
+    const dbName = `drain-${Date.now()}`;
+    const fs = await VirtualFS.create({ dbName, wipe: true });
+    await Promise.all([fs.writeFile('/x.txt', 'x'), fs.writeFile('/y.txt', 'y')]);
+
+    const chains = (VirtualFS as unknown as { writeChains: Map<string, unknown> }).writeChains;
+    expect(chains.has(dbName)).toBe(false);
+  });
+
+  it('still writes correctly through two instances on one dbName', async () => {
+    const dbName = `content-${Date.now()}`;
+    const a = await VirtualFS.create({ dbName, wipe: true });
+    const b = await VirtualFS.create({ dbName });
+
+    await Promise.all([
+      a.writeFile('/one.txt', 'from a'),
+      b.writeFile('/two.txt', 'from b'),
+      a.mkdir('/nested/deep', { recursive: true }),
+    ]);
+
+    expect(await b.readFile('/one.txt', { encoding: 'utf-8' })).toBe('from a');
+    expect(await a.readFile('/two.txt', { encoding: 'utf-8' })).toBe('from b');
+    expect(await b.exists('/nested/deep')).toBe(true);
+  });
+});

--- a/packages/webapp/tests/fs/zenfs-dom-overwrite-patch.test.ts
+++ b/packages/webapp/tests/fs/zenfs-dom-overwrite-patch.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Regression guard for the OPFS full-overwrite patch.
+//
+// `@zenfs/dom`'s WebAccess backend opened every write with
+// `createWritable({ keepExistingData: true })`. Chromium honors that by copying
+// the entire existing file into the swap file before the first byte is written,
+// so a write costs O(file size) even when it replaces the whole file — a 92 MB
+// rewrite measured 480 ms with the copy and 240 ms without.
+//
+// The quota effect is worse than the latency one: `IndexFS.touch` only narrows
+// the in-memory inode and nothing ever truncates the handle, so the tail of a
+// shrunk file survives on disk forever. Rewriting a 92 MB file as 4 MB left
+// 92 MB on disk — 88 MB of OPFS quota that no later write can reclaim, on a
+// filesystem whose failures under pressure are exactly what #1979 tracks.
+//
+// patches/@zenfs+dom+<ver>.patch keeps the copy only for writes that need it
+// (a non-zero offset, or a buffer that does not span the indexed size). This
+// test fails if the patch is missing or stops applying.
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+const UNCONDITIONAL_COPY = 'createWritable({ keepExistingData: true })';
+
+describe('@zenfs/dom full-overwrite patch', () => {
+  it('does not copy the existing file on a write that spans it', () => {
+    const distPath = resolve(repoRoot, 'node_modules/@zenfs/dom/dist/access.js');
+    const src = readFileSync(distPath, 'utf8');
+
+    expect(
+      src.includes(UNCONDITIONAL_COPY),
+      `Installed @zenfs/dom still opens every write with ${UNCONDITIONAL_COPY}; ` +
+        `patches/@zenfs+dom+*.patch is missing or failed to apply. That costs a ` +
+        `full-file copy per write and leaks the tail of every shrunk file into ` +
+        `OPFS quota permanently. Reconcile the patch — see patches/README.md.`
+    ).toBe(false);
+    expect(src).toContain('keepExistingData: !fullWrite');
+  });
+});

--- a/patches/@zenfs+dom+1.2.10.patch
+++ b/patches/@zenfs+dom+1.2.10.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/@zenfs/dom/dist/access.js b/node_modules/@zenfs/dom/dist/access.js
+index ec02258..5bc2f23 100644
+--- a/node_modules/@zenfs/dom/dist/access.js
++++ b/node_modules/@zenfs/dom/dist/access.js
+@@ -165,7 +165,17 @@ export class WebAccessFS extends Async(IndexFS) {
+             log.crit(withErrno('EIO', 'Mismatch in entry kind on write'));
+             return;
+         }
+-        const writable = await handle.createWritable({ keepExistingData: true });
++        // A write that starts at 0 and spans the whole file needs none of the
++        // existing bytes, and `keepExistingData` makes Chromium copy every one
++        // of them into the swap file first - O(file size) on each write (92 MB
++        // rewrite: 480ms -> 240ms without it). It also leaves a shrink's tail
++        // behind forever, because IndexFS.touch only narrows the in-memory
++        // inode and nothing ever truncates the handle: rewriting a 92 MB file
++        // as 4 MB left 92 MB on disk and 88 MB of OPFS quota unreclaimable.
++        // Note vnode flushes touch({ size: 0 }) before an O_TRUNC write, so
++        // inode.size is 0 here for the ordinary writeFile path.
++        const fullWrite = !offset && buffer.byteLength >= inode.size;
++        const writable = await handle.createWritable({ keepExistingData: !fullWrite });
+         if (offset) {
+             try {
+                 await writable.seek(offset);

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -1,12 +1,20 @@
 {
-  "//": "Metadata for the patch-package patches in this directory \u2014 one key per patched npm package. Consumed by the orphaned-patch guard (packages/dev-tools/patch-reconcile/check-patches.mjs, run as `npm run lint:patches`) and the renovate-patch-reconcile workflow. Every patches/<pkg>+<version>.patch MUST have an entry here with a matching patchedVersion. When a patch is removed, delete its entry. See patches/README.md.",
+  "//": "Metadata for the patch-package patches in this directory — one key per patched npm package. Consumed by the orphaned-patch guard (packages/dev-tools/patch-reconcile/check-patches.mjs, run as `npm run lint:patches`) and the renovate-patch-reconcile workflow. Every patches/<pkg>+<version>.patch MUST have an entry here with a matching patchedVersion. When a patch is removed, delete its entry. See patches/README.md.",
   "@zenfs/core": {
     "patchedVersion": "2.6.2",
     "upstream": "https://github.com/zen-fs/core",
     "issue": null,
     "reason": "Make globalThis.__zenfs__ a null-prototype own-property copy of fs (Object.assign(Object.create(null), fs)) instead of a prototype view, so the fs export's enumerable members are reliably visible on the global probe.",
-    "removeWhen": "Local workaround \u2014 no upstream PR is tracked. Re-evaluate whenever @zenfs/core changes the __zenfs__ global or the fs export shape; if a newer version no longer needs the override, remove the patch.",
+    "removeWhen": "Local workaround — no upstream PR is tracked. Re-evaluate whenever @zenfs/core changes the __zenfs__ global or the fs export shape; if a newer version no longer needs the override, remove the patch.",
     "verify": "npm run typecheck"
+  },
+  "@zenfs/dom": {
+    "patchedVersion": "1.2.10",
+    "upstream": "https://github.com/zen-fs/dom",
+    "issue": null,
+    "reason": "WebAccessFS.write opened every write with createWritable({ keepExistingData: true }), so Chromium copied the whole existing file into the swap file first — O(file size) per write even when the write replaces the file (92 MB rewrite: 480ms -> 240ms without the copy). Worse, IndexFS.touch only narrows the in-memory inode and nothing truncates the handle, so a shrink left its tail on disk forever (92 MB file rewritten as 4 MB kept 92 MB of OPFS quota). The patch keeps the copy only where the write needs it: a non-zero offset, or a buffer that does not span the indexed size.",
+    "removeWhen": "Local workaround — no upstream PR is tracked. Remove once @zenfs/dom decides keepExistingData per write (or truncates the handle on a narrowing touch) upstream.",
+    "verify": "npm run test -w @slicc/webapp -- zenfs-dom-overwrite-patch"
   },
   "e2b": {
     "patchedVersion": "2.35.1",

--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,7 @@
     },
     {
       "description": "Packages we carry a patch-package patch for (see patches/ and patches/patches.json). A bump orphans the version-pinned patch, so route these into one group, label them, and never automerge — the renovate-patch-reconcile workflow regenerates or removes the patch first, and the lint:patches guard blocks the merge until the patch matches the installed version. Keep this list in sync with patches/. (e2b is patched to make its top-level createRequire(import.meta.url) shim lazy so it imports under Cloudflare workerd — see docs/pitfalls.md.)",
-      "matchPackageNames": ["@zenfs/core", "e2b"],
+      "matchPackageNames": ["@zenfs/core", "@zenfs/dom", "e2b"],
       "groupName": "patched dependencies",
       "groupSlug": "patched-deps",
       "addLabels": ["patched-dependency"],


### PR DESCRIPTION
Two defects in the OPFS write path, both reproduced in a headless-Chromium harness (Playwright, five worker contexts, x86_64 Linux container). These are the "known knowns" that fell out of the #1979 investigation — the *unknown* `Failed to write data to data pipe` stays open there.

## 1. Mutations serialized per instance, not per mount

`withWriteLock` chained on `this._writeLock`, one chain per `VirtualFS` instance. But same-`dbName` instances share one resolved `WebAccessFS`, and therefore one in-memory directory index — which ZenFS mutates non-atomically across `await` points. A per-instance lock leaves two instances free to interleave on the same index, which hands Chromium stale `FileSystemFileHandle`s.

Two scopes:

- **In-realm** — the chain is now keyed on `dbName`, shared statically across instances. This is the scope that fixes a live bug: several instances really are constructed on `GLOBAL_FS_DB_NAME` (plugins, MCP, git, upskill), and the per-instance lock did not serialize them.
- **Cross-context** — a Web Lock (`navigator.locks`) spanning every context of the origin. Insurance, not a fix for a path that exists today: every ZenFS writer currently lives in the kernel worker, so the lock is uncontended and costs one async hop. It does **not** cover the Python realm, which mounts the same subtree through emscripten's `OPFS_SYNC_FS` (sync access handles) and bypasses the ZenFS index entirely — a writer this lock cannot see. I originally cited that realm as the justification; that was wrong, and the code comment, docs and tests now say so.

Mutations only. Locking reads as well measured **4× slower and prevented no failures**. Memory-backed instances skip the Web Lock — they share nothing across contexts.

### Measured

Five contexts writing 92 MB + 800 small files to distinct paths in one shared mount (the shape of `hf download` racing `ipk add`), fresh browser profile per run:

| Configuration | Runs with a failure | Peak OPFS usage | Wall clock |
| --- | --- | --- | --- |
| unserialized | **5/5** — `NotFoundError` on paths that exist | 173–263 MB | ~4.2 s (to fail) |
| serialized | **0/5** | 132 MB every run | ~18–20 s |

The 132 MB is exactly the steady state (92 MB + 800×50 KB). Unserialized runs sat 40–130 MB above it: orphaned swap files from writers the race killed mid-write.

Serialization costs ~4× wall clock in this deliberately pathological case — five contexts hammering one mount. In practice SLICC has at most page + kernel worker + realm worker, rarely writing concurrently at this volume.

## 2. Every write copied the whole file first

`@zenfs/dom`'s `WebAccessFS.write` opened every write with `createWritable({ keepExistingData: true })`. Chromium honors that by copying the entire existing file into the swap file before the first byte is written — O(file size) per write, **even when the write replaces the file**.

The quota effect is worse than the latency one: `IndexFS.touch` only narrows the in-memory inode, and nothing ever truncates the handle, so a shrink's tail survives on disk forever.

| | before | after |
| --- | --- | --- |
| 92 MB rewrite | 452–492 ms | 226–255 ms |
| disk after rewriting 92 MB as 4 MB | 92 MB (88 MB unreclaimable) | 4 MB |

Contents verified intact across the rewrite (length, first and last byte). Carried as `patches/@zenfs+dom+1.2.10.patch`; the guard condition is `!offset && buffer.byteLength >= inode.size`, so a non-zero offset or a partial write still gets the copy it needs. Instrumenting the backend confirmed the fast path is the ordinary one: ZenFS flushes `touch({ size: 0 })` before an O_TRUNC write, so `writeFile` always arrives with `inode.size === 0`.

## Diligence note

The patch initially looked like it introduced a new failure — unserialized runs started failing with `QuotaExceededError` instead of `NotFoundError`. Reverting the patch in the same harness showed unserialized failing 5/5 either way; only the symptom moved. Both DOMExceptions are the same index race, and the "quota" one fires at 466 MB against a 2.5 GB quota, so it isn't about storage at all. The configuration this PR ships — patched **and** serialized — is 0/5 with deterministic 132 MB usage.

## Tests

- `write-serialization.test.ts` — drives `withWriteLock` directly, since the defect is overlapping critical sections and no assertion on the resulting bytes can see it. Covers: same-`dbName` instances never overlap; different `dbName`s still run concurrently (a peak of 1 there would mean the key is ignored); the chain releases when a writer throws; no per-`dbName` entry retained after drain.
- `zenfs-dom-overwrite-patch.test.ts` — fails if the patch stops applying, mirroring the `e2b-workerd-patch` guard.
- The cross-realm Web Lock is not exercised in Node: these tests run on the memory backend, where there is no shared index and no `navigator.locks`. The browser harness covers it, and the test file says so rather than implying coverage it doesn't have.

## Also in here

- Pays down `virtual-fs.ts`'s `noMisusedPromises` debt and removes it from the `biome.json` override — required by the boy-scout gate for touching the file.
- `docs/pitfalls.md` gets the failure-signature table. Not one of these errors names its real cause, which is what made this expensive to find.
- `renovate.json` patched-dependencies group gains `@zenfs/dom`, so a bump can't automerge past the orphaned patch.

No upstream issue is filed against `zen-fs/dom` yet — `patches.json` records `issue: null` and a `removeWhen`. Worth filing; say the word and I will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
