### PR TITLE
fix(vfs): stop the log flood that hit V8's Set cap and took the VFS offline

### DIFF
--- a/packages/webapp/src/fs/error-rebrand.ts
+++ b/packages/webapp/src/fs/error-rebrand.ts
@@ -47,6 +47,23 @@ const KNOWN_CODES: FsErrorCode[] = [
  */
 export function convertError(err: unknown, path: string): FsError {
   if (err instanceof FsError) return err;
+  // V8 caps Set/Map at 2^24 elements; an overflowing structure inside the FS
+  // stack (kerium's log backlog, 2026-08-18 incident) throws
+  // `RangeError: Set maximum size exceeded` into every operation. ZenFS wraps
+  // it as EINVAL, which made a data-structure overflow read as a storage
+  // problem ("file system too full"). Detect the marker before the code
+  // mapping — whether it arrives raw or already errno-wrapped — and surface
+  // it as EIO with an explicit label instead.
+  {
+    const overflowMsg = err instanceof Error ? err.message : String(err);
+    if (overflowMsg.includes('maximum size exceeded')) {
+      return new FsError(
+        'EIO',
+        `internal overflow, not storage: ${overflowMsg} — reload the session`,
+        path
+      );
+    }
+  }
   // ZenFS ErrnoError carries `.code` directly (POSIX string).
   const structured = (err as { code?: unknown })?.code;
   if (typeof structured === 'string') {

--- a/packages/webapp/src/fs/sidecar-repair.ts
+++ b/packages/webapp/src/fs/sidecar-repair.ts
@@ -55,6 +55,15 @@ export interface SidecarRepairSummary {
    * sibling-size truncation).
    */
   inosReassigned: number;
+  /**
+   * Entries whose persisted `nlink` was zero/absent and got trued up to 1.
+   * ZenFS's `Inode` constructor warns on every `ino != 0 && nlink == 0`
+   * inode it materializes, and kerium retains every log entry — a sidecar
+   * full of `nlink: 0` entries (the pre-fix #2146 allocations wrote them)
+   * flooded the kernel worker's log until its backing Set hit V8's 2^24
+   * element cap and every FS op threw (2026-08-18 VFS-offline incident).
+   */
+  nlinksFixed: number;
   /** Whether anything changed (callers skip the rewrite when false). */
   changed: boolean;
 }
@@ -64,6 +73,7 @@ interface MutableEntry {
   size?: number;
   ino?: number;
   data?: number;
+  nlink?: number;
 }
 
 /**
@@ -74,8 +84,11 @@ interface MutableEntry {
  * - a `file` entry whose `size` disagrees with the real file is trued up
  *   (stale sizes surface as ZenFS "file data size mismatch" read errors);
  * - an entry whose path is missing on disk is dropped;
- * - symlink entries are left alone: their payload lives in a small real
- *   file, and `probe` reporting `file` for them is expected.
+ * - an entry persisted with `nlink: 0` is trued up to 1 (every such entry
+ *   makes ZenFS warn on every inode materialization, and kerium's log
+ *   retention turned that into the 2026-08-18 Set-overflow VFS outage);
+ * - symlink entries otherwise are left alone: their payload lives in a small
+ *   real file, and `probe` reporting `file` for them is expected.
  *
  * Mutates and returns `doc`; the summary says what happened.
  */
@@ -89,6 +102,7 @@ export async function repairSidecarDocument(
     dropped: 0,
     selfEntryDropped: false,
     inosReassigned: 0,
+    nlinksFixed: 0,
     changed: false,
   };
   const entries = doc.entries ?? {};
@@ -107,7 +121,10 @@ export async function repairSidecarDocument(
     }
     const entry = raw as MutableEntry;
     const fmt = (entry.mode ?? 0) & S_IFMT;
-    if (fmt === S_IFLNK) continue;
+    if (fmt === S_IFLNK) {
+      healNlink(entry, summary);
+      continue;
+    }
     const real = await probe(path);
     if (real.kind === 'missing') {
       delete entries[path];
@@ -115,6 +132,7 @@ export async function repairSidecarDocument(
       summary.changed = true;
       continue;
     }
+    healNlink(entry, summary);
     repairEntryAgainstReality(path, entry, fmt, real, summary);
   }
   reassignDuplicateInos(entries, summary);
@@ -162,6 +180,21 @@ function reassignDuplicateInos(
     summary.inosReassigned += 1;
     summary.changed = true;
   }
+}
+
+/**
+ * True up a persisted `nlink: 0` (or absent) to 1. ZenFS's `Inode`
+ * constructor logs a warning for every materialized inode with a real ino
+ * and no links, so a poisoned sidecar re-arms the warning on every stat of
+ * every path — see {@link SidecarRepairSummary.nlinksFixed}. Hardlinks are
+ * unsupported on this backend (`IndexFS.link` is ENOSYS), so 1 is always
+ * the correct count for a live entry.
+ */
+function healNlink(entry: MutableEntry, summary: SidecarRepairSummary): void {
+  if (entry.nlink) return;
+  entry.nlink = 1;
+  summary.nlinksFixed += 1;
+  summary.changed = true;
 }
 
 /** Correct one present-on-disk entry's format bits or size in place. */

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -378,6 +378,7 @@ export class VirtualFS {
             sizesFixed: preboot.sizesFixed,
             dropped: preboot.dropped,
             inosReassigned: preboot.inosReassigned,
+            nlinksFixed: preboot.nlinksFixed,
             selfEntryDropped: preboot.selfEntryDropped,
           });
         }
@@ -397,6 +398,7 @@ export class VirtualFS {
             kindFixed: summary.kindFixed,
             sizesFixed: summary.sizesFixed,
             dropped: summary.dropped,
+            nlinksFixed: summary.nlinksFixed,
             selfEntryDropped: summary.selfEntryDropped,
           })
       )) as { index?: { toJSON: () => unknown } };

--- a/packages/webapp/tests/fs/error-rebrand.test.ts
+++ b/packages/webapp/tests/fs/error-rebrand.test.ts
@@ -39,6 +39,40 @@ describe('convertError', () => {
   });
 });
 
+describe('convertError on internal Set/Map overflow (2026-08-18 outage)', () => {
+  it('maps a raw RangeError to EIO with an explicit internal-overflow label', () => {
+    const out = convertError(new RangeError('Set maximum size exceeded'), '/shared/x');
+    expect(out.code).toBe('EIO');
+    expect(out.message).toContain('internal overflow, not storage');
+    expect(out.message).toContain('Set maximum size exceeded');
+    expect(out.path).toBe('/shared/x');
+  });
+
+  it('catches the marker even after ZenFS already errno-wrapped it as EINVAL', () => {
+    // The live incident shape: the RangeError from kerium's log Set was
+    // errno-wrapped before reaching convertError, so the code-first mapping
+    // kept EINVAL and a data-structure overflow read as a storage problem.
+    const err = Object.assign(
+      new Error(
+        "EINVAL: undefined: undefined, mkdir '/__opfs__/slicc-fs/shared/change-work' (Set maximum size exceeded)"
+      ),
+      { code: 'EINVAL' }
+    );
+    const out = convertError(err, '/shared/change-work');
+    expect(out.code).toBe('EIO');
+    expect(out.message).toContain('internal overflow, not storage');
+  });
+
+  it('catches a Map overflow too', () => {
+    expect(convertError(new RangeError('Map maximum size exceeded'), '/p').code).toBe('EIO');
+  });
+
+  it('does not reroute ordinary EINVAL errors', () => {
+    const err = Object.assign(new Error('EINVAL: invalid argument, chmod'), { code: 'EINVAL' });
+    expect(convertError(err, '/p').code).toBe('EINVAL');
+  });
+});
+
 describe('rebrandFsError', () => {
   it('rethrows an FsError with the caller-facing path', () => {
     const backendErr = new FsError('ENOENT', 'no such file or directory', 'pack');

--- a/packages/webapp/tests/fs/kerium-log-cap-patch.test.ts
+++ b/packages/webapp/tests/fs/kerium-log-cap-patch.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Regression guard for the kerium bounded-log-backlog patch.
+//
+// kerium's `log()` retains EVERY entry in a module-global List (a plain Set
+// underneath) — including entries below the output threshold that are never
+// printed — with no cap or rotation. In a long-lived kernel worker under log
+// pressure (ZenFS's per-inode "nlink of 0" warning at its worst) the Set
+// eventually hits V8's 2^24-element cap, after which `entries.add` throws
+// `RangeError: Set maximum size exceeded` into every logging caller: every
+// ZenFS operation failed and the VFS root went offline (2026-08-18 incident;
+// the UI read "file system too full" while storage sat at 14% of quota).
+//
+// patches/kerium+*.patch bounds the backlog to a 10,000-entry ring. These
+// tests fail if the patch is missing or stops applying.
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+const logJsPath = resolve(repoRoot, 'node_modules/kerium/dist/log.js');
+
+describe('kerium bounded log backlog patch', () => {
+  it('the ring-eviction patch is present in the installed dist', () => {
+    const src = readFileSync(logJsPath, 'utf8');
+    expect(
+      src.includes('entries.size >= 10000'),
+      'Installed kerium retains an unbounded log backlog; patches/kerium+*.patch ' +
+        'is missing or failed to apply. A long-lived kernel worker will hit ' +
+        "V8's 2^24 Set cap and every ZenFS op will throw " +
+        '"Set maximum size exceeded". See patches/README.md.'
+    ).toBe(true);
+  });
+
+  it('behaviorally: the backlog stays bounded and keeps the newest entries', async () => {
+    const { entries, log, Level } = await import(/* @vite-ignore */ logJsPath);
+    // DEBUG sits below the default output threshold (ALERT), so the flood
+    // exercises pure retention without spamming the test output.
+    for (let i = 0; i < 12_345; i++) log(Level.DEBUG, `flood ${i}`);
+    expect(entries.size).toBeLessThanOrEqual(10_000);
+    const messages = entries.toArray().map((entry: { message: string }) => entry.message);
+    expect(messages.at(-1)).toBe('flood 12344'); // newest retained
+    expect(messages).not.toContain('flood 0'); // oldest evicted
+  });
+});

--- a/packages/webapp/tests/fs/sidecar-repair.test.ts
+++ b/packages/webapp/tests/fs/sidecar-repair.test.ts
@@ -11,9 +11,9 @@ const S_IFDIR = 0o40000;
 const S_IFREG = 0o100000;
 const S_IFLNK = 0o120000;
 
-const file = (size: number, perms = 0o644) => ({ mode: S_IFREG | perms, size });
-const dir = (perms = 0o755) => ({ mode: S_IFDIR | perms });
-const symlink = () => ({ mode: S_IFLNK | 0o777, size: 10 });
+const file = (size: number, perms = 0o644) => ({ mode: S_IFREG | perms, size, nlink: 1 });
+const dir = (perms = 0o755) => ({ mode: S_IFDIR | perms, nlink: 1 });
+const symlink = () => ({ mode: S_IFLNK | 0o777, size: 10, nlink: 1 });
 
 const probeFrom =
   (real: Record<string, { kind: 'file'; size: number } | { kind: 'directory' }>): SidecarProbe =>
@@ -96,6 +96,7 @@ describe('repairSidecarDocument', () => {
       dropped: 0,
       selfEntryDropped: false,
       inosReassigned: 0,
+      nlinksFixed: 0,
       changed: false,
     });
   });
@@ -192,6 +193,66 @@ describe('repairSidecarDocument — ino uniqueness (#2146)', () => {
   });
 });
 
+describe('repairSidecarDocument — nlink healing (2026-08-18 log-flood outage)', () => {
+  it('trues up nlink 0 and absent nlink to 1 on files, dirs, and symlinks', async () => {
+    // Every persisted `nlink: 0` re-arms ZenFS's per-inode "nlink of 0"
+    // warning on each materialization; with kerium retaining every entry the
+    // flood hit V8's 2^24 Set cap and every FS op threw. The heal must cover
+    // symlinks too — they skip the reality probe but still materialize.
+    const doc: SidecarIndexJson = {
+      entries: {
+        '/': { ...dir(), ino: 0, data: 0 },
+        '/f.txt': { mode: S_IFREG | 0o644, size: 3, ino: 1, data: 2, nlink: 0 },
+        '/d': { mode: S_IFDIR | 0o755, ino: 3, data: 4 },
+        '/link': { mode: S_IFLNK | 0o777, size: 10, ino: 5, data: 6, nlink: 0 },
+      } as SidecarIndexJson['entries'],
+    };
+    const summary = await repairSidecarDocument(
+      doc,
+      probeFrom({
+        '/f.txt': { kind: 'file', size: 3 },
+        '/d': { kind: 'directory' },
+        '/link': { kind: 'file', size: 10 },
+      })
+    );
+    expect(summary.nlinksFixed).toBe(3);
+    expect(summary.changed).toBe(true);
+    const entries = doc.entries as Record<string, { nlink?: number }>;
+    for (const path of ['/f.txt', '/d', '/link']) {
+      expect(entries[path].nlink).toBe(1);
+    }
+  });
+
+  it('leaves healthy entries and the root alone', async () => {
+    // ZenFS forces `/` to ino 0 on load, so a root nlink of 0 never warns —
+    // the heal skips it, keeping the no-op guarantee for healthy sidecars.
+    const doc: SidecarIndexJson = {
+      entries: {
+        '/': { ...dir(), ino: 0, data: 0, nlink: 0 },
+        '/ok.txt': { ...file(4), ino: 1, data: 2 },
+      } as SidecarIndexJson['entries'],
+    };
+    const summary = await repairSidecarDocument(
+      doc,
+      probeFrom({ '/ok.txt': { kind: 'file', size: 4 } })
+    );
+    expect(summary.nlinksFixed).toBe(0);
+    expect(summary.changed).toBe(false);
+    expect((doc.entries as Record<string, { nlink?: number }>)['/'].nlink).toBe(0);
+  });
+
+  it('does not count dropped entries as healed', async () => {
+    const doc: SidecarIndexJson = {
+      entries: {
+        '/gone.txt': { mode: S_IFREG | 0o644, size: 5, ino: 3, data: 4, nlink: 0 },
+      } as SidecarIndexJson['entries'],
+    };
+    const summary = await repairSidecarDocument(doc, probeFrom({}));
+    expect(summary.dropped).toBe(1);
+    expect(summary.nlinksFixed).toBe(0);
+  });
+});
+
 describe('resolveWithSidecarRepair', () => {
   const repaired: SidecarRepairSummary = {
     kindFixed: ['/x'],
@@ -199,6 +260,7 @@ describe('resolveWithSidecarRepair', () => {
     dropped: 0,
     selfEntryDropped: false,
     inosReassigned: 0,
+    nlinksFixed: 0,
     changed: true,
   };
 

--- a/packages/webapp/tests/fs/zenfs-ino-collision-patch.test.ts
+++ b/packages/webapp/tests/fs/zenfs-ino-collision-patch.test.ts
@@ -34,6 +34,18 @@ describe('@zenfs/dom ino allocation patch (#2146)', () => {
     expect(src).toContain('const recoveredId = this.index._alloc();');
     expect(src).toContain('nextRealityId');
   });
+
+  it('the #2146 allocations set nlink: 1 (nlink-0 warn flood, 2026-08-18 outage)', () => {
+    // Every minted inode must carry a link count: ZenFS's Inode constructor
+    // warns on `ino != 0 && nlink == 0`, kerium retains every log entry, and
+    // a tree indexed through these sites re-warned on every inode
+    // materialization until the log Set hit V8's 2^24 cap and every FS op
+    // threw "Set maximum size exceeded" — the VFS-offline outage.
+    const src = readFileSync(resolve(repoRoot, 'node_modules/@zenfs/dom/dist/access.js'), 'utf8');
+    expect(src).toContain('nlink: 1, mode: 0o644 | constants.S_IFREG');
+    expect(src).toContain('nlink: 1, mode: 0o777 | constants.S_IFDIR');
+    expect(src).toContain('data: recoveredId + 1, nlink: 1');
+  });
 });
 
 describe('@zenfs/core vnode-cache coalescing guard (#2146)', () => {

--- a/patches/@zenfs+dom+1.2.10.patch
+++ b/patches/@zenfs+dom+1.2.10.patch
@@ -1,32 +1,36 @@
 diff --git a/node_modules/@zenfs/dom/dist/access.js b/node_modules/@zenfs/dom/dist/access.js
-index ec02258..cccf324 100644
+index ec02258..74d4c83 100644
 --- a/node_modules/@zenfs/dom/dist/access.js
 +++ b/node_modules/@zenfs/dom/dist/access.js
-@@ -52,15 +52,21 @@ export class WebAccessFS extends Async(IndexFS) {
+@@ -52,15 +52,25 @@ export class WebAccessFS extends Async(IndexFS) {
              this.index.fromJSON(data);
              return;
          }
 +        // PATCH(#2146): allocate unique ino/data pairs — the upstream code
 +        // left every inode at ino 0, collapsing the whole tree onto one
 +        // vnode-cache slot. Local counter: _alloc() is O(index) per call.
++        // nlink MUST be 1: the Inode constructor warns on every inode with a
++        // real ino and nlink 0, and kerium retains every log entry — leaving
++        // nlink unset here flooded a long-lived kernel worker until the log
++        // Set hit V8's 2^24 cap and every FS op threw (2026-08-18 incident).
 +        let nextRealityId = 1;
          for (const [path, handle] of this._handles) {
              if (isKind(handle, 'file')) {
                  const { lastModified, size } = await handle.getFile();
 -                this.index.set(path, new Inode({ mode: 0o644 | constants.S_IFREG, size, mtimeMs: lastModified }));
-+                this.index.set(path, new Inode({ ino: nextRealityId, data: nextRealityId + 1, mode: 0o644 | constants.S_IFREG, size, mtimeMs: lastModified }));
++                this.index.set(path, new Inode({ ino: nextRealityId, data: nextRealityId + 1, nlink: 1, mode: 0o644 | constants.S_IFREG, size, mtimeMs: lastModified }));
 +                nextRealityId += 2;
                  continue;
              }
              if (!isKind(handle, 'directory'))
                  throw withErrno('EIO', 'Invalid handle');
 -            this.index.set(path, new Inode({ mode: 0o777 | constants.S_IFDIR, size: 0 }));
-+            this.index.set(path, new Inode({ ino: nextRealityId, data: nextRealityId + 1, mode: 0o777 | constants.S_IFDIR, size: 0 }));
++            this.index.set(path, new Inode({ ino: nextRealityId, data: nextRealityId + 1, nlink: 1, mode: 0o777 | constants.S_IFDIR, size: 0 }));
 +            nextRealityId += 2;
          }
      }
      constructor(root, disableHandleCache = false) {
-@@ -91,7 +97,13 @@ export class WebAccessFS extends Async(IndexFS) {
+@@ -91,7 +101,13 @@ export class WebAccessFS extends Async(IndexFS) {
              // This handle must have been created after initialization
              // Try to add a new inode for the handle to the index
              const handle = await this.get(null, path);
@@ -37,11 +41,11 @@ index ec02258..cccf324 100644
 +            // file's size/mode onto another path on sync — the phantom-
 +            // directory / sibling-size corruption class. Allocate real ids.
 +            const recoveredId = this.index._alloc();
-+            const inode = new Inode({ ino: recoveredId, data: recoveredId + 1 });
++            const inode = new Inode({ ino: recoveredId, data: recoveredId + 1, nlink: 1 });
              if (isKind(handle, 'file')) {
                  const file = await handle.getFile();
                  inode.update({
-@@ -165,7 +177,17 @@ export class WebAccessFS extends Async(IndexFS) {
+@@ -165,7 +181,17 @@ export class WebAccessFS extends Async(IndexFS) {
              log.crit(withErrno('EIO', 'Mismatch in entry kind on write'));
              return;
          }

--- a/patches/kerium+1.4.2.patch
+++ b/patches/kerium+1.4.2.patch
@@ -1,0 +1,22 @@
+diff --git a/node_modules/kerium/dist/log.js b/node_modules/kerium/dist/log.js
+index 2bc3eff..34bd4ec 100644
+--- a/node_modules/kerium/dist/log.js
++++ b/node_modules/kerium/dist/log.js
+@@ -50,6 +50,17 @@ export function log(level, message) {
+         timestamp: new Date(),
+         elapsedMs: performance.now(),
+     };
++    // PATCH: bound the backlog. Upstream retains every entry forever — even
++    // levels below the output threshold that are never printed — so a
++    // long-lived worker under log pressure eventually hits V8's 2^24-element
++    // Set cap, after which entries.add throws RangeError('Set maximum size
++    // exceeded') into every logging caller (SLICC 2026-08-18: every ZenFS op
++    // failed and the VFS went offline). Evict the oldest entry once full.
++    if (entries.size >= 10000) {
++        const oldest = entries.values().next().value;
++        if (oldest !== undefined)
++            entries.delete(oldest);
++    }
+     entries.add(entry);
+     output(entry);
+ }

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -1,19 +1,19 @@
 {
-  "//": "Metadata for the patch-package patches in this directory \u2014 one key per patched npm package. Consumed by the orphaned-patch guard (packages/dev-tools/patch-reconcile/check-patches.mjs, run as `npm run lint:patches`) and the renovate-patch-reconcile workflow. Every patches/<pkg>+<version>.patch MUST have an entry here with a matching patchedVersion. When a patch is removed, delete its entry. See patches/README.md.",
+  "//": "Metadata for the patch-package patches in this directory — one key per patched npm package. Consumed by the orphaned-patch guard (packages/dev-tools/patch-reconcile/check-patches.mjs, run as `npm run lint:patches`) and the renovate-patch-reconcile workflow. Every patches/<pkg>+<version>.patch MUST have an entry here with a matching patchedVersion. When a patch is removed, delete its entry. See patches/README.md.",
   "@zenfs/core": {
     "patchedVersion": "2.6.2",
     "upstream": "https://github.com/zen-fs/core",
     "issue": null,
-    "reason": "Make globalThis.__zenfs__ a null-prototype own-property copy of fs (Object.assign(Object.create(null), fs)) instead of a prototype view, so the fs export's enumerable members are reliably visible on the global probe. ALSO (#2146): VCache.ref coalesced DIFFERENT paths onto one vnode when their inodes shared an ino (poisoned indexes carry many ino-0 entries) \u2014 the shared inode object cross-stamps size/mode between unrelated files. The patch refuses cross-path coalescing when ino is 0 or the format bits differ (hardlinks share both a real ino and a mode, so they still coalesce).",
-    "removeWhen": "Local workaround \u2014 no upstream PR is tracked. Re-evaluate whenever @zenfs/core changes the __zenfs__ global or the fs export shape; if a newer version no longer needs the override, remove the patch.",
+    "reason": "Make globalThis.__zenfs__ a null-prototype own-property copy of fs (Object.assign(Object.create(null), fs)) instead of a prototype view, so the fs export's enumerable members are reliably visible on the global probe. ALSO (#2146): VCache.ref coalesced DIFFERENT paths onto one vnode when their inodes shared an ino (poisoned indexes carry many ino-0 entries) — the shared inode object cross-stamps size/mode between unrelated files. The patch refuses cross-path coalescing when ino is 0 or the format bits differ (hardlinks share both a real ino and a mode, so they still coalesce).",
+    "removeWhen": "Local workaround — no upstream PR is tracked. Re-evaluate whenever @zenfs/core changes the __zenfs__ global or the fs export shape; if a newer version no longer needs the override, remove the patch.",
     "verify": "npm run test -w @slicc/webapp -- zenfs-ino-collision-patch"
   },
   "@zenfs/dom": {
     "patchedVersion": "1.2.10",
     "upstream": "https://github.com/zen-fs/dom",
     "issue": null,
-    "reason": "WebAccessFS.write opened every write with createWritable({ keepExistingData: true }), so Chromium copied the whole existing file into the swap file first \u2014 O(file size) per write even when the write replaces the file (92 MB rewrite: 480ms -> 240ms without the copy). Worse, IndexFS.touch only narrows the in-memory inode and nothing truncates the handle, so a shrink left its tail on disk forever (92 MB file rewritten as 4 MB kept 92 MB of OPFS quota). The patch keeps the copy only where the write needs it: a non-zero offset, or a buffer that does not span the indexed size. ALSO (#2146): WebAccessFS minted ino:0 inodes in stat's ENOENT recovery and _loadMetadata's reality branch; thousands of ino-0 index entries collapse onto one VFS vnode-cache slot, stamping one file's size/mode onto another path on sync (phantom directories, sibling-size truncation). The patch allocates unique ino/data pairs at both sites.",
-    "removeWhen": "Local workaround \u2014 no upstream PR is tracked. Remove once @zenfs/dom decides keepExistingData per write (or truncates the handle on a narrowing touch) upstream.",
+    "reason": "WebAccessFS.write opened every write with createWritable({ keepExistingData: true }), so Chromium copied the whole existing file into the swap file first — O(file size) per write even when the write replaces the file (92 MB rewrite: 480ms -> 240ms without the copy). Worse, IndexFS.touch only narrows the in-memory inode and nothing truncates the handle, so a shrink left its tail on disk forever (92 MB file rewritten as 4 MB kept 92 MB of OPFS quota). The patch keeps the copy only where the write needs it: a non-zero offset, or a buffer that does not span the indexed size. ALSO (#2146): WebAccessFS minted ino:0 inodes in stat's ENOENT recovery and _loadMetadata's reality branch; thousands of ino-0 index entries collapse onto one VFS vnode-cache slot, stamping one file's size/mode onto another path on sync (phantom directories, sibling-size truncation). The patch allocates unique ino/data pairs at both sites. ALSO: those #2146 allocations must set nlink: 1 — ZenFS's Inode constructor warns on every ino!=0/nlink==0 inode and kerium retains every log entry, so leaving nlink unset flooded the in-memory log on every inode materialization until its backing Set hit V8's 2^24 cap and every FS op threw 'Set maximum size exceeded' (2026-08-18 VFS-offline incident).",
+    "removeWhen": "Local workaround — no upstream PR is tracked. Remove once @zenfs/dom decides keepExistingData per write (or truncates the handle on a narrowing touch) upstream.",
     "verify": "npm run test -w @slicc/webapp -- zenfs-dom-overwrite-patch"
   },
   "e2b": {
@@ -23,5 +23,13 @@
     "reason": "e2b >=2.33.0 emits a top-level `var __require = (() => createRequire(import.meta.url))()` ESM-interop shim (from its bundler, Rolldown) in dist/index.mjs. It runs at module-eval time; under Cloudflare workerd `import.meta.url` is undefined, so createRequire throws on import and crashes the tray-hub worker (which bundles e2b via @slicc/cloud-core). The patch makes __require lazy (init on first call); __require is only reached on Node paths, so this is behaviour-preserving. See docs/pitfalls.md.",
     "removeWhen": "Remove once e2b ships the shim lazily (init on first use) or provides an edge/browser export condition without the node:module path. e2b officially lists Workers/Edge as unsupported, so this may be long-lived; do NOT drop the patch while the tray-hub worker still bundles the e2b SDK.",
     "verify": "npm run test -w @slicc/cloud-core -- e2b-workerd-patch"
+  },
+  "kerium": {
+    "patchedVersion": "1.4.2",
+    "upstream": "https://github.com/zen-fs/kerium",
+    "issue": null,
+    "reason": "kerium's log() retains EVERY entry in a module-global List (a plain Set underneath) with no cap or rotation — even entries below the output threshold that are never printed (default minLevel is ALERT). A long-lived kernel worker under log pressure (e.g. ZenFS's per-inode nlink warning) eventually hits V8's 2^24-element Set cap, after which entries.add throws RangeError('Set maximum size exceeded') into every logging caller — every ZenFS op failed and the VFS went offline (2026-08-18 incident). The patch evicts the oldest entry beyond a 10,000-entry ring so the backlog stays bounded.",
+    "removeWhen": "Remove once kerium bounds its log backlog upstream (ring buffer or opt-in retention).",
+    "verify": "npm run test -w @slicc/webapp -- kerium-log-cap-patch"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,7 @@
     },
     {
       "description": "Packages we carry a patch-package patch for (see patches/ and patches/patches.json). A bump orphans the version-pinned patch, so route these into one group, label them, and never automerge — the renovate-patch-reconcile workflow regenerates or removes the patch first, and the lint:patches guard blocks the merge until the patch matches the installed version. Keep this list in sync with patches/. (e2b is patched to make its top-level createRequire(import.meta.url) shim lazy so it imports under Cloudflare workerd — see docs/pitfalls.md.)",
-      "matchPackageNames": ["@zenfs/core", "@zenfs/dom", "e2b"],
+      "matchPackageNames": ["@zenfs/core", "@zenfs/dom", "e2b", "kerium"],
       "groupName": "patched dependencies",
       "groupSlug": "patched-deps",
       "addLabels": ["patched-dependency"],


### PR DESCRIPTION
## The outage

2026-08-18, on the live leader: the VFS root went fully offline — `mkdir` threw `EINVAL … (Set maximum size exceeded)`, `ls /` reported ENOENT, `mount list` showed nothing, and the UI read as "file system too full" — while `df` showed OPFS at **14% of quota** throughout. A reload "fixed" it.

## Root cause (confirmed live via CDP on the kernel worker)

1. **kerium retains every log entry forever.** `log()` appends to a module-global `List` (a plain `Set` underneath) — even DEBUG entries that are never printed (default output threshold is ALERT) — with no cap or rotation. At V8's hard 2²⁴-element Set limit, `Set.add` throws `RangeError: Set maximum size exceeded` into every logging caller, i.e. every ZenFS operation. ZenFS errno-wraps it as EINVAL, so a data-structure overflow presented as a storage failure.
2. **The flood is ZenFS's per-inode nlink warning.** `Inode`'s constructor warns `"Inode N has an nlink of 0"` for every materialized inode with a real ino and no links. Measured on the live worker: **414,934 of 414,953** retained entries were this message, accumulated within ~10 minutes of a fresh boot (~700/s under FS load).
3. **The #2146 ino patch armed it.** The patched allocation sites mint real inos but never set `nlink`, and the field data confirms it: 1,772 of 2,000 sampled sidecar entries persist `nlink: 0` (directories especially). Pre-#2146, inos were 0 and the `ino && !nlink` warning never fired.

## The fix — four layers

| Layer | Change |
| --- | --- |
| `patches/@zenfs+dom+1.2.10.patch` | The three #2146 allocation sites now set `nlink: 1` — newly indexed/recovered inodes stop warning. |
| `patches/kerium+1.4.2.patch` (new) | `log()` evicts the oldest entry beyond a **10,000-entry ring** — the backlog can never reach the Set cap. |
| `sidecar-repair.ts` | The unconditional boot-time repair trues up persisted `nlink: 0`/absent to 1 (`nlinksFixed` in the summary), healing sidecars already poisoned in the field. |
| `error-rebrand.ts` | A `maximum size exceeded` marker — raw `RangeError` or already errno-wrapped — surfaces as **EIO "internal overflow, not storage"** instead of a storage-shaped EINVAL, so a recurrence can't masquerade again. |

`renovate.json` adds kerium to the patched-dependencies group; `patches/patches.json` documents both patches (`lint:patches` green).

## Tests

- `kerium-log-cap-patch.test.ts` (new): patch-presence guard + behavioral flood of 12,345 entries → size stays ≤ 10,000, newest retained, oldest evicted.
- `zenfs-ino-collision-patch.test.ts`: asserts all three allocation sites carry `nlink: 1`.
- `sidecar-repair.test.ts`: nlink healing on files/dirs/symlinks, root exemption, dropped-entry non-counting; existing fixtures updated to carry healthy `nlink: 1`.
- `error-rebrand.test.ts`: raw RangeError → EIO, errno-wrapped incident shape → EIO, Map overflow → EIO, ordinary EINVAL untouched.

## Verification

`npm run verify` (7/7 incl. boy-scout-debt) · `check-touched-exemptions` OK · `npm run typecheck` (9 projects) · `npm run test` (14,455 passed) · webapp coverage gate exit 0 · `npm run build` + extension build · `bundle-size` within budgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65
