### PR TITLE
fix(fs): sidecar writes merge only dirty paths under the write lock

### DIFF
--- a/packages/webapp/src/fs/sidecar-merge.ts
+++ b/packages/webapp/src/fs/sidecar-merge.ts
@@ -1,0 +1,91 @@
+/**
+ * `sidecar-merge.ts` — pure merge logic for the OPFS `/.metadata.json`
+ * sidecar (the persisted ZenFS `WebAccessFS` index).
+ *
+ * Why this exists (#1992): the sidecar used to be written as a whole-file
+ * snapshot of the calling context's in-memory index. Multiple contexts
+ * (kernel worker, page-side `VirtualFS` instances) each hold their own
+ * lazily-populated index and each call `flush()`, so whichever context
+ * wrote LAST replaced the sidecar with its private view — including
+ * entries it never touched and whose cached kind/size had drifted from
+ * reality. In production that re-poisoned a freshly repaired sidecar
+ * within hours and bricked boot twice (EISDIR in `crossCopy`, see #1984).
+ *
+ * The fix: a context may only overwrite sidecar entries for paths it
+ * actually mutated (its "dirty" paths); everything else is preserved from
+ * the sidecar currently on disk. Combined with the cross-context Web Lock
+ * around the read-merge-write (taken by the caller in `virtual-fs.ts`),
+ * concurrent writers converge instead of clobbering each other.
+ *
+ * This module is deliberately DOM/OPFS-free so the merge semantics are
+ * unit-testable in Node.
+ */
+
+/**
+ * Parsed shape of the sidecar document — `Index.toJSON()` from
+ * `@zenfs/core` (`{ version, maxSize, entries }`). Entry values are
+ * opaque inode records; this module never inspects them beyond identity.
+ */
+export interface SidecarIndexJson {
+  version?: number;
+  maxSize?: number;
+  entries?: Record<string, unknown>;
+}
+
+/**
+ * Paths this context mutated since its last successful sidecar write.
+ *
+ * - `paths` — exact entries to overwrite (files written, directories
+ *   created, symlinks minted, plus their ancestor directories, whose
+ *   index records materialize alongside).
+ * - `prefixes` — subtrees whose entire on-disk entry set is superseded by
+ *   this context's view (recursive removes, renames): every sidecar entry
+ *   at or under the prefix is dropped, then every in-memory entry at or
+ *   under it is copied in — so deleted children disappear instead of
+ *   resurrecting from the on-disk base.
+ */
+export interface SidecarDirtyState {
+  paths: Set<string>;
+  prefixes: Set<string>;
+}
+
+/** Whether `key` is `prefix` itself or a descendant path of it. */
+function isUnder(key: string, prefix: string): boolean {
+  return key === prefix || key.startsWith(prefix === '/' ? '/' : `${prefix}/`);
+}
+
+/**
+ * Merge this context's in-memory index (`own`) over the sidecar currently
+ * on disk (`onDisk`), constrained to the context's dirty paths/prefixes.
+ *
+ * Top-level fields (`version`, `maxSize`) come from `own` — they describe
+ * the writing code's format, not filesystem state. The root entry `/` is
+ * taken from `own` when present (it is structural and always current).
+ */
+export function mergeSidecarEntries(
+  onDisk: SidecarIndexJson,
+  own: SidecarIndexJson,
+  dirty: SidecarDirtyState
+): SidecarIndexJson {
+  const ownEntries = own.entries ?? {};
+  const entries: Record<string, unknown> = { ...(onDisk.entries ?? {}) };
+
+  if ('/' in ownEntries) entries['/'] = ownEntries['/'];
+
+  for (const path of dirty.paths) {
+    if (path in ownEntries) entries[path] = ownEntries[path];
+    else delete entries[path];
+  }
+
+  for (const prefix of dirty.prefixes) {
+    for (const key of Object.keys(entries)) {
+      if (isUnder(key, prefix)) delete entries[key];
+    }
+    for (const key of Object.keys(ownEntries)) {
+      if (isUnder(key, prefix)) entries[key] = ownEntries[key];
+    }
+  }
+
+  const { entries: _ownEntries, ...ownRest } = own;
+  return { ...ownRest, entries };
+}

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -28,6 +28,11 @@ import {
   saveMountEntry,
 } from './mount-table-store.js';
 import { joinPath, normalizePath, splitPath } from './path-utils.js';
+import {
+  mergeSidecarEntries,
+  type SidecarDirtyState,
+  type SidecarIndexJson,
+} from './sidecar-merge.js';
 import { MAX_SYMLINK_DEPTH, realpath, resolveSymlinks } from './symlink-resolver.js';
 import type {
   DirEntry,
@@ -351,7 +356,7 @@ export class VirtualFS {
       } catch {
         /* already mounted with this backend — safe to ignore */
       }
-      entry = { backendFs, refs: 0 };
+      entry = { backendFs, refs: 0, sidecarDirty: { paths: new Set(), prefixes: new Set() } };
       VirtualFS.opfsBackends.set(vfs.dbName, entry);
     }
     entry.refs += 1;
@@ -453,7 +458,17 @@ export class VirtualFS {
    */
   private static opfsBackends: Map<
     string,
-    { backendFs: { index?: { toJSON: () => unknown } }; refs: number }
+    {
+      backendFs: { index?: { toJSON: () => unknown } };
+      refs: number;
+      /**
+       * Paths this realm mutated since its last successful sidecar write.
+       * Shared per `dbName` (like the index itself) so every same-name
+       * instance contributes to — and is covered by — one merge scope.
+       * See {@link writeOpfsMetadataSidecarUnlocked} and `sidecar-merge.ts`.
+       */
+      sidecarDirty: SidecarDirtyState;
+    }
   > = new Map();
   private static async ensureRootMount(zenfs: typeof import('@zenfs/core')): Promise<void> {
     // Testing the memo for presence, not for a result — a promise is always
@@ -681,23 +696,87 @@ export class VirtualFS {
   }
 
   /**
-   * Serialize the live OPFS WebAccessFS index back to `/.metadata.json`
-   * in the OPFS subdir so filemode bits and symlinks survive a reload.
-   * No-op on the InMemory backend, on backends without a captured index
-   * reference (defensive — should not happen after a successful
-   * `initOpfsBackend`), or if the OPFS handle was never captured. See
-   * {@link opfsBackendFs}.
+   * Persist the sidecar from OUTSIDE a {@link withWriteLock} critical
+   * section (flush / dispose): takes the lock so the read-merge-write is
+   * serialized against every mutation and every other sidecar writer —
+   * in this realm AND in any other context of the origin.
    */
   private async writeOpfsMetadataSidecar(): Promise<void> {
+    if (this.backend !== 'opfs') return;
+    await this.withWriteLock(() => this.writeOpfsMetadataSidecarUnlocked());
+  }
+
+  /**
+   * Serialize this realm's view of the index back to `/.metadata.json` —
+   * but only for the paths this realm actually mutated (#1992).
+   *
+   * The sidecar is shared by every context of the origin (kernel worker,
+   * page-side instances), each holding an independently drifting in-memory
+   * index. A whole-index overwrite from a context with a stale view
+   * re-poisoned a repaired sidecar in production and bricked boot with
+   * `EISDIR` in `crossCopy`. Instead: read the sidecar on disk, overlay
+   * ONLY this realm's dirty paths/prefixes (see {@link markSidecarDirty}),
+   * and write the merge back. A missing/corrupt on-disk sidecar falls back
+   * to the full own-index snapshot (also the fresh-boot seed case).
+   *
+   * The caller must hold {@link withWriteLock} — either the public
+   * {@link writeOpfsMetadataSidecar} wrapper or an in-lock mutation path
+   * (rm / symlink persist eagerly inside their critical section).
+   * No-op on the InMemory backend, on backends without a captured index
+   * reference, or if the OPFS handle was never captured.
+   */
+  private async writeOpfsMetadataSidecarUnlocked(): Promise<void> {
     if (this.backend !== 'opfs') return;
     const backendFs = this.opfsBackendFs;
     const handle = this.opfsHandle;
     if (!backendFs || !handle) return;
-    const json = JSON.stringify(backendFs.index.toJSON());
+    const own = backendFs.index.toJSON() as SidecarIndexJson;
+    const dirty = VirtualFS.opfsBackends.get(this.dbName)?.sidecarDirty;
+    let merged: SidecarIndexJson = own;
+    if (dirty) {
+      let onDisk: SidecarIndexJson | null = null;
+      try {
+        const existing = await handle.getFileHandle('.metadata.json');
+        const parsed: unknown = JSON.parse(await (await existing.getFile()).text());
+        if (parsed && typeof parsed === 'object' && (parsed as SidecarIndexJson).entries) {
+          onDisk = parsed as SidecarIndexJson;
+        }
+      } catch {
+        /* absent or unreadable → full own snapshot below (seed/recovery) */
+      }
+      if (onDisk) merged = mergeSidecarEntries(onDisk, own, dirty);
+    }
+    const json = JSON.stringify(merged);
     const fileHandle = await handle.getFileHandle('.metadata.json', { create: true });
     const writable = await fileHandle.createWritable();
     await writable.write(json);
     await writable.close();
+    // Only clear after a successful write; the write lock guarantees no
+    // same-realm mutation ran (and dirtied new paths) mid-critical-section.
+    if (dirty) {
+      dirty.paths.clear();
+      dirty.prefixes.clear();
+    }
+  }
+
+  /**
+   * Record that this realm mutated `path`, so the next sidecar write may
+   * overwrite that entry (and, for `prefix` marks, the whole subtree —
+   * recursive removes and renames supersede every on-disk child). Ancestor
+   * directories are marked too: parent-ensure materializes their index
+   * records alongside the mutation. Cheap no-op on the memory backend.
+   */
+  private markSidecarDirty(path: string, kind: 'path' | 'prefix' = 'path'): void {
+    if (this.backend !== 'opfs') return;
+    const dirty = VirtualFS.opfsBackends.get(this.dbName)?.sidecarDirty;
+    if (!dirty) return;
+    const normalized = normalizePath(path);
+    (kind === 'prefix' ? dirty.prefixes : dirty.paths).add(normalized);
+    let { dir } = splitPath(normalized);
+    while (dir !== '/') {
+      dirty.paths.add(dir);
+      dir = splitPath(dir).dir;
+    }
   }
 
   /**
@@ -721,6 +800,10 @@ export class VirtualFS {
       const path = normalizePath(raw);
       fs.index.delete(path);
       fs._handles?.delete(path);
+      // The external write changed real state for this path: let the next
+      // sidecar write persist the freshly re-read entry instead of keeping
+      // whatever the sidecar recorded before the external writer ran.
+      this.markSidecarDirty(path);
     }
   }
 
@@ -1336,6 +1419,7 @@ export class VirtualFS {
     // write hit a not-yet-created parent (spurious ENOENT). See withWriteLock.
     const { dir } = splitPath(resolved);
     await this.withWriteLock(async () => {
+      this.markSidecarDirty(resolved);
       if (dir !== '/') {
         await this.mkdirRecursiveUnlocked(dir);
       }
@@ -1579,9 +1663,13 @@ export class VirtualFS {
     if (options?.recursive) {
       // Create all parent directories under the write lock so a concurrent
       // writeFile/symlink can't observe a half-materialized path.
-      await this.withWriteLock(() => this.mkdirRecursiveUnlocked(normalized));
+      await this.withWriteLock(() => {
+        this.markSidecarDirty(normalized);
+        return this.mkdirRecursiveUnlocked(normalized);
+      });
     } else {
       await this.withWriteLock(async () => {
+        this.markSidecarDirty(normalized);
         try {
           await this.lfs.mkdir(normalized);
         } catch (err) {
@@ -1637,7 +1725,10 @@ export class VirtualFS {
         } else {
           await this.lfs.unlink(normalized);
         }
-        await this.writeOpfsMetadataSidecar();
+        // Prefix mark: a recursive remove supersedes every on-disk child
+        // entry, not just the top path (see sidecar-merge.ts).
+        this.markSidecarDirty(normalized, 'prefix');
+        await this.writeOpfsMetadataSidecarUnlocked();
       });
     } catch (err) {
       throw convertError(err, normalized);
@@ -1753,6 +1844,10 @@ export class VirtualFS {
     } catch (err) {
       throw convertError(err, normalizedOld);
     }
+    // Prefix marks on both ends: a directory rename supersedes every
+    // on-disk child entry under the old AND new paths (see sidecar-merge.ts).
+    this.markSidecarDirty(normalizedOld, 'prefix');
+    this.markSidecarDirty(normalizedNew, 'prefix');
     this.watcher?.notify([
       { type: 'delete', path: normalizedOld, entryType },
       { type: 'create', path: normalizedNew, entryType },
@@ -1868,7 +1963,8 @@ export class VirtualFS {
       // write) and only for symlinks (rare vs file writes) keeps a full
       // clone cheap. No-op on the memory backend. See "Root cause: git
       // symlink/binary corruption".
-      await this.writeOpfsMetadataSidecar();
+      this.markSidecarDirty(normalizedLinkPath);
+      await this.writeOpfsMetadataSidecarUnlocked();
     });
     this.watcher?.notify([{ type: 'create', path: normalizedLinkPath, entryType: 'symlink' }]);
   }

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -1840,14 +1840,24 @@ export class VirtualFS {
       /* best effort */
     }
     try {
-      await this.lfs.rename(normalizedOld, normalizedNew);
+      // Mutation, prefix marks, and eager persist share ONE critical
+      // section, matching rm/symlink: marking after an unlocked rename
+      // leaves an await-sized window where a concurrent same-`dbName`
+      // flush snapshots the renamed shared index with clean prefixes and
+      // preserves the on-disk `/old/**` entries — resurrecting the
+      // pre-rename subtree. Marks go BEFORE the mutation; if the rename
+      // then fails, an over-marked prefix merely re-persists reality.
+      // Prefix marks on both ends: a directory rename supersedes every
+      // on-disk child entry under the old AND new paths (sidecar-merge.ts).
+      await this.withWriteLock(async () => {
+        this.markSidecarDirty(normalizedOld, 'prefix');
+        this.markSidecarDirty(normalizedNew, 'prefix');
+        await this.lfs.rename(normalizedOld, normalizedNew);
+        await this.writeOpfsMetadataSidecarUnlocked();
+      });
     } catch (err) {
       throw convertError(err, normalizedOld);
     }
-    // Prefix marks on both ends: a directory rename supersedes every
-    // on-disk child entry under the old AND new paths (see sidecar-merge.ts).
-    this.markSidecarDirty(normalizedOld, 'prefix');
-    this.markSidecarDirty(normalizedNew, 'prefix');
     this.watcher?.notify([
       { type: 'delete', path: normalizedOld, entryType },
       { type: 'create', path: normalizedNew, entryType },

--- a/packages/webapp/tests/fs/sidecar-merge.test.ts
+++ b/packages/webapp/tests/fs/sidecar-merge.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergeSidecarEntries,
+  type SidecarDirtyState,
+  type SidecarIndexJson,
+} from '../../src/fs/sidecar-merge.js';
+
+const entry = (tag: string) => ({ tag });
+
+const dirty = (paths: string[] = [], prefixes: string[] = []): SidecarDirtyState => ({
+  paths: new Set(paths),
+  prefixes: new Set(prefixes),
+});
+
+const doc = (entries: Record<string, unknown>, rest: Partial<SidecarIndexJson> = {}) => ({
+  version: 1,
+  maxSize: 100,
+  ...rest,
+  entries,
+});
+
+describe('mergeSidecarEntries', () => {
+  it('regression #1992: preserves foreign entries a stale context never touched', () => {
+    // On disk: an externally repaired sidecar (e.g. the manual EISDIR fix).
+    const onDisk = doc({
+      '/': entry('root-disk'),
+      '/workspace': entry('dir-repaired'),
+      '/etc': entry('dir-repaired'),
+      '/scoops/x/.github': entry('dir-repaired'),
+    });
+    // This context's stale in-memory index still believes the old poison.
+    const own = doc({
+      '/': entry('root-own'),
+      '/workspace': entry('file-poison'),
+      '/etc': entry('file-poison'),
+      '/scoops/x/.github': entry('file-poison'),
+      '/tmp/own-new.txt': entry('file-own'),
+    });
+    // The context only ever wrote /tmp/own-new.txt.
+    const merged = mergeSidecarEntries(onDisk, own, dirty(['/tmp/own-new.txt', '/tmp']));
+
+    // The repair SURVIVES; only the genuinely-dirty path is overwritten.
+    expect(merged.entries?.['/workspace']).toEqual(entry('dir-repaired'));
+    expect(merged.entries?.['/etc']).toEqual(entry('dir-repaired'));
+    expect(merged.entries?.['/scoops/x/.github']).toEqual(entry('dir-repaired'));
+    expect(merged.entries?.['/tmp/own-new.txt']).toEqual(entry('file-own'));
+  });
+
+  it('an empty dirty set leaves the on-disk entries untouched (root aside)', () => {
+    const onDisk = doc({ '/': entry('root-disk'), '/a.txt': entry('disk') });
+    const own = doc({ '/': entry('root-own'), '/a.txt': entry('stale'), '/b.txt': entry('stale') });
+    const merged = mergeSidecarEntries(onDisk, own, dirty());
+    expect(merged.entries).toEqual({ '/': entry('root-own'), '/a.txt': entry('disk') });
+  });
+
+  it('a dirty path missing from the own index is deleted from the sidecar', () => {
+    const onDisk = doc({ '/gone.txt': entry('disk') });
+    const own = doc({});
+    const merged = mergeSidecarEntries(onDisk, own, dirty(['/gone.txt']));
+    expect(merged.entries).not.toHaveProperty('/gone.txt');
+  });
+
+  it('a dirty prefix drops every on-disk child and copies every own child', () => {
+    const onDisk = doc({
+      '/dir': entry('disk-dir'),
+      '/dir/old-child.txt': entry('disk-child'),
+      '/dir/sub/deep.txt': entry('disk-deep'),
+      '/other.txt': entry('disk-other'),
+    });
+    const own = doc({
+      '/dir': entry('own-dir'),
+      '/dir/new-child.txt': entry('own-child'),
+    });
+    const merged = mergeSidecarEntries(onDisk, own, dirty([], ['/dir']));
+    expect(merged.entries).toEqual({
+      '/dir': entry('own-dir'),
+      '/dir/new-child.txt': entry('own-child'),
+      '/other.txt': entry('disk-other'),
+    });
+  });
+
+  it('a prefix does not swallow a sibling that merely shares the name prefix', () => {
+    const onDisk = doc({ '/ab': entry('disk-ab'), '/a': entry('disk-a') });
+    const own = doc({});
+    const merged = mergeSidecarEntries(onDisk, own, dirty([], ['/a']));
+    // '/a' removed (own has nothing under it); '/ab' is NOT under '/a'.
+    expect(merged.entries).toEqual({ '/ab': entry('disk-ab') });
+  });
+
+  it('rename shape: old prefix disappears, new prefix comes wholly from own', () => {
+    const onDisk = doc({
+      '/old': entry('disk'),
+      '/old/f.txt': entry('disk'),
+    });
+    const own = doc({
+      '/new': entry('own'),
+      '/new/f.txt': entry('own'),
+    });
+    const merged = mergeSidecarEntries(onDisk, own, dirty([], ['/old', '/new']));
+    expect(merged.entries).toEqual({ '/new': entry('own'), '/new/f.txt': entry('own') });
+  });
+
+  it('takes root entry and top-level fields from the own index', () => {
+    const onDisk = doc({ '/': entry('root-disk') }, { version: 0, maxSize: 5 });
+    const own = doc({ '/': entry('root-own') }, { version: 2, maxSize: 200 });
+    const merged = mergeSidecarEntries(onDisk, own, dirty());
+    expect(merged.version).toBe(2);
+    expect(merged.maxSize).toBe(200);
+    expect(merged.entries?.['/']).toEqual(entry('root-own'));
+  });
+
+  it('tolerates documents with absent entries maps', () => {
+    const merged = mergeSidecarEntries({ version: 1 }, { version: 1 }, dirty(['/x']));
+    expect(merged.entries).toEqual({});
+  });
+});

--- a/packages/webapp/tests/fs/virtual-fs.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs.test.ts
@@ -161,9 +161,11 @@ describe('VirtualFS', () => {
         (_, i) => `/large-tree/pkg${i % 10}/nested/file${i}.txt`
       );
       await Promise.all(paths.map((path) => vfs.writeFile(path, path)));
+      // rm persists eagerly INSIDE its write-lock critical section, so it
+      // calls the unlocked variant (the locked wrapper would deadlock).
       const flushSpy = vi.spyOn(
-        vfs as unknown as { writeOpfsMetadataSidecar(): Promise<void> },
-        'writeOpfsMetadataSidecar'
+        vfs as unknown as { writeOpfsMetadataSidecarUnlocked(): Promise<void> },
+        'writeOpfsMetadataSidecarUnlocked'
       );
 
       await vfs.rm('/large-tree', { recursive: true });

--- a/packages/webapp/tests/fs/virtual-fs.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs.test.ts
@@ -217,6 +217,23 @@ describe('VirtualFS', () => {
       expect(await vfs.exists('/src')).toBe(false);
       expect(await vfs.readTextFile('/source/main.ts')).toBe('code');
     });
+
+    it('persists sidecar metadata eagerly inside the rename critical section', async () => {
+      await vfs.writeFile('/ren-src/file.txt', 'x');
+      // rename persists INSIDE its write-lock critical section (same shape
+      // as rm/symlink), so it calls the unlocked variant — marking dirty
+      // after an unlocked rename would let a concurrent flush resurrect
+      // the on-disk /old subtree (PR #1993 review).
+      const flushSpy = vi.spyOn(
+        vfs as unknown as { writeOpfsMetadataSidecarUnlocked(): Promise<void> },
+        'writeOpfsMetadataSidecarUnlocked'
+      );
+
+      await vfs.rename('/ren-src', '/ren-dest');
+
+      expect(await vfs.readTextFile('/ren-dest/file.txt')).toBe('x');
+      expect(flushSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('copyFile', () => {


### PR DESCRIPTION
## What

Fixes #1992 — the root cause of both production boot-bricks (2026-08-07 and 2026-08-08).

The OPFS `/.metadata.json` sidecar was written as a **whole-file snapshot of the calling context's in-memory `WebAccessFS` index, outside any lock** (`writeOpfsMetadataSidecar` in `fs/virtual-fs.ts`). Multiple contexts — the kernel worker and page-side `VirtualFS` instances — each hold an independently drifting, lazily-populated index and each call `flush()`. Whichever context wrote last replaced the sidecar with its private view, including entries it never touched. Observed in production: a manually repaired sidecar was re-poisoned within hours (the exact repaired paths re-flipped `dir→file`, and 71 entries carried stale sizes), bricking boot with `EISDIR` in `crossCopy` (#1984).

## How

1. **Lock**: sidecar writes now run under the same cross-context Web Lock (`slicc-vfs:<dbName>`) as every OPFS mutation — via `withWriteLock`, reusing the in-realm chain too. In-lock persist sites (the eager `rm`/`symlink` writes) call a new `writeOpfsMetadataSidecarUnlocked` to keep the lock non-reentrant.
2. **Merge-on-write**: `sidecar-merge.ts` (new, pure, unit-tested) merges this realm's index over the on-disk sidecar constrained to the realm's **dirty paths** — tracked per `dbName` alongside the shared backend entry. Exact marks for `writeFile`/`mkdir`/`symlink` (plus ancestors); **prefix marks** for `rm`/`rename`, superseding whole subtrees so deleted children can't resurrect from the on-disk base. `invalidatePaths` (external writers, e.g. the Python realm) marks too, so the freshly re-read entries persist.
3. **Fallback**: a missing/corrupt on-disk sidecar falls back to the full own-index snapshot — the previous behavior, and the fresh-boot seed path.

A context that mutated nothing now leaves the sidecar untouched on `flush()` — which is precisely the property whose absence caused the incident.

## Tests

- `tests/fs/sidecar-merge.test.ts` — merge semantics, including the incident regression (external repair survives a stale context's flush), prefix supersession, rename shape, sibling-name-prefix safety, root/top-level field sourcing.
- `tests/fs/virtual-fs.test.ts` — the rm eager-persist spy retargeted to the unlocked variant.
- Full pass: verify, debt gate, typecheck, 13,972 tests, coverage, both builds, bundle-size — green.

## Follow-up (separate PR, next in queue)

Boot-time sidecar validate/self-heal + kernel boot-error propagation (#1984) — defense in depth so any residual poisoning degrades to a repaired boot instead of a 30s timeout and a data-wipe prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65