### PR TITLE
fix(swift-launcher): stop per-app symlink resolution in 2s runtime refresh

### DIFF
--- a/packages/swift-launcher/CLAUDE.md
+++ b/packages/swift-launcher/CLAUDE.md
@@ -27,6 +27,10 @@ npm run format -w @slicc/swift-launcher        # swift format --in-place
 
 `Sliccstart/` — SwiftUI app (`SliccstartApp.swift` boots UI; `Models/AppScanner.swift` finds Chromium/CDP apps; `Models/SliccBootstrapper.swift` + `Models/SliccProcess.swift` handle launch/lifecycle; `Views/`). `SliccstartTests/` — tests. `assemble-app.mjs` — assembles `.app` bundle. `sign-and-package.sh` — signing/packaging.
 
+## Runtime Refresh Budget
+
+`SliccstartApp` ticks `refreshRuntimeStates` every 2 s and `runtimeState(for:)` runs on every SwiftUI render, so anything on that path must be O(1) and filesystem-free in the steady state. Electron liveness uses the launch record's `observedAppPID` (`kill(pid, 0)`) first; the `NSWorkspace.runningApplications` scan (`candidateBundlePaths` + `appMatches`, pure string compares) is a fallback only. Do not reintroduce per-app `resolvingSymlinksInPath()` — with ~270 running apps it pinned the launcher at ~40% CPU. Tests: `ElectronAppMatchingTests`.
+
 ## Operational Telemetry (OpTel)
 
 `SliccstartApp.swift`'s `WindowGroup` root calls `.optelAutoInstrument(appID:)` from `@slicc/swift-optel` once; on macOS that activates `enter`, global `click`, `navigate`, and `error` (uncaught `NSException`). `appID = Bundle.main.bundleIdentifier` (`com.slicc.sliccstart`); beacons land in `helix-225321.helix_rum.cluster`.

--- a/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
+++ b/packages/swift-launcher/Sliccstart/Models/SliccProcess.swift
@@ -1102,6 +1102,11 @@ final class SliccProcess {
             return
         }
 
+        // Once the app PID is known, a `kill(pid, 0)` probe is enough; only
+        // fall back to the `NSWorkspace` scan when the PID is gone or unknown.
+        if let observedAppPID = record.observedAppPID, Self.isPIDRunning(observedAppPID) {
+            return
+        }
         let runningApps = runningElectronApplications(for: target)
         if let app = runningApps.first {
             record.observedAppPID = app.processIdentifier
@@ -1203,7 +1208,16 @@ final class SliccProcess {
     }
 
     private func isElectronAppRunning(_ target: AppTarget) -> Bool {
-        !runningElectronApplications(for: target).isEmpty
+        // Fast path: a launch record that already observed the app's PID only
+        // needs a `kill(pid, 0)` probe. The full `NSWorkspace` scan below is
+        // called from every SwiftUI render *and* the 2s refresh timer, so it
+        // must stay off the hot path once the app is known.
+        if let observedAppPID = launchRecords[target.id]?.observedAppPID,
+            Self.isPIDRunning(observedAppPID)
+        {
+            return true
+        }
+        return !runningElectronApplications(for: target).isEmpty
     }
 
     private func runningElectronApplications(for target: AppTarget) -> [NSRunningApplication] {
@@ -1230,21 +1244,55 @@ final class SliccProcess {
     }
 
     private static func runningElectronApplications(atAppPaths appPaths: [String]) -> [NSRunningApplication] {
-        let appURLs = Set(appPaths.map { standardizedFileURL(path: $0) })
+        let candidates = candidateBundlePaths(for: appPaths)
         return NSWorkspace.shared.runningApplications.filter { app in
             guard !app.isTerminated else { return false }
-            if let bundleURL = app.bundleURL.map({ standardizedFileURL(path: $0.path) }),
-                appURLs.contains(bundleURL)
-            {
-                return true
-            }
-            if let executableURL = app.executableURL?.standardizedFileURL.resolvingSymlinksInPath() {
-                return appURLs.contains { appURL in
-                    executableURL.path.hasPrefix(appURL.appendingPathComponent("Contents/MacOS").path)
-                }
-            }
-            return false
+            return appMatches(
+                bundlePath: app.bundleURL?.path,
+                executablePath: app.executableURL?.path,
+                candidateBundlePaths: candidates
+            )
         }
+    }
+
+    /// Expands each launcher-side app path into the set of spellings a running
+    /// app's `bundleURL` may report (as given, tilde-expanded, standardized,
+    /// symlink-resolved). Symlink resolution touches the filesystem, so it is
+    /// done once per *candidate* here rather than once per *running app* in
+    /// the scan — the latter cost ~35% CPU on the main thread with a few
+    /// hundred apps running (lstat per path component, every 2s and every
+    /// SwiftUI render).
+    static func candidateBundlePaths(for appPaths: [String]) -> Set<String> {
+        var candidates = Set<String>()
+        for path in appPaths {
+            let expanded = NSString(string: path).expandingTildeInPath
+            let url = URL(fileURLWithPath: expanded)
+            for variant in [expanded, url.standardizedFileURL.path, standardizedFileURL(path: path).path] {
+                candidates.insert(stripTrailingSlash(variant))
+            }
+        }
+        return candidates
+    }
+
+    /// Pure string comparison — no filesystem access. `bundlePath` matches
+    /// exactly; `executablePath` matches when it lives under a candidate's
+    /// `Contents/MacOS/`.
+    static func appMatches(
+        bundlePath: String?,
+        executablePath: String?,
+        candidateBundlePaths: Set<String>
+    ) -> Bool {
+        if let bundlePath, candidateBundlePaths.contains(stripTrailingSlash(bundlePath)) {
+            return true
+        }
+        if let executablePath {
+            return candidateBundlePaths.contains { executablePath.hasPrefix($0 + "/Contents/MacOS/") }
+        }
+        return false
+    }
+
+    private static func stripTrailingSlash(_ path: String) -> String {
+        path.count > 1 && path.hasSuffix("/") ? String(path.dropLast()) : path
     }
 
     private static func standardizedFileURL(path: String) -> URL {

--- a/packages/swift-launcher/SliccstartTests/ElectronAppMatchingTests.swift
+++ b/packages/swift-launcher/SliccstartTests/ElectronAppMatchingTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import Sliccstart
+
+/// Guards the cheap running-app matcher that replaced a per-app
+/// `resolvingSymlinksInPath()` scan (~35% main-thread CPU every 2s).
+final class ElectronAppMatchingTests: XCTestCase {
+    func testCandidatePathsIncludeRawStandardizedAndResolvedSpellings() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("slicc-match-\(UUID().uuidString)")
+        let real = dir.appendingPathComponent("Real.app")
+        let link = dir.appendingPathComponent("Link.app")
+        try FileManager.default.createDirectory(at: real, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: real)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+
+        let candidates = SliccProcess.candidateBundlePaths(for: [link.path + "/"])
+        XCTAssertTrue(candidates.contains(link.path), "raw (trailing slash stripped)")
+        XCTAssertTrue(
+            candidates.contains(real.resolvingSymlinksInPath().path),
+            "symlink-resolved spelling is present so LaunchServices' canonical bundleURL matches"
+        )
+    }
+
+    func testAppMatchesByBundlePathOrExecutablePrefixWithoutTouchingDisk() {
+        let candidates = SliccProcess.candidateBundlePaths(for: ["/Applications/Does-Not-Exist.app"])
+        XCTAssertTrue(
+            SliccProcess.appMatches(
+                bundlePath: "/Applications/Does-Not-Exist.app/", executablePath: nil,
+                candidateBundlePaths: candidates))
+        XCTAssertTrue(
+            SliccProcess.appMatches(
+                bundlePath: nil,
+                executablePath: "/Applications/Does-Not-Exist.app/Contents/MacOS/Thing",
+                candidateBundlePaths: candidates))
+        XCTAssertFalse(
+            SliccProcess.appMatches(
+                bundlePath: "/Applications/Does-Not-Exist.app Helper.app",
+                executablePath: "/Applications/Does-Not-Exist.app-other/Contents/MacOS/Thing",
+                candidateBundlePaths: candidates))
+        XCTAssertFalse(
+            SliccProcess.appMatches(
+                bundlePath: nil, executablePath: nil, candidateBundlePaths: candidates))
+    }
+}


### PR DESCRIPTION
## Why

Sliccstart.app idled at **20–40% CPU** for days. `sample` on the running process put ~36% of main-thread time inside `SliccProcess.runningElectronApplications(atAppPaths:)`, reached from the 2 s `runtimeRefreshTimer` and from `runtimeState(for:)` on every SwiftUI render. For every running app (~270 on a dev box) it called `standardizedFileURL` + `resolvingSymlinksInPath()` on `bundleURL` and `executableURL` — an `lstat` per path component — plus sysctl-backed property lookups.

## What

- **PID fast path**: when a launch record already has `observedAppPID` and `kill(pid, 0)` says it's alive, skip the `NSWorkspace` scan entirely (`refreshRuntimeState` and `isElectronAppRunning`). Steady state is now one syscall per tick.
- **Cheap scan fallback**: resolve symlinks once per *candidate* launcher path (`candidateBundlePaths`) and compare running apps by plain string (`appMatches`) — no filesystem access per app.

## Measured

Benchmark against this machine's live `runningApplications` (271 apps): old scan **13.4 ms**, new scan **2.1 ms**; and the scan no longer runs at all once the PID is known.

## Tests / docs

- New `ElectronAppMatchingTests` (symlinked bundle path resolves; bundle/executable string matching). Full launcher suite: 367/367 green.
- `packages/swift-launcher/CLAUDE.md`: "Runtime Refresh Budget" section so the per-app symlink resolution doesn't come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)