### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -96,7 +96,7 @@
     "cloud-core": {
       "lines": 85,
       "statements": 83,
-      "functions": 76,
+      "functions": 77,
       "branches": 77,
       "coverageExclude": [
         "**/node_modules/**",


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.