### PR TITLE
fix(webapp): reconcile in-memory VFS kind corruption in-session (#2006)

### DIFF
--- a/packages/webapp/src/fs/kind-reconcile.ts
+++ b/packages/webapp/src/fs/kind-reconcile.ts
@@ -65,10 +65,16 @@ function modeOf(entry: unknown): number | undefined {
 }
 
 /**
- * Find dirty paths whose kind in the realm's own index DISAGREES with the
- * on-disk sidecar record — the candidates for propagating in-memory
- * corruption onto a correct sidecar (#2006 direction 2). Pure; the caller
- * probes OPFS for each candidate and drops the ones where memory is the liar.
+ * Find paths the sidecar merge would overlay from the realm's own index whose
+ * kind DISAGREES with the on-disk record — the candidates for propagating
+ * in-memory corruption onto a correct sidecar (#2006 direction 2). Pure; the
+ * caller probes OPFS for each candidate and restores the on-disk record for
+ * the ones where memory is the liar (or where reality cannot be verified).
+ *
+ * Covers BOTH overlay sources of `mergeSidecarEntries`: explicit dirty paths
+ * AND every own-index entry under a dirty prefix — a rename's subtree marks
+ * overlay entries the paths set never names, so auditing `dirty.paths` alone
+ * lets a poisoned descendant bypass the probe entirely.
  *
  * Only paths present on BOTH sides can flip; adds and deletes are not kind
  * conflicts.
@@ -76,10 +82,22 @@ function modeOf(entry: unknown): number | undefined {
 export function findDirtyKindFlips(
   own: { entries?: { [path: string]: unknown } },
   onDisk: { entries?: { [path: string]: unknown } },
-  dirtyPaths: ReadonlySet<string>
+  dirtyPaths: ReadonlySet<string>,
+  dirtyPrefixes: ReadonlySet<string> = new Set()
 ): DirtyKindFlip[] {
+  const candidates = new Set<string>(dirtyPaths);
+  if (dirtyPrefixes.size > 0) {
+    for (const path of Object.keys(own.entries ?? {})) {
+      for (const prefix of dirtyPrefixes) {
+        if (path === prefix || path.startsWith(`${prefix}/`)) {
+          candidates.add(path);
+          break;
+        }
+      }
+    }
+  }
   const flips: DirtyKindFlip[] = [];
-  for (const path of dirtyPaths) {
+  for (const path of candidates) {
     const ownEntry = own.entries?.[path];
     const diskEntry = onDisk.entries?.[path];
     if (!ownEntry || !diskEntry) continue;

--- a/packages/webapp/src/fs/kind-reconcile.ts
+++ b/packages/webapp/src/fs/kind-reconcile.ts
@@ -1,0 +1,93 @@
+/**
+ * `kind-reconcile.ts` — pure decision logic for in-session VFS kind-mismatch
+ * recovery (#2006).
+ *
+ * The in-memory ZenFS index is authoritative at runtime and never re-reads
+ * the on-disk sidecar, so an entry whose kind (file vs directory) diverges
+ * from OPFS reality poisons every read for the rest of the session:
+ * `readFile` on a genuine file throws `EISDIR`, repairs to the on-disk
+ * sidecar are invisible until reload, and agents loop on repairs that can
+ * never take effect. Production incident 2026-08-08: `/workspace/CLAUDE.md`
+ * (a real 16 KB file, clean on disk AND in the sidecar) read as a directory
+ * for hours.
+ *
+ * The decisions live here, pure and unit-testable; `VirtualFS` wires them to
+ * the real index, handle cache, and OPFS probe (`makeOpfsProbe`).
+ */
+
+import type { SidecarProbeResult } from './sidecar-repair.js';
+
+const S_IFMT = 0o170000;
+const S_IFDIR = 0o40000;
+
+/** What the in-memory layer believes a path is. */
+export type MemoryKind = 'file' | 'directory' | 'absent';
+
+/** Classify a ZenFS inode `mode` into a {@link MemoryKind}. */
+export function memoryKindOfMode(mode: number | undefined): MemoryKind {
+  if (mode === undefined) return 'absent';
+  return (mode & S_IFMT) === S_IFDIR ? 'directory' : 'file';
+}
+
+/**
+ * Should the in-memory entry be evicted so the next access re-reads OPFS
+ * reality?
+ *
+ * Heal only when memory HOLDS something and reality disagrees:
+ *
+ * - memory `directory`, reality `file` (the incident) → heal
+ * - memory `file`, reality `directory` → heal
+ * - memory holds an entry, reality `missing` → heal (stale entry)
+ * - memory agrees with reality → the error was genuine (e.g. actually
+ *   reading a directory); do NOT heal, do NOT retry — that would loop.
+ * - memory `absent` → nothing to evict; the error came from elsewhere.
+ */
+export function shouldReconcileKind(truth: SidecarProbeResult, memory: MemoryKind): boolean {
+  if (memory === 'absent') return false;
+  if (truth.kind === 'missing') return true;
+  return truth.kind !== memory;
+}
+
+/** One dirty sidecar entry whose kind flipped between memory and disk. */
+export interface DirtyKindFlip {
+  path: string;
+  /** What this realm's in-memory index wants to persist. */
+  ownIsDirectory: boolean;
+}
+
+/**
+ * Read an entry's `mode` from the sidecar's untyped entry value
+ * (`Inode.toJSON()` — `sidecar-merge.ts` keeps entries opaque on purpose).
+ */
+function modeOf(entry: unknown): number | undefined {
+  const mode = (entry as { mode?: unknown } | null)?.mode;
+  return typeof mode === 'number' ? mode : undefined;
+}
+
+/**
+ * Find dirty paths whose kind in the realm's own index DISAGREES with the
+ * on-disk sidecar record — the candidates for propagating in-memory
+ * corruption onto a correct sidecar (#2006 direction 2). Pure; the caller
+ * probes OPFS for each candidate and drops the ones where memory is the liar.
+ *
+ * Only paths present on BOTH sides can flip; adds and deletes are not kind
+ * conflicts.
+ */
+export function findDirtyKindFlips(
+  own: { entries?: { [path: string]: unknown } },
+  onDisk: { entries?: { [path: string]: unknown } },
+  dirtyPaths: ReadonlySet<string>
+): DirtyKindFlip[] {
+  const flips: DirtyKindFlip[] = [];
+  for (const path of dirtyPaths) {
+    const ownEntry = own.entries?.[path];
+    const diskEntry = onDisk.entries?.[path];
+    if (!ownEntry || !diskEntry) continue;
+    const ownKind = memoryKindOfMode(modeOf(ownEntry));
+    const diskKind = memoryKindOfMode(modeOf(diskEntry));
+    if (ownKind !== diskKind) {
+      flips.push({ path, ownIsDirectory: ownKind === 'directory' });
+    }
+  }
+  return flips;
+}

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -17,6 +17,7 @@
 
 import { convertError, rebrandFsError } from './error-rebrand.js';
 import type { FsWatcher } from './fs-watcher.js';
+import { findDirtyKindFlips, memoryKindOfMode, shouldReconcileKind } from './kind-reconcile.js';
 import type { MountBackend, RefreshReport } from './mount/backend.js';
 import { LocalMountBackend } from './mount/backend-local.js';
 import { MountIndex, type MountIndexEnv, resolveMountIndexLimits } from './mount-index.js';
@@ -34,6 +35,7 @@ import {
   type SidecarIndexJson,
   stripSidecarSelfEntry,
 } from './sidecar-merge.js';
+import { makeOpfsProbe } from './sidecar-repair.js';
 import { MAX_SYMLINK_DEPTH, realpath, resolveSymlinks } from './symlink-resolver.js';
 import type {
   DirEntry,
@@ -770,7 +772,10 @@ export class VirtualFS {
       } catch {
         /* absent or unreadable → full own snapshot below (seed/recovery) */
       }
-      if (onDisk) merged = mergeSidecarEntries(onDisk, own, dirty);
+      if (onDisk) {
+        const effectiveDirty = await this.auditDirtyKindFlips(own, onDisk, dirty, handle);
+        merged = mergeSidecarEntries(onDisk, own, effectiveDirty);
+      }
     }
     // `merged` is the raw ZenFS index (`own`) whenever the merge is skipped —
     // no dirty state, or an absent/unreadable on-disk sidecar (seed/recovery).
@@ -788,6 +793,49 @@ export class VirtualFS {
       dirty.paths.clear();
       dirty.prefixes.clear();
     }
+  }
+
+  /**
+   * Fail-closed guard for the sidecar flush (#2006 direction 2): a dirty path
+   * whose kind in this realm's index DISAGREES with the on-disk record may be
+   * in-memory corruption about to clobber a correct sidecar. Probe OPFS for
+   * just those paths; when reality sides with the disk, keep the on-disk
+   * record for this flush and evict the lying in-memory entry so the next
+   * access re-reads truth. A flip reality agrees with (a genuine
+   * replace-file-with-directory) merges as before.
+   */
+  private async auditDirtyKindFlips(
+    own: SidecarIndexJson,
+    onDisk: SidecarIndexJson,
+    dirty: SidecarDirtyState,
+    handle: FileSystemDirectoryHandle
+  ): Promise<SidecarDirtyState> {
+    const flips = findDirtyKindFlips(own, onDisk, dirty.paths);
+    if (flips.length === 0) return dirty;
+    const probe = makeOpfsProbe(handle);
+    const poisoned = new Set<string>();
+    const backendFs = this.opfsBackendFs as unknown as {
+      index?: Map<string, unknown>;
+      _handles?: Map<string, unknown>;
+    } | null;
+    for (const flip of flips) {
+      const truth = await probe(flip.path).catch(() => null);
+      if (!truth || truth.kind === 'missing') continue;
+      if ((truth.kind === 'directory') !== flip.ownIsDirectory) {
+        poisoned.add(flip.path);
+        backendFs?.index?.delete(flip.path);
+        backendFs?._handles?.delete(flip.path);
+        console.warn(
+          '[virtual-fs] refused to flush in-memory kind flip over correct sidecar (#2006)',
+          { path: flip.path, reality: truth.kind }
+        );
+      }
+    }
+    if (poisoned.size === 0) return dirty;
+    return {
+      paths: new Set([...dirty.paths].filter((p) => !poisoned.has(p))),
+      prefixes: dirty.prefixes,
+    };
   }
 
   /**
@@ -836,6 +884,102 @@ export class VirtualFS {
       // whatever the sidecar recorded before the external writer ran.
       this.markSidecarDirty(path);
     }
+  }
+
+  /**
+   * Retry `op` ONCE when it fails with a kind mismatch (`EISDIR`/`ENOTDIR`)
+   * that {@link reconcileKindMismatch} confirms is in-memory corruption
+   * rather than a genuine error (#2006). A genuine mismatch — really reading
+   * a directory as a file — reconciles nothing and rethrows immediately, so
+   * this can never loop.
+   */
+  private async withKindMismatchRetry<T>(path: string, op: () => Promise<T>): Promise<T> {
+    try {
+      return await op();
+    } catch (err) {
+      const code = (err as { code?: string } | null)?.code;
+      if (code !== 'EISDIR' && code !== 'ENOTDIR') throw err;
+      const healed = await this.reconcileKindMismatch(path).catch(() => false);
+      if (!healed) throw err;
+      return await op();
+    }
+  }
+
+  /**
+   * In-session heal for an in-memory index entry whose kind disagrees with
+   * OPFS reality (#2006).
+   *
+   * The in-memory ZenFS index is authoritative at runtime and never re-reads
+   * the on-disk sidecar — so once an entry's kind flips (a real file held as
+   * a directory), every read fails `EISDIR` for the rest of the session and
+   * on-disk repairs are invisible until reload. Production incident
+   * 2026-08-08: the cone looped for hours on `/workspace/CLAUDE.md`, a
+   * genuine file, clean on disk and in the sidecar.
+   *
+   * Probes OPFS reality for the single path (same probe the boot-time
+   * `sidecar-repair.ts` uses) and, when memory disagrees, evicts the index
+   * entry and cached handle — the identical mechanism `invalidatePaths`
+   * already uses for external writers — so the next access re-reads truth.
+   * When memory wrongly held a DIRECTORY, its phantom children are evicted
+   * too. Returns whether anything was healed; `false` means the error was
+   * genuine and must propagate.
+   */
+  private async reconcileKindMismatch(rawPath: string): Promise<boolean> {
+    if (this.backend !== 'opfs') return false;
+    const backendFs = this.opfsBackendFs as unknown as {
+      index?: Map<string, { mode?: number }>;
+      // Private field on @zenfs/dom WebAccessFS — pinned at v1.2.9 (same
+      // caveat as `invalidatePaths`).
+      _handles?: Map<string, { kind?: string }>;
+    } | null;
+    const handle = this.opfsHandle;
+    if (!backendFs?.index || !handle) return false;
+    const normalized = normalizePath(rawPath);
+    // Heal the resolved node (the index key) when resolution works; the
+    // corrupt entry itself may make resolution throw — fall back to the
+    // normalized path.
+    let target = normalized;
+    try {
+      target = await this.resolveSymlinks(normalized);
+    } catch {
+      /* keep normalized */
+    }
+    const truth = await makeOpfsProbe(handle)(target);
+    const indexKind = memoryKindOfMode(backendFs.index.get(target)?.mode);
+    const cachedHandle = backendFs._handles?.get(target);
+    const cachedKind: ReturnType<typeof memoryKindOfMode> =
+      cachedHandle?.kind === 'directory'
+        ? 'directory'
+        : cachedHandle?.kind === 'file'
+          ? 'file'
+          : 'absent';
+    const indexLies = shouldReconcileKind(truth, indexKind);
+    const handleLies = shouldReconcileKind(truth, cachedKind);
+    if (!indexLies && !handleLies) return false;
+
+    backendFs.index.delete(target);
+    backendFs._handles?.delete(target);
+    // A phantom directory may have accumulated phantom children.
+    if (indexKind === 'directory' || cachedKind === 'directory') {
+      const prefix = `${target}/`;
+      for (const key of [...backendFs.index.keys()]) {
+        if (key.startsWith(prefix)) backendFs.index.delete(key);
+      }
+      if (backendFs._handles) {
+        for (const key of [...backendFs._handles.keys()]) {
+          if (key.startsWith(prefix)) backendFs._handles.delete(key);
+        }
+      }
+    }
+    // Let the next sidecar flush persist the freshly re-read (correct) entry.
+    this.markSidecarDirty(target);
+    console.warn('[virtual-fs] reconciled in-memory kind mismatch (#2006)', {
+      path: target,
+      reality: truth.kind,
+      indexHeld: indexKind,
+      handleHeld: cachedKind,
+    });
+    return true;
   }
 
   /**
@@ -1351,6 +1495,10 @@ export class VirtualFS {
    * @throws FsError ENOENT if file doesn't exist, EISDIR if path is a directory
    */
   async readFile(path: string, options?: ReadFileOptions): Promise<FileContent> {
+    return this.withKindMismatchRetry(path, () => this.readFileInner(path, options));
+  }
+
+  private async readFileInner(path: string, options?: ReadFileOptions): Promise<FileContent> {
     const normalized = normalizePath(path);
     const mount = this.findMount(normalized);
     if (mount) {
@@ -1384,6 +1532,14 @@ export class VirtualFS {
    * @throws FsError EISDIR if path is an existing directory
    */
   async writeFile(
+    path: string,
+    content: FileContent,
+    _options?: { recursive?: boolean }
+  ): Promise<void> {
+    return this.withKindMismatchRetry(path, () => this.writeFileInner(path, content, _options));
+  }
+
+  private async writeFileInner(
     path: string,
     content: FileContent,
     _options?: { recursive?: boolean }
@@ -1548,6 +1704,10 @@ export class VirtualFS {
 
   /** readDir implementation for local (non-mounted) paths. */
   private async readDirLocal(normalized: string): Promise<DirEntry[]> {
+    return this.withKindMismatchRetry(normalized, () => this.readDirLocalInner(normalized));
+  }
+
+  private async readDirLocalInner(normalized: string): Promise<DirEntry[]> {
     const resolved = await this.resolveSymlinks(normalized);
     try {
       const names = await this.lfs.readdir(resolved);
@@ -1789,6 +1949,10 @@ export class VirtualFS {
    * @throws FsError ENOENT if path doesn't exist
    */
   async stat(path: string): Promise<Stats> {
+    return this.withKindMismatchRetry(path, () => this.statInner(path));
+  }
+
+  private async statInner(path: string): Promise<Stats> {
     const normalized = normalizePath(path);
     const mount = this.findMount(normalized);
     if (mount) {

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -773,8 +773,8 @@ export class VirtualFS {
         /* absent or unreadable → full own snapshot below (seed/recovery) */
       }
       if (onDisk) {
-        const effectiveDirty = await this.auditDirtyKindFlips(own, onDisk, dirty, handle);
-        merged = mergeSidecarEntries(onDisk, own, effectiveDirty);
+        await this.auditDirtyKindFlips(own, onDisk, dirty, handle);
+        merged = mergeSidecarEntries(onDisk, own, dirty);
       }
     }
     // `merged` is the raw ZenFS index (`own`) whenever the merge is skipped —
@@ -796,46 +796,58 @@ export class VirtualFS {
   }
 
   /**
-   * Fail-closed guard for the sidecar flush (#2006 direction 2): a dirty path
-   * whose kind in this realm's index DISAGREES with the on-disk record may be
-   * in-memory corruption about to clobber a correct sidecar. Probe OPFS for
-   * just those paths; when reality sides with the disk, keep the on-disk
-   * record for this flush and evict the lying in-memory entry so the next
-   * access re-reads truth. A flip reality agrees with (a genuine
-   * replace-file-with-directory) merges as before.
+   * Fail-closed guard for the sidecar flush (#2006 direction 2): any entry
+   * the merge would overlay from this realm's own index — an explicit dirty
+   * path OR an entry under a dirty prefix — whose kind DISAGREES with the
+   * on-disk record may be in-memory corruption about to clobber a correct
+   * sidecar. Probe OPFS for just those paths and RESTORE the on-disk record
+   * into the own snapshot when:
+   *
+   * - reality sides with the disk (memory is the liar) — also evict the
+   *   lying in-memory entry so the next access re-reads truth; or
+   * - reality cannot be verified (probe error, or the path is gone) — a
+   *   flip that cannot be confirmed must not overwrite the sidecar record;
+   *   the live index is left alone, and a genuinely deleted path heals via
+   *   ZenFS's own ENOENT fallback on the next access.
+   *
+   * A flip reality agrees with (a genuine replace-file-with-directory)
+   * merges as before. Restoring into `own` (rather than shrinking the dirty
+   * set) covers the prefix overlay too, which a paths-only exclusion cannot
+   * express.
    */
   private async auditDirtyKindFlips(
     own: SidecarIndexJson,
     onDisk: SidecarIndexJson,
     dirty: SidecarDirtyState,
     handle: FileSystemDirectoryHandle
-  ): Promise<SidecarDirtyState> {
-    const flips = findDirtyKindFlips(own, onDisk, dirty.paths);
-    if (flips.length === 0) return dirty;
+  ): Promise<void> {
+    const flips = findDirtyKindFlips(own, onDisk, dirty.paths, dirty.prefixes);
+    if (flips.length === 0) return;
     const probe = makeOpfsProbe(handle);
-    const poisoned = new Set<string>();
     const backendFs = this.opfsBackendFs as unknown as {
       index?: Map<string, unknown>;
       _handles?: Map<string, unknown>;
     } | null;
     for (const flip of flips) {
       const truth = await probe(flip.path).catch(() => null);
-      if (!truth || truth.kind === 'missing') continue;
-      if ((truth.kind === 'directory') !== flip.ownIsDirectory) {
-        poisoned.add(flip.path);
+      const verifiedOwnCorrect =
+        truth !== null &&
+        truth.kind !== 'missing' &&
+        (truth.kind === 'directory') === flip.ownIsDirectory;
+      if (verifiedOwnCorrect) continue;
+      // Keep the on-disk record for this flush.
+      const diskEntry = onDisk.entries?.[flip.path];
+      if (own.entries && diskEntry !== undefined) own.entries[flip.path] = diskEntry;
+      const contradicted = truth !== null && truth.kind !== 'missing';
+      if (contradicted) {
         backendFs?.index?.delete(flip.path);
         backendFs?._handles?.delete(flip.path);
-        console.warn(
-          '[virtual-fs] refused to flush in-memory kind flip over correct sidecar (#2006)',
-          { path: flip.path, reality: truth.kind }
-        );
       }
+      console.warn(
+        '[virtual-fs] refused to flush in-memory kind flip over sidecar record (#2006)',
+        { path: flip.path, reality: truth?.kind ?? 'unverifiable', evicted: contradicted }
+      );
     }
-    if (poisoned.size === 0) return dirty;
-    return {
-      paths: new Set([...dirty.paths].filter((p) => !poisoned.has(p))),
-      prefixes: dirty.prefixes,
-    };
   }
 
   /**

--- a/packages/webapp/tests/fs/kind-reconcile.test.ts
+++ b/packages/webapp/tests/fs/kind-reconcile.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findDirtyKindFlips,
+  memoryKindOfMode,
+  shouldReconcileKind,
+} from '../../src/fs/kind-reconcile.js';
+
+const S_IFDIR = 0o40000;
+const S_IFREG = 0o100000;
+
+describe('memoryKindOfMode', () => {
+  it('classifies directory and file format bits, and absence', () => {
+    expect(memoryKindOfMode(S_IFDIR | 0o755)).toBe('directory');
+    expect(memoryKindOfMode(S_IFREG | 0o644)).toBe('file');
+    expect(memoryKindOfMode(undefined)).toBe('absent');
+  });
+});
+
+describe('shouldReconcileKind', () => {
+  // The production incident: a genuine file held in memory as a directory.
+  it('heals a memory directory over a real file (the #2006 incident)', () => {
+    expect(shouldReconcileKind({ kind: 'file', size: 16249 }, 'directory')).toBe(true);
+  });
+
+  it('heals a memory file over a real directory', () => {
+    expect(shouldReconcileKind({ kind: 'directory' }, 'file')).toBe(true);
+  });
+
+  it('heals a memory entry whose path is gone from OPFS', () => {
+    expect(shouldReconcileKind({ kind: 'missing' }, 'file')).toBe(true);
+    expect(shouldReconcileKind({ kind: 'missing' }, 'directory')).toBe(true);
+  });
+
+  // The guard that prevents retry loops: agreement means the error was
+  // genuine (really reading a directory), so nothing is healed.
+  it('refuses to heal when memory agrees with reality', () => {
+    expect(shouldReconcileKind({ kind: 'directory' }, 'directory')).toBe(false);
+    expect(shouldReconcileKind({ kind: 'file', size: 1 }, 'file')).toBe(false);
+  });
+
+  it('refuses to heal when memory holds nothing', () => {
+    expect(shouldReconcileKind({ kind: 'file', size: 1 }, 'absent')).toBe(false);
+    expect(shouldReconcileKind({ kind: 'missing' }, 'absent')).toBe(false);
+  });
+});
+
+describe('findDirtyKindFlips', () => {
+  const file = { mode: S_IFREG | 0o644 };
+  const dir = { mode: S_IFDIR | 0o755 };
+
+  it('finds a dirty path whose kind flipped between memory and disk', () => {
+    const flips = findDirtyKindFlips(
+      { entries: { '/workspace/CLAUDE.md': dir } },
+      { entries: { '/workspace/CLAUDE.md': file } },
+      new Set(['/workspace/CLAUDE.md'])
+    );
+    expect(flips).toEqual([{ path: '/workspace/CLAUDE.md', ownIsDirectory: true }]);
+  });
+
+  it('ignores same-kind dirty paths, adds, and deletes', () => {
+    const flips = findDirtyKindFlips(
+      { entries: { '/a': file, '/added': file } },
+      { entries: { '/a': file, '/deleted': file } },
+      new Set(['/a', '/added', '/deleted'])
+    );
+    expect(flips).toEqual([]);
+  });
+
+  it('only considers dirty paths, never the whole index', () => {
+    const flips = findDirtyKindFlips(
+      { entries: { '/clean-flip': dir, '/dirty-flip': dir } },
+      { entries: { '/clean-flip': file, '/dirty-flip': file } },
+      new Set(['/dirty-flip'])
+    );
+    expect(flips.map((f) => f.path)).toEqual(['/dirty-flip']);
+  });
+});

--- a/packages/webapp/tests/fs/kind-reconcile.test.ts
+++ b/packages/webapp/tests/fs/kind-reconcile.test.ts
@@ -66,6 +66,29 @@ describe('findDirtyKindFlips', () => {
     expect(flips).toEqual([]);
   });
 
+  // Review catch on #2135: a rename marks subtrees in dirty.prefixes, and the
+  // merge overlays every own entry beneath them — entries dirty.paths never
+  // names. The audit must see those too.
+  it('finds flips under dirty prefixes, not just explicit dirty paths', () => {
+    const flips = findDirtyKindFlips(
+      { entries: { '/renamed/child.md': dir, '/renamed/ok.md': file } },
+      { entries: { '/renamed/child.md': file, '/renamed/ok.md': file } },
+      new Set(),
+      new Set(['/renamed'])
+    );
+    expect(flips).toEqual([{ path: '/renamed/child.md', ownIsDirectory: true }]);
+  });
+
+  it('a prefix matches its own path and children, not lookalike siblings', () => {
+    const flips = findDirtyKindFlips(
+      { entries: { '/pre': dir, '/prefix-lookalike': dir } },
+      { entries: { '/pre': file, '/prefix-lookalike': file } },
+      new Set(),
+      new Set(['/pre'])
+    );
+    expect(flips.map((f) => f.path)).toEqual(['/pre']);
+  });
+
   it('only considers dirty paths, never the whole index', () => {
     const flips = findDirtyKindFlips(
       { entries: { '/clean-flip': dir, '/dirty-flip': dir } },

--- a/packages/webapp/tests/fs/virtual-fs.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs.test.ts
@@ -787,6 +787,109 @@ describe('sidecar flush guard against in-memory kind flips (#2006)', () => {
       await vfs.dispose();
     }
   });
+
+  // Review catches on #2135, both against the flush guard:
+  //  - a poisoned entry reached only via a dirty PREFIX must not bypass the
+  //    probe (rename subtree marks overlay entries dirty.paths never names);
+  //  - a flip whose probe reports missing/unreadable must be excluded from
+  //    the overlay rather than accepted (fail closed).
+  it('prefix-covered and unverifiable flips cannot overwrite the sidecar record', async () => {
+    const dbName = `test-2006-flush2-${Date.now()}`;
+    const vfs = await VirtualFS.create({ dbName, wipe: true });
+
+    const onDisk = {
+      version: 1,
+      entries: {
+        '/renamed/poisoned.md': { mode: S_IFREG | 0o644, size: 10 },
+        '/gone/unverifiable.md': { mode: S_IFREG | 0o644, size: 20 },
+      },
+    };
+    let written: string | null = null;
+    const metadataFile = {
+      kind: 'file',
+      getFile: async () => ({ text: async () => JSON.stringify(onDisk), size: 100 }),
+      createWritable: async () => ({
+        write: async (data: string) => {
+          written = data;
+        },
+        close: async () => {},
+      }),
+    };
+    // OPFS reality: /renamed/poisoned.md is a real FILE (memory lies);
+    // /gone is absent entirely (probe reports missing).
+    const opfsRoot = {
+      kind: 'directory',
+      getFileHandle: async (name: string) => {
+        if (name === '.metadata.json') return metadataFile;
+        throw new Error('TypeMismatch');
+      },
+      getDirectoryHandle: async (name: string) => {
+        if (name === 'renamed') {
+          return {
+            kind: 'directory',
+            getFileHandle: async (n: string) => {
+              if (n === 'poisoned.md') return { kind: 'file', getFile: async () => ({ size: 10 }) };
+              throw new Error('TypeMismatch');
+            },
+            getDirectoryHandle: async () => {
+              throw new Error('TypeMismatch');
+            },
+          };
+        }
+        throw new Error('TypeMismatch'); // '/gone' does not exist
+      },
+    };
+
+    const fakeIndex = new Map<string, { mode?: number }>([
+      ['/renamed/poisoned.md', { mode: S_IFDIR | 0o755 }],
+      ['/gone/unverifiable.md', { mode: S_IFDIR | 0o755 }],
+    ]);
+    const backendFs = {
+      index: Object.assign(fakeIndex, {
+        toJSON: () => ({ version: 1, entries: Object.fromEntries(fakeIndex) }),
+      }),
+      _handles: new Map<string, unknown>(),
+    };
+    const internal = vfs as unknown as {
+      backend: string;
+      opfsBackendFs: unknown;
+      opfsHandle: unknown;
+      writeOpfsMetadataSidecarUnlocked(): Promise<void>;
+    };
+    internal.backend = 'opfs';
+    internal.opfsBackendFs = backendFs;
+    internal.opfsHandle = opfsRoot;
+    const statics = VirtualFS as unknown as {
+      opfsBackends: Map<string, { backendFs: unknown; refs: number; sidecarDirty: unknown }>;
+    };
+    // Neither path is in dirty.paths — they are covered only by prefixes,
+    // exactly the overlay route the first review comment named.
+    statics.opfsBackends.set(dbName, {
+      backendFs,
+      refs: 1,
+      sidecarDirty: { paths: new Set(), prefixes: new Set(['/renamed', '/gone']) },
+    });
+
+    try {
+      await internal.writeOpfsMetadataSidecarUnlocked();
+      const flushed = JSON.parse(written as unknown as string) as {
+        entries: Record<string, { mode: number }>;
+      };
+      // Prefix-covered poison: reality sided with the disk — record survives,
+      // liar evicted.
+      expect(flushed.entries['/renamed/poisoned.md'].mode & 0o170000).toBe(S_IFREG);
+      expect(fakeIndex.has('/renamed/poisoned.md')).toBe(false);
+      // Unverifiable flip: on-disk record survives, but the live index is
+      // NOT evicted on an unverified probe.
+      expect(flushed.entries['/gone/unverifiable.md'].mode & 0o170000).toBe(S_IFREG);
+      expect(fakeIndex.has('/gone/unverifiable.md')).toBe(true);
+    } finally {
+      statics.opfsBackends.delete(dbName);
+      internal.backend = 'memory';
+      internal.opfsBackendFs = null;
+      await vfs.dispose();
+    }
+  });
 });
 
 describe('writeFile truncation (shrinking rewrites)', () => {

--- a/packages/webapp/tests/fs/virtual-fs.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs.test.ts
@@ -533,6 +533,262 @@ describe('VirtualFS', () => {
   });
 });
 
+describe('in-session kind-mismatch reconcile (#2006)', () => {
+  const S_IFDIR = 0o40000;
+  const S_IFREG = 0o100000;
+
+  /** A fake OPFS directory handle tree the probe can walk. */
+  function fakeDirHandle(children: Record<string, unknown>): unknown {
+    return {
+      kind: 'directory',
+      getDirectoryHandle: async (name: string) => {
+        const child = children[name] as { kind?: string } | undefined;
+        if (child?.kind !== 'directory') throw new Error('TypeMismatch');
+        return child;
+      },
+      getFileHandle: async (name: string) => {
+        const child = children[name] as { kind?: string } | undefined;
+        if (child?.kind !== 'file') throw new Error('TypeMismatch');
+        return child;
+      },
+    };
+  }
+  const fakeFileHandle = (size = 5): unknown => ({ kind: 'file', getFile: async () => ({ size }) });
+
+  /** Detach the injected fakes so dispose()'s sidecar flush stays a no-op. */
+  function detachFakes(vfs: VirtualFS): void {
+    const internal = vfs as unknown as { backend: string; opfsBackendFs: unknown };
+    internal.backend = 'memory';
+    internal.opfsBackendFs = null;
+  }
+
+  type Wrapped = {
+    withKindMismatchRetry<T>(path: string, op: () => Promise<T>): Promise<T>;
+  };
+
+  async function corruptedVfs() {
+    const vfs = await VirtualFS.create({ dbName: `test-2006-${Date.now()}`, wipe: true });
+    // OPFS reality: a genuine file — what the probe sees. Memory: a directory.
+    const opfsRoot = fakeDirHandle({
+      workspace: fakeDirHandle({ 'CLAUDE.md': fakeFileHandle(16249) }),
+    });
+    const fakeIndex = new Map<string, { mode?: number }>([
+      ['/workspace/CLAUDE.md', { mode: S_IFDIR | 0o755 }],
+      ['/workspace/CLAUDE.md/phantom-child.txt', { mode: S_IFREG | 0o644 }],
+      ['/workspace/keep.txt', { mode: S_IFREG | 0o644 }],
+    ]);
+    const fakeHandles = new Map<string, { kind?: string }>([
+      ['/workspace/CLAUDE.md', { kind: 'directory' }],
+      ['/workspace/keep.txt', { kind: 'file' }],
+    ]);
+    const internal = vfs as unknown as {
+      backend: string;
+      opfsBackendFs: unknown;
+      opfsHandle: unknown;
+    };
+    internal.backend = 'opfs';
+    internal.opfsBackendFs = { index: fakeIndex, _handles: fakeHandles };
+    internal.opfsHandle = opfsRoot;
+    return { vfs, fakeIndex, fakeHandles };
+  }
+
+  // The acceptance case: an in-memory kind that disagrees with the backing
+  // store reconciles in-session — the retried read succeeds, no reload.
+  it('a poisoned EISDIR read heals the index and the single retry succeeds', async () => {
+    const { vfs, fakeIndex, fakeHandles } = await corruptedVfs();
+    let calls = 0;
+    const op = async (): Promise<string> => {
+      calls += 1;
+      // First attempt: ZenFS serves the poisoned index -> EISDIR. After the
+      // eviction the retry re-reads OPFS truth and succeeds.
+      if (fakeIndex.has('/workspace/CLAUDE.md')) {
+        throw new FsError('EISDIR', 'is a directory', '/workspace/CLAUDE.md');
+      }
+      return 'real content';
+    };
+
+    const result = await (vfs as unknown as Wrapped).withKindMismatchRetry(
+      '/workspace/CLAUDE.md',
+      op
+    );
+    expect(result).toBe('real content');
+    expect(calls).toBe(2); // one failure, one retry — never a loop
+    expect(fakeIndex.has('/workspace/CLAUDE.md')).toBe(false);
+    expect(fakeHandles.has('/workspace/CLAUDE.md')).toBe(false);
+    // Phantom children of the phantom directory are evicted with it.
+    expect(fakeIndex.has('/workspace/CLAUDE.md/phantom-child.txt')).toBe(false);
+    // Innocent bystanders are untouched.
+    expect(fakeIndex.has('/workspace/keep.txt')).toBe(true);
+    expect(fakeHandles.has('/workspace/keep.txt')).toBe(true);
+    detachFakes(vfs);
+    await vfs.dispose();
+  });
+
+  it('a genuine EISDIR (reality agrees) reconciles nothing and does not retry', async () => {
+    const vfs = await VirtualFS.create({ dbName: `test-2006b-${Date.now()}`, wipe: true });
+    const fakeIndex = new Map<string, { mode?: number }>([
+      ['/workspace/real-dir', { mode: S_IFDIR | 0o755 }],
+    ]);
+    const internal = vfs as unknown as {
+      backend: string;
+      opfsBackendFs: unknown;
+      opfsHandle: unknown;
+    };
+    internal.backend = 'opfs';
+    internal.opfsBackendFs = { index: fakeIndex, _handles: new Map() };
+    internal.opfsHandle = fakeDirHandle({
+      workspace: fakeDirHandle({ 'real-dir': fakeDirHandle({}) }),
+    });
+
+    let calls = 0;
+    const op = async (): Promise<string> => {
+      calls += 1;
+      throw new FsError('EISDIR', 'is a directory', '/workspace/real-dir');
+    };
+    await expect(
+      (vfs as unknown as Wrapped).withKindMismatchRetry('/workspace/real-dir', op)
+    ).rejects.toMatchObject({ code: 'EISDIR' });
+    expect(calls).toBe(1); // no retry: memory agreed with reality
+    expect(fakeIndex.has('/workspace/real-dir')).toBe(true);
+    detachFakes(vfs);
+    await vfs.dispose();
+  });
+
+  it('non-kind errors pass through untouched, without probing', async () => {
+    const { vfs, fakeIndex } = await corruptedVfs();
+    let calls = 0;
+    const op = async (): Promise<string> => {
+      calls += 1;
+      throw new FsError('ENOENT', 'no such file', '/workspace/CLAUDE.md');
+    };
+    await expect(
+      (vfs as unknown as Wrapped).withKindMismatchRetry('/workspace/CLAUDE.md', op)
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(calls).toBe(1);
+    expect(fakeIndex.has('/workspace/CLAUDE.md')).toBe(true); // untouched
+    detachFakes(vfs);
+    await vfs.dispose();
+  });
+
+  it('the memory backend never reconciles (no OPFS to probe)', async () => {
+    const vfs = await VirtualFS.create({ dbName: `test-2006c-${Date.now()}`, wipe: true });
+    let calls = 0;
+    const op = async (): Promise<string> => {
+      calls += 1;
+      throw new FsError('EISDIR', 'is a directory', '/d');
+    };
+    await expect((vfs as unknown as Wrapped).withKindMismatchRetry('/d', op)).rejects.toMatchObject(
+      { code: 'EISDIR' }
+    );
+    expect(calls).toBe(1);
+    await vfs.dispose();
+  });
+});
+
+describe('sidecar flush guard against in-memory kind flips (#2006)', () => {
+  const S_IFDIR = 0o40000;
+  const S_IFREG = 0o100000;
+
+  it('a write cannot propagate a lying in-memory kind onto a correct sidecar', async () => {
+    const dbName = `test-2006-flush-${Date.now()}`;
+    const vfs = await VirtualFS.create({ dbName, wipe: true });
+
+    // On disk: the CORRECT sidecar — CLAUDE.md is a file.
+    const onDisk = {
+      version: 1,
+      entries: {
+        '/workspace/CLAUDE.md': { mode: S_IFREG | 0o644, size: 16249 },
+      },
+    };
+    let written: string | null = null;
+    const metadataFile = {
+      kind: 'file',
+      getFile: async () => ({ text: async () => JSON.stringify(onDisk), size: 100 }),
+      createWritable: async () => ({
+        write: async (data: string) => {
+          written = data;
+        },
+        close: async () => {},
+      }),
+    };
+    // OPFS reality: CLAUDE.md is a real file (sides with the disk record).
+    const opfsRoot = {
+      kind: 'directory',
+      getFileHandle: async (name: string) => {
+        if (name === '.metadata.json') return metadataFile;
+        throw new Error('TypeMismatch');
+      },
+      getDirectoryHandle: async (name: string) => {
+        if (name === 'workspace') {
+          return {
+            kind: 'directory',
+            getFileHandle: async (n: string) => {
+              if (n === 'CLAUDE.md')
+                return { kind: 'file', getFile: async () => ({ size: 16249 }) };
+              throw new Error('TypeMismatch');
+            },
+            getDirectoryHandle: async () => {
+              throw new Error('TypeMismatch');
+            },
+          };
+        }
+        throw new Error('TypeMismatch');
+      },
+    };
+
+    // In memory: the POISONED index wants to persist CLAUDE.md as a directory.
+    const fakeIndex = new Map<string, { mode?: number }>([
+      ['/workspace/CLAUDE.md', { mode: S_IFDIR | 0o755 }],
+    ]);
+    const backendFs = {
+      index: Object.assign(fakeIndex, {
+        toJSON: () => ({
+          version: 1,
+          entries: Object.fromEntries(fakeIndex),
+        }),
+      }),
+      _handles: new Map<string, unknown>([['/workspace/CLAUDE.md', { kind: 'directory' }]]),
+    };
+    const internal = vfs as unknown as {
+      backend: string;
+      opfsBackendFs: unknown;
+      opfsHandle: unknown;
+      writeOpfsMetadataSidecarUnlocked(): Promise<void>;
+    };
+    internal.backend = 'opfs';
+    internal.opfsBackendFs = backendFs;
+    internal.opfsHandle = opfsRoot;
+    // The realm marked the flipped path dirty (the re-corruption window).
+    const statics = VirtualFS as unknown as {
+      opfsBackends: Map<string, { backendFs: unknown; refs: number; sidecarDirty: unknown }>;
+    };
+    statics.opfsBackends.set(dbName, {
+      backendFs,
+      refs: 1,
+      sidecarDirty: { paths: new Set(['/workspace/CLAUDE.md']), prefixes: new Set() },
+    });
+
+    try {
+      await internal.writeOpfsMetadataSidecarUnlocked();
+
+      expect(written).not.toBeNull();
+      const flushed = JSON.parse(written as unknown as string) as {
+        entries: Record<string, { mode: number }>;
+      };
+      // The on-disk (correct) kind survived the flush…
+      expect(flushed.entries['/workspace/CLAUDE.md'].mode & 0o170000).toBe(S_IFREG);
+      // …and the lying in-memory entry was evicted so the next access re-reads truth.
+      expect(fakeIndex.has('/workspace/CLAUDE.md')).toBe(false);
+      expect(backendFs._handles.has('/workspace/CLAUDE.md')).toBe(false);
+    } finally {
+      statics.opfsBackends.delete(dbName);
+      internal.backend = 'memory';
+      internal.opfsBackendFs = null;
+      await vfs.dispose();
+    }
+  });
+});
+
 describe('writeFile truncation (shrinking rewrites)', () => {
   it('a shorter rewrite must not leave the previous tail behind', async () => {
     // ZenFS' OPFS backend writes at offset 0 without truncating; the


### PR DESCRIPTION
Fixes #2006.

## Summary

The in-memory ZenFS index is authoritative at runtime and never re-reads the on-disk sidecar. Once an entry's kind flips — a genuine file held as a directory — every read fails `EISDIR` for the rest of the session, on-disk repairs are invisible until reload, and agents burn turns looping on repairs that can never take effect. This implements the issue's directions 1 and 2: **in-session detection + single-path self-heal**, and a **fail-closed flush guard** so the corruption cannot propagate back onto a correct sidecar.

Production incident (2026-08-08, from the issue): the cone looped for hours on `/workspace/CLAUDE.md` — a real 16 KB file, clean on disk *and* in the sidecar — because only the in-memory index held it as a directory. This corruption class is still being hit.

## Approach

**Direction 1 — reconcile on the failing read.** `readFile` / `writeFile` / `stat` / `readDir` route through `withKindMismatchRetry`: on `EISDIR`/`ENOTDIR`,

1. probe OPFS reality for that one path — `makeOpfsProbe`, the same probe boot-time `sidecar-repair.ts` trusts;
2. compare against what memory holds (both the index inode's format bits *and* the cached `FileSystemHandle`'s kind — either can lie independently);
3. if memory disagrees with reality: evict the index entry + cached handle (the identical mechanism `invalidatePaths` already uses for external writers), plus any phantom children when memory wrongly held a directory, mark the path sidecar-dirty, and **retry once** — the retried read re-materializes truth from OPFS;
4. if memory *agrees* with reality, the error was genuine (really reading a directory): heal nothing, rethrow immediately — **the retry cannot loop by construction**.

**Direction 2 — the flush guard.** Before `mergeSidecarEntries`, dirty paths whose kind in the realm's own index disagrees with the on-disk record (`findDirtyKindFlips`, pure) are probed; when reality sides with the disk, the on-disk record is kept for that flush and the lying in-memory entry is evicted. A flip reality agrees with — a genuine replace-file-with-directory — merges exactly as before. This closes the issue's re-corruption window: a poisoned index can no longer clobber the sidecar a scoop just repaired.

**Deliberately not here — direction 3** (the "reload to recover" UI affordance). With 1+2, a reload should no longer be *needed* for this corruption class; a UI surface is a separate change with a different review audience. The `console.warn` breadcrumbs (`reconciled in-memory kind mismatch (#2006)`) are the observability hook until then.

## Design notes

- Decisions are pure and live in the new `fs/kind-reconcile.ts` (`shouldReconcileKind`, `findDirtyKindFlips`, `memoryKindOfMode`) — unit-tested as a matrix, no fakes needed.
- The heal is **eviction, not mutation**: rather than patching mode bits in place (and guessing sizes/times), the entry is dropped so ZenFS's own ENOENT fallback re-reads OPFS. Same trust chain as boot repair: reality wins, and only reality is consulted.
- Symlinks: the heal targets the resolved node (the index key) when resolution works; resolution failing on the corrupt entry itself falls back to the normalized path.
- `_handles` is a pinned private field of `@zenfs/dom` v1.2.9 with the same no-op-if-removed caveat `invalidatePaths` already documents.
- The probe runs only on the *failure* path (and only for kind-mismatch codes), so healthy reads pay nothing; the flush guard probes only *flipped dirty* paths, typically zero.

## Test plan

- [x] `npx vitest run packages/webapp/tests/fs/` — **560 passing** (was 547): 9 pure decision/flip tests + 4 wrapper tests + the flush-guard test
- [x] **All five behavioral tests verified failing against `origin/main`** before the fix was restored
- [x] Acceptance criterion 1: *seeded in-memory kind disagreeing with the backing store → the runtime read reconciles and the single retry **succeeds*** (`a poisoned EISDIR read heals the index and the single retry succeeds`)
- [x] Acceptance criterion 2: *a VFS write cannot propagate a lying in-memory kind onto the sidecar* (`a write cannot propagate a lying in-memory kind onto a correct sidecar` — asserts the flushed JSON keeps the on-disk kind AND the in-memory liar is evicted)
- [x] Loop-safety pinned: genuine `EISDIR` (reality agrees) → no heal, exactly one attempt; non-kind errors pass through without probing; memory backend never reconciles
- [x] `npm run verify` 7/7 · `npm run typecheck` clean · `check-touched-exemptions` OK (new file uses index signatures, not `Record<string, unknown>` — the ratchet catches new files too) · `npm run test` 14231 passing

**Pre-existing failures, unrelated:** the two `biome-command.test.ts` version-pin tests (`2.5.7` vs `2.5.6`), failing all week on every branch.

## Risk & rollback

The retry path activates only on `EISDIR`/`ENOTDIR` from OPFS-backed local paths, and only when an OPFS probe contradicts memory — healthy instances never enter it. The flush guard can at worst *keep* an on-disk record for one flush (the failure mode it replaces was clobbering it). Revert restores today's behaviour: corruption persists until reload.
