### PR TITLE
feat(dev-tools): migrate the Backlog Dispatcher off Cosmos

### DIFF
--- a/.github/workflows/backlog-dispatcher.yml
+++ b/.github/workflows/backlog-dispatcher.yml
@@ -1,0 +1,287 @@
+name: Backlog Dispatcher
+
+# 🎫 Daily backlog picker. Scans this repository's open issues, decides which of
+# them a competent engineer could implement today without asking anybody a
+# question, and opens a pull request for a handful of them. Two phases, the same
+# shape as .github/workflows/rum-error-triage.yml:
+#
+#   0. a deterministic Node selector
+#      (packages/dev-tools/backlog-dispatcher/select-backlog-issues.mjs) screens
+#      and ranks the open issues, writes the survivors to
+#      `backlog-candidates.json`, and emits the triage prompt + the dispatch
+#      budget. It performs NO writes against GitHub.
+#   1. TRIAGE — claude-code-action reads the candidates, investigates each
+#      against the codebase, labels the ready ones `backlog-ready` and the
+#      rejected ones `backlog-skipped` (with ONE comment saying why). It writes
+#      no code and opens no PR.
+#   2. AUTHOR — a second claude-code-action run takes the open `backlog-ready`
+#      issues, implements the minimal change, opens the PR with `Closes #<n>`,
+#      and swaps the label to `backlog-dispatched`.
+#   3. a deterministic stale sweep (sweep-stale-prs.mjs) labels + comments once
+#      on dispatcher-owned PRs idle for a week. It NEVER closes a PR.
+#
+# READINESS RUBRIC PROVENANCE — this migrates an Augment Code ("Cosmos") expert
+# whose prompt body was a `kb://` include that did not survive the platform's
+# retirement. What survived is ~50 of its decisions, left on this repo as
+# `cosmos-dispatched` / `cosmos-skipped` labels plus its own verbatim skip
+# comments. The hard-override catalog (security/authorization surfaces; upstream
+# or platform bugs and design calls; cross-cutting redesigns including
+# god-class "Bloat" splits; unconfirmed root causes; concurrency/data-integrity
+# bugs spanning layers; native work CI cannot verify; unspecified UX) and the
+# ready classes (a named agentic-debt sin in a named file, a small localised bug
+# with a concrete symptom, a missing shell command with a clear spec, one named
+# flaky test, doc drift naming the stale file, a narrow test addition) were
+# reconstructed from that record and live in
+# packages/dev-tools/backlog-dispatcher/lib.mjs, where they are unit-tested.
+#
+# STATE — GitHub-native; no state file, state branch, or Actions cache. The
+# labels ARE the work queue AND the dedup key:
+#   `backlog-ready`      phase 1 said yes → phase 2's queue
+#   `backlog-dispatched` a PR exists (also how the PR Fix Dispatcher and the
+#                        stale sweep recognise the PR as ours)
+#   `backlog-skipped`    decided against, ONCE
+#   `backlog-stale`      a dispatcher PR has gone idle
+#   `cosmos-dispatch-failed`  the author phase died (legacy name reused: the
+#                        label already exists in this repo and means this)
+# The legacy `cosmos-dispatched` / `cosmos-skipped` / `cosmos-dispatch-failed`
+# labels are treated as EQUIVALENT to the new ones when excluding candidates, or
+# the first run would re-propose work Cosmos already rejected. Deciding once is
+# deliberate: the original re-posted its skip comment on the same issue on every
+# tick (#2072 got one on 2026-08-12 and another on 2026-08-17). A human removing
+# a label is the intended, documented way to re-queue an issue.
+#
+# SCOPE — `ai-ecoverse/slicc` only, because BOT_PAT is a fine-grained PAT scoped
+# to this repository. The repository is never hardcoded in the selector or the
+# lib (it comes from `GITHUB_REPOSITORY` / `REPO`), so promoting this to
+# `ai-ecoverse/.github` for the whole org is a packaging change — adding
+# `workflow_call` and a repo input — and not a rewrite.
+#
+# Required repository secrets (both already present):
+#   AWS_BEARER_TOKEN_BEDROCK  Amazon Bedrock API key (Adobe CAMP `ABSK...`
+#                             bearer token) for claude-code-action, shared with
+#                             boy-scout-debt-dispatcher.yml / rum-error-triage.yml.
+#   BOT_PAT                   Fine-grained PAT scoped to this repo (contents +
+#                             issues + pull-requests write). The branch is pushed
+#                             and the PR opened with BOT_PAT — NOT GITHUB_TOKEN —
+#                             because GitHub's anti-recursion guard suppresses
+#                             workflow runs for GITHUB_TOKEN-authored pushes, and
+#                             these PRs MUST get the full check suite.
+# Optional repo variables: BACKLOG_BEDROCK_MODEL / RUM_BEDROCK_MODEL,
+# RUM_AWS_REGION.
+#
+# Third-party actions are pinned to immutable commit SHAs (the same SHAs used by
+# .github/workflows/boy-scout-debt-dispatcher.yml) — this job can push branches.
+
+on:
+  schedule:
+    # Daily at 09:35 UTC. Cosmos ran this expert at ~09:05; this slot is clear of
+    # the repo's occupied crons (02:17 / 03:00 / 04:15 / 05:33 daily, `7 */2 * * *`,
+    # Sat 22:40, Mon 06:50).
+    - cron: '35 9 * * *'
+  workflow_dispatch:
+    inputs:
+      issue:
+        description: 'Override: consider only this issue number (waives the settling-age wait only)'
+        required: false
+      dry_run:
+        description: 'Selector only; no labels, no comments, no Claude, no PR'
+        type: boolean
+        required: false
+        default: false
+      max_dispatches:
+        description: 'Lower the dispatch budget for this run (default 5)'
+        required: false
+
+concurrency:
+  group: backlog-dispatcher
+  cancel-in-progress: false
+
+permissions:
+  contents: write # push the implementation branch
+  # Repo-level label CREATION (`gh label create`) goes through
+  # POST /repos/{repo}/labels, which is gated on `issues`, NOT
+  # `pull-requests` — pull-requests only covers applying an existing label to a
+  # PR. Without this the bootstrap step below fails before the selector runs.
+  # Same reason rum-error-triage.yml / pr-fix-dispatcher.yml carry issues: write.
+  issues: write # label + comment on issues
+  pull-requests: write # open the PR, label it, comment on a stale one
+  id-token: write # claude-code-action fetches an OIDC token during setup
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0 # full history: the author phase runs the debt gate against origin/main
+          # BOT_PAT (persisted as the push credential) so the author phase's
+          # branch push fires the pull_request events that run CI on the PR. See
+          # the header note on GitHub's anti-recursion guard.
+          token: ${{ secrets.BOT_PAT }}
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      # The author phase runs biome, typecheck, focused vitest and the debt
+      # gate, so it needs a full install — not just the selector's Node builtins.
+      - run: npm ci
+
+      - name: Ensure dispatcher labels exist
+        if: github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create backlog-ready --color 0e8a16 --description "Backlog Dispatcher: triage judged this ready for an authored PR" --force
+          gh label create backlog-dispatched --color 1d76db --description "Backlog Dispatcher: a PR was opened for this issue" --force
+          gh label create backlog-skipped --color cccccc --description "Backlog Dispatcher: decided against dispatching; remove this label to re-queue" --force
+          gh label create backlog-stale --color fbca04 --description "Backlog Dispatcher: dispatcher-owned PR has gone idle and needs a human" --force
+          gh label create cosmos-dispatch-failed --color b60205 --description "Backlog Dispatcher: the PR author phase did not finish" --force
+
+      # Deterministic screening + ranking. Writes `backlog-candidates.json` for
+      # phase 1 to read (mirroring `rum-error-candidates.json`) and emits the
+      # triage prompt, the candidate count, and the dispatch budget.
+      - name: Select candidate issues
+        id: select
+        env:
+          REPO: ${{ github.repository }}
+          # Read-only here: list open issues and open PRs. Phase 1 does the
+          # labelling with the same token.
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          MAX_DISPATCHES: ${{ github.event.inputs.max_dispatches }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node packages/dev-tools/backlog-dispatcher/select-backlog-issues.mjs
+
+      # ── Phase 1: judge the candidates and label them ────────────────────────
+      # Split from phase 2 so each Claude run gets its own turn budget, and so an
+      # issue is never labelled ready by a run that then exhausts its turns
+      # before a PR exists.
+      - name: Triage the candidates
+        if: steps.select.outputs.has_candidates == 'true' && github.event.inputs.dry_run != 'true'
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
+        env:
+          # Bedrock path: authenticate with an Amazon Bedrock API key (the Adobe
+          # CAMP `ABSK...` bearer token). RUM_AWS_REGION / BACKLOG_BEDROCK_MODEL
+          # tune region + inference profile. (Bearer-token auth for Bedrock is
+          # newer in Claude Code — if a run fails on auth, fall back to
+          # `anthropic_api_key`.)
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          AWS_REGION: ${{ vars.RUM_AWS_REGION || 'us-east-1' }}
+          # claude-code-action does NOT expose a token to the Bash tool's `gh`,
+          # so set it explicitly or `gh issue edit` fails. Triage only labels and
+          # comments, so the job's GITHUB_TOKEN is the right, narrower identity —
+          # only the author phase needs BOT_PAT.
+          GH_TOKEN: ${{ github.token }}
+        with:
+          use_bedrock: 'true'
+          # Pass the workflow's GITHUB_TOKEN explicitly so the action uses it
+          # directly instead of attempting an OIDC -> GitHub App token exchange
+          # (which fails with "User does not have write access" when the Claude
+          # GitHub App is not installed on this repo).
+          github_token: ${{ github.token }}
+          # On `schedule` events GitHub sets the actor to the last actor on the
+          # default branch, which in this merge-queue repo is `github-merge-queue`
+          # (a bot). claude-code-action's human-actor gate otherwise rejects the
+          # scheduled run with "Workflow initiated by non-human actor".
+          allowed_bots: '*'
+          # Full turn-by-turn output on manual dispatch only; the cron keeps it
+          # off so routine runs don't log tool output that may be sensitive.
+          show_full_output: ${{ github.event_name == 'workflow_dispatch' }}
+          claude_args: |
+            --model ${{ vars.BACKLOG_BEDROCK_MODEL || vars.RUM_BEDROCK_MODEL || 'global.anthropic.claude-sonnet-4-6' }}
+            --allowedTools "Read,Grep,Glob,Bash(gh issue:*),Bash(gh label:*)"
+            --max-turns 150
+          prompt: ${{ steps.select.outputs.prompt }}
+
+      # ── Phase 2: open the PRs for whatever phase 1 marked ready ─────────────
+      # `backlog-ready` is the cross-phase work queue, so an issue marked ready
+      # by a previous run whose author phase died is picked up here.
+      - name: List backlog-ready issues for the author phase
+        id: ready
+        if: github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BUDGET: ${{ steps.select.outputs.dispatch_budget }}
+        run: |
+          gh issue list --repo "$REPO" --label backlog-ready --state open \
+            --limit 25 --json number,title,body > backlog-ready-issues.json
+          count=$(jq 'length' backlog-ready-issues.json)
+          echo "Found $count open backlog-ready issue(s) to author PRs for."
+          if [ "$count" -gt 0 ]; then
+            echo "has_ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_ready=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Compose the author brief from the same unit-tested builder the triage
+          # prompt comes from, so the two phases cannot drift apart.
+          node --input-type=module -e '
+            import { appendFileSync, readFileSync } from "node:fs";
+            import { buildAuthorPrompt, CONFIG } from "./packages/dev-tools/backlog-dispatcher/lib.mjs";
+            const issues = JSON.parse(readFileSync("backlog-ready-issues.json", "utf8"));
+            const budget = Number(process.env.BUDGET) || CONFIG.MAX_DISPATCHES_PER_RUN;
+            const prompt = buildAuthorPrompt(issues, { repo: process.env.REPO, budget });
+            appendFileSync(process.env.GITHUB_OUTPUT, `prompt<<EOF_BACKLOG_PROMPT\n${prompt}\nEOF_BACKLOG_PROMPT\n`);
+          '
+
+      - name: Configure git identity
+        if: steps.ready.outputs.has_ready == 'true' && github.event.inputs.dry_run != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Author the PRs for backlog-ready issues
+        if: steps.ready.outputs.has_ready == 'true' && github.event.inputs.dry_run != 'true'
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
+        env:
+          # Same Bedrock auth as phase 1 (see the notes on that step).
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          AWS_REGION: ${{ vars.RUM_AWS_REGION || 'us-east-1' }}
+          # BOT_PAT (not github.token) so the opened PR gets the full check
+          # suite — see the header note on the anti-recursion guard.
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+        with:
+          use_bedrock: 'true'
+          # Job permissions above scope this token; Claude's own `gh`/`git` work
+          # runs under BOT_PAT via the env block.
+          github_token: ${{ github.token }}
+          allowed_bots: '*'
+          show_full_output: ${{ github.event_name == 'workflow_dispatch' }}
+          claude_args: |
+            --model ${{ vars.BACKLOG_BEDROCK_MODEL || vars.RUM_BEDROCK_MODEL || 'global.anthropic.claude-sonnet-4-6' }}
+            --allowedTools "Read,Grep,Glob,Edit,Write,Bash(git:*),Bash(gh pr:*),Bash(gh issue:*),Bash(npm:*),Bash(npx:*),Bash(node:*)"
+            --max-turns 200
+          prompt: ${{ steps.ready.outputs.prompt }}
+
+      # An author phase that died owes every issue it was holding one label swap
+      # so the next tick (and any human reading the issue) can see it. Issues
+      # that made it to a PR already lost `backlog-ready`, so only the ones it
+      # never finished are still labelled.
+      - name: Report a failed author phase
+        if: failure() && steps.ready.outputs.has_ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          for n in $(gh issue list --repo "$REPO" --label backlog-ready --state open --json number --jq '.[].number'); do
+            gh issue edit "$n" --repo "$REPO" --add-label cosmos-dispatch-failed --remove-label backlog-ready || true
+            gh issue comment "$n" --repo "$REPO" --body "<sup>🎫 [Backlog Dispatcher]($RUN_URL)</sup>
+
+          **The PR author phase did not finish.** It stopped before a pull request existed (it may have run out of turns, hit something it was told not to work around, or crashed). Nothing was merged and nothing was closed; this issue now needs a human. Remove the \`cosmos-dispatch-failed\` label to put it back in the queue." || true
+          done
+
+      # Deterministic, no Claude: label + comment ONCE on dispatcher-owned PRs
+      # that have gone idle. It never closes a pull request — the Cosmos original
+      # did, which threw away work whose only sin was waiting for review.
+      - name: Sweep stale dispatcher PRs
+        if: ${{ !cancelled() && github.event.inputs.dry_run != 'true' }}
+        env:
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node packages/dev-tools/backlog-dispatcher/sweep-stale-prs.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@ packages/cloudflare-worker/src/preview-bridge-assets.ts
 
 # RUM error-triage runtime artifact
 rum-error-candidates.json
+
+# Scratch hand-off files the scheduled agentic workflows write to the repo root
+# for their Claude phases to read. The authoring phases run `git` with write
+# access to a branch, so an un-ignored scratch file is one `git add -A` away
+# from landing in a pull request.
+rum-fix-ready-issues.json
+backlog-candidates.json
+backlog-ready-issues.json

--- a/docs/dev-tools-details.md
+++ b/docs/dev-tools-details.md
@@ -21,7 +21,7 @@ its `README.md` for label semantics and workflow behavior.
 
 ## scheduled-agentic-workflows
 
-Four scheduled agents that read repository or CI state, pick at most one piece
+Five scheduled agents that read repository or CI state, pick at most one piece
 of work, and hand it to `claude-code-action`. Each is the same two-part shape,
 which is the house pattern for every agentic workflow here (see also
 `rum-error-triage.yml` and `agentic-debt-triage.yml`): a **deterministic Node
@@ -37,8 +37,9 @@ genuinely needs a model is left to Claude.
 | `pr-fix-dispatcher/`   | `pr-fix-dispatcher.yml`         | every 2h    | failing automation PRs → re-run, fix, or skip              |
 | `claude-md-compactor/` | `claude-md-compactor.yml`       | Sat 22:40   | oversized `CLAUDE.md` guides → one compaction PR           |
 | `flaky-ci-hunter/`     | `flaky-ci-hunter.yml`           | Mon 06:50   | one job with proven same-commit flips → determinism fix PR |
+| `backlog-dispatcher/`  | `backlog-dispatcher.yml`        | daily 09:35 | open issues that look ready → authored PRs                 |
 
-**State is GitHub-native.** None of the four keeps a state file, a state
+**State is GitHub-native.** None of the five keeps a state file, a state
 branch, or an Actions cache entry. Cross-run memory is derived from GitHub
 itself, which cannot drift from reality the way a committed ledger can:
 
@@ -55,6 +56,9 @@ itself, which cannot drift from reality the way a committed ledger can:
   carries the compaction prefix.
 - _"this flaky job is in cooldown"_ → the `automation/flaky-fix/<slug>` PRs;
   the branch name is the registry key and the PR dates are the clock.
+- _"this issue was already decided"_ → a `backlog-*` (or legacy `cosmos-*`)
+  label on the issue. The backlog dispatcher is the one member of the family
+  whose labels **are** the dedup key; see its subsection below for why.
 
 Two details that are easy to get wrong and are therefore pinned by tests:
 
@@ -80,10 +84,53 @@ a retry count, adding a bare sleep, loosening an assertion, or skipping a test
 are rejected fixes, and "this nondeterminism is irreducible" is an acceptable
 answer.
 
-Both the boy-scout and flake-fix PRs are pushed with `BOT_PAT`, not
+The boy-scout, flake-fix, and backlog PRs are pushed with `BOT_PAT`, not
 `GITHUB_TOKEN` — GitHub's anti-recursion guard suppresses workflow runs for
 `GITHUB_TOKEN`-authored pushes, so CI would never run on them. Same constraint
 as `coverage-ratchet.yml` and `renovate-patch-reconcile.yml`.
+
+### The backlog dispatcher's recovered rubric
+
+`backlog-dispatcher/` migrates an Augment Code ("Cosmos") expert whose prompt
+body was a `kb://` include that did not survive that platform's retirement. What
+survived is roughly fifty of its **decisions**, left on this repo as
+`cosmos-dispatched` / `cosmos-skipped` labels plus its own verbatim skip
+comments. The hard-override catalog (security/authorization surfaces; upstream or
+platform bugs and design calls; cross-cutting redesigns, which includes the
+god-class "Bloat" splits; unconfirmed root causes; concurrency and
+data-integrity bugs spanning layers; native work CI cannot verify; unspecified
+UX) and the ready classes (a named agentic-debt sin in a named file, a small
+localised bug with a concrete symptom, a missing shell command with a clear spec,
+one named flaky test, doc drift naming the stale file, a narrow test addition)
+were reconstructed from that record and live in `lib.mjs`, unit-tested. The
+selector only orders and caps the pool; the go/no-go call is Claude's in phase 1,
+with each candidate's detected smells named for it.
+
+Three things set it apart from its four siblings:
+
+- **The labels ARE the dedup key**, not just human-visible markers. An issue
+  carrying `backlog-ready` / `backlog-dispatched` / `backlog-skipped` — or the
+  legacy `cosmos-dispatched` / `cosmos-skipped` / `cosmos-dispatch-failed`,
+  which are treated as equivalent so the first run cannot re-propose work Cosmos
+  already rejected — is not a candidate at all. The original re-posted its skip
+  comment on the same issue on every tick (#2072 got one on 2026-08-12 and
+  another on 2026-08-17); deciding **once** is the fix, and a human removing the
+  label is the documented way to re-queue an issue.
+- **The stale sweep never closes a pull request.** `sweep-stale-prs.mjs` labels
+  `backlog-stale` and comments once on a dispatcher PR idle for a week, then
+  leaves it alone. The Cosmos original closed those, which threw away work whose
+  only sin was waiting for review.
+- **Branch naming is load-bearing.** PRs land on
+  `automation/backlog/issue-<n>`; the `automation/` prefix is what makes
+  `isAutomationPr()` in `pr-fix-dispatcher/lib.mjs` return true, so a backlog PR
+  with failing CI gets a fixer. `lib.test.mjs` imports both libs and asserts the
+  agreement rather than trusting the convention.
+
+Scope is `ai-ecoverse/slicc` only, because `BOT_PAT` is a fine-grained PAT scoped
+to this repo. The repository is read from `GITHUB_REPOSITORY` / `REPO` and never
+hardcoded, so promoting this to `ai-ecoverse/.github` for the org is a packaging
+change (`workflow_call` plus a repo input), not a rewrite. Linear support is
+deliberately absent — Cosmos's `LINEAR_TEAM_KEYS` was empty.
 
 ### Running one on demand
 
@@ -93,17 +140,19 @@ occur. `dry_run: true` stops after the selector, which is the read-only way to
 see what a run _would_ do:
 
 ```bash
-# Selector only, no Claude, no PR — safe on any of the four.
+# Selector only, no Claude, no PR — safe on any of the five.
 gh workflow run boy-scout-debt-dispatcher.yml -f dry_run=true
 gh workflow run pr-fix-dispatcher.yml         -f dry_run=true
 gh workflow run claude-md-compactor.yml       -f dry_run=true
 gh workflow run flaky-ci-hunter.yml           -f dry_run=true
+gh workflow run backlog-dispatcher.yml        -f dry_run=true
 
 # Force real work without waiting for the natural trigger:
 gh workflow run boy-scout-debt-dispatcher.yml -f file=packages/webapp/src/fs/sudo-fs.ts
 gh workflow run pr-fix-dispatcher.yml         -f pr_number=1234
 gh workflow run claude-md-compactor.yml       -f max_chars=9000 -f target_chars=8500
 gh workflow run flaky-ci-hunter.yml           -f window_days=14 -f job=node-server
+gh workflow run backlog-dispatcher.yml        -f issue=2101 -f max_dispatches=1
 
 gh run list --workflow=pr-fix-dispatcher.yml --limit 3   # then `gh run view <id> --log`
 ```
@@ -115,6 +164,10 @@ waits — there is nobody to yield to when an operator points at a specific PR �
 and nothing else. Automation authorship, the self-healing labels, the marker
 dedup, the hard-override categories, and the dispatch budget all still apply, so
 a targeted run cannot be used to aim a fixer at a human's PR.
+
+`backlog-dispatcher.yml`'s `issue` input works the same way: it waives only the
+one-hour settling wait, leaving the decided-label dedup, the denylist, the
+in-flight-PR check, and the dispatch budget in force.
 
 ## doc-dead-reference-gate
 

--- a/packages/dev-tools/CLAUDE.md
+++ b/packages/dev-tools/CLAUDE.md
@@ -9,7 +9,7 @@ Developer-tooling surface for `packages/dev-tools/`. Long-form notes: [`docs/dev
 - **Build configs**: `packages/webapp/vite.config.ts`, `packages/chrome-extension/vite.config.ts`, `biome.json`.
 - **QA setup**: `packages/node-server/src/qa-setup.ts` plus root `npm run qa:*` scripts. Visual/integration helper: `packages/webapp/tests/test-dips.mjs`.
 - **RUM error triage**: `packages/dev-tools/rum-error-triage/triage-rum-errors.mjs`, nightly via `.github/workflows/rum-error-triage.yml`.
-- **Scheduled agentic workflows** (selector `.mjs` + `claude-code-action`): `boy-scout-debt/`, `pr-fix-dispatcher/`, `claude-md-compactor/`, `flaky-ci-hunter/`. Deep ref: [dev-tools-details.md#scheduled-agentic-workflows](../../docs/dev-tools-details.md#scheduled-agentic-workflows).
+- **Scheduled agentic workflows** (selector `.mjs` + `claude-code-action`): `boy-scout-debt/`, `pr-fix-dispatcher/`, `claude-md-compactor/`, `flaky-ci-hunter/`, `backlog-dispatcher/`. Deep ref: [dev-tools-details.md#scheduled-agentic-workflows](../../docs/dev-tools-details.md#scheduled-agentic-workflows).
 - **AI comment detection**: `packages/dev-tools/ai-comment-detection/` — labels `ai-generated`/`human-in-the-loop` via `.github/workflows/ai-comment-detection.yml`. Deep ref: [dev-tools-details.md#ai-comment-detection](../../docs/dev-tools-details.md#ai-comment-detection).
 - **Doc gates** (`npm run lint:docs`, `.husky/pre-commit`): `packages/dev-tools/tools/check-doc-sizes.mjs` (+ `check-doc-sizes-lib.mjs`) and `check-doc-refs.mjs` (+ `check-doc-refs-lib.mjs`). Deep ref: [dev-tools-details.md#doc-dead-reference-gate](../../docs/dev-tools-details.md#doc-dead-reference-gate).
 - **Linear-history check**: `bash packages/dev-tools/tools/check-linear-history.sh [base-ref] [head-ref]`. `linear-history` CI job.
@@ -41,7 +41,7 @@ Developer-tooling surface for `packages/dev-tools/`. Long-form notes: [`docs/dev
 
 ### Fresh Dev Harnesses
 
-Five isolated harnesses on distinct ports. Standalone fails on an occupied bridge unless `SLICC_FRESH_REAP=1` reaps a stale harness; reaping production bridge `:5710` is refused, Chrome CDP is never reaped, and cleanup is port-scoped.
+Five isolated harnesses on distinct ports; reaping is opt-in (`SLICC_FRESH_REAP=1`) and port-scoped.
 
 | Harness        | Script                        | Bridge                 | CDP     | Notes                                       |
 | -------------- | ----------------------------- | ---------------------- | ------- | ------------------------------------------- |

--- a/packages/dev-tools/backlog-dispatcher/README.md
+++ b/packages/dev-tools/backlog-dispatcher/README.md
@@ -1,0 +1,212 @@
+# Backlog Dispatcher — issues in, pull requests out
+
+🎫 A daily scheduled agent that reads this repository's open issues, decides
+which of them a competent engineer could implement today **without asking
+anybody a question**, and opens a pull request for a handful of them. It never
+closes an issue, never closes a pull request, and never merges.
+
+Workflow: [`.github/workflows/backlog-dispatcher.yml`](../../../.github/workflows/backlog-dispatcher.yml).
+
+## Flow
+
+```
+schedule (daily 09:35 UTC)
+  └─ select-backlog-issues.mjs            (deterministic; NO writes)
+       ├─ GET /issues?state=open           (candidates; PRs screened out by `pull_request`)
+       ├─ GET /pulls?state=open            (in-flight dedup + the open-PR ceiling)
+       ├─ backlog-candidates.json          (phase 1 reads this)
+       └─ $GITHUB_OUTPUT: has_candidates, candidate_count, dispatch_budget, prompt
+  └─ phase 1 TRIAGE   claude-code-action → labels `backlog-ready` / `backlog-skipped` (+1 comment)
+  └─ phase 2 AUTHOR   claude-code-action → branch, minimal change, PR with `Closes #<n>`,
+                                            label swapped to `backlog-dispatched`
+  └─ sweep-stale-prs.mjs                  (deterministic; label + one comment, NEVER closes)
+```
+
+`lib.mjs` is pure and unit-tested (`lib.test.mjs`, `dev-tools` vitest project);
+the two `.mjs` CLIs do all the I/O. Both prompts are built in `lib.mjs`
+(`buildTriagePrompt`, `buildAuthorPrompt`) so the rubric has exactly one source
+of truth and the tests can assert that the hard overrides survive.
+
+## Where the rubric came from
+
+This replaces an Augment Code ("Cosmos") expert of the same name. Its prompt body
+was a `kb://` include that did not survive the platform's retirement — but ~50 of
+its **decisions** did, left on this repo as `cosmos-dispatched` /
+`cosmos-skipped` labels plus its own verbatim skip comments. The catalogs in
+`lib.mjs` are reconstructed from that record, so this dispatcher applies the
+rubric the previous one demonstrably applied.
+
+### Hard overrides — never dispatched
+
+| Class                                  | Evidence                                                                                                        |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Security / authorization surface       | #2062 "sudo over tray": _"touches sudo authorization/security and requires human review"_                       |
+| Upstream/platform bug or a design call | #2072 iOS transcript jump: _"needs on-device experimentation and a design call, not a localised fix"_           |
+| Cross-cutting redesign / architectural | #2043 Atomics/SAB fast path: _"architectural scope, not a small contained PR"_; also the "Bloat" god-class asks |
+| Unconfirmed root cause                 | #2034 concurrent VFS reads: _"root cause is unconfirmed … needs a human to pick the approach"_                  |
+| Concurrency / data integrity           | #2034 again: _"spans service, caching, and protocol behavior"_                                                  |
+| Native work CI cannot verify           | several `feat(ios-app)` asks needing a device                                                                   |
+| New UX / product surface, unspecified  | "Shell: make PATH and HOME real concepts" (a redesign, not a task)                                              |
+
+### Ready classes — what it did dispatch
+
+An agentic-debt item naming both the sin and the file (`Paranoia:`,
+`Necrophilia:`, `Entanglement:`, `Duplication:`, `Complicatification:`, `Drift:`);
+a small localised bug with a concrete symptom ("output without trailing newline
+is invisible"); a missing shell command or flag with a clear spec (`feat(git):
+implement git clean`); one named flaky test; doc drift naming the stale file; a
+narrow test addition. `Bloat:` is deliberately **not** a ready class — a
+god-class split is architectural.
+
+`lib.mjs` only **orders and caps** the pool; the actual go/no-go call is Claude's
+in phase 1. The scorer ranks the ready classes first, rewards a named file and a
+concrete symptom, and pushes long bodies and hard-override smells down — but a
+smelly issue is still shown to Claude with its smells named, rather than being
+silently dropped.
+
+## State model — the labels are the work queue
+
+No state file, no state branch, no Actions cache.
+
+| Label                    | Meaning                                                        | Set by          |
+| ------------------------ | -------------------------------------------------------------- | --------------- |
+| `backlog-ready`          | Triage said yes; phase 2's queue                               | phase 1         |
+| `backlog-dispatched`     | A PR exists (also on the PR itself)                            | phase 2         |
+| `backlog-skipped`        | Decided against, once                                          | phase 1         |
+| `backlog-stale`          | A dispatcher-owned PR has gone idle                            | the stale sweep |
+| `cosmos-dispatch-failed` | The author phase died (legacy name reused — it already exists) | `if: failure()` |
+
+Unlike the [PR Fix Dispatcher](../pr-fix-dispatcher/README.md), the labels here
+**are** the dedup key: an issue carrying any of them is not a candidate at all.
+That is deliberate and fixes a bug in the original, which re-posted its skip
+comment on the same issue on every tick (#2072 got one on 2026-08-12 and another
+on 2026-08-17). **A decision is made once.**
+
+### Legacy label equivalence
+
+~50 issues already carry the Cosmos-era labels, so `LABELS.legacyDispatched` /
+`LABELS.legacySkipped` / `LABELS.legacyFailed` are treated as equivalent to the
+new names when excluding candidates (see `DECIDED_LABELS`, unit-tested). Without
+this the first run would re-propose work Cosmos already rejected — starting with
+the sudo-over-tray issue.
+
+### Re-queueing a skipped issue
+
+Removing the label is the intended, documented escape hatch:
+
+```bash
+gh issue edit 2072 --remove-label backlog-skipped   # or cosmos-skipped
+```
+
+The next tick sees the issue as undecided and reconsiders it from scratch.
+
+## Backpressure
+
+| Knob                        | Value | Meaning                                                    |
+| --------------------------- | ----: | ---------------------------------------------------------- |
+| `MAX_DISPATCHES_PER_RUN`    |     5 | PRs authored per tick.                                     |
+| `MAX_CANDIDATES_PER_SOURCE` |    25 | Issues kept per tick after screening and ranking.          |
+| `MAX_OPEN_PRS`              |    10 | Dispatcher-owned open PRs allowed in flight.               |
+| `SETTLING_AGE_HOURS`        |     1 | Minimum issue age — lets the author edit and triage first. |
+| `STALE_PR_DAYS`             |     7 | A dispatcher PR idle this long is swept.                   |
+
+Budget per tick is `min(MAX_DISPATCHES_PER_RUN, MAX_OPEN_PRS - open dispatcher PRs)`.
+At exactly 10 open the budget is **0**: the dispatcher stops adding review load
+instead of closing something to make room.
+
+Silent screen-outs (no label, no comment) happen before Claude ever sees an
+issue: it is a pull request, not open, assigned, younger than the settling
+window, already decided (new or legacy label), on the denylist (`question`,
+`wontfix`, `invalid`, `duplicate`, `skill issue`, `help wanted`), or already has
+an open PR referencing it (`Closes #n` / `Fixes #n` / `#n` in a PR body or the
+dispatcher's own `automation/backlog/issue-<n>` branch — the #2155 case).
+
+## The stale sweep never closes
+
+`sweep-stale-prs.mjs` is deterministic and runs no Claude. It labels
+`backlog-stale` and posts one comment asking a human to merge, take over, or
+close. The Cosmos original **closed** those PRs, which threw away work whose only
+sin was waiting for review; the replacement policy is "make it visible, let a
+human decide". Idempotent via the label, so the comment lands exactly once.
+
+## Branch naming is load-bearing
+
+PRs are opened on `automation/backlog/issue-<n>`. The `automation/` prefix is
+what makes
+[`isAutomationPr()`](../pr-fix-dispatcher/lib.mjs) in the PR Fix Dispatcher
+return true, so a backlog PR whose CI fails gets a fixer instead of rotting.
+`lib.test.mjs` imports **both** libs and asserts they agree — if the prefix ever
+changes, that test fails rather than the coupling silently breaking.
+
+## Run it locally
+
+```bash
+# Read-only rehearsal against the live repo (no writes at all — the selector
+# never writes; labelling is phase 1's job).
+REPO=ai-ecoverse/slicc GH_TOKEN=$(gh auth token) DRY_RUN=true \
+  node packages/dev-tools/backlog-dispatcher/select-backlog-issues.mjs
+
+# Fully offline: canned `{ "issues": [...], "prs": [...] }` API payloads.
+BACKLOG_FIXTURE=/tmp/fixture.json OUTPUT_PATH=/tmp/candidates.json \
+  node packages/dev-tools/backlog-dispatcher/select-backlog-issues.mjs
+
+# Stale sweep rehearsal (a fixture run is a dry run by construction).
+BACKLOG_FIXTURE=/tmp/fixture.json \
+  node packages/dev-tools/backlog-dispatcher/sweep-stale-prs.mjs
+
+# Unit tests
+node node_modules/vitest/vitest.mjs run --project dev-tools packages/dev-tools/backlog-dispatcher/
+```
+
+### Environment variables
+
+| Var               | Used by  | Meaning                                                                     |
+| ----------------- | -------- | --------------------------------------------------------------------------- |
+| `REPO`            | both     | `owner/repo` to scan; falls back to `GITHUB_REPOSITORY`. Never hardcoded.   |
+| `GH_TOKEN`        | both     | Token for the GitHub REST calls (required unless `BACKLOG_FIXTURE` is set). |
+| `ISSUE_NUMBER`    | selector | Consider only this issue; waives the settling-age wait and nothing else.    |
+| `DRY_RUN`         | both     | `true` → report only; the sweep writes nothing.                             |
+| `MAX_DISPATCHES`  | selector | Lower override of `MAX_DISPATCHES_PER_RUN`.                                 |
+| `SKIP_PR_CHECK`   | selector | `1` → skip the open-PR reads (offline-ish run; in-flight dedup disabled).   |
+| `BACKLOG_FIXTURE` | both     | Path to canned `{ issues, prs }` payloads — fully offline.                  |
+| `OUTPUT_PATH`     | selector | Candidates JSON path (default `./backlog-candidates.json`).                 |
+| `RUN_URL`         | both     | Actions run URL used in the comment attribution line.                       |
+
+### Running it on demand
+
+```bash
+gh workflow run backlog-dispatcher.yml -f dry_run=true                 # selector only
+gh workflow run backlog-dispatcher.yml -f issue=2101                   # one named issue
+gh workflow run backlog-dispatcher.yml -f max_dispatches=1             # author at most one PR
+gh run list --workflow=backlog-dispatcher.yml --limit 3                # then `gh run view <id> --log`
+```
+
+`issue` is the input that needed building: the routine tick only considers issues
+at least an hour old, which is awkward to arrange on demand. Naming an issue
+waives exactly that wait — there is nobody to yield to when an operator points at
+an issue — and nothing else: the decided-label dedup, the denylist, the
+in-flight-PR check, and the dispatch budget all still apply.
+
+## Scope: this repo only, for now
+
+`BOT_PAT` is a fine-grained PAT scoped to `ai-ecoverse/slicc`, and the Cosmos
+original's 21-repo sweep has no equivalent here. So the repository comes from
+`GITHUB_REPOSITORY` / `REPO` and is **never hardcoded** in the lib or the CLIs:
+promoting this to `ai-ecoverse/.github` for the whole org is a packaging change
+(add `workflow_call` plus a repo input) rather than a rewrite. Linear support is
+deliberately absent — Cosmos's `LINEAR_TEAM_KEYS` was empty.
+
+### Required secrets / variables (GitHub Actions)
+
+No new secrets — both are shared with `boy-scout-debt-dispatcher.yml`.
+
+| Name                       | Kind     | Purpose                                                                                                          |
+| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `AWS_BEARER_TOKEN_BEDROCK` | secret   | Amazon Bedrock API key (Adobe CAMP `ABSK...` bearer token) used by `claude-code-action` (`use_bedrock`).         |
+| `BOT_PAT`                  | secret   | Fine-grained PAT (contents + issues + pull-requests write); the branch push must not be `GITHUB_TOKEN`-authored. |
+| `RUM_AWS_REGION`           | variable | Optional. Bedrock region for the CAMP key (default `us-east-1`).                                                 |
+| `BACKLOG_BEDROCK_MODEL`    | variable | Optional. Bedrock model; falls back to `RUM_BEDROCK_MODEL`, then `global.anthropic.claude-sonnet-4-6`.           |
+
+The workflow needs `issues: write` **as well as** `pull-requests: write`:
+repo-level label creation (`gh label create`) goes through
+`POST /repos/{repo}/labels`, which is gated on `issues`.

--- a/packages/dev-tools/backlog-dispatcher/lib.mjs
+++ b/packages/dev-tools/backlog-dispatcher/lib.mjs
@@ -1,0 +1,758 @@
+/*
+ * Backlog Dispatcher — pure logic.
+ *
+ * Scans the repository's open issues on a schedule, keeps the ones that look
+ * ready to be implemented without a human design conversation, and hands them
+ * to a PR-authoring Claude phase. It never closes an issue, never closes a pull
+ * request, and never merges anything.
+ *
+ * This module is free of I/O (Node builtins only, no `process.env`, no fetch)
+ * so it can be unit-tested in isolation; the GitHub REST calls and the side
+ * effects (labels, comments, the composed prompts reaching Actions outputs)
+ * live in `select-backlog-issues.mjs` and `sweep-stale-prs.mjs`.
+ *
+ * READINESS RUBRIC PROVENANCE — the original (Augment Code "Cosmos") expert's
+ * prompt body was a `kb://` include that did not survive the platform's
+ * retirement. What DID survive is roughly fifty of its decisions, left in this
+ * repo as `cosmos-dispatched` / `cosmos-skipped` labels plus its own verbatim
+ * skip comments. {@link HARD_OVERRIDES} and {@link READY_CLASSES} below are
+ * reconstructed from that record, so the rubric this dispatcher applies is the
+ * rubric the previous one demonstrably applied.
+ *
+ * STATE — GitHub-native, no state file, state branch, or Actions cache. The
+ * labels ARE the work queue, and unlike the PR Fix Dispatcher they ARE the
+ * dedup key: an issue carrying a decided label is not a candidate at all. That
+ * is deliberate and fixes a bug in the original, which re-posted its skip
+ * comment on the same issue on every tick. A decision is made once; a human
+ * removing the label is the intended, documented way to re-queue an issue.
+ *
+ * The repository is never hardcoded here — the caller supplies it — so this
+ * package can be promoted to a reusable `ai-ecoverse/.github` workflow without
+ * a rewrite.
+ */
+
+/** Backpressure and eligibility configuration (the Cosmos-era knobs, verbatim). */
+export const CONFIG = {
+  /** PR-author dispatches per tick. */
+  MAX_DISPATCHES_PER_RUN: 5,
+  /** Issues kept per tick after screening and ranking. */
+  MAX_CANDIDATES_PER_SOURCE: 25,
+  /** Dispatcher-owned open PRs allowed in flight at once. */
+  MAX_OPEN_PRS: 10,
+  /** Minimum issue age before it is eligible — lets the author edit/triage first. */
+  SETTLING_AGE_HOURS: 1,
+  /** A dispatcher-owned open PR idle this long is swept (labelled, never closed). */
+  STALE_PR_DAYS: 7,
+};
+
+/**
+ * Labels the dispatcher maintains, plus the legacy Cosmos-era names that mean
+ * the same thing. ~50 issues in this repo already carry the legacy labels, so
+ * treating them as equivalent is what stops the first run from re-proposing
+ * work the previous dispatcher already rejected (the sudo-over-tray issue being
+ * the obvious example).
+ */
+export const LABELS = {
+  /** Phase 1 marked this ready; phase 2's work queue. */
+  ready: 'backlog-ready',
+  /** Phase 2 opened a PR for it. */
+  dispatched: 'backlog-dispatched',
+  /** Decided against, once and for all (until a human removes the label). */
+  skipped: 'backlog-skipped',
+  /** A dispatcher-owned PR that has gone idle. */
+  stale: 'backlog-stale',
+  /**
+   * The author phase died. Reuses the legacy name deliberately: the label
+   * already exists in this repo and means exactly this.
+   */
+  failed: 'cosmos-dispatch-failed',
+  /** Legacy names equivalent to `dispatched`. */
+  legacyDispatched: ['cosmos-dispatched'],
+  /** Legacy names equivalent to `skipped`. */
+  legacySkipped: ['cosmos-skipped'],
+  /** Legacy names equivalent to `failed`. */
+  legacyFailed: ['cosmos-dispatch-failed'],
+};
+
+/**
+ * Every label that means "this issue has already been decided". Carrying any of
+ * them takes the issue out of the candidate pool.
+ */
+export const DECIDED_LABELS = [
+  LABELS.ready,
+  LABELS.dispatched,
+  LABELS.skipped,
+  LABELS.failed,
+  ...LABELS.legacyDispatched,
+  ...LABELS.legacySkipped,
+  ...LABELS.legacyFailed,
+];
+
+/**
+ * Labels whose presence says a human has already routed the issue somewhere
+ * other than "implement this": a question, a rejected ask, or work explicitly
+ * reserved for an outside contributor.
+ */
+export const DENYLIST_LABELS = [
+  'question',
+  'wontfix',
+  'invalid',
+  'duplicate',
+  'skill issue',
+  'help wanted',
+];
+
+/** Colour + description used when bootstrapping labels (`gh label create --force`). */
+export const LABEL_META = {
+  [LABELS.ready]: {
+    color: '0e8a16',
+    description: 'Backlog Dispatcher: triage judged this ready for an authored PR',
+  },
+  [LABELS.dispatched]: {
+    color: '1d76db',
+    description: 'Backlog Dispatcher: a PR was opened for this issue',
+  },
+  [LABELS.skipped]: {
+    color: 'cccccc',
+    description: 'Backlog Dispatcher: decided against dispatching; remove this label to re-queue',
+  },
+  [LABELS.stale]: {
+    color: 'fbca04',
+    description: 'Backlog Dispatcher: dispatcher-owned PR has gone idle and needs a human',
+  },
+  [LABELS.failed]: {
+    color: 'b60205',
+    description: 'Backlog Dispatcher: the PR author phase did not finish',
+  },
+};
+
+/** Head-branch prefix for every PR this dispatcher opens. */
+export const BRANCH_PREFIX = 'automation/backlog';
+
+/**
+ * The hard-override catalog: classes of issue that are never dispatched,
+ * whatever they score. Every entry was derived from a real Cosmos skip on this
+ * repo; the quoted reason is the shape of its own explanation.
+ */
+export const HARD_OVERRIDES = [
+  {
+    id: 'security-surface',
+    label: 'Security / authorization surface',
+    detail:
+      'sudo, approvals, grants, secrets, tokens, CSP, permissions — authorization changes need human review.',
+    pattern: /\b(sudo|approval|authoriz|grant|secret|token|csp|permission|credential)\w*/i,
+  },
+  {
+    id: 'platform-bug',
+    label: 'Upstream/platform bug or a design call',
+    detail:
+      'an upstream framework bug, or anything needing on-device experimentation or a design decision, not a localised fix.',
+    pattern:
+      /\b(upstream|feedback assistant|fb\d{6,}|radar|workaround for|on[- ]device|design (call|decision)|needs? (a )?design)\b/i,
+  },
+  {
+    id: 'architectural',
+    label: 'Cross-cutting redesign / architectural scope',
+    detail:
+      'god-class splits (the "Bloat" sin), transport replacements, runtime redesigns — not one small contained PR.',
+    pattern:
+      /\b(bloat|redesign|re-?architect|architectur\w*|rewrite|cross-cutting|split .* into|replace the .* (transport|protocol)|fast path)\b/i,
+  },
+  {
+    id: 'unconfirmed-cause',
+    label: 'Unconfirmed root cause',
+    detail: 'the cause is suspected, not proven — a human must pick the approach first.',
+    pattern:
+      /\b(unconfirmed|suspected|not reproduc\w+|cannot reproduce|root cause is unknown|unclear (why|cause))\b/i,
+  },
+  {
+    id: 'concurrency',
+    label: 'Concurrency / data integrity across layers',
+    detail: 'races and corruption spanning service, cache, and protocol behaviour.',
+    pattern:
+      /\b(race condition|concurren\w+|deadlock|data (integrity|corruption)|locking|atomics|sharedarraybuffer)\b/i,
+  },
+  {
+    id: 'native-unverifiable',
+    label: 'Native work CI cannot verify',
+    detail: 'iOS/Swift/macOS behaviour that needs a device or a Simulator session to confirm.',
+    pattern: /\b(ios-app|ios app|simulator|swiftui|on a device|xcode|notariz\w+|entitlement)\b/i,
+  },
+  {
+    id: 'unspecified-ux',
+    label: 'New UX / product surface with no specified behaviour',
+    detail: 'the ask names an outcome but not the behaviour; somebody has to design it.',
+    pattern:
+      /\b(make .* (a )?real concepts?|rethink|explore|proposal|we should probably|some kind of|nice to have)\b/i,
+  },
+];
+
+/**
+ * Signals of the classes the previous dispatcher actually dispatched. Ordered
+ * best-first; `base` feeds {@link scoreCandidate}.
+ */
+export const READY_CLASSES = [
+  {
+    id: 'debt',
+    base: 100,
+    labels: ['agentic-debt', 'debt'],
+    /** The codebase-sins vocabulary, minus Bloat (a god-class split is architectural). */
+    pattern:
+      /^(paranoia|necrophilia|entanglement|duplication|complicatification|drift|amnesia|cargo[- ]cult)\b/i,
+  },
+  { id: 'bug', base: 80, labels: ['bug'], pattern: /^(bug|fix)\(|^flaky test\b/i },
+  { id: 'docs', base: 60, labels: ['documentation', 'area/docs'], pattern: /^docs?\(/i },
+  { id: 'feat', base: 40, labels: ['enhancement'], pattern: /^(feat|test|chore|refactor)\(/i },
+];
+
+/** A path-looking token: `packages/webapp/src/x.ts`, `foo.mjs`, `wc-live.ts`. */
+const NAMED_FILE_RE = /[\w./-]+\.(ts|tsx|mjs|js|json|md|swift|go|yml|yaml|sh|grit)\b/;
+
+/** A concrete, observable symptom — the difference between a bug report and a vibe. */
+const CONCRETE_SYMPTOM_RE =
+  /\b(throws?|error|times? out|hangs?|crashes?|returns? (the )?wrong|is (invisible|ignored|dropped|empty)|swallows?|off[- ]by[- ]one|regress\w*|does not|doesn't|never (fires|runs|resolves))\b/i;
+
+/**
+ * Characters of an issue body any regex is allowed to see. The file/symptom
+ * patterns backtrack, so an unbounded body (issues here reach tens of KB) turns
+ * a scan into a visibly slow one; the signals we look for are always near the
+ * top of a well-formed brief anyway.
+ */
+const MAX_SCANNED_BODY_CHARS = 4000;
+
+/** Milliseconds per hour, for the age arithmetic. */
+const HOUR_MS = 3_600_000;
+
+/** Normalise a GitHub label array (strings or `{name}` objects) to lowercase names. */
+export function labelNames(issue) {
+  const raw = Array.isArray(issue?.labels) ? issue.labels : [];
+  return raw
+    .map((l) => String(typeof l === 'string' ? l : (l?.name ?? '')).toLowerCase())
+    .filter((n) => n.length > 0);
+}
+
+/** Hours between two instants; Infinity when `then` is unusable (never blocks on bad data). */
+function hoursSince(then, now) {
+  const thenMs = new Date(then ?? '').getTime();
+  const nowMs = new Date(now ?? Date.now()).getTime();
+  if (Number.isNaN(thenMs) || Number.isNaN(nowMs)) return Number.POSITIVE_INFINITY;
+  return (nowMs - thenMs) / HOUR_MS;
+}
+
+/** Days between two instants; Infinity when `then` is unusable. */
+function daysSince(then, now) {
+  return hoursSince(then, now) / 24;
+}
+
+/** The head branch this dispatcher uses for an issue. */
+export function issueBranch(number) {
+  return `${BRANCH_PREFIX}/issue-${Number(number)}`;
+}
+
+/**
+ * Does a PR belong to this dispatcher? True for its own branch prefix or its
+ * dispatched label, so a relabelled-but-correctly-named PR is still recognised.
+ * @param {{head?: {ref?: string}, headRef?: string, labels?: Array<string|{name?: string}>}} pr
+ * @returns {boolean}
+ */
+export function isDispatcherPr(pr) {
+  if (!pr) return false;
+  const ref = String(pr.head?.ref ?? pr.headRef ?? '');
+  if (ref.startsWith(`${BRANCH_PREFIX}/`)) return true;
+  const labels = labelNames(pr);
+  return labels.includes(LABELS.dispatched) || labels.includes(LABELS.legacyDispatched[0]);
+}
+
+/** Build a regex that matches `#12` but not `#123`. */
+function issueRefRe(number) {
+  return new RegExp(`#${Number(number)}(?!\\d)`);
+}
+
+/**
+ * Is there already an open PR in flight for this issue? Matches `Closes #n` /
+ * `Fixes #n` / a bare `#n` in the PR body or title, and this dispatcher's own
+ * branch name. The Cosmos original skipped #2155 for exactly this reason ("A PR
+ * already exists for this ticket (#2156)").
+ * @param {{number?: number}} issue
+ * @param {Array<{title?: string, body?: string, head?: {ref?: string}, headRef?: string}>} openPrs
+ * @returns {boolean}
+ */
+export function hasLinkedOpenPr(issue, openPrs = []) {
+  const number = Number(issue?.number);
+  if (!Number.isFinite(number)) return false;
+  const branch = issueBranch(number);
+  const ref = issueRefRe(number);
+  return (Array.isArray(openPrs) ? openPrs : []).some((pr) => {
+    const head = String(pr?.head?.ref ?? pr?.headRef ?? '');
+    if (head === branch) return true;
+    return ref.test(`${String(pr?.title ?? '')}\n${String(pr?.body ?? '')}`);
+  });
+}
+
+/** A structured screening verdict. */
+const reject = (code, reason) => ({ eligible: false, code, reason });
+const ACCEPT = { eligible: true, code: 'eligible', reason: 'Passed every screening rule.' };
+
+/** The label-based half of the screen, split out to keep the screen readable. */
+function screenLabels(labels) {
+  const decided = labels.find((l) => DECIDED_LABELS.includes(l));
+  if (decided) {
+    return reject(
+      'already-decided',
+      `Already carries "${decided}" — this dispatcher decides once. Remove the label to re-queue.`
+    );
+  }
+  const denied = labels.find((l) => DENYLIST_LABELS.includes(l));
+  if (denied) return reject('denylisted', `Labelled "${denied}" — a human has already routed it.`);
+  return null;
+}
+
+/**
+ * Screen one issue for candidacy. Every rejection carries a machine-readable
+ * `code` so the digest and the tests can assert on the rule, not the prose.
+ *
+ * `targeted: true` is an operator naming one issue on `workflow_dispatch`; it
+ * waives ONLY the settling-age wait (there is nobody to yield to when a human
+ * points at an issue). Every other rule still applies.
+ *
+ * @param {object} issue a `GET /issues` item
+ * @param {{now?: Date|string, targeted?: boolean, openPrs?: Array<object>}} [opts]
+ * @returns {{eligible: boolean, code: string, reason: string}}
+ */
+export function screenIssue(issue, opts = {}) {
+  const { now = new Date(), targeted = false, openPrs = [] } = opts;
+  if (!issue || typeof issue !== 'object') return reject('malformed', 'Not an issue object.');
+  if (issue.pull_request != null) return reject('pull-request', 'This is a pull request.');
+  if (String(issue.state ?? 'open').toLowerCase() !== 'open') {
+    return reject('not-open', `Issue is ${issue.state}.`);
+  }
+  if (issue.assignee != null || (issue.assignees ?? []).length > 0) {
+    return reject('assigned', 'Someone is already assigned — leaving it to them.');
+  }
+
+  const labelVerdict = screenLabels(labelNames(issue));
+  if (labelVerdict) return labelVerdict;
+
+  const age = hoursSince(issue.created_at, now);
+  if (!targeted && age < CONFIG.SETTLING_AGE_HOURS) {
+    return reject(
+      'too-young',
+      `Opened ${age.toFixed(1)}h ago (< ${CONFIG.SETTLING_AGE_HOURS}h settling window).`
+    );
+  }
+  if (hasLinkedOpenPr(issue, openPrs)) {
+    return reject('pr-in-flight', 'An open pull request already references this issue.');
+  }
+  return ACCEPT;
+}
+
+/** Convenience predicate over {@link screenIssue}. */
+export function isCandidate(issue, opts = {}) {
+  return screenIssue(issue, opts).eligible;
+}
+
+/** Which ready class does this issue look like? Label match beats title match. */
+export function classifyIssue(issue) {
+  const labels = labelNames(issue);
+  const title = String(issue?.title ?? '');
+  for (const cls of READY_CLASSES) {
+    const byLabel = labels.some((l) => cls.labels.some((c) => l === c || l.startsWith(`${c}:`)));
+    if (byLabel || cls.pattern.test(title)) return cls.id;
+  }
+  return 'other';
+}
+
+/** Hard-override ids whose smell shows in an issue's title, body, or labels. */
+export function detectSmells(issue) {
+  const text = [
+    String(issue?.title ?? ''),
+    String(issue?.body ?? '').slice(0, MAX_SCANNED_BODY_CHARS),
+    labelNames(issue).join(' '),
+  ].join('\n');
+  return HARD_OVERRIDES.filter((o) => o.pattern.test(text)).map((o) => o.id);
+}
+
+/**
+ * Rank an issue: higher is better. Ready-class membership dominates; a named
+ * file and a concrete symptom are the two signals that separated the previous
+ * dispatcher's dispatches from its skips. Long bodies and hard-override smells
+ * push an issue down but never disqualify it — this function only ORDERS the
+ * pool. The actual go/no-go call is Claude's, in phase 1.
+ * @param {object} issue
+ * @returns {{score: number, class: string, smells: string[], namedFile: string|null}}
+ */
+export function scoreCandidate(issue) {
+  const cls = classifyIssue(issue);
+  const base = READY_CLASSES.find((c) => c.id === cls)?.base ?? 10;
+  const title = String(issue?.title ?? '');
+  const body = String(issue?.body ?? '');
+  const scanned = body.slice(0, MAX_SCANNED_BODY_CHARS);
+  const namedFile = (NAMED_FILE_RE.exec(title) ?? NAMED_FILE_RE.exec(scanned))?.[0] ?? null;
+  const smells = detectSmells(issue);
+
+  let score = base;
+  if (NAMED_FILE_RE.test(title)) score += 20;
+  else if (namedFile) score += 10;
+  if (CONCRETE_SYMPTOM_RE.test(`${title}\n${scanned}`)) score += 15;
+  // A 4,000-char issue is a discussion, not a brief. Capped so a very long body
+  // cannot outweigh class membership entirely.
+  score -= Math.min(30, Math.floor(body.length / 500) * 3);
+  score -= 25 * smells.length;
+  return { score, class: cls, smells, namedFile };
+}
+
+/** Compact candidate view handed to the prompts and the digest. */
+function toCandidate(issue) {
+  const ranked = scoreCandidate(issue);
+  return {
+    number: issue.number,
+    title: String(issue.title ?? ''),
+    url: issue.html_url ?? null,
+    createdAt: issue.created_at ?? null,
+    labels: labelNames(issue),
+    body: String(issue.body ?? ''),
+    ...ranked,
+  };
+}
+
+/**
+ * Screen, rank, and cap the issue list. Ordering is deterministic: score
+ * descending, then issue number ascending, so two runs over the same data agree.
+ * @param {Array<object>} issues
+ * @param {{now?: Date|string, limit?: number, openPrs?: Array<object>, targeted?: boolean}} [opts]
+ * @returns {{candidates: Array<object>, rejected: Array<{number: number, code: string, reason: string}>, truncated: number}}
+ */
+export function selectCandidates(issues, opts = {}) {
+  const { limit = CONFIG.MAX_CANDIDATES_PER_SOURCE } = opts;
+  const candidates = [];
+  const rejected = [];
+  for (const issue of Array.isArray(issues) ? issues : []) {
+    const verdict = screenIssue(issue, opts);
+    if (verdict.eligible) candidates.push(toCandidate(issue));
+    else
+      rejected.push({ number: issue?.number ?? null, code: verdict.code, reason: verdict.reason });
+  }
+  candidates.sort((a, b) => b.score - a.score || a.number - b.number);
+  const kept = candidates.slice(0, Math.max(0, limit));
+  return { candidates: kept, rejected, truncated: candidates.length - kept.length };
+}
+
+/**
+ * How many dispatches this tick may perform:
+ * `min(maxPerRun, maxOpenPrs - openDispatcherPrs)`, floored at 0. At the
+ * ceiling the answer is 0 — the dispatcher stops adding review load instead of
+ * closing something to make room.
+ * @param {{openDispatcherPrs?: number, maxOpenPrs?: number, maxPerRun?: number}} [input]
+ * @returns {number}
+ */
+export function dispatchBudget(input = {}) {
+  const {
+    openDispatcherPrs = 0,
+    maxOpenPrs = CONFIG.MAX_OPEN_PRS,
+    maxPerRun = CONFIG.MAX_DISPATCHES_PER_RUN,
+  } = input;
+  const headroom = maxOpenPrs - Math.max(0, Number(openDispatcherPrs) || 0);
+  return Math.max(0, Math.min(maxPerRun, headroom));
+}
+
+/**
+ * Dispatcher-owned open PRs that have gone idle. Already-labelled ones are
+ * excluded: the sweep decides once and never re-comments.
+ * @param {Array<object>} prs open pull requests
+ * @param {{now?: Date|string, staleDays?: number}} [opts]
+ * @returns {Array<{number: number, title: string, headRef: string, idleDays: number, url: string|null}>}
+ */
+export function selectStalePrs(prs, opts = {}) {
+  const { now = new Date(), staleDays = CONFIG.STALE_PR_DAYS } = opts;
+  return (Array.isArray(prs) ? prs : [])
+    .filter((pr) => isDispatcherPr(pr))
+    .filter((pr) => String(pr.state ?? 'open').toLowerCase() === 'open')
+    .filter((pr) => !labelNames(pr).includes(LABELS.stale))
+    .map((pr) => ({
+      number: pr.number,
+      title: String(pr.title ?? ''),
+      headRef: String(pr.head?.ref ?? pr.headRef ?? ''),
+      url: pr.html_url ?? null,
+      idleDays: daysSince(pr.updated_at ?? pr.created_at, now),
+    }))
+    .filter((pr) => pr.idleDays >= staleDays)
+    .sort((a, b) => b.idleDays - a.idleDays || a.number - b.number);
+}
+
+/** The hidden marker every dispatcher comment carries, for durable dedup. */
+export function buildMarker(kind, number) {
+  // Non-numeric input is passed through verbatim so prompts can render the
+  // marker with a `<number>` placeholder instead of a bogus `NaN`.
+  const parsed = Number(number);
+  return `<!-- backlog-${kind}:${Number.isFinite(parsed) ? parsed : String(number)} -->`;
+}
+
+/** The `<sup>` attribution line every comment opens with (Cosmos header convention). */
+function attribution(runUrl) {
+  const link = runUrl ? `[Backlog Dispatcher](${runUrl})` : 'Backlog Dispatcher';
+  return `<sup>🎫 ${link}</sup>`;
+}
+
+/**
+ * The one comment a skipped issue gets, ever.
+ * @param {string} reason plain-language explanation
+ * @param {{runUrl?: string, issueNumber?: number}} ctx
+ * @returns {string}
+ */
+export function formatSkipComment(reason, ctx = {}) {
+  return [
+    attribution(ctx.runUrl),
+    '',
+    `**Not dispatching this one.** ${reason}`,
+    '',
+    `Nothing was changed and no pull request was opened. This decision is made once — remove the \`${LABELS.skipped}\` label to put the issue back in the queue.`,
+    buildMarker('skip', ctx.issueNumber ?? 0),
+  ].join('\n');
+}
+
+/**
+ * The comment a stale dispatcher PR gets, ever. Explicitly promises not to
+ * close: the sweep labels and comments only.
+ * @param {{number: number, idleDays: number}} pr
+ * @param {{runUrl?: string}} ctx
+ * @returns {string}
+ */
+export function formatStaleComment(pr, ctx = {}) {
+  return [
+    attribution(ctx.runUrl),
+    '',
+    `**This dispatcher-owned PR has been idle for ${Math.floor(pr.idleDays)} day(s)** (threshold ${CONFIG.STALE_PR_DAYS}).`,
+    '',
+    `It is labelled \`${LABELS.stale}\` so a human can pick it up — merge it, take it over, or close it. **This sweep never closes a pull request**, and it will not comment on this PR again.`,
+    buildMarker('stale', pr.number),
+  ].join('\n');
+}
+
+/** One candidate rendered for a prompt. Bodies are truncated; briefs, not novels. */
+function candidateBlock(candidate, maxBody = 1200) {
+  const body = candidate.body.trim().slice(0, maxBody) || '_(empty body)_';
+  const smells = candidate.smells.length ? candidate.smells.join(', ') : 'none detected';
+  return [
+    `### #${candidate.number} — ${candidate.title}`,
+    `Class: \`${candidate.class}\` · score ${candidate.score} · labels: ${candidate.labels.join(', ') || 'none'}`,
+    `Named file: ${candidate.namedFile ?? 'none in the title/body'} · hard-override smells: ${smells}`,
+    '',
+    body,
+    '',
+  ].join('\n');
+}
+
+/** The shared rubric text, so triage and authoring cannot drift apart. */
+function rubricSection() {
+  const overrides = HARD_OVERRIDES.map((o) => `- **${o.label}** — ${o.detail}`).join('\n');
+  return `## Hard overrides — NEVER mark these ready
+
+${overrides}
+
+These are not heuristics; each one is a class the previous dispatcher explicitly
+refused on this repository. When an issue matches one, skip it and say which.
+
+## What "ready" looks like
+
+An issue is ready when a competent engineer could open the PR today without
+asking anybody a question:
+
+- an agentic-debt item naming both the sin and the file it lives in;
+- a small, localised bug with a concrete, observable symptom;
+- a missing shell command or flag with a clear spec, or a spec bug in one;
+- one named flaky test;
+- documentation drift where the stale file is named;
+- a narrow test addition.
+
+The change must be verifiable by CI in this repository. If it needs a device, a
+Simulator, a design decision, a dependency change, or a conversation, it is not
+ready.`;
+}
+
+/**
+ * Phase 1 prompt: judge each candidate and label the ready ones.
+ * @param {Array<object>} candidates from {@link selectCandidates}
+ * @param {{repo: string, runUrl?: string, budget?: number}} ctx
+ * @returns {string}
+ */
+export function buildTriagePrompt(candidates = [], ctx = {}) {
+  const budget = Number(ctx.budget ?? CONFIG.MAX_DISPATCHES_PER_RUN);
+  return `# Backlog triage — is this issue ready to implement?
+
+You are the 🎫 **Backlog Dispatcher** for \`${ctx.repo ?? 'this repository'}\`. A
+deterministic selector already screened the open issues (dropping pull requests,
+assigned issues, issues younger than ${CONFIG.SETTLING_AGE_HOURS}h, issues with a
+PR already in flight, and every issue that was already decided) and wrote the
+survivors to \`backlog-candidates.json\` in the repo root. They are listed below
+in the same order, best-first.
+
+Your job in this phase is **judgement only**: decide which candidates are ready
+and label them. Do NOT read or write code, do NOT create a branch, and do NOT
+open a pull request — a later phase does that for at most **${budget}** issue(s)
+this run.
+
+${rubricSection()}
+
+## What to do per candidate, in order
+
+1. Read the issue. Investigate the codebase with Read/Grep/Glob to confirm the
+   named file exists and the change really is as contained as the issue implies.
+2. If it is ready: \`gh issue edit <number> --add-label ${LABELS.ready}\`. Add no
+   comment — the PR itself will be the announcement.
+3. If it is not ready: \`gh issue edit <number> --add-label ${LABELS.skipped}\` and
+   post exactly ONE comment in the format given under "The skip comment" below.
+   Never post a second comment on an issue that already has one; the selector
+   guarantees you are seeing each issue for the first time.
+4. Mark at most **${budget}** issue(s) \`${LABELS.ready}\`. Spend that budget on
+   the ones you are most confident about, best-first. Leave the rest completely
+   untouched — no label, no comment — so a later run reconsiders them.
+
+Never close an issue, never assign anybody, never edit an issue's title or body,
+and never remove a label a human added. Being wrong is more expensive than being
+slow: when a candidate is borderline, skip it and explain.
+
+## The skip comment
+
+Post it verbatim in this shape, replacing the reason sentence and \`<number>\`
+with the issue's number. The \`${LABELS.skipped}\` label — not the trailing marker
+— is what stops a later run reconsidering the issue, so the label edit is the
+part you must not skip; the marker is a machine-readable record of which run
+decided, and belongs on its own line:
+
+\`\`\`markdown
+${formatSkipComment('<one sentence naming the hard override or the missing precondition that decided it>', { runUrl: ctx.runUrl, issueNumber: '<number>' })}
+\`\`\`
+
+## Candidates (${candidates.length})
+
+${candidates.map((c) => candidateBlock(c)).join('\n') || '_None._'}
+
+End by printing a short table of what you marked ready and what you skipped,
+with the deciding reason for each.`;
+}
+
+/**
+ * Phase 2 prompt: implement the ready issues and open the PRs.
+ * @param {Array<{number: number, title: string}>} issues the `backlog-ready` issues
+ * @param {{repo: string, runUrl?: string, budget?: number}} ctx
+ * @returns {string}
+ */
+export function buildAuthorPrompt(issues = [], ctx = {}) {
+  const list =
+    issues.map((i) => `- #${i.number} — ${String(i.title ?? '')}`).join('\n') || '_None._';
+  return `# Backlog PR author
+
+You are the 🎫 **Backlog Dispatcher**'s authoring phase for
+\`${ctx.repo ?? 'this repository'}\`. An earlier phase judged the issues below
+ready: small, contained, and verifiable by CI in this repository. They were also
+written to \`backlog-ready-issues.json\` in the repo root with their full bodies.
+
+${list}
+
+Work them **one at a time**, in the order given, and stop after
+${Number(ctx.budget ?? CONFIG.MAX_DISPATCHES_PER_RUN)} of them.
+
+## Per issue
+
+1. PREFLIGHT (idempotency — before creating anything): check for work already in
+   flight from an interrupted run:
+   \`gh pr list --state open --search "<number> in:body" --json number,headRefName\`
+   and \`git ls-remote --exit-code --heads origin ${BRANCH_PREFIX}/issue-<number>\`.
+   If either exists, do NOT create a second branch or PR — just reconcile the
+   labels (step 5) and move on.
+2. \`git switch -c ${BRANCH_PREFIX}/issue-<number>\` off the default branch and
+   implement the **minimal** change the issue asks for. Nothing else: no
+   drive-by refactors, no dependency changes, no CI-config changes, no
+   reformatting of untouched code.
+3. Add or update focused tests (\`packages/*/tests/\` mirroring \`src/\`; see
+   \`.agents/skills/writing-slicc-tests/SKILL.md\`). Never lower a coverage floor
+   or add a lint suppression, an exemption, or a baseline entry to pass a gate.
+4. Verify before pushing, per
+   \`.agents/skills/verifying-before-push/SKILL.md\`:
+   \`\`\`bash
+   npx biome check --write <files you touched>
+   npm run typecheck
+   npx vitest run <the focused test files>
+   node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main
+   \`\`\`
+5. Push and open the PR:
+   \`\`\`bash
+   git push -u origin ${BRANCH_PREFIX}/issue-<number>
+   gh pr create --base main --label ${LABELS.dispatched} \\
+     --title "<conventional-commit title>" \\
+     --body "Closes #<number>
+
+   <what changed, why, how you verified>"
+   gh issue edit <number> --remove-label ${LABELS.ready} --add-label ${LABELS.dispatched}
+   \`\`\`
+   The \`Closes #<number>\` line is required — it is how merging the PR closes the
+   issue. The \`${LABELS.dispatched}\` label on the PR is how the PR Fix
+   Dispatcher and the stale sweep recognise it as ours.
+
+## If it turns out not to be ready
+
+If the change is larger than the issue implied, needs a design decision, touches
+a security/authorization surface, or cannot be verified by CI here: open NO pull
+request, leave the working tree clean (\`git checkout -- .\`), swap the label
+(\`gh issue edit <number> --remove-label ${LABELS.ready} --add-label ${LABELS.skipped}\`),
+and post ONE comment explaining what you found. A wrong PR is worse than none.
+
+Never close an issue or a pull request, never merge, never request reviewers, and
+never force-push over somebody else's branch. End by printing each issue number
+with its PR URL or the reason you left it alone.`;
+}
+
+/** One digest row per rejection code, so the summary explains the funnel. */
+function rejectionTally(rejected) {
+  const counts = new Map();
+  for (const r of rejected) counts.set(r.code, (counts.get(r.code) ?? 0) + 1);
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([code, n]) => `| \`${code}\` | ${n} |`)
+    .join('\n');
+}
+
+/**
+ * The Actions step summary.
+ * @param {{repo?: string, candidates?: Array<object>, rejected?: Array<object>, budget?: number, openDispatcherPrs?: number, stale?: Array<object>, truncated?: number, dryRun?: boolean}} input
+ * @returns {string}
+ */
+export function buildDigest(input = {}) {
+  const {
+    repo = '',
+    candidates = [],
+    rejected = [],
+    budget = 0,
+    openDispatcherPrs = 0,
+    stale = [],
+    truncated = 0,
+    dryRun = false,
+  } = input;
+  const rows =
+    candidates
+      .map(
+        (c) =>
+          `| #${c.number} | ${c.title.replaceAll('|', '\\|')} | \`${c.class}\` | ${c.score} | ${c.smells.join(', ') || '—'} |`
+      )
+      .join('\n') || '| — | _no candidates_ | | | |';
+
+  return `## 🎫 Backlog Dispatcher${dryRun ? ' — **DRY RUN**' : ''}
+
+Repository: \`${repo}\` · candidates: **${candidates.length}**${truncated > 0 ? ` (+${truncated} over the cap of ${CONFIG.MAX_CANDIDATES_PER_SOURCE})` : ''} · dispatcher PRs open: **${openDispatcherPrs}**/${CONFIG.MAX_OPEN_PRS} · dispatch budget: **${budget}**
+
+| Issue | Title | Class | Score | Hard-override smells |
+| --- | --- | --- | --- | --- |
+${rows}
+
+### Screened out (${rejected.length})
+
+| Reason code | Count |
+| --- | --- |
+${rejectionTally(rejected) || '| — | 0 |'}
+
+### Stale dispatcher PRs (${stale.length})
+
+${stale.map((p) => `- #${p.number} idle ${Math.floor(p.idleDays)}d — \`${p.headRef}\``).join('\n') || '_None._'}
+
+A stale PR is labelled \`${LABELS.stale}\` and commented on once. It is never closed.`;
+}

--- a/packages/dev-tools/backlog-dispatcher/lib.test.mjs
+++ b/packages/dev-tools/backlog-dispatcher/lib.test.mjs
@@ -1,0 +1,642 @@
+import { describe, expect, it } from 'vitest';
+import { isAutomationPr } from '../pr-fix-dispatcher/lib.mjs';
+import {
+  buildAuthorPrompt,
+  buildDigest,
+  buildMarker,
+  buildTriagePrompt,
+  CONFIG,
+  classifyIssue,
+  DECIDED_LABELS,
+  DENYLIST_LABELS,
+  detectSmells,
+  dispatchBudget,
+  formatSkipComment,
+  formatStaleComment,
+  hasLinkedOpenPr,
+  isCandidate,
+  isDispatcherPr,
+  issueBranch,
+  LABELS,
+  labelNames,
+  scoreCandidate,
+  screenIssue,
+  selectCandidates,
+  selectStalePrs,
+} from './lib.mjs';
+
+const NOW = new Date('2026-09-01T12:00:00Z');
+const hoursAgo = (h) => new Date(NOW.getTime() - h * 3_600_000).toISOString();
+const daysAgo = (d) => hoursAgo(d * 24);
+
+/** An issue that passes every screening rule. */
+function issue(overrides = {}) {
+  return {
+    number: 100,
+    title: 'Paranoia: session-freezer updateSessionsIndex swallows all readFile errors',
+    body: 'The catch in packages/webapp/src/sessions/session-freezer.ts swallows every error.',
+    state: 'open',
+    created_at: daysAgo(3),
+    updated_at: daysAgo(1),
+    html_url: 'https://github.com/o/r/issues/100',
+    labels: [{ name: 'agentic-debt' }],
+    assignee: null,
+    assignees: [],
+    ...overrides,
+  };
+}
+
+describe('CONFIG', () => {
+  it('carries the Cosmos-era knobs verbatim', () => {
+    expect(CONFIG).toMatchObject({
+      MAX_DISPATCHES_PER_RUN: 5,
+      MAX_CANDIDATES_PER_SOURCE: 25,
+      MAX_OPEN_PRS: 10,
+      SETTLING_AGE_HOURS: 1,
+      STALE_PR_DAYS: 7,
+    });
+  });
+});
+
+describe('LABELS', () => {
+  it('uses the new vocabulary but reuses the existing failure label', () => {
+    expect(LABELS.ready).toBe('backlog-ready');
+    expect(LABELS.dispatched).toBe('backlog-dispatched');
+    expect(LABELS.skipped).toBe('backlog-skipped');
+    expect(LABELS.stale).toBe('backlog-stale');
+    expect(LABELS.failed).toBe('cosmos-dispatch-failed');
+  });
+
+  it('treats the legacy Cosmos labels as equivalent when excluding candidates', () => {
+    expect(LABELS.legacyDispatched).toContain('cosmos-dispatched');
+    expect(LABELS.legacySkipped).toContain('cosmos-skipped');
+    expect(DECIDED_LABELS).toEqual(
+      expect.arrayContaining([
+        'backlog-ready',
+        'backlog-dispatched',
+        'backlog-skipped',
+        'cosmos-dispatched',
+        'cosmos-skipped',
+        'cosmos-dispatch-failed',
+      ])
+    );
+  });
+});
+
+describe('labelNames', () => {
+  it('normalises both label shapes to lowercase and drops blanks', () => {
+    expect(labelNames({ labels: [{ name: 'Bug' }, 'Area/Docs', { name: '' }, null] })).toEqual([
+      'bug',
+      'area/docs',
+    ]);
+  });
+
+  it('tolerates a missing label array', () => {
+    expect(labelNames({})).toEqual([]);
+    expect(labelNames(null)).toEqual([]);
+  });
+});
+
+describe('screenIssue', () => {
+  it('accepts a well-formed, aged, unassigned, undecided issue', () => {
+    expect(screenIssue(issue(), { now: NOW })).toMatchObject({ eligible: true, code: 'eligible' });
+    expect(isCandidate(issue(), { now: NOW })).toBe(true);
+  });
+
+  it('rejects a pull request masquerading as an issue in GET /issues', () => {
+    expect(screenIssue(issue({ pull_request: { url: 'x' } }), { now: NOW })).toMatchObject({
+      eligible: false,
+      code: 'pull-request',
+    });
+  });
+
+  it('rejects a closed issue', () => {
+    expect(screenIssue(issue({ state: 'closed' }), { now: NOW })).toMatchObject({
+      code: 'not-open',
+    });
+  });
+
+  it('rejects an assigned issue via either assignee field', () => {
+    expect(screenIssue(issue({ assignee: { login: 'a' } }), { now: NOW }).code).toBe('assigned');
+    expect(screenIssue(issue({ assignees: [{ login: 'a' }] }), { now: NOW }).code).toBe('assigned');
+  });
+
+  it('rejects malformed input instead of throwing', () => {
+    expect(screenIssue(null).code).toBe('malformed');
+    expect(screenIssue('nope').code).toBe('malformed');
+  });
+
+  it('rejects every denylist label', () => {
+    for (const label of DENYLIST_LABELS) {
+      expect(screenIssue(issue({ labels: [{ name: label }] }), { now: NOW })).toMatchObject({
+        eligible: false,
+        code: 'denylisted',
+      });
+    }
+  });
+
+  it('rejects an issue this dispatcher already decided', () => {
+    for (const label of [LABELS.ready, LABELS.dispatched, LABELS.skipped, LABELS.failed]) {
+      expect(screenIssue(issue({ labels: [{ name: label }] }), { now: NOW }).code).toBe(
+        'already-decided'
+      );
+    }
+  });
+
+  it('rejects an issue Cosmos already decided (legacy label equivalence)', () => {
+    for (const label of ['cosmos-dispatched', 'cosmos-skipped', 'cosmos-dispatch-failed']) {
+      const verdict = screenIssue(issue({ labels: [{ name: label }] }), { now: NOW });
+      expect(verdict.code).toBe('already-decided');
+      expect(verdict.reason).toContain(label);
+    }
+  });
+
+  it('explains the re-queue escape hatch in the already-decided reason', () => {
+    const verdict = screenIssue(issue({ labels: [{ name: LABELS.skipped }] }), { now: NOW });
+    expect(verdict.reason).toMatch(/remove the label to re-queue/i);
+  });
+});
+
+describe('screenIssue settling age', () => {
+  it('rejects an issue younger than the settling window', () => {
+    const verdict = screenIssue(issue({ created_at: hoursAgo(0.5) }), { now: NOW });
+    expect(verdict).toMatchObject({ eligible: false, code: 'too-young' });
+  });
+
+  it('accepts an issue exactly at the boundary', () => {
+    expect(screenIssue(issue({ created_at: hoursAgo(1) }), { now: NOW }).eligible).toBe(true);
+  });
+
+  it('waives only the settling wait for a targeted run', () => {
+    const young = issue({ created_at: hoursAgo(0.1) });
+    expect(screenIssue(young, { now: NOW, targeted: true }).eligible).toBe(true);
+    // A targeted run does not waive anything else.
+    expect(
+      screenIssue({ ...young, labels: [{ name: 'cosmos-skipped' }] }, { now: NOW, targeted: true })
+        .code
+    ).toBe('already-decided');
+  });
+
+  it('does not block on an unparseable created_at', () => {
+    expect(screenIssue(issue({ created_at: 'not-a-date' }), { now: NOW }).eligible).toBe(true);
+  });
+});
+
+describe('hasLinkedOpenPr', () => {
+  it('matches Closes / Fixes / a bare reference in the PR body', () => {
+    expect(hasLinkedOpenPr({ number: 42 }, [{ body: 'Closes #42' }])).toBe(true);
+    expect(hasLinkedOpenPr({ number: 42 }, [{ body: 'Fixes #42 in one line' }])).toBe(true);
+    expect(hasLinkedOpenPr({ number: 42 }, [{ body: 'relates to #42' }])).toBe(true);
+    expect(hasLinkedOpenPr({ number: 42 }, [{ title: 'fix: #42 terminal output' }])).toBe(true);
+  });
+
+  it('does not confuse #42 with #421', () => {
+    expect(hasLinkedOpenPr({ number: 42 }, [{ body: 'Closes #421' }])).toBe(false);
+  });
+
+  it('matches the dispatcher own branch even with no body reference', () => {
+    expect(hasLinkedOpenPr({ number: 7 }, [{ head: { ref: 'automation/backlog/issue-7' } }])).toBe(
+      true
+    );
+    expect(hasLinkedOpenPr({ number: 7 }, [{ headRef: 'automation/backlog/issue-7' }])).toBe(true);
+    expect(hasLinkedOpenPr({ number: 7 }, [{ headRef: 'automation/backlog/issue-70' }])).toBe(
+      false
+    );
+  });
+
+  it('returns false for no PRs or a numberless issue', () => {
+    expect(hasLinkedOpenPr({ number: 1 }, [])).toBe(false);
+    expect(hasLinkedOpenPr({}, [{ body: 'Closes #1' }])).toBe(false);
+  });
+
+  it('takes an issue with a PR in flight out of the candidate pool (the #2155 case)', () => {
+    const verdict = screenIssue(issue({ number: 2155 }), {
+      now: NOW,
+      openPrs: [{ number: 2156, body: 'Closes #2155' }],
+    });
+    expect(verdict).toMatchObject({ eligible: false, code: 'pr-in-flight' });
+  });
+});
+
+describe('classifyIssue', () => {
+  it('recognises the debt class by label or by sin title', () => {
+    expect(classifyIssue({ labels: [{ name: 'agentic-debt' }], title: 'whatever' })).toBe('debt');
+    expect(classifyIssue({ labels: [{ name: 'debt:complexity' }], title: 'whatever' })).toBe(
+      'debt'
+    );
+    expect(classifyIssue({ title: 'Necrophilia: search-tools.ts (213 LOC) is dead' })).toBe('debt');
+    expect(classifyIssue({ title: 'Drift: packages/swift-optel/CLAUDE.md Scope is stale' })).toBe(
+      'debt'
+    );
+  });
+
+  it('does not treat Bloat as ready debt (a god-class split is architectural)', () => {
+    expect(classifyIssue({ title: 'Bloat: ui/wc/wc-live.ts is 2,359 lines' })).not.toBe('debt');
+  });
+
+  it('recognises bugs, docs, and small feats', () => {
+    expect(classifyIssue({ title: 'bug(git): git ls-files ignores pathspec' })).toBe('bug');
+    expect(classifyIssue({ title: 'Flaky test: wc-placeholder times out' })).toBe('bug');
+    expect(classifyIssue({ labels: [{ name: 'area/docs' }], title: 'stale docs' })).toBe('docs');
+    expect(classifyIssue({ title: 'feat(git): implement git clean' })).toBe('feat');
+    expect(classifyIssue({ title: 'test(ios): compare follower hello payload fields' })).toBe(
+      'feat'
+    );
+  });
+
+  it('falls back to other', () => {
+    expect(classifyIssue({ title: 'Shell: make PATH and HOME real concepts' })).toBe('other');
+  });
+});
+
+describe('detectSmells', () => {
+  const smellsOf = (title, body = '') => detectSmells({ title, body });
+
+  it('flags the security/authorization surface (#2062 sudo over tray)', () => {
+    expect(smellsOf('Sudo over tray: approve a follower sudo prompt')).toContain(
+      'security-surface'
+    );
+  });
+
+  it('flags an upstream platform bug needing on-device work (#2072)', () => {
+    expect(
+      smellsOf('iOS transcript jump', 'workaround for an upstream iOS 26 SwiftUI bug FB20979569')
+    ).toContain('platform-bug');
+  });
+
+  it('flags architectural scope (#2043 and the Bloat god-class splits)', () => {
+    expect(smellsOf('DIP unlock: Atomics/SAB fast path')).toContain('architectural');
+    expect(smellsOf('Bloat: kernel/facade.ts is 2,021 lines')).toContain('architectural');
+  });
+
+  it('flags an unconfirmed root cause (#2034)', () => {
+    expect(
+      smellsOf('Concurrent VFS reads fail', 'root cause is unconfirmed, suspected ZenFS')
+    ).toEqual(expect.arrayContaining(['unconfirmed-cause', 'concurrency']));
+  });
+
+  it('flags native work CI cannot verify', () => {
+    expect(smellsOf('feat(ios-app): add a share sheet')).toContain('native-unverifiable');
+  });
+
+  it('flags an unspecified UX ask', () => {
+    expect(smellsOf('Shell: make PATH and HOME real concepts')).toContain('unspecified-ux');
+  });
+
+  it('returns nothing for a clean localised bug', () => {
+    expect(
+      smellsOf('Terminal panel: command output without trailing newline is invisible')
+    ).toEqual([]);
+  });
+});
+
+describe('scoreCandidate', () => {
+  it('ranks a named-file debt item above a bare feat request', () => {
+    const debt = scoreCandidate(issue());
+    const feat = scoreCandidate({ title: 'feat(git): implement git clean', body: '' });
+    expect(debt.score).toBeGreaterThan(feat.score);
+    expect(debt.class).toBe('debt');
+  });
+
+  it('rewards a named file in the title over one only in the body', () => {
+    const inTitle = scoreCandidate({ title: 'Drift: docs/development.md is stale', body: '' });
+    const inBody = scoreCandidate({
+      title: 'Drift: the dev docs are stale',
+      body: 'docs/development.md',
+    });
+    expect(inTitle.score).toBeGreaterThan(inBody.score);
+    expect(inBody.namedFile).toBe('docs/development.md');
+  });
+
+  it('rewards a concrete symptom', () => {
+    const concrete = scoreCandidate({ title: 'bug(term): output is invisible', body: '' });
+    const vague = scoreCandidate({ title: 'bug(term): terminal feels bad', body: '' });
+    expect(concrete.score).toBeGreaterThan(vague.score);
+  });
+
+  it('penalises a very long body, but the penalty is capped', () => {
+    const short = scoreCandidate({ title: 'bug(x): it throws', body: 'a'.repeat(100) });
+    const long = scoreCandidate({ title: 'bug(x): it throws', body: 'a'.repeat(5000) });
+    const longer = scoreCandidate({ title: 'bug(x): it throws', body: 'a'.repeat(50_000) });
+    expect(long.score).toBeLessThan(short.score);
+    expect(longer.score).toBe(long.score);
+  });
+
+  it('deprioritises but never disqualifies a hard-override smell', () => {
+    const smelly = scoreCandidate({
+      title: 'bug(sudo): approval prompt throws',
+      body: '',
+    });
+    expect(smelly.smells).toContain('security-surface');
+    expect(Number.isFinite(smelly.score)).toBe(true);
+  });
+});
+
+describe('selectCandidates', () => {
+  it('is deterministic: score descending, then issue number ascending', () => {
+    const same = (n) => issue({ number: n, title: 'feat(git): implement git clean', body: '' });
+    const { candidates } = selectCandidates([same(30), same(10), same(20)], { now: NOW });
+    expect(candidates.map((c) => c.number)).toEqual([10, 20, 30]);
+  });
+
+  it('puts the debt item first and reports why the rest were dropped', () => {
+    const { candidates, rejected } = selectCandidates(
+      [
+        issue({ number: 1 }),
+        issue({ number: 2, title: 'feat(git): implement git clean', body: '', labels: [] }),
+        issue({ number: 3, labels: [{ name: 'cosmos-skipped' }] }),
+        issue({ number: 4, pull_request: {} }),
+      ],
+      { now: NOW }
+    );
+    expect(candidates.map((c) => c.number)).toEqual([1, 2]);
+    expect(rejected).toEqual([
+      { number: 3, code: 'already-decided', reason: expect.any(String) },
+      { number: 4, code: 'pull-request', reason: expect.any(String) },
+    ]);
+  });
+
+  it('caps at MAX_CANDIDATES_PER_SOURCE and reports the overflow', () => {
+    const many = Array.from({ length: 40 }, (_, i) => issue({ number: i + 1 }));
+    const { candidates, truncated } = selectCandidates(many, { now: NOW });
+    expect(candidates).toHaveLength(CONFIG.MAX_CANDIDATES_PER_SOURCE);
+    expect(truncated).toBe(40 - CONFIG.MAX_CANDIDATES_PER_SOURCE);
+  });
+
+  it('honours an explicit lower limit and tolerates junk input', () => {
+    expect(selectCandidates([issue()], { now: NOW, limit: 0 }).candidates).toHaveLength(0);
+    expect(selectCandidates(null, { now: NOW }).candidates).toEqual([]);
+  });
+});
+
+describe('dispatchBudget', () => {
+  it('allows MAX_DISPATCHES_PER_RUN when nothing is in flight', () => {
+    expect(dispatchBudget({ openDispatcherPrs: 0 })).toBe(5);
+  });
+
+  it('is limited by the headroom under MAX_OPEN_PRS', () => {
+    expect(dispatchBudget({ openDispatcherPrs: 7 })).toBe(3);
+    expect(dispatchBudget({ openDispatcherPrs: 9 })).toBe(1);
+  });
+
+  it('is zero exactly at the ceiling and beyond it', () => {
+    expect(dispatchBudget({ openDispatcherPrs: 10 })).toBe(0);
+    expect(dispatchBudget({ openDispatcherPrs: 25 })).toBe(0);
+  });
+
+  it('accepts overrides and treats junk as zero in flight', () => {
+    expect(dispatchBudget({ openDispatcherPrs: 0, maxPerRun: 2 })).toBe(2);
+    expect(dispatchBudget({ openDispatcherPrs: 1, maxOpenPrs: 2 })).toBe(1);
+    expect(dispatchBudget({ openDispatcherPrs: Number.NaN })).toBe(5);
+    expect(dispatchBudget()).toBe(5);
+  });
+});
+
+describe('issueBranch and isAutomationPr agreement', () => {
+  it('names branches under automation/backlog/issue-<n>', () => {
+    expect(issueBranch(2155)).toBe('automation/backlog/issue-2155');
+    expect(issueBranch('42')).toBe('automation/backlog/issue-42');
+  });
+
+  it('produces a branch the PR Fix Dispatcher recognises as automation', () => {
+    // If this ever diverges, backlog PRs stop getting their CI failures fixed.
+    expect(isAutomationPr({ user: { type: 'User' }, head: { ref: issueBranch(1) } })).toBe(true);
+    expect(isAutomationPr({ user: { type: 'User' }, headRef: issueBranch(999) })).toBe(true);
+  });
+});
+
+describe('isDispatcherPr', () => {
+  it('recognises its own branch prefix and its own label', () => {
+    expect(isDispatcherPr({ head: { ref: issueBranch(3) } })).toBe(true);
+    expect(isDispatcherPr({ headRef: 'feature/x', labels: [{ name: LABELS.dispatched }] })).toBe(
+      true
+    );
+    expect(isDispatcherPr({ headRef: 'feature/x', labels: [{ name: 'cosmos-dispatched' }] })).toBe(
+      true
+    );
+  });
+
+  it('rejects unrelated PRs and junk', () => {
+    expect(isDispatcherPr({ headRef: 'renovate/vite-6.x' })).toBe(false);
+    expect(isDispatcherPr(null)).toBe(false);
+  });
+});
+
+describe('selectStalePrs', () => {
+  const pr = (overrides = {}) => ({
+    number: 500,
+    title: 'fix: something',
+    state: 'open',
+    head: { ref: issueBranch(100) },
+    updated_at: daysAgo(9),
+    html_url: 'https://github.com/o/r/pull/500',
+    labels: [],
+    ...overrides,
+  });
+
+  it('selects a dispatcher PR idle past the threshold', () => {
+    const [stale] = selectStalePrs([pr()], { now: NOW });
+    expect(stale).toMatchObject({ number: 500, headRef: issueBranch(100) });
+    expect(stale.idleDays).toBeCloseTo(9, 5);
+  });
+
+  it('is exclusive at the boundary in the safe direction', () => {
+    expect(selectStalePrs([pr({ updated_at: daysAgo(6.9) })], { now: NOW })).toHaveLength(0);
+    expect(selectStalePrs([pr({ updated_at: daysAgo(7) })], { now: NOW })).toHaveLength(1);
+  });
+
+  it('ignores PRs that are not the dispatcher own', () => {
+    expect(selectStalePrs([pr({ head: { ref: 'renovate/x' }, labels: [] })], { now: NOW })).toEqual(
+      []
+    );
+  });
+
+  it('is idempotent: an already-labelled PR is never selected again', () => {
+    expect(selectStalePrs([pr({ labels: [{ name: LABELS.stale }] })], { now: NOW })).toEqual([]);
+  });
+
+  it('ignores closed PRs and orders oldest-idle first', () => {
+    expect(selectStalePrs([pr({ state: 'closed' })], { now: NOW })).toEqual([]);
+    const ordered = selectStalePrs(
+      [pr({ number: 2, updated_at: daysAgo(8) }), pr({ number: 1, updated_at: daysAgo(20) })],
+      { now: NOW }
+    );
+    expect(ordered.map((p) => p.number)).toEqual([1, 2]);
+  });
+
+  it('falls back to created_at and tolerates junk', () => {
+    expect(
+      selectStalePrs([pr({ updated_at: undefined, created_at: daysAgo(30) })], { now: NOW })
+    ).toHaveLength(1);
+    expect(selectStalePrs(null, { now: NOW })).toEqual([]);
+  });
+});
+
+describe('formatSkipComment', () => {
+  const body = formatSkipComment('It touches the sudo authorization surface.', {
+    runUrl: 'https://github.com/o/r/actions/runs/1',
+    issueNumber: 2062,
+  });
+
+  it('opens with the 🎫 attribution linking the Actions run', () => {
+    expect(body.split('\n')[0]).toBe(
+      '<sup>🎫 [Backlog Dispatcher](https://github.com/o/r/actions/runs/1)</sup>'
+    );
+  });
+
+  it('carries the reason, the re-queue instruction, and the hidden marker', () => {
+    expect(body).toContain('It touches the sudo authorization surface.');
+    expect(body).toContain(`remove the \`${LABELS.skipped}\` label`);
+    expect(body).toContain(buildMarker('skip', 2062));
+    expect(buildMarker('skip', 2062)).toBe('<!-- backlog-skip:2062 -->');
+  });
+
+  it('degrades to a plain role name with no run URL', () => {
+    expect(formatSkipComment('nope', {}).split('\n')[0]).toBe('<sup>🎫 Backlog Dispatcher</sup>');
+  });
+
+  it('renders a placeholder issue number verbatim instead of NaN', () => {
+    // The triage prompt embeds this template with `<number>` for Claude to fill
+    // in; a `Number()` coercion here used to turn that into `backlog-skip:NaN`.
+    expect(buildMarker('skip', '<number>')).toBe('<!-- backlog-skip:<number> -->');
+    expect(buildMarker('skip', '2062')).toBe('<!-- backlog-skip:2062 -->');
+  });
+
+  it('is the single source of the skip format the triage prompt hands Claude', () => {
+    // Guards the wiring: if the prompt stopped embedding this builder, the model
+    // would invent its own comment shape and the 🎫 header would drift.
+    const prompt = buildTriagePrompt([], { repo: 'o/r', runUrl: 'https://run', budget: 2 });
+    expect(prompt).toContain('## The skip comment');
+    expect(prompt).toContain('<sup>🎫 [Backlog Dispatcher](https://run)</sup>');
+    expect(prompt).toContain('<!-- backlog-skip:<number> -->');
+    // The label, not the marker, is the dedup key — the prompt must say so.
+    expect(prompt).toContain(`The \`${LABELS.skipped}\` label`);
+  });
+});
+
+describe('formatStaleComment', () => {
+  const body = formatStaleComment(
+    { number: 501, idleDays: 9.7 },
+    { runUrl: 'https://github.com/o/r/actions/runs/2' }
+  );
+
+  it('states the idle age, promises never to close, and carries a marker', () => {
+    expect(body).toContain('idle for 9 day(s)');
+    expect(body).toMatch(/never closes a pull request/i);
+    expect(body).toContain(buildMarker('stale', 501));
+  });
+});
+
+describe('buildTriagePrompt', () => {
+  const { candidates } = selectCandidates([issue()], { now: NOW });
+  const prompt = buildTriagePrompt(candidates, { repo: 'o/r', budget: 3 });
+
+  it('names the repo, the candidates file, and the budget', () => {
+    expect(prompt).toContain('`o/r`');
+    expect(prompt).toContain('backlog-candidates.json');
+    expect(prompt).toContain('at most **3**');
+  });
+
+  it('carries the whole recovered hard-override catalog', () => {
+    for (const fragment of [
+      'Security / authorization surface',
+      'Upstream/platform bug',
+      'Cross-cutting redesign',
+      'Unconfirmed root cause',
+      'Concurrency / data integrity',
+      'Native work CI cannot verify',
+      'New UX / product surface',
+    ]) {
+      expect(prompt).toContain(fragment);
+    }
+  });
+
+  it('forbids code, PRs, closing, and a second comment', () => {
+    expect(prompt).toMatch(/do NOT read or write code/i);
+    expect(prompt).toMatch(/do NOT\s+open a pull request/i);
+    expect(prompt).toMatch(/never close an issue/i);
+    expect(prompt).toMatch(/Never post a second comment/i);
+  });
+
+  it('renders each candidate with its class, score, and named file', () => {
+    expect(prompt).toContain('### #100 —');
+    expect(prompt).toContain('Class: `debt`');
+    expect(prompt).toContain('session-freezer.ts');
+  });
+
+  it('survives an empty candidate list', () => {
+    expect(buildTriagePrompt([], { repo: 'o/r' })).toContain('_None._');
+  });
+});
+
+describe('buildAuthorPrompt', () => {
+  const prompt = buildAuthorPrompt([{ number: 100, title: 'Paranoia: swallowed errors' }], {
+    repo: 'o/r',
+    budget: 2,
+  });
+
+  it('lists the issues and the branch convention', () => {
+    expect(prompt).toContain('#100 — Paranoia: swallowed errors');
+    expect(prompt).toContain('automation/backlog/issue-<number>');
+    expect(prompt).toContain('stop after\n2 of them');
+  });
+
+  it('requires the Closes line and the label swap', () => {
+    expect(prompt).toContain('Closes #<number>');
+    expect(prompt).toContain(
+      `gh issue edit <number> --remove-label ${LABELS.ready} --add-label ${LABELS.dispatched}`
+    );
+  });
+
+  it('forbids closing anything, merging, and gate-dodging', () => {
+    expect(prompt).toMatch(/Never close an issue or a pull request/i);
+    expect(prompt).toMatch(/never merge/i);
+    expect(prompt).toMatch(/Never lower a coverage floor/i);
+    expect(prompt).toMatch(/lint suppression/i);
+  });
+
+  it('tells it to back out rather than force a PR', () => {
+    expect(prompt).toMatch(/open NO pull\s+request/i);
+    expect(prompt).toContain(`--add-label ${LABELS.skipped}`);
+  });
+
+  it('survives an empty issue list', () => {
+    expect(buildAuthorPrompt([], { repo: 'o/r' })).toContain('_None._');
+  });
+});
+
+describe('buildDigest', () => {
+  const { candidates, rejected, truncated } = selectCandidates(
+    [issue({ number: 1 }), issue({ number: 2, labels: [{ name: 'cosmos-skipped' }] })],
+    { now: NOW }
+  );
+
+  it('reports the funnel, the budget, and the never-close policy', () => {
+    const digest = buildDigest({
+      repo: 'o/r',
+      candidates,
+      rejected,
+      truncated,
+      budget: 5,
+      openDispatcherPrs: 2,
+      stale: [{ number: 9, idleDays: 8.2, headRef: issueBranch(3) }],
+    });
+    expect(digest).toContain('🎫 Backlog Dispatcher');
+    expect(digest).toContain('dispatcher PRs open: **2**/10');
+    expect(digest).toContain('| `already-decided` | 1 |');
+    expect(digest).toContain('#9 idle 8d');
+    expect(digest).toMatch(/never closed/i);
+  });
+
+  it('escapes pipes in titles so the table survives', () => {
+    const digest = buildDigest({ candidates: [{ ...candidates[0], title: 'a | b' }] });
+    expect(digest).toContain('a \\| b');
+  });
+
+  it('marks a dry run and survives empty input', () => {
+    const digest = buildDigest({ dryRun: true });
+    expect(digest).toContain('**DRY RUN**');
+    expect(digest).toContain('_no candidates_');
+    expect(digest).toContain('_None._');
+  });
+});

--- a/packages/dev-tools/backlog-dispatcher/select-backlog-issues.mjs
+++ b/packages/dev-tools/backlog-dispatcher/select-backlog-issues.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+/*
+ * Backlog Dispatcher — selector (I/O).
+ *
+ * Lists the repository's open issues and open pull requests, screens and ranks
+ * them with `lib.mjs` (pure, unit-tested), writes the survivors to
+ * `backlog-candidates.json` for the triage phase to read (mirroring
+ * `rum-error-candidates.json` in rum-error-triage.yml), and emits the triage
+ * prompt plus the dispatch budget to `$GITHUB_OUTPUT`.
+ *
+ * This selector performs NO writes against GitHub: no labels, no comments, no
+ * PRs. Labelling is the triage phase's job; the only deterministic writer in
+ * this package is `sweep-stale-prs.mjs`.
+ *
+ * The repository is read from the environment, never hardcoded, so this package
+ * can be promoted to a reusable `ai-ecoverse/.github` workflow unchanged.
+ *
+ * Env:
+ *   REPO               owner/repo (falls back to GITHUB_REPOSITORY)   (required)
+ *   GH_TOKEN           token for the GitHub REST reads                (required unless FIXTURE)
+ *   ISSUE_NUMBER       consider ONLY this issue (workflow_dispatch). Waives the
+ *                      settling-age wait and nothing else.
+ *   DRY_RUN            "true" → report only; still performs no write anyway
+ *   MAX_DISPATCHES     optional lower override of CONFIG.MAX_DISPATCHES_PER_RUN
+ *   SKIP_PR_CHECK      "1" → do not read open PRs (skips the in-flight/budget reads)
+ *   BACKLOG_FIXTURE    path to `{ "issues": [...], "prs": [...] }` — runs the
+ *                      whole selector offline against canned API payloads
+ *   OUTPUT_PATH        candidates JSON path (default ./backlog-candidates.json)
+ *
+ * Outputs: `has_candidates`, `candidate_count`, `dispatch_budget`, `prompt`.
+ * Exit codes: 0 on a pick AND on a clean no-op; non-zero only on missing env or
+ * an unexpected GitHub API failure.
+ */
+import { randomUUID } from 'node:crypto';
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  buildDigest,
+  buildTriagePrompt,
+  CONFIG,
+  dispatchBudget,
+  isDispatcherPr,
+  selectCandidates,
+  selectStalePrs,
+} from './lib.mjs';
+
+const SCRIPT = 'backlog-dispatcher';
+const API = 'https://api.github.com';
+const OUTPUT_PATH = process.env.OUTPUT_PATH || 'backlog-candidates.json';
+const DRY_RUN = (process.env.DRY_RUN ?? '').trim() === 'true';
+const SKIP_PR_CHECK = (process.env.SKIP_PR_CHECK ?? '').trim() === '1';
+const FIXTURE = (process.env.BACKLOG_FIXTURE ?? '').trim();
+/** Pages of 100 read per list endpoint. Bounded so a huge backlog cannot make the run long. */
+const MAX_PAGES = 5;
+
+// ── Actions plumbing ─────────────────────────────────────────────────────────
+
+/** Append `key=value` to $GITHUB_OUTPUT, using the heredoc form for multi-line values. */
+function setOutput(key, value) {
+  const file = process.env.GITHUB_OUTPUT;
+  if (!file) return;
+  const text = String(value);
+  if (text.includes('\n')) {
+    const delim = `EOF_${randomUUID().replace(/-/g, '')}`;
+    appendFileSync(file, `${key}<<${delim}\n${text}\n${delim}\n`);
+  } else {
+    appendFileSync(file, `${key}=${text}\n`);
+  }
+}
+
+function appendSummary(markdown) {
+  const file = process.env.GITHUB_STEP_SUMMARY;
+  if (!file) return;
+  appendFileSync(file, `${markdown}\n`);
+}
+
+// ── REST layer (same shape as pr-fix-dispatcher/scan-failing-prs.mjs) ────────
+
+/** Low-level GitHub REST call. Throws a one-line error on an untolerated non-OK response. */
+async function request(method, path, { tolerate = [] } = {}) {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${process.env.GH_TOKEN}`,
+      'user-agent': SCRIPT,
+      'x-github-api-version': '2022-11-28',
+    },
+  });
+  if (!res.ok && !tolerate.includes(res.status)) {
+    const text = await res.text().catch(() => '');
+    // Collapse onto one line: GitHub's error JSON is multi-line and the
+    // top-level handler prints only the first line of the message.
+    throw new Error(
+      `${method} ${path} → ${res.status} ${res.statusText} ${text.replace(/\s+/g, ' ').trim().slice(0, 200)}`
+    );
+  }
+  return res;
+}
+
+/**
+ * Read returning parsed JSON, or `null`. An empty body also yields `null`:
+ * `res.json()` throws "Unexpected end of JSON input" on one, and GitHub
+ * legitimately answers some calls with no body at all.
+ */
+async function ghGet(path, opts = {}) {
+  const res = await request('GET', path, opts);
+  if (!res.ok) return null;
+  const text = await res.text();
+  return text.trim() === '' ? null : JSON.parse(text);
+}
+
+/** GET every page of a list endpoint (per_page=100), stopping at MAX_PAGES. */
+async function ghGetAll(path) {
+  const joiner = path.includes('?') ? '&' : '?';
+  const all = [];
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const batch = await ghGet(`${path}${joiner}per_page=100&page=${page}`);
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    all.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return all;
+}
+
+// ── Sources ──────────────────────────────────────────────────────────────────
+
+/** `{ issues, prs }` from a fixture file — the fully offline path. */
+function readFixture(path) {
+  const parsed = JSON.parse(readFileSync(path, 'utf8'));
+  return { issues: parsed.issues ?? [], prs: parsed.prs ?? [] };
+}
+
+/**
+ * Open issues to consider. `GET /issues` also returns pull requests; the lib
+ * screens those out by their `pull_request` field rather than trusting a query
+ * parameter GitHub does not offer.
+ */
+async function readIssues(repo, single) {
+  if (single) {
+    const issue = await ghGet(`/repos/${repo}/issues/${single}`);
+    return issue ? [issue] : [];
+  }
+  return ghGetAll(`/repos/${repo}/issues?state=open&sort=created&direction=desc`);
+}
+
+async function readOpenPrs(repo) {
+  if (SKIP_PR_CHECK) {
+    console.log(`${SCRIPT}: SKIP_PR_CHECK=1 — not reading open PRs; in-flight dedup is disabled`);
+    return [];
+  }
+  return ghGetAll(`/repos/${repo}/pulls?state=open&sort=updated&direction=desc`);
+}
+
+// ── Reporting ────────────────────────────────────────────────────────────────
+
+function reportCandidates(selection) {
+  console.log(`${SCRIPT}: ${selection.candidates.length} candidate issue(s) after screening`);
+  for (const c of selection.candidates.slice(0, 10)) {
+    const smells = c.smells.length ? ` [smells: ${c.smells.join(', ')}]` : '';
+    console.log(`  - #${c.number} (${c.class}, score ${c.score}) ${c.title}${smells}`);
+  }
+  if (selection.truncated > 0) {
+    console.log(
+      `  … ${selection.truncated} more over the cap of ${CONFIG.MAX_CANDIDATES_PER_SOURCE}`
+    );
+  }
+}
+
+/** The candidate payload phase 1 reads. Bodies are kept — Claude needs the brief. */
+function writeCandidatesFile(candidates) {
+  writeFileSync(OUTPUT_PATH, `${JSON.stringify(candidates, null, 2)}\n`);
+  console.log(`${SCRIPT}: wrote ${candidates.length} candidate(s) to ${OUTPUT_PATH}`);
+}
+
+function resolveRepo() {
+  const repo = (process.env.REPO || process.env.GITHUB_REPOSITORY || '').trim();
+  if (repo || FIXTURE) return repo;
+  console.error(`${SCRIPT}: REPO (or GITHUB_REPOSITORY) is required, e.g. owner/repo`);
+  return null;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function loadSources(repo, single) {
+  if (FIXTURE) {
+    console.log(`${SCRIPT}: BACKLOG_FIXTURE=${FIXTURE} — offline run, no GitHub API calls`);
+    return readFixture(FIXTURE);
+  }
+  const [issues, prs] = await Promise.all([readIssues(repo, single), readOpenPrs(repo)]);
+  return { issues, prs };
+}
+
+async function main() {
+  const repo = resolveRepo();
+  if (repo === null) return 2;
+  if (!process.env.GH_TOKEN && !FIXTURE) {
+    console.error(
+      `${SCRIPT}: GH_TOKEN is required (or set BACKLOG_FIXTURE=<path> for an offline run)`
+    );
+    return 2;
+  }
+
+  const now = new Date();
+  const single = (process.env.ISSUE_NUMBER ?? '').trim();
+  if (single) console.log(`${SCRIPT}: targeted run for ${repo}#${single} (settling wait waived)`);
+
+  const { issues, prs } = await loadSources(repo, single);
+  const openDispatcherPrs = prs.filter((pr) => isDispatcherPr(pr)).length;
+  const maxPerRun = Number(process.env.MAX_DISPATCHES) || CONFIG.MAX_DISPATCHES_PER_RUN;
+  const budget = dispatchBudget({ openDispatcherPrs, maxPerRun });
+
+  const selection = selectCandidates(issues, {
+    now,
+    openPrs: prs,
+    targeted: Boolean(single),
+  });
+  reportCandidates(selection);
+  writeCandidatesFile(selection.candidates);
+
+  const stale = selectStalePrs(prs, { now });
+  appendSummary(
+    buildDigest({
+      repo,
+      candidates: selection.candidates,
+      rejected: selection.rejected,
+      budget,
+      openDispatcherPrs,
+      stale,
+      truncated: selection.truncated,
+      dryRun: DRY_RUN,
+    })
+  );
+
+  const hasCandidates = selection.candidates.length > 0 && budget > 0;
+  setOutput('has_candidates', hasCandidates ? 'true' : 'false');
+  setOutput('candidate_count', String(selection.candidates.length));
+  setOutput('dispatch_budget', String(budget));
+  setOutput(
+    'prompt',
+    buildTriagePrompt(selection.candidates, {
+      repo,
+      budget,
+      runUrl: process.env.RUN_URL ?? '',
+    })
+  );
+
+  if (budget === 0) {
+    console.log(
+      `${SCRIPT}: no dispatch — ${openDispatcherPrs} dispatcher PR(s) already open (ceiling ${CONFIG.MAX_OPEN_PRS})`
+    );
+  } else if (!hasCandidates) {
+    console.log(`${SCRIPT}: no dispatch — nothing survived screening; an empty tick is a success`);
+  } else {
+    console.log(`${SCRIPT}: budget ${budget} dispatch(es) this tick`);
+  }
+  return 0;
+}
+
+try {
+  process.exit(await main());
+} catch (err) {
+  console.error(
+    `${SCRIPT}: ${err instanceof Error ? (err.message.split('\n')[0] ?? '') : String(err)}`
+  );
+  console.error(
+    `${SCRIPT}: hint — the reads need a GH_TOKEN with issues:read + pull-requests:read; ` +
+      'set BACKLOG_FIXTURE=<path> to exercise the screening logic offline.'
+  );
+  process.exit(1);
+}

--- a/packages/dev-tools/backlog-dispatcher/sweep-stale-prs.mjs
+++ b/packages/dev-tools/backlog-dispatcher/sweep-stale-prs.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/*
+ * Backlog Dispatcher — stale-PR sweep (I/O, deterministic, no Claude).
+ *
+ * Finds this dispatcher's own open pull requests that have been idle for at
+ * least CONFIG.STALE_PR_DAYS, labels each `backlog-stale`, and posts ONE
+ * comment asking a human to pick it up.
+ *
+ * IT NEVER CLOSES A PULL REQUEST. The Cosmos-era original did, which threw away
+ * work whose only sin was waiting for review; the deliberate replacement policy
+ * is "make it visible, let a human decide". It also never pushes, never merges,
+ * never requests reviewers, and never touches a PR's title, body, or base.
+ *
+ * Idempotent: a PR already carrying `backlog-stale` is not selected, so the
+ * comment is posted exactly once however many times the sweep runs.
+ *
+ * Env:
+ *   REPO             owner/repo (falls back to GITHUB_REPOSITORY)   (required)
+ *   GH_TOKEN         token with pull-requests + issues write        (required unless FIXTURE)
+ *   DRY_RUN          "true" → report what it would do, write nothing
+ *   RUN_URL          Actions run URL for the comment attribution
+ *   BACKLOG_FIXTURE  path to `{ "prs": [...] }` — offline rehearsal, forces DRY_RUN
+ */
+import { appendFileSync, readFileSync } from 'node:fs';
+import { CONFIG, formatStaleComment, LABELS, selectStalePrs } from './lib.mjs';
+
+const SCRIPT = 'backlog-stale-sweep';
+const API = 'https://api.github.com';
+const FIXTURE = (process.env.BACKLOG_FIXTURE ?? '').trim();
+// A fixture run has no repository to write to, so it is a rehearsal by
+// construction rather than by the operator remembering DRY_RUN.
+const DRY_RUN = (process.env.DRY_RUN ?? '').trim() === 'true' || FIXTURE !== '';
+const MAX_PAGES = 5;
+
+function appendSummary(markdown) {
+  const file = process.env.GITHUB_STEP_SUMMARY;
+  if (!file) return;
+  appendFileSync(file, `${markdown}\n`);
+}
+
+/** Low-level GitHub REST call. Throws a one-line error on an untolerated non-OK response. */
+async function request(method, path, { body, tolerate = [] } = {}) {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${process.env.GH_TOKEN}`,
+      'user-agent': SCRIPT,
+      'x-github-api-version': '2022-11-28',
+      ...(body ? { 'content-type': 'application/json' } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  if (!res.ok && !tolerate.includes(res.status)) {
+    const text = await res.text().catch(() => '');
+    throw new Error(
+      `${method} ${path} → ${res.status} ${res.statusText} ${text.replace(/\s+/g, ' ').trim().slice(0, 200)}`
+    );
+  }
+  return res;
+}
+
+/** Read returning parsed JSON, or `null` for an empty/tolerated body. */
+async function ghGet(path) {
+  const res = await request('GET', path);
+  const text = await res.text();
+  return text.trim() === '' ? null : JSON.parse(text);
+}
+
+/**
+ * Write that reports only whether GitHub accepted it and never parses a body:
+ * some GitHub write endpoints answer 201 with an empty body, and `res.json()`
+ * would then throw AFTER the write had already landed.
+ */
+async function ghWrite(method, path, opts) {
+  const res = await request(method, path, opts);
+  return res.ok;
+}
+
+async function readOpenPrs(repo) {
+  if (FIXTURE) return JSON.parse(readFileSync(FIXTURE, 'utf8')).prs ?? [];
+  const all = [];
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const batch = await ghGet(
+      `/repos/${repo}/pulls?state=open&per_page=100&page=${page}&sort=updated&direction=asc`
+    );
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    all.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return all;
+}
+
+/** Label + comment one stale PR. Both writes go through the issues endpoints. */
+async function markStale(repo, pr) {
+  if (DRY_RUN) return;
+  await ghWrite('POST', `/repos/${repo}/issues/${pr.number}/labels`, {
+    body: { labels: [LABELS.stale] },
+  });
+  await ghWrite('POST', `/repos/${repo}/issues/${pr.number}/comments`, {
+    body: { body: formatStaleComment(pr, { runUrl: process.env.RUN_URL ?? '' }) },
+  });
+}
+
+function writeSummary(stale) {
+  const rows =
+    stale
+      .map((p) => `| #${p.number} | \`${p.headRef}\` | ${Math.floor(p.idleDays)} |`)
+      .join('\n') || '| — | _none idle_ | |';
+  appendSummary(
+    [
+      `### 🎫 Backlog Dispatcher — stale sweep${DRY_RUN ? ' (dry run)' : ''}`,
+      '',
+      `Threshold: **${CONFIG.STALE_PR_DAYS} day(s)** idle. Labelled \`${LABELS.stale}\` and commented once. **Never closed.**`,
+      '',
+      '| PR | Head branch | Idle days |',
+      '| --- | --- | --- |',
+      rows,
+    ].join('\n')
+  );
+}
+
+async function main() {
+  const repo = (process.env.REPO || process.env.GITHUB_REPOSITORY || '').trim();
+  if (!repo && !FIXTURE) {
+    console.error(`${SCRIPT}: REPO (or GITHUB_REPOSITORY) is required, e.g. owner/repo`);
+    return 2;
+  }
+  if (!process.env.GH_TOKEN && !FIXTURE) {
+    console.error(`${SCRIPT}: GH_TOKEN is required (or set BACKLOG_FIXTURE=<path> to rehearse)`);
+    return 2;
+  }
+
+  const prs = await readOpenPrs(repo);
+  const stale = selectStalePrs(prs, { now: new Date() });
+  console.log(
+    `${SCRIPT}: ${prs.length} open PR(s); ${stale.length} dispatcher-owned PR(s) idle >= ${CONFIG.STALE_PR_DAYS}d`
+  );
+  for (const pr of stale) {
+    console.log(`  - #${pr.number} idle ${pr.idleDays.toFixed(1)}d — ${pr.title}`);
+    await markStale(repo, pr);
+  }
+  writeSummary(stale);
+  if (DRY_RUN) console.log(`${SCRIPT}: DRY RUN — no labels or comments were written`);
+  return 0;
+}
+
+try {
+  process.exit(await main());
+} catch (err) {
+  console.error(
+    `${SCRIPT}: ${err instanceof Error ? (err.message.split('\n')[0] ?? '') : String(err)}`
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
Stacked on top of #2163 (the other four Cosmos experts). **Merge that first** — this branch is based on it, and the docs section this PR extends is created there. GitHub will retarget this PR to `main` automatically once #2163 lands.

## Summary

Migrates the fifth and last Augment Code ("Cosmos") expert, the **Backlog Dispatcher**, onto GitHub Actions + claude-code-action. Daily at 09:35 UTC it screens this repo's open issues, judges which ones a competent engineer could implement today without asking anybody a question, and opens a pull request for a handful of them. A final step notices dispatcher PRs that have gone idle for a week and asks a human to look.

## Why

Cosmos is retired. Four experts moved in #2163; this one was remembered afterwards.

It is not a straight port, because its prompt body was a `kb://expert-templates/prompts/backlog-dispatcher.md` include that did not survive the platform's retirement. What *did* survive is roughly 50 of its own decisions, still recorded on this repository: `cosmos-dispatched` / `cosmos-skipped` labels, plus its verbatim skip comments. The readiness rubric in this PR was reconstructed from that record rather than invented. Its own words, now encoded as the hard-override catalog:

| Issue | Cosmos' skip reason |
| --- | --- |
| #2062 Sudo over tray | "touches the sudo/approval authorization surface, and the ask spans tray and host surfaces rather than one localised change" |
| #2072 iOS transcript jump | "upstream iOS 26 SwiftUI bug (FB20979569) needs on-device experimentation and a design call, not a localised fix" |
| #2043 Atomics/SAB fast path | "large cross-cutting redesign … architectural scope, not a small contained PR" |
| #2034 concurrent VFS reads | "root cause is unconfirmed … the real fix is an FS-layer locking design — needs a human to pick the approach" |
| #2155 | "A PR already exists for this ticket (#2156), so no additional dispatch is needed." |

And the classes it *did* dispatch: an agentic-debt item naming both the sin and its file, a small localised bug with a concrete symptom, a missing shell command with a clear spec, one named flaky test, doc drift naming the stale file, a narrow test addition.

## Approach / Implementation notes

Two phases, copying `rum-error-triage.yml` rather than inventing a shape: a deterministic Node selector screens and ranks, a **triage** Claude run labels the ready ones `backlog-ready` and the rejected ones `backlog-skipped` with one comment saying why, and a second **author** Claude run implements the ready ones and opens the PRs. Splitting the phases means an issue is never labelled ready by a run that then exhausts its turns before a PR exists.

Everything expressible as a rule is a pure, unit-tested function in `packages/dev-tools/backlog-dispatcher/lib.mjs`; only genuine judgement ("is this really contained?") is left to the model. The selector performs no writes.

**Three deliberate departures from the original**, all flagged to the requester before implementation:

- **Scope is this repository only.** The original scanned 21 `ai-ecoverse` repos. `BOT_PAT` is a fine-grained PAT scoped to slicc, and no workflow here touches another repo's API, so a fleet version would mean putting write access to 20 other repos into this repo's secret store where every workflow could reach it. Nothing hardcodes the repo name (it comes from `GITHUB_REPOSITORY`), so promoting this to `ai-ecoverse/.github` later is a packaging change — adding `workflow_call` and a repo input — not a rewrite.
- **The stale sweep never closes a pull request.** The original closed dispatcher PRs after `STALE_PR_DAYS: 7`, discarding work whose only sin was waiting for review. This one labels `backlog-stale` and comments once.
- **Skip decisions are made once.** The original re-posted its skip comment on every tick (#2072 got one on 2026-08-12 and another on 2026-08-17). The label is now the dedup key; removing it is the documented way to re-queue an issue.

**State is GitHub-native** — no state file, state branch, or Actions cache. The labels are both the work queue and the dedup key. The legacy `cosmos-dispatched` / `cosmos-skipped` / `cosmos-dispatch-failed` labels are treated as **equivalent** to the new `backlog-*` ones when screening; without that the first run would re-propose everything Cosmos already refused, starting with the sudo-over-tray issue.

Config carried over from the expert: `MAX_DISPATCHES_PER_RUN: 5`, `MAX_CANDIDATES_PER_SOURCE: 25`, `MAX_OPEN_PRS: 10`, `SETTLING_AGE_HOURS: 1`, `STALE_PR_DAYS: 7`. `LINEAR_TEAM_KEYS` was empty, so there is no Linear support here.

## Cross-cutting impact

- **Floats exercised**: none. This is CI-only — a workflow plus a `packages/dev-tools/` package. No runtime, UI, or shell code changes.
- **Interaction with the PR Fix Dispatcher (#2163)**: branch naming is `automation/backlog/issue-<n>`, which `isAutomationPr()` matches via its `automation/` prefix, so the PR Fix Dispatcher will pick up CI failures on backlog PRs and try to fix them. That coupling is now pinned by a test that imports **both** libs, so renaming the prefix fails a test instead of silently severing it.
- **Permissions**: `issues: write` is present for label creation. `POST /repos/{repo}/labels` is gated on `issues`, not `pull-requests` — the exact P1 bug found on #2163's first review.
- **Token identity**: the author phase runs under `BOT_PAT` so its branch push fires `pull_request` events and the PR gets the full check suite; triage and the selector use the job's `GITHUB_TOKEN`, which is the narrower identity and all they need.
- **Security**: the author phase can write code and push a branch. Its blast radius is one PR per issue against a fresh branch, always reviewable before merge; it never closes, assigns, or edits issue bodies, and the hard-override catalog explicitly routes security and authorization surfaces to a human.
- **Scratch files**: the dispatchers write JSON hand-offs to the repo root and the author phases run `git`, so `.gitignore` now covers them. This also closes the same pre-existing gap for `rum-fix-ready-issues.json`.

## Test plan

- [x] `npx prettier --write <changed-files>` — via the pre-commit hook; `npm run verify` passes `prettier`
- [x] `npm run verify` — **all 7 checks pass** (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod)
- [x] `node node_modules/vitest/vitest.mjs run --project dev-tools` — **924 passing, 41 files** (850 baseline + 74 new, nothing regressed; the suite grew to 76 after two tests added during review of the worker's output)
- [x] **New behavior is covered by unit tests** — 76 in `packages/dev-tools/backlog-dispatcher/lib.test.mjs`: every screening rule and reason code, the settling-age boundary, legacy-label equivalence, linked-PR detection, ranking and caps, `dispatchBudget` boundaries (exactly 10 open PRs → 0 dispatches), stale selection and its idempotency, branch-naming ↔ `isAutomationPr` agreement, and prompt contents
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — `OK (23 changed file(s), 0 still on any debt list)`
- [x] `npm run lint:docs` — no dead references; all `CLAUDE.md` sizes ok
- [x] Workflow YAML parses (`yaml.safe_load`): 11 steps, permissions `contents`/`id-token`/`issues`/`pull-requests`
- [x] **Offline end-to-end proof of the selector** against a fixture, no network: a `cosmos-skipped` issue was suppressed by the legacy label, a fresh issue was held back by the 1h settling age, and the `debt:paranoia` issue was selected (`class=debt, score=125`). A wider fixture also exercised one issue per reason code (`pr-in-flight` matching `Closes #2155`, `assigned`, `denylisted`, `pull-request`, `too-young`) and the stale sweep, which selected only the idle `automation/backlog/` PR and ignored a `renovate/` one.
- [ ] `npm run typecheck` / `npm run test` / `npm run build` — **N/A**: no TypeScript, no runtime code, and no bundled asset changes. The `dev-tools` vitest project above is the suite that covers `.mjs` tooling.
- [ ] Manual smoke — **N/A locally**; the two Claude phases need Bedrock credentials and the GitHub API. See "Risk & rollback" for the intended first-contact sequence.
- [ ] UI change — N/A

**Pre-existing failures**: none observed; the `dev-tools` project is fully green.

## Documentation

- [x] Relevant `CLAUDE.md` — `packages/dev-tools/CLAUDE.md` gains the new package in the grouped scheduled-workflows bullet. An equivalent number of characters that were duplicated verbatim in `docs/dev-tools-details.md` were trimmed to keep the file under the compactor's own 10,000-char policy (now 9,880).
- [x] `docs/` — `docs/dev-tools-details.md`: table row, the recovered-rubric subsection, the label work queue, the never-close policy, the slicc-only scope with promotion intent, and the `gh workflow run` line.
- [x] `packages/dev-tools/backlog-dispatcher/README.md` — the rubric and its provenance, the state model and label table including legacy equivalence, the env-var table, and how to re-queue a skipped issue.

## Risk & rollback

- **Blast radius**: CI only. Nothing ships to users; no float, no data migration, no persisted state. A regression shows up as an unwanted pull request or an unwanted label, both trivially reversible.
- **Kill switches**: delete or disable the workflow; or `dry_run: true`, which runs the selector and stops before any label, comment, Claude run, or PR. `max_dispatches` lowers the budget for one run, and `MAX_OPEN_PRS: 10` is standing backpressure — at ten open dispatcher PRs it dispatches nothing.
- **Rollback**: revert the three commits. The only durable side effects are labels and comments on issues, which a human can remove; no branch protection, secret, or repo setting changes.
- **What CI cannot catch, and the intended first-contact sequence**: the REST paths, `gh label create` under the real token, and both Claude phases' behaviour against these prompts are unverifiable locally. Suggested order once merged — `dry_run=true` to confirm the selector, auth, and model vars resolve against the real API; then `-f issue=<n>` on a single well-understood issue (an agentic-debt item with a named file is the best first target) to watch one triage-and-author cycle end to end; then let the cron take over. Reviewers should sanity-check the hard-override catalog in `lib.mjs` against their own judgement, since it was reconstructed rather than handed over — that is the single highest-value thing to review here.

## Checklist

- [x] Commits are focused and package-local where possible (feature / `.gitignore` / docs)
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff — secrets are referenced as `${{ secrets.* }}` only
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs — none; new labels and their meanings are documented
- [x] If this changes a contract used by other floats — N/A; the only cross-component contract is the branch prefix shared with the PR Fix Dispatcher, asserted by a test
