### PR TITLE
Refactor kernel facade projections

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -63,7 +63,6 @@
   "packages/webapp/src/git/commands/symbolic-ref.ts": 2,
   "packages/webapp/src/kernel/cdp-bridge.ts": 7,
   "packages/webapp/src/kernel/cdp-worker-proxy.ts": 3,
-  "packages/webapp/src/kernel/facade.ts": 3,
   "packages/webapp/src/kernel/host.ts": 6,
   "packages/webapp/src/kernel/kernel-worker.ts": 2,
   "packages/webapp/src/kernel/messages.ts": 5,

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -24,13 +24,13 @@ import {
   capTranscriptToolResultForBuffer,
   capTranscriptToolResultForEvent,
 } from '../scoops/transcript-limits.js';
-import { getFollowerTrayRuntimeStatus } from '../scoops/tray-follower-status.js';
 import type { FollowerSyncManager } from '../scoops/tray-follower-sync.js';
-import { getLeaderTrayRuntimeStatus } from '../scoops/tray-leader.js';
 import type { ChannelMessage, RegisteredScoop, ScoopTabState } from '../scoops/types.js';
 import { TOOL_UI_MOUNTED_ACTION, toolUIRegistry } from '../tools/tool-ui.js';
+import { AgentEventStream } from './facade/agent-event-stream.js';
+import { ScoopPresentation } from './facade/scoop-presentation.js';
+import { buildTrayRuntimeSnapshot } from './facade/tray-runtime.js';
 import type {
-  AgentEventMsg,
   AgentSpawnResultMsg,
   ErrorMsg,
   ExtensionMessage,
@@ -44,19 +44,30 @@ import type {
   ScoopCreatedMsg,
   ScoopListMsg,
   ScoopMessagesReplacedMsg,
-  ScoopSnapshotConfig,
   ScoopStatusMsg,
   SetThinkingLevelMsg,
   StateSnapshotMsg,
   ToolUIActionMsg,
-  TrayFollowerStatusSnapshot,
-  TrayLeaderStatusSnapshot,
   TrayRuntimeStatusMsg,
 } from './messages.js';
 import { createOffscreenChromeRuntimeTransport } from './transport-chrome-runtime.js';
 import type { KernelFacade, KernelTransport } from './types.js';
 
 const log = createLogger('kernel-bridge');
+
+interface FacadeLickManager {
+  setForwarder(forwarder: ((event: ForwardedLickEvent) => void) | null): void;
+  emitEvent(event: ForwardedLickEvent): void;
+}
+
+interface KernelFacadeGlobals {
+  __slicc_agent?: AgentBridge;
+  __slicc_lickManager?: FacadeLickManager;
+}
+
+function getKernelFacadeGlobals(): typeof globalThis & KernelFacadeGlobals {
+  return globalThis as typeof globalThis & KernelFacadeGlobals;
+}
 
 /**
  * Parse a dip lick body for a human navigate·handoff approval resolution.
@@ -115,8 +126,10 @@ export class Bridge implements KernelFacade {
   private messageBuffers = new Map<string, BufferedChatMessage[]>();
   /** Current assistant message ID per scoop */
   private currentMessageId = new Map<string, string>();
-  /** Status per scoop */
-  private scoopStatuses = new Map<string, ScoopTabState['status']>();
+  /** Panel-facing scoop state and projection. */
+  private readonly scoopPresentation = new ScoopPresentation();
+  /** Post-transport agent-event translation and fan-out. */
+  private readonly agentEventStream = new AgentEventStream();
   /** Shared UI session store — writes to browser-coding-agent IndexedDB */
   private sessionStore: SessionStore | null = null;
   /**
@@ -151,33 +164,6 @@ export class Bridge implements KernelFacade {
    * a second `bind()` doesn't double-register the listener.
    */
   private transportUnsubscribe: (() => void) | null = null;
-  /**
-   * The panel's currently-viewed scoop jid. Updated via
-   * `setActiveScoopJid()` whenever a `leader-active-scoop` envelope
-   * arrives from the panel. Read by snapshot/leader-broadcast paths to
-   * replace the always-cone behavior previously baked into
-   * `state-snapshot.activeScoopJid`. The bridge owns only the cache; no
-   * envelope handler lives on the panel-message switch.
-   */
-  private activeScoopJid: string | null = null;
-  /**
-   * Subscribers to the post-emit `agent-event` fan-out. Each handler
-   * receives the same `AgentEvent` shape the panel sees (`ui/types.ts`),
-   * not the wire envelope — the bridge does the same wire→UI translation
-   * server-side that `offscreen-client.ts` `handleAgentEvent` does.
-   */
-  private readonly agentEventListeners = new Set<(scoopJid: string, event: AgentEvent) => void>();
-  /**
-   * Per-scoop "current message id" tracking for the fan-out's
-   * `message_start` gating. Held separately from the bridge's
-   * buffer-keyed `currentMessageId` because the callbacks that produce
-   * wire `agent-event` envelopes mutate `currentMessageId` BEFORE
-   * `emit()` runs (e.g. `getOrCreateAssistantMsg` in `onResponse`),
-   * which would short-circuit the fan-out's `message_start` emission.
-   * Mirrors the panel-side `currentMessageId` in
-   * `offscreen-client.ts:handleAgentEvent` exactly.
-   */
-  private readonly fanOutMessageId = new Map<string, string>();
 
   /**
    * Optional transport injection. If omitted (today's extension
@@ -279,7 +265,7 @@ export class Bridge implements KernelFacade {
       },
 
       onStatusChange: (scoopJid, status) => {
-        bridge.scoopStatuses.set(scoopJid, status);
+        bridge.scoopPresentation.setStatus(scoopJid, status);
 
         if (status === 'ready') {
           bridge.currentMessageId.delete(scoopJid);
@@ -459,8 +445,8 @@ export class Bridge implements KernelFacade {
   private evictScoopState(scoop: RegisteredScoop): void {
     this.messageBuffers.delete(scoop.jid);
     this.currentMessageId.delete(scoop.jid);
-    this.fanOutMessageId.delete(scoop.jid);
-    this.scoopStatuses.delete(scoop.jid);
+    this.agentEventStream.clear(scoop.jid);
+    this.scoopPresentation.clearStatus(scoop.jid);
     // Drop the persisted UI session too — `persistScoop` writes
     // `session-<folder>` for every scoop with buffered messages, so
     // dead ephemeral scoops otherwise pile up in the
@@ -537,49 +523,17 @@ export class Bridge implements KernelFacade {
     } satisfies MessageUpdatedMsg);
   }
 
-  /**
-   * Project an orchestrator `RegisteredScoop` down to the snapshot shape
-   * the panel sees. Carries `config.modelId` / `config.thinkingLevel`
-   * (the only config bits the panel reads — see `ScoopSnapshotConfig`)
-   * so the brain icon and model pill rehydrate correctly across
-   * reconnects and scoop switches.
-   */
-  private toScoopSnapshot(s: RegisteredScoop): ScoopListMsg['scoops'][number] {
-    const config: ScoopSnapshotConfig | undefined =
-      s.config && (s.config.modelId !== undefined || s.config.thinkingLevel !== undefined)
-        ? {
-            ...(s.config.modelId !== undefined ? { modelId: s.config.modelId } : {}),
-            ...(s.config.thinkingLevel !== undefined
-              ? { thinkingLevel: s.config.thinkingLevel }
-              : {}),
-          }
-        : undefined;
-    return {
-      jid: s.jid,
-      name: s.name,
-      folder: s.folder,
-      isCone: s.isCone,
-      assistantLabel: s.assistantLabel,
-      status: (this.scoopStatuses.get(s.jid) ?? 'ready') as ScoopTabState['status'],
-      ...(config ? { config } : {}),
-    };
+  /** Project an orchestrator scoop to the panel snapshot shape. */
+  private toScoopSnapshot(scoop: RegisteredScoop): ScoopListMsg['scoops'][number] {
+    return this.scoopPresentation.projectScoop(scoop);
   }
 
   /** Build a full state snapshot for panel reconnect. */
   buildStateSnapshot(): StateSnapshotMsg {
-    const scoops = this.orchestrator?.getScoops().map((s) => this.toScoopSnapshot(s)) ?? [];
-
-    const cone = scoops.find((s) => s.isCone);
-
-    return {
-      type: 'state-snapshot',
-      scoops,
-      // Honour the panel's leader-pushed selection when present so a
-      // sub-scoop survives panel reload; fall back to the cone for
-      // first-boot / pre-leader cases.
-      activeScoopJid: this.getActiveScoopJid() ?? cone?.jid ?? null,
-      trayRuntimeStatus: this.buildTrayRuntimeStatus(),
-    };
+    return this.scoopPresentation.buildStateSnapshot(
+      this.orchestrator?.getScoops() ?? [],
+      buildTrayRuntimeSnapshot()
+    );
   }
 
   /**
@@ -589,44 +543,9 @@ export class Bridge implements KernelFacade {
    * "Enable multi-browser sync" surface that standalone has.
    */
   emitTrayRuntimeStatus(): void {
-    const status = this.buildTrayRuntimeStatus();
-    const msg: TrayRuntimeStatusMsg = {
-      type: 'tray-runtime-status',
-      leader: status.leader,
-      follower: status.follower,
-    };
+    const status = buildTrayRuntimeSnapshot();
+    const msg: TrayRuntimeStatusMsg = { type: 'tray-runtime-status', ...status };
     this.emit(msg);
-  }
-
-  private buildTrayRuntimeStatus(): {
-    leader: TrayLeaderStatusSnapshot;
-    follower: TrayFollowerStatusSnapshot;
-  } {
-    const leader = getLeaderTrayRuntimeStatus();
-    const follower = getFollowerTrayRuntimeStatus();
-    return {
-      leader: {
-        state: leader.state,
-        // Carry the whole session so the panel singleton matches
-        // offscreen field-for-field. `getLeaderTrayRuntimeStatus()`
-        // already returns a defensive copy.
-        session: leader.session,
-        error: leader.error ?? null,
-        reconnectAttempts: leader.reconnectAttempts ?? 0,
-      },
-      follower: {
-        state: follower.state,
-        joinUrl: follower.joinUrl,
-        trayId: follower.trayId,
-        error: follower.error,
-        lastError: follower.lastError,
-        reconnectAttempts: follower.reconnectAttempts,
-        attachAttempts: follower.attachAttempts,
-        lastAttachCode: follower.lastAttachCode,
-        connectingSince: follower.connectingSince,
-        lastPingTime: follower.lastPingTime,
-      },
-    };
   }
 
   /**
@@ -655,7 +574,7 @@ export class Bridge implements KernelFacade {
    * to clear.
    */
   setActiveScoopJid(jid: string | null): void {
-    this.activeScoopJid = jid;
+    this.scoopPresentation.setActiveScoopJid(jid);
   }
 
   /**
@@ -663,7 +582,7 @@ export class Bridge implements KernelFacade {
    * has been observed yet.
    */
   getActiveScoopJid(): string | null {
-    return this.activeScoopJid;
+    return this.scoopPresentation.getActiveScoopJid();
   }
 
   /**
@@ -687,127 +606,7 @@ export class Bridge implements KernelFacade {
    * standalone wire path.
    */
   onAgentEvent(handler: (scoopJid: string, event: AgentEvent) => void): () => void {
-    this.agentEventListeners.add(handler);
-    return () => {
-      this.agentEventListeners.delete(handler);
-    };
-  }
-
-  /**
-   * @internal — called from `emit()` whenever a wire `agent-event`
-   * envelope flows out to the panel. Translates the envelope to the
-   * matching `AgentEvent` (or pair of events when `message_start`
-   * needs to be synthesized) and notifies each registered listener.
-   * Uses its own `fanOutMessageId` map (instead of the bridge's
-   * buffer-keyed `currentMessageId`) so the gating matches the
-   * panel's `handleAgentEvent` step for step — the callbacks that
-   * produce wire envelopes pre-populate `currentMessageId` BEFORE
-   * `emit()` runs, which would otherwise suppress every synthesized
-   * `message_start`.
-   */
-  private fanOutAgentEvent(msg: AgentEventMsg): void {
-    // Don't early-return on `agentEventListeners.size === 0`: the
-    // gating state (`fanOutMessageId`) must track every wire envelope
-    // even when nobody is subscribed, so a listener that subscribes
-    // mid-stream sees a consistent view (e.g. a subsequent `text_delta`
-    // continues the existing message instead of synthesizing a stray
-    // `message_start`).
-    const { scoopJid, eventType } = msg;
-    const events: AgentEvent[] = [];
-    const ensureMessageStart = (): string => {
-      let msgId = this.fanOutMessageId.get(scoopJid);
-      if (!msgId) {
-        msgId = `scoop-${scoopJid}-${uid()}`;
-        this.fanOutMessageId.set(scoopJid, msgId);
-        events.push({ type: 'message_start', messageId: msgId });
-      }
-      return msgId;
-    };
-
-    switch (eventType) {
-      case 'text_delta': {
-        const messageId = ensureMessageStart();
-        events.push({ type: 'content_delta', messageId, text: msg.text ?? '' });
-        break;
-      }
-      case 'tool_start': {
-        const messageId = ensureMessageStart();
-        events.push({
-          type: 'tool_use_start',
-          messageId,
-          toolName: msg.toolName ?? '',
-          toolInput: msg.toolInput,
-        });
-        break;
-      }
-      case 'tool_end': {
-        const messageId = this.fanOutMessageId.get(scoopJid);
-        if (!messageId) return;
-        events.push({
-          type: 'tool_result',
-          messageId,
-          toolName: msg.toolName ?? '',
-          result: msg.toolResult ?? '',
-          isError: msg.isError,
-        });
-        break;
-      }
-      case 'tool_ui': {
-        const messageId = ensureMessageStart();
-        events.push({
-          type: 'tool_ui',
-          messageId,
-          toolName: msg.toolName ?? '',
-          requestId: msg.requestId ?? '',
-          html: msg.html ?? '',
-        });
-        break;
-      }
-      case 'tool_ui_done': {
-        const messageId = this.fanOutMessageId.get(scoopJid);
-        if (!messageId) return;
-        events.push({ type: 'tool_ui_done', messageId, requestId: msg.requestId ?? '' });
-        break;
-      }
-      case 'response_done': {
-        const messageId = this.fanOutMessageId.get(scoopJid);
-        if (!messageId) return;
-        events.push({
-          type: 'content_done',
-          messageId,
-          model: msg.model,
-          usage: msg.usage,
-        });
-        this.fanOutMessageId.delete(scoopJid);
-        // NB: `turn_end` synthesis is deliberately deferred. Do NOT
-        // synthesize `turn_end` here without first capturing the
-        // standalone leader's `agent.event` wire payload under a
-        // multi-turn scenario and diffing against the events this
-        // synthesizer produces — adding a phantom `turn_end` risks
-        // duplicate events on followers that already see one from the
-        // standalone wire path.
-        break;
-      }
-      case 'turn_end': {
-        // No emit — `turn_end` synthesis is deferred (see comment
-        // above). The gating-state still needs cleanup, mirroring the
-        // panel-side reference in `offscreen-client.ts` `handleAgentEvent`.
-        this.fanOutMessageId.delete(scoopJid);
-        break;
-      }
-    }
-
-    for (const event of events) {
-      for (const fn of this.agentEventListeners) {
-        try {
-          fn(scoopJid, event);
-        } catch (err) {
-          log.error('onAgentEvent listener threw', {
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-    }
+    return this.agentEventStream.subscribe(handler);
   }
 
   /**
@@ -923,7 +722,7 @@ export class Bridge implements KernelFacade {
     }));
     this.messageBuffers.set(cone.jid, buf);
     this.currentMessageId.delete(cone.jid);
-    this.fanOutMessageId.delete(cone.jid);
+    this.agentEventStream.clear(cone.jid);
     if (this.sessionStore) {
       const sessionId = cone.isCone ? 'session-cone' : `session-${cone.folder}`;
       this.sessionStore.saveMessages(sessionId, messages).catch((err) => {
@@ -1017,7 +816,7 @@ export class Bridge implements KernelFacade {
     const scoopJid = this.getConeJid();
     if (!scoopJid) return;
     const status: ScoopTabState['status'] = scoopStatus === 'processing' ? 'processing' : 'ready';
-    this.scoopStatuses.set(scoopJid, status);
+    this.scoopPresentation.setStatus(scoopJid, status);
     this.emit({ type: 'scoop-status', scoopJid, status });
   }
 
@@ -1083,7 +882,7 @@ export class Bridge implements KernelFacade {
       if (!buf) continue;
       this.messageBuffers.set(scoop.jid, buf);
       this.currentMessageId.delete(scoop.jid);
-      this.fanOutMessageId.delete(scoop.jid);
+      this.agentEventStream.clear(scoop.jid);
       await this.persistScoopAwait(scoop.jid);
     }
   }
@@ -1122,13 +921,13 @@ export class Bridge implements KernelFacade {
       // Hydrate the buffer so subsequent agent events extend the
       // restored history instead of starting from empty (which would
       // silently overwrite the UI store via persistScoop). Clear
-      // `currentMessageId`/`fanOutMessageId` for the same reason: a
+      // both buffer and fan-out message pointers for the same reason: a
       // stale id pointing at a (now non-existent) buffer entry would
       // have `getOrCreateAssistantMsg` write into the rehydrated buffer
       // under an unrelated id.
       this.messageBuffers.set(scoopJid, buf);
       this.currentMessageId.delete(scoopJid);
-      this.fanOutMessageId.delete(scoopJid);
+      this.agentEventStream.clear(scoopJid);
       // Persist the rebuilt buffer back to the UI session store so
       // a subsequent panel reload (without further agent activity)
       // sees the canonical history instead of whatever truncated
@@ -1156,7 +955,7 @@ export class Bridge implements KernelFacade {
         if (messages.length > 0) {
           this.messageBuffers.set(scoopJid, messages as unknown as BufferedChatMessage[]);
           this.currentMessageId.delete(scoopJid);
-          this.fanOutMessageId.delete(scoopJid);
+          this.agentEventStream.clear(scoopJid);
           this.emit({
             type: 'scoop-messages-replaced',
             scoopJid,
@@ -1669,9 +1468,7 @@ export class Bridge implements KernelFacade {
   private async handleAgentSpawn(
     msg: Extract<PanelToOffscreenMessage, { type: 'agent-spawn-request' }>
   ): Promise<void> {
-    const agentBridge = (globalThis as Record<string, unknown>)[AGENT_BRIDGE_GLOBAL_KEY] as
-      | AgentBridge
-      | undefined;
+    const agentBridge = getKernelFacadeGlobals()[AGENT_BRIDGE_GLOBAL_KEY];
     if (!agentBridge || typeof agentBridge.spawn !== 'function') {
       this.emit({
         type: 'agent-spawn-result',
@@ -1801,8 +1598,8 @@ export class Bridge implements KernelFacade {
     await this.orchestrator.unregisterScoop(scoopJid);
     this.messageBuffers.delete(scoopJid);
     this.currentMessageId.delete(scoopJid);
-    this.fanOutMessageId.delete(scoopJid);
-    this.scoopStatuses.delete(scoopJid);
+    this.agentEventStream.clear(scoopJid);
+    this.scoopPresentation.clearStatus(scoopJid);
     if (droppedScoop && this.sessionStore) {
       const sessionId = droppedScoop.isCone ? 'session-cone' : `session-${droppedScoop.folder}`;
       this.sessionStore.delete(sessionId).catch((err) => {
@@ -1831,7 +1628,7 @@ export class Bridge implements KernelFacade {
     if (coneJid) {
       this.messageBuffers.delete(coneJid);
       this.currentMessageId.delete(coneJid);
-      this.fanOutMessageId.delete(coneJid);
+      this.agentEventStream.clear(coneJid);
     }
     this.emit({ type: 'clear-chat-ack', requestId });
   }
@@ -1883,9 +1680,7 @@ export class Bridge implements KernelFacade {
    * installs the forwarder directly in offscreen.ts.
    */
   private handleSetFollowerForwarding(enabled: boolean): void {
-    const lm = (globalThis as Record<string, unknown>).__slicc_lickManager as
-      | { setForwarder(fn: ((e: ForwardedLickEvent) => void) | null): void }
-      | undefined;
+    const lm = getKernelFacadeGlobals().__slicc_lickManager;
     if (!lm) {
       console.warn(
         '[kernel-bridge] set-follower-forwarding ignored: worker LickManager unavailable'
@@ -1907,9 +1702,7 @@ export class Bridge implements KernelFacade {
    * `handleSetFollowerForwarding`).
    */
   private handleInjectForwardedLick(event: ForwardedLickEvent): void {
-    const lm = (globalThis as Record<string, unknown>).__slicc_lickManager as
-      | { emitEvent(e: ForwardedLickEvent): void }
-      | undefined;
+    const lm = getKernelFacadeGlobals().__slicc_lickManager;
     if (!lm) {
       console.warn(
         '[kernel-bridge] inject-forwarded-lick dropped: worker LickManager unavailable',
@@ -1981,21 +1774,17 @@ export class Bridge implements KernelFacade {
   }
 
   /** @internal */ emitScoopList(): void {
-    const scoops = this.orchestrator?.getScoops().map((s) => this.toScoopSnapshot(s)) ?? [];
+    const scoops = this.scoopPresentation.projectScoops(this.orchestrator?.getScoops() ?? []);
     this.emit({ type: 'scoop-list', scoops } satisfies ScoopListMsg);
   }
 
   /** Send a message to all panels via the kernel transport. */
   private emit(payload: OffscreenToPanelMessage): void {
     this.transport.send(payload);
-    // Fan out to leader-sync subscribers when the payload is an
-    // agent-event. Cheap when it isn't — the type check skips
-    // `fanOutAgentEvent` entirely. (Listener count is deliberately NOT
-    // checked here; the fan-out maintains `fanOutMessageId` gating
-    // state for every wire envelope regardless of subscriber presence
-    // — see the comment in `fanOutAgentEvent`.)
-    if ((payload as { type?: string }).type === 'agent-event') {
-      this.fanOutAgentEvent(payload as AgentEventMsg);
+    // Transport delivery must happen before fan-out. Publishing with no
+    // listeners is still required so stream gating remains current.
+    if (payload.type === 'agent-event') {
+      this.agentEventStream.publish(payload);
     }
   }
 }

--- a/packages/webapp/src/kernel/facade/agent-event-stream.ts
+++ b/packages/webapp/src/kernel/facade/agent-event-stream.ts
@@ -1,0 +1,123 @@
+import { createLogger } from '../../base/logger.js';
+import type { AgentEvent } from '../../core/agent-types.js';
+import type { AgentEventMsg } from '../messages.js';
+
+const log = createLogger('kernel-agent-event-stream');
+
+export type AgentEventListener = (scoopJid: string, event: AgentEvent) => void;
+
+/** Translates outgoing agent-event envelopes and fans them out to kernel subscribers. */
+export class AgentEventStream {
+  private readonly listeners = new Set<AgentEventListener>();
+  private readonly messageIds = new Map<string, string>();
+
+  subscribe(listener: AgentEventListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  clear(scoopJid: string): void {
+    this.messageIds.delete(scoopJid);
+  }
+
+  publish(message: AgentEventMsg): void {
+    const events = this.translate(message);
+    for (const event of events) {
+      for (const listener of this.listeners) {
+        try {
+          listener(message.scoopJid, event);
+        } catch (error) {
+          log.error('onAgentEvent listener threw', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+  }
+
+  private translate(message: AgentEventMsg): AgentEvent[] {
+    const { scoopJid, eventType } = message;
+    const events: AgentEvent[] = [];
+    const ensureMessageStart = (): string => {
+      let messageId = this.messageIds.get(scoopJid);
+      if (!messageId) {
+        messageId = `scoop-${scoopJid}-${uid()}`;
+        this.messageIds.set(scoopJid, messageId);
+        events.push({ type: 'message_start', messageId });
+      }
+      return messageId;
+    };
+
+    switch (eventType) {
+      case 'text_delta': {
+        const messageId = ensureMessageStart();
+        events.push({ type: 'content_delta', messageId, text: message.text ?? '' });
+        break;
+      }
+      case 'tool_start': {
+        const messageId = ensureMessageStart();
+        events.push({
+          type: 'tool_use_start',
+          messageId,
+          toolName: message.toolName ?? '',
+          toolInput: message.toolInput,
+        });
+        break;
+      }
+      case 'tool_end': {
+        const messageId = this.messageIds.get(scoopJid);
+        if (!messageId) return events;
+        events.push({
+          type: 'tool_result',
+          messageId,
+          toolName: message.toolName ?? '',
+          result: message.toolResult ?? '',
+          isError: message.isError,
+        });
+        break;
+      }
+      case 'tool_ui': {
+        const messageId = ensureMessageStart();
+        events.push({
+          type: 'tool_ui',
+          messageId,
+          toolName: message.toolName ?? '',
+          requestId: message.requestId ?? '',
+          html: message.html ?? '',
+        });
+        break;
+      }
+      case 'tool_ui_done': {
+        const messageId = this.messageIds.get(scoopJid);
+        if (!messageId) return events;
+        events.push({ type: 'tool_ui_done', messageId, requestId: message.requestId ?? '' });
+        break;
+      }
+      case 'response_done': {
+        const messageId = this.messageIds.get(scoopJid);
+        if (!messageId) return events;
+        events.push({
+          type: 'content_done',
+          messageId,
+          model: message.model,
+          usage: message.usage,
+        });
+        this.messageIds.delete(scoopJid);
+        break;
+      }
+      case 'turn_end':
+        // Keep gating state aligned with the panel translator, but deliberately
+        // do not synthesize a turn_end event from the wire envelope.
+        this.messageIds.delete(scoopJid);
+        break;
+    }
+
+    return events;
+  }
+}
+
+function uid(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}

--- a/packages/webapp/src/kernel/facade/scoop-presentation.ts
+++ b/packages/webapp/src/kernel/facade/scoop-presentation.ts
@@ -1,0 +1,72 @@
+import type { RegisteredScoop, ScoopTabState } from '../../scoops/types.js';
+import type {
+  ScoopListMsg,
+  ScoopSnapshotConfig,
+  StateSnapshotMsg,
+  TrayRuntimeStatusMsg,
+} from '../messages.js';
+
+export type ScoopSnapshot = ScoopListMsg['scoops'][number];
+
+/** Owns panel-facing scoop selection/status state and its wire projections. */
+export class ScoopPresentation {
+  private readonly statuses = new Map<string, ScoopTabState['status']>();
+  private activeScoopJid: string | null = null;
+
+  setStatus(scoopJid: string, status: ScoopTabState['status']): void {
+    this.statuses.set(scoopJid, status);
+  }
+
+  clearStatus(scoopJid: string): void {
+    this.statuses.delete(scoopJid);
+  }
+
+  setActiveScoopJid(scoopJid: string | null): void {
+    this.activeScoopJid = scoopJid;
+  }
+
+  getActiveScoopJid(): string | null {
+    return this.activeScoopJid;
+  }
+
+  projectScoop(scoop: RegisteredScoop): ScoopSnapshot {
+    const config = projectConfig(scoop);
+    return {
+      jid: scoop.jid,
+      name: scoop.name,
+      folder: scoop.folder,
+      isCone: scoop.isCone,
+      assistantLabel: scoop.assistantLabel,
+      status: this.statuses.get(scoop.jid) ?? 'ready',
+      ...(config ? { config } : {}),
+    };
+  }
+
+  projectScoops(scoops: readonly RegisteredScoop[]): ScoopListMsg['scoops'] {
+    return scoops.map((scoop) => this.projectScoop(scoop));
+  }
+
+  buildStateSnapshot(
+    registeredScoops: readonly RegisteredScoop[],
+    trayRuntimeStatus: Pick<TrayRuntimeStatusMsg, 'leader' | 'follower'>
+  ): StateSnapshotMsg {
+    const scoops = this.projectScoops(registeredScoops);
+    const cone = scoops.find((scoop) => scoop.isCone);
+    return {
+      type: 'state-snapshot',
+      scoops,
+      activeScoopJid: this.activeScoopJid ?? cone?.jid ?? null,
+      trayRuntimeStatus,
+    };
+  }
+}
+
+function projectConfig(scoop: RegisteredScoop): ScoopSnapshotConfig | undefined {
+  if (!scoop.config) return undefined;
+  const { modelId, thinkingLevel } = scoop.config;
+  if (modelId === undefined && thinkingLevel === undefined) return undefined;
+  return {
+    ...(modelId !== undefined ? { modelId } : {}),
+    ...(thinkingLevel !== undefined ? { thinkingLevel } : {}),
+  };
+}

--- a/packages/webapp/src/kernel/facade/tray-runtime.ts
+++ b/packages/webapp/src/kernel/facade/tray-runtime.ts
@@ -1,0 +1,59 @@
+import {
+  type FollowerTrayRuntimeStatus,
+  getFollowerTrayRuntimeStatus,
+} from '../../scoops/tray-follower-status.js';
+import {
+  getLeaderTrayRuntimeStatus,
+  type LeaderTrayRuntimeStatus,
+} from '../../scoops/tray-leader.js';
+import type { TrayRuntimeStatusMsg } from '../messages.js';
+
+export type TrayRuntimeSnapshot = Pick<TrayRuntimeStatusMsg, 'leader' | 'follower'>;
+
+/** Read and defensively project the tray runtime singletons onto their wire shape. */
+export function buildTrayRuntimeSnapshot(): TrayRuntimeSnapshot {
+  return projectTrayRuntimeStatus(getLeaderTrayRuntimeStatus(), getFollowerTrayRuntimeStatus());
+}
+
+export function projectTrayRuntimeStatus(
+  leader: LeaderTrayRuntimeStatus,
+  follower: FollowerTrayRuntimeStatus
+): TrayRuntimeSnapshot {
+  return {
+    leader: {
+      state: leader.state,
+      session: leader.session
+        ? {
+            workerBaseUrl: leader.session.workerBaseUrl,
+            trayId: leader.session.trayId,
+            createdAt: leader.session.createdAt,
+            controllerId: leader.session.controllerId,
+            controllerUrl: leader.session.controllerUrl,
+            joinUrl: leader.session.joinUrl,
+            webhookUrl: leader.session.webhookUrl,
+            ...(leader.session.leaderKey !== undefined
+              ? { leaderKey: leader.session.leaderKey }
+              : {}),
+            ...(leader.session.leaderWebSocketUrl !== undefined
+              ? { leaderWebSocketUrl: leader.session.leaderWebSocketUrl }
+              : {}),
+            runtime: leader.session.runtime,
+          }
+        : null,
+      error: leader.error ?? null,
+      reconnectAttempts: leader.reconnectAttempts ?? 0,
+    },
+    follower: {
+      state: follower.state,
+      joinUrl: follower.joinUrl,
+      trayId: follower.trayId,
+      error: follower.error,
+      lastError: follower.lastError,
+      reconnectAttempts: follower.reconnectAttempts,
+      attachAttempts: follower.attachAttempts,
+      lastAttachCode: follower.lastAttachCode,
+      connectingSince: follower.connectingSince,
+      lastPingTime: follower.lastPingTime,
+    },
+  };
+}

--- a/packages/webapp/tests/kernel/bridge.test.ts
+++ b/packages/webapp/tests/kernel/bridge.test.ts
@@ -707,6 +707,20 @@ describe('Bridge onScoopUnregistered eviction', () => {
     expect(mockStore.delete).toHaveBeenCalledWith('session-agent-probe');
   });
 
+  it('resets agent-event message gating after eviction', () => {
+    const events: string[] = [];
+    bridge.onAgentEvent((scoopJid, event) => {
+      if (scoopJid === unregisteredScoop.jid) events.push(event.type);
+    });
+    callbacks.onResponse(unregisteredScoop.jid, 'before', true);
+    events.length = 0;
+
+    callbacks.onScoopUnregistered?.(unregisteredScoop);
+    callbacks.onResponse(unregisteredScoop.jid, 'after', true);
+
+    expect(events).toEqual(['message_start', 'content_delta']);
+  });
+
   it('refreshes the panel scoop list after eviction', () => {
     const emitSpy = vi.spyOn(bridge as any, 'emitScoopList');
 

--- a/packages/webapp/tests/kernel/bridge.test.ts
+++ b/packages/webapp/tests/kernel/bridge.test.ts
@@ -282,8 +282,6 @@ describe('Bridge createCallbacks', () => {
     const scoopJid = 'cone_1';
     callbacks.onStatusChange(scoopJid, 'processing');
 
-    expect((bridge as any).scoopStatuses.get(scoopJid)).toBe('processing');
-
     const emitted = sentMessages[0] as any;
     expect(emitted.payload.type).toBe('scoop-status');
     expect(emitted.payload.scoopJid).toBe(scoopJid);
@@ -448,9 +446,10 @@ describe('Bridge buildStateSnapshot', () => {
     expect(snapshot.activeScoopJid).toBeNull();
   });
 
-  it('includes status from scoopStatuses map', () => {
-    (bridge as any).scoopStatuses.set('cone_1', 'processing');
-    (bridge as any).scoopStatuses.set('scoop_test', 'ready');
+  it('includes statuses received through callbacks', () => {
+    const callbacks = Bridge.createCallbacks(bridge);
+    callbacks.onStatusChange('cone_1', 'processing');
+    callbacks.onStatusChange('scoop_test', 'ready');
 
     const snapshot = bridge.buildStateSnapshot();
     expect(snapshot.scoops[0].status).toBe('processing');
@@ -693,14 +692,11 @@ describe('Bridge onScoopUnregistered eviction', () => {
 
     expect((bridge as any).messageBuffers.has('agent_probe_1')).toBe(true);
     expect((bridge as any).currentMessageId.has('agent_probe_1')).toBe(true);
-    expect((bridge as any).scoopStatuses.has('agent_probe_1')).toBe(true);
 
     callbacks.onScoopUnregistered?.(unregisteredScoop);
 
     expect((bridge as any).messageBuffers.has('agent_probe_1')).toBe(false);
     expect((bridge as any).currentMessageId.has('agent_probe_1')).toBe(false);
-    expect((bridge as any).fanOutMessageId.has('agent_probe_1')).toBe(false);
-    expect((bridge as any).scoopStatuses.has('agent_probe_1')).toBe(false);
   });
 
   it('deletes the persisted UI session for the unregistered scoop', () => {
@@ -1608,7 +1604,20 @@ describe('Bridge.onAgentEvent tap', () => {
     vi.clearAllMocks();
   });
 
-  it('text_delta with no current messageId emits message_start + content_delta', () => {
+  it('sends over transport before publishing to fan-out listeners', () => {
+    const order: string[] = [];
+    const bridge = new Bridge({
+      onMessage: () => () => {},
+      send: () => order.push('transport'),
+    });
+    bridge.onAgentEvent(() => order.push('listener'));
+
+    Bridge.createCallbacks(bridge).onResponse?.('scoop-1', 'hello', true);
+
+    expect(order).toEqual(['transport', 'listener', 'listener']);
+  });
+
+  it('text_delta uses a fan-out message id separate from the buffered message id', () => {
     const bridge = new Bridge();
     const callbacks = Bridge.createCallbacks(bridge);
     const { events } = captureEvents(bridge);
@@ -1616,6 +1625,7 @@ describe('Bridge.onAgentEvent tap', () => {
     expect(events.map((e) => e.event.type)).toEqual(['message_start', 'content_delta']);
     expect(events[1].event.text).toBe('hello');
     expect(events.every((e) => e.scoopJid === 'scoop-1')).toBe(true);
+    expect(events[0].event.messageId).not.toBe(bridge.getMessagesForJid('scoop-1')[0].id);
   });
 
   it('subsequent text_delta with same messageId emits only content_delta', () => {

--- a/packages/webapp/tests/kernel/facade/agent-event-stream.test.ts
+++ b/packages/webapp/tests/kernel/facade/agent-event-stream.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AgentEventStream } from '../../../src/kernel/facade/agent-event-stream.js';
+
+function textDelta(text: string) {
+  return { type: 'agent-event', scoopJid: 'scoop-1', eventType: 'text_delta', text } as const;
+}
+
+describe('AgentEventStream', () => {
+  it('tracks message state with no listeners', () => {
+    const stream = new AgentEventStream();
+    stream.publish(textDelta('before'));
+    const events: Array<{ type: string; messageId?: string }> = [];
+    stream.subscribe((_jid, event) =>
+      events.push({
+        type: event.type,
+        messageId: 'messageId' in event ? event.messageId : undefined,
+      })
+    );
+
+    stream.publish(textDelta('after'));
+
+    expect(events.map((event) => event.type)).toEqual(['content_delta']);
+    expect(events[0].messageId).toMatch(/^scoop-scoop-1-/);
+  });
+
+  it('does not synthesize turn_end and resets message gating', () => {
+    const stream = new AgentEventStream();
+    const types: string[] = [];
+    stream.subscribe((_jid, event) => types.push(event.type));
+    stream.publish(textDelta('first'));
+    stream.publish({ type: 'agent-event', scoopJid: 'scoop-1', eventType: 'turn_end' });
+    stream.publish(textDelta('next'));
+
+    expect(types).toEqual(['message_start', 'content_delta', 'message_start', 'content_delta']);
+  });
+
+  it('isolates and logs a throwing listener before notifying later listeners', () => {
+    const stream = new AgentEventStream();
+    const healthy = vi.fn();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stream.subscribe(() => {
+      throw new Error('listener failed');
+    });
+    stream.subscribe(healthy);
+
+    stream.publish(textDelta('hello'));
+
+    expect(healthy).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/webapp/tests/kernel/facade/scoop-presentation.test.ts
+++ b/packages/webapp/tests/kernel/facade/scoop-presentation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { ScoopPresentation } from '../../../src/kernel/facade/scoop-presentation.js';
+import type { RegisteredScoop } from '../../../src/scoops/types.js';
+
+const trayRuntimeStatus = {
+  leader: { state: 'inactive', session: null, error: null, reconnectAttempts: 0 },
+  follower: {
+    state: 'inactive',
+    joinUrl: null,
+    trayId: null,
+    error: null,
+    lastError: null,
+    reconnectAttempts: 0,
+    attachAttempts: 0,
+    lastAttachCode: null,
+    connectingSince: null,
+    lastPingTime: null,
+  },
+} as const;
+
+function scoop(overrides: Partial<RegisteredScoop> = {}): RegisteredScoop {
+  return {
+    jid: 'cone-1',
+    name: 'Cone',
+    folder: 'cone',
+    isCone: true,
+    type: 'cone',
+    requiresTrigger: false,
+    assistantLabel: 'sliccy',
+    addedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('ScoopPresentation', () => {
+  it('tracks status and falls back to the cone for active scoop', () => {
+    const presentation = new ScoopPresentation();
+    presentation.setStatus('cone-1', 'processing');
+
+    const snapshot = presentation.buildStateSnapshot([scoop()], trayRuntimeStatus);
+
+    expect(snapshot.activeScoopJid).toBe('cone-1');
+    expect(snapshot.scoops[0].status).toBe('processing');
+  });
+
+  it('prefers the cached active scoop and falls back after it is cleared', () => {
+    const presentation = new ScoopPresentation();
+    presentation.setActiveScoopJid('scoop-2');
+    expect(presentation.buildStateSnapshot([scoop()], trayRuntimeStatus).activeScoopJid).toBe(
+      'scoop-2'
+    );
+    presentation.setActiveScoopJid(null);
+    expect(presentation.buildStateSnapshot([scoop()], trayRuntimeStatus).activeScoopJid).toBe(
+      'cone-1'
+    );
+  });
+
+  it('projects only modelId and thinkingLevel from config', () => {
+    const presentation = new ScoopPresentation();
+    const projected = presentation.projectScoop(
+      scoop({
+        config: {
+          modelId: 'model-1',
+          thinkingLevel: 'high',
+          systemPromptAppend: 'private projection detail',
+          writablePaths: ['/tmp'],
+        },
+      })
+    );
+
+    expect(projected.config).toEqual({ modelId: 'model-1', thinkingLevel: 'high' });
+  });
+});

--- a/packages/webapp/tests/kernel/facade/tray-runtime.test.ts
+++ b/packages/webapp/tests/kernel/facade/tray-runtime.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { projectTrayRuntimeStatus } from '../../../src/kernel/facade/tray-runtime.js';
+
+describe('projectTrayRuntimeStatus', () => {
+  it('defensively maps only tray snapshot fields and defaults leader diagnostics', () => {
+    const snapshot = projectTrayRuntimeStatus(
+      {
+        state: 'leader',
+        session: {
+          workerBaseUrl: 'https://tray.example',
+          trayId: 'tray-1',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          controllerId: 'controller-1',
+          controllerUrl: 'https://tray.example/controller',
+          joinUrl: 'https://tray.example/join',
+          webhookUrl: 'https://tray.example/webhook',
+          runtime: 'extension',
+        },
+        error: null,
+      },
+      {
+        state: 'connected',
+        joinUrl: 'https://tray.example/join',
+        trayId: 'tray-1',
+        error: null,
+        lastError: null,
+        reconnectAttempts: 2,
+        attachAttempts: 3,
+        lastAttachCode: 'LEADER_CONNECTED',
+        connectingSince: 10,
+        lastPingTime: 20,
+        stalled: true,
+      }
+    );
+
+    expect(snapshot.leader.reconnectAttempts).toBe(0);
+    expect(snapshot.follower).not.toHaveProperty('stalled');
+    expect(snapshot.follower).toEqual({
+      state: 'connected',
+      joinUrl: 'https://tray.example/join',
+      trayId: 'tray-1',
+      error: null,
+      lastError: null,
+      reconnectAttempts: 2,
+      attachAttempts: 3,
+      lastAttachCode: 'LEADER_CONNECTED',
+      connectingSince: 10,
+      lastPingTime: 20,
+    });
+  });
+});


### PR DESCRIPTION
Closes #2019

**Solution**
- Starts the approved staged decomposition by extracting agent-event fan-out, scoop/state projection, and tray-runtime projection while preserving `Bridge` compatibility; [spec](https://app.augmentcode.com/app/files/kernel-facade-decomposition-41ebb4fd9e12465c870244c36b3af63e).

**Testing**
- Full coverage suite: 14,248 passed; lint/typecheck/build/bundle-size gates pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M07GBGNYYBY3Z0AZTNS0QHAH&panel=chat)