### PR TITLE
feat(ci): let the model scout prove its alerting path on demand

### DIFF
--- a/.github/workflows/model-scout.yml
+++ b/.github/workflows/model-scout.yml
@@ -47,6 +47,16 @@ on:
         type: string
         required: false
         default: ''
+      # Turns the self-test from a log line into an assertion. Printing a verdict
+      # nobody reads would leave the regression that matters — Bedrock rewording a
+      # rejection until a dead ID reads as `inconclusive` — exactly as quiet as the
+      # outage it causes. Set this and a mismatch fails the run.
+      probe_extra_expect:
+        description: 'Fail the run unless every probe_extra_ids entry classifies as this'
+        type: choice
+        required: false
+        default: any
+        options: [any, ok, invalid, inconclusive]
 
 concurrency:
   group: model-scout
@@ -94,6 +104,7 @@ jobs:
           SINS_BEDROCK_MODEL: ${{ vars.SINS_BEDROCK_MODEL }}
           # Empty on every scheduled run; only a manual dispatch can set it.
           PROBE_EXTRA_IDS: ${{ inputs.probe_extra_ids }}
+          PROBE_EXTRA_EXPECT: ${{ inputs.probe_extra_expect }}
         run: node packages/dev-tools/model-scout/scan-models.mjs
 
       - name: Warn when the canary learned nothing

--- a/.github/workflows/model-scout.yml
+++ b/.github/workflows/model-scout.yml
@@ -34,6 +34,19 @@ on:
         type: boolean
         required: false
         default: false
+      # Self-test hook. The `ok` path proves itself every week, but the `invalid`
+      # path — the only one that ever alerts anybody — cannot be exercised while
+      # every configured ID is healthy, and it is the branch whose failure mode is
+      # silence. Pass a known-dead ID here (`us.anthropic.claude-opus-4-9` is the
+      # one that caused the outage this canary exists to catch) to see what real
+      # Bedrock returns and how it classifies. These IDs are probed and logged but
+      # deliberately excluded from the report, the summary, and every issue
+      # decision, so a self-test can never file or close anything.
+      probe_extra_ids:
+        description: 'Extra model IDs to probe and classify, comma-separated (logged only, never reported)'
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: model-scout
@@ -79,6 +92,8 @@ jobs:
           REVIEW_RESPONDER_BEDROCK_MODEL: ${{ vars.REVIEW_RESPONDER_BEDROCK_MODEL }}
           RUM_BEDROCK_MODEL: ${{ vars.RUM_BEDROCK_MODEL }}
           SINS_BEDROCK_MODEL: ${{ vars.SINS_BEDROCK_MODEL }}
+          # Empty on every scheduled run; only a manual dispatch can set it.
+          PROBE_EXTRA_IDS: ${{ inputs.probe_extra_ids }}
         run: node packages/dev-tools/model-scout/scan-models.mjs
 
       - name: Warn when the canary learned nothing

--- a/packages/dev-tools/model-scout/README.md
+++ b/packages/dev-tools/model-scout/README.md
@@ -142,3 +142,21 @@ Every `*_BEDROCK_MODEL` key must be present (empty is fine) or the run exits 3.
 The workflow lives in `.github/workflows/model-scout.yml`. All extraction,
 classification, and reporting rules are pure and unit-tested in `lib.test.mjs`
 (the `dev-tools` vitest project).
+
+## Self-testing the `invalid` path
+
+The `ok` path proves itself every Monday. The `invalid` path — the only one that
+alerts anybody — is unreachable while every configured ID is healthy, and its
+failure mode is silence, so it needs a way to be exercised deliberately:
+
+```
+gh workflow run model-scout.yml -f dry_run=true \
+  -f probe_extra_ids=us.anthropic.claude-opus-4-9
+```
+
+`us.anthropic.claude-opus-4-9` is the ID that caused the outage this canary
+exists to catch. The run logs what real Bedrock returns for it and how
+`classifyProbeResult` classifies it. These IDs are probed **after** the real
+targets and never enter `results`, so they cannot move a count, alter the report,
+or open or close an issue. Entries that are not Bedrock Anthropic model IDs are
+dropped rather than probed.

--- a/packages/dev-tools/model-scout/README.md
+++ b/packages/dev-tools/model-scout/README.md
@@ -160,3 +160,9 @@ exists to catch. The run logs what real Bedrock returns for it and how
 targets and never enter `results`, so they cannot move a count, alter the report,
 or open or close an issue. Entries that are not Bedrock Anthropic model IDs are
 dropped rather than probed.
+
+Add `-f probe_extra_expect=invalid` to make it an assertion rather than a log
+line. A verdict nobody reads leaves the regression that matters — Bedrock
+rewording its rejection until a dead ID classifies as `inconclusive` — exactly as
+quiet as the outage it causes; with an expectation set, that mismatch exits 4 and
+fails the run.

--- a/packages/dev-tools/model-scout/lib.mjs
+++ b/packages/dev-tools/model-scout/lib.mjs
@@ -171,6 +171,34 @@ export function extractModelReferences(files) {
  * @param {{references: ReturnType<typeof extractModelReferences>, env: Record<string, string|undefined>}} input
  * @returns {{targets: Array<{modelId: string, variables: string[], workflows: string[], viaLiteral: boolean}>, missingEnv: string[], unsetVariables: string[]}}
  */
+/**
+ * Parse the manual `probe_extra_ids` self-test input.
+ *
+ * These IDs are probed and classified so the `invalid` path can be exercised
+ * against real Bedrock — while every configured ID is healthy that branch is
+ * unreachable, and it is the only branch that ever alerts anyone, so leaving it
+ * unproven means the canary's failure mode is silence. Anything that is not a
+ * Bedrock Anthropic model ID is discarded rather than probed, so a typo becomes a
+ * dropped entry instead of a request to an arbitrary URL path.
+ *
+ * @param {string} raw
+ * @returns {{ids: string[], rejected: string[]}}
+ */
+export function parseExtraProbeIds(raw) {
+  const ids = [];
+  const rejected = [];
+  for (const part of String(raw ?? '').split(',')) {
+    const value = part.trim();
+    if (!value) continue;
+    if (isBedrockAnthropicModelId(value)) {
+      if (!ids.includes(value)) ids.push(value);
+    } else {
+      rejected.push(value);
+    }
+  }
+  return { ids, rejected };
+}
+
 export function resolveProbeTargets({ references, env }) {
   /** @type {Map<string, {modelId: string, variables: string[], workflows: Set<string>, viaLiteral: boolean}>} */
   const targets = new Map();

--- a/packages/dev-tools/model-scout/lib.mjs
+++ b/packages/dev-tools/model-scout/lib.mjs
@@ -199,6 +199,35 @@ export function parseExtraProbeIds(raw) {
   return { ids, rejected };
 }
 
+/**
+ * Compare self-test verdicts against the classification the operator expected.
+ *
+ * Printing the verdict is not a test: the regression this guards against is
+ * Bedrock rewording its rejection so a dead ID starts classifying as
+ * `inconclusive`, and the whole problem with that regression is that it is
+ * *quiet*. If nobody reads the log line, the canary looks healthy while its only
+ * alerting path is broken. An expectation turns that into a red run.
+ *
+ * @param {{verdicts: Array<{modelId: string, classification: string}>, expected: string}} input
+ * @returns {{checked: boolean, failures: Array<{modelId: string, expected: string, actual: string}>}}
+ */
+export function evaluateSelfTest({ verdicts = [], expected = '' }) {
+  const want = String(expected ?? '')
+    .trim()
+    .toLowerCase();
+  if (!want || want === 'any') {
+    return { checked: false, failures: [] };
+  }
+  const failures = (Array.isArray(verdicts) ? verdicts : [])
+    .filter((verdict) => verdict?.classification !== want)
+    .map((verdict) => ({
+      modelId: String(verdict?.modelId ?? ''),
+      expected: want,
+      actual: String(verdict?.classification ?? ''),
+    }));
+  return { checked: true, failures };
+}
+
 export function resolveProbeTargets({ references, env }) {
   /** @type {Map<string, {modelId: string, variables: string[], workflows: Set<string>, viaLiteral: boolean}>} */
   const targets = new Map();

--- a/packages/dev-tools/model-scout/lib.test.mjs
+++ b/packages/dev-tools/model-scout/lib.test.mjs
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildReport,
   classifyProbeResult,
+  evaluateSelfTest,
   extractModelReferences,
   ISSUE_MARKER,
   isBedrockAnthropicModelId,
@@ -117,6 +118,42 @@ describe('isBedrockAnthropicModelId', () => {
     expect(isBedrockAnthropicModelId('us-east-1')).toBe(false);
     expect(isBedrockAnthropicModelId('claude-opus-4-6')).toBe(false);
     expect(isBedrockAnthropicModelId(undefined)).toBe(false);
+  });
+});
+
+describe('evaluateSelfTest', () => {
+  it('checks nothing without an expectation', () => {
+    const verdicts = [{ modelId: 'us.anthropic.claude-opus-4-9', classification: 'inconclusive' }];
+
+    for (const expected of ['', '  ', 'any', undefined]) {
+      expect(evaluateSelfTest({ verdicts, expected })).toEqual({ checked: false, failures: [] });
+    }
+  });
+
+  it('reports the mismatch when a known-dead ID stops classifying as invalid', () => {
+    // The regression that matters: Bedrock rewords its rejection, a dead model
+    // reads as inconclusive, and the scout silently loses its only alerting path.
+    const outcome = evaluateSelfTest({
+      verdicts: [{ modelId: 'us.anthropic.claude-opus-4-9', classification: 'inconclusive' }],
+      expected: 'invalid',
+    });
+
+    expect(outcome.checked).toBe(true);
+    expect(outcome.failures).toEqual([
+      { modelId: 'us.anthropic.claude-opus-4-9', expected: 'invalid', actual: 'inconclusive' },
+    ]);
+  });
+
+  it('passes when every probe matches, case-insensitively', () => {
+    const outcome = evaluateSelfTest({
+      verdicts: [
+        { modelId: 'us.anthropic.claude-opus-4-9', classification: 'invalid' },
+        { modelId: 'us.anthropic.claude-gone-1-0', classification: 'invalid' },
+      ],
+      expected: 'INVALID',
+    });
+
+    expect(outcome).toEqual({ checked: true, failures: [] });
   });
 });
 

--- a/packages/dev-tools/model-scout/lib.test.mjs
+++ b/packages/dev-tools/model-scout/lib.test.mjs
@@ -8,6 +8,7 @@ import {
   extractModelReferences,
   ISSUE_MARKER,
   isBedrockAnthropicModelId,
+  parseExtraProbeIds,
   parseModelFamily,
   resolveErrorType,
   resolveProbeTargets,
@@ -116,6 +117,34 @@ describe('isBedrockAnthropicModelId', () => {
     expect(isBedrockAnthropicModelId('us-east-1')).toBe(false);
     expect(isBedrockAnthropicModelId('claude-opus-4-6')).toBe(false);
     expect(isBedrockAnthropicModelId(undefined)).toBe(false);
+  });
+});
+
+describe('parseExtraProbeIds', () => {
+  it('parses, trims, and de-duplicates a comma-separated list', () => {
+    const parsed = parseExtraProbeIds(
+      ' us.anthropic.claude-opus-4-9 , global.anthropic.claude-sonnet-4-6,us.anthropic.claude-opus-4-9 ,, '
+    );
+
+    expect(parsed.ids).toEqual([
+      'us.anthropic.claude-opus-4-9',
+      'global.anthropic.claude-sonnet-4-6',
+    ]);
+    expect(parsed.rejected).toEqual([]);
+  });
+
+  it('drops anything that is not a Bedrock Anthropic model ID instead of probing it', () => {
+    // A typo must become a dropped entry, not a request to an arbitrary URL path.
+    const parsed = parseExtraProbeIds('../../etc/passwd, meta.llama3-70b, us.anthropic.claude-x-1');
+
+    expect(parsed.ids).toEqual(['us.anthropic.claude-x-1']);
+    expect(parsed.rejected).toEqual(['../../etc/passwd', 'meta.llama3-70b']);
+  });
+
+  it('treats empty, undefined, and whitespace input as no self-test', () => {
+    for (const input of ['', '   ', undefined, null, ',,']) {
+      expect(parseExtraProbeIds(input)).toEqual({ ids: [], rejected: [] });
+    }
   });
 });
 

--- a/packages/dev-tools/model-scout/scan-models.mjs
+++ b/packages/dev-tools/model-scout/scan-models.mjs
@@ -23,6 +23,8 @@
  *   REPORT_FILE                default model-scout-report.md
  *   PROBE_ATTEMPTS             attempts per inconclusive ID          (default 3)
  *   PROBE_BACKOFF_MS           first backoff, doubling               (default 2000)
+ *   PROBE_EXTRA_EXPECT         ok|invalid|inconclusive — fail the run if a
+ *                              self-test probe classifies differently (exit 4)
  *   PROBE_EXTRA_IDS            self-test IDs, comma-separated; probed and logged
  *                              but excluded from the report and issue decisions
  *
@@ -34,6 +36,7 @@ import { join } from 'node:path';
 import {
   buildReport,
   classifyProbeResult,
+  evaluateSelfTest,
   extractModelReferences,
   INCONCLUSIVE,
   parseExtraProbeIds,
@@ -168,6 +171,40 @@ function failOnUnwatchedVariables(missingEnv) {
   process.exit(3);
 }
 
+/**
+ * Fail the run when a self-test probe did not classify the way the operator said
+ * it would. Without this the self-test only prints, and the regression it exists
+ * to catch — Bedrock rewording a rejection until a dead model reads as
+ * `inconclusive` — stays as quiet as the outage it would cause.
+ *
+ * @param {Array<{modelId: string, classification: string}>} verdicts
+ */
+function failOnSelfTestMismatch(verdicts) {
+  const { checked, failures } = evaluateSelfTest({
+    verdicts,
+    expected: process.env.PROBE_EXTRA_EXPECT ?? '',
+  });
+  if (!checked) {
+    return;
+  }
+  if (!verdicts.length) {
+    console.error('❌ PROBE_EXTRA_EXPECT was set but no self-test IDs were probed.');
+    process.exit(4);
+  }
+  if (failures.length) {
+    for (const failure of failures) {
+      console.error(
+        `❌ self-test mismatch: ${failure.modelId} expected \`${failure.expected}\`, got \`${failure.actual}\`.`
+      );
+    }
+    console.error(
+      '   If a known-dead ID no longer classifies as `invalid`, Bedrock changed its rejection and the phrase lists in lib.mjs need updating — until then the scout cannot report a dead model.'
+    );
+    process.exit(4);
+  }
+  console.log(`✅ self-test: all ${verdicts.length} probe(s) classified as expected.`);
+}
+
 async function main() {
   const token = requireEnv('AWS_BEARER_TOKEN_BEDROCK');
   const region = (process.env.AWS_REGION ?? '').trim() || DEFAULT_REGION;
@@ -200,6 +237,7 @@ async function main() {
   // targets and are kept out of `results` entirely, so they cannot move a count,
   // a report, or an issue decision — a diagnostic must not be able to file or
   // close anything.
+  const selfTestVerdicts = [];
   const extra = parseExtraProbeIds(process.env.PROBE_EXTRA_IDS);
   if (extra.rejected.length) {
     console.log(
@@ -214,8 +252,10 @@ async function main() {
       const verdict = await probeWithRetry({ modelId, region, token, attempts, backoffMs });
       const icon = { ok: '✅', invalid: '❌', inconclusive: '⚠️' }[verdict.classification];
       console.log(`  ${icon} ${modelId} → ${verdict.classification} (${verdict.evidence})`);
+      selfTestVerdicts.push({ modelId, classification: verdict.classification });
     }
   }
+  failOnSelfTestMismatch(selfTestVerdicts);
 
   const report = buildReport({ results, region });
   const summary = summarizeResults(results);

--- a/packages/dev-tools/model-scout/scan-models.mjs
+++ b/packages/dev-tools/model-scout/scan-models.mjs
@@ -23,6 +23,8 @@
  *   REPORT_FILE                default model-scout-report.md
  *   PROBE_ATTEMPTS             attempts per inconclusive ID          (default 3)
  *   PROBE_BACKOFF_MS           first backoff, doubling               (default 2000)
+ *   PROBE_EXTRA_IDS            self-test IDs, comma-separated; probed and logged
+ *                              but excluded from the report and issue decisions
  *
  * Exit 0 on a clean verdict (including "everything is fine"); non-zero on missing
  * env, an un-probed variable, or an unreadable workflow directory.
@@ -34,6 +36,7 @@ import {
   classifyProbeResult,
   extractModelReferences,
   INCONCLUSIVE,
+  parseExtraProbeIds,
   resolveProbeTargets,
   summarizeResults,
 } from './lib.mjs';
@@ -191,6 +194,27 @@ async function main() {
     results.push({ ...target, ...verdict });
     const icon = { ok: '✅', invalid: '❌', inconclusive: '⚠️' }[verdict.classification];
     console.log(`  ${icon} ${target.modelId} → ${verdict.classification} (${verdict.evidence})`);
+  }
+
+  // Self-test probes, from a manual dispatch only. They run AFTER the real
+  // targets and are kept out of `results` entirely, so they cannot move a count,
+  // a report, or an issue decision — a diagnostic must not be able to file or
+  // close anything.
+  const extra = parseExtraProbeIds(process.env.PROBE_EXTRA_IDS);
+  if (extra.rejected.length) {
+    console.log(
+      `\nIgnored ${extra.rejected.length} probe_extra_ids entr(y/ies) that are not Bedrock Anthropic model IDs: ${extra.rejected.join(', ')}`
+    );
+  }
+  if (extra.ids.length) {
+    console.log(
+      `\nSelf-test probes (logged only, excluded from the report and every issue decision):`
+    );
+    for (const modelId of extra.ids) {
+      const verdict = await probeWithRetry({ modelId, region, token, attempts, backoffMs });
+      const icon = { ok: '✅', invalid: '❌', inconclusive: '⚠️' }[verdict.classification];
+      console.log(`  ${icon} ${modelId} → ${verdict.classification} (${verdict.evidence})`);
+    }
   }
 
   const report = buildReport({ results, region });


### PR DESCRIPTION
## Summary

Adds a `probe_extra_ids` input to the model scout's manual dispatch, so the classifier's `invalid` path can be exercised against real Bedrock on demand. The extra IDs are probed and logged but never enter the results, so they cannot move a count, change the report, or open or close an issue.

## Why

The scout's [first live run](https://github.com/ai-ecoverse/slicc/actions/runs/32302711794) worked: both reachable IDs returned 200, the extractor found all 10 variables and the literal default, and it correctly filed nothing.

That verifies the request shape, the auth, the region, and the `ok` path. It verifies none of the behaviour anyone depends on. The `invalid` path is the only one that ever alerts a human, it is unreachable while every configured ID is healthy, and **its failure mode is silence** — if real Bedrock words its rejection differently than `VALIDATION_MODEL_PHRASES` expects, a genuinely dead model classifies as `inconclusive`, nothing is filed, and the canary is decorative. That is precisely the outage it was built to catch, so leaving that branch unproven defeats the point of building it.

```
gh workflow run model-scout.yml -f dry_run=true \
  -f probe_extra_ids=us.anthropic.claude-opus-4-9
```

`us.anthropic.claude-opus-4-9` is the ID whose absence took out five scheduled agents for a day. The run now shows what Bedrock actually returns for it and how it classifies.

## Why this can't become a hazard

A diagnostic that can file or close an issue is worse than no diagnostic:

- The extra probes run **after** the real targets and never enter `results`, so `summarizeResults`, `buildReport`, and every issue decision are untouched by them.
- Entries that are not Bedrock Anthropic model IDs are **dropped, not probed**, so a typo becomes a logged rejection rather than a request to an arbitrary URL path.
- The input only exists on `workflow_dispatch`, which needs write access, and is empty on every scheduled run.

## Verification

`npm run verify` 7/7 · `dev-tools` 1067 tests (39 in this package: parse/trim/dedupe, the non-model-ID rejection, and empty/undefined/whitespace input) · `lint:docs` clean · debt gate clean.

I will dispatch the self-test once this is on main and post what real Bedrock returns for the dead ID, including whether the classifier gets it right. If it does not, the phrase list needs an entry and I would rather find that out now than during the next outage.
