### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -158,7 +158,7 @@
     },
     "ios-app": {
       "lines": 72,
-      "functions": 70,
+      "functions": 71,
       "regions": 68
     }
   }


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.