### PR TITLE
fix(work-unit): scope scoop_wait and name-based child resolution to the caller's subtree

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -363,7 +363,10 @@ Scoop-only (not registered for the cone — it has no parent to message; its ass
 
 ### list_scoops
 
-Cone-only. List all registered scoops.
+Cone-only. List the scoops you own — your own subtree, not another cone's
+(#2360). Every name-based scoop tool (`feed_scoop`, `drop_scoop`, `scoop_mute`,
+`scoop_unmute`, `scoop_wait`) resolves names against exactly this list, so a
+name that is not here is an error, never a cross-cone match.
 
 | Property   | Value                                            |
 | ---------- | ------------------------------------------------ |
@@ -385,7 +388,12 @@ Cone-only. Create a new scoop.
 
 **Behavior**:
 
-- Folder is auto-derived from name (lowercase, slugified)
+- Folder is auto-derived from name (lowercase, slugified), and suffixed
+  (`helper-scoop-2`) when that folder is already taken anywhere on the roster —
+  `/scoops/<folder>/` is one shared VFS path, so two cones' scoops must not
+  collide there
+- A name already used inside your own subtree is rejected; the same name under a
+  different cone is fine
 - Scoop is registered but not activated
 - Use `feed_scoop` to give it a task
 
@@ -403,6 +411,8 @@ Cone-only. Delegate a task to a scoop.
 
 **Requirements**:
 
+- The scoop must be one you own (your subtree); another cone's scoop resolves as
+  "not found"
 - `prompt` must be complete and self-contained
 - Scoop has NO access to cone's conversation history
 - Include all context: file paths, URLs, instructions, expected output format
@@ -418,6 +428,8 @@ Cone-only. Remove a scoop.
 | **Name**   | `drop_scoop`                   |
 | **Input**  | `{ scoop_name: string }`       |
 | **Output** | `{ content: "Scoop removed" }` |
+
+Scoped to your own subtree — a cone cannot drop a sibling cone's scoop.
 
 ---
 

--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -326,6 +326,7 @@ the kernel host, for every float.
 - Unaddressed events (licks, sprinkles, workflow completions, follower snapshots) resolve the default root through `rootsOf(...)[0]` / `WorkUnitManager.resolveDefaultRoot()`; `bootstrapCone` only seeds a root when none exists.
 - `normalizeScoopRecord` sanitizes a root's trigger fields on register and restore; `ScoopPresentation` projects the wire's `isCone` from `isRootUnit`. Since #2279 the record has no role field at all, so nothing — `ui/` included — can branch on one.
 - `WorkUnitManager.close(id)` cascades to the unit's children first; closing root A leaves root B's subtree untouched.
+- Name-based child resolution in the scoop-management tools (`feed_scoop`, `drop_scoop`, `scoop_mute`, `scoop_unmute`, `scoop_wait`, `list_scoops`, `scoop_scoop`'s duplicate check) runs against `subtreeOf(roster, caller.jid)` — the caller plus what it transitively owns. An unmatched name is an error naming the caller's subtree; it never widens to a global match, so cone A's `scoop_wait helper` cannot capture cone B's `helper` (#2360). Scoop _folders_ stay globally unique (suffixed on collision) because `/scoops/<folder>/` is one shared VFS path. Cross-subtree operations wait on #2278's supervisor APIs.
 
 ### Phase 2 detail
 

--- a/packages/vfs-root/workspace/skills/delegation/SKILL.md
+++ b/packages/vfs-root/workspace/skills/delegation/SKILL.md
@@ -213,6 +213,8 @@ These three cone-only tools collapse the fan-out into a single follow-up turn:
 
 ### When to use which
 
+> Every scoop name you pass to `feed_scoop`, `drop_scoop`, `scoop_mute`, `scoop_unmute` or `scoop_wait` is resolved against the scoops YOU own — what `list_scoops` shows you. Another cone's identically named scoop is never matched; the call errors instead (#2360).
+
 - **Fan-out + synthesis** (your next useful step depends on all scoops) → `scoop_wait`.
 - **Background work you'll check later** → `scoop_mute` now, `scoop_unmute` when you want the summaries.
 - **Single delegation, no parallelism** → don't mute. Default `scoop-notify` is fine.

--- a/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
+++ b/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
@@ -37,6 +37,7 @@ import {
   normalizeScoopRecord,
   setUnitModel,
   setUnitThinking,
+  uniqueFolder,
 } from '../work-unit/record.js';
 import type { AppendConeMemoryMeta } from './cone-memory-store.js';
 import { globalSeedModel } from './model-seed.js';
@@ -592,8 +593,38 @@ export class ScoopLifecycleManager {
     const scoops = this.deps.getScoops();
     normalizeScoopRecord(scoop);
     this.inheritModel(scoop);
-    await this.deps.db.saveScoop(scoop);
+    // Claim the folder and the registry slot synchronously, BEFORE the first
+    // await. `scoop_scoop` already picks a free folder, but two cones creating
+    // the same name concurrently would both pass that check while the first
+    // record is still inside `saveScoop` — and land in one shared
+    // `/scoops/<folder>/` sandbox (#2360). This is the critical section: the
+    // roster read and the insert happen in one synchronous run.
+    if (scoop.parentJid !== null) {
+      const taken: string[] = [];
+      for (const existing of scoops.values()) {
+        if (existing.jid !== scoop.jid) taken.push(existing.folder);
+      }
+      const free = uniqueFolder(scoop.folder, taken);
+      if (free !== scoop.folder) {
+        log.warn('Scoop folder already taken — registering under a free variant', {
+          jid: scoop.jid,
+          requested: scoop.folder,
+          folder: free,
+        });
+        scoop.folder = free;
+        scoop.trigger = `@${free}`;
+        scoop.assistantLabel = free;
+      }
+    }
     scoops.set(scoop.jid, scoop);
+    try {
+      await this.deps.db.saveScoop(scoop);
+    } catch (err) {
+      // Release the claim: a record that could not be persisted must not
+      // linger in the live roster holding its folder.
+      scoops.delete(scoop.jid);
+      throw err;
+    }
     this.deps.messageRouter.ensureQueue(scoop.jid);
     log.info('Scoop registered', { jid: scoop.jid, name: scoop.name });
     try {

--- a/packages/webapp/src/scoops/scoop-management-tools.ts
+++ b/packages/webapp/src/scoops/scoop-management-tools.ts
@@ -11,6 +11,7 @@ import type { SudoDecision, SudoKind, SudoRequest } from '../sudo/types.js';
 import type { ToolDefinition } from '../tools/types.js';
 import { defaultChildVisibleRoots, workspaceFor } from '../work-unit/descriptor.js';
 import { derivePolicy, isRootUnit, subtreeOf } from '../work-unit/policy.js';
+import { uniqueFolder } from '../work-unit/record.js';
 import {
   CURRENT_SCOOP_CONFIG_VERSION,
   isThinkingLevel,
@@ -143,24 +144,6 @@ function folderFromDisplayName(name: string): string {
       .replace(/^-+|-+$/g, '')
       .slice(0, 50) + '-scoop'
   );
-}
-
-/**
- * The first free variant of `folder` across the whole roster: `helper-scoop`,
- * then `helper-scoop-2`, `helper-scoop-3`… A folder names a real directory
- * under `/scoops/`, so a collision would silently hand a second cone's scoop
- * the first one's sandbox.
- */
-function uniqueFolder(folder: string, all: readonly RegisteredScoop[]): string {
-  const taken = new Set(all.map((s) => s.folder));
-  if (!taken.has(folder)) return folder;
-  // At most one suffix per registered scoop can be taken, so the roster size
-  // plus one always yields a free candidate.
-  for (let n = 2; n <= all.length + 1; n++) {
-    const candidate = `${folder}-${n}`;
-    if (!taken.has(candidate)) return candidate;
-  }
-  return `${folder}-${all.length + 2}`;
 }
 
 /** Validate a thinking level input or return an error result. */
@@ -508,7 +491,10 @@ async function executeScoopScoop(
   // Folder uniqueness is checked against the WHOLE roster, not just the
   // subtree: `/scoops/<folder>/` is one shared VFS path, so two cones each
   // spawning a "helper" must not land in the same sandbox (#2360).
-  const folder = uniqueFolder(wantedFolder, config.getScoops());
+  const folder = uniqueFolder(
+    wantedFolder,
+    config.getScoops().map((s) => s.folder)
+  );
   try {
     const record = buildScoopRecord({
       name,

--- a/packages/webapp/src/scoops/scoop-management-tools.ts
+++ b/packages/webapp/src/scoops/scoop-management-tools.ts
@@ -10,7 +10,7 @@ import type { ScoopModelResolution } from '../providers/account-store.js';
 import type { SudoDecision, SudoKind, SudoRequest } from '../sudo/types.js';
 import type { ToolDefinition } from '../tools/types.js';
 import { defaultChildVisibleRoots, workspaceFor } from '../work-unit/descriptor.js';
-import { derivePolicy, isRootUnit } from '../work-unit/policy.js';
+import { derivePolicy, isRootUnit, subtreeOf } from '../work-unit/policy.js';
 import {
   CURRENT_SCOOP_CONFIG_VERSION,
   isThinkingLevel,
@@ -91,19 +91,41 @@ export interface ScoopManagementToolsConfig {
   }>;
 }
 
+/**
+ * The caller's own subtree: the calling unit plus everything it transitively
+ * owns, in registry order. Every name-based child lookup runs against this
+ * list and nothing else — with several cones on one roster a global match let
+ * cone A's `scoop_wait helper` capture cone B's identically named scoop
+ * (#2360). An unmatched name is an error, never a widening fallback.
+ */
+function callerSubtree(config: ScoopManagementToolsConfig): RegisteredScoop[] {
+  return subtreeOf(config.getScoops(), config.scoop.jid);
+}
+
+/** The caller's transitive children — its subtree minus the caller itself. */
+function ownedScoops(config: ScoopManagementToolsConfig): RegisteredScoop[] {
+  return callerSubtree(config).filter((s) => s.jid !== config.scoop.jid && s.parentJid !== null);
+}
+
+/** Match a user-supplied name (folder or display name) against a roster. */
+function byName(name: string) {
+  return (s: RegisteredScoop): boolean => s.folder === name || s.name === name;
+}
+
 /** Resolve a list of user-supplied scoop names (folder or display name) to
- *  registered scoop records. Returns the resolved scoops plus any unknown
- *  names so the tool can surface a helpful error without bailing out on the
- *  first miss. Cones are rejected — they can't be muted / waited on. */
+ *  registered scoop records the caller owns. Returns the resolved scoops plus
+ *  any unknown names so the tool can surface a helpful error without bailing
+ *  out on the first miss. Scoops outside the caller's subtree — including
+ *  another cone's identically named child — never match. */
 function resolveScoopNames(
   names: readonly string[],
-  getScoops: () => RegisteredScoop[]
+  config: ScoopManagementToolsConfig
 ): { resolved: RegisteredScoop[]; unknown: string[] } {
-  const all = getScoops();
+  const owned = ownedScoops(config);
   const resolved: RegisteredScoop[] = [];
   const unknown: string[] = [];
   for (const name of names) {
-    const s = all.find((x) => x.parentJid !== null && (x.folder === name || x.name === name));
+    const s = owned.find(byName(name));
     if (s) resolved.push(s);
     else unknown.push(name);
   }
@@ -121,6 +143,24 @@ function folderFromDisplayName(name: string): string {
       .replace(/^-+|-+$/g, '')
       .slice(0, 50) + '-scoop'
   );
+}
+
+/**
+ * The first free variant of `folder` across the whole roster: `helper-scoop`,
+ * then `helper-scoop-2`, `helper-scoop-3`… A folder names a real directory
+ * under `/scoops/`, so a collision would silently hand a second cone's scoop
+ * the first one's sandbox.
+ */
+function uniqueFolder(folder: string, all: readonly RegisteredScoop[]): string {
+  const taken = new Set(all.map((s) => s.folder));
+  if (!taken.has(folder)) return folder;
+  // At most one suffix per registered scoop can be taken, so the roster size
+  // plus one always yields a free candidate.
+  for (let n = 2; n <= all.length + 1; n++) {
+    const candidate = `${folder}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return `${folder}-${all.length + 2}`;
 }
 
 /** Validate a thinking level input or return an error result. */
@@ -190,13 +230,16 @@ function parseModelId(
   };
 }
 
-/** Render a "scoop not found" error including the available list. */
-function notFoundError(name: string, getScoops: () => RegisteredScoop[]) {
-  const available = getScoops()
-    .filter((s) => s.parentJid !== null)
+/** Render a "scoop not found" error naming the caller's own subtree — the
+ *  only place a name is looked up (#2360). */
+function notFoundError(name: string, config: ScoopManagementToolsConfig) {
+  const available = ownedScoops(config)
     .map((s) => s.folder)
     .join(', ');
-  return { content: `Scoop "${name}" not found. Available: ${available}`, isError: true as const };
+  return {
+    content: `Scoop "${name}" not found in your scoops (${config.scoop.folder}). Available: ${available || '(none)'}`,
+    isError: true as const,
+  };
 }
 
 /** Format a single line in the list_scoops output. */
@@ -300,12 +343,15 @@ async function executeFeedScoop(
   config: ScoopManagementToolsConfig
 ): Promise<ToolResult> {
   const { scoop_name, prompt } = input as { scoop_name: string; prompt: string };
-  const target = config.getScoops().find((s) => s.folder === scoop_name || s.name === scoop_name);
-  if (!target) return notFoundError(scoop_name, config.getScoops);
-  if (target.jid === config.scoop.jid) return { content: 'Cannot feed yourself.', isError: true };
-  if (target.parentJid === null) {
-    return { content: 'Cannot feed a cone (root unit).', isError: true };
+  // Subtree-scoped: another cone (or another cone's scoop) simply is not
+  // found, rather than being fed across the ownership boundary (#2360).
+  const target = callerSubtree(config).find(byName(scoop_name));
+  // The caller is the only root in its own subtree, so a cone can never be
+  // the target here — a sibling cone is simply not found.
+  if (target?.jid === config.scoop.jid) {
+    return { content: 'Cannot feed yourself.', isError: true };
   }
+  if (!target) return notFoundError(scoop_name, config);
   try {
     await config.onFeedScoop!(target.jid, prompt);
     log.info('Fed scoop', { target: target.folder, promptLength: prompt.length });
@@ -319,7 +365,10 @@ async function executeFeedScoop(
 }
 
 async function executeListScoops(config: ScoopManagementToolsConfig): Promise<ToolResult> {
-  const scoops = config.getScoops();
+  // Your own subtree only: the names this listing offers are exactly the
+  // names feed_scoop / drop_scoop / scoop_wait can resolve (#2360). Listing
+  // a sibling cone's scoops would advertise targets every tool rejects.
+  const scoops = callerSubtree(config);
   if (scoops.length === 0) return { content: 'No scoops registered.' };
   const formatted = scoops.map((s) => formatScoopLine(s, config.getScoopTabState)).join('\n');
   return { content: `Registered scoops:\n${formatted}` };
@@ -445,7 +494,21 @@ async function executeScoopScoop(
   const parsedModel = parseModelId(model, config.resolveModelSelection);
   if (!parsedModel.ok) return { content: parsedModel.content, isError: parsedModel.isError };
 
-  const folder = folderFromDisplayName(name);
+  const wantedFolder = folderFromDisplayName(name);
+
+  const duplicate = ownedScoops(config).find((s) => s.name === name || s.folder === wantedFolder);
+  if (duplicate) {
+    return {
+      content:
+        `A scoop named "${duplicate.name}" (${duplicate.folder}) already exists in your scoops. ` +
+        `Use feed_scoop to give it another task, or drop_scoop first.`,
+      isError: true,
+    };
+  }
+  // Folder uniqueness is checked against the WHOLE roster, not just the
+  // subtree: `/scoops/<folder>/` is one shared VFS path, so two cones each
+  // spawning a "helper" must not land in the same sandbox (#2360).
+  const folder = uniqueFolder(wantedFolder, config.getScoops());
   try {
     const record = buildScoopRecord({
       name,
@@ -479,12 +542,15 @@ async function executeDropScoop(
   config: ScoopManagementToolsConfig
 ): Promise<ToolResult> {
   const { scoop_name } = input as { scoop_name: string };
-  const target = config.getScoops().find((s) => s.folder === scoop_name || s.name === scoop_name);
-  if (!target) return notFoundError(scoop_name, config.getScoops);
-  if (target.jid === config.scoop.jid) return { content: 'Cannot drop yourself.', isError: true };
-  if (target.parentJid === null) {
-    return { content: 'Cannot drop a cone (root unit).', isError: true };
+  // Subtree-scoped for the same reason as feed_scoop: a cone can only drop
+  // what it owns, and a sibling cone's scoop is not found (#2360).
+  const target = callerSubtree(config).find(byName(scoop_name));
+  // The caller is the only root in its own subtree, so a cone can never be
+  // the target here — a sibling cone is simply not found.
+  if (target?.jid === config.scoop.jid) {
+    return { content: 'Cannot drop yourself.', isError: true };
   }
+  if (!target) return notFoundError(scoop_name, config);
   try {
     await config.onDropScoop!(target.jid);
     log.info('Scoop dropped', { name: target.name, folder: target.folder });
@@ -499,9 +565,17 @@ function emptyNamesError(): ToolResult {
   return { content: 'scoop_names must be a non-empty array.', isError: true };
 }
 
-function noMatchingScoopsError(unknownNames: readonly string[]): ToolResult {
+function noMatchingScoopsError(
+  unknownNames: readonly string[],
+  config: ScoopManagementToolsConfig
+): ToolResult {
+  const available = ownedScoops(config)
+    .map((s) => s.folder)
+    .join(', ');
   return {
-    content: `No matching scoops found. Unknown: ${unknownNames.join(', ')}`,
+    content:
+      `No matching scoops found in your scoops (${config.scoop.folder}). ` +
+      `Unknown: ${unknownNames.join(', ')}. Available: ${available || '(none)'}`,
     isError: true,
   };
 }
@@ -512,8 +586,8 @@ async function executeMuteScoops(
 ): Promise<ToolResult> {
   const { scoop_names } = input as { scoop_names: string[] };
   if (!Array.isArray(scoop_names) || scoop_names.length === 0) return emptyNamesError();
-  const { resolved, unknown } = resolveScoopNames(scoop_names, config.getScoops);
-  if (resolved.length === 0) return noMatchingScoopsError(unknown);
+  const { resolved, unknown } = resolveScoopNames(scoop_names, config);
+  if (resolved.length === 0) return noMatchingScoopsError(unknown, config);
   config.onMuteScoops!(resolved.map((s) => s.jid));
   log.info('Scoops muted', { names: resolved.map((s) => s.folder) });
   const muted = resolved.map((s) => s.folder).join(', ');
@@ -550,8 +624,8 @@ async function executeUnmuteScoops(
 ): Promise<ToolResult> {
   const { scoop_names } = input as { scoop_names: string[] };
   if (!Array.isArray(scoop_names) || scoop_names.length === 0) return emptyNamesError();
-  const { resolved, unknown } = resolveScoopNames(scoop_names, config.getScoops);
-  if (resolved.length === 0) return noMatchingScoopsError(unknown);
+  const { resolved, unknown } = resolveScoopNames(scoop_names, config);
+  if (resolved.length === 0) return noMatchingScoopsError(unknown, config);
   const jids = resolved.map((s) => s.jid);
   const jidToFolder = new Map(resolved.map((s) => [s.jid, s.folder]));
   const consumed = await config.onUnmuteScoops!(jids);
@@ -607,8 +681,8 @@ async function executeScoopWait(
   const inputError = validateWaitInput(scoop_names, timeout_ms);
   if (inputError) return inputError;
 
-  const { resolved, unknown } = resolveScoopNames(scoop_names, config.getScoops);
-  if (resolved.length === 0) return noMatchingScoopsError(unknown);
+  const { resolved, unknown } = resolveScoopNames(scoop_names, config);
+  if (resolved.length === 0) return noMatchingScoopsError(unknown, config);
 
   const jids = resolved.map((s) => s.jid);
   // Use the orchestrator's return value to build the acknowledgement: a
@@ -803,7 +877,7 @@ function feedScoopTool(config: ScoopManagementToolsConfig): ToolDefinition {
         scoop_name: {
           type: 'string',
           description:
-            'The scoop folder name (e.g., "test-scoop"). Use list_scoops to see available scoops.',
+            'The scoop folder name (e.g., "test-scoop"). Must be a scoop you own — use list_scoops to see them.',
         },
         prompt: {
           type: 'string',
@@ -820,7 +894,8 @@ function feedScoopTool(config: ScoopManagementToolsConfig): ToolDefinition {
 function listScoopsTool(config: ScoopManagementToolsConfig): ToolDefinition {
   return {
     name: 'list_scoops',
-    description: 'List all registered scoops.',
+    description:
+      'List the scoops you own (your own subtree). Names from this list are the only ones feed_scoop / drop_scoop / scoop_mute / scoop_unmute / scoop_wait can resolve.',
     inputSchema: { type: 'object', properties: {} },
     execute: () => executeListScoops(config),
   };
@@ -892,7 +967,7 @@ function dropScoopTool(config: ScoopManagementToolsConfig): ToolDefinition {
         scoop_name: {
           type: 'string',
           description:
-            'The scoop folder name (e.g., "test-scoop"). Use list_scoops to see available scoops.',
+            'The scoop folder name (e.g., "test-scoop"). Must be a scoop you own — use list_scoops to see them.',
         },
       },
       required: ['scoop_name'],
@@ -954,7 +1029,7 @@ function scoopWaitTool(config: ScoopManagementToolsConfig): ToolDefinition {
           type: 'array',
           items: { type: 'string' },
           description:
-            'Folder or display names of scoops to wait for (e.g., ["writer-scoop", "reviewer-scoop"]).',
+            'Folder or display names of scoops YOU own (e.g., ["writer-scoop", "reviewer-scoop"]). Another cone\'s scoop is not a valid target.',
         },
         timeout_ms: {
           type: 'number',

--- a/packages/webapp/src/transcript/collect.ts
+++ b/packages/webapp/src/transcript/collect.ts
@@ -15,7 +15,7 @@ import { TranscriptExportError } from '@slicc/shared-ts';
 import type { SessionData } from '../core/types.js';
 import type { ChatMessage, Session } from '../scoops/chat-types.js';
 import type { RegisteredScoop } from '../scoops/types.js';
-import { isRootUnit } from '../work-unit/policy.js';
+import { isRootUnit, subtreeOf } from '../work-unit/policy.js';
 import { chatSessionIdFor } from '../work-unit/record.js';
 import type { TranscriptConversationSource } from './normalize.js';
 
@@ -63,28 +63,9 @@ function uiSessionId(scoop: RegisteredScoop): string {
   return chatSessionIdFor(scoop);
 }
 
-/**
- * `rootJid`'s unit plus every unit it transitively owns, in registry order.
- * Empty when the root is no longer registered — the caller decides what an
- * empty scope means rather than silently widening back to everything.
- */
-export function subtreeOf(scoops: readonly RegisteredScoop[], rootJid: string): RegisteredScoop[] {
-  const owned = new Set<string>([rootJid]);
-  // One pass per generation: a child is admitted once its parent is, and the
-  // depth of the ownership tree can never exceed the roster size.
-  for (let pass = 0; pass < scoops.length; pass++) {
-    let grew = false;
-    for (const scoop of scoops) {
-      if (owned.has(scoop.jid)) continue;
-      if (scoop.parentJid !== null && owned.has(scoop.parentJid)) {
-        owned.add(scoop.jid);
-        grew = true;
-      }
-    }
-    if (!grew) break;
-  }
-  return scoops.filter((scoop) => owned.has(scoop.jid));
-}
+// `subtreeOf` lives in `work-unit/policy.ts` (the ownership-tree helpers) and
+// is re-exported here for the transcript callers that already import it.
+export { subtreeOf } from '../work-unit/policy.js';
 
 /**
  * Compute a stable string signature of the current scoop list, processing

--- a/packages/webapp/src/work-unit/policy.ts
+++ b/packages/webapp/src/work-unit/policy.ts
@@ -108,6 +108,34 @@ export function childrenOf<T extends Pick<RegisteredScoop, 'parentJid'>>(
 }
 
 /**
+ * `rootId`'s unit plus every unit it transitively owns, in registry order.
+ * Empty when the root is no longer registered — the caller decides what an
+ * empty scope means rather than silently widening back to everything.
+ */
+export function subtreeOf<T extends Pick<RegisteredScoop, 'jid' | 'parentJid'>>(
+  units: readonly T[],
+  rootId: WorkUnitId
+): T[] {
+  const owned = new Set<string>([rootId]);
+  // One pass per generation: a child is admitted once its parent is, and the
+  // depth of the ownership tree can never exceed the roster size. Order-
+  // independent by construction — the answer does not depend on where a child
+  // sits in the registry relative to its parent.
+  for (let pass = 0; pass < units.length; pass++) {
+    let grew = false;
+    for (const unit of units) {
+      if (owned.has(unit.jid)) continue;
+      if (unit.parentJid !== null && owned.has(unit.parentJid)) {
+        owned.add(unit.jid);
+        grew = true;
+      }
+    }
+    if (!grew) break;
+  }
+  return units.filter((unit) => owned.has(unit.jid));
+}
+
+/**
  * The root that owns `unit` — the unit itself when it is one. Walks the
  * `parentJid` chain; returns `undefined` when the chain dangles (a parent that
  * is no longer registered) or loops, so callers can fall back deliberately

--- a/packages/webapp/src/work-unit/record.ts
+++ b/packages/webapp/src/work-unit/record.ts
@@ -55,6 +55,26 @@ export function normalizeScoopRecord(scoop: RegisteredScoop): RegisteredScoop {
   return scoop;
 }
 
+/**
+ * The first free variant of `folder` across the whole roster: `helper-scoop`,
+ * then `helper-scoop-2`, `helper-scoop-3`… A folder names a real directory
+ * under `/scoops/`, so a collision would silently hand a second cone's child
+ * the first one's sandbox (#2360). Folder uniqueness is deliberately GLOBAL,
+ * not per-subtree — the VFS path is shared even when the owners are not.
+ */
+export function uniqueFolder(folder: string, taken: Iterable<string>): string {
+  const used = new Set(taken);
+  if (!used.has(folder)) return folder;
+  // At most one suffix per taken folder can itself be taken, so `size + 2`
+  // candidates always contain a free one.
+  for (let n = 2; n <= used.size + 2; n++) {
+    const candidate = `${folder}-${n}`;
+    if (!used.has(candidate)) return candidate;
+  }
+  /* c8 ignore next -- unreachable: the loop above exhausts every taken name */
+  return `${folder}-${used.size + 3}`;
+}
+
 /** Folder of the primary root — the one a fresh profile bootstraps. */
 export const PRIMARY_CONE_FOLDER = 'cone';
 

--- a/packages/webapp/tests/scoops/scoop-lifecycle-manager.test.ts
+++ b/packages/webapp/tests/scoops/scoop-lifecycle-manager.test.ts
@@ -233,4 +233,87 @@ describe('ScoopLifecycleManager', () => {
       }),
     ]);
   });
+
+  // #2360 (review follow-up): `scoop_scoop` picks a free folder from the
+  // roster, but two cones creating the same name concurrently would both pass
+  // that check while the first record is still inside `saveScoop`. The claim
+  // therefore happens synchronously inside `register`, before the first await.
+  it('reserves a free folder synchronously so concurrent registrations cannot share a sandbox', async () => {
+    const scoops = new Map<string, RegisteredScoop>([[scoop.jid, scoop]]);
+    let releaseSave: (() => void) | undefined;
+    const saveScoop = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSave = resolve;
+        })
+    );
+    const manager = new ScoopLifecycleManager({
+      getScoops: () => scoops,
+      getSharedFs: () => ({}),
+      getSessionStore: () => null,
+      getProcessManager: () => null,
+      getSudoManager: () => null,
+      getLickManager: () => null,
+      callbacks: { onStatusChange: vi.fn() },
+      db: { saveScoop, deleteScoop: vi.fn(async () => {}) },
+      idleTimers: { start: vi.fn(), clear: vi.fn() },
+      messageRouter: {
+        ensureQueue: vi.fn(),
+        forgetScoop: vi.fn(),
+        flushOnIdle: vi.fn(async () => {}),
+      },
+      costTracker: { snapshot: vi.fn() },
+      approvalRouter: { failScoop: vi.fn(() => 0) },
+      completionService: { forgetScoop: vi.fn(), clearResponse: vi.fn() },
+    } as unknown as ScoopLifecycleDeps);
+
+    const first: RegisteredScoop = { ...worker, jid: 'scoop_a', folder: 'helper-scoop' };
+    // Cone B's identically named scoop, created while `first` is mid-save.
+    const second: RegisteredScoop = {
+      ...worker,
+      jid: 'scoop_b',
+      parentJid: 'cone_b',
+      folder: 'helper-scoop',
+    };
+
+    void manager.register(first).catch(() => {});
+    void manager.register(second).catch(() => {});
+
+    expect(first.folder).toBe('helper-scoop');
+    expect(second.folder).toBe('helper-scoop-2');
+    expect(second.trigger).toBe('@helper-scoop-2');
+    expect(scoops.get('scoop_b')?.folder).toBe('helper-scoop-2');
+    releaseSave?.();
+  });
+
+  it('releases the claimed registry slot when the record cannot be persisted', async () => {
+    const scoops = new Map<string, RegisteredScoop>([[scoop.jid, scoop]]);
+    const manager = new ScoopLifecycleManager({
+      getScoops: () => scoops,
+      getSharedFs: () => ({}),
+      getSessionStore: () => null,
+      getProcessManager: () => null,
+      getSudoManager: () => null,
+      getLickManager: () => null,
+      callbacks: { onStatusChange: vi.fn() },
+      db: {
+        saveScoop: vi.fn(async () => {
+          throw new Error('quota exceeded');
+        }),
+        deleteScoop: vi.fn(async () => {}),
+      },
+      idleTimers: { start: vi.fn(), clear: vi.fn() },
+      messageRouter: {
+        ensureQueue: vi.fn(),
+        forgetScoop: vi.fn(),
+        flushOnIdle: vi.fn(async () => {}),
+      },
+      costTracker: { snapshot: vi.fn() },
+      approvalRouter: { failScoop: vi.fn(() => 0) },
+      completionService: { forgetScoop: vi.fn(), clearResponse: vi.fn() },
+    } as unknown as ScoopLifecycleDeps);
+
+    await expect(manager.register({ ...worker, jid: 'scoop_c' })).rejects.toThrow(/quota exceeded/);
+    expect(scoops.has('scoop_c')).toBe(false);
+  });
 });

--- a/packages/webapp/tests/scoops/scoop-management-tools.test.ts
+++ b/packages/webapp/tests/scoops/scoop-management-tools.test.ts
@@ -956,3 +956,225 @@ describe('scoop_scoop — parentJid propagation from cone', () => {
     expect(created.originToolCallId).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Subtree-scoped name resolution (#2360)
+//
+// With several cones on one roster, name-based child resolution used to match
+// globally: cone A's `scoop_wait helper` could capture cone B's identically
+// named scoop. Every name lookup now runs against the caller's own subtree —
+// the calling unit plus what it transitively owns — and an unmatched name is
+// an error naming that subtree, never a global match.
+// ---------------------------------------------------------------------------
+
+describe('name resolution is scoped to the caller subtree (#2360)', () => {
+  const coneA: RegisteredScoop = {
+    jid: 'cone_a',
+    name: 'Cone A',
+    folder: 'cone',
+    parentJid: null,
+    requiresTrigger: false,
+    assistantLabel: 'sliccy',
+    addedAt: '2026-01-01T00:00:00.000Z',
+  };
+  const coneB: RegisteredScoop = {
+    ...coneA,
+    jid: 'cone_b',
+    name: 'Cone B',
+    folder: 'cone-b',
+    assistantLabel: 'cone-b',
+    addedAt: '2026-01-02T00:00:00.000Z',
+  };
+  const helperA: RegisteredScoop = {
+    jid: 'scoop_helper_a',
+    name: 'helper',
+    folder: 'helper-scoop',
+    parentJid: coneA.jid,
+    requiresTrigger: true,
+    assistantLabel: 'helper-scoop',
+    addedAt: '2026-01-03T00:00:00.000Z',
+  };
+  // Cone B's own `helper`: same display name, distinct folder (folders are
+  // globally unique because they name a real /scoops/<folder>/ directory).
+  const helperB: RegisteredScoop = {
+    ...helperA,
+    jid: 'scoop_helper_b',
+    folder: 'helper-scoop-2',
+    assistantLabel: 'helper-scoop-2',
+    parentJid: coneB.jid,
+  };
+  // A grandchild of cone A — reachable through the transitive parentJid walk.
+  const grandchildA: RegisteredScoop = {
+    ...helperA,
+    jid: 'scoop_deep_a',
+    name: 'deep',
+    folder: 'deep-scoop',
+    assistantLabel: 'deep-scoop',
+    parentJid: helperA.jid,
+  };
+
+  const ROSTER = [coneA, coneB, helperA, helperB, grandchildA];
+  /** Same units, reversed — resolution must not depend on registry order. */
+  const REVERSED = [...ROSTER].reverse();
+
+  function toolsFor(caller: RegisteredScoop, roster: readonly RegisteredScoop[] = ROSTER) {
+    const onScheduleScoopWait = vi.fn((jids: readonly string[]) => ({
+      scheduled: [...jids],
+      unknown: [],
+    }));
+    const onFeedScoop = vi.fn(async () => {});
+    const onDropScoop = vi.fn(async () => {});
+    const onScoopScoop = vi.fn(
+      async (scoop: Omit<RegisteredScoop, 'jid'>): Promise<RegisteredScoop> => ({
+        ...scoop,
+        jid: `scoop_${scoop.folder}_1`,
+      })
+    );
+    const tools = createScoopManagementTools({
+      scoop: caller,
+      onSendMessage: vi.fn(),
+      getScoops: () => [...roster],
+      onScheduleScoopWait,
+      onFeedScoop,
+      onDropScoop,
+      onScoopScoop,
+      onMuteScoops: vi.fn(),
+    });
+    const pick = (name: string) => tools.find((t) => t.name === name)!;
+    return { pick, onScheduleScoopWait, onFeedScoop, onDropScoop, onScoopScoop };
+  }
+
+  it('scoop_wait resolves each cone to its OWN same-named scoop', async () => {
+    const a = toolsFor(coneA);
+    await a.pick('scoop_wait').execute({ scoop_names: ['helper'] });
+    expect(a.onScheduleScoopWait).toHaveBeenCalledWith([helperA.jid], undefined);
+
+    const b = toolsFor(coneB);
+    await b.pick('scoop_wait').execute({ scoop_names: ['helper'] });
+    expect(b.onScheduleScoopWait).toHaveBeenCalledWith([helperB.jid], undefined);
+  });
+
+  it('scoop_wait resolution is registry-order independent', async () => {
+    for (const roster of [ROSTER, REVERSED]) {
+      const b = toolsFor(coneB, roster);
+      await b.pick('scoop_wait').execute({ scoop_names: ['helper'] });
+      expect(b.onScheduleScoopWait).toHaveBeenCalledWith([helperB.jid], undefined);
+    }
+  });
+
+  it('scoop_wait errors on another cone’s scoop folder instead of crossing', async () => {
+    const b = toolsFor(coneB);
+    const result = await b.pick('scoop_wait').execute({ scoop_names: [helperA.folder] });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('cone-b');
+    expect(result.content).toContain(helperA.folder);
+    expect(b.onScheduleScoopWait).not.toHaveBeenCalled();
+  });
+
+  it('scoop_wait reaches a grandchild through the transitive walk', async () => {
+    const a = toolsFor(coneA);
+    await a.pick('scoop_wait').execute({ scoop_names: ['deep-scoop'] });
+    expect(a.onScheduleScoopWait).toHaveBeenCalledWith([grandchildA.jid], undefined);
+
+    const b = toolsFor(coneB);
+    const crossed = await b.pick('scoop_wait').execute({ scoop_names: ['deep-scoop'] });
+    expect(crossed.isError).toBe(true);
+  });
+
+  it('scoop_mute only resolves the caller’s own children', async () => {
+    const onMuteScoops = vi.fn();
+    const tools = createScoopManagementTools({
+      scoop: coneB,
+      onSendMessage: vi.fn(),
+      getScoops: () => [...ROSTER],
+      onMuteScoops,
+    });
+    const result = await tools
+      .find((t) => t.name === 'scoop_mute')!
+      .execute({ scoop_names: [helperA.folder] });
+    expect(result.isError).toBe(true);
+    expect(onMuteScoops).not.toHaveBeenCalled();
+  });
+
+  it('feed_scoop refuses another cone’s scoop and its sibling cone', async () => {
+    const b = toolsFor(coneB);
+    const foreignScoop = await b
+      .pick('feed_scoop')
+      .execute({ scoop_name: helperA.folder, prompt: 'go' });
+    expect(foreignScoop.isError).toBe(true);
+    expect(foreignScoop.content).toContain('not found in your scoops (cone-b)');
+
+    const foreignCone = await b
+      .pick('feed_scoop')
+      .execute({ scoop_name: coneA.folder, prompt: 'go' });
+    expect(foreignCone.isError).toBe(true);
+    expect(b.onFeedScoop).not.toHaveBeenCalled();
+
+    const own = await b.pick('feed_scoop').execute({ scoop_name: 'helper', prompt: 'go' });
+    expect(own.isError).toBeUndefined();
+    expect(b.onFeedScoop).toHaveBeenCalledWith(helperB.jid, 'go');
+  });
+
+  it('feed_scoop still reports self-feeding rather than "not found"', async () => {
+    const a = toolsFor(coneA);
+    const result = await a.pick('feed_scoop').execute({ scoop_name: coneA.folder, prompt: 'go' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Cannot feed yourself.');
+  });
+
+  it('drop_scoop refuses another cone’s scoop and its sibling cone', async () => {
+    const b = toolsFor(coneB);
+    const foreignScoop = await b.pick('drop_scoop').execute({ scoop_name: helperA.folder });
+    expect(foreignScoop.isError).toBe(true);
+    expect(foreignScoop.content).toContain('not found in your scoops (cone-b)');
+
+    const foreignCone = await b.pick('drop_scoop').execute({ scoop_name: coneA.folder });
+    expect(foreignCone.isError).toBe(true);
+    expect(b.onDropScoop).not.toHaveBeenCalled();
+
+    const own = await b.pick('drop_scoop').execute({ scoop_name: helperB.folder });
+    expect(own.isError).toBeUndefined();
+    expect(b.onDropScoop).toHaveBeenCalledWith(helperB.jid);
+  });
+
+  it('drop_scoop still reports self-dropping rather than "not found"', async () => {
+    const a = toolsFor(coneA);
+    const result = await a.pick('drop_scoop').execute({ scoop_name: coneA.folder });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Cannot drop yourself.');
+  });
+
+  it('list_scoops lists only the caller’s subtree', async () => {
+    const b = toolsFor(coneB);
+    const listed = await b.pick('list_scoops').execute({});
+    expect(listed.content).toContain(`(${helperB.folder})`);
+    expect(listed.content).not.toContain(`(${helperA.folder})`);
+    expect(listed.content).not.toContain('deep-scoop');
+
+    const a = toolsFor(coneA);
+    const listedA = await a.pick('list_scoops').execute({});
+    expect(listedA.content).toContain(helperA.folder);
+    expect(listedA.content).toContain('deep-scoop');
+    expect(listedA.content).not.toContain('cone-b');
+  });
+
+  it('scoop_scoop rejects a duplicate name inside the caller’s own subtree', async () => {
+    const a = toolsFor(coneA);
+    const result = await a.pick('scoop_scoop').execute({ name: 'helper' });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('already exists in your scoops');
+    expect(a.onScoopScoop).not.toHaveBeenCalled();
+  });
+
+  it('scoop_scoop allows the same name in another subtree but keeps folders unique', async () => {
+    const roster = [coneA, coneB, helperA];
+    const b = toolsFor(coneB, roster);
+    const result = await b.pick('scoop_scoop').execute({ name: 'helper' });
+    expect(result.isError).toBeUndefined();
+    const created = b.onScoopScoop.mock.calls[0][0] as Omit<RegisteredScoop, 'jid'>;
+    expect(created.name).toBe('helper');
+    expect(created.folder).toBe('helper-scoop-2');
+    expect(created.parentJid).toBe(coneB.jid);
+    expect(result.content).toContain('helper-scoop-2');
+  });
+});

--- a/packages/webapp/tests/work-unit/policy.test.ts
+++ b/packages/webapp/tests/work-unit/policy.test.ts
@@ -8,6 +8,7 @@ import {
   isPolicySubset,
   isRootUnit,
   rootsOf,
+  subtreeOf,
 } from '../../src/work-unit/policy.js';
 import { childRecord, rootRecord, withLegacyRoleFields } from './fixtures.js';
 
@@ -113,5 +114,36 @@ describe('work-unit policy', () => {
     expect(childrenOf(all, a1.jid)).toEqual([]);
     // oldest root first
     expect(rootsOf(all).map((s) => s.jid)).toEqual(['cone_b', 'cone_a']);
+  });
+});
+
+describe('subtreeOf', () => {
+  const coneA = rootRecord({ jid: 'cone_a', folder: 'cone' });
+  const coneB = rootRecord({ jid: 'cone_b', folder: 'cone-b' });
+  const child = childRecord(coneA.jid, { folder: 'helper-scoop' });
+  const grandchild = childRecord(child.jid, { folder: 'deep-scoop' });
+  const sibling = childRecord(coneB.jid, { folder: 'helper-scoop-2' });
+
+  it('returns the unit plus everything it transitively owns', () => {
+    const all = [coneA, coneB, child, grandchild, sibling];
+    expect(subtreeOf(all, coneA.jid).map((u) => u.jid)).toEqual([
+      coneA.jid,
+      child.jid,
+      grandchild.jid,
+    ]);
+    expect(subtreeOf(all, coneB.jid).map((u) => u.jid)).toEqual([coneB.jid, sibling.jid]);
+    expect(subtreeOf(all, child.jid).map((u) => u.jid)).toEqual([child.jid, grandchild.jid]);
+  });
+
+  it('is registry-order independent', () => {
+    const forward = [coneA, coneB, child, grandchild, sibling];
+    const reversed = [...forward].reverse();
+    expect(new Set(subtreeOf(reversed, coneA.jid).map((u) => u.jid))).toEqual(
+      new Set(subtreeOf(forward, coneA.jid).map((u) => u.jid))
+    );
+  });
+
+  it('is empty for an unregistered root rather than widening to everything', () => {
+    expect(subtreeOf([coneA, child], 'gone')).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #2360.

## Bug

`resolveScoopNames` matched scoop names against the **whole roster**, so with several cones on `main` cone A's `scoop_wait helper` could match and wait on cone B's identically named scoop. Completion *delivery* was already grouped per parent (#2262 phase 3); the *matching* was not.

## Fix

Every name-based child lookup reachable from a unit's tools now resolves against `subtreeOf(roster, caller.jid)` — the calling unit plus what it transitively owns (`parentJid` walk). An unmatched name is an error naming the caller's subtree; it never widens to a global match.

- `scoop_wait` / `scoop_mute` / `scoop_unmute` — `resolveScoopNames(names, config)`
- `feed_scoop` / `drop_scoop` — self-feed / self-drop are still reported as such; a sibling cone and its scoops are simply *not found* ("not found in your scoops (`<caller folder>`). Available: …")
- `list_scoops` — lists the caller's subtree, so what it advertises is exactly what the other tools can resolve
- `scoop_scoop` (audit result) — there was **no** name dedup at all, and folder derivation was collision-blind: two cones each spawning "helper" both got `/scoops/helper-scoop/`, i.e. one shared sandbox. Now a duplicate name inside the caller's own subtree is rejected, and the derived folder is suffixed (`helper-scoop-2`) when taken *anywhere* on the roster — folder uniqueness stays global on purpose because `/scoops/<folder>/` is one real VFS path.

A cone waiting on / feeding / dropping another cone's scoop stays unsupported until #2278's supervisor APIs.

`subtreeOf` moves from `transcript/collect.ts` to `work-unit/policy.ts` beside the other ownership-tree helpers (`childrenOf`, `rootOwnerOf`, `rootsOf`), generic over the record shape; `transcript/collect.ts` re-exports it so existing callers are untouched. That avoids a `scoops/ → transcript/ → scoops/` import back-edge.

## Tests

`packages/webapp/tests/scoops/scoop-management-tools.test.ts` — new `#2360` block with two cones, each owning a same-named `helper`, plus a grandchild under cone A:

- each cone's `scoop_wait helper` resolves only its own scoop
- registry-order independence (forward and reversed roster give the same answer, same pattern as `matchLickTargetAlias`)
- a cross-cone folder name errors instead of crossing (`scoop_wait`, `scoop_mute`)
- the transitive walk reaches a grandchild for its owner and nobody else
- `feed_scoop` / `drop_scoop` refuse a sibling cone and its scoops, still succeed on their own, and still say "Cannot feed/drop yourself"
- `list_scoops` shows only the caller's subtree
- `scoop_scoop` rejects a duplicate name in its own subtree; the same name under another cone succeeds with a uniquified folder

`packages/webapp/tests/work-unit/policy.test.ts` — `subtreeOf` at its new home: transitive ownership, order independence, empty (not global) for an unregistered root.

## Docs

`docs/work-unit.md` (Phase 3 detail), `docs/tools-reference.md`, `packages/vfs-root/workspace/skills/delegation/SKILL.md`, and the agent-facing tool descriptions.

## Verification

`verify` · `check-touched-exemptions` (0 debt) · `typecheck` · `test` · `test:coverage:webapp` (stmts 81.59 / branches 72.81 / funcs 81.67 / lines 83.60 — all above floors) · both builds · `bundle-size` (page 730/740, worker 4129/4160, kernel-worker 1595 kB). No UI change, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
