### PR TITLE
fix(webcomponents): pass ownerDocument bare in the lick card

### DIFF
--- a/packages/webcomponents/src/chat/slicc-lick-card.ts
+++ b/packages/webcomponents/src/chat/slicc-lick-card.ts
@@ -283,7 +283,7 @@ export class SliccLickCard extends HTMLElement {
   }
 
   connectedCallback(): void {
-    ensureSlottedStyle(this.ownerDocument ?? document);
+    ensureSlottedStyle(this.ownerDocument);
     this.#render();
   }
 


### PR DESCRIPTION
Follow-up to #2261, addressing the one review nit that couldn't be pushed there (the PR was already in the merge queue and the branch was locked).

`ensureSlottedStyle(this.ownerDocument ?? document)` becomes `ensureSlottedStyle(this.ownerDocument)`. `ownerDocument` is non-null for any element created via `document.createElement` or the parser, so the fallback branch was dead — and all six sibling document-sheet injectors (`slicc-agent-message`, `slicc-action-row`, `slicc-action-card`, `slicc-chat-table`, `slicc-chat-thread`, `slicc-tool-cluster`) pass it bare.

Behavior is unchanged; this is strict consistency with the siblings.

## Verification

`npm run verify` (7/7), `npm run typecheck`, `npm test` (15860 passed), `npm run test -w @slicc/webcomponents` (2075 passed), `check-touched-exemptions` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)