### PR TITLE
feat(webapp): LiveWorkUnit owns scoop lifecycle (#1666 phase 2)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -281,6 +281,7 @@ All skills (native and compatibility) are read-only — the slicc-specific `mani
 | `policy.ts`     | Root/child presets, `derivePolicy`, `isRootUnit` (`parentJid === null` — the only root test), `isPolicySubset`, `childrenOf`, `rootsOf`                                     |
 | `descriptor.ts` | Pure projection of a `RegisteredScoop` + tab state onto a descriptor; `workspaceFor` computes cwd / memory / scratch paths                                                  |
 | `runtime.ts`    | `WorkUnitRuntime` contract + `ScoopContextWorkUnit` adapter over `ScoopContext` / `ScoopLifecycleManager`                                                                   |
+| `live-unit.ts`  | `LiveWorkUnit` — owning runtime per scoop (context, tab, observers); legal-transition table; `close()` single teardown. `ScoopLifecycleManager` hosts these                 |
 | `manager.ts`    | `WorkUnitManager` (`Orchestrator.getWorkUnits()`): hierarchy queries (`getParent`, `getChildren`, `roots`, `resolveDefaultRoot`) replacing the global `scoops.find(isCone)` |
 
 Cone and scoop are roles over this one runtime; see [`docs/work-unit.md`](./work-unit.md) for the decision record and migration phases.

--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -70,7 +70,7 @@ A strangler migration, each phase a separate PR with deletion criteria:
 
 - `LiveWorkUnit` (`work-unit/live-unit.ts`) owns a scoop's `ScoopContext`, `ScoopTabState` and observers. A unit may exist before its context (an observer subscribed ahead of spawn, or a boot-time error tab).
 - `transition(next)` applies `LEGAL_TRANSITIONS` (`initializing → ready|error`, `ready → processing|error|initializing`, `processing → ready|error`, `error → initializing|ready|processing`); illegal moves and anything on a closed unit are logged and ignored, so a stale callback from a disposed context cannot resurrect a unit.
-- `close()` runs in a fixed order — idle timer, stop turn, dispose context (realm workers + shell processes), drop observers, release `scoop_wait` callers — and is idempotent. `destroyTab` and `unregister` both end in it.
+- `teardown()` runs in a fixed order — idle timer, stop turn, dispose context (realm workers + shell processes), drop observers, release `scoop_wait` callers — and is idempotent. `destroyTab` and `unregister` both end in it. `close()` (the `WorkUnitRuntime` contract) unregisters through the host, so the active-licks guard and record deletion apply exactly as for `drop_scoop`.
 - `detachContext()` (filesystem reset) stops without disposing and keeps observers; `disposeContext()` (re-spawn after a failed init) disposes and keeps observers.
 - `WorkUnitManager.get()` returns the live unit when the host has one (`Orchestrator.getLiveUnit`), else the Phase 1 read-through adapter.
 
@@ -78,7 +78,7 @@ A strangler migration, each phase a separate PR with deletion criteria:
 
 - `LiveWorkUnit` (`work-unit/live-unit.ts`) owns a scoop's `ScoopContext`, `ScoopTabState` and observers. A unit may exist before its context (an observer subscribed ahead of spawn, or a boot-time error tab).
 - `transition(next)` applies `LEGAL_TRANSITIONS` (`initializing → ready|error`, `ready → processing|error|initializing`, `processing → ready|error`, `error → initializing|ready|processing`); illegal moves and anything on a closed unit are logged and ignored, so a stale callback from a disposed context cannot resurrect a unit.
-- `close()` runs in a fixed order — idle timer, stop turn, dispose context (realm workers + shell processes), drop observers, release `scoop_wait` callers — and is idempotent. `destroyTab` and `unregister` both end in it.
+- `teardown()` runs in a fixed order — idle timer, stop turn, dispose context (realm workers + shell processes), drop observers, release `scoop_wait` callers — and is idempotent. `destroyTab` and `unregister` both end in it. `close()` (the `WorkUnitRuntime` contract) unregisters through the host, so the active-licks guard and record deletion apply exactly as for `drop_scoop`.
 - `detachContext()` (filesystem reset) stops without disposing and keeps observers; `disposeContext()` (re-spawn after a failed init) disposes and keeps observers.
 - `WorkUnitManager.get()` returns the live unit when the host has one (`Orchestrator.getLiveUnit`), else the Phase 1 read-through adapter.
 

--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -43,13 +43,15 @@ Cone and scoop stay the product vocabulary (UI, prompts, tool names, skills). Th
 
 ## Module map
 
-| File            | Purpose                                                                                                                                                             |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `types.ts`      | `WorkUnitDescriptor`, `WorkUnitPolicy`, `CompletionPolicy`, `WorkUnitStatus` (`creating → ready ⇄ running`, `* → failed`, `* → closed`), events, `statusFromTab`    |
-| `policy.ts`     | `interactiveRootPolicy`, `delegatedChildPolicy`, `derivePolicy`, `deriveCompletion`, `isRootUnit`, `isPolicySubset`, `childrenOf`, `rootsOf`                        |
-| `descriptor.ts` | `toDescriptor(scoop, tab?)`, `workspaceFor` — pure projections                                                                                                      |
-| `runtime.ts`    | `WorkUnitRuntime` contract + `ScoopContextWorkUnit`, the Phase 1 adapter over `ScoopContext` / `ScoopLifecycleManager`                                              |
-| `manager.ts`    | `WorkUnitManager` — `create / list / get / getParent / getChildren / roots / rootOf / resolveDefaultRoot / abort / close`; exposed as `Orchestrator.getWorkUnits()` |
+| File            | Purpose                                                                                                                                                                   |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `types.ts`      | `WorkUnitDescriptor`, `WorkUnitPolicy`, `CompletionPolicy`, `WorkUnitStatus` (`creating → ready ⇄ running`, `* → failed`, `* → closed`), events, `statusFromTab`          |
+| `policy.ts`     | `interactiveRootPolicy`, `delegatedChildPolicy`, `derivePolicy`, `deriveCompletion`, `isRootUnit`, `isPolicySubset`, `childrenOf`, `rootsOf`                              |
+| `descriptor.ts` | `toDescriptor(scoop, tab?)`, `workspaceFor` — pure projections                                                                                                            |
+| `runtime.ts`    | `WorkUnitRuntime` contract + `ScoopContextWorkUnit`, the Phase 1 adapter over `ScoopContext` / `ScoopLifecycleManager`                                                    |
+| `live-unit.ts`  | `LiveWorkUnit` — the owning runtime: holds the `ScoopContext`, tab record and observer set; `transition()` enforces `LEGAL_TRANSITIONS`; `close()` is the single teardown |
+| `live-unit.ts`  | `LiveWorkUnit` — the owning runtime: holds the `ScoopContext`, tab record and observer set; `transition()` enforces `LEGAL_TRANSITIONS`; `close()` is the single teardown |
+| `manager.ts`    | `WorkUnitManager` — `create / list / get / getParent / getChildren / roots / rootOf / resolveDefaultRoot / abort / close`; exposed as `Orchestrator.getWorkUnits()`       |
 
 Tests: `packages/webapp/tests/work-unit/`. `conformance.ts` is a reusable suite any `WorkUnitRuntime` implementation must pass.
 
@@ -60,9 +62,25 @@ A strangler migration, each phase a separate PR with deletion criteria:
 | Phase | Scope                                                                                                                                                                                                                                                                                                     | Status                    |
 | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
 | 1     | Types, required `parentJid` + restore backfill, adapter, manager facade, conformance tests. No behaviour change.                                                                                                                                                                                          | done                      |
-| 2     | Lifecycle ownership: the runtime owns context, tab, observers, timers; `close()` is the single teardown; lifecycle tested as one state machine.                                                                                                                                                           | planned                   |
+| 2     | Lifecycle ownership: `ScoopLifecycleManager` hosts one `LiveWorkUnit` per scoop (its context, tab, observers); `getContexts()` / `getTabsMap()` are derived views; `close()` is the single teardown; transitions tested as one state machine.                                                             | done                      |
 | 3     | Replace `isCone` with hierarchy and policy, one category at a time: filesystem, approvals, child tools, shared memory, completion, default-target routing, presentation. Add a CI ratchet that forbids new `isCone` reads outside presentation files. Prove two independent roots with children in tests. | planned                   |
 | 4–9   | `WorkUnitClient` for local/remote UI, one persistence store, `CapabilityBroker`, explicit workspace sharing modes, generic parallel APIs, deletion of legacy paths.                                                                                                                                       | deferred; separate issues |
+
+### Phase 2 detail
+
+- `LiveWorkUnit` (`work-unit/live-unit.ts`) owns a scoop's `ScoopContext`, `ScoopTabState` and observers. A unit may exist before its context (an observer subscribed ahead of spawn, or a boot-time error tab).
+- `transition(next)` applies `LEGAL_TRANSITIONS` (`initializing → ready|error`, `ready → processing|error|initializing`, `processing → ready|error`, `error → initializing|ready|processing`); illegal moves and anything on a closed unit are logged and ignored, so a stale callback from a disposed context cannot resurrect a unit.
+- `close()` runs in a fixed order — idle timer, stop turn, dispose context (realm workers + shell processes), drop observers, release `scoop_wait` callers — and is idempotent. `destroyTab` and `unregister` both end in it.
+- `detachContext()` (filesystem reset) stops without disposing and keeps observers; `disposeContext()` (re-spawn after a failed init) disposes and keeps observers.
+- `WorkUnitManager.get()` returns the live unit when the host has one (`Orchestrator.getLiveUnit`), else the Phase 1 read-through adapter.
+
+### Phase 2 detail
+
+- `LiveWorkUnit` (`work-unit/live-unit.ts`) owns a scoop's `ScoopContext`, `ScoopTabState` and observers. A unit may exist before its context (an observer subscribed ahead of spawn, or a boot-time error tab).
+- `transition(next)` applies `LEGAL_TRANSITIONS` (`initializing → ready|error`, `ready → processing|error|initializing`, `processing → ready|error`, `error → initializing|ready|processing`); illegal moves and anything on a closed unit are logged and ignored, so a stale callback from a disposed context cannot resurrect a unit.
+- `close()` runs in a fixed order — idle timer, stop turn, dispose context (realm workers + shell processes), drop observers, release `scoop_wait` callers — and is idempotent. `destroyTab` and `unregister` both end in it.
+- `detachContext()` (filesystem reset) stops without disposing and keeps observers; `disposeContext()` (re-spawn after a failed init) disposes and keeps observers.
+- `WorkUnitManager.get()` returns the live unit when the host has one (`Orchestrator.getLiveUnit`), else the Phase 1 read-through adapter.
 
 ### Phase 1 detail
 

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -36,6 +36,7 @@ import { registerTranscriptExportService } from '../transcript/export-provider.j
 import { DefaultTranscriptExportService } from '../transcript/export-service.js';
 import { readSnapshot, writeSnapshot } from '../transcript/snapshot-store.js';
 import { getStrictKnownSecretRedactor } from '../transcript/strict-secret-client.js';
+import type { LiveWorkUnit } from '../work-unit/live-unit.js';
 import { WorkUnitManager } from '../work-unit/manager.js';
 import { SessionStore as UiSessionStore } from './chat-session-store.js';
 import { ConeMemoryStore } from './cone-memory-store.js';
@@ -957,6 +958,11 @@ export class Orchestrator implements ConeApprovalRouter {
   /** Hierarchy-aware work-unit view over the registry (#1666). */
   getWorkUnits(): WorkUnitManager {
     return this.workUnits;
+  }
+
+  /** The owning live runtime of a scoop, once spawned or observed. */
+  getLiveUnit(jid: string): LiveWorkUnit | undefined {
+    return this.lifecycle.getUnit(jid);
   }
 
   /** Wipe the virtual filesystem and re-seed default files (skills, shared CLAUDE.md). */

--- a/packages/webapp/src/scoops/scoop-completion-service.ts
+++ b/packages/webapp/src/scoops/scoop-completion-service.ts
@@ -120,7 +120,7 @@ export class ScoopCompletionService {
    * Any registered waiters are resolved with `null` so `scoop_wait` callers
    * unblock on teardown instead of stalling indefinitely.
    */
-  forgetScoop(jid: string, reason: 'unregister' | 'fatal-error'): void {
+  forgetScoop(jid: string, reason: 'unregister' | 'fatal-error' | 'close'): void {
     this.scoopResponseBuffer.delete(jid);
     this.mutedScoops.delete(jid);
     this.pendingCompletions.delete(jid);

--- a/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
+++ b/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
@@ -200,13 +200,17 @@ export class ScoopLifecycleManager {
           this.sendPrompt(j, text, senderId, senderName, [], options),
         clearIdleTimer: (j) => this.deps.idleTimers.clear(j),
         forgetCompletion: (j, reason) => this.deps.completionService.forgetScoop(j, reason),
+        unregister: (j) => this.unregister(j),
       });
       this.units.set(jid, unit);
     }
     return unit;
   }
 
-  /** Live contexts view (derived; read-only for callers). */
+  /**
+   * Live contexts view. A per-call snapshot derived from the units — hold the
+   * result for the duration of a loop rather than re-reading it per item.
+   */
   getContexts(): Map<string, ScoopContext> {
     const out = new Map<string, ScoopContext>();
     for (const [jid, unit] of this.units) {
@@ -378,16 +382,16 @@ export class ScoopLifecycleManager {
     this.deps.idleTimers.clear(jid);
     const unit = this.units.get(jid);
     if (!unit) return;
-    // `close()` is the single teardown: stops the turn, disposes the context
-    // (realm workers + shell processes), drops observers and releases any
-    // `scoop_wait` caller. Shutdown / reset / rollback paths that bypass
-    // `unregister` reclaim everything the same way.
-    void unit.close();
+    // `teardown()` is the single runtime teardown: stops the turn, disposes
+    // the context (realm workers + shell processes), drops observers and
+    // releases any `scoop_wait` caller. Shutdown / reset / rollback paths
+    // that bypass `unregister` reclaim everything the same way.
+    void unit.teardown();
     this.units.delete(jid);
     log.info('Scoop context destroyed', { jid });
   }
 
-  /** Live tabs view (derived; read-only for callers). */
+  /** Live tabs view. A per-call snapshot, like {@link getContexts}. */
   getTabsMap(): Map<string, ScoopTabState> {
     const out = new Map<string, ScoopTabState>();
     for (const [jid, unit] of this.units) {

--- a/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
+++ b/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
@@ -8,8 +8,11 @@
  * "unrecoverable scoop failure" handler that escalates a fatal error to the
  * cone (`handleFatalError`).
  *
- * Extracted from `Orchestrator` so the lifecycle maps (`tabs`, `contexts`,
- * `scoopObservers`) live next to the methods that mutate them. Everything
+ * Since #1666 (Phase 2) the manager is a host of {@link LiveWorkUnit}s: one
+ * `Map<jid, LiveWorkUnit>` owns each scoop's context, tab record and
+ * observers, and `getContexts()` / `getTabsMap()` are derived views kept for
+ * the message router, cost tracker and idle timers. `LiveWorkUnit.close()` is
+ * the single teardown path. Everything
  * else — scoop registry, callbacks, memory store, completion service, sudo
  * pieces, idle timers, message router — is reached through
  * {@link ScoopLifecycleDeps}, so this module stays free of orchestrator
@@ -25,6 +28,7 @@ import { RestrictedFS } from '../fs/restricted-fs.js';
 import type { ProcessManager } from '../kernel/process-manager.js';
 import type { SudoDecision, SudoRequest } from '../sudo/index.js';
 import type { SudoManager } from '../sudo/sudo-manager.js';
+import { LiveWorkUnit } from '../work-unit/live-unit.js';
 import { ScoopContext, type ScoopContextCallbacks } from './scoop-context.js';
 import { emitScoopLifecycle } from './scoop-telemetry-hook.js';
 import type { ChannelMessage, RegisteredScoop, ScoopTabState, ThinkingLevel } from './types.js';
@@ -101,7 +105,7 @@ export interface ScoopLifecycleDeps {
     appendResponseChunk(jid: string, chunk: string): void;
     setResponseFull(jid: string, text: string): void;
     notifyCompletion(jid: string): Promise<void> | void;
-    forgetScoop(jid: string, reason: string): void;
+    forgetScoop(jid: string, reason: 'unregister' | 'fatal-error' | 'close'): void;
     clearResponse(jid: string): void;
   };
   /** Persistent storage for scoop records. Threaded so tests can stub. */
@@ -172,34 +176,62 @@ export interface ScoopLifecycleDeps {
 }
 
 export class ScoopLifecycleManager {
-  private tabs: Map<string, ScoopTabState> = new Map();
-  private contexts: Map<string, ScoopContext> = new Map();
-  private scoopObservers: Map<string, Set<ScoopObserver>> = new Map();
+  /** One owning runtime per scoop jid (#1666). */
+  private units: Map<string, LiveWorkUnit> = new Map();
 
   constructor(private deps: ScoopLifecycleDeps) {}
 
-  /** Live contexts view. */
+  /** The live unit for `jid`, or `undefined` when none has been spawned or observed. */
+  getUnit(jid: string): LiveWorkUnit | undefined {
+    return this.units.get(jid);
+  }
+
+  /**
+   * Get-or-create the unit record for `jid`. A unit can exist before its
+   * context (an observer subscribed ahead of spawn, or a boot-time error
+   * tab) — it simply has no `context` / `tab` yet.
+   */
+  private ensureUnit(jid: string): LiveWorkUnit {
+    let unit = this.units.get(jid);
+    if (!unit || unit.isClosed) {
+      unit = new LiveWorkUnit(jid, {
+        getScoop: (j) => this.deps.getScoops().get(j),
+        sendPrompt: (j, text, senderId, senderName, options) =>
+          this.sendPrompt(j, text, senderId, senderName, [], options),
+        clearIdleTimer: (j) => this.deps.idleTimers.clear(j),
+        forgetCompletion: (j, reason) => this.deps.completionService.forgetScoop(j, reason),
+      });
+      this.units.set(jid, unit);
+    }
+    return unit;
+  }
+
+  /** Live contexts view (derived; read-only for callers). */
   getContexts(): Map<string, ScoopContext> {
-    return this.contexts;
+    const out = new Map<string, ScoopContext>();
+    for (const [jid, unit] of this.units) {
+      if (unit.context) out.set(jid, unit.context as ScoopContext);
+    }
+    return out;
   }
 
   /** Live context for a single jid (or `undefined`). */
   getContext(jid: string): ScoopContext | undefined {
-    return this.contexts.get(jid);
+    return (this.units.get(jid)?.context as ScoopContext | null | undefined) ?? undefined;
   }
 
   /** Synchronize live read ACLs after a global or per-scoop policy reload. */
   syncReadGrants(folder?: string): void {
     for (const scoop of this.deps.getScoops().values()) {
       if (scoop.isCone || (folder !== undefined && scoop.folder !== folder)) continue;
-      const fs = this.contexts.get(scoop.jid)?.getFS();
+      const fs = this.getContext(scoop.jid)?.getFS();
       this.applyPolicyReadGrants(scoop, fs);
     }
   }
 
   /** Live tab state for a single jid (or `undefined`). */
   getTab(jid: string): ScoopTabState | undefined {
-    return this.tabs.get(jid);
+    return this.units.get(jid)?.tab ?? undefined;
   }
 
   /**
@@ -208,18 +240,7 @@ export class ScoopLifecycleManager {
    * set holds strong references and leaks otherwise.
    */
   observe(jid: string, observer: ScoopObserver): () => void {
-    let set = this.scoopObservers.get(jid);
-    if (!set) {
-      set = new Set();
-      this.scoopObservers.set(jid, set);
-    }
-    set.add(observer);
-    return () => {
-      const s = this.scoopObservers.get(jid);
-      if (!s) return;
-      s.delete(observer);
-      if (s.size === 0) this.scoopObservers.delete(jid);
-    };
+    return this.ensureUnit(jid).observe(observer);
   }
 
   private dispatch<K extends keyof ScoopObserver>(
@@ -227,21 +248,7 @@ export class ScoopLifecycleManager {
     event: K,
     ...args: Parameters<NonNullable<ScoopObserver[K]>>
   ): void {
-    const observers = this.scoopObservers.get(jid);
-    if (!observers) return;
-    for (const o of observers) {
-      const handler = o[event];
-      if (!handler) continue;
-      try {
-        (handler as (...a: unknown[]) => void)(...(args as unknown[]));
-      } catch (err) {
-        log.warn('scoop observer threw', {
-          jid,
-          event,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    }
+    this.units.get(jid)?.dispatch(event, ...args);
   }
 
   /**
@@ -286,13 +293,11 @@ export class ScoopLifecycleManager {
     const scoop = this.deps.getScoops().get(jid);
     if (!scoop) throw new Error(`Scoop not found: ${jid}`);
 
-    if (this.contexts.has(jid)) {
-      const existingTab = this.tabs.get(jid);
-      if (existingTab?.status === 'error') {
+    const unit = this.ensureUnit(jid);
+    if (unit.context) {
+      if (unit.tab?.status === 'error') {
         log.info('Re-creating context after error', { jid });
-        this.contexts.get(jid)?.dispose();
-        this.contexts.delete(jid);
-        this.tabs.delete(jid);
+        unit.disposeContext();
       } else {
         log.debug('Context already exists', { jid });
         return;
@@ -341,20 +346,11 @@ export class ScoopLifecycleManager {
       this.deps.getSudoManager()
     );
 
-    this.contexts.set(jid, context);
-    this.tabs.set(jid, {
-      jid,
-      contextId,
-      status: 'initializing',
-      lastActivity: new Date().toISOString(),
-    });
+    unit.attachContext(context, contextId);
 
     await context.init();
 
-    const initTab = this.tabs.get(jid);
-    if (initTab && initTab.status === 'initializing') {
-      initTab.status = 'ready';
-      this.tabs.set(jid, initTab);
+    if (unit.tab?.status === 'initializing' && unit.transition('ready')) {
       this.deps.callbacks.onStatusChange(jid, 'ready');
       this.dispatch(jid, 'onStatusChange', 'ready');
       // Probe persisted messages when context init did not emit its own ready
@@ -380,32 +376,24 @@ export class ScoopLifecycleManager {
   /** Destroy a scoop context. */
   destroyTab(jid: string): void {
     this.deps.idleTimers.clear(jid);
-    const context = this.contexts.get(jid);
-    if (context) {
-      context.dispose();
-      this.contexts.delete(jid);
-      this.tabs.delete(jid);
-      // Drop any lingering per-scoop observers alongside the context so
-      // the shutdown / reset paths (which call us directly, bypassing
-      // `unregisterScoop`) also reclaim them.
-      this.scoopObservers.delete(jid);
-      log.info('Scoop context destroyed', { jid });
-    }
+    const unit = this.units.get(jid);
+    if (!unit) return;
+    // `close()` is the single teardown: stops the turn, disposes the context
+    // (realm workers + shell processes), drops observers and releases any
+    // `scoop_wait` caller. Shutdown / reset / rollback paths that bypass
+    // `unregister` reclaim everything the same way.
+    void unit.close();
+    this.units.delete(jid);
+    log.info('Scoop context destroyed', { jid });
   }
 
-  /** Drop the observer set for a scoop. Used by `unregisterScoop`. */
-  forgetObservers(jid: string): void {
-    this.scoopObservers.delete(jid);
-  }
-
-  /** Live tabs view; the message router reads through this. */
+  /** Live tabs view (derived; read-only for callers). */
   getTabsMap(): Map<string, ScoopTabState> {
-    return this.tabs;
-  }
-
-  /** Write back a tab record. Used by `sendPrompt` to flip `processing`. */
-  setTab(jid: string, tab: ScoopTabState): void {
-    this.tabs.set(jid, tab);
+    const out = new Map<string, ScoopTabState>();
+    for (const [jid, unit] of this.units) {
+      if (unit.tab) out.set(jid, unit.tab);
+    }
+    return out;
   }
 
   /**
@@ -417,13 +405,10 @@ export class ScoopLifecycleManager {
    * a silent no-tab (or stuck `'initializing'`) entry that can never recover.
    */
   markTabError(jid: string, message: string): void {
-    const existing = this.tabs.get(jid);
-    this.tabs.set(jid, {
-      jid,
-      contextId: existing?.contextId ?? `scoop-error-${jid}`,
-      status: 'error',
+    const unit = this.ensureUnit(jid);
+    unit.transition('error', {
+      contextId: unit.tab?.contextId ?? `scoop-error-${jid}`,
       error: message,
-      lastActivity: new Date().toISOString(),
     });
   }
 
@@ -443,16 +428,14 @@ export class ScoopLifecycleManager {
    * the new VFS is swapped in.
    */
   stopAndClearAllContexts(): void {
-    for (const [jid, ctx] of this.contexts.entries()) {
-      this.deps.idleTimers.clear(jid);
-      ctx.stop();
-      this.contexts.delete(jid);
+    for (const unit of this.units.values()) {
+      unit.detachContext();
     }
   }
 
   /** Destroy every live context. Used by `shutdown`. */
   async destroyAllTabs(): Promise<void> {
-    for (const jid of Array.from(this.contexts.keys())) {
+    for (const jid of Array.from(this.units.keys())) {
       this.destroyTab(jid);
     }
   }
@@ -461,7 +444,7 @@ export class ScoopLifecycleManager {
   private async waitForTabReady(jid: string, timeoutMs: number = 10000): Promise<boolean> {
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {
-      const tab = this.tabs.get(jid);
+      const tab = this.getTab(jid);
       if (!tab) return false;
       if (tab.status === 'ready' || tab.status === 'processing') return true;
       if (tab.status === 'error') return false;
@@ -484,26 +467,25 @@ export class ScoopLifecycleManager {
     images: ImageContent[] = [],
     options?: { steer?: boolean }
   ): Promise<void> {
-    let context = this.contexts.get(jid);
+    let context = this.getContext(jid);
 
     if (!context) {
       await this.createTab(jid);
-      context = this.contexts.get(jid);
+      context = this.getContext(jid);
     }
 
-    let tab = this.tabs.get(jid);
-    if (tab?.status === 'initializing') {
+    const unit = this.units.get(jid);
+    if (unit?.tab?.status === 'initializing') {
       log.debug('Context initializing, waiting to send message', { jid });
       const ready = await this.waitForTabReady(jid);
       if (!ready) {
         log.error('Context did not become ready in time, dropping prompt', { jid });
         return;
       }
-      context = this.contexts.get(jid);
-      tab = this.tabs.get(jid);
+      context = this.getContext(jid);
     }
 
-    if (!context) {
+    if (!context || !unit) {
       log.error('Context not found after creation', { jid });
       return;
     }
@@ -511,10 +493,7 @@ export class ScoopLifecycleManager {
     this.deps.idleTimers.clear(jid);
 
     this.deps.completionService.clearResponse(jid);
-    if (tab) {
-      tab.status = 'processing';
-      tab.lastActivity = new Date().toISOString();
-      this.tabs.set(jid, tab);
+    if (unit.tab && unit.transition('processing')) {
       this.deps.callbacks.onStatusChange(jid, 'processing');
       this.dispatch(jid, 'onStatusChange', 'processing');
     }
@@ -604,7 +583,6 @@ export class ScoopLifecycleManager {
       });
     }
 
-    this.deps.idleTimers.clear(jid);
     this.destroyTab(jid);
     this.deps
       .getSessionStore()
@@ -618,7 +596,6 @@ export class ScoopLifecycleManager {
     await this.deps.db.deleteScoop(jid);
     scoops.delete(jid);
     this.deps.messageRouter.forgetScoop(jid);
-    this.scoopObservers.delete(jid);
     this.deps.completionService.forgetScoop(jid, 'unregister');
     const sudoFailed = this.deps.approvalRouter.failScoop(jid);
     if (sudoFailed > 0) {
@@ -642,17 +619,18 @@ export class ScoopLifecycleManager {
 
   /** Update the model on every active scoop context. */
   updateModelOnAll(): void {
-    for (const context of this.contexts.values()) {
+    const contexts = this.getContexts();
+    for (const context of contexts.values()) {
       context.updateModel();
     }
-    log.info('Model updated on all active contexts', { contextCount: this.contexts.size });
+    log.info('Model updated on all active contexts', { contextCount: contexts.size });
   }
 
   /** Reload skills on every ready / processing scoop context. */
   async reloadAllSkills(): Promise<void> {
     const promises: Promise<void>[] = [];
-    for (const [jid, context] of this.contexts) {
-      const tab = this.tabs.get(jid);
+    for (const [jid, context] of this.getContexts()) {
+      const tab = this.getTab(jid);
       if (tab?.status === 'ready' || tab?.status === 'processing') {
         promises.push(
           context.reloadSkills().catch((err) => {
@@ -682,7 +660,7 @@ export class ScoopLifecycleManager {
     const scoop = this.deps.getScoops().get(jid);
     if (!scoop) return null;
 
-    const context = this.contexts.get(jid);
+    const context = this.getContext(jid);
     const applied = context ? context.setThinkingLevel(level, effortOverride) : null;
 
     // Persist the requested level (not the resolved/clamped one): on a
@@ -745,22 +723,13 @@ export class ScoopLifecycleManager {
         // Per-turn callback — DON'T set tab to 'ready' here.
         // The tab stays 'processing' until prompt() resolves (setStatus('ready') in finally).
         // This prevents the message queue from dequeuing during multi-turn.
-        const tab = this.tabs.get(jid);
-        if (tab) {
-          tab.lastActivity = new Date().toISOString();
-          this.tabs.set(jid, tab);
-        }
+        this.units.get(jid)?.touch();
         callbacks.onResponseDone(jid);
       },
       onError: (error) => {
         if (!scoops().has(jid)) return;
 
-        const tab = this.tabs.get(jid);
-        if (tab) {
-          tab.status = 'error';
-          tab.error = error;
-          this.tabs.set(jid, tab);
-        }
+        this.units.get(jid)?.transition('error', { error });
         emitScoopLifecycle('error', scoop.folder, error);
         callbacks.onError(jid, error);
         callbacks.onStatusChange(jid, 'error');
@@ -771,12 +740,7 @@ export class ScoopLifecycleManager {
       onStatusChange: (status) => {
         if (!scoops().has(jid)) return;
 
-        const tab = this.tabs.get(jid);
-        if (tab) {
-          tab.status = status;
-          tab.lastActivity = new Date().toISOString();
-          this.tabs.set(jid, tab);
-        }
+        this.units.get(jid)?.transition(status);
         callbacks.onStatusChange(jid, status);
         this.dispatch(jid, 'onStatusChange', status);
 
@@ -814,7 +778,7 @@ export class ScoopLifecycleManager {
         this.dispatch(jid, 'onSendMessage', text);
       },
       getScoops: () => cone.getScoops(),
-      getScoopTabState: scoop.isCone ? (j: string) => this.tabs.get(j) : undefined,
+      getScoopTabState: scoop.isCone ? (j: string) => this.getTab(j) : undefined,
       onFeedScoop: scoop.isCone
         ? (scoopJid, prompt) => cone.delegateToScoop(scoopJid, prompt, scoop.assistantLabel)
         : undefined,
@@ -874,12 +838,7 @@ export class ScoopLifecycleManager {
 
     emitScoopLifecycle('error', scoopRecord.folder, error);
 
-    const tab = this.tabs.get(jid);
-    if (tab) {
-      tab.status = 'error';
-      tab.error = error;
-      this.tabs.set(jid, tab);
-    }
+    this.units.get(jid)?.transition('error', { error });
     this.deps.callbacks.onError(jid, error);
     this.deps.callbacks.onStatusChange(jid, 'error');
     this.dispatch(jid, 'onError', error);

--- a/packages/webapp/src/scoops/scoop-message-router.ts
+++ b/packages/webapp/src/scoops/scoop-message-router.ts
@@ -589,8 +589,10 @@ export class ScoopMessageRouter {
     // DedicatedWorker contexts. The standalone runtime runs the orchestrator
     // in a worker; `window` is undefined there.
     this.pollInterval = setInterval(() => {
+      // `getTabs()` is a per-tick snapshot; read it once per tick, not per scoop.
+      const tabs = this.deps.getTabs();
       for (const jid of this.deps.getScoops().keys()) {
-        const tab = this.deps.getTabs().get(jid);
+        const tab = tabs.get(jid);
         this.recordBusyDeferralIfPresent(jid);
         const queueHasMessages = (this.messageQueues.get(jid)?.length ?? 0) > 0;
         if (tab?.status === 'ready' && queueHasMessages && !this.debounceStates.has(jid)) {

--- a/packages/webapp/src/work-unit/live-unit.ts
+++ b/packages/webapp/src/work-unit/live-unit.ts
@@ -1,0 +1,283 @@
+/**
+ * `LiveWorkUnit` — the owning runtime of one unit (#1666, Phase 2).
+ *
+ * Phase 1 shipped an adapter that *looked at* state scattered across the
+ * lifecycle manager's `tabs` / `contexts` / `scoopObservers` maps. This class
+ * *owns* that state for one unit: its `ScoopContext`, its tab record, its
+ * observer set and its lifecycle. `ScoopLifecycleManager` keeps a
+ * `Map<jid, LiveWorkUnit>` and every map-shaped view it still exposes
+ * (`getContexts()`, `getTabsMap()`) is derived from these units.
+ *
+ * The one thing this buys that the maps never had: `close()` is a single,
+ * idempotent teardown — idle timer, running turn, context (realm workers,
+ * shell processes), observers, completion buffers and waiters — so nothing
+ * about a dropped unit lingers in a global map.
+ *
+ * The unit knows nothing about the DOM, floats, the extension, or tray
+ * transports; everything external arrives through {@link LiveWorkUnitDeps}.
+ */
+
+import { createLogger } from '../base/logger.js';
+import type { ScoopObserver } from '../scoops/scoop-lifecycle-manager.js';
+import type { RegisteredScoop, ScoopTabState } from '../scoops/types.js';
+import { toDescriptor } from './descriptor.js';
+import type { WorkUnitRuntime } from './runtime.js';
+import {
+  statusFromTab,
+  type Unsubscribe,
+  type WorkUnitDescriptor,
+  type WorkUnitEventListener,
+  type WorkUnitId,
+  type WorkUnitInput,
+  type WorkUnitSnapshot,
+  type WorkUnitStatus,
+} from './types.js';
+
+const log = createLogger('work-unit');
+
+/** The slice of `ScoopContext` a unit drives. Structural so tests can stub it. */
+export interface UnitContext {
+  init(): Promise<void>;
+  stop(): void;
+  dispose(): void;
+  getAgentMessages(): unknown[];
+  getContextFill(): number;
+}
+
+export interface LiveWorkUnitDeps {
+  /** Registry record for this unit (`undefined` once unregistered). */
+  getScoop(jid: WorkUnitId): RegisteredScoop | undefined;
+  /** Deliver a prompt through the host's queue-aware send path. */
+  sendPrompt(
+    jid: WorkUnitId,
+    text: string,
+    senderId: string,
+    senderName: string,
+    options?: { steer?: boolean }
+  ): Promise<void>;
+  /** Disarm the "no work received yet" notifier. */
+  clearIdleTimer(jid: WorkUnitId): void;
+  /** Drop response buffers / mute state and release `scoop_wait` callers. */
+  forgetCompletion(jid: WorkUnitId, reason: 'close'): void;
+}
+
+/**
+ * Legal tab-status transitions. Keys are the current status, values the
+ * statuses it may move to. `closed` is modelled separately ({@link LiveWorkUnit.close})
+ * and is terminal. An illegal transition is logged and ignored so a stale
+ * callback from a disposed context can never resurrect a unit.
+ */
+export const LEGAL_TRANSITIONS: Readonly<
+  Record<ScoopTabState['status'], ReadonlySet<ScoopTabState['status']>>
+> = {
+  initializing: new Set(['ready', 'error']),
+  ready: new Set(['processing', 'error', 'initializing']),
+  processing: new Set(['ready', 'error']),
+  // `initializing` = a re-spawn after a failed init; `ready` = recovery
+  // paths that re-open the same context (`routeToScoop` retry-on-error).
+  error: new Set(['initializing', 'ready', 'processing']),
+};
+
+export class LiveWorkUnit implements WorkUnitRuntime {
+  /** Live tab record, or `null` while no runtime has been spawned. */
+  tab: ScoopTabState | null = null;
+  /** Live agent context, or `null` before spawn / after close / after detach. */
+  context: UnitContext | null = null;
+  private readonly observers = new Set<ScoopObserver>();
+  private closed = false;
+
+  constructor(
+    readonly id: WorkUnitId,
+    private readonly deps: LiveWorkUnitDeps
+  ) {}
+
+  // ---------------------------------------------------------------------
+  // Descriptor / status
+  // ---------------------------------------------------------------------
+
+  get descriptor(): WorkUnitDescriptor {
+    const scoop = this.deps.getScoop(this.id);
+    if (!scoop) throw new Error(`Work unit not found: ${this.id}`);
+    const descriptor = toDescriptor(scoop, this.tab ?? undefined);
+    return this.closed ? { ...descriptor, status: 'closed' } : descriptor;
+  }
+
+  get status(): WorkUnitStatus {
+    return this.closed ? 'closed' : statusFromTab(this.tab?.status);
+  }
+
+  get isClosed(): boolean {
+    return this.closed;
+  }
+
+  /**
+   * Move the tab to `next` if the transition is legal. Returns whether it
+   * happened. A unit without a tab accepts any first status (it is being
+   * spawned); a closed unit accepts none.
+   */
+  transition(next: ScoopTabState['status'], patch: Partial<ScoopTabState> = {}): boolean {
+    if (this.closed) {
+      log.debug('ignoring transition on closed unit', { jid: this.id, next });
+      return false;
+    }
+    const current = this.tab?.status;
+    if (current !== undefined && current !== next && !LEGAL_TRANSITIONS[current].has(next)) {
+      log.warn('illegal work-unit transition ignored', { jid: this.id, from: current, to: next });
+      return false;
+    }
+    const now = new Date().toISOString();
+    this.tab = {
+      jid: this.id,
+      contextId: this.tab?.contextId ?? `scoop-${this.id}`,
+      ...this.tab,
+      ...patch,
+      status: next,
+      lastActivity: patch.lastActivity ?? now,
+    };
+    if (next !== 'error') delete this.tab.error;
+    return true;
+  }
+
+  /** Record activity on the current status without changing it. */
+  touch(): void {
+    if (this.tab) this.tab = { ...this.tab, lastActivity: new Date().toISOString() };
+  }
+
+  // ---------------------------------------------------------------------
+  // Context ownership
+  // ---------------------------------------------------------------------
+
+  /**
+   * Adopt a freshly constructed context. The tab starts `initializing` under
+   * `contextId`; an error tab from an earlier failed spawn is replaced.
+   */
+  attachContext(context: UnitContext, contextId: string): void {
+    if (this.closed) throw new Error(`Cannot attach a context to closed unit ${this.id}`);
+    this.context = context;
+    this.tab = {
+      jid: this.id,
+      contextId,
+      status: 'initializing',
+      lastActivity: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Stop and forget the context WITHOUT disposing it or touching observers.
+   * Used when the shared filesystem is swapped underneath every unit
+   * (`resetFilesystem`): the contexts are rebuilt, the subscriptions are not.
+   */
+  detachContext(): void {
+    this.deps.clearIdleTimer(this.id);
+    this.context?.stop();
+    this.context = null;
+  }
+
+  /** Dispose the context and drop the tab, keeping observers. Used by re-spawn. */
+  disposeContext(): void {
+    this.deps.clearIdleTimer(this.id);
+    this.context?.dispose();
+    this.context = null;
+    this.tab = null;
+  }
+
+  // ---------------------------------------------------------------------
+  // Observers
+  // ---------------------------------------------------------------------
+
+  /** Raw observer subscription (the `ScoopObserver` shape `observeScoop` exposes). */
+  observe(observer: ScoopObserver): () => void {
+    if (this.closed) return () => {};
+    this.observers.add(observer);
+    return () => {
+      this.observers.delete(observer);
+    };
+  }
+
+  get observerCount(): number {
+    return this.observers.size;
+  }
+
+  /** Fan an observer event out; a throwing observer never breaks the others. */
+  dispatch<K extends keyof ScoopObserver>(
+    event: K,
+    ...args: Parameters<NonNullable<ScoopObserver[K]>>
+  ): void {
+    for (const observer of this.observers) {
+      const handler = observer[event];
+      if (!handler) continue;
+      try {
+        (handler as (...a: unknown[]) => void)(...(args as unknown[]));
+      } catch (err) {
+        log.warn('scoop observer threw', {
+          jid: this.id,
+          event,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // WorkUnitRuntime
+  // ---------------------------------------------------------------------
+
+  send(input: WorkUnitInput): Promise<void> {
+    if (this.closed) return Promise.reject(new Error(`Work unit is closed: ${this.id}`));
+    const scoop = this.deps.getScoop(this.id);
+    return this.deps.sendPrompt(
+      this.id,
+      input.text,
+      input.senderId ?? 'user',
+      input.senderName ?? scoop?.assistantLabel ?? this.id,
+      input.steer === undefined ? undefined : { steer: input.steer }
+    );
+  }
+
+  subscribe(listener: WorkUnitEventListener): Unsubscribe {
+    return this.observe({
+      onStatusChange: (status) => listener({ type: 'status', status: statusFromTab(status) }),
+      onResponse: (text, isPartial) => listener({ type: 'response', text, isPartial }),
+      onSendMessage: (text) => listener({ type: 'send-message', text }),
+      onError: (error) => listener({ type: 'error', error }),
+    });
+  }
+
+  async abort(_reason?: string): Promise<void> {
+    this.context?.stop();
+  }
+
+  /**
+   * The single teardown path. Idempotent. Order matters: disarm the idle
+   * timer first (so it cannot fire into a half-torn unit), stop the turn,
+   * dispose the context (realm workers + shell processes go with it), then
+   * release everyone waiting on this unit.
+   */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.deps.clearIdleTimer(this.id);
+    const context = this.context;
+    this.context = null;
+    try {
+      context?.stop();
+      context?.dispose();
+    } catch (err) {
+      log.warn('context dispose threw during close', {
+        jid: this.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    this.observers.clear();
+    this.deps.forgetCompletion(this.id, 'close');
+    log.info('Work unit closed', { jid: this.id });
+  }
+
+  async snapshot(): Promise<WorkUnitSnapshot> {
+    return {
+      descriptor: this.descriptor,
+      messages: this.context ? this.context.getAgentMessages() : [],
+      contextFill: this.context ? this.context.getContextFill() : 0,
+    };
+  }
+}

--- a/packages/webapp/src/work-unit/live-unit.ts
+++ b/packages/webapp/src/work-unit/live-unit.ts
@@ -8,10 +8,12 @@
  * `Map<jid, LiveWorkUnit>` and every map-shaped view it still exposes
  * (`getContexts()`, `getTabsMap()`) is derived from these units.
  *
- * The one thing this buys that the maps never had: `close()` is a single,
- * idempotent teardown — idle timer, running turn, context (realm workers,
- * shell processes), observers, completion buffers and waiters — so nothing
- * about a dropped unit lingers in a global map.
+ * The one thing this buys that the maps never had: `teardown()` is a single,
+ * idempotent runtime teardown — idle timer, running turn, context (realm
+ * workers, shell processes), observers, completion buffers and waiters — so
+ * nothing about a dropped unit lingers in a global map. `close()` keeps the
+ * `WorkUnitRuntime` contract: it unregisters through the host (which checks
+ * active licks, deletes the record, then ends in `teardown()`).
  *
  * The unit knows nothing about the DOM, floats, the extension, or tray
  * transports; everything external arrives through {@link LiveWorkUnitDeps}.
@@ -59,6 +61,11 @@ export interface LiveWorkUnitDeps {
   clearIdleTimer(jid: WorkUnitId): void;
   /** Drop response buffers / mute state and release `scoop_wait` callers. */
   forgetCompletion(jid: WorkUnitId, reason: 'close'): void;
+  /**
+   * Unregister the unit through the host's full path: rejects when active
+   * licks pin it, deletes the record, and ends in {@link LiveWorkUnit.teardown}.
+   */
+  unregister(jid: WorkUnitId): Promise<void>;
 }
 
 /**
@@ -248,12 +255,22 @@ export class LiveWorkUnit implements WorkUnitRuntime {
   }
 
   /**
-   * The single teardown path. Idempotent. Order matters: disarm the idle
-   * timer first (so it cannot fire into a half-torn unit), stop the turn,
-   * dispose the context (realm workers + shell processes go with it), then
-   * release everyone waiting on this unit.
+   * `WorkUnitRuntime.close()`: unregister and tear down. Routed through the
+   * host so the active-licks guard and record deletion apply exactly as
+   * they do for `drop_scoop`; the host ends in {@link teardown}.
    */
-  async close(): Promise<void> {
+  close(): Promise<void> {
+    if (this.closed) return Promise.resolve();
+    return this.deps.unregister(this.id);
+  }
+
+  /**
+   * The single runtime teardown path. Idempotent. Order matters: disarm the
+   * idle timer first (so it cannot fire into a half-torn unit), stop the
+   * turn, dispose the context (realm workers + shell processes go with it),
+   * then release everyone waiting on this unit.
+   */
+  async teardown(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
     this.deps.clearIdleTimer(this.id);

--- a/packages/webapp/src/work-unit/manager.ts
+++ b/packages/webapp/src/work-unit/manager.ts
@@ -47,7 +47,7 @@ export function buildWorkUnitRecord(
 }
 
 export class WorkUnitManager {
-  private readonly runtimes = new Map<WorkUnitId, ScoopContextWorkUnit>();
+  private readonly runtimes = new Map<WorkUnitId, WorkUnitRuntime>();
 
   constructor(private readonly host: WorkUnitManagerHost) {}
 
@@ -71,6 +71,13 @@ export class WorkUnitManager {
     if (!this.host.getScoop(id)) {
       this.runtimes.delete(id);
       return null;
+    }
+    // Prefer the owning live runtime; fall back to the read-through adapter
+    // for a record whose runtime has not been spawned yet.
+    const live = this.host.getLiveUnit?.(id);
+    if (live) {
+      this.runtimes.set(id, live);
+      return live;
     }
     let runtime = this.runtimes.get(id);
     if (!runtime) {

--- a/packages/webapp/src/work-unit/manager.ts
+++ b/packages/webapp/src/work-unit/manager.ts
@@ -73,12 +73,11 @@ export class WorkUnitManager {
       return null;
     }
     // Prefer the owning live runtime; fall back to the read-through adapter
-    // for a record whose runtime has not been spawned yet.
+    // for a record whose runtime has not been spawned yet. The live unit is
+    // deliberately NOT cached: once the host drops it (e.g. `destroyScoopTab`
+    // without unregister) a fresh adapter must take over, not a closed unit.
     const live = this.host.getLiveUnit?.(id);
-    if (live) {
-      this.runtimes.set(id, live);
-      return live;
-    }
+    if (live) return live;
     let runtime = this.runtimes.get(id);
     if (!runtime) {
       runtime = new ScoopContextWorkUnit(id, this.host);

--- a/packages/webapp/src/work-unit/runtime.ts
+++ b/packages/webapp/src/work-unit/runtime.ts
@@ -63,6 +63,8 @@ export interface WorkUnitHost {
         getContextFill(): number;
       }
     | undefined;
+  /** The owning live runtime for `jid` when one exists (Phase 2 hosts). */
+  getLiveUnit?(jid: WorkUnitId): WorkUnitRuntime | undefined;
 }
 
 /** Phase 1 adapter: a `WorkUnitRuntime` view over a registered scoop. */

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -1305,12 +1305,13 @@ describe('Orchestrator observer cleanup on scoop teardown', () => {
 
   interface OrchestratorObserverInternals {
     lifecycle: {
-      scoopObservers: Map<string, Set<unknown>>;
       dispatchEvent(jid: string, event: 'onSendMessage', text: string): void;
     };
   }
-  const observerSet = (o: Orchestrator) =>
-    (o as unknown as OrchestratorObserverInternals).lifecycle.scoopObservers;
+  // Observers are owned by the scoop's LiveWorkUnit (#1666 Phase 2); a
+  // closed unit reports zero and is dropped from the host.
+  const hasObservers = (o: Orchestrator, jid: string) =>
+    (o.getLiveUnit(jid)?.observerCount ?? 0) > 0;
   const dispatch = (o: Orchestrator, jid: string, ev: 'onSendMessage', text: string) =>
     (o as unknown as OrchestratorObserverInternals).lifecycle.dispatchEvent(jid, ev, text);
 
@@ -1343,11 +1344,11 @@ describe('Orchestrator observer cleanup on scoop teardown', () => {
     // on purpose.
     orch.observeScoop(scoop.jid, { onSendMessage: handler });
 
-    expect(observerSet(orch).has(scoop.jid)).toBe(true);
+    expect(hasObservers(orch, scoop.jid)).toBe(true);
 
     await orch.unregisterScoop(scoop.jid);
 
-    expect(observerSet(orch).has(scoop.jid)).toBe(false);
+    expect(hasObservers(orch, scoop.jid)).toBe(false);
 
     // A post-teardown dispatch must NOT reach the lingering handler.
     dispatch(orch, scoop.jid, 'onSendMessage', 'post-teardown text');
@@ -1416,11 +1417,11 @@ describe('Orchestrator observer cleanup on scoop teardown', () => {
     const handler = vi.fn();
     orch.observeScoop(scoop.jid, { onSendMessage: handler });
 
-    expect(observerSet(orch).has(scoop.jid)).toBe(true);
+    expect(hasObservers(orch, scoop.jid)).toBe(true);
 
     await orch.destroyScoopTab(scoop.jid);
 
-    expect(observerSet(orch).has(scoop.jid)).toBe(false);
+    expect(hasObservers(orch, scoop.jid)).toBe(false);
     dispatch(orch, scoop.jid, 'onSendMessage', 'post-teardown text');
     expect(handler).not.toHaveBeenCalled();
   });

--- a/packages/webapp/tests/work-unit/lifecycle.test.ts
+++ b/packages/webapp/tests/work-unit/lifecycle.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it, type Mock, vi } from 'vitest';
+import type { ScoopTabState } from '../../src/scoops/types.js';
+import {
+  LEGAL_TRANSITIONS,
+  LiveWorkUnit,
+  type LiveWorkUnitDeps,
+  type UnitContext,
+} from '../../src/work-unit/live-unit.js';
+import { runWorkUnitConformance } from './conformance.js';
+import { childRecord, rootRecord } from './fixtures.js';
+
+type Status = ScoopTabState['status'];
+const STATUSES: Status[] = ['initializing', 'ready', 'processing', 'error'];
+
+function makeDeps(records = [rootRecord(), childRecord('cone_1')]) {
+  const scoops = new Map(records.map((r) => [r.jid, r]));
+  const deps: LiveWorkUnitDeps & {
+    sendPrompt: ReturnType<typeof vi.fn<LiveWorkUnitDeps['sendPrompt']>>;
+    clearIdleTimer: ReturnType<typeof vi.fn<LiveWorkUnitDeps['clearIdleTimer']>>;
+    forgetCompletion: ReturnType<typeof vi.fn<LiveWorkUnitDeps['forgetCompletion']>>;
+  } = {
+    getScoop: (jid) => scoops.get(jid),
+    sendPrompt: vi.fn(async () => {}),
+    clearIdleTimer: vi.fn(),
+    forgetCompletion: vi.fn(),
+  };
+  return { deps, scoops };
+}
+
+function makeContext(): UnitContext & { stop: Mock<() => void>; dispose: Mock<() => void> } {
+  return {
+    init: vi.fn(async () => {}),
+    stop: vi.fn(),
+    dispose: vi.fn(),
+    getAgentMessages: vi.fn(() => [{ role: 'user', content: 'hi' }]),
+    getContextFill: vi.fn(() => 0.5),
+  };
+}
+
+describe('LiveWorkUnit state machine', () => {
+  it('starts as creating with no tab and no context', () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('scoop_worker-scoop_1', deps);
+    expect(unit.tab).toBeNull();
+    expect(unit.context).toBeNull();
+    expect(unit.status).toBe('creating');
+    expect(unit.descriptor.status).toBe('creating');
+  });
+
+  it('accepts any first status on a unit without a tab', () => {
+    for (const status of STATUSES) {
+      const { deps } = makeDeps();
+      const unit = new LiveWorkUnit('cone_1', deps);
+      expect(unit.transition(status)).toBe(true);
+      expect(unit.tab?.status).toBe(status);
+      expect(unit.tab?.jid).toBe('cone_1');
+    }
+  });
+
+  it('applies exactly the legal transition table', () => {
+    for (const from of STATUSES) {
+      for (const to of STATUSES) {
+        const { deps } = makeDeps();
+        const unit = new LiveWorkUnit('cone_1', deps);
+        unit.transition(from);
+        const ok = unit.transition(to);
+        const expected = from === to || LEGAL_TRANSITIONS[from].has(to);
+        expect(ok, `${from} → ${to}`).toBe(expected);
+        expect(unit.tab?.status, `${from} → ${to}`).toBe(expected ? to : from);
+      }
+    }
+  });
+
+  it('encodes the lifecycle the runtime relies on', () => {
+    // creating → ready ⇄ running; any → failed; failed → re-spawn / recover
+    expect(LEGAL_TRANSITIONS.initializing.has('ready')).toBe(true);
+    expect(LEGAL_TRANSITIONS.ready.has('processing')).toBe(true);
+    expect(LEGAL_TRANSITIONS.processing.has('ready')).toBe(true);
+    for (const from of STATUSES) {
+      if (from !== 'error') expect(LEGAL_TRANSITIONS[from].has('error')).toBe(true);
+    }
+    expect(LEGAL_TRANSITIONS.error.has('initializing')).toBe(true);
+    // a running turn cannot jump back to initializing
+    expect(LEGAL_TRANSITIONS.processing.has('initializing')).toBe(false);
+  });
+
+  it('clears a stale error message when leaving error', () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('cone_1', deps);
+    unit.transition('error', { error: 'boom' });
+    expect(unit.tab?.error).toBe('boom');
+    unit.transition('ready');
+    expect(unit.tab?.error).toBeUndefined();
+  });
+
+  it('maps tab status onto the descriptor lifecycle', () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('cone_1', deps);
+    unit.transition('initializing');
+    expect(unit.status).toBe('creating');
+    unit.transition('ready');
+    expect(unit.status).toBe('ready');
+    unit.transition('processing');
+    expect(unit.status).toBe('running');
+    unit.transition('error');
+    expect(unit.status).toBe('failed');
+  });
+
+  it('touch updates lastActivity without changing status', async () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('cone_1', deps);
+    unit.transition('ready', { lastActivity: '2020-01-01T00:00:00.000Z' });
+    unit.touch();
+    expect(unit.tab?.status).toBe('ready');
+    expect(unit.tab?.lastActivity).not.toBe('2020-01-01T00:00:00.000Z');
+  });
+});
+
+describe('LiveWorkUnit context ownership', () => {
+  it('attachContext starts the tab initializing under the given contextId', () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('cone_1', deps);
+    const ctx = makeContext();
+    unit.attachContext(ctx, 'ctx-1');
+    expect(unit.context).toBe(ctx);
+    expect(unit.tab).toMatchObject({ jid: 'cone_1', contextId: 'ctx-1', status: 'initializing' });
+  });
+
+  it('disposeContext disposes and drops the tab but keeps observers (re-spawn)', () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('cone_1', deps);
+    const ctx = makeContext();
+    unit.attachContext(ctx, 'ctx-1');
+    const seen: string[] = [];
+    unit.observe({ onStatusChange: (s) => seen.push(s) });
+    unit.transition('error', { error: 'init failed' });
+
+    unit.disposeContext();
+    expect(ctx.dispose).toHaveBeenCalledOnce();
+    expect(deps.clearIdleTimer).toHaveBeenCalledWith('cone_1');
+    expect(unit.context).toBeNull();
+    expect(unit.tab).toBeNull();
+    expect(unit.observerCount).toBe(1);
+
+    const fresh = makeContext();
+    unit.attachContext(fresh, 'ctx-2');
+    unit.transition('ready');
+    unit.dispatch('onStatusChange', 'ready');
+    expect(seen).toEqual(['ready']);
+  });
+
+  it('detachContext stops without disposing and keeps the tab (filesystem reset)', () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('cone_1', deps);
+    const ctx = makeContext();
+    unit.attachContext(ctx, 'ctx-1');
+    unit.transition('ready');
+    unit.detachContext();
+    expect(ctx.stop).toHaveBeenCalledOnce();
+    expect(ctx.dispose).not.toHaveBeenCalled();
+    expect(unit.context).toBeNull();
+    expect(unit.tab?.status).toBe('ready');
+    expect(unit.isClosed).toBe(false);
+  });
+});
+
+describe('LiveWorkUnit.close() is the single teardown', () => {
+  it('tears down idle timer, turn, context, observers and completion state in order', async () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('scoop_worker-scoop_1', deps);
+    const ctx = makeContext();
+    unit.attachContext(ctx, 'ctx-1');
+    unit.transition('processing');
+    const events: string[] = [];
+    unit.observe({ onStatusChange: (s) => events.push(s) });
+
+    const order: string[] = [];
+    deps.clearIdleTimer.mockImplementation(() => order.push('idle'));
+    ctx.stop.mockImplementation(() => order.push('stop'));
+    ctx.dispose.mockImplementation(() => order.push('dispose'));
+    deps.forgetCompletion.mockImplementation(() => order.push('forget'));
+
+    await unit.close();
+
+    expect(order).toEqual(['idle', 'stop', 'dispose', 'forget']);
+    expect(deps.forgetCompletion).toHaveBeenCalledWith('scoop_worker-scoop_1', 'close');
+    expect(unit.context).toBeNull();
+    expect(unit.observerCount).toBe(0);
+    expect(unit.isClosed).toBe(true);
+    expect(unit.status).toBe('closed');
+    expect(unit.descriptor.status).toBe('closed');
+
+    // nothing reaches a closed unit
+    unit.dispatch('onStatusChange', 'ready');
+    expect(events).toEqual([]);
+    expect(unit.transition('ready')).toBe(false);
+    expect(unit.observe({})).toBeTypeOf('function');
+    expect(unit.observerCount).toBe(0);
+    await expect(unit.send({ text: 'x' })).rejects.toThrow(/closed/);
+    expect(() => unit.attachContext(makeContext(), 'ctx-2')).toThrow(/closed/);
+  });
+
+  it('is idempotent and survives a throwing dispose', async () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('cone_1', deps);
+    const ctx = makeContext();
+    ctx.dispose.mockImplementation(() => {
+      throw new Error('dispose exploded');
+    });
+    unit.attachContext(ctx, 'ctx-1');
+    await expect(unit.close()).resolves.toBeUndefined();
+    await unit.close();
+    expect(ctx.dispose).toHaveBeenCalledOnce();
+    expect(deps.forgetCompletion).toHaveBeenCalledOnce();
+  });
+
+  it('closes cleanly when no context was ever attached', async () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('cone_1', deps);
+    await unit.close();
+    expect(unit.isClosed).toBe(true);
+    expect(deps.clearIdleTimer).toHaveBeenCalledWith('cone_1');
+    expect(deps.forgetCompletion).toHaveBeenCalledWith('cone_1', 'close');
+  });
+});
+
+describe('LiveWorkUnit runtime surface', () => {
+  it('send routes through the host with sender defaults and steer passthrough', async () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('scoop_worker-scoop_1', deps);
+    await unit.send({ text: 'go' });
+    expect(deps.sendPrompt).toHaveBeenLastCalledWith(
+      'scoop_worker-scoop_1',
+      'go',
+      'user',
+      'worker-scoop',
+      undefined
+    );
+    await unit.send({ text: 'now', senderId: 'cone', senderName: 'sliccy', steer: true });
+    expect(deps.sendPrompt).toHaveBeenLastCalledWith(
+      'scoop_worker-scoop_1',
+      'now',
+      'cone',
+      'sliccy',
+      {
+        steer: true,
+      }
+    );
+  });
+
+  it('abort stops the running context only', async () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('cone_1', deps);
+    await unit.abort();
+    const ctx = makeContext();
+    unit.attachContext(ctx, 'ctx-1');
+    await unit.abort('user');
+    expect(ctx.stop).toHaveBeenCalledOnce();
+    expect(ctx.dispose).not.toHaveBeenCalled();
+    expect(unit.isClosed).toBe(false);
+  });
+
+  it('snapshot reflects the live context', async () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('cone_1', deps);
+    expect(await unit.snapshot()).toMatchObject({ messages: [], contextFill: 0 });
+    unit.attachContext(makeContext(), 'ctx-1');
+    const snap = await unit.snapshot();
+    expect(snap.messages).toEqual([{ role: 'user', content: 'hi' }]);
+    expect(snap.contextFill).toBe(0.5);
+  });
+
+  it('a throwing observer does not break the others', () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('cone_1', deps);
+    const seen: string[] = [];
+    unit.observe({
+      onResponse: () => {
+        throw new Error('observer bug');
+      },
+    });
+    unit.observe({ onResponse: (t) => seen.push(t) });
+    unit.dispatch('onResponse', 'hello', false);
+    expect(seen).toEqual(['hello']);
+  });
+
+  it('throws a descriptor for an unregistered id', () => {
+    const { deps } = makeDeps([]);
+    const unit = new LiveWorkUnit('ghost', deps);
+    expect(() => unit.descriptor).toThrow(/Work unit not found/);
+  });
+
+  runWorkUnitConformance('LiveWorkUnit (Phase 2 owner)', () => {
+    const { deps } = makeDeps();
+    const root = new LiveWorkUnit('cone_1', deps);
+    const child = new LiveWorkUnit('scoop_worker-scoop_1', deps);
+    const units = new Map([
+      [root.id, root],
+      [child.id, child],
+    ]);
+    return {
+      root,
+      child,
+      emitStatus: (id, status) => {
+        const unit = units.get(id)!;
+        unit.transition(status);
+        unit.dispatch('onStatusChange', status);
+      },
+    };
+  });
+});

--- a/packages/webapp/tests/work-unit/lifecycle.test.ts
+++ b/packages/webapp/tests/work-unit/lifecycle.test.ts
@@ -18,11 +18,13 @@ function makeDeps(records = [rootRecord(), childRecord('cone_1')]) {
     sendPrompt: ReturnType<typeof vi.fn<LiveWorkUnitDeps['sendPrompt']>>;
     clearIdleTimer: ReturnType<typeof vi.fn<LiveWorkUnitDeps['clearIdleTimer']>>;
     forgetCompletion: ReturnType<typeof vi.fn<LiveWorkUnitDeps['forgetCompletion']>>;
+    unregister: ReturnType<typeof vi.fn<LiveWorkUnitDeps['unregister']>>;
   } = {
     getScoop: (jid) => scoops.get(jid),
     sendPrompt: vi.fn(async () => {}),
     clearIdleTimer: vi.fn(),
     forgetCompletion: vi.fn(),
+    unregister: vi.fn(async () => {}),
   };
   return { deps, scoops };
 }
@@ -164,7 +166,30 @@ describe('LiveWorkUnit context ownership', () => {
   });
 });
 
-describe('LiveWorkUnit.close() is the single teardown', () => {
+describe('LiveWorkUnit.close() unregisters through the host', () => {
+  it('routes to deps.unregister so the active-licks guard and record deletion apply', async () => {
+    const { deps } = makeDeps();
+    const unit = new LiveWorkUnit('scoop_worker-scoop_1', deps);
+    unit.attachContext(makeContext(), 'ctx-1');
+    await unit.close();
+    expect(deps.unregister).toHaveBeenCalledWith('scoop_worker-scoop_1');
+    // teardown itself is the host's job (it ends in `teardown()`); close()
+    // alone must not half-drop the unit.
+    expect(unit.isClosed).toBe(false);
+  });
+
+  it('propagates the active-licks rejection unchanged and is a no-op once torn down', async () => {
+    const { deps } = makeDeps();
+    deps.unregister.mockRejectedValueOnce(new Error('has active licks'));
+    const unit = new LiveWorkUnit('scoop_worker-scoop_1', deps);
+    await expect(unit.close()).rejects.toThrow('has active licks');
+    await unit.teardown();
+    await unit.close();
+    expect(deps.unregister).toHaveBeenCalledOnce();
+  });
+});
+
+describe('LiveWorkUnit.teardown() is the single runtime teardown', () => {
   it('tears down idle timer, turn, context, observers and completion state in order', async () => {
     const { deps } = makeDeps();
     const unit = new LiveWorkUnit('scoop_worker-scoop_1', deps);
@@ -180,7 +205,7 @@ describe('LiveWorkUnit.close() is the single teardown', () => {
     ctx.dispose.mockImplementation(() => order.push('dispose'));
     deps.forgetCompletion.mockImplementation(() => order.push('forget'));
 
-    await unit.close();
+    await unit.teardown();
 
     expect(order).toEqual(['idle', 'stop', 'dispose', 'forget']);
     expect(deps.forgetCompletion).toHaveBeenCalledWith('scoop_worker-scoop_1', 'close');
@@ -208,8 +233,8 @@ describe('LiveWorkUnit.close() is the single teardown', () => {
       throw new Error('dispose exploded');
     });
     unit.attachContext(ctx, 'ctx-1');
-    await expect(unit.close()).resolves.toBeUndefined();
-    await unit.close();
+    await expect(unit.teardown()).resolves.toBeUndefined();
+    await unit.teardown();
     expect(ctx.dispose).toHaveBeenCalledOnce();
     expect(deps.forgetCompletion).toHaveBeenCalledOnce();
   });
@@ -217,7 +242,7 @@ describe('LiveWorkUnit.close() is the single teardown', () => {
   it('closes cleanly when no context was ever attached', async () => {
     const { deps } = makeDeps();
     const unit = new LiveWorkUnit('cone_1', deps);
-    await unit.close();
+    await unit.teardown();
     expect(unit.isClosed).toBe(true);
     expect(deps.clearIdleTimer).toHaveBeenCalledWith('cone_1');
     expect(deps.forgetCompletion).toHaveBeenCalledWith('cone_1', 'close');


### PR DESCRIPTION
Stacked on #2252 (merge that first). Part of #1666 — phase 2 of 3; does not close it.

## Summary

`ScoopLifecycleManager` now hosts one `LiveWorkUnit` per scoop. Each unit owns its `ScoopContext`, tab record and observer set; the `tabs` / `contexts` / `scoopObservers` maps are gone and `getContexts()` / `getTabsMap()` are derived read-only views for the message router, cost tracker and idle timers.

- `LiveWorkUnit.transition()` applies an explicit legal-transition table; illegal moves and anything on a closed unit are logged and ignored, so a stale callback from a disposed context cannot resurrect a unit.
- `LiveWorkUnit.close()` is the single, idempotent teardown (idle timer → stop turn → dispose context → drop observers → release `scoop_wait` callers). `destroyTab` and `unregister` both end in it.
- `detachContext()` (filesystem reset) and `disposeContext()` (re-spawn after a failed init) keep observers alive across a context swap.
- `WorkUnitManager.get()` returns the live unit when the host has one (`Orchestrator.getLiveUnit`), else the Phase 1 read-through adapter; the conformance suite runs against both.

No tool, UI, wire or persistence behaviour changes.

## Why

#1666 names "lifecycle is not atomic" as a core problem: dropping a scoop had to coordinate `destroyTab`, `forgetObservers`, `completionService.forgetScoop`, `idleTimers.clear` and `stopScoop` from several call sites, and the three maps could disagree. One owner per unit with one `close()` is what lets Phase 3 route on hierarchy/policy without leaking state.

## Test plan
- [x] `tests/work-unit/lifecycle.test.ts`: full transition matrix, teardown order, idempotent/throwing-dispose close, detach vs dispose, conformance against `LiveWorkUnit`
- [x] `orchestrator.test.ts` observer-leak tests now assert through the public `getLiveUnit(jid)?.observerCount`
- [x] tsc (4 projects), full vitest suite, webapp coverage gate (lines 82.5 / statements 80.45 / functions 80.72 / branches 71.55), biome, prettier, lint:docs, layer / record-bag / boy-scout gates, webapp + extension builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
