### PR TITLE
test(ios-app): stage the transcript-jump reproduction (#2072)

### DIFF
--- a/docs/ios-app-details.md
+++ b/docs/ios-app-details.md
@@ -49,6 +49,36 @@ The second one is why `ComposerConnectionUITests` stages a blip that **heals** (
 
 Push-to-talk therefore arms on `text.isEmpty` alone. Dictating with no usable leader is allowed and lands somewhere useful: `submit` refuses it and the transcript stays in the composer as a draft, which beats taking the microphone away because a ping was late.
 
+## Transcript jumps when the keyboard opens (iOS 26, unfixed)
+
+A reader who has scrolled back through the history is thrown hundreds of points further back the moment the keyboard's inset lands — the conversation they were reading is replaced by older messages, and any small scroll resolves it again. **This is a platform bug, not ours**: `ScrollView` + `LazyVStack` + dynamic-height rows mis-restores its position when the container resizes, on iOS 26 but not iOS 18. Apple DTS acknowledged it on [the forums](https://developer.apple.com/forums/thread/805306) (FB20979569, open as of 2026-08). Fixed-height rows do not trigger it, which chat bubbles cannot be.
+
+The mechanism is in [WWDC26 "Dive into lazy stacks and scrolling"](https://developer.apple.com/videos/play/wwdc2026/321/): a lazy stack _estimates_ off-screen row heights and coordinates the correction with the scroll view's content offset, so absolute offsets under a lazy stack are "estimated and unstable". Everything below acts above that layer, which is why none of it works.
+
+**Reproduce it** — the scroll is load-bearing, since until the reader drags, `scrollPosition` still holds the programmatic `edge: .bottom` that SwiftUI re-pins for free:
+
+```bash
+xcodebuild test -only-testing:SliccFollowerUITests/TranscriptComposerGrowthUITests …
+```
+
+`-uiTestTranscriptFixture YES` seeds the fixture conversation into the **real** chat surface (`-uiTestFixtureRoute` has no composer, so it cannot show this). The test scrolls back, focuses the composer, types, and reports each row's geometry.
+
+**Measured, so nobody repeats them** (anchor row displacement, ~301pt keyboard inset):
+
+| attempt                                                                | result                                                                 |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| baseline                                                               | +453pt                                                                 |
+| `.defaultScrollAnchor(.bottom, for: .sizeChanges)`                     | +323pt                                                                 |
+| `.defaultScrollAnchor(.bottom)`                                        | +265pt                                                                 |
+| `GeometryReader` → `onGeometryChange`                                  | +514pt                                                                 |
+| composer moved into `safeAreaInset`                                    | +522pt, then +365pt — worse                                            |
+| explicit re-pin via `onScrollTargetVisibilityChange` + `scrollTo(id:)` | breaks the initial scroll-to-bottom                                    |
+| `LazyVStack` → `VStack`                                                | fixes the estimation, but eager `WKWebView` sprinkle rows never settle |
+
+Note also that the keyboard's inset is **not** applied when the keyboard appears — the composer stays put until the next render pass, so the first keystroke is what lands it. Sampling before that reads as "focus changes nothing".
+
+Tracking issue: [#2072](https://github.com/ai-ecoverse/slicc/issues/2072).
+
 ## UI-test details
 
 - Put accessibility identifiers on leaves (`message-<id>`). Container ids propagate; `.accessibilityElement(children: .contain)` does not fix it.

--- a/packages/ios-app/SliccFollower/App/UITestHooks.swift
+++ b/packages/ios-app/SliccFollower/App/UITestHooks.swift
@@ -116,6 +116,23 @@ import UIKit
             return (dropAfter, parts.count > 1 ? parts[1] : nil)
         }
 
+        /// Fill the REAL chat surface with a transcript taller than any
+        /// viewport (`-uiTestTranscriptFixture YES`), reusing the same fixture
+        /// conversation the leaderless fixture route renders.
+        ///
+        /// `-uiTestFixtureRoute` cannot stand in for this: that route has no
+        /// composer, and anything about how the transcript and the composer
+        /// share the screen needs both of them.
+        @MainActor
+        static func seedTranscriptFixture(into appState: AppState) {
+            guard UserDefaults.standard.bool(forKey: "uiTestTranscriptFixture") else { return }
+            let scoopJid = "ui-test-cone"
+            appState.selectedScoopJid = scoopJid
+            let messages = ChatFixture.makeMessages()
+            appState.messagesByScoop[scoopJid] = messages
+            appState.messages = messages
+        }
+
         /// Stage a completed visible turn without a leader
         /// (`-uiTestCompletedTurn YES`). All messages enter through the real
         /// data-channel decoder; status: ready settles the turn because the

--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/TranscriptComposerGrowthUITests.swift
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerUITests/TranscriptComposerGrowthUITests.swift
@@ -1,0 +1,90 @@
+import XCTest
+
+/// Reproduction for #2072: the transcript throws the reader backwards through
+/// the history when the keyboard's inset lands.
+///
+/// **This documents an open iOS 26 SwiftUI bug (FB20979569), not ours.**
+/// `ScrollView` + `LazyVStack` + dynamic-height rows mis-restores its position
+/// when the container resizes. It is skipped by default because it asserts
+/// behaviour the platform does not currently provide — running it green is the
+/// goal, not the status quo.
+///
+/// Run it deliberately:
+///
+/// ```bash
+/// SLICC_REPRO_2072=1 xcodebuild test \
+///   -only-testing:SliccFollowerUITests/TranscriptComposerGrowthUITests …
+/// ```
+///
+/// Re-check it whenever the Xcode/simulator SDK moves: the day this passes
+/// unmodified, Apple has fixed the bug and the skip can go.
+final class TranscriptComposerGrowthUITests: XCTestCase {
+
+    /// How far a row may move while the composer and keyboard claim their
+    /// space. Sliding up by the height the viewport loses is legitimate;
+    /// jumping backwards through the conversation is not. The measured
+    /// regression moves a row by +453pt against a ~301pt inset, so this sits
+    /// well below the bug and above the honest shift.
+    private let allowedDrift: CGFloat = 120
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testHistoryStaysPutWhenTheComposerAndKeyboardClaimSpace() throws {
+        try XCTSkipIf(
+            ProcessInfo.processInfo.environment["SLICC_REPRO_2072"] == nil,
+            "Reproduces #2072, an open iOS 26 SwiftUI bug (FB20979569). "
+                + "Set SLICC_REPRO_2072=1 to run it.")
+
+        let app = launchWithTranscript()
+
+        let anchor = app.descendants(matching: .any)
+            .matching(identifier: "message-fx-delegation-1").firstMatch
+        XCTAssertTrue(anchor.waitForExistence(timeout: 60), "fixture transcript should render")
+
+        // The scroll is load-bearing. Until the reader drags, the transcript's
+        // `ScrollPosition` still holds the programmatic `edge: .bottom` from
+        // `scrollToBottom()`, which SwiftUI re-pins for free when the viewport
+        // shrinks — four reproduction attempts came back clean for exactly
+        // this reason. Only once the position is the reader's does the resize
+        // have to restore it, which is the path that fails.
+        anchor.swipeDown()
+        let afterScroll = anchor.frame.midY
+
+        let composer = app.textViews.firstMatch
+        XCTAssertTrue(composer.waitForExistence(timeout: 10))
+        composer.tap()
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 10))
+
+        // One character first: the keyboard's inset is applied on the next
+        // render pass rather than when the keyboard appears, so the first
+        // keystroke is what lands it — and that is the larger of the two jumps.
+        composer.typeText("x")
+        XCTAssertLessThan(
+            abs(anchor.frame.midY - afterScroll), allowedDrift,
+            "the keyboard's inset threw the reader through the history "
+                + "(moved \(anchor.frame.midY - afterScroll)pt)")
+
+        composer.typeText(" and now a great deal more text that wraps onto four separate lines")
+        XCTAssertLessThan(
+            abs(anchor.frame.midY - afterScroll), allowedDrift,
+            "growing the composer threw the reader through the history "
+                + "(moved \(anchor.frame.midY - afterScroll)pt)")
+    }
+
+    /// Seeds the fixture conversation into the REAL chat surface.
+    /// `-uiTestFixtureRoute` cannot stand in: it has no composer, and this
+    /// needs a transcript and a composer sharing the screen.
+    private func launchWithTranscript() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-joinUrl", "",
+            "-uiTestConnectionState", "connected",
+            "-uiTestTranscriptFixture", "YES",
+        ]
+        app.launch()
+        return app
+    }
+}


### PR DESCRIPTION
Draft. Reproduction only — **this fixes nothing**, and is opened so the work behind #2072 is on a branch anyone can check out rather than living in one session's scrollback.

Refs #2072.

## What this adds

- **`-uiTestTranscriptFixture`** seeds the fixture conversation into the **real** chat surface. This bug was previously impossible to test: `-uiTestFixtureRoute` has no composer, so no existing fixture could put a transcript and a composer on screen together.
- **`TranscriptComposerGrowthUITests`** performs the sequence that reproduces it and asserts the behaviour we want.
- **`docs/ios-app-details.md` → "Transcript jumps when the keyboard opens"** — the attribution, the recipe, and every approach already measured and rejected.

## The test is skipped by default, deliberately

It asserts behaviour the platform does not currently provide, so running it green is the goal rather than the status quo:

```bash
SLICC_REPRO_2072=1 xcodebuild test \
  -only-testing:SliccFollowerUITests/TranscriptComposerGrowthUITests …
```

Skipped, it prints its own reason with the issue and FB number. **The day it passes unmodified, Apple has fixed the bug** — that makes it a tripwire on every SDK bump rather than a monument. That is the argument for merging this even though nothing is fixed.

## Two findings that cost hours, recorded so they cost nobody else any

1. **The manual scroll is load-bearing.** Until the reader drags, `scrollPosition` still holds the programmatic `edge: .bottom` from `scrollToBottom()`, which SwiftUI re-pins for free when the viewport shrinks. Four reproduction attempts came back clean for exactly this reason.
2. **The keyboard's inset lands on the first keystroke, not when the keyboard appears.** With the keyboard fully up the composer is still at `y=794`; the first character moves it to `493` and the transcript lurches. Sampling in between reads as "focus changes nothing", which killed two hypotheses.

## Not ours

`ScrollView` + `LazyVStack` + dynamic-height rows mis-restores its scroll position when the container resizes — iOS 26 only, absent on iOS 18, acknowledged by Apple DTS ([forum thread](https://developer.apple.com/forums/thread/805306)), filed as **FB20979569**, open. Fixed-height rows do not trigger it, which chat bubbles cannot be. [WWDC26 "Dive into lazy stacks and scrolling"](https://developer.apple.com/videos/play/wwdc2026/321/) explains why every modifier-level fix fails: lazy-stack content offsets are "estimated and unstable", and anchors and insets all act above that layer.

Eight approaches were measured and rejected; the table is in the issue and the doc.

## Test plan

- [x] The class skips cleanly by default, printing its reason
- [x] `swiftlint` 0 serious, `swift format lint --strict` clean
- [x] `npm run verify` 7/7, `check-touched-exemptions` OK
- [x] Rebased onto current `main`

CI does not run this class in any leg, so it cannot turn anything red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HprQQw9b14nfKRUcBTy66
