### PR TITLE
ci: give release-gate a timeout that can clear a whole release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1843,23 +1843,43 @@ jobs:
 
   # Wait for any in-progress release before allowing merge queue to land.
   # Only runs on merge_group events; skipped (= passing) for PRs.
+  #
+  # The timeout must clear a whole release, because the `ci` aggregate below
+  # treats `cancelled` exactly like `failure` — so a gate killed by its own
+  # timeout dequeues every PR in the batch for a reason that has nothing to do
+  # with their contents. Over the 330 releases in the month to 2026-08-24:
+  # p50 20m, p90 28m, p95 31m, p99 44m, max 60m. The former 35m sat between p95
+  # and p99 and fired on 9 of them; #2380 was dequeued after entering the queue
+  # two minutes into a 60-minute release. 90m clears the observed max with 50%
+  # headroom. Raise it if a release ever legitimately exceeds it — do NOT trim
+  # it back toward the median, and note that idle wait costs one sleeping runner
+  # while a dequeue costs a full batch re-run.
   release-gate:
     if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 90
     permissions:
       actions: read
     steps:
       - name: Wait for active release
         env:
           GH_TOKEN: ${{ github.token }}
+          # Below `timeout-minutes` so the loop reports WHY it gave up. A job
+          # killed by the runner timeout can emit nothing, and the aggregate
+          # gate then prints only its generic "failed or were cancelled" line.
+          DEADLINE_MINUTES: '85'
         run: |
+          deadline=$(( $(date +%s) + DEADLINE_MINUTES * 60 ))
           while true; do
             ACTIVE=$(gh api "repos/${{ github.repository }}/actions/workflows/release.yml/runs?status=in_progress&per_page=1" --jq '.total_count')
             QUEUED=$(gh api "repos/${{ github.repository }}/actions/workflows/release.yml/runs?status=queued&per_page=1" --jq '.total_count')
             if [ "$ACTIVE" = "0" ] && [ "$QUEUED" = "0" ]; then
               echo "No release in progress, proceeding"
               break
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Release still running (active=$ACTIVE queued=$QUEUED) after ${DEADLINE_MINUTES}m; giving up so this batch does not merge mid-release. Re-enqueue once the release completes."
+              exit 1
             fi
             echo "Release running (active=$ACTIVE queued=$QUEUED), waiting 30s..."
             sleep 30


### PR DESCRIPTION
## What

Raises `release-gate`'s `timeout-minutes` from **35 → 90**, and gives its wait loop an 85-minute in-loop deadline so it can report *why* it gave up.

## Why

`release-gate` (`.github/workflows/ci.yml`) is a `merge_group`-only job that busy-waits until no `release.yml` run is active, so a batch can't land mid-release. When it exceeds `timeout-minutes` the runner kills it and the job's conclusion is `cancelled` — and the `ci` aggregate treats `cancelled` exactly like `failure`:

```yaml
if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" || "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
  echo "::error::One or more jobs failed or were cancelled"
```

So a gate that simply waited too long silently dequeues **every PR in the batch**, with no failing test and no indication of the cause.

That is what took #2380 out of the queue:

```
release-gate                cancelled
  Wait for active release   14:58:15 → 15:33:36   (35m21s, killed by timeout)
```

Its batch had **zero failing jobs** — the aggregate gate's log shows `failure=false, cancelled=true`. #2380 was enqueued at 14:57:50, two minutes into release run `32741765410`, which ran **14:56:06 → 15:56:21 (60 minutes)**. The gate burned its full 35 minutes with ~23 still to go and took the batch down with it.

## The number is data-derived

330 successful `release.yml` runs in the month to 2026-08-24:

| p50 | p90 | p95 | p99 | max |
| --- | --- | --- | --- | --- |
| 20m | 28m | 31m | 44m | 60m |

35m sat between p95 and p99 and would fire on **9 of the 330** — and each firing dequeues whatever happened to be in the batch, so the blast radius is much wider than 3% of releases. 90m clears the observed max with 50% headroom.

The rationale is recorded in a comment on the job, including a "do NOT trim this back toward the median" note, so the next person to read it has the distribution rather than a bare magic number.

## The 85-minute in-loop deadline

A job killed by `timeout-minutes` can't emit anything, so all a maintainer sees is the aggregate's generic "failed or were cancelled" — which is exactly why this took a log dig to pin down. The loop now checks its own deadline first and fails with a real message:

```
::error::Release still running (active=1 queued=0) after 85m; giving up so this
batch does not merge mid-release. Re-enqueue once the release completes.
```

Same outcome (the batch still doesn't land mid-release — that protection is the point of the gate and is unchanged), but self-describing.

## Cost

Idle wait is one runner sleeping in a 30s poll loop. A dequeue costs a full batch CI re-run. Raising the ceiling is the cheaper failure mode, not the more expensive one.

## Verification

- `actionlint` — no new findings (the single `SC2034` at `ci.yml:501` is pre-existing on `main`; verified by running actionlint against `origin/main`'s copy)
- YAML parses; `timeout-minutes: 90` and the step env confirmed on the parsed job
- Both branches of the deadline arithmetic exercised under `bash -e`: `DEADLINE_MINUTES=85` → waits (delta 85m); `DEADLINE_MINUTES=0` → emits the `::error::` and exits 1
- `prettier --check` clean · `check-touched-exemptions` OK

## Related

- #2380 — the PR this dequeued (green, unrelated to the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
