### PR TITLE
fix(compaction): strip images in the oversized-message early return (Codex P1 on #2013)

### DIFF
--- a/packages/webapp/src/core/context-compaction.ts
+++ b/packages/webapp/src/core/context-compaction.ts
@@ -577,8 +577,17 @@ function applyHopelessElision(
   });
   const postTokens = estimateTotalTokens(workingMessages);
   // If elision alone brought us back under the compaction threshold, return
-  // immediately — no LLM summary, no naive drop needed.
-  const earlyReturn = shouldCompact(postTokens, contextWindow, settings) ? null : workingMessages;
+  // immediately — no LLM summary, no naive drop needed. But first strip images
+  // the same way the summarize path does: `estimateTokens` assigns each image a
+  // fixed ~1,200 tokens regardless of its real base64 size, so this early return
+  // could otherwise hand back large image payloads that keep the real backend
+  // over its limit (post-#2011 the size-elision path bypassed both
+  // `elideTailImages` and the hopeless image strip — Codex P1 on #2013).
+  // `elideTailImages` stubs every image except the latest user message's, which
+  // the model has not acted on yet — parity with the normal summarize path.
+  const earlyReturn = shouldCompact(postTokens, contextWindow, settings)
+    ? null
+    : elideTailImages([], workingMessages, contextWindow, settings);
   return { messages: workingMessages, isHopeless, earlyReturn };
 }
 

--- a/packages/webapp/tests/core/context-compaction.test.ts
+++ b/packages/webapp/tests/core/context-compaction.test.ts
@@ -1233,6 +1233,38 @@ describe('createCompactContext image elision (#1986)', () => {
     expect(elisionStubs(keptToolResult)).toHaveLength(1);
   });
 
+  it('strips images (except the latest) when the oversized-tool-result early return fires (Codex P1 on #2013)', async () => {
+    const compact = createCompactContext({
+      model: mockModel,
+      getApiKey: () => 'test-key',
+      contextWindow: 2000,
+      reserveTokens: 500,
+      keepRecentTokens: 600,
+    });
+    // A giant tool result triggers the #2011 size-elision early return. Images
+    // ride along but estimateTokens under-counts them (~1,200 tokens each
+    // regardless of base64 size), so before the fix they passed through
+    // untouched and could re-overflow the real backend on the next turn.
+    const messages = [
+      createMessageWithImage('user', 'earlier screenshot', 40_000),
+      createAssistantWithToolCalls('running', ['big-1']),
+      createToolResult('x'.repeat(20_000), 'big-1'),
+      createMessageWithImage('user', 'latest screenshot', 40_000),
+    ];
+
+    const result = await compact(messages);
+
+    // Early return: elision alone sufficed, no LLM summary call.
+    expect(mockCompleteSimple).not.toHaveBeenCalled();
+    // The giant tool result is stubbed in place.
+    expect(result.some((m) => firstText(m).includes('Tool result elided'))).toBe(true);
+    // The OLD image is stubbed; the LATEST user image is kept — parity with the
+    // summarize path, so no oversized image survives the early return.
+    const users = result.filter((m) => asTestMessage(m).role === 'user');
+    expect(imageBlocks(users[0])).toHaveLength(0);
+    expect(imageBlocks(users[users.length - 1])).toHaveLength(1);
+  });
+
   it('hopeless branch strips image blocks from user messages', async () => {
     const compact = createCompactContext({
       model: mockModel,


### PR DESCRIPTION
## What

Fixes the **P1** [Codex flagged on #2013](https://github.com/ai-ecoverse/slicc/pull/2013#discussion) (merged).

PR #2013 added a non-hopeless early-return in `applyHopelessElision`: when eliding an oversized tool result alone brings the token estimate back under threshold, compaction returns the elided messages without an LLM summary. But `estimateTokens` assigns each image a **fixed ~1,200 tokens regardless of its real base64 size**, so that early return could hand back large image payloads that still exceed the real backend limit — bypassing both the summarize path's `elideTailImages` and the hopeless path's image strip. An overflow retry would then fail again.

## Fix

Run `elideTailImages([], workingMessages, …)` in the early return. It stubs every image **except the latest user message's** (which the model hasn't acted on yet) — exactly the guarantee the normal summarize path already gives. In the hopeless branch (images already stripped) it's a no-op.

## Test

New regression: a giant tool result + an old image + a latest image → early return fires (no LLM call), the giant is stubbed, the **old** image is stubbed, and the **latest** user image is kept. 55 compaction tests green.

Closes #2013 (review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65