### PR TITLE
fix(webapp): truncate handoff lick labels that break chat layout

### DIFF
--- a/packages/webapp/src/ui/wc/wc-message-view.ts
+++ b/packages/webapp/src/ui/wc/wc-message-view.ts
@@ -122,6 +122,45 @@ function firstLine(text: string): string {
   return line.length > 80 ? `${line.slice(0, 79)}…` : line;
 }
 
+function isProbablyUrl(text: string): boolean {
+  return /^https?:\/\//i.test(text);
+}
+
+/** Handoff/upskill navigate licks carry the verb in the JSON body, not the header. */
+function navigateVerbFromLickContent(content: string): string | null {
+  const match = /"verb"\s*:\s*"([^"\\]+)"/.exec(content);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Human-readable pill label for a lick card header. Navigate/discovery licks put
+ * the full target URL in the `[Channel Event: …]` header — using that verbatim
+ * as `event-label` blows out the collapsed card; prefer verb/hostname/ellipsis.
+ */
+export function lickEventLabel(
+  content: string,
+  channel: string | null | undefined,
+  header: RegExpExecArray | null,
+  scoopName: string | null
+): string {
+  if (scoopName) return scoopName;
+  const raw = header?.[2]?.trim();
+  if (!raw) return channel ?? 'event';
+  if (channel === 'navigate') {
+    const verb = navigateVerbFromLickContent(content);
+    if (verb) return verb;
+    if (isProbablyUrl(raw)) return 'navigate';
+  }
+  if (channel === 'discovery' && isProbablyUrl(raw)) {
+    try {
+      return new URL(raw).hostname;
+    } catch {
+      return 'discovery';
+    }
+  }
+  return firstLine(raw);
+}
+
 function inputField(input: unknown, field: string): string {
   if (typeof input !== 'object' || input == null) return '';
   // biome-ignore lint/plugin: same any-tool input bag, read by caller-supplied field name.
@@ -1133,7 +1172,7 @@ function lickCardEl(message: ChatMessage): HTMLElement {
   const scoopName = scoopMarker ? scoopTagName(scoopMarker[1]) : null;
   const card = el('slicc-lick-card', {
     kind: message.channel ?? 'webhook',
-    'event-label': scoopName ?? header?.[2] ?? message.channel ?? 'event',
+    'event-label': lickEventLabel(message.content, message.channel, header, scoopName),
     // Licks are ambient noise until the user opts in: collapsed by default,
     // the header click expands.
     collapsible: '',

--- a/packages/webapp/tests/ui/wc/wc-message-view.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-message-view.test.ts
@@ -25,6 +25,7 @@ import {
   isAuthExpiredError,
   isInvalidModelError,
   isNoApiKeyError,
+  lickEventLabel,
   messageEls,
   NO_API_KEY_ERROR_PREFIX,
   summarizeToolInput,
@@ -860,5 +861,47 @@ describe('render-time lick classification + scoop-identity tags', () => {
     expect(run).toHaveLength(1);
     expect(run[0].lickCount).toBe(3);
     expect(run[0].channel).toBe('scoop-idle');
+  });
+});
+
+describe('navigate / discovery lick event labels', () => {
+  const longHandoffUrl =
+    'https://www.sliccy.ai/handoff?handoff=' + 'move-this-to-slicc-and-'.repeat(8);
+
+  it('uses the handoff verb for navigate licks instead of the full URL', () => {
+    const content =
+      `[Navigate Event: ${longHandoffUrl}]\n\`\`\`json\n` +
+      JSON.stringify({ url: longHandoffUrl, verb: 'handoff', target: longHandoffUrl }, null, 2) +
+      '\n```';
+    const [card] = messageEls({
+      id: 'nav-handoff',
+      role: 'user',
+      content,
+      timestamp: 1,
+      source: 'lick',
+      channel: 'navigate',
+    });
+    expect(card.getAttribute('event-label')).toBe('handoff');
+    expect((card.getAttribute('event-label') ?? '').length).toBeLessThan(20);
+  });
+
+  it('falls back to navigate when the header is a URL without a verb', () => {
+    const content = `[Navigate Event: ${longHandoffUrl}]`;
+    const header = /^\[([^:\]]+):\s*([^\]]+)\]\s*\n?/.exec(content);
+    expect(lickEventLabel(content, 'navigate', header, null)).toBe('navigate');
+  });
+
+  it('uses the hostname for discovery licks', () => {
+    const url = 'https://docs.example.com/.well-known/ai-catalog.json';
+    const content = `[Discovery Event: ${url}]\n\`\`\`json\n{"kind":"ai-catalog"}\n\`\`\``;
+    const [card] = messageEls({
+      id: 'disc',
+      role: 'user',
+      content,
+      timestamp: 1,
+      source: 'lick',
+      channel: 'discovery',
+    });
+    expect(card.getAttribute('event-label')).toBe('docs.example.com');
   });
 });

--- a/packages/webcomponents/src/chat/slicc-lick-card.ts
+++ b/packages/webcomponents/src/chat/slicc-lick-card.ts
@@ -116,6 +116,8 @@ const STYLE = `
   /* Shrink to content and cap the width so the right-aligned card never spans
      the full column; the body wraps within this cap. */
   max-width:85%;
+  min-width:0;
+  overflow:hidden;
   border:1px solid var(--lick-border);
   background:var(--lick-bg);
   border-radius:12px;
@@ -137,6 +139,7 @@ const STYLE = `
 
 .lh{
   display:flex;align-items:center;gap:7px;
+  min-width:0;
   font-family:var(--ui);font-size:10.5px;color:var(--lick-head);
   margin-bottom:4px;
 }
@@ -151,9 +154,15 @@ const STYLE = `
 :host([state="dismissed"]) .status{color:var(--lick-dismiss);}
 /* The clickable affordance only exists while collapsible. */
 :host([collapsible]) .lh{cursor:pointer;user-select:none;}
+.lh .kind{
+  min-width:0;flex:1 1 auto;
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+}
 .lk{
   margin-left:auto;border-radius:26px;background:var(--lick-pill,var(--amber));
   color:var(--lick-pill-ink,color-mix(in srgb,var(--amber) 40%,#000));font-size:9px;font-weight:700;padding:1px 7px;
+  flex:0 1 auto;min-width:0;max-width:min(50%,14rem);
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
 }
 
 .lb{

--- a/packages/webcomponents/tests/chat/slicc-lick-card.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-lick-card.test.ts
@@ -294,6 +294,29 @@ describe('slicc-lick-card', () => {
       expect((el.shadowRoot?.querySelector('.lk') as HTMLElement).textContent).toBe('event');
     });
 
+    it('ellipsizes a long event-label pill instead of bursting the card', () => {
+      const wrap = document.createElement('div');
+      wrap.style.width = '400px';
+      document.body.appendChild(wrap);
+      const el = document.createElement('slicc-lick-card') as SliccLickCard;
+      el.kind = 'navigate';
+      el.eventLabel = `https://www.sliccy.ai/handoff?handoff=${'x'.repeat(200)}`;
+      el.collapsible = true;
+      el.collapsed = true;
+      wrap.appendChild(el);
+      const pill = el.shadowRoot?.querySelector('.lk') as HTMLElement;
+      const cardEl = card(el);
+      expect(getComputedStyle(pill).textOverflow).toBe('ellipsis');
+      expect(getComputedStyle(pill).overflow).toBe('hidden');
+      expect(getComputedStyle(pill).whiteSpace).toBe('nowrap');
+      // Layout containment: the card must stay inside the chat column, not
+      // grow to the full URL width (regression: handoff licks blew the thread).
+      expect(cardEl.scrollWidth).toBeLessThanOrEqual(cardEl.clientWidth + 1);
+      expect(cardEl.getBoundingClientRect().width).toBeLessThanOrEqual(400);
+      el.remove();
+      wrap.remove();
+    });
+
     it('reflects body text (escaped) into the .lb body', () => {
       const el = mount((e) => {
         e.body = 'plain body';


### PR DESCRIPTION
## Summary

Handoff (navigate) licks no longer put the full handoff URL in the collapsed card’s amber pill, which was blowing out the chat column. Labels now show short text (`handoff`, hostname, or ellipsis), and the pill CSS clips overflow as a backstop.

## Why

**Repro**
1. Receive a navigate/handoff lick whose header is `[Navigate Event: https://www.sliccy.ai/handoff?handoff=<very long instruction>]`
2. Observe the collapsed lick card in chat

**Expected:** Card stays within the chat column (≤85% width).

**Actual:** The event pill renders the entire URL (~1000px wide), scrolling the thread horizontally.

Confirmed via CDP on port 9222: injected `slicc-lick-card` with a 251-char `event-label` produced `cardScrollWidth: 1067` inside a 400px container.

## Approach / Implementation notes

- **`wc-message-view.ts`**: new `lickEventLabel()` — navigate licks use JSON `verb` (`handoff`/`upskill`); discovery licks use hostname; other channels keep `firstLine()` truncation.
- **`slicc-lick-card.ts`**: defensive CSS on `.lk` / `.lh` (ellipsis, `min-width: 0`, card `overflow: hidden`) so any long label cannot burst the column.

## Cross-cutting impact

- **Floats exercised**: hosted leader + extension (shared webcomponents + webapp message view). No kernel/scoop changes.
- **Persisted state**: none — render-time only.

## Test plan

- [x] `npm run verify`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npx vitest run --project webapp tests/ui/wc/wc-message-view.test.ts` — 59 passing
- [x] `npm run test -w @slicc/webcomponents -- tests/chat/slicc-lick-card.test.ts` — 48 passing
- [x] CDP repro on :9222 — long URL pill no longer expands card past container

## Documentation

- [x] No documentation changes needed

## Risk & rollback

Low blast radius (UI label + CSS only). Revert cleanly with no migration.
