### PR TITLE
Memory curator: staged-draft three-way merge + durable curation ledger

### DIFF
--- a/docs/webapp-details.md
+++ b/docs/webapp-details.md
@@ -78,7 +78,7 @@ One roster, three renderings, one vocabulary — `ui/follower-presentation.ts` o
 
 ## Frozen Sessions ("New session" flow)
 
-- Path: `ui/session-freezer.ts`, `ui/new-session.ts`. **Save**, **Skip memory**, and **Erase** clear cone chat and non-mount `/tmp`, not scoops. Archives in `/sessions/<timestamp>-<slug>.md` + `index.json`. Idle boot recovers pending markers serially (≤3 times) through the **bounded** legacy enrichment call — never the unbounded curator (`timeoutSeconds` cannot stop it). Agentic Save: quick snapshot then clear; title (`skipMemory`) + curator in background. Cone-only `OffscreenClient.clearAllMessages()` awaits `clear-chat-ack` before panel reload.
+- Path: `ui/session-freezer.ts`, `ui/new-session.ts`. **Save**, **Skip memory**, and **Erase** clear cone chat and non-mount `/tmp`, not scoops. Archives in `/sessions/<timestamp>-<slug>.md` + `index.json`. Idle boot recovers pending markers serially (≤3 times) through the **bounded** legacy enrichment call — never the unbounded curator (`timeoutSeconds` cannot stop it). Agentic Save: quick snapshot then clear; title (`skipMemory`) + curator in background. The curator edits a staged draft under `/sessions/.curation/<archive>/` that the agent bridge three-way-merges onto the live memory file on exit 0 (`mergeOnSuccess`; concurrent live edits survive, conflicts resolve to the curator); the bridge also writes `status.json` there on both exit paths (`outcomeReceiptPath`), and the index entry records `memoryCuratedAt` on success / `memoryFailed` on failure or retry exhaustion — the durable which-sessions-curated ledger. Cone-only `OffscreenClient.clearAllMessages()` awaits `clear-chat-ack` before panel reload.
 
 ## UI
 

--- a/packages/vfs-root/CLAUDE.md
+++ b/packages/vfs-root/CLAUDE.md
@@ -30,8 +30,17 @@ This file covers the default virtual filesystem payload in `packages/vfs-root/`.
   entries containing commas must be quoted. A bare `/` is rejected from `writablePaths`.
 - Frontmatter `allowedCommands` entries extend the curator's built-in base set; they do not
   replace or remove base commands.
-- The curator may rewrite the entire `/workspace/CLAUDE.md`, and the hard character budget
+- The curator may rewrite the entire memory file, and the hard character budget
   applies to the entire file with no protected region.
+- **The curator edits a staged draft, never the live file.** `{{MEMORY_PATH}}` resolves to
+  `/sessions/.curation/<archive>/draft.md`, seeded (with a `base.md` snapshot) from the live
+  memory when the pass spawns; the agent bridge three-way-merges base→draft onto the live file
+  on exit 0, before the success receipt (`mergeOnSuccess`). Concurrent live edits survive;
+  conflicting regions resolve to the curator. A killed or failed run leaves the live memory
+  untouched. The bridge also writes `/sessions/.curation/<archive>/status.json` on both exit
+  paths (`outcomeReceiptPath`) — the durable ledger of which sessions completed vs failed
+  curation; the index entry mirrors it as `memoryCuratedAt` / `memoryFailed`. Per-archive
+  keying means parallel per-cone curators (#1666) never share staging state.
 - Every `##`/`###` memory section ends with a `YYYY-MM-DD` last-verified date, in UTC to match
   archive timestamps. Each pass re-verifies the oldest sections first; undated sections are
   maximally stale.

--- a/packages/vfs-root/shared/MEMORY.md
+++ b/packages/vfs-root/shared/MEMORY.md
@@ -37,7 +37,7 @@ thinkingLevel: medium
 
 Curate the durable memory for session {{SESSION_COUNT}}. Today's date is {{TODAY}}.
 
-**Work fast: a full pass should finish in well under 10 minutes.** The run is hard-stopped at 20 minutes, and a kill mid-write can corrupt the memory file or leave it over budget — so mine the three signals, rewrite the file, compact it in the same pass, and stop, rather than exploring the archive exhaustively.
+**Work fast: a full pass should finish in well under 10 minutes.** The run is hard-stopped at 20 minutes, and your rewrite only lands if the pass completes — a killed run is discarded wholesale. So mine the three signals, rewrite the file, compact it in the same pass, and stop, rather than exploring the archive exhaustively.
 
 Read the entire current memory at {{MEMORY_PATH}} if it exists. Then mine the archived session at {{SESSION_ARCHIVE_PATH}} using the reading recipes below. Rewrite the entire {{MEMORY_PATH}} file with the durable information worth carrying into future sessions. Every part of the file is editable and counts toward the budget.
 
@@ -121,6 +121,8 @@ Rules:
 
 <!-- How to customize
 Add curator instructions here, for example: also update the knowledge base at /path following its WIKI.md. Extend visiblePaths or writablePaths above to grant access to extra stores, and adjust timeoutSeconds when needed.
+
+{{MEMORY_PATH}} resolves to a staged per-archive draft under /sessions/.curation/, not the live memory file: the pass snapshots the live file when it spawns, the curator rewrites the draft, and on a successful exit the runtime three-way-merges the rewrite back onto the live file. Edits the cone or the user makes to the live memory while the curator runs survive; where both sides changed the same lines the curator's version wins. An entry in writablePaths naming the memory file is substituted with the draft automatically, so this file keeps working unchanged. A failed or killed run leaves the live memory untouched and its outcome recorded at /sessions/.curation/<archive>/status.json.
 
 writablePaths defaults to the memory file alone rather than /workspace/, because the curator can run upskill and a directory-wide grant would also let it install skills into /workspace/skills. Widen it only as far as a task genuinely needs; a single file is a valid entry, not just a directory.
 

--- a/packages/webapp/src/scoops/agent-bridge.ts
+++ b/packages/webapp/src/scoops/agent-bridge.ts
@@ -182,9 +182,12 @@ export interface AgentSpawnOptions {
    * the bridge removes `basePath` + `draftPath`; a failed run keeps them
    * for a retry or a human post-mortem. Runs in the worker realm with the
    * bridge's full shared-VFS handle, so a page death after spawn cannot
-   * lose the completed rewrite (#1989 companion). Best-effort: a merge
-   * failure is logged and recorded in the outcome receipt, never fails
-   * the spawn.
+   * lose the completed rewrite (#1989 companion). A merge failure (I/O
+   * error, missing base snapshot) DOWNGRADES the spawn to a non-zero
+   * exit: the run succeeded but its rewrite never landed, and a success
+   * signal would let callers clear their pending bookkeeping with the
+   * work undone. The error is logged and recorded in the outcome
+   * receipt; the success receipt is not written.
    */
   mergeOnSuccess?: AgentMergeOnSuccess;
   /**
@@ -580,10 +583,25 @@ async function applyMergeOnSuccess(
       await cleanup();
       return { applied: false, conflicts: 0 };
     }
-    const [base, current] = await Promise.all([read(spec.basePath), read(spec.targetPath)]);
-    if (draft === base || draft === current) {
-      // The scoop left the draft untouched (or wrote directly to the
-      // target under a custom grant) — nothing to fold in.
+    // A missing target is a legitimately empty original (first-ever pass);
+    // read() maps its ENOENT to ''.
+    const current = await read(spec.targetPath);
+    if (draft === current) {
+      // The scoop wrote directly to the target under a custom grant —
+      // nothing left to fold in, and no base needed to know that.
+      await cleanup();
+      return { applied: false, conflicts: 0 };
+    }
+    // The caller always seeds the base, so its absence is lost staging
+    // too — treating it as an empty original would turn the whole live
+    // file into a conflict the draft wins, silently discarding concurrent
+    // memories. Surface an error (which fails the run) instead.
+    const base = await readOrNull(spec.basePath);
+    if (base === null) {
+      return { applied: false, conflicts: 0, error: 'base snapshot missing; target left as-is' };
+    }
+    if (draft === base) {
+      // The scoop left the draft untouched — nothing to fold in.
       await cleanup();
       return { applied: false, conflicts: 0 };
     }
@@ -883,7 +901,7 @@ async function runScoopToOutcome(
   jid: string,
   observerHandle: ReturnType<typeof registerScoopObserver>
 ): Promise<AgentSpawnResult> {
-  const outcome = await runScoopToOutcomeInner(ctx, options, scoop, jid, observerHandle);
+  let outcome = await runScoopToOutcomeInner(ctx, options, scoop, jid, observerHandle);
   // Durable bookkeeping in run order, all written BEFORE the spawn resolves
   // so they land strictly earlier than any caller-side bookkeeping: fold a
   // staged rewrite onto its live target (success only), then the
@@ -892,6 +910,17 @@ async function runScoopToOutcome(
   let merge: MergeOutcome | undefined;
   if (outcome.exitCode === 0 && options.mergeOnSuccess) {
     merge = await applyMergeOnSuccess(ctx.sharedFs, options.mergeOnSuccess);
+    if (merge.error !== undefined) {
+      // The scoop ran fine but its rewrite never reached the target — a
+      // success signal here would clear the caller's pending marker (and
+      // the receipt would satisfy crash recovery) with the work undone.
+      // Fail the spawn instead; the staging survives for a post-mortem
+      // and the caller's failure path recovers the memory another way.
+      outcome = {
+        finalText: `agent: mergeOnSuccess failed: ${merge.error}`,
+        exitCode: 1,
+      };
+    }
   }
   if (outcome.exitCode === 0 && options.successReceiptPath) {
     await writeSuccessReceipt(ctx.sharedFs, options.successReceiptPath);

--- a/packages/webapp/src/scoops/agent-bridge.ts
+++ b/packages/webapp/src/scoops/agent-bridge.ts
@@ -33,6 +33,8 @@ import { createLogger } from '../base/logger.js';
 import type { SessionStore } from '../core/session.js';
 import type { VirtualFS } from '../fs/index.js';
 import { normalizePath } from '../fs/path-utils.js';
+// Legal down-edge (`scoops/` → `git/`) for the staged-rewrite merge.
+import { threeWayMerge } from '../git/merge-file-core.js';
 import {
   resolveModelSelectionForScoop,
   type ScoopModelResolution,
@@ -54,6 +56,16 @@ import {
 } from './types.js';
 
 const log = createLogger('agent-bridge');
+
+/** Staged-rewrite spec for {@link AgentSpawnOptions.mergeOnSuccess}. */
+export interface AgentMergeOnSuccess {
+  /** Live file the merged result is written to. */
+  targetPath: string;
+  /** Snapshot of the target taken by the caller at spawn time. */
+  basePath: string;
+  /** The staged copy the spawned scoop actually edited. */
+  draftPath: string;
+}
 
 /** Arguments accepted by {@link AgentBridge.spawn}. */
 export interface AgentSpawnOptions {
@@ -157,6 +169,34 @@ export interface AgentSpawnOptions {
    * Best-effort: a receipt write failure is logged, never fails the spawn.
    */
   successReceiptPath?: string;
+  /**
+   * Fold a staged rewrite back onto a live file when the run exits 0,
+   * BEFORE `successReceiptPath` is written and the spawn resolves. The
+   * bridge three-way-merges (diff3) the scoop's `draftPath` edits — diffed
+   * against the `basePath` snapshot the caller took at spawn time — onto
+   * whatever `targetPath` holds NOW, so edits that landed on the target
+   * during the run survive instead of being clobbered by a whole-file
+   * rewrite. Conflicting regions resolve to the draft (the spawned agent
+   * is the curator of record for the file). All three paths are absolute
+   * VFS paths; the scoop itself only ever sees `draftPath`. On a merge
+   * the bridge removes `basePath` + `draftPath`; a failed run keeps them
+   * for a retry or a human post-mortem. Runs in the worker realm with the
+   * bridge's full shared-VFS handle, so a page death after spawn cannot
+   * lose the completed rewrite (#1989 companion). Best-effort: a merge
+   * failure is logged and recorded in the outcome receipt, never fails
+   * the spawn.
+   */
+  mergeOnSuccess?: AgentMergeOnSuccess;
+  /**
+   * Absolute VFS path of a JSON outcome record the bridge writes on BOTH
+   * exit paths, after any `mergeOnSuccess` and before the spawn resolves:
+   * `{ status: 'ok'|'failed', exitCode, finishedAt, reason?, merge? }`.
+   * Unlike `successReceiptPath` (success-only existence signal) this is a
+   * durable per-spawn ledger entry — it answers "did this detached run
+   * fail, and why" even when the caller's realm died mid-run. Best-effort:
+   * a write failure is logged, never fails the spawn.
+   */
+  outcomeReceiptPath?: string;
   /**
    * Persist the spawned agent's full session transcript to disk when the run
    * completes — written on BOTH success and failure, BEFORE the scoop's IDB
@@ -416,15 +456,8 @@ function validateSpawnOptions(
     };
   }
 
-  const receiptPath = options.successReceiptPath;
-  if (receiptPath !== undefined && !receiptPath.startsWith('/')) {
-    return {
-      error: {
-        finalText: `agent: successReceiptPath must be absolute: ${receiptPath}`,
-        exitCode: 1,
-      },
-    };
-  }
+  const pathError = validateBookkeepingPaths(options);
+  if (pathError) return pathError;
 
   const requestedName = options.name;
   if (requestedName !== undefined && !isValidAgentName(requestedName)) {
@@ -458,6 +491,160 @@ function validateSpawnOptions(
  * {@link AgentSpawnOptions.successReceiptPath}). Best-effort — a failure
  * is logged and the successful spawn result stands.
  */
+/**
+ * The bridge-side bookkeeping paths (`successReceiptPath`,
+ * `outcomeReceiptPath`, `mergeOnSuccess.*`) must all be absolute VFS
+ * paths — they are written with the bridge's full shared-VFS handle, so a
+ * relative one would silently land somewhere cwd-dependent. Returns the
+ * spawn error to surface, or `null` when everything checks out.
+ */
+function validateBookkeepingPaths(
+  options: AgentSpawnOptions
+): { error: { finalText: string; exitCode: number } } | null {
+  const merge = options.mergeOnSuccess;
+  const entries: Array<[string, string | undefined]> = [
+    ['successReceiptPath', options.successReceiptPath],
+    ['outcomeReceiptPath', options.outcomeReceiptPath],
+    ['mergeOnSuccess.targetPath', merge?.targetPath],
+    ['mergeOnSuccess.basePath', merge?.basePath],
+    ['mergeOnSuccess.draftPath', merge?.draftPath],
+  ];
+  // A merge spec present at all must carry three absolute paths.
+  const requiredWhenMerge = merge === undefined ? undefined : '';
+  for (const [field, value] of entries) {
+    const effective = value ?? (field.startsWith('mergeOnSuccess') ? requiredWhenMerge : undefined);
+    if (effective !== undefined && !effective.startsWith('/')) {
+      return {
+        error: {
+          finalText: `agent: ${field} must be absolute: ${String(value)}`,
+          exitCode: 1,
+        },
+      };
+    }
+  }
+  return null;
+}
+
+/** Merge summary recorded in the outcome receipt. */
+interface MergeOutcome {
+  /** Whether the target file was rewritten. False when the draft never diverged. */
+  applied: boolean;
+  /** Conflicting regions (resolved to the draft), when a real 3-way ran. */
+  conflicts: number;
+  /** Present instead of a result when the merge itself failed. */
+  error?: string;
+}
+
+/**
+ * Fold the scoop's staged rewrite onto the live target (see
+ * {@link AgentSpawnOptions.mergeOnSuccess}). Never throws — an error is
+ * returned for the outcome receipt and logged.
+ */
+async function applyMergeOnSuccess(
+  sharedFs: VirtualFS,
+  spec: AgentMergeOnSuccess
+): Promise<MergeOutcome> {
+  const read = async (path: string): Promise<string> => {
+    try {
+      const raw = await sharedFs.readFile(path, { encoding: 'utf-8' });
+      return typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+    } catch (err) {
+      if (isFsErrorCode(err, 'ENOENT')) return '';
+      throw err;
+    }
+  };
+  const cleanup = async (): Promise<void> => {
+    for (const path of [spec.basePath, spec.draftPath]) {
+      try {
+        await sharedFs.rm(path);
+      } catch {
+        /* already gone — the artifacts are only staging state */
+      }
+    }
+  };
+  const readOrNull = async (path: string): Promise<string | null> => {
+    try {
+      const raw = await sharedFs.readFile(path, { encoding: 'utf-8' });
+      return typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+    } catch (err) {
+      if (isFsErrorCode(err, 'ENOENT')) return null;
+      throw err;
+    }
+  };
+  try {
+    // A MISSING draft is not an empty draft: the caller seeded it, so its
+    // absence means the staging was lost — merging '' would read as "the
+    // scoop deleted everything". Leave the target alone instead.
+    const draft = await readOrNull(spec.draftPath);
+    if (draft === null) {
+      await cleanup();
+      return { applied: false, conflicts: 0 };
+    }
+    const [base, current] = await Promise.all([read(spec.basePath), read(spec.targetPath)]);
+    if (draft === base || draft === current) {
+      // The scoop left the draft untouched (or wrote directly to the
+      // target under a custom grant) — nothing to fold in.
+      await cleanup();
+      return { applied: false, conflicts: 0 };
+    }
+    if (current === base) {
+      // No concurrent edits — the rewrite lands verbatim.
+      await sharedFs.writeFile(spec.targetPath, draft);
+      await cleanup();
+      return { applied: true, conflicts: 0 };
+    }
+    // Concurrent edits on the target: keep both sides where they touch
+    // different regions; where they collide, the spawned agent's rewrite
+    // wins — it is the curator of record and its deletions are deliberate.
+    const merged = threeWayMerge(current, base, draft, { favor: 'theirs' });
+    await sharedFs.writeFile(spec.targetPath, merged.content);
+    await cleanup();
+    return { applied: true, conflicts: merged.conflicts };
+  } catch (err) {
+    const error = errText(err);
+    log.warn('mergeOnSuccess failed; target left as-is, staging kept', {
+      target: spec.targetPath,
+      error,
+    });
+    return { applied: false, conflicts: 0, error };
+  }
+}
+
+/**
+ * Write the caller's durable per-spawn outcome record (see
+ * {@link AgentSpawnOptions.outcomeReceiptPath}). Best-effort — a failure
+ * is logged and the spawn result stands.
+ */
+async function writeOutcomeReceipt(
+  sharedFs: VirtualFS,
+  path: string,
+  result: AgentSpawnResult,
+  merge?: MergeOutcome
+): Promise<void> {
+  try {
+    const dir = path.slice(0, path.lastIndexOf('/'));
+    if (dir) await sharedFs.mkdir(dir, { recursive: true });
+    await sharedFs.writeFile(
+      path,
+      JSON.stringify(
+        {
+          status: result.exitCode === 0 ? 'ok' : 'failed',
+          exitCode: result.exitCode,
+          finishedAt: new Date().toISOString(),
+          // The head of the final text identifies a failure (bound note,
+          // spawn error) without archiving a whole report here.
+          ...(result.exitCode === 0 ? {} : { reason: result.finalText.slice(0, 500) }),
+          ...(merge ? { merge } : {}),
+        },
+        null,
+        2
+      )
+    );
+  } catch (err) {
+    log.warn('outcome receipt write failed', { path, error: errText(err) });
+  }
+}
+
 async function writeSuccessReceipt(sharedFs: VirtualFS, path: string): Promise<void> {
   try {
     const dir = path.slice(0, path.lastIndexOf('/'));
@@ -696,6 +883,33 @@ async function runScoopToOutcome(
   jid: string,
   observerHandle: ReturnType<typeof registerScoopObserver>
 ): Promise<AgentSpawnResult> {
+  const outcome = await runScoopToOutcomeInner(ctx, options, scoop, jid, observerHandle);
+  // Durable bookkeeping in run order, all written BEFORE the spawn resolves
+  // so they land strictly earlier than any caller-side bookkeeping: fold a
+  // staged rewrite onto its live target (success only), then the
+  // success-only receipt, then the both-ways outcome record that carries
+  // the merge summary.
+  let merge: MergeOutcome | undefined;
+  if (outcome.exitCode === 0 && options.mergeOnSuccess) {
+    merge = await applyMergeOnSuccess(ctx.sharedFs, options.mergeOnSuccess);
+  }
+  if (outcome.exitCode === 0 && options.successReceiptPath) {
+    await writeSuccessReceipt(ctx.sharedFs, options.successReceiptPath);
+  }
+  if (options.outcomeReceiptPath) {
+    await writeOutcomeReceipt(ctx.sharedFs, options.outcomeReceiptPath, outcome, merge);
+  }
+  return outcome;
+}
+
+/** The run itself; every failure path returns an exit-1 result. */
+async function runScoopToOutcomeInner(
+  ctx: BridgeContext,
+  options: AgentSpawnOptions,
+  scoop: RegisteredScoop,
+  jid: string,
+  observerHandle: ReturnType<typeof registerScoopObserver>
+): Promise<AgentSpawnResult> {
   try {
     await ctx.orchestrator.registerScoop(scoop);
   } catch (err) {
@@ -714,11 +928,6 @@ async function runScoopToOutcome(
       return { finalText: 'agent: aborted', exitCode: 1 };
     }
     if (result) {
-      // Durable completion signal, written before the spawn resolves so
-      // it lands strictly earlier than any caller-side bookkeeping.
-      if (result.exitCode === 0 && options.successReceiptPath) {
-        await writeSuccessReceipt(ctx.sharedFs, options.successReceiptPath);
-      }
       return result;
     }
     return { finalText: observerHandle.scoopError ?? '', exitCode: 1 };

--- a/packages/webapp/src/scoops/agentic-memory.ts
+++ b/packages/webapp/src/scoops/agentic-memory.ts
@@ -132,9 +132,20 @@ interface MemoryConfig {
   promptTemplate: string;
 }
 
+/**
+ * VFS surface the pass needs: reads for `MEMORY.md` and the live memory
+ * file, writes to seed the per-archive base snapshot + draft the curator
+ * edits instead of the live file (see {@link curationDirPath}).
+ */
+export interface CuratorVfs {
+  readFile: LocalVfsClient['readFile'];
+  writeFile(path: string, content: string): Promise<void>;
+  mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
+}
+
 export interface RunAgenticMemoryPassOptions {
   spawn: AgentBridge['spawn'];
-  vfs: Pick<LocalVfsClient, 'readFile'>;
+  vfs: CuratorVfs;
   sessionArchivePath: string;
   sessionCount: number;
   /**
@@ -274,9 +285,17 @@ export async function runAgenticMemoryPass(
     const workspace = curatorWorkspaceFor(opts.cone);
     const scratchDir = curatorScratchDir(opts.cone?.folder ?? PRIMARY_CONE_FOLDER);
     const config = await loadMemoryConfig(opts.vfs, workspace);
+    const draftPath = curationDraftPath(opts.sessionArchivePath);
+    try {
+      await seedCurationSnapshot(opts.vfs, workspace.memoryPath, opts.sessionArchivePath);
+    } catch (error) {
+      // Nothing spawned yet, so the legacy single-call append cannot race a
+      // curator — falling back is safe.
+      return { ok: false, reason: `snapshot: ${errorText(error)}`, legacyFallbackSafe: true };
+    }
     const prompt = rebaseScratchMentions(
       substitutePlaceholders(config.promptTemplate, {
-        MEMORY_PATH: workspace.memoryPath,
+        MEMORY_PATH: draftPath,
         SESSION_ARCHIVE_PATH: opts.sessionArchivePath,
         SESSION_COUNT: String(opts.sessionCount),
         BUDGET_CHARS: String(computeBudget(opts.sessionCount)),
@@ -531,6 +550,76 @@ export function curatorReceiptPath(sessionArchivePath: string): string {
   return `/sessions/.curated/${base}`;
 }
 
+/**
+ * Per-archive curation state folder. The curator never rewrites the live
+ * memory file directly any more: the pass snapshots the live file here as
+ * `base.md`, hands the curator an identical `draft.md` to rewrite, and the
+ * agent bridge three-way-merges base→draft back onto the live file when the
+ * run exits 0. Keyed by the archive basename — the same attribution
+ * guarantee as {@link curatorReceiptPath} — so parallel curators for
+ * different cones (#1666/#2271) never share state, and a run killed
+ * mid-write corrupts only its own draft, never the live memory.
+ */
+export function curationDirPath(sessionArchivePath: string): string {
+  const base = sessionArchivePath.slice(sessionArchivePath.lastIndexOf('/') + 1);
+  return `/sessions/.curation/${base}`;
+}
+
+/** Snapshot of the live memory file taken when the pass spawned. */
+export function curationBasePath(sessionArchivePath: string): string {
+  return `${curationDirPath(sessionArchivePath)}/base.md`;
+}
+
+/** The file the curator actually edits; seeded from the live memory file. */
+export function curationDraftPath(sessionArchivePath: string): string {
+  return `${curationDirPath(sessionArchivePath)}/draft.md`;
+}
+
+/**
+ * Durable per-archive run outcome the agent bridge writes (worker realm)
+ * on BOTH exit paths — success and failure. Unlike the success-only
+ * receipt this answers "which sessions caused failed curation" even when
+ * the page died before the caller could record the failure.
+ */
+export function curationStatusPath(sessionArchivePath: string): string {
+  return `${curationDirPath(sessionArchivePath)}/status.json`;
+}
+
+/**
+ * Snapshot the live memory file into the per-archive curation folder: the
+ * `base.md` the completion merge diffs against, and the `draft.md` the
+ * curator rewrites in place of the live file. A missing live file seeds
+ * both as empty — a first-ever pass merges onto whatever exists then.
+ */
+async function seedCurationSnapshot(
+  vfs: CuratorVfs,
+  memoryPath: string,
+  sessionArchivePath: string
+): Promise<void> {
+  let live = '';
+  try {
+    const raw = await vfs.readFile(memoryPath, { encoding: 'utf-8' });
+    live = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+  } catch {
+    // No live memory yet — snapshot the empty state.
+  }
+  await vfs.mkdir(curationDirPath(sessionArchivePath), { recursive: true });
+  await vfs.writeFile(curationBasePath(sessionArchivePath), live);
+  await vfs.writeFile(curationDraftPath(sessionArchivePath), live);
+}
+
+/**
+ * Point the configured write policy at the draft instead of the live
+ * memory file. An entry naming the memory file itself is substituted; any
+ * other entry (a knowledge base, a whole-workspace grant) is kept, and the
+ * draft is appended when no entry named the memory file — the prompt's
+ * `{{MEMORY_PATH}}` writes must always land somewhere granted.
+ */
+function redirectWritesToDraft(paths: string[], memoryPath: string, draftPath: string): string[] {
+  const redirected = paths.map((path) => (path === memoryPath ? draftPath : path));
+  return redirected.includes(draftPath) ? redirected : [...redirected, draftPath];
+}
+
 function buildSpawnOptions(
   config: MemoryConfig,
   prompt: string,
@@ -539,11 +628,16 @@ function buildSpawnOptions(
   cone: CuratorConeRef | undefined
 ): AgentSpawnOptions {
   const inheritedModel = config.model === 'parent' || config.model === 'cone';
+  const basePath = curationBasePath(sessionArchivePath);
+  const draftPath = curationDraftPath(sessionArchivePath);
   return {
     // Directory the curator starts in; `writablePaths` may be a bare file.
     cwd: workspace.root,
-    writablePaths: config.writablePaths,
-    visiblePaths: config.visiblePaths,
+    writablePaths: redirectWritesToDraft(config.writablePaths, workspace.memoryPath, draftPath),
+    // A Write grant does not imply Read; the curator must re-read the draft
+    // it measures with `wc -c`, so the curation folder is made visible even
+    // under a custom config that dropped `/sessions/`.
+    visiblePaths: [...config.visiblePaths, `${curationDirPath(sessionArchivePath)}/`],
     allowedCommands: config.allowedCommands,
     prompt,
     thinkingLevel: config.thinkingLevel,
@@ -559,6 +653,19 @@ function buildSpawnOptions(
     // and the cone never learns the pass happened at all.
     notifyOnComplete: true,
     successReceiptPath: curatorReceiptPath(sessionArchivePath),
+    // On exit 0 the bridge folds the curator's base→draft rewrite onto the
+    // live memory file with a three-way merge (worker realm, before the
+    // receipt) — concurrent live edits during the up-to-20-minute run merge
+    // instead of being clobbered by a whole-file rewrite, and a run killed
+    // mid-write never leaves a half-written live file.
+    mergeOnSuccess: {
+      targetPath: workspace.memoryPath,
+      basePath,
+      draftPath,
+    },
+    // Durable success/failure record for THIS archive, written on both exit
+    // paths — the ledger of which sessions completed vs failed curation.
+    outcomeReceiptPath: curationStatusPath(sessionArchivePath),
     // What `timeoutSeconds` always claimed to mean: the RUN stops at the
     // bound (#1972), instead of only the caller's wait resolving while
     // the agent kept taking turns.

--- a/packages/webapp/src/transcript/frozen-archive-format.ts
+++ b/packages/webapp/src/transcript/frozen-archive-format.ts
@@ -75,6 +75,21 @@ export interface FrozenSessionIndexEntry {
    */
   memoryPending?: true;
   /**
+   * ISO timestamp of the curator pass that completed for this archive.
+   * Stamped when `memoryPending` clears — the durable positive record that
+   * curation happened, as opposed to a bare marker-less entry (which could
+   * equally mean the pass was never owed). Cleared together with
+   * `memoryFailed` on a later successful pass.
+   */
+  memoryCuratedAt?: string;
+  /**
+   * Head of the reason the LAST curator attempt for this archive failed
+   * (timeout, spawn error, retry cap). Purely a ledger for humans and UI —
+   * recovery still keys off `memoryPending` / `pendingAttemptCount`.
+   * Removed when a later pass succeeds.
+   */
+  memoryFailed?: string;
+  /**
    * The user chose to freeze this chat WITHOUT any memory extraction — now
    * or later (a dropped cone, #2272). The title/icon catch-up still runs;
    * the memory half of the legacy enrichment is skipped for good.

--- a/packages/webapp/src/ui/session-freezer.ts
+++ b/packages/webapp/src/ui/session-freezer.ts
@@ -32,7 +32,12 @@ import { FsError } from '../fs/types.js';
 import type { LocalVfsClient } from '../kernel/local-vfs-client.js';
 import type { WritableVfsClient } from '../kernel/writable-vfs-client.js';
 import type { AgentBridge } from '../scoops/agent-bridge.js';
-import { curatorReceiptPath, runAgenticMemoryPass } from '../scoops/agentic-memory.js';
+import {
+  curationBasePath,
+  curationDraftPath,
+  curatorReceiptPath,
+  runAgenticMemoryPass,
+} from '../scoops/agentic-memory.js';
 import type { SessionStore } from '../scoops/chat-session-store.js';
 import { applyConeMemoryBudget, readSessionCount } from '../scoops/cone-memory-budget.js';
 import type {
@@ -263,6 +268,9 @@ export async function curateFrozenSessionMemories(
     log.info('Agentic memory pass completed', { filename: frozen.filename });
     return updated;
   }
+  // Either failure branch leaves a durable note on the index entry — the
+  // other half of the ledger `memoryCuratedAt` provides on success.
+  await stampMemoryFailure(opts.vfs, frozen.filename, result.reason);
   if (!result.legacyFallbackSafe) {
     log.warn('Agentic memory pass unfinished — entry stays pending for boot catch-up', {
       filename: frozen.filename,
@@ -928,6 +936,22 @@ export async function processPendingSessions(
   const result = { attempted: 0, completed: 0 };
   if (!opts.model || !opts.apiKey) return result;
   try {
+    // Entries at the retry cap are silently skipped by the filter below —
+    // record that terminal state once so "gave up" is visible in the
+    // ledger instead of looking identical to "still retrying".
+    for (const capped of await readSessionsIndex(opts.vfs)) {
+      if (
+        capped.memoryPending === true &&
+        capped.memoryFailed === undefined &&
+        pendingAttemptCount(capped) >= PENDING_SESSION_ATTEMPT_LIMIT
+      ) {
+        await stampMemoryFailure(
+          opts.vfs,
+          capped.filename,
+          `catch-up retries exhausted (${PENDING_SESSION_ATTEMPT_LIMIT})`
+        );
+      }
+    }
     const entries = await listPendingEnrichments(opts.vfs);
     for (const listedEntry of entries) {
       try {
@@ -1049,8 +1073,35 @@ export async function enrichPendingSession(
     icon,
     opts.skipMemory === true
   );
-  if (committed && curatorAlreadyRan) await removeCuratorReceipt(vfs, entry.filename);
+  if (committed && curatorAlreadyRan) {
+    await removeCuratorReceipt(vfs, entry.filename);
+    // The curator DID finish (receipt proved it) — record that under the
+    // committed (possibly renamed) filename, and drop the staging snapshot
+    // its interrupted caller never cleaned up.
+    await stampMemoryCurated(vfs, committed.filename);
+    await removeCurationStaging(vfs, entry.filename);
+  }
   return committed;
+}
+
+/**
+ * Best-effort removal of the per-archive base/draft staging pair once the
+ * pass is definitively resolved. The bridge removes them after a merged
+ * run; this covers passes whose caller realm died in between. The
+ * `status.json` beside them is deliberately kept — it is the durable
+ * outcome ledger, not staging state.
+ */
+async function removeCurationStaging(vfs: WritableVfsClient, filename: string): Promise<void> {
+  for (const path of [
+    curationBasePath(`/sessions/${filename}`),
+    curationDraftPath(`/sessions/${filename}`),
+  ]) {
+    try {
+      await vfs.rm(path);
+    } catch {
+      /* already gone */
+    }
+  }
 }
 
 /**
@@ -1391,7 +1442,13 @@ function rewriteArchiveTitle(content: string, newTitle: string): string {
  */
 let indexWriteChain: Promise<void> = Promise.resolve();
 
-/** Clear every catch-up marker and its attempt counter after successful work. */
+/**
+ * Clear every catch-up marker and its attempt counter after successful
+ * work, and stamp the durable positive record that curation completed
+ * (`memoryCuratedAt`; any earlier failure note is superseded). Without the
+ * stamp, "curated" and "never owed a pass" are indistinguishable in the
+ * index — the gap that made failed-vs-finished curation unauditable.
+ */
 async function clearPendingMarkers(
   vfs: WritableVfsClient,
   filename: string
@@ -1405,8 +1462,13 @@ async function clearPendingMarkers(
       memoryPending: _memoryPending,
       pendingEnrichment: _pendingEnrichment,
       pendingAttemptCount: _pendingAttemptCount,
-      ...updatedEntry
+      memoryFailed: _memoryFailed,
+      ...rest
     } = existing[index];
+    const updatedEntry: FrozenSessionIndexEntry = {
+      ...rest,
+      memoryCuratedAt: new Date().toISOString(),
+    };
     const updated = existing.slice();
     updated[index] = updatedEntry;
     await vfs.writeFile(SESSIONS_INDEX_PATH, JSON.stringify(updated, null, 2));
@@ -1456,6 +1518,73 @@ async function recordPendingAttempt(
   );
   await next;
   return attempted;
+}
+
+/**
+ * Record why the last curator attempt for `filename` failed — a ledger
+ * note for humans and UI, serialized with every other index mutation.
+ * Recovery semantics are untouched: `memoryPending` (when still set)
+ * keeps driving the boot catch-up. Best-effort: never throws.
+ */
+async function stampMemoryFailure(
+  vfs: WritableVfsClient,
+  filename: string,
+  reason: string
+): Promise<void> {
+  const run = async (): Promise<void> => {
+    const existing = await readSessionsIndex(vfs);
+    const index = existing.findIndex((entry) => entry.filename === filename);
+    if (index === -1) return;
+    const updated = existing.slice();
+    updated[index] = { ...existing[index], memoryFailed: reason.slice(0, 300) };
+    await vfs.writeFile(SESSIONS_INDEX_PATH, JSON.stringify(updated, null, 2));
+    await vfs.flush();
+  };
+  const next = indexWriteChain.then(run, run);
+  indexWriteChain = next.then(
+    () => undefined,
+    () => undefined
+  );
+  try {
+    await next;
+  } catch (err) {
+    log.warn('Failed to record curator failure in sessions index', {
+      filename,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Stamp `memoryCuratedAt` (superseding any failure note) on an entry whose
+ * markers were already handled elsewhere — the #1989 receipt-recovery path,
+ * where `commitEnrichedArchive` drops the pending marker itself. Serialized
+ * with every other index mutation; best-effort.
+ */
+async function stampMemoryCurated(vfs: WritableVfsClient, filename: string): Promise<void> {
+  const run = async (): Promise<void> => {
+    const existing = await readSessionsIndex(vfs);
+    const index = existing.findIndex((entry) => entry.filename === filename);
+    if (index === -1) return;
+    const { memoryFailed: _memoryFailed, ...rest } = existing[index];
+    const updated = existing.slice();
+    updated[index] = { ...rest, memoryCuratedAt: new Date().toISOString() };
+    await vfs.writeFile(SESSIONS_INDEX_PATH, JSON.stringify(updated, null, 2));
+    await vfs.flush();
+  };
+  const next = indexWriteChain.then(run, run);
+  indexWriteChain = next.then(
+    () => undefined,
+    () => undefined
+  );
+  try {
+    await next;
+  } catch (err) {
+    log.warn('Failed to record curator completion in sessions index', {
+      filename,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 /**

--- a/packages/webapp/tests/kernel/transport-message-channel.test.ts
+++ b/packages/webapp/tests/kernel/transport-message-channel.test.ts
@@ -189,7 +189,11 @@ describe('createBridgeMessageChannelTransport / createPanelMessageChannelTranspo
     );
     const result = await runAgenticMemoryPass({
       spawn: (options) => client.spawnAgent(options),
-      vfs: { readFile: async () => Promise.reject(new Error('MEMORY.md absent')) },
+      vfs: {
+        readFile: async () => Promise.reject(new Error('MEMORY.md absent')),
+        writeFile: async () => {},
+        mkdir: async () => {},
+      },
       sessionArchivePath: '/sessions/frozen.md',
       sessionCount: 1,
     });
@@ -199,8 +203,10 @@ describe('createBridgeMessageChannelTransport / createPanelMessageChannelTranspo
     expect(spawn).toHaveBeenCalledWith(
       expect.objectContaining({
         cwd: '/workspace',
-        writablePaths: ['/workspace/CLAUDE.md'],
-        visiblePaths: ['/sessions/', '/shared/', '/workspace/'],
+        // The curator writes a staged per-archive draft; the bridge merges
+        // it onto /workspace/CLAUDE.md on exit 0 (mergeOnSuccess).
+        writablePaths: ['/sessions/.curation/frozen.md/draft.md'],
+        visiblePaths: ['/sessions/', '/shared/', '/workspace/', '/sessions/.curation/frozen.md/'],
         notifyOnComplete: true,
       })
     );

--- a/packages/webapp/tests/scoops/agent-bridge.test.ts
+++ b/packages/webapp/tests/scoops/agent-bridge.test.ts
@@ -2175,7 +2175,7 @@ describe('createAgentBridge — mergeOnSuccess + outcome receipts', () => {
     expect(status.merge).toBeUndefined();
   });
 
-  it('a merge failure is recorded but never fails the successful spawn', async () => {
+  it('a merge failure downgrades the spawn to failure and skips the success receipt', async () => {
     const { orchestrator, scripts } = makeMockOrchestrator();
     const shared = makeMockSharedFs({
       files: {
@@ -2196,15 +2196,47 @@ describe('createAgentBridge — mergeOnSuccess + outcome receipts', () => {
       ...BASE_OPTS,
       persistSession: false,
       mergeOnSuccess: MERGE,
+      successReceiptPath: '/sessions/.curated/a.md',
       outcomeReceiptPath: STATUS,
     });
 
-    expect(result.exitCode).toBe(0);
+    // The run itself succeeded, but its rewrite never landed — a success
+    // signal here would clear the caller's pending marker (and satisfy the
+    // #1989 receipt recovery) with the work undone.
+    expect(result.exitCode).toBe(1);
+    expect(result.finalText).toContain('mergeOnSuccess failed');
+    expect(result.finalText).toContain('quota exceeded');
+    expect(shared.files.has('/sessions/.curated/a.md')).toBe(false);
     const status = JSON.parse(shared.files.get(STATUS) ?? '{}');
-    expect(status.status).toBe('ok');
+    expect(status.status).toBe('failed');
     expect(status.merge.error).toContain('quota exceeded');
     // Staging survives a failed merge for the post-mortem.
     expect(shared.files.has(MERGE.draftPath)).toBe(true);
+  });
+
+  it('a missing base snapshot aborts the merge (never treated as an empty original)', async () => {
+    // No base.md: staging was lost. Merging against '' would turn the whole
+    // live file into a conflict the draft wins, silently discarding the
+    // concurrent memories the merge exists to protect.
+    const { bridge, shared } = mergeBridge({
+      [MERGE.draftPath]: 'curated rewrite\n',
+      [MERGE.targetPath]: 'live memory with concurrent edits\n',
+    });
+
+    const result = await bridge.spawn({
+      ...BASE_OPTS,
+      persistSession: false,
+      mergeOnSuccess: MERGE,
+      outcomeReceiptPath: STATUS,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.finalText).toContain('base snapshot missing');
+    expect(shared.files.get(MERGE.targetPath)).toBe('live memory with concurrent edits\n');
+    // The draft is kept for the post-mortem.
+    expect(shared.files.has(MERGE.draftPath)).toBe(true);
+    const status = JSON.parse(shared.files.get(STATUS) ?? '{}');
+    expect(status).toMatchObject({ status: 'failed', exitCode: 1 });
   });
 
   it('rejects a relative mergeOnSuccess path without spawning', async () => {

--- a/packages/webapp/tests/scoops/agent-bridge.test.ts
+++ b/packages/webapp/tests/scoops/agent-bridge.test.ts
@@ -223,21 +223,36 @@ function makeMockSharedFs(options?: {
   rm?: (path: string) => Promise<void>;
   /** Throw from `writeFile` (receipt-failure tests). */
   writeFile?: (path: string) => Promise<void>;
-}): { fs: VirtualFS; rmCalls: string[]; writes: Array<{ path: string; content: string }> } {
+  /** Initial file contents served by `readFile` (mergeOnSuccess tests). */
+  files?: Record<string, string>;
+}): {
+  fs: VirtualFS;
+  rmCalls: string[];
+  writes: Array<{ path: string; content: string }>;
+  files: Map<string, string>;
+} {
   const rmCalls: string[] = [];
   const writes: Array<{ path: string; content: string }> = [];
+  const files = new Map<string, string>(Object.entries(options?.files ?? {}));
   const mock: Partial<VirtualFS> = {
     rm: vi.fn(async (path: string) => {
       rmCalls.push(path);
       if (options?.rm) await options.rm(path);
+      files.delete(path);
     }) as unknown as VirtualFS['rm'],
     mkdir: vi.fn(async () => {}) as unknown as VirtualFS['mkdir'],
     writeFile: vi.fn(async (path: string, content: string) => {
       if (options?.writeFile) await options.writeFile(path);
       writes.push({ path, content });
+      files.set(path, content);
     }) as unknown as VirtualFS['writeFile'],
+    readFile: vi.fn(async (path: string) => {
+      const content = files.get(path);
+      if (content === undefined) throw new FsError('ENOENT', 'no such file', path);
+      return content;
+    }) as unknown as VirtualFS['readFile'],
   };
-  return { fs: mock as unknown as VirtualFS, rmCalls, writes };
+  return { fs: mock as unknown as VirtualFS, rmCalls, writes, files };
 }
 
 const BASE_OPTS: AgentSpawnOptions = {
@@ -2017,5 +2032,212 @@ describe('createAgentBridge — session archive (persistSession)', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.finalText).toBe('done');
+  });
+});
+
+describe('createAgentBridge — mergeOnSuccess + outcome receipts', () => {
+  const MERGE = {
+    targetPath: '/workspace/CLAUDE.md',
+    basePath: '/sessions/.curation/a.md/base.md',
+    draftPath: '/sessions/.curation/a.md/draft.md',
+  };
+  const STATUS = '/sessions/.curation/a.md/status.json';
+
+  function mergeBridge(files: Record<string, string>) {
+    const { orchestrator, scripts, registerCalls } = makeMockOrchestrator();
+    const shared = makeMockSharedFs({ files });
+    const bridge = createAgentBridge(orchestrator, shared.fs, null, {
+      generateName: () => 'calm-torte',
+    });
+    scripts.set('agent_calm_torte', (obs) => obs.onSendMessage?.('curated'));
+    return { bridge, shared, scripts, registerCalls };
+  }
+
+  it('fast-forwards the draft onto an unchanged target and drops the staging pair', async () => {
+    const { bridge, shared } = mergeBridge({
+      [MERGE.basePath]: 'old memory\n',
+      [MERGE.draftPath]: 'curated memory\n',
+      [MERGE.targetPath]: 'old memory\n',
+    });
+
+    const result = await bridge.spawn({
+      ...BASE_OPTS,
+      persistSession: false,
+      mergeOnSuccess: MERGE,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(shared.files.get(MERGE.targetPath)).toBe('curated memory\n');
+    // Staging is consumed; nothing left to leak into a later pass.
+    expect(shared.files.has(MERGE.basePath)).toBe(false);
+    expect(shared.files.has(MERGE.draftPath)).toBe(false);
+  });
+
+  it('keeps concurrent target edits alongside the draft rewrite (real 3-way)', async () => {
+    const base =
+      '# Memory\n\n## Alpha (2026-01-01)\nstale fact\n\n## Beta (2026-02-02)\nkept fact\n';
+    // The curator rewrote Alpha; someone appended Gamma to the LIVE file
+    // while the curator ran. Both changes must land.
+    const draft =
+      '# Memory\n\n## Alpha (2026-08-24)\nfresh fact\n\n## Beta (2026-02-02)\nkept fact\n';
+    const current =
+      '# Memory\n\n## Alpha (2026-01-01)\nstale fact\n\n## Beta (2026-02-02)\nkept fact\n\n## Gamma (2026-08-24)\nconcurrent fact\n';
+    const { bridge, shared } = mergeBridge({
+      [MERGE.basePath]: base,
+      [MERGE.draftPath]: draft,
+      [MERGE.targetPath]: current,
+    });
+
+    const result = await bridge.spawn({
+      ...BASE_OPTS,
+      persistSession: false,
+      mergeOnSuccess: MERGE,
+      outcomeReceiptPath: STATUS,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const merged = shared.files.get(MERGE.targetPath) ?? '';
+    expect(merged).toContain('## Alpha (2026-08-24)\nfresh fact');
+    expect(merged).toContain('## Gamma (2026-08-24)\nconcurrent fact');
+    expect(merged).not.toContain('stale fact');
+    const status = JSON.parse(shared.files.get(STATUS) ?? '{}');
+    expect(status).toMatchObject({
+      status: 'ok',
+      exitCode: 0,
+      merge: { applied: true, conflicts: 0 },
+    });
+  });
+
+  it('resolves conflicting regions to the draft (curator of record)', async () => {
+    const { bridge, shared } = mergeBridge({
+      [MERGE.basePath]: 'line\n',
+      [MERGE.draftPath]: 'curator version\n',
+      [MERGE.targetPath]: 'concurrent version\n',
+    });
+
+    const result = await bridge.spawn({
+      ...BASE_OPTS,
+      persistSession: false,
+      mergeOnSuccess: MERGE,
+      outcomeReceiptPath: STATUS,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(shared.files.get(MERGE.targetPath)).toBe('curator version\n');
+    const status = JSON.parse(shared.files.get(STATUS) ?? '{}');
+    expect(status.merge).toMatchObject({ applied: true, conflicts: 1 });
+  });
+
+  it('leaves the target untouched when the draft never diverged from base', async () => {
+    const { bridge, shared } = mergeBridge({
+      [MERGE.basePath]: 'unchanged\n',
+      [MERGE.draftPath]: 'unchanged\n',
+      [MERGE.targetPath]: 'live got edits meanwhile\n',
+    });
+
+    const result = await bridge.spawn({
+      ...BASE_OPTS,
+      persistSession: false,
+      mergeOnSuccess: MERGE,
+      outcomeReceiptPath: STATUS,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(shared.files.get(MERGE.targetPath)).toBe('live got edits meanwhile\n');
+    const status = JSON.parse(shared.files.get(STATUS) ?? '{}');
+    expect(status.merge).toMatchObject({ applied: false, conflicts: 0 });
+  });
+
+  it('records a failed run in the outcome receipt and keeps the staging pair', async () => {
+    const { orchestrator, scripts } = makeMockOrchestrator();
+    const shared = makeMockSharedFs({
+      files: { [MERGE.basePath]: 'old\n', [MERGE.draftPath]: 'old\n' },
+    });
+    const bridge = createAgentBridge(orchestrator, shared.fs, null, {
+      generateName: () => 'moody-fudge',
+    });
+    scripts.set('agent_moody_fudge', (obs) => obs.onError?.('provider exploded'));
+
+    const result = await bridge.spawn({
+      ...BASE_OPTS,
+      persistSession: false,
+      mergeOnSuccess: MERGE,
+      outcomeReceiptPath: STATUS,
+    });
+
+    expect(result.exitCode).toBe(1);
+    // No merge on failure — the draft may be half-written.
+    expect(shared.files.has(MERGE.targetPath)).toBe(false);
+    expect(shared.files.has(MERGE.draftPath)).toBe(true);
+    const status = JSON.parse(shared.files.get(STATUS) ?? '{}');
+    expect(status).toMatchObject({ status: 'failed', exitCode: 1 });
+    expect(status.reason).toContain('provider exploded');
+    expect(status.merge).toBeUndefined();
+  });
+
+  it('a merge failure is recorded but never fails the successful spawn', async () => {
+    const { orchestrator, scripts } = makeMockOrchestrator();
+    const shared = makeMockSharedFs({
+      files: {
+        [MERGE.basePath]: 'old\n',
+        [MERGE.draftPath]: 'new\n',
+        [MERGE.targetPath]: 'old\n',
+      },
+      writeFile: async (path) => {
+        if (path === MERGE.targetPath) throw new Error('quota exceeded');
+      },
+    });
+    const bridge = createAgentBridge(orchestrator, shared.fs, null, {
+      generateName: () => 'brave-sorbet',
+    });
+    scripts.set('agent_brave_sorbet', (obs) => obs.onSendMessage?.('curated'));
+
+    const result = await bridge.spawn({
+      ...BASE_OPTS,
+      persistSession: false,
+      mergeOnSuccess: MERGE,
+      outcomeReceiptPath: STATUS,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const status = JSON.parse(shared.files.get(STATUS) ?? '{}');
+    expect(status.status).toBe('ok');
+    expect(status.merge.error).toContain('quota exceeded');
+    // Staging survives a failed merge for the post-mortem.
+    expect(shared.files.has(MERGE.draftPath)).toBe(true);
+  });
+
+  it('rejects a relative mergeOnSuccess path without spawning', async () => {
+    const { orchestrator, registerCalls } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'terse-parfait',
+    });
+
+    const result = await bridge.spawn({
+      ...BASE_OPTS,
+      mergeOnSuccess: { ...MERGE, draftPath: 'relative/draft.md' },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.finalText).toContain('mergeOnSuccess.draftPath must be absolute');
+    expect(registerCalls).toHaveLength(0);
+  });
+
+  it('rejects a relative outcomeReceiptPath without spawning', async () => {
+    const { orchestrator, registerCalls } = makeMockOrchestrator();
+    const { fs } = makeMockSharedFs();
+    const bridge = createAgentBridge(orchestrator, fs, null, {
+      generateName: () => 'plain-taffy',
+    });
+
+    const result = await bridge.spawn({
+      ...BASE_OPTS,
+      outcomeReceiptPath: 'sessions/status.json',
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.finalText).toContain('outcomeReceiptPath must be absolute');
+    expect(registerCalls).toHaveLength(0);
   });
 });

--- a/packages/webapp/tests/scoops/agentic-memory-default.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory-default.test.ts
@@ -14,6 +14,15 @@ afterEach(async () => {
   vfs = undefined;
 });
 
+const stubVfs = (memoryMd: string) => ({
+  readFile: async (path: string) => {
+    if (path === '/shared/MEMORY.md') return memoryMd;
+    throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' });
+  },
+  writeFile: async () => {},
+  mkdir: async () => {},
+});
+
 describe('bundled MEMORY.md', () => {
   it('parses as the runner fallback', async () => {
     const spawn = vi.fn(async () => ({ finalText: 'done', exitCode: 0 }));
@@ -21,7 +30,7 @@ describe('bundled MEMORY.md', () => {
     await expect(
       runAgenticMemoryPass({
         spawn,
-        vfs: { readFile: async () => DEFAULT_MEMORY_MD },
+        vfs: stubVfs(DEFAULT_MEMORY_MD),
         sessionArchivePath: '/sessions/frozen.md',
         sessionCount: 1,
       })
@@ -45,12 +54,12 @@ describe('bundled MEMORY.md', () => {
     );
     await runAgenticMemoryPass({
       spawn,
-      vfs: { readFile: async () => DEFAULT_MEMORY_MD },
+      vfs: stubVfs(DEFAULT_MEMORY_MD),
       sessionArchivePath: '/sessions/frozen.md',
       sessionCount: 1,
     });
     const { writablePaths = [], name, prompt } = spawn.mock.calls[0][0];
-    expect(writablePaths).toEqual(['/workspace/CLAUDE.md']);
+    expect(writablePaths).toEqual(['/sessions/.curation/frozen.md/draft.md']);
     const scratchFolder = `/scoops/agent-${name}`;
     // The document names the scratch folder as `{{SCRATCH_DIR}}` — the folder
     // follows the per-cone agent name (#2271) — so the assertion is against

--- a/packages/webapp/tests/scoops/agentic-memory.test.ts
+++ b/packages/webapp/tests/scoops/agentic-memory.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetLoggerDedupForTests } from '../../src/base/logger.js';
-import type { LocalVfsClient } from '../../src/kernel/local-vfs-client.js';
 import {
   AGENT_NAME_IN_USE_PREFIX,
   type AgentSpawnOptions,
   type AgentSpawnResult,
 } from '../../src/scoops/agent-bridge.js';
 import {
+  type CuratorVfs,
+  curationBasePath,
+  curationDraftPath,
+  curationStatusPath,
   curatorAgentName,
   curatorScratchDir,
   DEFAULT_MEMORY_MD,
@@ -15,6 +18,10 @@ import {
 import { CONE_MEMORY_PATH, computeBudget } from '../../src/scoops/cone-memory-budget.js';
 
 const ARCHIVE_PATH = '/sessions/2026-08-05-memory.md';
+// The staged copy the curator edits instead of the live memory file; the
+// bridge merges it back on exit 0 (mergeOnSuccess).
+const DRAFT_PATH = curationDraftPath(ARCHIVE_PATH);
+const CURATION_DIR = '/sessions/.curation/2026-08-05-memory.md';
 const BASE_ALLOWED_COMMANDS = [
   'awk',
   'cat',
@@ -49,12 +56,34 @@ const BASE_ALLOWED_COMMANDS = [
   'xxd',
 ];
 
-function fakeVfs(content: string | Error): Pick<LocalVfsClient, 'readFile'> {
+interface FakeVfs extends CuratorVfs {
+  /** Path → content of every `writeFile` the pass performed. */
+  writes: Map<string, string>;
+}
+
+/**
+ * Path-aware fake: `/shared/MEMORY.md` serves `content` (or throws it);
+ * any other read serves what the pass wrote there, or the optional
+ * `liveMemory`, or ENOENT — the snapshot-seeding path tolerates all three.
+ */
+function fakeVfs(content: string | Error, liveMemory?: string): FakeVfs {
+  const writes = new Map<string, string>();
   return {
-    readFile: vi.fn(async () => {
-      if (content instanceof Error) throw content;
-      return content;
+    writes,
+    readFile: vi.fn(async (path: string) => {
+      if (path === '/shared/MEMORY.md') {
+        if (content instanceof Error) throw content;
+        return content;
+      }
+      const written = writes.get(path);
+      if (written !== undefined) return written;
+      if (liveMemory !== undefined) return liveMemory;
+      throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' });
     }),
+    writeFile: vi.fn(async (path: string, body: string) => {
+      writes.set(path, body);
+    }),
+    mkdir: vi.fn(async () => {}),
   };
 }
 
@@ -98,19 +127,29 @@ Memory={{MEMORY_PATH}} archive={{SESSION_ARCHIVE_PATH}} count={{SESSION_COUNT}} 
     const options = spawn.mock.calls[0][0];
     expect(options).toMatchObject({
       cwd: '/workspace',
-      writablePaths: ['/workspace/', '/knowledge/'],
-      visiblePaths: ['/sessions/', '/shared/', '/knowledge/'],
+      // Directory grants are kept as-is; the staged draft is appended so
+      // the prompt's {{MEMORY_PATH}} writes always land somewhere granted.
+      writablePaths: ['/workspace/', '/knowledge/', DRAFT_PATH],
+      visiblePaths: ['/sessions/', '/shared/', '/knowledge/', `${CURATION_DIR}/`],
       allowedCommands: [...BASE_ALLOWED_COMMANDS, 'custom-text'],
       modelId: 'claude-sonnet-4-6',
       // Per-archive completion receipt the bridge writes on exit 0 —
       // the boot catch-up's crash-safe curator-finished signal (#1989).
       successReceiptPath: '/sessions/.curated/2026-08-05-memory.md',
+      // Staged rewrite folded onto the live file by the bridge on exit 0,
+      // plus the durable both-ways outcome record.
+      mergeOnSuccess: {
+        targetPath: CONE_MEMORY_PATH,
+        basePath: curationBasePath(ARCHIVE_PATH),
+        draftPath: DRAFT_PATH,
+      },
+      outcomeReceiptPath: curationStatusPath(ARCHIVE_PATH),
       // timeoutSeconds becomes a REAL in-run wall-clock bound (#1972);
       // this fixture sets timeoutSeconds: 45.
       maxWallClockMs: 45_000,
     });
     expect(options.prompt).toBe(
-      `Memory=${CONE_MEMORY_PATH} archive=${ARCHIVE_PATH} count=30 budget=${computeBudget(30)} today=2026-08-06 unknown={{KEEP_ME}}`
+      `Memory=${DRAFT_PATH} archive=${ARCHIVE_PATH} count=30 budget=${computeBudget(30)} today=2026-08-06 unknown={{KEEP_ME}}`
     );
   });
 
@@ -182,7 +221,7 @@ Curate {{MEMORY_PATH}} on {{TODAY}}.`;
 
     expect(result).toEqual({ ok: true, report: 'done' });
     expect(spawn.mock.calls[0][0].prompt).toContain('## Existing instructions');
-    expect(spawn.mock.calls[0][0].prompt).toContain('Curate /workspace/CLAUDE.md on 2026-08-06.');
+    expect(spawn.mock.calls[0][0].prompt).toContain(`Curate ${DRAFT_PATH} on 2026-08-06.`);
   });
 
   it('strips block-array comments and preserves quoted inline commas', async () => {
@@ -206,8 +245,8 @@ Curate {{MEMORY_PATH}}.`;
 
     expect(result).toEqual({ ok: true, report: 'done' });
     expect(spawn.mock.calls[0][0]).toMatchObject({
-      writablePaths: ['/workspace/', '/knowledge/lars,rebecca/'],
-      visiblePaths: ['/sessions/', '/shared/#reference'],
+      writablePaths: ['/workspace/', '/knowledge/lars,rebecca/', DRAFT_PATH],
+      visiblePaths: ['/sessions/', '/shared/#reference', `${CURATION_DIR}/`],
       allowedCommands: BASE_ALLOWED_COMMANDS,
     });
   });
@@ -326,7 +365,8 @@ Curate {{MEMORY_PATH}}.`;
 
     expect(result).toEqual({ ok: true, report: 'done' });
     expect(warn).toHaveBeenCalled();
-    expect(spawn.mock.calls[0][0].writablePaths).toEqual(['/workspace/CLAUDE.md']);
+    expect(spawn.mock.calls[0][0].writablePaths).toEqual([DRAFT_PATH]);
+    expect(spawn.mock.calls[0][0].mergeOnSuccess?.targetPath).toBe(CONE_MEMORY_PATH);
   });
 
   it('uses the built-in default and warns when MEMORY.md is missing', async () => {
@@ -347,9 +387,14 @@ Curate {{MEMORY_PATH}}.`;
     // `/workspace/skills/`. `/workspace/` stays readable so it can orient.
     expect(spawn.mock.calls[0][0]).toMatchObject({
       cwd: '/workspace',
-      writablePaths: ['/workspace/CLAUDE.md'],
-      visiblePaths: ['/sessions/', '/shared/', '/workspace/'],
+      writablePaths: [DRAFT_PATH],
+      visiblePaths: ['/sessions/', '/shared/', '/workspace/', `${CURATION_DIR}/`],
       notifyOnComplete: true,
+      mergeOnSuccess: {
+        targetPath: CONE_MEMORY_PATH,
+        basePath: curationBasePath(ARCHIVE_PATH),
+        draftPath: DRAFT_PATH,
+      },
     });
     expect(spawn.mock.calls[0][0].prompt).toContain(
       'Organize retained information into concise per-topic'
@@ -372,7 +417,65 @@ Curate {{MEMORY_PATH}}.`;
 
     expect(result.ok).toBe(true);
     expect(warn).toHaveBeenCalled();
-    expect(spawn.mock.calls[0][0].prompt).toContain(CONE_MEMORY_PATH);
+    expect(spawn.mock.calls[0][0].prompt).toContain(DRAFT_PATH);
+  });
+
+  it('seeds the base snapshot and the draft from the live memory file', async () => {
+    const spawn = successSpawn();
+    const vfs = fakeVfs(DEFAULT_MEMORY_MD, '# Memory\n\n## Facts (2026-08-01)\n');
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs,
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+
+    expect(result).toEqual({ ok: true, report: 'done' });
+    // Both files carry the SAME live content: the base is what the
+    // completion merge diffs against, the draft is what the curator edits.
+    expect(vfs.writes.get(curationBasePath(ARCHIVE_PATH))).toBe(
+      '# Memory\n\n## Facts (2026-08-01)\n'
+    );
+    expect(vfs.writes.get(DRAFT_PATH)).toBe('# Memory\n\n## Facts (2026-08-01)\n');
+  });
+
+  it('seeds empty base and draft when no live memory exists yet', async () => {
+    const spawn = successSpawn();
+    const vfs = fakeVfs(DEFAULT_MEMORY_MD);
+
+    await runAgenticMemoryPass({
+      spawn,
+      vfs,
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+
+    expect(vfs.writes.get(curationBasePath(ARCHIVE_PATH))).toBe('');
+    expect(vfs.writes.get(DRAFT_PATH)).toBe('');
+  });
+
+  it('falls back safely (nothing spawned) when snapshot seeding fails', async () => {
+    const spawn = successSpawn();
+    const vfs = fakeVfs(DEFAULT_MEMORY_MD);
+    vfs.writeFile = vi.fn(async () => {
+      throw new Error('disk full');
+    });
+
+    const result = await runAgenticMemoryPass({
+      spawn,
+      vfs,
+      sessionArchivePath: ARCHIVE_PATH,
+      sessionCount: 1,
+    });
+
+    // No curator ran, so the legacy single-call append cannot be clobbered.
+    expect(result).toEqual({
+      ok: false,
+      reason: 'snapshot: disk full',
+      legacyFallbackSafe: true,
+    });
+    expect(spawn).not.toHaveBeenCalled();
   });
 
   it('returns ok:false when spawn throws', async () => {
@@ -505,8 +608,15 @@ Curate {{MEMORY_PATH}}.`;
       expect(options).toMatchObject({
         cwd: '/cones/cone-beta/workspace',
         // The shipped MEMORY.md names the PRIMARY memory file; the pass
-        // applies that same policy to this cone's own file instead.
-        writablePaths: ['/cones/cone-beta/CLAUDE.md'],
+        // applies that policy to this cone's own file — which is then
+        // staged: the curator writes the per-archive draft and the bridge
+        // merges it onto this cone's live file on exit 0.
+        writablePaths: [DRAFT_PATH],
+        mergeOnSuccess: {
+          targetPath: '/cones/cone-beta/CLAUDE.md',
+          basePath: curationBasePath(ARCHIVE_PATH),
+          draftPath: DRAFT_PATH,
+        },
         // Parented to the cone it curates, so an escalation reaches that
         // cone's approval router.
         parentJid: 'cone_beta',
@@ -521,8 +631,9 @@ Curate {{MEMORY_PATH}}.`;
         '/shared/',
         '/cones/cone-beta/workspace/',
         '/workspace/skills/',
+        `${CURATION_DIR}/`,
       ]);
-      expect(options.prompt).toContain('/cones/cone-beta/CLAUDE.md');
+      expect(options.prompt).toContain(DRAFT_PATH);
       expect(options.prompt).not.toContain('/workspace/CLAUDE.md');
     });
 
@@ -560,7 +671,7 @@ Curate {{MEMORY_PATH}}.`;
       });
 
       expect(spawn.mock.calls[0][0].prompt).toBe(
-        'Draft in `/scoops/agent-memory-curator-cone-beta/draft.md`, then write /cones/cone-beta/CLAUDE.md.'
+        `Draft in \`/scoops/agent-memory-curator-cone-beta/draft.md\`, then write ${DRAFT_PATH}.`
       );
     });
 
@@ -580,10 +691,20 @@ Curate {{MEMORY_PATH}}.`;
       expect(curatorAgentName('cone')).toBe('memory-curator');
       expect(options).toMatchObject({
         cwd: '/workspace',
-        writablePaths: [CONE_MEMORY_PATH],
+        writablePaths: [DRAFT_PATH],
         name: 'memory-curator',
+        mergeOnSuccess: {
+          targetPath: CONE_MEMORY_PATH,
+          basePath: curationBasePath(ARCHIVE_PATH),
+          draftPath: DRAFT_PATH,
+        },
       });
-      expect(options.visiblePaths).toEqual(['/sessions/', '/shared/', '/workspace/']);
+      expect(options.visiblePaths).toEqual([
+        '/sessions/',
+        '/shared/',
+        '/workspace/',
+        `${CURATION_DIR}/`,
+      ]);
       expect(options.parentJid).toBeUndefined();
       expect(options.prompt).toContain('/scoops/agent-memory-curator/');
     });
@@ -606,7 +727,8 @@ Curate {{MEMORY_PATH}}.`;
       const options = spawn.mock.calls[0][0];
       expect(options.name).toBe('memory-curator-cone-beta-2');
       expect(options.name).toMatch(/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/);
-      expect(options.writablePaths).toEqual(['/cones/cone-beta-2/CLAUDE.md']);
+      expect(options.writablePaths).toEqual([DRAFT_PATH]);
+      expect(options.mergeOnSuccess?.targetPath).toBe('/cones/cone-beta-2/CLAUDE.md');
     });
 
     it('falls back to the primary curator name for an unusable folder', async () => {
@@ -626,7 +748,8 @@ Curate {{MEMORY_PATH}}.`;
 
       const options = spawn.mock.calls[0][0];
       expect(options.name).toBe('memory-curator');
-      expect(options.writablePaths).toEqual(['/cones/Cone_Weird!/CLAUDE.md']);
+      expect(options.writablePaths).toEqual([DRAFT_PATH]);
+      expect(options.mergeOnSuccess?.targetPath).toBe('/cones/Cone_Weird!/CLAUDE.md');
     });
 
     it('keeps an explicitly configured non-workspace path unrebased', async () => {
@@ -649,8 +772,8 @@ Curate {{MEMORY_PATH}}.`;
       // configuration is left exactly as written, and the skills library is
       // NOT added because the original list never covered it either.
       expect(spawn.mock.calls[0][0]).toMatchObject({
-        writablePaths: ['/knowledge/notes.md'],
-        visiblePaths: ['/sessions/', '/knowledge/'],
+        writablePaths: ['/knowledge/notes.md', DRAFT_PATH],
+        visiblePaths: ['/sessions/', '/knowledge/', `${CURATION_DIR}/`],
       });
     });
   });

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -21,6 +21,12 @@ vi.mock('../../src/scoops/agentic-memory.js', () => ({
   // this exact path against the fake VFS.
   curatorReceiptPath: (sessionArchivePath: string) =>
     `/sessions/.curated/${sessionArchivePath.slice(sessionArchivePath.lastIndexOf('/') + 1)}`,
+  // Real staging-path derivation too — the receipt-recovery path removes the
+  // leftover base/draft pair against the fake VFS.
+  curationBasePath: (sessionArchivePath: string) =>
+    `/sessions/.curation/${sessionArchivePath.slice(sessionArchivePath.lastIndexOf('/') + 1)}/base.md`,
+  curationDraftPath: (sessionArchivePath: string) =>
+    `/sessions/.curation/${sessionArchivePath.slice(sessionArchivePath.lastIndexOf('/') + 1)}/draft.md`,
 }));
 
 // Mock the budget sink so tests can assert the freezer routes through it
@@ -353,7 +359,12 @@ describe('freezeConeSession', () => {
 
     expect(updated?.memoryPending).toBeUndefined();
     expect(frozen?.memoryPending).toBeUndefined();
-    expect((await readSessionsIndex(vfs as never))[0].memoryPending).toBeUndefined();
+    const [entry] = await readSessionsIndex(vfs as never);
+    expect(entry.memoryPending).toBeUndefined();
+    // The durable positive record: without it, "curated" and "never owed a
+    // pass" are indistinguishable in the index.
+    expect(entry.memoryCuratedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(updated?.memoryCuratedAt).toBe(entry.memoryCuratedAt);
     expect(mockRunAgenticMemoryPass).toHaveBeenCalledOnce();
     expect(spawn).toHaveBeenCalledOnce();
     expect(mockRunOneOffCompactionCall).toHaveBeenCalledOnce();
@@ -478,7 +489,11 @@ describe('freezeConeSession', () => {
     expect(vfs.files.get('/workspace/CLAUDE.md')).toContain('durable fallback memory');
     expect(mockApplyConeMemoryBudget).toHaveBeenCalledOnce();
     expect(frozen?.memoryPending).toBe(true);
-    expect((await readSessionsIndex(vfs as never))[0].memoryPending).toBe(true);
+    const [failedEntry] = await readSessionsIndex(vfs as never);
+    expect(failedEntry.memoryPending).toBe(true);
+    // The failure ledger: the reason the curator did not finish is durable.
+    expect(failedEntry.memoryFailed).toBe('spawn failed');
+    expect(failedEntry.memoryCuratedAt).toBeUndefined();
   });
 
   it('retains persisted memoryPending when reload interrupts before curation', async () => {
@@ -544,7 +559,9 @@ describe('freezeConeSession', () => {
 
     expect(frozen).not.toBeNull();
     expect(frozen?.memoryPending).toBe(true);
-    expect((await readSessionsIndex(vfs as never))[0].memoryPending).toBe(true);
+    const [timedOutEntry] = await readSessionsIndex(vfs as never);
+    expect(timedOutEntry.memoryPending).toBe(true);
+    expect(timedOutEntry.memoryFailed).toBe('timeout');
     expect(mockRunOneOffCompactionCall).toHaveBeenCalledOnce();
     expect(vfs.files.get('/workspace/CLAUDE.md')).toBeUndefined();
     expect(mockApplyConeMemoryBudget).not.toHaveBeenCalled();
@@ -1846,6 +1863,9 @@ describe('processPendingSessions', () => {
     expect(mockRunAgenticMemoryPass).not.toHaveBeenCalled();
     const [failed] = await readSessionsIndex(vfs as never);
     expect(failed).toMatchObject({ memoryPending: true, pendingAttemptCount: 3 });
+    // The capped entry is no longer silently abandoned — the terminal state
+    // is stamped so "gave up" is visible in the ledger.
+    expect(failed.memoryFailed).toBe('catch-up retries exhausted (3)');
     expect(await listPendingEnrichments(vfs as never)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Two improvements to the agentic memory curator, both in preparation for multi-cone (#1666) where several curators can run in parallel:

**1. Staged draft + three-way merge — the curator never touches the live memory file.**
`runAgenticMemoryPass` snapshots the live memory into `/sessions/.curation/<archive>/base.md` and hands the curator an identical `draft.md` to rewrite (`{{MEMORY_PATH}}` and the write grant now resolve to the draft; user-customized `MEMORY.md` files keep working unchanged because placeholders substitute at runtime). On exit 0 the agent bridge folds the rewrite onto the live file with the existing diff3 tooling (`git/merge-file-core.threeWayMerge`) via a new `mergeOnSuccess` spawn option — in the worker realm, before the success receipt, so a dead caller realm can't lose the completed rewrite (#1989 companion).

- Concurrent edits to the live memory during the up-to-20-minute pass **survive** instead of being clobbered by the whole-file rewrite; conflicting regions resolve to the curator (its deletions are deliberate).
- A killed or failed run leaves the live memory untouched — the mid-write-corruption failure mode is gone.
- A *missing* draft is treated as "staging lost", never as "curator deleted everything".
- Staging is keyed per archive, so parallel per-cone curators never share state.

**2. Durable ledger of which sessions completed vs failed curation.**
- New `outcomeReceiptPath` bridge option: `/sessions/.curation/<archive>/status.json` is written on **both** exit paths (`{status, exitCode, reason?, finishedAt, merge?}`) — failure evidence survives even when the page died mid-run.
- The sessions index now records `memoryCuratedAt` on success (previously "curated" and "never owed a pass" were indistinguishable) and `memoryFailed` with the reason on failure — including `catch-up retries exhausted (3)` for entries the boot pass used to abandon silently.
- The #1989 receipt-recovery path stamps the curated timestamp and cleans up staging left behind by an interrupted caller.

## Testing

- 14 new tests: snapshot seeding (live/empty/failing), draft path rebasing incl. per-cone, bridge merge (fast-forward, real 3-way with concurrent edits, conflict favoring, no-op draft, failure receipt, merge-failure resilience, path validation), ledger stamping (success, failure, timeout, retry exhaustion).
- Full pass: lint, typecheck (all 9 projects), full test run (16 748 passed; one unrelated `chrome-extension` fetch-proxy flake passes in isolation), `test:coverage:webapp`, both builds, `check-touched-exemptions` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
