### PR TITLE
fix(webapp): recover serial handles after a device re-enumerates

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -909,6 +909,21 @@ Web Serial access from the shell (`packages/webapp/src/shell/supplemental-comman
 
 The `serial request` chooser requires a real user gesture (see [Gesture bridge](#gesture-bridge-usb--serial--hid)). `read` emits raw bytes by default; `--hex` hex-dumps. Reads/writes are capped at 4 MiB.
 
+**Handles are invalidated by re-enumeration.** A board that resets — every
+`esptool` flash does this — cycles its USB device, and Chrome hands back a
+_new_ `SerialPort` object. `serial list` reconciles on each call: ports that
+disappeared are evicted and their handles stop resolving, so a script must
+re-read the handle rather than cache `serial1`:
+
+```bash
+H=$(serial list | head -1 | cut -f1)
+serial open "$H" --baud 115200
+```
+
+Opening a handle whose device went away reports that the handle may be stale
+and tells you to re-run `serial list`, instead of surfacing the browser's bare
+`Failed to open serial port`.
+
 ### Subcommands
 
 | Form                                      | Behavior                                                                |
@@ -916,7 +931,7 @@ The `serial request` chooser requires a real user gesture (see [Gesture bridge](
 | `serial list`                             | List currently-granted ports as `handle  vid:pid [open]`.               |
 | `serial request [--vid 0x.. --pid 0x..]`  | Open the port picker (needs a user gesture); prints the granted handle. |
 | `serial open <handle> [open flags]`       | Open a port with the given line settings.                               |
-| `serial close <handle>`                   | Close a port.                                                           |
+| `serial close <handle>`                   | Close a port. Idempotent — closing an already-closed port succeeds.     |
 | `serial read <handle> [read flags]`       | Read bytes (raw by default, `--hex` to dump).                           |
 | `serial write <handle>`                   | Write stdin bytes to the port; prints `<n> bytes written`.              |
 | `serial signals <handle> get`             | Print control input signals (`cts dcd dsr ri`).                         |

--- a/packages/webapp/src/kernel/serial-operations.ts
+++ b/packages/webapp/src/kernel/serial-operations.ts
@@ -59,6 +59,9 @@ export async function serialList(
   serial: SerialApi
 ): Promise<SerialDeviceInfo[]> {
   const ports = await serial.getPorts();
+  // Reconcile first: a re-enumerated device hands back a new SerialPort object,
+  // and the stale one must not keep answering to its old handle.
+  registry.retainOnly(ports);
   return ports.map((p) => {
     const handle = registry.register(p);
     return deviceToInfo(handle, registry.get(handle)!);
@@ -85,7 +88,19 @@ export async function serialOpen(
   options: SerialOpenOptions
 ): Promise<void> {
   const entry = resolve(registry, handle);
-  await entry.port.open(options);
+  try {
+    await entry.port.open(options);
+  } catch (err) {
+    // A handle whose device re-enumerated (board reset, replug) can never be
+    // opened again. Say so, instead of passing through Chrome's opaque
+    // "Failed to open serial port", which reads like a hardware fault and sent
+    // us chasing phantom problems for hours.
+    throw new Error(
+      `${err instanceof Error ? err.message : String(err)} ` +
+        `(handle '${handle}' may be stale after a device reset — ` +
+        `re-run 'serial list' to pick up the current handle)`
+    );
+  }
   entry.opened = true;
 }
 
@@ -114,8 +129,22 @@ export async function serialClose(registry: SerialPortRegistry, handle: string):
     }
     entry.writer = undefined;
   }
-  await entry.port.close();
-  entry.opened = false;
+  // Idempotent: closing an already-closed port is a no-op, not an error. The
+  // state reset must happen even if close() rejects, otherwise a failed close
+  // leaves the entry permanently marked open and every later op is refused.
+  try {
+    await entry.port.close();
+  } catch (err) {
+    if (!isAlreadyClosed(err)) throw err;
+  } finally {
+    entry.opened = false;
+  }
+}
+
+/** Chrome reports a redundant close as an InvalidStateError; treat it as success. */
+function isAlreadyClosed(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /already closed|not open/i.test(message);
 }
 
 function getReader(entry: SerialPortEntry): ReadableStreamDefaultReader<Uint8Array> {

--- a/packages/webapp/src/kernel/serial-operations.ts
+++ b/packages/webapp/src/kernel/serial-operations.ts
@@ -54,14 +54,64 @@ function indexOfSub(hay: Uint8Array, needle: Uint8Array, start: number): number 
   return -1;
 }
 
+/**
+ * Cancel the reader and release both stream locks, dropping buffered state.
+ * A port whose streams stay locked cannot be reopened — not even by a freshly
+ * acquired `SerialPort` object for the same device.
+ */
+async function releaseStreams(entry: SerialPortEntry): Promise<void> {
+  if (entry.reader) {
+    try {
+      await entry.reader.cancel();
+    } catch {
+      /* reader may already be closed */
+    }
+    try {
+      entry.reader.releaseLock();
+    } catch {
+      /* lock may already be released */
+    }
+    entry.reader = undefined;
+  }
+  entry.pendingRead = undefined;
+  entry.leftover = undefined;
+  if (entry.writer) {
+    try {
+      entry.writer.releaseLock();
+    } catch {
+      /* lock may already be released */
+    }
+    entry.writer = undefined;
+  }
+}
+
+/**
+ * Fully retire an evicted entry: release its streams and close the underlying
+ * port. Best-effort — the device is already gone, so a failure here must not
+ * break `serial list`.
+ */
+async function retireEvicted(entry: SerialPortEntry): Promise<void> {
+  await releaseStreams(entry);
+  if (!entry.opened) return;
+  try {
+    await entry.port.close();
+  } catch {
+    /* the device is gone; nothing more we can do */
+  }
+  entry.opened = false;
+}
+
 export async function serialList(
   registry: SerialPortRegistry,
   serial: SerialApi
 ): Promise<SerialDeviceInfo[]> {
   const ports = await serial.getPorts();
   // Reconcile first: a re-enumerated device hands back a new SerialPort object,
-  // and the stale one must not keep answering to its old handle.
-  registry.retainOnly(ports);
+  // and the stale one must not keep answering to its old handle. Evicted
+  // entries are RETIRED, not merely forgotten — see retireEvicted.
+  for (const { entry } of registry.retainOnly(ports)) {
+    await retireEvicted(entry);
+  }
   return ports.map((p) => {
     const handle = registry.register(p);
     return deviceToInfo(handle, registry.get(handle)!);
@@ -106,39 +156,17 @@ export async function serialOpen(
 
 export async function serialClose(registry: SerialPortRegistry, handle: string): Promise<void> {
   const entry = resolve(registry, handle);
-  if (entry.reader) {
-    try {
-      await entry.reader.cancel();
-    } catch {
-      /* reader may already be closed */
-    }
-    try {
-      entry.reader.releaseLock();
-    } catch {
-      /* lock may already be released */
-    }
-    entry.reader = undefined;
-  }
-  entry.pendingRead = undefined;
-  entry.leftover = undefined;
-  if (entry.writer) {
-    try {
-      entry.writer.releaseLock();
-    } catch {
-      /* lock may already be released */
-    }
-    entry.writer = undefined;
-  }
-  // Idempotent: closing an already-closed port is a no-op, not an error. The
-  // state reset must happen even if close() rejects, otherwise a failed close
-  // leaves the entry permanently marked open and every later op is refused.
+  await releaseStreams(entry);
   try {
     await entry.port.close();
   } catch (err) {
+    // Only a confirmed already-closed port may be marked closed. For any other
+    // failure the browser port may STILL be open, and lying about it makes
+    // `serial list` wrong and causes esptool's takeOverPort() to skip its own
+    // close (it closes only when `opened`), so the next transport open fails.
     if (!isAlreadyClosed(err)) throw err;
-  } finally {
-    entry.opened = false;
   }
+  entry.opened = false;
 }
 
 /** Chrome reports a redundant close as an InvalidStateError; treat it as success. */

--- a/packages/webapp/src/kernel/serial-port-registry.ts
+++ b/packages/webapp/src/kernel/serial-port-registry.ts
@@ -133,19 +133,17 @@ export class SerialPortRegistry {
    * its old handle forever: every `open` on it fails with an opaque
    * "Failed to open serial port" and only a page reload clears it.
    *
-   * Returns the handles that were evicted.
+   * Returns the evicted entries. The caller MUST release each one (cancel the
+   * reader, release both locks, close the port) — dropping the map entry alone
+   * would strand an open/locked port with no handle left to close it through,
+   * which is the very wedge this reconciliation exists to prevent.
    */
-  retainOnly(live: readonly SerialPort[]): string[] {
-    const evicted: string[] = [];
+  retainOnly(live: readonly SerialPort[]): Array<{ handle: string; entry: SerialPortEntry }> {
+    const evicted: Array<{ handle: string; entry: SerialPortEntry }> = [];
     for (const [handle, entry] of [...this.byHandle]) {
       if (live.includes(entry.port)) continue;
-      entry.reader = undefined;
-      entry.writer = undefined;
-      entry.pendingRead = undefined;
-      entry.leftover = undefined;
-      entry.opened = false;
       this.byHandle.delete(handle);
-      evicted.push(handle);
+      evicted.push({ handle, entry });
     }
     return evicted;
   }

--- a/packages/webapp/src/kernel/serial-port-registry.ts
+++ b/packages/webapp/src/kernel/serial-port-registry.ts
@@ -123,6 +123,32 @@ export class SerialPortRegistry {
   list(): Array<{ handle: string; entry: SerialPortEntry }> {
     return [...this.byHandle].map(([handle, entry]) => ({ handle, entry }));
   }
+
+  /**
+   * Drop entries whose port is no longer present in `live`.
+   *
+   * A device that re-enumerates (USB replug, or a board reset that cycles the
+   * port — routine when flashing) gets a BRAND NEW `SerialPort` object from
+   * `navigator.serial.getPorts()`. Without this, the old object lingers under
+   * its old handle forever: every `open` on it fails with an opaque
+   * "Failed to open serial port" and only a page reload clears it.
+   *
+   * Returns the handles that were evicted.
+   */
+  retainOnly(live: readonly SerialPort[]): string[] {
+    const evicted: string[] = [];
+    for (const [handle, entry] of [...this.byHandle]) {
+      if (live.includes(entry.port)) continue;
+      entry.reader = undefined;
+      entry.writer = undefined;
+      entry.pendingRead = undefined;
+      entry.leftover = undefined;
+      entry.opened = false;
+      this.byHandle.delete(handle);
+      evicted.push(handle);
+    }
+    return evicted;
+  }
 }
 
 let sharedRegistry: SerialPortRegistry | null = null;

--- a/packages/webapp/tests/kernel/serial-port-registry.test.ts
+++ b/packages/webapp/tests/kernel/serial-port-registry.test.ts
@@ -180,7 +180,7 @@ describe('serial-operations', () => {
     expect(reg.get(second[0]!.handle)?.port).toBe(after);
   });
 
-  it('retainOnly reports evicted handles and clears their stream state', () => {
+  it('retainOnly returns evicted entries so the caller can retire them', () => {
     const reg = new SerialPortRegistry();
     const gone = makePort();
     const kept = makePort();
@@ -188,7 +188,12 @@ describe('serial-operations', () => {
     const keptHandle = reg.register(kept);
     reg.get(goneHandle)!.opened = true;
 
-    expect(reg.retainOnly([kept])).toEqual([goneHandle]);
+    const evicted = reg.retainOnly([kept]);
+    expect(evicted.map((e) => e.handle)).toEqual([goneHandle]);
+    // The entry is handed back still describing the live port, so the caller
+    // can close it — dropping it silently would strand an open port.
+    expect(evicted[0]!.entry.port).toBe(gone);
+    expect(evicted[0]!.entry.opened).toBe(true);
     expect(reg.get(goneHandle)).toBeUndefined();
     expect(reg.get(keptHandle)?.port).toBe(kept);
   });
@@ -217,7 +222,7 @@ describe('serial-operations', () => {
     expect(reg.get(handle)?.opened).toBe(false);
   });
 
-  it('serialClose still surfaces genuine close failures but resets state', async () => {
+  it('serialClose keeps `opened` true when a genuine close fails', async () => {
     const reg = new SerialPortRegistry();
     const port = makePort();
     port.close = vi.fn(async () => {
@@ -226,6 +231,34 @@ describe('serial-operations', () => {
     const handle = reg.register(port);
     reg.get(handle)!.opened = true;
     await expect(serialOps.serialClose(reg, handle)).rejects.toThrow(/disconnected/);
-    expect(reg.get(handle)?.opened).toBe(false);
+    // The browser port may still be open. Claiming otherwise makes `serial list`
+    // wrong and makes esptool's takeOverPort() skip its close.
+    expect(reg.get(handle)?.opened).toBe(true);
+  });
+
+  it('serialList retires an evicted port that was still open and locked', async () => {
+    const reg = new SerialPortRegistry();
+    const { readable, reader } = makeReadable([]);
+    const { writable, writer } = makeWritable();
+    const stale = makePort(readable, writable);
+    const handle = reg.register(stale);
+
+    // Simulate a port left open with live stream locks (mid read/write).
+    const entry = reg.get(handle)!;
+    entry.opened = true;
+    entry.reader = reader as unknown as ReadableStreamDefaultReader<Uint8Array>;
+    entry.writer = writer as unknown as WritableStreamDefaultWriter<Uint8Array>;
+
+    // Device re-enumerates: getPorts() now reports a different object.
+    const fresh = makePort();
+    const serial = { getPorts: vi.fn(async () => [fresh]) } as never;
+    await serialOps.serialList(reg, serial);
+
+    // Merely forgetting the entry would strand an open, locked port.
+    expect(reader.cancel).toHaveBeenCalled();
+    expect(reader.releaseLock).toHaveBeenCalled();
+    expect(writer.releaseLock).toHaveBeenCalled();
+    expect(stale.close).toHaveBeenCalled();
+    expect(reg.get(handle)).toBeUndefined();
   });
 });

--- a/packages/webapp/tests/kernel/serial-port-registry.test.ts
+++ b/packages/webapp/tests/kernel/serial-port-registry.test.ts
@@ -156,4 +156,76 @@ describe('serial-operations', () => {
       /unknown serial handle/
     );
   });
+  // ── Re-enumeration wedge (#serial-stale-handle) ────────────────────────────
+  // A board reset during flashing cycles the USB device, so getPorts() returns
+  // a NEW SerialPort object. Before the fix the old object stayed registered
+  // and its handle failed to open forever, recoverable only by reloading.
+
+  it('serialList evicts entries whose port vanished after re-enumeration', async () => {
+    const reg = new SerialPortRegistry();
+    const before = makePort();
+    const serial = { getPorts: vi.fn(async () => [before]) } as never;
+
+    const first = await serialOps.serialList(reg, serial);
+    expect(first[0]?.handle).toBe('serial1');
+
+    // Device re-enumerates: same vid/pid, different object identity.
+    const after = makePort();
+    (serial as unknown as { getPorts: () => Promise<unknown[]> }).getPorts = async () => [after];
+
+    const second = await serialOps.serialList(reg, serial);
+    expect(second).toHaveLength(1);
+    // The dead handle must be gone, not merely shadowed.
+    expect(reg.get('serial1')).toBeUndefined();
+    expect(reg.get(second[0]!.handle)?.port).toBe(after);
+  });
+
+  it('retainOnly reports evicted handles and clears their stream state', () => {
+    const reg = new SerialPortRegistry();
+    const gone = makePort();
+    const kept = makePort();
+    const goneHandle = reg.register(gone);
+    const keptHandle = reg.register(kept);
+    reg.get(goneHandle)!.opened = true;
+
+    expect(reg.retainOnly([kept])).toEqual([goneHandle]);
+    expect(reg.get(goneHandle)).toBeUndefined();
+    expect(reg.get(keptHandle)?.port).toBe(kept);
+  });
+
+  it('opening a stale handle explains that it is stale', async () => {
+    const reg = new SerialPortRegistry();
+    const port = makePort();
+    port.open = vi.fn(async () => {
+      throw new Error('Failed to open serial port.');
+    });
+    const handle = reg.register(port);
+    await expect(serialOps.serialOpen(reg, handle, { baudRate: 9600 })).rejects.toThrow(
+      /may be stale after a device reset/
+    );
+  });
+
+  it('serialClose is idempotent when the port is already closed', async () => {
+    const reg = new SerialPortRegistry();
+    const port = makePort();
+    port.close = vi.fn(async () => {
+      throw new Error('The port is already closed.');
+    });
+    const handle = reg.register(port);
+    reg.get(handle)!.opened = true;
+    await expect(serialOps.serialClose(reg, handle)).resolves.toBeUndefined();
+    expect(reg.get(handle)?.opened).toBe(false);
+  });
+
+  it('serialClose still surfaces genuine close failures but resets state', async () => {
+    const reg = new SerialPortRegistry();
+    const port = makePort();
+    port.close = vi.fn(async () => {
+      throw new Error('device disconnected mid-transfer');
+    });
+    const handle = reg.register(port);
+    reg.get(handle)!.opened = true;
+    await expect(serialOps.serialClose(reg, handle)).rejects.toThrow(/disconnected/);
+    expect(reg.get(handle)?.opened).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

A Web Serial handle stopped working permanently once its device re-enumerated. Before: after any board reset (every `esptool` flash does one), `serial open serial1` failed forever with `Failed to open serial port`, and the only recovery was reloading the page. Now: `serial list` reconciles against the live port set, so re-running it yields a working handle and the session recovers in place.

## Why

Found while flashing an ESP32-S3 over Web Serial from the shell. The port wedged **8+ times**, each needing a full harness restart. The tell was handles climbing `serial1` → `serial2` → `serial3`: each re-enumeration produced a *new* `SerialPort` object, and the dead one stayed registered.

`serialList` registered every port from `getPorts()` but never evicted entries whose port had vanished. `SerialPortRegistry.register()` dedupes by object identity, which is correct — but nothing ever removed the stale objects, so old handles kept resolving to corpses.

**Repro**

1. Grant a serial port (a USB-CDC device that resets, e.g. any ESP32)
2. `serial list` → `serial1`
3. Cause a re-enumeration: `esptool --port serial1 write_flash …` (resets the board), or just unplug/replug
4. `serial open serial1 --baud 115200`

Expected: a clear error telling you the handle is stale, and `serial list` yields a working one.
Actual (before): `Failed to open serial port.` forever, on every handle, until page reload.

## Approach / Implementation notes

- `SerialPortRegistry.retainOnly(live)` drops entries absent from the current `getPorts()`, clearing reader/writer/leftover state and returning evicted handles. `serialList` calls it **before** registering.
- `serialClose` is now idempotent — `port.close()` guarded, `opened` reset in `finally`. Previously a redundant close threw *after* the reader/writer teardown, so `opened` was never cleared and every later op was refused. This is what forced `serial close || true` in scripts.
- `serialOpen` wraps open failures with "handle may be stale after a device reset — re-run `serial list`". The browser's raw message reads like a hardware fault; it cost me hours chasing the board instead of the code.

**Deliberate behaviour change worth a reviewer's eye:** Chrome returns a *different* object from `requestPort()` than from `getPorts()`, so the handle returned by `serial request` is now retired by the next `serial list`. That's correct — the `getPorts()` objects are canonical — but it means callers must re-read the handle rather than cache it. Docs updated to show `H=$(serial list | head -1 | cut -f1)`.

**Not fixed, deliberately:** a read in flight when the device disappears still reports `The device has been lost`. That is accurate — the device did go away. The fix is that re-listing now recovers instead of requiring a reload.

## Cross-cutting impact

- **Floats exercised**: CLI (standalone Chrome, local `wrangler dev` origin). The `serial` command is Chromium-only and unavailable in the cloud / hosted-leader float, so no change there.
- **Other callers of the changed contract**: `serial-backends.ts` `LocalDomSerialBackend` (calls `serialOps.*` directly) and `ui/panel-rpc-handlers.ts` (worker → page bridge) both go through the same ops module, so both inherit the fix. `esptool-command.ts` layers on the same handle namespace and benefits without change.
- **`retainOnly` and `remove`**: `remove()` is untouched and still used by explicit teardown paths.
- **Persisted state**: none. The registry is in-memory, per DOM realm.
- **Security / bundle size**: no new dependencies, no new surface.

## Test plan

- [x] `npx prettier --write docs/shell-reference.md` — `prettier --check .` now clean (it caught my markdown edit)
- [x] `npm run lint:ci` — exit 0
- [x] `npm run typecheck` — exit 0 (all 9 projects)
- [x] `npm run test` — **16743 passed | 46 skipped**, no failures
- [x] `npm run build` — exit 0
- [x] `npm run build -w @slicc/chrome-extension` — exit 0
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK, 4 changed files, 0 on any debt list
- [x] New behaviour covered by unit tests: `npx vitest run packages/webapp/tests/kernel/serial-port-registry.test.ts` — 5 new tests. **Each was confirmed FAILING against the unfixed source** before being trusted (reverted `src/`, saw 5 red, restored).
- [x] **Manual smoke on real hardware** (CLI float, local build at `localhost:8788`, ESP32-S3 over USB-Serial-JTAG): forced repeated re-enumerations by flashing, then `serial list` + open — three consecutive `RECOVERED-serialN`, no page reload, no harness restart. Stale handles now report `unknown serial handle 'serial1'`.

No UI change, so no screencast.
