### PR TITLE
fix(speech): close the asset-staging races behind warmup failures

### DIFF
--- a/docs/webapp-details.md
+++ b/docs/webapp-details.md
@@ -31,6 +31,7 @@ Overflow from `packages/webapp/CLAUDE.md`. Each section is the deep reference fo
 
 - Path: `packages/webapp/src/speech/`; entry `supplemental-commands/hear-command.ts`. **Page realm only** (mic, AudioContext); kernel worker bridges via `hear-*` panel-RPC.
 - Web Speech API (immediate) hot-swapped to on-device Whisper (`onnx-community/whisper-tiny`); Kokoro TTS (`Kokoro-82M-v1.0-ONNX`) chains off the whisper load. Kokoro selects on English + on-device readiness; Web Speech is fallback.
+- Asset staging (`ensure-speech-assets.ts` via `kernel/speech-assets-bridge.ts`) is **single-flight**: the worker responder coalesces concurrent page requests (`hear --warmup`, `say --warmup`, the composer warmup) onto one run and fans progress/result out to every caller — never run two stagers over the same tree. `hf download` skips a present file only at the **listed byte length** (a torn write is re-fetched), and the ort install is gated on the required jsep + plain threaded builds only — optional `asyncify`/`jspi` variants missing must not trigger a `dist/` rewrite under a loading engine.
 - **Extension `uiOnly` side panel**: Chrome denies `getUserMedia` (mic prompt keys on extension origin, ungrantable from cross-origin iframe), so `wc-follower.ts` skips `ptt` and drops "Take a photo". Voice/camera live in the leader tab or detached popout.
 
 ## MCP Servers

--- a/packages/webapp/src/kernel/speech-assets-bridge.ts
+++ b/packages/webapp/src/kernel/speech-assets-bridge.ts
@@ -61,10 +61,24 @@ function newRequestId(): string {
 export type EnsureSpeechAssetsRunner = (onProgress: SpeechAssetProgressFn) => Promise<unknown>;
 
 /**
- * Install the worker-side responder. Each incoming request runs `ensure`,
- * forwarding every progress event back on the channel, then posts a final
- * response (empty on success, `error` on failure). Returns a disposer. No-op
- * when `BroadcastChannel` is unavailable (older test runners).
+ * Install the worker-side responder. Incoming requests are **coalesced onto a
+ * single in-flight `ensure` run**: the first request starts it, any request
+ * arriving while it runs subscribes to the same run, every progress event
+ * fans out to all subscribers (each under its own request id), and the final
+ * response (empty on success, `error` on failure) is posted to each. A request
+ * arriving after the run settled starts a fresh one (already-staged assets
+ * make that a fast no-op).
+ *
+ * Why coalesce: `hear --warmup`, `say --warmup` and the composer's push-to-talk
+ * warmup are independent page-side callers that all stage the SAME files. Run
+ * concurrently, two `hf download`s of one repo overlap — the second sees the
+ * first's half-written file, "skips" it, reports staging complete, and its
+ * caller's engine load runs against a tree the first run is still writing
+ * (`weights … are missing` / size-mismatch EIO). One run, awaited by every
+ * caller, is what makes "staged" mean staged.
+ *
+ * Returns a disposer. No-op when `BroadcastChannel` is unavailable (older test
+ * runners).
  */
 export function installSpeechAssetsResponder(options: {
   instanceId?: string;
@@ -84,20 +98,45 @@ export function installSpeechAssetsResponder(options: {
     }
   };
 
-  const listener = async (event: MessageEvent): Promise<void> => {
+  /** Request ids waiting on the current run; `null` when nothing is running. */
+  let inflight: Set<string> | null = null;
+
+  const settleAll = (error?: string): void => {
+    const ids = inflight ?? new Set<string>();
+    inflight = null;
+    for (const id of ids) {
+      post(
+        error === undefined
+          ? { type: 'speech-assets-response', id }
+          : { type: 'speech-assets-response', id, error }
+      );
+    }
+  };
+
+  const listener = (event: MessageEvent): void => {
     const msg = event.data as RequestMsg | undefined;
     if (msg?.type !== 'speech-assets-request') return;
     const { id } = msg;
-    try {
-      await options.ensure((progress) => post({ type: 'speech-assets-progress', id, progress }));
-      post({ type: 'speech-assets-response', id });
-    } catch (err) {
-      post({
-        type: 'speech-assets-response',
-        id,
-        error: err instanceof Error ? err.message : String(err),
-      });
+    if (inflight) {
+      // Join the run already in progress — never start a parallel stager.
+      inflight.add(id);
+      return;
     }
+    const subscribers = new Set<string>([id]);
+    inflight = subscribers;
+    let run: Promise<unknown>;
+    try {
+      run = options.ensure((progress) => {
+        for (const sid of subscribers) post({ type: 'speech-assets-progress', id: sid, progress });
+      });
+    } catch (err) {
+      settleAll(err instanceof Error ? err.message : String(err));
+      return;
+    }
+    void run.then(
+      () => settleAll(),
+      (err) => settleAll(err instanceof Error ? err.message : String(err))
+    );
   };
 
   channel.addEventListener('message', listener as (ev: MessageEvent) => void);

--- a/packages/webapp/src/shell/supplemental-commands/hf-download.ts
+++ b/packages/webapp/src/shell/supplemental-commands/hf-download.ts
@@ -115,13 +115,23 @@ async function downloadOne(
   revision: string,
   file: string,
   targetDir: string,
-  force: boolean
+  force: boolean,
+  declaredSize?: number
 ): Promise<{ status: 'downloaded' | 'skipped'; bytes: number }> {
   const destPath = `${targetDir}/${file}`;
   if (!force && (await fs.exists(destPath))) {
     try {
       const stat = await fs.stat(destPath);
-      return { status: 'skipped', bytes: stat.size ?? 0 };
+      // Skip only a COMPLETE file. When the tree listing told us the declared
+      // byte length, a present file of any other size is a torn write — a
+      // download that died mid-stream, or a concurrent stager still writing
+      // it — and "skipping" it would hand the caller a truncated weight file
+      // that later fails to load with a size-mismatch EIO. Without a declared
+      // size (explicit file list, or a listing without sizes) presence is the
+      // best we can check.
+      const complete =
+        declaredSize === undefined || declaredSize <= 0 || stat.size === declaredSize;
+      if (complete) return { status: 'skipped', bytes: stat.size ?? 0 };
     } catch {
       // fall through to re-download
     }
@@ -225,12 +235,15 @@ export async function downloadHfRepo(opts: DownloadHfRepoOptions): Promise<HfRep
   const force = opts.force ?? false;
 
   let files = opts.files ?? [];
+  /** Declared byte length per file, known only after a tree listing. */
+  const declaredSizes = new Map<string, number>();
   if (files.length === 0) {
     const tree = await listRepoTree(opts.fetch, opts.repo, revision);
     if (tree.length === 0) {
       throw new Error(`repo ${opts.repo}@${revision} has no files`);
     }
     files = tree.map((e) => e.path);
+    for (const e of tree) declaredSizes.set(e.path, e.size);
     const totalBytes = tree.reduce((sum, e) => sum + e.size, 0);
     opts.progress?.onListed?.({ files, totalBytes });
   }
@@ -244,7 +257,16 @@ export async function downloadHfRepo(opts: DownloadHfRepoOptions): Promise<HfRep
     const file = files[i];
     let r: { status: 'downloaded' | 'skipped'; bytes: number };
     try {
-      r = await downloadOne(opts.fetch, opts.fs, opts.repo, revision, file, opts.targetDir, force);
+      r = await downloadOne(
+        opts.fetch,
+        opts.fs,
+        opts.repo,
+        revision,
+        file,
+        opts.targetDir,
+        force,
+        declaredSizes.get(file)
+      );
     } catch (err) {
       throw new HfFileDownloadError(file, err);
     }

--- a/packages/webapp/src/speech/ensure-speech-assets.ts
+++ b/packages/webapp/src/speech/ensure-speech-assets.ts
@@ -98,13 +98,26 @@ export interface EnsureSpeechAssetsResult {
   repos: Array<{ repo: string; downloaded: number; skipped: number }>;
 }
 
-/** Stage the ort wasm runtime if any known dist file is missing. */
+/**
+ * The dist files an ort install MUST carry for speech to run: the JSEP
+ * (WebGPU) and plain SIMD (CPU) threaded builds. The remaining entries of
+ * `ORT_WASM_DIST_FILES` (asyncify / jspi variants) come and go across ort-web
+ * releases and are read only when present, so their absence must NOT trigger
+ * a reinstall: `ipk add` rewrites the whole `dist/` directory, and an engine
+ * that is loading at that moment reads ENOENT for every file and fails with
+ * the misleading "onnxruntime-web is not installed".
+ */
+const ORT_REQUIRED_DIST_FILES: ReadonlyArray<string> = ORT_WASM_DIST_FILES.filter(
+  (f) => !/\.(asyncify|jspi)\./.test(f)
+);
+
+/** Stage the ort wasm runtime if any REQUIRED dist file is missing. */
 async function ensureOrtStaged(
   deps: EnsureSpeechAssetsDeps,
   onProgress?: SpeechAssetProgressFn
 ): Promise<boolean> {
   const present = await Promise.all(
-    ORT_WASM_DIST_FILES.map((f) => deps.fs.exists(`${ORT_DIST_VFS_PATH}${f}`))
+    ORT_REQUIRED_DIST_FILES.map((f) => deps.fs.exists(`${ORT_DIST_VFS_PATH}${f}`))
   );
   if (present.every(Boolean)) {
     onProgress?.({ asset: ORT_PACKAGE, phase: 'present' });

--- a/packages/webapp/tests/kernel/speech-assets-bridge.test.ts
+++ b/packages/webapp/tests/kernel/speech-assets-bridge.test.ts
@@ -117,4 +117,65 @@ describe('speech-assets-bridge', () => {
     ).resolves.toBeUndefined();
     stop();
   });
+
+  it('coalesces concurrent requests onto ONE ensure run and answers every caller', async () => {
+    // `hear --warmup`, `say --warmup` and the composer warmup all stage the same
+    // files; two overlapping `hf download`s of one repo is the staging race.
+    let runs = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    let emit!: (p: SpeechAssetProgress) => void;
+    const stop = installSpeechAssetsResponder({
+      instanceId: 'co',
+      ensure: async (onProgress) => {
+        runs += 1;
+        emit = onProgress;
+        await gate;
+        return { ok: true };
+      },
+    });
+    const seenA: SpeechAssetProgress[] = [];
+    const seenB: SpeechAssetProgress[] = [];
+    const a = callEnsureSpeechAssets({ instanceId: 'co', onProgress: (p) => seenA.push(p) });
+    // Let A's request reach the responder before B arrives.
+    await new Promise((r) => setTimeout(r, 0));
+    const b = callEnsureSpeechAssets({ instanceId: 'co', onProgress: (p) => seenB.push(p) });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(runs).toBe(1);
+    emit({ asset: 'owner/model', phase: 'downloaded', filesLoaded: 1, filesTotal: 2 });
+    await new Promise((r) => setTimeout(r, 0));
+    // Progress fans out to BOTH subscribers, each under its own request id.
+    expect(seenA).toHaveLength(1);
+    expect(seenB).toHaveLength(1);
+    release();
+    await expect(Promise.all([a, b])).resolves.toEqual([undefined, undefined]);
+    expect(runs).toBe(1);
+
+    // After the run settled, a new request starts a fresh (fast no-op) run.
+    release = () => {};
+    await callEnsureSpeechAssets({ instanceId: 'co' }).catch(() => {});
+    expect(runs).toBe(2);
+    stop();
+  });
+
+  it('fans a failure of the shared run out to every joined caller', async () => {
+    let reject!: (e: Error) => void;
+    const stop = installSpeechAssetsResponder({
+      instanceId: 'cf',
+      ensure: () =>
+        new Promise((_r, rej) => {
+          reject = rej;
+        }),
+    });
+    const a = callEnsureSpeechAssets({ instanceId: 'cf' });
+    await new Promise((r) => setTimeout(r, 0));
+    const b = callEnsureSpeechAssets({ instanceId: 'cf' });
+    await new Promise((r) => setTimeout(r, 0));
+    reject(new Error('HF unreachable'));
+    await expect(a).rejects.toThrow('HF unreachable');
+    await expect(b).rejects.toThrow('HF unreachable');
+    stop();
+  });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/hf-download.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/hf-download.test.ts
@@ -91,13 +91,14 @@ describe('downloadHfRepo', () => {
     expect(await fs.exists('/m/b.txt')).toBe(false);
   });
 
-  it('skips byte-present files unless force is set', async () => {
+  it('skips files already present at the listed byte length unless force is set', async () => {
     const fetch = makeFetch({ 'a.txt': bytes('A') });
     await fs.mkdir('/m', { recursive: true });
-    await fs.writeFile('/m/a.txt', bytes('PRE'));
+    // Same length as the listed file → complete → skipped (content untouched).
+    await fs.writeFile('/m/a.txt', bytes('P'));
     const skip = await downloadHfRepo({ fetch, fs, repo: 'owner/name', targetDir: '/m' });
     expect(skip).toMatchObject({ downloaded: 0, skipped: 1 });
-    expect(await fs.readFile('/m/a.txt')).toBe('PRE');
+    expect(await fs.readFile('/m/a.txt')).toBe('P');
     const forced = await downloadHfRepo({
       fetch,
       fs,
@@ -142,5 +143,40 @@ describe('downloadHfRepo', () => {
     );
     expect(err).not.toBeInstanceOf(HfFileDownloadError);
     expect(String(err)).toMatch(/has no files/);
+  });
+
+  it('re-downloads a present file whose size differs from the listing (torn write)', async () => {
+    // A download that died mid-stream (or a concurrent stager still writing)
+    // leaves a file of the wrong length. Presence alone must not "skip" it —
+    // the engine would later fail to load it with a size-mismatch EIO.
+    const fetch = makeFetch({ 'model.onnx': bytes('COMPLETE') });
+    await fs.mkdir('/m', { recursive: true });
+    await fs.writeFile('/m/model.onnx', bytes('COMP'));
+    const events: HfFileEvent[] = [];
+    const r = await downloadHfRepo({
+      fetch,
+      fs,
+      repo: 'owner/name',
+      targetDir: '/m',
+      progress: { onFile: (e) => events.push(e) },
+    });
+    expect(r).toMatchObject({ downloaded: 1, skipped: 0 });
+    expect(await fs.readFile('/m/model.onnx')).toBe('COMPLETE');
+    expect(events[0]).toMatchObject({ file: 'model.onnx', status: 'downloaded', bytes: 8 });
+  });
+
+  it('keeps presence-only skipping for an explicit file list (no declared sizes)', async () => {
+    const fetch = makeFetch({ 'a.txt': bytes('A') });
+    await fs.mkdir('/m', { recursive: true });
+    await fs.writeFile('/m/a.txt', bytes('PRE'));
+    const r = await downloadHfRepo({
+      fetch,
+      fs,
+      repo: 'owner/name',
+      targetDir: '/m',
+      files: ['a.txt'],
+    });
+    expect(r).toMatchObject({ downloaded: 0, skipped: 1 });
+    expect(await fs.readFile('/m/a.txt')).toBe('PRE');
   });
 });

--- a/packages/webapp/tests/speech/ensure-speech-assets.test.ts
+++ b/packages/webapp/tests/speech/ensure-speech-assets.test.ts
@@ -159,4 +159,28 @@ describe('ensureSpeechAssetsStaged', () => {
       /failed to stage onnxruntime-web/
     );
   });
+
+  it('does not reinstall ort when only an optional (asyncify/jspi) variant is absent', async () => {
+    // A reinstall rewrites the whole dist/ under any engine that is loading it
+    // ("onnxruntime-web is not installed" despite the files existing). Only the
+    // REQUIRED jsep + plain threaded builds gate the install.
+    const fs = await newFs();
+    await stageEspeak(fs);
+    await fs.mkdir(ORT_DIST_VFS_PATH, { recursive: true });
+    for (const f of ORT_WASM_DIST_FILES) {
+      if (/\.asyncify\./.test(f)) continue;
+      await fs.writeFile(`${ORT_DIST_VFS_PATH}${f}`, bytes('wasm'));
+    }
+    let registryHits = 0;
+    const fetch = (async (url: string) => {
+      if (url.includes('registry.npmjs.org')) {
+        registryHits += 1;
+        throw new Error('registry must not be contacted');
+      }
+      return hfFetch({ 'config.json': bytes('{}') })(url);
+    }) as unknown as SecureFetch;
+    const result = await ensureSpeechAssetsStaged({ fs, fetch, repos: [REPO] });
+    expect(result.ortStaged).toBe(false);
+    expect(registryHits).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

`hear --warmup` / `say --warmup` could fail with `weights for onnx-community/whisper-tiny are missing` while the download was still writing, and a later engine load could fail with `onnxruntime-web is not installed` although every dist file existed. Three defects, one per layer; all three fixed.

## Why

Seen live while benchmarking #2230 on the Tier-1 harness (details in that PR's comment). Repro: run `hear --warmup; say --warmup` on a cold `/workspace` — two stagers race over the same files; or let a weight download die mid-stream and retry — the truncated file is "skipped" forever.

## Approach / Implementation notes

- **`kernel/speech-assets-bridge.ts` — single-flight staging.** The worker responder ran one `ensureSpeechAssetsStaged` per request, so `hear --warmup`, `say --warmup` and the composer warmup each started their own stager. Requests arriving while a run is in flight now join it; progress and the final result fan out to every joined caller under its own request id. A request after the run settled starts a fresh (fast no-op) run. Page-side `callEnsureSpeechAssets` is unchanged.
- **`shell/supplemental-commands/hf-download.ts` — size-aware skip.** A present file was skipped on existence alone. With a tree listing (the default) the skip now requires the *listed* byte length, so a torn write (died mid-stream, or a concurrent stager still writing) is re-fetched. Explicit file lists carry no sizes and keep presence-only skipping. `hf`'s help already said "matching byte length" — now true.
- **`speech/ensure-speech-assets.ts` — required-files gate.** The ort reinstall was gated on *every* known dist file including the `asyncify`/`jspi` variants that come and go across ort-web releases, so a harmless absent variant rewrote `dist/` under a loading engine. Only the required jsep + plain threaded builds gate it now.
- Docs: `docs/webapp-details.md` § Speech.

## Test plan

- [x] `speech-assets-bridge`: concurrent requests → one `ensure` run, progress to both, both resolve; failure fans out to both; post-settle request starts a new run
- [x] `hf-download`: torn write re-downloaded (progress says `downloaded`), same-length file skipped, explicit list keeps presence skip (existing "byte-present" test corrected to actually be byte-present)
- [x] `ensure-speech-assets`: optional variant absent → `ortStaged: false`, registry never contacted
- [x] 40 tests across the four suites, webapp typecheck, biome, `lint:docs`, debt gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)