### PR TITLE
fix(compaction): elide oversized single messages so a giant tool result can’t wedge recovery

### DIFF
--- a/packages/webapp/src/core/context-compaction.ts
+++ b/packages/webapp/src/core/context-compaction.ts
@@ -403,22 +403,26 @@ function elideMessageContent(message: AgentMessage): AgentMessage {
 }
 
 /**
- * In the hopeless branch, replace the content of any single `toolResult`
- * (or assistant message carrying tool calls) whose estimated tokens exceed
- * `(contextWindow - reserveTokens) / 2` with a short stub.
+ * Replace the content of any single `toolResult` (or assistant message carrying
+ * tool calls) whose estimated tokens exceed `(contextWindow - reserveTokens) / 2`
+ * with a short stub. A message that large cannot be summarized — serializing it
+ * into the summary prompt would itself blow context — so it must be stubbed in
+ * place before either summarization or naive drop (#2011).
  *
  * - Message ordering, role, `toolCallId`, and `toolName` are preserved.
  * - For assistant messages, `toolCall` content blocks are kept (with `id`,
  *   `name`, and `type` intact) so the agent loop's tool-call/tool-result
  *   pairing stays valid. Each block's `arguments` payload is rewritten to
  *   a small `{ elided: true, originalBytes: <n> }` stub so multi-megabyte
- *   `write_file`-style argument blobs don't survive elision and re-trigger
- *   the hopeless branch on the next turn.
+ *   `write_file`-style argument blobs don't survive elision.
  * - Assistant messages without any `toolCall` block are passed through
- *   unchanged — only assistant turns that actually carry tool calls
- *   participate in this elision, matching the JSDoc invariant.
+ *   unchanged — only assistant turns that actually carry tool calls participate.
+ *
+ * Unlike {@link elideHopelessMessages}, this does NOT strip images: it runs on
+ * every compaction (not only when the context is multiples of the window), so it
+ * must touch only messages that are individually oversized.
  */
-function elideHopelessMessages(
+function elideOversizedMessages(
   messages: AgentMessage[],
   contextWindow: number,
   reserveTokens: number
@@ -427,18 +431,7 @@ function elideHopelessMessages(
   let elidedCount = 0;
   let elidedBytes = 0;
 
-  const out = messages.map((rawMsg) => {
-    // Hopeless-branch image strip (#1986): the context is multiples of the
-    // window, so no image payload can survive to the model anyway — and
-    // user-role messages (where photo attachments live) never reach the
-    // role-gated elision below.
-    const msg = elideImagesInMessage(rawMsg);
-    if (msg !== rawMsg) {
-      elidedCount++;
-      elidedBytes +=
-        approxContentBytes((rawMsg as { content?: unknown }).content) -
-        approxContentBytes((msg as { content?: unknown }).content);
-    }
+  const out = messages.map((msg) => {
     const tokens = estimateTokens(msg);
     if (tokens <= perMessageThreshold) return msg;
     const role = (msg as { role: string }).role;
@@ -455,12 +448,7 @@ function elideHopelessMessages(
 
     // Assistant branch: only elide turns that actually carry tool calls.
     const content = Array.isArray(m.content) ? m.content : [];
-    const toolCalls = content.filter((b) => (b as { type?: string }).type === 'toolCall') as Array<{
-      type: string;
-      id?: string;
-      name?: string;
-      arguments?: unknown;
-    }>;
+    const toolCalls = content.filter((b) => (b as { type?: string }).type === 'toolCall');
     if (toolCalls.length === 0) return msg;
 
     elidedCount++;
@@ -469,6 +457,40 @@ function elideHopelessMessages(
   });
 
   return { messages: out, elidedCount, elidedBytes };
+}
+
+/**
+ * Hopeless-branch elision: strip images from every message (#1986 — the context
+ * is multiples of the window, so no image payload can survive to the model
+ * anyway, and user-role messages where photo attachments live never reach the
+ * role-gated size elision), then stub every oversized message via
+ * {@link elideOversizedMessages}.
+ */
+function elideHopelessMessages(
+  messages: AgentMessage[],
+  contextWindow: number,
+  reserveTokens: number
+): { messages: AgentMessage[]; elidedCount: number; elidedBytes: number } {
+  let elidedCount = 0;
+  let elidedBytes = 0;
+
+  const imageStripped = messages.map((rawMsg) => {
+    const msg = elideImagesInMessage(rawMsg);
+    if (msg !== rawMsg) {
+      elidedCount++;
+      elidedBytes +=
+        approxContentBytes((rawMsg as { content?: unknown }).content) -
+        approxContentBytes((msg as { content?: unknown }).content);
+    }
+    return msg;
+  });
+
+  const sized = elideOversizedMessages(imageStripped, contextWindow, reserveTokens);
+  return {
+    messages: sized.messages,
+    elidedCount: elidedCount + sized.elidedCount,
+    elidedBytes: elidedBytes + sized.elidedBytes,
+  };
 }
 
 /** Sum the estimated token cost of a message list. */
@@ -516,21 +538,48 @@ function applyHopelessElision(
   hopelessMultiplier: number,
   settings: Parameters<typeof shouldCompact>[2]
 ): { messages: AgentMessage[]; isHopeless: boolean; earlyReturn: AgentMessage[] | null } {
-  if (totalTokens <= contextWindow * hopelessMultiplier) {
+  // #2011: stub any individually-oversized message on EVERY compaction, decoupled
+  // from the 4x-window "hopeless" gate below. A single tool result larger than
+  // half the window (e.g. a multi-hundred-KB command dump) cannot be summarized —
+  // sending it to the summary LLM re-blows context — so it must be elided in
+  // place whether or not the conversation total is multiples of the window.
+  const sizeElision = elideOversizedMessages(messages, contextWindow, reserveTokens);
+  let workingMessages = sizeElision.messages;
+  let elidedCount = sizeElision.elidedCount;
+  let elidedBytes = sizeElision.elidedBytes;
+
+  const postSizeTokens = elidedCount > 0 ? estimateTotalTokens(workingMessages) : totalTokens;
+
+  // Hopeless branch (#1986): even after size-elision the context is still
+  // multiples of the window, so strip images too and skip the LLM summary —
+  // serializing this much conversation would itself blow context.
+  const isHopeless = postSizeTokens > contextWindow * hopelessMultiplier;
+  if (isHopeless) {
+    const hopeless = elideHopelessMessages(workingMessages, contextWindow, reserveTokens);
+    workingMessages = hopeless.messages;
+    elidedCount += hopeless.elidedCount;
+    elidedBytes += hopeless.elidedBytes;
+  }
+
+  // True no-op: nothing oversized and not hopeless — let the caller run the
+  // normal summarize path on the untouched messages.
+  if (!isHopeless && elidedCount === 0) {
     return { messages, isHopeless: false, earlyReturn: null };
   }
-  const elision = elideHopelessMessages(messages, contextWindow, reserveTokens);
-  const workingMessages = elision.messages;
-  log.warn('Compaction hopeless branch', {
+
+  log.warn('Compaction oversized-message elision', {
     totalTokens,
+    postSizeTokens,
     contextWindow,
-    multiplier: hopelessMultiplier,
-    elidedCount: elision.elidedCount,
-    elidedBytes: elision.elidedBytes,
+    isHopeless,
+    elidedCount,
+    elidedBytes,
   });
   const postTokens = estimateTotalTokens(workingMessages);
+  // If elision alone brought us back under the compaction threshold, return
+  // immediately — no LLM summary, no naive drop needed.
   const earlyReturn = shouldCompact(postTokens, contextWindow, settings) ? null : workingMessages;
-  return { messages: workingMessages, isHopeless: true, earlyReturn };
+  return { messages: workingMessages, isHopeless, earlyReturn };
 }
 
 /**
@@ -693,11 +742,21 @@ async function summarizeWithLlm(
   messagesToSummarize: AgentMessage[],
   messagesToKeep: AgentMessage[],
   reserveTokens: number,
+  contextWindow: number,
   originalMessageCount: number,
   signal: AbortSignal | undefined
 ): Promise<AgentMessage[] | null> {
   try {
-    const conversationText = serializeMessages(messagesToSummarize);
+    // #2012 defense-in-depth: never serialize an individually-oversized message
+    // into the summary prompt. In the normal flow applyHopelessElision already
+    // stubbed these upstream; this guard guarantees the summary LLM call can't
+    // be handed an un-summarizable message by any future or forced path.
+    const safeToSummarize = elideOversizedMessages(
+      messagesToSummarize,
+      contextWindow,
+      reserveTokens
+    ).messages;
+    const conversationText = serializeMessages(safeToSummarize);
     const systemPrompt = buildSharedSystemPrompt(conversationText);
     // Summary uses ~80% of the reserve budget for output, mirroring the
     // pi-coding-agent default.
@@ -817,6 +876,7 @@ export function createCompactContext(
         messagesToSummarize,
         messagesToKeep,
         reserveTokens,
+        contextWindow,
         messages.length,
         signal
       );

--- a/packages/webapp/tests/core/context-compaction-real-estimator.test.ts
+++ b/packages/webapp/tests/core/context-compaction-real-estimator.test.ts
@@ -118,13 +118,20 @@ describe('createCompactContext with the real estimator', () => {
       createUser('what did you find?'),
     ];
 
-    await createCompactContext(mockConfig)(messages);
+    const result = await createCompactContext(mockConfig)(messages);
 
-    // completeSimple firing proves shouldCompact returned true, which proves
-    // the real estimateTokens counted the toolResult bytes — the whole point
-    // of this regression guard. If a future pi-coding-agent release changes
-    // `estimateTokens` to drop toolResult accounting, this assertion fails.
-    expect(mockCompleteSimple).toHaveBeenCalled();
+    // The oversized toolResult being elided proves shouldCompact returned true,
+    // which proves the real estimateTokens counted the toolResult bytes — the
+    // whole point of this regression guard. If a future pi-coding-agent release
+    // changes `estimateTokens` to drop toolResult accounting, total would be
+    // tiny, shouldCompact false, and the messages returned unchanged (blob
+    // intact), failing these assertions.
+    const resultText = JSON.stringify(result);
+    expect(resultText).not.toContain('x'.repeat(1000));
+    expect(resultText).toContain('Tool result elided');
+    // #2011: a single oversized message is stubbed in place — no doomed LLM
+    // summary round-trip (sending it would re-blow the window).
+    expect(mockCompleteSimple).not.toHaveBeenCalled();
   });
 
   it('does NOT trigger compaction when toolResult payloads are small', async () => {

--- a/packages/webapp/tests/core/context-compaction.test.ts
+++ b/packages/webapp/tests/core/context-compaction.test.ts
@@ -343,6 +343,81 @@ describe('createCompactContext', () => {
     expect(firstText(result[0])).toContain('<context-summary>');
   });
 
+  // #2011 / #2012 — a single oversized tool result (e.g. an unbounded command
+  // dump) must be stubbed in place, not summarized. Summarizing it re-blows the
+  // window (the model sees the whole message), which is what wedged the live
+  // cone: one 1.9M-char Signal dump made compaction escalate to "could not be
+  // reduced". Per-message threshold for mockConfig = (200000 - 16384) / 2 =
+  // 91,808 tokens ≈ 367K chars.
+  it('elides an oversized tool result instead of summarizing it (#2011)', async () => {
+    const compact = createCompactContext(mockConfig);
+    // 1M chars ≈ 250K tokens: over the per-message threshold AND pushes the
+    // conversation over the shouldCompact threshold, so the proactive path runs.
+    const giant = createToolResult('x'.repeat(1_000_000), 'tool-1');
+    const messages = [
+      createMessage('user', 'inspect the app'),
+      createAssistantWithToolCalls('running', ['tool-1']),
+      giant,
+    ];
+
+    const result = await compact(messages);
+
+    // Elided in place — no doomed LLM summary call.
+    expect(mockCompleteSimple).not.toHaveBeenCalled();
+    expect(hasCompactionProgress(messages, result)).toBe(true);
+    // The 1MB blob is now a short stub; nothing oversized survives.
+    expect(result.some((m) => firstText(m).includes('Tool result elided'))).toBe(true);
+    expect(result.every((m) => firstText(m).length < 2000)).toBe(true);
+  });
+
+  it('force-compacts by eliding an oversized message under the normal threshold (#2012)', async () => {
+    const compact = createCompactContext(mockConfig);
+    // 500K chars ≈ 125K tokens: over the per-message threshold (91,808) but the
+    // whole conversation is under the shouldCompact threshold (183,616), so only
+    // the forced overflow-recovery path reaches compaction.
+    const giant = createToolResult('y'.repeat(500_000), 'tool-1');
+    const messages = [
+      createMessage('user', 'hi'),
+      createAssistantWithToolCalls('ok', ['tool-1']),
+      giant,
+    ];
+
+    // Without force: under threshold → returned unchanged.
+    expect(await compact(messages)).toBe(messages);
+
+    // With force (overflow recovery): the oversized message is elided, no LLM call.
+    const result = await compact(messages, undefined, { force: true });
+    expect(mockCompleteSimple).not.toHaveBeenCalled();
+    expect(hasCompactionProgress(messages, result)).toBe(true);
+    expect(result.some((m) => firstText(m).includes('Tool result elided'))).toBe(true);
+  });
+
+  it('never serializes oversized content into the summary prompt (#2012 guard)', async () => {
+    const compact = createCompactContext(mockConfig);
+    // Oversized tool result placed early so it lands in the summarize slice
+    // (not the recent-keep window). Filler keeps the post-elision total over the
+    // summarize threshold so the LLM summary path actually runs.
+    const giant = createToolResult('z'.repeat(500_000), 'tool-1');
+    const filler = Array.from({ length: 8 }, (_, i) =>
+      createMessage('user', 'w'.repeat(100_000) + ` #${i}`)
+    );
+    const messages = [
+      createMessage('user', 'inspect'),
+      createAssistantWithToolCalls('run', ['tool-1']),
+      giant,
+      ...filler,
+    ];
+
+    await compact(messages);
+
+    // Summary path ran, but the raw 500K blob never reached the summary prompt.
+    expect(mockCompleteSimple).toHaveBeenCalled();
+    // completeSimple(model, { systemPrompt, messages }, opts) — args object is [1].
+    const call = mockCompleteSimple.mock.calls[0][1] as { systemPrompt?: string };
+    expect(call.systemPrompt).toBeDefined();
+    expect(call.systemPrompt).not.toContain('z'.repeat(1000));
+  });
+
   it('calls completeSimple twice when onMemoryUpdates wired', async () => {
     const onMemoryUpdates = vi.fn();
     mockCompleteSimple
@@ -832,9 +907,10 @@ describe('createCompactContext hopeless branch', () => {
     'skips LLM, elides oversized toolResult, emits structured warn, ' +
       'and returns under the soft threshold',
     async () => {
-      // 4 MB of text → ~1M est. tokens. With contextWindow = 200k and
-      // hopelessMultiplier = 4 (default), totalTokens > 800k triggers
-      // the hopeless branch.
+      // 4 MB of text → ~1M est. tokens in a single toolResult. That one message
+      // is individually oversized (> half the window), so the decoupled
+      // per-message elision (#2011) stubs it in place — no LLM summary needed —
+      // and the post-elision total is nowhere near the 4x hopeless threshold.
       const hugeText = 'x'.repeat(4_000_000);
       const messages: AgentMessage[] = [
         createMessage('user', 'run tool'),
@@ -863,14 +939,15 @@ describe('createCompactContext hopeless branch', () => {
       // Structured warn log MUST carry the documented fields.
       const warnCalls = (console.warn as ReturnType<typeof vi.fn>).mock.calls;
       const hopelessCall = warnCalls.find(
-        (c) => typeof c[1] === 'string' && c[1] === 'Compaction hopeless branch'
+        (c) => typeof c[1] === 'string' && c[1] === 'Compaction oversized-message elision'
       );
       expect(hopelessCall).toBeDefined();
       const fields = hopelessCall![2] as Record<string, unknown>;
       expect(fields).toEqual({
         totalTokens: expect.any(Number),
+        postSizeTokens: expect.any(Number),
         contextWindow: 200000,
-        multiplier: 4,
+        isHopeless: false,
         elidedCount: expect.any(Number),
         elidedBytes: expect.any(Number),
       });


### PR DESCRIPTION
## What

A single tool result larger than half the context window can't be summarized — to summarize it the summarizer must **send** it, which re-blows the real backend limit. That wedged the live cone: one **1.9M-char Signal CDP dump (~482K tokens)** as one `toolResult` made compaction escalate to *"context window was exceeded and could not be reduced"* → new session.

The cure already existed — `elideHopelessMessages` stubs any single `toolResult` exceeding `(contextWindow - reserveTokens)/2` — but it was gated behind `totalTokens > contextWindow * 4`, which a single ~1×-window message never trips (482K in a 500K window ≈ 0.97×, nowhere near 4×). So the cure never ran.

## Changes

- **#2011 — decouple per-message elision from the 4× "hopeless" gate.** Extract a size-only `elideOversizedMessages` (no image strip) and run it on **every** compaction; the 4× gate now only governs `isHopeless` (image strip + skip-LLM, #1986). When elision alone drops the total under threshold, return early — no LLM summary, no naive drop. Covers the forced overflow-recovery path (`force: true`).
- **#2012 — defense-in-depth.** `summarizeWithLlm` elides oversized messages from the summarize slice before serializing, so the summary LLM call can never be handed an un-summarizable message by any future or forced path.

## Tests

- Proactive + forced oversized-message elision → stubbed, **no LLM call**.
- The summary prompt never carries oversized raw content.
- Real-estimator guard and the #1986 hopeless image-strip test updated for the new decoupled behavior. All 65 compaction tests green.

## Evidence

Captured live on the wedged leader (CDP 9222): cone `cone_1783576515993` = 5 messages / 1.93M chars, one `toolResult` of 1,926,395 chars. On "Try again", `overflowRecoveryAttempted` was latched → `[scoop-context] Context overflow recovery exhausted`, no LLM call.

This is the acute wedge-stopper. Follow-up PRs bound the tool output at the source (#2010) and re-converge our bash tool with pi's contract (#2009).

Closes #2011
Closes #2012

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65