### PR TITLE
feat(agent): persist agent session (tri-value /sessions|/tmp|off) + fixed name; enable for memory curator

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -17,7 +17,6 @@
   "packages/webapp/src/shell/bsh-watchdog.ts": 3,
   "packages/webapp/src/shell/mcp/redirect-uri.ts": 1,
   "packages/webapp/src/shell/proxied-fetch.ts": 2,
-  "packages/webapp/src/shell/supplemental-commands/agent-command.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/cherry-emit-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/crontask-command.ts": 6,
   "packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts": 1,

--- a/packages/webapp/src/base/thinking-level.ts
+++ b/packages/webapp/src/base/thinking-level.ts
@@ -1,0 +1,29 @@
+/**
+ * Foundational (`base/` layer) home for the reasoning/thinking-level
+ * vocabulary. The `ThinkingLevel` type itself comes from
+ * `@earendil-works/pi-agent-core`; the runtime enumeration and its type guard
+ * live here so lower layers (e.g. `shell/`'s `agent` command) can validate a
+ * `--thinking` value without an up-the-stack back-edge into `scoops/`.
+ *
+ * `scoops/types.ts` re-exports these so its existing importers are unchanged.
+ * New code should import from `base/thinking-level.js`.
+ */
+
+import type { ThinkingLevel } from '@earendil-works/pi-agent-core';
+
+export type { ThinkingLevel };
+
+/** Full enumeration accepted by the `agent --thinking` flag and tools. */
+export const THINKING_LEVELS: readonly ThinkingLevel[] = [
+  'off',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+] as const;
+
+/** Type guard: is `value` a valid {@link ThinkingLevel}? */
+export function isThinkingLevel(value: unknown): value is ThinkingLevel {
+  return typeof value === 'string' && (THINKING_LEVELS as readonly string[]).includes(value);
+}

--- a/packages/webapp/src/scoops/agent-bridge.ts
+++ b/packages/webapp/src/scoops/agent-bridge.ts
@@ -653,6 +653,14 @@ export function createAgentBridge(
     const nameToken = options.name !== undefined ? options.name : pickFreshNameToken(ctx);
     const folder = `agent-${nameToken}`;
     const jid = `agent_${tokenToJid(nameToken)}`;
+    // A fixed name bypasses pickFreshNameToken's collision guard: if a scoop
+    // with this JID is still registered — a detached run still in flight, or a
+    // crashed one not yet cleaned up — reusing the name would clobber its
+    // session history and scratch folder. Reject rather than collide; the
+    // random path can never hit this (it excludes live JIDs by construction).
+    if (options.name !== undefined && ctx.orchestrator.getScoops().some((s) => s.jid === jid)) {
+      return { finalText: `agent: name already in use: ${nameToken}`, exitCode: 1 };
+    }
     const scratchFolder = `/scoops/${folder}`;
 
     const scoopConfig = buildScoopConfig(

--- a/packages/webapp/src/scoops/agent-bridge.ts
+++ b/packages/webapp/src/scoops/agent-bridge.ts
@@ -34,6 +34,7 @@ import type { SessionStore } from '../core/session.js';
 import type { VirtualFS } from '../fs/index.js';
 import { normalizePath } from '../fs/path-utils.js';
 import { resolveModelIdForScoop } from '../providers/account-store.js';
+import { serializeAgentSessionArchive } from './agent-session-archive.js';
 import type { Orchestrator } from './orchestrator.js';
 import {
   CURRENT_SCOOP_CONFIG_VERSION,
@@ -137,6 +138,30 @@ export interface AgentSpawnOptions {
    * Best-effort: a receipt write failure is logged, never fails the spawn.
    */
   successReceiptPath?: string;
+  /**
+   * Persist the spawned agent's full session transcript to disk when the run
+   * completes — written on BOTH success and failure, BEFORE the scoop's IDB
+   * session is dropped, with the bridge's full shared-VFS handle (the scoop
+   * itself never sees the path). For later human analysis; it never touches
+   * `/sessions/index.json`. Tri-value:
+   *   - `true`      → durable archive at `/sessions/agent-<name>-<timestamp>.md`
+   *   - `undefined` → ephemeral archive at `/tmp/agent-<name>-<timestamp>.md`
+   *                   (default; `/tmp` is cleared on a new chat)
+   *   - `false`     → no archive is written at all
+   * `<name>` is the agent name token; `<timestamp>` is
+   * `new Date().toISOString()` with `:` and `.` replaced by `-`.
+   * Best-effort: a write failure is logged, never fails the spawn.
+   */
+  persistSession?: boolean;
+  /**
+   * Fixed agent name token, used instead of the random `<adjective>-<flavor>`
+   * generator when provided. Must match the generated name shape — one or more
+   * lowercase tokens joined by single dashes, e.g. `memory-curator` — so the
+   * `agent-<name>` scratch folder and `agent_<name_with_underscores>` jid both
+   * parse cleanly. Validated in `validateSpawnOptions`; a malformed value
+   * returns a spawn error instead of registering a scoop.
+   */
+  name?: string;
   /**
    * Hard turn ceiling for the spawned run (#1972). Enforced in
    * `ScoopContext` where the agent loop runs — the run stops at the
@@ -310,6 +335,16 @@ function validateSpawnOptions(
     };
   }
 
+  const requestedName = options.name;
+  if (requestedName !== undefined && !isValidAgentName(requestedName)) {
+    return {
+      error: {
+        finalText: `agent: invalid name: ${requestedName} (lowercase tokens joined by single dashes)`,
+        exitCode: 1,
+      },
+    };
+  }
+
   for (const [name, value] of [
     ['maxTurns', options.maxTurns],
     ['maxWallClockMs', options.maxWallClockMs],
@@ -339,6 +374,51 @@ async function writeSuccessReceipt(sharedFs: VirtualFS, path: string): Promise<v
     await sharedFs.writeFile(path, new Date().toISOString());
   } catch (err) {
     log.warn('success receipt write failed', { path, error: errText(err) });
+  }
+}
+
+/** A valid fixed agent name: one or more lowercase tokens joined by dashes. */
+const AGENT_NAME_PATTERN = /^[a-z]+(?:-[a-z]+)*$/;
+function isValidAgentName(name: string): boolean {
+  return AGENT_NAME_PATTERN.test(name);
+}
+
+/**
+ * Persist the spawned agent's transcript to disk (see
+ * {@link AgentSpawnOptions.persistSession}). Called from the spawn `finally`,
+ * so it runs on BOTH success and failure and BEFORE `cleanupScoop` deletes
+ * the IDB session and the `ScoopContext` the history is read from. Uses the
+ * bridge's own shared-VFS handle. Best-effort — a failure is logged, never
+ * fails the spawn.
+ */
+async function writeAgentSessionArchive(
+  ctx: BridgeContext,
+  options: AgentSpawnOptions,
+  jid: string,
+  nameToken: string,
+  outcome: AgentSpawnResult
+): Promise<void> {
+  if (options.persistSession === false) return;
+  const dir = options.persistSession === true ? '/sessions' : '/tmp';
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const path = `${dir}/agent-${nameToken}-${timestamp}.md`;
+  try {
+    // The ScoopContext may already be gone (e.g. registerScoop threw); guard.
+    const scoopCtx = ctx.orchestrator.getScoopContext(jid);
+    const messages =
+      typeof scoopCtx?.getAgentMessages === 'function' ? scoopCtx.getAgentMessages() : [];
+    const markdown = serializeAgentSessionArchive({
+      name: nameToken,
+      jid,
+      prompt: options.prompt,
+      exitCode: outcome.exitCode,
+      messages,
+      timestamp,
+    });
+    await ctx.sharedFs.mkdir(dir, { recursive: true });
+    await ctx.sharedFs.writeFile(path, markdown);
+  } catch (err) {
+    log.warn('agent session archive write failed', { path, error: errText(err) });
   }
 }
 
@@ -490,6 +570,51 @@ async function cleanupScoop(
 }
 
 /**
+ * Register the scoop, run its agent loop, and map the run to an
+ * {@link AgentSpawnResult} — never throwing (every failure path returns an
+ * exit-1 result). Extracted from `spawn` so the caller can keep the
+ * archive-then-cleanup `finally` thin. A `registerScoop` failure still
+ * returns a value here, so `spawn`'s `finally` runs cleanup regardless.
+ */
+async function runScoopToOutcome(
+  ctx: BridgeContext,
+  options: AgentSpawnOptions,
+  scoop: RegisteredScoop,
+  jid: string,
+  observerHandle: ReturnType<typeof registerScoopObserver>
+): Promise<AgentSpawnResult> {
+  try {
+    await ctx.orchestrator.registerScoop(scoop);
+  } catch (err) {
+    return { finalText: observerHandle.scoopError ?? errText(err), exitCode: 1 };
+  }
+
+  try {
+    const result = await runScoopAndCaptureOutput(
+      ctx.orchestrator,
+      jid,
+      options.prompt,
+      options.structuredOutputSchema,
+      observerHandle
+    );
+    if (options.signal?.aborted) {
+      return { finalText: 'agent: aborted', exitCode: 1 };
+    }
+    if (result) {
+      // Durable completion signal, written before the spawn resolves so
+      // it lands strictly earlier than any caller-side bookkeeping.
+      if (result.exitCode === 0 && options.successReceiptPath) {
+        await writeSuccessReceipt(ctx.sharedFs, options.successReceiptPath);
+      }
+      return result;
+    }
+    return { finalText: observerHandle.scoopError ?? '', exitCode: 1 };
+  } catch (err) {
+    return { finalText: observerHandle.scoopError ?? errText(err), exitCode: 1 };
+  }
+}
+
+/**
  * Create an {@link AgentBridge} bound to an orchestrator + shared VFS.
  *
  * `sharedFs` is used only for the scratch-folder cleanup
@@ -524,7 +649,8 @@ export function createAgentBridge(
       resolveParentThinkingLevel(ctx.orchestrator, options.parentJid) ??
       undefined;
 
-    const nameToken = pickFreshNameToken(ctx);
+    // A validated fixed name wins; otherwise pick a fresh collision-free token.
+    const nameToken = options.name !== undefined ? options.name : pickFreshNameToken(ctx);
     const folder = `agent-${nameToken}`;
     const jid = `agent_${tokenToJid(nameToken)}`;
     const scratchFolder = `/scoops/${folder}`;
@@ -575,38 +701,18 @@ export function createAgentBridge(
       return { finalText: 'agent: aborted before start', exitCode: 1 };
     }
 
+    // Held so the `finally` can archive the transcript with the real exit
+    // code, whatever path `runScoopToOutcome` leaves through.
+    let outcome: AgentSpawnResult = { finalText: '', exitCode: 1 };
     try {
-      try {
-        await ctx.orchestrator.registerScoop(scoop);
-      } catch (err) {
-        return { finalText: observerHandle.scoopError ?? errText(err), exitCode: 1 };
-      }
-
-      const result = await runScoopAndCaptureOutput(
-        ctx.orchestrator,
-        jid,
-        options.prompt,
-        options.structuredOutputSchema,
-        observerHandle
-      );
-      if (options.signal?.aborted) {
-        return { finalText: 'agent: aborted', exitCode: 1 };
-      }
-      if (result) {
-        // Durable completion signal, written before the spawn resolves so
-        // it lands strictly earlier than any caller-side bookkeeping.
-        if (result.exitCode === 0 && options.successReceiptPath) {
-          await writeSuccessReceipt(ctx.sharedFs, options.successReceiptPath);
-        }
-        return result;
-      }
-
-      return { finalText: observerHandle.scoopError ?? '', exitCode: 1 };
-    } catch (err) {
-      return { finalText: observerHandle.scoopError ?? errText(err), exitCode: 1 };
+      outcome = await runScoopToOutcome(ctx, options, scoop, jid, observerHandle);
+      return outcome;
     } finally {
       options.signal?.removeEventListener('abort', onAbort);
       observerHandle.unsubscribe?.();
+      // Archive the transcript BEFORE cleanupScoop drops the IDB session and
+      // the ScoopContext the history is read from. Runs on success AND failure.
+      await writeAgentSessionArchive(ctx, options, jid, nameToken, outcome);
       await cleanupScoop(ctx, jid, folder, scratchFolder);
     }
   }

--- a/packages/webapp/src/scoops/agent-session-archive.ts
+++ b/packages/webapp/src/scoops/agent-session-archive.ts
@@ -1,0 +1,112 @@
+/**
+ * Small, human-readable markdown serializer for a spawned agent's session
+ * transcript. Written to disk on spawn completion (see
+ * `agent-bridge.ts`'s `writeAgentSessionArchive`) for later human analysis —
+ * NOT a machine-reload format, and it deliberately does not touch
+ * `/sessions/index.json`.
+ *
+ * It reuses {@link agentMessagesToChatMessages} (same `scoops/` layer) to
+ * collapse the `AgentMessage[]` tool-call/result pairing into the flat
+ * `ChatMessage` shape, then renders each message as `## <role>` + its text
+ * with tool calls and results summarized. It imports nothing from `ui/` or
+ * `transcript/` — those are layer back-edges from `scoops/` (the
+ * session-freezer's `formatArchiveAsMarkdown` lives in `ui/`, so it is
+ * intentionally NOT used here).
+ */
+
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
+import { agentMessagesToChatMessages } from './agent-message-to-chat.js';
+import type { ChatMessage, ToolCall } from './chat-types.js';
+
+/** Inputs to {@link serializeAgentSessionArchive}. */
+export interface AgentSessionArchiveInput {
+  /** Agent name token, e.g. `memory-curator` or `zesty-custard`. */
+  name: string;
+  /** Full jid, e.g. `agent_memory_curator`. */
+  jid: string;
+  /** Prompt the agent was spawned with. */
+  prompt: string;
+  /** Final exit code (0 = success, non-zero = failure). */
+  exitCode: number;
+  /**
+   * Canonical agent history (`ScoopContext.getAgentMessages()`). May be
+   * empty when the context was already gone by the time the archive is
+   * written — the header still renders.
+   */
+  messages: readonly AgentMessage[];
+  /** Archive timestamp, already filename-safe (ISO with `:`/`.` → `-`). */
+  timestamp: string;
+}
+
+/**
+ * Render an {@link AgentSessionArchiveInput} to a markdown document: a short
+ * header (name, jid, prompt, exit code, turn/message counts, timestamp)
+ * followed by each message as `## <role>` + text with tool calls summarized.
+ */
+export function serializeAgentSessionArchive(input: AgentSessionArchiveInput): string {
+  const chat = agentMessagesToChatMessages(input.messages, { source: input.name });
+  const turns = chat.filter((m) => m.role === 'assistant').length;
+
+  const lines: string[] = [
+    `# Agent session: ${input.name}`,
+    '',
+    `- jid: ${input.jid}`,
+    `- exit code: ${input.exitCode}`,
+    `- turns: ${turns}`,
+    `- messages: ${input.messages.length}`,
+    `- timestamp: ${input.timestamp}`,
+    '',
+    '## Prompt',
+    '',
+    input.prompt.length > 0 ? input.prompt : '_(empty prompt)_',
+    '',
+    '---',
+    '',
+  ];
+
+  if (chat.length === 0) {
+    lines.push('_(no messages captured)_', '');
+  } else {
+    for (const msg of chat) {
+      appendMessage(lines, msg);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/** Render one flattened chat message (`## <role>` + text + tool calls). */
+function appendMessage(lines: string[], msg: ChatMessage): void {
+  lines.push(`## ${msg.role}`, '');
+  const text = msg.content.trim();
+  if (text.length > 0) lines.push(text, '');
+  for (const call of msg.toolCalls ?? []) {
+    appendToolCall(lines, call);
+  }
+}
+
+/** Summarize a single tool call and its result, readably. */
+function appendToolCall(lines: string[], call: ToolCall): void {
+  lines.push(
+    `### tool: ${call.name}`,
+    '',
+    'Input:',
+    '',
+    '```json',
+    stringifyInput(call.input),
+    '```',
+    ''
+  );
+  if (call.result !== undefined) {
+    lines.push(call.isError ? 'Result (error):' : 'Result:', '', '```', call.result, '```', '');
+  }
+}
+
+/** Best-effort JSON pretty-print; falls back to `String()` on a cycle. */
+function stringifyInput(input: unknown): string {
+  try {
+    return JSON.stringify(input, null, 2) ?? String(input);
+  } catch {
+    return String(input);
+  }
+}

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -392,6 +392,10 @@ function buildSpawnOptions(
     allowedCommands: config.allowedCommands,
     prompt,
     thinkingLevel: config.thinkingLevel,
+    // Durable transcript under a stable name — /sessions/agent-memory-curator-*.md
+    // survives a new chat, so a curator run stays auditable for humans.
+    persistSession: true,
+    name: 'memory-curator',
     // The pass is detached, so the caller's return value goes nowhere. Without
     // this the curator's report — including any skill it found — is discarded
     // and the cone never learns the pass happened at all.

--- a/packages/webapp/src/scoops/types.ts
+++ b/packages/webapp/src/scoops/types.ts
@@ -9,6 +9,10 @@
 import type { ThinkingLevel } from '@earendil-works/pi-agent-core';
 import type { MessageAttachment } from '../core/attachments.js';
 
+// The runtime enumeration and guard live in the foundational `base/` layer so
+// lower layers (shell/'s `agent` command) can validate a `--thinking` value
+// without a back-edge into `scoops/`. Re-exported here for existing importers.
+export { isThinkingLevel, THINKING_LEVELS } from '../base/thinking-level.js';
 export type { ThinkingLevel };
 
 /**
@@ -25,21 +29,6 @@ export const THINKING_LEVEL_CYCLE: readonly ThinkingLevel[] = [
   'high',
   'xhigh',
 ] as const;
-
-/** Full enumeration accepted by the `agent --thinking` flag and tools. */
-export const THINKING_LEVELS: readonly ThinkingLevel[] = [
-  'off',
-  'minimal',
-  'low',
-  'medium',
-  'high',
-  'xhigh',
-] as const;
-
-/** Type guard: is `value` a valid {@link ThinkingLevel}? */
-export function isThinkingLevel(value: unknown): value is ThinkingLevel {
-  return typeof value === 'string' && (THINKING_LEVELS as readonly string[]).includes(value);
-}
 
 /**
  * Current `ScoopConfig` schema generation. Bumped whenever a new field is

--- a/packages/webapp/src/shell/supplemental-commands/agent-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/agent-command.ts
@@ -1,8 +1,8 @@
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
-import { createLogger } from '../../core/logger.js';
+import { createLogger } from '../../base/logger.js';
+import { isThinkingLevel, THINKING_LEVELS, type ThinkingLevel } from '../../base/thinking-level.js';
 import { normalizePath } from '../../fs/path-utils.js';
-import { isThinkingLevel, THINKING_LEVELS, type ThinkingLevel } from '../../scoops/types.js';
 
 const log = createLogger('agent-command');
 
@@ -28,6 +28,13 @@ interface AgentSpawnOptions {
   thinkingLevel?: ThinkingLevel;
   /** Structured output schema for the spawned scoop. */
   structuredOutputSchema?: Record<string, unknown>;
+  /**
+   * Tri-value session-transcript persistence forwarded to the bridge:
+   * `true` (`--persist-session`) writes a durable `/sessions/...` archive,
+   * `false` (`--no-persist-session`) writes nothing, and `undefined` (neither
+   * flag) leaves the bridge's default — an ephemeral `/tmp/...` archive.
+   */
+  persistSession?: boolean;
 }
 
 /** Options accepted by {@link createAgentCommand}. */
@@ -96,6 +103,13 @@ Options:
                           explicit list if you want them back (e.g.
                           "/workspace/,$(pwd)"). Each entry is normalized to
                           a trailing slash.
+  --persist-session       Write the spawned agent's full session transcript to
+                          /sessions/agent-<name>-<timestamp>.md (durable —
+                          survives a new chat) for later human analysis.
+  --no-persist-session    Do not write a session transcript at all. With
+                          NEITHER flag, the transcript is written to
+                          /tmp/agent-<name>-<timestamp>.md, which a new chat
+                          clears.
   -h, --help              Show this help message and exit.
 
 Examples:
@@ -115,6 +129,7 @@ interface ParsedArgs {
   visiblePaths?: string[];
   thinkingLevel?: ThinkingLevel;
   structuredOutputSchema?: Record<string, unknown>;
+  persistSession?: boolean;
   error?: string;
 }
 
@@ -201,6 +216,7 @@ interface ParseState {
   visiblePaths?: string[];
   thinkingLevel?: ThinkingLevel;
   schemaOut?: Record<string, unknown>;
+  persistSession?: boolean;
 }
 
 /** Process one argument. Returns error or null and consumed count. */
@@ -246,6 +262,16 @@ function processArg(
     if (result.error) return { error: result.error, consumed: 0 };
     state.schemaOut = result.value;
     return { consumed: result.consumed };
+  }
+
+  if (arg === '--persist-session') {
+    state.persistSession = true;
+    return { consumed: 1 };
+  }
+
+  if (arg === '--no-persist-session') {
+    state.persistSession = false;
+    return { consumed: 1 };
   }
 
   if (arg.length > 0 && arg.startsWith('-')) {
@@ -327,6 +353,7 @@ function parseArgs(args: string[]): ParsedArgs {
     visiblePaths: state.visiblePaths,
     thinkingLevel: state.thinkingLevel,
     structuredOutputSchema: state.schemaOut,
+    persistSession: state.persistSession,
   };
 }
 
@@ -433,6 +460,9 @@ function buildSpawnOptions(
   }
   if (parsed.structuredOutputSchema !== undefined) {
     spawnOptions.structuredOutputSchema = parsed.structuredOutputSchema;
+  }
+  if (parsed.persistSession !== undefined) {
+    spawnOptions.persistSession = parsed.persistSession;
   }
   if (ctx.cwd && ctx.cwd.length > 0) {
     spawnOptions.invokingCwd = ctx.cwd;

--- a/packages/webapp/tests/scoops/agent-bridge.test.ts
+++ b/packages/webapp/tests/scoops/agent-bridge.test.ts
@@ -1364,6 +1364,8 @@ describe('createAgentBridge — success receipts (#1989)', () => {
 
     const result = await bridge.spawn({
       ...BASE_OPTS,
+      // Isolate the receipt write from the default /tmp session archive.
+      persistSession: false,
       successReceiptPath: '/sessions/.curated/pending-abc.md',
     });
 
@@ -1384,6 +1386,8 @@ describe('createAgentBridge — success receipts (#1989)', () => {
 
     const result = await bridge.spawn({
       ...BASE_OPTS,
+      // Isolate the receipt assertion from the default /tmp session archive.
+      persistSession: false,
       successReceiptPath: '/sessions/.curated/pending-abc.md',
     });
 
@@ -1494,5 +1498,143 @@ describe('createAgentBridge — run bounds + cancellation (#1972)', () => {
 
     expect(stopScoop).toHaveBeenCalledWith('agent_reclaimed_sorbet');
     expect(result).toEqual({ finalText: 'agent: aborted', exitCode: 1 });
+  });
+});
+
+describe('createAgentBridge — session archive (persistSession)', () => {
+  it('persistSession: true writes a durable archive under /sessions', async () => {
+    const { orchestrator, scripts } = makeMockOrchestrator();
+    const { fs, writes } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'zesty-custard',
+    });
+    scripts.set('agent_zesty_custard', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn({ ...BASE_OPTS, persistSession: true });
+
+    const archive = writes.filter((w) => w.path.startsWith('/sessions/agent-zesty-custard-'));
+    expect(archive).toHaveLength(1);
+    expect(archive[0].path).toMatch(/^\/sessions\/agent-zesty-custard-.*\.md$/);
+    expect(archive[0].content).toContain('# Agent session: zesty-custard');
+  });
+
+  it('persistSession undefined (default) writes an ephemeral archive under /tmp', async () => {
+    const { orchestrator, scripts } = makeMockOrchestrator();
+    const { fs, writes } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'zesty-custard',
+    });
+    scripts.set('agent_zesty_custard', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn(BASE_OPTS);
+
+    const archive = writes.filter((w) => w.path.startsWith('/tmp/agent-'));
+    expect(archive).toHaveLength(1);
+    expect(archive[0].path).toMatch(/^\/tmp\/agent-zesty-custard-.*\.md$/);
+  });
+
+  it('persistSession: false writes no session archive', async () => {
+    const { orchestrator, scripts } = makeMockOrchestrator();
+    const { fs, writes } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'zesty-custard',
+    });
+    scripts.set('agent_zesty_custard', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn({ ...BASE_OPTS, persistSession: false });
+
+    expect(writes).toHaveLength(0);
+  });
+
+  it('a fixed name produces the agent-<name> folder and agent_<name> jid', async () => {
+    const { orchestrator, registerCalls, scripts } = makeMockOrchestrator();
+    const { fs, writes } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      // Would be used only on the default (random) path — the fixed name wins.
+      generateName: () => 'should-not-be-used',
+    });
+    scripts.set('agent_memory_curator', (obs) => obs.onSendMessage?.('done'));
+
+    await bridge.spawn({ ...BASE_OPTS, name: 'memory-curator', persistSession: true });
+
+    expect(registerCalls[0].folder).toBe('agent-memory-curator');
+    expect(registerCalls[0].jid).toBe('agent_memory_curator');
+    const archive = writes.filter((w) => w.path.startsWith('/sessions/agent-memory-curator-'));
+    expect(archive).toHaveLength(1);
+  });
+
+  it('rejects a malformed fixed name without spawning', async () => {
+    const { orchestrator, registerCalls } = makeMockOrchestrator();
+    const { fs, writes } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'jolly-mint',
+    });
+
+    const result = await bridge.spawn({ ...BASE_OPTS, name: 'Bad_Name!' });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.finalText).toContain('invalid name');
+    expect(registerCalls).toHaveLength(0);
+    expect(writes).toHaveLength(0);
+  });
+
+  it('writes the session archive even when the agent exits non-zero', async () => {
+    const { orchestrator, scripts } = makeMockOrchestrator();
+    const { fs, writes } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'zesty-custard',
+    });
+    scripts.set('agent_zesty_custard', (obs) => obs.onError?.('provider exploded'));
+
+    const result = await bridge.spawn({ ...BASE_OPTS, persistSession: true });
+
+    expect(result.exitCode).toBe(1);
+    const archive = writes.filter((w) => w.path.startsWith('/sessions/agent-zesty-custard-'));
+    expect(archive).toHaveLength(1);
+    // The header carries the non-zero exit for the human reader.
+    expect(archive[0].content).toContain('exit code: 1');
+  });
+
+  it('serializes captured agent messages into the archive body', async () => {
+    const { orchestrator, scripts } = makeMockOrchestrator();
+    const { fs, writes } = makeMockSharedFs();
+    const messages = [
+      { role: 'user', content: 'do the thing', timestamp: 1 },
+      { role: 'assistant', content: 'did it', timestamp: 2 },
+    ];
+    (orchestrator.getScoopContext as ReturnType<typeof vi.fn>).mockReturnValue({
+      getAgentMessages: () => messages,
+    } as unknown as ScoopContext);
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'zesty-custard',
+    });
+    scripts.set('agent_zesty_custard', (obs) => obs.onSendMessage?.('did it'));
+
+    await bridge.spawn({ ...BASE_OPTS, prompt: 'do the thing', persistSession: true });
+
+    const archive = writes.find((w) => w.path.startsWith('/sessions/agent-zesty-custard-'));
+    expect(archive?.content).toContain('## Prompt');
+    expect(archive?.content).toContain('do the thing');
+    expect(archive?.content).toContain('## user');
+    expect(archive?.content).toContain('## assistant');
+    expect(archive?.content).toContain('did it');
+  });
+
+  it('never fails the spawn when the archive write throws', async () => {
+    const { orchestrator, scripts } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs({
+      writeFile: async () => {
+        throw new Error('quota exceeded');
+      },
+    });
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'zesty-custard',
+    });
+    scripts.set('agent_zesty_custard', (obs) => obs.onSendMessage?.('done'));
+
+    const result = await bridge.spawn({ ...BASE_OPTS, persistSession: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.finalText).toBe('done');
   });
 });

--- a/packages/webapp/tests/scoops/agent-bridge.test.ts
+++ b/packages/webapp/tests/scoops/agent-bridge.test.ts
@@ -1578,6 +1578,28 @@ describe('createAgentBridge — session archive (persistSession)', () => {
     expect(writes).toHaveLength(0);
   });
 
+  it('rejects a fixed name whose jid is already registered, without spawning', async () => {
+    const { orchestrator, registerCalls, knownScoops } = makeMockOrchestrator();
+    const { fs, writes } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'should-not-be-used',
+    });
+    // A prior curator (still running, or crashed-but-registered) holds the jid.
+    knownScoops.push({ jid: 'agent_memory_curator', folder: 'agent-memory-curator' } as never);
+
+    const result = await bridge.spawn({
+      ...BASE_OPTS,
+      name: 'memory-curator',
+      persistSession: true,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.finalText).toContain('name already in use');
+    // No second scoop registered, no archive clobbering the live run's folder.
+    expect(registerCalls).toHaveLength(0);
+    expect(writes).toHaveLength(0);
+  });
+
   it('writes the session archive even when the agent exits non-zero', async () => {
     const { orchestrator, scripts } = makeMockOrchestrator();
     const { fs, writes } = makeMockSharedFs();

--- a/packages/webapp/tests/scoops/agentic-memory.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory.test.ts
@@ -105,6 +105,24 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
     );
   });
 
+  it('persists a durable transcript under the fixed memory-curator name', async () => {
+    const spawn = successSpawn();
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs: fakeVfs(DEFAULT_MEMORY_MD),
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 3,
+      today: '2026-08-06',
+    });
+
+    expect(result).toEqual({ ok: true, report: 'done' });
+    expect(spawn.mock.calls[0][0]).toMatchObject({
+      persistSession: true,
+      name: 'memory-curator',
+    });
+  });
+
   it('passes whole-file budget and freshness rules to the curator', async () => {
     const spawn = successSpawn();
 

--- a/packages/webapp/tests/shell/supplemental-commands/agent-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/agent-command.test.ts
@@ -12,6 +12,7 @@ interface SpawnArgs {
   invokingCwd?: string;
   thinkingLevel?: string;
   structuredOutputSchema?: Record<string, unknown>;
+  persistSession?: boolean;
 }
 
 interface SpawnResult {
@@ -1107,6 +1108,65 @@ describe('agent command', () => {
       });
       await createAgentCommand().execute(['.', '*', 'p'], createMockCtx());
       expect(captured?.structuredOutputSchema).toBeUndefined();
+    });
+  });
+
+  describe('--persist-session / --no-persist-session flags', () => {
+    it('--persist-session forwards persistSession: true', async () => {
+      let captured: SpawnArgs | undefined;
+      installBridge((args) => {
+        captured = args;
+        return { finalText: 'ok', exitCode: 0 };
+      });
+      const result = await createAgentCommand().execute(
+        ['--persist-session', '.', '*', 'p'],
+        createMockCtx()
+      );
+      expect(result.exitCode).toBe(0);
+      expect(captured?.persistSession).toBe(true);
+    });
+
+    it('--no-persist-session forwards persistSession: false', async () => {
+      let captured: SpawnArgs | undefined;
+      installBridge((args) => {
+        captured = args;
+        return { finalText: 'ok', exitCode: 0 };
+      });
+      const result = await createAgentCommand().execute(
+        ['--no-persist-session', '.', '*', 'p'],
+        createMockCtx()
+      );
+      expect(result.exitCode).toBe(0);
+      expect(captured?.persistSession).toBe(false);
+    });
+
+    it('omits persistSession when neither flag is present', async () => {
+      let captured: SpawnArgs | undefined;
+      installBridge((args) => {
+        captured = args;
+        return { finalText: 'ok', exitCode: 0 };
+      });
+      await createAgentCommand().execute(['.', '*', 'p'], createMockCtx());
+      expect(captured?.persistSession).toBeUndefined();
+    });
+
+    it('treats --persist-session as the prompt in the third positional slot', async () => {
+      let captured: SpawnArgs | undefined;
+      installBridge((args) => {
+        captured = args;
+        return { finalText: 'ok', exitCode: 0 };
+      });
+      await createAgentCommand().execute(['.', '*', '--persist-session'], createMockCtx());
+      expect(captured?.prompt).toBe('--persist-session');
+      expect(captured?.persistSession).toBeUndefined();
+    });
+
+    it('mentions both flags in --help', async () => {
+      installBridge(() => ({ finalText: '', exitCode: 0 }));
+      const result = await createAgentCommand().execute(['--help'], createMockCtx());
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/--persist-session/);
+      expect(result.stdout).toMatch(/--no-persist-session/);
     });
   });
 });


### PR DESCRIPTION
## What

A new way to study the memory-curator over-collection (#18): instead of tailing an ephemeral agent, **persist agent sessions to disk**.

Adds a tri-value `persistSession` option + a fixed `name` option to the `agent` supplemental command and its `__slicc_agent` bridge, and enables both for the memory/curator agent.

| `persistSession` | Destination | Lifetime |
|---|---|---|
| `true` | `/sessions/agent-<name>-<ts>.md` | durable |
| `undefined` (default) | `/tmp/agent-<name>-<ts>.md` | cleared on new-chat |
| `false` | — not written — | none |

CLI: `--persist-session` → true, `--no-persist-session` → false, absent → undefined. The **memory curator** is pinned to `name: "memory-curator"` + `persistSession: true`, so every run leaves a durable, consistently-named `/sessions/agent-memory-curator-<ts>.md` transcript to diff over time.

## Design notes
- **Persist runs on success AND failure**, in the spawn `finally` BEFORE `cleanupScoop` deletes the IDB session (that delete is why timing matters). Best-effort (try/catch) — never breaks the spawn.
- **Serializer lives in `scoops/`** (`agent-session-archive.ts`, reusing `agentMessagesToChatMessages`) — deliberately NOT reusing `ui/`'s `formatArchiveAsMarkdown` or `transcript/`, which would be `scoops→ui`/`scoops→transcript` layer back-edges.
- **No `/sessions/index.json` update** — these are analysis artifacts with the `agent-` prefix, kept out of the session-list UI.
- Fixed name validated against `/^[a-z]+(?:-[a-z]+)*$/` → folder `agent-<name>`, jid `agent_<name>`.

## Debt paydown (touched-file gate)
`agent-command.ts` was already on the layer-back-edge baseline (count 2); touching it required paying it down. Moved its logger import `core→base` and extracted `THINKING_LEVELS`/`isThinkingLevel` to `base/thinking-level.ts` (re-exported from `scoops/types.ts`, so all importers are unchanged). Baseline ratcheted.

## Verification
Full 9-project `npm run typecheck`, `npm run verify` (7 checks), touched-exemptions, 4008 scoops+shell tests, `build -w @slicc/webapp`, and coverage floors — all green. New tests cover all three destinations, the fixed name, persist-on-failure, malformed-name rejection, and the CLI flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65