### PR TITLE
fix(swift-server): match TS loopback set in isLoopbackBridgeOrigin

### DIFF
--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -903,17 +903,10 @@ private func makeProxyRequest(from request: Request, targetURL: URL, rawBody: By
         headers.add(name: "Cookie", value: proxyCookie)
     }
 
-    // Helper to check if a URL string is localhost
-    func isLocalhostOrigin(_ value: String) -> Bool {
-        guard let url = URL(string: value) else { return false }
-        let host = url.host ?? ""
-        return host == "localhost" || host == "127.0.0.1" || host == "::1"
-    }
-
     // Forbidden-header transport: restore X-Proxy-Origin → Origin
     if let proxyOrigin = headers["X-Proxy-Origin"].first {
         headers.replaceOrAdd(name: "Origin", value: proxyOrigin)
-    } else if let currentOrigin = headers["Origin"].first, isLocalhostOrigin(currentOrigin) {
+    } else if let currentOrigin = headers["Origin"].first, BridgeSecurity.isLoopbackBridgeOrigin(currentOrigin) {
         // Only strip browser's auto-added localhost origin, preserve legitimate origins
         headers.remove(name: "Origin")
     }
@@ -922,7 +915,7 @@ private func makeProxyRequest(from request: Request, targetURL: URL, rawBody: By
     // Forbidden-header transport: restore X-Proxy-Referer → Referer
     if let proxyReferer = headers["X-Proxy-Referer"].first {
         headers.replaceOrAdd(name: "Referer", value: proxyReferer)
-    } else if let currentReferer = headers["Referer"].first, isLocalhostOrigin(currentReferer) {
+    } else if let currentReferer = headers["Referer"].first, BridgeSecurity.isLoopbackBridgeOrigin(currentReferer) {
         // Only strip browser's auto-added localhost referer, preserve legitimate referers
         headers.remove(name: "Referer")
     }

--- a/packages/swift-server/Sources/Server/BridgeSecurity.swift
+++ b/packages/swift-server/Sources/Server/BridgeSecurity.swift
@@ -187,7 +187,29 @@ enum BridgeSecurity {
         return devAllowedOrigins.contains(normalized)
     }
 
-    /// True iff `origin` is a loopback host (localhost / 127.0.0.1 / ::1).
+    /// True iff `hostname` is a loopback name (no URL parse — host only).
+    /// Canonical set matches `@slicc/shared-ts` `isLoopbackHostname`:
+    /// `localhost`, the full `127.0.0.0/8` block, bracketed/bare `::1`.
+    static func isLoopbackHostname(_ hostname: String) -> Bool {
+        guard !hostname.isEmpty else { return false }
+        // URLComponents keeps brackets on IPv6 hosts (`http://[::1]` → `[::1]`);
+        // socket addresses and some callers pass bare `::1`. Accept both.
+        let host: String
+        if hostname.hasPrefix("["), hostname.hasSuffix("]") {
+            host = String(hostname.dropFirst().dropLast())
+        } else {
+            host = hostname
+        }
+        if host == "localhost" || host == "::1" { return true }
+        // 127.0.0.0/8 — octet shape only (same as `@slicc/shared-ts`).
+        let octets = host.split(separator: ".", omittingEmptySubsequences: false)
+        guard octets.count == 4, octets[0] == "127" else { return false }
+        return octets.allSatisfy { octet in
+            octet.count >= 1 && octet.count <= 3 && octet.allSatisfy(\.isNumber)
+        }
+    }
+
+    /// True iff `origin` is a loopback host.
     /// Loopback allowlisted origins (e.g. the locally-served OAuth callback
     /// page at `http://localhost:5710/auth/callback` posting to
     /// `/api/oauth-result`) are exempt from the bridge-token requirement —
@@ -195,15 +217,14 @@ enum BridgeSecurity {
     /// with a hostile script", not "local server talking to itself". Returns
     /// `false` for nil/empty or anything that does not parse as a URL with a
     /// host; never throws. Mirrors `isLoopbackBridgeOrigin` in
-    /// `packages/node-server/src/bridge-security.ts`.
+    /// `packages/node-server/src/bridge-security.ts` (thin wrapper over
+    /// `@slicc/shared-ts` `isLoopbackOrigin`).
     static func isLoopbackBridgeOrigin(_ origin: String?) -> Bool {
         guard let origin, !origin.isEmpty else { return false }
         guard let components = URLComponents(string: origin), let host = components.host else {
             return false
         }
-        // URLComponents keeps the brackets on IPv6 hosts
-        // (`http://[::1]:5710` → `[::1]`); accept both bracketed and bare.
-        return host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "[::1]"
+        return isLoopbackHostname(host)
     }
 
     /// Constant-time compare for the bridge token. Returns `false` for a nil

--- a/packages/swift-server/Tests/BridgeSecurityTests.swift
+++ b/packages/swift-server/Tests/BridgeSecurityTests.swift
@@ -209,14 +209,36 @@ final class BridgeSecurityTests: XCTestCase {
 
     // MARK: - Loopback origin (token-gate exemption)
 
+    func testIsLoopbackHostnameAcceptsCanonicalSet() {
+        XCTAssertTrue(BridgeSecurity.isLoopbackHostname("localhost"))
+        XCTAssertTrue(BridgeSecurity.isLoopbackHostname("127.0.0.1"))
+        XCTAssertTrue(BridgeSecurity.isLoopbackHostname("127.0.0.2"))
+        XCTAssertTrue(BridgeSecurity.isLoopbackHostname("127.255.255.255"))
+        XCTAssertTrue(BridgeSecurity.isLoopbackHostname("::1"))
+        XCTAssertTrue(BridgeSecurity.isLoopbackHostname("[::1]"))
+    }
+
+    func testIsLoopbackHostnameRejectsLookalikes() {
+        XCTAssertFalse(BridgeSecurity.isLoopbackHostname(""))
+        XCTAssertFalse(BridgeSecurity.isLoopbackHostname("www.sliccy.ai"))
+        XCTAssertFalse(BridgeSecurity.isLoopbackHostname("localhost.evil.com"))
+        XCTAssertFalse(BridgeSecurity.isLoopbackHostname("192.168.0.1"))
+        XCTAssertFalse(BridgeSecurity.isLoopbackHostname("10.0.0.5"))
+        XCTAssertFalse(BridgeSecurity.isLoopbackHostname("::2"))
+        XCTAssertFalse(BridgeSecurity.isLoopbackHostname("0.0.0.0"))
+    }
+
     func testIsLoopbackBridgeOriginAcceptsLoopbackHosts() {
         XCTAssertTrue(BridgeSecurity.isLoopbackBridgeOrigin("http://localhost:5710"))
         XCTAssertTrue(BridgeSecurity.isLoopbackBridgeOrigin("http://127.0.0.1:5710"))
+        XCTAssertTrue(BridgeSecurity.isLoopbackBridgeOrigin("http://127.0.0.2:5710"))
         XCTAssertTrue(BridgeSecurity.isLoopbackBridgeOrigin("http://[::1]:5710"))
+        XCTAssertTrue(BridgeSecurity.isLoopbackBridgeOrigin("http://localhost"))
     }
 
     func testIsLoopbackBridgeOriginRejectsRemoteAndMalformed() {
         XCTAssertFalse(BridgeSecurity.isLoopbackBridgeOrigin("https://www.sliccy.ai"))
+        XCTAssertFalse(BridgeSecurity.isLoopbackBridgeOrigin("https://localhost.evil.com"))
         XCTAssertFalse(BridgeSecurity.isLoopbackBridgeOrigin(nil))
         XCTAssertFalse(BridgeSecurity.isLoopbackBridgeOrigin(""))
         XCTAssertFalse(BridgeSecurity.isLoopbackBridgeOrigin("not a url"))


### PR DESCRIPTION
Addresses the inline review on #2350: widening TS `isLoopbackBridgeOrigin` to `127.0.0.0/8` left the Swift mirror hard-coding exact `127.0.0.1`.

## Summary

Swift `BridgeSecurity.isLoopbackBridgeOrigin` now uses the same canonical set as the intended shared helper (`localhost`, full `127.0.0.0/8`, bracketed/bare `::1`). Fetch-proxy origin/referer stripping in `APIRoutes.swift` delegates to that helper instead of a second, narrower copy.

## Why

The CLI path is about to accept `http://127.0.0.2:5710` as loopback (#2350). Swift-server CORS (`ThinBridgeCorsMiddleware`) and the Swift fetch-proxy still treated it as remote. Not a hole (Swift failed closed) — the same silent cross-runtime drift #2305 set out to eliminate. This PR lands on `main` independently.

## Approach / Implementation notes

- Added `BridgeSecurity.isLoopbackHostname` matching the TS octet-shape check.
- `isLoopbackBridgeOrigin` delegates to it after the existing URLComponents parse.
- `makeProxyRequest` no longer has a private `isLocalhostOrigin`; it calls `isLoopbackBridgeOrigin` (also picks up `[::1]`, which the old helper missed).

## Cross-cutting impact

- **Floats exercised**: Sliccstart / swift-server thin-bridge CORS and `/api/fetch-proxy`.
- **Security**: widening Swift to the full loopback set, still reject lookalikes (`localhost.evil.com`, `192.168.0.1`, `::2`, `0.0.0.0`). Until #2350 merges, Swift is slightly *more* accepting than node-server (`127.0.0.2`); both still fail closed on remote hosts.
- **Persisted state / async lifecycle**: none.

## Test plan

- [x] `swift format lint --strict` and `swiftlint` on `@slicc/swift-server`
- [x] `swift test --filter BridgeSecurityTests` — 25 tests, 0 failures (covers `127.0.0.2`, `127.255.255.255`, IPv6, lookalikes)
- [x] Pre-push lint gate
- [x] N/A — no UI change

## Documentation

- [x] Behavior documented on `isLoopbackHostname` / `isLoopbackBridgeOrigin` in `BridgeSecurity.swift`

## Risk & rollback

- Blast radius: swift-server loopback exemption only.
- Rollback: revert this PR. No persisted state.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Cross-runtime contract (CLI ↔ swift-server) — Swift now matches the canonical loopback set