### PR TITLE
fix(providers): bump pi-ai to 0.84.2 so Grok 4.6 reaches the model dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1458,21 +1458,20 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.0.tgz",
-      "integrity": "sha512-N9RDk8q0eglGiy+NqTZ3Ev2j+6oFNXSAJa8b0CYhvWB9HGiKZjsoCESXkUvMDLybrn0wXp75sdsoBzEtHxk9kA==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.2.tgz",
+      "integrity": "sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.0",
+        "@earendil-works/pi-telemetry": "^0.84.2",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
         "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -1484,13 +1483,10 @@
       }
     },
     "node_modules/@earendil-works/pi-ai/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -3368,9 +3364,9 @@
       }
     },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.0.tgz",
-      "integrity": "sha512-g6hLxEfAUk3zJlDmFWhWHJNcYXYiNGeWuJC9YkcHpkdkj0gxD4uaMNNNU3QsAEJXW9Qcxnl21+U8GfhVsc8C5g==",
+      "version": "0.84.2",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.2.tgz",
+      "integrity": "sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -4823,26 +4819,6 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mixmark-io/domino": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
@@ -5089,15 +5065,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -23143,18 +23110,10 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zwitch": {
@@ -23184,7 +23143,7 @@
       "name": "@slicc/chrome-extension",
       "dependencies": {
         "@ai-ecoverse/cherry": "*",
-        "@earendil-works/pi-ai": "^0.84.0",
+        "@earendil-works/pi-ai": "^0.84.2",
         "@earendil-works/pi-coding-agent": "^0.84.0",
         "@slicc/shared-ts": "*"
       }
@@ -23266,7 +23225,7 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.41.0",
         "@earendil-works/pi-agent-core": "^0.84.0",
-        "@earendil-works/pi-ai": "^0.84.0",
+        "@earendil-works/pi-ai": "^0.84.2",
         "@earendil-works/pi-coding-agent": "^0.84.0",
         "@ffmpeg/ffmpeg": "0.12.15",
         "@huggingface/transformers": "4.2.0",

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "@ai-ecoverse/cherry": "*",
-    "@earendil-works/pi-ai": "^0.84.0",
+    "@earendil-works/pi-ai": "^0.84.2",
     "@earendil-works/pi-coding-agent": "^0.84.0",
     "@slicc/shared-ts": "*"
   }

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -40,7 +40,7 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.41.0",
     "@earendil-works/pi-agent-core": "^0.84.0",
-    "@earendil-works/pi-ai": "^0.84.0",
+    "@earendil-works/pi-ai": "^0.84.2",
     "@earendil-works/pi-coding-agent": "^0.84.0",
     "@ffmpeg/ffmpeg": "0.12.15",
     "@huggingface/transformers": "4.2.0",

--- a/packages/webapp/src/shell/provider-env-seed.ts
+++ b/packages/webapp/src/shell/provider-env-seed.ts
@@ -36,6 +36,9 @@ export const PROVIDER_API_KEY_ENV: Readonly<Record<string, string>> = Object.fre
   'ant-ling': 'ANT_LING_API_KEY',
   'qwen-token-plan': 'QWEN_TOKEN_PLAN_API_KEY',
   'qwen-token-plan-cn': 'QWEN_TOKEN_PLAN_CN_API_KEY',
+  // pi-ai 0.84.2 split the individual Qwen plan into its own provider id; it
+  // reads the same variable as `qwen-token-plan`.
+  'qwen-token-plan-individual': 'QWEN_TOKEN_PLAN_API_KEY',
   openai: 'OPENAI_API_KEY',
   'azure-openai-responses': 'AZURE_OPENAI_API_KEY',
   nvidia: 'NVIDIA_API_KEY',

--- a/packages/webapp/tests/providers/xai-grok.test.ts
+++ b/packages/webapp/tests/providers/xai-grok.test.ts
@@ -254,6 +254,22 @@ describe('xai-grok provider', () => {
     );
   });
 
+  // Catalog-staleness guard: `getModelIds()` is a pass-through over pi-ai's
+  // bundled xAI data, so a stale `@earendil-works/pi-ai` pin is the only way a
+  // shipped Grok model can go missing from the dropdown. Assert against the
+  // real catalog (not the mock) so a lockfile that predates a model release
+  // fails here instead of silently in the UI.
+  it('surfaces every shipped Grok model from the real pi-ai catalog', async () => {
+    const { getModels } = await vi.importActual<typeof import('@earendil-works/pi-ai/compat')>(
+      '@earendil-works/pi-ai/compat'
+    );
+
+    const ids = (getModels('xai') as Model<Api>[]).map((model) => model.id);
+
+    expect(ids).toContain('grok-4.6');
+    expect(ids).toContain(config.defaultModelId);
+  });
+
   it('defaults to Grok 4.5 without the retired Grok Heavy copy', () => {
     expect(config.defaultModelId).toBe('grok-4.5');
     expect(config.description).toContain('Default model is Grok 4.5');


### PR DESCRIPTION
## Why Grok 4.6 was missing

`packages/webapp/providers/xai-grok.ts` doesn't maintain its own model list — `config.getModelIds()` is a pass-through over pi-ai's bundled xAI catalog:

```ts
getModelIds: () => getNativeXaiModels().map(toModelMetadata),
// getNativeXaiModels() === getModels('xai')
```

So the dropdown can only ever show what the pinned `@earendil-works/pi-ai` ships in `dist/providers/data/xai.json`.

**Root cause:** `package.json` declared `^0.84.0`, but `package-lock.json` was pinned to exactly **0.84.0**, whose xAI catalog is:

| api | models |
| --- | --- |
| `openai-completions` | `grok-4.3`, `grok-build-0.1` |
| `openai-responses` | `grok-4.5` |

No `grok-4.6`. Confirmed against the **live running build** over CDP (port 9222) by fetching every loaded chunk and grepping the catalog data — the shipped bundle carried exactly those three ids.

pi-ai **0.84.2** adds it:

```json
{ "id": "grok-4.6", "name": "Grok 4.6", "api": "openai-completions",
  "provider": "xai", "reasoning": true, "input": ["text","image"],
  "contextWindow": 500000, "maxTokens": 500000 }
```

## The fix

- Bump `@earendil-works/pi-ai` to `^0.84.2` in `packages/webapp` + `packages/chrome-extension`, and refresh the lockfile.
- No provider code change needed — `grok-4.6` is `openai-completions`, which `resolveNativeXaiModel` / `streamXai` already dispatch (same path as `grok-4.3` and `grok-build-0.1`).
- Lockfile churn beyond the version bump is pi-ai's own dependency changes: it dropped the `@mistralai/mistralai` SDK (the Mistral *catalog* is still present, and slicc never used that SDK) and moved `openai` 6.26.0 → 6.40.0.

## Regression guard

`packages/webapp/tests/providers/xai-grok.test.ts` mocks `getModels`, so a stale pin is invisible to it. Added a test that asserts against the **real** pi-ai catalog via `vi.importActual`, so a lockfile that predates a Grok release fails in CI rather than silently in the UI.

## Verification

- `npm run lint` ✅ · `npm run typecheck` ✅ · `npm run test` (16 085 passed) ✅ · `npm run build` + extension build ✅ · `npm run bundle-size` ✅ (kernel worker still under budget) · `check-touched-exemptions` ✅
- Built `dist/` and re-grepped the catalog chunk: `grok-4.3 grok-4.5 grok-4.6 grok-build-0.1` — Grok 4.6 is now in the shipped catalog.
- `test:coverage:webapp` hit the known `playwright-command` iframe Chrome-launch flake locally; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
