### PR TITLE
fix(dev-tools): let pr-fix see the debt boy-scout gate

### DIFF
--- a/docs/dev-tools-details.md
+++ b/docs/dev-tools-details.md
@@ -149,6 +149,41 @@ hardcoded, so promoting this to `ai-ecoverse/.github` for the org is a packaging
 change (`workflow_call` plus a repo input), not a rewrite. Linear support is
 deliberately absent — Cosmos's `LINEAR_TEAM_KEYS` was empty.
 
+### What the PR fixer recognises, and the failure it sees most
+
+`pr-fix-dispatcher/lib.mjs` names a failing job's cause from its name plus a
+bounded log excerpt, and the `debt-gate` signature is deliberately first in
+`CODE_SIGNATURES`. The Debt boy-scout gate
+(`tools/check-touched-exemptions.mjs`, the `lint` job's last step) fails any PR
+that touches a file still on a debt list — function size, cognitive complexity,
+floating or misused promises, layer back-edges, untyped string-keyed bags — and
+the boy-scout and backlog dispatchers are built to edit precisely those files.
+That makes it the most probable way an automation PR in this repo fails, and one
+of the most mechanically fixable: the gate prints both the offending file and the
+change it wants.
+
+Two properties of that output are what the dispatcher has to accommodate:
+
+- **It never uses linter vocabulary.** No "biome", no "eslint", no "lint error"
+  — it prints `check-touched-exemptions: FAIL`, `still on the <rule> debt list`,
+  and, for the frozen-list check, `debt list is frozen and must not grow`. A
+  signature table written for ordinary linters classifies it as `unknown`, and
+  `unknown` is a skip, so the PR strands waiting for a human.
+- **The actionable part reads as calm prose.** The filename line and the `Fix:`
+  paragraph contain no failure-ish word, so a per-line "keep the error lines"
+  filter keeps the announcement and discards the diagnosis.
+  `extractLogExcerpt()` therefore keeps a few lines _after_ each failure line
+  (trailing only — the detail always follows the announcement, and leading
+  context would just re-add the passing output) within the same size cap, since
+  the excerpt is what the fixer's prompt is built from.
+
+The `CI / ci` aggregator (`if: always()` over `needs: [everything]`) fails
+alongside whichever job actually broke, and its own log says only "One or more
+jobs failed". It classifies as `unknown` and cannot outrank a sibling: verdicts
+fold in `blocked` → `code` → `infra` order, with `unknown` used only when nothing
+else matched. The flake hunter's `PLUMBING_LINE` guard solves the same problem for
+signatures rather than verdicts.
+
 ### Running one on demand
 
 Every one takes `workflow_dispatch`, and each has an input that forces work to

--- a/packages/dev-tools/pr-fix-dispatcher/README.md
+++ b/packages/dev-tools/pr-fix-dispatcher/README.md
@@ -28,11 +28,11 @@ schedule (every 2h) ─▶ scan-failing-prs.mjs ─▶ queue (JSON) ─▶ fix j
 
 ## The three paths
 
-| Path         | When                                                                                                                                     | Side effects                                                       |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| **re-run**   | The failure never evaluated the code: artifact up/download, DNS/reset/timeout, registry 5xx, runner lost, a bare cancel. Once per SHA.   | `rerun-failed-jobs` only — no label, no comment.                   |
-| **dispatch** | The failure is in the code and mechanically fixable: lint/format, types, a snapshot or coverage floor, lockfile drift, a merge conflict. | `ci-fix-dispatched` + one marker comment, then the `fix` job runs. |
-| **skip**     | Everything else, and always for the hard overrides below.                                                                                | `ci-fix-skipped` + one short comment (never two for the same SHA). |
+| Path         | When                                                                                                                                                              | Side effects                                                       |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| **re-run**   | The failure never evaluated the code: artifact up/download, DNS/reset/timeout, registry 5xx, runner lost, a bare cancel. Once per SHA.                            | `rerun-failed-jobs` only — no label, no comment.                   |
+| **dispatch** | The failure is in the code and mechanically fixable: the debt boy-scout gate, lint/format, types, a snapshot or coverage floor, lockfile drift, a merge conflict. | `ci-fix-dispatched` + one marker comment, then the `fix` job runs. |
+| **skip**     | Everything else, and always for the hard overrides below.                                                                                                         | `ci-fix-skipped` + one short comment (never two for the same SHA). |
 
 Hard overrides to skip: auth, billing, secrets/credentials, schema migrations,
 release/publish/deploy jobs, an expired token or exhausted quota, an
@@ -40,6 +40,24 @@ infrastructure failure that **recurred after a re-run** (so it is not a flake), 
 fix needing a new dependency / version change / CI-config change, and any failure
 whose cause cannot be named. When in doubt between dispatch and skip, skip; when
 in doubt between re-run and skip, re-run.
+
+### The debt boy-scout gate is the likeliest dispatch of all
+
+`check-touched-exemptions.mjs` (the `lint` job's "Debt boy-scout gate" step) fails
+any PR that touches a file still on a debt list — function size, cognitive
+complexity, floating or misused promises, layer back-edges, untyped string-keyed
+bags. The boy-scout and backlog dispatchers exist to edit exactly those files, so
+this is the failure an automation PR is most likely to hit, and it is mechanically
+fixable: the gate prints the offending file and the fix it wants.
+
+It is also invisible to a keyword list built for ordinary linters, because its
+output never says "biome", "eslint", or "lint error" — it says
+`check-touched-exemptions: FAIL` and `still on the <rule> debt list`. Both
+phrasings, plus the "debt list is frozen and must not grow" variant, are matched
+by the `debt-gate` code signature, which is checked before the broader `lint` one.
+The log excerpt keeps the lines that _follow_ a failure line for the same reason:
+the filename and the `Fix:` instruction contain no failure-ish word of their own,
+and without them the fixer's prompt names a failure it cannot act on.
 
 Silent drops (no label, no comment) happen before the rubric: the PR is not
 machine-authored, CI is green or still running, the newest failing conclusion is

--- a/packages/dev-tools/pr-fix-dispatcher/lib.mjs
+++ b/packages/dev-tools/pr-fix-dispatcher/lib.mjs
@@ -189,7 +189,13 @@ export const CODE_SIGNATURES = [
   {
     category: 'debt-gate',
     pattern:
-      /check-touched-exemptions:\s*FAIL|still on the [\w-]+ debt list|debt list is frozen and must not grow/i,
+      // The rule label is matched loosely on purpose. Every label today is a
+      // single hyphenated token, so `[\w-]+` would do — but this whole class of
+      // failure was invisible for exactly one reason: a phrase the classifier
+      // expected did not match the phrase the gate printed, and the symptom was
+      // silence rather than an error. A label gaining a space should not be able
+      // to re-create that.
+      /check-touched-exemptions:\s*FAIL|still on the .{1,40}? debt list|debt list is frozen and must not grow/i,
   },
   {
     category: 'lint',

--- a/packages/dev-tools/pr-fix-dispatcher/lib.mjs
+++ b/packages/dev-tools/pr-fix-dispatcher/lib.mjs
@@ -178,6 +178,19 @@ export const INFRA_SIGNATURES = [
  * the rubric's "canceled with no preceding assertion failure" rule.
  */
 export const CODE_SIGNATURES = [
+  // First, because it is this repo's single most likely automation-PR failure and
+  // its output never says "biome", "lint error", or anything else the broader
+  // `lint` entry below looks for. The boy-scout and backlog dispatchers edit
+  // debt-listed files by design, so `check-touched-exemptions.mjs` — which fails
+  // a PR that touches a file still on ANY debt list (function size, cognitive
+  // complexity, floating/misused promises, layer back-edges, untyped
+  // string-keyed bags) — is exactly the gate they trip. Matches both the
+  // touched-file variant and the "list must not grow" variant.
+  {
+    category: 'debt-gate',
+    pattern:
+      /check-touched-exemptions:\s*FAIL|still on the [\w-]+ debt list|debt list is frozen and must not grow/i,
+  },
   {
     category: 'lint',
     pattern: /biome (found|check)|eslint|prettier|lint(ing)? (error|failed)|format(ter)? would/i,
@@ -630,8 +643,22 @@ export function formatFailuresForMatrix(failures = [], maxChars = 1500) {
     .slice(0, maxChars);
 }
 
+/** A line that, on its own, looks like it names a failure. */
+const FAILURE_LINE = /error|fail|✕|✗|cannot|unable|denied|conflict|timed out|canceled|cancelled/i;
+
 /**
- * Collapse a raw job log to the tail lines most likely to name the failure.
+ * Lines kept after each {@link FAILURE_LINE}. A gate that fails usually announces
+ * the failure on one line and then spends the next few naming the offending file
+ * and prescribing the fix — none of which contain a failure-ish word, so a
+ * line-by-line filter throws away the only actionable part. Trailing context
+ * only: the detail follows the announcement in every gate this repo runs, and
+ * leading context would pad the excerpt with the passing output that preceded it.
+ */
+const CONTEXT_AFTER = 8;
+
+/**
+ * Collapse a raw job log to the tail lines most likely to name the failure,
+ * each with the following lines that explain it.
  * @param {string} log raw text from `GET /actions/jobs/{id}/logs`
  * @param {number} maxChars
  * @returns {string}
@@ -642,9 +669,13 @@ export function extractLogExcerpt(log, maxChars = 2000) {
     // Strip the ISO timestamp Actions prefixes every log line with.
     .map((line) => line.replace(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s?/, ''))
     .filter((line) => line.trim().length > 0);
-  const interesting = lines.filter((line) =>
-    /error|fail|✕|✗|cannot|unable|denied|conflict|timed out|canceled|cancelled/i.test(line)
-  );
+  const keep = new Set();
+  for (const [index, line] of lines.entries()) {
+    if (!FAILURE_LINE.test(line)) continue;
+    const last = Math.min(lines.length - 1, index + CONTEXT_AFTER);
+    for (let i = index; i <= last; i += 1) keep.add(i);
+  }
+  const interesting = [...keep].sort((a, b) => a - b).map((i) => lines[i]);
   const chosen = (interesting.length ? interesting : lines).slice(-40);
   return chosen.join('\n').slice(-maxChars);
 }

--- a/packages/dev-tools/pr-fix-dispatcher/lib.test.mjs
+++ b/packages/dev-tools/pr-fix-dispatcher/lib.test.mjs
@@ -12,10 +12,32 @@ import {
   hasRerunForSha,
   isAutomationPr,
   parseMarkers,
+  screenPr,
   summarizeChecks,
 } from './lib.mjs';
 
 const NOW = new Date('2025-01-15T12:00:00Z');
+
+/**
+ * Verbatim tail of the `lint` job log of PR #2215
+ * (`automation/backlog/issue-2209`), whose only real failure was the Debt
+ * boy-scout gate. The dispatcher classified this as `unknown` and skipped the PR.
+ */
+const DEBT_GATE_EXCERPT = [
+  'check-touched-exemptions: FAIL',
+  '',
+  'The following changed files are still on the misused-promise debt list',
+  '(biome.json `overrides` → nursery.noMisusedPromises = off):',
+  '',
+  '  - packages/chrome-extension/src/fetch-proxy-shared.ts  [misused-promise]',
+  '',
+  'Fix: in this same PR, keep promises out of synchronous callback/conditional',
+  'positions, then remove the file from the debt-list override in biome.json.',
+  '##[error]Process completed with exit code 1.',
+].join('\n');
+
+/** What the `CI / ci` aggregator (`if: always()` over `needs: [*]`) prints. */
+const AGGREGATOR_EXCERPT = '::error::One or more jobs failed or were cancelled';
 const minutesAgo = (m) => new Date(NOW.getTime() - m * 60_000).toISOString();
 const SHA = 'abc1234def5678000000000000000000000000aa';
 const OTHER_SHA = 'bbb1234def5678000000000000000000000000cc';
@@ -225,6 +247,36 @@ describe('classifyFailure', () => {
     }
   });
 
+  it('classifies the debt boy-scout gate as a fixable code failure (PR #2215)', () => {
+    const out = classifyFailure({ jobName: 'lint', logExcerpt: DEBT_GATE_EXCERPT });
+    expect(out.kind).toBe('code');
+    expect(out.category).toBe('debt-gate');
+  });
+
+  it('recognises every debt list check-touched-exemptions.mjs can name', () => {
+    const labels = [
+      'function-size',
+      'cognitive-complexity',
+      'floating-promise',
+      'misused-promise',
+      'layer-back-edge',
+      'record-string-unknown',
+    ];
+    for (const label of labels) {
+      const touched = classifyFailure({
+        jobName: 'lint',
+        logExcerpt: `check-touched-exemptions: FAIL\nThe following changed files are still on the ${label} debt list\n  - packages/webapp/src/x.ts  [${label}]`,
+      });
+      expect(touched, label).toMatchObject({ kind: 'code', category: 'debt-gate' });
+
+      const grown = classifyFailure({
+        jobName: 'lint',
+        logExcerpt: `The ${label} debt list is frozen and must not grow; this PR adds new entries\n  + packages/webapp/src/x.ts  [${label}]`,
+      });
+      expect(grown, `${label} (grown)`).toMatchObject({ kind: 'code', category: 'debt-gate' });
+    }
+  });
+
   it('prefers the code signature when a cancel line accompanies an assertion failure', () => {
     const out = classifyFailure({
       jobName: 'test',
@@ -284,6 +336,24 @@ describe('classifyFailures', () => {
         { name: 'lint', logExcerpt: 'biome found 1 error' },
       ]).kind
     ).toBe('code');
+  });
+
+  // `CI / ci` is `if: always()` over `needs: [everything]`, so it fails whenever
+  // any child job does while its own log names no failure mode. It must never
+  // decide the PR's verdict when a sibling job named a real cause.
+  it('does not let the unknown CI aggregator mask a diagnosable sibling failure', () => {
+    for (const failures of [
+      [
+        { name: 'ci', logExcerpt: AGGREGATOR_EXCERPT },
+        { name: 'lint', logExcerpt: DEBT_GATE_EXCERPT },
+      ],
+      [
+        { name: 'lint', logExcerpt: DEBT_GATE_EXCERPT },
+        { name: 'ci', logExcerpt: AGGREGATOR_EXCERPT },
+      ],
+    ]) {
+      expect(classifyFailures(failures)).toMatchObject({ kind: 'code', category: 'debt-gate' });
+    }
   });
 
   it('reports unknown for an empty list', () => {
@@ -630,5 +700,70 @@ describe('extractLogExcerpt', () => {
   it('honours the char budget and tolerates empty input', () => {
     expect(extractLogExcerpt(`error ${'y'.repeat(500)}`, 50)).toHaveLength(50);
     expect(extractLogExcerpt()).toBe('');
+  });
+
+  it('keeps the detail that follows a failure line, even though it reads as calm prose', () => {
+    const stamp = (n, line) => `2025-01-15T11:59:${String(n).padStart(2, '0')}.1234567Z ${line}`;
+    const log = [
+      stamp(0, '##[group]Run node packages/dev-tools/tools/check-touched-exemptions.mjs'),
+      stamp(1, 'Checked 12 changed file(s) against 6 debt list(s)'),
+      stamp(2, 'check-touched-exemptions: FAIL'),
+      stamp(3, ''),
+      stamp(4, 'The following changed files are still on the misused-promise debt list'),
+      stamp(5, '(biome.json `overrides` → nursery.noMisusedPromises = off):'),
+      stamp(6, ''),
+      stamp(7, '  - packages/chrome-extension/src/fetch-proxy-shared.ts  [misused-promise]'),
+      stamp(8, ''),
+      stamp(9, 'Fix: in this same PR, keep promises out of synchronous callback/conditional'),
+      stamp(10, 'positions, then remove the file from the debt-list override in biome.json.'),
+    ].join('\n');
+    const out = extractLogExcerpt(log);
+    expect(out).toContain('packages/chrome-extension/src/fetch-proxy-shared.ts');
+    expect(out).toContain('Fix: in this same PR');
+    // The passing chatter that preceded the failure is still dropped.
+    expect(out).not.toContain('##[group]');
+    expect(out).not.toContain('Checked 12 changed file(s)');
+  });
+
+  it('still respects the size cap once context lines are kept', () => {
+    const log = Array.from({ length: 200 }, (_, i) =>
+      i % 10 === 0 ? `FAIL at step ${i}` : `detail line ${i} ${'z'.repeat(80)}`
+    ).join('\n');
+    expect(extractLogExcerpt(log, 600)).toHaveLength(600);
+  });
+});
+
+// PR #2215 (`automation/backlog/issue-2209`) failed exactly two checks: the
+// `lint` job on the Debt boy-scout gate, and the `CI / ci` aggregator mirroring
+// it. The dispatcher named neither, called the PR `unknown`, and skipped it,
+// stranding a mechanically fixable PR for a human.
+describe('regression: PR #2215 — a debt-gate-only automation PR', () => {
+  const failing = [
+    { name: 'lint', conclusion: 'failure', logExcerpt: DEBT_GATE_EXCERPT },
+    { name: 'ci', conclusion: 'failure', logExcerpt: AGGREGATOR_EXCERPT },
+  ];
+  const input = candidate({
+    pr: {
+      number: 2215,
+      title: 'feat(chrome-extension): share the fetch proxy',
+      headRef: 'automation/backlog/issue-2209',
+      headSha: SHA,
+      labels: [],
+      user: { type: 'User', login: 'trieloff' },
+    },
+    failing,
+    checks: { failing, pending: false, newestFailureAt: minutesAgo(90) },
+  });
+
+  it('reaches the rubric rather than being screened out', () => {
+    expect(screenPr(input)).toBeNull();
+  });
+
+  it('is dispatched to a fixer with the debt gate named', () => {
+    const out = decidePrAction(input);
+    expect(out.action).toBe('dispatch');
+    expect(out.category).toBe('debt-gate');
+    expect(out.reason).toMatch(/debt-gate/);
+    expect(out.reason).not.toMatch(/no plausible cause/i);
   });
 });


### PR DESCRIPTION
## Summary

Teaches the PR fixer to recognise the Debt boy-scout gate, and stops the log excerpt from throwing away the part of a gate failure that says how to fix it.

## Why

This is live bug #4 in the migrated automation, found by watching a real dispatched PR fail rather than by any test.

The backlog dispatcher opened **#2215** for issue #2209 at 10:03 today. CI failed: the debt gate caught that the PR touched `packages/chrome-extension/src/fetch-proxy-shared.ts`, which is still on the misused-promise debt list, and the boy-scout rule says touching a debt-listed file means cleaning it up. Fair catch.

The pr-fix dispatcher exists to fix exactly that, and it skipped:

```
• #2215 skip — "ci" failed but no plausible cause could be named from its log.
```

Reproduced against the real job logs — two stacked defects:

1. **No signature matched.** `CODE_SIGNATURES`' `lint` entry looks for `biome found|eslint|prettier|lint error|formatter would`. The gate says none of those; it says `check-touched-exemptions: FAIL` and `still on the … debt list`. So `classifyFailure` fell through to `unknown`, and `unknown` means skip.
2. **The excerpt discarded the fix.** `extractLogExcerpt` kept only lines containing a failure-ish word, so `check-touched-exemptions: FAIL` survived while the lines naming the offending file and prescribing `Fix: keep promises out of synchronous callback positions…` did not. Even once classified, the fixer's prompt would have been missing the only information that makes the failure actionable.

**Why this one matters more than a missing pattern usually would:** the boy-scout and backlog dispatchers touch debt-listed files *by design*. The debt gate is therefore the single most likely way their PRs fail — and the workflow whose only job is fixing their PRs was blind to precisely that. Every such PR stranded and waited for a human, which is what #2215 did.

## What changed

- A `debt-gate` entry in `CODE_SIGNATURES`, covering all six debt lists (function-size, cognitive-complexity, floating-promise, misused-promise, layer-back-edge, record-string-unknown) and both variants the gate emits: a touched file still on a list, and a list being grown while frozen. The rule label is matched loosely on purpose — this whole class of failure was invisible because a phrase the classifier expected differed from the phrase the gate printed, and the symptom was silence rather than an error.
- `extractLogExcerpt` keeps the 8 lines following each failure line. Trailing-only, because every gate here announces the failure first and explains it after, and leading context would re-admit the passing output above it. The size cap is unchanged, since this text goes into a model prompt.
- No change to what the fixer does with a verdict, the dispatch budget, the marker/dedupe scheme, the re-run path, or any workflow.

## Verification

`npm run verify` 7/7 (**exit status checked, not the last line of a pipe** — piping through `tail` hid a real biome failure earlier today) · `dev-tools` 1077 tests, 65 in this package, up 6 · `lint:docs` clean · debt gate clean.

Live read-only proof against #2215, before and after:

```
before:  • #2215 skip — "ci" failed but no plausible cause could be named from its log.
         Queued 0 fixer dispatch(es)

after:   • #2215 dispatch — "lint" failed in the code (debt-gate). Dispatching a fixer to get CI green on the branch.
         Queued 1 fixer dispatch(es)
```

I re-ran that myself rather than taking it on trust.

One thing checked and deliberately left alone: an aggregator (`ci`, an `if: always()` job whose log only says "One or more jobs failed") cannot mask a diagnosable sibling, because failures are classified independently and folded `blocked` → `code` → `infra` before `unknown`. That was already true at 10:38; #2215's message merely *named* `ci` because `lint` was also unclassified. A test now pins both orderings instead of adding logic.

No skip marker was ever written for #2215's head SHA, so once this is on main a later pr-fix cron should dispatch a fixer for it — which is both the live test of this fix and the first real exercise of the fixer phase.
