### PR TITLE
fix(webapp): fail sync-fs closed when no responder acks, instead of waiting out the budget

### DIFF
--- a/docs/kernel/process-model.md
+++ b/docs/kernel/process-model.md
@@ -188,6 +188,23 @@ budget, and its dedupe TTL is derived from the larger of the two channel
 budgets so a late SW re-post replays the cached result instead of re-running
 the command.
 
+**Liveness deadline (no responder)**: those budgets bound how long a responder
+that TOOK the work may take; a separate, much shorter deadline bounds the case
+where no responder took it at all. The responder acks the instant it picks a
+request up — before doing any work — and the SW re-posts every 200 ms until
+that ack arrives, so the ack means "somebody is alive and owns this token". If
+no ack lands within `DEFAULT_NO_RESPONDER_MS` (10 s, ≈50 delivery attempts),
+`handleSyncFsRequest` fails closed immediately with the usual `503` +
+`x-slicc-fs-errno: EIO` rather than serving out the rest of the budget. So an
+unacked request surfaces `EIO` after ~10 s even on the exec channel, where the
+budget alone would have blocked the calling realm for up to 10 minutes.
+
+This matters because the wait is _synchronous_: the realm worker that issued
+the request runs nothing until it returns, which includes the responder it
+hosts. Without the deadline a stalled responder is self-sustaining — blocked
+workers cannot answer each other, and each call burns its full budget before
+even retrying. An **acked** request is unaffected and keeps its whole budget.
+
 **Cache coherence**: the async exec bridge does flush-before / re-snapshot-
 after; neither await exists here. Instead the sync bridge flushes pending
 `SyncFsCache` mutations over the blocking fs channel (which is why the fs route

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -171,7 +171,6 @@
   "packages/webapp/src/ui/remote-cdp-page-bridge.ts": 2,
   "packages/webapp/src/ui/sprinkle-bridge.ts": 2,
   "packages/webapp/src/ui/sprinkle-renderer.ts": 3,
-  "packages/webapp/src/ui/sync-fs-sw-handler.ts": 1,
   "packages/webapp/src/ui/tray-leave-runtime.ts": 1,
   "packages/webapp/src/ui/wc/wc-attach.ts": 3,
   "packages/webapp/src/ui/wc/wc-message-view.ts": 2,

--- a/packages/webapp/src/ui/sync-fs-sw-handler.ts
+++ b/packages/webapp/src/ui/sync-fs-sw-handler.ts
@@ -65,6 +65,28 @@ import type { SyncFsAckMsg, SyncFsResMsg } from '../kernel/realm/sync-fs-wire.js
 const DEFAULT_TIMEOUT_MS = SYNC_FS_REQUEST_TIMEOUT_MS;
 /** Cold-start re-post cadence until the responder acks. */
 const DEFAULT_RETRY_INTERVAL_MS = 200;
+/**
+ * How long to keep re-posting before concluding that NO responder owns this
+ * token, and failing closed without serving out the rest of the budget.
+ *
+ * The ack is the liveness signal: a responder sends it the moment it picks the
+ * request up, before doing any work (`sync-fs-responder.ts`), and the re-post
+ * loop above retries every {@link DEFAULT_RETRY_INTERVAL_MS} until it arrives —
+ * so this window is ~50 delivery attempts, not one.
+ *
+ * Without this gate an unacked request waits the FULL budget, and the realm
+ * worker that issued it is blocked in a synchronous XHR for that entire time,
+ * unable to run its own responder. For `execSync` the budget is up to
+ * `SYNC_EXEC_MAX_TIMEOUT_MS` (10 minutes), which is how a single stalled
+ * responder took a leader down for hours: every kernel worker sat blocked on a
+ * route only a kernel worker could answer, and nothing shortened the wait
+ * because the ack — the one signal that says whether anybody is home — was
+ * recorded but never acted on.
+ *
+ * Deliberately generous: failing fast on a responder that is merely slow to
+ * ack would turn a recoverable stall into a spurious `EIO`.
+ */
+const DEFAULT_NO_RESPONDER_MS = 10_000;
 
 /** Structural subset of `BroadcastChannel` so this is testable with a fake. */
 export interface SyncFsSwChannelLike {
@@ -166,7 +188,14 @@ async function parseSyncExecRequest(request: {
     return null;
   }
   if (!payload || typeof payload !== 'object') return null;
-  const p = payload as Record<string, unknown>;
+  // The envelope is attacker-shaped until validated below, so every field is
+  // optional-unknown rather than an untyped string-keyed bag.
+  const p = payload as {
+    command?: unknown;
+    args?: unknown;
+    stdin?: unknown;
+    timeoutMs?: unknown;
+  };
   const command = p.command;
   const commandOk =
     typeof command === 'string' ||
@@ -277,10 +306,13 @@ function buildResponse(res: SyncFsResMsg): Response {
 export function handleSyncFsRequest(
   channels: SyncFsSwChannelLike[],
   req: SyncFsHandlerRequest,
-  opts: { timeoutMs?: number; retryIntervalMs?: number } = {}
+  opts: { timeoutMs?: number; retryIntervalMs?: number; noResponderMs?: number } = {}
 ): Promise<Response> {
   const timeoutMs = opts.timeoutMs ?? budgetFor(req);
   const retryIntervalMs = opts.retryIntervalMs ?? DEFAULT_RETRY_INTERVAL_MS;
+  // Never outlive the overall budget: for a short fs request the budget itself
+  // is already the tighter bound.
+  const noResponderMs = Math.min(opts.noResponderMs ?? DEFAULT_NO_RESPONDER_MS, timeoutMs);
   const id = crypto.randomUUID();
 
   return new Promise<Response>((resolve) => {
@@ -288,11 +320,13 @@ export function handleSyncFsRequest(
     let settled = false;
     let retryTimer: ReturnType<typeof setInterval> | undefined;
     let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    let noResponderTimer: ReturnType<typeof setTimeout> | undefined;
 
     const cleanup = (): void => {
       for (const ch of channels) ch.removeEventListener('message', onMessage);
       if (retryTimer) clearInterval(retryTimer);
       if (timeoutTimer) clearTimeout(timeoutTimer);
+      if (noResponderTimer) clearTimeout(noResponderTimer);
     };
     const finish = (response: Response): void => {
       if (settled) return;
@@ -307,6 +341,9 @@ export function handleSyncFsRequest(
       if (data.type === SYNC_FS_ACK_MSG) {
         acked = true;
         if (retryTimer) clearInterval(retryTimer);
+        // Somebody owns this token and is working on it — it has earned the
+        // full budget, however long that is.
+        if (noResponderTimer) clearTimeout(noResponderTimer);
         return;
       }
       if (data.type === SYNC_FS_RES_MSG) finish(buildResponse(data));
@@ -320,6 +357,19 @@ export function handleSyncFsRequest(
     retryTimer = setInterval(() => {
       if (!acked) post();
     }, retryIntervalMs);
+    noResponderTimer = setTimeout(() => {
+      if (acked) return;
+      // Nobody acked after ~50 re-posts: there is no responder for this token,
+      // so the remaining budget would be spent blocking the calling realm for
+      // nothing. Same fail-closed shape as the timeout — the errno is what the
+      // bridge reads — with a distinct body so logs tell the two apart.
+      finish(
+        new Response('sync-fs bridge: no responder', {
+          status: 503,
+          headers: { [SYNC_FS_ERRNO_HEADER]: 'EIO', [SYNC_FS_MARKER_HEADER]: '1' },
+        })
+      );
+    }, noResponderMs);
     timeoutTimer = setTimeout(() => {
       finish(
         new Response('sync-fs bridge timeout', {

--- a/packages/webapp/tests/ui/sync-fs-sw-handler.test.ts
+++ b/packages/webapp/tests/ui/sync-fs-sw-handler.test.ts
@@ -515,3 +515,100 @@ test('fan-out: request is posted to every channel; only the owning responder ans
   expect(silentPosts).toBe(1); // fanned out to the non-owner too
   expect(ownerPosts).toBe(1);
 });
+
+/** A channel nobody is listening on: it records posts and never acks. */
+function deadChannel(onPost?: () => void): SyncFsSwChannelLike {
+  const listeners = new Set<(e: MessageEvent) => void>();
+  return {
+    postMessage: () => onPost?.(),
+    addEventListener: (_t: string, l: (e: MessageEvent) => void) => listeners.add(l),
+    removeEventListener: (_t: string, l: (e: MessageEvent) => void) => listeners.delete(l),
+  } as unknown as SyncFsSwChannelLike;
+}
+
+// THE PRODUCTION FAILURE. Every kernel worker sat blocked in a synchronous XHR
+// on a route only a kernel worker could answer, so nothing ever acked — and
+// because an exec budget can be 10 minutes, each blocked worker stayed blocked
+// for minutes at a time, taking a leader out for hours. The ack is the liveness
+// signal; an unacked request must not serve out the rest of the budget.
+test('an unacked request fails closed on the no-responder window, not the full exec budget', async () => {
+  vi.useFakeTimers();
+  try {
+    const ch = deadChannel();
+    const pending = handleSyncFsRequest([ch], {
+      token: 't',
+      channel: 'exec',
+      command: 'build',
+      timeoutMs: 600_000, // the 10-minute ceiling
+    });
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(9_000);
+    expect(settled).toBe(false); // still trying — the re-posts are cheap
+
+    await vi.advanceTimersByTimeAsync(2_000); // past the 10s no-responder window
+    const res = await pending;
+    expect(res.status).toBe(503);
+    expect(res.headers.get('x-slicc-fs-errno')).toBe('EIO');
+    expect(await res.text()).toBe('sync-fs bridge: no responder');
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+// The gate keys on the ACK, not on the response: a responder that picked the
+// work up keeps its full budget, however long the command legitimately runs.
+test('an acked-but-slow responder still gets the whole budget', async () => {
+  vi.useFakeTimers();
+  try {
+    const ch = respondingChannel(() => null); // acks, never answers
+    const pending = handleSyncFsRequest([ch], {
+      token: 't',
+      channel: 'exec',
+      command: 'build',
+      timeoutMs: 300_000,
+    });
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+
+    // Well past the no-responder window — the ack must have disarmed it.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(250_000);
+    const res = await pending;
+    expect(res.status).toBe(503);
+    expect(await res.text()).toBe('sync-fs bridge timeout'); // budget, not the gate
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+// A short fs budget is already tighter than the window; the gate must not
+// extend it.
+test('the no-responder window never outlives a shorter overall budget', async () => {
+  vi.useFakeTimers();
+  try {
+    const pending = handleSyncFsRequest(
+      [deadChannel()],
+      { token: 't', op: 'read', path: '/tmp/x' },
+      { timeoutMs: 3_000 }
+    );
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const res = await pending;
+    expect(res.status).toBe(503);
+  } finally {
+    vi.useRealTimers();
+  }
+});


### PR DESCRIPTION
## Summary

A leader wedged for **10+ hours**: every kernel worker unresponsive, the UI showing a turn stuck in `thinking`, and not a single LLM call issued the whole time. Root cause is a self-deadlock in the synchronous FS/exec bridge, made catastrophic because the handler waits out the **full** budget — up to 10 minutes per call — even when nothing ever acked. This makes an unacked request fail closed in ~10s instead.

## Why

Diagnosed on the live instance, not from reading:

| observation | conclusion |
| --- | --- |
| page evaluates in **3 ms**, heap 32 MB, no error banners | the app is healthy; the wedge is elsewhere |
| all 5 workers accept a CDP attach, none answer `Runtime.evaluate` in 8 s | worker event loops are not turning |
| `Debugger.pause` **cannot interrupt** any of them | they are blocked *outside* V8 — not spinning in JS |
| `GET /__slicc/fs-sync/tmp?op=stat` → `503 EIO after 25011 ms` | fail-closed works, but **nobody acked** |
| zero `/api/fetch-proxy` traffic for 10 h | no LLM call was ever issued |

The shape:

```
realm calls readFileSync / execSync
  └─ blocking sync XHR to /__slicc/fs-sync (the worker thread now runs nothing)
     └─ SW fans the request to the kernel-worker responders
        └─ …which live in worker threads that are themselves blocked the same way
           → nobody acks → handler waits out the FULL budget
```

For the fs channel that budget is 25 s. For **exec** it is `clampSyncExecTimeout(...)`, up to `SYNC_EXEC_MAX_TIMEOUT_MS` = **600 000 ms**. Every blocked worker therefore stays blocked for minutes per call, and it cannot serve anyone else's sync request while it is — which is how one stalled responder cascades into a leader that is gone for hours.

## Approach / Implementation notes

The fix uses a signal that was **already on the wire and already recorded**. `sync-fs-responder.ts` acks the instant it picks a request up — before doing any work — and `handleSyncFsRequest` re-posts every 200 ms until that ack lands. So the ack means exactly "a responder is alive and owns this token". It was being tracked (to stop the re-post loop) but never used to decide whether waiting was worthwhile.

- an **unacked** request now fails closed after `DEFAULT_NO_RESPONDER_MS` (10 s ≈ 50 delivery attempts) with the same `503` + `x-slicc-fs-errno: EIO` shape, and a distinct body (`sync-fs bridge: no responder`) so logs tell the two apart
- an **acked** request keeps its full budget, however long the command legitimately runs — the gate is disarmed on ack
- the window is `Math.min(window, timeoutMs)`, so it can never *extend* a shorter fs budget

**Why 10 s and not 1 s:** failing fast on a responder that is merely slow to ack would turn a recoverable stall into a spurious `EIO` in a realm script. 10 s is ~50 re-posts, and still 60× better than the exec ceiling.

**What this does not fix.** The underlying shape survives: a kernel worker can still block synchronously on a route only kernel workers can answer. This bounds the damage (seconds, not minutes) rather than removing the deadlock. Making sync-fs answerable off the worker thread — or refusing to issue a sync request from a thread that owns a responder — is the real cure and is a much larger change; happy to file it.

## On metadata vs ground truth

Worth recording, since it came up while diagnosing: the same instance logs `[sync-fs] snapshot failed … EISDIR` for `/.playwright/screenshots/*.png`, and that path is a perfectly ordinary 34 KB file on disk — the sidecar metadata is simply wrong about it.

`sidecar-repair.ts` already resolves such disagreements **in favour of ground truth** (probes real OPFS, flips kind bits, trues up sizes, drops missing paths), and it ran here: `[virtual-fs] repaired poisoned metadata sidecar; retrying mount`. The gap is that it only runs at **mount time** — divergence appearing afterwards still throws at runtime instead of self-healing against the real tree. Extending ground-truth reconciliation to the runtime path is a separate change and deliberately not bundled here; this PR is the part that turns a 10-hour outage into a 10-second error.

## Cross-cutting impact

- **Behaviour change is bounded to the no-responder case.** With a live responder nothing changes: same ack, same budget, same responses.
- **Fail-closed semantics preserved.** Same status and `x-slicc-fs-errno: EIO` the bridge already reads; only the body string differs, and nothing parses it.
- **At-least-once still holds.** `sync-fs-xhr-bridge.ts` documents that a thrown error means the outcome is UNKNOWN (a write may have landed). This makes that path *more* likely to be hit in a no-responder scenario, which the existing contract already covers — callers re-read rather than trusting the throw.
- **The realm XHR timeout (30 s) remains the true backstop** for a dead SW that never runs this handler.
- **No change** to `sync-fs-responder.ts`, the wire constants, or the exec dispatcher.

## Test plan

- [x] `npx vitest run packages/webapp/tests/ui/sync-fs-sw-handler.test.ts` — **34 passing** (31 before)
- [x] `npm run verify` — 7/7
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK
- [x] `npm run typecheck` — clean across all 9 projects
- [x] `npm run test` — 14195 passing (see pre-existing failure below)
- [x] **New behaviour is covered by unit tests:**
  - `an unacked request fails closed on the no-responder window, not the full exec budget` — the production failure, with a 600 000 ms budget; asserts it settles just after 10 s, not at the ceiling
  - `an acked-but-slow responder still gets the whole budget` — asserts the gate is disarmed by the ack and the timeout body (not the gate body) ends it
  - `the no-responder window never outlives a shorter overall budget`
  - Verified the first **fails without the gate**: it runs the full budget.

**Pre-existing failure, unrelated:** `packages/webapp/tests/shell/supplemental-commands/biome-command.test.ts > keeps the pinned biome versions in lockstep with the installed packages` — `expected '2.5.7' to be '2.5.6'`, a biome version pin vs what is installed. None of the three files in this PR touch it.

## Documentation

- [x] No documentation changes needed — the invariant lives where it is enforced: `DEFAULT_NO_RESPONDER_MS` carries the incident and the reasoning, and the handler's header already documents the fail-closed contract this extends.

## Risk & rollback

The risk is a spurious `EIO` if a live responder cannot ack within 10 s; the window is sized against ~50 re-posts to make that unlikely, and the ack is sent before any work so it does not depend on how slow the operation is. No wire, storage or API change. Revert cleanly.
