### PR TITLE
fix(webapp): let every agent spawn path use the owning cone's roots (#2271)

### DIFF
--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -169,8 +169,13 @@ per-scoop sudoers.
   resolved from the `cone` provenance the archive already records — and the
   budget pass bounds that same file.
 
-Known limit (unchanged by this phase): the workflow prelude's `agent()` still
-grants sub-agents a read-only `/workspace/` alongside the invoking cwd.
+Every `agent` spawn path now leaves the read-only roots to the command, which
+resolves them from the owning cone: the shell command's own default, the realm
+module (`sliccy:agent`) and the workflow prelude's `agent()` all omit
+`--read-only` unless the caller passes one. The flag is pure-replace, so a
+hardcoded `/workspace/` in a wrapper silently overrode the owner-relative
+roots — an extra cone's sub-agent read the primary cone's files and not its
+own.
 
 ### Per-cone sessions ([#2272](https://github.com/ai-ecoverse/slicc/issues/2272))
 

--- a/packages/webapp/src/kernel/realm/realm-agent-module.ts
+++ b/packages/webapp/src/kernel/realm/realm-agent-module.ts
@@ -18,7 +18,12 @@ interface SliccyAgentOptions {
   cwd?: string;
   /** Comma-separated allowed bash commands; defaults to `*`. */
   allowedCommands?: string;
-  /** Read-only VFS paths (array or CSV) forwarded as `--read-only`; defaults to `/workspace/`. */
+  /**
+   * Read-only VFS paths (array or CSV) forwarded as `--read-only`. Omitted,
+   * the flag is not sent at all, so the spawned scoop gets the `agent`
+   * command's owner-relative default — the OWNING cone's workspace plus the
+   * invoking cwd (#2271), not a hardcoded `/workspace/`.
+   */
   readOnly?: string | string[];
 }
 
@@ -50,23 +55,28 @@ function agentSchemaToB64(json: string): string {
 /**
  * Build the `agent` command argv. Mirrors the workflow-DSL `agent()` in
  * `workflow-prelude.ts`: flags (`--model` / `--thinking` / `--schema-b64`)
- * first, then the `--read-only <csv>` flag and the three positionals
+ * first, then an optional `--read-only <csv>` flag and the three positionals
  * `<cwd> <allowedCommands> <prompt>`.
+ *
+ * `--read-only` is emitted ONLY when the caller asked for it. The flag is
+ * pure-replace, so passing a default here would override the command's
+ * owner-relative roots and hand JS running under an extra cone the PRIMARY
+ * cone's files instead of its own (#2271).
  */
 function buildAgentArgv(prompt: string, opts: SliccyAgentOptions, realmCwd: string): string[] {
   const flags: string[] = [];
   if (opts.model) flags.push('--model', String(opts.model));
   if (opts.thinking) flags.push('--thinking', String(opts.thinking));
   if (opts.schema) flags.push('--schema-b64', agentSchemaToB64(JSON.stringify(opts.schema)));
-  const readOnly =
-    opts.readOnly === undefined
-      ? '/workspace/'
-      : Array.isArray(opts.readOnly)
-        ? opts.readOnly.join(',')
-        : String(opts.readOnly);
+  if (opts.readOnly !== undefined) {
+    flags.push(
+      '--read-only',
+      Array.isArray(opts.readOnly) ? opts.readOnly.join(',') : String(opts.readOnly)
+    );
+  }
   const cwd = opts.cwd !== undefined ? String(opts.cwd) : realmCwd || '.';
   const allowed = opts.allowedCommands !== undefined ? String(opts.allowedCommands) : '*';
-  return ['agent', ...flags, '--read-only', readOnly, cwd, allowed, String(prompt)];
+  return ['agent', ...flags, cwd, allowed, String(prompt)];
 }
 
 /**

--- a/packages/webapp/src/shell/supplemental-commands/workflow-prelude.ts
+++ b/packages/webapp/src/shell/supplemental-commands/workflow-prelude.ts
@@ -70,7 +70,10 @@ async function agent(prompt, opts) {
     if (opts.model) flags.push('--model', String(opts.model));
     if (opts.thinking) flags.push('--thinking', String(opts.thinking));
     if (opts.schema) flags.push('--schema-b64', __b64(JSON.stringify(opts.schema)));
-    const argv = ['agent'].concat(flags, ['--read-only', '/workspace/', __agentCwd, '*', String(prompt)]);
+    // No --read-only: the flag is pure-replace, so naming '/workspace/' here
+    // would override the command's owner-relative default and hand a workflow
+    // agent running under an extra cone the primary cone's files (#2271).
+    const argv = ['agent'].concat(flags, [__agentCwd, '*', String(prompt)]);
     const r = await __execSpawn(argv);
     if (!r || r.exitCode !== 0) {
       // Surface the subagent's real failure (bad model, 5xx, scoop error) before

--- a/packages/webapp/tests/kernel/realm/sliccy-modules.test.ts
+++ b/packages/webapp/tests/kernel/realm/sliccy-modules.test.ts
@@ -483,16 +483,33 @@ describe("require('sliccy:agent') — callable + non-throwing .spawn", () => {
     const out = await runCode(code, ctx);
     expect(out.exitCode).toBe(0);
     // realm ctx.cwd is '/workspace', so the default positional cwd is '/workspace'.
+    // No `--read-only`: the flag is pure-replace, so emitting a default here
+    // would override the command's owner-relative roots and give JS running
+    // under an extra cone the PRIMARY cone's files (#2271).
+    expect(argvOf(calls[0])).toEqual(['agent', '/workspace', '*', 'hi']);
+    // finalText only strips trailing newlines, not surrounding spaces.
+    expect(out.stdout.trim()).toBe(JSON.stringify('  the answer  '));
+  });
+
+  it('forwards --read-only only when the caller asked for it (#2271)', async () => {
+    const calls: ExecCall[] = [];
+    const ctx = makeAgentCtx({ stdout: 'ok' }, calls);
+    const code = `
+      const agent = require('sliccy:agent');
+      await agent('a', { readOnly: ['/data/', '/etc/'] });
+      await agent('b', { readOnly: '/data/' });
+    `;
+    const out = await runCode(code, ctx);
+    expect(out.exitCode).toBe(0);
     expect(argvOf(calls[0])).toEqual([
       'agent',
       '--read-only',
-      '/workspace/',
+      '/data/,/etc/',
       '/workspace',
       '*',
-      'hi',
+      'a',
     ]);
-    // finalText only strips trailing newlines, not surrounding spaces.
-    expect(out.stdout.trim()).toBe(JSON.stringify('  the answer  '));
+    expect(argvOf(calls[1])).toEqual(['agent', '--read-only', '/data/', '/workspace', '*', 'b']);
   });
 
   it('--model / --thinking / readOnly[] / custom cwd + allowedCommands map to argv', async () => {

--- a/packages/webapp/tests/shell/supplemental-commands/workflow-prelude.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/workflow-prelude.test.ts
@@ -58,7 +58,7 @@ const WF = {
 };
 
 describe('workflow-prelude', () => {
-  it('agent() spawns via exec.spawn with --read-only + agentCwd and trims text', async () => {
+  it('agent() spawns via exec.spawn with agentCwd and trims text', async () => {
     const calls: string[][] = [];
     const exec = {
       spawn: async (a: string[]) => {
@@ -68,7 +68,9 @@ describe('workflow-prelude', () => {
     };
     await run('globalThis.__t = await agent("q");', exec, WF);
     expect((globalThis as any).__t).toBe('answer');
-    expect(calls[0]).toEqual(['agent', '--read-only', '/workspace/', '/s/scratch/', '*', 'q']);
+    // No `--read-only` — pure-replace, so a hardcoded default would override
+    // the owner-relative roots and reach into the primary cone (#2271).
+    expect(calls[0]).toEqual(['agent', '/s/scratch/', '*', 'q']);
   });
   it('agent({schema}) adds --schema-b64 and JSON-parses', async () => {
     const calls: string[][] = [];


### PR DESCRIPTION
Follow-up to #2286 (part of #1666). Addresses the Codex P2 that landed on #2286 after it was already on the merge queue — https://github.com/ai-ecoverse/slicc/pull/2286#discussion_r3836578139.

## Summary

`--read-only` on the `agent` command is **pure-replace**: passing it drops the owner-relative default roots *and* the implicit invoking-cwd add. #2286 made those defaults follow the owning cone, but two JS-facing wrappers always sent the flag with a hardcoded `/workspace/`, so they silently overrode it.

| Caller | Before | After |
| --- | --- | --- |
| `sliccy:agent` (`kernel/realm/realm-agent-module.ts`) | substituted `--read-only /workspace/` when `opts.readOnly` was absent | omits the flag unless the caller passes one |
| workflow prelude `agent()` (`shell/supplemental-commands/workflow-prelude.ts`) | hardcoded `--read-only /workspace/` unconditionally | omits it |
| `ui/sprinkle-bridge.ts` | already only sent the flag when the caller set one | unchanged |

## Why

Under an extra cone, JS calling `sliccy:agent()` — or any workflow `agent()` — spawned a sub-agent that read the **primary** cone's files and could not read its own owning cone's workspace. That is the exact inversion #2271 is for, and it is invisible to the caller: the sub-agent simply sees the wrong tree.

Codex flagged the realm module; the prelude is the same defect at a second call site. #2286's `docs/work-unit.md` recorded it as a known limit ("the workflow prelude's `agent()` still grants sub-agents a read-only `/workspace/`"), so that line is replaced here by the rule that now holds on every spawn path.

## Notes

- A caller-supplied `readOnly` still replaces the roots verbatim — that is the documented pure-replace contract and is unchanged.
- Dropping the flag also restores the implicit invoking-cwd read-only add for these two paths, which the hardcoded default had been suppressing. That is what the command's help has always promised.

## Test plan

- [x] `npm run verify` (7/7) · `npm run lint` · `npm run typecheck` (9 projects)
- [x] `npm run test` — 16353 passing, 0 failing
- [x] `npm run test:coverage:webapp` — exit 0 (81.41 / 72.63 / 81.42 / 83.45 vs floors 79 / 71 / 80 / 82)
- [x] `npm run build -w @slicc/webapp` and `-w @slicc/chrome-extension` · `npm run bundle-size` exit 0
- [x] `check-touched-exemptions` — 5 changed files, 0 on any debt list
- [x] Argv assertions updated in `tests/kernel/realm/sliccy-modules.test.ts` and `tests/shell/supplemental-commands/workflow-prelude.test.ts`; new test pinning that a supplied `readOnly` (array and CSV) is still forwarded
- [ ] No UI change — no screencast

## Documentation

- [x] `docs/work-unit.md` — the known-limit line is replaced by the every-spawn-path rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)
