### PR TITLE
test(swift-launcher): assert the release walk paginates, not that it lands on an asset

### DIFF
--- a/packages/swift-launcher/SliccstartTests/UpdateCheckIntegrationTests.swift
+++ b/packages/swift-launcher/SliccstartTests/UpdateCheckIntegrationTests.swift
@@ -62,14 +62,24 @@ final class UpdateCheckIntegrationTests: XCTestCase {
     }
 
     /// Proves the pagination walk works against GitHub's real `Link` headers:
-    /// with one release per page, page 1 (`v5.81.1`-style tags carry no macOS
-    /// artifact) cannot satisfy the check, so the provider must follow
-    /// `rel="next"` until it reaches a release shipping `Sliccstart-*.zip`.
-    /// A frozen fixture could not catch header-format drift here.
-    func testPaginationWalkFindsAnInstallableReleaseOnRealAPI() async throws {
+    /// forcing `per_page=1` means a single page can never satisfy the walk, so
+    /// the provider must parse `rel="next"` out of a live header to make any
+    /// progress at all. A frozen fixture could not catch header-format drift.
+    ///
+    /// This asserts on the *walk*, deliberately not on reaching an installable
+    /// release. Native artifacts are built conditionally, so the newest
+    /// asset-bearing release drifts arbitrarily far down the list as ordinary
+    /// releases accumulate — at one release per page it slid past the
+    /// `maxReleasePages` loop guard, which failed this test for reasons that
+    /// had nothing to do with pagination. That the walk does reach an
+    /// installable release stays covered by
+    /// `testTolerantProviderFetchesReleasesWithCorrectVersions`, which runs at
+    /// the production page size.
+    func testPaginationWalkFollowsRealLinkHeaders() async throws {
         // `currentVersion` is pinned: the walk stops at the running build's own
         // release, and the XCTest host bundle's version is unrelated to the
         // repo's release history.
+        let pagesFetched = PageCounter()
         let provider = TolerantGithubReleaseProvider(
             currentVersion: Version(0, 0, 0),
             fetchPage: { request in
@@ -79,6 +89,7 @@ final class UpdateCheckIntegrationTests: XCTestCase {
                 components.queryItems = items
                 var paged = request
                 paged.url = components.url
+                await pagesFetched.increment()
                 let (data, response) = try await URLSession.shared.data(for: paged)
                 guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
                 return (data, http)
@@ -86,17 +97,30 @@ final class UpdateCheckIntegrationTests: XCTestCase {
 
         let releases = try await provider.fetchReleases(owner: "ai-ecoverse", repo: "slicc", proxy: nil)
 
-        if releases.isEmpty {
-            // Preserve the assertion below unless GitHub itself confirms that
-            // its list endpoint is temporarily inconsistent.
-            _ = try await fetchReleasesJSON(owner: "ai-ecoverse", repo: "slicc")
-        }
-
-        XCTAssertFalse(
-            releases.isEmpty,
-            "Expected the paginated walk to reach a release with an installable Sliccstart asset "
-                + "within \(TolerantGithubReleaseProvider.maxReleasePages) pages"
+        // The first request is unconditional; any page beyond it could only
+        // have come from parsing a real `rel="next"` off GitHub's Link header.
+        let pages = await pagesFetched.value
+        XCTAssertGreaterThan(
+            pages, 1,
+            "Expected the provider to follow rel=\"next\" past the first page; it fetched \(pages). "
+                + "GitHub's Link header format may have drifted."
         )
+
+        // Whatever the walk did surface must be installable — filtering to an
+        // installable asset is the point of `fetchReleases`, and it still holds
+        // when release churn means the walk surfaces nothing.
+        for release in releases {
+            XCTAssertTrue(
+                release.assets.contains { $0.name.hasPrefix("Sliccstart-") && $0.name.hasSuffix(".zip") },
+                "fetchReleases returned \(release.tagName) without an installable Sliccstart-*.zip asset"
+            )
+        }
+    }
+
+    /// Serialises the page tally across the provider's `@Sendable` fetch seam.
+    private actor PageCounter {
+        private(set) var value = 0
+        func increment() { value += 1 }
     }
 
     // MARK: - Strict decoder (the bug — contrast test)


### PR DESCRIPTION
## Summary

Unblocks the merge queue. `testPaginationWalkFindsAnInstallableReleaseOnRealAPI` has been failing on every `merge_group` run since v6.71.0 was published, for reasons that have nothing to do with the PR under test.

## Why

The test forces `per_page=1` against the live releases API — deliberately, so the provider has to follow a real `rel="next"` — and then required an installable `Sliccstart-*.zip` to appear within `maxReleasePages` (20) single-release pages.

Native artifacts are built conditionally, so asset-bearing releases are sparse. The newest one is **v6.57.2** (2026-08-18). It sat at position 20 — just inside the window — until v6.71.0 was published at 19:51 UTC, which pushed it to 21 and put it permanently out of reach:

| # | tag | Sliccstart asset |
|---|-----|------------------|
| 1–20 | v6.71.0 … v6.57.3 | none |
| **21** | **v6.57.2** | `Sliccstart-6.57.2.zip` |

Every release cut from here pushes it further down, so this fails harder over time, and it blocks all PRs — it dequeued #2236 twice.

The sibling test's own comment already acknowledges the underlying reality: *"native artifacts are now built conditionally, so the filtered list can be small."* That test asserts the same "many releases" intent against the unfiltered list. This one never got the same treatment.

## Approach

Assert on the walk, which is what the test is actually for.

- Still forces `per_page=1`, so the provider cannot make progress without parsing a live `rel="next"` — the header-format drift detection a frozen fixture can't give us is preserved.
- Counts pages through the injected `fetchPage` seam (via a small `actor`, since the seam is `@Sendable`) and asserts it fetched more than one.
- Whatever the walk surfaces must still carry an installable asset, so the `fetchReleases` filter stays covered — and that holds even when churn means it surfaces nothing.
- Renamed to `testPaginationWalkFollowsRealLinkHeaders` to match what it proves.

Reaching an installable release stays covered by `testTolerantProviderFetchesReleasesWithCorrectVersions`, which runs at the production page size (100) and is unaffected by this churn. Note the 20-page guard is not a problem in production: at `per_page=100` it spans 2,000 releases.

## Verification

`swift-coverage-check.sh packages/swift-launcher SliccstartPackageTests` locally: **365 tests, 0 failures**, floors clear.

| | result | floor |
|---|---|---|
| Lines | 42.44% | 41% |
| Functions | 45.80% | 45% |
| Regions | 52.99% | 52% |

Confirmed pristine `main` fails the same way locally, so this is a pre-existing repo-wide break, not a regression from any open PR.

## Out of scope

Whether native artifacts *should* be shipping more often is a separate question about the release pipeline — this only stops a conditional-artifact policy from breaking an unrelated pagination test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
