### PR TITLE
refactor: pay down boy-scout debt in packages/cloud-core/src/errors.ts

### DIFF
--- a/packages/cloud-core/src/errors.ts
+++ b/packages/cloud-core/src/errors.ts
@@ -18,11 +18,28 @@ export type CloudErrorCode =
   | 'UPSTREAM_UNAVAILABLE'
   | 'INTERNAL';
 
+/**
+ * Structured context attached to a {@link CloudError}. Carried through to the
+ * worker's HTTP error envelope (`errorResponse`) and surfaced to consumers.
+ * Today only the cap-exceeded errors populate it; extend this shape rather than
+ * widening it back to an untyped bag when a new code needs to carry context.
+ */
+export interface CloudErrorDetails {
+  /** Number of running cones when a running cap was exceeded. */
+  running?: number;
+  /** Number of paused cones when a paused cap was exceeded. */
+  paused?: number;
+  /** The cap limit that was exceeded. */
+  cap?: number;
+  /** The sandbox involved, e.g. when a cone fails to become ready. */
+  sandboxId?: string;
+}
+
 export class CloudError extends Error {
   constructor(
     public readonly code: CloudErrorCode,
     message: string,
-    public readonly details?: Record<string, unknown>
+    public readonly details?: CloudErrorDetails
   ) {
     super(message);
     this.name = 'CloudError';

--- a/packages/cloud-core/tests/errors.test.ts
+++ b/packages/cloud-core/tests/errors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { CloudErrorCode, CloudErrorDetails } from '../src/index.js';
+import { CloudError, isCloudError } from '../src/index.js';
+
+describe('CloudError', () => {
+  it('exposes the code and message and defaults details to undefined', () => {
+    const err = new CloudError('NOT_FOUND', 'cloud session not found: abc');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('CloudError');
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.message).toBe('cloud session not found: abc');
+    expect(err.details).toBeUndefined();
+  });
+
+  it('carries typed cap-exceeded details', () => {
+    const details: CloudErrorDetails = { running: 3, cap: 3 };
+    const err = new CloudError('CAP_EXCEEDED', 'at running cap (3/3)', details);
+    expect(err.details).toEqual({ running: 3, cap: 3 });
+  });
+
+  it('accepts a paused-cap details shape', () => {
+    const err = new CloudError('CAP_EXCEEDED', 'at paused cap (5/5)', { paused: 5, cap: 5 });
+    expect(err.details).toEqual({ paused: 5, cap: 5 });
+  });
+});
+
+describe('isCloudError', () => {
+  it('narrows a CloudError instance', () => {
+    const err: unknown = new CloudError('INTERNAL', 'boom');
+    expect(isCloudError(err)).toBe(true);
+    if (isCloudError(err)) {
+      const code: CloudErrorCode = err.code;
+      expect(code).toBe('INTERNAL');
+    }
+  });
+
+  it('rejects a plain Error and non-error values', () => {
+    expect(isCloudError(new Error('nope'))).toBe(false);
+    expect(isCloudError('CAP_EXCEEDED')).toBe(false);
+    expect(isCloudError(null)).toBe(false);
+    expect(isCloudError(undefined)).toBe(false);
+  });
+});

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -5,7 +5,6 @@
   "packages/chrome-extension/src/bridge-sw.ts": 17,
   "packages/chrome-extension/src/secrets-storage.ts": 3,
   "packages/cloud-core/src/cone-config/index.ts": 6,
-  "packages/cloud-core/src/errors.ts": 1,
   "packages/cloudflare-worker/src/cloud/handlers.ts": 1,
   "packages/cloudflare-worker/src/flags.ts": 2,
   "packages/cloudflare-worker/src/index.ts": 3,


### PR DESCRIPTION
## Boy-scout debt cleanup — `packages/cloud-core/src/errors.ts`

Pays down the boy-scout debt on this one file so it is clean from every debt rule, in a single focused PR.

### Debt list cleared

**`record-string-unknown` (untyped string-keyed bags)**
- Replaced the untyped `Record<string, unknown>` on `CloudError.details` with a named `CloudErrorDetails` interface describing the shape cloud-core actually attaches:
  - `running?`, `paused?`, `cap?` — set at the two `CAP_EXCEEDED` throw sites in `operations/start.ts`.
  - `sandboxId?` — set at the `SANDBOX_NOT_READY` throw site in `operations/start.ts`.
- `CloudErrorDetails` is a structural subset of the worker's existing local `CloudErrorDetails` (`cloudflare-worker/src/cloud/error-envelope.ts`), so `err.details` remains assignable everywhere the worker forwards it via `errorResponse`.
- Ratcheted the baseline with the supported command `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`; the only change is the removal of the `packages/cloud-core/src/errors.ts` entry (`-1`). No other baseline entry was touched.

### Behaviour

Behaviour-preserving: the new type is a compile-time refinement only. `CloudError`'s runtime shape (code, message, `details` payload) is unchanged, and the `details` objects constructed at every throw site already match the named fields.

### Tests

Added `packages/cloud-core/tests/errors.test.ts` (mirrors `src/errors.ts`) pinning:
- `CloudError` code/message/name and default-`undefined` details,
- the typed running-cap and paused-cap `details` shapes,
- `isCloudError` narrowing and its rejection of plain errors and non-error values.

### Verification

- `npx biome check --write` on the touched files — clean.
- `npm run typecheck` — passes.
- `npx vitest run packages/cloud-core/tests/errors.test.ts packages/cloud-core/tests/start.test.ts` — 16 passed.
- `npm run test:coverage:cloud-core` — passes, coverage floor held.
- `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — `OK (2 changed file(s), 0 still on any debt list)`.
- `npm run verify` — all 7 lint-gate checks passed.

### Confirmation

No exemption, `biome.json` override, `biome-ignore`/`eslint-disable` suppression, new baseline entry, threshold relaxation, or unsafe cast was added. The `record-string-unknown-baseline.json` change is solely the removal of the now-clean `packages/cloud-core/src/errors.ts` entry via the `--update` command.
