### PR TITLE
refactor: pay down boy-scout debt in packages/cloud-core/src/errors.ts

### DIFF
--- a/.github/workflows/backlog-dispatcher.yml
+++ b/.github/workflows/backlog-dispatcher.yml
@@ -15,8 +15,12 @@ name: Backlog Dispatcher
 #      rejected ones `backlog-skipped` (with ONE comment saying why). It writes
 #      no code and opens no PR.
 #   2. AUTHOR — a second claude-code-action run takes the open `backlog-ready`
-#      issues, implements the minimal change, opens the PR with `Closes #<n>`,
-#      and swaps the label to `backlog-dispatched`.
+#      issues, implements the minimal change, pushes one branch per issue, and
+#      writes each PR's title + body to `$RUNNER_TEMP/backlog-pr-<n>.{title,md}`.
+#      It opens no PR and touches no `backlog-dispatched` label.
+#   2b. a deterministic shell step opens ONE PR per pushed branch with BOT_PAT,
+#      labels it, and swaps the issue's `backlog-ready` label for
+#      `backlog-dispatched` (see that step's note on why Claude cannot do it).
 #   3. a deterministic stale sweep (sweep-stale-prs.mjs) labels + comments once
 #      on dispatcher-owned PRs idle for a week. It NEVER closes a PR.
 #
@@ -61,11 +65,16 @@ name: Backlog Dispatcher
 #                             bearer token) for claude-code-action, shared with
 #                             boy-scout-debt-dispatcher.yml / rum-error-triage.yml.
 #   BOT_PAT                   Fine-grained PAT scoped to this repo (contents +
-#                             issues + pull-requests write). The branch is pushed
-#                             and the PR opened with BOT_PAT — NOT GITHUB_TOKEN —
-#                             because GitHub's anti-recursion guard suppresses
-#                             workflow runs for GITHUB_TOKEN-authored pushes, and
-#                             these PRs MUST get the full check suite.
+#                             pull-requests write; NO issues). The branches are
+#                             pushed and the PRs opened with BOT_PAT — NOT
+#                             GITHUB_TOKEN — because GitHub's anti-recursion
+#                             guard suppresses workflow runs for
+#                             GITHUB_TOKEN-authored pushes and queues the checks
+#                             of a GITHUB_TOKEN-authored PR as
+#                             `action_required`, while these PRs MUST get the
+#                             full check suite unattended. Every label and issue
+#                             edit is an Issues API write BOT_PAT cannot make, so
+#                             those calls use GITHUB_TOKEN.
 # Optional repo variables: BACKLOG_BEDROCK_MODEL / RUM_BEDROCK_MODEL,
 # RUM_AWS_REGION.
 #
@@ -234,16 +243,23 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Author the PRs for backlog-ready issues
+      - name: Author the branches for backlog-ready issues
         if: steps.ready.outputs.has_ready == 'true' && github.event.inputs.dry_run != 'true'
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         env:
           # Same Bedrock auth as phase 1 (see the notes on that step).
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           AWS_REGION: ${{ vars.RUM_AWS_REGION || 'us-east-1' }}
-          # BOT_PAT (not github.token) so the opened PR gets the full check
-          # suite — see the header note on the anti-recursion guard.
-          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          # Claude's Bash `gh` always ends up with the action's own
+          # `github_token:` input, NOT whatever GH_TOKEN is set here — the action
+          # overrides it. That is why the PRs are opened by the step below
+          # instead; this phase's own `gh` work (the skip-path label swaps) needs
+          # only the job's GITHUB_TOKEN, and branch pushes use the BOT_PAT
+          # credential persisted by actions/checkout.
+          GH_TOKEN: ${{ github.token }}
+          # One body + title file per issue; the step below opens the PRs from
+          # them. Passed as env so the brief and that step cannot drift apart.
+          PR_BODY_FILE_TEMPLATE: ${{ runner.temp }}/backlog-pr-<issue-number>.md
         with:
           use_bedrock: 'true'
           # Job permissions above scope this token; Claude's own `gh`/`git` work
@@ -256,6 +272,105 @@ jobs:
             --allowedTools "Read,Grep,Glob,Edit,Write,Bash(git:*),Bash(gh pr:*),Bash(gh issue:*),Bash(npm:*),Bash(npx:*),Bash(node:*)"
             --max-turns 200
           prompt: ${{ steps.ready.outputs.prompt }}
+
+      # PR creation is deliberately NOT Claude's job. claude-code-action forces
+      # its Bash `gh` onto the action's `github_token:` (GITHUB_TOKEN here), so a
+      # PR Claude opens is authored by `github-actions[bot]` — and GitHub then
+      # queues EVERY workflow run for that PR as `action_required`, awaiting a
+      # human click, so the PR lands with zero checks (observed on #2168/#2169).
+      # Opening them here with BOT_PAT is the shape coverage-ratchet.yml uses.
+      #
+      # One PR per pushed branch, so the loop is over the same backlog-ready list
+      # the author phase was given: an issue Claude left alone (or backed out of)
+      # simply has no branch, which is a clean no-op — it keeps `backlog-ready`
+      # and comes back next run.
+      - name: Open the PRs for the authored branches
+        id: prs
+        if: success() && steps.ready.outputs.has_ready == 'true' && github.event.inputs.dry_run != 'true'
+        env:
+          # BOT_PAT: contents + pull-requests write, no issues — enough to create
+          # the PRs, NOT to label them or the issues (both are Issues API writes,
+          # hence the separate GITHUB_TOKEN step below).
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          REPO: ${{ github.repository }}
+          # Must match `$RUNNER_TEMP/backlog-pr-<number>.md` in the author brief.
+          TEMP_DIR: ${{ runner.temp }}
+          OPENED_FILE: ${{ runner.temp }}/backlog-opened-prs.txt
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main
+          : > "$OPENED_FILE"
+          for n in $(jq -r '.[].number' backlog-ready-issues.json); do
+            branch="automation/backlog/issue-$n"
+            body="$TEMP_DIR/backlog-pr-$n.md"
+            # Explicit refspec: the checkout's fetch config is not guaranteed to
+            # map an arbitrary new branch into refs/remotes/origin/.
+            git fetch --quiet origin "+refs/heads/$branch:refs/remotes/origin/$branch" || true
+            if ! git rev-parse --quiet --verify "refs/remotes/origin/$branch" >/dev/null; then
+              echo "#$n: no branch pushed — nothing to open."
+              continue
+            fi
+            if [ "$(git rev-list --count "origin/main..refs/remotes/origin/$branch")" -eq 0 ]; then
+              echo "#$n: $branch has no commits ahead of origin/main — nothing to open."
+              continue
+            fi
+            url=$(gh pr list --repo "$REPO" --base main --head "$branch" --state open --json url --jq '.[0].url // ""')
+            if [ -n "$url" ]; then
+              # An earlier run already opened it; fall through so its labels are
+              # still reconciled.
+              echo "#$n: a PR for $branch is already open: $url"
+            elif [ ! -s "$body" ]; then
+              echo "::warning::#$n: $branch was pushed but no PR body exists at $body — leaving the branch for a human."
+              continue
+            else
+              title=""
+              if [ -s "$TEMP_DIR/backlog-pr-$n.title" ]; then
+                title=$(head -n 1 "$TEMP_DIR/backlog-pr-$n.title")
+              fi
+              # Fall back to the commit subject, which the brief also requires to
+              # be a conventional-commit line, rather than losing the PR.
+              if [ -z "$title" ]; then
+                title=$(git log -1 --format=%s "refs/remotes/origin/$branch")
+              fi
+              url=$(gh pr create \
+                --repo "$REPO" \
+                --base main \
+                --head "$branch" \
+                --title "$title" \
+                --body-file "$body")
+              echo "#$n: opened $url"
+            fi
+            printf '%s %s\n' "$n" "$url" >> "$OPENED_FILE"
+            echo "🎫 #$n → $url" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+      # Separate step, separate token: labelling a PR and editing an issue's
+      # labels are Issues API writes, which BOT_PAT (contents + pull-requests
+      # only) cannot do — `gh pr create --label` under BOT_PAT would 403 and lose
+      # the PR. The `backlog-dispatched` label on the PR is how the PR Fix
+      # Dispatcher and the stale sweep recognise it as ours, and the swap on the
+      # issue is what takes it out of the author phase's queue — done here, after
+      # the PR provably exists, rather than trusted to the model.
+      - name: Label the PRs and swap the issue labels
+        if: success() && steps.ready.outputs.has_ready == 'true' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          OPENED_FILE: ${{ runner.temp }}/backlog-opened-prs.txt
+        run: |
+          set -euo pipefail
+          [ -s "$OPENED_FILE" ] || { echo "No PRs were opened — nothing to label."; exit 0; }
+          # Non-fatal on purpose: the PRs already exist, and failing here would
+          # make the "author phase did not finish" reporter below lie about them.
+          # An unswapped label is self-healing — the next run finds the open PR
+          # and reconciles it.
+          while read -r n url; do
+            [ -n "${url:-}" ] || continue
+            gh pr edit "$url" --repo "$REPO" --add-label backlog-dispatched ||
+              echo "::warning::could not label $url"
+            gh issue edit "$n" --repo "$REPO" --remove-label backlog-ready --add-label backlog-dispatched ||
+              echo "::warning::could not swap the labels on #$n"
+          done < "$OPENED_FILE"
 
       # An author phase that died owes every issue it was holding one label swap
       # so the next tick (and any human reading the issue) can see it. Issues

--- a/.github/workflows/boy-scout-debt-dispatcher.yml
+++ b/.github/workflows/boy-scout-debt-dispatcher.yml
@@ -4,7 +4,8 @@ name: Boy Scout Debt Dispatcher
 # codebase debt, this workflow PAYS DOWN one item of the repo's mechanically
 # tracked debt: it selects exactly one tractable file currently on a debt list
 # and hands a focused refactor brief to claude-code-action, which cleans the
-# file and opens the pull request itself.
+# file and pushes a branch. A deterministic shell step then opens the pull
+# request — Claude never runs `gh pr create` (see that step's note).
 #
 # The six debt lists (authoritative procedure:
 # .agents/skills/verifying-before-push/SKILL.md; gate:
@@ -38,14 +39,20 @@ name: Boy Scout Debt Dispatcher
 #                             BOY_SCOUT_BEDROCK_MODEL / RUM_BEDROCK_MODEL tune
 #                             region + inference profile.
 #   BOT_PAT                   Fine-grained PAT scoped to this repo (contents +
-#                             pull-requests write). The cleanup branch is pushed
-#                             and the PR opened with BOT_PAT — NOT GITHUB_TOKEN
-#                             — because GitHub's anti-recursion guard suppresses
-#                             workflow runs for GITHUB_TOKEN-authored pushes, and
-#                             this PR MUST get the full check suite (the
+#                             pull-requests write; NO issues). The cleanup branch
+#                             is pushed and the PR opened with BOT_PAT — NOT
+#                             GITHUB_TOKEN — because GitHub's anti-recursion
+#                             guard suppresses workflow runs for
+#                             GITHUB_TOKEN-authored pushes and queues the checks
+#                             of a GITHUB_TOKEN-authored PR as
+#                             `action_required`, while this PR MUST get the full
+#                             check suite unattended (the
 #                             check-touched-exemptions gate is the whole point).
 #                             Same identity requirement documented in
 #                             coverage-ratchet.yml / renovate-patch-reconcile.yml.
+#                             Labelling the PR needs the Issues API, which
+#                             BOT_PAT cannot reach — that one call uses
+#                             GITHUB_TOKEN.
 #
 # Third-party actions are pinned to immutable commit SHAs (identical to
 # .github/workflows/agentic-debt-triage.yml) — this job can push branches.
@@ -113,10 +120,10 @@ jobs:
           FILE_OVERRIDE: ${{ github.event.inputs.file }}
         run: node packages/dev-tools/boy-scout-debt/select-debt-file.mjs
 
-      # Created here, with GITHUB_TOKEN, because Claude's `gh` runs under BOT_PAT
-      # (contents + pull-requests only) and label creation needs Issues write —
-      # see the note on `permissions:` above. The brief tells Claude the label
-      # already exists and not to try creating it.
+      # Created here, with GITHUB_TOKEN, because label creation needs Issues
+      # write — see the note on `permissions:` above. The label is applied to the
+      # PR by the last step in this job; the brief tells Claude to touch no
+      # labels at all.
       - name: Ensure the boy-scout label exists
         if: steps.select.outputs.has_candidate == 'true' && github.event.inputs.dry_run != 'true'
         env:
@@ -131,7 +138,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Pay down the debt and open the PR
+      - name: Pay down the debt and push the cleanup branch
         if: steps.select.outputs.has_candidate == 'true' && github.event.inputs.dry_run != 'true'
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         env:
@@ -143,11 +150,17 @@ jobs:
           # run fails on auth, fall back to `anthropic_api_key`.)
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           AWS_REGION: ${{ vars.RUM_AWS_REGION || 'us-east-1' }}
-          # claude-code-action does NOT expose a token to the Bash tool's `gh`,
-          # so set it explicitly or `gh pr create` / `gh label create` fail.
-          # BOT_PAT (not github.token) so the opened PR gets the full check
-          # suite — see the header note.
-          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          # Claude's Bash `gh` always ends up with the action's own
+          # `github_token:` input, NOT whatever GH_TOKEN is set here — the action
+          # overrides it. That is precisely why Claude no longer opens the PR:
+          # a GITHUB_TOKEN-authored PR gets its checks queued as
+          # `action_required`. Read-only `gh` use by Claude is fine on this
+          # token; branch pushes use the BOT_PAT credential persisted by
+          # actions/checkout.
+          GH_TOKEN: ${{ github.token }}
+          # The brief writes the PR body here; the step below opens the PR from
+          # it. Passed as env so the prompt and that step cannot drift apart.
+          PR_BODY_FILE: ${{ runner.temp }}/boy-scout-pr-body.md
         with:
           use_bedrock: 'true'
           # Pass the workflow's GITHUB_TOKEN explicitly so the action uses it
@@ -172,3 +185,69 @@ jobs:
             --allowedTools "Bash,Read,Edit,Write,Grep,Glob"
             --max-turns 200
           prompt: ${{ steps.select.outputs.prompt }}
+
+      # PR creation is deliberately NOT Claude's job. claude-code-action forces
+      # its Bash `gh` onto the action's `github_token:` (GITHUB_TOKEN here), so a
+      # PR Claude opens is authored by `github-actions[bot]` — and GitHub then
+      # queues EVERY workflow run for that PR as `action_required`, awaiting a
+      # human click, so the PR lands with zero checks. Observed twice, on #2168
+      # and #2169. Opening it here with BOT_PAT is the same shape
+      # coverage-ratchet.yml uses, and its PRs pick up the whole suite unattended.
+      #
+      # A run where Claude pushed nothing (the "prohibited fix" escape hatch) is
+      # a clean no-op, not a failure.
+      - name: Open the cleanup PR
+        id: pr
+        if: success() && steps.select.outputs.has_candidate == 'true' && github.event.inputs.dry_run != 'true'
+        env:
+          # BOT_PAT: contents + pull-requests write, no issues — enough to create
+          # the PR, NOT to label it (labels go through the Issues API, hence the
+          # separate GITHUB_TOKEN step below).
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          REPO: ${{ github.repository }}
+          BRANCH: automation/boy-scout/${{ steps.select.outputs.slug }}
+          DEBT_FILE: ${{ steps.select.outputs.file }}
+          PR_BODY_FILE: ${{ runner.temp }}/boy-scout-pr-body.md
+        run: |
+          set -euo pipefail
+          # Explicit refspec: the checkout's fetch config is not guaranteed to map
+          # an arbitrary new branch into refs/remotes/origin/.
+          git fetch --quiet origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" || true
+          git fetch --quiet origin main
+          if ! git rev-parse --quiet --verify "refs/remotes/origin/$BRANCH" >/dev/null; then
+            echo "Claude pushed nothing — nothing to open."
+            exit 0
+          fi
+          if [ "$(git rev-list --count "origin/main..refs/remotes/origin/$BRANCH")" -eq 0 ]; then
+            echo "$BRANCH has no commits ahead of origin/main — nothing to open."
+            exit 0
+          fi
+          PR_URL=$(gh pr list --repo "$REPO" --base main --head "$BRANCH" --state open --json url --jq '.[0].url // ""')
+          if [ -n "$PR_URL" ]; then
+            echo "A PR for $BRANCH is already open: $PR_URL"
+          elif [ ! -s "$PR_BODY_FILE" ]; then
+            echo "::warning::$BRANCH was pushed but no PR body exists at $PR_BODY_FILE — leaving the branch for a human."
+            exit 0
+          else
+            PR_URL=$(gh pr create \
+              --repo "$REPO" \
+              --base main \
+              --head "$BRANCH" \
+              --title "refactor: pay down boy-scout debt in $DEBT_FILE" \
+              --body-file "$PR_BODY_FILE")
+            echo "Opened $PR_URL"
+          fi
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "🧹 Boy-scout cleanup PR: $PR_URL" >> "$GITHUB_STEP_SUMMARY"
+
+      # Separate step, separate token: applying a label is an Issues API write,
+      # which BOT_PAT (contents + pull-requests only) cannot do — `gh pr create
+      # --label` under BOT_PAT would 403 and lose the PR.
+      - name: Label the cleanup PR
+        if: success() && steps.pr.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+        run: |
+          set -euo pipefail
+          gh pr edit "$PR_URL" --add-label boy-scout-debt

--- a/.github/workflows/claude-md-compactor.yml
+++ b/.github/workflows/claude-md-compactor.yml
@@ -2,9 +2,10 @@ name: Weekend CLAUDE.md Compactor
 
 # Weekly instruction-file compaction. Saturday night a deterministic Node step
 # measures every TRACKED file named CLAUDE.md (root, docs/, every package) and
-# hands the oversized ones to claude-code-action, which rewrites them and opens
-# exactly ONE pull request. Silence is a valid outcome: nothing oversized → no
-# branch, no PR.
+# hands the oversized ones to claude-code-action, which rewrites them and pushes
+# ONE branch; a deterministic step then opens exactly ONE pull request from it
+# (Claude never runs `gh pr create` — see that step's note). Silence is a valid
+# outcome: nothing oversized → no branch, no PR.
 #
 # TWO BUDGETS, do not confuse them:
 #   * The repo's committed GATE is 20,000 chars for packages/*/CLAUDE.md
@@ -23,10 +24,12 @@ name: Weekend CLAUDE.md Compactor
 # Required repository secrets:
 #   AWS_BEARER_TOKEN_BEDROCK  Amazon Bedrock API key for claude-code-action
 #                             (same secret as agentic-debt-triage.yml).
-#   BOT_PAT                   Used for checkout so the branch push and the PR
-#                             trigger CI — a PR pushed with GITHUB_TOKEN does
-#                             not (GitHub's anti-recursion guard), same
-#                             constraint as coverage-ratchet.yml.
+#   BOT_PAT                   Used for checkout, and for `gh pr create`, so the
+#                             branch push and the PR trigger CI — a PR pushed or
+#                             opened with GITHUB_TOKEN does not (GitHub's
+#                             anti-recursion guard; its checks sit at
+#                             `action_required`), same constraint as
+#                             coverage-ratchet.yml.
 #
 # Third-party actions are pinned to immutable commit SHAs.
 
@@ -53,7 +56,7 @@ concurrency:
 
 permissions:
   contents: write # Claude creates the compaction branch and pushes it
-  pull-requests: write # ... and opens one PR
+  pull-requests: write # ... and a later deterministic step opens one PR from it
   id-token: write # claude-code-action fetches an OIDC token during GitHub token setup
 
 jobs:
@@ -100,7 +103,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Compact the oversized guides and open the PR
+      - name: Compact the oversized guides and push the branch
         id: claude
         if: steps.measure.outputs.has_oversized == 'true' && steps.measure.outputs.existing_pr == '' && github.event.inputs.dry_run != 'true'
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
@@ -109,10 +112,15 @@ jobs:
           # CAMP `ABSK...` bearer token), same as agentic-debt-triage.yml.
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           AWS_REGION: ${{ vars.RUM_AWS_REGION || 'us-east-1' }}
-          # claude-code-action does NOT expose a token to the Bash tool's `gh`,
-          # so set it explicitly or `gh pr create` fails. BOT_PAT (not
-          # GITHUB_TOKEN) so the created PR triggers CI.
-          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          # Claude's Bash `gh` always ends up with the action's own
+          # `github_token:` input, NOT whatever GH_TOKEN is set here — the action
+          # overrides it. That is why Claude no longer opens the PR (see the
+          # step below); read-only `gh` use is fine on this token, and the branch
+          # push uses the BOT_PAT credential persisted by actions/checkout.
+          GH_TOKEN: ${{ github.token }}
+          # The brief writes the PR body here; the step below opens the PR from
+          # it. Passed as env so the prompt and that step cannot drift apart.
+          PR_BODY_FILE: ${{ runner.temp }}/claude-md-compaction-pr-body.md
         with:
           use_bedrock: 'true'
           # Pass the workflow's GITHUB_TOKEN explicitly so the action uses it
@@ -151,3 +159,52 @@ jobs:
           TARGET_CHARS: ${{ github.event.inputs.target_chars }}
           WORKLIST: ${{ steps.measure.outputs.worklist }}
         run: node packages/dev-tools/claude-md-compactor/measure-claude-guides.mjs --check
+
+      # PR creation is deliberately NOT Claude's job. claude-code-action forces
+      # its Bash `gh` onto the action's `github_token:` (GITHUB_TOKEN here), so a
+      # PR Claude opens is authored by `github-actions[bot]` — and GitHub then
+      # queues EVERY workflow run for that PR as `action_required`, awaiting a
+      # human click, so the PR lands with zero checks (observed on #2168/#2169).
+      # Opening it here with BOT_PAT is the shape coverage-ratchet.yml uses.
+      # Ordered after the policy check on purpose: a compaction that failed the
+      # invariant must not become a PR. Claude pushing nothing is a clean no-op.
+      - name: Open the compaction PR
+        if: success() && steps.measure.outputs.has_oversized == 'true' && steps.measure.outputs.existing_pr == '' && github.event.inputs.dry_run != 'true'
+        env:
+          # BOT_PAT (contents + pull-requests write, no issues) — enough to open
+          # the PR; this workflow applies no label, so no second token is needed.
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ steps.measure.outputs.branch }}
+          PR_TITLE: ${{ steps.measure.outputs.pr_title }}
+          PR_BODY_FILE: ${{ runner.temp }}/claude-md-compaction-pr-body.md
+        run: |
+          set -euo pipefail
+          # Explicit refspec: the checkout's fetch config is not guaranteed to map
+          # an arbitrary new branch into refs/remotes/origin/.
+          git fetch --quiet origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" || true
+          git fetch --quiet origin main
+          if ! git rev-parse --quiet --verify "refs/remotes/origin/$BRANCH" >/dev/null; then
+            echo "Claude pushed nothing — nothing to open."
+            exit 0
+          fi
+          if [ "$(git rev-list --count "origin/main..refs/remotes/origin/$BRANCH")" -eq 0 ]; then
+            echo "$BRANCH has no commits ahead of origin/main — nothing to open."
+            exit 0
+          fi
+          PR_URL=$(gh pr list --repo "$REPO" --base main --head "$BRANCH" --state open --json url --jq '.[0].url // ""')
+          if [ -n "$PR_URL" ]; then
+            echo "A PR for $BRANCH is already open: $PR_URL"
+          elif [ ! -s "$PR_BODY_FILE" ]; then
+            echo "::warning::$BRANCH was pushed but no PR body exists at $PR_BODY_FILE — leaving the branch for a human."
+            exit 0
+          else
+            PR_URL=$(gh pr create \
+              --repo "$REPO" \
+              --base main \
+              --head "$BRANCH" \
+              --title "$PR_TITLE" \
+              --body-file "$PR_BODY_FILE")
+            echo "Opened $PR_URL"
+          fi
+          echo "🧹 CLAUDE.md compaction PR: $PR_URL" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/flaky-ci-hunter.yml
+++ b/.github/workflows/flaky-ci-hunter.yml
@@ -14,8 +14,9 @@ name: Flaky CI Hunter
 #      candidate. It lists runs ONE DAY AT A TIME: the runs endpoint returns at
 #      most 1000 items no matter how you page, and this repo produces ~2400 runs
 #      a week, so a window-wide query silently truncates and fakes a quiet week.
-#   2. claude-code-action fixes that one flake on a branded branch and opens ONE
-#      pull request.
+#   2. claude-code-action fixes that one flake on a branded branch and pushes it.
+#   3. a deterministic shell step opens ONE pull request from that branch with
+#      BOT_PAT — Claude never runs `gh pr create` (see that step's note).
 #
 # Cross-run state is GitHub-native — there is no state file, state branch, or
 # Actions cache:
@@ -25,15 +26,19 @@ name: Flaky CI Hunter
 #     artifact. The digest is uploaded on EVERY run (`if: always()`), because the
 #     weeks where nothing is dispatched are exactly when it matters.
 #
-# Checkout uses BOT_PAT, not GITHUB_TOKEN: a PR pushed with GITHUB_TOKEN does
-# not trigger CI (same anti-recursion constraint documented in
-# .github/workflows/coverage-ratchet.yml), and a flaky-test fix that CI never
-# runs is worthless.
+# Checkout and `gh pr create` use BOT_PAT, not GITHUB_TOKEN: a PR pushed or
+# opened with GITHUB_TOKEN does not trigger CI — its checks sit at
+# `action_required` until a human approves them (same anti-recursion constraint
+# documented in .github/workflows/coverage-ratchet.yml) — and a flaky-test fix
+# that CI never runs is worthless.
 #
 # Required repository secrets (already present — same as rum-error-triage.yml):
 #   AWS_BEARER_TOKEN_BEDROCK  Amazon Bedrock API key (Adobe CAMP `ABSK...`
 #                             bearer token) for claude-code-action.
-#   BOT_PAT                   PAT used for checkout/push so the fix PR triggers CI.
+#   BOT_PAT                   PAT used for checkout/push and for `gh pr create`
+#                             so the fix PR triggers CI. Contents +
+#                             pull-requests only: the label is applied with
+#                             GITHUB_TOKEN (Issues API).
 # Optional repo vars: RUM_AWS_REGION, FLAKY_HUNTER_BEDROCK_MODEL,
 # RUM_BEDROCK_MODEL. No new secrets are required.
 #
@@ -64,7 +69,7 @@ concurrency:
 
 permissions:
   contents: write # the fixer pushes its automation/flaky-fix/<slug> branch
-  pull-requests: write # the fixer opens exactly one PR
+  pull-requests: write # a later deterministic step opens exactly one PR from it
   # `gh label create flaky-fix` is POST /repos/{repo}/labels, which is gated on
   # `issues` rather than `pull-requests` (that one covers applying an existing
   # label to a PR). Without this the label step fails before Claude runs. Same
@@ -123,7 +128,7 @@ jobs:
         run: |
           gh label create flaky-fix --color FBCA04 --description "Determinism fix for a proven CI flake" --force
 
-      - name: Fix the flake and open one PR
+      - name: Fix the flake and push the branch
         if: steps.scan.outputs.has_candidate == 'true' && github.event.inputs.dry_run != 'true'
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         env:
@@ -135,11 +140,17 @@ jobs:
           # run fails on auth, fall back to `anthropic_api_key`.)
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           AWS_REGION: ${{ vars.RUM_AWS_REGION || 'us-east-1' }}
-          # claude-code-action does NOT expose a token to the Bash tool's `gh`,
-          # so set it explicitly or `gh pr create` / `git push` fail. BOT_PAT
-          # (not github.token) so the resulting PR triggers CI.
-          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          # Claude's Bash `gh` always ends up with the action's own
+          # `github_token:` input, NOT whatever GH_TOKEN is set here — the action
+          # overrides it. That is why Claude no longer opens the PR (see the step
+          # below); the branch push uses the BOT_PAT credential persisted by
+          # actions/checkout.
+          GH_TOKEN: ${{ github.token }}
           FLAKY_SLUG: ${{ steps.scan.outputs.slug }}
+          # The brief writes the PR title and body here; the step below opens the
+          # PR from them. Passed as env so the prompt and that step cannot drift.
+          PR_TITLE_FILE: ${{ runner.temp }}/flaky-fix-pr-title.txt
+          PR_BODY_FILE: ${{ runner.temp }}/flaky-fix-pr-body.md
         with:
           use_bedrock: 'true'
           # Pass the workflow's GITHUB_TOKEN explicitly so the action uses it
@@ -163,3 +174,78 @@ jobs:
             --allowedTools "Bash,Read,Edit,Write,Grep,Glob"
             --max-turns 200
           prompt: ${{ steps.scan.outputs.prompt }}
+
+      # PR creation is deliberately NOT Claude's job. claude-code-action forces
+      # its Bash `gh` onto the action's `github_token:` (GITHUB_TOKEN here), so a
+      # PR Claude opens is authored by `github-actions[bot]` — and GitHub then
+      # queues EVERY workflow run for that PR as `action_required`, awaiting a
+      # human click, so the PR lands with zero checks (observed on #2168/#2169).
+      # A determinism fix whose CI never runs is exactly the failure mode this
+      # workflow exists to avoid, so the PR is opened here with BOT_PAT, the same
+      # shape coverage-ratchet.yml uses. Claude declining to push (the banned-fix
+      # escape hatch) is a clean no-op.
+      - name: Open the fix PR
+        id: pr
+        if: success() && steps.scan.outputs.has_candidate == 'true' && github.event.inputs.dry_run != 'true'
+        env:
+          # BOT_PAT: contents + pull-requests write, no issues — enough to create
+          # the PR, NOT to label it (labels go through the Issues API, hence the
+          # separate GITHUB_TOKEN step below).
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          REPO: ${{ github.repository }}
+          BRANCH: automation/flaky-fix/${{ steps.scan.outputs.slug }}
+          FLAKY_JOB: ${{ steps.scan.outputs.job }}
+          PR_TITLE_FILE: ${{ runner.temp }}/flaky-fix-pr-title.txt
+          PR_BODY_FILE: ${{ runner.temp }}/flaky-fix-pr-body.md
+        run: |
+          set -euo pipefail
+          # Explicit refspec: the checkout's fetch config is not guaranteed to map
+          # an arbitrary new branch into refs/remotes/origin/.
+          git fetch --quiet origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH" || true
+          git fetch --quiet origin main
+          if ! git rev-parse --quiet --verify "refs/remotes/origin/$BRANCH" >/dev/null; then
+            echo "Claude pushed nothing — nothing to open."
+            exit 0
+          fi
+          if [ "$(git rev-list --count "origin/main..refs/remotes/origin/$BRANCH")" -eq 0 ]; then
+            echo "$BRANCH has no commits ahead of origin/main — nothing to open."
+            exit 0
+          fi
+          PR_URL=$(gh pr list --repo "$REPO" --base main --head "$BRANCH" --state open --json url --jq '.[0].url // ""')
+          if [ -n "$PR_URL" ]; then
+            echo "A PR for $BRANCH is already open: $PR_URL"
+          elif [ ! -s "$PR_BODY_FILE" ]; then
+            echo "::warning::$BRANCH was pushed but no PR body exists at $PR_BODY_FILE — leaving the branch for a human."
+            exit 0
+          else
+            # The title carries Claude's root-cause sentence, so it is read from
+            # the file; the fallback keeps a missing file from losing the PR.
+            PR_TITLE=""
+            if [ -s "$PR_TITLE_FILE" ]; then
+              PR_TITLE=$(head -n 1 "$PR_TITLE_FILE")
+            fi
+            if [ -z "$PR_TITLE" ]; then
+              PR_TITLE="fix(ci): make $FLAKY_JOB deterministic"
+            fi
+            PR_URL=$(gh pr create \
+              --repo "$REPO" \
+              --base main \
+              --head "$BRANCH" \
+              --title "$PR_TITLE" \
+              --body-file "$PR_BODY_FILE")
+            echo "Opened $PR_URL"
+          fi
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "🔧 Flaky-fix PR: $PR_URL" >> "$GITHUB_STEP_SUMMARY"
+
+      # Separate step, separate token: applying a label is an Issues API write,
+      # which BOT_PAT (contents + pull-requests only) cannot do — `gh pr create
+      # --label` under BOT_PAT would 403 and lose the PR.
+      - name: Label the fix PR
+        if: success() && steps.pr.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+        run: |
+          set -euo pipefail
+          gh pr edit "$PR_URL" --add-label flaky-fix

--- a/docs/dev-tools-details.md
+++ b/docs/dev-tools-details.md
@@ -89,6 +89,23 @@ The boy-scout, flake-fix, and backlog PRs are pushed with `BOT_PAT`, not
 `GITHUB_TOKEN`-authored pushes, so CI would never run on them. Same constraint
 as `coverage-ratchet.yml` and `renovate-patch-reconcile.yml`.
 
+**Claude never opens the pull request.** In `boy-scout-debt-dispatcher.yml`,
+`claude-md-compactor.yml`, `flaky-ci-hunter.yml`, and the backlog dispatcher's
+author phase, Claude pushes the branch and writes the PR body (and, for the flake
+hunter and the backlog author, the title) to a file named by a `PR_BODY_FILE` /
+`PR_TITLE_FILE` env var; a deterministic shell step then runs `gh pr create` with
+`GH_TOKEN: secrets.BOT_PAT`, exactly as `coverage-ratchet.yml` does. The reason is
+that `claude-code-action` overrides `GH_TOKEN` for its Bash tool with its own
+`github_token:` input (deliberately `${{ github.token }}` here, because the
+OIDC → GitHub App exchange fails on this repo), so a PR Claude opens is authored by
+`github-actions[bot]` — and GitHub queues every workflow run for such a PR as
+`action_required`, leaving it at **zero checks** until a human clicks "Approve and
+run". `BOT_PAT` carries contents + pull-requests only, so labelling is a separate
+`gh pr edit --add-label` call under `GITHUB_TOKEN` (labels are an Issues API
+write); `gh pr create --label` under `BOT_PAT` would 403. Each of these steps is a
+clean no-op when Claude pushed nothing, which is what the "report instead of
+forcing a fix" escape hatches produce.
+
 ### The backlog dispatcher's recovered rubric
 
 `backlog-dispatcher/` migrates an Augment Code ("Cosmos") expert whose prompt

--- a/packages/cloud-core/src/errors.ts
+++ b/packages/cloud-core/src/errors.ts
@@ -18,11 +18,29 @@ export type CloudErrorCode =
   | 'UPSTREAM_UNAVAILABLE'
   | 'INTERNAL';
 
+/**
+ * Optional machine-readable diagnostics attached to a {@link CloudError}.
+ * Each field is populated only for the codes it makes sense for: `running`/`cap`
+ * and `paused`/`cap` accompany `CAP_EXCEEDED`, and `sandboxId` accompanies
+ * `SANDBOX_NOT_READY`. Consumers read these to surface actionable detail (the
+ * worker forwards them into its HTTP error envelope).
+ */
+export interface CloudErrorDetails {
+  /** Number of running cones at the time a running-cap `CAP_EXCEEDED` was thrown. */
+  running?: number;
+  /** Number of paused cones at the time a paused-cap `CAP_EXCEEDED` was thrown. */
+  paused?: number;
+  /** The cap that was hit, for a `CAP_EXCEEDED` error. */
+  cap?: number;
+  /** The sandbox whose boot failed, for a `SANDBOX_NOT_READY` error. */
+  sandboxId?: string;
+}
+
 export class CloudError extends Error {
   constructor(
     public readonly code: CloudErrorCode,
     message: string,
-    public readonly details?: Record<string, unknown>
+    public readonly details?: CloudErrorDetails
   ) {
     super(message);
     this.name = 'CloudError';

--- a/packages/cloud-core/tests/errors.test.ts
+++ b/packages/cloud-core/tests/errors.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import type { CloudErrorDetails } from '../src/index.js';
+import { CloudError, isCloudError } from '../src/index.js';
+
+describe('CloudError', () => {
+  it('carries the code and message, and names itself', () => {
+    const err = new CloudError('NOT_FOUND', 'cloud session not found: foo');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.message).toBe('cloud session not found: foo');
+    expect(err.name).toBe('CloudError');
+    expect(err.details).toBeUndefined();
+  });
+
+  it('preserves typed cap-exceeded details', () => {
+    const details: CloudErrorDetails = { running: 1, cap: 1 };
+    const err = new CloudError('CAP_EXCEEDED', 'at running cap (1/1)', details);
+    expect(err.details).toEqual({ running: 1, cap: 1 });
+  });
+
+  it('preserves the sandboxId on a boot failure', () => {
+    const err = new CloudError('SANDBOX_NOT_READY', 'boot failed', { sandboxId: 'sbx-1' });
+    expect(err.details?.sandboxId).toBe('sbx-1');
+  });
+
+  it('isCloudError narrows only CloudError instances', () => {
+    expect(isCloudError(new CloudError('INTERNAL', 'boom'))).toBe(true);
+    expect(isCloudError(new Error('plain'))).toBe(false);
+    expect(isCloudError('NOT_FOUND')).toBe(false);
+    expect(isCloudError(null)).toBe(false);
+  });
+});

--- a/packages/dev-tools/backlog-dispatcher/README.md
+++ b/packages/dev-tools/backlog-dispatcher/README.md
@@ -17,8 +17,10 @@ schedule (daily 09:35 UTC)
        ├─ backlog-candidates.json          (phase 1 reads this)
        └─ $GITHUB_OUTPUT: has_candidates, candidate_count, dispatch_budget, prompt
   └─ phase 1 TRIAGE   claude-code-action → labels `backlog-ready` / `backlog-skipped` (+1 comment)
-  └─ phase 2 AUTHOR   claude-code-action → branch, minimal change, PR with `Closes #<n>`,
-                                            label swapped to `backlog-dispatched`
+  └─ phase 2 AUTHOR   claude-code-action → one branch per issue, minimal change,
+                                            $RUNNER_TEMP/backlog-pr-<n>.{title,md}
+  └─ phase 2b OPEN    shell (BOT_PAT)    → ONE PR per pushed branch, `Closes #<n>` in the body,
+                                            then (GITHUB_TOKEN) PR label + issue label swap
   └─ sweep-stale-prs.mjs                  (deterministic; label + one comment, NEVER closes)
 ```
 
@@ -71,7 +73,7 @@ No state file, no state branch, no Actions cache.
 | Label                    | Meaning                                                        | Set by          |
 | ------------------------ | -------------------------------------------------------------- | --------------- |
 | `backlog-ready`          | Triage said yes; phase 2's queue                               | phase 1         |
-| `backlog-dispatched`     | A PR exists (also on the PR itself)                            | phase 2         |
+| `backlog-dispatched`     | A PR exists (also on the PR itself)                            | phase 2b        |
 | `backlog-skipped`        | Decided against, once                                          | phase 1         |
 | `backlog-stale`          | A dispatcher-owned PR has gone idle                            | the stale sweep |
 | `cosmos-dispatch-failed` | The author phase died (legacy name reused — it already exists) | `if: failure()` |
@@ -128,6 +130,43 @@ dispatcher's own `automation/backlog/issue-<n>` branch — the #2155 case).
 close. The Cosmos original **closed** those PRs, which threw away work whose only
 sin was waiting for review; the replacement policy is "make it visible, let a
 human decide". Idempotent via the label, so the comment lands exactly once.
+
+## Why Claude does not open the PRs
+
+Phase 2 is split in two, deliberately: **Claude pushes one branch per issue and
+writes each PR's title and body to `$RUNNER_TEMP/backlog-pr-<n>.title` and
+`$RUNNER_TEMP/backlog-pr-<n>.md`; a deterministic shell step then opens one PR per
+pushed branch.** The author brief forbids `gh pr create` and forbids touching the
+`backlog-dispatched` label.
+
+The reason is token identity. `claude-code-action` overrides `GH_TOKEN` for its
+Bash tool with its own `github_token:` input, which this workflow sets to
+`${{ github.token }}` (an OIDC → GitHub App exchange fails on this repo), so
+Claude's `gh` is always `GITHUB_TOKEN`. A PR created with `GITHUB_TOKEN` is
+authored by `github-actions[bot]`, and GitHub queues every workflow run for such a
+PR as `action_required`: the PR sits at **zero checks** until a human clicks
+"Approve and run". The deterministic step is the same shape
+[`coverage-ratchet.yml`](../../../.github/workflows/coverage-ratchet.yml) uses.
+
+The loop is over the same `backlog-ready-issues.json` the author phase was given,
+and each iteration is a clean no-op (never a failure) when no branch was pushed,
+when the branch is not ahead of `origin/main`, or when no body file was written —
+which is what the brief's "if it turns out not to be ready, open NO pull request"
+path produces. The issue simply keeps `backlog-ready` and comes back next run. An
+already-open PR for the head is not recreated, only relabelled.
+
+Two tokens, because `BOT_PAT` is scoped to **contents + pull-requests only**:
+
+| Call                                                         | Token          | Why                                                        |
+| ------------------------------------------------------------ | -------------- | ---------------------------------------------------------- |
+| `gh pr create`                                               | `BOT_PAT`      | The author's events must trigger CI.                       |
+| `gh label create`, `gh pr edit --add-label`, `gh issue edit` | `GITHUB_TOKEN` | Labels are an Issues API write; `BOT_PAT` has no `issues`. |
+
+Passing `--label` to `gh pr create` under `BOT_PAT` would 403 and lose the PR, so
+the PR label and the issue's `backlog-ready` → `backlog-dispatched` swap are a
+separate `GITHUB_TOKEN` step — which also means the swap happens only after the PR
+provably exists, instead of on the model's word. That step's failures are warnings,
+not job failures: the PRs already exist, and the next run reconciles the labels.
 
 ## Branch naming is load-bearing
 
@@ -200,13 +239,15 @@ deliberately absent — Cosmos's `LINEAR_TEAM_KEYS` was empty.
 
 No new secrets — both are shared with `boy-scout-debt-dispatcher.yml`.
 
-| Name                       | Kind     | Purpose                                                                                                          |
-| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
-| `AWS_BEARER_TOKEN_BEDROCK` | secret   | Amazon Bedrock API key (Adobe CAMP `ABSK...` bearer token) used by `claude-code-action` (`use_bedrock`).         |
-| `BOT_PAT`                  | secret   | Fine-grained PAT (contents + issues + pull-requests write); the branch push must not be `GITHUB_TOKEN`-authored. |
-| `RUM_AWS_REGION`           | variable | Optional. Bedrock region for the CAMP key (default `us-east-1`).                                                 |
-| `BACKLOG_BEDROCK_MODEL`    | variable | Optional. Bedrock model; falls back to `RUM_BEDROCK_MODEL`, then `global.anthropic.claude-sonnet-4-6`.           |
+| Name                       | Kind     | Purpose                                                                                                                                   |
+| -------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `AWS_BEARER_TOKEN_BEDROCK` | secret   | Amazon Bedrock API key (Adobe CAMP `ABSK...` bearer token) used by `claude-code-action` (`use_bedrock`).                                  |
+| `BOT_PAT`                  | secret   | Fine-grained PAT (contents + pull-requests write, **no** issues); the branch push and `gh pr create` must not be `GITHUB_TOKEN`-authored. |
+| `RUM_AWS_REGION`           | variable | Optional. Bedrock region for the CAMP key (default `us-east-1`).                                                                          |
+| `BACKLOG_BEDROCK_MODEL`    | variable | Optional. Bedrock model; falls back to `RUM_BEDROCK_MODEL`, then `global.anthropic.claude-sonnet-4-6`.                                    |
 
 The workflow needs `issues: write` **as well as** `pull-requests: write`:
 repo-level label creation (`gh label create`) goes through
-`POST /repos/{repo}/labels`, which is gated on `issues`.
+`POST /repos/{repo}/labels`, which is gated on `issues` — and so is applying a
+label to a PR, which is why every label call runs under `GITHUB_TOKEN` rather than
+`BOT_PAT`.

--- a/packages/dev-tools/backlog-dispatcher/lib.mjs
+++ b/packages/dev-tools/backlog-dispatcher/lib.mjs
@@ -674,19 +674,31 @@ ${Number(ctx.budget ?? CONFIG.MAX_DISPATCHES_PER_RUN)} of them.
    npx vitest run <the focused test files>
    node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main
    \`\`\`
-5. Push and open the PR:
+5. Push the branch and write the PR body to
+   \`$RUNNER_TEMP/backlog-pr-<number>.md\` (the pattern is also in
+   \`$PR_BODY_FILE_TEMPLATE\`), plus the one-line conventional-commit PR title to
+   \`$RUNNER_TEMP/backlog-pr-<number>.title\`:
    \`\`\`bash
    git push -u origin ${BRANCH_PREFIX}/issue-<number>
-   gh pr create --base main --label ${LABELS.dispatched} \\
-     --title "<conventional-commit title>" \\
-     --body "Closes #<number>
+   printf '%s\\n' "<conventional-commit title>" > "$RUNNER_TEMP/backlog-pr-<number>.title"
+   cat > "$RUNNER_TEMP/backlog-pr-<number>.md" <<'EOF'
+   Closes #<number>
 
-   <what changed, why, how you verified>"
-   gh issue edit <number> --remove-label ${LABELS.ready} --add-label ${LABELS.dispatched}
+   <what changed, why, how you verified>
+   EOF
    \`\`\`
    The \`Closes #<number>\` line is required — it is how merging the PR closes the
-   issue. The \`${LABELS.dispatched}\` label on the PR is how the PR Fix
-   Dispatcher and the stale sweep recognise it as ours.
+   issue.
+6. **Do NOT run \`gh pr create\`, and do not label the issue \`${LABELS.dispatched}\`.**
+   A later, deterministic workflow step opens one PR per pushed branch from those
+   files, applies the \`${LABELS.dispatched}\` label to the PR (that label is how the
+   PR Fix Dispatcher and the stale sweep recognise it as ours), and swaps the
+   issue's \`${LABELS.ready}\` label for \`${LABELS.dispatched}\`. The PR must be
+   authored by a token whose events trigger CI: a PR opened by your \`gh\` is
+   authored by \`github-actions[bot]\`, and GitHub then queues every check on it as
+   \`action_required\` until a human clicks "Approve and run". If you push nothing
+   for an issue, that step is a clean no-op for it and the issue keeps its
+   \`${LABELS.ready}\` label for the next run.
 
 ## If it turns out not to be ready
 

--- a/packages/dev-tools/backlog-dispatcher/lib.mjs
+++ b/packages/dev-tools/backlog-dispatcher/lib.mjs
@@ -92,15 +92,14 @@ export const DECIDED_LABELS = [
  * Labels whose presence says a human has already routed the issue somewhere
  * other than "implement this": a question, a rejected ask, or work explicitly
  * reserved for an outside contributor.
+ *
+ * `skill issue` is deliberately NOT here, however much it sounds like one.
+ * `.github/workflows/issue-skill.yml` applies it to EVERY issue on `opened`, as
+ * a joke — so in this repository it means "an issue exists", not "user error".
+ * Denying it silently disabled this whole dispatcher: 14 of 17 open items
+ * carried it, and every future issue is born with it.
  */
-export const DENYLIST_LABELS = [
-  'question',
-  'wontfix',
-  'invalid',
-  'duplicate',
-  'skill issue',
-  'help wanted',
-];
+export const DENYLIST_LABELS = ['question', 'wontfix', 'invalid', 'duplicate', 'help wanted'];
 
 /** Colour + description used when bootstrapping labels (`gh label create --force`). */
 export const LABEL_META = {

--- a/packages/dev-tools/backlog-dispatcher/lib.test.mjs
+++ b/packages/dev-tools/backlog-dispatcher/lib.test.mjs
@@ -135,6 +135,16 @@ describe('screenIssue', () => {
     }
   });
 
+  it('does NOT deny "skill issue", which this repo applies to every new issue', () => {
+    // `.github/workflows/issue-skill.yml` labels EVERY issue on `opened` as a
+    // joke, so denying it disables the dispatcher outright — 14 of 17 open items
+    // carried it when this was caught on the first live run.
+    expect(DENYLIST_LABELS).not.toContain('skill issue');
+    expect(screenIssue(issue({ labels: [{ name: 'skill issue' }] }), { now: NOW })).toMatchObject({
+      eligible: true,
+    });
+  });
+
   it('rejects an issue this dispatcher already decided', () => {
     for (const label of [LABELS.ready, LABELS.dispatched, LABELS.skipped, LABELS.failed]) {
       expect(screenIssue(issue({ labels: [{ name: label }] }), { now: NOW }).code).toBe(

--- a/packages/dev-tools/backlog-dispatcher/lib.test.mjs
+++ b/packages/dev-tools/backlog-dispatcher/lib.test.mjs
@@ -591,11 +591,27 @@ describe('buildAuthorPrompt', () => {
     expect(prompt).toContain('stop after\n2 of them');
   });
 
-  it('requires the Closes line and the label swap', () => {
+  it('requires the Closes line and leaves the dispatched label swap to the workflow', () => {
     expect(prompt).toContain('Closes #<number>');
-    expect(prompt).toContain(
+    expect(prompt).not.toContain(
       `gh issue edit <number> --remove-label ${LABELS.ready} --add-label ${LABELS.dispatched}`
     );
+    expect(prompt).toMatch(
+      new RegExp(`swaps the\\s+issue's \`${LABELS.ready}\` label for \`${LABELS.dispatched}\``)
+    );
+  });
+
+  it('pushes the branch and leaves PR creation to the deterministic step', () => {
+    // A PR opened by Claude's `gh` is authored by github-actions[bot], and
+    // GitHub queues every check on such a PR as `action_required` until a human
+    // approves it — so the workflow opens one PR per pushed branch with BOT_PAT,
+    // from the per-issue title/body files the brief names here.
+    expect(prompt).toContain('git push -u origin automation/backlog/issue-<number>');
+    expect(prompt).toContain('$RUNNER_TEMP/backlog-pr-<number>.md');
+    expect(prompt).toContain('$PR_BODY_FILE_TEMPLATE');
+    expect(prompt).not.toMatch(/^\s*gh pr create/m);
+    expect(prompt.match(/gh pr create/g)).toHaveLength(1);
+    expect(prompt).toContain('action_required');
   });
 
   it('forbids closing anything, merging, and gate-dodging', () => {

--- a/packages/dev-tools/backlog-dispatcher/select-backlog-issues.mjs
+++ b/packages/dev-tools/backlog-dispatcher/select-backlog-issues.mjs
@@ -164,6 +164,26 @@ function reportCandidates(selection) {
       `  … ${selection.truncated} more over the cap of ${CONFIG.MAX_CANDIDATES_PER_SOURCE}`
     );
   }
+  reportRejections(selection.rejected);
+}
+
+/**
+ * Say why every screened-out issue was screened out. "0 candidates" is this
+ * workflow's most common healthy outcome, so without the reasons a correct
+ * quiet tick and a broken selector look identical in the log — which is exactly
+ * how the `skill issue` denylist entry hid for a whole review cycle. The
+ * siblings (pr-fix-dispatcher, boy-scout-debt) both log per-item verdicts.
+ */
+function reportRejections(rejected = []) {
+  if (rejected.length === 0) return;
+  const byCode = new Map();
+  for (const r of rejected) byCode.set(r.code, [...(byCode.get(r.code) ?? []), r]);
+  console.log(`${SCRIPT}: screened out ${rejected.length} issue(s):`);
+  for (const [code, group] of [...byCode.entries()].sort((a, b) => b[1].length - a[1].length)) {
+    const numbers = group.map((r) => `#${r.number}`).join(' ');
+    console.log(`  - ${code} (${group.length}): ${numbers}`);
+    console.log(`      ${group[0].reason}`);
+  }
 }
 
 /** The candidate payload phase 1 reads. Bodies are kept — Claude needs the brief. */

--- a/packages/dev-tools/boy-scout-debt/README.md
+++ b/packages/dev-tools/boy-scout-debt/README.md
@@ -2,7 +2,9 @@
 
 A daily job that selects **exactly one** tractable file currently on the
 repository's boy-scout debt lists and hands a focused refactor brief to
-claude-code-action, which cleans the file and opens the pull request itself.
+claude-code-action, which cleans the file and pushes a branch — a deterministic
+workflow step then opens the pull request (see
+[Why Claude does not open the PR](#why-claude-does-not-open-the-pr)).
 Where [`codebase-sins/`](../codebase-sins/README.md) _files issues_ about
 qualitative debt, this pays down debt the repo already tracks mechanically.
 
@@ -63,9 +65,41 @@ policy, not boy-scout debt, and is therefore never a candidate.
 
 Driven by
 [`.github/workflows/boy-scout-debt-dispatcher.yml`](../../../.github/workflows/boy-scout-debt-dispatcher.yml)
-(daily at 02:17 UTC). That workflow checks out with `secrets.BOT_PAT` and gives
-Claude `GH_TOKEN: secrets.BOT_PAT`, because GitHub suppresses workflow runs for
-`GITHUB_TOKEN`-authored pushes and the cleanup PR must get the full check suite.
+(daily at 02:17 UTC). That workflow checks out with `secrets.BOT_PAT`, because
+GitHub suppresses workflow runs for `GITHUB_TOKEN`-authored pushes and the
+cleanup PR must get the full check suite.
+
+## Why Claude does not open the PR
+
+Two phases, deliberately: **Claude pushes the branch and writes the PR body to
+`$PR_BODY_FILE`; a deterministic shell step opens the PR.** The brief forbids
+`gh pr create` outright.
+
+The reason is token identity. `claude-code-action` overrides `GH_TOKEN` for its
+Bash tool with its own `github_token:` input, which this workflow deliberately
+sets to `${{ github.token }}` (an OIDC → GitHub App exchange fails on this repo),
+so Claude's `gh` is always `GITHUB_TOKEN`. A PR created with `GITHUB_TOKEN` is
+authored by `github-actions[bot]`, and GitHub queues every workflow run for such
+a PR as `action_required` — the PR sits at **zero checks** until a human clicks
+"Approve and run". For a change whose entire purpose is to satisfy
+`check-touched-exemptions.mjs`, that is worthless. The deterministic step is the
+same shape [`coverage-ratchet.yml`](../../../.github/workflows/coverage-ratchet.yml)
+uses, and those PRs pick up the full suite unattended.
+
+The step is a clean no-op (never a failure) when Claude pushed nothing, when the
+branch is not ahead of `origin/main`, or when no body file was written — which is
+what the brief's "if the honest fix is prohibited, report instead" escape hatch
+produces. It also skips creation when an open PR for the head already exists.
+
+Two tokens, because `BOT_PAT` is scoped to **contents + pull-requests only**:
+
+| Call                                         | Token          | Why                                                        |
+| -------------------------------------------- | -------------- | ---------------------------------------------------------- |
+| `gh pr create`                               | `BOT_PAT`      | The author's events must trigger CI.                       |
+| `gh label create` / `gh pr edit --add-label` | `GITHUB_TOKEN` | Labels are an Issues API write; `BOT_PAT` has no `issues`. |
+
+Passing `--label` to `gh pr create` under `BOT_PAT` would 403 and lose the PR, so
+the label is always a separate `gh pr edit` call.
 
 ## Run it locally
 

--- a/packages/dev-tools/boy-scout-debt/lib.mjs
+++ b/packages/dev-tools/boy-scout-debt/lib.mjs
@@ -430,27 +430,35 @@ node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main
 \`check-touched-exemptions.mjs origin/main\` is the decisive gate: it must report
 OK with \`${file}\` in the diff. If time allows, also run \`npm run verify\`.
 
-## Open the PR
+## Push the branch and hand off the PR
 
 1. \`git switch -c ${branch}\`
 2. Commit with a focused conventional-commit message, e.g.
    \`refactor(<scope>): pay down boy-scout debt in ${file}\`
-3. Push and create the PR. The \`${PR_LABEL}\` label already exists — an earlier
-   workflow step created it with a token that carries Issues write, which your
-   \`GH_TOKEN\` does not. Do NOT run \`gh label create\`; it would fail:
+3. Push the branch, then write the pull-request body to the file named by the
+   \`PR_BODY_FILE\` environment variable:
    \`\`\`bash
    git push -u origin ${branch}
-   gh pr create --base main --label ${PR_LABEL} \\
-     --title "refactor: pay down boy-scout debt in ${file}" \\
-     --body "<what changed, which debt lists were cleared, how you verified>"
+   cat > "$PR_BODY_FILE" <<'EOF'
+   <what changed, which debt lists were cleared, how you verified>
+   EOF
    \`\`\`
-4. The PR body must state, per debt list, what was fixed and which entry was
+4. **Do NOT run \`gh pr create\`, \`gh pr edit\`, or \`gh label create\`.** A later,
+   deterministic workflow step opens the PR from your pushed branch and that body
+   file and applies the \`${PR_LABEL}\` label. The PR must be authored by a token
+   whose events trigger CI: a PR opened by your \`gh\` is authored by
+   \`github-actions[bot]\`, and GitHub then queues every check on it as
+   \`action_required\` until a human clicks "Approve and run" — which would defeat
+   the whole point, since the debt gate is the check that matters here. The title
+   is fixed by that step; only the body is yours to write.
+5. The PR body must state, per debt list, what was fixed and which entry was
    removed, and must confirm that no exemption, suppression, baseline entry, or
    threshold relaxation was added.
-5. Print the PR URL as the last line of your final message.
+6. Print the branch name as the last line of your final message.
 
 If — and only if — the file cannot be cleaned without a behaviour change or a
-prohibited escape hatch, open NO pull request, leave the repository untouched
-(\`git checkout -- .\`), and report the specific blocker instead.
+prohibited escape hatch, push NOTHING, write no body file, leave the repository
+untouched (\`git checkout -- .\`), and report the specific blocker instead. The
+step that opens the PR treats an unpushed branch as a clean no-op.
 `;
 }

--- a/packages/dev-tools/boy-scout-debt/lib.test.mjs
+++ b/packages/dev-tools/boy-scout-debt/lib.test.mjs
@@ -377,21 +377,24 @@ describe('buildPrompt', () => {
     expect(prompt).toContain('behaviour-preservingly');
   });
 
-  it('requires a focused, labelled PR and the PR URL', () => {
-    expect(prompt).toContain(`--label ${PR_LABEL}`);
-    expect(prompt).toContain('gh pr create');
-    expect(prompt).toContain('Print the PR URL');
+  it('pushes the branch and hands the PR off to the workflow', () => {
+    expect(prompt).toContain(`git push -u origin ${BRANCH_PREFIX}/${candidate.slug}`);
+    expect(prompt).toContain('PR_BODY_FILE');
+    expect(prompt).toContain(PR_LABEL);
+    expect(prompt).toContain('Print the branch name');
   });
 
-  it('never tells Claude to create the label itself', () => {
-    // Claude's `gh` runs under BOT_PAT (contents + pull-requests only), and
-    // `gh label create` — even with `--force` — needs Issues write. The
-    // workflow bootstraps the label with GITHUB_TOKEN beforehand instead, so a
-    // create instruction here would kill the run after the refactor was done.
-    // The only mention left is the prohibition itself, never an invocation.
-    expect(prompt).not.toMatch(/^\s*gh label create/m);
-    expect(prompt).toContain('Do NOT run `gh label create`');
-    expect(prompt).toContain('already exists');
+  it('never tells Claude to open the PR or touch a label itself', () => {
+    // A PR opened by Claude's `gh` is authored by github-actions[bot], and
+    // GitHub queues every check on such a PR as `action_required` until a human
+    // approves it — so a deterministic workflow step opens it with BOT_PAT and
+    // applies the label with GITHUB_TOKEN (labels need Issues write, which
+    // BOT_PAT does not carry). Both verbs may appear in the prohibition, never
+    // as an invocation.
+    expect(prompt).not.toMatch(/^\s*gh (pr|label) (create|edit)/m);
+    expect(prompt.match(/gh pr create/g)).toHaveLength(1);
+    expect(prompt).toContain('Do NOT run `gh pr create`, `gh pr edit`, or `gh label create`');
+    expect(prompt).toContain('action_required');
   });
 
   it('requires focused tests', () => {

--- a/packages/dev-tools/claude-md-compactor/README.md
+++ b/packages/dev-tools/claude-md-compactor/README.md
@@ -3,8 +3,10 @@
 A weekly job that keeps the repo's machine-read instruction guides small. Every
 Saturday night a deterministic Node step measures every **tracked** file named
 `CLAUDE.md` and hands the oversized ones to `claude-code-action`, which rewrites
-them and opens exactly **one** pull request. Nothing oversized → no branch, no
-PR; silence is a valid outcome. Driven by
+them and pushes **one** branch; a deterministic workflow step then opens exactly
+**one** pull request from it (see
+[Why Claude does not open the PR](#why-claude-does-not-open-the-pr)). Nothing
+oversized → no branch, no PR; silence is a valid outcome. Driven by
 `.github/workflows/claude-md-compactor.yml`. Mirrors the
 `packages/dev-tools/codebase-sins/` layout (pure logic + CLI + co-located tests
 run by the `dev-tools` vitest project).
@@ -43,6 +45,31 @@ GitHub-native: the CLI queries open PRs and reports the first whose head branch
 starts with `automation/weekend-claude-compaction-` or whose title starts with
 `chore(docs): compact CLAUDE.md guides`. The workflow then skips the Claude step.
 No state file, no state branch, no Actions cache.
+
+## Why Claude does not open the PR
+
+Two phases, deliberately: **Claude pushes the branch and writes the PR body to
+`$PR_BODY_FILE`; a deterministic shell step opens the PR** with
+`GH_TOKEN: secrets.BOT_PAT`, using the `pr_title` output so the title stays on the
+`COMPACTION_PR_TITLE` constant. The brief forbids `gh pr create`.
+
+The reason is token identity. `claude-code-action` overrides `GH_TOKEN` for its
+Bash tool with its own `github_token:` input, which this workflow sets to
+`${{ github.token }}` (an OIDC → GitHub App exchange fails on this repo), so
+Claude's `gh` is always `GITHUB_TOKEN`. A PR created with `GITHUB_TOKEN` is
+authored by `github-actions[bot]`, and GitHub queues every workflow run for such a
+PR as `action_required`: the PR sits at **zero checks** until a human clicks
+"Approve and run". The deterministic step is the same shape
+[`coverage-ratchet.yml`](../../../.github/workflows/coverage-ratchet.yml) uses.
+
+It runs **after** the `--check` invariant, so a compaction that failed the policy
+never becomes a PR, and it is a clean no-op (never a failure) when Claude pushed
+nothing, when the branch is not ahead of `origin/main`, or when no body file was
+written. This workflow applies no label, so it needs no second token — the
+`BOT_PAT`/`GITHUB_TOKEN` split for create-vs-label only matters in the sibling
+dispatchers ([boy-scout](../boy-scout-debt/README.md#why-claude-does-not-open-the-pr)),
+where `BOT_PAT`'s missing `issues` permission forces the label into its own
+`gh pr edit` call under `GITHUB_TOKEN`.
 
 ## Files
 
@@ -97,8 +124,9 @@ successfully rewritten guide no longer looks oversized to a fresh measurement.
 
 ### Outputs
 
-`has_oversized`, `oversized_count`, `branch`, `existing_pr`, `worklist`, and the
-multi-line `report` and `prompt`.
+`has_oversized`, `oversized_count`, `branch`, `pr_title` (the fixed
+`COMPACTION_PR_TITLE`, consumed by the `gh pr create` step), `existing_pr`,
+`worklist`, and the multi-line `report` and `prompt`.
 
 ## Exit codes
 

--- a/packages/dev-tools/claude-md-compactor/lib.mjs
+++ b/packages/dev-tools/claude-md-compactor/lib.mjs
@@ -317,17 +317,27 @@ not characters. It is excluded from the worklist by construction; do not touch i
    documentation-only changes.
 4. Review \`git diff\` and confirm there is nothing behavioural, generated, or
    unrelated in it.
-5. Commit with a conventional-commit message, push the branch, and open ONE PR
-   against \`main\` titled exactly:
+5. Commit with a conventional-commit message and push the branch:
+   \`\`\`bash
+   git push -u origin ${branch || `${COMPACTION_BRANCH_PREFIX}<YYYY-MM-DD UTC>`}
+   \`\`\`
+6. Write the pull-request body to the file named by the \`PR_BODY_FILE\`
+   environment variable — e.g.
+   \`cat > "$PR_BODY_FILE" <<'EOF' … EOF\`. **Do NOT run \`gh pr create\`.** A
+   later, deterministic workflow step opens the PR from your pushed branch and
+   that body file, because the PR must be authored by a token whose events
+   trigger CI: a PR opened by your \`gh\` is authored by \`github-actions[bot]\`,
+   and GitHub then queues every check on it as \`action_required\` until a human
+   clicks "Approve and run". The title is fixed by that step and is exactly:
    \`${COMPACTION_PR_TITLE}\`
    The body must contain: a before/after character-count table, a link for every
    document you moved detail into, and these exact validation commands:
 ${VALIDATION_COMMANDS.map((c) => `   - \`${c}\``).join('\n')}
-6. **Never merge the PR.** Do not enable auto-merge. Do not poll CI afterwards —
+7. **Never merge the PR.** Do not enable auto-merge. Do not poll CI afterwards —
    existing automation handles follow-up failures.
-7. Report the PR URL and a one-paragraph summary. If you are blocked, report the
-   exact blocker and leave no misleading success state — an empty PR is worse
-   than no PR.
+8. Report a one-paragraph summary. If you are blocked, push NOTHING and write no
+   body file, then report the exact blocker — the deterministic step treats an
+   unpushed branch as a clean no-op, and an empty PR is worse than no PR.
 
 ${report ? `## Pre-run measurement\n\n${report}\n` : ''}`;
 }

--- a/packages/dev-tools/claude-md-compactor/lib.test.mjs
+++ b/packages/dev-tools/claude-md-compactor/lib.test.mjs
@@ -327,6 +327,15 @@ describe('buildPrompt', () => {
     expect(prompt).toContain('npx vitest run --project dev-tools');
   });
 
+  it('pushes the branch but leaves PR creation to the deterministic workflow step', () => {
+    expect(prompt).toContain('git push -u origin automation/weekend-claude-compaction-2026-02-07');
+    // `gh pr create` may appear in the prohibition, never as an invocation.
+    expect(prompt).not.toMatch(/^\s*gh pr create/m);
+    expect(prompt.match(/gh pr create/g)).toHaveLength(1);
+    expect(prompt).toContain('PR_BODY_FILE');
+    expect(prompt).toContain('action_required');
+  });
+
   it('forbids merging and CI polling', () => {
     expect(prompt).toContain('Never merge the PR');
     expect(prompt).toContain('Do not poll CI');

--- a/packages/dev-tools/claude-md-compactor/measure-claude-guides.mjs
+++ b/packages/dev-tools/claude-md-compactor/measure-claude-guides.mjs
@@ -47,6 +47,7 @@ import { fileURLToPath } from 'node:url';
 import {
   buildBranchName,
   buildPrompt,
+  COMPACTION_PR_TITLE,
   COMPACTOR_MAX_CHARS,
   COMPACTOR_TARGET_CHARS,
   findExistingCompactionPr,
@@ -197,6 +198,9 @@ async function main() {
   // paths no longer look oversized, so the check cannot rediscover them.
   setOutput('worklist', oversized.map((m) => m.path).join(','));
   setOutput('branch', branch);
+  // The workflow, not Claude, opens the PR; exporting the title keeps the
+  // `gh pr create` step and the brief on one constant.
+  setOutput('pr_title', COMPACTION_PR_TITLE);
   setOutput('existing_pr', existing?.url ?? '');
   setOutput('report', report);
   setOutput(

--- a/packages/dev-tools/flaky-ci-hunter/README.md
+++ b/packages/dev-tools/flaky-ci-hunter/README.md
@@ -85,8 +85,27 @@ release/publish/deploy job, is below `FLAKE_THRESHOLD`, has hit
 `MAX_ATTEMPTS_PER_JOB`, is inside `COOLDOWN_DAYS`, already has an open fix PR, is
 fully explained by known-mitigated infrastructure (npm-registry IPv6 — already
 mitigated by `NODE_OPTIONS: --dns-result-order=ipv4first` in `ci.yml`, which
-removed ~79% of observed flakes — artifact transport, runner outage), or has no
-failure signature common to two of its flips.
+removed ~79% of observed flakes — artifact transport, runner outage), has no
+failure signature common to two of its flips, or has a signature made of
+**nothing but Actions plumbing**.
+
+That last filter is what excludes gate jobs, and it was added because the first
+live run tripped over one. `CI / ci` is `if: always()` over `needs:
+[everything]`: it fails whenever any child job fails, so it flips whenever any
+child flips, and it scored 3 on a "common signature" of
+
+```
+##[error]One or more jobs failed or were cancelled
+##[error]Process completed with exit code 1.
+```
+
+which names no failure mode at all. An aggregator has no nondeterminism of its
+own — it mirrors everyone else's — so a fixer sent at it chases a phantom.
+Rather than pattern-match job names (plenty of repos have a real job called
+`ci`), `localizeFlake` requires the shared signature to contain at least one
+line that is not Actions plumbing. That generalizes: whenever we cannot see a
+real error line, we do not dispatch, and the job lands in the digest as "not
+localized" instead.
 
 The dispatch brief bans the fixes this repo has already ruled out in
 [`.agents/skills/writing-slicc-tests/SKILL.md`](../../../.agents/skills/writing-slicc-tests/SKILL.md)

--- a/packages/dev-tools/flaky-ci-hunter/README.md
+++ b/packages/dev-tools/flaky-ci-hunter/README.md
@@ -12,7 +12,7 @@ quiet week is a valid outcome that needs no justification beyond the digest.
 ## Flow
 
 ```
-cron (Mon 06:50 UTC) ─▶ scan-flakes.mjs ─▶ has_candidate? ─▶ claude-code-action (branch + ONE PR)
+cron (Mon 06:50 UTC) ─▶ scan-flakes.mjs ─▶ has_candidate? ─▶ claude-code-action (branch + title/body files) ─▶ shell step (ONE PR)
                           │                     │
                           │                     └─ always: digest ─▶ step summary + `flaky-ci-digest` artifact
                           ├─ runs, ONE DAY AT A TIME (1000-item cap workaround)
@@ -128,8 +128,41 @@ If the honest fix is one of those, the fixer must report back instead of pushing
 
 `jobSlug(workflow, job)` → `automation/flaky-fix/<slug>` is therefore the durable
 registry key, which is why the dispatch brief insists on that exact branch name
-and the `flaky-fix` label. Nothing is committed to the repo, no state branch is
-created, and the Actions cache is not used.
+and the workflow applies the `flaky-fix` label. Nothing is committed to the repo,
+no state branch is created, and the Actions cache is not used.
+
+## Why Claude does not open the PR
+
+Two phases, deliberately: **Claude pushes the branch and writes the PR title to
+`$PR_TITLE_FILE` and the body to `$PR_BODY_FILE`; a deterministic shell step opens
+the PR.** The brief forbids `gh pr create`. The title is a file rather than a
+constant because it has to carry Claude's one-sentence root cause; the step falls
+back to `fix(ci): make <workflow> / <job> deterministic` if the file is missing.
+
+The reason is token identity. `claude-code-action` overrides `GH_TOKEN` for its
+Bash tool with its own `github_token:` input, which this workflow sets to
+`${{ github.token }}` (an OIDC → GitHub App exchange fails on this repo), so
+Claude's `gh` is always `GITHUB_TOKEN`. A PR created with `GITHUB_TOKEN` is
+authored by `github-actions[bot]`, and GitHub queues every workflow run for such a
+PR as `action_required`: the PR sits at **zero checks** until a human clicks
+"Approve and run" — and a determinism fix CI never runs is worthless. The
+deterministic step is the same shape
+[`coverage-ratchet.yml`](../../../.github/workflows/coverage-ratchet.yml) uses.
+
+The step is a clean no-op (never a failure) when Claude pushed nothing, when the
+branch is not ahead of `origin/main`, or when no body file was written — which is
+exactly what the "if the honest fix is banned, stop and report" escape hatch
+produces. It also skips creation when an open PR for the head already exists.
+
+Two tokens, because `BOT_PAT` is scoped to **contents + pull-requests only**:
+
+| Call                                         | Token          | Why                                                        |
+| -------------------------------------------- | -------------- | ---------------------------------------------------------- |
+| `gh pr create`                               | `BOT_PAT`      | The author's events must trigger CI.                       |
+| `gh label create` / `gh pr edit --add-label` | `GITHUB_TOKEN` | Labels are an Issues API write; `BOT_PAT` has no `issues`. |
+
+Passing `--label` to `gh pr create` under `BOT_PAT` would 403 and lose the PR, so
+the label is always a separate `gh pr edit` call.
 
 ## Run it locally
 
@@ -212,12 +245,12 @@ candidate `CI / node-server` with score 2, a common `EADDRINUSE` signature, and
 
 Shared with `rum-error-triage` and `coverage-ratchet` — no new secrets.
 
-| Name                         | Kind     | Purpose                                                                                                  |
-| ---------------------------- | -------- | -------------------------------------------------------------------------------------------------------- |
-| `AWS_BEARER_TOKEN_BEDROCK`   | secret   | Amazon Bedrock API key (Adobe CAMP `ABSK...` bearer token) used by `claude-code-action` (`use_bedrock`). |
-| `BOT_PAT`                    | secret   | Checkout/push token — a PR pushed with `GITHUB_TOKEN` does not trigger CI.                               |
-| `RUM_AWS_REGION`             | variable | Optional. Bedrock region for the CAMP key (default `us-east-1`).                                         |
-| `FLAKY_HUNTER_BEDROCK_MODEL` | variable | Optional. Bedrock model; falls back to `RUM_BEDROCK_MODEL`, then `global.anthropic.claude-sonnet-4-6`.   |
+| Name                         | Kind     | Purpose                                                                                                     |
+| ---------------------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `AWS_BEARER_TOKEN_BEDROCK`   | secret   | Amazon Bedrock API key (Adobe CAMP `ABSK...` bearer token) used by `claude-code-action` (`use_bedrock`).    |
+| `BOT_PAT`                    | secret   | Checkout/push **and `gh pr create`** token — a PR pushed or opened with `GITHUB_TOKEN` does not trigger CI. |
+| `RUM_AWS_REGION`             | variable | Optional. Bedrock region for the CAMP key (default `us-east-1`).                                            |
+| `FLAKY_HUNTER_BEDROCK_MODEL` | variable | Optional. Bedrock model; falls back to `RUM_BEDROCK_MODEL`, then `global.anthropic.claude-sonnet-4-6`.      |
 
 ## Design notes
 
@@ -229,7 +262,8 @@ Shared with `rum-error-triage` and `coverage-ratchet` — no new secrets.
   attempts) run first so log reads are only ever spent on the ONE candidate whose
   sole open question is "is this actually a single flake?".
 - **Read-only scanner.** No comments, no labels, no re-runs, no pushes. Only the
-  Claude step writes, and only a branch and one PR. No GitHub comment is ever
+  Claude step and the two shell steps after it write, and only a branch, one PR,
+  and that PR's label. No GitHub comment is ever
   posted: a flaky job has no natural PR or issue to comment on, and the fix PR
   speaks for itself.
 - **Not automated on purpose.** The brief asks Claude for the one-sentence root

--- a/packages/dev-tools/flaky-ci-hunter/lib.mjs
+++ b/packages/dev-tools/flaky-ci-hunter/lib.mjs
@@ -908,8 +908,31 @@ and confirming it passes every time. State the iteration count in the PR body.
    \`${FIX_BRANCH_PREFIX}*\` pull requests to learn how many times this job has
    already been dispatched and when. Do not rename it.
 2. Keep the change scoped to this one flake.
-3. Open **exactly ONE** pull request, labelled \`${FIX_LABEL}\`. Do not merge it and
-   do not assign reviewers.
-4. Report back with the PR URL and the iteration count you verified with.
+3. Commit, then \`git push -u origin ${branch}\`.
+4. Write two files instead of opening the pull request yourself:
+   - the one-line PR title to the path in \`$PR_TITLE_FILE\` (a conventional-commit
+     subject naming the root cause, e.g.
+     \`fix(<scope>): <the nondeterminism you removed>\`);
+   - the PR body to the path in \`$PR_BODY_FILE\`, stating the root cause, the
+     evidence links above, and the iteration count you verified with.
+
+   \`\`\`bash
+   printf '%s\\n' "fix(<scope>): <root cause>" > "$PR_TITLE_FILE"
+   cat > "$PR_BODY_FILE" <<'EOF'
+   <root cause, evidence, iteration count>
+   EOF
+   \`\`\`
+
+   **Do NOT run \`gh pr create\` and do not label anything.** A later,
+   deterministic workflow step opens **exactly ONE** pull request from your pushed
+   branch and those two files and applies the \`${FIX_LABEL}\` label. The PR must be
+   authored by a token whose events trigger CI: a PR opened by your \`gh\` is
+   authored by \`github-actions[bot]\`, and GitHub then queues every check on it as
+   \`action_required\` until a human clicks "Approve and run" — worthless for a
+   determinism fix nobody's CI ever runs. Do not merge it and do not assign
+   reviewers.
+5. Report back with the branch name and the iteration count you verified with. If
+   the honest fix is one of the banned options, push NOTHING and write neither
+   file — the step that opens the PR treats an unpushed branch as a clean no-op.
 `;
 }

--- a/packages/dev-tools/flaky-ci-hunter/lib.mjs
+++ b/packages/dev-tools/flaky-ci-hunter/lib.mjs
@@ -636,6 +636,14 @@ const INTERESTING_LINE =
   /(FAIL|✕|×|AssertionError|Error:|Timeout|expected|##\[error\]|EADDRINUSE|ECONNREFUSED)/i;
 
 /**
+ * Lines that are GitHub Actions telling you *that* something failed, never
+ * *what* failed. Kept in an excerpt as context, but a signature made of nothing
+ * else has localized nothing — see {@link localizeFlake}.
+ */
+const PLUMBING_LINE =
+  /^(##\[error\])?\s*(one or more jobs failed|process completed with exit code|the (job|operation) was canceled|the run was canceled|echo "::error|::error::one or more jobs)/i;
+
+/**
  * Pull the interesting lines out of a job log: strip ANSI and the per-line
  * timestamp Actions prefixes, keep failure-ish lines, drop duplicates.
  * @param {string} logText
@@ -700,6 +708,19 @@ export function localizeFlake(excerpts = []) {
       localized: false,
       signature: '',
       reason: `Read ${usable.length} flip logs and found no shared failure line — the flips have nothing in common, so this is not one fixable flake.`,
+    };
+  }
+  // A signature made only of Actions plumbing names no failure mode. This is
+  // what an aggregator/gate job looks like: `CI / ci` in this repo is
+  // `if: always()` over `needs: [everything]`, so it "flakes" whenever any
+  // child job does and its shared lines are just "One or more jobs failed".
+  // Dispatching a fixer at that sends the model after a phantom. A mirror of
+  // other jobs' flakiness belongs in the digest, not in a pull request.
+  if (common.every((line) => PLUMBING_LINE.test(line))) {
+    return {
+      localized: false,
+      signature: common.slice(0, 5).join('\n'),
+      reason: `The only lines shared by ${usable.length} flips are GitHub Actions plumbing ("job failed", "exit code"), naming no failure mode. This is what a gate/aggregator job looks like — it mirrors other jobs' flakiness rather than having its own.`,
     };
   }
   return {

--- a/packages/dev-tools/flaky-ci-hunter/lib.test.mjs
+++ b/packages/dev-tools/flaky-ci-hunter/lib.test.mjs
@@ -794,6 +794,20 @@ describe('buildPrompt', () => {
     expect(prompt).toContain('Do not merge');
   });
 
+  it('pushes the branch and leaves PR creation to the deterministic step', () => {
+    // A PR opened by Claude's `gh` is authored by github-actions[bot], whose
+    // checks GitHub queues as `action_required` until a human approves them —
+    // useless for a determinism fix. The workflow opens it with BOT_PAT from the
+    // title/body files instead, so the brief must name both env vars and never
+    // invoke `gh pr create`.
+    expect(prompt).toContain('git push -u origin automation/flaky-fix/ci--node-server');
+    expect(prompt).toContain('$PR_TITLE_FILE');
+    expect(prompt).toContain('$PR_BODY_FILE');
+    expect(prompt).not.toMatch(/^\s*gh pr create/m);
+    expect(prompt.match(/gh pr create/g)).toHaveLength(1);
+    expect(prompt).toContain('action_required');
+  });
+
   it('tolerates a candidate with no captured evidence', () => {
     const bare = buildPrompt({ workflow: 'CI', job: 'x', slug: 'ci--x', flakeScore: 2 });
     expect(bare).toContain('(no evidence links captured)');

--- a/packages/dev-tools/flaky-ci-hunter/lib.test.mjs
+++ b/packages/dev-tools/flaky-ci-hunter/lib.test.mjs
@@ -668,6 +668,34 @@ describe('extractFailureLines / localizeFlake', () => {
     expect(out.reason).toContain('nothing in common');
   });
 
+  it('refuses to localize a gate job whose only shared lines are Actions plumbing', () => {
+    // Verbatim from the first live run's digest: `CI / ci` is `if: always()` over
+    // `needs: [everything]`, so it flips whenever ANY child job flips and its
+    // shared "signature" names no failure mode. It scored 3 and was dispatched.
+    const plumbing = [
+      'echo "::error::One or more jobs failed or were cancelled"',
+      '##[error]One or more jobs failed or were cancelled',
+      '##[error]Process completed with exit code 1.',
+    ];
+    const out = localizeFlake([{ lines: plumbing }, { lines: plumbing }, { lines: plumbing }]);
+    expect(out.localized).toBe(false);
+    expect(out.reason).toMatch(/plumbing/i);
+    expect(out.reason).toMatch(/gate\/aggregator/i);
+    // The signature is still reported so the digest can show what was seen.
+    expect(out.signature).toContain('One or more jobs failed');
+  });
+
+  it('still localizes when a real failure line rides along with plumbing', () => {
+    const lines = [
+      '##[error]Process completed with exit code 1.',
+      'FAIL packages/webapp/tests/kernel/host.test.ts > boots',
+      'AssertionError: expected 3 to be 4',
+    ];
+    const out = localizeFlake([{ lines }, { lines }]);
+    expect(out.localized).toBe(true);
+    expect(out.signature).toContain('AssertionError');
+  });
+
   it('refuses to localize from fewer than two readable logs', () => {
     const out = localizeFlake([{ lines: ['FAIL tests/a.test.ts > alpha'] }]);
     expect(out.localized).toBe(false);

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -5,7 +5,6 @@
   "packages/chrome-extension/src/bridge-sw.ts": 17,
   "packages/chrome-extension/src/secrets-storage.ts": 3,
   "packages/cloud-core/src/cone-config/index.ts": 6,
-  "packages/cloud-core/src/errors.ts": 1,
   "packages/cloudflare-worker/src/cloud/handlers.ts": 1,
   "packages/cloudflare-worker/src/flags.ts": 2,
   "packages/cloudflare-worker/src/index.ts": 3,


### PR DESCRIPTION
## Boy-scout debt cleanup: `packages/cloud-core/src/errors.ts`

Pays down the sole boy-scout debt entry on this file so the touched-file gate
(`check-touched-exemptions.mjs`) passes, without changing observable behaviour.

### Debt list cleared

**Untyped string-keyed bags (`record-string-unknown`)** — 1 occurrence
- Replaced `CloudError.details?: Record<string, unknown>` with a named
  `CloudErrorDetails` interface. The shape captures exactly the diagnostic
  fields the codebase attaches to a `CloudError`:
  - `running` / `paused` / `cap` — set on `CAP_EXCEEDED` in `operations/start.ts`
  - `sandboxId` — set on `SANDBOX_NOT_READY` in `operations/start.ts`
- The worker's HTTP error envelope (`cloudflare-worker/src/cloud/error-envelope.ts`)
  already declared a matching local `CloudErrorDetails`; `err.details` from
  cloud-core stays assignable to it, so `errorResponse(..., err.details)` is
  unchanged.
- Removed the `packages/cloud-core/src/errors.ts` entry from
  `record-string-unknown-baseline.json` using the supported command
  `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
  (not hand-edited).

### Tests

Added `packages/cloud-core/tests/errors.test.ts` pinning `CloudError`
construction (code, message, `name`), the typed `details` for the cap-exceeded
and boot-failure cases, and `isCloudError` narrowing.

### Verification

- `npx biome check --write` on the touched files — clean
- `npm run typecheck` — pass
- `npx vitest run packages/cloud-core/tests/ packages/cloudflare-worker/tests/cloud*` — pass (consumers of `err.details` unaffected)
- `npm run verify` — all 7 checks pass
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — **OK, 0 still on any debt list**

### Confirmation

No exemption, `biome-ignore`/`eslint-disable` suppression, `biome.json`
override, new baseline entry, coverage/threshold relaxation, or unsafe cast was
added. Only the now-stale debt entry for `packages/cloud-core/src/errors.ts` was
removed; all other baseline entries are untouched.
