### PR TITLE
fix(scoops): no mid-compaction memory building when agentic memory is on (#2003)

### DIFF
--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -51,9 +51,8 @@ User → ChatPanel → Orchestrator → ScoopContext.prompt() → pi-agent-core 
   `readFileSync`/`writeFileSync` and `child_process.execSync`/`execFileSync`/`spawnSync`
   for realm scripts, over one blocking sync-XHR transport (`synchronify`) and one
   capability token scoped to the calling realm's `ctx.fs` / `ctx.exec`.
-  See `docs/kernel/process-model.md` for method surface, coherence, and cold-start.
 
-Deep reference: `docs/kernel/process-model.md`.
+Deep reference (method surface, coherence, cold-start): `docs/kernel/process-model.md`.
 
 ### Orchestrator
 
@@ -75,8 +74,8 @@ Deep reference: `docs/kernel/process-model.md`.
 ### VirtualFS
 
 - Path: `packages/webapp/src/fs/`
-- `virtual-fs.ts` — POSIX-like FS backed by OPFS (in-memory in Node tests). Legacy
-  LightningFS/IDB backend and boot-time migration are fully removed.
+- `virtual-fs.ts` — POSIX-like FS backed by OPFS (in-memory in Node tests); the legacy
+  LightningFS/IDB backend is gone.
 - `restricted-fs.ts` — path ACLs for scoop sandboxes.
 - `mount-commands.ts` — parses `--source` / `--profile` / `--no-probe` etc.;
   `path-utils.ts` defines normalization.
@@ -201,10 +200,11 @@ See docs/architecture.md "Multi-Browser Sync (Tray) Architecture".
 ### Context Compaction
 
 - Path: `packages/webapp/src/core/context-compaction.ts`
-- `scoop-context.ts` passes `model.contextWindow`; compaction fires at window minus reserve,
-  falling back to 200K when absent/zero.
-- Cone memory appends to `/workspace/CLAUDE.md`; the agentic budget covers the whole file, legacy
-  restructuring only `## Auto-extracted`.
+- `scoop-context.ts` passes `model.contextWindow`; compaction fires at window minus
+  reserve (200K fallback when absent/zero).
+- Cone memory appends to `/workspace/CLAUDE.md`; the agentic budget covers the whole file,
+  legacy restructuring only `## Auto-extracted`. `agentic-memory` on → compaction builds
+  no memory (#2003); the curator owns it.
 
 ### Frozen Sessions ("New session" flow)
 

--- a/packages/webapp/src/core/context-compaction.ts
+++ b/packages/webapp/src/core/context-compaction.ts
@@ -121,6 +121,15 @@ export interface CompactionConfig {
    */
   onMemoryUpdates?: (bullets: string) => Promise<void> | void;
   /**
+   * Consulted immediately before the memory-extraction phase of EACH
+   * compaction. Return `false` to skip extraction for this compaction —
+   * unlike omitting `onMemoryUpdates` (a construction-time decision),
+   * the check is live, so a mid-session toggle (the agentic-memory flag,
+   * #2003) applies to the very next compaction without a reload. Absent
+   * → extract whenever `onMemoryUpdates` is wired.
+   */
+  shouldExtractMemories?: () => boolean;
+  /**
    * Optional lifecycle hook for the UI. Fired around the compaction LLM
    * calls so the chat panel can render a ghost-bubble affordance instead
    * of leaving the user wondering why the agent is silent.
@@ -640,6 +649,8 @@ async function extractMemoriesIfConfigured(
   signal: AbortSignal | undefined
 ): Promise<void> {
   if (!config.onMemoryUpdates) return;
+  // Live per-compaction gate — see `shouldExtractMemories` (#2003).
+  if (config.shouldExtractMemories?.() === false) return;
   // Memory budget is much smaller — bullets, not a structured doc.
   const memoryMaxTokens = 2048;
   try {

--- a/packages/webapp/src/kernel/kernel-worker.ts
+++ b/packages/webapp/src/kernel/kernel-worker.ts
@@ -26,6 +26,8 @@
 
 import { BrowserAPI } from '../cdp/browser-api.js';
 import { createPanelRpcTrayProvider } from '../cdp/panel-rpc-tray-provider.js';
+import type { FeatureFlagFloat } from '../core/feature-flags.js';
+import { initFeatureFlagsFromRemoteCache } from '../core/feature-flags-cache.js';
 import {
   broadcastIfMixedBuildGraph,
   broadcastIfStaleAssetError,
@@ -147,6 +149,15 @@ export interface KernelWorkerInitMsg {
    * the comparison then stays silent.
    */
   pageBuildId?: string | null;
+  /**
+   * The page's resolved feature-flag float (its `UiRuntimeMode`). The
+   * worker adopts the page's cached remote flag values for this float
+   * from the localStorage shim at boot, so `isFeatureEnabled` in this
+   * realm matches the page even for remote-only enablement (#2003).
+   * Absent (older pages) → local overrides still apply; remote values
+   * stay empty.
+   */
+  flagFloat?: FeatureFlagFloat | null;
 }
 
 /** Posted back over the kernel port once `createKernelHost` resolves. */
@@ -337,6 +348,11 @@ function configureWorkerEnvironment(init: KernelWorkerInitMsg): void {
   // `local-storage-*` handlers + `installPageStorageSync` on the page
   // keep the shim in sync with subsequent page writes.
   installLocalStorageShim(init.localStorageSeed ?? {});
+  // The shim now carries the page's cached /api/flags values; adopt them
+  // for the page's float so this realm's `isFeatureEnabled` matches the
+  // page even for remote-only enablement (#2003). Runs AFTER the shim —
+  // the cache reader resolves `globalThis.localStorage` at call time.
+  if (init.flagFloat) initFeatureFlagsFromRemoteCache(init.flagFloat);
 }
 
 async function boot(init: KernelWorkerInitMsg): Promise<void> {

--- a/packages/webapp/src/kernel/spawn.ts
+++ b/packages/webapp/src/kernel/spawn.ts
@@ -29,6 +29,7 @@
  */
 
 import type { CDPTransport } from '../cdp/transport.js';
+import type { FeatureFlagFloat } from '../core/feature-flags.js';
 import { startPageCdpForwarder } from './cdp-worker-proxy.js';
 import type {
   KernelWorkerBootErrorMsg,
@@ -136,6 +137,12 @@ export interface KernelWorkerSpawnOptions<TClient> {
    * thin-bridge extension leader.
    */
   extensionDelegateId?: string | null;
+  /**
+   * The page's resolved feature-flag float (its `UiRuntimeMode`) — the
+   * worker adopts the page's cached remote flag values for it at boot so
+   * worker-realm `isFeatureEnabled` matches the page (#2003).
+   */
+  flagFloat?: FeatureFlagFloat | null;
   /** Page-side hook fired on ANY uncaught kernel-worker `error` event — notably a
    *  stale worker ENTRY chunk failing to load after a deploy (the worker never
    *  evaluates, so its own boot catch can't run). Not message-filtered: a
@@ -169,6 +176,8 @@ export interface KernelWorkerBootstrapOptions<TClient> {
   localLickWsUrl?: string | null;
   /** See `KernelWorkerSpawnOptions.extensionDelegateId`. */
   extensionDelegateId?: string | null;
+  /** See `KernelWorkerSpawnOptions.flagFloat`. */
+  flagFloat?: FeatureFlagFloat | null;
   /** Page-side hook fired on ANY uncaught kernel-worker `error` event — notably a
    *  stale worker ENTRY chunk failing to load after a deploy (the worker never
    *  evaluates, so its own boot catch can't run). Not message-filtered: a
@@ -326,6 +335,7 @@ export function bootstrapKernelWorker<TClient>(
     // compares it against its own copy to catch mixed-build graphs after
     // a mid-session deploy (#1983).
     pageBuildId: __SLICC_BUILD_ID__,
+    flagFloat: options.flagFloat ?? null,
   };
   worker.postMessage(init, [kernelChannel.port2, cdpChannel.port2]);
 
@@ -400,6 +410,7 @@ export function spawnKernelWorker<TClient>(
     syncFsChannelNonce: options.syncFsChannelNonce,
     localLickWsUrl: options.localLickWsUrl,
     extensionDelegateId: options.extensionDelegateId,
+    flagFloat: options.flagFloat,
     onWorkerScriptError: options.onWorkerScriptError,
   });
 }

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -23,6 +23,7 @@ import {
   hasCompactionProgress,
   stripOrphanedToolResults,
 } from '../core/context-compaction.js';
+import { isFeatureEnabled } from '../core/feature-flags.js';
 import type {
   AgentMessage,
   AssistantMessage,
@@ -633,8 +634,17 @@ export class ScoopContext {
     const compactionHeaders =
       model.provider === 'adobe' ? { 'X-Session-Id': adobeSessionId } : undefined;
     const getCompactionApiKey = () => getApiKey() ?? undefined;
+    // With agentic memory enabled, the end-of-session curator is the ONLY
+    // memory builder (#2003): wiring onMemoryUpdates here would make every
+    // mid-session compaction append legacy bullets to the curated file and
+    // trigger the legacy budget restructure, repeatedly squeezing curated
+    // content until only the recent session survives. Leaving the callback
+    // unset skips the extraction LLM call, its state, and the append+budget
+    // chain. The flag resolves in this (worker) realm via the seeded/synced
+    // localStorage shim, so the avatar-dialog toggle applies at the next
+    // prompt without a reload.
     const onMemoryUpdates =
-      this.scoop.isCone && this.callbacks.appendConeMemory
+      this.scoop.isCone && !isFeatureEnabled('agentic-memory') && this.callbacks.appendConeMemory
         ? (bullets: string) =>
             this.callbacks.appendConeMemory!(bullets, {
               source: 'compaction',

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -634,17 +634,8 @@ export class ScoopContext {
     const compactionHeaders =
       model.provider === 'adobe' ? { 'X-Session-Id': adobeSessionId } : undefined;
     const getCompactionApiKey = () => getApiKey() ?? undefined;
-    // With agentic memory enabled, the end-of-session curator is the ONLY
-    // memory builder (#2003): wiring onMemoryUpdates here would make every
-    // mid-session compaction append legacy bullets to the curated file and
-    // trigger the legacy budget restructure, repeatedly squeezing curated
-    // content until only the recent session survives. Leaving the callback
-    // unset skips the extraction LLM call, its state, and the append+budget
-    // chain. The flag resolves in this (worker) realm via the seeded/synced
-    // localStorage shim, so the avatar-dialog toggle applies at the next
-    // prompt without a reload.
     const onMemoryUpdates =
-      this.scoop.isCone && !isFeatureEnabled('agentic-memory') && this.callbacks.appendConeMemory
+      this.scoop.isCone && this.callbacks.appendConeMemory
         ? (bullets: string) =>
             this.callbacks.appendConeMemory!(bullets, {
               source: 'compaction',
@@ -663,6 +654,16 @@ export class ScoopContext {
       getApiKey: getCompactionApiKey,
       headers: compactionHeaders,
       onMemoryUpdates,
+      // With agentic memory enabled, the end-of-session curator is the
+      // ONLY memory builder (#2003): mid-session extraction appends legacy
+      // bullets to the curated file and triggers the legacy budget
+      // restructure, repeatedly squeezing curated content until only the
+      // recent session survives. Checked live at EACH compaction (the
+      // compactFn built here outlives prompts), so an avatar-dialog toggle
+      // applies to the next compaction without a reload; the flag resolves
+      // in this (worker) realm via the seeded/synced localStorage shim
+      // plus the remote cache adopted at boot.
+      shouldExtractMemories: () => !isFeatureEnabled('agentic-memory'),
       // States flow to the UI untouched; OffscreenClient renders the
       // transcript notices (#1985). Emitting them here via onResponse would
       // clobber the streaming bubble on the bridge path and poison non-cone

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -2228,6 +2228,8 @@ export async function mountWcUiLive(
     syncFsChannelNonce,
     localLickWsUrl,
     extensionDelegateId,
+    // The worker adopts this float's cached remote flags at boot (#2003).
+    flagFloat: runtimeMode,
     onWorkerScriptError: () => {
       guardedReload();
     },

--- a/packages/webapp/tests/core/context-compaction.test.ts
+++ b/packages/webapp/tests/core/context-compaction.test.ts
@@ -360,6 +360,52 @@ describe('createCompactContext', () => {
     expect(onMemoryUpdates.mock.calls[0][0]).toContain('user prefers vim');
   });
 
+  it('shouldExtractMemories false skips the memory call, the append, and its state (#2003)', async () => {
+    const onMemoryUpdates = vi.fn();
+    const onCompactionStateChange = vi.fn();
+    mockCompleteSimple.mockResolvedValueOnce(llmResponse('## Goal\ndo a thing'));
+
+    const compact = createCompactContext({
+      ...mockConfig,
+      onMemoryUpdates,
+      onCompactionStateChange,
+      shouldExtractMemories: () => false,
+    });
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+    await compact(messages);
+
+    // Summary only — with agentic memory on, the curator owns memory.
+    expect(mockCompleteSimple).toHaveBeenCalledTimes(1);
+    expect(onMemoryUpdates).not.toHaveBeenCalled();
+    const states = onCompactionStateChange.mock.calls.map((c) => c[0]);
+    expect(states).not.toContain('extracting-memory');
+  });
+
+  it('shouldExtractMemories is consulted per compaction — a flipped gate extracts again', async () => {
+    const onMemoryUpdates = vi.fn();
+    mockCompleteSimple
+      .mockResolvedValueOnce(llmResponse('summary one'))
+      .mockResolvedValueOnce(llmResponse('summary two'))
+      .mockResolvedValueOnce(llmResponse('- a memory'));
+
+    let extract = false;
+    const compact = createCompactContext({
+      ...mockConfig,
+      onMemoryUpdates,
+      shouldExtractMemories: () => extract,
+    });
+    const baseMsg = 'x'.repeat(65000);
+    const messages = Array.from({ length: 12 }, () => createMessage('user', baseMsg));
+
+    await compact(messages);
+    expect(onMemoryUpdates).not.toHaveBeenCalled();
+
+    extract = true;
+    await compact(messages);
+    expect(onMemoryUpdates).toHaveBeenCalledOnce();
+  });
+
   it('emits compaction lifecycle states in order, ending with idle', async () => {
     const onMemoryUpdates = vi.fn();
     const onCompactionStateChange = vi.fn();

--- a/packages/webapp/tests/kernel/kernel-worker-flags.test.ts
+++ b/packages/webapp/tests/kernel/kernel-worker-flags.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression guards for worker-realm feature-flag adoption (#2003).
+ *
+ * The kernel worker must adopt the page's cached remote flag values
+ * (`initFeatureFlagsFromRemoteCache(init.flagFloat)`) or remote-only
+ * enablement is invisible in this realm — `isFeatureEnabled` would fall
+ * back to the bundled default. Ordering is load-bearing: the cache
+ * reader resolves `globalThis.localStorage` at call time, which in the
+ * worker only exists after `installLocalStorageShim`.
+ *
+ * Static-text guards, mirroring `kernel-worker-telemetry.test.ts` —
+ * boot side effects are exercised end-to-end by the init-guard tests.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const workerPath = join(here, '..', '..', 'src', 'kernel', 'kernel-worker.ts');
+const source = readFileSync(workerPath, 'utf8');
+
+describe('kernel-worker.ts feature-flag adoption (#2003)', () => {
+  it('adopts the page float remote flag cache', () => {
+    expect(source).toMatch(/initFeatureFlagsFromRemoteCache\(init\.flagFloat\)/);
+  });
+
+  it('adopts flags AFTER the localStorage shim is installed', () => {
+    const shimIdx = source.indexOf('installLocalStorageShim(init.localStorageSeed');
+    const flagsIdx = source.indexOf('initFeatureFlagsFromRemoteCache(init.flagFloat)');
+    expect(shimIdx).toBeGreaterThan(-1);
+    expect(flagsIdx).toBeGreaterThan(-1);
+    expect(shimIdx).toBeLessThan(flagsIdx);
+  });
+});

--- a/packages/webapp/tests/scoops/scoop-context.compaction-window.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.compaction-window.test.ts
@@ -22,6 +22,7 @@ type CompactConfig = {
   headers?: Record<string, string>;
   contextWindow?: number;
   onMemoryUpdates?: unknown;
+  shouldExtractMemories?: unknown;
 };
 
 const captures = vi.hoisted(() => ({
@@ -190,18 +191,23 @@ describe('ScoopContext compaction memory gating (#2003)', () => {
     mocks.enabledFlags.clear();
   });
 
-  it('wires onMemoryUpdates for the cone when agentic memory is off', async () => {
-    const config = await initWith(MODEL, { appendConeMemory: vi.fn() });
-    expect(config.onMemoryUpdates).toBeTypeOf('function');
-  });
-
-  it('leaves onMemoryUpdates unset when agentic memory is on — the curator owns memory', async () => {
-    // Mid-session compaction memory building appends legacy bullets and
-    // triggers the budget restructure on the curated file, repeatedly
-    // squeezing it toward "last session summed up" (#2003).
+  it('wires onMemoryUpdates for the cone regardless of the flag (the gate is live)', async () => {
     mocks.enabledFlags.add('agentic-memory');
     const config = await initWith(MODEL, { appendConeMemory: vi.fn() });
-    expect(config.onMemoryUpdates).toBeUndefined();
+    expect(config.onMemoryUpdates).toBeTypeOf('function');
+    expect(config.shouldExtractMemories).toBeTypeOf('function');
+  });
+
+  it('shouldExtractMemories tracks the flag LIVE — a mid-session toggle applies to the next compaction', async () => {
+    // The compactFn built at init outlives prompts; a construction-time
+    // decision would keep extracting until a reload (#2003 review P1).
+    const config = await initWith(MODEL, { appendConeMemory: vi.fn() });
+    const gate = config.shouldExtractMemories as () => boolean;
+    expect(gate()).toBe(true);
+    mocks.enabledFlags.add('agentic-memory');
+    expect(gate()).toBe(false);
+    mocks.enabledFlags.delete('agentic-memory');
+    expect(gate()).toBe(true);
   });
 
   it('leaves onMemoryUpdates unset without an appendConeMemory callback (unchanged)', async () => {

--- a/packages/webapp/tests/scoops/scoop-context.compaction-window.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.compaction-window.test.ts
@@ -18,7 +18,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RegisteredScoop } from '../../src/scoops/types.js';
 
 type AgentCtorOptions = { streamFn?: unknown; transformContext?: unknown };
-type CompactConfig = { headers?: Record<string, string>; contextWindow?: number };
+type CompactConfig = {
+  headers?: Record<string, string>;
+  contextWindow?: number;
+  onMemoryUpdates?: unknown;
+};
 
 const captures = vi.hoisted(() => ({
   agentCtorCalls: [] as AgentCtorOptions[],
@@ -27,6 +31,11 @@ const captures = vi.hoisted(() => ({
 
 const mocks = vi.hoisted(() => ({
   resolveCurrentModel: vi.fn(() => ({ id: 'test-model', provider: 'anthropic' })),
+  enabledFlags: new Set<string>(),
+}));
+
+vi.mock('../../src/core/feature-flags.js', () => ({
+  isFeatureEnabled: (id: string) => mocks.enabledFlags.has(id),
 }));
 
 vi.mock('../../src/core/index.js', () => {
@@ -130,9 +139,13 @@ function createMockFs() {
   };
 }
 
-async function initWith(model: Record<string, unknown>): Promise<CompactConfig> {
+async function initWith(
+  model: Record<string, unknown>,
+  extraCallbacks: Record<string, unknown> = {}
+): Promise<CompactConfig> {
   mocks.resolveCurrentModel.mockReturnValue(model as never);
-  const ctx = new ScoopContext(baseScoop, createMockCallbacks() as never, createMockFs() as never);
+  const callbacks = { ...createMockCallbacks(), ...extraCallbacks };
+  const ctx = new ScoopContext(baseScoop, callbacks as never, createMockFs() as never);
   await ctx.init();
   expect(captures.createCompactContextCalls).toHaveLength(1);
   return captures.createCompactContextCalls[0];
@@ -164,5 +177,35 @@ describe('ScoopContext compaction context-window wiring', () => {
   it('omits contextWindow (default applies) when the model reports no window', async () => {
     const config = await initWith({ id: 'none', provider: 'adobe' });
     expect(config.contextWindow).toBeUndefined();
+  });
+});
+
+describe('ScoopContext compaction memory gating (#2003)', () => {
+  const MODEL = { id: 'sonnet', provider: 'adobe', contextWindow: 200_000 };
+
+  beforeEach(() => {
+    captures.agentCtorCalls.length = 0;
+    captures.createCompactContextCalls.length = 0;
+    mocks.resolveCurrentModel.mockReset();
+    mocks.enabledFlags.clear();
+  });
+
+  it('wires onMemoryUpdates for the cone when agentic memory is off', async () => {
+    const config = await initWith(MODEL, { appendConeMemory: vi.fn() });
+    expect(config.onMemoryUpdates).toBeTypeOf('function');
+  });
+
+  it('leaves onMemoryUpdates unset when agentic memory is on — the curator owns memory', async () => {
+    // Mid-session compaction memory building appends legacy bullets and
+    // triggers the budget restructure on the curated file, repeatedly
+    // squeezing it toward "last session summed up" (#2003).
+    mocks.enabledFlags.add('agentic-memory');
+    const config = await initWith(MODEL, { appendConeMemory: vi.fn() });
+    expect(config.onMemoryUpdates).toBeUndefined();
+  });
+
+  it('leaves onMemoryUpdates unset without an appendConeMemory callback (unchanged)', async () => {
+    const config = await initWith(MODEL);
+    expect(config.onMemoryUpdates).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #2003 — twice now the production curator found `/workspace/CLAUDE.md` over-compacted down to essentially the last session's summary, requiring restore from a manual backup.

## Mechanism

With `agentic-memory` enabled, mid-session context compaction still ran the legacy memory extraction on every compaction: a 2048-token bullet call, an `## Auto-extracted (date, compaction)` append onto the **curated** file, and the legacy budget restructure that consolidates everything from the first `## Auto-extracted` heading onward. Long or photo-heavy sessions compact repeatedly, so curated content that follows any such heading got LLM-compressed again and again — converging on "last session summed up".

## Fix

`scoop-context.ts` wires `onMemoryUpdates` into `createCompactContext` only when the `agentic-memory` flag is **off**. With it unset, `extractMemoriesIfConfigured` no-ops — no extraction LLM call, no `extracting-memory` state, no append, no budget restructure. **The end-of-session curator is the only memory builder.** Compaction's summarization role is untouched.

The flag is read in the kernel-worker realm through the seeded/live-synced localStorage shim (the same override the Experimental-features dialog writes), so toggling applies at the next prompt without a reload. Known limitation, noted in the code: a remote-only flag enablement with no local override isn't visible to the worker — the flag is `userToggleable` and local-first, and a deployment-level default flip would land in the bundled default anyway.

## Tests

3 cases in `scoop-context.compaction-window.test.ts` (which already captures the `createCompactContext` config): flag off + cone + `appendConeMemory` → `onMemoryUpdates` wired; flag on → unset; no callback → unset (unchanged). Doc note added to the webapp `CLAUDE.md` Context Compaction section.

## Verification

`npm run verify` 7/7 · debt gate OK · `typecheck` clean · `npm run test` 14,019 passed · coverage floors pass · both builds · bundle-size within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65