### PR TITLE
feat(ios-app): show the app as Sliccy

### DIFF
--- a/packages/ios-app/SliccFileProvider/Info.plist
+++ b/packages/ios-app/SliccFileProvider/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Sliccy</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -18,16 +20,10 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>CFBundleDisplayName</key>
-	<string>SLICC</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionFileProviderDocumentGroup</key>
 		<string>group.ai.sliccy.follower</string>
-		<!-- Required for Files.app Locations visibility. Apple's File Provider
-		     extension template sets this; without it iOS can register the
-		     domain (getDomains succeeds) while leaving userEnabled=false and
-		     omitting the provider from Browse → Edit. -->
 		<key>NSExtensionFileProviderSupportsEnumeration</key>
 		<true/>
 		<key>NSExtensionPointIdentifier</key>

--- a/packages/ios-app/SliccFollower/App/FileProviderDomainLifecycle.swift
+++ b/packages/ios-app/SliccFollower/App/FileProviderDomainLifecycle.swift
@@ -34,8 +34,14 @@ struct SystemFileProviderDomainRegistrar: FileProviderDomainRegistering {
 }
 
 final class FileProviderDomainLifecycle {
+    /// The identifier is the domain's identity and must NOT follow the name —
+    /// changing it orphans the registered domain and the Files.app location
+    /// disappears rather than being renamed.
     static let domainIdentifier = NSFileProviderDomainIdentifier(rawValue: "slicc-vfs")
-    static let domainDisplayName = "SLICC"
+    /// What Files.app puts under Locations. A domain already registered on a
+    /// device keeps the name it was created with until it is re-registered,
+    /// so an existing install can read "SLICC" until then.
+    static let domainDisplayName = "Sliccy"
 
     static func makeDomain() -> NSFileProviderDomain {
         NSFileProviderDomain(

--- a/packages/ios-app/SliccShareExtension/Info.plist
+++ b/packages/ios-app/SliccShareExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>SLICC</string>
+	<string>Sliccy</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/packages/ios-app/SliccTrayKit/FileProvider/LeaderVFSProvider.swift
+++ b/packages/ios-app/SliccTrayKit/FileProvider/LeaderVFSProvider.swift
@@ -134,7 +134,8 @@ public final class LeaderVFSItem: NSObject, NSFileProviderItemProtocol {
         itemIdentifier = try VFSItemIdentity.identifier(for: path)
         if path == "/" {
             parentItemIdentifier = .rootContainer
-            filename = "SLICC"
+            // Display only — identity is the path, so this is safe to rename.
+            filename = "Sliccy"
         } else {
             let parent = (path as NSString).deletingLastPathComponent
             parentItemIdentifier = try VFSItemIdentity.identifier(for: parent.isEmpty ? "/" : parent)

--- a/packages/ios-app/project.yml
+++ b/packages/ios-app/project.yml
@@ -52,7 +52,12 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sliccy.follower
-        INFOPLIST_KEY_CFBundleDisplayName: SliccFollower
+        # What the user sees: home screen, Settings, permission prompts, the
+        # app switcher. Deliberately not `PRODUCT_NAME`, which names the
+        # binary, the scheme and the `.app` — the coverage gate, the simulator
+        # test scripts, the CI job names and the TestFlight script all address
+        # the target as SliccFollower.
+        INFOPLIST_KEY_CFBundleDisplayName: Sliccy
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: 'UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight'
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: 'UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight'
@@ -88,18 +93,25 @@ targets:
     info:
       path: SliccFileProvider/Info.plist
       properties:
-        CFBundleDisplayName: SLICC
+        CFBundleDisplayName: Sliccy
         NSExtension:
           NSExtensionPointIdentifier: com.apple.fileprovider-nonui
           NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).FileProviderExtension
           NSExtensionFileProviderDocumentGroup: group.ai.sliccy.follower
-          # Required for Files.app Locations visibility (Apple template default).
+          # Required for Files.app Locations visibility. Apple's File Provider
+          # extension template sets this; without it iOS can register the
+          # domain (getDomains succeeds) while leaving userEnabled=false and
+          # omitting the provider from Browse → Edit.
+          #
+          # This comment lives here, not in the generated Info.plist: xcodegen
+          # rewrites that file from these properties and strips anything it
+          # did not write.
           NSExtensionFileProviderSupportsEnumeration: true
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sliccy.follower.fileprovider
         PRODUCT_NAME: SliccFileProvider
-        INFOPLIST_KEY_CFBundleDisplayName: SLICC
+        INFOPLIST_KEY_CFBundleDisplayName: Sliccy
         CODE_SIGN_ENTITLEMENTS: SliccFileProvider.entitlements
         APPLICATION_EXTENSION_API_ONLY: YES
     dependencies:
@@ -117,7 +129,7 @@ targets:
     info:
       path: SliccShareExtension/Info.plist
       properties:
-        CFBundleDisplayName: SLICC
+        CFBundleDisplayName: Sliccy
         NSExtension:
           NSExtensionPointIdentifier: com.apple.share-services
           NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).ShareViewController
@@ -130,7 +142,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sliccy.follower.share
         PRODUCT_NAME: SliccShareExtension
-        INFOPLIST_KEY_CFBundleDisplayName: SLICC
+        INFOPLIST_KEY_CFBundleDisplayName: Sliccy
         CODE_SIGN_ENTITLEMENTS: SliccShareExtension.entitlements
         # The share row still reaches UIApplication.open through the
         # responder chain (the ChatGPT/Claude/Grok/Bluesky pattern) —


### PR DESCRIPTION
## Summary

The app calls itself three different things on the three surfaces a user actually sees:

| surface | before | after |
| --- | --- | --- |
| home screen, Settings, permission prompts, app switcher | `SliccFollower` | **Sliccy** |
| Safari share-sheet row | `SLICC` | **Sliccy** |
| Files.app location + its root folder | `SLICC` | **Sliccy** |

`SliccFollower` is the *target's* name leaking to users; `SLICC` is a third spelling. All three now read Sliccy.

## Why

"SliccFollower" is build vocabulary. It shows up in the place people look most — under the icon — and in every permission prompt: *"SliccFollower would like to access the microphone"* now reads *"Sliccy would like to access the microphone"*.

## Approach

Display only. Nothing that carries identity moves:

- **`PRODUCT_NAME` stays `SliccFollower`.** It names the binary, the scheme and the `.app`, and `swift-coverage-check.sh --xcodebuild SliccFollower`, `ios-sim-test.sh`, the `ios-app` / `ios-app-tests` job names and `package-and-upload-testflight.sh` all address the target by it. Renaming it is a large change with no user-visible gain.
- **The File Provider's domain identifier stays `slicc-vfs`.** That is the domain's identity, not its label — changing it orphans the registered domain, so the Files.app location would *vanish* instead of being renamed.
- **Bundle identifiers are untouched**, so no provisioning profile, entitlement or App Store Connect record changes.
- The VFS root item's filename is display-only (identity is the path), so it renames safely.

The `NSExtensionFileProviderSupportsEnumeration` rationale moves from the generated `SliccFileProvider/Info.plist` into `project.yml`. xcodegen rewrites that plist from the `properties` block and strips comments it did not write, so the note only survives at the source. Its content is unchanged — including the part that matters, that without the key iOS registers the domain while leaving `userEnabled=false`.

## Two things that are NOT covered by this PR

1. **TestFlight and the App Store listing** take their name from App Store Connect, not `CFBundleDisplayName`. If testers should see "Sliccy" there, that is a manual change in ASC → App Information → Name. It takes effect immediately for TestFlight; a public listing rename goes through review with the next submission.
2. **Existing installs may keep "SLICC" in Files.app for a while.** A File Provider domain keeps the display name it was *registered* with. The app removes and re-adds the domain when credentials change, so it corrects itself then — but not necessarily on first launch of the new build. New installs get "Sliccy" immediately.

## Test plan

- [x] `xcodebuild build` clean, and the built bundles verified rather than the source: `plutil -extract CFBundleDisplayName` reads **Sliccy** in `SliccFollower.app`, `SliccShareExtension.appex` and `SliccFileProvider.appex`
- [x] Installed on a simulator and read the home screen — the icon label is **Sliccy** (screenshot in a follow-up comment)
- [x] `SliccFollowerTests` 539/539, `ComposerConnectionUITests` 4/4 — nothing asserted the old string, including the File Provider tests
- [x] `swiftlint` 0 serious, `swift format lint --strict` clean
- [x] `npm run verify` (7/7), `npm run typecheck`, `check-touched-exemptions` OK
- [ ] `npm run test` / `build` — no TypeScript in this change; CI covers both

The `ios-screenshots` job will re-render every registered screen under the new name, so its sticky comment is a real check here rather than a formality.

## Risk & rollback

- Blast radius: labels on one app. Clean revert; no persisted state, no protocol, no identifiers.
- The one thing to watch after release: the Files.app location on an **existing** install, per note 2 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HprQQw9b14nfKRUcBTy66
