### PR TITLE
chore(docs): compact CLAUDE.md guides for weekly headroom

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,13 +104,13 @@ Run the full pre-push/PR pass — `lint` (first; top CI failure), `typecheck`, `
 
 Skill-aware harnesses load these directly; this list routes AGENTS.md-only harnesses to them.
 
-- Add/change a SLICC feature surface → `adding-slicc-features`
-- Deploy/debug the Cloudflare tray hub worker → `deploying-tray-worker`
-- Record a UI demo for a PR → `demo-recording`
-- Hand work off to SLICC → `slicc-handoff`
-- Smoke-test a build in a controlled browser → `cdp-smoke-test`
-- Write/update SLICC tests → `writing-slicc-tests`
-- Commit, push, open/update a PR, diagnose verification CI failures → `verifying-before-push`
+- Add/change a SLICC feature surface → use `adding-slicc-features`
+- Deploy/debug the Cloudflare tray hub worker → use `deploying-tray-worker`
+- Record a UI demo for a PR → use `demo-recording`
+- Hand work off to SLICC → use `slicc-handoff`
+- Smoke-test a build in a controlled browser → use `cdp-smoke-test`
+- Write/update SLICC tests → use `writing-slicc-tests`
+- Commit, push, open/update a PR, diagnose verification CI failures → use `verifying-before-push`
 
 ## Automated PR Review Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,41 +1,16 @@
 # CLAUDE.md
 
-This is the repo navigation hub. Keep package details in the nearest package `CLAUDE.md` and fast-changing how-to material in `docs/`.
+Repo navigation hub. Keep package details in the nearest package `CLAUDE.md` and fast-changing how-to in `docs/`.
 
 ## Module Map
 
-### Packages
+Purposes per package: [`docs/root-details.md`](docs/root-details.md). Per-package internals: each `packages/<name>/CLAUDE.md`.
 
-| Path                           | Purpose                                                                                                             |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `packages/webapp/`             | Browser app core: UI, VFS, shell, CDP, tools, providers, skills, scoops                                             |
-| `packages/cherry/`             | Host-side embed SDK (`mountSlicc`) lending a third-party page to a leader as a target                               |
-| `packages/chrome-extension/`   | Manifest V3 extension entry points, HTML shells, and message bridges                                                |
-| `packages/cloudflare-worker/`  | Tray hub worker: session coordination, signaling, TURN credentials, `sliccy.ai/cloud` dashboard                     |
-| `packages/node-server/`        | Node.js CLI/Electron server: Chrome launch, CDP proxy, dev serving, hosted-leader mode                              |
-| `packages/cloud-core/`         | `@slicc/cloud-core` — sandbox-lifecycle library shared by `node-server --cloud` and the worker                      |
-| `packages/shared-ts/`          | `@slicc/shared-ts` — platform-agnostic primitives (secret masking, secrets pipeline)                                |
-| `packages/webcomponents/`      | `@slicc/webcomponents` — the webapp's UI shell (Storybook + `@vitest/browser`)                                      |
-| `packages/spoon/`              | `@ai-ecoverse/spoon` — injection overlay web component + IIFE bootstrap, used across all floats                     |
-| `packages/vfs-root/`           | Default VFS content copied into the app on init/reset                                                               |
-| `packages/go-optel/`           | Dependency-free Go RUM client used by `slicc-cli`                                                                   |
-| `packages/swift-launcher/`     | Native macOS SwiftUI launcher app (`Sliccstart`)                                                                    |
-| `packages/swift-optel/`        | Pure-Swift RUM library shared by the iOS and macOS apps                                                             |
-| `packages/swift-server/`       | Native macOS Hummingbird server (`slicc-server`)                                                                    |
-| `packages/swift-traysession/`  | Foundation-only iCloud tray-session sync shared by the launcher and iOS app                                         |
-| `packages/swift-trayfollower/` | `SliccTrayFollower` — shared headless tray-follower transport (WebRTC + tray-sync) used by ios-app and swift-server |
-| `packages/ios-app/`            | Native iOS SwiftUI follower app (`SliccFollower`) — joins a leader over WebRTC (SPM, not npm)                       |
-| `packages/slicc-cli/`          | `slicc` — headless Go (pion) follower CLI: `prompt`/`exec`/`follow`; cross-compiled binaries (Go module, not npm)   |
-| `packages/dev-tools/`          | Repo-level tooling: build helpers, QA setup, providers build filter, e2b template                                   |
-| `packages/assets/`             | Shared static files (logos, fonts, favicon) used by multiple packages (folder, not an npm workspace)                |
+- **Web / TS**: `packages/webapp/`, `packages/webcomponents/`, `packages/chrome-extension/`, `packages/cherry/`, `packages/spoon/`
+- **Node / cloud**: `packages/node-server/`, `packages/cloudflare-worker/`, `packages/cloud-core/`, `packages/shared-ts/`, `packages/vfs-root/`, `packages/dev-tools/`, `packages/assets/`
+- **Native (Swift / iOS / Go)**: `packages/swift-launcher/`, `packages/swift-server/`, `packages/swift-optel/`, `packages/swift-traysession/`, `packages/swift-trayfollower/`, `packages/ios-app/`, `packages/slicc-cli/`, `packages/go-optel/`
 
-### Other Top-Level Directories
-
-| Path                | Purpose                                                                                   |
-| ------------------- | ----------------------------------------------------------------------------------------- |
-| `docs/`             | Long-form developer and agent reference docs, including screenshots and other docs assets |
-| `packages/*/tests/` | Per-package TypeScript/Vitest tests mirrored by subsystem                                 |
-| `dist/`             | Generated build output; do not hand-edit                                                  |
+Other top-level: `docs/` (long-form docs + screenshots), `packages/*/tests/` (Vitest suites), `dist/` (generated; do not hand-edit).
 
 ## Top-Level Commands
 
@@ -49,54 +24,34 @@ npm run typecheck                        # Browser + Node typecheck
 npm run dev                              # Thin /cdp bridge + Chrome (UI from hosted origin)
 ```
 
-For runtime-specific commands, use the nearest guide:
-
-- [`packages/webapp/CLAUDE.md`](packages/webapp/CLAUDE.md)
-- [`packages/cherry/CLAUDE.md`](packages/cherry/CLAUDE.md)
-- [`packages/chrome-extension/CLAUDE.md`](packages/chrome-extension/CLAUDE.md)
-- [`packages/cloudflare-worker/CLAUDE.md`](packages/cloudflare-worker/CLAUDE.md)
-- [`packages/node-server/CLAUDE.md`](packages/node-server/CLAUDE.md)
-- [`packages/cloud-core/CLAUDE.md`](packages/cloud-core/CLAUDE.md)
-- [`packages/shared-ts/CLAUDE.md`](packages/shared-ts/CLAUDE.md)
-- [`packages/webcomponents/CLAUDE.md`](packages/webcomponents/CLAUDE.md)
-- [`packages/spoon/CLAUDE.md`](packages/spoon/CLAUDE.md)
-- [`packages/vfs-root/CLAUDE.md`](packages/vfs-root/CLAUDE.md)
-- [`packages/go-optel/CLAUDE.md`](packages/go-optel/CLAUDE.md)
-- [`packages/swift-launcher/CLAUDE.md`](packages/swift-launcher/CLAUDE.md)
-- [`packages/swift-optel/CLAUDE.md`](packages/swift-optel/CLAUDE.md)
-- [`packages/swift-server/CLAUDE.md`](packages/swift-server/CLAUDE.md)
-- [`packages/swift-traysession/CLAUDE.md`](packages/swift-traysession/CLAUDE.md)
-- [`packages/swift-trayfollower/CLAUDE.md`](packages/swift-trayfollower/CLAUDE.md)
-- [`packages/ios-app/CLAUDE.md`](packages/ios-app/CLAUDE.md)
-- [`packages/slicc-cli/CLAUDE.md`](packages/slicc-cli/CLAUDE.md)
-- [`packages/dev-tools/CLAUDE.md`](packages/dev-tools/CLAUDE.md)
-- [`docs/CLAUDE.md`](docs/CLAUDE.md)
+Runtime-specific guides:
+[webapp](packages/webapp/CLAUDE.md) · [cherry](packages/cherry/CLAUDE.md) · [chrome-extension](packages/chrome-extension/CLAUDE.md) · [cloudflare-worker](packages/cloudflare-worker/CLAUDE.md) · [node-server](packages/node-server/CLAUDE.md) · [cloud-core](packages/cloud-core/CLAUDE.md) · [shared-ts](packages/shared-ts/CLAUDE.md) · [webcomponents](packages/webcomponents/CLAUDE.md) · [spoon](packages/spoon/CLAUDE.md) · [vfs-root](packages/vfs-root/CLAUDE.md) · [go-optel](packages/go-optel/CLAUDE.md) · [swift-launcher](packages/swift-launcher/CLAUDE.md) · [swift-optel](packages/swift-optel/CLAUDE.md) · [swift-server](packages/swift-server/CLAUDE.md) · [swift-traysession](packages/swift-traysession/CLAUDE.md) · [swift-trayfollower](packages/swift-trayfollower/CLAUDE.md) · [ios-app](packages/ios-app/CLAUDE.md) · [slicc-cli](packages/slicc-cli/CLAUDE.md) · [dev-tools](packages/dev-tools/CLAUDE.md) · [docs](docs/CLAUDE.md)
 
 ## External Handoffs
 
-`handoff to slicc` or `move this to slicc` means opening `https://www.sliccy.ai/handoff?handoff=<text>` (or `?upskill=<url>`) with a verb-prefixed `handoff:` or `upskill:` instruction. The worker returns an RFC 8288 `Link` header that SLICC observes on navigation and presents for approval. Prefer `.agents/skills/slicc-handoff/scripts/slicc-handoff`.
+`handoff to slicc` / `move this to slicc` opens `https://www.sliccy.ai/handoff?handoff=<text>` (or `?upskill=<url>`) with a `handoff:`/`upskill:` verb-prefixed instruction. Worker returns an RFC 8288 `Link` header SLICC observes on navigation for approval. Prefer `.agents/skills/slicc-handoff/scripts/slicc-handoff`.
 
 ## Ice Cream Vocabulary
 
-- **Cone**: the main agent. Full filesystem access, all tools.
-- **Scoops**: isolated sub-agents with sandboxed filesystems (`/scoops/{name}/` + `/shared/`). Tools: `scoop_scoop`, `feed_scoop`, `drop_scoop`.
-- **Licks**: external events such as webhooks, cron tasks, or workflow completions.
-- **Floats**: runtime environments — CLI, extension, Electron, cloud (hosted-leader), and Cherry (embedded follower garnish — `?cherry=1` in a host page's iframe).
+- **Cone**: main agent. Full filesystem access, all tools.
+- **Scoops**: isolated sub-agents; sandboxed filesystems (`/scoops/{name}/` + `/shared/`). Tools: `scoop_scoop`, `feed_scoop`, `drop_scoop`.
+- **Licks**: external events — webhooks, cron, workflow completions.
+- **Floats**: runtime envs — CLI, extension, Electron, cloud (hosted-leader), Cherry (embedded follower garnish; `?cherry=1` in a host page's iframe).
 
-Use ice cream terms in code review comments and docs when they match the domain (e.g., "feed_scoop" not "delegate_to_scoop").
+Use ice cream terms in review comments and docs when they match the domain (e.g., `feed_scoop` not `delegate_to_scoop`).
 
 ## Git Conventions
 
 - Keep commits focused and package-local when possible.
-- **Linear history**: CI rejects merge commits. Rebase onto `origin/main`; Husky enforces this via `packages/dev-tools/tools/check-linear-history.sh`.
+- **Linear history**: CI rejects merge commits. Rebase onto `origin/main`; Husky enforces via `packages/dev-tools/tools/check-linear-history.sh`.
 - Do not hand-edit generated output in `dist/`.
-- Auth uses `git config github.token <PAT>` or GitHub OAuth login; see `docs/secrets.md`.
+- Auth: `git config github.token <PAT>` or GitHub OAuth login; see [`docs/secrets.md`](docs/secrets.md).
 
-**Requires Node >= 22** (LTS). Ports: 5710 (bridge + /api), 9222 (Chrome CDP), 9223 (Electron CDP). node-server serves no UI in any mode — the webapp loads from the hosted origin and dials back to the local `/cdp` bridge.
+**Requires Node >= 22** (LTS). Ports: 5710 (bridge + /api), 9222 (Chrome CDP), 9223 (Electron CDP). node-server serves no UI — the webapp loads from the hosted origin and dials back to the local `/cdp` bridge.
 
 ### Parallel Instances
 
-Run parallel standalone instances by overriding the UI port; profiles and CDP ports stay isolated:
+Override the UI port to run parallel standalone instances; profiles and CDP ports stay isolated:
 
 ```bash
 PORT=5720 npm run dev   # Second instance on port 5720
@@ -105,24 +60,22 @@ PORT=5730 npm run dev   # Third instance on port 5730
 
 ## Principles
 
-1. **Claw pattern** — SLICC is a persistent browser orchestration layer over [Pi](https://github.com/earendil-works/pi-mono).
-2. **Virtual CLIs first** — Prefer composable shell commands over dedicated tools.
-3. **Browser-first** — Keep state client-side and the server a stateless relay; the extension has zero server.
-4. **Skills over hardcoded features** — Add capabilities as SKILL.md files when possible.
+1. **Claw pattern** — persistent browser orchestration layer over [Pi](https://github.com/earendil-works/pi-mono).
+2. **Virtual CLIs first** — composable shell commands over dedicated tools.
+3. **Browser-first** — state client-side; the server is a stateless relay; the extension has zero server.
+4. **Skills over hardcoded features** — add capabilities as SKILL.md files when possible.
 
 ## Architecture
 
-SLICC runs as a standalone CLI (Express + Chrome), Chrome extension, Electron float, cloud hosted leader, or Cherry follower. See [`docs/architecture.md`](docs/architecture.md) and its [float topology diagram](docs/architecture-diagram.png).
-
-Each package `CLAUDE.md` is the authoritative source for its subsystem internals. Shell command reference: [`docs/shell-reference.md`](docs/shell-reference.md). Verification commands and CI gates: [`.agents/skills/verifying-before-push/SKILL.md`](.agents/skills/verifying-before-push/SKILL.md).
+SLICC runs as standalone CLI (Express + Chrome), Chrome extension, Electron float, cloud hosted leader, or Cherry follower. See [`docs/architecture.md`](docs/architecture.md) + [float topology](docs/architecture-diagram.png). Each package `CLAUDE.md` is authoritative for its subsystem. Shell: [`docs/shell-reference.md`](docs/shell-reference.md). Verification/CI gates: [`.agents/skills/verifying-before-push/SKILL.md`](.agents/skills/verifying-before-push/SKILL.md).
 
 ## Key Conventions
 
-- **Tests**: `packages/*/tests/` mirrors the `src/` structure. Vitest, globals: true, environment: node. Use `fake-indexeddb/auto` for VFS tests.
-- **Dual-mode compatibility**: Features MUST work in both CLI and extension. The thin extension runs no dynamic code itself — UI, sprinkles/dips, JS realms, WASM all run in the hosted leader tab / kernel worker; extension assets load via `chrome.runtime.getURL()`.
+- **Tests**: `packages/*/tests/` mirrors `src/`. Vitest, `globals: true`, `environment: node`. `fake-indexeddb/auto` for VFS tests.
+- **Dual-mode compatibility**: features MUST work in CLI and extension. The thin extension runs no dynamic code — UI, sprinkles/dips, JS realms, WASM all run in the hosted leader tab / kernel worker; extension assets load via `chrome.runtime.getURL()`.
 - **Extension detection**: `isExtensionRealm()` from `core/runtime-env.ts` (lint-gated).
-- **Model ID aliases**: Use pi-ai aliases (e.g., `claude-opus-4-6`) not dated snapshot IDs.
-- **Developer vs agent CLAUDE.md**: Developer-facing `CLAUDE.md` lives at the repo root and in each package. The single agent-facing runtime `CLAUDE.md` lives at `packages/vfs-root/shared/CLAUDE.md` and is bundled into the VFS as `/shared/CLAUDE.md`. See [`docs/CLAUDE.md`](docs/CLAUDE.md) for the tier table.
+- **Model ID aliases**: use pi-ai aliases (e.g., `claude-opus-4-6`), not dated snapshot IDs.
+- **Developer vs agent CLAUDE.md**: developer-facing `CLAUDE.md` lives at repo root and each package. Agent-facing runtime `CLAUDE.md` is `packages/vfs-root/shared/CLAUDE.md` (bundled as `/shared/CLAUDE.md`). Tier table: [`docs/CLAUDE.md`](docs/CLAUDE.md).
 
 ## Change Requirements
 
@@ -130,52 +83,50 @@ Every change must satisfy **tests**, **docs**, and **verification**.
 
 ### Tests
 
-- Add or update tests for behavior changes.
-- TypeScript tests live in `packages/*/tests/`, mirrored by subsystem.
-- See `.agents/skills/writing-slicc-tests/SKILL.md` for test patterns and command selection.
-- **Coverage thresholds are enforced in CI.** Floors live in `coverage-thresholds.json` and are raised automatically by the nightly ratchet (`packages/dev-tools/tools/coverage-ratchet.mjs`). Never hand-lower these values. TypeScript: `npm run test:coverage:<package>`; Swift: `packages/dev-tools/tools/swift-coverage-check.sh`.
+- Add/update tests for behavior changes; TS tests in `packages/*/tests/`, mirrored by subsystem. Patterns: `.agents/skills/writing-slicc-tests/SKILL.md`.
+- **Coverage thresholds enforced in CI.** Floors in `coverage-thresholds.json`; raised by the nightly ratchet (`packages/dev-tools/tools/coverage-ratchet.mjs`). Never hand-lower them. TS: `npm run test:coverage:<package>`; Swift: `packages/dev-tools/tools/swift-coverage-check.sh`.
 
 ### Documentation
 
-| Tier                   | File                                   | Update when...                                                                       |
-| ---------------------- | -------------------------------------- | ------------------------------------------------------------------------------------ |
-| Public                 | `README.md`                            | User-facing behavior changes                                                         |
-| Development            | `CLAUDE.md` files                      | Developer conventions, architecture, builds                                          |
-| Agent reference        | `docs/`                                | Detailed tools, commands, and patterns                                               |
-| Agent skills           | `vfs-root/workspace/skills/*/SKILL.md` | Shell command changes (agent system prompt)                                          |
-| Developer agent skills | `.agents/skills/*/SKILL.md`            | A repo procedure (verification, feature wiring, test patterns, ops runbooks) changes |
+Doc tier map (full table: [`docs/CLAUDE.md`](docs/CLAUDE.md)):
+
+- `README.md` — user-facing behavior changes
+- `CLAUDE.md` files — developer conventions, architecture, builds
+- `docs/` — detailed tools, commands, patterns
+- `vfs-root/workspace/skills/*/SKILL.md` — agent skills (shell command changes)
+- `.agents/skills/*/SKILL.md` — developer agent skills (verification, wiring, tests, runbooks)
 
 ### Verification
 
-Run the full pre-push/PR pass — `lint` (always first; the most common CI failure), `typecheck`, `test`, `test:coverage`, both `build`s, plus the touched-file debt gate — before committing. Commands, lint internals, and the CI-only gates: [`.agents/skills/verifying-before-push/SKILL.md`](.agents/skills/verifying-before-push/SKILL.md). CI runs these gates in `.github/workflows/ci.yml`.
+Run the full pre-push/PR pass — `lint` (first; top CI failure), `typecheck`, `test`, `test:coverage`, both `build`s, plus the touched-file debt gate — before committing. Commands and CI-only gates: [`.agents/skills/verifying-before-push/SKILL.md`](.agents/skills/verifying-before-push/SKILL.md); CI in `.github/workflows/ci.yml`.
 
 ## Developer Agent Skills (.agents/skills/)
 
-Skill-aware harnesses load these developer procedures directly; this list routes AGENTS.md-only harnesses to them.
+Skill-aware harnesses load these directly; this list routes AGENTS.md-only harnesses to them.
 
-- Adding or changing a SLICC feature surface → use `adding-slicc-features`
-- Deploying or debugging the Cloudflare tray hub worker → use `deploying-tray-worker`
-- Recording a UI demo for a PR → use `demo-recording`
-- Handing work off to SLICC → use `slicc-handoff`
-- Smoke-testing a build in a controlled browser → use `cdp-smoke-test`
-- Writing or updating SLICC tests → use `writing-slicc-tests`
-- Committing, pushing, opening or updating a PR, or diagnosing verification CI failures → use `verifying-before-push`
+- Add/change a SLICC feature surface → `adding-slicc-features`
+- Deploy/debug the Cloudflare tray hub worker → `deploying-tray-worker`
+- Record a UI demo for a PR → `demo-recording`
+- Hand work off to SLICC → `slicc-handoff`
+- Smoke-test a build in a controlled browser → `cdp-smoke-test`
+- Write/update SLICC tests → `writing-slicc-tests`
+- Commit, push, open/update a PR, diagnose verification CI failures → `verifying-before-push`
 
 ## Automated PR Review Checklist
 
-Automated reviewers (Claude action, Codex via `AGENTS.md`, Copilot via `.github/copilot-instructions.md`) and humans check PRs against these blind spots. Full catalog: [`docs/review-patterns.md`](docs/review-patterns.md).
+Reviewers (Claude action, Codex `AGENTS.md`, Copilot `.github/copilot-instructions.md`) and humans check PRs against these blind spots. Descriptions: [`docs/root-details.md`](docs/root-details.md); full catalog: [`docs/review-patterns.md`](docs/review-patterns.md).
 
-1. **Error-path coverage** — timeouts/retries/`.catch` on external calls.
-2. **UI state preservation** — capture+restore UI state around DOM rebuilds.
-3. **Cross-runtime parity** — peer runtimes updated or explicitly excluded.
-4. **CDP edge cases** — foreground before screenshots; validate target/port.
-5. **Native/macOS permissions** — entitlements + TCC check + graceful denial.
-6. **Model metadata / provider pipeline** — metadata forwarding, version predicates, thinking levels, costs; see `docs/pitfalls.md`.
-7. **Test coverage** — mirrored `tests/`; bug fixes ship regression tests.
-8. **Follower wiring parity** — leader broadcasts need matching follower handler + UI action; check all boot paths.
-9. **Origin/bridge routing** — `fetch('/api/...')` must work in thin-bridge mode; normalize trailing slashes.
-10. **Agent skill freshness** — shell command changes → update matching `vfs-root/workspace/skills/*/SKILL.md`.
-11. **Transcript export** — fail-closed redaction; approval gate; unknown errors → `transfer-corrupt`; SHA-256.
-12. **Layer import direction** — no new `ui/` imports below ui; move helpers down.
+1. Error-path coverage
+2. UI state preservation
+3. Cross-runtime parity
+4. CDP edge cases
+5. Native/macOS permissions
+6. Model metadata / provider pipeline
+7. Test coverage
+8. Follower wiring parity
+9. Origin/bridge routing
+10. Agent skill freshness
+11. Transcript export
+12. Layer import direction
 
 When you change a category, update `docs/review-patterns.md` (source of truth) and the ≤4,000-char `.github/copilot-instructions.md` so all reviewers stay in sync.

--- a/docs/cherry-details.md
+++ b/docs/cherry-details.md
@@ -1,0 +1,137 @@
+# Cherry SDK details
+
+Deep-dive material for `packages/cherry/`. The package guide
+(`packages/cherry/CLAUDE.md`) is the entry point; this file expands the
+sections that did not fit its size budget.
+
+## `mountSlicc` field notes
+
+- **`features` (`CherryFeatures`)** controls which UI panels the follower
+  renders. Every field defaults to `true` when omitted. Setting a feature to
+  `false` removes the panel entirely from the DOM — no tab, no placeholder.
+  Features are static — resolved at mount time and sent in
+  `handshake.welcome`; there is no runtime toggle. Separate from
+  `capabilities` (which gates agent _powers_ over the host page); features
+  gate _UI surfaces_ shown to the user.
+- **Feature flags are separate from `CherryFeatures`.** The `?cherry=1` boot
+  uses the shared registry in `feature-flags.ts` (Cherry default:
+  `experimental-settings` off, hiding the dialog that would toggle these).
+  `flags` on `mountSlicc` is the host's session-only bridge into that
+  registry — same `userToggleable`-and-float gate a local override must pass;
+  see `docs/layouts.md`. Not `SIDE_PANEL_FEATURES` in
+  `cherry-panel-protocol.ts` (extension), which is mount-time `CherryFeatures`
+  panel visibility, not a registry flag.
+- **`theme`** accepts a `SliccTheme` object
+  (`{ id, name, base, tokens, css?, disableShader?, components? }`) that the
+  SDK serializes as JSON in the handshake welcome. The follower applies it on
+  boot via `applyCherryTheme`, overriding its default appearance. Static —
+  resolved at mount time; there is no runtime re-theme. The
+  `examples/host.html` harness includes a dropdown with hardcoded brand
+  presets, plus a custom-JSON textarea, for manual testing.
+- **CSS-injection guard:** `theme.tokens`, `theme.css`, and every
+  `components` property flow through `sanitizeTheme`
+  (`packages/webapp/src/ui/theme-engine.ts`) before reaching the follower's
+  `<style>` element — any value containing `url(`, `@import`, `expression(`,
+  `javascript:`, angle brackets, or a call to a CSS function outside a small
+  allowlist (`rgb`/`rgba`/`hsl`/`hsla`/`hwb`/`var`/`calc`/`clamp`/`min`/`max`)
+  is dropped rather than partially escaped. This blocks the classic
+  CSS-exfiltration vector (a host beaconing DOM state out via a themed
+  `url(...)`) without requiring the host page itself to be trusted.
+- **`layout`** pushes an arrangement into the follower, serialized as JSON in
+  the handshake welcome and applied ONCE at boot — static, like `theme`.
+  Structurally typed as `unknown` (this SDK ships independently, so no
+  cross-package import). `wc-follower.ts` accepts EITHER shape, sniffed on
+  the object: a `LayoutDocument` (has `base`) or the older `DockTreeSpec`
+  (has `zones`) — embedders vendor the SDK and upgrade on their own
+  schedule, so a version field older hosts never sent would be more brittle
+  than sniffing. See `docs/layouts.md`. Set `locked: true` — tree-wide or
+  per panel — so the user can't rearrange what was pushed. Applied WITHOUT a
+  filesystem, so it can't persist or drift, and `layout save` in an embed
+  reports it needs one rather than writing your arrangement into the user's
+  profile. An invalid document falls back to the default.
+  `examples/host.html` has a custom-JSON textarea for testing.
+
+## Preview bootstrap (`serve --bridge`)
+
+`src/preview-bootstrap.ts` is the injected bootstrap for driveable previews.
+It opens the `/__slicc/bridge` WebSocket, runs `createCdpHostHandler` against
+its **own** `document` (same-origin, no postMessage hop), and exposes
+`window.slicc.emit(name, detail?)` / `window.slicc.on(name, cb)` to the page.
+`emit` sends a `{ t:'emit', … }` frame over that same WebSocket (so the DO can
+attribute it to this tab), falling back to
+`navigator.sendBeacon('/__slicc/emit', …)` only when the socket isn't `OPEN`
+— e.g. during page unload. Builds as a single classic IIFE (html2canvas-pro
+bundled in) embedded into the worker, served at `/__slicc/preview-bridge.js`.
+
+## Protocol version negotiation
+
+Embedders **vendor** this SDK, so the two sides of the handshake routinely
+run different builds. The contract that keeps that safe:
+
+- The follower iframe posts one `handshake.hello` per entry in
+  `SUPPORTED_CHERRY_PROTOCOL_VERSIONS` (newest first, same `channelId`) and
+  pins the negotiated version from whichever `handshake.welcome` the host
+  answers with. All subsequent envelopes — both directions — are stamped
+  with the negotiated version. Version-gated envelope kinds (e.g.
+  `session.export.*`, v2+) must not be used on a lower-negotiated channel.
+- The host SDK accepts only its own `CHERRY_PROTOCOL_VERSION`. When a
+  handshake attempt arrives at a version it cannot speak (and origin + source
+  prove it is our iframe), it replies `handshake.version-mismatch` so the
+  follower fails `connect()` fast with an actionable error instead of eating
+  the handshake timeout, and fires `hooks.onProtocolMismatch`.
+- **When bumping `CHERRY_PROTOCOL_VERSION`:** keep the previous version in
+  `SUPPORTED_CHERRY_PROTOCOL_VERSIONS` and gate any new envelope kinds on
+  the negotiated version. Removing a version from the supported set
+  hard-breaks every embedder still shipping a vendored SDK at that version —
+  do it only for a genuinely breaking wire change, and say so in the
+  changelog. The 2026-07-27 labs incident (P1: every embed failed with an
+  opaque 30s "Cherry handshake timed out") was caused by bumping 1 → 2 for
+  an _additive_ feature while both sides still validated with strict
+  equality.
+
+## Manual end-to-end embed harness
+
+`examples/host.html` is a throwaway host page for exercising a real embed.
+It imports the built SDK (`../dist/index.js`), so run
+`npm run build -w @ai-ecoverse/cherry` first. Steps:
+
+1. `npm run dev` (webapp at `http://localhost:5710`); in that browser, avatar
+   popover → **Enable multi-browser sync** to become a tray **leader**, and
+   copy the `/join/…` URL it shows — that string is the `joinToken`.
+2. Serve the repo root on a **different** origin
+   (`npx http-server . -p 8080`) and open
+   `http://localhost:8080/packages/cherry/examples/host.html`.
+3. Paste the join URL, press **Mount**. The right-hand log shows handshake
+   progress and `onSliccEvent` / `onOpenUrl` / `onPermissionRequest`
+   callbacks. The **send event** row drives
+   `handle.emitHostEvent(name, detail)` (detail is parsed as JSON, falling
+   back to a string) so you can exercise the host → cone direction and
+   watch the `[cherry]` lick land on the leader.
+
+The host-page origin must differ from `sliccOrigin`, and `sliccOrigin` must
+exactly match where the webapp is served — a mismatch fails the three-factor
+`acceptEnvelope` gate (surfaces as a 30s handshake timeout, now logged). The
+dev server does not apply the `frame-ancestors` CSP (only the worker does),
+so local framing works without worker config.
+
+**The harness mirrors real embedder code.** `host.html` is authored exactly
+as a real consumer would write it —
+`import { mountSlicc } from '@ai-ecoverse/cherry'`. A real embedder
+`npm install`s the package and their bundler (or a CDN like esm.sh) resolves
+it plus its `html2canvas-pro` dependency automatically. Since this SDK isn't
+published yet and the harness has no bundler, `host.html` carries an
+`importmap` (clearly labelled as plumbing) that maps the
+`@ai-ecoverse/cherry` specifier to the local `dist/` and the
+`html2canvas-pro` specifier to the copy in the repo's `node_modules` — the
+same file a bundler would resolve. **Serve from the repo root**
+(`npx http-server . -p 8080`) so both relative map paths resolve.
+
+**Screenshots:** set the **screenshot** dropdown to `html2canvas` (it
+defaults to `none`) _before_ Mount — capabilities are fixed at mount time.
+The SDK is built with `tsc` (no bundling), so the screenshot path keeps a
+bare `await import('html2canvas-pro')` (resolved per the import map above).
+The renderer is the maintained **`html2canvas-pro`** fork — the original
+`html2canvas@1.4.1` throws on CSS Color 4 syntax (`color()`, `oklch`, …);
+the capability value stays `'html2canvas'`, only the implementation lib
+differs. Cherry's screenshot is a best-effort DOM raster of `document.body`,
+not a pixel-level CDP capture.

--- a/docs/chrome-extension-details.md
+++ b/docs/chrome-extension-details.md
@@ -1,0 +1,111 @@
+# Chrome Extension Details
+
+Deep-dive companion to [`packages/chrome-extension/CLAUDE.md`](../packages/chrome-extension/CLAUDE.md).
+The bridge Port protocol, toast attribution/dedup, side-panel six-step flow,
+dev-watch loop, QA recipe, and smoke-test knobs live in
+[`extension-thin-bridge.md`](extension-thin-bridge.md); this file collects the
+per-surface implementation rationale that doesn't fit either page.
+
+## Responsibilities
+
+- **Service worker** (`src/service-worker.ts`): pins the leader tab,
+  opens/focuses the side panel on action-click (`chrome.sidePanel.open`,
+  `setPanelBehavior`), accepts the leader's bridge Port via
+  `externally_connectable`, pass-through proxies `chrome.debugger` through
+  `bridge-sw.ts`, hosts the secret-aware fetch proxy and the S3/DA mount
+  sign-and-forward backends, and surfaces SLICC handoff notifications observed
+  via `webRequest` — payload-naming toast with origin attribution,
+  control-character sanitization, and per-fingerprint session dedup (see
+  `extension-thin-bridge.md` "Handoff Toast").
+- **Side-panel cockpit** (`sidepanel.html` + `src/sidepanel-entry.ts`):
+  on-demand `chrome.sidePanel` surface that iframes the hosted ui-only cherry
+  follower (`?cherry=1&ui-only=1`) and runs the tri-state
+  (booting → ready → disconnected) controller over a `cherry-panel` Port to
+  the service worker. It relays the follower avatar menu's "Bring leader to
+  front" (`slicc.focus-leader-tab`) as `focus-leader` with
+  `openSettings: false` — the follower iframe has no `chrome.tabs` access, and
+  the pinned leader lives in one window only.
+- **Secrets options page** (`secrets.html` + `src/secrets-entry.ts`): user-
+  facing CRUD over `chrome.storage.local` credentials consumed by the SW's
+  fetch-proxy and sign-and-forward backends.
+
+## Leader-Tab Lifecycle
+
+The service worker keeps one pinned tab at the hosted leader URL but does
+**not** create it on browser startup — Chrome restores the sticky pinned tab.
+`reconcileLeaderTabOnBoot()` runs at top-level (SW-wake hygiene) to clear a
+stale stored id. `ensureLeaderTab()` (adopt-or-create + dedup) runs **on
+demand** when the icon is clicked or a `cherry-panel` Port connects. After
+restart, the restored leader re-pins itself via **self-adopt**: when no leader
+id is stored, a top-frame connection from an allowlisted origin carrying
+`?slicc=leader` is accepted and persisted. Adoption reloads a
+discarded/unloaded leader tab (memory saver, lazy session restore) — it runs
+no JS and could never deliver `leader.join-url` to the side panel otherwise.
+See `extension-thin-bridge.md` "Leader-Tab Lifecycle" for the extended
+sequence and edge cases.
+
+## `bridge-sw.ts` CDP Ownership
+
+`bridge-sw.ts` is the `externally_connectable` Port handler that
+pass-through-proxies CDP to `chrome.debugger`.
+
+- `cdpGetTargets` marks the `lastFocusedWindow` active tab so
+  `playwright list-tabs` shows `(active)` and cherry prompts can resolve
+  'this page'.
+- The webapp's `CDPRouter` alone owns temporary follower-preview focus and
+  restoration; the bridge applies every `Page.bringToFront` by activating the
+  target tab and forwarding the command, without trying to classify its
+  origin.
+- Synthetic sessions keep the `sessionId === targetId` convention and
+  ref-count duplicate tab attachments; disconnect and target close
+  force-release them.
+- Debugger ownership is shared symmetrically with the legacy compatibility
+  path: whichever consumer performs `chrome.debugger.attach` owns the
+  matching detach, while the borrowing consumer's detach is a no-op.
+- External detach clears every live bridge Port's tab, session, and
+  ref-count state and emits `Target.detachedFromTarget` so the hosted leader
+  invalidates its cached session before reattaching; target close also
+  clears ownership.
+
+## Device / Directory Picker Popups
+
+Directory results carry an opaque `{ handleInIdb, idbKey, dirName }` — the
+popup stashes the non-postable `FileSystemDirectoryHandle` in the shared
+`slicc-pending-mount` IDB store. Device results carry identifiers
+(`vendorId/productId/serialNumber`) the caller re-acquires via
+`navigator.{usb,serial,hid}.getDevices()` in its own realm. Both
+`picker-popup.html` and `picker-popup.js` must stay in the `closeBundle`
+static-asset copy list in `packages/chrome-extension/vite.config.ts` or all
+four picker windows 404.
+
+## Mount Secrets Options Page
+
+`secrets.html` is the manifest's `options_ui` page. Users reach it via
+right-click the toolbar icon → Options, `chrome://extensions` → SLICC →
+Extension options, or the in-app `secret edit` terminal command (which opens
+the page over `chrome-extension://<id>/secrets.html`). The page reads/writes
+`chrome.storage.local` directly (full chrome.\* API access, not sandboxed) and
+is the extension-mode equivalent of editing `~/.slicc/secrets.env` in CLI
+mode. Pure logic lives in `src/secrets-storage.ts` (tested by
+`tests/secrets-storage.test.ts`); the DOM entrypoint `src/secrets-entry.ts`
+is bundled to `dist/extension/secrets.js` via the `build-secrets-page`
+esbuild plugin in `vite.config.ts`.
+
+## MV3 Remote Hosted Code Guard — Debugging
+
+`packages/dev-tools/tools/check-extension-rhc.sh` scans `dist/extension/`
+(recursively, across `.js`/`.html`/`.json`/`.css`, excluding `.map` files)
+and exits non-zero if a full third-party CDN URL literal appears — even one
+the runtime overrides is enough to fail Chrome Web Store review (violation
+reference Blue Argon). Forbidden patterns:
+
+- `https://unpkg.com/<path>` (scoped or non-scoped)
+- `https://esm.sh/<path>`
+- `https://cdn.jsdelivr.net/npm/<path>`
+
+Bare hostnames and the host-only form (no path) are allowed. The script
+prints `file:line:URL` for every match. Open the cited file, find the call
+site that constructed the URL, and migrate it to
+`packages/webapp/src/shell/supplemental-commands/cdn-url-builder.ts` so only
+the bare host appears as a string literal and the path is composed at
+runtime via `new URL(path, ...)`.

--- a/docs/cloud-core-details.md
+++ b/docs/cloud-core-details.md
@@ -1,0 +1,95 @@
+# Cloud Core — Deep Reference
+
+Companion to [`packages/cloud-core/CLAUDE.md`](../packages/cloud-core/CLAUDE.md).
+This file holds the multi-paragraph detail that would otherwise inflate the guide
+past its character budget. Invariants and safety rules stay in the guide; expansions
+live here.
+
+## <a name="e2b-substrate"></a>e2b substrate — timeouts and template filtering
+
+`src/substrates/e2b.ts` pins `requestTimeoutMs` to 120s so Cloudflare Workers do
+not abort cold-start restores under their 30s subrequest timeout — resume
+operations reconnect to a paused sandbox and can exceed the default budget on
+first byte.
+
+`list` filters team sandboxes by template alias via the exported
+`isSliccTemplate` predicate. The match is a `slicc` **prefix**, not an equality
+check, so isolated test-template cones (`slicc-test`) list as SLICC-owned
+instead of surfacing as `dead` in the reconciliation pass in `listCones`.
+
+The template image itself is defined in `packages/dev-tools/e2b-template/`.
+Cloud-core orchestrates it but does not build it; template changes are shipped
+independently and pinned by alias.
+
+## <a name="stable-contracts"></a>Stable Contracts — rationale
+
+### `ConeEntry.state = 'reserved'`
+
+`'reserved'` is the in-flight placeholder used during start/resume to hold a cap
+slot before the substrate reports real state. The worker's
+`CloudSessionsDurableObject` calls `reserveSlot` under `blockConcurrencyWhile`
+so per-user concurrency caps are enforced against a single serialized view of
+the registry, then completes the substrate call outside the critical section.
+`listCones` GCs `reserved` entries older than 10 minutes (`reservedAt`) so a
+crashed start attempt eventually frees its slot.
+
+### `trayId` + `lastJoinUpdatedAt` preservation on pause
+
+`startCone` reads `/tmp/slicc-join.json` from the sandbox and records the
+`trayId` and the `updatedAt` timestamp of that read into the registry as
+`lastJoinUpdatedAt`. `pauseCone` must not overwrite either field — it just
+transitions `state` to `'paused'`.
+
+`resumeCone` reconnects to the paused sandbox, posts to
+`/api/leader-restart` on the hosted node-server, then polls
+`/tmp/slicc-join.json` via `pollForRefreshedStatus`, which only returns success
+when the file's `updatedAt` is strictly newer than the baseline. Without
+preservation, the baseline would be reset on pause and every resume would
+succeed instantly against a stale join URL — the follower would still be
+pointed at the pre-pause tray, silently.
+
+### `/tmp/slicc-join.json` as IPC channel
+
+The hosted node-server writes this file from its `/api/cloud-status` POST
+handler (see `packages/node-server/src/cloud-status.ts`). Cloud-core reads it
+back through the substrate's `readFile`. The shape is `CloudStatus` in
+`src/types.ts`. Because the file is written into the template image at build
+time, `pollCloudStatus` uses `minUpdatedAt` on the start path to ignore that
+template-baked file until the hosted node-server has written a fresh one.
+
+### Registry persistence schema
+
+Both `FileRegistry` (`~/.slicc/cloud-sessions.json`) and `LocalRegistry`
+(DurableObject storage) persist `{ sessions: ConeEntry[] }`. The `sessions`
+field name is a legacy carry-over from before the "cone" rename — CLI files
+already on disk use it, so it stays. `append` is upsert-by-`sandboxId`, not
+insert-or-throw; `listCones`'s reconciliation pass depends on this to fold
+substrate-reported state back into the registry without duplicating rows.
+
+## <a name="secrets"></a>Secret injection paths
+
+The user's substrate credential (`E2B_API_KEY`, and optionally
+`E2B_API_KEY_DOMAINS`) belongs to the substrate client, not the workload.
+`filterSecretsEnv` in `src/secrets-filter.ts` strips both from the env bag
+before it is uploaded into the sandbox at start/resume, so the cone never sees
+the credential that could spawn or kill other sandboxes on the same team.
+
+Everything else in the env bag is forwarded as-is; consumers layer their own
+policy on top (the worker only accepts explicitly listed variables from the
+user; the CLI forwards the caller's shell env). Adjustments to the strip list
+should be made here — not in a consumer — so both consumers stay in sync.
+
+## <a name="hosted-leader-boot"></a>Hosted-leader boot sequence
+
+1. Consumer calls `startCone`; `reserveSlot` writes a `'reserved'` row.
+2. `SandboxSubstrate.create` provisions an e2b sandbox from the SLICC template.
+3. cloud-core uploads filtered env and starts `node-server --hosted`.
+4. The hosted node-server writes `/tmp/slicc-join.json` from its
+   `/api/cloud-status` POST once its tray-hub handshake completes.
+5. `pollCloudStatus` reads the file with `minUpdatedAt` set to the reservation
+   time, so the template-baked copy is ignored.
+6. `startCone` writes `trayId` + `lastJoinUpdatedAt` into the registry and
+   flips `state` from `'reserved'` to `'running'`.
+
+Resume follows the same shape without provisioning: reconnect, kick
+`/api/leader-restart`, poll for strictly-newer `updatedAt`.

--- a/docs/cloudflare-worker-details.md
+++ b/docs/cloudflare-worker-details.md
@@ -1,0 +1,109 @@
+# Cloudflare Worker — Deep Reference
+
+Companion to [`packages/cloudflare-worker/CLAUDE.md`](../packages/cloudflare-worker/CLAUDE.md).
+This file holds the multi-paragraph detail that would otherwise inflate the guide
+past its character budget. Invariants and safety rules stay in the guide; expansions
+live here.
+
+## <a name="public-routes"></a>Public Routes — full semantics
+
+Every route below must also appear in `src/index.ts`, `tests/index.test.ts`, and
+`tests/deployed.test.ts` per the routes-mirror rule in the guide.
+
+| Route                                 | Description                                                                                                                                |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `POST /tray`                          | Create a tray; return join/controller/webhook capability URLs                                                                              |
+| `GET /handoff`                        | Convert `?upskill=`, `?handoff=`, or `?msg=` into RFC 8288 `Link` header                                                                   |
+| `GET /install-cli`                    | POSIX installer script for the Go `slicc` follower CLI (`curl -fsSL …/install-cli \| sh`); covers macOS/Linux/WSL/Git Bash                 |
+| `GET /install-cli.ps1`                | Native-Windows PowerShell installer (`irm …/install-cli.ps1 \| iex`) — installs to `%LOCALAPPDATA%\Programs\slicc`, persists the user PATH |
+| `GET /download/slicc-cli/:target`     | 302 to the newest release asset for a CLI target (`darwin-arm64`, …); scans past binary-less releases; real HTTP errors, no SPA fallback   |
+| `GET /.well-known/api-catalog`        | RFC 9264 linkset for all public routes                                                                                                     |
+| `GET /llms.txt`                       | LLM markdown digest                                                                                                                        |
+| `GET\|HEAD /privacy`                  | 301 to www.sliccy.com/privacy (App Store Connect link)                                                                                     |
+| `GET\|HEAD /status`                   | Public health document (`{ status, service, timestamp, version }`); no auth, `Cache-Control: no-store`                                     |
+| `GET /rel/:name`                      | Dereferenceable docs for SLICC custom rel URIs                                                                                             |
+| `GET\|POST /join/:token`              | Follower join and bootstrap polling (HTTP poll/answer/ice-candidate/retry actions)                                                         |
+| `GET\|POST /controller/:token`        | Leader attach and WS upgrade                                                                                                               |
+| `POST /webhook/:token/:webhookId`     | Forward webhook events into the live leader                                                                                                |
+| `POST /api/tray/:trayId/preview`      | Mint a preview token; body `{ path, bridge?, maxTabs?, quiet?, webhookId? }`; response `{ previewToken, url }`                             |
+| `POST /api/tray/:trayId/preview/stop` | Revoke a preview token; body `{ previewToken }`                                                                                            |
+| `GET /api/tray/:trayId/previews`      | List active previews for a tray                                                                                                            |
+| `GET <token>.sliccy.now/*`            | Preview HTTP pipe — streams file from leader via DO; 30s timeout; bridge mode injects the preview-bridge script                            |
+| `GET __slicc/preview-bridge.js`       | Bundled preview bootstrap (bridge-enabled previews only; build-generated, not committed)                                                   |
+| `WS __slicc/bridge`                   | Preview bridge WS (`slicc.preview-bridge.v1.<connId>`); relays CDP + attributed `emit`; hibernated via `setWebSocketAutoResponse`          |
+| `POST __slicc/emit`                   | Fallback beacon relay for `window.slicc.emit` on page unload                                                                               |
+| `GET /auth/callback`                  | OAuth callback relay; capture hop for the cloud dashboard (no `state` → `postMessage` to opener)                                           |
+| `GET /auth/mcp-callback`              | MCP OAuth capture hop; preserves opaque `state` and posts the untouched callback URL to the same-origin opener                             |
+| `GET /api/flags`                      | Resolve `{ float, flags }` string values for `?float=<float>`; unknown/invalid profiles fall back to `base`                                |
+
+## <a name="cone-configuration"></a>Cone Configuration flow
+
+`ConeConfig` = `{ model, accounts[], secrets[] }` (types in
+`@slicc/cloud-core/cone-config`) lets users pick the cone's model, provide flat
+secrets, and provision provider logins. `src/cloud/cone-config-bridge.ts` handles the
+start/resume flows:
+
+- **start:** validates config, splits into `/slicc/secrets.env` and
+  `/slicc/cone-config.json`. No config ⇒ synthesizes an Adobe default from the cloud
+  bearer.
+- **resume:** merges a `coneConfigDelta` into both files in-sandbox, then reloads the
+  leader via `POST /api/secrets/reload` → `Page.reload`.
+- **Adobe oauth expiry:** every path that synthesizes an Adobe `{kind:'oauth'}`
+  account stamps `tokenExpiresAt` via `imsTokenExpiry` in
+  `@slicc/cloud-core/cone-config` (decodes the IMS JWT's `created_at + expires_in`
+  with `atob`).
+- **DO index:** `CloudSessionsDurableObject` persists a **names-only**
+  `coneConfigIndex` per cone — never values.
+
+## <a name="signaling"></a>Signaling Model — protocol detail
+
+- Leader attaches via controller capability + WS to the DO.
+- **Last-key-holder-wins reconnect**: a leader reconnect with matching credentials
+  closes the stale socket and accepts the new one rather than rejecting. Workerd does
+  not reliably deliver `webSocketClose` on dropped/half-open connections; rejecting
+  the rightful reconnect deadlocks it. Full ghost-leader analysis:
+  [`deploying-tray-worker` skill](../.agents/skills/deploying-tray-worker/SKILL.md).
+- Followers attach via the join capability; bootstrap over HTTP poll
+  (poll/answer/ice-candidate/retry actions).
+- Preview bridge tabs (`serve --bridge`) attach via `/__slicc/bridge` WS. DO relays
+  `bridge.cdp.request`/`bridge.cdp.response` between leader and each bridge socket,
+  keyed by `connId`. On leader (re)connect the DO replays `bridge.connected` for every
+  live bridge socket. Hibernated via `setWebSocketAutoResponse`.
+
+## <a name="static-assets"></a>Static Asset Serving — full rules
+
+- Worker serves `dist/ui/` via Cloudflare Workers Static Assets (`ASSETS` binding).
+- `wantsJSON()` in `shared.ts` checks `?json=true` for content negotiation.
+- GET/HEAD to `/join/:token` and `/controller/:token` without `?json=true` → SPA.
+- Unmatched paths without `?json=true` → SPA fallback.
+- `?json=true`, POST, and WebSocket upgrades → API/JSON.
+- **Cherry embed (`?cherry=1`):** `frame-ancestors` is set from
+  `ALLOWED_CHERRY_HOST_ORIGINS`. A bare `*` also adds any explicit
+  `chrome-extension://` origins (CSP `*` does not authorize extension ancestors).
+  Every non-cherry response gets `frame-ancestors 'none'`. Cherry responses set
+  `Cache-Control: no-store` and `Vary: Sec-Fetch-Dest` to prevent cache mixing.
+- **25 MiB per-asset cap:** Cloudflare rejects any `dist/ui/` file over 25 MiB; the CI
+  `cloudflare-worker` job runs `npm run build -w @slicc/cloudflare-worker`
+  (`wrangler deploy --dry-run`) as a hard gate.
+- `ASSET_ARCHIVE` (R2) retains hashed `/assets/*` across deploys;
+  `serveAssetWithArchiveFallback` tries `ASSETS`, then R2, then stale-asset reload;
+  bucket GC is 14 days.
+
+## <a name="cloud-routes"></a>Cloud Cones routes
+
+All `/api/cloud/*` require `Authorization: Bearer <ims-access-token>` and route to
+`env.CLOUD_SESSIONS.idFromName(userId)`.
+
+| Route                         | Description                                                                 |
+| ----------------------------- | --------------------------------------------------------------------------- |
+| `GET /cloud`                  | Dashboard SPA (CSP-enforced)                                                |
+| `GET /auth/cloud-callback`    | IMS popup callback (HTML)                                                   |
+| `GET /auth/cloud-callback.js` | IMS popup callback (JS, served inline by worker)                            |
+| `POST /api/cloud/start`       | Start a new cone (auth + cap-checked); optional `coneConfig` bundle         |
+| `GET /api/cloud/list`         | Per-user cone list (reconciled with e2b per call)                           |
+| `GET /api/cloud/cone-config`  | `?sandboxId=<id>`: names-only config index (model + account + secret names) |
+| `POST /api/cloud/pause`       | Pause a cone                                                                |
+| `POST /api/cloud/resume`      | Resume a paused cone; optional `coneConfigDelta`                            |
+| `POST /api/cloud/kill`        | Kill a cone (idempotent)                                                    |
+| `POST /api/cloud/sign-out`    | Invalidate auth cache for the bearer                                        |
+| `GET /api/cloud/admin/stats`  | Admin-gated by `ADMIN_USER_IDS`                                             |

--- a/docs/dev-tools-details.md
+++ b/docs/dev-tools-details.md
@@ -1,0 +1,108 @@
+# Dev-Tools Deep Reference
+
+Rationale, gotchas, and non-obvious behavior for tools listed in
+[`packages/dev-tools/CLAUDE.md`](../packages/dev-tools/CLAUDE.md). The
+guide keeps entry commands; this page keeps the "why".
+
+## ai-comment-detection
+
+`packages/dev-tools/ai-comment-detection/` classifies PR/issue thread
+contributions and applies `ai-generated` or `human-in-the-loop` labels.
+The classifier is a cost-ordered cascade:
+
+1. Account check
+2. Markdown density
+3. Similarity
+4. Pangram API
+
+The `human-in-the-loop` label is sticky — once applied it is never
+removed. Pure logic lives in `lib.mjs` (vitest `dev-tools` project). See
+its `README.md` for label semantics and workflow behavior.
+
+## doc-dead-reference-gate
+
+`check-doc-refs.mjs` (+ `check-doc-refs-lib.mjs`) skips globs,
+angle-bracket templates, illustrative `my-*` paths, absolute VFS
+runtime paths, and a small built-in allowlist for build artifacts,
+external-repo refs, and spec/plan future files. TypeScript ESM
+`.js`→`.ts` resolution is handled automatically. Chained after
+`check-doc-sizes.mjs` in `lint:docs`.
+
+## layer-back-edge-ratchet
+
+`check-layer-back-edges.mjs` fails on any NEW import in
+`packages/webapp/src/` that points up the stack
+`fs → shell/git → cdp → tools → core → scoops → ui`
+(e.g. `cdp/` → `scoops/`, or any layer → `ui/`).
+
+Unranked directories (`kernel/`, `providers/`, `speech/`, …) rank just
+below `ui/`: they may import ranked layers but not `ui/`, and are never
+a back-edge target. Pre-existing back-edges are grandfathered per file
+in `layer-back-edge-baseline.json` (one-way ratchet; regenerate after
+paying debt down with `--update`). The baseline doubles as a debt list
+for the boy-scout gate. Chained into `npm run lint`, `lint:ci`,
+pre-commit (webapp-source commits), and the pre-push gate.
+
+## storybook-screenshots-upload
+
+`storybook-screenshots-upload.mjs` (+ `storybook-screenshots-upload-lib.mjs`)
+uploads the affected-story manifest to the `slicc-pr-screenshots` R2
+bucket, content-hash deduplicated, with bounded concurrency
+(`--concurrency`, default 4) via an injectable `r2` client so
+`mapWithConcurrency`/dedup logic is testable without a real `wrangler`
+process.
+
+Sequential per-file `wrangler` subprocess spawns previously took ~4s per
+file — timing out the CI job on large PRs (many affected stories). Each
+shot retries up to 5 times with jittered exponential backoff, since R2
+rate-limits upload bursts with `429` / code 971. Driven by the "Upload
+screenshots to Cloudflare R2" step in
+`.github/workflows/storybook-screenshots.yml`.
+
+## knip-production-suffix-discipline
+
+`npm run deadcode:production-files` runs `knip --production --include files`
+to surface test-only dead files the default knip gate misses.
+
+**Production-suffix discipline**: every workspace `entry`/`project`
+glob in the production graph MUST be `!`-suffixed;
+`knip --production` keeps only suffixed patterns. Test-only fixtures
+are excluded via negated `project` patterns in `knip.json`, **not**
+`ignoreFiles`. See the
+[verifying-before-push skill](../.agents/skills/verifying-before-push/SKILL.md)
+§ "Knip fixture exclusion" for why `ignoreFiles` is wrong and the
+correct approach.
+
+## swift-coverage-retry
+
+`swift-coverage-check.sh` sources `swift-coverage-runner-retry.sh` in
+`--xcodebuild` mode to retry once when the UI-test runner dies at
+initialization. This is an infrastructure failure
+`-retry-tests-on-failure` cannot see (the runner never gets far enough
+to report per-test results); tested by
+`swift-coverage-runner-retry.test.mjs`. Set `SLICC_IOS_SIM_UDID` to a
+worktree-owned simulator UDID to override automatic selection locally;
+when unset or empty, existing SDK-runtime selection remains unchanged.
+
+## fresh-dev-harnesses
+
+Five harness scripts bring up isolated dev environments on distinct
+ports so they can run concurrently. Port-selection, reaping, and
+LaunchServices lifecycle are covered in
+[`docs/development.md`](development.md) § "Fresh Dev Harness Details".
+
+Reaping semantics (also enforced in the harness scripts):
+
+- The standalone harness fails if its selected bridge port is occupied
+  by default.
+- `SLICC_FRESH_REAP=1` opts into reaping a confirmed stale harness on
+  that port.
+- Forced reaping of the documented production bridge `:5710` is always
+  refused.
+- The harness never reaps Chrome CDP (`:9222` production, per-harness
+  `:9224`/`:9225`/`:9226`/`:9333` dev).
+- Other harness cleanup remains strictly port-scoped, never by process
+  name.
+
+Labeled Chrome bundle clones (`clone-labeled-chrome.sh`) provide
+distinct ⌘-Tab entries.

--- a/docs/ios-app-details.md
+++ b/docs/ios-app-details.md
@@ -1,0 +1,37 @@
+# iOS Follower App — Deep Reference
+
+Long-form detail moved out of [`packages/ios-app/CLAUDE.md`](../packages/ios-app/CLAUDE.md) so the package guide stays under its size budget. Anchors below match the summary links in the guide.
+
+## x-callback exec
+
+`--x-callback` replaces any supplied callback keys with app-owned nonce URLs. A correlated success/error/cancel emits one ordered `{status, parameters:[{name,value}]}` JSON line on stdout, then exits 0/1/130. Results are capped at 16 parameters and 16 KiB serialized JSON; overflow fails without truncation. Callback state is process-local, so a callback after app restoration is consumed silently and the leader owns its timeout.
+
+## Transcript swipe arbitration
+
+Nested horizontal content keeps a drag while it can scroll that way; scoop navigation or frozen dismissal takes over only at the departing edge. Freeze edge state at drag start, tolerate either callback order, fail closed for unknown guarded contexts. Edge math includes both 8pt negative-padding expansions. On iOS 18+, each guarded scroller uses `UIGestureRecognizerRepresentable` and snapshots its `UIScrollView` at touch-down; the parent handles ordinary content. Keep the iOS 17 fallback and preserve vertical scrolling.
+
+## iCloud tray supersede chain
+
+iCloud keeps advertising the **old** tray after a leader reconnects. `SessionReachability` and both attach loops must follow the `TRAY_SUPERSEDED` chain (`SupersedeRedirect`, which also moves the tray the connection owns) or a row reads live but cannot connect.
+
+## Local Kokoro models
+
+Settings downloads the anonymous, revision-pinned ~83 MB Hugging Face pack after Wi-Fi consent with progress, cancel, retry, and removal; replies never provision. Pack: nine CoreML stages, two vocabularies, `af_heart`. Marker/cache delete together; weights are not committed. Live-simulator QA: [`docs/ios-simulator-qa.md`](ios-simulator-qa.md).
+
+## Agent avatar treatment
+
+`SliccAgentAvatarView` shares its treatment with the browser `<slicc-agent-avatar>`. The chat header is one 36pt row: scoop pill leading, avatar centered, session-controls cluster trailing. The cluster is a shell overlay, not a toolbar item — the nav bar clips its own items and the cluster must overlap the dock rail. It tracks the chat toolbar: hidden under a compact workbench, kept in the regular split where the conversation stays visible. Menu rows stay text-only. Fullness is pupil size only — never a ring, gauge, badge, or text. Connection trouble outranks lifecycle and replaces pupils and eye whites with 1pt TV static; the a11y phrase still carries label, lifecycle, fill, and connection status. CoreMotion pupil movement is relative to the rolling 60-second average tilt and capped at one eye diameter per second; reduce-motion and closed eyes center pupils. `-uiTestAvatarFixture light-static|dark-static` freezes a noise frame.
+
+No connection banner row: recoverable state stays in the avatar and composer placeholder so it cannot move message rows; terminal `.gaveUp` opens Settings.
+
+## UI-test details
+
+- Put accessibility identifiers on leaves (`message-<id>`). Container ids propagate; `.accessibilityElement(children: .contain)` does not fix it.
+- Row ids alone are blind — also add a `variantMarkers` string only that renderer can emit.
+- The transcript pins to the newest message; variant walks scroll bottom-to-top and must be bounded.
+- A red CI job names the test, not the reason. Read XCTAssert text from the uploaded `test-timings-ios-app-<ios>-<device>` xcresult via `xcrun xcresulttool get test-results tests`. Host death before XCTest connects is usually a runtime mismatch or `CODE_SIGNING_ALLOWED=NO`, not flake.
+- Regular-width browser tabs claim the whole iPad window; returning to the overview restores the split. CI runs this enter/exit regression in the `ios-app-tests` matrix (iPad cells).
+
+## TestFlight distribute
+
+`scripts/testflight-distribute.mjs` (gated on `SLICC_TF_EXTERNAL_GROUP`; unset = upload-only) waits for processing, sets What to Test notes (appending `SLICC_TF_DEMO_JOIN_URL`), submits Beta App Review, and attaches the build to that group. **Submission and attach are independent** — only a `fatal` submit aborts; `deferred` (review quota) warns and still attaches, so the build ships once review clears. Tests: `testflight-distribute.test.mjs`.

--- a/docs/root-details.md
+++ b/docs/root-details.md
@@ -1,0 +1,53 @@
+# Root CLAUDE.md — Detail Overflow
+
+Descriptions for items summarized in the root [`CLAUDE.md`](../CLAUDE.md). Update
+this file when a category grows; keep the root file to bare titles.
+
+## Module Map — Package Purposes
+
+| Path                           | Purpose                                                                                  |
+| ------------------------------ | ---------------------------------------------------------------------------------------- |
+| `packages/webapp/`             | Browser app core (UI, VFS, shell, CDP, tools, providers, skills, scoops)                 |
+| `packages/cherry/`             | Host-side embed SDK (`mountSlicc`) lending a third-party page to a leader                |
+| `packages/chrome-extension/`   | Manifest V3 extension entry points, HTML shells, message bridges                         |
+| `packages/cloudflare-worker/`  | Tray hub worker: sessions, signaling, TURN, `sliccy.ai/cloud` dashboard                  |
+| `packages/node-server/`        | Node CLI/Electron server: Chrome launch, CDP proxy, dev serve, hosted-leader             |
+| `packages/cloud-core/`         | `@slicc/cloud-core` — sandbox-lifecycle lib (worker + `node-server --cloud`)             |
+| `packages/shared-ts/`          | `@slicc/shared-ts` — platform-agnostic primitives (secret masking pipeline)              |
+| `packages/webcomponents/`      | `@slicc/webcomponents` — webapp UI shell (Storybook + `@vitest/browser`)                 |
+| `packages/spoon/`              | `@ai-ecoverse/spoon` — injection overlay + IIFE bootstrap; used in all floats            |
+| `packages/vfs-root/`           | Default VFS content copied into the app on init/reset                                    |
+| `packages/go-optel/`           | Dependency-free Go RUM client used by `slicc-cli`                                        |
+| `packages/swift-launcher/`     | macOS SwiftUI launcher app (`Sliccstart`)                                                |
+| `packages/swift-optel/`        | Pure-Swift RUM library shared by iOS + macOS apps                                        |
+| `packages/swift-server/`       | macOS Hummingbird server (`slicc-server`)                                                |
+| `packages/swift-traysession/`  | Foundation-only iCloud tray-session sync (launcher + iOS)                                |
+| `packages/swift-trayfollower/` | `SliccTrayFollower` — shared tray-follower transport (WebRTC + tray-sync)                |
+| `packages/ios-app/`            | iOS SwiftUI follower (`SliccFollower`) — WebRTC join (SPM, not npm)                      |
+| `packages/slicc-cli/`          | `slicc` — headless Go (pion) follower CLI (`prompt`/`exec`/`follow`; Go module, not npm) |
+| `packages/dev-tools/`          | Repo tooling: build helpers, QA, providers filter, e2b template                          |
+| `packages/assets/`             | Shared static files (logos, fonts, favicon); folder, not an npm workspace                |
+
+## Automated PR Review Checklist — Descriptions
+
+Numbering matches the root checklist. Full catalog:
+[`review-patterns.md`](review-patterns.md).
+
+1. **Error-path coverage** — timeouts/retries/`.catch` on external calls.
+2. **UI state preservation** — capture+restore UI state around DOM rebuilds.
+3. **Cross-runtime parity** — peer runtimes updated or explicitly excluded.
+4. **CDP edge cases** — foreground before screenshots; validate target/port.
+5. **Native/macOS permissions** — entitlements + TCC check + graceful denial.
+6. **Model metadata / provider pipeline** — metadata forwarding, version
+   predicates, thinking levels, costs; see [`pitfalls.md`](pitfalls.md).
+7. **Test coverage** — mirrored `tests/`; bug fixes ship regression tests.
+8. **Follower wiring parity** — leader broadcasts need matching follower
+   handler + UI action; check all boot paths.
+9. **Origin/bridge routing** — `fetch('/api/...')` must work in thin-bridge
+   mode; normalize trailing slashes.
+10. **Agent skill freshness** — shell command changes → update matching
+    `vfs-root/workspace/skills/*/SKILL.md`.
+11. **Transcript export** — fail-closed redaction; approval gate; unknown
+    errors → `transfer-corrupt`; SHA-256.
+12. **Layer import direction** — no new `ui/` imports below ui; move helpers
+    down.

--- a/docs/slicc-cli-details.md
+++ b/docs/slicc-cli-details.md
@@ -1,0 +1,149 @@
+# slicc-cli deep reference
+
+Long-form implementation detail split out of `packages/slicc-cli/CLAUDE.md` to
+keep that guide under the 20,000-char cap. The CLAUDE.md still owns the
+authoritative command list, safety rules, env-var and Makefile references.
+
+## Layout
+
+| Path                  | Purpose                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `main.go`             | Arg parsing + subcommand dispatch + Ctrl+C                                           |
+| `commands.go`         | `prompt` / `exec` / `follow` implementations                                         |
+| `internal/protocol/`  | Wire structs mirroring `packages/shared-ts/src/tray-sync-protocol.ts`                |
+| `internal/signaling/` | HTTP follower client for `tray-signaling.ts` (attach → poll/answer/ice/retry)        |
+| `internal/tray/`      | pion peer + `tray-control` data channel + follower state machine                     |
+| `internal/cloud/`     | iCloud tray-session parse/select/format + darwin `Sliccstart --list-sessions` reader |
+| `cloud.go`            | `list-sessions` + `<verb>-cloud` family                                              |
+| `internal/execrun/`   | Cross-platform runner backing `follow` + `EvalSession` (`--eval`)                    |
+| `update.go`           | `cmdUpdate` + on-launch update-notice hook                                           |
+| `telemetry.go`        | `initTelemetry`/`reportRuntimeError` — RUM via `@ai-ecoverse/go-optel`               |
+| `internal/update/`    | Release discovery (sparse scan) + self-update apply + cached notice                  |
+| `internal/logging/`   | `log/slog` diagnostic logger + `Logf` adapter for the `tray` seam                    |
+
+## `watch` rendering
+
+`watch` is a passive `tail -f` on the agent, mirroring the browser thread. It
+sends nothing and renders the human's prompt (`user_message_echo` → `> …`),
+assistant text (`content_delta`), and tool calls (`tool_use_start` → `⚙ …`,
+`tool_result` → `↳ …`), blanking a line at each turn boundary — reconnecting
+with backoff (`cmdWatch`/`watchOnce`; `printWatchEvent` does the rendering).
+
+## `follow` startup ergonomics
+
+All in `commands.go`:
+
+- **Banner** — a small ASCII wordmark + the identity/runner/exec warning prints
+  to stderr on start; `--no-banner` drops the art but keeps the safety warning.
+- **Runner heuristic** (`runnerExecWarning`) — a known shell
+  (`bash`/`sh`/`zsh`/…) or wrapper (`docker`/`podman`/…) without a trailing
+  `-c` warns that the leader's command would be treated as a script FILE, not
+  a command line — the `follow bash` (vs `follow bash -c`) footgun.
+- **MOTD** (`hello.motd`, `followMotd`) — a one-line "who/what/where" summary
+  the follower advertises so the leader surfaces it to the agent via
+  `ssh --list`. The leader captures it in `tray-leader-sync.ts`
+  (`getFollowerMotds`) and, alongside `getBrowserCapableBootstrapIds`, tags
+  followers `[ssh]` / `[playwright]` in `host`. Additive + optional on the
+  wire (browser/iOS peers omit it).
+
+## `follow --eval` (persistent REPL) lifecycle
+
+`execrun.EvalSession` spawns the runner ONCE and serializes leader commands
+into its stdin as lines; responses are framed by **output quiescence**
+(`--eval-quiet`, default 500 ms) because REPLs never signal completion. The
+session outlives connections AND connection drops — a cancelled per-connection
+context interrupts the in-flight computation (`interruptProcess`, SIGINT to
+the group; no-op on Windows) but never kills the REPL; only `Close` (process
+shutdown) and leader-sent SIGTERM/SIGKILL do. Leader SIGINT likewise
+interrupts without killing (ignored on Windows — a hard kill would destroy
+session state). Late output is forwarded at the head of the next response,
+exec exit codes are always 0 while the REPL lives, `req.Cwd`/`req.Env` are
+ignored, and REPL death marks the session dead (commands then error until
+restart). `follow.NewEvalSession` routes `exec.request` into it; the MOTD
+advertises a REPL target so the leader's agent sends language code, not
+shell. The banner warns about `node` without `-i` (it buffers piped stdin
+until EOF). Tests fake the REPL with a self-exec helper process
+(`TestEvalHelperProcess`) so the suite runs on all three CI OSes; the e2e
+(`TestCLIFollowEvalPersistsState`) proves cross-command state over real
+WebRTC using the platform shell as a line-eval stand-in.
+
+## Self-update mechanics
+
+`internal/update` scans GitHub releases newest→oldest for the first one
+carrying this platform's `slicc-<os>-<arch>[.exe]` asset — releases are
+**sparse** (CLI binaries only attach when `packages/slicc-cli` changed), so
+`releases/latest` is not enough. Same bounded pagination as the worker's
+`/download/slicc-cli` route (30/page, 5 pages max). `Apply` downloads next
+to the executable, runs the staged binary's `--version` as a sanity gate,
+then atomically renames over the running binary (Windows: parks the old
+file at `.old`, swept on later runs).
+
+Regular verbs call `startUpdateNotice()` (main-package `update.go`): the
+upgrade notice prints from a local cache
+(`<user-cache-dir>/slicc/update-check.json`) and a background refresh runs
+at most once per 24 h, bounded-flushed at command exit so short verbs still
+persist it. Disabled via `SLICC_NO_UPDATE_CHECK=1` and for any
+non-release-stamped version (`dev`, `git describe` output) —
+`IsReleaseVersion` gates both the notice and the self-replace, so `slicc
+update` refuses to clobber a local build that is ahead of the latest tag.
+`SLICC_UPDATE_API_BASE` overrides the API base (tests/mirrors).
+
+## Telemetry design rationale
+
+`telemetry.go` wires `packages/go-optel` (`github.com/ai-ecoverse/go-optel`,
+a sibling Go module pulled in via a local `replace` directive — this
+monorepo has no `go.work`) into two checkpoints only: `enter` on launch
+(`initTelemetry(sub)`, deferred right after `initTelemetry(sub)()` executes
+immediately in `main.go`'s `run()`) and `error` on an operational failure
+(`reportRuntimeError(source, err)`, called from the dial-error branches in
+`commands.go` and the update-check/apply error branches in `update.go`).
+`source` for `error` beacons is always one of a small fixed set (`dial`,
+`watch`, `follow`, `update`) — never user-typed input (join URL,
+exec/prompt text) — and `classifySubcommand` applies the same
+allowlist-not-passthrough treatment to the `enter` beacon's subcommand
+name.
+
+Gated the same way as the update notifier: `SLICC_NO_TELEMETRY=1` opts out
+outright, and `update.IsReleaseVersion(version)` means a `dev`/git-describe
+local build never configures a client at all (no env var needed for that
+case). Sampling is one coin flip per process (weight 100 by default,
+`OPTEL_RATE`/`OPTEL_DEBUG` env override), not per checkpoint. See
+`packages/go-optel/CLAUDE.md` for why `Sanitize()` (URL/path redaction
+before truncation) is mandatory here rather than a nice-to-have — this
+CLI's error strings can embed a leader's bearer-token join URL — and
+`docs/operational-telemetry.md` ("CLI Telemetry") for the cross-float
+design.
+
+## Release signing / notarization pipeline
+
+Release binaries are cut **atomically with the semantic-release flow** and
+only when `packages/slicc-cli/` changed since the last tag.
+`release-native.mjs` (the prepareCmd gate) calls `sign-and-package.sh` when
+`decideSliccCliGating` opens: it cross-compiles every target on the macOS
+release runner, Developer ID-signs + notarizes the two darwin binaries
+(reusing release.yml's `APPLE_CERTIFICATE_BASE64` cert and
+`APPLE_API_KEY_*` notarytool creds, and the `setup-go` toolchain), and
+stages `artifacts/release/slicc-*` for `@semantic-release/github` to
+attach. A bare CLI binary can't be stapled (only `.app`/`.dmg`/`.pkg`), so
+Gatekeeper verifies the notarization online. With no cert (a fork / local
+run) the binaries build + stage unsigned instead of failing.
+
+## OS matrix and integration test
+
+CI runs `go test ./...` on macOS/Linux/Windows (`strategy.matrix.os`) to
+exercise real per-OS runtime paths — process-group signalling and the
+`cmd /c` vs `sh -c` runner — that a compile-only check would miss. Tests
+pick the platform shell via a `testRunner()` helper so they run rather than
+skip on Windows; only the genuinely POSIX-specific cases (`sleep` + signal
+delivery) stay `runtime.GOOS == "windows"`-skipped. The static gate
+(`make check`) and cross-compile (`make dist`) run once on Linux — they are
+platform-independent, and the coverage floor would under-count where those
+cases skip.
+
+`integration_test.go` is the real end-to-end test: it drives the whole
+follower path over an actual WebRTC connection (pion ↔ pion on loopback) —
+a leader peer creates the `tray-control` channel, a mock signaling server
+bridges the SDP/ICE exchange to `tray.Dial`, and the leader issues an
+`exec.request` that the follow session runs locally and streams back.
+Deterministic (no browser, no TURN), so it runs in the normal `go test`
+gate.

--- a/docs/swift-launcher-details.md
+++ b/docs/swift-launcher-details.md
@@ -1,0 +1,44 @@
+# Swift Launcher Details
+
+Deep-reference companion to [`packages/swift-launcher/CLAUDE.md`](../packages/swift-launcher/CLAUDE.md). Extended rationale that does not fit the package guide's size budget.
+
+## optel
+
+`.optelAutoInstrument`'s `error` hook only catches Objective-C `NSException`s — Swift errors are values and cannot be intercepted globally. `Models/LauncherErrorReport.swift` bridges every `do/catch` boundary in the launcher:
+
+- `LauncherErrorReport.report(.<operation>, error)` emits an `error` checkpoint with `source = sliccstart:<operation>`. The `Operation` enum values (`update-check`, `update-detach`, `bootstrap`, `bootstrap-update`, `launch-standalone`, `launch-electron`, `auto-launch`, `debug-build`, `terminal-follower`, `reattach`, `secrets-unlock`, `secrets-persist`) are a wire contract — RUM dashboards filter on these strings.
+- `target` is the bridged error domain plus its description, redacted before it leaves the machine: URLs collapse to `<url>` (a join URL carries the session secret), absolute paths to `<path>` (home reveals the user name), `token`/`secret`/`password`/`key` values to `<redacted>`, whitespace collapses, and the result truncates to `maxTargetLength`.
+- Add a new call site together with an `Operation` case and a `log.error` line. Never report the up-to-date outcome of an update check (`AUError.cancelled`) — that is a normal result, not a fault.
+- `Optel.sample` no-ops until `.optelAutoInstrument` has configured a session, so reporting from a failure that happens before instrumentation mounts (or from a unit test) is safe.
+
+## terminal-followers
+
+`SliccCliLocator` resolves an executable in this order: managed `~/Library/Application Support/Sliccstart/bin/slicc`, the repository's local `make build` output, its architecture-specific `make dist` output, then `/usr/local/bin`, `~/.local/bin`, `/opt/homebrew/bin`. The CLI is never bundled in `Sliccstart.app`.
+
+If none is found, the launcher asks before downloading the current Darwin release from `https://www.sliccy.ai/download/slicc-cli/darwin-<arch>`, validates its Developer ID Application signature and release team identifier (`S8LB56P782`) before making it executable or running `--version`, then atomically installs it in the managed location. A successful terminal launch exposes that managed binary through `~/.local/bin/slicc`; the best-effort symlink step preserves regular files and unrelated user symlinks, and only re-points stale links under Sliccstart's own Application Support root.
+
+Release Darwin binaries are signed and notarized, but a bare Mach-O gets no stapled ticket — see [`docs/pitfalls.md`](pitfalls.md) § "Downloaded `slicc` CLI" for why Sliccstart neither strips quarantine nor trusts `spctl`.
+
+## icloud-sync
+
+`SessionReachability` follows bounded `TRAY_SUPERSEDED` chains; only a terminal HTTP 200 with `leader.connected == true` is live. Replacement URLs stay private.
+
+- **Producer** — `SliccstartApp` publishes non-nil `leaderJoinUrl`, withdraws when cleared, and refreshes every 4 hours. Clean quit withdraws; update/detach does not because the browser survives and relaunch republishes.
+- **Consumer** — `AppListView` probes remote rows on section appearance/store reload and stably sorts live/unprobed first. Unreachable rows use `icloud.slash`, `· not responding`, 0.55 opacity, and disable Attach/Follow, not Copy; local rows skip probing. Remote Follow passes a join URL override; Attach-browser uses `launchBrowserFollower`.
+- **Security** — secret-bearing join URLs sync only through same-Apple-ID, encrypted iCloud KVS. `TraySessionLauncherTests` covers row state and Follow.
+
+### Headless CLI (`Sliccstart --list-sessions`)
+
+The iCloud store is readable only by this signed, iCloud-entitled binary, so the Go `slicc` CLI shells out to a subcommand parsed in `main.swift` before the SwiftUI app boots (`TraySessionCLI.parse` returns `nil` for a normal launch). `--list-sessions` prints active sessions as JSON, metadata only (`joinUrl` redacted). `--reveal-urls` adds `joinUrl` behind a consent gate: a remembered "Always" (`UserDefaults`, keyed by caller code-signing id / path) wins; else an `NSAlert` (Deny / Allow Once / Always Allow / Always Deny) shows in a GUI session and a headless/SSH caller is denied (exit 3). Pure logic in `Models/TraySessionCLI.swift` is unit-tested (`TraySessionCLITests`); untestable glue (NSAlert, `getppid`/`proc_pidpath`/`SecCode`, store read) sits in `TraySessionCLIRunner`. Caller identity is spoofable, so redaction-by-default is the real control and the dialog a speed bump.
+
+## updates
+
+`Models/UpdateCheckStatus.swift` is the footer's report on the last check (`idle`, `checking`, `upToDate`, `noInstallableRelease`, `translocated`, `failed(message)`). `AppUpdater` hands every failure to a callback and otherwise only publishes a downloaded bundle, so without this a rate-limited or asset-less check was indistinguishable from "never checked" and the footer just kept offering "Check for Updates". `AUError.cancelled` maps to `upToDate` (that is how `findViableUpdate` says "nothing newer"); `AppUpdater.Error.noValidUpdate` to `noInstallableRelease`.
+
+`AppUpdater` stages its download next to `Bundle.main.bundleURL` before it ever hits the network, so a translocated launch (Gatekeeper copies an unmoved, quarantined `.app` to a read-only synthetic volume under `.../T/AppTranslocation/...`) fails every check with Cocoa's `NSFileWriteVolumeReadOnlyError`; that specific code maps to `translocated` instead of the raw OS error text so the footer tells the user to move the app to `/Applications`.
+
+`Models/TolerantGithubReleaseProvider.swift` tolerates release-naming drift in the `ai-ecoverse/slicc` release history. It also filters out releases lacking an installable macOS asset (`Sliccstart-<version>.zip`/`.tar`), so `AppUpdater` falls back to the newest release that actually ships a binary (needed now that native artifacts are conditionally built). Because the repo releases many times a day while the macOS artifact is built only on `packages/swift-launcher/**` changes, the newest installable release routinely sits beyond the default 30-release page: the provider requests `per_page=100` and follows the RFC 8288 `Link: rel="next"` chain (same host, HTTP(S) only) until a page yields a viable release or reaches `currentVersion` — the release the running build came from, since nothing older can ever be an update.
+
+"Reached" is not "saw an older tag": `/releases` is creation-ordered, so a backport published after a newer release, or a non-semver tag decoding to `Version.null`, would otherwise stop page one and hide the installable release further back. `hasReached(_:on:)` therefore stops only when the page carries the running build's own version or when every _parsed_ release on it is older, ignoring unparsable tags. `maxReleasePages` is only a loop guard for a host whose `Link` chain never terminates, not the intended stop. `currentVersion` defaults to `Bundle.main.version` (the same value `AppUpdater` compares against) and `fetchPage` injects a stub transport; both are pinned in tests because the XCTest host bundle's version is unrelated to the release history.
+
+`Models/LaunchRecordStore.swift` persists a `PersistedLaunchRecord` JSON (servePort, CDP port, electronAppPath, target name, target type, joinUrl, bridgeToken) at `~/Library/Application Support/Sliccstart/launch-records.json`, plus `CDPLiveProbe` for liveness checks via `/json/version`. No PID is stored — process identity isn't needed for reattach because the CDP port answering `/json/version` is what decides whether the previous browser is still alive. The `bridgeToken` is persisted because the surviving browser tab carries it in its launch URL (`?bridgeToken=<token>`); reattach re-forwards the same token so the re-spawned `--serve-only` slicc-server keeps gating `/cdp` against the secret the tab already has, instead of a freshly-minted static one. Legacy records carrying a `staticRoot` key still decode; the extra key is ignored, and a missing `bridgeToken`/`joinUrl` key loads as nil.

--- a/docs/swift-server-details.md
+++ b/docs/swift-server-details.md
@@ -1,0 +1,54 @@
+# swift-server extended internals
+
+Deep-dive material moved out of `packages/swift-server/CLAUDE.md` for headroom. The package guide remains the entry point; consult it first.
+
+## Thin-bridge internals
+
+The Electron overlay bootstrap bundle (`window.__SLICC_ELECTRON_OVERLAY__.inject()`) is embedded at build time by `loadOverlayBundleSource()`, which reads `dist/ui/electron-overlay-entry.js` from the packaged `Contents/Resources/slicc/` and falls back to a minimal inline stub if absent. That single artifact is produced by the `@ai-ecoverse/spoon` package (`node packages/spoon/build.mjs`), a fast webapp-free esbuild — **not** the webapp. `swift-launcher`'s `assemble-app.mjs` (`copy-overlay-entry.mjs`) copies it into the `.app`, and CI builds only spoon before assembly. Consequences:
+
+- A `packages/spoon/**` change re-triggers the macOS `swift-launcher` job.
+- A general webapp UI change does not — the overlay entry is decoupled.
+- `node-server` reads the same `dist/ui/electron-overlay-entry.js` from disk via `getElectronOverlayEntryDistPath`, so both bridges stay byte-for-byte compatible on the overlay too.
+
+`ElectronOverlayInjector`'s production initializer requires a `ThinBridgeConfig`. The hosted-leader origin defaults to production via `resolveHostedLeaderOrigin`, so the only unresolvable case is a missing per-process bridge token; `ServerCommand` then logs a clear error and skips the injector (fail fast) instead of ever serving a bundled overlay.
+
+## Formatting quirks (swift-format)
+
+The shared `.swift-format` config parses on swift-format 6.1 and newer. Two version-sensitive keys:
+
+- `reflowMultilineStringLiterals` must stay in the object enum form (`{ "never": {} }`). 6.1 rejects the plain-string spelling; 6.2+ accepts both.
+- `orderedImports` is only honoured from 6.3 on; older toolchains ignore it silently.
+
+CI runs whatever `macos-latest` ships (6.3 today).
+
+Avoid multi-line string interpolations inside a multi-line string literal: swift-format re-indents the two independently and can emit non-compiling Swift. Hoist the interpolated expression into a local instead.
+
+## CDP-over-CDP follower
+
+`ElectronTrayFollower.swift` joins the tray, answers the leader's WebRTC offer, opens the `tray-control` channel, sends `hello` + `targets.advertise`, and routes inbound messages (ping→pong, `cdp.request`→servicer). The signalling + WebRTC + supersede-redirect transport is the shared `TrayFollowerConnector` from the `packages/swift-trayfollower` package's `SliccTrayFollower` product, also used by the iOS app — the WebRTC framework is not double-shipped.
+
+`FederatedCDPServicer.swift` connects to the app's raw browser-level CDP (`/json/version`) and translates the leader's tray-sync CDP messages to/from it (`targets.advertise`, `cdp.request`→`cdp.response` with `sendCDPResponse`-compatible 64 KB-threshold / 32 KB chunking, `cdp.event`). Its `CDPWebSocketTransport` (shared with `CDPBrowserSession`) is injectable so the frame pump is unit-tested without a live browser.
+
+`ElectronOverlayInjector.onEgressBlocked` fires once on first detection; `ServerCommand` starts the follower on that signal and stops it on shutdown. Mirrors node-server's `electron-tray-follower.ts` / `electron-federated-cdp.ts` (which use `werift`); the Swift path uses in-process `stasel/WebRTC`.
+
+## Keychain trust model — why the prompt recurs
+
+`SecretStore.swift` reads the single `ai.sliccy.slicc / __envfile__` Keychain blob synchronously at startup via one `SecItemCopyMatching` in `readBlob()`. That item was created with the default trusted-application ACL, which trusts ONLY the creating binary identified by its code-signing cdhash. An ad-hoc signature gets a NEW cdhash on every `swift build`, so each rebuilt `slicc-server` is a different, untrusted binary and macOS re-raises the "allow access" ACL dialog.
+
+The durable fix is a stable code-signing identity (`packages/dev-tools/tools/setup-dev-cert.sh`): a constant Designated Requirement means a single interactive **"Always Allow"** grant survives every rebuild. Notes:
+
+- The `unsigned:` partition-list token is **not** a reliable grant for per-rebuild ad-hoc binaries — do not rely on it.
+- The identity must be TRUSTED, not just imported. A self-signed cert imports as `CSSMERR_TP_NOT_TRUSTED`, so `security find-identity -v -p codesigning` (the valid-only form both `setup-dev-cert.sh` and `dev-swift-fresh.sh` use to detect it) lists nothing, and the harness silently falls back to ad-hoc signing — leaving `/api/secrets/masked` empty.
+- `setup-dev-cert.sh` therefore runs `security add-trusted-cert -p codeSign` in the user trust domain (no `sudo`/`-d`, applied non-interactively) after import, and de-duplicates any pre-existing copies by SHA-1 hash first (a CN is "ambiguous" once stacked) so exactly one valid identity remains.
+
+`SLICC_KEYCHAIN_NONINTERACTIVE=1` (set by the dev fresh-bridge harness) is only an anti-hang guard, not a fix for the prompt: it makes `readBlob` pass `kSecUseAuthenticationUIFail` so a headless launch that would otherwise block on the unanswerable dialog fails fast with `errSecInteractionNotAllowed` instead of hanging. An already-granted item still reads fine; otherwise the read path logs an actionable hint and the server continues without Keychain secrets. It never produces silent success.
+
+## API route contracts
+
+Full validation semantics for handlers whose contract is byte-mirrored from `packages/node-server/`:
+
+- `POST /api/handoff` (`Sources/Server/Handoff.swift`) — mirrors `packages/node-server/src/routes/handoff.ts`: validates the structured `{ verb, target, instruction?, url?, title?, branch?, path? }` payload; invalid → 400 with node-server's exact error string. Exception: a non-object JSON body returns this server's generic `Invalid JSON payload` (vs express's body-parser error). Broadcasts a `navigate_event` on the lick WebSocket.
+- `POST /api/secrets/scrub` — mirrors node-server's `routes/secrets.ts`: 400 on non-string `text`, else `{ text: scrubbed }` via `SecretInjector.scrub(text:)`. Real→masked scrub (defense-in-depth).
+- `POST /api/s3-sign-and-forward`, `POST /api/da-sign-and-forward` (`Sources/Server/SignAndForward.swift`) — mirror `packages/node-server/src/secrets/sign-and-forward.ts`. S3 creds resolved from the Keychain (`SecretStore`); DA accepts a transient IMS bearer.
+- `POST /api/sudo-approve` (`Sources/Server/SudoApprove.swift`) — mirrors `packages/node-server/src/sudo/` (`endpoint.ts` + `dialog-backends.ts`): validates the `{ kind, detail, suggestedPattern? }` envelope (invalid → 400) and raises the same native `osascript` dialog by shelling out via `Process`. Loopback-only by construction; fail-closed to `{ decision: "deny" }` on any error.
+- `ALL /api/fetch-proxy` — accepts standard HTTP verbs (`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`) plus the WebDAV (RFC 4918) and CalDAV (RFC 4791) verbs `PROPFIND`, `PROPPATCH`, `MKCOL`, `MKCALENDAR`, `REPORT`, `COPY`, `MOVE`, `LOCK`, `UNLOCK`. Unknown verbs are forwarded to AsyncHTTPClient via `HTTPMethod.RAW(value:)`.

--- a/docs/webapp-details.md
+++ b/docs/webapp-details.md
@@ -1,0 +1,109 @@
+# webapp subsystem details
+
+Overflow from `packages/webapp/CLAUDE.md`. Each section is the deep reference for a subsystem enumerated there.
+
+## Kernel Host
+
+- Path: `packages/webapp/src/kernel/`
+- `host.ts` — `createKernelHost(config)` factory: single boot sequence for every float (orchestrator, lick-manager, agent-bridge, tray subs, cone bootstrap, BshWatchdog, `/proc` mount). `node-rest` opens the `/licks-ws` bridge; extension-delegate leaders route licks through the tray worker. Float discriminator: `resolveFloatTopology()` in `core/float-topology.ts`. `kernel-worker.ts` is the DedicatedWorker entry.
+- `process-manager.ts` tracks every long-running async unit; pids uint32 from 1024+; `signal(pid, sig)` honors SIGINT/SIGTERM/SIGKILL/SIGSTOP/SIGCONT. `proc-mount.ts` serves read-only `/proc` (`cat /proc/<pid>/{status,cmdline,cwd,stat}`).
+- `realm/` hard-killable runner. `runInRealm()` spawns per-task `DedicatedWorker`; SIGKILL → exit 137. JS runs in kernel worker via `createJsWorkerRealm()`; `realm-host` proxies `vfs`/`exec`/`fetch`. Node shims in `realm/helpers/` (barrel: `js-realm-helpers.ts`). Sync-XHR bridge (`readFileSync`/`writeFileSync`, `child_process.execSync`/`execFileSync`/`spawnSync`) via `realm/sync-{xhr,fs-*,exec-*}.ts` + `ui/sync-fs-sw-handler.ts` with per-realm capability tokens.
+- Deep reference: `docs/kernel/process-model.md`.
+
+## Orchestrator
+
+- Path: `packages/webapp/src/scoops/`
+- `orchestrator.ts` owns scoop lifecycle, routing, shared state, and pre-removal `onScoopUnregistered` snapshots. `scoop-context.ts` owns per-scoop prompt execution and FS/tool isolation. `agent-bridge.ts` exposes `globalThis.__slicc_agent` (defaults: writable `[cwd, /shared/, <scratch>/, /tmp/]`, visible `[/workspace/, invokingCwd]`; `--read-only` replaces).
+- `scoop-message-router.ts`: licks use `SCOOP_QUEUE_DEBOUNCE_MS` (1 s) bounded by `SCOOP_QUEUE_MAX_COALESCE_MS` (3 s); pure-lick batches defer while `ScoopContext.isBusy` without queue/watermark loss; `SCOOP_DEFERRAL_STARVATION_MS` reports backpressure once after 5 min. User `web` bypasses the window (immediate/awaited, prevents deferral).
+- `transcript-limits.ts` caps bridge/event transcripts at 64 KB — never canonical `agent-sessions` history or compaction input.
+
+## VirtualFS
+
+- Path: `packages/webapp/src/fs/`. `virtual-fs.ts` POSIX-like FS backed by OPFS (in-memory in Node tests). `restricted-fs.ts` path ACLs. `mount-commands.ts` parses `--source`/`--profile`/`--no-probe`; `path-utils.ts` normalization.
+- `mount/` — `MountBackend` + `backend-local.ts` / `backend-s3.ts` / `backend-da.ts` and shared `RemoteMountCache` (TTL+ETag, IDB). Browser-naive signing: CLI → `/api/s3-sign-and-forward`, extension → SW. `mount-table-store.ts` / `mount-recovery.ts` persist and restore. See `docs/mounts.md`.
+
+## Shell
+
+- Path: `packages/webapp/src/shell/`. `almost-bash-shell.ts` is the just-bash runtime; `supplemental-commands/` built-ins live under `docs/shell-reference.md`. `script-catalog.ts` is the shared `.jsh`/`.bsh` discovery for the shell and `which`; its `FsWatcher` cache is bypassed for mounted trees (external changes invisible). `vfs-adapter.ts` bridges shell → VFS and forwards `canWrite` (duck-typed for `VirtualFS`/`RestrictedFS`).
+- `typescript` v7 (native) runs checks/builds; `typescript-js` (JS v6) powers browser `tsc`/`test`/`esm-transpile` because v7 has no browser/WASM API. `builtin-shadow-map.ts` is authoritative for `ipx`/`npx` → built-in redirects. Raw scans: `jsh-discovery.ts` / `bsh-discovery.ts`.
+
+## Speech
+
+- Path: `packages/webapp/src/speech/`; entry `supplemental-commands/hear-command.ts`. **Page realm only** (mic, AudioContext); kernel worker bridges via `hear-*` panel-RPC.
+- Web Speech API (immediate) hot-swapped to on-device Whisper (`onnx-community/whisper-tiny`); Kokoro TTS (`Kokoro-82M-v1.0-ONNX`) chains off the whisper load. Kokoro selects on English + on-device readiness; Web Speech is fallback.
+- **Extension `uiOnly` side panel**: Chrome denies `getUserMedia` (mic prompt keys on extension origin, ungrantable from cross-origin iframe), so `wc-follower.ts` skips `ptt` and drops "Take a photo". Voice/camera live in the leader tab or detached popout.
+
+## MCP Servers
+
+- Path: `src/shell/mcp/`; command `supplemental-commands/mcp-command.ts`. Lazy registration from `/workspace/.mcp/servers.json`. Subcommands, alias shim, MCP-Apps-as-sprinkles: `docs/shell-reference.md`.
+
+## CDP
+
+- Path: `packages/webapp/src/cdp/`. `transport.ts` CDP transport interface; `browser-api.ts` Playwright-style API. `synthetic-cdp-transport.ts` shared base synthesizes the session lifecycle (`Target.getTargets/attachToTarget`, `Page/Runtime/DOM.enable`, `Page.frameNavigated` + `Page.loadEventFired` after navigate) so `BrowserAPI.navigate()` doesn't hang.
+- `preview-bridge-cdp-transport.ts` extends it for driveable preview tabs (`serve --bridge`) over the tray controller WebSocket (`bridge.cdp.request`, `bridge.close` on `Target.closeTarget`). `cdp/panel-rpc-tray-provider.ts` + `cdp/panel-rpc-cdp-transport.ts` let worker-side `BrowserAPI` drive federated tray/cherry/preview targets via the panel-RPC BroadcastChannel.
+- `cherry-host-transport.ts` extends `SyntheticCdpTransport` for the embedded follower iframe (`?cherry=1`). **`resolveParentOrigin()` prefers `location.ancestorOrigins[0]` (unforgeable); `document.referrer` alone breaks when Referer is stripped or in HTTP-in-HTTPS dev embeds.**
+- `cherry-host-protocol.ts` canonical cherry envelope + three-factor `acceptEnvelope` gate (origin allowlist + `MessageEvent.source` identity + per-mount `channelId` nonce). `packages/cherry/src/protocol.ts` is a structural mirror; keep in sync.
+
+## Sudo (agent action approvals)
+
+- Paths: `shell/sudo/sudoers.ts` (parser/matcher), `fs/sudo-fs.ts` (FS gate), `shell/sudo/command-guard.ts` (command gate), `sudo/` (brokers + manager).
+- `SudoManager` (`sudo/sudo-manager.ts`) per-float policy store; seeds and live-reloads `/etc/sudoers` + `/etc/sudoers.d/*` (edits and "Always" grants apply without restart). `scoop-context.ts` wraps the agent's FS once with `createSudoFs`; single handle backs both file tools and shell. Panel terminal is intentionally NOT gated. Brokers float-specific (`createSudoBroker`): extension-delegate relays via hosted leader tab; standalone/Electron POSTs `/api/sudo-approve`.
+- **Self-protection**: writes to `/etc/sudoers` + `/etc/sudoers.d/*` always require approval, hardcoded in `matchPath` regardless of policy.
+- **"Agent can't self-approve" does NOT cover page-realm code** (which can reassign `globalThis.confirm`): `sudo/panel-responder.ts` captures natives at module init; approval chrome mounts via `ui/wc/trusted-layer.ts`, never `document.body`.
+- Deep reference: `docs/approvals.md`.
+
+## Tray
+
+Modules in `scoops/`: `tray-leader-sync.ts` (façade + lifecycle), `context.ts`, `follower-registry.ts`, `follower-dispatch.ts`, `broadcast.ts`, `cdp-router.ts`, `fs-router.ts`, `tab-router.ts`, `remote-exec.ts`, `transcript-export.ts` (streaming), `preview-bridge.ts`, `cherry-router.ts`, `teleport-pool.ts`. Follower model/thinking pills share `ui/wc/wc-follower-model-surface.ts`; `wc-follower.ts` mount and `wc-tray.ts`'s `slicc:tray-join` role switch both consume it. Cherry gated by `CherryFeatureSet.modelPicker`. See `docs/architecture.md` "Multi-Browser Sync (Tray) Architecture".
+
+## Feature Flags
+
+- Add IDs to `FeatureFlagId`/`FEATURE_FLAGS` in `core/feature-flags.ts` and both `wrangler.jsonc` `FEATURE_FLAGS` lists. User-toggleable flags live in the standalone **Experimental features…** avatar dialog (`listFlags()`), not Account settings.
+- Parse with `isFeatureEnabled`/`coerceFeatureFlagValue` (trimmed, case-insensitive `on`/`true`/`1`). With `overridableFloats`, precedence is local → remote → bundled. `experimental-settings` is worker-controlled (`userToggleable: false`).
+- `setupFeatureFlagsForPage` loads the isolated cache synchronously, then non-blocking `/api/flags?float=<float>` refresh; later config needs reload.
+
+## Context Compaction
+
+- Path: `packages/webapp/src/core/context-compaction.ts`. `scoop-context.ts` passes `model.contextWindow`; compaction fires at window minus reserve (200K fallback when absent/zero). Cone memory appends to `/workspace/CLAUDE.md`; agentic budget covers the whole file, legacy restructuring only `## Auto-extracted`. `agentic-memory` on → compaction builds no memory (#2003); the curator owns it.
+
+## Frozen Sessions ("New session" flow)
+
+- Path: `ui/session-freezer.ts`, `ui/new-session.ts`. **Save**, **Skip memory**, and **Erase** clear cone chat and non-mount `/tmp`, not scoops. Archives in `/sessions/<timestamp>-<slug>.md` + `index.json`. Idle boot recovers pending markers serially (≤3 times) through the **bounded** legacy enrichment call — never the unbounded curator (`timeoutSeconds` cannot stop it). Agentic Save: quick snapshot then clear; title (`skipMemory`) + curator in background. Cone-only `OffscreenClient.clearAllMessages()` awaits `clear-chat-ack` before panel reload.
+
+## UI
+
+- Path: `packages/webapp/src/ui/`; WC shell in `ui/wc/`. `main.ts` boots the WC shell for every float: standalone/electron/hosted-leader/cherry → `wc/wc-live.ts` (kernel worker + tray sync + panel RPC); extension side panel + detached popout → `wc/wc-extension.ts` (`OffscreenClient`). Float discriminator: `resolveUiRuntimeMode()`. `ui/wc/` map: `wc-live`, `wc-shell`, `wc-chat-controller`, `wc-message-view`, `wc-tray`, `wc-sprinkles`, `wc-nav`, `wc-workbench`, `wc-freezer`, `wc-memory`, `wc-extension`; panels in `panelize-shell`, `builtin-panels`, `panel-visibility`, `layout-store`, `agent-panels`, `add-panel-menu`.
+- **Layouts** (`docs/layouts.md`): all chrome is a `SliccPanel` in `<slicc-layout>` except the fixed avatar strip (trusted layer). Behind the `panel-layouts` flag. `panelize-shell.ts` RE-PARENTS what `mountWcShell` built, so `WcShellRefs` stays valid. Documents save to `/workspace/layouts/` (free) or `/etc/slicc/layouts/` (gated). `setPanelVisible` must add an unplaced panel but never duplicate a placed one; `sanitizeLayoutName` guards the path a name becomes.
+- **URL state**: `ctx` (active context, pushed), `at` (scroll pos, debounced replace), `ws` (open workspace surface). No global manager; the host only routes.
+- **Cherry `?cherry=1`** (`main-cherry.ts`): builds `CherryHostTransport` against `window.parent`, reads `joinUrl` from handshake, wraps `BrowserAPI`. Origin detection: see CDP section.
+- **Cherry `?cherry=1&ui-only=1`** (extension side panel): suppresses CDP target advertisement, skips `ptt`, drops "Take a photo" (mic denied in cross-origin side panel). Login/onboarding hand-off to the leader tab is gated to `isExtensionSidePanel` only.
+- **Cloud cone config** (`ui/hosted-config-apply.ts`): `applyHostedAccounts` reconciles accounts from `/api/hosted-bootstrap`, removing only providers tracked in `localStorage['slicc_cloud_managed']` — never user-added ones. `?connect=1` is a login-only surface (`ui/connect-surface.ts`) with no kernel.
+
+## Skills
+
+- Path: `packages/webapp/src/skills/`. Precedence: native `/workspace/skills/` → `.agents/skills/*/SKILL.md` → `.claude/skills/*/SKILL.md` → marketplace (`.claude-plugin/marketplace.json`) → agent plugins (`plugin` command, `shell/plugins/`).
+- **Never monkeypatch a method on a get/set-asymmetric Proxy.** The sudo-fs Proxy advertises `MONKEYPATCH_UNSAFE_FS` (a `Symbol.for` marker); `getCompatibilitySkillCandidates` skips hooks and cache for it (always re-discovers). Reassigning a gated method creates an `override↔wrapper` async recursion that OOMs the kernel worker.
+
+## Sprinkles & Dips
+
+- Sprinkles: `ui/sprinkle-renderer.ts`, `sprinkle-manager.ts`, `sprinkle-discovery.ts`. `.shtml` panels discovered from VFS. CLI: fragments/full docs in `srcdoc` iframes. Extension renders in the hosted `?cherry=1` follower — no extension sandbox.
+- Dips: `ui/dip.ts` hydrates assistant `shtml` code blocks into sandboxed iframes after streaming completes. Minimal lick bridge; auto-height via ResizeObserver.
+
+## Stale-asset recovery (post-deploy)
+
+- `setup-preload-error-reload.ts` + `stale-asset-channel.ts` funnel preload, page Worker, worker boot, and scoop-classifier failures into an `instanceId`-scoped 60 s reload; only the owning page reacts. A cone `replayTurn` marker replays one unanswered turn after recovery.
+
+## Shell command authoring
+
+### `.jsh` commands
+
+- `.jsh` files are JavaScript shell scripts discovered anywhere on the VFS; command name is the basename without `.jsh`. `script-catalog.ts` shares discovery across `AlmostBashShell`, `which`, and other lookup paths. Scripts run in an async wrapper: prefer top-level `await`.
+- Stdin (`process.stdin`) is fully buffered read-ahead (no streaming; latin1 strings, not `Buffer`s; `'error'` never fires) and one-shot: `read()`, events (`on('data')`→`'end'`→`'close'`, single chunk), and the async iterator share one `consumed` flag, so whichever drains first wins and the others see EOF. On the events surface, `pause()` suppresses the deferred emission until `resume()` (the buffer stays drainable) and `process.exit(N)` from a handler exits with code `N`. `process.stdin.isTTY` is always `false`. Do not expose `stdin` as a top-level identifier (collides with user declarations).
+
+### `.bsh` browser scripts
+
+- `.bsh` files are JavaScript browser-navigation helpers that run in the **target browser page context** via CDP `Runtime.evaluate`. Access `document`, `window`, page globals — NOT `process`/`fs`/`exec()`. Filename controls hostname matching: `-.okta.com.bsh` → `*.okta.com`; `login.okta.com.bsh` → exact host match. Optional `// @match` directives in the first 10 lines narrow further. `BshWatchdog` uses `ScriptCatalog` for matching.
+
+## Secret-Aware Fetch Proxy
+
+`createProxiedFetch()` (`packages/webapp/src/shell/proxied-fetch.ts`) routes agent-initiated HTTP through the fetch proxy. Extension mode uses a Port-based path (`chrome.runtime.connect({ name: 'fetch-proxy.fetch' })`). Shell-env population: `secret-env.ts` filters secret names to POSIX-valid identifiers (`/^[A-Za-z_][A-Za-z0-9_]*$/`) so dot-namespaced internal secrets stay out of `$ENV`. See `docs/secrets.md` for OAuth bootstrap, silent renewal, and per-provider extra domains.

--- a/docs/webcomponents-details.md
+++ b/docs/webcomponents-details.md
@@ -1,0 +1,225 @@
+# `@slicc/webcomponents` — internals
+
+Extended reference for `packages/webcomponents/CLAUDE.md`. Deep notes only;
+see the package `CLAUDE.md` for commands, invariants, and the top-level map.
+
+## Panel system
+
+Per-file internals for `src/panel/` beyond the summary in the package guide.
+
+- **`SliccPanel`** (`panel/slicc-panel.ts`) — base class for every panel (chat,
+  both rails, the switcher, the floatbar, each tool panel, each sprinkle). Owns
+  identity (`panelId`, falling back to static `panelMeta.id` so one class backs
+  many ids), `visible` (inverse of native `hidden`, so a11y comes free),
+  `locked`, `presentation`/`anchor`, and `onPanelShow`/`onPanelHide`/`onPanelResize`
+  lifecycle. Light DOM; the shared stylesheet keys on a `data-slicc-panel` marker
+  rather than the tag, because one rule set must cover runtime-registered
+  subclasses. **Panels default to VISIBLE** — the opposite polarity from
+  `<slicc-surface>`, since a panel is placed by the layout rather than being one
+  of a show-one stack.
+- **`panel-meta.ts`** — `PanelMeta`/`PanelSize`/`PanelPresentation` +
+  `panelMetaOf`. DOM-free, exported as `@slicc/webcomponents/panel/meta` so the
+  webapp and kernel worker can import metadata without the barrel (which
+  registers every component and needs `CSSStyleSheet`).
+- **`panel-registry.ts`** (`./panel/registry`) — id → `{ meta, source, origin }`
+  for `builtin` / `sprinkle` / `agent` panels. A duplicate id REPLACES and
+  returns `false`: every caller is a legitimate re-registration (HMR, discovery
+  resync, the agent rewriting its own panel), so throwing would break boot and
+  ignoring would leave stale code live. `panelRegistryEvents` lets a live
+  add-panel menu re-render when kernel-gated discovery lands after first paint.
+- **`layout-schema.ts`** (`./panel/layout-schema`) — the document and its pure
+  resolution. TWO layers: `docks[]` is FIXED CHROME pinned to an edge at an
+  exact size (fr-only zones can't say "44px"); `zones` is the working area the
+  docks leave over — five BorderLayout regions (`ZoneName`:
+  top/left/center/right/bottom). Nesting inside what the docks left puts `top`
+  below the scoop strip and the side zones inboard of the rails, so chrome and
+  zones never overlap; `center` is the remainder. A zone holds ANY NUMBER of
+  panels along its `axis` (`zoneAxis` — wide bands default `row`, tall ones
+  `col`): the simplicity is the five DESTINATIONS, not the capacity. Ops are
+  list edits (`moveToZone`/`removeFromZones`/`zoneOfPanel`). Replaced a split
+  tree that expressed more but nothing a user could aim at; `zonesFromCenter`
+  flattens a legacy `center`. `sizeToFlex`: number/`fr` → grow factor, zero
+  basis; `px`/`%` → fixed. Variants REPLACE a section; `panels` overrides merge
+  per id.
+- **`center-ops.ts`** (`./panel/center-ops`) — just `liveArrangement`: which
+  section (a matched variant, else `base`) owns the working area on screen, and
+  therefore what a drag edits.
+- **`layout-interaction.ts`** — the pointer gestures: hover-reveal corner grip,
+  the five-zone drop compass, divider drag. Grabbing PAINTS the five
+  destinations from the WORKING AREA's box, so a badge appears where the panel
+  lands, and hit-tests them — the drop is what was aimed at; a zone's area
+  works too. Overlays and pointer capture live on the HOST, not a slot: a slot
+  is rebuilt every render (including every resize frame), and a captured
+  element removed from the DOM loses capture per spec — which once left resize
+  stuck to the mouse. TWO seam kinds: between panels in a zone (weights) and
+  between ZONES (px — a thickness is absolute; a weight would rubber-band an
+  edge band on window resize). The zone clamp reserves for EVERY element in the
+  run — fixed zones at actual width, the flexible one at a 48px floor;
+  reserving one floor let a drag crush the center to 0px. No grip on
+  locked/docked panels; no seam beside an empty or locked zone.
+- **Stories** (`panel/*.stories.ts`) — needed for PR screenshots to cover
+  panels at all (the affected-story heuristic is directory-level). Includes
+  `Stacked Docks`, which shows a dock spanning OVER the rails vs `zones.top`
+  between them — the distinction that gets layouts authored wrong.
+- **`<slicc-layout>`** (`panel/slicc-layout.ts`) — renders a document by MOVING
+  matched `SliccPanel` children into slots. Unplaced panels are parked
+  offstage, not destroyed, so a panel keeps its scroll position / live terminal
+  session across variant switches; `getPlacedPanelIds()` reports what actually
+  rendered, not what the document mentions. Re-resolves on HOST resize (not
+  window — a nested layout must react to its own box), rAF-debounced and
+  skipped when the matched variant set is unchanged. Rebuilds target a stable
+  inner root: replacing the host's own children would re-enter its
+  `MutationObserver` forever.
+
+## Dock-tree
+
+Extended notes for `slicc-dock-tree` (`src/workbench/slicc-dock-tree.ts`).
+
+- **Model**: a fixed skeleton of 5 zones (`ZoneName`:
+  `top`/`left`/`middle`/`right`/`bottom`), each holding a recursive `DockNode`
+  — either a `leaf` (one surface) or a `split` (`dir: 'row' | 'col'`, children
+  - relative `sizes`). A zone whose node is `null` collapses entirely (no
+    space, no divider) in normal rendering; a private dragging flag reveals
+    collapsed zones as drop-target placeholders for the duration of any drag.
+- **API**: `setTree`/`getTree` (full serialization incl. sizes),
+  `getSurfaceIds`, `placeSurface(surfaceId, zone)`, `removeSurface`,
+  `moveSurfaceToZone` (detach-then-reinsert, bypassing the pinned guard —
+  needed for `chat`), `setSurfaceSize(surfaceId, size)` (exact px or percent of
+  the sibling group, the programmatic counterpart to dragging a divider),
+  `beginExternalDrag(surfaceId, pointerId?)` (a drag started outside the
+  component enters the same state machine). Per-method contracts are in the
+  source doc comments.
+- **Chat as a movable panel**: `CHAT_SURFACE_ID = 'chat'` is the reserved
+  surfaceId the webapp composes the live `<slicc-chatpane>` into at boot (see
+  `packages/webapp/CLAUDE.md`'s Layouts section). `labelForSurface(surfaceId)`
+  derives a tile's friendly label — `'Chat'` for `CHAT_SURFACE_ID`, otherwise
+  the id with any `sprinkle:` prefix stripped — surfaced as the move button's
+  `title`/`aria-label`, not a visible text bar. `setPinned(surfaceIds:
+string[])` marks leaves as pinned (runtime-only — never serialized by
+  `getTree()`/persisted); a pinned leaf's `removeSurface` is a no-op
+  (defense-in-depth so chat can never be orphaned even if a caller mis-calls
+  remove) — dragging a pinned leaf still moves it normally.
+- **Locking**: `DockTreeSpec.locked` (tree-wide) and `DockNode.locked`
+  (per-leaf or per-split, inherited down to every descendant) block drag,
+  resize, and `removeSurface` for the affected node(s). A locked leaf renders
+  no move button at all — there's nothing to click, matching "cannot drag"
+  literally. Used by embedders (e.g. Cherry) to push a fixed, unmovable
+  arrangement — see `packages/webapp/CLAUDE.md`'s Layouts section.
+- **Drag-drop interaction**: `tilesMovable` / `tiles-movable` defaults off and
+  locking still wins. It remains an opt-in embedder/test contract but is
+  dormant in the shipped webapp: flag-off keeps it off, while flag-on replaces
+  the dock-tree with `<slicc-layout>`. Full `DropRegion` and no-op contracts:
+  `docs/layouts.md`.
+- **Resize**: every skeleton divider (between shown blocks/zones) and every
+  in-zone split divider is pointer-drag-resizable, moving `fr` weight (or a
+  split's `sizes`) between adjacent slots, clamped to 2% of the dragged pair's
+  combined weight — the floor `setSurfaceSize` enforces. Pointer capture is
+  held on the host, not the divider (see the panel system's note above: a
+  captured element removed from the DOM loses capture per spec).
+- **Events**: `dock-tree-change` (composed + bubbling, `detail: { tree }`)
+  fires after a drag-drop (internal or external), `placeSurface`, or
+  `removeSurface` mutates the tree; `dock-tree-resize` (same shape) fires on
+  divider-drag `pointerup` or a `setSurfaceSize` call that actually changed
+  something. Neither event persists anything itself — see
+  `packages/webapp/CLAUDE.md`'s Layouts section for the webapp's
+  `wireDockTreePersistence` listener.
+
+## Composer push-to-talk
+
+Extended reference for the `<slicc-composer ptt>` bullet in the package guide.
+
+The composer owns the hold-to-dictate GESTURE but never the audio stack:
+
+- **3s hold-to-enable permission stage** — first press must be held for 3s to
+  trigger a mic-permission request; a shorter tap is ignored so accidental
+  brushes don't prompt.
+- **Recording overlay** — caption line (live transcript), mic picker, and
+  engine-status line while recording; release appends the transcript and
+  submits.
+- **Speech contract** — hosts inject a `ComposerSpeech` controller via the
+  `speech` property. The contract and a built-in Web Speech fallback live in
+  `composer/speech.ts`, also exported as the DOM-free subpath
+  `@slicc/webcomponents/composer/speech` (safe for node/worker realms; the
+  barrel is not — it registers every component and needs `CSSStyleSheet`).
+  The webapp injects its whisper-upgradable controller there.
+- **Dictation source tag** — dictated submits carry `detail.source ===
+'dictation'` (via the input card's `submit(source?)`) so hosts can speak
+  the reply back to spoken input.
+
+## Storybook PR screenshots
+
+Extended reference for the workflow summary in the package guide.
+
+**Trigger.** `.github/workflows/storybook-screenshots.yml` is event-filtered to
+`packages/webcomponents/**`, its screenshot tooling, and the workflow
+definition on a `pull_request` to `main`. Unrelated PRs do not start the
+workflow.
+
+**Affected-story heuristic** (directory-level, intentionally coarse — easy to
+reason about, no module-graph plumbing):
+
+- A changed `src/<area>/**/*.stories.ts` selects only the stories declared in
+  that file (matched by Storybook's `importPath`).
+- Any other changed file under `src/<area>/` selects **all** stories whose
+  `importPath` lives under that `<area>`.
+- Files outside `packages/webcomponents/src/<area>/` (no area subdir, or
+  outside the package) contribute nothing.
+
+Each affected story is screenshotted at the desktop viewport (1280×900) for
+both the `light` and `dark` theme globals.
+
+**Hosting.** PNGs are uploaded to the Cloudflare R2 bucket
+`slicc-pr-screenshots` under the key `pr-<number>/<head-sha>/<file>.png` and
+embedded inline in the comment via the public r2.dev base URL. The bucket has
+a 30-day object lifecycle rule (`expire-30d`) so screenshots self-clean.
+
+**Fork PRs / missing secret.** When `CLOUDFLARE_API_TOKEN` is unavailable
+(typical for fork PRs) the job degrades to attaching the PNGs as a workflow
+artifact and the comment links to the run instead of embedding images. The
+artifact upload always runs, R2 or not, and the R2 upload step is
+`continue-on-error: true` so a single failed object put still leaves the
+artifact + comment intact.
+
+**Ops secrets/vars.** The repo needs `CLOUDFLARE_API_TOKEN` (R2 read+write on
+the `slicc-pr-screenshots` bucket) as an Actions secret. The account ID,
+bucket name, and public base URL have sensible defaults baked into the
+workflow but can be overridden via the `CLOUDFLARE_ACCOUNT_ID`, `R2_BUCKET`,
+and `R2_PUBLIC_BASE_URL` repo variables.
+
+**Manifest** (`<out>/manifest.json`, schema v1, consumed by the workflow's
+comment builder):
+
+```json
+{
+  "version": 1,
+  "generatedAt": "<ISO8601>",
+  "viewport": { "width": 1280, "height": 900 },
+  "shots": [
+    {
+      "storyId": "pill-pill--cone-open-idle",
+      "title": "Pill/Pill",
+      "name": "Cone Open Idle",
+      "area": "pill",
+      "importPath": "./src/pill/slicc-pill.stories.ts",
+      "theme": "light",
+      "file": "pill-pill--cone-open-idle.light.png",
+      "triggeredBy": ["packages/webcomponents/src/pill/slicc-pill.ts"]
+    }
+  ]
+}
+```
+
+The schema is **flat**: one `shots[]` entry per (story × theme). Consumers
+group by `storyId` themselves (no `stories[].screenshots[]` nesting). The
+capture script is the source of truth for the schema and the CLI; the
+workflow YAML follows.
+
+**R2 upload — dedupe + retry.** Uploads are driven by
+`packages/dev-tools/tools/storybook-screenshots-upload.mjs` (+ pure lib
+`storybook-screenshots-upload-lib.mjs`). Sequential per-file `wrangler`
+subprocess spawns previously took ~4s/file and timed out CI on large PRs,
+so uploads run through an injectable `r2` client with bounded concurrency
+(`--concurrency`, default 4) and content-hash deduplication. Each shot
+retries up to 5 times with jittered exponential backoff, since R2
+rate-limits upload bursts with `429` / code 971. Driven by the workflow's
+"Upload screenshots to Cloudflare R2" step.

--- a/packages/cherry/CLAUDE.md
+++ b/packages/cherry/CLAUDE.md
@@ -1,314 +1,188 @@
 # CLAUDE.md
 
-This file covers the embedded-follower host SDK in `packages/cherry/`.
+Embedded-follower host SDK in `packages/cherry/`. Deep-dives (field
+notes, preview bootstrap, version negotiation, harness):
+[`docs/cherry-details.md`](../../docs/cherry-details.md).
 
 ## Scope
 
-`@ai-ecoverse/cherry` is a tiny, dependency-light host-side SDK that a **third-party
-web page** embeds. It mounts a SLICC follower in an iframe (the webapp loaded
-with `?cherry=1`) and lends the host page to a remote cloud-cone **leader** as a
-driveable, capability-limited CDP target — over cooperative, postMessage-backed
-_synthetic_ CDP. The host page becomes a browser target the remote agent can
-navigate / screenshot / open-url on, but **never** drive raw `Network.*` against.
-
-This package ships independently to third-party origins, so it must NOT import
-from `@slicc/webapp`.
+Dependency-light host-side SDK a **third-party web page** embeds. Mounts
+a SLICC follower iframe (webapp with `?cherry=1`) and lends the host
+page to a remote cloud-cone **leader** as a driveable,
+capability-limited CDP target over postMessage-backed _synthetic_ CDP.
+Agent may navigate / screenshot / open-url, but **never** drive raw
+`Network.*`. Ships to third-party origins; must NOT import from
+`@slicc/webapp`.
 
 ## Main Files
 
-- `src/index.ts` — public surface: `mountSlicc(options)`, `MountSliccOptions`,
-  `HostCapabilities`, `HostHooks`, `SliccHandle`.
-- `src/mount.ts` — `mountSliccImpl`: creates the `?cherry=1` iframe, runs the
-  handshake, dispatches inbound `cdp.request` envelopes through the host
-  handlers, and posts `cdp.response` back. Holds the per-mount `channelId` and
-  the `window` `message` listener.
-- `src/cdp-host-handlers.ts` — `createCdpHostHandler`: host-realm execution of
-  the synthetic CDP subset, plus `CherryUnsupportedError` (`code = -32601`).
-  Also consumed by `preview-bootstrap.ts` (the browser runs it against its own
-  `document` for driveable previews — `serve --bridge`).
-- `src/preview-bootstrap.ts` — the injected bootstrap for driveable previews
-  (`serve --bridge`). Opens the `/__slicc/bridge` WebSocket, runs
-  `createCdpHostHandler` against its **own** `document` (same-origin, no
-  postMessage hop), and exposes `window.slicc.emit(name, detail?)` /
-  `window.slicc.on(name, cb)` to the page. `emit` sends a `{ t:'emit', … }`
-  frame over that same WebSocket (so the DO can attribute it to this tab),
-  falling back to a `navigator.sendBeacon('/__slicc/emit', …)` only when the
-  socket isn't `OPEN` — e.g. during page unload. Builds as a single classic
-  IIFE (html2canvas-pro bundled in) embedded into the worker, served at
-  `/__slicc/preview-bridge.js`.
-- `scripts/build-preview-bootstrap.mjs` — esbuild-bundles `preview-bootstrap.ts`
-  into that IIFE and writes it as the `PREVIEW_BRIDGE_JS` string constant at
-  `packages/cloudflare-worker/src/preview-bridge-assets.ts`. Runs at the end of
-  the cherry `build` (so it's regenerated on every `npm ci`/`npm install` via the
-  root `postinstall`, and again in the root `build` chain which orders cherry
-  before the worker). The output is **`.gitignored` — never commit it**: it's a
-  ~232 KiB minified blob that drifts by dep/toolchain version, so a committed
-  copy goes stale (see #1308). The worker imports it at build/deploy time.
-- `src/protocol.ts` — the postMessage envelope contract and the three-factor
-  `acceptEnvelope` gate. **Structural MIRROR** of the canonical webapp copy (see
-  below).
+- `src/index.ts` — public surface: `mountSlicc(options)`,
+  `MountSliccOptions`, `HostCapabilities`, `HostHooks`, `SliccHandle`.
+- `src/mount.ts` — `mountSliccImpl`: creates `?cherry=1` iframe, runs
+  handshake, dispatches `cdp.request` via host handlers, posts
+  `cdp.response` back. Holds `channelId`, `message` listener.
+- `src/cdp-host-handlers.ts` — `createCdpHostHandler`: host-realm
+  execution of the synthetic CDP subset + `CherryUnsupportedError`
+  (`code = -32601`). Also consumed by `preview-bootstrap.ts`.
+- `src/preview-bootstrap.ts` — driveable-preview bootstrap (same-origin
+  previews for `serve --bridge`); opens `/__slicc/bridge` WS, runs
+  `createCdpHostHandler` against its **own** `document` (no postMessage
+  hop), exposes `window.slicc.emit`/`.on`. See docs/cherry-details.md.
+- `scripts/build-preview-bootstrap.mjs` — esbuilds the IIFE, writes it
+  as `PREVIEW_BRIDGE_JS` at
+  `packages/cloudflare-worker/src/preview-bridge-assets.ts`. Runs at
+  end of cherry `build` (also root `postinstall`; before worker).
+  **`.gitignored` — never commit it** (~232 KiB minified; #1308).
+- `src/protocol.ts` — postMessage envelope contract + three-factor
+  `acceptEnvelope` gate. **Structural MIRROR** of the canonical webapp.
 
 ## The `mountSlicc` surface
 
 ```ts
 mountSlicc({
-  container, // HTMLElement the follower iframe is appended to (optional when `iframe` is provided)
-  iframe, // Caller-provided iframe (opt-in; SDK uses it instead of creating one)
-  sliccOrigin, // origin serving the worker-hosted webapp, e.g. https://app.sliccy.ai
-  capabilities, // { navigate: boolean; screenshot: 'html2canvas' | 'none'; openUrl: boolean }
-  features, // { terminal?, files?, memory?, browser?, modelPicker?, history?, nav?, newSprinkle?, monitor? } — all default true
-  theme, // SliccTheme object — optional brand theme applied inside the follower (serialized in handshake welcome)
-  layout, // DockTreeSpec-shaped object — optional pushed layout, typically with locked: true (serialized in handshake welcome)
-  flags, // { [flagId]: value } — optional feature-flag overrides for this embed, e.g. panel-layouts
+  container, // HTMLElement (optional when `iframe` provided)
+  iframe, // Caller-provided iframe (opt-in)
+  sliccOrigin, // worker-hosted webapp origin, e.g. https://app.sliccy.ai
+  capabilities, // { navigate; screenshot: 'html2canvas'|'none'; openUrl }
+  features, // CherryFeatures — { terminal?, files?, memory?, browser?, modelPicker?, history?, nav?, newSprinkle?, monitor? } default true
+  theme, // SliccTheme — optional brand theme
+  layout, // DockTreeSpec-shaped — optional pushed layout, typically locked
+  flags, // { [flagId]: value } — feature-flag overrides
   hooks, // { onOpenUrl?, onSliccEvent?, onPermissionRequest?, onHandshakeComplete? }
-  joinToken, // REQUIRED: existing tray join URL the host (or its backend) provisioned
-  uiOnly, // Opt-in: append `ui-only=1` AFTER `cherry=1` (follower renders UI but advertises no CDP target)
+  joinToken, // REQUIRED: existing tray join URL the host provisioned
+  uiOnly, // Opt-in: append `ui-only=1` AFTER `cherry=1` (UI only, no target)
 }): SliccHandle; // { iframe, emitHostEvent(name, detail?), destroy() }
 ```
 
-> **Scope:** this SDK only **embeds** against an already-provisioned leader —
-> the host supplies a ready `joinToken` (a tray join URL). Creating/provisioning
-> a cloud cone from the SDK (the old `imsToken` / `coneName` / `createIfMissing`
-> path) is deliberately **out of scope** and tracked as future work. See the
-> design doc's descope note.
+Field notes (theme, layout, `features`/`flags`/`SIDE_PANEL_FEATURES`,
+`HostCapabilities.screenshot`) in docs/cherry-details.md. Invariants:
 
-- **`iframe?` (opt-in):** Caller-provided iframe to drive instead of creating one.
-  When set, the SDK uses this element (already placed in the DOM by the caller) and
-  does not create or append an iframe. `container` becomes optional in this mode.
-  Used by the extension's managed-launcher sidebar. Backward compatible: existing
-  container-only callers keep the create+append+style+remove behavior.
-- **`uiOnly?` (opt-in):** Append `ui-only=1` AFTER `cherry=1` to the follower URL
-  so the follower renders chat/UI but advertises no CDP target. `cherry=1` MUST
-  be present — the worker's `frame-ancestors` CSP relaxation and the follower's
-  cherry-mode boot both key on the `cherry=1` query param (there is no DNR rule;
-  framing is a worker CSP response header). `ui-only=1` is an additive flag.
-
-- `CherryFeatures` controls which UI panels the follower renders. Each field
-  defaults to `true` when omitted. Setting a feature to `false` removes the panel
-  entirely from the DOM (no tab, no placeholder). Features are static — resolved
-  at mount time and sent in `handshake.welcome`; there is no runtime toggle.
-  Separate from `capabilities` (which gates agent _powers_ over the host page);
-  features gate _UI surfaces_ shown to the user.
-- **Feature flags are separate** from `CherryFeatures`: the `?cherry=1` boot uses the shared
-  registry in `feature-flags.ts` (Cherry default: `experimental-settings` off, hiding the
-  dialog that would toggle these). `flags` on `mountSlicc` is the host's session-only bridge
-  into that registry — same `userToggleable`-and-float gate a local override must pass; see
-  `docs/layouts.md`. Not `SIDE_PANEL_FEATURES` in `cherry-panel-protocol.ts` (extension), which
-  is mount-time `CherryFeatures` panel visibility, not a registry flag.
-- `theme` accepts a `SliccTheme` object (`{ id, name, base, tokens, css?,
-disableShader?, components? }`) that the SDK serializes as JSON in the
-  handshake welcome. The follower applies it on boot via `applyCherryTheme`,
-  overriding its default appearance. Static — resolved at mount time; there is no
-  runtime re-theme. The `examples/host.html` harness includes a dropdown with
-  hardcoded brand presets, plus a custom-JSON textarea, for manual testing.
-  **CSS-injection guard:** `theme.tokens`, `theme.css`, and every `components`
-  property flow through `sanitizeTheme` (`packages/webapp/src/ui/theme-engine.ts`)
-  before reaching the follower's `<style>` element — any value containing
-  `url(`, `@import`, `expression(`, `javascript:`, angle brackets, or a call to
-  a CSS function outside a small allowlist (`rgb`/`rgba`/`hsl`/`hsla`/`hwb`/
-  `var`/`calc`/`clamp`/`min`/`max`) is dropped rather than partially escaped.
-  This blocks the classic CSS-exfiltration vector (a host beaconing DOM state
-  out via a themed `url(...)`) without requiring the host page itself to be
-  trusted.
-- `layout` pushes an arrangement into the follower, serialized as JSON in the
-  handshake welcome and applied ONCE at boot — static, like `theme`. Structurally
-  typed as `unknown` (this SDK ships independently, so no cross-package import).
-  `wc-follower.ts` accepts EITHER shape, sniffed on the object: a `LayoutDocument`
-  (has `base`) or the older `DockTreeSpec` (has `zones`) — embedders vendor the SDK
-  and upgrade on their own schedule, so a version field older hosts never sent
-  would be more brittle than sniffing. See `docs/layouts.md`.
-  Set `locked: true` — tree-wide or per panel — so the user can't rearrange what was
-  pushed. Applied WITHOUT a filesystem, so it can't persist or drift, and `layout
-save` in an embed reports it needs one rather than writing your arrangement into
-  the user's profile. An invalid document falls back to the default.
-  `examples/host.html` has a custom-JSON textarea for testing.
-- `HostCapabilities.screenshot` is `'html2canvas' | 'none'` — a strategy, not a
-  boolean. The host SDK lazily `import()`s `html2canvas` only when a screenshot
-  is requested under the `'html2canvas'` strategy.
-- `hooks.onHandshakeComplete()` fires once after the handshake completes and the
-  channelId is pinned (synchronous, single-shot per hello).
-- `hooks.onPermissionRequest(domain)` gates each synthetic CDP domain the leader
-  tries to use (return `false` to deny — the SDK answers `-32601`).
-- `hooks.onSliccEvent(name, detail)` observes `slicc.event` envelopes (telemetry, plus the host's `open-url` convenience path) — the **cone → host** direction. The follower also emits two transport-layer sentinels: `slicc.follower.ready` (WebRTC channel connected) and `slicc.follower.disconnected` (transient drop or terminal `onGaveUp`) — see `wc-follower.ts:onConnectionChange`. Defer `emitHostEvent` until `ready`: calls before the tray channel opens are silently dropped.
-- `SliccHandle.emitHostEvent(name, detail?)` is the **host → cone** direction: the host page emits a named event that posts a `host.event` envelope to the follower, which forwards it over the tray channel as `cherry.host_event`; the leader turns it into a `cherry` lick (labeled **Cherry Event**) on the cone. No-ops with a warning before the handshake completes (no `channelId` to pin it to).
+- **Scope:** SDK only **embeds** against a provisioned leader; host
+  supplies a ready `joinToken`. Cone creation
+  (`imsToken`/`coneName`/`createIfMissing`) is **out of scope**.
+- **`iframe?`:** SDK uses the caller-placed iframe; `container` becomes
+  optional. Used by the extension's managed-launcher sidebar.
+- **`uiOnly?`:** appends `ui-only=1` AFTER `cherry=1`; follower renders
+  UI but advertises no CDP target. `cherry=1` MUST be present — the
+  worker's `frame-ancestors` CSP relaxation and the follower's
+  cherry-mode boot key on it (worker CSP, not DNR).
+- **Three axes:** `capabilities` gate _powers_ (sandbox-escaping — see
+  boundary). `features` (`CherryFeatures`) gate _UI panels_ statically
+  in `handshake.welcome`. `flags` bridge into `feature-flags.ts` (Cherry
+  default: `experimental-settings` off) with the same
+  `userToggleable`-and-float gate as local overrides; see
+  `docs/layouts.md`. Do NOT conflate with `SIDE_PANEL_FEATURES`
+  (`cherry-panel-protocol.ts`, extension side-panel) — mount-time
+  `CherryFeatures` visibility, not a registry flag.
+- **`theme`** flows through `sanitizeTheme`
+  (`packages/webapp/src/ui/theme-engine.ts`) — blocks CSS-exfiltration
+  via themed `url(...)`. **`layout`** applied ONCE at boot, no
+  filesystem; `locked: true` prevents rearrangement.
+- **Hooks:** `onHandshakeComplete()` fires once per hello.
+  `onPermissionRequest(domain)` gates each CDP domain (`false` → SDK
+  answers `-32601`). `onSliccEvent` observes `slicc.event`
+  (**cone → host**). Transport sentinels `slicc.follower.ready` /
+  `.disconnected` (`wc-follower.ts:onConnectionChange`). Defer
+  `emitHostEvent` until `ready`.
+- **`emitHostEvent(name, detail?)`** — **host → cone**: posts
+  `host.event`, forwarded as `cherry.host_event`; leader emits a
+  `cherry` lick (**Cherry Event**).
 
 ## Host-SDK ↔ iframe synthetic-CDP boundary
 
-- The SDK runs on the **host page**; the follower runs in the **iframe**. They
-  speak the cherry envelope protocol over `postMessage`.
-- The iframe side is `CherryHostTransport`
-  (`packages/webapp/src/cdp/cherry-host-transport.ts`) — the **third**
-  `CDPTransport`. It synthesizes the session lifecycle `BrowserAPI` expects
-  (`Target.getTargets` / `attachToTarget`, `Page`/`Runtime`/`DOM.enable`,
-  `Page.getFrameTree`) locally and forwards everything else to the host SDK as
-  `cdp.request`.
-- The SDK answers `cdp.request` by running `createCdpHostHandler` against the
-  host page realm. Methods the host did not opt into (or Cherry does not
-  implement) throw `CherryUnsupportedError` → `cdp.response.error` with code
-  `-32601`.
-- **Two-tier gating** (by design): the `capabilities` booleans gate side effects
-  that ESCAPE the page sandbox — `navigate`, `screenshot`, `openUrl` — and fail
-  closed in the handler. DOM read/query and `Input` (clicking/typing _within_ the
-  page) are the baseline driveable contract; per-domain authorization is enforced
-  upstream by `onPermissionRequest` at the mount layer, so the handler does not
-  re-gate them.
-- **`Runtime.evaluate` is governed by the host page's CSP.** The handler runs an
-  _indirect_ `eval` in the host global scope; if the host CSP forbids dynamic
-  eval it throws natively and surfaces as `exceptionDetails`. Cherry adds no
-  escape hatch.
+SDK on the **host page**; follower in the **iframe**. Iframe side:
+`CherryHostTransport` (`packages/webapp/src/cdp/cherry-host-transport.ts`)
+— the **third** `CDPTransport`. Synthesizes session lifecycle locally
+(`Target.getTargets`/`attachToTarget`, `Page`/`Runtime`/`DOM.enable`,
+`Page.getFrameTree`); forwards everything else as `cdp.request`. SDK
+runs `createCdpHostHandler` in the host realm; unimplemented methods
+→ `CherryUnsupportedError` → `cdp.response.error` `-32601`.
+
+**Two-tier gating**: `capabilities` gate sandbox-escaping effects —
+`navigate`, `screenshot`, `openUrl` — fail closed. DOM read/query and
+`Input` (_within_ the page) are baseline; per-domain auth enforced by
+`onPermissionRequest`. **`Runtime.evaluate` is governed by host CSP** —
+_indirect_ `eval` in the host global scope; forbidden dynamic eval
+throws → `exceptionDetails`. No escape hatch.
 
 ## Three-factor postMessage pinning
 
-Every inbound message is validated by `acceptEnvelope()` against three
-independent factors before any synthetic CDP is acted on:
+`acceptEnvelope()` validates every inbound message against three
+independent factors before any synthetic CDP acts:
 
-1. **Origin allowlist** — `event.origin` must be in `allowOrigins` (the host
-   passes `[sliccOrigin]`; the iframe derives it from `document.referrer`).
-2. **Source identity** — `event.source` must be identity-equal to the expected
-   window (`iframe.contentWindow` on the host side; `window.parent` on the iframe
-   side). `null` accepts any source — only used pre-handshake.
-3. **`channelId` nonce** — `envelope.channelId` must equal the pinned per-mount
-   nonce (the iframe mints `cherry-<uuid>` in `handshake.hello`). `null` skips
-   this factor, only during the pre-handshake window.
+1. **Origin allowlist** — `event.origin` must be in `allowOrigins`
+   (host passes `[sliccOrigin]`; iframe derives it from
+   `document.referrer` — NOT `location.ancestorOrigins`, Chromium-only
+   and not portable as trust root).
+2. **Source identity** — `event.source` must be identity-equal to the
+   expected window (`iframe.contentWindow` host-side; `window.parent`
+   iframe-side). `null` accepts any source — pre-handshake only.
+3. **`channelId` nonce** — `envelope.channelId` must equal the pinned
+   per-mount nonce (iframe mints `cherry-<uuid>` in `handshake.hello`).
+   `null` skips factor 3 — pre-handshake only.
 
-## Embedding only — the host supplies the join URL
+## Embedding only + iframe reload
 
-The SDK forwards the host-supplied `joinToken` over the handshake
-(→ `handshake.welcome.joinUrl`); the follower embeds against that
-already-provisioned leader. The SDK **never calls `/api/cloud/*` itself** — that
-would be a cross-origin call from the third-party host carrying a third-party
-`Authorization` header.
+SDK forwards `joinToken` over the handshake (→
+`handshake.welcome.joinUrl`); follower embeds against the provisioned
+leader. The SDK **never calls `/api/cloud/*` itself** — cross-origin
+with a third-party `Authorization` header (rationale for retiring old
+IMS-bearer / `coneName` / `createIfMissing`: docs/cherry-details.md).
 
-Cone creation/provisioning from the SDK is **out of scope** for now. The host
-page (or its own backend) is responsible for obtaining a join URL and passing it
-in as `joinToken`. The earlier in-iframe provisioning path (forwarding an IMS
-bearer + `coneName` + `createIfMissing` so the same-origin iframe could drive
-`/api/cloud/*`) was removed because a third-party host's IMS token is issued to a
-different client than the cloud LLM proxy and so fails `validateBearer`, and
-because passing secrets through the browser handshake exposes them to the host
-page's user. Reintroducing creation is tracked as a separate future PR; see the
-design doc's descope note.
+SDK survives an iframe reload without `destroy()` + `mountSlicc()`:
+`onMessage` detects a **re-hello** (trusted-peer `handshake.hello` with
+new channelId) and re-runs the handshake. Acceptance is host-side
+policy in `mount.ts`, not `acceptEnvelope`; the gate stays strict —
+only `handshake.hello` bypasses factor 3.
 
-## Iframe reload / re-handshake
+## Protocol mirror & version negotiation
 
-The host SDK survives an iframe reload without the host calling `destroy()` +
-`mountSlicc()` again. When the iframe reloads (host-page re-render, follower
-stale-chunk recovery, crashed renderer), the new page boots a fresh
-`CherryHostTransport` and mints a new `channelId`. The host SDK's `onMessage`
-detects this as a **re-hello** — a `handshake.hello` from a trusted peer
-(origin + WindowProxy identity match) carrying a channelId that differs from
-the pinned one — and re-runs the handshake: re-pins the channelId, resends the
-welcome envelope with theme/config/features, and fires `onHandshakeComplete`.
+`packages/cherry/src/protocol.ts` is a structural **MIRROR** of
+`packages/webapp/src/cdp/cherry-host-protocol.ts` (same `CherryEnvelope`
+union, `CHERRY_PROTOCOL_VERSION`, `SUPPORTED_CHERRY_PROTOCOL_VERSIONS`,
+`isCherryEnvelope`, `AcceptContext`, `acceptEnvelope`; SDK copy has no
+webapp import). Change one → change the other.
 
-The re-hello acceptance rule lives in `mount.ts` (host-side policy), not in
-`acceptEnvelope` (shared protocol). The three-factor gate in `protocol.ts`
-remains strict — only the `handshake.hello` kind bypasses factor 3 under factors
-1-2 trust.
+Embedders **vendor** this SDK; both sides run different builds (full
+contract, incl. 2026-07-27 labs P1: docs/cherry-details.md). Rules:
 
-## Protocol mirror invariant
-
-`packages/cherry/src/protocol.ts` is a structural **MIRROR** of the canonical
-`packages/webapp/src/cdp/cherry-host-protocol.ts`. The two must stay in sync —
-same `CherryEnvelope` union, `CHERRY_PROTOCOL_VERSION`, `isCherryEnvelope`,
-`AcceptContext`, and the three-factor `acceptEnvelope` gate. The ONLY intended
-difference is the package location (the SDK copy carries no webapp import). When
-you change one, change the other.
-
-## Protocol version negotiation and bump rules
-
-Embedders **vendor** this SDK, so the two sides of the handshake routinely run
-different builds. The contract that keeps that safe:
-
-- The follower iframe posts one `handshake.hello` per entry in
-  `SUPPORTED_CHERRY_PROTOCOL_VERSIONS` (newest first, same `channelId`) and pins
-  the negotiated version from whichever `handshake.welcome` the host answers
-  with. All subsequent envelopes — both directions — are stamped with the
-  negotiated version. Version-gated envelope kinds (e.g. `session.export.*`,
-  v2+) must not be used on a lower-negotiated channel.
-- The host SDK accepts only its own `CHERRY_PROTOCOL_VERSION`. When a
-  handshake attempt arrives at a version it cannot speak (and origin + source
-  prove it is our iframe), it replies `handshake.version-mismatch` so the
-  follower fails `connect()` fast with an actionable error instead of eating
-  the handshake timeout, and fires `hooks.onProtocolMismatch`.
-- **When bumping `CHERRY_PROTOCOL_VERSION`:** keep the previous version in
-  `SUPPORTED_CHERRY_PROTOCOL_VERSIONS` and gate any new envelope kinds on the
-  negotiated version. Removing a version from the supported set hard-breaks
-  every embedder still shipping a vendored SDK at that version — do it only
-  for a genuinely breaking wire change, and say so in the changelog. The
-  2026-07-27 labs incident (P1: every embed failed with an opaque 30s
-  "Cherry handshake timed out") was caused by bumping 1 → 2 for an _additive_
-  feature while both sides still validated with strict equality.
+- Follower posts one `handshake.hello` per entry in
+  `SUPPORTED_CHERRY_PROTOCOL_VERSIONS` (newest first, same `channelId`);
+  pins whichever `handshake.welcome` the host answers. Version-gated
+  kinds (e.g. `session.export.*`, v2+) must not run on lower channels.
+- Host SDK accepts only its own `CHERRY_PROTOCOL_VERSION`; mismatch →
+  `handshake.version-mismatch` (fires `hooks.onProtocolMismatch` so the
+  follower fails fast, not the 30s timeout).
+- **Bumping `CHERRY_PROTOCOL_VERSION`:** keep the prior in
+  `SUPPORTED_CHERRY_PROTOCOL_VERSIONS` and gate new kinds on the
+  negotiated version. Removing a supported version hard-breaks vendored
+  SDKs — reserve for genuinely breaking wire changes.
 
 ## Build and test
 
 ```bash
-npm run build -w @ai-ecoverse/cherry   # tsc -p tsconfig.build.json → dist/ (tsconfig.json is the noEmit typecheck config incl. tests/)
+npm run build -w @ai-ecoverse/cherry   # tsc -p tsconfig.build.json → dist/
 npm test -w @ai-ecoverse/cherry        # vitest (jsdom)
 ```
 
-`mountSliccImpl` and `CherryHostTransport` both expose `test*` seams (e.g.
-`__test_post`, `testReceive`) so the postMessage round-trip can be exercised
-without a real cross-origin window.
-
-### Manual end-to-end embed harness
-
-`examples/host.html` is a throwaway host page for exercising a real embed. It
-imports the built SDK (`../dist/index.js`), so run `npm run build -w @ai-ecoverse/cherry`
-first. Steps:
-
-1. `npm run dev` (webapp at `http://localhost:5710`); in that browser, avatar
-   popover → **Enable multi-browser sync** to become a tray **leader**, and copy
-   the `/join/…` URL it shows — that string is the `joinToken`.
-2. Serve the repo root on a **different** origin (`npx http-server . -p 8080`)
-   and open `http://localhost:8080/packages/cherry/examples/host.html`.
-3. Paste the join URL, press **Mount**. The right-hand log shows handshake
-   progress and `onSliccEvent` / `onOpenUrl` / `onPermissionRequest` callbacks.
-   The **send event** row drives `handle.emitHostEvent(name, detail)` (detail is
-   parsed as JSON, falling back to a string) so you can exercise the host → cone
-   direction and watch the `[cherry]` lick land on the leader.
-
-The host-page origin must differ from `sliccOrigin`, and `sliccOrigin` must
-exactly match where the webapp is served — a mismatch fails the three-factor
-`acceptEnvelope` gate (surfaces as a 30s handshake timeout, now logged). The dev
-server does not apply the `frame-ancestors` CSP (only the worker does), so local
-framing works without worker config.
-
-**The harness mirrors real embedder code.** `host.html` is authored exactly as a
-real consumer would write it — `import { mountSlicc } from '@ai-ecoverse/cherry'`.
-A real embedder `npm install`s the package and their bundler (or a CDN like
-esm.sh) resolves it plus its `html2canvas-pro` dependency automatically. Since
-this SDK isn't published yet and the harness has no bundler, `host.html` carries
-an `importmap` (clearly labelled as plumbing) that maps the `@ai-ecoverse/cherry`
-specifier to the local `dist/` and the `html2canvas-pro` specifier to the copy in
-the repo's `node_modules` — the same file a bundler would resolve. **Serve from
-the repo root** (`npx http-server . -p 8080`) so both relative map paths resolve.
-
-**Screenshots:** set the **screenshot** dropdown to `html2canvas` (it defaults to
-`none`) _before_ Mount — capabilities are fixed at mount time. The SDK is built
-with `tsc` (no bundling), so the screenshot path keeps a bare
-`await import('html2canvas-pro')` (resolved per the import map above). The
-renderer is the maintained **`html2canvas-pro`** fork — the original
-`html2canvas@1.4.1` throws on CSS Color 4 syntax (`color()`, `oklch`, …); the
-capability value stays `'html2canvas'`, only the implementation lib differs.
-Cherry's screenshot is a best-effort DOM raster of `document.body`, not a
-pixel-level CDP capture.
+Default `tsconfig.json` is the noEmit typecheck config (incl. tests/).
+`mountSliccImpl` and `CherryHostTransport` expose `test*` seams
+(`__test_post`, `testReceive`) exercising the postMessage round-trip
+without a real cross-origin window. Harness: `examples/host.html`.
 
 ## Transcript export
 
-Cherry hosts can request a transcript export via `handle.exportSession()`. The export
-flows through the `session.export.*` wire protocol (request → approval on the leader →
-progress events → response or error). Approval is one-time per request.
-
-See [`docs/transcript-export.md`](../../docs/transcript-export.md) for the full protocol,
-error codes, and `TranscriptExportError` usage.
+`handle.exportSession()` → `session.export.*` (request → approval on
+leader → progress → response/error); approval is one-time. Full
+protocol, error codes, `TranscriptExportError`:
+[`docs/transcript-export.md`](../../docs/transcript-export.md).
 
 ## Related Guides
 
-- `packages/webapp/CLAUDE.md` — `CherryHostTransport`, the `?cherry=1` boot mode,
-  and the `'cherry'` lick type.
-- `packages/cloudflare-worker/CLAUDE.md` — the `?cherry=1` `frame-ancestors` CSP,
-  `ALLOWED_CHERRY_HOST_ORIGINS`, and cache isolation.
-- `packages/vfs-root/workspace/skills/cherry/SKILL.md` — the cone-facing skill.
-- `docs/transcript-export.md` — transcript export full reference (bundle layout,
-  privacy guarantees, Cherry SDK API, approval semantics).
-- `docs/architecture.md` — float topology + the synthetic-CDP translation matrix.
+- `packages/webapp/CLAUDE.md` — `CherryHostTransport`, `?cherry=1` boot,
+  `'cherry'` lick.
+- `packages/cloudflare-worker/CLAUDE.md` — `?cherry=1` `frame-ancestors`
+  CSP, `ALLOWED_CHERRY_HOST_ORIGINS`, cache isolation.
+- `packages/vfs-root/workspace/skills/cherry/SKILL.md` — cone skill.
+- `docs/cherry-details.md`, `docs/transcript-export.md`,
+  `docs/architecture.md` (topology + translation matrix).

--- a/packages/chrome-extension/CLAUDE.md
+++ b/packages/chrome-extension/CLAUDE.md
@@ -1,313 +1,203 @@
 # CLAUDE.md
 
-This file covers the Chrome Manifest V3 float in `packages/chrome-extension/`.
+Chrome Manifest V3 float in `packages/chrome-extension/`.
 
 ## Scope
 
-`packages/chrome-extension/` contains the manifest, service-worker CDP bridge,
-the on-demand cherry side-panel cockpit (`sidepanel.html` +
-`sidepanel-entry.ts`), the secrets options page, the preview service worker,
-and the device / media popup shells (capture-popup / picker-popup). The webapp
-UI and the agent engine load from the hosted leader tab and are NOT bundled
-into the extension.
-
-### Permissions
-
-The manifest declares `sidePanel` to enable the Chrome-native per-window
-side-panel cockpit. There is no `content_scripts` array in the manifest.
+Contains the manifest, service-worker CDP bridge, on-demand cherry side-panel
+cockpit (`sidepanel.html` + `sidepanel-entry.ts`), the secrets options page,
+the preview service worker, and the device / media popup shells
+(capture-popup / picker-popup). Webapp UI and agent engine load from the
+hosted leader tab and are NOT bundled into the extension. Manifest declares
+`sidePanel`; no `content_scripts`.
 
 ## Thin Bridge Architecture
 
-The extension is a CDP pass-through + bootstrapper. There is no bundled
-side-panel UI and no offscreen agent engine — both moved to a pinned hosted
-leader tab (`https://www.sliccy.ai/?slicc=leader`).
+CDP pass-through + bootstrapper. No bundled side-panel UI, no offscreen
+engine - both moved to a pinned hosted leader tab
+(`https://www.sliccy.ai/?slicc=leader`).
 
 ```text
 Hosted leader tab (https://www.sliccy.ai/?slicc=leader)
   webapp UI, kernel worker, orchestrator, VFS, agent shell
-        ↑ chrome.runtime.connect({ name: 'slicc.cdp-bridge' })
-Service Worker bridge
-  service-worker.ts, bridge-sw.ts, chrome.debugger pass-through,
-  fetch-proxy backend, mount sign-and-forward backend, secrets storage
-        ↑ chrome.runtime.connect({ name: 'cherry-panel' })
+        ^ chrome.runtime.connect({ name: 'slicc.cdp-bridge' })
+Service Worker bridge (service-worker.ts, bridge-sw.ts)
+  chrome.debugger pass-through, fetch-proxy backend,
+  mount sign-and-forward backend, secrets storage
+        ^ chrome.runtime.connect({ name: 'cherry-panel' })
 Side-panel cockpit (sidepanel.html + sidepanel-entry.ts)
-  Iframes the hosted ui-only follower (?cherry=1&ui-only=1),
-  connected to the leader over the tray; no CDP target
+  Iframes hosted ui-only follower (?cherry=1&ui-only=1)
 ```
 
-See `docs/architecture.md` "Extension Thin-Bridge Architecture" for the full
-cross-origin model. See `docs/extension-thin-bridge.md` for bridge protocol,
-toast dedup, QA scenarios, and dev-watch details.
+Leader-tab bridge Port (`name: 'slicc.cdp-bridge'`) carries CDP pass-through
+(`cdp.request/response/event`), handoff licks (`extension.lick`),
+open-settings (`extension.open-settings`), and `leader.join-url`. Hosted
+leader tab is the tray leader (page-side `LeaderSyncManager` at
+`packages/webapp/src/ui/page-leader-tray.ts`); extension bypasses the tray
+data path.
+
+Refs: `docs/architecture.md` (cross-origin);
+`docs/extension-thin-bridge.md` (Bridge Port protocol, toast dedup,
+dev-watch, QA, side-panel six-step flow, Secret-Aware Fetch Proxy handler,
+Smoke Test knobs); `docs/chrome-extension-details.md` (per-surface
+responsibilities, leader-tab lifecycle rationale, `bridge-sw.ts` CDP
+ownership, picker payload shapes, secrets-page detail, MV3 RHC debug);
+`docs/pitfalls.md`; `docs/transcript-export.md`;
+`packages/webapp/CLAUDE.md`; `packages/shared-ts/CLAUDE.md`.
 
 ### Responsibilities
 
-- **Service worker** (`src/service-worker.ts`): pins the leader tab,
-  opens/focuses the side panel on action-click (`chrome.sidePanel.open`,
-  `setPanelBehavior`), accepts the leader's bridge Port via
-  `externally_connectable`, pass-through proxies `chrome.debugger` through
-  `bridge-sw.ts`, hosts the secret-aware fetch proxy and the S3/DA mount
-  sign-and-forward backends, and surfaces SLICC handoff notifications observed
-  via `webRequest` (payload-naming toast with origin attribution,
-  control-character sanitization, and per-fingerprint session dedup; see
-  `docs/extension-thin-bridge.md` "Handoff Toast" for details).
+- **Service worker** (`src/service-worker.ts`): pins the leader tab, opens
+  the side panel (`chrome.sidePanel.open`, `setPanelBehavior`), accepts the
+  leader's Port via `externally_connectable`, proxies `chrome.debugger`
+  through `bridge-sw.ts`, hosts the secret-aware fetch proxy and S3/DA
+  mount sign-and-forward backends, surfaces SLICC handoff notifications
+  via `webRequest`.
 - **Side-panel cockpit** (`sidepanel.html` + `src/sidepanel-entry.ts`):
-  on-demand `chrome.sidePanel` surface that iframes the hosted ui-only cherry
-  follower (`?cherry=1&ui-only=1`) and runs the tri-state
-  (booting → ready → disconnected) controller over a `cherry-panel` Port to
-  the service worker. It relays the follower avatar menu's "Bring leader to
-  front" (`slicc.focus-leader-tab`) as `focus-leader` with
-  `openSettings: false` — the follower iframe has no `chrome.tabs` access, and
-  the pinned leader lives in one window only.
-- **Secrets options page** (`secrets.html` + `src/secrets-entry.ts`): user-
-  facing CRUD over `chrome.storage.local` credentials consumed by the SW's
-  fetch-proxy and sign-and-forward backends.
+  on-demand `chrome.sidePanel` surface iframing the hosted ui-only cherry
+  follower (`?cherry=1&ui-only=1`); runs the tri-state
+  (booting -> ready -> disconnected) controller over a `cherry-panel` Port;
+  relays `slicc.focus-leader-tab` as `focus-leader` with
+  `openSettings: false`.
+- **Secrets options page** (`secrets.html` + `src/secrets-entry.ts`): CRUD
+  over `chrome.storage.local`.
 
 ### Leader-tab lifecycle
 
-The service worker keeps one pinned tab at the hosted leader URL but does
-**not** create it on browser startup — Chrome restores the sticky pinned tab.
-`reconcileLeaderTabOnBoot()` runs at top-level (SW-wake hygiene) to clear a
-stale stored id. `ensureLeaderTab()` (adopt-or-create + dedup) runs **on
-demand** when the icon is clicked or a cherry-panel Port connects. After
-restart, the restored leader re-pins itself via **self-adopt**: when no leader
-id is stored, a top-frame connection from an allowlisted origin carrying
-`?slicc=leader` is accepted and persisted. Adoption reloads a
-discarded/unloaded leader tab (memory saver, lazy session restore) — it runs
-no JS and could never deliver `leader.join-url` to the side panel otherwise.
-See `docs/extension-thin-bridge.md` "Leader-Tab Lifecycle" for the full
-rationale.
-
-### Tray leader / multi-browser sync
-
-The hosted leader tab is the tray leader — it runs the standard page-side
-`LeaderSyncManager` (`packages/webapp/src/ui/page-leader-tray.ts`) exactly
-like any other standalone leader. The extension is not in the tray data path
-at all: extra browsers join as followers by connecting to the same worker URL
-the hosted leader publishes.
+SW keeps one pinned leader tab but does **not** create it on browser
+startup - Chrome restores the sticky pinned tab.
+`reconcileLeaderTabOnBoot()` runs at top-level (SW-wake hygiene);
+`ensureLeaderTab()` (adopt-or-create + dedup) runs **on demand**. After
+restart the restored leader re-pins via **self-adopt**: a top-frame
+connection from an allowlisted origin carrying `?slicc=leader` is accepted
+when no leader id is stored; adoption reloads a discarded/unloaded leader
+tab so it can deliver `leader.join-url`.
 
 ## On-Demand Per-Window Cherry Side Panel
 
-Clicking the toolbar icon opens a window-level Chrome side panel
-(`sidepanel.html`) — no per-page injection. The panel iframes the hosted
-`?cherry=1&ui-only=1` follower and connects to the leader over the tray.
+Toolbar-icon click opens window-level `sidepanel.html` - no per-page
+injection. Panel iframes the hosted `?cherry=1&ui-only=1` follower and
+connects to the leader over the tray.
 
-**Framing**: the cloudflare worker sets a `Content-Security-Policy`
-`frame-ancestors` header naming the extension origin (`chrome-extension://<id>`).
-A bare `*` does not authorize `chrome-extension://` ancestors; there is no
+**Framing**: cloudflare worker sets `Content-Security-Policy`
+`frame-ancestors` naming the extension origin (`chrome-extension://<id>`);
+bare `*` does not authorize `chrome-extension://` ancestors; no
 `declarativeNetRequest` framing rule.
 
-**Login hand-off**: provider login runs in the leader tab, not the panel. The
-follower detects the side-panel via `location.ancestorOrigins` and shortcuts
-onboarding to a "Set up SLICC in the main tab" card; see
-`docs/extension-thin-bridge.md` "On-Demand Cherry Side Panel" for the full
-six-step flow and tri-state UI details.
+**Login hand-off**: provider login runs in the leader tab, not the panel;
+the follower detects the side-panel via `location.ancestorOrigins` and
+shortcuts onboarding to a "Set up SLICC in the main tab" card.
 
 ## Key Files
 
-- `src/service-worker.ts` — MV3 background bridge + leader-tab lifecycle +
-  secret-aware fetch proxy + handoff notifications
-- `src/bridge-sw.ts` — `externally_connectable` Port handler that
-  pass-through-proxies CDP to `chrome.debugger`. `cdpGetTargets` marks the
-  `lastFocusedWindow` active tab so `playwright list-tabs` shows `(active)`
-  and cherry prompts can resolve 'this page'. The webapp's `CDPRouter` alone
-  owns temporary follower-preview focus and restoration; the bridge applies
-  every `Page.bringToFront` by activating the target tab and forwarding the
-  command, without trying to classify its origin. Synthetic sessions keep the
-  `sessionId === targetId` convention and ref-count duplicate tab attachments;
-  disconnect and target close force-release them. Debugger ownership is shared
-  symmetrically with the legacy compatibility path: whichever consumer performs
-  `chrome.debugger.attach` owns the matching detach, while the borrowing consumer's
-  detach is a no-op. External detach clears every live bridge Port's tab, session,
-  and ref-count state and emits `Target.detachedFromTarget` so the hosted leader
-  invalidates its cached session before reattaching; target close also clears ownership.
-- `src/sidepanel-entry.ts` — side-panel host controller (bundled to
-  `dist/extension/sidepanel.js`): mounts the ui-only cherry follower iframe
-  and drives the tri-state UI over a `cherry-panel` Port.
-- `src/cherry-panel-sw.ts` — SW-side `cherry-panel` Port hub: tracks panel
-  ports, caches/persists the tri-state (`chrome.storage.session`), and
-  recovers a dead-tray leader.
-- `packages/webapp/src/kernel/messages.ts` — wire-protocol message types
-  (extension imports from here).
-- `src/tab-group.ts` — persistent Chrome tab group handling.
-- `src/secrets-entry.ts` + `src/secrets-storage.ts` — options-page CRUD over
+- `src/service-worker.ts` - MV3 background bridge + leader-tab lifecycle +
+  secret-aware fetch proxy + handoff notifications.
+- `src/bridge-sw.ts` - `externally_connectable` Port handler that
+  pass-through-proxies CDP to `chrome.debugger`. Synthetic sessions keep
+  `sessionId === targetId` and ref-count duplicate tab attachments;
+  disconnect and target close force-release them.
+- `src/sidepanel-entry.ts` - side-panel host controller (bundled to
+  `dist/extension/sidepanel.js`).
+- `src/cherry-panel-sw.ts` - SW-side `cherry-panel` Port hub: caches/persists
+  tri-state (`chrome.storage.session`), recovers a dead-tray leader.
+- `packages/webapp/src/kernel/messages.ts` - wire-protocol message types.
+- `src/tab-group.ts` - persistent Chrome tab group handling.
+- `src/secrets-entry.ts` + `src/secrets-storage.ts` - options-page CRUD over
   `chrome.storage.local`.
-
-## Extension Bridge Port Control Messages
-
-The leader tab communicates with the service worker over a long-lived
-`chrome.runtime.connect` Port (`name: 'slicc.cdp-bridge'`). Post-handshake
-the Port carries: CDP pass-through (`cdp.request/response/event`), handoff
-licks (`extension.lick`), open-settings commands (`extension.open-settings`),
-and the leader's tray joinUrl (`leader.join-url`). Full protocol details in
-`docs/extension-thin-bridge.md` "Bridge Port Control Messages".
 
 ## CSP Workarounds
 
-The thin extension runs no dynamic code of its own. Dynamic JS (the JavaScript
-tool, `node -e`, `.jsh`, `workflow`), sprinkle/dip rendering, and WASM
-(`convert` / `python3` / `ffmpeg`) all execute in the hosted leader tab — a
-normal `https://www.sliccy.ai` origin under ordinary web CSP — and its kernel
-worker, using the `dist/ui` build. The MV3 sandbox-iframe escapes the fat
-extension relied on and all bundled WASM/JS under `dist/extension/` have been
-removed.
-
-The only extension-origin surfaces left are the service worker, the side-panel
-host, the secrets options page, and the picker/capture popups. For those, load
-bundled assets via `chrome.runtime.getURL(...)`.
+Thin extension runs no dynamic code. Dynamic JS (JavaScript tool, `node -e`,
+`.jsh`, `workflow`), sprinkle/dip rendering, and WASM (`convert` /
+`python3` / `ffmpeg`) execute in the hosted leader tab under ordinary web
+CSP. Extension-origin surfaces (SW, side-panel host, secrets page,
+picker/capture popups) load bundled assets via `chrome.runtime.getURL(...)`;
+no bundled WASM/JS under `dist/extension/`.
 
 ## Device / Directory Picker Popups
 
-The `mount` / `usb` / `serial` / `hid` shell commands call system choosers
-(`showDirectoryPicker` / `navigator.{usb,serial,hid}.request*`), which the
-hosted leader tab cannot host reliably under TCC. All four pickers share a
-single popup entry point — `picker-popup.html` + `picker-popup.js` —
-parameterized by `?kind=directory|usb-device|serial-port|hid-device`. The two
-files are copied into `dist/extension/` by the `closeBundle` hook in
-`vite.config.ts` (not Rollup `input` entries).
-
-Directory results carry an opaque `{ handleInIdb, idbKey, dirName }` (the popup
-stashes the non-postable `FileSystemDirectoryHandle` in the shared
-`slicc-pending-mount` IDB store); device results carry identifiers
-(`vendorId/productId/serialNumber`) the caller re-acquires via
-`navigator.{usb,serial,hid}.getDevices()` in its own realm.
-
-Any change to the `closeBundle` static-asset copy list must keep both
-`picker-popup.html` and `picker-popup.js` listed or all four picker windows 404.
+`mount` / `usb` / `serial` / `hid` shell commands call system choosers
+(`showDirectoryPicker` / `navigator.{usb,serial,hid}.request*`) that the
+hosted leader tab cannot host reliably under TCC. All four share
+`picker-popup.html` + `picker-popup.js` - parameterized by
+`?kind=directory|usb-device|serial-port|hid-device`. Both files are copied
+into `dist/extension/` by the `closeBundle` hook in `vite.config.ts` (not
+Rollup `input` entries); any change must keep both listed or all four
+picker windows 404.
 
 ## Media Capture (popup grant path)
 
-Camera / microphone / screen capture (`ffmpeg -f avfoundation`,
-`screencapture`) work without any new manifest permission:
-
-- **Media capture needs a visible surface**: route the capture through a real
-  window — `capture-popup.html` / `capture-popup.js`. The shell command
-  (`extension-media-capture.ts:captureViaPopup`) asks the service worker to
-  open the popup (`capture-open-window` message → `chrome.windows.create`,
-  no permission needed), the
-  popup performs the capture and posts the bytes back over `chrome.runtime`
-  messaging, and `ffmpeg-command.ts` / `screencapture-command.ts` gate this
-  path behind `isExtensionFloat()`. CLI / standalone and the hosted leader tab
-  keep their page-served auto-grant path unchanged.
+Camera / mic / screen capture (`ffmpeg -f avfoundation`, `screencapture`)
+needs a visible surface: route through `capture-popup.html` /
+`capture-popup.js`. `extension-media-capture.ts:captureViaPopup` asks the
+SW to open the popup (`capture-open-window` -> `chrome.windows.create`);
+popup posts bytes over `chrome.runtime` messaging.
+`ffmpeg-command.ts` / `screencapture-command.ts` gate this behind
+`isExtensionFloat()`.
 
 ## Runtime Conventions
 
 - **Extension detection**: `typeof chrome !== 'undefined' && !!chrome?.runtime?.id`
-- **`window.open()`**: in extension flows it often returns `null`; treat it as
-  fire-and-forget, not a failure signal.
-- **Persistence**: the hosted leader tab is the source of truth for chat/session
-  state. The extension never holds it.
-- **CDP access**: only the service worker can call `chrome.debugger`; the hosted
-  leader tab reaches it via the `externally_connectable` Port in `bridge-sw.ts`.
+- **`window.open()`**: often returns `null`; treat fire-and-forget.
+- **Persistence**: hosted leader tab is source of truth; extension never
+  holds chat/session state.
+- **CDP access**: only the SW can call `chrome.debugger`; leader tab reaches
+  it via the `externally_connectable` Port in `bridge-sw.ts`.
 
-## Mount Secrets Options Page
+## Secrets Options Page + Build Notes
 
-`secrets.html` is the manifest's `options_ui` page. Users reach it via
-right-click the toolbar icon → Options, `chrome://extensions` → SLICC →
-Extension options, or the in-app `secret edit` terminal command (which opens
-the page over `chrome-extension://<id>/secrets.html`). The page reads/writes
-`chrome.storage.local` directly (full chrome.\* API access, not sandboxed) and
-is the extension-mode equivalent of editing `~/.slicc/secrets.env` in CLI mode.
+`secrets.html` is the manifest's `options_ui` page - extension-mode
+equivalent of `~/.slicc/secrets.env`. Pure logic in `src/secrets-storage.ts`
+(tested by `tests/secrets-storage.test.ts`); DOM entry `src/secrets-entry.ts`
+bundles to `dist/extension/secrets.js` via `build-secrets-page` esbuild
+plugin in `vite.config.ts`.
 
-Pure logic lives in `src/secrets-storage.ts` (testable;
-`tests/secrets-storage.test.ts` covers it). The DOM entrypoint
-`src/secrets-entry.ts` is bundled to `dist/extension/secrets.js` via the
-`build-secrets-page` esbuild plugin in `vite.config.ts`.
-
-## Telemetry
-
-The thin extension does not emit Helix RUM beacons. The service worker is not
-instrumented; the hosted leader tab uses the standalone webapp's telemetry path
-(`@adobe/helix-rum-js` via `telemetry.ts:initTelemetry()`).
-
-## Build Notes
-
-- `packages/chrome-extension/vite.config.ts` builds the service worker,
-  side-panel host, secrets options page, preview service worker, and copied
-  static assets (picker/capture popups, toolbar icons/fonts) into
-  `dist/extension/`. Rollup's `input` is a single virtual no-op entry — all
-  bundled outputs are produced by `closeBundle` esbuild plugins.
-- The extension's side-panel host + secrets page consume shared webapp code
-  from `packages/webapp/` rather than duplicating core runtime logic.
-- `manifest.json` ships a stable `key` (so the production ID is fixed). For
-  local debugging that key triggers `Content verify job failed for extension …`
-  and the extension refuses to load. Build with
-  `SLICC_EXT_DEV=1 npm run build -w @slicc/chrome-extension` to strip `key`
-  so Chrome assigns a path-derived ID instead.
+- `packages/chrome-extension/vite.config.ts` builds SW, side-panel host,
+  secrets page, preview SW, and copied static assets into `dist/extension/`.
+  Rollup `input` is a single virtual no-op entry; outputs come from
+  `closeBundle` esbuild plugins.
+- `manifest.json` ships a stable `key` (production ID fixed). Local
+  debugging triggers `Content verify job failed for extension ...`; build
+  with `SLICC_EXT_DEV=1 npm run build -w @slicc/chrome-extension` to strip
+  `key`.
+- No Helix RUM beacons; hosted leader tab uses standalone webapp telemetry
+  (`@adobe/helix-rum-js` via `telemetry.ts:initTelemetry()`).
 
 ## MV3 Remote Hosted Code Guard
 
-Chrome Web Store rejects MV3 submissions when its reviewer string-matches a
-full third-party CDN URL in the built bundle (violation reference Blue Argon).
-Even a literal that the runtime overrides is enough to fail review.
-
+Chrome Web Store rejects MV3 submissions when its reviewer string-matches
+a full third-party CDN URL (violation ref Blue Argon); even a literal the
+runtime overrides fails review.
 `packages/dev-tools/tools/check-extension-rhc.sh` scans `dist/extension/`
-(recursively, across `.js`/`.html`/`.json`/`.css`, excluding `.map` files) and
-exits non-zero if any of these patterns appear:
-
-- `https://unpkg.com/<path>` (scoped or non-scoped)
-- `https://esm.sh/<path>`
-- `https://cdn.jsdelivr.net/npm/<path>`
-
-Bare hostnames and the host-only form (no path) are allowed.
-
-**Debugging a failure:** the script prints `file:line:URL` for every match.
-Open the cited file, find the call site that constructed the URL, and migrate
-it to `packages/webapp/src/shell/supplemental-commands/cdn-url-builder.ts` so
-only the bare host appears as a string literal and the path is composed at
-runtime via `new URL(path, ...)`.
-
-The check runs via `npm run postbuild:check -w @slicc/chrome-extension` and in
-the `chrome-extension` CI job.
-
-## Local QA and Dev Watch
-
-For the full manual recipe (Chrome for Testing, extension profile, QA
-scenarios) and the dev-watch loop details, see
-`docs/extension-thin-bridge.md`.
-
-Quick start:
-
-```bash
-# Build and serve (automated — builds webapp if missing, starts wrangler)
-npm run dev:extension:fresh
-
-# Or manual build + launch for a fixed extension ID across runs:
-SLICC_EXT_DEV=1 npm run build -w @slicc/chrome-extension
-# Then follow the Chrome for Testing recipe in docs/extension-thin-bridge.md
-```
+and exits non-zero if `https://unpkg.com/<path>`, `https://esm.sh/<path>`,
+or `https://cdn.jsdelivr.net/npm/<path>` appears; bare hostnames allowed.
+Runs via `npm run postbuild:check -w @slicc/chrome-extension` and the
+`chrome-extension` CI job. Debug + `cdn-url-builder.ts` migration:
+`docs/chrome-extension-details.md`.
 
 ## Secret-Aware Fetch Proxy
 
-The service worker handles `fetch-proxy.fetch` Port connections for
-secret-aware HTTP proxying. Key invariant: the `onMessage` listener attaches
-**synchronously** in `onConnect` (the pipeline is awaited inside the listener).
-The previous "await build → then add listener" pattern silently dropped
-immediate `request` messages. Full handler reference and OAuth-domain extras
-in `docs/extension-thin-bridge.md` "Secret-Aware Fetch Proxy".
+SW handles `fetch-proxy.fetch` Port connections. Key invariant: the
+`onMessage` listener attaches **synchronously** in `onConnect` (pipeline
+awaited inside); the previous "await build -> add listener" pattern
+dropped immediate `request` messages. Handler:
+`docs/extension-thin-bridge.md`.
 
-## Automated CDP Smoke Test
+## Local QA, Dev Watch, Smoke Test
 
-`packages/dev-tools/tools/extension-smoke-test.ts` is the end-to-end
-verification script. Run after a fresh extension build:
+Recipe (Chrome for Testing, extension profile, QA scenarios, dev-watch
+loop, smoke-test knobs): `docs/extension-thin-bridge.md`. End-to-end smoke
+`packages/dev-tools/tools/extension-smoke-test.ts` runs with
+`continue-on-error: true` in CI while the thin-bridge replacement lands.
 
 ```bash
+# Build and serve (automated - builds webapp if missing, starts wrangler)
+npm run dev:extension:fresh
+
+# Manual build + launch for a fixed extension ID across runs:
+SLICC_EXT_DEV=1 npm run build -w @slicc/chrome-extension
+
+# Smoke test after a fresh extension build
 npm run build -w @slicc/chrome-extension
 npm run test:extension-smoke -w @slicc/chrome-extension
 ```
-
-The script was written against the legacy fat-extension architecture and runs
-with `continue-on-error: true` in CI while the thin-bridge replacement lands.
-See `docs/extension-thin-bridge.md` "Automated CDP Smoke Test" for full
-details and local debugging knobs.
-
-## Related Guides
-
-- `packages/webapp/CLAUDE.md` — shared browser architecture
-- `packages/shared-ts/CLAUDE.md` — secret masking primitives
-- `docs/architecture.md` — extension message flow, persistence model, cross-
-  origin model (authoritative overview)
-- `docs/extension-thin-bridge.md` — bridge protocol, toast dedup, leader-tab
-  lifecycle rationale, side-panel flow, dev-watch loop, QA recipe
-- `docs/pitfalls.md` — extension-specific gotchas
-- `docs/transcript-export.md` — transcript export (runs in the hosted leader tab;
-  the extension bridge is transparent)

--- a/packages/cloud-core/CLAUDE.md
+++ b/packages/cloud-core/CLAUDE.md
@@ -47,43 +47,42 @@ npm run typecheck                    # included in root pipeline
 
 ## Key Files
 
-| Path                       | Purpose                                                                                                                                                                                                                                                                                                                                                |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `src/index.ts`             | Public re-exports — the only surface consumers should import from                                                                                                                                                                                                                                                                                      |
-| `src/types.ts`             | `ConeEntry` (registry row), `CloudStatus` (`/tmp/slicc-join.json` shape), `StartResult`, `ResumeResult`, `SandboxSummary`                                                                                                                                                                                                                              |
-| `src/errors.ts`            | `CloudError` + `CloudErrorCode` union. Workers translate codes to HTTP statuses; CLI prints them. Stable contract — adding codes is fine, renaming/removing is breaking                                                                                                                                                                                |
-| `src/substrate.ts`         | `SandboxSubstrate` interface (`create`, `connect`, `list`, `extendTimeout`), `SandboxHandle` (`pause`, `kill`, `getInfo`, `writeFile`, `readFile`, `run`), and supporting types                                                                                                                                                                        |
-| `src/substrate-factory.ts` | `createSubstrate(id, cfg)` — the only place that maps a `SubstrateId` to a concrete impl. `SubstrateId = 'e2b'` today; widen the union when a real second substrate lands                                                                                                                                                                              |
-| `src/substrates/e2b.ts`    | The e2b implementation. Pins `requestTimeoutMs` to 120s so CF Workers don't abort cold-start restores under their 30s subrequest timeout. `list` filters team sandboxes by template alias via the exported `isSliccTemplate` predicate — a `slicc` **prefix** match, so isolated test-template cones (`slicc-test`) list too instead of showing `dead` |
-| `src/registry.ts`          | `Registry` interface. Two implementations live with their consumers: `FileRegistry` (node-server, `~/.slicc/cloud-sessions.json`) and `LocalRegistry` (worker, DurableObject storage)                                                                                                                                                                  |
-| `src/polling.ts`           | `pollCloudStatus` (start path — uses `minUpdatedAt` to ignore the stale template-baked file) and `pollForRefreshedStatus` (resume path — requires strictly newer `updatedAt`)                                                                                                                                                                          |
-| `src/secrets-filter.ts`    | `filterSecretsEnv` — strips `E2B_API_KEY` / `E2B_API_KEY_DOMAINS` before upload. The cone never sees the user's substrate credential                                                                                                                                                                                                                   |
-| `src/operations/start.ts`  | `startCone` + `reserveSlot` (worker uses reserve-then-start under `blockConcurrencyWhile`)                                                                                                                                                                                                                                                             |
-| `src/operations/list.ts`   | `listCones` — reconciles registry against substrate.list, GCs stale `reserved` entries (10-minute TTL)                                                                                                                                                                                                                                                 |
-| `src/operations/pause.ts`  | `pauseCone` — preserves `trayId` + `lastJoinUpdatedAt` (resume needs them as a freshness baseline)                                                                                                                                                                                                                                                     |
-| `src/operations/resume.ts` | `resumeCone` — reconnects, posts `/api/leader-restart`, polls until `updatedAt > baseline`                                                                                                                                                                                                                                                             |
-| `src/operations/kill.ts`   | `killCone` — idempotent removal                                                                                                                                                                                                                                                                                                                        |
+| Path                       | Purpose                                                                                                                                                            |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/index.ts`             | Public re-exports — the only surface consumers should import from                                                                                                  |
+| `src/types.ts`             | `ConeEntry`, `CloudStatus` (`/tmp/slicc-join.json` shape), `StartResult`, `ResumeResult`, `SandboxSummary`                                                         |
+| `src/errors.ts`            | `CloudError` + `CloudErrorCode` union. Workers map codes to HTTP; CLI prints them. Stable contract — renaming/removing breaks                                      |
+| `src/substrate.ts`         | `SandboxSubstrate` (`create`, `connect`, `list`, `extendTimeout`) + `SandboxHandle` (`pause`, `kill`, `getInfo`, `writeFile`, `readFile`, `run`)                   |
+| `src/substrate-factory.ts` | `createSubstrate(id, cfg)` — sole `SubstrateId` → impl dispatch. `SubstrateId = 'e2b'` today; widen when a real second lands                                       |
+| `src/substrates/e2b.ts`    | The e2b implementation — see [details](../../docs/cloud-core-details.md#e2b-substrate) for the 120s `requestTimeoutMs` pin and the `isSliccTemplate` prefix filter |
+| `src/registry.ts`          | `Registry` interface. `FileRegistry` lives in node-server (`~/.slicc/cloud-sessions.json`); `LocalRegistry` in the worker (DO storage)                             |
+| `src/polling.ts`           | `pollCloudStatus` (start — `minUpdatedAt` ignores the template-baked file) and `pollForRefreshedStatus` (resume — strictly newer `updatedAt`)                      |
+| `src/secrets-filter.ts`    | `filterSecretsEnv` — strips `E2B_API_KEY` / `E2B_API_KEY_DOMAINS` before upload. The cone never sees the user's substrate credential                               |
+| `src/operations/start.ts`  | `startCone` + `reserveSlot` (worker uses reserve-then-start under `blockConcurrencyWhile`)                                                                         |
+| `src/operations/list.ts`   | `listCones` — reconciles registry against `substrate.list`, GCs stale `reserved` entries (10-minute TTL)                                                           |
+| `src/operations/pause.ts`  | `pauseCone` — **preserves** `trayId` + `lastJoinUpdatedAt` (resume freshness baseline)                                                                             |
+| `src/operations/resume.ts` | `resumeCone` — reconnects, posts `/api/leader-restart`, polls until `updatedAt > baseline`                                                                         |
+| `src/operations/kill.ts`   | `killCone` — idempotent removal                                                                                                                                    |
 
 ## Stable Contracts
 
-The fields and behaviors below are load-bearing for both consumers; changes need migration thought.
+The fields and behaviors below are load-bearing for both consumers; changes need migration thought. Deep rationale in [`docs/cloud-core-details.md`](../../docs/cloud-core-details.md#stable-contracts).
 
 ### `ConeEntry.state`
 
-`'running' | 'paused' | 'dead' | 'reserved'`.  
-`'reserved'` is the in-flight placeholder used during start/resume to hold a cap slot before the substrate reports real state. `listCones` GCs `reserved` entries older than 10 minutes (`reservedAt` field).
+`'running' | 'paused' | 'dead' | 'reserved'`. `'reserved'` is the in-flight placeholder that holds a cap slot during start/resume before the substrate reports real state. `listCones` GCs `reserved` entries older than 10 minutes (`reservedAt`).
 
 ### `ConeEntry.trayId` and `lastJoinUpdatedAt`
 
-Set by `startCone` after the initial `/tmp/slicc-join.json` read. `pauseCone` **must preserve** them — `resumeCone` polls for `updatedAt` strictly newer than `lastJoinUpdatedAt`, so resume only declares success after the leader-restart kick produced a fresh refresh. Overwriting these on pause would make every resume succeed instantly against the old join URL.
+Set by `startCone` after the initial `/tmp/slicc-join.json` read. `pauseCone` **must preserve** them — `resumeCone` polls for `updatedAt` strictly newer than `lastJoinUpdatedAt`. Overwriting these on pause would make every resume succeed instantly against the old join URL.
 
 ### `/tmp/slicc-join.json`
 
-The shape persisted inside the sandbox by `node-server --hosted`'s `/api/cloud-status` POST. Defined as `CloudStatus` in `src/types.ts`. Used as the IPC channel between the hosted node-server and the orchestrating cloud-core. Changes here are coordinated with `packages/node-server/src/cloud-status.ts`.
+Shape persisted inside the sandbox by `node-server --hosted`'s `/api/cloud-status` POST. Defined as `CloudStatus` in `src/types.ts`. IPC channel between the hosted node-server and cloud-core; changes here are coordinated with `packages/node-server/src/cloud-status.ts`. Boot sequence: see [details](../../docs/cloud-core-details.md#hosted-leader-boot).
 
 ### Registry persistence schema
 
-`Registry` implementations persist `{ sessions: ConeEntry[] }` (the legacy field name `sessions` is kept for CLI files already on disk — do not rename to `cones`). `append` is upsert-by-`sandboxId`, not insert-or-throw; reconciliation passes depend on this.
+`Registry` implementations persist `{ sessions: ConeEntry[] }` (legacy field name kept for CLI files already on disk — do not rename to `cones`). `append` is upsert-by-`sandboxId`, not insert-or-throw; reconciliation depends on this.
 
 ## Substrate Authoring
 
@@ -107,3 +106,4 @@ To add a new substrate (e.g., Modal, Fly, Daytona):
 - `packages/node-server/CLAUDE.md` — CLI `--cloud` subcommands (the adapter layer)
 - `packages/cloudflare-worker/CLAUDE.md` — `sliccy.ai/cloud` web feature (the other adapter layer)
 - `packages/dev-tools/e2b-template/` — the sandbox image cloud-core orchestrates
+- [`docs/cloud-core-details.md`](../../docs/cloud-core-details.md) — deep reference for e2b gotchas, stable-contract rationale, secret paths, and the hosted-leader boot sequence

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -1,148 +1,105 @@
 # CLAUDE.md
 
-This file covers the tray hub worker in `packages/cloudflare-worker/`.
+Tray hub worker in `packages/cloudflare-worker/`: tray session coordination,
+capability-token routing, TURN credential lookup, and leader/follower signaling for
+tray-connected SLICC runtimes; also serves the built webapp as static assets.
 
-## Scope
-
-The worker provides tray session coordination, capability-token routing, TURN credential
-lookup, and leader/follower signaling for tray-connected SLICC runtimes. It also serves
-the built SLICC webapp as static assets to browser visitors.
+Deep reference: [`docs/cloudflare-worker-details.md`](../../docs/cloudflare-worker-details.md).
 
 ## Main Files
 
-| Path                                                                                   | Purpose                                                                                                             |
-| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `src/index.ts`                                                                         | Worker entry point and public HTTP routing                                                                          |
-| `src/session-tray.ts`                                                                  | `SessionTrayDurableObject` — manages controller WS (leader), follower WebRTC signaling, and preview bridge WS       |
-| `src/turn-credentials.ts`                                                              | Cloudflare TURN credential fetcher                                                                                  |
-| `src/shared.ts`                                                                        | Capability token helpers; `reclaimMsForTray`; `TRAY_RECLAIM_TTL_MS`/`HOSTED_TRAY_RECLAIM_TTL_MS`; DO-internal types |
-| `src/links.ts`                                                                         | `applySliccLinks` — RFC 8288 `Link` rel set on every response                                                       |
-| `src/handoff-page.ts`                                                                  | `/handoff` route — converts `?upskill=`/`?handoff=`/`?msg=` into `Link` response header                             |
-| `src/api-catalog.ts`                                                                   | `/.well-known/api-catalog` (RFC 9264 linkset) builder                                                               |
-| `src/install-cli.ts`                                                                   | `/install-cli` POSIX installer script + `/download/slicc-cli/:target` release-asset resolver                        |
-| `src/llms-txt.ts`, `src/privacy.ts`                                                    | `/llms.txt` builder; `/privacy` canonical-policy redirect                                                           |
-| `src/rel-docs.ts`                                                                      | `/rel/:name` — dereferenceable docs for SLICC custom rels                                                           |
-| `src/flags.ts`                                                                         | `/api/flags` string-map resolution, CORS, and per-float edge caching                                                |
-| `src/oauth-exchange.ts`, `src/oauth-registry.ts`                                       | OAuth callback relay (`/auth/callback`)                                                                             |
-| `src/auth/cloud-callback.ts`                                                           | `/auth/cloud-callback` IMS popup callback for the cloud dashboard                                                   |
-| `src/cloud/cloud-sessions-do.ts`                                                       | `CloudSessionsDurableObject` — per-user state for `/api/cloud/*`                                                    |
-| `src/cloud/handlers.ts`, `handler-signout.ts`, `handler-admin.ts`, `handler-config.ts` | HTTP handlers for `/api/cloud/*`                                                                                    |
-| `src/cloud/auth.ts`, `auth-cache.ts`, `auth-middleware.ts`                             | IMS bearer auth: extraction, verification, caching, and middleware                                                  |
-| `src/cloud/caps.ts`                                                                    | `checkCapsForRun` — per-user cone cap enforcement (`CONE_CAP_RUNNING`, `CONE_CAP_PAUSED`)                           |
-| `src/cloud/local-registry.ts`                                                          | `Registry` backed by DO storage — worker counterpart of node-server's `FileRegistry`                                |
-| `src/cloud/error-envelope.ts`                                                          | `errorResponse`/`okResponse` JSON helpers for `/api/cloud/*` replies                                                |
-| `src/cloud/proxy-config.ts`                                                            | Adobe LLM proxy `/v1/config` sync — keeps dashboard popup in sync                                                   |
-| `src/cloud/rate-limit.ts`                                                              | Per-user rate limiting on cloud endpoints                                                                           |
-| `wrangler.jsonc`                                                                       | Wrangler config, DO bindings (`TRAY_HUB`, `CLOUD_SESSIONS`), staging env, asset binding                             |
+- `src/index.ts` — entry + public HTTP routing
+- `src/session-tray.ts` — `SessionTrayDurableObject`: controller WS (leader), follower
+  WebRTC signaling, preview bridge WS
+- `src/turn-credentials.ts` — Cloudflare TURN credential fetcher
+- `src/shared.ts` — capability tokens; `reclaimMsForTray`;
+  `TRAY_RECLAIM_TTL_MS`/`HOSTED_TRAY_RECLAIM_TTL_MS`
+- `src/links.ts` — `applySliccLinks` (RFC 8288 `Link` rel set on every response)
+- `src/handoff-page.ts`, `src/api-catalog.ts`, `src/install-cli.ts`, `src/llms-txt.ts`,
+  `src/privacy.ts`, `src/rel-docs.ts`, `src/flags.ts` — public route handlers
+- `src/oauth-exchange.ts`, `src/oauth-registry.ts`, `src/auth/cloud-callback.ts` —
+  OAuth relays (`/auth/callback`, `/auth/cloud-callback`)
+- `src/cloud/*` — `/api/cloud/*` handlers, `CloudSessionsDurableObject`, IMS auth,
+  `checkCapsForRun` cone caps, DO-backed `Registry`, Adobe proxy `/v1/config` sync,
+  `rate-limit.ts`, `error-envelope.ts`
+- `wrangler.jsonc` — bindings (`TRAY_HUB`, `CLOUD_SESSIONS`, `ASSETS`, `ASSET_ARCHIVE`,
+  `CF_VERSION_METADATA`), staging env, feature flags
 
-Sandbox lifecycle logic lives in `@slicc/cloud-core`; worker `src/cloud/` is adapter glue.
+Sandbox lifecycle lives in `@slicc/cloud-core`; `src/cloud/` is adapter glue.
 
 ## Tray Hub Architecture
 
-### Durable Objects
-
-- `TRAY_HUB` maps each tray to one `SessionTrayDurableObject`, tracking capabilities,
-  leader/follower state, reconnect windows, and cached ICE servers.
+`TRAY_HUB` maps each tray to one `SessionTrayDurableObject`, tracking capabilities,
+leader/follower state, reconnect windows, and cached ICE servers.
 
 ### Public Routes
 
-| Route                                 | Description                                                                                                                                |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `POST /tray`                          | Create a tray; return join/controller/webhook capability URLs                                                                              |
-| `GET /handoff`                        | Convert `?upskill=`, `?handoff=`, or `?msg=` into RFC 8288 `Link` header                                                                   |
-| `GET /install-cli`                    | POSIX installer script for the Go `slicc` follower CLI (`curl -fsSL …/install-cli \| sh`); covers macOS/Linux/WSL/Git Bash                 |
-| `GET /install-cli.ps1`                | Native-Windows PowerShell installer (`irm …/install-cli.ps1 \| iex`) — installs to `%LOCALAPPDATA%\Programs\slicc`, persists the user PATH |
-| `GET /download/slicc-cli/:target`     | 302 to the newest release asset for a CLI target (`darwin-arm64`, …); scans past binary-less releases; real HTTP errors, no SPA fallback   |
-| `GET /.well-known/api-catalog`        | RFC 9264 linkset for all public routes                                                                                                     |
-| `GET /llms.txt`                       | LLM markdown digest                                                                                                                        |
-| `GET\|HEAD /privacy`                  | 301 to www.sliccy.com/privacy (App Store Connect link)                                                                                     |
-| `GET\|HEAD /status`                   | Public health document (`{ status, service, timestamp, version }`); no auth, `Cache-Control: no-store`                                     |
-| `GET /rel/:name`                      | Dereferenceable docs for SLICC custom rel URIs                                                                                             |
-| `GET\|POST /join/:token`              | Follower join and bootstrap polling (HTTP poll/answer/ice-candidate/retry actions)                                                         |
-| `GET\|POST /controller/:token`        | Leader attach and WS upgrade                                                                                                               |
-| `POST /webhook/:token/:webhookId`     | Forward webhook events into the live leader                                                                                                |
-| `POST /api/tray/:trayId/preview`      | Mint a preview token; body `{ path, bridge?, maxTabs?, quiet?, webhookId? }`; response `{ previewToken, url }`                             |
-| `POST /api/tray/:trayId/preview/stop` | Revoke a preview token; body `{ previewToken }`                                                                                            |
-| `GET /api/tray/:trayId/previews`      | List active previews for a tray                                                                                                            |
-| `GET <token>.sliccy.now/*`            | Preview HTTP pipe — streams file from leader via DO; 30s timeout; bridge mode injects the preview-bridge script                            |
-| `GET __slicc/preview-bridge.js`       | Bundled preview bootstrap (bridge-enabled previews only; build-generated, not committed)                                                   |
-| `WS __slicc/bridge`                   | Preview bridge WS (`slicc.preview-bridge.v1.<connId>`); relays CDP + attributed `emit`; hibernated via `setWebSocketAutoResponse`          |
-| `POST __slicc/emit`                   | Fallback beacon relay for `window.slicc.emit` on page unload                                                                               |
-| `GET /auth/callback`                  | OAuth callback relay; capture hop for the cloud dashboard (no `state` → `postMessage` to opener)                                           |
-| `GET /auth/mcp-callback`              | MCP OAuth capture hop; preserves opaque `state` and posts the untouched callback URL to the same-origin opener                             |
-| `GET /api/flags`                      | Resolve `{ float, flags }` string values for `?float=<float>`; unknown/invalid profiles fall back to `base`                                |
+Route inventory: `POST /tray`, `GET /handoff`, `GET /install-cli`,
+`GET /install-cli.ps1`, `GET /download/slicc-cli/:target`,
+`GET /.well-known/api-catalog`, `GET /llms.txt`, `GET|HEAD /privacy`,
+`GET|HEAD /status`, `GET /rel/:name`, `GET|POST /join/:token`,
+`GET|POST /controller/:token`, `POST /webhook/:token/:webhookId`,
+`POST /api/tray/:trayId/preview`, `POST /api/tray/:trayId/preview/stop`,
+`GET /api/tray/:trayId/previews`, `GET <token>.sliccy.now/*`,
+`GET __slicc/preview-bridge.js`, `WS __slicc/bridge`, `POST __slicc/emit`,
+`GET /auth/callback`, `GET /auth/mcp-callback`, `GET /api/flags`. Per-route semantics:
+[docs/cloudflare-worker-details.md § Public Routes](../../docs/cloudflare-worker-details.md#public-routes).
 
-**Routes-mirror rule:** every new route must appear in three places:
+**Routes-mirror rule:** every new route MUST appear in
 
 1. `src/index.ts` routes array (the default `GET /` body)
 2. `tests/index.test.ts` routes-list assertion
 3. `tests/deployed.test.ts` routes-list assertion
 
-Missing any of these causes CI failures.
+Missing any of these fails CI.
 
 ### Feature Flag Configuration
 
-`FEATURE_FLAGS` in `wrangler.jsonc` is a JSON var shaped as
-`{ base: Record<string, string>, floats: Record<string, Record<string, string>> }`.
-Float maps overlay `base`; invalid profiles return `{ float: "default", flags: base }`.
-Keep production and `env.staging` aligned. Values cache for five minutes; config needs deploy.
-Keep `/api/flags` in the routes array and both routes-list assertions per the rule above.
+`FEATURE_FLAGS` in `wrangler.jsonc` is a JSON var
+`{ base: Record<string,string>, floats: Record<string, Record<string,string>> }`.
+Floats overlay `base`; invalid profiles → `{ float: "default", flags: base }`. Keep
+production and `env.staging` aligned. 5-min cache; config changes need deploy. Keep
+`/api/flags` in the routes array + both routes-list assertions.
 
 ### Signaling Model
 
-- A leader attaches through the controller capability and opens a WebSocket to the DO.
-- **Last-key-holder-wins reconnect** — a leader reconnect with matching credentials
-  closes the stale socket and accepts the new one rather than rejecting. Workerd doesn't
-  reliably deliver `webSocketClose` on dropped/half-open connections; rejecting the
-  rightful reconnect would deadlock it. See the
-  [`deploying-tray-worker` skill](../../.agents/skills/deploying-tray-worker/SKILL.md)
-  for the full ghost-leader analysis.
-- Followers attach through the join capability; bootstrap over HTTP poll.
-- Preview bridge tabs (`serve --bridge`) attach via `/__slicc/bridge` WS. DO relays
-  `bridge.cdp.request`/`bridge.cdp.response` between the leader and each bridge socket,
-  keyed by `connId`. On leader (re)connect the DO replays `bridge.connected` for every
-  live bridge socket.
+Leader attaches via controller capability + WS to the DO. **Last-key-holder-wins
+reconnect** — a leader reconnect with matching credentials closes the stale socket;
+rejecting deadlocks on workerd's unreliable `webSocketClose`. Followers attach via the
+join capability and bootstrap over HTTP poll. Preview bridge tabs (`serve --bridge`)
+attach via `/__slicc/bridge` WS; DO relays `bridge.cdp.request`/`bridge.cdp.response`
+keyed by `connId`, replays `bridge.connected` on leader (re)connect, hibernates via
+`setWebSocketAutoResponse`. Ghost-leader analysis + full protocol:
+[docs/cloudflare-worker-details.md § Signaling](../../docs/cloudflare-worker-details.md#signaling),
+[deploying-tray-worker skill](../../.agents/skills/deploying-tray-worker/SKILL.md).
 
 ### TURN Credentials
 
-TURN credentials are fetched with `CLOUDFLARE_TURN_KEY_ID` and
-`CLOUDFLARE_TURN_API_TOKEN`. `session-tray.ts` caches ICE servers and refreshes them
-before TTL expiry. The key ID is in `wrangler.jsonc`; the API token is a Wrangler
-secret.
+Fetched with `CLOUDFLARE_TURN_KEY_ID` (in `wrangler.jsonc`) and
+`CLOUDFLARE_TURN_API_TOKEN` (Wrangler secret). `session-tray.ts` caches ICE servers
+and refreshes before TTL expiry.
 
 ### Tray Kind (desktop / hosted)
 
-`TrayRecord.kind` is `'desktop' | 'hosted'`, defaulting to `'desktop'` when absent.
-`POST /tray` reads an optional `kind` from the request body. The reclaim TTL is
-`HOSTED_TRAY_RECLAIM_TTL_MS = 30 days` for hosted trays, `TRAY_RECLAIM_TTL_MS = 1 hour`
-for desktop trays — branched through `reclaimMsForTray(tray)` in `shared.ts`.
+`TrayRecord.kind` is `'desktop' | 'hosted'` (default `'desktop'`). `POST /tray` reads
+optional `kind`. Reclaim TTL branches through `reclaimMsForTray(tray)` in `shared.ts`:
+`HOSTED_TRAY_RECLAIM_TTL_MS = 30 days` (hosted), `TRAY_RECLAIM_TTL_MS = 1 hour`
+(desktop).
 
-### Static Asset Serving
+### Static Assets & R2
 
-- Worker serves `dist/ui/` via Cloudflare Workers Static Assets (`ASSETS` binding).
-- `wantsJSON()` in `shared.ts` checks `?json=true` for content negotiation.
-- GET/HEAD to `/join/:token` and `/controller/:token` without `?json=true` → SPA.
-- Unmatched paths without `?json=true` → SPA fallback.
-- `?json=true`, POST, and WebSocket upgrades → API/JSON.
-- **Cherry embed (`?cherry=1`):** `frame-ancestors` is set from the
-  `ALLOWED_CHERRY_HOST_ORIGINS` env var. A bare `*` also adds any explicit
-  `chrome-extension://` origins (CSP `*` does not authorize extension ancestors).
-  Every non-cherry response gets `frame-ancestors 'none'`. Cherry responses set
-  `Cache-Control: no-store` and `Vary: Sec-Fetch-Dest` to prevent cache mixing.
-- **25 MiB per-asset cap:** Cloudflare rejects any `dist/ui/` file over 25 MiB; the
-  CI `cloudflare-worker` job runs `npm run build -w @slicc/cloudflare-worker`
-  (`wrangler deploy --dry-run`) as a hard gate.
-
-### R2 Asset Archive
-
-`ASSET_ARCHIVE` retains hashed `/assets/*` across deploys. `serveAssetWithArchiveFallback`
-tries `ASSETS`, then R2, then stale-asset reload; bucket GC is 14 days. The
-[`deploying-tray-worker` skill](../../.agents/skills/deploying-tray-worker/SKILL.md) is the
-ops runbook for bucket setup, permissions, uploads, and the 2026-07-13 incident.
+Worker serves `dist/ui/` via Static Assets (`ASSETS`); `?json=true`/POST/WS → API,
+else SPA. **Cherry embed (`?cherry=1`):** `frame-ancestors` from
+`ALLOWED_CHERRY_HOST_ORIGINS` (bare `*` also enumerates `chrome-extension://` origins);
+non-cherry → `frame-ancestors 'none'`; cherry sets `Cache-Control: no-store` +
+`Vary: Sec-Fetch-Dest`. **25 MiB per-asset cap** — CI runs `wrangler deploy --dry-run`
+as a hard gate. `ASSET_ARCHIVE` (R2) retains hashed `/assets/*` across deploys;
+`serveAssetWithArchiveFallback` tries `ASSETS` → R2 → stale-asset reload; bucket GC
+14 days. Full rules:
+[docs/cloudflare-worker-details.md § Static Assets](../../docs/cloudflare-worker-details.md#static-assets);
+ops: [deploying-tray-worker skill](../../.agents/skills/deploying-tray-worker/SKILL.md).
 
 ## Commands
-
-### Worker and deploy
 
 ```bash
 # Build webapp first (required for static assets)
@@ -154,92 +111,51 @@ npx wrangler deploy --config packages/cloudflare-worker/wrangler.jsonc
 cd packages/cloudflare-worker && WORKER_BASE_URL=https://... npm test -- tests/deployed.test.ts
 ```
 
-### Extension testing with the worker
-
-```bash
-npm run start:extension
-```
+Extension testing with the worker: `npm run start:extension`.
 
 ## CI and Deployment
 
-`release-native.mjs --gate=worker` gates production. Hub and preview configs deploy as a pair
-(shared DO/token format); R2 uploads always precede deploy. Routes-only failures are non-fatal.
-Required: `CLOUDFLARE_API_TOKEN` (Workers Edit, R2 R/W, Zone Routes Edit) and account ID.
-
-See the
-[`deploying-tray-worker` skill](../../.agents/skills/deploying-tray-worker/SKILL.md)
-for retry logic, routes-only failure classification, the staging deployment guide, and
-the local `serve --bridge` test setup.
+`release-native.mjs --gate=worker` gates production. Hub + preview configs deploy as a
+pair (shared DO/token format); R2 uploads always precede deploy. Routes-only failures
+are non-fatal. Required: `CLOUDFLARE_API_TOKEN` (Workers Edit, R2 R/W, Zone Routes
+Edit) + account ID. Retry logic, staging deploy, local `serve --bridge`:
+[deploying-tray-worker skill](../../.agents/skills/deploying-tray-worker/SKILL.md).
 
 ## Operational Notes
 
-- Treat the worker as coordination infrastructure, not canonical session storage.
-- `GET /status` is the post-deploy liveness probe. Its `version` field comes from the
-  `version_metadata` binding (`CF_VERSION_METADATA` in `wrangler.jsonc`, declared for both
-  the default and `staging` envs). `wrangler dev` binds it to a per-session local UUID; in
-  tests the binding is unbound and the field reads `unknown`. It is unauthenticated — keep
-  the body to
-  `{ status, service, timestamp, version }` and never add config or binding names.
-  Deploy-impact signals for the worker are catalogued in
-  [`docs/operational-telemetry.md`](../../docs/operational-telemetry.md).
-- The `/handoff` page is stateless; query parameters are translated into a single RFC
-  8288 `Link` response header.
-- Every worker response is wrapped by `applySliccLinks` (see `src/links.ts`) — standard
-  rel set ships on every reply.
-- Keep signaling protocol changes aligned with the browser tray runtime in
-  `packages/webapp/src/scoops/`.
+- Worker is coordination infrastructure, not canonical session storage.
+- `GET /status`: post-deploy liveness probe; `version` from `CF_VERSION_METADATA`
+  binding (declared for default + `staging`; `unknown` when unbound). Unauthenticated
+  — body is exactly `{ status, service, timestamp, version }`, never config/binding
+  names. Signals: [`docs/operational-telemetry.md`](../../docs/operational-telemetry.md).
+- `/handoff` is stateless; query params → single RFC 8288 `Link` header.
+- Every response is wrapped by `applySliccLinks` (`src/links.ts`).
+- Keep signaling protocol changes aligned with `packages/webapp/src/scoops/`.
 
 ## Cloud Cones (sliccy.ai/cloud)
 
-Web feature shipped via Plan D. All `/api/cloud/*` require
+Shipped via Plan D. All `/api/cloud/*` require
 `Authorization: Bearer <ims-access-token>` and route to
-`env.CLOUD_SESSIONS.idFromName(userId)` for per-user state.
-
-### Routes
-
-| Route                         | Description                                                                 |
-| ----------------------------- | --------------------------------------------------------------------------- |
-| `GET /cloud`                  | Dashboard SPA (CSP-enforced)                                                |
-| `GET /auth/cloud-callback`    | IMS popup callback (HTML)                                                   |
-| `GET /auth/cloud-callback.js` | IMS popup callback (JS, served inline by worker)                            |
-| `POST /api/cloud/start`       | Start a new cone (auth + cap-checked); optional `coneConfig` bundle         |
-| `GET /api/cloud/list`         | Per-user cone list (reconciled with e2b per call)                           |
-| `GET /api/cloud/cone-config`  | `?sandboxId=<id>`: names-only config index (model + account + secret names) |
-| `POST /api/cloud/pause`       | Pause a cone                                                                |
-| `POST /api/cloud/resume`      | Resume a paused cone; optional `coneConfigDelta`                            |
-| `POST /api/cloud/kill`        | Kill a cone (idempotent)                                                    |
-| `POST /api/cloud/sign-out`    | Invalidate auth cache for the bearer                                        |
-| `GET /api/cloud/admin/stats`  | Admin-gated by `ADMIN_USER_IDS`                                             |
+`env.CLOUD_SESSIONS.idFromName(userId)` for per-user state. Route table:
+[docs/cloudflare-worker-details.md § Cloud Routes](../../docs/cloudflare-worker-details.md#cloud-routes).
 
 ### Cone Configuration
 
-A `ConeConfig` bundle (`{ model, accounts[], secrets[] }`, types in
-`@slicc/cloud-core/cone-config`) lets users pick the cone's model, provide flat secrets,
-and provision provider logins. `src/cloud/cone-config-bridge.ts` handles the start/resume
-flows:
-
-- **start:** validates config, splits into `/slicc/secrets.env` and
-  `/slicc/cone-config.json`. No config ⇒ synthesizes Adobe default from the cloud bearer.
-- **resume:** merges a `coneConfigDelta` into both files in-sandbox, then reloads the
-  leader via `POST /api/secrets/reload` → `Page.reload`.
-- **Adobe oauth expiry:** every path that synthesizes an Adobe `{kind:'oauth'}` account
-  stamps `tokenExpiresAt` via `imsTokenExpiry` in `@slicc/cloud-core/cone-config`
-  (decodes the IMS JWT's `created_at + expires_in` with `atob`).
-- **DO index:** `CloudSessionsDurableObject` persists a **names-only** `coneConfigIndex`
-  per cone — never values.
+`ConeConfig` = `{ model, accounts[], secrets[] }` (in `@slicc/cloud-core/cone-config`);
+`src/cloud/cone-config-bridge.ts` handles start (writes `/slicc/secrets.env` +
+`/slicc/cone-config.json`; no-config synthesizes Adobe default) and resume (merges
+`coneConfigDelta`, reloads leader via `POST /api/secrets/reload` → `Page.reload`).
+Adobe `{kind:'oauth'}` accounts stamp `tokenExpiresAt` via `imsTokenExpiry` (IMS JWT
+`created_at + expires_in`). `CloudSessionsDurableObject` persists a **names-only**
+`coneConfigIndex` — never values. Detail:
+[docs/cloudflare-worker-details.md § Cone Configuration](../../docs/cloudflare-worker-details.md#cone-configuration).
 
 ### Wrangler Config (cloud)
 
-Vars in `wrangler.jsonc`:
-
-- `ADOBE_PROXY_ENDPOINT` — Adobe LLM proxy URL.
-- `ALLOWED_EMAIL_DOMAIN` — CSV, default `adobe.com`. Set to `*` to allow any domain.
-- `BLOCKED_EMAILS` — CSV denylist.
-- `REQUIRE_OWNER_ORG` — `true` for expansion to any ownerOrg-holder.
-- `CONE_CAP_RUNNING`, `CONE_CAP_PAUSED` — per-user caps (default 1 / 5).
-- `ADMIN_USER_IDS` — CSV of IMS userIds with admin access.
-
-Secrets (`wrangler secret put`): `E2B_API_KEY` (Adobe team key; worker-only).
+Vars: `ADOBE_PROXY_ENDPOINT`; `ALLOWED_EMAIL_DOMAIN` (CSV, default `adobe.com`; `*` =
+any); `BLOCKED_EMAILS` (CSV); `REQUIRE_OWNER_ORG` (`true` expands to ownerOrg-holders);
+`CONE_CAP_RUNNING`, `CONE_CAP_PAUSED` (default 1/5); `ADMIN_USER_IDS` (CSV of IMS
+userIds). Secret: `E2B_API_KEY` (worker-only).
 
 ### v1 → v2 Expansion
 
@@ -251,8 +167,8 @@ npx wrangler deploy
 
 ### Stable API Contract (worker ↔ sandbox)
 
-These surfaces inside paused-cone images have a deprecation obligation — paused cones
-from older templates cannot be patched in-place:
+Deprecation obligation — paused cones from older templates cannot be patched
+in-place:
 
 - `POST /api/leader-restart` (loopback in sandbox)
 - `GET /api/hosted-bootstrap` (loopback in sandbox)

--- a/packages/dev-tools/CLAUDE.md
+++ b/packages/dev-tools/CLAUDE.md
@@ -1,84 +1,69 @@
 # CLAUDE.md
 
-This file covers the repo's developer-tooling surface.
-
-## Scope
-
-`packages/dev-tools/` is the home for build helpers, QA setup guidance, and developer verification utilities. Some of that tooling still lives at the repo root while the modularization settles; treat the locations below as the active surface.
+Developer-tooling surface for `packages/dev-tools/`. Long-form notes: [`docs/dev-tools-details.md`](../../docs/dev-tools-details.md).
 
 ## Key Tooling Areas
 
-- **playwright-cli gap sync**: `packages/dev-tools/tools/playwright-cli-sync.mjs` — diffs Slicc's playwright-cli against the official `@playwright/cli` schema. Run after upgrading `@playwright/cli` or after adding/removing a handler. Full reference: [`docs/playwright-cli-sync.md`](../../docs/playwright-cli-sync.md).
-- **Dev-only VFS skills** (`packages/dev-tools/vfs-dev-skills/`): skills available in dev mode (`npm run dev`) but stripped from production builds. Loaded via a `__DEV__`-gated `import.meta.glob` in `packages/webapp/src/scoops/skills.ts` and remapped to `/workspace/skills/` in the VFS. Currently contains `playwright-cli-e2e` — an automated + manual E2E regression suite for the playwright-cli command. Run it in a Slicc dev instance: `pcli-e2e`.
-- **Build configs**: `packages/webapp/vite.config.ts`, `packages/chrome-extension/vite.config.ts`, `biome.json`
-- **QA setup**: `packages/node-server/src/qa-setup.ts` plus the root `npm run qa:*` scripts
-- **Visual/integration helpers**: `packages/webapp/tests/test-dips.mjs` and related targeted test utilities
-- **RUM error triage**: `packages/dev-tools/rum-error-triage/` — run `node packages/dev-tools/rum-error-triage/triage-rum-errors.mjs` to query RUM for new SLICC errors and write triage candidates. Pure logic in `lib.mjs` (vitest `dev-tools` project). Driven nightly by `.github/workflows/rum-error-triage.yml`. See its `README.md`.
-- **AI comment detection**: `packages/dev-tools/ai-comment-detection/` — classifies contributions on a PR/issue thread and applies `ai-generated` or `human-in-the-loop` labels. Cost-ordered cascade (account check → markdown density → similarity → Pangram API). `human-in-the-loop` is sticky. Pure logic in `lib.mjs` (vitest `dev-tools` project). Driven by `.github/workflows/ai-comment-detection.yml`. See its `README.md`.
-- **Doc size/router check** (`npm run lint:docs`): `packages/dev-tools/tools/check-doc-sizes.mjs` — enforces instruction-file size budgets and requires every `packages/*/CLAUDE.md` to be linked from the root navigation hub. Non-zero exit on violation. Also runs in `.husky/pre-commit`.
-- **Doc dead-reference gate** (`npm run lint:docs`): `packages/dev-tools/tools/check-doc-refs.mjs` (+ pure lib `check-doc-refs-lib.mjs`) — fails on backtick-enclosed repo paths in `CLAUDE.md` or `docs/*.md` files that don't exist on disk. Skips globs, templates, illustrative paths, VFS runtime paths, and a built-in allowlist. TypeScript ESM `.js`→`.ts` resolution is handled. Chained after `check-doc-sizes.mjs` in `lint:docs`.
-- **Linear-history check**: `packages/dev-tools/tools/check-linear-history.sh` — fails if a PR branch contains merge commits. Run `bash packages/dev-tools/tools/check-linear-history.sh [base-ref] [head-ref]`. Driven by the `linear-history` CI job.
-- **Skill lint** (`npm run lint:skills`): `packages/dev-tools/tools/lint-skills.mjs` — runs `tessl skill lint` over all `SKILL.md` skills via `@tessl/cli`. Warns and skips locally; fails under `--strict` / CI.
-- **Developer-skill sync** (`npm run lint:skill-router`): `packages/dev-tools/tools/check-skill-router-sync.sh` — keeps the root router, canonical `.agents/skills/`, and `.claude/skills/` aliases synchronized.
-- **Patch reconcile** (`npm run lint:patches`): `packages/dev-tools/patch-reconcile/` — guards version-pinned `patch-package` patches (`patches/`). `check-patches.mjs` fails on undocumented, out-of-sync, or orphaned patches. `reconcile-context.mjs` emits metadata for the Renovate patch-reconcile workflow. Pure logic in `lib.mjs` (vitest `dev-tools` project). See `patches/README.md`.
-- **innerHTML guard** (`npm run lint:no-innerhtml`): `packages/dev-tools/tools/check-no-innerhtml.mjs` — fails on `.innerHTML =` / `.outerHTML =` / `insertAdjacentHTML()` in shipped `@slicc/webcomponents` source. Stories and tests are exempt. Chained into `npm run lint` and `lint:ci`.
-- **Providers boundary guard** (`npm run lint:no-ui-in-providers`): `packages/dev-tools/tools/check-no-ui-imports-in-providers.mjs` — fails on `from '…ui/…'` imports in `providers/built-in/`. Comments and tests are exempt. Chained into `npm run lint` and `lint:ci`.
-- **Layer back-edge ratchet** (`npm run lint:layer-back-edges`): `packages/dev-tools/tools/check-layer-back-edges.mjs` — fails on any NEW import in `packages/webapp/src/` that points up the stack `fs → shell/git → cdp → tools → core → scoops → ui` (e.g. `cdp/` → `scoops/`, or any layer → `ui/`). Unranked directories (`kernel/`, `providers/`, `speech/`, …) rank just below `ui/`: they may import ranked layers but not `ui/`, and are never a back-edge target. Pre-existing back-edges are grandfathered per file in `layer-back-edge-baseline.json` (one-way ratchet; regenerate after paying debt down with `--update`). Chained into `npm run lint`, `lint:ci`, pre-commit (webapp-source commits), and the pre-push gate. The baseline doubles as a debt list for the boy-scout gate below.
-- **Hosted-origin literal guard**: `packages/dev-tools/tools/check-hosted-origin-literal.mjs` — ensures all TS source files import `SLICC_HOSTED_ORIGIN` from `@slicc/shared-ts` instead of inlining the literal. Comment-only refs and tests are exempt.
-- **Chrome runtime.id guard**: `packages/dev-tools/tools/check-no-raw-chrome-runtime-id.mjs` — ensures all extension-environment detection goes through `core/runtime-env.ts` helpers. Tests are exempt.
-- **AGENTS.md symlink guard**: `packages/dev-tools/tools/check-agents-symlinks.mjs` — ensures every `packages/*/CLAUDE.md` has a sibling `AGENTS.md` symlink pointing to it.
-- **iOS PR screenshots**: `packages/dev-tools/tools/ios-screenshots.mjs` (+ pure lib `ios-screenshots-lib.mjs`) — captures deterministic leaderless simulator states from `packages/ios-app/screenshot-screens.json` and writes a Storybook-compatible `manifest.json`. Every screen runs on iPhone, while the conversation fixture also runs on iPad as regular-width proof. Local run: build the Debug app, then `node packages/dev-tools/tools/ios-screenshots.mjs --app=<SliccFollower.app> --out=<dir>`; use `--device=ipad --screen=conversation-fixture` for the tablet proof. Driven by `.github/workflows/ios-screenshots.yml` (same R2 bucket + sticky-comment pattern as Storybook).
-- **Storybook PR screenshots**: `packages/dev-tools/tools/storybook-affected-screenshots.mjs` (+ pure lib `storybook-affected-stories-lib.mjs`) — captures light/dark screenshots of webcomponents stories affected by a PR diff. Writes a `manifest.json` for the CI workflow. Local run: `npm run build-storybook -w @slicc/webcomponents && node packages/dev-tools/tools/storybook-affected-screenshots.mjs --changed-files=<path> --storybook-static=… --out=<dir>`. Driven by `.github/workflows/storybook-screenshots.yml`. See `packages/webcomponents/CLAUDE.md` for the end-to-end flow.
-- **Storybook PR screenshots upload**: `packages/dev-tools/tools/storybook-screenshots-upload.mjs` (+ pure lib `storybook-screenshots-upload-lib.mjs`) — uploads the manifest above to the `slicc-pr-screenshots` R2 bucket, content-hash deduplicated, with bounded concurrency (`--concurrency`, default 4) via an injectable `r2` client so `mapWithConcurrency`/dedup logic is testable without a real `wrangler` process. Sequential per-file `wrangler` subprocess spawns previously took ~4s/file — timing out the CI job on large PRs (many affected stories). Each shot retries up to 5 times with jittered exponential backoff, since R2 rate-limits upload bursts with `429` / code 971. Driven by `.github/workflows/storybook-screenshots.yml`'s "Upload screenshots to Cloudflare R2" step.
-- **Dead code detection — production-mode files** (`npm run deadcode:production-files`): `knip --production --include files`. Surfaces test-only dead files the default knip gate misses. **Production-suffix discipline**: every workspace `entry`/`project` glob in the production graph MUST be `!`-suffixed; `knip --production` keeps only suffixed patterns. Test-only fixtures are excluded via negated `project` patterns in `knip.json` (not `ignoreFiles`). See the [verifying-before-push skill](../../.agents/skills/verifying-before-push/SKILL.md) § "Knip fixture exclusion" for why `ignoreFiles` is wrong and the correct approach.
-- **Debt boy-scout gate**: `packages/dev-tools/tools/check-touched-exemptions.mjs` (+ pure lib `size-exemption-lib.mjs`) — enforces every single-rule debt override in `biome.json` (complexity and promise safety) plus the `layer-back-edge-baseline.json` list. It fails when a PR touches a listed file or grows a list. Auto-skips on non-PR events. Run: `node packages/dev-tools/tools/check-touched-exemptions.mjs [base-ref]`. See the [verifying-before-push skill](../../.agents/skills/verifying-before-push/SKILL.md) for details.
-- **Coverage gate + ratchet**: `packages/dev-tools/tools/coverage-gate.mjs` reads per-package floors from `coverage-thresholds.json` and runs vitest with those thresholds; argv after the package name is forwarded verbatim to vitest, so a caller can add run-wide options instead of running the suite twice. `coverage-ratchet.mjs` raises floors nightly toward measured coverage. The Swift-side `swift-coverage-check.sh` sources `swift-coverage-runner-retry.sh` in `--xcodebuild` mode to retry once when the UI-test runner dies at initialization (an infrastructure failure `-retry-tests-on-failure` cannot see; tested by `swift-coverage-runner-retry.test.mjs`). Set `SLICC_IOS_SIM_UDID` to a worktree-owned simulator UDID to override automatic selection locally; when unset or empty, existing SDK-runtime selection remains unchanged. See `coverage-thresholds.json` and the [verifying-before-push skill](../../.agents/skills/verifying-before-push/SKILL.md).
-- **Optional-binary guard**: `packages/dev-tools/tools/run-if-installed.mjs <binary> [args...]` — runs a command only when its binary resolves on `PATH`, otherwise warns and exits 0. Used by the root `lint-staged` Swift/Go globs so a missing `swiftlint`/`gofmt` cannot break `git commit`.
-- **Cross-impl mask vectors**: `packages/dev-tools/tools/gen-mask-vectors.mjs` — regenerate pinned mask vectors for TS/Swift parity tests after intentional masking changes.
-- **Cross-impl theme vectors**: `packages/dev-tools/tools/gen-theme-vectors.mjs` (run via `npx tsx`) — regenerate pinned theme-derivation vectors after intentional `theme-engine.ts` changes; asserted by `packages/webapp/tests/ui/theme-vectors.test.ts` and `ThemeEngineTests.swift` against the same fixture.
-- **Preflight deps check**: `packages/dev-tools/tools/preflight-deps.mjs` — fast `npm ci` staleness check wired via `pretypecheck` and `pretest` scripts.
-- **Release gating**: `packages/dev-tools/tools/release-plan.mjs` invokes semantic-release's commit analyzer directly for the read-only Linux preflight. `release-native.mjs` gates native macOS/iOS packaging, the signed + notarized `slicc` Go CLI binaries (`packages/slicc-cli/sign-and-package.sh`), Chrome Web Store/worker publish steps, and the `@ai-ecoverse/biome-jsh` npm release (`--gate=biome-jsh-version` in prepare, `--gate=biome-jsh` in publish) on whether relevant source changed since the last tag.
+- **playwright-cli gap sync**: `packages/dev-tools/tools/playwright-cli-sync.mjs` — diffs Slicc's playwright-cli against `@playwright/cli`. Ref: [`docs/playwright-cli-sync.md`](../../docs/playwright-cli-sync.md).
+- **Dev-only VFS skills** (`packages/dev-tools/vfs-dev-skills/`): `__DEV__`-gated `import.meta.glob` in `packages/webapp/src/scoops/skills.ts`, remapped to `/workspace/skills/`. Contains `playwright-cli-e2e`.
+- **Build configs**: `packages/webapp/vite.config.ts`, `packages/chrome-extension/vite.config.ts`, `biome.json`.
+- **QA setup**: `packages/node-server/src/qa-setup.ts` plus root `npm run qa:*` scripts.
+- **Visual/integration helpers**: `packages/webapp/tests/test-dips.mjs`.
+- **RUM error triage**: `packages/dev-tools/rum-error-triage/triage-rum-errors.mjs`. Nightly via `.github/workflows/rum-error-triage.yml`.
+- **AI comment detection**: `packages/dev-tools/ai-comment-detection/` — labels `ai-generated`/`human-in-the-loop`; driven by `.github/workflows/ai-comment-detection.yml`. Deep ref: [dev-tools-details.md#ai-comment-detection](../../docs/dev-tools-details.md#ai-comment-detection).
+- **Doc gates** (`npm run lint:docs`, `.husky/pre-commit`): `packages/dev-tools/tools/check-doc-sizes.mjs` + `packages/dev-tools/tools/check-doc-refs.mjs` (+ `check-doc-refs-lib.mjs`). Deep ref: [dev-tools-details.md#doc-dead-reference-gate](../../docs/dev-tools-details.md#doc-dead-reference-gate).
+- **Linear-history check**: `bash packages/dev-tools/tools/check-linear-history.sh [base-ref] [head-ref]`. `linear-history` CI job.
+- **Skill lint** (`npm run lint:skills`): `packages/dev-tools/tools/lint-skills.mjs` — `tessl skill lint` via `@tessl/cli`. Warns locally; fails under `--strict`/CI.
+- **Developer-skill sync** (`npm run lint:skill-router`): `packages/dev-tools/tools/check-skill-router-sync.sh` — root router, `.agents/skills/`, `.claude/skills/` aliases in sync.
+- **Patch reconcile** (`npm run lint:patches`): `packages/dev-tools/patch-reconcile/check-patches.mjs` + `reconcile-context.mjs` (Renovate metadata). See `patches/README.md`.
+- **innerHTML guard** (`npm run lint:no-innerhtml`): `packages/dev-tools/tools/check-no-innerhtml.mjs` bans `.innerHTML =`, `.outerHTML =`, `insertAdjacentHTML()` in `@slicc/webcomponents` (stories/tests exempt).
+- **Providers boundary** (`npm run lint:no-ui-in-providers`): `packages/dev-tools/tools/check-no-ui-imports-in-providers.mjs` bans `from '…ui/…'` in `providers/built-in/`.
+- **Layer back-edge ratchet** (`npm run lint:layer-back-edges`): `packages/dev-tools/tools/check-layer-back-edges.mjs`; baseline `layer-back-edge-baseline.json` (`--update`). Deep ref: [dev-tools-details.md#layer-back-edge-ratchet](../../docs/dev-tools-details.md#layer-back-edge-ratchet).
+- **Hosted-origin literal guard**: `packages/dev-tools/tools/check-hosted-origin-literal.mjs` — TS must import `SLICC_HOSTED_ORIGIN` from `@slicc/shared-ts` (no inline literal).
+- **Chrome runtime.id guard**: `packages/dev-tools/tools/check-no-raw-chrome-runtime-id.mjs` — go through `core/runtime-env.ts` (tests exempt).
+- **AGENTS.md symlink guard**: `packages/dev-tools/tools/check-agents-symlinks.mjs` — every `packages/*/CLAUDE.md` has an `AGENTS.md` sibling symlink.
+- **iOS PR screenshots**: `packages/dev-tools/tools/ios-screenshots.mjs` (+ `ios-screenshots-lib.mjs`) reads `packages/ios-app/screenshot-screens.json`, emits Storybook `manifest.json`. Driven by `.github/workflows/ios-screenshots.yml`.
+- **Storybook PR screenshots**: `packages/dev-tools/tools/storybook-affected-screenshots.mjs` (+ `storybook-affected-stories-lib.mjs`) — light/dark shots of affected webcomponents stories. Pair with `npm run build-storybook -w @slicc/webcomponents`. Driven by `.github/workflows/storybook-screenshots.yml`.
+- **Storybook screenshots upload**: `packages/dev-tools/tools/storybook-screenshots-upload.mjs` (+ `storybook-screenshots-upload-lib.mjs`) — R2 `slicc-pr-screenshots`, content-hash dedup, `--concurrency`. Deep ref: [dev-tools-details.md#storybook-screenshots-upload](../../docs/dev-tools-details.md#storybook-screenshots-upload).
+- **Dead code (production files)** (`npm run deadcode:production-files`): `knip --production --include files`; config `knip.json`. Deep ref: [dev-tools-details.md#knip-production-suffix-discipline](../../docs/dev-tools-details.md#knip-production-suffix-discipline).
+- **Debt boy-scout gate**: `node packages/dev-tools/tools/check-touched-exemptions.mjs [base-ref]` (+ `size-exemption-lib.mjs`) — enforces `biome.json` debt overrides plus `layer-back-edge-baseline.json`; skips non-PR events. See [verifying-before-push skill](../../.agents/skills/verifying-before-push/SKILL.md).
+- **Coverage gate + ratchet**: `packages/dev-tools/tools/coverage-gate.mjs` + `coverage-ratchet.mjs` (`coverage-thresholds.json`). Swift: `packages/dev-tools/tools/swift-coverage-check.sh` + `swift-coverage-runner-retry.sh`; `SLICC_IOS_SIM_UDID` overrides. Deep ref: [dev-tools-details.md#swift-coverage-retry](../../docs/dev-tools-details.md#swift-coverage-retry).
+- **Optional-binary guard**: `packages/dev-tools/tools/run-if-installed.mjs <binary> [args...]` — runs iff on `PATH`, else warns and exits 0. Used by root `lint-staged` Swift/Go globs.
+- **Cross-impl mask vectors**: `packages/dev-tools/tools/gen-mask-vectors.mjs` — regenerate TS/Swift parity mask vectors.
+- **Cross-impl theme vectors**: `packages/dev-tools/tools/gen-theme-vectors.mjs` (via `npx tsx`) — regenerate after `theme-engine.ts` changes; asserted by `packages/webapp/tests/ui/theme-vectors.test.ts` + `ThemeEngineTests.swift`.
+- **Preflight deps check**: `packages/dev-tools/tools/preflight-deps.mjs` — wired via `pretypecheck`/`pretest`.
+- **Release gating**: `packages/dev-tools/tools/release-plan.mjs` (Linux preflight) + `release-native.mjs` — gates macOS/iOS packaging, `slicc` Go CLI (`packages/slicc-cli/sign-and-package.sh`), Chrome Web Store/worker publish, `@ai-ecoverse/biome-jsh` (`--gate=biome-jsh-version`/`--gate=biome-jsh`).
 
-### SLICC CDP Debug Toolkit
+### SLICC CDP Debug + Screencast
 
-`packages/dev-tools/tools/slicc-debug.mjs` — CDP diagnostic CLI for the standalone dev harness. Subcommands: `targets`, `logs`, `vfs ls/cat`, `eval`, `shell`. Page-target selection via `--url`/`--url-pattern`. Payload input via `--file`. Run: `node packages/dev-tools/tools/slicc-debug.mjs --help`. See the script's header comment for the full option reference.
-
-### SLICC CDP Screencast Recorder
-
-`packages/dev-tools/tools/slicc-screencast.mjs` (+ `slicc-screencast-lib.mjs`, `slicc-screencast-video.mjs`) — records `Page.startScreencast` frames of the running SLICC leader tab. Writes timestamped frames + `manifest.json`; optional `--video` assembly via ffmpeg. Agent-facing usage: the `demo-recording` skill. Run: `node packages/dev-tools/tools/slicc-screencast.mjs --help`. See the script's header comment for the full option reference.
+- `packages/dev-tools/tools/slicc-debug.mjs` — CDP diagnostic CLI (`targets`, `logs`, `vfs ls/cat`, `eval`, `shell`; `--url`/`--url-pattern`/`--file`). `node packages/dev-tools/tools/slicc-debug.mjs --help`.
+- `packages/dev-tools/tools/slicc-screencast.mjs` (+ `slicc-screencast-lib.mjs`, `slicc-screencast-video.mjs`) — `Page.startScreencast` frames + `manifest.json`; `--video` via ffmpeg. Skill: `demo-recording`.
 
 ### Fresh Dev Harnesses
 
-Five harness scripts bring up isolated dev environments on distinct ports so they can run concurrently. The standalone harness fails if its selected bridge is occupied unless `SLICC_FRESH_REAP=1` explicitly opts into reaping a confirmed stale harness; forced reaping of the documented production bridge `:5710` is refused, and it never reaps Chrome CDP. Other harness cleanup remains strictly port-scoped, never by process name. Labeled Chrome bundle clones (`clone-labeled-chrome.sh`) provide distinct ⌘-Tab entries.
+Five isolated harnesses on distinct ports. Standalone fails on an occupied bridge unless `SLICC_FRESH_REAP=1` reaps a stale harness. Reaping production bridge `:5710` is refused; Chrome CDP is never reaped. Cleanup is port-scoped. `clone-labeled-chrome.sh` gives distinct ⌘-Tab entries.
 
-| Harness        | Script                        | Bridge                 | CDP     | Chrome Label  | Notes                                                                          |
-| -------------- | ----------------------------- | ---------------------- | ------- | ------------- | ------------------------------------------------------------------------------ |
-| Standalone     | `dev-standalone-fresh.sh`     | `:$PORT` (use `:5715`) | auto    | `SLICC-Node`  | Fails on occupied bridge by default; self-builds leader UI                     |
-| Swift          | `dev-swift-fresh.sh`          | `:5720`                | `:9224` | `SLICC-Swift` | Native `swift-server` bridge; auto-signs with stable dev cert                  |
-| Extension      | `dev-extension-fresh.sh`      | (SW)                   | `:9333` | `SLICC-Ext`   | MV3 extension IS the bridge; self-builds leader UI; uses LaunchServices launch |
-| Electron-Node  | `dev-electron-node-fresh.sh`  | `:5730`                | `:9225` | —             | Attaches to external Electron app (default: Slack)                             |
-| Electron-Swift | `dev-electron-swift-fresh.sh` | `:5740`                | `:9226` | —             | Swift backend attaching to external Electron app                               |
+| Harness        | Script                        | Bridge                 | CDP     | Chrome Label  | Notes                                                  |
+| -------------- | ----------------------------- | ---------------------- | ------- | ------------- | ------------------------------------------------------ |
+| Standalone     | `dev-standalone-fresh.sh`     | `:$PORT` (use `:5715`) | auto    | `SLICC-Node`  | Fails on occupied bridge; self-builds leader UI        |
+| Swift          | `dev-swift-fresh.sh`          | `:5720`                | `:9224` | `SLICC-Swift` | Native `swift-server`; auto-signs with stable dev cert |
+| Extension      | `dev-extension-fresh.sh`      | (SW)                   | `:9333` | `SLICC-Ext`   | MV3 extension IS the bridge; LaunchServices launch     |
+| Electron-Node  | `dev-electron-node-fresh.sh`  | `:5730`                | `:9225` | —             | Attaches to external Electron app (default: Slack)     |
+| Electron-Swift | `dev-electron-swift-fresh.sh` | `:5740`                | `:9226` | —             | Swift backend attaching to external Electron app       |
 
-Run standalone in an isolated lane with `PORT=5715 WRANGLER_PORT=8787 npm run dev:standalone:fresh`; never use or clear production bridge `:5710` or Chrome CDP `:9222`. Other entry points are `npm run dev:swift:fresh`, `npm run dev:extension:fresh`, `npm run dev:electron:node:fresh`, and `npm run dev:electron:swift:fresh`. Override bridge port with `PORT=…`, target app with positional arg or `ELECTRON_APP=…`. All pair with `slicc-debug.mjs` for verification. For detailed lifecycle, port resolution, reaping, LaunchServices, and wrangler reuse behavior, see [`docs/development.md`](../../docs/development.md) § "Fresh Dev Harness Details".
+Isolated lane: `PORT=5715 WRANGLER_PORT=8787 npm run dev:standalone:fresh`; never touch production bridge `:5710` or Chrome CDP `:9222`. Also `npm run dev:swift:fresh`, `dev:extension:fresh`, `dev:electron:node:fresh`, `dev:electron:swift:fresh`. `PORT=…`/`ELECTRON_APP=…` override. Lifecycle + reaping: [`docs/development.md`](../../docs/development.md); [dev-tools-details.md#fresh-dev-harnesses](../../docs/dev-tools-details.md#fresh-dev-harnesses).
 
 ### Supporting Utilities
 
-- **Labeled Chrome bundle clone**: `clone-labeled-chrome.sh` — APFS COW-clones a Chrome for Testing `.app` under a distinct `CFBundleName`/`CFBundleIdentifier` so concurrent harnesses get separate ⌘-Tab entries. Re-signs ad-hoc (top-level only). No-op on non-darwin.
-- **Stable dev code-signing identity**: `setup-dev-cert.sh` — one-time setup creating a persistent self-signed `SLICC Dev Code Signing` identity so swift-server's Keychain DR stops changing on every build. Run once: `bash packages/dev-tools/tools/setup-dev-cert.sh`. `dev-swift-fresh.sh` signs with it automatically when present.
+- **Labeled Chrome clone**: `clone-labeled-chrome.sh` — APFS COW-clone with distinct `CFBundleName`/`CFBundleIdentifier`; ad-hoc re-signed (top-level only). No-op on non-darwin.
+- **Stable dev code-signing identity**: `bash packages/dev-tools/tools/setup-dev-cert.sh` — one-time; creates persistent self-signed `SLICC Dev Code Signing`. `dev-swift-fresh.sh` picks it up automatically.
 
 ## e2b Template
 
-The hosted-leader cloud float runs inside an e2b sandbox. The template definition lives in `packages/dev-tools/e2b-template/` — see `packages/cloud-core/CLAUDE.md` for the substrate lifecycle.
-
-## What Lives Here Conceptually
-
-- Scripts that support local development rather than runtime behavior
-- Config files that shape builds or verification flows
-- QA setup flows for isolated profiles and tray testing
-- One-off utilities used by release, validation, or inspection workflows
+Hosted-leader cloud float runs in an e2b sandbox; template in `packages/dev-tools/e2b-template/`. See `packages/cloud-core/CLAUDE.md`.
 
 ## Usage Notes
 
 - Prefer root npm scripts when a helper already has one.
-- Keep dev-only configs and utilities out of runtime packages unless they are required at runtime.
-- When adding new tooling, document both the file location and the intended entry command.
+- Keep dev-only configs and utilities out of runtime packages unless required at runtime.
+- When adding new tooling, document both file location and entry command.

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -1,107 +1,51 @@
 # CLAUDE.md
 
-This file covers the iOS follower app in `packages/ios-app/`.
-
-## Scope
-
-`packages/ios-app/SliccFollower/` is a native iOS SwiftUI app that connects to a SLICC leader over WebRTC and presents the leader's chat + sprinkles + (limited) federated CDP. It is **a follower only** — it does not host an agent runtime.
-
-`packages/ios-app` is a Swift Package Manager project (`Package.swift`), not an npm workspace. It targets iOS 26.
+iOS follower app in `packages/ios-app/` — native iOS 26 SwiftUI SPM project (`Package.swift`), not an npm workspace. **Follower only**: connects to a SLICC leader over WebRTC (chat + sprinkles + limited federated CDP); no agent runtime. Deep reference: [`docs/ios-app-details.md`](../../docs/ios-app-details.md).
 
 ## Layout
 
-| Path                                                                                                | Purpose                                                                                                                                                                                                                                                                                                     |
-| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SliccFollower/App/SliccFollowerApp.swift`, `App/AppState.swift`                                    | App entry + central `@MainActor AppState`                                                                                                                                                                                                                                                                   |
-| `SliccTrayFollower/Models/SyncProtocol.swift`                                                       | Partial `Codable` mirror of `packages/shared-ts/src/tray-sync-protocol.ts`                                                                                                                                                                                                                                  |
-| `SliccFollower/Models/ScoopStatus.swift`                                                            | Scoop lifecycle and context-fullness presentation                                                                                                                                                                                                                                                           |
-| `SliccTrayFollower/Models/{ChatMessage,TrayTypes,TrayChunkFraming}.swift`                           | Chat/signaling types and transport chunk reassembly                                                                                                                                                                                                                                                         |
-| `SliccFollower/Sync/Keepalive.swift`                                                                | `DataChannelKeepalive` ping/pong actor                                                                                                                                                                                                                                                                      |
-| `SliccFollower/Sync/TerminalClient.swift`                                                           | Single-flight `exec.*` client for the leader shell                                                                                                                                                                                                                                                          |
-| `SliccFollower/Models/ICloudSessionList.swift`, `SliccFollower.entitlements`                        | iCloud tray-session discovery over `SliccTraySession` + KVS entitlement                                                                                                                                                                                                                                     |
-| `SliccTrayFollower/Networking/{TraySignaling,TrayFollowerConnector,WebRTCManager}.swift`            | Signaling + WebRTC peer/data-channel setup                                                                                                                                                                                                                                                                  |
-| `SliccTrayKit/FileProvider/`, `SliccFileProvider/`                                                  | Read/write Files.app provider for the leader VFS (kit logic + thin appex). Appex Info.plist must set `NSExtensionFileProviderSupportsEnumeration` or Files can register the domain while leaving `userEnabled=false` and hiding it from Browse → Locations.                                                 |
-| `SliccFollower/CDP/CDPBridge.swift`, `CDPTarget.swift`                                              | Hosts WKWebViews as CDP targets the leader can drive                                                                                                                                                                                                                                                        |
-| `SliccFollower/Views/ChatView.swift`, `MessageListView.swift`, `MarkdownText.swift`                 | Adaptive chat shell; `ChatPresentationState` owns compact/regular branch state. While a compact workbench overlay covers the conversation, the shell suppresses the chat toolbar (`toolbarSuppressed`); transcript http(s) links open in-app unless `openLinksInBuiltInBrowser` (Settings → Advanced) off   |
-| `SliccFollower/Views/SprinkleWebView.swift`, `InlineSprinkleView.swift`, `SprinkleDetailView.swift` | Renders `.shtml`; intercepts bridge calls and stubs VFS APIs                                                                                                                                                                                                                                                |
-| `SliccFollower/Views/DockModel.swift`, `DockRail.swift`, `WorkbenchHost.swift`, `LucideIcon.swift`  | Phone IA: 48pt dock rail; workbench overlays chat                                                                                                                                                                                                                                                           |
-| `SliccFollower/Views/TerminalView.swift`, `TerminalViewModel.swift`                                 | Persistent libghostty surface                                                                                                                                                                                                                                                                               |
-| `SliccFollower/Views/TabsCarouselView.swift`                                                        | Safari-shaped browser: two-column tab overview (local WKWebView tabs + remote preview cards as peers; tapping a remote card opens its URL locally); full-screen browsing with a bottom Liquid Glass address bar hides the rail + nav bar (`AppState.browserViewingTabId`); controls live in-content (#1916) |
-| `SliccFollower/App/{InboundActions,AppGroupInbox,OpenInSliccIntents}.swift`, `SliccShareExtension/` | Inbound actions (#1918): `slicc://open\|prompt` (+`x-callback-url` form), `sliccy.ai/app/*` universal links, App Intents, and the share appex parking URLs in the `group.ai.sliccy.follower` inbox. One coordinator funnel; deep links confirm via card (fail-closed), intents are explicit                 |
-| `SliccFollower/{Models,Views}/*Avatar*.swift`                                                       | Avatar geometry/motion, renderer, screenshot fixture                                                                                                                                                                                                                                                        |
+- `SliccFollower/App/` — `SliccFollowerApp`, `@MainActor AppState`; inbound coordinator (`InboundActions`, `AppGroupInbox`, `OpenInSliccIntents`) + `SliccShareExtension/` funnel `slicc://open|prompt` (+`x-callback-url`), `sliccy.ai/app/*` universal links, App Intents, share URLs in `group.ai.sliccy.follower`. Deep links confirm via card (fail-closed).
+- `SliccFollower/Models/` — `ScoopStatus`; `ICloudSessionList` + `SliccFollower.entitlements` (iCloud via `SliccTraySession` + KVS); `*Avatar*`.
+- `SliccFollower/Sync/` — `Keepalive` (`DataChannelKeepalive`); `TerminalClient` (single-flight `exec.*`).
+- `SliccFollower/CDP/` — `CDPBridge` + `CDPTarget` host WKWebViews as CDP targets.
+- `SliccFollower/Views/` — `ChatView`/`MessageListView`/`MarkdownText` (`ChatPresentationState`; compact workbench sets `toolbarSuppressed`; http(s) links open in-app unless Settings → Advanced `openLinksInBuiltInBrowser` off); `SprinkleWebView`/`InlineSprinkleView`/`SprinkleDetailView` (`.shtml`); `DockModel`/`DockRail`/`WorkbenchHost`/`LucideIcon` (48pt rail); `TerminalView`/`TerminalViewModel`; `TabsCarouselView` (full-screen hides rail via `AppState.browserViewingTabId`).
+- `SliccTrayFollower/` (`swift-trayfollower`, re-exported via `TrayFollowerExports.swift`) — `Models/SyncProtocol.swift` (partial `Codable` mirror of `packages/shared-ts/src/tray-sync-protocol.ts`), `Models/{ChatMessage,TrayTypes,TrayChunkFraming}.swift`, `Networking/{TraySignaling,TrayFollowerConnector,WebRTCManager}.swift`.
+- `SliccTrayKit/FileProvider/` + `SliccFileProvider/` — Files.app provider for leader VFS. Appex Info.plist MUST set `NSExtensionFileProviderSupportsEnumeration` or Files hides the domain (`userEnabled=false`).
 
-Plain SPM commands do nothing useful on a macOS host. Build and test go through the XcodeGen project on a simulator (see "Test + coverage"). **It is generated from `project.yml`, not committed** — `xcodegen generate` after cloning and whenever sources change; project-editor edits are overwritten. The `SliccTrayFollower/*` rows are in the `swift-trayfollower` package, re-exported via `TrayFollowerExports.swift`.
+Plain SPM commands do nothing on a macOS host; build/test go through XcodeGen. **Xcode project generated from `project.yml`, not committed** — run `xcodegen generate` after clone and whenever sources change.
 
 ## Protocol Mirror Invariant
 
-`SliccTrayFollower/Models/SyncProtocol.swift` (in `swift-trayfollower`) mirrors a **subset** of `packages/shared-ts/src/tray-sync-protocol.ts`. The matrix in `docs/architecture.md` is the cross-float source of truth. iOS-local facts:
+`SliccTrayFollower/Models/SyncProtocol.swift` mirrors a **subset** of `packages/shared-ts/src/tray-sync-protocol.ts`; the matrix in `docs/architecture.md` is source of truth. iOS-local:
 
 - `preview.open` → `CDPBridge.handleTabOpen`, acks `tab.opened`.
-- iOS never originates transcript export; those prompts decode to `.unknown` / `undecodable` in the corpus.
-- `capabilities.exec: true`; `handleExecMessage` accepts only `open [--universal|--x-callback] <url>`, gated by scoped approval, then launches it via `UIApplication.open` (`universalLinksOnly` for `--universal`). Raw paths reject traversal and encoded delimiters; hierarchical URLs must standardize unchanged. 1,024 IDs tombstoned; 128 failed terminal deliveries retry FIFO.
-- `--x-callback` replaces any supplied callback keys with app-owned nonce URLs. A correlated success/error/cancel emits one ordered `{status, parameters:[{name,value}]}` JSON line on stdout, then exit 0/1/130. Results are capped at 16 parameters and 16 KiB serialized JSON; overflow fails without truncation. Callback state is process-local, so a callback after app restoration is consumed silently and the leader owns its timeout.
+- iOS never originates transcript export; those prompts decode to `.unknown` / `undecodable`.
+- `capabilities.exec: true`; `handleExecMessage` accepts only `open [--universal|--x-callback] <url>`, scoped-approval gated, launched via `UIApplication.open` (`universalLinksOnly` for `--universal`). Raw paths reject traversal + encoded delimiters; hierarchical URLs must standardize unchanged. 1,024 IDs tombstoned; 128 failed retries FIFO.
+- `--x-callback` nonces, JSON result shape, 16-param / 16-KiB caps: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#x-callback-exec).
 
-Both union doc-comments state omissions; `// MARK: -` boundaries are the anchors.
+`// MARK: -` boundaries are the anchors. Every variant needs a fixture + iOS expectation in `tray-sync-protocol-corpus.ts`, decoded by vitest + Swift. Order: (1) TS union, (2) Swift enum + `init(from:)` arm, (3) leader broadcast, (4) browser + iOS dispatch (`AppState.handleDataChannelMessage` is the only iOS switch), (5) corpus + tests, (6) architecture matrix. Skipping iOS fails `SyncProtocolCorpusTests` instead of `.unknown`.
 
-**Mechanical enforcement:** every union variant needs a fixture + iOS expectation in `tray-sync-protocol-corpus.ts`, decoded by vitest and Swift. When changing the protocol: (1) TS union, (2) Swift enum **and** `init(from:)` arm, (3) leader broadcast, (4) browser + iOS dispatch (`AppState.handleDataChannelMessage` is the only iOS switch), (5) corpus + tests, (6) architecture matrix row. Skipping iOS fails `SyncProtocolCorpusTests` instead of dropping to `.unknown`.
+## Follower on `AppState`
 
-## What this app supports vs the browser follower
-
-Model TS follower features on `AppState`:
-
-- Lifecycle: `connect` / `disconnect` / `dataChannelOpened` / `handleDisconnect`
-- Health: `Keepalive` splits **stalled** vs **dead**; `lastError` is transport, `leaderError` is the cone's
-- Dispatch: `handleDataChannelMessage`
-- Sprinkles: refresh/fetch/lick/handle content (chunk reassembly + waiter dedup)
-- Leader VFS: `FsClient` requests with `targetRuntimeId: "leader"`; leader-origin requests get `ENOTSUP` (not silence). Client owns deadline + reassembly.
-- `hello` sends `exec: true` + device `motd`
-- Multi-scoop buffers, model/thinking controls, agent events
-
-### Transcript swipe arbitration
-
-Nested horizontal content keeps a drag while it can scroll that way; scoop navigation or frozen dismissal takes over only at the departing edge. Freeze edge state at drag start, tolerate either callback order, fail closed for unknown guarded contexts. Edge math includes both 8pt negative-padding expansions. On iOS 18+, each guarded scroller uses `UIGestureRecognizerRepresentable` and snapshots its `UIScrollView` at touch-down; the parent handles ordinary content. Keep the iOS 17 fallback and preserve vertical scrolling.
-
-### Licks
-
-`sprinkle.lick` is its own message (`sprinkle` is not `FORWARDABLE_TO_LEADER`). `LickEvent` mirrors only `navigate` and `discovery`. `navigate` handoffs come from `WKNavigationResponse` Link headers (main frame only).
-
-### Message rendering parity
-
-- Attachment chips: thumbnail/glyph + filename on user messages only
-- Error card omits web CTAs (no follower→leader equivalent)
-- `tool_ui` is a read-only card by `requestId`; `tool_ui_done` / snapshot clear it
+Lifecycle `connect`/`disconnect`/`dataChannelOpened`/`handleDisconnect`; `Keepalive` splits **stalled** vs **dead** (`lastError`=transport, `leaderError`=cone); dispatch via `handleDataChannelMessage`; leader VFS uses `FsClient` with `targetRuntimeId: "leader"` (leader-origin gets `ENOTSUP`); `hello` sends `exec: true` + device `motd`. Invariants: swipe arbitration freezes edge state at drag start and fails closed; `sprinkle.lick` is its own message (`sprinkle` not `FORWARDABLE_TO_LEADER`); `LickEvent` mirrors only `navigate` + `discovery` from `WKNavigationResponse` Link headers; user-only attachment chips, no web CTAs, `tool_ui` cleared by `tool_ui_done` / snapshot. Details: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#transcript-swipe-arbitration).
 
 ## iCloud Sessions
 
-`AppState.sessionStore` uses **`packages/swift-traysession`**; the launcher publishes and `SettingsView` joins. Liveness requires a connected leader. KVS `S8LB56P782.ai.sliccy.trays` MUST match macOS. Unprovisioned builds have no cache; `SLICC_IOS_NO_ICLOUD=1` omits iCloud. Never expose `joinUrl`.
+`AppState.sessionStore` uses **`packages/swift-traysession`**; launcher publishes, `SettingsView` joins. Liveness requires a connected leader. KVS `S8LB56P782.ai.sliccy.trays` MUST match macOS. Unprovisioned builds have no cache; `SLICC_IOS_NO_ICLOUD=1` omits iCloud. **Never expose `joinUrl`.** Attach loops after reconnect must follow `TRAY_SUPERSEDED` / `SupersedeRedirect`: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#icloud-tray-supersede-chain).
 
-iCloud keeps advertising the **old** tray after a leader reconnects, so `SessionReachability` and both attach loops must follow the `TRAY_SUPERSEDED` chain (`SupersedeRedirect`, which also moves the tray the connection owns) or a row reads live but cannot connect.
-
-## Frozen Sessions
-
-`FrozenSessions.swift` mirrors `transcript/frozen-archive-format.ts`; its view opens saved transcripts read-only. Hook: `-uiTestFrozenFixture/Empty`.
+**Frozen sessions**: `FrozenSessions.swift` mirrors `transcript/frozen-archive-format.ts`; opens saved transcripts read-only. Hook: `-uiTestFrozenFixture/Empty`.
 
 ## Push to Talk
 
-Hold an empty composer to dictate (`PttController` + `Dictation`/`SFSpeechRecognizer`); release calls `InputBar.submit(_:dictated:)`. Only matching dictated replies speak: English uses Kokoro, other paths use `AVSpeechSynthesizer`; typed turns stay silent. `AudioSessionCoordinator` solely owns `AVAudioSession`, serializes recording/playback, and restores the inherited category/rate. Hooks: `-uiTestSpeechPermission/Script`, `-uiTestPttStage`.
-
-### Local Kokoro models
-
-Settings downloads the anonymous, revision-pinned ~83 MB Hugging Face pack after
-Wi-Fi consent with progress, cancel, retry, and removal; replies never provision.
-Pack: nine CoreML stages, two vocabularies, `af_heart`. Marker/cache delete
-together; weights are not committed. See
-[`docs/ios-simulator-qa.md`](../../docs/ios-simulator-qa.md) for QA.
+Hold empty composer to dictate (`PttController` + `Dictation`/`SFSpeechRecognizer`); release calls `InputBar.submit(_:dictated:)`. Only dictated replies speak: English uses Kokoro, others `AVSpeechSynthesizer`; typed turns silent. `AudioSessionCoordinator` solely owns `AVAudioSession`. Hooks: `-uiTestSpeechPermission/Script`, `-uiTestPttStage`. Kokoro pack (~83 MB, Wi-Fi consent; replies never provision): [`docs/ios-app-details.md`](../../docs/ios-app-details.md#local-kokoro-models). QA: [`docs/ios-simulator-qa.md`](../../docs/ios-simulator-qa.md).
 
 ## Terminal
 
-Libghostty `InMemoryTerminalSession` + `TerminalClient` exec against the leader shell (`hello.capabilities.exec`). One virtual shell per connection; Ctrl-C → `SIGINT` until `exec.response`. No interactive output.
+`InMemoryTerminalSession` + `TerminalClient` exec against the leader shell (`hello.capabilities.exec`). One virtual shell per connection; Ctrl-C → `SIGINT` until `exec.response`.
 
 ## Agent Avatar
 
-`SliccAgentAvatarView` shares its treatment with the browser `<slicc-agent-avatar>`. The chat header is one 36pt row: scoop pill leading, avatar centered, session-controls cluster trailing. The cluster is a shell overlay, not a toolbar item — the nav bar clips its own items and the cluster must overlap the dock rail. It tracks the chat toolbar: hidden under a compact workbench, kept in the regular split where the conversation stays visible. Menu rows stay text-only. Fullness is pupil size only — never a ring, gauge, badge, or text. Connection trouble outranks lifecycle and replaces pupils and eye whites with 1pt TV static; the a11y phrase still carries label, lifecycle, fill, and connection status. CoreMotion pupil movement is relative to the rolling 60-second average tilt and capped at one eye diameter per second; reduce-motion and closed eyes center pupils. `-uiTestAvatarFixture light-static|dark-static` freezes a noise frame.
-
-No connection banner row: recoverable state stays in the avatar and composer placeholder so it cannot move message rows; terminal `.gaveUp` opens Settings.
+`SliccAgentAvatarView` mirrors the browser `<slicc-agent-avatar>`. Chat header is a 36pt row (scoop pill, avatar, session-controls cluster); the cluster is a shell overlay that must overlap the dock rail. Fullness = pupil size only, never ring/gauge/badge/text. Connection trouble replaces pupils + eye whites with 1pt TV static; a11y phrase carries label, lifecycle, fill, connection. Recoverable state stays in avatar/composer (no banner row); `.gaveUp` opens Settings. `-uiTestAvatarFixture light-static|dark-static` freezes noise. Details: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#agent-avatar-treatment).
 
 ## Build
 
@@ -116,49 +60,27 @@ swiftlint lint
 
 ## Test + coverage
 
-Run unit tests through `xcodebuild test` on a simulator. The coverage gate boots an iPhone matching the simulator SDK, retries infra failures, and enforces `coverage-thresholds.json`. Override selection locally with a worktree-owned `SLICC_IOS_SIM_UDID`. Never pass `CODE_SIGNING_ALLOWED=NO` to tests: XCTest needs ad-hoc signing; use it only for the build above.
+Run `xcodebuild test` on a simulator. Coverage gate boots an iPhone matching the simulator SDK, retries infra failures, enforces `coverage-thresholds.json`. Override via worktree-owned `SLICC_IOS_SIM_UDID`. **Never pass `CODE_SIGNING_ALLOWED=NO` to tests** (XCTest needs ad-hoc signing).
 
 ```bash
 ./packages/dev-tools/tools/swift-coverage-check.sh \
   --xcodebuild SliccFollower packages/ios-app SliccFollower
 ```
 
-Outputs land in `.build/coverage/`. The gate runs only `SliccFollowerTests`, disables parallel clones for shared app-state isolation, and keeps random order. Coverage combines the app dylib with linked frameworks so `SliccTrayKit` stays measured; SwiftUI/CDP/AppState orchestration remains on the UI-test gate.
-
-Exclude `SliccFileProvider/` from coverage: the appex does not launch in unit tests, and its measured enumeration/read/error logic lives in `SliccTrayKit`. Never add the thin adapter binary as a coverage object.
-
-File Provider reads are memory-bound: `readBinaryFile` holds the full base64 response and decoded `Data` before writing. Treat very large leader VFS files as unsupported until reads stream to disk.
+Outputs in `.build/coverage/`. Gate runs only `SliccFollowerTests`, disables parallel clones, keeps random order. Coverage combines app dylib + linked frameworks so `SliccTrayKit` stays measured. Exclude `SliccFileProvider/` (appex not launched in unit tests); **never add the thin adapter binary as a coverage object**. File Provider reads are memory-bound (`readBinaryFile` holds full base64 + decoded `Data`); large VFS files unsupported until reads stream to disk.
 
 ## UI tests (`SliccFollowerUITests`)
 
-A `bundle.ui-testing` target remains in the scheme, but the unit coverage gate excludes it. Run `-only-testing:SliccFollowerUITests` when UI changes, as a separate CI job. No test needs a leader: `-uiTestFixtureRoute YES` opens the leaderless **UI Fixture** route; `-uiTestSessionsFixture/Empty YES` seeds iCloud sessions in-memory; `-uiTestScoopStatusFixture` covers lifecycle/fill; `-uiTestReduceMotion` freezes pupil motion and static noise. `UITestHooks` is `#if DEBUG` only. The failure-state test dials `http://127.0.0.1:1/…` so the avatar reaches `Connection Failed` without DNS. `-uiTestCompletedTurn YES` feeds a full completed turn through the real dispatcher.
-
-Regular-width browser tabs claim the whole iPad window; returning to the overview restores the split. CI runs this enter/exit regression in the `ios-app-tests` matrix (iPad cells).
-
-- Put accessibility identifiers on leaves (`message-<id>`). Container ids propagate; `.accessibilityElement(children: .contain)` does not fix it.
-- Row ids alone are blind — also add a `variantMarkers` string only that renderer can emit.
-- The transcript pins to the newest message; variant walks scroll bottom-to-top and must be bounded.
-- A red CI job names the test, not the reason. Read XCTAssert text from the uploaded `test-timings-ios-app-<ios>-<device>` xcresult via `xcrun xcresulttool get test-results tests`. Host death before XCTest connects is usually a runtime mismatch or `CODE_SIGNING_ALLOWED=NO`, not flake.
+`bundle.ui-testing` stays in the scheme; the unit gate excludes it. Run `-only-testing:SliccFollowerUITests` on UI changes as a separate CI job. **No test needs a leader**: `-uiTestFixtureRoute YES` opens the leaderless **UI Fixture**; `-uiTestSessionsFixture/Empty YES` seeds iCloud sessions; `-uiTestScoopStatusFixture` covers lifecycle/fill; `-uiTestReduceMotion` freezes pupil motion + noise; `-uiTestCompletedTurn YES` feeds a completed turn. `UITestHooks` is `#if DEBUG` only. Failure-state dials `http://127.0.0.1:1/…` so the avatar reaches `Connection Failed` without DNS. Details: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#ui-test-details).
 
 ## Linting
 
-`.swiftlint.yml` inherits the repo-root rule set via `parent_config` and excludes `.build`/`SliccFollower.xcodeproj`. Only `error`-severity violations fail CI. `swiftlint --fix` rewrites every scanned file — run it on a clean tree.
-
-The CI job ends with an informational Periphery dead-code scan (`|| true`). App and test targets live in the XcodeGen project, not the SPM manifest, so the scan names project, scheme, and target explicitly.
-
-SwiftLint lints; `swift format` formats against the repo-root `.swift-format` — run `npm run lint:swift:format` / `format:swift` from the repo root (they cover `SliccTrayKit` too).
+`.swiftlint.yml` inherits repo-root via `parent_config`, excludes `.build`/`SliccFollower.xcodeproj`; only `error` severity fails CI. `swiftlint --fix` rewrites every scanned file (clean tree only). CI ends with informational Periphery scan (`|| true`) naming project/scheme/target. `swift format` uses repo-root `.swift-format`; run `npm run lint:swift:format` / `format:swift` from repo root (covers `SliccTrayKit`).
 
 ## TestFlight
 
-Releases run `scripts/package-and-upload-testflight.sh` (secrets via `setup-testflight-secrets.sh`), path-gated by `release-native.mjs`. The script **soft-skips with exit 0** when `SLICC_SKIP_TESTFLIGHT=1`, an Apple secret is missing/`-`, or default Xcode is below 26. A green release is not proof an ipa shipped. It generates the project (after those gates), then patches the pbxproj to codesign.
+Releases run `scripts/package-and-upload-testflight.sh` (secrets via `setup-testflight-secrets.sh`), path-gated by `release-native.mjs`. Script **soft-skips with exit 0** when `SLICC_SKIP_TESTFLIGHT=1`, an Apple secret is missing/`-`, or default Xcode < 26 (a green release is not proof an ipa shipped). Distribution: `scripts/testflight-distribute.mjs`; [`docs/ios-app-details.md`](../../docs/ios-app-details.md#testflight-distribute).
 
-After upload, `scripts/testflight-distribute.mjs` (gated on `SLICC_TF_EXTERNAL_GROUP`; unset = upload-only) waits for processing, sets What to Test notes (appending `SLICC_TF_DEMO_JOIN_URL`), submits Beta App Review, and attaches the build to that group. **Submission and attach are independent** — only a `fatal` submit aborts; `deferred` (review quota) warns and still attaches, so the build ships once review clears. Tests: `testflight-distribute.test.mjs`.
+## Related
 
-## Related Guides
-
-- `packages/shared-ts/src/tray-sync-protocol.ts` — canonical protocol
-- `packages/webapp/src/scoops/tray-leader-sync.ts` — leader broadcast/respond
-- `packages/webapp/src/scoops/tray-follower-sync.ts` — browser follower
-- `packages/webapp/src/ui/sprinkle-follower-controller.ts` — browser sprinkle renderer
-- `docs/architecture.md` "Multi-Browser Sync (Tray) Architecture"
-- `docs/ios-simulator-qa.md` — live-leader simulator QA
+`packages/shared-ts/src/tray-sync-protocol.ts` (canonical), `packages/webapp/src/scoops/tray-leader-sync.ts`, `packages/webapp/src/scoops/tray-follower-sync.ts`, `packages/webapp/src/ui/sprinkle-follower-controller.ts`; `docs/architecture.md` "Multi-Browser Sync (Tray) Architecture"; `docs/ios-simulator-qa.md`; `docs/ios-app-details.md`.

--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -1,9 +1,10 @@
 # slicc-cli
 
-`slicc` — a headless SLICC **follower** CLI in Go. It joins a leader session over
-the same WebRTC tray-control data channel the browser and iOS followers use, and
-exposes three verbs. It is a **Go module, not an npm workspace** (like
-`packages/ios-app`), so it is built with `go`/`make`, not `npm`.
+`slicc` — headless SLICC **follower** CLI in Go, joining a leader over the
+same WebRTC tray-control data channel as browser + iOS followers. **Go
+module, not an npm workspace** (like `packages/ios-app`) — built with
+`go`/`make`, not `npm`. Deep-dive:
+[`docs/slicc-cli-details.md`](../../docs/slicc-cli-details.md).
 
 ```
 slicc <join-url> prompt "<text>"                Stream one assistant turn, then exit
@@ -16,236 +17,153 @@ slicc list-sessions [--json]                    List iCloud-synced tray sessions
 slicc <verb>-cloud [--index N|--session <id>]   Resolve a session's join URL from iCloud, then run <verb>
 ```
 
-`watch` is a passive `tail -f` on the agent that mirrors the browser thread: it
-sends nothing and renders the human's prompt (`user_message_echo` → `> …`),
-assistant text (`content_delta`), and tool calls (`tool_use_start` → `⚙ …`,
-`tool_result` → `↳ …`), blanking a line at each turn boundary — reconnecting with
-backoff (`cmdWatch`/`watchOnce`; `printWatchEvent` does the rendering). By default
-it does **not** filter by scoop (the cone's `scoopJid` is a generated uid, not the
-literal `"cone"`, and the leader broadcasts the selected scoop — the browser
-view); pass a scoop jid to filter to one.
-
-The `<text>`/`<command>` argument is curl-style: a literal string, `@path` (read a
-file), or `-` / `@-` (read stdin) — so `git log | slicc <url> exec -` and
-`slicc <url> prompt @brief.md` work. Resolution lives in `readTextArg` (main.go)
-and only kicks in for a single `@…`/`-` argument, so multi-word prompts still join
-verbatim.
-
-The trailing argv of `follow` is the **runner** each leader-issued command is handed
-to (command appended as the final arg): `follow bash -c`, `follow sh -c`,
-`follow docker exec -i sandbox sh -c`, a multiplexer, `flatpak-spawn --host …`, etc.
-With no runner, `follow` connects as a plain follower and refuses every command.
+- `watch` — passive `tail -f` mirror; sends nothing, reconnects with backoff.
+  **Does NOT filter by scoop by default** — the cone's `scoopJid` is a
+  generated uid (not `"cone"`); pass a scoop jid to filter. Render map:
+  [details](../../docs/slicc-cli-details.md).
+- `<text>`/`<command>` is curl-style: literal, `@path` (file), `-` / `@-`
+  (stdin) — e.g. `git log | slicc <url> exec -`,
+  `slicc <url> prompt @brief.md`. `readTextArg` (`main.go`) only fires for a
+  single `@…`/`-` arg; multi-word prompts join verbatim.
+- The trailing argv of `follow` is the **runner** — each leader command is
+  appended as the final arg: `follow bash -c`, `follow sh -c`,
+  `follow docker exec -i sandbox sh -c`, a multiplexer,
+  `flatpak-spawn --host …`. **With no runner, `follow` refuses every command.**
 
 ## iCloud tray sessions (`list-sessions`, `<verb>-cloud`)
 
-macOS only. iCloud key-value storage is an Apple API readable only by the signed,
-iCloud-entitled `Sliccstart` launcher, so `internal/cloud` **shells out** to
-`Sliccstart --list-sessions` rather than reading iCloud from Go (which would need
-cgo + entitlement/profile signing and break the `CGO_ENABLED=0` cross-compile).
-`LocateExecutable` finds the app via `$SLICCSTART_APP` → `mdfind` (bundle id
-`com.slicc.sliccstart`) → `/Applications` → `~/Applications`. Off macOS the reader
-returns `ErrUnsupported` and every verb reports it.
+macOS only. `internal/cloud` **shells out** to `Sliccstart --list-sessions`
+(cgo + entitlements would break `CGO_ENABLED=0`); `LocateExecutable` tries
+`$SLICCSTART_APP` → `mdfind` (bundle id `com.slicc.sliccstart`) →
+`/Applications` → `~/Applications`. Off macOS: `ErrUnsupported`.
 
-- `list-sessions [--json]` prints **metadata only** (opaque id, label, device,
-  age) — never a join URL — so it is safe to pipe and log.
-- `<verb>-cloud` (`follow`/`prompt`/`exec`/`watch`) resolves a session's **join
-  URL** with `--reveal-urls`, which prompts for consent on the Mac (denied over
-  SSH until granted once from the screen), then dispatches to the plain verb. The
-  URL is never printed. Selection defaults to the newest session; `--index N` /
-  `--session <id-prefix>` (leading options, consumed by `ParseSelector`) pick
-  another, and the remaining argv passes through verbatim (runner argv / text).
+- `list-sessions [--json]` — **metadata only** (opaque id, label, device,
+  age), **never a join URL** — safe to pipe/log.
+- `<verb>-cloud` (`follow`/`prompt`/`exec`/`watch`) resolves a session's
+  **join URL** via `--reveal-urls` (Mac consent prompt; denied over SSH
+  until granted once from the screen) then dispatches. **URL never printed.**
+  Newest by default; `--index N` / `--session <id-prefix>` (`ParseSelector`)
+  picks another; remaining argv verbatim.
 
 Pure logic (`ParseSessions`, `ParseSelector`, `Select`, `FormatTable`) is
-platform-independent and unit-tested; the exec/locate glue lives in the
-darwin-only `resolve_darwin.go` (not counted by the Linux coverage gate). The
-`cloudList` seam in `cloud.go` is overridden in tests so dispatch is exercised
-without a real launcher.
+platform-independent + unit-tested; darwin-only exec/locate lives in
+`resolve_darwin.go`; the `cloudList` seam in `cloud.go` is overridden in
+tests.
 
 ## Why Go + pion
 
-The follower must speak real WebRTC (SCTP data channel) and interoperate with
-browser leaders + Cloudflare TURN. `github.com/pion/webrtc/v4` is pure Go, so the
-CLI cross-compiles to a single static binary for macOS/Linux/Windows × amd64/arm64
-with `CGO_ENABLED=0` (see the `dist` target). No native toolchain required.
+`github.com/pion/webrtc/v4` is pure Go — the follower cross-compiles to a
+single static binary for macOS/Linux/Windows × amd64/arm64 with
+`CGO_ENABLED=0` (`dist` target). Interoperates with browser leaders +
+Cloudflare TURN. No native toolchain.
 
 ## Layout
 
-| Path                  | Purpose                                                                                                                                     |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `main.go`             | Arg parsing + subcommand dispatch + Ctrl+C handling                                                                                         |
-| `commands.go`         | `prompt` / `exec` / `follow` implementations                                                                                                |
-| `internal/protocol/`  | Wire structs mirroring `packages/shared-ts/src/tray-sync-protocol.ts` (the subset the CLI uses)                                             |
-| `internal/signaling/` | HTTP follower client for `tray-signaling.ts` (attach → poll/answer/ice/retry), ported from the iOS connector                                |
-| `internal/tray/`      | pion peer + `tray-control` data channel + follower state machine (hello, ping/pong, dispatch)                                               |
-| `internal/cloud/`     | iCloud tray-session discovery: parse/select/format (pure) + a darwin-only reader that shells out to `Sliccstart --list-sessions`            |
-| `cloud.go`            | `list-sessions` + the `<verb>-cloud` family (resolve a session's join URL from iCloud, then hand off to the plain verb)                     |
-| `internal/execrun/`   | Cross-platform OS command runner backing `follow` (streams stdout/stderr, forwards signals) + `EvalSession` (persistent-REPL `--eval` mode) |
-| `update.go`           | `cmdUpdate` (`slicc update [--check]`) + the on-launch update-notice hook                                                                   |
-| `telemetry.go`        | `initTelemetry`/`reportRuntimeError` — launch + error RUM beacons via `@ai-ecoverse/go-optel`                                               |
-| `internal/update/`    | Release discovery (sparse-release scan), self-update apply, once-a-day cached notice                                                        |
-| `internal/logging/`   | `log/slog` structured diagnostic logger (text/JSON handler, env-driven level) + the `Logf` adapter the `tray` seam consumes                 |
+`main.go` (argv + dispatch), `commands.go` (`prompt`/`exec`/`follow`),
+`cloud.go` (`list-sessions` + `<verb>-cloud`), `update.go`, `telemetry.go`,
+`internal/{protocol,signaling,tray,cloud,execrun,update,logging}/`. Full
+per-file map: [details](../../docs/slicc-cli-details.md#layout).
 
 ## Protocol parity
 
-`internal/protocol` mirrors a subset of the canonical TS union. The golden corpus
-(`packages/webapp/src/scoops/tray-sync-protocol-corpus.ts` →
+`internal/protocol` mirrors a subset of the canonical TS union. The golden
+corpus (`packages/webapp/src/scoops/tray-sync-protocol-corpus.ts` →
 `packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json`)
-is decoded by `internal/protocol/corpus_test.go` for the message types the CLI
-produces/consumes (`exec.*`, `hello`, `status`), so a wire change that breaks the CLI fails
-`go test`. When the
-tray protocol changes, regenerate the corpus JSON and update the Go structs +
-`corpus_test.go` alongside the TS and Swift mirrors.
+is decoded by `internal/protocol/corpus_test.go` for `exec.*`/`hello`/`status`;
+a wire change breaks `go test`. On protocol changes, regenerate the corpus
+JSON and update Go structs + `corpus_test.go` alongside TS + Swift mirrors.
 
 ## Diagnostics vs user-facing output
 
-Two output paths, deliberately separate:
+- **User-facing** — `prompt`/`exec`/`watch` write leader bytes to stdout,
+  status to stderr. **Never route through the logger**; the CLI is pipeable.
+- **Diagnostics** — signaling retries, supersede redirects, ICE failures,
+  unparseable frames go through `internal/logging` (`log/slog` `diagLogger`
+  in `commands.go`, to stderr); `debugLogf` adapts to `tray.Options.Logf`.
 
-- **User-facing streaming** — `prompt`/`exec`/`watch` write the leader's bytes
-  straight to stdout (and their own status lines to stderr). Never route this
-  through the logger; the CLI is meant to be pipeable.
-- **Diagnostics** — signaling retries, supersede redirects, ICE failures and
-  unparseable frames go through `internal/logging`, a `log/slog` logger built
-  once in `commands.go` (`diagLogger`) and written to stderr. `debugLogf` is the
-  thin `func(format string, args ...any)` adapter that satisfies the existing
-  `tray.Options.Logf` seam, so `internal/tray` keeps its callback-shaped API.
-
-Off by default. Enable with `SLICC_DEBUG=1` (legacy switch, equals
-`SLICC_LOG_LEVEL=debug`) or `SLICC_LOG_LEVEL=debug|info|warn|error`;
-`SLICC_LOG_FORMAT=json` swaps `slog.TextHandler` for `slog.JSONHandler`.
+Off by default. `SLICC_DEBUG=1` (legacy = `SLICC_LOG_LEVEL=debug`) or
+`SLICC_LOG_LEVEL=debug|info|warn|error`; `SLICC_LOG_FORMAT=json` swaps
+`slog.TextHandler` for `slog.JSONHandler`.
 
 ## Exec safety (`follow`)
 
-A `follow` with a runner advertises `hello.capabilities.exec = true`, telling the
-leader it may send `exec.request`. Each command runs as `<runner> <command>` (so
-the runner names — and can sandbox — the exec surface, e.g. a container or a
-restricted shell), as the user who started `slicc`, and is echoed to stderr as it
-runs. A `follow` with **no** runner advertises no capability and refuses every
-`exec.request` with an error response.
-
-Startup ergonomics (all in `commands.go`):
-
-- **Banner** — a small ASCII wordmark + the identity/runner/exec warning prints to
-  stderr on start; `--no-banner` drops the art but keeps the safety warning.
-- **Runner heuristic** (`runnerExecWarning`) — a known shell (`bash`/`sh`/`zsh`/…)
-  or wrapper (`docker`/`podman`/…) without a trailing `-c` warns that the leader's
-  command would be treated as a script FILE, not a command line — the `follow bash`
-  (vs `follow bash -c`) footgun.
-- **MOTD** (`hello.motd`, `followMotd`) — a one-line "who/what/where" summary the
-  follower advertises so the leader surfaces it to the agent via `ssh --list`. The
-  leader captures it in `tray-leader-sync.ts` (`getFollowerMotds`) and, alongside
-  `getBrowserCapableBootstrapIds`, tags followers `[ssh]` / `[playwright]` in
-  `host`. Additive + optional on the wire (browser/iOS peers omit it).
+A `follow` with a runner advertises `hello.capabilities.exec = true`; each
+command runs as `<runner> <command>` (runner sandboxes the exec surface),
+as the user who started `slicc`, echoed to stderr. **A `follow` with no
+runner advertises no capability and refuses every `exec.request` with an
+error.** Banner + safety warning on start (`--no-banner` drops art, keeps
+warning); `runnerExecWarning` flags the `follow bash` vs `follow bash -c`
+footgun; MOTD (`hello.motd`, `followMotd`) surfaces via the leader's
+`ssh --list` (`tray-leader-sync.ts` tags `[ssh]` / `[playwright]` in
+`host`). Additive + optional on the wire.
+[Details](../../docs/slicc-cli-details.md).
 
 ## follow `--eval` (persistent REPL)
 
-`execrun.EvalSession` spawns the runner ONCE and serializes leader commands
-into its stdin as lines; responses are framed by **output quiescence**
-(`--eval-quiet`, default 500 ms) because REPLs never signal completion. The
-session outlives connections AND connection drops — a cancelled per-connection
-context interrupts the in-flight computation (`interruptProcess`, SIGINT to
-the group; no-op on Windows) but never kills the REPL; only `Close` (process
-shutdown) and leader-sent SIGTERM/SIGKILL do. Leader SIGINT likewise
-interrupts without killing (ignored on Windows — a hard kill would destroy
-session state). Late output is forwarded at the head of the next response,
-exec exit codes are always 0 while the REPL lives, `req.Cwd`/`req.Env` are
-ignored, and REPL death marks the session dead (commands then error until
-restart). `follow.NewEvalSession`
-routes `exec.request` into it; the MOTD advertises a REPL target so the
-leader's agent sends language code, not shell. The banner warns about `node`
-without `-i` (it buffers piped stdin until EOF). Tests fake the REPL with a
-self-exec helper process (`TestEvalHelperProcess`) so the suite runs on all
-three CI OSes; the e2e (`TestCLIFollowEvalPersistsState`) proves cross-command
-state over real WebRTC using the platform shell as a line-eval stand-in.
+`execrun.EvalSession` spawns the runner ONCE; responses framed by **output
+quiescence** (`--eval-quiet`, default 500 ms) — REPLs never signal
+completion. **Session outlives connections and drops**: cancelled
+per-connection contexts run `interruptProcess` (SIGINT to the group; no-op
+on Windows) but never kill the REPL; only `Close` and leader-sent
+SIGTERM/SIGKILL do. `req.Cwd`/`req.Env` ignored; exec exit codes 0 while
+REPL lives. `follow.NewEvalSession` routes `exec.request` in; MOTD
+advertises a REPL target. Banner warns about `node` without `-i`.
+[Details](../../docs/slicc-cli-details.md).
 
 ## Self-update (`slicc update`)
 
-`internal/update` scans GitHub releases newest→oldest for the first one carrying
-this platform's `slicc-<os>-<arch>[.exe]` asset — releases are **sparse** (CLI
-binaries only attach when `packages/slicc-cli` changed), so `releases/latest` is
-not enough. The same bounded pagination as the worker's `/download/slicc-cli`
-route (30/page, 5 pages max). `Apply` downloads next to the executable, runs the
-staged binary's `--version` as a sanity gate, then atomically renames over the
-running binary (Windows: parks the old file at `.old`, swept on later runs).
-
-Regular verbs call `startUpdateNotice()` (main-package `update.go`): the upgrade
-notice prints from a local cache (`<user-cache-dir>/slicc/update-check.json`)
-and a background refresh runs at most once per 24 h, bounded-flushed at command
-exit so short verbs still persist it. Disabled via `SLICC_NO_UPDATE_CHECK=1`
-and for any non-release-stamped version (`dev`, `git describe` output) —
-`IsReleaseVersion` gates both the notice and the self-replace, so `slicc
-update` refuses to clobber a local build that is ahead of the latest tag.
-`SLICC_UPDATE_API_BASE` overrides the API base (tests/mirrors).
+`internal/update` scans GitHub releases newest→oldest for the first with
+this platform's `slicc-<os>-<arch>[.exe]` asset — releases are **sparse**
+(CLI binaries only attach when `packages/slicc-cli` changed); same bounded
+pagination as the worker's `/download/slicc-cli` route (30/page, 5 pages
+max). `Apply` downloads, sanity-gates via `--version`, then atomically
+renames over the running binary (Windows parks the old at `.old`).
+`startUpdateNotice()` (`update.go`) refreshes
+`<user-cache-dir>/slicc/update-check.json` at most once per 24 h.
+`SLICC_NO_UPDATE_CHECK=1` disables it; `IsReleaseVersion` gates both notice
+and self-replace, so **`slicc update` refuses to clobber a local build
+ahead of the latest tag** (`dev`, `git describe`). `SLICC_UPDATE_API_BASE`
+overrides the API base. [Details](../../docs/slicc-cli-details.md).
 
 ## Telemetry
 
-`telemetry.go` wires `packages/go-optel` (`github.com/ai-ecoverse/go-optel`, a
-sibling Go module pulled in via a local `replace` directive — this monorepo has
-no `go.work`) into two checkpoints only: `enter` on launch
-(`initTelemetry(sub)`, deferred right after `initTelemetry(sub)()` executes
-immediately in `main.go`'s `run()`) and `error` on an operational failure
-(`reportRuntimeError(source, err)`, called from the dial-error branches in
-`commands.go` and the update-check/apply error branches in `update.go`).
-`source` for `error` beacons is always one of a small fixed set (`dial`,
-`watch`, `follow`, `update`) — never user-typed input (join URL, exec/prompt
-text) — and `classifySubcommand` applies the same allowlist-not-passthrough
-treatment to the `enter` beacon's subcommand name.
+`telemetry.go` wires `packages/go-optel` (sibling Go module via local
+`replace`) into two checkpoints: `enter` on launch (`initTelemetry` from
+`main.go`'s `run()`) and `error` on operational failure
+(`reportRuntimeError(source, err)` from dial-error branches in
+`commands.go` and update-check/apply branches in `update.go`). **`source`
+is always one of a fixed set (`dial`, `watch`, `follow`, `update`) — never
+user-typed input** (join URL, exec/prompt text); `classifySubcommand`
+allowlists the `enter` beacon's subcommand. `SLICC_NO_TELEMETRY=1` opts
+out; `update.IsReleaseVersion(version)` means a `dev`/git-describe build
+never configures a client. See `packages/go-optel/CLAUDE.md` for why
+`Sanitize()` is **mandatory** — CLI error strings can embed a bearer-token
+join URL — and `docs/operational-telemetry.md` ("CLI Telemetry").
 
-Gated the same way as the update notifier: `SLICC_NO_TELEMETRY=1` opts out
-outright, and `update.IsReleaseVersion(version)` means a `dev`/git-describe
-local build never configures a client at all (no env var needed for that
-case). Sampling is one coin flip per process (weight 100 by default,
-`OPTEL_RATE`/`OPTEL_DEBUG` env override), not per checkpoint. See
-`packages/go-optel/CLAUDE.md` for why `Sanitize()` (URL/path redaction before
-truncation) is mandatory here rather than a nice-to-have — this CLI's error
-strings can embed a leader's bearer-token join URL — and
-`docs/operational-telemetry.md` ("CLI Telemetry") for the cross-float design.
-
-## Build / test
+## Build / test / release
 
 ```bash
 make build          # → bin/slicc
-make check          # CI gate: gofmt + tidy-check + go vet + golangci-lint + race tests + coverage floor
-make lint           # golangci-lint run (config in .golangci.yml)
-make tidy-check     # fail when go.mod/go.sum drift from the tree's imports
-make cover          # race tests + total-coverage floor (COVER_MIN, default 58%)
+make check          # CI gate: gofmt + tidy-check + vet + golangci-lint + race + coverage floor
+make lint           # golangci-lint (.golangci.yml)
+make tidy-check     # fail when go.mod/go.sum drift from imports
+make cover          # race tests + COVER_MIN floor (default 58%)
 make test-json      # per-test timings → test-report.json (CI artifact)
 make dist           # cross-compiled static binaries → dist/
 ```
 
-`make test-json` exists only to produce the `test-timings-slicc-cli-<os>` CI
-artifact; it is a separate pass so `test`/`cover` console output stays
-human-readable. There is **no** retry wrapper around the Go suite, deliberately:
-every test in this module is hermetic (no network, no real signaling server — the
-WebRTC integration test drives an in-process leader harness), so a failure is a
-real failure and a retry would only mask it.
+**No retry wrapper**: every test is hermetic. Gates via `make check` in
+the `slicc-cli` CI job: staticcheck/errcheck/unused + funlen/gocyclo/
+gocognit; `make tidy-check` (Go analogue of TS knip); `COVER_MIN` floor.
 
-Gates: `.golangci.yml` (staticcheck/errcheck/unused + funlen/gocyclo/gocognit for
-complexity, matching the TS side's biome complexity gate), `make tidy-check`
-(unused/missing module dependencies — the Go analogue of the TS side's knip run)
-and the `COVER_MIN` coverage floor in the Makefile. All run in the `slicc-cli` CI
-job via `make check`. Release binaries are cut **atomically with the semantic-release flow** and only
-when `packages/slicc-cli/` changed since the last tag. `release-native.mjs`
-(the prepareCmd gate) calls `sign-and-package.sh` when `decideSliccCliGating`
-opens: it cross-compiles every target on the macOS release runner, Developer
-ID-signs + notarizes the two darwin binaries (reusing release.yml's
-`APPLE_CERTIFICATE_BASE64` cert and `APPLE_API_KEY_*` notarytool creds, and the
-`setup-go` toolchain), and stages `artifacts/release/slicc-*` for
-`@semantic-release/github` to attach. A bare CLI binary can't be stapled (only
-`.app`/`.dmg`/`.pkg`), so Gatekeeper verifies the notarization online. With no
-cert (a fork / local run) the binaries build + stage unsigned instead of failing.
-
-**OS matrix:** the follower targets macOS/Linux/Windows, so CI runs `go test ./...`
-on all three (`strategy.matrix.os`) to exercise the real per-OS runtime paths —
-process-group signalling and the `cmd /c` vs `sh -c` runner — that a compile-only
-check would miss. Tests pick the platform shell via a `testRunner()` helper so they
-run rather than skip on Windows; only the genuinely POSIX-specific cases (`sleep` +
-signal delivery) stay `runtime.GOOS == "windows"`-skipped. The static gate
-(`make check`) and cross-compile (`make dist`) run once on Linux — they are
-platform-independent, and the coverage floor would under-count where those cases skip.
-
-`integration_test.go` is the real end-to-end test: it drives the whole follower
-path over an actual WebRTC connection (pion ↔ pion on loopback) — a leader peer
-creates the `tray-control` channel, a mock signaling server bridges the SDP/ICE
-exchange to `tray.Dial`, and the leader issues an `exec.request` that the follow
-session runs locally and streams back. Deterministic (no browser, no TURN), so it
-runs in the normal `go test` gate.
+Release binaries cut **atomically with semantic-release** and only when
+`packages/slicc-cli/` changed since the last tag: `release-native.mjs`
+(prepareCmd gate) invokes `sign-and-package.sh` when `decideSliccCliGating`
+opens, cross-compiling every target on the macOS runner, Developer
+ID-signing + notarizing the darwin binaries (`APPLE_CERTIFICATE_BASE64` +
+`APPLE_API_KEY_*`), staging `artifacts/release/slicc-*` for
+`@semantic-release/github`. **A bare CLI binary can't be stapled**;
+Gatekeeper verifies notarization online. Without cert (fork/local): stages
+unsigned instead of failing. Full pipeline + OS-matrix rationale
+(`testRunner()`, `integration_test.go` pion↔pion loopback):
+[details](../../docs/slicc-cli-details.md).

--- a/packages/swift-launcher/CLAUDE.md
+++ b/packages/swift-launcher/CLAUDE.md
@@ -1,10 +1,6 @@
 # CLAUDE.md
 
-This file covers the native macOS launcher in `packages/swift-launcher/`.
-
-## Scope
-
-`Sliccstart` is a SwiftUI launcher that finds supported browsers, Electron apps, and terminal emulators, starts the right SLICC runtime, and helps create debug-friendly Electron builds when needed.
+Native macOS launcher `Sliccstart` in `packages/swift-launcher/`. SwiftUI app: finds browsers, Electron apps, and terminals; starts the right SLICC runtime; creates debug-friendly Electron builds. Deep reference: [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md).
 
 ## Build and Test Commands
 
@@ -18,194 +14,81 @@ npm run lint -w @slicc/swift-launcher   # SwiftLint
 ./sign-and-package.sh
 ```
 
-## Linting
+## Linting and Formatting
 
-`packages/swift-launcher/.swiftlint.yml` inherits the shared rule set from the
-repo-root `.swiftlint.yml` (via `parent_config`) and excludes this package's
-`.build`. Warnings surface code-quality issues; only `error`-severity violations
-fail CI. Run `npm run lint:fix -w @slicc/swift-launcher` to auto-correct fixable
-violations.
-
-## Formatting
-
-SwiftLint is a linter, not a formatter. Formatting is `swift format` (bundled with
-the Swift 6+ toolchain) against the single repo-root `.swift-format`; swift-format
-resolves its config by walking up from each input file, so there is no per-package
-copy to keep in sync.
+`.swiftlint.yml` inherits repo-root `.swiftlint.yml` via `parent_config` and excludes `.build`; only `error`-severity violations fail CI. Auto-fix: `npm run lint:fix -w @slicc/swift-launcher`. Formatting is `swift format` (Swift 6+) against the single repo-root `.swift-format`.
 
 ```bash
 npm run lint:format -w @slicc/swift-launcher   # swift format lint --strict (CI gate)
 npm run format -w @slicc/swift-launcher        # swift format --in-place
 ```
 
-## Main Package Layout
+## Layout
 
-- `Sliccstart/` — SwiftUI app entry, models, and views
-- `SliccstartTests/` — package tests
-- `assemble-app.mjs` — assembles the `.app` bundle from compiled binaries
-- `sign-and-package.sh` — signing/packaging helper
-
-## App Overview
-
-- `SliccstartApp.swift` boots the launcher UI.
-- `Models/AppScanner.swift` finds Chromium browsers and CDP-capable desktop apps.
-- `Models/SliccBootstrapper.swift` and `Models/SliccProcess.swift` handle runtime launch and lifecycle.
-- `Views/` contains the launcher UI and setup/progress views.
+`Sliccstart/` — SwiftUI app (`SliccstartApp.swift` boots UI; `Models/AppScanner.swift` finds Chromium/CDP apps; `Models/SliccBootstrapper.swift` + `Models/SliccProcess.swift` handle launch/lifecycle; `Views/`). `SliccstartTests/` — tests. `assemble-app.mjs` — assembles `.app` bundle. `sign-and-package.sh` — signing/packaging.
 
 ## Operational Telemetry (OpTel)
 
-Sliccstart depends on `@slicc/swift-optel` and wires `.optelAutoInstrument(appID:)` once on the `WindowGroup` root in `SliccstartApp.swift`. On macOS that single call activates the full RUM surface: `enter` (launch + foreground), global `click` (app-level `NSEvent` monitor → `NSAccessibility`-derived `source`), `navigate` (key/main-window changes + new Settings window), and `error` (uncaught `NSException`). No per-control plumbing is needed in the launcher views.
+`SliccstartApp.swift`'s `WindowGroup` root calls `.optelAutoInstrument(appID:)` from `@slicc/swift-optel` once; on macOS that activates `enter`, global `click`, `navigate`, and `error` (uncaught `NSException`). `appID = Bundle.main.bundleIdentifier` (`com.slicc.sliccstart`); beacons land in `helix-225321.helix_rum.cluster`.
 
-The `appID` is sourced from `Bundle.main.bundleIdentifier` (`com.slicc.sliccstart`); RUM beacons land in `helix-225321.helix_rum.cluster` filtered by that hostname. The opt-in per-view modifiers (`.optelView`, `.optelTap`, `OptelButton`) remain available for finer-grained `source` quality.
+Swift errors are values and cannot be intercepted globally, so `do/catch` boundaries report through **`Models/LauncherErrorReport.swift`**. `source = sliccstart:<operation>` is a wire contract (RUM filters on `Operation` enum strings). `target` is **redacted**: URLs → `<url>`, paths → `<path>`, `token`/`secret`/`password`/`key` → `<redacted>`. **Never report `AUError.cancelled`** — that is the normal up-to-date outcome.
 
-`.optelAutoInstrument`'s `error` hook only catches Objective-C `NSException`s — Swift errors are values and cannot be intercepted globally — so the launcher's `do/catch` boundaries report through **`Models/LauncherErrorReport.swift`**:
-
-- `LauncherErrorReport.report(.<operation>, error)` emits an `error` checkpoint with `source = sliccstart:<operation>` (see the `Operation` enum: `update-check`, `update-detach`, `bootstrap`, `bootstrap-update`, `launch-standalone`, `launch-electron`, `auto-launch`, `debug-build`, `terminal-follower`, `reattach`, `secrets-unlock`, `secrets-persist`). Dashboards filter on these strings, so treat them as a wire contract.
-- `target` is the bridged error domain plus its description, **redacted** before it leaves the machine: URLs collapse to `<url>` (a join URL carries the session secret), absolute paths to `<path>` (home reveals the user name), `token`/`secret`/`password`/`key` values to `<redacted>`, whitespace collapses, and the result truncates to `maxTargetLength`.
-- Add a new call site together with an `Operation` case and a `log.error` line; never report the up-to-date outcome of an update check (`AUError.cancelled`), which is a normal result rather than a fault.
-- `Optel.sample` no-ops until `.optelAutoInstrument` has configured a session, so reporting from a failure that happens before instrumentation mounts (or from a unit test) is safe.
-
-Key launcher controls carry stable `.accessibilityIdentifier` values (`get-extension`, `rescan`, `check-for-updates`, `restart-to-update`, `update`, `app-row-<Name>`) so RUM `click` sources stay readable across releases.
+Key controls carry stable `.accessibilityIdentifier` values (`get-extension`, `rescan`, `check-for-updates`, `restart-to-update`, `update`, `app-row-<Name>`).
 
 ## App Scanning
 
-- Known Chromium browsers are discovered by bundle ID.
-- `/Applications` is scanned for Electron or WebView2-style app bundles with CDP-capable frameworks.
-- `~/Applications` is scanned first for `* Debug.app` builds so patched debug builds win over originals.
-- Terminal.app, iTerm2, Ghostty, WezTerm, kitty, and Alacritty are discovered by bundle ID. Installed terminals appear in a **Terminals** category between **Desktop Apps** and **Extension**.
+Chromium browsers by bundle ID; `/Applications` for Electron/WebView2 bundles with CDP frameworks; `~/Applications` scanned first so `* Debug.app` wins over originals; Terminal.app, iTerm2, Ghostty, WezTerm, kitty, Alacritty by bundle ID.
 
 ## Terminal Followers
 
-Terminal rows attach the selected terminal to the current leader through `slicc <join-url> follow`. They remain disabled until `leaderJoinUrl` is known and never auto-start a leader. The first launch warns that the leader can run commands on this machine; the user can persist suppression or reset it in Settings.
+Terminal rows attach the selected terminal to the current leader via `slicc <join-url> follow`. **Disabled until `leaderJoinUrl` is known; never auto-start a leader.**
 
-The **Terminals** Settings tab persists these `UserDefaults` keys:
+`SliccCliLocator` order: managed `~/Library/Application Support/Sliccstart/bin/slicc`, repo `make build`, arch-specific `make dist`, `/usr/local/bin`, `~/.local/bin`, `/opt/homebrew/bin`. **The CLI is never bundled in `Sliccstart.app`.** If none is found, the launcher **asks before** downloading from `https://www.sliccy.ai/download/slicc-cli/darwin-<arch>`, validates Developer ID signature and team `S8LB56P782` before making executable, then atomically installs. Bare Mach-Os carry no stapled ticket — see [`docs/pitfalls.md`](../../docs/pitfalls.md) § "Downloaded `slicc` CLI".
 
-- `terminalFollowCommand` — user-editable template with `{slicc}`, `{joinUrl}`, and `{shell}` placeholders; the default is `{slicc} {joinUrl} follow {shell} -c`.
-- `suppressTerminalWarning` — one-time access-warning suppression.
-
-`{shell}` is the login shell from the password database (`getpwuid`), falling back to `/bin/zsh`. The Settings preview always redacts the join URL.
-
-`SliccCliLocator` resolves an executable in this order: the managed `~/Library/Application Support/Sliccstart/bin/slicc`, the repository's local `make build` output, its architecture-specific `make dist` output, then `/usr/local/bin`, `~/.local/bin`, and `/opt/homebrew/bin`. The CLI is never bundled in `Sliccstart.app`. If none is found, the launcher asks before downloading the current Darwin release from `https://www.sliccy.ai/download/slicc-cli/darwin-<arch>`, validates its Developer ID Application signature and release team identifier (`S8LB56P782`) before making it executable or running `--version`, then atomically installs it in the managed location. A successful terminal launch exposes that managed binary through `~/.local/bin/slicc`; the best-effort symlink step preserves regular files and unrelated user symlinks, and only re-points stale links under Sliccstart's own Application Support root.
-
-Release Darwin binaries are signed and notarized, but a bare Mach-O gets no stapled ticket: [`docs/pitfalls.md`](../../docs/pitfalls.md) § "Downloaded `slicc` CLI" covers why Sliccstart neither strips quarantine nor trusts `spctl`.
-
-Terminal.app and iTerm2 launch through Apple Events. `assemble-app.mjs` supplies the user-facing usage description, and `sign-and-package.sh` signs the outer app with `Sliccstart.entitlements`, including `com.apple.security.automation.apple-events`. A TCC denial is surfaced with a direct path to the Sliccstart controls in System Settings → Privacy & Security → Automation.
+Terminal.app and iTerm2 launch through Apple Events; `sign-and-package.sh` signs with `Sliccstart.entitlements` including `com.apple.security.automation.apple-events`.
 
 ## iCloud Sync (Tray Sessions)
 
-Cross-device discovery of active tray join URLs. Shared models
-(`SyncedTraySession`, `TraySessionSyncStore`, `SessionReachability`) live in
-**`packages/swift-traysession`**; its `CLAUDE.md` documents storage, TTL, and tests.
+Shared models in **`packages/swift-traysession`**. **Secret-bearing join URLs sync only through same-Apple-ID, encrypted iCloud KVS.** `SessionReachability` follows bounded `TRAY_SUPERSEDED` chains; only HTTP 200 with `leader.connected == true` is live. `SliccstartApp` publishes non-nil `leaderJoinUrl` (refreshes every 4 h); clean quit withdraws, update/detach does not. Coverage: `TraySessionLauncherTests`.
 
-`SessionReachability` follows bounded `TRAY_SUPERSEDED` chains; only terminal
-HTTP 200 with `leader.connected == true` is live. Replacement URLs stay private.
+**Headless CLI (`Sliccstart --list-sessions`)** — parsed in `main.swift` **before** SwiftUI boots. Prints JSON, **metadata only** (`joinUrl` redacted). `--reveal-urls` gates behind `NSAlert`; headless/SSH callers **denied** (exit 3). Pure logic in `Models/TraySessionCLI.swift`; glue in `TraySessionCLIRunner`.
 
-- **Producer** — `SliccstartApp` publishes non-nil `leaderJoinUrl`, withdraws
-  when cleared, and refreshes every 4 hours. Clean quit withdraws; update/detach
-  does not because the browser survives and relaunch republishes.
-- **Consumer** — `AppListView` probes remote rows on section appearance/store
-  reload and stably sorts live/unprobed first. Unreachable rows use
-  `icloud.slash`, `· not responding`, 0.55 opacity, and disable Attach/Follow,
-  not Copy; local rows skip probing. Remote Follow passes a join URL override;
-  Attach-browser uses `launchBrowserFollower`.
-- **Security** — secret-bearing join URLs sync only through same-Apple-ID,
-  encrypted iCloud KVS. `TraySessionLauncherTests` covers row state and Follow.
+## App Ordering, Browser Followers, Startup
 
-### Headless CLI (`Sliccstart --list-sessions`)
-
-The iCloud store is readable only by this signed, iCloud-entitled binary, so the
-Go `slicc` CLI shells out to a subcommand parsed in `main.swift` **before** the
-SwiftUI app boots (`TraySessionCLI.parse` returns `nil` for a normal launch).
-`--list-sessions` prints active sessions as JSON, **metadata only** (`joinUrl`
-redacted). `--reveal-urls` adds `joinUrl` behind a **consent gate**: a remembered
-"Always" (`UserDefaults`, keyed by caller code-signing id / path) wins; else an
-`NSAlert` (Deny / Allow Once / Always Allow / Always Deny) shows in a GUI session
-and a headless/SSH caller is **denied** (exit 3). Pure logic in
-`Models/TraySessionCLI.swift` is unit-tested (`TraySessionCLITests`); untestable
-glue (NSAlert, `getppid`/`proc_pidpath`/`SecCode`, store read) sits in
-`TraySessionCLIRunner`. Caller identity is spoofable, so redaction-by-default is
-the real control and the dialog a speed bump.
-
-## App Ordering, Browser Followers, and Startup
-
-- `Models/AppOrdering.swift` — pure default ordering (`browserBundlePriority`
-  market-share, `terminalBundlePriority` power-user-first); a user drag-reorder
-  persists via `AppOrderStore` (UserDefaults `browserOrder`/`terminalOrder`,
-  bundle-id arrays) and wins. `AppTarget.bundleId` (populated by `AppScanner`;
-  `nil` for CDP-sniffed electron apps) is the ordering/matching key.
-  `AppListView` drag-reorders via the `ReorderableRow` modifier
-  (`.onDrag`/`.onDrop`), keyed off the on-screen order so newly installed apps
-  are draggable too.
-- **Browser as follower** — `browserFollowerArgs(cdpPort:joinUrl:)` passes
-  `--join=<url>` (vs `--lead`). `launchBrowserFollower` flags the record
-  `isFollower`, excluding it from `isLeaderReady`, `leaderTargetName`,
-  leader-URL clearing, and reattach. Clicking a browser with remote sessions
-  opens a lead-vs-attach dialog; with none it launches standalone.
-- **Startup** — `Models/StartupPreference.swift`: the `launchBrowserAtStartup`
-  checkbox replaces the per-browser picker; `resolveEnabled(defaults:)` migrates
-  legacy `autoLaunchAppId` once; launch starts the **top** ordered browser
-  (`AppOrdering.topBrowser`, shared with the link handler).
-- Tests: `AppOrderingTests`, `StartupPreferenceTests`, `SliccProcessLaunchArgsTests`.
+`Models/AppOrdering.swift` (default `browserBundlePriority`/`terminalBundlePriority`; user drag-reorder via `AppOrderStore` UserDefaults wins). `browserFollowerArgs(cdpPort:joinUrl:)` passes `--join=<url>` vs `--lead`; `launchBrowserFollower` flags `isFollower`. `Models/StartupPreference.swift`: launch starts top-ordered browser (`AppOrdering.topBrowser`). Tests: `AppOrderingTests`, `StartupPreferenceTests`, `SliccProcessLaunchArgsTests`.
 
 ## Default Browser Role
 
-Sliccstart can hold the macOS http/https handler role (Settings → Startup).
-`Models/DefaultBrowserRegistration.swift` claims it, `assemble-app.mjs`'s
-`CFBundleURLTypes` is the precondition, and `Models/IncomingURLRouter.swift`
-opens each link `application(_:open:)` receives as a tab in the leader browser
-over CDP, starting it first when none runs. See
-[`docs/sliccstart-browser.md`](../../docs/sliccstart-browser.md).
+Sliccstart can hold the macOS http/https handler role (Settings → Startup). `Models/DefaultBrowserRegistration.swift` claims it; `assemble-app.mjs`'s `CFBundleURLTypes` is the precondition; `Models/IncomingURLRouter.swift` opens each link over CDP. See [`docs/sliccstart-browser.md`](../../docs/sliccstart-browser.md).
 
-### iCloud provisioning (Developer ID app)
+## iCloud Provisioning (Developer ID app)
 
-Sync needs an iCloud KVS entitlement backed by an _embedded_ provisioning
-profile (Developer ID signing alone does not authorize iCloud).
-`sign-and-package.sh` gates on optional **`PROVISION_PROFILE`**: **unset** signs
-`Sliccstart.entitlements` only and `NSUbiquitousKeyValueStore` degrades to a
-local cache; **set** embeds the profile and signs a merged file (base +
-`ubiquity-kvstore-identifier`). CI decodes `APPLE_MACOS_PROVISIONING_PROFILE_BASE64`
-and exports `PROVISION_PROFILE` and `KVSTORE_IDENTIFIER` (default
-`${APPLE_TEAM_ID}.com.slicc.sliccstart`; releases ship `S8LB56P782.ai.sliccy.trays`,
-which the iOS follower must match). Signing contract: `macos-permissions.test.mjs`.
+Sync needs an iCloud KVS entitlement backed by an _embedded_ provisioning profile — **Developer ID signing alone does not authorize iCloud.** `sign-and-package.sh` gates on optional **`PROVISION_PROFILE`**: unset → signs `Sliccstart.entitlements` only, `NSUbiquitousKeyValueStore` degrades to a local cache; set → embeds the profile and signs a merged file. CI exports `PROVISION_PROFILE` and `KVSTORE_IDENTIFIER` (releases ship `S8LB56P782.ai.sliccy.trays`, **which the iOS follower must match**). Signing contract: `macos-permissions.test.mjs`.
 
 ## Debug Build Creation
 
-`Models/DebugBuildCreator.swift` creates Electron debug builds by:
-
-1. copying the app into `~/Applications/<Name> Debug.app`
-2. patching Electron fuses to allow remote debugging
-3. unpacking and patching `app.asar` JavaScript checks that block CDP
-4. ad-hoc signing the copied app
-5. removing quarantine attributes
-
-Use this path when an Electron app disables remote debugging in production builds.
+`Models/DebugBuildCreator.swift` creates Electron debug builds by: (1) copying into `~/Applications/<Name> Debug.app`, (2) patching Electron fuses for remote debugging, (3) unpacking/patching `app.asar` JS checks that block CDP, (4) ad-hoc signing, (5) removing quarantine attributes. Use when an Electron app disables remote debugging in production.
 
 ## Packaging Notes
 
-- `npm run build` assembles the `.app` bundle for manual testing from already-built artifacts.
-- `sign-and-package.sh` is the packaging path for distributable artifacts.
-- When running from inside the repo, the launcher expects the Swift server binary (`packages/swift-server/.build/release/slicc-server`) to already be built by the root-level tooling. The webapp is **not** bundled — the UI loads from the hosted origin, so `assemble-app.mjs` creates an empty `Contents/Resources/slicc` marker dir (which `SliccBootstrapper.resolveBundledSliccDir` still keys bundled-mode detection off of) instead of copying `dist/ui`.
-- **`WebRTC.framework` ships next to `slicc-server`** (its `@rpath`/`@loader_path`): `assemble-app.mjs` copies it in, `sign-and-package.sh` re-signs it innermost-first — else dyld fails and every spawned server dies as "start failed".
-- The **one** web artifact still embedded is the Electron overlay bootstrap. `copy-overlay-entry.mjs` copies `dist/ui/electron-overlay-entry.js` into `Contents/Resources/slicc/dist/ui/` so packaged `slicc-server --electron` loads the real overlay instead of its inline fallback. That file is produced by **`@ai-ecoverse/spoon`** (`npm run build -w @ai-ecoverse/spoon`), so it must be built before `assemble-app.mjs` runs — and a `packages/spoon/**` change is what re-triggers this job in CI (not a general webapp change).
-- Packaging emits only the full `Sliccstart-<v>.zip`. There is no webapp-only smooth-update pair anymore.
+- `npm run build` assembles the `.app` from pre-built artifacts; `sign-and-package.sh` is the distributable path.
+- Expects `packages/swift-server/.build/release/slicc-server` to be pre-built. Webapp is **not** bundled — `assemble-app.mjs` writes an empty `Contents/Resources/slicc` marker dir.
+- **`WebRTC.framework` ships next to `slicc-server`**: `sign-and-package.sh` re-signs **innermost-first** — else dyld fails and every spawned server dies as "start failed".
+- Electron overlay bootstrap `dist/ui/electron-overlay-entry.js` is produced by **`@ai-ecoverse/spoon`** (`npm run build -w @ai-ecoverse/spoon`) and must be built before `assemble-app.mjs`; a `packages/spoon/**` change re-triggers this CI job.
+- Packaging emits only the full `Sliccstart-<v>.zip`.
 
 ## Updates
 
-Updates are **full-app-only**, driven by the external `AppUpdater` SPM package (`import AppUpdater`). The launcher no longer ships a webapp-only "smooth update" path — with local UI serving removed (the UI loads from the hosted origin), there is nothing to hot-swap, so `UpdateManifest`, `RunningAppHashes`, `WebappOverlayStore`, `SmoothUpdateCoordinator`, and the `--probe-update` probe were all removed.
+**Full-app-only**, driven by external `AppUpdater` SPM package. `SliccstartApp.swift` owns an `AppUpdater` `@StateObject`; `checkForUpdates()` records outcome in `UpdateCheckStatus`. On `.downloaded`, `AppListView.fullUpdateButton` surfaces `restart-to-update` → `appUpdater.install(bundle)`. The 2 s timer polls `/api/agent-activity`; `AgentActivityProbe` fails open after 1 s.
 
-- `SliccstartApp.swift` owns an `AppUpdater` `@StateObject` and drives every check through `checkForUpdates()`, which records the outcome in `UpdateCheckStatus` and logs it. When a newer release is downloaded, `appUpdater.state` becomes `.downloaded` and `AppListView.fullUpdateButton` surfaces the `restart-to-update` action that calls `appUpdater.install(bundle)`.
-- While an update is ready, the two-second timer polls each live server's `/api/agent-activity`. `AgentActivityProbe` fails open after one second; activity makes the restart action grey instead of green.
-- `Models/UpdateCheckStatus.swift` — the footer's report on the last check (`idle`, `checking`, `upToDate`, `noInstallableRelease`, `translocated`, `failed(message)`). `AppUpdater` hands every failure to a callback and otherwise only publishes a downloaded bundle, so without this a rate-limited or asset-less check was indistinguishable from "never checked" and the footer just kept offering "Check for Updates". `AUError.cancelled` maps to `upToDate` (that is how `findViableUpdate` says "nothing newer"), `AppUpdater.Error.noValidUpdate` to `noInstallableRelease`. `AppUpdater` stages its download next to `Bundle.main.bundleURL` before it ever hits the network, so a translocated launch (Gatekeeper copies an unmoved, quarantined `.app` to a read-only synthetic volume under `.../T/AppTranslocation/...`) fails every check with Cocoa's `NSFileWriteVolumeReadOnlyError`; that specific code maps to `translocated` instead of the raw OS error text so the footer tells the user to move the app to `/Applications`.
-- `Models/UpdateHostConfiguration.swift` — parses `--update-host=<url>` argument or `SLICC_UPDATE_HOST` env, defaulting to `https://api.github.com`. `AppUpdater`'s releases listing routes through it.
-- `Models/TolerantGithubReleaseProvider.swift` — the release provider used by `AppUpdater`; tolerates release-naming drift in the `ai-ecoverse/slicc` release history. It also filters out releases lacking an installable macOS asset (`Sliccstart-<version>.zip`/`.tar`), so `AppUpdater` falls back to the newest release that actually ships a binary (needed now that native artifacts are conditionally built). Because the repo releases many times a day while the macOS artifact is built only on `packages/swift-launcher/**` changes, the newest installable release routinely sits beyond the default 30-release page: the provider requests `per_page=100` and follows the RFC 8288 `Link: rel="next"` chain (same host, HTTP(S) only) until a page yields a viable release **or reaches `currentVersion`** — the release the running build came from, since nothing older can ever be an update. "Reached" is not "saw an older tag": `/releases` is creation-ordered, so a backport published after a newer release, or a non-semver tag decoding to `Version.null`, would otherwise stop page one and hide the installable release further back. `hasReached(_:on:)` therefore stops only when the page carries the running build's own version or when every _parsed_ release on it is older, ignoring unparsable tags. `maxReleasePages` is only a loop guard for a host whose `Link` chain never terminates, not the intended stop. `currentVersion` defaults to `Bundle.main.version` (the same value `AppUpdater` compares against) and `fetchPage` injects a stub transport; both are pinned in tests because the XCTest host bundle's version is unrelated to the release history.
-- `Models/LaunchRecordStore.swift` — persisted `PersistedLaunchRecord` JSON (servePort, CDP port, electronAppPath, target name, target type, joinUrl, bridgeToken) at `~/Library/Application Support/Sliccstart/launch-records.json`, plus `CDPLiveProbe` for liveness checks via `/json/version`. No PID is stored — process identity isn't needed for reattach because the CDP port answering `/json/version` is what we use to decide whether the previous browser is still alive. The `bridgeToken` is persisted because the surviving browser tab carries it in its launch URL (`?bridgeToken=<token>`); reattach re-forwards the SAME token so the re-spawned `--serve-only` slicc-server keeps gating `/cdp` against the secret the tab already has, instead of a freshly-minted static one. (Legacy records carrying a `staticRoot` key still decode; the extra key is ignored, and a missing `bridgeToken`/`joinUrl` key loads as nil.)
-- `Models/SliccProcess.swift` extensions: `detachAll()` and `reattachPersistedRecords()`. The launcher only ever spawns thin-bridge `slicc-server` processes — no `--static-root` / overlay plumbing.
+- `Models/UpdateCheckStatus.swift` — `idle`, `checking`, `upToDate`, `noInstallableRelease`, `translocated`, `failed(message)`.
+- `Models/UpdateHostConfiguration.swift` — `--update-host=<url>` / `SLICC_UPDATE_HOST` (default `https://api.github.com`).
+- `Models/TolerantGithubReleaseProvider.swift` — filters releases lacking `Sliccstart-<version>.zip`/`.tar`; `per_page=100`; follows RFC 8288 `Link: rel="next"` (same host, HTTP(S) only) until viable release or `currentVersion`.
+- `Models/LaunchRecordStore.swift` — `PersistedLaunchRecord` JSON at `~/Library/Application Support/Sliccstart/launch-records.json` + `CDPLiveProbe` (`/json/version`). **No PID stored.** `bridgeToken` persisted so reattach re-forwards the same secret the surviving tab has.
+- `Models/SliccProcess.swift`: `detachAll()`, `reattachPersistedRecords()`. **The launcher only ever spawns thin-bridge `slicc-server` — no `--static-root` / overlay plumbing.**
 
 ## Update Tests
 
-- `SliccstartTests/UpdateHostConfigurationTests.swift` — unit coverage for `--update-host` / `SLICC_UPDATE_HOST` parsing and defaulting.
-- `SliccstartTests/UpdateCheckIntegrationTests.swift` — integration tests that hit the **real GitHub API** (via `TolerantGithubReleaseProvider`) to catch release-naming drift a frozen fixture could not, including a `per_page=1` walk that proves the `Link: rel="next"` pagination reaches an installable release. They share a single authenticated call (`GH_TOKEN`, set by `ci.yml` from `${{ github.token }}`) to stay inside the rate budget; without a token — or with an **empty** one — they fall back to the unauthenticated path and may flake under contention.
-- `SliccstartTests/ReleaseFetchPaginationTests.swift` — stubbed-transport coverage for the paginated walk: follows `Link` headers until a viable release appears, stops on the first page that has one, stops at the page holding the running build's release, keeps auth on every page, honours the page budget, and rejects off-host or non-HTTP(S) `rel="next"` targets.
-- `SliccstartTests/UpdateCheckStatusTests.swift` — error-to-status mapping so no check outcome can be swallowed silently.
-- `SliccstartTests/AgentActivityProbeTests.swift` — aggregation and fail-open tests.
-- `SliccstartTests/LauncherErrorReportTests.swift` — RUM beacon contract: stable `source` keys and the redaction/truncation rules applied to `target`.
+`UpdateHostConfigurationTests.swift`, `UpdateCheckIntegrationTests.swift` (real GitHub API — needs `GH_TOKEN` from `${{ github.token }}` in `ci.yml`), `ReleaseFetchPaginationTests.swift`, `UpdateCheckStatusTests.swift`, `AgentActivityProbeTests.swift`, `LauncherErrorReportTests.swift`.
+
+Deep reference for every section above: [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md).

--- a/packages/swift-server/CLAUDE.md
+++ b/packages/swift-server/CLAUDE.md
@@ -1,20 +1,18 @@
 # CLAUDE.md
 
-This file covers the native macOS server in `packages/swift-server/`.
+Native macOS server in `packages/swift-server/`.
 
 ## Scope
 
-`packages/swift-server/` is a Hummingbird-based standalone server that launches Chrome/Electron, proxies CDP, exposes the lick WebSocket/event surface, and owns the `/api` bridge surface (fetch-proxy, sign-and-forward, OAuth callback, secrets). It serves **no** UI in any mode (matching node-server, see below): the launched Chrome/Electron always loads the hosted webapp. There is no `--dev` flag and no bundled `dist/ui` static serving.
+`packages/swift-server/` is a Hummingbird standalone server: launches Chrome/Electron, proxies CDP, exposes the lick WebSocket/event surface, and owns the `/api` bridge (fetch-proxy, sign-and-forward, OAuth callback, secrets). Serves **no** UI in any mode (matching node-server). No `--dev` flag, no bundled `dist/ui`.
 
 ## Thin-bridge parity
 
-Swift-server and `packages/node-server/` are byte-for-byte compatible bridges. With the breaking thin-extension release the launched Chrome/Electron pages load the hosted webapp from `https://www.sliccy.ai` (or `http://localhost:8787` for the wrangler dev harness) with the local bridge attached via `?bridge=ws://localhost:<cdpPort>/cdp&bridgeToken=<token>` (or `/electron?...&role=leader|follower` for Electron pages). `CDPProxy.swift` echoes the `slicc.bridge.v1.<token>` Sec-WebSocket-Protocol per RFC 6455, matching node-server's `Sec-WebSocket-Protocol` handling — the webapp's `CDPClient` uses the same subprotocol regardless of bridge implementation. See [`docs/architecture.md` §Thin-Bridge Architecture](../../docs/architecture.md#thin-bridge-architecture) for the cross-bridge contract.
+Swift-server and `packages/node-server/` are byte-for-byte compatible bridges. Chrome/Electron pages load the hosted webapp (`https://www.sliccy.ai` or `http://localhost:8787` in wrangler dev) with local bridge via `?bridge=ws://localhost:<cdpPort>/cdp&bridgeToken=<token>` (Electron: `/electron?...&role=leader|follower`). `CDPProxy.swift` echoes `slicc.bridge.v1.<token>` per RFC 6455. See [`docs/architecture.md`](../../docs/architecture.md#thin-bridge-architecture).
 
-Both launchers also disable Local Network Access checks on every launch: `ChromeLauncher.buildLaunchArgs` (`Sources/Browser/ChromeLauncher.swift`) appends `--disable-features=LocalNetworkAccessChecks,LocalNetworkAccessChecksWebSockets`, matching node-server's `buildChromeLaunchArgs`. Chromium 142+ gates the hosted-UI (sliccy.ai) → local-bridge hop (public→local) behind an "Apps on device" permission prompt; without the flag a Deny silently breaks CDP + `/api/*` (provider config/login). See [`docs/pitfalls.md` — Local Network Access](../../docs/pitfalls.md).
+Both launchers disable Local Network Access checks: `ChromeLauncher.buildLaunchArgs` (`Sources/Browser/ChromeLauncher.swift`) appends `--disable-features=LocalNetworkAccessChecks,LocalNetworkAccessChecksWebSockets`. Chromium 142+ gates the hop behind an "Apps on device" prompt; Deny silently breaks CDP + `/api/*`. See [`docs/pitfalls.md`](../../docs/pitfalls.md).
 
-The Electron overlay (`Sources/Browser/ElectronLauncher.swift`) is **thin-bridge only** — the legacy bundled-UI overlay served from `http://localhost:<servePort>/electron` (Path A) was retired, matching node-server's `electron-controller.ts`. `ElectronOverlayInjector`'s production initializer requires a `ThinBridgeConfig`; the hosted-leader origin defaults to production (`resolveHostedLeaderOrigin`), so the only unresolvable case is a missing per-process bridge token — `ServerCommand` then logs a clear error and skips the injector (fail fast) instead of serving a bundled overlay.
-
-The overlay **bootstrap bundle** (`window.__SLICC_ELECTRON_OVERLAY__.inject()`) is **embedded at build time**: `loadOverlayBundleSource()` reads `dist/ui/electron-overlay-entry.js` from the packaged `Contents/Resources/slicc/` (falling back to a minimal inline stub if absent). That single artifact is produced by the small **`@ai-ecoverse/spoon`** package (`node packages/spoon/build.mjs`), NOT the webapp — `swift-launcher`'s `assemble-app.mjs` (`copy-overlay-entry.mjs`) copies it into the `.app`, and CI builds only spoon (a fast, webapp-free esbuild) before assembly. This is why a `packages/spoon/**` change re-triggers the macOS `swift-launcher` job while a general webapp UI change does not. node-server reads the same `dist/ui/electron-overlay-entry.js` from disk (`getElectronOverlayEntryDistPath`).
+The Electron overlay (`Sources/Browser/ElectronLauncher.swift`) is **thin-bridge only**; the legacy `http://localhost:<servePort>/electron` (Path A) bundled overlay was retired. Bootstrap `window.__SLICC_ELECTRON_OVERLAY__.inject()` is embedded from `dist/ui/electron-overlay-entry.js` (in `Contents/Resources/slicc/`), built by `@ai-ecoverse/spoon` (`node packages/spoon/build.mjs`); node-server reads the same file. Internals: [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
 
 ## Build and Test Commands
 
@@ -26,130 +24,85 @@ swift run slicc-server --help
 npm run lint -w @slicc/swift-server   # SwiftLint
 ```
 
-## Linting
+## Linting & Formatting
 
-`packages/swift-server/.swiftlint.yml` inherits the shared rule set from the
-repo-root `.swiftlint.yml` (via `parent_config`) and excludes this package's
-`.build`. Warnings surface code-quality issues; only `error`-severity violations
-fail CI. Run `npm run lint:fix -w @slicc/swift-server` to auto-correct fixable
-violations.
+`.swiftlint.yml` inherits repo-root via `parent_config`, excludes `.build`. Only `error` fails CI. Auto-correct: `npm run lint:fix -w @slicc/swift-server`.
 
-## Formatting
-
-SwiftLint is a linter, not a formatter. Formatting is `swift format` (bundled with
-the Swift 6+ toolchain) against the single repo-root `.swift-format`; swift-format
-resolves its config by walking up from each input file, so there is no per-package
-copy to keep in sync.
+Formatting is `swift format` (Swift 6+) against repo-root `.swift-format` (swift-format walks up from each input file — no per-package copy).
 
 ```bash
 npm run lint:format -w @slicc/swift-server   # swift format lint --strict (CI gate)
 npm run format -w @slicc/swift-server        # swift format --in-place
 ```
 
-The shared config parses on swift-format 6.1 and newer — `reflowMultilineStringLiterals`
-must stay in the object enum form (`{ "never": {} }`), since 6.1 rejects the plain-string
-spelling while 6.2+ accepts both. CI runs whatever `macos-latest` ships (6.3 today), and
-`orderedImports` is only honoured from 6.3 on; older toolchains ignore it silently.
-
-Avoid multi-line string interpolations inside a multi-line string literal:
-swift-format re-indents the two independently and can emit non-compiling Swift.
-Hoist the interpolated expression into a local instead.
+Version-sensitive keys and the multi-line-interpolation footgun: [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
 
 ## Main Package Layout
 
-- `Sources/Browser/` — Chrome and Electron launchers plus console forwarding. `ElectronLauncher.swift` owns launch + `ElectronOverlayInjector`; the per-target CDP worker `OverlayTargetSession` lives in its own file (`OverlayTargetSession.swift`) to stay under the SwiftLint file-length cap.
-- `Sources/CLI/` — `ServerCommand` argument parsing and runtime bootstrap
-- `Sources/Follower/` — headless CDP-over-CDP follower for egress-blocked Electron apps (below)
-- `Sources/Server/` — HTTP routes, thin-bridge CORS middleware, request logging, shutdown
-- `Sources/Signing/` — `SigV4Signer` (mirrors the JS signers in webapp + node-server byte-for-byte against AWS canonical test vectors)
-- `Sources/WebSocket/` — CDP proxy and lick WebSocket system
-- `Tests/` — package tests
+- `Sources/Browser/` — Chrome/Electron launchers, console forwarding. `ElectronLauncher.swift` owns launch + `ElectronOverlayInjector`; per-target CDP worker: `OverlayTargetSession.swift`.
+- `Sources/CLI/` — `ServerCommand` arg parsing / runtime bootstrap.
+- `Sources/Follower/` — headless CDP-over-CDP follower for egress-blocked Electron apps.
+- `Sources/Server/` — HTTP routes, thin-bridge CORS, logging, shutdown.
+- `Sources/Signing/` — `SigV4Signer` (mirrors JS signers byte-for-byte against AWS canonical vectors).
+- `Sources/WebSocket/` — CDP proxy and lick WebSocket system.
+- `Tests/` — package tests.
 
 ## Egress-blocked Electron apps (Signal) — CDP over CDP
 
-Signal (and similarly locked-down Electron apps) deny **all** renderer network egress at the main-process layer (`net::ERR_ACCESS_DENIED`), beneath where `Page.setBypassCSP` / the CDP Fetch proxy operate — so the hosted overlay iframe can never load. `ElectronOverlayEgress.swift` detects this from `Network.loadingFailed` on our overlay iframe's document request and shows a **status-only** overlay instead of a silent blank panel (mirrors node-server's `electron-controller.ts`).
+Signal-class Electron apps deny **all** renderer egress at the main process (`net::ERR_ACCESS_DENIED`), beneath `Page.setBypassCSP` / CDP Fetch. `ElectronOverlayEgress.swift` detects this via `Network.loadingFailed` on the overlay iframe and shows a **status-only** overlay (mirrors node-server's `electron-controller.ts`).
 
-When such a block is detected AND a `--join` tray URL was given, swift-server exposes the app's CDP to the leader over a headless WebRTC tray follower (`Sources/Follower/`), so the leader drives Signal's pages as a federated target — no webapp runs in Signal's renderer:
-
-- `ElectronTrayFollower.swift` joins the tray, answers the leader's WebRTC offer, opens the `tray-control` channel, sends `hello` + `targets.advertise`, and routes inbound messages (ping→pong, `cdp.request`→servicer). The signalling + WebRTC + supersede-redirect transport is the shared `TrayFollowerConnector` from the `packages/swift-trayfollower` package's `SliccTrayFollower` product (also used by the iOS app — the WebRTC framework is not double-shipped).
-- `FederatedCDPServicer.swift` connects to the app's raw browser-level CDP (`/json/version`) and translates the leader's tray-sync CDP messages to/from it (`targets.advertise`, `cdp.request`→`cdp.response` with `sendCDPResponse`-compatible 64 KB-threshold / 32 KB chunking, `cdp.event`). Its `CDPWebSocketTransport` (shared with `CDPBrowserSession`) is injectable so the frame pump is unit-tested without a live browser.
-
-`ElectronOverlayInjector.onEgressBlocked` fires once on first detection; `ServerCommand` starts the follower on that signal and stops it on shutdown. This mirrors node-server's `electron-tray-follower.ts` / `electron-federated-cdp.ts` (which use `werift`); the Swift path uses in-process `stasel/WebRTC`.
+When blocked AND `--join` tray URL is given, swift-server exposes the app's CDP to the leader via a headless WebRTC tray follower (`Sources/Follower/`): `ElectronTrayFollower.swift` routes `tray-control`; `FederatedCDPServicer.swift` speaks raw browser CDP (`/json/version`) with `sendCDPResponse`-compatible 64 KB/32 KB chunking. Mirrors node-server's `electron-tray-follower.ts` / `electron-federated-cdp.ts`; Swift uses `stasel/WebRTC` via `packages/swift-trayfollower`. See [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
 
 ## Server Overview
 
-- `CLI/ServerCommand.swift` is the entry point and mirrors the major Node runtime flags.
-- The server resolves ports and launches or attaches to a browser target. It serves no UI in any mode; the root router only mounts `ThinBridgeCorsMiddleware` (gated by `shouldMountThinBridgeCors`). The legacy `--serve-only` / `--electron` modes mount no root middleware (API/CDP bridge only). Mirrors node-server's thin-bridge gate — see `ServerCommand.isThinBridgeMode` (`!serveOnly && !electron`).
-- `WebSocket/CDPProxy.swift` exposes the CDP proxy to browser clients.
-- `WebSocket/LickSystem.swift` keeps a set of connected browser clients, sends request/response messages, and broadcasts lick events.
-- `CDPProxy` keeps a single browser WebSocket open and forwards inbound Chrome frames through an ordered, bounded async message pump to avoid per-frame task churn and unbounded buffering.
+- `CLI/ServerCommand.swift` — entry; mirrors Node runtime flags; launches/attaches to a browser. Root mounts only `ThinBridgeCorsMiddleware` (`shouldMountThinBridgeCors`); `--serve-only` / `--electron` mount none. Gate: `isThinBridgeMode = !serveOnly && !electron`.
+- `WebSocket/CDPProxy.swift` — CDP proxy; one browser WebSocket, ordered bounded async pump.
+- `WebSocket/LickSystem.swift` — tracks clients, sends request/response, broadcasts lick events.
 
 ## API Routes
 
-`Sources/Server/APIRoutes.swift` is the main route registry. Important routes include:
+`Sources/Server/APIRoutes.swift` — main registry. Handlers mirror `packages/node-server/`; full contract details: [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
 
-- `GET /api/status` — health doc mirroring the Node server's; `service: "slicc-server"` is the float fingerprint the UI uses to label the floatbar `sliccstart` (vs `npx` for the Node CLI)
-- `GET /api/agent-activity` — returns whether a non-OPTIONS `/api/fetch-proxy` request started within the fixed 60-second activity window
-- `GET /api/runtime-config`
-- `GET /api/tray-status`
-- `GET|POST|DELETE /api/webhooks...`
-- `GET|POST|DELETE /api/crontasks...`
-- `POST /api/handoff` — profile-independent handoff injection. Mirrors `packages/node-server/src/routes/handoff.ts`: validates the structured `{ verb, target, instruction?, url?, title?, branch?, path? }` payload (invalid → 400 with node-server's exact error string; exception: a non-object JSON body returns this server's generic `Invalid JSON payload` instead of express's body-parser error) and broadcasts a `navigate_event` over the lick WebSocket. See `Sources/Server/Handoff.swift`.
-- `GET /auth/callback`
-- `GET|POST /api/oauth-result`
-- `GET /api/secrets`, `GET /api/secrets/masked`
-- `POST /api/secrets/scrub` — tool-output real→masked scrub (defense-in-depth). Mirrors node-server's `routes/secrets.ts`: 400 on non-string `text`, else `{ text: scrubbed }` via `SecretInjector.scrub(text:)`.
-- `POST /api/s3-sign-and-forward`, `POST /api/da-sign-and-forward` — server-side request signing for S3 and Adobe da.live mounts. Mirrors `packages/node-server/src/secrets/sign-and-forward.ts`; resolves S3 credentials from the Keychain (`SecretStore`) and accepts a transient IMS bearer for DA. See `Sources/Server/SignAndForward.swift`.
-- `POST /api/sudo-approve` — native sudo approval for the in-browser broker. Mirrors `packages/node-server/src/sudo/` (`endpoint.ts` + `dialog-backends.ts`): validates a `{ kind, detail, suggestedPattern? }` envelope (invalid → 400) and raises the same native `osascript` dialog by shelling out via `Process`. Loopback-only by construction; fail-closed to `{ decision: "deny" }` on any error. See `Sources/Server/SudoApprove.swift`.
-- `ALL /api/fetch-proxy` — accepts standard verbs (`GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`) plus the WebDAV (RFC 4918) and CalDAV (RFC 4791) verbs `PROPFIND`, `PROPPATCH`, `MKCOL`, `MKCALENDAR`, `REPORT`, `COPY`, `MOVE`, `LOCK`, `UNLOCK`. Unknown verbs are forwarded to AsyncHTTPClient via `HTTPMethod.RAW(value:)`.
+- `GET /api/status` — `service: "slicc-server"` labels the floatbar `sliccstart` (vs `npx` for Node CLI).
+- `GET /api/agent-activity` — non-OPTIONS `/api/fetch-proxy` within the 60-second window.
+- `GET /api/runtime-config`, `/api/tray-status`, `/auth/callback`, `GET|POST /api/oauth-result`.
+- `GET|POST|DELETE /api/webhooks...`, `/api/crontasks...`.
+- `POST /api/handoff` (`Sources/Server/Handoff.swift`) — validates payload, broadcasts `navigate_event` on lick WebSocket.
+- `GET /api/secrets`, `/api/secrets/masked`, `POST /api/secrets/scrub` (via `SecretInjector.scrub(text:)`).
+- `POST /api/s3-sign-and-forward`, `/api/da-sign-and-forward` (`Sources/Server/SignAndForward.swift`) — S3 creds from Keychain, transient IMS bearer for DA.
+- `POST /api/sudo-approve` (`Sources/Server/SudoApprove.swift`) — native `osascript` via `Process`; loopback-only; fail-closed to `{ decision: "deny" }`.
+- `ALL /api/fetch-proxy` — HTTP verbs plus WebDAV/CalDAV `PROPFIND`, `PROPPATCH`, `MKCOL`, `MKCALENDAR`, `REPORT`, `COPY`, `MOVE`, `LOCK`, `UNLOCK`. Unknown → AsyncHTTPClient via `HTTPMethod.RAW(value:)`.
 
-WebSocket routes are installed separately for CDP proxying and the lick system.
+WebSocket routes install separately for CDP and lick.
 
 ## UI Serving (none)
 
-- **swift-server serves no static UI in any mode** — the launched Chrome loads the hosted webapp from `https://www.sliccy.ai` (or `http://localhost:8787` in the wrangler dev harness). `StaticFileMiddleware` and `--static-root` have been removed; the root router only mounts `ThinBridgeCorsMiddleware` (gated by `shouldMountThinBridgeCors`). This matches node-server, which is thin-bridge in **every** mode and serves no static UI either.
+**swift-server serves no static UI in any mode** — Chrome loads the hosted webapp from `https://www.sliccy.ai` (or `http://localhost:8787` in wrangler dev). `StaticFileMiddleware` / `--static-root` removed. Matches node-server (thin-bridge in **every** mode).
 
 ## Tab Session Restore
 
-A launched Chrome reopens the tabs the previous session had open, minus the SLICC
-tab (its bridge token is dead by then, and a second leader tab restarts the
-`/cdp` eviction war `clearChromeSessionRestore` exists to prevent). Chrome's own
-session restore therefore stays wiped; swift-server keeps its own URL-only
-snapshot in `Sources/Browser/TabSessionStore.swift` (sanitized on save **and**
-load — every entry becomes a Chrome argv slot) fed by
-`Sources/Browser/TabSessionRecorder.swift` (polls `/json/list`, so it can never
-evict the webapp's CDP session) and replayed through
-`ChromeLaunchConfig.restoreUrls`. Not wired for `--serve-only` or `--electron`,
-and **node-server has no equivalent** — `chrome-launch.ts` keeps the plain
-session wipe. Full reference:
-[`docs/sliccstart-browser.md`](../../docs/sliccstart-browser.md).
+Chrome reopens previous session tabs minus the SLICC tab (dead token; `clearChromeSessionRestore` prevents `/cdp` eviction wars). URL-only snapshot in `Sources/Browser/TabSessionStore.swift` (sanitized on save **and** load — each entry is a Chrome argv slot), fed by `TabSessionRecorder.swift` (polls `/json/list`), replayed via `ChromeLaunchConfig.restoreUrls`. Not wired for `--serve-only` / `--electron`; node-server has no equivalent. See [`docs/sliccstart-browser.md`](../../docs/sliccstart-browser.md).
 
 ## Lick / WebSocket System
 
-- `LickSystem` is an actor that tracks connected browser clients and pending requests.
-- `LickWebSocketRoute` exposes the `/licks-ws` endpoint.
-- Browser-originated messages resolve pending requests or broadcast events back into the runtime.
+`LickSystem` (actor) tracks clients + pending requests; `LickWebSocketRoute` exposes `/licks-ws`. Browser-originated messages resolve pending requests or broadcast events into the runtime.
 
 ## Secrets Architecture
 
-Swift-server includes `OAuthSecretStore.swift` for OAuth token replicas plus matching `POST /api/secrets/oauth-update` and `DELETE /api/secrets/oauth/:providerId` endpoints in `Sources/Server/APIRoutes.swift`. The Swift port of the secrets pipeline lives in `Sources/Keychain/SecretInjector.swift` (Basic-auth-aware unmask, URL-credential extraction, byte-safe body unmask, the OAuth replica chain, and sessionId persistence). Mask outputs match `@slicc/shared-ts`'s TS implementation byte-for-byte via `Tests/CrossImplementationTests.swift` (pinned against `packages/shared-ts/tests/cross-impl-vectors.test.ts`).
+`OAuthSecretStore.swift` handles OAuth replicas via `POST /api/secrets/oauth-update` and `DELETE /api/secrets/oauth/:providerId`. Pipeline: `Sources/Keychain/SecretInjector.swift`. Masks match `@slicc/shared-ts` byte-for-byte via `Tests/CrossImplementationTests.swift` (pinned to `packages/shared-ts/tests/cross-impl-vectors.test.ts`). `SecretStore.swift` reads `ai.sliccy.slicc / __envfile__` at startup via `SecItemCopyMatching`.
 
-`SecretStore.swift` reads the single `ai.sliccy.slicc / __envfile__` Keychain blob synchronously at startup (before the port binds) via one `SecItemCopyMatching` in `readBlob()`.
+**Trust model (why the prompt recurs).** The default ACL trusts only the creating binary's cdhash; ad-hoc signatures get a new cdhash every `swift build`, re-raising the "allow access" dialog. Durable fix: `packages/dev-tools/tools/setup-dev-cert.sh` installs a stable code-signing identity so one **"Always Allow"** survives rebuilds. Identity must be **trusted** via `security add-trusted-cert -p codeSign`, not just imported. Deep-dive: [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
 
-**Trust model (why the prompt recurs).** That single item was created with the default trusted-application ACL, which trusts ONLY the creating binary identified by its code-signing cdhash. An ad-hoc signature gets a NEW cdhash on every `swift build`, so each rebuilt `slicc-server` is a different, untrusted binary and macOS re-raises the "allow access" ACL dialog. The **durable fix** is a stable code-signing identity (`packages/dev-tools/tools/setup-dev-cert.sh`): a constant Designated Requirement means a single interactive **"Always Allow"** grant survives every rebuild. The `unsigned:` partition-list token is **not** a reliable grant for per-rebuild ad-hoc binaries — do not rely on it. **The identity must be TRUSTED, not just imported.** A self-signed cert imports as `CSSMERR_TP_NOT_TRUSTED`, so `security find-identity -v -p codesigning` (the valid-only form both `setup-dev-cert.sh` and `dev-swift-fresh.sh` use to detect it) lists nothing and the harness silently falls back to ad-hoc signing — leaving `/api/secrets/masked` empty. `setup-dev-cert.sh` therefore runs `security add-trusted-cert -p codeSign` in the user trust domain (no `sudo`/`-d`, applied non-interactively) after import, and de-duplicates any pre-existing copies by SHA-1 hash first (a CN is "ambiguous" once stacked) so exactly one valid identity remains.
-
-`SLICC_KEYCHAIN_NONINTERACTIVE=1` (the dev fresh-bridge harness sets it) is **only an anti-hang guard**, not a fix for the prompt: it makes `readBlob` pass `kSecUseAuthenticationUIFail` so a headless launch that would otherwise block on the unanswerable dialog fails fast with `errSecInteractionNotAllowed` instead of hanging. An already-granted item still reads fine; otherwise the read path logs an actionable hint and the server continues **without** Keychain secrets. It never produces silent success.
+`SLICC_KEYCHAIN_NONINTERACTIVE=1` (dev harness) is an **anti-hang guard only**: `readBlob` passes `kSecUseAuthenticationUIFail`, so headless launches fail fast with `errSecInteractionNotAllowed` instead of hanging. Already-granted items read; otherwise continues **without** Keychain secrets. Never silent success.
 
 ## Graceful Shutdown and Detach
 
-- `Sources/Server/GracefulShutdown.swift` registers handlers for `SIGINT`, `SIGTERM`, and `SIGUSR1`.
-- `SIGINT` / `SIGTERM` run the full shutdown sequence with `closeBrowser: true` — the browser/Electron session is torn down.
-- `SIGUSR1` calls `detach()`, which runs the same sequence with `closeBrowser: false`. The HTTP listener and CDP proxy stop, but the launched browser stays open. Sliccstart uses this to swap binaries without killing the user's session; see `packages/swift-launcher/CLAUDE.md` ("Smooth-Update Modules") for the launcher-side reattach flow.
-- A second signal after `detach()` is a no-op, guarded by the private `GracefulShutdownHandler.shuttingDown` latch.
+`Sources/Server/GracefulShutdown.swift` handles `SIGINT`/`SIGTERM` (full shutdown, `closeBrowser: true`) and `SIGUSR1` (`detach()`, `closeBrowser: false` — HTTP + CDP stop, browser stays open). Sliccstart uses `detach()` for binary swaps without killing the user's session (see `packages/swift-launcher/CLAUDE.md` "Smooth-Update Modules"). Second signal after `detach()` no-ops via `GracefulShutdownHandler.shuttingDown`.
 
 ## Related Guides
 
-- `packages/node-server/CLAUDE.md` for the parallel Node runtime
-- `packages/shared-ts/CLAUDE.md` for secret masking primitives
-- `docs/development.md` for broader run/debug workflow guidance
-- `docs/transcript-export.md` — transcript export (runs in the webapp; swift-server is transparent)
+- `packages/node-server/CLAUDE.md` — parallel Node runtime
+- `packages/shared-ts/CLAUDE.md` — masking primitives
+- `docs/development.md` — run/debug workflow
+- `docs/transcript-export.md` — transcript export (webapp; swift-server transparent)
+- [`docs/swift-server-details.md`](../../docs/swift-server-details.md) — extended internals

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Browser app guide for `packages/webapp/`. Keep extension-only behavior in `packages/chrome-extension/CLAUDE.md` and runtime/server details in float-specific guides.
+Browser app guide for `packages/webapp/`. Extension-only behavior lives in `packages/chrome-extension/CLAUDE.md`; runtime/server details in float-specific guides.
 
 ## Scope
 
@@ -27,320 +27,121 @@ User → ChatPanel → Orchestrator → ScoopContext.prompt() → pi-agent-core 
 
 ## Key Subsystems
 
-### Kernel Host
+Per-subsystem file paths + non-obvious invariants live in
+[`docs/webapp-details.md`](../../docs/webapp-details.md). Root paths only here; the
+never-rules below flag what a reviewer must recognise.
 
-- Path: `packages/webapp/src/kernel/`
-- `host.ts` — `createKernelHost(config)` factory. Single boot sequence for all floats:
-  orchestrator + lick-manager + agent-bridge + tray subs + cone bootstrap + BshWatchdog +
-  `/proc` mount. In `node-rest` topology the host also opens the `/licks-ws` bridge;
-  extension-delegate leaders route licks through the tray worker instead. Float
-  discriminator: `resolveFloatTopology()` in `core/float-topology.ts`.
-- `kernel-worker.ts` — DedicatedWorker entry. Standalone path defaults here; `?inline=1` is
-  removed.
-- `process-manager.ts` — `ProcessManager` tracks every long-running async unit (scoop turns,
-  tool calls, shell execs, jsh/py scripts). Pids are uint32 from 1024+; `signal(pid, sig)`
-  honors SIGINT/SIGTERM/SIGKILL/SIGSTOP/SIGCONT.
-- `proc-mount.ts` — read-only procfs-shaped view at `/proc` (scoop-invisible, not persisted).
-  `cat /proc/<pid>/{status,cmdline,cwd,stat}` works from any panel terminal.
-- `realm/` — hard-killable runner. `runInRealm()` spawns a per-task `DedicatedWorker`;
-  SIGKILL terminates it with exit 137. JS always runs in the kernel worker through
-  `createJsWorkerRealm()` → `js-realm-shared.ts`; `realm-host` proxies `vfs` / `exec` /
-  `fetch`. Pure-JS helpers and Node shims live in `realm/helpers/`, behind the
-  `js-realm-helpers.ts` compatibility barrel. No extension iframe realm remains.
-- `realm/sync-{xhr,fs-*,exec-*}.ts` + `ui/sync-fs-sw-handler.ts` — synchronous
-  `readFileSync`/`writeFileSync` and `child_process.execSync`/`execFileSync`/`spawnSync`
-  for realm scripts, over one blocking sync-XHR transport (`synchronify`) and one
-  capability token scoped to the calling realm's `ctx.fs` / `ctx.exec`.
+- Kernel host — `packages/webapp/src/kernel/` (also `docs/kernel/process-model.md`)
+- Orchestrator + tray — `packages/webapp/src/scoops/`
+- VirtualFS + mounts — `packages/webapp/src/fs/` (also `docs/mounts.md`)
+- Shell (`.jsh`/`.bsh`, MCP) — `packages/webapp/src/shell/`
+  (also `docs/shell-reference.md`)
+- Speech (mic/TTS) — `packages/webapp/src/speech/`
+- CDP + cherry — `packages/webapp/src/cdp/`
+- Tools (file/`bash`/scoop helpers) — `packages/webapp/src/tools/`; browser
+  automation routes through shell commands, not a separate tool family
+- Sudo — `packages/webapp/src/sudo/` + `fs/sudo-fs.ts` + `shell/sudo/`
+  (also `docs/approvals.md`)
+- Core agent — `packages/webapp/src/core/` (pi-agent-core + pi-ai;
+  `tool-adapter.ts` bridges legacy tools; feature flags, context compaction)
+- UI + layouts — `packages/webapp/src/ui/` and `ui/wc/` (also `docs/layouts.md`)
+- Skills — `packages/webapp/src/skills/`
+- Sprinkles + Dips — `ui/sprinkle-*.ts`, `ui/dip.ts`
+- Stale-asset recovery — `setup-preload-error-reload.ts` + `stale-asset-channel.ts`
 
-Deep reference (method surface, coherence, cold-start): `docs/kernel/process-model.md`.
+## Never-Rules
 
-### Orchestrator
-
-- Path: `packages/webapp/src/scoops/`
-- `orchestrator.ts` owns scoop lifecycle, routing, shared state, observer teardown, and
-  pre-removal `onScoopUnregistered` snapshots.
-- `scoop-message-router.ts`: licks use `SCOOP_QUEUE_DEBOUNCE_MS` (1 s), bounded by
-  `SCOOP_QUEUE_MAX_COALESCE_MS` (3 s). Pure-lick batches defer while `ScoopContext.isBusy`
-  without queue or watermark loss; `SCOOP_DEFERRAL_STARVATION_MS` reports backpressure once
-  after 5 minutes on a dedicated non-error channel. User `web` bypasses the window, stays
-  immediate/awaited, and prevents deferral. The 2 s safety poll skips active windows.
-- `scoop-context.ts` owns per-scoop prompt execution and filesystem/tool isolation.
-- `agent-bridge.ts` exposes `globalThis.__slicc_agent`. Defaults: writable
-  `[cwd, /shared/, <scratch>/, /tmp/]`, visible `[/workspace/, invokingCwd]`; `--read-only`
-  replaces them.
-- `transcript-limits.ts` caps bridge/event transcripts at 64 KB, never canonical
-  `agent-sessions` history or compaction input.
-
-### VirtualFS
-
-- Path: `packages/webapp/src/fs/`
-- `virtual-fs.ts` — POSIX-like FS backed by OPFS (in-memory in Node tests); the legacy
-  LightningFS/IDB backend is gone.
-- `restricted-fs.ts` — path ACLs for scoop sandboxes.
-- `mount-commands.ts` — parses `--source` / `--profile` / `--no-probe` etc.;
-  `path-utils.ts` defines normalization.
-- `mount/` — `MountBackend` interface plus three implementations: `backend-local.ts` (FS
-  Access), `backend-s3.ts` (S3/R2/MinIO), `backend-da.ts` (da.live). Shared
-  `RemoteMountCache` (TTL + ETag, IDB-backed). Signing is browser-naive: backends hand
-  logical requests to an injected transport routed per deployment (CLI → `/api/s3-sign-and-forward`,
-  extension → SW). `mount-table-store.ts` / `mount-recovery.ts` persist and restore backends.
-
-See `docs/mounts.md`.
-
-### Shell
-
-- Path: `packages/webapp/src/shell/`
-- `almost-bash-shell.ts` — just-bash runtime host.
-- `script-catalog.ts` — shared `.jsh`/`.bsh` discovery for the shell and `which`; its
-  `FsWatcher` cache is bypassed for mounted trees, where external changes are invisible.
-- `supplemental-commands/` — built-ins (see `docs/shell-reference.md`).
-  `typescript` v7 (native) runs checks/builds; `typescript-js` (JS v6) powers browser
-  `tsc`/`test`/`esm-transpile` because v7 has no browser/WASM API.
-- `builtin-shadow-map.ts` is authoritative for `ipx`/`npx` npm-name → built-in redirects.
-- `jsh-discovery.ts` / `bsh-discovery.ts` — raw VFS scans backing the shared catalog.
-- `vfs-adapter.ts` — bridges shell calls into VFS; forwards `canWrite` (duck-typed for
-  both `VirtualFS` and `RestrictedFS`).
-
-### Speech
-
-- Path: `packages/webapp/src/speech/`; entry: `supplemental-commands/hear-command.ts`.
-  **Page realm only** (mic, AudioContext); kernel worker bridges via `hear-*` panel-RPC ops.
-- Two engines: Web Speech API (immediate) hot-swapped to on-device Whisper
-  (`onnx-community/whisper-tiny`) once ready. Kokoro TTS (`Kokoro-82M-v1.0-ONNX`) chains
-  automatically off the whisper load. Kokoro selects on English + on-device readiness; Web
-  Speech is the fallback.
-- **Extension `uiOnly` side panel**: Chrome denies `getUserMedia` (the mic prompt keys on the
-  extension origin, ungrantable from a cross-origin iframe), so `wc-follower.ts` skips `ptt`
-  and drops "Take a photo". Voice/camera live in the leader tab or detached popout.
-
-### MCP Servers
-
-- Path: `src/shell/mcp/`; command: `supplemental-commands/mcp-command.ts`.
-- Registration is lazy from `/workspace/.mcp/servers.json`. Subcommands, the alias shim,
-  MCP-Apps-as-sprinkles: `docs/shell-reference.md`.
-
-### CDP
-
-- Path: `packages/webapp/src/cdp/`
-- `transport.ts` — CDP transport interface; `browser-api.ts` — Playwright-style browser API.
-- `synthetic-cdp-transport.ts` — shared base synthesizing the session lifecycle (`Target.getTargets/attachToTarget`,
-  `Page/Runtime/DOM.enable`, `Page.frameNavigated` + `Page.loadEventFired` after navigate) so
-  `BrowserAPI.navigate()` doesn't hang. Subclasses provide the backhaul.
-- `cherry-host-transport.ts` — extends `SyntheticCdpTransport` for the embedded follower
-  iframe (`?cherry=1`). `resolveParentOrigin()` prefers `location.ancestorOrigins[0]`
-  (unforgeable); `document.referrer` alone breaks when Referer is stripped or in HTTP-in-HTTPS
-  dev embeds.
-- `preview-bridge-cdp-transport.ts` — extends `SyntheticCdpTransport` for driveable preview
-  tabs (`serve --bridge`). Sends `bridge.cdp.request` over the tray controller WebSocket;
-  `bridge.close` on `Target.closeTarget`.
-- `cherry-host-protocol.ts` — canonical cherry envelope contract and three-factor
-  `acceptEnvelope` gate (origin allowlist + `MessageEvent.source` identity + per-mount
-  `channelId` nonce). `packages/cherry/src/protocol.ts` is a structural mirror; keep in sync.
-- `cdp/panel-rpc-tray-provider.ts` + `cdp/panel-rpc-cdp-transport.ts` — enable the
-  worker-side `BrowserAPI` to drive federated tray/cherry/preview targets via the panel-RPC
-  BroadcastChannel.
-
-### Tools
-
-- Path: `packages/webapp/src/tools/`
-- Active surface: file tools, `bash`, and scoop/nanoclaw helpers. Browser automation routes
-  through shell commands, not a separate tool family.
-
-### Sudo (agent action approvals)
-
-- Paths: `shell/sudo/sudoers.ts` (parser/matcher), `fs/sudo-fs.ts` (FS gate),
-  `shell/sudo/command-guard.ts` (command gate), `sudo/` (brokers + manager).
-- `SudoManager` (`sudo/sudo-manager.ts`) — per-float policy store, constructed in
-  `Orchestrator.init()` once the shared VFS + `FsWatcher` exist; seeds and live-reloads
-  `/etc/sudoers` + `/etc/sudoers.d/*`, so edits and "Always" grants apply without restart.
-- Wiring: `scoop-context.ts` wraps the agent's FS once with `createSudoFs`; that single
-  handle backs both file tools and shell. Panel terminal is intentionally NOT gated.
-- Brokers are float-specific (`createSudoBroker`): extension-delegate relays via the hosted
-  leader tab; standalone/Electron POSTs `/api/sudo-approve`.
-- Self-protection: writes to `/etc/sudoers` + `/etc/sudoers.d/*` always require approval,
-  hardcoded in `matchPath` regardless of policy.
-- "Agent can't self-approve" does NOT cover page-realm code (which can reassign
-  `globalThis.confirm`): `sudo/panel-responder.ts` captures the natives at module init;
-  approval chrome mounts via `ui/wc/trusted-layer.ts`, never `document.body`.
-
-Deep reference: `docs/approvals.md`.
-
-### Tray
-
-Modules in `scoops/` — `tray-leader-sync.ts` (façade + lifecycle), `context.ts` (shared
-deps), `follower-registry.ts` (registry + keepalive), `follower-dispatch.ts` (exhaustive
-dispatch), `broadcast.ts` (snapshot + broadcast), `cdp-router.ts`, `fs-router.ts`,
-`tab-router.ts`, `remote-exec.ts`, `transcript-export.ts` (streaming), `preview-bridge.ts`
-(connections), `cherry-router.ts` (events), `teleport-pool.ts` (target selection).
-
-Follower model/thinking pills share `ui/wc/wc-follower-model-surface.ts`; the dedicated
-`wc-follower.ts` mount and `wc-tray.ts`'s `slicc:tray-join` role switch both consume it.
-Cherry remains gated by `CherryFeatureSet.modelPicker`.
-See docs/architecture.md "Multi-Browser Sync (Tray) Architecture".
-
-### Core Agent
-
-- Path: `packages/webapp/src/core/`
-- Built on `pi-agent-core` and `pi-ai`.
-- `tool-adapter.ts` bridges legacy tool definitions into the pi-compatible tool layer.
-- `session.ts` and UI session storage keep the browser runtime restorable.
-
-### Feature Flags
-
-- Add IDs to `FeatureFlagId`/`FEATURE_FLAGS` in `core/feature-flags.ts` and both `wrangler.jsonc`
-  `FEATURE_FLAGS` lists. User-toggleable flags live in the standalone **Experimental features…**
-  avatar dialog (`listFlags()`), not Account settings.
-- Parse booleans with `isFeatureEnabled`/`coerceFeatureFlagValue` (trimmed, case-insensitive
-  `on`/`true`/`1`). When `overridableFloats` allows, precedence is local → remote → bundled defaults.
-- `experimental-settings` is worker-controlled (`userToggleable: false`); it gates the avatar item
-  and exported dialog, ignoring local overrides.
-- `setupFeatureFlagsForPage` loads the float's isolated cache synchronously, then starts a
-  non-blocking `/api/flags?float=<float>` refresh. Later config needs reload.
-
-### Context Compaction
-
-- Path: `packages/webapp/src/core/context-compaction.ts`
-- `scoop-context.ts` passes `model.contextWindow`; compaction fires at window minus
-  reserve (200K fallback when absent/zero).
-- Cone memory appends to `/workspace/CLAUDE.md`; the agentic budget covers the whole file,
-  legacy restructuring only `## Auto-extracted`. `agentic-memory` on → compaction builds
-  no memory (#2003); the curator owns it.
-
-### Frozen Sessions ("New session" flow)
-
-- Path: `ui/session-freezer.ts`, `ui/new-session.ts`.
-- **Save**, **Skip memory**, and **Erase** clear cone chat and non-mount `/tmp`, not scoops.
-- Archives use `/sessions/<timestamp>-<slug>.md` plus `index.json`. Idle boot recovers both
-  pending markers serially, up to three times, through the bounded legacy enrichment call —
-  never the unbounded curator, which `timeoutSeconds` cannot stop.
-- Agentic Save: quick snapshot then clear; title (`skipMemory`) + curator in background.
-- Cone-only `OffscreenClient.clearAllMessages()` awaits `clear-chat-ack` before panel reload.
-
-### UI
-
-- Path: `packages/webapp/src/ui/`; WC shell in `ui/wc/`.
-- `main.ts` boots the WC shell for every float: standalone/electron/hosted-leader/cherry →
-  `wc/wc-live.ts` (kernel worker + tray sync + panel RPC); extension side panel + detached
-  popout → `wc/wc-extension.ts` (`OffscreenClient`). Float discriminator:
-  `resolveUiRuntimeMode()`.
-- `ui/wc/` map: `wc-live`, `wc-shell`, `wc-chat-controller`, `wc-message-view`, `wc-tray`,
-  `wc-sprinkles`, `wc-nav`, `wc-workbench`, `wc-freezer`, `wc-memory`, `wc-extension`; panels in
-  `panelize-shell`, `builtin-panels`, `panel-visibility`, `layout-store`, `agent-panels`, `add-panel-menu`.
-- **Layouts** (`docs/layouts.md`): all chrome is a `SliccPanel` in `<slicc-layout>` except the fixed avatar strip (trusted layer). Behind the `panel-layouts` flag. `panelize-shell.ts` RE-PARENTS what `mountWcShell` built, so `WcShellRefs` stays valid. Documents save to `/workspace/layouts/` (free) or `/etc/slicc/layouts/` (gated). `setPanelVisible` must add an unplaced panel but never duplicate a placed one; `sanitizeLayoutName` guards the path a name becomes.
-- **URL state**: `ctx` (active context, pushed), `at` (scroll pos, debounced replace),
-  `ws` (open workspace surface). No global manager; the host only routes.
-- **Cherry `?cherry=1`** (`main-cherry.ts`): builds `CherryHostTransport` against
-  `window.parent`, reads `joinUrl` from the handshake, wraps `BrowserAPI`. Origin detection:
-  see `cherry-host-transport.ts` note in the CDP section.
-- **Cherry `?cherry=1&ui-only=1`** (extension side panel): suppresses CDP target
-  advertisement, skips `ptt`, drops "Take a photo" (mic denied in cross-origin side panel).
-  Login/onboarding hand-off to the leader tab is gated to `isExtensionSidePanel` only.
-- **Cloud cone config** (`ui/hosted-config-apply.ts`): `applyHostedAccounts` reconciles
-  accounts from `/api/hosted-bootstrap`, removing only providers tracked in
-  `localStorage['slicc_cloud_managed']` — never user-added ones. `?connect=1` is a login-only
-  surface (`ui/connect-surface.ts`) with no kernel.
-
-### Skills
-
-- Path: `packages/webapp/src/skills/`
-- Precedence: native `/workspace/skills/` → `.agents/skills/*/SKILL.md` → `.claude/skills/*/SKILL.md` → marketplace (`.claude-plugin/marketplace.json`) → agent plugins (`plugin` command, `shell/plugins/`).
-- **Never monkeypatch a method on a get/set-asymmetric Proxy.** The sudo-fs Proxy advertises
-  `MONKEYPATCH_UNSAFE_FS` (a `Symbol.for` marker); `getCompatibilitySkillCandidates` skips
-  hooks and cache for it (always re-discovers). Reassigning a gated method creates an
-  `override↔wrapper` async recursion that OOMs the kernel worker.
-
-### Sprinkle Rendering
-
-- Main files: `ui/sprinkle-renderer.ts`, `sprinkle-manager.ts`, `sprinkle-discovery.ts`.
-- `.shtml` panels discovered from VFS. CLI: fragments/full docs in `srcdoc` iframes.
-  Extension: renders in the hosted `?cherry=1` follower — no extension sandbox.
-
-### Dips
-
-- Main file: `ui/dip.ts`. Hydrates assistant `shtml` code blocks into sandboxed iframes
-  after streaming completes. Minimal lick bridge; auto-height via ResizeObserver.
-
-### Stale-asset recovery (post-deploy)
-
-- `setup-preload-error-reload.ts` + `stale-asset-channel.ts` funnel preload, page Worker,
-  worker boot, and scoop-classifier failures into an `instanceId`-scoped 60 s reload; only
-  the owning page reacts. A cone `replayTurn` marker replays one unanswered turn after recovery.
+- **Kernel realms**: `runInRealm()` spawns per-task `DedicatedWorker`; SIGKILL → exit 137. Sync `readFileSync`/`writeFileSync` and
+  `child_process.execSync`/`execFileSync`/`spawnSync` from realm scripts go through
+  `realm/sync-{xhr,fs-*,exec-*}.ts` + `ui/sync-fs-sw-handler.ts` with per-realm
+  capability tokens; never bypass. Deep reference: `docs/kernel/process-model.md`.
+- **Scoop queue**: pure-lick batches defer while `ScoopContext.isBusy` without
+  queue/watermark loss; user `web` bypasses the window (immediate/awaited,
+  prevents deferral). `transcript-limits.ts` caps bridge/event transcripts at 64 KB
+  — never the canonical `agent-sessions` history or compaction input.
+- **Agent bridge defaults** (`agent-bridge.ts`): writable
+  `[cwd, /shared/, <scratch>/, /tmp/]`, visible `[/workspace/, invokingCwd]`;
+  `--read-only` replaces them.
+- **Mount signing is browser-naive**: CLI → `/api/s3-sign-and-forward`,
+  extension → SW. Never sign in the browser. See `docs/mounts.md`.
+- **Shell/mount cache**: `script-catalog.ts`'s `FsWatcher` cache is bypassed for
+  mounted trees; external changes are invisible.
+- **`typescript` v7 has no browser/WASM API** — use `typescript-js` (v6) for browser
+  `tsc`/`test`/`esm-transpile`. `builtin-shadow-map.ts` is authoritative for
+  `ipx`/`npx` → built-in redirects.
+- **Speech is page-realm only** (mic, AudioContext); kernel worker bridges via
+  `hear-*` panel-RPC. Extension `uiOnly` side panel: Chrome denies `getUserMedia`
+  from a cross-origin iframe, so `wc-follower.ts` skips `ptt` and drops
+  "Take a photo".
+- **Cherry origin detection** (`cherry-host-transport.ts`): `resolveParentOrigin()`
+  prefers `location.ancestorOrigins[0]` (unforgeable); `document.referrer` alone
+  breaks when Referer is stripped or in HTTP-in-HTTPS dev embeds.
+- **Cherry envelope gate** (`cherry-host-protocol.ts`): three factors — origin
+  allowlist + `MessageEvent.source` identity + per-mount `channelId` nonce.
+  `packages/cherry/src/protocol.ts` is a structural mirror; keep in sync.
+- **Sudo self-protection**: writes to `/etc/sudoers` + `/etc/sudoers.d/*` always
+  require approval, hardcoded in `matchPath`. Deep reference: `docs/approvals.md`.
+- **"Agent can't self-approve" does NOT cover page-realm code** (which can reassign
+  `globalThis.confirm`): `sudo/panel-responder.ts` captures natives at module
+  init; approval chrome mounts via `ui/wc/trusted-layer.ts`, never `document.body`.
+  The panel terminal is intentionally NOT gated.
+- **Sudo brokers** are float-specific (`createSudoBroker`): extension-delegate
+  relays via hosted leader tab; standalone/Electron POSTs `/api/sudo-approve`.
+- **Frozen-session recovery** must go through the **bounded** legacy enrichment
+  call — never the unbounded curator (`timeoutSeconds` cannot stop it). Save /
+  Skip memory / Erase clear cone chat and non-mount `/tmp`, not scoops.
+- **Layouts** (`docs/layouts.md`): behind `panel-layouts` flag. `panelize-shell.ts`
+  RE-PARENTS what `mountWcShell` built, so `WcShellRefs` stays valid.
+  `setPanelVisible` must add an unplaced panel but never duplicate a placed one;
+  `sanitizeLayoutName` guards the path a name becomes.
+- **Cloud cone config** (`ui/hosted-config-apply.ts`): `applyHostedAccounts`
+  removes only providers tracked in `localStorage['slicc_cloud_managed']` — never
+  user-added ones. `?connect=1` is login-only (`ui/connect-surface.ts`), no kernel.
+- **Never monkeypatch a method on a get/set-asymmetric Proxy.** The sudo-fs Proxy
+  advertises `MONKEYPATCH_UNSAFE_FS` (a `Symbol.for` marker);
+  `getCompatibilitySkillCandidates` skips hooks and cache for it. Reassigning a
+  gated method creates an `override↔wrapper` async recursion that OOMs the kernel
+  worker.
+- **Adobe `X-Session-Id` invariant**: every LLM call to the Adobe proxy must attach
+  the `X-Session-Id` header. `scoop-context.ts` wires it for the agent `streamFn`
+  and compaction `headers`; new call sites (`streamSimple`/`completeSimple`,
+  pi-coding-agent helpers) must attach it explicitly.
+  `providers/adobe.ts`'s `ensureSessionIdHeader` is defense-in-depth
+  (daily-rotated sentinel UUID + warning), not the fix location. See
+  `docs/pitfalls.md`.
+- **Claude Bedrock capability shims** (temperature rejected by Opus ≥ 4.7;
+  adaptive thinking for Opus/Sonnet ≥ 4.6): fix at the provider layer via
+  `src/providers/claude-model-version.ts` (`parseClaudeVersion` + predicate
+  helpers), never at the call site. See `docs/pitfalls.md`.
 
 ## Key Conventions
 
-- **Two type systems**: legacy `tools/` + pi-compatible `core/`; bridge via `tool-adapter.ts`.
+- **Two type systems**: legacy `tools/` + pi-compatible `core/`; bridge via
+  `tool-adapter.ts`.
 - **Logging**: `createLogger('namespace')` (`base/logger.ts`).
 - **Extension detection**: `typeof chrome !== 'undefined' && !!chrome?.runtime?.id`.
-- **Dual-mode compatibility**: features must work in both standalone/CLI and extension. The
-  thin extension runs no dynamic code itself — all JS execution (realms, WASM, sprinkles/dips)
-  runs in the hosted leader tab / kernel worker.
-- **Model IDs**: use pi-ai aliases such as `claude-opus-4-6`, not dated snapshot names.
-- **Provider composition**: pi-ai auto-discovered + `src/providers/built-in/` + `providers/`;
-  three-layer merge: pi-ai → `modelOverrides` → `getModelIds()`. Build filtering:
-  `packages/dev-tools/providers.build.json`.
-- **Adobe `X-Session-Id` invariant**: every LLM call to the Adobe proxy must attach the
-  `X-Session-Id` header (`scoop-context.ts` wires it for both the agent `streamFn` and
-  compaction `headers`). New LLM call sites — `streamSimple`/`completeSimple` callers or
-  pi-coding-agent helpers — must attach it explicitly. `providers/adobe.ts`'s
-  `ensureSessionIdHeader` is a defense-in-depth net (daily-rotated sentinel UUID + warning),
-  not the fix location. See `docs/pitfalls.md`.
-- **Claude Bedrock capability shims** (temperature rejected by Opus ≥ 4.7; adaptive thinking
-  for Opus/Sonnet ≥ 4.6): fix at the provider layer via `src/providers/claude-model-version.ts`
-  (`parseClaudeVersion` + predicate helpers). Never fix at the call site — the shared
-  predicates handle future model versions automatically. See `docs/pitfalls.md`.
+- **Dual-mode compatibility**: features must work in both standalone/CLI and
+  extension. The thin extension runs no dynamic code itself — realms, WASM, and
+  sprinkles/dips run in the hosted leader tab / kernel worker.
+- **Model IDs**: pi-ai aliases such as `claude-opus-4-6`, not dated snapshots.
+- **Provider composition**: pi-ai auto-discovered + `src/providers/built-in/` +
+  `providers/`; merge order pi-ai → `modelOverrides` → `getModelIds()`. Build
+  filtering: `packages/dev-tools/providers.build.json`.
 
 ## VFS API Patterns
 
 - Prefer absolute VFS paths: `/workspace/...` and `/shared/...`.
-- `VirtualFS.create({ dbName, wipe })` is the entry point for isolated testable instances.
-- Mounted directories bridge directly to `FileSystemDirectoryHandle`; do not copy large trees
-  into IndexedDB unless you mean to.
+- `VirtualFS.create({ dbName, wipe })` is the entry point for isolated testable
+  instances.
+- Mounted directories bridge directly to `FileSystemDirectoryHandle`; do not copy
+  large trees into IndexedDB unless you mean to.
 - Use `fs.walk()` and `path-utils.ts` helpers instead of ad hoc path splitting.
 - `RestrictedFS` is the correct boundary when code should not see the whole VFS.
 
-## Shell Command Authoring
-
-### `.jsh` commands
-
-- `.jsh` files are JavaScript shell scripts discovered anywhere on the VFS; command name is
-  the basename without `.jsh`.
-- `script-catalog.ts` shares discovery across `AlmostBashShell`, `which`, and other lookup
-  paths.
-- Scripts run in an async wrapper: prefer top-level `await`. Stdin (`process.stdin`) is fully
-  buffered read-ahead (no streaming; latin1 strings, not `Buffer`s; `'error'` never fires) and
-  one-shot: `read()`, events (`on('data')`→`'end'`→`'close'`, single chunk), and the async
-  iterator share one `consumed` flag, so whichever drains first wins and the others see EOF.
-  On the events surface, `pause()` suppresses the deferred emission until `resume()` (the buffer
-  stays drainable) and `process.exit(N)` from a handler exits with code `N`.
-  `process.stdin.isTTY` is always `false`. Do not expose `stdin` as a top-level identifier
-  (collides with user declarations).
-
-### `.bsh` browser scripts
-
-- `.bsh` files are JavaScript browser-navigation helpers that run in the **target browser page
-  context** via CDP `Runtime.evaluate`. Access `document`, `window`, page globals — NOT
-  `process`/`fs`/`exec()`.
-- Filename controls hostname matching: `-.okta.com.bsh` → `*.okta.com`;
-  `login.okta.com.bsh` → exact host match. Optional `// @match` directives in the first
-  10 lines narrow further. `BshWatchdog` uses `ScriptCatalog` for matching.
-
-## Secret-Aware Fetch Proxy
-
-`createProxiedFetch()` (`packages/webapp/src/shell/proxied-fetch.ts`) routes agent-initiated
-HTTP through the fetch proxy. Extension mode uses a Port-based path
-(`chrome.runtime.connect({ name: 'fetch-proxy.fetch' })`). Shell-env population:
-`secret-env.ts` filters secret names to POSIX-valid identifiers
-(`/^[A-Za-z_][A-Za-z0-9_]*$/`) so dot-namespaced internal secrets stay out of `$ENV`.
-
-See `docs/secrets.md` for OAuth bootstrap, silent renewal, and per-provider extra domains.
-
 ## Related Guides
 
-- `packages/chrome-extension/CLAUDE.md` — extension runtime constraints
-- `packages/node-server/CLAUDE.md` — CLI/Electron float
-- `docs/architecture.md` — repo-wide file maps and deeper subsystem inventories
-- `docs/shell-reference.md` — command-by-command shell behavior
-- `docs/mounts.md` — mount setup, architecture, and error patterns
-- `docs/secrets.md` — secrets storage, masking, and domain-scoped injection
-- `docs/kernel/process-model.md` — kernel process model, signals, `/proc`, sync-fs bridge
-- `docs/transcript-export.md` — ZIP format, privacy guarantees, approval, Cherry SDK
+- [`docs/webapp-details.md`](../../docs/webapp-details.md) — full subsystem detail
+- `packages/chrome-extension/CLAUDE.md`, `packages/node-server/CLAUDE.md` — float guides
+- `docs/architecture.md`, `docs/shell-reference.md`, `docs/mounts.md`, `docs/secrets.md`
+- `docs/kernel/process-model.md`, `docs/transcript-export.md`, `docs/approvals.md`
+- `docs/layouts.md`, `docs/pitfalls.md`

--- a/packages/webcomponents/CLAUDE.md
+++ b/packages/webcomponents/CLAUDE.md
@@ -1,12 +1,6 @@
 # CLAUDE.md — `@slicc/webcomponents`
 
-Standalone library that extracts the UI prototype `proto/StellarRubySwift.html`
-into reusable, individually testable web components. **Webapp wiring is underway**:
-`?ui=wc` mounts the migration shell from `packages/webapp/src/ui/wc/` (live mode
-boots the kernel worker; `&ui-fixture` renders the design-time fixture). The
-webapp imports the package barrel; its legacy `ui/press-button.ts` is now a
-re-export shim over this library's `slicc-press-button`. Components remain
-individually testable here: functional (`@vitest/browser`) + visual (Storybook).
+Standalone library extracting `proto/StellarRubySwift.html` into reusable, individually testable web components. **Webapp wiring underway**: `?ui=wc` mounts the migration shell from `packages/webapp/src/ui/wc/` (live boots the kernel worker; `&ui-fixture` renders the design-time fixture). Webapp imports the barrel; legacy `ui/press-button.ts` is a shim over `slicc-press-button`. Tested functionally (`@vitest/browser`) + visually (Storybook).
 
 ## Layout
 
@@ -26,173 +20,58 @@ tests/**/<name>.test.ts    co-located browser tests, mirroring src/ subsystem
 
 ## Panel system (`src/panel/`)
 
-**`SliccPanel` + `<slicc-layout>` are the layout API going forward**; `slicc-dock-tree` (below) is the shipping default until the `panel-layouts` flag flips on. Full model, locking, and the Cherry wire path: `docs/layouts.md`; rationale: `docs/panel-system-design.md`.
+**`SliccPanel` + `<slicc-layout>` are the layout API going forward**; `slicc-dock-tree` (below) is the shipping default until the `panel-layouts` flag flips. Model, locking, Cherry wire: `docs/layouts.md`; rationale: `docs/panel-system-design.md`; internals: `docs/webcomponents-details.md`.
 
-- **`SliccPanel`** (`panel/slicc-panel.ts`) — base class for every panel (chat, both rails, the switcher, the floatbar, each tool panel, each sprinkle). Owns identity (`panelId`, falling back to static `panelMeta.id` so one class backs many ids), `visible` (inverse of native `hidden`, so a11y comes free), `locked`, `presentation`/`anchor`, and `onPanelShow`/`onPanelHide`/`onPanelResize` lifecycle. Light DOM; the shared stylesheet keys on a `data-slicc-panel` marker rather than the tag, because one rule set must cover runtime-registered subclasses. **Panels default to VISIBLE** — the opposite polarity from `<slicc-surface>`, since a panel is placed by the layout rather than being one of a show-one stack.
-- **`panel-meta.ts`** — `PanelMeta`/`PanelSize`/`PanelPresentation` + `panelMetaOf`. DOM-free, exported as `@slicc/webcomponents/panel/meta` so the webapp and kernel worker can import metadata without the barrel (which registers every component and needs `CSSStyleSheet`).
-- **`panel-registry.ts`** (`./panel/registry`) — id → `{ meta, source, origin }` for `builtin` / `sprinkle` / `agent` panels. A duplicate id REPLACES and returns `false`: every caller is a legitimate re-registration (HMR, discovery resync, the agent rewriting its own panel), so throwing would break boot and ignoring would leave stale code live. `panelRegistryEvents` lets a live add-panel menu re-render when kernel-gated discovery lands after first paint.
-- **`layout-schema.ts`** (`./panel/layout-schema`) — the document and its pure resolution. TWO layers: `docks[]` is FIXED CHROME pinned to an edge at an exact size (fr-only zones can't say "44px"); `zones` is the working area the docks leave over — five BorderLayout regions (`ZoneName`: top/left/center/right/bottom). Nesting inside what the docks left puts `top` below the scoop strip and the side zones inboard of the rails, so chrome and zones never overlap; `center` is the remainder. A zone holds ANY NUMBER of panels along its `axis` (`zoneAxis` — wide bands default `row`, tall ones `col`): the simplicity is the five DESTINATIONS, not the capacity. Ops are list edits (`moveToZone`/`removeFromZones`/`zoneOfPanel`). Replaced a split tree that expressed more but nothing a user could aim at; `zonesFromCenter` flattens a legacy `center`. `sizeToFlex`: number/`fr` → grow factor, zero basis; `px`/`%` → fixed. Variants REPLACE a section; `panels` overrides merge per id.
-- **`center-ops.ts`** (`./panel/center-ops`) — just `liveArrangement`: which section (a matched variant, else `base`) owns the working area on screen, and therefore what a drag edits.
-- **`layout-interaction.ts`** — the pointer gestures: hover-reveal corner grip, the five-zone drop compass, divider drag. Grabbing PAINTS the five destinations from the WORKING AREA's box, so a badge appears where the panel lands, and hit-tests them — the drop is what was aimed at; a zone's area works too. Overlays and pointer capture live on the HOST, not a slot: a slot is rebuilt every render (including every resize frame), and a captured element removed from the DOM loses capture per spec — which once left resize stuck to the mouse. TWO seam kinds: between panels in a zone (weights) and between ZONES (px — a thickness is absolute; a weight would rubber-band an edge band on window resize). The zone clamp reserves for EVERY element in the run — fixed zones at actual width, the flexible one at a 48px floor; reserving one floor let a drag crush the center to 0px. No grip on locked/docked panels; no seam beside an empty or locked zone.
-- **Stories** (`panel/*.stories.ts`) — needed for PR screenshots to cover panels at all (the affected-story heuristic is directory-level). Includes `Stacked Docks`, which shows a dock spanning OVER the rails vs `zones.top` between them — the distinction that gets layouts authored wrong.
-- **`<slicc-layout>`** (`panel/slicc-layout.ts`) — renders a document by MOVING matched `SliccPanel` children into slots. Unplaced panels are parked offstage, not destroyed, so a panel keeps its scroll position / live terminal session across variant switches; `getPlacedPanelIds()` reports what actually rendered, not what the document mentions. Re-resolves on HOST resize (not window — a nested layout must react to its own box), rAF-debounced and skipped when the matched variant set is unchanged. Rebuilds target a stable inner root: replacing the host's own children would re-enter its `MutationObserver` forever.
+Non-obvious invariants:
+
+- **`SliccPanel` is light-DOM**; shared stylesheet keys on a `data-slicc-panel` marker (must cover runtime-registered subclasses). **Panels default VISIBLE** (opposite of `<slicc-surface>`).
+- **DOM-free metadata subpath** `@slicc/webcomponents/panel/meta` is safe for webapp + kernel worker; barrel is not (needs `CSSStyleSheet`).
+- **Layout schema** — `docks[]` (fixed chrome pinned to an edge at exact size; fr-only zones can't say `"44px"`) + `zones` (five BorderLayout regions, `ZoneName`: top/left/center/right/bottom); variants REPLACE a section, `panels` overrides merge per id.
+- **Slot pitfall — overlays + pointer capture live on the HOST, not a slot**: slots rebuild every render; a captured element removed from the DOM loses capture per spec.
+- **`<slicc-layout>` parks unplaced panels offstage** (not destroyed), preserving scroll / live terminal session across variant switches. Re-resolves on HOST resize (not window), rAF-debounced. Rebuilds target a stable inner root (replacing host's own children re-enters its `MutationObserver`).
+- Panel stories (`panel/*.stories.ts`) required for PR screenshots to cover panels (directory-level heuristic).
 
 ## Dock-tree (the shipping default)
 
-**`slicc-dock-tree` (`src/workbench/slicc-dock-tree.ts`) is what a default install boots** — superseded by the panel system above, not yet removed. Driven by the webapp's `layout` shell command (see `docs/shell-reference.md`, `docs/layouts.md`). Light DOM, no shadow root: it never owns surface content — `<slicc-surface>` children are matched to tree leaves by identity (`surface-id` → `data-s` → plain `id`) and moved (not cloned) into their leaf's container; unmatched surfaces park offstage. Every panel (chat, the four fixed tool panels, every sprinkle) is composed directly into it as an independent, permanently-mounted leaf — there is no separate "workbench body," grid mode, or chat-placement API on `slicc-shell` anymore; `slicc-shell` (`src/shell/slicc-shell.ts`) is just a flex row hosting the dock-tree beside the dock rail.
+**`slicc-dock-tree` (`src/workbench/slicc-dock-tree.ts`) is what a default install boots** — superseded by the panel system above, not yet removed. Driven by the webapp's `layout` shell command (`docs/shell-reference.md`, `docs/layouts.md`). Light DOM: `<slicc-surface>` children match leaves by identity (`surface-id`/`data-s`/`id`) and are MOVED (not cloned); unmatched park offstage. `slicc-shell` (`src/shell/slicc-shell.ts`) hosts it beside the dock rail. Internals: `docs/webcomponents-details.md`.
 
-- **Model**: a fixed skeleton of 5 zones (`ZoneName`: `top`/`left`/`middle`/`right`/`bottom`), each holding a recursive `DockNode` — either a `leaf` (one surface) or a `split` (`dir: 'row' | 'col'`, children + relative `sizes`). A zone whose node is `null` collapses entirely (no space, no divider) in normal rendering; a private dragging flag reveals collapsed zones as drop-target placeholders for the duration of any drag.
-- **API**: `setTree`/`getTree` (full serialization incl. sizes), `getSurfaceIds`, `placeSurface(surfaceId, zone)`, `removeSurface`, `moveSurfaceToZone` (detach-then-reinsert, bypassing the pinned guard — needed for `chat`), `setSurfaceSize(surfaceId, size)` (exact px or percent of the sibling group, the programmatic counterpart to dragging a divider), `beginExternalDrag(surfaceId, pointerId?)` (a drag started outside the component enters the same state machine). Per-method contracts are in the source doc comments.
-- **Chat as a movable panel**: `CHAT_SURFACE_ID = 'chat'` is the reserved surfaceId the webapp composes the live `<slicc-chatpane>` into at boot (see `packages/webapp/CLAUDE.md`'s Layouts section). `labelForSurface(surfaceId)` derives a tile's friendly label — `'Chat'` for `CHAT_SURFACE_ID`, otherwise the id with any `sprinkle:` prefix stripped — surfaced as the move button's `title`/`aria-label` (see below), not a visible text bar. `setPinned(surfaceIds: string[])` marks leaves as pinned (runtime-only — never serialized by `getTree()`/persisted); a pinned leaf's `removeSurface` is a no-op (defense-in-depth so chat can never be orphaned even if a caller mis-calls remove) — dragging a pinned leaf still moves it normally.
-- **Locking**: `DockTreeSpec.locked` (tree-wide) and `DockNode.locked` (per-leaf or per-split, inherited down to every descendant) block drag, resize, and `removeSurface` for the affected node(s). A locked leaf renders no move button at all — there's nothing to click, matching "cannot drag" literally. Used by embedders (e.g. Cherry) to push a fixed, unmovable arrangement — see `packages/webapp/CLAUDE.md`'s Layouts section.
-- **Drag-drop interaction**: `tilesMovable` / `tiles-movable` defaults off and locking still wins. It remains an opt-in embedder/test contract but is dormant in the shipped webapp: flag-off keeps it off, while flag-on replaces the dock-tree with `<slicc-layout>`. Full `DropRegion` and no-op contracts: `docs/layouts.md`.
-- **Resize**: every skeleton divider (between shown blocks/zones) and every in-zone split divider is pointer-drag-resizable, moving `fr` weight (or a split's `sizes`) between adjacent slots, clamped to 2% of the dragged pair's combined weight — the floor `setSurfaceSize` enforces. Pointer capture is held on the host, not the divider (see the panel system's note above: a captured element removed from the DOM loses capture per spec).
-- **Events**: `dock-tree-change` (composed + bubbling, `detail: { tree }`) fires after a drag-drop (internal or external), `placeSurface`, or `removeSurface` mutates the tree; `dock-tree-resize` (same shape) fires on divider-drag `pointerup` or a `setSurfaceSize` call that actually changed something. Neither event persists anything itself — see `packages/webapp/CLAUDE.md`'s Layouts section for the webapp's `wireDockTreePersistence` listener.
+Non-obvious rules:
+
+- `CHAT_SURFACE_ID = 'chat'` is reserved; `setPinned([...])` marks leaves runtime-only (never serialized by `getTree()`) so pinned `removeSurface` is a no-op. `moveSurfaceToZone` bypasses the pinned guard (needed for chat).
+- `DockTreeSpec.locked`/`DockNode.locked` (inherited) block drag, resize, `removeSurface`; locked leaves render no move button. Cherry uses this — see `packages/webapp/CLAUDE.md`'s Layouts section.
+- `tilesMovable`/`tiles-movable` defaults off; flag-on replaces the dock-tree with `<slicc-layout>`. Full `DropRegion` contracts: `docs/layouts.md`.
+- Divider resize clamps to 2% of pair's combined weight (floor `setSurfaceSize` enforces). **Pointer capture is held on the host, not the divider**.
+- `dock-tree-change`/`dock-tree-resize` (composed + bubbling, `detail: { tree }`) never persist — see `packages/webapp/CLAUDE.md`'s `wireDockTreePersistence`.
 
 ## Conventions (every component MUST follow)
 
-- **Vanilla web components**, no framework. One element per file, `slicc-*` tag,
-  `Slicc*` PascalCase class.
-- **No `innerHTML` — build the DOM.** Construct markup with the `internal/dom.ts`
-  builder (`h(tag, props, ...children)`, `frag()`, `append()`) and commit it via
-  `replaceChildren()`; text passed as `h()` children / `textContent` is escaped by
-  the DOM, so there is no injection surface and `escapeHtml` is unnecessary. Render
-  lucide glyphs with `iconEl(name, opts)` (a live `<svg>`), never an icon string.
-  Shadow components share one constructable stylesheet: `const SHEET = sheet(STYLE)`
-  at module scope, `this.#root.adoptedStyleSheets = [SHEET]` in the constructor (no
-  `<style>` node). Light-DOM hosts keep their one-time document `<style>` injection
-  (`style.textContent = CSS` is fine) but build their subtree with `h()`. See
-  `src/primitives/slicc-logo.ts` for the reference shape. This is **enforced**: the
-  `lint:no-innerhtml` gate (in `npm run lint` / `lint:ci`) fails on any
-  `.innerHTML =` / `.outerHTML =` / `insertAdjacentHTML` in `src/**/*.ts`
-  (`*.stories.ts` / `*.test.ts` exempt).
-- **Register via `define(tag, ctor)`** from `internal/define.js` at module bottom
-  (self-guards double-registration). Add a `HTMLElementTagNameMap` augmentation.
-- **NodeNext imports:** relative imports MUST carry the `.js` extension
-  (`./foo.js`), including in stories and tests. tsc enforces this.
-- **Shadow vs light vs iframe** (per project decision):
-  - Shadow DOM for self-contained chips: pill, add-menu, tag, icon-button, logo.
-  - Light DOM for layout/gesture/slotting hosts: nav, composer, shell, file-tree,
-    press-button (slots app content, app CSS styles it).
-  - `slicc-dip` stays **iframe-isolated** (preserve the webapp `dip.ts`
-    trusted-source security boundary — shadow DOM is NOT a security boundary).
-- **Theming:** reference prototype tokens (`var(--canvas)`, `--ink`, `--ctx`,
-  `--rainbow`, `--ctl-h`, …). Tokens are inherited, so they pierce shadow roots —
-  do not re-declare them. Light is default; dark is `body.dark` / `.dark` /
-  `[data-theme="dark"]`. Components needing per-element dark tweaks add their own
-  `.dark &` / `:host(...)` rules. Preserve `::part` hooks on lifted elements
-  (`slicc-pill`, `slicc-add-menu`) exactly.
-- **Animation loops must not force reflow.** A `requestAnimationFrame` loop must
-  never call `getComputedStyle`, append/measure a DOM probe, or otherwise read
-  computed style/layout per frame — each one forces a full-document style recalc,
-  and the cumulative storm flickers/janks the whole app (regression: `slicc-shader`
-  resolved its `tint` + `--ink` uniforms via `getComputedStyle` plus a
-  `document.body` color probe ~3×/frame — at 120 Hz that's ~360 style-recalcs/sec).
-  Resolve CSS-derived values ONCE and cache them; invalidate on the relevant
-  attribute change and on a theme change (a `class` / `data-theme` MutationObserver
-  on `<html>`/`<body>` plus a `prefers-color-scheme` listener, torn down in
-  `disconnectedCallback`).
-- **Public API:** export the class; expose attributes (reflected to properties),
-  `::part` hooks, named slots, and `CustomEvent`s (composed + bubbling) — never
-  reach into another component's internals.
-- **Composer push-to-talk:** `<slicc-composer ptt>` owns the hold-to-dictate
-  GESTURE (3s hold-to-enable permission stage, recording overlay with caption
-  line + mic picker + engine-status line, append+submit on release) but not the
-  audio stack — hosts inject a `ComposerSpeech` controller via the `speech`
-  property. The contract + built-in Web Speech fallback live in
-  `composer/speech.ts`, also exported as the DOM-free subpath
-  `@slicc/webcomponents/composer/speech` (safe for node/worker realms; the
-  barrel is not). The webapp injects its whisper-upgradable controller there.
-  Dictated submits carry `detail.source === 'dictation'` (via the input card's
-  `submit(source?)`) so hosts can speak the reply back to spoken input.
+- **Vanilla web components**, no framework. One element per file, `slicc-*` tag, `Slicc*` class. Register via `define(tag, ctor)` from `internal/define.js` at module bottom (self-guards double-registration); add `HTMLElementTagNameMap` augmentation.
+- **No `innerHTML` — build the DOM.** Use `internal/dom.ts` (`h(tag, props, ...children)`, `frag()`, `append()`) + `replaceChildren()`; `h()` children / `textContent` is DOM-escaped. Render lucide glyphs with `iconEl(name, opts)`. Shadow components share one constructable stylesheet: `const SHEET = sheet(STYLE)` module-scope, `this.#root.adoptedStyleSheets = [SHEET]` in ctor (no `<style>` node). Light-DOM hosts keep document `<style>` injection but build subtree with `h()`. Reference: `src/primitives/slicc-logo.ts`. **Enforced** by `lint:no-innerhtml` (in `npm run lint`/`lint:ci`) on `.innerHTML =`/`.outerHTML =`/`insertAdjacentHTML` in `src/**/*.ts` (stories/tests exempt).
+- **NodeNext imports:** relative imports MUST carry `.js` (`./foo.js`), including stories/tests. tsc enforces this.
+- **Shadow vs light vs iframe** — shadow DOM for self-contained chips (pill, add-menu, tag, icon-button, logo); light DOM for layout/gesture/slotting hosts (nav, composer, shell, file-tree, press-button); `slicc-dip` stays **iframe-isolated** (webapp `dip.ts` trusted-source boundary — shadow DOM is NOT a security boundary).
+- **Theming:** reference prototype tokens (`var(--canvas)`, `--ink`, `--ctx`, `--rainbow`, `--ctl-h`, …); inherited (pierce shadow roots; don't re-declare). Light default; dark is `body.dark`/`.dark`/`[data-theme="dark"]`. Preserve `::part` hooks on lifted elements (`slicc-pill`, `slicc-add-menu`) exactly.
+- **Animation loops must not force reflow.** A `requestAnimationFrame` loop must never call `getComputedStyle` or read computed style/layout per frame (regression: `slicc-shader` did ~360 recalcs/sec at 120 Hz). Resolve CSS-derived values once + cache; invalidate on attribute + theme changes (`MutationObserver` on `<html>`/`<body>` `class`/`data-theme` + `prefers-color-scheme` listener, torn down in `disconnectedCallback`).
+- **Public API:** export the class; expose attributes (reflected to properties), `::part` hooks, named slots, `CustomEvent`s (composed + bubbling) — never reach into another component's internals.
+- **Composer push-to-talk:** `<slicc-composer ptt>` owns the hold-to-dictate gesture but not the audio stack — hosts inject a `ComposerSpeech` via `speech`. Contract + Web Speech fallback: `composer/speech.ts`, exported DOM-free as `@slicc/webcomponents/composer/speech`. Dictated submits carry `detail.source === 'dictation'`. Stages + whisper upgrade: `docs/webcomponents-details.md`.
 
 ## Tests (`@vitest/browser`, real Chromium)
 
-- `tests/<area>/<name>.test.ts`, `globals: true`. Assert: registration,
-  attribute↔property reflection, shadow structure (`el.shadowRoot.querySelector`),
-  events, lifecycle cleanup, and — leveraging the real browser — `getComputedStyle`
-  / geometry where appearance matters. Stub `ResizeObserver`/`IntersectionObserver`
-  only if the component needs them and you assert reflow logic directly.
-- Run: `npm run test -w @slicc/webcomponents` (uses `vitest.config.ts`, browser
-  mode — needs `npx playwright install chromium`). Kept OUT of the root
-  `vitest run` projects so the default `npm test` stays browser-free.
+- `tests/<area>/<name>.test.ts`, `globals: true`. Assert registration, attribute↔property reflection, shadow structure (`el.shadowRoot.querySelector`), events, lifecycle cleanup, and (via real browser) `getComputedStyle`/geometry. Stub `ResizeObserver`/`IntersectionObserver` only when asserting reflow directly.
+- Run: `npm run test -w @slicc/webcomponents` (browser mode via `vitest.config.ts`; needs `npx playwright install chromium`). Kept OUT of root `vitest run` projects so default `npm test` stays browser-free.
 
 ## Stories (Storybook, `@storybook/web-components-vite`)
 
-- `src/<area>/<name>.stories.ts`. Cover the **state matrix**: every variant/state
-  × light/dark (theme toolbar) × screen sizes (viewport toolbar). `render`
-  returns a constructed element or HTML string.
+- `src/<area>/<name>.stories.ts`. Cover the **state matrix**: variant/state × light/dark (theme toolbar) × screen sizes (viewport toolbar). `render` returns a constructed element or HTML string.
 - Run: `npm run storybook -w @slicc/webcomponents`; build: `npm run build-storybook`.
 
 ## Storybook PR screenshots (visual spot-check)
 
-PRs that touch `packages/webcomponents/**` automatically get a sticky comment
-with light + dark Storybook screenshots of the **affected** stories. Driven by
-`.github/workflows/storybook-screenshots.yml`; the capture script and resolver
-live under `packages/dev-tools/tools/` (see that package's `CLAUDE.md`).
-
-**Trigger:** the workflow is event-filtered to `packages/webcomponents/**`, its
-screenshot tooling, and the workflow definition on a `pull_request` to `main`.
-Unrelated PRs do not start the workflow.
-
-**Affected-story heuristic** (directory-level, intentionally coarse — easy to
-reason about, no module-graph plumbing):
-
-- A changed `src/<area>/**/*.stories.ts` selects only the stories declared in
-  that file (matched by Storybook's `importPath`).
-- Any other changed file under `src/<area>/` selects **all** stories whose
-  `importPath` lives under that `<area>`.
-- Files outside `packages/webcomponents/src/<area>/` (no area subdir, or
-  outside the package) contribute nothing.
-
-Each affected story is screenshotted at the desktop viewport (1280×900) for
-both the `light` and `dark` theme globals.
-
-**Hosting:** PNGs are uploaded to the Cloudflare R2 bucket
-`slicc-pr-screenshots` under the key `pr-<number>/<head-sha>/<file>.png` and
-embedded inline in the comment via the public r2.dev base URL. The bucket has
-a 30-day object lifecycle rule (`expire-30d`) so screenshots self-clean.
-
-**Fork PRs / missing secret:** when `CLOUDFLARE_API_TOKEN` is unavailable
-(typical for fork PRs) the job degrades to attaching the PNGs as a workflow
-artifact and the comment links to the run instead of embedding images. The
-artifact upload always runs, R2 or not, and the R2 upload step is
-`continue-on-error: true` so a single failed object put still leaves the
-artifact + comment intact.
-
-**Manifest** (`<out>/manifest.json`, schema v1, consumed by the workflow's
-comment builder):
-
-```json
-{
-  "version": 1,
-  "generatedAt": "<ISO8601>",
-  "viewport": { "width": 1280, "height": 900 },
-  "shots": [
-    {
-      "storyId": "pill-pill--cone-open-idle",
-      "title": "Pill/Pill",
-      "name": "Cone Open Idle",
-      "area": "pill",
-      "importPath": "./src/pill/slicc-pill.stories.ts",
-      "theme": "light",
-      "file": "pill-pill--cone-open-idle.light.png",
-      "triggeredBy": ["packages/webcomponents/src/pill/slicc-pill.ts"]
-    }
-  ]
-}
-```
-
-The schema is **flat**: there is one `shots[]` entry per (story × theme).
-Consumers group by `storyId` themselves (no `stories[].screenshots[]`
-nesting). The capture script is the source of truth for the schema and the
-CLI; the workflow YAML follows.
+PRs touching `packages/webcomponents/**` get a sticky comment with light + dark screenshots of **affected** stories at 1280×900. Driven by `.github/workflows/storybook-screenshots.yml`; capture + resolver under `packages/dev-tools/tools/`. PNGs upload to R2 bucket `slicc-pr-screenshots` at `pr-<number>/<head-sha>/<file>.png` (30-day `expire-30d` lifecycle); fork PRs fall back to a workflow artifact. Directory-level heuristic, manifest v1, R2 dedupe/retry (jittered backoff on `429`/code 971), and secrets/vars (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `R2_BUCKET`, `R2_PUBLIC_BASE_URL`) in `docs/webcomponents-details.md`.
 
 **Running it locally:**
 
 ```bash
 npm run build-storybook -w @slicc/webcomponents
-# write the diff to a file, one repo-relative path per line:
 git diff --name-only main... > /tmp/changed.txt
 npx playwright install chromium   # once
 node packages/dev-tools/tools/storybook-affected-screenshots.mjs \
@@ -201,21 +80,10 @@ node packages/dev-tools/tools/storybook-affected-screenshots.mjs \
   --out=/tmp/sb-shots
 ```
 
-Flags are `--flag=value` form only (no `--output`, no `--manifest` — the
-manifest is always written to `<out>/manifest.json`). An empty / unrelated
-diff produces an empty `shots[]` and the PR comment renders a "no affected
-stories" message instead of an empty table.
-
-**Ops note:** the repo needs `CLOUDFLARE_API_TOKEN` (R2 read+write on the
-`slicc-pr-screenshots` bucket) as an Actions secret. The account ID, bucket
-name, and public base URL have sensible defaults baked into the workflow but
-can be overridden via the `CLOUDFLARE_ACCOUNT_ID`, `R2_BUCKET`, and
-`R2_PUBLIC_BASE_URL` repo variables.
+Flags are `--flag=value` only; manifest is always `<out>/manifest.json`. Empty diff → empty `shots[]` + "no affected stories" comment.
 
 ## Build / typecheck
 
 - `npm run build` → `tsc -p tsconfig.build.json` (emits `dist/`, excludes stories).
 - `npm run typecheck` → `tsc --noEmit -p tsconfig.json` (src + tests, DOM libs).
-- Wired into the root `build`, `typecheck`, and `postinstall` chains before
-  `@slicc/webapp`. Coverage floor lives in root `coverage-thresholds.json`
-  under `typescript.webcomponents`.
+- Wired into root `build`, `typecheck`, `postinstall` chains before `@slicc/webapp`. Coverage floor in root `coverage-thresholds.json` under `typescript.webcomponents`.


### PR DESCRIPTION
Weekend compaction pass. Trims oversized `CLAUDE.md` guides (≥10,000 chars) to ≤9,500 chars so each package guide keeps clear headroom under the 20,000-char repo gate. Substantive detail was preserved and moved into per-package deep-reference docs under `docs/`; every guide is still linked from the root router.

## Before → after (chars)

| File                                  | Before | After |
| ------------------------------------- | ------ | ----- |
| `CLAUDE.md`                           | 14230  | 8615  |
| `packages/cherry/CLAUDE.md`           | 19862  | 9493  |
| `packages/chrome-extension/CLAUDE.md` | 15491  | 9494  |
| `packages/cloud-core/CLAUDE.md`       | 11184  | 8510  |
| `packages/cloudflare-worker/CLAUDE.md`| 19773  | 8797  |
| `packages/dev-tools/CLAUDE.md`        | 16207  | 9298  |
| `packages/ios-app/CLAUDE.md`          | 19961  | 9492  |
| `packages/slicc-cli/CLAUDE.md`        | 16605  | 9100  |
| `packages/swift-launcher/CLAUDE.md`   | 19998  | 8557  |
| `packages/swift-server/CLAUDE.md`     | 16380  | 9082  |
| `packages/webapp/CLAUDE.md`           | 19999  | 8222  |
| `packages/webcomponents/CLAUDE.md`    | 19501  | 9488  |

`packages/vfs-root/shared/CLAUDE.md` (runtime, 3,000-byte cap) was not touched.

## Moved-document links

New per-package deep-reference docs (linked from each package's compacted guide):

- `docs/webapp-details.md`
- `docs/cherry-details.md`
- `docs/chrome-extension-details.md`
- `docs/cloud-core-details.md`
- `docs/cloudflare-worker-details.md`
- `docs/dev-tools-details.md`
- `docs/ios-app-details.md`
- `docs/slicc-cli-details.md`
- `docs/swift-launcher-details.md`
- `docs/swift-server-details.md`
- `docs/webcomponents-details.md`
- `docs/root-details.md` (holds the expanded PR-review-checklist descriptions previously inline in the root guide)

## Preserved

- Every command literal, path reference, and doc link in each guide.
- All `](packages/*/CLAUDE.md)` router links in the root `CLAUDE.md`.
- Every safety/never rule and non-obvious gotcha (Adobe `X-Session-Id` invariant, Claude Bedrock capability shims, sudo self-protection, monkeypatch-on-Proxy rule, cherry three-factor envelope gate, TRAY_SUPERSEDED chain, `NSExtensionFileProviderSupportsEnumeration`, thin-extension no-dynamic-code invariant, secret-aware fetch proxy sync-listener rule, thin-bridge-only rule for swift-server, `:5710` production-bridge protection, MV3 async-messaging quirks, etc.).

## Validation

```
node packages/dev-tools/tools/check-doc-sizes.mjs
node packages/dev-tools/tools/check-doc-refs.mjs
node packages/dev-tools/tools/check-agents-symlinks.mjs
npx prettier --check CLAUDE.md 'packages/*/CLAUDE.md' 'docs/*-details.md'
```

All four pass. No repository size gates or exemptions were changed. No code, config, or dependency changes.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KZHSP0Z8XM9BXXSBX2PJ905W&panel=chat)