### PR TITLE
fix(fs): share a vnode across paths only for genuine hardlinks (#2034)

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -434,6 +434,19 @@ enforced by `patches/@zenfs+dom+*.patch`:
   mechanism behind the long-standing "phantom deletions" in `/workspace`
   (files a `git` checkout reports as deleted that will not go away).
 
+**Concurrent reads are only as safe as the inode numbers.** ZenFS keys its
+vnode cache by `ino`, and every vnode owns a sparse data cache. Two paths whose
+inodes share an ino while both are open therefore share one vnode — and the
+second reader is served the first file's cached bytes. That was #2034: eight
+parallel `/preview/*` fetches of distinct `dist/*.js` chunks all returned the
+entry file, while sequential fetches were byte-correct because the vnode is
+evicted on the last `unref` between calls. The ino floods came from the #2146
+minting bugs; `patches/@zenfs+core+*.patch` now lets `VCache.ref` share a vnode
+across paths **only for a genuine hardlink** (nonzero ino, matching format bits,
+`nlink > 1` on both sides — `IndexFS.link` is `ENOSYS` on OPFS anyway). Callers
+do not need to serialize reads; `preview-vfs-responder` keeps its queue only as
+defense in depth. Regression: `tests/fs/virtual-fs-concurrent-read.test.ts`.
+
 ## CDP Transport: Extension Mode
 
 **File**: `packages/webapp/src/cdp/extension-bridge-transport.ts`

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -117,7 +117,6 @@
   "packages/webapp/src/ui/boot/setup-welcome-flow.ts": 13,
   "packages/webapp/src/ui/dip.ts": 4,
   "packages/webapp/src/ui/main.ts": 1,
-  "packages/webapp/src/ui/preview-vfs-responder.ts": 1,
   "packages/webapp/src/ui/remote-cdp-page-bridge.ts": 2,
   "packages/webapp/src/ui/sprinkle-bridge.ts": 2,
   "packages/webapp/src/ui/sprinkle-renderer.ts": 3,

--- a/packages/webapp/src/ui/preview-vfs-responder.ts
+++ b/packages/webapp/src/ui/preview-vfs-responder.ts
@@ -67,7 +67,13 @@ export interface PreviewVfsResponderOptions {
   /** Pre-constructed channel; tests inject the polyfill. */
   channel: PreviewVfsChannelLike;
   /** Optional logger — defaults to silent on ENOENT, error on the rest. */
-  logger?: { error(msg: string, meta?: Record<string, unknown>): void };
+  logger?: { error(msg: string, meta?: PreviewVfsReadFailure): void };
+}
+
+/** Structured context attached to a failed-read log line. */
+export interface PreviewVfsReadFailure {
+  path: string;
+  error: string;
 }
 
 export interface PreviewVfsResponderHandle {
@@ -123,15 +129,18 @@ export function installPreviewVfsResponder(
     }
   }
 
-  // Reads are SERIALIZED through this per-responder chain. The kernel VFS
-  // (ZenFS WebAccess-on-OPFS behind the RemoteVfsClient RPC) is not safe
-  // under same-context concurrent reads: overlapping readFile calls can
-  // resolve with each other's content. Observed live with a parallel
-  // module-graph fetch through the preview SW — every chunk URL of an
-  // ipk-installed package came back with the entry file's bytes, so the
-  // import linked but failed with a missing-export error. Sequential
-  // reads are verified correct; the throughput cost is negligible next
-  // to the BroadcastChannel + RPC round trip each read already pays.
+  // Reads are SERIALIZED through this per-responder chain. Observed live
+  // (#2034) with a parallel module-graph fetch through the preview SW —
+  // every chunk URL of an ipk-installed package came back with the entry
+  // file's bytes, so the import linked but failed with a missing-export
+  // error. Root cause: ZenFS keys its vnode cache by ino and each vnode
+  // owns a data cache, so paths with colliding inos (the poisoned-index
+  // class of #2146) shared one vnode while concurrently open. That is
+  // fixed at the FS layer (patches/@zenfs+core: VCache.ref only shares
+  // across paths for genuine hardlinks); the queue stays as defense in
+  // depth — its cost is negligible next to the BroadcastChannel + RPC
+  // round trip each read already pays, and the ack/start protocol below
+  // is built on it.
   let queue: Promise<void> = Promise.resolve();
 
   const listener = (event: MessageEvent): void => {

--- a/packages/webapp/tests/fs/virtual-fs-concurrent-read.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs-concurrent-read.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression for #2034: concurrent `readFile` calls against the OPFS-backed
+ * VirtualFS must return each path's own bytes.
+ *
+ * ZenFS keys its vnode cache by `ino`, and every vnode owns a sparse data
+ * cache. Two paths that share an ino while both are open share one vnode —
+ * and therefore one data cache — so the second reader is served the first
+ * file's bytes. Sequential reads never collide because the vnode is evicted
+ * on the last `unref`, which is why the original report saw byte-correct
+ * sequential fetches and a collapsed parallel module-graph fetch.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMutableDirectoryHandle } from './fsa-test-helpers.js';
+
+function installOpfsStub(handle: FileSystemDirectoryHandle): void {
+  vi.stubGlobal('navigator', {
+    storage: { getDirectory: async (): Promise<FileSystemDirectoryHandle> => handle },
+  });
+}
+
+interface IndexLike {
+  get(path: string): { ino: number; data: number } | undefined;
+}
+
+describe('VirtualFS — concurrent reads (#2034)', () => {
+  beforeEach(() => {
+    installOpfsStub(createMutableDirectoryHandle({}).handle);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('parallel reads of distinct files return distinct content', async () => {
+    const { VirtualFS } = await import('../../src/fs/virtual-fs.js');
+    const vfs = await VirtualFS.create({
+      dbName: 'concurrent-read-a',
+      backend: 'opfs',
+      wipe: true,
+    });
+    const names = Array.from({ length: 8 }, (_, i) => `/workspace/dist/chunk-${i}.js`);
+    for (const n of names) await vfs.writeFile(n, `export const id = '${n}';\n`);
+
+    const results = await Promise.all(names.map((n) => vfs.readFile(n, { encoding: 'utf-8' })));
+    expect(results).toEqual(names.map((n) => `export const id = '${n}';\n`));
+    await vfs.dispose();
+  });
+
+  it('parallel reads stay distinct even when two index entries collide on ino', async () => {
+    const { VirtualFS } = await import('../../src/fs/virtual-fs.js');
+    const vfs = await VirtualFS.create({
+      dbName: 'concurrent-read-b',
+      backend: 'opfs',
+      wipe: true,
+    });
+    await vfs.writeFile('/workspace/index.js', 'INDEX'.repeat(10));
+    await vfs.writeFile('/workspace/chunk-a.js', 'CHUNK-A'.repeat(10));
+
+    // Forge the collision a poisoned sidecar used to produce in the field
+    // (#2146): make chunk-a carry index.js's ino.
+    const index = (vfs as unknown as { opfsBackendFs: { index: IndexLike } }).opfsBackendFs.index;
+    const a = index.get('/workspace/index.js');
+    const b = index.get('/workspace/chunk-a.js');
+    if (!a || !b) throw new Error('index entries missing');
+    b.ino = a.ino;
+
+    const [idx, chunk] = await Promise.all([
+      vfs.readFile('/workspace/index.js', { encoding: 'utf-8' }),
+      vfs.readFile('/workspace/chunk-a.js', { encoding: 'utf-8' }),
+    ]);
+    expect(idx).toBe('INDEX'.repeat(10));
+    expect(chunk).toBe('CHUNK-A'.repeat(10));
+    await vfs.dispose();
+  });
+});

--- a/packages/webapp/tests/fs/zenfs-ino-collision-patch.test.ts
+++ b/packages/webapp/tests/fs/zenfs-ino-collision-patch.test.ts
@@ -17,8 +17,11 @@ import { describe, expect, it } from 'vitest';
 //
 // Two patches close it: @zenfs/dom allocates unique ino/data pairs at both
 // minting sites, and @zenfs/core's VCache refuses to coalesce DIFFERENT
-// paths onto one vnode when the ino is 0 or the format bits differ. These
-// tests fail if either patch is missing or stops applying.
+// paths onto one vnode unless they are a genuine hardlink (nonzero ino,
+// matching format bits, nlink > 1 on both sides — #2034 added the nlink
+// rule after a duplicated real ino made concurrent reads of two paths
+// return the same bytes). These tests fail if either patch is missing or
+// stops applying.
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
 
 describe('@zenfs/dom ino allocation patch (#2146)', () => {
@@ -54,7 +57,7 @@ describe('@zenfs/core vnode-cache coalescing guard (#2146)', () => {
   it('the guard is present in the installed dist', () => {
     const src = readFileSync(vcachePath, 'utf8');
     expect(
-      src.includes('PATCH(#2146)'),
+      src.includes('PATCH(#2146, #2034)'),
       'Installed @zenfs/core VCache.ref still coalesces different paths onto ' +
         'one vnode for ino-0/format-mismatched inodes; ' +
         'patches/@zenfs+core+*.patch is missing or failed to apply. ' +
@@ -85,10 +88,23 @@ describe('@zenfs/core vnode-cache coalescing guard (#2146)', () => {
     const d = cache.ref('/dir', { ino: 7, mode: S_IFDIR | 0o755, size: 0 });
     expect(f).not.toBe(d);
 
-    // Genuine hardlinks — same real ino, same mode — still share one vnode.
-    const h1 = cache.ref('/link1', { ino: 9, mode: S_IFREG | 0o644, size: 42 });
-    const h2 = cache.ref('/link2', { ino: 9, mode: S_IFREG | 0o644, size: 42 });
+    // Genuine hardlinks — same real ino, same mode, nlink > 1 — still share
+    // one vnode.
+    const h1 = cache.ref('/link1', { ino: 9, mode: S_IFREG | 0o644, size: 42, nlink: 2 });
+    const h2 = cache.ref('/link2', { ino: 9, mode: S_IFREG | 0o644, size: 42, nlink: 2 });
     expect(h1).toBe(h2);
+
+    // A DUPLICATED real ino with nlink 1 is a poisoned index, not a hardlink
+    // (#2034): the two paths must keep separate vnodes — and separate data
+    // caches — or a concurrent read of one returns the other's bytes.
+    const p = cache.ref('/dist/index.js', { ino: 11, mode: S_IFREG | 0o644, size: 50, nlink: 1 });
+    const q = cache.ref('/dist/chunk-a.js', { ino: 11, mode: S_IFREG | 0o644, size: 70, nlink: 1 });
+    expect(p).not.toBe(q);
+    expect(p.inode.size).toBe(50);
+    expect(q.inode.size).toBe(70);
+    expect(
+      cache.ref('/dist/index.js', { ino: 11, mode: S_IFREG | 0o644, size: 50, nlink: 1 })
+    ).toBe(p);
 
     // Re-refing the SAME path with ino 0 joins its own vnode (no churn).
     const a2 = cache.ref('/a.txt', { ino: 0, mode: S_IFREG | 0o644, size: 100 });

--- a/patches/@zenfs+core+2.6.2.patch
+++ b/patches/@zenfs+core+2.6.2.patch
@@ -9,23 +9,30 @@ index 555af55..e88a5b9 100644
 -globalThis.__zenfs__ = Object.create(fs);
 +globalThis.__zenfs__ = Object.assign(Object.create(null), fs);
 diff --git a/node_modules/@zenfs/core/dist/vfs/vcache.js b/node_modules/@zenfs/core/dist/vfs/vcache.js
-index e978bba..c34939b 100644
+index e978bba..0e00a9e 100644
 --- a/node_modules/@zenfs/core/dist/vfs/vcache.js
 +++ b/node_modules/@zenfs/core/dist/vfs/vcache.js
-@@ -76,6 +76,20 @@ export class VCache {
+@@ -76,6 +76,27 @@ export class VCache {
       */
      ref(path, inode) {
          let node = this.byIno.get(inode.ino);
-+        // PATCH(#2146): never coalesce DIFFERENT paths onto one vnode via a
-+        // zero/unset ino, or across differing format bits. Hardlinks share a
-+        // real ino AND a mode; a poisoned index (thousands of ino-0 entries
-+        // observed in the field) must not make unrelated files share an
-+        // inode object — the shared vnode stamps one file's size/mode onto
-+        // the other path on sync.
++        // PATCH(#2146, #2034): never coalesce DIFFERENT paths onto one vnode
++        // unless they are a genuine hardlink. Hardlinks share a real ino, a
++        // mode, AND carry nlink > 1; anything else with a matching ino is a
++        // poisoned index (ino-0 floods and duplicated ids both observed in
++        // the field). A shared vnode shares its inode object (stamping one
++        // file's size/mode onto the other on sync) and its data cache —
++        // which is why concurrent reads of two colliding paths returned the
++        // same bytes (#2034): the second open found the first file's vnode
++        // and its cached regions, while sequential reads evicted the vnode
++        // between calls and never collided.
 +        if (node && !node.paths.has(path)
-+            && (inode.ino === 0 || ((node.inode.mode ^ inode.mode) & 0o170000) !== 0)) {
-+            // The byIno slot may have been claimed by ANOTHER ino-0 path; a
-+            // re-ref of an already-known path must still find its own vnode.
++            && (inode.ino === 0
++                || inode.nlink <= 1
++                || node.inode.nlink <= 1
++                || ((node.inode.mode ^ inode.mode) & 0o170000) !== 0)) {
++            // The byIno slot may have been claimed by ANOTHER colliding path;
++            // a re-ref of an already-known path must still find its own vnode.
 +            node = this.byPath.get(path);
 +            if (node && ((node.inode.mode ^ inode.mode) & 0o170000) !== 0)
 +                node = undefined;

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -4,9 +4,9 @@
     "patchedVersion": "2.6.2",
     "upstream": "https://github.com/zen-fs/core",
     "issue": null,
-    "reason": "Make globalThis.__zenfs__ a null-prototype own-property copy of fs (Object.assign(Object.create(null), fs)) instead of a prototype view, so the fs export's enumerable members are reliably visible on the global probe. ALSO (#2146): VCache.ref coalesced DIFFERENT paths onto one vnode when their inodes shared an ino (poisoned indexes carry many ino-0 entries) — the shared inode object cross-stamps size/mode between unrelated files. The patch refuses cross-path coalescing when ino is 0 or the format bits differ (hardlinks share both a real ino and a mode, so they still coalesce).",
+    "reason": "Make globalThis.__zenfs__ a null-prototype own-property copy of fs (Object.assign(Object.create(null), fs)) instead of a prototype view, so the fs export's enumerable members are reliably visible on the global probe. ALSO (#2146): VCache.ref coalesced DIFFERENT paths onto one vnode when their inodes shared an ino (poisoned indexes carry many ino-0 entries) — the shared inode object cross-stamps size/mode between unrelated files. The patch refuses cross-path coalescing unless the inodes are a genuine hardlink: ino must be nonzero, format bits must match, AND nlink must be > 1 on both sides (#2034). A duplicated real ino with nlink 1 is a poisoned index, not a link — and because every vnode also owns its sparse data cache, two colliding paths open at once returned each other's bytes (8 parallel preview fetches all served the entry file; sequential reads evicted the vnode between calls and were correct).",
     "removeWhen": "Local workaround — no upstream PR is tracked. Re-evaluate whenever @zenfs/core changes the __zenfs__ global or the fs export shape; if a newer version no longer needs the override, remove the patch.",
-    "verify": "npm run test -w @slicc/webapp -- zenfs-ino-collision-patch"
+    "verify": "npm run test -w @slicc/webapp -- zenfs-ino-collision-patch virtual-fs-concurrent-read"
   },
   "@zenfs/dom": {
     "patchedVersion": "1.2.10",


### PR DESCRIPTION
Fixes #2034

## Summary

Concurrent `readFile` calls against the OPFS-backed VirtualFS could return the *same* file's bytes for distinct paths. Root cause, now closed at the FS layer: ZenFS keys its vnode cache by `ino` and every vnode owns a sparse data cache, so two paths with colliding inos that are open at once share one vnode — the second reader gets the first file's cached bytes. Sequential reads evict the vnode between calls and never collide, which is exactly the "sequential correct, 8 parallel fetches all return `index.js`" shape in the report.

## Why

The ino floods themselves were the #2146 minting bugs (fixed 2026-08-17, after this issue was filed on 08-09), so the originally observed path is already healthy on `main` (the new test's first case passes without this PR). What remained: `VCache.ref` still coalesced any duplicated *nonzero* ino with matching format bits, so a poisoned index or a cross-context allocation race would still cross-contaminate concurrent reads (the second case fails on `main` with the size cross-stamp `tried to read 70 bytes but the file is 50`).

**Repro** (`packages/webapp/tests/fs/virtual-fs-concurrent-read.test.ts`): write two files on the OPFS mock, forge `b.ino = a.ino`, `Promise.all` both reads → on `main` the second read gets the first file's size/bytes.

## Approach / Implementation notes

- `patches/@zenfs+core+2.6.2.patch`: `VCache.ref` shares a vnode across different paths only for a genuine hardlink — nonzero ino, matching format bits, **and `nlink > 1` on both sides**. `IndexFS.link` is `ENOSYS` on the OPFS backend anyway, so cross-path sharing there was never legitimate. Regenerated from the pristine 2.6.2 tarball (patch-package's generator can't run in the sandbox); `npx patch-package` applies cleanly, `lint:patches` OK.
- Existing `zenfs-ino-collision-patch` guard: hardlink case now states `nlink: 2`; new "duplicated ino, nlink 1 → distinct vnodes" case.
- `preview-vfs-responder`: the serial read queue from #2029/#2037 stays as defense in depth (its ack/start protocol is built on it); comment now cites the root cause. Boy-scout: logger meta is a named type.
- `docs/pitfalls.md` gets the invariant under "OPFS Writes".

## Verification

- vitest: fs suites (virtual-fs, write-serialization, opfs-multi-instance, sidecar-repair, zenfs-ino-collision-patch, preview-vfs-responder) + the new test — green
- webapp typecheck, biome, `lint:patches`, `check-touched-exemptions` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)