### PR TITLE
refactor(webapp): type __slicc_connect_mode global in float-topology

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -51,7 +51,6 @@
   "packages/webapp/src/core/feature-flags-cache.ts": 1,
   "packages/webapp/src/core/feature-flags-remote.ts": 1,
   "packages/webapp/src/core/feature-flags.ts": 2,
-  "packages/webapp/src/core/float-topology.ts": 1,
   "packages/webapp/src/core/secrets-bridge-client.ts": 2,
   "packages/webapp/src/core/tool-adapter.ts": 2,
   "packages/webapp/src/core/tool-registry.ts": 1,

--- a/packages/webapp/src/core/float-topology.ts
+++ b/packages/webapp/src/core/float-topology.ts
@@ -13,6 +13,10 @@ import { isExtensionRealm } from './runtime-env.js';
 
 export type FloatTopology = 'extension-direct' | 'extension-delegate' | 'connect' | 'node-rest';
 
+type ConnectModeGlobal = {
+  __slicc_connect_mode?: unknown;
+};
+
 /**
  * Resolve the current realm's float topology. First match wins:
  * 1. **extension-direct** — real `chrome-extension://` page (`chrome.runtime.id`).
@@ -32,7 +36,7 @@ export function resolveFloatTopology(): FloatTopology {
   if (getExtensionDelegateId()) {
     return 'extension-delegate';
   }
-  if ((globalThis as Record<string, unknown>).__slicc_connect_mode) {
+  if ((globalThis as ConnectModeGlobal).__slicc_connect_mode) {
     return 'connect';
   }
   return 'node-rest';


### PR DESCRIPTION
## Solution
- Types the ambient `__slicc_connect_mode` shape locally in `packages/webapp/src/core/float-topology.ts`; truthiness and first-match-wins behavior are unchanged.
- Removes that file from its only debt list, `packages/dev-tools/tools/record-string-unknown-baseline.json`, via the supported generator.

## Testing
- `npm run verify`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/core/float-topology.test.ts`
- `npm run test`
- `npm run test:coverage`
- `npm run build`
- `npm run build -w @slicc/chrome-extension`
- `npm run bundle-size`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M04X4BNBHD4XDR0DK1VT79VA&panel=chat)