### PR TITLE
test(e2e): contain a mid-suite wrangler crash instead of losing the run

### DIFF
--- a/.agents/skills/writing-slicc-tests/SKILL.md
+++ b/.agents/skills/writing-slicc-tests/SKILL.md
@@ -852,6 +852,8 @@ the UI:
 - **wrangler dev on 8787** — serves the built `dist/ui` (the leader / UI
   origin and the Playwright `baseURL`) with SPA fallback, exactly as the
   production worker does. Requires `npm run build -w @slicc/webapp` first.
+  Runs under the supervisor in `wrangler-server.ts` — see "Survive a wrangler
+  crash" below.
 - **node-server `--serve-only --cdp-port=9222` on 5710** — the thin `/cdp`
   bridge + `/api` surface only. `SLICC_BRIDGE_TOKEN` arms the `/cdp` upgrade
   gate + cross-origin `/api` token check, and `BRIDGE_DEV_ALLOWED_ORIGINS`
@@ -892,6 +894,41 @@ conditional leg: when the `speech` path filter matches, the run sets
 `RUN_REAL_SPEECH_E2E=1` (un-skipping `speech-roundtrip.test.ts`) and
 frees runner disk first so Chromium's free-disk-derived storage quota
 can hold the staged weights.
+
+### Survive a wrangler Crash
+
+`wrangler dev` (workerd) dies mid-suite (#2372). Left alone, the first crash
+turns every later spec into a ~200 ms `ERR_CONNECTION_REFUSED` failure — a wall
+of red naming eighteen innocent tests. The likely cause is
+[workers-sdk#15202](https://github.com/cloudflare/workers-sdk/issues/15202):
+workerd exits with `kj/async-io-unix.c++: … Broken pipe` when the consumer of
+its stdout (Playwright's `webServer` capture) stops draining the pipe.
+
+Three pieces contain it, and one rule applies when you write a spec:
+
+- **Import `test` from `./fixtures.js`, never from `@playwright/test`.** That
+  is the whole rule. `fixtures.ts` re-exports `expect` unchanged and adds one
+  auto fixture that probes `HEAD <baseURL>/status` before and after every test.
+- **`wrangler-server.ts`** supervises wrangler instead of Playwright spawning it
+  directly: it owns (and always drains) wrangler's stdout, mirrors it to
+  `.wrangler/e2e-logs/wrangler-output.log`, re-spawns workerd when it exits, and
+  serves `POST /restart` on `SLICC_E2E_WRANGLER_SUPERVISOR_PORT`
+  (default: leader port + 1).
+- **`leader-health.ts`** decides what happens on a dead origin: restart through
+  the supervisor and fail _only_ the current spec with an error named
+  `WRANGLER_CRASHED`. If the restart fails, the remaining specs fail instantly
+  with the same named error instead of burning their timeouts — the job then
+  names its cause. Its logic is dependency-injected and unit-tested in
+  `packages/webapp/tests/e2e-harness/leader-health.test.ts`.
+
+So a crash costs one spec (which CI then retries), not the run. Evidence lands
+in `.wrangler/e2e-logs/`: wrangler's own `wrangler-<ts>.log`, the mirrored
+output, and `crash-report.md` (one section per unexpected workerd exit, with
+the output tail). The CI job prints the crash report and uploads the directory
+as the `wrangler-logs-e2e` artifact.
+
+Grep a red e2e job for `WRANGLER_CRASHED` before believing the failing spec
+names are meaningful.
 
 ### Verify Risks with the Reference Scenario
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,18 +548,36 @@ jobs:
             packages/webapp/test-results/
             packages/webapp/tests/e2e/test-results/
           if-no-files-found: ignore
+      - name: Show wrangler crash report
+        # The supervisor (`packages/webapp/tests/e2e/wrangler-server.ts`) appends
+        # one section per unexpected workerd exit — code, signal, and the tail of
+        # its output. Printing it here means a mid-suite crash (#2372) is visible
+        # in the job log itself, without downloading an artifact, even when the
+        # Playwright retry made the job green.
+        if: always()
+        run: |
+          if [ -f .wrangler/e2e-logs/crash-report.md ]; then
+            echo '::warning title=WRANGLER_CRASHED::wrangler dev crashed during the e2e run - see the crash report below and the wrangler-logs-e2e artifact'
+            cat .wrangler/e2e-logs/crash-report.md
+          else
+            echo 'No wrangler crash recorded.'
+          fi
       - name: Upload wrangler logs
         # wrangler writes structured startup + request logs to
-        # ~/.config/.wrangler/logs/wrangler-YYYY-MM-DD_HH-MM-SS.log even when
-        # its stderr is captured by another process; that file is where the
-        # real workerd bring-up stack ends up when the process crashes during
-        # the tail of `wrangler dev` startup. Uploading it turns an otherwise
-        # empty `X [ERROR]` in the Playwright surface into a full stack.
+        # wrangler-YYYY-MM-DD_HH-MM-SS.log even when its stderr is captured by
+        # another process; that file is where the real workerd bring-up stack
+        # ends up when the process crashes. The Playwright config points
+        # `WRANGLER_LOG_PATH` at `.wrangler/e2e-logs/` so those logs (plus the
+        # supervisor's crash report) land in the workspace and can be uploaded;
+        # the home-directory path stays listed for a wrangler invocation that
+        # does not inherit the override.
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wrangler-logs-e2e
-          path: ~/.config/.wrangler/logs/
+          path: |
+            .wrangler/e2e-logs/
+            ~/.config/.wrangler/logs/
           if-no-files-found: ignore
 
   node-server:

--- a/packages/webapp/tests/e2e-harness/leader-health.test.ts
+++ b/packages/webapp/tests/e2e-harness/leader-health.test.ts
@@ -1,0 +1,138 @@
+// Unit coverage for the E2E leader-origin health gate (#2372). The gate itself
+// only runs inside Playwright, so its decision logic lives in a dependency-
+// injected module that Vitest can drive without a browser or a live workerd.
+import { describe, expect, it, vi } from 'vitest';
+import {
+  assertLeaderAlive,
+  createLeaderHealthState,
+  type LeaderHealthDeps,
+  probeLeader,
+  WRANGLER_CRASHED,
+  WranglerCrashedError,
+} from '../e2e/leader-health.js';
+
+function makeDeps(
+  responder: (url: string, init?: RequestInit) => Promise<{ ok: boolean }>
+): LeaderHealthDeps & { logs: string[] } {
+  const logs: string[] = [];
+  return {
+    statusUrl: 'http://localhost:8787/status',
+    restartUrl: 'http://127.0.0.1:8788/restart',
+    fetch: responder,
+    sleep: async () => {},
+    log: (message) => logs.push(message),
+    logs,
+  };
+}
+
+describe('probeLeader', () => {
+  it('accepts a single healthy HEAD without a second request', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => ({ ok: true }));
+    const deps = makeDeps(fetchMock);
+
+    await expect(probeLeader(deps)).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[1]?.method).toBe('HEAD');
+  });
+
+  it('confirms a failed HEAD with a GET so one dropped response is not a crash', async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) =>
+      init?.method === 'HEAD' ? { ok: false } : { ok: true }
+    );
+
+    await expect(probeLeader(makeDeps(fetchMock))).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a refused connection (throw) as dead', async () => {
+    const deps = makeDeps(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+
+    await expect(probeLeader(deps)).resolves.toBe(false);
+  });
+});
+
+describe('assertLeaderAlive', () => {
+  it('is a no-op while the origin answers', async () => {
+    const deps = makeDeps(async () => ({ ok: true }));
+    const state = createLeaderHealthState();
+
+    await expect(assertLeaderAlive(deps, state, 'spec', 'before')).resolves.toBeUndefined();
+    expect(state.restarts).toBe(0);
+    expect(state.aborted).toBeNull();
+  });
+
+  it('restarts wrangler and fails only the current spec when the origin died', async () => {
+    let restarted = false;
+    const deps = makeDeps(async (url) => {
+      if (url.endsWith('/restart')) {
+        restarted = true;
+        return { ok: true };
+      }
+      return { ok: restarted };
+    });
+    const state = createLeaderHealthState();
+
+    const error = await assertLeaderAlive(deps, state, 'reference scenario', 'before').catch(
+      (e: unknown) => e
+    );
+
+    expect(error).toBeInstanceOf(WranglerCrashedError);
+    expect((error as Error).name).toBe(WRANGLER_CRASHED);
+    expect((error as Error).message).toContain('before "reference scenario"');
+    expect(restarted).toBe(true);
+    // Restart succeeded, so the suite is NOT latched off — later specs run.
+    expect(state.aborted).toBeNull();
+    expect(state.restarts).toBe(1);
+  });
+
+  it('names the running spec when the origin dies during it', async () => {
+    const deps = makeDeps(async (url) => ({ ok: url.endsWith('/restart') }));
+    const state = createLeaderHealthState();
+
+    const error = await assertLeaderAlive(deps, state, 'transcript export', 'after').catch(
+      (e: unknown) => e
+    );
+
+    // Restart POST answered ok but the origin never came back → suite latched.
+    expect((error as Error).message).toContain('during "transcript export"');
+    expect(state.aborted).not.toBeNull();
+  });
+
+  it('latches the suite off when no supervisor can restart wrangler', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    const deps = makeDeps(fetchMock);
+    const state = createLeaderHealthState();
+
+    await expect(assertLeaderAlive(deps, state, 'first', 'before')).rejects.toThrow(
+      /could not.*bring it back/s
+    );
+    expect(state.aborted).toContain('died before "first"');
+
+    const callsAfterFirst = fetchMock.mock.calls.length;
+    // Every later spec fails instantly with the same named error rather than
+    // burning its 30 s timeout against a dead origin.
+    const error = await assertLeaderAlive(deps, state, 'second', 'before').catch((e: unknown) => e);
+    expect((error as Error).name).toBe(WRANGLER_CRASHED);
+    expect((error as Error).message).toContain('skipping "second"');
+    expect(fetchMock.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it('emits a CI warning annotation so a contained crash stays visible', async () => {
+    const previous = process.env['CI'];
+    process.env['CI'] = 'true';
+    try {
+      const deps = makeDeps(async (url) => ({ ok: url.endsWith('/restart') }));
+      await assertLeaderAlive(deps, createLeaderHealthState(), 'spec', 'before').catch(() => {});
+      expect(
+        deps.logs.some((line) => line.startsWith(`::warning title=${WRANGLER_CRASHED}::`))
+      ).toBe(true);
+    } finally {
+      if (previous === undefined) delete process.env['CI'];
+      else process.env['CI'] = previous;
+    }
+  });
+});

--- a/packages/webapp/tests/e2e-harness/leader-health.test.ts
+++ b/packages/webapp/tests/e2e-harness/leader-health.test.ts
@@ -121,6 +121,33 @@ describe('assertLeaderAlive', () => {
     expect(fetchMock.mock.calls.length).toBe(callsAfterFirst);
   });
 
+  it('signals the slow path once, before any restart is awaited', async () => {
+    const onSlowPath = vi.fn();
+    const healthy = makeDeps(async () => ({ ok: true }));
+
+    await assertLeaderAlive(healthy, createLeaderHealthState(), 'spec', 'before', onSlowPath);
+    // A live origin must not inflate the spec's timeout budget.
+    expect(onSlowPath).not.toHaveBeenCalled();
+
+    const dead = makeDeps(async (url) => ({ ok: url.endsWith('/restart') }));
+    await assertLeaderAlive(dead, createLeaderHealthState(), 'spec', 'before', onSlowPath).catch(
+      () => {}
+    );
+    expect(onSlowPath).toHaveBeenCalledTimes(1);
+  });
+
+  it('latches when the supervisor refuses to restart (its permanent-failure short circuit)', async () => {
+    // The supervisor answers 503 without attempting another cold start once it
+    // has given up; the fixture must treat that as unrecoverable, not retry it.
+    const deps = makeDeps(async () => ({ ok: false }));
+    const state = createLeaderHealthState();
+
+    await expect(assertLeaderAlive(deps, state, 'spec', 'before')).rejects.toThrow(
+      /could not.*bring it back/s
+    );
+    expect(state.aborted).not.toBeNull();
+  });
+
   it('emits a CI warning annotation so a contained crash stays visible', async () => {
     const previous = process.env['CI'];
     process.env['CI'] = 'true';

--- a/packages/webapp/tests/e2e/compaction-robustness.test.ts
+++ b/packages/webapp/tests/e2e/compaction-robustness.test.ts
@@ -19,7 +19,6 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { expect, test } from '@playwright/test';
 import {
   loadFakeLlmFixture,
   resetFakeLlm,
@@ -27,6 +26,7 @@ import {
   submitUserMessage,
   waitForTurnComplete,
 } from './fake-llm-helpers.js';
+import { expect, test } from './fixtures.js';
 import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
 
 const fixture = (name: string): unknown =>

--- a/packages/webapp/tests/e2e/fixtures.ts
+++ b/packages/webapp/tests/e2e/fixtures.ts
@@ -1,0 +1,50 @@
+/**
+ * The E2E suite's `test` object. Import `{ expect, test }` from here, never
+ * from `@playwright/test` directly — the difference is one auto fixture that
+ * contains a mid-suite `wrangler dev` crash (#2372).
+ *
+ * Before and after every spec it checks that the leader origin still answers.
+ * A dead origin restarts workerd through the supervisor and fails the current
+ * spec with a `WRANGLER_CRASHED`-named error, instead of letting the remaining
+ * specs bleed out with `ERR_CONNECTION_REFUSED`. The post-test half attributes
+ * the crash to the spec that was running when workerd went down.
+ */
+import { test as base, expect } from '@playwright/test';
+import {
+  assertLeaderAlive,
+  createLeaderHealthState,
+  type LeaderHealthDeps,
+} from './leader-health.js';
+import { LEADER_ORIGIN, WRANGLER_SUPERVISOR_ORIGIN } from './playwright.config.js';
+
+export { WRANGLER_CRASHED, WranglerCrashedError } from './leader-health.js';
+export { expect };
+
+function healthDeps(origin: string): LeaderHealthDeps {
+  return {
+    // `/status` runs the worker's own `fetch` handler (assets are configured
+    // `run_worker_first`), so a 200 proves workerd is warm — not merely bound.
+    statusUrl: `${origin}/status`,
+    restartUrl: `${WRANGLER_SUPERVISOR_ORIGIN}/restart`,
+    fetch: (input, init) => fetch(input, init),
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    log: (message) => console.log(message),
+  };
+}
+
+/** Per-worker-process state. Playwright restarts a worker after a failure, so
+ *  the abort latch only shortcuts specs inside the same process; a fresh worker
+ *  re-probes (a refused connection costs milliseconds) and may recover. */
+const state = createLeaderHealthState();
+
+export const test = base.extend<{ leaderAlive: void }>({
+  leaderAlive: [
+    async ({ baseURL }, use, testInfo) => {
+      const deps = healthDeps(baseURL ?? LEADER_ORIGIN);
+      await assertLeaderAlive(deps, state, testInfo.title, 'before');
+      await use();
+      await assertLeaderAlive(deps, state, testInfo.title, 'after');
+    },
+    { auto: true },
+  ],
+});

--- a/packages/webapp/tests/e2e/fixtures.ts
+++ b/packages/webapp/tests/e2e/fixtures.ts
@@ -14,6 +14,7 @@ import {
   assertLeaderAlive,
   createLeaderHealthState,
   type LeaderHealthDeps,
+  RESTART_TIMEOUT_MS,
 } from './leader-health.js';
 import { LEADER_ORIGIN, WRANGLER_SUPERVISOR_ORIGIN } from './playwright.config.js';
 
@@ -41,9 +42,15 @@ export const test = base.extend<{ leaderAlive: void }>({
   leaderAlive: [
     async ({ baseURL }, use, testInfo) => {
       const deps = healthDeps(baseURL ?? LEADER_ORIGIN);
-      await assertLeaderAlive(deps, state, testInfo.title, 'before');
+      // A spec's own timeout also bounds its fixtures, and it is far shorter
+      // than a workerd cold start. Extend it only on the slow path, so a real
+      // hang in a healthy run still fails at the configured timeout.
+      const grantRestartBudget = (): void => {
+        testInfo.setTimeout(testInfo.timeout + RESTART_TIMEOUT_MS);
+      };
+      await assertLeaderAlive(deps, state, testInfo.title, 'before', grantRestartBudget);
       await use();
-      await assertLeaderAlive(deps, state, testInfo.title, 'after');
+      await assertLeaderAlive(deps, state, testInfo.title, 'after', grantRestartBudget);
     },
     { auto: true },
   ],

--- a/packages/webapp/tests/e2e/git-clone-live.test.ts
+++ b/packages/webapp/tests/e2e/git-clone-live.test.ts
@@ -29,7 +29,7 @@
  *   Run: npm run test:e2e -- git-clone-live
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures.js';
 import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
 
 const CLONE_URL = 'https://github.com/ai-ecoverse/skills.git';

--- a/packages/webapp/tests/e2e/leader-health.ts
+++ b/packages/webapp/tests/e2e/leader-health.ts
@@ -1,0 +1,156 @@
+/**
+ * Leader-origin health gate for the E2E suite (#2372).
+ *
+ * `wrangler dev` (workerd) dies mid-suite often enough to matter. Playwright
+ * never revives a `webServer`, so the first crash turns every remaining spec
+ * into a ~200 ms `ERR_CONNECTION_REFUSED` failure: a wall of red that names
+ * eighteen innocent tests instead of the one thing that broke.
+ *
+ * This module is the containment layer. Around every test the fixture in
+ * `fixtures.ts` asks whether the leader origin still answers; when it does not,
+ * it asks the supervisor (`wrangler-server.ts`) to restart workerd and fails
+ * only the current spec with a {@link WRANGLER_CRASHED}-named error. The suite
+ * carries on against a fresh origin, and the job's failure names the cause.
+ *
+ * Kept free of `@playwright/test` imports (and of any ambient state beyond the
+ * caller-owned {@link LeaderHealthState}) so the logic is unit-testable under
+ * Vitest — see `packages/webapp/tests/e2e-harness/leader-health.test.ts`.
+ */
+
+/** `Error.name` every crash-containment failure carries, so a CI log search
+ *  for one string finds the real cause of a mass e2e failure. */
+export const WRANGLER_CRASHED = 'WRANGLER_CRASHED';
+
+/** Failure raised when the leader origin is dead around a spec. */
+export class WranglerCrashedError extends Error {
+  override readonly name = WRANGLER_CRASHED;
+}
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<{ ok: boolean }>;
+
+export interface LeaderHealthDeps {
+  /** Worker-backed readiness URL (`<leader origin>/status`). */
+  readonly statusUrl: string;
+  /** Supervisor control-plane restart endpoint. */
+  readonly restartUrl: string;
+  readonly fetch: FetchLike;
+  readonly sleep: (ms: number) => Promise<void>;
+  readonly log: (message: string) => void;
+}
+
+export interface LeaderHealthState {
+  /** Set once a restart has failed: every later spec then fails immediately
+   *  with the named error instead of burning its full timeout. */
+  aborted: string | null;
+  /** Restarts this worker process has driven — reported in the failure text. */
+  restarts: number;
+}
+
+export function createLeaderHealthState(): LeaderHealthState {
+  return { aborted: null, restarts: 0 };
+}
+
+/** How long a single probe may hang before the origin counts as unreachable.
+ *  A live workerd answers `/status` in single-digit ms; a dead one refuses the
+ *  connection instantly. The budget only covers a wedged-but-listening socket. */
+const PROBE_TIMEOUT_MS = 5_000;
+/** Probes to run before declaring death. A crashed origin refuses instantly, so
+ *  the confirmation round costs nothing on the failure path and protects
+ *  against a single blip on the (far more common) healthy path. */
+const PROBE_ATTEMPTS = 2;
+/** Bound on the supervisor's restart round-trip: workerd's cold start is ~10 s
+ *  locally and can exceed a minute on a loaded runner. */
+const RESTART_TIMEOUT_MS = 150_000;
+
+async function probeOnce(deps: LeaderHealthDeps, method: 'HEAD' | 'GET'): Promise<boolean> {
+  try {
+    const response = await deps.fetch(deps.statusUrl, {
+      method,
+      headers: { 'cache-control': 'no-store' },
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Is the leader origin serving? A cheap `HEAD /status` first (the worker's own
+ * `fetch` handler runs, so this proves workerd is warm, not merely bound); a
+ * `GET` confirmation only on failure, so one dropped response never fails a
+ * spec that would otherwise have passed.
+ */
+export async function probeLeader(deps: LeaderHealthDeps): Promise<boolean> {
+  for (let attempt = 0; attempt < PROBE_ATTEMPTS; attempt++) {
+    if (await probeOnce(deps, attempt === 0 ? 'HEAD' : 'GET')) return true;
+    if (attempt + 1 < PROBE_ATTEMPTS) await deps.sleep(250);
+  }
+  return false;
+}
+
+/** Ask the supervisor to respawn workerd. Resolves true once the origin
+ *  answers again. A supervisor that is itself gone (connection refused) means
+ *  no restart is possible — the suite then aborts with the named error. */
+async function requestRestart(deps: LeaderHealthDeps): Promise<boolean> {
+  try {
+    const response = await deps.fetch(deps.restartUrl, {
+      method: 'POST',
+      signal: AbortSignal.timeout(RESTART_TIMEOUT_MS),
+    });
+    if (!response.ok) return false;
+  } catch {
+    return false;
+  }
+  return probeLeader(deps);
+}
+
+/** GitHub Actions surfaces `::warning::` lines in the job summary, so a
+ *  contained crash stays visible even when the retry turns the job green. */
+function warn(deps: LeaderHealthDeps, message: string): void {
+  deps.log(process.env['CI'] ? `::warning title=${WRANGLER_CRASHED}::${message}` : message);
+}
+
+/**
+ * Assert the leader origin is alive around `context` (a spec title), restarting
+ * workerd if it is not.
+ *
+ * Throws {@link WranglerCrashedError} whenever the origin was found dead —
+ * whether or not the restart succeeded. Failing the current spec is the point:
+ * it attributes the crash to a named cause at a known moment, and the following
+ * specs run against a healthy origin instead of inheriting the corpse.
+ */
+export async function assertLeaderAlive(
+  deps: LeaderHealthDeps,
+  state: LeaderHealthState,
+  context: string,
+  phase: 'before' | 'after'
+): Promise<void> {
+  if (state.aborted) {
+    throw new WranglerCrashedError(
+      `Leader origin (wrangler dev) is down and could not be restarted; skipping "${context}". ` +
+        `First failure: ${state.aborted}`
+    );
+  }
+  if (await probeLeader(deps)) return;
+
+  const when = phase === 'before' ? `before "${context}"` : `during "${context}"`;
+  warn(deps, `Leader origin ${deps.statusUrl} stopped answering ${when} — restarting wrangler.`);
+
+  const recovered = await requestRestart(deps);
+  if (!recovered) {
+    const message =
+      `Leader origin (wrangler dev / workerd) died ${when} and the supervisor could not ` +
+      `bring it back. Remaining specs are aborted; see the wrangler crash log artifact.`;
+    state.aborted = message;
+    throw new WranglerCrashedError(message);
+  }
+
+  state.restarts += 1;
+  throw new WranglerCrashedError(
+    `Leader origin (wrangler dev / workerd) died ${when}. wrangler was restarted ` +
+      `(#${state.restarts} this worker) and the suite continues; only this spec is failed, ` +
+      `so a workerd crash no longer reads as a wall of unrelated test failures. ` +
+      `See the wrangler crash log artifact (crash-report.md) for workerd's own output.`
+  );
+}

--- a/packages/webapp/tests/e2e/leader-health.ts
+++ b/packages/webapp/tests/e2e/leader-health.ts
@@ -59,8 +59,11 @@ const PROBE_TIMEOUT_MS = 5_000;
  *  against a single blip on the (far more common) healthy path. */
 const PROBE_ATTEMPTS = 2;
 /** Bound on the supervisor's restart round-trip: workerd's cold start is ~10 s
- *  locally and can exceed a minute on a loaded runner. */
-const RESTART_TIMEOUT_MS = 150_000;
+ *  locally and can exceed a minute on a loaded runner. Exported because a spec's
+ *  own 30 s timeout also covers its fixtures — the fixture must extend the test
+ *  budget by this much before waiting on a restart, or Playwright kills it first
+ *  and reports a generic timeout instead of {@link WRANGLER_CRASHED}. */
+export const RESTART_TIMEOUT_MS = 150_000;
 
 async function probeOnce(deps: LeaderHealthDeps, method: 'HEAD' | 'GET'): Promise<boolean> {
   try {
@@ -124,7 +127,10 @@ export async function assertLeaderAlive(
   deps: LeaderHealthDeps,
   state: LeaderHealthState,
   context: string,
-  phase: 'before' | 'after'
+  phase: 'before' | 'after',
+  /** Called once, before any restart is awaited, so the caller can extend the
+   *  current test's timeout to cover {@link RESTART_TIMEOUT_MS}. */
+  onSlowPath?: () => void
 ): Promise<void> {
   if (state.aborted) {
     throw new WranglerCrashedError(
@@ -133,6 +139,7 @@ export async function assertLeaderAlive(
     );
   }
   if (await probeLeader(deps)) return;
+  onSlowPath?.();
 
   const when = phase === 'before' ? `before "${context}"` : `during "${context}"`;
   warn(deps, `Leader origin ${deps.statusUrl} stopped answering ${when} — restarting wrangler.`);

--- a/packages/webapp/tests/e2e/multiple-cones-follower.test.ts
+++ b/packages/webapp/tests/e2e/multiple-cones-follower.test.ts
@@ -19,11 +19,11 @@
  * follower can and cannot do (no local CDP surface: never teleport-eligible).
  */
 
-import { expect, test } from '@playwright/test';
 import followerFixture from './fake-llm/fixtures/multiple-cones-follower.json' with {
   type: 'json',
 };
 import { resetFakeLlm } from './fake-llm-helpers.js';
+import { expect, test } from './fixtures.js';
 import type { BrowserDiagnostics } from './two-instance-helpers.js';
 import {
   activeTabLabel,

--- a/packages/webapp/tests/e2e/multiple-cones-licks.test.ts
+++ b/packages/webapp/tests/e2e/multiple-cones-licks.test.ts
@@ -16,9 +16,9 @@
  * is absent from the primary cone, which is where a regression would send it.
  */
 
-import { expect, test } from '@playwright/test';
 import licksFixture from './fake-llm/fixtures/multiple-cones-licks.json' with { type: 'json' };
 import { resetFakeLlm } from './fake-llm-helpers.js';
+import { expect, test } from './fixtures.js';
 import {
   bootMultiConeLeader,
   CONE_TEST_TIMEOUT_MS,

--- a/packages/webapp/tests/e2e/multiple-cones.test.ts
+++ b/packages/webapp/tests/e2e/multiple-cones.test.ts
@@ -13,10 +13,10 @@
  * `two-instance-helpers.ts`.
  */
 
-import { expect, test } from '@playwright/test';
 import multipleConesFixture from './fake-llm/fixtures/multiple-cones.json' with { type: 'json' };
 import railFixture from './fake-llm/fixtures/multiple-cones-rail.json' with { type: 'json' };
 import { resetFakeLlm } from './fake-llm-helpers.js';
+import { expect, test } from './fixtures.js';
 import {
   activeTabLabel,
   bootMultiConeLeader,

--- a/packages/webapp/tests/e2e/open-view-image.test.ts
+++ b/packages/webapp/tests/e2e/open-view-image.test.ts
@@ -32,7 +32,6 @@
  */
 
 import type { Page } from '@playwright/test';
-import { expect, test } from '@playwright/test';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import {
@@ -43,6 +42,7 @@ import {
   submitUserMessage,
   waitForTurnComplete,
 } from './fake-llm-helpers.js';
+import { expect, test } from './fixtures.js';
 import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
 
 const VIEWER_MODEL = 'fake-viewer';

--- a/packages/webapp/tests/e2e/pdf-rasterize.test.ts
+++ b/packages/webapp/tests/e2e/pdf-rasterize.test.ts
@@ -30,7 +30,6 @@
  */
 
 import type { Page } from '@playwright/test';
-import { expect, test } from '@playwright/test';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import {
@@ -40,6 +39,7 @@ import {
   submitUserMessage,
   waitForTurnComplete,
 } from './fake-llm-helpers.js';
+import { expect, test } from './fixtures.js';
 import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
 
 const RASTERIZE_MODEL = 'fake-rasterizer';

--- a/packages/webapp/tests/e2e/playwright.config.ts
+++ b/packages/webapp/tests/e2e/playwright.config.ts
@@ -29,6 +29,22 @@ export const BRIDGE_PORT = resolvePort('SLICC_E2E_BRIDGE_PORT', 5710);
 export const CDP_PORT = resolvePort('SLICC_E2E_CDP_PORT', 9222);
 
 /**
+ * Control-plane port of the `wrangler dev` supervisor (`wrangler-server.ts`).
+ * Defaults to {@link WRANGLER_PORT} + 1 so an isolated `SLICC_E2E_WRANGLER_PORT`
+ * moves the supervisor with it. The `leaderAlive` fixture POSTs `/restart` here
+ * when the leader origin stops answering mid-suite (#2372).
+ */
+export const WRANGLER_SUPERVISOR_PORT = resolvePort(
+  'SLICC_E2E_WRANGLER_SUPERVISOR_PORT',
+  WRANGLER_PORT + 1
+);
+
+/** Directory wrangler writes its own `wrangler-<ts>.log` crash logs into, and
+ *  where the supervisor appends `crash-report.md`. Repo-local (rather than
+ *  wrangler's default global config dir) so CI can upload it as an artifact. */
+export const WRANGLER_LOG_DIR = resolve(repoRoot, '.wrangler/e2e-logs');
+
+/**
  * Fixed per-process bridge token shared between node-server (`SLICC_BRIDGE_TOKEN`
  * env) and the webapp boot URL (`?bridgeToken=`, appended by `gotoLeader`). A
  * static value is fine for a loopback-only E2E harness — the token's threat
@@ -41,6 +57,10 @@ export const E2E_BRIDGE_TOKEN = 'e2e-fixed-bridge-token';
 
 /** Leader (UI) origin served by wrangler — the Playwright `baseURL`. */
 export const LEADER_ORIGIN = `http://localhost:${WRANGLER_PORT}`;
+
+/** Supervisor control plane — loopback only, no auth: it can restart the local
+ *  harness's workerd and nothing else. */
+export const WRANGLER_SUPERVISOR_ORIGIN = `http://127.0.0.1:${WRANGLER_SUPERVISOR_PORT}`;
 
 /** Local node-server thin-bridge `/cdp` WebSocket URL the leader dials. */
 export const BRIDGE_WS_URL = `ws://localhost:${BRIDGE_PORT}/cdp`;
@@ -93,11 +113,23 @@ export default defineConfig({
       // reaches the real hub, which has never heard of the tray it just
       // created (`TRAY_NOT_INITIALIZED`, HTTP 500). Pinning the route to the
       // harness origin keeps every URL the worker hands out local.
-      command: `npx wrangler dev --config ${resolve(repoRoot, 'packages/cloudflare-worker/wrangler.jsonc')} --port ${WRANGLER_PORT} --ip 127.0.0.1 --route ${LEADER_ORIGIN}/*`,
+      //
+      // wrangler runs under `wrangler-server.ts`, a supervisor, rather than
+      // being spawned directly: Playwright never revives a `webServer`, and
+      // workerd dies mid-suite often enough (#2372) that the first crash used
+      // to fail every remaining spec with `ERR_CONNECTION_REFUSED`. The
+      // supervisor re-spawns workerd and exposes `POST /restart`, which the
+      // `leaderAlive` fixture in `fixtures.ts` drives.
+      command: `npx tsx ${resolve(repoRoot, 'packages/webapp/tests/e2e/wrangler-server.ts')} -- dev --config ${resolve(repoRoot, 'packages/cloudflare-worker/wrangler.jsonc')} --port ${WRANGLER_PORT} --ip 127.0.0.1 --route ${LEADER_ORIGIN}/*`,
       env: {
         // Wrangler 4.118 enables local observability by default. Its extra
         // collector can disconnect Miniflare during this long-running suite.
         X_LOCAL_OBSERVABILITY: 'false',
+        SLICC_E2E_WRANGLER_PORT: String(WRANGLER_PORT),
+        SLICC_E2E_WRANGLER_SUPERVISOR_PORT: String(WRANGLER_SUPERVISOR_PORT),
+        // Repo-local crash logs (CI uploads them when the job fails); wrangler
+        // otherwise buries them in its global config dir.
+        WRANGLER_LOG_PATH: WRANGLER_LOG_DIR,
       },
       // Gate readiness on a real HTTP 200 from `/status`, NOT a bare TCP probe.
       // workerd's `dev` process binds the listen socket well before the worker
@@ -120,6 +152,12 @@ export default defineConfig({
       // wrangler's first cold start (workerd bring-up) can exceed Playwright's
       // 60s default in CI.
       timeout: 120_000,
+      // Playwright otherwise SIGKILLs the web server's process group, which the
+      // supervisor cannot handle — and its wrangler chain runs in its own group
+      // (so a crashed shim's workerd can still be reaped), so the chain would
+      // survive the run and squat the leader port. SIGTERM gives the supervisor
+      // the moment it needs to take wrangler down with it.
+      gracefulShutdown: { signal: 'SIGTERM', timeout: 5_000 },
     },
     {
       // Thin /cdp bridge + `/api` surface only — no UI. `--cdp-port=9222` pins

--- a/packages/webapp/tests/e2e/preview-serve.test.ts
+++ b/packages/webapp/tests/e2e/preview-serve.test.ts
@@ -1,5 +1,5 @@
 // packages/webapp/tests/e2e/preview-serve.test.ts
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures.js';
 import {
   gotoLeader,
   installVfsFallbackResponder,

--- a/packages/webapp/tests/e2e/python-print.test.ts
+++ b/packages/webapp/tests/e2e/python-print.test.ts
@@ -24,10 +24,10 @@
  *   Run: npm run test:e2e -- python-print
  */
 
-import { expect, test } from '@playwright/test';
 import { readFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
+import { expect, test } from './fixtures.js';
 import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
 
 const rootPkg = JSON.parse(

--- a/packages/webapp/tests/e2e/reference-scenario.test.ts
+++ b/packages/webapp/tests/e2e/reference-scenario.test.ts
@@ -33,7 +33,6 @@
  * (`{ pattern, flags }`), and multi-target CDP enumeration at 9222.
  */
 
-import { expect, test } from '@playwright/test';
 import {
   closeCdpPageTargets,
   FAKE_LLM_BASE_URL,
@@ -43,6 +42,7 @@ import {
   submitUserMessage,
   waitForTurnComplete,
 } from './fake-llm-helpers.js';
+import { expect, test } from './fixtures.js';
 import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
 
 const REFERENCE_MODEL = 'fake-coder-reference';

--- a/packages/webapp/tests/e2e/speech-roundtrip.test.ts
+++ b/packages/webapp/tests/e2e/speech-roundtrip.test.ts
@@ -21,7 +21,7 @@
  * it when the `speech` path filter matches).
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures.js';
 import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
 
 const RUN = process.env['RUN_REAL_SPEECH_E2E'] === '1';

--- a/packages/webapp/tests/e2e/transcript-export.test.ts
+++ b/packages/webapp/tests/e2e/transcript-export.test.ts
@@ -38,7 +38,6 @@
 
 import * as fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { expect, test } from '@playwright/test';
 import { unzipSync } from 'fflate';
 import {
   FAKE_LLM_BASE_URL,
@@ -47,6 +46,7 @@ import {
   seedLocalLlmProvider,
   submitUserMessage,
 } from './fake-llm-helpers.js';
+import { expect, test } from './fixtures.js';
 import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
 
 /** Read a fixture JSON from the fake-llm fixtures directory. */

--- a/packages/webapp/tests/e2e/wrangler-server.ts
+++ b/packages/webapp/tests/e2e/wrangler-server.ts
@@ -1,0 +1,332 @@
+/**
+ * Supervisor for the E2E leader origin (`wrangler dev` → workerd).
+ *
+ * Playwright's `webServer` spawns a command once and never revives it. workerd
+ * dies mid-suite often enough to matter (#2372: four sightings in three days —
+ * `kj::getCaughtExceptionAsKj … Broken pipe` under parallel contexts + tray
+ * websockets), and when it does, every remaining spec fails in ~200 ms with
+ * `ERR_CONNECTION_REFUSED`: an 18-casualty pile-up that reads as unrelated test
+ * failures and evicts the PR from the merge queue.
+ *
+ * So the `webServer` entry starts this supervisor instead of wrangler directly.
+ * It:
+ *   - spawns `npx wrangler <argv after -->` and re-spawns it if it exits
+ *     without being asked to,
+ *   - exposes a tiny control plane on {@link supervisorPort} that the
+ *     `leaderAlive` fixture uses to force a restart and wait for readiness
+ *     (`POST /restart`, `GET /health`),
+ *   - records every crash — exit code, signal, and the tail of workerd's own
+ *     output — into `crash-report.md` inside the wrangler log directory, which
+ *     CI uploads as an artifact.
+ *
+ * Usage (see `playwright.config.ts`):
+ *   npx tsx wrangler-server.ts -- dev --config <path> --port <n> ...
+ */
+import { type ChildProcess, spawn } from 'node:child_process';
+import { appendFileSync, createWriteStream, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { resolve } from 'node:path';
+
+/** Wrangler argv: everything after the `--` separator. */
+const wranglerArgs = process.argv.slice(2).filter((arg) => arg !== '--');
+
+function envPort(name: string, fallback: number): number {
+  const value = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isInteger(value) && value > 0 && value <= 65_535 ? value : fallback;
+}
+
+/** Port wrangler serves the leader origin on — probed for readiness. */
+const leaderPort = envPort('SLICC_E2E_WRANGLER_PORT', 8787);
+/** Control-plane port. Defaults to `leaderPort + 1`, so an isolated
+ *  `SLICC_E2E_WRANGLER_PORT` moves the supervisor with it. */
+const supervisorPort = envPort('SLICC_E2E_WRANGLER_SUPERVISOR_PORT', leaderPort + 1);
+const statusUrl = `http://127.0.0.1:${leaderPort}/status`;
+
+/** Directory wrangler writes `wrangler-<ts>.log` into (`WRANGLER_LOG_PATH`),
+ *  and where this supervisor appends its crash report next to them. */
+const logDir = process.env['WRANGLER_LOG_PATH'] ?? resolve(process.cwd(), '.wrangler/e2e-logs');
+const crashReportPath = resolve(logDir, 'crash-report.md');
+/** Durable copy of everything wrangler prints. cloudflare/workers-sdk#15202:
+ *  when `wrangler dev`'s stdout is a pipe whose consumer stops draining or
+ *  closes it, workerd dies mid-run with
+ *  `kj/async-io-unix.c++: … write(): Broken pipe` — the exact signature in
+ *  #2372. Playwright's `webServer` capture is such a pipe, so this supervisor
+ *  owns wrangler's output instead: it always drains it and mirrors it to a file
+ *  that outlives the process.
+ *
+ *  This is also the evidence trail — CI uploads this directory. */
+const outputLogPath = resolve(logDir, 'wrangler-output.log');
+/** Process groups this supervisor owns, recorded on disk so a run that is
+ *  SIGKILLed (Playwright's default `webServer` shutdown) cannot leak a workerd
+ *  that then squats the leader port. Keyed by leader port so two harnesses on
+ *  isolated `SLICC_E2E_*` ports never reap each other. */
+const groupFilePath = resolve(logDir, `wrangler-groups-${leaderPort}.pid`);
+
+/** Keep the tail of workerd's output so a crash report carries the lines that
+ *  preceded it — wrangler's own log file is the full record, this is the part
+ *  that fits in a CI job log. */
+const OUTPUT_TAIL_LINES = 60;
+const outputTail: string[] = [];
+
+let child: ChildProcess | null = null;
+/** PIDs of every wrangler chain this supervisor has started. Each is a process
+ *  group leader (see `detached` in {@link spawnWrangler}); a crashed shim can
+ *  leave workerd alive in that group still holding the listen socket, so the
+ *  next spawn must reap the group, not just the process it saw exit. */
+const spawnedGroups = new Set<number>();
+let shuttingDown = false;
+/** Set while a restart is in flight so concurrent `POST /restart` calls (and a
+ *  crash landing mid-restart) join the same attempt instead of racing. */
+let restartInFlight: Promise<void> | null = null;
+let restarts = 0;
+let lastCrash: string | null = null;
+
+/** SIGKILL any process group left behind by a previous run of this harness. */
+function reapStaleGroups(): void {
+  let recorded: string;
+  try {
+    recorded = readFileSync(groupFilePath, 'utf8');
+  } catch {
+    return;
+  }
+  for (const line of recorded.split('\n')) {
+    const pid = Number.parseInt(line, 10);
+    if (!Number.isInteger(pid) || pid <= 1) continue;
+    try {
+      process.kill(-pid, 'SIGKILL');
+      process.stderr.write(`[e2e-wrangler] reaped stale wrangler process group ${pid}\n`);
+    } catch {
+      /* already gone — the common case */
+    }
+  }
+  try {
+    writeFileSync(groupFilePath, '');
+  } catch {
+    /* best effort */
+  }
+}
+
+function recordGroup(pid: number): void {
+  try {
+    appendFileSync(groupFilePath, `${pid}\n`);
+  } catch {
+    /* best effort */
+  }
+}
+
+let outputLog: ReturnType<typeof createWriteStream> | null = null;
+
+function log(message: string): void {
+  // stderr: Playwright forwards a webServer's stderr to the run log, while its
+  // stdout is suppressed unless `stdout: 'pipe'` is set (which would drown the
+  // log in `WRANGLER_LOG=debug` request noise).
+  process.stderr.write(`[e2e-wrangler] ${message}\n`);
+}
+
+function recordTail(chunk: Buffer): void {
+  outputLog?.write(chunk);
+  for (const line of chunk.toString('utf8').split('\n')) {
+    if (!line.trim()) continue;
+    outputTail.push(line);
+    if (outputTail.length > OUTPUT_TAIL_LINES) outputTail.shift();
+  }
+}
+
+function writeCrashReport(reason: string): void {
+  const report = [
+    `## workerd exit #${restarts + 1} (${reason})`,
+    '',
+    'Last lines of wrangler/workerd output before the exit:',
+    '',
+    '```',
+    ...outputTail,
+    '```',
+    '',
+  ].join('\n');
+  try {
+    mkdirSync(logDir, { recursive: true });
+    appendFileSync(crashReportPath, `${report}\n`);
+  } catch (error) {
+    log(`could not write crash report: ${String(error)}`);
+  }
+  log(`workerd exited unexpectedly (${reason}); crash report → ${crashReportPath}`);
+  for (const line of outputTail.slice(-20)) log(`  | ${line}`);
+}
+
+function spawnWrangler(): ChildProcess {
+  // `detached` puts wrangler in its own process group. wrangler is a chain of
+  // shims (`npx` → `.bin/wrangler` → `wrangler-dist/cli.js` → workerd), and
+  // signalling only the direct child orphans the rest — which then keeps the
+  // listen socket and makes the replacement fail with EADDRINUSE. Killing the
+  // group takes the whole chain down.
+  const proc = spawn('npx', ['wrangler', ...wranglerArgs], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+    env: { ...process.env, WRANGLER_LOG_PATH: logDir },
+  });
+  if (proc.pid !== undefined) {
+    spawnedGroups.add(proc.pid);
+    recordGroup(proc.pid);
+  }
+  proc.stdout?.on('data', recordTail);
+  proc.stderr?.on('data', (chunk: Buffer) => {
+    recordTail(chunk);
+    process.stderr.write(chunk);
+  });
+  proc.once('exit', (code, signal) => {
+    if (proc !== child || shuttingDown) return;
+    child = null;
+    writeCrashReport(`code=${String(code)} signal=${String(signal)}`);
+    lastCrash = `code=${String(code)} signal=${String(signal)}`;
+    // Bring it back immediately: by the time the next spec's health check
+    // runs, the origin may already be warm again.
+    void restart('crash');
+  });
+  return proc;
+}
+
+async function isLeaderUp(): Promise<boolean> {
+  try {
+    const response = await fetch(statusUrl, {
+      method: 'GET',
+      signal: AbortSignal.timeout(5_000),
+      headers: { 'cache-control': 'no-store' },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Poll `/status` until the worker answers 200 — workerd binds its listen
+ *  socket well before the worker module finishes loading, so a TCP probe would
+ *  return "ready" during a window where navigations still fail. */
+async function waitForLeader(timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isLeaderUp()) return true;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return false;
+}
+
+/** Signal every wrangler process group this supervisor started. Groups whose
+ *  members are all gone raise ESRCH, which is the success case. */
+function signalSpawnedGroups(signal: NodeJS.Signals): void {
+  for (const pid of spawnedGroups) {
+    try {
+      process.kill(-pid, signal);
+    } catch {
+      /* group already reaped */
+    }
+  }
+}
+
+/** Tear the current chain down — including a workerd orphaned by a shim that
+ *  died on its own, which would otherwise win the listen socket back from its
+ *  own replacement (`EADDRINUSE`, then a crash loop). */
+async function killChain(): Promise<void> {
+  child = null;
+  signalSpawnedGroups('SIGTERM');
+  await new Promise((r) => setTimeout(r, 1_000));
+  signalSpawnedGroups('SIGKILL');
+  spawnedGroups.clear();
+  try {
+    writeFileSync(groupFilePath, '');
+  } catch {
+    /* best effort */
+  }
+}
+
+async function restart(reason: string): Promise<void> {
+  if (restartInFlight !== null) return restartInFlight;
+  restartInFlight = (async () => {
+    restarts += 1;
+    log(`restarting wrangler (reason=${reason}, restart #${restarts})`);
+    await killChain();
+    // Give the OS a moment to release the listen socket; workerd otherwise
+    // loses the EADDRINUSE race with its own replacement.
+    await new Promise((r) => setTimeout(r, 1_000));
+    child = spawnWrangler();
+    const ready = await waitForLeader(120_000);
+    log(ready ? `wrangler ready again after restart #${restarts}` : 'wrangler did NOT come back');
+  })().finally(() => {
+    restartInFlight = null;
+  });
+  return restartInFlight;
+}
+
+function respond(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { 'content-type': 'application/json', 'cache-control': 'no-store' });
+  res.end(payload);
+}
+
+async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const path = (req.url ?? '/').split('?')[0];
+  if (path === '/health') {
+    respond(res, 200, {
+      running: child !== null && child.exitCode === null,
+      restarts,
+      lastCrash,
+      logDir,
+    });
+    return;
+  }
+  if (path === '/restart' && req.method === 'POST') {
+    await restart('requested');
+    const alive = await isLeaderUp();
+    respond(res, alive ? 200 : 503, { ok: alive, restarts, lastCrash, logDir });
+    return;
+  }
+  respond(res, 404, { error: 'not found' });
+}
+
+const control = createServer((req, res) => {
+  void handle(req, res).catch((error: unknown) => {
+    respond(res, 500, { error: String(error) });
+  });
+});
+control.listen(supervisorPort, '127.0.0.1', () => {
+  log(`supervisor control plane on 127.0.0.1:${supervisorPort} (logs → ${logDir})`);
+});
+
+mkdirSync(logDir, { recursive: true });
+outputLog = createWriteStream(outputLogPath, { flags: 'a' });
+// A supervisor killed by its own logging would defeat the point: swallow EPIPE
+// on the (Playwright-owned) stderr pipe rather than dying with it.
+process.stderr.on('error', () => {});
+outputLog.on('error', () => {});
+reapStaleGroups();
+child = spawnWrangler();
+
+function shutdown(): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  child = null;
+  signalSpawnedGroups('SIGTERM');
+  control.close();
+  // Escalate quickly: the `gracefulShutdown` budget Playwright grants this
+  // supervisor is short, and anything still alive when it expires becomes a
+  // port-squatting orphan.
+  setTimeout(() => {
+    signalSpawnedGroups('SIGKILL');
+    process.exit(0);
+  }, 500).unref();
+}
+
+process.once('SIGINT', shutdown);
+process.once('SIGTERM', shutdown);
+// Best effort for the paths that skip `shutdown` (an uncaught throw, or a
+// SIGKILL of the supervisor itself): a detached wrangler survives its parent,
+// and a leaked workerd holds the port against the next run.
+process.once('exit', () => {
+  signalSpawnedGroups('SIGKILL');
+  // Drop the ownership record so the next run does not signal a group whose
+  // pid the OS may since have recycled.
+  try {
+    writeFileSync(groupFilePath, '');
+  } catch {
+    /* best effort */
+  }
+});

--- a/packages/webapp/tests/e2e/wrangler-server.ts
+++ b/packages/webapp/tests/e2e/wrangler-server.ts
@@ -80,6 +80,16 @@ let shuttingDown = false;
 let restartInFlight: Promise<void> | null = null;
 let restarts = 0;
 let lastCrash: string | null = null;
+/** Restart attempts since the origin was last healthy. */
+let failedRestarts = 0;
+/** Set once repeated restarts have failed to bring workerd back. The control
+ *  plane then answers `/restart` immediately instead of burning another cold-
+ *  start budget per spec: the abort latch in `leader-health.ts` lives in a
+ *  Playwright worker that is discarded after each failure, so THIS process is
+ *  the only place a permanent failure can be remembered. */
+let permanentFailure = false;
+/** Restart attempts allowed before the origin is declared unrecoverable. */
+const MAX_FAILED_RESTARTS = 2;
 
 /** SIGKILL any process group left behind by a previous run of this harness. */
 function reapStaleGroups(): void {
@@ -249,7 +259,17 @@ async function restart(reason: string): Promise<void> {
     await new Promise((r) => setTimeout(r, 1_000));
     child = spawnWrangler();
     const ready = await waitForLeader(120_000);
-    log(ready ? `wrangler ready again after restart #${restarts}` : 'wrangler did NOT come back');
+    if (ready) {
+      failedRestarts = 0;
+      log(`wrangler ready again after restart #${restarts}`);
+      return;
+    }
+    failedRestarts += 1;
+    if (failedRestarts >= MAX_FAILED_RESTARTS) permanentFailure = true;
+    log(
+      `wrangler did NOT come back (failed restarts: ${failedRestarts}` +
+        `${permanentFailure ? ', giving up — remaining specs abort immediately' : ''})`
+    );
   })().finally(() => {
     restartInFlight = null;
   });
@@ -268,15 +288,23 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
     respond(res, 200, {
       running: child !== null && child.exitCode === null,
       restarts,
+      failedRestarts,
+      permanentFailure,
       lastCrash,
       logDir,
     });
     return;
   }
   if (path === '/restart' && req.method === 'POST') {
+    if (permanentFailure) {
+      // Answer instantly: every remaining spec then fails in milliseconds with
+      // the named error instead of waiting out another doomed cold start.
+      respond(res, 503, { ok: false, permanentFailure, restarts, lastCrash, logDir });
+      return;
+    }
     await restart('requested');
     const alive = await isLeaderUp();
-    respond(res, alive ? 200 : 503, { ok: alive, restarts, lastCrash, logDir });
+    respond(res, alive ? 200 : 503, { ok: alive, permanentFailure, restarts, lastCrash, logDir });
     return;
   }
   respond(res, 404, { error: 'not found' });


### PR DESCRIPTION
Closes #2372

## Summary

`wrangler dev` (workerd) dies mid-suite in the `e2e` job. Playwright never
revives a `webServer`, so before this PR the first crash turned every later spec
into a ~200 ms `ERR_CONNECTION_REFUSED` failure — a wall of red naming eighteen
innocent tests. Now wrangler runs under a supervisor that restarts it, and only
the spec that was running when the origin died fails, with an error named
`WRANGLER_CRASHED`.

## Why

Four sightings in three days (#2372), each costing a merge-queue cycle: the job
failed with a list of unrelated-looking specs and no hint that the harness, not
the product, had died.

The cause is very likely
[cloudflare/workers-sdk#15202](https://github.com/cloudflare/workers-sdk/issues/15202)
(filed 2026-08-23, open, same wrangler 4.123.0, same Playwright `webServer`
setup): workerd exits with `kj/async-io-unix.c++: … write(): Broken pipe` when
the consumer of its stdout stops draining the pipe, after which everything is
`ECONNREFUSED`. Our job sets `WRANGLER_LOG=debug`, which makes that stream very
chatty. The supervisor now owns and always drains wrangler's stdout — the same
workaround that issue's reporter landed on — so this is plausibly a fix, not
just containment. No version bump: 4.125.0 exists but carries nothing related;
Renovate owns that pin.

## Approach / Implementation notes

- **`tests/e2e/wrangler-server.ts`** (new) — supervises `wrangler dev` in place
  of Playwright spawning it directly. Owns and drains its stdout (mirroring it
  to `wrangler-output.log`), re-spawns workerd on an unexpected exit, and serves
  a loopback control plane (`GET /health`, `POST /restart`) on
  `SLICC_E2E_WRANGLER_SUPERVISOR_PORT` (default: leader port + 1).
  - The wrangler chain (`npx` → `.bin/wrangler` → `cli.js` → workerd) runs in
    its own process group, so a shim that dies on its own does not leave workerd
    holding the listen socket against its own replacement (`EADDRINUSE`, then a
    crash loop). Verified: without the group reap, the injected-crash run does
    hit exactly that.
  - Because the chain is detached, `gracefulShutdown: { signal: 'SIGTERM' }` is
    set on the `webServer` entry (Playwright otherwise SIGKILLs the group, which
    the supervisor cannot handle) and the owned group ids are recorded on disk
    so a hard-killed run's orphan is reaped at the next start. Verified: no
    listener survives a normal run.
- **`tests/e2e/leader-health.ts` + `fixtures.ts`** (new) — an auto fixture
  probes `HEAD <baseURL>/status` before and after every spec (a failed HEAD is
  confirmed with a GET, so one dropped response cannot fail a green spec). A
  dead origin restarts wrangler and fails **only the current spec** with a
  `WRANGLER_CRASHED`-named error; if the restart fails, the remaining specs fail
  instantly with the same named error rather than burning their timeouts. The
  post-test half attributes the crash to the spec that was running.
- Every spec now imports `{ expect, test }` from `./fixtures.js` instead of
  `@playwright/test` — the only change to the specs themselves.

## Cross-cutting impact

- **Floats**: none. This is test-harness only; no `src/` file changes.
- **CI**: `WRANGLER_LOG_PATH` now points at `.wrangler/e2e-logs/`, so the
  existing `wrangler-logs-e2e` artifact step (which pointed at wrangler's global
  config dir, and would have been empty) now has files: wrangler's own
  `wrangler-<ts>.log`, the mirrored output, and `crash-report.md`. A new step
  prints the crash report into the job log, so a contained crash stays visible
  even when the retry turns the job green.
- **Callers**: `two-instance-helpers.ts` imports only `expect`, which is
  re-exported unchanged.
- A contained crash now makes a job *green after retry* where it used to be red.
  That is the intent — the `::warning title=WRANGLER_CRASHED::` annotation plus
  the printed crash report keep it from being silent.

## Test plan

- [x] `npm run verify` + `check-touched-exemptions.mjs` — pass (0 debt-list files)
- [x] `npm run typecheck`
- [x] `npm run test` — 16657 passing; one flake (`wc-follower.test.ts`) that
      passes in isolation and touches nothing in this diff
- [x] `npm run test:coverage` — no floor breached
- [x] `npm run build`, `npm run build -w @slicc/chrome-extension`,
      `npm run bundle-size` — first-load budgets OK
- [x] New unit coverage: `packages/webapp/tests/e2e-harness/leader-health.test.ts`
      (8 tests over the probe / restart / abort-latch logic, dependency-injected)
- [x] **3 consecutive full local e2e runs** on isolated `SLICC_E2E_*` ports
      (22 / 21 / 22 passed): no `WRANGLER_CRASHED`, no leaked listeners after
      teardown
- [x] **Crash injection, twice** — `SIGKILL` of workerd mid-suite, and `SIGKILL`
      of the wrangler shim (which orphans workerd on the port). Both produce one
      `WRANGLER_CRASHED` failure naming the running spec, a logged restart, a
      written `crash-report.md`, and the rest of the suite green.

**Pre-existing failures** (verified against `main`, unrelated to this PR): the
`transcript-export` ZIP-download spec times out on this machine on stock `main`
config too (confirmed by reverting both the fixture import and the supervisor);
`multiple-cones` rail-row-actions flaked once in run 2 as an ordinary
fake-LLM turn flake, with no wrangler crash in the log.

## Documentation

- [x] `.agents/skills/writing-slicc-tests/SKILL.md` — new "Survive a wrangler
      crash" section: the import rule, what each piece does, and where the
      evidence lands.

## Risk & rollback

Test-harness only; reverts cleanly. Worst case if the supervisor itself
misbehaves, the leader origin fails to come up and the `webServer` readiness
gate fails loudly at startup rather than mid-suite. Irony budget: this should
remove the wrangler-death entry from the known-flake list.
