### PR TITLE
fix(memory): point curator drafts at /tmp instead of claiming nothing is writable

### DIFF
--- a/packages/vfs-root/shared/MEMORY.md
+++ b/packages/vfs-root/shared/MEMORY.md
@@ -88,7 +88,7 @@ upskill search <a few words from the pitfall>
 upskill list                      # what is already installed — never suggest a duplicate
 ```
 
-`upskill ai-ecoverse/skills` and `upskill adobe/skills` list a repo's skills without installing anything. **Never install.** You have no write access outside {{MEMORY_PATH}}, so an install attempt will fail or interrupt the user for approval; recommending is your job, deciding is theirs. Put any suggestion in your closing message, with the pitfall it addresses — that message is delivered to the main agent.
+`upskill ai-ecoverse/skills` and `upskill adobe/skills` list a repo's skills without installing anything. **Never install.** You have no write access to the skills tree, so an install attempt will fail or interrupt the user for approval; recommending is your job, deciding is theirs. Put any suggestion in your closing message, with the pitfall it addresses — that message is delivered to the main agent.
 
 ## Working within the budget
 
@@ -99,13 +99,18 @@ Measure, decide, then write once. Do not converge on the budget by trial and err
 3. Write the complete file once, already inside the budget. Never write a version you know to be over budget «to fix in the next step»: the pass can be killed at any moment, and the file you leave behind is the one the next session inherits.
 4. `wc -c {{MEMORY_PATH}}` to confirm. If you are still over, cut a whole section rather than shaving a few characters at a time.
 
+Per-section costs come out of `awk`, not an interpreter: `awk '/^## /{h=$0} {c[h]+=length($0)+1} END{for(k in c) printf "%7d  %s\n", c[k], k}' {{MEMORY_PATH}} | sort -rn` tells you which sections pay for the surplus.
+
+To draft before committing, draft in `/tmp/`. It is writable for every scoop without a grant and without an approval prompt, so `/tmp/memory-draft.md` costs you nothing — but reuse that one filename rather than numbering drafts, because you have no `rm` and whatever you leave behind stays.
+
 If the pass is running long, drop the oldest-dated section wholesale and write. An under-budget file missing one stale section is a good outcome; an over-budget file is a broken one.
 
 Rules:
 
 - Keep durable preferences, stable project facts, validated approaches, named resources, and the pitfalls worth not repeating.
 - Organize retained information into concise per-topic sections rather than one flat list. Let the topic lead the heading; preferences, projects and pitfalls are what to look for, not a required table of contents.
-- Write the memory file only. Do not create backups or scratch copies next to it — the file is versioned, and you have no write access anywhere else.
+- Never write next to the memory file. It is versioned, so backups and scratch copies beside it are noise; drafts belong in `/tmp/`.
+- Shell tools only. Interpreters such as `python3` and `node -e` are not on your allow-list, so reaching for one costs an approval round-trip and may fail even when approved — `awk`, `sed`, `wc` and `sort` cover every measurement this pass needs.
 - End every `##` and `###` section heading with its last-verified date in `YYYY-MM-DD` form, for example `## Deployment pipeline (2026-08-06)`. Dates are UTC, matching the session archive timestamps, so a late-evening freeze west of UTC stamps the next day.
 - Stamp sections you write or confirm with today's date, {{TODAY}}.
 - Prioritize re-verifying the oldest-dated sections. Treat undated headings as maximally stale and date them on this pass.
@@ -118,6 +123,8 @@ Rules:
 Add curator instructions here, for example: also update the knowledge base at /path following its WIKI.md. Extend visiblePaths or writablePaths above to grant access to extra stores, and adjust timeoutSeconds when needed.
 
 writablePaths defaults to the memory file alone rather than /workspace/, because the curator can run upskill and a directory-wide grant would also let it install skills into /workspace/skills. Widen it only as far as a task genuinely needs; a single file is a valid entry, not just a directory.
+
+Scratch space needs no entry here: /tmp/ is read/write for every scoop without a grant or a prompt, the way it is on Unix, so the curator can draft a rewrite before committing it without the sandbox being widened. That space is shared with other scoops and visible to the cone, so nothing secret belongs in it.
 
 thinkingLevel accepts off, minimal, low, medium, high, or xhigh. Curation is cheaper with reasoning than without: an unreasoned pass converges on the budget by trial and error, and because every turn re-reads the whole context, turn count is what the pass costs. Lower it to off only if you also shrink the prompt to a single mechanical instruction.
 

--- a/packages/vfs-root/shared/MEMORY.md
+++ b/packages/vfs-root/shared/MEMORY.md
@@ -101,7 +101,7 @@ Measure, decide, then write once. Do not converge on the budget by trial and err
 
 Per-section costs come out of `awk`, not an interpreter: `awk '/^## /{h=$0} {c[h]+=length($0)+1} END{for(k in c) printf "%7d  %s\n", c[k], k}' {{MEMORY_PATH}} | sort -rn` tells you which sections pay for the surplus.
 
-To draft before committing, draft in `/tmp/`. It is writable for every scoop without a grant and without an approval prompt, so `/tmp/memory-draft.md` costs you nothing — but reuse that one filename rather than numbering drafts, because you have no `rm` and whatever you leave behind stays.
+To draft before committing, draft in `/scoops/agent-memory-curator/`. That is your own scratch folder: writable without a grant and without an approval prompt, private to this pass, and deleted when the pass ends. Reuse one filename such as `/scoops/agent-memory-curator/draft.md` rather than numbering drafts — you have no `rm`, so every extra draft survives until the folder goes.
 
 If the pass is running long, drop the oldest-dated section wholesale and write. An under-budget file missing one stale section is a good outcome; an over-budget file is a broken one.
 
@@ -109,7 +109,7 @@ Rules:
 
 - Keep durable preferences, stable project facts, validated approaches, named resources, and the pitfalls worth not repeating.
 - Organize retained information into concise per-topic sections rather than one flat list. Let the topic lead the heading; preferences, projects and pitfalls are what to look for, not a required table of contents.
-- Never write next to the memory file. It is versioned, so backups and scratch copies beside it are noise; drafts belong in `/tmp/`.
+- Never write next to the memory file. It is versioned, so backups and scratch copies beside it are noise; drafts belong in `/scoops/agent-memory-curator/`. Do not draft in `/tmp/` either: it is shared with every other scoop, which can read and overwrite what you leave there.
 - Shell tools only. Interpreters such as `python3` and `node -e` are not on your allow-list, so reaching for one costs an approval round-trip and may fail even when approved — `awk`, `sed`, `wc` and `sort` cover every measurement this pass needs.
 - End every `##` and `###` section heading with its last-verified date in `YYYY-MM-DD` form, for example `## Deployment pipeline (2026-08-06)`. Dates are UTC, matching the session archive timestamps, so a late-evening freeze west of UTC stamps the next day.
 - Stamp sections you write or confirm with today's date, {{TODAY}}.
@@ -124,7 +124,7 @@ Add curator instructions here, for example: also update the knowledge base at /p
 
 writablePaths defaults to the memory file alone rather than /workspace/, because the curator can run upskill and a directory-wide grant would also let it install skills into /workspace/skills. Widen it only as far as a task genuinely needs; a single file is a valid entry, not just a directory.
 
-Scratch space needs no entry here: /tmp/ is read/write for every scoop without a grant or a prompt, the way it is on Unix, so the curator can draft a rewrite before committing it without the sandbox being widened. That space is shared with other scoops and visible to the cone, so nothing secret belongs in it.
+Scratch space needs no entry here. The curator spawns under the fixed name memory-curator, so the bridge grants it /scoops/agent-memory-curator/ — private to the run, writable without a prompt, and removed when the pass ends — and that is where the prompt sends drafts. /tmp/ is writable too, but it is shared with every other scoop and visible to the cone, so a full rewrite of durable memory does not belong there.
 
 thinkingLevel accepts off, minimal, low, medium, high, or xhigh. Curation is cheaper with reasoning than without: an unreasoned pass converges on the budget by trial and error, and because every turn re-reads the whole context, turn count is what the pass costs. Lower it to off only if you also shrink the prompt to a single mechanical instruction.
 

--- a/packages/webapp/tests/scoops/agentic-memory-default.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory-default.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { RestrictedFS } from '../../src/fs/restricted-fs.js';
 import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import type { AgentSpawnOptions, AgentSpawnResult } from '../../src/scoops/agent-bridge.js';
 import { DEFAULT_MEMORY_MD, runAgenticMemoryPass } from '../../src/scoops/agentic-memory.js';
 import { createDefaultSharedFiles } from '../../src/scoops/skills.js';
 
@@ -24,6 +27,42 @@ describe('bundled MEMORY.md', () => {
       })
     ).resolves.toEqual({ ok: true, report: 'done' });
     expect(spawn).toHaveBeenCalledOnce();
+  });
+
+  // The prompt tells the curator to draft in `/tmp/` rather than beside the
+  // memory file. That instruction is only true because `/tmp` is writable for
+  // every sandbox regardless of ACLs (`ALWAYS_WRITABLE_PREFIXES`) — the shipped
+  // `writablePaths` never mentions it. Lose that exemption and the curator is
+  // back to escalating a sudo request mid-pass, so pin the pair together.
+  it('can write the scratch path its prompt names, using only the shipped grants', async () => {
+    const spawn = vi.fn(
+      async (_options: AgentSpawnOptions): Promise<AgentSpawnResult> => ({
+        finalText: 'done',
+        exitCode: 0,
+      })
+    );
+    await runAgenticMemoryPass({
+      spawn,
+      vfs: { readFile: async () => DEFAULT_MEMORY_MD },
+      sessionArchivePath: '/sessions/frozen.md',
+      sessionCount: 1,
+    });
+    const writablePaths = spawn.mock.calls[0][0].writablePaths ?? [];
+    expect(writablePaths).toEqual(['/workspace/CLAUDE.md']);
+    expect(DEFAULT_MEMORY_MD).toContain('/tmp/memory-draft.md');
+
+    vfs = await VirtualFS.create({ dbName: `memory-scratch-${dbCounter++}`, wipe: true });
+    await vfs.mkdir('/tmp', { recursive: true });
+    await vfs.mkdir('/workspace', { recursive: true });
+    const restricted = new RestrictedFS(vfs, writablePaths);
+
+    await restricted.writeFile('/tmp/memory-draft.md', 'draft');
+    expect(await restricted.readFile('/tmp/memory-draft.md', { encoding: 'utf-8' })).toBe('draft');
+    // A scratch copy beside the memory file stays blocked — the reason the
+    // prompt sends drafts to `/tmp` instead of next door.
+    await expect(restricted.writeFile('/workspace/CLAUDE.md.bak', 'copy')).rejects.toThrow(
+      'EACCES'
+    );
   });
 
   it('is seeded on a fresh VFS without overwriting user edits', async () => {

--- a/packages/webapp/tests/scoops/agentic-memory-default.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory-default.test.ts
@@ -29,12 +29,14 @@ describe('bundled MEMORY.md', () => {
     expect(spawn).toHaveBeenCalledOnce();
   });
 
-  // The prompt tells the curator to draft in `/tmp/` rather than beside the
-  // memory file. That instruction is only true because `/tmp` is writable for
-  // every sandbox regardless of ACLs (`ALWAYS_WRITABLE_PREFIXES`) — the shipped
-  // `writablePaths` never mentions it. Lose that exemption and the curator is
-  // back to escalating a sudo request mid-pass, so pin the pair together.
-  it('can write the scratch path its prompt names, using only the shipped grants', async () => {
+  // The prompt sends drafts to the curator's own scratch folder. That path is
+  // never in the shipped `writablePaths` — the bridge unions `/scoops/agent-<name>/`
+  // in at spawn time from the fixed agent name, and deletes it when the pass
+  // ends. So the literal path in the prompt is only correct as long as the name
+  // stays put; derive it here rather than hardcoding it, and pin that the
+  // sandbox actually admits the write. Lose either half and the curator is back
+  // to escalating a sudo request mid-pass (#2164).
+  it('can write the scratch path its prompt names, using only the grants it is spawned with', async () => {
     const spawn = vi.fn(
       async (_options: AgentSpawnOptions): Promise<AgentSpawnResult> => ({
         finalText: 'done',
@@ -47,19 +49,28 @@ describe('bundled MEMORY.md', () => {
       sessionArchivePath: '/sessions/frozen.md',
       sessionCount: 1,
     });
-    const writablePaths = spawn.mock.calls[0][0].writablePaths ?? [];
+    const { writablePaths = [], name } = spawn.mock.calls[0][0];
     expect(writablePaths).toEqual(['/workspace/CLAUDE.md']);
-    expect(DEFAULT_MEMORY_MD).toContain('/tmp/memory-draft.md');
+    const scratchFolder = `/scoops/agent-${name}`;
+    expect(DEFAULT_MEMORY_MD).toContain(`${scratchFolder}/draft.md`);
+    // Shared `/tmp` is writable too, but a full rewrite of durable memory is
+    // readable and clobberable by every other scoop there, so the prompt must
+    // not send drafts to it.
+    expect(DEFAULT_MEMORY_MD).not.toContain('/tmp/memory-draft.md');
 
     vfs = await VirtualFS.create({ dbName: `memory-scratch-${dbCounter++}`, wipe: true });
-    await vfs.mkdir('/tmp', { recursive: true });
+    await vfs.mkdir(scratchFolder, { recursive: true });
     await vfs.mkdir('/workspace', { recursive: true });
-    const restricted = new RestrictedFS(vfs, writablePaths);
+    // What `buildScoopConfig` hands the sandbox: the frontmatter grants plus
+    // the scratch folder.
+    const restricted = new RestrictedFS(vfs, [...writablePaths, `${scratchFolder}/`]);
 
-    await restricted.writeFile('/tmp/memory-draft.md', 'draft');
-    expect(await restricted.readFile('/tmp/memory-draft.md', { encoding: 'utf-8' })).toBe('draft');
+    await restricted.writeFile(`${scratchFolder}/draft.md`, 'draft');
+    expect(await restricted.readFile(`${scratchFolder}/draft.md`, { encoding: 'utf-8' })).toBe(
+      'draft'
+    );
     // A scratch copy beside the memory file stays blocked — the reason the
-    // prompt sends drafts to `/tmp` instead of next door.
+    // prompt sends drafts elsewhere rather than next door.
     await expect(restricted.writeFile('/workspace/CLAUDE.md.bak', 'copy')).rejects.toThrow(
       'EACCES'
     );


### PR DESCRIPTION
Fixes #2164

The escalations that issue reported are already impossible: #2235 made `/tmp` read/write for every scoop at both gates (`builtinScoopGrants()` and `ALWAYS_WRITABLE_PREFIXES`), with no grant and no approval prompt. What survived was the prompt, which still told the curator «you have no write access anywhere else». An agent that believes that line has no legal way to draft-then-measure under a hard character budget — so it improvises `/workspace/.s.txt` and `python3 -`, gets denied twice, and loses the two turns it needed for the compaction step.

This is a prompt correction plus a test that stops the two from drifting apart again. No sandbox change.

## `packages/vfs-root/shared/MEMORY.md`

- Drafts go to **`/scoops/agent-memory-curator/draft.md`** — the curator's own scratch folder. `buildScoopConfig` unions `` `${scratchFolder}/` `` into `writablePaths` at spawn time, so it is writable without a grant or a prompt, and `cleanupScoop` `rm -r`s it in the `finally` of every run, on success and failure. That is private *and* genuinely self-cleaning, which is what the issue thread wanted from `/tmp` but could not confirm.
- Not `/tmp`: it is shared with every scoop, and the curator reads its draft back to write the final file, so a concurrent scoop clobbering it is a poisoning path into `/workspace/CLAUDE.md`. (Raised in review; the first commit had it in `/tmp`.)
- One reused filename rather than numbered drafts — the curator has no `rm`, and the issue's verification comment found `d2.md`…`d7.md` left from a single pass.
- Per-section byte accounting is an `awk` one-liner, which is what the `python3 -` escalation was for.
- Interpreters named as off-limits: neither `python3` nor `node` is on the allow-list, so reaching for one costs an approval round-trip and may fail even when approved.
- The `upskill` paragraph now says the curator cannot write *the skills tree*, instead of repeating the nothing-is-writable claim — that was the reason the sentence existed.

`writablePaths` is untouched: still `/workspace/CLAUDE.md` alone, so `upskill` still cannot install into `/workspace/skills`, and the curator still cannot rewrite its own instructions.

## Test

`agentic-memory-default.test.ts` derives the scratch path from the spawn options' `name` rather than hardcoding it, asserts the prompt names that exact path (and does *not* send drafts to `/tmp`), then builds a `RestrictedFS` from the frontmatter grants plus the scratch folder and checks the write and read-back land while a copy beside the memory file stays `EACCES`.

Both halves were checked by reverting rather than assumed: renaming the fixed agent name fails the test, and so did dropping `/tmp` from `ALWAYS_WRITABLE_PREFIXES` in the earlier `/tmp` version.

## Verification

`lint`, `typecheck` (all 9 projects), `test` (16,199 passed), `test:coverage:webapp` (83.38 lines / 81.33 statements, floors 82 / 79), both builds, and `check-touched-exemptions` — all green.

Still open and out of scope: `mktemp` does not exist in this shell, so the prompt names a literal path rather than minting one. #2269 adds the shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)