### PR TITLE
fix(swift-launcher): trigger macOS native packaging rebuild

### DIFF
--- a/packages/swift-launcher/README.md
+++ b/packages/swift-launcher/README.md
@@ -161,3 +161,6 @@ covers `--update-host` / `SLICC_UPDATE_HOST` parsing, and
 `SliccstartTests/UpdateCheckIntegrationTests.swift` hits the real GitHub API
 through `TolerantGithubReleaseProvider` to catch release-naming drift that a
 frozen fixture could not.
+
+Native packaging (signed DMG + update ZIP) runs when files under this package
+change since the previous release tag.


### PR DESCRIPTION
## Summary

No-op README note under `packages/swift-launcher/` so `release-native` treats this release as macOS-gated and rebuilds the Sliccstart DMG + update ZIP (including the File Provider appex that never completed a native publish after the 30m timeout failures).

## Why

v6.85.0–v6.87.0 tags existed without GitHub Release macOS assets. The timeout bump shipped as v6.87.1 but skipped macOS packaging (workflow-only diff). This patch intentionally touches a `MACOS_PATH_PREFIXES` path so the next release rebuilds native artifacts.

## Approach / Implementation notes

- README-only change; commit subject is `fix(swift-launcher): …` so semantic-release cuts a patch and `decideGating` sets `macos: true`.

## Cross-cutting impact

- **Floats exercised**: CI release pipeline / Sliccstart native publish only.
- No runtime behavior change.

## Test plan

- [ ] Merge via merge queue; confirm Release workflow runs on `main`.
- [ ] Confirm `[release-native] Updated known-good macOS pointer` (not “Skipping macOS”).
- [ ] Confirm GitHub Release includes `sliccstart-v*.dmg` (or equivalent) and `known-good-macos.json` advances past 6.85.0.
- [x] N/A — README-only; no unit tests.

## Documentation

- [x] Relevant package README (trivial note about packaging gate)

## Risk & rollback

- Blast radius: one extra patch release + full native packaging (~30–60m). Rollback: revert this PR if the note is unwanted after the rebuild ships.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] Follower/leader contracts unchanged
