### PR TITLE
feat(slicc-cli): give follow/watch a live status bar and silence pion's stderr

### DIFF
--- a/docs/slicc-cli-details.md
+++ b/docs/slicc-cli-details.md
@@ -83,7 +83,10 @@ console): raw ANSI, ~4 files.
   are zero cells, the East Asian wide/fullwidth blocks and the emoji blocks are
   two, everything else one. `visibleWidth` sums those (skipping escapes) and
   `truncateVisible` drops a double-wide rune rather than splitting it, since half
-  a cell is what makes a terminal wrap.
+  a cell is what makes a terminal wrap. The bar is clamped twice — per field in
+  `joinSegments` and as a whole in `render` — because "ambiguous width"
+  characters in a hostname or runner can still be undercounted, and a bar that
+  wraps pushes the log up on every repaint.
 - **Events** — `Line` stamps and marks the first row and indents continuation
   rows (`│ …`), so a multi-line error reads as one event. An identical
   consecutive event is folded in place with a `(×3)` counter; one that cannot be
@@ -114,7 +117,14 @@ the CLI's output under `turnc ERROR: Fail to refresh permissions: …` walls tha
 no `SLICC_LOG_LEVEL` can quiet. Routed through the factory they become ordinary
 diagnostics (silent by default, back with `SLICC_DEBUG=1`), and
 `Options.OnLinkDiag` tallies the warn-and-above ones into the status bar's
-`link ⚠ N` field. `Options.OnActivity` feeds the `♥ <age>` field and fires on
+`link ⚠ N` field — that tap only sees **warn and above**, since everything below
+is pion's per-packet commentary. Formatting is gated on the same question:
+`Options.LogWanted` (wired to `diagLogger.EnabledAt`) lets the adapter drop a
+trace record before `Sprintf` touches it, because `Logf` in this binary is always
+a live closure over a logger that is usually disabled — without the predicate,
+every STUN packet would be formatted just to be thrown away.
+
+`Options.OnActivity` feeds the `♥ <age>` field and fires on
 **every** inbound frame, not just keepalives: the leader _answers_ pings
 (`tray-follower-sync.ts` is the pinger, `LEADER_TRAY_PING_INTERVAL_MS` is the
 signaling socket's keepalive, not a data-channel ping), so a follower watching

--- a/docs/slicc-cli-details.md
+++ b/docs/slicc-cli-details.md
@@ -19,7 +19,8 @@ authoritative command list, safety rules, env-var and Makefile references.
 | `update.go`           | `cmdUpdate` + on-launch update-notice hook                                           |
 | `telemetry.go`        | `initTelemetry`/`reportRuntimeError` — RUM via `@ai-ecoverse/go-optel`               |
 | `internal/update/`    | Release discovery (sparse scan) + self-update apply + cached notice                  |
-| `internal/logging/`   | `log/slog` diagnostic logger + `Logf` adapter for the `tray` seam                    |
+| `internal/logging/`   | `log/slog` diagnostic logger + `Logf` adapter for the `tray` seam + pion factory     |
+| `internal/ui/`        | Terminal presentation: capability detection, event lines, sticky status bar          |
 
 ## `watch` rendering
 
@@ -28,6 +29,79 @@ sends nothing and renders the human's prompt (`user_message_echo` → `> …`),
 assistant text (`content_delta`), and tool calls (`tool_use_start` → `⚙ …`,
 `tool_result` → `↳ …`), blanking a line at each turn boundary — reconnecting
 with backoff (`cmdWatch`/`watchOnce`; `printWatchEvent` does the rendering).
+
+Glyphs and wording on stdout are **literal, not mode-dependent** — the stream is
+a transcript other tools grep (`cli_e2e_test.go` asserts `> <text>` and
+`⚙ <tool>`); only the color varies, and only when stdout itself is a terminal.
+
+## Terminal presentation (`internal/ui`)
+
+`internal/ui` is the CLI's presentation layer for the long-running verbs. No
+dependencies beyond the stdlib and `golang.org/x/sys` (winsize ioctl / Windows
+console): raw ANSI, ~4 files.
+
+- **Capability detection** (`Detect`) — resolves a `Mode{Color, Sticky, Unicode}`
+  per stream. `Sticky` (cursor movement) requires a character device **that also
+  answers a window-size query**, because `/dev/null` is a character device too.
+  `Unicode` is inferred from `LC_ALL`/`LC_CTYPE`/`LANG` (plus `WT_SESSION`), and
+  a false negative matters: mojibake on a legacy code page breaks the bar's
+  width accounting, so every glyph has an ASCII twin. Windows opts the console
+  into `ENABLE_VIRTUAL_TERMINAL_PROCESSING` and falls back to plain output if
+  the console refuses.
+- **Plain mode is the contract.** With no terminal (pipe, file, CI) the console
+  writes `"<tag>: <msg>"` — byte-for-byte what the CLI emitted before this
+  package existed, newlines inside a message included, with no repeat
+  collapsing (a redirected stream is someone's log; every occurrence belongs in
+  it). Without the bar the same one-line form is used, colored when the stream
+  can take it — `Paint` is a no-op without color, so redirected bytes are
+  unchanged either way. `--plain` and `SLICC_NO_TUI=1` force plain; `NO_COLOR`
+  keeps the bar but drops color; `FORCE_COLOR`/`CLICOLOR_FORCE` colors a
+  redirected stream but never makes it sticky.
+- **Sticky status bar** — one repainted line below the log: state badge
+  (spinner while connecting, live countdown while waiting to retry), uptime,
+  time since the last frame from the leader (green→yellow→red as it ages), exec
+  count, reconnect count, suppressed link diagnostics, `user@host · runner`, and
+  a 16-cell history strip whose cells hold the **worst** state seen per 5 s
+  bucket. Fields are laid out most-important-first and any that no longer fits
+  is _skipped_, not treated as the end of the line — otherwise one long hostname
+  on a narrow pane would hide the short fields behind it. Width is re-queried
+  per repaint, so a resize needs no SIGWINCH handler. Only `follow` gets the
+  bar unconditionally: `watch` streams the transcript to stdout in partial
+  lines, so when stdout is a terminal too it keeps the colors and drops the bar
+  rather than let the two fight over the last row. Deliberately **no alternate screen buffer and no scroll regions**:
+  output still scrolls back normally and a killed process leaves a usable
+  terminal. Repaints from state changes are throttled (80 ms); the 1 s ticker
+  catches up.
+- **Events** — `Line` stamps and marks the first row and indents continuation
+  rows (`│ …`), so a multi-line error reads as one event. An identical
+  consecutive event is folded in place with a `(×3)` counter; one too tall
+  (> 6 rows) or too wide to rewrite safely — a soft-wrapped row invalidates the
+  cursor walk — keeps its detail on screen once and collapses into a single
+  `↺ repeated (×N)` row instead. `Note` prints **only** in plain mode, for
+  information the bar already carries live (the reconnect wait): duplicating it
+  would also interleave the identical errors and defeat the collapsing.
+- **Seams** — `LineWriter(kind)` adapts the console to an `io.Writer` so
+  `follow.Session`'s per-command log needs no console awareness (it writes a
+  bare `exec: <command>`; the console owns the prefix). `Raw` writes verbatim,
+  for the banner, whose wording must not vary with the output stream.
+
+### pion's own logging
+
+`Conn.pionLoggerFactory` (`internal/tray/conn.go`) installs
+`logging.PionFactory` on `SettingEngine.LoggerFactory`. This is load-bearing:
+left nil, webrtc installs `pion/logging.NewDefaultLoggerFactory()`, which writes
+**error records straight to `os.Stderr`** — a flaky TURN allocation then buries
+the CLI's output under `turnc ERROR: Fail to refresh permissions: …` walls that
+no `SLICC_LOG_LEVEL` can quiet. Routed through the factory they become ordinary
+diagnostics (silent by default, back with `SLICC_DEBUG=1`), and
+`Options.OnLinkDiag` tallies the warn-and-above ones into the status bar's
+`link ⚠ N` field. `Options.OnActivity` feeds the `♥ <age>` field and fires on
+**every** inbound frame, not just keepalives: the leader _answers_ pings
+(`tray-follower-sync.ts` is the pinger, `LEADER_TRAY_PING_INTERVAL_MS` is the
+signaling socket's keepalive, not a data-channel ping), so a follower watching
+ping/pong alone would show an empty field forever. Anything arriving — chunk
+framing, an unparseable frame — is proof the leader is alive, which is what the
+field claims.
 
 ## `follow` startup ergonomics
 

--- a/docs/slicc-cli-details.md
+++ b/docs/slicc-cli-details.md
@@ -65,19 +65,38 @@ console): raw ANSI, ~4 files.
   bucket. Fields are laid out most-important-first and any that no longer fits
   is _skipped_, not treated as the end of the line — otherwise one long hostname
   on a narrow pane would hide the short fields behind it. Width is re-queried
-  per repaint, so a resize needs no SIGWINCH handler. Only `follow` gets the
-  bar unconditionally: `watch` streams the transcript to stdout in partial
-  lines, so when stdout is a terminal too it keeps the colors and drops the bar
-  rather than let the two fight over the last row. Deliberately **no alternate screen buffer and no scroll regions**:
+  per repaint, so a resize needs no SIGWINCH handler. Deliberately **no alternate screen buffer and no scroll regions**:
   output still scrolls back normally and a killed process leaves a usable
   terminal. Repaints from state changes are throttled (80 ms); the 1 s ticker
   catches up.
+- **The bar needs the last row to itself**, so it is dropped (colors kept)
+  whenever something else writes to the same stream — there are two such cases,
+  and both are decided once, at startup, in `commands.go`:
+  - `watch` streams the transcript to **stdout** in partial lines (a
+    `content_delta` rarely ends at a line boundary), so `watchModes` drops the
+    bar when stdout is a terminal too.
+  - the diagnostic logger writes to **stderr** on its own once turned up, so
+    `stickyUnlessLogging` drops the bar whenever `diagLogger.Enabled()`. Without
+    it, `SLICC_DEBUG=1` on a terminal would land a record on the bar's row and
+    every later erase would target the wrong line.
+- **Width accounting** (`cellWidth`) — combining marks and variation selectors
+  are zero cells, the East Asian wide/fullwidth blocks and the emoji blocks are
+  two, everything else one. `visibleWidth` sums those (skipping escapes) and
+  `truncateVisible` drops a double-wide rune rather than splitting it, since half
+  a cell is what makes a terminal wrap.
 - **Events** — `Line` stamps and marks the first row and indents continuation
   rows (`│ …`), so a multi-line error reads as one event. An identical
-  consecutive event is folded in place with a `(×3)` counter; one too tall
-  (> 6 rows) or too wide to rewrite safely — a soft-wrapped row invalidates the
-  cursor walk — keeps its detail on screen once and collapses into a single
-  `↺ repeated (×N)` row instead. `Note` prints **only** in plain mode, for
+  consecutive event is folded in place with a `(×3)` counter; one that cannot be
+  rewritten keeps its detail on screen once and collapses into a single
+  `↺ repeated (×N)` row instead, which is then rewritten from there on. Three
+  things disqualify a rewrite, all of them cases where the cursor walk would
+  land somewhere other than where the event started: more than 6 rows, a row at
+  or past the terminal width (it has soft-wrapped), and a row holding anything
+  beyond ASCII plus this package's own symbols (`rewriteSafe`). That last one is
+  deliberately blunt: leader-supplied text can contain emoji ZWJ sequences,
+  "ambiguous width" characters a CJK locale draws wide, or bytes the terminal
+  replaces with a glyph of its own choosing, and an undercounted row wraps
+  invisibly — so such an event is never rewritten, only marked. `Note` prints **only** in plain mode, for
   information the bar already carries live (the reconnect wait): duplicating it
   would also interleave the identical errors and defeat the collapsing.
 - **Seams** — `LineWriter(kind)` adapts the console to an `io.Writer` so

--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -102,12 +102,18 @@ countdown), uptime, `♥` age of the last frame from the leader (fed by
 `tray.Options.OnActivity`, which fires on _every_ inbound frame — the leader
 answers pings rather than sending them, so keepalives alone would never
 populate it), exec + reconnect counts, suppressed link diagnostics,
-`user@host · runner`, and a per-5s connection-history strip. `watch` drops the
-bar when **stdout** is also a terminal: it streams the transcript there in
-partial lines, and both cannot own the last row.
+`user@host · runner`, and a per-5s connection-history strip.
 Event lines are stamped, colored and glyph-marked; an identical repeat folds in
-place as `(×N)` (or a compact `↺ repeated (×N)` row when the event is too
-tall/wide to rewrite), so a reconnect loop no longer scrolls the screen away.
+place as `(×N)`, or into a compact `↺ repeated (×N)` row when the event cannot
+be rewritten safely (too tall, soft-wrapped, or holding text whose cell width we
+cannot be sure of — emoji, CJK, invalid bytes). So a reconnect loop no longer
+scrolls the screen away.
+
+**The bar must own the last row**, so it is dropped (colors kept) when anything
+else writes to the same stream: `watch` when **stdout** is also a terminal (its
+transcript arrives in partial lines), and any verb once the diagnostic logger is
+turned up (`SLICC_DEBUG=1` and friends write to **stderr** directly). Both
+decisions live in `commands.go` — `watchModes` and `stickyUnlessLogging`.
 
 **Plain mode is the contract**: with no terminal attached, output is
 byte-for-byte the pre-TUI `slicc <verb>: <msg>` text, escape-free, with every

--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -9,8 +9,9 @@ module, not an npm workspace** (like `packages/ios-app`) — built with
 ```
 slicc <join-url> prompt "<text>"                Stream one assistant turn, then exit
 slicc <join-url> exec "<command>"               Run a command in the leader's shell, stream output
-slicc <join-url> watch [scoop]                  Tail the leader's live agent output, read-only
-slicc <join-url> follow [--no-banner] [runner]  Stay connected; run leader-issued commands via <runner>
+slicc <join-url> watch [--plain] [scoop]        Tail the leader's live agent output, read-only
+slicc <join-url> follow [--no-banner] [--plain] [runner]
+                                                Stay connected; run leader-issued commands via <runner>
 slicc <join-url> follow --eval [repl]           Same, into ONE persistent REPL (state persists; see README)
 slicc update [--check]                          Self-update to the newest released CLI binary
 slicc list-sessions [--json]                    List iCloud-synced tray sessions (macOS only; no join URLs)
@@ -61,7 +62,7 @@ Cloudflare TURN. No native toolchain.
 
 `main.go` (argv + dispatch), `commands.go` (`prompt`/`exec`/`follow`),
 `cloud.go` (`list-sessions` + `<verb>-cloud`), `update.go`, `telemetry.go`,
-`internal/{protocol,signaling,tray,cloud,execrun,update,logging}/`. Full
+`internal/{protocol,signaling,tray,cloud,execrun,update,logging,ui}/`. Full
 per-file map: [details](../../docs/slicc-cli-details.md#layout).
 
 ## Protocol parity
@@ -80,16 +81,48 @@ JSON and update Go structs + `corpus_test.go` alongside TS + Swift mirrors.
 - **Diagnostics** — signaling retries, supersede redirects, ICE failures,
   unparseable frames go through `internal/logging` (`log/slog` `diagLogger`
   in `commands.go`, to stderr); `debugLogf` adapts to `tray.Options.Logf`.
+- **pion's own records** — `Conn.pionLoggerFactory` installs
+  `logging.PionFactory` on `SettingEngine.LoggerFactory`. **Required**: left
+  nil, webrtc installs pion's default factory, which writes error records
+  straight to `os.Stderr` — TURN refresh churn (`turnc ERROR: Fail to refresh
+permissions`) then buries the CLI's own output and no log level of ours can
+  quiet it. Warn-and-above records are tallied into the status bar
+  (`tray.Options.OnLinkDiag`) instead of printed.
 
 Off by default. `SLICC_DEBUG=1` (legacy = `SLICC_LOG_LEVEL=debug`) or
 `SLICC_LOG_LEVEL=debug|info|warn|error`; `SLICC_LOG_FORMAT=json` swaps
 `slog.TextHandler` for `slog.JSONHandler`.
 
+## Terminal presentation (`internal/ui`)
+
+`follow`/`watch` render through `internal/ui` (stdlib + `golang.org/x/sys`, raw
+ANSI — no TUI framework). On an interactive terminal `follow` keeps a **sticky
+one-line status bar** below the log: state badge (connect spinner, live retry
+countdown), uptime, `♥` age of the last frame from the leader (fed by
+`tray.Options.OnActivity`, which fires on _every_ inbound frame — the leader
+answers pings rather than sending them, so keepalives alone would never
+populate it), exec + reconnect counts, suppressed link diagnostics,
+`user@host · runner`, and a per-5s connection-history strip. `watch` drops the
+bar when **stdout** is also a terminal: it streams the transcript there in
+partial lines, and both cannot own the last row.
+Event lines are stamped, colored and glyph-marked; an identical repeat folds in
+place as `(×N)` (or a compact `↺ repeated (×N)` row when the event is too
+tall/wide to rewrite), so a reconnect loop no longer scrolls the screen away.
+
+**Plain mode is the contract**: with no terminal attached, output is
+byte-for-byte the pre-TUI `slicc <verb>: <msg>` text, escape-free, with every
+occurrence kept. Cursor control is never written to a non-terminal.
+`--plain` / `SLICC_NO_TUI=1` force plain; `NO_COLOR` keeps the bar without
+color; `FORCE_COLOR`/`CLICOLOR_FORCE` colors a redirected stream (still not
+sticky); `COLUMNS` overrides the detected width. Design notes + the glyph/ASCII
+fallback rules: [details](../../docs/slicc-cli-details.md).
+
 ## Exec safety (`follow`)
 
 A `follow` with a runner advertises `hello.capabilities.exec = true`; each
 command runs as `<runner> <command>` (runner sandboxes the exec surface),
-as the user who started `slicc`, echoed to stderr. **A `follow` with no
+as the user who started `slicc`, echoed to stderr (`follow.Session` writes a
+bare `exec: <command>`; the console owns the prefix and styling). **A `follow` with no
 runner advertises no capability and refuses every `exec.request` with an
 error.** Banner + safety warning on start (`--no-banner` drops art, keeps
 warning); `runnerExecWarning` flags the `follow bash` vs `follow bash -c`

--- a/packages/slicc-cli/README.md
+++ b/packages/slicc-cli/README.md
@@ -12,8 +12,9 @@ first run.
 ```
 slicc <join-url> prompt "<text>"                Send one message, stream the assistant's reply, exit
 slicc <join-url> exec "<command>"               Run a command in the leader's shell, stream output, exit
-slicc <join-url> watch [scoop]                  Tail the agent's output live (a scoop jid filters), until Ctrl+C
-slicc <join-url> follow [--no-banner] [runner]  Stay connected; let the leader run commands on THIS machine
+slicc <join-url> watch [--plain] [scoop]        Tail the agent's output live (a scoop jid filters), until Ctrl+C
+slicc <join-url> follow [--no-banner] [--plain] [runner]
+                                                Stay connected; let the leader run commands on THIS machine
 slicc <join-url> follow --eval [repl]           Same, but into ONE persistent REPL process (state persists)
 slicc update [--check]                          Self-update to the newest released CLI binary
 ```
@@ -58,6 +59,35 @@ slicc <url> follow docker exec -i sandbox sh -c  # scope the leader to a contain
 ⚠️ **`follow <runner>` is remote code execution by design.** The leader gets to
 run commands on your machine. Only point it at leaders you trust, and prefer a
 sandboxing runner. Set `SLICC_DEBUG=1` to see connection diagnostics on stderr.
+
+## Live status bar
+
+In an interactive terminal, `follow` keeps a status bar pinned below its output
+and color-codes events as they happen (`watch` color-codes too, but leaves the
+screen to the agent transcript it is streaming):
+
+```
+12:14:15 ✔ connected
+12:14:26 ▸ exec: git status --short
+12:15:02 ✖ tray attach: unexpected role "" (body: {
+         │   "code": "TRAY_NOT_INITIALIZED"
+         │ })
+12:15:41 ✖ ↺ repeated (×6)
+● connected  up 2m14s  ♥ 4s  ▸ 3 execs  ⇅ 1 reconnects  alice@laptop · bash -c  ▁▄████
+```
+
+Left to right, the bar shows the connection state (a spinner while connecting, a
+live countdown while waiting to retry), uptime, how long ago the last message
+from the leader arrived, exec and reconnect counts, suppressed link diagnostics
+(`link ⚠ N` — the WebRTC/TURN churn that used to scroll past as
+`turnc ERROR: …`, still readable with `SLICC_DEBUG=1`), who the leader runs
+commands as, and a strip of recent connection history. A repeated error collapses
+into one counted line instead of a wall.
+
+Redirected output is plain and unchanged — no colors, no cursor tricks, every
+occurrence logged — so pipes and CI keep working. To force that in a terminal,
+use `--plain` or `SLICC_NO_TUI=1`; `NO_COLOR` keeps the bar without color, and
+`COLUMNS` overrides the detected width.
 
 On macOS, [Sliccstart](../swift-launcher/) can open `follow` mode in Terminal.app,
 iTerm2, Ghostty, WezTerm, kitty, or Alacritty after a leader session is running.

--- a/packages/slicc-cli/cli_test.go
+++ b/packages/slicc-cli/cli_test.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ai-ecoverse/slicc-cli/internal/ui"
 )
 
 func TestReadTextArg(t *testing.T) {
@@ -71,6 +74,9 @@ func TestParseFollowArgs(t *testing.T) {
 		{"eval quiet value form", []string{"--eval", "--eval-quiet", "2s", "node", "-i"}, followArgs{runner: []string{"node", "-i"}, showBanner: true, eval: true, evalQuiet: 2 * time.Second}},
 		{"invalid eval quiet falls back to default", []string{"--eval", "--eval-quiet=soon", "clojure"}, followArgs{runner: []string{"clojure"}, showBanner: true, eval: true}},
 		{"eval composes with no-banner", []string{"--no-banner", "--eval", "python", "-i"}, followArgs{runner: []string{"python", "-i"}, eval: true}},
+		{"plain strips flag", []string{"--plain", "sh", "-c"}, followArgs{runner: []string{"sh", "-c"}, showBanner: true, plain: true}},
+		{"plain composes with the others", []string{"--no-banner", "--plain", "--eval", "python", "-i"}, followArgs{runner: []string{"python", "-i"}, plain: true, eval: true}},
+		{"a runner named --plain survives the terminator", []string{"--", "--plain"}, followArgs{runner: []string{"--plain"}, showBanner: true}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -120,11 +126,17 @@ func TestFollowMotd(t *testing.T) {
 	}
 }
 
+// bannerOutput renders a banner through a plain-mode console over a buffer, the
+// presentation a redirected stderr gets.
+func bannerOutput(fa followArgs) string {
+	var buf bytes.Buffer
+	printFollowBanner(ui.New(&buf, ui.Options{Tag: "slicc follow"}), fa)
+	return buf.String()
+}
+
 func TestPrintFollowBanner(t *testing.T) {
 	t.Run("art + exec warning + heuristic when runner is bare bash", func(t *testing.T) {
-		var buf bytes.Buffer
-		printFollowBanner(&buf, followArgs{runner: []string{"bash"}, showBanner: true})
-		out := buf.String()
+		out := bannerOutput(followArgs{runner: []string{"bash"}, showBanner: true})
 		if !strings.Contains(out, "follow") { // the ASCII wordmark ends with "follow"
 			t.Error("expected the ASCII wordmark when showArt=true")
 		}
@@ -136,9 +148,7 @@ func TestPrintFollowBanner(t *testing.T) {
 		}
 	})
 	t.Run("no art when suppressed, but exec warning stays", func(t *testing.T) {
-		var buf bytes.Buffer
-		printFollowBanner(&buf, followArgs{runner: []string{"sh", "-c"}})
-		out := buf.String()
+		out := bannerOutput(followArgs{runner: []string{"sh", "-c"}})
 		if strings.Contains(out, "_____") {
 			t.Error("art should be suppressed when showArt=false")
 		}
@@ -147,10 +157,152 @@ func TestPrintFollowBanner(t *testing.T) {
 		}
 	})
 	t.Run("no runner => exec-disabled notice", func(t *testing.T) {
-		var buf bytes.Buffer
-		printFollowBanner(&buf, followArgs{showBanner: true})
-		if !strings.Contains(buf.String(), "exec disabled") {
+		out := bannerOutput(followArgs{showBanner: true})
+		if !strings.Contains(out, "slicc follow: connecting as ") {
+			t.Errorf("expected the tagged plain-mode line, got %q", out)
+		}
+		if !strings.Contains(out, "exec disabled") {
 			t.Error("expected the exec-disabled notice for a no-runner follow")
 		}
 	})
+	t.Run("a redirected banner carries no escape sequences", func(t *testing.T) {
+		out := bannerOutput(followArgs{runner: []string{"bash"}, showBanner: true, eval: false})
+		if strings.Contains(out, "\x1b") {
+			t.Errorf("plain-mode banner must be escape-free, got %q", out)
+		}
+	})
+}
+
+func TestTakePlainFlag(t *testing.T) {
+	rest, plain := takePlainFlag([]string{"--plain", "scoop-1"})
+	if !plain || !reflect.DeepEqual(rest, []string{"scoop-1"}) {
+		t.Errorf("takePlainFlag consumed wrong: rest=%v plain=%v", rest, plain)
+	}
+	rest, plain = takePlainFlag([]string{"scoop-1"})
+	if plain || !reflect.DeepEqual(rest, []string{"scoop-1"}) {
+		t.Errorf("a scoop jid is not a flag: rest=%v plain=%v", rest, plain)
+	}
+	if rest, plain := takePlainFlag(nil); plain || rest != nil {
+		t.Errorf("empty argv: rest=%v plain=%v", rest, plain)
+	}
+}
+
+func TestOutputModeHonorsPlain(t *testing.T) {
+	if mode := outputMode(os.Stderr, true); !mode.Plain() {
+		t.Errorf("--plain must force plain output, got %+v", mode)
+	}
+}
+
+func TestFollowPeer(t *testing.T) {
+	unicode := ui.Mode{Unicode: true}
+	if got := followPeer(unicode, nil); !strings.HasSuffix(got, "(no exec)") {
+		t.Errorf("a no-runner follow should say so, got %q", got)
+	}
+	got := followPeer(unicode, []string{"bash", "-c"})
+	if !strings.Contains(got, "@") || !strings.HasSuffix(got, "· bash -c") {
+		t.Errorf("peer = %q, want user@host · bash -c", got)
+	}
+	if got := followPeer(ui.Mode{}, []string{"bash", "-c"}); !strings.HasSuffix(got, "| bash -c") {
+		t.Errorf("ascii peer = %q, want the ASCII separator", got)
+	}
+}
+
+func TestStatusTransitions(t *testing.T) {
+	var st ui.Status
+	markConnected(&st)
+	markConnected(&st)
+	if st.State != ui.StateConnected || st.Sessions != 2 || st.Attempt != 0 {
+		t.Errorf("after two connects: %+v", st)
+	}
+	retrying(3, 8*time.Second)(&st)
+	if st.State != ui.StateRetrying || st.Attempt != 3 {
+		t.Errorf("after a retry: %+v", st)
+	}
+	if wait := time.Until(st.RetryAt); wait <= 0 || wait > 8*time.Second {
+		t.Errorf("RetryAt is %s away, want just under 8s", wait)
+	}
+}
+
+func TestLinkDiagCounterOnlyCountsWarnings(t *testing.T) {
+	var buf bytes.Buffer
+	console := ui.New(&buf, ui.Options{Tag: "slicc follow"})
+	count := linkDiagCounter(console)
+	count("turnc", slog.LevelDebug, "trace noise")
+	count("turnc", slog.LevelInfo, "state change")
+	count("turnc", slog.LevelWarn, "retrying")
+	count("turnc", slog.LevelError, "Fail to refresh permissions")
+	if got := console.Snapshot().Diags; got != 2 {
+		t.Errorf("counted %d diagnostics, want the 2 at warn and above", got)
+	}
+	if buf.String() != "" {
+		t.Errorf("link diagnostics must not print, got %q", buf.String())
+	}
+}
+
+func TestPrintSessionSummary(t *testing.T) {
+	t.Run("a session that never connected stays quiet", func(t *testing.T) {
+		var buf bytes.Buffer
+		printSessionSummary(ui.New(&buf, ui.Options{Tag: "slicc follow"}))
+		if buf.String() != "" {
+			t.Errorf("want no summary, got %q", buf.String())
+		}
+	})
+	t.Run("a connected session reports its numbers", func(t *testing.T) {
+		var buf bytes.Buffer
+		console := ui.New(&buf, ui.Options{Tag: "slicc follow"})
+		console.Update(func(s *ui.Status) {
+			s.Sessions, s.Execs, s.Diags = 3, 1, 17
+		})
+		printSessionSummary(console)
+		out := buf.String()
+		for _, want := range []string{"session ended after", "1 exec,", "2 reconnects", "17 link diagnostics"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("summary %q is missing %q", out, want)
+			}
+		}
+	})
+}
+
+func TestPlural(t *testing.T) {
+	cases := map[int]string{0: "0 execs", 1: "1 exec", 2: "2 execs"}
+	for n, want := range cases {
+		if got := plural(n, "exec"); got != want {
+			t.Errorf("plural(%d) = %q, want %q", n, got, want)
+		}
+	}
+}
+
+func TestShortHost(t *testing.T) {
+	cases := map[string]string{
+		"laptop.local": "laptop",
+		"laptop":       "laptop",
+		"a.b.c":        "a",
+		".leading":     ".leading",
+		"":             "",
+	}
+	for in, want := range cases {
+		if got := shortHost(in); got != want {
+			t.Errorf("shortHost(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWatchModesDropTheBarWhenStdoutIsATerminal(t *testing.T) {
+	tty := ui.Mode{Color: true, Sticky: true, Unicode: true}
+	piped := ui.Mode{}
+
+	// Both on the terminal: the transcript writes partial lines to stdout, so
+	// the bar has to go — but the status lines keep their colors.
+	console, out := watchModes(tty, tty)
+	if console.Sticky {
+		t.Error("kept the status bar while the transcript shares the screen")
+	}
+	if !console.Color || !out.Sticky {
+		t.Errorf("lost more than the bar: console=%+v out=%+v", console, out)
+	}
+
+	// Transcript redirected: stderr alone owns the screen, bar included.
+	if console, _ = watchModes(tty, piped); !console.Sticky {
+		t.Error("dropped the status bar even though stdout is redirected")
+	}
 }

--- a/packages/slicc-cli/cli_test.go
+++ b/packages/slicc-cli/cli_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ai-ecoverse/slicc-cli/internal/logging"
 	"github.com/ai-ecoverse/slicc-cli/internal/ui"
 )
 
@@ -304,5 +306,32 @@ func TestWatchModesDropTheBarWhenStdoutIsATerminal(t *testing.T) {
 	// Transcript redirected: stderr alone owns the screen, bar included.
 	if console, _ = watchModes(tty, piped); !console.Sticky {
 		t.Error("dropped the status bar even though stdout is redirected")
+	}
+}
+
+func TestStickyUnlessLogging(t *testing.T) {
+	tty := ui.Mode{Color: true, Sticky: true, Unicode: true}
+
+	// Diagnostics off (the default): the bar owns the last row.
+	off := logging.New(io.Discard, logging.Config{})
+	if got := stickyUnlessLogging(tty, off); !got.Sticky {
+		t.Error("dropped the status bar while nothing else writes to stderr")
+	}
+
+	// SLICC_DEBUG=1: tray's records go straight to stderr, so the bar has to
+	// step aside — but the status lines keep their colors.
+	on := logging.New(io.Discard, logging.Config{Enabled: true, Level: slog.LevelDebug})
+	got := stickyUnlessLogging(tty, on)
+	if got.Sticky {
+		t.Error("kept the status bar while diagnostics write to the same stream")
+	}
+	if !got.Color || !got.Unicode {
+		t.Errorf("lost more than the bar: %+v", got)
+	}
+
+	// A nil logger is a valid no-op logger; it must not be mistaken for one that
+	// is emitting.
+	if got := stickyUnlessLogging(tty, nil); !got.Sticky {
+		t.Error("a nil logger dropped the status bar")
 	}
 }

--- a/packages/slicc-cli/cloud.go
+++ b/packages/slicc-cli/cloud.go
@@ -112,11 +112,12 @@ func cmdCloud(ctx context.Context, verb string, args []string) int {
 		}
 		return cmdExec(ctx, session.JoinURL, command)
 	case "watch-cloud":
+		rest, plain := takePlainFlag(rest)
 		scoopJid := ""
 		if len(rest) > 0 {
 			scoopJid = rest[0]
 		}
-		return cmdWatch(ctx, session.JoinURL, scoopJid)
+		return cmdWatch(ctx, session.JoinURL, scoopJid, plain)
 	default:
 		fmt.Fprintf(os.Stderr, "slicc: unknown cloud verb %q\n", verb)
 		return 2

--- a/packages/slicc-cli/commands.go
+++ b/packages/slicc-cli/commands.go
@@ -7,7 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
+	"log/slog"
 	"os"
 	"runtime"
 	"strings"
@@ -18,6 +18,7 @@ import (
 	"github.com/ai-ecoverse/slicc-cli/internal/logging"
 	"github.com/ai-ecoverse/slicc-cli/internal/protocol"
 	"github.com/ai-ecoverse/slicc-cli/internal/tray"
+	"github.com/ai-ecoverse/slicc-cli/internal/ui"
 )
 
 type inbound struct {
@@ -52,7 +53,7 @@ func cmdPrompt(ctx context.Context, joinURL, text string) int {
 			case protocol.AgentTurnEnd:
 				finish(0)
 			case protocol.AgentError:
-				fmt.Fprintf(os.Stderr, "\nslicc prompt: %s\n", env.Event.Error)
+				errLineAfterStream("prompt", "%s", env.Event.Error)
 				finish(1)
 			}
 		case protocol.TypeStatus:
@@ -70,14 +71,14 @@ func cmdPrompt(ctx context.Context, joinURL, text string) int {
 				Error string `json:"error"`
 			}
 			_ = json.Unmarshal(raw, &e)
-			fmt.Fprintf(os.Stderr, "\nslicc prompt: %s\n", e.Error)
+			errLineAfterStream("prompt", "%s", e.Error)
 			finish(1)
 		}
 	}
 
 	conn, err := tray.Dial(ctx, joinURL, tray.Options{OnMessage: handler, Logf: debugLogf})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "slicc prompt: %s\n", err)
+		errLine("prompt", "%s", err)
 		reportRuntimeError("dial", err)
 		return 1
 	}
@@ -86,7 +87,7 @@ func cmdPrompt(ctx context.Context, joinURL, text string) int {
 	if err := conn.SendJSON(protocol.UserMessage{
 		Type: "user_message", Text: text, MessageID: newID(),
 	}); err != nil {
-		fmt.Fprintf(os.Stderr, "slicc prompt: %s\n", err)
+		errLine("prompt", "%s", err)
 		return 1
 	}
 
@@ -95,7 +96,7 @@ func cmdPrompt(ctx context.Context, joinURL, text string) int {
 		fmt.Println()
 		return code
 	case <-conn.Done():
-		fmt.Fprintln(os.Stderr, "\nslicc prompt: connection closed before the turn completed")
+		errLineAfterStream("prompt", "connection closed before the turn completed")
 		return 1
 	case <-ctx.Done():
 		// Tell the leader to stop the turn so it doesn't keep spending tokens.
@@ -136,7 +137,7 @@ func cmdExec(ctx context.Context, joinURL, command string) int {
 				return
 			}
 			if r.Error != "" {
-				fmt.Fprintf(os.Stderr, "slicc exec: %s\n", r.Error)
+				errLine("exec", "%s", r.Error)
 			}
 			finish(r.ExitCode)
 		}
@@ -144,7 +145,7 @@ func cmdExec(ctx context.Context, joinURL, command string) int {
 
 	conn, err := tray.Dial(ctx, joinURL, tray.Options{OnMessage: handler, Logf: debugLogf})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "slicc exec: %s\n", err)
+		errLine("exec", "%s", err)
 		reportRuntimeError("dial", err)
 		return 1
 	}
@@ -153,7 +154,7 @@ func cmdExec(ctx context.Context, joinURL, command string) int {
 	if err := conn.SendJSON(protocol.ExecRequest{
 		Type: "exec.request", RequestID: requestID, Command: command,
 	}); err != nil {
-		fmt.Fprintf(os.Stderr, "slicc exec: %s\n", err)
+		errLine("exec", "%s", err)
 		return 1
 	}
 
@@ -161,7 +162,7 @@ func cmdExec(ctx context.Context, joinURL, command string) int {
 	case code := <-done:
 		return code
 	case <-conn.Done():
-		fmt.Fprintln(os.Stderr, "slicc exec: connection closed")
+		errLine("exec", "connection closed")
 		return 1
 	case <-ctx.Done():
 		// Ctrl+C: ask the leader to interrupt the command, then wait briefly.
@@ -182,19 +183,24 @@ func cmdExec(ctx context.Context, joinURL, command string) int {
 // blank line at each turn boundary — until interrupted. It sends nothing to the
 // leader and never completes on its own: a read-only `tail -f` on what the agent
 // is doing, reconnecting with backoff so it survives leader reloads.
-func cmdWatch(ctx context.Context, joinURL, scoopJid string) int {
+func cmdWatch(ctx context.Context, joinURL, scoopJid string, plain bool) int {
 	what := "the leader's agent output"
 	if scoopJid != "" {
 		what = fmt.Sprintf("scoop %q", scoopJid)
 	}
-	fmt.Fprintf(os.Stderr, "slicc watch: tailing %s (Ctrl+C to stop)\n", what)
+	consoleMode, outMode := watchModes(outputMode(os.Stderr, plain), outputMode(os.Stdout, plain))
+	r := watchRender{console: newConsole("slicc watch", consoleMode), out: outMode}
+	r.console.Line(ui.KindInfo, "tailing %s (Ctrl+C to stop)", what)
+	r.console.Start()
+	defer printSessionSummary(r.console)
 	backoff := time.Second
 	failures := 0
 	for {
 		if ctx.Err() != nil {
 			return 0
 		}
-		clean, err := watchOnce(ctx, joinURL, scoopJid)
+		r.console.Update(func(s *ui.Status) { s.State = ui.StateConnecting; s.Attempt = failures })
+		clean, err := watchOnce(ctx, joinURL, scoopJid, r)
 		if ctx.Err() != nil {
 			return 0
 		}
@@ -204,15 +210,16 @@ func cmdWatch(ctx context.Context, joinURL, scoopJid string) int {
 		} else {
 			failures++
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "slicc watch: %s\n", err)
+				r.console.Line(ui.KindError, "%s", err)
 				reportRuntimeError("watch", err)
 			}
 			if failures >= 20 {
-				fmt.Fprintln(os.Stderr, "slicc watch: giving up after 20 failed attempts")
+				r.console.Line(ui.KindError, "giving up after 20 failed attempts")
 				return 1
 			}
 		}
-		fmt.Fprintf(os.Stderr, "slicc watch: reconnecting in %s…\n", backoff)
+		r.console.Update(retrying(failures, backoff))
+		r.console.Note(ui.KindInfo, "reconnecting in %s…", backoff)
 		if !sleepCtx(ctx, backoff) {
 			return 0
 		}
@@ -220,7 +227,14 @@ func cmdWatch(ctx context.Context, joinURL, scoopJid string) int {
 	}
 }
 
-func watchOnce(ctx context.Context, joinURL, scoopJid string) (clean bool, err error) {
+// watchRender carries `watch`'s two output surfaces: the status console on
+// stderr and the resolved styling for the agent stream on stdout.
+type watchRender struct {
+	console *ui.Console
+	out     ui.Mode
+}
+
+func watchOnce(ctx context.Context, joinURL, scoopJid string, r watchRender) (clean bool, err error) {
 	sawProcessing := false
 	// Empty scoopJid = no filter (tail whatever the leader broadcasts).
 	inScoop := func(js string) bool { return scoopJid == "" || js == scoopJid }
@@ -231,12 +245,12 @@ func watchOnce(ctx context.Context, joinURL, scoopJid string) (clean bool, err e
 			// shows the same thread as the browser.
 			var m protocol.UserMessageEcho
 			if json.Unmarshal(raw, &m) == nil && inScoop(m.ScoopJid) {
-				fmt.Printf("\n> %s\n", m.Text)
+				fmt.Printf("\n%s\n", r.out.Paint(ui.StyleBold, "> "+m.Text))
 			}
 		case protocol.TypeAgentEvent:
 			var env protocol.AgentEventEnvelope
 			if json.Unmarshal(raw, &env) == nil && inScoop(env.ScoopJid) {
-				printWatchEvent(env.Event)
+				printWatchEvent(env.Event, r)
 			}
 		case protocol.TypeStatus:
 			var s protocol.Status
@@ -253,40 +267,52 @@ func watchOnce(ctx context.Context, joinURL, scoopJid string) (clean bool, err e
 			}
 		}
 	}
-	conn, dialErr := tray.Dial(ctx, joinURL, tray.Options{OnMessage: handler, Logf: debugLogf})
+	conn, dialErr := tray.Dial(ctx, joinURL, tray.Options{
+		OnMessage:  handler,
+		OnActivity: r.console.Beat,
+		OnLinkDiag: linkDiagCounter(r.console),
+		Logf:       debugLogf,
+	})
 	if dialErr != nil {
 		return false, dialErr
 	}
 	defer conn.Close()
-	fmt.Fprintln(os.Stderr, "slicc watch: connected")
+	r.console.Update(markConnected)
+	r.console.Line(ui.KindOk, "connected")
 	select {
 	case <-ctx.Done():
 		return true, nil
 	case <-conn.Done():
-		fmt.Fprintln(os.Stderr, "slicc watch: connection closed")
+		r.console.Update(func(s *ui.Status) { s.State = ui.StateOffline })
+		r.console.Line(ui.KindWarn, "connection closed")
 		return true, nil
 	}
 }
 
 // printWatchEvent renders one agent event the way the browser thread shows it:
 // assistant text inline, tool calls + a short result on their own lines, errors
-// on stderr. Unmodeled event types are silently skipped.
-func printWatchEvent(ev protocol.AgentEvent) {
+// through the status console. Unmodeled event types are silently skipped.
+//
+// The glyphs are literal rather than mode-dependent: the stream is a transcript
+// other tools grep, so only color varies with the terminal.
+func printWatchEvent(ev protocol.AgentEvent, r watchRender) {
 	switch ev.Type {
 	case protocol.AgentContentDelta:
 		fmt.Print(ev.Text)
 	case protocol.AgentToolUseStart:
-		fmt.Printf("\n⚙ %s%s\n", ev.ToolName, compactArgs(ev.ToolInput))
+		fmt.Printf("\n%s%s\n",
+			r.out.Paint(ui.StyleBoldCyan, "⚙ "+ev.ToolName),
+			r.out.Paint(ui.StyleDim, compactArgs(ev.ToolInput)))
 	case protocol.AgentToolResult:
-		mark := "↳"
+		mark, style := "↳", ui.StyleDim
 		if ev.IsError != nil && *ev.IsError {
-			mark = "↳ ✗"
+			mark, style = "↳ ✗", ui.StyleRed
 		}
-		fmt.Printf("%s %s\n", mark, truncateOneLine(ev.Result, 200))
+		fmt.Println(r.out.Paint(style, fmt.Sprintf("%s %s", mark, truncateOneLine(ev.Result, 200))))
 	case protocol.AgentTurnEnd:
 		fmt.Println()
 	case protocol.AgentError:
-		fmt.Fprintf(os.Stderr, "\nslicc watch: %s\n", ev.Error)
+		r.console.Line(ui.KindError, "%s", ev.Error)
 	}
 }
 
@@ -324,25 +350,30 @@ func cmdFollow(ctx context.Context, joinURL string, fa followArgs) int {
 	var eval *execrun.EvalSession
 	if fa.eval {
 		if len(fa.runner) == 0 {
-			fmt.Fprintln(os.Stderr, "slicc follow --eval: missing REPL runner (e.g. follow --eval python -i)")
+			errLine("follow --eval", "missing REPL runner (e.g. follow --eval python -i)")
 			return 2
 		}
 		var err error
 		eval, err = execrun.StartEval(execrun.EvalOptions{Runner: fa.runner, Quiet: fa.evalQuiet})
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "slicc follow --eval: starting %s: %s\n", strings.Join(fa.runner, " "), err)
+			errLine("follow --eval", "starting %s: %s", strings.Join(fa.runner, " "), err)
 			return 1
 		}
 		defer eval.Close()
 	}
-	printFollowBanner(os.Stderr, fa)
+	console := newConsole("slicc follow", outputMode(os.Stderr, fa.plain))
+	printFollowBanner(console, fa)
+	console.Update(func(s *ui.Status) { s.Peer = followPeer(console.Mode(), fa.runner) })
+	console.Start()
+	defer printSessionSummary(console)
 	backoff := time.Second
 	failures := 0
 	for {
 		if ctx.Err() != nil {
 			return 0
 		}
-		connected, err := followOnce(ctx, joinURL, fa.runner, eval)
+		console.Update(func(s *ui.Status) { s.State = ui.StateConnecting; s.Attempt = failures })
+		connected, err := followOnce(ctx, joinURL, fa.runner, eval, console)
 		if ctx.Err() != nil {
 			return 0
 		}
@@ -352,15 +383,16 @@ func cmdFollow(ctx context.Context, joinURL string, fa followArgs) int {
 		} else {
 			failures++
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "slicc follow: %s\n", err)
+				console.Line(ui.KindError, "%s", err)
 				reportRuntimeError("follow", err)
 			}
 			if failures >= 20 {
-				fmt.Fprintln(os.Stderr, "slicc follow: giving up after 20 failed attempts")
+				console.Line(ui.KindError, "giving up after 20 failed attempts")
 				return 1
 			}
 		}
-		fmt.Fprintf(os.Stderr, "slicc follow: reconnecting in %s…\n", backoff)
+		console.Update(retrying(failures, backoff))
+		console.Note(ui.KindInfo, "reconnecting in %s…", backoff)
 		if !sleepCtx(ctx, backoff) {
 			return 0
 		}
@@ -373,6 +405,7 @@ func followOnce(
 	joinURL string,
 	runner []string,
 	eval *execrun.EvalSession,
+	console *ui.Console,
 ) (connected bool, err error) {
 	// Connection-scoped context: cancelled on ANY return (disconnect, ctx done),
 	// so a leader-issued command that's still running is killed with the
@@ -391,6 +424,8 @@ func followOnce(
 		Capabilities: caps,
 		Motd:         followMotd(runner, eval != nil),
 		Logf:         debugLogf,
+		OnActivity:   console.Beat,
+		OnLinkDiag:   linkDiagCounter(console),
 		OnMessage: func(typ string, raw []byte) {
 			select {
 			case msgCh <- inbound{typ: typ, raw: raw}:
@@ -402,25 +437,155 @@ func followOnce(
 		return false, dialErr
 	}
 	defer conn.Close()
+	execLog := console.LineWriter(ui.KindExec)
 	var session *follow.Session
 	if eval != nil {
-		session = follow.NewEvalSession(conn, eval, os.Stderr)
+		session = follow.NewEvalSession(conn, eval, execLog)
 	} else {
-		session = follow.NewSession(conn, runner, os.Stderr)
+		session = follow.NewSession(conn, runner, execLog)
 	}
-	fmt.Fprintln(os.Stderr, "slicc follow: connected")
+	console.Update(markConnected)
+	console.Line(ui.KindOk, "connected")
 
 	for {
 		select {
 		case <-ctx.Done():
 			return true, nil
 		case <-conn.Done():
-			fmt.Fprintln(os.Stderr, "slicc follow: connection closed")
+			console.Update(func(s *ui.Status) { s.State = ui.StateOffline })
+			console.Line(ui.KindWarn, "connection closed")
 			return true, nil
 		case m := <-msgCh:
+			if m.typ == protocol.TypeExecRequest && caps != nil {
+				console.Update(func(s *ui.Status) { s.Execs++ })
+			}
 			session.Handle(connCtx, m.typ, m.raw)
 		}
 	}
+}
+
+// --- presentation ------------------------------------------------------------
+
+// newConsole builds the stderr status console for a long-running verb.
+func newConsole(tag string, mode ui.Mode) *ui.Console {
+	return ui.New(os.Stderr, ui.Options{
+		Mode:  mode,
+		Tag:   tag,
+		Width: func() int { return ui.Width(os.Stderr, os.LookupEnv) },
+	})
+}
+
+// watchModes resolves `watch`'s two surfaces. The status bar owns the last line
+// of the terminal, which only works while nothing else writes there — and
+// `watch` streams the agent transcript to stdout in partial lines (a
+// content_delta rarely ends at a line boundary). So when stdout is a terminal
+// too, the transcript wins: the console keeps its colors and drops the bar.
+func watchModes(console, out ui.Mode) (ui.Mode, ui.Mode) {
+	if out.Sticky {
+		console.Sticky = false
+	}
+	return console, out
+}
+
+// outputMode resolves how much decoration f can take, with --plain as an
+// override.
+func outputMode(f *os.File, plain bool) ui.Mode {
+	if plain {
+		return ui.Mode{}
+	}
+	return ui.Detect(f, os.LookupEnv)
+}
+
+// errLine writes a one-shot verb's fatal stderr line — red on an interactive
+// terminal, and the same text as always when redirected. The one-shot verbs
+// (`prompt`, `exec`) get no status bar: they are pipeline citizens whose stdout
+// is the payload.
+func errLine(verb, format string, args ...any) {
+	mode := outputMode(os.Stderr, false)
+	msg := fmt.Sprintf("slicc %s: %s", verb, fmt.Sprintf(format, args...))
+	fmt.Fprintln(os.Stderr, mode.Paint(ui.StyleRed, msg))
+}
+
+// errLineAfterStream is errLine preceded by a blank line, for a failure that
+// interrupts leader output already streaming on stdout.
+func errLineAfterStream(verb, format string, args ...any) {
+	fmt.Fprintln(os.Stderr)
+	errLine(verb, format, args...)
+}
+
+// markConnected records a successful connection.
+func markConnected(s *ui.Status) {
+	s.State = ui.StateConnected
+	s.Sessions++
+	s.Attempt = 0
+	s.RetryAt = time.Time{}
+}
+
+// retrying records the wait before the next attempt, which the status bar
+// counts down.
+func retrying(failures int, backoff time.Duration) func(*ui.Status) {
+	retryAt := time.Now().Add(backoff)
+	return func(s *ui.Status) {
+		s.State = ui.StateRetrying
+		s.RetryAt = retryAt
+		s.Attempt = failures
+	}
+}
+
+// linkDiagCounter tallies pion's own warnings and errors in the status bar.
+// They are the ICE/TURN churn that used to scroll past as `turnc ERROR: Fail to
+// refresh permissions` walls: worth a count, not worth a line each. The records
+// themselves stay available through SLICC_DEBUG=1.
+func linkDiagCounter(console *ui.Console) logging.PionEvent {
+	return func(_ string, level slog.Level, _ string) {
+		if level >= slog.LevelWarn {
+			console.CountDiag()
+		}
+	}
+}
+
+// printSessionSummary tears the status bar down and, for a session that reached
+// the leader at least once, replaces it with one closing line — the numbers the
+// bar was showing, kept in the scrollback.
+func printSessionSummary(console *ui.Console) {
+	console.Stop()
+	st := console.Snapshot()
+	if st.Sessions == 0 {
+		return
+	}
+	console.Line(ui.KindInfo, "session ended after %s — %s, %s, %s",
+		ui.CompactDuration(time.Since(st.Started)),
+		plural(st.Execs, "exec"),
+		plural(st.Sessions-1, "reconnect"),
+		plural(st.Diags, "link diagnostic"))
+}
+
+// followPeer is the status bar's "who and how" field: the identity a leader
+// command would run as, plus the runner it goes through.
+//
+// The host is shortened to its first label — the bar competes for one line, and
+// "laptop" says the same thing there as "laptop.local". The banner and the MOTD
+// keep the full name; those are the identity record.
+func followPeer(mode ui.Mode, runner []string) string {
+	who := fmt.Sprintf("%s@%s", currentUser(), shortHost(hostname()))
+	if len(runner) == 0 {
+		return who + " (no exec)"
+	}
+	return fmt.Sprintf("%s %s %s", who, mode.Glyph(ui.GlyphSeparator), strings.Join(runner, " "))
+}
+
+func shortHost(host string) string {
+	if i := strings.IndexByte(host, '.'); i > 0 {
+		return host[:i]
+	}
+	return host
+}
+
+func plural(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
 }
 
 // --- helpers -----------------------------------------------------------------
@@ -439,27 +604,34 @@ const followArt = `   _____ _ _
 // printFollowBanner writes the startup banner: the ASCII wordmark (unless
 // suppressed), who the leader would run as, the runner, and — when the runner
 // looks like it won't actually execute commands — a heuristic warning.
-func printFollowBanner(w io.Writer, fa followArgs) {
+//
+// The banner is written with Console.Raw, so its wording and layout are
+// byte-identical whether or not a terminal is attached: only the color changes.
+// A safety warning is not a place to vary text by output stream.
+func printFollowBanner(console *ui.Console, fa followArgs) {
 	if fa.showBanner {
-		fmt.Fprint(w, followArt)
+		console.Raw(ui.StyleBoldCyan, followArt)
 	}
 	who := fmt.Sprintf("%s@%s", currentUser(), hostname())
 	if len(fa.runner) == 0 {
-		fmt.Fprintf(w, "slicc follow: connecting as %s (exec disabled — no runner given)\n", who)
+		console.Line(ui.KindInfo, "connecting as %s (exec disabled — no runner given)", who)
 		return
 	}
-	fmt.Fprintf(w, "⚠  the leader can run commands on this machine as %s\n", who)
+	console.Raw(ui.StyleBoldRed, fmt.Sprintf("⚠  the leader can run commands on this machine as %s", who))
 	if fa.eval {
-		fmt.Fprintf(w, "   REPL/eval mode: one persistent `%s` process; each command is a line on its stdin\n", strings.Join(fa.runner, " "))
-		fmt.Fprint(w, "   (a response ends once the REPL goes quiet; state persists across commands)\n")
+		console.Raw(ui.StyleDim, fmt.Sprintf(
+			"   REPL/eval mode: one persistent `%s` process; each command is a line on its stdin",
+			strings.Join(fa.runner, " ")))
+		console.Raw(ui.StyleDim, "   (a response ends once the REPL goes quiet; state persists across commands)")
 		if warn := evalRunnerWarning(fa.runner); warn != "" {
-			fmt.Fprintf(w, "⚠  %s\n", warn)
+			console.Raw(ui.StyleYellow, "⚠  "+warn)
 		}
 		return
 	}
-	fmt.Fprintf(w, "   via: %s <command>   (each command is printed here as it runs)\n", strings.Join(fa.runner, " "))
+	console.Raw(ui.StyleDim, fmt.Sprintf(
+		"   via: %s <command>   (each command is printed here as it runs)", strings.Join(fa.runner, " ")))
 	if warn := runnerExecWarning(fa.runner); warn != "" {
-		fmt.Fprintf(w, "⚠  %s\n", warn)
+		console.Raw(ui.StyleYellow, "⚠  "+warn)
 	}
 }
 

--- a/packages/slicc-cli/commands.go
+++ b/packages/slicc-cli/commands.go
@@ -493,7 +493,21 @@ func outputMode(f *os.File, plain bool) ui.Mode {
 	if plain {
 		return ui.Mode{}
 	}
-	return ui.Detect(f, os.LookupEnv)
+	return stickyUnlessLogging(ui.Detect(f, os.LookupEnv), diagLogger)
+}
+
+// stickyUnlessLogging drops the bar while the diagnostic logger is emitting.
+// diagLogger writes to stderr on its own — `tray` logs its retries and ICE
+// transitions there — and the bar can only own the last row while nothing else
+// writes to it. Turned up (SLICC_DEBUG=1, SLICC_LOG_LEVEL=…), a record would land
+// on the bar's row and every later erase would target the wrong line. Debugging
+// wants the full record stream anyway, so the records win and the bar steps
+// aside; the status lines keep their colors.
+func stickyUnlessLogging(mode ui.Mode, diag *logging.Logger) ui.Mode {
+	if diag.Enabled() {
+		mode.Sticky = false
+	}
+	return mode
 }
 
 // errLine writes a one-shot verb's fatal stderr line — red on an interactive

--- a/packages/slicc-cli/commands.go
+++ b/packages/slicc-cli/commands.go
@@ -76,7 +76,7 @@ func cmdPrompt(ctx context.Context, joinURL, text string) int {
 		}
 	}
 
-	conn, err := tray.Dial(ctx, joinURL, tray.Options{OnMessage: handler, Logf: debugLogf})
+	conn, err := tray.Dial(ctx, joinURL, tray.Options{OnMessage: handler, Logf: debugLogf, LogWanted: diagLogger.EnabledAt})
 	if err != nil {
 		errLine("prompt", "%s", err)
 		reportRuntimeError("dial", err)
@@ -143,7 +143,7 @@ func cmdExec(ctx context.Context, joinURL, command string) int {
 		}
 	}
 
-	conn, err := tray.Dial(ctx, joinURL, tray.Options{OnMessage: handler, Logf: debugLogf})
+	conn, err := tray.Dial(ctx, joinURL, tray.Options{OnMessage: handler, Logf: debugLogf, LogWanted: diagLogger.EnabledAt})
 	if err != nil {
 		errLine("exec", "%s", err)
 		reportRuntimeError("dial", err)
@@ -272,6 +272,7 @@ func watchOnce(ctx context.Context, joinURL, scoopJid string, r watchRender) (cl
 		OnActivity: r.console.Beat,
 		OnLinkDiag: linkDiagCounter(r.console),
 		Logf:       debugLogf,
+		LogWanted:  diagLogger.EnabledAt,
 	})
 	if dialErr != nil {
 		return false, dialErr
@@ -424,6 +425,7 @@ func followOnce(
 		Capabilities: caps,
 		Motd:         followMotd(runner, eval != nil),
 		Logf:         debugLogf,
+		LogWanted:    diagLogger.EnabledAt,
 		OnActivity:   console.Beat,
 		OnLinkDiag:   linkDiagCounter(console),
 		OnMessage: func(typ string, raw []byte) {

--- a/packages/slicc-cli/go.mod
+++ b/packages/slicc-cli/go.mod
@@ -5,7 +5,9 @@ go 1.26.5
 require (
 	github.com/ai-ecoverse/go-optel v0.0.0
 	github.com/pion/ice/v4 v4.4.1
+	github.com/pion/logging v0.2.4
 	github.com/pion/webrtc/v4 v4.2.18
+	golang.org/x/sys v0.41.0
 )
 
 // go-optel is a sibling package in this monorepo (no go.work file), so the
@@ -17,7 +19,6 @@ require (
 	github.com/pion/datachannel v1.6.2 // indirect
 	github.com/pion/dtls/v3 v3.1.5 // indirect
 	github.com/pion/interceptor v0.1.47 // indirect
-	github.com/pion/logging v0.2.4 // indirect
 	github.com/pion/mdns/v2 v2.1.0 // indirect
 	github.com/pion/randutil v0.1.0 // indirect
 	github.com/pion/rtcp v1.2.17 // indirect
@@ -31,6 +32,5 @@ require (
 	github.com/wlynxg/anet v0.0.5 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
-	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 )

--- a/packages/slicc-cli/internal/follow/follow.go
+++ b/packages/slicc-cli/internal/follow/follow.go
@@ -33,7 +33,9 @@ type Session struct {
 	// execrun.EvalSession). The eval session outlives this connection so REPL
 	// state survives reconnects.
 	eval *execrun.EvalSession
-	// Log receives one line per command as it starts (per-command visibility).
+	// log receives one line per command as it starts (per-command visibility).
+	// The line carries no CLI prefix: the writer the caller passes owns the
+	// presentation (the `follow` console prefixes or decorates it).
 	log io.Writer
 
 	mu      sync.Mutex
@@ -97,7 +99,7 @@ func (s *Session) Handle(ctx context.Context, msgType string, raw []byte) {
 
 func (s *Session) startExec(ctx context.Context, req protocol.ExecRequest) {
 	if s.log != nil {
-		fmt.Fprintf(s.log, "slicc follow: exec: %s\n", req.Command)
+		fmt.Fprintf(s.log, "exec: %s\n", req.Command)
 	}
 	ctrl := make(chan string, 4)
 	s.mu.Lock()

--- a/packages/slicc-cli/internal/logging/logging.go
+++ b/packages/slicc-cli/internal/logging/logging.go
@@ -116,6 +116,17 @@ func (l *Logger) Enabled() bool {
 	return l != nil && l.enabled
 }
 
+// EnabledAt reports whether a record at level would be emitted. It lets a hot
+// producer skip building a record the handler would only drop — pion emits a
+// trace record per STUN packet, and formatting all of them to discard them is
+// pure waste in the default silent build.
+func (l *Logger) EnabledAt(level slog.Level) bool {
+	if !l.Enabled() {
+		return false
+	}
+	return l.slog.Enabled(context.Background(), level)
+}
+
 // With returns a Logger that adds attrs to every record.
 func (l *Logger) With(args ...any) *Logger {
 	if !l.Enabled() || len(args) == 0 {

--- a/packages/slicc-cli/internal/logging/pion.go
+++ b/packages/slicc-cli/internal/logging/pion.go
@@ -7,10 +7,18 @@ import (
 	pionlogging "github.com/pion/logging"
 )
 
-// PionEvent is the optional structured tap on a pion record. It runs on
-// whatever pion goroutine produced the record (an ICE agent, a TURN client's
-// refresh loop), so implementations must be non-blocking and concurrency-safe.
+// PionEvent is the optional structured tap on a pion record at warn level or
+// above — the link problems worth summarizing. Lower levels are pion's running
+// commentary (a trace record per STUN packet) and never reach it, so the tap
+// costs nothing on a healthy connection.
+//
+// It runs on whatever pion goroutine produced the record (an ICE agent, a TURN
+// client's refresh loop), so implementations must be non-blocking and
+// concurrency-safe.
 type PionEvent func(scope string, level slog.Level, msg string)
+
+// eventLevel is the lowest level PionEvent receives.
+const eventLevel = slog.LevelWarn
 
 // PionFactory adapts this package's diagnostic logging to the
 // pion/logging.LoggerFactory that webrtc.SettingEngine accepts.
@@ -22,13 +30,30 @@ type PionEvent func(scope string, level slog.Level, msg string)
 // output under `turnc ERROR: Fail to refresh permissions: …` lines that no
 // SLICC_LOG_LEVEL can turn off. Routed through here they are diagnostics: quiet
 // by default, back with SLICC_DEBUG=1, and countable via event.
-func PionFactory(logf func(format string, args ...any), event PionEvent) pionlogging.LoggerFactory {
-	return &pionFactory{logf: logf, event: event}
+//
+// wanted reports whether logf would do anything with a record at that level;
+// nil means it takes everything. Supplying it is what keeps the adapter cheap:
+// logf is normally a live closure over a *disabled* logger, so without wanted
+// every one of pion's per-packet trace records gets formatted just to be
+// dropped one call later.
+func PionFactory(logf func(format string, args ...any), event PionEvent, wanted func(slog.Level) bool) pionlogging.LoggerFactory {
+	return &pionFactory{logf: logf, event: event, wanted: wanted}
 }
 
 type pionFactory struct {
-	logf  func(format string, args ...any)
-	event PionEvent
+	logf   func(format string, args ...any)
+	event  PionEvent
+	wanted func(slog.Level) bool
+}
+
+// logs reports whether a record at level reaches logf.
+func (f *pionFactory) logs(level slog.Level) bool {
+	return f.logf != nil && (f.wanted == nil || f.wanted(level))
+}
+
+// consumes reports whether anything at all is waiting for a record at level.
+func (f *pionFactory) consumes(level slog.Level) bool {
+	return f.logs(level) || (f.event != nil && level >= eventLevel)
 }
 
 func (f *pionFactory) NewLogger(scope string) pionlogging.LeveledLogger {
@@ -42,18 +67,17 @@ type pionLogger struct {
 }
 
 func (l *pionLogger) emit(level slog.Level, msg string) {
-	if l.factory.logf != nil {
+	if l.factory.logs(level) {
 		l.factory.logf("pion %s: %s", l.scope, msg)
 	}
-	if l.factory.event != nil {
+	if l.factory.event != nil && level >= eventLevel {
 		l.factory.event(l.scope, level, msg)
 	}
 }
 
 func (l *pionLogger) emitf(level slog.Level, format string, args ...any) {
-	// Formatting is skipped entirely when nothing consumes the record — pion
-	// traces every STUN packet at trace level.
-	if l.factory.logf == nil && l.factory.event == nil {
+	// Formatting is skipped entirely when nothing is waiting for the record.
+	if !l.factory.consumes(level) {
 		return
 	}
 	l.emit(level, fmt.Sprintf(format, args...))

--- a/packages/slicc-cli/internal/logging/pion.go
+++ b/packages/slicc-cli/internal/logging/pion.go
@@ -1,0 +1,71 @@
+package logging
+
+import (
+	"fmt"
+	"log/slog"
+
+	pionlogging "github.com/pion/logging"
+)
+
+// PionEvent is the optional structured tap on a pion record. It runs on
+// whatever pion goroutine produced the record (an ICE agent, a TURN client's
+// refresh loop), so implementations must be non-blocking and concurrency-safe.
+type PionEvent func(scope string, level slog.Level, msg string)
+
+// PionFactory adapts this package's diagnostic logging to the
+// pion/logging.LoggerFactory that webrtc.SettingEngine accepts.
+//
+// Installing it matters for presentation, not just plumbing: with
+// SettingEngine.LoggerFactory left nil, webrtc installs
+// pion/logging.NewDefaultLoggerFactory(), which writes every record at error
+// level straight to os.Stderr — so a flaky TURN allocation buries the CLI's own
+// output under `turnc ERROR: Fail to refresh permissions: …` lines that no
+// SLICC_LOG_LEVEL can turn off. Routed through here they are diagnostics: quiet
+// by default, back with SLICC_DEBUG=1, and countable via event.
+func PionFactory(logf func(format string, args ...any), event PionEvent) pionlogging.LoggerFactory {
+	return &pionFactory{logf: logf, event: event}
+}
+
+type pionFactory struct {
+	logf  func(format string, args ...any)
+	event PionEvent
+}
+
+func (f *pionFactory) NewLogger(scope string) pionlogging.LeveledLogger {
+	return &pionLogger{scope: scope, factory: f}
+}
+
+// pionLogger is one scope's ("turnc", "ice", "sctp") sink.
+type pionLogger struct {
+	scope   string
+	factory *pionFactory
+}
+
+func (l *pionLogger) emit(level slog.Level, msg string) {
+	if l.factory.logf != nil {
+		l.factory.logf("pion %s: %s", l.scope, msg)
+	}
+	if l.factory.event != nil {
+		l.factory.event(l.scope, level, msg)
+	}
+}
+
+func (l *pionLogger) emitf(level slog.Level, format string, args ...any) {
+	// Formatting is skipped entirely when nothing consumes the record — pion
+	// traces every STUN packet at trace level.
+	if l.factory.logf == nil && l.factory.event == nil {
+		return
+	}
+	l.emit(level, fmt.Sprintf(format, args...))
+}
+
+func (l *pionLogger) Trace(msg string)                  { l.emit(slog.LevelDebug, msg) }
+func (l *pionLogger) Tracef(format string, args ...any) { l.emitf(slog.LevelDebug, format, args...) }
+func (l *pionLogger) Debug(msg string)                  { l.emit(slog.LevelDebug, msg) }
+func (l *pionLogger) Debugf(format string, args ...any) { l.emitf(slog.LevelDebug, format, args...) }
+func (l *pionLogger) Info(msg string)                   { l.emit(slog.LevelInfo, msg) }
+func (l *pionLogger) Infof(format string, args ...any)  { l.emitf(slog.LevelInfo, format, args...) }
+func (l *pionLogger) Warn(msg string)                   { l.emit(slog.LevelWarn, msg) }
+func (l *pionLogger) Warnf(format string, args ...any)  { l.emitf(slog.LevelWarn, format, args...) }
+func (l *pionLogger) Error(msg string)                  { l.emit(slog.LevelError, msg) }
+func (l *pionLogger) Errorf(format string, args ...any) { l.emitf(slog.LevelError, format, args...) }

--- a/packages/slicc-cli/internal/logging/pion_test.go
+++ b/packages/slicc-cli/internal/logging/pion_test.go
@@ -1,0 +1,114 @@
+package logging
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type pionRecord struct {
+	scope string
+	level slog.Level
+	msg   string
+}
+
+func TestPionFactoryRoutesEveryLevel(t *testing.T) {
+	var mu sync.Mutex
+	var lines []string
+	var events []pionRecord
+	factory := PionFactory(
+		func(format string, args ...any) {
+			mu.Lock()
+			defer mu.Unlock()
+			lines = append(lines, fmt.Sprintf(format, args...))
+		},
+		func(scope string, level slog.Level, msg string) {
+			mu.Lock()
+			defer mu.Unlock()
+			events = append(events, pionRecord{scope, level, msg})
+		},
+	)
+
+	log := factory.NewLogger("turnc")
+	log.Trace("t")
+	log.Tracef("t%d", 1)
+	log.Debug("d")
+	log.Debugf("d%d", 1)
+	log.Info("i")
+	log.Infof("i%d", 1)
+	log.Warn("w")
+	log.Warnf("w%d", 1)
+	log.Error("e")
+	log.Errorf("e%d", 1)
+
+	if len(lines) != 10 || len(events) != 10 {
+		t.Fatalf("routed %d lines / %d events, want 10 each", len(lines), len(events))
+	}
+	if !strings.HasPrefix(lines[0], "pion turnc: ") {
+		t.Errorf("record %q is missing the scope prefix", lines[0])
+	}
+	// Levels must survive the trip; the status bar counts warnings and errors.
+	wantLevels := []slog.Level{
+		slog.LevelDebug, slog.LevelDebug, slog.LevelDebug, slog.LevelDebug,
+		slog.LevelInfo, slog.LevelInfo, slog.LevelWarn, slog.LevelWarn,
+		slog.LevelError, slog.LevelError,
+	}
+	for i, want := range wantLevels {
+		if events[i].level != want {
+			t.Errorf("event %d level = %v, want %v", i, events[i].level, want)
+		}
+		if events[i].scope != "turnc" {
+			t.Errorf("event %d scope = %q, want turnc", i, events[i].scope)
+		}
+	}
+	if events[1].msg != "t1" {
+		t.Errorf("formatted message = %q, want t1", events[1].msg)
+	}
+}
+
+func TestPionFactoryWithNoSinksIsSilent(_ *testing.T) {
+	// Nothing consumes the records, so nothing should be formatted either —
+	// pion traces every STUN packet at trace level.
+	log := PionFactory(nil, nil).NewLogger("ice")
+	log.Errorf("%s", panicOnFormat{})
+	log.Error("plain")
+}
+
+func TestPionFactoryEventOnlyStillFires(t *testing.T) {
+	var got int
+	log := PionFactory(nil, func(string, slog.Level, string) { got++ }).NewLogger("sctp")
+	log.Warnf("dropped %d", 3)
+	if got != 1 {
+		t.Errorf("event fired %d times, want 1", got)
+	}
+}
+
+func TestPionFactoryThroughTheDiagnosticLogger(t *testing.T) {
+	var buf strings.Builder
+	logger := New(&buf, Config{Enabled: true, Level: slog.LevelDebug})
+	PionFactory(logger.Logf, nil).NewLogger("turnc").
+		Errorf("Fail to refresh permissions: %s", "broken pipe")
+
+	out := buf.String()
+	if !strings.Contains(out, "pion turnc: Fail to refresh permissions: broken pipe") {
+		t.Errorf("diagnostic output %q is missing the pion record", out)
+	}
+}
+
+func TestPionFactoryIsQuietWhenTheLoggerIsOff(t *testing.T) {
+	// The default build has diagnostics disabled: this is what keeps TURN churn
+	// off a user's terminal.
+	var buf strings.Builder
+	logger := New(&buf, Config{})
+	PionFactory(logger.Logf, nil).NewLogger("turnc").Error("Fail to refresh permissions")
+	if buf.String() != "" {
+		t.Errorf("a disabled logger must emit nothing, got %q", buf.String())
+	}
+}
+
+// panicOnFormat panics if anything formats it, proving the format is skipped.
+type panicOnFormat struct{}
+
+func (panicOnFormat) String() string { panic("formatted a record nobody consumes") }

--- a/packages/slicc-cli/internal/logging/pion_test.go
+++ b/packages/slicc-cli/internal/logging/pion_test.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"sync"
@@ -29,6 +30,7 @@ func TestPionFactoryRoutesEveryLevel(t *testing.T) {
 			defer mu.Unlock()
 			events = append(events, pionRecord{scope, level, msg})
 		},
+		nil,
 	)
 
 	log := factory.NewLogger("turnc")
@@ -43,17 +45,19 @@ func TestPionFactoryRoutesEveryLevel(t *testing.T) {
 	log.Error("e")
 	log.Errorf("e%d", 1)
 
-	if len(lines) != 10 || len(events) != 10 {
-		t.Fatalf("routed %d lines / %d events, want 10 each", len(lines), len(events))
+	// The logger takes every level; the event tap is for link problems only, so
+	// pion's running commentary (trace/debug/info) never reaches it.
+	if len(lines) != 10 {
+		t.Fatalf("routed %d lines, want 10: %v", len(lines), lines)
 	}
 	if !strings.HasPrefix(lines[0], "pion turnc: ") {
 		t.Errorf("record %q is missing the scope prefix", lines[0])
 	}
-	// Levels must survive the trip; the status bar counts warnings and errors.
 	wantLevels := []slog.Level{
-		slog.LevelDebug, slog.LevelDebug, slog.LevelDebug, slog.LevelDebug,
-		slog.LevelInfo, slog.LevelInfo, slog.LevelWarn, slog.LevelWarn,
-		slog.LevelError, slog.LevelError,
+		slog.LevelWarn, slog.LevelWarn, slog.LevelError, slog.LevelError,
+	}
+	if len(events) != len(wantLevels) {
+		t.Fatalf("tapped %d events, want %d: %v", len(events), len(wantLevels), events)
 	}
 	for i, want := range wantLevels {
 		if events[i].level != want {
@@ -63,22 +67,22 @@ func TestPionFactoryRoutesEveryLevel(t *testing.T) {
 			t.Errorf("event %d scope = %q, want turnc", i, events[i].scope)
 		}
 	}
-	if events[1].msg != "t1" {
-		t.Errorf("formatted message = %q, want t1", events[1].msg)
+	if events[1].msg != "w1" {
+		t.Errorf("formatted message = %q, want w1", events[1].msg)
 	}
 }
 
 func TestPionFactoryWithNoSinksIsSilent(_ *testing.T) {
 	// Nothing consumes the records, so nothing should be formatted either —
 	// pion traces every STUN packet at trace level.
-	log := PionFactory(nil, nil).NewLogger("ice")
+	log := PionFactory(nil, nil, nil).NewLogger("ice")
 	log.Errorf("%s", panicOnFormat{})
 	log.Error("plain")
 }
 
 func TestPionFactoryEventOnlyStillFires(t *testing.T) {
 	var got int
-	log := PionFactory(nil, func(string, slog.Level, string) { got++ }).NewLogger("sctp")
+	log := PionFactory(nil, func(string, slog.Level, string) { got++ }, nil).NewLogger("sctp")
 	log.Warnf("dropped %d", 3)
 	if got != 1 {
 		t.Errorf("event fired %d times, want 1", got)
@@ -88,7 +92,7 @@ func TestPionFactoryEventOnlyStillFires(t *testing.T) {
 func TestPionFactoryThroughTheDiagnosticLogger(t *testing.T) {
 	var buf strings.Builder
 	logger := New(&buf, Config{Enabled: true, Level: slog.LevelDebug})
-	PionFactory(logger.Logf, nil).NewLogger("turnc").
+	PionFactory(logger.Logf, nil, logger.EnabledAt).NewLogger("turnc").
 		Errorf("Fail to refresh permissions: %s", "broken pipe")
 
 	out := buf.String()
@@ -102,7 +106,7 @@ func TestPionFactoryIsQuietWhenTheLoggerIsOff(t *testing.T) {
 	// off a user's terminal.
 	var buf strings.Builder
 	logger := New(&buf, Config{})
-	PionFactory(logger.Logf, nil).NewLogger("turnc").Error("Fail to refresh permissions")
+	PionFactory(logger.Logf, nil, logger.EnabledAt).NewLogger("turnc").Error("Fail to refresh permissions")
 	if buf.String() != "" {
 		t.Errorf("a disabled logger must emit nothing, got %q", buf.String())
 	}
@@ -112,3 +116,48 @@ func TestPionFactoryIsQuietWhenTheLoggerIsOff(t *testing.T) {
 type panicOnFormat struct{}
 
 func (panicOnFormat) String() string { panic("formatted a record nobody consumes") }
+
+func TestPionFactorySkipsFormattingForALoggerThatWouldDropIt(t *testing.T) {
+	// The production wiring: logf is a live closure over a logger that is off by
+	// default, and the event tap is always installed. pion still calls Tracef per
+	// STUN packet, so the record must die before it is formatted.
+	logger := New(io.Discard, Config{})
+	log := PionFactory(logger.Logf, func(string, slog.Level, string) {}, logger.EnabledAt).NewLogger("ice")
+	log.Tracef("%s", panicOnFormat{})
+	log.Debugf("%s", panicOnFormat{})
+	log.Infof("%s", panicOnFormat{})
+
+	// Warn and above still reach the tap, so those are formatted.
+	var got string
+	tapped := PionFactory(logger.Logf, func(_ string, _ slog.Level, msg string) { got = msg }, logger.EnabledAt).
+		NewLogger("turnc")
+	tapped.Errorf("Fail to refresh permissions: %s", "broken pipe")
+	if got != "Fail to refresh permissions: broken pipe" {
+		t.Errorf("tapped %q, want the formatted record", got)
+	}
+}
+
+func TestPionFactoryFormatsWhatTheLoggerAsksFor(t *testing.T) {
+	// SLICC_DEBUG=1: now the trace records are wanted, and nothing may swallow
+	// them.
+	var buf strings.Builder
+	logger := New(&buf, Config{Enabled: true, Level: slog.LevelDebug})
+	PionFactory(logger.Logf, nil, logger.EnabledAt).NewLogger("ice").Tracef("candidate %d", 7)
+	if !strings.Contains(buf.String(), "pion ice: candidate 7") {
+		t.Errorf("debug output %q dropped a wanted trace record", buf.String())
+	}
+}
+
+func TestEnabledAtFollowsTheConfiguredLevel(t *testing.T) {
+	warn := New(io.Discard, Config{Enabled: true, Level: slog.LevelWarn})
+	if warn.EnabledAt(slog.LevelDebug) {
+		t.Error("a warn logger claims to want debug records")
+	}
+	if !warn.EnabledAt(slog.LevelError) {
+		t.Error("a warn logger refuses error records")
+	}
+	var off *Logger
+	if off.EnabledAt(slog.LevelError) {
+		t.Error("a nil logger claims to want records")
+	}
+}

--- a/packages/slicc-cli/internal/tray/conn.go
+++ b/packages/slicc-cli/internal/tray/conn.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -85,6 +86,11 @@ type Options struct {
 	OnLinkDiag logging.PionEvent
 	// Logf is an optional diagnostic logger.
 	Logf func(format string, args ...any)
+	// LogWanted, when set, reports whether Logf would do anything with a record
+	// at that level. It exists for pion's records, which arrive per STUN packet
+	// at trace level: without it each one is formatted only for a disabled logger
+	// to throw it away. nil → every record is formatted.
+	LogWanted func(level slog.Level) bool
 	// HTTPClient overrides the signaling HTTP client (tests). nil → default.
 	HTTPClient *http.Client
 }
@@ -348,7 +354,7 @@ func (c *Conn) configurePeer(iceServers []signaling.TurnIceServer, sig *signalin
 // CLI's own output under `turnc ERROR: Fail to refresh permissions` lines that
 // no log level of ours can quiet.
 func (c *Conn) pionLoggerFactory() pionlogging.LoggerFactory {
-	return logging.PionFactory(c.opts.Logf, c.opts.OnLinkDiag)
+	return logging.PionFactory(c.opts.Logf, c.opts.OnLinkDiag, c.opts.LogWanted)
 }
 
 func (c *Conn) recreatePeer(iceServers []signaling.TurnIceServer, sig *signaling.Client, controllerID string, bootstrapIDRef *string) error {

--- a/packages/slicc-cli/internal/tray/conn.go
+++ b/packages/slicc-cli/internal/tray/conn.go
@@ -17,8 +17,10 @@ import (
 	"unicode/utf8"
 
 	"github.com/pion/ice/v4"
+	pionlogging "github.com/pion/logging"
 	"github.com/pion/webrtc/v4"
 
+	"github.com/ai-ecoverse/slicc-cli/internal/logging"
 	"github.com/ai-ecoverse/slicc-cli/internal/protocol"
 	"github.com/ai-ecoverse/slicc-cli/internal/signaling"
 )
@@ -70,6 +72,17 @@ type Options struct {
 	// OnMessage receives every inbound message except ping/pong (auto-handled).
 	// It runs on the data-channel read goroutine; keep it non-blocking.
 	OnMessage func(msgType string, raw []byte)
+	// OnActivity fires for every inbound frame, including keepalives and the
+	// transport framing OnMessage never sees. Any frame is proof the leader is
+	// alive; keepalives alone are not enough, because the leader answers pings
+	// rather than sending them. Runs on the data-channel read goroutine; keep it
+	// non-blocking.
+	OnActivity func()
+	// OnLinkDiag taps pion's own records (ICE state churn, TURN refresh
+	// failures) so a caller can summarize them — a counter in a status bar —
+	// instead of letting them scroll. Runs on pion goroutines; keep it
+	// non-blocking and concurrency-safe.
+	OnLinkDiag logging.PionEvent
 	// Logf is an optional diagnostic logger.
 	Logf func(format string, args ...any)
 	// HTTPClient overrides the signaling HTTP client (tests). nil → default.
@@ -289,6 +302,7 @@ func (c *Conn) configurePeer(iceServers []signaling.TurnIceServer, sig *signalin
 	// no TURN.
 	settingEngine := webrtc.SettingEngine{}
 	settingEngine.SetICEMulticastDNSMode(ice.MulticastDNSModeQueryOnly)
+	settingEngine.LoggerFactory = c.pionLoggerFactory()
 	api := webrtc.NewAPI(webrtc.WithSettingEngine(settingEngine))
 	pc, err := api.NewPeerConnection(config)
 	if err != nil {
@@ -324,6 +338,17 @@ func (c *Conn) configurePeer(iceServers []signaling.TurnIceServer, sig *signalin
 	c.pc = pc
 	c.mu.Unlock()
 	return nil
+}
+
+// pionLoggerFactory is the logging pion gets on every peer connection.
+//
+// It must be installed explicitly: with SettingEngine.LoggerFactory left nil,
+// webrtc falls back to pion/logging.NewDefaultLoggerFactory(), which writes
+// error records straight to os.Stderr — a flaky TURN allocation then buries the
+// CLI's own output under `turnc ERROR: Fail to refresh permissions` lines that
+// no log level of ours can quiet.
+func (c *Conn) pionLoggerFactory() pionlogging.LoggerFactory {
+	return logging.PionFactory(c.opts.Logf, c.opts.OnLinkDiag)
 }
 
 func (c *Conn) recreatePeer(iceServers []signaling.TurnIceServer, sig *signaling.Client, controllerID string, bootstrapIDRef *string) error {
@@ -421,6 +446,9 @@ type chunkReassembly struct {
 
 // dispatch decodes the discriminant and routes inbound messages.
 func (c *Conn) dispatch(data []byte) {
+	if c.opts.OnActivity != nil {
+		c.opts.OnActivity()
+	}
 	var env protocol.Envelope
 	if err := json.Unmarshal(data, &env); err != nil {
 		c.opts.logf("tray: dropping unparseable message: %v", err)

--- a/packages/slicc-cli/internal/tray/conn_test.go
+++ b/packages/slicc-cli/internal/tray/conn_test.go
@@ -2,6 +2,8 @@ package tray
 
 import (
 	"encoding/json"
+	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -355,5 +357,53 @@ func TestDispatchPassesSmallMessagesThrough(t *testing.T) {
 
 	if gotType != protocol.TypeUserMessageEcho {
 		t.Errorf("got type %q, want %q", gotType, protocol.TypeUserMessageEcho)
+	}
+}
+
+func TestDispatchReportsActivity(t *testing.T) {
+	beats := 0
+	c := &Conn{
+		opts: Options{OnActivity: func() { beats++ }},
+		done: make(chan struct{}),
+	}
+	// Every inbound frame counts as proof of life, keepalives included — the
+	// leader answers pings rather than sending them, so a follower that only
+	// watched keepalives would never see one. Unparseable frames count too:
+	// something is still arriving.
+	c.dispatch([]byte(`{"type":"ping"}`))
+	c.dispatch([]byte(`{"type":"pong"}`))
+	c.dispatch([]byte(`{"type":"status","scoopStatus":"ready"}`))
+	c.dispatch([]byte(`not json`))
+	if beats != 4 {
+		t.Errorf("counted %d frames, want 4", beats)
+	}
+}
+
+func TestDispatchWithoutActivityHookIsFine(_ *testing.T) {
+	c := newConnForDispatch(nil)
+	c.dispatch([]byte(`{"type":"pong"}`)) // must not panic
+}
+
+func TestPionRecordsReachTheConnsDiagnostics(t *testing.T) {
+	// pion must never reach os.Stderr on its own: webrtc's default factory logs
+	// error records there, which is what buried the CLI's output in
+	// `turnc ERROR: Fail to refresh permissions` walls.
+	var logged []string
+	var counted []slog.Level
+	c := &Conn{
+		opts: Options{
+			Logf:       func(format string, args ...any) { logged = append(logged, fmt.Sprintf(format, args...)) },
+			OnLinkDiag: func(_ string, level slog.Level, _ string) { counted = append(counted, level) },
+		},
+		done: make(chan struct{}),
+	}
+
+	c.pionLoggerFactory().NewLogger("turnc").Errorf("Fail to refresh permissions: %s", "broken pipe")
+
+	if len(logged) != 1 || !strings.Contains(logged[0], "pion turnc: Fail to refresh permissions: broken pipe") {
+		t.Errorf("pion record did not reach the diagnostic logger: %v", logged)
+	}
+	if len(counted) != 1 || counted[0] != slog.LevelError {
+		t.Errorf("link diagnostics = %v, want one error", counted)
 	}
 }

--- a/packages/slicc-cli/internal/ui/console.go
+++ b/packages/slicc-cli/internal/ui/console.go
@@ -358,14 +358,15 @@ const maxRewritableRows = 6
 // rewritableRows reports how many rows the event occupies for the purpose of
 // rewriting it, or 0 when it must not be rewritten: a row at or past the
 // terminal width has soft-wrapped, so the row count no longer matches what the
-// terminal actually did.
+// terminal actually did, and a row whose width cannot be measured with certainty
+// might have wrapped without us knowing.
 func (c *Console) rewritableRows(rows []string) int {
 	if len(rows) == 0 || len(rows) > maxRewritableRows {
 		return 0
 	}
 	width := c.widthLocked()
 	for _, row := range rows {
-		if visibleWidth(row) >= width {
+		if !rewriteSafe(row) || visibleWidth(row) >= width {
 			return 0
 		}
 	}

--- a/packages/slicc-cli/internal/ui/console.go
+++ b/packages/slicc-cli/internal/ui/console.go
@@ -1,0 +1,478 @@
+package ui
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Kind classifies an event line: it picks the glyph and color, and nothing
+// else. Plain mode ignores it entirely, so a kind is never load-bearing.
+type Kind uint8
+
+// Event kinds.
+const (
+	KindInfo Kind = iota
+	KindOk
+	KindWarn
+	KindError
+	KindExec
+	KindTool
+)
+
+// ANSI control sequences used by the sticky line. Deliberately the smallest
+// possible set: erase-line plus one-line-up, no alternate screen buffer and no
+// scroll regions, so output still scrolls back normally and a killed process
+// leaves the terminal usable.
+const (
+	eraseLine = "\r\x1b[2K"
+	cursorUp  = "\x1b[1A"
+)
+
+// minRepaint throttles bar repaints triggered by state changes; a burst of
+// counter updates (pion retrying a TURN allocation) must not turn into a burst
+// of writes. The ticker paints the pending state within one tick anyway.
+const minRepaint = 80 * time.Millisecond
+
+// tapeBucketTicks is how many ticks one history cell covers.
+const tapeBucketTicks = 5
+
+// Options configures a Console.
+type Options struct {
+	// Mode is the resolved capability of the target stream.
+	Mode Mode
+	// Tag prefixes every line in plain mode ("slicc follow"), reproducing the
+	// CLI's pre-TUI output verbatim.
+	Tag string
+	// Width reports the current terminal width; nil assumes DefaultWidth.
+	// Called per repaint so a resized window needs no signal handler.
+	Width func() int
+	// Now overrides the clock (tests).
+	Now func() time.Time
+	// Tick is the status-bar repaint interval (0 = one second).
+	Tick time.Duration
+}
+
+// Console renders event lines and, on an interactive terminal, keeps a status
+// bar pinned below them. Every method is safe to call from any goroutine: lines
+// arrive from the data-channel reader, counters from pion's internals, repaints
+// from the ticker.
+type Console struct {
+	w     io.Writer
+	mode  Mode
+	tag   string
+	width func() int
+	now   func() time.Time
+	tick  time.Duration
+
+	mu       sync.Mutex
+	status   Status
+	frame    int
+	bucket   int
+	barShown bool
+	lastPain time.Time
+	// last* track the most recent event so an identical repeat can be folded
+	// into it instead of scrolling a wall of the same message.
+	lastMsg   string
+	lastKind  Kind
+	lastCount int
+	// lastRows is how many terminal rows that event occupies, since rewriting it
+	// walks the cursor back up exactly that far. Zero means "not rewritable"
+	// (a wrapped or oversized event), which disables collapsing rather than
+	// risking a cursor walk over rows that are no longer where we left them.
+	lastRows int
+	// repeatRow marks that the row on screen is a compact repeat marker rather
+	// than the event itself — what an event too tall or too wide to rewrite in
+	// place collapses into.
+	repeatRow bool
+	stopped   bool
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+// New builds a Console writing to w.
+func New(w io.Writer, opts Options) *Console {
+	c := &Console{
+		w:     w,
+		mode:  opts.Mode,
+		tag:   opts.Tag,
+		width: opts.Width,
+		now:   opts.Now,
+		tick:  opts.Tick,
+	}
+	if c.now == nil {
+		c.now = time.Now
+	}
+	if c.width == nil {
+		c.width = func() int { return DefaultWidth }
+	}
+	if c.tick <= 0 {
+		c.tick = time.Second
+	}
+	c.status = Status{Started: c.now(), State: StateConnecting}
+	return c
+}
+
+// Mode reports the console's resolved presentation mode.
+func (c *Console) Mode() Mode { return c.mode }
+
+// Start begins repainting the status bar. It is a no-op in plain mode, so
+// callers need no conditionals.
+func (c *Console) Start() {
+	if !c.mode.Sticky {
+		return
+	}
+	c.mu.Lock()
+	if c.stop != nil || c.stopped {
+		c.mu.Unlock()
+		return
+	}
+	c.stop, c.done = make(chan struct{}), make(chan struct{})
+	stop, done := c.stop, c.done
+	c.mu.Unlock()
+	go c.run(stop, done)
+}
+
+// Stop removes the status bar and stops repainting. Later lines still print (a
+// closing summary), just without a bar. Safe to call more than once.
+func (c *Console) Stop() {
+	c.mu.Lock()
+	if c.stopped {
+		c.mu.Unlock()
+		return
+	}
+	c.stopped = true
+	stop, done := c.stop, c.done
+	c.mu.Unlock()
+
+	// The ticker goroutine takes the same lock, so it is joined unlocked.
+	if stop != nil {
+		close(stop)
+		<-done
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.barShown {
+		fmt.Fprint(c.w, eraseLine)
+		c.barShown = false
+	}
+}
+
+func (c *Console) run(stop <-chan struct{}, done chan<- struct{}) {
+	defer close(done)
+	ticker := time.NewTicker(c.tick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			c.mu.Lock()
+			c.frame++
+			c.status.tape.sample(c.status.State)
+			c.bucket++
+			if c.bucket >= tapeBucketTicks {
+				c.bucket = 0
+				c.status.tape.commit()
+			}
+			c.paintBarLocked(true)
+			c.mu.Unlock()
+		}
+	}
+}
+
+// Update mutates the status model and refreshes the bar.
+func (c *Console) Update(mutate func(*Status)) {
+	if mutate == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	mutate(&c.status)
+	c.status.tape.sample(c.status.State)
+	c.paintBarLocked(false)
+}
+
+// Snapshot copies the status model, for a closing summary.
+func (c *Console) Snapshot() Status {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.status
+}
+
+// Beat records an inbound keepalive.
+func (c *Console) Beat() {
+	c.Update(func(s *Status) { s.LastBeat = c.now() })
+}
+
+// CountDiag records one suppressed link diagnostic.
+func (c *Console) CountDiag() {
+	c.Update(func(s *Status) { s.Diags++ })
+}
+
+// Line prints one event. A multi-line message (an HTTP body quoted into an
+// error) stays one event: the first line is stamped and marked, the rest are
+// indented continuations.
+func (c *Console) Line(kind Kind, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.writeEntryLocked(kind, msg)
+}
+
+// Note prints a line only when there is no status bar. It is for information the
+// bar already carries live — the wait before the next reconnect, which the badge
+// counts down — where a line per occurrence would both duplicate the bar and,
+// by interleaving, stop the identical errors around it from collapsing.
+func (c *Console) Note(kind Kind, format string, args ...any) {
+	if c.mode.Sticky {
+		return
+	}
+	c.Line(kind, format, args...)
+}
+
+// Raw prints text (which may span lines) with no glyph, timestamp or plain-mode
+// tag — for the startup banner, whose layout is its own.
+func (c *Console) Raw(style Style, text string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.clearBarLocked()
+	fmt.Fprint(c.w, c.mode.Paint(style, text))
+	if !strings.HasSuffix(text, "\n") {
+		fmt.Fprintln(c.w)
+	}
+	c.resetDedupLocked()
+	c.paintBarLocked(true)
+}
+
+func (c *Console) writeEntryLocked(kind Kind, msg string) {
+	if !c.mode.Sticky {
+		// The classic one-line-per-event form, colored when the stream can take
+		// it. Newlines inside msg are left as they are and nothing is collapsed,
+		// so a redirected stream reads exactly as it did before this package
+		// existed — byte for byte, since Paint is a no-op without color.
+		_, style := kindLook(c.mode, kind)
+		if c.tag != "" {
+			msg = c.tag + ": " + msg
+		}
+		fmt.Fprintln(c.w, c.mode.Paint(style, msg))
+		return
+	}
+	if c.lastCount > 0 && c.lastMsg == msg && c.lastKind == kind {
+		c.collapseRepeatLocked(kind, msg)
+		return
+	}
+	rows := c.renderEntry(kind, msg, 1)
+	c.emitRowsLocked(rows, 0)
+	c.lastKind, c.lastMsg, c.lastCount = kind, msg, 1
+	c.lastRows = c.rewritableRows(rows)
+	c.repeatRow = false
+}
+
+// collapseRepeatLocked accounts for one more occurrence of the event already on
+// screen instead of scrolling a duplicate. A reconnect loop against a dead
+// leader repeats the same error every few seconds; without this the interesting
+// lines above scroll away.
+//
+// A small event is rewritten in place with a "(×3)" counter. An event too tall
+// or too wide for that keeps its detail on screen once and collapses into a
+// compact repeat marker, which is itself rewritten from then on — so the wall of
+// a wrapped multi-line error costs one extra row, no matter how long the leader
+// stays unreachable.
+func (c *Console) collapseRepeatLocked(kind Kind, msg string) {
+	c.lastCount++
+	if !c.repeatRow && c.lastRows > 0 {
+		rows := c.renderEntry(kind, msg, c.lastCount)
+		if len(rows) == c.lastRows && c.rewritableRows(rows) == c.lastRows {
+			c.emitRowsLocked(rows, c.lastRows)
+			return
+		}
+	}
+	rewind := 0
+	if c.repeatRow {
+		rewind = c.lastRows
+	}
+	marker := []string{c.repeatMarker(kind)}
+	c.emitRowsLocked(marker, rewind)
+	c.lastRows = c.rewritableRows(marker)
+	c.repeatRow = c.lastRows > 0
+}
+
+// repeatMarker is the one-row stand-in for an event that cannot be rewritten
+// where it sits.
+func (c *Console) repeatMarker(kind Kind) string {
+	glyph, style := kindLook(c.mode, kind)
+	count := fmt.Sprintf("%s repeated (%s%d)", c.mode.Glyph(GlyphRepeat), multiplySign(c.mode), c.lastCount)
+	return fmt.Sprintf("%s %s %s",
+		c.mode.Paint(StyleDim, c.now().Format("15:04:05")),
+		c.mode.Paint(style, glyph),
+		c.mode.Paint(StyleDim, count))
+}
+
+// emitRowsLocked writes rows, first walking the cursor back over rewind rows to
+// replace what is there.
+func (c *Console) emitRowsLocked(rows []string, rewind int) {
+	c.clearBarLocked()
+	if rewind > 0 {
+		fmt.Fprintf(c.w, "\x1b[%dA", rewind)
+	}
+	for _, row := range rows {
+		if rewind > 0 {
+			fmt.Fprint(c.w, eraseLine)
+		}
+		fmt.Fprintln(c.w, row)
+	}
+	c.paintBarLocked(true)
+}
+
+// renderEntry lays one event out as terminal rows.
+func (c *Console) renderEntry(kind Kind, msg string, count int) []string {
+	glyph, style := kindLook(c.mode, kind)
+	stamp := c.now().Format("15:04:05")
+	parts := strings.Split(strings.TrimRight(msg, "\n"), "\n")
+
+	head := fmt.Sprintf("%s %s %s", c.mode.Paint(StyleDim, stamp), c.mode.Paint(style, glyph), parts[0])
+	if count > 1 {
+		head += c.mode.Paint(StyleDim, fmt.Sprintf(" (%s%d)", multiplySign(c.mode), count))
+	}
+	rows := []string{head}
+	// Continuations line up under the message and are marked, not stamped: the
+	// event happened once, so it reads as one event.
+	indent := strings.Repeat(" ", len(stamp)+1)
+	for _, part := range parts[1:] {
+		rows = append(rows, indent+c.mode.Paint(StyleDim, c.mode.Glyph(GlyphContinuation)+" "+part))
+	}
+	return rows
+}
+
+// maxRewritableRows bounds how tall an event may be and still be collapsed in
+// place. A rewrite walks the cursor up, which is only sound while the event is
+// still on screen; a short pane and a long event are not worth the risk.
+const maxRewritableRows = 6
+
+// rewritableRows reports how many rows the event occupies for the purpose of
+// rewriting it, or 0 when it must not be rewritten: a row at or past the
+// terminal width has soft-wrapped, so the row count no longer matches what the
+// terminal actually did.
+func (c *Console) rewritableRows(rows []string) int {
+	if len(rows) == 0 || len(rows) > maxRewritableRows {
+		return 0
+	}
+	width := c.widthLocked()
+	for _, row := range rows {
+		if visibleWidth(row) >= width {
+			return 0
+		}
+	}
+	return len(rows)
+}
+
+func multiplySign(m Mode) string {
+	if m.Unicode {
+		return "×"
+	}
+	return "x"
+}
+
+func kindLook(m Mode, kind Kind) (glyph string, style Style) {
+	switch kind {
+	case KindOk:
+		return m.Glyph(GlyphOk), StyleGreen
+	case KindWarn:
+		return m.Glyph(GlyphWarn), StyleYellow
+	case KindError:
+		return m.Glyph(GlyphError), StyleRed
+	case KindExec:
+		return m.Glyph(GlyphExec), StyleCyan
+	case KindTool:
+		return m.Glyph(GlyphTool), StyleMagenta
+	default:
+		return m.Glyph(GlyphInfo), StyleDim
+	}
+}
+
+func (c *Console) clearBarLocked() {
+	if !c.barShown {
+		return
+	}
+	fmt.Fprint(c.w, eraseLine)
+	c.barShown = false
+}
+
+func (c *Console) resetDedupLocked() {
+	c.lastCount, c.lastMsg, c.lastRows, c.repeatRow = 0, "", 0, false
+}
+
+func (c *Console) paintBarLocked(force bool) {
+	if !c.mode.Sticky || c.stopped {
+		return
+	}
+	now := c.now()
+	if !force && c.barShown && now.Sub(c.lastPain) < minRepaint {
+		return
+	}
+	// One cell short of the width: a bar that fills the last column makes some
+	// terminals wrap to a new row, which would push the log up on every repaint.
+	bar := c.status.render(c.mode, now, c.frame, c.widthLocked()-1)
+	fmt.Fprint(c.w, eraseLine+bar)
+	c.barShown = true
+	c.lastPain = now
+}
+
+func (c *Console) widthLocked() int {
+	w := c.width()
+	if w <= 0 {
+		return DefaultWidth
+	}
+	return w
+}
+
+// maxPartialLine bounds a LineWriter's buffer so a runner that never emits a
+// newline cannot grow it without limit.
+const maxPartialLine = 8 << 10
+
+// LineWriter adapts the console to an io.Writer that expects to write whole
+// lines, so components holding an io.Writer (follow.Session's per-command log)
+// need no console awareness.
+func (c *Console) LineWriter(kind Kind) io.Writer {
+	return &lineWriter{console: c, kind: kind}
+}
+
+type lineWriter struct {
+	console *Console
+	kind    Kind
+
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (w *lineWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.buf = append(w.buf, p...)
+	var lines []string
+	for {
+		idx := bytes.IndexByte(w.buf, '\n')
+		if idx < 0 {
+			break
+		}
+		lines = append(lines, string(w.buf[:idx]))
+		w.buf = w.buf[idx+1:]
+	}
+	if len(w.buf) > maxPartialLine {
+		lines = append(lines, string(w.buf))
+		w.buf = w.buf[:0]
+	}
+	w.mu.Unlock()
+
+	// Emitted outside the writer's lock: Line takes the console lock, and a
+	// console repaint must never wait on a writer.
+	for _, line := range lines {
+		w.console.Line(w.kind, "%s", strings.TrimRight(line, "\r"))
+	}
+	return len(p), nil
+}

--- a/packages/slicc-cli/internal/ui/console_test.go
+++ b/packages/slicc-cli/internal/ui/console_test.go
@@ -1,0 +1,401 @@
+package ui
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer is a strings.Builder that survives the ticker goroutine writing
+// while a test reads.
+type syncBuffer struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+// fixedClock returns a clock that advances one second per reading, so
+// timestamps are deterministic but distinguishable.
+func fixedClock() func() time.Time {
+	base := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	var mu sync.Mutex
+	calls := 0
+	return func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		return base.Add(time.Duration(calls) * time.Second)
+	}
+}
+
+func plainConsole(w *syncBuffer) *Console {
+	return New(w, Options{Tag: "slicc follow", Now: fixedClock()})
+}
+
+func stickyConsole(w *syncBuffer, width int) *Console {
+	return New(w, Options{
+		Mode:  Mode{Sticky: true, Unicode: true},
+		Tag:   "slicc follow",
+		Width: func() int { return width },
+		Now:   fixedClock(),
+	})
+}
+
+func TestPlainModeReproducesTheClassicLines(t *testing.T) {
+	var buf syncBuffer
+	c := plainConsole(&buf)
+	c.Start() // must be inert without a terminal
+	c.Line(KindOk, "connected")
+	c.Line(KindError, "%s", "tray attach failed")
+	c.Update(func(s *Status) { s.State = StateConnected; s.Sessions++ })
+	c.Stop()
+
+	want := "slicc follow: connected\nslicc follow: tray attach failed\n"
+	if got := buf.String(); got != want {
+		t.Errorf("plain output = %q, want %q", got, want)
+	}
+}
+
+func TestPlainModeKeepsMultiLineMessagesIntact(t *testing.T) {
+	var buf syncBuffer
+	plainConsole(&buf).Line(KindError, "attach failed (body: {\n  \"code\": \"NOPE\"\n})")
+	want := "slicc follow: attach failed (body: {\n  \"code\": \"NOPE\"\n})\n"
+	if got := buf.String(); got != want {
+		t.Errorf("plain output = %q, want %q", got, want)
+	}
+}
+
+func TestPlainModeWithoutTag(t *testing.T) {
+	var buf syncBuffer
+	New(&buf, Options{Now: fixedClock()}).Line(KindInfo, "bare")
+	if got := buf.String(); got != "bare\n" {
+		t.Errorf("untagged output = %q", got)
+	}
+}
+
+func TestPlainModeRepeatsAreNotCollapsed(t *testing.T) {
+	// A redirected stream is somebody's log: every occurrence must be in it.
+	var buf syncBuffer
+	c := plainConsole(&buf)
+	for i := 0; i < 3; i++ {
+		c.Line(KindError, "same")
+	}
+	if got := strings.Count(buf.String(), "same"); got != 3 {
+		t.Errorf("logged %d occurrences, want 3", got)
+	}
+}
+
+func TestNoteOnlyPrintsWithoutABar(t *testing.T) {
+	var plain, sticky syncBuffer
+	plainConsole(&plain).Note(KindInfo, "reconnecting in 2s…")
+	stickyConsole(&sticky, 80).Note(KindInfo, "reconnecting in 2s…")
+
+	if !strings.Contains(plain.String(), "reconnecting in 2s…") {
+		t.Error("plain mode must keep the retry note")
+	}
+	if strings.Contains(sticky.String(), "reconnecting") {
+		t.Error("the status bar counts the retry down; the note must be dropped")
+	}
+}
+
+func TestStickyLineCarriesStampGlyphAndBar(t *testing.T) {
+	var buf syncBuffer
+	c := stickyConsole(&buf, 80)
+	c.Update(func(s *Status) { s.State = StateConnected; s.Sessions = 1 })
+	c.Line(KindOk, "connected")
+
+	out := buf.String()
+	if !strings.Contains(out, "✔ connected") {
+		t.Errorf("output %q is missing the marked line", out)
+	}
+	if !strings.Contains(out, "12:00:") {
+		t.Errorf("output %q is missing a timestamp", out)
+	}
+	if !strings.Contains(out, "● connected") {
+		t.Errorf("output %q is missing the status bar", out)
+	}
+	if !strings.Contains(out, eraseLine) {
+		t.Errorf("output %q never erases the bar before writing", out)
+	}
+}
+
+func TestStickyMultiLineIsOneEvent(t *testing.T) {
+	var buf syncBuffer
+	stickyConsole(&buf, 200).Line(KindError, "attach failed:\n  detail one\n  detail two")
+	out := buf.String()
+	if got := strings.Count(out, "✖"); got != 1 {
+		t.Errorf("marked %d rows, want 1 (%q)", got, out)
+	}
+	if got := strings.Count(out, "│"); got != 2 {
+		t.Errorf("continued %d rows, want 2 (%q)", got, out)
+	}
+}
+
+func TestStickyRepeatIsRewrittenInPlace(t *testing.T) {
+	var buf syncBuffer
+	c := stickyConsole(&buf, 80)
+	c.Line(KindError, "boom")
+	c.Line(KindError, "boom")
+	c.Line(KindError, "boom")
+
+	out := buf.String()
+	if !strings.Contains(out, "(×3)") {
+		t.Errorf("output %q is missing the repeat counter", out)
+	}
+	if strings.Contains(out, "(×2)") && strings.Contains(out, "(×3)") {
+		// Both may appear: each rewrite prints a new counter over the old row.
+		if got := strings.Count(out, cursorUp); got < 2 {
+			t.Errorf("output %q rewrote in place %d times, want 2", out, got)
+		}
+	}
+	if got := strings.Count(out, "\x1b[1A"); got != 2 {
+		t.Errorf("walked the cursor up %d times, want 2 (%q)", got, out)
+	}
+}
+
+func TestStickyWideRepeatCollapsesToAMarker(t *testing.T) {
+	// A message wider than the terminal soft-wraps, so its rows cannot be
+	// rewritten; the repeats must still not scroll the screen away.
+	var buf syncBuffer
+	c := stickyConsole(&buf, 24)
+	long := strings.Repeat("wide error ", 6)
+	for i := 0; i < 4; i++ {
+		c.Line(KindError, "%s", long)
+	}
+	out := buf.String()
+	if got := strings.Count(out, long); got != 1 {
+		t.Errorf("printed the long message %d times, want 1", got)
+	}
+	if !strings.Contains(out, "↺ repeated (×4)") {
+		t.Errorf("output %q is missing the repeat marker", out)
+	}
+}
+
+func TestStickyTallRepeatCollapsesToAMarker(t *testing.T) {
+	var buf syncBuffer
+	c := stickyConsole(&buf, 200)
+	tall := "head\n" + strings.Repeat("body\n", maxRewritableRows+2)
+	c.Line(KindError, "%s", tall)
+	c.Line(KindError, "%s", tall)
+	if !strings.Contains(buf.String(), "↺ repeated (×2)") {
+		t.Errorf("output %q is missing the repeat marker", buf.String())
+	}
+}
+
+func TestStickyDifferentMessageResetsCollapsing(t *testing.T) {
+	var buf syncBuffer
+	c := stickyConsole(&buf, 80)
+	c.Line(KindError, "first")
+	c.Line(KindError, "first")
+	c.Line(KindWarn, "first") // same text, different kind: a different event
+	c.Line(KindError, "second")
+	out := buf.String()
+	if !strings.Contains(out, "⚠ first") {
+		t.Errorf("output %q lost the differently-marked line", out)
+	}
+	if !strings.Contains(out, "✖ second") {
+		t.Errorf("output %q lost the new line", out)
+	}
+}
+
+func TestRawKeepsTextVerbatim(t *testing.T) {
+	var buf syncBuffer
+	plainConsole(&buf).Raw(StyleBoldCyan, "  banner art  ")
+	if got := buf.String(); got != "  banner art  \n" {
+		t.Errorf("raw output = %q", got)
+	}
+}
+
+func TestRawPaintsWhenColored(t *testing.T) {
+	var buf syncBuffer
+	New(&buf, Options{Mode: Mode{Color: true}, Now: fixedClock()}).Raw(StyleRed, "warning\n")
+	if got := buf.String(); got != "\x1b[31mwarning\n\x1b[0m" {
+		t.Errorf("raw colored output = %q", got)
+	}
+}
+
+func TestRawBreaksCollapsing(t *testing.T) {
+	var buf syncBuffer
+	c := stickyConsole(&buf, 80)
+	c.Line(KindError, "boom")
+	c.Raw(StyleNone, "----")
+	c.Line(KindError, "boom")
+	if strings.Contains(buf.String(), "×2") {
+		t.Error("a raw write sits between the two events; they must not be merged")
+	}
+}
+
+func TestLineWriterSplitsOnNewlines(t *testing.T) {
+	var buf syncBuffer
+	w := plainConsole(&buf).LineWriter(KindExec)
+	if _, err := w.Write([]byte("exec: ls\nexec: pwd\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := w.Write([]byte("exec: partial")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out := buf.String()
+	if out != "slicc follow: exec: ls\nslicc follow: exec: pwd\n" {
+		t.Errorf("line writer output = %q", out)
+	}
+	if _, err := w.Write([]byte(" done\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !strings.Contains(buf.String(), "slicc follow: exec: partial done\n") {
+		t.Errorf("a line split across writes must be joined, got %q", buf.String())
+	}
+}
+
+func TestLineWriterTrimsCarriageReturns(t *testing.T) {
+	var buf syncBuffer
+	w := plainConsole(&buf).LineWriter(KindExec)
+	_, _ = w.Write([]byte("windows line\r\n"))
+	if got := buf.String(); got != "slicc follow: windows line\n" {
+		t.Errorf("output = %q", got)
+	}
+}
+
+func TestLineWriterFlushesAnEndlessLine(t *testing.T) {
+	var buf syncBuffer
+	w := plainConsole(&buf).LineWriter(KindExec)
+	_, _ = w.Write([]byte(strings.Repeat("x", maxPartialLine+1)))
+	if buf.String() == "" {
+		t.Error("a writer that never sees a newline must still flush")
+	}
+}
+
+func TestBeatAndDiagCounters(t *testing.T) {
+	var buf syncBuffer
+	c := stickyConsole(&buf, 200)
+	c.Beat()
+	c.CountDiag()
+	c.CountDiag()
+	st := c.Snapshot()
+	if st.LastBeat.IsZero() {
+		t.Error("Beat must record a keepalive")
+	}
+	if st.Diags != 2 {
+		t.Errorf("Diags = %d, want 2", st.Diags)
+	}
+	if c.Mode().Sticky != true {
+		t.Error("Mode must report the resolved mode")
+	}
+}
+
+func TestUpdateIgnoresNil(_ *testing.T) {
+	var buf syncBuffer
+	c := stickyConsole(&buf, 80)
+	c.Update(nil) // must not panic
+}
+
+func TestStopClearsTheBarAndIsIdempotent(t *testing.T) {
+	var buf syncBuffer
+	c := stickyConsole(&buf, 80)
+	c.Start()
+	c.Line(KindOk, "connected")
+	c.Stop()
+	c.Stop()
+	if !strings.HasSuffix(buf.String(), eraseLine) {
+		t.Errorf("Stop must erase the bar, output ends %q", tail(buf.String(), 12))
+	}
+	// A line after Stop still prints, without resurrecting the bar.
+	before := buf.String()
+	c.Line(KindInfo, "session ended")
+	after := strings.TrimPrefix(buf.String(), before)
+	if !strings.Contains(after, "session ended") {
+		t.Errorf("post-Stop line missing, got %q", after)
+	}
+	if strings.Contains(after, "● ") || strings.Contains(after, "◌ ") {
+		t.Errorf("post-Stop output %q repainted a bar", after)
+	}
+}
+
+func TestTickerRepaintsAndStopJoins(t *testing.T) {
+	var buf syncBuffer
+	c := New(&buf, Options{
+		Mode:  Mode{Sticky: true, Unicode: true},
+		Width: func() int { return 80 },
+		Tick:  time.Millisecond,
+	})
+	c.Start()
+	c.Start() // a second Start must not spawn a second ticker
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && strings.Count(buf.String(), eraseLine) < 3 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	c.Stop()
+	painted := strings.Count(buf.String(), eraseLine)
+	after := buf.String()
+	time.Sleep(20 * time.Millisecond)
+	if buf.String() != after {
+		t.Error("Stop must join the ticker; output kept growing")
+	}
+	if painted < 3 {
+		t.Errorf("ticker painted %d times, want at least 3", painted)
+	}
+}
+
+func TestConcurrentLinesAndUpdates(t *testing.T) {
+	var buf syncBuffer
+	c := New(&buf, Options{
+		Mode:  Mode{Sticky: true, Unicode: true, Color: true},
+		Width: func() int { return 60 },
+		Tick:  time.Millisecond,
+	})
+	c.Start()
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				c.Line(KindExec, "exec: command %d-%d", n, j)
+				c.CountDiag()
+				c.Beat()
+			}
+		}(i)
+	}
+	wg.Wait()
+	c.Stop()
+	if got := c.Snapshot().Diags; got != 400 {
+		t.Errorf("Diags = %d, want 400", got)
+	}
+}
+
+// tail returns the last n bytes of s, for readable failure messages.
+func tail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}
+
+func TestConsoleColorsLinesWithoutTheBar(t *testing.T) {
+	var buf strings.Builder
+	// `watch` on a terminal: colors, but no sticky bar to fight the transcript.
+	c := New(&buf, Options{Mode: Mode{Color: true}, Tag: "slicc watch"})
+	c.Line(KindError, "boom")
+
+	got := buf.String()
+	if !strings.Contains(got, "slicc watch: boom") {
+		t.Errorf("output %q lost the classic line form", got)
+	}
+	if !strings.Contains(got, "\x1b[") {
+		t.Errorf("output %q was not colored", got)
+	}
+	if strings.Contains(got, eraseLine) {
+		t.Errorf("output %q moved the cursor without a bar to maintain", got)
+	}
+}

--- a/packages/slicc-cli/internal/ui/console_test.go
+++ b/packages/slicc-cli/internal/ui/console_test.go
@@ -399,3 +399,48 @@ func TestConsoleColorsLinesWithoutTheBar(t *testing.T) {
 		t.Errorf("output %q moved the cursor without a bar to maintain", got)
 	}
 }
+
+func TestRepeatOfUnmeasurableTextUsesTheMarkerNotACursorRewind(t *testing.T) {
+	var buf syncBuffer
+	c := stickyConsole(&buf, 80)
+	// Leader-supplied text: the CJK run may be drawn two cells per rune, so the
+	// row may already have wrapped. Rewinding over it would erase whatever the
+	// terminal put on the extra row.
+	msg := "tray attach failed: 世界世界"
+	c.Line(KindError, "%s", msg)
+	first := buf.String()
+	if strings.Contains(first, cursorUp) {
+		t.Fatalf("first occurrence moved the cursor: %q", first)
+	}
+	c.Line(KindError, "%s", msg)
+
+	got := strings.TrimPrefix(buf.String(), first)
+	if !strings.Contains(got, "repeated (×2)") {
+		t.Errorf("repeat %q did not fall back to the marker", got)
+	}
+	if strings.Contains(got, "世界") {
+		t.Errorf("repeat %q rewrote the unmeasurable row in place", got)
+	}
+	// The marker itself is built from runes we control, so from here on it is
+	// rewritten in place rather than adding a row per occurrence.
+	c.Line(KindError, "%s", msg)
+	if last := strings.TrimPrefix(buf.String(), first+got); !strings.Contains(last, cursorUp) {
+		t.Errorf("marker %q was not rewritten in place", last)
+	}
+}
+
+func TestRepeatOfPlainTextStillCollapsesInPlace(t *testing.T) {
+	var buf syncBuffer
+	c := stickyConsole(&buf, 80)
+	c.Line(KindError, "connection closed")
+	before := buf.String()
+	c.Line(KindError, "connection closed")
+
+	got := strings.TrimPrefix(buf.String(), before)
+	if !strings.Contains(got, cursorUp) || !strings.Contains(got, "(×2)") {
+		t.Errorf("repeat %q did not rewrite the row in place", got)
+	}
+	if strings.Contains(got, "repeated") {
+		t.Errorf("repeat %q used the marker for a row it could measure", got)
+	}
+}

--- a/packages/slicc-cli/internal/ui/status.go
+++ b/packages/slicc-cli/internal/ui/status.go
@@ -1,0 +1,231 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// State is the connection state shown in the status bar's badge.
+type State uint8
+
+// Connection states, in the order a follower moves through them.
+const (
+	StateConnecting State = iota
+	StateConnected
+	StateRetrying
+	StateOffline
+)
+
+// Status is the model behind the status bar. It is owned by a Console and only
+// ever mutated inside Console.Update, which holds the console lock — the
+// counters are bumped from pion goroutines and the bar is repainted from a
+// ticker.
+type Status struct {
+	// Started is the launch time the uptime counter counts from.
+	Started time.Time
+	// State is the current connection state.
+	State State
+	// RetryAt is when the next attempt fires (StateRetrying only); it drives a
+	// live countdown rather than a one-off "reconnecting in 30s" line.
+	RetryAt time.Time
+	// Attempt counts consecutive failed attempts (reset on a connect).
+	Attempt int
+	// Sessions counts successful connections; everything after the first is a
+	// reconnect. Zero means this process never reached the leader, which is why
+	// it also gates the closing summary.
+	Sessions int
+	// Execs counts leader-issued commands run in this process.
+	Execs int
+	// Diags counts pion records suppressed into the diagnostic logger — the
+	// TURN/ICE churn that used to scroll past as `turnc ERROR:` lines.
+	Diags int
+	// LastBeat is when the leader's last keepalive arrived (zero = none yet).
+	LastBeat time.Time
+	// Peer describes who the leader would run commands as, e.g.
+	// "alice@laptop · bash -c".
+	Peer string
+
+	tape tape
+}
+
+// segment is one styled span of the status bar. The bar is assembled as
+// segments so it can be truncated by display width without cutting an escape
+// sequence in half.
+type segment struct {
+	text  string
+	style Style
+}
+
+// render lays out the status bar for the given moment and caps it at width
+// cells. frame animates the spinner.
+func (s *Status) render(m Mode, now time.Time, frame, width int) string {
+	segs := []segment{s.badge(m, now, frame)}
+	segs = append(segs, segment{"up " + CompactDuration(now.Sub(s.Started)), StyleDim})
+	if !s.LastBeat.IsZero() {
+		segs = append(segs, segment{
+			fmt.Sprintf("%s %s", m.Glyph(GlyphBeat), CompactDuration(now.Sub(s.LastBeat))),
+			beatStyle(now.Sub(s.LastBeat)),
+		})
+	}
+	if s.Execs > 0 {
+		segs = append(segs, segment{fmt.Sprintf("%s %d execs", m.Glyph(GlyphExec), s.Execs), StyleCyan})
+	}
+	if s.Sessions > 1 {
+		segs = append(segs, segment{
+			fmt.Sprintf("%s %d reconnects", m.Glyph(GlyphReconnect), s.Sessions-1), StyleDim,
+		})
+	}
+	if s.Diags > 0 {
+		segs = append(segs, segment{
+			fmt.Sprintf("link %s %d", m.Glyph(GlyphWarn), s.Diags), StyleYellow,
+		})
+	}
+	if s.Peer != "" {
+		segs = append(segs, segment{s.Peer, StyleDim})
+	}
+	if tape := s.tape.render(m); tape != "" {
+		segs = append(segs, segment{tape, StyleNone})
+	}
+	return joinSegments(m, segs, width)
+}
+
+// badge is the leading state indicator: a colored dot for a settled state, a
+// spinner while a connection is in flight, and a live countdown while waiting
+// to retry.
+func (s *Status) badge(m Mode, now time.Time, frame int) segment {
+	switch s.State {
+	case StateConnected:
+		return segment{m.Glyph(GlyphConnected) + " connected", StyleBoldGreen}
+	case StateConnecting:
+		label := "connecting"
+		if s.Attempt > 0 {
+			label = fmt.Sprintf("reconnecting (try %d)", s.Attempt+1)
+		}
+		return segment{m.spinner(frame) + " " + label, StyleYellow}
+	case StateRetrying:
+		wait := time.Duration(0)
+		if !s.RetryAt.IsZero() && s.RetryAt.After(now) {
+			wait = s.RetryAt.Sub(now)
+		}
+		return segment{
+			fmt.Sprintf("%s retry in %s", m.Glyph(GlyphRetry), CompactDuration(wait.Round(time.Second))),
+			StyleYellow,
+		}
+	default:
+		return segment{m.Glyph(GlyphOffline) + " offline", StyleBoldRed}
+	}
+}
+
+// beatStyle ages the heartbeat field: the leader pings on a timer, so a beat
+// that stops arriving is the earliest sign of a half-open channel.
+func beatStyle(age time.Duration) Style {
+	switch {
+	case age < 30*time.Second:
+		return StyleGreen
+	case age < 90*time.Second:
+		return StyleYellow
+	default:
+		return StyleRed
+	}
+}
+
+// joinSegments lays fields out left to right within width, skipping any that no
+// longer fit. A field that is skipped does not disqualify the ones after it: on
+// a narrow terminal a long hostname would otherwise hide the short, useful
+// fields that follow it.
+func joinSegments(m Mode, segs []segment, width int) string {
+	const sep = "  "
+	var b strings.Builder
+	used := 0
+	for _, seg := range segs {
+		if seg.text == "" {
+			continue
+		}
+		cost := visibleWidth(seg.text)
+		if used > 0 {
+			cost += len(sep)
+		}
+		if used+cost > width {
+			continue
+		}
+		if used > 0 {
+			b.WriteString(sep)
+		}
+		b.WriteString(m.Paint(seg.style, seg.text))
+		used += cost
+	}
+	return b.String()
+}
+
+// tapeCells is how many buckets of connection history the bar shows.
+const tapeCells = 16
+
+// tape is a fixed-size history strip of connection state, one cell per bucket,
+// newest on the right — a glanceable answer to "has this link been stable?"
+// that costs one character per bucket.
+type tape struct {
+	cells   [tapeCells]State
+	filled  int
+	pending State
+	// hasPending marks a bucket in progress; the worst state seen in a bucket
+	// wins, so a blip inside it cannot be hidden by a recovery.
+	hasPending bool
+}
+
+// sample folds one observation into the bucket in progress.
+func (t *tape) sample(state State) {
+	if !t.hasPending || state > t.pending {
+		t.pending = state
+		t.hasPending = true
+	}
+}
+
+// commit closes the bucket in progress and pushes it onto the strip.
+func (t *tape) commit() {
+	if !t.hasPending {
+		return
+	}
+	copy(t.cells[:], t.cells[1:])
+	t.cells[tapeCells-1] = t.pending
+	if t.filled < tapeCells {
+		t.filled++
+	}
+	t.hasPending = false
+}
+
+func (t *tape) render(m Mode) string {
+	if t.filled == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, state := range t.cells[tapeCells-t.filled:] {
+		switch state {
+		case StateConnected:
+			b.WriteString(m.Paint(StyleGreen, m.Glyph(GlyphBlockFull)))
+		case StateConnecting, StateRetrying:
+			b.WriteString(m.Paint(StyleYellow, m.Glyph(GlyphBlockHalf)))
+		default:
+			b.WriteString(m.Paint(StyleRed, m.Glyph(GlyphBlockLow)))
+		}
+	}
+	return b.String()
+}
+
+// CompactDuration formats a duration for a status bar: one or two units, no
+// fractions, always short enough to sit next to a dozen other fields.
+func CompactDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm%02ds", int(d.Minutes()), int(d.Seconds())%60)
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh%02dm", int(d.Hours()), int(d.Minutes())%60)
+	default:
+		return fmt.Sprintf("%dd%02dh", int(d.Hours())/24, int(d.Hours())%24)
+	}
+}

--- a/packages/slicc-cli/internal/ui/status.go
+++ b/packages/slicc-cli/internal/ui/status.go
@@ -87,7 +87,11 @@ func (s *Status) render(m Mode, now time.Time, frame, width int) string {
 	if tape := s.tape.render(m); tape != "" {
 		segs = append(segs, segment{tape, StyleNone})
 	}
-	return joinSegments(m, segs, width)
+	// Clamped as a whole as well as per field: Peer carries a hostname and a
+	// runner command, and cellWidth cannot know how wide a terminal draws an
+	// "ambiguous width" character in either. One cell too many wraps the bar, and
+	// a wrapped bar pushes the log up on every repaint, so the width wins.
+	return truncateVisible(joinSegments(m, segs, width), width)
 }
 
 // badge is the leading state indicator: a colored dot for a settled state, a

--- a/packages/slicc-cli/internal/ui/status_test.go
+++ b/packages/slicc-cli/internal/ui/status_test.go
@@ -83,14 +83,24 @@ func TestStatusBadges(t *testing.T) {
 
 func TestStatusRenderNeverExceedsWidth(t *testing.T) {
 	now := time.Now()
-	st := Status{
-		Started: now.Add(-time.Hour), State: StateConnected, Sessions: 9, Execs: 99, Diags: 999,
-		LastBeat: now, Peer: "someone@a-very-long-hostname-indeed · docker exec -i sandbox sh -c",
+	peers := []string{
+		"someone@a-very-long-hostname-indeed · docker exec -i sandbox sh -c",
+		// Characters whose drawn width depends on the terminal's locale. The
+		// per-field measurement can undercount them, so the whole bar is clamped
+		// too: one cell too many wraps it, and a wrapped bar pushes the log up on
+		// every repaint.
+		"私@ホスト · bash -c",
 	}
-	for _, mode := range []Mode{unicodeMode, {Unicode: true, Color: true}, {}} {
-		for width := 1; width <= 120; width++ {
-			if got := visibleWidth(st.render(mode, now, 0, width)); got > width {
-				t.Fatalf("width %d overflowed to %d cells (mode %+v)", width, got, mode)
+	for _, peer := range peers {
+		st := Status{
+			Started: now.Add(-time.Hour), State: StateConnected, Sessions: 9, Execs: 99, Diags: 999,
+			LastBeat: now, Peer: peer,
+		}
+		for _, mode := range []Mode{unicodeMode, {Unicode: true, Color: true}, {}} {
+			for width := 1; width <= 120; width++ {
+				if got := visibleWidth(st.render(mode, now, 0, width)); got > width {
+					t.Fatalf("width %d overflowed to %d cells (mode %+v, peer %q)", width, got, mode, peer)
+				}
 			}
 		}
 	}

--- a/packages/slicc-cli/internal/ui/status_test.go
+++ b/packages/slicc-cli/internal/ui/status_test.go
@@ -1,0 +1,184 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+var unicodeMode = Mode{Unicode: true}
+
+func TestCompactDuration(t *testing.T) {
+	cases := map[time.Duration]string{
+		0:                             "0s",
+		1500 * time.Millisecond:       "1s",
+		59 * time.Second:              "59s",
+		time.Minute + 2*time.Second:   "1m02s",
+		90 * time.Minute:              "1h30m",
+		25*time.Hour + 30*time.Minute: "1d01h",
+		-5 * time.Second:              "0s",
+	}
+	for in, want := range cases {
+		if got := CompactDuration(in); got != want {
+			t.Errorf("CompactDuration(%s) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestStatusRenderFields(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	st := Status{
+		Started:  now.Add(-2 * time.Minute),
+		State:    StateConnected,
+		Sessions: 3,
+		Execs:    12,
+		Diags:    21,
+		LastBeat: now.Add(-4 * time.Second),
+		Peer:     "alice@laptop · bash -c",
+	}
+	got := st.render(unicodeMode, now, 0, 200)
+	for _, want := range []string{
+		"● connected", "up 2m00s", "♥ 4s", "▸ 12 execs", "⇅ 2 reconnects", "link ⚠ 21",
+		"alice@laptop · bash -c",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("bar %q is missing %q", got, want)
+		}
+	}
+}
+
+func TestStatusRenderOmitsEmptyFields(t *testing.T) {
+	now := time.Now()
+	st := Status{Started: now, State: StateConnected, Sessions: 1}
+	got := st.render(unicodeMode, now, 0, 200)
+	for _, unwanted := range []string{"execs", "reconnects", "link", "♥"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("a fresh session must not show %q: %q", unwanted, got)
+		}
+	}
+}
+
+func TestStatusBadges(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+		st   Status
+		want string
+	}{
+		{"connecting", Status{State: StateConnecting}, "connecting"},
+		{"retrying attempt", Status{State: StateConnecting, Attempt: 2}, "reconnecting (try 3)"},
+		{"countdown", Status{State: StateRetrying, RetryAt: now.Add(12 * time.Second)}, "retry in 12s"},
+		{"elapsed countdown", Status{State: StateRetrying, RetryAt: now.Add(-time.Second)}, "retry in 0s"},
+		{"offline", Status{State: StateOffline}, "offline"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.st.Started = now
+			if got := tc.st.render(unicodeMode, now, 0, 200); !strings.Contains(got, tc.want) {
+				t.Errorf("bar %q is missing %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStatusRenderNeverExceedsWidth(t *testing.T) {
+	now := time.Now()
+	st := Status{
+		Started: now.Add(-time.Hour), State: StateConnected, Sessions: 9, Execs: 99, Diags: 999,
+		LastBeat: now, Peer: "someone@a-very-long-hostname-indeed · docker exec -i sandbox sh -c",
+	}
+	for _, mode := range []Mode{unicodeMode, {Unicode: true, Color: true}, {}} {
+		for width := 1; width <= 120; width++ {
+			if got := visibleWidth(st.render(mode, now, 0, width)); got > width {
+				t.Fatalf("width %d overflowed to %d cells (mode %+v)", width, got, mode)
+			}
+		}
+	}
+}
+
+func TestStatusRenderKeepsStateWhenNarrow(t *testing.T) {
+	now := time.Now()
+	st := Status{Started: now, State: StateConnected, Sessions: 1, Execs: 5, Peer: "alice@laptop"}
+	// The badge is the field worth keeping when there is room for one field.
+	got := st.render(unicodeMode, now, 0, 12)
+	if !strings.Contains(got, "connected") {
+		t.Errorf("narrow bar %q dropped the state badge", got)
+	}
+	if strings.Contains(got, "execs") {
+		t.Errorf("narrow bar %q should have dropped the later fields", got)
+	}
+}
+
+func TestBeatStyleAges(t *testing.T) {
+	cases := map[time.Duration]Style{
+		time.Second:      StyleGreen,
+		45 * time.Second: StyleYellow,
+		5 * time.Minute:  StyleRed,
+	}
+	for age, want := range cases {
+		if got := beatStyle(age); got != want {
+			t.Errorf("beatStyle(%s) = %v, want %v", age, got, want)
+		}
+	}
+}
+
+func TestTapeWorstStateWins(t *testing.T) {
+	var tp tape
+	if tp.render(unicodeMode) != "" {
+		t.Error("an empty tape must render nothing")
+	}
+	// Within one bucket a blip must survive a recovery, or the strip would
+	// pretend the link was fine.
+	tp.sample(StateConnected)
+	tp.sample(StateOffline)
+	tp.sample(StateConnected)
+	tp.commit()
+	if got := tp.render(unicodeMode); got != "▁" {
+		t.Errorf("tape = %q, want the offline cell", got)
+	}
+	tp.sample(StateConnected)
+	tp.commit()
+	if got := tp.render(unicodeMode); got != "▁█" {
+		t.Errorf("tape = %q, want offline then connected", got)
+	}
+}
+
+func TestTapeCommitWithoutSampleIsNoop(t *testing.T) {
+	var tp tape
+	tp.commit()
+	if tp.filled != 0 {
+		t.Errorf("filled = %d, want 0", tp.filled)
+	}
+}
+
+func TestTapeRingIsBounded(t *testing.T) {
+	var tp tape
+	for i := 0; i < tapeCells*3; i++ {
+		tp.sample(StateConnected)
+		tp.commit()
+	}
+	if got := visibleWidth(tp.render(unicodeMode)); got != tapeCells {
+		t.Errorf("tape width = %d, want %d", got, tapeCells)
+	}
+}
+
+func TestStatusRenderSkipsOnlyTheFieldsThatDoNotFit(t *testing.T) {
+	now := time.Now()
+	// The peer name is far too long for this width; the history strip after it
+	// is three cells and must still make it in.
+	st := Status{
+		Started: now, State: StateConnected, Sessions: 1,
+		Peer: "somebody@an-absurdly-long-hostname-that-will-not-fit · bash -c",
+	}
+	for i := 0; i < 3; i++ {
+		st.tape.sample(StateConnected)
+		st.tape.commit()
+	}
+	got := st.render(unicodeMode, now, 0, 30)
+	if strings.Contains(got, "absurdly") {
+		t.Errorf("bar %q kept a field that cannot fit", got)
+	}
+	if !strings.Contains(got, "███") {
+		t.Errorf("bar %q dropped the history strip behind the oversized field", got)
+	}
+}

--- a/packages/slicc-cli/internal/ui/style.go
+++ b/packages/slicc-cli/internal/ui/style.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"strings"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -128,8 +129,7 @@ func (m Mode) spinner(frame int) string {
 }
 
 // visibleWidth counts the display cells a rendered string occupies, skipping
-// ANSI escape sequences. Every glyph in this package is single-cell, so runes
-// are cells.
+// ANSI escape sequences.
 func visibleWidth(s string) int {
 	width := 0
 	for i := 0; i < len(s); {
@@ -137,10 +137,120 @@ func visibleWidth(s string) int {
 			i += escapeLen(s[i:])
 			continue
 		}
-		i += runeLen(s[i:])
-		width++
+		r, size := decodeRune(s[i:])
+		i += size
+		width += cellWidth(r)
 	}
 	return width
+}
+
+// wideRanges are the code points a terminal draws two cells wide: the East Asian
+// Wide and Fullwidth blocks, plus the emoji blocks that are almost universally
+// double-width. Sorted; searched by bisection.
+//
+// It does not cover the Unicode "ambiguous width" class (which depends on the
+// terminal's locale), so a stray such character can still be undercounted by
+// one cell. That is why anything beyond this package's own symbols disqualifies
+// a row from being rewritten — see rewriteSafe.
+var wideRanges = [][2]rune{
+	{0x1100, 0x115F},   // Hangul Jamo
+	{0x2E80, 0x303E},   // CJK radicals, Kangxi, CJK symbols
+	{0x3041, 0x33FF},   // Kana, Bopomofo, Hangul compat, CJK compat
+	{0x3400, 0x4DBF},   // CJK ext A
+	{0x4E00, 0x9FFF},   // CJK unified
+	{0xA000, 0xA4CF},   // Yi
+	{0xA960, 0xA97F},   // Hangul Jamo ext A
+	{0xAC00, 0xD7A3},   // Hangul syllables
+	{0xF900, 0xFAFF},   // CJK compat ideographs
+	{0xFE10, 0xFE19},   // vertical forms
+	{0xFE30, 0xFE6F},   // CJK compat forms
+	{0xFF00, 0xFF60},   // fullwidth forms
+	{0xFFE0, 0xFFE6},   // fullwidth signs
+	{0x1F300, 0x1F64F}, // emoji: symbols, pictographs, emoticons
+	{0x1F680, 0x1F6FF}, // emoji: transport
+	{0x1F900, 0x1F9FF}, // emoji: supplemental
+	{0x1FA70, 0x1FAFF}, // emoji: extended
+	{0x20000, 0x3FFFD}, // CJK ext B and beyond
+}
+
+// cellWidth reports the terminal cells r occupies. Combining marks, variation
+// selectors and other zero-width code points add nothing (they decorate the
+// previous cell), the wide ranges take two, everything else one. Getting this
+// wrong breaks the bar's truncation and, worse, the row arithmetic behind an
+// in-place rewrite.
+func cellWidth(r rune) int {
+	if r == 0 {
+		return 0
+	}
+	if r < 0x80 {
+		return 1
+	}
+	if unicode.In(r, unicode.Mn, unicode.Me, unicode.Cf) {
+		return 0
+	}
+	lo, hi := 0, len(wideRanges)-1
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		switch {
+		case r < wideRanges[mid][0]:
+			hi = mid - 1
+		case r > wideRanges[mid][1]:
+			lo = mid + 1
+		default:
+			return 2
+		}
+	}
+	return 1
+}
+
+// ownRunes are the non-ASCII runes this package itself emits. Their width is
+// known (one cell each), which is what makes a row containing them safe to
+// rewrite in place.
+var ownRunes = func() map[rune]bool {
+	set := map[rune]bool{'×': true}
+	add := func(s string) {
+		for _, r := range s {
+			set[r] = true
+		}
+	}
+	for _, pair := range glyphs {
+		add(pair[0])
+		add(pair[1])
+	}
+	for _, frame := range spinnerUnicode {
+		add(frame)
+	}
+	return set
+}()
+
+// rewriteSafe reports whether every cell in s has a width this package can be
+// sure of, so the row count that follows from it can be trusted.
+//
+// Leader-supplied text (an error body, a scoop name) may hold anything: emoji
+// ZWJ sequences, "ambiguous width" characters a CJK locale draws wide, a rune
+// the terminal replaces with a box of its own choosing. Undercount such a row
+// and it silently soft-wraps, at which point walking the cursor up by the row
+// count lands mid-event and erases someone else's output. Rather than guess, a
+// row that is not plain ASCII plus our own symbols is never rewritten — it
+// collapses into the compact repeat marker instead, which is built only from
+// runes we control.
+func rewriteSafe(s string) bool {
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b {
+			i += escapeLen(s[i:])
+			continue
+		}
+		r, size := decodeRune(s[i:])
+		i += size
+		if r < 0x20 || r == 0x7f {
+			return false // a control character moves the cursor unpredictably
+		}
+		if r < 0x80 || ownRunes[r] {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // truncateVisible caps s at limit display cells, keeping escape sequences whole
@@ -160,16 +270,18 @@ func truncateVisible(s string, limit int) string {
 			i += n
 			continue
 		}
-		if width == limit {
+		r, size := decodeRune(s[i:])
+		// A double-wide rune with one cell left is dropped rather than split:
+		// half a cell is what makes a terminal wrap.
+		if width+cellWidth(r) > limit {
 			if styled {
 				b.WriteString(sgrReset)
 			}
 			return b.String()
 		}
-		size := runeLen(s[i:])
 		b.WriteString(s[i : i+size])
 		i += size
-		width++
+		width += cellWidth(r)
 	}
 	return b.String()
 }
@@ -189,11 +301,13 @@ func escapeLen(s string) int {
 	return len(s)
 }
 
-// runeLen returns the byte length of the rune at the start of s. An invalid byte
-// counts as one cell, so width accounting never stalls on malformed input.
-func runeLen(s string) int {
-	if _, size := utf8.DecodeRuneInString(s); size > 0 {
-		return size
+// decodeRune returns the rune at the start of s and its byte length. An invalid
+// byte decodes as utf8.RuneError over one byte, so scanning always advances and
+// malformed input is measured as the replacement character the terminal shows.
+func decodeRune(s string) (rune, int) {
+	r, size := utf8.DecodeRuneInString(s)
+	if size == 0 {
+		return utf8.RuneError, 1
 	}
-	return 1
+	return r, size
 }

--- a/packages/slicc-cli/internal/ui/style.go
+++ b/packages/slicc-cli/internal/ui/style.go
@@ -1,0 +1,199 @@
+package ui
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// Style is a semantic text style resolved to ANSI SGR codes (or dropped when
+// color is off).
+type Style uint8
+
+// The palette. Deliberately limited to the 8 basic colors plus dim/bold, which
+// every terminal since the 1980s renders and every user color scheme remaps.
+const (
+	StyleNone Style = iota
+	StyleDim
+	StyleBold
+	StyleRed
+	StyleGreen
+	StyleYellow
+	StyleBlue
+	StyleCyan
+	StyleMagenta
+	StyleBoldGreen
+	StyleBoldRed
+	StyleBoldCyan
+)
+
+var sgr = map[Style]string{
+	StyleDim:       "\x1b[2m",
+	StyleBold:      "\x1b[1m",
+	StyleRed:       "\x1b[31m",
+	StyleGreen:     "\x1b[32m",
+	StyleYellow:    "\x1b[33m",
+	StyleBlue:      "\x1b[34m",
+	StyleCyan:      "\x1b[36m",
+	StyleMagenta:   "\x1b[35m",
+	StyleBoldGreen: "\x1b[1;32m",
+	StyleBoldRed:   "\x1b[1;31m",
+	StyleBoldCyan:  "\x1b[1;36m",
+}
+
+const sgrReset = "\x1b[0m"
+
+// Paint wraps s in style when the mode allows color, and returns it untouched
+// otherwise.
+func (m Mode) Paint(style Style, s string) string {
+	code, ok := sgr[style]
+	if !m.Color || !ok || s == "" {
+		return s
+	}
+	return code + s + sgrReset
+}
+
+// Glyph is a semantic symbol with an ASCII fallback for terminals whose
+// encoding cannot be assumed UTF-8.
+type Glyph uint8
+
+// The symbol set.
+const (
+	GlyphOk Glyph = iota
+	GlyphWarn
+	GlyphError
+	GlyphExec
+	GlyphTool
+	GlyphInfo
+	GlyphConnected
+	GlyphConnecting
+	GlyphRetry
+	GlyphOffline
+	GlyphBeat
+	GlyphReconnect
+	GlyphBlockFull
+	GlyphBlockHalf
+	GlyphBlockLow
+	GlyphSeparator
+	GlyphContinuation
+	GlyphRepeat
+)
+
+var glyphs = map[Glyph][2]string{
+	// {unicode, ascii}
+	GlyphOk:           {"✔", "+"},
+	GlyphWarn:         {"⚠", "!"},
+	GlyphError:        {"✖", "x"},
+	GlyphExec:         {"▸", ">"},
+	GlyphTool:         {"⚙", "*"},
+	GlyphInfo:         {"·", "-"},
+	GlyphConnected:    {"●", "*"},
+	GlyphConnecting:   {"◌", "o"},
+	GlyphRetry:        {"⟳", "~"},
+	GlyphOffline:      {"○", "."},
+	GlyphBeat:         {"♥", "^"},
+	GlyphReconnect:    {"⇅", "@"},
+	GlyphBlockFull:    {"█", "#"},
+	GlyphBlockHalf:    {"▄", "="},
+	GlyphBlockLow:     {"▁", "_"},
+	GlyphSeparator:    {"·", "|"},
+	GlyphContinuation: {"│", "|"},
+	GlyphRepeat:       {"↺", "~"},
+}
+
+// Glyph renders g for the mode's encoding.
+func (m Mode) Glyph(g Glyph) string {
+	pair, ok := glyphs[g]
+	if !ok {
+		return ""
+	}
+	if m.Unicode {
+		return pair[0]
+	}
+	return pair[1]
+}
+
+// spinnerFrames animate a pending connection; the braille set is smooth, the
+// ASCII set is the classic four-frame twirl.
+var (
+	spinnerUnicode = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+	spinnerASCII   = []string{"|", "/", "-", "\\"}
+)
+
+func (m Mode) spinner(frame int) string {
+	set := spinnerASCII
+	if m.Unicode {
+		set = spinnerUnicode
+	}
+	return set[((frame%len(set))+len(set))%len(set)]
+}
+
+// visibleWidth counts the display cells a rendered string occupies, skipping
+// ANSI escape sequences. Every glyph in this package is single-cell, so runes
+// are cells.
+func visibleWidth(s string) int {
+	width := 0
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b {
+			i += escapeLen(s[i:])
+			continue
+		}
+		i += runeLen(s[i:])
+		width++
+	}
+	return width
+}
+
+// truncateVisible caps s at limit display cells, keeping escape sequences whole
+// and appending a reset so a cut inside styled text cannot leak color into the
+// rest of the line.
+func truncateVisible(s string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	var b strings.Builder
+	width, styled := 0, false
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b {
+			n := escapeLen(s[i:])
+			b.WriteString(s[i : i+n])
+			styled = true
+			i += n
+			continue
+		}
+		if width == limit {
+			if styled {
+				b.WriteString(sgrReset)
+			}
+			return b.String()
+		}
+		size := runeLen(s[i:])
+		b.WriteString(s[i : i+size])
+		i += size
+		width++
+	}
+	return b.String()
+}
+
+// escapeLen returns the byte length of the escape sequence at the start of s
+// (CSI sequences end at their final byte; anything else counts as one byte so
+// scanning always advances).
+func escapeLen(s string) int {
+	if len(s) < 2 || s[1] != '[' {
+		return 1
+	}
+	for i := 2; i < len(s); i++ {
+		if s[i] >= 0x40 && s[i] <= 0x7e {
+			return i + 1
+		}
+	}
+	return len(s)
+}
+
+// runeLen returns the byte length of the rune at the start of s. An invalid byte
+// counts as one cell, so width accounting never stalls on malformed input.
+func runeLen(s string) int {
+	if _, size := utf8.DecodeRuneInString(s); size > 0 {
+		return size
+	}
+	return 1
+}

--- a/packages/slicc-cli/internal/ui/style_test.go
+++ b/packages/slicc-cli/internal/ui/style_test.go
@@ -91,3 +91,71 @@ func TestTruncateVisible(t *testing.T) {
 		t.Errorf("multibyte truncate = %q, want ♥♥", got)
 	}
 }
+
+func TestCellWidthCountsTerminalCells(t *testing.T) {
+	cases := map[rune]int{
+		'a':      1,
+		'✔':      1, // our own symbols are single-cell
+		'界':      2, // CJK unified
+		'ｗ':      2, // fullwidth form
+		'한':      2, // Hangul syllable
+		'🚀':      2, // emoji
+		'\u0301': 0, // combining acute
+		'\ufe0f': 0, // variation selector
+		'\u200d': 0, // zero-width joiner
+	}
+	for r, want := range cases {
+		if got := cellWidth(r); got != want {
+			t.Errorf("cellWidth(%q) = %d, want %d", r, got, want)
+		}
+	}
+}
+
+func TestVisibleWidthMeasuresWideAndCombiningRunes(t *testing.T) {
+	// Two double-wide runes plus an accented "e" whose mark adds nothing.
+	if got := visibleWidth("世界e\u0301"); got != 5 {
+		t.Errorf("visibleWidth = %d, want 5", got)
+	}
+	// Styling still costs nothing.
+	if got := visibleWidth("\x1b[31m世\x1b[0m"); got != 2 {
+		t.Errorf("visibleWidth with color = %d, want 2", got)
+	}
+}
+
+func TestTruncateVisibleKeepsWideRunesWhole(t *testing.T) {
+	// One cell left over: the next rune needs two, so it is dropped rather than
+	// half-written — a split cell is exactly what makes a terminal wrap.
+	got := truncateVisible("a世界", 2)
+	if got != "a" {
+		t.Errorf("truncateVisible = %q, want %q", got, "a")
+	}
+	if got := truncateVisible("a世界", 3); got != "a世" {
+		t.Errorf("truncateVisible = %q, want %q", got, "a世")
+	}
+}
+
+func TestRewriteSafeOnlyTrustsRunesWeControl(t *testing.T) {
+	safe := []string{
+		"12:00:00 + connected",
+		"12:00:00 ✔ connected",                   // our glyph
+		"\x1b[2m12:00:00\x1b[0m ↺ repeated (×3)", // the repeat marker
+		"⠋ connecting  up 4s  ♥ 0s  ▁▄███",       // every bar symbol
+	}
+	for _, s := range safe {
+		if !rewriteSafe(s) {
+			t.Errorf("rewriteSafe(%q) = false, want true", s)
+		}
+	}
+	unsafe := []string{
+		"tray attach failed: 世界", // leader text a CJK locale may draw wide
+		"deploy 🚀 failed",        // emoji width is terminal-specific
+		"combining e\u0301",      // a mark whose placement we cannot verify
+		"tab\there",              // a control character moves the cursor
+		"bad utf8: \xff",         // replaced by a glyph of the terminal's choosing
+	}
+	for _, s := range unsafe {
+		if rewriteSafe(s) {
+			t.Errorf("rewriteSafe(%q) = true, want false", s)
+		}
+	}
+}

--- a/packages/slicc-cli/internal/ui/style_test.go
+++ b/packages/slicc-cli/internal/ui/style_test.go
@@ -1,0 +1,93 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPaint(t *testing.T) {
+	colored := Mode{Color: true}
+	if got := colored.Paint(StyleRed, "boom"); got != "\x1b[31mboom\x1b[0m" {
+		t.Errorf("colored paint = %q", got)
+	}
+	if got := colored.Paint(StyleNone, "plain"); got != "plain" {
+		t.Errorf("StyleNone must not wrap, got %q", got)
+	}
+	if got := colored.Paint(StyleRed, ""); got != "" {
+		t.Errorf("empty text must stay empty, got %q", got)
+	}
+	if got := (Mode{}).Paint(StyleRed, "boom"); got != "boom" {
+		t.Errorf("plain paint = %q, want the bare text", got)
+	}
+}
+
+func TestGlyphFallsBackToASCII(t *testing.T) {
+	if got := (Mode{Unicode: true}).Glyph(GlyphOk); got != "✔" {
+		t.Errorf("unicode glyph = %q", got)
+	}
+	if got := (Mode{}).Glyph(GlyphOk); got != "+" {
+		t.Errorf("ascii glyph = %q", got)
+	}
+	if got := (Mode{}).Glyph(Glyph(200)); got != "" {
+		t.Errorf("unknown glyph = %q, want empty", got)
+	}
+	// Width accounting assumes single-cell glyphs in both sets.
+	for g := range glyphs {
+		for _, mode := range []Mode{{Unicode: true}, {}} {
+			if w := visibleWidth(mode.Glyph(g)); w != 1 {
+				t.Errorf("glyph %d in %+v is %d cells, want 1", g, mode, w)
+			}
+		}
+	}
+}
+
+func TestSpinnerWraps(t *testing.T) {
+	mode := Mode{Unicode: true}
+	if mode.spinner(0) != mode.spinner(len(spinnerUnicode)) {
+		t.Error("spinner must cycle")
+	}
+	if got := (Mode{}).spinner(-1); got == "" {
+		t.Error("a negative frame must still render a frame")
+	}
+}
+
+func TestVisibleWidthIgnoresEscapes(t *testing.T) {
+	cases := map[string]int{
+		"abc":                   3,
+		"\x1b[31mabc\x1b[0m":    3,
+		"✔ ok":                  4,
+		"\x1b[1;32m✔\x1b[0m ok": 4,
+		"":                      0,
+		"\x1b[2K":               0,
+		"\x1bincomplete":        10, // a bare ESC consumes only itself; the rest counts
+	}
+	for in, want := range cases {
+		if got := visibleWidth(in); got != want {
+			t.Errorf("visibleWidth(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestTruncateVisible(t *testing.T) {
+	if got := truncateVisible("abcdef", 3); got != "abc" {
+		t.Errorf("plain truncate = %q", got)
+	}
+	if got := truncateVisible("abc", 10); got != "abc" {
+		t.Errorf("short input must pass through, got %q", got)
+	}
+	if got := truncateVisible("abc", 0); got != "" {
+		t.Errorf("zero limit = %q, want empty", got)
+	}
+	// A cut inside styled text must not leak the style into whatever follows.
+	got := truncateVisible("\x1b[31mabcdef\x1b[0m", 3)
+	if visibleWidth(got) != 3 {
+		t.Errorf("styled truncate kept %d cells, want 3 (%q)", visibleWidth(got), got)
+	}
+	if !strings.HasSuffix(got, sgrReset) {
+		t.Errorf("styled truncate must end reset, got %q", got)
+	}
+	// Multi-byte runes are never split.
+	if got := truncateVisible("♥♥♥♥", 2); got != "♥♥" {
+		t.Errorf("multibyte truncate = %q, want ♥♥", got)
+	}
+}

--- a/packages/slicc-cli/internal/ui/term_other.go
+++ b/packages/slicc-cli/internal/ui/term_other.go
@@ -1,0 +1,11 @@
+//go:build !unix && !windows
+
+package ui
+
+import "os"
+
+// terminalSize has no portable implementation on the remaining platforms
+// (js/wasm, plan9), so they always take the plain-output path.
+func terminalSize(*os.File) (int, bool) { return 0, false }
+
+func prepareTerminal(*os.File) bool { return false }

--- a/packages/slicc-cli/internal/ui/term_unix.go
+++ b/packages/slicc-cli/internal/ui/term_unix.go
@@ -1,0 +1,22 @@
+//go:build unix
+
+package ui
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// terminalSize returns the terminal's column count, and false when f is not a
+// terminal (the ioctl fails for pipes, files and /dev/null).
+func terminalSize(f *os.File) (int, bool) {
+	ws, err := unix.IoctlGetWinsize(int(f.Fd()), unix.TIOCGWINSZ)
+	if err != nil {
+		return 0, false
+	}
+	return int(ws.Col), true
+}
+
+// prepareTerminal is a no-op on unix: ANSI support needs no opt-in.
+func prepareTerminal(*os.File) bool { return true }

--- a/packages/slicc-cli/internal/ui/term_windows.go
+++ b/packages/slicc-cli/internal/ui/term_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package ui
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// terminalSize returns the console's column count, and false when f is not a
+// console handle.
+func terminalSize(f *os.File) (int, bool) {
+	var info windows.ConsoleScreenBufferInfo
+	if err := windows.GetConsoleScreenBufferInfo(windows.Handle(f.Fd()), &info); err != nil {
+		return 0, false
+	}
+	// Window, not buffer: the buffer is usually far wider than what is shown.
+	return int(info.Window.Right - info.Window.Left + 1), true
+}
+
+// prepareTerminal opts the console into ANSI escape-sequence processing, which
+// Windows leaves off for legacy consoles. A console that refuses is reported as
+// non-interactive so the caller falls back to plain output rather than printing
+// raw escape sequences.
+func prepareTerminal(f *os.File) bool {
+	handle := windows.Handle(f.Fd())
+	var mode uint32
+	if err := windows.GetConsoleMode(handle, &mode); err != nil {
+		return false
+	}
+	if mode&windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0 {
+		return true
+	}
+	return windows.SetConsoleMode(handle, mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING) == nil
+}

--- a/packages/slicc-cli/internal/ui/ui.go
+++ b/packages/slicc-cli/internal/ui/ui.go
@@ -1,0 +1,149 @@
+// Package ui renders the CLI's human-facing status output: colored event lines
+// and a sticky one-line status bar for the long-running verbs (`follow`,
+// `watch`).
+//
+// It is deliberately dependency-free (raw ANSI + stdlib) and degrades in one
+// step: when the target stream is not an interactive terminal — a pipe, a log
+// file, CI — Mode collapses to plain mode, where every line is written exactly
+// as the pre-TUI CLI wrote it ("slicc follow: connected") with no escape
+// sequences and no cursor movement. Machine-readable output must never depend
+// on a terminal being attached.
+//
+// Environment:
+//
+//	SLICC_NO_TUI=1    plain mode even on a terminal (also `--plain`)
+//	NO_COLOR          keep the status bar, drop the colors
+//	FORCE_COLOR       colors even when the stream is not a terminal
+//	COLUMNS           overrides the detected terminal width
+package ui
+
+import (
+	"os"
+	"strings"
+)
+
+// EnvNoTUI disables all terminal decoration when set to a non-empty, non-"0"
+// value.
+const EnvNoTUI = "SLICC_NO_TUI"
+
+// Env matches os.LookupEnv; injected so tests need no process env.
+type Env func(string) (string, bool)
+
+// Mode is the resolved presentation capability of one output stream. The zero
+// value is plain mode: no color, no status bar, ASCII only.
+type Mode struct {
+	// Color allows ANSI SGR sequences.
+	Color bool
+	// Sticky allows cursor movement — the repainted status bar and in-place
+	// line updates. Only ever true for an interactive terminal.
+	Sticky bool
+	// Unicode allows the non-ASCII glyph set.
+	Unicode bool
+}
+
+// Detect resolves the presentation mode for f.
+func Detect(f *os.File, env Env) Mode {
+	if env == nil {
+		env = os.LookupEnv
+	}
+	if v, ok := env(EnvNoTUI); ok && v != "" && v != "0" {
+		return Mode{}
+	}
+	term, _ := env("TERM")
+	// TERM=dumb promises no escape-sequence support at all; an unset TERM on a
+	// real terminal is common on Windows, so it is not disqualifying.
+	dumb := term == "dumb"
+	tty := IsTerminal(f) && !dumb
+
+	color := tty
+	if v, ok := env("NO_COLOR"); ok && v != "" {
+		color = false
+	}
+	if forcedColor(env) {
+		color = !dumb
+	}
+	return Mode{Color: color, Sticky: tty, Unicode: unicodeCapable(env)}
+}
+
+// Plain reports whether the mode carries no decoration at all.
+func (m Mode) Plain() bool { return !m.Color && !m.Sticky }
+
+func forcedColor(env Env) bool {
+	for _, key := range []string{"FORCE_COLOR", "CLICOLOR_FORCE"} {
+		if v, ok := env(key); ok && v != "" && v != "0" {
+			return true
+		}
+	}
+	return false
+}
+
+// unicodeCapable reports whether the terminal's encoding can be assumed UTF-8.
+// A wrong guess is not cosmetic on a legacy code page: glyphs turn into
+// multi-cell mojibake that breaks the status bar's width accounting.
+func unicodeCapable(env Env) bool {
+	for _, key := range []string{"LC_ALL", "LC_CTYPE", "LANG"} {
+		if v, ok := env(key); ok && v != "" {
+			lower := strings.ToLower(v)
+			return strings.Contains(lower, "utf-8") || strings.Contains(lower, "utf8")
+		}
+	}
+	// Windows sets no locale variables; the modern terminals that do set these
+	// are UTF-8, the legacy console is not.
+	if _, ok := env("WT_SESSION"); ok {
+		return true
+	}
+	if _, ok := env("TERM_PROGRAM"); ok {
+		return true
+	}
+	return false
+}
+
+// IsTerminal reports whether f is an interactive terminal. A character device
+// alone is not enough (/dev/null is one), so the terminal must also answer a
+// window-size query.
+func IsTerminal(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil || info.Mode()&os.ModeCharDevice == 0 {
+		return false
+	}
+	if _, ok := terminalSize(f); !ok {
+		return false
+	}
+	return prepareTerminal(f)
+}
+
+// DefaultWidth is the width assumed when a terminal reports none.
+const DefaultWidth = 80
+
+// Width returns the usable column count for f, honoring a COLUMNS override.
+func Width(f *os.File, env Env) int {
+	if env == nil {
+		env = os.LookupEnv
+	}
+	if v, ok := env("COLUMNS"); ok {
+		if n := atoiSafe(v); n > 0 {
+			return n
+		}
+	}
+	if n, ok := terminalSize(f); ok && n > 0 {
+		return n
+	}
+	return DefaultWidth
+}
+
+func atoiSafe(s string) int {
+	n := 0
+	for _, r := range strings.TrimSpace(s) {
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int(r-'0')
+		if n > 1<<16 {
+			return 0
+		}
+	}
+	return n
+}

--- a/packages/slicc-cli/internal/ui/ui_test.go
+++ b/packages/slicc-cli/internal/ui/ui_test.go
@@ -1,0 +1,120 @@
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// envMap builds an Env from a map, so a case declares only what it sets.
+func envMap(vars map[string]string) Env {
+	return func(key string) (string, bool) {
+		v, ok := vars[key]
+		return v, ok
+	}
+}
+
+// notATerminal is a regular file: a stream that must never be decorated.
+func notATerminal(t *testing.T) *os.File {
+	t.Helper()
+	f, err := os.Create(filepath.Join(t.TempDir(), "out"))
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	return f
+}
+
+func TestDetectRedirectedStreamIsPlain(t *testing.T) {
+	mode := Detect(notATerminal(t), envMap(map[string]string{"TERM": "xterm-256color"}))
+	if !mode.Plain() {
+		t.Fatalf("a redirected stream must be plain, got %+v", mode)
+	}
+}
+
+func TestDetectNilFileIsPlain(t *testing.T) {
+	if !Detect(nil, envMap(nil)).Plain() {
+		t.Fatal("a nil stream must be plain")
+	}
+}
+
+func TestDetectEnvOverrides(t *testing.T) {
+	f := notATerminal(t)
+	cases := []struct {
+		name      string
+		env       map[string]string
+		wantColor bool
+	}{
+		{"FORCE_COLOR paints a redirected stream", map[string]string{"FORCE_COLOR": "1"}, true},
+		{"CLICOLOR_FORCE too", map[string]string{"CLICOLOR_FORCE": "1"}, true},
+		{"FORCE_COLOR=0 is not forcing", map[string]string{"FORCE_COLOR": "0"}, false},
+		{"TERM=dumb beats FORCE_COLOR", map[string]string{"FORCE_COLOR": "1", "TERM": "dumb"}, false},
+		{"SLICC_NO_TUI beats FORCE_COLOR", map[string]string{"FORCE_COLOR": "1", EnvNoTUI: "1"}, false},
+		{"SLICC_NO_TUI=0 does not disable", map[string]string{"FORCE_COLOR": "1", EnvNoTUI: "0"}, true},
+		{"NO_COLOR drops color", map[string]string{"FORCE_COLOR": "1", "NO_COLOR": ""}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mode := Detect(f, envMap(tc.env))
+			if mode.Color != tc.wantColor {
+				t.Errorf("Color = %v, want %v (mode %+v)", mode.Color, tc.wantColor, mode)
+			}
+			// Cursor control is never emitted into something that is not a
+			// terminal, whatever the environment claims.
+			if mode.Sticky {
+				t.Error("a redirected stream must never be sticky")
+			}
+		})
+	}
+}
+
+func TestDetectNoColorKeepsBarOff(t *testing.T) {
+	mode := Detect(notATerminal(t), envMap(map[string]string{"NO_COLOR": "1", "FORCE_COLOR": ""}))
+	if mode.Color {
+		t.Error("NO_COLOR must drop color")
+	}
+}
+
+func TestUnicodeCapable(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"UTF-8 locale", map[string]string{"LANG": "en_US.UTF-8"}, true},
+		{"utf8 spelling", map[string]string{"LC_CTYPE": "de_DE.utf8"}, true},
+		{"LC_ALL wins", map[string]string{"LC_ALL": "C", "LANG": "en_US.UTF-8"}, false},
+		{"legacy code page", map[string]string{"LANG": "en_US.ISO8859-1"}, false},
+		{"windows terminal", map[string]string{"WT_SESSION": "abc"}, true},
+		{"nothing known", map[string]string{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := unicodeCapable(envMap(tc.env)); got != tc.want {
+				t.Errorf("unicodeCapable = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWidth(t *testing.T) {
+	f := notATerminal(t)
+	if got := Width(f, envMap(map[string]string{"COLUMNS": "133"})); got != 133 {
+		t.Errorf("COLUMNS override = %d, want 133", got)
+	}
+	if got := Width(f, envMap(map[string]string{"COLUMNS": "not-a-number"})); got != DefaultWidth {
+		t.Errorf("garbage COLUMNS = %d, want the default %d", got, DefaultWidth)
+	}
+	if got := Width(f, envMap(nil)); got != DefaultWidth {
+		t.Errorf("non-terminal width = %d, want the default %d", got, DefaultWidth)
+	}
+}
+
+func TestAtoiSafe(t *testing.T) {
+	cases := map[string]int{"80": 80, " 120 ": 120, "": 0, "12a": 0, "-5": 0, "999999999": 0}
+	for in, want := range cases {
+		if got := atoiSafe(in); got != want {
+			t.Errorf("atoiSafe(%q) = %d, want %d", in, got, want)
+		}
+	}
+}

--- a/packages/slicc-cli/main.go
+++ b/packages/slicc-cli/main.go
@@ -114,6 +114,7 @@ func dispatchJoinVerb(ctx context.Context, joinURL, sub string, rest []string) i
 		// Optional positional: a scoop jid to filter to. Default empty = tail
 		// whatever the leader broadcasts (the selected scoop — the browser view),
 		// since the cone's jid is a generated uid, not the literal "cone".
+		rest, plain := takePlainFlag(rest)
 		scoopJid := ""
 		if len(rest) > 0 {
 			if rest[0] == "-h" || rest[0] == "--help" {
@@ -122,7 +123,7 @@ func dispatchJoinVerb(ctx context.Context, joinURL, sub string, rest []string) i
 			}
 			scoopJid = rest[0]
 		}
-		return cmdWatch(ctx, joinURL, scoopJid)
+		return cmdWatch(ctx, joinURL, scoopJid, plain)
 	case "follow":
 		// Leading slicc-owned options (`--no-banner`, `--eval`, `--eval-quiet`,
 		// `--`) are consumed; everything after is the runner argv (verbatim), so
@@ -146,8 +147,9 @@ func usage(w *os.File) {
 Usage:
   slicc <join-url> prompt "<text>"    Stream one assistant turn from the leader, then exit
   slicc <join-url> exec "<command>"   Run a command in the leader's shell, stream stdout/stderr
-  slicc <join-url> watch [scoop]      Tail the leader's live agent output (a scoop jid filters) until Ctrl+C
-  slicc <join-url> follow [--no-banner] [runner...]
+  slicc <join-url> watch [--plain] [scoop]
+                                      Tail the leader's live agent output (a scoop jid filters) until Ctrl+C
+  slicc <join-url> follow [--no-banner] [--plain] [runner...]
                                       Stay connected as a follower. If a runner is given,
                                       the leader can run commands on THIS machine — each
                                       one is executed as "<runner> <command>", as the user
@@ -192,6 +194,11 @@ The <text>/<command> argument, curl-style:
   @-  or  -      read it from stdin        (echo "hi" | slicc <url> prompt -)
 
 The <join-url> is a leader's https://…/join/<token> link.
+
+On an interactive terminal, follow/watch keep a live status bar (connection
+state, uptime, heartbeat, exec + reconnect counts) below their output. Piped
+output is plain by construction; --plain or SLICC_NO_TUI=1 forces it, and
+NO_COLOR keeps the bar without color.
 `)
 }
 
@@ -230,6 +237,9 @@ type followArgs struct {
 	runner     []string
 	showBanner bool
 	help       bool
+	// plain forces the piped output style (no status bar, no color) even on an
+	// interactive terminal.
+	plain bool
 	// eval switches follow into persistent-REPL mode: the runner is spawned
 	// once and each leader command is written as a line to its stdin.
 	eval bool
@@ -254,6 +264,10 @@ func parseFollowArgs(rest []string) followArgs {
 			fa.showBanner = false
 			rest = rest[1:]
 			continue
+		case rest[0] == "--plain":
+			fa.plain = true
+			rest = rest[1:]
+			continue
 		case rest[0] == "--eval":
 			fa.eval = true
 			rest = rest[1:]
@@ -274,6 +288,16 @@ func parseFollowArgs(rest []string) followArgs {
 	}
 	fa.runner = rest
 	return fa
+}
+
+// takePlainFlag consumes a leading `--plain` from a verb's argv, returning the
+// rest. Only `watch` needs it standalone; `follow` parses it with its other
+// options.
+func takePlainFlag(rest []string) ([]string, bool) {
+	if len(rest) > 0 && rest[0] == "--plain" {
+		return rest[1:], true
+	}
+	return rest, false
 }
 
 // parseEvalQuiet parses a `--eval-quiet` duration ("750ms", "2s"); invalid or


### PR DESCRIPTION
## Summary

`slicc follow` and `slicc watch` used to bury their own output under pion's TURN churn and repeat their reconnect lines forever. They now render through a new `internal/ui` package: a sticky one-line status bar under the log, color-coded and glyph-marked event lines, and repeated errors folded into a counted line. The `turnc ERROR:` records are silenced at the source and counted instead. Redirected output is unchanged, byte for byte.

## Why

Sitting in a `follow` session looked like this:

```
turnc ERROR: 2026/08/19 12:04:11 Fail to refresh permissions: ... broken pipe
turnc ERROR: 2026/08/19 12:04:14 Fail to refresh permissions: ... all retransmissions failed
slicc follow: connection closed
slicc follow: reconnecting in 2s...
slicc follow: connected
```

**Repro:** run `slicc <join-url> follow bash -c` on a flaky link (or against a leader whose TURN allocation churns) and watch stderr.
Expected: a readable picture of whether the link is up.
Actual: hundreds of `turnc ERROR:` lines from a logger SLICC does not own, plus one reconnect triplet per attempt, scrolling everything useful away.

The flood was never SLICC's logging. Leaving `SettingEngine.LoggerFactory` nil makes webrtc install **pion's own default factory**, which writes error records straight to `os.Stderr` — no `SLICC_LOG_LEVEL` of ours can reach them.

## Approach / Implementation notes

- **Layering.** `logging.PionFactory` (new) implements `pion/logging.LoggerFactory`; `Conn.pionLoggerFactory()` installs it on the setting engine, so pion records become ordinary diagnostics (silent by default, back with `SLICC_DEBUG=1`) and the warn-and-above ones are tallied through `tray.Options.OnLinkDiag` into the bar's `link ⚠ N`. `internal/ui` (new) owns all presentation; `commands.go` holds the wiring; `follow.Session` writes a bare `exec: <cmd>` and the console owns the prefix.
- **No new modules.** Stdlib plus the winsize ioctl from `golang.org/x/sys`, which was already in the module graph (both it and `pion/logging` are just promoted to direct). Raw ANSI, no TUI framework.
- **Deliberately no alternate screen buffer and no scroll regions** — only `\r\x1b[2K` and `\x1b[NA` — so scrollback still works and a `kill -9` leaves a usable terminal. Width is re-queried per repaint, so a resize needs no SIGWINCH handler.
- **Plain mode is the contract.** With no terminal the console emits the pre-existing `"<tag>: <msg>"` text, escape-free, newlines preserved, nothing collapsed (a redirected stream is someone's log; every occurrence belongs in it). Cursor control is never written to a non-terminal. `--plain` / `SLICC_NO_TUI=1` force it; `NO_COLOR` keeps the bar without color; `FORCE_COLOR`/`CLICOLOR_FORCE` colors a pipe without making it sticky; `COLUMNS` overrides the width. Every glyph has an ASCII twin, because mojibake on a legacy code page would break the bar's width accounting.
- **Two non-obvious rules**, both found by reading the leader and watching real panes:
  - The bar's heartbeat feeds off **every inbound frame** (`tray.Options.OnActivity`), not keepalives: the leader *answers* pings rather than sending them (`tray-follower-sync.ts` is the pinger; `LEADER_TRAY_PING_INTERVAL_MS` is the signaling socket's keepalive), so a follower watching ping/pong alone would show an empty field forever.
  - `watch` **drops the bar when stdout is a terminal too**: it streams the transcript there in partial lines (`content_delta` rarely ends at a line boundary), and the bar's line-erase would eat half-written assistant text. The transcript wins; the status lines keep their colors.
- **Locking.** One mutex guards the console's writer and dedup state; repaints from state changes are throttled to 80 ms and a 1 s ticker catches up, so the ticker goroutine and the data-channel callbacks cannot interleave escapes.

What it looks like now:

```
12:14:15 ✔ connected
12:14:26 ▸ exec: git status --short
12:15:02 ✖ tray attach: unexpected role "" (body: {
         │   "code": "TRAY_NOT_INITIALIZED"
         │ })
12:15:41 ✖ ↺ repeated (×6)
● connected  up 2m14s  ♥ 4s  ▸ 3 execs  ⇅ 1 reconnects  alice@laptop · bash -c  ▁▄████
```

## Cross-cutting impact

- **Floats exercised**: CLI only. No TypeScript, Swift, extension, worker or Electron code is touched; the webapp was read (to establish who sends keepalives) but not changed.
- **Other callers of the changed contract**: `tray.Options` gained two optional hooks and lost none; `internal/tray`'s existing callers (`cmdWatch`, `cmdFollow`, `cloud.go`) are all updated, and `cmdWatch` gained a `plain` parameter that `watch-cloud` passes through. `follow.Session`'s stderr echo lost its `slicc follow: ` prefix because the console adds it — the visible text on a pipe is unchanged.
- **Output contracts**: `prompt`/`exec`/`watch` still write leader bytes to stdout untouched, and `watch`'s stdout glyphs stay literal (`cli_e2e_test.go` greps for `> <text>` and `⚙ <tool>`); only color varies there, and only when stdout is itself a terminal.
- **Security**: nothing new is printed. The bar shows `user@host · runner`, all of which the banner already printed; join URLs and tokens are not part of any status line, and pion records go to the diagnostic logger, not the bar.
- **Bundle size**: N/A (Go binary; no new modules).

## Test plan

- [x] `cd packages/slicc-cli && make check` — gofmt, `go mod tidy -diff`, `go vet`, golangci-lint (**0 issues**), `go test -race`, coverage **67.9%** (floor 58%).
- [x] `npm run verify` — all 7 checks pass (biome, prettier, custom-lints incl. `lint:docs` + jscpd duplication, boy-scout-debt, manifest, deadcode, deadcode-prod).
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK (11 changed files, 0 on any debt list).
- [x] **New behavior is covered by unit tests**: `internal/ui/{ui,style,status,console}_test.go` (capability detection, width accounting, bar layout and field-skipping, repeat collapsing, plain-mode byte fidelity, colored non-sticky path), `internal/logging/pion_test.go` (level mapping, no-sink silence), `internal/tray/conn_test.go` (activity hook fires on every frame incl. unparseable; pion records reach the diagnostics), `cli_test.go` (`--plain` parsing, `watchModes`, `followPeer`, `shortHost`, status transitions, session summary).
- [x] Manual smoke against a **live leader** in zellij panes: `watch` shows colored tool calls with the transcript owning the screen; `follow` shows the bar with a populating `♥`, the retry countdown, and `link ⚠ 17` for records that previously printed as `turnc ERROR:` walls. Three rendering bugs were found on screen this way and fixed: per-row glyphs on multi-line errors, collapsing defeated by an interleaved retry line, and a narrow pane where one long hostname hid every field behind it.
- [x] Verified plain mode by redirecting: `slicc … follow 2>&1 | cat` produces the same escape-free text as before.
- TS gates (`npm run typecheck` / `test` / `test:coverage` / both builds) were **not** run locally: no TS/JS source is in the diff. Left to CI.

**Pre-existing failures**: none observed.

## Documentation

- [x] `packages/slicc-cli/README.md` (user-facing: `--plain` in the usage block, new "Live status bar" section with an annotated sample)
- [x] `packages/slicc-cli/CLAUDE.md` (pion diagnostics bullet, new "Terminal presentation" section, `internal/ui` in the layout)
- [x] `docs/slicc-cli-details.md` (design notes: capability detection, plain-mode contract, bar fields, event collapsing, "pion's own logging", `watch` glyph literalness)

## Risk & rollback

- **Blast radius**: the CLI only, and mostly its stderr. The worst plausible regression is cosmetic (a misdrawn bar on an exotic terminal), and the two escape hatches — `--plain` and `SLICC_NO_TUI=1` — restore the old output exactly.
- **Env knobs introduced**: `SLICC_NO_TUI`; `NO_COLOR`, `FORCE_COLOR`, `CLICOLOR_FORCE`, `COLUMNS` are honored.
- **Rollback**: revert cleanly, single commit, no persisted state and no protocol change (the two new `tray.Options` hooks are optional and nil-safe).
- **Worth a human eye**: rendering on a terminal I could not test — Windows Terminal / conhost (the VT-processing opt-in path) and a non-UTF-8 locale (the ASCII glyph twins).

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] Contract used by other floats: the tray data-channel protocol is untouched; only the follower's local rendering changed
