### PR TITLE
fix(slicc-cli): persist superseded join URLs across follow/watch reconnects

### DIFF
--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -78,7 +78,8 @@ JSON and update Go structs + `corpus_test.go` alongside TS + Swift mirrors.
 
 - **User-facing** — `prompt`/`exec`/`watch` write leader bytes to stdout,
   status to stderr. **Never route through the logger**; the CLI is pipeable.
-- **Diagnostics** — signaling retries, supersede redirects, ICE failures,
+- **Diagnostics** — signaling retries, supersede redirects (`OnJoinURLChanged`
+  persists the replacement across `follow`/`watch` reconnects), ICE failures,
   unparseable frames go through `internal/logging` (`log/slog` `diagLogger`
   in `commands.go`, to stderr); `debugLogf` adapts to `tray.Options.Logf`.
 - **pion's own records** — `Conn.pionLoggerFactory` installs

--- a/packages/slicc-cli/commands.go
+++ b/packages/slicc-cli/commands.go
@@ -211,7 +211,7 @@ func cmdWatch(ctx context.Context, joinURL, scoopJid string, plain bool) int {
 			backoff = time.Second
 		} else {
 			var resetBackoff bool
-			failures, resetBackoff = join.recordReconnectFailure(failures)
+			failures, resetBackoff = join.recordReconnectFailure(failures, err)
 			if resetBackoff {
 				backoff = time.Second
 			}
@@ -397,7 +397,7 @@ func cmdFollow(ctx context.Context, joinURL string, fa followArgs) int {
 			backoff = time.Second
 		} else {
 			var resetBackoff bool
-			failures, resetBackoff = join.recordReconnectFailure(failures)
+			failures, resetBackoff = join.recordReconnectFailure(failures, err)
 			if resetBackoff {
 				backoff = time.Second
 			}

--- a/packages/slicc-cli/commands.go
+++ b/packages/slicc-cli/commands.go
@@ -193,14 +193,16 @@ func cmdWatch(ctx context.Context, joinURL, scoopJid string, plain bool) int {
 	r.console.Line(ui.KindInfo, "tailing %s (Ctrl+C to stop)", what)
 	r.console.Start()
 	defer printSessionSummary(r.console)
+	join := newJoinURLState(joinURL)
 	backoff := time.Second
 	failures := 0
 	for {
 		if ctx.Err() != nil {
 			return 0
 		}
+		join.beginAttempt()
 		r.console.Update(func(s *ui.Status) { s.State = ui.StateConnecting; s.Attempt = failures })
-		clean, err := watchOnce(ctx, joinURL, scoopJid, r)
+		clean, err := watchOnce(ctx, join.current(), scoopJid, r, join.onTrayJoinURLChanged)
 		if ctx.Err() != nil {
 			return 0
 		}
@@ -208,7 +210,11 @@ func cmdWatch(ctx context.Context, joinURL, scoopJid string, plain bool) int {
 			failures = 0
 			backoff = time.Second
 		} else {
-			failures++
+			var resetBackoff bool
+			failures, resetBackoff = join.recordReconnectFailure(failures)
+			if resetBackoff {
+				backoff = time.Second
+			}
 			if err != nil {
 				r.console.Line(ui.KindError, "%s", err)
 				reportRuntimeError("watch", err)
@@ -234,7 +240,12 @@ type watchRender struct {
 	out     ui.Mode
 }
 
-func watchOnce(ctx context.Context, joinURL, scoopJid string, r watchRender) (clean bool, err error) {
+func watchOnce(
+	ctx context.Context,
+	joinURL, scoopJid string,
+	r watchRender,
+	onJoinURLChanged func(string),
+) (clean bool, err error) {
 	sawProcessing := false
 	// Empty scoopJid = no filter (tail whatever the leader broadcasts).
 	inScoop := func(js string) bool { return scoopJid == "" || js == scoopJid }
@@ -268,11 +279,12 @@ func watchOnce(ctx context.Context, joinURL, scoopJid string, r watchRender) (cl
 		}
 	}
 	conn, dialErr := tray.Dial(ctx, joinURL, tray.Options{
-		OnMessage:  handler,
-		OnActivity: r.console.Beat,
-		OnLinkDiag: linkDiagCounter(r.console),
-		Logf:       debugLogf,
-		LogWanted:  diagLogger.EnabledAt,
+		OnMessage:        handler,
+		OnActivity:       r.console.Beat,
+		OnLinkDiag:       linkDiagCounter(r.console),
+		OnJoinURLChanged: onJoinURLChanged,
+		Logf:             debugLogf,
+		LogWanted:        diagLogger.EnabledAt,
 	})
 	if dialErr != nil {
 		return false, dialErr
@@ -367,14 +379,16 @@ func cmdFollow(ctx context.Context, joinURL string, fa followArgs) int {
 	console.Update(func(s *ui.Status) { s.Peer = followPeer(console.Mode(), fa.runner) })
 	console.Start()
 	defer printSessionSummary(console)
+	join := newJoinURLState(joinURL)
 	backoff := time.Second
 	failures := 0
 	for {
 		if ctx.Err() != nil {
 			return 0
 		}
+		join.beginAttempt()
 		console.Update(func(s *ui.Status) { s.State = ui.StateConnecting; s.Attempt = failures })
-		connected, err := followOnce(ctx, joinURL, fa.runner, eval, console)
+		connected, err := followOnce(ctx, join.current(), fa.runner, eval, console, join.onTrayJoinURLChanged)
 		if ctx.Err() != nil {
 			return 0
 		}
@@ -382,7 +396,11 @@ func cmdFollow(ctx context.Context, joinURL string, fa followArgs) int {
 			failures = 0
 			backoff = time.Second
 		} else {
-			failures++
+			var resetBackoff bool
+			failures, resetBackoff = join.recordReconnectFailure(failures)
+			if resetBackoff {
+				backoff = time.Second
+			}
 			if err != nil {
 				console.Line(ui.KindError, "%s", err)
 				reportRuntimeError("follow", err)
@@ -407,6 +425,7 @@ func followOnce(
 	runner []string,
 	eval *execrun.EvalSession,
 	console *ui.Console,
+	onJoinURLChanged func(string),
 ) (connected bool, err error) {
 	// Connection-scoped context: cancelled on ANY return (disconnect, ctx done),
 	// so a leader-issued command that's still running is killed with the
@@ -422,12 +441,13 @@ func followOnce(
 	}
 
 	conn, dialErr := tray.Dial(connCtx, joinURL, tray.Options{
-		Capabilities: caps,
-		Motd:         followMotd(runner, eval != nil),
-		Logf:         debugLogf,
-		LogWanted:    diagLogger.EnabledAt,
-		OnActivity:   console.Beat,
-		OnLinkDiag:   linkDiagCounter(console),
+		Capabilities:     caps,
+		Motd:             followMotd(runner, eval != nil),
+		Logf:             debugLogf,
+		LogWanted:        diagLogger.EnabledAt,
+		OnActivity:       console.Beat,
+		OnLinkDiag:       linkDiagCounter(console),
+		OnJoinURLChanged: onJoinURLChanged,
 		OnMessage: func(typ string, raw []byte) {
 			select {
 			case msgCh <- inbound{typ: typ, raw: raw}:

--- a/packages/slicc-cli/internal/tray/attach_error.go
+++ b/packages/slicc-cli/internal/tray/attach_error.go
@@ -1,0 +1,46 @@
+package tray
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	// AttachCodeSupersededMissingJoin is returned when the hub reports
+	// TRAY_SUPERSEDED but omits a replacement joinUrl.
+	AttachCodeSupersededMissingJoin = "TRAY_SUPERSEDED_MISSING_JOIN_URL"
+	// AttachCodeSupersededChainExhausted is returned when the follower followed
+	// maxSupersedeRetries replacements and the hub still reports superseded.
+	AttachCodeSupersededChainExhausted = "TRAY_SUPERSEDED_CHAIN_EXHAUSTED"
+)
+
+// AttachError is a normalized tray attach failure from signaling.
+type AttachError struct {
+	Code    string
+	Message string
+}
+
+func (e *AttachError) Error() string {
+	return fmt.Sprintf("tray attach failed (%s): %s", e.Code, e.Message)
+}
+
+// IsSupersedeChainExhausted reports whether err is a bounded supersede-chain
+// failure from tray.Dial.
+func IsSupersedeChainExhausted(err error) bool {
+	var ae *AttachError
+	return errors.As(err, &ae) && ae.Code == AttachCodeSupersededChainExhausted
+}
+
+// IsSupersedeMissingJoin reports whether err is TRAY_SUPERSEDED without a
+// replacement joinUrl.
+func IsSupersedeMissingJoin(err error) bool {
+	var ae *AttachError
+	return errors.As(err, &ae) && ae.Code == AttachCodeSupersededMissingJoin
+}
+
+func supersedeChainExhaustedMessage() string {
+	return fmt.Sprintf(
+		"this session moved %d times without settling (possible redirect loop)",
+		maxSupersedeRetries,
+	)
+}

--- a/packages/slicc-cli/internal/tray/attach_error_test.go
+++ b/packages/slicc-cli/internal/tray/attach_error_test.go
@@ -1,0 +1,35 @@
+package tray
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAttachErrorString(t *testing.T) {
+	err := &AttachError{Code: AttachCodeSupersededChainExhausted, Message: "moved too far"}
+	want := "tray attach failed (TRAY_SUPERSEDED_CHAIN_EXHAUSTED): moved too far"
+	if err.Error() != want {
+		t.Fatalf("Error() = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestIsSupersedeChainExhausted(t *testing.T) {
+	if !IsSupersedeChainExhausted(&AttachError{Code: AttachCodeSupersededChainExhausted}) {
+		t.Fatal("expected chain exhausted")
+	}
+	if IsSupersedeChainExhausted(&AttachError{Code: AttachCodeSupersededMissingJoin}) {
+		t.Fatal("missing join should not match chain exhausted")
+	}
+	if IsSupersedeChainExhausted(errors.New("other")) {
+		t.Fatal("unrelated error should not match")
+	}
+}
+
+func TestIsSupersedeMissingJoin(t *testing.T) {
+	if !IsSupersedeMissingJoin(&AttachError{Code: AttachCodeSupersededMissingJoin}) {
+		t.Fatal("expected missing join")
+	}
+	if IsSupersedeMissingJoin(&AttachError{Code: AttachCodeSupersededChainExhausted}) {
+		t.Fatal("chain exhausted should not match missing join")
+	}
+}

--- a/packages/slicc-cli/internal/tray/conn.go
+++ b/packages/slicc-cli/internal/tray/conn.go
@@ -84,6 +84,10 @@ type Options struct {
 	// instead of letting them scroll. Runs on pion goroutines; keep it
 	// non-blocking and concurrency-safe.
 	OnLinkDiag logging.PionEvent
+	// OnJoinURLChanged fires when a TRAY_SUPERSEDED redirect is followed so the
+	// caller can persist the replacement across reconnects (mirrors
+	// tray-webrtc.ts onJoinUrlChanged and Swift currentJoinUrl).
+	OnJoinURLChanged func(joinURL string)
 	// Logf is an optional diagnostic logger.
 	Logf func(format string, args ...any)
 	// LogWanted, when set, reports whether Logf would do anything with a record
@@ -155,17 +159,45 @@ func Dial(ctx context.Context, joinURL string, opts Options) (*Conn, error) {
 			}
 			return dialBootstrap(ctx, sig, controllerID, plan, opts)
 		case "fail":
-			if plan.Code == "TRAY_SUPERSEDED" && plan.JoinURL != "" && redirects < maxSupersedeRetries {
+			nextURL, retry, err := handleAttachFail(plan, redirects, opts)
+			if err != nil {
+				return nil, err
+			}
+			if retry {
 				redirects++
-				currentURL = plan.JoinURL
+				currentURL = nextURL
 				controllerID = newUUID()
-				opts.logf("tray attach superseded; following redirect (%d/%d)", redirects, maxSupersedeRetries)
 				continue
 			}
-			return nil, fmt.Errorf("tray attach failed (%s): %s", plan.Code, plan.Error)
 		default:
 			return nil, fmt.Errorf("tray attach: unexpected action %q", plan.Action)
 		}
+	}
+}
+
+// handleAttachFail normalizes attach failures. When retry is true, the caller
+// should re-attach at nextURL with a fresh controller id.
+func handleAttachFail(plan *signaling.AttachPlan, redirects int, opts Options) (nextURL string, retry bool, err error) {
+	if plan.Code != "TRAY_SUPERSEDED" {
+		return "", false, &AttachError{Code: plan.Code, Message: plan.Error}
+	}
+	if plan.JoinURL != "" && redirects < maxSupersedeRetries {
+		if opts.OnJoinURLChanged != nil {
+			opts.OnJoinURLChanged(plan.JoinURL)
+		}
+		opts.logf("tray attach superseded; following redirect (%d/%d)", redirects+1, maxSupersedeRetries)
+		return plan.JoinURL, true, nil
+	}
+	if plan.JoinURL == "" {
+		msg := plan.Error
+		if msg == "" {
+			msg = "replacement join URL missing"
+		}
+		return "", false, &AttachError{Code: AttachCodeSupersededMissingJoin, Message: msg}
+	}
+	return "", false, &AttachError{
+		Code:    AttachCodeSupersededChainExhausted,
+		Message: supersedeChainExhaustedMessage(),
 	}
 }
 

--- a/packages/slicc-cli/internal/tray/dial_test.go
+++ b/packages/slicc-cli/internal/tray/dial_test.go
@@ -1,0 +1,76 @@
+package tray
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ai-ecoverse/slicc-cli/internal/signaling"
+)
+
+func supersedeAttachResponse(next string) map[string]any {
+	return map[string]any{
+		"trayId": "t1", "role": "follower", "participantCount": 0,
+		"result": map[string]any{
+			"action": "fail", "code": "TRAY_SUPERSEDED",
+			"error": "moved", "joinUrl": next,
+		},
+	}
+}
+
+func TestHandleAttachFailFollowsSupersede(t *testing.T) {
+	var seen string
+	opts := Options{OnJoinURLChanged: func(joinURL string) { seen = joinURL }}
+	next, retry, err := handleAttachFail(&signaling.AttachPlan{
+		Code: "TRAY_SUPERSEDED", JoinURL: "https://hub.example/join/b",
+	}, 0, opts)
+	if err != nil || !retry || next != "https://hub.example/join/b" {
+		t.Fatalf("handleAttachFail() = (%q, %v, %v), want (b, true, nil)", next, retry, err)
+	}
+	if seen != "https://hub.example/join/b" {
+		t.Fatalf("OnJoinURLChanged = %q", seen)
+	}
+}
+
+func TestDialSupersedeMissingJoinURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"trayId": "t1", "role": "follower", "participantCount": 0,
+			"result": map[string]any{
+				"action": "fail", "code": "TRAY_SUPERSEDED", "error": "moved without replacement",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	_, err := Dial(context.Background(), srv.URL, Options{})
+	if !IsSupersedeMissingJoin(err) {
+		t.Fatalf("expected missing join error, got %v", err)
+	}
+}
+
+func TestDialSupersedeChainExhausted(t *testing.T) {
+	// Same host, hop query counts redirects; the hub still reports superseded
+	// once maxSupersedeRetries have been followed.
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hop := 0
+		if h := r.URL.Query().Get("hop"); h != "" {
+			_, _ = fmt.Sscanf(h, "%d", &hop)
+		}
+		next := srv.URL
+		if hop < maxSupersedeRetries+1 {
+			next = srv.URL + "?hop=" + fmt.Sprint(hop+1)
+		}
+		_ = json.NewEncoder(w).Encode(supersedeAttachResponse(next))
+	}))
+	defer srv.Close()
+
+	_, err := Dial(context.Background(), srv.URL, Options{})
+	if !IsSupersedeChainExhausted(err) {
+		t.Fatalf("expected chain exhausted, got %v", err)
+	}
+}

--- a/packages/slicc-cli/join_url_state.go
+++ b/packages/slicc-cli/join_url_state.go
@@ -1,6 +1,10 @@
 package main
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/ai-ecoverse/slicc-cli/internal/tray"
+)
 
 // joinURLState tracks the join URL across reconnect attempts. When the tray hub
 // returns TRAY_SUPERSEDED, tray.Dial follows the chain and notifies
@@ -9,10 +13,12 @@ import "strings"
 type joinURLState struct {
 	url      string
 	advanced bool
+	seen     map[string]struct{}
 }
 
 func newJoinURLState(initial string) *joinURLState {
-	return &joinURLState{url: initial}
+	seen := map[string]struct{}{initial: {}}
+	return &joinURLState{url: initial, seen: seen}
 }
 
 func (s *joinURLState) current() string { return s.url }
@@ -21,17 +27,28 @@ func (s *joinURLState) beginAttempt() { s.advanced = false }
 
 func (s *joinURLState) onTrayJoinURLChanged(next string) {
 	next = strings.TrimSpace(next)
-	if next != "" && next != s.url {
-		s.url = next
-		s.advanced = true
+	if next == "" || next == s.url {
+		return
 	}
+	if _, revisit := s.seen[next]; revisit {
+		// A→B→A cycles advance the current URL but are not progress toward a
+		// fresh tray — don't reset the give-up budget on them.
+		s.url = next
+		s.advanced = false
+		return
+	}
+	s.seen[next] = struct{}{}
+	s.url = next
+	s.advanced = true
 }
 
 // recordReconnectFailure returns the updated failure count and whether backoff
-// should reset to the base interval. URL advancement during a dial is progress,
-// not a dead end — don't burn the give-up budget.
-func (s *joinURLState) recordReconnectFailure(failures int) (int, bool) {
-	if s.advanced {
+// should reset to the base interval. Only a forward supersede hop that did not
+// end in a terminal attach error counts as progress.
+func (s *joinURLState) recordReconnectFailure(failures int, err error) (int, bool) {
+	if s.advanced &&
+		!tray.IsSupersedeChainExhausted(err) &&
+		!tray.IsSupersedeMissingJoin(err) {
 		return 0, true
 	}
 	return failures + 1, false

--- a/packages/slicc-cli/join_url_state.go
+++ b/packages/slicc-cli/join_url_state.go
@@ -1,0 +1,38 @@
+package main
+
+import "strings"
+
+// joinURLState tracks the join URL across reconnect attempts. When the tray hub
+// returns TRAY_SUPERSEDED, tray.Dial follows the chain and notifies
+// onTrayJoinURLChanged; follow/watch persist the replacement so later reconnects
+// do not walk the supersede chain from the original argv URL again.
+type joinURLState struct {
+	url      string
+	advanced bool
+}
+
+func newJoinURLState(initial string) *joinURLState {
+	return &joinURLState{url: initial}
+}
+
+func (s *joinURLState) current() string { return s.url }
+
+func (s *joinURLState) beginAttempt() { s.advanced = false }
+
+func (s *joinURLState) onTrayJoinURLChanged(next string) {
+	next = strings.TrimSpace(next)
+	if next != "" && next != s.url {
+		s.url = next
+		s.advanced = true
+	}
+}
+
+// recordReconnectFailure returns the updated failure count and whether backoff
+// should reset to the base interval. URL advancement during a dial is progress,
+// not a dead end — don't burn the give-up budget.
+func (s *joinURLState) recordReconnectFailure(failures int) (int, bool) {
+	if s.advanced {
+		return 0, true
+	}
+	return failures + 1, false
+}

--- a/packages/slicc-cli/join_url_state_test.go
+++ b/packages/slicc-cli/join_url_state_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/ai-ecoverse/slicc-cli/internal/tray"
+)
 
 func TestJoinURLStatePersistsReplacement(t *testing.T) {
 	s := newJoinURLState("https://hub.example/join/a")
@@ -22,17 +26,37 @@ func TestJoinURLStateIgnoresBlankAndDuplicate(t *testing.T) {
 	}
 }
 
+func TestJoinURLStateRevisitIsNotProgress(t *testing.T) {
+	s := newJoinURLState("https://hub.example/join/a")
+	s.onTrayJoinURLChanged("https://hub.example/join/b")
+	s.onTrayJoinURLChanged("https://hub.example/join/a")
+	if got := s.current(); got != "https://hub.example/join/a" {
+		t.Fatalf("current = %q, want a", got)
+	}
+	if s.advanced {
+		t.Fatal("revisiting a URL should not count as progress")
+	}
+}
+
 func TestJoinURLStateRecordReconnectFailure(t *testing.T) {
 	s := newJoinURLState("https://hub.example/join/a")
 	s.beginAttempt()
-	failures, reset := s.recordReconnectFailure(3)
+	failures, reset := s.recordReconnectFailure(3, nil)
 	if failures != 4 || reset {
 		t.Fatalf("stale URL: failures=%d reset=%v, want 4 false", failures, reset)
 	}
 
 	s.onTrayJoinURLChanged("https://hub.example/join/b")
-	failures, reset = s.recordReconnectFailure(3)
+	failures, reset = s.recordReconnectFailure(3, nil)
 	if failures != 0 || !reset {
-		t.Fatalf("advanced URL: failures=%d reset=%v, want 0 true", failures, reset)
+		t.Fatalf("forward hop: failures=%d reset=%v, want 0 true", failures, reset)
+	}
+
+	s.beginAttempt()
+	s.onTrayJoinURLChanged("https://hub.example/join/c")
+	chainErr := &tray.AttachError{Code: tray.AttachCodeSupersededChainExhausted}
+	failures, reset = s.recordReconnectFailure(5, chainErr)
+	if failures != 6 || reset {
+		t.Fatalf("chain exhausted: failures=%d reset=%v, want 6 false", failures, reset)
 	}
 }

--- a/packages/slicc-cli/join_url_state_test.go
+++ b/packages/slicc-cli/join_url_state_test.go
@@ -1,0 +1,38 @@
+package main
+
+import "testing"
+
+func TestJoinURLStatePersistsReplacement(t *testing.T) {
+	s := newJoinURLState("https://hub.example/join/a")
+	s.onTrayJoinURLChanged("https://hub.example/join/b")
+	if got := s.current(); got != "https://hub.example/join/b" {
+		t.Fatalf("current = %q, want b", got)
+	}
+	if !s.advanced {
+		t.Fatal("expected advanced after replacement")
+	}
+}
+
+func TestJoinURLStateIgnoresBlankAndDuplicate(t *testing.T) {
+	s := newJoinURLState("https://hub.example/join/a")
+	s.onTrayJoinURLChanged("   ")
+	s.onTrayJoinURLChanged("https://hub.example/join/a")
+	if s.advanced {
+		t.Fatal("blank/duplicate should not advance")
+	}
+}
+
+func TestJoinURLStateRecordReconnectFailure(t *testing.T) {
+	s := newJoinURLState("https://hub.example/join/a")
+	s.beginAttempt()
+	failures, reset := s.recordReconnectFailure(3)
+	if failures != 4 || reset {
+		t.Fatalf("stale URL: failures=%d reset=%v, want 4 false", failures, reset)
+	}
+
+	s.onTrayJoinURLChanged("https://hub.example/join/b")
+	failures, reset = s.recordReconnectFailure(3)
+	if failures != 0 || !reset {
+		t.Fatalf("advanced URL: failures=%d reset=%v, want 0 true", failures, reset)
+	}
+}


### PR DESCRIPTION
## Summary

- `follow` and `watch` now persist the replacement join URL when the tray hub returns `TRAY_SUPERSEDED`, matching iOS (`currentJoinUrl`) and the browser follower (`onJoinUrlChanged`).
- Reconnect failures no longer burn the 20-attempt give-up budget when the join URL advanced during a dial (partial or full supersede chain walk).
- Distinct attach errors for missing `joinUrl` (`TRAY_SUPERSEDED_MISSING_JOIN_URL`) vs. exhausted redirect chains (`TRAY_SUPERSEDED_CHAIN_EXHAUSTED`).

Fixes the shutdown seen after long `follow` sessions when the leader reconnects and supersedes its tray: the CLI was re-dialing the original argv URL on every reconnect, repeatedly hitting the 5-hop supersede limit and exiting with code 1.

## Test plan

- [x] `cd packages/slicc-cli && make check` (lint, vet, race tests, coverage floor)
- [ ] Manual: start `slicc <url> follow bash -c`, reload the leader tab, confirm follower reconnects without needing a fresh join URL


Made with [Cursor](https://cursor.com)