### PR TITLE
fix(vfs): kill the ino-collision corruption class behind #2146 and #2006

### DIFF
--- a/packages/webapp/src/fs/error-rebrand.ts
+++ b/packages/webapp/src/fs/error-rebrand.ts
@@ -60,8 +60,15 @@ export function convertError(err: unknown, path: string): FsError {
       // degraded double-wrapped shape from #2146. Strip the code prefix,
       // the dangling `undefined` syscall slot, and any trailing quoted
       // path, mirroring rebrandFsError above.
-      if (msg.startsWith(`${code}: `)) msg = msg.slice(code.length + 2);
-      msg = msg.replace(/, undefined( '[^']*')?$/, '').replace(/ '[^']*'$/, '');
+      // Only a message that arrived PRE-FORMATTED (leading `CODE: `) is a
+      // ZenFS errno string whose trailing `syscall 'path'` decoration should
+      // be stripped. A plain structured message keeps its quoted details —
+      // `EIO: cannot open key 'config.json'` is a diagnostic, not a path
+      // (Codex P2 on #2148).
+      if (msg.startsWith(`${code}: `)) {
+        msg = msg.slice(code.length + 2);
+        msg = msg.replace(/, undefined( '[^']*')?$/, '').replace(/ '[^']*'$/, '');
+      }
       return new FsError(code, msg || code, path);
     }
   }

--- a/packages/webapp/src/fs/error-rebrand.ts
+++ b/packages/webapp/src/fs/error-rebrand.ts
@@ -52,7 +52,16 @@ export function convertError(err: unknown, path: string): FsError {
   if (typeof structured === 'string') {
     const code = structured as FsErrorCode;
     if ((KNOWN_CODES as string[]).includes(code)) {
-      const msg = err instanceof Error ? err.message : String(err);
+      let msg = err instanceof Error ? err.message : String(err);
+      // ZenFS messages arrive pre-formatted (`ENOTDIR: not a directory,
+      // undefined '/__opfs__/…'`). FsError re-prefixes the code and
+      // re-appends its own quoted path, so wrapping the formatted string
+      // verbatim produced `ENOTDIR: ENOTDIR: …, undefined '…' '…'` — the
+      // degraded double-wrapped shape from #2146. Strip the code prefix,
+      // the dangling `undefined` syscall slot, and any trailing quoted
+      // path, mirroring rebrandFsError above.
+      if (msg.startsWith(`${code}: `)) msg = msg.slice(code.length + 2);
+      msg = msg.replace(/, undefined( '[^']*')?$/, '').replace(/ '[^']*'$/, '');
       return new FsError(code, msg || code, path);
     }
   }

--- a/packages/webapp/src/fs/sidecar-repair.ts
+++ b/packages/webapp/src/fs/sidecar-repair.ts
@@ -47,6 +47,14 @@ export interface SidecarRepairSummary {
    * entry is dropped outright.
    */
   selfEntryDropped: boolean;
+  /**
+   * Entries whose `ino` was zero/absent or duplicated another entry's and
+   * got a fresh unique id (#2146). ZenFS keys its vnode cache by `ino`, so
+   * colliding ids collapse unrelated paths onto one shared inode — which
+   * then cross-stamps size/mode between them on sync (phantom directories,
+   * sibling-size truncation).
+   */
+  inosReassigned: number;
   /** Whether anything changed (callers skip the rewrite when false). */
   changed: boolean;
 }
@@ -54,6 +62,8 @@ export interface SidecarRepairSummary {
 interface MutableEntry {
   mode?: number;
   size?: number;
+  ino?: number;
+  data?: number;
 }
 
 /**
@@ -78,6 +88,7 @@ export async function repairSidecarDocument(
     sizesFixed: 0,
     dropped: 0,
     selfEntryDropped: false,
+    inosReassigned: 0,
     changed: false,
   };
   const entries = doc.entries ?? {};
@@ -106,7 +117,51 @@ export async function repairSidecarDocument(
     }
     repairEntryAgainstReality(path, entry, fmt, real, summary);
   }
+  reassignDuplicateInos(entries, summary);
   return summary;
+}
+
+/**
+ * Give every entry a UNIQUE `ino` (#2146). The root keeps whatever it has
+ * (ZenFS forces `/` to ino 0 on load); any other entry whose ino is
+ * zero/absent, or already claimed by an earlier entry, gets a fresh id above
+ * the current max of every ino AND data field — mirroring `Index._alloc`'s
+ * contract — with `data = ino + 1`. Pure: no I/O, unit-testable.
+ *
+ * Field data point (2026-08-17, production leader): 2,858 of 14,763 sidecar
+ * entries shared ino 0, including both files of the sibling-size incident.
+ */
+function reassignDuplicateInos(
+  entries: { [path: string]: unknown },
+  summary: SidecarRepairSummary
+): void {
+  let ceiling = 0;
+  for (const raw of Object.values(entries)) {
+    const e = raw as MutableEntry | null;
+    if (typeof e?.ino === 'number') ceiling = Math.max(ceiling, e.ino);
+    if (typeof e?.data === 'number') ceiling = Math.max(ceiling, e.data);
+  }
+  let next = ceiling + 1;
+  const claimed = new Set<number>();
+  for (const [path, raw] of Object.entries(entries)) {
+    if (typeof raw !== 'object' || raw === null) continue;
+    const entry = raw as MutableEntry;
+    if (path === '/') {
+      if (typeof entry.ino === 'number') claimed.add(entry.ino);
+      continue;
+    }
+    const ino = entry.ino;
+    if (typeof ino === 'number' && ino !== 0 && !claimed.has(ino)) {
+      claimed.add(ino);
+      continue;
+    }
+    entry.ino = next;
+    entry.data = next + 1;
+    claimed.add(next);
+    next += 2;
+    summary.inosReassigned += 1;
+    summary.changed = true;
+  }
 }
 
 /** Correct one present-on-disk entry's format bits or size in place. */

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -363,6 +363,27 @@ export class VirtualFS {
       const { resolveWithSidecarRepair, repairOpfsMetadataSidecar } = await import(
         './sidecar-repair.js'
       );
+      // Unconditional pre-boot repair (#2146): an UNDER-sized or ino-colliding
+      // sidecar entry never throws during mount — reads silently clamp to the
+      // recorded size and colliding inos share one vnode — so the on-throw
+      // retry below can never see this corruption class. Truing the document
+      // up BEFORE ZenFS parses it costs one metadata-only probe per entry per
+      // cold boot and heals sidecars already poisoned in the field.
+      try {
+        const preboot = await vfs.withWriteLock(() => repairOpfsMetadataSidecar(handle));
+        if (preboot?.changed) {
+          console.warn('[virtual-fs] repaired metadata sidecar before mount (#2146)', {
+            dbName: vfs.dbName,
+            kindFixed: preboot.kindFixed,
+            sizesFixed: preboot.sizesFixed,
+            dropped: preboot.dropped,
+            inosReassigned: preboot.inosReassigned,
+            selfEntryDropped: preboot.selfEntryDropped,
+          });
+        }
+      } catch {
+        /* best-effort — the on-throw retry below still covers hard failures */
+      }
       const backendFs = (await resolveWithSidecarRepair(
         resolveBackend,
         // The repair's read-mutate-write shares the sidecar with every
@@ -906,14 +927,32 @@ export class VirtualFS {
    * this can never loop.
    */
   private async withKindMismatchRetry<T>(path: string, op: () => Promise<T>): Promise<T> {
+    return this.withKindMismatchRetryPaths([path], op);
+  }
+
+  /**
+   * Multi-path variant: `rename` can trip a kind mismatch on either end, so
+   * each candidate path gets a reconcile attempt; the first heal wins the
+   * single retry. `EINVAL` is retryable alongside `EISDIR`/`ENOTDIR` — a
+   * poisoned index entry surfaces as EINVAL on the read/write path and as
+   * ENOTDIR on the unlink/rmdir path (#2146); a GENUINE EINVAL (bad
+   * argument, mount-point rm) reconciles nothing and rethrows after one
+   * cheap probe.
+   */
+  private async withKindMismatchRetryPaths<T>(
+    paths: readonly string[],
+    op: () => Promise<T>
+  ): Promise<T> {
     try {
       return await op();
     } catch (err) {
       const code = (err as { code?: string } | null)?.code;
-      if (code !== 'EISDIR' && code !== 'ENOTDIR') throw err;
-      const healed = await this.reconcileKindMismatch(path).catch(() => false);
-      if (!healed) throw err;
-      return await op();
+      if (code !== 'EISDIR' && code !== 'ENOTDIR' && code !== 'EINVAL') throw err;
+      for (const path of paths) {
+        const healed = await this.reconcileKindMismatch(path).catch(() => false);
+        if (healed) return await op();
+      }
+      throw err;
     }
   }
 
@@ -1830,9 +1869,23 @@ export class VirtualFS {
       try {
         await this.lfs.mkdir(current);
       } catch (err: unknown) {
-        // Ignore EEXIST errors in recursive mode
         if (err instanceof Error && !err.message.includes('EEXIST')) {
           throw convertError(err, current);
+        }
+        // EEXIST in recursive mode is fine — but ONLY when the existing node
+        // is a directory. A FILE parked on a path component (e.g. a stray
+        // `mv x /tmp` when /tmp did not exist) used to be swallowed here,
+        // silently poisoning every later write under the prefix with an
+        // unattributed ENOTDIR from deep inside ZenFS (#2146 finding 2).
+        // Name the offending component instead.
+        try {
+          const existing = await this.lfs.lstat(current);
+          if (!existing.isDirectory() && !existing.isSymbolicLink()) {
+            throw new FsError('ENOTDIR', 'not a directory', current);
+          }
+        } catch (checkErr) {
+          if (checkErr instanceof FsError && checkErr.code === 'ENOTDIR') throw checkErr;
+          /* lstat raced a concurrent delete — let the caller's op surface it */
         }
       }
     }
@@ -1889,6 +1942,13 @@ export class VirtualFS {
    *                 ENOTEMPTY if directory is not empty (non-recursive)
    */
   async rm(path: string, options?: RmOptions): Promise<void> {
+    // The delete family dispatches on the (possibly lying) lstat type, so a
+    // poisoned entry fails ENOTDIR on every unlink/rmdir route (#2146) —
+    // route through the same heal-and-retry as the read path.
+    return this.withKindMismatchRetry(normalizePath(path), () => this.rmInner(path, options));
+  }
+
+  private async rmInner(path: string, options?: RmOptions): Promise<void> {
     const normalized = normalizePath(path);
     const mount = this.findMount(normalized);
     if (mount) {
@@ -2038,6 +2098,15 @@ export class VirtualFS {
    * @throws FsError ENOENT if source doesn't exist
    */
   async rename(oldPath: string, newPath: string): Promise<void> {
+    // Rename mostly ESCAPES poisoned entries (#2146 finding 1) — but a kind
+    // mismatch on either end (e.g. renaming ONTO a poisoned path) heals the
+    // offending side and retries once.
+    return this.withKindMismatchRetryPaths([normalizePath(oldPath), normalizePath(newPath)], () =>
+      this.renameInner(oldPath, newPath)
+    );
+  }
+
+  private async renameInner(oldPath: string, newPath: string): Promise<void> {
     const normalizedOld = normalizePath(oldPath);
     const normalizedNew = normalizePath(newPath);
     let entryType: EntryType | undefined;

--- a/packages/webapp/src/kernel/realm/realm-exec-bridge.ts
+++ b/packages/webapp/src/kernel/realm/realm-exec-bridge.ts
@@ -80,7 +80,16 @@ export function createExecBridge(
     if (!syncFs?.wasUsed()) return;
     const mutations = syncFs.getMutations();
     if (mutations.created.length || mutations.modified.length || mutations.deleted.length) {
-      await rpc.call('vfs', 'flushWrites', [mutations]);
+      try {
+        await rpc.call('vfs', 'flushWrites', [mutations]);
+      } catch (err: unknown) {
+        // One poisoned path must not reject the exec (and with it every
+        // `.jsh`-implemented command in the session — #2146 finding 2).
+        // Mirror the guarded end-of-script flush in js-realm-shared.ts:
+        // warn loudly, run the exec anyway; the end-of-script flush retries.
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[realm-exec] pre-exec sync-fs flush failed (writes may be missing): ${msg}`);
+      }
     }
     syncFs.resetBaseline();
   };

--- a/packages/webapp/src/kernel/realm/realm-exec-bridge.ts
+++ b/packages/webapp/src/kernel/realm/realm-exec-bridge.ts
@@ -86,9 +86,14 @@ export function createExecBridge(
         // One poisoned path must not reject the exec (and with it every
         // `.jsh`-implemented command in the session — #2146 finding 2).
         // Mirror the guarded end-of-script flush in js-realm-shared.ts:
-        // warn loudly, run the exec anyway; the end-of-script flush retries.
+        // warn loudly, run the exec anyway. The baseline is NOT reset on
+        // failure — resetting would mark the unflushed mutations as
+        // persisted and the end-of-script retry would never re-apply them
+        // (Codex P1 on #2148). Healthy writes that DID land are re-applied
+        // on the retry; VFS writes are idempotent by content.
         const msg = err instanceof Error ? err.message : String(err);
-        console.error(`[realm-exec] pre-exec sync-fs flush failed (writes may be missing): ${msg}`);
+        console.error(`[realm-exec] pre-exec sync-fs flush failed (will retry at exit): ${msg}`);
+        return;
       }
     }
     syncFs.resetBaseline();

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -660,20 +660,35 @@ async function applySyncFsMutations(
   // by a directory of the same name) must tear down the old node BEFORE the
   // new one is written, or the create step can throw/merge against stale
   // state. `deleted` first, then `created`, then `modified`.
+  // Per-entry fault tolerance (#2146): one poisoned path used to abort the
+  // whole flush and reject the RPC — every OTHER pending write was lost and
+  // the caller (each `.jsh` execSync) died with it. Apply what can be
+  // applied; report the casualties in one error so the caller still learns.
+  const failures: string[] = [];
+  const attempt = async (path: string, op: () => Promise<void>): Promise<void> => {
+    try {
+      await op();
+    } catch (err) {
+      failures.push(`${path}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
   for (const path of mutations.deleted) {
-    await ctx.fs.rm(path, { recursive: true });
+    await attempt(path, () => ctx.fs.rm(path, { recursive: true }));
   }
   for (const entry of mutations.created) {
     if (entry.isSymbolicLink) {
-      await ctx.fs.symlink(entry.symlinkTarget ?? '', entry.path);
+      await attempt(entry.path, () => ctx.fs.symlink(entry.symlinkTarget ?? '', entry.path));
     } else if (entry.isDirectory) {
-      await ctx.fs.mkdir(entry.path, { recursive: true });
+      await attempt(entry.path, () => ctx.fs.mkdir(entry.path, { recursive: true }));
     } else {
-      await ctx.fs.writeFile(entry.path, entry.content);
+      await attempt(entry.path, () => ctx.fs.writeFile(entry.path, entry.content));
     }
   }
   for (const entry of mutations.modified) {
-    await ctx.fs.writeFile(entry.path, entry.content);
+    await attempt(entry.path, () => ctx.fs.writeFile(entry.path, entry.content));
+  }
+  if (failures.length > 0) {
+    throw new Error(`sync-fs flush failed for ${failures.length} path(s): ${failures.join('; ')}`);
   }
 }
 

--- a/packages/webapp/src/shell/almost-bash-shell-headless.ts
+++ b/packages/webapp/src/shell/almost-bash-shell-headless.ts
@@ -1047,9 +1047,52 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
    */
   private makeScriptCommand(name: string): Command {
     const catalog = this.scriptCatalog;
-    const shell = this;
     const discoveryFs = this.options.jshDiscoveryFs ?? this.options.fs;
     const cmdName = name;
+    const executeInner = async (args: string[], ctx: CommandContext): Promise<ExecResult> => {
+      const execFn: typeof ctx.exec =
+        ctx.exec ??
+        ((cmd, opts) =>
+          // Forward `args` — the workflow branch passes the `workflow run …` argv via
+          // opts.args; dropping it would run a bare `workflow` (just-bash's Bash.exec
+          // appends opts.args to the command).
+          this.bash.exec(cmd, {
+            env: Object.fromEntries(ctx.env),
+            cwd: opts?.cwd ?? ctx.cwd,
+            args: opts?.args,
+          }));
+
+      // 1) .jsh wins the bare name.
+      const jshMap = await catalog.getJshCommands(this.currentScanRoots());
+      const jshPath = jshMap.get(cmdName);
+      if (jshPath) {
+        let code: string;
+        try {
+          const raw = await discoveryFs.readFile(jshPath, { encoding: 'utf-8' });
+          code = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+        } catch {
+          return { stdout: '', stderr: `jsh: cannot read script '${jshPath}'\n`, exitCode: 127 };
+        }
+        return executeJsCode(
+          code,
+          ['node', jshPath, ...args],
+          { fs: ctx.fs, cwd: ctx.cwd, env: ctx.env, stdin: ctx.stdin, exec: execFn },
+          this.buildJshProcessConfig()
+        );
+      }
+
+      // 2) Else a workflow (saved bare or skill <skill>:<name>) — route through the
+      //    `workflow run` command path (NOT executeJsCode on the raw file).
+      const wfMap = await catalog.getWorkflowCommands();
+      const wf = wfMap.get(cmdName);
+      if (wf) {
+        const argv = buildWorkflowRunArgv(wf.path, args);
+        return execFn(argv[0], { args: argv.slice(1), cwd: ctx.cwd });
+      }
+
+      // 3) Gone.
+      return { stdout: '', stderr: `${cmdName}: command no longer exists\n`, exitCode: 127 };
+    };
     return {
       name,
       // just-bash v3 monkey-patches async primitives in the defense-in-depth sandbox for
@@ -1059,48 +1102,17 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
       // how `git`, `mount`, and other host-extension commands are registered.
       trusted: true,
       async execute(args: string[], ctx) {
-        const execFn: typeof ctx.exec =
-          ctx.exec ??
-          ((cmd, opts) =>
-            // Forward `args` — the workflow branch passes the `workflow run …` argv via
-            // opts.args; dropping it would run a bare `workflow` (just-bash's Bash.exec
-            // appends opts.args to the command).
-            shell.bash.exec(cmd, {
-              env: Object.fromEntries(ctx.env),
-              cwd: opts?.cwd ?? ctx.cwd,
-              args: opts?.args,
-            }));
-
-        // 1) .jsh wins the bare name.
-        const jshMap = await catalog.getJshCommands(shell.currentScanRoots());
-        const jshPath = jshMap.get(cmdName);
-        if (jshPath) {
-          let code: string;
-          try {
-            const raw = await discoveryFs.readFile(jshPath, { encoding: 'utf-8' });
-            code = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
-          } catch {
-            return { stdout: '', stderr: `jsh: cannot read script '${jshPath}'\n`, exitCode: 127 };
-          }
-          return executeJsCode(
-            code,
-            ['node', jshPath, ...args],
-            { fs: ctx.fs, cwd: ctx.cwd, env: ctx.env, stdin: ctx.stdin, exec: execFn },
-            shell.buildJshProcessConfig()
-          );
+        // A THROW from a .jsh escapes into just-bash's error sanitizer,
+        // which rewrites path-like substrings to the literal `<path>` —
+        // destroying the only diagnostic the user gets (#2146 finding 2,
+        // and the mis-diagnosed #1033-1 scrub in git/clone.ts). Convert
+        // failures into ordinary results so the message survives verbatim.
+        try {
+          return await executeInner(args, ctx);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return { stdout: '', stderr: `${cmdName}: ${message}\n`, exitCode: 1 };
         }
-
-        // 2) Else a workflow (saved bare or skill <skill>:<name>) — route through the
-        //    `workflow run` command path (NOT executeJsCode on the raw file).
-        const wfMap = await catalog.getWorkflowCommands();
-        const wf = wfMap.get(cmdName);
-        if (wf) {
-          const argv = buildWorkflowRunArgv(wf.path, args);
-          return execFn(argv[0], { args: argv.slice(1), cwd: ctx.cwd });
-        }
-
-        // 3) Gone.
-        return { stdout: '', stderr: `${cmdName}: command no longer exists\n`, exitCode: 127 };
       },
     };
   }

--- a/packages/webapp/tests/fs/error-rebrand.test.ts
+++ b/packages/webapp/tests/fs/error-rebrand.test.ts
@@ -59,3 +59,24 @@ describe('rebrandFsError', () => {
     expect(() => rebrandFsError(raw, '/x')).toThrow(raw);
   });
 });
+
+describe('convertError on pre-formatted ZenFS messages (#2146)', () => {
+  it('strips the code prefix, dangling undefined syscall, and quoted path', () => {
+    const zenfsErr = Object.assign(
+      new Error("ENOTDIR: not a directory, undefined '/__opfs__/slicc-fs/tmp/foo'"),
+      { code: 'ENOTDIR' }
+    );
+    const out = convertError(zenfsErr, '/tmp/foo');
+    // Pre-fix this produced the degraded double-wrapped shape:
+    // "ENOTDIR: ENOTDIR: not a directory, undefined '/__opfs__/…' '/tmp/foo'"
+    expect(out.message).toBe("ENOTDIR: not a directory '/tmp/foo'");
+    expect(out.code).toBe('ENOTDIR');
+    expect(out.path).toBe('/tmp/foo');
+  });
+
+  it('keeps a plain structured message intact', () => {
+    const err = Object.assign(new Error('some backend detail'), { code: 'EIO' });
+    const out = convertError(err, '/x');
+    expect(out.message).toBe("EIO: some backend detail '/x'");
+  });
+});

--- a/packages/webapp/tests/fs/error-rebrand.test.ts
+++ b/packages/webapp/tests/fs/error-rebrand.test.ts
@@ -79,4 +79,12 @@ describe('convertError on pre-formatted ZenFS messages (#2146)', () => {
     const out = convertError(err, '/x');
     expect(out.message).toBe("EIO: some backend detail '/x'");
   });
+
+  it('preserves quoted details in unformatted backend errors (#2148 P2)', () => {
+    // Only the pre-formatted ZenFS shape gets its trailing quote stripped —
+    // a quoted value in an ordinary diagnostic is not a path decoration.
+    const err = Object.assign(new Error("cannot open key 'config.json'"), { code: 'EIO' });
+    const out = convertError(err, '/settings');
+    expect(out.message).toBe("EIO: cannot open key 'config.json' '/settings'");
+  });
 });

--- a/packages/webapp/tests/fs/sidecar-repair.test.ts
+++ b/packages/webapp/tests/fs/sidecar-repair.test.ts
@@ -62,7 +62,10 @@ describe('repairSidecarDocument', () => {
 
   it('drops entries whose paths are gone and leaves symlinks alone', async () => {
     const doc: SidecarIndexJson = {
-      entries: { '/gone.txt': file(5), '/link': symlink() },
+      entries: {
+        '/gone.txt': { ...file(5), ino: 3, data: 4 },
+        '/link': { ...symlink(), ino: 5, data: 6 },
+      } as SidecarIndexJson['entries'],
     };
     const summary = await repairSidecarDocument(
       doc,
@@ -71,11 +74,18 @@ describe('repairSidecarDocument', () => {
     expect(summary.dropped).toBe(1);
     expect(doc.entries).not.toHaveProperty('/gone.txt');
     // Symlink entry untouched even though the probe reports a plain file.
-    expect(doc.entries?.['/link']).toEqual(symlink());
+    expect(doc.entries?.['/link']).toEqual({ ...symlink(), ino: 5, data: 6 });
   });
 
   it('reports changed=false for a healthy sidecar', async () => {
-    const doc: SidecarIndexJson = { entries: { '/': dir(), '/ok.txt': file(4) } };
+    // Healthy now includes unique inos (#2146) — ino-less entries are
+    // legitimately reassigned, so the no-op fixture must carry them.
+    const doc: SidecarIndexJson = {
+      entries: {
+        '/': { ...dir(), ino: 0, data: 0 },
+        '/ok.txt': { ...file(4), ino: 1, data: 2 },
+      } as SidecarIndexJson['entries'],
+    };
     const summary = await repairSidecarDocument(
       doc,
       probeFrom({ '/ok.txt': { kind: 'file', size: 4 } })
@@ -85,6 +95,7 @@ describe('repairSidecarDocument', () => {
       sizesFixed: 0,
       dropped: 0,
       selfEntryDropped: false,
+      inosReassigned: 0,
       changed: false,
     });
   });
@@ -125,12 +136,69 @@ describe('repairSidecarDocument', () => {
   });
 });
 
+describe('repairSidecarDocument — ino uniqueness (#2146)', () => {
+  it('reassigns zero and duplicate inos to fresh unique ids above the max', async () => {
+    const doc: SidecarIndexJson = {
+      entries: {
+        '/': { ...dir(), ino: 0, data: 0 },
+        '/a.txt': { ...file(10), ino: 0, data: 0 },
+        '/b.txt': { ...file(20), ino: 0, data: 0 },
+        '/c.txt': { ...file(30), ino: 7, data: 8 },
+        '/dup.txt': { ...file(40), ino: 7, data: 9 },
+      } as SidecarIndexJson['entries'],
+    };
+    const summary = await repairSidecarDocument(
+      doc,
+      probeFrom({
+        '/a.txt': { kind: 'file', size: 10 },
+        '/b.txt': { kind: 'file', size: 20 },
+        '/c.txt': { kind: 'file', size: 30 },
+        '/dup.txt': { kind: 'file', size: 40 },
+      })
+    );
+    expect(summary.inosReassigned).toBe(3); // a, b, dup — c keeps 7, / exempt
+    expect(summary.changed).toBe(true);
+    const entries = doc.entries as Record<string, { ino?: number; data?: number }>;
+    expect(entries['/'].ino).toBe(0); // ZenFS forces / to ino 0 — leave it
+    expect(entries['/c.txt'].ino).toBe(7); // first claimant keeps its id
+    const reassigned = ['/a.txt', '/b.txt', '/dup.txt'].map((p) => entries[p].ino);
+    // Fresh ids are unique, nonzero, and above the pre-existing max (9).
+    expect(new Set(reassigned).size).toBe(3);
+    for (const ino of reassigned) {
+      expect(ino).toBeGreaterThan(9);
+    }
+    for (const p of ['/a.txt', '/b.txt', '/dup.txt']) {
+      expect(entries[p].data).toBe((entries[p].ino as number) + 1);
+    }
+  });
+
+  it('a document with already-unique inos is untouched', async () => {
+    const doc: SidecarIndexJson = {
+      entries: {
+        '/': { ...dir(), ino: 0 },
+        '/x.txt': { ...file(1), ino: 3, data: 4 },
+        '/y.txt': { ...file(2), ino: 5, data: 6 },
+      } as SidecarIndexJson['entries'],
+    };
+    const summary = await repairSidecarDocument(
+      doc,
+      probeFrom({
+        '/x.txt': { kind: 'file', size: 1 },
+        '/y.txt': { kind: 'file', size: 2 },
+      })
+    );
+    expect(summary.inosReassigned).toBe(0);
+    expect(summary.changed).toBe(false);
+  });
+});
+
 describe('resolveWithSidecarRepair', () => {
   const repaired: SidecarRepairSummary = {
     kindFixed: ['/x'],
     sizesFixed: 0,
     dropped: 0,
     selfEntryDropped: false,
+    inosReassigned: 0,
     changed: true,
   };
 

--- a/packages/webapp/tests/fs/virtual-fs.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs.test.ts
@@ -61,6 +61,20 @@ describe('VirtualFS', () => {
       expect(names).toEqual(['index.ts', 'readme.md']);
     });
 
+    it('mkdir -p over a FILE component fails ENOTDIR naming the component (#2146)', async () => {
+      await vfs.writeFile('/plainfile', 'i am a file');
+      // Pre-fix the kind-blind EEXIST swallow resolved this silently,
+      // leaving a poisoned prefix that failed deep inside ZenFS later.
+      await expect(vfs.mkdir('/plainfile', { recursive: true })).rejects.toMatchObject({
+        code: 'ENOTDIR',
+        path: '/plainfile',
+      });
+      await expect(vfs.mkdir('/plainfile/sub/dir', { recursive: true })).rejects.toMatchObject({
+        code: 'ENOTDIR',
+        path: '/plainfile',
+      });
+    });
+
     it('creates nested directories recursively', async () => {
       await vfs.mkdir('/a/b/c/d', { recursive: true });
       expect(await vfs.exists('/a/b/c/d')).toBe(true);
@@ -690,6 +704,140 @@ describe('in-session kind-mismatch reconcile (#2006)', () => {
       { code: 'EISDIR' }
     );
     expect(calls).toBe(1);
+    await vfs.dispose();
+  });
+
+  // #2146: rm and rename must ROUTE through the heal — pin the delegation
+  // (the memory backend never triggers kind errors, so an op-level fake
+  // cannot exercise it; the spy proves the wiring).
+  it('rm and rename route through the kind-mismatch retry (#2146)', async () => {
+    const vfs = await VirtualFS.create({ dbName: `test-2146-wire-${Date.now()}`, wipe: true });
+    const spy = vi.spyOn(
+      vfs as unknown as {
+        withKindMismatchRetryPaths<T>(paths: readonly string[], op: () => Promise<T>): Promise<T>;
+      },
+      'withKindMismatchRetryPaths'
+    );
+    await vfs.writeFile('/wire/a.txt', 'x');
+    spy.mockClear();
+    await vfs.rm('/wire/a.txt');
+    expect(spy).toHaveBeenCalledWith(['/wire/a.txt'], expect.any(Function));
+
+    await vfs.writeFile('/wire/b.txt', 'y');
+    spy.mockClear();
+    await vfs.rename('/wire/b.txt', '/wire/c.txt');
+    expect(spy).toHaveBeenCalledWith(['/wire/b.txt', '/wire/c.txt'], expect.any(Function));
+    await vfs.dispose();
+  });
+
+  // #2146: the delete family fails ENOTDIR on a poisoned entry (rm dispatches
+  // on the lying lstat type), and reads/writes surface EINVAL — both must
+  // route through the same heal-and-retry.
+  it('a poisoned ENOTDIR delete heals the index and the retry succeeds (#2146)', async () => {
+    const { vfs, fakeIndex } = await corruptedVfs();
+    let calls = 0;
+    const op = async (): Promise<string> => {
+      calls += 1;
+      if (fakeIndex.has('/workspace/CLAUDE.md')) {
+        throw new FsError('ENOTDIR', 'not a directory', '/workspace/CLAUDE.md');
+      }
+      return 'deleted';
+    };
+    const result = await (vfs as unknown as Wrapped).withKindMismatchRetry(
+      '/workspace/CLAUDE.md',
+      op
+    );
+    expect(result).toBe('deleted');
+    expect(calls).toBe(2);
+    expect(fakeIndex.has('/workspace/CLAUDE.md')).toBe(false);
+    detachFakes(vfs);
+    await vfs.dispose();
+  });
+
+  it('a poisoned EINVAL read heals and retries; a genuine EINVAL does not (#2146)', async () => {
+    const { vfs, fakeIndex } = await corruptedVfs();
+    let calls = 0;
+    const op = async (): Promise<string> => {
+      calls += 1;
+      if (fakeIndex.has('/workspace/CLAUDE.md')) {
+        throw new FsError('EINVAL', 'invalid operation', '/workspace/CLAUDE.md');
+      }
+      return 'read after heal';
+    };
+    const result = await (vfs as unknown as Wrapped).withKindMismatchRetry(
+      '/workspace/CLAUDE.md',
+      op
+    );
+    expect(result).toBe('read after heal');
+    expect(calls).toBe(2);
+    detachFakes(vfs);
+    await vfs.dispose();
+
+    // Genuine EINVAL (reality agrees with memory): one probe, no retry.
+    // Reality must CONTAIN keep.txt as a file for agreement — a missing
+    // path would legitimately heal.
+    const vfs2 = await VirtualFS.create({ dbName: `test-2146-${Date.now()}`, wipe: true });
+    const idx2 = new Map<string, { mode?: number }>([
+      ['/workspace/keep.txt', { mode: S_IFREG | 0o644 }],
+    ]);
+    const h2 = new Map<string, { kind?: string }>([['/workspace/keep.txt', { kind: 'file' }]]);
+    const internal2 = vfs2 as unknown as {
+      backend: string;
+      opfsBackendFs: unknown;
+      opfsHandle: unknown;
+    };
+    internal2.backend = 'opfs';
+    internal2.opfsBackendFs = { index: idx2, _handles: h2 };
+    internal2.opfsHandle = fakeDirHandle({
+      workspace: fakeDirHandle({ 'keep.txt': fakeFileHandle(10) }),
+    });
+    let calls2 = 0;
+    const op2 = async (): Promise<string> => {
+      calls2 += 1;
+      throw new FsError('EINVAL', 'bad argument', '/workspace/keep.txt');
+    };
+    await expect(
+      (vfs2 as unknown as Wrapped).withKindMismatchRetry('/workspace/keep.txt', op2)
+    ).rejects.toMatchObject({ code: 'EINVAL' });
+    expect(calls2).toBe(1);
+    expect(h2.has('/workspace/keep.txt')).toBe(true);
+    detachFakes(vfs2);
+    await vfs2.dispose();
+  });
+
+  it('rename heals whichever end is poisoned (multi-path retry, #2146)', async () => {
+    const { vfs, fakeIndex } = await corruptedVfs();
+    // Give reality a keep.txt so the healthy source AGREES with memory and
+    // reconciles nothing — only the poisoned destination heals.
+    const internalR = vfs as unknown as { opfsHandle: unknown };
+    internalR.opfsHandle = fakeDirHandle({
+      workspace: fakeDirHandle({
+        'CLAUDE.md': fakeFileHandle(16249),
+        'keep.txt': fakeFileHandle(10),
+      }),
+    });
+    type WrappedPaths = {
+      withKindMismatchRetryPaths<T>(paths: readonly string[], op: () => Promise<T>): Promise<T>;
+    };
+    let calls = 0;
+    const op = async (): Promise<string> => {
+      calls += 1;
+      // The poisoned entry is the DESTINATION; the source is healthy.
+      if (fakeIndex.has('/workspace/CLAUDE.md')) {
+        throw new FsError('ENOTDIR', 'not a directory', '/workspace/CLAUDE.md');
+      }
+      return 'renamed';
+    };
+    const result = await (vfs as unknown as WrappedPaths).withKindMismatchRetryPaths(
+      ['/workspace/keep.txt', '/workspace/CLAUDE.md'],
+      op
+    );
+    expect(result).toBe('renamed');
+    // keep.txt reconciles nothing (healthy), CLAUDE.md heals — exactly one retry.
+    expect(calls).toBe(2);
+    expect(fakeIndex.has('/workspace/CLAUDE.md')).toBe(false);
+    expect(fakeIndex.has('/workspace/keep.txt')).toBe(true);
+    detachFakes(vfs);
     await vfs.dispose();
   });
 });

--- a/packages/webapp/tests/fs/zenfs-ino-collision-patch.test.ts
+++ b/packages/webapp/tests/fs/zenfs-ino-collision-patch.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Regression guard for the ino-collision patches (#2146).
+//
+// ZenFS keys its VFS vnode cache by `inode.ino`. `@zenfs/dom`'s WebAccess
+// backend minted `ino: 0` inodes in two places (stat's ENOENT recovery and
+// `_loadMetadata`'s reality branch), so a production index accumulated
+// thousands of ino-0 entries — 2,858 of 14,763 on the live leader that filed
+// the issue. Colliding entries collapse onto ONE shared vnode, and
+// `VNode.sync()` then stamps that shared inode's size AND mode onto a single
+// path: phantom directories (a file whose mode became its sibling
+// directory's) and sibling-size truncation (a 26,623-byte file recorded at
+// its sibling's 5,752).
+//
+// Two patches close it: @zenfs/dom allocates unique ino/data pairs at both
+// minting sites, and @zenfs/core's VCache refuses to coalesce DIFFERENT
+// paths onto one vnode when the ino is 0 or the format bits differ. These
+// tests fail if either patch is missing or stops applying.
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+describe('@zenfs/dom ino allocation patch (#2146)', () => {
+  it('stat ENOENT recovery and the reality branch mint unique inos', () => {
+    const src = readFileSync(resolve(repoRoot, 'node_modules/@zenfs/dom/dist/access.js'), 'utf8');
+    expect(
+      src.includes('const inode = new Inode();'),
+      'Installed @zenfs/dom still mints zeroed (ino: 0) inodes in stat()’s ' +
+        'ENOENT recovery; patches/@zenfs+dom+*.patch is missing or failed to ' +
+        'apply. Every recovered path then collides in the vnode cache and ' +
+        'cross-stamps size/mode with unrelated files. See patches/README.md.'
+    ).toBe(false);
+    expect(src).toContain('const recoveredId = this.index._alloc();');
+    expect(src).toContain('nextRealityId');
+  });
+});
+
+describe('@zenfs/core vnode-cache coalescing guard (#2146)', () => {
+  const vcachePath = resolve(repoRoot, 'node_modules/@zenfs/core/dist/vfs/vcache.js');
+
+  it('the guard is present in the installed dist', () => {
+    const src = readFileSync(vcachePath, 'utf8');
+    expect(
+      src.includes('PATCH(#2146)'),
+      'Installed @zenfs/core VCache.ref still coalesces different paths onto ' +
+        'one vnode for ino-0/format-mismatched inodes; ' +
+        'patches/@zenfs+core+*.patch is missing or failed to apply. ' +
+        'See patches/README.md.'
+    ).toBe(true);
+  });
+
+  it('behaviorally: two ino-0 paths get DISTINCT vnodes; hardlinks still share', async () => {
+    const { VCache } = await import(
+      /* @vite-ignore */ resolve(repoRoot, 'node_modules/@zenfs/core/dist/vfs/vcache.js')
+    );
+    const S_IFREG = 0o100000;
+    const S_IFDIR = 0o40000;
+    const fakeFs = { uuid: 'test', attributes: new Map() };
+    const cache = new VCache(fakeFs);
+
+    // Two unrelated paths whose inodes both carry ino 0 (the poisoned-index
+    // shape) must NOT share a vnode.
+    const a = cache.ref('/a.txt', { ino: 0, mode: S_IFREG | 0o644, size: 100 });
+    const b = cache.ref('/b.txt', { ino: 0, mode: S_IFREG | 0o644, size: 5 });
+    expect(a).not.toBe(b);
+    expect(a.inode.size).toBe(100);
+    expect(b.inode.size).toBe(5);
+
+    // Format-bit mismatch on a shared nonzero ino must not coalesce either —
+    // that is the file↔directory phantom of #2146 findings 1/2.
+    const f = cache.ref('/file', { ino: 7, mode: S_IFREG | 0o644, size: 10 });
+    const d = cache.ref('/dir', { ino: 7, mode: S_IFDIR | 0o755, size: 0 });
+    expect(f).not.toBe(d);
+
+    // Genuine hardlinks — same real ino, same mode — still share one vnode.
+    const h1 = cache.ref('/link1', { ino: 9, mode: S_IFREG | 0o644, size: 42 });
+    const h2 = cache.ref('/link2', { ino: 9, mode: S_IFREG | 0o644, size: 42 });
+    expect(h1).toBe(h2);
+
+    // Re-refing the SAME path with ino 0 joins its own vnode (no churn).
+    const a2 = cache.ref('/a.txt', { ino: 0, mode: S_IFREG | 0o644, size: 100 });
+    expect(a2).toBe(a);
+  });
+});

--- a/packages/webapp/tests/kernel/realm/sync-fs-bridge.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-fs-bridge.test.ts
@@ -6,6 +6,7 @@
  * flush back to the real VFS.
  */
 
+import type { CommandContext } from 'just-bash';
 import { describe, expect, it } from 'vitest';
 import { makeCtx, runCode } from './cjs-realm-harness.js';
 
@@ -178,6 +179,35 @@ describe('sync FS bridge (integration)', () => {
     expect(await ctx.fs.readFile('/workspace/healthy.txt')).toBe('survives');
     // …and the failure is still reported, naming the poisoned path.
     expect(out.stderr).toContain('poisoned.txt');
+  });
+
+  it('a failed pre-exec flush keeps its mutations pending for the exit flush (#2148 P1)', async () => {
+    const ctx = makeCtx();
+    let attempts = 0;
+    const originalWriteFile = ctx.fs.writeFile.bind(ctx.fs);
+    ctx.fs.writeFile = async (path: string, content: string | Uint8Array) => {
+      if (path === '/workspace/transient.txt') {
+        attempts += 1;
+        // First flush attempt (pre-exec) fails; the exit-flush retry succeeds.
+        if (attempts === 1) throw new Error('transient backend failure');
+      }
+      return originalWriteFile(path, content);
+    };
+    ctx.exec = (async () => ({ stdout: '', stderr: '', exitCode: 0 })) as CommandContext['exec'];
+    const out = await runCode(
+      `const fs = require('fs');
+       const exec = require('sliccy:exec');
+       fs.writeFileSync('/workspace/transient.txt', 'survives');
+       exec('true');
+       console.log('done');`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    // Pre-fix, the failed pre-exec flush still reset the mutation baseline,
+    // so the exit flush saw nothing pending and the write was silently lost.
+    expect(attempts).toBe(2);
+    expect(await ctx.fs.readFile('/workspace/transient.txt')).toBe('survives');
+    // (The failure breadcrumb goes to the worker console, not script stderr.)
   });
 
   it('sync and async coexist on same require("fs")', async () => {

--- a/packages/webapp/tests/kernel/realm/sync-fs-bridge.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-fs-bridge.test.ts
@@ -157,6 +157,29 @@ describe('sync FS bridge (integration)', () => {
     expect(out.stderr).toContain('simulated flush failure');
   });
 
+  it('one poisoned path does not sink the other pending writes (#2146)', async () => {
+    const ctx = makeCtx();
+    const originalWriteFile = ctx.fs.writeFile.bind(ctx.fs);
+    ctx.fs.writeFile = async (path: string, content: string | Uint8Array) => {
+      if (path === '/workspace/poisoned.txt') {
+        throw new Error("ENOTDIR: not a directory '/workspace/poisoned.txt'");
+      }
+      return originalWriteFile(path, content);
+    };
+    const out = await runCode(
+      `const fs = require('fs');
+       fs.writeFileSync('/workspace/healthy.txt', 'survives');
+       fs.writeFileSync('/workspace/poisoned.txt', 'dies');
+       console.log('done');`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    // The healthy write reached the real VFS even though its batch-mate failed…
+    expect(await ctx.fs.readFile('/workspace/healthy.txt')).toBe('survives');
+    // …and the failure is still reported, naming the poisoned path.
+    expect(out.stderr).toContain('poisoned.txt');
+  });
+
   it('sync and async coexist on same require("fs")', async () => {
     const ctx = makeCtx({ files: { '/workspace/both.txt': 'original' } });
     const out = await runCode(

--- a/packages/webapp/tests/shell/almost-bash-shell.test.ts
+++ b/packages/webapp/tests/shell/almost-bash-shell.test.ts
@@ -593,6 +593,28 @@ describe('AlmostBashShell .jsh command registration', () => {
     expect(piped.stdout).toContain('cold ok');
   });
 
+  // #2146 finding 2: a THROW escaping a .jsh command runs through just-bash's
+  // error sanitizer, which rewrites path-like substrings to the literal
+  // `<path>` — the degraded `'/…<path>' '<path>'` messages from the issue.
+  // The handler must convert failures into results so diagnostics survive.
+  it('a .jsh dispatch failure surfaces its real message, not a sanitized <path> (#2146)', async () => {
+    await fs.writeFile('/workspace/skills/test-cmd/scripts/failer.jsh', 'console.log("hi");');
+    const shell = new AlmostBashShell({ fs });
+    await shell.syncJshCommands();
+
+    const catalog = shell.getScriptCatalog();
+    vi.spyOn(catalog, 'getJshCommands').mockRejectedValue(
+      new Error("ENOTDIR: not a directory '/tmp/poisoned'")
+    );
+    const result = await shell.executeCommand('failer');
+    vi.restoreAllMocks();
+
+    expect(result.exitCode).toBe(1);
+    // The real path survives verbatim; the sanitizer's placeholder does not appear.
+    expect(result.stderr).toContain("'/tmp/poisoned'");
+    expect(result.stderr).not.toContain('<path>');
+  });
+
   // The bare case must keep working too — it went through `tryJshFallback`
   // before and now resolves as a registered command; either way, exit 0.
   it('still resolves a bare .jsh command on a cold shell', async () => {

--- a/patches/@zenfs+core+2.6.2.patch
+++ b/patches/@zenfs+core+2.6.2.patch
@@ -8,3 +8,28 @@ index 555af55..e88a5b9 100644
  export * as vfs from './vfs/index.js';
 -globalThis.__zenfs__ = Object.create(fs);
 +globalThis.__zenfs__ = Object.assign(Object.create(null), fs);
+diff --git a/node_modules/@zenfs/core/dist/vfs/vcache.js b/node_modules/@zenfs/core/dist/vfs/vcache.js
+index e978bba..c34939b 100644
+--- a/node_modules/@zenfs/core/dist/vfs/vcache.js
++++ b/node_modules/@zenfs/core/dist/vfs/vcache.js
+@@ -76,6 +76,20 @@ export class VCache {
+      */
+     ref(path, inode) {
+         let node = this.byIno.get(inode.ino);
++        // PATCH(#2146): never coalesce DIFFERENT paths onto one vnode via a
++        // zero/unset ino, or across differing format bits. Hardlinks share a
++        // real ino AND a mode; a poisoned index (thousands of ino-0 entries
++        // observed in the field) must not make unrelated files share an
++        // inode object — the shared vnode stamps one file's size/mode onto
++        // the other path on sync.
++        if (node && !node.paths.has(path)
++            && (inode.ino === 0 || ((node.inode.mode ^ inode.mode) & 0o170000) !== 0)) {
++            // The byIno slot may have been claimed by ANOTHER ino-0 path; a
++            // re-ref of an already-known path must still find its own vnode.
++            node = this.byPath.get(path);
++            if (node && ((node.inode.mode ^ inode.mode) & 0o170000) !== 0)
++                node = undefined;
++        }
+         if (!node) {
+             node = new VNode(this.fs, path, inode);
+             this.byIno.set(inode.ino, node);

--- a/patches/@zenfs+dom+1.2.10.patch
+++ b/patches/@zenfs+dom+1.2.10.patch
@@ -1,8 +1,47 @@
 diff --git a/node_modules/@zenfs/dom/dist/access.js b/node_modules/@zenfs/dom/dist/access.js
-index ec02258..5bc2f23 100644
+index ec02258..cccf324 100644
 --- a/node_modules/@zenfs/dom/dist/access.js
 +++ b/node_modules/@zenfs/dom/dist/access.js
-@@ -165,7 +165,17 @@ export class WebAccessFS extends Async(IndexFS) {
+@@ -52,15 +52,21 @@ export class WebAccessFS extends Async(IndexFS) {
+             this.index.fromJSON(data);
+             return;
+         }
++        // PATCH(#2146): allocate unique ino/data pairs — the upstream code
++        // left every inode at ino 0, collapsing the whole tree onto one
++        // vnode-cache slot. Local counter: _alloc() is O(index) per call.
++        let nextRealityId = 1;
+         for (const [path, handle] of this._handles) {
+             if (isKind(handle, 'file')) {
+                 const { lastModified, size } = await handle.getFile();
+-                this.index.set(path, new Inode({ mode: 0o644 | constants.S_IFREG, size, mtimeMs: lastModified }));
++                this.index.set(path, new Inode({ ino: nextRealityId, data: nextRealityId + 1, mode: 0o644 | constants.S_IFREG, size, mtimeMs: lastModified }));
++                nextRealityId += 2;
+                 continue;
+             }
+             if (!isKind(handle, 'directory'))
+                 throw withErrno('EIO', 'Invalid handle');
+-            this.index.set(path, new Inode({ mode: 0o777 | constants.S_IFDIR, size: 0 }));
++            this.index.set(path, new Inode({ ino: nextRealityId, data: nextRealityId + 1, mode: 0o777 | constants.S_IFDIR, size: 0 }));
++            nextRealityId += 2;
+         }
+     }
+     constructor(root, disableHandleCache = false) {
+@@ -91,7 +97,13 @@ export class WebAccessFS extends Async(IndexFS) {
+             // This handle must have been created after initialization
+             // Try to add a new inode for the handle to the index
+             const handle = await this.get(null, path);
+-            const inode = new Inode();
++            // PATCH(#2146): a zeroed Inode carries ino 0 (and data 0). Every
++            // path recovered through this branch then collides in the VFS
++            // vnode cache (keyed by ino), and a shared vnode stamps one
++            // file's size/mode onto another path on sync — the phantom-
++            // directory / sibling-size corruption class. Allocate real ids.
++            const recoveredId = this.index._alloc();
++            const inode = new Inode({ ino: recoveredId, data: recoveredId + 1 });
+             if (isKind(handle, 'file')) {
+                 const file = await handle.getFile();
+                 inode.update({
+@@ -165,7 +177,17 @@ export class WebAccessFS extends Async(IndexFS) {
              log.crit(withErrno('EIO', 'Mismatch in entry kind on write'));
              return;
          }

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -1,19 +1,19 @@
 {
-  "//": "Metadata for the patch-package patches in this directory — one key per patched npm package. Consumed by the orphaned-patch guard (packages/dev-tools/patch-reconcile/check-patches.mjs, run as `npm run lint:patches`) and the renovate-patch-reconcile workflow. Every patches/<pkg>+<version>.patch MUST have an entry here with a matching patchedVersion. When a patch is removed, delete its entry. See patches/README.md.",
+  "//": "Metadata for the patch-package patches in this directory \u2014 one key per patched npm package. Consumed by the orphaned-patch guard (packages/dev-tools/patch-reconcile/check-patches.mjs, run as `npm run lint:patches`) and the renovate-patch-reconcile workflow. Every patches/<pkg>+<version>.patch MUST have an entry here with a matching patchedVersion. When a patch is removed, delete its entry. See patches/README.md.",
   "@zenfs/core": {
     "patchedVersion": "2.6.2",
     "upstream": "https://github.com/zen-fs/core",
     "issue": null,
-    "reason": "Make globalThis.__zenfs__ a null-prototype own-property copy of fs (Object.assign(Object.create(null), fs)) instead of a prototype view, so the fs export's enumerable members are reliably visible on the global probe.",
-    "removeWhen": "Local workaround — no upstream PR is tracked. Re-evaluate whenever @zenfs/core changes the __zenfs__ global or the fs export shape; if a newer version no longer needs the override, remove the patch.",
-    "verify": "npm run typecheck"
+    "reason": "Make globalThis.__zenfs__ a null-prototype own-property copy of fs (Object.assign(Object.create(null), fs)) instead of a prototype view, so the fs export's enumerable members are reliably visible on the global probe. ALSO (#2146): VCache.ref coalesced DIFFERENT paths onto one vnode when their inodes shared an ino (poisoned indexes carry many ino-0 entries) \u2014 the shared inode object cross-stamps size/mode between unrelated files. The patch refuses cross-path coalescing when ino is 0 or the format bits differ (hardlinks share both a real ino and a mode, so they still coalesce).",
+    "removeWhen": "Local workaround \u2014 no upstream PR is tracked. Re-evaluate whenever @zenfs/core changes the __zenfs__ global or the fs export shape; if a newer version no longer needs the override, remove the patch.",
+    "verify": "npm run test -w @slicc/webapp -- zenfs-ino-collision-patch"
   },
   "@zenfs/dom": {
     "patchedVersion": "1.2.10",
     "upstream": "https://github.com/zen-fs/dom",
     "issue": null,
-    "reason": "WebAccessFS.write opened every write with createWritable({ keepExistingData: true }), so Chromium copied the whole existing file into the swap file first — O(file size) per write even when the write replaces the file (92 MB rewrite: 480ms -> 240ms without the copy). Worse, IndexFS.touch only narrows the in-memory inode and nothing truncates the handle, so a shrink left its tail on disk forever (92 MB file rewritten as 4 MB kept 92 MB of OPFS quota). The patch keeps the copy only where the write needs it: a non-zero offset, or a buffer that does not span the indexed size.",
-    "removeWhen": "Local workaround — no upstream PR is tracked. Remove once @zenfs/dom decides keepExistingData per write (or truncates the handle on a narrowing touch) upstream.",
+    "reason": "WebAccessFS.write opened every write with createWritable({ keepExistingData: true }), so Chromium copied the whole existing file into the swap file first \u2014 O(file size) per write even when the write replaces the file (92 MB rewrite: 480ms -> 240ms without the copy). Worse, IndexFS.touch only narrows the in-memory inode and nothing truncates the handle, so a shrink left its tail on disk forever (92 MB file rewritten as 4 MB kept 92 MB of OPFS quota). The patch keeps the copy only where the write needs it: a non-zero offset, or a buffer that does not span the indexed size. ALSO (#2146): WebAccessFS minted ino:0 inodes in stat's ENOENT recovery and _loadMetadata's reality branch; thousands of ino-0 index entries collapse onto one VFS vnode-cache slot, stamping one file's size/mode onto another path on sync (phantom directories, sibling-size truncation). The patch allocates unique ino/data pairs at both sites.",
+    "removeWhen": "Local workaround \u2014 no upstream PR is tracked. Remove once @zenfs/dom decides keepExistingData per write (or truncates the handle on a narrowing touch) upstream.",
     "verify": "npm run test -w @slicc/webapp -- zenfs-dom-overwrite-patch"
   },
   "e2b": {


### PR DESCRIPTION
Fixes #2146 (and closes the reopened half of #2006 — same mechanism).

**Stacked on #2143** — merge that first; the `.jsh` throw-guard builds on its `makeScriptCommand` changes. This PR's own diff is what shows against the `feat/shell-real-path-home` base.

## Root cause — one bug behind all three findings

ZenFS keys its VFS **vnode cache by `inode.ino`**, and `@zenfs/dom` minted `ino: 0` inodes at two sites (stat's ENOENT recovery, `_loadMetadata`'s reality branch). Colliding entries collapse onto ONE shared vnode; `VNode.sync()` then stamps the shared inode's **size and mode** onto a single path:

- **Phantom directories** (findings 1–2, and #2006 itself): a file's mode became its sibling *directory's* — `session.md` even carried `snapshots/`'s size 15,014.
- **Sibling-size truncation** (finding 3): `newrelic.jsh` (26,623 B) recorded at its batch-mate `SKILL.md`'s 5,752. The sidecar `size` is authoritative at boot, reads clamp to the inode size (an **under**-sized inode never throws — the over-sized case trips the existing repair, which is why this hid), and `crossCopy` seeds the sync cache short for the whole session. Disk bytes were intact all along.
- **The spread**: our own #2006 heal evicted index entries, which were re-minted at `ino: 0` — a feedback loop.

**Confirmed live before writing a line**: on the production leader that filed the issue, 2,858 of 14,763 sidecar entries shared `ino: 0` — one cluster containing `/`, `/workspace`, whole mounted subtrees, and `newrelic.jsh` itself.

## The fix set

| Layer | Change |
| --- | --- |
| `patches/@zenfs+dom` | both ino-minting sites allocate unique `ino`/`data` pairs |
| `patches/@zenfs+core` | `VCache.ref` refuses to coalesce **different paths** onto one vnode when `ino === 0` or the format bits differ (hardlinks share a real ino *and* a mode, so they still coalesce; a same-path re-ref falls back to the by-path lookup) |
| boot repair | runs **unconditionally** before mount (was wired only as an on-throw retry — unreachable for this silent class) + a pure ino-uniqueness pass that heals field-poisoned sidecars on next load (`inosReassigned` in the summary) |
| in-session heal | `rm`/`rename` join `withKindMismatchRetry` (rename via a dual-path variant healing whichever end is poisoned — finding 1's rename-escape observation, weaponized); `EINVAL` joins `EISDIR`/`ENOTDIR` as retryable — the issue's full op table |
| diagnostics | the literal `<path>` messages die three ways: `convertError` stops double-wrapping pre-formatted ZenFS messages (`ENOTDIR: ENOTDIR: …, undefined '…' '…'`); a `.jsh` dispatch failure returns a result instead of **throwing into just-bash's path sanitizer** (the actual `<path>` producer — also invalidates the mis-diagnosed #1033-1 scrub in `git/clone.ts`); `mkdir -p` reports `ENOTDIR` naming the FILE component it used to swallow as `EEXIST` (how `/dev/null`'s phantom was born) |
| realm flush | one poisoned path no longer sinks the batch: the per-exec flush is guarded (mirroring the end-of-script flush) and `applySyncFsMutations` applies per-entry, reporting casualties — this is what turned one bad entry into "every `.jsh` command is dead" |

## Test plan

- [x] 8 behavioral tests verified failing against the pre-fix source (delete-family heal ×3, mkdir ENOTDIR, `.jsh` message survival, sidecar ino pass ×2, convertError, realm per-entry flush)
- [x] zenfs patch-presence guards + a behavioral `VCache` test (distinct vnodes for ino-0 paths and format mismatches; hardlinks still share) — wired as the `patches.json` `verify` commands
- [x] `npm run lint:patches` green (both patches regenerated, manifest updated)
- [x] Full webapp suite 11,590 passing; typecheck clean; `check-touched-exemptions` OK (33 files, 0 debt)
- [x] Base-branch caveat: local `verify`'s biome leg shows the `secrets-entry.ts` `$` error pre-existing from the branch point (fixed on later main; disappears on the queue rebase)

## Risk & rollback

The zenfs patches change only the two minting sites and one cache-admission check; hardlink semantics are preserved and pinned by test. The unconditional boot repair costs one metadata-only probe per sidecar entry per cold boot (skips the rewrite when nothing changed). Reverting restores today's behavior: silent cross-file corruption under concurrent writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65
