### PR TITLE
fix(swift-server): stop --lead pointing at flag forms it cannot parse

### DIFF
--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -29,10 +29,16 @@ struct ServerCommand: AsyncParsableCommand {
     @Flag(name: .long, help: "Kill existing Electron app")
     var kill: Bool = false
 
-    @Flag(name: .long, help: "Lead mode")
+    // Unlike `--join` below, `--lead` is a plain flag here: it carries no value
+    // of its own, so the tray worker base URL has to arrive via
+    // `--lead-worker-base-url` or `WORKER_BASE_URL`. node-server's
+    // `runtime-flags.ts` additionally accepts `--lead <url>` / `--lead=<url>`;
+    // that parity gap is deliberate for now, so the help below names only the
+    // forms this binary actually parses.
+    @Flag(name: .long, help: "Lead mode (needs --lead-worker-base-url or WORKER_BASE_URL)")
     var lead: Bool = false
 
-    @Option(name: .long, help: "Lead worker base URL")
+    @Option(name: .long, help: "Tray worker base URL for --lead (or set WORKER_BASE_URL)")
     var leadWorkerBaseUrl: String?
 
     @Option(name: .long, help: "Chrome profile name")
@@ -766,8 +772,13 @@ extension ServerCommand {
                     config.leadWorkerBaseUrl ?? environment["WORKER_BASE_URL"]
                 )
             else {
+                // Name only the forms THIS binary parses. `--lead` is an
+                // ArgumentParser `@Flag`, so the `--lead <url>` / `--lead=<url>`
+                // spellings that node-server accepts are rejected here — the
+                // first as a stray positional, the second as an unexpected
+                // value. Suggesting them sends the reader down a dead end.
                 throw ValidationError(
-                    "The --lead launch flow requires a tray worker base URL via --lead <url>, --lead=<url>, or WORKER_BASE_URL."
+                    "The --lead launch flow requires a tray worker base URL via --lead-worker-base-url <url> or the WORKER_BASE_URL environment variable."
                 )
             }
             launchURL = try buildCanonicalTrayLaunchURL(locationHref: baseHref, trayValue: workerBaseURL)

--- a/packages/swift-server/Tests/ServerCommandTests.swift
+++ b/packages/swift-server/Tests/ServerCommandTests.swift
@@ -180,6 +180,81 @@ final class ServerCommandTests: XCTestCase {
         )
     }
 
+    // A `--lead` run with no worker base URL must fail with a message that
+    // names a spelling this binary can actually parse. `--lead` is a `@Flag`
+    // here (node-server's `runtime-flags.ts` also accepts `--lead <url>` /
+    // `--lead=<url>`; swift-server does not), so advertising those forms sends
+    // the reader into an "Unexpected argument" dead end. Guard both halves:
+    // the message must not name them, and whatever it DOES name must parse.
+    func testLeadWithoutWorkerBaseURLSuggestsOnlyParsableForms() throws {
+        let parsed = try ServerCommand.parseAsRoot(["--lead"])
+        let command = try XCTUnwrap(parsed as? ServerCommand)
+        let config = ServerConfig.resolve(from: command, arguments: ["slicc-server", "--lead"])
+
+        XCTAssertThrowsError(
+            try ServerCommand.resolveBrowserLaunchURL(
+                serveOrigin: "http://localhost:5710",
+                config: config,
+                environment: [:]
+            )
+        ) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(
+                message.contains("--lead-worker-base-url"),
+                "error must name the flag that actually carries the URL, got: \(message)"
+            )
+            XCTAssertTrue(
+                message.contains("WORKER_BASE_URL"),
+                "error must keep the env-var escape hatch, got: \(message)"
+            )
+            XCTAssertFalse(
+                message.contains("--lead <url>") || message.contains("--lead=<url>"),
+                "error must not suggest forms this binary rejects, got: \(message)"
+            )
+        }
+    }
+
+    // The form the error recommends has to survive the parser — otherwise the
+    // message is just a different dead end.
+    func testLeadWorkerBaseURLFormFromTheErrorMessageParses() throws {
+        let parsed = try ServerCommand.parseAsRoot([
+            "--lead", "--lead-worker-base-url", "https://worker.example",
+        ])
+        let command = try XCTUnwrap(parsed as? ServerCommand)
+        let config = ServerConfig.resolve(
+            from: command,
+            arguments: [
+                "slicc-server", "--lead", "--lead-worker-base-url", "https://worker.example",
+            ]
+        )
+
+        XCTAssertTrue(config.lead)
+        XCTAssertEqual(config.leadWorkerBaseURL?.absoluteString, "https://worker.example")
+        XCTAssertNoThrow(
+            try ServerCommand.resolveBrowserLaunchURL(
+                serveOrigin: "http://localhost:5710",
+                config: config,
+                environment: [:]
+            )
+        )
+    }
+
+    // The env-var escape hatch the message names must work on its own, with
+    // `--lead` and nothing else on the command line.
+    func testLeadResolvesWorkerBaseURLFromEnvironment() throws {
+        let parsed = try ServerCommand.parseAsRoot(["--lead"])
+        let command = try XCTUnwrap(parsed as? ServerCommand)
+        let config = ServerConfig.resolve(from: command, arguments: ["slicc-server", "--lead"])
+
+        XCTAssertNoThrow(
+            try ServerCommand.resolveBrowserLaunchURL(
+                serveOrigin: "http://localhost:5710",
+                config: config,
+                environment: ["WORKER_BASE_URL": "https://worker.example"]
+            )
+        )
+    }
+
     // MARK: - Thin-bridge launch URL parity with node-server Path A
 
     // Thin-bridge mode appends `bridge=<ws-url>&bridgeToken=<token>` to the


### PR DESCRIPTION
## Summary

Starting a leader from the command line currently walks you into two dead ends in a row. `slicc-server --help` describes `--lead` as plain "Lead mode", so nothing tells you a tray worker base URL is also required. The run then fails with a message that suggests two flag spellings this binary **rejects**, and never mentions the one that works. This PR makes the help and the error describe what the binary actually parses.

Found while bringing a leader back up by hand after a restart — it cost three failed launches to get past.

## Why

```console
$ slicc-server --cdp-port=9222 --lead
Error: The --lead launch flow requires a tray worker base URL via --lead <url>, --lead=<url>, or WORKER_BASE_URL.

$ slicc-server --cdp-port=9222 --lead https://www.sliccy.ai
Error: Unexpected argument 'https://www.sliccy.ai'

$ slicc-server --cdp-port=9222 --lead --lead-worker-base-url https://www.sliccy.ai
... Server started and listening on 127.0.0.1:5710   # the form the error never mentions
```

`--lead` is an ArgumentParser `@Flag`, so it carries no value: `--lead <url>` is parsed as a stray positional and `--lead=<url>` as an unexpected value. Both suggested forms are unreachable, and `--lead-worker-base-url <url>` — the one that works — is absent from the message.

**The message is not wrong everywhere, which is how it got here.** node-server's `runtime-flags.ts` genuinely accepts both forms:

- `--lead=<url>` — `runtime-flags.ts:131`
- `--lead <url>` followed by a URL-looking token — `runtime-flags.ts:174`

swift-server copied the wording without the parsing. This is review-checklist category **3 (cross-runtime parity)**, and the repo already fixed the identical problem for the neighbouring flag: `--join` accepts `--join <url>` here, pinned by `testJoinFlagParsesUrlAsValue`. `--lead` never got the same treatment.

## Approach / Implementation notes

Deliberately the **documentation half** of the fix:

- `--lead` help → `Lead mode (needs --lead-worker-base-url or WORKER_BASE_URL)`
- `--lead-worker-base-url` help → `Tray worker base URL for --lead (or set WORKER_BASE_URL)`
- the `ValidationError` now names `--lead-worker-base-url <url>` and the `WORKER_BASE_URL` environment variable, and nothing else
- a comment beside the flag records the node-server divergence so the next reader meets it in the source rather than in a failed launch

**Not done here, on purpose:** teaching swift-server to parse `--lead <url>` / `--lead=<url>` the way `--join` already does. That would close the parity gap and make the original message true everywhere, but it is a behavior change to argument parsing and deserves its own PR and its own risk assessment. Happy to follow up with it if that is the preferred direction — in which case this PR's error string becomes wrong in the other direction, so the two should not sit in the queue together.

node-server's copy of the string is left alone: it is accurate there.

## Cross-cutting impact

- **Strings only.** No flag was added, removed, or re-parsed; every previously working invocation still works identically. `WORKER_BASE_URL` and `--lead-worker-base-url` precedence is untouched (`config.leadWorkerBaseUrl ?? environment["WORKER_BASE_URL"]`).
- **Nothing parses this error text.** Grepped for the old string: the only other occurrence is node-server's own copy in `launch-url.ts`, asserted by `launch-url.test.ts:92` against a regex (`/--lead launch flow requires a tray worker base URL/`) that matches the shared prefix and is unaffected either way. No Swift test asserted the old wording.
- **Sliccstart is unaffected** — the launcher passes its own flags; this only changes what a human sees.
- **No JS/TS surface touched**; the JS gates below are for completeness.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — **565 passing**, 0 failures (includes the 3 new cases)
- [x] `swift run slicc-server --help` — renders the corrected text (wrapped over two lines by ArgumentParser)
- [x] `npm run lint:swift` — 24 warnings, **0 serious**, none in the changed files
- [x] `npm run lint:swift:format` — clean (`swift format lint --strict`)
- [x] `./packages/dev-tools/tools/swift-coverage-check.sh packages/swift-server SliccServerPackageTests` — lines 63.16% (floor 62), functions 62.24% (floor 61), regions 60.78% (floor 60)
- [x] `npm run verify` — 7/7
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK
- [x] `npm run typecheck` — clean across all 9 projects
- [x] `npm run test` — 14193 passing
- [x] **New behavior is covered by unit tests** in `packages/swift-server/Tests/ServerCommandTests.swift`:
  - `testLeadWithoutWorkerBaseURLSuggestsOnlyParsableForms` — the error must name `--lead-worker-base-url` and `WORKER_BASE_URL`, and must **not** name `--lead <url>` / `--lead=<url>`
  - `testLeadWorkerBaseURLFormFromTheErrorMessageParses` — the form the message recommends survives the parser and resolves a launch URL (otherwise the fix is just a different dead end)
  - `testLeadResolvesWorkerBaseURLFromEnvironment` — the env-var escape hatch works with `--lead` alone
  - Verified the first **fails** against the old string, on both the "must name" and "must not name" assertions.
- [x] Manual smoke: the corrected invocation is what is currently running my leader on 9222.

**Pre-existing failures**: none.

## Documentation

- [x] No documentation changes needed — this *is* the documentation fix, and it lives in the two places a user actually meets it (`--help` and the failure message). No `CLAUDE.md` or `docs/` page documents the `--lead` spelling; `packages/swift-server/CLAUDE.md` covers the `--join` egress routing, not leader startup.

## Risk & rollback

Three string literals and a comment. No behavior change, no migration. Revert cleanly.
