### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -72,7 +72,7 @@
     "webapp": {
       "lines": 81,
       "statements": 79,
-      "functions": 79,
+      "functions": 80,
       "branches": 70,
       "coverageExclude": [
         "**/node_modules/**",
@@ -94,7 +94,7 @@
       "branches": 76
     },
     "cloud-core": {
-      "lines": 85,
+      "lines": 86,
       "statements": 83,
       "functions": 77,
       "branches": 77,


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.