### PR TITLE
fix(kernel): clear the thread when a scoop has no history

### DIFF
--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -900,6 +900,9 @@ export class Bridge implements KernelFacade {
    *      a streaming tail).
    *   2. Translate the scoop's `AgentMessage[]` into the chat shape.
    *   3. Fall back to whatever the UI `sessionStore` has on disk.
+   *
+   * A scoop with no history anywhere still gets an EMPTY replace — see the
+   * tail of the method for why silence is not an option.
    */
   private async handleRequestScoopMessages(scoopJid: string): Promise<void> {
     if (!this.orchestrator) return;
@@ -962,6 +965,7 @@ export class Bridge implements KernelFacade {
             scoopJid,
             messages: messages as unknown as BufferedChatMessage[],
           });
+          return;
         }
       } catch (err) {
         log.error('sessionStore load failed', {
@@ -970,6 +974,16 @@ export class Bridge implements KernelFacade {
         });
       }
     }
+
+    // Every source came back empty (a brand-new scoop, a cone whose history
+    // was just cleared, or an unreadable session store). Emit the empty
+    // replace anyway: `scoop-messages-replaced` is the ONLY thing that drives
+    // the panel's `loadMessages`, so staying silent leaves the PREVIOUSLY
+    // selected scoop's thread rendered underneath the new scoop's label and
+    // accent — and the next real message for this scoop appends onto that
+    // foreign transcript. No buffer is seeded: with nothing to restore, a
+    // later agent event should start a fresh buffer.
+    this.emit({ type: 'scoop-messages-replaced', scoopJid, messages: [] });
   }
 
   /**

--- a/packages/webapp/tests/kernel/bridge.test.ts
+++ b/packages/webapp/tests/kernel/bridge.test.ts
@@ -2529,7 +2529,7 @@ describe('Bridge handleRequestScoopMessages', () => {
     expect(replaced?.payload.messages[0].id).toBe('m1');
   });
 
-  it('swallows sessionStore.load errors without emitting', async () => {
+  it('swallows sessionStore.load errors but still clears the thread', async () => {
     const store = (bridge as any).sessionStore;
     store.load = vi.fn().mockRejectedValue(new Error('idb closed'));
     await expect(
@@ -2538,21 +2538,76 @@ describe('Bridge handleRequestScoopMessages', () => {
         scoopJid: 'cone_1',
       })
     ).resolves.toBeUndefined();
-    expect(sentMessages.filter((m: any) => m.payload?.type === 'scoop-messages-replaced')).toEqual(
-      []
-    );
+    // An unreadable store is still not a licence to leave the previously
+    // selected scoop's transcript on screen under this scoop's label.
+    const replaced = sentMessages.filter(
+      (m: any) => m.payload?.type === 'scoop-messages-replaced'
+    ) as Array<{ payload: { scoopJid: string; messages: unknown[] } }>;
+    expect(replaced).toHaveLength(1);
+    expect(replaced[0].payload.scoopJid).toBe('cone_1');
+    expect(replaced[0].payload.messages).toEqual([]);
   });
 
-  it('emits nothing when sessionStore returns no messages', async () => {
+  it('emits an EMPTY replace when every source is empty', async () => {
     const store = (bridge as any).sessionStore;
     store.load = vi.fn().mockResolvedValue({ messages: [] });
     await (bridge as any).handlePanelMessage({
       type: 'request-scoop-messages',
       scoopJid: 'cone_1',
     });
-    expect(sentMessages.filter((m: any) => m.payload?.type === 'scoop-messages-replaced')).toEqual(
-      []
-    );
+    const replaced = sentMessages.filter(
+      (m: any) => m.payload?.type === 'scoop-messages-replaced'
+    ) as Array<{ payload: { scoopJid: string; messages: unknown[] } }>;
+    expect(replaced).toHaveLength(1);
+    expect(replaced[0].payload.scoopJid).toBe('cone_1');
+    expect(replaced[0].payload.messages).toEqual([]);
+  });
+
+  it('seeds no buffer for an empty scoop so a later event starts fresh', async () => {
+    const store = (bridge as any).sessionStore;
+    store.load = vi.fn().mockResolvedValue({ messages: [] });
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-messages',
+      scoopJid: 'cone_1',
+    });
+    expect((bridge as any).messageBuffers.get('cone_1')).toBeUndefined();
+  });
+
+  // Regression: switching to a scoop with no history left the PREVIOUS
+  // scoop's thread rendered under the new scoop's label/accent, because the
+  // handler returned without emitting and `scoop-messages-replaced` is the
+  // only thing that drives the panel's `loadMessages`.
+  it('clears the thread when switching from a scoop WITH history to one without', async () => {
+    mockOrchestrator.getScoops.mockReturnValue([
+      { jid: 'cone_1', name: 'Cone', folder: 'cone', isCone: true, assistantLabel: 'sliccy' },
+      { jid: 'scoop_fresh', name: 'fresh', folder: 'fresh-scoop', isCone: false },
+    ]);
+    const store = (bridge as any).sessionStore;
+    store.load = vi.fn().mockResolvedValue(null);
+
+    // Scoop A: a populated in-flight buffer, as after a live turn.
+    const buf = (bridge as any).getBuffer('cone_1');
+    buf.push({ id: 'a1', role: 'assistant', content: 'cone history', timestamp: 100 });
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-messages',
+      scoopJid: 'cone_1',
+    });
+
+    // Scoop B: brand new, nothing anywhere.
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-messages',
+      scoopJid: 'scoop_fresh',
+    });
+
+    const replaced = sentMessages.filter(
+      (m: any) => m.payload?.type === 'scoop-messages-replaced'
+    ) as Array<{ payload: { scoopJid: string; messages: Array<{ id: string }> } }>;
+    expect(replaced).toHaveLength(2);
+    expect(replaced[0].payload.scoopJid).toBe('cone_1');
+    expect(replaced[0].payload.messages.map((m) => m.id)).toEqual(['a1']);
+    expect(replaced[1].payload.scoopJid).toBe('scoop_fresh');
+    expect(replaced[1].payload.messages).toEqual([]);
+    expect(store.load).toHaveBeenCalledWith('session-fresh-scoop');
   });
 });
 


### PR DESCRIPTION
## Summary

Switching to a scoop with no history left the **previously selected scoop's** chat thread rendered on screen, underneath the new scoop's label and accent. Later messages for the real scoop then appended onto that foreign transcript. Now an empty scoop actively clears the thread.

## Why

`Bridge.handleRequestScoopMessages` (`packages/webapp/src/kernel/facade.ts`) resolves a scoop's history from three sources in order, and **every one was gated on non-empty**:

1. `messageBuffers.get(scoopJid)` — `if (buffered && buffered.length > 0)`
2. `buildBufferFromAgentMessages(scoop)` — returns `null` when `agentMessages.length === 0`
3. `sessionStore.load(sessionId)` — `if (messages.length > 0)`

When all three came back empty, the method fell off the end **without emitting `scoop-messages-replaced`**. That envelope is the only thing that drives the panel's `loadMessages` (`wc-live-callbacks.ts:193`), so the thread was never replaced.

`selectScoop` (`wc-live.ts:130`) has already run `applyThreadContext` by then, which flips the label, accent and URL `ctx` — hence the cone's chrome over another scoop's transcript.

### Repro

1. Be on a scoop with history (or a cone whose history was just cleared).
2. Switch to a scoop with no history yet — a brand-new scoop on first selection, or a cone right after `clearAllMessages`.

Expected: an empty thread under the new scoop's label.
Actual: the previous scoop's full transcript, under the new scoop's label. The next real message for the new scoop appends to it.

### Observed live

Diagnosed against a running instance over CDP. The cone was selected (`active=cone_…`, `context="cone"`, `ctx=cone`) and the thread had 195 rows, but IndexedDB `browser-coding-agent` → `sessions` held:

| session | messages |
|---|---|
| `session-cone` | **3** |
| `session-loose-ends-scoop` | 120 |

The rendered thread was `loose-ends`' 120 messages — ending on its exact last message — with the cone's 3 appended. `session-cone`'s first persisted message is the lick that arrived *after* the switch, confirming the cone had zero history at the moment of selection.

## Approach / Implementation notes

- Emit `scoop-messages-replaced` with `messages: []` as the terminal fallback, and `return` after the `sessionStore` emit so the two paths can't both fire.
- **No buffer is seeded** for the empty case. With nothing to restore, a later agent event should start a fresh buffer — seeding `[]` would only add a pointer for `getOrCreateAssistantMsg` to trip over.
- **The two early guards are deliberately left alone.** `!this.orchestrator` and `!scoop` are "can't answer", not "empty history", and existing tests pin them as silent no-ops.
- **Judgement call:** an unreadable session store now clears the thread too (this flipped an existing test, rewritten rather than deleted). Showing another scoop's transcript under this scoop's label is worse than showing nothing, since the user can reply into it.

## Cross-cutting impact

- **Floats exercised**: the kernel `Bridge` is shared by every float. The change is in the worker-side reply to `request-scoop-messages`, so CLI / extension / Electron / Sliccstart all get it identically. No float-specific branch touched.
- **Other consumers of `scoop-messages-replaced`** — both already handle an empty array correctly:
  - `OffscreenClient.resyncStreamPointer` (`offscreen-client.ts:968`) scans for a streaming tail and **deletes** the pointer when there is none, which is right for `[]`.
  - `wc-live-callbacks.ts:193` `onScoopMessagesReplaced` guards on `getSelected()?.jid !== jid` before calling `loadMessages`, so a late reply for a scoop you already switched away from is still dropped.
- **`loadMessages([])` side effect**: it also drops the local queued stack via `#onQueuedCancel`. This is a *fix*, not a regression — `selectScoop` already cancels the previous scoop's queued ids backend-side, and the empty path was previously the one case where the local queue survived that cancel.
- **Persisted state**: none. No IndexedDB write, no schema change, no localStorage key. The empty case explicitly does *not* call `persistScoop`, so an empty replace cannot overwrite a session on disk.
- **Security / bundle size**: N/A.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run test:coverage:webapp` — 695 files / 12,617 tests, no threshold breach
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK, 0 on any debt list
- [x] **New behavior covered by unit tests** in `packages/webapp/tests/kernel/bridge.test.ts`:
  - `emits an EMPTY replace when every source is empty`
  - `swallows sessionStore.load errors but still clears the thread` (was `…without emitting`)
  - `seeds no buffer for an empty scoop so a later event starts fresh`
  - `clears the thread when switching from a scoop WITH history to one without` — the regression itself, asserting both envelopes in order
- [x] **Tests verified non-vacuous**: reverting only the source change makes exactly 3 of them fail; restoring it makes all 8 pass.
- [x] Diagnosed and confirmed live over CDP against a running instance (see *Observed live*).
- [ ] Manual smoke — the live instance is still on the pre-fix build; needs a rebuild + reload to re-verify in situ.

**Pre-existing failures**: none. The final `npm run test` on this branch's base is fully green — **894 files / 15,862 tests passed, 0 failed**.

Worth flagging for the flaky-test backlog rather than this PR: earlier runs, made while a `test:coverage` run was executing concurrently, showed 20 and then 11 failures in *different* files each time (`ui/wc/wc-follower.test.ts`, then `shell/ipk/*`), all `Test timed out in 5000ms`. Those same files pass in isolation (504/504) and in the clean full run. They're genuinely timeout-flaky under CPU contention, which matches the merge-queue flake pattern.

Not a UI-code change (kernel message path only), so no screencast — the user-visible effect is a thread that clears instead of showing stale content.

## Documentation

- [x] No documentation changes needed — restores the documented contract rather than changing it.

## Risk & rollback

- **Blast radius**: one method, on the reply to `request-scoop-messages`. The only behavior change is emitting where it previously stayed silent.
- **Worst case**: a thread clears when it previously showed stale content — which is the intent.
- **Rollback**: revert cleanly. No persisted-state migration to undo.
- **Worth a human check**: the error-branch judgement call above, if you'd rather an IDB read failure stay silent than clear the thread.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets or tokens in the diff
- [x] No public API / tool / shell-command / lick-channel change
- [x] Contract used by other floats: checked both `scoop-messages-replaced` consumers (see *Cross-cutting impact*)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
