### PR TITLE
fix(ci): name the bots allowed to initiate Claude runs instead of allowing all

### DIFF
--- a/.github/workflows/agentic-debt-triage.yml
+++ b/.github/workflows/agentic-debt-triage.yml
@@ -109,9 +109,17 @@ jobs:
           # On `schedule` events GitHub sets the actor to the last actor on the
           # default branch, which in this merge-queue repo is `github-merge-queue`
           # (a bot). claude-code-action's human-actor gate otherwise rejects the
-          # nightly run with "Workflow initiated by non-human actor". Allow all
-          # bots so the cron can run unattended.
-          allowed_bots: '*'
+          # nightly run with "Workflow initiated by non-human actor".
+          #
+          # Named bots rather than `'*'`: this repo is PUBLIC, and the action's own
+          # docs warn that `'*'` lets external Apps invoke it with prompts they
+          # control. Both names below are GitHub's first-party bots, which no third
+          # party can act as, so every installed App (Renovate, Codex, Copilot)
+          # stays out. `github-actions[bot]` is here because a release commit can
+          # land on main between merges, making it the last actor. If a run is ever
+          # rejected by the actor gate, the log names the actor — add it here
+          # deliberately rather than widening back to `'*'`.
+          allowed_bots: 'github-merge-queue[bot],github-actions[bot]'
           # Print Claude's full turn-by-turn output to the Actions log on manual
           # dispatch (to inspect its reasoning); kept off for the nightly cron so
           # routine runs don't log tool output that may contain sensitive data.

--- a/.github/workflows/backlog-dispatcher.yml
+++ b/.github/workflows/backlog-dispatcher.yml
@@ -196,7 +196,16 @@ jobs:
           # default branch, which in this merge-queue repo is `github-merge-queue`
           # (a bot). claude-code-action's human-actor gate otherwise rejects the
           # scheduled run with "Workflow initiated by non-human actor".
-          allowed_bots: '*'
+          #
+          # Named bots rather than `'*'`: this repo is PUBLIC, and the action's own
+          # docs warn that `'*'` lets external Apps invoke it with prompts they
+          # control. Both names below are GitHub's first-party bots, which no third
+          # party can act as, so every installed App (Renovate, Codex, Copilot)
+          # stays out. `github-actions[bot]` is here because a release commit can
+          # land on main between merges, making it the last actor. If a run is ever
+          # rejected by the actor gate, the log names the actor — add it here
+          # deliberately rather than widening back to `'*'`.
+          allowed_bots: 'github-merge-queue[bot],github-actions[bot]'
           # Full turn-by-turn output on manual dispatch only; the cron keeps it
           # off so routine runs don't log tool output that may be sensitive.
           show_full_output: ${{ github.event_name == 'workflow_dispatch' }}
@@ -265,7 +274,16 @@ jobs:
           # Job permissions above scope this token; Claude's own `gh`/`git` work
           # runs under BOT_PAT via the env block.
           github_token: ${{ github.token }}
-          allowed_bots: '*'
+          #
+          # Named bots rather than `'*'`: this repo is PUBLIC, and the action's own
+          # docs warn that `'*'` lets external Apps invoke it with prompts they
+          # control. Both names below are GitHub's first-party bots, which no third
+          # party can act as, so every installed App (Renovate, Codex, Copilot)
+          # stays out. `github-actions[bot]` is here because a release commit can
+          # land on main between merges, making it the last actor. If a run is ever
+          # rejected by the actor gate, the log names the actor — add it here
+          # deliberately rather than widening back to `'*'`.
+          allowed_bots: 'github-merge-queue[bot],github-actions[bot]'
           show_full_output: ${{ github.event_name == 'workflow_dispatch' }}
           claude_args: |
             --model ${{ vars.BACKLOG_BEDROCK_MODEL || vars.RUM_BEDROCK_MODEL || 'global.anthropic.claude-sonnet-4-6' }}

--- a/.github/workflows/backlog-dispatcher.yml
+++ b/.github/workflows/backlog-dispatcher.yml
@@ -274,7 +274,6 @@ jobs:
           # Job permissions above scope this token; Claude's own `gh`/`git` work
           # runs under BOT_PAT via the env block.
           github_token: ${{ github.token }}
-          #
           # Named bots rather than `'*'`: this repo is PUBLIC, and the action's own
           # docs warn that `'*'` lets external Apps invoke it with prompts they
           # control. Both names below are GitHub's first-party bots, which no third

--- a/.github/workflows/boy-scout-debt-dispatcher.yml
+++ b/.github/workflows/boy-scout-debt-dispatcher.yml
@@ -173,9 +173,17 @@ jobs:
           # On `schedule` events GitHub sets the actor to the last actor on the
           # default branch, which in this merge-queue repo is `github-merge-queue`
           # (a bot). claude-code-action's human-actor gate otherwise rejects the
-          # nightly run with "Workflow initiated by non-human actor". Allow all
-          # bots so the cron can run unattended.
-          allowed_bots: '*'
+          # nightly run with "Workflow initiated by non-human actor".
+          #
+          # Named bots rather than `'*'`: this repo is PUBLIC, and the action's own
+          # docs warn that `'*'` lets external Apps invoke it with prompts they
+          # control. Both names below are GitHub's first-party bots, which no third
+          # party can act as, so every installed App (Renovate, Codex, Copilot)
+          # stays out. `github-actions[bot]` is here because a release commit can
+          # land on main between merges, making it the last actor. If a run is ever
+          # rejected by the actor gate, the log names the actor — add it here
+          # deliberately rather than widening back to `'*'`.
+          allowed_bots: 'github-merge-queue[bot],github-actions[bot]'
           # Print Claude's full turn-by-turn output to the Actions log on manual
           # dispatch (to inspect its reasoning); kept off for the nightly cron so
           # routine runs don't log tool output that may contain sensitive data.

--- a/.github/workflows/claude-md-compactor.yml
+++ b/.github/workflows/claude-md-compactor.yml
@@ -133,7 +133,16 @@ jobs:
           # (a bot). claude-code-action's human-actor gate otherwise rejects the
           # run with "Workflow initiated by non-human actor". Allow all bots so
           # the cron can run unattended.
-          allowed_bots: '*'
+          #
+          # Named bots rather than `'*'`: this repo is PUBLIC, and the action's own
+          # docs warn that `'*'` lets external Apps invoke it with prompts they
+          # control. Both names below are GitHub's first-party bots, which no third
+          # party can act as, so every installed App (Renovate, Codex, Copilot)
+          # stays out. `github-actions[bot]` is here because a release commit can
+          # land on main between merges, making it the last actor. If a run is ever
+          # rejected by the actor gate, the log names the actor — add it here
+          # deliberately rather than widening back to `'*'`.
+          allowed_bots: 'github-merge-queue[bot],github-actions[bot]'
           # Print Claude's full turn-by-turn output on manual dispatch (to
           # inspect its reasoning); kept off for the weekly cron so routine runs
           # don't log tool output that may contain sensitive data.

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -171,7 +171,15 @@ jobs:
           # is what makes reviewing our own agents' PRs possible at all; the
           # job-level `if` still keeps every other bot's PRs (Renovate) out, and
           # the fork guard is unchanged.
-          allowed_bots: '*'
+          #
+          # Named rather than `'*'`: this repo is PUBLIC, and the action's own docs
+          # warn that `'*'` lets external Apps invoke it with prompts they control —
+          # a real concern here, because this job checks out PR-authored code and
+          # runs it. The only bot that can author an in-repo `automation/*` PR is
+          # `github-actions[bot]`. Renovate is excluded by the job `if` and must
+          # stay excluded here too, so a future `if` change cannot quietly let a
+          # third-party App's PR content drive a reviewer that executes code.
+          allowed_bots: 'github-actions[bot]'
           # allowedTools: the inline-comment MCP tool PLUS unrestricted Bash, so
           # the reviewer can use `gh pr comment` / `gh api` for PR context AND
           # actually run the code (npm ci, targeted tests, build) to verify

--- a/.github/workflows/flaky-ci-hunter.yml
+++ b/.github/workflows/flaky-ci-hunter.yml
@@ -162,9 +162,17 @@ jobs:
           # On `schedule` events GitHub sets the actor to the last actor on the
           # default branch, which in this merge-queue repo is `github-merge-queue`
           # (a bot). claude-code-action's human-actor gate otherwise rejects the
-          # weekly run with "Workflow initiated by non-human actor". Allow all
-          # bots so the cron can run unattended.
-          allowed_bots: '*'
+          # weekly run with "Workflow initiated by non-human actor".
+          #
+          # Named bots rather than `'*'`: this repo is PUBLIC, and the action's own
+          # docs warn that `'*'` lets external Apps invoke it with prompts they
+          # control. Both names below are GitHub's first-party bots, which no third
+          # party can act as, so every installed App (Renovate, Codex, Copilot)
+          # stays out. `github-actions[bot]` is here because a release commit can
+          # land on main between merges, making it the last actor. If a run is ever
+          # rejected by the actor gate, the log names the actor — add it here
+          # deliberately rather than widening back to `'*'`.
+          allowed_bots: 'github-merge-queue[bot],github-actions[bot]'
           # Print Claude's full turn-by-turn output to the Actions log on manual
           # dispatch (to inspect its reasoning); kept off for the weekly cron so
           # routine runs don't log tool output that may contain sensitive data.

--- a/.github/workflows/pr-fix-dispatcher.yml
+++ b/.github/workflows/pr-fix-dispatcher.yml
@@ -174,7 +174,16 @@ jobs:
           # default branch, which in this merge-queue repo is `github-merge-queue`
           # (a bot). claude-code-action's human-actor gate otherwise rejects the
           # scheduled run with "Workflow initiated by non-human actor".
-          allowed_bots: '*'
+          #
+          # Named bots rather than `'*'`: this repo is PUBLIC, and the action's own
+          # docs warn that `'*'` lets external Apps invoke it with prompts they
+          # control. Both names below are GitHub's first-party bots, which no third
+          # party can act as, so every installed App (Renovate, Codex, Copilot)
+          # stays out. `github-actions[bot]` is here because a release commit can
+          # land on main between merges, making it the last actor. If a run is ever
+          # rejected by the actor gate, the log names the actor — add it here
+          # deliberately rather than widening back to `'*'`.
+          allowed_bots: 'github-merge-queue[bot],github-actions[bot]'
           # Full turn-by-turn output on manual dispatch only; the cron keeps it
           # off so routine runs don't log tool output that may be sensitive.
           show_full_output: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/renovate-patch-reconcile.yml
+++ b/.github/workflows/renovate-patch-reconcile.yml
@@ -17,8 +17,13 @@ name: Renovate Patch Reconcile
 # Trigger gating: Renovate-authored PRs in THIS repo (not forks) carrying the
 # `patched-dependency` label. claude-code-action normally rejects bot-initiated
 # runs; `allowed_bots: renovate[bot]` opts this one bot in (a fixed prompt — the
-# PR's dependency diff is data, not instructions — and a private repo, so the
-# external-App caveat in the action docs does not apply).
+# PR's dependency diff is data, not instructions).
+#
+# The action's external-App caveat DOES apply here: this repo is public, and
+# Renovate is a third-party App. Naming exactly one bot is what bounds it —
+# only Renovate can initiate this workflow, on its own labelled PRs in this
+# repo, with a prompt this file controls. (An earlier version of this comment
+# waved the caveat away on the grounds that the repo was private. It is not.)
 #
 # Security: the reconcile step runs `npm ci` (executing the bumped dependency's
 # lifecycle scripts) and pushes to the PR branch with contents:write. That is

--- a/.github/workflows/rum-error-triage.yml
+++ b/.github/workflows/rum-error-triage.yml
@@ -205,7 +205,6 @@ jobs:
         with:
           use_bedrock: 'true'
           github_token: ${{ github.token }}
-          #
           # Named bots rather than `'*'`: this repo is PUBLIC, and the action's own
           # docs warn that `'*'` lets external Apps invoke it with prompts they
           # control. Both names below are GitHub's first-party bots, which no third

--- a/.github/workflows/rum-error-triage.yml
+++ b/.github/workflows/rum-error-triage.yml
@@ -112,9 +112,17 @@ jobs:
           # On `schedule` events GitHub sets the actor to the last actor on the
           # default branch, which in this merge-queue repo is `github-merge-queue`
           # (a bot). claude-code-action's human-actor gate otherwise rejects the
-          # nightly run with "Workflow initiated by non-human actor". Allow all
-          # bots so the cron can run unattended.
-          allowed_bots: '*'
+          # nightly run with "Workflow initiated by non-human actor".
+          #
+          # Named bots rather than `'*'`: this repo is PUBLIC, and the action's own
+          # docs warn that `'*'` lets external Apps invoke it with prompts they
+          # control. Both names below are GitHub's first-party bots, which no third
+          # party can act as, so every installed App (Renovate, Codex, Copilot)
+          # stays out. `github-actions[bot]` is here because a release commit can
+          # land on main between merges, making it the last actor. If a run is ever
+          # rejected by the actor gate, the log names the actor — add it here
+          # deliberately rather than widening back to `'*'`.
+          allowed_bots: 'github-merge-queue[bot],github-actions[bot]'
           # Print Claude's full turn-by-turn output to the Actions log on manual
           # dispatch (to inspect its reasoning); kept off for the nightly cron so
           # routine runs don't log tool output that may contain sensitive data.
@@ -197,7 +205,16 @@ jobs:
         with:
           use_bedrock: 'true'
           github_token: ${{ github.token }}
-          allowed_bots: '*'
+          #
+          # Named bots rather than `'*'`: this repo is PUBLIC, and the action's own
+          # docs warn that `'*'` lets external Apps invoke it with prompts they
+          # control. Both names below are GitHub's first-party bots, which no third
+          # party can act as, so every installed App (Renovate, Codex, Copilot)
+          # stays out. `github-actions[bot]` is here because a release commit can
+          # land on main between merges, making it the last actor. If a run is ever
+          # rejected by the actor gate, the log names the actor — add it here
+          # deliberately rather than widening back to `'*'`.
+          allowed_bots: 'github-merge-queue[bot],github-actions[bot]'
           show_full_output: ${{ github.event_name == 'workflow_dispatch' }}
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |


### PR DESCRIPTION
## Summary

`allowed_bots: '*'` appeared at **eleven call sites across nine workflows**. The action's own input description warns against exactly that:

> or `'*'` to allow all bots. **WARNING: On public repos with `'*'`, external Apps may be able to invoke this action with prompts they control.**

This repo is public. I added five of those eleven yesterday (#2167, #2177) without reading that warning closely enough; the rest predate that work. `renovate-patch-reconcile.yml` had already established the better pattern by naming a single bot.

## The rule

**Allow GitHub's own first-party bots; never a third-party App.** No external party can act as `github-merge-queue[bot]` or `github-actions[bot]`, so naming them keeps the automation working while Renovate, Codex, Copilot and anything installed later stay out.

I verified the list against the bots that actually appear in this repo rather than guessing:

| Bot | Seen as | Allowed? |
| --- | --- | --- |
| `github-merge-queue[bot]` | Actor on **every** scheduled run (20/20 of the last runs of both pre-existing workflows) | Yes — first-party |
| `github-actions[bot]` | 21 comments; can author an `automation/*` PR; last actor after a release commit | Yes — first-party |
| `renovate[bot]` / `app/renovate` | 18 comments, 6 commits on main, 5 `claude-pr-review` runs (all skipped by the job `if:`) | No — third-party App |
| `chatgpt-codex-connector[bot]` | 38 comments | No — third-party App |
| `copilot-pull-request-reviewer[bot]` | Reviews on automation PRs | No — third-party App |

## Per-workflow

- **Scheduled agents** (boy-scout, pr-fix, backlog ×2, compactor, flake hunter, agentic-debt-triage, rum-error-triage ×2) → `github-merge-queue[bot],github-actions[bot]`. On `schedule`, GitHub attributes the run to the last actor on the default branch, which in this merge-queue repo is the queue bot. `github-actions[bot]` covers a release commit landing on main between merges (`semantic-release` does push to main), which would make it the last actor instead.
- **`claude-pr-review.yml`** → `github-actions[bot]` alone. The actor on a `pull_request` event is the PR author, and the only bot that can author an in-repo `automation/*` PR is that one. This is the job where the caveat matters most, because it checks out PR-authored code and runs it. Renovate is excluded by the job `if:` today; naming the list means a future `if:` change cannot quietly hand a third-party App's content to a reviewer that executes code.
- **`renovate-patch-reconcile.yml`** — comment only. It dismissed the caveat with "and a private repo, so the external-App caveat in the action docs does not apply". The repo is public, so the caveat does apply; naming one bot is what actually bounds it, which is what that workflow was already doing. The stale premise is worse than no comment, because the next person tightening this file would reason from it.

## Cross-cutting impact

- **Floats exercised**: none. CI-only.
- **Blast radius**: if a run is ever initiated by a bot not on the list, `claude-code-action` rejects it and the run fails **loudly** with the actor named in the log. The comments instruct adding that actor deliberately rather than widening back to `'*'`. A visible failed run is the right trade against a silent prompt-injection surface on a public repo.
- **No behaviour change expected**: today's reviewer runs are initiated by `trieloff` (a User, since #2167 opens automation PRs with `BOT_PAT`), which the actor gate never blocked.

## Test plan

- [x] `npm run verify` — 7/7
- [x] `npm run lint:docs` — clean
- [x] `check-touched-exemptions.mjs origin/main` — `OK (9 changed file(s), 0 still on any debt list)`
- [x] `npx prettier --check .github/workflows/*.yml` — clean
- [x] All eleven values re-read by parsing the YAML, not by eye — every site now names bots and none is `'*'`
- [x] Actor evidence gathered from the API (`workflow_runs[].actor.login`) across six workflows before choosing the list
- [ ] **Verified live after merge**: the scheduled runs are the real test. Next up is pr-fix (every 2h at :07), then boy-scout at 02:17 UTC. Both must still start.
- [ ] N/A — `typecheck` / `test` / `build`: workflow YAML and comments only

## Documentation

Rationale lives next to each value, since that is where someone loosening it will look. Each site says why those two names, and what to do instead of widening.

## Risk & rollback

- **Rollback**: revert. The prior state is `'*'`, so a revert cannot break a run, only re-widen the surface.
- **Watch for**: the next scheduled run of any of these nine workflows failing at the actor gate. `pr-fix-dispatcher` runs every two hours, so a mistake surfaces within ~2h rather than waiting for a nightly.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Public API / tool / shell-command changes: none
- [x] No cross-float contract changed
