### PR TITLE
fix(ios-app): say Sliccy in the share panel too

### DIFF
--- a/packages/ios-app/SliccShareExtension/ShareViewController.swift
+++ b/packages/ios-app/SliccShareExtension/ShareViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import UniformTypeIdentifiers
 
-/// Safari's "SLICC" share row (#1918): ChatGPT-style instant handoff. The
+/// Safari's "Sliccy" share row (#1918): ChatGPT-style instant handoff. The
 /// panel appears just long enough to validate the URL, park it in the App
 /// Group inbox, and open the containing app through the responder chain's
 /// `UIApplication` — the pattern ChatGPT, Claude, Grok, and Bluesky
@@ -24,7 +24,7 @@ final class ShareViewController: UIViewController {
         statusLabel.font = .preferredFont(forTextStyle: .callout)
         statusLabel.textAlignment = .center
         statusLabel.numberOfLines = 0
-        statusLabel.text = "Opening SLICC…"
+        statusLabel.text = "Opening Sliccy…"
         statusLabel.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(statusLabel)
         NSLayoutConstraint.activate([
@@ -49,14 +49,14 @@ final class ShareViewController: UIViewController {
                 $0.hasItemConformingToTypeIdentifier(UTType.url.identifier)
             })
         else {
-            finish(message: "Nothing SLICC can open here.")
+            finish(message: "Nothing Sliccy can open here.")
             return
         }
         provider.loadItem(forTypeIdentifier: UTType.url.identifier) { [weak self] item, _ in
             DispatchQueue.main.async {
                 guard let self else { return }
                 guard let url = item as? URL, Self.isWebURL(url) else {
-                    self.finish(message: "Nothing SLICC can open here.")
+                    self.finish(message: "Nothing Sliccy can open here.")
                     return
                 }
                 self.handOff(url: url)
@@ -73,7 +73,7 @@ final class ShareViewController: UIViewController {
             let bounce = URL(string: "slicc://open?url=\(encoded)"),
             openViaResponderChain(bounce)
         else {
-            finish(message: "Sent to SLICC — open the app to continue.")
+            finish(message: "Sent to Sliccy — open the app to continue.")
             return
         }
         extensionContext?.completeRequest(returningItems: nil)


### PR DESCRIPTION
## Summary

Follow-up to #2080, which renamed the app to **Sliccy** but left the share panel calling it SLICC one screen later. Codex flagged it in review after the PR had already been added to the merge queue, and queued branches cannot be updated — so the fix lands here.

Four strings in `ShareViewController`:

| before | after |
| --- | --- |
| `"Opening SLICC…"` | `"Opening Sliccy…"` |
| `"Nothing SLICC can open here."` (×2) | `"Nothing Sliccy can open here."` |
| `"Sent to SLICC — open the app to continue."` | `"Sent to Sliccy — open the app to continue."` |

Plus the doc comment describing the row.

## Why

Tapping a share row labelled **Sliccy** and immediately reading "Opening SLICC…" is the exact inconsistency #2080 set out to remove — worse than before it, because now the two names sit one screen apart in a single flow.

## Scope

Deliberately the share extension only. The other user-visible `SLICC` strings mostly name the **system** or the **leader** rather than this app, and replacing them is a brand decision rather than a rename side effect:

| copy | names | left alone because |
| --- | --- | --- |
| `"Open in SLICC's Browser"`, `"Prompt SLICC"`, `"Get Current SLICC Conversation"` (App Intents, in Shortcuts) | the app | arguably should follow the brand — owner's call |
| `"SLICC is not connected to a leader."` | the app | same |
| `"Connected SLICC leader"` (approval card) | the leader machine | not this app |
| `"SLICC iOS follower on …"` (device motd) | this device as the leader sees it | not this app |

## Test plan

- [x] `xcodebuild build` clean
- [x] `swiftlint` 0 serious, `swift format lint --strict` clean
- [x] `check-touched-exemptions` OK (1 file, 0 on any debt list)
- [ ] No test asserts this copy; the strings are display-only in a share panel that needs a real share sheet to exercise. CI's iOS legs cover the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HprQQw9b14nfKRUcBTy66
