### PR TITLE
docs: align automated review categories

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,35 +1,21 @@
 # SLICC — Copilot Code Review Instructions
 
-SLICC is a browser-centric AI coding agent shipped across five runtimes — `webapp`
-(browser), `chrome-extension`, `node-server`, `swift-server`, and `ios-app` — sharing
-behavior but not code. Review changed code against these recurring blind spots, highest
-value first. Only flag a category when the surrounding code does not already handle it.
-Full catalog: `docs/review-patterns.md`.
+Review SLICC's five runtimes (`webapp`, extension, Node, Swift, iOS) against these blind
+spots. Flag only genuine risks. Full catalog: `docs/review-patterns.md`.
 
 ## 1. Error-path coverage (often Critical)
 
-External calls need bounded failure. Flag `fetch()` to external hosts without
-`AbortSignal.timeout(ms)`; e2b `Sandbox.create()` / `Sandbox.connect()` without
-`requestTimeoutMs`; API calls with no retry/backoff; and `await`/promise chains with no
-`.catch()` / `try`-`catch`. (A missing e2b timeout once caused production sandbox-start
-failures.)
+External calls need bounded failure: timeouts, retry/backoff where appropriate, and surfaced
+errors. Flag unbounded `fetch()`, E2B calls, and async work.
 
 ## 2. Cross-runtime parity (often Critical)
 
-A change to a shared feature in one runtime usually needs its peers updated — or an explicit
-note that a peer is intentionally excluded. Watch especially:
-
-- `packages/node-server/` ↔ `packages/swift-server/` — HTTP endpoints, server-side signing,
-  mount handling.
-- browser ↔ extension — VFS, mount backends, secrets, agent integration.
-
-The cloud / hosted-leader float reuses `node-server`; Cherry inherits browser behavior.
+Shared behavior needs peer updates or an explicit exclusion. Check Node ↔ Swift servers and
+browser ↔ extension, especially endpoints, signing, mounts, VFS, and secrets.
 
 ## 3. UI state preservation
 
-Flag `innerHTML = …`, `replaceChildren()`, or reflow/navigation that rebuilds DOM holding
-live UI state without first capturing and then restoring it (or persisting it to
-`localStorage` / IndexedDB).
+DOM rebuilds (`innerHTML`, `replaceChildren`, reflow) must capture and restore live state.
 
 ## 4. CDP / Chrome edge cases
 
@@ -38,46 +24,50 @@ capture. Validate the CDP target and port before trusting them; handle disconnec
 
 ## 5. Native / macOS permissions
 
-In `swift-server` / `swift-launcher` / `ios-app`, keychain, camera, microphone, and
-screen-recording access needs the matching entitlement or usage description plus a TCC check,
-and must degrade gracefully when consent is denied.
+Native protected-resource access needs entitlements/usage descriptions, TCC checks, and
+graceful denial.
 
-## 6. Test coverage
+## 6. Model metadata / provider pipeline
 
-New `src/` files need mirrored `tests/` files; changed logic needs updated tests; bug fixes
-need a regression test. CI enforces per-package coverage floors — a drop below the floor fails
-the build.
+When model IDs or provider metadata change, verify forwarding of reasoning, input, cost, and
+thinking levels through discovery, enrichment, account storage, and API effort mapping.
 
-## 7. Follower surface wiring parity (often Critical)
+## 7. Test coverage
 
-Every leader broadcast (`LeaderToFollowerMessage` / `broadcast*` in `tray-leader-sync.ts`)
-needs a matching follower handler in `tray-follower-sync.ts` AND a UI action wired in
-`wc-follower.ts`. New interactive elements on leader surfaces need follower counterparts.
-Check all three boot paths (`mountWcUiLive` / `mountWcUiFollower` / `mountWcUiExtension`).
-Also flag: a fallback removed from a shared helper for a leader-only replacement, or a
-gate keyed on a float name (`isCherry`) where a capability check belongs (#1706).
-The largest empirical failure class.
+New `src/` files need mirrored tests; changed logic needs updated tests; bug fixes need a
+regression test. Do not lower coverage floors.
 
-## 8. Origin / bridge routing contract (often Major)
+## 8. Follower surface wiring parity (often Critical)
 
-In thin-bridge mode the UI runs on the hosted origin while `/api/` lives on the local
-bridge. Flag `fetch('/api/...')` that assumes same-origin, hard-coded origin strings, and
-origin comparisons without trailing-slash normalization. 15 call-site fixes across ~9 PRs.
+Leader broadcasts need follower handlers and UI actions. Check live, follower, and extension
+boot paths; preserve shared fallbacks and prefer capability checks over float names.
 
-## Severity
+## 9. Origin / bridge routing contract (often Major)
 
-🔴 Critical = likely production issue · 🟡 Major = bites in a specific scenario ·
-🔵 Minor = quality / consistency. Stay high-signal; prefer no comment over a speculative one.
-
-## 9. Transcript export — redaction boundary (Critical)
-
-- Fail-closed: redactor failure → abort with `redaction-unavailable`, never emit raw.
-- `privacy.reasoningExcluded` must always be `true`.
-- Follower/Cherry paths must call `openTranscriptExportApproval()`; approval is one-time.
-- Unknown follower error codes and SHA-256 mismatches → `transfer-corrupt`.
+Thin-bridge UI and API origins differ. Flag same-origin `/api/` assumptions, hard-coded
+origins, and comparisons without slash normalization.
 
 ## 10. Layer import direction (Major)
 
-Stack: `fs → shell/git → cdp → tools → core → scoops → ui`. Flag new imports up
-the stack (`cdp/` → `scoops/`, any layer → `ui/`) — even types or pure helpers;
-move the helper down. Flag growth of `layer-back-edge-baseline.json`.
+Stack: `fs → shell/git → cdp → tools → core → scoops → ui`. Flag imports up the stack,
+even types or pure helpers; move helpers down. Never grow the back-edge baseline.
+
+## 11. Untyped string-keyed bags
+
+Flag new `Record<string, unknown>` in source when the shape is known. Require a named type,
+boundary validation, or a justified Biome suppression; never grow the frozen baseline.
+
+## 12. Agent skill freshness
+
+Capability, command, argument, or workflow changes must update the matching runtime and
+developer `SKILL.md` files. Run the skill-router and any specialized sync check.
+
+## 13. Transcript export — redaction boundary (Critical)
+
+Require fail-closed redaction, `reasoningExcluded: true`, one-time reachable approval, binary
+integrity, and `transfer-corrupt` for unknown errors or SHA-256 mismatches.
+
+## Severity
+
+🔴 Critical = likely production issue · 🟡 Major = scenario-specific · 🔵 Minor = quality.
+Stay high-signal; prefer no comment over a speculative one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,9 +125,9 @@ Reviewers (Claude action, Codex `AGENTS.md`, Copilot `.github/copilot-instructio
 7. Test coverage
 8. Follower wiring parity
 9. Origin/bridge routing
-10. Agent skill freshness
-11. Transcript export
-12. Layer import direction
-13. Untyped string-keyed bags (`Record<string, unknown>`)
+10. Layer import direction
+11. Untyped string-keyed bags (`Record<string, unknown>`)
+12. Agent skill freshness
+13. Transcript export
 
 When you change a category, update `docs/review-patterns.md` (source of truth) and the ≤4,000-char `.github/copilot-instructions.md` so all reviewers stay in sync.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -73,7 +73,7 @@ Subsystems:
 Review & gotchas:
 
 - `pitfalls.md` — runtime and extension gotchas (CSP, dual-mode runtime detection, WASM heap views, etc.)
-- `review-patterns.md` — source of truth for the automated PR reviewers (Claude action, Codex, Copilot): the nine recurring blind-spot categories, the five-runtime parity matrix, and the severity rubric
+- `review-patterns.md` — source of truth for the automated PR reviewers (Claude action, Codex, Copilot): the numbered blind-spot categories, the five-runtime parity matrix, and the severity rubric
 
 Other:
 

--- a/docs/review-patterns.md
+++ b/docs/review-patterns.md
@@ -338,7 +338,28 @@ occurrence not in the frozen baseline; the baseline is a one-way ratchet — shr
 grow it. Touching a baselined file obliges you to clear that file
 (`check-touched-exemptions.mjs`).
 
-## Transcript export — redaction boundary and protocol parity
+### 12. Agent skill freshness
+
+**Trigger patterns**
+
+- A shell command, tool, provider, approval flow, or runtime capability changes without the
+  matching agent-facing `packages/vfs-root/workspace/skills/*/SKILL.md` update.
+- New command arguments, flags, aliases, or output semantics are absent from the skill that
+  teaches agents how to invoke the command.
+- A developer workflow changes without updating the matching `.agents/skills/*/SKILL.md`
+  procedure and its `.claude/skills/` discovery alias.
+
+**Historical precedent** — **PR #1130** aligned SLICC's `playwright-cli` with the official
+CLI, closing 39 command gaps and refreshing the runtime skill with the newly supported
+commands. Its sync script detects command-surface drift; the skill update keeps that surface
+usable by agents after it lands.
+
+**Remediation** — follow the cross-reference checklist in
+[adding-slicc-features](../.agents/skills/adding-slicc-features/SKILL.md): update the matching
+runtime and developer skills in the same PR, run `npm run lint:skill-router`, and run the
+specialized sync check (such as `playwright-cli-sync.mjs`) when one exists.
+
+### 13. Transcript export — redaction boundary and protocol parity
 
 Changes to export-service, redaction logic, or the Cherry/follower export protocol.
 

--- a/docs/review-patterns.md
+++ b/docs/review-patterns.md
@@ -355,9 +355,10 @@ commands. Its sync script detects command-surface drift; the skill update keeps 
 usable by agents after it lands.
 
 **Remediation** — follow the cross-reference checklist in
-[adding-slicc-features](../.agents/skills/adding-slicc-features/SKILL.md): update the matching
-runtime and developer skills in the same PR, run `npm run lint:skill-router`, and run the
-specialized sync check (such as `playwright-cli-sync.mjs`) when one exists.
+[adding-slicc-features](../.agents/skills/adding-slicc-features/SKILL.md): update each affected
+audience's skill in the same PR—runtime skills for agent-facing capabilities, developer skills
+for developer workflows. Run `npm run lint:skill-router` and any specialized sync check (such
+as `playwright-cli-sync.mjs`) that covers the changed surface.
 
 ### 13. Transcript export — redaction boundary and protocol parity
 

--- a/docs/root-details.md
+++ b/docs/root-details.md
@@ -45,11 +45,11 @@ Numbering matches the root checklist. Full catalog:
    handler + UI action; check all boot paths.
 9. **Origin/bridge routing** — `fetch('/api/...')` must work in thin-bridge
    mode; normalize trailing slashes.
-10. **Agent skill freshness** — shell command changes → update matching
-    `vfs-root/workspace/skills/*/SKILL.md`.
-11. **Transcript export** — fail-closed redaction; approval gate; unknown
-    errors → `transfer-corrupt`; SHA-256.
-12. **Layer import direction** — no new `ui/` imports below ui; move helpers
-    down.
-13. **Untyped string-keyed bags** — no new `Record<string, unknown>` in source;
+10. **Layer import direction** — no imports up the documented layer stack;
+    move pure helpers down.
+11. **Untyped string-keyed bags** — no new `Record<string, unknown>` in source;
     name the shape, or `// biome-ignore lint/plugin:` with a reason.
+12. **Agent skill freshness** — capability changes → update matching runtime
+    and developer `SKILL.md` files.
+13. **Transcript export** — fail-closed redaction; approval gate; unknown
+    errors → `transfer-corrupt`; SHA-256.


### PR DESCRIPTION
Closes #2104

## Solution
Makes the 13-category source catalog and every condensed reviewer checklist use one numbering scheme, including first-class skill-freshness and transcript-export categories.

## Testing
- Documentation, lint, touched-debt, typecheck, browser builds, and bundle budgets pass.
- Full tests: 14,239 pass; one pre-existing fake-LLM sequential-request ordering test fails consistently. Aggregate build additionally lacks the Swift toolchain.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M07G98V9JCDG7AC9DJN315R7&panel=chat)