### PR TITLE
ci: retry registry-resolving installs, and make retry loops report failure

### DIFF
--- a/.github/actions/npm-ci/action.yml
+++ b/.github/actions/npm-ci/action.yml
@@ -13,12 +13,17 @@ runs:
         attempts=3
         for i in $(seq 1 "$attempts"); do
           echo "::group::npm ci (attempt $i/$attempts)"
-          if npm ci; then
-            echo "::endgroup::"
+          # Capture the status from the command itself. `if npm ci; then …; fi`
+          # followed by `status=$?` reads the status of the IF STATEMENT, which
+          # is 0 whenever no branch ran — so a genuinely failing `npm ci` used to
+          # log "failed (exit 0)" and, worse, `exit "$status"` below handed the
+          # step a SUCCESS after all attempts were spent.
+          status=0
+          npm ci || status=$?
+          echo "::endgroup::"
+          if [ "$status" -eq 0 ]; then
             exit 0
           fi
-          status=$?
-          echo "::endgroup::"
           if [ "$i" -lt "$attempts" ]; then
             delay=$((i * 15))
             echo "npm ci failed (exit $status) on attempt $i/$attempts; retrying in ${delay}s" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1666,12 +1666,71 @@ jobs:
       - name: Pack
         run: echo "tarball=$(npm pack --quiet | tail -1)" >> "$GITHUB_OUTPUT"
         id: pack
+      # `npm install -g <tarball>` and `npx sliccy@file:…` resolve the packed
+      # tarball's dependencies FRESH from the registry — the repo lockfile does
+      # not apply to either — so this is the one job whose result depends on
+      # registry state at the moment it runs. That is deliberate (it is what a
+      # real `npm i -g sliccy` does), but it means transient registry flux fails
+      # a job that has nothing to do with the diff under test.
+      #
+      # Seen 2026-08-20: a newly published `@peculiar/*` release pinned
+      # `@peculiar/asn1-schema@^2.9.4` before that version had replicated to the
+      # runner's registry mirror, and the install died with
+      # `ETARGET No matching version found`. The same commit passed this job 15
+      # minutes earlier and again 15 minutes later. npm's own fetch-retries do
+      # not cover it — the packument fetch SUCCEEDS, it just does not list the
+      # version yet — so nothing retried and a green PR (#2216) was dequeued from
+      # the merge queue, where a run gets no second chance.
+      #
+      # `prefer-online` carries as much weight as the loop: without it a retry
+      # can re-read the same stale packument from the runner's metadata cache and
+      # fail identically. A dependency that genuinely does not resolve still
+      # fails, just after ~45s of trying.
       - name: Test global install
+        env:
+          npm_config_prefer_online: 'true'
         run: |
-          npm install -g ./${{ steps.pack.outputs.tarball }}
+          set -o pipefail
+          attempts=3
+          for i in $(seq 1 "$attempts"); do
+            echo "::group::npm install -g (attempt $i/$attempts)"
+            status=0
+            npm install -g "./${{ steps.pack.outputs.tarball }}" || status=$?
+            echo "::endgroup::"
+            if [ "$status" -eq 0 ]; then
+              break
+            fi
+            if [ "$i" -ge "$attempts" ]; then
+              echo "global install failed (exit $status) after $attempts attempts" >&2
+              exit "$status"
+            fi
+            delay=$((i * 15))
+            echo "global install failed (exit $status) on attempt $i/$attempts; retrying in ${delay}s" >&2
+            sleep "$delay"
+          done
           slicc --version
       - name: Test npx
-        run: npx --yes "sliccy@file:./${{ steps.pack.outputs.tarball }}" --version
+        env:
+          npm_config_prefer_online: 'true'
+        run: |
+          set -o pipefail
+          attempts=3
+          for i in $(seq 1 "$attempts"); do
+            echo "::group::npx (attempt $i/$attempts)"
+            status=0
+            npx --yes "sliccy@file:./${{ steps.pack.outputs.tarball }}" --version || status=$?
+            echo "::endgroup::"
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            if [ "$i" -ge "$attempts" ]; then
+              echo "npx failed (exit $status) after $attempts attempts" >&2
+              exit "$status"
+            fi
+            delay=$((i * 15))
+            echo "npx failed (exit $status) on attempt $i/$attempts; retrying in ${delay}s" >&2
+            sleep "$delay"
+          done
 
   # Wait for any in-progress release before allowing merge queue to land.
   # Only runs on merge_group events; skipped (= passing) for PRs.


### PR DESCRIPTION
## Summary

Two fixes to the same piece of CI machinery. The first is the flake that dequeued #2216 from the merge queue; the second is a bug I found while writing the fix, in the retry loop this one is modelled on.

## 1. `global-install` retries registry-resolving installs

`global-install` is the one job whose result depends on **registry state at the moment it runs**: `npm install -g <tarball>` and `npx sliccy@file:…` resolve the packed tarball's dependencies fresh, and the repo lockfile does not apply to either. That's deliberate — it's what a real `npm i -g sliccy` does, and it's the signal the job exists to provide — but it means registry flux fails a job that has nothing to do with the diff under test.

**What happened on 2026-08-20:** a newly published `@peculiar/*` release pinned `@peculiar/asn1-schema@^2.9.4` before that version had replicated to the runner's registry mirror, and the install died with `ETARGET No matching version found`. Nothing in this repo requests `^2.9.4` — the lockfile pins 2.8.0, every range is `^2.8.0`/`^2.6.0`, and the package predates the PR that got blamed. The same commit **passed this job 15 minutes earlier and passed again 15 minutes later**; `2.9.4` is now `latest` on the registry.

npm's own fetch-retries never engaged, and can't: the packument fetch **succeeds**, it just doesn't list the version yet. So nothing retried, and a fully green PR (#2216) was dequeued from the merge queue — where a run gets no second chance.

Both steps now retry three times with backoff, matching the shape of `.github/actions/npm-ci`. `prefer-online` carries as much weight as the loop: without it a retry can re-read the same stale packument from the runner's metadata cache and fail identically. A dependency that genuinely doesn't resolve still fails, just ~45s later.

## 2. The retry loops didn't actually report failure

While mirroring the existing idiom I found it doesn't work. This pattern:

```bash
if npm ci; then
  echo "::endgroup::"
  exit 0
fi
status=$?          # <- status of the IF STATEMENT, not of npm ci
```

Bash defines an `if` with no matching branch as returning **0**. So `status` was always 0:

```console
$ bash -c 'f(){ return 7; }; if f; then :; fi; status=$?; echo $status'
0
```

Consequences in `.github/actions/npm-ci` (used by most jobs in the repo):

- every failure logged `npm ci failed (exit 0)`, and
- after all three attempts were spent, `exit "$status"` exited **0** — handing the step a **SUCCESS**. Jobs then continued against a missing or partial `node_modules`, so a real `npm ci` failure surfaced later as some confusing downstream error, or not at all.

Both the shared action and the two new loops now capture the status from the command itself (`status=0; cmd || status=$?`).

I fixed this here rather than filing it separately because shipping a third copy of a retry loop next to a known-broken one seemed worse than the slightly wider diff. Happy to split it out if you'd rather review them apart.

## Verification

No unit test can cover a workflow, so I extracted the three real loop bodies out of the YAML and drove them against a stub command:

| loop | first-try success | transient, 3rd attempt OK | permanent failure |
|---|---|---|---|
| `global-install` | exit 0 ✅ | exit 0 ✅ | **exit 7** ✅ |
| `npx` | exit 0 ✅ | exit 0 ✅ | **exit 7** ✅ |
| `npm-ci` (shared action) | exit 0 ✅ | exit 0 ✅ | **exit 7** ✅ |

All three previously exited **0** on permanent failure. Also confirmed the post-loop assertion (`slicc --version`) runs on both success paths and is *not* reached when the install fails.

Plus: both files parse as YAML, `prettier --check` clean, `biome check` clean, `check-touched-exemptions` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
