### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/unzip-command.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -314,7 +314,6 @@
         "packages/webapp/src/shell/supplemental-commands/pdftk-command.ts",
         "packages/webapp/src/shell/supplemental-commands/ps-command.ts",
         "packages/webapp/src/shell/supplemental-commands/screencapture-command.ts",
-        "packages/webapp/src/shell/supplemental-commands/unzip-command.ts",
         "packages/webapp/src/shell/supplemental-commands/websocat-command.ts",
         "packages/webapp/src/skills/install-from-drop.ts",
         "packages/webapp/src/ui/oauth-bootstrap.ts"

--- a/packages/webapp/src/shell/supplemental-commands/unzip-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/unzip-command.ts
@@ -1,14 +1,74 @@
 import { unzipSync } from 'fflate';
-import type { Command } from 'just-bash';
+import type { Command, CommandContext } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import { dirname, ensureWithinRoot } from './shared.js';
 
-function unzipHelp(): { stdout: string; stderr: string; exitCode: number } {
+type CommandResult = { stdout: string; stderr: string; exitCode: number };
+
+function unzipHelp(): CommandResult {
   return {
     stdout: 'usage: unzip <archive.zip> [-d <destination>]\n',
     stderr: '',
     exitCode: 0,
   };
+}
+
+type ParsedArgs =
+  | { kind: 'ok'; archive: string; destination: string }
+  | { kind: 'error'; result: CommandResult };
+
+function parseUnzipArgs(args: string[]): ParsedArgs {
+  let destination = '.';
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '-d') {
+      destination = args[i + 1] ?? '';
+      i++;
+      continue;
+    }
+    if (arg.startsWith('-')) {
+      return {
+        kind: 'error',
+        result: { stdout: '', stderr: `unzip: unsupported option ${arg}\n`, exitCode: 1 },
+      };
+    }
+    positional.push(arg);
+  }
+
+  if (positional.length < 1) {
+    return {
+      kind: 'error',
+      result: { stdout: '', stderr: 'unzip: expected archive path\n', exitCode: 1 },
+    };
+  }
+
+  return { kind: 'ok', archive: positional[0], destination: destination || '.' };
+}
+
+/**
+ * Write one archive entry to `outputRoot`. Returns `true` when a file was
+ * written, `false` when the entry is a directory placeholder (skipped), or a
+ * `CommandResult` when the entry's resolved path escapes `outputRoot`.
+ */
+async function extractEntry(
+  ctx: CommandContext,
+  outputRoot: string,
+  entry: string,
+  content: Uint8Array
+): Promise<boolean | CommandResult> {
+  const normalized = entry.replace(/\\/g, '/');
+  if (!normalized || normalized.endsWith('/')) return false;
+
+  const outputPath = ctx.fs.resolvePath(outputRoot, normalized);
+  if (!ensureWithinRoot(outputRoot, outputPath)) {
+    return { stdout: '', stderr: `unzip: blocked suspicious path ${entry}\n`, exitCode: 1 };
+  }
+
+  const parent = dirname(outputPath);
+  if (parent !== '/') await ctx.fs.mkdir(parent, { recursive: true });
+  await ctx.fs.writeFile(outputPath, content);
+  return true;
 }
 
 export function createUnzipCommand(): Command {
@@ -17,35 +77,11 @@ export function createUnzipCommand(): Command {
       return unzipHelp();
     }
 
-    let destination = '.';
-    const positional: string[] = [];
-    for (let i = 0; i < args.length; i++) {
-      const arg = args[i];
-      if (arg === '-d') {
-        destination = args[i + 1] ?? '';
-        i++;
-        continue;
-      }
-      if (arg.startsWith('-')) {
-        return {
-          stdout: '',
-          stderr: `unzip: unsupported option ${arg}\n`,
-          exitCode: 1,
-        };
-      }
-      positional.push(arg);
-    }
+    const parsed = parseUnzipArgs(args);
+    if (parsed.kind === 'error') return parsed.result;
 
-    if (positional.length < 1) {
-      return {
-        stdout: '',
-        stderr: 'unzip: expected archive path\n',
-        exitCode: 1,
-      };
-    }
-
-    const archivePath = ctx.fs.resolvePath(ctx.cwd, positional[0]);
-    const outputRoot = ctx.fs.resolvePath(ctx.cwd, destination || '.');
+    const archivePath = ctx.fs.resolvePath(ctx.cwd, parsed.archive);
+    const outputRoot = ctx.fs.resolvePath(ctx.cwd, parsed.destination);
     await ctx.fs.mkdir(outputRoot, { recursive: true });
 
     const archiveBytes = await ctx.fs.readFileBuffer(archivePath);
@@ -53,22 +89,12 @@ export function createUnzipCommand(): Command {
 
     let extracted = 0;
     for (const [entry, content] of Object.entries(files)) {
-      const normalized = entry.replace(/\\/g, '/');
-      if (!normalized || normalized.endsWith('/')) continue;
-
-      const outputPath = ctx.fs.resolvePath(outputRoot, normalized);
-      if (!ensureWithinRoot(outputRoot, outputPath)) {
-        return {
-          stdout: '',
-          stderr: `unzip: blocked suspicious path ${entry}\n`,
-          exitCode: 1,
-        };
+      const written = await extractEntry(ctx, outputRoot, entry, content);
+      if (written === true) {
+        extracted++;
+      } else if (written !== false) {
+        return written;
       }
-
-      const parent = dirname(outputPath);
-      if (parent !== '/') await ctx.fs.mkdir(parent, { recursive: true });
-      await ctx.fs.writeFile(outputPath, content);
-      extracted++;
     }
 
     return {

--- a/packages/webapp/tests/shell/supplemental-commands/unzip-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/unzip-command.test.ts
@@ -1,0 +1,85 @@
+import 'fake-indexeddb/auto';
+import { zipSync } from 'fflate';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
+
+describe('unzip command', () => {
+  let fs: VirtualFS;
+  let shell: AlmostBashShellHeadless;
+  let dbCounter = 0;
+
+  beforeEach(async () => {
+    fs = await VirtualFS.create({
+      dbName: `test-unzip-command-${dbCounter++}`,
+      wipe: true,
+    });
+    shell = new AlmostBashShellHeadless({ fs });
+    await fs.mkdir('/workspace', { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.dispose();
+  });
+
+  async function writeZip(path: string, entries: Record<string, Uint8Array>): Promise<void> {
+    await fs.writeFile(path, zipSync(entries));
+  }
+
+  it('prints help with no args or with -h/--help', async () => {
+    for (const command of ['unzip', 'unzip -h', 'unzip --help']) {
+      const result = await shell.executeCommand(command);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('usage: unzip');
+    }
+  });
+
+  it('extracts files into the current directory by default', async () => {
+    const enc = new TextEncoder();
+    await writeZip('/workspace/archive.zip', {
+      'hello.txt': enc.encode('hello unzip'),
+      'nested/data.bin': new Uint8Array([0, 1, 2, 255]),
+      'emptydir/': new Uint8Array(0),
+    });
+
+    const result = await shell.executeCommand('cd /workspace && unzip archive.zip');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('extracted 2 file(s)');
+    expect(await fs.readFile('/workspace/hello.txt')).toBe('hello unzip');
+    const binary = await fs.readFile('/workspace/nested/data.bin', { encoding: 'binary' });
+    expect(Array.from(binary as Uint8Array)).toEqual([0, 1, 2, 255]);
+    // Directory placeholder entries are skipped, not counted.
+    expect(await fs.exists('/workspace/emptydir')).toBe(false);
+  });
+
+  it('extracts into an explicit -d destination', async () => {
+    const enc = new TextEncoder();
+    await writeZip('/workspace/archive.zip', { 'file.txt': enc.encode('data') });
+
+    const result = await shell.executeCommand('cd /workspace && unzip archive.zip -d out');
+    expect(result.exitCode).toBe(0);
+    expect(await fs.readFile('/workspace/out/file.txt')).toBe('data');
+  });
+
+  it('rejects unsupported options', async () => {
+    const result = await shell.executeCommand('unzip -q archive.zip');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('unsupported option -q');
+  });
+
+  it('requires an archive path when only flags are given', async () => {
+    const result = await shell.executeCommand('unzip -d out');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('expected archive path');
+  });
+
+  it('blocks entries that escape the destination root', async () => {
+    const enc = new TextEncoder();
+    await writeZip('/workspace/evil.zip', { '../escape.txt': enc.encode('escape') });
+
+    const result = await shell.executeCommand('cd /workspace && unzip evil.zip -d out');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('blocked suspicious path ../escape.txt');
+    expect(await fs.exists('/workspace/escape.txt')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Boy-scout debt cleanup: `packages/webapp/src/shell/supplemental-commands/unzip-command.ts`

Pays down the boy-scout debt on this single file, behaviour-preservingly.

### Debt list cleared

- **`complexity.noExcessiveCognitiveComplexity`** — The single `defineCommand('unzip', ...)` handler carried all the argument parsing, path resolution, and per-entry extraction (with nested branching for `-d`, unsupported options, directory placeholders, and traversal blocking) in one function, exceeding the cap of 25. Refactored by extracting two pure/focused helpers:
  - `parseUnzipArgs(args)` — returns a tagged `{ kind: 'ok' | 'error' }` result, moving option/positional parsing and validation out of the handler.
  - `extractEntry(ctx, outputRoot, entry, content)` — writes one archive entry, returning `true` (wrote a file), `false` (skipped a directory placeholder), or a `CommandResult` (blocked suspicious path).

  The handler now reads as a flat sequence: help → parse → resolve → extract loop. Removed the now-stale entry `packages/webapp/src/shell/supplemental-commands/unzip-command.ts` from the `complexity.noExcessiveCognitiveComplexity: "off"` override `includes` array in `biome.json`.

### Behaviour preservation

No observable behaviour changed: identical stdout/stderr strings, exit codes, extraction counting (directory placeholders skipped, not counted), traversal blocking via `ensureWithinRoot`, and `-d`/default-destination handling.

### Tests

Added `packages/webapp/tests/shell/supplemental-commands/unzip-command.test.ts` (there was no prior test) covering: help output, default-cwd extraction with directory-placeholder skipping, `-d` destination, unsupported-option rejection, missing-archive rejection, and traversal blocking.

### Verification

- `npx biome check --write` on touched files — clean
- `npm run typecheck` — pass
- `npx vitest run` on the new test file — 6/6 pass
- `npm run verify` — all 7 checks pass (incl. `boy-scout-debt`)
- `GITHUB_BASE_REF=main node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — `OK (3 changed file(s), 0 still on any debt list)`

### No escape hatches

No exemption, `biome.json` override entry, `biome-ignore`/`eslint-disable` suppression, baseline entry, or threshold/coverage relaxation was added. The only `biome.json` change is the removal of this file's stale debt entry.
