### PR TITLE
feat(shell): global ipk uninstall, list, root + PATH e2e

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -138,6 +138,21 @@ packages still land in `<cwd>/node_modules` and update the nearest project
 `package.json`. Module resolution and `ipx`/`npx` also search the global tree after
 the cwd-relative `node_modules` walk.
 
+### `ipk uninstall -g` / `npm uninstall -g`
+
+`ipk uninstall -g <pkg>` (aliases: `npm uninstall -g`, `npm remove -g`, `npm rm -g`)
+removes the named package from `/shared/lib/package.json`, prunes orphaned
+top-level entries from `/shared/lib/node_modules`, re-resolves remaining global
+direct dependencies, and refreshes `.bin` shims plus `/shared/bin` delegators.
+Without `-g`, uninstall removes entries from the cwd `package.json` and reconciles
+`<cwd>/node_modules` the same way.
+
+### `ipk list -g` / `npm root -g`
+
+`npm list -g` (and `ipk list -g`) prints direct global dependencies with installed
+versions. `npm root -g` prints `/shared/lib/node_modules`; `npm root` without `-g`
+prints `<cwd>/node_modules`.
+
 ### `ipx` / `npx` built-in redirects
 
 `ipx` runs JavaScript package bins from the nearest installed `node_modules`, then the

--- a/packages/webapp/src/shell/ipk/installer.ts
+++ b/packages/webapp/src/shell/ipk/installer.ts
@@ -641,3 +641,236 @@ export async function installFromManifest(
 
   return { results, errors, empty: false };
 }
+
+async function removeDirectDependencies(
+  fs: VirtualFS,
+  manifestRoot: string,
+  names: ReadonlySet<string>
+): Promise<string> {
+  const manifestPath = joinPath(manifestRoot, 'package.json');
+  const existing = await readJsonOr<ProjectManifest>(fs, manifestPath, {});
+  const deps = { ...(existing.dependencies ?? {}) };
+  for (const name of names) {
+    delete deps[name];
+  }
+  const next: ProjectManifest = { ...existing, dependencies: deps };
+  await fs.writeFile(manifestPath, `${JSON.stringify(next, null, 2)}\n`);
+  return manifestPath;
+}
+
+async function pruneTopLevelPackages(
+  fs: VirtualFS,
+  modulesDir: string,
+  keepTopLevel: ReadonlySet<string>
+): Promise<void> {
+  if (!(await fs.exists(modulesDir))) return;
+  let dirEntries: DirEntry[];
+  try {
+    dirEntries = await fs.readDir(modulesDir);
+  } catch {
+    return;
+  }
+  for (const entry of dirEntries) {
+    if (entry.name === '.bin') continue;
+    if (entry.type !== 'directory') continue;
+    if (entry.name.startsWith('@')) {
+      const scopeDir = joinPath(modulesDir, entry.name);
+      let scopeEntries: DirEntry[];
+      try {
+        scopeEntries = await fs.readDir(scopeDir);
+      } catch {
+        continue;
+      }
+      for (const sub of scopeEntries) {
+        if (sub.type !== 'directory') continue;
+        const pkgName = `${entry.name}/${sub.name}`;
+        if (!keepTopLevel.has(pkgName)) {
+          await removeIfExists(fs, joinPath(scopeDir, sub.name));
+        }
+      }
+      continue;
+    }
+    if (!keepTopLevel.has(entry.name)) {
+      await removeIfExists(fs, joinPath(modulesDir, entry.name));
+    }
+  }
+}
+
+/**
+ * Reconcile the global install tree with `/shared/lib/package.json` direct
+ * dependencies: resolve the merged graph, prune orphaned top-level packages,
+ * materialize, and refresh bin shims + PATH delegators.
+ */
+export async function syncGlobalInstallTree(
+  fs: VirtualFS,
+  fetch: SecureFetch,
+  timeoutMs?: number
+): Promise<void> {
+  const manifest = await readJsonOr<ProjectManifest>(fs, GLOBAL_PACKAGE_JSON, {});
+  const entries = collectManifestEntries(manifest);
+
+  if (entries.length === 0) {
+    await removeIfExists(fs, GLOBAL_NODE_MODULES);
+    await reconcileGlobalBinDelegators(fs, new Set());
+    return;
+  }
+
+  const { supplier } = buildPackumentSupplier(fetch, timeoutMs);
+  const rootDependencies: Record<string, string> = {};
+  for (const entry of entries) {
+    rootDependencies[entry.name] = entry.range;
+  }
+
+  const plan = await resolveDependencyTree({
+    rootDependencies,
+    fetchPackument: supplier,
+  });
+
+  await pruneTopLevelPackages(fs, GLOBAL_NODE_MODULES, new Set(Object.keys(plan.root)));
+  await materializePlan(fs, GLOBAL_NODE_MODULES, plan, fetch, timeoutMs);
+  await reconcileRootBinShims(fs, GLOBAL_NODE_MODULES);
+  const installed = await collectInstalledBins(fs, GLOBAL_NODE_MODULES);
+  const chosen = chooseRootBins(installed);
+  await reconcileGlobalBinDelegators(fs, new Set(chosen.keys()));
+}
+
+export interface UninstallResult {
+  name: string;
+  removed: boolean;
+}
+
+export interface UninstallPackagesResult {
+  results: UninstallResult[];
+  errors: InstallFailure[];
+}
+
+export async function uninstallPackages(
+  specs: string[],
+  options: InstallOptions
+): Promise<UninstallPackagesResult> {
+  const { fs, fetch, cwd, timeoutMs, global: globalUninstall = false } = options;
+  if (specs.length === 0) {
+    return { results: [], errors: [] };
+  }
+
+  const names = new Set<string>();
+  const errors: InstallFailure[] = [];
+  for (const spec of specs) {
+    try {
+      names.add(parseInstallSpec(spec).name);
+    } catch (err) {
+      errors.push({ spec, error: toError(err) });
+    }
+  }
+  if (names.size === 0) {
+    return { results: [], errors };
+  }
+
+  const manifestRoot = globalUninstall ? GLOBAL_NPM_PREFIX : cwd;
+  const manifestPath = joinPath(manifestRoot, 'package.json');
+  if (!(await fs.exists(manifestPath))) {
+    for (const spec of specs) {
+      errors.push({
+        spec,
+        error: new ManifestNotFoundError(manifestPath),
+      });
+    }
+    return { results: [], errors };
+  }
+
+  const before = await readJsonOr<ProjectManifest>(fs, manifestPath, {});
+  const beforeDeps = before.dependencies ?? {};
+  const results: UninstallResult[] = [];
+  for (const name of names) {
+    results.push({ name, removed: name in beforeDeps });
+  }
+
+  await removeDirectDependencies(fs, manifestRoot, names);
+
+  if (globalUninstall) {
+    await syncGlobalInstallTree(fs, fetch, timeoutMs);
+  } else {
+    await syncLocalInstallTree(fs, fetch, cwd, timeoutMs);
+  }
+
+  return { results, errors };
+}
+
+async function syncLocalInstallTree(
+  fs: VirtualFS,
+  fetch: SecureFetch,
+  cwd: string,
+  timeoutMs?: number
+): Promise<void> {
+  const manifestPath = joinPath(cwd, 'package.json');
+  const manifest = await readJsonOr<ProjectManifest>(fs, manifestPath, {});
+  const entries = collectManifestEntries(manifest);
+  const modulesDir = joinPath(cwd, 'node_modules');
+
+  if (entries.length === 0) {
+    await removeIfExists(fs, modulesDir);
+    return;
+  }
+
+  const { supplier } = buildPackumentSupplier(fetch, timeoutMs);
+  const rootDependencies: Record<string, string> = {};
+  for (const entry of entries) {
+    rootDependencies[entry.name] = entry.range;
+  }
+
+  const plan = await resolveDependencyTree({
+    rootDependencies,
+    fetchPackument: supplier,
+  });
+
+  await pruneTopLevelPackages(fs, modulesDir, new Set(Object.keys(plan.root)));
+  await materializePlan(fs, modulesDir, plan, fetch, timeoutMs);
+  await reconcileRootBinShims(fs, modulesDir);
+}
+
+export interface GlobalPackageListing {
+  name: string;
+  version: string;
+  range: string;
+}
+
+export async function listGlobalPackages(fs: VirtualFS): Promise<GlobalPackageListing[]> {
+  const manifest = await readJsonOr<ProjectManifest>(fs, GLOBAL_PACKAGE_JSON, {});
+  const deps = manifest.dependencies ?? {};
+  const out: GlobalPackageListing[] = [];
+  for (const [name, range] of Object.entries(deps)) {
+    if (typeof name !== 'string' || typeof range !== 'string') continue;
+    const installedPath = joinPath(packageDirIn(GLOBAL_NODE_MODULES, name), 'package.json');
+    const installed = await readJsonOr<{ version?: string }>(fs, installedPath, {});
+    out.push({
+      name,
+      version: typeof installed.version === 'string' ? installed.version : '?',
+      range,
+    });
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}
+
+export async function listLocalPackages(
+  fs: VirtualFS,
+  cwd: string
+): Promise<GlobalPackageListing[]> {
+  const manifestPath = joinPath(cwd, 'package.json');
+  if (!(await fs.exists(manifestPath))) return [];
+  const manifest = await readJsonOr<ProjectManifest>(fs, manifestPath, {});
+  const entries = collectManifestEntries(manifest);
+  const modulesDir = joinPath(cwd, 'node_modules');
+  const out: GlobalPackageListing[] = [];
+  for (const entry of entries) {
+    const installedPath = joinPath(packageDirIn(modulesDir, entry.name), 'package.json');
+    const installed = await readJsonOr<{ version?: string }>(fs, installedPath, {});
+    out.push({
+      name: entry.name,
+      version: typeof installed.version === 'string' ? installed.version : '?',
+      range: entry.range,
+    });
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}

--- a/packages/webapp/src/shell/supplemental-commands/index.ts
+++ b/packages/webapp/src/shell/supplemental-commands/index.ts
@@ -198,9 +198,24 @@ export function createSupplementalCommands(options: SupplementalCommandsConfig =
     createPython3LikeCommand('python', { buildProcessConfig: options.buildProcessConfig }),
     ...(options.fs && options.fetch
       ? [
-          createIpkCommand('ipk', { fs: options.fs, fetch: options.fetch }),
-          createIpkCommand('npm', { fs: options.fs, fetch: options.fetch }),
-          createIpkCommand('i', { fs: options.fs, fetch: options.fetch }),
+          createIpkCommand('ipk', {
+            fs: options.fs,
+            fetch: options.fetch,
+            scriptCatalog: options.scriptCatalog,
+            syncScriptCommands: options.syncScriptCommands,
+          }),
+          createIpkCommand('npm', {
+            fs: options.fs,
+            fetch: options.fetch,
+            scriptCatalog: options.scriptCatalog,
+            syncScriptCommands: options.syncScriptCommands,
+          }),
+          createIpkCommand('i', {
+            fs: options.fs,
+            fetch: options.fetch,
+            scriptCatalog: options.scriptCatalog,
+            syncScriptCommands: options.syncScriptCommands,
+          }),
           createIpxCommand('ipx', { fs: options.fs, fetch: options.fetch }),
           createIpxCommand('npx', { fs: options.fs, fetch: options.fetch }),
           createDiCommand('di', { fs: options.fs, fetch: options.fetch }),

--- a/packages/webapp/src/shell/supplemental-commands/ipk-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/ipk-command.ts
@@ -15,20 +15,31 @@
 import type { Command, CommandContext, ExecResult, SecureFetch } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import type { VirtualFS } from '../../fs/index.js';
+import { GLOBAL_NODE_MODULES, GLOBAL_NPM_PREFIX } from '../ipk/global-prefix.js';
 import {
   type InstallFromManifestResult,
   installFromManifest,
   installPackages,
+  listGlobalPackages,
+  listLocalPackages,
   ManifestNotFoundError,
+  uninstallPackages,
 } from '../ipk/installer.js';
+import type { ScriptCatalog } from '../script-catalog.js';
 import { LIFECYCLE_SHORTCUTS, RUN_ALIASES, runNpmScript } from './npm-run.js';
 
 export interface IpkCommandDeps {
   fs: VirtualFS;
   fetch: SecureFetch;
+  /** Invalidate `.jsh` discovery after global bin delegator changes. */
+  scriptCatalog?: ScriptCatalog;
+  /** Re-register PATH-visible commands in the active shell session. */
+  syncScriptCommands?: () => void | Promise<void>;
 }
 
 const INSTALL_ALIASES = new Set(['install', 'i', 'add']);
+const UNINSTALL_ALIASES = new Set(['uninstall', 'remove', 'rm', 'un']);
+const LIST_ALIASES = new Set(['list', 'ls']);
 const GLOBAL_INSTALL_FLAGS = new Set(['-g', '--global', '--location=global']);
 
 function usage(name: string): string {
@@ -51,6 +62,14 @@ Global installs:
   ${name} install -g <pkg>   install into /shared/lib/node_modules and publish
                              CLI bins to /shared/bin (on the default $PATH).
                              Records deps in /shared/lib/package.json, not cwd.
+  ${name} uninstall -g <pkg> remove a global package and reconcile the tree
+  ${name} list -g            list globally installed direct dependencies
+  ${name} root -g            print the global node_modules path
+
+Local project (no -g):
+  ${name} uninstall <pkg>    remove from cwd package.json and reconcile node_modules
+  ${name} list               list direct dependencies from cwd package.json
+  ${name} root               print <cwd>/node_modules
 
 Script running:
   ${name} run <script>       run that scripts entry in the directory holding
@@ -95,6 +114,11 @@ export interface ParsedInstallArgs {
 
 /** Split install flags from package specs (supports `-g` anywhere before specs). */
 export function parseInstallArgs(args: string[]): ParsedInstallArgs {
+  return parseGlobalFlagArgs(args);
+}
+
+/** Split global flags from positional args (supports `-g` anywhere before names). */
+export function parseGlobalFlagArgs(args: string[]): ParsedInstallArgs {
   let global = false;
   const specs: string[] = [];
   for (const arg of args) {
@@ -121,6 +145,11 @@ function isHelpRequest(args: string[]): boolean {
 function describeError(err: unknown): string {
   if (err instanceof Error) return err.message;
   return String(err);
+}
+
+async function refreshGlobalBinCommands(deps: IpkCommandDeps): Promise<void> {
+  deps.scriptCatalog?.invalidateJsh();
+  await deps.syncScriptCommands?.();
 }
 
 async function runManifestInstall(
@@ -213,11 +242,118 @@ async function runInstall(
     (e) => `${name}: failed to install ${e.spec}: ${describeError(e.error)}`
   );
 
+  if (global && outcome.errors.length === 0 && outcome.results.length > 0) {
+    await refreshGlobalBinCommands(deps);
+  }
+
   return {
     stdout: stdout.length > 0 ? `${stdout.join('\n')}\n` : '',
     stderr: stderr.length > 0 ? `${stderr.join('\n')}\n` : '',
     exitCode: outcome.errors.length === 0 ? 0 : 1,
   };
+}
+
+function formatPackageList(
+  prefix: string,
+  packages: Array<{ name: string; version: string }>
+): string {
+  if (packages.length === 0) {
+    return `${prefix}\n└── (empty)\n`;
+  }
+  const lines = [`${prefix}`];
+  for (let i = 0; i < packages.length; i++) {
+    const branch = i === packages.length - 1 ? '└──' : '├──';
+    lines.push(`${branch} ${packages[i].name}@${packages[i].version}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+async function runUninstall(
+  name: string,
+  args: string[],
+  ctx: CommandContext,
+  deps: IpkCommandDeps
+): Promise<ExecResult> {
+  const { global, specs } = parseGlobalFlagArgs(args);
+  if (specs.length === 0) {
+    return {
+      stdout: '',
+      stderr: `${name}: uninstall requires at least one package name\n`,
+      exitCode: 1,
+    };
+  }
+
+  let outcome: Awaited<ReturnType<typeof uninstallPackages>>;
+  try {
+    outcome = await uninstallPackages(specs, {
+      fs: deps.fs,
+      fetch: deps.fetch,
+      cwd: ctx.cwd,
+      global,
+    });
+  } catch (err) {
+    return {
+      stdout: '',
+      stderr: `${name}: uninstall failed: ${describeError(err)}\n`,
+      exitCode: 1,
+    };
+  }
+
+  const stdout = outcome.results.filter((r) => r.removed).map((r) => `${name}: removed ${r.name}`);
+  const skipped = outcome.results.filter((r) => !r.removed).map((r) => r.name);
+  const stderrParts = outcome.errors.map(
+    (e) => `${name}: failed to uninstall ${e.spec}: ${describeError(e.error)}`
+  );
+  if (skipped.length > 0) {
+    stderrParts.push(`${name}: ${skipped.join(', ')} not installed${global ? ' globally' : ''}`);
+  }
+
+  const hasErrors = outcome.errors.length > 0;
+  if (global && !hasErrors) {
+    await refreshGlobalBinCommands(deps);
+  }
+  return {
+    stdout: stdout.length > 0 ? `${stdout.join('\n')}\n` : '',
+    stderr: stderrParts.length > 0 ? `${stderrParts.join('\n')}\n` : '',
+    exitCode: hasErrors ? 1 : 0,
+  };
+}
+
+async function runList(
+  name: string,
+  args: string[],
+  ctx: CommandContext,
+  deps: IpkCommandDeps
+): Promise<ExecResult> {
+  const { global } = parseGlobalFlagArgs(args);
+  try {
+    const packages = global
+      ? await listGlobalPackages(deps.fs)
+      : await listLocalPackages(deps.fs, ctx.cwd);
+    const prefix = global ? GLOBAL_NPM_PREFIX : ctx.cwd;
+    return {
+      stdout: formatPackageList(prefix, packages),
+      stderr: '',
+      exitCode: 0,
+    };
+  } catch (err) {
+    return {
+      stdout: '',
+      stderr: `${name}: list failed: ${describeError(err)}\n`,
+      exitCode: 1,
+    };
+  }
+}
+
+async function runRoot(
+  _name: string,
+  args: string[],
+  ctx: CommandContext,
+  _deps: IpkCommandDeps
+): Promise<ExecResult> {
+  const { global } = parseGlobalFlagArgs(args);
+  const path = global ? GLOBAL_NODE_MODULES : `${ctx.cwd.replace(/\/$/, '')}/node_modules`;
+  return { stdout: `${path}\n`, stderr: '', exitCode: 0 };
 }
 
 export function createIpkCommand(name: string, deps: IpkCommandDeps): Command {
@@ -240,6 +376,15 @@ export function createIpkCommand(name: string, deps: IpkCommandDeps): Command {
     if (INSTALL_ALIASES.has(sub)) {
       return runInstall(name, rest, ctx, deps);
     }
+    if (UNINSTALL_ALIASES.has(sub)) {
+      return runUninstall(name, rest, ctx, deps);
+    }
+    if (LIST_ALIASES.has(sub)) {
+      return runList(name, rest, ctx, deps);
+    }
+    if (sub === 'root') {
+      return runRoot(name, rest, ctx, deps);
+    }
     if (RUN_ALIASES.has(sub)) {
       return runNpmScript(name, rest, ctx, { fs: deps.fs });
     }
@@ -251,7 +396,7 @@ export function createIpkCommand(name: string, deps: IpkCommandDeps): Command {
 
     return {
       stdout: '',
-      stderr: `${name}: unknown subcommand '${sub}' (supported: install, i, run)\n`,
+      stderr: `${name}: unknown subcommand '${sub}' (supported: install, uninstall, list, root, run)\n`,
       exitCode: 1,
     };
   });

--- a/packages/webapp/tests/shell/ipk/ipk-global-bin-e2e.test.ts
+++ b/packages/webapp/tests/shell/ipk/ipk-global-bin-e2e.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Global ipk e2e: install -g publishes PATH-visible bins; uninstall -g removes them.
+ */
+import 'fake-indexeddb/auto';
+import { gzipSync } from 'fflate';
+import type { SecureFetch } from 'just-bash';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GLOBAL_BIN_DIR, GLOBAL_NODE_MODULES } from '../../../src/shell/ipk/global-prefix.js';
+
+type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
+type FetchResult = Awaited<ReturnType<SecureFetch>>;
+
+function bytes(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function writeString(view: Uint8Array, offset: number, len: number, value: string): void {
+  for (let i = 0; i < len; i++) view[offset + i] = i < value.length ? value.charCodeAt(i) : 0;
+}
+function writeOctal(view: Uint8Array, offset: number, len: number, value: number): void {
+  const oct = value.toString(8);
+  writeString(view, offset, len - 1, oct.padStart(len - 1, '0'));
+  view[offset + len - 1] = 0;
+}
+function buildHeader(name: string, dataLen: number): Uint8Array {
+  const header = new Uint8Array(512);
+  writeString(header, 0, 100, name);
+  writeOctal(header, 100, 8, 0o644);
+  writeOctal(header, 108, 8, 0);
+  writeOctal(header, 116, 8, 0);
+  writeOctal(header, 124, 12, dataLen);
+  writeOctal(header, 136, 12, 0);
+  for (let i = 0; i < 8; i++) header[148 + i] = 0x20;
+  header[156] = '0'.charCodeAt(0);
+  writeString(header, 257, 6, 'ustar');
+  writeString(header, 263, 2, '00');
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += header[i];
+  writeString(header, 148, 6, sum.toString(8).padStart(6, '0'));
+  header[154] = 0;
+  header[155] = 0x20;
+  return header;
+}
+function buildTar(entries: { name: string; data: Uint8Array }[]): Uint8Array {
+  const chunks: Uint8Array[] = [];
+  for (const e of entries) {
+    chunks.push(buildHeader(e.name, e.data.length));
+    chunks.push(e.data);
+    const pad = (512 - (e.data.length % 512)) % 512;
+    if (pad > 0) chunks.push(new Uint8Array(pad));
+  }
+  chunks.push(new Uint8Array(1024));
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(total);
+  let o = 0;
+  for (const c of chunks) {
+    out.set(c, o);
+    o += c.length;
+  }
+  return out;
+}
+
+interface SyntheticPackage {
+  name: string;
+  version: string;
+  files: Record<string, string>;
+}
+
+function buildTarball(pkg: SyntheticPackage): Uint8Array {
+  return gzipSync(
+    buildTar(
+      Object.entries(pkg.files).map(([path, content]) => ({
+        name: `package/${path}`,
+        data: bytes(content),
+      }))
+    )
+  );
+}
+
+function tarballBasename(name: string, version: string): string {
+  const base = name.startsWith('@') ? name.split('/')[1] : name;
+  return `${base}-${version}.tgz`;
+}
+
+interface Registry {
+  packuments: Record<string, unknown>;
+  tarballs: Record<string, Uint8Array>;
+}
+
+function buildRegistry(packages: SyntheticPackage[]): Registry {
+  const packuments: Record<string, unknown> = {};
+  const tarballs: Record<string, Uint8Array> = {};
+  for (const p of packages) {
+    const url = `https://registry.npmjs.org/${p.name}/-/${tarballBasename(p.name, p.version)}`;
+    tarballs[url] = buildTarball(p);
+    packuments[p.name] = {
+      name: p.name,
+      'dist-tags': { latest: p.version },
+      versions: {
+        [p.version]: {
+          name: p.name,
+          version: p.version,
+          dist: { tarball: url },
+        },
+      },
+    };
+  }
+  return { packuments, tarballs };
+}
+
+const sharedRegistry: { current: Registry } = { current: { packuments: {}, tarballs: {} } };
+
+vi.mock('../../../src/shell/proxied-fetch.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/shell/proxied-fetch.js')>();
+  const mockFetch = (async (url: string, _opts?: SecureFetchOptions): Promise<FetchResult> => {
+    const reg = sharedRegistry.current;
+    if (reg.tarballs[url]) {
+      return {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'content-type': 'application/octet-stream' },
+        body: reg.tarballs[url],
+        url,
+      };
+    }
+    for (const name of Object.keys(reg.packuments)) {
+      if (url.endsWith(`/${name}`)) {
+        return {
+          status: 200,
+          statusText: 'OK',
+          headers: { 'content-type': 'application/json' },
+          body: bytes(JSON.stringify(reg.packuments[name])),
+          url,
+        };
+      }
+    }
+    return {
+      status: 404,
+      statusText: 'Not Found',
+      headers: {},
+      body: bytes('not found'),
+      url,
+    };
+  }) as unknown as SecureFetch;
+  return {
+    ...actual,
+    createProxiedFetch: () => mockFetch,
+  };
+});
+
+let dbCounter = 0;
+
+describe('global ipk bins via PATH (AlmostBashShellHeadless)', () => {
+  beforeEach(() => {
+    sharedRegistry.current = { packuments: {}, tarballs: {} };
+  });
+
+  async function newShell(cwd = '/work') {
+    const { VirtualFS } = await import('../../../src/fs/index.js');
+    const { AlmostBashShellHeadless } = await import(
+      '../../../src/shell/almost-bash-shell-headless.js'
+    );
+    const fs = await VirtualFS.create({
+      dbName: `test-ipk-global-bin-${dbCounter++}`,
+      wipe: true,
+    });
+    await fs.mkdir(cwd, { recursive: true });
+    await fs.mkdir('/tmp/other', { recursive: true });
+    const shell = new AlmostBashShellHeadless({ fs, cwd });
+    return { shell, fs };
+  }
+
+  it('invokes a globally installed bin from an unrelated cwd via PATH', async () => {
+    sharedRegistry.current = buildRegistry([
+      {
+        name: 'greet',
+        version: '1.0.0',
+        files: {
+          'package.json': JSON.stringify({
+            name: 'greet',
+            version: '1.0.0',
+            bin: { greet: 'cli.js' },
+          }),
+          'cli.js': 'console.log("hello-global");\n',
+        },
+      },
+    ]);
+    const { shell, fs } = await newShell();
+
+    const install = await shell.executeCommand('ipk install -g greet');
+    expect(install.exitCode).toBe(0);
+    expect(await fs.exists(`${GLOBAL_BIN_DIR}/greet.jsh`)).toBe(true);
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/greet/package.json`)).toBe(true);
+
+    const run = await shell.executeCommand('cd /tmp/other && greet');
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout).toContain('hello-global');
+
+    await fs.dispose();
+  });
+
+  it('npm uninstall -g removes the PATH delegator', async () => {
+    sharedRegistry.current = buildRegistry([
+      {
+        name: 'greet',
+        version: '1.0.0',
+        files: {
+          'package.json': JSON.stringify({
+            name: 'greet',
+            version: '1.0.0',
+            bin: { greet: 'cli.js' },
+          }),
+          'cli.js': 'console.log("hello");\n',
+        },
+      },
+    ]);
+    const { shell, fs } = await newShell();
+
+    await shell.executeCommand('npm install -g greet');
+    expect(await fs.exists(`${GLOBAL_BIN_DIR}/greet.jsh`)).toBe(true);
+
+    const uninstall = await shell.executeCommand('npm uninstall -g greet');
+    expect(uninstall.exitCode).toBe(0);
+    expect(await fs.exists(`${GLOBAL_BIN_DIR}/greet.jsh`)).toBe(false);
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/greet`)).toBe(false);
+
+    await fs.dispose();
+  });
+});

--- a/packages/webapp/tests/shell/ipk/ipk-no-arg-shell.test.ts
+++ b/packages/webapp/tests/shell/ipk/ipk-no-arg-shell.test.ts
@@ -442,8 +442,6 @@ describe('npm-alias failure-path parity', () => {
   it.each([
     ['ipk bogus', 'ipk'],
     ['npm bogus', 'npm'],
-    ['npm uninstall foo', 'npm'],
-    ['npm remove foo', 'npm'],
   ])('`%s` is rejected as an unsupported subcommand', async (cmd) => {
     sharedRegistry.current = { packuments: {}, tarballs: {}, calls: [] };
     const { shell, fs } = await newShell();

--- a/packages/webapp/tests/shell/supplemental-commands/ipk-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/ipk-command.test.ts
@@ -6,6 +6,7 @@ import { VirtualFS } from '../../../src/fs/index.js';
 import {
   GLOBAL_BIN_DIR,
   GLOBAL_NODE_MODULES,
+  GLOBAL_NPM_PREFIX,
   GLOBAL_PACKAGE_JSON,
 } from '../../../src/shell/ipk/global-prefix.js';
 import {
@@ -400,9 +401,9 @@ describe('createIpkCommand', () => {
 
   it('npm with an unsupported subcommand prints an error and exits non-zero', async () => {
     const cmd = createIpkCommand('npm', { fs, fetch: makeFetch(buildRegistry([])) });
-    const r = await cmd.execute(['remove', 'x'], ctxOf(fs) as never);
+    const r = await cmd.execute(['bogus', 'x'], ctxOf(fs) as never);
     expect(r.exitCode).not.toBe(0);
-    expect(r.stderr).toMatch(/unknown subcommand|remove/);
+    expect(r.stderr).toMatch(/unknown subcommand|bogus/);
   });
 
   it('i with no args reports a clear error', async () => {
@@ -626,5 +627,57 @@ describe('createIpkCommand', () => {
     expect(r.exitCode).toBe(1);
     expect(r.stderr).toMatch(/refusing to overwrite/i);
     expect((await fs.readFile(`${GLOBAL_BIN_DIR}/say.jsh`)) as string).toBe('// user script\n');
+  });
+
+  it('npm root -g prints the global node_modules path', async () => {
+    const cmd = createIpkCommand('npm', { fs, fetch: makeFetch(buildRegistry([])) });
+    const r = await cmd.execute(['root', '-g'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe(GLOBAL_NODE_MODULES);
+  });
+
+  it('npm list -g lists globally installed direct dependencies', async () => {
+    const reg = buildRegistry([{ name: 'is-number', version: '7.0.0' }]);
+    const cmd = createIpkCommand('npm', { fs, fetch: makeFetch(reg) });
+    await cmd.execute(['install', '-g', 'is-number'], ctxOf(fs) as never);
+    const r = await cmd.execute(['list', '-g'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain(GLOBAL_NPM_PREFIX);
+    expect(r.stdout).toContain('is-number@7.0.0');
+  });
+
+  it('ipk uninstall -g removes a global package and reconciles the tree', async () => {
+    const reg = buildRegistry([
+      { name: 'keep', version: '1.0.0' },
+      { name: 'drop', version: '1.0.0' },
+    ]);
+    const cmd = createIpkCommand('ipk', { fs, fetch: makeFetch(reg) });
+    await cmd.execute(['install', '-g', 'keep', 'drop'], ctxOf(fs) as never);
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/keep`)).toBe(true);
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/drop`)).toBe(true);
+
+    const r = await cmd.execute(['uninstall', '-g', 'drop'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/removed drop/);
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/drop`)).toBe(false);
+    expect(await fs.exists(`${GLOBAL_NODE_MODULES}/keep`)).toBe(true);
+    const manifest = JSON.parse((await fs.readFile(GLOBAL_PACKAGE_JSON)) as string);
+    expect(manifest.dependencies.keep).toBeDefined();
+    expect(manifest.dependencies.drop).toBeUndefined();
+  });
+
+  it('local uninstall removes package from cwd manifest and node_modules', async () => {
+    const reg = buildRegistry([
+      { name: 'keep', version: '1.0.0' },
+      { name: 'drop', version: '1.0.0' },
+    ]);
+    const cmd = createIpkCommand('npm', { fs, fetch: makeFetch(reg) });
+    await cmd.execute(['install', 'keep', 'drop'], ctxOf(fs) as never);
+    const r = await cmd.execute(['uninstall', 'drop'], ctxOf(fs) as never);
+    expect(r.exitCode).toBe(0);
+    expect(await fs.exists('/work/node_modules/drop')).toBe(false);
+    expect(await fs.exists('/work/node_modules/keep')).toBe(true);
+    const manifest = JSON.parse((await fs.readFile('/work/package.json')) as string);
+    expect(manifest.dependencies.drop).toBeUndefined();
   });
 });


### PR DESCRIPTION
<!-- Stacked on / follow-up to: Stacked on #2368. Merge that PR first. -->

## Summary

- Adds `ipk`/`npm` uninstall (`remove`/`rm`/`un`), list, and root subcommands with `-g` for the shared global prefix
- Global uninstall removes entries from `/shared/lib/package.json`, prunes orphaned top-level packages, re-resolves remaining direct deps, and refreshes `.bin` shims plus `/shared/bin` delegators
- Local uninstall/list/root (without `-g`) reconcile the cwd `package.json` and `node_modules`
- After global install/uninstall, invalidates the script catalog and re-syncs PATH-visible `.jsh` commands so new bins work in the same shell session
- Shell e2e: globally installed bin invocable from an unrelated cwd via `$PATH`

## Why

PR #2368 added `ipk install -g`; this follow-up completes the npm-global surface (uninstall/list/root) and proves PATH delegators work end-to-end in a real shell.

## Test plan

- [x] `ipk-command.test.ts` — uninstall -g, list -g, root -g, local uninstall
- [x] `ipk-global-bin-e2e.test.ts` — PATH invocation + uninstall removes delegator
- [ ] CI green (stacked on #2368)

## Documentation

- [x] `docs/shell-reference.md`
