### PR TITLE
feat(shell): support ipk/npm install -g

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -128,9 +128,20 @@ git checkout -b feature origin/feature
 
 Use `--depth <n>` to request a different history depth.
 
+### `ipk install -g` / `npm install -g`
+
+`ipk install -g <pkg>` (and `npm install -g`, `npm i -g`) installs into the shared
+global prefix at `/shared/lib/node_modules`, records direct dependencies in
+`/shared/lib/package.json`, and publishes PATH-visible `.jsh` delegators under
+`/shared/bin` for package bins. Local project installs are unchanged: without `-g`,
+packages still land in `<cwd>/node_modules` and update the nearest project
+`package.json`. Module resolution and `ipx`/`npx` also search the global tree after
+the cwd-relative `node_modules` walk.
+
 ### `ipx` / `npx` built-in redirects
 
-`ipx` runs JavaScript package bins from the nearest installed `node_modules`; `npx` is an
+`ipx` runs JavaScript package bins from the nearest installed `node_modules`, then the
+shared global tree at `/shared/lib/node_modules`; `npx` is an
 alias with the same behavior. When no local bin or installed package resolves, the command
 normally installs the requested package and runs its bin. Before that network install,
 `ipx`/`npx` consults `builtin-shadow-map.ts`. A match exits non-zero and prints a stderr hint

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -81,7 +81,6 @@
   "packages/webapp/src/shell/plugins/types.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/biome-configuration.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/discover-command.ts": 1,
-  "packages/webapp/src/shell/supplemental-commands/ipx-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/jsh-biome-source.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/kill-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/open-command.ts": 1,

--- a/packages/webapp/src/shell/ipk/global-bin-delegators.ts
+++ b/packages/webapp/src/shell/ipk/global-bin-delegators.ts
@@ -1,0 +1,77 @@
+/**
+ * Publish PATH-visible `.jsh` delegators for globally installed package bins.
+ *
+ * Each delegator forwards to `ipx <bin> …` so execution uses the same jsh
+ * runtime, module loader, and provider env seeding as a direct ipx invocation.
+ */
+
+import type { DirEntry, VirtualFS } from '../../fs/index.js';
+import { GLOBAL_BIN_DELEGATOR_MARKER, GLOBAL_BIN_DIR } from './global-prefix.js';
+
+function joinPath(base: string, ...parts: string[]): string {
+  const segments = [base, ...parts]
+    .join('/')
+    .split('/')
+    .filter((p) => p.length > 0);
+  return `/${segments.join('/')}`;
+}
+
+function buildDelegatorSource(binName: string): string {
+  const escaped = JSON.stringify(binName);
+  return [
+    `// ${GLOBAL_BIN_DELEGATOR_MARKER}`,
+    "const { spawn } = require('sliccy:exec');",
+    `const __bin = ${escaped};`,
+    "spawn(['ipx', __bin, ...process.argv.slice(2)])",
+    '  .then((r) => process.exit(r.exitCode), () => process.exit(1));',
+    '',
+  ].join('\n');
+}
+
+async function readDelegatorMarker(fs: VirtualFS, path: string): Promise<boolean> {
+  try {
+    const raw = await fs.readFile(path);
+    const text = typeof raw === 'string' ? raw : new TextDecoder().decode(raw as Uint8Array);
+    return text.includes(GLOBAL_BIN_DELEGATOR_MARKER);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write or refresh `.jsh` delegators under {@link GLOBAL_BIN_DIR} for the given
+ * bin names. Removes stale ipk-managed delegators whose names are absent from
+ * `activeBinNames` without touching user-authored scripts in the same directory.
+ */
+export async function reconcileGlobalBinDelegators(
+  fs: VirtualFS,
+  activeBinNames: ReadonlySet<string>
+): Promise<void> {
+  if (!(await fs.exists(GLOBAL_BIN_DIR))) {
+    if (activeBinNames.size === 0) return;
+    await fs.mkdir(GLOBAL_BIN_DIR, { recursive: true });
+  }
+
+  let existing: DirEntry[] = [];
+  try {
+    existing = await fs.readDir(GLOBAL_BIN_DIR);
+  } catch {
+    existing = [];
+  }
+
+  for (const entry of existing) {
+    if (entry.type !== 'file' || !entry.name.endsWith('.jsh')) continue;
+    const binName = entry.name.slice(0, -'.jsh'.length);
+    if (activeBinNames.has(binName)) continue;
+    const path = joinPath(GLOBAL_BIN_DIR, entry.name);
+    if (await readDelegatorMarker(fs, path)) {
+      await fs.rm(path);
+    }
+  }
+
+  for (const binName of activeBinNames) {
+    if (!binName || binName.includes('/')) continue;
+    const path = joinPath(GLOBAL_BIN_DIR, `${binName}.jsh`);
+    await fs.writeFile(path, buildDelegatorSource(binName));
+  }
+}

--- a/packages/webapp/src/shell/ipk/global-bin-delegators.ts
+++ b/packages/webapp/src/shell/ipk/global-bin-delegators.ts
@@ -20,12 +20,29 @@ function buildDelegatorSource(binName: string): string {
   const escaped = JSON.stringify(binName);
   return [
     `// ${GLOBAL_BIN_DELEGATOR_MARKER}`,
-    "const { spawn } = require('sliccy:exec');",
+    "const { start } = require('sliccy:exec');",
     `const __bin = ${escaped};`,
-    "spawn(['ipx', __bin, ...process.argv.slice(2)])",
-    '  .then((r) => process.exit(r.exitCode), () => process.exit(1));',
+    "const __argv = ['ipx', __bin, ...process.argv.slice(2)];",
+    "const __stdin = typeof stdin !== 'undefined' ? stdin : undefined;",
+    'const __h = start(__argv, __stdin !== undefined ? { stdin: __stdin } : undefined);',
+    '__h.stdin.end();',
+    'const __r = await __h.done;',
+    'if (__r.stdout) process.stdout.write(__r.stdout);',
+    'if (__r.stderr) process.stderr.write(__r.stderr);',
+    'process.exit(__r.exitCode);',
     '',
   ].join('\n');
+}
+
+/** Thrown when a global bin name would overwrite a user-authored `/shared/bin` script. */
+export class GlobalBinCollisionError extends Error {
+  constructor(
+    public readonly binName: string,
+    public readonly path: string
+  ) {
+    super(`ipk: refusing to overwrite user script at ${path} (bin '${binName}')`);
+    this.name = 'GlobalBinCollisionError';
+  }
 }
 
 async function readDelegatorMarker(fs: VirtualFS, path: string): Promise<boolean> {
@@ -72,6 +89,11 @@ export async function reconcileGlobalBinDelegators(
   for (const binName of activeBinNames) {
     if (!binName || binName.includes('/')) continue;
     const path = joinPath(GLOBAL_BIN_DIR, `${binName}.jsh`);
+    if (await fs.exists(path)) {
+      if (!(await readDelegatorMarker(fs, path))) {
+        throw new GlobalBinCollisionError(binName, path);
+      }
+    }
     await fs.writeFile(path, buildDelegatorSource(binName));
   }
 }

--- a/packages/webapp/src/shell/ipk/global-prefix.ts
+++ b/packages/webapp/src/shell/ipk/global-prefix.ts
@@ -1,0 +1,22 @@
+/**
+ * VFS locations for ipk global installs (`ipk install -g` / `npm install -g`).
+ *
+ * Mirrors npm's prefix layout: packages under `<prefix>/node_modules`, CLI
+ * entrypoints published to `<prefix>/../bin` (here `/shared/bin`, already on
+ * the default `$PATH`).
+ */
+
+/** npm-style prefix directory (holds `node_modules` + `package.json`). */
+export const GLOBAL_NPM_PREFIX = '/shared/lib';
+
+/** Global package tree root. */
+export const GLOBAL_NODE_MODULES = `${GLOBAL_NPM_PREFIX}/node_modules`;
+
+/** Directory for PATH-visible `.jsh` delegators to global bins. */
+export const GLOBAL_BIN_DIR = '/shared/bin';
+
+/** Manifest recording directly-requested global packages. */
+export const GLOBAL_PACKAGE_JSON = `${GLOBAL_NPM_PREFIX}/package.json`;
+
+/** Marker comment identifying ipk-managed delegators in `/shared/bin`. */
+export const GLOBAL_BIN_DELEGATOR_MARKER = '@ipk-global-delegator';

--- a/packages/webapp/src/shell/ipk/installer.ts
+++ b/packages/webapp/src/shell/ipk/installer.ts
@@ -18,7 +18,7 @@
 import type { SecureFetch } from 'just-bash';
 import type { DirEntry, VirtualFS } from '../../fs/index.js';
 import { reconcileGlobalBinDelegators } from './global-bin-delegators.js';
-import { GLOBAL_NODE_MODULES, GLOBAL_NPM_PREFIX } from './global-prefix.js';
+import { GLOBAL_NODE_MODULES, GLOBAL_NPM_PREFIX, GLOBAL_PACKAGE_JSON } from './global-prefix.js';
 import { fetchPackument, fetchTarball, type Packument, resolveVersion } from './registry.js';
 import {
   type InstallNode,
@@ -477,6 +477,12 @@ export async function installPackages(
   }
 
   const rootDependencies: Record<string, string> = {};
+  if (globalInstall) {
+    const existingGlobal = await readJsonOr<ProjectManifest>(fs, GLOBAL_PACKAGE_JSON, {});
+    for (const [name, range] of Object.entries(existingGlobal.dependencies ?? {})) {
+      rootDependencies[name] = range;
+    }
+  }
   for (const direct of directs) {
     rootDependencies[direct.parsed.name] = direct.parsed.range;
   }

--- a/packages/webapp/src/shell/ipk/installer.ts
+++ b/packages/webapp/src/shell/ipk/installer.ts
@@ -17,6 +17,8 @@
 
 import type { SecureFetch } from 'just-bash';
 import type { DirEntry, VirtualFS } from '../../fs/index.js';
+import { reconcileGlobalBinDelegators } from './global-bin-delegators.js';
+import { GLOBAL_NODE_MODULES, GLOBAL_NPM_PREFIX } from './global-prefix.js';
 import { fetchPackument, fetchTarball, type Packument, resolveVersion } from './registry.js';
 import {
   type InstallNode,
@@ -31,6 +33,8 @@ export interface InstallOptions {
   fetch: SecureFetch;
   cwd: string;
   timeoutMs?: number;
+  /** Install into `/shared/lib/node_modules` instead of `<cwd>/node_modules`. */
+  global?: boolean;
 }
 
 export interface InstallResult {
@@ -461,7 +465,7 @@ export async function installPackages(
   specs: string[],
   options: InstallOptions
 ): Promise<InstallPackagesResult> {
-  const { fs, fetch, cwd, timeoutMs } = options;
+  const { fs, fetch, cwd, timeoutMs, global: globalInstall = false } = options;
   if (specs.length === 0) {
     return { results: [], errors: [] };
   }
@@ -482,16 +486,22 @@ export async function installPackages(
     fetchPackument: supplier,
   });
 
-  const modulesDir = joinPath(cwd, 'node_modules');
+  const modulesDir = globalInstall ? GLOBAL_NODE_MODULES : joinPath(cwd, 'node_modules');
   await materializePlan(fs, modulesDir, plan, fetch, timeoutMs);
   await reconcileRootBinShims(fs, modulesDir);
+  if (globalInstall) {
+    const installed = await collectInstalledBins(fs, modulesDir);
+    const chosen = chooseRootBins(installed);
+    await reconcileGlobalBinDelegators(fs, new Set(chosen.keys()));
+  }
 
   const records = directs.map((d) => {
     const node = plan.root[d.parsed.name];
     if (!node) throw new Error(`installer: resolved node missing for ${d.parsed.name}`);
     return { name: d.parsed.name, range: chooseSavedRange(d.parsed, node.version) };
   });
-  const manifestPath = await recordDirectDependencies(fs, cwd, records);
+  const manifestRoot = globalInstall ? GLOBAL_NPM_PREFIX : cwd;
+  const manifestPath = await recordDirectDependencies(fs, manifestRoot, records);
 
   const results: InstallResult[] = directs.map((d) => {
     const node = plan.root[d.parsed.name];

--- a/packages/webapp/src/shell/ipk/resolver.ts
+++ b/packages/webapp/src/shell/ipk/resolver.ts
@@ -38,6 +38,7 @@
 
 import { joinPath, splitPath } from '../../fs/path-utils.js';
 import { NODE_BUILTINS } from '../../kernel/realm/node-builtins.js';
+import { GLOBAL_NODE_MODULES } from './global-prefix.js';
 import type { Packument, PackumentVersion } from './registry.js';
 import { resolveVersion } from './registry.js';
 import { satisfies } from './semver.js';
@@ -509,6 +510,9 @@ export function nodeModulesSearchPath(fromDir: string): string[] {
     dirs.push(joinPath(dir, 'node_modules'));
     if (dir === '/' || dir === '') break;
     dir = dirOf(dir);
+  }
+  if (!dirs.includes(GLOBAL_NODE_MODULES)) {
+    dirs.push(GLOBAL_NODE_MODULES);
   }
   return dirs;
 }

--- a/packages/webapp/src/shell/supplemental-commands/ipk-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/ipk-command.ts
@@ -29,6 +29,7 @@ export interface IpkCommandDeps {
 }
 
 const INSTALL_ALIASES = new Set(['install', 'i', 'add']);
+const GLOBAL_INSTALL_FLAGS = new Set(['-g', '--global', '--location=global']);
 
 function usage(name: string): string {
   return `${name} - install packages from the npm registry into node_modules
@@ -36,6 +37,7 @@ function usage(name: string): string {
 
 Usage:
   ${name} install [<pkg>[@<spec>] ...]
+  ${name} install -g <pkg>[@<spec>] ...
   ${name} i       [<pkg>[@<spec>] ...]
   ${name} run     [<script> [-- <args>...]]
   ${name} test | start | stop | restart
@@ -44,6 +46,11 @@ No-arg forms:
   ${name} install            read cwd package.json and install every entry
                              from dependencies AND devDependencies
   ${name} run                list the scripts the nearest package.json defines
+
+Global installs:
+  ${name} install -g <pkg>   install into /shared/lib/node_modules and publish
+                             CLI bins to /shared/bin (on the default $PATH).
+                             Records deps in /shared/lib/package.json, not cwd.
 
 Script running:
   ${name} run <script>       run that scripts entry in the directory holding
@@ -70,13 +77,35 @@ Spec forms:
   @scope/name      scoped packages install under node_modules/@scope/name
 
 Options:
+  -g, --global     install packages into the shared global prefix (/shared/lib)
   -h, --help       Show this help message
 
 Installed packages are extracted into <cwd>/node_modules and named installs
-are recorded in <cwd>/package.json under dependencies. Existing fields are
-preserved. Idempotent: re-installing an already-satisfied package is a clean
-no-op.
+are recorded in <cwd>/package.json under dependencies. With -g, packages go
+to /shared/lib/node_modules and deps are recorded in /shared/lib/package.json.
+Existing fields are preserved. Idempotent: re-installing an already-satisfied
+package is a clean no-op.
 `;
+}
+
+export interface ParsedInstallArgs {
+  global: boolean;
+  specs: string[];
+}
+
+/** Split install flags from package specs (supports `-g` anywhere before specs). */
+export function parseInstallArgs(args: string[]): ParsedInstallArgs {
+  let global = false;
+  const specs: string[] = [];
+  for (const arg of args) {
+    if (GLOBAL_INSTALL_FLAGS.has(arg)) {
+      global = true;
+      continue;
+    }
+    if (arg.startsWith('-')) continue;
+    specs.push(arg);
+  }
+  return { global, specs };
 }
 
 /**
@@ -149,7 +178,14 @@ async function runInstall(
   ctx: CommandContext,
   deps: IpkCommandDeps
 ): Promise<ExecResult> {
-  const specs = args.filter((a) => !a.startsWith('-'));
+  const { global, specs } = parseInstallArgs(args);
+  if (global && specs.length === 0) {
+    return {
+      stdout: '',
+      stderr: `${name}: global install requires at least one package name\n`,
+      exitCode: 1,
+    };
+  }
   if (specs.length === 0) {
     return runManifestInstall(name, ctx, deps);
   }
@@ -160,6 +196,7 @@ async function runInstall(
       fs: deps.fs,
       fetch: deps.fetch,
       cwd: ctx.cwd,
+      global,
     });
   } catch (err) {
     return {

--- a/packages/webapp/src/shell/supplemental-commands/ipx-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/ipx-command.ts
@@ -22,6 +22,7 @@
 import type { Command, CommandContext, ExecResult, SecureFetch } from 'just-bash';
 import type { VirtualFS } from '../../fs/index.js';
 import { joinPath, normalizePath, splitPath } from '../../fs/path-utils.js';
+import { GLOBAL_NODE_MODULES } from '../ipk/global-prefix.js';
 import { installPackages } from '../ipk/installer.js';
 import { executeJsCode } from '../jsh-executor.js';
 import { stripShebang } from '../strip-shebang.js';
@@ -78,7 +79,7 @@ async function isDirectory(fs: VirtualFS, path: string): Promise<boolean> {
   }
 }
 
-/** Yield each `<dir>/node_modules` from `cwd` up to the filesystem root. */
+/** Yield each `<dir>/node_modules` from `cwd` up to the filesystem root, then global. */
 function* nodeModulesDirs(cwd: string): Generator<string> {
   let dir = normalizePath(cwd);
   while (true) {
@@ -86,6 +87,7 @@ function* nodeModulesDirs(cwd: string): Generator<string> {
     if (dir === '/') break;
     dir = splitPath(dir).dir;
   }
+  yield GLOBAL_NODE_MODULES;
 }
 
 /** Resolve a `node_modules/.bin/<name>` shim to its real bin file, if present. */
@@ -125,14 +127,16 @@ function pickPackageBin(
     return { binName: unscopedName(pkgName), binPath: bin };
   }
   if (bin === null || typeof bin !== 'object') return null;
-  const map = bin as Record<string, unknown>;
   const candidates = [pkgName, unscopedName(pkgName)];
   for (const key of candidates) {
-    if (typeof map[key] === 'string') return { binName: key, binPath: map[key] as string };
+    const value = Object.getOwnPropertyDescriptor(bin, key)?.value;
+    if (typeof value === 'string') return { binName: key, binPath: value };
   }
-  const entries = Object.entries(map).filter(([, v]) => typeof v === 'string');
-  if (entries.length === 1) {
-    const [binName, binPath] = entries[0] as [string, string];
+  const stringEntries = Object.entries(bin as object).filter(
+    (entry): entry is [string, string] => typeof entry[1] === 'string'
+  );
+  if (stringEntries.length === 1) {
+    const [binName, binPath] = stringEntries[0];
     return { binName, binPath };
   }
   return null;

--- a/packages/webapp/tests/shell/ipk/global-bin-delegators.test.ts
+++ b/packages/webapp/tests/shell/ipk/global-bin-delegators.test.ts
@@ -1,0 +1,69 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import {
+  GlobalBinCollisionError,
+  reconcileGlobalBinDelegators,
+} from '../../../src/shell/ipk/global-bin-delegators.js';
+import {
+  GLOBAL_BIN_DELEGATOR_MARKER,
+  GLOBAL_BIN_DIR,
+} from '../../../src/shell/ipk/global-prefix.js';
+
+let dbCounter = 0;
+async function newFs(): Promise<VirtualFS> {
+  return VirtualFS.create({ dbName: `test-global-bin-delegators-${dbCounter++}`, wipe: true });
+}
+
+describe('reconcileGlobalBinDelegators', () => {
+  let fs: VirtualFS;
+
+  beforeEach(async () => {
+    fs = await newFs();
+    await fs.mkdir(GLOBAL_BIN_DIR, { recursive: true });
+  });
+
+  it('writes a delegator that awaits exec.start and relays stdout/stderr/stdin', async () => {
+    await reconcileGlobalBinDelegators(fs, new Set(['say']));
+    const source = (await fs.readFile(`${GLOBAL_BIN_DIR}/say.jsh`)) as string;
+    expect(source).toContain(GLOBAL_BIN_DELEGATOR_MARKER);
+    expect(source).toContain("require('sliccy:exec')");
+    expect(source).toContain('const { start }');
+    expect(source).toContain('await __h.done');
+    expect(source).toContain('process.stdout.write(__r.stdout)');
+    expect(source).toContain('process.stderr.write(__r.stderr)');
+    expect(source).toContain('process.exit(__r.exitCode)');
+    expect(source).toContain('__stdin');
+    expect(source).not.toContain('.then(');
+    expect(source).not.toContain('(async');
+  });
+
+  it('refreshes an existing ipk-managed delegator', async () => {
+    await reconcileGlobalBinDelegators(fs, new Set(['say']));
+    await fs.writeFile(
+      `${GLOBAL_BIN_DIR}/say.jsh`,
+      `// ${GLOBAL_BIN_DELEGATOR_MARKER}\n// stale\n`
+    );
+    await reconcileGlobalBinDelegators(fs, new Set(['say']));
+    const source = (await fs.readFile(`${GLOBAL_BIN_DIR}/say.jsh`)) as string;
+    expect(source).toContain('await __h.done');
+    expect(source).not.toContain('// stale');
+  });
+
+  it('refuses to overwrite a user-authored script', async () => {
+    const path = `${GLOBAL_BIN_DIR}/say.jsh`;
+    await fs.writeFile(path, '// user script\n');
+    await expect(reconcileGlobalBinDelegators(fs, new Set(['say']))).rejects.toThrow(
+      GlobalBinCollisionError
+    );
+    expect((await fs.readFile(path)) as string).toBe('// user script\n');
+  });
+
+  it('removes stale ipk delegators but leaves user scripts', async () => {
+    await reconcileGlobalBinDelegators(fs, new Set(['keep']));
+    await fs.writeFile(`${GLOBAL_BIN_DIR}/user.jsh`, '// user\n');
+    await reconcileGlobalBinDelegators(fs, new Set(['keep']));
+    expect(await fs.exists(`${GLOBAL_BIN_DIR}/keep.jsh`)).toBe(true);
+    expect(await fs.exists(`${GLOBAL_BIN_DIR}/user.jsh`)).toBe(true);
+  });
+});

--- a/packages/webapp/tests/shell/ipk/global-prefix.test.ts
+++ b/packages/webapp/tests/shell/ipk/global-prefix.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { GLOBAL_NODE_MODULES } from '../../../src/shell/ipk/global-prefix.js';
+import { nodeModulesSearchPath } from '../../../src/shell/ipk/resolver.js';
+
+describe('global ipk prefix', () => {
+  it('nodeModulesSearchPath appends the global tree after local ancestors', () => {
+    const dirs = nodeModulesSearchPath('/work/project');
+    expect(dirs[0]).toBe('/work/project/node_modules');
+    expect(dirs[dirs.length - 1]).toBe(GLOBAL_NODE_MODULES);
+    expect(dirs.filter((d) => d === GLOBAL_NODE_MODULES)).toHaveLength(1);
+  });
+});

--- a/packages/webapp/tests/shell/ipk/module-resolve.test.ts
+++ b/packages/webapp/tests/shell/ipk/module-resolve.test.ts
@@ -11,6 +11,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { normalizePath, splitPath } from '../../../src/fs/path-utils.js';
+import { GLOBAL_NODE_MODULES } from '../../../src/shell/ipk/global-prefix.js';
 import {
   createVfsModuleReader,
   detectModuleKind,
@@ -653,12 +654,13 @@ describe('nodeModulesSearchPath()', () => {
       '/shared/nodetest/node_modules',
       '/shared/node_modules',
       '/node_modules',
+      GLOBAL_NODE_MODULES,
     ]);
   });
 
   it('terminates at the VFS root for root and empty starting directories', () => {
-    expect(nodeModulesSearchPath('/')).toEqual(['/node_modules']);
-    expect(nodeModulesSearchPath('')).toEqual(['/node_modules']);
+    expect(nodeModulesSearchPath('/')).toEqual(['/node_modules', GLOBAL_NODE_MODULES]);
+    expect(nodeModulesSearchPath('')).toEqual(['/node_modules', GLOBAL_NODE_MODULES]);
   });
 
   it('matches where resolve() actually finds a package (the walk it reports is the walk it did)', async () => {

--- a/packages/webapp/tests/shell/supplemental-commands/esbuild-wasm.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/esbuild-wasm.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GLOBAL_NODE_MODULES } from '../../../src/shell/ipk/global-prefix.js';
 import type { ModuleReader } from '../../../src/shell/ipk/resolver.js';
 import {
   ESBUILD_VERSION,
@@ -43,7 +44,7 @@ describe('getEsbuild browser recovery guidance', () => {
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toBe(
       `esbuild-wasm is not installed in node_modules: run \`${bootstrap}\`` +
-        ' (searched from /workspace: /workspace/node_modules, /node_modules)'
+        ` (searched from /workspace: /workspace/node_modules, /node_modules, ${GLOBAL_NODE_MODULES})`
     );
     expect((error as Error).message).not.toContain('ipx esbuild');
   });

--- a/packages/webapp/tests/shell/supplemental-commands/ipk-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/ipk-command.test.ts
@@ -93,6 +93,7 @@ function buildTar(entries: TarEntryInput[]): Uint8Array {
 interface SyntheticPackage {
   name: string;
   version: string;
+  dependencies?: Record<string, string>;
   files?: Record<string, string>;
 }
 
@@ -133,6 +134,7 @@ function buildRegistry(packages: SyntheticPackage[]): Registry {
       versionMap[p.version] = {
         name,
         version: p.version,
+        ...(p.dependencies ? { dependencies: p.dependencies } : {}),
         dist: {
           tarball: `https://registry.npmjs.org/${name}/-/${tarballBasename(name, p.version)}`,
         },
@@ -541,6 +543,88 @@ describe('createIpkCommand', () => {
     expect(await fs.exists(delegator)).toBe(true);
     const source = (await fs.readFile(delegator)) as string;
     expect(source).toMatch(/@ipk-global-delegator/);
+    expect(source).toMatch(/await __h\.done/);
+    expect(source).toMatch(/process\.stdout\.write/);
     expect(source).toMatch(/ipx/);
+  });
+
+  it('incremental global installs merge prior direct dependencies into resolution', async () => {
+    const reg = buildRegistry([
+      {
+        name: 'cli-a',
+        version: '1.0.0',
+        dependencies: { dep: '^1.0.0' },
+        files: {
+          'package.json': JSON.stringify({
+            name: 'cli-a',
+            version: '1.0.0',
+            dependencies: { dep: '^1.0.0' },
+            bin: { 'cli-a': 'cli.js' },
+          }),
+          'cli.js': 'require("dep");\n',
+        },
+      },
+      {
+        name: 'cli-b',
+        version: '1.0.0',
+        dependencies: { dep: '^3.0.0' },
+        files: {
+          'package.json': JSON.stringify({
+            name: 'cli-b',
+            version: '1.0.0',
+            dependencies: { dep: '^3.0.0' },
+            bin: { 'cli-b': 'cli.js' },
+          }),
+          'cli.js': 'require("dep");\n',
+        },
+      },
+      { name: 'dep', version: '1.0.0' },
+      { name: 'dep', version: '3.0.0' },
+    ]);
+    const cmd = createIpkCommand('ipk', { fs, fetch: makeFetch(reg) });
+    const r1 = await cmd.execute(['install', '-g', 'cli-a'], ctxOf(fs) as never);
+    expect(r1.exitCode).toBe(0);
+    const depRoot1 = JSON.parse(
+      (await fs.readFile(`${GLOBAL_NODE_MODULES}/dep/package.json`)) as string
+    );
+    expect(depRoot1.version).toBe('1.0.0');
+
+    const r2 = await cmd.execute(['install', '-g', 'cli-b'], ctxOf(fs) as never);
+    expect(r2.exitCode).toBe(0);
+    const depRoot2 = JSON.parse(
+      (await fs.readFile(`${GLOBAL_NODE_MODULES}/dep/package.json`)) as string
+    );
+    expect(depRoot2.version).toBe('1.0.0');
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/cli-b/node_modules/dep/package.json`)).toBe(
+      true
+    );
+    const depNested = JSON.parse(
+      (await fs.readFile(`${GLOBAL_NODE_MODULES}/cli-b/node_modules/dep/package.json`)) as string
+    );
+    expect(depNested.version).toBe('3.0.0');
+  });
+
+  it('global install refuses to overwrite a user script in /shared/bin', async () => {
+    await fs.mkdir(GLOBAL_BIN_DIR, { recursive: true });
+    await fs.writeFile(`${GLOBAL_BIN_DIR}/say.jsh`, '// user script\n');
+    const reg = buildRegistry([
+      {
+        name: 'say',
+        version: '1.0.0',
+        files: {
+          'package.json': JSON.stringify({
+            name: 'say',
+            version: '1.0.0',
+            bin: { say: 'cli.js' },
+          }),
+          'cli.js': 'console.log("cli");\n',
+        },
+      },
+    ]);
+    const cmd = createIpkCommand('ipk', { fs, fetch: makeFetch(reg) });
+    const r = await cmd.execute(['install', '-g', 'say'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/refusing to overwrite/i);
+    expect((await fs.readFile(`${GLOBAL_BIN_DIR}/say.jsh`)) as string).toBe('// user script\n');
   });
 });

--- a/packages/webapp/tests/shell/supplemental-commands/ipk-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/ipk-command.test.ts
@@ -3,7 +3,15 @@ import { gzipSync } from 'fflate';
 import type { IFileSystem, SecureFetch } from 'just-bash';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { VirtualFS } from '../../../src/fs/index.js';
-import { createIpkCommand } from '../../../src/shell/supplemental-commands/ipk-command.js';
+import {
+  GLOBAL_BIN_DIR,
+  GLOBAL_NODE_MODULES,
+  GLOBAL_PACKAGE_JSON,
+} from '../../../src/shell/ipk/global-prefix.js';
+import {
+  createIpkCommand,
+  parseInstallArgs,
+} from '../../../src/shell/supplemental-commands/ipk-command.js';
 
 /** just-bash does not re-export SecureFetchOptions from its root entry. */
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -472,5 +480,67 @@ describe('createIpkCommand', () => {
     expect(root.dependencies['is-number']).toBeDefined();
     expect(root.dependencies['is-odd']).toBeDefined();
     expect(root.dependencies['bogus-xyz123']).toBeUndefined();
+  });
+
+  it('parseInstallArgs recognizes -g / --global and collects specs', () => {
+    expect(parseInstallArgs(['-g', 'left-pad'])).toEqual({ global: true, specs: ['left-pad'] });
+    expect(parseInstallArgs(['--global', '@acme/util'])).toEqual({
+      global: true,
+      specs: ['@acme/util'],
+    });
+    expect(parseInstallArgs(['is-number'])).toEqual({ global: false, specs: ['is-number'] });
+  });
+
+  it('ipk install -g installs into /shared/lib/node_modules, not cwd', async () => {
+    const reg = buildRegistry([{ name: 'is-number', version: '7.0.0' }]);
+    const cmd = createIpkCommand('ipk', { fs, fetch: makeFetch(reg) });
+    const r = await cmd.execute(['install', '-g', 'is-number'], ctxOf(fs, '/tmp/other') as never);
+
+    expect(r.exitCode).toBe(0);
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/is-number/package.json`)).toBe(true);
+    expect(await fs.exists('/tmp/other/node_modules/is-number')).toBe(false);
+    expect(await fs.exists('/tmp/other/package.json')).toBe(false);
+    const globalManifest = JSON.parse((await fs.readFile(GLOBAL_PACKAGE_JSON)) as string);
+    expect(globalManifest.dependencies['is-number']).toBeDefined();
+  });
+
+  it('npm install -g behaves identically to ipk install -g', async () => {
+    const reg = buildRegistry([{ name: 'is-number', version: '7.0.0' }]);
+    const cmd = createIpkCommand('npm', { fs, fetch: makeFetch(reg) });
+    const r = await cmd.execute(['install', '-g', 'is-number'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(0);
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/is-number/package.json`)).toBe(true);
+  });
+
+  it('global install with no package name fails clearly', async () => {
+    const cmd = createIpkCommand('ipk', { fs, fetch: makeFetch(buildRegistry([])) });
+    const r = await cmd.execute(['install', '-g'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/global install requires/i);
+  });
+
+  it('global install publishes a PATH delegator for package bins', async () => {
+    const reg = buildRegistry([
+      {
+        name: 'say',
+        version: '1.0.0',
+        files: {
+          'package.json': JSON.stringify({
+            name: 'say',
+            version: '1.0.0',
+            bin: { say: 'cli.js' },
+          }),
+          'cli.js': 'console.log("cli");\n',
+        },
+      },
+    ]);
+    const cmd = createIpkCommand('ipk', { fs, fetch: makeFetch(reg) });
+    const r = await cmd.execute(['install', '-g', 'say'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(0);
+    const delegator = `${GLOBAL_BIN_DIR}/say.jsh`;
+    expect(await fs.exists(delegator)).toBe(true);
+    const source = (await fs.readFile(delegator)) as string;
+    expect(source).toMatch(/@ipk-global-delegator/);
+    expect(source).toMatch(/ipx/);
   });
 });


### PR DESCRIPTION
## Summary

Adds `ipk install -g` / `npm install -g` so CLI packages install into the shared VFS prefix (`/shared/lib/node_modules`), record deps in `/shared/lib/package.json`, publish PATH delegators under `/shared/bin`, and become visible to `ipx`/`npx` and module resolution after the local `node_modules` walk.

## Why

Agents and skills often need toolchain CLIs available from any cwd without polluting every project `package.json`. Real npm `-g` is the familiar surface; this mirrors it inside SLICC's browser-first VFS.

## Approach / Implementation notes

- `global-prefix.ts` — canonical paths for prefix, node_modules, bin dir, manifest
- `installer.ts` — `InstallOptions.global` skips cwd manifest, reconciles `/shared/bin` delegators
- `ipk-command.ts` — parses `-g` / `--global`
- `ipx-command.ts` + `resolver.ts` — append global tree to bin/module search
- Delegators tagged `@ipk-global-delegator` so stale ones can be removed without touching user scripts in `/shared/bin`

## Cross-cutting impact

- **Floats**: CLI + extension (kernel worker shell); uses existing SecureFetch registry path
- **Persisted state**: global installs live under `/shared/lib` in IndexedDB
- **Follow-up PRs planned**: `npm uninstall -g`, `npm list -g`, shell e2e for global bin from unrelated cwd

## Test plan

- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/ipk-command.test.ts packages/webapp/tests/shell/ipk/global-prefix.test.ts packages/webapp/tests/shell/ipk/module-resolve.test.ts`
- [x] `npm run verify` (pre-push hook)
- [ ] Full CI on PR

**Pre-existing failures**: some ipk e2e shell tests time out locally under parallel load; unrelated.

## Documentation

- [x] `docs/shell-reference.md`
- [ ] No other tiers needed

## Risk & rollback

Low blast radius: local `ipk install` unchanged. Revert PR to drop behavior; `/shared/lib` content may remain in profiles until cleared.

## Checklist

- [x] Commits focused and package-local
- [x] No hand-edited `dist/`
- [x] No secrets in diff
- [x] Shell-command change in docs
- [x] CLI/extension parity
