### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -70,10 +70,10 @@
       ]
     },
     "webapp": {
-      "lines": 81,
+      "lines": 82,
       "statements": 79,
       "functions": 80,
-      "branches": 70,
+      "branches": 71,
       "coverageExclude": [
         "**/node_modules/**",
         "**/dist/**",
@@ -152,9 +152,9 @@
       "regions": 83
     },
     "swift-trayfollower": {
-      "lines": 63,
+      "lines": 64,
       "functions": 48,
-      "regions": 73
+      "regions": 74
     },
     "ios-app": {
       "lines": 73,


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.