### PR TITLE
refactor(cloud-core): extract shared poll-join-file loop in polling.ts

### DIFF
--- a/packages/cloud-core/src/polling.ts
+++ b/packages/cloud-core/src/polling.ts
@@ -1,3 +1,4 @@
+import type { CloudErrorCode } from './errors.js';
 import { CloudError } from './errors.js';
 import type { SandboxHandle } from './substrate.js';
 import type { CloudStatus } from './types.js';
@@ -16,45 +17,28 @@ export interface PollOpts {
   minUpdatedAt?: string;
 }
 
-export async function pollCloudStatus(handle: SandboxHandle, opts: PollOpts): Promise<CloudStatus> {
-  const start = Date.now();
-  let lastError: unknown = null;
-  let lastStalePayload: CloudStatus | null = null;
-  while (Date.now() - start < opts.timeoutMs) {
-    try {
-      const raw = await handle.readFile('/tmp/slicc-join.json');
-      const parsed = JSON.parse(raw) as CloudStatus;
-      if (parsed.joinUrl) {
-        if (!opts.minUpdatedAt) return parsed;
-        if (parsed.updatedAt && parsed.updatedAt > opts.minUpdatedAt) return parsed;
-        lastStalePayload = parsed;
-      }
-    } catch (err) {
-      lastError = err;
-    }
-    await new Promise((r) => setTimeout(r, opts.intervalMs));
-  }
-  let errSuffix = '';
-  if (lastStalePayload) {
-    errSuffix =
-      ` (file present but stale: minUpdatedAt=${opts.minUpdatedAt}, ` +
-      `current.updatedAt=${lastStalePayload.updatedAt}, ` +
-      `current.trayId=${lastStalePayload.trayId})`;
-  } else if (lastError) {
-    errSuffix = ` (last error: ${lastError instanceof Error ? lastError.message : String(lastError)})`;
-  } else {
-    errSuffix = ' (file never appeared)';
-  }
-  throw new CloudError(
-    'SANDBOX_NOT_READY',
-    `cloud-status did not appear within ${opts.timeoutMs}ms; sandbox may have failed to boot${errSuffix}`
-  );
-}
-
-export async function pollForRefreshedStatus(
+/**
+ * Shared poll-until-ready loop behind {@link pollCloudStatus} and
+ * {@link pollForRefreshedStatus}. Repeatedly reads `/tmp/slicc-join.json`
+ * until it parses to a payload with a `joinUrl` whose `updatedAt` is strictly
+ * newer than `floor` (or any well-formed read when `floor` is unset), then
+ * returns it. On timeout it throws a {@link CloudError} that distinguishes
+ * stale-but-present, last-read-error, and never-appeared cases.
+ *
+ * The two exports differ only in the freshness floor's source, the error
+ * code, and two label strings — captured here as `errorCode`, `floorLabel`,
+ * and `timeoutMessage` so the loop itself has a single source of truth.
+ */
+async function pollJoinFile(
   handle: SandboxHandle,
-  baselineUpdatedAt: string | undefined,
-  opts: PollOpts
+  opts: {
+    timeoutMs: number;
+    intervalMs: number;
+    floor: string | undefined;
+    floorLabel: string;
+    errorCode: CloudErrorCode;
+    timeoutMessage: (ms: number, errSuffix: string) => string;
+  }
 ): Promise<CloudStatus> {
   const start = Date.now();
   let lastError: unknown = null;
@@ -64,15 +48,14 @@ export async function pollForRefreshedStatus(
       const raw = await handle.readFile('/tmp/slicc-join.json');
       const parsed = JSON.parse(raw) as CloudStatus;
       if (parsed.joinUrl) {
-        // Require a STRICTLY newer updatedAt than the registry baseline.
-        // If we have no baseline (first-time resume of an externally-created
-        // sandbox), accept any well-formed read.
-        if (!baselineUpdatedAt) return parsed;
-        if (parsed.updatedAt && parsed.updatedAt > baselineUpdatedAt) {
-          return parsed;
-        }
-        // File exists, joinUrl present, but updatedAt unchanged — capture for
-        // the timeout error so we can tell "missing" from "stale".
+        // Require a STRICTLY newer updatedAt than the freshness floor.
+        // If we have no floor (CLI legacy start, or first-time resume of an
+        // externally-created sandbox), accept any well-formed read.
+        if (!opts.floor) return parsed;
+        if (parsed.updatedAt && parsed.updatedAt > opts.floor) return parsed;
+        // File exists, joinUrl present, but updatedAt not newer than the
+        // floor — capture for the timeout error so we can tell "missing"
+        // from "stale".
         lastStalePayload = parsed;
       }
     } catch (err) {
@@ -83,7 +66,7 @@ export async function pollForRefreshedStatus(
   let errSuffix = '';
   if (lastStalePayload) {
     errSuffix =
-      ` (file present but stale: baseline.updatedAt=${baselineUpdatedAt}, ` +
+      ` (file present but stale: ${opts.floorLabel}=${opts.floor}, ` +
       `current.updatedAt=${lastStalePayload.updatedAt}, ` +
       `current.trayId=${lastStalePayload.trayId})`;
   } else if (lastError) {
@@ -91,8 +74,32 @@ export async function pollForRefreshedStatus(
   } else {
     errSuffix = ' (file never appeared)';
   }
-  throw new CloudError(
-    'LEADER_NOT_READY',
-    `cloud-status did not refresh within ${opts.timeoutMs}ms${errSuffix}`
-  );
+  throw new CloudError(opts.errorCode, opts.timeoutMessage(opts.timeoutMs, errSuffix));
+}
+
+export async function pollCloudStatus(handle: SandboxHandle, opts: PollOpts): Promise<CloudStatus> {
+  return pollJoinFile(handle, {
+    timeoutMs: opts.timeoutMs,
+    intervalMs: opts.intervalMs,
+    floor: opts.minUpdatedAt,
+    floorLabel: 'minUpdatedAt',
+    errorCode: 'SANDBOX_NOT_READY',
+    timeoutMessage: (ms, errSuffix) =>
+      `cloud-status did not appear within ${ms}ms; sandbox may have failed to boot${errSuffix}`,
+  });
+}
+
+export async function pollForRefreshedStatus(
+  handle: SandboxHandle,
+  baselineUpdatedAt: string | undefined,
+  opts: PollOpts
+): Promise<CloudStatus> {
+  return pollJoinFile(handle, {
+    timeoutMs: opts.timeoutMs,
+    intervalMs: opts.intervalMs,
+    floor: baselineUpdatedAt,
+    floorLabel: 'baseline.updatedAt',
+    errorCode: 'LEADER_NOT_READY',
+    timeoutMessage: (ms, errSuffix) => `cloud-status did not refresh within ${ms}ms${errSuffix}`,
+  });
 }

--- a/packages/cloud-core/tests/polling.test.ts
+++ b/packages/cloud-core/tests/polling.test.ts
@@ -27,7 +27,16 @@ function makeReadSequenceHandle(reads: Array<string | Error>): {
   return { handle, readCount: () => i };
 }
 
-const FAST_OPTS = { timeoutMs: 40, intervalMs: 1 };
+/**
+ * Deadline for tests that expect the poll to *succeed*. It is never actually
+ * reached (the fixture serves an acceptable read on the first or second pass),
+ * so a generous value costs nothing while keeping the outcome independent of
+ * how long a contended CI worker stalls the event loop between reads.
+ */
+const SUCCESS_OPTS = { timeoutMs: 2_000, intervalMs: 1 };
+
+/** Deadline for tests that expect the poll to time out; always reached. */
+const TIMEOUT_OPTS = { timeoutMs: 40, intervalMs: 1 };
 
 describe('pollCloudStatus', () => {
   it('returns any well-formed read when no minUpdatedAt floor is set', async () => {
@@ -37,7 +46,7 @@ describe('pollCloudStatus', () => {
       updatedAt: '2026-01-01T00:00:00.000Z',
     };
     const { handle } = makeReadSequenceHandle([JSON.stringify(payload)]);
-    await expect(pollCloudStatus(handle, FAST_OPTS)).resolves.toMatchObject(payload);
+    await expect(pollCloudStatus(handle, SUCCESS_OPTS)).resolves.toMatchObject(payload);
   });
 
   it('rejects a read whose updatedAt is not strictly newer than minUpdatedAt, then accepts a fresh one', async () => {
@@ -56,7 +65,7 @@ describe('pollCloudStatus', () => {
       JSON.stringify(fresh),
     ]);
     await expect(
-      pollCloudStatus(handle, { ...FAST_OPTS, minUpdatedAt: '2026-01-01T00:00:01.000Z' })
+      pollCloudStatus(handle, { ...SUCCESS_OPTS, minUpdatedAt: '2026-01-01T00:00:01.000Z' })
     ).resolves.toMatchObject(fresh);
     expect(readCount()).toBeGreaterThan(1); // proves the stale read was rejected
   });
@@ -69,7 +78,7 @@ describe('pollCloudStatus', () => {
     };
     const { handle } = makeReadSequenceHandle([JSON.stringify(stale)]);
     await expect(
-      pollCloudStatus(handle, { ...FAST_OPTS, minUpdatedAt: '2026-01-01T00:00:01.000Z' })
+      pollCloudStatus(handle, { ...TIMEOUT_OPTS, minUpdatedAt: '2026-01-01T00:00:01.000Z' })
     ).rejects.toMatchObject({
       name: 'CloudError',
       code: 'SANDBOX_NOT_READY',
@@ -79,7 +88,7 @@ describe('pollCloudStatus', () => {
 
   it('throws SANDBOX_NOT_READY with "file never appeared" when reads keep failing', async () => {
     const { handle } = makeReadSequenceHandle([new Error('ENOENT /tmp/slicc-join.json')]);
-    await expect(pollCloudStatus(handle, FAST_OPTS)).rejects.toMatchObject({
+    await expect(pollCloudStatus(handle, TIMEOUT_OPTS)).rejects.toMatchObject({
       code: 'SANDBOX_NOT_READY',
       message: expect.stringContaining('last error: ENOENT /tmp/slicc-join.json'),
     });
@@ -94,7 +103,7 @@ describe('pollForRefreshedStatus', () => {
       updatedAt: '2026-01-01T00:00:00.000Z',
     };
     const { handle } = makeReadSequenceHandle([JSON.stringify(payload)]);
-    await expect(pollForRefreshedStatus(handle, undefined, FAST_OPTS)).resolves.toMatchObject(
+    await expect(pollForRefreshedStatus(handle, undefined, SUCCESS_OPTS)).resolves.toMatchObject(
       payload
     );
   });
@@ -112,7 +121,7 @@ describe('pollForRefreshedStatus', () => {
     };
     const { handle } = makeReadSequenceHandle([JSON.stringify(stale), JSON.stringify(fresh)]);
     await expect(
-      pollForRefreshedStatus(handle, '2026-05-01T12:00:00.000Z', FAST_OPTS)
+      pollForRefreshedStatus(handle, '2026-05-01T12:00:00.000Z', SUCCESS_OPTS)
     ).resolves.toMatchObject(fresh);
   });
 
@@ -120,7 +129,7 @@ describe('pollForRefreshedStatus', () => {
     const baseline = '2026-05-01T12:00:00.000Z';
     const stale = { joinUrl: 'https://w/join/stale', trayId: 't-stale', updatedAt: baseline };
     const { handle } = makeReadSequenceHandle([JSON.stringify(stale)]);
-    await expect(pollForRefreshedStatus(handle, baseline, FAST_OPTS)).rejects.toMatchObject({
+    await expect(pollForRefreshedStatus(handle, baseline, TIMEOUT_OPTS)).rejects.toMatchObject({
       name: 'CloudError',
       code: 'LEADER_NOT_READY',
       message: expect.stringContaining(`baseline.updatedAt=${baseline}`),
@@ -129,7 +138,7 @@ describe('pollForRefreshedStatus', () => {
 
   it('throws LEADER_NOT_READY with "did not refresh" on a never-appearing file', async () => {
     const { handle } = makeReadSequenceHandle([new Error('boom')]);
-    await expect(pollForRefreshedStatus(handle, undefined, FAST_OPTS)).rejects.toMatchObject({
+    await expect(pollForRefreshedStatus(handle, undefined, TIMEOUT_OPTS)).rejects.toMatchObject({
       code: 'LEADER_NOT_READY',
       message: expect.stringContaining('did not refresh within'),
     });

--- a/packages/cloud-core/tests/polling.test.ts
+++ b/packages/cloud-core/tests/polling.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { pollCloudStatus, pollForRefreshedStatus } from '../src/polling.js';
+import type { SandboxHandle } from '../src/substrate.js';
+import { makeFakeHandle } from './fixtures/fake-substrate.js';
+
+/**
+ * Build a handle whose /tmp/slicc-join.json read returns each entry of
+ * `reads` in turn (last entry sticks). A `string` is returned verbatim;
+ * an `Error` is thrown for that read.
+ */
+function makeReadSequenceHandle(reads: Array<string | Error>): {
+  handle: SandboxHandle;
+  readCount: () => number;
+} {
+  let i = 0;
+  const base = makeFakeHandle();
+  const handle: SandboxHandle = {
+    ...base,
+    readFile: async (path: string): Promise<string> => {
+      if (path !== '/tmp/slicc-join.json') throw new Error(`ENOENT ${path}`);
+      const entry = reads[Math.min(i, reads.length - 1)];
+      i += 1;
+      if (entry instanceof Error) throw entry;
+      return entry;
+    },
+  };
+  return { handle, readCount: () => i };
+}
+
+const FAST_OPTS = { timeoutMs: 40, intervalMs: 1 };
+
+describe('pollCloudStatus', () => {
+  it('returns any well-formed read when no minUpdatedAt floor is set', async () => {
+    const payload = {
+      joinUrl: 'https://w/join/x',
+      trayId: 't1',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const { handle } = makeReadSequenceHandle([JSON.stringify(payload)]);
+    await expect(pollCloudStatus(handle, FAST_OPTS)).resolves.toMatchObject(payload);
+  });
+
+  it('rejects a read whose updatedAt is not strictly newer than minUpdatedAt, then accepts a fresh one', async () => {
+    const stale = {
+      joinUrl: 'https://w/join/stale',
+      trayId: 't-stale',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const fresh = {
+      joinUrl: 'https://w/join/fresh',
+      trayId: 't-fresh',
+      updatedAt: '2026-01-01T00:00:02.000Z',
+    };
+    const { handle, readCount } = makeReadSequenceHandle([
+      JSON.stringify(stale),
+      JSON.stringify(fresh),
+    ]);
+    await expect(
+      pollCloudStatus(handle, { ...FAST_OPTS, minUpdatedAt: '2026-01-01T00:00:01.000Z' })
+    ).resolves.toMatchObject(fresh);
+    expect(readCount()).toBeGreaterThan(1); // proves the stale read was rejected
+  });
+
+  it('throws SANDBOX_NOT_READY with a stale suffix labelled minUpdatedAt on timeout', async () => {
+    const stale = {
+      joinUrl: 'https://w/join/stale',
+      trayId: 't-stale',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const { handle } = makeReadSequenceHandle([JSON.stringify(stale)]);
+    await expect(
+      pollCloudStatus(handle, { ...FAST_OPTS, minUpdatedAt: '2026-01-01T00:00:01.000Z' })
+    ).rejects.toMatchObject({
+      name: 'CloudError',
+      code: 'SANDBOX_NOT_READY',
+      message: expect.stringContaining('minUpdatedAt=2026-01-01T00:00:01.000Z'),
+    });
+  });
+
+  it('throws SANDBOX_NOT_READY with "file never appeared" when reads keep failing', async () => {
+    const { handle } = makeReadSequenceHandle([new Error('ENOENT /tmp/slicc-join.json')]);
+    await expect(pollCloudStatus(handle, FAST_OPTS)).rejects.toMatchObject({
+      code: 'SANDBOX_NOT_READY',
+      message: expect.stringContaining('last error: ENOENT /tmp/slicc-join.json'),
+    });
+  });
+});
+
+describe('pollForRefreshedStatus', () => {
+  it('returns any well-formed read when baselineUpdatedAt is undefined', async () => {
+    const payload = {
+      joinUrl: 'https://w/join/x',
+      trayId: 't1',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    const { handle } = makeReadSequenceHandle([JSON.stringify(payload)]);
+    await expect(pollForRefreshedStatus(handle, undefined, FAST_OPTS)).resolves.toMatchObject(
+      payload
+    );
+  });
+
+  it('requires a strictly newer updatedAt than the baseline', async () => {
+    const stale = {
+      joinUrl: 'https://w/join/stale',
+      trayId: 't-stale',
+      updatedAt: '2026-05-01T12:00:00.000Z',
+    };
+    const fresh = {
+      joinUrl: 'https://w/join/fresh',
+      trayId: 't-fresh',
+      updatedAt: '2026-05-01T12:00:05.000Z',
+    };
+    const { handle } = makeReadSequenceHandle([JSON.stringify(stale), JSON.stringify(fresh)]);
+    await expect(
+      pollForRefreshedStatus(handle, '2026-05-01T12:00:00.000Z', FAST_OPTS)
+    ).resolves.toMatchObject(fresh);
+  });
+
+  it('throws LEADER_NOT_READY with a stale suffix labelled baseline.updatedAt on timeout', async () => {
+    const baseline = '2026-05-01T12:00:00.000Z';
+    const stale = { joinUrl: 'https://w/join/stale', trayId: 't-stale', updatedAt: baseline };
+    const { handle } = makeReadSequenceHandle([JSON.stringify(stale)]);
+    await expect(pollForRefreshedStatus(handle, baseline, FAST_OPTS)).rejects.toMatchObject({
+      name: 'CloudError',
+      code: 'LEADER_NOT_READY',
+      message: expect.stringContaining(`baseline.updatedAt=${baseline}`),
+    });
+  });
+
+  it('throws LEADER_NOT_READY with "did not refresh" on a never-appearing file', async () => {
+    const { handle } = makeReadSequenceHandle([new Error('boom')]);
+    await expect(pollForRefreshedStatus(handle, undefined, FAST_OPTS)).rejects.toMatchObject({
+      code: 'LEADER_NOT_READY',
+      message: expect.stringContaining('did not refresh within'),
+    });
+  });
+});


### PR DESCRIPTION
Closes #2183

## What

`packages/cloud-core/src/polling.ts` had two exported functions —
`pollCloudStatus` and `pollForRefreshedStatus` — that were ~90%-identical
copies of the same poll-until-ready loop over `/tmp/slicc-join.json`. They
differed only in three details: where the freshness floor comes from
(`opts.minUpdatedAt` vs the positional `baselineUpdatedAt`), the `CloudError`
code (`SANDBOX_NOT_READY` vs `LEADER_NOT_READY`), and two label/message
strings.

This change folds the shared loop into a single private `pollJoinFile` helper
parameterized by `floor`, `floorLabel`, `errorCode`, and a `timeoutMessage`
builder. The two exports become thin wrappers over it. Public signatures are
unchanged, and so is all observable behavior:

- strict-newer (`>`) freshness comparison, with the "no floor ⇒ accept any
  well-formed read" branch;
- the three-branch timeout suffix (stale / last-error / never-appeared), with
  the same `minUpdatedAt=` vs `baseline.updatedAt=` labels;
- the same two error codes and timeout messages.

The freshness/timeout/error logic now has a single source of truth, so future
changes (AbortSignal support, interval jitter, `>` vs `>=` semantics, error
contract tweaks) can no longer silently drift between the two paths.

## Why

Flagged as Complicatification debt (see the issue). The freshness-comparison
semantics are load-bearing per `packages/cloud-core/CLAUDE.md` → "Stable
Contracts" → `ConeEntry.trayId and lastJoinUpdatedAt`, so duplicated drift here
is a correctness risk, not just cosmetic.

## How verified

- New focused test `packages/cloud-core/tests/polling.test.ts` (8 tests) pins
  both wrappers: no-floor acceptance, strict-newer rejection-then-accept, and
  each timeout error (stale suffix + label, last-error suffix, and the distinct
  `SANDBOX_NOT_READY` / `LEADER_NOT_READY` codes and messages).
- Existing `start.test.ts` (11) and `resume.test.ts` (11) still pass — the two
  callers are unchanged.
- `npm run verify` (lint gate, 7/7), `npm run typecheck`,
  `npm run test:coverage:cloud-core` (116 tests; `polling.ts` at 100%
  statements/functions/lines), and the touched-file exemptions gate all pass.
