### PR TITLE
Wire floatbar status beacon (connection × float kind × tray role)

### DIFF
--- a/packages/webapp/src/ui/wc/wc-extension.ts
+++ b/packages/webapp/src/ui/wc/wc-extension.ts
@@ -9,6 +9,8 @@
 import type { BootStageLogger } from '../boot/types.js';
 import { OffscreenClient } from '../offscreen-client.js';
 import { wireWcDetached } from './wc-detached.js';
+import { floatLabelForKind } from './wc-float-label.js';
+import { installFloatbarStatus } from './wc-floatbar-online.js';
 import { attachWcClient, prepareWcShell } from './wc-live.js';
 import { createWcLiveCallbacks } from './wc-live-callbacks.js';
 
@@ -17,7 +19,9 @@ export async function mountWcUiExtension(
   log: BootStageLogger,
   isDetached = false
 ): Promise<void> {
-  const boot = prepareWcShell(app, 'extension · wc');
+  const floatKind = 'extension';
+  const boot = prepareWcShell(app, floatLabelForKind(floatKind));
+  installFloatbarStatus(boot.refs.floatbar, { floatKind });
   const client = new OffscreenClient(createWcLiveCallbacks(boot.wiring));
   // Shared attach wiring applies session stats (rate + scoped costs) in this float too.
   attachWcClient(boot, client, log);

--- a/packages/webapp/src/ui/wc/wc-float-label.ts
+++ b/packages/webapp/src/ui/wc/wc-float-label.ts
@@ -14,9 +14,6 @@ const FLOAT_KIND_BY_SERVICE: Record<string, FloatbarFloatKind> = {
   'slicc-node-server': 'npx',
 };
 
-/** @deprecated Use {@link resolveStandaloneFloatKind} + {@link floatLabelForKind}. */
-export const DEFAULT_STANDALONE_LABEL = 'standalone';
-
 export function floatLabelForKind(kind: FloatbarFloatKind): string {
   return floatKindLabel(kind);
 }
@@ -60,13 +57,4 @@ export async function resolveStandaloneFloatKind(opts?: {
   } catch {
     return 'standalone';
   }
-}
-
-/** @deprecated Use {@link resolveStandaloneFloatKind} + {@link floatLabelForKind}. */
-export async function resolveStandaloneFloatLabel(opts?: {
-  fetchFn?: typeof fetch;
-  timeoutMs?: number;
-}): Promise<string> {
-  const kind = await resolveStandaloneFloatKind(opts);
-  return floatLabelForKind(kind);
 }

--- a/packages/webapp/src/ui/wc/wc-float-label.ts
+++ b/packages/webapp/src/ui/wc/wc-float-label.ts
@@ -1,25 +1,48 @@
 /**
- * Standalone float fingerprinting for the floatbar label: "standalone" hides
- * which runtime actually serves the page, so ask the server. Both local
- * servers expose `/api/status` whose `service` field names them —
- * `slicc-server` is the native Hummingbird server Sliccstart (mac) launches,
- * `slicc-node-server` is the Node CLI (`npx slicc` / `npm run dev`).
- * Unknown/unreachable keeps the generic label (cherry iframes, old servers).
+ * Float fingerprinting for the floatbar: which runtime serves this page.
+ * Standalone hides the answer behind `/api/status` (`slicc-server` →
+ * sliccstart, `slicc-node-server` → npx). Unknown/unreachable → standalone.
  */
 
+import type { FloatbarFloatKind } from '@slicc/webcomponents';
+import { floatKindLabel } from '@slicc/webcomponents';
 import { apiHeaders, resolveApiUrl } from '../../shell/proxied-fetch.js';
+import type { UiRuntimeMode } from '../runtime-mode.js';
 
-const FLOAT_BY_SERVICE: Record<string, string> = {
+const FLOAT_KIND_BY_SERVICE: Record<string, FloatbarFloatKind> = {
   'slicc-server': 'sliccstart',
   'slicc-node-server': 'npx',
 };
 
-export const DEFAULT_STANDALONE_LABEL = 'standalone · live';
+/** @deprecated Use {@link resolveStandaloneFloatKind} + {@link floatLabelForKind}. */
+export const DEFAULT_STANDALONE_LABEL = 'standalone';
 
-export async function resolveStandaloneFloatLabel(opts?: {
+export function floatLabelForKind(kind: FloatbarFloatKind): string {
+  return floatKindLabel(kind);
+}
+
+export function floatKindForRuntimeMode(mode: UiRuntimeMode): FloatbarFloatKind {
+  switch (mode) {
+    case 'extension':
+    case 'extension-detached':
+      return 'extension';
+    case 'cherry':
+      return 'cherry';
+    case 'hosted-leader':
+      return 'hosted';
+    case 'electron-overlay':
+      return 'electron';
+    case 'follower':
+      return 'standalone';
+    default:
+      return 'standalone';
+  }
+}
+
+export async function resolveStandaloneFloatKind(opts?: {
   fetchFn?: typeof fetch;
   timeoutMs?: number;
-}): Promise<string> {
+}): Promise<FloatbarFloatKind> {
   const fetchFn = opts?.fetchFn ?? fetch;
   const timeoutMs = opts?.timeoutMs ?? 1500;
   try {
@@ -30,11 +53,20 @@ export async function resolveStandaloneFloatLabel(opts?: {
       signal: ctrl.signal,
       headers: apiHeaders(),
     }).finally(() => clearTimeout(timer));
-    if (!res.ok) return DEFAULT_STANDALONE_LABEL;
+    if (!res.ok) return 'standalone';
     const body = (await res.json()) as { service?: string };
-    const float = body.service ? FLOAT_BY_SERVICE[body.service] : undefined;
-    return float ? `${float} · live` : DEFAULT_STANDALONE_LABEL;
+    const kind = body.service ? FLOAT_KIND_BY_SERVICE[body.service] : undefined;
+    return kind ?? 'standalone';
   } catch {
-    return DEFAULT_STANDALONE_LABEL;
+    return 'standalone';
   }
+}
+
+/** @deprecated Use {@link resolveStandaloneFloatKind} + {@link floatLabelForKind}. */
+export async function resolveStandaloneFloatLabel(opts?: {
+  fetchFn?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<string> {
+  const kind = await resolveStandaloneFloatKind(opts);
+  return floatLabelForKind(kind);
 }

--- a/packages/webapp/src/ui/wc/wc-floatbar-online.ts
+++ b/packages/webapp/src/ui/wc/wc-floatbar-online.ts
@@ -1,24 +1,17 @@
 /**
- * `wc-floatbar-online.ts` — the single producer for `slicc-floatbar`'s
- * `online` attribute (#1707: the component API existed, storybook exercised
- * it, and nothing in the app ever drove it — the dot never lit and the pill
- * tooltip always read "offline").
+ * `wc-floatbar-online.ts` — drives `<slicc-floatbar>` status beacon attributes
+ * from tray runtime statuses and the serving float kind.
  *
- * Semantics: the dot means "this float has a live tray link" — it is lit
- * while this page is LEADING a tray (reachable by followers) or FOLLOWING
- * one (connected to a leader). A purely local float with no tray shows no
- * dot, which is truthful: nothing is linked to it.
+ * Three orthogonal channels (see `floatbar-status.ts` in webcomponents):
+ *  - `connection` — tray link health (ring color)
+ *  - `float-kind` — npx / extension / … (center icon)
+ *  - `tray-role` — leader / follower (corner pip)
  *
- * A leader stall (`stalled` overlay) deliberately keeps the dot lit: the
- * data channel is open and recovers on its own — a stalled follower is
- * still `connected` (see `tray-follower-status.ts`).
- *
- * Every mount installs the same helper: the no-kernel follower
- * (`wc-follower.ts`) and the kernel float (`wc-tray.ts`, which handles both
- * roles). In each float the inactive role's status simply stays `inactive`,
- * so one OR across both statuses is correct everywhere.
+ * Follower count stays in the pill's followers segment; the label names only
+ * the float kind.
  */
 
+import type { FloatbarConnection, FloatbarFloatKind } from '@slicc/webcomponents';
 import {
   type FollowerTrayRuntimeStatus,
   getFollowerTrayRuntimeStatus,
@@ -29,24 +22,47 @@ import {
   type LeaderTrayRuntimeStatus,
   subscribeToLeaderTrayRuntimeStatus,
 } from '../../scoops/tray-leader.js';
+import { floatLabelForKind } from './wc-float-label.js';
+
+export interface InstallFloatbarStatusOptions {
+  floatKind: FloatbarFloatKind;
+  /** Pill label; defaults to the float kind name. */
+  label?: string;
+}
 
 /**
- * Drive `floatbar`'s `online` attribute from the tray runtime statuses.
- * Seeds the current state immediately and updates on every transition.
- * Returns an uninstall function that stops both subscriptions.
+ * Drive floatbar status attrs from tray runtime statuses. Seeds immediately and
+ * updates on every leader/follower transition. Returns an uninstall function.
  */
-export function installFloatbarOnline(floatbar: HTMLElement): () => void {
-  let leaderOnline = isLeaderOnline(getLeaderTrayRuntimeStatus());
-  let followerOnline = isFollowerOnline(getFollowerTrayRuntimeStatus());
+export function installFloatbarStatus(
+  floatbar: HTMLElement,
+  options: InstallFloatbarStatusOptions
+): () => void {
+  const label = options.label ?? floatLabelForKind(options.floatKind);
+  floatbar.setAttribute('label', label);
+  floatbar.setAttribute('float-kind', options.floatKind);
+
+  let leader = getLeaderTrayRuntimeStatus();
+  let follower = getFollowerTrayRuntimeStatus();
+
   const apply = (): void => {
-    floatbar.toggleAttribute('online', leaderOnline || followerOnline);
+    const merged = mergeTrayStatus(leader, follower);
+    floatbar.setAttribute('connection', merged.connection);
+    if (merged.trayRole === 'none') floatbar.removeAttribute('tray-role');
+    else floatbar.setAttribute('tray-role', merged.trayRole);
+    // Legacy boolean for callers/tests that still read `online`.
+    floatbar.toggleAttribute(
+      'online',
+      merged.connection === 'live' || merged.connection === 'stalled'
+    );
   };
+
   const unsubscribeLeader = subscribeToLeaderTrayRuntimeStatus((status) => {
-    leaderOnline = isLeaderOnline(status);
+    leader = status;
     apply();
   });
   const unsubscribeFollower = subscribeToFollowerTrayRuntimeStatus((status) => {
-    followerOnline = isFollowerOnline(status);
+    follower = status;
     apply();
   });
   apply();
@@ -56,10 +72,57 @@ export function installFloatbarOnline(floatbar: HTMLElement): () => void {
   };
 }
 
-function isLeaderOnline(status: LeaderTrayRuntimeStatus): boolean {
-  return status.state === 'leader';
+/** @deprecated Prefer {@link installFloatbarStatus} with an explicit float kind. */
+export function installFloatbarOnline(floatbar: HTMLElement): () => void {
+  return installFloatbarStatus(floatbar, { floatKind: 'standalone' });
 }
 
-function isFollowerOnline(status: FollowerTrayRuntimeStatus): boolean {
-  return status.state === 'connected';
+export function mergeTrayStatus(
+  leader: LeaderTrayRuntimeStatus,
+  follower: FollowerTrayRuntimeStatus
+): { connection: FloatbarConnection; trayRole: 'none' | 'leader' | 'follower' } {
+  if (leader.state !== 'inactive') {
+    return {
+      connection: mapLeaderConnection(leader),
+      trayRole: 'leader',
+    };
+  }
+  if (follower.state !== 'inactive') {
+    return {
+      connection: mapFollowerConnection(follower),
+      trayRole: 'follower',
+    };
+  }
+  return { connection: 'offline', trayRole: 'none' };
+}
+
+function mapLeaderConnection(status: LeaderTrayRuntimeStatus): FloatbarConnection {
+  switch (status.state) {
+    case 'connecting':
+      return 'connecting';
+    case 'leader':
+      return 'live';
+    case 'reconnecting':
+      return 'reconnecting';
+    case 'error':
+      return 'error';
+    default:
+      return 'offline';
+  }
+}
+
+function mapFollowerConnection(status: FollowerTrayRuntimeStatus): FloatbarConnection {
+  if (status.stalled) return 'stalled';
+  switch (status.state) {
+    case 'connecting':
+      return 'connecting';
+    case 'connected':
+      return 'live';
+    case 'reconnecting':
+      return 'reconnecting';
+    case 'error':
+      return 'error';
+    default:
+      return 'offline';
+  }
 }

--- a/packages/webapp/src/ui/wc/wc-floatbar-online.ts
+++ b/packages/webapp/src/ui/wc/wc-floatbar-online.ts
@@ -50,11 +50,6 @@ export function installFloatbarStatus(
     floatbar.setAttribute('connection', merged.connection);
     if (merged.trayRole === 'none') floatbar.removeAttribute('tray-role');
     else floatbar.setAttribute('tray-role', merged.trayRole);
-    // Legacy boolean for callers/tests that still read `online`.
-    floatbar.toggleAttribute(
-      'online',
-      merged.connection === 'live' || merged.connection === 'stalled'
-    );
   };
 
   const unsubscribeLeader = subscribeToLeaderTrayRuntimeStatus((status) => {
@@ -70,11 +65,6 @@ export function installFloatbarStatus(
     unsubscribeLeader();
     unsubscribeFollower();
   };
-}
-
-/** @deprecated Prefer {@link installFloatbarStatus} with an explicit float kind. */
-export function installFloatbarOnline(floatbar: HTMLElement): () => void {
-  return installFloatbarStatus(floatbar, { floatKind: 'standalone' });
 }
 
 export function mergeTrayStatus(

--- a/packages/webapp/src/ui/wc/wc-follower.ts
+++ b/packages/webapp/src/ui/wc/wc-follower.ts
@@ -21,7 +21,8 @@ import { applyCherryTheme } from '../theme-engine.js';
 import type { AgentHandle } from '../types.js';
 import { wireWcAttach } from './wc-attach.js';
 import { WcChatController } from './wc-chat-controller.js';
-import { installFloatbarOnline } from './wc-floatbar-online.js';
+import { floatLabelForKind } from './wc-float-label.js';
+import { installFloatbarStatus } from './wc-floatbar-online.js';
 import { wireWcFollowerBrowser } from './wc-follower-browser.js';
 import { createFollowerModelSurface } from './wc-follower-model-surface.js';
 import { openDelegatedOAuthPopup } from './wc-follower-oauth.js';
@@ -343,7 +344,8 @@ export async function mountWcUiFollower(
 
   // Reuse the WC shell frame WITHOUT a client (never call boot.setClient /
   // attachWcClient - those require an OffscreenClient + spawn the worker).
-  const boot = prepareWcShell(app, isCherry ? 'cherry · follower' : 'follower');
+  const floatKind = isCherry ? 'cherry' : isExtensionSidePanel ? 'extension' : 'standalone';
+  const boot = prepareWcShell(app, floatLabelForKind(floatKind));
 
   // Apply host-supplied theme AFTER the shell mounts — mountWcShell's
   // ensureSystemTheme() sets body data-theme from OS preference, so we must
@@ -568,11 +570,8 @@ export async function mountWcUiFollower(
   };
   setComposerState(false, CONNECTING);
 
-  // Drive the floatbar's `online` dot from the tray statuses (#1707) — the
-  // no-kernel follower's install point; the kernel float installs the same
-  // helper in `wc-tray.ts`. Before this, the API existed but had no producer:
-  // the dot never lit and the pill tooltip read "offline" mid-stream.
-  installFloatbarOnline(boot.refs.floatbar);
+  // Drive the floatbar status beacon from tray runtime statuses.
+  installFloatbarStatus(boot.refs.floatbar, { floatKind });
 
   // Mirror the follower tray status into `localStorage`, matching what
   // `wc-tray.ts` does for the kernel-backed floats. Without this the

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -357,8 +357,7 @@ export interface AttachWcClientOptions {
     browser: BrowserAPI;
     realCdpTransport: CDPTransport;
     runtimeMode: UiRuntimeMode;
-    /** Resolved floatbar base label (`sliccstart · live` / `npx · live`). */
-    baseFloatLabel?: string;
+    floatKind: import('@slicc/webcomponents').FloatbarFloatKind;
   };
 }
 
@@ -1057,7 +1056,6 @@ export function attachWcClient(
           agentHandle,
           openFs: openReader,
           openWriter: async () => (await openVfs()).writer,
-          baseFloatLabel: options.standalone.baseFloatLabel,
           window,
           log,
         });
@@ -1203,17 +1201,19 @@ export async function mountWcUiLive(
     log,
   });
 
-  // The floatbar names the serving runtime, not just "standalone": the
-  // native Sliccstart server vs the Node CLI, fingerprinted via /api/status.
-  const { resolveStandaloneFloatLabel, DEFAULT_STANDALONE_LABEL } = await import(
+  // Floatbar names the serving runtime (npx / sliccstart / hosted / …).
+  const { floatKindForRuntimeMode, floatLabelForKind, resolveStandaloneFloatKind } = await import(
     './wc-float-label.js'
   );
-  const floatLabel =
+  const { installFloatbarStatus } = await import('./wc-floatbar-online.js');
+  const floatKind =
     runtimeMode === 'standalone' || runtimeMode === 'electron-overlay'
-      ? await resolveStandaloneFloatLabel()
-      : DEFAULT_STANDALONE_LABEL;
+      ? await resolveStandaloneFloatKind()
+      : floatKindForRuntimeMode(runtimeMode);
+  const floatLabel = floatLabelForKind(floatKind);
 
   const boot = prepareWcShell(app, floatLabel);
+  installFloatbarStatus(boot.refs.floatbar, { floatKind, label: floatLabel });
   // #1330: install the reload listener BEFORE spawning — BroadcastChannel doesn't
   // buffer and the worker posts init synchronously, so a late listener would miss
   // a fast boot-time failure.
@@ -1246,7 +1246,7 @@ export async function mountWcUiLive(
       browser,
       realCdpTransport,
       runtimeMode,
-      baseFloatLabel: floatLabel,
+      floatKind,
     },
   });
 

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -1207,7 +1207,7 @@ export async function mountWcUiLive(
   );
   const { installFloatbarStatus } = await import('./wc-floatbar-online.js');
   const floatKind =
-    runtimeMode === 'standalone' || runtimeMode === 'electron-overlay'
+    runtimeMode === 'standalone'
       ? await resolveStandaloneFloatKind()
       : floatKindForRuntimeMode(runtimeMode);
   const floatLabel = floatLabelForKind(floatKind);

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -90,7 +90,6 @@ import {
   type LeaderRunNewSessionDetail,
 } from './leader-session-events.js';
 import type { WcChatController } from './wc-chat-controller.js';
-import { installFloatbarOnline } from './wc-floatbar-online.js';
 import { createFollowerModelSurface } from './wc-follower-model-surface.js';
 import { openDelegatedOAuthPopup } from './wc-follower-oauth.js';
 import { getLeaderPermissionsSurface } from './wc-permissions-registry.js';
@@ -114,8 +113,6 @@ export interface WcTrayDeps {
   agentHandle: AgentHandle;
   openFs(): Promise<import('../../kernel/local-vfs-client.js').LocalVfsClient>;
   openWriter(): Promise<import('../../kernel/writable-vfs-client.js').WritableVfsClient>;
-  /** Floatbar label to restore when the last follower leaves. */
-  baseFloatLabel?: string;
   window: Window;
   log: BootStageLogger;
 }
@@ -396,15 +393,8 @@ function applyFollowerPresentation(
     state.persistenceGuard.deactivate();
   }
   // The count used to be smuggled into the label string; it now has its own
-  // hoverable/clickable segment, so the label goes back to naming the float.
-  deps.refs.floatbar.setAttribute(
-    'label',
-    count > 0 ? 'tray · live' : (deps.baseFloatLabel ?? 'standalone · live')
-  );
-  // A peer still handshaking is mirrored to the shim and shown in the Monitor,
-  // but it is NOT counted by the registry — so it must not appear in the pill
-  // either, or the segment would contradict its own count. Anything without an
-  // explicit `connecting` state stays visible.
+  // hoverable/clickable segment — the label names the float kind only
+  // (see installFloatbarStatus in wc-floatbar-online.ts).
   (deps.refs.floatbar as SliccFloatbar).followers = toFollowerHudRows(
     followers.filter((follower) => follower.peerState !== 'connecting')
   );
@@ -1018,11 +1008,6 @@ export async function wireWcTray(deps: WcTrayDeps): Promise<WcTrayHandle> {
   });
 
   startInitialRole(deps, state, leaderOptions, wireLeaderHooks, lockManager);
-
-  // Drive the floatbar's `online` dot from the tray statuses (#1707). This is
-  // the kernel float's install point (covers both roles); the no-kernel
-  // follower mount installs the same helper in `wc-follower.ts`.
-  installFloatbarOnline(deps.refs.floatbar);
 
   subscribeToLeaderTrayRuntimeStatus((status) => {
     win.localStorage.setItem('slicc.leaderTrayStatus', JSON.stringify(status));

--- a/packages/webapp/tests/ui/wc/wc-float-label.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-float-label.test.ts
@@ -8,6 +8,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { setBridgeToken, setLocalApiBaseUrl } from '../../../src/shell/proxied-fetch.js';
 import {
+  floatKindForRuntimeMode,
   floatLabelForKind,
   resolveStandaloneFloatKind,
   resolveStandaloneFloatLabel,
@@ -41,6 +42,12 @@ describe('resolveStandaloneFloatKind', () => {
     await expect(
       resolveStandaloneFloatKind({ fetchFn: okJson({ status: 'ok', service: 'mystery' }) })
     ).resolves.toBe('standalone');
+  });
+});
+
+describe('floatKindForRuntimeMode', () => {
+  it('maps electron-overlay to electron without server fingerprinting', () => {
+    expect(floatKindForRuntimeMode('electron-overlay')).toBe('electron');
   });
 });
 

--- a/packages/webapp/tests/ui/wc/wc-float-label.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-float-label.test.ts
@@ -2,13 +2,14 @@
 /**
  * Floatbar runtime fingerprinting: /api/status names the serving runtime —
  * the native Sliccstart server vs the Node CLI — and unknown/unreachable
- * keeps the generic standalone label.
+ * keeps the generic standalone kind.
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { setBridgeToken, setLocalApiBaseUrl } from '../../../src/shell/proxied-fetch.js';
 import {
-  DEFAULT_STANDALONE_LABEL,
+  floatLabelForKind,
+  resolveStandaloneFloatKind,
   resolveStandaloneFloatLabel,
 } from '../../../src/ui/wc/wc-float-label.js';
 
@@ -21,76 +22,41 @@ afterEach(() => {
   setBridgeToken(null);
 });
 
-describe('resolveStandaloneFloatLabel', () => {
-  it('labels the native Sliccstart server', async () => {
+describe('resolveStandaloneFloatKind', () => {
+  it('detects the native Sliccstart server', async () => {
     await expect(
-      resolveStandaloneFloatLabel({ fetchFn: okJson({ status: 'ok', service: 'slicc-server' }) })
-    ).resolves.toBe('sliccstart · live');
+      resolveStandaloneFloatKind({ fetchFn: okJson({ status: 'ok', service: 'slicc-server' }) })
+    ).resolves.toBe('sliccstart');
   });
 
-  it('labels the Node CLI', async () => {
+  it('detects the Node CLI', async () => {
+    await expect(
+      resolveStandaloneFloatKind({
+        fetchFn: okJson({ status: 'ok', service: 'slicc-node-server' }),
+      })
+    ).resolves.toBe('npx');
+  });
+
+  it('falls back to standalone for unknown services', async () => {
+    await expect(
+      resolveStandaloneFloatKind({ fetchFn: okJson({ status: 'ok', service: 'mystery' }) })
+    ).resolves.toBe('standalone');
+  });
+});
+
+describe('floatLabelForKind', () => {
+  it('returns the float kind name without tray suffixes', () => {
+    expect(floatLabelForKind('npx')).toBe('npx');
+    expect(floatLabelForKind('extension')).toBe('extension');
+  });
+});
+
+describe('resolveStandaloneFloatLabel (deprecated)', () => {
+  it('returns the float kind label', async () => {
     await expect(
       resolveStandaloneFloatLabel({
         fetchFn: okJson({ status: 'ok', service: 'slicc-node-server' }),
       })
-    ).resolves.toBe('npx · live');
-  });
-
-  it('keeps the generic label for unknown services', async () => {
-    await expect(
-      resolveStandaloneFloatLabel({ fetchFn: okJson({ status: 'ok', service: 'mystery' }) })
-    ).resolves.toBe(DEFAULT_STANDALONE_LABEL);
-    await expect(resolveStandaloneFloatLabel({ fetchFn: okJson({ status: 'ok' }) })).resolves.toBe(
-      DEFAULT_STANDALONE_LABEL
-    );
-  });
-
-  it('keeps the generic label on a non-OK response', async () => {
-    const fetchFn = vi.fn(async () => ({
-      ok: false,
-      json: async () => ({}),
-    })) as unknown as typeof fetch;
-    await expect(resolveStandaloneFloatLabel({ fetchFn })).resolves.toBe(DEFAULT_STANDALONE_LABEL);
-  });
-
-  it('keeps the generic label when the probe throws (cherry iframes, old servers)', async () => {
-    const fetchFn = vi.fn(async () => {
-      throw new Error('network down');
-    }) as unknown as typeof fetch;
-    await expect(resolveStandaloneFloatLabel({ fetchFn })).resolves.toBe(DEFAULT_STANDALONE_LABEL);
-  });
-
-  it('aborts a hung probe after the timeout and falls back', async () => {
-    vi.useFakeTimers();
-    try {
-      const fetchFn = vi.fn(
-        (_url: string, init?: RequestInit) =>
-          new Promise((_resolve, reject) => {
-            init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
-          })
-      ) as unknown as typeof fetch;
-      const pending = resolveStandaloneFloatLabel({ fetchFn, timeoutMs: 100 });
-      await vi.advanceTimersByTimeAsync(150);
-      await expect(pending).resolves.toBe(DEFAULT_STANDALONE_LABEL);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('rewrites URL and attaches X-Bridge-Token in thin-bridge mode', async () => {
-    setLocalApiBaseUrl('http://localhost:5710');
-    setBridgeToken('test-bridge-token');
-    const fetchFn = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ status: 'ok', service: 'slicc-node-server' }),
-    })) as unknown as typeof fetch;
-
-    await resolveStandaloneFloatLabel({ fetchFn });
-
-    expect(fetchFn).toHaveBeenCalledTimes(1);
-    const [url, init] = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(url).toBe('http://localhost:5710/api/status');
-    const headers = init?.headers as Record<string, string> | undefined;
-    expect(headers?.['X-Bridge-Token']).toBe('test-bridge-token');
+    ).resolves.toBe('npx');
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-float-label.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-float-label.test.ts
@@ -11,7 +11,6 @@ import {
   floatKindForRuntimeMode,
   floatLabelForKind,
   resolveStandaloneFloatKind,
-  resolveStandaloneFloatLabel,
 } from '../../../src/ui/wc/wc-float-label.js';
 
 function okJson(body: unknown): typeof fetch {
@@ -55,15 +54,5 @@ describe('floatLabelForKind', () => {
   it('returns the float kind name without tray suffixes', () => {
     expect(floatLabelForKind('npx')).toBe('npx');
     expect(floatLabelForKind('extension')).toBe('extension');
-  });
-});
-
-describe('resolveStandaloneFloatLabel (deprecated)', () => {
-  it('returns the float kind label', async () => {
-    await expect(
-      resolveStandaloneFloatLabel({
-        fetchFn: okJson({ status: 'ok', service: 'slicc-node-server' }),
-      })
-    ).resolves.toBe('npx');
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-floatbar-online.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-floatbar-online.test.ts
@@ -7,11 +7,7 @@ import {
   setFollowerTrayRuntimeStatus,
 } from '../../../src/scoops/tray-follower-status.js';
 import { setLeaderTrayRuntimeStatus } from '../../../src/scoops/tray-leader.js';
-import {
-  installFloatbarOnline,
-  installFloatbarStatus,
-  mergeTrayStatus,
-} from '../../../src/ui/wc/wc-floatbar-online.js';
+import { installFloatbarStatus, mergeTrayStatus } from '../../../src/ui/wc/wc-floatbar-online.js';
 
 const INACTIVE_FOLLOWER = {
   state: 'inactive' as const,
@@ -66,7 +62,6 @@ describe('installFloatbarStatus', () => {
     expect(floatbar.getAttribute('float-kind')).toBe('npx');
     expect(floatbar.getAttribute('connection')).toBe('live');
     expect(floatbar.getAttribute('tray-role')).toBe('follower');
-    expect(floatbar.hasAttribute('online')).toBe(true);
     uninstall();
   });
 
@@ -92,7 +87,6 @@ describe('installFloatbarStatus', () => {
 
     setFollowerTrayRuntimeStatus(followerStatus('error'));
     expect(floatbar.getAttribute('connection')).toBe('error');
-    expect(floatbar.hasAttribute('online')).toBe(false);
 
     setFollowerTrayRuntimeStatus(followerStatus('reconnecting'));
     expect(floatbar.getAttribute('connection')).toBe('reconnecting');
@@ -107,7 +101,6 @@ describe('installFloatbarStatus', () => {
     setFollowerTrayRuntimeStatus(followerStatus('connected'));
     setFollowerStalled(true);
     expect(floatbar.getAttribute('connection')).toBe('stalled');
-    expect(floatbar.hasAttribute('online')).toBe(true);
     setFollowerStalled(false);
     expect(floatbar.getAttribute('connection')).toBe('live');
     uninstall();
@@ -120,15 +113,5 @@ describe('installFloatbarStatus', () => {
     uninstall();
     setFollowerTrayRuntimeStatus(followerStatus('error'));
     expect(floatbar.getAttribute('connection')).toBe('live');
-  });
-});
-
-describe('installFloatbarOnline (legacy)', () => {
-  it('defaults float kind to standalone', () => {
-    setFollowerTrayRuntimeStatus(followerStatus('connected'));
-    const floatbar = document.createElement('slicc-floatbar');
-    installFloatbarOnline(floatbar);
-    expect(floatbar.getAttribute('float-kind')).toBe('standalone');
-    expect(floatbar.hasAttribute('online')).toBe(true);
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-floatbar-online.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-floatbar-online.test.ts
@@ -1,11 +1,17 @@
 // @vitest-environment jsdom
+import '@slicc/webcomponents';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
+  getFollowerTrayRuntimeStatus,
   setFollowerStalled,
   setFollowerTrayRuntimeStatus,
 } from '../../../src/scoops/tray-follower-status.js';
 import { setLeaderTrayRuntimeStatus } from '../../../src/scoops/tray-leader.js';
-import { installFloatbarOnline } from '../../../src/ui/wc/wc-floatbar-online.js';
+import {
+  installFloatbarOnline,
+  installFloatbarStatus,
+  mergeTrayStatus,
+} from '../../../src/ui/wc/wc-floatbar-online.js';
 
 const INACTIVE_FOLLOWER = {
   state: 'inactive' as const,
@@ -24,78 +30,105 @@ function followerStatus(state: 'inactive' | 'connecting' | 'connected' | 'reconn
   return { ...INACTIVE_FOLLOWER, state };
 }
 
-describe('installFloatbarOnline (#1707)', () => {
+describe('mergeTrayStatus', () => {
+  it('prefers leader role while leading', () => {
+    expect(
+      mergeTrayStatus({ state: 'leader', session: null, error: null }, followerStatus('inactive'))
+    ).toEqual({ connection: 'live', trayRole: 'leader' });
+  });
+
+  it('maps follower stalled overlay to stalled connection', () => {
+    setFollowerTrayRuntimeStatus(followerStatus('connected'));
+    setFollowerStalled(true);
+    expect(
+      mergeTrayStatus(
+        { state: 'inactive', session: null, error: null },
+        getFollowerTrayRuntimeStatus()
+      )
+    ).toEqual({ connection: 'stalled', trayRole: 'follower' });
+    setFollowerStalled(false);
+  });
+});
+
+describe('installFloatbarStatus', () => {
   let floatbar: HTMLElement;
 
   beforeEach(() => {
-    // Reset both module-global statuses so test order can't leak state.
     setFollowerTrayRuntimeStatus(followerStatus('inactive'));
     setLeaderTrayRuntimeStatus({ state: 'inactive', session: null, error: null });
-    floatbar = document.createElement('div');
+    floatbar = document.createElement('slicc-floatbar');
   });
 
-  it('seeds the current state on install (already-connected follower lights the dot)', () => {
+  it('sets float kind, label, and status beacon attrs on install', () => {
     setFollowerTrayRuntimeStatus(followerStatus('connected'));
-    const uninstall = installFloatbarOnline(floatbar);
+    const uninstall = installFloatbarStatus(floatbar, { floatKind: 'npx' });
+    expect(floatbar.getAttribute('label')).toBe('npx');
+    expect(floatbar.getAttribute('float-kind')).toBe('npx');
+    expect(floatbar.getAttribute('connection')).toBe('live');
+    expect(floatbar.getAttribute('tray-role')).toBe('follower');
     expect(floatbar.hasAttribute('online')).toBe(true);
     uninstall();
   });
 
-  it('lights the dot when the follower connects and clears it on error/reconnecting', () => {
-    const uninstall = installFloatbarOnline(floatbar);
-    expect(floatbar.hasAttribute('online')).toBe(false);
+  it('updates connection and tray role on leader transitions', () => {
+    const uninstall = installFloatbarStatus(floatbar, { floatKind: 'extension' });
+    expect(floatbar.getAttribute('connection')).toBe('offline');
+    expect(floatbar.hasAttribute('tray-role')).toBe(false);
 
+    setLeaderTrayRuntimeStatus({ state: 'leader', session: null, error: null });
+    expect(floatbar.getAttribute('connection')).toBe('live');
+    expect(floatbar.getAttribute('tray-role')).toBe('leader');
+
+    setLeaderTrayRuntimeStatus({ state: 'inactive', session: null, error: null });
+    expect(floatbar.getAttribute('connection')).toBe('offline');
+    expect(floatbar.hasAttribute('tray-role')).toBe(false);
+    uninstall();
+  });
+
+  it('maps follower error/reconnecting to offline beacon states', () => {
+    const uninstall = installFloatbarStatus(floatbar, { floatKind: 'npx' });
     setFollowerTrayRuntimeStatus(followerStatus('connected'));
-    expect(floatbar.hasAttribute('online')).toBe(true);
+    expect(floatbar.getAttribute('connection')).toBe('live');
 
-    // The exact regression from #1707: a transient drop must read offline…
     setFollowerTrayRuntimeStatus(followerStatus('error'));
-    expect(floatbar.hasAttribute('online')).toBe(false);
-    setFollowerTrayRuntimeStatus(followerStatus('reconnecting'));
+    expect(floatbar.getAttribute('connection')).toBe('error');
     expect(floatbar.hasAttribute('online')).toBe(false);
 
-    // …and recovery must light it again without any manual action.
+    setFollowerTrayRuntimeStatus(followerStatus('reconnecting'));
+    expect(floatbar.getAttribute('connection')).toBe('reconnecting');
+
     setFollowerTrayRuntimeStatus(followerStatus('connected'));
-    expect(floatbar.hasAttribute('online')).toBe(true);
+    expect(floatbar.getAttribute('connection')).toBe('live');
     uninstall();
   });
 
-  it('keeps the dot lit through a leader stall (stalled is still connected)', () => {
-    const uninstall = installFloatbarOnline(floatbar);
+  it('keeps live connection through a follower stall', () => {
+    const uninstall = installFloatbarStatus(floatbar, { floatKind: 'npx' });
     setFollowerTrayRuntimeStatus(followerStatus('connected'));
     setFollowerStalled(true);
+    expect(floatbar.getAttribute('connection')).toBe('stalled');
     expect(floatbar.hasAttribute('online')).toBe(true);
     setFollowerStalled(false);
-    expect(floatbar.hasAttribute('online')).toBe(true);
+    expect(floatbar.getAttribute('connection')).toBe('live');
     uninstall();
   });
 
-  it('lights the dot while leading a tray and clears it when the tray goes inactive', () => {
-    const uninstall = installFloatbarOnline(floatbar);
-    setLeaderTrayRuntimeStatus({ state: 'leader', session: null, error: null });
-    expect(floatbar.hasAttribute('online')).toBe(true);
-    setLeaderTrayRuntimeStatus({ state: 'inactive', session: null, error: null });
-    expect(floatbar.hasAttribute('online')).toBe(false);
-    uninstall();
-  });
-
-  it('either role alone keeps the dot lit (leader OR follower link)', () => {
-    const uninstall = installFloatbarOnline(floatbar);
-    setLeaderTrayRuntimeStatus({ state: 'leader', session: null, error: null });
+  it('uninstall stops driving attrs', () => {
+    const uninstall = installFloatbarStatus(floatbar, { floatKind: 'npx' });
     setFollowerTrayRuntimeStatus(followerStatus('connected'));
-    // Dropping one role while the other is live must not clear the dot.
-    setLeaderTrayRuntimeStatus({ state: 'inactive', session: null, error: null });
-    expect(floatbar.hasAttribute('online')).toBe(true);
-    uninstall();
-  });
-
-  it('uninstall stops driving the attribute', () => {
-    const uninstall = installFloatbarOnline(floatbar);
-    setFollowerTrayRuntimeStatus(followerStatus('connected'));
-    expect(floatbar.hasAttribute('online')).toBe(true);
+    expect(floatbar.getAttribute('connection')).toBe('live');
     uninstall();
     setFollowerTrayRuntimeStatus(followerStatus('error'));
-    // No longer subscribed — attribute stays as-is after uninstall.
+    expect(floatbar.getAttribute('connection')).toBe('live');
+  });
+});
+
+describe('installFloatbarOnline (legacy)', () => {
+  it('defaults float kind to standalone', () => {
+    setFollowerTrayRuntimeStatus(followerStatus('connected'));
+    const floatbar = document.createElement('slicc-floatbar');
+    installFloatbarOnline(floatbar);
+    expect(floatbar.getAttribute('float-kind')).toBe('standalone');
     expect(floatbar.hasAttribute('online')).toBe(true);
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-follower.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-follower.test.ts
@@ -115,10 +115,9 @@ describe('mountWcUiFollower', () => {
     expect(opts.browserAPI).toBeTruthy();
   }, 10_000);
 
-  it('drives the floatbar online dot from the follower tray status (#1707)', async () => {
-    // Integration guard: the slicc-floatbar `online` API existed with NO
-    // producer — the dot never lit while connected. Assert the mount installs
-    // one, end to end through the runtime-status subscription.
+  it('drives the floatbar status beacon from the follower tray status (#1707)', async () => {
+    // Integration guard: mount installs installFloatbarStatus and the beacon
+    // tracks follower runtime transitions end to end.
     const { setFollowerTrayRuntimeStatus } = await import(
       '../../../src/scoops/tray-follower-status.js'
     );
@@ -141,13 +140,13 @@ describe('mountWcUiFollower', () => {
 
     const floatbar = app.querySelector('slicc-floatbar') as HTMLElement;
     expect(floatbar).toBeTruthy();
-    expect(floatbar.hasAttribute('online')).toBe(false);
+    expect(floatbar.getAttribute('connection')).toBe('offline');
 
     setFollowerTrayRuntimeStatus({ ...inactive, state: 'connected' });
-    expect(floatbar.hasAttribute('online')).toBe(true);
+    expect(floatbar.getAttribute('connection')).toBe('live');
 
     setFollowerTrayRuntimeStatus({ ...inactive, state: 'error', error: 'Data channel closed' });
-    expect(floatbar.hasAttribute('online')).toBe(false);
+    expect(floatbar.getAttribute('connection')).toBe('error');
   });
 
   // Must run BEFORE the "Disconnect from leader" test below: that test's

--- a/packages/webapp/tests/ui/wc/wc-tray-followers.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-tray-followers.test.ts
@@ -199,7 +199,6 @@ describe('WC tray connected follower mapping', () => {
     const deps = {
       refs: { floatbar },
       client: {},
-      baseFloatLabel: 'standalone · live',
       window: { dispatchEvent },
     } as unknown as Parameters<typeof createLeaderOptionsFactory>[0];
     const state = {
@@ -219,7 +218,7 @@ describe('WC tray connected follower mapping', () => {
 
     options.onFollowerCountChanged?.(0);
 
-    expect(floatbar.setAttribute).toHaveBeenCalledWith('label', 'standalone · live');
+    expect(floatbar.setAttribute).not.toHaveBeenCalledWith('label', expect.anything());
     expect(storage.setItem).toHaveBeenCalledWith(
       'slicc.leaderTrayFollowers',
       expect.stringContaining('"peerState":"connecting"')
@@ -279,8 +278,8 @@ describe('WC tray connected follower mapping', () => {
       {} as Parameters<typeof createLeaderOptionsFactory>[2]
     )('https://tray.example').onFollowerCountChanged?.(1);
 
-    // The count no longer rides in the label string — it has its own segment.
-    expect(floatbar.setAttribute).toHaveBeenCalledWith('label', 'tray · live');
+    // The count lives in the followers segment only — label is not mutated.
+    expect(floatbar.setAttribute).not.toHaveBeenCalledWith('label', expect.anything());
     expect((floatbar as unknown as { followers: unknown[] }).followers).toEqual([
       {
         id: 'follower-cli-1',

--- a/packages/webapp/tests/ui/wc/wc-tray.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-tray.test.ts
@@ -74,9 +74,6 @@ vi.mock('../../../src/ui/tray-leader-lock.js', () => ({
   getDefaultLockManager: () => null,
   requestLeaderLock: vi.fn(),
 }));
-vi.mock('../../../src/ui/wc/wc-floatbar-online.js', () => ({
-  installFloatbarOnline: vi.fn(),
-}));
 vi.mock('../../../src/shell/supplemental-commands/host-command.js', () => ({
   getConnectedFollowers: () => [],
   setConnectedFollowersGetter: vi.fn(),

--- a/packages/webcomponents/src/index.ts
+++ b/packages/webcomponents/src/index.ts
@@ -181,6 +181,20 @@ export {
   panelMetaOf,
   SliccPanel,
 } from './panel/slicc-panel.js';
+export type {
+  FloatbarConnection,
+  FloatbarFloatKind,
+  FloatbarStatus,
+  FloatbarTrayRole,
+} from './primitives/floatbar-status.js';
+export {
+  connectionLabel,
+  defaultFloatLabel,
+  floatKindIcon,
+  floatKindLabel,
+  statusTipFragment,
+  trayRoleLabel,
+} from './primitives/floatbar-status.js';
 export { SliccAvatar } from './primitives/slicc-avatar.js';
 export {
   type CostOverlayModel,

--- a/packages/webcomponents/src/nav/slicc-nav.stories.ts
+++ b/packages/webcomponents/src/nav/slicc-nav.stories.ts
@@ -162,7 +162,9 @@ function makeNav(
   floatbar.setAttribute('label', 'CLI · tray · 1 follower');
   floatbar.setAttribute('spent', '$2.41');
   floatbar.setAttribute('linked', '');
-  floatbar.setAttribute('online', '');
+  floatbar.setAttribute('float-kind', 'npx');
+  floatbar.setAttribute('connection', 'live');
+  floatbar.setAttribute('tray-role', 'leader');
 
   const toggle = document.createElement('slicc-theme-toggle');
 
@@ -279,7 +281,9 @@ export const MinimalAutoSpacer: Story = {
     const floatbar = document.createElement('slicc-floatbar');
     floatbar.setAttribute('label', 'cloud · hosted leader');
     floatbar.setAttribute('spent', '$0.18');
-    floatbar.setAttribute('online', '');
+    floatbar.setAttribute('float-kind', 'hosted');
+    floatbar.setAttribute('connection', 'live');
+    floatbar.setAttribute('tray-role', 'leader');
     const avatar = document.createElement('slicc-avatar');
     avatar.setAttribute('name', 'Lars Trieloff');
     nav.append(floatbar, avatar);

--- a/packages/webcomponents/src/primitives/floatbar-status.ts
+++ b/packages/webcomponents/src/primitives/floatbar-status.ts
@@ -145,14 +145,6 @@ export function defaultFloatbarStatus(): FloatbarStatus {
   return { connection: 'offline', floatKind: 'standalone', trayRole: 'none' };
 }
 
-/**
- * Legacy bridge: the old `online` boolean meant "tray link is up". Map it to
- * `live` vs `offline` when the new `connection` attribute is unset.
- */
-export function connectionFromLegacyOnline(online: boolean): FloatbarConnection {
-  return online ? 'live' : 'offline';
-}
-
 /** Human-readable beacon tooltip fragment. */
 export function statusTipFragment(status: FloatbarStatus): string {
   return [

--- a/packages/webcomponents/src/primitives/floatbar-status.ts
+++ b/packages/webcomponents/src/primitives/floatbar-status.ts
@@ -1,0 +1,168 @@
+/**
+ * Floatbar status vocabulary — connection health, float kind, and tray role
+ * are orthogonal. Follower count lives in the pill's followers segment, not
+ * here. Pure/DOM-free so Storybook matrices and app wiring share one mapper.
+ */
+
+export type FloatbarConnection =
+  | 'offline'
+  | 'connecting'
+  | 'live'
+  | 'stalled'
+  | 'reconnecting'
+  | 'error';
+
+export type FloatbarFloatKind =
+  | 'npx'
+  | 'sliccstart'
+  | 'extension'
+  | 'standalone'
+  | 'cherry'
+  | 'electron'
+  | 'hosted';
+
+export type FloatbarTrayRole = 'none' | 'leader' | 'follower';
+
+export interface FloatbarStatus {
+  connection: FloatbarConnection;
+  floatKind: FloatbarFloatKind;
+  trayRole: FloatbarTrayRole;
+}
+
+export const FLOATBAR_CONNECTIONS: readonly FloatbarConnection[] = [
+  'offline',
+  'connecting',
+  'live',
+  'stalled',
+  'reconnecting',
+  'error',
+];
+
+export const FLOATBAR_FLOAT_KINDS: readonly FloatbarFloatKind[] = [
+  'npx',
+  'sliccstart',
+  'extension',
+  'standalone',
+  'cherry',
+  'electron',
+  'hosted',
+];
+
+export const FLOATBAR_TRAY_ROLES: readonly FloatbarTrayRole[] = ['none', 'leader', 'follower'];
+
+const CONNECTION_FILL: Record<FloatbarConnection, string> = {
+  offline: '#94a3b8',
+  connecting: '#f59e0b',
+  live: '#22c55e',
+  stalled: '#eab308',
+  reconnecting: '#f97316',
+  error: '#ef4444',
+};
+
+const CONNECTION_GLOW: Record<FloatbarConnection, string> = {
+  offline: 'color-mix(in srgb, #94a3b8 18%, transparent)',
+  connecting: 'color-mix(in srgb, #f59e0b 28%, transparent)',
+  live: 'color-mix(in srgb, #22c55e 22%, transparent)',
+  stalled: 'color-mix(in srgb, #eab308 26%, transparent)',
+  reconnecting: 'color-mix(in srgb, #f97316 28%, transparent)',
+  error: 'color-mix(in srgb, #ef4444 24%, transparent)',
+};
+
+const CONNECTION_LABEL: Record<FloatbarConnection, string> = {
+  offline: 'offline',
+  connecting: 'connecting',
+  live: 'live',
+  stalled: 'leader busy',
+  reconnecting: 'reconnecting',
+  error: 'connection error',
+};
+
+const FLOAT_KIND_ICON: Record<FloatbarFloatKind, string> = {
+  npx: 'terminal',
+  sliccstart: 'monitor',
+  extension: 'blocks',
+  standalone: 'monitor',
+  cherry: 'frame',
+  electron: 'laptop',
+  hosted: 'cloud',
+};
+
+const FLOAT_KIND_LABEL: Record<FloatbarFloatKind, string> = {
+  npx: 'npx',
+  sliccstart: 'sliccstart',
+  extension: 'extension',
+  standalone: 'standalone',
+  cherry: 'cherry',
+  electron: 'electron',
+  hosted: 'hosted',
+};
+
+const TRAY_ROLE_ICON: Record<Exclude<FloatbarTrayRole, 'none'>, string> = {
+  leader: 'crown',
+  follower: 'radio',
+};
+
+const TRAY_ROLE_LABEL: Record<FloatbarTrayRole, string> = {
+  none: 'local',
+  leader: 'leading tray',
+  follower: 'following tray',
+};
+
+export function floatKindIcon(kind: FloatbarFloatKind): string {
+  return FLOAT_KIND_ICON[kind];
+}
+
+export function floatKindLabel(kind: FloatbarFloatKind): string {
+  return FLOAT_KIND_LABEL[kind];
+}
+
+export function connectionFill(connection: FloatbarConnection): string {
+  return CONNECTION_FILL[connection];
+}
+
+export function connectionGlow(connection: FloatbarConnection): string {
+  return CONNECTION_GLOW[connection];
+}
+
+export function connectionLabel(connection: FloatbarConnection): string {
+  return CONNECTION_LABEL[connection];
+}
+
+export function trayRoleIcon(role: FloatbarTrayRole): string | null {
+  return role === 'none' ? null : TRAY_ROLE_ICON[role];
+}
+
+export function trayRoleLabel(role: FloatbarTrayRole): string {
+  return TRAY_ROLE_LABEL[role];
+}
+
+export function connectionPulses(connection: FloatbarConnection): boolean {
+  return connection === 'connecting' || connection === 'reconnecting';
+}
+
+/** Default status when nothing is wired yet. */
+export function defaultFloatbarStatus(): FloatbarStatus {
+  return { connection: 'offline', floatKind: 'standalone', trayRole: 'none' };
+}
+
+/**
+ * Legacy bridge: the old `online` boolean meant "tray link is up". Map it to
+ * `live` vs `offline` when the new `connection` attribute is unset.
+ */
+export function connectionFromLegacyOnline(online: boolean): FloatbarConnection {
+  return online ? 'live' : 'offline';
+}
+
+/** Human-readable beacon tooltip fragment. */
+export function statusTipFragment(status: FloatbarStatus): string {
+  return [
+    floatKindLabel(status.floatKind),
+    trayRoleLabel(status.trayRole),
+    connectionLabel(status.connection),
+  ].join(' · ');
+}
+
+/** Recommended float label: float kind only — never encodes follower count. */
+export function defaultFloatLabel(kind: FloatbarFloatKind): string {
+  return floatKindLabel(kind);
+}

--- a/packages/webcomponents/src/primitives/slicc-cost-overlay.stories.ts
+++ b/packages/webcomponents/src/primitives/slicc-cost-overlay.stories.ts
@@ -61,8 +61,9 @@ export const FloatbarWithOverlay: Story = {
     wrapper.style.padding = '16px 24px';
 
     const fb = document.createElement('slicc-floatbar') as SliccFloatbar;
-    fb.label = 'npx · live';
-    fb.online = true;
+    fb.label = 'npx';
+    fb.connection = 'live';
+    fb.floatKind = 'npx';
     fb.spent = '3.96';
     fb.costModels = [
       { model: 'claude-opus-4-6', cost: 3.5, turns: 8, tokens: 1_200_000 },

--- a/packages/webcomponents/src/primitives/slicc-floatbar.stories.ts
+++ b/packages/webcomponents/src/primitives/slicc-floatbar.stories.ts
@@ -18,7 +18,6 @@ import '../nav/slicc-nav.js';
 interface FloatbarArgs {
   label?: string;
   linked?: boolean;
-  online?: boolean;
   connection?: FloatbarConnection;
   floatKind?: FloatbarFloatKind;
   trayRole?: FloatbarTrayRole;
@@ -66,7 +65,6 @@ function mountFloatbar(args: FloatbarArgs): SliccFloatbar {
   if (args.connection != null) el.connection = args.connection;
   if (args.floatKind != null) el.floatKind = args.floatKind;
   if (args.trayRole != null) el.trayRole = args.trayRole;
-  if (args.online) el.online = true;
   if (args.rate != null && args.rate !== '') el.rate = args.rate;
   if (args.spent != null && args.spent !== '') el.spent = args.spent;
   if (args.followerCount != null && args.followerCount > 0) {
@@ -105,10 +103,6 @@ const meta: Meta<FloatbarArgs> = {
   argTypes: {
     label: { control: 'text', description: 'Float name only (no tray/follower encoding)' },
     linked: { control: 'boolean', description: 'Rose-tinted border (legacy linked runtime)' },
-    online: {
-      control: 'boolean',
-      description: 'Legacy: maps to live/offline when connection unset',
-    },
     connection: {
       control: 'select',
       options: FLOATBAR_CONNECTIONS,
@@ -140,11 +134,6 @@ type Story = StoryObj<FloatbarArgs>;
 /** Local float — offline, no tray role. */
 export const Default: Story = {
   args: { label: 'standalone', floatKind: 'standalone', connection: 'offline' },
-};
-
-/** Legacy `online` still lights the beacon (live + standalone icon). */
-export const LegacyOnline: Story = {
-  args: { label: 'npx', online: true },
 };
 
 /** Leader on npx with two followers — label stays float kind; count is in the middle. */
@@ -368,13 +357,11 @@ export const CleanupBeforeAfter: Story = {
 
     const before = mountFloatbar({
       label: 'tray · live',
-      online: true,
+      floatKind: 'npx',
+      connection: 'live',
       followerCount: 2,
       rate: '23.10',
     });
-    before.removeAttribute('float-kind');
-    before.removeAttribute('connection');
-    before.removeAttribute('tray-role');
 
     const after = mountFloatbar({
       label: 'npx',
@@ -389,7 +376,7 @@ export const CleanupBeforeAfter: Story = {
       mk(
         'Before (today)',
         before,
-        'Green dot + label switches to "tray · live" when followers connect — duplicates the middle segment.'
+        'Label switches to "tray · live" when followers connect — duplicates the middle segment.'
       ),
       mk(
         'After (proposed)',

--- a/packages/webcomponents/src/primitives/slicc-floatbar.stories.ts
+++ b/packages/webcomponents/src/primitives/slicc-floatbar.stories.ts
@@ -1,12 +1,101 @@
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import {
+  connectionLabel,
+  defaultFloatLabel,
+  FLOATBAR_CONNECTIONS,
+  FLOATBAR_FLOAT_KINDS,
+  type FloatbarConnection,
+  type FloatbarFloatKind,
+  type FloatbarTrayRole,
+  floatKindLabel,
+  trayRoleLabel,
+} from './floatbar-status.js';
+import type { SliccFloatbar } from './slicc-floatbar.js';
+import type { FollowerHudRow } from './slicc-follower-hud.js';
 import './slicc-floatbar.js';
+import '../nav/slicc-nav.js';
 
 interface FloatbarArgs {
   label?: string;
   linked?: boolean;
   online?: boolean;
+  connection?: FloatbarConnection;
+  floatKind?: FloatbarFloatKind;
+  trayRole?: FloatbarTrayRole;
   rate?: string;
   spent?: string;
+  followerCount?: number;
+}
+
+function sampleFollowers(count: number): FollowerHudRow[] {
+  const kinds: FollowerHudRow[] = [
+    {
+      id: 'follower-ext1',
+      icon: 'blocks',
+      title: 'Extension · 5b4a3928…',
+      detail: 'slicc-extension',
+      state: 'active',
+      stateText: 'connected 4m',
+    },
+    {
+      id: 'follower-cli1',
+      icon: 'terminal',
+      title: 'CLI · build-box',
+      detail: 'lars@build-box',
+      state: 'active',
+      stateText: 'connected 2h',
+      chips: ['can run commands'],
+    },
+    {
+      id: 'follower-tab1',
+      icon: 'monitor',
+      title: 'Standalone · 9f8e7d6c…',
+      detail: 'slicc-standalone',
+      state: 'active',
+      stateText: 'connected 31s',
+      chips: ['hosts tabs'],
+    },
+  ];
+  return kinds.slice(0, Math.max(0, count));
+}
+
+function mountFloatbar(args: FloatbarArgs): SliccFloatbar {
+  const el = document.createElement('slicc-floatbar') as SliccFloatbar;
+  if (args.label != null) el.label = args.label;
+  if (args.linked) el.linked = true;
+  if (args.connection != null) el.connection = args.connection;
+  if (args.floatKind != null) el.floatKind = args.floatKind;
+  if (args.trayRole != null) el.trayRole = args.trayRole;
+  if (args.online) el.online = true;
+  if (args.rate != null && args.rate !== '') el.rate = args.rate;
+  if (args.spent != null && args.spent !== '') el.spent = args.spent;
+  if (args.followerCount != null && args.followerCount > 0) {
+    el.followers = sampleFollowers(args.followerCount);
+  }
+  return el;
+}
+
+function navRow(floatbar: SliccFloatbar): HTMLElement {
+  const nav = document.createElement('slicc-nav');
+  nav.style.cssText = 'width:min(720px, 100vw);padding:8px 12px;';
+  nav.appendChild(floatbar);
+  return nav;
+}
+
+function legend(): HTMLElement {
+  const box = document.createElement('div');
+  box.style.cssText =
+    'font:11px/1.45 var(--ui, system-ui);color:var(--txt-2,#666);max-width:720px;margin:0 0 16px;';
+  box.textContent =
+    'Left beacon: ring color = connection health · center icon = float kind · corner pip = leader (crown) or follower (radio). Follower count lives only in the middle segment — never in the label.';
+  return box;
+}
+
+function cellCaption(parts: string[]): HTMLElement {
+  const cap = document.createElement('div');
+  cap.style.cssText = 'font:10px/1.3 var(--ui,system-ui);color:var(--txt-2,#666);margin-top:6px;';
+  cap.textContent = parts.join(' · ');
+  return cap;
 }
 
 const meta: Meta<FloatbarArgs> = {
@@ -14,69 +103,300 @@ const meta: Meta<FloatbarArgs> = {
   component: 'slicc-floatbar',
   tags: ['autodocs'],
   argTypes: {
-    label: { control: 'text', description: 'Runtime label text' },
-    linked: { control: 'boolean', description: 'Rose-tinted border (linked runtime)' },
-    online: { control: 'boolean', description: 'Show the green status dot' },
-    rate: { control: 'text', description: 'Active-session hourly rate shown in the pill' },
-    spent: { control: 'text', description: 'Cumulative cost shown in the overlay total' },
+    label: { control: 'text', description: 'Float name only (no tray/follower encoding)' },
+    linked: { control: 'boolean', description: 'Rose-tinted border (legacy linked runtime)' },
+    online: {
+      control: 'boolean',
+      description: 'Legacy: maps to live/offline when connection unset',
+    },
+    connection: {
+      control: 'select',
+      options: FLOATBAR_CONNECTIONS,
+      description: 'Tray link health (beacon ring color)',
+    },
+    floatKind: {
+      control: 'select',
+      options: FLOATBAR_FLOAT_KINDS,
+      description: 'Serving float (beacon center icon)',
+    },
+    trayRole: {
+      control: 'select',
+      options: ['none', 'leader', 'follower'],
+      description: 'Tray role (beacon corner pip)',
+    },
+    rate: { control: 'text', description: 'Hourly burn rate' },
+    spent: { control: 'text', description: 'Cumulative cost (overlay total)' },
+    followerCount: {
+      control: { type: 'number', min: 0, max: 3 },
+      description: 'Middle segment count',
+    },
   },
-  render: ({ label, linked, online, rate, spent }) => {
-    const el = document.createElement('slicc-floatbar');
-    if (label != null) el.setAttribute('label', label);
-    if (linked) el.toggleAttribute('linked', true);
-    if (online) el.toggleAttribute('online', true);
-    if (rate != null && rate !== '') el.setAttribute('rate', rate);
-    if (spent != null && spent !== '') el.setAttribute('spent', spent);
-    return el;
-  },
+  render: (args) => navRow(mountFloatbar(args)),
 };
 
 export default meta;
 type Story = StoryObj<FloatbarArgs>;
 
-/** Unlinked, offline runtime — neutral border, no status dot. */
-export const Default: Story = { args: { label: 'CLI float' } };
-
-/** Linked runtime — rose-tinted border. */
-export const Linked: Story = {
-  args: { label: 'CLI · tray · 1 follower', linked: true },
+/** Local float — offline, no tray role. */
+export const Default: Story = {
+  args: { label: 'standalone', floatKind: 'standalone', connection: 'offline' },
 };
 
-/** Online — green status dot, unlinked. */
-export const Online: Story = {
-  args: { label: 'CLI float', online: true },
+/** Legacy `online` still lights the beacon (live + standalone icon). */
+export const LegacyOnline: Story = {
+  args: { label: 'npx', online: true },
 };
 
-/** The prototype nav state: linked, online, full label. */
-export const LinkedOnline: Story = {
-  args: { label: 'CLI · tray · 1 follower', linked: true, online: true },
+/** Leader on npx with two followers — label stays float kind; count is in the middle. */
+export const LeaderNpxWithFollowers: Story = {
+  args: {
+    label: 'npx',
+    floatKind: 'npx',
+    connection: 'live',
+    trayRole: 'leader',
+    followerCount: 2,
+    rate: '23.10',
+    spent: '18.42',
+  },
 };
 
-/** With an hourly rate segment — coin icon + `$2.41/h` after a thin divider. */
+/** Same follower count on a different float kind — orthogonal. */
+export const LeaderExtensionWithFollowers: Story = {
+  args: {
+    label: 'extension',
+    floatKind: 'extension',
+    connection: 'live',
+    trayRole: 'leader',
+    followerCount: 1,
+    rate: '4.20',
+    spent: '6.15',
+  },
+};
+
+export const LeaderSliccstartWithFollowers: Story = {
+  args: {
+    label: 'sliccstart',
+    floatKind: 'sliccstart',
+    connection: 'live',
+    trayRole: 'leader',
+    followerCount: 3,
+    rate: '12.07',
+  },
+};
+
+/** Tray leader, zero followers — dot live, no middle segment, label unchanged. */
+export const LeaderNoFollowers: Story = {
+  args: {
+    label: 'npx',
+    floatKind: 'npx',
+    connection: 'live',
+    trayRole: 'leader',
+    rate: '1.05',
+  },
+};
+
+/** Following another leader — follower pip, float kind still names this surface. */
+export const FollowerConnected: Story = {
+  args: {
+    label: 'extension',
+    floatKind: 'extension',
+    connection: 'live',
+    trayRole: 'follower',
+  },
+};
+
+export const FollowerConnecting: Story = {
+  args: {
+    label: 'cherry',
+    floatKind: 'cherry',
+    connection: 'connecting',
+    trayRole: 'follower',
+  },
+};
+
+export const FollowerReconnecting: Story = {
+  args: {
+    label: 'npx',
+    floatKind: 'npx',
+    connection: 'reconnecting',
+    trayRole: 'follower',
+  },
+};
+
+export const FollowerError: Story = {
+  args: {
+    label: 'standalone',
+    floatKind: 'standalone',
+    connection: 'error',
+    trayRole: 'follower',
+  },
+};
+
+/** Leader channel open but leader busy (stalled) — amber ring, still live. */
+export const LeaderStalled: Story = {
+  args: {
+    label: 'sliccstart',
+    floatKind: 'sliccstart',
+    connection: 'stalled',
+    trayRole: 'follower',
+    followerCount: 0,
+  },
+};
+
 export const WithSpent: Story = {
-  args: { label: 'CLI float', rate: '2.41', spent: '2.41' },
+  args: {
+    label: 'npx',
+    floatKind: 'npx',
+    connection: 'offline',
+    rate: '2.41',
+    spent: '2.41',
+  },
 };
 
-/** Online + spent — green dot, label, divider, and the cost segment together. */
-export const OnlineSpent: Story = {
-  args: { label: 'CLI · tray · 1 follower', online: true, rate: '12.07', spent: '18.42' },
-};
-
-/** Live burn-rate headline while the cumulative total remains available to the overlay. */
-export const RateHeadline: Story = {
-  args: { label: 'CLI · tray · 1 follower', online: true, rate: '23.10', spent: '23.19' },
+export const NarrowMobile: Story = {
+  args: {
+    label: 'npx',
+    floatKind: 'npx',
+    connection: 'live',
+    trayRole: 'leader',
+    followerCount: 2,
+    rate: '2.41',
+    spent: '12.07',
+  },
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
 };
 
 /**
- * Narrow / mobile viewport — the label, divider, and cost segment drop and the
- * host collapses to a square (width == height) round badge carrying just the
- * status light, rather than an elongated upright pill. Because the verbose
- * label is hidden, hovering or focusing the badge reveals a dark `::part(tip)`
- * tooltip (and a matching native `title`) re-surfacing the label, spend, and
- * connection state. Select the mobile viewport from the toolbar to see the
- * square form, then hover the badge for the tooltip.
+ * Design review matrix — every connection health × tray role for one float kind.
+ * Open this story to compare ring colors and role pips side by side.
  */
-export const NarrowMobile: Story = {
-  args: { label: 'CLI · tray · 1 follower', online: true, rate: '2.41', spent: '12.07' },
-  parameters: { viewport: { defaultViewport: 'mobile1' } },
+export const StatusBeaconMatrix: Story = {
+  render: () => {
+    const root = document.createElement('div');
+    root.style.cssText = 'padding:16px;display:flex;flex-direction:column;gap:20px;';
+    root.appendChild(legend());
+
+    const roles: FloatbarTrayRole[] = ['none', 'leader', 'follower'];
+    for (const role of roles) {
+      const section = document.createElement('section');
+      const heading = document.createElement('h3');
+      heading.style.cssText =
+        'font:600 12px/1 var(--ui,system-ui);margin:0 0 10px;color:var(--ink,#111);';
+      heading.textContent = `Tray role: ${trayRoleLabel(role)}`;
+      section.appendChild(heading);
+
+      const grid = document.createElement('div');
+      grid.style.cssText =
+        'display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:12px 16px;';
+
+      for (const connection of FLOATBAR_CONNECTIONS) {
+        const cell = document.createElement('div');
+        const bar = mountFloatbar({
+          label: defaultFloatLabel('npx'),
+          floatKind: 'npx',
+          connection,
+          trayRole: role,
+          followerCount: role === 'leader' && connection === 'live' ? 2 : 0,
+          rate: '3.50',
+        });
+        cell.append(navRow(bar));
+        cell.appendChild(
+          cellCaption([
+            connectionLabel(connection),
+            role === 'leader' && connection === 'live' ? '2 followers (segment)' : 'no followers',
+          ])
+        );
+        grid.appendChild(cell);
+      }
+      section.appendChild(grid);
+      root.appendChild(section);
+    }
+    return root;
+  },
+};
+
+/**
+ * Float kinds are independent of tray role — each can lead with followers.
+ */
+export const FloatKindOrthogonality: Story = {
+  render: () => {
+    const root = document.createElement('div');
+    root.style.cssText = 'padding:16px;display:flex;flex-direction:column;gap:16px;';
+    root.appendChild(legend());
+
+    const grid = document.createElement('div');
+    grid.style.cssText =
+      'display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:14px 18px;';
+
+    for (const kind of FLOATBAR_FLOAT_KINDS) {
+      const cell = document.createElement('div');
+      const bar = mountFloatbar({
+        label: defaultFloatLabel(kind),
+        floatKind: kind,
+        connection: 'live',
+        trayRole: 'leader',
+        followerCount: 1,
+        rate: '8.00',
+      });
+      cell.append(navRow(bar));
+      cell.appendChild(cellCaption([floatKindLabel(kind), 'leading · 1 follower']));
+      grid.appendChild(cell);
+    }
+    root.appendChild(grid);
+    return root;
+  },
+};
+
+/** Before/after — old label encoded tray+followers vs cleaned split. */
+export const CleanupBeforeAfter: Story = {
+  render: () => {
+    const root = document.createElement('div');
+    root.style.cssText =
+      'padding:16px;display:flex;flex-direction:column;gap:20px;max-width:760px;';
+
+    const mk = (title: string, bar: SliccFloatbar, note: string) => {
+      const block = document.createElement('div');
+      const h = document.createElement('h3');
+      h.style.cssText = 'font:600 12px/1 var(--ui,system-ui);margin:0 0 8px;color:var(--ink,#111);';
+      h.textContent = title;
+      const p = document.createElement('p');
+      p.style.cssText = 'font:11px/1.4 var(--ui,system-ui);color:var(--txt-2,#666);margin:0 0 8px;';
+      p.textContent = note;
+      block.append(h, p, navRow(bar));
+      return block;
+    };
+
+    const before = mountFloatbar({
+      label: 'tray · live',
+      online: true,
+      followerCount: 2,
+      rate: '23.10',
+    });
+    before.removeAttribute('float-kind');
+    before.removeAttribute('connection');
+    before.removeAttribute('tray-role');
+
+    const after = mountFloatbar({
+      label: 'npx',
+      floatKind: 'npx',
+      connection: 'live',
+      trayRole: 'leader',
+      followerCount: 2,
+      rate: '23.10',
+    });
+
+    root.append(
+      mk(
+        'Before (today)',
+        before,
+        'Green dot + label switches to "tray · live" when followers connect — duplicates the middle segment.'
+      ),
+      mk(
+        'After (proposed)',
+        after,
+        'Beacon encodes health + float kind + role; label stays "npx"; followers only in 👥 segment.'
+      )
+    );
+    return root;
+  },
 };

--- a/packages/webcomponents/src/primitives/slicc-floatbar.ts
+++ b/packages/webcomponents/src/primitives/slicc-floatbar.ts
@@ -5,6 +5,22 @@ import type { CostOverlayModel, CostOverlayScoop, SliccCostOverlay } from './sli
 import './slicc-cost-overlay.js';
 import type { FollowerHudRow, SliccFollowerHud } from './slicc-follower-hud.js';
 import './slicc-follower-hud.js';
+import {
+  connectionFill,
+  connectionFromLegacyOnline,
+  connectionGlow,
+  connectionLabel,
+  connectionPulses,
+  defaultFloatbarStatus,
+  type FloatbarConnection,
+  type FloatbarFloatKind,
+  type FloatbarStatus,
+  type FloatbarTrayRole,
+  floatKindIcon,
+  floatKindLabel,
+  statusTipFragment,
+  trayRoleIcon,
+} from './floatbar-status.js';
 
 const DEFAULT_LABEL = 'CLI float';
 
@@ -58,6 +74,66 @@ const STYLE = `
   border-color: color-mix(in srgb, var(--rose) 40%, var(--line));
 }
 
+/* Status beacon — connection color, float-kind icon, tray-role pip. Replaces
+   the legacy plain green status dot. */
+.beacon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+}
+.beacon__ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--beacon-fill, #94a3b8);
+  box-shadow: 0 0 0 2.5px var(--beacon-glow, color-mix(in srgb, #94a3b8 18%, transparent));
+}
+.beacon__icon {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  color: var(--canvas, #fff);
+  line-height: 0;
+}
+.beacon__icon svg {
+  display: block;
+  width: 9px;
+  height: 9px;
+}
+.beacon__role {
+  position: absolute;
+  right: -3px;
+  bottom: -2px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1px solid var(--canvas, #fff);
+  background: var(--ink, #111);
+  color: var(--canvas, #fff);
+  line-height: 0;
+}
+.beacon__role svg {
+  display: block;
+  width: 5px;
+  height: 5px;
+}
+.beacon[data-pulse] .beacon__ring {
+  animation: beacon-pulse 1.4s ease-in-out infinite;
+}
+@keyframes beacon-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.08); opacity: 0.82; }
+}
+
+/* Legacy alias — tests and older ::part(dot) hooks still resolve. */
 .fdot {
   width: 7px;
   height: 7px;
@@ -195,7 +271,12 @@ const SHEET = sheet(STYLE);
  *
  * @attr label - the runtime label text (defaults to "CLI float")
  * @attr linked - boolean; rose-tints the border to signal a linked runtime
- * @attr online - boolean; shows the green status dot
+ * @attr connection - tray link health: offline | connecting | live | stalled |
+ *   reconnecting | error (colors the beacon ring)
+ * @attr float-kind - serving float: npx | sliccstart | extension | standalone |
+ *   cherry | electron | hosted (beacon center icon)
+ * @attr tray-role - none | leader | follower (corner pip on the beacon)
+ * @attr online - legacy boolean; when `connection` is unset, maps to live/offline
  * @attr rate - hourly cost, a number or numeric string (e.g. `23.1`); renders a
  *   coin-icon + formatted `$23.10/h` cost segment after a thin divider
  * @attr spent - cumulative cost shown in the cost overlay's total row
@@ -204,7 +285,11 @@ const SHEET = sheet(STYLE);
  *   and feeds `<slicc-follower-hud>` on hover/focus
  * @fires slicc-followers-click - the followers segment was activated (open the
  *   sync dialog on its Status tab)
- * @csspart dot - the green status dot (present only when `online`)
+ * @csspart beacon - the status beacon wrapper (connection + float kind + role)
+ * @csspart beacon-ring - the colored health ring
+ * @csspart beacon-icon - the float-kind icon
+ * @csspart beacon-role - the leader/follower pip (when tray-role ≠ none)
+ * @csspart dot - alias for {@link csspart beacon}
  * @csspart label - the runtime label span
  * @csspart sep - the thin dividers before the followers and cost segments
  * @csspart followers - the followers segment button
@@ -214,7 +299,16 @@ const SHEET = sheet(STYLE);
  * @slot - default slot overrides the label text
  */
 export class SliccFloatbar extends HTMLElement {
-  static readonly observedAttributes = ['label', 'linked', 'online', 'rate', 'spent'];
+  static readonly observedAttributes = [
+    'label',
+    'linked',
+    'online',
+    'connection',
+    'float-kind',
+    'tray-role',
+    'rate',
+    'spent',
+  ];
 
   readonly #root: ShadowRoot;
   #resizeObserver: ResizeObserver | null = null;
@@ -279,6 +373,75 @@ export class SliccFloatbar extends HTMLElement {
 
   set online(value: boolean) {
     this.toggleAttribute('online', !!value);
+  }
+
+  get connection(): FloatbarConnection {
+    const raw = this.getAttribute('connection');
+    if (
+      raw === 'connecting' ||
+      raw === 'live' ||
+      raw === 'stalled' ||
+      raw === 'reconnecting' ||
+      raw === 'error'
+    ) {
+      return raw;
+    }
+    if (this.hasAttribute('online')) return connectionFromLegacyOnline(true);
+    return 'offline';
+  }
+
+  set connection(value: FloatbarConnection | null) {
+    if (value == null) this.removeAttribute('connection');
+    else this.setAttribute('connection', value);
+  }
+
+  get floatKind(): FloatbarFloatKind {
+    const raw = this.getAttribute('float-kind');
+    if (
+      raw === 'npx' ||
+      raw === 'sliccstart' ||
+      raw === 'extension' ||
+      raw === 'standalone' ||
+      raw === 'cherry' ||
+      raw === 'electron' ||
+      raw === 'hosted'
+    ) {
+      return raw;
+    }
+    return defaultFloatbarStatus().floatKind;
+  }
+
+  set floatKind(value: FloatbarFloatKind | null) {
+    if (value == null) this.removeAttribute('float-kind');
+    else this.setAttribute('float-kind', value);
+  }
+
+  get trayRole(): FloatbarTrayRole {
+    const raw = this.getAttribute('tray-role');
+    if (raw === 'leader' || raw === 'follower') return raw;
+    return 'none';
+  }
+
+  set trayRole(value: FloatbarTrayRole | null) {
+    if (value == null || value === 'none') this.removeAttribute('tray-role');
+    else this.setAttribute('tray-role', value);
+  }
+
+  /** Resolved status tuple for hosts/tests. */
+  get status(): FloatbarStatus {
+    return {
+      connection: this.connection,
+      floatKind: this.floatKind,
+      trayRole: this.trayRole,
+    };
+  }
+
+  set status(value: FloatbarStatus) {
+    this.connection = value.connection;
+    this.floatKind = value.floatKind;
+    this.trayRole = value.trayRole;
+    if (value.connection === 'live') this.online = true;
+    else if (value.connection === 'offline') this.online = false;
   }
 
   /** Raw `spent` attribute value (number/string), or `null` when unset. */
@@ -347,14 +510,76 @@ export class SliccFloatbar extends HTMLElement {
    */
   #tipText(): string {
     const parts: string[] = [this.label];
+    if (
+      this.hasAttribute('connection') ||
+      this.hasAttribute('float-kind') ||
+      this.hasAttribute('tray-role')
+    ) {
+      parts.push(statusTipFragment(this.status));
+    } else {
+      parts.push(this.online ? 'online' : 'offline');
+    }
     const followers = this.#followers.length;
     if (followers > 0) {
       parts.push(`${followers} ${followers === 1 ? 'follower' : 'followers'}`);
     }
     parts.push(formatRate(this.rate));
     parts.push('recency-weighted session avg');
-    parts.push(this.online ? 'online' : 'offline');
     return parts.join(' · ');
+  }
+
+  /** Explicit status model — beacon replaces the legacy dot. */
+  #usesStatusBeacon(): boolean {
+    return (
+      this.hasAttribute('connection') ||
+      this.hasAttribute('float-kind') ||
+      this.hasAttribute('tray-role')
+    );
+  }
+
+  /** Whether the new status beacon renders. */
+  #showsBeacon(): boolean {
+    return this.#usesStatusBeacon();
+  }
+
+  /** Legacy plain green dot when only `online` is set. */
+  #showsLegacyDot(): boolean {
+    return this.online && !this.#usesStatusBeacon();
+  }
+
+  #beaconEl(status: FloatbarStatus): HTMLElement {
+    const { connection, floatKind, trayRole } = status;
+    const ring = h('span', {
+      class: 'beacon__ring',
+      part: 'beacon-ring',
+      style: `--beacon-fill:${connectionFill(connection)};--beacon-glow:${connectionGlow(connection)}`,
+    });
+    const icon = h(
+      'span',
+      { class: 'beacon__icon', part: 'beacon-icon' },
+      iconEl(floatKindIcon(floatKind), { size: 9, strokeWidth: 2.25 })
+    );
+    const attrs: Record<string, string> = {
+      class: 'beacon',
+      part: 'beacon dot',
+      'data-connection': connection,
+      'data-float-kind': floatKind,
+      'aria-label': `${floatKindLabel(floatKind)}, ${connectionLabel(connection)}`,
+    };
+    if (trayRole !== 'none') attrs['data-tray-role'] = trayRole;
+    if (connectionPulses(connection)) attrs['data-pulse'] = '';
+    const nodes: Node[] = [ring, icon];
+    const roleIcon = trayRoleIcon(trayRole);
+    if (roleIcon) {
+      nodes.push(
+        h(
+          'span',
+          { class: 'beacon__role', part: 'beacon-role', 'aria-hidden': 'true' },
+          iconEl(roleIcon, { size: 5, strokeWidth: 2.5 })
+        )
+      );
+    }
+    return h('span', attrs, ...nodes);
   }
 
   /** Mirror the full tip onto `title` whenever any detail has been collapsed. */
@@ -373,7 +598,8 @@ export class SliccFloatbar extends HTMLElement {
   #render(): void {
     const nodes: Node[] = [];
 
-    if (this.online) nodes.push(h('span', { class: 'fdot', part: 'dot' }));
+    if (this.#showsBeacon()) nodes.push(this.#beaconEl(this.status));
+    else if (this.#showsLegacyDot()) nodes.push(h('span', { class: 'fdot', part: 'dot' }));
 
     const [runtime, ...detail] = this.label.split(' · ');
     const fallback = [h('span', { class: 'runtime' }, runtime)];

--- a/packages/webcomponents/src/primitives/slicc-floatbar.ts
+++ b/packages/webcomponents/src/primitives/slicc-floatbar.ts
@@ -9,7 +9,6 @@ import {
   connectionFill,
   connectionFromLegacyOnline,
   connectionGlow,
-  connectionLabel,
   connectionPulses,
   defaultFloatbarStatus,
   type FloatbarConnection,
@@ -17,7 +16,6 @@ import {
   type FloatbarStatus,
   type FloatbarTrayRole,
   floatKindIcon,
-  floatKindLabel,
   statusTipFragment,
   trayRoleIcon,
 } from './floatbar-status.js';
@@ -257,6 +255,7 @@ const STYLE = `
 
 @media (prefers-reduced-motion: reduce) {
   .tip { transition: none; }
+  .beacon[data-pulse] .beacon__ring { animation: none; }
 }
 `;
 const SHEET = sheet(STYLE);
@@ -564,7 +563,7 @@ export class SliccFloatbar extends HTMLElement {
       part: 'beacon dot',
       'data-connection': connection,
       'data-float-kind': floatKind,
-      'aria-label': `${floatKindLabel(floatKind)}, ${connectionLabel(connection)}`,
+      'aria-label': statusTipFragment({ connection, floatKind, trayRole }),
     };
     if (trayRole !== 'none') attrs['data-tray-role'] = trayRole;
     if (connectionPulses(connection)) attrs['data-pulse'] = '';

--- a/packages/webcomponents/src/primitives/slicc-floatbar.ts
+++ b/packages/webcomponents/src/primitives/slicc-floatbar.ts
@@ -7,7 +7,6 @@ import type { FollowerHudRow, SliccFollowerHud } from './slicc-follower-hud.js';
 import './slicc-follower-hud.js';
 import {
   connectionFill,
-  connectionFromLegacyOnline,
   connectionGlow,
   connectionPulses,
   defaultFloatbarStatus,
@@ -72,8 +71,7 @@ const STYLE = `
   border-color: color-mix(in srgb, var(--rose) 40%, var(--line));
 }
 
-/* Status beacon — connection color, float-kind icon, tray-role pip. Replaces
-   the legacy plain green status dot. */
+/* Status beacon — connection color, float-kind icon, tray-role pip. */
 .beacon {
   position: relative;
   display: inline-flex;
@@ -129,16 +127,6 @@ const STYLE = `
 @keyframes beacon-pulse {
   0%, 100% { transform: scale(1); opacity: 1; }
   50% { transform: scale(1.08); opacity: 0.82; }
-}
-
-/* Legacy alias — tests and older ::part(dot) hooks still resolve. */
-.fdot {
-  width: 7px;
-  height: 7px;
-  flex: 0 0 auto;
-  border-radius: 50%;
-  background: #22c55e;
-  box-shadow: 0 0 0 3px color-mix(in srgb, #22c55e 22%, transparent);
 }
 
 .label { white-space: nowrap; }
@@ -262,11 +250,10 @@ const SHEET = sheet(STYLE);
 
 /**
  * `<slicc-floatbar>` — the Runtime Float Pill from the prototype nav
- * (`.floatbar`). An inline-flex rounded pill carrying a status dot (`.fdot`)
- * and a runtime label such as `CLI · tray · 1 follower`. Self-contained shadow
- * DOM; themes via inherited tokens (--canvas, --line, --txt-2, --rose, --ui,
- * --ctl-h). The green status dot and the linked rose tint are fixed across
- * light/dark.
+ * (`.floatbar`). An inline-flex rounded pill carrying a status beacon and a
+ * runtime label such as `npx` or `extension`. Self-contained shadow DOM;
+ * themes via inherited tokens (--canvas, --line, --txt-2, --rose, --ui,
+ * --ctl-h). The linked rose tint is fixed across light/dark.
  *
  * @attr label - the runtime label text (defaults to "CLI float")
  * @attr linked - boolean; rose-tints the border to signal a linked runtime
@@ -275,7 +262,6 @@ const SHEET = sheet(STYLE);
  * @attr float-kind - serving float: npx | sliccstart | extension | standalone |
  *   cherry | electron | hosted (beacon center icon)
  * @attr tray-role - none | leader | follower (corner pip on the beacon)
- * @attr online - legacy boolean; when `connection` is unset, maps to live/offline
  * @attr rate - hourly cost, a number or numeric string (e.g. `23.1`); renders a
  *   coin-icon + formatted `$23.10/h` cost segment after a thin divider
  * @attr spent - cumulative cost shown in the cost overlay's total row
@@ -301,7 +287,6 @@ export class SliccFloatbar extends HTMLElement {
   static readonly observedAttributes = [
     'label',
     'linked',
-    'online',
     'connection',
     'float-kind',
     'tray-role',
@@ -365,15 +350,6 @@ export class SliccFloatbar extends HTMLElement {
     this.toggleAttribute('linked', !!value);
   }
 
-  /** Whether the status dot is shown (online/green). */
-  get online(): boolean {
-    return this.hasAttribute('online');
-  }
-
-  set online(value: boolean) {
-    this.toggleAttribute('online', !!value);
-  }
-
   get connection(): FloatbarConnection {
     const raw = this.getAttribute('connection');
     if (
@@ -385,7 +361,6 @@ export class SliccFloatbar extends HTMLElement {
     ) {
       return raw;
     }
-    if (this.hasAttribute('online')) return connectionFromLegacyOnline(true);
     return 'offline';
   }
 
@@ -439,8 +414,6 @@ export class SliccFloatbar extends HTMLElement {
     this.connection = value.connection;
     this.floatKind = value.floatKind;
     this.trayRole = value.trayRole;
-    if (value.connection === 'live') this.online = true;
-    else if (value.connection === 'offline') this.online = false;
   }
 
   /** Raw `spent` attribute value (number/string), or `null` when unset. */
@@ -508,16 +481,7 @@ export class SliccFloatbar extends HTMLElement {
    * separator the verbose label uses, so the collapsed badge stays legible.
    */
   #tipText(): string {
-    const parts: string[] = [this.label];
-    if (
-      this.hasAttribute('connection') ||
-      this.hasAttribute('float-kind') ||
-      this.hasAttribute('tray-role')
-    ) {
-      parts.push(statusTipFragment(this.status));
-    } else {
-      parts.push(this.online ? 'online' : 'offline');
-    }
+    const parts: string[] = [this.label, statusTipFragment(this.status)];
     const followers = this.#followers.length;
     if (followers > 0) {
       parts.push(`${followers} ${followers === 1 ? 'follower' : 'followers'}`);
@@ -525,25 +489,6 @@ export class SliccFloatbar extends HTMLElement {
     parts.push(formatRate(this.rate));
     parts.push('recency-weighted session avg');
     return parts.join(' · ');
-  }
-
-  /** Explicit status model — beacon replaces the legacy dot. */
-  #usesStatusBeacon(): boolean {
-    return (
-      this.hasAttribute('connection') ||
-      this.hasAttribute('float-kind') ||
-      this.hasAttribute('tray-role')
-    );
-  }
-
-  /** Whether the new status beacon renders. */
-  #showsBeacon(): boolean {
-    return this.#usesStatusBeacon();
-  }
-
-  /** Legacy plain green dot when only `online` is set. */
-  #showsLegacyDot(): boolean {
-    return this.online && !this.#usesStatusBeacon();
   }
 
   #beaconEl(status: FloatbarStatus): HTMLElement {
@@ -597,8 +542,7 @@ export class SliccFloatbar extends HTMLElement {
   #render(): void {
     const nodes: Node[] = [];
 
-    if (this.#showsBeacon()) nodes.push(this.#beaconEl(this.status));
-    else if (this.#showsLegacyDot()) nodes.push(h('span', { class: 'fdot', part: 'dot' }));
+    nodes.push(this.#beaconEl(this.status));
 
     const [runtime, ...detail] = this.label.split(' · ');
     const fallback = [h('span', { class: 'runtime' }, runtime)];

--- a/packages/webcomponents/src/primitives/slicc-follower-hud.stories.ts
+++ b/packages/webcomponents/src/primitives/slicc-follower-hud.stories.ts
@@ -99,8 +99,10 @@ export const FloatbarWithFollowers: Story = {
     wrapper.style.cssText =
       'display: flex; justify-content: flex-end; padding: 16px; margin-bottom: 280px;';
     const floatbar = document.createElement('slicc-floatbar') as SliccFloatbar;
-    floatbar.label = 'tray · live';
-    floatbar.online = true;
+    floatbar.label = 'npx';
+    floatbar.floatKind = 'npx';
+    floatbar.connection = 'live';
+    floatbar.trayRole = 'leader';
     floatbar.rate = '23.10';
     floatbar.followers = allKinds();
     wrapper.appendChild(floatbar);

--- a/packages/webcomponents/tests/nav/slicc-nav.test.ts
+++ b/packages/webcomponents/tests/nav/slicc-nav.test.ts
@@ -27,7 +27,7 @@ function makeNav(accent?: string): SliccNav {
   el.innerHTML = `
     <div data-testid="nav-leading"></div>
     <slicc-agent-tabs active="cone"></slicc-agent-tabs>
-    <slicc-floatbar label="CLI · tray · 1 follower" linked online></slicc-floatbar>
+    <slicc-floatbar label="CLI · tray · 1 follower" linked float-kind="npx" connection="live" tray-role="leader"></slicc-floatbar>
     <slicc-theme-toggle></slicc-theme-toggle>
     <slicc-avatar initials="PM"></slicc-avatar>`;
   return el;

--- a/packages/webcomponents/tests/primitives/floatbar-status.test.ts
+++ b/packages/webcomponents/tests/primitives/floatbar-status.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import {
-  connectionFromLegacyOnline,
   defaultFloatLabel,
   floatKindLabel,
   statusTipFragment,
@@ -8,11 +7,6 @@ import {
 } from '../../src/primitives/floatbar-status.js';
 
 describe('floatbar-status', () => {
-  it('maps legacy online to live/offline', () => {
-    expect(connectionFromLegacyOnline(true)).toBe('live');
-    expect(connectionFromLegacyOnline(false)).toBe('offline');
-  });
-
   it('keeps float labels free of tray/follower encoding', () => {
     expect(defaultFloatLabel('npx')).toBe('npx');
     expect(defaultFloatLabel('extension')).toBe('extension');

--- a/packages/webcomponents/tests/primitives/floatbar-status.test.ts
+++ b/packages/webcomponents/tests/primitives/floatbar-status.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  connectionFromLegacyOnline,
+  defaultFloatLabel,
+  floatKindLabel,
+  statusTipFragment,
+  trayRoleIcon,
+} from '../../src/primitives/floatbar-status.js';
+
+describe('floatbar-status', () => {
+  it('maps legacy online to live/offline', () => {
+    expect(connectionFromLegacyOnline(true)).toBe('live');
+    expect(connectionFromLegacyOnline(false)).toBe('offline');
+  });
+
+  it('keeps float labels free of tray/follower encoding', () => {
+    expect(defaultFloatLabel('npx')).toBe('npx');
+    expect(defaultFloatLabel('extension')).toBe('extension');
+    expect(floatKindLabel('sliccstart')).toBe('sliccstart');
+  });
+
+  it('builds orthogonal status tip fragments', () => {
+    expect(statusTipFragment({ connection: 'live', floatKind: 'npx', trayRole: 'leader' })).toBe(
+      'npx · leading tray · live'
+    );
+  });
+
+  it('returns role icons only for leader/follower', () => {
+    expect(trayRoleIcon('none')).toBeNull();
+    expect(trayRoleIcon('leader')).toBe('crown');
+    expect(trayRoleIcon('follower')).toBe('radio');
+  });
+});

--- a/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
+++ b/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
@@ -66,21 +66,46 @@ describe('slicc-floatbar', () => {
     expect(label?.textContent).toBe('<script>x</script>');
   });
 
-  describe('the status dot (online state)', () => {
+  describe('the status beacon (explicit connection / float-kind / tray-role)', () => {
     it('is absent by default', () => {
       const el = document.createElement('slicc-floatbar');
       document.body.appendChild(el);
-      expect(el.shadowRoot?.querySelector('.fdot')).toBeNull();
+      expect(el.shadowRoot?.querySelector('.beacon')).toBeNull();
     });
 
-    it('appears when online, exposing a `dot` part, painted green', () => {
+    it('appears with a live green ring when status attrs are set', () => {
+      const el = document.createElement('slicc-floatbar');
+      el.setAttribute('float-kind', 'npx');
+      el.setAttribute('connection', 'live');
+      document.body.appendChild(el);
+      const beacon = el.shadowRoot?.querySelector('.beacon') as HTMLElement;
+      expect(beacon).not.toBeNull();
+      expect(beacon.getAttribute('part')).toContain('dot');
+      expect(beacon.dataset.connection).toBe('live');
+      const ring = el.shadowRoot?.querySelector('.beacon__ring') as HTMLElement;
+      expect(getComputedStyle(ring).backgroundColor).toBe('rgb(34, 197, 94)');
+    });
+
+    it('renders float-kind icon and leader role pip', () => {
+      const el = document.createElement('slicc-floatbar');
+      el.setAttribute('float-kind', 'npx');
+      el.setAttribute('connection', 'live');
+      el.setAttribute('tray-role', 'leader');
+      document.body.appendChild(el);
+      expect(el.shadowRoot?.querySelector('.beacon__icon svg')).not.toBeNull();
+      expect(el.shadowRoot?.querySelector('.beacon__role svg')).not.toBeNull();
+      expect(el.status.trayRole).toBe('leader');
+    });
+  });
+
+  describe('the legacy status dot (online only)', () => {
+    it('uses the plain green fdot when only online is set', () => {
       const el = document.createElement('slicc-floatbar');
       el.online = true;
       document.body.appendChild(el);
       const dot = el.shadowRoot?.querySelector('.fdot') as HTMLElement;
       expect(dot).not.toBeNull();
-      expect(dot.getAttribute('part')).toBe('dot');
-      // #22c55e === rgb(34, 197, 94)
+      expect(el.shadowRoot?.querySelector('.beacon')).toBeNull();
       expect(getComputedStyle(dot).backgroundColor).toBe('rgb(34, 197, 94)');
     });
 
@@ -327,7 +352,7 @@ describe('slicc-floatbar', () => {
       // decorative — the accessible name rides the host title, not the tip node
       expect(tip.getAttribute('aria-hidden')).toBe('true');
       expect(tip.textContent).toBe(
-        'CLI · tray · 1 follower · $2.41/h · recency-weighted session avg · online'
+        'CLI · tray · 1 follower · online · $2.41/h · recency-weighted session avg'
       );
     });
 
@@ -349,7 +374,7 @@ describe('slicc-floatbar', () => {
       const el = document.createElement('slicc-floatbar');
       document.body.appendChild(el);
       expect(el.shadowRoot?.querySelector('.tip')?.textContent).toBe(
-        'CLI float · $0.00/h · recency-weighted session avg · offline'
+        'CLI float · offline · $0.00/h · recency-weighted session avg'
       );
     });
 
@@ -371,7 +396,7 @@ describe('slicc-floatbar', () => {
     it('exposes the tip text as an accessible host title only when collapsed', () => {
       const el = mountAt(640);
       expect(el.getAttribute('title')).toBe(
-        'CLI · tray · 1 follower · $2.41/h · recency-weighted session avg · online'
+        'CLI · tray · 1 follower · online · $2.41/h · recency-weighted session avg'
       );
     });
 

--- a/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
+++ b/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
@@ -96,6 +96,41 @@ describe('slicc-floatbar', () => {
       expect(el.shadowRoot?.querySelector('.beacon__role svg')).not.toBeNull();
       expect(el.status.trayRole).toBe('leader');
     });
+
+    it('includes tray role in the beacon aria-label', () => {
+      const el = document.createElement('slicc-floatbar');
+      el.setAttribute('float-kind', 'npx');
+      el.setAttribute('connection', 'live');
+      el.setAttribute('tray-role', 'leader');
+      document.body.appendChild(el);
+      const beacon = el.shadowRoot?.querySelector('.beacon') as HTMLElement;
+      expect(beacon.getAttribute('aria-label')).toBe('npx · leading tray · live');
+    });
+
+    it('disables the connecting pulse under prefers-reduced-motion', () => {
+      const el = document.createElement('slicc-floatbar');
+      document.body.appendChild(el);
+      let guarded = false;
+      for (const s of el.shadowRoot?.adoptedStyleSheets ?? []) {
+        for (const rule of s.cssRules) {
+          if (
+            rule instanceof CSSMediaRule &&
+            rule.conditionText.includes('prefers-reduced-motion')
+          ) {
+            for (const inner of rule.cssRules) {
+              if (
+                inner instanceof CSSStyleRule &&
+                inner.selectorText.includes('.beacon[data-pulse]') &&
+                inner.style.animationName === 'none'
+              ) {
+                guarded = true;
+              }
+            }
+          }
+        }
+      }
+      expect(guarded).toBe(true);
+    });
   });
 
   describe('the legacy status dot (online only)', () => {

--- a/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
+++ b/packages/webcomponents/tests/primitives/slicc-floatbar.test.ts
@@ -49,14 +49,6 @@ describe('slicc-floatbar', () => {
     expect(el.hasAttribute('linked')).toBe(false);
   });
 
-  it('reflects the online boolean attribute to the property', () => {
-    const el = document.createElement('slicc-floatbar');
-    document.body.appendChild(el);
-    expect(el.online).toBe(false);
-    el.online = true;
-    expect(el.hasAttribute('online')).toBe(true);
-  });
-
   it('escapes label text', () => {
     const el = document.createElement('slicc-floatbar');
     el.label = '<script>x</script>';
@@ -66,11 +58,14 @@ describe('slicc-floatbar', () => {
     expect(label?.textContent).toBe('<script>x</script>');
   });
 
-  describe('the status beacon (explicit connection / float-kind / tray-role)', () => {
-    it('is absent by default', () => {
+  describe('the status beacon (connection / float-kind / tray-role)', () => {
+    it('renders a default offline beacon when unset', () => {
       const el = document.createElement('slicc-floatbar');
       document.body.appendChild(el);
-      expect(el.shadowRoot?.querySelector('.beacon')).toBeNull();
+      const beacon = el.shadowRoot?.querySelector('.beacon') as HTMLElement;
+      expect(beacon).not.toBeNull();
+      expect(beacon.dataset.connection).toBe('offline');
+      expect(beacon.dataset.floatKind).toBe('standalone');
     });
 
     it('appears with a live green ring when status attrs are set', () => {
@@ -130,26 +125,6 @@ describe('slicc-floatbar', () => {
         }
       }
       expect(guarded).toBe(true);
-    });
-  });
-
-  describe('the legacy status dot (online only)', () => {
-    it('uses the plain green fdot when only online is set', () => {
-      const el = document.createElement('slicc-floatbar');
-      el.online = true;
-      document.body.appendChild(el);
-      const dot = el.shadowRoot?.querySelector('.fdot') as HTMLElement;
-      expect(dot).not.toBeNull();
-      expect(el.shadowRoot?.querySelector('.beacon')).toBeNull();
-      expect(getComputedStyle(dot).backgroundColor).toBe('rgb(34, 197, 94)');
-    });
-
-    it('toggles back off when online is cleared', () => {
-      const el = document.createElement('slicc-floatbar');
-      el.online = true;
-      document.body.appendChild(el);
-      el.online = false;
-      expect(el.shadowRoot?.querySelector('.fdot')).toBeNull();
     });
   });
 
@@ -279,12 +254,13 @@ describe('slicc-floatbar', () => {
       expect(el.shadowRoot?.querySelector('.amount')?.textContent).toBe('$0.00/h');
     });
 
-    it('coexists with the online status dot and the label', () => {
+    it('coexists with the status beacon and the label', () => {
       const el = document.createElement('slicc-floatbar');
-      el.online = true;
+      el.connection = 'live';
+      el.floatKind = 'standalone';
       el.rate = '12.07';
       document.body.appendChild(el);
-      expect(el.shadowRoot?.querySelector('.fdot')).not.toBeNull();
+      expect(el.shadowRoot?.querySelector('.beacon')).not.toBeNull();
       expect(el.shadowRoot?.querySelector('.label')?.textContent).toContain('CLI float');
       expect(el.shadowRoot?.querySelector('.amount')?.textContent).toBe('$12.07/h');
       expect(el.shadowRoot?.querySelector('.spent svg')).not.toBeNull();
@@ -292,11 +268,12 @@ describe('slicc-floatbar', () => {
   });
 
   describe('dark mode', () => {
-    it('flips the canvas/line/text tokens but keeps the dot green', () => {
+    it('flips the canvas/line/text tokens but keeps the live beacon green', () => {
       const wrap = document.createElement('div');
       wrap.className = 'dark';
       const el = document.createElement('slicc-floatbar');
-      el.online = true;
+      el.connection = 'live';
+      el.floatKind = 'standalone';
       wrap.appendChild(el);
       document.body.appendChild(wrap);
 
@@ -305,8 +282,8 @@ describe('slicc-floatbar', () => {
       expect(cs.backgroundColor).toBe(rgb('#161618'));
       expect(cs.borderTopColor).toBe(rgb('#2a2a2e'));
 
-      const dot = el.shadowRoot?.querySelector('.fdot') as HTMLElement;
-      expect(getComputedStyle(dot).backgroundColor).toBe('rgb(34, 197, 94)');
+      const ring = el.shadowRoot?.querySelector('.beacon__ring') as HTMLElement;
+      expect(getComputedStyle(ring).backgroundColor).toBe('rgb(34, 197, 94)');
     });
   });
 
@@ -316,7 +293,8 @@ describe('slicc-floatbar', () => {
       nav.style.width = `${width}px`;
       const el = document.createElement('slicc-floatbar') as SliccFloatbar;
       el.label = 'CLI · tray · 1 follower';
-      el.online = true;
+      el.connection = 'live';
+      el.floatKind = 'standalone';
       el.rate = '2.41';
       nav.appendChild(el);
       document.body.appendChild(nav);
@@ -387,7 +365,7 @@ describe('slicc-floatbar', () => {
       // decorative — the accessible name rides the host title, not the tip node
       expect(tip.getAttribute('aria-hidden')).toBe('true');
       expect(tip.textContent).toBe(
-        'CLI · tray · 1 follower · online · $2.41/h · recency-weighted session avg'
+        'CLI · tray · 1 follower · standalone · local · live · $2.41/h · recency-weighted session avg'
       );
     });
 
@@ -409,7 +387,7 @@ describe('slicc-floatbar', () => {
       const el = document.createElement('slicc-floatbar');
       document.body.appendChild(el);
       expect(el.shadowRoot?.querySelector('.tip')?.textContent).toBe(
-        'CLI float · offline · $0.00/h · recency-weighted session avg'
+        'CLI float · standalone · local · offline · $0.00/h · recency-weighted session avg'
       );
     });
 
@@ -431,7 +409,7 @@ describe('slicc-floatbar', () => {
     it('exposes the tip text as an accessible host title only when collapsed', () => {
       const el = mountAt(640);
       expect(el.getAttribute('title')).toBe(
-        'CLI · tray · 1 follower · online · $2.41/h · recency-weighted session avg'
+        'CLI · tray · 1 follower · standalone · local · live · $2.41/h · recency-weighted session avg'
       );
     });
 


### PR DESCRIPTION
## Summary

- Adds a **status beacon** to `<slicc-floatbar>`: ring color = connection health, center icon = float kind, corner pip = leader/follower role.
- Wires the beacon from tray runtime status via `installFloatbarStatus()` in live, follower, and extension boots.
- **Decouples label from tray/followers**: the pill label is the float kind only (`npx`, `extension`, …); follower count stays in the middle `👥` segment (no more `tray · live` label swap).
- Storybook stories include a status matrix and before/after comparison for design review.

## Test plan

- [x] `npm run test -w @slicc/webcomponents -- tests/primitives/slicc-floatbar.test.ts tests/primitives/floatbar-status.test.ts`
- [x] `npm run test -w @slicc/webapp -- tests/ui/wc/wc-floatbar-online.test.ts tests/ui/wc/wc-float-label.test.ts tests/ui/wc/wc-tray-followers.test.ts`
- [x] `npm run build -w @slicc/webcomponents`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [ ] Storybook: **Primitives → Floatbar → StatusBeaconMatrix**, **CleanupBeforeAfter**
- [ ] Manual: lead a tray on `npm run dev` — beacon shows green + crown; connect a follower — label stays `npx`, middle segment shows count


Made with [Cursor](https://cursor.com)