### PR TITLE
fix(webapp): pair tool results by call id; fill the cluster head k-of-N

### DIFF
--- a/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json
+++ b/packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json
@@ -1024,12 +1024,14 @@
       "dropped": [
         "messageId",
         "progress",
+        "toolCallId",
         "toolName"
       ],
       "event": {
         "type": "tool_progress",
         "messageId": "m2",
         "toolName": "bash",
+        "toolCallId": "call-1",
         "progress": {
           "id": "sleep-1",
           "label": "sleep 30",
@@ -1052,13 +1054,16 @@
         "toolName",
         "type"
       ],
-      "dropped": [],
+      "dropped": [
+        "toolCallId"
+      ],
       "event": {
         "type": "tool_result",
         "messageId": "m2",
         "toolName": "read_file",
         "result": "file contents",
-        "isError": false
+        "isError": false,
+        "toolCallId": "call-1"
       }
     },
     {
@@ -1104,14 +1109,17 @@
         "toolName",
         "type"
       ],
-      "dropped": [],
+      "dropped": [
+        "toolCallId"
+      ],
       "event": {
         "type": "tool_use_start",
         "messageId": "m2",
         "toolName": "read_file",
         "toolInput": {
           "path": "/workspace/notes.md"
-        }
+        },
+        "toolCallId": "call-1"
       }
     },
     {

--- a/packages/shared-ts/src/agent-wire-types.ts
+++ b/packages/shared-ts/src/agent-wire-types.ts
@@ -88,11 +88,38 @@ export type AgentEvent =
       model?: string;
       usage?: ChatMessageUsage;
     }
-  | { type: 'tool_use_start'; messageId: string; toolName: string; toolInput: unknown }
-  | { type: 'tool_result'; messageId: string; toolName: string; result: string; isError?: boolean }
+  | {
+      type: 'tool_use_start';
+      messageId: string;
+      toolName: string;
+      toolInput: unknown;
+      /**
+       * Provider tool-call id. Optional only for back-compat with followers
+       * built before it existed; without it the UI must fall back to matching
+       * results by tool NAME, which mispairs concurrent same-named calls
+       * (the agent loop runs a message's tool calls with `Promise.all`).
+       */
+      toolCallId?: string;
+    }
+  | {
+      type: 'tool_result';
+      messageId: string;
+      toolName: string;
+      result: string;
+      isError?: boolean;
+      /** Provider tool-call id; see `tool_use_start`. */
+      toolCallId?: string;
+    }
   | { type: 'tool_ui'; messageId: string; toolName: string; requestId: string; html: string }
   | { type: 'tool_ui_done'; messageId: string; requestId: string }
-  | { type: 'tool_progress'; messageId: string; toolName: string; progress: ToolProgressEvent }
+  | {
+      type: 'tool_progress';
+      messageId: string;
+      toolName: string;
+      progress: ToolProgressEvent;
+      /** Provider tool-call id; see `tool_use_start`. */
+      toolCallId?: string;
+    }
   | { type: 'turn_end'; messageId: string }
   | { type: 'error'; error: string }
   | { type: 'screenshot'; base64: string; url?: string }

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -318,14 +318,14 @@ export class Bridge implements KernelFacade {
         } satisfies LickBackpressureMsg);
       },
 
-      onToolStart: (scoopJid, toolName, toolInput) => {
+      onToolStart: (scoopJid, toolName, toolInput, toolCallId) => {
         if (HIDDEN_TOOL_NAMES.has(toolName)) return;
-        bridge.bufferToolStart(scoopJid, toolName, toolInput);
+        bridge.bufferToolStart(scoopJid, toolName, toolInput, toolCallId);
       },
 
-      onToolEnd: (scoopJid, toolName, result, isError) => {
+      onToolEnd: (scoopJid, toolName, result, isError, toolCallId) => {
         if (HIDDEN_TOOL_NAMES.has(toolName)) return;
-        bridge.bufferToolEnd(scoopJid, toolName, result, isError);
+        bridge.bufferToolEnd(scoopJid, toolName, result, isError, toolCallId);
       },
 
       onToolUI: (scoopJid, toolName, requestId, html) => {
@@ -348,13 +348,14 @@ export class Bridge implements KernelFacade {
         });
       },
 
-      onToolProgress: (scoopJid, toolName, progress) => {
+      onToolProgress: (scoopJid, toolName, progress, toolCallId) => {
         bridge.emit({
           type: 'agent-event',
           scoopJid,
           eventType: 'tool_progress',
           toolName,
           progress,
+          toolCallId,
         });
       },
 
@@ -374,12 +375,19 @@ export class Bridge implements KernelFacade {
    * human-facing transcript is capped — uncapped it grows ~1:1 with
    * tool traffic and OOMs long sessions (see transcript-limits.ts).
    */
-  private bufferToolStart(scoopJid: string, toolName: string, toolInput: unknown): void {
+  private bufferToolStart(
+    scoopJid: string,
+    toolName: string,
+    toolInput: unknown,
+    toolCallId?: string
+  ): void {
     const cappedInput = capTranscriptToolInput(toolInput);
 
     const msg = this.getOrCreateAssistantMsg(scoopJid);
     if (!msg.toolCalls) msg.toolCalls = [];
-    msg.toolCalls.push({ id: uid(), name: toolName, input: cappedInput });
+    // Prefer the provider's tool-call id so `bufferToolEnd` can pair results
+    // by identity; `uid()` only when a caller predates the threaded id.
+    msg.toolCalls.push({ id: toolCallId ?? uid(), name: toolName, input: cappedInput });
 
     this.emit({
       type: 'agent-event',
@@ -387,6 +395,7 @@ export class Bridge implements KernelFacade {
       eventType: 'tool_start',
       toolName,
       toolInput: cappedInput,
+      toolCallId,
     });
   }
 
@@ -402,16 +411,21 @@ export class Bridge implements KernelFacade {
     scoopJid: string,
     toolName: string,
     result: string,
-    isError: boolean
+    isError: boolean,
+    toolCallId?: string
   ): void {
     const msgId = this.currentMessageId.get(scoopJid);
     if (msgId) {
       const buf = this.getBuffer(scoopJid);
       const msg = buf.find((m) => m.id === msgId);
       if (msg?.toolCalls) {
-        const tc = [...msg.toolCalls]
-          .reverse()
-          .find((t) => t.name === toolName && t.result === undefined);
+        // Pair by id when we have one: a message's tool calls run under
+        // `Promise.all`, so several same-named calls can be in flight at once
+        // and "last unfinished call with this name" attaches results to the
+        // wrong entry. Name matching stays as the pre-id fallback.
+        const tc = toolCallId
+          ? msg.toolCalls.find((t) => t.id === toolCallId)
+          : [...msg.toolCalls].reverse().find((t) => t.name === toolName && t.result === undefined);
         if (tc) {
           tc.result = capTranscriptToolResultForBuffer(result);
           tc.isError = isError;
@@ -428,6 +442,7 @@ export class Bridge implements KernelFacade {
       toolName,
       toolResult: capTranscriptToolResultForEvent(result),
       isError,
+      toolCallId,
     });
   }
 

--- a/packages/webapp/src/kernel/facade/agent-event-stream.ts
+++ b/packages/webapp/src/kernel/facade/agent-event-stream.ts
@@ -63,6 +63,7 @@ export class AgentEventStream {
           messageId,
           toolName: message.toolName ?? '',
           toolInput: message.toolInput,
+          toolCallId: message.toolCallId,
         });
         break;
       }
@@ -75,6 +76,7 @@ export class AgentEventStream {
           toolName: message.toolName ?? '',
           result: message.toolResult ?? '',
           isError: message.isError,
+          toolCallId: message.toolCallId,
         });
         break;
       }
@@ -103,6 +105,7 @@ export class AgentEventStream {
           messageId,
           toolName: message.toolName ?? '',
           progress: message.progress,
+          toolCallId: message.toolCallId,
         });
         break;
       }

--- a/packages/webapp/src/kernel/messages.ts
+++ b/packages/webapp/src/kernel/messages.ts
@@ -842,6 +842,8 @@ export interface AgentEventMsg {
   text?: string;
   /** `tool_progress` payload. */
   progress?: ToolProgressEvent;
+  /** Provider tool-call id for `tool_start` / `tool_end` / `tool_progress`. */
+  toolCallId?: string;
   toolName?: string;
   toolInput?: unknown;
   toolResult?: string;

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -110,15 +110,31 @@ export interface OrchestratorCallbacks {
   /** Get the BrowserAPI used by browser automation commands */
   getBrowserAPI: () => BrowserAPI;
   /** Called when a tool starts executing */
-  onToolStart?: (scoopJid: string, toolName: string, toolInput: unknown) => void;
+  onToolStart?: (
+    scoopJid: string,
+    toolName: string,
+    toolInput: unknown,
+    toolCallId?: string
+  ) => void;
   /** Called when a tool finishes executing */
-  onToolEnd?: (scoopJid: string, toolName: string, result: string, isError: boolean) => void;
+  onToolEnd?: (
+    scoopJid: string,
+    toolName: string,
+    result: string,
+    isError: boolean,
+    toolCallId?: string
+  ) => void;
   /** Called when a tool requests UI interaction */
   onToolUI?: (scoopJid: string, toolName: string, requestId: string, html: string) => void;
   /** Called when tool UI interaction is complete */
   onToolUIDone?: (scoopJid: string, requestId: string) => void;
   /** Called for each bash progress tick inside a tool call */
-  onToolProgress?: (scoopJid: string, toolName: string, progress: ToolProgressEvent) => void;
+  onToolProgress?: (
+    scoopJid: string,
+    toolName: string,
+    progress: ToolProgressEvent,
+    toolCallId?: string
+  ) => void;
   /** Called when a message is routed to a scoop (delegation, lick, etc.) */
   onIncomingMessage?: (scoopJid: string, message: ChannelMessage) => void;
   /**

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -252,15 +252,15 @@ export interface ScoopContextCallbacks {
   onFatalError?: (error: string) => void;
   onStatusChange: (status: 'initializing' | 'ready' | 'processing' | 'error') => void;
   /** Called when a tool starts executing */
-  onToolStart?: (toolName: string, toolInput: unknown) => void;
+  onToolStart?: (toolName: string, toolInput: unknown, toolCallId?: string) => void;
   /** Called when a tool finishes executing */
-  onToolEnd?: (toolName: string, result: string, isError: boolean) => void;
+  onToolEnd?: (toolName: string, result: string, isError: boolean, toolCallId?: string) => void;
   /** Called when a tool requests UI interaction */
   onToolUI?: (toolName: string, requestId: string, html: string) => void;
   /** Called when tool UI interaction is complete */
   onToolUIDone?: (requestId: string) => void;
   /** Called for each bash progress tick (`tool_progress` agent event). */
-  onToolProgress?: (toolName: string, progress: ToolProgressEvent) => void;
+  onToolProgress?: (toolName: string, progress: ToolProgressEvent, toolCallId?: string) => void;
   /** Called when agent uses send_message tool */
   onSendMessage: (text: string, sender?: string) => void;
   /** Get all scoops (for cone) */
@@ -1639,7 +1639,11 @@ export class ScoopContext {
   }
 
   /** Handle tool UI events. */
-  private handleToolUIEvents(event: { partialResult: unknown; toolName: string }): void {
+  private handleToolUIEvents(event: {
+    partialResult: unknown;
+    toolName: string;
+    toolCallId?: string;
+  }): void {
     const partialResult = event.partialResult as {
       content?: Array<{
         type: string;
@@ -1654,13 +1658,18 @@ export class ScoopContext {
       } else if (c.type === 'tool_ui_done' && c.requestId) {
         this.callbacks.onToolUIDone?.(c.requestId);
       } else if (c.type === PROGRESS_CONTENT_TYPE && c.progress) {
-        this.callbacks.onToolProgress?.(event.toolName, c.progress);
+        this.callbacks.onToolProgress?.(event.toolName, c.progress, event.toolCallId);
       }
     }
   }
 
   /** Handle tool result formatting. */
-  private formatToolResult(event: { result: unknown; toolName: string; isError: boolean }): void {
+  private formatToolResult(event: {
+    result: unknown;
+    toolName: string;
+    isError: boolean;
+    toolCallId?: string;
+  }): void {
     const result = event.result as {
       content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
     };
@@ -1682,7 +1691,7 @@ export class ScoopContext {
       const telemetryText = parts.filter((p) => !p.startsWith('<img:')).join('\n');
       emitAgentError('tool', `${event.toolName}: ${telemetryText}`);
     }
-    this.callbacks.onToolEnd?.(event.toolName, joined, event.isError);
+    this.callbacks.onToolEnd?.(event.toolName, joined, event.isError, event.toolCallId);
   }
 
   private shouldRecoverFromOverflow(message: PiAssistantMessage): boolean {
@@ -1785,7 +1794,7 @@ export class ScoopContext {
       }
 
       case 'tool_execution_start': {
-        this.callbacks.onToolStart?.(event.toolName, event.args);
+        this.callbacks.onToolStart?.(event.toolName, event.args, event.toolCallId);
         break;
       }
 

--- a/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
+++ b/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
@@ -69,11 +69,22 @@ export interface ScoopLifecycleCallbacks {
   ): void;
   onError(scoopJid: string, error: string): void;
   getBrowserAPI(): ReturnType<ScoopContextCallbacks['getBrowserAPI']>;
-  onToolStart?(scoopJid: string, toolName: string, toolInput: unknown): void;
-  onToolEnd?(scoopJid: string, toolName: string, result: string, isError: boolean): void;
+  onToolStart?(scoopJid: string, toolName: string, toolInput: unknown, toolCallId?: string): void;
+  onToolEnd?(
+    scoopJid: string,
+    toolName: string,
+    result: string,
+    isError: boolean,
+    toolCallId?: string
+  ): void;
   onToolUI?(scoopJid: string, toolName: string, requestId: string, html: string): void;
   onToolUIDone?(scoopJid: string, requestId: string): void;
-  onToolProgress?(scoopJid: string, toolName: string, progress: ToolProgressEvent): void;
+  onToolProgress?(
+    scoopJid: string,
+    toolName: string,
+    progress: ToolProgressEvent,
+    toolCallId?: string
+  ): void;
   onIncomingMessage?(scoopJid: string, message: ChannelMessage): void;
   onScoopUnregistered?(scoop: RegisteredScoop): void;
 }
@@ -805,11 +816,11 @@ export class ScoopLifecycleManager {
       onCompactionStateChange: (state) => {
         callbacks.onCompactionStateChange?.(jid, state);
       },
-      onToolStart: (toolName, toolInput) => {
-        callbacks.onToolStart?.(jid, toolName, toolInput);
+      onToolStart: (toolName, toolInput, toolCallId) => {
+        callbacks.onToolStart?.(jid, toolName, toolInput, toolCallId);
       },
-      onToolEnd: (toolName, result, isError) => {
-        callbacks.onToolEnd?.(jid, toolName, result, isError);
+      onToolEnd: (toolName, result, isError, toolCallId) => {
+        callbacks.onToolEnd?.(jid, toolName, result, isError, toolCallId);
       },
       onToolUI: (toolName, requestId, html) => {
         callbacks.onToolUI?.(jid, toolName, requestId, html);
@@ -817,8 +828,8 @@ export class ScoopLifecycleManager {
       onToolUIDone: (requestId) => {
         callbacks.onToolUIDone?.(jid, requestId);
       },
-      onToolProgress: (toolName, progress) => {
-        callbacks.onToolProgress?.(jid, toolName, progress);
+      onToolProgress: (toolName, progress, toolCallId) => {
+        callbacks.onToolProgress?.(jid, toolName, progress, toolCallId);
       },
       onSendMessage: (text, sender) => {
         const prefixed = `${sender ? `[${sender}] ` : ''}${text}`;

--- a/packages/webapp/src/scoops/tray-sync-protocol-corpus.ts
+++ b/packages/webapp/src/scoops/tray-sync-protocol-corpus.ts
@@ -830,12 +830,17 @@ export const AGENT_EVENT_CORPUS: AgentEventCorpus = {
       messageId: 'mirrored',
       toolName: 'mirrored',
       toolInput: 'mirrored',
+      // New field; `SyncProtocol.swift` has no property for it yet, so a
+      // follower still pairs results by tool NAME and can mispair concurrent
+      // same-named calls. Inventoried here rather than left silent.
+      toolCallId: 'dropped',
     },
     event: {
       type: 'tool_use_start',
       messageId: 'm2',
       toolName: 'read_file',
       toolInput: { path: '/workspace/notes.md' },
+      toolCallId: 'call-1',
     },
   },
   tool_result: {
@@ -846,6 +851,8 @@ export const AGENT_EVENT_CORPUS: AgentEventCorpus = {
       toolName: 'mirrored',
       result: 'mirrored',
       isError: 'mirrored',
+      /** See `tool_use_start.toolCallId`. */
+      toolCallId: 'dropped',
     },
     event: {
       type: 'tool_result',
@@ -853,6 +860,7 @@ export const AGENT_EVENT_CORPUS: AgentEventCorpus = {
       toolName: 'read_file',
       result: 'file contents',
       isError: false,
+      toolCallId: 'call-1',
     },
   },
   // Tool-UI cards render as interactive HTML on the leader. A follower has no
@@ -885,11 +893,18 @@ export const AGENT_EVENT_CORPUS: AgentEventCorpus = {
   // inventoried rather than silent.
   tool_progress: {
     ios: 'unknown',
-    fields: { type: 'mirrored', messageId: 'dropped', toolName: 'dropped', progress: 'dropped' },
+    fields: {
+      type: 'mirrored',
+      messageId: 'dropped',
+      toolName: 'dropped',
+      progress: 'dropped',
+      toolCallId: 'dropped',
+    },
     event: {
       type: 'tool_progress',
       messageId: 'm2',
       toolName: 'bash',
+      toolCallId: 'call-1',
       progress: {
         id: 'sleep-1',
         label: 'sleep 30',

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -1043,6 +1043,7 @@ export class OffscreenClient implements KernelClientFacade {
         messageId: msgId,
         toolName: msg.toolName ?? '',
         progress: msg.progress,
+        toolCallId: msg.toolCallId,
       });
     }
   }
@@ -1103,6 +1104,7 @@ export class OffscreenClient implements KernelClientFacade {
           messageId: msgId,
           toolName: msg.toolName ?? '',
           toolInput: msg.toolInput,
+          toolCallId: msg.toolCallId,
         });
         break;
       }
@@ -1116,6 +1118,7 @@ export class OffscreenClient implements KernelClientFacade {
             toolName: msg.toolName ?? '',
             result: msg.toolResult ?? '',
             isError: msg.isError,
+            toolCallId: msg.toolCallId,
           });
         }
         break;

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -283,6 +283,16 @@ export class WcChatController {
    */
   readonly #toolProgress = new Map<string, ToolProgressEvent>();
 
+  /**
+   * Row keys for tool calls THIS session started (via `tool_use_start`), kept
+   * until the thread is reset. Liveness cannot be read off the rendered
+   * `result` badge: a transcript restored after an aborted turn contains
+   * result-less calls whose badge is a permanent `…`, and treating those as
+   * running would pin a stale 0% indicator on a historical cluster. Entries
+   * survive completion so a finished call still counts toward the batch total.
+   */
+  readonly #sessionToolCalls = new Set<string>();
+
   constructor(options: WcChatControllerOptions) {
     this.#thread = options.thread;
     this.#agent = options.agent;
@@ -312,6 +322,7 @@ export class WcChatController {
     this.#thread.removeEventListener('slicc-error-retry', this.#onErrorRetry);
     for (const id of [...this.#toolUiDips.keys()]) this.#disposeToolUiDip(id);
     this.#toolProgress.clear();
+    this.#sessionToolCalls.clear();
     this.#publishToolProgress();
   }
 
@@ -447,6 +458,7 @@ export class WcChatController {
     // the worker-side request is canceled when its scoop unloads.
     for (const id of [...this.#toolUiDips.keys()]) this.#disposeToolUiDip(id);
     this.#toolProgress.clear();
+    this.#sessionToolCalls.clear();
     this.#publishToolProgress();
     // The queued stack is live-only — a scoop switch / session reload starts
     // with an empty pile rather than carrying the previous scoop's queue.
@@ -926,6 +938,16 @@ export class WcChatController {
     this.#rerenderMessage(message);
   }
 
+  /**
+   * Row key for a call. The provider id is scoped by message because it is
+   * only unique per assistant message — a provider that reuses an id in a
+   * later message would otherwise produce duplicate `data-tool-id`s, and the
+   * thread-wide row lookup would paint the first (historical) match.
+   */
+  static #rowKey(messageId: string, toolCallId: string): string {
+    return `${messageId}:${toolCallId}`;
+  }
+
   #handleToolUseStart(
     messageId: string,
     toolName: string,
@@ -935,9 +957,11 @@ export class WcChatController {
     const message = this.#findMessage(messageId);
     if (!message) return;
     message.toolCalls = message.toolCalls ?? [];
-    // Adopt the provider's tool-call id so results and progress can be paired
-    // by identity; `uid()` only for pre-id senders (older followers).
-    message.toolCalls.push({ id: toolCallId ?? uid(), name: toolName, input: toolInput });
+    // Adopt the provider's tool-call id (message-scoped) so results and
+    // progress pair by identity; `uid()` only for pre-id senders.
+    const id = toolCallId ? WcChatController.#rowKey(messageId, toolCallId) : uid();
+    this.#sessionToolCalls.add(id);
+    message.toolCalls.push({ id, name: toolName, input: toolInput });
     // A tool is now in flight — flip the busy phase to `tool` so the send
     // button stops the LLM-wait fill treatment and spins instead.
     this.#activeToolCount += 1;
@@ -955,7 +979,13 @@ export class WcChatController {
    */
   #findToolCall(message: ChatMessage | undefined, toolName: string, toolCallId?: string) {
     const calls = message?.toolCalls ?? [];
-    if (toolCallId) return calls.find((t) => t.id === toolCallId);
+    if (toolCallId) {
+      // Rows started this session carry the message-scoped key; a transcript
+      // restored from an older build stored the bare provider id, so accept
+      // both before giving up.
+      const scoped = message ? WcChatController.#rowKey(message.id, toolCallId) : undefined;
+      return calls.find((t) => t.id === scoped) ?? calls.find((t) => t.id === toolCallId);
+    }
     return [...calls].reverse().find((t) => t.name === toolName && t.result === undefined);
   }
 
@@ -1127,14 +1157,18 @@ export class WcChatController {
       // fraction comes from the per-call progress unit.
       const calls: ClusterCallState[] = [
         ...cluster.querySelectorAll<HTMLElement>('slicc-action-row[data-tool-id]'),
-      ].map((row) => {
-        const id = row.dataset.toolId;
-        const badge = row.getAttribute('result');
-        return {
-          done: badge !== null && badge !== '…',
-          fraction: id ? this.#toolProgress.get(id)?.fraction : undefined,
-        };
-      });
+      ]
+        // Only calls this session actually started. Restored history is not
+        // "running" however its badge reads (see `#sessionToolCalls`).
+        .filter((row) => row.dataset.toolId && this.#sessionToolCalls.has(row.dataset.toolId))
+        .map((row) => {
+          const id = row.dataset.toolId as string;
+          const badge = row.getAttribute('result');
+          return {
+            done: badge !== null && badge !== '…',
+            fraction: this.#toolProgress.get(id)?.fraction,
+          };
+        });
       applyClusterProgress(cluster, aggregateClusterProgress(calls));
     }
   }

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -23,6 +23,7 @@ import {
   aggregateClusterProgress,
   applyClusterProgress,
   applyToolProgress,
+  type ClusterCallState,
   collateLickMessages,
   daySeparatorEl,
   isAuthExpiredError,
@@ -822,10 +823,21 @@ export class WcChatController {
         this.#handleContentDone(event.messageId, event.model, event.usage);
         break;
       case 'tool_use_start':
-        this.#handleToolUseStart(event.messageId, event.toolName, event.toolInput);
+        this.#handleToolUseStart(
+          event.messageId,
+          event.toolName,
+          event.toolInput,
+          event.toolCallId
+        );
         break;
       case 'tool_result':
-        this.#handleToolResult(event.messageId, event.toolName, event.result, event.isError);
+        this.#handleToolResult(
+          event.messageId,
+          event.toolName,
+          event.result,
+          event.isError,
+          event.toolCallId
+        );
         break;
       case 'tool_ui':
         this.#handleToolUI(event.messageId, event.requestId, event.html);
@@ -834,7 +846,7 @@ export class WcChatController {
         this.#handleToolUIDone(event.requestId);
         break;
       case 'tool_progress':
-        this.#handleToolProgress(event.messageId, event.toolName, event.progress);
+        this.#handleToolProgress(event.messageId, event.toolName, event.progress, event.toolCallId);
         break;
       case 'turn_end':
         this.#handleTurnEnd(event.messageId);
@@ -914,11 +926,18 @@ export class WcChatController {
     this.#rerenderMessage(message);
   }
 
-  #handleToolUseStart(messageId: string, toolName: string, toolInput: unknown): void {
+  #handleToolUseStart(
+    messageId: string,
+    toolName: string,
+    toolInput: unknown,
+    toolCallId?: string
+  ): void {
     const message = this.#findMessage(messageId);
     if (!message) return;
     message.toolCalls = message.toolCalls ?? [];
-    message.toolCalls.push({ id: uid(), name: toolName, input: toolInput });
+    // Adopt the provider's tool-call id so results and progress can be paired
+    // by identity; `uid()` only for pre-id senders (older followers).
+    message.toolCalls.push({ id: toolCallId ?? uid(), name: toolName, input: toolInput });
     // A tool is now in flight — flip the busy phase to `tool` so the send
     // button stops the LLM-wait fill treatment and spins instead.
     this.#activeToolCount += 1;
@@ -926,11 +945,29 @@ export class WcChatController {
     this.#rerenderMessage(message);
   }
 
-  #handleToolResult(messageId: string, toolName: string, result: string, isError?: boolean): void {
+  /**
+   * Find the tool call an event belongs to. A message's tool calls execute
+   * concurrently (`Promise.all` in the agent loop), so several same-named
+   * calls can be in flight at once and "last unfinished call with this name"
+   * attaches events to the wrong row — visibly crossing `bash` outputs.
+   * Match on the provider id when present; keep the name scan for pre-id
+   * senders, where the ambiguity is unavoidable.
+   */
+  #findToolCall(message: ChatMessage | undefined, toolName: string, toolCallId?: string) {
+    const calls = message?.toolCalls ?? [];
+    if (toolCallId) return calls.find((t) => t.id === toolCallId);
+    return [...calls].reverse().find((t) => t.name === toolName && t.result === undefined);
+  }
+
+  #handleToolResult(
+    messageId: string,
+    toolName: string,
+    result: string,
+    isError?: boolean,
+    toolCallId?: string
+  ): void {
     const message = this.#findMessage(messageId);
-    const call = [...(message?.toolCalls ?? [])]
-      .reverse()
-      .find((t) => t.name === toolName && t.result === undefined);
+    const call = this.#findToolCall(message, toolName, toolCallId);
     if (!message || !call) return;
     call.result = result;
     call.isError = isError;
@@ -1051,11 +1088,14 @@ export class WcChatController {
    * (same lookup `#handleToolResult` uses) and patches the row in place —
    * no message rerender, since ticks arrive up to 4×/s per unit.
    */
-  #handleToolProgress(messageId: string, toolName: string, progress: ToolProgressEvent): void {
+  #handleToolProgress(
+    messageId: string,
+    toolName: string,
+    progress: ToolProgressEvent,
+    toolCallId?: string
+  ): void {
     const message = this.#findMessage(messageId);
-    const call = [...(message?.toolCalls ?? [])]
-      .reverse()
-      .find((t) => t.name === toolName && t.result === undefined);
+    const call = this.#findToolCall(message, toolName, toolCallId);
     if (!call?.id) return;
     if (progress.phase === 'end') this.#toolProgress.delete(call.id);
     else this.#toolProgress.set(call.id, progress);
@@ -1082,10 +1122,20 @@ export class WcChatController {
   #refreshClusterProgress(): void {
     const clusters = this.#thread.querySelectorAll<HTMLElement>('slicc-tool-cluster');
     for (const cluster of clusters) {
-      const units = [...cluster.querySelectorAll<HTMLElement>('slicc-action-row[data-tool-id]')]
-        .map((r) => (r.dataset.toolId ? this.#toolProgress.get(r.dataset.toolId) : undefined))
-        .filter((u): u is ToolProgressEvent => u !== undefined);
-      applyClusterProgress(cluster, aggregateClusterProgress(units));
+      // Read each wrapped call's state off its row: the `result` badge is the
+      // rendered truth for "finished" (`…` while in flight), and the live
+      // fraction comes from the per-call progress unit.
+      const calls: ClusterCallState[] = [
+        ...cluster.querySelectorAll<HTMLElement>('slicc-action-row[data-tool-id]'),
+      ].map((row) => {
+        const id = row.dataset.toolId;
+        const badge = row.getAttribute('result');
+        return {
+          done: badge !== null && badge !== '…',
+          fraction: id ? this.#toolProgress.get(id)?.fraction : undefined,
+        };
+      });
+      applyClusterProgress(cluster, aggregateClusterProgress(calls));
     }
   }
 

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -394,21 +394,20 @@ const WCMSG_CSS = [
   // The cluster keeps its "N steps" count; the dots sit just before it.
   'slicc-tool-cluster[data-progress] .wcmsg-dots{margin-left:auto;}',
   'slicc-tool-cluster[data-progress] .slicc-cluster__count{margin-left:8px;}',
-  'slicc-action-row[data-progress] .slicc-act__body,slicc-tool-cluster[data-progress] .slicc-cluster__body{',
-  'position:relative;overflow:hidden;}',
-  'slicc-action-row[data-progress] .slicc-act__body::before,',
-  'slicc-tool-cluster[data-progress] .slicc-cluster__body::before{content:"";position:absolute;',
+  // The top-border bar is deliberately ROW-ONLY. A cluster is a summary of
+  // many calls; a bar there reads as noise, so it advances through the icon
+  // fill and the dots alone as calls complete.
+  'slicc-action-row[data-progress] .slicc-act__body{position:relative;overflow:hidden;}',
+  'slicc-action-row[data-progress] .slicc-act__body::before{content:"";position:absolute;',
   'top:0;left:0;height:3px;width:calc(var(--slicc-progress,0)*100%);',
   'background:var(--slicc-progress-ink,var(--accent));transition:width .25s linear;z-index:1;}',
   'slicc-action-row[data-progress] .slicc-act__body:has(> .wcmsg-bash)::before{background:#9ad17e;}',
-  'slicc-action-row[data-progress="indeterminate"] .slicc-act__body::before,',
-  'slicc-tool-cluster[data-progress="indeterminate"] .slicc-cluster__body::before{width:30%;',
+  'slicc-action-row[data-progress="indeterminate"] .slicc-act__body::before{width:30%;',
   'animation:wcmsg-progress-slide 1.2s ease-in-out infinite;}',
   '@keyframes wcmsg-progress-slide{0%{transform:translateX(-100%)}100%{transform:translateX(340%)}}',
   '@media (prefers-reduced-motion:reduce){.wcmsg-dots__dot,',
   'slicc-action-row[data-progress] .slicc-act__ic,slicc-tool-cluster[data-progress] .slicc-cluster__ic,',
-  'slicc-action-row[data-progress] .slicc-act__body::before,',
-  'slicc-tool-cluster[data-progress] .slicc-cluster__body::before{animation:none!important;}}',
+  'slicc-action-row[data-progress] .slicc-act__body::before{animation:none!important;}}',
 ].join('');
 
 function ensureWcmsgStyle(): void {
@@ -543,30 +542,41 @@ export function applyClusterProgress(cluster: HTMLElement, unit: ToolProgressEve
   applyProgressTreatment(cluster, unit, CLUSTER_CHROME);
 }
 
+/** One wrapped call's state, as read off the cluster's rows. */
+export interface ClusterCallState {
+  /** The call has a result (finished, success or error). */
+  done: boolean;
+  /** Live fraction of a still-running call, when it reports one. */
+  fraction?: number;
+}
+
 /**
- * Fold several in-flight tool-call units into one synthetic unit for a
- * cluster head: determinate (mean fraction) only when EVERY unit is
- * determinate — one unknown child makes the whole cluster indeterminate —
- * with the longest child ETA. `null` when nothing is running.
+ * Fold a cluster's calls into ONE determinate unit: "how far through this
+ * batch are we", not "how fast is the current command".
+ *
+ * The count is known up front — a message's tool calls all arrive before any
+ * of them finishes — so this is `(finished + partial) / total` and never
+ * indeterminate. A still-running call contributes its own fraction when it
+ * has one, which keeps the icon filling smoothly between completions instead
+ * of jumping a whole step. Returns `null` once nothing is running, which
+ * clears the treatment.
  */
 export function aggregateClusterProgress(
-  units: readonly ToolProgressEvent[]
+  calls: readonly ClusterCallState[]
 ): ToolProgressEvent | null {
-  if (units.length === 0) return null;
-  const fractions = units.map((u) => u.fraction);
-  const determinate = fractions.every((f) => typeof f === 'number' && Number.isFinite(f));
-  const fraction = determinate
-    ? (fractions as number[]).reduce((a, b) => a + b, 0) / fractions.length
-    : undefined;
-  const etaMs = units.reduce<number | undefined>((max, u) => {
-    if (u.etaMs === undefined) return max;
-    return max === undefined ? u.etaMs : Math.max(max, u.etaMs);
-  }, undefined);
+  const total = calls.length;
+  if (total === 0) return null;
+  const done = calls.filter((c) => c.done).length;
+  if (done === total) return null;
+  const partial = calls
+    .filter((c) => !c.done && typeof c.fraction === 'number' && Number.isFinite(c.fraction))
+    .reduce((sum, c) => sum + Math.min(1, Math.max(0, c.fraction as number)), 0);
   return {
     id: 'cluster',
-    label: `${units.length} running`,
-    fraction,
-    etaMs,
+    label: `${done} of ${total} done`,
+    fraction: Math.min(1, (done + partial) / total),
+    done,
+    total,
     unit: 'iterations',
     phase: 'update',
   };

--- a/packages/webapp/tests/ui/wc/wc-chat-controller-progress.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller-progress.test.ts
@@ -60,6 +60,7 @@ describe('WcChatController tool_progress handling', () => {
       messageId: 'm1',
       toolName: 'bash',
       toolInput: { command: 'sleep 30' },
+      toolCallId: 'tc-1',
     });
   });
 
@@ -139,37 +140,95 @@ describe('WcChatController tool_progress handling', () => {
     expect(ring.at(-1)).toBeCloseTo(0.4);
   });
 
-  it('propagates progress onto a tool cluster head once 3+ calls collapse', () => {
+  it('fills the cluster head as calls complete (k of N), with no progress bar', () => {
     // beforeEach already started one bash call; two more collapse into a cluster.
-    for (let i = 0; i < 2; i++) {
+    for (const id of ['c2', 'c3']) {
       agent.emit({
         type: 'tool_use_start',
         messageId: 'm1',
         toolName: 'bash',
-        toolInput: { command: `echo ${i}` },
+        toolInput: { command: `echo ${id}` },
+        toolCallId: id,
       });
     }
-    const cluster = thread.querySelector<HTMLElement>('slicc-tool-cluster');
-    expect(cluster).not.toBeNull();
-    expect(cluster?.querySelectorAll('slicc-action-row[data-tool-id]')).toHaveLength(3);
+    const cluster = () => thread.querySelector<HTMLElement>('slicc-tool-cluster');
+    expect(cluster()?.querySelectorAll('slicc-action-row[data-tool-id]')).toHaveLength(3);
 
-    // Drive the most recent in-flight bash call (the controller resolves the id).
-    emit(progress({ fraction: 0.6 }));
-    const head = cluster?.querySelector('.slicc-cluster__head');
-    expect(cluster?.getAttribute('data-progress')).toBe('determinate');
+    // Nothing finished yet, one call reporting 0.6 → (0 + 0.6) / 3.
+    agent.emit({
+      type: 'tool_progress',
+      messageId: 'm1',
+      toolName: 'bash',
+      progress: progress({ fraction: 0.6 }),
+      toolCallId: 'c2',
+    });
+    const head = cluster()?.querySelector('.slicc-cluster__head');
+    expect(cluster()?.getAttribute('data-progress')).toBe('determinate');
     expect(head?.querySelectorAll('.wcmsg-dots__dot')).toHaveLength(3);
-    // One of three rows running at 0.6 → cluster mean is 0.6 (in-flight units only).
-    expect(cluster?.style.getPropertyValue('--slicc-progress')).toBe('0.6');
-    expect(cluster?.getAttribute('title')).toContain('1 running');
+    expect(Number(cluster()?.style.getPropertyValue('--slicc-progress'))).toBeCloseTo(0.2);
+    expect(cluster()?.getAttribute('title')).toContain('0 of 3 done');
     // The cluster keeps its "3 steps" count alongside the dots.
-    expect(cluster?.querySelector('.slicc-cluster__count')?.textContent).toContain('3');
+    expect(cluster()?.querySelector('.slicc-cluster__count')?.textContent).toContain('3');
 
-    // Finishing that call clears the cluster treatment. (tool_result rerenders
-    // the message, so the cluster element is rebuilt — re-query it.)
-    agent.emit({ type: 'tool_result', messageId: 'm1', toolName: 'bash', result: 'done' });
-    const after = thread.querySelector<HTMLElement>('slicc-tool-cluster');
-    expect(after?.hasAttribute('data-progress')).toBe(false);
-    expect(after?.querySelector('.slicc-cluster__head .wcmsg-dots')).toBeNull();
+    // A completed call advances the fill by a whole step.
+    agent.emit({
+      type: 'tool_result',
+      messageId: 'm1',
+      toolName: 'bash',
+      result: 'ok',
+      toolCallId: 'c2',
+    });
+    expect(Number(cluster()?.style.getPropertyValue('--slicc-progress'))).toBeCloseTo(1 / 3);
+    expect(cluster()?.getAttribute('title')).toContain('1 of 3 done');
+
+    // A cluster never wears the row's top-border bar — icon + dots only.
+    const css = document.getElementById('slicc-wcmsg-style')?.textContent ?? '';
+    expect(css).toContain('slicc-action-row[data-progress] .slicc-act__body::before');
+    expect(css).not.toContain('slicc-tool-cluster[data-progress] .slicc-cluster__body::before');
+
+    // Once every call has settled the treatment clears entirely.
+    for (const id of ['c3', 'tc-1']) {
+      agent.emit({
+        type: 'tool_result',
+        messageId: 'm1',
+        toolName: 'bash',
+        result: 'ok',
+        toolCallId: id,
+      });
+    }
+    expect(cluster()?.hasAttribute('data-progress')).toBe(false);
+    expect(cluster()?.querySelector('.slicc-cluster__head .wcmsg-dots')).toBeNull();
+  });
+
+  it('pairs results with the right row when same-named calls run concurrently', () => {
+    // Regression: a message's tool calls execute under Promise.all, so three
+    // `bash` calls are in flight at once. Matching a result by "last unfinished
+    // call with this name" attached outputs to the wrong row — `echo BBB`
+    // rendered `CCC` on the live harness.
+    for (const id of ['c2', 'c3']) {
+      agent.emit({
+        type: 'tool_use_start',
+        messageId: 'm1',
+        toolName: 'bash',
+        toolInput: { command: `echo ${id}` },
+        toolCallId: id,
+      });
+    }
+    // Resolve the MIDDLE call first — the id must decide, not arrival order.
+    agent.emit({
+      type: 'tool_result',
+      messageId: 'm1',
+      toolName: 'bash',
+      result: 'output-for-c2',
+      toolCallId: 'c2',
+    });
+    const byId = (id: string) =>
+      thread.querySelector<HTMLElement>(`slicc-action-row[data-tool-id="${id}"]`);
+    expect(byId('c2')?.getAttribute('result')).toBe('done');
+    expect(byId('c3')?.getAttribute('result')).toBe('…');
+    expect(byId('tc-1')?.getAttribute('result')).toBe('…');
+    expect(byId('c2')?.textContent).toContain('output-for-c2');
+    expect(byId('c3')?.textContent ?? '').not.toContain('output-for-c2');
   });
 
   it('ignores progress for an unknown message or a tool with no in-flight call', () => {

--- a/packages/webapp/tests/ui/wc/wc-chat-controller-progress.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller-progress.test.ts
@@ -222,13 +222,81 @@ describe('WcChatController tool_progress handling', () => {
       result: 'output-for-c2',
       toolCallId: 'c2',
     });
+    // Row ids are message-scoped (`<messageId>:<toolCallId>`) so a provider
+    // that reuses an id in a later message cannot collide.
     const byId = (id: string) =>
-      thread.querySelector<HTMLElement>(`slicc-action-row[data-tool-id="${id}"]`);
+      thread.querySelector<HTMLElement>(`slicc-action-row[data-tool-id="m1:${id}"]`);
     expect(byId('c2')?.getAttribute('result')).toBe('done');
     expect(byId('c3')?.getAttribute('result')).toBe('…');
     expect(byId('tc-1')?.getAttribute('result')).toBe('…');
     expect(byId('c2')?.textContent).toContain('output-for-c2');
     expect(byId('c3')?.textContent ?? '').not.toContain('output-for-c2');
+  });
+
+  it('scopes a reused provider call id per message (no cross-message bleed)', () => {
+    // Review finding: a provider that reuses a tool-call id in a LATER message
+    // would produce duplicate `data-tool-id`s, and the thread-wide row lookup
+    // would paint the first (historical) match.
+    agent.emit({
+      type: 'tool_result',
+      messageId: 'm1',
+      toolName: 'bash',
+      result: 'ok',
+      toolCallId: 'tc-1',
+    });
+    agent.emit({ type: 'message_start', messageId: 'm2' });
+    agent.emit({
+      type: 'tool_use_start',
+      messageId: 'm2',
+      toolName: 'bash',
+      toolInput: { command: 'sleep 5' },
+      toolCallId: 'tc-1', // same id as the m1 call
+    });
+
+    const ids = [...thread.querySelectorAll<HTMLElement>('slicc-action-row[data-tool-id]')].map(
+      (r) => r.dataset.toolId
+    );
+    expect(new Set(ids).size).toBe(ids.length); // all distinct
+    expect(ids).toContain('m1:tc-1');
+    expect(ids).toContain('m2:tc-1');
+
+    // Progress for the NEW call must land on the new row, not the old one.
+    agent.emit({
+      type: 'tool_progress',
+      messageId: 'm2',
+      toolName: 'bash',
+      progress: progress({ fraction: 0.5 }),
+      toolCallId: 'tc-1',
+    });
+    const row = (id: string) =>
+      thread.querySelector<HTMLElement>(`slicc-action-row[data-tool-id="${id}"]`);
+    expect(row('m2:tc-1')?.getAttribute('data-progress')).toBe('determinate');
+    expect(row('m1:tc-1')?.hasAttribute('data-progress')).toBe(false);
+  });
+
+  it('does not mark a restored, never-started cluster as running', () => {
+    // Review finding: a transcript restored after an aborted turn keeps
+    // result-less calls whose badge is a permanent `…`. Those are history, not
+    // in-flight work, and must not pin a determinate 0% on the cluster.
+    controller.loadMessages([
+      {
+        id: 'restored',
+        role: 'assistant',
+        content: 'earlier turn',
+        timestamp: Date.now(),
+        toolCalls: [
+          { id: 'old-1', name: 'bash', input: { command: 'a' } },
+          { id: 'old-2', name: 'bash', input: { command: 'b' } },
+          { id: 'old-3', name: 'bash', input: { command: 'c' } },
+        ],
+      },
+    ]);
+    const cluster = thread.querySelector<HTMLElement>('slicc-tool-cluster');
+    expect(cluster).not.toBeNull();
+    expect(cluster?.querySelectorAll('slicc-action-row')).toHaveLength(3);
+    // Every row still reads `…`, but none of them was started this session.
+    expect(cluster?.hasAttribute('data-progress')).toBe(false);
+    expect(cluster?.querySelector('.slicc-cluster__head .wcmsg-dots')).toBeNull();
   });
 
   it('ignores progress for an unknown message or a tool with no in-flight call', () => {


### PR DESCRIPTION
## Summary

A message's tool calls execute **concurrently**, but `tool_result` carried no tool-call id — so both the chat UI and the buffered transcript paired results by *"last unfinished call with this **name**"*. The moment two same-named calls overlapped, output landed on the wrong row. Before: three parallel `bash` calls rendered `echo BBB → CCC` and `echo CCC → BBB`. After: each row shows its own output.

With ids in hand, the tool cluster also becomes determinate — the whole batch is known before any call finishes — so the cluster head now fills as calls complete.

## Why

Found while investigating whether 3+ tool calls arrive in one turn (they do). Measured on the standalone harness with a real provider:

1. Prompt: *"Issue three PARALLEL bash tool calls in one turn: `sleep 5; echo AAA` / `BBB` / `CCC`"*
2. Observe the three rendered rows.

```
Expected            Actual (before)
echo AAA -> AAA     echo AAA -> AAA
echo BBB -> BBB     echo BBB -> CCC   *** crossed ***
echo CCC -> CCC     echo CCC -> BBB   *** crossed ***
```

**The agent's own view was always correct** — asked directly, it reported `ONE -> ONE`, `TWO -> TWO`, `THREE -> THREE`, because pi pairs by id internally. This was a display + persisted-transcript defect, not a data-integrity one. That is also why it went unnoticed: nothing downstream of the model was wrong.

Why calls overlap at all: `agent-loop.js` picks `executeToolCallsSequential` only when some tool declares `executionMode: 'sequential'`. SLICC declares it **nowhere**, so it takes `executeToolCallsParallel` → `await Promise.all(...)`. Measured: 3 × `sleep 8` completed in ~8 s, not 24 s.

## Approach / Implementation notes

- **Threads `toolCallId`** through `scoop-context` → `scoop-lifecycle-manager` → `orchestrator`/`facade` → kernel `AgentEventMsg` → `agent-event-stream` / `offscreen-client` → `WcChatController`, on `tool_use_start`, `tool_result` and `tool_progress`. The id is **optional on the wire** purely for back-compat with followers built before it existed.
- **Pairing** moves to `#findToolCall(message, toolName, toolCallId)`: match by id when present, else the old name scan. The fallback is kept deliberately — for a pre-id sender the ambiguity is unavoidable, and silently dropping those events would be worse than an occasional mispair.
- **`bufferToolEnd` matches by id too.** It had the identical name-based lookup, so *persisted transcripts* mis-attributed results as well — that defect outlived the session, and replaying a session reproduced it.
- **Rows adopt the provider id** instead of a local `uid()`, so progress and results address the same identity.
- **Cluster is now `(finished + partial) / N`** and never indeterminate: the batch size is known before any call finishes. A still-running call contributes its own fraction so the fill advances smoothly between completions instead of jumping a whole step. Returns to "no treatment" once every call settles.

### UI: the cluster gets no progress bar — by design

The row keeps its 3px top-border bar. A cluster is a *summary* of many calls, and a bar there reads as noise, so it advances only through its lucide **icon fill** and the **three dots**, keeping the existing "N steps" count. The CSS selector for the bar is now explicitly row-only, and a test pins that (asserts the cluster body has no `::before` rule while the row does) so it can't drift back.

## Cross-cutting impact

- **Floats**: the id rides the existing kernel/offscreen envelopes; extension and CLI both exercised. No new message types.
- **Follower parity**: `toolCallId` is inventoried in the tray-sync corpus as `dropped` for `tool_use_start` / `tool_result` / `tool_progress` — `SyncProtocol.swift` has no property for it yet, **so followers still name-pair and can still cross outputs on a parallel batch**. Adding the Swift property is the natural follow-up; the corpus keeps the gap visible rather than silent. Generated JSON regenerated.
- **Other callers**: every relay of `onToolStart` / `onToolEnd` / `onToolProgress` was updated; the id is appended as an optional trailing parameter so no positional call site changes meaning.
- **Side effect (good)**: previously all concurrent calls' progress collapsed onto one row (`prog:1` observed on the harness). Per-call progress under parallel batches now works.

## Test plan

- [x] `npm run typecheck` (webapp + node-server + worker)
- [x] `npm run test` — **14,013 passing**, no new failures
- [x] `npx prettier --check .` / `biome check .`
- [x] boy-scout debt gate, layer-back-edges, record-string-unknown, `lint:patches`
- [x] `npm run build -w @slicc/webapp` + `-w @slicc/chrome-extension`; bundle size 1.92 / 1.93 MB
- [x] **New tests**: a regression test that resolves the **middle** of three concurrent calls and asserts the *id* — not arrival order — decides which row receives it; and a cluster test covering k-of-N fill, the "no bar on cluster" CSS invariant, and clearing once all calls settle
- [x] **Manual smoke (CLI harness + real provider)**: parallel batch now renders `AAA→AAA`, `BBB→BBB`, `CCC→CCC`; cluster measured mid-flight at `title: "0/3 · 0 of 3 done — 30%"`, dots `● ○ ○`, computed cluster `::before` width `auto` (no bar), `3 steps` count intact

**Cluster mid-flight** — head at 30%, dots `● ○ ○`, lucide icon filling, and no bar; the per-call rows keep their own dots underneath:

![cluster k-of-n fill](https://slicc--ai-ecoverse.agentbin.net/c68a0288e62dcf296029db7f3150a253bd7f7b19b56abdb5bd29ae4962e04c44.png)

**Pre-existing failures**: none. (Three `zenfs-alloc-overflow` patch tests failed locally until `@zenfs/core` was reinstalled — a half-patched `node_modules`, not a code issue; CI installs clean.)

## Documentation

- [x] No documentation changes needed — no user-facing surface or agent-facing contract changed; the wire addition is documented inline on the type.

## Risk & rollback

- Blast radius: chat rendering + transcript attribution. Clean single-commit revert; no persisted-state migration (the id is additive and optional).
- Sessions persisted *before* this change keep their old (possibly mispaired) tool results — the fix is not retroactive.
- CI can't catch the real-provider parallel batch; verified by hand on the harness as described above.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets or tokens in the diff
- [x] Cross-float contract change (`toolCallId`) checked through offscreen / facade / kernel / follower paths and inventoried in the corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)
