### PR TITLE
refactor(webapp): simplify sqlite command

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -316,7 +316,6 @@
         "packages/webapp/src/shell/supplemental-commands/pdftk-command.ts",
         "packages/webapp/src/shell/supplemental-commands/ps-command.ts",
         "packages/webapp/src/shell/supplemental-commands/screencapture-command.ts",
-        "packages/webapp/src/shell/supplemental-commands/sqlite-command.ts",
         "packages/webapp/src/shell/supplemental-commands/unzip-command.ts",
         "packages/webapp/src/shell/supplemental-commands/websocat-command.ts",
         "packages/webapp/src/skills/install-from-drop.ts",

--- a/packages/webapp/src/shell/supplemental-commands/sqlite-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/sqlite-command.ts
@@ -1,7 +1,20 @@
-import type { Command } from 'just-bash';
+import type { Command, CommandContext } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import { stdinAsText } from '../just-bash-compat.js';
-import { formatSqlValue, getSqlJs } from './shared.js';
+import {
+  formatSqlValue,
+  getSqlJs,
+  type SqlJsDatabase,
+  type SqlJsModule,
+  type SqlJsResultSet,
+} from './shared.js';
+
+type SqliteCommandName = 'sqlite3' | 'sqllite';
+
+interface SqliteArguments {
+  database: string;
+  sql: string;
+}
 
 function sqliteHelp(): { stdout: string; stderr: string; exitCode: number } {
   return {
@@ -11,62 +24,82 @@ function sqliteHelp(): { stdout: string; stderr: string; exitCode: number } {
   };
 }
 
-export function createSqliteCommand(name: 'sqlite3' | 'sqllite' = 'sqlite3'): Command {
+function parseArguments(args: string[], ctx: CommandContext): SqliteArguments {
+  const hasDatabase = args.length > 0 && !args[0].startsWith('-');
+  const database = hasDatabase ? args[0] : ':memory:';
+  const sqlArguments = hasDatabase ? args.slice(1) : args;
+  return {
+    database,
+    sql: sqlArguments.join(' ').trim() || stdinAsText(ctx.stdin).trim(),
+  };
+}
+
+function resolveDatabasePath(database: string, ctx: CommandContext): string {
+  return database === ':memory:' ? database : ctx.fs.resolvePath(ctx.cwd, database);
+}
+
+async function loadDatabase(
+  Sql: SqlJsModule,
+  databasePath: string,
+  ctx: CommandContext
+): Promise<SqlJsDatabase> {
+  if (databasePath === ':memory:' || !(await ctx.fs.exists(databasePath))) {
+    return new Sql.Database();
+  }
+  return new Sql.Database(await ctx.fs.readFileBuffer(databasePath));
+}
+
+async function persistDatabase(
+  database: SqlJsDatabase,
+  databasePath: string,
+  ctx: CommandContext
+): Promise<void> {
+  if (databasePath !== ':memory:') {
+    await ctx.fs.writeFile(databasePath, database.export());
+  }
+}
+
+function formatResultSets(resultSets: SqlJsResultSet[]): string {
+  const lines = resultSets.flatMap((set) =>
+    set.values.map((row) => row.map(formatSqlValue).join('|'))
+  );
+  return lines.length > 0 ? `${lines.join('\n')}\n` : '';
+}
+
+async function executeSql(databaseArgument: string, sql: string, ctx: CommandContext) {
+  const SQL = await getSqlJs();
+  const databasePath = resolveDatabasePath(databaseArgument, ctx);
+  const database = await loadDatabase(SQL, databasePath, ctx);
+  const resultSets = database.exec(sql);
+  await persistDatabase(database, databasePath, ctx);
+  database.close();
+  return formatResultSets(resultSets);
+}
+
+function errorResult(name: SqliteCommandName, error: unknown) {
+  return {
+    stdout: '',
+    stderr: `${name}: ${error instanceof Error ? error.message : String(error)}\n`,
+    exitCode: 1,
+  };
+}
+
+export function createSqliteCommand(name: SqliteCommandName = 'sqlite3'): Command {
   return defineCommand(name, async (args, ctx) => {
     if (args.includes('--help') || args.includes('-h')) return sqliteHelp();
 
-    let dbArg = ':memory:';
-    let sqlArgv = args;
-    if (args.length > 0 && !args[0].startsWith('-')) {
-      dbArg = args[0];
-      sqlArgv = args.slice(1);
-    }
-
-    const sql = sqlArgv.join(' ').trim() || stdinAsText(ctx.stdin).trim();
+    const { database, sql } = parseArguments(args, ctx);
     if (!sql) {
-      return {
-        stdout: '',
-        stderr: `${name}: interactive mode is not supported; provide SQL as argument or stdin\n`,
-        exitCode: 1,
-      };
+      return errorResult(
+        name,
+        'interactive mode is not supported; provide SQL as argument or stdin'
+      );
     }
 
     try {
-      const SQL = await getSqlJs();
-      const isMemory = dbArg === ':memory:';
-      const dbPath = isMemory ? ':memory:' : ctx.fs.resolvePath(ctx.cwd, dbArg);
-
-      let dbBytes: Uint8Array | undefined;
-      if (!isMemory && (await ctx.fs.exists(dbPath))) {
-        dbBytes = await ctx.fs.readFileBuffer(dbPath);
-      }
-
-      const db = dbBytes ? new SQL.Database(dbBytes) : new SQL.Database();
-      const resultSets = db.exec(sql);
-
-      if (!isMemory) {
-        await ctx.fs.writeFile(dbPath, db.export());
-      }
-      db.close();
-
-      const lines: string[] = [];
-      for (const set of resultSets) {
-        for (const row of set.values) {
-          lines.push(row.map(formatSqlValue).join('|'));
-        }
-      }
-
-      return {
-        stdout: lines.length > 0 ? `${lines.join('\n')}\n` : '',
-        stderr: '',
-        exitCode: 0,
-      };
-    } catch (err) {
-      return {
-        stdout: '',
-        stderr: `${name}: ${err instanceof Error ? err.message : String(err)}\n`,
-        exitCode: 1,
-      };
+      return { stdout: await executeSql(database, sql, ctx), stderr: '', exitCode: 0 };
+    } catch (error) {
+      return errorResult(name, error);
     }
   });
 }

--- a/packages/webapp/tests/shell/supplemental-commands/sqlite-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/sqlite-command.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSqliteCommand } from '../../../src/shell/supplemental-commands/sqlite-command.js';
+import { mockCommandContext } from '../helpers/mock-command-context.js';
+
+const { database, Database } = vi.hoisted(() => {
+  const databaseMock = {
+    exec: vi.fn(),
+    export: vi.fn(),
+    close: vi.fn(),
+  };
+  return {
+    database: databaseMock,
+    Database: vi.fn(function Database() {
+      return databaseMock;
+    }),
+  };
+});
+
+vi.mock('../../../src/shell/supplemental-commands/shared.js', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('../../../src/shell/supplemental-commands/shared.js')>();
+  return {
+    ...original,
+    getSqlJs: vi.fn().mockResolvedValue({ Database }),
+  };
+});
+
+function context(options: { stdin?: string; exists?: boolean; databaseBytes?: Uint8Array } = {}) {
+  return mockCommandContext({
+    cwd: '/work',
+    stdin: options.stdin,
+    fs: {
+      exists: vi.fn().mockResolvedValue(options.exists ?? false),
+      readFileBuffer: vi.fn().mockResolvedValue(options.databaseBytes ?? new Uint8Array()),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+    },
+  });
+}
+
+describe('sqlite command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    database.exec.mockReturnValue([]);
+    database.export.mockReturnValue(new Uint8Array([9, 8, 7]));
+  });
+
+  it.each(['sqlite3', 'sqllite'] as const)('shows help for %s', async (name) => {
+    const result = await createSqliteCommand(name).execute(['--help'], context());
+
+    expect(result).toEqual({
+      stdout: 'usage: sqlite3 [database] [sql]\n',
+      stderr: '',
+      exitCode: 0,
+    });
+  });
+
+  it('executes SQL supplied in arguments and formats result rows', async () => {
+    database.exec.mockReturnValue([
+      { columns: ['value', 'empty', 'blob'], values: [[42, null, new Uint8Array([10, 255])]] },
+    ]);
+
+    const result = await createSqliteCommand().execute([':memory:', 'select', '42'], context());
+
+    expect(database.exec).toHaveBeenCalledWith('select 42');
+    expect(result).toEqual({ stdout: "42||x'0aff'\n", stderr: '', exitCode: 0 });
+  });
+
+  it('executes SQL supplied on stdin', async () => {
+    const result = await createSqliteCommand().execute([], context({ stdin: ' select 1; \n' }));
+
+    expect(database.exec).toHaveBeenCalledWith('select 1;');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('rejects empty SQL because interactive mode is unsupported', async () => {
+    const result = await createSqliteCommand('sqllite').execute([], context({ stdin: '  ' }));
+
+    expect(result).toEqual({
+      stdout: '',
+      stderr: 'sqllite: interactive mode is not supported; provide SQL as argument or stdin\n',
+      exitCode: 1,
+    });
+    expect(Database).not.toHaveBeenCalled();
+  });
+
+  it('keeps in-memory databases out of the filesystem', async () => {
+    const ctx = context();
+
+    await createSqliteCommand().execute([':memory:', 'select 1'], ctx);
+
+    expect(ctx.fs.exists).not.toHaveBeenCalled();
+    expect(ctx.fs.writeFile).not.toHaveBeenCalled();
+    expect(Database).toHaveBeenCalledWith();
+    expect(database.close).toHaveBeenCalledOnce();
+  });
+
+  it('loads and persists file-backed databases', async () => {
+    const existingBytes = new Uint8Array([1, 2, 3]);
+    const exportedBytes = new Uint8Array([9, 8, 7]);
+    database.export.mockReturnValue(exportedBytes);
+    const ctx = context({ exists: true, databaseBytes: existingBytes });
+
+    await createSqliteCommand().execute(['data.sqlite', 'select 1'], ctx);
+
+    expect(ctx.fs.readFileBuffer).toHaveBeenCalledWith('/work/data.sqlite');
+    expect(Database).toHaveBeenCalledWith(existingBytes);
+    expect(ctx.fs.writeFile).toHaveBeenCalledWith('/work/data.sqlite', exportedBytes);
+    expect(database.close).toHaveBeenCalledOnce();
+  });
+
+  it('returns an error when database execution throws', async () => {
+    database.exec.mockImplementation(() => {
+      throw new Error('bad SQL');
+    });
+
+    const result = await createSqliteCommand().execute([':memory:', 'broken'], context());
+
+    expect(result).toEqual({ stdout: '', stderr: 'sqlite3: bad SQL\n', exitCode: 1 });
+  });
+});


### PR DESCRIPTION
## Solution
Extract SQLite argument parsing, database lifecycle, and result formatting helpers so the command no longer needs its cognitive-complexity exemption.

## Testing
- Added focused coverage for help, argv/stdin SQL, persistence, formatting, aliases, and execution errors.
- Lint, typecheck, focused tests, webapp/extension builds, bundle size, and touched-debt gate pass; full webapp tests/coverage reproduce an unrelated fake-LLM request-order failure.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M02AJTXDJZ41TDJVCTR5R7KD&panel=chat)