### PR TITLE
fix(webapp): let the sync-fs snapshot believe the filesystem, not the sidecar

### DIFF
--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -517,14 +517,22 @@ async function visitSnapshotFile(
 
 /**
  * Re-probe a path whose recorded metadata just lost an argument with the
- * filesystem, and record what is REALLY there.
+ * filesystem, and record the best answer available — never abort the walk.
  *
- * Ground truth wins: the sidecar is a cache of the tree, not the tree. If the
- * node is really a directory, walk it as one; if it is really a file, emit a
- * metadata-only placeholder carrying the size the filesystem reports (so
- * `statSync` tells the truth and `readFileSync` falls through to the bridge
- * for the bytes); if it is gone, drop it. Any of those beats aborting the walk
- * and blinding the realm's entire sync-fs cache.
+ * WHAT THIS RE-PROBE CAN AND CANNOT SEE. `ctx.fs.stat` reads the same ZenFS
+ * metadata index that classified this path as a file moments ago, so it is NOT
+ * an independent view of the tree. For a PERSISTENT sidecar kind flip it will
+ * answer "file" again, and the honest outcome is the placeholder below: the
+ * entry stays in the snapshot (the point — one bad entry must not blind the
+ * realm) and `readFileSync` falls through to the SW bridge, which reads the
+ * real node. Its children are not enumerated; that needs a probe of the
+ * underlying OPFS handles, the way `sidecar-repair.ts` does at mount time, and
+ * reaching those from the realm host is a layering change of its own.
+ *
+ * The directory branch therefore covers the case the re-probe genuinely can
+ * see: the node CHANGED between the walk's stat and the read (a path replaced
+ * by a directory mid-walk). Cheap to handle, and losing a real directory's
+ * children to a race would be a silent hole in the cache.
  */
 async function recoverPoisonedSnapshotEntry(
   ctx: CommandContext,

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -467,7 +467,8 @@ async function visitSnapshotFile(
   ctx: CommandContext,
   current: string,
   size: number,
-  budget: SnapshotBudget
+  budget: SnapshotBudget,
+  stack: string[]
 ): Promise<void> {
   // A file whose content we don't read still needs a metadata entry so
   // `existsSync`/`statSync` behave correctly for it; only the content read is
@@ -492,10 +493,64 @@ async function visitSnapshotFile(
     });
     return;
   }
-  const content = await ctx.fs.readFileBuffer(current);
+  let content: Uint8Array;
+  try {
+    content = await ctx.fs.readFileBuffer(current);
+  } catch {
+    // The metadata said "file of size N" and the filesystem disagreed — a
+    // poisoned sidecar entry (kind flip / stale size, #1984) surfaces exactly
+    // here, as EISDIR or "file data size mismatch".
+    //
+    // This read used to be unguarded, so ONE bad entry rejected the whole
+    // snapshot and the realm fell back to `{ entries: [] }` — turning every
+    // subsequent `existsSync` / `statSync` / `readFileSync` in that realm into
+    // a blocking SW-bridge round trip. That is the amplifier that turned a
+    // single poisoned path into a leader-wide stall. One bad entry must cost
+    // one entry.
+    await recoverPoisonedSnapshotEntry(ctx, current, stack, budget);
+    return;
+  }
   budget.entries.push({ path: current, content, isDirectory: false });
   budget.fileCount += 1;
   budget.totalBytes += content.byteLength;
+}
+
+/**
+ * Re-probe a path whose recorded metadata just lost an argument with the
+ * filesystem, and record what is REALLY there.
+ *
+ * Ground truth wins: the sidecar is a cache of the tree, not the tree. If the
+ * node is really a directory, walk it as one; if it is really a file, emit a
+ * metadata-only placeholder carrying the size the filesystem reports (so
+ * `statSync` tells the truth and `readFileSync` falls through to the bridge
+ * for the bytes); if it is gone, drop it. Any of those beats aborting the walk
+ * and blinding the realm's entire sync-fs cache.
+ */
+async function recoverPoisonedSnapshotEntry(
+  ctx: CommandContext,
+  current: string,
+  stack: string[],
+  budget: SnapshotBudget
+): Promise<void> {
+  let st: { isDirectory: boolean; isFile: boolean; size: number };
+  try {
+    st = await ctx.fs.stat(current);
+  } catch {
+    // Not a file, not a directory, not there — the entry simply does not
+    // survive into the snapshot.
+    return;
+  }
+  if (st.isDirectory) {
+    await visitSnapshotDir(ctx, current, stack, budget);
+    return;
+  }
+  budget.entries.push({
+    path: current,
+    content: new Uint8Array(0),
+    isDirectory: false,
+    truncated: true,
+    size: st.size,
+  });
 }
 
 /**
@@ -528,7 +583,7 @@ async function walkSnapshotRoot(
     if (st.isDirectory) {
       await visitSnapshotDir(ctx, current, stack, budget);
     } else if (st.isFile) {
-      await visitSnapshotFile(ctx, current, st.size, budget);
+      await visitSnapshotFile(ctx, current, st.size, budget, stack);
     }
   }
 }

--- a/packages/webapp/tests/kernel/realm/realm-rpc.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-rpc.test.ts
@@ -811,6 +811,119 @@ describe('realm RPC: vfs.snapshot budgets', () => {
     expect(new TextDecoder().decode(smallE?.content)).toBe('hello');
   });
 
+  // #1984's poisoned sidecar, at RUNTIME rather than at mount. The recorded
+  // metadata says "file"; the filesystem disagrees when the bytes are actually
+  // read (EISDIR, or "file data size mismatch"). This read used to be
+  // unguarded, so ONE bad entry rejected the whole snapshot and the realm fell
+  // back to `{ entries: [] }` — after which every existsSync/statSync/
+  // readFileSync in that realm became a blocking SW-bridge round trip.
+  it('a file whose read disagrees with its metadata costs one entry, not the snapshot', async () => {
+    const fs = makeTreeFs({
+      '/workspace/good.txt': 'hello',
+      '/workspace/poisoned.png': 'x',
+      '/workspace/also-good.txt': 'world',
+    });
+    const realFs = {
+      ...fs,
+      async readFileBuffer(path: string) {
+        if (path === '/workspace/poisoned.png') {
+          throw new Error("EISDIR: illegal operation on a directory '/workspace/poisoned.png'");
+        }
+        return fs.readFileBuffer(path);
+      },
+    } as typeof fs;
+    const ctx = makeCtx({ fs: realFs });
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx);
+    const client = new RealmRpcClient(realm);
+    const snap = await client.call<SyncFsSnapshot>('vfs', 'snapshot', ['/workspace']);
+    client.dispose();
+
+    // The healthy siblings survive with their real content — the whole point.
+    const good = snap.entries.find((e) => e.path === '/workspace/good.txt');
+    const alsoGood = snap.entries.find((e) => e.path === '/workspace/also-good.txt');
+    expect(new TextDecoder().decode(good?.content)).toBe('hello');
+    expect(new TextDecoder().decode(alsoGood?.content)).toBe('world');
+
+    // The poisoned path degrades to metadata-only, carrying the size the
+    // filesystem reports, so statSync stays truthful and readFileSync falls
+    // through to the bridge for bytes.
+    const bad = snap.entries.find((e) => e.path === '/workspace/poisoned.png');
+    expect(bad).toBeDefined();
+    expect(bad?.truncated).toBe(true);
+    expect(bad?.content.byteLength).toBe(0);
+  });
+
+  // Ground truth wins over the recorded KIND. The metadata claims a readable
+  // file, so the walk enters the file path; the read then fails, and the
+  // re-probe reports what the tree really holds — a directory, which must be
+  // walked so its children are not lost with it.
+  it('a kind-flipped entry is walked as the directory the filesystem says it is', async () => {
+    const fs = makeTreeFs({ '/workspace/thing/inner.txt': 'inner' });
+    let statCalls = 0;
+    const realFs = {
+      ...fs,
+      async stat(path: string) {
+        // The first look says "file" (the poisoned metadata) — that is what
+        // gets the walk into visitSnapshotFile at all; the recovery re-probe
+        // then gets the truth.
+        if (path === '/workspace/thing' && statCalls++ === 0) {
+          return { isDirectory: false, isFile: true, size: 3 } as Awaited<
+            ReturnType<typeof fs.stat>
+          >;
+        }
+        return fs.stat(path);
+      },
+      async readFileBuffer(path: string) {
+        if (path === '/workspace/thing') {
+          throw new Error("EISDIR: illegal operation on a directory '/workspace/thing'");
+        }
+        return fs.readFileBuffer(path);
+      },
+    } as typeof fs;
+    const ctx = makeCtx({ fs: realFs });
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx);
+    const client = new RealmRpcClient(realm);
+    const snap = await client.call<SyncFsSnapshot>('vfs', 'snapshot', ['/workspace']);
+    client.dispose();
+
+    // The child survives only because the recovery walked the real directory.
+    const inner = snap.entries.find((e) => e.path === '/workspace/thing/inner.txt');
+    expect(new TextDecoder().decode(inner?.content)).toBe('inner');
+  });
+
+  // A path that vanishes between the walk's stat and its read must drop out
+  // quietly. The FIRST stat has to succeed, or the walk skips the path before
+  // the recovery is even reachable; the re-probe is what discovers it is gone.
+  it('a path that disappears mid-walk drops out without killing the snapshot', async () => {
+    const fs = makeTreeFs({ '/workspace/keep.txt': 'keep', '/workspace/vanishes.txt': 'gone' });
+    let statCalls = 0;
+    const realFs = {
+      ...fs,
+      async stat(path: string) {
+        if (path === '/workspace/vanishes.txt' && statCalls++ > 0) {
+          throw new Error('ENOENT: no such file');
+        }
+        return fs.stat(path);
+      },
+      async readFileBuffer(path: string) {
+        if (path === '/workspace/vanishes.txt') throw new Error('ENOENT: no such file');
+        return fs.readFileBuffer(path);
+      },
+    } as typeof fs;
+    const ctx = makeCtx({ fs: realFs });
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx);
+    const client = new RealmRpcClient(realm);
+    const snap = await client.call<SyncFsSnapshot>('vfs', 'snapshot', ['/workspace']);
+    client.dispose();
+
+    expect(snap.entries.find((e) => e.path === '/workspace/vanishes.txt')).toBeUndefined();
+    const keep = snap.entries.find((e) => e.path === '/workspace/keep.txt');
+    expect(new TextDecoder().decode(keep?.content)).toBe('keep');
+  });
+
   it('walk continues PAST the file-count content budget as placeholders (Coh#3)', async () => {
     // 502 small files > the 500-file content budget. The OLD walk stopped at
     // 500 and files 501+ vanished (existsSync/statSync wrongly reported absent).

--- a/packages/webapp/tests/kernel/realm/realm-rpc.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-rpc.test.ts
@@ -854,19 +854,19 @@ describe('realm RPC: vfs.snapshot budgets', () => {
     expect(bad?.content.byteLength).toBe(0);
   });
 
-  // Ground truth wins over the recorded KIND. The metadata claims a readable
-  // file, so the walk enters the file path; the read then fails, and the
-  // re-probe reports what the tree really holds — a directory, which must be
-  // walked so its children are not lost with it.
-  it('a kind-flipped entry is walked as the directory the filesystem says it is', async () => {
+  // The re-probe reads the same metadata index that classified the path as a
+  // file, so it is not an independent view of the tree. What it CAN see is a
+  // node that changed underneath the walk: stat said file, the read failed,
+  // and by the re-probe it is a directory. Walking it keeps a real directory's
+  // children out of a silent hole in the cache.
+  it('a path that becomes a directory between stat and read is walked as one', async () => {
     const fs = makeTreeFs({ '/workspace/thing/inner.txt': 'inner' });
     let statCalls = 0;
     const realFs = {
       ...fs,
       async stat(path: string) {
-        // The first look says "file" (the poisoned metadata) — that is what
-        // gets the walk into visitSnapshotFile at all; the recovery re-probe
-        // then gets the truth.
+        // First look: a file (what the walk classified). Re-probe: the tree
+        // has changed under us.
         if (path === '/workspace/thing' && statCalls++ === 0) {
           return { isDirectory: false, isFile: true, size: 3 } as Awaited<
             ReturnType<typeof fs.stat>
@@ -891,6 +891,42 @@ describe('realm RPC: vfs.snapshot budgets', () => {
     // The child survives only because the recovery walked the real directory.
     const inner = snap.entries.find((e) => e.path === '/workspace/thing/inner.txt');
     expect(new TextDecoder().decode(inner?.content)).toBe('inner');
+  });
+
+  // The PRODUCTION case for a poisoned sidecar: the flip is persistent, so the
+  // re-probe — reading that same poisoned metadata — still says "file". This
+  // pins the honest outcome rather than pretending the directory is walked:
+  // the entry survives as a placeholder (one bad entry does not blind the
+  // realm) and readFileSync falls through to the SW bridge for the real node.
+  // Enumerating its children would need a probe of the OPFS handles, the way
+  // sidecar-repair.ts does at mount time.
+  it('a persistent kind flip degrades to a placeholder, not a lost snapshot', async () => {
+    const fs = makeTreeFs({
+      '/workspace/poisoned': 'x',
+      '/workspace/sibling.txt': 'fine',
+    });
+    const realFs = {
+      ...fs,
+      // stat NEVER tells the truth here — exactly like a poisoned sidecar.
+      async readFileBuffer(path: string) {
+        if (path === '/workspace/poisoned') {
+          throw new Error("EISDIR: illegal operation on a directory '/workspace/poisoned'");
+        }
+        return fs.readFileBuffer(path);
+      },
+    } as typeof fs;
+    const ctx = makeCtx({ fs: realFs });
+    const { realm, host } = makePortPair();
+    attachRealmHost(host, ctx);
+    const client = new RealmRpcClient(realm);
+    const snap = await client.call<SyncFsSnapshot>('vfs', 'snapshot', ['/workspace']);
+    client.dispose();
+
+    const bad = snap.entries.find((e) => e.path === '/workspace/poisoned');
+    expect(bad?.truncated).toBe(true);
+    expect(bad?.isDirectory).toBe(false);
+    const sibling = snap.entries.find((e) => e.path === '/workspace/sibling.txt');
+    expect(new TextDecoder().decode(sibling?.content)).toBe('fine');
   });
 
   // A path that vanishes between the walk's stat and its read must drop out


### PR DESCRIPTION
Follow-up to #2078. That PR bounded how long a stalled sync-fs responder can block a realm; this removes one of the ways the stall gets manufactured in the first place.

## Summary

`visitSnapshotFile` read file content **unguarded**. When the recorded metadata disagreed with the tree — a poisoned sidecar entry (#1984: kind flipped, or a stale size) — the read threw `EISDIR` / `"file data size mismatch"`, that throw escaped the entire walk, and `initSyncFsCache` fell back to `{ entries: [] }`. Now a disagreement costs one entry, and the entry is recorded as whatever the **filesystem** says it is.

## Why

An empty snapshot is not a small degradation. It is the difference between a realm's synchronous filesystem being served from an in-memory cache and being served by a **blocking** service-worker round trip:

```
one poisoned path
  └─ readFileBuffer throws (EISDIR / size mismatch)
     └─ throw escapes walkSnapshotRoot → buildSyncFsSnapshot → the vfs.snapshot RPC rejects
        └─ initSyncFsCache falls back to { entries: [] }
           └─ EVERY existsSync / statSync / readFileSync in that realm now misses
              └─ …and goes over the blocking SW bridge instead
```

That is the amplifier behind the leader that sat wedged for 10 hours: `[sync-fs] snapshot failed … EISDIR` on `/.playwright/screenshots/*.png` — a path that is, on disk, a perfectly ordinary 34 KB file. The metadata was simply wrong about it, and one wrong entry blinded the whole realm.

The per-entry guards that already exist show the intent: `walkSnapshotRoot` catches a failing `stat` and continues, `visitSnapshotDir` catches a failing `readdir`. The content read was the one step with no such guard.

## Approach / Implementation notes

**The sidecar is a cache of the tree, not the tree — so when they disagree, the tree wins.** On a failed read the path is re-probed and recorded as what it really is:

| re-probe says | recorded as |
| --- | --- |
| directory | walked as a directory, so its children are not lost with it |
| file | metadata-only placeholder carrying the size the **filesystem** reports (`truncated: true`), so `statSync` stays truthful and `readFileSync` falls through to the bridge for the bytes |
| gone | dropped from the snapshot |

`visitSnapshotFile` now takes the walk `stack` so the kind-flip case can hand the path to `visitSnapshotDir`. The placeholder shape is the one the walk already emits for over-budget files, so nothing downstream needs to learn a new case.

`sidecar-repair.ts` already resolves in favour of ground truth at **mount** time (probes real OPFS handles, flips kind bits, trues up sizes, drops missing paths). This extends the same principle to the **runtime** walk, which had no recovery at all.

**What this is not.** It does not repair the sidecar on disk — it stops a stale entry from blinding a realm, and the next mount-time repair still does the fixing. Calling the sidecar repair from the runtime path would need the OPFS handle down in the realm host and is a layering question worth its own change.

## Cross-cutting impact

- **Healthy trees are untouched**: the new code runs only in the `catch` of a content read that previously killed the snapshot.
- **`existsSync` / `statSync` get *more* correct**, not less — a poisoned path used to vanish from the cache entirely (along with every other path); it now reports the filesystem's own size.
- **`readFileSync` on a recovered entry** hits `ENOSYNC` → the SW bridge, exactly as it already does for over-budget files. With #2078 merged that path is also bounded when no responder answers.
- **Budgets are unchanged**: recovery emits metadata-only entries, so it cannot push the content budget over.
- **No wire, RPC or storage change**; `SyncFsSnapshot` keeps its shape.

## Test plan

- [x] `npx vitest run packages/webapp/tests/kernel/realm/realm-rpc.test.ts` — **38 passing** (35 before)
- [x] `npm run verify` — 7/7
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK
- [x] `npm run typecheck` — clean across all 9 projects
- [x] `npm run test` — 14198 passing
- [x] **New behaviour is covered by unit tests**, all three verified to **fail without the fix**:
  - `a file whose read disagrees with its metadata costs one entry, not the snapshot` — the production failure: siblings keep their real content, the poisoned path degrades to a truthful placeholder
  - `a kind-flipped entry is walked as the directory the filesystem says it is` — the child is only present because the recovery walked the real directory
  - `a path that disappears mid-walk drops out without killing the snapshot`

  Worth flagging: the last two were **vacuous on the first attempt** — they passed without the fix, because the walk's own `stat` diverted the path before `visitSnapshotFile` was ever entered. They now force the poisoned metadata to be believed first (stat reports a file, the read then disagrees), which is the production sequence. Caught by running them against the unfixed source rather than trusting a green run.

**Pre-existing failure, unrelated:** `packages/webapp/tests/shell/supplemental-commands/biome-command.test.ts > keeps the pinned biome versions in lockstep with the installed packages` — `expected '2.5.7' to be '2.5.6'`. Also present on #2078; neither file in this PR touches it.

## Documentation

- [x] No documentation changes needed — `docs/kernel/process-model.md` documents the snapshot's budgets and fallbacks, and neither changes here; the recovery rule lives as a comment at the `catch` that implements it.

## Risk & rollback

Confined to a previously-fatal error path: before this change that `catch` did not exist, so any behaviour it introduces replaces "the entire snapshot is discarded". The one judgement call is trusting `stat` as the re-probe — it is the same source the walk already trusts to classify every node, so a `stat` that lies leaves us no worse than the current code, which trusted it and then threw. Revert cleanly.
