### PR TITLE
fix(build): include pi truncate .d.ts in webapp-worker tsconfig (unblocks #2010 release)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,36 @@ jobs:
   # + Node >= 25 quirks around vi.unstubAllGlobals + localStorage). Build/E2E
   # stay on a single Node version in the per-package jobs to keep CI time
   # bounded.
+  # Full 9-project `tsc` matrix. The per-package jobs only run package-scoped
+  # typechecks; the cross-project configs (tsconfig.webapp-worker.json, etc.)
+  # were previously typechecked ONLY in the release job, so a type error there
+  # merged green and then broke the release (bash-tool truncate import, #2020).
+  # ~7s of tsc on top of npm ci — cheap insurance against that class of break.
+  typecheck:
+    needs: changes
+    if: >-
+      needs.changes.outputs.webapp == 'true' ||
+      needs.changes.outputs.vfs-root == 'true' ||
+      needs.changes.outputs.assets == 'true' ||
+      needs.changes.outputs.cloud-core == 'true' ||
+      needs.changes.outputs.node-server == 'true' ||
+      needs.changes.outputs.shared == 'true' ||
+      needs.changes.outputs.extension == 'true' ||
+      needs.changes.outputs.cloudflare-worker == 'true' ||
+      needs.changes.outputs.cherry == 'true' ||
+      needs.changes.outputs.dev-tools == 'true' ||
+      needs.changes.outputs.root-config == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+      - uses: ./.github/actions/npm-ci
+      - name: Typecheck (all tsc projects)
+        run: npm run typecheck
+
   node-matrix-tests:
     needs: changes
     if: >-
@@ -1689,6 +1719,7 @@ jobs:
         changes,
         lint,
         linear-history,
+        typecheck,
         node-matrix-tests,
         webapp,
         speech-e2e,

--- a/tsconfig.webapp-worker.json
+++ b/tsconfig.webapp-worker.json
@@ -33,6 +33,7 @@
     "packages/webapp/src/types/helix-rum-js.d.ts",
     "packages/webapp/src/types/pi-ai-internals.d.ts",
     "packages/webapp/src/types/pi-coding-agent-compaction.d.ts",
+    "packages/webapp/src/types/pi-coding-agent-truncate.d.ts",
     "packages/webapp/src/core/stale-asset-channel.ts",
     "packages/chrome-extension/src/chrome.d.ts"
   ]


### PR DESCRIPTION
## Why

The **v6.41.0 release failed** at `npm run typecheck` — so #2010 (the bash 40 KB cap) merged but never shipped; the CDN is still v6.40.0.

```
packages/webapp/src/tools/bash-tool.ts(12,8): error TS2307:
  Cannot find module '@earendil-works/pi-coding-agent/dist/core/tools/truncate.js'
```

`tsconfig.webapp-worker.json` uses an **explicit file `include` list** (not a glob), so an ambient `declare module` .d.ts is only seen if it is listed. #2015 added `pi-coding-agent-truncate.d.ts` and wired it into the glob configs but not this one — so `truncate.js` types are invisible here and `bash-tool.ts` (reachable from the worker graph) cannot resolve them.

**Why CI missed it:** PR/merge-queue CI only runs *package-scoped* typechecks (`-w @slicc/shared-ts`, etc.); the full 9-project `npm run typecheck` runs **only in the release job**. So this class of error is invisible until release.

## Fix

Add `pi-coding-agent-truncate.d.ts` to `tsconfig.webapp-worker.json`'s include, right after the sibling `pi-coding-agent-compaction.d.ts`. Verified with `tsc -p tsconfig.webapp-worker.json` (clean) + projects 6–9 (clean). Unblocks the release that ships #2010, and pre-empts the read_file cap (#2009) hitting the identical wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65