### PR TITLE
refactor(shared-ts): move fetch-proxy wire types down, break webapp→ext cycle

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -363,7 +363,6 @@
     },
     {
       "includes": [
-        "packages/chrome-extension/src/fetch-proxy-shared.ts",
         "packages/webapp/providers/adobe.ts",
         "packages/webapp/src/kernel/cdp-worker-proxy.ts",
         "packages/webapp/src/providers/index.ts",

--- a/packages/chrome-extension/src/fetch-proxy-shared.ts
+++ b/packages/chrome-extension/src/fetch-proxy-shared.ts
@@ -1,5 +1,7 @@
 import {
   base64ToUint8,
+  type FetchProxyRequestMsg,
+  type FetchProxyResponseMsg,
   HMAC_SIGN_HEADER,
   type SecretsPipeline,
   uint8ToBase64,
@@ -55,33 +57,12 @@ export interface PortLike {
   postMessage: (msg: unknown) => void;
 }
 
-export interface RequestMsg {
-  type: 'request';
-  url: string;
-  method: string;
-  headers: Record<string, string>;
-  bodyBase64?: string;
-  requestBodyTooLarge?: boolean;
-}
-
-/**
- * Port-streamed response protocol. The SW emits exactly one `response-head`
- * followed by 0..N `response-chunk`s + a terminating `response-end`, OR a
- * single `response-error` (terminal). Discriminated union so both the SW
- * emitters AND the page consumer narrow on `type` exhaustively — typos like
- * `response-haed` no longer compile, and adding a new variant forces an
- * update at both ends.
- */
-export type ResponseMsg =
-  | {
-      type: 'response-head';
-      status: number;
-      statusText: string;
-      headers: Record<string, string>;
-    }
-  | { type: 'response-chunk'; dataBase64: string }
-  | { type: 'response-end' }
-  | { type: 'response-error'; error: string };
+// The fetch-proxy wire contract lives in `@slicc/shared-ts` (the platform-
+// agnostic layer both `@slicc/webapp` and this float depend on *downward*).
+// Local aliases keep the SW-side code reading in terms of request/response
+// without re-declaring the shapes here.
+export type RequestMsg = FetchProxyRequestMsg;
+export type ResponseMsg = FetchProxyResponseMsg;
 
 function send(port: PortLike, msg: ResponseMsg): void {
   port.postMessage(msg);
@@ -349,6 +330,46 @@ async function processProxyRequest(
 }
 
 /**
+ * Handle the single `request` message a fetch-proxy Port carries: await the
+ * pipeline, then unmask/fetch/stream. Split out of the onMessage listener so
+ * the listener itself stays synchronous and `void`-returning — Chrome ignores
+ * a listener's return value, so handing it a Promise would strand rejections.
+ */
+async function handleProxyMessage(
+  port: PortLike,
+  pipelinePromise: Promise<SecretsPipeline>,
+  raw: unknown,
+  signal: AbortSignal
+): Promise<void> {
+  const msg = raw as RequestMsg;
+  if (msg.type !== 'request') return;
+
+  if (msg.requestBodyTooLarge) {
+    send(port, {
+      type: 'response-head',
+      status: 413,
+      statusText: 'Payload Too Large',
+      headers: {},
+    });
+    send(port, { type: 'response-end' });
+    return;
+  }
+
+  let pipeline: SecretsPipeline;
+  try {
+    pipeline = await pipelinePromise;
+  } catch (err) {
+    send(port, {
+      type: 'response-error',
+      error: `fetch-proxy init failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    return;
+  }
+
+  await processProxyRequest(port, pipeline, msg, signal);
+}
+
+/**
  * Variant that accepts a Promise for the pipeline so the caller can attach
  * the onMessage listener SYNCHRONOUSLY in the onConnect callback — Chrome
  * drops port messages that arrive before any listener exists, and the
@@ -365,35 +386,18 @@ export function handleFetchProxyConnectionAsync(
 
   port.onDisconnect.addListener(() => ac.abort());
 
-  port.onMessage.addListener(async (raw) => {
+  port.onMessage.addListener((raw) => {
     if (started) return;
     started = true;
-    const msg = raw as RequestMsg;
-    if (msg.type !== 'request') return;
-
-    if (msg.requestBodyTooLarge) {
-      send(port, {
-        type: 'response-head',
-        status: 413,
-        statusText: 'Payload Too Large',
-        headers: {},
-      });
-      send(port, { type: 'response-end' });
-      return;
-    }
-
-    let pipeline: SecretsPipeline;
-    try {
-      pipeline = await pipelinePromise;
-    } catch (err) {
+    handleProxyMessage(port, pipelinePromise, raw, ac.signal).catch((err) => {
+      // `processProxyRequest` already converts upstream failures into a
+      // `response-error`; this is the safety net for a throw in the
+      // pre-dispatch envelope handling itself.
       send(port, {
         type: 'response-error',
-        error: `fetch-proxy init failed: ${err instanceof Error ? err.message : String(err)}`,
+        error: err instanceof Error ? err.message : String(err),
       });
-      return;
-    }
-
-    await processProxyRequest(port, pipeline, msg, ac.signal);
+    });
   });
 }
 

--- a/packages/shared-ts/src/fetch-proxy-protocol.ts
+++ b/packages/shared-ts/src/fetch-proxy-protocol.ts
@@ -1,6 +1,30 @@
 /**
- * Port-streamed fetch-proxy response protocol shared by the extension backend
- * and browser clients.
+ * Port-streamed fetch-proxy wire protocol shared by the extension backend and
+ * browser clients. Platform-agnostic on purpose so `@slicc/webapp` and
+ * `@slicc/chrome-extension` both import it *downward* from here rather than the
+ * webapp reaching *up* into the extension for a duplicate copy.
+ */
+
+/**
+ * Request the page/SW side sends to the fetch-proxy backend. One `request` per
+ * Port connection.
+ */
+export interface FetchProxyRequestMsg {
+  type: 'request';
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  bodyBase64?: string;
+  requestBodyTooLarge?: boolean;
+}
+
+/**
+ * Port-streamed response protocol. The backend emits exactly one
+ * `response-head` followed by 0..N `response-chunk`s + a terminating
+ * `response-end`, OR a single `response-error` (terminal). Discriminated union
+ * so both the emitters AND the consumer narrow on `type` exhaustively — typos
+ * like `response-haed` no longer compile, and adding a new variant forces an
+ * update at both ends.
  */
 export type FetchProxyResponseMsg =
   | {

--- a/packages/shared-ts/tests/fetch-proxy-protocol.test.ts
+++ b/packages/shared-ts/tests/fetch-proxy-protocol.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { FetchProxyRequestMsg, FetchProxyResponseMsg } from '../src/fetch-proxy-protocol.js';
+
+// The fetch-proxy request/response shapes are the wire contract spoken across
+// the `@slicc/webapp` page/SW side and the `@slicc/chrome-extension` backend.
+// They live here — in the platform-agnostic layer both packages already depend
+// on — so neither package reaches *up* into the other for a duplicate copy
+// (the cross-package cycle removed in this change). This test pins the shape so
+// a drift is a deliberate, reviewed protocol change.
+describe('fetch-proxy wire protocol', () => {
+  it('pins the request discriminator and fields', () => {
+    const req: FetchProxyRequestMsg = {
+      type: 'request',
+      url: 'https://example.com/v1',
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      bodyBase64: 'e30=',
+      requestBodyTooLarge: false,
+    };
+    expect(req.type).toBe('request');
+    // Optional fields really are optional.
+    const minimal: FetchProxyRequestMsg = {
+      type: 'request',
+      url: 'https://example.com',
+      method: 'GET',
+      headers: {},
+    };
+    expect(minimal.bodyBase64).toBeUndefined();
+    expect(minimal.requestBodyTooLarge).toBeUndefined();
+  });
+
+  it('pins the four terminal-or-streaming response variants', () => {
+    const head: FetchProxyResponseMsg = {
+      type: 'response-head',
+      status: 200,
+      statusText: 'OK',
+      headers: { 'x-proxy-set-cookie': '[]' },
+    };
+    const chunk: FetchProxyResponseMsg = { type: 'response-chunk', dataBase64: 'AAA=' };
+    const end: FetchProxyResponseMsg = { type: 'response-end' };
+    const error: FetchProxyResponseMsg = { type: 'response-error', error: 'boom' };
+    expect([head.type, chunk.type, end.type, error.type]).toEqual([
+      'response-head',
+      'response-chunk',
+      'response-end',
+      'response-error',
+    ]);
+  });
+
+  it('narrows the response union exhaustively on `type`', () => {
+    const summarize = (msg: FetchProxyResponseMsg): string => {
+      switch (msg.type) {
+        case 'response-head':
+          return `head ${msg.status}`;
+        case 'response-chunk':
+          return `chunk ${msg.dataBase64.length}`;
+        case 'response-end':
+          return 'end';
+        case 'response-error':
+          return `error ${msg.error}`;
+        default: {
+          // Compile-time exhaustiveness: a new variant makes this fail to build.
+          const never: never = msg;
+          return never;
+        }
+      }
+    };
+    expect(summarize({ type: 'response-end' })).toBe('end');
+    expect(summarize({ type: 'response-error', error: 'x' })).toBe('error x');
+  });
+
+  it('keeps the request `type` literal narrow (not a bare string)', () => {
+    expectTypeOf<FetchProxyRequestMsg['type']>().toEqualTypeOf<'request'>();
+  });
+});

--- a/packages/webapp/src/ui/boot/setup-extension-fetch-delegate.ts
+++ b/packages/webapp/src/ui/boot/setup-extension-fetch-delegate.ts
@@ -12,10 +12,7 @@
  * stays intact). The chrome Port maps 1:1 to the SW's `MessageChannel`.
  */
 
-import type {
-  RequestMsg,
-  ResponseMsg,
-} from '../../../../chrome-extension/src/fetch-proxy-shared.js';
+import type { FetchProxyRequestMsg, FetchProxyResponseMsg } from '@slicc/shared-ts';
 import { createLogger } from '../../core/index.js';
 import {
   type ExtensionFetchDelegateRequest,
@@ -59,7 +56,7 @@ function runDelegatedFetch(
       responsePort.postMessage({
         type: 'response-error',
         error: 'extension-delegate: chrome.runtime.connect unavailable',
-      } satisfies ResponseMsg);
+      } satisfies FetchProxyResponseMsg);
     } catch {
       /* port may already be gone */
     }
@@ -76,7 +73,7 @@ function runDelegatedFetch(
       responsePort.postMessage({
         type: 'response-error',
         error: `extension-delegate: connect failed — ${err instanceof Error ? err.message : String(err)}`,
-      } satisfies ResponseMsg);
+      } satisfies FetchProxyResponseMsg);
     } catch {
       /* port may already be gone */
     }
@@ -101,7 +98,7 @@ function runDelegatedFetch(
 
   port.onMessage.addListener((raw: unknown) => {
     if (terminated) return;
-    const msg = raw as ResponseMsg;
+    const msg = raw as FetchProxyResponseMsg;
     try {
       responsePort.postMessage(msg);
     } catch {
@@ -116,7 +113,7 @@ function runDelegatedFetch(
       responsePort.postMessage({
         type: 'response-error',
         error: 'extension-delegate: fetch-proxy port disconnected',
-      } satisfies ResponseMsg);
+      } satisfies FetchProxyResponseMsg);
     } catch {
       /* already gone */
     }
@@ -124,7 +121,7 @@ function runDelegatedFetch(
   });
 
   // Re-add the `request` discriminator the SW stripped before delegating.
-  port.postMessage({ type: 'request', ...envelope.request } satisfies RequestMsg);
+  port.postMessage({ type: 'request', ...envelope.request } satisfies FetchProxyRequestMsg);
 }
 
 /**

--- a/packages/webapp/src/ui/llm-proxy-extension-delegate.ts
+++ b/packages/webapp/src/ui/llm-proxy-extension-delegate.ts
@@ -15,7 +15,7 @@
  * structural port (`onmessage` + optional `start`/`close`).
  */
 
-import type { ResponseMsg } from '../../../chrome-extension/src/fetch-proxy-shared.js';
+import type { FetchProxyResponseMsg } from '@slicc/shared-ts';
 import { decodeForbiddenResponseHeaders } from '../shell/proxy-headers.js';
 
 /**
@@ -81,7 +81,7 @@ export function buildDelegatedResponseStream(port: DelegateResponsePort): {
     }
   };
 
-  const onHead = (msg: Extract<ResponseMsg, { type: 'response-head' }>): void => {
+  const onHead = (msg: Extract<FetchProxyResponseMsg, { type: 'response-head' }>): void => {
     if (headReceived) return;
     headReceived = true;
     const headers = new Headers();
@@ -95,7 +95,7 @@ export function buildDelegatedResponseStream(port: DelegateResponsePort): {
     resolveResp(new Response(body, { status: msg.status, statusText: msg.statusText, headers }));
   };
 
-  const onError = (msg: Extract<ResponseMsg, { type: 'response-error' }>): void => {
+  const onError = (msg: Extract<FetchProxyResponseMsg, { type: 'response-error' }>): void => {
     terminated = true;
     const err = new Error(msg.error);
     if (headReceived) errorStream(err);
@@ -104,7 +104,7 @@ export function buildDelegatedResponseStream(port: DelegateResponsePort): {
   };
 
   port.onmessage = (event: MessageEvent) => {
-    const msg = event.data as ResponseMsg;
+    const msg = event.data as FetchProxyResponseMsg;
     if (!msg || typeof (msg as { type?: unknown }).type !== 'string' || terminated) return;
     if (msg.type === 'response-head') onHead(msg);
     else if (msg.type === 'response-chunk') controller?.enqueue(decodeBase64Bytes(msg.dataBase64));

--- a/packages/webapp/src/ui/llm-proxy-sw-config.ts
+++ b/packages/webapp/src/ui/llm-proxy-sw-config.ts
@@ -21,7 +21,7 @@
  * `bridgeToken` from the controlling client's URL.
  */
 
-import type { RequestMsg } from '../../../chrome-extension/src/fetch-proxy-shared.js';
+import type { FetchProxyRequestMsg } from '@slicc/shared-ts';
 import {
   LEADER_EXT_ID_QUERY_NAME,
   LEADER_RUNTIME_QUERY_NAME,
@@ -292,7 +292,7 @@ export interface ExtensionFetchDelegateRequest {
   /** Extension id the page should `chrome.runtime.connect` to. */
   extensionId: string;
   /** Upstream request in the extension fetch-proxy wire shape. */
-  request: Omit<RequestMsg, 'type'>;
+  request: Omit<FetchProxyRequestMsg, 'type'>;
 }
 
 /** Type guard for the page → SW extension-delegate config message. */


### PR DESCRIPTION
Closes #2209

## What

Removes the `@slicc/webapp` → `@slicc/chrome-extension` back-edge that formed a
package-level cycle: three `webapp/src/ui/` modules imported the fetch-proxy
wire types (`RequestMsg` / `ResponseMsg`) from
`chrome-extension/src/fetch-proxy-shared.ts` via `../../../chrome-extension/src`
relative paths — invisible to npm and to `lint:layer-back-edges` (which only
scans within `packages/webapp/src`), and inverting the intended
`chrome-extension → webapp` stack.

- **shared-ts**: added `FetchProxyRequestMsg` alongside the existing
  `FetchProxyResponseMsg` in `packages/shared-ts/src/fetch-proxy-protocol.ts`
  (the response half already lived here). Both are re-exported from the package
  barrel.
- **chrome-extension**: `fetch-proxy-shared.ts` now imports the shared types and
  aliases its local `RequestMsg` / `ResponseMsg` to them, so the SW-side code
  reads unchanged while the duplicate `ResponseMsg` clone is deleted.
- **webapp**: the three `ui/` (+`ui/boot/`) imports now point at
  `@slicc/shared-ts` — a proper downward edge every package already depends on.

The correct-direction edge (extension importing `decodeForbiddenRequestHeaders`
from `webapp/src/shell/proxy-headers.ts`) is untouched.

## Why

- Breaks the cross-package cycle and the duplicated-type smell called out in the
  issue.
- De-duplicates `ResponseMsg` === `FetchProxyResponseMsg` into one source of
  truth.

## How verified

- `npx biome check` — clean on all touched files.
- `npm run typecheck` — passes (all tsconfig projects).
- `npx vitest run` on `shared-ts/tests/fetch-proxy-protocol.test.ts` (new) and
  `chrome-extension/tests/fetch-proxy-shared.test.ts` — 37 tests pass.
- `npm run lint:layer-back-edges` — no new back-edges; the webapp→ext edge is
  gone (`grep` for `chrome-extension/src/fetch-proxy-shared` in `webapp/` now
  returns nothing).

New test `packages/shared-ts/tests/fetch-proxy-protocol.test.ts` pins the wire
contract (request discriminator/fields, the four response variants, and
exhaustive `type` narrowing) so future drift is a deliberate, reviewed change.
