### PR TITLE
fix(ui): unify tool cluster progress to dots-only, collapsed by default

### DIFF
--- a/packages/ios-app/SliccFollower/Views/MessageBubble.swift
+++ b/packages/ios-app/SliccFollower/Views/MessageBubble.swift
@@ -307,14 +307,12 @@ struct MessageBubble: View {
     }
 
     /// Collapsed "Working" cluster — mirrors the webapp's
-    /// `.tool-call-cluster` (`packages/webapp/src/ui/chat-panel.ts` →
-    /// `createToolClusterEl`). Three or more consecutive tool calls
-    /// collapse behind a single disclosure so they don't push assistant
-    /// content out of view; one small dot per inner call shows the run's
-    /// progression at a glance, and the comma-joined preview hints at
-    /// what's running.
+    /// `<slicc-tool-cluster>`. Three or more consecutive tool calls
+    /// collapse behind a single disclosure; the summary head shows only
+    /// the three-dot progress badge while the batch runs.
     @ViewBuilder
     private func workingClusterRow(_ toolCalls: [ToolCall]) -> some View {
+        let aggregate = aggregateToolProgress(calls: toolCalls, progress: toolProgress)
         DisclosureGroup {
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(toolCalls) { tc in
@@ -331,8 +329,7 @@ struct MessageBubble: View {
         } label: {
             HStack(spacing: 6) {
                 ToolProgressIcon(
-                    systemName: "gearshape.fill", size: 11,
-                    unit: aggregateToolProgress(calls: toolCalls, progress: toolProgress),
+                    systemName: "gearshape.fill", size: 11, unit: nil,
                     base: palette.ink.opacity(0.55), accent: palette.accent)
                 Text("Working")
                     .font(.system(.caption, design: .monospaced))
@@ -343,7 +340,16 @@ struct MessageBubble: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                 Spacer(minLength: 4)
-                clusterDots(for: toolCalls)
+                if let aggregate {
+                    Text(toolProgressCaption(aggregate))
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundStyle(palette.ink.opacity(0.45))
+                        .lineLimit(1)
+                        .accessibilityHidden(true)
+                    ToolProgressDots(unit: aggregate, color: palette.ink.opacity(0.7))
+                } else {
+                    clusterDots(for: toolCalls)
+                }
             }
         }
         .tint(.white.opacity(0.4))

--- a/packages/ios-app/SliccFollower/Views/ToolProgressChrome.swift
+++ b/packages/ios-app/SliccFollower/Views/ToolProgressChrome.swift
@@ -14,6 +14,8 @@ import SwiftUI
 //  3. an EXPANDED row body wears a thin top bar — row-only, never on a cluster
 //     head, because a bar over a summary of N calls reads as noise.
 //
+// Cluster summary heads wear cue (2) only — no icon fill.
+//
 // A phone adds one thing the web leaves to the hover title: the percentage and
 // ETA are always visible, since there is no cursor to hover with.
 

--- a/packages/ios-app/SliccFollower/Views/ToolProgressChrome.swift
+++ b/packages/ios-app/SliccFollower/Views/ToolProgressChrome.swift
@@ -188,7 +188,9 @@ struct ToolProgressDots: View {
         Circle()
             .fill(color)
             .frame(width: 5, height: 5)
-            .opacity(isDone ? 1 : 0.25)
+            // Active dots start at full opacity so the blink animates 1→0.25,
+            // not 0.25→0.0625 when SwiftUI composes nested opacity modifiers.
+            .opacity(isDone || isActive ? 1 : 0.25)
             .modifier(ToolProgressBlink(active: isActive, delay: Double(index) * 0.2))
     }
 }

--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -373,12 +373,12 @@ const WCMSG_CSS = [
   // 2. the result badge becomes three dots, one per third — done dots solid,
   //    the active one blinking, the rest faded;
   // 3. an open dark terminal body wears a 3px top-border bar.
-  'slicc-action-row[data-progress] .slicc-act__ic,slicc-tool-cluster[data-progress] .slicc-cluster__ic{',
+  // Clusters wear cue (2) only — no icon fill or body bar on the summary head.
+  'slicc-action-row[data-progress] .slicc-act__ic{',
   'background:linear-gradient(to top,',
   'var(--slicc-progress-ink,var(--accent)) calc(var(--slicc-progress,0)*100%),',
   'color-mix(in srgb,var(--slicc-progress-ink,var(--accent)) 30%,transparent) 0);}',
-  'slicc-action-row[data-progress="indeterminate"] .slicc-act__ic,',
-  'slicc-tool-cluster[data-progress="indeterminate"] .slicc-cluster__ic{',
+  'slicc-action-row[data-progress="indeterminate"] .slicc-act__ic{',
   'animation:wcmsg-progress-breathe 1.6s ease-in-out infinite;}',
   '@keyframes wcmsg-progress-breathe{0%,100%{opacity:.45}50%{opacity:1}}',
   '.wcmsg-dots{margin-left:auto;display:inline-flex;gap:4px;align-items:center;',
@@ -394,9 +394,8 @@ const WCMSG_CSS = [
   // The cluster keeps its "N steps" count; the dots sit just before it.
   'slicc-tool-cluster[data-progress] .wcmsg-dots{margin-left:auto;}',
   'slicc-tool-cluster[data-progress] .slicc-cluster__count{margin-left:8px;}',
-  // The top-border bar is deliberately ROW-ONLY. A cluster is a summary of
-  // many calls; a bar there reads as noise, so it advances through the icon
-  // fill and the dots alone as calls complete.
+  // The top-border bar is deliberately ROW-ONLY. A cluster head advances
+  // through the three-dot badge alone as calls complete.
   'slicc-action-row[data-progress] .slicc-act__body{position:relative;overflow:hidden;}',
   'slicc-action-row[data-progress] .slicc-act__body::before{content:"";position:absolute;',
   'top:0;left:0;height:3px;width:calc(var(--slicc-progress,0)*100%);',
@@ -406,7 +405,7 @@ const WCMSG_CSS = [
   'animation:wcmsg-progress-slide 1.2s ease-in-out infinite;}',
   '@keyframes wcmsg-progress-slide{0%{transform:translateX(-100%)}100%{transform:translateX(340%)}}',
   '@media (prefers-reduced-motion:reduce){.wcmsg-dots__dot,',
-  'slicc-action-row[data-progress] .slicc-act__ic,slicc-tool-cluster[data-progress] .slicc-cluster__ic,',
+  'slicc-action-row[data-progress] .slicc-act__ic,',
   'slicc-action-row[data-progress] .slicc-act__body::before{animation:none!important;}}',
 ].join('');
 
@@ -465,25 +464,28 @@ interface ProgressChrome {
   chev: string;
   /** Selector for the element the dots sit before (chevron, or a count badge). */
   dotsBefore: string;
+  /** When false, only the three-dot badge is painted (cluster summary head). */
+  iconFill: boolean;
 }
 const ROW_CHROME: ProgressChrome = {
   head: 'slicc-act__head',
   chev: 'slicc-act__chev',
   dotsBefore: '.slicc-act__chev',
+  iconFill: true,
 };
 const CLUSTER_CHROME: ProgressChrome = {
   head: 'slicc-cluster__head',
   chev: 'slicc-cluster__chev',
   // Keep the "N steps" count; the dots slot in just before it.
   dotsBefore: '.slicc-cluster__count',
+  iconFill: false,
 };
 
 /**
  * Apply (or clear, with `null`) the progress treatment to a tool row OR a
- * tool cluster: the icon fill, the three-dot badge and the body top bar all
- * read the same `--slicc-progress` custom property + `data-progress` state,
- * so this only sets those and upserts the dots. Idempotent; safe after a
- * rebuild. `chrome` selects which container's class names to target.
+ * tool cluster. Rows get the icon fill, three-dot badge and body top bar;
+ * clusters get the three-dot badge only. Idempotent; safe after a rebuild.
+ * `chrome` selects which container's class names to target.
  */
 function applyProgressTreatment(
   host: HTMLElement,
@@ -503,7 +505,11 @@ function applyProgressTreatment(
   const determinate = typeof unit.fraction === 'number' && Number.isFinite(unit.fraction);
   const fraction = determinate ? Math.min(1, Math.max(0, unit.fraction as number)) : undefined;
   host.setAttribute(PROGRESS_ATTR, determinate ? 'determinate' : 'indeterminate');
-  host.style.setProperty('--slicc-progress', fraction === undefined ? '0' : String(fraction));
+  if (chrome.iconFill) {
+    host.style.setProperty('--slicc-progress', fraction === undefined ? '0' : String(fraction));
+  } else {
+    host.style.removeProperty('--slicc-progress');
+  }
   host.setAttribute('title', progressTitle(unit, fraction));
   if (!head) return;
   let dots = existing;
@@ -940,10 +946,8 @@ export function unwrapToolClusters(container: HTMLElement, openClusterAnchors: S
   }
 }
 
-/** Record the first row's msg id as a sticky open anchor — but only if the
- *  cluster was opened by the user, not auto-opened by the streaming
- *  single-message reflow path (which would otherwise re-open forever after
- *  the user collapsed it mid-stream). */
+/** Record the first row's msg id as a sticky open anchor when the user
+ *  expanded the cluster before the next reflow unwraps it. */
 function captureUserOpenAnchor(
   cluster: HTMLElement,
   rows: readonly HTMLElement[],
@@ -951,13 +955,7 @@ function captureUserOpenAnchor(
 ): void {
   if (!cluster.hasAttribute('open')) return;
   const anchorId = rows[0]?.dataset.msgId;
-  if (!anchorId) return;
-  const allSameMsg = rows.length > 0 && rows.every((r) => r.dataset.msgId === anchorId);
-  const owningBubble = cluster.parentElement?.querySelector(
-    `slicc-agent-message[data-msg-id="${anchorId}"]`
-  );
-  const autoOpen = allSameMsg && owningBubble?.hasAttribute('streaming') === true;
-  if (!autoOpen) openClusterAnchors.add(anchorId);
+  if (anchorId) openClusterAnchors.add(anchorId);
 }
 
 /** Restore an unwrapped row next to its owning `slicc-agent-message` (or
@@ -1041,16 +1039,6 @@ function collectRunsInChain(chain: readonly HTMLElement[]): HTMLElement[][] {
   return runs;
 }
 
-/** True iff `run` is one assistant message's tool calls AND that message
- *  is currently streaming (mid-turn). */
-function isSingleMessageStreaming(parent: ParentNode, run: readonly HTMLElement[]): boolean {
-  const anchorMsgId = run[0]?.dataset.msgId;
-  if (!anchorMsgId) return false;
-  if (!run.every((r) => r.dataset.msgId === anchorMsgId)) return false;
-  const bubble = parent.querySelector(`slicc-agent-message[data-msg-id="${anchorMsgId}"]`);
-  return bubble?.hasAttribute('streaming') === true;
-}
-
 /** Resolve a run's rows back to their owning `ToolCall`s via the
  *  optional lookup; returns `undefined` if any row can't be resolved. */
 function resolveRunToolCalls(
@@ -1087,12 +1075,8 @@ function wrapRunIntoCluster(
   let anchor: Node | null = firstRow.nextSibling;
   while (anchor && runSet.has(anchor)) anchor = anchor.nextSibling;
   const anchorMsgId = firstRow.dataset.msgId;
-  // Anchor preservation keeps a user-expanded cross-message cluster
-  // open across rebuilds. Single-message streaming runs auto-open so
-  // live tool progress is visible (matches pre-merge per-message
-  // behavior). Cross-message runs never auto-open.
-  const userOpen = Boolean(anchorMsgId && opts.openClusterAnchors.has(anchorMsgId));
-  const open = userOpen || isSingleMessageStreaming(parent, run);
+  // Clusters stay collapsed unless the user expanded them before reflow.
+  const open = Boolean(anchorMsgId && opts.openClusterAnchors.has(anchorMsgId));
   const toolCalls = opts.toolCallLookup ? resolveRunToolCalls(run, opts.toolCallLookup) : undefined;
   const cluster = buildClusterFromElements(run, { open, toolCalls });
   parent.insertBefore(cluster, anchor);

--- a/packages/webapp/tests/ui/wc/wc-chat-controller-progress.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-chat-controller-progress.test.ts
@@ -140,7 +140,7 @@ describe('WcChatController tool_progress handling', () => {
     expect(ring.at(-1)).toBeCloseTo(0.4);
   });
 
-  it('fills the cluster head as calls complete (k of N), with no progress bar', () => {
+  it('fills the cluster head with dots as calls complete (k of N), with no icon fill', () => {
     // beforeEach already started one bash call; two more collapse into a cluster.
     for (const id of ['c2', 'c3']) {
       agent.emit({
@@ -165,12 +165,12 @@ describe('WcChatController tool_progress handling', () => {
     const head = cluster()?.querySelector('.slicc-cluster__head');
     expect(cluster()?.getAttribute('data-progress')).toBe('determinate');
     expect(head?.querySelectorAll('.wcmsg-dots__dot')).toHaveLength(3);
-    expect(Number(cluster()?.style.getPropertyValue('--slicc-progress'))).toBeCloseTo(0.2);
+    expect(cluster()?.style.getPropertyValue('--slicc-progress')).toBe('');
     expect(cluster()?.getAttribute('title')).toContain('0 of 3 done');
     // The cluster keeps its "3 steps" count alongside the dots.
     expect(cluster()?.querySelector('.slicc-cluster__count')?.textContent).toContain('3');
 
-    // A completed call advances the fill by a whole step.
+    // A completed call advances the dots by a whole step.
     agent.emit({
       type: 'tool_result',
       messageId: 'm1',
@@ -178,12 +178,17 @@ describe('WcChatController tool_progress handling', () => {
       result: 'ok',
       toolCallId: 'c2',
     });
-    expect(Number(cluster()?.style.getPropertyValue('--slicc-progress'))).toBeCloseTo(1 / 3);
+    expect(cluster()?.style.getPropertyValue('--slicc-progress')).toBe('');
     expect(cluster()?.getAttribute('title')).toContain('1 of 3 done');
+    const activeAfter = [...(head?.querySelectorAll('.wcmsg-dots__dot') ?? [])].findIndex((d) =>
+      d.classList.contains('is-active')
+    );
+    expect(activeAfter).toBe(0);
 
-    // A cluster never wears the row's top-border bar — icon + dots only.
+    // A cluster never wears the row's top-border bar or icon fill — dots only.
     const css = document.getElementById('slicc-wcmsg-style')?.textContent ?? '';
     expect(css).toContain('slicc-action-row[data-progress] .slicc-act__body::before');
+    expect(css).not.toContain('slicc-tool-cluster[data-progress] .slicc-cluster__ic');
     expect(css).not.toContain('slicc-tool-cluster[data-progress] .slicc-cluster__body::before');
 
     // Once every call has settled the treatment clears entirely.

--- a/packages/webapp/tests/ui/wc/wc-message-view.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-message-view.test.ts
@@ -683,7 +683,7 @@ describe('tool presentation', () => {
     (cluster as HTMLElement).remove();
   });
 
-  it('clusters 3+ tool calls (open while streaming, collapsed when settled)', () => {
+  it('clusters 3+ tool calls collapsed by default (streaming or settled)', () => {
     const stamp = Date.now();
     const calls = [1, 2, 3].map((i) => ({
       id: `tcollapse-${stamp}-${i}`,
@@ -712,7 +712,7 @@ describe('tool presentation', () => {
     const streaming = { ...settled, id: 'm-s', isStreaming: true };
     const liveChildren = buildThreadChildren([streaming]);
     const live = liveChildren.find((c) => c.tagName.toLowerCase() === 'slicc-tool-cluster');
-    expect(live?.hasAttribute('open')).toBe(true);
+    expect(live?.hasAttribute('open')).toBe(false);
 
     // Two calls stay flat — no cluster wrapper.
     const flat: ChatMessage = { ...settled, id: 'm-f', toolCalls: calls.slice(0, 2) };


### PR DESCRIPTION
## Summary

Tool cluster summary heads now show only the three-dot progress badge while a batch runs, instead of also filling the cluster icon. Clusters stay collapsed by default on both the webapp and iOS follower, and only reopen when the user expanded them before a reflow.

## Why

Two progress cues on the cluster head (icon fill plus dots) were redundant and noisy. Auto-opening clusters during streaming also pushed assistant content out of view before the user asked to inspect the steps.

## Approach / Implementation notes

- **Webapp** (`wc-message-view.ts`): `CLUSTER_CHROME` sets `iconFill: false`, so clusters get the dot badge and title only; removed streaming auto-open in `wrapRunIntoCluster`.
- **iOS** (`MessageBubble.swift`): cluster header uses a static gear icon plus `ToolProgressDots` when `aggregateToolProgress` is active; per-call status dots remain when the batch is idle.
- Individual tool rows are unchanged (icon fill, dots, expanded body bar).

## Cross-cutting impact

- **Floats exercised**: webapp WC chat UI, iOS follower transcript
- **Other callers**: cluster open-state preservation via `openClusterAnchors` is simplified now that streaming auto-open is gone

## Test plan

- [x] `npx vitest run --config vitest.config.ts --project webapp packages/webapp/tests/ui/wc/wc-chat-controller-progress.test.ts packages/webapp/tests/ui/wc/wc-message-view.test.ts packages/webapp/tests/ui/wc/wc-chat-controller-cluster.test.ts` — 83 passing
- [ ] `npm run typecheck`
- [ ] `npm run build -w @slicc/webapp`
- [ ] Manual smoke: run a 3+ tool-call turn and confirm the cluster stays collapsed with dot-only progress until expanded

## Documentation

- [x] No documentation changes needed

## Risk & rollback

Low blast radius — presentation-only change to cluster chrome and default disclosure. Revert cleanly with no persisted-state migration.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Cross-float parity checked (webapp + iOS follower)