### PR TITLE
test(webcomponents): pin display:block on the agent-avatar brow layer

### DIFF
--- a/packages/webcomponents/tests/switcher/slicc-agent-avatar.test.ts
+++ b/packages/webcomponents/tests/switcher/slicc-agent-avatar.test.ts
@@ -423,6 +423,14 @@ describe('slicc-agent-avatar expression kit', () => {
     expect(layer.getAttribute('style')).toBe(
       (crop.querySelector('.icon-inner') as HTMLElement).getAttribute('style')
     );
+    // An inline <svg> sits on a text baseline, which drops the brows a few px —
+    // unnoticeable at review size, straight onto the eyeballs at 26 px.
+    const browsSvg = layer.querySelector('.brows-svg') as SVGElement;
+    expect(getComputedStyle(browsSvg).display).toBe('block');
+    expect(browsSvg.getBoundingClientRect().top).toBeCloseTo(
+      (crop.querySelector('.eyes-svg') as SVGElement).getBoundingClientRect().top,
+      1
+    );
   });
 
   it('holds the brows still through a blink instead of folding them onto the eye', () => {


### PR DESCRIPTION
Follow-up to #2373 (review catch).

The `display:block` fix on `.brows-svg` was the one behavioral change in that PR without a regression test. As an inline SVG the brow band sits on a text baseline and lands a few px low — imperceptible at review size, but at 26 px in the rail it drops the brows straight onto the eyeballs. A future edit of `STYLE` could silently reintroduce it.

This pins two things:

- `getComputedStyle(...).display === 'block'` on `.brows-svg`
- the brow band's top edge lining up with the eye band's — the geometry that actually breaks, which the browser-mode suite can assert for real

Verified it fails without the fix (`expected 'inline' to be 'block'`) rather than trusting a guard I hadn't seen go red.

Split out rather than amended because #2373 was already in the merge queue when the test was written, and dequeuing a queued merge to slip a test in isn't worth it.

## Verification

`npm run verify`, typecheck, `npm run test` (16678 passed), the touched-file debt gate, and the webcomponents switcher suite (166 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
