### PR TITLE
fix(renovate): pin npm deps so workspace packages stop silently freezing

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -116,6 +116,19 @@ This repo uses Renovate (`renovate.json`) to keep dependencies current, but enfo
 
 These delays are configured in `renovate.json` via `minimumReleaseAge` (top-level default) and per-rule overrides under `packageRules`. `internalChecksFilter: "strict"` ensures Renovate also applies the cooldown when deciding whether a PR is _eligible to merge_, not just when it is created — automerge will not fire until the release-age threshold has been satisfied for every package in the PR.
 
+### Exact pins, no ranges
+
+Every npm `dependencies` / `devDependencies` entry is pinned to an exact version (`renovate.json` → `rangeStrategy: "pin"` for `matchManagers: ["npm"]`). Do not reintroduce `^` or `~` ranges in a `package.json`; `engines` and `peerDependencies` intentionally keep their ranges.
+
+This is not just a style preference — a caret range in a workspace `package.json` is silently unmaintained. npm hoists every dependency into the root `node_modules/`, but since [renovatebot/renovate#37407](https://github.com/renovatebot/renovate/pull/37407) Renovate resolves a workspace dep's locked version by looking for `packages/<pkg>/node_modules/<dep>` in `package-lock.json` — a key npm never writes when the dep is hoisted. The lookup returns `lockedVersion: null`, so Renovate can only propose updates that change the _range_, and an in-range patch release never produces a PR. `@earendil-works/pi-ai` sat on 0.84.0 under `^0.84.0` for a week that way, which is why Grok 4.6 never reached the model dropdown (PR #2293). Only deps declared in the root `package.json` are unaffected, because their lock key has no directory prefix.
+
+To check for drift by hand, compare the locked version against the registry:
+
+```bash
+node -p "JSON.parse(require('fs').readFileSync('package-lock.json','utf8')).packages['node_modules/<dep>'].version"
+npm view <dep> version
+```
+
 ### Reviewer expectations
 
 - Do not manually merge a Renovate PR that Renovate is still holding for the cooldown window. Wait for Renovate to mark the PR mergeable.

--- a/renovate.json
+++ b/renovate.json
@@ -19,15 +19,21 @@
   },
   "packageRules": [
     {
+      "description": "Pin every npm dependency to an exact version. Renovate cannot see the locked version of a dep declared in a workspace package.json: npm hoists everything into the root `node_modules/`, but since renovatebot/renovate#37407 Renovate looks the dep up under `packages/<pkg>/node_modules/<dep>` and gives up when that never-written key is missing. With `lockedVersion: null` it can only offer updates that change the range, so caret-ranged workspace deps silently froze at whatever the lockfile happened to hold — `@earendil-works/pi-ai` sat on 0.84.0 under `^0.84.0` for a week, which is why Grok 4.6 never reached the model dropdown (PR #2293). Exact pins make every version change a visible package.json diff in its own PR, which is what the one-dep-per-PR philosophy above wants anyway. Scoped to dependencies/devDependencies so `engines` and `peerDependencies` keep their ranges.",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "rangeStrategy": "pin"
+    },
+    {
       "matchPackageNames": ["pyodide"],
       "rangeStrategy": "pin"
     },
     {
-      "matchPackagePrefixes": ["@semantic-release/"],
+      "matchPackageNames": ["@semantic-release/{/,}**"],
       "groupName": "semantic-release packages"
     },
     {
-      "matchPackagePrefixes": ["@xterm/"],
+      "matchPackageNames": ["@xterm/{/,}**"],
       "groupName": "xterm packages"
     },
     {
@@ -54,7 +60,7 @@
     },
     {
       "description": "pi (Earendil) agent engine packages: fast-track with a shorter 3-day cooldown. Placed after the 14-day major rule so even major bumps get 3 days.",
-      "matchPackagePrefixes": ["@earendil-works/"],
+      "matchPackageNames": ["@earendil-works/{/,}**"],
       "groupName": "earendil-works packages",
       "minimumReleaseAge": "3 days"
     },
@@ -68,6 +74,12 @@
       "description": "Formatter/linter bumps (biome, prettier) reflow existing source, so `biome check .` / `prettier --check .` in the CI lint gate fail on files the new version would reformat (e.g. biome 2.5.4's curried-call reflow, PR #1602). The Mend-hosted Renovate app can't run postUpgradeTasks, so label these and let the renovate-format-reconcile workflow run the formatter and push the reflow to the PR branch (mirrors the renovate-patch-reconcile pattern). Keep separate PRs (no groupName) per the one-dep-per-PR philosophy above.",
       "matchPackageNames": ["@biomejs/biome", "prettier"],
       "addLabels": ["formatter-bump"]
+    },
+    {
+      "description": "go-optel is a sibling module resolved through a `replace` directive in packages/slicc-cli/go.mod, so it is never published to a proxy and every run reports it under 'Package lookup failures' on the Dependency Dashboard. Disable it so that banner only ever means a real lookup failure.",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["github.com/ai-ecoverse/go-optel"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## What's actually broken

Renovate is running fine — it opened a PR this morning. What it has **never** done in this repo is propose an *in-range* update for a dependency declared in a `packages/*/package.json`.

`packages/webapp/package.json` pins `@earendil-works/pi-ai: ^0.84.0`. 0.84.2 shipped on 2026-08-14 (7 days ago, past the 3-day earendil cooldown), satisfies the caret, and never produced a PR. The lockfile stayed on 0.84.0 — which is why Grok 4.6 was missing from the model dropdown (#2293).

## Root cause

Renovate resolves a dep's locked version in [`lib/modules/manager/npm/extract/post/locked-versions.ts`](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/npm/extract/post/locked-versions.ts):

```ts
const relativeDir = upath.relative(npmRootDir, packageDir);
let lockedDepName = dep.depName;
if (relativeDir && relativeDir !== '.') {
  lockedDepName = `${relativeDir}/node_modules/${dep.depName}`;   // ← packages/webapp/node_modules/@earendil-works/pi-ai
}
dep.lockedVersion = semver.valid(lockedVersions?.[lockedDepName]); // ← undefined
```

npm **hoists** every dependency into the root `node_modules/`, so that key does not exist — this lockfile has **0** entries under `packages/webapp/node_modules/` out of 1,713. There is no fallback to the hoisted root entry, so `lockedVersion` is `null`, and with no locked version Renovate can only offer updates that change the *range*. An in-range patch release produces nothing at all.

The prefixing was introduced by [renovatebot/renovate#37407](https://github.com/renovatebot/renovate/pull/37407) (merged 2025-08-09, ref [#37347](https://github.com/renovatebot/renovate/issues/37347)) to fix the opposite case — a workspace that pins a *different* version than root, which npm nests. Before it, all package files looked up the flat root key and hoisted workspace deps resolved correctly. This repo was created 2026-03-02, so this has been broken here since day one; nobody noticed because out-of-range bumps kept flowing normally. No upstream issue reports the regression.

Confirmed in a local dry run (`renovate --platform=local --dry-run=full` against `origin/main`):

| dep | package file | `lockedVersion` | `updates` |
| --- | --- | --- | --- |
| `e2b` | `package.json` (root) | `"2.39.0"` | `[…]` |
| `e2b` | `packages/cloud-core/package.json` | `null` | `[]` |
| `@earendil-works/pi-ai` | `packages/webapp/package.json` | `null` | `[]` |
| `lucide` | `packages/webcomponents/package.json` | `null` | `[]` |

Which matches the Dependency Dashboard exactly: every `-lockfile` PR Renovate has ever opened here (`e2b`, `knip`, `ws`) is for a **root** `package.json` dep.

## What else was stale

33 deps are in-range but behind. Worst offenders:

| dep | declared | locked | latest |
| --- | --- | --- | --- |
| `lucide` (webapp, webcomponents) | `^1.8.0` | 1.8.0 | **1.33.0** |
| `isomorphic-dompurify` | `^3.1.0` | 3.7.1 | **3.22.0** |
| `unpdf` | `^1.4.0` | 1.4.0 | **1.8.1** |
| `puppeteer-core` | `^25.0.0` | 25.0.2 | **25.8.0** |
| `storybook` / `@storybook/web-components-vite` | `^10.4.2` | 10.4.2 | **10.5.10** |
| `@cantoo/pdf-lib` | `^2.6.1` | 2.6.5 | **2.9.1** |
| `@codemirror/view` | `^6.41.0` | 6.41.0 | **6.43.9** |
| `openai` | `^7.0.0` | 7.0.0 | **7.5.0** |
| `@earendil-works/pi-{ai,coding-agent,agent-core}` | `^0.84.0` | 0.84.0 | **0.84.2** |

(Full list in the thread. The 20 out-of-range deps were all fine — Renovate had branches queued for every one.)

## The fix

`rangeStrategy: "pin"` for npm `dependencies`/`devDependencies`. Exact pins sidestep the `lockedVersion` blind spot entirely and make every version change a visible `package.json` diff in its own PR — which is what the one-dep-per-PR philosophy already documented in this config wants anyway.

- **Scoped by depType.** An unscoped rule rewrote `engines.node` (`>=22.18.0` → `>=22.23.2`, plus a `>=24.19.0` major). `engines` and `peerDependencies` keep their ranges.
- **Placed first** in `packageRules` so the later per-package rules (pyodide, patched-deps, earendil, just-bash…) still win.
- Also migrated the three deprecated `matchPackagePrefixes` rules to `matchPackageNames` globs (clears the dashboard's "Config Migration Needed" banner) and disabled `github.com/ai-ecoverse/go-optel`, a `replace`-directive sibling module that is never published and shows up as a permanent "Package lookup failures" repository problem.

## Verification

`renovate --platform=local --dry-run=full` against `origin/main`, before → after:

- **16 → 22 proposed branches**, incl. new `renovate/earendil-works-packages`, `renovate/just-bash`, `renovate/xterm-packages`, `renovate/codemirror`, `renovate/e2b-2.x`, `renovate/puppeteer`.
- `@earendil-works/pi-ai` now resolves as `{"updateType": "pin", "newValue": "0.84.2"}` — i.e. this config would have shipped Grok 4.6.
- No `renovate/node-*` engines branches.
- `No config migration necessary`; go-optel reports `skipReason: "disabled"`.
- `renovate-config-validator` clean, `npm run lint` clean, `check-touched-exemptions` clean.

## What happens after merge

Renovate opens one `pin-dependencies` PR converting the remaining ranges to their currently-locked versions; deps covered by a `groupName` (earendil-works, xterm, just-bash) or a monorepo preset (codemirror, storybook, puppeteer) pin inside their own group PRs. Catch-up updates then flow one dep per PR at the existing `prHourlyLimit: 4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
