### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -132,9 +132,9 @@
   },
   "swift": {
     "swift-server": {
-      "lines": 62,
-      "functions": 61,
-      "regions": 60
+      "lines": 63,
+      "functions": 62,
+      "regions": 61
     },
     "swift-launcher": {
       "lines": 41,


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.