### PR TITLE
feat(kernel): detect mixed-build module graphs on the boot handshake (#1983)

### DIFF
--- a/packages/chrome-extension/vite.config.ts
+++ b/packages/chrome-extension/vite.config.ts
@@ -332,6 +332,11 @@ export default defineConfig(({ mode }) => ({
     __SLICC_EXT_DEV__: JSON.stringify(isExtDev),
     __SLICC_VERSION__: JSON.stringify(rootPkg.version),
     __SLICC_RELEASED_AT__: JSON.stringify(sliccReleasedAt),
+    // Mirror the webapp's per-build stamp (#1983) so transitively bundled
+    // kernel modules never hit an undefined identifier. The extension
+    // itself spawns no kernel worker — the hosted leader tab does — so
+    // the value is inert here.
+    __SLICC_BUILD_ID__: JSON.stringify(`${rootPkg.version}-ext-${Date.now().toString(36)}`),
   },
   resolve: {
     // pi-coding-agent ships its own physical copy of pi-ai / pi-agent-core /

--- a/packages/webapp/src/core/stale-asset-channel.ts
+++ b/packages/webapp/src/core/stale-asset-channel.ts
@@ -75,6 +75,33 @@ export function broadcastIfStaleAssetError(err: unknown): void {
 }
 
 /**
+ * Mixed-build-graph tripwire (#1983). A deploy landing mid-session can
+ * leave stale page HTML (build N) spawning a kernel worker whose hashed
+ * import graph resolves to build N±1 — every chunk servable (the R2
+ * asset archive keeps prior builds alive by design), so the drift loads
+ * silently and surfaces later as protocol-shaped runtime bugs. Called
+ * from worker boot with the page's inlined build id (rode in on
+ * `kernel-worker-init`) and the worker's own: on mismatch, requests the
+ * page's guarded reload over the stale-asset channel and reports `true`
+ * so the caller can RUM-tag it. Boot continues either way — if the
+ * (rate-limited) reload is suppressed, a mixed graph that would have run
+ * before still runs, now with a breadcrumb.
+ *
+ * The channel name and message shape are a cross-build wire contract:
+ * this signal must survive exactly the build skew it detects. Keep them
+ * stable.
+ */
+export function broadcastIfMixedBuildGraph(
+  pageBuildId: string | null | undefined,
+  workerBuildId: string
+): boolean {
+  if (!pageBuildId || pageBuildId === workerBuildId) return false;
+  log.warn(`mixed build graph: page ${pageBuildId} vs worker ${workerBuildId} — requesting reload`);
+  broadcastStaleAssetReload();
+  return true;
+}
+
+/**
  * Page-side listener PRIMITIVE. Invokes `onReload` only for a broadcast stamped
  * with the page's own `instanceId`. Returns a fresh disposer per call (like
  * `installNukeReloadListener`); single-install is enforced by the page wrapper

--- a/packages/webapp/src/globals.d.ts
+++ b/packages/webapp/src/globals.d.ts
@@ -2,6 +2,7 @@ declare const __DEV__: boolean;
 declare const __SLICC_EXT_DEV__: boolean;
 declare const __SLICC_VERSION__: string;
 declare const __SLICC_RELEASED_AT__: string | null;
+declare const __SLICC_BUILD_ID__: string;
 // Wasm dependency versions baked from packages/webapp/package.json at build
 // time (Vite `define` / vitest `define`). See the wasm-wrapping commands that
 // derive their `ipk add <pkg>@<version>` guidance from these.

--- a/packages/webapp/src/kernel/kernel-worker.ts
+++ b/packages/webapp/src/kernel/kernel-worker.ts
@@ -27,6 +27,7 @@
 import { BrowserAPI } from '../cdp/browser-api.js';
 import { createPanelRpcTrayProvider } from '../cdp/panel-rpc-tray-provider.js';
 import {
+  broadcastIfMixedBuildGraph,
   broadcastIfStaleAssetError,
   setStaleAssetInstanceId,
 } from '../core/stale-asset-channel.js';
@@ -54,7 +55,7 @@ import { getPanelRpcClient } from './panel-rpc.js';
 import { createPanelTerminalHost } from './panel-terminal-host.js';
 import { setSyncFsBridgeEnabled } from './realm/sync-fs-enabled.js';
 import type { SyncFsNonce } from './realm/sync-fs-wire.js';
-import { initTelemetry } from './telemetry.js';
+import { initTelemetry, trackError } from './telemetry.js';
 import { createBridgeMessageChannelTransport } from './transport-message-channel.js';
 import { startVfsRpcHost } from './vfs-rpc-host.js';
 
@@ -138,6 +139,14 @@ export interface KernelWorkerInitMsg {
    * undefined outside the thin-bridge extension leader.
    */
   extensionDelegateId?: string | null;
+  /**
+   * The PAGE graph's inlined `__SLICC_BUILD_ID__`. The worker compares it
+   * against its own copy on boot: a mismatch means stale HTML mixed two
+   * deploys' chunk graphs (#1983) — beaconed and answered with a guarded
+   * reload request over the stale-asset channel. Absent on older pages;
+   * the comparison then stays silent.
+   */
+  pageBuildId?: string | null;
 }
 
 /** Posted back over the kernel port once `createKernelHost` resolves. */
@@ -275,41 +284,69 @@ self.addEventListener('message', (event: MessageEvent) => {
   initGuard.handle(event.data as KernelWorkerInitMsg);
 });
 
+/**
+ * #1983: the page inlined ITS build id into the init message; this module
+ * carries the worker graph's. A mismatch means stale HTML mixed two
+ * deploys' chunks — request the page's guarded reload immediately and let
+ * boot continue (the reload, if not rate-limited, tears this worker down
+ * anyway; if suppressed, mixed operation matches today's behavior but is
+ * no longer silent). Returns the RUM beacon to fire once `initTelemetry`
+ * has bound `trackError` — a per-realm no-op before then.
+ */
+function checkMixedBuildGraph(init: KernelWorkerInitMsg): () => void {
+  const mixed = broadcastIfMixedBuildGraph(init.pageBuildId, __SLICC_BUILD_ID__);
+  return () => {
+    if (mixed) {
+      trackError('mixed-build-graph', `page ${init.pageBuildId} worker ${__SLICC_BUILD_ID__}`);
+    }
+  };
+}
+
+/**
+ * Environment wiring that must precede any fetch, provider read, or
+ * telemetry decision. Extracted from `boot()` for the per-function line
+ * cap; ordering within is load-bearing (see the inline comments).
+ */
+function configureWorkerEnvironment(init: KernelWorkerInitMsg): void {
+  // Stamp `x-bypass-llm-proxy: 1` on same-origin worker fetches so
+  // the page-installed LLM-proxy SW doesn't double-intercept them.
+  // Cross-origin requests are intentionally left bare — see
+  // `kernel-worker-fetch-bypass.ts` for the CORS-preflight reasoning.
+  // Must run before any fetcher does.
+  installFetchBypass();
+
+  // Thin-bridge: the hosted leader serves the UI but has no local /api
+  // surface, so proxied-fetch must target the bridge-discovered local
+  // node-server origin + carry the per-process `X-Bridge-Token` (origin
+  // allowlist alone is insufficient — see `bridge-security.ts`). The
+  // page realm sets its own copy in `setupStandalonePrelude`.
+  setLocalApiBaseUrl(init.localApiBaseUrl ?? null);
+  setBridgeToken(init.bridgeToken ?? null);
+  setSyncFsBridgeEnabled(init.syncFsBridgeEnabled ?? false); // realm sync-fs SW bridge (see sync-fs-enabled.ts)
+  // Thin-bridge extension leader: the worker has no `chrome`, so a
+  // configured delegate id routes cross-origin shell fetches over panel-RPC
+  // to the page realm, which opens the extension Port (host_permissions CORS
+  // bypass). `null` outside the thin-bridge extension leader.
+  setExtensionDelegateId(init.extensionDelegateId ?? null);
+  // The worker has no `localStorage` (Web Workers don't get one).
+  // `provider-settings.getApiKey()` and `selected-model` reads on the
+  // worker side would otherwise crash or return empty, which makes
+  // `ScoopContext.init` fail with no provider configured. Seed a
+  // Map-backed shim from the page's `localStorage` snapshot the page
+  // passed in `kernel-worker-init`. The `Bridge`
+  // `local-storage-*` handlers + `installPageStorageSync` on the page
+  // keep the shim in sync with subsequent page writes.
+  installLocalStorageShim(init.localStorageSeed ?? {});
+}
+
 async function boot(init: KernelWorkerInitMsg): Promise<void> {
   // #1330: record instanceId up front so a stale-import failure anywhere in boot
   // (registerProviders eagerly imports every provider chunk) broadcasts an
   // instanceId-scoped reload request to the owning page.
   setStaleAssetInstanceId(init.instanceId);
+  const beaconMixedBuildGraph = checkMixedBuildGraph(init);
   try {
-    // Stamp `x-bypass-llm-proxy: 1` on same-origin worker fetches so
-    // the page-installed LLM-proxy SW doesn't double-intercept them.
-    // Cross-origin requests are intentionally left bare — see
-    // `kernel-worker-fetch-bypass.ts` for the CORS-preflight reasoning.
-    // Must run before any fetcher does.
-    installFetchBypass();
-
-    // Thin-bridge: the hosted leader serves the UI but has no local /api
-    // surface, so proxied-fetch must target the bridge-discovered local
-    // node-server origin + carry the per-process `X-Bridge-Token` (origin
-    // allowlist alone is insufficient — see `bridge-security.ts`). The
-    // page realm sets its own copy in `setupStandalonePrelude`.
-    setLocalApiBaseUrl(init.localApiBaseUrl ?? null);
-    setBridgeToken(init.bridgeToken ?? null);
-    setSyncFsBridgeEnabled(init.syncFsBridgeEnabled ?? false); // realm sync-fs SW bridge (see sync-fs-enabled.ts)
-    // Thin-bridge extension leader: the worker has no `chrome`, so a
-    // configured delegate id routes cross-origin shell fetches over panel-RPC
-    // to the page realm, which opens the extension Port (host_permissions CORS
-    // bypass). `null` outside the thin-bridge extension leader.
-    setExtensionDelegateId(init.extensionDelegateId ?? null);
-    // The worker has no `localStorage` (Web Workers don't get one).
-    // `provider-settings.getApiKey()` and `selected-model` reads on the
-    // worker side would otherwise crash or return empty, which makes
-    // `ScoopContext.init` fail with no provider configured. Seed a
-    // Map-backed shim from the page's `localStorage` snapshot the page
-    // passed in `kernel-worker-init`. The `Bridge`
-    // `local-storage-*` handlers + `installPageStorageSync` on the page
-    // keep the shim in sync with subsequent page writes.
-    installLocalStorageShim(init.localStorageSeed ?? {});
+    configureWorkerEnvironment(init);
 
     // Initialize RUM telemetry so beacons fire from the worker
     // AlmostBashShell and uncaught errors in the agent loop are captured.
@@ -318,7 +355,9 @@ async function boot(init: KernelWorkerInitMsg): Promise<void> {
     // shim so the `telemetry-disabled` / `slicc-rum-debug` keys the page
     // seeded propagate into the worker's `initTelemetry` decision. Fire-
     // and-forget — telemetry init must never block the boot.
-    void initTelemetry().catch(() => {});
+    void initTelemetry()
+      .then(beaconMixedBuildGraph)
+      .catch(() => {});
 
     // Register providers first — kernel host construction reads the
     // provider registry (via scoop-context → provider-settings).

--- a/packages/webapp/src/kernel/spawn.ts
+++ b/packages/webapp/src/kernel/spawn.ts
@@ -322,6 +322,10 @@ export function bootstrapKernelWorker<TClient>(
     syncFsChannelNonce: options.syncFsChannelNonce ?? null,
     localLickWsUrl: options.localLickWsUrl ?? null,
     extensionDelegateId: options.extensionDelegateId ?? null,
+    // Inlined into THIS (page-graph) chunk at build time; the worker
+    // compares it against its own copy to catch mixed-build graphs after
+    // a mid-session deploy (#1983).
+    pageBuildId: __SLICC_BUILD_ID__,
   };
   worker.postMessage(init, [kernelChannel.port2, cdpChannel.port2]);
 

--- a/packages/webapp/tests/core/stale-asset-channel.test.ts
+++ b/packages/webapp/tests/core/stale-asset-channel.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  broadcastIfMixedBuildGraph,
   broadcastIfStaleAssetError,
   broadcastStaleAssetReload,
   installStaleAssetReloadListener,
@@ -113,5 +114,50 @@ describe('broadcast + listener (instanceId-scoped)', () => {
     // Dev-only warning; assert it does not throw and (in DEV) warns at least 0+ times.
     expect(() => setStaleAssetInstanceId(undefined)).not.toThrow();
     warn.mockRestore();
+  });
+});
+
+describe('broadcastIfMixedBuildGraph (#1983)', () => {
+  beforeEach(() => installFakeBroadcastChannel());
+  afterEach(() => {
+    setStaleAssetInstanceId(undefined);
+    resetFakeBroadcastChannel();
+  });
+
+  it('requests the guarded reload when page and worker build ids differ', async () => {
+    const onReload = vi.fn();
+    const dispose = installStaleAssetReloadListener('inst-A', onReload);
+    setStaleAssetInstanceId('inst-A');
+
+    expect(broadcastIfMixedBuildGraph('6.36.2-aaa', '6.36.2-bbb')).toBe(true);
+    await Promise.resolve();
+    expect(onReload).toHaveBeenCalledTimes(1);
+    // A boot-time trigger: never a turn replay.
+    expect(onReload).toHaveBeenCalledWith(false);
+    dispose();
+  });
+
+  it('stays silent when the ids match', async () => {
+    const onReload = vi.fn();
+    const dispose = installStaleAssetReloadListener('inst-A', onReload);
+    setStaleAssetInstanceId('inst-A');
+
+    expect(broadcastIfMixedBuildGraph('6.36.2-aaa', '6.36.2-aaa')).toBe(false);
+    await Promise.resolve();
+    expect(onReload).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it('makes no claim when the page id is absent (older page HTML)', async () => {
+    const onReload = vi.fn();
+    const dispose = installStaleAssetReloadListener('inst-A', onReload);
+    setStaleAssetInstanceId('inst-A');
+
+    expect(broadcastIfMixedBuildGraph(undefined, '6.36.2-bbb')).toBe(false);
+    expect(broadcastIfMixedBuildGraph(null, '6.36.2-bbb')).toBe(false);
+    expect(broadcastIfMixedBuildGraph('', '6.36.2-bbb')).toBe(false);
+    await Promise.resolve();
+    expect(onReload).not.toHaveBeenCalled();
+    dispose();
   });
 });

--- a/packages/webapp/tests/kernel/kernel-worker-telemetry.test.ts
+++ b/packages/webapp/tests/kernel/kernel-worker-telemetry.test.ts
@@ -21,8 +21,9 @@ const source = readFileSync(workerPath, 'utf8');
 
 describe('kernel-worker.ts telemetry wiring', () => {
   it('imports initTelemetry from the webapp telemetry module', () => {
+    // Allow sibling named imports (e.g. trackError for the #1983 beacon).
     expect(source).toMatch(
-      /import\s+\{\s*initTelemetry\s*\}\s+from\s+['"][^'"]*\/telemetry\.js['"]/
+      /import\s+\{[^}]*\binitTelemetry\b[^}]*\}\s+from\s+['"][^'"]*\/telemetry\.js['"]/
     );
   });
 
@@ -58,7 +59,10 @@ describe('kernel-worker.ts telemetry wiring', () => {
   it('swallows initTelemetry rejection so a telemetry failure cannot block boot', () => {
     // Match the same `.catch(() => {})` discipline used by offscreen.ts so
     // a transient rum-worker.js import / fetch failure does not break the
-    // worker boot sequence.
-    expect(source).toMatch(/initTelemetry\(\)\s*\.catch\(/);
+    // worker boot sequence. The chain may carry a `.then` first (the #1983
+    // mixed-build beacon fires once telemetry is bound); the trailing
+    // catch still covers the whole chain. Non-greedy: with exactly one
+    // `initTelemetry()` call (asserted above), this stops at ITS catch.
+    expect(source).toMatch(/initTelemetry\(\)[\s\S]*?\.catch\(/);
   });
 });

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -306,6 +306,15 @@ export default defineConfig(({ mode }) => ({
     __DEV__: JSON.stringify(mode !== 'production'),
     __SLICC_VERSION__: JSON.stringify(rootPkg.version),
     __SLICC_RELEASED_AT__: JSON.stringify(sliccReleasedAt),
+    // Per-build stamp inlined into every chunk that references it (page
+    // AND kernel-worker graphs). A deploy landing mid-session can leave
+    // stale HTML running page chunks from build N while the worker's
+    // hashed import graph resolves to build N±1 — both servable via the
+    // R2 asset archive, so the mixed graph loads silently. Comparing the
+    // page's inlined copy against the worker's on the boot handshake
+    // detects that drift (#1983). One evaluation per config load: a
+    // single build (or dev-server run) stamps both realms identically.
+    __SLICC_BUILD_ID__: JSON.stringify(`${rootPkg.version}-${Date.now().toString(36)}`),
     // Wasm dependency versions baked from webapp/package.json so the
     // ipk-wrapping commands (convert/magick, biome, ffmpeg) derive their
     // install guidance + version guards from the pinned dep instead of a literal.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -95,6 +95,7 @@ export default defineConfig({
           __DEV__: 'true',
           __SLICC_VERSION__: JSON.stringify(rootPkg.version),
           __SLICC_RELEASED_AT__: 'null',
+          __SLICC_BUILD_ID__: JSON.stringify('test-build'),
           ...wasmVersionDefines,
           global: 'globalThis',
         },
@@ -179,6 +180,7 @@ export default defineConfig({
           // Extension tests transitively import webapp modules; keep the
           // wasm version constants defined so those imports don't throw.
           ...wasmVersionDefines,
+          __SLICC_BUILD_ID__: JSON.stringify('test-build'),
         },
         test: {
           name: 'chrome-extension',


### PR DESCRIPTION
Closes #1983 — from the 2026-08-07 incident diagnosis, where the running page and its kernel worker were silently executing chunks from two different builds (both servable because the R2 asset archive keeps prior builds' chunks alive by design).

## What changed

- **`__SLICC_BUILD_ID__`** (`<version>-<base36 stamp>`, one evaluation per Vite config load) is inlined into every chunk that references it. Verified on the built output: the page graph (`wc-live-*.js`, where `spawn.ts` lands) and `kernel-worker-*.js` carry the identical literal from one build — in a mixed graph they come from different builds and differ.
- **Handshake**: `spawn.ts` sends the page graph's copy as `pageBuildId` on `kernel-worker-init`; the worker compares it against its own at boot start. Absent (older page HTML) → silent, no claim.
- **On mismatch**: the worker requests the page's existing instanceId-scoped **guarded reload** over the stale-asset channel (`installWorkerStaleAssetReloadListener` is installed before spawn; the 60 s rate limit means a suppressed reload leaves mixed operation exactly as before — just no longer silent) and beacons **`error` / `mixed-build-graph`** with both ids once `initTelemetry` binds (`trackError` is a per-realm no-op before that, so the beacon rides the init promise). Boot continues either way — the reload, when it fires, tears the worker down; when suppressed, nothing regresses.
- The comparator (`broadcastIfMixedBuildGraph`) lives in `core/stale-asset-channel.ts` with a stated cross-build wire-contract note: this signal must survive exactly the build skew it detects, so the channel name and message shape stay stable.
- Defines mirrored into `vitest.config.ts` (both webapp and chrome-extension projects) and the extension's Vite config so transitively bundled kernel modules never hit an undefined identifier.
- `boot()` re-ran into the 150-line function cap; the environment-wiring block moved to `configureWorkerEnvironment(init)` (comment-preserving extraction, ordering unchanged).

## Tests

3 new cases in `stale-asset-channel.test.ts` over the fake BroadcastChannel: mismatch → guarded-reload request with `replayTurn: false`; match → silent; absent/empty page id → silent. The kernel-worker telemetry source-guard regexes were widened to allow the sibling `trackError` import and the `.then(beacon)` link in the init chain (still pinned: exactly one `initTelemetry()` call, still `.catch`-swallowed).

## Verification

`npm run verify` 7/7 · debt gate OK · `typecheck` clean · `npm run test` 14,019 passed · coverage floors pass · both builds · bundle-size within budget · stamp identity confirmed in `dist/ui` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65