### PR TITLE
feat(worker): cross-origin isolate the leader via Document-Isolation-Policy

### DIFF
--- a/docs/kernel/process-model.md
+++ b/docs/kernel/process-model.md
@@ -104,7 +104,14 @@ The user-facing surface is the `node` (`-e`/`script.js`/stdin), `.jsh` discovery
 Realm scripts (`.jsh` / `node -e` / `python3`) need synchronous filesystem
 access to satisfy Node's `fs.readFileSync` / `writeFileSync` API shape. The
 bridge (`realm/sync-fs-*.ts` + `ui/sync-fs-sw-handler.ts`) implements this
-without `SharedArrayBuffer` or COOP/COEP:
+without _requiring_ `SharedArrayBuffer` or cross-origin isolation, so it
+works on every float — including embedded leaders (Cherry, spoon/Electron)
+that can never be isolated. The hosted leader document _is_ now
+cross-origin isolated via `Document-Isolation-Policy` (per-document, no
+COOP/COEP, SW control unaffected — see the `serveSPA` comment in
+`packages/cloudflare-worker/src/index.ts`), which makes an Atomics/SAB
+fast path a possible future perf lever where `crossOriginIsolated` is
+true; the SW sync-XHR path below remains the universal baseline:
 
 **Fast path**: an in-memory snapshot of up to 500 files / 1 MB total / 10 MB
 per file, warm-populated at realm start. Reads that hit the snapshot return

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -92,7 +92,10 @@ Worker serves `dist/ui/` via Static Assets (`ASSETS`); `?json=true`/POST/WS → 
 else SPA. **Cherry embed (`?cherry=1`):** `frame-ancestors` from
 `ALLOWED_CHERRY_HOST_ORIGINS` (bare `*` also enumerates `chrome-extension://` origins);
 non-cherry → `frame-ancestors 'none'`; cherry sets `Cache-Control: no-store` +
-`Vary: Sec-Fetch-Dest`. **25 MiB per-asset cap** — CI runs `wrangler deploy --dry-run`
+`Vary: Sec-Fetch-Dest`. **Non-cherry, non-electron SPA responses also carry
+`Document-Isolation-Policy: isolate-and-credentialless`** — per-document
+cross-origin isolation (SAB for vpod guest networking) without COOP/COEP;
+cherry/electron branches must stay header-free (embedded, never need SAB). **25 MiB per-asset cap** — CI runs `wrangler deploy --dry-run`
 as a hard gate. `ASSET_ARCHIVE` (R2) retains hashed `/assets/*` across deploys;
 `serveAssetWithArchiveFallback` tries `ASSETS` → R2 → stale-asset reload; bucket GC
 14 days. Full rules:

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -279,6 +279,22 @@ async function serveSPA(request: Request, env: WorkerEnv): Promise<Response> {
     out.headers.set('Vary', 'Sec-Fetch-Dest');
   } else {
     out.headers.set('Content-Security-Policy', "frame-ancestors 'none'");
+    // Per-document cross-origin isolation (#2036): grants the leader (and
+    // its dedicated/nested workers) `crossOriginIsolated` + SharedArrayBuffer
+    // WITHOUT COOP/COEP — popups keep window.opener, iframes embed normally,
+    // and the controlling service worker keeps controlling (verified live;
+    // the COEP↔SW-script compatibility rule does not apply to DIP). First
+    // consumer: vpod's guest-network SAB ring buffer. `credentialless` (not
+    // `require-corp`) so no-cors cross-origin subresources — gravatars,
+    // agent-rendered external images, sprinkle assets — load anonymously
+    // instead of being blocked. Unsupported browsers (pre-Chrome-137,
+    // non-desktop) ignore the header and degrade to today's non-isolated
+    // behavior. This branch also serves `/join`/`/controller` follower pages;
+    // isolation is harmless there (no popup/iframe/embedding restrictions),
+    // and one unconditional value per URL keeps caching Vary-free. The
+    // `?cherry=1` and electron-overlay branches above stay header-free:
+    // embedded surfaces run no realms and never needed SAB.
+    out.headers.set('Document-Isolation-Policy', 'isolate-and-credentialless');
   }
   return out;
 }

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -3092,6 +3092,28 @@ describe('cherry framing policy', () => {
     expect(res.headers.get('cache-control') ?? '').not.toContain('no-store');
   });
 
+  it('default SPA (leader + join/controller) is cross-origin isolated via DIP', async () => {
+    const { env } = createTestHarness();
+    for (const path of ['/', '/join/tok-abc', '/controller/tok-abc']) {
+      const res = await worker.fetch(new Request(`https://app.example${path}`), env);
+      expect(res.headers.get('document-isolation-policy')).toBe('isolate-and-credentialless');
+    }
+  });
+
+  it('cherry and electron-overlay responses carry NO isolation header', async () => {
+    const env = {
+      ...createTestHarness().env,
+      ALLOWED_CHERRY_HOST_ORIGINS: '*',
+    };
+    const cherry = await worker.fetch(new Request('https://app.example/?cherry=1'), env);
+    expect(cherry.headers.get('document-isolation-policy')).toBeNull();
+    const overlay = await worker.fetch(
+      new Request('https://app.example/electron?bridge=ws://localhost:9222/cdp&role=leader'),
+      env
+    );
+    expect(overlay.headers.get('document-isolation-policy')).toBeNull();
+  });
+
   it('cherry boot allows configured ancestors and is uncacheable', async () => {
     const env = {
       ...createTestHarness().env,

--- a/packages/webapp/src/speech/transformers-env.ts
+++ b/packages/webapp/src/speech/transformers-env.ts
@@ -45,7 +45,7 @@ import { detectMimeType, toPreviewUrl } from '../shell/supplemental-commands/sha
 
 /** Structural slice of transformers.js' `env` that we touch. */
 export interface TransformersEnvLike {
-  backends?: { onnx?: { wasm?: { wasmPaths?: unknown } } };
+  backends?: { onnx?: { wasm?: { wasmPaths?: unknown; numThreads?: number } } };
   fetch?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
   /** Disable HF-Hub fetches; weights load only from `localModelPath`. */
   allowRemoteModels?: boolean;
@@ -386,6 +386,13 @@ export function configureTransformersEnv(env: TransformersEnvLike): void {
     // by the time ort reads wasmPaths at session-creation time the object
     // form is in place.
     onnxWasm.wasmPaths = toPreviewUrl(ORT_DIST_VFS_PATH);
+    // Pin single-threaded execution explicitly. With the leader now
+    // cross-origin isolated (Document-Isolation-Policy, #2036), ort-web
+    // would otherwise auto-select multi-threaded execution — a silent
+    // behavior change with its own worker-spawning and memory profile.
+    // Raising this is a deliberate future perf experiment, not a side
+    // effect of enabling isolation.
+    onnxWasm.numThreads = 1;
   }
   env.allowRemoteModels = false;
   env.allowLocalModels = true;

--- a/packages/webapp/tests/speech/transformers-env.test.ts
+++ b/packages/webapp/tests/speech/transformers-env.test.ts
@@ -20,7 +20,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 interface FakeEnv {
-  backends?: { onnx?: { wasm?: { wasmPaths?: unknown } } };
+  backends?: { onnx?: { wasm?: { wasmPaths?: unknown; numThreads?: number } } };
   fetch?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
   allowRemoteModels?: boolean;
   allowLocalModels?: boolean;
@@ -69,6 +69,11 @@ describe('configureTransformersEnv', () => {
     expect(wasmPaths).toMatch(/\/preview\/workspace\/node_modules\/onnxruntime-web\/dist\/$/);
     // Defense in depth: must not point at any CDN host.
     expect(wasmPaths).not.toMatch(/jsdelivr|unpkg|huggingface/);
+    // With the leader cross-origin isolated (Document-Isolation-Policy),
+    // ort-web would auto-select multi-threaded execution — the explicit
+    // single-thread pin is what keeps that a deliberate choice, so its
+    // removal must fail a test, not ship silently.
+    expect(env.backends?.onnx?.wasm?.numThreads).toBe(1);
   });
 
   it('pins model loading to local /workspace/models via the preview SW', async () => {

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -397,6 +397,12 @@ export default defineConfig(({ mode }) => ({
     },
   },
   server: {
+    // Dev parity with the worker's `serveSPA` (#2036): the leader document is
+    // cross-origin isolated via Document-Isolation-Policy in production, so
+    // `npm run dev` must match or SAB-dependent paths (vpod --net) diverge.
+    headers: {
+      'Document-Isolation-Policy': 'isolate-and-credentialless',
+    },
     watch: {
       // Anchor to workspaceRoot so the ignore only matches the top-level
       // .yolo/.intent dirs in the main checkout. Using a bare `**/.yolo/**`


### PR DESCRIPTION
Closes #2036. One header on the leader route:

```
Document-Isolation-Policy: isolate-and-credentialless
```

This grants the leader document — and its dedicated/nested workers — `crossOriginIsolated` + SharedArrayBuffer with **none of the COOP/COEP costs** that made isolation a deliberate non-starter in the sync-FS design (PR #1519, commits `079944d08` → `b69546f75`):

| COOP/COEP cost | Under DIP |
|---|---|
| OAuth popups lose `window.opener` (logout close-detection, cancel detection) | **No COOP** — popups and opener untouched |
| Agent-rendered external images / sprinkle assets blocked (`require-corp`) | `credentialless` — no-cors embeds load anonymously |
| COEP'd page needs a COEP'd SW script or loses SW control (→ sync-FS, `/preview/*`, LLM proxy all cascade-fail) | **Verified live: SW keeps controlling** under DIP |
| Cherry/spoon/Electron embedded leaders can never isolate | Their branches stay header-free; DIP is per-document, embedded surfaces unaffected |

**Live proof** (wrangler dev, Chrome 151): `crossOriginIsolated: true`, SW controller intact, sync-FS + `/preview/*` functional, `vpod net` → `backend: fetch`, and guest `python3` fetched `https://api.github.com/zen` → **HTTP 200** through vpod's SAB ring buffer + fetch driver. Unsupported browsers (pre-Chrome-137 / non-desktop) ignore the header and keep exactly today's behavior — strictly additive.

**Scope decisions** (documented in the `serveSPA` comment):
- The else-branch also serves `/join`/`/controller` follower pages — they get the header too; harmless under DIP (no popup/iframe/embedding restrictions), and one unconditional value per URL keeps caching `Vary`-free. Tests assert all three paths.
- `?cherry=1` and the electron overlay stay header-free (tests assert absence).

**Side-effect containment**:
- ort-web would silently auto-select multi-threaded execution once `crossOriginIsolated` is true — `transformers-env` now pins `numThreads = 1`, so speech behavior is byte-for-byte unchanged and raising it becomes a deliberate perf experiment.
- Vite dev server sends the same header (`server.headers`) for dev/prod parity.
- `docs/kernel/process-model.md` reframed: the sync-FS bridge does not *require* isolation (and remains the universal baseline for embedded leaders); the Atomics/SAB fast path demoted in #1519 is now a genuine future perf lever.

First consumer: vpod guest networking (#2029). Related: #2037 (preview responder serialization, also required by #2029).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8Pt2nX6koz4K868SWBMN9