### PR TITLE
fix(ci): review our own agents' pull requests instead of skipping them

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -64,14 +64,26 @@ jobs:
     # Skip fork PRs: secrets are unavailable on `pull_request` from forks, and
     # reviewing them safely would require `pull_request_target` + a security
     # review (out of scope). Only run when the PR head lives in this repo.
-    # Also skip bot-authored PRs (e.g. Renovate dependency bumps): they don't
-    # need an AI review, and claude-code-action rejects bot-initiated runs by
-    # default ("Workflow initiated by non-human actor"), which only produced
-    # noisy failed runs. Manual dispatch always runs (operator intent).
+    #
+    # Bot-authored PRs are skipped — EXCEPT the `automation/*` heads our own
+    # scheduled agents push. That exclusion was written for Renovate dependency
+    # bumps, which genuinely do not need an AI review. Applied to an agent's PR
+    # it removes review from the code that needs it most: a model wrote it
+    # unattended, and nobody assigned themselves as its author. Observed on
+    # #2168/#2169/#2170, which arrived with no automated review of any kind
+    # (Codex and Copilot ignore bot-authored PRs too, so this workflow is the
+    # only reviewer they can get).
+    #
+    # Those PRs are normally authored by the BOT_PAT owner — a User, not a Bot —
+    # so the type check alone usually lets them through. The head-ref carve-out
+    # is what makes that independent of which token happened to open the PR.
+    # Manual dispatch always runs (operator intent).
     if: >-
       github.event_name == 'workflow_dispatch' || (
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.user.type != 'Bot'
+        github.event.pull_request.head.repo.full_name == github.repository && (
+          github.event.pull_request.user.type != 'Bot' ||
+          startsWith(github.event.pull_request.head.ref, 'automation/')
+        )
       )
     steps:
       - name: Wait 5 minutes for personal/human reviewers
@@ -147,6 +159,14 @@ jobs:
           track_progress: ${{ github.event_name != 'workflow_dispatch' }}
           # Needed by the action for the inline-comment MCP tool.
           github_token: ${{ github.token }}
+          # An `automation/*` PR opened by `github-actions[bot]` makes the bot the
+          # triggering actor, and the action's human-actor gate would reject the
+          # run outright ("Workflow initiated by non-human actor") — which is the
+          # failure the old blanket bot exclusion was avoiding. Allowing bots here
+          # is what makes reviewing our own agents' PRs possible at all; the
+          # job-level `if` still keeps every other bot's PRs (Renovate) out, and
+          # the fork guard is unchanged.
+          allowed_bots: '*'
           # allowedTools: the inline-comment MCP tool PLUS unrestricted Bash, so
           # the reviewer can use `gh pr comment` / `gh api` for PR context AND
           # actually run the code (npm ci, targeted tests, build) to verify

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,8 +28,13 @@ name: Claude PR Review
 # revision; the PR head is only checked out (conditionally) for the review step.
 # The REVIEW step then intentionally runs PR-authored code (Bash) to verify
 # behaviour — bounded by the job `if`: same-repo head only (fork PRs excluded, so
-# no secret exposure to forks) and non-bot authors, and the job holds
-# contents: read (a review can never push) with pull-requests: write for comments.
+# no secret exposure to forks), and the job holds contents: read (a review can
+# never push) with pull-requests: write for comments.
+#
+# Note the trust boundary is the HEAD REPO, not the author: bot-authored
+# `automation/*` PRs are reviewed (see the job `if`), and that is safe for the
+# same reason a human's PR is — pushing an `automation/*` branch to this repo
+# already requires write access, so the code was authored by someone trusted.
 #
 # Required repository secret (already present — shared with rum-error-triage):
 #   AWS_BEARER_TOKEN_BEDROCK  Amazon Bedrock API key (Adobe CAMP `ABSK...`

--- a/packages/dev-tools/pr-review-gate/README.md
+++ b/packages/dev-tools/pr-review-gate/README.md
@@ -40,6 +40,14 @@ The workflow lives in `.github/workflows/claude-pr-review.yml`.
   `$GITHUB_OUTPUT`.
 - **Skip rules.** The gate skips when the PR is not `open`, is a draft, or
   already has any inline review comment. Otherwise it reviews.
+- **Who is eligible at all** is decided before the gate, by the job-level `if:`
+  in [`claude-pr-review.yml`](../../../.github/workflows/claude-pr-review.yml):
+  in-repo heads only (fork PRs cannot see secrets), and bot-authored PRs are
+  skipped **except** `automation/*` heads. That carve-out exists because the
+  blanket bot exclusion was written for Renovate bumps, and applied to our own
+  scheduled agents it removed review from the code that needs it most — a model
+  wrote it unattended. Codex and Copilot both ignore bot-authored PRs, so this
+  workflow is the only review such a PR can get.
 
 ## Required secrets / variables (GitHub Actions)
 


### PR DESCRIPTION
## Summary

The PR reviewer skipped every bot-authored pull request, which meant the PRs our five scheduled agents open got **no automated review at all**. #2168, #2169 and #2170 each arrived with zero reviews; I only got any by dispatching this workflow by hand.

## Why

The `if:` rule was written for Renovate dependency bumps, and for those it is right — a version bump does not need an AI review. Applied to an agent's PR it removes review from the code that needs it most: a model wrote it unattended, and no human put their name on it as author.

There is no fallback, either. Codex and Copilot both ignore bot-authored PRs — Codex stayed silent on #2168 through two explicit `@codex review` requests — so this workflow is the only review such a PR can get.

And the manual reviews I had to trigger found real things: on #2169 it caught that the PR description still described an abandoned first attempt and contradicted the shipped diff. That is exactly the class of defect nobody else was going to catch on an unattended PR.

## Approach

Two changes, and either one alone does nothing:

1. **The job-level `if:` now admits `automation/*` heads regardless of author.** Since #2167 those PRs are opened with `BOT_PAT`, so their author is a User and the existing type check already lets them through — but that makes review contingent on which token happened to open the PR, a property we could regress without noticing. Keying on the head ref states the intent directly: our automation's PRs get reviewed.

2. **`allowed_bots: '*'` on the review step.** A PR opened by `github-actions[bot]` makes the bot the triggering actor, and `claude-code-action`'s human-actor gate would reject the run outright ("Workflow initiated by non-human actor") — the exact noisy failure the blanket exclusion was avoiding. Without this the job starts and then refuses, which is worse than skipping.

Renovate stays excluded, because its heads are `renovate/*`. The fork guard is untouched: in-repo heads only, since `pull_request` from a fork cannot see secrets.

## Cross-cutting impact

- **Floats exercised**: none. CI-only.
- **Blast radius**: one more review per automation PR (roughly one a day from the boy-scout dispatcher, plus occasional compaction/flake/backlog PRs). The reviewer has `contents: read`, so a review can never push.
- **Security**: `allowed_bots: '*'` permits bot-*initiated* runs; it does not widen what the reviewer may do, and the job-level `if:` still restricts which PRs reach it.

## Test plan

- [x] `npm run verify` — 7/7
- [x] `npm run lint:docs` — clean
- [x] `node node_modules/vitest/vitest.mjs run --project dev-tools packages/dev-tools/pr-review-gate/` — 8 passing
- [x] `check-touched-exemptions.mjs origin/main` — `OK (2 changed file(s), 0 still on any debt list)`
- [x] `npx prettier --check` on the workflow; the `if:` expression and both `with:` keys verified by parsing the YAML rather than by eye
- [ ] **Verified live after merge**: the next boy-scout PR should draw a review with no human dispatch. That is the only real proof, and I will confirm it on the next nightly (or a manual dispatch) rather than assume.
- [ ] N/A — `typecheck` / `test` / `build`: workflow YAML and a README

## Documentation

- [x] `packages/dev-tools/pr-review-gate/README.md` — documents who is eligible before the gate runs, the `automation/*` carve-out, and why (the gate's own skip rules were documented; eligibility was not)

## Risk & rollback

- **Rollback**: revert; automation PRs go back to being unreviewed.
- **Watch for**: a review loop. The reviewer only comments and the gate skips any PR that already has inline review comments, so a review cannot trigger another review — but the first automation PR after this merges is worth a look to confirm exactly one review lands.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Public API / tool / shell-command changes: none
- [x] No cross-float contract changed
