### PR TITLE
fix(fs): drop the self-referential /.metadata.json sidecar entry that bricks boot

### DIFF
--- a/packages/webapp/src/fs/sidecar-merge.ts
+++ b/packages/webapp/src/fs/sidecar-merge.ts
@@ -55,6 +55,25 @@ function isUnder(key: string, prefix: string): boolean {
 }
 
 /**
+ * The one sidecar path that must never appear in its own entry map.
+ *
+ * ZenFS's `crossCopy` indexes the physical `.metadata.json` file, so it turns
+ * up in the in-memory index every session. Persisting a self-entry is a latent
+ * boot brick: its recorded size can never match reality (writing the sidecar
+ * changes the very size stored), so the next cold-boot `crossCopy` hits a "file
+ * data size mismatch" and fails. Both the merge result AND any full-snapshot
+ * recovery flush — which skips {@link mergeSidecarEntries} entirely — must
+ * strip it. The boot self-heal in `sidecar-repair.ts` drops any already on disk.
+ */
+export const SIDECAR_SELF_ENTRY = '/.metadata.json';
+
+/** Drop the self-referential sidecar entry from `doc` in place; returns `doc`. */
+export function stripSidecarSelfEntry(doc: SidecarIndexJson): SidecarIndexJson {
+  if (doc.entries) delete doc.entries[SIDECAR_SELF_ENTRY];
+  return doc;
+}
+
+/**
  * Merge this context's in-memory index (`own`) over the sidecar currently
  * on disk (`onDisk`), constrained to the context's dirty paths/prefixes.
  *
@@ -86,14 +105,8 @@ export function mergeSidecarEntries(
     }
   }
 
-  // The sidecar lives inside the mounted directory, so ZenFS's index scan picks
-  // up `.metadata.json` as a file. Persisting a self-entry is a latent boot
-  // brick: its recorded size can never match (writing the sidecar changes that
-  // very size), so the next cold-boot `crossCopy` hits a "file data size
-  // mismatch" and fails. Never write one; the boot self-heal in
-  // `sidecar-repair.ts` drops any that already exist on disk.
-  delete entries['/.metadata.json'];
-
   const { entries: _ownEntries, ...ownRest } = own;
-  return { ...ownRest, entries };
+  // Never persist a self-entry (see {@link SIDECAR_SELF_ENTRY}); the writer
+  // applies the same strip to its full-snapshot recovery path.
+  return stripSidecarSelfEntry({ ...ownRest, entries });
 }

--- a/packages/webapp/src/fs/sidecar-merge.ts
+++ b/packages/webapp/src/fs/sidecar-merge.ts
@@ -86,6 +86,14 @@ export function mergeSidecarEntries(
     }
   }
 
+  // The sidecar lives inside the mounted directory, so ZenFS's index scan picks
+  // up `.metadata.json` as a file. Persisting a self-entry is a latent boot
+  // brick: its recorded size can never match (writing the sidecar changes that
+  // very size), so the next cold-boot `crossCopy` hits a "file data size
+  // mismatch" and fails. Never write one; the boot self-heal in
+  // `sidecar-repair.ts` drops any that already exist on disk.
+  delete entries['/.metadata.json'];
+
   const { entries: _ownEntries, ...ownRest } = own;
   return { ...ownRest, entries };
 }

--- a/packages/webapp/src/fs/sidecar-repair.ts
+++ b/packages/webapp/src/fs/sidecar-repair.ts
@@ -14,7 +14,7 @@
  * OPFS handles and rewrites the file only when something changed.
  */
 
-import type { SidecarIndexJson } from './sidecar-merge.js';
+import { SIDECAR_SELF_ENTRY, type SidecarIndexJson } from './sidecar-merge.js';
 
 const S_IFMT = 0o170000;
 const S_IFDIR = 0o40000;
@@ -88,7 +88,7 @@ export async function repairSidecarDocument(
     // boot repair can never converge. Drop it rather than true it up — see
     // {@link SidecarRepairSummary.selfEntryDropped}. Prevention lives in
     // `sidecar-merge.ts`, which never persists this entry in the first place.
-    if (path === '/.metadata.json') {
+    if (path === SIDECAR_SELF_ENTRY) {
       delete entries[path];
       summary.selfEntryDropped = true;
       summary.changed = true;

--- a/packages/webapp/src/fs/sidecar-repair.ts
+++ b/packages/webapp/src/fs/sidecar-repair.ts
@@ -37,6 +37,16 @@ export interface SidecarRepairSummary {
   sizesFixed: number;
   /** Entries dropped because their path no longer exists. */
   dropped: number;
+  /**
+   * Whether the self-referential `/.metadata.json` entry was dropped. The
+   * sidecar lives inside the mounted directory, so ZenFS indexes it as a file
+   * — but its recorded size is stale the instant the sidecar is rewritten (the
+   * write changes the very size stored), so a self-entry is a perpetual "file
+   * data size mismatch" that re-bricks `crossCopy` on the next mount. Truing
+   * the size up cannot converge (each rewrite invalidates it again), so the
+   * entry is dropped outright.
+   */
+  selfEntryDropped: boolean;
   /** Whether anything changed (callers skip the rewrite when false). */
   changed: boolean;
 }
@@ -67,11 +77,23 @@ export async function repairSidecarDocument(
     kindFixed: [],
     sizesFixed: 0,
     dropped: 0,
+    selfEntryDropped: false,
     changed: false,
   };
   const entries = doc.entries ?? {};
   for (const [path, raw] of Object.entries(entries)) {
     if (path === '/' || typeof raw !== 'object' || raw === null) continue;
+    // A sidecar must never track itself: writing it changes its own size, so
+    // any recorded `/.metadata.json` size is stale on the retry mount and the
+    // boot repair can never converge. Drop it rather than true it up — see
+    // {@link SidecarRepairSummary.selfEntryDropped}. Prevention lives in
+    // `sidecar-merge.ts`, which never persists this entry in the first place.
+    if (path === '/.metadata.json') {
+      delete entries[path];
+      summary.selfEntryDropped = true;
+      summary.changed = true;
+      continue;
+    }
     const entry = raw as MutableEntry;
     const fmt = (entry.mode ?? 0) & S_IFMT;
     if (fmt === S_IFLNK) continue;

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -373,6 +373,7 @@ export class VirtualFS {
             kindFixed: summary.kindFixed,
             sizesFixed: summary.sizesFixed,
             dropped: summary.dropped,
+            selfEntryDropped: summary.selfEntryDropped,
           })
       )) as { index?: { toJSON: () => unknown } };
       try {

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -32,6 +32,7 @@ import {
   mergeSidecarEntries,
   type SidecarDirtyState,
   type SidecarIndexJson,
+  stripSidecarSelfEntry,
 } from './sidecar-merge.js';
 import { MAX_SYMLINK_DEPTH, realpath, resolveSymlinks } from './symlink-resolver.js';
 import type {
@@ -771,7 +772,12 @@ export class VirtualFS {
       }
       if (onDisk) merged = mergeSidecarEntries(onDisk, own, dirty);
     }
-    const json = JSON.stringify(merged);
+    // `merged` is the raw ZenFS index (`own`) whenever the merge is skipped —
+    // no dirty state, or an absent/unreadable on-disk sidecar (seed/recovery).
+    // That index carries the self-referential `.metadata.json` entry ZenFS's
+    // crossCopy adds, which would re-brick the next boot; strip it on every
+    // path, not only inside `mergeSidecarEntries`.
+    const json = JSON.stringify(stripSidecarSelfEntry(merged));
     const fileHandle = await handle.getFileHandle('.metadata.json', { create: true });
     const writable = await fileHandle.createWritable();
     await writable.write(json);

--- a/packages/webapp/tests/fs/sidecar-merge.test.ts
+++ b/packages/webapp/tests/fs/sidecar-merge.test.ts
@@ -46,6 +46,16 @@ describe('mergeSidecarEntries', () => {
     expect(merged.entries?.['/tmp/own-new.txt']).toEqual(entry('file-own'));
   });
 
+  it('never persists a self-referential /.metadata.json entry (the boot brick)', () => {
+    // ZenFS indexes its own sidecar file, so the entry can arrive from either
+    // the on-disk base or this context's own index. A persisted self-entry
+    // re-bricks the next cold-boot crossCopy; the merge must strip it.
+    const onDisk = doc({ '/': entry('root'), '/.metadata.json': entry('disk-self') });
+    const own = doc({ '/': entry('root'), '/.metadata.json': entry('own-self') });
+    const merged = mergeSidecarEntries(onDisk, own, dirty(['/.metadata.json']));
+    expect(merged.entries).not.toHaveProperty('/.metadata.json');
+  });
+
   it('an empty dirty set leaves the on-disk entries untouched (root aside)', () => {
     const onDisk = doc({ '/': entry('root-disk'), '/a.txt': entry('disk') });
     const own = doc({ '/': entry('root-own'), '/a.txt': entry('stale'), '/b.txt': entry('stale') });

--- a/packages/webapp/tests/fs/sidecar-merge.test.ts
+++ b/packages/webapp/tests/fs/sidecar-merge.test.ts
@@ -3,6 +3,7 @@ import {
   mergeSidecarEntries,
   type SidecarDirtyState,
   type SidecarIndexJson,
+  stripSidecarSelfEntry,
 } from '../../src/fs/sidecar-merge.js';
 
 const entry = (tag: string) => ({ tag });
@@ -122,5 +123,26 @@ describe('mergeSidecarEntries', () => {
   it('tolerates documents with absent entries maps', () => {
     const merged = mergeSidecarEntries({ version: 1 }, { version: 1 }, dirty(['/x']));
     expect(merged.entries).toEqual({});
+  });
+});
+
+describe('stripSidecarSelfEntry', () => {
+  // The writer applies this to its full-snapshot recovery path, which skips
+  // mergeSidecarEntries — the raw ZenFS index there still carries the self-entry.
+  it('drops the self-referential entry, leaving real entries intact', () => {
+    const d = doc({ '/': entry('root'), '/.metadata.json': entry('self'), '/a.txt': entry('a') });
+    const out = stripSidecarSelfEntry(d);
+    expect(out.entries).not.toHaveProperty('/.metadata.json');
+    expect(out.entries?.['/a.txt']).toEqual(entry('a'));
+    expect(out).toBe(d); // mutates in place and returns the same doc
+  });
+
+  it('is a no-op when the self-entry is absent', () => {
+    const d = doc({ '/a.txt': entry('a') });
+    expect(stripSidecarSelfEntry(d).entries).toEqual({ '/a.txt': entry('a') });
+  });
+
+  it('tolerates a document with no entries map', () => {
+    expect(() => stripSidecarSelfEntry({ version: 1 })).not.toThrow();
   });
 });

--- a/packages/webapp/tests/fs/sidecar-repair.test.ts
+++ b/packages/webapp/tests/fs/sidecar-repair.test.ts
@@ -80,7 +80,48 @@ describe('repairSidecarDocument', () => {
       doc,
       probeFrom({ '/ok.txt': { kind: 'file', size: 4 } })
     );
-    expect(summary).toEqual({ kindFixed: [], sizesFixed: 0, dropped: 0, changed: false });
+    expect(summary).toEqual({
+      kindFixed: [],
+      sizesFixed: 0,
+      dropped: 0,
+      selfEntryDropped: false,
+      changed: false,
+    });
+  });
+
+  it('drops the self-referential /.metadata.json entry instead of truing it up', async () => {
+    // The live boot brick: the sidecar records its OWN size, which can never
+    // match reality because writing the sidecar changes that very size. Pre-fix
+    // the repair trued the size up and the rewrite invalidated it again — a
+    // non-converging boot loop. Now the entry is dropped and real files are left
+    // untouched.
+    const doc: SidecarIndexJson = {
+      entries: { '/': dir(), '/.metadata.json': file(3403559), '/ok.txt': file(4) },
+    };
+    const summary = await repairSidecarDocument(
+      doc,
+      probeFrom({
+        '/.metadata.json': { kind: 'file', size: 3336477 },
+        '/ok.txt': { kind: 'file', size: 4 },
+      })
+    );
+    expect(summary.selfEntryDropped).toBe(true);
+    expect(summary.changed).toBe(true);
+    expect(summary.sizesFixed).toBe(0); // dropped, NOT trued up
+    expect(doc.entries).not.toHaveProperty('/.metadata.json');
+    expect(doc.entries).toHaveProperty('/ok.txt'); // real files survive
+  });
+
+  it('converges: a repaired sidecar has no self-entry left to re-fix', async () => {
+    const doc: SidecarIndexJson = { entries: { '/.metadata.json': file(100) } };
+    const probe = probeFrom({ '/.metadata.json': { kind: 'file', size: 50 } });
+    const first = await repairSidecarDocument(doc, probe);
+    expect(first.changed).toBe(true);
+    // Second pass over the already-repaired doc finds nothing — the
+    // non-converging boot-repair loop cannot recur.
+    const second = await repairSidecarDocument(doc, probe);
+    expect(second.changed).toBe(false);
+    expect(second.selfEntryDropped).toBe(false);
   });
 });
 
@@ -89,6 +130,7 @@ describe('resolveWithSidecarRepair', () => {
     kindFixed: ['/x'],
     sizesFixed: 0,
     dropped: 0,
+    selfEntryDropped: false,
     changed: true,
   };
 


### PR DESCRIPTION
## The brick

A production leader failed to boot today — `shell` never mounts, banner reads **"Failed to start"**:

```
Kernel worker boot failed: Unexpected mismatch in file data size.
  tried to read 3403559 bytes but the file is 3336715 bytes. path: /.metadata.json
```

## Root cause

The OPFS sidecar (`/.metadata.json`) lives **inside** the mounted directory, so ZenFS's index scan picks it up as a file and records a size for it. But that size is stale the instant the sidecar is rewritten — **writing the sidecar changes the very size stored** — so a self-entry is a perpetual "file data size mismatch" that fails the next cold boot's `crossCopy`.

The boot self-heal (`repairSidecarDocument`, #1984) made it worse by *truing the size up*: it wrote the corrected size, the rewrite changed the file size again, and the **retry** mount mismatched anew. With only one retry, the leader bricked. The repair could never converge:

```
mount #1:  read 3,488,523 but file is 3,403,559   → repair sets entry=3,403,559, rewrites (file→3,336,715)
mount #2:  read 3,403,559 but file is 3,336,715   → boot fails (retries exhausted)
```

## Fix (two pure, DOM-free layers)

- **`sidecar-merge.ts` — prevention:** never persist a `/.metadata.json` entry. New sidecars stay clean.
- **`sidecar-repair.ts` — self-heal + convergence:** drop the self-entry instead of truing it up. The boot repair now **converges** (a second pass finds nothing to fix), and sidecars already poisoned in the wild self-heal on the next boot. A new `selfEntryDropped` summary field is surfaced in the retry-mount log.

## Live remediation already applied

The affected leader was unbricked **in place** (never wiped) by removing the self-entry from both the `slicc-fs` (phantom 3,403,559-byte record) and `slicc-fs-global` sidecars — the only corruption present; all 11,376 file entries matched reality. It rebooted clean (kernel up, scoops restored, no boot errors). This PR makes that repair automatic and prevents recurrence.

## Tests

- `sidecar-repair.test.ts`: drops the self-entry (not trued up), real files survive, and a **convergence** test (repair twice → the second pass is a no-op).
- `sidecar-merge.test.ts`: merge never emits a `/.metadata.json` entry, from either the on-disk base or the own index.

Full 9-project typecheck, `npm run verify`, touched-exemptions, webapp coverage, and build all green. Sibling bricks: #1984, #1992.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65
