### PR TITLE
fix(preview): serialize preview-vfs responder reads — concurrent reads collapse to one file's content

### DIFF
--- a/packages/webapp/src/speech/espeak-phonemizer.ts
+++ b/packages/webapp/src/speech/espeak-phonemizer.ts
@@ -101,13 +101,22 @@ function readVfsBytes(path: string): Promise<Uint8Array> {
       channel.close();
       cb();
     };
-    const timer = setTimeout(
-      () => done(() => reject(new Error(`ENOENT: ${path} (timed out)`))),
-      30000
-    );
+    let timer: ReturnType<typeof setTimeout>;
+    const armTimeout = (): void => {
+      clearTimeout(timer);
+      timer = setTimeout(() => done(() => reject(new Error(`ENOENT: ${path} (timed out)`))), 30000);
+    };
+    armTimeout();
     const listener = (ev: MessageEvent): void => {
       const data = ev.data as { type?: string; id?: string; content?: unknown; error?: string };
-      if (data?.type !== 'preview-vfs-response' || data.id !== id) return;
+      if (!data || data.id !== id) return;
+      // Serialized responder dequeued this read — restart the budget so time
+      // queued behind another large read doesn't count against this one.
+      if (data.type === 'preview-vfs-start') {
+        armTimeout();
+        return;
+      }
+      if (data.type !== 'preview-vfs-response') return;
       clearTimeout(timer);
       if (typeof data.error === 'string') {
         done(() => reject(new Error(data.error)));

--- a/packages/webapp/src/speech/transformers-env.ts
+++ b/packages/webapp/src/speech/transformers-env.ts
@@ -192,18 +192,30 @@ function readVfsBytes(path: string): Promise<Uint8Array> {
       channel.close();
       cb();
     };
-    const timer = setTimeout(() => {
-      const err = new Error(`ENOENT: ${path} (preview-vfs responder timed out)`) as Error & {
-        [VFS_ENOENT_MARKER]?: true;
-      };
-      err[VFS_ENOENT_MARKER] = true;
-      finish(() => reject(err));
-    }, VFS_READ_TIMEOUT_MS);
+    let timer: ReturnType<typeof setTimeout>;
+    const armTimeout = (): void => {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        const err = new Error(`ENOENT: ${path} (preview-vfs responder timed out)`) as Error & {
+          [VFS_ENOENT_MARKER]?: true;
+        };
+        err[VFS_ENOENT_MARKER] = true;
+        finish(() => reject(err));
+      }, VFS_READ_TIMEOUT_MS);
+    };
+    armTimeout();
     const listener = (ev: MessageEvent): void => {
       const data = ev.data as
         | { type?: string; id?: string; content?: string | Uint8Array; error?: string }
         | undefined;
-      if (data?.type !== 'preview-vfs-response' || data.id !== id) return;
+      if (!data || data.id !== id) return;
+      // Serialized responder dequeued this read — restart the budget so time
+      // queued behind another large read doesn't count against this one.
+      if (data.type === 'preview-vfs-start') {
+        armTimeout();
+        return;
+      }
+      if (data.type !== 'preview-vfs-response') return;
       clearTimeout(timer);
       if (typeof data.error === 'string') {
         const err = new Error(data.error) as Error & { [VFS_ENOENT_MARKER]?: true };

--- a/packages/webapp/src/ui/preview-sw-handler.ts
+++ b/packages/webapp/src/ui/preview-sw-handler.ts
@@ -133,11 +133,16 @@ export async function readViaMainPage(
       }
     }
 
-    const timer = setTimeout(() => {
-      stopRetries();
-      channel.removeEventListener('message', handler);
-      resolve({ ok: false, error: null });
-    }, timeoutMs);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    function armTimeout(): void {
+      if (timer !== undefined) clearTimeout(timer);
+      timer = setTimeout(() => {
+        stopRetries();
+        channel.removeEventListener('message', handler);
+        resolve({ ok: false, error: null });
+      }, timeoutMs);
+    }
+    armTimeout();
 
     function handler(event: MessageEvent): void {
       const data = event.data as
@@ -148,6 +153,14 @@ export async function readViaMainPage(
       // for the actual response (a large read may still be in flight).
       if (data.type === 'preview-vfs-ack') {
         stopRetries();
+        return;
+      }
+      // The serialized responder dequeued this read — restart the budget so
+      // time spent queued behind a large read (multi-hundred-MB model files)
+      // does not count against this read's own deadline.
+      if (data.type === 'preview-vfs-start') {
+        stopRetries();
+        armTimeout();
         return;
       }
       if (data.type !== 'preview-vfs-response') return;

--- a/packages/webapp/src/ui/preview-vfs-responder.ts
+++ b/packages/webapp/src/ui/preview-vfs-responder.ts
@@ -35,6 +35,14 @@ export type PreviewVfsResponse =
    * large read is never issued twice.
    */
   | { type: 'preview-vfs-ack'; id: string }
+  /**
+   * Dequeue notification: the serialized read pipeline reached this request
+   * and its read is starting NOW. Requesters restart their timeout budget on
+   * this signal so time spent queued behind a large read (e.g. a multi-hundred-
+   * MB model file) does not count against the read's own deadline. Requesters
+   * that predate the signal simply never restart — same behavior as before.
+   */
+  | { type: 'preview-vfs-start'; id: string }
   | { type: 'preview-vfs-response'; id: string; content: string | Uint8Array }
   | { type: 'preview-vfs-response'; id: string; error: string };
 
@@ -136,10 +144,13 @@ export function installPreviewVfsResponder(
     channel.postMessage({ type: 'preview-vfs-ack', id } satisfies PreviewVfsResponse);
     // `respond` never rejects (its body is fully try/caught), but guard the
     // chain anyway — a poisoned queue would silently starve every later read.
-    queue = queue.then(
-      () => respond(id, path, asText),
-      () => respond(id, path, asText)
-    );
+    const dequeue = (): Promise<void> => {
+      // Signal dequeue-time so the requester's timeout measures the read
+      // itself, not its wait in the backlog.
+      channel.postMessage({ type: 'preview-vfs-start', id } satisfies PreviewVfsResponse);
+      return respond(id, path, asText);
+    };
+    queue = queue.then(dequeue, dequeue);
   };
   channel.addEventListener('message', listener);
   return {

--- a/packages/webapp/src/ui/preview-vfs-responder.ts
+++ b/packages/webapp/src/ui/preview-vfs-responder.ts
@@ -75,52 +75,71 @@ export function installPreviewVfsResponder(
   opts: PreviewVfsResponderOptions
 ): PreviewVfsResponderHandle {
   const { channel, getReader, logger } = opts;
+
+  async function respond(id: string, path: string, asText: boolean): Promise<void> {
+    try {
+      const reader = getReader();
+      // ZenFS' readFile does not throw EISDIR on a directory — it returns
+      // the directory entry's bytes — so the preview SW's directory →
+      // index.html fallback (which keys off an EISDIR error) never fires.
+      // Detect directories with a stat and surface EISDIR explicitly, the
+      // same POSIX-contract enforcement shell/vfs-adapter.ts applies for
+      // ZenFS. stat() throws ENOENT for missing paths, so the silent-404
+      // path below is preserved.
+      const stats = await reader.stat(path);
+      if (stats.type === 'directory') {
+        channel.postMessage({
+          type: 'preview-vfs-response',
+          id,
+          error: `EISDIR: is a directory '${path}'`,
+        } satisfies PreviewVfsResponse);
+        return;
+      }
+      const encoding = asText ? 'utf-8' : 'binary';
+      const content = await reader.readFile(path, { encoding });
+      channel.postMessage({
+        type: 'preview-vfs-response',
+        id,
+        content,
+      } satisfies PreviewVfsResponse);
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      if (!errMsg.includes('ENOENT')) {
+        logger?.error('Preview VFS read failed', { path, error: errMsg });
+      }
+      channel.postMessage({
+        type: 'preview-vfs-response',
+        id,
+        error: errMsg,
+      } satisfies PreviewVfsResponse);
+    }
+  }
+
+  // Reads are SERIALIZED through this per-responder chain. The kernel VFS
+  // (ZenFS WebAccess-on-OPFS behind the RemoteVfsClient RPC) is not safe
+  // under same-context concurrent reads: overlapping readFile calls can
+  // resolve with each other's content. Observed live with a parallel
+  // module-graph fetch through the preview SW — every chunk URL of an
+  // ipk-installed package came back with the entry file's bytes, so the
+  // import linked but failed with a missing-export error. Sequential
+  // reads are verified correct; the throughput cost is negligible next
+  // to the BroadcastChannel + RPC round trip each read already pays.
+  let queue: Promise<void> = Promise.resolve();
+
   const listener = (event: MessageEvent): void => {
     const data = event.data as PreviewVfsReadRequest | undefined;
     if (data?.type !== 'preview-vfs-read') return;
     const { id, path, asText } = data;
-    // Ack on receipt so the SW halts its cold-start re-post loop before this
-    // (potentially multi-MB) read begins; without it a slow read would be
-    // re-requested and duplicated.
+    // Ack on receipt (synchronously, before queueing) so the SW halts its
+    // cold-start re-post loop before this (potentially multi-MB) read
+    // begins; without it a slow read would be re-requested and duplicated.
     channel.postMessage({ type: 'preview-vfs-ack', id } satisfies PreviewVfsResponse);
-    void (async () => {
-      try {
-        const reader = getReader();
-        // ZenFS' readFile does not throw EISDIR on a directory — it returns
-        // the directory entry's bytes — so the preview SW's directory →
-        // index.html fallback (which keys off an EISDIR error) never fires.
-        // Detect directories with a stat and surface EISDIR explicitly, the
-        // same POSIX-contract enforcement shell/vfs-adapter.ts applies for
-        // ZenFS. stat() throws ENOENT for missing paths, so the silent-404
-        // path below is preserved.
-        const stats = await reader.stat(path);
-        if (stats.type === 'directory') {
-          channel.postMessage({
-            type: 'preview-vfs-response',
-            id,
-            error: `EISDIR: is a directory '${path}'`,
-          } satisfies PreviewVfsResponse);
-          return;
-        }
-        const encoding = asText ? 'utf-8' : 'binary';
-        const content = await reader.readFile(path, { encoding });
-        channel.postMessage({
-          type: 'preview-vfs-response',
-          id,
-          content,
-        } satisfies PreviewVfsResponse);
-      } catch (err) {
-        const errMsg = err instanceof Error ? err.message : String(err);
-        if (!errMsg.includes('ENOENT')) {
-          logger?.error('Preview VFS read failed', { path, error: errMsg });
-        }
-        channel.postMessage({
-          type: 'preview-vfs-response',
-          id,
-          error: errMsg,
-        } satisfies PreviewVfsResponse);
-      }
-    })();
+    // `respond` never rejects (its body is fully try/caught), but guard the
+    // chain anyway — a poisoned queue would silently starve every later read.
+    queue = queue.then(
+      () => respond(id, path, asText),
+      () => respond(id, path, asText)
+    );
   };
   channel.addEventListener('message', listener);
   return {

--- a/packages/webapp/tests/ui/preview-sw-handler.test.ts
+++ b/packages/webapp/tests/ui/preview-sw-handler.test.ts
@@ -23,6 +23,7 @@ import {
   type PreviewChannel,
   pathnameOf,
   projectServeVfsPath,
+  readViaMainPage,
 } from '../../src/ui/preview-sw-handler.js';
 
 type ResponderReply =
@@ -177,6 +178,39 @@ describe('handlePreviewRequest', () => {
       expect(r.status).toBe(200);
       expect(await r.text()).toBe('late');
       expect(ch.reads.length).toBeGreaterThan(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('restarts the timeout budget on the responder dequeue (start) signal', async () => {
+    // Serialized responder: a read queued behind a large one must get its
+    // FULL budget measured from when its read actually starts, not from
+    // when it was posted — otherwise backlog time alone times it out.
+    vi.useFakeTimers();
+    try {
+      const listeners = new Set<(ev: MessageEvent) => void>();
+      let id = '';
+      const ch: PreviewChannel = {
+        postMessage: (data: unknown) => {
+          const msg = data as { type?: string; id?: string };
+          if (msg?.type === 'preview-vfs-read' && msg.id) id = msg.id;
+        },
+        addEventListener: (_t, l) => listeners.add(l),
+        removeEventListener: (_t, l) => listeners.delete(l),
+      };
+      const emit = (data: unknown): void => {
+        for (const l of listeners) l({ data } as MessageEvent);
+      };
+
+      const pending = readViaMainPage(ch, '/queued.bin', false, 1000);
+      // Just before the original deadline the responder dequeues the read.
+      await vi.advanceTimersByTimeAsync(900);
+      emit({ type: 'preview-vfs-start', id });
+      // Past the ORIGINAL deadline but within the restarted budget.
+      await vi.advanceTimersByTimeAsync(900);
+      emit({ type: 'preview-vfs-response', id, content: 'late-but-alive' });
+      await expect(pending).resolves.toEqual({ ok: true, content: 'late-but-alive' });
     } finally {
       vi.useRealTimers();
     }

--- a/packages/webapp/tests/ui/preview-vfs-responder.test.ts
+++ b/packages/webapp/tests/ui/preview-vfs-responder.test.ts
@@ -179,6 +179,54 @@ describe('installPreviewVfsResponder', () => {
     expect(ch.outbound).toHaveLength(0);
   });
 
+  it('serializes overlapping reads — the backing VFS is not concurrency-safe', async () => {
+    const ch = new FakeChannel();
+    // Instrumented reader: counts in-flight reads and resolves each with
+    // its own path so cross-contamination (the live ZenFS-on-OPFS failure
+    // mode: every concurrent read resolving with one file's bytes) or an
+    // overlap would both be visible.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const pendingResolvers: Array<() => void> = [];
+    const stat = vi.fn(async (): Promise<Stats> => ({ type: 'file', size: 1, mtime: 0, ctime: 0 }));
+    const readFile = vi.fn((path: string): Promise<string | Uint8Array> => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      return new Promise((resolve) => {
+        pendingResolvers.push(() => {
+          inFlight--;
+          resolve(`content-of:${path}`);
+        });
+      });
+    });
+    const client: LocalVfsClient = { readDir: vi.fn(async () => []), readFile, stat };
+    installPreviewVfsResponder({ channel: ch, getReader: () => client });
+
+    // Three reads land back-to-back (a parallel module-graph fetch).
+    ch.emit({ type: 'preview-vfs-read', id: 'q1', path: '/dist/index.js', asText: true });
+    ch.emit({ type: 'preview-vfs-read', id: 'q2', path: '/dist/chunk-a.js', asText: true });
+    ch.emit({ type: 'preview-vfs-read', id: 'q3', path: '/dist/chunk-b.js', asText: true });
+    await tick();
+
+    // All three are acked immediately, but only the first read started.
+    expect(acksOf(ch)).toHaveLength(3);
+    expect(readFile).toHaveBeenCalledTimes(1);
+
+    // Draining the queue one read at a time never overlaps calls…
+    while (pendingResolvers.length > 0 || responsesOf(ch).length < 3) {
+      pendingResolvers.shift()?.();
+      await tick();
+    }
+    expect(maxInFlight).toBe(1);
+
+    // …and every response carries ITS OWN file's content, in order.
+    expect(responsesOf(ch)).toEqual([
+      { type: 'preview-vfs-response', id: 'q1', content: 'content-of:/dist/index.js' },
+      { type: 'preview-vfs-response', id: 'q2', content: 'content-of:/dist/chunk-a.js' },
+      { type: 'preview-vfs-response', id: 'q3', content: 'content-of:/dist/chunk-b.js' },
+    ]);
+  });
+
   it('reader swap takes effect on the next request (flag flip path)', async () => {
     const ch = new FakeChannel();
     const initial = makeStubVfs();

--- a/packages/webapp/tests/ui/preview-vfs-responder.test.ts
+++ b/packages/webapp/tests/ui/preview-vfs-responder.test.ts
@@ -74,6 +74,14 @@ function responsesOf(ch: FakeChannel): PreviewVfsResponse[] {
   );
 }
 
+/** Outbound `preview-vfs-start` (dequeue) envelopes. */
+function startsOf(ch: FakeChannel): Array<{ type: 'preview-vfs-start'; id: string }> {
+  return ch.outbound.filter(
+    (m): m is { type: 'preview-vfs-start'; id: string } =>
+      (m as { type?: string })?.type === 'preview-vfs-start'
+  );
+}
+
 /** Outbound `preview-vfs-ack` envelopes. */
 function acksOf(ch: FakeChannel): Array<{ type: 'preview-vfs-ack'; id: string }> {
   return ch.outbound.filter(
@@ -208,9 +216,13 @@ describe('installPreviewVfsResponder', () => {
     ch.emit({ type: 'preview-vfs-read', id: 'q3', path: '/dist/chunk-b.js', asText: true });
     await tick();
 
-    // All three are acked immediately, but only the first read started.
+    // All three are acked immediately, but only the first read started —
+    // and only the first got its dequeue (`start`) signal, which is what
+    // lets requesters restart their timeout budget at read-start instead
+    // of burning it in the backlog.
     expect(acksOf(ch)).toHaveLength(3);
     expect(readFile).toHaveBeenCalledTimes(1);
+    expect(startsOf(ch).map((s) => s.id)).toEqual(['q1']);
 
     // Draining the queue one read at a time never overlaps calls…
     while (pendingResolvers.length > 0 || responsesOf(ch).length < 3) {
@@ -218,6 +230,9 @@ describe('installPreviewVfsResponder', () => {
       await tick();
     }
     expect(maxInFlight).toBe(1);
+
+    // Each read got its dequeue signal exactly once, in queue order.
+    expect(startsOf(ch).map((s) => s.id)).toEqual(['q1', 'q2', 'q3']);
 
     // …and every response carries ITS OWN file's content, in order.
     expect(responsesOf(ch)).toEqual([


### PR DESCRIPTION
Fixes the preview-surface symptom of #2034.

When several `/preview/*` URLs are read concurrently (e.g. the browser fetching a module graph's chunks in parallel), every response carried the **same file's bytes** — hash-verified live: 8 parallel fetches of distinct `dist/*.js` files of an ipk-installed package all returned the entry file's content. Sequential reads are always byte-correct. For a module import this is worst-case: the graph parses and links, then dies with `does not provide an export named …`, and the worker's module map caches the poisoned chunk for the life of the realm.

Correlation ids are matched correctly at every layer by inspection (SW `readViaMainPage`, responder, `RemoteVfsClient` pending map, `VfsRpcHost` per-request closures) — the collapse is below the RPC, in the ZenFS WebAccess-on-OPFS read path under same-context concurrent reads. Until that is fixed at the FS layer (#2034 stays open for it), this serializes the responder's stat+read pipeline: the receipt ack stays synchronous so the SW's cold-start re-post loop still stops immediately, and the throughput cost is noise next to the BroadcastChannel + kernel-RPC round trip each read already pays.

Regression test: three overlapping reads → all acked immediately, reader never re-entered (`maxInFlight === 1`), every response carries its own file's content in order.

Split out of #2029 (whose vpod loader is how this was found — that PR's cold-boot path **depends on this landing**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8Pt2nX6koz4K868SWBMN9