### PR TITLE
style(swift-launcher): make the Terminals settings tab a real macOS pane

### DIFF
--- a/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
@@ -189,12 +189,18 @@ struct TerminalsSettingsView: View {
                         .gridColumnAlignment(.trailing)
                         .padding(.top, 5)
                     VStack(alignment: .leading, spacing: 8) {
-                        TextField(FollowCommandTemplate.defaultTemplate, text: $followCommand, axis: .vertical)
-                            .font(.system(.body, design: .monospaced))
-                            .textFieldStyle(.roundedBorder)
-                            .lineLimit(2...4)
-                            .disableAutocorrection(true)
-                            .accessibilityIdentifier("follow-command-template")
+                        TextField(
+                            "Command",
+                            text: $followCommand,
+                            prompt: Text(FollowCommandTemplate.defaultTemplate),
+                            axis: .vertical
+                        )
+                        .font(.system(.body, design: .monospaced))
+                        .textFieldStyle(.roundedBorder)
+                        .lineLimit(2...4)
+                        .disableAutocorrection(true)
+                        .accessibilityLabel("Command")
+                        .accessibilityIdentifier("follow-command-template")
                         placeholderLegend
                     }
                 }

--- a/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
+++ b/packages/swift-launcher/Sliccstart/Views/SettingsView.swift
@@ -167,6 +167,12 @@ struct TerminalsSettingsView: View {
     @AppStorage(terminalFollowCommandKey) private var followCommand = FollowCommandTemplate.defaultTemplate
     @AppStorage(suppressTerminalWarningKey) private var suppressTerminalWarning = false
 
+    private static let placeholders: [(token: String, help: String)] = [
+        ("{slicc}", "Path to the slicc CLI"),
+        ("{joinUrl}", "Session join URL"),
+        ("{shell}", "Login shell"),
+    ]
+
     private var preview: String {
         FollowCommandTemplate.preview(
             template: followCommand,
@@ -176,42 +182,99 @@ struct TerminalsSettingsView: View {
     }
 
     var body: some View {
-        Form {
-            Section("Follow command") {
-                TextField("Command template", text: $followCommand, axis: .vertical)
-                    .font(.system(.body, design: .monospaced))
-                    .lineLimit(2...5)
+        VStack(spacing: 0) {
+            Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 12, verticalSpacing: 16) {
+                GridRow(alignment: .top) {
+                    Text("Command")
+                        .gridColumnAlignment(.trailing)
+                        .padding(.top, 5)
+                    VStack(alignment: .leading, spacing: 8) {
+                        TextField(FollowCommandTemplate.defaultTemplate, text: $followCommand, axis: .vertical)
+                            .font(.system(.body, design: .monospaced))
+                            .textFieldStyle(.roundedBorder)
+                            .lineLimit(2...4)
+                            .disableAutocorrection(true)
+                            .accessibilityIdentifier("follow-command-template")
+                        placeholderLegend
+                    }
+                }
+                GridRow(alignment: .top) {
+                    Text("Preview")
+                        .gridColumnAlignment(.trailing)
+                        .padding(.top, 6)
+                    previewWell
+                }
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
-                Text("Available placeholders: {slicc}, {joinUrl}, and {shell}.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+            Divider()
 
-                Button("Restore default") {
+            HStack(spacing: 6) {
+                Button("Restore Default") {
                     followCommand = FollowCommandTemplate.defaultTemplate
                 }
                 .disabled(followCommand == FollowCommandTemplate.defaultTemplate)
-            }
+                .help("Reset the command to the default template")
+                .accessibilityIdentifier("restore-follow-command")
 
-            Section("Preview") {
-                Text(preview)
-                    .font(.system(.body, design: .monospaced))
-                    .textSelection(.enabled)
-                Text("The session join URL is always redacted in this preview.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+                Spacer()
 
-            Section("Terminal access warning") {
-                Button("Show warning again") {
+                Button("Show Warning Again") {
                     suppressTerminalWarning = false
                 }
                 .disabled(!suppressTerminalWarning)
+                .help("Show the terminal access warning the next time you follow a session")
+                .accessibilityIdentifier("show-terminal-warning-again")
             }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(.bar)
         }
-        .formStyle(.grouped)
-        .padding(20)
-        .frame(width: 560)
-        .fixedSize(horizontal: false, vertical: true)
+        .frame(width: 620, height: 420)
+    }
+
+    private var placeholderLegend: some View {
+        HStack(spacing: 6) {
+            ForEach(Self.placeholders, id: \.token) { item in
+                FollowCommandPlaceholderChip(token: item.token, help: item.help)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var previewWell: some View {
+        ScrollView {
+            Text(preview)
+                .font(.system(.callout, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, minHeight: 160, maxHeight: .infinity, alignment: .topLeading)
+        .padding(10)
+        .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(.separator, lineWidth: 0.5)
+        )
+        .accessibilityIdentifier("follow-command-preview")
+    }
+}
+
+private struct FollowCommandPlaceholderChip: View {
+    let token: String
+    let help: String
+
+    var body: some View {
+        Text(token)
+            .font(.system(.caption, design: .monospaced))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+            .help(help)
+            .accessibilityLabel(help)
+            .accessibilityValue(token)
     }
 }
 

--- a/packages/swift-launcher/SliccstartTests/FollowCommandTemplateTests.swift
+++ b/packages/swift-launcher/SliccstartTests/FollowCommandTemplateTests.swift
@@ -80,8 +80,6 @@ final class FollowCommandTemplateTests: XCTestCase {
 
     @MainActor
     func testTerminalsSettingsViewBodyBuilds() {
-        // Walks the SwiftUI body so the pane's template → preview path is
-        // covered; the view itself is not otherwise exercised by `swift test`.
         _ = TerminalsSettingsView().body
     }
 }

--- a/packages/swift-launcher/SliccstartTests/FollowCommandTemplateTests.swift
+++ b/packages/swift-launcher/SliccstartTests/FollowCommandTemplateTests.swift
@@ -77,4 +77,11 @@ final class FollowCommandTemplateTests: XCTestCase {
         XCTAssertFalse(preview.contains(secret))
         XCTAssertFalse(preview.contains("super-secret-value"))
     }
+
+    @MainActor
+    func testTerminalsSettingsViewBodyBuilds() {
+        // Walks the SwiftUI body so the pane's template → preview path is
+        // covered; the view itself is not otherwise exercised by `swift test`.
+        _ = TerminalsSettingsView().body
+    }
 }


### PR DESCRIPTION
## Summary

The Sliccstart **Settings → Terminals** tab is now a first-class macOS settings pane instead of a grouped Form with a wall of placeholder prose. Layout matches the Secrets tab chrome (fixed 620×420, labeled Grid, wrapping preview well, quiet footer bar) in the same spirit as the Mounts tab on #2339.

## Why

The old pane was verbose and developer-facing: a free-text command template, captions listing `{slicc}` / `{joinUrl}` / `{shell}`, a preview section that restated the redaction, and a loud **Show warning again** button. The live preview already *is* the explanation; the captions truncated or overflowed, and the window size jumped relative to Secrets.

## Approach / Implementation notes

- Visual/UX refactor only. `terminalFollowCommandKey`, `suppressTerminalWarningKey`, `FollowCommandTemplate.defaultTemplate` / `.preview`, and `LoginShellResolver` are unchanged.
- Command field: right-aligned **Command** label, rounded-border monospaced `TextField`, compact placeholder chips with `.help()` instead of caption prose.
- Preview: selectable, wrapping monospaced well (`fixedSize(horizontal: false, vertical: true)` so long quoted paths do not truncate). The redacted join URL is visible in the preview, so the old redaction caption is gone.
- Footer (Secrets/Mounts idiom): **Restore Default** (disabled on the default template) and **Show Warning Again** (disabled unless the warning is suppressed).
- Fixed frame `620×420` to match Secrets, so switching tabs no longer resizes the window.

## Cross-cutting impact

- **Floats exercised**: Sliccstart only. CLI / extension / Electron / worker unchanged.
- **Persisted state**: same UserDefaults keys; no migration.
- **Launch path**: `TerminalFollowerLaunchFlow` still reads the same keys. No change to Apple Events, CLI download, or the access-warning alert itself — only the Settings affordance that re-enables it.

## Test plan

- [x] `swift format lint --strict` (`npm run lint:format -w @slicc/swift-launcher`)
- [x] `swiftlint lint` — 0 errors (12 pre-existing warnings, none in the touched files)
- [x] `cd packages/swift-launcher && swift build && swift test` — 378 tests, 0 failures
- [x] `./packages/dev-tools/tools/swift-coverage-check.sh packages/swift-launcher SliccstartPackageTests` — lines 45.18% / functions 47.20% / regions 53.90% (floors 41 / 45 / 52)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK
- [x] `npm run lint:swift-deps` — OK
- [x] New `testTerminalsSettingsViewBodyBuilds` walks the SwiftUI body so the template → preview path is covered
- [ ] **UI change?** Screencast not recorded: a Sliccstart instance is already running from another worktree (`env_7b5tkxetqn`) for inspection, so this change was not launched over it. Layout of Settings → Terminals:
  - 620×420 pane (same as Secrets)
  - **Command** (trailing label) → monospaced rounded field → `{slicc}` `{joinUrl}` `{shell}` chips
  - **Preview** (trailing label) → wrapping selectable well with redacted join URL
  - Footer bar: Restore Default (left), Show Warning Again (right)

**Pre-existing failures**: none in `swift-launcher`.

## Documentation

- [x] No documentation changes needed — user-facing behavior is the same; `packages/slicc-cli/README.md` still correctly says the template is editable in Settings → Terminals

## Risk & rollback

- Blast radius: Sliccstart Settings → Terminals only. Revert this PR cleanly.
- CI cannot catch live window chrome (tab-switch resize, wrapping at 620pt). Worth a glance in Settings → Terminals after install: chips not clipped, preview wraps, footer buttons disabled in the default state.
