### PR TITLE
fix(sudo): persist read grants in scoop ACLs

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -350,7 +350,6 @@
         "packages/webapp/tests/fs/internal-mount.test.ts",
         "packages/webapp/tests/fs/sudo-fs.test.ts",
         "packages/webapp/tests/kernel/realm/realm-runner.test.ts",
-        "packages/webapp/tests/scoops/orchestrator.test.ts",
         "packages/webapp/tests/shell/di/di.test.ts",
         "packages/webapp/tests/shell/supplemental-commands/esbuild-command.test.ts",
         "packages/webapp/tests/shell/supplemental-commands/v86-command.test.ts",

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -212,10 +212,11 @@ shutdown, or the per-request timeout (`CONE_SUDO_TIMEOUT_MS`).
 sink that powers `seedScoopSudoers`, so it bypasses the per-scoop self-protection
 on `/scoops/<folder>/etc/sudoers`). Persisted `Read` globs also widen the live
 `RestrictedFS` ACL, and are reapplied from the scoop policy whenever its context
-is recreated; non-matching sibling paths remain hidden. `kind: 'secret'` cannot
-be persisted because there is no matching sudoers directive — the cone tool
-surfaces this as "approved but not persisted" so the agent retries the request
-next time.
+is recreated. Live sudoers reloads replace those dynamic grants, so manually
+adding or revoking a rule updates the running scoop too; non-matching sibling
+paths remain hidden. `kind: 'secret'` cannot be persisted because there is no
+matching sudoers directive — the cone tool surfaces this as "approved but not
+persisted" so the agent retries the request next time.
 
 An "always" grant is only as durable as the folder it lands in. One-shot agents
 spawned through `AgentBridge` get a random `agent-<adjective>-<flavor>` folder

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -210,9 +210,12 @@ shutdown, or the per-request timeout (`CONE_SUDO_TIMEOUT_MS`).
 "Always" grants for `kind: 'command' | 'read' | 'write'` are persisted via
 `SudoManager.appendScoopRule(folder, kind, pattern)` (raw-VFS write, same trusted
 sink that powers `seedScoopSudoers`, so it bypasses the per-scoop self-protection
-on `/scoops/<folder>/etc/sudoers`). `kind: 'secret'` cannot be persisted because
-there is no matching sudoers directive — the cone tool surfaces this as
-"approved but not persisted" so the agent retries the request next time.
+on `/scoops/<folder>/etc/sudoers`). Persisted `Read` globs also widen the live
+`RestrictedFS` ACL, and are reapplied from the scoop policy whenever its context
+is recreated; non-matching sibling paths remain hidden. `kind: 'secret'` cannot
+be persisted because there is no matching sudoers directive — the cone tool
+surfaces this as "approved but not persisted" so the agent retries the request
+next time.
 
 An "always" grant is only as durable as the folder it lands in. One-shot agents
 spawned through `AgentBridge` get a random `agent-<adjective>-<flavor>` folder

--- a/packages/webapp/src/fs/path-utils.ts
+++ b/packages/webapp/src/fs/path-utils.ts
@@ -27,6 +27,43 @@ export function normalizePath(path: string): string {
   return '/' + resolved.join('/');
 }
 
+/** Escape a single literal character for use inside a RegExp. */
+function escapeRegExpChar(ch: string): string {
+  return '.+^$()[]|\\{}'.includes(ch) ? `\\${ch}` : ch;
+}
+
+/**
+ * Glob → RegExp for normalized VFS paths. `*` matches within a single path
+ * segment (no `/`); `**` matches across segments. A trailing `/**` also
+ * matches the directory itself (so `/a/b/**` matches `/a/b`).
+ */
+export function pathGlobToRegExp(pattern: string): RegExp {
+  let re = '';
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === '*' && pattern[i + 1] === '*') {
+      if (re.endsWith('/')) {
+        re = `${re.slice(0, -1)}(?:/.*)?`;
+      } else {
+        re += '.*';
+      }
+      i += 2;
+      if (pattern[i] === '/') i += 1;
+    } else if (ch === '*') {
+      re += '[^/]*';
+      i += 1;
+    } else if (ch === '?') {
+      re += '[^/]';
+      i += 1;
+    } else {
+      re += escapeRegExpChar(ch);
+      i += 1;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
 /** Split a path into its directory and base name. */
 export function splitPath(path: string): { dir: string; base: string } {
   const normalized = normalizePath(path);

--- a/packages/webapp/src/fs/restricted-fs.ts
+++ b/packages/webapp/src/fs/restricted-fs.ts
@@ -90,12 +90,18 @@ export class RestrictedFS {
   }
 
   /**
-   * Widen this live sandbox with an approved read glob. Ancestor matchers let
-   * directory traversal and filtered `readDir` calls reach matching files
-   * without exposing non-matching siblings.
+   * Replace dynamic read grants from the current sudoers policy. Ancestor
+   * matchers let directory traversal and filtered `readDir` calls reach
+   * matching files without exposing non-matching siblings.
    */
-  addReadGrant(pattern: string): void {
-    if (this.readGrantPatterns.some((grant) => grant.pattern === pattern)) return;
+  setReadGrants(patterns: readonly string[]): void {
+    this.readGrantPatterns = [];
+    for (const pattern of new Set(patterns)) {
+      this.addReadGrant(pattern);
+    }
+  }
+
+  private addReadGrant(pattern: string): void {
     const segments = pattern.split('/');
     const ancestorRegexes: RegExp[] = [];
     for (let i = 1; i < segments.length; i++) {

--- a/packages/webapp/src/fs/restricted-fs.ts
+++ b/packages/webapp/src/fs/restricted-fs.ts
@@ -21,7 +21,7 @@
 import type { FsWatchCallback, FsWatchFilter } from './fs-watcher.js';
 import type { MountBackend, RefreshReport } from './mount/backend.js';
 import type { MountIndexEnv } from './mount-index.js';
-import { normalizePath } from './path-utils.js';
+import { normalizePath, pathGlobToRegExp } from './path-utils.js';
 import type {
   DirEntry,
   FileContent,
@@ -63,6 +63,8 @@ export class RestrictedFS {
   private vfs: VirtualFS;
   private allowedPrefixes: string[];
   private readOnlyPrefixes: string[];
+  private readGrantPatterns: Array<{ pattern: string; regex: RegExp; ancestorRegexes: RegExp[] }> =
+    [];
   private writeEnforcement: RestrictedFsWriteEnforcement;
 
   constructor(
@@ -87,16 +89,49 @@ export class RestrictedFS {
     return [...this.allowedPrefixes, ...this.readOnlyPrefixes, ...mountPrefixes];
   }
 
+  /**
+   * Widen this live sandbox with an approved read glob. Ancestor matchers let
+   * directory traversal and filtered `readDir` calls reach matching files
+   * without exposing non-matching siblings.
+   */
+  addReadGrant(pattern: string): void {
+    if (this.readGrantPatterns.some((grant) => grant.pattern === pattern)) return;
+    const segments = pattern.split('/');
+    const ancestorRegexes: RegExp[] = [];
+    for (let i = 1; i < segments.length; i++) {
+      ancestorRegexes.push(pathGlobToRegExp(segments.slice(0, i).join('/') || '/'));
+    }
+    this.readGrantPatterns.push({
+      pattern,
+      regex: pathGlobToRegExp(pattern),
+      ancestorRegexes,
+    });
+  }
+
+  private matchesReadGrant(path: string): boolean {
+    return this.readGrantPatterns.some((grant) => grant.regex.test(path));
+  }
+
+  private leadsToReadGrant(path: string): boolean {
+    return this.readGrantPatterns.some((grant) =>
+      grant.ancestorRegexes.some((regex) => regex.test(path))
+    );
+  }
+
   /** Check if a path is within or is a parent of allowed or read-only prefixes. */
   private isAllowed(path: string): boolean {
     const normalized = normalizePath(path);
     const allPrefixes = this.getAllPrefixes();
-    return allPrefixes.some(
-      (prefix) =>
-        normalized === prefix.slice(0, -1) ||
-        normalized.startsWith(prefix) ||
-        normalized === '/' ||
-        prefix.startsWith(normalized + '/')
+    return (
+      this.matchesReadGrant(normalized) ||
+      this.leadsToReadGrant(normalized) ||
+      allPrefixes.some(
+        (prefix) =>
+          normalized === prefix.slice(0, -1) ||
+          normalized.startsWith(prefix) ||
+          normalized === '/' ||
+          prefix.startsWith(normalized + '/')
+      )
     );
   }
 
@@ -104,8 +139,11 @@ export class RestrictedFS {
   private isAllowedStrict(path: string): boolean {
     const normalized = normalizePath(path);
     const allPrefixes = this.getAllPrefixes();
-    return allPrefixes.some(
-      (prefix) => normalized === prefix.slice(0, -1) || normalized.startsWith(prefix)
+    return (
+      this.matchesReadGrant(normalized) ||
+      allPrefixes.some(
+        (prefix) => normalized === prefix.slice(0, -1) || normalized.startsWith(prefix)
+      )
     );
   }
 

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -220,7 +220,6 @@ export class Orchestrator implements ConeApprovalRouter {
   private approvalRouter: ScoopApprovalRouter = new ScoopApprovalRouter({
     getScoops: () => this.scoops,
     getSudoManager: () => this.sudoManager,
-    applyReadGrant: (jid, pattern) => this.lifecycle.applyReadGrant(jid, pattern),
     getLickManager: () => this.lickManager,
     handleMessage: (msg) => this.handleMessage(msg),
     onMessageUpdate: (jid, update) => this.callbacks.onMessageUpdate?.(jid, update),
@@ -368,7 +367,11 @@ export class Orchestrator implements ConeApprovalRouter {
     // template, loads + merges the live policy, and watches for changes so
     // edits (and "Always" grants) take effect with no restart. The same
     // manager is threaded into every ScoopContext below.
-    this.sudoManager = new SudoManager({ fs: this.sharedFs, watcher: this.fsWatcher });
+    this.sudoManager = new SudoManager({
+      fs: this.sharedFs,
+      watcher: this.fsWatcher,
+      onPolicyReload: (folder) => this.lifecycle.syncReadGrants(folder),
+    });
     await this.sudoManager.init();
 
     const savedScoops = await db.getAllScoops();
@@ -896,7 +899,11 @@ export class Orchestrator implements ConeApprovalRouter {
     // Rebuild the sudo manager against the fresh VFS: re-seeds the default
     // /etc/sudoers template and re-attaches the live-reload watcher.
     this.sudoManager?.dispose();
-    this.sudoManager = new SudoManager({ fs: this.sharedFs, watcher: this.fsWatcher });
+    this.sudoManager = new SudoManager({
+      fs: this.sharedFs,
+      watcher: this.fsWatcher,
+      onPolicyReload: (folder) => this.lifecycle.syncReadGrants(folder),
+    });
     await this.sudoManager.init();
     this.costTracker.reset();
     log.info('Filesystem reset and defaults re-seeded');

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -220,6 +220,7 @@ export class Orchestrator implements ConeApprovalRouter {
   private approvalRouter: ScoopApprovalRouter = new ScoopApprovalRouter({
     getScoops: () => this.scoops,
     getSudoManager: () => this.sudoManager,
+    applyReadGrant: (jid, pattern) => this.lifecycle.applyReadGrant(jid, pattern),
     getLickManager: () => this.lickManager,
     handleMessage: (msg) => this.handleMessage(msg),
     onMessageUpdate: (jid, update) => this.callbacks.onMessageUpdate?.(jid, update),

--- a/packages/webapp/src/scoops/scoop-approval-router.ts
+++ b/packages/webapp/src/scoops/scoop-approval-router.ts
@@ -37,8 +37,6 @@ export interface ScoopApprovalRouterDeps {
   getScoops(): Map<string, RegisteredScoop>;
   /** Live SudoManager (or null before init / after shutdown). The `'always'` path writes a NOPASSWD rule via this sink. */
   getSudoManager(): SudoManager | null;
-  /** Widen the requesting scoop's live RestrictedFS after a Read rule is persisted. */
-  applyReadGrant(scoopJid: string, pattern: string): void;
   /** Live LickManager (or null before wiring). Used to emit the `'sudo-request'` UI chip. */
   getLickManager(): LickManager | null;
   /** Route the cone-facing actionable message through the orchestrator's normal queue. */
@@ -218,6 +216,14 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
       return { settled: false, persisted: false };
     }
 
+    // Claim the request synchronously before any persistence await. This
+    // cancels its fail-closed timer, so an expired request can never gain a
+    // durable rule after the registry has already denied it.
+    const settled = this.resolveSudoRequest(id, decision);
+    if (!settled) {
+      return { settled: false, persisted: false };
+    }
+
     const scoop = this.deps.getScoops().get(pending.scoopJid);
     const kind = pending.request.kind;
     const scoopFolder = scoop?.folder;
@@ -238,9 +244,6 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
           if (saved) {
             persisted = true;
             persistedPattern = saved;
-            if (kind === 'read') {
-              this.deps.applyReadGrant(pending.scoopJid, saved);
-            }
           } else {
             persistError = 'pattern collapsed to empty after sanitization';
           }
@@ -258,10 +261,7 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
       }
     }
 
-    const settled = this.resolveSudoRequest(id, decision);
-    if (settled) {
-      await this.persistLickDecision(id, decision.decision);
-    }
+    await this.persistLickDecision(id, decision.decision);
     return { settled, persisted, persistedPattern, persistError, scoopFolder, kind };
   }
 

--- a/packages/webapp/src/scoops/scoop-approval-router.ts
+++ b/packages/webapp/src/scoops/scoop-approval-router.ts
@@ -37,6 +37,8 @@ export interface ScoopApprovalRouterDeps {
   getScoops(): Map<string, RegisteredScoop>;
   /** Live SudoManager (or null before init / after shutdown). The `'always'` path writes a NOPASSWD rule via this sink. */
   getSudoManager(): SudoManager | null;
+  /** Widen the requesting scoop's live RestrictedFS after a Read rule is persisted. */
+  applyReadGrant(scoopJid: string, pattern: string): void;
   /** Live LickManager (or null before wiring). Used to emit the `'sudo-request'` UI chip. */
   getLickManager(): LickManager | null;
   /** Route the cone-facing actionable message through the orchestrator's normal queue. */
@@ -226,13 +228,7 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
     let persistError: string | undefined;
 
     if (decision.decision === 'always' && sudoManager && scoop && !scoop.isCone) {
-      if (kind === 'read') {
-        // A persisted `NOPASSWD Read <pattern>` would silently no-op: the
-        // scoop's `RestrictedFS.visiblePaths` is fixed at construction, so
-        // subsequent reads of paths outside the original sandbox keep
-        // throwing ENOENT. Reporting `persisted: true` would be a lie.
-        persistError = 'read grants need ACL widening, not yet supported';
-      } else if (kind === 'command' || kind === 'write') {
+      if (kind === 'command' || kind === 'read' || kind === 'write') {
         const raw =
           decision.pattern?.trim() ||
           pending.request.suggestedPattern?.trim() ||
@@ -242,6 +238,9 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
           if (saved) {
             persisted = true;
             persistedPattern = saved;
+            if (kind === 'read') {
+              this.deps.applyReadGrant(pending.scoopJid, saved);
+            }
           } else {
             persistError = 'pattern collapsed to empty after sanitization';
           }

--- a/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
+++ b/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
@@ -188,11 +188,12 @@ export class ScoopLifecycleManager {
     return this.contexts.get(jid);
   }
 
-  /** Apply a newly approved Read glob to a scoop's live RestrictedFS. */
-  applyReadGrant(jid: string, pattern: string): void {
-    const fs = this.contexts.get(jid)?.getFS();
-    if (fs instanceof RestrictedFS) {
-      fs.addReadGrant(pattern);
+  /** Synchronize live read ACLs after a global or per-scoop policy reload. */
+  syncReadGrants(folder?: string): void {
+    for (const scoop of this.deps.getScoops().values()) {
+      if (scoop.isCone || (folder !== undefined && scoop.folder !== folder)) continue;
+      const fs = this.contexts.get(scoop.jid)?.getFS();
+      this.applyPolicyReadGrants(scoop, fs);
     }
   }
 
@@ -269,14 +270,15 @@ export class ScoopLifecycleManager {
     }
   }
 
-  /** Reapply durable NOPASSWD Read rules when constructing a RestrictedFS. */
-  private applyPersistedReadGrants(scoop: RegisteredScoop, fs: VirtualFS | RestrictedFS): void {
+  /** Replace dynamic read ACLs from the scoop's current effective policy. */
+  private applyPolicyReadGrants(
+    scoop: RegisteredScoop,
+    fs: VirtualFS | RestrictedFS | null | undefined
+  ): void {
     if (!(fs instanceof RestrictedFS)) return;
     const policy = this.deps.getSudoManager()?.getPolicyForScoop(scoop.folder);
     if (!policy) return;
-    for (const rule of policy.read) {
-      if (rule.nopasswd) fs.addReadGrant(rule.pattern);
-    }
+    fs.setReadGrants(policy.read.filter((rule) => rule.nopasswd).map((rule) => rule.pattern));
   }
 
   /** Create and initialize a scoop context. */
@@ -322,7 +324,7 @@ export class ScoopLifecycleManager {
 
     if (!scoop.isCone) {
       await this.ensureSudoersLoaded(scoop);
-      this.applyPersistedReadGrants(scoop, fs);
+      this.applyPolicyReadGrants(scoop, fs);
     }
 
     const contextCallbacks = this.buildContextCallbacks(jid, scoop);

--- a/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
+++ b/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
@@ -188,6 +188,14 @@ export class ScoopLifecycleManager {
     return this.contexts.get(jid);
   }
 
+  /** Apply a newly approved Read glob to a scoop's live RestrictedFS. */
+  applyReadGrant(jid: string, pattern: string): void {
+    const fs = this.contexts.get(jid)?.getFS();
+    if (fs instanceof RestrictedFS) {
+      fs.addReadGrant(pattern);
+    }
+  }
+
   /** Live tab state for a single jid (or `undefined`). */
   getTab(jid: string): ScoopTabState | undefined {
     return this.tabs.get(jid);
@@ -261,6 +269,16 @@ export class ScoopLifecycleManager {
     }
   }
 
+  /** Reapply durable NOPASSWD Read rules when constructing a RestrictedFS. */
+  private applyPersistedReadGrants(scoop: RegisteredScoop, fs: VirtualFS | RestrictedFS): void {
+    if (!(fs instanceof RestrictedFS)) return;
+    const policy = this.deps.getSudoManager()?.getPolicyForScoop(scoop.folder);
+    if (!policy) return;
+    for (const rule of policy.read) {
+      if (rule.nopasswd) fs.addReadGrant(rule.pattern);
+    }
+  }
+
   /** Create and initialize a scoop context. */
   async createTab(jid: string): Promise<void> {
     const scoop = this.deps.getScoops().get(jid);
@@ -304,6 +322,7 @@ export class ScoopLifecycleManager {
 
     if (!scoop.isCone) {
       await this.ensureSudoersLoaded(scoop);
+      this.applyPersistedReadGrants(scoop, fs);
     }
 
     const contextCallbacks = this.buildContextCallbacks(jid, scoop);

--- a/packages/webapp/src/shell/sudo/sudoers.ts
+++ b/packages/webapp/src/shell/sudo/sudoers.ts
@@ -12,8 +12,10 @@
  */
 
 import { createLogger } from '../../base/logger.js';
-import { normalizePath } from '../../fs/path-utils.js';
+import { normalizePath, pathGlobToRegExp } from '../../fs/path-utils.js';
 import { isNoOpWriteDevicePath } from '../../fs/virtual-device-paths.js';
+
+export { pathGlobToRegExp } from '../../fs/path-utils.js';
 
 const log = createLogger('sudo:sudoers');
 
@@ -124,38 +126,6 @@ export function commandGlobToRegExp(pattern: string): RegExp {
   }
   // dotAll ('s') so `*` and `?` match across newlines in multiline commands
   return new RegExp(`^${re}$`, 's');
-}
-
-/**
- * Glob → RegExp for normalized VFS paths. `*` matches within a single path
- * segment (no `/`); `**` matches across segments. A trailing `/**` also
- * matches the directory itself (so `/a/b/**` matches `/a/b`).
- */
-export function pathGlobToRegExp(pattern: string): RegExp {
-  let re = '';
-  let i = 0;
-  while (i < pattern.length) {
-    const ch = pattern[i];
-    if (ch === '*' && pattern[i + 1] === '*') {
-      if (re.endsWith('/')) {
-        re = `${re.slice(0, -1)}(?:/.*)?`;
-      } else {
-        re += '.*';
-      }
-      i += 2;
-      if (pattern[i] === '/') i += 1;
-    } else if (ch === '*') {
-      re += '[^/]*';
-      i += 1;
-    } else if (ch === '?') {
-      re += '[^/]';
-      i += 1;
-    } else {
-      re += escapeRegExpChar(ch);
-      i += 1;
-    }
-  }
-  return new RegExp(`^${re}$`);
 }
 
 /**

--- a/packages/webapp/src/sudo/sudo-manager.ts
+++ b/packages/webapp/src/sudo/sudo-manager.ts
@@ -48,6 +48,8 @@ export interface SudoManagerDeps {
   watcher?: FsWatcher | null;
   /** Override the broker (tests). Defaults to the float-appropriate broker. */
   broker?: SudoBroker;
+  /** Notify consumers after global or per-scoop policy reloads. */
+  onPolicyReload?: (folder?: string) => void;
 }
 
 /** Whether `path` is one of the (live-reload-triggering) sudoers files. */
@@ -146,6 +148,7 @@ export class SudoManager {
   private readonly fs: VirtualFS;
   private readonly watcher: FsWatcher | null;
   private readonly broker: SudoBroker;
+  private readonly onPolicyReload: (folder?: string) => void;
   private policy: SudoersPolicy = emptyPolicy();
   private unwatch: (() => void) | null = null;
   private scoopUnwatch: (() => void) | null = null;
@@ -159,6 +162,7 @@ export class SudoManager {
     this.fs = deps.fs;
     this.watcher = deps.watcher ?? null;
     this.broker = deps.broker ?? createSudoBroker();
+    this.onPolicyReload = deps.onPolicyReload ?? (() => {});
   }
 
   /** Seed defaults, load the policy, and start watching for live reload. */
@@ -313,13 +317,16 @@ export class SudoManager {
     try {
       if (!(await this.fs.exists(path))) {
         this.scoopPolicies.delete(folder);
+        this.onPolicyReload(folder);
         return;
       }
     } catch {
       this.scoopPolicies.delete(folder);
+      this.onPolicyReload(folder);
       return;
     }
     this.scoopPolicies.set(folder, await this.readPolicyFile(path));
+    this.onPolicyReload(folder);
   }
 
   private async doReload(): Promise<void> {
@@ -337,6 +344,7 @@ export class SudoManager {
       /* no drop-in directory yet */
     }
     this.policy = mergePolicies(...policies);
+    this.onPolicyReload();
   }
 
   private async readPolicyFile(path: string): Promise<SudoersPolicy> {

--- a/packages/webapp/src/sudo/sudo-manager.ts
+++ b/packages/webapp/src/sudo/sudo-manager.ts
@@ -245,8 +245,8 @@ export class SudoManager {
         const raw = await this.fs.readFile(path, { encoding: 'utf-8' });
         existing = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
       }
-    } catch {
-      existing = '';
+    } catch (err) {
+      if (!(err instanceof FsError && err.code === 'ENOENT')) throw err;
     }
     try {
       await this.fs.mkdir(`/scoops/${folder}/etc`, { recursive: true });

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -83,13 +83,16 @@ describe('RestrictedFS', () => {
     await vfs.writeFile('/recordings/notes.txt', 'private');
 
     await expect(restricted.readFile('/recordings/first.har')).rejects.toThrow('ENOENT');
-    restricted.addReadGrant('/recordings/*.har');
+    restricted.setReadGrants(['/recordings/*.har']);
 
     expect(await restricted.readTextFile('/recordings/first.har')).toBe('approved');
     await expect(restricted.readFile('/recordings/notes.txt')).rejects.toThrow('ENOENT');
     expect((await restricted.readDir('/recordings')).map((entry) => entry.name)).toEqual([
       'first.har',
     ]);
+
+    restricted.setReadGrants([]);
+    await expect(restricted.readFile('/recordings/first.har')).rejects.toThrow('ENOENT');
   });
 
   it('writes within allowed dirs', async () => {

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -77,6 +77,21 @@ describe('RestrictedFS', () => {
     expect(entries).toEqual([]);
   });
 
+  it('widens reads for an approved glob without exposing non-matching siblings', async () => {
+    await vfs.mkdir('/recordings', { recursive: true });
+    await vfs.writeFile('/recordings/first.har', 'approved');
+    await vfs.writeFile('/recordings/notes.txt', 'private');
+
+    await expect(restricted.readFile('/recordings/first.har')).rejects.toThrow('ENOENT');
+    restricted.addReadGrant('/recordings/*.har');
+
+    expect(await restricted.readTextFile('/recordings/first.har')).toBe('approved');
+    await expect(restricted.readFile('/recordings/notes.txt')).rejects.toThrow('ENOENT');
+    expect((await restricted.readDir('/recordings')).map((entry) => entry.name)).toEqual([
+      'first.har',
+    ]);
+  });
+
   it('writes within allowed dirs', async () => {
     await restricted.writeFile('/scoops/andy-scoop/new.txt', 'new content');
     const content = await vfs.readFile('/scoops/andy-scoop/new.txt', { encoding: 'utf-8' });

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -1819,7 +1819,7 @@ describe('Orchestrator scoop-notify onIncomingMessage visibility', () => {
     // Give the micro-tasks a chance to register the waiters.
     await new Promise((resolve) => setTimeout(resolve, 5));
     priv.completionService.scoopResponseBuffer.set(scoop.jid, 'dedup output');
-    priv.completionService.notifyCompletion(scoop.jid);
+    await priv.completionService.notifyCompletion(scoop.jid);
     const results = await waitPromise;
 
     expect(results).toHaveLength(2);
@@ -2796,9 +2796,14 @@ describe('Orchestrator.resolveSudoRequestAndPersist', () => {
         list: () => Array<{ id: string }>;
       };
     };
+    lifecycle: {
+      getContext: (jid: string) => {
+        getFS: () => import('../../src/fs/restricted-fs.js').RestrictedFS;
+      };
+    };
   }
 
-  it('rejects read+always persistence with the ACL-widening error', async () => {
+  it('persists read+always and widens the live and restored scoop ACL to the approved glob', async () => {
     const container =
       typeof document !== 'undefined'
         ? document.createElement('div')
@@ -2807,25 +2812,46 @@ describe('Orchestrator.resolveSudoRequestAndPersist', () => {
     await orch.init();
 
     const priv = orch as unknown as OrchestratorPrivateSudo;
+    const sharedFs = orch.getSharedFS();
+    if (!sharedFs) throw new Error('Expected initialized shared filesystem');
+    await sharedFs.mkdir('/recordings', { recursive: true });
+    await sharedFs.writeFile('/recordings/first.har', 'approved capture');
+    await sharedFs.writeFile('/recordings/notes.txt', 'not approved');
+    const scoopFs = priv.lifecycle.getContext(testScoop.jid).getFS();
+    await expect(scoopFs.readFile('/recordings/first.har')).rejects.toThrow('ENOENT');
+
     const { id } = priv.approvalRouter.registry.register(testScoop.jid, {
       kind: 'read',
-      detail: '/shared/secrets/api.key',
+      detail: '/recordings/first.har',
     });
 
     const result = await orch.resolveSudoRequestAndPersist(id, {
       decision: 'always',
-      pattern: '/shared/secrets/**',
+      pattern: '/recordings/*.har',
     });
 
     expect(result.settled).toBe(true);
-    expect(result.persisted).toBe(false);
-    expect(result.persistedPattern).toBeUndefined();
-    expect(result.persistError).toBe('read grants need ACL widening, not yet supported');
+    expect(result.persisted).toBe(true);
+    expect(result.persistedPattern).toBe('/recordings/*.har');
+    expect(result.persistError).toBeUndefined();
     expect(result.kind).toBe('read');
     expect(result.scoopFolder).toBe(testScoop.folder);
+    expect(await scoopFs.readTextFile('/recordings/first.har')).toBe('approved capture');
+    await expect(scoopFs.readFile('/recordings/notes.txt')).rejects.toThrow('ENOENT');
+
+    const sudoers = (await sharedFs.readFile('/scoops/test-scoop/etc/sudoers', {
+      encoding: 'utf-8',
+    })) as string;
+    expect(sudoers).toContain('NOPASSWD Read /recordings/*.har');
+
+    await orch.destroyScoopTab(testScoop.jid);
+    await orch.createScoopTab(testScoop.jid);
+    const restoredFs = priv.lifecycle.getContext(testScoop.jid).getFS();
+    expect(await restoredFs.readTextFile('/recordings/first.har')).toBe('approved capture');
+    await expect(restoredFs.readFile('/recordings/notes.txt')).rejects.toThrow('ENOENT');
   });
 
-  it('still persists write+always (positive control — read rejection is read-only)', async () => {
+  it('still persists write+always', async () => {
     const container =
       typeof document !== 'undefined'
         ? document.createElement('div')

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -2849,6 +2849,12 @@ describe('Orchestrator.resolveSudoRequestAndPersist', () => {
     const restoredFs = priv.lifecycle.getContext(testScoop.jid).getFS();
     expect(await restoredFs.readTextFile('/recordings/first.har')).toBe('approved capture');
     await expect(restoredFs.readFile('/recordings/notes.txt')).rejects.toThrow('ENOENT');
+
+    await sharedFs.writeFile('/scoops/test-scoop/etc/sudoers', '# grant revoked\n');
+    await vi.waitFor(async () => {
+      expect(await restoredFs.exists('/recordings/first.har')).toBe(false);
+    });
+    await expect(restoredFs.readFile('/recordings/first.har')).rejects.toThrow('ENOENT');
   });
 
   it('still persists write+always', async () => {

--- a/packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts
+++ b/packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts
@@ -54,6 +54,7 @@ function makeHarness() {
   const deps: ScoopApprovalRouterDeps = {
     getScoops: () => scoops,
     getSudoManager: () => null,
+    applyReadGrant: vi.fn(),
     getLickManager: () => null,
     handleMessage,
     onMessageUpdate,

--- a/packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts
+++ b/packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../../src/scoops/scoop-approval-router.js';
 import type { ChannelMessage, RegisteredScoop } from '../../src/scoops/types.js';
 import { CONE_SUDO_TIMEOUT_MS } from '../../src/sudo/index.js';
+import type { SudoManager } from '../../src/sudo/sudo-manager.js';
 import type { SudoRequest } from '../../src/sudo/types.js';
 
 const REQ: SudoRequest = { kind: 'command', detail: 'git push origin main' };
@@ -34,7 +35,7 @@ function scoop(jid: string, isCone: boolean): RegisteredScoop {
   };
 }
 
-function makeHarness() {
+function makeHarness(sudoManager: SudoManager | null = null) {
   const cone = scoop('cone_jid', true);
   const requester = scoop('scoop_a', false);
   const scoops = new Map<string, RegisteredScoop>([
@@ -53,8 +54,7 @@ function makeHarness() {
   const onMessageUpdate = vi.fn();
   const deps: ScoopApprovalRouterDeps = {
     getScoops: () => scoops,
-    getSudoManager: () => null,
-    applyReadGrant: vi.fn(),
+    getSudoManager: () => sudoManager,
     getLickManager: () => null,
     handleMessage,
     onMessageUpdate,
@@ -63,6 +63,43 @@ function makeHarness() {
   };
   return { router: new ScoopApprovalRouter(deps), store, handleMessage, onMessageUpdate };
 }
+
+describe('ScoopApprovalRouter persistence settlement', () => {
+  it('claims the request before awaiting a durable rule write', async () => {
+    let finishAppend: (pattern: string) => void = () => {};
+    const appendScoopRule = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          finishAppend = resolve;
+        })
+    );
+    const sudoManager = { appendScoopRule } as unknown as SudoManager;
+    const h = makeHarness(sudoManager);
+    const pendingDecision = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'read',
+      detail: '/recordings/first.har',
+    });
+    await flush();
+    const [{ id }] = h.router.listPendingSudoRequests();
+
+    const resultPromise = h.router.resolveSudoRequestAndPersist(id, {
+      decision: 'always',
+      pattern: '/recordings/**',
+    });
+
+    expect(appendScoopRule).toHaveBeenCalledOnce();
+    expect(h.router.failAll()).toBe(0);
+    await expect(pendingDecision).resolves.toEqual({
+      decision: 'always',
+      pattern: '/recordings/**',
+    });
+
+    finishAppend('/recordings/**');
+    await expect(resultPromise).resolves.toEqual(
+      expect.objectContaining({ settled: true, persisted: true })
+    );
+  });
+});
 
 describe('ScoopApprovalRouter settle paths flip the lick card off pending', () => {
   it('scoop-dropped: failScoop flips the stored card to dismissed', async () => {

--- a/packages/webapp/tests/sudo/sudo-manager.test.ts
+++ b/packages/webapp/tests/sudo/sudo-manager.test.ts
@@ -10,6 +10,7 @@ import 'fake-indexeddb/auto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FsWatcher } from '../../src/fs/fs-watcher.js';
 import { VirtualFS } from '../../src/fs/index.js';
+import { FsError } from '../../src/fs/types.js';
 import {
   matchCommand,
   matchPath,
@@ -415,6 +416,26 @@ describe('SudoManager per-scoop policy view', () => {
     expect(matchCommand(mgr.getPolicyForScoop('andy'), 'git push origin main')).toBe(
       'nopasswd-allow'
     );
+    mgr.dispose();
+  });
+
+  it('appendScoopRule preserves existing grants when reading the policy fails', async () => {
+    const mgr = new SudoManager({ fs: vfs, watcher, broker });
+    await mgr.init();
+    await mgr.seedScoopSudoers('andy', { allowedCommands: ['git'] });
+    const path = scoopSudoersPath('andy');
+    const before = (await vfs.readFile(path, { encoding: 'utf-8' })) as string;
+    const readFile = vi
+      .spyOn(vfs, 'readFile')
+      .mockRejectedValueOnce(new FsError('EIO', 'transient read failure', path));
+
+    await expect(mgr.appendScoopRule('andy', 'read', '/recordings/**')).rejects.toThrow(
+      'transient read failure'
+    );
+
+    readFile.mockRestore();
+    expect(await vfs.readFile(path, { encoding: 'utf-8' })).toBe(before);
+    expect(matchCommand(mgr.getPolicyForScoop('andy'), 'git status')).toBe('nopasswd-allow');
     mgr.dispose();
   });
 


### PR DESCRIPTION
## Summary

- persist `always` Read approvals as `NOPASSWD Read` sudoers rules
- widen the requesting scoop's live `RestrictedFS` for the approved glob
- restore persisted Read grants whenever the scoop context is recreated
- preserve narrow glob visibility so non-matching sibling files remain hidden

## Verification

- `npm run typecheck`
- `npm run test`
- `npm run test:coverage`
- targeted Biome checks for all touched files
- `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- `npm run build -w @slicc/chrome-extension`
- `npm run bundle-size`
- full `npm run build` completed browser, Node, Cherry, and Cloudflare packages, then stopped at the untouched Swift package because Swift is not installed in the orb

`npm run verify` remains blocked by unrelated existing repository lint findings in `packages/chrome-extension/src/secrets-entry.ts` and `packages/shared-ts/src/tray-sync-protocol.ts`; its dead-code scan also exceeded the orb's memory limit. Touched-file checks pass.

Fixes #2139

Fixes #2154