### PR TITLE
feat(swift-server): accept node-server's --lead <url> and --lead=<url>

### DIFF
--- a/packages/swift-server/Sources/CLI/ServerCommand.swift
+++ b/packages/swift-server/Sources/CLI/ServerCommand.swift
@@ -29,13 +29,13 @@ struct ServerCommand: AsyncParsableCommand {
     @Flag(name: .long, help: "Kill existing Electron app")
     var kill: Bool = false
 
-    // Unlike `--join` below, `--lead` is a plain flag here: it carries no value
-    // of its own, so the tray worker base URL has to arrive via
-    // `--lead-worker-base-url` or `WORKER_BASE_URL`. node-server's
-    // `runtime-flags.ts` additionally accepts `--lead <url>` / `--lead=<url>`;
-    // that parity gap is deliberate for now, so the help below names only the
-    // forms this binary actually parses.
-    @Flag(name: .long, help: "Lead mode (needs --lead-worker-base-url or WORKER_BASE_URL)")
+    // `--lead` stays a `@Flag` because the URL is optional (bare `--lead` reads
+    // `WORKER_BASE_URL`), and ArgumentParser has no "option with an optional
+    // value". The inline `--lead <url>` / `--lead=<url>` spellings that
+    // node-server's `runtime-flags.ts` accepts are folded into
+    // `--lead-worker-base-url` by `normalizeLeadArguments` before parsing —
+    // see `main()`.
+    @Flag(name: .long, help: "Lead mode (accepts --lead <url> or --lead=<url>)")
     var lead: Bool = false
 
     @Option(name: .long, help: "Tray worker base URL for --lead (or set WORKER_BASE_URL)")
@@ -66,6 +66,86 @@ struct ServerCommand: AsyncParsableCommand {
 
     @Option(name: .long, help: "Path to secrets .env file")
     var envFile: String?
+
+    /// Parse a normalized argument list so `--lead <url>` / `--lead=<url>`
+    /// reach ArgumentParser as the `--lead-worker-base-url` option it can
+    /// actually model. Everything else (help, error rendering, exit codes) is
+    /// still ArgumentParser's.
+    static func main() async {
+        await main(normalizeLeadArguments(Array(CommandLine.arguments.dropFirst())))
+    }
+
+    /// A token that reads as a URL: `scheme://…`, matching the `looksLikeUrl`
+    /// test in node-server's `runtime-flags.ts`.
+    private static func looksLikeURL(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let schemeEnd = trimmed.range(of: "://")?.lowerBound, schemeEnd > trimmed.startIndex
+        else { return false }
+        let scheme = trimmed[trimmed.startIndex..<schemeEnd]
+        guard let first = scheme.first, first.isLetter else { return false }
+        return scheme.allSatisfy { $0.isLetter || $0.isNumber || $0 == "+" || $0 == "." || $0 == "-" }
+    }
+
+    /// Rewrite the inline `--lead` spellings into the canonical
+    /// `--lead --lead-worker-base-url <url>` form.
+    ///
+    /// Mirrors node-server's `runtime-flags.ts`, including its restraint: a
+    /// following token is only swallowed when it LOOKS like a URL, so
+    /// `--lead --cdp-port 9222` keeps its port and a bare `--lead` still falls
+    /// through to `WORKER_BASE_URL`. Everything after a `--` separator is
+    /// passed through untouched, and the rewrite is idempotent.
+    static func normalizeLeadArguments(_ arguments: [String]) -> [String] {
+        var normalized: [String] = []
+        normalized.reserveCapacity(arguments.count + 2)
+        var index = arguments.startIndex
+        var sawSeparator = false
+
+        while index < arguments.endIndex {
+            let argument = arguments[index]
+            if sawSeparator {
+                normalized.append(argument)
+                index += 1
+                continue
+            }
+            if argument == "--" {
+                sawSeparator = true
+                normalized.append(argument)
+                index += 1
+                continue
+            }
+
+            if argument == "--lead" {
+                normalized.append(argument)
+                index += 1
+                // `--lead <url>`: only a URL-looking token belongs to `--lead`.
+                if index < arguments.endIndex, looksLikeURL(arguments[index]) {
+                    normalized.append("--lead-worker-base-url")
+                    normalized.append(arguments[index].trimmingCharacters(in: .whitespacesAndNewlines))
+                    index += 1
+                }
+                continue
+            }
+
+            if argument.hasPrefix("--lead=") {
+                // `--lead=<url>`; an empty value degrades to a bare `--lead`
+                // rather than injecting an empty option value.
+                let value = String(argument.dropFirst("--lead=".count))
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                normalized.append("--lead")
+                if !value.isEmpty {
+                    normalized.append("--lead-worker-base-url")
+                    normalized.append(value)
+                }
+                index += 1
+                continue
+            }
+
+            normalized.append(argument)
+            index += 1
+        }
+
+        return normalized
+    }
 
     mutating func run() async throws {
         let config = ServerConfig.resolve(from: self)
@@ -772,13 +852,12 @@ extension ServerCommand {
                     config.leadWorkerBaseUrl ?? environment["WORKER_BASE_URL"]
                 )
             else {
-                // Name only the forms THIS binary parses. `--lead` is an
-                // ArgumentParser `@Flag`, so the `--lead <url>` / `--lead=<url>`
-                // spellings that node-server accepts are rejected here — the
-                // first as a stray positional, the second as an unexpected
-                // value. Suggesting them sends the reader down a dead end.
+                // Every spelling named here parses (`normalizeLeadArguments`
+                // folds the inline ones into `--lead-worker-base-url`), and
+                // the first two match node-server's `runtime-flags.ts` so one
+                // command line now starts a leader on either runtime.
                 throw ValidationError(
-                    "The --lead launch flow requires a tray worker base URL via --lead-worker-base-url <url> or the WORKER_BASE_URL environment variable."
+                    "The --lead launch flow requires a tray worker base URL via --lead <url>, --lead=<url>, --lead-worker-base-url <url>, or WORKER_BASE_URL."
                 )
             }
             launchURL = try buildCanonicalTrayLaunchURL(locationHref: baseHref, trayValue: workerBaseURL)

--- a/packages/swift-server/Tests/ServerCommandTests.swift
+++ b/packages/swift-server/Tests/ServerCommandTests.swift
@@ -180,12 +180,92 @@ final class ServerCommandTests: XCTestCase {
         )
     }
 
-    // A `--lead` run with no worker base URL must fail with a message that
-    // names a spelling this binary can actually parse. `--lead` is a `@Flag`
-    // here (node-server's `runtime-flags.ts` also accepts `--lead <url>` /
-    // `--lead=<url>`; swift-server does not), so advertising those forms sends
-    // the reader into an "Unexpected argument" dead end. Guard both halves:
-    // the message must not name them, and whatever it DOES name must parse.
+    // MARK: - `--lead <url>` / `--lead=<url>` parity with node-server
+
+    // The two inline spellings node-server's `runtime-flags.ts` accepts must
+    // reach `--lead-worker-base-url`, so one command line starts a leader on
+    // either runtime.
+    func testNormalizeLeadArgumentsFoldsInlineSpellings() {
+        XCTAssertEqual(
+            ServerCommand.normalizeLeadArguments(["--lead", "https://worker.example"]),
+            ["--lead", "--lead-worker-base-url", "https://worker.example"]
+        )
+        XCTAssertEqual(
+            ServerCommand.normalizeLeadArguments(["--lead=https://worker.example"]),
+            ["--lead", "--lead-worker-base-url", "https://worker.example"]
+        )
+    }
+
+    // Restraint, mirroring node-server: only a URL-LOOKING token belongs to
+    // `--lead`. A bare `--lead` must keep falling through to WORKER_BASE_URL,
+    // and a following flag or plain word must stay where it is.
+    func testNormalizeLeadArgumentsLeavesNonURLTokensAlone() {
+        XCTAssertEqual(ServerCommand.normalizeLeadArguments(["--lead"]), ["--lead"])
+        XCTAssertEqual(
+            ServerCommand.normalizeLeadArguments(["--lead", "--cdp-port", "9222"]),
+            ["--lead", "--cdp-port", "9222"]
+        )
+        XCTAssertEqual(
+            ServerCommand.normalizeLeadArguments(["--lead", "notaurl"]),
+            ["--lead", "notaurl"]
+        )
+        // An empty inline value degrades to a bare flag rather than injecting
+        // an empty option value.
+        XCTAssertEqual(ServerCommand.normalizeLeadArguments(["--lead="]), ["--lead"])
+    }
+
+    // Unrelated arguments, the `--` separator, and a second pass must all be
+    // pass-throughs — the rewrite has to be safe to run over any argv.
+    func testNormalizeLeadArgumentsIsIdempotentAndScoped() {
+        let canonical = ["--lead", "--lead-worker-base-url", "https://worker.example"]
+        XCTAssertEqual(ServerCommand.normalizeLeadArguments(canonical), canonical)
+        XCTAssertEqual(
+            ServerCommand.normalizeLeadArguments(ServerCommand.normalizeLeadArguments(canonical)),
+            canonical
+        )
+        XCTAssertEqual(
+            ServerCommand.normalizeLeadArguments(["--join", "https://join.example/x"]),
+            ["--join", "https://join.example/x"]
+        )
+        // Past `--`, a literal `--lead https://…` belongs to whoever is reading
+        // the trailing arguments, not to us.
+        XCTAssertEqual(
+            ServerCommand.normalizeLeadArguments(["--", "--lead", "https://worker.example"]),
+            ["--", "--lead", "https://worker.example"]
+        )
+    }
+
+    // End to end: the normalized argv must actually parse and resolve, for
+    // both inline spellings.
+    func testInlineLeadSpellingsParseIntoConfig() throws {
+        for argv in [
+            ["--lead", "https://worker.example"],
+            ["--lead=https://worker.example"],
+        ] {
+            let normalized = ServerCommand.normalizeLeadArguments(argv)
+            let parsed = try ServerCommand.parseAsRoot(normalized)
+            let command = try XCTUnwrap(parsed as? ServerCommand)
+            let config = ServerConfig.resolve(from: command, arguments: ["slicc-server"] + normalized)
+
+            XCTAssertTrue(config.lead, "expected lead mode for \(argv)")
+            XCTAssertEqual(
+                config.leadWorkerBaseURL?.absoluteString,
+                "https://worker.example",
+                "expected worker base URL for \(argv)"
+            )
+            XCTAssertNoThrow(
+                try ServerCommand.resolveBrowserLaunchURL(
+                    serveOrigin: "http://localhost:5710",
+                    config: config,
+                    environment: [:]
+                ),
+                "expected a resolvable launch URL for \(argv)"
+            )
+        }
+    }
+
+    // A `--lead` run with no worker base URL anywhere must still fail, and the
+    // message must name only spellings that parse — all four now do.
     func testLeadWithoutWorkerBaseURLSuggestsOnlyParsableForms() throws {
         let parsed = try ServerCommand.parseAsRoot(["--lead"])
         let command = try XCTUnwrap(parsed as? ServerCommand)
@@ -207,9 +287,13 @@ final class ServerCommandTests: XCTestCase {
                 message.contains("WORKER_BASE_URL"),
                 "error must keep the env-var escape hatch, got: \(message)"
             )
-            XCTAssertFalse(
-                message.contains("--lead <url>") || message.contains("--lead=<url>"),
-                "error must not suggest forms this binary rejects, got: \(message)"
+            // Previously these two spellings were forbidden here because the
+            // binary rejected them. `normalizeLeadArguments` makes them real,
+            // so the message is now expected to advertise them — and
+            // `testInlineLeadSpellingsParseIntoConfig` holds them to it.
+            XCTAssertTrue(
+                message.contains("--lead <url>") && message.contains("--lead=<url>"),
+                "error must name the inline spellings now that they parse, got: \(message)"
             )
         }
     }


### PR DESCRIPTION
Stacked on top of #2064. **Merge that one first** — this PR flips one of its assertions, so they must not sit in the merge queue together.

## Summary

#2064 made `--lead`'s help and error message honest about what swift-server accepts. This closes the gap they were honest *about*: `slicc-server` now accepts `--lead <url>` and `--lead=<url>`, the spellings node-server has always taken, so one command line starts a leader on either runtime.

## Why

Before this pair of PRs, the two runtimes had **zero overlap** on the flag that carries the tray worker base URL:

| form | node-server | swift-server (before) |
| --- | --- | --- |
| `--lead=<url>` | ✅ `runtime-flags.ts:131` | ❌ unexpected value |
| `--lead <url>` | ✅ `runtime-flags.ts:174` | ❌ `Unexpected argument` |
| `--lead-worker-base-url <url>` | ❌ flag does not exist | ✅ |
| bare `--lead` + `WORKER_BASE_URL` | ✅ | ✅ |

So a `--lead https://...` line copied from the Node runtime died on the Swift one, and swift-server's own working spelling did not exist on the Node side to copy back. Review-checklist category **3 (cross-runtime parity)**. `--join` was brought into line long ago (`testJoinFlagParsesUrlAsValue`); `--lead` is the last holdout.

## Approach / Implementation notes

**Why not just make `--lead` an `@Option`.** The URL is optional — a bare `--lead` still reads `WORKER_BASE_URL`, which Sliccstart and the docs both rely on — and ArgumentParser has no "option with an optional value". Turning it into an `@Option` would break every bare `--lead` invocation.

So the inline spellings are folded into the canonical form *before* parsing:

- `normalizeLeadArguments([String]) -> [String]` rewrites `--lead <url>` and `--lead=<url>` into `--lead --lead-worker-base-url <url>`
- a custom `static func main()` runs argv through it and hands the result to ArgumentParser's own `main(_:)`, so help text, error rendering and exit codes stay ArgumentParser's

The rewrite mirrors `runtime-flags.ts` **including its restraint** — a following token is swallowed only when it looks like a URL (`scheme://`, matching `looksLikeUrl`):

- `--lead --cdp-port 9222` → keeps its port
- `--lead notaurl` → left alone for the parser to reject, rather than silently becoming a worker URL
- bare `--lead` → still falls through to `WORKER_BASE_URL`
- `--lead=` (empty) → degrades to a bare `--lead` instead of injecting an empty option value
- anything after a `--` separator → untouched
- running it twice changes nothing (idempotent), so it is safe over any argv

**`--lead-worker-base-url` is kept.** It is what Sliccstart and existing scripts pass; removing it would trade one break for another. swift-server is now a superset: all four forms work.

The error message goes back to naming the inline spellings — truthfully this time — plus the Swift-only flag and the env var.

## Cross-cutting impact

- **Purely additive at the CLI.** Every invocation that worked before works unchanged; the normalizer only ever *inserts* `--lead-worker-base-url` where `--lead` carried an inline URL.
- **`--join` is untouched** — it is already an `@Option` with a `join`/`join-url` alias pair and needs no rewriting. The normalizer explicitly passes it through, with a test.
- **Custom `main()`**: the one behavioral subtlety. It delegates to `AsyncParsableCommand.main(_:)`, so `--help`, `--version`, validation errors and exit codes are unchanged — but it is worth a reviewer's eye, since it is the process entry point.
- **Sliccstart**: passes `--lead-worker-base-url` (or the env var) and is unaffected either way.
- **node-server is not modified.** Its parsing was already correct; this PR brings Swift up to it rather than changing the contract.
- **No JS/TS surface touched**; JS gates below are for completeness.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — **569 passing**, 0 failures (was 565 on #2064)
- [x] `npm run lint:swift` — 24 warnings, **0 serious**, none in the changed files
- [x] `npm run lint:swift:format` — clean
- [x] `./packages/dev-tools/tools/swift-coverage-check.sh packages/swift-server SliccServerPackageTests` — lines 63.82% (floor 62), functions 62.10% (floor 61), regions 61.13% (floor 60)
- [x] `npm run verify` — 7/7
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK
- [x] `npm run typecheck` — clean across all 9 projects
- [x] `npm run test` — 14193 passing
- [x] **New behavior is covered by unit tests** in `packages/swift-server/Tests/ServerCommandTests.swift`:
  - `testNormalizeLeadArgumentsFoldsInlineSpellings` — both spellings reach `--lead-worker-base-url`
  - `testNormalizeLeadArgumentsLeavesNonURLTokensAlone` — bare `--lead`, a following flag, a non-URL word, and `--lead=` all stay as they are
  - `testNormalizeLeadArgumentsIsIdempotentAndScoped` — canonical argv unchanged, second pass unchanged, `--join` untouched, `--` respected
  - `testInlineLeadSpellingsParseIntoConfig` — both spellings parse, set `config.lead` + `leadWorkerBaseURL`, and resolve a launch URL
  - Verified these **fail** without the normalizer, with the same `ParserError.unexpectedExtraValues` the command line produced.
- [x] **Amended from #2064**: `testLeadWithoutWorkerBaseURLSuggestsOnlyParsableForms` asserted the error must *not* advertise `--lead <url>` / `--lead=<url>`. It now asserts the opposite, because they parse. That inversion is the reason these two PRs cannot be queued together.

**Pre-existing failures**: none.

## Documentation

- [x] No documentation changes needed — the help text and error message are the documentation, and both now name all four working forms. No `docs/` page or `CLAUDE.md` spells out `--lead` usage.

## Risk & rollback

The blast radius is the process entry point: if `normalizeLeadArguments` were wrong, it would corrupt argv for every invocation. That risk is bounded by the rewrite being a no-op for any argv without an inline `--lead` value (covered by the idempotence/scoping test) and by the full 569-test suite passing. No flags removed, no migration. Revert cleanly; reverting this alone leaves #2064's honest-but-narrower message in place, which is a coherent state.
