### PR TITLE
feat(ios-app): call the product Sliccy everywhere the user sees it

### DIFF
--- a/packages/ios-app/SliccFollower/App/AppState+OpenApproval.swift
+++ b/packages/ios-app/SliccFollower/App/AppState+OpenApproval.swift
@@ -8,7 +8,7 @@ extension AppState {
     func handleExecMessage(_ message: LeaderToFollowerMessage) {
         handleApprovalGatedExecMessage(
             message,
-            requesterIdentity: activeDisplayName ?? "Connected SLICC leader",
+            requesterIdentity: activeDisplayName ?? "Connected Sliccy leader",
             sessionIdentity: trayId ?? "Current tray")
     }
 

--- a/packages/ios-app/SliccFollower/App/InboundActions.swift
+++ b/packages/ios-app/SliccFollower/App/InboundActions.swift
@@ -278,8 +278,8 @@ enum InboundActionError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .invalidPrompt: return "The prompt is empty or too long."
-        case .busy: return "SLICC is already waiting on another automation request."
-        case .notConnected: return "SLICC is not connected to a leader."
+        case .busy: return "Sliccy is already waiting on another automation request."
+        case .notConnected: return "Sliccy is not connected to a leader."
         case .timedOut: return "Timed out waiting for the reply."
         case .cancelled: return "The request was dismissed."
         case .agent(let message): return message

--- a/packages/ios-app/SliccFollower/App/OpenInSliccIntents.swift
+++ b/packages/ios-app/SliccFollower/App/OpenInSliccIntents.swift
@@ -1,13 +1,13 @@
 import AppIntents
 
-/// "Open in SLICC's Browser" — the App-Review-safe share-sheet route
+/// "Open in Sliccy's Browser" — the App-Review-safe share-sheet route
 /// (#1918): a Shortcut carrying this intent appears in Safari's share
 /// sheet, receives the page URL, and foregrounds the app. The intent only
 /// enqueues into `InboundActionCoordinator`; the shell owns execution.
 struct OpenInSliccBrowserIntent: AppIntent {
-    static let title: LocalizedStringResource = "Open in SLICC's Browser"
+    static let title: LocalizedStringResource = "Open in Sliccy's Browser"
     static let description = IntentDescription(
-        "Opens a web page as a local tab in SLICC's browser.")
+        "Opens a web page as a local tab in Sliccy's browser.")
     static let openAppWhenRun = true
 
     @Parameter(title: "URL") var url: URL
@@ -29,19 +29,19 @@ enum InboundOpenError: Error, CustomLocalizedStringResourceConvertible {
     var localizedStringResource: LocalizedStringResource {
         switch self {
         case .invalidURL:
-            return "SLICC can only open http(s) web addresses without embedded credentials."
+            return "Sliccy can only open http(s) web addresses without embedded credentials."
         }
     }
 }
 
-/// "Prompt SLICC" — sends a prompt to the connected leader and returns the
+/// "Prompt Sliccy" — sends a prompt to the connected leader and returns the
 /// completed reply as an intent value, so it can feed the next Shortcut
 /// action (#1918). Invoking the intent is the explicit user action; the
 /// shell executes without a second card and the intent awaits settlement.
 struct PromptSliccIntent: AppIntent {
-    static let title: LocalizedStringResource = "Prompt SLICC"
+    static let title: LocalizedStringResource = "Prompt Sliccy"
     static let description = IntentDescription(
-        "Sends a prompt to the connected SLICC leader and returns the completed reply.")
+        "Sends a prompt to the connected Sliccy leader and returns the completed reply.")
     static let openAppWhenRun = true
 
     @Parameter(title: "Prompt") var prompt: String
@@ -53,13 +53,13 @@ struct PromptSliccIntent: AppIntent {
     }
 }
 
-/// "Get Current SLICC Conversation" — returns the selected conversation as
+/// "Get Current Sliccy Conversation" — returns the selected conversation as
 /// a bounded Markdown file after a fresh leader snapshot (#1918). Exports
 /// exactly what the phone renders on screen; nothing is logged.
 struct GetSliccConversationIntent: AppIntent {
-    static let title: LocalizedStringResource = "Get Current SLICC Conversation"
+    static let title: LocalizedStringResource = "Get Current Sliccy Conversation"
     static let description = IntentDescription(
-        "Returns the currently selected SLICC conversation as a Markdown file.")
+        "Returns the currently selected Sliccy conversation as a Markdown file.")
     static let openAppWhenRun = true
 
     @MainActor

--- a/packages/ios-app/SliccFollower/App/SliccFollowerApp.swift
+++ b/packages/ios-app/SliccFollower/App/SliccFollowerApp.swift
@@ -30,7 +30,7 @@ struct SliccFollowerApp: App {
         .onChange(of: scenePhase) { _, phase in
             // The Share extension cannot foreground the app; whatever it
             // parked in the App Group inbox surfaces as confirmation
-            // cards the next time the user opens SLICC (#1918).
+            // cards the next time the user opens Sliccy (#1918).
             if phase == .active {
                 inboundActions.drainShareInbox()
             }

--- a/packages/ios-app/SliccFollower/App/UITestHooks.swift
+++ b/packages/ios-app/SliccFollower/App/UITestHooks.swift
@@ -293,7 +293,7 @@ import UIKit
             return [
                 TrayTargetEntry(
                     targetId: "leader:tab-docs", localTargetId: "tab-docs",
-                    runtimeId: "leader", title: "SLICC docs — architecture",
+                    runtimeId: "leader", title: "Sliccy docs — architecture",
                     url: "https://www.sliccy.ai/docs/architecture", isLocal: false),
                 TrayTargetEntry(
                     targetId: "cli:tab-ci", localTargetId: "tab-ci",

--- a/packages/ios-app/SliccFollower/Models/TrayFollowerDeviceMetadata.swift
+++ b/packages/ios-app/SliccFollower/Models/TrayFollowerDeviceMetadata.swift
@@ -6,5 +6,5 @@ import UIKit
 /// the `motd` the Go CLI sets. Identifies the phone among several followers.
 var trayFollowerMotd: String {
     let device = UIDevice.current
-    return "SLICC iOS follower on \(device.name) (\(device.systemName) \(device.systemVersion)) — only supported command: open"
+    return "Sliccy iOS follower on \(device.name) (\(device.systemName) \(device.systemVersion)) — only supported command: open"
 }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/ChatPresentationStateTests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/ChatPresentationStateTests.swift
@@ -125,7 +125,7 @@ final class ChatPresentationStateTests: XCTestCase {
         // model rather than one of its own. Without this the rest of the test
         // would just be re-checking that a memoized getter memoizes.
         let started = await settle(until: {
-            terminal.accessibilityTranscript.contains("SLICC leader terminal")
+            terminal.accessibilityTranscript.contains("Sliccy leader terminal")
         })
         XCTAssertTrue(started, "the mounted TerminalView never started the shell's model")
 

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/ConnectionStateUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/ConnectionStateUITests.swift
@@ -19,7 +19,7 @@ final class ConnectionStateUITests: XCTestCase {
 
         let avatar = avatar(
             in: app,
-            labeled: "SLICC: unknown, context fill unknown. The leader is busy — hang on…")
+            labeled: "Sliccy: unknown, context fill unknown. The leader is busy — hang on…")
         XCTAssertTrue(avatar.waitForExistence(timeout: 60), "A stall should remain in the avatar")
         XCTAssertFalse(
             avatar.label.contains("Disconnected"),
@@ -45,7 +45,7 @@ final class ConnectionStateUITests: XCTestCase {
 
         let avatar = avatar(
             in: app,
-            labeled: "SLICC: unknown, context fill unknown. Reconnecting… (3/10)")
+            labeled: "Sliccy: unknown, context fill unknown. Reconnecting… (3/10)")
         XCTAssertTrue(avatar.waitForExistence(timeout: 60))
         XCTAssertEqual(app.staticTexts["composer-placeholder"].label, "Disconnected")
     }

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/InboundActionsUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/InboundActionsUITests.swift
@@ -22,7 +22,7 @@ final class InboundActionsUITests: XCTestCase {
     func testDeepLinkedOpenConfirmsBeforeOpening() {
         let app = launch()
 
-        let alert = app.alerts["Open in SLICC's browser?"]
+        let alert = app.alerts["Open in Sliccy's browser?"]
         XCTAssertTrue(alert.waitForExistence(timeout: 60), "the system alert renders")
         XCTAssertTrue(
             alert.staticTexts["https://example.com/docs"].exists,
@@ -40,11 +40,11 @@ final class InboundActionsUITests: XCTestCase {
     func testDismissDropsTheRequest() {
         let app = launch()
 
-        let alert = app.alerts["Open in SLICC's browser?"]
+        let alert = app.alerts["Open in Sliccy's browser?"]
         XCTAssertTrue(alert.waitForExistence(timeout: 60))
         alert.buttons["Cancel"].tap()
         XCTAssertFalse(
-            app.alerts["Open in SLICC's browser?"].exists,
+            app.alerts["Open in Sliccy's browser?"].exists,
             "cancel drops the request")
         XCTAssertTrue(
             app.buttons["dock-browser"].exists,

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/RemoteTabUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/RemoteTabUITests.swift
@@ -19,7 +19,7 @@ final class RemoteTabUITests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(
-            app.staticTexts["SLICC docs — architecture"].waitForExistence(timeout: 60),
+            app.staticTexts["Sliccy docs — architecture"].waitForExistence(timeout: 60),
             "remote registry entries render as cards")
         XCTAssertTrue(
             app.images["remote-preview-leader:tab-docs"].waitForExistence(timeout: 10),
@@ -40,7 +40,7 @@ final class RemoteTabUITests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(
-            app.staticTexts["SLICC docs — architecture"].waitForExistence(timeout: 60),
+            app.staticTexts["Sliccy docs — architecture"].waitForExistence(timeout: 60),
             "the remote-only overview renders before any local tab exists")
 
         let openNewTab = app.buttons["browser-open-new-tab"].firstMatch
@@ -77,7 +77,7 @@ final class RemoteTabUITests: XCTestCase {
             app.staticTexts["browser-local-tab-title"].firstMatch.waitForExistence(timeout: 10),
             "the overview lists the local tab as a card")
         XCTAssertTrue(
-            app.staticTexts["SLICC docs — architecture"].waitForExistence(timeout: 10),
+            app.staticTexts["Sliccy docs — architecture"].waitForExistence(timeout: 10),
             "remote previews share the overview grid with local tabs")
         XCTAssertTrue(
             app.buttons["dock-browser"].waitForExistence(timeout: 10),
@@ -96,7 +96,7 @@ final class RemoteTabUITests: XCTestCase {
         ]
         app.launch()
 
-        let card = app.staticTexts["SLICC docs — architecture"].firstMatch
+        let card = app.staticTexts["Sliccy docs — architecture"].firstMatch
         XCTAssertTrue(card.waitForExistence(timeout: 60), "the overview lists the remote card")
         card.tap()
 
@@ -124,7 +124,7 @@ final class RemoteTabUITests: XCTestCase {
         guard UIDevice.current.userInterfaceIdiom == .pad, window.frame.width > 560 else {
             throw XCTSkip("Requires a regular-width iPad simulator destination")
         }
-        let remoteCard = app.staticTexts["SLICC docs — architecture"].firstMatch
+        let remoteCard = app.staticTexts["Sliccy docs — architecture"].firstMatch
         XCTAssertTrue(remoteCard.waitForExistence(timeout: 60))
         XCTAssertTrue(app.buttons["settings-button"].exists, "the split starts with chat visible")
         XCTAssertTrue(app.buttons["dock-browser"].exists, "the split starts with its rail visible")

--- a/packages/ios-app/SliccFollower/Views/ChatFixture.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatFixture.swift
@@ -97,11 +97,11 @@ enum ChatFixture {
                     ```shtml
                     <div class="sprinkle-action-card">
                       <div class="sprinkle-action-card__header">
-                        SLICC upgraded
+                        Sliccy upgraded
                         <span class="sprinkle-badge sprinkle-badge--notice">2.29.0 → 2.29.1</span>
                       </div>
                       <div class="sprinkle-action-card__body">
-                        <p>SLICC was upgraded. You can review what changed and optionally pull the new bundled workspace files into your VFS.</p>
+                        <p>Sliccy was upgraded. You can review what changed and optionally pull the new bundled workspace files into your VFS.</p>
                       </div>
                       <div class="sprinkle-action-card__actions">
                         <button class="sprinkle-btn sprinkle-btn--secondary" onclick="slicc.lick({action:'dismiss'})">Dismiss</button>

--- a/packages/ios-app/SliccFollower/Views/ChatView.swift
+++ b/packages/ios-app/SliccFollower/Views/ChatView.swift
@@ -32,7 +32,7 @@ struct ChatView: View {
     /// Opt-in unattended prompts: the user made this policy call
     /// explicitly by choosing Always on the prompt card.
     @AppStorage("inboundAlwaysAllowPrompts") private var alwaysAllowPrompts = false
-    /// Transcript links stay in SLICC's own browser by default — a tap on a
+    /// Transcript links stay in Sliccy's own browser by default — a tap on a
     /// link the agent sent should not evict the user from the session.
     /// Settings → Advanced hands them back to the system browser.
     @AppStorage("openLinksInBuiltInBrowser") private var openLinksInBuiltInBrowser = true
@@ -141,7 +141,7 @@ struct ChatView: View {
             inboundPhaseChip
         }
         .alert(
-            "Open in SLICC's browser?",
+            "Open in Sliccy's browser?",
             isPresented: inboundOpenAlertPresented,
             presenting: inboundActions.pendingOpen
         ) { action in
@@ -157,7 +157,7 @@ struct ChatView: View {
             Text(action.url.absoluteString)
         }
         .alert(
-            "Send this prompt to SLICC?",
+            "Send this prompt to Sliccy?",
             isPresented: inboundPromptAlertPresented,
             presenting: inboundActions.pendingPrompt
         ) { action in
@@ -299,11 +299,11 @@ struct ChatView: View {
             let scoopJid = appState.selectedScoopJid
         else {
             fireCallback(
-                action.xError, params: ["errorMessage": "SLICC is not connected to a leader"])
+                action.xError, params: ["errorMessage": "Sliccy is not connected to a leader"])
             inboundActions.resolve(id: action.id, with: .failure(InboundActionError.notConnected))
             return
         }
-        inboundActions.phase = .running("Waiting for SLICC's reply…")
+        inboundActions.phase = .running("Waiting for Sliccy's reply…")
         let timeoutToken = appState.inboundPrompt.arm(scoopJid: scoopJid) { outcome in
             switch outcome {
             case .reply(let text):
@@ -340,7 +340,7 @@ struct ChatView: View {
         ) {
             inboundActions.phase = nil
             let markdown = Self.transcriptMarkdown(
-                label: appState.selectedScoop?.assistantLabel ?? "SLICC",
+                label: appState.selectedScoop?.assistantLabel ?? "Sliccy",
                 messages: appState.messages)
             inboundActions.resolve(id: request.id, with: .success(markdown))
         }
@@ -383,7 +383,7 @@ struct ChatView: View {
     /// renders, nothing more. Truncated head-first when over budget so the
     /// newest turns survive.
     static func transcriptMarkdown(label: String, messages: [ChatMessage]) -> String {
-        var sections: [String] = ["# SLICC — \(label)"]
+        var sections: [String] = ["# Sliccy — \(label)"]
         for message in messages {
             let heading = message.role == .user ? "## You" : "## \(label)"
             var body = message.content
@@ -843,7 +843,7 @@ struct ConversationView: View {
     private var selectedAccessibilityLabel: String {
         let lifecycleLabel =
             (appState.selectedScoop?.status ?? ScoopStatus(state: nil, fill: nil))
-            .accessibilityPhrase(label: appState.selectedScoop?.assistantLabel ?? "SLICC")
+            .accessibilityPhrase(label: appState.selectedScoop?.assistantLabel ?? "Sliccy")
         guard let connectionStatusText else { return lifecycleLabel }
         return "\(lifecycleLabel). \(connectionStatusText)"
     }
@@ -1098,12 +1098,12 @@ struct ScoopSwitcher: View {
             } label: {
                 identityLabel
             }
-            .accessibilityLabel(appState.selectedScoop?.assistantLabel ?? "SLICC")
+            .accessibilityLabel(appState.selectedScoop?.assistantLabel ?? "Sliccy")
             .accessibilityHint("Switch scoop")
             .accessibilityIdentifier("scoop-switcher")
         } else {
             identityLabel
-                .accessibilityLabel(appState.selectedScoop?.assistantLabel ?? "SLICC")
+                .accessibilityLabel(appState.selectedScoop?.assistantLabel ?? "Sliccy")
                 .accessibilityIdentifier("scoop-switcher")
         }
     }
@@ -1114,7 +1114,7 @@ struct ScoopSwitcher: View {
     /// Leader-active is spoken in the menu rows, not as a dot here.
     private var identityLabel: some View {
         HStack(spacing: 5) {
-            Text(appState.selectedScoop?.assistantLabel ?? "SLICC")
+            Text(appState.selectedScoop?.assistantLabel ?? "Sliccy")
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(palette.ink)
                 .lineLimit(1)

--- a/packages/ios-app/SliccFollower/Views/PttOverlayView.swift
+++ b/packages/ios-app/SliccFollower/Views/PttOverlayView.swift
@@ -48,7 +48,7 @@ struct PttOverlayView: View {
                     .foregroundStyle(palette.ink)
                 Text(
                     message
-                        ?? "Enable the microphone and speech recognition for SLICC in Settings, then hold again."
+                        ?? "Enable the microphone and speech recognition for Sliccy in Settings, then hold again."
                 )
                 .font(.caption2)
                 .foregroundStyle(palette.inkSecondary)

--- a/packages/ios-app/SliccFollower/Views/SettingsView.swift
+++ b/packages/ios-app/SliccFollower/Views/SettingsView.swift
@@ -195,7 +195,7 @@ struct SettingsView: View {
             let unreachable = reachability.verdicts[session.id] == .unreachable
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(session.label.isEmpty ? "SLICC session" : session.label)
+                    Text(session.label.isEmpty ? "Sliccy session" : session.label)
                         .foregroundStyle(.primary)
                     Text(
                         "\(deviceName) · \(ICloudSessionList.age(of: session.lastSeenAt, now: now))"
@@ -272,7 +272,7 @@ struct SettingsView: View {
         } header: {
             Text("Connection")
         } footer: {
-            Text("Connect to a SLICC session with its Join URL.")
+            Text("Connect to a Sliccy session with its Join URL.")
         }
     }
 
@@ -344,14 +344,14 @@ struct SettingsView: View {
     /// Mirrors the webapp's "How do I get the sync URL?" disclosure
     /// (provider-settings.ts → renderJoinTrayForm). New users repeatedly
     /// hit the empty Join URL field with no idea where to find one;
-    /// inline guidance points them at the desktop SLICC's avatar menu
+    /// inline guidance points them at the desktop Sliccy's avatar menu
     /// or the agent prompt that returns a tray URL.
     private var joinUrlHelpDisclosure: some View {
         DisclosureGroup {
             VStack(alignment: .leading, spacing: 10) {
                 joinUrlStep(
                     number: 1,
-                    text: "Open SLICC on your computer (Sliccstart, the Chrome extension, or the standalone CLI)."
+                    text: "Open Sliccy on your computer (Sliccstart, the Chrome extension, or the standalone CLI)."
                 )
                 joinUrlStep(
                     number: 2,
@@ -363,7 +363,7 @@ struct SettingsView: View {
                 )
                 joinUrlStep(
                     number: 4,
-                    text: "Paste the URL into the **Join URL** field above. Both sides must be on the same SLICC version."
+                    text: "Paste the URL into the **Join URL** field above. Both sides must be on the same Sliccy version."
                 )
             }
             .padding(.vertical, 4)
@@ -468,7 +468,7 @@ struct SettingsView: View {
             // reachability is a hand-dominance question, not a layout one.
             Toggle("Left-handed dock", isOn: $leftHandedDock)
 
-            Toggle("Open links in SLICC", isOn: $openLinksInBuiltInBrowser)
+            Toggle("Open links in Sliccy", isOn: $openLinksInBuiltInBrowser)
                 .accessibilityIdentifier("open-links-in-app-toggle")
 
             if !appState.joinUrlHistory.isEmpty {
@@ -494,7 +494,7 @@ struct SettingsView: View {
             Text("Advanced")
         } footer: {
             Text(
-                "Links in the conversation open as tabs in SLICC's browser. "
+                "Links in the conversation open as tabs in Sliccy's browser. "
                     + "Turn that off to hand them to your default browser instead.")
         }
     }

--- a/packages/ios-app/SliccFollower/Views/TerminalViewModel.swift
+++ b/packages/ios-app/SliccFollower/Views/TerminalViewModel.swift
@@ -85,7 +85,7 @@ final class TerminalViewModel: ObservableObject {
         }
         guard !Task.isCancelled, !didStart else { return }
         didStart = true
-        emit(Data("SLICC leader terminal\r\n\(Self.prompt)".utf8))
+        emit(Data("Sliccy leader terminal\r\n\(Self.prompt)".utf8))
     }
 
     func setConnectionAvailable(_ available: Bool) {

--- a/packages/ios-app/SliccShareExtension/ShareViewController.swift
+++ b/packages/ios-app/SliccShareExtension/ShareViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import UniformTypeIdentifiers
 
-/// Safari's "SLICC" share row (#1918): ChatGPT-style instant handoff. The
+/// Safari's "Sliccy" share row (#1918): ChatGPT-style instant handoff. The
 /// panel appears just long enough to validate the URL, park it in the App
 /// Group inbox, and open the containing app through the responder chain's
 /// `UIApplication` — the pattern ChatGPT, Claude, Grok, and Bluesky
@@ -24,7 +24,7 @@ final class ShareViewController: UIViewController {
         statusLabel.font = .preferredFont(forTextStyle: .callout)
         statusLabel.textAlignment = .center
         statusLabel.numberOfLines = 0
-        statusLabel.text = "Opening SLICC…"
+        statusLabel.text = "Opening Sliccy…"
         statusLabel.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(statusLabel)
         NSLayoutConstraint.activate([
@@ -49,14 +49,14 @@ final class ShareViewController: UIViewController {
                 $0.hasItemConformingToTypeIdentifier(UTType.url.identifier)
             })
         else {
-            finish(message: "Nothing SLICC can open here.")
+            finish(message: "Nothing Sliccy can open here.")
             return
         }
         provider.loadItem(forTypeIdentifier: UTType.url.identifier) { [weak self] item, _ in
             DispatchQueue.main.async {
                 guard let self else { return }
                 guard let url = item as? URL, Self.isWebURL(url) else {
-                    self.finish(message: "Nothing SLICC can open here.")
+                    self.finish(message: "Nothing Sliccy can open here.")
                     return
                 }
                 self.handOff(url: url)
@@ -73,7 +73,7 @@ final class ShareViewController: UIViewController {
             let bounce = URL(string: "slicc://open?url=\(encoded)"),
             openViaResponderChain(bounce)
         else {
-            finish(message: "Sent to SLICC — open the app to continue.")
+            finish(message: "Sent to Sliccy — open the app to continue.")
             return
         }
         extensionContext?.completeRequest(returningItems: nil)


### PR DESCRIPTION
## Summary

#2080 renamed the app's label, #2082 the share panel. Everywhere else still called the product **SLICC**, so the app introduced itself one way on the home screen and another in every sentence it wrote. This finishes it.

**Stacked on #2082** — merge that first, or this PR carries its one-file diff along harmlessly.

| surface | before | after |
| --- | --- | --- |
| Shortcuts actions | "Open in SLICC's Browser", "Prompt SLICC", "Get Current SLICC Conversation" | …Sliccy… |
| Open confirmation alert | "Open in SLICC's browser?" | "Open in Sliccy's browser?" |
| Prompt confirmation alert | "Send this prompt to SLICC?" | "Send this prompt to Sliccy?" |
| Inbound automation errors | "SLICC is not connected to a leader." | "Sliccy is …" |
| Inbound phase chip | "Waiting for SLICC's reply…" | "Waiting for Sliccy's reply…" |
| Settings | session rows, join hint, pairing walkthrough, "Open links in SLICC" + footnote | …Sliccy… |
| Terminal banner | "SLICC leader terminal" | "Sliccy leader terminal" |
| Microphone prompt | "…speech recognition for SLICC in Settings…" | "…for Sliccy…" |
| Approval card | "Connected SLICC leader" | "Connected Sliccy leader" |
| Avatar fallback label | "SLICC" | "Sliccy" |
| Transcript export header | `# SLICC — <label>` | `# Sliccy — <label>` |
| Device motd (what the leader sees) | "SLICC iOS follower on …" | "Sliccy iOS follower on …" |
| Fixture copy rendered in screenshots | "SLICC upgraded", "SLICC docs — architecture" | …Sliccy… |

## Deliberately NOT renamed

This is not a find-and-replace: the same token is configuration, an API name, and protocol vocabulary.

| left alone | why |
| --- | --- |
| `SLICC_KOKORO_MODELS_DIR` (constant **and** the Settings line that prints it) | an environment variable; renaming breaks configuration, and Settings shows it verbatim so it can be typed |
| `SLICC_HOSTED_ORIGIN` reference in the fixture | shared constant, must match `packages/shared-ts` |
| the `SLICC-bridge` JS alias | an API name sprinkles call |
| handoff/upskill vocabulary in developer comments | names the **wire protocol** shared with the leader, not this app |
| the note in `FileProviderDomainLifecycle` that an old install still reads "SLICC" | that sentence is *about* the old name and stays accurate |

If the protocol vocabulary should also become Sliccy, that is a cross-runtime rename touching `shared-ts` and the leader, and belongs in its own change.

## Test plan

- [x] `SliccFollowerTests` 539/539
- [x] UI tests that assert the changed copy, all updated and passing: `ConnectionStateUITests` (avatar a11y phrase), `InboundActionsUITests` (alert title), `ChatPresentationStateTests` (terminal banner), `RemoteTabUITests` (fixture tab title)
- [x] `swiftlint` 0 serious, `swift format lint --strict` clean
- [x] `npm run verify` 7/7, `check-touched-exemptions` OK (16 files, 0 on any debt list)
- [ ] `npm run test` / `build` — no TypeScript here; CI covers both

The `ios-screenshots` sticky comment is a real check on this one: Settings, the pairing walkthrough and the fixture screens all re-render with the new copy.

## Risk & rollback

- Blast radius: strings in one app. Clean revert; no identifiers, no persisted state, no protocol.
- The motd is the only string that leaves the device — it is display text in the leader's device list, not something the leader parses.
- Still outside the repo: TestFlight and the App Store listing take their name from App Store Connect, not from anything here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HprQQw9b14nfKRUcBTy66
