### PR TITLE
refactor(worker): type cloud response envelopes

### DIFF
--- a/packages/cloudflare-worker/src/cloud/error-envelope.ts
+++ b/packages/cloudflare-worker/src/cloud/error-envelope.ts
@@ -1,12 +1,58 @@
+import type { ConeConfigIndex, ConeEntry } from '@slicc/cloud-core';
+
+interface CloudErrorDetails {
+  retryAfterSec?: number;
+  running?: number;
+  paused?: number;
+  cap?: number | { running: number; paused: number };
+  sandboxId?: string;
+}
+
+interface DefaultSuccessPayload {
+  ok: true;
+}
+
+interface StartSuccessPayload {
+  sandboxId: string;
+  name?: string;
+  joinUrl: string;
+}
+
+interface ResumeSuccessPayload {
+  sandboxId: string;
+  joinUrl: string;
+  trayRebuilt: boolean;
+}
+
+interface ListSuccessPayload {
+  cones: ConeEntry[];
+}
+
+interface ConeConfigSuccessPayload {
+  coneConfigIndex: ConeConfigIndex | null;
+}
+
+interface AdminStatsSuccessPayload {
+  note: string;
+}
+
+type CloudSuccessPayload =
+  | DefaultSuccessPayload
+  | StartSuccessPayload
+  | ResumeSuccessPayload
+  | ListSuccessPayload
+  | ConeConfigSuccessPayload
+  | AdminStatsSuccessPayload;
+
 export function errorResponse(
   status: number,
   code: string,
   message: string,
-  details?: Record<string, unknown>
+  details?: CloudErrorDetails
 ): Response {
   return Response.json({ error: code, message, ...(details ? { details } : {}) }, { status });
 }
 
-export function okResponse(payload: Record<string, unknown> = { ok: true }): Response {
+export function okResponse(payload: CloudSuccessPayload = { ok: true }): Response {
   return Response.json(payload, { status: 200 });
 }

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -6,7 +6,6 @@
   "packages/chrome-extension/src/secrets-storage.ts": 3,
   "packages/cloud-core/src/cone-config/index.ts": 6,
   "packages/cloud-core/src/errors.ts": 1,
-  "packages/cloudflare-worker/src/cloud/error-envelope.ts": 2,
   "packages/cloudflare-worker/src/cloud/handlers.ts": 1,
   "packages/cloudflare-worker/src/flags.ts": 2,
   "packages/cloudflare-worker/src/index.ts": 3,


### PR DESCRIPTION
**Solution**
- Name the accepted cloud error-detail fields and success envelopes so the helper no longer accepts generic string-keyed bags; serialization and callers remain unchanged.
- Regenerate the debt baseline to remove only `error-envelope.ts`.

**Testing**
- Full lint/typecheck/tests/coverage pass (14,458 tests; 80.72% line coverage); worker dry-run, extension build, bundle budgets, and touched-debt gate pass.
- Root JS build completed through the worker dry-run; native workspace continuation is unavailable because this Linux image has no Swift toolchain.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M0A1PHYZF1QXWEM62WG1DY8B&panel=chat)