### PR TITLE
docs(shell): note that the synthetic /usr tree answers lstat

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -1123,6 +1123,16 @@ Rules: earlier root wins a basename conflict; first basename wins inside a root;
        node_modules/ and dot-dirs below a root never register commands.
 ```
 
+`/usr`, `/usr/bin`, and `/usr/bin/<command>` are synthesized from the command
+registry — they have no VFS entry — so `VfsAdapter` answers for them directly.
+All three metadata surfaces agree: `exists`, `stat`, **and `lstat`** (none of
+these paths can be a symlink, so `stat` and `lstat` return the same answer).
+That last one matters for commands that read metadata without following links —
+`du`, `find -type`, `tar`. When `lstat` did not answer, they saw `ENOENT` for
+the whole tree, and because `du` reports any error during its walk as
+`cannot access '<argument>'`, even `du -sh /` failed once the walk reached
+`/usr`.
+
 There is no full-filesystem scan: a `.jsh` outside the roots is not a command
 until its directory is added to `PATH` — `export PATH="$PATH:/my/tools"`
 interactively (registration completes between submissions) or persistently in


### PR DESCRIPTION
Follow-up to #2290, addressing the Codex **P1** on that PR.

#2290 made `VfsAdapter.lstat()` answer for the synthetic `/usr` tree, which changes user-visible shell behavior — `du`, `find -type`, and `tar` can now traverse `/usr` — but it touched only implementation and tests. Repo policy requires docs for user-facing changes.

The doc note was written while #2290 was already in the merge queue, so the branch was locked (`protected branch hook declined`) and the commit could not ride along. Dequeuing would have cost the slot for a docs-only change, so it lands here instead.

Documented in `docs/shell-reference.md`, next to the existing description of the synthetic `/usr/bin` registry dir — including why `lstat` specifically is the surface that matters (metadata reads that do not follow links) and why `du` blamed the wrong path when it was missing (`du` reports any error during its walk as `cannot access '<argument>'`, so `du -sh /` failed once the walk reached `/usr`).

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)