### PR TITLE
fix(pr-fix-dispatcher): don't treat NODE_OPTIONS dns as network infra

### DIFF
--- a/.github/workflows/pr-fix-dispatcher.yml
+++ b/.github/workflows/pr-fix-dispatcher.yml
@@ -214,9 +214,11 @@ jobs:
             `npm run typecheck`, `npm test` — run only what is relevant to the
             failing checks), then commit and `git push` to the head branch.
 
-            If the fix turns out to need a dependency change, a schema change, a
+            If the fix turns out to need a *new* dependency, a schema change, a
             CI/deploy config change, or a redesign, stop and report back instead
-            of pushing.
+            of pushing. Syncing a version pin that Renovate already bumped in
+            one manifest but missed in a sibling (e.g. Package.swift vs
+            xcodegen project.yml `exactVersion`) is allowed and expected.
 
             Do not merge the PR. Do not assign reviewers. Report back with the PR
             URL and whether CI went green, and post that as one short

--- a/docs/dev-tools-details.md
+++ b/docs/dev-tools-details.md
@@ -179,10 +179,22 @@ Two properties of that output are what the dispatcher has to accommodate:
 
 The `CI / ci` aggregator (`if: always()` over `needs: [everything]`) fails
 alongside whichever job actually broke, and its own log says only "One or more
-jobs failed". It classifies as `unknown` and cannot outrank a sibling: verdicts
-fold in `blocked` → `code` → `infra` order, with `unknown` used only when nothing
-else matched. The flake hunter's `PLUMBING_LINE` guard solves the same problem for
-signatures rather than verdicts.
+jobs failed" (plus the job env dump). It is forced to `unknown` and cannot
+outrank a sibling: verdicts fold in `blocked` → `code` → `infra` order, with
+`unknown` used only when nothing else matched. A bare `dns` substring must never
+appear in the network infra signature — every Actions job dumps
+`NODE_OPTIONS: --dns-result-order=ipv4first`, and matching that classified PR
+#2320's real SPM pin conflict as a network flake. The flake hunter's
+`PLUMBING_LINE` guard solves the same problem for signatures rather than
+verdicts.
+
+SPM version conflicts (`Could not resolve package dependencies` /
+`depends on 'webrtc' 151… and root depends on 'webrtc' 150`) are a
+`pin-sync` code signature: Renovate's swift manager updates `Package.swift` but
+historically missed the sibling xcodegen `project.yml` `exactVersion` pins.
+Syncing those pins is mechanical; inventing a new dependency is still a hard
+skip. `renovate.json`'s regex `customManagers` entry now covers `project.yml`
+so both pins move in the same Renovate PR.
 
 ### Running one on demand
 

--- a/packages/dev-tools/pr-fix-dispatcher/README.md
+++ b/packages/dev-tools/pr-fix-dispatcher/README.md
@@ -28,18 +28,29 @@ schedule (every 2h) ─▶ scan-failing-prs.mjs ─▶ queue (JSON) ─▶ fix j
 
 ## The three paths
 
-| Path         | When                                                                                                                                                              | Side effects                                                       |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| **re-run**   | The failure never evaluated the code: artifact up/download, DNS/reset/timeout, registry 5xx, runner lost, a bare cancel. Once per SHA.                            | `rerun-failed-jobs` only — no label, no comment.                   |
-| **dispatch** | The failure is in the code and mechanically fixable: the debt boy-scout gate, lint/format, types, a snapshot or coverage floor, lockfile drift, a merge conflict. | `ci-fix-dispatched` + one marker comment, then the `fix` job runs. |
-| **skip**     | Everything else, and always for the hard overrides below.                                                                                                         | `ci-fix-skipped` + one short comment (never two for the same SHA). |
+| Path         | When                                                                                                                                                                                                                                              | Side effects                                                       |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| **re-run**   | The failure never evaluated the code: artifact up/download, DNS/reset/timeout, registry 5xx, runner lost, a bare cancel. Once per SHA.                                                                                                            | `rerun-failed-jobs` only — no label, no comment.                   |
+| **dispatch** | The failure is in the code and mechanically fixable: the debt boy-scout gate, lint/format, types, a snapshot or coverage floor, lockfile drift, a merge conflict, or an SPM/xcodegen pin Renovate bumped in one manifest but missed in a sibling. | `ci-fix-dispatched` + one marker comment, then the `fix` job runs. |
+| **skip**     | Everything else, and always for the hard overrides below.                                                                                                                                                                                         | `ci-fix-skipped` + one short comment (never two for the same SHA). |
 
 Hard overrides to skip: auth, billing, secrets/credentials, schema migrations,
 release/publish/deploy jobs, an expired token or exhausted quota, an
 infrastructure failure that **recurred after a re-run** (so it is not a flake), a
-fix needing a new dependency / version change / CI-config change, and any failure
-whose cause cannot be named. When in doubt between dispatch and skip, skip; when
-in doubt between re-run and skip, re-run.
+failure needing a _new_ dependency / version change / CI-config change (syncing a
+pin Renovate already bumped in a sibling manifest is dispatch, not this), and any
+failure whose cause cannot be named. When in doubt between dispatch and skip, skip;
+when in doubt between re-run and skip, re-run.
+
+### Network infra must not match Actions `NODE_OPTIONS`
+
+Every job in this repo dumps `NODE_OPTIONS: --dns-result-order=ipv4first`. The
+`CI / ci` aggregator's script-echo puts that line inside the failure excerpt of
+`One or more jobs failed…`. A bare `dns` substring used to classify that as
+network plumbing (PR #2320), burn the one re-run, then skip forever. The network
+signature now requires an explicit DNS-failure phrase (`getaddrinfo`,
+`ENOTFOUND`, `dns resolution`, …), and the aggregator job is forced to
+`unknown` so a sibling that named a real cause can win.
 
 ### The debt boy-scout gate is the likeliest dispatch of all
 

--- a/packages/dev-tools/pr-fix-dispatcher/lib.mjs
+++ b/packages/dev-tools/pr-fix-dispatcher/lib.mjs
@@ -142,6 +142,15 @@ export const HARD_SKIP_JOB_PATTERN =
 /**
  * Failures that did not evaluate the code — CI plumbing. These take the re-run
  * path (once per head SHA).
+ *
+ * Network patterns deliberately omit a bare `dns` substring: every Actions job
+ * in this repo dumps `NODE_OPTIONS: --dns-result-order=ipv4first` into its log,
+ * and the `CI / ci` aggregator's script-echo + env dump puts that line inside
+ * the log excerpt of `##[error]One or more jobs failed…`. Matching bare `dns`
+ * classified PR #2320's real SPM pin conflict as a network flake (re-run once,
+ * then skip) and never dispatched a fixer. Real DNS failures still match via
+ * `getaddrinfo`, `ENOTFOUND`, `EAI_AGAIN`, or an explicit "dns resolution /
+ * lookup / error" phrase.
  */
 export const INFRA_SIGNATURES = [
   {
@@ -152,7 +161,7 @@ export const INFRA_SIGNATURES = [
   {
     category: 'network',
     pattern:
-      /ENOTFOUND|EAI_AGAIN|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|socket hang up|getaddrinfo|connection reset by peer|tls handshake|dns/i,
+      /ENOTFOUND|EAI_AGAIN|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|socket hang up|getaddrinfo|connection reset by peer|tls handshake|dns (resolution|lookup|error)|name resolution/i,
   },
   {
     category: 'registry',
@@ -220,6 +229,15 @@ export const CODE_SIGNATURES = [
     category: 'generated-artifact',
     pattern:
       /package-lock\.json|lock ?file (is )?out of (sync|date)|npm ci can only install|git diff --exit-code|generated file .* out of date|working tree is dirty/i,
+  },
+  // Renovate updates Package.swift / Package.resolved but historically missed
+  // the sibling xcodegen `project.yml` `exactVersion:` pins (PR #2320). SPM
+  // then fails with a version conflict that is a mechanical pin sync, not a
+  // design decision and not CI plumbing.
+  {
+    category: 'pin-sync',
+    pattern:
+      /could not resolve package dependencies|dependencies could not be resolved because|depends on ['"]?[\w.-]+['"]? [\d.]+(?:\.\.<[\d.]+)? and .+ depends on ['"]?[\w.-]+['"]? [\d.]+/i,
   },
   {
     category: 'merge-conflict',
@@ -326,6 +344,20 @@ function matchSignature(table, text) {
 }
 
 /**
+ * The `CI / ci` aggregator (`if: always()` over `needs: [*]`) always fails
+ * whenever any child does; its own log only echoes that fact (plus the job
+ * env dump). Classifying it from its log would let boilerplate — or a false
+ * infra hit inside that dump — dominate a sibling that named the real cause.
+ * @param {string} jobName
+ * @param {string} logExcerpt
+ * @returns {boolean}
+ */
+function isCiAggregatorNoise(jobName, logExcerpt) {
+  if (String(jobName).toLowerCase() !== 'ci') return false;
+  return /one or more jobs failed or were cancelled/i.test(String(logExcerpt));
+}
+
+/**
  * Classify a single failure as infrastructure, code, blocked (hard skip), or
  * unknown, from its job name plus a log excerpt.
  * @param {{jobName?: string, logExcerpt?: string}} failure
@@ -334,6 +366,16 @@ function matchSignature(table, text) {
 export function classifyFailure({ jobName = '', logExcerpt = '' } = {}) {
   const name = String(jobName);
   const text = `${name}\n${String(logExcerpt)}`;
+
+  // Aggregator boilerplate never names a cause — treat as unknown so a sibling
+  // with a real signature can win in {@link classifyFailures}.
+  if (isCiAggregatorNoise(name, logExcerpt)) {
+    return {
+      kind: 'unknown',
+      category: null,
+      reason: `"${name}" is the CI aggregator and does not name a failure cause.`,
+    };
+  }
 
   if (HARD_SKIP_JOB_PATTERN.test(name)) {
     return {

--- a/packages/dev-tools/pr-fix-dispatcher/lib.test.mjs
+++ b/packages/dev-tools/pr-fix-dispatcher/lib.test.mjs
@@ -220,6 +220,7 @@ describe('classifyFailure', () => {
     const cases = [
       ['upload artifacts', 'Failed to upload artifact: 500'],
       ['test', 'getaddrinfo ENOTFOUND registry.example.com'],
+      ['test', 'DNS resolution failed for registry.example.com'],
       ['install', 'npm ERR! network request to https://registry.npmjs.org failed'],
       ['test', 'The runner has received a shutdown signal.'],
       ['test', 'The operation was canceled.'],
@@ -229,6 +230,35 @@ describe('classifyFailure', () => {
         'infra'
       );
     }
+  });
+
+  // PR #2320: the CI aggregator's script-echo + env dump put
+  // `NODE_OPTIONS: --dns-result-order=ipv4first` inside the failure excerpt.
+  // A bare `dns` substring must never classify that as network plumbing.
+  it('does not treat Actions NODE_OPTIONS --dns-result-order as a network failure (PR #2320)', () => {
+    const excerpt = [
+      'echo "::error::One or more jobs failed or were cancelled"',
+      'exit 1',
+      'fi',
+      'shell: /usr/bin/bash -e {0}',
+      'env:',
+      '  NODE_OPTIONS: --dns-result-order=ipv4first',
+      '##[endgroup]',
+      '##[error]One or more jobs failed or were cancelled',
+      '##[error]Process completed with exit code 1.',
+    ].join('\n');
+    const out = classifyFailure({ jobName: 'ci', logExcerpt: excerpt });
+    expect(out.kind).toBe('unknown');
+    expect(out.reason).toMatch(/aggregator/i);
+  });
+
+  it('classifies SPM version pin conflicts as a fixable pin-sync (PR #2320)', () => {
+    const excerpt =
+      'xcodebuild: error: Could not resolve package dependencies:\n' +
+      '  Failed to resolve dependencies Dependencies could not be resolved because ' +
+      "'swift-trayfollower' depends on 'webrtc' 151.0.0..<152.0.0 and root depends on 'webrtc' 150.0.0.";
+    const out = classifyFailure({ jobName: 'ios-app', logExcerpt: excerpt });
+    expect(out).toMatchObject({ kind: 'code', category: 'pin-sync' });
   });
 
   it('classifies lint/type/test/snapshot/lockfile/conflict failures as code', () => {
@@ -354,6 +384,26 @@ describe('classifyFailures', () => {
     ]) {
       expect(classifyFailures(failures)).toMatchObject({ kind: 'code', category: 'debt-gate' });
     }
+  });
+
+  // PR #2320 regression: aggregator excerpt used to match bare `dns` via
+  // NODE_OPTIONS and win as infra over an SPM pin-sync sibling (unknown then).
+  it('lets an SPM pin-sync sibling beat a dns-contaminated aggregator excerpt (PR #2320)', () => {
+    const aggregatorWithDns = [
+      'echo "::error::One or more jobs failed or were cancelled"',
+      'env:',
+      '  NODE_OPTIONS: --dns-result-order=ipv4first',
+      '##[error]One or more jobs failed or were cancelled',
+    ].join('\n');
+    const spm =
+      "Could not resolve package dependencies: 'swift-trayfollower' depends on " +
+      "'webrtc' 151.0.0..<152.0.0 and root depends on 'webrtc' 150.0.0.";
+    expect(
+      classifyFailures([
+        { name: 'ci', logExcerpt: aggregatorWithDns },
+        { name: 'ios-app', logExcerpt: spm },
+      ])
+    ).toMatchObject({ kind: 'code', category: 'pin-sync' });
   });
 
   it('reports unknown for an empty list', () => {

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,18 @@
     "minimumReleaseAge": "0 days",
     "enabled": true
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "XcodeGen project.yml `exactVersion` pins for GitHub SPM packages. Renovate's swift manager updates Package.swift / Package.resolved but not these sibling pins — missing them left WebRTC at 150 in project.yml while Package.swift required 151 (PR #2320).",
+      "managerFilePatterns": ["/(^|/)project\\.yml$/"],
+      "matchStrings": [
+        "url:\\s*https://github\\.com/(?<depName>[^\\s/]+/[^\\s/]+?)(?:\\.git)?\\s*\\n\\s+exactVersion:\\s*(?<currentValue>\\S+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
+  ],
   "packageRules": [
     {
       "description": "Pin every npm dependency to an exact version. Renovate cannot see the locked version of a dep declared in a workspace package.json: npm hoists everything into the root `node_modules/`, but since renovatebot/renovate#37407 Renovate looks the dep up under `packages/<pkg>/node_modules/<dep>` and gives up when that never-written key is missing. With `lockedVersion: null` it can only offer updates that change the range, so caret-ranged workspace deps silently froze at whatever the lockfile happened to hold — `@earendil-works/pi-ai` sat on 0.84.0 under `^0.84.0` for a week, which is why Grok 4.6 never reached the model dropdown (PR #2293). Exact pins make every version change a visible package.json diff in its own PR, which is what the one-dep-per-PR philosophy above wants anyway. Scoped to dependencies/devDependencies so `engines` and `peerDependencies` keep their ranges.",


### PR DESCRIPTION
## Summary

Stops the PR Fix Dispatcher from misclassifying real code failures as network flakes (the reason it skipped [#2320](https://github.com/ai-ecoverse/slicc/pull/2320)), and teaches Renovate to bump xcodegen `project.yml` `exactVersion` pins alongside `Package.swift`.

## Why

**Repro (dispatcher on #2320):**
1. Renovate bumped `stasel/WebRTC` in `Package.swift` / `Package.resolved` to 151 but left `packages/*/project.yml` at `exactVersion: 150.0.0`.
2. CI failed with SPM: `swift-trayfollower depends on webrtc 151… and root depends on webrtc 150`.
3. The dispatcher classified the `CI / ci` aggregator as network infra because its log excerpt included `NODE_OPTIONS: --dns-result-order=ipv4first`, matching a bare `dns` substring.
4. Expected: dispatch a fixer (or at least skip with "unknown / pin conflict"). Actual: re-run once, then skip forever as "not a flake".

## Approach / Implementation notes

- Tighten network infra: require explicit DNS-failure phrases (`getaddrinfo`, `ENOTFOUND`, `dns resolution`, …), not bare `dns`.
- Force the `CI / ci` aggregator to `unknown` so it cannot outrank a sibling that named a real cause.
- Add a `pin-sync` code signature for SPM version conflicts; allow the fixer prompt to sync sibling manifests Renovate already bumped.
- Add a Renovate regex `customManagers` entry for `project.yml` `exactVersion` pins so both pins move in the same Renovate PR.

## Cross-cutting impact

- **Floats exercised:** none (CI automation / Renovate config only).
- No runtime, shell, persisted-state, or security surface changes.

## Test plan

- [x] `npx vitest run --project dev-tools packages/dev-tools/pr-fix-dispatcher/lib.test.mjs` — 68 passing, including PR #2320 regressions
- [x] Pre-push lint gate (`npm run verify` subset via husky) passed on commit
- [ ] N/A — no typecheck / app build / UI change for this PR
- [ ] Optional: `gh workflow run pr-fix-dispatcher.yml -f dry_run=true` and confirm aggregator logs no longer classify as network

## Documentation

- [x] `packages/dev-tools/pr-fix-dispatcher/README.md`
- [x] `docs/dev-tools-details.md`
- [ ] No user-facing `README.md` / agent `CLAUDE.md` changes needed

## Risk & rollback

- Blast radius: scheduled PR Fix Dispatcher classification only; false negatives would skip (safe), false positives could over-dispatch (budget-capped).
- Rollback: revert this PR.
- Nothing CI cannot catch that a reviewer must verify by hand beyond the unit tests.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs (N/A — none)
- [x] No float contract changes