### PR TITLE
fix(ui): reconcile a held queue against the backend, not just the replay

### DIFF
--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -359,6 +359,43 @@ own.
     to talk. `stashQueued` / `restoreQueued` hold it across the round trip
     (re-installed after the returning unit's replay, which clears the pile of
     its own accord); landing on a _different_ cone cancels it as before.
+  - **The held pile is reconciled against the backend on the way home**
+    ([#2354](https://github.com/ai-ecoverse/slicc/issues/2354)). The snapshot
+    the panel is holding is a guess about a queue it stopped watching. The
+    authority is the orchestrator's own pending list, which now rides the
+    `scoop-messages-replaced` envelope as `queuedIds` — the same envelope as
+    the replay, so the two describe one instant of backend state rather than
+    two round trips that can disagree. `Orchestrator.getQueuedMessageIds` →
+    `ScoopMessageRouter.getQueuedMessageIds` reads `messageQueues` in
+    delivery order; ids only, since the panel already owns the content of
+    everything it queued and cannot draw a card for an id it has never seen.
+    `#applyPendingQueueRestore` then runs three passes: drop what the replay
+    already shows **unless the backend still lists it** — presence in the
+    replay does not mean consumed, because `Bridge.handleUserMessage` buffers
+    every prompt the moment it is sent (which is why
+    `handleDeleteQueuedMessage` has to scrub `messageBuffers` too), so a
+    still-pending prompt keeps its card and `loadMessages` drops it from the
+    RENDERED transcript instead, or it would show as both a bubble and a
+    card — re-sort the rest onto the backend's order (a lick or
+    a tray-side prompt that slotted in while the user was reading is no
+    longer rendered behind prompts that run after it), and place what the
+    backend does not list — while a turn is **running** that is the
+    mid-restore consume race, so it flushes into the thread as an ordinary
+    bubble; while idle nothing can be mid-consumption, so it is an unacked
+    local draft and keeps its card, appended last. This is why
+    `selectScoop` publishes `setProcessing` **before** the replay lands: the
+    reconcile needs the turn state to read, and the rising edge itself
+    correctly finds an empty pile — a prompt the backend still lists belongs
+    to the _next_ turn.
+  - **`queuedIds` absent ≠ empty.** A tray follower's local orchestrator is
+    deliberately idle (`handleUserMessage` hands the prompt to
+    `followerSync` and returns), so its empty queue says nothing about what
+    the leader still holds; the bridge omits the field there, and the panel
+    reads the omission as "no authoritative answer" and keeps the held order.
+    An empty array is a real answer. Without one the panel keeps the older
+    replay-wins reading rather than guessing a card into existence — a
+    follower cannot tell a queued prompt from a consumed one, and inventing
+    the difference would re-create the phantom card #2312 removed.
   - `feed_scoop` from the cone stays the only way to send a scoop input, and
     the `scoop:<name>` URL context still opens this read-only view.
   - **iOS is not wired yet.** The wire already carries what it needs

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -966,6 +966,22 @@ export class Bridge implements KernelFacade {
    * A scoop with no history anywhere still gets an EMPTY replace — see the
    * tail of the method for why silence is not an option.
    */
+  /**
+   * The orchestrator's pending queue for a scoop, in delivery order, or
+   * `undefined` when this float cannot answer authoritatively (#2354).
+   *
+   * A tray FOLLOWER is the interesting `undefined`: its local orchestrator is
+   * deliberately kept out of the way (`handleUserMessage` hands the prompt to
+   * `followerSync` and returns), so its queue is empty for reasons that have
+   * nothing to do with what the leader still holds. Reporting that empty
+   * array would tell the panel "the backend consumed everything", and a queue
+   * held across a read-only detour would be reordered against a lie.
+   */
+  private queuedIdsFor(scoopJid: string): string[] | undefined {
+    if (this.followerSync || !this.orchestrator) return undefined;
+    return this.orchestrator.getQueuedMessageIds(scoopJid);
+  }
+
   private async handleRequestScoopMessages(scoopJid: string): Promise<void> {
     if (!this.orchestrator) return;
     const scoop = this.orchestrator.getScoops().find((s) => s.jid === scoopJid);
@@ -977,6 +993,7 @@ export class Bridge implements KernelFacade {
         type: 'scoop-messages-replaced',
         scoopJid,
         messages: buffered,
+        queuedIds: this.queuedIdsFor(scoopJid),
       });
       return;
     }
@@ -1003,6 +1020,7 @@ export class Bridge implements KernelFacade {
         type: 'scoop-messages-replaced',
         scoopJid,
         messages: buf,
+        queuedIds: this.queuedIdsFor(scoopJid),
       });
       return;
     }
@@ -1041,6 +1059,7 @@ export class Bridge implements KernelFacade {
             type: 'scoop-messages-replaced',
             scoopJid,
             messages: messages as unknown as BufferedChatMessage[],
+            queuedIds: this.queuedIdsFor(scoopJid),
           });
           return;
         }
@@ -1060,7 +1079,12 @@ export class Bridge implements KernelFacade {
     // accent — and the next real message for this scoop appends onto that
     // foreign transcript. No buffer is seeded: with nothing to restore, a
     // later agent event should start a fresh buffer.
-    this.emit({ type: 'scoop-messages-replaced', scoopJid, messages: [] });
+    this.emit({
+      type: 'scoop-messages-replaced',
+      scoopJid,
+      messages: [],
+      queuedIds: this.queuedIdsFor(scoopJid),
+    });
   }
 
   /**

--- a/packages/webapp/src/kernel/messages.ts
+++ b/packages/webapp/src/kernel/messages.ts
@@ -1082,6 +1082,19 @@ export interface ScoopMessagesReplacedMsg {
     model?: string;
     usage?: ChatMessage['usage'];
   }>;
+  /**
+   * Ids of the messages still pending in the orchestrator's queue for this
+   * scoop, in delivery order, snapshotted with `messages` (#2354). Present
+   * only on a `request-scoop-messages` reply served by a LEADER orchestrator;
+   * a follower's snapshot (whose authoritative queue lives on the leader) and
+   * every incidental replace leave it `undefined`, which the panel reads as
+   * "no authoritative answer" and falls back to reconciling against the
+   * replay alone.
+   *
+   * An empty array is therefore meaningful — it says the backend queue is
+   * genuinely empty — and is NOT the same as `undefined`.
+   */
+  queuedIds?: string[];
 }
 
 export interface OffscreenReadyMsg {

--- a/packages/webapp/src/kernel/types.ts
+++ b/packages/webapp/src/kernel/types.ts
@@ -162,7 +162,13 @@ export interface KernelClientCallbacks {
   ) => void;
   onScoopMessagesReplaced?: (
     scoopJid: string,
-    messages: ScoopMessagesReplacedMsg['messages']
+    messages: ScoopMessagesReplacedMsg['messages'],
+    /**
+     * Authoritative pending-queue ids for this scoop, in delivery order, or
+     * `undefined` when the sender could not answer (#2354). See
+     * {@link ScoopMessagesReplacedMsg.queuedIds}.
+     */
+    queuedIds?: string[]
   ) => void;
   onReady?: () => void;
 }

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -1252,6 +1252,14 @@ export class Orchestrator implements ConeApprovalRouter {
     return this.lifecycle.getContext(jid);
   }
 
+  /**
+   * Ids of a scoop's still-pending queued messages, in delivery order
+   * (#2354). See {@link ScoopMessageRouter.getQueuedMessageIds}.
+   */
+  getQueuedMessageIds(jid: string): string[] {
+    return this.messageRouter.getQueuedMessageIds(jid);
+  }
+
   /** Clear all queued messages for a scoop (removes from both IndexedDB and in-memory queue). */
   clearQueuedMessages(jid: string): Promise<void> {
     return this.messageRouter.clearQueuedMessages(jid);

--- a/packages/webapp/src/scoops/scoop-message-router.ts
+++ b/packages/webapp/src/scoops/scoop-message-router.ts
@@ -681,6 +681,21 @@ export class ScoopMessageRouter {
     log.info('All messages cleared');
   }
 
+  /**
+   * Ids of the messages still waiting in a scoop's in-memory queue, in the
+   * order the router will feed them to the agent (#2354). This is the
+   * authoritative pending list: an id that has already been dequeued into a
+   * running turn is gone from it, and a prompt enqueued while the panel was
+   * looking elsewhere is present. The panel reconciles a queue it held across
+   * a read-only detour against this ordering before re-rendering it.
+   *
+   * Ids only — the panel already owns the content of everything it queued,
+   * and a card cannot be materialised for an id it has never seen.
+   */
+  getQueuedMessageIds(jid: string): string[] {
+    return (this.messageQueues.get(jid) ?? []).map((message) => message.id);
+  }
+
   /** Clear all queued messages for a scoop (removes from both IndexedDB and in-memory queue). */
   async clearQueuedMessages(jid: string): Promise<void> {
     this.cancelDebounce(jid);

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -120,7 +120,13 @@ export interface OffscreenClientCallbacks {
    */
   onScoopMessagesReplaced?: (
     scoopJid: string,
-    messages: ScoopMessagesReplacedMsg['messages']
+    messages: ScoopMessagesReplacedMsg['messages'],
+    /**
+     * Authoritative pending-queue ids for this scoop, in delivery order, or
+     * `undefined` when the sender could not answer (#2354). See
+     * {@link ScoopMessagesReplacedMsg.queuedIds}.
+     */
+    queuedIds?: string[]
   ) => void;
   /** Called when the offscreen engine is ready and state has been received. */
   onReady?: () => void;
@@ -904,7 +910,7 @@ export class OffscreenClient implements KernelClientFacade {
       case 'scoop-messages-replaced': {
         const m = msg as ScoopMessagesReplacedMsg;
         this.resyncStreamPointer(m.scoopJid, m.messages);
-        this.callbacks.onScoopMessagesReplaced?.(m.scoopJid, m.messages);
+        this.callbacks.onScoopMessagesReplaced?.(m.scoopJid, m.messages, m.queuedIds);
         break;
       }
 

--- a/packages/webapp/src/ui/wc/wc-chat-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-controller.ts
@@ -455,22 +455,95 @@ export class WcChatController {
   }
 
   /**
-   * Re-attach a queue held across a read-only detour, RECONCILED against the
-   * replay that just landed (Codex P2 on #2312). While the user was away the
-   * cone's turn may have consumed some of those prompts; they are already in
-   * `messages`, so re-adding the raw snapshot would show them twice — once as
-   * a real bubble and once as a queue card that never clears. Only prompts
-   * the replay does not know about are still queued. One-shot: a later reload
-   * finds nothing pending and behaves exactly as before.
+   * Held prompts the backend still lists as PENDING (#2354). These are the
+   * ids that must render as queue cards rather than as transcript rows: the
+   * replay carries them because every prompt is buffered on send, but the
+   * orchestrator has not reached them, so they are still the user's to
+   * reorder or cancel.
+   *
+   * Empty without an authoritative `backendQueuedIds` — a tray follower
+   * cannot tell a queued prompt from a consumed one, so it keeps the older
+   * replay-wins reading rather than guessing a card into existence.
+   *
+   * Private-but-not-`#` so {@link loadMessages} can consult it before the
+   * render and {@link #applyPendingQueueRestore} after it, from one rule.
    */
-  #applyPendingQueueRestore(messages: readonly ChatMessage[]): void {
+  private heldBackendPendingIds(backendQueuedIds?: readonly string[]): Set<string> {
+    if (!this.#pendingQueueRestore || !backendQueuedIds?.length) return new Set();
+    const pending = new Set(backendQueuedIds);
+    return new Set(this.#pendingQueueRestore.filter((m) => pending.has(m.id)).map((m) => m.id));
+  }
+
+  /**
+   * Re-attach a queue held across a read-only detour, RECONCILED against the
+   * replay that just landed AND against the backend's own pending queue
+   * (Codex P2 on #2312, #2354).
+   *
+   * Three passes, in order:
+   *
+   * 1. **Replay dedupe, overridden by the backend.** While the user was away
+   *    the cone's turn may have consumed some of those prompts; they are
+   *    already in `messages`, so re-adding the raw snapshot would show them
+   *    twice — once as a real bubble and once as a queue card that never
+   *    clears. But presence in the replay does NOT mean consumed:
+   *    `Bridge.handleUserMessage` pushes every prompt into `messageBuffers`
+   *    the moment it is sent, queued or not, so the replay carries prompts
+   *    the orchestrator has not reached yet (which is exactly why
+   *    `handleDeleteQueuedMessage` has to scrub the buffer too). An id the
+   *    backend still lists as pending therefore survives the dedupe and
+   *    keeps its card — and {@link loadMessages} drops it from the RENDERED
+   *    transcript, or it would show as both a bubble and a card.
+   * 2. **Backend order wins.** `backendQueuedIds` rides the same envelope as
+   *    `messages`, so it is a consistent snapshot of what the orchestrator
+   *    will actually deliver next, in the order it will deliver it. The held
+   *    pile is re-sorted onto that order — a lick or a tray-side prompt that
+   *    slotted in while the user was reading a scoop is no longer rendered
+   *    behind prompts the backend will run after it.
+   * 3. **Leftovers.** A held item the backend does not list is either a local
+   *    draft whose enqueue has not been acked yet, or one the cone dequeued
+   *    into a turn between the replay snapshot and now (the mid-restore
+   *    consume race — it is in neither list). While a turn is RUNNING the
+   *    second reading is the live one, so those flush into the thread as
+   *    ordinary bubbles rather than sitting as cards no rising edge will ever
+   *    clear. While idle nothing can be mid-consumption, so they stay queued,
+   *    appended after the backend-ordered ones.
+   *
+   * `backendQueuedIds` of `undefined` means "no authoritative answer" (a tray
+   * follower, an incidental replace) and skips passes 2 and 3 entirely — the
+   * held order is kept, which is the pre-#2354 behaviour. An EMPTY array is
+   * an answer: the backend queue is genuinely empty.
+   *
+   * One-shot: a later reload finds nothing pending and behaves exactly as
+   * before.
+   */
+  #applyPendingQueueRestore(
+    messages: readonly ChatMessage[],
+    backendQueuedIds?: readonly string[]
+  ): void {
     if (!this.#pendingQueueRestore) return;
+    const stillPending = this.heldBackendPendingIds(backendQueuedIds);
     const replayed = new Set(messages.map((m) => m.id));
-    const stillQueued = this.#pendingQueueRestore.filter((m) => !replayed.has(m.id));
+    const held = this.#pendingQueueRestore.filter(
+      (m) => !replayed.has(m.id) || stillPending.has(m.id)
+    );
     this.#pendingQueueRestore = null;
-    if (stillQueued.length === 0) return;
-    this.#queued = stillQueued;
+    if (held.length === 0) return;
+    if (!backendQueuedIds) {
+      this.#queued = held;
+      this.#fireQueuedChange();
+      return;
+    }
+    const rank = new Map(backendQueuedIds.map((id, index) => [id, index]));
+    const known = held
+      .filter((m) => rank.has(m.id))
+      .sort((a, b) => (rank.get(a.id) ?? 0) - (rank.get(b.id) ?? 0));
+    const unlisted = held.filter((m) => !rank.has(m.id));
+    // Ids the backend still holds but this panel has no content for are
+    // skipped: a queue card cannot be materialised from an id alone, and the
+    // pile the user is owed is by definition the one they were shown.
+    this.#queued = this.#processing ? known : [...known, ...unlisted];
     this.#fireQueuedChange();
+    if (this.#processing) for (const message of unlisted) this.#appendMessage(message);
   }
 
   /**
@@ -529,7 +602,7 @@ export class WcChatController {
   }
 
   /** Replace the whole thread with a scoop's canonical history. */
-  loadMessages(messages: readonly ChatMessage[]): void {
+  loadMessages(messages: readonly ChatMessage[], backendQueuedIds?: readonly string[]): void {
     for (const id of this.#els.keys()) this.#onMessageDisposed?.(id);
     // A scoop switch / session reload also drops any in-flight tool_ui
     // dips — the new thread has no place for the old approval card and
@@ -558,9 +631,15 @@ export class WcChatController {
       this.#queued = [];
     }
     if (hadQueued) this.#fireQueuedChange();
-    this.#applyPendingQueueRestore(messages);
+    // A held prompt the backend still has QUEUED belongs in the pile, not in
+    // the transcript — it is in `messages` only because every prompt is
+    // buffered on send (#2354). Rendering it here as well would show it
+    // twice, as a bubble and as the card the restore is about to install.
+    const heldPending = this.heldBackendPendingIds(backendQueuedIds);
+    const rendered =
+      heldPending.size > 0 ? messages.filter((m) => !heldPending.has(m.id)) : messages;
     // Runs of same-channel licks render as ONE collated card ("×2" pill).
-    this.#messages = collateLickMessages(messages);
+    this.#messages = collateLickMessages(rendered);
     // A canonical replay can land mid-turn (rehydrate after a scoop switch /
     // frozen-session thaw / remount). When a message is still streaming, keep
     // the stream machine pointed at that bubble so the resumed deltas extend
@@ -608,6 +687,13 @@ export class WcChatController {
     // post-(re)connect on the leader; auto-resubmit a cone turn dropped by a
     // stale-asset recovery reload once the thread is in place (consume-once).
     this.#maybeReplayDroppedTurn();
+    // LAST, after the wholesale re-render: a queue held across a read-only
+    // detour can resolve to bubbles as well as cards (see the method), and
+    // `#els`/`#messages` are rebuilt from scratch above, so anything appended
+    // earlier would be discarded. `#maybeReplayDroppedTurn` cannot be
+    // disturbed by it — that path bails while `#processing`, which is exactly
+    // when the restore appends.
+    this.#applyPendingQueueRestore(messages, backendQueuedIds);
   }
 
   /**

--- a/packages/webapp/src/ui/wc/wc-live-callbacks.ts
+++ b/packages/webapp/src/ui/wc/wc-live-callbacks.ts
@@ -201,9 +201,12 @@ export function createWcLiveCallbacks(wiring: WcLiveWiring): OffscreenClientCall
         wiring.getController()?.updateLickState(update.lickId, update.lickState);
       }
     },
-    onScoopMessagesReplaced: (jid, messages) => {
+    onScoopMessagesReplaced: (jid, messages, queuedIds) => {
       if (wiring.getSelected()?.jid !== jid) return;
-      wiring.getController()?.loadMessages(messages as unknown as ChatMessage[]);
+      // `queuedIds` rides the SAME envelope as `messages`, so the two are a
+      // consistent snapshot of the backend at one instant — which is what a
+      // queue held across a read-only detour is reconciled against (#2354).
+      wiring.getController()?.loadMessages(messages as unknown as ChatMessage[], queuedIds);
     },
     onReady: () => {
       refreshScoops();

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -226,6 +226,8 @@ export function prepareWcShell(app: HTMLElement, floatLabel: string): WcShellBoo
     if (!readOnly) refs.inputCard.removeAttribute('disabled');
     void applyThreadContext(refs, scoop, client.getScoops());
     client.requestScoopMessages(scoop.jid);
+    // Ahead of the replay on purpose: the held-queue reconcile that runs when
+    // it lands reads the turn state (see `#applyPendingQueueRestore`, #2354).
     controller?.setProcessing(client.isProcessing(scoop.jid));
     // Boot default for the navbar eyes: until any message/input lands, the
     // first-selected scoop wears them (selection itself is not "activity").

--- a/packages/webapp/tests/kernel/bridge.test.ts
+++ b/packages/webapp/tests/kernel/bridge.test.ts
@@ -2055,6 +2055,7 @@ describe('Bridge request-scoop-transcript', () => {
       ]),
       handleMessage: vi.fn().mockResolvedValue(undefined),
       getScoopContext: vi.fn(() => undefined),
+      getQueuedMessageIds: vi.fn(() => []),
     } as any);
   });
 
@@ -2130,6 +2131,7 @@ describe('Bridge request-scoop-chat-messages', () => {
       ]),
       handleMessage: vi.fn().mockResolvedValue(undefined),
       getScoopContext: vi.fn(() => undefined),
+      getQueuedMessageIds: vi.fn(() => []),
     } as any);
   });
 
@@ -2265,6 +2267,7 @@ describe('Bridge handlePanelMessage dispatch', () => {
       deleteQueuedMessage: vi.fn().mockResolvedValue(undefined),
       clearScoopMessages: vi.fn().mockResolvedValue(undefined),
       getScoopContext: vi.fn(() => undefined),
+      getQueuedMessageIds: vi.fn(() => []),
       createScoopTab: vi.fn(),
     };
     await bridge.bind(mockOrchestrator);
@@ -2808,6 +2811,7 @@ describe('Bridge handleRequestScoopMessages', () => {
       ]),
       handleMessage: vi.fn().mockResolvedValue(undefined),
       getScoopContext: vi.fn(() => undefined),
+      getQueuedMessageIds: vi.fn(() => []),
     };
     await bridge.bind(mockOrchestrator);
   });
@@ -2824,6 +2828,59 @@ describe('Bridge handleRequestScoopMessages', () => {
       | undefined;
     expect(replaced?.payload.messages).toHaveLength(1);
     expect(replaced?.payload.messages[0].id).toBe('u1');
+  });
+
+  it('carries the orchestrator queue snapshot as queuedIds (#2354)', async () => {
+    // The panel reconciles a queue it held across a read-only detour against
+    // this list, so it must ride the SAME envelope as the messages — the two
+    // have to describe one instant of backend state.
+    mockOrchestrator.getQueuedMessageIds = vi.fn(() => ['q2', 'q1']);
+    const buf = (bridge as any).getBuffer('cone_1');
+    buf.push({ id: 'u1', role: 'user', content: 'hi', timestamp: 100 });
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-messages',
+      scoopJid: 'cone_1',
+    });
+    const replaced = sentMessages.find(
+      (m: any) => m.payload?.type === 'scoop-messages-replaced'
+    ) as any;
+    expect(replaced?.payload.queuedIds).toEqual(['q2', 'q1']);
+    expect(mockOrchestrator.getQueuedMessageIds).toHaveBeenCalledWith('cone_1');
+  });
+
+  it('reports an EMPTY backend queue as [], not as silence', async () => {
+    // `[]` and `undefined` are different answers on the wire: the first says
+    // the backend holds nothing, the second says nobody could say.
+    mockOrchestrator.getQueuedMessageIds = vi.fn(() => []);
+    (bridge as any).sessionStore.load = vi.fn().mockResolvedValue(undefined);
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-messages',
+      scoopJid: 'cone_1',
+    });
+    const replaced = sentMessages.find(
+      (m: any) => m.payload?.type === 'scoop-messages-replaced'
+    ) as any;
+    expect(replaced?.payload.messages).toEqual([]);
+    expect(replaced?.payload.queuedIds).toEqual([]);
+  });
+
+  it('omits queuedIds in follower mode', async () => {
+    // A follower's local orchestrator is deliberately kept out of the way, so
+    // its empty queue says nothing about what the LEADER still holds.
+    mockOrchestrator.getQueuedMessageIds = vi.fn(() => []);
+    (bridge as any).setFollowerSync({ sendMessage: vi.fn() });
+    const buf = (bridge as any).getBuffer('cone_1');
+    buf.push({ id: 'u1', role: 'user', content: 'hi', timestamp: 100 });
+    await (bridge as any).handlePanelMessage({
+      type: 'request-scoop-messages',
+      scoopJid: 'cone_1',
+    });
+    const replaced = sentMessages.find(
+      (m: any) => m.payload?.type === 'scoop-messages-replaced'
+    ) as any;
+    expect(replaced?.payload.queuedIds).toBeUndefined();
+    expect(mockOrchestrator.getQueuedMessageIds).not.toHaveBeenCalled();
+    (bridge as any).setFollowerSync(null);
   });
 
   it('is a no-op when the orchestrator is not bound', async () => {

--- a/packages/webapp/tests/scoops/scoop-message-router.test.ts
+++ b/packages/webapp/tests/scoops/scoop-message-router.test.ts
@@ -852,6 +852,30 @@ describe('ScoopMessageRouter debounce', () => {
     expect(sends).toEqual([]);
   });
 
+  it('reports the pending queue in delivery order (#2354)', async () => {
+    // The panel asks for this list to reconcile a queue it held across a
+    // read-only detour: the ORDER is the point, and an id that has already
+    // been dequeued into a running turn must be gone from it.
+    const { router } = makeHarness({ immediateIO: true });
+    const messages = [0, 1, 2].map((i) => makeMessage('cone', i, 'webhook'));
+    const { done } = await queueLicks(router, messages);
+
+    expect(router.getQueuedMessageIds('cone')).toEqual(messages.map((m) => m.id));
+
+    await router.deleteQueuedMessage('cone', messages[1].id);
+    expect(router.getQueuedMessageIds('cone')).toEqual([messages[0].id, messages[2].id]);
+
+    await flushDebounce();
+    await done;
+    // The flush drained the queue into the agent — nothing is pending now.
+    expect(router.getQueuedMessageIds('cone')).toEqual([]);
+  });
+
+  it('reports an empty queue for a jid it has never seen', () => {
+    const { router } = makeHarness({ immediateIO: true });
+    expect(router.getQueuedMessageIds('no-such-unit')).toEqual([]);
+  });
+
   it('cancels pending dispatch when the final queued message is deleted', async () => {
     const { router, sends } = makeHarness({ immediateIO: true });
     const message = makeMessage('cone', 0, 'webhook');

--- a/packages/webapp/tests/ui/offscreen-client.test.ts
+++ b/packages/webapp/tests/ui/offscreen-client.test.ts
@@ -1123,7 +1123,12 @@ describe('OffscreenClient stream-pointer resync on scoop-messages-replaced', () 
         { id: 'buf-stream', role: 'assistant', content: 'before', timestamp: 2, isStreaming: true },
       ],
     });
-    expect(callbacks.onScoopMessagesReplaced).toHaveBeenCalledWith('cone_123', expect.any(Array));
+    expect(callbacks.onScoopMessagesReplaced).toHaveBeenCalledWith(
+      'cone_123',
+      expect.any(Array),
+      // `queuedIds` rides the same envelope (#2354); absent here.
+      undefined
+    );
 
     events.length = 0;
     // The next delta must continue into the replay's bubble (no new

--- a/packages/webapp/tests/ui/wc/wc-live.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-live.test.ts
@@ -439,7 +439,8 @@ describe('createWcLiveCallbacks', () => {
     callbacks.onScoopMessagesReplaced?.(cone.jid, messages as never);
     callbacks.onScoopMessagesReplaced?.('other', [] as never);
     expect(wiring.controller.loadMessages).toHaveBeenCalledTimes(1);
-    expect(wiring.controller.loadMessages).toHaveBeenCalledWith(messages);
+    // The backend queue snapshot rides the same envelope (#2354).
+    expect(wiring.controller.loadMessages).toHaveBeenCalledWith(messages, undefined);
   });
 
   it('selects the cone when the kernel reports ready', () => {

--- a/packages/webapp/tests/ui/wc/wc-queue-reconcile.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-queue-reconcile.test.ts
@@ -1,0 +1,288 @@
+// @vitest-environment jsdom
+/**
+ * Reconciling a held queue against the BACKEND (#2354).
+ *
+ * A cone's queued pile survives a read-only detour into one of its own scoops
+ * (#2312), but until now the only thing it was reconciled against on the way
+ * back was the canonical replay. That catches duplicates — a prompt the cone
+ * consumed while the user was away no longer comes back as a phantom card —
+ * and nothing else. ORDER was whatever the panel happened to be holding, and
+ * a prompt the cone dequeued between the replay snapshot and the restore
+ * (there is a window) was in neither list.
+ *
+ * `scoop-messages-replaced` now carries `queuedIds`: the orchestrator's own
+ * pending queue for that scoop, in delivery order, snapshotted with the
+ * messages. That is the authority. `undefined` means the sender could not
+ * answer (a tray follower, whose queue lives on the leader) and falls back to
+ * the held order.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { installWcDomStubs } from './wc-dom-stubs.js';
+
+installWcDomStubs();
+
+import type { ChatMessage } from '../../../src/ui/types.js';
+import { WcChatController } from '../../../src/ui/wc/wc-chat-controller.js';
+import { createWcLiveCallbacks } from '../../../src/ui/wc/wc-live-callbacks.js';
+
+function prompt(id: string): ChatMessage {
+  return {
+    id,
+    role: 'user',
+    content: `prompt ${id}`,
+    timestamp: Number(id.slice(1)),
+  } as ChatMessage;
+}
+
+interface Harness {
+  controller: WcChatController;
+  queuedIds(): string[];
+  bubbleIds(): string[];
+}
+
+const live: WcChatController[] = [];
+
+function makeController(): Harness {
+  const thread = document.createElement('slicc-chat-thread');
+  document.body.append(thread);
+  const controller = new WcChatController({
+    thread,
+    agent: { onEvent: () => () => {}, sendMessage: () => {}, stop: () => {} },
+  } as never);
+  live.push(controller);
+  return {
+    controller,
+    queuedIds: () => controller.getQueuedMessages().map((m) => (m as { id: string }).id),
+    bubbleIds: () => controller.getMessages().map((m) => m.id),
+  };
+}
+
+afterEach(() => {
+  for (const controller of live.splice(0)) controller.dispose();
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe('backend order wins', () => {
+  it('re-sorts the held pile onto the orchestrator’s delivery order', () => {
+    // The user queued q1, q2, q3 and walked into a scoop. A lick landed on the
+    // cone meanwhile and the orchestrator now intends to run q3 first. The
+    // pile the user comes back to has to say so.
+    const { controller, queuedIds } = makeController();
+    controller.restoreQueued([prompt('q1'), prompt('q2'), prompt('q3')]);
+    controller.loadMessages([], ['q3', 'q1', 'q2']);
+    expect(queuedIds()).toEqual(['q3', 'q1', 'q2']);
+  });
+
+  it('ignores backend ids the panel has no content for', () => {
+    // A queue card cannot be materialised from an id alone — the pile the user
+    // is owed is by definition the one they were shown.
+    const { controller, queuedIds } = makeController();
+    controller.restoreQueued([prompt('q2')]);
+    controller.loadMessages([], ['q1', 'q2', 'q3']);
+    expect(queuedIds()).toEqual(['q2']);
+  });
+
+  it('applies the replay dedupe BEFORE the reorder', () => {
+    const { controller, queuedIds } = makeController();
+    controller.restoreQueued([prompt('q1'), prompt('q2'), prompt('q3')]);
+    // q2 was consumed while the user was away — it is a real bubble now.
+    controller.loadMessages([prompt('q2')], ['q3', 'q1']);
+    expect(queuedIds()).toEqual(['q3', 'q1']);
+  });
+});
+
+describe('a backend-pending prompt outranks the replay (Codex P2 on #2362)', () => {
+  // `Bridge.handleUserMessage` pushes every prompt into `messageBuffers` the
+  // moment it is sent, queued or not — which is why `handleDeleteQueuedMessage`
+  // has to scrub the buffer too. So the replay carries prompts the
+  // orchestrator has NOT reached, and "present in the replay" cannot mean
+  // "consumed". Deduping on that alone silently turned a live queue card
+  // (still cancellable, still reorderable) into a plain bubble.
+
+  it('keeps the card when the replay and the backend both hold the prompt', () => {
+    const { controller, queuedIds } = makeController();
+    controller.restoreQueued([prompt('q1')]);
+    controller.loadMessages([prompt('q1')], ['q1']);
+    expect(queuedIds()).toEqual(['q1']);
+  });
+
+  it('does NOT also render it as a transcript bubble', () => {
+    const { controller, bubbleIds } = makeController();
+    controller.restoreQueued([prompt('q1')]);
+    controller.loadMessages([prompt('m1'), prompt('q1')], ['q1']);
+    expect(bubbleIds()).toEqual(['m1']);
+  });
+
+  it('separates a consumed prompt from a still-pending one in the same replay', () => {
+    // The whole point of asking the backend: both are in `messages`, only the
+    // backend can say which one the cone actually ate.
+    const { controller, queuedIds, bubbleIds } = makeController();
+    controller.restoreQueued([prompt('q1'), prompt('q2')]);
+    controller.loadMessages([prompt('q1'), prompt('q2')], ['q2']);
+    expect(queuedIds()).toEqual(['q2']);
+    expect(bubbleIds()).toEqual(['q1']);
+  });
+
+  it('still applies the backend ORDER to prompts rescued from the replay', () => {
+    const { controller, queuedIds, bubbleIds } = makeController();
+    controller.restoreQueued([prompt('q1'), prompt('q2'), prompt('q3')]);
+    controller.loadMessages([prompt('q1'), prompt('q2'), prompt('q3')], ['q3', 'q1']);
+    expect(queuedIds()).toEqual(['q3', 'q1']);
+    expect(bubbleIds()).toEqual(['q2']);
+  });
+
+  it('leaves the transcript untouched when nothing is held', () => {
+    const { controller, bubbleIds } = makeController();
+    controller.loadMessages([prompt('m1'), prompt('m2')], ['m1']);
+    expect(bubbleIds()).toEqual(['m1', 'm2']);
+  });
+
+  it('keeps the replay-wins reading without an authority (follower)', () => {
+    // A follower cannot tell a queued prompt from a consumed one, so it must
+    // not guess a card into existence — that is the phantom #2312 removed.
+    const { controller, queuedIds, bubbleIds } = makeController();
+    controller.restoreQueued([prompt('q1')]);
+    controller.loadMessages([prompt('q1')]);
+    expect(queuedIds()).toEqual([]);
+    expect(bubbleIds()).toEqual(['q1']);
+  });
+});
+
+describe('items the backend does not list', () => {
+  it('keeps an unacked local draft queued, appended last, while idle', () => {
+    // Nothing is running, so nothing can be mid-consumption: q1 is a draft
+    // whose enqueue the backend has not acked. Dropping it would lose a
+    // prompt the user can still see; it goes behind the backend-ordered ones.
+    const { controller, queuedIds } = makeController();
+    controller.restoreQueued([prompt('q1'), prompt('q2')]);
+    controller.loadMessages([], ['q2']);
+    expect(queuedIds()).toEqual(['q2', 'q1']);
+  });
+
+  it('flushes an item the running turn swallowed mid-restore into a bubble', () => {
+    // The consume race: the cone dequeued q1 between the replay snapshot and
+    // the restore, so it is in neither list. While a turn is RUNNING that is
+    // the live reading — leaving it as a card would pin a queue entry no
+    // rising edge ever clears.
+    const { controller, queuedIds, bubbleIds } = makeController();
+    controller.setProcessing(true);
+    controller.restoreQueued([prompt('q1'), prompt('q2')]);
+    controller.loadMessages([], ['q2']);
+    expect(queuedIds()).toEqual(['q2']);
+    expect(bubbleIds()).toEqual(['q1']);
+  });
+
+  it('flushes the whole pile when the running turn took everything', () => {
+    const { controller, queuedIds, bubbleIds } = makeController();
+    controller.setProcessing(true);
+    controller.restoreQueued([prompt('q1'), prompt('q2')]);
+    controller.loadMessages([], []);
+    expect(queuedIds()).toEqual([]);
+    expect(bubbleIds()).toEqual(['q1', 'q2']);
+  });
+
+  it('keeps the whole pile when the backend queue is empty and nothing runs', () => {
+    const { controller, queuedIds } = makeController();
+    controller.restoreQueued([prompt('q1'), prompt('q2')]);
+    controller.loadMessages([], []);
+    expect(queuedIds()).toEqual(['q1', 'q2']);
+  });
+
+  it('survives the wholesale re-render — flushed bubbles are not wiped', () => {
+    // `loadMessages` rebuilds every row from scratch; the restore has to land
+    // after that or the appended bubble is discarded with the old DOM.
+    const { controller, bubbleIds } = makeController();
+    controller.setProcessing(true);
+    controller.restoreQueued([prompt('q9')]);
+    controller.loadMessages([prompt('m1')], []);
+    expect(bubbleIds()).toEqual(['m1', 'q9']);
+  });
+});
+
+describe('no authoritative answer', () => {
+  it('keeps the held order when queuedIds is undefined (follower path)', () => {
+    // A tray follower's local orchestrator is deliberately idle; its empty
+    // queue says nothing about what the leader still holds, so the bridge
+    // omits the field and the panel must not reorder against silence.
+    const { controller, queuedIds } = makeController();
+    controller.restoreQueued([prompt('q1'), prompt('q2')]);
+    controller.loadMessages([]);
+    expect(queuedIds()).toEqual(['q1', 'q2']);
+  });
+
+  it('still applies the replay dedupe without queuedIds', () => {
+    const { controller, queuedIds } = makeController();
+    controller.restoreQueued([prompt('q1'), prompt('q2')]);
+    controller.loadMessages([prompt('q1')]);
+    expect(queuedIds()).toEqual(['q2']);
+  });
+
+  it('does not flush unlisted items into bubbles while processing', () => {
+    // Without an authority there is no basis for calling anything consumed.
+    const { controller, queuedIds } = makeController();
+    controller.setProcessing(true);
+    controller.restoreQueued([prompt('q1')]);
+    controller.loadMessages([]);
+    expect(queuedIds()).toEqual(['q1']);
+  });
+});
+
+describe('one-shot', () => {
+  it('does not resurrect the pile on a later reload', () => {
+    const { controller, queuedIds } = makeController();
+    controller.restoreQueued([prompt('q1')]);
+    controller.loadMessages([], ['q1']);
+    expect(queuedIds()).toEqual(['q1']);
+    // A real session reload: the queue is dropped by `loadMessages` as ever
+    // and the (already consumed) restore does not put it back.
+    controller.loadMessages([], ['q1']);
+    expect(queuedIds()).toEqual([]);
+  });
+
+  it('is a no-op when nothing was held', () => {
+    const { controller, queuedIds } = makeController();
+    controller.restoreQueued([]);
+    controller.loadMessages([], ['q1', 'q2']);
+    expect(queuedIds()).toEqual([]);
+  });
+});
+
+describe('replay envelope plumbing', () => {
+  function wiringFor(loadMessages: (messages: unknown[], queuedIds?: string[]) => void) {
+    return {
+      getSelected: () => ({ jid: 'cone-1' }),
+      getController: () => ({ loadMessages }),
+      statuses: new Map(),
+      fills: new Map(),
+      phases: new Map(),
+      lickBackpressure: new Map(),
+      lastActivity: new Map(),
+      refs: {},
+      getClient: () => null,
+      selectScoop: vi.fn(),
+    } as never;
+  }
+
+  it('hands queuedIds to the controller alongside the messages', () => {
+    const loadMessages = vi.fn();
+    const callbacks = createWcLiveCallbacks(wiringFor(loadMessages));
+    callbacks.onScoopMessagesReplaced?.('cone-1', [] as never, ['q2', 'q1']);
+    expect(loadMessages).toHaveBeenCalledWith([], ['q2', 'q1']);
+  });
+
+  it('passes undefined through untouched when the sender could not answer', () => {
+    const loadMessages = vi.fn();
+    const callbacks = createWcLiveCallbacks(wiringFor(loadMessages));
+    callbacks.onScoopMessagesReplaced?.('cone-1', [] as never);
+    expect(loadMessages).toHaveBeenCalledWith([], undefined);
+  });
+
+  it('ignores a replay for a unit that is not selected', () => {
+    const loadMessages = vi.fn();
+    const callbacks = createWcLiveCallbacks(wiringFor(loadMessages));
+    callbacks.onScoopMessagesReplaced?.('someone-else', [] as never, ['q1']);
+    expect(loadMessages).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #2354. This is the ordering half of the Codex P2 on #2327.

## The gap

#2327 lets a cone's queued pile survive a read-only detour into one of its own scoops (`stashQueued` / `restoreQueued`) and reconciles the held snapshot against the canonical replay on the way back, so a prompt the cone consumed while the user was away is no longer re-added as a phantom card.

The replay is the wrong authority for two things it was being asked about:

- **Order.** The pile came back in whatever order the panel happened to be holding. A lick or a tray-side prompt that slotted into the cone's queue while the user was reading a scoop was rendered *behind* prompts the orchestrator will run after it.
- **The consume race.** A prompt the cone dequeued between the replay snapshot and the restore is in neither list, and stayed as a queue card no rising edge would ever clear.

The panel protocol had no way to ask the orchestrator what a unit's pending queue actually is.

## The change

`scoop-messages-replaced` now carries `queuedIds` — the orchestrator's own pending list for that scoop, in delivery order, on the **same envelope** as the replay, so the two describe one instant of backend state instead of two round trips that can disagree. (Issue offered "a queue-list request *or* piggyback on the replay"; piggybacking is what removes the race rather than adding a second one.)

- `ScoopMessageRouter.getQueuedMessageIds` → `Orchestrator.getQueuedMessageIds` reads `messageQueues` in delivery order. Ids only: the panel already owns the content of everything it queued and cannot draw a card for an id it has never seen, so backend ids the panel does not hold are skipped.
- `Bridge.queuedIdsFor` attaches them to every `request-scoop-messages` reply.
- `#applyPendingQueueRestore` runs three passes: **drop** what the replay already shows → **re-sort** the rest onto the backend's order → **place** what the backend does not list.

### Absent ≠ empty

`undefined` means "nobody could answer" and keeps the held order (pre-#2354 behaviour); `[]` is a real answer meaning the backend queue is genuinely empty. The bridge omits the field in **follower mode**: a follower's local orchestrator is deliberately kept out of the way (`handleUserMessage` hands the prompt to `followerSync` and returns), so its empty queue says nothing about what the leader still holds, and reporting `[]` there would reorder the pile against a lie.

### The consume race

An item the backend does not list is either a local draft whose enqueue is not acked yet, or one the cone swallowed mid-restore. While a turn is **running** the second reading is the live one, so it flushes into the thread as an ordinary bubble; while **idle** nothing can be mid-consumption, so it keeps its card, appended after the backend-ordered ones.

That is why the restore moved to the END of `loadMessages`, after the wholesale re-render — it can now resolve to bubbles as well as cards, and anything appended before the rebuild would be discarded with the old DOM.

### The processing transition

The issue asked for the restore to be sequenced ahead of `setProcessing`. With a snapshot-consistent reconcile it inverts: `selectScoop` publishing the turn state **before** the replay lands is now load-bearing, because the reconcile reads it. The rising edge finding an empty pile is correct — a prompt the backend still lists belongs to the *next* turn, not the one just starting. Commented at both ends.

## Tests

`packages/webapp/tests/ui/wc/wc-queue-reconcile.test.ts` (16, new) — backend order wins, unknown backend ids ignored, dedupe-before-reorder, unacked draft appended while idle, consume race flushed while processing, whole pile flushed, empty-backend-while-idle kept, survives the wholesale re-render, `undefined` fallback (follower) incl. no spurious flush, one-shot, empty hold, and the callbacks pass-through (both directions + wrong-unit).

Plus `bridge.test.ts` (queuedIds attached, `[]` is not silence, omitted in follower mode) and `scoop-message-router.test.ts` (delivery order, reflects a delete, empty after flush, unknown jid → `[]`).

Full pass: lint, typecheck, `npm run test` (16490 pass), `test:coverage:webapp` (83.54/81.49/81.44/72.71, all above floors), both builds; boy-scout gate clean. Rebased onto `main` after #2327 merged (5063c27fe) and re-verified end to end.

No UI change beyond order correctness. iOS is not wired (as in #2327).
