### PR TITLE
fix(webcomponents): close the post-#1784 layout regressions — phantom rail gap, narrow state, pane chrome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -376,8 +376,7 @@
         "packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts",
         "packages/webapp/src/shell/supplemental-commands/upskill/registries/browse-sh.ts",
         "packages/webapp/tests/kernel/realm/js-realm-drain.test.ts",
-        "packages/webapp/tests/providers/adobe-provider.test.ts",
-        "packages/webcomponents/src/composer/slicc-composer.ts"
+        "packages/webapp/tests/providers/adobe-provider.test.ts"
       ],
       "linter": {
         "rules": {

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -452,6 +452,21 @@ whose node is `null` collapses entirely.
   the same state machine.
 - `setPinned(surfaceIds)` — non-removable leaves (runtime-only, never serialized).
 
+Rendering: every non-chat leaf's tile carries the floating rounded
+workbench-pane chrome (`.dock-tree__tile--chrome`: `--canvas` card, 1px `--line`
+border, 14px radius, the elevated two-layer shadow, 12px float margin,
+`overflow: hidden` clipping full-bleed content to the corners) — the look the
+deleted `<slicc-workbench-pane>` → `<slicc-pane elevated>` chain gave right-rail
+slide-ins. The reserved `chat` leaf renders flat/full-bleed over the shader.
+After **every** render — the deliberately silent `setTree` restore included —
+the tree fires `dock-tree-render` (composed + bubbling,
+`detail: { placed: string[] }`), a display-only notification that never drives
+persistence. `<slicc-shell>` keys the chatpane's `narrow` state off it: `narrow`
+is set exactly while any non-chat leaf is placed, and re-themes the
+thread/composer (tight feather, hidden ⏎/⇧⏎ hints) without sizing the column —
+the leaf owns width now, so the shell-era `calc(100% - 48px)` / `34%` widths are
+gone from `<slicc-chatpane>`.
+
 Drag-drop: every unlocked leaf reveals a `.dock-tree__tile-move` button on hover
 over its top-left corner; hovering another tile computes a `DropRegion`
 (`n`/`s`/`e`/`w`/`center`) and splits accordingly.

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -457,7 +457,14 @@ workbench-pane chrome (`.dock-tree__tile--chrome`: `--canvas` card, 1px `--line`
 border, 14px radius, the elevated two-layer shadow, 12px float margin,
 `overflow: hidden` clipping full-bleed content to the corners) — the look the
 deleted `<slicc-workbench-pane>` → `<slicc-pane elevated>` chain gave right-rail
-slide-ins. The reserved `chat` leaf renders flat/full-bleed over the shader.
+slide-ins. A tile a render NEWLY placed slides in from the right (0.38s, the
+prototype's workbench easing, `prefers-reduced-motion` aware); re-renders with
+an unchanged placed set — one per divider-drag pointermove — never replay it,
+and closing is instant. The reserved `chat` leaf renders flat/full-bleed over
+the shader. The composer's band is full-bleed in the shell: its paint lives on
+a `::before` extending right past the column (under the floating pane, which
+sits above at z-index 3 along with the rail — `slicc-composer.ts`), so no raw
+shader strip shows between the composer and the rail.
 After **every** render — the deliberately silent `setTree` restore included —
 the tree fires `dock-tree-render` (composed + bubbling,
 `detail: { placed: string[] }`), a display-only notification that never drives

--- a/docs/webcomponents-details.md
+++ b/docs/webcomponents-details.md
@@ -122,7 +122,15 @@ string[])` marks leaves as pinned (runtime-only — never serialized by
   divider-drag `pointerup` or a `setSurfaceSize` call that actually changed
   something. Neither event persists anything itself — see
   `packages/webapp/CLAUDE.md`'s Layouts section for the webapp's
-  `wireDockTreePersistence` listener.
+  `wireDockTreePersistence` listener. `dock-tree-render` (composed + bubbling,
+  `detail: { placed: string[] }`) fires after EVERY render — the deliberately
+  change-silent `setTree` restore included — and is display-only:
+  `<slicc-shell>` keys the chatpane's `narrow` re-theming off it; it must never
+  feed persistence.
+- **Tile chrome**: every non-chat tile carries the floating rounded
+  workbench-pane card (`.dock-tree__tile--chrome` — `--canvas`, 1px `--line`,
+  14px radius, elevated shadow, 12px margin, `overflow: hidden`); the reserved
+  `chat` leaf renders flat/full-bleed over the shader.
 
 ## Composer push-to-talk
 

--- a/packages/webcomponents/CLAUDE.md
+++ b/packages/webcomponents/CLAUDE.md
@@ -42,6 +42,7 @@ Non-obvious rules:
 - `tilesMovable`/`tiles-movable` defaults off; flag-on replaces the dock-tree with `<slicc-layout>`. Full `DropRegion` contracts: `docs/layouts.md`.
 - Divider resize clamps to 2% of pair's combined weight (floor `setSurfaceSize` enforces). **Pointer capture is held on the host, not the divider**.
 - `dock-tree-change`/`dock-tree-resize` (composed + bubbling, `detail: { tree }`) never persist — see `packages/webapp/CLAUDE.md`'s `wireDockTreePersistence`.
+- Non-chat tiles carry the rounded workbench-pane chrome (`.dock-tree__tile--chrome`); the reserved chat leaf renders flat. `dock-tree-render` (`detail: { placed }`) fires after EVERY render — the change-silent `setTree` included — and is display-only: `slicc-shell` keys the chatpane's `narrow` re-theming (never its width — the leaf sizes the column) off it.
 
 ## Conventions (every component MUST follow)
 

--- a/packages/webcomponents/src/composer/slicc-composer.ts
+++ b/packages/webcomponents/src/composer/slicc-composer.ts
@@ -50,6 +50,37 @@ slicc-composer {
 slicc-composer[hidden] {
   display: none;
 }
+/* Full-bleed band inside the dock-tree shell: the VISUAL band extends past
+   the chat column's right edge — under the floating tool pane, up to the
+   frame clip — while the composer's content column is untouched (an open
+   pane still pushes the textarea/labels left). The paint moves host →
+   ::before so the extension is one continuous tint/blur with no seam at the
+   column edge; the pseudo's z-index:-1 keeps it under the composer's own
+   content inside the host's stacking context. The chrome tool tile
+   (z-index 3, slicc-dock-tree.ts) and the dock rail (z-index 3,
+   slicc-shell.ts) float ABOVE the band, which outranks them at the
+   composer's z-index 2 otherwise. Extends RIGHT only: leftward it would
+   paint over the freezer rail, which sits below the app column. */
+.slicc-shell slicc-composer {
+  border-top: none;
+  background: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+.slicc-shell slicc-composer::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: -100vw;
+  z-index: -1;
+  pointer-events: none;
+  border-top: 1px solid var(--line);
+  background: color-mix(in srgb, var(--ctx) 12%, color-mix(in srgb, var(--bg) 68%, transparent));
+  backdrop-filter: blur(18px) saturate(1.4);
+  -webkit-backdrop-filter: blur(18px) saturate(1.4);
+}
 slicc-composer > .slicc-composer__inner {
   box-sizing: border-box;
   max-width: 680px;
@@ -916,7 +947,7 @@ export class SliccComposer extends HTMLElement {
   #cancelPendingStart(): void {
     const pending = this.#startingSession;
     this.#startingSession = null;
-    if (pending) {
+    if (pending !== null) {
       void pending.then(
         (session) => session.cancel(),
         () => {}
@@ -1023,7 +1054,7 @@ export class SliccComposer extends HTMLElement {
     this.#startingSession = null;
     if (!finalize) {
       session?.cancel();
-      if (pending)
+      if (pending !== null)
         void pending.then(
           (s) => s.cancel(),
           () => {}
@@ -1032,7 +1063,7 @@ export class SliccComposer extends HTMLElement {
       this.#teardownOverlay();
       return;
     }
-    if (!session && !pending) {
+    if (!session && pending === null) {
       // Quick click: the engine never came up — keep the caret behavior.
       this.#target = null;
       this.#teardownOverlay();

--- a/packages/webcomponents/src/shell/slicc-chatpane.stories.ts
+++ b/packages/webcomponents/src/shell/slicc-chatpane.stories.ts
@@ -17,7 +17,12 @@ function populated(narrow: boolean): HTMLElement {
   frame.style.cssText =
     'display:flex;height:520px;width:880px;border:1px solid var(--line);border-radius:14px;overflow:hidden;background:var(--bg);';
   const pane = document.createElement('slicc-chatpane');
-  if (narrow) pane.setAttribute('narrow', '');
+  if (narrow) {
+    pane.setAttribute('narrow', '');
+    // `narrow` no longer sizes the column (the dock-tree leaf does, in the
+    // app) — emulate that zone sizing here so the narrow theming reads.
+    pane.style.flex = '0 0 34%';
+  }
 
   const thread = document.createElement('slicc-chat-thread');
   const u = document.createElement('slicc-user-message');
@@ -31,10 +36,13 @@ function populated(narrow: boolean): HTMLElement {
 
   pane.append(thread, composer);
   frame.appendChild(pane);
-  // A faux dock gutter so the 34% narrow split reads against something.
-  const gutter = document.createElement('div');
-  gutter.style.cssText = 'flex:1;background:color-mix(in srgb,var(--ctx) 8%,var(--bg));';
-  frame.appendChild(gutter);
+  if (narrow) {
+    // A faux panel gutter beside the narrowed column, standing in for the
+    // tool tile the dock-tree would render there.
+    const gutter = document.createElement('div');
+    gutter.style.cssText = 'flex:1;background:color-mix(in srgb,var(--ctx) 8%,var(--bg));';
+    frame.appendChild(gutter);
+  }
   return frame;
 }
 

--- a/packages/webcomponents/src/shell/slicc-chatpane.ts
+++ b/packages/webcomponents/src/shell/slicc-chatpane.ts
@@ -6,25 +6,27 @@ import { define } from '../internal/define.js';
  * the host document (idempotent) and scoped by the host class `.slicc-chatpane`
  * (added on connect) so it can't leak.
  *
- * Lifted faithfully from the prototype (`proto/StellarRubySwift.html` `.chatpane`
- * + `.shell.open .chatpane`): the flat, full-bleed left column of the chat shell.
- * Unlike the floating, rounded `.workbench` pane beside it, the chat column stays
- * FLAT (shadcn-style) — it is just a `flex-direction: column` that stacks the nav
- * + chat thread + composer and owns the column width animation.
+ * Lifted from the prototype (`proto/StellarRubySwift.html` `.chatpane`): the
+ * flat, full-bleed chat column of the shell. Unlike the framed tool tiles
+ * beside it, the chat column stays FLAT (shadcn-style) — it is just a
+ * `flex-direction: column` that stacks the nav + chat thread + composer.
  *
- * Width: `calc(100% - 48px)` in the wide (shell-collapsed) layout — the full row
- * minus the 48px dock rail — narrowing to `34%` in the `narrow` layout (the
- * prototype's `.shell.open .chatpane`, where the workbench floats in beside it).
- * The `width .38s cubic-bezier(.4,0,.2,1)` transition is the slide the whole chat
- * column performs as the workbench opens / closes. `flex: 0 0 auto` keeps the
- * column from flex-growing past that explicit width; `min-height: 0` lets the
- * inner thread scroll instead of overflowing the column.
+ * Width: the column always fills its container. Since the dock-tree became the
+ * sole layout host (the chatpane lives inside a `<slicc-surface>` leaf, and the
+ * 48px dock rail is a separate `<slicc-shell>` flex sibling of the tree), the
+ * column's width is entirely the tree's business — the shell-era
+ * `calc(100% - 48px)` / `34%` widths would double-count the rail and fight the
+ * zone sizing. `flex: 1 1 0` + `width: 100%` fill the surface either way
+ * (flex item or block child); `min-width: 0` / `min-height: 0` let the inner
+ * thread scroll and shrink instead of overflowing the column.
  *
- * The `narrow` host attribute mirrors the prototype's `.shell.open`: besides the
- * 34% width it is forwarded as `open` onto the slotted `<slicc-chat-thread>` and
- * `<slicc-composer>` (tightening the thread feather + padding and hiding the
- * composer's keyboard hint) — that forwarding happens in script, not CSS, since
- * those children own their own scoped rules.
+ * The `narrow` host attribute mirrors the prototype's `.shell.open`: it no
+ * longer changes the column's width (the dock-tree owns that), but is forwarded
+ * as `open` onto the slotted `<slicc-chat-thread>` and `<slicc-composer>`
+ * (tightening the thread feather + padding and hiding the composer's keyboard
+ * hint) — that forwarding happens in script, not CSS, since those children own
+ * their own scoped rules. `<slicc-shell>` toggles it whenever the dock-tree
+ * shows any non-chat leaf.
  *
  * Everything is var-driven (`--bg` / `--ink` here; children theme themselves via
  * `--ctx` / `--shaderbg` / `--line` / `--ui`) so dark mode flips automatically
@@ -36,23 +38,19 @@ import { define } from '../internal/define.js';
  */
 const STYLE = `
 .slicc-chatpane {
-  flex: 0 0 auto;
-  width: calc(100% - 48px);
+  flex: 1 1 0;
+  width: 100%;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
+  min-width: 0;
   min-height: 0;
   font-family: var(--ui);
   color: var(--ink);
   background: var(--bg);
-  transition: width .38s cubic-bezier(.4, 0, .2, 1);
 }
 .slicc-chatpane[hidden] {
   display: none;
-}
-/* narrow-chat (.shell.open .chatpane): the column shrinks to 34% and slides. */
-.slicc-chatpane[narrow] {
-  width: 34%;
 }
 /* The reading column is background-free in every layout (the frosted card was
    dropped — the shader renders low-contrast instead). In the narrow column the
@@ -96,13 +94,12 @@ function ensureChatpaneStyle(doc: Document): void {
 const OPEN_FORWARD_TAGS = ['slicc-chat-thread', 'slicc-composer'] as const;
 
 /**
- * `<slicc-chatpane>` — the flat, full-bleed left column of the chat shell from
+ * `<slicc-chatpane>` — the flat, full-bleed chat column of the shell from
  * the prototype (`.chatpane`). A `flex-direction: column` host that stacks — in
  * DOM order — an optional top `<slicc-nav>`, the `<slicc-chat-thread>`, and the
  * `<slicc-composer>`, composing each BY TAG (it never imports or reaches into
- * them). It owns the column's width and the slide animation: `calc(100% - 48px)`
- * wide when the shell is collapsed, `34%` when `narrow` (the prototype's
- * `.shell.open .chatpane`).
+ * them). It always fills its container (`flex: 1 1 0` / `width: 100%`) — the
+ * dock-tree leaf it lives in owns the column's width.
  *
  * Light DOM (no shadow root): the host IS the column, so its children lay out
  * directly inside it (DOM order is layout order) — there is no inner wrapper to
@@ -110,15 +107,15 @@ const OPEN_FORWARD_TAGS = ['slicc-chat-thread', 'slicc-composer'] as const;
  * the scoped stylesheet is injected once into the host document and scoped by the
  * `.slicc-chatpane` host class so it can't leak.
  *
- * The `narrow` boolean attribute mirrors `.shell.open`: it drives the 34% width
- * via CSS AND is forwarded in script as the `open` attribute onto the slotted
- * `<slicc-chat-thread>` + `<slicc-composer>` so they switch to their own narrow
- * variants (tighter thread feather/padding; the composer hides its keyboard
- * hint). Forwarding re-runs whenever the column's direct children change, so a
- * thread/composer added later still inherits the current state.
+ * The `narrow` boolean attribute mirrors `.shell.open`: it is forwarded in
+ * script as the `open` attribute onto the slotted `<slicc-chat-thread>` +
+ * `<slicc-composer>` so they switch to their own narrow variants (tighter
+ * thread feather/padding; the composer hides its keyboard hint). Forwarding
+ * re-runs whenever the column's direct children change, so a thread/composer
+ * added later still inherits the current state.
  *
- * @attr narrow - boolean; narrow-chat variant (34% width + forwards `open` to
- *   the thread/composer + the thread inner fills full width/height with its
+ * @attr narrow - boolean; narrow-chat variant (forwards `open` to the
+ *   thread/composer + the thread inner fills full width/height with its
  *   frosted background dropped), mirrors `.shell.open .chatpane`
  * @csspart pane - the column (the host element itself carries `part="pane"`)
  * @slot - default; the column's children in DOM order: an optional `<slicc-nav>`,

--- a/packages/webcomponents/src/shell/slicc-shell.ts
+++ b/packages/webcomponents/src/shell/slicc-shell.ts
@@ -38,6 +38,13 @@ function ensureShellStyle(doc: Document): void {
 }
 
 /**
+ * The reserved chat surfaceId — a literal mirror of `CHAT_SURFACE_ID` in
+ * `../workbench/slicc-dock-tree.js` (not imported: a constant is not worth
+ * pulling the whole dock-tree module into every shell consumer).
+ */
+const CHAT_SURFACE_ID = 'chat';
+
+/**
  * `<slicc-shell>` — the top-level flex row laying out the dock-tree (the sole
  * layout host — chat and every panel are independent leaves within it) beside
  * the right dock rail (composed BY TAG as `<slicc-dock-tree>`, `<slicc-dock>`).
@@ -45,14 +52,36 @@ function ensureShellStyle(doc: Document): void {
  * Light DOM (no shadow root): the host IS the flex row; its children lay out
  * in DOM order.
  *
+ * The shell also owns the prototype's `.shell.open` forwarding, re-homed from
+ * the deleted workbench pane: whenever the composed dock-tree announces a
+ * render (`dock-tree-render`, fired on every mutation AND `setTree` restore),
+ * the shell toggles `narrow` on the descendant `<slicc-chatpane>` iff any
+ * non-chat leaf is placed — which cascades `open` onto the thread + composer
+ * (tighter reading-column feather, hidden ⏎/⇧⏎ keyboard hints).
+ *
  * @csspart shell - the host row (also styleable via the element itself)
  * @slot - default; `<slicc-dock-tree>`, `<slicc-dock>` by tag
  */
 export class SliccShell extends HTMLElement {
+  /** Bound listener so `disconnectedCallback` can remove exactly what connect added. */
+  readonly #onDockTreeRender = (event: Event): void => {
+    const placed = (event as CustomEvent<{ placed?: string[] }>).detail?.placed;
+    if (!Array.isArray(placed)) return;
+    const narrow = placed.some((id) => id !== CHAT_SURFACE_ID);
+    this.querySelector('slicc-chatpane')?.toggleAttribute('narrow', narrow);
+  };
+
   connectedCallback(): void {
     ensureShellStyle(this.ownerDocument);
     this.classList.add('slicc-shell');
     this.setAttribute('part', 'shell');
+    // Composed + bubbling from the dock-tree child, so listening on the host
+    // works no matter when the tree is slotted in.
+    this.addEventListener('dock-tree-render', this.#onDockTreeRender);
+  }
+
+  disconnectedCallback(): void {
+    this.removeEventListener('dock-tree-render', this.#onDockTreeRender);
   }
 
   /** The composed dock-tree, if present. */

--- a/packages/webcomponents/src/shell/slicc-shell.ts
+++ b/packages/webcomponents/src/shell/slicc-shell.ts
@@ -21,9 +21,12 @@ const STYLE = `
 }
 /* Pin the dock to its full 48px basis. This selector outranks the dock's own
    "flex: 0 0 48px" rule, so an "auto" basis here would collapse the rail to its
-   ~35px icon-content width and leave a bare-shader strip down the right edge. */
+   ~35px icon-content width and leave a bare-shader strip down the right edge.
+   z-index 3 lifts the rail above the composer's full-bleed band (z-index 2,
+   extending -100vw rightward — slicc-composer.ts), which would otherwise tint
+   and blur the rail's own opaque strip. */
 .slicc-shell > slicc-dock,
-.slicc-shell > .dock { flex: 0 0 48px; }
+.slicc-shell > .dock { flex: 0 0 48px; position: relative; z-index: 3; }
 `;
 
 const STYLE_ID = 'slicc-shell-style';

--- a/packages/webcomponents/src/workbench/slicc-dock-tree.ts
+++ b/packages/webcomponents/src/workbench/slicc-dock-tree.ts
@@ -126,6 +126,29 @@ slicc-dock-tree .dock-tree__tile {
   min-height: 0;
   box-sizing: border-box;
 }
+/* Tool tiles (every leaf except the reserved chat column) carry the
+   prototype's floating rounded workbench-pane chrome — the .pane card that
+   \`<slicc-workbench-pane>\` used to compose via \`<slicc-pane elevated>\`:
+   --canvas surface, 1px --line border, 14px radius, the elevated two-layer
+   shadow, 12px float margin. \`overflow: hidden\` clips full-bleed content
+   (xterm's dark surface, iframes) to the rounded corners. The chat tile stays
+   FLAT (full-bleed over the shader), exactly like the prototype's .chatpane. */
+slicc-dock-tree .dock-tree__tile--chrome {
+  margin: 12px;
+  background: var(--canvas, #fff);
+  border: 1px solid var(--line, #b7c6cf);
+  border-radius: 14px;
+  box-shadow:
+    rgba(10, 10, 10, 0.1) 0 14px 36px -12px,
+    rgba(10, 10, 10, 0.05) 0 4px 10px -4px;
+  overflow: hidden;
+}
+.dark slicc-dock-tree .dock-tree__tile--chrome,
+[data-theme="dark"] slicc-dock-tree .dock-tree__tile--chrome {
+  box-shadow:
+    rgba(0, 0, 0, 0.45) 0 14px 36px -12px,
+    rgba(0, 0, 0, 0.3) 0 4px 10px -4px;
+}
 slicc-dock-tree .dock-tree__tile-move {
   position: absolute;
   top: 4px;
@@ -715,6 +738,7 @@ function buildPreviewEl(): HTMLDivElement {
  * @slot - default; `<slicc-surface>` children, matched into the tree by id
  * @fires dock-tree-change - composed + bubbling; `detail: { tree: DockTreeSpec }`; fired after a drag-drop (internal or external), `placeSurface`, or `removeSurface` mutates the tree
  * @fires dock-tree-resize - composed + bubbling; `detail: { tree: DockTreeSpec }`; fired on divider-drag pointerup, or `setSurfaceSize` actually changing a weight
+ * @fires dock-tree-render - composed + bubbling; `detail: { placed: string[] }` (the placed surfaceIds); fired after EVERY render, `setTree` included — a display notification (drives `<slicc-shell>`'s chatpane `narrow` sync), never a persistence trigger
  */
 export class SliccDockTree extends HTMLElement {
   static readonly observedAttributes = ['tiles-movable'];
@@ -1140,6 +1164,18 @@ export class SliccDockTree extends HTMLElement {
       parkSurfaceInline(surfaceEl);
       if (surfaceEl.parentElement !== this.#parking) this.#parking.appendChild(surfaceEl);
     }
+
+    // Every render (setTree restore included — which deliberately does NOT
+    // fire dock-tree-change, so persistence can't loop) announces what is
+    // currently placed. `<slicc-shell>` keys the chatpane's `narrow` state off
+    // this; it is a display notification, never a persistence trigger.
+    this.dispatchEvent(
+      new CustomEvent<{ placed: string[] }>('dock-tree-render', {
+        detail: { placed: [...usedIds] },
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   /** Build the center row (`left`/`middle`/`right`), or `null` when none of them show. */
@@ -1237,6 +1273,9 @@ export class SliccDockTree extends HTMLElement {
   ): HTMLElement {
     const tile = document.createElement('div');
     tile.className = 'dock-tree__tile';
+    // Tool tiles get the floating rounded pane chrome; the reserved chat
+    // column renders flat (see the .dock-tree__tile--chrome CSS above).
+    if (surfaceId !== CHAT_SURFACE_ID) tile.classList.add('dock-tree__tile--chrome');
     if (this.tilesMovable && !this.#isLockedNode(node, zone)) {
       const label = labelForSurface(surfaceId);
       const move = document.createElement('button');

--- a/packages/webcomponents/src/workbench/slicc-dock-tree.ts
+++ b/packages/webcomponents/src/workbench/slicc-dock-tree.ts
@@ -142,12 +142,42 @@ slicc-dock-tree .dock-tree__tile--chrome {
     rgba(10, 10, 10, 0.1) 0 14px 36px -12px,
     rgba(10, 10, 10, 0.05) 0 4px 10px -4px;
   overflow: hidden;
+  /* Float above the composer's full-bleed band (z-index 2 + a ::before that
+     extends under the pane — slicc-composer.ts): the pane is chrome ON TOP
+     of the band, not content beneath it. */
+  z-index: 3;
 }
 .dark slicc-dock-tree .dock-tree__tile--chrome,
 [data-theme="dark"] slicc-dock-tree .dock-tree__tile--chrome {
   box-shadow:
     rgba(0, 0, 0, 0.45) 0 14px 36px -12px,
     rgba(0, 0, 0, 0.3) 0 4px 10px -4px;
+}
+/* Slide-in for a NEWLY PLACED tool tile — the prototype workbench's .38s
+   cubic-bezier(.4,0,.2,1) open, re-homed as an entrance animation because the
+   dock-tree rebuilds its DOM on every render (a width transition has no
+   persistent element to ride). Applied only when the render actually ADDED
+   the surface to the placed set — divider-drag re-renders (one per
+   pointermove) keep the set unchanged and never replay it. Closing is
+   instant: an exit animation would mean keeping dead tiles in the tree past
+   their render. */
+slicc-dock-tree .dock-tree__tile--enter {
+  animation: slicc-dock-tile-in 0.38s cubic-bezier(0.4, 0, 0.2, 1);
+}
+@keyframes slicc-dock-tile-in {
+  from {
+    transform: translateX(32px);
+    opacity: 0;
+  }
+  to {
+    transform: none;
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  slicc-dock-tree .dock-tree__tile--enter {
+    animation: none;
+  }
 }
 slicc-dock-tree .dock-tree__tile-move {
   position: absolute;
@@ -724,8 +754,10 @@ function buildPreviewEl(): HTMLDivElement {
  * actually change the tree.
  *
  * **Programmatic sizing API**: `setSurfaceSize(surfaceId, size)` resizes the
- * leaf holding `surfaceId` to an exact width/height, in pixels or as a
- * percent (0–100) of the space its current sibling group renders into — the
+ * leaf holding `surfaceId` so its VISIBLE surface lands on an exact
+ * width/height, in pixels (the leaf itself grows by the tile chrome's margin
+ * + border inset) or as a percent (0–100) of the space its current sibling
+ * group renders into — the
  * agent-facing counterpart to dragging a divider by hand (see
  * `#sizeAxesFor`/`#applyAxisSize`). Only the axis(es) that leaf actually has
  * a lever for are honored (e.g. a top/bottom zone root has no width lever —
@@ -765,6 +797,13 @@ export class SliccDockTree extends HTMLElement {
 
   /** Maps a rendered `.dock-tree__tile` element back to the `DockNode` it displays (identity, current render only). */
   readonly #tileNodeMap = new WeakMap<HTMLElement, DockNode>();
+
+  /**
+   * The surfaceIds the PREVIOUS render placed — the diff base that decides
+   * which tool tiles are entrances (slide-in) vs. carry-overs. Starts empty,
+   * so a restored tree's tool panes slide in once on boot too.
+   */
+  #prevPlaced: ReadonlySet<string> = new Set();
 
   readonly #root: HTMLDivElement = buildRootEl();
 
@@ -975,17 +1014,37 @@ export class SliccDockTree extends HTMLElement {
     if (!axes) return false;
 
     const surfaceEl = this.#collectSurfacePool().get(surfaceId) ?? null;
+    // The LEAF is the flex item the weights actually size; on a chrome tile
+    // (every non-chat leaf) the surface rect is smaller than the leaf's flex
+    // allocation by the tile's 12px float margins + 1px borders. Calibrate
+    // the weight inversion off the leaf rect — still exactly proportional to
+    // currentFr / sum(groupFr) — and grow a px target by the measured inset
+    // so the VISIBLE surface (what the caller sees) converges to the asked
+    // pixels. A flat (chat) or unrendered leaf measures a zero inset and
+    // behaves as before.
     const rect = surfaceEl?.getBoundingClientRect() ?? null;
+    const leafRect = surfaceEl?.closest('.dock-tree__leaf')?.getBoundingClientRect() ?? rect;
 
     let changed = false;
     if (axes.width && (size.widthPx != null || size.widthPercent != null)) {
+      const inset = leafRect && rect ? Math.max(0, leafRect.width - rect.width) : 0;
       changed =
-        this.#applyAxisSize(axes.width, size.widthPx, size.widthPercent, rect?.width) || changed;
+        this.#applyAxisSize(
+          axes.width,
+          size.widthPx == null ? undefined : size.widthPx + inset,
+          size.widthPercent,
+          leafRect?.width
+        ) || changed;
     }
     if (axes.height && (size.heightPx != null || size.heightPercent != null)) {
+      const inset = leafRect && rect ? Math.max(0, leafRect.height - rect.height) : 0;
       changed =
-        this.#applyAxisSize(axes.height, size.heightPx, size.heightPercent, rect?.height) ||
-        changed;
+        this.#applyAxisSize(
+          axes.height,
+          size.heightPx == null ? undefined : size.heightPx + inset,
+          size.heightPercent,
+          leafRect?.height
+        ) || changed;
     }
 
     if (changed) {
@@ -1084,11 +1143,14 @@ export class SliccDockTree extends HTMLElement {
    * Resolve a `px`/`percent` target (percent wins if both given) into a
    * fraction of `axis`'s group and apply it via `weightForFraction`. A
    * `percent` target needs no measurement at all — it IS the fraction. A
-   * `px` target self-calibrates off `renderedPx` (the leaf's own current
-   * live size along this axis): `renderedPx` already reflects whatever the
-   * browser's actual flex layout (gaps, dividers, everything) produced for
+   * `px` target self-calibrates off `renderedPx` (the LEAF's own current
+   * live size along this axis — not the surface's, which a chrome tile's
+   * margins shrink): `renderedPx` already reflects whatever the browser's
+   * actual flex layout (gaps, dividers, everything) produced for
    * `axis.currentFr / sum(axis.groupFr)`, so inverting that ratio recovers
    * the group's live pixel span without re-deriving CSS geometry by hand.
+   * The caller (`setSurfaceSize`) has already folded the chrome inset into
+   * `px`, so the weight applied here lands the visible surface on target.
    */
   #applyAxisSize(
     axis: SizeAxis,
@@ -1164,6 +1226,10 @@ export class SliccDockTree extends HTMLElement {
       parkSurfaceInline(surfaceEl);
       if (surfaceEl.parentElement !== this.#parking) this.#parking.appendChild(surfaceEl);
     }
+
+    // AFTER the tiles were built against the old base (see #buildTile's
+    // entrance diff), advance it to this render's placed set.
+    this.#prevPlaced = usedIds;
 
     // Every render (setTree restore included — which deliberately does NOT
     // fire dock-tree-change, so persistence can't loop) announces what is
@@ -1275,7 +1341,12 @@ export class SliccDockTree extends HTMLElement {
     tile.className = 'dock-tree__tile';
     // Tool tiles get the floating rounded pane chrome; the reserved chat
     // column renders flat (see the .dock-tree__tile--chrome CSS above).
-    if (surfaceId !== CHAT_SURFACE_ID) tile.classList.add('dock-tree__tile--chrome');
+    // A tool tile that this render NEWLY placed slides in from the right —
+    // re-renders with an unchanged placed set (divider drags) never replay it.
+    if (surfaceId !== CHAT_SURFACE_ID) {
+      tile.classList.add('dock-tree__tile--chrome');
+      if (!this.#prevPlaced.has(surfaceId)) tile.classList.add('dock-tree__tile--enter');
+    }
     if (this.tilesMovable && !this.#isLockedNode(node, zone)) {
       const label = labelForSurface(surfaceId);
       const move = document.createElement('button');

--- a/packages/webcomponents/tests/shell/slicc-chatpane.test.ts
+++ b/packages/webcomponents/tests/shell/slicc-chatpane.test.ts
@@ -80,12 +80,21 @@ describe('slicc-chatpane', () => {
     expect(seen).toEqual([true, false]);
   });
 
-  it('narrows to 34% width when narrow is set', () => {
+  it('keeps the container-filling width when narrow is set — the dock-tree leaf owns column width', () => {
+    // Shell-era `narrow` shrank the column to 34% beside the floating
+    // workbench. Post-dock-tree the surface leaf sizes the column, so `narrow`
+    // only re-themes the thread/composer (via the forwarded `open`) and the
+    // width must NOT change — a 34%-of-the-leaf column would re-open the
+    // phantom gap beside the panel.
     const wide = mount();
-    const wideW = getComputedStyle(wide).width;
+    const wideW = wide.getBoundingClientRect().width;
     const narrow = mount(true);
-    const narrowW = getComputedStyle(narrow).width;
-    expect(narrowW).not.toBe(wideW);
+    const narrowW = narrow.getBoundingClientRect().width;
+    expect(narrowW).toBeCloseTo(wideW, 1);
+    // And the column fills its container rather than reserving the shell-era
+    // 48px rail strip (the rail is a shell sibling now, never inside the leaf).
+    expect(getComputedStyle(wide).flexGrow).toBe('1');
+    expect(wideW).toBeCloseTo(wide.parentElement!.getBoundingClientRect().width, 1);
   });
 
   it('narrow (workbench open, wide viewport): drops the frosted card but KEEPS the centered reading cap', () => {

--- a/packages/webcomponents/tests/shell/slicc-shell.test.ts
+++ b/packages/webcomponents/tests/shell/slicc-shell.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SliccShell } from '../../src/shell/slicc-shell.js';
 // Composed children (by tag) — import so they are registered when tests run.
 import '../../src/dock/slicc-dock.js';
+import '../../src/shell/slicc-chatpane.js';
+import '../../src/workbench/slicc-surface.js';
+import type { DockTreeSpec, SliccDockTree } from '../../src/workbench/slicc-dock-tree.js';
 import '../../src/workbench/slicc-dock-tree.js';
 import { ensureGlobalTokens } from '../../src/theme/tokens.js';
 
@@ -51,5 +54,44 @@ describe('slicc-shell', () => {
     );
     // Chromium's CSSOM normalizes the unitless 0 flex-basis to "0px".
     expect(treeRule?.style.flex).toBe('1 1 0px');
+  });
+
+  it('narrows the chatpane exactly while the dock-tree places any non-chat leaf — the silent setTree restore included', () => {
+    const shell = document.createElement('slicc-shell') as SliccShell;
+    const dockTree = document.createElement('slicc-dock-tree') as SliccDockTree;
+    const chatSurface = document.createElement('slicc-surface');
+    chatSurface.setAttribute('surface-id', 'chat');
+    const pane = document.createElement('slicc-chatpane');
+    chatSurface.append(pane);
+    const term = document.createElement('slicc-surface');
+    term.setAttribute('surface-id', 'term');
+    dockTree.append(chatSurface, term);
+    shell.append(dockTree, document.createElement('slicc-dock'));
+    document.body.appendChild(shell);
+
+    const spec = (withTerm: boolean): DockTreeSpec => ({
+      zones: {
+        top: null,
+        left: { type: 'leaf', surfaceId: 'chat' },
+        middle: null,
+        right: withTerm ? { type: 'leaf', surfaceId: 'term' } : null,
+        bottom: null,
+      },
+      rowFr: { top: 1, center: 1, bottom: 1 },
+      colFr: { left: 1, middle: 1, right: 1 },
+    });
+
+    dockTree.setTree(spec(false));
+    expect(pane.hasAttribute('narrow')).toBe(false);
+
+    // `setTree` fires no `dock-tree-change` (a restore must not re-persist) —
+    // the narrow sync must ride the render notification instead, or a restored
+    // two-leaf layout boots with the wide reading-column feather squeezed into
+    // the narrow column (the post-#1784 regression).
+    dockTree.setTree(spec(true));
+    expect(pane.hasAttribute('narrow')).toBe(true);
+
+    dockTree.removeSurface('term');
+    expect(pane.hasAttribute('narrow')).toBe(false);
   });
 });

--- a/packages/webcomponents/tests/shell/slicc-shell.test.ts
+++ b/packages/webcomponents/tests/shell/slicc-shell.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SliccShell } from '../../src/shell/slicc-shell.js';
 // Composed children (by tag) — import so they are registered when tests run.
+import '../../src/composer/slicc-composer.js';
 import '../../src/dock/slicc-dock.js';
 import '../../src/shell/slicc-chatpane.js';
 import '../../src/workbench/slicc-surface.js';
@@ -93,5 +94,48 @@ describe('slicc-shell', () => {
 
     dockTree.removeSurface('term');
     expect(pane.hasAttribute('narrow')).toBe(false);
+  });
+
+  it('extends the composer band full-bleed on ::before, with the tool pane and rail floating above it', () => {
+    const shell = document.createElement('slicc-shell') as SliccShell;
+    const dockTree = document.createElement('slicc-dock-tree') as SliccDockTree;
+    const chatSurface = document.createElement('slicc-surface');
+    chatSurface.setAttribute('surface-id', 'chat');
+    const pane = document.createElement('slicc-chatpane');
+    const composer = document.createElement('slicc-composer');
+    pane.append(composer);
+    chatSurface.append(pane);
+    const term = document.createElement('slicc-surface');
+    term.setAttribute('surface-id', 'term');
+    dockTree.append(chatSurface, term);
+    const dock = document.createElement('slicc-dock');
+    shell.append(dockTree, dock);
+    document.body.appendChild(shell);
+    dockTree.setTree({
+      zones: {
+        top: null,
+        left: { type: 'leaf', surfaceId: 'chat' },
+        middle: null,
+        right: { type: 'leaf', surfaceId: 'term' },
+        bottom: null,
+      },
+      rowFr: { top: 1, center: 1, bottom: 1 },
+      colFr: { left: 1, middle: 1, right: 1 },
+    });
+
+    // The host no longer paints the band — the ::before does, extending right
+    // (-100vw resolves to a large negative used value) so the band runs under
+    // the floating pane instead of stopping at the column edge.
+    const host = getComputedStyle(composer);
+    expect(host.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    const band = getComputedStyle(composer, '::before');
+    expect(band.content).toBe('""');
+    expect(Number.parseFloat(band.right)).toBeLessThan(0);
+    expect(band.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+    // Pane chrome and rail float ABOVE the band (composer stacks at z-index 2).
+    const termTile = term.closest('.dock-tree__tile') as HTMLElement;
+    expect(getComputedStyle(termTile).zIndex).toBe('3');
+    expect(getComputedStyle(dock).zIndex).toBe('3');
+    expect(getComputedStyle(composer).zIndex).toBe('2');
   });
 });

--- a/packages/webcomponents/tests/workbench/slicc-dock-tree.test.ts
+++ b/packages/webcomponents/tests/workbench/slicc-dock-tree.test.ts
@@ -1861,7 +1861,11 @@ describe('slicc-dock-tree', () => {
       expect(events[0].detail.tree).toEqual(el.getTree());
     });
 
-    it('a pixel target converges the leaf to (approximately) that many rendered pixels', () => {
+    it('a pixel target converges the VISIBLE surface to (approximately) that many rendered pixels', () => {
+      // Both leaves are non-chat, so both tiles carry the 12px-margin chrome:
+      // the calibration must measure the leaf (the actual flex item) and fold
+      // the chrome inset into the target, or the surface lands ~26px short
+      // (the P2 caught on #2023).
       const el = mount(); // 600x400 host
       el.appendChild(surface('a'));
       el.appendChild(surface('b'));
@@ -1873,8 +1877,8 @@ describe('slicc-dock-tree', () => {
       const width = (
         el.querySelector('slicc-surface[surface-id="a"]') as HTMLElement
       ).getBoundingClientRect().width;
-      expect(width).toBeGreaterThan(190);
-      expect(width).toBeLessThan(210);
+      expect(width).toBeGreaterThan(194);
+      expect(width).toBeLessThan(206);
     });
   });
 
@@ -1906,6 +1910,35 @@ describe('slicc-dock-tree', () => {
       const chatCs = getComputedStyle(chatTile);
       expect(chatCs.borderTopLeftRadius).toBe('0px');
       expect(chatCs.marginLeft).toBe('0px');
+    });
+  });
+
+  describe('tile entrance animation', () => {
+    it('slides in only the tiles a render NEWLY placed — carry-over renders never replay it', () => {
+      const el = mount();
+      el.append(surface(CHAT_SURFACE_ID), surface('term'));
+      const chatOnly: DockTreeSpec = {
+        ...EMPTY_SPEC,
+        zones: { ...EMPTY_SPEC.zones, left: leaf(CHAT_SURFACE_ID) },
+      };
+      el.setTree(chatOnly);
+      el.setTree({
+        ...EMPTY_SPEC,
+        zones: { ...EMPTY_SPEC.zones, left: leaf(CHAT_SURFACE_ID), right: leaf('term') },
+      });
+      const termTile = () =>
+        el.querySelector('slicc-surface[surface-id="term"]')?.closest('.dock-tree__tile');
+      const chatTile = el
+        .querySelector(`slicc-surface[surface-id="${CHAT_SURFACE_ID}"]`)
+        ?.closest('.dock-tree__tile');
+      // The newly placed tool tile enters; the carried-over chat leaf (flat,
+      // never animated) does not.
+      expect(termTile()?.classList.contains('dock-tree__tile--enter')).toBe(true);
+      expect(chatTile?.classList.contains('dock-tree__tile--enter')).toBe(false);
+      // A re-render with an unchanged placed set (what every divider-drag
+      // pointermove produces) must NOT restart the slide-in.
+      el.setSurfaceSize('term', { widthPercent: 40 });
+      expect(termTile()?.classList.contains('dock-tree__tile--enter')).toBe(false);
     });
   });
 

--- a/packages/webcomponents/tests/workbench/slicc-dock-tree.test.ts
+++ b/packages/webcomponents/tests/workbench/slicc-dock-tree.test.ts
@@ -1877,4 +1877,59 @@ describe('slicc-dock-tree', () => {
       expect(width).toBeLessThan(210);
     });
   });
+
+  describe('tile chrome', () => {
+    it('frames every non-chat tile with the rounded pane chrome and keeps chat flat', () => {
+      const el = mount();
+      el.append(surface(CHAT_SURFACE_ID), surface('term'));
+      el.setTree({
+        ...EMPTY_SPEC,
+        zones: { ...EMPTY_SPEC.zones, left: leaf(CHAT_SURFACE_ID), right: leaf('term') },
+      });
+      const chatTile = el
+        .querySelector(`slicc-surface[surface-id="${CHAT_SURFACE_ID}"]`)
+        ?.closest('.dock-tree__tile') as HTMLElement;
+      const termTile = el
+        .querySelector('slicc-surface[surface-id="term"]')
+        ?.closest('.dock-tree__tile') as HTMLElement;
+      expect(chatTile.classList.contains('dock-tree__tile--chrome')).toBe(false);
+      expect(termTile.classList.contains('dock-tree__tile--chrome')).toBe(true);
+      // The chrome is the old floating workbench-pane card (the deleted
+      // `<slicc-workbench-pane>` → `<slicc-pane elevated>` chain): rounded,
+      // bordered, clipped to the radius, floated off the edges.
+      const cs = getComputedStyle(termTile);
+      expect(cs.borderTopLeftRadius).toBe('14px');
+      expect(cs.overflow).toBe('hidden');
+      expect(cs.borderTopWidth).toBe('1px');
+      expect(cs.marginLeft).toBe('12px');
+      // The chat column keeps the prototype's flat full-bleed treatment.
+      const chatCs = getComputedStyle(chatTile);
+      expect(chatCs.borderTopLeftRadius).toBe('0px');
+      expect(chatCs.marginLeft).toBe('0px');
+    });
+  });
+
+  describe('dock-tree-render notification', () => {
+    it('announces the placed surfaceIds after every render — the silent setTree restore included', () => {
+      const el = mount();
+      el.append(surface(CHAT_SURFACE_ID), surface('term'));
+      const placed: string[][] = [];
+      const changes: unknown[] = [];
+      el.addEventListener('dock-tree-render', (e) =>
+        placed.push([...(e as CustomEvent<{ placed: string[] }>).detail.placed])
+      );
+      el.addEventListener('dock-tree-change', (e) => changes.push(e));
+      el.setTree({
+        ...EMPTY_SPEC,
+        zones: { ...EMPTY_SPEC.zones, left: leaf(CHAT_SURFACE_ID), right: leaf('term') },
+      });
+      expect(placed.at(-1)?.sort()).toEqual([CHAT_SURFACE_ID, 'term']);
+      // `setTree` deliberately fires no `dock-tree-change` (persistence must
+      // not loop on restore) — the render notification is the display-only
+      // channel that still fires, so `<slicc-shell>` can sync chatpane state.
+      expect(changes).toHaveLength(0);
+      el.removeSurface('term');
+      expect(placed.at(-1)).toEqual([CHAT_SURFACE_ID]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the layout regressions introduced by #1784 (collapse to a single dock-tree layout) that neither follow-up (#1935, #1966) addressed — the phantom gap beside the chat column, the missing narrow-chat state, and the missing rounded frame around right-rail slide-ins.

### Root cause 1 — shell-era chatpane widths (the gaps)

`<slicc-chatpane>` still carried `width: calc(100% - 48px)` (and `34%` when `narrow`) from the pre-#1784 shell, where it sat directly beside the 48px dock rail. Post-#1784 the chatpane lives inside a `<slicc-surface>` dock-tree leaf and the rail is a separate `<slicc-shell>` flex sibling **outside** the tree — so the 48px was subtracted twice, leaving a permanent dead strip between the chat column and whatever sits to its right (measured live: surface 932px / chatpane 884px collapsed; zone 417px / chatpane 369px with a panel open, plus the 18px divider seam).

**Fix:** the column now fills its surface leaf (`flex: 1 1 0; width: 100%; min-width: 0`); the leaf owns column width. The flag-gated panel path already neutralized exactly these rules for itself (`panelize-shell.ts` — "reserving 48px here would double-count it"); this applies the same contract to the shipping path, at the component.

### Root cause 2 — nobody set `narrow` anymore (squeezed reading column, overflowing "newline" hint)

Pre-#1784 the shell toggled `chatpane[narrow]` when the workbench opened, which forwarded `open` to the thread + composer (tight reading feather, hidden ⏎ send / ⇧⏎ newline hints — `slicc-composer-meta` has `:host([narrow]) .hint{display:none}` for precisely this). That wiring died with the workbench pane, so a squeezed column kept the wide-layout 72px padding + 54px margins, and the visible hint row jutted into the phantom strip.

**Fix:** `<slicc-dock-tree>` now fires `dock-tree-render` (composed + bubbling, `detail: { placed }`) after **every** render — including the deliberately change-silent `setTree` restore, which `dock-tree-change` must not cover (persistence would loop). `<slicc-shell>` keys the chatpane's `narrow` off it: set exactly while any non-chat leaf is placed. Display-only; never feeds persistence. `narrow` no longer changes the column width — it only re-themes the thread/composer.

### Root cause 3 — the rounded frame died with `<slicc-workbench-pane>` (bare files tree / flush black terminal)

Right-rail slide-ins used to render inside `<slicc-workbench-pane>` → `<slicc-pane elevated>`: `--canvas` card, 1px `--line` border, 14px radius, elevated two-layer shadow, 12px float margin. #1784 deleted the wrapper and dock-tree tiles rendered surfaces completely bare — the files tree floated directly on the shader with no background at all.

**Fix:** non-chat tiles now carry the same chrome via `.dock-tree__tile--chrome` (dark-mode shadow override included; `overflow: hidden` clips xterm's dark fill and iframes to the corners). The reserved `chat` leaf stays flat/full-bleed, exactly like the prototype. Per review decision, the chrome lives in the component's tile renderer so **all floats get it** — not in webapp glue.

## Tests

- `slicc-chatpane`: narrow keeps the container-filling width (regression guard for the 34% phantom gap); existing narrow-forwarding suite unchanged.
- `slicc-dock-tree`: chrome class + computed chrome on non-chat tiles, chat stays flat; `dock-tree-render` fires with placed ids on every render while `setTree` stays `dock-tree-change`-silent.
- `slicc-shell`: `narrow` syncs on place/remove **and** across the silent `setTree` restore.

Full pass run locally: `npm run verify` (incl. boy-scout debt gate), `npm run typecheck`, root `npm run test` (14098 passed), `@slicc/webcomponents` browser suite (2070 passed), `npm run test:coverage`, both builds, `npm run bundle-size`.

## Docs

`docs/layouts.md` (dock-tree section), `docs/webcomponents-details.md` (events + tile chrome), `packages/webcomponents/CLAUDE.md` (dock-tree rules).

## Screenshots

This is a UI PR — please wait for the Storybook screenshot comment (the `Shell/Layouts (prototype)` story shows the framed tool tiles + narrowed chat end-to-end; `Shell/Chat Pane` covers wide/narrow) and give it a visual once-over before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqwJGNn7Y2ic9zDacroz66
