### PR TITLE
feat(realm): Atomics/SharedArrayBuffer fast path for the sync bridges (#2043)

### DIFF
--- a/docs/kernel/process-model.md
+++ b/docs/kernel/process-model.md
@@ -131,9 +131,27 @@ works on every float — including embedded leaders (Cherry, spoon/Electron)
 that can never be isolated. The hosted leader document _is_ now
 cross-origin isolated via `Document-Isolation-Policy` (per-document, no
 COOP/COEP, SW control unaffected — see the `serveSPA` comment in
-`packages/cloudflare-worker/src/index.ts`), which makes an Atomics/SAB
-fast path a possible future perf lever where `crossOriginIsolated` is
-true; the SW sync-XHR path below remains the universal baseline:
+`packages/cloudflare-worker/src/index.ts`). Where `crossOriginIsolated` is
+true the bridges take the **Atomics/SharedArrayBuffer fast path** below; the
+SW sync-XHR path remains the universal baseline everywhere else:
+
+**Atomics/SAB fast path (isolated leaders, #2043)**: `realm-runner` allocates
+one `SharedArrayBuffer` per realm that owns its thread (`Realm.isolatedThread`
+— a `DedicatedWorker`; never the in-process factory, which would deadlock
+against its own responder) and hands it over in `RealmInitMsg.syncSab`. The
+realm (`realm/sync-sab-bridge.ts`) posts the structured request on its control
+port and blocks in `Atomics.wait`; the kernel-side `realm/sync-sab-responder.ts`
+— attached to the same port by `attachRealmHost` — runs it through the SAME
+token-scoped `dispatchSyncFs` / `dispatchSyncExec` as the SW route (identical
+ACL, sudo, errno), writes the encoded result into the shared window and
+`Atomics.notify`s. Results larger than the window stream in rounds
+(`sync-sab-next`), one post per chunk, so the kernel never blocks and needs no
+`Atomics.waitAsync`. The body carries no token: the port is private to one
+realm, so the responder binds the host-minted token itself. Layout + encode/
+decode live in the dependency-free `realm/sync-sab-wire.ts`. On this path the
+SW-confirmation gate (`syncFsBridgeEnabled`) is not required to mint the realm's
+token — the SAB is the transport — and `ENOSYNC` never reaches user code: every
+over-cap or post-snapshot read falls through to a live, unbounded, chunked read.
 
 **Fast path**: an in-memory snapshot of up to 500 files / 1 MB total / 10 MB
 per file, warm-populated at realm start. Reads that hit the snapshot return

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -59,7 +59,6 @@
   "packages/webapp/src/kernel/realm/mount-bomb-fs.ts": 2,
   "packages/webapp/src/kernel/realm/py-realm-shared.ts": 1,
   "packages/webapp/src/kernel/realm/realm-browser-fetch.ts": 2,
-  "packages/webapp/src/kernel/realm/realm-types.ts": 1,
   "packages/webapp/src/kernel/realm/skill-global.ts": 7,
   "packages/webapp/src/kernel/realm/ws-router-page.ts": 7,
   "packages/webapp/src/kernel/telemetry.ts": 1,

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -73,7 +73,10 @@ Non-obvious rules:
 - **Kernel realms**: `runInRealm()` spawns per-task `DedicatedWorker`; SIGKILL → exit 137. Sync `readFileSync`/`writeFileSync` and
   `child_process.execSync`/`execFileSync`/`spawnSync` from realm scripts go through
   `realm/sync-{xhr,fs-*,exec-*}.ts` + `ui/sync-fs-sw-handler.ts` with per-realm
-  capability tokens; never bypass. Deep reference: `docs/kernel/process-model.md`.
+  capability tokens; never bypass. On an isolated leader the same dispatchers are
+  reached over `realm/sync-sab-*.ts` (Atomics/SharedArrayBuffer on the realm's
+  own port) — only for `Realm.isolatedThread` realms; the in-process factory must
+  never get a SAB (self-deadlock). Deep reference: `docs/kernel/process-model.md`.
 - **Scoop queue**: pure-lick batches defer while `ScoopContext.isBusy` without
   queue/watermark loss; user `web` bypasses the window (immediate/awaited,
   prevents deferral). `transcript-limits.ts` caps bridge/event transcripts at 64 KB

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -54,6 +54,12 @@ import { createSkillGlobal, type SkillFsBridge } from './skill-global.js';
 import { createSyncExecXhrBridge, type SyncExecXhrBridge } from './sync-exec-xhr-bridge.js';
 import { SyncFsCache, type SyncFsSnapshot } from './sync-fs-cache.js';
 import { createSyncFsXhrBridge, type SyncFsXhrMutatingBridge } from './sync-fs-xhr-bridge.js';
+import {
+  createSyncExecSabTransport,
+  createSyncFsSabBridge,
+  createSyncSabTransport,
+  type SyncSabTransport,
+} from './sync-sab-bridge.js';
 
 /**
  * Request the `vfs.snapshot` RPC and build the {@link SyncFsCache} it backs.
@@ -106,8 +112,28 @@ function syncFsSnapshotErrorSink(
  * absent (default / in-process tests / boot-before-control) → `undefined` →
  * the bounded snapshot fallback. See `sync-fs-xhr-bridge.ts` + the plan.
  */
-function resolveSyncFsBridge(init: RealmInitMsg): SyncFsXhrMutatingBridge | undefined {
+function resolveSyncFsBridge(
+  init: RealmInitMsg,
+  sab: SyncSabTransport | undefined
+): SyncFsXhrMutatingBridge | undefined {
+  if (sab) return createSyncFsSabBridge(sab);
   return init.syncFsToken ? createSyncFsXhrBridge(init.syncFsToken) : undefined;
+}
+
+/**
+ * The Atomics/SAB transport (#2043) when the host handed us a shared buffer —
+ * only ever on a cross-origin-isolated leader for a realm on its own thread
+ * (`Realm.isolatedThread`); `Atomics.wait` is otherwise unavailable or a
+ * deadlock. The SW sync-XHR path stays the universal baseline.
+ */
+function resolveSyncSabTransport(
+  init: RealmInitMsg,
+  port: RealmPortLike
+): SyncSabTransport | undefined {
+  if (!init.syncSab || typeof Atomics === 'undefined' || typeof Atomics.wait !== 'function') {
+    return undefined;
+  }
+  return createSyncSabTransport(init.syncSab, port);
 }
 
 /**
@@ -120,16 +146,19 @@ function resolveSyncFsBridge(init: RealmInitMsg): SyncFsXhrMutatingBridge | unde
  */
 function installSyncBridges(
   init: RealmInitMsg,
+  port: RealmPortLike,
   syncFs: SyncFsCache,
   fsBridge: object,
   stdio: RealmStdioBridge
 ): SyncExecXhrBridge | undefined {
-  const syncFsXhr = resolveSyncFsBridge(init);
+  const sab = resolveSyncSabTransport(init, port);
+  const syncFsXhr = resolveSyncFsBridge(init, sab);
   Object.assign(fsBridge, createSyncFsBridge(syncFs, init.cwd, syncFsXhr, stdio));
   if (!init.syncFsToken) return undefined;
   return createSyncExecXhrBridge(init.syncFsToken, {
     syncFs,
     ...(syncFsXhr ? { fsBridge: syncFsXhr } : {}),
+    ...(sab ? { transport: createSyncExecSabTransport(sab) } : {}),
   });
 }
 
@@ -233,7 +262,7 @@ export async function runJsRealm(init: RealmInitMsg, port: RealmPortLike): Promi
   const fsBridge = createFsBridge(rpc, realmFetch, stdio);
 
   const syncFs = await initSyncFsCache(rpc, init.cwd, syncFsSnapshotErrorSink(init, writeStderr));
-  const syncExecBridge = installSyncBridges(init, syncFs, fsBridge, stdio);
+  const syncExecBridge = installSyncBridges(init, port, syncFs, fsBridge, stdio);
 
   const execBridge = createExecBridge(rpc, syncFs, init.cwd, writeStderr);
   const agentModule = createSliccyAgentModule(execBridge, { cwd: init.cwd });

--- a/packages/webapp/src/kernel/realm/realm-factory.ts
+++ b/packages/webapp/src/kernel/realm/realm-factory.ts
@@ -82,6 +82,10 @@ function wrapWorker(worker: Worker): Realm {
   let terminated = false;
   return {
     controlPort: port,
+    // A real DedicatedWorker owns its thread, so it may block in
+    // `Atomics.wait` — this is what lets the runner hand it the SAB sync
+    // bridge (#2043). The in-process fallbacks deliberately leave it unset.
+    isolatedThread: true,
     // Forwards both `error` (worker crash / uncaught bootstrap throw) and
     // `messageerror` (realm posted an un-deserializable message — a worker
     // that died mid-post) so the runner can settle non-zero on either.

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -58,6 +58,7 @@ import type {
 import type { SyncFsMutations, SyncFsSnapshot } from './sync-fs-cache.js';
 import { mintSyncFsToken, revokeSyncFsToken } from './sync-fs-token-registry.js';
 import type { SyncFsToken } from './sync-fs-wire.js';
+import { attachSyncSabResponder } from './sync-sab-responder.js';
 import { compileWasmFromVfs } from './wasm-compiler.js';
 import type { WsSubscriberRegistry } from './ws-subscribers.js';
 
@@ -135,6 +136,13 @@ export interface RealmHostOptions {
    * can actually be served. Default off → no token → today's snapshot fallback.
    */
   syncFsBridgeEnabled?: boolean;
+  /**
+   * Shared buffer for the Atomics/SAB sync fast path (#2043). When present
+   * (and the token is minted), a `sync-sab-responder` is attached to the same
+   * port and answers the realm's blocking fs/exec requests through the same
+   * token-scoped dispatchers the SW route uses. Disposed with the host.
+   */
+  syncSab?: SharedArrayBuffer;
 }
 
 /**
@@ -188,12 +196,19 @@ export function attachRealmHost(
     void respond(port, req, ctx, opts, hidCtx, execCtx);
   };
   port.addEventListener('message', handler);
+  // The SAB responder shares this port: the realm's blocking requests are
+  // plain messages, answered into the shared window (see sync-sab-responder).
+  const sabResponder =
+    syncFsToken && opts.syncSab
+      ? attachSyncSabResponder(port, opts.syncSab, syncFsToken)
+      : undefined;
   port.start?.();
   return {
     syncFsToken,
     dispose: () => {
       if (disposed) return;
       disposed = true;
+      sabResponder?.dispose();
       if (syncFsToken) revokeSyncFsToken(syncFsToken);
       port.removeEventListener('message', handler);
       // Abort any in-flight `exec.start` commands so a terminated realm

--- a/packages/webapp/src/kernel/realm/realm-runner.ts
+++ b/packages/webapp/src/kernel/realm/realm-runner.ts
@@ -43,6 +43,7 @@ import type {
   RealmKind,
   RealmMountPoint,
 } from './realm-types.js';
+import { isSyncSabSupported, SAB_DEFAULT_WINDOW_BYTES, SAB_HEADER_BYTES } from './sync-sab-wire.js';
 
 // ---------------------------------------------------------------------------
 // Realm abstraction
@@ -58,6 +59,14 @@ export interface Realm {
   readonly controlPort: RealmPortLike;
   /** Synchronous hard-stop. Idempotent. */
   terminate(): void;
+  /**
+   * `true` when the realm executes on its OWN thread (a `DedicatedWorker`),
+   * i.e. it may block in `Atomics.wait` without stalling the kernel. Only such
+   * realms get the SharedArrayBuffer sync bridge (#2043); the in-process test
+   * factory leaves this unset and keeps the SW / snapshot paths — a blocking
+   * wait on the kernel thread would deadlock against its own responder.
+   */
+  readonly isolatedThread?: boolean;
   /**
    * Optional: kernel-host can subscribe to abnormal realm ends. `error`
    * fires on an uncaught bootstrap error / worker crash; `messageerror`
@@ -152,6 +161,11 @@ export interface RunInRealmOptions {
    * today's snapshot behavior and is what the in-process test factory uses.
    */
   syncFsBridgeEnabled?: boolean;
+  /**
+   * Payload window size for the Atomics/SAB sync bridge (#2043); default
+   * `SAB_DEFAULT_WINDOW_BYTES`. Tests shrink it to exercise chunking.
+   */
+  syncSabBytes?: number;
 }
 
 export interface RealmResult {
@@ -194,12 +208,19 @@ export async function runInRealm(opts: RunInRealmOptions): Promise<RealmResult> 
   // register each realm-spawned command as a real PM process (parented to
   // THIS realm's pid, so a signal to the realm fans out to its children)
   // and a `kill` op can signal it. See `realm-host.ts` dispatchExecStart.
+  // Atomics/SAB fast path (#2043): on a cross-origin-isolated leader a realm
+  // that owns its thread gets a shared buffer and blocks on it directly —
+  // no Service Worker in the loop, so the SW-confirmation gate
+  // (`syncFsBridgeEnabled`) is not required to mint its token. Everywhere
+  // else the SW transport (when confirmed) or the snapshot remains.
+  const syncSab = realm.isolatedThread ? allocateSyncSab(opts.syncSabBytes) : undefined;
   const host: RealmHostHandle = attachRealmHost(realm.controlPort, opts.ctx, {
     ...(opts.owner.scoopJid !== undefined ? { scoopJid: opts.owner.scoopJid } : {}),
     pm: opts.pm,
     owner: opts.owner,
     ppid: proc.pid,
-    syncFsBridgeEnabled: opts.syncFsBridgeEnabled,
+    syncFsBridgeEnabled: Boolean(opts.syncFsBridgeEnabled) || syncSab !== undefined,
+    ...(syncSab ? { syncSab } : {}),
   });
 
   return new Promise<RealmResult>((resolve) => {
@@ -310,7 +331,24 @@ export async function runInRealm(opts: RunInRealmOptions): Promise<RealmResult> 
       // Thread the minted sync-fs token (present only when the bridge is
       // enabled) so the realm can address its own ctx.fs over the SW bridge.
       ...(host.syncFsToken !== undefined ? { syncFsToken: host.syncFsToken } : {}),
+      ...(syncSab ? { syncSab } : {}),
     };
     realm.controlPort.postMessage(init);
   });
+}
+
+/**
+ * Allocate the per-realm shared buffer for the Atomics fast path, or
+ * `undefined` where `SharedArrayBuffer` is not constructible (a non-isolated
+ * document). Exported for tests.
+ */
+export function allocateSyncSab(windowBytes?: number): SharedArrayBuffer | undefined {
+  if (!isSyncSabSupported()) return undefined;
+  try {
+    return new SharedArrayBuffer(SAB_HEADER_BYTES + (windowBytes ?? SAB_DEFAULT_WINDOW_BYTES));
+  } catch {
+    // Constructor can still throw (quota, an isolation probe that lied):
+    // degrade to the SW / snapshot paths rather than failing the run.
+    return undefined;
+  }
 }

--- a/packages/webapp/src/kernel/realm/realm-types.ts
+++ b/packages/webapp/src/kernel/realm/realm-types.ts
@@ -53,6 +53,17 @@ export interface RealmInitMsg {
    */
   syncFsToken?: SyncFsToken;
   /**
+   * Atomics/SharedArrayBuffer fast path for the synchronous bridges (#2043).
+   * Present only on a cross-origin-isolated leader AND for a realm that runs
+   * on its own thread (a `DedicatedWorker` — see `Realm.isolatedThread`): the
+   * realm then blocks in `Atomics.wait` on this buffer instead of issuing a
+   * sync XHR through the Service Worker. The structured-clone of a SAB shares
+   * memory rather than copying it. The kernel-side responder is attached to
+   * the realm's control port by `attachRealmHost`. Absent → the SW transport
+   * (when {@link syncFsToken} is present) or the bounded snapshot.
+   */
+  syncSab?: SharedArrayBuffer;
+  /**
    * Optional initial stdin (string). Consumed by both realms:
    *   • Python — surfaced as `sys.stdin`.
    *   • JS — surfaced as `process.stdin.read()` / `for await ... of
@@ -254,6 +265,15 @@ export interface SerializedFetchResponse {
 }
 
 /**
+ * A caller-authored deep-match template for an observed WebSocket frame:
+ * arbitrary JSON keys, each compared by deep equality against the parsed
+ * frame. It has no fixed shape by design — the keys are the caller's.
+ */
+export interface WsFrameTemplate {
+  [key: string]: unknown;
+}
+
+/**
  * Declarative WebSocket frame selector. Skill code never supplies a
  * `Function` or a string of JS — only a JSON object whose `where` is
  * a deep-equality template the runtime matches against the parsed
@@ -268,7 +288,7 @@ export interface WsSelector {
    * Deep-equality template. Every key/value present in `where` must
    * match the parsed frame. Missing keys on the frame fail the match.
    */
-  where?: Record<string, unknown>;
+  where?: WsFrameTemplate;
   /** Project a subset of the parsed object's top-level fields. */
   project?: readonly string[];
 }

--- a/packages/webapp/src/kernel/realm/sync-exec-xhr-bridge.ts
+++ b/packages/webapp/src/kernel/realm/sync-exec-xhr-bridge.ts
@@ -31,6 +31,7 @@
 import {
   clampSyncExecTimeout,
   SYNC_EXEC_CHANNEL,
+  type SyncExecRequestPayload,
   type SyncExecResultPayload,
 } from './sync-exec-dispatch.js';
 import type { SyncFsCache } from './sync-fs-cache.js';
@@ -54,6 +55,44 @@ export interface SyncExecOptions {
 
 export interface SyncExecXhrBridge {
   run(command: string | string[], opts?: SyncExecOptions): SyncExecResultPayload;
+}
+
+/**
+ * One blocking exec round-trip. The default is the sync-XHR → SW route; the
+ * Atomics/SAB fast path (`sync-sab-bridge.ts`) supplies its own. Either way
+ * the envelope is the same `SyncExecRequestPayload`, so `dispatchSyncExec`
+ * cannot tell the transports apart. Must throw an errno `Error` on any
+ * transport or dispatch failure and return only a well-formed payload.
+ */
+export type SyncExecTransport = (
+  payload: SyncExecRequestPayload,
+  timeoutMs: number,
+  label: string
+) => SyncExecResultPayload;
+
+function xhrExecTransport(token: string): SyncExecTransport {
+  return (payload, timeoutMs, label) => {
+    const json = synchronifyJson({
+      method: 'POST',
+      url: SYNC_EXEC_ROUTE,
+      token,
+      body: new TextEncoder().encode(JSON.stringify({ ...payload, channel: SYNC_EXEC_CHANNEL })),
+      // Give the transport a margin over the command budget so the SW's
+      // authoritative errno wins the race with the bare XHR-timeout EIO —
+      // same ordering the fs channel relies on.
+      timeoutMs: timeoutMs + SYNC_EXEC_XHR_MARGIN_MS,
+      label,
+    }) as Partial<SyncExecResultPayload> | null;
+    if (
+      !json ||
+      typeof json.stdout !== 'string' ||
+      typeof json.stderr !== 'string' ||
+      typeof json.exitCode !== 'number'
+    ) {
+      throw syncXhrError('EIO', label);
+    }
+    return { stdout: json.stdout, stderr: json.stderr, exitCode: json.exitCode };
+  };
 }
 
 /**
@@ -81,10 +120,17 @@ function flushBeforeSyncExec(syncFs: SyncFsCache, fsBridge: SyncFsXhrMutatingBri
  */
 export function createSyncExecXhrBridge(
   token: string,
-  opts: { syncFs?: SyncFsCache; fsBridge?: SyncFsXhrMutatingBridge; timeoutMs?: number } = {}
+  opts: {
+    syncFs?: SyncFsCache;
+    fsBridge?: SyncFsXhrMutatingBridge;
+    timeoutMs?: number;
+    /** Blocking transport; defaults to the sync-XHR → SW route bound to `token`. */
+    transport?: SyncExecTransport;
+  } = {}
 ): SyncExecXhrBridge {
   const defaultTimeoutMs = opts.timeoutMs ?? SYNC_EXEC_DEFAULT_TIMEOUT_MS;
   const { syncFs, fsBridge } = opts;
+  const transport = opts.transport ?? xhrExecTransport(token);
 
   return {
     run(command: string | string[], runOpts: SyncExecOptions = {}): SyncExecResultPayload {
@@ -98,34 +144,14 @@ export function createSyncExecXhrBridge(
       // SYNC_EXEC_XHR_MARGIN_MS; an oversized one must hit the wire ceiling
       // here too, or the XHR waits long past the command the SW already killed.
       const timeoutMs = clampSyncExecTimeout(runOpts.timeout, defaultTimeoutMs);
-      const payload = {
+      const payload: SyncExecRequestPayload = {
         command,
         ...(runOpts.args !== undefined ? { args: runOpts.args } : {}),
         ...(runOpts.input !== undefined ? { stdin: runOpts.input } : {}),
         timeoutMs,
-        channel: SYNC_EXEC_CHANNEL,
       };
       try {
-        const json = synchronifyJson({
-          method: 'POST',
-          url: SYNC_EXEC_ROUTE,
-          token,
-          body: new TextEncoder().encode(JSON.stringify(payload)),
-          // Give the transport a margin over the command budget so the SW's
-          // authoritative errno wins the race with the bare XHR-timeout EIO —
-          // same ordering the fs channel relies on.
-          timeoutMs: timeoutMs + SYNC_EXEC_XHR_MARGIN_MS,
-          label,
-        }) as Partial<SyncExecResultPayload> | null;
-        if (
-          !json ||
-          typeof json.stdout !== 'string' ||
-          typeof json.stderr !== 'string' ||
-          typeof json.exitCode !== 'number'
-        ) {
-          throw syncXhrError('EIO', label);
-        }
-        return { stdout: json.stdout, stderr: json.stderr, exitCode: json.exitCode };
+        return transport(payload, timeoutMs, label);
       } finally {
         // INVALIDATE (not re-snapshot): the command may have changed anything
         // under the cache, and every sync read falls through to the live fs

--- a/packages/webapp/src/kernel/realm/sync-sab-bridge.ts
+++ b/packages/webapp/src/kernel/realm/sync-sab-bridge.ts
@@ -1,0 +1,252 @@
+/**
+ * Realm-side client for the Atomics/SharedArrayBuffer sync bridge (#2043).
+ *
+ * Runs INSIDE the realm's DedicatedWorker on a cross-origin-isolated leader.
+ * Each op posts a structured request over the realm's control port and blocks
+ * the realm thread in `Atomics.wait` until the kernel-side responder
+ * (`sync-sab-responder.ts`) has written the answer into the shared window.
+ * There is no Service Worker, no HTTP, no BroadcastChannel and no snapshot cap
+ * on this path; the per-op cost is one postMessage hop plus a memcpy per
+ * window-sized chunk.
+ *
+ * The fs surface implements the SAME {@link SyncFsXhrMutatingBridge} the SW
+ * transport does, so `createSyncFsBridge` (the `fs` shim) is transport-blind;
+ * the exec surface is a {@link SyncExecTransport} plugged into
+ * `createSyncExecXhrBridge`, which keeps its cache-coherence dance.
+ *
+ * Failure semantics match `sync-xhr.ts`: every transport fault (timeout, stale
+ * wake-up, torn header) throws an `Error` with a POSIX `.code` — never a hang,
+ * never a bare error — and a dispatch errno is rethrown with its own code.
+ */
+
+import type { SyncExecRequestPayload } from './sync-exec-dispatch.js';
+import { SYNC_EXEC_CHANNEL, type SyncExecResultPayload } from './sync-exec-dispatch.js';
+import type { SyncExecTransport } from './sync-exec-xhr-bridge.js';
+import type { SyncFsResult } from './sync-fs-dispatch.js';
+import { SYNC_FS_REQUEST_TIMEOUT_MS } from './sync-fs-wire.js';
+import type { SyncFsBridgeStat, SyncFsXhrMutatingBridge } from './sync-fs-xhr-bridge.js';
+import {
+  decodeSabResult,
+  SAB_I_CHUNK,
+  SAB_I_OFFSET,
+  SAB_I_SEQ,
+  SAB_I_STATE,
+  SAB_I_STATUS,
+  SAB_I_TOTAL,
+  SAB_STATE_IDLE,
+  SAB_STATE_PENDING,
+  SAB_STATE_READY,
+  type SabViews,
+  SYNC_SAB_NEXT_MSG,
+  SYNC_SAB_REQ_MSG,
+  type SyncSabNextMsg,
+  type SyncSabReqMsg,
+  type SyncSabRequestBody,
+  sabViews,
+} from './sync-sab-wire.js';
+import { syncXhrError } from './sync-xhr.js';
+
+/** The one port method the transport needs; `RealmPortLike` satisfies it. */
+export interface SabPostLike {
+  postMessage(message: unknown): void;
+}
+
+export interface SyncSabTransport {
+  /** Issue one blocking round-trip and return the decoded dispatch result. */
+  call(req: SyncSabRequestBody, timeoutMs: number, label: string): SyncFsResult;
+}
+
+/** Blocking-wait seam so tests can observe/replace `Atomics.wait`. */
+export type AtomicsWaitLike = (
+  typedArray: Int32Array,
+  index: number,
+  value: number,
+  timeout?: number
+) => 'ok' | 'not-equal' | 'timed-out';
+
+/**
+ * Build the transport over `sab`. `port` is the realm's control port (the
+ * same one the async RPC rides); the kernel-side responder is attached to the
+ * other end by `attachRealmHost`.
+ */
+export function createSyncSabTransport(
+  sab: SharedArrayBuffer,
+  port: SabPostLike,
+  deps: { wait?: AtomicsWaitLike; now?: () => number } = {}
+): SyncSabTransport {
+  const views: SabViews = sabViews(sab);
+  const { header, window } = views;
+  const wait: AtomicsWaitLike = deps.wait ?? ((a, i, v, t) => Atomics.wait(a, i, v, t));
+  const now = deps.now ?? (() => performance.now());
+  let seq = 0;
+
+  /**
+   * Block until the responder has written a chunk for `id`, or the deadline
+   * passes. A wake-up carrying another request's SEQ (a late chunk from a
+   * request that already timed out) is ignored and the wait resumes.
+   */
+  function awaitReady(id: number, deadline: number, label: string): void {
+    for (;;) {
+      const remaining = deadline - now();
+      if (remaining <= 0) throw syncXhrError('ETIMEDOUT', label);
+      // `not-equal` means the responder already flipped STATE before we got
+      // here — proceed to the checks below exactly as after a genuine wake.
+      wait(header, SAB_I_STATE, SAB_STATE_PENDING, remaining);
+      if (
+        Atomics.load(header, SAB_I_STATE) === SAB_STATE_READY &&
+        Atomics.load(header, SAB_I_SEQ) === id
+      ) {
+        return;
+      }
+      if (Atomics.load(header, SAB_I_STATE) === SAB_STATE_READY) {
+        // Stale chunk for a previous serial: re-arm and keep waiting.
+        Atomics.store(header, SAB_I_STATE, SAB_STATE_PENDING);
+      }
+    }
+  }
+
+  return {
+    call(req, timeoutMs, label): SyncFsResult {
+      const id = ++seq;
+      const deadline = now() + timeoutMs;
+      let out: Uint8Array | null = null;
+      let status = 0;
+      let offset = 0;
+      try {
+        for (;;) {
+          Atomics.store(header, SAB_I_STATE, SAB_STATE_PENDING);
+          const msg: SyncSabReqMsg | SyncSabNextMsg =
+            offset === 0
+              ? { type: SYNC_SAB_REQ_MSG, id, req }
+              : { type: SYNC_SAB_NEXT_MSG, id, offset };
+          try {
+            port.postMessage(msg);
+          } catch {
+            throw syncXhrError('EIO', label);
+          }
+          awaitReady(id, deadline, label);
+          const total = Atomics.load(header, SAB_I_TOTAL);
+          const chunk = Atomics.load(header, SAB_I_CHUNK);
+          const at = Atomics.load(header, SAB_I_OFFSET);
+          if (at !== offset || chunk < 0 || total < 0 || offset + chunk > total) {
+            throw syncXhrError('EIO', label);
+          }
+          if (out === null) {
+            status = Atomics.load(header, SAB_I_STATUS);
+            out = new Uint8Array(total);
+          }
+          out.set(window.subarray(0, chunk), offset);
+          offset += chunk;
+          if (offset >= total) break;
+          // A zero-length chunk with bytes outstanding would spin forever.
+          if (chunk === 0) throw syncXhrError('EIO', label);
+        }
+      } finally {
+        Atomics.store(header, SAB_I_STATE, SAB_STATE_IDLE);
+      }
+      return decodeSabResult(status, out);
+    },
+  };
+}
+
+function errnoError(code: string, path: string): Error & { code: string } {
+  return syncXhrError(code, `sync-sab bridge, '${path}'`);
+}
+
+function isStat(json: unknown): json is SyncFsBridgeStat {
+  const s = json as Partial<SyncFsBridgeStat> | null;
+  return (
+    !!s &&
+    typeof s.isFile === 'boolean' &&
+    typeof s.isDirectory === 'boolean' &&
+    typeof s.size === 'number'
+  );
+}
+
+/**
+ * The fs half: same method surface + error contract as `createSyncFsXhrBridge`,
+ * so the `fs` shim cannot tell the transports apart.
+ */
+export function createSyncFsSabBridge(
+  transport: SyncSabTransport,
+  opts: { timeoutMs?: number } = {}
+): SyncFsXhrMutatingBridge {
+  const timeoutMs = opts.timeoutMs ?? SYNC_FS_REQUEST_TIMEOUT_MS;
+
+  function run(req: SyncSabRequestBody, path: string): SyncFsResult {
+    const result = transport.call(req, timeoutMs, `sync-sab bridge, '${path}'`);
+    if (!result.ok) throw errnoError(result.errno, path);
+    return result;
+  }
+  function bytes(req: SyncSabRequestBody, path: string): Uint8Array {
+    const r = run(req, path);
+    if (r.ok && r.kind === 'bytes') return r.bytes;
+    throw errnoError('EIO', path);
+  }
+  function json(req: SyncSabRequestBody, path: string): unknown {
+    const r = run(req, path);
+    if (r.ok && r.kind === 'json') return r.json;
+    throw errnoError('EIO', path);
+  }
+
+  return {
+    readFile: (path) => bytes({ op: 'read', path }, path),
+    writeFile: (path, data) => {
+      // AT-LEAST-ONCE, same as the SW transport: a throw means the outcome is
+      // unknown (the responder may have committed before a timeout fired).
+      run({ op: 'write', path, body: data }, path);
+    },
+    stat: (path) => {
+      const s = json({ op: 'stat', path }, path);
+      if (!isStat(s)) throw errnoError('EIO', path);
+      return s;
+    },
+    lstat: (path) => {
+      const s = json({ op: 'lstat', path }, path);
+      if (!isStat(s)) throw errnoError('EIO', path);
+      return s;
+    },
+    readdir: (path) => {
+      const list = json({ op: 'readdir', path }, path);
+      if (!Array.isArray(list) || !list.every((s) => typeof s === 'string')) {
+        throw errnoError('EIO', path);
+      }
+      return list as string[];
+    },
+    exists: (path) => {
+      const v = json({ op: 'exists', path }, path);
+      if (typeof v !== 'boolean') throw errnoError('EIO', path);
+      return v;
+    },
+    mkdir: (path) => {
+      run({ op: 'mkdir', path }, path);
+    },
+    rm: (path) => {
+      run({ op: 'rm', path }, path);
+    },
+  };
+}
+
+/**
+ * The exec half: a {@link SyncExecTransport} for `createSyncExecXhrBridge`.
+ * The envelope is the SW route's POST body verbatim (`channel: 'exec'`), so
+ * `dispatchSyncExec` sees an identical request either way.
+ */
+export function createSyncExecSabTransport(transport: SyncSabTransport): SyncExecTransport {
+  return (payload: SyncExecRequestPayload, timeoutMs: number, label: string) => {
+    const result = transport.call({ ...payload, channel: SYNC_EXEC_CHANNEL }, timeoutMs, label);
+    if (!result.ok) throw syncXhrError(result.errno, label);
+    const json = (
+      result.kind === 'json' ? result.json : null
+    ) as Partial<SyncExecResultPayload> | null;
+    if (
+      !json ||
+      typeof json.stdout !== 'string' ||
+      typeof json.stderr !== 'string' ||
+      typeof json.exitCode !== 'number'
+    ) {
+      throw syncXhrError('EIO', label);
+    }
+    return { stdout: json.stdout, stderr: json.stderr, exitCode: json.exitCode };
+  };
+}

--- a/packages/webapp/src/kernel/realm/sync-sab-bridge.ts
+++ b/packages/webapp/src/kernel/realm/sync-sab-bridge.ts
@@ -23,7 +23,7 @@ import type { SyncExecRequestPayload } from './sync-exec-dispatch.js';
 import { SYNC_EXEC_CHANNEL, type SyncExecResultPayload } from './sync-exec-dispatch.js';
 import type { SyncExecTransport } from './sync-exec-xhr-bridge.js';
 import type { SyncFsResult } from './sync-fs-dispatch.js';
-import { SYNC_FS_REQUEST_TIMEOUT_MS } from './sync-fs-wire.js';
+import { SYNC_EXEC_XHR_MARGIN_MS, SYNC_FS_REQUEST_TIMEOUT_MS } from './sync-fs-wire.js';
 import type { SyncFsBridgeStat, SyncFsXhrMutatingBridge } from './sync-fs-xhr-bridge.js';
 import {
   decodeSabResult,
@@ -234,7 +234,16 @@ export function createSyncFsSabBridge(
  */
 export function createSyncExecSabTransport(transport: SyncSabTransport): SyncExecTransport {
   return (payload: SyncExecRequestPayload, timeoutMs: number, label: string) => {
-    const result = transport.call({ ...payload, channel: SYNC_EXEC_CHANNEL }, timeoutMs, label);
+    // Wait a margin PAST the command budget, exactly like the SW transport
+    // (`SYNC_EXEC_XHR_MARGIN_MS`): the kernel aborts `ctx.exec` at the budget
+    // and only THEN encodes + publishes the result, so a deadline equal to the
+    // budget would let a just-in-time success be clobbered by a realm-side
+    // ETIMEDOUT. The kernel's authoritative result must win that race.
+    const result = transport.call(
+      { ...payload, channel: SYNC_EXEC_CHANNEL },
+      timeoutMs + SYNC_EXEC_XHR_MARGIN_MS,
+      label
+    );
     if (!result.ok) throw syncXhrError(result.errno, label);
     const json = (
       result.kind === 'json' ? result.json : null

--- a/packages/webapp/src/kernel/realm/sync-sab-responder.ts
+++ b/packages/webapp/src/kernel/realm/sync-sab-responder.ts
@@ -1,0 +1,185 @@
+/**
+ * Kernel-side responder for the Atomics/SharedArrayBuffer sync bridge (#2043).
+ *
+ * Attached by `attachRealmHost` to ONE realm's control port, bound to that
+ * realm's host-minted capability token. A `sync-sab-req` runs through the very
+ * same `dispatchSyncFs` / `dispatchSyncExec` the SW transport uses — the token
+ * resolves to the realm's gated `ctx.fs` / `ctx.exec`, so ACLs, sudo prompts
+ * and errno fidelity are identical — and the encoded result is streamed into
+ * the shared window one chunk per round. The realm is parked in `Atomics.wait`
+ * meanwhile; this thread never blocks.
+ *
+ * Security: the request body carries NO token. The port is private to the
+ * realm (a targeted `worker.postMessage`, not a broadcast), so "which realm
+ * sent this" is answered by which responder received it — the token is
+ * injected here from the host, never read from the realm. A realm therefore
+ * cannot address another realm's scope, and a forged `id` can at worst replay
+ * its own pending payload.
+ *
+ * Per-request state is a pending payload keyed by the realm serial `id`,
+ * retained until the realm has drained the last chunk or a TTL elapses (a
+ * realm that timed out mid-drain never sends `sync-sab-next`).
+ */
+
+import { dispatchSyncExec, isSyncExecRequest, type SyncExecRequest } from './sync-exec-dispatch.js';
+import { dispatchSyncFs, type SyncFsRequest, type SyncFsResult } from './sync-fs-dispatch.js';
+import { SYNC_EXEC_MAX_TIMEOUT_MS, SYNC_FS_REQUEST_TIMEOUT_MS } from './sync-fs-wire.js';
+import {
+  encodeSabResult,
+  SAB_I_CHUNK,
+  SAB_I_OFFSET,
+  SAB_I_SEQ,
+  SAB_I_STATE,
+  SAB_I_STATUS,
+  SAB_I_TOTAL,
+  SAB_STATE_READY,
+  type SabViews,
+  SYNC_SAB_NEXT_MSG,
+  SYNC_SAB_REQ_MSG,
+  type SyncSabNextMsg,
+  type SyncSabReqMsg,
+  sabViews,
+} from './sync-sab-wire.js';
+
+/** Listener surface the responder needs from the realm port. */
+export interface SabPortLike {
+  addEventListener(type: 'message', handler: (event: MessageEvent) => void): void;
+  removeEventListener(type: 'message', handler: (event: MessageEvent) => void): void;
+}
+
+export interface SyncSabResponderHandle {
+  /** Detach + drop pending payloads. Idempotent. */
+  dispose(): void;
+}
+
+interface PendingPayload {
+  status: number;
+  payload: Uint8Array;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/** Retain an undrained payload at least as long as any realm-side wait can last. */
+const PENDING_TTL_MS = Math.max(SYNC_FS_REQUEST_TIMEOUT_MS, SYNC_EXEC_MAX_TIMEOUT_MS) + 5_000;
+
+export interface SyncSabResponderOptions {
+  /** Override the dispatchers (tests). Production uses the token-scoped ones. */
+  dispatch?: (req: SyncFsRequest | SyncExecRequest) => Promise<SyncFsResult>;
+}
+
+/**
+ * Install the responder on `port` for the realm that owns `token`.
+ */
+export function attachSyncSabResponder(
+  port: SabPortLike,
+  sab: SharedArrayBuffer,
+  token: string,
+  opts: SyncSabResponderOptions = {}
+): SyncSabResponderHandle {
+  const views: SabViews = sabViews(sab);
+  const { header, window } = views;
+  const pending = new Map<number, PendingPayload>();
+  let disposed = false;
+
+  const dispatch =
+    opts.dispatch ??
+    ((req: SyncFsRequest | SyncExecRequest) =>
+      isSyncExecRequest(req) ? dispatchSyncExec(req) : dispatchSyncFs(req));
+
+  function drop(id: number): void {
+    const entry = pending.get(id);
+    if (!entry) return;
+    clearTimeout(entry.timer);
+    pending.delete(id);
+  }
+
+  /** Copy one chunk into the window and wake the realm. */
+  function publish(id: number, entry: PendingPayload, offset: number): void {
+    const chunk = Math.min(window.byteLength, entry.payload.byteLength - offset);
+    if (chunk > 0) window.set(entry.payload.subarray(offset, offset + chunk));
+    Atomics.store(header, SAB_I_STATUS, entry.status);
+    Atomics.store(header, SAB_I_TOTAL, entry.payload.byteLength);
+    Atomics.store(header, SAB_I_CHUNK, chunk);
+    Atomics.store(header, SAB_I_OFFSET, offset);
+    Atomics.store(header, SAB_I_SEQ, id);
+    Atomics.store(header, SAB_I_STATE, SAB_STATE_READY);
+    Atomics.notify(header, SAB_I_STATE);
+    // Last chunk delivered → nothing left to drain.
+    if (offset + chunk >= entry.payload.byteLength) drop(id);
+  }
+
+  function settle(id: number, result: SyncFsResult): void {
+    if (disposed) return;
+    const { status, payload } = encodeSabResult(result);
+    // Replace any stale entry under the same serial (cannot happen for a
+    // well-behaved realm — serials are monotonic — but never leak a timer).
+    drop(id);
+    const entry: PendingPayload = {
+      status,
+      payload,
+      timer: setTimeout(() => drop(id), PENDING_TTL_MS),
+    };
+    pending.set(id, entry);
+    publish(id, entry, 0);
+  }
+
+  const handler = (event: MessageEvent): void => {
+    const data = event.data as
+      | { type?: unknown; id?: unknown; req?: unknown; offset?: unknown }
+      | undefined;
+    if (!data || typeof data.id !== 'number') return;
+    if (data.type === SYNC_SAB_NEXT_MSG) {
+      const entry = pending.get(data.id);
+      const offset = (data as Partial<SyncSabNextMsg>).offset;
+      if (
+        !entry ||
+        typeof offset !== 'number' ||
+        !Number.isInteger(offset) ||
+        offset < 0 ||
+        offset > entry.payload.byteLength
+      ) {
+        // Unknown serial or a nonsense offset: answer with an errno so the
+        // realm fails closed instead of waiting out its budget.
+        settle(data.id, { ok: false, errno: 'EIO', message: 'sync-sab: bad continuation' });
+        return;
+      }
+      publish(data.id, entry, offset);
+      return;
+    }
+    if (data.type !== SYNC_SAB_REQ_MSG || !data.req || typeof data.req !== 'object') return;
+    const id = data.id;
+    // Bind the HOST's token — whatever the realm may have put in the body is
+    // discarded by the spread order below.
+    const body = (data as SyncSabReqMsg).req;
+    const req = { ...body, token } as SyncFsRequest | SyncExecRequest;
+    let dispatched: Promise<SyncFsResult>;
+    try {
+      dispatched = dispatch(req);
+    } catch (err) {
+      settle(id, {
+        ok: false,
+        errno: 'EIO',
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+    void dispatched.then(
+      (result) => settle(id, result),
+      (err) =>
+        settle(id, {
+          ok: false,
+          errno: 'EIO',
+          message: err instanceof Error ? err.message : String(err),
+        })
+    );
+  };
+
+  port.addEventListener('message', handler);
+  return {
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      port.removeEventListener('message', handler);
+      for (const id of [...pending.keys()]) drop(id);
+    },
+  };
+}

--- a/packages/webapp/src/kernel/realm/sync-sab-wire.ts
+++ b/packages/webapp/src/kernel/realm/sync-sab-wire.ts
@@ -1,0 +1,178 @@
+/**
+ * Wire contract for the Atomics/SharedArrayBuffer fast path of the synchronous
+ * bridges (fs + exec) — the isolated-leader alternative to the sync-XHR → SW →
+ * BroadcastChannel transport (#2043).
+ *
+ * Shape: one `SharedArrayBuffer` per realm, allocated by the kernel-side
+ * realm runner and handed to the realm in `RealmInitMsg.syncSab`. The realm
+ * posts a structured request on its existing control port, then blocks in
+ * `Atomics.wait` on the header's STATE word. The kernel-side responder
+ * dispatches through the very same `dispatchSyncFs` / `dispatchSyncExec` the SW
+ * path uses (same token, same ACL + sudo enforcement), writes the encoded
+ * result into the data window and `Atomics.notify`s. A result larger than the
+ * window is drained in rounds: every chunk is its own `sync-sab-next` post +
+ * wait, so the kernel never needs `Atomics.waitAsync` and is never blocked.
+ *
+ * Dependency-free on purpose (constants + pure encode/decode + types): the
+ * realm worker bundle and the kernel worker bundle both import it, and a
+ * renamed constant must fail at compile time on both ends rather than desync at
+ * runtime.
+ *
+ * Layout (little-endian Int32 header, then the byte window):
+ *
+ *   i32[STATE]   0 idle · 1 pending (realm waiting) · 2 ready (chunk written)
+ *   i32[SEQ]     request serial echoed by the responder — a stale wake-up
+ *                (a previous request's late chunk) is ignored by the realm
+ *   i32[STATUS]  result kind — see `SAB_STATUS_*`
+ *   i32[TOTAL]   total payload bytes for this request
+ *   i32[CHUNK]   bytes valid in the window for this round
+ *   i32[OFFSET]  payload offset this chunk starts at (echo of the request)
+ */
+
+import type { SyncExecRequest } from './sync-exec-dispatch.js';
+import type { SyncFsRequest, SyncFsResult } from './sync-fs-dispatch.js';
+
+/** Int32 slots reserved for the header (64 bytes). */
+export const SAB_HEADER_I32 = 16;
+export const SAB_HEADER_BYTES = SAB_HEADER_I32 * 4;
+
+export const SAB_I_STATE = 0;
+export const SAB_I_SEQ = 1;
+export const SAB_I_STATUS = 2;
+export const SAB_I_TOTAL = 3;
+export const SAB_I_CHUNK = 4;
+export const SAB_I_OFFSET = 5;
+
+export const SAB_STATE_IDLE = 0;
+export const SAB_STATE_PENDING = 1;
+export const SAB_STATE_READY = 2;
+
+export const SAB_STATUS_BYTES = 1;
+export const SAB_STATUS_JSON = 2;
+export const SAB_STATUS_VOID = 3;
+export const SAB_STATUS_ERRNO = 4;
+
+/**
+ * Default window: 1 MiB of payload per round. A `readFileSync` of a 10 MB file
+ * costs ten rounds (~10 postMessage hops) instead of a 10 MB allocation per
+ * realm. Large enough that the snapshot's old 1 MB/file cap is a single round.
+ */
+export const SAB_DEFAULT_WINDOW_BYTES = 1024 * 1024;
+/** Smallest useful buffer: header + one 4 KiB window. */
+export const SAB_MIN_BYTES = SAB_HEADER_BYTES + 4096;
+
+/** Realm → host: start a request. `id` is the realm's serial (also written to SEQ). */
+export const SYNC_SAB_REQ_MSG = 'sync-sab-req';
+/** Realm → host: the window was consumed, write the chunk at `offset`. */
+export const SYNC_SAB_NEXT_MSG = 'sync-sab-next';
+
+/**
+ * The request body, WITHOUT the capability token. The port is private to one
+ * realm, so the responder binds the host-minted token itself and never trusts
+ * a token the realm supplies — a realm cannot name another realm's scope.
+ */
+export type SyncSabRequestBody = Omit<SyncFsRequest, 'token'> | Omit<SyncExecRequest, 'token'>;
+
+export interface SyncSabReqMsg {
+  type: typeof SYNC_SAB_REQ_MSG;
+  id: number;
+  req: SyncSabRequestBody;
+}
+export interface SyncSabNextMsg {
+  type: typeof SYNC_SAB_NEXT_MSG;
+  id: number;
+  offset: number;
+}
+
+/** A result encoded for the window: a status word + flat payload bytes. */
+export interface SabEncodedResult {
+  status: number;
+  payload: Uint8Array;
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/** Flatten a dispatch result into `{ status, payload }` for the window. */
+export function encodeSabResult(result: SyncFsResult): SabEncodedResult {
+  if (!result.ok) {
+    return {
+      status: SAB_STATUS_ERRNO,
+      payload: encoder.encode(JSON.stringify({ errno: result.errno, message: result.message })),
+    };
+  }
+  switch (result.kind) {
+    case 'bytes':
+      return { status: SAB_STATUS_BYTES, payload: result.bytes };
+    case 'json':
+      return { status: SAB_STATUS_JSON, payload: encoder.encode(JSON.stringify(result.json)) };
+    default:
+      return { status: SAB_STATUS_VOID, payload: new Uint8Array(0) };
+  }
+}
+
+/**
+ * Inverse of {@link encodeSabResult}. A malformed payload (responder bug,
+ * torn write) decodes to an `EIO` errno result rather than throwing a bare
+ * `SyntaxError` — the realm shim relies on `.code` being present.
+ */
+export function decodeSabResult(status: number, payload: Uint8Array): SyncFsResult {
+  switch (status) {
+    case SAB_STATUS_BYTES:
+      return { ok: true, kind: 'bytes', bytes: payload };
+    case SAB_STATUS_VOID:
+      return { ok: true, kind: 'void' };
+    case SAB_STATUS_JSON: {
+      try {
+        return { ok: true, kind: 'json', json: JSON.parse(decoder.decode(payload)) };
+      } catch {
+        return { ok: false, errno: 'EIO', message: 'sync-sab: malformed json payload' };
+      }
+    }
+    case SAB_STATUS_ERRNO: {
+      try {
+        const parsed = JSON.parse(decoder.decode(payload)) as {
+          errno?: unknown;
+          message?: unknown;
+        };
+        const errno =
+          typeof parsed.errno === 'string' && /^E[A-Z]+$/.test(parsed.errno) ? parsed.errno : 'EIO';
+        return { ok: false, errno, message: String(parsed.message ?? errno) };
+      } catch {
+        return { ok: false, errno: 'EIO', message: 'sync-sab: malformed errno payload' };
+      }
+    }
+    default:
+      return { ok: false, errno: 'EIO', message: `sync-sab: unknown status ${status}` };
+  }
+}
+
+/** Typed views over one shared buffer; both ends build the same pair. */
+export interface SabViews {
+  header: Int32Array;
+  window: Uint8Array;
+}
+
+export function sabViews(sab: SharedArrayBuffer): SabViews {
+  if (sab.byteLength < SAB_MIN_BYTES) {
+    throw new Error(`sync-sab: buffer too small (${sab.byteLength} < ${SAB_MIN_BYTES})`);
+  }
+  return {
+    header: new Int32Array(sab, 0, SAB_HEADER_I32),
+    window: new Uint8Array(sab, SAB_HEADER_BYTES),
+  };
+}
+
+/**
+ * Is the Atomics/SAB fast path usable in THIS realm? True only where a
+ * `SharedArrayBuffer` can be constructed (cross-origin isolated document, or
+ * Node) — the realm side additionally requires a thread that may block (a
+ * `DedicatedWorker`), which the runner decides per realm (`Realm.isolatedThread`).
+ */
+export function isSyncSabSupported(): boolean {
+  if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined') return false;
+  // In a browser, SAB is only constructible under cross-origin isolation; in
+  // Node it is always available. `crossOriginIsolated` is undefined in Node.
+  const coi = (globalThis as { crossOriginIsolated?: boolean }).crossOriginIsolated;
+  return coi === undefined || coi === true;
+}

--- a/packages/webapp/tests/kernel/realm/sync-sab-bridge.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-sab-bridge.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Realm-side Atomics/SAB transport (#2043).
+ *
+ * `Atomics.wait` cannot be serviced from the same thread that blocks on it, so
+ * the "kernel" here is a fake port whose `postMessage` answers SYNCHRONOUSLY
+ * into the shared window before the realm reaches `Atomics.wait` — which then
+ * returns `not-equal` and the transport takes the exact post-wake path it would
+ * after a genuine cross-thread notify. The cross-thread shape is covered by
+ * `sync-sab-responder.test.ts` (the writer) + the Tier-1 browser harness.
+ */
+import { describe, expect, it } from 'vitest';
+import { createSyncExecXhrBridge } from '../../../src/kernel/realm/sync-exec-xhr-bridge.js';
+import type { SyncFsResult } from '../../../src/kernel/realm/sync-fs-dispatch.js';
+import {
+  createSyncExecSabTransport,
+  createSyncFsSabBridge,
+  createSyncSabTransport,
+} from '../../../src/kernel/realm/sync-sab-bridge.js';
+import {
+  encodeSabResult,
+  SAB_HEADER_BYTES,
+  SAB_I_CHUNK,
+  SAB_I_OFFSET,
+  SAB_I_SEQ,
+  SAB_I_STATE,
+  SAB_I_STATUS,
+  SAB_I_TOTAL,
+  SAB_STATE_IDLE,
+  SAB_STATE_READY,
+  SYNC_SAB_NEXT_MSG,
+  SYNC_SAB_REQ_MSG,
+  type SyncSabNextMsg,
+  type SyncSabReqMsg,
+  sabViews,
+} from '../../../src/kernel/realm/sync-sab-wire.js';
+
+const WINDOW = 4096;
+
+/** `op` of an fs request body (the exec body has none). */
+function opOf(req: unknown): string | undefined {
+  return (req as { op?: string }).op;
+}
+
+/** A fake kernel: answers each request from `answer`, chunked to the window. */
+function fakeKernel(sab: SharedArrayBuffer, answer: (req: SyncSabReqMsg['req']) => SyncFsResult) {
+  const { header, window } = sabViews(sab);
+  const sent: Array<SyncSabReqMsg | SyncSabNextMsg> = [];
+  const pending = new Map<number, { status: number; payload: Uint8Array }>();
+  const publish = (id: number, offset: number) => {
+    const entry = pending.get(id)!;
+    const chunk = Math.min(window.byteLength, entry.payload.byteLength - offset);
+    window.set(entry.payload.subarray(offset, offset + chunk));
+    Atomics.store(header, SAB_I_STATUS, entry.status);
+    Atomics.store(header, SAB_I_TOTAL, entry.payload.byteLength);
+    Atomics.store(header, SAB_I_CHUNK, chunk);
+    Atomics.store(header, SAB_I_OFFSET, offset);
+    Atomics.store(header, SAB_I_SEQ, id);
+    Atomics.store(header, SAB_I_STATE, SAB_STATE_READY);
+  };
+  const port = {
+    postMessage(msg: unknown) {
+      const m = msg as SyncSabReqMsg | SyncSabNextMsg;
+      sent.push(m);
+      if (m.type === SYNC_SAB_REQ_MSG) {
+        pending.set(m.id, encodeSabResult(answer(m.req)));
+        publish(m.id, 0);
+      } else if (m.type === SYNC_SAB_NEXT_MSG) {
+        publish(m.id, m.offset);
+      }
+    },
+  };
+  return { port, sent, header };
+}
+
+describe('createSyncSabTransport', () => {
+  it('delivers a single-round result and resets STATE to idle', () => {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const k = fakeKernel(sab, () => ({ ok: true, kind: 'json', json: { hello: 'world' } }));
+    const t = createSyncSabTransport(sab, k.port);
+    expect(t.call({ op: 'stat', path: '/x' }, 1000, 'l')).toEqual({
+      ok: true,
+      kind: 'json',
+      json: { hello: 'world' },
+    });
+    expect(Atomics.load(k.header, SAB_I_STATE)).toBe(SAB_STATE_IDLE);
+    expect(k.sent).toEqual([{ type: SYNC_SAB_REQ_MSG, id: 1, req: { op: 'stat', path: '/x' } }]);
+  });
+
+  it('drains a payload larger than the window over multiple rounds, byte-exact', () => {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const big = new Uint8Array(WINDOW * 3 + 17);
+    for (let i = 0; i < big.length; i++) big[i] = (i * 7) & 0xff;
+    const k = fakeKernel(sab, () => ({ ok: true, kind: 'bytes', bytes: big }));
+    const t = createSyncSabTransport(sab, k.port);
+    const res = t.call({ op: 'read', path: '/big' }, 1000, 'l');
+    expect(res.ok && res.kind === 'bytes' && res.bytes).toBeTruthy();
+    if (res.ok && res.kind === 'bytes') {
+      expect(res.bytes.byteLength).toBe(big.byteLength);
+      expect(Buffer.from(res.bytes).equals(Buffer.from(big))).toBe(true);
+    }
+    // 1 req + 3 continuations (4096·3 + 17 bytes → 4 rounds).
+    expect(k.sent.map((m) => m.type)).toEqual([
+      SYNC_SAB_REQ_MSG,
+      SYNC_SAB_NEXT_MSG,
+      SYNC_SAB_NEXT_MSG,
+      SYNC_SAB_NEXT_MSG,
+    ]);
+    expect((k.sent[1] as SyncSabNextMsg).offset).toBe(WINDOW);
+    expect((k.sent[3] as SyncSabNextMsg).offset).toBe(WINDOW * 3);
+  });
+
+  it('increments the serial per call and rejects a chunk for the wrong offset', () => {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const k = fakeKernel(sab, () => ({ ok: true, kind: 'void' }));
+    const t = createSyncSabTransport(sab, k.port);
+    t.call({ op: 'mkdir', path: '/a' }, 1000, 'l');
+    t.call({ op: 'mkdir', path: '/b' }, 1000, 'l');
+    expect(k.sent.map((m) => m.id)).toEqual([1, 2]);
+
+    // Torn header: the kernel claims an offset the realm did not ask for.
+    const torn = {
+      ...k.port,
+      postMessage: (m: unknown) => {
+        k.port.postMessage(m);
+        Atomics.store(k.header, SAB_I_OFFSET, 99);
+      },
+    };
+    const t2 = createSyncSabTransport(sab, torn);
+    expect(() => t2.call({ op: 'exists', path: '/x' }, 1000, 'l')).toThrow(
+      expect.objectContaining({ code: 'EIO' })
+    );
+    expect(Atomics.load(k.header, SAB_I_STATE)).toBe(SAB_STATE_IDLE);
+  });
+
+  it('times out as ETIMEDOUT when nobody answers (no hang)', () => {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const silent = { postMessage: () => {} };
+    let clock = 0;
+    const t = createSyncSabTransport(sab, silent, {
+      // Simulated clock + wait: each wait "sleeps" the full remaining budget.
+      now: () => clock,
+      wait: (_a, _i, _v, timeout) => {
+        clock += timeout ?? 0;
+        return 'timed-out';
+      },
+    });
+    expect(() => t.call({ op: 'read', path: '/never' }, 50, 'sync-sab bridge')).toThrow(
+      expect.objectContaining({ code: 'ETIMEDOUT' })
+    );
+  });
+
+  it('ignores a stale wake-up carrying a previous serial and keeps waiting', () => {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const { header, window } = sabViews(sab);
+    let calls = 0;
+    const port = {
+      postMessage(msg: unknown) {
+        const m = msg as SyncSabReqMsg;
+        // First: a late chunk for serial 0 (never ours). The transport must
+        // re-arm; our fake `wait` then supplies the real answer for `m.id`.
+        Atomics.store(header, SAB_I_SEQ, 0);
+        Atomics.store(header, SAB_I_STATE, SAB_STATE_READY);
+        pendingId = m.id;
+      },
+    };
+    let pendingId = -1;
+    const t = createSyncSabTransport(sab, port, {
+      wait: () => {
+        calls++;
+        if (calls === 2) {
+          const enc = encodeSabResult({ ok: true, kind: 'json', json: true });
+          window.set(enc.payload);
+          Atomics.store(header, SAB_I_STATUS, enc.status);
+          Atomics.store(header, SAB_I_TOTAL, enc.payload.byteLength);
+          Atomics.store(header, SAB_I_CHUNK, enc.payload.byteLength);
+          Atomics.store(header, SAB_I_OFFSET, 0);
+          Atomics.store(header, SAB_I_SEQ, pendingId);
+          Atomics.store(header, SAB_I_STATE, SAB_STATE_READY);
+        }
+        return 'not-equal';
+      },
+    });
+    expect(t.call({ op: 'exists', path: '/x' }, 1000, 'l')).toEqual({
+      ok: true,
+      kind: 'json',
+      json: true,
+    });
+    expect(calls).toBe(2);
+  });
+});
+
+describe('createSyncFsSabBridge — fs surface parity with the XHR bridge', () => {
+  function bridgeWith(answer: (req: SyncSabReqMsg['req']) => SyncFsResult) {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const k = fakeKernel(sab, answer);
+    return { bridge: createSyncFsSabBridge(createSyncSabTransport(sab, k.port)), k };
+  }
+
+  it('maps every op onto the dispatch request shape', () => {
+    const { bridge, k } = bridgeWith((req) => {
+      switch (opOf(req)) {
+        case 'read':
+          return { ok: true, kind: 'bytes', bytes: new TextEncoder().encode('hi') };
+        case 'stat':
+        case 'lstat':
+          return { ok: true, kind: 'json', json: { isFile: true, isDirectory: false, size: 2 } };
+        case 'readdir':
+          return { ok: true, kind: 'json', json: ['a', 'b'] };
+        case 'exists':
+          return { ok: true, kind: 'json', json: false };
+        default:
+          return { ok: true, kind: 'void' };
+      }
+    });
+    expect(new TextDecoder().decode(bridge.readFile('/f'))).toBe('hi');
+    bridge.writeFile('/f', new Uint8Array([1]));
+    expect(bridge.stat('/f')).toEqual({ isFile: true, isDirectory: false, size: 2 });
+    expect(bridge.lstat('/f').size).toBe(2);
+    expect(bridge.readdir('/d')).toEqual(['a', 'b']);
+    expect(bridge.exists('/nope')).toBe(false);
+    bridge.mkdir('/d');
+    bridge.rm('/d');
+    expect(k.sent.map((m) => opOf((m as SyncSabReqMsg).req))).toEqual([
+      'read',
+      'write',
+      'stat',
+      'lstat',
+      'readdir',
+      'exists',
+      'mkdir',
+      'rm',
+    ]);
+    expect((k.sent[1] as SyncSabReqMsg).req).toMatchObject({ body: new Uint8Array([1]) });
+    // Never a token in the body — the responder binds the host's.
+    for (const m of k.sent) expect('token' in (m as SyncSabReqMsg).req).toBe(false);
+  });
+
+  it('rethrows a dispatch errno with its code, and EIO on a malformed payload', () => {
+    const { bridge } = bridgeWith((req) =>
+      opOf(req) === 'read'
+        ? { ok: false, errno: 'EACCES', message: 'nope' }
+        : { ok: true, kind: 'json', json: { not: 'a stat' } }
+    );
+    expect(() => bridge.readFile('/secret')).toThrow(expect.objectContaining({ code: 'EACCES' }));
+    expect(() => bridge.stat('/x')).toThrow(expect.objectContaining({ code: 'EIO' }));
+  });
+});
+
+describe('createSyncExecSabTransport — plugs into createSyncExecXhrBridge', () => {
+  it('runs a command through the SAB channel with the exec envelope', () => {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const k = fakeKernel(sab, (req) => {
+      expect(req).toMatchObject({ channel: 'exec', command: 'echo hi', timeoutMs: 5000 });
+      return { ok: true, kind: 'json', json: { stdout: 'hi\n', stderr: '', exitCode: 0 } };
+    });
+    const transport = createSyncSabTransport(sab, k.port);
+    const exec = createSyncExecXhrBridge('unused-token', {
+      transport: createSyncExecSabTransport(transport),
+    });
+    expect(exec.run('echo hi', { timeout: 5000 })).toEqual({
+      stdout: 'hi\n',
+      stderr: '',
+      exitCode: 0,
+    });
+  });
+
+  it('surfaces ETIMEDOUT from the dispatcher as an errno error', () => {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const k = fakeKernel(sab, () => ({ ok: false, errno: 'ETIMEDOUT', message: 'slow' }));
+    const exec = createSyncExecXhrBridge('t', {
+      transport: createSyncExecSabTransport(createSyncSabTransport(sab, k.port)),
+    });
+    expect(() => exec.run('sleep 99')).toThrow(expect.objectContaining({ code: 'ETIMEDOUT' }));
+  });
+});

--- a/packages/webapp/tests/kernel/realm/sync-sab-bridge.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-sab-bridge.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, it } from 'vitest';
 import { createSyncExecXhrBridge } from '../../../src/kernel/realm/sync-exec-xhr-bridge.js';
 import type { SyncFsResult } from '../../../src/kernel/realm/sync-fs-dispatch.js';
+import { SYNC_EXEC_XHR_MARGIN_MS } from '../../../src/kernel/realm/sync-fs-wire.js';
 import {
   createSyncExecSabTransport,
   createSyncFsSabBridge,
@@ -262,6 +263,26 @@ describe('createSyncExecSabTransport — plugs into createSyncExecXhrBridge', ()
       stderr: '',
       exitCode: 0,
     });
+  });
+
+  it('waits a margin past the command budget so a just-in-time success wins', () => {
+    // Parity with the SW transport's SYNC_EXEC_XHR_MARGIN_MS: the kernel aborts
+    // at the budget and encodes/publishes afterwards, so the realm's deadline
+    // must sit past the budget, never on it.
+    const seen: number[] = [];
+    const transport = {
+      call: (_req: unknown, timeoutMs: number) => {
+        seen.push(timeoutMs);
+        return {
+          ok: true as const,
+          kind: 'json' as const,
+          json: { stdout: '', stderr: '', exitCode: 0 },
+        };
+      },
+    };
+    const exec = createSyncExecXhrBridge('t', { transport: createSyncExecSabTransport(transport) });
+    exec.run('true', { timeout: 5000 });
+    expect(seen).toEqual([5000 + SYNC_EXEC_XHR_MARGIN_MS]);
   });
 
   it('surfaces ETIMEDOUT from the dispatcher as an errno error', () => {

--- a/packages/webapp/tests/kernel/realm/sync-sab-responder.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-sab-responder.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Kernel-side Atomics/SAB responder (#2043). Drives it through a fake realm
+ * port and inspects the shared window after each round — no `Atomics.wait`
+ * here (the writer never blocks), so everything is plain async.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { SyncExecRequest } from '../../../src/kernel/realm/sync-exec-dispatch.js';
+import type { SyncFsRequest, SyncFsResult } from '../../../src/kernel/realm/sync-fs-dispatch.js';
+import {
+  mintSyncFsToken,
+  revokeSyncFsToken,
+} from '../../../src/kernel/realm/sync-fs-token-registry.js';
+import { attachSyncSabResponder } from '../../../src/kernel/realm/sync-sab-responder.js';
+import {
+  decodeSabResult,
+  SAB_HEADER_BYTES,
+  SAB_I_CHUNK,
+  SAB_I_OFFSET,
+  SAB_I_SEQ,
+  SAB_I_STATE,
+  SAB_I_STATUS,
+  SAB_I_TOTAL,
+  SAB_STATE_PENDING,
+  SAB_STATE_READY,
+  SYNC_SAB_NEXT_MSG,
+  SYNC_SAB_REQ_MSG,
+  sabViews,
+} from '../../../src/kernel/realm/sync-sab-wire.js';
+
+const WINDOW = 4096;
+
+function fakePort() {
+  const listeners = new Set<(ev: MessageEvent) => void>();
+  return {
+    addEventListener: (_t: 'message', h: (ev: MessageEvent) => void) => listeners.add(h),
+    removeEventListener: (_t: 'message', h: (ev: MessageEvent) => void) => listeners.delete(h),
+    /** Realm → host. */
+    emit(data: unknown) {
+      for (const h of [...listeners]) h({ data } as MessageEvent);
+    },
+    get listenerCount() {
+      return listeners.size;
+    },
+  };
+}
+
+/** Wait until the responder flips STATE to READY (it runs an async dispatch). */
+async function untilReady(header: Int32Array): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    if (Atomics.load(header, SAB_I_STATE) === SAB_STATE_READY) return;
+    await new Promise((r) => setTimeout(r, 1));
+  }
+  throw new Error('responder never published');
+}
+
+function readWindow(sab: SharedArrayBuffer) {
+  const { header, window } = sabViews(sab);
+  const chunk = Atomics.load(header, SAB_I_CHUNK);
+  return {
+    seq: Atomics.load(header, SAB_I_SEQ),
+    status: Atomics.load(header, SAB_I_STATUS),
+    total: Atomics.load(header, SAB_I_TOTAL),
+    chunk,
+    offset: Atomics.load(header, SAB_I_OFFSET),
+    bytes: window.slice(0, chunk),
+  };
+}
+
+describe('attachSyncSabResponder', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('binds the HOST token, dispatches, and publishes the encoded result', async () => {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const { header } = sabViews(sab);
+    const port = fakePort();
+    const seen: Array<SyncFsRequest | SyncExecRequest> = [];
+    const handle = attachSyncSabResponder(port, sab, 'host-token', {
+      dispatch: async (req) => {
+        seen.push(req);
+        return { ok: true, kind: 'json', json: { isFile: true, isDirectory: false, size: 3 } };
+      },
+    });
+    Atomics.store(header, SAB_I_STATE, SAB_STATE_PENDING);
+    // The realm tries to smuggle a token: it must be overwritten by the host's.
+    port.emit({ type: SYNC_SAB_REQ_MSG, id: 7, req: { op: 'stat', path: '/f', token: 'forged' } });
+    await untilReady(header);
+    expect(seen).toEqual([{ op: 'stat', path: '/f', token: 'host-token' }]);
+    const w = readWindow(sab);
+    expect(w.seq).toBe(7);
+    expect(w.offset).toBe(0);
+    expect(w.chunk).toBe(w.total);
+    expect(decodeSabResult(w.status, w.bytes)).toEqual({
+      ok: true,
+      kind: 'json',
+      json: { isFile: true, isDirectory: false, size: 3 },
+    });
+    handle.dispose();
+    expect(port.listenerCount).toBe(0);
+  });
+
+  it('streams a payload larger than the window across sync-sab-next rounds', async () => {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const { header } = sabViews(sab);
+    const port = fakePort();
+    const big = new Uint8Array(WINDOW * 2 + 5).map((_, i) => i & 0xff);
+    attachSyncSabResponder(port, sab, 't', {
+      dispatch: async () => ({ ok: true, kind: 'bytes', bytes: big }),
+    });
+    Atomics.store(header, SAB_I_STATE, SAB_STATE_PENDING);
+    port.emit({ type: SYNC_SAB_REQ_MSG, id: 1, req: { op: 'read', path: '/big' } });
+    await untilReady(header);
+    const out = new Uint8Array(big.byteLength);
+    let w = readWindow(sab);
+    expect(w.total).toBe(big.byteLength);
+    expect(w.chunk).toBe(WINDOW);
+    out.set(w.bytes, 0);
+    for (const offset of [WINDOW, WINDOW * 2]) {
+      Atomics.store(header, SAB_I_STATE, SAB_STATE_PENDING);
+      port.emit({ type: SYNC_SAB_NEXT_MSG, id: 1, offset });
+      // Continuations are synchronous (no dispatch) — READY immediately.
+      w = readWindow(sab);
+      expect(Atomics.load(header, SAB_I_STATE)).toBe(SAB_STATE_READY);
+      expect(w.offset).toBe(offset);
+      out.set(w.bytes, offset);
+    }
+    expect(w.chunk).toBe(5);
+    expect(Buffer.from(out).equals(Buffer.from(big))).toBe(true);
+
+    // Fully drained → a further continuation is unknown → EIO, not a hang.
+    Atomics.store(header, SAB_I_STATE, SAB_STATE_PENDING);
+    port.emit({ type: SYNC_SAB_NEXT_MSG, id: 1, offset: 0 });
+    w = readWindow(sab);
+    expect(decodeSabResult(w.status, w.bytes)).toMatchObject({ ok: false, errno: 'EIO' });
+  });
+
+  it('turns a throwing or rejecting dispatcher into an EIO result', async () => {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const { header } = sabViews(sab);
+    const port = fakePort();
+    let mode: 'throw' | 'reject' = 'throw';
+    attachSyncSabResponder(port, sab, 't', {
+      dispatch: (): Promise<SyncFsResult> => {
+        if (mode === 'throw') throw new Error('sync boom');
+        return Promise.reject(new Error('async boom'));
+      },
+    });
+    Atomics.store(header, SAB_I_STATE, SAB_STATE_PENDING);
+    port.emit({ type: SYNC_SAB_REQ_MSG, id: 1, req: { op: 'read', path: '/x' } });
+    await untilReady(header);
+    let w = readWindow(sab);
+    expect(decodeSabResult(w.status, w.bytes)).toEqual({
+      ok: false,
+      errno: 'EIO',
+      message: 'sync boom',
+    });
+    mode = 'reject';
+    Atomics.store(header, SAB_I_STATE, SAB_STATE_PENDING);
+    port.emit({ type: SYNC_SAB_REQ_MSG, id: 2, req: { op: 'read', path: '/x' } });
+    await untilReady(header);
+    w = readWindow(sab);
+    expect(w.seq).toBe(2);
+    expect(decodeSabResult(w.status, w.bytes)).toMatchObject({
+      errno: 'EIO',
+      message: 'async boom',
+    });
+  });
+
+  it('ignores unrelated port traffic and malformed envelopes', async () => {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const { header } = sabViews(sab);
+    const port = fakePort();
+    const dispatch = vi.fn(async (): Promise<SyncFsResult> => ({ ok: true, kind: 'void' }));
+    attachSyncSabResponder(port, sab, 't', { dispatch });
+    port.emit({ type: 'realm-rpc-req', id: 1, channel: 'vfs', op: 'readFile', args: [] });
+    port.emit({ type: SYNC_SAB_REQ_MSG, id: 'nope', req: { op: 'read', path: '/x' } });
+    port.emit({ type: SYNC_SAB_REQ_MSG, id: 3 });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(Atomics.load(header, SAB_I_STATE)).not.toBe(SAB_STATE_READY);
+  });
+
+  it('end-to-end through the real token-scoped dispatcher (ACL via the realm fs)', async () => {
+    const sab = new SharedArrayBuffer(SAB_HEADER_BYTES + WINDOW);
+    const { header } = sabViews(sab);
+    const port = fakePort();
+    const files = new Map<string, Uint8Array>([
+      ['/workspace/a.txt', new TextEncoder().encode('alpha')],
+    ]);
+    const fs = {
+      resolvePath: (cwd: string, p: string) => (p.startsWith('/') ? p : `${cwd}/${p}`),
+      readFileBuffer: async (p: string) => {
+        const v = files.get(p);
+        if (!v) throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' });
+        return v;
+      },
+      writeFile: async (p: string, b: Uint8Array) => {
+        files.set(p, b);
+      },
+      exists: async (p: string) => files.has(p),
+    };
+    const token = mintSyncFsToken({ fs: fs as never, cwd: '/workspace' });
+    const handle = attachSyncSabResponder(port, sab, token);
+
+    Atomics.store(header, SAB_I_STATE, SAB_STATE_PENDING);
+    port.emit({ type: SYNC_SAB_REQ_MSG, id: 1, req: { op: 'read', path: 'a.txt' } });
+    await untilReady(header);
+    let w = readWindow(sab);
+    expect(decodeSabResult(w.status, w.bytes)).toEqual({
+      ok: true,
+      kind: 'bytes',
+      bytes: new TextEncoder().encode('alpha'),
+    });
+
+    Atomics.store(header, SAB_I_STATE, SAB_STATE_PENDING);
+    port.emit({ type: SYNC_SAB_REQ_MSG, id: 2, req: { op: 'read', path: '/workspace/missing' } });
+    await untilReady(header);
+    w = readWindow(sab);
+    expect(decodeSabResult(w.status, w.bytes)).toMatchObject({ ok: false, errno: 'ENOENT' });
+
+    // Revoked token → EACCES, never the ambient VFS.
+    revokeSyncFsToken(token);
+    Atomics.store(header, SAB_I_STATE, SAB_STATE_PENDING);
+    port.emit({ type: SYNC_SAB_REQ_MSG, id: 3, req: { op: 'read', path: 'a.txt' } });
+    await untilReady(header);
+    w = readWindow(sab);
+    expect(decodeSabResult(w.status, w.bytes)).toMatchObject({ ok: false, errno: 'EACCES' });
+    handle.dispose();
+  });
+});

--- a/packages/webapp/tests/kernel/realm/sync-sab-wire.test.ts
+++ b/packages/webapp/tests/kernel/realm/sync-sab-wire.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decodeSabResult,
+  encodeSabResult,
+  SAB_HEADER_BYTES,
+  SAB_MIN_BYTES,
+  SAB_STATUS_BYTES,
+  SAB_STATUS_ERRNO,
+  SAB_STATUS_JSON,
+  SAB_STATUS_VOID,
+  sabViews,
+} from '../../../src/kernel/realm/sync-sab-wire.js';
+
+describe('sync-sab wire — encode/decode', () => {
+  it('round-trips every result kind', () => {
+    const bytes = new Uint8Array([1, 2, 3, 250]);
+    expect(decodeSabResult(...spread(encodeSabResult({ ok: true, kind: 'bytes', bytes })))).toEqual(
+      {
+        ok: true,
+        kind: 'bytes',
+        bytes,
+      }
+    );
+    expect(encodeSabResult({ ok: true, kind: 'bytes', bytes }).status).toBe(SAB_STATUS_BYTES);
+
+    const json = { isFile: true, isDirectory: false, size: 7, names: ['a', 'ü'] };
+    const enc = encodeSabResult({ ok: true, kind: 'json', json });
+    expect(enc.status).toBe(SAB_STATUS_JSON);
+    expect(decodeSabResult(...spread(enc))).toEqual({ ok: true, kind: 'json', json });
+
+    const v = encodeSabResult({ ok: true, kind: 'void' });
+    expect(v.status).toBe(SAB_STATUS_VOID);
+    expect(v.payload.byteLength).toBe(0);
+    expect(decodeSabResult(...spread(v))).toEqual({ ok: true, kind: 'void' });
+
+    const e = encodeSabResult({ ok: false, errno: 'EACCES', message: 'denied' });
+    expect(e.status).toBe(SAB_STATUS_ERRNO);
+    expect(decodeSabResult(...spread(e))).toEqual({
+      ok: false,
+      errno: 'EACCES',
+      message: 'denied',
+    });
+  });
+
+  it('fails closed on malformed payloads and unknown statuses', () => {
+    const junk = new TextEncoder().encode('{not json');
+    expect(decodeSabResult(SAB_STATUS_JSON, junk)).toMatchObject({ ok: false, errno: 'EIO' });
+    expect(decodeSabResult(SAB_STATUS_ERRNO, junk)).toMatchObject({ ok: false, errno: 'EIO' });
+    // A non-errno-shaped code must not cross into the realm as `.code`.
+    const bad = new TextEncoder().encode(JSON.stringify({ errno: 'boom!', message: 'x' }));
+    expect(decodeSabResult(SAB_STATUS_ERRNO, bad)).toMatchObject({ ok: false, errno: 'EIO' });
+    expect(decodeSabResult(99, new Uint8Array(0))).toMatchObject({ ok: false, errno: 'EIO' });
+  });
+
+  it('views split the buffer into a 64-byte header and the window', () => {
+    const sab = new SharedArrayBuffer(SAB_MIN_BYTES);
+    const { header, window } = sabViews(sab);
+    expect(header.byteLength).toBe(SAB_HEADER_BYTES);
+    expect(window.byteOffset).toBe(SAB_HEADER_BYTES);
+    expect(window.byteLength).toBe(SAB_MIN_BYTES - SAB_HEADER_BYTES);
+    expect(() => sabViews(new SharedArrayBuffer(16))).toThrow(/too small/);
+  });
+});
+
+function spread(enc: { status: number; payload: Uint8Array }): [number, Uint8Array] {
+  return [enc.status, enc.payload];
+}


### PR DESCRIPTION
Part of #2043 (first slice: the transport)

## Summary

On a cross-origin-isolated leader, a realm that owns its thread no longer takes the sync-XHR → Service Worker → BroadcastChannel round-trip for `readFileSync` / `writeFileSync` / `execSync` / `spawnSync`. The kernel hands each `DedicatedWorker` realm a `SharedArrayBuffer`; the realm posts the structured request on its existing control port and parks in `Atomics.wait`; the kernel-side responder answers into the shared window and notifies. The SW path stays the universal baseline for embedded leaders.

**Draft** until verified live in the Tier-1 harness (see test plan).

## Why

The #1519 design demoted the SAB bridge to a future lever because isolation was untenable. With Document-Isolation-Policy (#2039) it is per-document and cheap. This slice retires, on isolated leaders: the per-call sync-XHR + SW round-trip, the SW-confirmation boot gate as a precondition for the sync bridge, and any user-visible `ENOSYNC` (every over-cap or post-snapshot read falls through to a live, chunked read).

## Approach / Implementation notes

- **Same dispatchers, different transport.** Realm side (`sync-sab-bridge.ts`) implements the same `SyncFsXhrMutatingBridge` surface + errno contract as the SW bridge, so the `fs` shim is transport-blind; exec plugs in as a `SyncExecTransport` on `createSyncExecXhrBridge` (small seam added), so flush-before / invalidate-after cache coherence is unchanged. Kernel side (`sync-sab-responder.ts`, attached by `attachRealmHost` to the realm's port) runs the op through the token-scoped `dispatchSyncFs` / `dispatchSyncExec` — identical ACL, sudo, errno.
- **Security:** the body carries no token. The port is private to one realm, so the responder binds the host-minted token itself; a realm cannot address another realm's scope.
- **No `Atomics.waitAsync`, kernel never blocks:** results larger than the 1 MiB window stream in rounds (`sync-sab-next`), one post per chunk.
- **Gating:** `Realm.isolatedThread` (set only by the real worker factory) + `isSyncSabSupported()`. The in-process factory never gets a SAB (it would deadlock against its own responder). SAB presence is enough to mint the token — the SW-confirmation gate is not required on this path.
- Layout/encode/decode live in the dependency-free `sync-sab-wire.ts` (64-byte Int32 header: STATE/SEQ/STATUS/TOTAL/CHUNK/OFFSET). Stale wake-ups (old serial) are ignored; every fault is an errno error (`ETIMEDOUT` / `EIO`), never a hang.
- Out of scope for this slice (follow-ups on #2043): shrinking/dropping the boot snapshot caps on isolated leaders; the Python realm.

## Test plan

- [x] `sync-sab-wire`, `sync-sab-bridge` (chunking, serial, timeout, torn header, fs parity, exec transport), `sync-sab-responder` (host-token binding, streaming, failure paths, end-to-end through the real token registry). `Atomics.wait` cannot be serviced from the blocking thread, so the realm-side tests use a fake kernel that answers synchronously (the `not-equal` path); the responder tests cover the writer.
- [x] All `tests/kernel/**` (1,410 tests), full webapp suite, typecheck, biome, root lint chain, `lint:docs`, debt gate, production webapp build
- [ ] **Live (before un-drafting):** Tier-1 harness on the hosted leader — `node -e` doing `readFileSync` of a >10 MB file and >500 files, `writeFileSync` + read-back, `execSync('ls')`, a sudo-gated write, and SIGKILL of a realm blocked in `execSync`; confirm no `/__slicc/fs-sync` traffic in the SW; confirm Cherry/extension side panel still take the SW path.

Docs: `docs/kernel/process-model.md` (new section), `packages/webapp/CLAUDE.md` never-rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)