### PR TITLE
test(e2e): browser python3 print(1+1) via pinned ipk pyodide

### DIFF
--- a/.agents/skills/writing-slicc-tests/SKILL.md
+++ b/.agents/skills/writing-slicc-tests/SKILL.md
@@ -644,6 +644,11 @@ Three pieces compose the framework:
   a second SLICC runtime joined to the leader through the real tray hub, plus
   the cone / freezer-rail / tab-strip / terminal helpers the multi-cone
   scenarios share. See "Write a Two-Instance Scenario" below.
+- **Terminal-only smokes** (no fake LLM): drive
+  `globalThis.__slicc_terminal_view.executeCommandInTerminal` after
+  `slicc-dock.selectItem('term')` — same seam as the chat panel's "run in
+  terminal". Examples: `git-clone-live.test.ts`, `python-print.test.ts`
+  (browser `ipk add pyodide@<root pin>` then `python3 -c "print(1 + 1)"`).
 
 ### Write a Scenario
 

--- a/packages/webapp/tests/e2e/python-print.test.ts
+++ b/packages/webapp/tests/e2e/python-print.test.ts
@@ -1,0 +1,125 @@
+// packages/webapp/tests/e2e/python-print.test.ts
+/**
+ * Real browser-float `python3 -c` smoke E2E.
+ *
+ * The Node-mode Vitest suite already boots Pyodide via
+ * `file://…/node_modules/pyodide/` (`bash-tool.test.ts` —
+ * `python3 -c "print(1 + 1)"` → `2`). That path never exercises the
+ * standalone/browser contract: resolve an ipk-installed
+ * `/workspace/node_modules/pyodide@<pin>`, fail fast with the pinned
+ * `ipk add pyodide@…` guidance when it is missing, then load the four
+ * runtime assets over realm VFS RPC.
+ *
+ * This scenario closes that gap against a real wrangler-served UI +
+ * kernel worker:
+ *
+ *   1. Missing install → exit 1 with `ipk add pyodide@<root pin>`.
+ *   2. `cd /workspace && ipk add pyodide@<pin>` through the fetch proxy.
+ *   3. `python3 -c "print(1 + 1)"` prints `2`.
+ *
+ * The pin is read from the root `package.json` so a Renovate pyodide
+ * bump cannot leave this fixture pointing at a stale version — the
+ * same source of truth `PYODIDE_VERSION` uses at runtime.
+ *
+ *   Run: npm run test:e2e -- python-print
+ */
+
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
+
+const rootPkg = JSON.parse(
+  readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../../../package.json'), 'utf8')
+) as { dependencies: { pyodide: string } };
+const PYODIDE_VERSION = rootPkg.dependencies.pyodide;
+
+interface ExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+declare global {
+  interface Window {
+    __slicc_terminal_view?: {
+      executeCommandInTerminal(cmd: string): Promise<ExecResult>;
+    };
+  }
+}
+
+/** Run a single command through the worker shell via the published view. */
+async function exec(page: import('@playwright/test').Page, cmd: string): Promise<ExecResult> {
+  return page.evaluate(async (command: string) => {
+    const view = window.__slicc_terminal_view;
+    if (!view) throw new Error('terminal view not published yet');
+    return view.executeCommandInTerminal(command);
+  }, cmd);
+}
+
+test.describe('python3 print smoke (browser ipk path)', () => {
+  test('ipk-installs the pinned pyodide and prints 1 + 1', async ({ page }, testInfo) => {
+    // Cold `ipk add pyodide` pulls the full WASM tree through the fetch
+    // proxy, then the realm boots Pyodide — well past the 30s default.
+    test.setTimeout(5 * 60_000);
+
+    expect(PYODIDE_VERSION, 'root package.json must pin an exact pyodide version').toMatch(
+      /^\d+\.\d+\.\d+/
+    );
+
+    await seedSkipSwReload(page);
+    // Thin-bridge launch params so `ipk add` reaches the node-server
+    // fetch proxy (same reason speech-roundtrip / git-clone-live boot
+    // via `gotoLeader`).
+    await gotoLeader(page);
+    await waitForSW(page);
+
+    await page.waitForSelector('slicc-input-card');
+    await expect(page.locator('slicc-chat-thread')).toContainText('Welcome to SLICC', {
+      timeout: 20_000,
+    });
+
+    await page.evaluate(() => {
+      const dock = document.querySelector('slicc-dock') as
+        | (HTMLElement & { selectItem?: (id: string) => void })
+        | null;
+      if (!dock?.selectItem) throw new Error('<slicc-dock>.selectItem(id) unavailable');
+      dock.selectItem('term');
+    });
+    await page.waitForFunction(() => window.__slicc_terminal_view != null, null, {
+      timeout: 30_000,
+    });
+
+    // 1. Fresh VFS: browser float refuses to boot without the pinned
+    //    install and surfaces the canonical remediation. `cd /workspace`
+    //    so the nearest-`node_modules` walk matches where `ipk add` lands
+    //    (terminal boots at `/`; see speech-roundtrip).
+    const missing = await exec(page, 'cd /workspace && python3 -c "print(1 + 1)"');
+    expect(missing.exitCode, `missing-install stderr: ${missing.stderr}`).toBe(1);
+    expect(missing.stderr).toContain(`ipk add pyodide@${PYODIDE_VERSION}`);
+
+    // 2. Install the exact pin the running build expects.
+    const installCmd = `cd /workspace && ipk add pyodide@${PYODIDE_VERSION}`;
+    const install = await exec(page, installCmd);
+    const installReport =
+      `command: ${installCmd}\n` +
+      `exitCode: ${install.exitCode}\n` +
+      `--- stdout ---\n${install.stdout}\n` +
+      `--- stderr ---\n${install.stderr}`;
+    await testInfo.attach('ipk-add-pyodide', { body: installReport, contentType: 'text/plain' });
+    expect(install.exitCode, `ipk add stderr: ${install.stderr}`).toBe(0);
+
+    // 3. Smoke: real Pyodide eval through the VFS-bytes loader.
+    const runCmd = 'cd /workspace && python3 -c "print(1 + 1)"';
+    const run = await exec(page, runCmd);
+    const runReport =
+      `command: ${runCmd}\n` +
+      `exitCode: ${run.exitCode}\n` +
+      `--- stdout ---\n${run.stdout}\n` +
+      `--- stderr ---\n${run.stderr}`;
+    await testInfo.attach('python3-print', { body: runReport, contentType: 'text/plain' });
+    expect(run.exitCode, `python3 stderr: ${run.stderr}`).toBe(0);
+    expect(run.stdout.trim()).toBe('2');
+  });
+});


### PR DESCRIPTION
## Summary

Add a Playwright E2E that exercises the standalone browser `python3` path: missing-install guidance, `ipk add pyodide@<root pin>`, then `python3 -c "print(1 + 1)"` → `2`.

## Why

Node Vitest already boots Pyodide from `file://…/node_modules` (`bash-tool.test.ts`). That never covers the browser float contract Renovate pyodide bumps rely on — VFS `ipk` install + pinned `ipk add pyodide@…` guidance + realm VFS-bytes load. This closes that gap so a pin bump cannot ship without a real browser smoke.

## Approach / Implementation notes

- New [`packages/webapp/tests/e2e/python-print.test.ts`](packages/webapp/tests/e2e/python-print.test.ts) drives `__slicc_terminal_view` (same seam as `git-clone-live` / `speech-roundtrip`).
- Pin is read from root `package.json` so it stays aligned with `PYODIDE_VERSION`.
- Documented as a terminal-only smoke in the writing-slicc-tests skill.

## Cross-cutting impact

- **Floats exercised**: standalone leader (wrangler UI + node-server bridge) only.
- No production code changes.

## Test plan

- [x] `npm run verify`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test:e2e -- python-print` — passed locally (~7s warm)

## CI

No workflow change needed: the `e2e` job already runs on `packages/webapp/**` (`dorny/paths-filter` → `webapp`) and executes `npm run test:e2e`, which picks up every `tests/e2e/*.test.ts` (unlike speech, this spec is not gated behind `RUN_REAL_SPEECH_E2E`).

## Documentation

- [x] `.agents/skills/writing-slicc-tests/SKILL.md` — terminal-only smoke examples

## Risk & rollback

- Low: test-only. If flaky under CI load, revert this PR.
- Cold `ipk add pyodide` can be slow; timeout is 5 minutes.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff


Made with [Cursor](https://cursor.com)