### PR TITLE
feat(webcomponents): shape the tab pin by what a busy agent is busy with

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -174,7 +174,6 @@
   "packages/webapp/src/ui/sync-fs-sw-handler.ts": 1,
   "packages/webapp/src/ui/tray-leave-runtime.ts": 1,
   "packages/webapp/src/ui/wc/wc-attach.ts": 3,
-  "packages/webapp/src/ui/wc/wc-live.ts": 1,
   "packages/webapp/src/ui/wc/wc-message-view.ts": 2,
   "packages/webapp/src/ui/wc/wc-onboarding.ts": 1,
   "packages/webapp/src/ui/wc/wc-sprinkles.ts": 1,

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -130,7 +130,18 @@ export interface OffscreenClientCallbacks {
    * controls thread routing in {@link handleAgentEvent} is unchanged.
    */
   onScoopActivity?: (scoopJid: string) => void;
+  /**
+   * Fired when any scoop (selected or not) crosses between waiting on the
+   * model and running a tool, so the switcher tab can shape its centre pin
+   * the way the composer's send button shapes its busy treatment. Deduped —
+   * only an actual change fires. This is the per-scoop twin of
+   * `WcChatController`'s busy phase, which only tracks the focused thread.
+   */
+  onScoopPhaseChange?: (scoopJid: string, phase: ScoopBusyPhase) => void;
 }
+
+/** What a busy scoop is busy with. Mirrors `<slicc-send-button>`'s `phase`. */
+export type ScoopBusyPhase = 'thinking' | 'tool';
 
 export class OffscreenClient implements KernelClientFacade {
   private eventListeners = new Set<(event: UIAgentEvent) => void>();
@@ -138,6 +149,14 @@ export class OffscreenClient implements KernelClientFacade {
   private scoops: RegisteredScoop[] = [];
   private scoopStatuses = new Map<string, ScoopTabState['status']>();
   private currentMessageId = new Map<string, string>();
+  /**
+   * Tool calls in flight per scoop — incremented on `tool_start`, decremented
+   * on the matching `tool_end`. A scoop is in the `tool` phase while this is
+   * above zero and `thinking` otherwise. Kept here rather than in the host
+   * because the raw per-scoop tool events never leave this class: everything
+   * downstream of the selection gate is the SELECTED scoop's thread only.
+   */
+  private toolDepth = new Map<string, number>();
   private ready = false;
   private stateRetryTimer: ReturnType<typeof setInterval> | null = null;
   private localFs: LocalVfsClient | null = null;
@@ -926,6 +945,21 @@ export class OffscreenClient implements KernelClientFacade {
     }
   }
 
+  /**
+   * Move a scoop's in-flight tool count and report the phase it lands in.
+   * `delta` of `null` resets the count (turn boundaries), which is what stops
+   * a turn that died mid-tool from stranding the tab on `tool` forever.
+   */
+  private trackToolPhase(scoopJid: string, delta: number | null): void {
+    const before = this.toolDepth.get(scoopJid) ?? 0;
+    const after = delta === null ? 0 : Math.max(0, before + delta);
+    if (after === 0) this.toolDepth.delete(scoopJid);
+    else this.toolDepth.set(scoopJid, after);
+    // Only the zero crossing changes the phase; nested tool calls do not.
+    if (before > 0 === after > 0) return;
+    this.callbacks.onScoopPhaseChange?.(scoopJid, after > 0 ? 'tool' : 'thinking');
+  }
+
   private handleAgentEvent(msg: AgentEventMsg): void {
     // Per-scoop activity ping fires BEFORE the selection gate so the
     // host can move the navbar eyes onto a non-selected scoop that is
@@ -937,6 +971,22 @@ export class OffscreenClient implements KernelClientFacade {
       case 'tool_ui':
       case 'turn_end':
         this.callbacks.onScoopActivity?.(msg.scoopJid);
+        break;
+    }
+
+    // Busy-phase bookkeeping also has to precede the selection gate: the tab
+    // for a scoop the user is NOT looking at still has to shape its pin. Note
+    // `tool_end` is deliberately absent from the activity ping above (it is
+    // not new output to point the eyes at) but is essential here.
+    switch (msg.eventType) {
+      case 'tool_start':
+        this.trackToolPhase(msg.scoopJid, 1);
+        break;
+      case 'tool_end':
+        this.trackToolPhase(msg.scoopJid, -1);
+        break;
+      case 'turn_end':
+        this.trackToolPhase(msg.scoopJid, null);
         break;
     }
 
@@ -1065,7 +1115,15 @@ export class OffscreenClient implements KernelClientFacade {
   }
 
   private handleScoopStatus(msg: ScoopStatusMsg): void {
+    const previous = this.scoopStatuses.get(msg.scoopJid);
     this.scoopStatuses.set(msg.scoopJid, msg.status);
+    // A CHANGED status is a turn boundary, and every boundary clears the tool
+    // count: a turn always opens in `thinking`, and one that ends — cleanly or
+    // by erroring mid-tool — must not strand the next turn on a stale `tool`.
+    // Same rising-edge reset `WcChatController.setProcessing` performs for the
+    // focused thread. A repeated identical broadcast is NOT a boundary, so it
+    // cannot yank the phase out from under a tool that is still running.
+    if (previous !== msg.status) this.trackToolPhase(msg.scoopJid, null);
     this.callbacks.onStatusChange(msg.scoopJid, msg.status);
   }
 

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -18,6 +18,7 @@ import {
   type SyncFsNonce,
   type SyncFsNonceMsg,
 } from '../../kernel/realm/sync-fs-wire.js';
+import type { RemoteTerminalView } from '../../kernel/remote-terminal-view.js';
 import { spawnKernelWorker } from '../../kernel/spawn.js';
 import {
   getAccounts,
@@ -50,7 +51,11 @@ import { setupStandalonePrelude } from '../boot/setup-standalone-prelude.js';
 import type { BootStageLogger } from '../boot/types.js';
 import { type DipInstance, disposeDips, hydrateDips } from '../dip.js';
 import { isLickChannel } from '../lick-channels.js';
-import { OffscreenClient, type OffscreenClientCallbacks } from '../offscreen-client.js';
+import {
+  OffscreenClient,
+  type OffscreenClientCallbacks,
+  type ScoopBusyPhase,
+} from '../offscreen-client.js';
 import type { UiRuntimeMode } from '../runtime-mode.js';
 import type { ChatMessage } from '../types.js';
 import { notifyLeaderLocalModelStateChanged } from './leader-model-events.js';
@@ -238,21 +243,26 @@ function stateFor(status: ScoopStatus | undefined): NonNullable<SwitcherScoop['s
 export function toSwitcherScoops(
   scoops: readonly RegisteredScoop[],
   statuses?: ReadonlyMap<string, ScoopStatus>,
-  fills?: ReadonlyMap<string, number>
+  fills?: ReadonlyMap<string, number>,
+  phases?: ReadonlyMap<string, ScoopBusyPhase>
 ): SwitcherScoop[] {
   return [...scoops]
     .sort((a, b) => Number(b.isCone) - Number(a.isCone))
     .map((scoop) => {
       const fill = fills?.get(scoop.jid);
+      const status = statuses?.get(scoop.jid);
       return {
         key: scoop.jid,
         type: scoop.isCone ? 'cone' : 'scoop',
         color: scoopColor(scoop),
         label: scoop.isCone ? 'sliccy' : scoop.name,
-        eyes: eyesFor(statuses?.get(scoop.jid)),
-        state: stateFor(statuses?.get(scoop.jid)),
+        eyes: eyesFor(status),
+        state: stateFor(status),
         // The chip pupils dilate with context fullness (pill `fill` 0-100).
         fill: typeof fill === 'number' ? Math.round(fill * 100) : undefined,
+        // Only a processing scoop has a busy phase; a stale entry for one that
+        // has since gone idle must not shape a pin that is no longer painted.
+        phase: status === 'processing' ? phases?.get(scoop.jid) : undefined,
       };
     });
 }
@@ -263,6 +273,12 @@ export interface WcLiveWiring {
   statuses: Map<string, ScoopStatus>;
   /** Per-scoop context-window fill (0..1), refreshed by the stats poller. */
   fills: Map<string, number>;
+  /**
+   * Per-scoop busy phase (`tool` while a tool call is in flight). Written by
+   * `onScoopPhaseChange` for every scoop, selected or not; only read while a
+   * scoop is processing.
+   */
+  phases: Map<string, ScoopBusyPhase>;
   /** Latest sustained lick-deferral state for each still-registered scoop. */
   lickBackpressure: Map<string, LickBackpressureState>;
   /**
@@ -299,7 +315,8 @@ export function createWcLiveCallbacks(wiring: WcLiveWiring): OffscreenClientCall
       wiring.refs.switcher.scoops = toSwitcherScoops(
         client.getScoops(),
         wiring.statuses,
-        wiring.fills
+        wiring.fills,
+        wiring.phases
       );
     }
   };
@@ -371,6 +388,14 @@ export function createWcLiveCallbacks(wiring: WcLiveWiring): OffscreenClientCall
       // eyes on whichever scoop is actively streaming. Mirrors the
       // `attention` write in `onIncomingMessage`; no thread routing.
       wiring.refs.switcher.setAttribute('attention', jid);
+    },
+    onScoopPhaseChange: (jid, phase) => {
+      // Busy detail for ANY scoop: the tab's centre pin goes square while the
+      // model thinks and circular while a tool runs, the same vocabulary the
+      // composer's send button spends on motion. Deduped upstream, so this
+      // only repaints on an actual crossing.
+      wiring.phases.set(jid, phase);
+      refreshScoops();
     },
     onIncomingMessage: (jid, message) => {
       // Most-recent-activity tracking: the scoop that just received a message
@@ -804,6 +829,7 @@ export function prepareWcShell(app: HTMLElement, floatLabel: string): WcShellBoo
       refs,
       statuses: new Map(),
       fills: new Map(),
+      phases: new Map(),
       lickBackpressure,
       lastActivity: new Map(),
       // The thread component owns the `ctx` param — the host only routes it.
@@ -1264,7 +1290,8 @@ function wireWcStats(wiring: WcLiveWiring, client: OffscreenClient): () => void 
       wiring.refs.switcher.scoops = toSwitcherScoops(
         client.getScoops(),
         wiring.statuses,
-        wiring.fills
+        wiring.fills,
+        wiring.phases
       );
     });
   };
@@ -1403,6 +1430,15 @@ export function wireWcChipTips(deps: {
  * when the kernel already reported ready, so this is free on late
  * activations. The client-side `open()` also retries defensively.
  */
+/**
+ * The one property this module hangs off `globalThis` — the mounted terminal
+ * view, published for Playwright. Named rather than an untyped string-keyed
+ * bag, mirroring `BrowserHolder` in `cdp/active-transport.ts`.
+ */
+interface TerminalViewHolder {
+  __slicc_terminal_view?: RemoteTerminalView;
+}
+
 async function mountWorkbenchTerminal(
   boot: WcShellBoot,
   client: OffscreenClient,
@@ -1422,7 +1458,7 @@ async function mountWorkbenchTerminal(
   // `executeCommandInTerminal` directly (mirrors the chat panel's "run
   // in terminal" affordance and avoids xterm-canvas scraping). Same
   // unconditional-publish pattern as `__slicc_pm` / `__slicc_browser`.
-  (globalThis as Record<string, unknown>).__slicc_terminal_view = view;
+  (globalThis as unknown as TerminalViewHolder).__slicc_terminal_view = view;
   window.addEventListener('beforeunload', () => view.dispose(), { once: true });
 }
 

--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -48,6 +48,12 @@ export interface SwitcherScoop {
   ephemeral?: boolean;
   /** 0-100 context-window fullness forwarded to the pill (pupils dilate). */
   fill?: number;
+  /**
+   * What a `working` agent is busy with — shapes the tab's centre pin (square
+   * for the model thinking, circle for a tool call), mirroring the composer's
+   * send button. Ignored for every other state.
+   */
+  phase?: 'thinking' | 'tool';
 }
 
 export interface WcShellOptions {

--- a/packages/webapp/tests/ui/offscreen-client.test.ts
+++ b/packages/webapp/tests/ui/offscreen-client.test.ts
@@ -47,6 +47,7 @@ describe('OffscreenClient', () => {
     onMessageUpdate: vi.fn(),
     onLickBackpressure: vi.fn(),
     onScoopActivity: vi.fn(),
+    onScoopPhaseChange: vi.fn(),
   };
 
   beforeEach(() => {
@@ -206,6 +207,89 @@ describe('OffscreenClient', () => {
     });
 
     expect(callbacks.onScoopActivity).not.toHaveBeenCalled();
+  });
+
+  describe('per-scoop busy phase (onScoopPhaseChange)', () => {
+    /** Feed one agent event for `jid` (defaults to a NON-selected scoop). */
+    function agentEvent(eventType: string, jid = 'other_scoop'): void {
+      simulateMessage('offscreen', {
+        type: 'agent-event',
+        scoopJid: jid,
+        eventType,
+        toolName: 't',
+        toolResult: 'ok',
+      });
+    }
+
+    /** The phases reported so far, as `jid:phase` pairs. */
+    function reported(): string[] {
+      return callbacks.onScoopPhaseChange.mock.calls.map(([jid, phase]) => `${jid}:${phase}`);
+    }
+
+    beforeEach(() => client.setSelectedScoopJid('cone_123'));
+
+    it('crosses to tool on tool_start and back to thinking on tool_end', () => {
+      agentEvent('tool_start');
+      agentEvent('tool_end');
+      expect(reported()).toEqual(['other_scoop:tool', 'other_scoop:thinking']);
+    });
+
+    it('tracks scoops the user is NOT looking at (the whole point of the tab pin)', () => {
+      agentEvent('tool_start', 'other_scoop');
+      expect(reported()).toEqual(['other_scoop:tool']);
+    });
+
+    it('reports only zero crossings, so nested tool calls do not flap the pin', () => {
+      agentEvent('tool_start');
+      agentEvent('tool_start');
+      agentEvent('tool_end');
+      expect(reported()).toEqual(['other_scoop:tool']);
+      agentEvent('tool_end');
+      expect(reported()).toEqual(['other_scoop:tool', 'other_scoop:thinking']);
+    });
+
+    it('never drops below zero on an unmatched tool_end', () => {
+      agentEvent('tool_end');
+      expect(reported()).toEqual([]);
+      agentEvent('tool_start');
+      expect(reported()).toEqual(['other_scoop:tool']);
+    });
+
+    it('resets at turn_end so a turn that died mid-tool cannot strand the pin', () => {
+      agentEvent('tool_start');
+      agentEvent('turn_end');
+      expect(reported()).toEqual(['other_scoop:tool', 'other_scoop:thinking']);
+    });
+
+    it('resets on a CHANGED scoop status, but not on a repeated one', () => {
+      /** Broadcast a lifecycle status for the non-selected scoop. */
+      function status(value: string): void {
+        simulateMessage('offscreen', {
+          type: 'scoop-status',
+          scoopJid: 'other_scoop',
+          status: value,
+        });
+      }
+      // Real ordering: the turn's `processing` edge lands before any tool.
+      status('processing');
+      agentEvent('tool_start');
+      callbacks.onScoopPhaseChange.mockClear();
+      // A repeated identical broadcast is not a turn boundary — a tool that is
+      // still running must keep its phase.
+      status('processing');
+      status('processing');
+      expect(reported()).toEqual([]);
+      // Erroring out mid-tool IS a boundary, and clears it.
+      status('error');
+      expect(reported()).toEqual(['other_scoop:thinking']);
+    });
+
+    it('keeps a separate count per scoop', () => {
+      agentEvent('tool_start', 'a');
+      agentEvent('tool_start', 'b');
+      agentEvent('tool_end', 'a');
+      expect(reported()).toEqual(['a:tool', 'b:tool', 'a:thinking']);
+    });
   });
 
   it('relays message-updated to onMessageUpdate (live lick flip)', () => {

--- a/packages/webapp/tests/ui/wc/wc-live.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-live.test.ts
@@ -130,6 +130,7 @@ function makeWiring(options: {
     controller,
     statuses: new Map(),
     fills: new Map(),
+    phases: new Map(),
     lickBackpressure: new Map(),
     lastActivity: new Map(),
     pendingUrlContext: null,
@@ -167,6 +168,38 @@ describe('toSwitcherScoops runtime state', () => {
 
   it('treats a missing first status broadcast as idle', () => {
     expect(toSwitcherScoops([cone])[0]?.state).toBe('idle');
+  });
+});
+
+describe('toSwitcherScoops busy phase', () => {
+  const processing = new Map([[cone.jid, 'processing' as const]]);
+
+  it('forwards the phase of a processing scoop to its tab', () => {
+    const tabs = toSwitcherScoops(
+      [cone],
+      processing,
+      undefined,
+      new Map([[cone.jid, 'tool' as const]])
+    );
+    expect(tabs[0]?.phase).toBe('tool');
+  });
+
+  it('leaves the phase unset when no crossing has been observed yet', () => {
+    expect(toSwitcherScoops([cone], processing)[0]?.phase).toBeUndefined();
+  });
+
+  it('drops a stale phase once the scoop stops processing', () => {
+    // The tab paints no pin at all when idle, so a leftover map entry must not
+    // survive into the descriptor and shape one the next time it goes busy.
+    const phases = new Map([[cone.jid, 'tool' as const]]);
+    const tabs = toSwitcherScoops(
+      [cone],
+      new Map([[cone.jid, 'ready' as const]]),
+      undefined,
+      phases
+    );
+    expect(tabs[0]?.state).toBe('idle');
+    expect(tabs[0]?.phase).toBeUndefined();
   });
 });
 

--- a/packages/webcomponents/src/switcher/slicc-agent-tabs.stories.ts
+++ b/packages/webcomponents/src/switcher/slicc-agent-tabs.stories.ts
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
 import { h } from '../internal/dom.js';
-import type { AgentState, ScoopDescriptor, SliccAgentTabs } from './slicc-agent-tabs.js';
+import type {
+  AgentPhase,
+  AgentState,
+  ScoopDescriptor,
+  SliccAgentTabs,
+} from './slicc-agent-tabs.js';
 import './slicc-agent-tabs.js';
 
 interface AgentTabsArgs {
@@ -111,6 +116,30 @@ function stateRoster(): ScoopDescriptor[] {
   }));
 }
 
+/** Both busy phases side by side, plus the unset default and a non-busy tab. */
+function phaseRoster(): ScoopDescriptor[] {
+  const busy = (
+    key: string,
+    label: string,
+    color: string,
+    phase?: AgentPhase
+  ): ScoopDescriptor => ({
+    key,
+    label,
+    color,
+    phase,
+    eyes: 'open',
+    fill: 48,
+    state: 'working',
+  });
+  return [
+    busy('thinking', 'thinking', '#8b5cf6', 'thinking'),
+    busy('tool', 'tool call', '#06b6d4', 'tool'),
+    busy('unset', 'phase unset', '#10b981'),
+    { key: 'idle', label: 'idle', color: '#f59e0b', eyes: 'open', fill: 30, state: 'idle' },
+  ];
+}
+
 function fullnessRoster(): ScoopDescriptor[] {
   return [0, 25, 50, 75, 100].map((fill) => ({
     key: `fill-${fill}`,
@@ -184,6 +213,21 @@ export const ScoopFocused: Story = {
 
 export const EveryStatus: Story = {
   args: { scoops: stateRoster(), active: 'working', width: 620 },
+};
+
+export const BusyPhases: Story = {
+  args: { scoops: phaseRoster(), active: 'thinking', width: 620 },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The centre pin carries what a working agent is busy with, borrowing the ' +
+          'composer vocabulary: rectangular for the model thinking, circular for a ' +
+          'tool call in flight. An unset phase reads as thinking, because a turn ' +
+          'always opens in LLM-wait. Non-working agents show no pin at all.',
+      },
+    },
+  },
 };
 
 export const Disconnected: Story = {

--- a/packages/webcomponents/src/switcher/slicc-agent-tabs.ts
+++ b/packages/webcomponents/src/switcher/slicc-agent-tabs.ts
@@ -10,6 +10,16 @@ import type {
 
 export type AgentState = 'working' | 'broken' | 'initializing' | 'idle';
 
+/**
+ * What a `working` agent is busy WITH, mirroring `<slicc-send-button>`'s
+ * `phase` attribute so one motion vocabulary covers the whole app: rectangular
+ * means the model is thinking, circular means a tool is running. The send
+ * button spends it on motion (pulsing square vs spinning ring); at 14px the tab
+ * glyph spends it on the centre pin's shape instead. Only meaningful while
+ * {@link AgentState} is `working`.
+ */
+export type AgentPhase = 'thinking' | 'tool';
+
 export interface ScoopDescriptor {
   key: string;
   type?: 'cone' | 'scoop';
@@ -19,6 +29,13 @@ export interface ScoopDescriptor {
   fill?: number;
   ephemeral?: boolean;
   state?: AgentState;
+  /**
+   * Busy detail for a `working` agent — `tool` while a tool call is in flight,
+   * `thinking` (the default) while waiting on or streaming from the model. A
+   * turn always opens in `thinking`, so an unset phase reads as thinking rather
+   * than as "unknown".
+   */
+  phase?: AgentPhase;
 }
 
 export interface ScoopSelectDetail extends SliccScoopSelectDetail {
@@ -68,10 +85,11 @@ const STYLE = `
 .slicc-agent-tabs__segment[data-attention='true'] .slicc-agent-tabs__glyph-glow{opacity:.72;}
 .slicc-agent-tabs__glyph-base{fill:none;stroke:color-mix(in srgb,currentColor 30%,var(--line));}
 .slicc-agent-tabs__glyph-arc{fill:none;stroke:currentColor;stroke-linecap:round;transform:rotate(-90deg);transform-box:fill-box;transform-origin:center;animation:slicc-agent-tabs-arc 10.8s linear infinite;animation-play-state:paused;}
-.slicc-agent-tabs__glyph-pin{display:none;fill:currentColor;}
+.slicc-agent-tabs__glyph-pin,.slicc-agent-tabs__glyph-pin-square{display:none;fill:currentColor;}
 .slicc-agent-tabs__broken-x,.slicc-agent-tabs__initializing-ring{display:none;}
 .slicc-agent-tabs [data-state='working'] .slicc-agent-tabs__glyph-arc{animation-play-state:running;}
-.slicc-agent-tabs [data-state='working'] .slicc-agent-tabs__glyph-pin{display:inline;}
+.slicc-agent-tabs [data-state='working'][data-phase='tool'] .slicc-agent-tabs__glyph-pin{display:inline;}
+.slicc-agent-tabs [data-state='working']:not([data-phase='tool']) .slicc-agent-tabs__glyph-pin-square{display:inline;}
 .slicc-agent-tabs [data-state='broken'] .slicc-agent-tabs__status-glyph{color:var(--red);}
 .slicc-agent-tabs [data-state='broken'] .slicc-agent-tabs__glyph-arc,.slicc-agent-tabs [data-state='initializing'] .slicc-agent-tabs__glyph-arc{display:none;}
 .slicc-agent-tabs [data-state='broken'] .slicc-agent-tabs__broken-x{display:inline;}
@@ -131,6 +149,16 @@ export function arcDash(fill: number): number {
   return (sweep / 360) * ARC_CIRCUMFERENCE;
 }
 
+/**
+ * The busy detail for a segment, or `null` when it does not apply. Only a
+ * `working` agent has a phase; everything else (idle, broken, initializing)
+ * would render a meaningless attribute.
+ */
+function phaseFor(scoop: ScoopDescriptor, state: AgentState): AgentPhase | null {
+  if (state !== 'working') return null;
+  return scoop.phase === 'tool' ? 'tool' : 'thinking';
+}
+
 function stateFor(scoop: ScoopDescriptor, attention: string | null): AgentState {
   if (scoop.state) return scoop.state;
   if (scoop.eyes === 'dead') return 'broken';
@@ -175,7 +203,23 @@ function statusGlyph(scoop: ScoopDescriptor): SVGSVGElement {
       'stroke-dasharray': `${arcDash(boundedFill(scoop.fill)).toFixed(3)} ${ARC_CIRCUMFERENCE.toFixed(3)}`,
       'stroke-dashoffset': 0,
     }),
+    // Both pins are always built; CSS shows exactly one, chosen by the phase.
+    // At this size the shapes only tell themselves apart by their CORNERS, so
+    // the square keeps them near-sharp (rx 0.15) and spans 3 — wide enough that
+    // its corners sit well outside the circle's 2.5 silhouette. A softer or
+    // smaller square just reads as the dot it is replacing. The circle keeps
+    // its original radius so the tool phase looks exactly like today's pin.
+    // Both are legible from 2x up; at 1x DPI a 3px square and a 3px circle
+    // antialias to nearly the same mark, which no geometry here can fix.
     svgEl('circle', { class: `${PREFIX}__glyph-pin`, cx: 7, cy: 7, r: 1.25 }),
+    svgEl('rect', {
+      class: `${PREFIX}__glyph-pin-square`,
+      x: 5.5,
+      y: 5.5,
+      width: 3,
+      height: 3,
+      rx: 0.15,
+    }),
     svgEl('line', {
       class: `${PREFIX}__broken-x`,
       x1: 4.8,
@@ -462,17 +506,22 @@ export class SliccAgentTabs extends HTMLElement {
 
   #updateSegment(segment: HTMLButtonElement, scoop: ScoopDescriptor, focused: string | null): void {
     const state = stateFor(scoop, this.attention);
+    const phase = phaseFor(scoop, state);
     const fill = boundedFill(scoop.fill);
     const wantsAttention = this.attention === scoop.key;
     segment.className = `${PREFIX}__segment${scoop.ephemeral ? ' ephemeral' : ''}`;
     segment.setAttribute('aria-selected', String(scoop.key === focused));
     segment.tabIndex = scoop.key === focused ? 0 : -1;
+    // The pin's shape is the only carrier of the phase, so spell it out for
+    // anyone who cannot see it.
+    const busyDetail = phase === 'tool' ? ' (running a tool)' : phase ? ' (thinking)' : '';
     segment.setAttribute(
       'aria-label',
-      `${scoop.label ?? scoop.key}: ${state}, ${Math.round(fill)}% context fill${wantsAttention ? ', spoke most recently' : ''}`
+      `${scoop.label ?? scoop.key}: ${state}${busyDetail}, ${Math.round(fill)}% context fill${wantsAttention ? ', spoke most recently' : ''}`
     );
     segment.dataset.k = scoop.key;
     segment.dataset.state = state;
+    this.#setAttribute(segment, 'data-phase', phase);
     this.#setAttribute(segment, 'data-attention', wantsAttention ? 'true' : null);
     segment.style.setProperty('--slicc-agent-tabs-hue', hueFor(scoop));
     const label = segment.querySelector<HTMLElement>(`.${PREFIX}__label`);

--- a/packages/webcomponents/tests/switcher/slicc-agent-tabs.test.ts
+++ b/packages/webcomponents/tests/switcher/slicc-agent-tabs.test.ts
@@ -267,27 +267,84 @@ describe('slicc-agent-tabs', () => {
   });
 
   describe('status glyphs and fullness arcs', () => {
+    /** Whether a segment's circle / square centre pin is currently painted. */
+    function pins(element: SliccAgentTabs, key: string): { circle: boolean; square: boolean } {
+      const seg = segment(element, key);
+      const shown = (selector: string): boolean =>
+        getComputedStyle(seg.querySelector(selector) as SVGElement).display !== 'none';
+      return {
+        circle: shown('.slicc-agent-tabs__glyph-pin'),
+        square: shown('.slicc-agent-tabs__glyph-pin-square'),
+      };
+    }
+
     it('maps idle and working to arcs, with a centre pin only for working', () => {
       const element = mount();
       expect(
         segment(element, 'designer').querySelector('.slicc-agent-tabs__glyph-arc')
       ).toBeTruthy();
-      expect(
-        getComputedStyle(
-          segment(element, 'designer').querySelector('.slicc-agent-tabs__glyph-pin') as SVGElement
-        ).display
-      ).toBe('none');
+      expect(pins(element, 'designer')).toEqual({ circle: false, square: false });
       expect(
         segment(element, 'researcher').querySelector('.slicc-agent-tabs__glyph-arc')
       ).toBeTruthy();
       expect(
         segment(element, 'researcher').querySelector('.slicc-agent-tabs__glyph-pin')
       ).toBeTruthy();
-      expect(
-        getComputedStyle(
-          segment(element, 'researcher').querySelector('.slicc-agent-tabs__glyph-pin') as SVGElement
-        ).display
-      ).not.toBe('none');
+      // Working always paints exactly one pin — which one is the phase's job.
+      const working = pins(element, 'researcher');
+      expect(working.circle !== working.square).toBe(true);
+    });
+
+    it('shapes the working pin by phase: square for thinking, circle for a tool call', () => {
+      const element = mount([
+        { key: 'thinker', label: 'Thinker', state: 'working', phase: 'thinking' },
+        { key: 'runner', label: 'Runner', state: 'working', phase: 'tool' },
+      ]);
+      expect(pins(element, 'thinker')).toEqual({ circle: false, square: true });
+      expect(pins(element, 'runner')).toEqual({ circle: true, square: false });
+      expect(segment(element, 'thinker').dataset.phase).toBe('thinking');
+      expect(segment(element, 'runner').dataset.phase).toBe('tool');
+    });
+
+    it('defaults an unset phase to thinking (a turn opens in LLM-wait)', () => {
+      const element = mount([{ key: 'bare', label: 'Bare', state: 'working' }]);
+      expect(pins(element, 'bare')).toEqual({ circle: false, square: true });
+      expect(segment(element, 'bare').dataset.phase).toBe('thinking');
+    });
+
+    it('carries no phase attribute unless the agent is working', () => {
+      const element = mount([
+        { key: 'idle', label: 'Idle', state: 'idle', phase: 'tool' },
+        { key: 'broken', label: 'Broken', state: 'broken', phase: 'tool' },
+      ]);
+      expect(segment(element, 'idle').hasAttribute('data-phase')).toBe(false);
+      expect(segment(element, 'broken').hasAttribute('data-phase')).toBe(false);
+      expect(pins(element, 'idle')).toEqual({ circle: false, square: false });
+    });
+
+    it('repaints the pin in place when a live segment flips phase', () => {
+      const element = mount([{ key: 'busy', label: 'Busy', state: 'working', phase: 'thinking' }]);
+      const before = segment(element, 'busy');
+      element.scoops = [{ key: 'busy', label: 'Busy', state: 'working', phase: 'tool' }];
+      // Reconciled, not rebuilt — the segment identity must survive so focus
+      // and the running arc animation are not reset mid-turn.
+      expect(segment(element, 'busy')).toBe(before);
+      expect(pins(element, 'busy')).toEqual({ circle: true, square: false });
+    });
+
+    it('names the busy detail in the accessible label', () => {
+      const element = mount([
+        { key: 'thinker', label: 'Thinker', state: 'working', phase: 'thinking', fill: 10 },
+        { key: 'runner', label: 'Runner', state: 'working', phase: 'tool', fill: 10 },
+        { key: 'idle', label: 'Idle', state: 'idle', fill: 10 },
+      ]);
+      expect(segment(element, 'thinker').getAttribute('aria-label')).toContain(
+        'working (thinking)'
+      );
+      expect(segment(element, 'runner').getAttribute('aria-label')).toContain(
+        'working (running a tool)'
+      );
+      expect(segment(element, 'idle').getAttribute('aria-label')).not.toContain('(');
     });
 
     it('maps broken to an X and initializing to a dashed ring while hiding their arcs', () => {


### PR DESCRIPTION
## Summary

The switcher's segmented tab bar showed one centre pin for every working cone or scoop, so a tab told you an agent was busy but not what it was busy *with*. Now the pin's shape says: a square while the model is thinking, the existing round pin while a tool call is in flight.

## Why

The composer's send button already draws this distinction — `phase="thinking"` pulses the stop square, `phase="tool"` overlays a spinning ring — so rectangular-means-LLM and circular-means-tool is established vocabulary in the app. The tab glyph is 14px and cannot carry two motions, so it spends the same distinction on the pin's shape instead. (Circular motion for tools also leaves room for a real progress protocol in just-bash later; a determinate arc has somewhere to go.)

**Repro (before this PR)**

1. Give the cone and a scoop some work.
2. Watch the nav tab bar.

Expected: you can tell thinking from tool-running at a glance.
Actual: both show the same dot, all turn long.

### Before / after — the new `BusyPhases` story at 3x

Dark:

![pins-final-dark](https://slicc--ai-ecoverse.agentbin.net/8244dbaf8e8ad4b59524fda282ddbb4c516b4cb88098efa154e4efbeca14a033.png)

Light:

![pins-final-light](https://slicc--ai-ecoverse.agentbin.net/d70a9aa237dfdc9e3240055474a63346bb74187c571e35ebb55b1d37c66de180.png)

Left to right: `thinking` (square), `tool call` (round — what every working tab looked like before), `phase unset` (defaults to thinking), `idle` (no pin at all, unchanged).

## Approach / Implementation notes

- **Modelled as `phase?: 'thinking' | 'tool'` on `ScoopDescriptor`, not a fifth `AgentState`.** Mirrors `<slicc-send-button>`'s attribute and keeps `state` about lifecycle (working / broken / initializing / idle) and `phase` about turn detail. Rejected alternative: `state: 'thinking'` alongside `'working'` — it would have made every existing `state` consumer (follower + tray mappers, the overflow severity sort) handle a new lifecycle value that isn't one.
- **Unset reads as thinking, not as unknown.** A turn always opens in LLM-wait — the same assumption `WcChatController.setProcessing` makes on its rising edge — so a working tab with no phase yet shows the square rather than flickering into shape later.
- **`data-phase` is only set while working.** Idle / broken / initializing carry no attribute and no pin, so nothing meaningless lands in the DOM.
- **Per-scoop, not just the focused tab.** `WcChatController`'s busy phase only tracks the selected thread, so the tool counting lives in `OffscreenClient` (which owns the raw per-scoop events) and is done **before** the selection gate — a tab you are not looking at still shapes correctly. `onScoopPhaseChange` fires only on zero crossings, so nested tool calls do not flap the pin.
- **Stale-phase guards, in two places.** Turn boundaries (`turn_end`, or a *changed* scoop status) reset the count, so a turn that died mid-tool cannot strand the next one on `tool`; a repeated identical `processing` broadcast is deliberately *not* a boundary, so it cannot yank the phase from a tool still running. `toSwitcherScoops` then only forwards a phase while the scoop is actually processing.
- **Geometry.** The square needs near-sharp corners (`rx 0.15`) and a 3.0 span to break the circle's 2.5 silhouette; at 2.4 with `rx 0.35` (tried first) it is indistinguishable from the dot it replaces. The circle keeps its original `r 1.25`, so the tool phase looks exactly like today's pin.

## Cross-cutting impact

- **Visual change to an existing state**: a working tab with no tool in flight now shows a square where it used to show a circle. That is the intent, but it is a change to shipping behavior, not purely additive.
- **Followers and tray tabs keep the thinking square while busy.** They map through `toFollowerSwitcherScoops`, whose sync protocol carries scoop status but no tool events, so no phase is available. Honest default rather than a wrong circle; carrying the phase across the tray wire is a separate change.
- **Floats**: `slicc-agent-tabs` is shared, so the shape logic is identical everywhere. Only the leader's live wiring feeds a real phase today.
- **No protocol, storage, or event-contract change.** `onScoopPhaseChange` is a new optional callback; every existing `OffscreenClientCallbacks` consumer is untouched. `tool_end` is still deliberately absent from the `onScoopActivity` ping (it is not new output to point the navbar eyes at) — the phase bookkeeping reads it separately.
- **Accessibility**: the accessible name gains `working (thinking)` / `working (running a tool)`, since shape is the only visual carrier.
- **1x DPI limitation**, stated plainly: a 3px square and a 3px circle antialias to nearly the same mark. This reads from 2x up (any retina display); at 1x the distinction is very subtle and no geometry at 14px fixes it. A larger glyph would be the fix if that matters.
- **Bundle size**: unchanged (29.99 MB against the 31 MB budget).

## Test plan

- [x] `npm run verify` — 7/7
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK, 0 touched files on any debt list
- [x] `npm run typecheck` — clean across all 9 projects
- [x] `npm run test` — 14187 passing
- [x] `npm run test -w @slicc/webcomponents` — 2078 passing in real Chromium
- [x] `npm run test:coverage` + `npm run test:coverage:webcomponents` — floors held
- [x] `npm run build`, `npm run build -w @slicc/chrome-extension`, `npm run bundle-size`
- [x] **New behavior is covered by unit tests.** Component (`packages/webcomponents/tests/switcher/slicc-agent-tabs.test.ts`): shape per phase, unset defaults to thinking, no `data-phase` unless working, segment identity survives a live phase flip (so focus and the running arc are not reset mid-turn), and the accessible name. Wiring (`packages/webapp/tests/ui/offscreen-client.test.ts`): zero-crossings only, nested calls, unmatched `tool_end` never going negative, `turn_end` reset, changed-vs-repeated status, per-scoop isolation, and non-selected scoops. Mapper (`packages/webapp/tests/ui/wc/wc-live.test.ts`): forwarding, unset, and stale-phase dropping.
- [x] **UI change** — screenshots above, from the new `BusyPhases` story. CI's sticky screenshot comment covers it in light + dark too.

**Pre-existing failures**: none. One full `npm run test` run showed a single failing file that did not reproduce on an immediate re-run (824 passed, exit 0) and is unrelated to these files — flagging it as a flake rather than silently dropping it.

## Documentation

- [x] No documentation changes needed — no developer convention or agent-facing surface changed. The vocabulary is documented where it is used: a `BusyPhases` story, the `AgentPhase` doc comment tying it to `<slicc-send-button>`, and a comment on the geometry explaining why the corners must stay sharp.

## Risk & rollback

One component's glyph plus an optional callback. No flags, no migrations, no persisted state. Revert cleanly to roll back.
