### PR TITLE
fix(kernel): reap terminated processes and read /proc in one read

### DIFF
--- a/docs/kernel/process-model.md
+++ b/docs/kernel/process-model.md
@@ -33,6 +33,22 @@ interface Process {
 
 Status transitions: `running` → `exited` (clean) or `killed` (any terminating signal recorded). The manager fires `spawn` and `exit` events synchronously inside the corresponding method calls so `/proc` and `ps` see live state without a tick of latency.
 
+### Retention
+
+A terminated process is not dropped the instant it exits — `ps` after a `kill` has to be able to show the exit code — but it is not kept forever either. The manager retains the most recent `TERMINATED_RETENTION` (128) terminated records and reaps older ones oldest-first, so the table stays O(live + 128) instead of accumulating every command the session ever ran. Eviction only ever considers already-terminated pids, so a live process can never be reaped.
+
+`stats()` carries the totals the reaped records used to:
+
+```ts
+{
+  (live, retained, terminated, spawned);
+}
+```
+
+`terminated` and `spawned` are monotonic for the session and keep counting past the retention window; `retained` is how many records are actually resident. Surfaces that want to say how much work ran (the monitor's "1,435 exited this session") read the counter — a number stays true without thousands of records having to stay resident to prove it.
+
+Consequences worth knowing: `get(pid)` and `wait(pid)` on a reaped pid behave exactly like an unknown pid (`null` / reject), and `allocatePid()` may reuse a reaped pid after the uint32 space wraps.
+
 ## Where pids come from
 
 | Kind         | Spawn site                                          | argv                                    |
@@ -84,9 +100,35 @@ Layout:
 /proc/<pid>/cwd         # plain text path
 /proc/<pid>/stat        # single-line: pid (kind) state ppid exit started finished
 /proc/1/                # synthesized kernel-host anchor, ppid=0
+/proc/table             # the whole retained table as one JSON document
 ```
 
 Deliberate omissions: no `/proc/self` (would require `currentPid()` tracking which we don't do), no `environ` (would leak masked secrets), no `fd/` or `task/`. The full Linux procfs surface is out of scope; just what `ps` and `kill` need to drive their views.
+
+One deliberate ADDITION: `/proc/table` has no Linux counterpart. Linux readers walk `/proc/<pid>/` per process because a syscall-backed read is cheap; here every read crosses the VFS, so a UI refreshing the process list paid a `readDir` plus two `readFile`s per pid — thousands of VFS reads per tick against the same VFS the boot path and the terminal mount contend for. `/proc/table` collapses that to one read, and carries the `stats()` counters, which no per-pid file can express:
+
+```jsonc
+{
+  "stats": { "live": 9, "retained": 137, "terminated": 1435, "spawned": 1444 },
+  "processes": [
+    {
+      "pid": 1024,
+      "ppid": 1,
+      "kind": "shell",
+      "state": "R",
+      "status": "running",
+      "argv": "sleep 9",
+      "cwd": "/workspace",
+      "owner": "cone",
+      "startedAt": 1700000000000,
+      "finishedAt": null,
+      "exitCode": null,
+    },
+  ],
+}
+```
+
+`processes` holds every RETAINED process (live plus the retention window), so a reader that only wants live ones filters on `status` — the same choice `ps` makes by default. `argv` is space-joined here, unlike the NUL-separated `cmdline` file: this is JSON, not procfs.
 
 ## `ps` and `kill`
 

--- a/packages/webapp/src/kernel/proc-mount.ts
+++ b/packages/webapp/src/kernel/proc-mount.ts
@@ -13,6 +13,7 @@
  *   /proc/<pid>/cmdline     null-separated argv (POSIX-style)
  *   /proc/<pid>/cwd         working directory as plain text
  *   /proc/<pid>/stat        single-line procfs-style record
+ *   /proc/table             the whole table as one JSON document
  *
  * Deliberate divergences from POSIX:
  *   - No `/proc/self`: requires `currentPid()` tracking, which
@@ -22,6 +23,14 @@
  *   - No `environ`, no `fd/`, no `task/`. The full Linux procfs
  *     surface is out of scope; just what `ps` and `kill` need to
  *     drive their views.
+ *   - `/proc/table` has no Linux counterpart. Linux readers walk
+ *     `/proc/<pid>/` per process because a syscall-backed read is
+ *     cheap; here every read crosses the VFS, so a UI refreshing the
+ *     process list paid two reads per pid — ~2,900 VFS reads per tick
+ *     at the table sizes this mount used to grow to. One JSON
+ *     document collapses that to a single read, and carries the
+ *     `ProcessManager` session counters (which no per-pid file can
+ *     express) alongside the rows.
  *   - All writes throw `EACCES` ('read-only filesystem') —
  *     `FsErrorCode` doesn't have `EROFS`, so `EACCES` with the
  *     read-only message is the closest match. The mount-layer
@@ -41,7 +50,7 @@ import type {
   RefreshReport,
 } from '../fs/mount/backend.js';
 import { FsError } from '../fs/types.js';
-import type { Process, ProcessManager } from './process-manager.js';
+import type { Process, ProcessManager, ProcessTableStats } from './process-manager.js';
 
 const KERNEL_PID = 1;
 
@@ -77,9 +86,19 @@ export class ProcMountBackend implements MountBackend {
       if (!procs.some((p) => p.pid === KERNEL_PID)) {
         entries.push({ name: String(KERNEL_PID), kind: 'directory' });
       }
-      return entries.sort((a, b) => Number(a.name) - Number(b.name));
+      entries.sort((a, b) => Number(a.name) - Number(b.name));
+      entries.push({
+        name: TABLE_FILE,
+        kind: 'file',
+        size: this.renderTable().length,
+        lastModified: Date.now(),
+      });
+      return entries;
     }
     if (segments.length === 1) {
+      if (segments[0] === TABLE_FILE) {
+        throw new FsError('ENOTDIR', 'not a directory', path);
+      }
       // /proc/<pid> — fixed file set.
       const pid = parsePid(segments[0]);
       if (pid === null) throw new FsError('ENOENT', 'no such file or directory', path);
@@ -99,6 +118,9 @@ export class ProcMountBackend implements MountBackend {
   async readFile(path: string): Promise<Uint8Array> {
     this.assertOpen(path);
     const segments = splitPath(path);
+    if (segments.length === 1 && segments[0] === TABLE_FILE) {
+      return new TextEncoder().encode(this.renderTable());
+    }
     if (segments.length !== 2) {
       throw new FsError('EISDIR', 'is a directory', path);
     }
@@ -124,6 +146,9 @@ export class ProcMountBackend implements MountBackend {
       return { kind: 'directory', size: 0, mtime: 0 };
     }
     if (segments.length === 1) {
+      if (segments[0] === TABLE_FILE) {
+        return { kind: 'file', size: this.renderTable().length, mtime: Date.now() };
+      }
       const pid = parsePid(segments[0]);
       if (pid === null) throw new FsError('ENOENT', 'no such file or directory', path);
       if (!this.pidExists(pid)) throw new FsError('ENOENT', 'no such file or directory', path);
@@ -191,6 +216,31 @@ export class ProcMountBackend implements MountBackend {
     return proc.finishedAt ?? proc.startedAt;
   }
 
+  /**
+   * The whole retained table as one JSON document. Shape is
+   * {@link ProcTableDocument}; `stats` mirrors `ProcessManager.stats()`
+   * so a reader can report totals that outlive the reaped rows.
+   */
+  private renderTable(): string {
+    const doc: ProcTableDocument = {
+      stats: this.pm.stats(),
+      processes: this.pm.list().map((proc) => ({
+        pid: proc.pid,
+        ppid: proc.ppid,
+        kind: proc.kind,
+        state: stateLetter(proc.status),
+        status: proc.status,
+        argv: proc.argv.join(' '),
+        cwd: proc.cwd,
+        owner: ownerLabel(proc),
+        startedAt: proc.startedAt,
+        finishedAt: proc.finishedAt,
+        exitCode: proc.exitCode,
+      })),
+    };
+    return JSON.stringify(doc) + '\n';
+  }
+
   private renderProcFile(pid: number, name: ProcFile): string {
     if (pid === KERNEL_PID) {
       return renderKernelHost(name);
@@ -215,6 +265,32 @@ export class ProcMountBackend implements MountBackend {
 
 const PROC_FILES = ['status', 'cmdline', 'cwd', 'stat'] as const;
 type ProcFile = (typeof PROC_FILES)[number];
+
+/** Top-level aggregate file — see the divergence note in the module doc. */
+const TABLE_FILE = 'table';
+
+/** One row of {@link ProcTableDocument}. Field names are the wire contract. */
+export interface ProcTableRow {
+  pid: number;
+  ppid: number;
+  kind: Process['kind'];
+  /** procfs state letter — `R` / `S` / `Z` / `K`. */
+  state: string;
+  status: Process['status'];
+  /** argv space-joined, NOT NUL-separated — this is JSON, not `cmdline`. */
+  argv: string;
+  cwd: string;
+  owner: string;
+  startedAt: number;
+  finishedAt: number | null;
+  exitCode: number | null;
+}
+
+/** The parsed contents of `/proc/table`. */
+export interface ProcTableDocument {
+  stats: ProcessTableStats;
+  processes: ProcTableRow[];
+}
 
 function splitPath(path: string): string[] {
   return path.replace(/^\/+/, '').replace(/\/+$/, '').split('/').filter(Boolean);

--- a/packages/webapp/src/kernel/process-manager.ts
+++ b/packages/webapp/src/kernel/process-manager.ts
@@ -45,6 +45,14 @@
  *     (`kernel/realm/realm-runner.ts`) subscribes to SIGKILL via
  *     `onSignal` and calls `realm.terminate()` synchronously so
  *     `node`/`.jsh`/`python` runaways are uncatchable.
+ *   - **Bounded post-mortem retention.** Terminated processes are NOT
+ *     dropped the instant they exit — `ps` after a `kill` has to be able
+ *     to show the exit code — but they are no longer kept forever either.
+ *     The last `TERMINATED_RETENTION` of them stay readable and older ones
+ *     are reaped, so a long session's table stays O(live + 128) instead of
+ *     growing with every command ever run. `stats()` keeps the totals the
+ *     reaped entries used to carry, so "1,435 commands ran this session"
+ *     survives as a number without surviving as 1,435 records.
  */
 
 // ---------------------------------------------------------------------------
@@ -198,6 +206,18 @@ export interface Process {
 
 export type ProcessEvent = 'spawn' | 'exit';
 
+/**
+ * Session-wide process counts. `terminated` / `spawned` are monotonic and
+ * include reaped entries; `retained` is how many records are actually
+ * resident (live + up to `TERMINATED_RETENTION` dead).
+ */
+export interface ProcessTableStats {
+  live: number;
+  retained: number;
+  terminated: number;
+  spawned: number;
+}
+
 export type ProcessEventListener = (proc: Process) => void;
 
 /**
@@ -216,6 +236,18 @@ export type ProcessSignalListener = (proc: Process, sig: Signal) => void;
 
 const PID_FLOOR = 1024;
 const PID_CEIL = 0xffffffff;
+
+/**
+ * How many terminated processes stay readable after they exit.
+ *
+ * Post-mortem inspection only ever looks at the recent past — the process
+ * you just killed, the command that just failed — so a window is enough,
+ * and an unbounded table is a slow leak: every shell command, tool call and
+ * scoop turn in the session accumulates a `Process` record (with its
+ * `AbortController`, `Gate`, argv and env) that nothing will ever read
+ * again. A five-hour session had 1,444 records for 9 live processes.
+ */
+const TERMINATED_RETENTION = 128;
 
 /**
  * Conventional Unix exit codes for signals — used as the default
@@ -239,6 +271,10 @@ export class ProcessManager {
     exit: new Set(),
   };
   private readonly signalListeners = new Set<ProcessSignalListener>();
+  /** Pids of terminated-but-still-retained processes, oldest first. */
+  private readonly terminatedPids: number[] = [];
+  private spawnedTotal = 0;
+  private terminatedTotal = 0;
 
   // -------------------------------------------------------------------------
   // Lifecycle
@@ -271,6 +307,7 @@ export class ProcessManager {
       finishedAt: null,
     };
     this.processes.set(pid, proc);
+    this.spawnedTotal++;
     this.fire('spawn', proc);
     return proc;
   }
@@ -301,7 +338,12 @@ export class ProcessManager {
     // `abort.signal.aborted` after their `wait()` resolves can then
     // bail out cleanly.
     proc.gate.release();
+    this.terminatedTotal++;
+    // Fire BEFORE reaping: an `exit` listener (and `wait()`'s internal
+    // handler) is handed the `Process` object directly, so it sees a full
+    // record even if this exit is the one that evicts an older entry.
     this.fire('exit', proc);
+    this.retire(proc.pid);
   }
 
   /**
@@ -429,15 +471,46 @@ export class ProcessManager {
     return result;
   }
 
-  /** Return a snapshot of all processes. The returned array is a copy. */
+  /**
+   * Return a snapshot of every RETAINED process — live plus the most
+   * recent `TERMINATED_RETENTION` terminated ones. The returned array is
+   * a copy. Callers that only want live processes should use
+   * {@link listLive}; `ps` filters here itself because `ps -e` still
+   * wants the retained dead.
+   */
   list(): Process[] {
     return Array.from(this.processes.values());
   }
 
+  /** Only the processes that are still `pending` or `running`. */
+  listLive(): Process[] {
+    return this.list().filter((p) => p.status === 'pending' || p.status === 'running');
+  }
+
   /**
-   * Return `proc` for `pid`, or `null` if the pid was never allocated.
-   * No reaping today — terminated entries persist so `ps` after `kill`
-   * still shows the exit code.
+   * Session totals, including the processes that have already been reaped.
+   *
+   * This is what a caller should render instead of a list when it wants to
+   * say how much work ran: `terminated` keeps counting past
+   * `TERMINATED_RETENTION`, so "1,435 exited this session" stays true
+   * without 1,435 records having to stay resident to prove it.
+   */
+  stats(): ProcessTableStats {
+    const live = this.listLive().length;
+    return {
+      live,
+      retained: this.processes.size,
+      terminated: this.terminatedTotal,
+      spawned: this.spawnedTotal,
+    };
+  }
+
+  /**
+   * Return `proc` for `pid`, or `null` if the pid was never allocated —
+   * or has since been reaped. A terminated process stays readable until
+   * `TERMINATED_RETENTION` further processes terminate after it, which is
+   * ample for the post-`kill` `ps` this exists for; anything wanting a
+   * durable record should hold the `Process` handle it was given.
    */
   get(pid: number): Process | null {
     return this.processes.get(pid) ?? null;
@@ -446,7 +519,11 @@ export class ProcessManager {
   /**
    * Resolve when the process exits. If the pid is unknown, rejects
    * synchronously — there's no "wait for a future spawn of this pid"
-   * semantic; callers wait on a `Process` they were handed.
+   * semantic; callers wait on a `Process` they were handed. A pid that
+   * was reaped (see {@link get}) is indistinguishable from one that never
+   * existed, so it rejects too — waiting on a process that terminated
+   * more than `TERMINATED_RETENTION` terminations ago is a bug in the
+   * caller, not a state worth modelling.
    */
   wait(pid: number): Promise<Process> {
     const proc = this.processes.get(pid);
@@ -494,11 +571,26 @@ export class ProcessManager {
   // Internal
   // -------------------------------------------------------------------------
 
+  /**
+   * Record `pid` as terminated and evict whatever fell out of the
+   * retention window. Eviction only ever touches entries in
+   * `terminatedPids`, so a live process can never be reaped no matter how
+   * the table is ordered.
+   */
+  private retire(pid: number): void {
+    this.terminatedPids.push(pid);
+    while (this.terminatedPids.length > TERMINATED_RETENTION) {
+      const oldest = this.terminatedPids.shift() as number;
+      this.processes.delete(oldest);
+    }
+  }
+
   private allocatePid(): number {
-    // Linear probe for a free pid. The table size IS the live-process
-    // count (no reaping yet), so the probe is bounded by
-    // `processes.size`: starting from `nextPid`, we can hit at most
-    // `size` collisions before finding a hole. Anything beyond
+    // Linear probe for a free pid. Every occupied pid is a key in
+    // `processes`, so the probe is bounded by `processes.size`: starting
+    // from `nextPid`, we can hit at most `size` collisions before finding
+    // a hole. Reaping only shrinks the table, which tightens this bound
+    // and frees pids for reuse after a wrap. Anything beyond
     // that means our bookkeeping is corrupt; fail loudly. Without
     // this bound, a corrupt table could spin a multi-billion-step
     // linear probe across the uint32 space and freeze the kernel

--- a/packages/webapp/src/ui/wc/wc-live-monitor-deps.ts
+++ b/packages/webapp/src/ui/wc/wc-live-monitor-deps.ts
@@ -13,7 +13,7 @@ import {
 } from '../../scoops/tray-runtime-config.js';
 import { getConnectedFollowers } from '../../shell/supplemental-commands/host-command.js';
 import type { OffscreenClient } from '../offscreen-client.js';
-import type { MonitorDeps, MonitorTrayInfo } from './wc-monitor.js';
+import type { MonitorDeps, MonitorProcessSnapshot, MonitorTrayInfo } from './wc-monitor.js';
 
 const PROC_STATE_LETTER_TO_WORD: Record<string, string> = {
   R: 'running',
@@ -26,6 +26,35 @@ const PROC_STATE_LETTER_TO_WORD: Record<string, string> = {
 export function parseProcStatLine(statLine: string): string {
   const stateLetter = statLine.trim().split(' ')[2] ?? '';
   return PROC_STATE_LETTER_TO_WORD[stateLetter] ?? 'unknown';
+}
+
+/**
+ * Parse the `/proc/table` JSON document into the monitor's snapshot shape,
+ * keeping only live rows. The mount retains a window of terminated
+ * processes so post-mortem `ps` works; the monitor doesn't render them, and
+ * reports `stats.terminated` — the kernel's session total, which keeps
+ * counting past that window — instead.
+ *
+ * Anything malformed degrades to an empty snapshot rather than throwing:
+ * a monitor tick is not worth failing a render over.
+ */
+export function parseProcTable(raw: string): MonitorProcessSnapshot {
+  try {
+    const doc = JSON.parse(raw) as {
+      stats?: { terminated?: number };
+      processes?: { pid?: number; argv?: string; status?: string }[];
+    };
+    const processes = (doc.processes ?? [])
+      .filter((row) => row.status === 'running' || row.status === 'pending')
+      .map((row) => ({
+        pid: Number(row.pid ?? 0),
+        argv: String(row.argv ?? ''),
+        status: String(row.status ?? 'unknown'),
+      }));
+    return { processes, terminated: Number(doc.stats?.terminated ?? 0) };
+  } catch {
+    return { processes: [], terminated: 0 };
+  }
 }
 
 export function getTrayMonitorInfo(storage: Pick<Storage, 'getItem'>): MonitorTrayInfo {
@@ -130,30 +159,17 @@ export function createWcMonitorDeps(deps: {
     },
     getSessionStats: async () => client.getSessionStats?.() ?? null,
     getProcesses: async () => {
+      // One read of the `/proc/table` aggregate, not a readDir plus two
+      // readFiles per pid. The monitor refreshes every 5s, so the per-pid
+      // walk cost ~2N VFS reads a tick — several thousand on a table that
+      // had grown into the low thousands, against the same VFS the boot
+      // path and terminal mount contend for.
       try {
         const fs = await openReader();
-        const entries = await fs.readDir('/proc');
-        const processes = [];
-        for (const entry of entries.filter(
-          (candidate) => candidate.type === 'directory' && /^\d+$/.test(candidate.name)
-        )) {
-          try {
-            const stat = await fs.readFile(`/proc/${entry.name}/stat`, { encoding: 'utf-8' });
-            const cmdline = await fs.readFile(`/proc/${entry.name}/cmdline`, {
-              encoding: 'utf-8',
-            });
-            processes.push({
-              pid: Number.parseInt(entry.name, 10),
-              argv: String(cmdline).trim(),
-              status: parseProcStatLine(String(stat)),
-            });
-          } catch {
-            // Process may have exited between listing and reading.
-          }
-        }
-        return processes;
+        const raw = await fs.readFile('/proc/table', { encoding: 'utf-8' });
+        return parseProcTable(typeof raw === 'string' ? raw : new TextDecoder().decode(raw));
       } catch {
-        return [];
+        return { processes: [], terminated: 0 };
       }
     },
     getTrayInfo: () => getTrayMonitorInfo(storage),

--- a/packages/webapp/src/ui/wc/wc-monitor.ts
+++ b/packages/webapp/src/ui/wc/wc-monitor.ts
@@ -49,6 +49,26 @@ export interface OAuthProviderEntry {
   valid?: boolean;
 }
 
+/** One live process row, already narrowed to what the monitor renders. */
+export interface MonitorProcess {
+  pid: number;
+  argv: string;
+  status: string;
+}
+
+/**
+ * What the monitor knows about the process table.
+ *
+ * `processes` is LIVE processes only. `terminated` is the session total of
+ * everything that has already exited — a number the kernel keeps counting
+ * past its own retention window, so it stays true without the dead rows
+ * having to stay resident (or rendered) to prove it.
+ */
+export interface MonitorProcessSnapshot {
+  processes: MonitorProcess[];
+  terminated: number;
+}
+
 export interface MonitorTrayInfo {
   role: 'leader' | 'follower' | 'standalone';
   state: 'inactive' | 'connecting' | 'connected' | 'leader' | 'reconnecting' | 'error';
@@ -71,7 +91,7 @@ export interface MonitorDeps {
     models: { model: string; cost: number }[];
     scoops: { name: string; cost: number }[];
   } | null>;
-  getProcesses(): Promise<{ pid: number; argv: string; status: string }[]>;
+  getProcesses(): Promise<MonitorProcessSnapshot>;
   getTrayInfo(): MonitorTrayInfo;
   getConnectedFollowers(): ConnectedFollowerInfo[];
 }
@@ -149,14 +169,15 @@ export async function fetchMonitorData(deps: MonitorDeps): Promise<MonitorSectio
   const scoops = deps.getScoops();
   const tray = deps.getTrayInfo();
   const followers = deps.getConnectedFollowers();
-  const [cronTasks, webhooks, mounts, mcpServers, sessionStats, processes] = await Promise.all([
+  const [cronTasks, webhooks, mounts, mcpServers, sessionStats, procSnapshot] = await Promise.all([
     deps.getCronTasks().catch(() => [] as CronTaskEntry[]),
     deps.getWebhooks().catch(() => [] as WebhookEntry[]),
     deps.getMounts().catch(() => [] as MountMonitorRow[]),
     deps.getMcpServers().catch(() => ({}) as Record<string, { url: string; tools?: unknown[] }>),
     deps.getSessionStats().catch(() => null),
-    deps.getProcesses().catch(() => []),
+    deps.getProcesses().catch(() => ({ processes: [], terminated: 0 })),
   ]);
+  const { processes, terminated } = procSnapshot;
   const oauthProviders = deps.getOAuthProviders();
   const mcpEntries = Object.entries(mcpServers);
 
@@ -186,8 +207,18 @@ export async function fetchMonitorData(deps: MonitorDeps): Promise<MonitorSectio
     },
     {
       id: 'processes',
+      // Live processes only — the same default `ps` has ("listing them by
+      // default is noisy", ps-command.ts). Exited processes are reported as
+      // a count in `meta`, never as rows: a long session terminates
+      // thousands of them, and a list of dead pids is not something anyone
+      // reads. The count comes from the kernel's session total, so it stays
+      // right even after those records are reaped.
       label: 'Processes',
       count: processes.length,
+      meta:
+        terminated > 0
+          ? `${processes.length} live · ${terminated.toLocaleString()} exited`
+          : undefined,
       rows: processes.map((proc) => {
         const shortArgv = proc.argv.length > 40 ? proc.argv.slice(0, 37) + '...' : proc.argv;
         const statusDot = proc.status === 'running';

--- a/packages/webapp/tests/kernel/proc-mount.test.ts
+++ b/packages/webapp/tests/kernel/proc-mount.test.ts
@@ -22,8 +22,9 @@ describe('ProcMountBackend — readDir', () => {
     expect(names).toContain('1024');
     expect(names).toContain('1025');
     expect(names).toContain('1'); // kernel-host anchor
+    expect(names).toContain('table'); // the aggregate, the one non-directory
     for (const e of entries) {
-      expect(e.kind).toBe('directory');
+      expect(e.kind).toBe(e.name === 'table' ? 'file' : 'directory');
     }
   });
 
@@ -217,6 +218,55 @@ describe('ProcMountBackend — lifecycle', () => {
     const proc = new ProcMountBackend(new ProcessManager());
     await proc.close();
     await expect(proc.readDir('/')).rejects.toMatchObject({ code: 'EBADF' });
+  });
+
+  it('reads the whole table in one read, with the session counters', async () => {
+    const pm = new ProcessManager();
+    const live = pm.spawn({ kind: 'shell', argv: ['sleep', '9'], owner: { kind: 'cone' } });
+    const dead = pm.spawn({ kind: 'tool', argv: ['read_file'], owner: { kind: 'system' } });
+    pm.exit(dead.pid, 3);
+    const proc = new ProcMountBackend(pm);
+    const doc = JSON.parse(decode(await proc.readFile('/table')));
+
+    expect(doc.stats).toEqual({ live: 1, retained: 2, terminated: 1, spawned: 2 });
+    const byPid = Object.fromEntries(doc.processes.map((r: { pid: number }) => [r.pid, r]));
+    expect(byPid[live.pid]).toMatchObject({
+      ppid: 1,
+      kind: 'shell',
+      state: 'R',
+      status: 'running',
+      argv: 'sleep 9',
+      owner: 'cone',
+      exitCode: null,
+      finishedAt: null,
+    });
+    expect(byPid[dead.pid]).toMatchObject({ state: 'Z', status: 'exited', exitCode: 3 });
+    expect(byPid[dead.pid].finishedAt).toBeGreaterThan(0);
+  });
+
+  it('treats /table as a file, not a pid', async () => {
+    const proc = new ProcMountBackend(new ProcessManager());
+    expect(await proc.stat('/table')).toMatchObject({ kind: 'file' });
+    await expect(proc.readDir('/table')).rejects.toMatchObject({ code: 'ENOTDIR' });
+    // The size a `stat` advertises has to match what a read returns, or a
+    // caller sizing a buffer from `stat` truncates the document.
+    const stat = await proc.stat('/table');
+    expect(stat.size).toBe(decode(await proc.readFile('/table')).length);
+  });
+
+  it('drops reaped processes out of the table', async () => {
+    const pm = new ProcessManager();
+    for (let i = 0; i < 200; i++) {
+      const p = pm.spawn({ kind: 'shell', argv: [`cmd${i}`], owner: { kind: 'cone' } });
+      pm.exit(p.pid, 0);
+    }
+    const proc = new ProcMountBackend(pm);
+    const doc = JSON.parse(decode(await proc.readFile('/table')));
+    // 200 ran, at most the retention window is still resident, and the
+    // session total survives the eviction.
+    expect(doc.stats.terminated).toBe(200);
+    expect(doc.processes.length).toBeLessThan(200);
+    expect(doc.processes.length).toBe(doc.stats.retained);
   });
 
   it('exited processes still appear in /proc/<pid>/* until reaped', async () => {

--- a/packages/webapp/tests/kernel/process-manager.test.ts
+++ b/packages/webapp/tests/kernel/process-manager.test.ts
@@ -60,10 +60,10 @@ describe('ProcessManager — pid allocation', () => {
     const a = pm.spawn({ kind: 'shell', argv: ['a'], owner: { kind: 'cone' } });
     const b = pm.spawn({ kind: 'shell', argv: ['b'], owner: { kind: 'cone' } });
     pm.exit(a.pid, 0);
-    // Even though a exited, the next pid is still monotonic (we don't
-    // reap exited entries). The probe only kicks in if `nextPid` lands
-    // on a still-live entry, which we can't reproduce without
-    // exhausting the space — covered structurally by the dedicated
+    // Even though a exited, the next pid is still monotonic: reaping frees
+    // table slots but never rewinds `nextPid`. The probe only kicks in if
+    // `nextPid` lands on a still-live entry, which we can't reproduce
+    // without exhausting the space — covered structurally by the dedicated
     // wraparound test below.
     const c = pm.spawn({ kind: 'shell', argv: ['c'], owner: { kind: 'cone' } });
     expect(c.pid).toBe(1026);
@@ -646,5 +646,96 @@ describe('runAsProcess', () => {
     });
     expect(received).not.toBeNull();
     expect(received!.kind).toBe('tool');
+  });
+});
+
+describe('ProcessManager — retention', () => {
+  it('keeps a terminated process readable for post-mortem ps', () => {
+    const pm = makeManager();
+    const proc = pm.spawn({ kind: 'shell', argv: ['boom'], owner: { kind: 'cone' } });
+    pm.exit(proc.pid, 42);
+    expect(pm.get(proc.pid)).toMatchObject({ status: 'exited', exitCode: 42 });
+  });
+
+  it('bounds the table so a long session does not grow without limit', () => {
+    const pm = makeManager();
+    for (let i = 0; i < 1500; i++) {
+      const p = pm.spawn({ kind: 'shell', argv: [`cmd${i}`], owner: { kind: 'cone' } });
+      pm.exit(p.pid, 0);
+    }
+    // The bug this replaces: 1,500 spawn/exit pairs left 1,500 resident
+    // records. The exact window is an implementation detail; that it is
+    // bounded well below the number of processes that ran is not.
+    expect(pm.list().length).toBeLessThan(200);
+    expect(pm.stats().terminated).toBe(1500);
+    expect(pm.stats().spawned).toBe(1500);
+    expect(pm.stats().live).toBe(0);
+    expect(pm.stats().retained).toBe(pm.list().length);
+  });
+
+  it('never reaps a live process, however many others terminate', () => {
+    const pm = makeManager();
+    const survivor = pm.spawn({ kind: 'shell', argv: ['sleep'], owner: { kind: 'cone' } });
+    for (let i = 0; i < 1000; i++) {
+      const p = pm.spawn({ kind: 'tool', argv: [`t${i}`], owner: { kind: 'cone' } });
+      pm.exit(p.pid, 0);
+    }
+    expect(pm.get(survivor.pid)).not.toBeNull();
+    expect(pm.listLive()).toEqual([survivor]);
+    expect(pm.stats().live).toBe(1);
+  });
+
+  it('reaps oldest-first, so the most recent deaths stay inspectable', () => {
+    const pm = makeManager();
+    const pids: number[] = [];
+    for (let i = 0; i < 300; i++) {
+      const p = pm.spawn({ kind: 'shell', argv: [`cmd${i}`], owner: { kind: 'cone' } });
+      pm.exit(p.pid, 0);
+      pids.push(p.pid);
+    }
+    expect(pm.get(pids[0])).toBeNull();
+    expect(pm.get(pids[pids.length - 1])).not.toBeNull();
+  });
+
+  it('fires the exit listener with a full record even when that exit evicts one', () => {
+    const pm = makeManager();
+    for (let i = 0; i < 400; i++) {
+      const p = pm.spawn({ kind: 'shell', argv: [`cmd${i}`], owner: { kind: 'cone' } });
+      pm.exit(p.pid, 0);
+    }
+    const seen: Process[] = [];
+    pm.on('exit', (p) => seen.push(p));
+    const last = pm.spawn({ kind: 'shell', argv: ['last'], owner: { kind: 'cone' } });
+    pm.exit(last.pid, 7);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ pid: last.pid, exitCode: 7, status: 'exited' });
+  });
+
+  it('listLive() excludes terminated processes', () => {
+    const pm = makeManager();
+    const a = pm.spawn({ kind: 'shell', argv: ['a'], owner: { kind: 'cone' } });
+    const b = pm.spawn({ kind: 'shell', argv: ['b'], owner: { kind: 'cone' } });
+    pm.signal(b.pid, 'SIGKILL');
+    pm.exit(b.pid, null);
+    expect(pm.listLive().map((p) => p.pid)).toEqual([a.pid]);
+    expect(pm.list()).toHaveLength(2);
+  });
+
+  it('counts a killed process as terminated', () => {
+    const pm = makeManager();
+    const p = pm.spawn({ kind: 'shell', argv: ['x'], owner: { kind: 'cone' } });
+    pm.signal(p.pid, 'SIGKILL');
+    pm.exit(p.pid, null);
+    expect(pm.get(p.pid)?.status).toBe('killed');
+    expect(pm.stats().terminated).toBe(1);
+  });
+
+  it('does not double-count a repeated exit()', () => {
+    const pm = makeManager();
+    const p = pm.spawn({ kind: 'shell', argv: ['x'], owner: { kind: 'cone' } });
+    pm.exit(p.pid, 0);
+    pm.exit(p.pid, 0);
+    expect(pm.stats().terminated).toBe(1);
+    expect(pm.list()).toHaveLength(1);
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-live.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-live.test.ts
@@ -23,7 +23,7 @@ import {
   toSwitcherScoops,
   type WcLiveWiring,
 } from '../../../src/ui/wc/wc-live-callbacks.js';
-import { parseProcStatLine } from '../../../src/ui/wc/wc-live-monitor-deps.js';
+import { parseProcStatLine, parseProcTable } from '../../../src/ui/wc/wc-live-monitor-deps.js';
 import {
   applyLeaderLocalThinkingChange,
   metaThinkingForScoop,
@@ -853,5 +853,43 @@ describe('wireDockTreePersistence', () => {
     expect(dockTree.setTree).toHaveBeenCalledWith(persisted);
     expect(setItemSpy).not.toHaveBeenCalled();
     setItemSpy.mockRestore();
+  });
+});
+
+describe('parseProcTable', () => {
+  const doc = JSON.stringify({
+    stats: { live: 2, retained: 4, terminated: 1435, spawned: 1437 },
+    processes: [
+      { pid: 1024, argv: 'sleep 9', status: 'running' },
+      { pid: 1025, argv: 'rg --json x', status: 'pending' },
+      { pid: 1026, argv: 'npm run lint', status: 'exited' },
+      { pid: 1027, argv: 'tsc --noEmit', status: 'killed' },
+    ],
+  });
+
+  it('keeps only live rows', () => {
+    const snapshot = parseProcTable(doc);
+    expect(snapshot.processes.map((p) => p.pid)).toEqual([1024, 1025]);
+  });
+
+  it('reports the session total, not the retained count', () => {
+    // The whole point of the counter: 1,435 exited, only 2 dead records are
+    // still resident, and the number the UI shows is the former.
+    expect(parseProcTable(doc).terminated).toBe(1435);
+  });
+
+  it('degrades to an empty snapshot on malformed input', () => {
+    expect(parseProcTable('not json')).toEqual({ processes: [], terminated: 0 });
+    expect(parseProcTable('')).toEqual({ processes: [], terminated: 0 });
+    expect(parseProcTable('{}')).toEqual({ processes: [], terminated: 0 });
+    expect(parseProcTable('null')).toEqual({ processes: [], terminated: 0 });
+  });
+
+  it('tolerates rows missing fields', () => {
+    const snapshot = parseProcTable(
+      JSON.stringify({ stats: {}, processes: [{ status: 'running' }] })
+    );
+    expect(snapshot.processes).toEqual([{ pid: 0, argv: '', status: 'running' }]);
+    expect(snapshot.terminated).toBe(0);
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-monitor.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-monitor.test.ts
@@ -17,7 +17,7 @@ function makeDeps(overrides: Partial<MonitorDeps> = {}): MonitorDeps {
     getMcpServers: async () => ({}),
     getOAuthProviders: () => [],
     getSessionStats: async () => null,
-    getProcesses: async () => [],
+    getProcesses: async () => ({ processes: [], terminated: 0 }),
     getTrayInfo: () => ({ role: 'standalone', state: 'inactive' }),
     getConnectedFollowers: () => [],
     ...overrides,
@@ -351,14 +351,17 @@ describe('fetchMonitorData', () => {
   it('shows processes section with pid and argv', async () => {
     const sections = await fetchMonitorData(
       makeDeps({
-        getProcesses: async () => [
-          { pid: 1024, argv: 'node script.js', status: 'running' },
-          {
-            pid: 1025,
-            argv: 'python3 -c "print(1234567890123456789012345678901234567890)"',
-            status: 'sleeping',
-          },
-        ],
+        getProcesses: async () => ({
+          processes: [
+            { pid: 1024, argv: 'node script.js', status: 'running' },
+            {
+              pid: 1025,
+              argv: 'python3 -c "print(1234567890123456789012345678901234567890)"',
+              status: 'sleeping',
+            },
+          ],
+          terminated: 0,
+        }),
       })
     );
     const processSection = sections.find((s) => s.id === 'processes')!;
@@ -367,5 +370,45 @@ describe('fetchMonitorData', () => {
     expect(processSection.rows[0].meta).toBe('node script.js');
     expect(processSection.rows[0].active).toBe(true);
     expect(processSection.rows[1].meta).toContain('...');
+  });
+
+  it('reports exited processes as a count, never as rows', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getProcesses: async () => ({
+          processes: [{ pid: 1024, argv: 'node script.js', status: 'running' }],
+          terminated: 1435,
+        }),
+      })
+    );
+    const processSection = sections.find((s) => s.id === 'processes')!;
+    expect(processSection.rows).toHaveLength(1);
+    expect(processSection.count).toBe(1);
+    expect(processSection.meta).toBe('1 live · 1,435 exited');
+  });
+
+  it('omits the exited count when nothing has exited yet', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getProcesses: async () => ({
+          processes: [{ pid: 1024, argv: 'node script.js', status: 'running' }],
+          terminated: 0,
+        }),
+      })
+    );
+    expect(sections.find((s) => s.id === 'processes')!.meta).toBeUndefined();
+  });
+
+  it('degrades to an empty snapshot when the process read fails', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getProcesses: async () => {
+          throw new Error('proc mount unavailable');
+        },
+      })
+    );
+    const processSection = sections.find((s) => s.id === 'processes')!;
+    expect(processSection.rows).toEqual([]);
+    expect(processSection.meta).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Why

The live monitor was showing **1,444 processes for a session with 9 alive**. That number turned out to be two independent data-layer bugs, and this PR fixes both. The UI redesign that motivated the investigation is a separate, stacked PR — this one changes no layout.

## `ProcessManager` never reaped

`process-manager.ts` said so out loud: *"No reaping today — terminated entries persist so `ps` after `kill` still shows the exit code."* The intent was right; the implementation had no upper bound. Every shell command, tool call and scoop turn in the session kept a resident `Process` record — with its `AbortController`, `Gate`, argv and env — that nothing would ever read again. A five-hour session accumulated 1,444 of them.

It now retains the most recent **128** terminated records and reaps older ones oldest-first, so the table is `O(live + 128)`. Post-mortem inspection only ever looks at the recent past — the process you just killed, the command that just failed — so a window serves the original purpose. Eviction only ever considers pids already in the terminated FIFO, so **a live process can never be reaped**, however many others die around it.

The totals those records used to carry survive as counters:

```ts
stats(): { live, retained, terminated, spawned }
```

`terminated` and `spawned` are monotonic for the session and keep counting past the retention window. "1,435 exited this session" stays true without 1,435 records staying resident to prove it.

## Reading `/proc` cost ~2,900 VFS reads per tick

`getProcesses()` did a `readDir('/proc')` and then **two `readFile`s per pid**. At the table sizes above that is roughly 2,900 VFS reads every 5 seconds, against the same VFS the boot path and the terminal lazy-mount contend for.

`/proc/table` serves the whole retained table plus the `stats()` counters as one JSON document. This is a deliberate non-Linux addition and is documented as one: Linux readers walk `/proc/<pid>/` per process because a syscall-backed read is cheap, which is not true here. The per-pid files are unchanged.

```jsonc
{
  "stats": { "live": 9, "retained": 137, "terminated": 1435, "spawned": 1444 },
  "processes": [
    { "pid": 1024, "ppid": 1, "kind": "shell", "state": "R", "status": "running",
      "argv": "sleep 9", "cwd": "/workspace", "owner": "cone",
      "startedAt": 1700000000000, "finishedAt": null, "exitCode": null }
  ]
}
```

## The monitor stops rendering the dead

The Processes section now lists **live processes only** — the same default `ps` has had all along (`ps-command.ts`: *"listing them by default is noisy"*; `-e` opts in). The panel was less disciplined than the shell command reading the same data. Exited processes are reported as `9 live · 1,435 exited`, sourced from the kernel counter so the number outlives the reaped rows.

## Behavior changes worth knowing

- `get(pid)` and `wait(pid)` on a reaped pid now behave exactly like an unknown pid (`null` / reject). Anything wanting a durable record should hold the `Process` handle it was given.
- `allocatePid()` may reuse a reaped pid after the uint32 space wraps. The linear-probe bound still holds — reaping only shrinks the table.
- `exit` listeners fire **before** reaping, so a listener always sees a full record even when that exit is the one that evicts an older entry. Pinned by a test.
- `MonitorDeps.getProcesses()` returns `MonitorProcessSnapshot` instead of a bare array.

## Tests

- **`process-manager.test.ts`** — post-mortem readability, bounded growth over 1,500 spawn/exit pairs, live process survives 1,000 deaths, oldest-first eviction, `exit` listener sees a full record mid-eviction, `listLive()`, killed counted as terminated, repeated `exit()` not double-counted.
- **`proc-mount.test.ts`** — `/proc/table` contents and counters, `stat().size` matches what a read returns (a caller sizing a buffer from `stat` must not truncate), `ENOTDIR` on `readDir('/table')`, reaped rows leave the document while `stats.terminated` keeps counting.
- **`wc-live.test.ts`** — `parseProcTable` keeps only live rows, reports the session total rather than the retained count, degrades to an empty snapshot on malformed input.
- **`wc-monitor.test.ts`** — exited reported as a count and never as rows, count omitted when nothing has exited, empty snapshot when the read fails.

## Verification

`lint` · `typecheck` · `test` (16,802) · `test:coverage` · `build` · `check-touched-exemptions` — all green locally.

Docs: `docs/kernel/process-model.md` gains a Retention section and the `/proc/table` layout entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
