### PR TITLE
fix(webapp): re-arm the sync-fs channel set when nobody acks

### DIFF
--- a/packages/webapp/src/kernel/realm/sync-fs-wire.ts
+++ b/packages/webapp/src/kernel/realm/sync-fs-wire.ts
@@ -91,6 +91,15 @@ export const SYNC_FS_ERRNO_HEADER = 'x-slicc-fs-errno';
 export const SYNC_FS_MARKER_HEADER = 'x-slicc-fs';
 
 /**
+ * Set on the fail-closed response when NOBODY acked — as opposed to a
+ * responder that acked and then ran out of budget. Both are `503` + `EIO` to
+ * the realm (which must not care), but the SW does: an unacked warm-path
+ * request is the one signal that its channel set may be stale, and the cue to
+ * ask the page(s) to re-publish. See `llm-proxy-sw.ts`.
+ */
+export const SYNC_FS_NO_RESPONDER_HEADER = 'x-slicc-fs-no-responder';
+
+/**
  * Channel-message discriminants. Constants (not inline literals) so the type
  * and every `postMessage` / comparison in the responder + SW handler reference
  * the SAME symbol — a rename/typo becomes a compile error rather than a silent

--- a/packages/webapp/src/ui/llm-proxy-sw.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw.ts
@@ -72,6 +72,7 @@ import {
   SYNC_EXEC_ROUTE,
   SYNC_FS_ERRNO_HEADER,
   SYNC_FS_MARKER_HEADER,
+  SYNC_FS_NO_RESPONDER_HEADER,
   SYNC_FS_ROUTE_PREFIX,
 } from './sync-fs-sw-handler.js';
 
@@ -275,7 +276,28 @@ self.addEventListener('fetch', (event: FetchEvent) => {
           });
         }
       }
-      return handleSyncFsRequest(channels, req);
+      const response = await handleSyncFsRequest(channels, req);
+      // Warm-path self-heal. `requestSyncFsNonce` above only runs when the
+      // channel set is EMPTY, so a channel left over from a previous page
+      // session permanently suppresses it: the SW keeps posting into a channel
+      // whose responder is gone, every request fails closed, and nothing ever
+      // asks the live page to re-publish. One unacked request is the cue.
+      //
+      // Deliberately narrow:
+      //   - only on the no-responder outcome, never on an acked-then-timed-out
+      //     one (that responder is alive, just slow);
+      //   - fire-and-forget AFTER the response, so the blocked realm still
+      //     unblocks at the deadline rather than waiting on a postMessage;
+      //   - it re-REQUESTS the existing nonce, never mints one — the responder
+      //     is bound to the session nonce for its lifetime (`sync-fs-wire.ts`);
+      //   - it never prunes a channel. A silent responder is indistinguishable
+      //     from the deliberate silence for a forged token
+      //     (`sync-fs-responder.ts`), so pruning would orphan another live
+      //     tab's channel. Re-publishing is additive and dedup-ed.
+      if (response.headers.get(SYNC_FS_NO_RESPONDER_HEADER) === '1') {
+        void requestSyncFsNonce();
+      }
+      return response;
     })()
   );
 });

--- a/packages/webapp/src/ui/sync-fs-sw-handler.ts
+++ b/packages/webapp/src/ui/sync-fs-sw-handler.ts
@@ -31,6 +31,7 @@ import {
   SYNC_FS_ACK_MSG,
   SYNC_FS_ERRNO_HEADER,
   SYNC_FS_MARKER_HEADER,
+  SYNC_FS_NO_RESPONDER_HEADER,
   SYNC_FS_REQ_MSG,
   SYNC_FS_REQUEST_TIMEOUT_MS,
   SYNC_FS_RES_MSG,
@@ -42,6 +43,7 @@ export {
   SYNC_EXEC_ROUTE,
   SYNC_FS_ERRNO_HEADER,
   SYNC_FS_MARKER_HEADER,
+  SYNC_FS_NO_RESPONDER_HEADER,
   SYNC_FS_ROUTE_PREFIX,
   SYNC_FS_TOKEN_HEADER,
 };
@@ -366,7 +368,13 @@ export function handleSyncFsRequest(
       finish(
         new Response('sync-fs bridge: no responder', {
           status: 503,
-          headers: { [SYNC_FS_ERRNO_HEADER]: 'EIO', [SYNC_FS_MARKER_HEADER]: '1' },
+          headers: {
+            [SYNC_FS_ERRNO_HEADER]: 'EIO',
+            [SYNC_FS_MARKER_HEADER]: '1',
+            // Distinguishes "nobody answered" from "answered late". The realm
+            // treats both as EIO; the SW uses this one to re-arm its channels.
+            [SYNC_FS_NO_RESPONDER_HEADER]: '1',
+          },
         })
       );
     }, noResponderMs);

--- a/packages/webapp/tests/ui/sync-fs-sw-handler.test.ts
+++ b/packages/webapp/tests/ui/sync-fs-sw-handler.test.ts
@@ -612,3 +612,34 @@ test('the no-responder window never outlives a shorter overall budget', async ()
     vi.useRealTimers();
   }
 });
+
+// The warm-path self-heal. A channel left over from a previous page session
+// keeps `channels.length > 0`, which permanently suppresses the SW's
+// cold-path `requestSyncFsNonce` — so every request fails closed and nothing
+// ever asks the live page to re-publish. The no-responder outcome is the cue
+// the SW re-arms on; an acked-but-slow responder must NOT trigger it, because
+// that responder is alive and re-arming would be noise.
+test('the no-responder response is tagged for SW re-arm; a plain timeout is not', async () => {
+  vi.useFakeTimers();
+  try {
+    const unacked = handleSyncFsRequest([deadChannel()], { token: 't', op: 'read', path: '/x' });
+    await vi.advanceTimersByTimeAsync(11_000);
+    const noResponder = await unacked;
+    expect(noResponder.headers.get('x-slicc-fs-no-responder')).toBe('1');
+    expect(await noResponder.text()).toBe('sync-fs bridge: no responder');
+
+    // Acked but never answered: alive, just slow — must not carry the tag.
+    const acked = handleSyncFsRequest([respondingChannel(() => null)], {
+      token: 't',
+      channel: 'exec',
+      command: 'build',
+      timeoutMs: 30_000,
+    });
+    await vi.advanceTimersByTimeAsync(40_000);
+    const timedOut = await acked;
+    expect(timedOut.headers.get('x-slicc-fs-no-responder')).toBeNull();
+    expect(await timedOut.text()).toBe('sync-fs bridge timeout');
+  } finally {
+    vi.useRealTimers();
+  }
+});


### PR DESCRIPTION
Follow-up to #2078. Closes a recovery gap that no page-side probe can even observe.

## Summary

The SW asks the page to (re)publish its sync-fs nonce **only when its channel set is empty** (`llm-proxy-sw.ts`, cold path). A channel left over from a previous page session keeps `channels.length > 0` forever — so a SW holding only a **stale** channel never asks. It keeps posting into a channel whose responder is gone, every sync-FS request fails closed, and nothing in the session can recover it.

Now the unacked outcome re-arms the channel set: one failed op, then heal — the same contract the cold path already has.

## Why

Two facts combine into a trap:

1. `requestSyncFsNonce()` is gated on `channels.length === 0` (`llm-proxy-sw.ts:261`). One stale entry permanently suppresses it.
2. `syncFsChannels` is SW **module state that survives page reloads** (`llm-proxy-sw.ts:220`), while the page mints a **fresh** nonce per session (`wc-live.ts:2225`). So a page whose `publishNonce` no-ops — `sw.controller` transiently null at that instant (`wc-live.ts:2229`, optional chain), or the publish rejected by `maySetSyncFsNonce` because the client isn't top-level (`llm-proxy-sw-config.ts:455`) — leaves the kernel responder on nonce N2 while the SW still posts only to N1.

The result is a session where every realm `readFileSync`/`execSync` fails `EIO` after the no-responder deadline, with no self-heal, and the UI looking healthy because realms fall back to the bounded snapshot.

## Approach / Implementation notes

The ack is the liveness signal, so its **absence** is the cue. The fail-closed response now carries `x-slicc-fs-no-responder: 1` and the SW re-requests the nonce when it sees it.

Deliberately narrow, because each alternative is worse:

- **Only on no-responder**, never on acked-then-timed-out — that responder is alive, just slow; re-arming there is noise.
- **Fire-and-forget, after the response** — a blocked realm still unblocks at the deadline instead of waiting on a `postMessage`.
- **Re-requests the existing nonce, never mints one** — the responder is bound to the session nonce for its lifetime (`sync-fs-wire.ts:56-64`); minting a new one page-side would strand it.
- **Never prunes a channel.** A silent responder is indistinguishable from the *deliberate* silence for a forged token (`sync-fs-responder.ts:34-37`), so pruning on non-ack would let one bad request orphan another live tab's channel. Re-publishing is additive and dedup-ed (`llm-proxy-sw.ts:232`).

The realm still sees `503` + `EIO` either way — the new header is SW-facing only.

## A diagnostic trap worth recording

This surfaced while chasing repeated leader freezes, and the obvious probe **lies**:

```
fetch('/__slicc/fs-sync/tmp?op=stat')   →  503 EIO after 10010ms
```

That looks exactly like a dead bridge. It isn't: a page-side fetch carries no `x-slicc-fs-token`, `parseSyncFsRequest` defaults it to `''` (`sync-fs-sw-handler.ts:245`), and the responder stays deliberately silent for unresolvable tokens (`sync-fs-responder.ts:117`) — the forged-token defence. So the request fails closed at exactly `DEFAULT_NO_RESPONDER_MS`, **identically on a healthy instance**. Absence of a `sync-fs-need-nonce` message is likewise the *healthy* signature (the SW only asks when its set is empty).

Only a **realm-issued** op can tell them apart, because only realms hold resolvable tokens:

```
node -e "require('fs').statSync('/tmp')"   →  SYNC_OK in 0ms      ← bridge fine
```

On the instance being diagnosed that returned in 0 ms, which is how the "persistently dead bridge" reading was retired. **This PR fixes the stale-channel trap that probe cannot see — not that instance.**

## Cross-cutting impact

- **No change on the healthy path**: with a live responder the ack arrives, the header is never set, nothing re-arms.
- **Realm-facing contract unchanged**: same status, same `x-slicc-fs-errno`, same body strings. Nothing parses the new header except the SW.
- **Cost when it does fire**: one dedup-ed `postMessage` per unacked request — including per forged-token request, which is the acceptable price of not being able to distinguish them (and exactly why pruning is off the table).
- **Cold path untouched** (`channels.length === 0` still waits `SYNC_FS_NONCE_WAIT_MS`).
- No wire, storage or API change beyond the added response header.

## Test plan

- [x] `npx vitest run packages/webapp/tests/ui/sync-fs-sw-handler.test.ts` — **35 passing** (34 before)
- [x] `npm run verify` — 7/7
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK
- [x] `npm run typecheck` — clean across all 9 projects
- [x] `npm run test` — 14208 passing
- [x] **New behaviour covered**: `the no-responder response is tagged for SW re-arm; a plain timeout is not` — asserts the tag on the unacked path AND its absence on the acked-but-slow path, so the narrowness is pinned rather than assumed.
- [x] Live: the tokened probe above, used to establish the bridge was healthy and this is a latent trap rather than the observed fault.

**Pre-existing failure, unrelated:** `biome-command.test.ts > keeps the pinned biome versions in lockstep with the installed packages` — `expected '2.5.7' to be '2.5.6'`.

## Documentation

- [x] No documentation changes needed — the new header documents itself at its definition (`sync-fs-wire.ts`), and the SW-side reasoning sits at the branch that acts on it. The process-model page describes budgets and the fail-closed contract, neither of which changes.

## Risk & rollback

Confined to a path that previously did nothing at all. Worst case is a redundant `postMessage` after a failed request; the constraints above are what keep it from becoming a channel-pruning footgun. Revert cleanly.
