### PR TITLE
feat(ui): worker self-triage before the recovery screen suggests a data wipe (#1982)

### DIFF
--- a/packages/assets/worker-probe.js
+++ b/packages/assets/worker-probe.js
@@ -1,0 +1,7 @@
+// Boot-triage probe (`ui/boot/worker-triage.ts`): a deliberately tiny
+// worker script served un-hashed from the app root. Its only job is to
+// prove that http(s) worker main-script loads work in this browser
+// session — a wedged Chrome starts blob workers but leaves this one
+// silent (#1982). Loaded as a module worker; keep it module-safe and
+// side-effect-free beyond the postMessage.
+self.postMessage(1);

--- a/packages/webapp/src/ui/boot/recovery-screen.ts
+++ b/packages/webapp/src/ui/boot/recovery-screen.ts
@@ -18,6 +18,7 @@
 
 import { NUKE_LOCAL_STORAGE_KEYS } from '../../shell/supplemental-commands/nuke-channel.js';
 import { wipeLocalStorageState } from '../../shell/supplemental-commands/wipe-local-storage-state.js';
+import type { WorkerTriageVerdict } from './worker-triage.js';
 
 /** Injectable seams so the render test can assert wipe+reload without
  *  touching real OPFS/IDB or navigating the test page. */
@@ -26,6 +27,12 @@ export interface RecoveryScreenDeps {
   wipe?: () => Promise<void>;
   /** Reload the page. Defaults to `location.reload()`. */
   reload?: () => void;
+  /**
+   * Worker-health triage verdict (#1982). `browser-wedged` switches the
+   * screen to the browser-restart variant: the data wipe demonstrably
+   * cannot fix a wedged browser, so it is demoted, not promoted.
+   */
+  verdict?: WorkerTriageVerdict;
 }
 
 /**
@@ -40,16 +47,22 @@ export function renderBootRecoveryScreen(
   error: unknown,
   deps: RecoveryScreenDeps = {}
 ): void {
+  // A wipe kicked off from a previous render must not be re-rendered
+  // over — the triage re-render (#1982) arrives seconds after the first
+  // paint and could otherwise replace the "Resetting…" state mid-wipe.
+  if (app.dataset['recoveryBusy'] === '1') return;
+
   const wipe = deps.wipe ?? wipeLocalStorageState;
   const reload = deps.reload ?? (() => location.reload());
   const message = error instanceof Error ? error.message : String(error);
+  const wedged = deps.verdict === 'browser-wedged';
 
   const box = document.createElement('div');
   box.style.cssText = 'padding:2rem;text-align:center;font-family:system-ui;';
 
   const h1 = document.createElement('h1');
   h1.style.color = 'var(--s2-negative, #e34850)';
-  h1.textContent = 'Failed to start';
+  h1.textContent = wedged ? 'Your browser needs a restart' : 'Failed to start';
 
   const p = document.createElement('p');
   p.style.color = 'var(--s2-content-tertiary, #717171)';
@@ -62,16 +75,24 @@ export function renderBootRecoveryScreen(
   const resetBtn = document.createElement('button');
   resetBtn.type = 'button';
   resetBtn.textContent = 'Reset local data & reload';
-  resetBtn.style.cssText =
-    'padding:0.5rem 1rem;cursor:pointer;border:1px solid var(--s2-negative, #e34850);' +
-    'background:var(--s2-negative, #e34850);color:#fff;border-radius:4px;';
+  // Demoted on a wedged browser: the wipe destroys intact data and fixes
+  // nothing there, so it renders as a plain outline action instead of the
+  // filled negative. The data attribute is the stable semantic hook.
+  resetBtn.dataset['variant'] = wedged ? 'demoted' : 'destructive';
+  resetBtn.style.cssText = wedged
+    ? 'padding:0.5rem 1rem;cursor:pointer;border:1px solid var(--s2-content-tertiary, #717171);' +
+      'background:transparent;color:inherit;border-radius:4px;'
+    : 'padding:0.5rem 1rem;cursor:pointer;border:1px solid var(--s2-negative, #e34850);' +
+      'background:var(--s2-negative, #e34850);color:#fff;border-radius:4px;';
 
   const reloadBtn = document.createElement('button');
   reloadBtn.type = 'button';
   reloadBtn.textContent = 'Reload';
-  reloadBtn.style.cssText =
-    'padding:0.5rem 1rem;cursor:pointer;border:1px solid var(--s2-content-tertiary, #717171);' +
-    'background:transparent;color:inherit;border-radius:4px;';
+  reloadBtn.style.cssText = wedged
+    ? 'padding:0.5rem 1rem;cursor:pointer;border:1px solid var(--s2-accent, #0265dc);' +
+      'background:var(--s2-accent, #0265dc);color:#fff;border-radius:4px;'
+    : 'padding:0.5rem 1rem;cursor:pointer;border:1px solid var(--s2-content-tertiary, #717171);' +
+      'background:transparent;color:inherit;border-radius:4px;';
 
   // Explicit click is the confirmation — no auto-wipe. Disable both
   // buttons while the wipe runs so a double-click can't fire it twice,
@@ -81,6 +102,7 @@ export function renderBootRecoveryScreen(
     resetBtn.disabled = true;
     reloadBtn.disabled = true;
     resetBtn.textContent = 'Resetting…';
+    app.dataset['recoveryBusy'] = '1';
     void (async () => {
       try {
         await wipe();
@@ -107,8 +129,23 @@ export function renderBootRecoveryScreen(
     reload();
   });
 
-  actions.append(resetBtn, reloadBtn);
-  box.append(h1, p, actions);
+  if (wedged) {
+    // Restart-first ordering, plus an explanation that names the actual
+    // fix and explicitly protects the (intact) local data.
+    const why = document.createElement('p');
+    why.style.cssText = 'max-width:34rem;margin:1rem auto 0;';
+    why.textContent =
+      'This browser has stopped starting web workers — a browser process ' +
+      'issue, not a problem with your data. Quit the browser completely, ' +
+      'reopen it, and come back. Your local data is intact; resetting it ' +
+      'will not fix this.';
+    box.append(h1, p, why);
+    actions.append(reloadBtn, resetBtn);
+  } else {
+    box.append(h1, p);
+    actions.append(resetBtn, reloadBtn);
+  }
+  box.append(actions);
 
   while (app.firstChild) app.removeChild(app.firstChild);
   app.appendChild(box);

--- a/packages/webapp/src/ui/boot/worker-triage.ts
+++ b/packages/webapp/src/ui/boot/worker-triage.ts
@@ -32,6 +32,11 @@ export interface WorkerTriageDeps {
   spawnBlobWorker?: () => ProbeWorker;
   /** Spawn the network module-worker probe. Defaults to `/worker-probe.js`. */
   spawnModuleWorker?: () => ProbeWorker;
+  /**
+   * Page-realm fetch of the probe URL; resolve `true` on an ok response.
+   * Defaults to `fetch('/worker-probe.js')` under the same timeout.
+   */
+  fetchProbeScript?: (timeoutMs: number) => Promise<boolean>;
   /** Per-probe silence window. */
   timeoutMs?: number;
 }
@@ -91,22 +96,45 @@ function defaultModuleWorker(): ProbeWorker {
 }
 
 /**
+ * The wedge's defining evidence in the incident: the PAGE could fetch
+ * the very asset the worker never loaded (~30 ms). A silent worker with
+ * an unfetchable script is a network/SW outage, not a browser wedge —
+ * restarting the browser wouldn't fix it, so no verdict is claimed.
+ */
+async function defaultFetchProbeScript(timeoutMs: number): Promise<boolean> {
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), timeoutMs);
+  try {
+    const res = await fetch('/worker-probe.js', { cache: 'no-store', signal: abort.signal });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Classify the browser's worker health. `browser-wedged` — blob workers
- * run but a network module worker stays silent: restarting the browser
- * is the fix and wiping local data is not. `workers-ok` — the network
- * module worker signalled, so the boot failure lies elsewhere.
- * `inconclusive` — anything else (both silent, spawn failures): no
- * claim, keep the default recovery UI.
+ * run, the page can fetch the probe script, yet a network module worker
+ * stays silent: restarting the browser is the fix and wiping local data
+ * is not. `workers-ok` — the network module worker signalled, so the
+ * boot failure lies elsewhere. `inconclusive` — anything else (both
+ * probes silent, spawn failures, probe script unfetchable): no claim,
+ * keep the default recovery UI.
  */
 export async function triageModuleWorkerHealth(
   deps: WorkerTriageDeps = {}
 ): Promise<WorkerTriageVerdict> {
   const timeoutMs = deps.timeoutMs ?? PROBE_TIMEOUT_MS;
-  const [blobResult, moduleResult] = await Promise.all([
+  const [blobResult, moduleResult, scriptFetchable] = await Promise.all([
     runProbe(deps.spawnBlobWorker ?? defaultBlobWorker, timeoutMs),
     runProbe(deps.spawnModuleWorker ?? defaultModuleWorker, timeoutMs),
+    (deps.fetchProbeScript ?? defaultFetchProbeScript)(timeoutMs),
   ]);
-  if (blobResult === 'signal' && moduleResult === 'silent') return 'browser-wedged';
+  if (blobResult === 'signal' && moduleResult === 'silent' && scriptFetchable) {
+    return 'browser-wedged';
+  }
   if (moduleResult === 'signal') return 'workers-ok';
   return 'inconclusive';
 }

--- a/packages/webapp/src/ui/boot/worker-triage.ts
+++ b/packages/webapp/src/ui/boot/worker-triage.ts
@@ -1,0 +1,112 @@
+/**
+ * `worker-triage.ts` — cheap browser-side self-triage for kernel-ready
+ * boot timeouts (#1982).
+ *
+ * A Chrome session can wedge its browser-process plumbing for http(s)
+ * module-worker MAIN-SCRIPT loads: `new Worker('/assets/x.js',
+ * {type:'module'})` then never starts — no message, no error — while
+ * blob workers, worker-context fetches, and imports from blob workers
+ * all keep working (observed in production on Chrome 151, 2026-08-07).
+ * In that state the kernel worker can never boot, the recovery screen's
+ * "Reset local data & reload" destroys the (intact) VFS + history
+ * without fixing anything, and only a full browser restart helps.
+ *
+ * Two probes tell the situations apart:
+ *  1. blob classic worker — proves worker infrastructure works at all.
+ *  2. network module worker (`/worker-probe.js`, an un-hashed static
+ *     file) — reproduces the exact shape that wedges. ANY signal
+ *     (message or error) within the window means the load path is fine;
+ *     the wedge's signature is silence.
+ */
+
+export type WorkerTriageVerdict = 'browser-wedged' | 'workers-ok' | 'inconclusive';
+
+/** Structural subset of `Worker` used by the probes, for test fakes. */
+export interface ProbeWorker {
+  addEventListener(type: 'message' | 'error', listener: () => void): void;
+  terminate(): void;
+}
+
+export interface WorkerTriageDeps {
+  /** Spawn the blob classic-worker probe. Defaults to a real `Worker`. */
+  spawnBlobWorker?: () => ProbeWorker;
+  /** Spawn the network module-worker probe. Defaults to `/worker-probe.js`. */
+  spawnModuleWorker?: () => ProbeWorker;
+  /** Per-probe silence window. */
+  timeoutMs?: number;
+}
+
+/**
+ * Silence window per probe. The wedge never resolves, so anything beyond
+ * "comfortably slower than a same-origin 20-byte script fetch" only
+ * delays the improved recovery message.
+ */
+const PROBE_TIMEOUT_MS = 3000;
+
+type ProbeResult = 'signal' | 'silent' | 'spawn-failed';
+
+function runProbe(spawn: () => ProbeWorker, timeoutMs: number): Promise<ProbeResult> {
+  return new Promise((resolve) => {
+    let worker: ProbeWorker;
+    try {
+      worker = spawn();
+    } catch {
+      resolve('spawn-failed');
+      return;
+    }
+    let settled = false;
+    const finish = (result: ProbeResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        worker.terminate();
+      } catch {
+        /* probe cleanup is best-effort */
+      }
+      resolve(result);
+    };
+    const timer = setTimeout(() => finish('silent'), timeoutMs);
+    // An 'error' still counts as a signal: the worker got far enough to
+    // fetch/parse its script. The wedge's signature is total silence.
+    worker.addEventListener('message', () => finish('signal'));
+    worker.addEventListener('error', () => finish('signal'));
+  });
+}
+
+function defaultBlobWorker(): ProbeWorker {
+  const blob = new Blob(['self.postMessage(1)'], { type: 'text/javascript' });
+  const url = URL.createObjectURL(blob);
+  try {
+    return new Worker(url);
+  } finally {
+    // The main-script fetch resolves against the live object URL at
+    // construction; revoking immediately after is safe and leak-free.
+    URL.revokeObjectURL(url);
+  }
+}
+
+function defaultModuleWorker(): ProbeWorker {
+  return new Worker('/worker-probe.js', { type: 'module' });
+}
+
+/**
+ * Classify the browser's worker health. `browser-wedged` — blob workers
+ * run but a network module worker stays silent: restarting the browser
+ * is the fix and wiping local data is not. `workers-ok` — the network
+ * module worker signalled, so the boot failure lies elsewhere.
+ * `inconclusive` — anything else (both silent, spawn failures): no
+ * claim, keep the default recovery UI.
+ */
+export async function triageModuleWorkerHealth(
+  deps: WorkerTriageDeps = {}
+): Promise<WorkerTriageVerdict> {
+  const timeoutMs = deps.timeoutMs ?? PROBE_TIMEOUT_MS;
+  const [blobResult, moduleResult] = await Promise.all([
+    runProbe(deps.spawnBlobWorker ?? defaultBlobWorker, timeoutMs),
+    runProbe(deps.spawnModuleWorker ?? defaultModuleWorker, timeoutMs),
+  ]);
+  if (blobResult === 'signal' && moduleResult === 'silent') return 'browser-wedged';
+  if (moduleResult === 'signal') return 'workers-ok';
+  return 'inconclusive';
+}

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -24,7 +24,6 @@ import { initTelemetry } from '../kernel/telemetry.js';
 // — the extension agent engine runs in the offscreen document, not in this file.
 import { registerProviders } from '../providers/index.js';
 import { parseBridgeLaunchParams } from './boot/bridge-launch-params.js';
-import { renderBootRecoveryScreen } from './boot/recovery-screen.js';
 import { installExtensionFetchDelegate } from './boot/setup-extension-fetch-delegate.js';
 import { setupFeatureFlagsForPage } from './boot/setup-feature-flags.js';
 import { startFreezeWatchdog } from './boot/setup-freeze-watchdog.js';
@@ -169,11 +168,59 @@ async function main(): Promise<void> {
   return mountWcUiLive(app, log, runtimeMode);
 }
 
+/**
+ * Absolute-last-resort surface when even the recovery chunk cannot load
+ * (offline plus boot failure). Inline on purpose: no imports, error text
+ * and a reload only — never a wipe the user can't be warned about.
+ */
+function renderMinimalRecovery(app: HTMLElement, err: unknown): void {
+  const box = document.createElement('div');
+  box.style.cssText = 'padding:2rem;text-align:center;font-family:system-ui;';
+  const h1 = document.createElement('h1');
+  h1.textContent = 'Failed to start';
+  const p = document.createElement('p');
+  p.textContent = err instanceof Error ? err.message : String(err);
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.textContent = 'Reload';
+  btn.addEventListener('click', () => location.reload());
+  box.append(h1, p, btn);
+  app.replaceChildren(box);
+}
+
+/**
+ * Boot-failure path. The recovery screen — error message, one-click
+ * "Reset local data & reload" (same wipe as `nuke`), plain "Reload" —
+ * lives in a lazy chunk to keep the main entry lean; page-realm dynamic
+ * imports keep working in every observed failure mode (including the
+ * module-worker wedge), with {@link renderMinimalRecovery} as the inline
+ * fallback. A kernel-ready timeout then runs the worker triage (#1982):
+ * a wedged browser gets the restart-first variant instead of a
+ * destructive wipe suggestion that cannot fix it.
+ */
+async function bootRecovery(app: HTMLElement, err: unknown): Promise<void> {
+  let renderScreen: typeof import('./boot/recovery-screen.js').renderBootRecoveryScreen;
+  try {
+    ({ renderBootRecoveryScreen: renderScreen } = await import('./boot/recovery-screen.js'));
+  } catch {
+    renderMinimalRecovery(app, err);
+    return;
+  }
+  renderScreen(app, err);
+  if (!(err instanceof Error && err.message.includes('did not signal ready'))) return;
+  try {
+    // The default screen above stays interactive while the ≤3 s probes run.
+    const { triageModuleWorkerHealth } = await import('./boot/worker-triage.js');
+    const verdict = await triageModuleWorkerHealth();
+    if (verdict === 'browser-wedged') renderScreen(app, err, { verdict });
+  } catch {
+    /* triage is best-effort; the default recovery screen stands */
+  }
+}
+
 main().catch((err) => {
   log.error('Fatal error', err);
   const app = document.getElementById('app');
-  // Render the recovery screen — the error message plus a one-click
-  // "Reset local data & reload" (same wipe as `nuke`) and a plain
-  // "Reload" retry — reachable even when the shell never booted.
-  if (app) renderBootRecoveryScreen(app, err);
+  if (!app) return;
+  void bootRecovery(app, err);
 });

--- a/packages/webapp/tests/ui/boot/recovery-screen.test.ts
+++ b/packages/webapp/tests/ui/boot/recovery-screen.test.ts
@@ -146,3 +146,79 @@ describe('renderBootRecoveryScreen', () => {
     expect(wipe).not.toHaveBeenCalled();
   });
 });
+
+describe('renderBootRecoveryScreen — browser-wedged variant (#1982)', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function mountWedged(deps: { wipe?: () => Promise<void>; reload?: () => void } = {}) {
+    const app = document.createElement('div');
+    document.body.appendChild(app);
+    renderBootRecoveryScreen(app, new Error('Kernel worker did not signal ready within 30000ms'), {
+      wipe: deps.wipe ?? vi.fn(async () => {}),
+      reload: deps.reload ?? vi.fn(),
+      verdict: 'browser-wedged',
+    });
+    return app;
+  }
+
+  it('leads with the browser restart, not the failure', () => {
+    const app = mountWedged();
+    expect(app.querySelector('h1')?.textContent).toBe('Your browser needs a restart');
+    // The explanation names the fix and protects the data.
+    const text = app.textContent ?? '';
+    expect(text).toContain('Quit the browser completely');
+    expect(text).toContain('resetting it will not fix this');
+  });
+
+  it('orders Reload first and demotes (but keeps) the destructive reset', () => {
+    const app = mountWedged();
+    const buttons = [...app.querySelectorAll('button')];
+    expect(buttons.map((b) => b.textContent)).toEqual(['Reload', 'Reset local data & reload']);
+    // Demoted: the reset is no longer the filled negative action.
+    expect(buttons[1]?.dataset['variant']).toBe('demoted');
+  });
+
+  it('the demoted reset still wipes and reloads when explicitly chosen', async () => {
+    const wipe = vi.fn(async () => {});
+    const reload = vi.fn();
+    const app = mountWedged({ wipe, reload });
+    const reset = [...app.querySelectorAll('button')].find(
+      (b) => b.textContent === 'Reset local data & reload'
+    ) as HTMLButtonElement;
+    reset.click();
+    await vi.waitFor(() => expect(reload).toHaveBeenCalled());
+    expect(wipe).toHaveBeenCalledTimes(1);
+  });
+
+  it('the triage re-render never replaces a wipe in progress', async () => {
+    let releaseWipe: () => void = () => {};
+    const wipe = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseWipe = resolve;
+        })
+    );
+    const reload = vi.fn();
+    const app = document.createElement('div');
+    document.body.appendChild(app);
+    const err = new Error('Kernel worker did not signal ready within 30000ms');
+    renderBootRecoveryScreen(app, err, { wipe, reload });
+    const reset = [...app.querySelectorAll('button')].find(
+      (b) => b.textContent === 'Reset local data & reload'
+    ) as HTMLButtonElement;
+    reset.click();
+    expect(reset.textContent).toBe('Resetting…');
+
+    // The (late) triage verdict arrives mid-wipe: the re-render is a no-op.
+    renderBootRecoveryScreen(app, err, { wipe, reload, verdict: 'browser-wedged' });
+    expect(app.querySelector('h1')?.textContent).toBe('Failed to start');
+    expect([...app.querySelectorAll('button')][0]?.textContent).toBe('Resetting…');
+
+    releaseWipe();
+    await vi.waitFor(() => expect(reload).toHaveBeenCalled());
+  });
+});

--- a/packages/webapp/tests/ui/boot/worker-triage.test.ts
+++ b/packages/webapp/tests/ui/boot/worker-triage.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type ProbeWorker, triageModuleWorkerHealth } from '../../../src/ui/boot/worker-triage.js';
+
+/** A fake worker that signals on the given channel after `delayMs` (or never). */
+function fakeWorker(behavior: 'message' | 'error' | 'silent', delayMs = 0) {
+  const terminate = vi.fn();
+  const spawn = (): ProbeWorker => ({
+    addEventListener(type, listener) {
+      if (type === behavior) setTimeout(listener, delayMs);
+    },
+    terminate,
+  });
+  return { spawn, terminate };
+}
+
+function throwingSpawn(): ProbeWorker {
+  throw new Error('worker construction refused');
+}
+
+describe('triageModuleWorkerHealth (#1982)', () => {
+  it('classifies blob-alive + module-silent as browser-wedged', async () => {
+    const blob = fakeWorker('message');
+    const mod = fakeWorker('silent');
+    const verdict = await triageModuleWorkerHealth({
+      spawnBlobWorker: blob.spawn,
+      spawnModuleWorker: mod.spawn,
+      timeoutMs: 20,
+    });
+    expect(verdict).toBe('browser-wedged');
+    // Both probes are torn down whatever they reported.
+    expect(blob.terminate).toHaveBeenCalledTimes(1);
+    expect(mod.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies a responsive module worker as workers-ok', async () => {
+    const blob = fakeWorker('message');
+    const mod = fakeWorker('message');
+    await expect(
+      triageModuleWorkerHealth({
+        spawnBlobWorker: blob.spawn,
+        spawnModuleWorker: mod.spawn,
+        timeoutMs: 20,
+      })
+    ).resolves.toBe('workers-ok');
+  });
+
+  it("counts a module worker 'error' event as a signal — the wedge is silence", async () => {
+    const blob = fakeWorker('message');
+    const mod = fakeWorker('error');
+    await expect(
+      triageModuleWorkerHealth({
+        spawnBlobWorker: blob.spawn,
+        spawnModuleWorker: mod.spawn,
+        timeoutMs: 20,
+      })
+    ).resolves.toBe('workers-ok');
+  });
+
+  it('is inconclusive when both probes stay silent', async () => {
+    const blob = fakeWorker('silent');
+    const mod = fakeWorker('silent');
+    await expect(
+      triageModuleWorkerHealth({
+        spawnBlobWorker: blob.spawn,
+        spawnModuleWorker: mod.spawn,
+        timeoutMs: 20,
+      })
+    ).resolves.toBe('inconclusive');
+  });
+
+  it('is inconclusive when the blob probe cannot even spawn', async () => {
+    const mod = fakeWorker('silent');
+    await expect(
+      triageModuleWorkerHealth({
+        spawnBlobWorker: throwingSpawn,
+        spawnModuleWorker: mod.spawn,
+        timeoutMs: 20,
+      })
+    ).resolves.toBe('inconclusive');
+  });
+
+  it('still reports workers-ok when only the blob spawn fails', async () => {
+    const mod = fakeWorker('message');
+    await expect(
+      triageModuleWorkerHealth({
+        spawnBlobWorker: throwingSpawn,
+        spawnModuleWorker: mod.spawn,
+        timeoutMs: 20,
+      })
+    ).resolves.toBe('workers-ok');
+  });
+});

--- a/packages/webapp/tests/ui/boot/worker-triage.test.ts
+++ b/packages/webapp/tests/ui/boot/worker-triage.test.ts
@@ -18,13 +18,17 @@ function throwingSpawn(): ProbeWorker {
 }
 
 describe('triageModuleWorkerHealth (#1982)', () => {
+  /** Defaults: probe script fetchable, short windows. Cases override. */
+  function triage(deps: Parameters<typeof triageModuleWorkerHealth>[0]) {
+    return triageModuleWorkerHealth({ fetchProbeScript: async () => true, timeoutMs: 20, ...deps });
+  }
+
   it('classifies blob-alive + module-silent as browser-wedged', async () => {
     const blob = fakeWorker('message');
     const mod = fakeWorker('silent');
-    const verdict = await triageModuleWorkerHealth({
+    const verdict = await triage({
       spawnBlobWorker: blob.spawn,
       spawnModuleWorker: mod.spawn,
-      timeoutMs: 20,
     });
     expect(verdict).toBe('browser-wedged');
     // Both probes are torn down whatever they reported.
@@ -36,10 +40,9 @@ describe('triageModuleWorkerHealth (#1982)', () => {
     const blob = fakeWorker('message');
     const mod = fakeWorker('message');
     await expect(
-      triageModuleWorkerHealth({
+      triage({
         spawnBlobWorker: blob.spawn,
         spawnModuleWorker: mod.spawn,
-        timeoutMs: 20,
       })
     ).resolves.toBe('workers-ok');
   });
@@ -48,10 +51,9 @@ describe('triageModuleWorkerHealth (#1982)', () => {
     const blob = fakeWorker('message');
     const mod = fakeWorker('error');
     await expect(
-      triageModuleWorkerHealth({
+      triage({
         spawnBlobWorker: blob.spawn,
         spawnModuleWorker: mod.spawn,
-        timeoutMs: 20,
       })
     ).resolves.toBe('workers-ok');
   });
@@ -60,10 +62,9 @@ describe('triageModuleWorkerHealth (#1982)', () => {
     const blob = fakeWorker('silent');
     const mod = fakeWorker('silent');
     await expect(
-      triageModuleWorkerHealth({
+      triage({
         spawnBlobWorker: blob.spawn,
         spawnModuleWorker: mod.spawn,
-        timeoutMs: 20,
       })
     ).resolves.toBe('inconclusive');
   });
@@ -71,10 +72,9 @@ describe('triageModuleWorkerHealth (#1982)', () => {
   it('is inconclusive when the blob probe cannot even spawn', async () => {
     const mod = fakeWorker('silent');
     await expect(
-      triageModuleWorkerHealth({
+      triage({
         spawnBlobWorker: throwingSpawn,
         spawnModuleWorker: mod.spawn,
-        timeoutMs: 20,
       })
     ).resolves.toBe('inconclusive');
   });
@@ -82,11 +82,26 @@ describe('triageModuleWorkerHealth (#1982)', () => {
   it('still reports workers-ok when only the blob spawn fails', async () => {
     const mod = fakeWorker('message');
     await expect(
-      triageModuleWorkerHealth({
+      triage({
         spawnBlobWorker: throwingSpawn,
         spawnModuleWorker: mod.spawn,
-        timeoutMs: 20,
       })
     ).resolves.toBe('workers-ok');
+  });
+
+  it('never blames the browser when the probe script is not fetchable', async () => {
+    // A network/SW outage produces the same blob-alive + module-silent
+    // shape as the wedge; the page-realm fetch is the discriminator — in
+    // the real incident the page fetched the asset the worker never
+    // loaded. Unfetchable script → no restart diagnosis.
+    const blob = fakeWorker('message');
+    const mod = fakeWorker('silent');
+    await expect(
+      triage({
+        spawnBlobWorker: blob.spawn,
+        spawnModuleWorker: mod.spawn,
+        fetchProbeScript: async () => false,
+      })
+    ).resolves.toBe('inconclusive');
   });
 });


### PR DESCRIPTION
Closes #1982 — from the 2026-08-07 production incident where a wedged Chrome (http(s) module workers silently never starting) made every reload fail with `Kernel worker did not signal ready within 30000ms`, and the recovery screen's primary suggestion was **Reset local data & reload** — which would have destroyed an intact VFS + chat history without fixing boot.

## What changed

**Two-probe triage** (`ui/boot/worker-triage.ts`, injectable + unit-tested): on a kernel-ready-timeout boot failure, the page runs, in parallel with the already-rendered default recovery screen staying interactive:
1. a **blob classic worker** probe — proves worker infrastructure works at all;
2. a **network module worker** probe from the new un-hashed static `/worker-probe.js` (`packages/assets/`, the webapp's Vite publicDir) — reproduces the exact load shape that wedges. Any signal within 3 s (message **or** error) counts as healthy; the wedge's signature is total silence.

**Verdicts**: blob-alive + module-silent → `browser-wedged`; module signal → `workers-ok`; anything else (both silent, spawn refused) → `inconclusive`, no claim. Only `browser-wedged` changes the UI.

**Restart-first recovery variant** (`recovery-screen.ts`): headline "Your browser needs a restart", an explanation naming the actual fix and stating the data is intact, **Reload promoted**, and the wipe demoted to a plain outline action (`data-variant="demoted"`), still available but no longer presented as the fix. A wipe already in progress is never re-rendered over (busy guard).

**Bundle discipline**: the main-entry budget had **56 bytes** of headroom, so rather than raising the ratchet the recovery screen moved into a lazy chunk (2.9 kB) with a tiny inline error+reload fallback if even that fetch fails; triage is a second lazy chunk (0.8 kB), loaded only on kernel-ready timeouts. Main entry: 15.3 kB → **14.3 kB** (22.87 kB total vs 24 kB budget).

## Failure-mode reasoning

- In the observed wedge, page-realm dynamic imports kept working (proven live during the incident), so the lazy recovery chunk loads fine exactly when the triage matters.
- Stale-deploy chunk failures already trigger `setupPreloadErrorReload`'s guarded reload before this path matters; offline+boot-failure degrades to the inline minimal screen (reload only — deliberately no un-warned wipe).
- Triage failure of any kind leaves the default recovery screen standing (best-effort `catch`).

## Tests

- `worker-triage.test.ts` (new, 6): wedged classification, ok via message, **ok via error event** (the wedge is silence, not failure), inconclusive on both-silent and blob-spawn-refused, ok when only blob fails, probe teardown.
- `recovery-screen.test.ts` (+4): restart-first copy and ordering, demoted-but-functional wipe, and the busy-guard (a late triage verdict never replaces a "Resetting…" in progress).

## Verification

`npm run verify` 7/7 · debt gate OK · `typecheck` clean · `npm run test` 14,015 passed · coverage floors pass · both builds · bundle-size within budget (headroom improved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65