### PR TITLE
refactor(cherry): type CDP response result

### DIFF
--- a/packages/cherry/src/mount.ts
+++ b/packages/cherry/src/mount.ts
@@ -21,8 +21,10 @@ import {
  */
 const MISMATCH_HOOK_GRACE_MS = 250;
 
+type CdpResult = Awaited<ReturnType<ReturnType<typeof createCdpHostHandler>>>;
+
 interface CdpResponseShape {
-  result?: Record<string, unknown>;
+  result?: CdpResult;
   error?: { code: number; message: string };
 }
 

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -1,6 +1,5 @@
 {
   "packages/cherry/src/cdp-host-handlers.ts": 3,
-  "packages/cherry/src/mount.ts": 1,
   "packages/cherry/src/preview-bootstrap.ts": 2,
   "packages/cherry/src/protocol.ts": 5,
   "packages/chrome-extension/src/bridge-sw.ts": 17,


### PR DESCRIPTION
## Solution
Derive Cherry’s CDP response result type from the host handler, removing the file’s untyped-bag debt without changing runtime behavior.

## Testing
- Full lint, typecheck, tests, coverage, builds, bundle-size, and touched-exemption gates pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M07F9JKQXT2QFXN94SDJ9N2B&panel=chat)