### PR TITLE
ci(release): upload the APNs secrets with the production worker publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,6 +345,11 @@ jobs:
           CLOUDFLARE_TURN_API_TOKEN: ${{ secrets.CLOUDFLARE_TURN_API_TOKEN }}
           GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          # iOS follower push (#2062): the tray hub's APNs token auth.
+          APNS_TEAM_ID: ${{ secrets.APNS_TEAM_ID }}
+          APNS_KEY_ID: ${{ secrets.APNS_KEY_ID }}
+          APNS_PRIVATE_KEY: ${{ secrets.APNS_PRIVATE_KEY }}
+          APNS_TOPIC: ${{ secrets.APNS_TOPIC }}
           WORKER_BASE_URL: https://www.sliccy.ai
           CHROME_WEB_STORE_PUBLISHER_ID: ${{ vars.CHROME_WEB_STORE_PUBLISHER_ID }}
           CHROME_WEB_STORE_ITEM_ID: ${{ vars.CHROME_WEB_STORE_ITEM_ID }}

--- a/packages/cloudflare-worker/scripts/publish-worker.sh
+++ b/packages/cloudflare-worker/scripts/publish-worker.sh
@@ -12,6 +12,7 @@
 #
 # Required env vars (set by semantic-release / release.yml):
 #   CLOUDFLARE_TURN_API_TOKEN, GITHUB_CLIENT_SECRET, E2B_API_KEY,
+#   APNS_TEAM_ID, APNS_KEY_ID, APNS_PRIVATE_KEY, APNS_TOPIC (follower push, #2062),
 #   CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID (the latter two consumed by wrangler).
 #   SLICC_LAST_RELEASE_TAG (empty means first release and always deploys).
 set -euo pipefail
@@ -91,6 +92,16 @@ echo "[publish-worker] Uploading worker secrets..."
 echo "$CLOUDFLARE_TURN_API_TOKEN" | npx wrangler secret put CLOUDFLARE_TURN_API_TOKEN --config "$WRANGLER_CONFIG"
 echo "$GITHUB_CLIENT_SECRET"      | npx wrangler secret put GITHUB_CLIENT_SECRET      --config "$WRANGLER_CONFIG"
 echo "$E2B_API_KEY"               | npx wrangler secret put E2B_API_KEY               --config "$WRANGLER_CONFIG"
+# APNs token auth for follower push (#2062). All four or the hub disables
+# pushing; uploaded only when set so a fork without the key still releases.
+if [ -n "${APNS_PRIVATE_KEY:-}" ]; then
+  echo "$APNS_TEAM_ID"     | npx wrangler secret put APNS_TEAM_ID     --config "$WRANGLER_CONFIG"
+  echo "$APNS_KEY_ID"      | npx wrangler secret put APNS_KEY_ID      --config "$WRANGLER_CONFIG"
+  printf '%s' "$APNS_PRIVATE_KEY" | npx wrangler secret put APNS_PRIVATE_KEY --config "$WRANGLER_CONFIG"
+  echo "$APNS_TOPIC"       | npx wrangler secret put APNS_TOPIC       --config "$WRANGLER_CONFIG"
+else
+  echo "[publish-worker] APNS_PRIVATE_KEY not set; skipping APNs secrets (follower push stays disabled)."
+fi
 
 # Hard-fail before deploy if archiving fails; a build must never go live
 # unarchived. The deploy path keeps its established template/secrets/archive order.


### PR DESCRIPTION
## Summary

The release-time worker publish (`publish-worker.sh`) re-uploads the tray hub secrets before every production deploy, but only knew `CLOUDFLARE_TURN_API_TOKEN` / `GITHUB_CLIENT_SECRET` / `E2B_API_KEY`. The four `APNS_*` secrets that follower push (#2062, shipped in #2213 / v6.67.0) needs were never going to reach production this way.

## Why

#2213 wired the secrets into `worker.yml` / `worker-staging.yml` (the manual deploys), but the Release workflow deploys production through `publish-worker.sh`, a different path. I have set the four secrets on the production and staging workers by hand in the meantime; this makes the next release keep them in sync instead of depending on that.

## Approach

- `release.yml` Publish step: pass `APNS_TEAM_ID` / `APNS_KEY_ID` / `APNS_PRIVATE_KEY` / `APNS_TOPIC` from repository secrets (all four exist).
- `publish-worker.sh`: upload them when `APNS_PRIVATE_KEY` is set, `printf` for the PEM so newlines survive; a checkout without the key logs and skips, and the hub already treats missing secrets as push-disabled.

## Verification

- `bash -n`, prettier on the workflow.
- Exercised for real on the next Release run (production publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)