### PR TITLE
Restore scoop git clone flush compatibility

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -90,6 +90,27 @@ Custom commands implemented in TypeScript and registered in just-bash.
 | **afplay / chime**                          | `afplay-command.ts`        | Play a sound file. `chime` is a convenience alias for the bundled notification sounds in `/shared/sounds/`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | `afplay <path>`, `chime [done\|alert\|...]`                                                                                                                                                                                                                                                                                  |
 | **pbcopy / pbpaste / xclip / xsel**         | `clipboard-commands.ts`    | Copy stdin to the clipboard / paste clipboard to stdout via the browser Clipboard API. All four aliases share the same implementation.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `echo hi \| pbcopy`, `pbpaste`                                                                                                                                                                                                                                                                                               |
 
+### Git clone depth and branch refs
+
+SLICC's browser-native `git clone` deliberately defaults to depth 1 and a single branch: without
+flags, it fetches only the tip of the remote's default branch. This differs from the native Git
+CLI's full-history, all-branch default and keeps browser-backed clones fast and compact.
+
+```bash
+# Clone a non-default branch (still depth 1 and single-branch)
+git clone --branch feature https://github.com/example/project.git project
+
+# Keep depth 1, but fetch all remote branch refs during clone
+git clone --no-single-branch https://github.com/example/project.git project
+
+# Add a branch to an existing optimized clone, then create its local branch
+cd project
+git fetch origin feature
+git checkout -b feature origin/feature
+```
+
+Use `--depth <n>` to request a different history depth.
+
 ### `ipx` / `npx` built-in redirects
 
 `ipx` runs JavaScript package bins from the nearest installed `node_modules`; `npx` is an

--- a/packages/webapp/src/fs/restricted-fs.ts
+++ b/packages/webapp/src/fs/restricted-fs.ts
@@ -234,6 +234,11 @@ export class RestrictedFS {
     this.vfs.invalidatePaths(paths);
   }
 
+  /** Persist backend-owned metadata; this operation is not path-selected. */
+  async flush(): Promise<void> {
+    await this.vfs.flush();
+  }
+
   /**
    * Mount-membership query — needed by the isomorphic-git fs adapter,
    * which routes mount-backed paths through the async VFS API instead of

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -8,9 +8,13 @@ vi.mock('isomorphic-git', async (importOriginal) => ({ ...(await importOriginal(
 
 import * as isoGit from 'isomorphic-git';
 import { GLOBAL_FS_DB_NAME } from '../../src/fs/global-db.js';
+import { RestrictedFS } from '../../src/fs/restricted-fs.js';
+import { createSudoFs } from '../../src/fs/sudo-fs.js';
 import { VirtualFS } from '../../src/fs/virtual-fs.js';
 import { GitCommands } from '../../src/git/git-commands.js';
 import { createIsomorphicGitFs } from '../../src/git/vfs-fs-adapter.js';
+import { AlmostBashShell } from '../../src/shell/index.js';
+import { parseSudoers } from '../../src/shell/sudo/sudoers.js';
 
 describe('GitCommands', () => {
   let vfs: VirtualFS;
@@ -3925,7 +3929,6 @@ describe('GitCommands with RestrictedFS (scoop sandbox, issue #507)', () => {
   let dbCounter = 0;
 
   it('runs init/status/add/commit through a RestrictedFS without "isPathUnderMount is not a function"', async () => {
-    const { RestrictedFS } = await import('../../src/fs/restricted-fs.js');
     const testId = dbCounter++;
     const vfs = await VirtualFS.create({ dbName: `git-restricted-fs-507-${testId}`, wipe: true });
     await vfs.mkdir('/scoops/regression-507', { recursive: true });
@@ -3958,5 +3961,66 @@ describe('GitCommands with RestrictedFS (scoop sandbox, issue #507)', () => {
     const commitResult = await git.execute(['commit', '-m', 'initial'], '/scoops/regression-507');
     expect(commitResult.exitCode).toBe(0);
     expect(commitResult.stdout).toContain('initial');
+  });
+});
+
+describe('GitCommands flush through production scoop filesystem wrappers', () => {
+  let dbCounter = 0;
+
+  it('flushes after clone and checkout without requesting sudo approval', async () => {
+    const testId = dbCounter++;
+    const scoopDir = '/scoops/git-flush-regression';
+    const vfs = await VirtualFS.create({
+      dbName: `git-restricted-fs-flush-${testId}`,
+      wipe: true,
+    });
+    const flushSpy = vi.spyOn(vfs, 'flush');
+    const cloneSpy = vi.spyOn(isoGit, 'clone').mockResolvedValue();
+    const listFilesSpy = vi.spyOn(isoGit, 'listFiles').mockResolvedValue([]);
+
+    try {
+      await vfs.mkdir(scoopDir, { recursive: true });
+      const restricted = new RestrictedFS(vfs, [`${scoopDir}/`, '/shared/'], [], 'sudo-delegated');
+      const approvalRequests: unknown[] = [];
+      const sudoFs = createSudoFs(restricted, {
+        broker: {
+          requestApproval: async (request) => {
+            approvalRequests.push(request);
+            return { decision: 'deny' };
+          },
+        },
+        getPolicy: () => parseSudoers(`NOPASSWD Write ${scoopDir}/**`),
+        defaultDisposition: 'require-approval',
+      });
+      const shell = new AlmostBashShell({
+        fs: sudoFs as unknown as VirtualFS,
+        cwd: scoopDir,
+      });
+
+      const cloneResult = await shell.executeCommand(
+        'git clone https://github.com/example/repo.git cloned'
+      );
+      expect(cloneResult.exitCode).toBe(0);
+      expect(cloneSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ depth: 1, singleBranch: true })
+      );
+      expect(flushSpy).toHaveBeenCalledTimes(1);
+
+      expect((await shell.executeCommand('git init')).exitCode).toBe(0);
+      await sudoFs.writeFile(`${scoopDir}/readme.txt`, 'hello scoop');
+      expect((await shell.executeCommand('git add readme.txt')).exitCode).toBe(0);
+      expect((await shell.executeCommand('git commit -m initial')).exitCode).toBe(0);
+      expect((await shell.executeCommand('git branch feature')).exitCode).toBe(0);
+
+      const checkoutResult = await shell.executeCommand('git checkout feature');
+      expect(checkoutResult.exitCode).toBe(0);
+      expect(checkoutResult.stdout).toContain("Switched to branch 'feature'");
+      expect(flushSpy).toHaveBeenCalledTimes(2);
+      expect(approvalRequests).toHaveLength(0);
+    } finally {
+      cloneSpy.mockRestore();
+      listFilesSpy.mockRestore();
+      await vfs.dispose();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Fix the clone/checkout failure caused by `GitCommands` calling `fs.flush()` through the production `SudoFS` → `RestrictedFS` wrapper chain, where `RestrictedFS` did not expose the underlying `VirtualFS.flush()` method.
- Delegate backend metadata flushing through `RestrictedFS` without adding a path-selected write or sudo approval.
- Add a production-shape regression covering clone and checkout through `SudoFS` + `RestrictedFS`, including the no-approval behavior.
- Preserve the intentional depth-1, single-branch clone defaults; `--branch` selects another branch and `--no-single-branch` fetches additional refs.
- Document optimized clone ref behavior and the explicit fetch/checkout workflow.

## Verification
- Focused GitCommands suite: 228/228 tests passed.
- `npm run verify`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- `npm run typecheck`
- `npm run test`
- `npm run test:coverage`
- `npm run build`
- `npm run build -w @slicc/chrome-extension`
- `npm run bundle-size`

All required gates passed and the working tree remained clean.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author