### PR TITLE
fix(release): raise macOS publish job timeout to 60 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,9 @@ jobs:
     # apps must be built with the iOS 26 SDK or later." macos-latest
     # still resolves to macos-15 (Xcode 16.x) as of this commit.
     runs-on: macos-26
-    timeout-minutes: 30
+    # File Provider appex packaging pushed publish past 30m (runs 32626876686
+    # onward); v6.84.1 finished in ~24m before that landed.
+    timeout-minutes: 60
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Summary

Raise the macOS `release` job `timeout-minutes` from 30 to 60 so semantic-release publish can finish worker deploy plus native packaging (including the File Provider appex) without being cancelled mid-run.

## Why

Release runs since the File Provider merge (v6.85.0) hit the 30-minute job ceiling during publish and were cancelled before GitHub Release assets uploaded. Tags `v6.85.0`–`v6.87.0` exist on `main`, but the GitHub Releases page still shows v6.84.1 as latest. The last successful release job (v6.84.1, run 32617479846) finished in ~24 minutes.

## Approach / Implementation notes

- Single workflow change in `.github/workflows/release.yml` with an inline comment citing the regression window.

## Cross-cutting impact

- **Floats exercised**: CI release pipeline only (worker deploy + Sliccstart native publish).
- No runtime, shell, or extension behavior changes.

## Test plan

- [ ] Merge and re-run the Release workflow via `workflow_dispatch` on `main`, or wait for the next merge-triggered release.
- [ ] Confirm the `release` job completes within 60 minutes and publishes GitHub Release assets.
- [x] N/A — workflow-only change; no unit tests apply.

**Pre-existing failures** (verified against `main`, unrelated to this PR):

N/A — CI-only workflow edit.

## Documentation

- [x] No documentation changes needed

## Risk & rollback

- Blast radius: release job may run longer on failure instead of failing fast at 30m; acceptable tradeoff to allow successful publishes.
- Rollback: revert this PR.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths