### PR TITLE
feat(webapp): tabbed session-sharing dialog + floatbar followers segment

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -342,7 +342,6 @@
         "packages/webapp/src/providers/intercepted-oauth.ts",
         "packages/webapp/src/scoops/scheduler.ts",
         "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts",
-        "packages/webapp/src/ui/wc/wc-nav.ts",
         "packages/webapp/tests/cdp/cdp-client.test.ts",
         "packages/webapp/tests/cdp/preview-bridge-cdp-transport.test.ts",
         "packages/webapp/tests/fs/internal-mount.test.ts",

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -278,7 +278,7 @@ host
 # join_url exposes the tray join capability directly when a session exists
 
 # Follow another browser's tray as a follower. Paste the https://…/join/<token>
-# URL the leader shows under "Copy tray join URL". Works in both the
+# join link the leader shows in its Session sharing dialog. Works in both the
 # standalone and extension floats — in the extension this is the only way to
 # follow a leader, since the WC UI dropped the join field. The follower
 # connects asynchronously; run `host` afterwards to check the status.

--- a/docs/webapp-details.md
+++ b/docs/webapp-details.md
@@ -58,6 +58,14 @@ Overflow from `packages/webapp/CLAUDE.md`. Each section is the deep reference fo
 
 Modules in `scoops/`: `tray-leader-sync.ts` (façade + lifecycle), `context.ts`, `follower-registry.ts`, `follower-dispatch.ts`, `broadcast.ts`, `cdp-router.ts`, `fs-router.ts`, `tab-router.ts`, `remote-exec.ts`, `transcript-export.ts` (streaming), `preview-bridge.ts`, `cherry-router.ts`, `teleport-pool.ts`. Follower model/thinking pills share `ui/wc/wc-follower-model-surface.ts`; `wc-follower.ts` mount and `wc-tray.ts`'s `slicc:tray-join` role switch both consume it. Cherry gated by `CherryFeatureSet.modelPicker`. See `docs/architecture.md` "Multi-Browser Sync (Tray) Architecture".
 
+### Session sharing surfaces (join link + followers)
+
+One roster, three renderings, one vocabulary — `ui/follower-presentation.ts` owns what a follower is called, its icon, its capability chips (`exec` → "can run commands", `cdp` → "hosts tabs") and its `connected 4m` state string. Consumers: the Monitor panel's Followers section (`wc/wc-monitor.ts`), the floatbar hover HUD, and the sync dialog's Status tab. `ssh --list` / `host` keep their own terser text output.
+
+- **`ui/sync-dialog.ts`** — the "Session sharing" dialog, reached from the avatar menu (**Enable multi-browser sync**, which also copies) and from the floatbar. Tabs come from the DOM-free `ui/sync-dialog-model.ts`: Browser · iPhone · Terminal, with **Status** prepended (and defaulted to) the moment a follower is attached. The join link is masked to `…/join/••••••••` until **Show** — it is a bearer secret, so it is never rendered by default and never sent anywhere for rendering (this is why there is no hosted-QR option). Revoke is two clicks: the first arms and names the blast radius.
+- **Floatbar followers segment** (`slicc-floatbar`'s `followers` property → `slicc-follower-hud`): the count used to be smuggled into the `label` string; it is now a real `<button>` with a `follower-count` reflection. Hover/focus opens the read-only HUD (same 150 ms grace as the cost overlay), click emits `slicc-followers-click` → the dialog on its Status tab. **Opening from the floatbar must never write the clipboard** — only the avatar-menu path copies.
+- **`FOLLOWERS_CHANGED_EVENT`** (`slicc:followers-changed`) — `wc/wc-tray.ts`'s `applyFollowerPresentation` is the single producer, on every follower-count change. An open dialog re-renders from it, so the Status tab appears live without polling the roster.
+
 ## Feature Flags
 
 - Add IDs to `FeatureFlagId`/`FEATURE_FLAGS` in `core/feature-flags.ts` and both `wrangler.jsonc` `FEATURE_FLAGS` lists. User-toggleable flags live in the standalone **Experimental features…** avatar dialog (`listFlags()`), not Account settings.

--- a/packages/ios-app/SliccFollower/Views/SettingsView.swift
+++ b/packages/ios-app/SliccFollower/Views/SettingsView.swift
@@ -252,7 +252,7 @@ struct SettingsView: View {
     private var connectionSection: some View {
         Section {
             HStack {
-                TextField("Join URL", text: $appState.joinUrl)
+                TextField("Join link", text: $appState.joinUrl)
                     .textContentType(.URL)
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
@@ -272,7 +272,7 @@ struct SettingsView: View {
         } header: {
             Text("Connection")
         } footer: {
-            Text("Connect to a Sliccy session with its Join URL.")
+            Text("Connect to a Sliccy session with its join link.")
         }
     }
 
@@ -332,7 +332,7 @@ struct SettingsView: View {
         case .failed, .gaveUp:
             HStack(spacing: 8) {
                 Circle().fill(.red).frame(width: 8, height: 8)
-                Text(appState.lastError ?? "Couldn't connect. Check the Join URL and try again.")
+                Text(appState.lastError ?? "Couldn't connect. Check the join link and try again.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
@@ -355,22 +355,22 @@ struct SettingsView: View {
                 )
                 joinUrlStep(
                     number: 2,
-                    text: "Click your avatar in the top-right corner and choose **Enable multi-browser sync** — the Join URL is copied to your clipboard."
+                    text: "Click your avatar in the top-right corner and choose **Enable multi-browser sync** — the join link is copied to your clipboard."
                 )
                 joinUrlStep(
                     number: 3,
-                    text: "On the latest version you can also ask the agent: _“Run host for me and give me the tray join URL.”_"
+                    text: "On the latest version you can also ask the agent: _“Run host for me and give me the tray join link.”_"
                 )
                 joinUrlStep(
                     number: 4,
-                    text: "Paste the URL into the **Join URL** field above. Both sides must be on the same Sliccy version."
+                    text: "Paste it into the **Join link** field above. Both sides must be on the same Sliccy version."
                 )
             }
             .padding(.vertical, 4)
             .font(.footnote)
             .foregroundStyle(.secondary)
         } label: {
-            Label("How do I get a Join URL?", systemImage: "questionmark.circle")
+            Label("How do I get a join link?", systemImage: "questionmark.circle")
                 .font(.subheadline)
         }
     }

--- a/packages/ios-app/SliccFollower/Views/TabsCarouselView.swift
+++ b/packages/ios-app/SliccFollower/Views/TabsCarouselView.swift
@@ -319,7 +319,7 @@ struct TabsCarouselView: View {
             Text(
                 canControlTabs
                     ? "Tabs you open live on this device — and the leader can drive them over the CDP bridge."
-                    : "Connect to a leader (Settings → Join URL) to host browser tabs here."
+                    : "Connect to a leader (Settings → Join link) to host browser tabs here."
             )
             .font(.caption)
             .foregroundStyle(.secondary)

--- a/packages/slicc-cli/README.md
+++ b/packages/slicc-cli/README.md
@@ -22,8 +22,10 @@ slicc update [--check]                          Self-update to the newest releas
 `watch` is read-only: it prints the leader's agent output as it streams (a
 `tail -f` on what the cone is doing) and sends nothing back.
 
-`<join-url>` is a leader's `https://…/join/<token>` link (from the leader's
-"Copy tray join URL", or its `host` command's `join_url`).
+`<join-url>` is a leader's `https://…/join/<token>` link — the join link. Get it
+from the leader's avatar menu → **Enable multi-browser sync** → the **Terminal**
+tab of the Session sharing dialog, which hands you this whole command
+ready to paste; or from its `host` command's `join_url`.
 
 The `<text>`/`<command>` is curl-style — a literal string, `@path` (read a file),
 or `-` / `@-` (read stdin):

--- a/packages/webapp/src/ui/follower-presentation.ts
+++ b/packages/webapp/src/ui/follower-presentation.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared presentation vocabulary for connected tray followers — the single
+ * place that decides what a follower is CALLED, which icon it gets, and how
+ * its connection state reads.
+ *
+ * Three surfaces render the same roster and must agree: the Monitor panel's
+ * Followers section (`wc/wc-monitor.ts`, where these helpers originally
+ * lived), the floatbar's hover HUD, and the sync dialog's Status tab. The
+ * `ssh --list` / `host` text output is the fourth, deliberately-terser view.
+ *
+ * Pure and DOM-free so the copy is unit-testable; `elapsedSince` takes an
+ * explicit `now` so tests don't race the clock.
+ */
+
+import type { FollowerHudRow } from '@slicc/webcomponents';
+import type { ConnectedFollowerInfo } from '../shell/supplemental-commands/host-command.js';
+
+/**
+ * Window event the leader float dispatches whenever its follower roster
+ * changes (`wc/wc-tray.ts` is the only producer). The floatbar reads the
+ * roster directly; the sync dialog listens so its Status tab appears — and
+ * its rows go live — while it is open.
+ */
+export const FOLLOWERS_CHANGED_EVENT = 'slicc:followers-changed';
+
+/** `follower-a1b2c3d4e5f6` → `a1b2c3d4…`; short enough for a pill, long enough to tell two apart. */
+export function shortFollowerId(runtimeId: string): string {
+  const unprefixed = runtimeId.replace(/^follower-/, '');
+  return unprefixed.length > 12 ? `${unprefixed.slice(0, 8)}…` : unprefixed;
+}
+
+/**
+ * Human name for the follower kind. `deriveFloatType` only knows the four
+ * browser-ish runtimes, so a `slicc-cli` follower arrives as `unknown` and is
+ * recognised from its runtime tag instead.
+ */
+export function followerTypeLabel(follower: ConnectedFollowerInfo): string {
+  if (follower.floatType === 'ios') return 'iOS';
+  if (follower.floatType === 'electron') return 'Electron';
+  if (follower.floatType === 'extension') return 'Extension';
+  if (follower.floatType === 'standalone') return 'Standalone';
+  return follower.runtime?.includes('cli') ? 'CLI' : 'Follower';
+}
+
+/** Lucide icon name for the follower kind. */
+export function followerIcon(follower: ConnectedFollowerInfo): string {
+  if (follower.floatType === 'ios') return 'smartphone';
+  if (follower.floatType === 'electron' || follower.floatType === 'standalone') return 'monitor';
+  if (follower.floatType === 'extension') return 'blocks';
+  return follower.runtime?.includes('cli') ? 'terminal' : 'radio';
+}
+
+/** `4m` / `2h` / `3d` since `connectedAt`, or `null` when it wasn't reported. */
+export function elapsedSince(connectedAt?: string, now: number = Date.now()): string | null {
+  if (!connectedAt) return null;
+  const timestamp = new Date(connectedAt).getTime();
+  if (!Number.isFinite(timestamp)) return null;
+  const seconds = Math.max(0, Math.floor((now - timestamp) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86_400)}d`;
+}
+
+/** Dot color bucket: live, stalled, or still handshaking. */
+export function followerStatus(follower: ConnectedFollowerInfo): 'active' | 'warn' | 'idle' {
+  if (follower.health === 'stalled') return 'warn';
+  if (follower.peerState === 'connecting') return 'idle';
+  if (follower.peerState === 'connected' && follower.health === 'live') return 'active';
+  return 'idle';
+}
+
+/** `connected 4m` / `stalled 12m` / `connecting`. */
+export function followerMeta(follower: ConnectedFollowerInfo, now: number = Date.now()): string {
+  const state =
+    follower.health === 'stalled'
+      ? 'stalled'
+      : follower.peerState === 'connecting'
+        ? 'connecting'
+        : 'connected';
+  const age = elapsedSince(follower.connectedAt, now);
+  return age ? `${state} ${age}` : state;
+}
+
+/**
+ * What this follower is allowed to do, in the user's words rather than the
+ * tool's. `exec` is the one that matters for consent — a `slicc … follow
+ * bash -c` follower is remote code execution by design — so it leads.
+ */
+export function followerCapabilities(follower: ConnectedFollowerInfo): string[] {
+  const chips: string[] = [];
+  if (follower.exec) chips.push('can run commands');
+  if (follower.cdp) chips.push('hosts tabs');
+  return chips;
+}
+
+/** Full display name: `iOS · phone-a1b2c3`. */
+export function followerTitle(follower: ConnectedFollowerInfo): string {
+  return `${followerTypeLabel(follower)} · ${shortFollowerId(follower.runtimeId)}`;
+}
+
+/** Secondary line: the follower's advertised MOTD, else its runtime tag. */
+export function followerDetail(follower: ConnectedFollowerInfo): string | undefined {
+  return follower.motd ?? follower.runtime ?? undefined;
+}
+
+/** Map the leader's roster onto the presentational rows the HUD renders. */
+export function toFollowerHudRows(
+  followers: ConnectedFollowerInfo[],
+  now: number = Date.now()
+): FollowerHudRow[] {
+  return followers.map((follower) => ({
+    id: follower.runtimeId,
+    icon: followerIcon(follower),
+    title: followerTitle(follower),
+    detail: followerDetail(follower),
+    state: followerStatus(follower),
+    stateText: followerMeta(follower, now),
+    chips: followerCapabilities(follower),
+  }));
+}

--- a/packages/webapp/src/ui/sync-dialog-model.ts
+++ b/packages/webapp/src/ui/sync-dialog-model.ts
@@ -8,6 +8,8 @@
  * by a unit test, the same way `tray-join-url.ts` covers the avatar popover.
  */
 
+import { SLICC_HOSTED_ORIGIN } from '@slicc/shared-ts';
+
 export type SyncDialogTabId = 'status' | 'browser' | 'iphone' | 'terminal';
 
 export interface SyncDialogTab {
@@ -70,6 +72,34 @@ export function cliFollowCommand(joinUrl: string): string {
   return `slicc ${joinUrl} follow bash -c`;
 }
 
+/** Where the CLI installers live when the join link can't be parsed. */
+const DEFAULT_TRAY_ORIGIN = SLICC_HOSTED_ORIGIN;
+
+/**
+ * The origin serving this session — which is also the origin serving
+ * `/install-cli`. Deriving the installer from the join link rather than
+ * hardcoding production means a staging leader hands out the staging
+ * installer, so the CLI you install can actually talk to the leader you got
+ * it from.
+ */
+export function trayOriginFor(joinUrl: string): string {
+  try {
+    return new URL(joinUrl).origin;
+  } catch {
+    return DEFAULT_TRAY_ORIGIN;
+  }
+}
+
+/** One-line POSIX install (macOS, Linux, WSL, Git Bash) → `~/.local/bin`. */
+export function cliInstallCommand(joinUrl: string): string {
+  return `curl -fsSL ${trayOriginFor(joinUrl)}/install-cli | sh`;
+}
+
+/** Native-Windows install, for the same binary. */
+export function cliInstallCommandWindows(joinUrl: string): string {
+  return `irm ${trayOriginFor(joinUrl)}/install-cli.ps1 | iex`;
+}
+
 /** Per-tab body copy. Two sentences maximum: the button below does the work. */
 export function syncDialogCopy(tab: Exclude<SyncDialogTabId, 'status'>): string[] {
   switch (tab) {
@@ -85,7 +115,7 @@ export function syncDialogCopy(tab: Exclude<SyncDialogTabId, 'status'>): string[
       ];
     case 'terminal':
       return [
-        'Lend a machine to this session — run this in its terminal:',
+        'Lend a machine to this session — run these in its terminal:',
         'The agent can then run commands on that machine as you.',
       ];
   }

--- a/packages/webapp/src/ui/sync-dialog-model.ts
+++ b/packages/webapp/src/ui/sync-dialog-model.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure model + copy for the session-sharing dialog (`sync-dialog.ts`).
+ *
+ * The dialog predates the iOS app and the `slicc` CLI: it used to be a
+ * browser-only numbered list ("open SLICC in another browser…"). It is now one
+ * tab per follower kind, plus a Status tab that appears as soon as something
+ * is actually attached. Kept DOM-free so every string a user reads is covered
+ * by a unit test, the same way `tray-join-url.ts` covers the avatar popover.
+ */
+
+export type SyncDialogTabId = 'status' | 'browser' | 'iphone' | 'terminal';
+
+export interface SyncDialogTab {
+  id: SyncDialogTabId;
+  label: string;
+  /** Live follower count, rendered as a pill on the Status tab. */
+  badge?: number;
+}
+
+/**
+ * Tabs for a given follower count. Status leads when anything is connected —
+ * "who is on this session?" is the question you have once sharing works, and
+ * the how-to tabs are the question you have before that.
+ */
+export function buildSyncDialogTabs(followerCount: number): SyncDialogTab[] {
+  const tabs: SyncDialogTab[] = [
+    { id: 'browser', label: 'Browser' },
+    { id: 'iphone', label: 'iPhone' },
+    { id: 'terminal', label: 'Terminal' },
+  ];
+  if (followerCount > 0) {
+    tabs.unshift({ id: 'status', label: 'Status', badge: followerCount });
+  }
+  return tabs;
+}
+
+/** Which tab opens by default: Status when connected, Browser otherwise. */
+export function defaultSyncDialogTab(followerCount: number): SyncDialogTabId {
+  return followerCount > 0 ? 'status' : 'browser';
+}
+
+/**
+ * The join link is a bearer secret — anyone holding it can drive the session.
+ * Show its shape, not its token, until the user asks. Returns the input
+ * unchanged when it isn't a parseable `/join/<token>` URL (the invalid-URL
+ * copy in `tray-join-url.ts` owns that failure mode).
+ */
+export function maskJoinUrl(joinUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(joinUrl);
+  } catch {
+    return joinUrl;
+  }
+  const segments = parsed.pathname.split('/');
+  const tokenIndex = segments.lastIndexOf('join') + 1;
+  if (tokenIndex === 0 || tokenIndex >= segments.length || !segments[tokenIndex]) return joinUrl;
+  segments[tokenIndex] = '\u2022'.repeat(8);
+  // Assembled by hand, not via `parsed.pathname = …`: assigning back through
+  // the URL parser percent-encodes the bullets into `%E2%80%A2` noise.
+  return `${parsed.origin}${segments.join('/')}${parsed.search}${parsed.hash}`;
+}
+
+/**
+ * The ready-to-paste CLI line. `follow bash -c` (not a bare `follow`) is the
+ * useful form — without a runner the leader can't run anything — so the
+ * dialog hands over the one that works and warns about what it grants.
+ */
+export function cliFollowCommand(joinUrl: string): string {
+  return `slicc ${joinUrl} follow bash -c`;
+}
+
+/** Per-tab body copy. Two sentences maximum: the button below does the work. */
+export function syncDialogCopy(tab: Exclude<SyncDialogTabId, 'status'>): string[] {
+  switch (tab) {
+    case 'browser':
+      return [
+        'Open Sliccy in the other browser, click the avatar, and choose “Connect to another browser”.',
+        'Paste the join link there.',
+      ];
+    case 'iphone':
+      return [
+        'In the Sliccy app, paste the join link into Settings → Join link.',
+        'Signed in to the same iCloud account? The session is already listed under iCloud Sessions — no link needed.',
+      ];
+    case 'terminal':
+      return [
+        'Lend a machine to this session — run this in its terminal:',
+        'The agent can then run commands on that machine as you.',
+      ];
+  }
+}
+
+/** Footer summary above the actions. */
+export function sharingSummary(followerCount: number): string {
+  if (followerCount === 0) return 'Nothing connected yet.';
+  return `${followerCount} ${followerCount === 1 ? 'device is' : 'devices are'} connected.`;
+}
+
+/**
+ * Confirmation copy for revoking the link. Names the blast radius: the number
+ * of devices this is about to drop.
+ */
+export function revokeConfirmLabel(followerCount: number): string {
+  if (followerCount === 0) return 'Revoke link? The old link stops working.';
+  return `Revoke link? ${followerCount} connected ${
+    followerCount === 1 ? 'device' : 'devices'
+  } will be disconnected.`;
+}

--- a/packages/webapp/src/ui/sync-dialog.ts
+++ b/packages/webapp/src/ui/sync-dialog.ts
@@ -60,6 +60,8 @@ interface SyncDialogCtx {
 const MONO =
   'font-family: var(--s2-font-mono); font-size: 11px; word-break: break-all; padding: 8px 12px; background: var(--s2-bg-sunken); border-radius: var(--s2-radius-default); border: 1px solid var(--s2-border-subtle);';
 const MUTED = 'font-size: 11px; color: var(--s2-content-secondary);';
+/** Escapes `.dialog__btn { width: 100% }` for buttons that sit inline in a row. */
+const INLINE_BTN = 'flex: 0 0 auto; width: auto; padding: 8px 14px;';
 
 function el<K extends keyof HTMLElementTagNameMap>(
   tag: K,
@@ -128,10 +130,15 @@ function linkBlock(ctx: SyncDialogCtx): HTMLElement {
   wrap.appendChild(copyBtn);
 
   const urlRow = el('div', 'display: flex; align-items: center; gap: 8px;');
-  const url = el('div', `${MONO} flex: 1; color: var(--s2-content-secondary);`);
+  const url = el(
+    'div',
+    `${MONO} flex: 1 1 auto; min-width: 0; color: var(--s2-content-secondary);`
+  );
   url.dataset.joinUrl = '1';
   url.textContent = ctx.urlRevealed ? ctx.options.joinUrl : maskJoinUrl(ctx.options.joinUrl);
-  const toggle = el('button', 'flex: 0 0 auto;', ctx.urlRevealed ? 'Hide' : 'Show');
+  // `width: auto` overrides `.dialog__btn { width: 100% }` — without it the
+  // button claims the row and squeezes the link into a 6-character column.
+  const toggle = el('button', `${INLINE_BTN}`, ctx.urlRevealed ? 'Hide' : 'Show');
   toggle.className = 'dialog__btn dialog__btn--secondary';
   toggle.dataset.action = 'toggle-url';
   toggle.addEventListener('click', () => {
@@ -163,7 +170,11 @@ function terminalBlock(ctx: SyncDialogCtx, note: string): HTMLElement {
   });
   wrap.appendChild(copyBtn);
 
-  const toggle = el('button', 'margin-bottom: 8px;', ctx.urlRevealed ? 'Hide link' : 'Show link');
+  const toggle = el(
+    'button',
+    `${INLINE_BTN} margin-bottom: 8px;`,
+    ctx.urlRevealed ? 'Hide link' : 'Show link'
+  );
   toggle.className = 'dialog__btn dialog__btn--secondary';
   toggle.dataset.action = 'toggle-url';
   toggle.addEventListener('click', () => {
@@ -180,13 +191,15 @@ function terminalBlock(ctx: SyncDialogCtx, note: string): HTMLElement {
 function renderHowTo(ctx: SyncDialogCtx, tab: Exclude<SyncDialogTabId, 'status'>): HTMLElement {
   const wrap = el('div');
   const [lead, note] = syncDialogCopy(tab);
-  wrap.appendChild(el('div', 'font-size: 12px; line-height: 1.5; margin-bottom: 10px;', lead));
+  wrap.appendChild(el('div', 'font-size: 12px; line-height: 1.5; margin-bottom: 6px;', lead));
   if (tab === 'terminal') {
+    // The terminal note is a warning about what `follow` grants, so it stays
+    // next to the command it qualifies.
     wrap.appendChild(terminalBlock(ctx, note));
     return wrap;
   }
+  wrap.appendChild(el('div', `${MUTED} margin-bottom: 10px;`, note));
   wrap.appendChild(linkBlock(ctx));
-  wrap.appendChild(el('div', `${MUTED} margin-top: 8px;`, note));
   return wrap;
 }
 

--- a/packages/webapp/src/ui/sync-dialog.ts
+++ b/packages/webapp/src/ui/sync-dialog.ts
@@ -1,122 +1,391 @@
+/**
+ * The session-sharing dialog — "here is the join link, here is what to do
+ * with it on each kind of device, and here is who is already attached".
+ *
+ * Tabs come from `sync-dialog-model.ts` (Status appears the moment a follower
+ * connects); follower rows are formatted by `follower-presentation.ts`, the
+ * same vocabulary the Monitor panel's Followers section uses. Rendering is
+ * split into module-level functions over a shared `SyncDialogCtx` so no single
+ * function owns the whole surface.
+ */
+
+import { iconEl } from '@slicc/webcomponents/icons';
+import type { ConnectedFollowerInfo } from '../shell/supplemental-commands/host-command.js';
 import { copyTextToClipboard } from './clipboard.js';
+import {
+  FOLLOWERS_CHANGED_EVENT,
+  followerCapabilities,
+  followerDetail,
+  followerIcon,
+  followerMeta,
+  followerStatus,
+  followerTitle,
+} from './follower-presentation.js';
+import {
+  buildSyncDialogTabs,
+  cliFollowCommand,
+  defaultSyncDialogTab,
+  maskJoinUrl,
+  revokeConfirmLabel,
+  type SyncDialogTabId,
+  sharingSummary,
+  syncDialogCopy,
+} from './sync-dialog-model.js';
 
 export interface SyncEnabledDialogOptions {
   joinUrl: string;
   copied: boolean;
   onReset?: (() => Promise<unknown>) | null;
+  /** Current roster; drives the Status tab and the revoke blast-radius copy. */
+  followers?: ConnectedFollowerInfo[];
+  /** Force a starting tab. Defaults to Status when connected, Browser otherwise. */
+  initialTab?: SyncDialogTabId;
 }
 
-export function showSyncEnabledDialog(options: SyncEnabledDialogOptions): void {
-  document.querySelectorAll('.dialog-overlay[data-sync-dialog]').forEach((el) => {
-    el.remove();
-  });
+interface SyncDialogCtx {
+  options: SyncEnabledDialogOptions;
+  followers: ConnectedFollowerInfo[];
+  activeTab: SyncDialogTabId;
+  urlRevealed: boolean;
+  revokeArmed: boolean;
+  overlay: HTMLElement;
+  tabsRow: HTMLElement;
+  body: HTMLElement;
+  statusEl: HTMLElement;
+  summaryEl: HTMLElement;
+  doneBtn: HTMLButtonElement;
+  revokeBtn: HTMLButtonElement | null;
+}
 
-  const overlay = document.createElement('div');
+const MONO =
+  'font-family: var(--s2-font-mono); font-size: 11px; word-break: break-all; padding: 8px 12px; background: var(--s2-bg-sunken); border-radius: var(--s2-radius-default); border: 1px solid var(--s2-border-subtle);';
+const MUTED = 'font-size: 11px; color: var(--s2-content-secondary);';
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  css?: string,
+  text?: string
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (css) node.style.cssText = css;
+  if (text != null) node.textContent = text;
+  return node;
+}
+
+function setStatus(ctx: SyncDialogCtx, message: string, tone: 'normal' | 'error' = 'normal'): void {
+  ctx.statusEl.textContent = message;
+  ctx.statusEl.style.color = tone === 'error' ? 'var(--slicc-cone)' : 'var(--s2-content-secondary)';
+}
+
+async function copyInto(ctx: SyncDialogCtx, value: string, okMessage: string): Promise<void> {
+  const ok = await copyTextToClipboard(value);
+  if (ok) setStatus(ctx, okMessage);
+  else setStatus(ctx, 'Couldn’t copy. Select the text and copy it manually.', 'error');
+}
+
+/**
+ * Revoking is two clicks, not a confirm dialog: the first arms the button and
+ * rewrites it to name the blast radius ("3 connected devices will be
+ * disconnected"), the second performs it.
+ */
+async function handleRevoke(ctx: SyncDialogCtx): Promise<void> {
+  const { onReset } = ctx.options;
+  const button = ctx.revokeBtn;
+  if (!onReset || !button) return;
+  if (!ctx.revokeArmed) {
+    ctx.revokeArmed = true;
+    button.textContent = revokeConfirmLabel(ctx.followers.length);
+    return;
+  }
+  button.disabled = true;
+  ctx.doneBtn.disabled = true;
+  setStatus(ctx, 'Revoking the join link…');
+  try {
+    await onReset();
+    setStatus(ctx, 'Join link revoked. Enable sharing from the avatar menu to get a new one.');
+    ctx.urlRevealed = false;
+    button.textContent = 'Revoked';
+    ctx.doneBtn.disabled = false;
+    render(ctx);
+  } catch (err) {
+    setStatus(ctx, `Revoke failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
+    ctx.revokeArmed = false;
+    button.textContent = 'Revoke link';
+    button.disabled = false;
+    ctx.doneBtn.disabled = false;
+  }
+}
+
+/** Copy-the-link block shared by the Browser and iPhone tabs. */
+function linkBlock(ctx: SyncDialogCtx): HTMLElement {
+  const wrap = el('div');
+  const copyBtn = el('button', 'margin-bottom: 8px;', 'Copy join link');
+  copyBtn.className = 'dialog__btn dialog__btn--secondary';
+  copyBtn.dataset.action = 'copy-link';
+  copyBtn.addEventListener('click', () => {
+    void copyInto(ctx, ctx.options.joinUrl, 'Join link copied.');
+  });
+  wrap.appendChild(copyBtn);
+
+  const urlRow = el('div', 'display: flex; align-items: center; gap: 8px;');
+  const url = el('div', `${MONO} flex: 1; color: var(--s2-content-secondary);`);
+  url.dataset.joinUrl = '1';
+  url.textContent = ctx.urlRevealed ? ctx.options.joinUrl : maskJoinUrl(ctx.options.joinUrl);
+  const toggle = el('button', 'flex: 0 0 auto;', ctx.urlRevealed ? 'Hide' : 'Show');
+  toggle.className = 'dialog__btn dialog__btn--secondary';
+  toggle.dataset.action = 'toggle-url';
+  toggle.addEventListener('click', () => {
+    ctx.urlRevealed = !ctx.urlRevealed;
+    render(ctx);
+  });
+  urlRow.append(url, toggle);
+  wrap.appendChild(urlRow);
+  wrap.appendChild(
+    el('div', `${MUTED} margin-top: 8px;`, 'Anyone with this link can drive this session.')
+  );
+  return wrap;
+}
+
+/** The Terminal tab: a ready-to-paste `slicc … follow` line, and what it grants. */
+function terminalBlock(ctx: SyncDialogCtx, note: string): HTMLElement {
+  const wrap = el('div');
+  const command = cliFollowCommand(ctx.options.joinUrl);
+  const shown = ctx.urlRevealed ? command : cliFollowCommand(maskJoinUrl(ctx.options.joinUrl));
+  const commandEl = el('div', `${MONO} margin-bottom: 8px;`, shown);
+  commandEl.dataset.command = '1';
+  wrap.appendChild(commandEl);
+
+  const copyBtn = el('button', 'margin-bottom: 8px;', 'Copy command');
+  copyBtn.className = 'dialog__btn dialog__btn--secondary';
+  copyBtn.dataset.action = 'copy-command';
+  copyBtn.addEventListener('click', () => {
+    void copyInto(ctx, command, 'Command copied.');
+  });
+  wrap.appendChild(copyBtn);
+
+  const toggle = el('button', 'margin-bottom: 8px;', ctx.urlRevealed ? 'Hide link' : 'Show link');
+  toggle.className = 'dialog__btn dialog__btn--secondary';
+  toggle.dataset.action = 'toggle-url';
+  toggle.addEventListener('click', () => {
+    ctx.urlRevealed = !ctx.urlRevealed;
+    render(ctx);
+  });
+  wrap.appendChild(toggle);
+
+  wrap.appendChild(el('div', `${MUTED} margin-bottom: 8px;`, `⚠ ${note}`));
+  wrap.appendChild(el('div', MUTED, 'Get the slicc CLI at github.com/ai-ecoverse/slicc/releases'));
+  return wrap;
+}
+
+function renderHowTo(ctx: SyncDialogCtx, tab: Exclude<SyncDialogTabId, 'status'>): HTMLElement {
+  const wrap = el('div');
+  const [lead, note] = syncDialogCopy(tab);
+  wrap.appendChild(el('div', 'font-size: 12px; line-height: 1.5; margin-bottom: 10px;', lead));
+  if (tab === 'terminal') {
+    wrap.appendChild(terminalBlock(ctx, note));
+    return wrap;
+  }
+  wrap.appendChild(linkBlock(ctx));
+  wrap.appendChild(el('div', `${MUTED} margin-top: 8px;`, note));
+  return wrap;
+}
+
+/** One Status-tab row: kind + short id, MOTD, capability chips, live state. */
+function followerRow(follower: ConnectedFollowerInfo): HTMLElement {
+  const row = el(
+    'div',
+    'display: grid; grid-template-columns: 16px 1fr auto; gap: 8px; align-items: start;'
+  );
+  row.dataset.follower = follower.runtimeId;
+
+  const icon = el('span', 'display: flex; margin-top: 2px; color: var(--s2-content-secondary);');
+  icon.appendChild(iconEl(followerIcon(follower), { size: 14 }));
+  row.appendChild(icon);
+
+  const main = el('div', 'display: flex; flex-direction: column; gap: 2px; min-width: 0;');
+  main.appendChild(el('div', 'font-size: 12px; font-weight: 500;', followerTitle(follower)));
+  const detail = followerDetail(follower);
+  if (detail) main.appendChild(el('div', `${MUTED} overflow-wrap: anywhere;`, detail));
+  const chips = followerCapabilities(follower);
+  if (chips.length > 0) {
+    const chipRow = el('div', 'display: flex; gap: 4px; flex-wrap: wrap; margin-top: 2px;');
+    for (const chip of chips) {
+      chipRow.appendChild(
+        el(
+          'span',
+          'padding: 1px 6px; border-radius: 9999px; background: var(--s2-bg-layer-1); border: 1px solid var(--s2-border-subtle); font-size: 10px; font-weight: 600; color: var(--s2-content-secondary);',
+          chip
+        )
+      );
+    }
+    main.appendChild(chipRow);
+  }
+  row.appendChild(main);
+
+  const state = followerStatus(follower);
+  const dotColor =
+    state === 'active' ? '#22c55e' : state === 'warn' ? '#f59e0b' : 'var(--s2-content-secondary)';
+  const stateEl = el(
+    'div',
+    `display: flex; align-items: center; gap: 5px; ${MUTED} white-space: nowrap;`
+  );
+  stateEl.appendChild(
+    el(
+      'span',
+      `width: 6px; height: 6px; border-radius: 50%; flex: 0 0 auto; background: ${dotColor};`
+    )
+  );
+  stateEl.appendChild(el('span', undefined, followerMeta(follower)));
+  row.appendChild(stateEl);
+  return row;
+}
+
+function renderStatusTab(ctx: SyncDialogCtx): HTMLElement {
+  const list = el('div', 'display: flex; flex-direction: column; gap: 10px;');
+  for (const follower of ctx.followers) list.appendChild(followerRow(follower));
+  if (ctx.followers.length === 0) {
+    list.appendChild(
+      el(
+        'div',
+        'font-size: 12px; color: var(--s2-content-secondary);',
+        'Nothing connected right now.'
+      )
+    );
+  }
+  return list;
+}
+
+function tabButton(ctx: SyncDialogCtx, id: SyncDialogTabId, label: string): HTMLElement {
+  const isActive = id === ctx.activeTab;
+  const btn = el(
+    'button',
+    `flex: 0 0 auto; padding: 4px 10px; border-radius: 9999px; font-size: 12px; cursor: pointer; border: 1px solid ${
+      isActive ? 'var(--s2-border-subtle)' : 'transparent'
+    }; background: ${isActive ? 'var(--s2-bg-layer-1)' : 'transparent'}; color: var(--s2-content-${
+      isActive ? 'primary' : 'secondary'
+    });`,
+    label
+  );
+  btn.type = 'button';
+  btn.setAttribute('role', 'tab');
+  btn.setAttribute('aria-selected', String(isActive));
+  btn.dataset.tab = id;
+  btn.addEventListener('click', () => {
+    ctx.activeTab = id;
+    render(ctx);
+  });
+  return btn;
+}
+
+function render(ctx: SyncDialogCtx): void {
+  const tabs = buildSyncDialogTabs(ctx.followers.length);
+  if (!tabs.some((tab) => tab.id === ctx.activeTab)) ctx.activeTab = defaultSyncDialogTab(0);
+
+  ctx.tabsRow.replaceChildren(
+    ...tabs.map((tab) =>
+      tabButton(ctx, tab.id, tab.badge != null ? `${tab.label} · ${tab.badge}` : tab.label)
+    )
+  );
+  ctx.body.replaceChildren(
+    ctx.activeTab === 'status' ? renderStatusTab(ctx) : renderHowTo(ctx, ctx.activeTab)
+  );
+  ctx.summaryEl.textContent = sharingSummary(ctx.followers.length);
+  if (ctx.revokeBtn && !ctx.revokeArmed && ctx.revokeBtn.textContent !== 'Revoked') {
+    ctx.revokeBtn.textContent = 'Revoke link';
+  }
+}
+
+/** Build the dialog chrome; every child is filled in by `render`. */
+function buildShell(options: SyncEnabledDialogOptions): SyncDialogCtx {
+  const overlay = el('div');
   overlay.className = 'dialog-overlay';
   overlay.dataset.syncDialog = '1';
 
-  const dialog = document.createElement('div');
+  const dialog = el('div');
   dialog.className = 'dialog';
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.setAttribute('aria-label', 'Session sharing');
   overlay.appendChild(dialog);
 
-  const title = document.createElement('div');
+  const title = el('div', undefined, 'Session sharing');
   title.className = 'dialog__title';
-  title.textContent = 'Multi-browser sync is on';
-  dialog.appendChild(title);
 
-  const desc = document.createElement('div');
-  desc.className = 'dialog__desc';
-  desc.textContent = options.copied
-    ? 'The sync URL is copied to your clipboard. Paste it into another SLICC browser to mirror this one.'
-    : 'Couldn\u2019t copy automatically. Use the button below to copy the sync URL, then paste it into another SLICC browser.';
-  dialog.appendChild(desc);
+  const tabsRow = el('div', 'display: flex; gap: 4px; margin-bottom: 12px; flex-wrap: wrap;');
+  tabsRow.setAttribute('role', 'tablist');
 
-  const stepsBox = document.createElement('div');
-  stepsBox.style.cssText =
-    'margin-bottom: 12px; padding: 10px 12px; background: var(--s2-bg-layer-1); border-radius: var(--s2-radius-default); border: 1px solid var(--s2-border-subtle); line-height: 1.5; font-size: 12px; color: var(--s2-content-secondary);';
-  const stepsList = document.createElement('ol');
-  stepsList.style.cssText = 'margin: 0; padding-left: 20px;';
-  const steps = [
-    'Open SLICC in another browser.',
-    'Click the avatar (top right) \u2192 \u201cConnect to another browser\u201d.',
-    'Paste the URL there. Both browsers must be on the same SLICC version.',
-  ];
-  for (const step of steps) {
-    const li = document.createElement('li');
-    li.textContent = step;
-    stepsList.appendChild(li);
-  }
-  stepsBox.appendChild(stepsList);
-  dialog.appendChild(stepsBox);
+  const body = el('div', 'margin-bottom: 12px;');
+  body.setAttribute('role', 'tabpanel');
 
-  const urlDisplay = document.createElement('div');
-  urlDisplay.style.cssText =
-    'font-family: var(--s2-font-mono); font-size: 11px; color: var(--s2-content-secondary); word-break: break-all; margin-bottom: 12px; padding: 8px 12px; background: var(--s2-bg-sunken); border-radius: var(--s2-radius-default); border: 1px solid var(--s2-border-subtle);';
-  urlDisplay.textContent = options.joinUrl;
-  dialog.appendChild(urlDisplay);
+  const statusEl = el('div', 'font-size: 12px; margin-bottom: 8px; min-height: 16px;');
+  statusEl.setAttribute('role', 'status');
+  statusEl.setAttribute('aria-live', 'polite');
 
-  const statusEl = document.createElement('div');
-  statusEl.style.cssText =
-    'font-size: 12px; color: var(--s2-content-secondary); margin-bottom: 8px; display: none;';
-  dialog.appendChild(statusEl);
-  if (options.copied) {
-    statusEl.textContent = 'URL copied to clipboard.';
-    statusEl.style.display = '';
-  }
+  const summaryEl = el('div', `${MUTED} margin-bottom: 8px;`);
 
-  const copyAgainBtn = document.createElement('button');
-  copyAgainBtn.className = 'dialog__btn dialog__btn--secondary';
-  copyAgainBtn.style.marginBottom = '8px';
-  copyAgainBtn.textContent = options.copied ? 'Copy again' : 'Copy URL';
-  copyAgainBtn.addEventListener('click', async () => {
-    const ok = await copyTextToClipboard(options.joinUrl);
-    statusEl.textContent = ok
-      ? 'URL copied to clipboard.'
-      : 'Couldn\u2019t copy. Select and copy manually.';
-    statusEl.style.color = ok ? 'var(--s2-content-secondary)' : 'var(--slicc-cone)';
-    statusEl.style.display = '';
-  });
-  dialog.appendChild(copyAgainBtn);
-
-  const doneBtn = document.createElement('button');
+  const doneBtn = el('button', undefined, 'Done');
   doneBtn.className = 'dialog__btn';
-  doneBtn.textContent = 'Done';
-  doneBtn.addEventListener('click', () => overlay.remove());
-  dialog.appendChild(doneBtn);
+
+  dialog.append(title, tabsRow, body, statusEl, summaryEl, doneBtn);
+
+  const followers = options.followers ?? [];
+  return {
+    options,
+    followers,
+    activeTab: options.initialTab ?? defaultSyncDialogTab(followers.length),
+    urlRevealed: false,
+    revokeArmed: false,
+    overlay,
+    tabsRow,
+    body,
+    statusEl,
+    summaryEl,
+    doneBtn,
+    revokeBtn: null,
+  };
+}
+
+export function showSyncEnabledDialog(options: SyncEnabledDialogOptions): void {
+  document.querySelectorAll('.dialog-overlay[data-sync-dialog]').forEach((node) => {
+    node.remove();
+  });
+
+  const ctx = buildShell(options);
+  const dialog = ctx.overlay.firstElementChild as HTMLElement;
 
   if (options.onReset) {
-    const resetBtn = document.createElement('button');
-    resetBtn.className = 'dialog__btn dialog__btn--secondary';
-    resetBtn.style.marginTop = '8px';
-    resetBtn.textContent = 'Reset URL (disconnect connected browsers)';
-    resetBtn.addEventListener('click', async () => {
-      resetBtn.disabled = true;
-      doneBtn.disabled = true;
-      copyAgainBtn.disabled = true;
-      statusEl.textContent = 'Resetting sync URL\u2026';
-      statusEl.style.color = 'var(--s2-content-secondary)';
-      statusEl.style.display = '';
-      try {
-        await options.onReset!();
-        statusEl.textContent =
-          'Sync URL reset. Reopen this dialog from the avatar to share the new URL.';
-        statusEl.style.color = 'var(--s2-content-secondary)';
-        urlDisplay.textContent = '\u2014';
-        copyAgainBtn.disabled = true;
-      } catch (err) {
-        statusEl.textContent = `Reset failed: ${err instanceof Error ? err.message : String(err)}`;
-        statusEl.style.color = 'var(--slicc-cone)';
-        resetBtn.disabled = false;
-        doneBtn.disabled = false;
-        copyAgainBtn.disabled = false;
-      }
+    const revokeBtn = el('button', 'margin-top: 8px;', 'Revoke link');
+    revokeBtn.className = 'dialog__btn dialog__btn--secondary';
+    revokeBtn.dataset.action = 'revoke';
+    revokeBtn.addEventListener('click', () => {
+      void handleRevoke(ctx);
     });
-    dialog.appendChild(resetBtn);
+    dialog.appendChild(revokeBtn);
+    ctx.revokeBtn = revokeBtn;
   }
 
-  overlay.addEventListener('click', (e) => {
-    if (e.target === overlay) overlay.remove();
-  });
+  const onFollowersChanged = (event: Event): void => {
+    ctx.followers =
+      (event as CustomEvent<{ followers?: ConnectedFollowerInfo[] }>).detail?.followers ?? [];
+    render(ctx);
+  };
+  const onKeydown = (event: KeyboardEvent): void => {
+    if (event.key === 'Escape') close();
+  };
+  function close(): void {
+    window.removeEventListener(FOLLOWERS_CHANGED_EVENT, onFollowersChanged);
+    document.removeEventListener('keydown', onKeydown);
+    ctx.overlay.remove();
+  }
 
-  document.body.appendChild(overlay);
+  ctx.doneBtn.addEventListener('click', () => close());
+  ctx.overlay.addEventListener('click', (event) => {
+    if (event.target === ctx.overlay) close();
+  });
+  window.addEventListener(FOLLOWERS_CHANGED_EVENT, onFollowersChanged);
+  document.addEventListener('keydown', onKeydown);
+
+  if (options.copied) setStatus(ctx, 'Join link copied to clipboard.');
+  render(ctx);
+  document.body.appendChild(ctx.overlay);
 }

--- a/packages/webapp/src/ui/sync-dialog.ts
+++ b/packages/webapp/src/ui/sync-dialog.ts
@@ -434,7 +434,20 @@ function buildShell(options: SyncEnabledDialogOptions): SyncDialogCtx {
   };
 }
 
+/**
+ * Teardown for the dialog currently on screen, if any. Removing the overlay
+ * NODE is not enough: the live instance also holds a `FOLLOWERS_CHANGED_EVENT`
+ * window listener and a `keydown` document listener, and both re-open paths
+ * (the avatar menu's tray-copy and the floatbar's followers segment) can fire
+ * while a dialog is already up. Without this, each re-open leaves the previous
+ * instance listening forever and re-rendering into a detached tree.
+ */
+let closeActiveDialog: (() => void) | null = null;
+
 export function showSyncEnabledDialog(options: SyncEnabledDialogOptions): void {
+  closeActiveDialog?.();
+  // Belt and braces: an overlay from an instance whose closer was lost (a hot
+  // reload, an older build) still gets cleared.
   document.querySelectorAll('.dialog-overlay[data-sync-dialog]').forEach((node) => {
     node.remove();
   });
@@ -465,6 +478,7 @@ export function showSyncEnabledDialog(options: SyncEnabledDialogOptions): void {
     window.removeEventListener(FOLLOWERS_CHANGED_EVENT, onFollowersChanged);
     document.removeEventListener('keydown', onKeydown);
     ctx.overlay.remove();
+    if (closeActiveDialog === close) closeActiveDialog = null;
   }
 
   ctx.doneBtn.addEventListener('click', () => close());
@@ -474,6 +488,7 @@ export function showSyncEnabledDialog(options: SyncEnabledDialogOptions): void {
   window.addEventListener(FOLLOWERS_CHANGED_EVENT, onFollowersChanged);
   document.addEventListener('keydown', onKeydown);
 
+  closeActiveDialog = close;
   if (options.copied) setStatus(ctx, 'Join link copied to clipboard.');
   render(ctx);
   document.body.appendChild(ctx.overlay);

--- a/packages/webapp/src/ui/sync-dialog.ts
+++ b/packages/webapp/src/ui/sync-dialog.ts
@@ -24,6 +24,8 @@ import {
 import {
   buildSyncDialogTabs,
   cliFollowCommand,
+  cliInstallCommand,
+  cliInstallCommandWindows,
   defaultSyncDialogTab,
   maskJoinUrl,
   revokeConfirmLabel,
@@ -58,8 +60,14 @@ interface SyncDialogCtx {
 }
 
 const MONO =
-  'font-family: var(--s2-font-mono); font-size: 11px; word-break: break-all; padding: 8px 12px; background: var(--s2-bg-sunken); border-radius: var(--s2-radius-default); border: 1px solid var(--s2-border-subtle);';
+  'font-family: var(--s2-font-mono); font-size: 11px; color: var(--s2-content-default); word-break: break-all; padding: 8px 12px; background: var(--s2-bg-sunken); border-radius: var(--s2-radius-default); border: 1px solid var(--s2-border-subtle);';
 const MUTED = 'font-size: 11px; color: var(--s2-content-secondary);';
+/**
+ * `.dialog` only colors `.dialog__title` / `.dialog__desc`, so any element
+ * this module builds MUST state its own color — an inherited one resolves to
+ * the document default and renders near-black on the dark dialog surface.
+ */
+const BODY = 'font-size: 12px; color: var(--s2-content-default);';
 /** Escapes `.dialog__btn { width: 100% }` for buttons that sit inline in a row. */
 const INLINE_BTN = 'flex: 0 0 auto; width: auto; padding: 8px 14px;';
 
@@ -97,6 +105,7 @@ async function handleRevoke(ctx: SyncDialogCtx): Promise<void> {
   if (!ctx.revokeArmed) {
     ctx.revokeArmed = true;
     button.textContent = revokeConfirmLabel(ctx.followers.length);
+    setRevokeArmedStyle(button, true);
     return;
   }
   button.disabled = true;
@@ -113,9 +122,23 @@ async function handleRevoke(ctx: SyncDialogCtx): Promise<void> {
     setStatus(ctx, `Revoke failed: ${err instanceof Error ? err.message : String(err)}`, 'error');
     ctx.revokeArmed = false;
     button.textContent = 'Revoke link';
+    setRevokeArmedStyle(button, false);
     button.disabled = false;
     ctx.doneBtn.disabled = false;
   }
+}
+
+/**
+ * The armed state is the destructive one, so it is the only one that goes
+ * red: an idle "Revoke link" is just another secondary button, while
+ * "Revoke link? 3 connected devices will be disconnected." is a click away
+ * from dropping every follower.
+ */
+function setRevokeArmedStyle(button: HTMLButtonElement, armed: boolean): void {
+  button.dataset.armed = armed ? '1' : '0';
+  button.style.background = armed ? 'var(--s2-negative)' : '';
+  button.style.borderColor = armed ? 'transparent' : '';
+  button.style.color = armed ? '#fff' : '';
 }
 
 /** Copy-the-link block shared by the Browser and iPhone tabs. */
@@ -153,22 +176,71 @@ function linkBlock(ctx: SyncDialogCtx): HTMLElement {
   return wrap;
 }
 
-/** The Terminal tab: a ready-to-paste `slicc … follow` line, and what it grants. */
-function terminalBlock(ctx: SyncDialogCtx, note: string): HTMLElement {
-  const wrap = el('div');
-  const command = cliFollowCommand(ctx.options.joinUrl);
-  const shown = ctx.urlRevealed ? command : cliFollowCommand(maskJoinUrl(ctx.options.joinUrl));
-  const commandEl = el('div', `${MONO} margin-bottom: 8px;`, shown);
-  commandEl.dataset.command = '1';
+/**
+ * A labelled step: caption, mono command, and its own copy button. `copyValue`
+ * defaults to what is shown — the connect step overrides it so the clipboard
+ * carries the real token while the display stays masked.
+ */
+function commandStep(
+  ctx: SyncDialogCtx,
+  opts: {
+    caption: string;
+    command: string;
+    copyValue?: string;
+    action: string;
+    copyLabel: string;
+    okMessage: string;
+  }
+): HTMLElement {
+  const wrap = el('div', 'margin-bottom: 10px;');
+  wrap.appendChild(el('div', `${MUTED} margin-bottom: 4px;`, opts.caption));
+  const commandEl = el('div', `${MONO} margin-bottom: 6px;`, opts.command);
+  commandEl.dataset.command = opts.action;
   wrap.appendChild(commandEl);
-
-  const copyBtn = el('button', 'margin-bottom: 8px;', 'Copy command');
+  const copyBtn = el('button', 'margin-bottom: 0;', opts.copyLabel);
   copyBtn.className = 'dialog__btn dialog__btn--secondary';
-  copyBtn.dataset.action = 'copy-command';
+  copyBtn.dataset.action = opts.action;
   copyBtn.addEventListener('click', () => {
-    void copyInto(ctx, command, 'Command copied.');
+    void copyInto(ctx, opts.copyValue ?? opts.command, opts.okMessage);
   });
   wrap.appendChild(copyBtn);
+  return wrap;
+}
+
+/**
+ * The Terminal tab: install the CLI, then connect with it. Handing over a
+ * `slicc …` command without saying where `slicc` comes from was the gap —
+ * anyone who doesn't already have the binary hits `command not found`.
+ */
+function terminalBlock(ctx: SyncDialogCtx, note: string): HTMLElement {
+  const wrap = el('div');
+  const { joinUrl } = ctx.options;
+  const command = cliFollowCommand(joinUrl);
+  const shown = ctx.urlRevealed ? command : cliFollowCommand(maskJoinUrl(joinUrl));
+
+  wrap.appendChild(
+    commandStep(ctx, {
+      caption: '1. Install the slicc CLI (skip if you already have it):',
+      command: cliInstallCommand(joinUrl),
+      action: 'copy-install',
+      copyLabel: 'Copy install command',
+      okMessage: 'Install command copied.',
+    })
+  );
+  wrap.appendChild(
+    el('div', `${MUTED} margin: -6px 0 12px;`, `Windows: ${cliInstallCommandWindows(joinUrl)}`)
+  );
+
+  wrap.appendChild(
+    commandStep(ctx, {
+      caption: '2. Connect that machine to this session:',
+      command: shown,
+      copyValue: command,
+      action: 'copy-command',
+      copyLabel: 'Copy command',
+      okMessage: 'Command copied.',
+    })
+  );
 
   const toggle = el(
     'button',
@@ -183,15 +255,14 @@ function terminalBlock(ctx: SyncDialogCtx, note: string): HTMLElement {
   });
   wrap.appendChild(toggle);
 
-  wrap.appendChild(el('div', `${MUTED} margin-bottom: 8px;`, `⚠ ${note}`));
-  wrap.appendChild(el('div', MUTED, 'Get the slicc CLI at github.com/ai-ecoverse/slicc/releases'));
+  wrap.appendChild(el('div', `${MUTED} margin-bottom: 0;`, `\u26a0 ${note}`));
   return wrap;
 }
 
 function renderHowTo(ctx: SyncDialogCtx, tab: Exclude<SyncDialogTabId, 'status'>): HTMLElement {
   const wrap = el('div');
   const [lead, note] = syncDialogCopy(tab);
-  wrap.appendChild(el('div', 'font-size: 12px; line-height: 1.5; margin-bottom: 6px;', lead));
+  wrap.appendChild(el('div', `${BODY} line-height: 1.5; margin-bottom: 6px;`, lead));
   if (tab === 'terminal') {
     // The terminal note is a warning about what `follow` grants, so it stays
     // next to the command it qualifies.
@@ -216,7 +287,7 @@ function followerRow(follower: ConnectedFollowerInfo): HTMLElement {
   row.appendChild(icon);
 
   const main = el('div', 'display: flex; flex-direction: column; gap: 2px; min-width: 0;');
-  main.appendChild(el('div', 'font-size: 12px; font-weight: 500;', followerTitle(follower)));
+  main.appendChild(el('div', `${BODY} font-weight: 500;`, followerTitle(follower)));
   const detail = followerDetail(follower);
   if (detail) main.appendChild(el('div', `${MUTED} overflow-wrap: anywhere;`, detail));
   const chips = followerCapabilities(follower);
@@ -237,7 +308,11 @@ function followerRow(follower: ConnectedFollowerInfo): HTMLElement {
 
   const state = followerStatus(follower);
   const dotColor =
-    state === 'active' ? '#22c55e' : state === 'warn' ? '#f59e0b' : 'var(--s2-content-secondary)';
+    state === 'active'
+      ? 'var(--s2-positive)'
+      : state === 'warn'
+        ? 'var(--s2-notice)'
+        : 'var(--s2-content-tertiary)';
   const stateEl = el(
     'div',
     `display: flex; align-items: center; gap: 5px; ${MUTED} white-space: nowrap;`
@@ -274,9 +349,9 @@ function tabButton(ctx: SyncDialogCtx, id: SyncDialogTabId, label: string): HTML
     'button',
     `flex: 0 0 auto; padding: 4px 10px; border-radius: 9999px; font-size: 12px; cursor: pointer; border: 1px solid ${
       isActive ? 'var(--s2-border-subtle)' : 'transparent'
-    }; background: ${isActive ? 'var(--s2-bg-layer-1)' : 'transparent'}; color: var(--s2-content-${
-      isActive ? 'primary' : 'secondary'
-    });`,
+    }; background: ${isActive ? 'var(--s2-bg-layer-1)' : 'transparent'}; color: ${
+      isActive ? 'var(--s2-content-default)' : 'var(--s2-content-secondary)'
+    };`,
     label
   );
   btn.type = 'button';
@@ -305,6 +380,7 @@ function render(ctx: SyncDialogCtx): void {
   ctx.summaryEl.textContent = sharingSummary(ctx.followers.length);
   if (ctx.revokeBtn && !ctx.revokeArmed && ctx.revokeBtn.textContent !== 'Revoked') {
     ctx.revokeBtn.textContent = 'Revoke link';
+    setRevokeArmedStyle(ctx.revokeBtn, false);
   }
 }
 

--- a/packages/webapp/src/ui/wc/wc-monitor.ts
+++ b/packages/webapp/src/ui/wc/wc-monitor.ts
@@ -9,6 +9,13 @@ import type { MountTableEntry } from '../../fs/mount-table-store.js';
 import type { CronTaskEntry, WebhookEntry } from '../../scoops/lick-manager.js';
 import type { RegisteredScoop } from '../../scoops/types.js';
 import type { ConnectedFollowerInfo } from '../../shell/supplemental-commands/host-command.js';
+import {
+  followerIcon,
+  followerMeta,
+  followerStatus,
+  followerTitle,
+  shortFollowerId,
+} from '../follower-presentation.js';
 
 /**
  * A persisted mount entry, augmented with the permission state as of the
@@ -68,55 +75,6 @@ export interface MonitorDeps {
   getConnectedFollowers(): ConnectedFollowerInfo[];
 }
 
-function shortId(runtimeId: string): string {
-  const unprefixed = runtimeId.replace(/^follower-/, '');
-  return unprefixed.length > 12 ? `${unprefixed.slice(0, 8)}…` : unprefixed;
-}
-
-function followerTypeLabel(follower: ConnectedFollowerInfo): string {
-  if (follower.floatType === 'ios') return 'iOS';
-  if (follower.floatType === 'electron') return 'Electron';
-  if (follower.floatType === 'extension') return 'Extension';
-  if (follower.floatType === 'standalone') return 'Standalone';
-  return follower.runtime?.includes('cli') ? 'CLI' : 'Follower';
-}
-
-function followerIcon(follower: ConnectedFollowerInfo): string {
-  if (follower.floatType === 'ios') return 'smartphone';
-  if (follower.floatType === 'electron' || follower.floatType === 'standalone') return 'monitor';
-  if (follower.floatType === 'extension') return 'blocks';
-  return follower.runtime?.includes('cli') ? 'terminal' : 'radio';
-}
-
-function elapsedSince(connectedAt?: string): string | null {
-  if (!connectedAt) return null;
-  const timestamp = new Date(connectedAt).getTime();
-  if (!Number.isFinite(timestamp)) return null;
-  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
-  if (seconds < 60) return `${seconds}s`;
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
-  if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h`;
-  return `${Math.floor(seconds / 86_400)}d`;
-}
-
-function followerStatus(follower: ConnectedFollowerInfo): 'active' | 'warn' | 'idle' {
-  if (follower.health === 'stalled') return 'warn';
-  if (follower.peerState === 'connecting') return 'idle';
-  if (follower.peerState === 'connected' && follower.health === 'live') return 'active';
-  return 'idle';
-}
-
-function followerMeta(follower: ConnectedFollowerInfo): string {
-  const state =
-    follower.health === 'stalled'
-      ? 'stalled'
-      : follower.peerState === 'connecting'
-        ? 'connecting'
-        : 'connected';
-  const age = elapsedSince(follower.connectedAt);
-  return age ? `${state} ${age}` : state;
-}
-
 export function buildFollowersSection(followers: ConnectedFollowerInfo[]): MonitorSection {
   const stalled = followers.filter((follower) => follower.health === 'stalled').length;
   const connecting = followers.filter(
@@ -140,7 +98,7 @@ export function buildFollowersSection(followers: ConnectedFollowerInfo[]): Monit
       const sublabel = follower.hostOrigin ? `${detail} · ${follower.hostOrigin}` : detail;
       const badges = [follower.exec ? 'ssh' : '', follower.cdp ? 'playwright' : ''].filter(Boolean);
       return {
-        name: `${followerTypeLabel(follower)} · ${shortId(follower.runtimeId)}`,
+        name: followerTitle(follower),
         sublabel,
         meta: followerMeta(follower),
         icon: followerIcon(follower),
@@ -161,7 +119,7 @@ function buildTraySection(tray: MonitorTrayInfo): MonitorSection {
         : tray.state === 'leader' || tray.state === 'connected'
           ? 'active'
           : 'idle';
-  const session = tray.sessionId ? `Session ${shortId(tray.sessionId)}` : null;
+  const session = tray.sessionId ? `Session ${shortFollowerId(tray.sessionId)}` : null;
   const worker = tray.workerBaseUrl ? `Worker · ${tray.workerBaseUrl}` : null;
   return {
     id: 'tray',

--- a/packages/webapp/src/ui/wc/wc-nav.ts
+++ b/packages/webapp/src/ui/wc/wc-nav.ts
@@ -15,10 +15,15 @@ import {
   DEFAULT_STAGING_TRAY_WORKER_BASE_URL,
   resolveTrayWorkerBaseUrl,
 } from '../../scoops/tray-runtime-config.js';
+import {
+  getConnectedFollowersWithFallback,
+  getTrayResetter,
+} from '../../shell/supplemental-commands/host-command.js';
 import type { BootStageLogger } from '../boot/types.js';
 import { copyTextToClipboard } from '../clipboard.js';
 import type { OffscreenClient } from '../offscreen-client.js';
 import type { GroupedModels } from '../provider-settings.js';
+import type { SyncDialogTabId } from '../sync-dialog-model.js';
 import { computeTrayMenuModel } from '../tray-join-url.js';
 import type { WcShellRefs } from './wc-shell.js';
 
@@ -244,6 +249,7 @@ export async function wireWcNav(deps: WcNavDeps): Promise<void> {
   );
   const openTheme = buildOpenTheme(log);
   const openExperimental = buildOpenExperimental(log);
+  wireFollowersSegment(refs, log);
 
   refs.avatarMenu.addEventListener('slicc-avatar-action', (event) => {
     const id = (event as CustomEvent<{ id?: string }>).detail?.id;
@@ -291,7 +297,7 @@ export async function wireWcNav(deps: WcNavDeps): Promise<void> {
   // in place rather than re-running the same failing turn.
   await wireLoginEvent({ refs, log, openSettings, refreshModels, applyIdentity, client });
 
-  wireAccountsChangedResync({ refreshModels, refreshModelPill, applyIdentity, client });
+  await wireAccountsChangedResync({ refreshModels, refreshModelPill, applyIdentity, client });
 }
 
 function buildOpenSettings(
@@ -328,6 +334,43 @@ function buildOpenExperimental(log: BootStageLogger): () => void {
   };
 }
 
+/**
+ * The floatbar's followers segment is the second door into the sync dialog:
+ * hovering it shows the read-only HUD, clicking lands on the Status tab.
+ */
+function wireFollowersSegment(refs: WcShellRefs, log: BootStageLogger): void {
+  refs.floatbar.addEventListener('slicc-followers-click', () => {
+    openSyncDialog(log, { copy: false, initialTab: 'status' });
+  });
+}
+
+/**
+ * Open the session-sharing dialog. `copy` copies the join link on the way in
+ * (the avatar-menu affordance); `initialTab` forces a starting tab (the
+ * floatbar's followers segment opens on Status).
+ */
+function openSyncDialog(
+  log: BootStageLogger,
+  opts: { copy: boolean; initialTab?: SyncDialogTabId }
+): void {
+  const joinUrl = getLeaderTrayRuntimeStatus().session?.joinUrl;
+  if (!joinUrl) return;
+  if (opts.copy) void copyTextToClipboard(joinUrl).catch(() => undefined);
+  void import('../legacy-styles.js')
+    .then(({ loadLegacyDialogStyles }) => loadLegacyDialogStyles())
+    .then(async () => {
+      const { showSyncEnabledDialog } = await import('../sync-dialog.js');
+      showSyncEnabledDialog({
+        joinUrl,
+        copied: opts.copy,
+        initialTab: opts.initialTab,
+        followers: getConnectedFollowersWithFallback(),
+        onReset: getTrayResetter() ?? null,
+      });
+    })
+    .catch((err) => log.error('sync dialog failed', err));
+}
+
 function handleTrayActionId(id: string, log: BootStageLogger): boolean {
   if (id === 'tray-enable') {
     void resolveTrayWorkerBaseUrl({
@@ -344,17 +387,11 @@ function handleTrayActionId(id: string, log: BootStageLogger): boolean {
     return true;
   }
   if (id === 'tray-copy') {
-    const joinUrl = getLeaderTrayRuntimeStatus().session?.joinUrl;
-    if (joinUrl) {
-      void copyTextToClipboard(joinUrl).catch(() => undefined);
-      void import('../legacy-styles.js')
-        .then(({ loadLegacyDialogStyles }) => loadLegacyDialogStyles())
-        .then(async () => {
-          const { showSyncEnabledDialog } = await import('../sync-dialog.js');
-          showSyncEnabledDialog({ joinUrl, copied: true });
-        })
-        .catch((err) => log.error('sync dialog failed', err));
-    }
+    // The avatar-menu entry is an explicit "give me the link" — it copies
+    // first, then explains. The floatbar entry (openSyncDialog with
+    // `copy: false`) must NOT touch the clipboard: clicking a status readout
+    // should never overwrite what you had on it.
+    openSyncDialog(log, { copy: true });
     return true;
   }
   if (id === 'tray-stop') {
@@ -510,6 +547,12 @@ async function wireModelPicker(
  * provider with a dynamic catalog (getModelIds) fetches it asynchronously:
  * kick its refreshModels and sync again when the catalog lands, so the
  * picker fills without a hard reload.
+ */
+/**
+ * Re-sync the model list, model pill and avatar identity whenever accounts
+ * change. Awaited by `wireWcNav` rather than left floating: its dynamic
+ * provider-settings import is already resolved by then, so awaiting costs
+ * nothing, and a floating call swallowed any failure of that import.
  */
 async function wireAccountsChangedResync(opts: {
   refreshModels(): void;

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -7,6 +7,7 @@
  * are reused verbatim — they were already Layout-free.
  */
 
+import type { SliccFloatbar } from '@slicc/webcomponents';
 import type { BrowserAPI, CDPTransport } from '../../cdp/index.js';
 import { type PanelRpcPushMsg, panelRpcChannelName } from '../../kernel/panel-rpc.js';
 import type { LickEvent } from '../../scoops/lick-manager.js';
@@ -45,6 +46,7 @@ import type { TeleportFollowerInfo } from '../../shell/supplemental-commands/pla
 import { setupStandalonePanelRpc } from '../boot/setup-standalone-panel-rpc.js';
 import { runHostedBootstrap } from '../boot/setup-standalone-tray-init-hosted.js';
 import type { BootStageLogger } from '../boot/types.js';
+import { FOLLOWERS_CHANGED_EVENT, toFollowerHudRows } from '../follower-presentation.js';
 import { LeaderExecSessionPool } from '../leader-exec-runner.js';
 import type { OffscreenClient } from '../offscreen-client.js';
 import { type PageFollowerTrayHandle, startPageFollowerTray } from '../page-follower-tray.js';
@@ -317,6 +319,45 @@ export function buildFollowerOptions(
   };
 }
 
+/**
+ * Publish the leader's follower roster to every surface that shows it: the
+ * tab-persistence guard, the floatbar (label + followers segment + HUD rows),
+ * the kernel-worker `localStorage` shim `host`/`ssh` read, and the window
+ * event an open sync dialog listens on.
+ */
+function applyFollowerPresentation(
+  deps: WcTrayDeps,
+  state: TrayRoleState,
+  fallbackCount: number
+): void {
+  const followers = state.leader ? getLeaderConnectedFollowers(state.leader) : [];
+  const count = fallbackCount;
+  if (count > 0) {
+    state.persistenceGuard.activate();
+  } else {
+    state.persistenceGuard.deactivate();
+  }
+  // The count used to be smuggled into the label string; it now has its own
+  // hoverable/clickable segment, so the label goes back to naming the float.
+  deps.refs.floatbar.setAttribute(
+    'label',
+    count > 0 ? 'tray · live' : (deps.baseFloatLabel ?? 'standalone · live')
+  );
+  // A peer still handshaking is mirrored to the shim and shown in the Monitor,
+  // but it is NOT counted by the registry — so it must not appear in the pill
+  // either, or the segment would contradict its own count. Anything without an
+  // explicit `connecting` state stays visible.
+  (deps.refs.floatbar as SliccFloatbar).followers = toFollowerHudRows(
+    followers.filter((follower) => follower.peerState !== 'connecting')
+  );
+  writeConnectedFollowersToShim(followers);
+  // Let an open sync dialog re-render (its Status tab appears on the first
+  // follower and its rows go live) without polling the roster. Dispatched on
+  // the INJECTED window (`deps.window`), the same one the rest of this module
+  // uses — never the global, which a detached/worker-side caller may not have.
+  deps.window.dispatchEvent(new CustomEvent(FOLLOWERS_CHANGED_EVENT, { detail: { followers } }));
+}
+
 /** Leader option factory — the WC equivalent of `buildLeaderTrayOptions`. */
 export function createLeaderOptionsFactory(
   deps: WcTrayDeps,
@@ -325,20 +366,7 @@ export function createLeaderOptionsFactory(
 ): (workerBaseUrl: string) => StartPageLeaderTrayOptions {
   const { client, refs } = deps;
   const refreshFollowerPresentation = (fallbackCount = 0): void => {
-    const followers = state.leader ? getLeaderConnectedFollowers(state.leader) : [];
-    const count = fallbackCount;
-    if (count > 0) {
-      state.persistenceGuard.activate();
-    } else {
-      state.persistenceGuard.deactivate();
-    }
-    refs.floatbar.setAttribute(
-      'label',
-      count > 0
-        ? `tray · ${count} follower${count === 1 ? '' : 's'}`
-        : (deps.baseFloatLabel ?? 'standalone · live')
-    );
-    writeConnectedFollowersToShim(followers);
+    applyFollowerPresentation(deps, state, fallbackCount);
   };
   const execSessions = new LeaderExecSessionPool(client);
   return (workerBaseUrl) => ({

--- a/packages/webapp/tests/ui/follower-presentation.test.ts
+++ b/packages/webapp/tests/ui/follower-presentation.test.ts
@@ -1,0 +1,179 @@
+/**
+ * The shared follower vocabulary used by the Monitor panel, the floatbar HUD
+ * and the sync dialog's Status tab. Pure — `now` is injected so the elapsed
+ * formatting doesn't race the clock.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ConnectedFollowerInfo } from '../../src/shell/supplemental-commands/host-command.js';
+import {
+  elapsedSince,
+  followerCapabilities,
+  followerDetail,
+  followerIcon,
+  followerMeta,
+  followerStatus,
+  followerTitle,
+  followerTypeLabel,
+  shortFollowerId,
+  toFollowerHudRows,
+} from '../../src/ui/follower-presentation.js';
+
+const NOW = Date.UTC(2026, 7, 21, 12, 0, 0);
+const ago = (ms: number): string => new Date(NOW - ms).toISOString();
+
+function follower(overrides: Partial<ConnectedFollowerInfo> = {}): ConnectedFollowerInfo {
+  return {
+    runtimeId: 'follower-abcdef012345678',
+    health: 'live',
+    peerState: 'connected',
+    ...overrides,
+  };
+}
+
+describe('shortFollowerId', () => {
+  it('drops the follower- prefix', () => {
+    expect(shortFollowerId('follower-abc')).toBe('abc');
+  });
+
+  it('truncates anything longer than 12 characters', () => {
+    expect(shortFollowerId('follower-abcdef012345678')).toBe('abcdef01…');
+  });
+
+  it('leaves an exactly-12-character id intact', () => {
+    expect(shortFollowerId('follower-abcdef012345')).toBe('abcdef012345');
+  });
+});
+
+describe('followerTypeLabel', () => {
+  it('names each browser-ish float type', () => {
+    expect(followerTypeLabel(follower({ floatType: 'ios' }))).toBe('iOS');
+    expect(followerTypeLabel(follower({ floatType: 'electron' }))).toBe('Electron');
+    expect(followerTypeLabel(follower({ floatType: 'extension' }))).toBe('Extension');
+    expect(followerTypeLabel(follower({ floatType: 'standalone' }))).toBe('Standalone');
+  });
+
+  it('recognises the CLI from its runtime tag, which derives no float type', () => {
+    expect(followerTypeLabel(follower({ runtime: 'slicc-cli' }))).toBe('CLI');
+  });
+
+  it('falls back to a generic name for an unknown runtime', () => {
+    expect(followerTypeLabel(follower({ runtime: 'something-else' }))).toBe('Follower');
+    expect(followerTypeLabel(follower())).toBe('Follower');
+  });
+});
+
+describe('followerIcon', () => {
+  it('gives each kind its own glyph', () => {
+    expect(followerIcon(follower({ floatType: 'ios' }))).toBe('smartphone');
+    expect(followerIcon(follower({ floatType: 'electron' }))).toBe('monitor');
+    expect(followerIcon(follower({ floatType: 'standalone' }))).toBe('monitor');
+    expect(followerIcon(follower({ floatType: 'extension' }))).toBe('blocks');
+    expect(followerIcon(follower({ runtime: 'slicc-cli' }))).toBe('terminal');
+    expect(followerIcon(follower())).toBe('radio');
+  });
+});
+
+describe('elapsedSince', () => {
+  it('scales the unit with the age', () => {
+    expect(elapsedSince(ago(5_000), NOW)).toBe('5s');
+    expect(elapsedSince(ago(4 * 60_000), NOW)).toBe('4m');
+    expect(elapsedSince(ago(3 * 3_600_000), NOW)).toBe('3h');
+    expect(elapsedSince(ago(2 * 86_400_000), NOW)).toBe('2d');
+  });
+
+  it('clamps a future timestamp to zero rather than printing a negative age', () => {
+    expect(elapsedSince(new Date(NOW + 60_000).toISOString(), NOW)).toBe('0s');
+  });
+
+  it('returns null for a missing or unparseable timestamp', () => {
+    expect(elapsedSince(undefined, NOW)).toBeNull();
+    expect(elapsedSince('not a date', NOW)).toBeNull();
+  });
+});
+
+describe('followerStatus', () => {
+  it('flags a stalled follower as a warning even while its peer reads connected', () => {
+    expect(followerStatus(follower({ health: 'stalled' }))).toBe('warn');
+  });
+
+  it('treats a handshaking peer as idle', () => {
+    expect(followerStatus(follower({ peerState: 'connecting' }))).toBe('idle');
+  });
+
+  it('is active only when the peer is connected and the channel is live', () => {
+    expect(followerStatus(follower())).toBe('active');
+    expect(followerStatus(follower({ health: undefined }))).toBe('idle');
+  });
+});
+
+describe('followerMeta', () => {
+  it('pairs the state with the age', () => {
+    expect(followerMeta(follower({ connectedAt: ago(4 * 60_000) }), NOW)).toBe('connected 4m');
+    expect(followerMeta(follower({ health: 'stalled', connectedAt: ago(60_000) }), NOW)).toBe(
+      'stalled 1m'
+    );
+    expect(followerMeta(follower({ peerState: 'connecting' }), NOW)).toBe('connecting');
+  });
+});
+
+describe('followerCapabilities', () => {
+  it('leads with the one that grants code execution', () => {
+    expect(followerCapabilities(follower({ exec: true, cdp: true }))).toEqual([
+      'can run commands',
+      'hosts tabs',
+    ]);
+  });
+
+  it('claims nothing for a plain follower', () => {
+    expect(followerCapabilities(follower())).toEqual([]);
+  });
+});
+
+describe('followerTitle / followerDetail', () => {
+  it('joins the kind and the short id', () => {
+    expect(followerTitle(follower({ floatType: 'ios', runtimeId: 'follower-phone1' }))).toBe(
+      'iOS · phone1'
+    );
+  });
+
+  it('prefers the advertised MOTD over the runtime tag', () => {
+    expect(followerDetail(follower({ runtime: 'slicc-cli', motd: 'lars@build-box' }))).toBe(
+      'lars@build-box'
+    );
+    expect(followerDetail(follower({ runtime: 'slicc-cli' }))).toBe('slicc-cli');
+    expect(followerDetail(follower())).toBeUndefined();
+  });
+});
+
+describe('toFollowerHudRows', () => {
+  it('maps the roster onto presentational rows keyed by runtime id', () => {
+    const rows = toFollowerHudRows(
+      [
+        follower({
+          runtimeId: 'follower-cli1',
+          runtime: 'slicc-cli',
+          exec: true,
+          motd: 'lars@build-box',
+          connectedAt: ago(120_000),
+        }),
+      ],
+      NOW
+    );
+    expect(rows).toEqual([
+      {
+        id: 'follower-cli1',
+        icon: 'terminal',
+        title: 'CLI · cli1',
+        detail: 'lars@build-box',
+        state: 'active',
+        stateText: 'connected 2m',
+        chips: ['can run commands'],
+      },
+    ]);
+  });
+
+  it('maps an empty roster to no rows', () => {
+    expect(toFollowerHudRows([], NOW)).toEqual([]);
+  });
+});

--- a/packages/webapp/tests/ui/sync-dialog-model.test.ts
+++ b/packages/webapp/tests/ui/sync-dialog-model.test.ts
@@ -4,15 +4,19 @@
  * `sync-dialog.test.ts` covers the rendering.
  */
 
+import { SLICC_HOSTED_ORIGIN } from '@slicc/shared-ts';
 import { describe, expect, it } from 'vitest';
 import {
   buildSyncDialogTabs,
   cliFollowCommand,
+  cliInstallCommand,
+  cliInstallCommandWindows,
   defaultSyncDialogTab,
   maskJoinUrl,
   revokeConfirmLabel,
   sharingSummary,
   syncDialogCopy,
+  trayOriginFor,
 } from '../../src/ui/sync-dialog-model.js';
 
 describe('buildSyncDialogTabs', () => {
@@ -83,6 +87,31 @@ describe('cliFollowCommand', () => {
     expect(cliFollowCommand('https://tray.example.com/join/tok')).toBe(
       'slicc https://tray.example.com/join/tok follow bash -c'
     );
+  });
+});
+
+describe('the CLI installers', () => {
+  it('derives the installer from the join link, so a staging leader hands out the staging CLI', () => {
+    expect(trayOriginFor('https://staging.example.com/join/tok')).toBe(
+      'https://staging.example.com'
+    );
+    expect(cliInstallCommand('https://staging.example.com/join/tok')).toBe(
+      'curl -fsSL https://staging.example.com/install-cli | sh'
+    );
+    expect(cliInstallCommandWindows('https://staging.example.com/join/tok')).toBe(
+      'irm https://staging.example.com/install-cli.ps1 | iex'
+    );
+  });
+
+  it('falls back to production when the join link is unparseable', () => {
+    expect(trayOriginFor('nonsense')).toBe(SLICC_HOSTED_ORIGIN);
+    expect(cliInstallCommand('nonsense')).toBe(
+      `curl -fsSL ${SLICC_HOSTED_ORIGIN}/install-cli | sh`
+    );
+  });
+
+  it('never leaks the join token into the install command', () => {
+    expect(cliInstallCommand('https://tray.example.com/join/s3cr3t')).not.toContain('s3cr3t');
   });
 });
 

--- a/packages/webapp/tests/ui/sync-dialog-model.test.ts
+++ b/packages/webapp/tests/ui/sync-dialog-model.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The session-sharing dialog's pure model: which tabs exist, which one opens,
+ * how the join link is masked, and the exact copy a user reads. DOM-free —
+ * `sync-dialog.test.ts` covers the rendering.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildSyncDialogTabs,
+  cliFollowCommand,
+  defaultSyncDialogTab,
+  maskJoinUrl,
+  revokeConfirmLabel,
+  sharingSummary,
+  syncDialogCopy,
+} from '../../src/ui/sync-dialog-model.js';
+
+describe('buildSyncDialogTabs', () => {
+  it('offers one tab per follower kind when nothing is connected', () => {
+    expect(buildSyncDialogTabs(0).map((tab) => tab.id)).toEqual(['browser', 'iphone', 'terminal']);
+  });
+
+  it('prepends Status, badged with the count, once something is connected', () => {
+    const tabs = buildSyncDialogTabs(3);
+    expect(tabs.map((tab) => tab.id)).toEqual(['status', 'browser', 'iphone', 'terminal']);
+    expect(tabs[0].badge).toBe(3);
+  });
+
+  it('never badges the how-to tabs', () => {
+    for (const tab of buildSyncDialogTabs(2).slice(1)) expect(tab.badge).toBeUndefined();
+  });
+});
+
+describe('defaultSyncDialogTab', () => {
+  it('opens on Browser before anything is connected', () => {
+    expect(defaultSyncDialogTab(0)).toBe('browser');
+  });
+
+  it('opens on Status once something is', () => {
+    expect(defaultSyncDialogTab(1)).toBe('status');
+  });
+});
+
+describe('maskJoinUrl', () => {
+  it('hides the token but keeps the shape of the link', () => {
+    expect(maskJoinUrl('https://tray.example.com/join/s3cr3t')).toBe(
+      'https://tray.example.com/join/••••••••'
+    );
+  });
+
+  it('does not percent-encode the mask', () => {
+    expect(maskJoinUrl('https://tray.example.com/join/s3cr3t')).not.toContain('%');
+  });
+
+  it('preserves a query string and fragment', () => {
+    expect(maskJoinUrl('https://tray.example.com/join/tok?a=1#f')).toBe(
+      'https://tray.example.com/join/••••••••?a=1#f'
+    );
+  });
+
+  it('masks the token under a path prefix', () => {
+    expect(maskJoinUrl('https://tray.example.com/t/join/tok')).toContain('/t/join/•');
+  });
+
+  it('returns anything it cannot parse unchanged', () => {
+    expect(maskJoinUrl('not a url')).toBe('not a url');
+    expect(maskJoinUrl('')).toBe('');
+  });
+
+  it('returns a URL with no /join/ segment unchanged', () => {
+    expect(maskJoinUrl('https://tray.example.com/other/tok')).toBe(
+      'https://tray.example.com/other/tok'
+    );
+  });
+
+  it('returns a /join/ with an empty token unchanged', () => {
+    expect(maskJoinUrl('https://tray.example.com/join/')).toBe('https://tray.example.com/join/');
+  });
+});
+
+describe('cliFollowCommand', () => {
+  it('hands over the runner-bearing form, which is the one that works', () => {
+    expect(cliFollowCommand('https://tray.example.com/join/tok')).toBe(
+      'slicc https://tray.example.com/join/tok follow bash -c'
+    );
+  });
+});
+
+describe('syncDialogCopy', () => {
+  it('routes the browser user through the avatar menu', () => {
+    const [lead] = syncDialogCopy('browser');
+    expect(lead).toMatch(/Connect to another browser/);
+  });
+
+  it('names both iPhone routes — the paste field and iCloud', () => {
+    const [lead, note] = syncDialogCopy('iphone');
+    expect(lead).toMatch(/Settings → Join link/);
+    expect(note).toMatch(/iCloud Sessions/);
+  });
+
+  it('warns the terminal user about what follow grants', () => {
+    const [, note] = syncDialogCopy('terminal');
+    expect(note).toMatch(/run commands on that machine/);
+  });
+
+  it('keeps every tab to two lines', () => {
+    for (const tab of ['browser', 'iphone', 'terminal'] as const) {
+      expect(syncDialogCopy(tab)).toHaveLength(2);
+    }
+  });
+});
+
+describe('sharingSummary', () => {
+  it('says nothing is connected at zero', () => {
+    expect(sharingSummary(0)).toBe('Nothing connected yet.');
+  });
+
+  it('agrees with itself in number', () => {
+    expect(sharingSummary(1)).toBe('1 device is connected.');
+    expect(sharingSummary(4)).toBe('4 devices are connected.');
+  });
+});
+
+describe('revokeConfirmLabel', () => {
+  it('names the blast radius', () => {
+    expect(revokeConfirmLabel(1)).toMatch(/1 connected device will be disconnected/);
+    expect(revokeConfirmLabel(3)).toMatch(/3 connected devices will be disconnected/);
+  });
+
+  it('still explains itself with nothing attached', () => {
+    expect(revokeConfirmLabel(0)).toMatch(/old link stops working/);
+  });
+});

--- a/packages/webapp/tests/ui/sync-dialog.test.ts
+++ b/packages/webapp/tests/ui/sync-dialog.test.ts
@@ -142,14 +142,27 @@ describe('showSyncEnabledDialog', () => {
   });
 
   describe('the Terminal tab', () => {
+    it('leads with installing the CLI, so `slicc` exists before it is invoked', async () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false, initialTab: 'terminal' });
+      const install = overlayEl().querySelector('[data-command="copy-install"]') as HTMLElement;
+      expect(install.textContent).toBe('curl -fsSL https://tray.example.com/install-cli | sh');
+      expect(overlayEl().textContent).toMatch(/Windows: irm .*\/install-cli\.ps1 \| iex/);
+
+      buttonByText(/Copy install command/).click();
+      await Promise.resolve();
+      expect(mockedCopy).toHaveBeenCalledWith(
+        'curl -fsSL https://tray.example.com/install-cli | sh'
+      );
+    });
+
     it('offers a runner-bearing follow command and copies it unmasked', async () => {
       showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false, initialTab: 'terminal' });
-      const command = overlayEl().querySelector('[data-command]') as HTMLElement;
+      const command = overlayEl().querySelector('[data-command="copy-command"]') as HTMLElement;
       expect(command.textContent).toMatch(
         /^slicc https:\/\/tray\.example\.com\/join\/•+ follow bash -c$/
       );
 
-      buttonByText(/Copy command/).click();
+      buttonByText(/^Copy command$/).click();
       await Promise.resolve();
       expect(mockedCopy).toHaveBeenCalledWith(`slicc ${JOIN_URL} follow bash -c`);
     });
@@ -242,6 +255,40 @@ describe('showSyncEnabledDialog', () => {
       expect(onReset).toHaveBeenCalledTimes(1);
     });
 
+    it('goes red only once armed — the idle button is not the destructive one', async () => {
+      showSyncEnabledDialog({
+        joinUrl: JOIN_URL,
+        copied: true,
+        onReset: async () => {},
+        followers: [cliFollower],
+      });
+      const revoke = buttonByText(/Revoke link/);
+      expect(revoke.dataset.armed).toBe('0');
+      expect(revoke.style.background).toBe('');
+
+      revoke.click();
+      await Promise.resolve();
+      expect(revoke.dataset.armed).toBe('1');
+      expect(revoke.style.background).toBe('var(--s2-negative)');
+    });
+
+    it('disarms — and drops the red — when the reset fails', async () => {
+      showSyncEnabledDialog({
+        joinUrl: JOIN_URL,
+        copied: true,
+        onReset: async () => {
+          throw new Error('boom');
+        },
+      });
+      const revoke = buttonByText(/Revoke link/);
+      revoke.click();
+      revoke.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(revoke.dataset.armed).toBe('0');
+      expect(revoke.style.background).toBe('');
+    });
+
     it('reports success and stops offering the stale link', async () => {
       showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: true, onReset: async () => {} });
       const revoke = buttonByText(/Revoke link/);
@@ -279,6 +326,28 @@ describe('showSyncEnabledDialog', () => {
       await Promise.resolve();
       await Promise.resolve();
       expect(overlayEl().textContent).toMatch(/Revoke failed: string-reason/);
+    });
+  });
+
+  describe('contrast', () => {
+    it('states an explicit color on its text — `.dialog` only colors its own title/desc classes', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false, followers: [cliFollower] });
+      const uncolored = Array.from(overlayEl().querySelectorAll('div')).filter((node) => {
+        const el = node as HTMLElement;
+        // Layout-only wrappers carry no text of their own.
+        const ownText = Array.from(el.childNodes).some(
+          (child) => child.nodeType === Node.TEXT_NODE && (child.textContent ?? '').trim() !== ''
+        );
+        return ownText && el.style.color === '' && !el.className.startsWith('dialog__');
+      });
+      expect(uncolored.map((el) => el.textContent)).toEqual([]);
+    });
+
+    it('uses the themed semantic colors for follower state, not hardcoded hexes', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false, followers: [cliFollower] });
+      const dot = overlayEl().querySelector('[data-follower] span') as HTMLElement;
+      expect(overlayEl().innerHTML).not.toMatch(/#22c55e|#f59e0b/);
+      expect(dot).toBeTruthy();
     });
   });
 

--- a/packages/webapp/tests/ui/sync-dialog.test.ts
+++ b/packages/webapp/tests/ui/sync-dialog.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 /**
- * DOM-only tests for `showSyncEnabledDialog` — the avatar-popover dialog
- * that surfaces the leader's join URL after a `host enable` succeeds.
- * Stubs the optional clipboard module so the copy-back button can be
- * exercised without depending on the browser's real clipboard API.
+ * DOM tests for `showSyncEnabledDialog` — the session-sharing dialog reached
+ * from the avatar menu ("Enable multi-browser sync") and from the floatbar's
+ * followers segment. Stubs the clipboard module so the copy buttons can be
+ * exercised without the browser's real clipboard API.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -12,10 +12,56 @@ vi.mock('../../src/ui/clipboard.js', () => ({
   copyTextToClipboard: vi.fn(async () => true),
 }));
 
+import type { ConnectedFollowerInfo } from '../../src/shell/supplemental-commands/host-command.js';
 import { copyTextToClipboard } from '../../src/ui/clipboard.js';
+import { FOLLOWERS_CHANGED_EVENT } from '../../src/ui/follower-presentation.js';
 import { showSyncEnabledDialog } from '../../src/ui/sync-dialog.js';
 
 const mockedCopy = vi.mocked(copyTextToClipboard);
+const JOIN_URL = 'https://tray.example.com/join/s3cr3t-token';
+
+function overlayEl(): HTMLElement {
+  return document.querySelector('.dialog-overlay[data-sync-dialog]') as HTMLElement;
+}
+
+function buttonByText(pattern: RegExp): HTMLButtonElement {
+  return Array.from(overlayEl().querySelectorAll('button')).find((b) =>
+    pattern.test(b.textContent ?? '')
+  ) as HTMLButtonElement;
+}
+
+function tabIds(): string[] {
+  return Array.from(overlayEl().querySelectorAll('[role="tab"]')).map(
+    (el) => (el as HTMLElement).dataset.tab ?? ''
+  );
+}
+
+function activeTab(): string {
+  const el = overlayEl().querySelector('[role="tab"][aria-selected="true"]') as HTMLElement;
+  return el?.dataset.tab ?? '';
+}
+
+function clickTab(id: string): void {
+  (overlayEl().querySelector(`[role="tab"][data-tab="${id}"]`) as HTMLButtonElement).click();
+}
+
+const cliFollower: ConnectedFollowerInfo = {
+  runtimeId: 'follower-abc123def456',
+  runtime: 'slicc-cli',
+  connectedAt: new Date(Date.now() - 4 * 60_000).toISOString(),
+  health: 'live',
+  peerState: 'connected',
+  exec: true,
+  motd: 'slicc-cli exec target · lars@build-box',
+};
+
+const iosFollower: ConnectedFollowerInfo = {
+  runtimeId: 'follower-ios999',
+  runtime: 'slicc-ios',
+  floatType: 'ios',
+  health: 'live',
+  peerState: 'connected',
+};
 
 beforeEach(() => {
   document.body.replaceChildren();
@@ -24,146 +70,237 @@ beforeEach(() => {
 });
 
 describe('showSyncEnabledDialog', () => {
-  it('mounts an overlay with the join URL and the copied-state status line', () => {
-    showSyncEnabledDialog({
-      joinUrl: 'https://slicc.example.com/join#abc',
-      copied: true,
-    });
-    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]');
-    expect(overlay).not.toBeNull();
-    expect(overlay!.querySelector('.dialog__title')!.textContent).toMatch(/sync is on/i);
-    expect(overlay!.textContent).toContain('https://slicc.example.com/join#abc');
-    expect(overlay!.textContent).toContain('URL copied to clipboard');
-  });
-
-  it('renders the not-copied desc and label when `copied: false`', () => {
-    showSyncEnabledDialog({
-      joinUrl: 'https://slicc.example.com/join#xyz',
-      copied: false,
-    });
-    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
-    const desc = overlay.querySelector('.dialog__desc')!;
-    expect(desc.textContent).toMatch(/Couldn[\u2019']t copy automatically/);
-    // The action button reads "Copy URL" instead of "Copy again".
-    const buttons = Array.from(overlay.querySelectorAll('button'));
-    const copyBtn = buttons.find((b) => /Copy URL/.test(b.textContent ?? ''));
-    expect(copyBtn).toBeDefined();
+  it('mounts an overlay titled "Session sharing"', () => {
+    showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: true });
+    expect(overlayEl()).not.toBeNull();
+    expect(overlayEl().querySelector('.dialog__title')!.textContent).toBe('Session sharing');
+    expect(overlayEl().textContent).toContain('Join link copied to clipboard');
   });
 
   it('removes any pre-existing instance before mounting (idempotent)', () => {
-    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true });
-    showSyncEnabledDialog({ joinUrl: 'https://b', copied: true });
-    const overlays = document.querySelectorAll('.dialog-overlay[data-sync-dialog]');
-    expect(overlays).toHaveLength(1);
-    expect(overlays[0].textContent).toContain('https://b');
+    showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: true });
+    showSyncEnabledDialog({ joinUrl: 'https://tray.example.com/join/second', copied: true });
+    expect(document.querySelectorAll('.dialog-overlay[data-sync-dialog]')).toHaveLength(1);
   });
 
-  it('removes the overlay when Done is clicked', () => {
-    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true });
-    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
-    const buttons = Array.from(overlay.querySelectorAll('button')) as HTMLButtonElement[];
-    const done = buttons.find((b) => b.textContent === 'Done')!;
-    done.click();
-    expect(document.querySelector('.dialog-overlay[data-sync-dialog]')).toBeNull();
-  });
-
-  it('removes the overlay on backdrop click', () => {
-    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true });
-    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]') as HTMLElement;
-    overlay.click();
-    expect(document.querySelector('.dialog-overlay[data-sync-dialog]')).toBeNull();
-  });
-
-  it('does not remove the overlay on inner click', () => {
-    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true });
-    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
-    const dialog = overlay.querySelector('.dialog')! as HTMLElement;
-    dialog.click();
-    expect(document.querySelector('.dialog-overlay[data-sync-dialog]')).not.toBeNull();
-  });
-
-  it('copy-again button writes the join URL and updates the status', async () => {
-    showSyncEnabledDialog({ joinUrl: 'https://slicc.example.com/join#abc', copied: true });
-    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
-    const copyBtn = Array.from(overlay.querySelectorAll('button')).find(
-      (b) => b.textContent === 'Copy again'
-    ) as HTMLButtonElement;
-    copyBtn.click();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(mockedCopy).toHaveBeenCalledWith('https://slicc.example.com/join#abc');
-    expect(overlay.textContent).toContain('URL copied to clipboard');
-  });
-
-  it('copy failure surfaces a manual-copy hint', async () => {
-    mockedCopy.mockResolvedValueOnce(false);
-    showSyncEnabledDialog({ joinUrl: 'https://a', copied: false });
-    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
-    const copyBtn = Array.from(overlay.querySelectorAll('button')).find(
-      (b) => b.textContent === 'Copy URL'
-    ) as HTMLButtonElement;
-    copyBtn.click();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(overlay.textContent).toMatch(/Select and copy manually/);
-  });
-
-  it('renders a Reset button only when `onReset` is supplied', () => {
-    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true });
-    let overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
-    expect(
-      Array.from(overlay.querySelectorAll('button')).some((b) =>
-        /Reset URL/.test(b.textContent ?? '')
-      )
-    ).toBe(false);
-
-    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true, onReset: async () => {} });
-    overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
-    expect(
-      Array.from(overlay.querySelectorAll('button')).some((b) =>
-        /Reset URL/.test(b.textContent ?? '')
-      )
-    ).toBe(true);
-  });
-
-  it('Reset button success path clears the URL display and disables buttons', async () => {
-    const onReset = vi.fn(async () => {});
-    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true, onReset });
-    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
-    const buttons = Array.from(overlay.querySelectorAll('button')) as HTMLButtonElement[];
-    const resetBtn = buttons.find((b) => /Reset URL/.test(b.textContent ?? ''))!;
-    resetBtn.click();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(onReset).toHaveBeenCalled();
-    expect(resetBtn.disabled).toBe(true);
-    expect(overlay.textContent).toMatch(/Sync URL reset/);
-  });
-
-  it('Reset button failure path re-enables buttons and shows the error', async () => {
-    const onReset = vi.fn(async () => {
-      throw new Error('boom');
+  describe('tabs', () => {
+    it('shows the three how-to tabs and starts on Browser when nothing is connected', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false });
+      expect(tabIds()).toEqual(['browser', 'iphone', 'terminal']);
+      expect(activeTab()).toBe('browser');
     });
-    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true, onReset });
-    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
-    const buttons = Array.from(overlay.querySelectorAll('button')) as HTMLButtonElement[];
-    const resetBtn = buttons.find((b) => /Reset URL/.test(b.textContent ?? ''))!;
-    const doneBtn = buttons.find((b) => b.textContent === 'Done')!;
-    resetBtn.click();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(overlay.textContent).toMatch(/Reset failed: boom/);
-    expect(resetBtn.disabled).toBe(false);
-    expect(doneBtn.disabled).toBe(false);
+
+    it('adds Status as the first tab and opens on it when a follower is connected', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false, followers: [cliFollower] });
+      expect(tabIds()).toEqual(['status', 'browser', 'iphone', 'terminal']);
+      expect(activeTab()).toBe('status');
+      expect(overlayEl().querySelector('[role="tab"][data-tab="status"]')!.textContent).toContain(
+        '1'
+      );
+    });
+
+    it('honours an explicit initialTab', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false, initialTab: 'terminal' });
+      expect(activeTab()).toBe('terminal');
+    });
+
+    it('falls back to Browser when initialTab is status but nothing is connected', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false, initialTab: 'status' });
+      expect(activeTab()).toBe('browser');
+    });
   });
 
-  it('Reset failure with non-Error rejection still surfaces a string', async () => {
-    const onReset = vi.fn(async () => {
-      throw 'string-reason';
+  describe('the join link', () => {
+    it('masks the token until Show is clicked', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false });
+      const url = overlayEl().querySelector('[data-join-url]') as HTMLElement;
+      expect(url.textContent).not.toContain('s3cr3t-token');
+      expect(url.textContent).toContain('••••••••');
+
+      buttonByText(/^Show$/).click();
+      expect((overlayEl().querySelector('[data-join-url]') as HTMLElement).textContent).toContain(
+        's3cr3t-token'
+      );
     });
-    showSyncEnabledDialog({ joinUrl: 'https://a', copied: true, onReset });
-    const overlay = document.querySelector('.dialog-overlay[data-sync-dialog]')!;
-    const resetBtn = Array.from(overlay.querySelectorAll('button')).find((b) =>
-      /Reset URL/.test(b.textContent ?? '')
-    ) as HTMLButtonElement;
-    resetBtn.click();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(overlay.textContent).toMatch(/Reset failed: string-reason/);
+
+    it('copies the unmasked link', async () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false });
+      buttonByText(/Copy join link/).click();
+      await Promise.resolve();
+      expect(mockedCopy).toHaveBeenCalledWith(JOIN_URL);
+      expect(overlayEl().textContent).toContain('Join link copied.');
+    });
+
+    it('surfaces a manual-copy hint when the clipboard write fails', async () => {
+      mockedCopy.mockResolvedValueOnce(false);
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false });
+      buttonByText(/Copy join link/).click();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(overlayEl().textContent).toMatch(/copy it manually/);
+    });
+  });
+
+  describe('the Terminal tab', () => {
+    it('offers a runner-bearing follow command and copies it unmasked', async () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false, initialTab: 'terminal' });
+      const command = overlayEl().querySelector('[data-command]') as HTMLElement;
+      expect(command.textContent).toMatch(
+        /^slicc https:\/\/tray\.example\.com\/join\/•+ follow bash -c$/
+      );
+
+      buttonByText(/Copy command/).click();
+      await Promise.resolve();
+      expect(mockedCopy).toHaveBeenCalledWith(`slicc ${JOIN_URL} follow bash -c`);
+    });
+
+    it('warns that the leader gets to run commands there', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false, initialTab: 'terminal' });
+      expect(overlayEl().textContent).toMatch(/run commands on that machine/);
+    });
+  });
+
+  describe('the iPhone tab', () => {
+    it('names both routes: paste into Settings, or pick it up from iCloud', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false, initialTab: 'iphone' });
+      expect(overlayEl().textContent).toMatch(/Settings → Join link/);
+      expect(overlayEl().textContent).toMatch(/iCloud Sessions/);
+    });
+  });
+
+  describe('the Status tab', () => {
+    it('renders one row per follower with its capability chips', () => {
+      showSyncEnabledDialog({
+        joinUrl: JOIN_URL,
+        copied: false,
+        followers: [cliFollower, iosFollower],
+      });
+      const rows = overlayEl().querySelectorAll('[data-follower]');
+      expect(rows).toHaveLength(2);
+      expect(overlayEl().textContent).toContain('CLI · abc123def456');
+      expect(overlayEl().textContent).toContain('iOS · ios999');
+      expect(overlayEl().textContent).toContain('can run commands');
+      expect(overlayEl().textContent).toContain('lars@build-box');
+    });
+
+    it('appears live when the first follower connects, without switching tabs', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false });
+      expect(tabIds()).not.toContain('status');
+
+      window.dispatchEvent(
+        new CustomEvent(FOLLOWERS_CHANGED_EVENT, { detail: { followers: [cliFollower] } })
+      );
+      expect(tabIds()).toEqual(['status', 'browser', 'iphone', 'terminal']);
+      expect(activeTab()).toBe('browser');
+
+      clickTab('status');
+      expect(overlayEl().querySelectorAll('[data-follower]')).toHaveLength(1);
+    });
+
+    it('drops back out of the Status tab when the last follower leaves', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false, followers: [cliFollower] });
+      expect(activeTab()).toBe('status');
+      window.dispatchEvent(new CustomEvent(FOLLOWERS_CHANGED_EVENT, { detail: { followers: [] } }));
+      expect(tabIds()).toEqual(['browser', 'iphone', 'terminal']);
+      expect(activeTab()).toBe('browser');
+    });
+
+    it('stops listening for roster changes once closed', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false });
+      buttonByText(/^Done$/).click();
+      window.dispatchEvent(
+        new CustomEvent(FOLLOWERS_CHANGED_EVENT, { detail: { followers: [cliFollower] } })
+      );
+      expect(overlayEl()).toBeNull();
+    });
+  });
+
+  describe('revoking the link', () => {
+    it('is offered only when onReset is supplied', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: true });
+      expect(buttonByText(/Revoke/)).toBeUndefined();
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: true, onReset: async () => {} });
+      expect(buttonByText(/Revoke/)).toBeDefined();
+    });
+
+    it('arms first, naming how many devices it will disconnect', async () => {
+      const onReset = vi.fn(async () => {});
+      showSyncEnabledDialog({
+        joinUrl: JOIN_URL,
+        copied: true,
+        onReset,
+        followers: [cliFollower, iosFollower],
+      });
+      const revoke = buttonByText(/Revoke link/);
+      revoke.click();
+      await Promise.resolve();
+      expect(onReset).not.toHaveBeenCalled();
+      expect(revoke.textContent).toMatch(/2 connected devices will be disconnected/);
+
+      revoke.click();
+      await Promise.resolve();
+      expect(onReset).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports success and stops offering the stale link', async () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: true, onReset: async () => {} });
+      const revoke = buttonByText(/Revoke link/);
+      revoke.click();
+      revoke.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(overlayEl().textContent).toMatch(/Join link revoked/);
+      expect(revoke.disabled).toBe(true);
+    });
+
+    it('re-enables and explains itself when the reset fails', async () => {
+      const onReset = vi.fn(async () => {
+        throw new Error('boom');
+      });
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: true, onReset });
+      const revoke = buttonByText(/Revoke link/);
+      revoke.click();
+      revoke.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(overlayEl().textContent).toMatch(/Revoke failed: boom/);
+      expect(revoke.disabled).toBe(false);
+      expect(buttonByText(/^Done$/).disabled).toBe(false);
+    });
+
+    it('surfaces a non-Error rejection as a string', async () => {
+      const onReset = vi.fn(async () => {
+        throw 'string-reason';
+      });
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: true, onReset });
+      const revoke = buttonByText(/Revoke link/);
+      revoke.click();
+      revoke.click();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(overlayEl().textContent).toMatch(/Revoke failed: string-reason/);
+    });
+  });
+
+  describe('dismissal', () => {
+    it('closes on Done', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: true });
+      buttonByText(/^Done$/).click();
+      expect(overlayEl()).toBeNull();
+    });
+
+    it('closes on backdrop click but not on an inner click', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: true });
+      (overlayEl().querySelector('.dialog') as HTMLElement).click();
+      expect(overlayEl()).not.toBeNull();
+      overlayEl().click();
+      expect(overlayEl()).toBeNull();
+    });
+
+    it('closes on Escape', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: true });
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(overlayEl()).toBeNull();
+    });
   });
 });

--- a/packages/webapp/tests/ui/sync-dialog.test.ts
+++ b/packages/webapp/tests/ui/sync-dialog.test.ts
@@ -64,6 +64,10 @@ const iosFollower: ConnectedFollowerInfo = {
 };
 
 beforeEach(() => {
+  // Close (don't just detach) any dialog a previous test left up: the module
+  // tracks the live instance so it can tear down its listeners on re-open, and
+  // `replaceChildren` alone would leave that state pointing at a dead dialog.
+  document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
   document.body.replaceChildren();
   mockedCopy.mockReset();
   mockedCopy.mockResolvedValue(true);
@@ -216,6 +220,46 @@ describe('showSyncEnabledDialog', () => {
       window.dispatchEvent(new CustomEvent(FOLLOWERS_CHANGED_EVENT, { detail: { followers: [] } }));
       expect(tabIds()).toEqual(['browser', 'iphone', 'terminal']);
       expect(activeTab()).toBe('browser');
+    });
+
+    it('re-opening tears the previous instance down — no orphaned roster listener', () => {
+      // The leak is invisible in the DOM (an orphaned instance re-renders into
+      // its own detached tree), so count the registrations instead: every
+      // roster listener a dialog adds must come back off.
+      const added = vi.spyOn(window, 'addEventListener');
+      const removed = vi.spyOn(window, 'removeEventListener');
+      // The DOM lib types `type` against the ambient global's event map, which
+      // knows nothing of our custom event name — compare as plain strings.
+      const countFor = (spy: typeof added) =>
+        spy.mock.calls.filter(([type]) => String(type) === FOLLOWERS_CHANGED_EVENT).length;
+
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false });
+      const addedAfterFirst = countFor(added);
+      const removedAfterFirst = countFor(removed);
+
+      // Re-open, the way the avatar menu and the floatbar segment can in turn.
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false, initialTab: 'terminal' });
+      expect(document.querySelectorAll('.dialog-overlay[data-sync-dialog]')).toHaveLength(1);
+      expect(countFor(added) - addedAfterFirst).toBe(1);
+      // The first instance's listener came off when the second replaced it.
+      expect(countFor(removed) - removedAfterFirst).toBe(1);
+
+      buttonByText(/^Done$/).click();
+      expect(countFor(removed) - removedAfterFirst).toBe(2);
+
+      window.dispatchEvent(
+        new CustomEvent(FOLLOWERS_CHANGED_EVENT, { detail: { followers: [cliFollower] } })
+      );
+      expect(document.querySelector('[data-follower]')).toBeNull();
+      added.mockRestore();
+      removed.mockRestore();
+    });
+
+    it('a re-opened dialog still closes on Escape (its listener is the live one)', () => {
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false });
+      showSyncEnabledDialog({ joinUrl: JOIN_URL, copied: false });
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(overlayEl()).toBeNull();
     });
 
     it('stops listening for roster changes once closed', () => {

--- a/packages/webapp/tests/ui/wc/wc-nav.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-nav.test.ts
@@ -29,12 +29,31 @@ vi.mock('../../../src/providers/oauth-service.js', () => ({
   createInterceptingOAuthLauncherForCurrentRuntime: async () => null,
 }));
 
+// The session-sharing dialog and the clipboard are stubbed so the two doors
+// into it (avatar menu, floatbar segment) can be told apart by what they do.
+// `vi.hoisted` because `wc-nav.ts` imports the clipboard statically: a plain
+// `const` would still be in its temporal dead zone when the hoisted factory runs.
+const { copyTextToClipboardSpy, showSyncEnabledDialogSpy } = vi.hoisted(() => ({
+  copyTextToClipboardSpy: vi.fn(async () => true),
+  showSyncEnabledDialogSpy: vi.fn(),
+}));
+vi.mock('../../../src/ui/sync-dialog.js', () => ({
+  showSyncEnabledDialog: showSyncEnabledDialogSpy,
+}));
+vi.mock('../../../src/ui/clipboard.js', () => ({
+  copyTextToClipboard: copyTextToClipboardSpy,
+}));
+vi.mock('../../../src/ui/legacy-styles.js', () => ({
+  loadLegacyDialogStyles: vi.fn(async () => undefined),
+}));
+
 import {
   FEATURE_FLAG_STORAGE_KEY,
   initFeatureFlags,
   setFeatureFlagOverride,
 } from '../../../src/core/feature-flags.js';
 import { registerProviderConfig, unregisterProviderConfig } from '../../../src/providers/index.js';
+import { setLeaderTrayRuntimeStatus } from '../../../src/scoops/tray-leader.js';
 import type { OffscreenClient } from '../../../src/ui/offscreen-client.js';
 import type { GroupedModels } from '../../../src/ui/provider-settings.js';
 import { accountIdentity, modelListForMeta, wireWcNav } from '../../../src/ui/wc/wc-nav.js';
@@ -93,8 +112,9 @@ describe('wireWcNav', () => {
     const inputCard = document.createElement('slicc-input-card');
     inputCard.append(document.createElement('slicc-send-button'));
     const thread = document.createElement('slicc-chat-thread');
-    document.body.append(composerMeta, avatarMenu, inputCard, thread);
-    return { composerMeta, avatarMenu, inputCard, thread } as unknown as WcShellRefs;
+    const floatbar = document.createElement('slicc-floatbar');
+    document.body.append(composerMeta, avatarMenu, inputCard, thread, floatbar);
+    return { composerMeta, avatarMenu, inputCard, thread, floatbar } as unknown as WcShellRefs;
   }
 
   it('feeds the model picker, persists selection, and wires the menu', async () => {
@@ -518,5 +538,85 @@ describe('wireWcNav', () => {
       localStorage.removeItem('selected-model');
       unregisterProviderConfig('adobe-pill-test');
     }
+  });
+});
+
+describe('session-sharing entry points', () => {
+  const JOIN_URL = 'https://tray.example.com/join/tok';
+
+  function makeRefs(): WcShellRefs {
+    const composerMeta = document.createElement('slicc-composer-meta');
+    const avatarMenu = document.createElement('slicc-avatar-menu');
+    avatarMenu.append(document.createElement('slicc-avatar'));
+    const inputCard = document.createElement('slicc-input-card');
+    inputCard.append(document.createElement('slicc-send-button'));
+    const thread = document.createElement('slicc-chat-thread');
+    const floatbar = document.createElement('slicc-floatbar');
+    document.body.append(composerMeta, avatarMenu, inputCard, thread, floatbar);
+    return { composerMeta, avatarMenu, inputCard, thread, floatbar } as unknown as WcShellRefs;
+  }
+
+  async function wire(): Promise<WcShellRefs> {
+    const refs = makeRefs();
+    await wireWcNav({
+      refs,
+      client: { updateModel: vi.fn() } as unknown as OffscreenClient,
+      log: { error: vi.fn() } as never,
+    });
+    return refs;
+  }
+
+  afterEach(() => {
+    showSyncEnabledDialogSpy.mockClear();
+    copyTextToClipboardSpy.mockClear();
+    setLeaderTrayRuntimeStatus({ state: 'inactive', session: null, error: null });
+    document.body.replaceChildren();
+  });
+
+  it('opens the dialog on its Status tab from the floatbar, without touching the clipboard', async () => {
+    setLeaderTrayRuntimeStatus({
+      state: 'leader',
+      session: { joinUrl: JOIN_URL } as never,
+      error: null,
+    });
+    const refs = await wire();
+
+    refs.floatbar.dispatchEvent(
+      new CustomEvent('slicc-followers-click', { bubbles: true, composed: true })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(copyTextToClipboardSpy).not.toHaveBeenCalled();
+    expect(showSyncEnabledDialogSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ joinUrl: JOIN_URL, copied: false, initialTab: 'status' })
+    );
+  });
+
+  it('copies the link when the avatar menu asks for it', async () => {
+    setLeaderTrayRuntimeStatus({
+      state: 'leader',
+      session: { joinUrl: JOIN_URL } as never,
+      error: null,
+    });
+    const refs = await wire();
+
+    refs.avatarMenu.dispatchEvent(
+      new CustomEvent('slicc-avatar-action', { detail: { id: 'tray-copy' } })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(copyTextToClipboardSpy).toHaveBeenCalledWith(JOIN_URL);
+    expect(showSyncEnabledDialogSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ copied: true, initialTab: undefined })
+    );
+  });
+
+  it('does nothing when there is no join link to share', async () => {
+    const refs = await wire();
+    refs.floatbar.dispatchEvent(
+      new CustomEvent('slicc-followers-click', { bubbles: true, composed: true })
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(showSyncEnabledDialogSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-tray-followers.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-tray-followers.test.ts
@@ -173,6 +173,7 @@ describe('WC tray connected follower mapping', () => {
 
   it('uses the registry count for the floatbar while mirroring connecting rows', () => {
     const floatbar = { setAttribute: vi.fn() };
+    const dispatchEvent = vi.fn();
     const storage = { setItem: vi.fn() };
     vi.stubGlobal('localStorage', storage);
     const handle = {
@@ -197,6 +198,7 @@ describe('WC tray connected follower mapping', () => {
       refs: { floatbar },
       client: {},
       baseFloatLabel: 'standalone · live',
+      window: { dispatchEvent },
     } as unknown as Parameters<typeof createLeaderOptionsFactory>[0];
     const state = {
       leader: handle,
@@ -220,5 +222,72 @@ describe('WC tray connected follower mapping', () => {
       'slicc.leaderTrayFollowers',
       expect.stringContaining('"peerState":"connecting"')
     );
+    // A connecting peer is mirrored to the shim but is NOT a follower yet, so
+    // the floatbar segment stays empty and the sync dialog hears about it.
+    expect((floatbar as unknown as { followers: unknown[] }).followers).toEqual([]);
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'slicc:followers-changed' })
+    );
+  });
+
+  it('feeds the floatbar one HUD row per connected follower', () => {
+    const floatbar = { setAttribute: vi.fn() };
+    const storage = { setItem: vi.fn() };
+    vi.stubGlobal('localStorage', storage);
+    const handle = {
+      sync: {
+        getExecCapableBootstrapIds: () => new Set(['cli-1']),
+        getBrowserCapableBootstrapIds: () => new Set(),
+        getTeleportEligibleBootstrapIds: () => new Set(),
+        getFollowerMotds: () => new Map([['cli-1', 'lars@build-box']]),
+        getFollowerDetails: () => [
+          {
+            bootstrapId: 'cli-1',
+            runtime: 'slicc-cli',
+            connectedAt: new Date().toISOString(),
+            lastActivity: 1,
+            floatType: 'unknown' as const,
+            health: 'live' as const,
+          },
+        ],
+      },
+      peers: {
+        getPeers: () => [
+          { bootstrapId: 'cli-1', state: 'connected' as const, runtime: 'slicc-cli' },
+        ],
+      },
+    } as unknown as PageLeaderTrayHandle;
+    const deps = {
+      refs: { floatbar },
+      client: {},
+      baseFloatLabel: 'standalone · live',
+      window: { dispatchEvent: vi.fn() },
+    } as unknown as Parameters<typeof createLeaderOptionsFactory>[0];
+    const state = {
+      leader: handle,
+      follower: null,
+      persistenceGuard: { activate: vi.fn(), deactivate: vi.fn() },
+      lockRelease: null,
+    } as unknown as Parameters<typeof createLeaderOptionsFactory>[1];
+
+    createLeaderOptionsFactory(
+      deps,
+      state,
+      {} as Parameters<typeof createLeaderOptionsFactory>[2]
+    )('https://tray.example').onFollowerCountChanged?.(1);
+
+    // The count no longer rides in the label string — it has its own segment.
+    expect(floatbar.setAttribute).toHaveBeenCalledWith('label', 'tray · live');
+    expect((floatbar as unknown as { followers: unknown[] }).followers).toEqual([
+      {
+        id: 'follower-cli-1',
+        icon: 'terminal',
+        title: 'CLI · cli-1',
+        detail: 'lars@build-box',
+        state: 'active',
+        stateText: 'connected 0s',
+        chips: ['can run commands'],
+      },
+    ]);
   });
 });

--- a/packages/webcomponents/src/index.ts
+++ b/packages/webcomponents/src/index.ts
@@ -189,6 +189,7 @@ export {
 } from './primitives/slicc-cost-overlay.js';
 export { SliccDaySeparator } from './primitives/slicc-day-separator.js';
 export { SliccFloatbar } from './primitives/slicc-floatbar.js';
+export { type FollowerHudRow, SliccFollowerHud } from './primitives/slicc-follower-hud.js';
 export { SliccGooglyEyes } from './primitives/slicc-googly-eyes.js';
 export { SliccIconButton } from './primitives/slicc-icon-button.js';
 export { SliccImagePreview } from './primitives/slicc-image-preview.js';

--- a/packages/webcomponents/src/primitives/slicc-floatbar.ts
+++ b/packages/webcomponents/src/primitives/slicc-floatbar.ts
@@ -323,8 +323,11 @@ export class SliccFloatbar extends HTMLElement {
     this.#followers = value;
     if (value.length > 0) this.setAttribute('follower-count', String(value.length));
     else this.removeAttribute('follower-count');
-    if (this.#followerHud) this.#followerHud.rows = value;
+    // `#render()` carries an OPEN hud across the rebuild and refreshes its rows
+    // (see `#render`), so a follower connecting or leaving updates the card
+    // under the cursor instead of yanking it away mid-read.
     if (this.isConnected) this.#render();
+    else if (this.#followerHud) this.#followerHud.rows = value;
   }
 
   get costScoops(): CostOverlayScoop[] {
@@ -397,9 +400,23 @@ export class SliccFloatbar extends HTMLElement {
 
     nodes.push(h('span', { class: 'tip', part: 'tip', 'aria-hidden': 'true' }, this.#tipText()));
 
+    // `replaceChildren` drops every existing child, including an open overlay
+    // or hud. The cost overlay is rebuilt on next hover, but the follower hud
+    // re-renders on every roster change — the one moment the user is most
+    // likely to be hovering it — so an OPEN hud is carried across the rebuild
+    // with fresh rows rather than torn down. A closed one is discarded as
+    // before; it costs nothing to rebuild on the next hover.
+    const openHud =
+      this.#followerHud?.hasAttribute('open') && this.#followers.length > 0
+        ? this.#followerHud
+        : null;
     this.#overlay = null;
-    this.#followerHud = null;
+    this.#followerHud = openHud;
     this.#root.replaceChildren(...nodes);
+    if (openHud) {
+      openHud.rows = this.#followers;
+      this.#root.appendChild(openHud);
+    }
     this.#syncTitle();
   }
 

--- a/packages/webcomponents/src/primitives/slicc-floatbar.ts
+++ b/packages/webcomponents/src/primitives/slicc-floatbar.ts
@@ -3,6 +3,8 @@ import { h, sheet } from '../internal/dom.js';
 import { iconEl } from '../internal/icons.js';
 import type { CostOverlayModel, CostOverlayScoop, SliccCostOverlay } from './slicc-cost-overlay.js';
 import './slicc-cost-overlay.js';
+import type { FollowerHudRow, SliccFollowerHud } from './slicc-follower-hud.js';
+import './slicc-follower-hud.js';
 
 const DEFAULT_LABEL = 'CLI float';
 
@@ -76,6 +78,37 @@ const STYLE = `
   background: var(--line);
 }
 
+/* Followers segment: lucide users icon + count. A real button — click opens
+   the sync dialog's Status tab, hover/focus reveals the follower HUD. */
+.followers {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 2px 6px;
+  border: 0;
+  border-radius: 9999px;
+  background: none;
+  color: inherit;
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.followers:hover,
+.followers:focus-visible {
+  background: color-mix(in srgb, var(--ctx) 55%, transparent);
+  color: var(--ink);
+}
+.followers svg {
+  display: block;
+  flex: 0 0 auto;
+  width: 12px;
+  height: 12px;
+}
+
 /* Hourly rate segment: lucide coin icon + formatted amount */
 .spent {
   display: inline-flex;
@@ -130,11 +163,13 @@ const STYLE = `
 }
 
 @container slicc-nav (max-width: 560px) {
-  .sep, .spent { display: none; }
+  .sep--spent, .spent { display: none; }
 }
 
+/* The followers segment outranks the runtime name: a leader with followers
+   keeps the pill (and the count) instead of collapsing to the square badge. */
 @container slicc-nav (max-width: 420px) {
-  :host {
+  :host(:not([follower-count])) {
     width: var(--ctl-h, 30px);
     aspect-ratio: 1 / 1;
     padding: 0;
@@ -164,9 +199,15 @@ const SHEET = sheet(STYLE);
  * @attr rate - hourly cost, a number or numeric string (e.g. `23.1`); renders a
  *   coin-icon + formatted `$23.10/h` cost segment after a thin divider
  * @attr spent - cumulative cost shown in the cost overlay's total row
+ * @attr follower-count - READ-ONLY; reflected from the `followers` property
+ * @property followers - {@link FollowerHudRow}[]; renders the followers segment
+ *   and feeds `<slicc-follower-hud>` on hover/focus
+ * @fires slicc-followers-click - the followers segment was activated (open the
+ *   sync dialog on its Status tab)
  * @csspart dot - the green status dot (present only when `online`)
  * @csspart label - the runtime label span
- * @csspart sep - the thin divider before the cost segment
+ * @csspart sep - the thin dividers before the followers and cost segments
+ * @csspart followers - the followers segment button
  * @csspart spent - the cost segment wrapper
  * @csspart rate - alias for the cost segment wrapper
  * @csspart tip - the narrow-view hover/focus tooltip surfacing the collapsed label
@@ -181,6 +222,9 @@ export class SliccFloatbar extends HTMLElement {
   #costModels: CostOverlayModel[] = [];
   #costScoops: CostOverlayScoop[] = [];
   #hideTimer: ReturnType<typeof setTimeout> | undefined;
+  #followers: FollowerHudRow[] = [];
+  #followerHud: SliccFollowerHud | null = null;
+  #followerHideTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor() {
     super();
@@ -201,6 +245,7 @@ export class SliccFloatbar extends HTMLElement {
     this.#resizeObserver?.disconnect();
     this.#resizeObserver = null;
     clearTimeout(this.#hideTimer);
+    clearTimeout(this.#followerHideTimer);
   }
 
   attributeChangedCallback(_name: string, oldValue: string | null, newValue: string | null): void {
@@ -265,6 +310,23 @@ export class SliccFloatbar extends HTMLElement {
     if (this.#overlay) this.#overlay.models = value;
   }
 
+  /**
+   * The followers attached to this leader. Setting it reflects the count to
+   * the read-only `follower-count` attribute (a CSS + test hook) and renders
+   * the followers segment; an empty array removes both.
+   */
+  get followers(): FollowerHudRow[] {
+    return this.#followers;
+  }
+
+  set followers(value: FollowerHudRow[]) {
+    this.#followers = value;
+    if (value.length > 0) this.setAttribute('follower-count', String(value.length));
+    else this.removeAttribute('follower-count');
+    if (this.#followerHud) this.#followerHud.rows = value;
+    if (this.isConnected) this.#render();
+  }
+
   get costScoops(): CostOverlayScoop[] {
     return this.#costScoops;
   }
@@ -282,6 +344,10 @@ export class SliccFloatbar extends HTMLElement {
    */
   #tipText(): string {
     const parts: string[] = [this.label];
+    const followers = this.#followers.length;
+    if (followers > 0) {
+      parts.push(`${followers} ${followers === 1 ? 'follower' : 'followers'}`);
+    }
     parts.push(formatRate(this.rate));
     parts.push('recency-weighted session avg');
     parts.push(this.online ? 'online' : 'offline');
@@ -313,7 +379,12 @@ export class SliccFloatbar extends HTMLElement {
     }
     nodes.push(h('span', { class: 'label', part: 'label' }, h('slot', null, ...fallback)));
 
-    nodes.push(h('span', { class: 'sep', part: 'sep' }));
+    if (this.#followers.length > 0) {
+      nodes.push(h('span', { class: 'sep sep--followers', part: 'sep' }));
+      nodes.push(this.#followersEl(this.#followers.length));
+    }
+
+    nodes.push(h('span', { class: 'sep sep--spent', part: 'sep' }));
     const spentEl = h(
       'span',
       { class: 'spent', part: 'spent rate' },
@@ -327,8 +398,68 @@ export class SliccFloatbar extends HTMLElement {
     nodes.push(h('span', { class: 'tip', part: 'tip', 'aria-hidden': 'true' }, this.#tipText()));
 
     this.#overlay = null;
+    this.#followerHud = null;
     this.#root.replaceChildren(...nodes);
     this.#syncTitle();
+  }
+
+  /**
+   * The followers segment. A `<button>` (not a span) so the roster is
+   * keyboard-reachable: focus reveals the HUD exactly like hover, and
+   * Enter/Space emits `slicc-followers-click` for the host to open the sync
+   * dialog on its Status tab.
+   */
+  #followersEl(count: number): HTMLElement {
+    const label = `${count} ${count === 1 ? 'follower' : 'followers'}`;
+    const el = h(
+      'button',
+      {
+        class: 'followers',
+        part: 'followers',
+        type: 'button',
+        'aria-haspopup': 'dialog',
+        'aria-label': `${label} connected — open session sharing`,
+      },
+      iconEl('users', { size: 12 }),
+      h('span', { class: 'follower-count' }, String(count))
+    );
+    el.addEventListener('mouseenter', () => this.#showFollowerHud());
+    el.addEventListener('mouseleave', () => this.#scheduleFollowerHide());
+    el.addEventListener('focus', () => this.#showFollowerHud());
+    el.addEventListener('blur', () => this.#scheduleFollowerHide());
+    el.addEventListener('keydown', (event) => {
+      if ((event as KeyboardEvent).key === 'Escape') this.#hideFollowerHud();
+    });
+    el.addEventListener('click', () => {
+      this.#hideFollowerHud();
+      this.dispatchEvent(
+        new CustomEvent('slicc-followers-click', { bubbles: true, composed: true })
+      );
+    });
+    return el;
+  }
+
+  #showFollowerHud(): void {
+    clearTimeout(this.#followerHideTimer);
+    if (!this.#followerHud) {
+      const hud = document.createElement('slicc-follower-hud') as SliccFollowerHud;
+      hud.rows = this.#followers;
+      hud.hint = 'Click for sharing options.';
+      hud.addEventListener('mouseenter', () => this.#showFollowerHud());
+      hud.addEventListener('mouseleave', () => this.#scheduleFollowerHide());
+      this.#root.appendChild(hud);
+      this.#followerHud = hud;
+    }
+    this.#followerHud.toggleAttribute('open', true);
+  }
+
+  #scheduleFollowerHide(): void {
+    this.#followerHideTimer = setTimeout(() => this.#hideFollowerHud(), 150);
+  }
+
+  #hideFollowerHud(): void {
+    clearTimeout(this.#followerHideTimer);
+    this.#followerHud?.removeAttribute('open');
   }
 
   #showOverlay(): void {

--- a/packages/webcomponents/src/primitives/slicc-follower-hud.stories.ts
+++ b/packages/webcomponents/src/primitives/slicc-follower-hud.stories.ts
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import './slicc-floatbar.js';
+import './slicc-follower-hud.js';
+import type { SliccFloatbar } from './slicc-floatbar.js';
+import type { FollowerHudRow } from './slicc-follower-hud.js';
+
+const meta: Meta = {
+  title: 'Primitives/FollowerHud',
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+/** One of each follower kind the leader can actually see. */
+const allKinds = (): FollowerHudRow[] => [
+  {
+    id: 'follower-ios1',
+    icon: 'smartphone',
+    title: 'iOS · a1b2c3d4…',
+    detail: 'iPhone 15 Pro · Sliccy 6.71',
+    state: 'active',
+    stateText: 'connected 4m',
+  },
+  {
+    id: 'follower-cli1',
+    icon: 'terminal',
+    title: 'CLI · build-box',
+    detail: 'slicc-cli exec target · lars@build-box · darwin/arm64 · runner: bash -c',
+    state: 'active',
+    stateText: 'connected 2h',
+    chips: ['can run commands'],
+  },
+  {
+    id: 'follower-tab1',
+    icon: 'monitor',
+    title: 'Standalone · 9f8e7d6c…',
+    detail: 'slicc-standalone',
+    state: 'active',
+    stateText: 'connected 31s',
+    chips: ['hosts tabs'],
+  },
+  {
+    id: 'follower-ext1',
+    icon: 'blocks',
+    title: 'Extension · 5b4a3928…',
+    detail: 'slicc-extension',
+    state: 'warn',
+    stateText: 'stalled 12m',
+  },
+];
+
+function anchored(build: (host: HTMLElement) => void): HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.style.cssText =
+    'position: relative; display: inline-block; margin: 24px 24px 260px 160px;';
+  build(wrapper);
+  return wrapper;
+}
+
+/** The card on its own, always open. */
+export const Standalone: Story = {
+  render: () =>
+    anchored((wrapper) => {
+      const hud = document.createElement('slicc-follower-hud');
+      hud.rows = allKinds();
+      hud.hint = 'Click for sharing options.';
+      hud.open = true;
+      wrapper.appendChild(hud);
+    }),
+};
+
+/** A single follower — the common case right after pairing a phone. */
+export const SingleFollower: Story = {
+  render: () =>
+    anchored((wrapper) => {
+      const hud = document.createElement('slicc-follower-hud');
+      hud.rows = [allKinds()[0]];
+      hud.open = true;
+      wrapper.appendChild(hud);
+    }),
+};
+
+/** Nothing attached — the empty state the floatbar never actually shows. */
+export const Empty: Story = {
+  render: () =>
+    anchored((wrapper) => {
+      const hud = document.createElement('slicc-follower-hud');
+      hud.rows = [];
+      hud.open = true;
+      wrapper.appendChild(hud);
+    }),
+};
+
+/** The live pairing: hover (or tab to) the followers segment in the pill. */
+export const FloatbarWithFollowers: Story = {
+  render: () => {
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText =
+      'display: flex; justify-content: flex-end; padding: 16px; margin-bottom: 280px;';
+    const floatbar = document.createElement('slicc-floatbar') as SliccFloatbar;
+    floatbar.label = 'tray · live';
+    floatbar.online = true;
+    floatbar.rate = '23.10';
+    floatbar.followers = allKinds();
+    wrapper.appendChild(floatbar);
+    return wrapper;
+  },
+};

--- a/packages/webcomponents/src/primitives/slicc-follower-hud.ts
+++ b/packages/webcomponents/src/primitives/slicc-follower-hud.ts
@@ -1,0 +1,273 @@
+import { define } from '../internal/define.js';
+import { h, sheet } from '../internal/dom.js';
+import { iconEl } from '../internal/icons.js';
+
+/**
+ * One follower row, already formatted by the caller. The component is
+ * deliberately presentational: the leader's `ConnectedFollowerInfo` lives in
+ * `@slicc/webapp` (a layer above), so the webapp maps it to these rows via
+ * `ui/follower-presentation.ts` and the component never learns tray types.
+ */
+export interface FollowerHudRow {
+  /** Stable row key — the follower's runtime id. */
+  id: string;
+  /** Lucide icon name for the follower kind (`smartphone`, `terminal`, …). */
+  icon: string;
+  /** Primary line, e.g. `iOS · phone-a1b2c3`. */
+  title: string;
+  /** Secondary line — the follower's MOTD or runtime tag. */
+  detail?: string;
+  /** Dot color: live, stalled/warning, or connecting/idle. */
+  state: 'active' | 'warn' | 'idle';
+  /** Right-aligned status text, e.g. `connected 4m`. */
+  stateText: string;
+  /** Capability chips, e.g. `can run commands`. */
+  chips?: string[];
+}
+
+const STYLE = `
+:host {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 100;
+  display: block;
+  pointer-events: none;
+}
+:host([open]) { pointer-events: auto; }
+
+.card {
+  display: none;
+  flex-direction: column;
+  min-width: 240px;
+  max-width: 340px;
+  background: var(--canvas);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  font-family: var(--ui);
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--ink);
+  max-height: calc(100vh - 64px);
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+:host([open]) .card { display: flex; }
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+}
+
+.section-title {
+  font-size: 9px;
+  text-transform: uppercase;
+  color: var(--txt-2);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 16px 1fr auto;
+  align-items: start;
+  gap: 8px;
+}
+
+.row svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+  margin-top: 1px;
+  color: var(--txt-2);
+}
+
+.row-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+
+.row-title {
+  font-weight: 500;
+  color: var(--ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row-detail {
+  color: var(--txt-2);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chips { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 2px; }
+
+.chip {
+  padding: 1px 6px;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--ctx) 45%, transparent);
+  color: var(--txt-2);
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.row-state {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--txt-2);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.sdot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #22c55e;
+}
+.sdot[data-state='warn'] { background: #f59e0b; }
+.sdot[data-state='idle'] { background: var(--txt-2); }
+
+.empty { color: var(--txt-2); padding: 12px; }
+
+.hint {
+  padding: 8px 12px;
+  border-top: 1px solid var(--line);
+  color: var(--txt-2);
+  font-size: 11px;
+}
+`;
+const SHEET = sheet(STYLE);
+
+/**
+ * `<slicc-follower-hud>` — a floating card listing the followers attached to
+ * this leader. Anchored below its parent (the floatbar's followers segment)
+ * and toggled with the `open` boolean attribute, mirroring
+ * `<slicc-cost-overlay>`'s hover mechanics.
+ *
+ * Read-only by design: the HUD answers "who is on this session?" at a glance,
+ * and the sync dialog's Status tab owns the actions.
+ *
+ * @attr open - boolean; shows the card when present
+ * @property rows - array of {@link FollowerHudRow} — one per connected follower
+ * @property hint - optional footer line (e.g. "Click for details")
+ * @csspart card - the floating card surface
+ * @csspart row - a single follower row
+ */
+export class SliccFollowerHud extends HTMLElement {
+  static readonly observedAttributes = ['open'];
+
+  readonly #root: ShadowRoot;
+  #rows: FollowerHudRow[] = [];
+  #hint: string | null = null;
+
+  constructor() {
+    super();
+    this.#root = this.attachShadow({ mode: 'open' });
+    this.#root.adoptedStyleSheets = [SHEET];
+  }
+
+  connectedCallback(): void {
+    this.#render();
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this.#render();
+  }
+
+  /** Whether the card is visible. */
+  get open(): boolean {
+    return this.hasAttribute('open');
+  }
+
+  set open(value: boolean) {
+    this.toggleAttribute('open', !!value);
+  }
+
+  /** The follower rows to render. */
+  get rows(): FollowerHudRow[] {
+    return this.#rows;
+  }
+
+  set rows(value: FollowerHudRow[]) {
+    this.#rows = value;
+    if (this.isConnected) this.#render();
+  }
+
+  /** Optional footer hint line. */
+  get hint(): string | null {
+    return this.#hint;
+  }
+
+  set hint(value: string | null) {
+    this.#hint = value && value.trim() !== '' ? value : null;
+    if (this.isConnected) this.#render();
+  }
+
+  #render(): void {
+    const count = this.#rows.length;
+    const children: Node[] = [];
+
+    if (count === 0) {
+      children.push(h('div', { class: 'empty' }, 'No followers connected.'));
+    } else {
+      const rows = this.#rows.map((row) =>
+        h(
+          'div',
+          { class: 'row', part: 'row' },
+          iconEl(row.icon, { size: 14 }),
+          h(
+            'div',
+            { class: 'row-main' },
+            h('span', { class: 'row-title' }, row.title),
+            row.detail ? h('span', { class: 'row-detail' }, row.detail) : false,
+            row.chips && row.chips.length > 0
+              ? h(
+                  'div',
+                  { class: 'chips' },
+                  ...row.chips.map((chip) => h('span', { class: 'chip' }, chip))
+                )
+              : false
+          ),
+          h(
+            'div',
+            { class: 'row-state' },
+            h('span', { class: 'sdot', 'data-state': row.state }),
+            row.stateText
+          )
+        )
+      );
+      children.push(
+        h(
+          'div',
+          { class: 'section' },
+          h(
+            'div',
+            { class: 'section-title' },
+            `${count} ${count === 1 ? 'follower' : 'followers'}`
+          ),
+          ...rows
+        )
+      );
+    }
+
+    if (this.#hint) children.push(h('div', { class: 'hint' }, this.#hint));
+
+    this.#root.replaceChildren(h('div', { class: 'card', part: 'card' }, ...children));
+  }
+}
+
+define('slicc-follower-hud', SliccFollowerHud);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'slicc-follower-hud': SliccFollowerHud;
+  }
+}

--- a/packages/webcomponents/src/register.ts
+++ b/packages/webcomponents/src/register.ts
@@ -44,6 +44,7 @@ import './primitives/slicc-avatar.js';
 import './primitives/slicc-cost-overlay.js';
 import './primitives/slicc-day-separator.js';
 import './primitives/slicc-floatbar.js';
+import './primitives/slicc-follower-hud.js';
 import './primitives/slicc-googly-eyes.js';
 import './primitives/slicc-icon-button.js';
 import './primitives/slicc-image-preview.js';

--- a/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
+++ b/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
@@ -588,6 +588,57 @@ describe('slicc-floatbar', () => {
       expect(hud.shadowRoot?.textContent).toContain('CLI · build-box');
     });
 
+    it('keeps an open HUD open — and refreshes it — when the roster changes', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      el.followers = rows();
+      const segment = el.shadowRoot?.querySelector('.followers') as HTMLElement;
+      segment.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      expect(el.shadowRoot?.querySelector('slicc-follower-hud')?.hasAttribute('open')).toBe(true);
+
+      // A follower connects while the cursor is on the segment.
+      el.followers = [
+        ...rows(),
+        {
+          id: 'follower-new',
+          icon: 'monitor',
+          title: 'Standalone · fresh',
+          state: 'active' as const,
+          stateText: 'connected 1s',
+        },
+      ];
+
+      const hud = el.shadowRoot?.querySelector('slicc-follower-hud') as SliccFollowerHud;
+      expect(hud).not.toBeNull();
+      expect(hud.hasAttribute('open')).toBe(true);
+      expect(hud.rows).toHaveLength(3);
+      expect(hud.shadowRoot?.textContent).toContain('Standalone · fresh');
+      expect(el.shadowRoot?.querySelector('.followers')?.textContent).toContain('3');
+    });
+
+    it('drops the HUD when the last follower leaves', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      el.followers = rows();
+      const segment = el.shadowRoot?.querySelector('.followers') as HTMLElement;
+      segment.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      el.followers = [];
+      expect(el.shadowRoot?.querySelector('slicc-follower-hud')).toBeNull();
+    });
+
+    it('does not resurrect a closed HUD on a roster change', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      el.followers = rows();
+      const segment = el.shadowRoot?.querySelector('.followers') as HTMLElement;
+      segment.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      (el.shadowRoot?.querySelector('slicc-follower-hud') as SliccFollowerHud).removeAttribute(
+        'open'
+      );
+      el.followers = [rows()[0]];
+      expect(el.shadowRoot?.querySelector('slicc-follower-hud')).toBeNull();
+    });
+
     it('emits a composed slicc-followers-click on activation', () => {
       const el = document.createElement('slicc-floatbar') as SliccFloatbar;
       document.body.appendChild(el);

--- a/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
+++ b/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '../../src/nav/slicc-nav.js';
 import { SliccFloatbar } from '../../src/primitives/slicc-floatbar.js';
+import type { SliccFollowerHud } from '../../src/primitives/slicc-follower-hud.js';
 import { ensureGlobalTokens } from '../../src/theme/tokens.js';
 
 const rgb = (hex: string): string => {
@@ -484,6 +485,126 @@ describe('slicc-floatbar', () => {
 
       const overlay = el.shadowRoot?.querySelector('slicc-cost-overlay') as any;
       expect(overlay.models).toBe(newModels);
+    });
+  });
+
+  describe('followers segment', () => {
+    const rows = () => [
+      {
+        id: 'follower-cli1',
+        icon: 'terminal',
+        title: 'CLI · build-box',
+        state: 'active' as const,
+        stateText: 'connected 2h',
+        chips: ['can run commands'],
+      },
+      {
+        id: 'follower-ios1',
+        icon: 'smartphone',
+        title: 'iOS · phone1',
+        state: 'active' as const,
+        stateText: 'connected 4m',
+      },
+    ];
+
+    it('renders nothing until there are followers', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      expect(el.shadowRoot?.querySelector('.followers')).toBeNull();
+      expect(el.hasAttribute('follower-count')).toBe(false);
+    });
+
+    it('renders the count and reflects follower-count once followers arrive', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      el.followers = rows();
+      const segment = el.shadowRoot?.querySelector('.followers') as HTMLElement;
+      expect(segment).not.toBeNull();
+      expect(segment.textContent).toContain('2');
+      expect(el.getAttribute('follower-count')).toBe('2');
+    });
+
+    it('drops the segment and the attribute when the last follower leaves', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      el.followers = rows();
+      el.followers = [];
+      expect(el.shadowRoot?.querySelector('.followers')).toBeNull();
+      expect(el.hasAttribute('follower-count')).toBe(false);
+    });
+
+    it('is a button with an accessible name naming the count', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      el.followers = [rows()[0]];
+      const segment = el.shadowRoot?.querySelector('.followers') as HTMLButtonElement;
+      expect(segment.tagName).toBe('BUTTON');
+      expect(segment.getAttribute('aria-label')).toMatch(/^1 follower connected/);
+      expect(segment.getAttribute('aria-haspopup')).toBe('dialog');
+    });
+
+    it('opens the follower HUD on hover and closes it on leave', async () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      el.followers = rows();
+      const segment = el.shadowRoot?.querySelector('.followers') as HTMLElement;
+
+      segment.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      const hud = el.shadowRoot?.querySelector('slicc-follower-hud');
+      expect(hud?.hasAttribute('open')).toBe(true);
+
+      segment.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(hud?.hasAttribute('open')).toBe(false);
+    });
+
+    it('opens the HUD on keyboard focus too', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      el.followers = rows();
+      const segment = el.shadowRoot?.querySelector('.followers') as HTMLElement;
+      segment.dispatchEvent(new FocusEvent('focus'));
+      expect(el.shadowRoot?.querySelector('slicc-follower-hud')?.hasAttribute('open')).toBe(true);
+    });
+
+    it('closes the HUD on Escape', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      el.followers = rows();
+      const segment = el.shadowRoot?.querySelector('.followers') as HTMLElement;
+      segment.dispatchEvent(new FocusEvent('focus'));
+      segment.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      expect(el.shadowRoot?.querySelector('slicc-follower-hud')?.hasAttribute('open')).toBe(false);
+    });
+
+    it('hands the HUD the current rows', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      el.followers = rows();
+      const segment = el.shadowRoot?.querySelector('.followers') as HTMLElement;
+      segment.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      const hud = el.shadowRoot?.querySelector('slicc-follower-hud') as SliccFollowerHud;
+      expect(hud.rows).toHaveLength(2);
+      expect(hud.shadowRoot?.textContent).toContain('CLI · build-box');
+    });
+
+    it('emits a composed slicc-followers-click on activation', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      el.followers = rows();
+      let seen = 0;
+      document.addEventListener('slicc-followers-click', () => {
+        seen += 1;
+      });
+      (el.shadowRoot?.querySelector('.followers') as HTMLButtonElement).click();
+      expect(seen).toBe(1);
+    });
+
+    it('surfaces the follower count in the collapsed-view tip', () => {
+      const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+      document.body.appendChild(el);
+      el.followers = rows();
+      expect(el.shadowRoot?.querySelector('.tip')?.textContent).toContain('2 followers');
     });
   });
 });

--- a/packages/webcomponents/tests/primitives/slicc-follower-hud.test.ts
+++ b/packages/webcomponents/tests/primitives/slicc-follower-hud.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { type FollowerHudRow, SliccFollowerHud } from '../../src/primitives/slicc-follower-hud.js';
+import { ensureGlobalTokens } from '../../src/theme/tokens.js';
+
+function rows(): FollowerHudRow[] {
+  return [
+    {
+      id: 'follower-cli1',
+      icon: 'terminal',
+      title: 'CLI · build-box',
+      detail: 'lars@build-box · darwin/arm64',
+      state: 'active',
+      stateText: 'connected 2h',
+      chips: ['can run commands'],
+    },
+    {
+      id: 'follower-ios1',
+      icon: 'smartphone',
+      title: 'iOS · phone1',
+      state: 'warn',
+      stateText: 'stalled 12m',
+    },
+  ];
+}
+
+function mount(configure?: (el: SliccFollowerHud) => void): SliccFollowerHud {
+  const el = document.createElement('slicc-follower-hud');
+  configure?.(el);
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('slicc-follower-hud', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    document.body.replaceChildren();
+  });
+
+  it('registers the custom element', () => {
+    expect(customElements.get('slicc-follower-hud')).toBe(SliccFollowerHud);
+  });
+
+  describe('visibility', () => {
+    it('hides the card until `open` is set', () => {
+      const el = mount((node) => {
+        node.rows = rows();
+      });
+      const card = el.shadowRoot?.querySelector('.card') as HTMLElement;
+      expect(getComputedStyle(card).display).toBe('none');
+      el.open = true;
+      expect(getComputedStyle(el.shadowRoot?.querySelector('.card') as HTMLElement).display).toBe(
+        'flex'
+      );
+    });
+
+    it('reflects `open` between attribute and property', () => {
+      const el = mount();
+      expect(el.open).toBe(false);
+      el.open = true;
+      expect(el.hasAttribute('open')).toBe(true);
+      el.removeAttribute('open');
+      expect(el.open).toBe(false);
+    });
+
+    it('ignores pointer events while closed so it cannot swallow clicks', () => {
+      const el = mount((node) => {
+        node.rows = rows();
+      });
+      expect(getComputedStyle(el).pointerEvents).toBe('none');
+      el.open = true;
+      expect(getComputedStyle(el).pointerEvents).toBe('auto');
+    });
+  });
+
+  describe('rows', () => {
+    it('renders one row per follower with title, detail, state and chips', () => {
+      const el = mount((node) => {
+        node.rows = rows();
+        node.open = true;
+      });
+      const rendered = el.shadowRoot?.querySelectorAll('.row');
+      expect(rendered).toHaveLength(2);
+      expect(el.shadowRoot?.textContent).toContain('CLI · build-box');
+      expect(el.shadowRoot?.textContent).toContain('lars@build-box · darwin/arm64');
+      expect(el.shadowRoot?.textContent).toContain('can run commands');
+      expect(el.shadowRoot?.textContent).toContain('stalled 12m');
+    });
+
+    it('renders an icon per row', () => {
+      const el = mount((node) => {
+        node.rows = rows();
+        node.open = true;
+      });
+      expect(el.shadowRoot?.querySelectorAll('.row svg')).toHaveLength(2);
+    });
+
+    it('colours the state dot by state', () => {
+      const el = mount((node) => {
+        node.rows = rows();
+        node.open = true;
+      });
+      const dots = Array.from(el.shadowRoot?.querySelectorAll('.sdot') ?? []);
+      expect(dots.map((dot) => dot.getAttribute('data-state'))).toEqual(['active', 'warn']);
+      expect(getComputedStyle(dots[0]).backgroundColor).not.toBe(
+        getComputedStyle(dots[1]).backgroundColor
+      );
+    });
+
+    it('titles the section with a count that agrees in number', () => {
+      const el = mount((node) => {
+        node.rows = [rows()[0]];
+        node.open = true;
+      });
+      expect(el.shadowRoot?.querySelector('.section-title')?.textContent).toBe('1 follower');
+      el.rows = rows();
+      expect(el.shadowRoot?.querySelector('.section-title')?.textContent).toBe('2 followers');
+    });
+
+    it('re-renders when rows are replaced', () => {
+      const el = mount((node) => {
+        node.rows = rows();
+        node.open = true;
+      });
+      el.rows = [];
+      expect(el.shadowRoot?.querySelectorAll('.row')).toHaveLength(0);
+      expect(el.shadowRoot?.textContent).toContain('No followers connected.');
+    });
+
+    it('omits the detail line and chip row when the row carries neither', () => {
+      const el = mount((node) => {
+        node.rows = [rows()[1]];
+        node.open = true;
+      });
+      expect(el.shadowRoot?.querySelector('.row-detail')).toBeNull();
+      expect(el.shadowRoot?.querySelector('.chips')).toBeNull();
+    });
+  });
+
+  describe('hint', () => {
+    it('renders a footer hint only when set to a non-blank string', () => {
+      const el = mount((node) => {
+        node.rows = rows();
+        node.open = true;
+      });
+      expect(el.shadowRoot?.querySelector('.hint')).toBeNull();
+      el.hint = 'Click for sharing options.';
+      expect(el.shadowRoot?.querySelector('.hint')?.textContent).toBe('Click for sharing options.');
+      el.hint = '   ';
+      expect(el.shadowRoot?.querySelector('.hint')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Why

The join-URL dialog predated the iOS app and the `slicc` CLI. It was a browser-only numbered list — *"Open SLICC in another browser… avatar → Connect to another browser… both browsers must be on the same SLICC version"* — that printed the bearer-token join link in the clear and offered **Reset URL (disconnect connected browsers)** as a flat third button.

## What changed

**One tab per follower kind, plus a live Status tab.**

| followers | tabs | default |
|---|---|---|
| 0 | Browser · iPhone · Terminal | Browser |
| >=1 | **Status** · Browser · iPhone · Terminal | Status |

- Each how-to is at most two sentences, next to the button that produces the artifact: the join link, or a ready-to-paste `slicc <url> follow bash -c` (the runner-bearing form — a bare `follow` can't run anything).
- The link is masked to `…/join/••••••••` until **Show**. It is a bearer secret; that is also why there is no hosted-QR option — see #2259 for local generation + scanning.
- **Revoke link** replaces *Reset URL*: two clicks, the first naming the blast radius (*"3 connected devices will be disconnected"*).
- The iPhone tab names both routes — paste into Settings, or pick the session up from **iCloud Sessions** with no link at all, which the old dialog never mentioned.

**The floatbar gets a real followers segment.** The count used to be smuggled into the pill's `label` string (`tray · 2 followers`). It is now a `<button>` with a reflected `follower-count`: hover or keyboard-focus opens a read-only `<slicc-follower-hud>` (same 150 ms grace as the cost overlay), click opens the dialog on Status. Opening from the floatbar **never writes the clipboard** — only the avatar-menu entry copies.

## Notes for review

- `ui/follower-presentation.ts` is now the single follower vocabulary — name, icon, capability chips (`exec` → "can run commands", `cdp` → "hosts tabs"), `connected 4m` — extracted from `wc-monitor.ts` so the Monitor panel, the HUD and the Status tab can't drift.
- `slicc:followers-changed` has exactly one producer (`wc-tray.ts`), dispatched on the **injected** `deps.window`. An open dialog re-renders from it instead of polling.
- A still-handshaking peer (`peerState: 'connecting'`) is mirrored to the shim and shown in the Monitor, but stays out of the pill — otherwise the segment would contradict its own count.
- **Deferred, deliberately:** per-row *Disconnect*. `FollowerRegistry.removeFollower` closes the sync channel but `LeaderTrayPeerManager` has no per-peer teardown, so the button would leave a half-dead peer that reconnects itself. Revoke-all is the honest kick today.
- Copy unified on **join link** across the dialog, iOS Settings (`SettingsView.swift`) and the slicc-cli README.
- Boy-scout: cleared `wc-nav.ts` off the floating-promise debt list.

## Verification

`npm run verify` (7/7) · `lint` · `typecheck` (all 9 projects) · `test` 15,862 passed · `test -w @slicc/webcomponents` 2,083 passed · `test:coverage:webapp` + `:webcomponents` above floors · `npm run build` + extension build · `check-touched-exemptions` OK.

New tests: `sync-dialog.test.ts` (24), `sync-dialog-model.test.ts` (21), `follower-presentation.test.ts` (20), `slicc-follower-hud.test.ts`, floatbar segment cases, plus wc-nav entry-point tests asserting the floatbar door does *not* touch the clipboard.

Storybook stories added (`Primitives/FollowerHud`) so the CI screenshot bot covers the HUD and the pill in light + dark. **The dialog itself has no story** — it is webapp DOM, so it is not in those shots; happy to record a CDP demo of it if you want one before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)