### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/mcp/redirect-uri.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -13,7 +13,6 @@
   "packages/webapp/src/scoops/sprinkle-bridge-channel.ts": 2,
   "packages/webapp/src/scoops/sprinkle-manager-proxy.ts": 1,
   "packages/webapp/src/shell/bsh-watchdog.ts": 3,
-  "packages/webapp/src/shell/mcp/redirect-uri.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/cherry-emit-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/crontask-command.ts": 6,
   "packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts": 1,

--- a/packages/webapp/src/shell/mcp/redirect-uri.ts
+++ b/packages/webapp/src/shell/mcp/redirect-uri.ts
@@ -1,4 +1,4 @@
-import { resolveFloatTopology } from '../../core/float-topology.js';
+import { resolveFloatTopology } from '../float-topology.js';
 
 /** Hosted callback that treats MCP OAuth `state` as an opaque value. */
 export const MCP_HOSTED_CALLBACK_PATH = '/auth/mcp-callback';

--- a/packages/webapp/tests/shell/mcp/redirect-uri.test.ts
+++ b/packages/webapp/tests/shell/mcp/redirect-uri.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mocked collaborators of resolveMcpRedirectUri. The module resolves topology
+// from the shell layer and lazily imports the proxied-fetch / oauth-service
+// helpers, so each branch is exercised by controlling these returns.
+const resolveFloatTopology = vi.fn();
+const getLocalApiBaseUrl = vi.fn();
+const getOAuthPageOrigin = vi.fn();
+
+vi.mock('../../../src/shell/float-topology.js', () => ({
+  resolveFloatTopology: () => resolveFloatTopology(),
+}));
+vi.mock('../../../src/shell/proxied-fetch.js', () => ({
+  getLocalApiBaseUrl: () => getLocalApiBaseUrl(),
+}));
+vi.mock('../../../src/providers/oauth-service.js', () => ({
+  getOAuthPageOrigin: () => getOAuthPageOrigin(),
+}));
+
+import {
+  MCP_HOSTED_CALLBACK_PATH,
+  resolveMcpRedirectUri,
+} from '../../../src/shell/mcp/redirect-uri.js';
+
+describe('resolveMcpRedirectUri', () => {
+  const originalChrome = (globalThis as { chrome?: unknown }).chrome;
+
+  beforeEach(() => {
+    resolveFloatTopology.mockReset();
+    getLocalApiBaseUrl.mockReset();
+    getOAuthPageOrigin.mockReset();
+  });
+
+  afterEach(() => {
+    (globalThis as { chrome?: unknown }).chrome = originalChrome;
+  });
+
+  it('uses chrome.identity.getRedirectURL for extension-direct', async () => {
+    resolveFloatTopology.mockReturnValue('extension-direct');
+    (globalThis as { chrome?: unknown }).chrome = {
+      identity: { getRedirectURL: (path?: string) => `https://ext-id.chromiumapp.org/${path}` },
+    };
+    expect(await resolveMcpRedirectUri()).toBe('https://ext-id.chromiumapp.org/mcp-callback');
+  });
+
+  it('falls back to runtime.id origin when identity API is unavailable', async () => {
+    resolveFloatTopology.mockReturnValue('extension-direct');
+    (globalThis as { chrome?: unknown }).chrome = { runtime: { id: 'abc123' } };
+    expect(await resolveMcpRedirectUri()).toBe('https://abc123.chromiumapp.org/mcp-callback');
+  });
+
+  it('uses the local API origin for node-rest when present', async () => {
+    resolveFloatTopology.mockReturnValue('node-rest');
+    getLocalApiBaseUrl.mockReturnValue('http://localhost:5710');
+    expect(await resolveMcpRedirectUri()).toBe('http://localhost:5710/auth/callback');
+  });
+
+  it('falls back to the OAuth page origin when node-rest has no local API', async () => {
+    resolveFloatTopology.mockReturnValue('node-rest');
+    getLocalApiBaseUrl.mockReturnValue('');
+    getOAuthPageOrigin.mockResolvedValue({ origin: 'https://hosted.example' });
+    expect(await resolveMcpRedirectUri()).toBe('https://hosted.example/auth/callback');
+  });
+
+  it('uses the hosted MCP callback path for extension-delegate', async () => {
+    resolveFloatTopology.mockReturnValue('extension-delegate');
+    getOAuthPageOrigin.mockResolvedValue({ origin: 'https://hosted.example' });
+    expect(await resolveMcpRedirectUri()).toBe(`https://hosted.example${MCP_HOSTED_CALLBACK_PATH}`);
+  });
+
+  it('uses the plain callback path for connect topology', async () => {
+    resolveFloatTopology.mockReturnValue('connect');
+    getOAuthPageOrigin.mockResolvedValue({ origin: 'https://hosted.example' });
+    expect(await resolveMcpRedirectUri()).toBe('https://hosted.example/auth/callback');
+  });
+});


### PR DESCRIPTION
## Boy-scout debt cleanup: `packages/webapp/src/shell/mcp/redirect-uri.ts`

Pays down the sole debt entry for this file so it is clean from every debt rule.

### Debt list cleared

**layer-back-edge** (`packages/dev-tools/tools/layer-back-edge-baseline.json`)
- The file imported `resolveFloatTopology` from `../../core/float-topology.js` — an up-the-stack edge (shell → core) that the layer ratchet grandfathered with a count of 1.
- `core/float-topology.ts` is only a back-compat re-export of the canonical `shell/float-topology.js`. Since `redirect-uri.ts` lives in `shell/mcp/`, the import now points directly at the shell-layer module (`../float-topology.js`), removing the back-edge entirely.
- Ratcheted the baseline with the supported command `node packages/dev-tools/tools/check-layer-back-edges.mjs --update`, which dropped the file's entry (never hand-edited).

### Behaviour

Behaviour-preserving: the imported symbol is identical (the removed module re-exports it verbatim); only the import path changed to a lower layer. No observable behaviour changed.

### Tests

Added `packages/webapp/tests/shell/mcp/redirect-uri.test.ts` pinning every topology branch of `resolveMcpRedirectUri` (extension-direct with and without the identity API, node-rest with/without a local API origin, extension-delegate hosted callback, and connect) — the behaviour the refactor preserves.

### Verification

- `npx biome check --write` on the touched files — clean
- `npm run typecheck` — pass
- `npx vitest run packages/webapp/tests/shell/mcp/redirect-uri.test.ts` — 6/6 pass
- `npm run verify` — all 7 checks pass (incl. `boy-scout-debt`)
- `check-touched-exemptions.mjs origin/main` — OK, 0 files still on any debt list
- `check-layer-back-edges.mjs` — no new back-edges; the file is no longer baselined

No exemption, `biome-ignore`/`eslint-disable` suppression, baseline entry, unsafe cast, or threshold/coverage relaxation was added. No unrelated cleanup was bundled.
