### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -157,9 +157,9 @@
       "regions": 73
     },
     "ios-app": {
-      "lines": 72,
-      "functions": 71,
-      "regions": 68
+      "lines": 73,
+      "functions": 72,
+      "regions": 69
     }
   }
 }


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.