### PR TITLE
refactor: pay down boy-scout debt in packages/node-server/src/cloud-status.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -10,7 +10,6 @@
   "packages/cloudflare-worker/src/oauth-exchange.ts": 1,
   "packages/dev-tools/tools/extension-smoke-test.ts": 6,
   "packages/node-server/src/cdp-proxy/session-url-tracker.ts": 3,
-  "packages/node-server/src/cloud-status.ts": 1,
   "packages/node-server/src/cloud/registry-file.ts": 1,
   "packages/node-server/src/electron-controller.ts": 13,
   "packages/node-server/src/electron-federated-cdp.ts": 5,

--- a/packages/node-server/src/cloud-status.ts
+++ b/packages/node-server/src/cloud-status.ts
@@ -5,19 +5,31 @@ export interface CloudStatusEndpointOptions {
   joinFilePath: string;
 }
 
-function isCloudStatusPayload(x: unknown): x is {
+/** Join info accepted by POST /api/cloud-status and persisted to the join file. */
+export interface CloudStatusPayload {
   joinUrl: string;
   trayId?: string;
   controllerUrl?: string;
   webhookUrl?: string;
   runtime?: string;
   sliccVersion?: string;
-} {
+}
+
+/** The optional string fields validated when present but never required. */
+const OPTIONAL_STRING_FIELDS = [
+  'trayId',
+  'controllerUrl',
+  'webhookUrl',
+  'runtime',
+  'sliccVersion',
+] as const satisfies ReadonlyArray<keyof CloudStatusPayload>;
+
+function isCloudStatusPayload(x: unknown): x is CloudStatusPayload {
   if (typeof x !== 'object' || x === null) return false;
-  const p = x as Record<string, unknown>;
+  const p = x as Partial<Record<keyof CloudStatusPayload, unknown>>;
   if (typeof p.joinUrl !== 'string' || p.joinUrl.length === 0) return false;
   // Optional fields: validate type if present, but don't require.
-  for (const key of ['trayId', 'controllerUrl', 'webhookUrl', 'runtime', 'sliccVersion']) {
+  for (const key of OPTIONAL_STRING_FIELDS) {
     if (key in p && typeof p[key] !== 'string') return false;
   }
   return true;


### PR DESCRIPTION
## Boy-scout debt cleanup — `packages/node-server/src/cloud-status.ts`

Pays down the boy-scout debt on this one file so it is clean from every debt rule it was listed on.

### Debt list cleared

**`record-string-unknown` (untyped string-keyed bags)** — the file had one `Record<string, unknown>` occurrence, used as a cast target inside the `isCloudStatusPayload` type guard.

- Extracted the guard's inline predicate shape into a named exported `CloudStatusPayload` interface (the shape the endpoint actually accepts and persists).
- Replaced `x as Record<string, unknown>` with `x as Partial<Record<keyof CloudStatusPayload, unknown>>`, so narrowing is keyed to the known field set rather than an open bag.
- Hoisted the optional-field list into a `const OPTIONAL_STRING_FIELDS` typed `as const satisfies ReadonlyArray<keyof CloudStatusPayload>`, keeping it in sync with the interface.
- Ratcheted the baseline with `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`; the only change is removal of the `packages/node-server/src/cloud-status.ts` entry (416 grandfathered occurrences remaining across 119 files, down from 417/120).

The refactor is behaviour-preserving: the guard accepts and rejects exactly the same inputs, and the persisted payload is unchanged. Existing tests in `packages/node-server/tests/cloud-status.test.ts` continue to pin that behaviour and pass.

### No escape hatches added

No exemption, `biome.json` override, `biome-ignore` / `eslint-disable` suppression, new baseline entry, or threshold/coverage-floor relaxation was added. No unsafe casts (`as any`, `as unknown as`, `@ts-expect-error`, non-null `!`) were introduced. Only the stale `record-string-unknown` baseline entry for this file was removed; all other entries are untouched.

### Verification

- `npx biome check --write packages/node-server/src/cloud-status.ts` — clean
- `npm run typecheck` — pass
- `npx vitest run packages/node-server/tests/cloud-status.test.ts` — 4/4 pass
- `check-touched-exemptions.mjs` (PR-event mode) — `OK (changed file(s), 0 still on any debt list)`
- pre-push lint gate — all 7 checks passed (`boy-scout-debt` included)
