### PR TITLE
fix(memory): raise curator run ceiling and make a killed pass fail safe

### DIFF
--- a/packages/vfs-root/shared/MEMORY.md
+++ b/packages/vfs-root/shared/MEMORY.md
@@ -10,9 +10,6 @@ allowedCommands:
   - cat
   - cp
   - cut
-  - date
-  - diff
-  - du
   - echo
   - file
   - find
@@ -21,23 +18,18 @@ allowedCommands:
   - jq # structured reads of JSON stores such as /shared/loose-ends.json
   - ls
   - mkdir
-  - mount # listing mount state; mutations blocked by the write grant, not this list
   - mv
-  - nl
   - od # read-only byte inspection of corrupted stores
   - printf
-  - readlink
+  - rg # recursive, .gitignore-aware search; what the curator actually uses over find|xargs grep
   - sed
   - sort
-  - stat
   - tail
-  - touch
   - tr
   - uniq
   - upskill
   - wc
-  - xxd
-timeoutSeconds: 600
+timeoutSeconds: 1200
 thinkingLevel: medium
 ---
 
@@ -45,7 +37,7 @@ thinkingLevel: medium
 
 Curate the durable memory for session {{SESSION_COUNT}}. Today's date is {{TODAY}}.
 
-**Work fast: a full pass should finish in well under 5 minutes.** The run is hard-stopped at 10 minutes, and a kill mid-write can corrupt the memory file — so mine the three signals, rewrite the file, and stop, rather than exploring the archive exhaustively.
+**Work fast: a full pass should finish in well under 10 minutes.** The run is hard-stopped at 20 minutes, and a kill mid-write can corrupt the memory file or leave it over budget — so mine the three signals, rewrite the file, compact it in the same pass, and stop, rather than exploring the archive exhaustively.
 
 Read the entire current memory at {{MEMORY_PATH}} if it exists. Then mine the archived session at {{SESSION_ARCHIVE_PATH}} using the reading recipes below. Rewrite the entire {{MEMORY_PATH}} file with the durable information worth carrying into future sessions. Every part of the file is editable and counts toward the budget.
 
@@ -104,8 +96,10 @@ Measure, decide, then write once. Do not converge on the budget by trial and err
 
 1. `wc -c {{MEMORY_PATH}}` to get the current size, and subtract {{BUDGET_CHARS}} to get the exact surplus.
 2. Decide up front which sections absorb that surplus, oldest-dated first, and roughly what each one costs. Budget the whole cut before editing anything.
-3. Write the complete file once.
+3. Write the complete file once, already inside the budget. Never write a version you know to be over budget «to fix in the next step»: the pass can be killed at any moment, and the file you leave behind is the one the next session inherits.
 4. `wc -c {{MEMORY_PATH}}` to confirm. If you are still over, cut a whole section rather than shaving a few characters at a time.
+
+If the pass is running long, drop the oldest-dated section wholesale and write. An under-budget file missing one stale section is a good outcome; an over-budget file is a broken one.
 
 Rules:
 

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -16,7 +16,7 @@ const log = createLogger('agentic-memory');
 
 export const MEMORY_INSTRUCTIONS_PATH = '/shared/MEMORY.md';
 export const DEFAULT_MEMORY_TIMEOUT_SECONDS = 600;
-export const MAX_MEMORY_TIMEOUT_SECONDS = 600;
+export const MAX_MEMORY_TIMEOUT_SECONDS = 1200;
 
 /**
  * Exactly the memory file, not `/workspace/`. The curator is given `upskill` so

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -190,7 +190,7 @@ export async function runAgenticMemoryPass(
     }
     if (outcome.result.exitCode !== 0) {
       // A name-in-use rejection means a PRIOR curator is still running and holds
-      // the fixed `memory-curator` name (its window is now up to 10 min). Unlike
+      // the fixed `memory-curator` name (its window is now up to 20 min). Unlike
       // a curator that spawned and failed, no run has released — the legacy
       // append is NOT safe: the running namesake read the memory file before
       // this session's append and its whole-file rewrite would clobber it. Defer

--- a/packages/webapp/tests/scoops/agentic-memory.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory.test.ts
@@ -124,9 +124,10 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
     expect(spawn.mock.calls[0][0]).toMatchObject({
       persistSession: true,
       name: 'memory-curator',
-      // Shipped MEMORY.md sets timeoutSeconds: 600 → a 10-minute wall-clock
-      // ceiling, generous enough that a slow pass is not killed mid-write.
-      maxWallClockMs: 600_000,
+      // Shipped MEMORY.md sets timeoutSeconds: 1200 → a 20-minute wall-clock
+      // ceiling, generous enough that a slow pass is not killed mid-write
+      // and left over budget (#2263).
+      maxWallClockMs: 1_200_000,
     });
   });
 
@@ -150,8 +151,8 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
     );
     expect(prompt).toContain('Prioritize re-verifying the oldest-dated sections');
     expect(prompt).toContain('Treat undated headings as maximally stale');
-    // The soft time budget: aim to finish under 5 minutes (hard stop at 10).
-    expect(prompt).toContain('should finish in well under 5 minutes');
+    // The soft time budget: aim to finish under 10 minutes (hard stop at 20).
+    expect(prompt).toContain('should finish in well under 10 minutes');
     expect(prompt).not.toContain('Preserve the user-authored header');
   });
 
@@ -404,7 +405,7 @@ Curate {{MEMORY_PATH}}.`;
   });
 
   it('defers (legacyFallbackSafe:false) when the curator name is already in use', async () => {
-    // A prior curator (now up to a 10-minute window) still holds the fixed
+    // A prior curator (now up to a 20-minute window) still holds the fixed
     // `memory-curator` name, so this spawn is rejected before it runs. No run
     // released — a legacy append here would be clobbered by the running
     // namesake's whole-file rewrite, so the pass must NOT mark it safe; the
@@ -450,7 +451,7 @@ Curate {{MEMORY_PATH}}.`;
     });
   });
 
-  it('clamps timeoutSeconds to the 600-second maximum', async () => {
+  it('clamps timeoutSeconds to the 1200-second maximum', async () => {
     vi.useFakeTimers();
     const memoryMd = `---\ntimeoutSeconds: 9999\n---\nCurate {{MEMORY_PATH}}.`;
     const spawn = vi.fn(
@@ -463,7 +464,7 @@ Curate {{MEMORY_PATH}}.`;
       sessionArchivePath: ARCHIVE_PATH,
       sessionCount: 1,
     });
-    await vi.advanceTimersByTimeAsync(599_999 + 30_000);
+    await vi.advanceTimersByTimeAsync(1_199_999 + 30_000);
     let settled = false;
     void pass.then(() => {
       settled = true;


### PR DESCRIPTION
Fixes #2263

The memory curator's prompt told the agent it had 10 minutes, the runtime hard-stopped the run at 600 s, and compaction ran *last* — so the most interruptible phase was the one enforcing the budget. A killed pass left the memory file over budget (24404 bytes against a 16608 budget after the 2026-08-21 08:35 kill) and the next pass paid to clean it up.

## Changes — `packages/vfs-root/shared/MEMORY.md`

1. **Raise the run ceiling.** `timeoutSeconds: 600` → `1200`, and the prose moves with the number (10 minutes soft, 20 minutes hard, "or leave it over budget", "compact it in the same pass"). Text verbatim from the issue. An agent that believes it is nearly out of time takes shortcuts in the wrong place.
2. **Make a killed pass fail safe.** «Working within the budget» step 3 now says to write a file that is *already* inside the budget and never one known to be over "to fix in the next step", plus a closing paragraph: when the pass runs long, drop the oldest-dated section wholesale and write. An under-budget file missing a stale section beats an over-budget one.
3. **`rg` on the `allowedCommands` list.** 32 invocations across the 21 analysed passes, and it was absent — while the list is read as documentation of what to reach for.
4. **Trim the never-used entries.** `date`, `diff`, `du`, `mount`, `nl`, `readlink`, `stat`, `touch`, `xxd` — zero uses in 417 curator bash calls. `od` stays for corrupt-store forensics. Removing an entry cannot remove a base command.

Out of scope, deliberately: no change to `writablePaths`/`visiblePaths` and no scratch grant — that is #2164 and it moves an authorization surface. `thinkingLevel` untouched.

## One extra change, outside `MEMORY.md`, flagged for a decision

`agentic-memory.ts` clamps `timeoutSeconds` with `MAX_MEMORY_TIMEOUT_SECONDS = 600`. Without touching it, change 1 is **inert**: `1200` in the frontmatter is pinned straight back to 600, and the prompt would promise 20 minutes while the runtime kills at 10 — the exact mismatch change 1 exists to remove. Verified against the existing test, which asserted `maxWallClockMs: 600_000` from the shipped prompt and still passed after the frontmatter bump.

So this PR also raises `MAX_MEMORY_TIMEOUT_SECONDS` to `1200`. `DEFAULT_MEMORY_TIMEOUT_SECONDS` (the value used when frontmatter omits the key) stays at 600. Worth noting for #2263's evidence: an installation running `timeoutSeconds: 1200` locally was still being killed at 600 s, which is consistent with "raising it helped but did not fix it".

## Tests

`packages/webapp/tests/scoops/agentic-memory.test.ts` — three assertions pinned the old numbers and were updated: the shipped-prompt `maxWallClockMs` (`600_000` → `1_200_000`), the soft-budget prose ("well under 5 minutes" → "10 minutes"), and the clamp test (600 → 1200 second maximum). `agentic-memory-default.test.ts` needed no change. The trim needed no test change; the `rg` addition needed none either, since frontmatter commands are unioned onto the base set.

```
$ npx vitest run packages/webapp/tests/scoops packages/webapp/tests/ui/session-freezer.test.ts
 Test Files  96 passed (96)
      Tests  1767 passed (1767)

$ npm run lint            # clean
$ npm run typecheck       # clean
$ node packages/dev-tools/tools/check-touched-exemptions.mjs
check-touched-exemptions: OK (3 changed file(s), 0 still on any debt list)
```

Draft on purpose: the `MAX_MEMORY_TIMEOUT_SECONDS` bump is a runtime-ceiling change and is yours to accept or split out.
