### PR TITLE
fix(kernel): beat the ready watchdog through the silent shared-FS mount

### DIFF
--- a/packages/webapp/src/scoops/mount-heartbeat.ts
+++ b/packages/webapp/src/scoops/mount-heartbeat.ts
@@ -1,0 +1,59 @@
+/**
+ * `mount-heartbeat.ts` — bounded liveness heartbeat for the shared-FS mount.
+ *
+ * The OPFS mount is the one boot phase with no natural milestones: ZenFS
+ * parses the multi-megabyte metadata sidecar and the unconditional pre-boot
+ * repair (#2146/#2148) probes every sidecar entry against the real OPFS
+ * tree. On a large tree (22k entries in the 2026-08-18 field incident) a
+ * COLD boot — fresh Chrome, no OPFS caches — spends 25-30s+ in that phase
+ * in silence, which blows the page's 30s kernel-ready watchdog (#2007):
+ * the leader bricked with "Kernel worker did not signal ready within
+ * 30000ms" on every restart, while a warm reload squeaked under the limit.
+ *
+ * The watchdog is a STALL detector, so the beat must not run forever — a
+ * genuinely wedged mount (deadlocked web lock, hung OPFS handle) has to
+ * stop beating and let the timeout fire. Hence the cap: up to
+ * {@link MOUNT_HEARTBEAT_MAX_BEATS} interval beats (~2 minutes of mount
+ * grace), then silence, and the watchdog rules again.
+ */
+
+/** Beat cadence while the mount is in flight. */
+export const MOUNT_HEARTBEAT_INTERVAL_MS = 5_000;
+/**
+ * Beats before the heartbeat goes quiet: 24 × 5s ≈ 2 minutes of grace for
+ * an O(tree) mount, after which a still-pending mount is treated as wedged
+ * (the page watchdog then fires one timeout-window later).
+ */
+export const MOUNT_HEARTBEAT_MAX_BEATS = 24;
+
+/**
+ * Run `work` while emitting `onProgress` liveness beats
+ * (`shared-fs-mount:start`, then `shared-fs-mount:<n>` per interval, capped
+ * at {@link MOUNT_HEARTBEAT_MAX_BEATS}). The timer is cleared on resolve
+ * AND reject; the work's outcome passes through untouched. With no
+ * `onProgress` this is a plain passthrough.
+ */
+export async function withMountHeartbeat<T>(
+  work: () => Promise<T>,
+  onProgress?: (stage: string) => void,
+  options: { intervalMs?: number; maxBeats?: number } = {}
+): Promise<T> {
+  if (!onProgress) return work();
+  const intervalMs = options.intervalMs ?? MOUNT_HEARTBEAT_INTERVAL_MS;
+  const maxBeats = options.maxBeats ?? MOUNT_HEARTBEAT_MAX_BEATS;
+  onProgress('shared-fs-mount:start');
+  let beats = 0;
+  const timer = setInterval(() => {
+    beats += 1;
+    if (beats > maxBeats) {
+      clearInterval(timer);
+      return;
+    }
+    onProgress(`shared-fs-mount:${beats}`);
+  }, intervalMs);
+  try {
+    return await work();
+  } finally {
+    clearInterval(timer);
+  }
+}

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -48,6 +48,7 @@ import {
 } from './lick-manager.js';
 import { LickRegistry } from './lick-registry.js';
 import { LlmsTxtIgnorePolicy } from './llms-txt-ignore.js';
+import { withMountHeartbeat } from './mount-heartbeat.js';
 import { TaskScheduler } from './scheduler.js';
 import { ScoopApprovalRouter } from './scoop-approval-router.js';
 import { ScoopCompletionService } from './scoop-completion-service.js';
@@ -360,8 +361,17 @@ export class Orchestrator implements ConeApprovalRouter {
   async init(onBootProgress?: (stage: string) => void): Promise<void> {
     await db.initDB();
 
-    // Create the single shared VirtualFS
-    this.sharedFs = await VirtualFS.create({ dbName: 'slicc-fs' });
+    // Create the single shared VirtualFS. The mount parses the metadata
+    // sidecar and runs the unconditional pre-boot repair (#2146) — O(tree
+    // size) with no milestones of its own, 25-30s+ on a COLD boot of a
+    // large tree (2026-08-18 restart brick: "did not signal ready" on
+    // every fresh Chrome start, warm reloads passed). The bounded
+    // heartbeat keeps the page's kernel-ready watchdog (#2007) armed
+    // while the mount provably advances.
+    this.sharedFs = await withMountHeartbeat(
+      () => VirtualFS.create({ dbName: 'slicc-fs' }),
+      onBootProgress
+    );
     this.sessionStore = new SessionStore();
 
     // Create and attach file system watcher

--- a/packages/webapp/tests/scoops/mount-heartbeat.test.ts
+++ b/packages/webapp/tests/scoops/mount-heartbeat.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MOUNT_HEARTBEAT_INTERVAL_MS,
+  MOUNT_HEARTBEAT_MAX_BEATS,
+  withMountHeartbeat,
+} from '../../src/scoops/mount-heartbeat.js';
+
+// The shared-FS mount heartbeat (2026-08-18 cold-boot brick): the OPFS
+// mount + pre-boot sidecar repair is O(tree size) and silent, so a cold
+// boot of a large tree blew the page's 30s kernel-ready watchdog (#2007).
+// The helper beats the watchdog while the mount is in flight — capped, so
+// a genuinely wedged mount still times out.
+describe('withMountHeartbeat', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('passes the result through and emits start + interval beats', async () => {
+    const stages: string[] = [];
+    let resolveWork: (v: string) => void = () => {};
+    const work = new Promise<string>((r) => {
+      resolveWork = r;
+    });
+    const p = withMountHeartbeat(
+      () => work,
+      (s) => stages.push(s)
+    );
+    expect(stages).toEqual(['shared-fs-mount:start']);
+    await vi.advanceTimersByTimeAsync(MOUNT_HEARTBEAT_INTERVAL_MS * 3);
+    expect(stages).toEqual([
+      'shared-fs-mount:start',
+      'shared-fs-mount:1',
+      'shared-fs-mount:2',
+      'shared-fs-mount:3',
+    ]);
+    resolveWork('mounted');
+    await expect(p).resolves.toBe('mounted');
+    // Beats stop once the mount resolves.
+    await vi.advanceTimersByTimeAsync(MOUNT_HEARTBEAT_INTERVAL_MS * 2);
+    expect(stages).toHaveLength(4);
+  });
+
+  it('caps the beats so a wedged mount stops re-arming the watchdog', async () => {
+    const stages: string[] = [];
+    const never = new Promise<never>(() => {});
+    void withMountHeartbeat(
+      () => never,
+      (s) => stages.push(s)
+    );
+    await vi.advanceTimersByTimeAsync(
+      MOUNT_HEARTBEAT_INTERVAL_MS * (MOUNT_HEARTBEAT_MAX_BEATS + 10)
+    );
+    // start + capped interval beats, nothing past the cap — the watchdog
+    // must regain authority over a mount that never finishes.
+    expect(stages).toHaveLength(1 + MOUNT_HEARTBEAT_MAX_BEATS);
+    expect(vi.getTimerCount()).toBe(0); // capped timer cleared itself
+  });
+
+  it('clears the timer and rethrows when the mount fails', async () => {
+    const stages: string[] = [];
+    const boom = new Error('mount failed');
+    const p = withMountHeartbeat(
+      () => Promise.reject(boom),
+      (s) => stages.push(s)
+    );
+    await expect(p).rejects.toBe(boom);
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(MOUNT_HEARTBEAT_INTERVAL_MS * 2);
+    expect(stages).toEqual(['shared-fs-mount:start']);
+  });
+
+  it('is a plain passthrough with no callback', async () => {
+    await expect(withMountHeartbeat(async () => 42)).resolves.toBe(42);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/webapp/tests/scoops/orchestrator-boot-progress.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator-boot-progress.test.ts
@@ -82,6 +82,16 @@ describe('orchestrator boot-progress heartbeat (#2007)', () => {
     expect(stages).toContain('scoop-restored:scoop_bp_1');
   });
 
+  it('emits the shared-fs mount start beat (2026-08-18 cold-boot brick)', async () => {
+    const container = { appendChild: () => {} } as unknown as HTMLElement;
+    orch = new Orchestrator(container, noopCallbacks());
+    const stages: string[] = [];
+    await orch.init((stage) => stages.push(stage));
+    // The mount phase is the boot's silent O(tree) stretch — the heartbeat
+    // must announce it so the kernel-ready watchdog re-arms (#2007).
+    expect(stages).toContain('shared-fs-mount:start');
+  });
+
   it('is optional — init() with no callback still boots', async () => {
     await saveScoop(scoop('cone_bp_2', true));
     const container = { appendChild: () => {} } as unknown as HTMLElement;


### PR DESCRIPTION
Follow-up to #2160, fixing the restart brick observed live on the leader today.

## Symptom

After a Chrome restart, every cold boot failed with **"Kernel worker did not signal ready within 30000ms"** next to the data-wipe recovery button; a warm reload then booted fine.

## Root cause (captured via CDP on the live leader)

The boot timeline shows the kernel worker going **silent for 25–30s+** right after `cdp-connected`: that stretch is the shared-FS mount — ZenFS parsing a 6.5 MB `.metadata.json` sidecar plus the unconditional pre-boot repair (#2146/#2148) probing all ~22k entries against OPFS. There is **no boot-progress milestone anywhere in that phase**, so the page's kernel-ready stall watchdog (#2007) — which re-arms on every milestone — fires mid-mount at 30s.

Cold boots (fresh Chrome, no OPFS caches) land just *over* the line; warm reloads just *under*. That's why the failure looked like "won't boot after restart" but self-healed on retry.

## Fix

`withMountHeartbeat` (new, `packages/webapp/src/scoops/mount-heartbeat.ts`) wraps the orchestrator's `VirtualFS.create({ dbName: 'slicc-fs' })` and emits liveness beats — `shared-fs-mount:start`, then one beat per 5 s — which ride the existing `onBootProgress` → `kernel-worker-boot-progress` path and re-arm the watchdog while the mount is provably in flight.

The beat is **capped at 24** (~2 minutes of mount grace). A genuinely wedged mount (deadlocked web lock, hung OPFS handle) stops beating and the watchdog regains authority — #2007's stall-detection contract is preserved, not bypassed.

## Tests

- `mount-heartbeat.test.ts` (new, fake timers): result/rejection passthrough, start + interval beats, beats stop on resolve, **cap enforcement** (timer clears itself, no beats past the cap), timer cleanup on failure, no-callback passthrough.
- `orchestrator-boot-progress.test.ts`: asserts `orchestrator.init` now emits `shared-fs-mount:start` through the real boot path.

## Not addressed here

The repair found changes on **every** boot of the affected leader (stale-size entries, e.g. `/workspace/skills/swarm/references/endpoints.md` recorded at 7808 bytes vs 5564 real) — something re-poisons sidecar sizes (#2006 family). That keeps the repair from converging to a no-op and deserves its own investigation.

## Verification

`npm run verify` · `check-touched-exemptions` · `npm run typecheck` · `npm run test` · webapp coverage gate · `npm run build` + extension build · `bundle-size`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65
