### PR TITLE
fix(webcomponents): scroll a long browser tab list instead of squashing the cards

### DIFF
--- a/packages/webcomponents/src/dock/slicc-tab-overlay.stories.ts
+++ b/packages/webcomponents/src/dock/slicc-tab-overlay.stories.ts
@@ -57,6 +57,23 @@ const TABS: TabDescriptor[] = [
 
 const FEW: TabDescriptor[] = TABS.slice(0, 3);
 
+/** Hues cycled through the generated long-list roster. */
+const HUES = ['#8b5cf6', '#06b6d4', '#f43f5e', '#f59e0b', '#16a34a', '#ea580c'];
+
+/**
+ * A roster long enough to overflow the grid at any realistic viewport — the
+ * case that used to squash every card down to a cropped sliver instead of
+ * scrolling. Every fifth tab omits its screenshot to keep the globe placeholder
+ * in the shot.
+ */
+const LONG: TabDescriptor[] = Array.from({ length: 32 }, (_, i) => ({
+  id: `long-${i}`,
+  title: `Open tab ${i + 1}`,
+  url: `example.com/page/${i + 1}`,
+  active: i === 0,
+  ...(i % 5 === 4 ? {} : { screenshot: shot(`tab ${i + 1}`, HUES[i % HUES.length]) }),
+}));
+
 /** Build an open overlay seeded with the given tabs. */
 function overlay(tabs: TabDescriptor[]): HTMLElement {
   const el = document.createElement('slicc-tab-overlay') as SliccTabOverlay;
@@ -78,9 +95,19 @@ export const FewTabs: Story = {
   render: () => overlay(FEW),
 };
 
-/** A full roster — the responsive grid scrolls; one tab is the active (ctx-ringed) tab. */
+/** A full roster — mixed cards and titles; one tab is the active (ctx-ringed) tab. */
 export const ManyTabs: Story = {
   render: () => overlay(TABS),
+};
+
+/**
+ * A long roster that outgrows the viewport: cards keep their 16/10 thumbnail and
+ * full height, and the grid scrolls. Rows must stay `max-content` for this — the
+ * initial `auto` lets the track sizer shrink them to fit, which squashed the
+ * cards flat and left nothing to scroll.
+ */
+export const LongList: Story = {
+  render: () => overlay(LONG),
 };
 
 /** The empty state — no open tabs, just the header and the empty message. */

--- a/packages/webcomponents/src/dock/slicc-tab-overlay.ts
+++ b/packages/webcomponents/src/dock/slicc-tab-overlay.ts
@@ -64,6 +64,13 @@ const STYLE = `
   flex: 1 1 auto; min-height: 0; overflow: auto; padding: 2px;
   display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 16px; align-content: start;
+  /* Implicit rows must be max-content, NOT the initial auto. Auto tracks shrink
+     to their min-content contribution once they no longer fit the grid's
+     definite height, so a long tab list silently squashed every card (220px
+     down to ~66px, its 16/10 thumbnail cropped to an unreadable sliver) and the
+     grid never overflowed — leaving the overflow property nothing to scroll.
+     Pinning rows to content height makes a long list overflow and scroll. */
+  grid-auto-rows: max-content;
 }
 .card {
   display: flex; flex-direction: column;
@@ -83,6 +90,9 @@ const STYLE = `
 .shot {
   display: block; width: 100%; aspect-ratio: 16 / 10; object-fit: cover;
   background: var(--ghost); color: var(--txt-3);
+  /* The card is a column flex container: without this the thumbnail is a
+     shrinkable flex item and any height pressure on the card deforms it. */
+  flex: 0 0 auto;
 }
 .shot.ph { display: grid; place-items: center; }
 .shot.ph svg { display: block; }

--- a/packages/webcomponents/tests/dock/slicc-tab-overlay.test.ts
+++ b/packages/webcomponents/tests/dock/slicc-tab-overlay.test.ts
@@ -218,4 +218,48 @@ describe('slicc-tab-overlay', () => {
     expect(cs.position).toBe('fixed');
     expect(cs.flexDirection).toBe('column');
   });
+
+  /** A 1×1 PNG — enough for Chromium to lay out a real `<img>` thumbnail. */
+  const PIXEL =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+  /** `n` uniform tabs, each with a screenshot, so card heights are comparable. */
+  function manyTabs(n: number): TabDescriptor[] {
+    return Array.from({ length: n }, (_, i) => ({
+      id: `t${i}`,
+      title: `Tab ${i}`,
+      url: `https://example.com/${i}`,
+      screenshot: PIXEL,
+    }));
+  }
+
+  /** Open an overlay with `n` tabs and measure its first card (real Chromium). */
+  function measure(n: number): { cardH: number; shotRatio: number; scrolls: boolean } {
+    const el = mount((o) => {
+      o.tabs = manyTabs(n);
+      o.show();
+    });
+    const grid = el.shadowRoot?.querySelector('.grid') as HTMLElement;
+    const card = cards(el)[0].getBoundingClientRect();
+    const shot = (cards(el)[0].querySelector('img.shot') as HTMLElement).getBoundingClientRect();
+    // Read every layout value while the overlay is still connected — a detached
+    // grid reports 0 for both scrollHeight and clientHeight.
+    const scrolls = grid.scrollHeight > grid.clientHeight;
+    el.remove();
+    return { cardH: card.height, shotRatio: shot.width / shot.height, scrolls };
+  }
+
+  it('scrolls a long tab list instead of squashing the cards (real Chromium)', () => {
+    // Regression: the grid's implicit rows were the initial `auto`, which lets
+    // the track sizing algorithm shrink rows below their content once they stop
+    // fitting the grid's definite height. A long list therefore compressed every
+    // card (220px → ~66px, thumbnail cropped to a sliver) and never overflowed,
+    // so the scroll container had nothing to scroll.
+    const few = measure(3);
+    const many = measure(40);
+    expect(few.scrolls).toBe(false);
+    expect(many.scrolls).toBe(true);
+    expect(many.cardH).toBe(few.cardH);
+    expect(many.shotRatio).toBeCloseTo(16 / 10, 1);
+  });
 });


### PR DESCRIPTION
## Summary

The dock globe's open-tabs overlay squashed its cards flat once the list got long. Before: with ~30+ tabs open (yours plus every follower's), each card collapsed from 220px to ~66px, the 16/10 thumbnail was cropped to an unreadable sliver, the title/URL row was pushed out of the card entirely, and the grid did not scroll. Now: cards keep their full height and thumbnail at any tab count, and the grid scrolls.

## Why

`.grid` in `<slicc-tab-overlay>` left its implicit rows at the initial `auto`. Auto tracks shrink to their **min-content contribution** once they stop fitting the grid's definite height, so a long list compressed every row instead of overflowing — and because the grid then never overflowed, the `overflow: auto` already on it had nothing to scroll. The cards' own `overflow: hidden` did the rest, cropping each thumbnail to a band.

**Repro**

1. Open enough browser tabs that the overlay needs more than ~3 rows (at 1280x900 that is >12 tabs; follower tabs count too).
2. Click the globe (`Browser · CDP`) at the bottom of the right rail.

Expected: cards keep their thumbnail + title, the grid scrolls.
Actual (before this PR): every card is squashed to a cropped band, no titles, nothing scrolls.

Measured in real Chromium at 1280x900:

| tabs | first card height | grid scrollHeight / clientHeight |
| --- | --- | --- |
| 3 | 220px -> 220px | 806 / 806 -> 806 / 806 |
| 40 | **66px** -> **220px** | 806 / 806 -> **2344 / 806** |

## Approach / Implementation notes

- `grid-auto-rows: max-content` on `.grid` — pins implicit rows to content height so a long list overflows and the existing scroll container does its job. This is the whole fix; the `overflow: auto` and `align-content: start` that were already there were correct.
- `flex: 0 0 auto` on `.shot` — the card is a column flex container, so the thumbnail was a shrinkable flex item. Defense in depth against any future height pressure deforming it.
- Rejected alternative: shrinking `minmax(220px, 1fr)` as the count grows. That trades one unreadable state for another and still caps the list at one viewport.

## Cross-cutting impact

- **One component, both surfaces.** The leader's globe overlay (`wireWcBrowser`) and the follower rail's (`wireWcFollowerBrowser`) both compose `<slicc-tab-overlay>` by tag, so local and federated (`runtimeId:targetId`) tabs are fixed by the same change. No webapp wiring touched.
- **Floats**: CSS-only inside a shadow root — identical in CLI, extension, Electron, and cloud. No runtime, no bundle, no persisted state, no event or attribute contract changed.
- **Other `auto-fill` grids checked**: `slicc-palette-grid` and `slicc-monitor` both lay out in normal flow with no definite height, so neither can hit this track-shrinking behavior. No change needed there.
- **Bundle size**: unchanged (`npm run bundle-size` green; webapp 29.99 MB against a 31 MB budget).

## Test plan

- [x] `npm run verify` — 7/7 checks (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK, 0 touched files on any debt list
- [x] `npm run typecheck` — clean across all 9 projects
- [x] `npm run test` — 14177 passing, 46 skipped, no new failures
- [x] `npm run test -w @slicc/webcomponents` — 2073 passing in real Chromium
- [x] `npm run test:coverage` + `npm run test:coverage:webcomponents` — floors held
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size`
- [x] **New behavior is covered by a unit test** — `packages/webcomponents/tests/dock/slicc-tab-overlay.test.ts`, `scrolls a long tab list instead of squashing the cards (real Chromium)`: asserts the 40-tab card height equals the 3-tab height, the thumbnail stays 16/10, and the grid overflows. Verified it **fails** with `grid-auto-rows` removed and passes with it.
- [x] **UI change** — before/after below. Captured with the repo's own Storybook screenshot tool (`storybook-affected-screenshots.mjs`) against the new `LongList` story, 32 tabs at 1280x900, dark theme. CI's sticky screenshot comment will cover the same story in light + dark.

### Before / after — 32 tabs at 1280x900, dark theme

**Before** — rows compressed to fit: every card a cropped band, titles and URLs gone, no scrollbar.

![tab-list-before](https://slicc--ai-ecoverse.agentbin.net/080f76bc9c425c32ded98aaa830e41faa7825b0bf9ce0ff17faadf78c3d5b79a.png)

**After** — cards keep their full height and 16/10 thumbnail, titles and URLs are back, and the grid scrolls (the fourth row is clipped at the fold rather than squeezed into it).

![tab-list-after](https://slicc--ai-ecoverse.agentbin.net/616e142b0f06b66405434f5916d2d81e0151d6ceaa8120e77273355e70a51d8b.png)

**Pre-existing failures**: none. (Note for anyone reproducing locally in a worktree: a stale `node_modules` pinned `@earendil-works/pi-ai` at 0.83.0 against the lockfile's 0.84.0 and produced unrelated `scoop-cost-tracker.ts` typecheck errors — `npm install` clears it.)

## Documentation

- [x] No documentation changes needed — no developer convention, architecture, or agent-facing surface changed. The behavior is documented where it belongs: a `LongList` Storybook story and the regression test, plus a comment on the rule explaining why it must not go back to `auto`.

## Risk & rollback

Blast radius is one shadow-DOM stylesheet in one component. No flags, no migrations. Revert this PR cleanly to roll back.
