### PR TITLE
test(swift-launcher): accept a page-1 hit in the release pagination walk

### DIFF
--- a/packages/swift-launcher/SliccstartTests/UpdateCheckIntegrationTests.swift
+++ b/packages/swift-launcher/SliccstartTests/UpdateCheckIntegrationTests.swift
@@ -62,9 +62,12 @@ final class UpdateCheckIntegrationTests: XCTestCase {
     }
 
     /// Proves the pagination walk works against GitHub's real `Link` headers:
-    /// forcing `per_page=1` means a single page can never satisfy the walk, so
-    /// the provider must parse `rel="next"` out of a live header to make any
-    /// progress at all. A frozen fixture could not catch header-format drift.
+    /// forcing `per_page=1` keeps each page to a single release, so unless that
+    /// one release is itself installable the provider must parse `rel="next"`
+    /// out of a live header to get anywhere. A frozen fixture could not catch
+    /// header-format drift. `ReleaseFetchPaginationTests` covers the walk's
+    /// mechanics deterministically; this test exists only to notice when the
+    /// real header stops looking like what we parse.
     ///
     /// This asserts on the *walk*, deliberately not on reaching an installable
     /// release. Native artifacts are built conditionally, so the newest
@@ -97,13 +100,21 @@ final class UpdateCheckIntegrationTests: XCTestCase {
 
         let releases = try await provider.fetchReleases(owner: "ai-ecoverse", repo: "slicc", proxy: nil)
 
-        // The first request is unconditional; any page beyond it could only
-        // have come from parsing a real `rel="next"` off GitHub's Link header.
+        // The walk stops as soon as a page yields a viable release, so page 1
+        // is enough exactly when the newest release ships an asset — which is
+        // the state right after a `packages/swift-launcher/**` change cuts a
+        // release. Demanding pagination unconditionally would just invert the
+        // churn flake this test was rewritten to remove.
+        //
+        // What must always hold: the walk either found something, or it proved
+        // it could keep going. Coming back with nothing after a single page is
+        // the signature of a `rel="next"` we failed to parse — a page-1 miss
+        // has more releases behind it, so the walk had somewhere to go.
         let pages = await pagesFetched.value
-        XCTAssertGreaterThan(
-            pages, 1,
-            "Expected the provider to follow rel=\"next\" past the first page; it fetched \(pages). "
-                + "GitHub's Link header format may have drifted."
+        XCTAssertTrue(
+            pages > 1 || !releases.isEmpty,
+            "The walk stopped after \(pages) page(s) with no viable release. GitHub's Link "
+                + "header format may have drifted, leaving `rel=\"next\"` unparsed."
         )
 
         // Whatever the walk did surface must be installable — filtering to an


### PR DESCRIPTION
Follow-up to #2249, addressing the automated reviewer's finding on [`discussion_r3828533112`](https://github.com/ai-ecoverse/slicc/pull/2249#discussion_r3828533112). The finding is correct.

## The problem

#2249 replaced "the walk must reach an installable release" with "the walk must fetch more than one page". That new assertion only holds while the **newest** release lacks an installable asset.

`fetchReleases` loops `while ... viable.isEmpty ...`, so it stops as soon as a page yields a viable release. At `per_page=1` that means: if the newest release ships a `Sliccstart-*.zip`, page 1 satisfies the walk, the provider correctly declines to follow `rel="next"`, `pages == 1`, and the test fails.

With `currentVersion` pinned to `0.0.0` the `reachedCurrentVersion` exit can never fire, so page-1 viability is the only way the walk stops early — exactly as the reviewer described.

That state occurs right after a `packages/swift-launcher/**` change cuts a release, which is precisely when someone is touching this file. It's the mirror image of the flake #2249 removed — short-lived and self-healing rather than permanent, but the same class, and it would dequeue a `merge_group` run at an unlucky moment.

## The fix

Assert the invariant that holds in both windows:

```swift
XCTAssertTrue(pages > 1 || !releases.isEmpty, ...)
```

The walk either found a viable release, or it proved it could keep going. Returning nothing after a single page is the signature of an unparsed `rel="next"` — a page-1 miss always has more releases behind it, so the walk had somewhere to go and didn't take it.

| state | pages | releases | result |
|---|---|---|---|
| newest release is installable | 1 | non-empty | ✅ passes (was ❌) |
| normal churn, walks the chain | >1 | empty or not | ✅ passes |
| `Link` header drifted, page-1 miss | 1 | empty | ❌ fails — drift caught |

The one case it cannot detect is a broken `Link` header *while* page 1 is viable — but there is nothing to paginate then, so there is no drift to observe. `ReleaseFetchPaginationTests` covers the walk's mechanics deterministically against stubs; this live test exists only to notice when the real header stops looking like what we parse, and the docstring now says so.

## Verification

`swift-coverage-check.sh packages/swift-launcher SliccstartPackageTests`: **365 tests, 0 failures**, floors clear (lines 42.44% / 41, functions 45.80% / 45, regions 52.99% / 52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
