### PR TITLE
fix(webapp): re-order the tab strip on the standalone tray follower too (#2272)

### DIFF
--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -28,6 +28,7 @@ import {
   TRAY_WORKER_STORAGE_KEY,
 } from '../../scoops/tray-runtime-config.js';
 import type {
+  ScoopSummary,
   TrayModelCatalogEntry,
   TrayModelSelectionState,
 } from '../../scoops/tray-sync-protocol.js';
@@ -248,6 +249,17 @@ export function buildFollowerOptions(
 ): Parameters<typeof startPageFollowerTray>[0] {
   const { browser, client, getController } = deps;
   let selectedScoopJid: string | null = null;
+  /**
+   * Last roster the leader sent. `toFollowerSwitcherScoops` orders the SELECTED
+   * cone's scoops ahead of the rest, so a local selection has to re-publish the
+   * descriptors — this leader-capable float is the third follower wiring path
+   * (with `wc-follower.ts` and the leader's own `wc-live.ts`) and needs the same
+   * behaviour (#2272).
+   */
+  let followerScoops: readonly ScoopSummary[] = [];
+  const publishFollowerScoops = (): void => {
+    deps.refs.switcher.scoops = toFollowerSwitcherScoops(followerScoops, selectedScoopJid);
+  };
   const modelSurface = createFollowerModelSurface({
     composerMeta: deps.refs.composerMeta,
     getSync,
@@ -272,6 +284,7 @@ export function buildFollowerOptions(
       const scoopJid = (event as CustomEvent<{ key?: string }>).detail?.key;
       if (!scoopJid) return;
       selectedScoopJid = scoopJid;
+      publishFollowerScoops(); // re-order for the new selection, as the leader does
       deps.refs.switcher.setAttribute('active', scoopJid);
       sync.selectScoop(scoopJid);
     },
@@ -308,7 +321,8 @@ export function buildFollowerOptions(
       if (!selectedScoopJid || !scoops.some((scoop) => scoop.jid === selectedScoopJid)) {
         selectedScoopJid = activeScoopJid;
       }
-      deps.refs.switcher.scoops = toFollowerSwitcherScoops(scoops);
+      followerScoops = scoops;
+      publishFollowerScoops();
       deps.refs.switcher.setAttribute('active', selectedScoopJid);
     },
     // #1915: this float has a mounted permissions surface (it can lead), so

--- a/packages/webapp/tests/ui/wc/wc-tray-models.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-tray-models.test.ts
@@ -82,6 +82,49 @@ describe('role-switch follower model controls', () => {
     expect(selectScoop).toHaveBeenCalledWith('research');
   });
 
+  it('re-orders the strip when this leader-capable follower selects a cone (Codex P2)', () => {
+    // Third follower wiring path, after wc-live (leader) and wc-follower: a
+    // standalone float that joined someone else's tray. It publishes through
+    // the same `toFollowerSwitcherScoops`, so it needs the same selection.
+    const composerMeta = document.createElement('div');
+    const switcher = document.createElement('div') as unknown as HTMLElement & {
+      scoops: Array<{ key: string }>;
+    };
+    const options = buildFollowerOptions(
+      {
+        refs: {
+          composerMeta,
+          switcher,
+          dock: document.createElement('div'),
+          overlaySurfaces: new Set(),
+        },
+        browser: {},
+        client: { sendSetFollowerForwarding: vi.fn() },
+        window: { localStorage: { getItem: vi.fn(() => null) } },
+        getController: () => null,
+        addSprinkle: vi.fn(),
+        removeSprinkle: vi.fn(),
+      } as never,
+      'https://tray.example/join/token',
+      () => ({ selectScoop: vi.fn() }) as never
+    );
+
+    options.onScoopsList?.(
+      [
+        { jid: 'cone-a', name: 'cone', isCone: true },
+        { jid: 'cone-b', name: 'research', isCone: true },
+        { jid: 'scoop-a', name: 'helper-a', isCone: false, parentId: 'cone-a' },
+        { jid: 'scoop-b', name: 'helper-b', isCone: false, parentId: 'cone-b' },
+      ] as never,
+      'cone-a'
+    );
+    const orderFor = () => switcher.scoops.map((entry) => entry.key);
+    expect(orderFor()).toEqual(['cone-a', 'cone-b', 'scoop-a', 'scoop-b']);
+
+    switcher.dispatchEvent(new CustomEvent('slicc-scoop-select', { detail: { key: 'cone-b' } }));
+    expect(orderFor()).toEqual(['cone-a', 'cone-b', 'scoop-b', 'scoop-a']);
+  });
+
   it('preserves the viewed scoop across transient disconnect and falls back when it disappears', () => {
     const composerMeta = document.createElement('div');
     const switcher = document.createElement('div') as HTMLElement & { scoops?: unknown[] };


### PR DESCRIPTION
Follow-up to #2285, closing the last Codex finding from that PR's final review round (it arrived after the PR had already been added to the merge queue, and GitHub refuses branch updates while queued).

## The bug

`buildFollowerOptions` in `ui/wc/wc-tray.ts` is the **third** follower wiring path — a leader-capable standalone float that has joined someone else's tray. #2285 fixed the ordering in the other two (`wc-live.ts` for the leader, `wc-follower.ts` for the dedicated follower mount) and missed this one.

It is the worst of the three:

- `onScoopsList` published with `toFollowerSwitcherScoops(scoops)`, dropping the `selectedScoopJid` argument entirely — so the selected cone's scoops were **never** ordered first in this runtime, not merely until the next roster push;
- its `slicc-scoop-select` handler only moved the `active` attribute, so a local click never re-ordered either.

Only visible with more than one cone, which is what #2272 introduced.

## The fix

Same shape as the other two paths: cache the last roster the leader sent and publish through a single `publishFollowerScoops()` that both `onScoopsList` and the click handler call.

## Tests

New case in `tests/ui/wc/wc-tray-models.test.ts` pins the real order across a selection change rather than just asserting a refresh fired:

`['cone-a','cone-b','scoop-a','scoop-b']` → select `cone-b` → `['cone-a','cone-b','scoop-b','scoop-a']`

Checked against a reverted fix — it fails without the change and passes with it.

## Verification

lint gate (7/7), boy-scout debt gate, typecheck (9 projects), webapp coverage (724 files / 13 033 tests), webapp + chrome-extension builds, bundle-size — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
