### PR TITLE
fix(shell): await .jsh registration before the first command

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -13,7 +13,6 @@
   "packages/webapp/src/scoops/lick-ws-bridge.ts": 1,
   "packages/webapp/src/scoops/sprinkle-bridge-channel.ts": 2,
   "packages/webapp/src/scoops/sprinkle-manager-proxy.ts": 1,
-  "packages/webapp/src/shell/almost-bash-shell-headless.ts": 1,
   "packages/webapp/src/shell/bsh-watchdog.ts": 3,
   "packages/webapp/src/shell/mcp/redirect-uri.ts": 1,
   "packages/webapp/src/shell/proxied-fetch.ts": 2,

--- a/packages/webapp/src/shell/almost-bash-shell-headless.ts
+++ b/packages/webapp/src/shell/almost-bash-shell-headless.ts
@@ -31,7 +31,15 @@
 
 import type { BashExecResult, Command, CommandContext, CommandName, ExecResult } from 'just-bash';
 import { Bash, defineCommand, getCommandNames, getNetworkCommandNames } from 'just-bash';
-import type { BrowserAPI } from '../cdp/index.js';
+// The shell only FORWARDS a BrowserAPI (to the supplemental commands and
+// upskill); it never calls one. Sourcing the type from the sibling that owns
+// that dependency keeps this file off the layer-back-edge list — importing it
+// from ../cdp/ would be an up-the-stack edge for a type this layer does not
+// actually use.
+import type { SupplementalCommandsConfig } from './supplemental-commands/index.js';
+
+type BrowserAPI = NonNullable<SupplementalCommandsConfig['browserAPI']>;
+
 import type { FsWatcher, VirtualFS } from '../fs/index.js';
 import { MountCommands } from '../fs/mount-commands.js';
 import { FsError } from '../fs/types.js';
@@ -230,6 +238,11 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
    */
   protected readonly allowedCommands: ReadonlySet<string> | null;
   protected readonly scriptCatalog: ScriptCatalog;
+  /**
+   * The constructor's initial `.jsh` registration, awaited once by the first
+   * command and then released. `null` after that (or when never started).
+   */
+  private initialJshSync: Promise<void> | null = null;
   protected readonly ownsScriptCatalog: boolean;
   /** Maps .jsh command names to their registered script paths. */
   protected registeredJshCommands = new Map<string, string>();
@@ -467,8 +480,8 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
     this.lastEnv = { ...initialEnv };
     this.cwd = initialCwd;
 
-    // Kick off initial .jsh registration (async, non-blocking).
-    void this.syncJshCommands().catch(() => undefined);
+    // Retained so the FIRST command can await it — see `runCommand`.
+    this.initialJshSync = this.syncJshCommands().catch(() => undefined);
   }
 
   // -------------------------------------------------------------------------
@@ -601,6 +614,28 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
   protected async runCommand(command: string, signal?: AbortSignal): Promise<BashExecResult> {
     const commandName = command.trim().split(/\s+/)[0] || 'unknown';
     emitShellCommand(commandName);
+
+    // Wait for the constructor's `.jsh` registration before the first command.
+    //
+    // WHY THIS IS NOT COVERED BY `tryJshFallback`. That fallback fires on
+    // `result.exitCode === 127`, which only surfaces when the WHOLE command is
+    // one unknown name. In a pipeline or a `;`-separated list the unknown
+    // command fails with 127 *inside* bash while the compound reports its last
+    // command's status — so the miss is invisible and the fallback never runs.
+    // `signal watches` therefore worked on a cold shell while
+    // `signal watches; echo done` did not.
+    //
+    // A long-lived shell (the agent's, the panel terminal's) finished
+    // registering long ago and never notices. A shell built per use does: the
+    // tray's `slicc … exec` constructs a fresh one for every follower
+    // connection, so EVERY compound command raced the scan and lost.
+    //
+    // Awaited once, then cleared — subsequent commands pay nothing.
+    if (this.initialJshSync !== null) {
+      const pending = this.initialJshSync;
+      this.initialJshSync = null;
+      await pending;
+    }
 
     // just-bash's published ExecOptions type does not yet expose
     // AbortSignal, but we still forward it so external callers and

--- a/packages/webapp/src/shell/almost-bash-shell-headless.ts
+++ b/packages/webapp/src/shell/almost-bash-shell-headless.ts
@@ -480,8 +480,7 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
     this.lastEnv = { ...initialEnv };
     this.cwd = initialCwd;
 
-    // Retained so the FIRST command can await it — see `runCommand`.
-    this.initialJshSync = this.syncJshCommands().catch(() => undefined);
+    this.startInitialJshSync();
   }
 
   // -------------------------------------------------------------------------
@@ -611,6 +610,53 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
    * Subclasses (the view layer) call this from
    * `executeCommandInTerminal` to share state.
    */
+  /**
+   * Wait for the constructor's `.jsh` registration, but never past an abort.
+   *
+   * Resolves on whichever comes first: the scan finishing, or `signal`
+   * aborting. An abort only stops US waiting — the registration promise keeps
+   * running, so the command after the cancelled one still finds a populated
+   * table. Without this, Ctrl+C during the first command of a fresh shell is
+   * swallowed for however long a full-VFS walk takes.
+   */
+  /**
+   * Begin the constructor's `.jsh` registration and retain it for the first
+   * command to await (see `runCommand`). The promise clears itself on settle
+   * rather than at the await site: a first command that ABORTS mid-wait must
+   * not leave the next one racing the scan again.
+   */
+  private startInitialJshSync(): void {
+    this.initialJshSync = this.syncJshCommands()
+      .catch(() => undefined)
+      .finally(() => {
+        this.initialJshSync = null;
+      });
+  }
+
+  private async waitForInitialJshSync(signal?: AbortSignal): Promise<void> {
+    const pending = this.initialJshSync;
+    if (pending === null) return;
+    if (!signal) {
+      await pending;
+      return;
+    }
+    if (signal.aborted) return;
+
+    let onAbort: (() => void) | undefined;
+    try {
+      await new Promise<void>((resolve) => {
+        onAbort = () => resolve();
+        signal.addEventListener('abort', onAbort, { once: true });
+        pending.then(
+          () => resolve(),
+          () => resolve()
+        );
+      });
+    } finally {
+      if (onAbort) signal.removeEventListener('abort', onAbort);
+    }
+  }
+
   protected async runCommand(command: string, signal?: AbortSignal): Promise<BashExecResult> {
     const commandName = command.trim().split(/\s+/)[0] || 'unknown';
     emitShellCommand(commandName);
@@ -630,12 +676,12 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
     // tray's `slicc … exec` constructs a fresh one for every follower
     // connection, so EVERY compound command raced the scan and lost.
     //
-    // Awaited once, then cleared — subsequent commands pay nothing.
-    if (this.initialJshSync !== null) {
-      const pending = this.initialJshSync;
-      this.initialJshSync = null;
-      await pending;
-    }
+    // Awaited once — the promise clears itself when it settles, so subsequent
+    // commands pay nothing. Abortable: the scan walks `/` and takes seconds on
+    // a populated instance, and a Ctrl+C that only lands after it finishes is
+    // not a Ctrl+C. On abort we stop WAITING but let the registration run on in
+    // the background, so the next command still benefits.
+    await this.waitForInitialJshSync(signal);
 
     // just-bash's published ExecOptions type does not yet expose
     // AbortSignal, but we still forward it so external callers and

--- a/packages/webapp/tests/shell/almost-bash-shell.test.ts
+++ b/packages/webapp/tests/shell/almost-bash-shell.test.ts
@@ -376,6 +376,40 @@ describe('AlmostBashShell .jsh command registration', () => {
     expect(piped.stdout).toContain('hello from jsh');
   });
 
+  // A shell that has NOT been warmed by an explicit `syncJshCommands()` — i.e.
+  // every shell the tray's `slicc … exec` builds, one per follower connection.
+  //
+  // The bare form always worked: an unknown single command exits 127 and
+  // `tryJshFallback` catches it. A compound does NOT — the unknown name fails
+  // with 127 *inside* bash while the compound reports its last command's
+  // status, so the fallback never sees a miss. Every compound sent over the
+  // tray therefore raced the constructor's async registration and lost.
+  it('resolves .jsh in a compound command on a cold shell (no explicit sync)', async () => {
+    await fs.writeFile('/workspace/skills/test-cmd/scripts/cold.jsh', 'console.log("cold ok");');
+
+    const shell = new AlmostBashShell({ fs });
+    // Deliberately NO `await shell.syncJshCommands()` — that is the warm path
+    // the other tests exercise, and it is what hid this bug.
+    const compound = await shell.executeCommand('cold; echo done');
+    expect(compound.stdout).toContain('cold ok');
+    expect(compound.stdout).toContain('done');
+
+    const piped = await shell.executeCommand('cold | cat');
+    expect(piped.exitCode).toBe(0);
+    expect(piped.stdout).toContain('cold ok');
+  });
+
+  // The bare case must keep working too — it went through `tryJshFallback`
+  // before and now resolves as a registered command; either way, exit 0.
+  it('still resolves a bare .jsh command on a cold shell', async () => {
+    await fs.writeFile('/workspace/skills/test-cmd/scripts/bare.jsh', 'console.log("bare ok");');
+
+    const shell = new AlmostBashShell({ fs });
+    const result = await shell.executeCommand('bare');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('bare ok');
+  });
+
   it('makes .jsh commands visible via which and /usr/bin', async () => {
     await fs.writeFile('/workspace/skills/test-cmd/scripts/mycmd.jsh', 'console.log("ok");');
 

--- a/packages/webapp/tests/shell/almost-bash-shell.test.ts
+++ b/packages/webapp/tests/shell/almost-bash-shell.test.ts
@@ -410,6 +410,34 @@ describe('AlmostBashShell .jsh command registration', () => {
     expect(result.stdout).toContain('bare ok');
   });
 
+  // Review catch on #2084: waiting for the initial scan must not swallow a
+  // Ctrl+C. The scan walks all of `/` and takes seconds on a populated
+  // instance, so an unconditional await makes cancellation dead for that long
+  // in every freshly-built shell — the panel's and the tray's.
+  //
+  // The discovery FS here NEVER finishes walking, so the abort is the only
+  // thing that can end the wait: if the await were unconditional this test
+  // would hang rather than fail.
+  it('aborting the first command does not wait out the initial .jsh scan', async () => {
+    const neverFinishes = {
+      exists: async () => true,
+      async *walk(): AsyncGenerator<string> {
+        await new Promise<never>(() => {}); // never settles, never yields
+      },
+      readFile: async () => '',
+    } as unknown as ConstructorParameters<typeof AlmostBashShell>[0]['jshDiscoveryFs'];
+
+    const shell = new AlmostBashShell({ fs, jshDiscoveryFs: neverFinishes });
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await Promise.race([
+      shell.executeCommand('echo hi', controller.signal).then(() => 'returned'),
+      new Promise((resolve) => setTimeout(() => resolve('HUNG'), 3000)),
+    ]);
+    expect(result).toBe('returned');
+  });
+
   it('makes .jsh commands visible via which and /usr/bin', async () => {
     await fs.writeFile('/workspace/skills/test-cmd/scripts/mycmd.jsh', 'console.log("ok");');
 


### PR DESCRIPTION
## Summary

`slicc … exec` over the tray could not run **any** skill command — `signal`, `bluebubbles` and `slack` all reported `command not found`, while the same commands worked fine for the agent. It presented as a WebRTC transport bug. It is not: WebRTC is innocent, and so is the tray. The shell was dispatching before its `.jsh` command table finished loading.

## Why

`AlmostBashShellHeadless`'s constructor kicked off registration fire-and-forget:

```ts
// Kick off initial .jsh registration (async, non-blocking).
void this.syncJshCommands().catch(() => undefined);
```

and `leader-exec-runner.ts` builds a **fresh shell per follower connection** — so every `slicc exec` got a cold one and dispatched immediately. A long-lived shell (the agent's, the panel terminal's) finished registering long ago and never notices, which is why the cone runs `bluebubbles send` happily.

**The existing 127 fallback does not cover it.** `tryJshFallback` fires on `result.exitCode === 127`, which only surfaces when the WHOLE command is one unknown name. In a pipeline or a `;`-separated list the unknown command fails with 127 *inside* bash while the compound reports its **last** command's status — so the miss is invisible and the fallback never runs.

Measured against a live leader over the tray:

| command | shape | result |
| --- | --- | --- |
| `signal watches` | bare | ✅ works (fallback catches it) |
| `signal watches; echo done` | compound | ❌ `command not found` |
| `signal help \| head` | pipeline | ❌ `command not found` |
| `sleep 6; signal watches` | compound | ✅ works — the scan won the race |
| `which signal; signal help` | compound | ✅ works — `which` warmed the catalog first |

That fourth row is the whole bug in one command: six seconds of doing nothing is the entire difference.

It also explains an earlier red herring — `which signal` printing a path while `signal` would not run. `which` awaits the catalog directly (`which-command.ts:96`), dispatch reads the pre-registered map. Two sources of truth, one warm and one cold.

## Approach / Implementation notes

Retain the constructor's sync promise and await it **once**, on the first command:

```ts
if (this.initialJshSync !== null) {
  const pending = this.initialJshSync;
  this.initialJshSync = null;   // subsequent commands pay nothing
  await pending;
}
```

- **Await-once, not per-command**: the field is cleared before awaiting, so command #2 onward is unchanged.
- **Failures do not wedge it**: the retained promise already carries `.catch(() => undefined)`, so a failed scan still releases the first command.
- **Not "re-sync on a dispatch miss"** — the obvious fix, and it does not work here. At shell level there IS no miss to react to: the compound's exit code is its last command's, so nothing signals that `signal` was unknown.

**Cost**: first-command latency. `discoverJshCommands` scans its priority roots and then walks **all of `/`** (`jsh-discovery.ts:38`) — on a real instance that means `node_modules`, `/sessions`, screenshot piles. Seconds. That scan is the actual problem and is filed separately (a real `PATH`, so discovery stops meaning "walk the whole VFS and hope"); this change stops it being a *correctness* bug in the meantime.

## Cross-cutting impact

- **Every shell gains the await**, not just the tray's — the agent's and the panel terminal's included. They already registered before their first command in practice, so the observable change is confined to cold shells.
- **Bare commands keep working** exactly as before (via `tryJshFallback`); they now typically resolve as registered commands instead, same exit code either way. Covered by a test.
- **No transport, RPC or protocol change.** `leader-exec-runner.ts`, the tray sync manager and the WebRTC path are untouched — this is a shell-construction fix.
- **Skill authors**: a `.jsh` referenced from a compound in a fresh shell now resolves, which is what `SKILL.md`'s documented `touch /usr/bin/<name>; hash -r` ritual was half-working around.

## Test plan

- [x] `npx vitest run packages/webapp/tests/shell/almost-bash-shell.test.ts` — **69 passing**
- [x] `npm run verify` — 7/7
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK
- [x] `npm run typecheck` — clean across all 9 projects
- [x] `npm run test` — 14204 passing
- [x] **New behaviour is covered by unit tests**, neither calling `syncJshCommands()` first (the existing pipeline test does, which is exactly what hid this):
  - `resolves .jsh in a compound command on a cold shell (no explicit sync)` — `cold; echo done` and `cold | cat`
  - `still resolves a bare .jsh command on a cold shell` — the path that already worked, pinned so the fallback is not lost
  - Verified the compound test **fails** against `origin/main` while the bare one passes either way — matching the live behaviour exactly.
- [x] Live check over the tray on the instance this was diagnosed on.

**Pre-existing failure, unrelated:** `packages/webapp/tests/shell/supplemental-commands/biome-command.test.ts > keeps the pinned biome versions in lockstep with the installed packages` — `expected '2.5.7' to be '2.5.6'`. Also present on #2078 and #2081.

## Documentation

- [x] No documentation changes needed — the rationale lives at the await site, where the next reader meets it. (The `SKILL.md` registration ritual is worth revisiting once the `PATH` issue lands, not before.)

## Risk & rollback

The await is the risk surface: a `syncJshCommands()` that never settled would hang the first command of every shell. It cannot reject (the retained promise carries its own `catch`), and the scan is bounded by the VFS walk it already performed on every shell before this change — the only difference is who waits for it. Revert cleanly.
