### PR TITLE
fix(webcomponents): re-acquire a live GL context when the shader remounts

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -1590,3 +1590,43 @@ Every decorative/ambient animation loop must carry a frame budget:
 - `packages/webcomponents/src/freezer/frame-budget.ts` — shared gating logic
 - `packages/webcomponents/src/freezer/slicc-shader.ts` — reference consumer
 - `docs/webcomponents-details.md` — the companion no-reflow-per-frame rule
+
+## A Lost WebGL Context Poisons Its Canvas Forever
+
+**The Incident**
+
+`<slicc-shader>` died on a tab switch and never came back. The console named the
+culprit: `WebGL: CONTEXT_LOST_WEBGL: loseContext: context lost` — the `loseContext:`
+prefix means the loss was _programmatic_, not a GPU eviction. It was the component's
+own teardown. `disconnectedCallback()` ends in `#dispose()`, which releases GPU
+memory with `getExtension('WEBGL_lose_context').loseContext()`. Switching tabs
+unmounts the panel host, so the field tore itself down correctly — and then
+`connectedCallback()` re-ran `#initGl()` against the **same** `<canvas>` element
+created once in the constructor.
+
+That is the trap: a canvas whose context has been lost returns that same dead
+context from `getContext()` forever. The UA only ever issues a new one after a
+restore _it_ initiates, and it never initiates one for a programmatic loss.
+So the remounted field came back holding invalid handles — every GL call a silent
+no-op, the last painted frame frozen on screen — with no `webglcontextrestored`
+event ever arriving to trigger the existing recovery path. Reproduced live over CDP:
+detach + reattach a healthy field, and `gl.isContextLost()` is `true` on the way back.
+
+**The Rule**
+
+If a component ever calls `loseContext()` (or must survive a context loss across a
+remount), it cannot reuse its canvas element. On re-init, check
+`gl.isContextLost()` and **replace the `<canvas>` node** before acquiring a context;
+a fresh element is the only way back to a live one. Then treat a still-lost context
+as an init failure and reflect the CSS fallback, rather than parking on dead handles
+behind a transparent canvas — a frozen field that claims to be working is worse than
+a visible gradient.
+
+Note the two recovery paths are distinct and both are needed: `webglcontextrestored`
+handles a UA-driven loss on a _live_ canvas (same context object, relink in place),
+while the fresh-canvas swap handles re-init after a teardown-driven loss.
+
+**Related Files**
+
+- `packages/webcomponents/src/freezer/slicc-shader.ts` — `#initGl` / `#replaceCanvas` / `#dispose`
+- `packages/webcomponents/tests/freezer/slicc-shader.test.ts` — remount regression test

--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -16,8 +16,10 @@ import { advanceFrameTs, BURST_MS, shouldRender } from './frame-budget.js';
  * synchronously with no burst). A static field — `cone` with `speed=0`, or
  * `prefers-reduced-motion` — renders once per stimulus and stops the loop
  * entirely (a `pulse()` first plays out its glow decay; reduced motion is
- * strictly one frame per wake). Pauses on disconnect and falls back to a
- * per-mode CSS gradient when WebGL is absent.
+ * strictly one frame per wake). Pauses on disconnect — releasing the GL context
+ * — and re-acquires a fresh one (on a fresh canvas) when it is mounted again, so
+ * a field that comes back after a tab switch resumes instead of staying frozen.
+ * Falls back to a per-mode CSS gradient when WebGL is absent.
  *
  * @attr mode - `cone` (default) | `scoop` | `freezer`
  * @attr tint - CSS color washed into the scoop field / event glow (the active accent)
@@ -731,18 +733,50 @@ export class SliccShader extends HTMLElement {
     return true;
   }
 
-  #initGl(): boolean {
-    const cv = this.#canvas;
-    if (!cv) return false;
+  /** Ask a canvas for a WebGL context, tolerating a throwing `getContext`. */
+  #acquireContext(cv: HTMLCanvasElement): WebGLRenderingContext | null {
     const opts: WebGLContextAttributes = { premultipliedAlpha: true, alpha: true, antialias: true };
-    let gl: WebGLRenderingContext | null = null;
     try {
-      gl = (cv.getContext('webgl', opts) ??
+      return (cv.getContext('webgl', opts) ??
         cv.getContext('experimental-webgl', opts)) as WebGLRenderingContext | null;
     } catch {
-      gl = null;
+      return null;
     }
-    if (!gl) return false;
+  }
+
+  /**
+   * Swap in a brand-new `<canvas>`, discarding the old one. A canvas whose
+   * context has been lost hands back that SAME dead context from `getContext()`
+   * forever — a new one is only ever issued after a restore the UA controls, and
+   * an explicit `loseContext()` never gets one. Replacing the element is the only
+   * way to obtain a live context. See #initGl.
+   */
+  #replaceCanvas(old: HTMLCanvasElement): HTMLCanvasElement {
+    this.#removeContextHandlers(old);
+    const fresh = h('canvas', { class: 'canvas', part: 'canvas' }) as HTMLCanvasElement;
+    if (old.parentNode) old.replaceWith(fresh);
+    else this.#root.prepend(fresh);
+    this.#canvas = fresh;
+    return fresh;
+  }
+
+  #initGl(): boolean {
+    let cv = this.#canvas;
+    if (!cv) return false;
+    let gl = this.#acquireContext(cv);
+    // Re-init on a canvas we already tore down: #dispose() ends in an explicit
+    // `loseContext()`, so every remount (a tab switch that unmounts the panel
+    // host, then re-mounts it) came back holding the dead context — GL calls
+    // no-op, nothing ever repaints, and no `webglcontextrestored` is coming
+    // because the UA does not restore a programmatic loss. A fresh canvas does.
+    if (gl?.isContextLost()) {
+      cv = this.#replaceCanvas(cv);
+      gl = this.#acquireContext(cv);
+    }
+    // A context that is still lost cannot be built on: report failure so the
+    // caller reflects `no-webgl` and the CSS gradient shows, rather than
+    // parking on dead handles behind a transparent canvas.
+    if (!gl || gl.isContextLost()) return false;
     this.#gl = gl;
     this.#installContextHandlers(cv);
     if (this.#setupGlResources()) return true;

--- a/packages/webcomponents/tests/freezer/slicc-shader.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-shader.test.ts
@@ -179,6 +179,55 @@ describe('slicc-shader', () => {
     expect(() => el.remove()).not.toThrow();
   });
 
+  it('re-acquires a live context when the field is remounted', async () => {
+    // Regression: a tab switch unmounts and re-mounts the panel host. The
+    // teardown ends in an explicit loseContext(), and a canvas holding a lost
+    // context hands that same dead context back from getContext() forever — so
+    // the remounted field used to come back permanently frozen (or blank behind
+    // an unset `no-webgl`). Re-init must swap in a fresh canvas.
+    const el = mount({ mode: 'scoop' });
+    await frame();
+    await frame();
+    if (el.noWebgl) return; // no WebGL in this runner at all
+    const first = el.shadowRoot?.querySelector('canvas') as HTMLCanvasElement;
+    expect(first.getContext('webgl')?.isContextLost()).toBe(false);
+
+    el.remove();
+    await frame();
+    expect(first.getContext('webgl')?.isContextLost()).toBe(true);
+
+    document.body.appendChild(el);
+    await frame();
+    await frame();
+
+    const second = el.shadowRoot?.querySelector('canvas') as HTMLCanvasElement;
+    expect(second.getContext('webgl')?.isContextLost()).toBe(false);
+    expect(second).not.toBe(first);
+    expect(el.noWebgl).toBe(false);
+    // and the shadow root still holds exactly one canvas, ahead of the fallback
+    expect(el.shadowRoot?.querySelectorAll('canvas')).toHaveLength(1);
+    expect(el.shadowRoot?.firstElementChild).toBe(second);
+  });
+
+  it('reflects no-webgl when the acquired context is already lost', async () => {
+    // A context that comes back dead (and cannot be replaced) must degrade to
+    // the CSS gradient rather than park on unusable handles.
+    const el = mount();
+    await frame();
+    if (el.noWebgl) return;
+    const spy = vi
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockReturnValue({ isContextLost: () => true } as unknown as WebGLRenderingContext);
+    try {
+      el.remove();
+      document.body.appendChild(el);
+      await frame();
+      expect(el.noWebgl).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it('releases partial GL resources when initialization fails', () => {
     const createBufferSpy = vi
       .spyOn(WebGLRenderingContext.prototype, 'createBuffer')
@@ -477,6 +526,71 @@ describe('slicc-shader', () => {
       // 60+. Wide bounds for slow CI — do not tighten.
       expect(spy.mock.calls.length).toBeGreaterThanOrEqual(3);
       expect(spy.mock.calls.length).toBeLessThanOrEqual(22);
+    });
+
+    it('draws nothing once unmounted (the disconnect energy win)', async () => {
+      // #2214's teardown must keep working: an unmounted field releases its GL
+      // context and stops drawing outright. The remount fix must not turn the
+      // teardown into a no-op to make re-init easier.
+      const el = mount({ mode: 'scoop' });
+      if (el.noWebgl) return;
+      await wait(100);
+      const canvas = el.shadowRoot?.querySelector('canvas') as HTMLCanvasElement;
+      el.remove();
+      const spy = spyDraws();
+      await wait(400);
+      expect(spy.mock.calls.length).toBe(0);
+      expect(canvas.getContext('webgl')?.isContextLost()).toBe(true);
+    });
+
+    it('a remounted animated field runs on the ambient budget, not display rate', async () => {
+      // Perf guard on the remount path (#2214): coming back from a tab switch
+      // must return to the 15fps ambient cadence, never the pre-#2214 burn.
+      const el = mount({ mode: 'scoop' });
+      if (el.noWebgl) return;
+      await wait(100);
+      el.remove();
+      document.body.appendChild(el);
+      await wait(1000); // past BURST_MS, so only ambient frames are counted
+      const spy = spyDraws();
+      await wait(1000);
+      // Same bounds as the post-burst ambient test — do not tighten.
+      expect(spy.mock.calls.length).toBeGreaterThanOrEqual(3);
+      expect(spy.mock.calls.length).toBeLessThanOrEqual(22);
+    });
+
+    it('a remounted static field renders once and re-stops', async () => {
+      // The true-static-stop guarantee must survive a remount too: cone at
+      // speed=0 repaints its one frame on connect, then the loop terminates.
+      const el = mount({ speed: '0' });
+      if (el.noWebgl) return;
+      await settle();
+      el.remove();
+      const spy = spyDraws();
+      document.body.appendChild(el);
+      await waitForDraws(spy, 1, 2000); // the one remount frame
+      await expectStopped(spy); // ...and then nothing
+    });
+
+    it('a remounted field keeps the DPR-1 backing-store cap', async () => {
+      // The fresh canvas must inherit the #2214 resolution cap. Measured under a
+      // stubbed ratio of 2 — at the runner's native ratio of 1 the cap is a
+      // no-op and the assertion would pass without proving anything.
+      const original = Object.getOwnPropertyDescriptor(window, 'devicePixelRatio');
+      Object.defineProperty(window, 'devicePixelRatio', { value: 2, configurable: true });
+      try {
+        const el = mount({ mode: 'scoop' });
+        if (el.noWebgl) return;
+        await wait(100);
+        el.remove();
+        document.body.appendChild(el);
+        await wait(300);
+        const canvas = el.shadowRoot?.querySelector('canvas') as HTMLCanvasElement;
+        expect(canvas.width).toBe(240); // min(cap 1, ratio 2) × 240px — 480 if uncapped
+      } finally {
+        if (original) Object.defineProperty(window, 'devicePixelRatio', original);
+        else delete (window as { devicePixelRatio?: number }).devicePixelRatio;
+      }
     });
 
     it('resumes rendering after the WebGL context is restored (animated)', {


### PR DESCRIPTION
## What

`<slicc-shader>` died on a tab switch and never came back. `#initGl()` now detects a lost context on re-init, swaps in a fresh `<canvas>` before acquiring, and treats a still-lost context as an init failure so the CSS gradient shows.

## Root cause (diagnosed live over CDP on :9222)

The console named the culprit:

```
WebGL: CONTEXT_LOST_WEBGL: loseContext: context lost
[slicc-shader] mode switch failed to link program
```

That `loseContext:` prefix means the loss was **programmatic**, not GPU eviction. It was the component's own teardown:

1. A tab switch unmounts the panel host → `disconnectedCallback()` → `#dispose()`, which ends in `getExtension('WEBGL_lose_context').loseContext()` — correct, and the point of #2214's teardown.
2. Switching back re-runs `connectedCallback()` → `#initGl()` against the **same** `<canvas>` created once in the constructor.
3. A canvas whose context has been lost hands back that *same dead context* from `getContext()` forever. The UA only issues a new one after a restore **it** initiates, and it never initiates one for a programmatic loss.

So the field came back holding invalid handles — every GL call a silent no-op, the last painted frame frozen on screen — and the existing `webglcontextrestored` recovery path never fired, because no such event was ever coming.

Reproduced deterministically on the live instance: detach + reattach a healthy field →

```
{"lostBeforeDetach": false, "lostAfterReattach": true, "noWebglAfter": true}
```

## Perf: no regression to #2214

This is the failure mode #2214's teardown created, so the fix was written to leave every one of its wins intact:

| #2214 property | Status |
| --- | --- |
| Teardown releases the GL context on disconnect | **Unchanged** — `#dispose()` still calls `loseContext()`; the fresh canvas is created on *re-init*, not to dodge teardown |
| 15 fps ambient cadence | Unchanged — remount goes through the normal `#wake()` / `#tick` path |
| True static stop (`speed=0`, reduced motion) | Unchanged |
| DPR-1 backing-store cap | Unchanged — `#resize()` reads the `dpr` attribute, not the canvas element |
| `#contextLost` scheduler parking | Untouched |

**Measured live after the fix** (Chrome 151, leader tab, `mode=cone`, patched `drawArrays` counter over 3 s):

- tab visible → **45 draws / 3.00 s = exactly 15.0 fps** — the #2214 ambient budget, hit on the nose
- tab hidden → **0 draws** — rAF still parks completely

One honest cost, stated plainly: a remounted field now *renders again*, so it costs the budgeted ~3% GPU instead of the 0% it cost while broken. That is the bug being fixed, not a regression.

Four new perf guards pin this so a future change can't quietly undo it:

- `draws nothing once unmounted (the disconnect energy win)` — asserts 0 draws **and** `isContextLost()` after `remove()`, so nobody "fixes" remount by gutting the teardown
- `a remounted animated field runs on the ambient budget, not display rate` — same bounds as the existing post-burst ambient test
- `a remounted static field renders once and re-stops`
- `a remounted field keeps the DPR-1 backing-store cap` — under a stubbed `devicePixelRatio` of 2, since at the runner's native 1 the cap is a no-op and the assertion would prove nothing

## Also

The still-lost-context branch reflects `no-webgl` and shows the CSS gradient rather than parking on dead handles behind a transparent canvas — the same degrade contract `e001cb5b4` established for the failed-restore path in #2214's review round 1. A frozen field that claims to be working is worse than a visible gradient.

The two recovery routes stay distinct and both are needed: `webglcontextrestored` handles a UA-driven loss on a *live* canvas (same context object, relink in place); the fresh-canvas swap handles re-init after a teardown-driven loss.

`slicc-shader` is the only `loseContext()` caller in the repo, so this is a single-site bug.

## Tests

- 2 regression tests + 4 perf guards (shader file 46 → 53 in-file).
- **Reverted the src fix to confirm the tests actually catch it** — 3 of the 4 remount tests fail without it. The DPR guard passes either way by construction; it guards a future regression, not this bug.
- `docs/pitfalls.md`: new incident entry, *A Lost WebGL Context Poisons Its Canvas Forever*.

## Verification

`lint` ✅ · `typecheck` ✅ · `test` (16650 passed, 0 failed) ✅ · `test:coverage:webcomponents` ✅ · `npm run build` ✅ · `build -w @slicc/chrome-extension` ✅ · `check-touched-exemptions` ✅ (3 files, 0 on any debt list)

## Related

- #2214 — the frame-budget perf work whose teardown exposed this
- #2260 — the `mode switch failed to link` log that turned out to be this bug's symptom

🤖 Generated with [Claude Code](https://claude.com/claude-code)
