### PR TITLE
fix(webcomponents): log when a slicc-shader mode switch fails to link

### DIFF
--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -467,6 +467,13 @@ export class SliccShader extends HTMLElement {
         this.#wake();
         return;
       }
+      // #linkMode() failed (compile/link) without touching #program/#loc/#builtMode:
+      // the `mode` getter already reports the new value, but the next #renderFrame
+      // keeps drawing the PREVIOUS mode's program, and the CSS fallback stays
+      // hidden (`no-webgl` is unset). Log so the stale render is not silent — all
+      // three sources are hardcoded and compile-verified, so this realistically
+      // only fires under an already-dying context.
+      console.error('[slicc-shader] mode switch failed to link program');
     }
     this.#applyFallbackBg();
     this.#wake({ burst: true });

--- a/packages/webcomponents/tests/freezer/slicc-shader.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-shader.test.ts
@@ -544,6 +544,39 @@ describe('slicc-shader program cache + immediate repaint (anti-flicker)', () => 
     }
   });
 
+  it('logs and keeps the prior program active when a mode switch fails to link', async () => {
+    const el = mount({ mode: 'cone' });
+    await frame();
+    if (el.noWebgl) return; // no WebGL in this runner — link failure is N/A
+    const useProgramSpy = vi.spyOn(WebGLRenderingContext.prototype, 'useProgram');
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Force the fresh (scoop) program to fail linking without disturbing the
+    // already-built cone program — the finding's "compile/link failure" path.
+    const realGetProgramParameter = WebGLRenderingContext.prototype.getProgramParameter;
+    const linkSpy = vi
+      .spyOn(WebGLRenderingContext.prototype, 'getProgramParameter')
+      .mockImplementation(function (this: WebGLRenderingContext, program, pname) {
+        if (pname === this.LINK_STATUS) return false;
+        return realGetProgramParameter.call(this, program, pname);
+      });
+    try {
+      const activeBefore = useProgramSpy.mock.calls.at(-1)?.[0];
+      el.mode = 'scoop';
+      // The getter reports the requested mode even though the link failed…
+      expect(el.mode).toBe('scoop');
+      // …a diagnostic is emitted rather than silently rendering the stale field…
+      expect(errSpy).toHaveBeenCalledWith('[slicc-shader] mode switch failed to link program');
+      // …and no NEW program was activated (the prior cone program stays bound).
+      const activeAfter = useProgramSpy.mock.calls.at(-1)?.[0];
+      expect(activeAfter).toBe(activeBefore);
+      el.remove();
+    } finally {
+      linkSpy.mockRestore();
+      errSpy.mockRestore();
+      useProgramSpy.mockRestore();
+    }
+  });
+
   it('repaints immediately with the new program on a mode change (not deferred to rAF)', async () => {
     const drawSpy = vi.spyOn(WebGLRenderingContext.prototype, 'drawArrays');
     const useProgramSpy = vi.spyOn(WebGLRenderingContext.prototype, 'useProgram');


### PR DESCRIPTION
Closes #2232

## What

On a `mode` attribute change, `SliccShader.attributeChangedCallback` calls
`#linkMode()` to switch to the (cached) program. If `#linkMode()` returns
`false` — a `#buildProgram` compile/link failure — control fell through to
`#applyFallbackBg(); #wake(...)` without touching `#program`/`#loc`/`#builtMode`.
The next `#renderFrame` then drew the **previous** mode's program while the
`mode` getter already reported the new value: the field silently showed the
wrong mode, with no log, and the prepared CSS fallback stayed hidden
(`no-webgl` was not set).

This adds a `console.error('[slicc-shader] mode switch failed to link program')`
on the `#linkMode()`-false fall-through and documents the stale-program
behavior inline (mirroring the existing diagnostic on the context-restore
degrade path).

## Why

The finding (split out of PR #2214 round-2 review) is Low severity: all three
fragment sources are hardcoded and compile-verified in the suite, so this
realistically only triggers under an already-dying GL context. But a silent
stale render with no signal is exactly the kind of thing the diagnostic makes
debuggable.

Minimal by design — no behavior change beyond the log; the stale-program
outcome itself is left as-is per the issue's scope ("add a log and document").

## How verified

- `npx biome check --write` on both touched files — clean.
- `npm run typecheck` — passes.
- `npx vitest run tests/freezer/slicc-shader.test.ts` — 47 passed, including a
  new test that forces `getProgramParameter(LINK_STATUS)` to `false` for the
  fresh program and asserts the diagnostic is emitted, the `mode` getter still
  reports the requested mode, and no new program is activated (the prior
  program stays bound).
- `npm run verify` (full pre-push lint gate) and the boy-scout debt gate — pass.
