### PR TITLE
feat(monitor): rebuild the live monitor around vitals, attention, and a real table

### DIFF
--- a/docs/kernel/process-model.md
+++ b/docs/kernel/process-model.md
@@ -33,6 +33,22 @@ interface Process {
 
 Status transitions: `running` → `exited` (clean) or `killed` (any terminating signal recorded). The manager fires `spawn` and `exit` events synchronously inside the corresponding method calls so `/proc` and `ps` see live state without a tick of latency.
 
+### Retention
+
+A terminated process is not dropped the instant it exits — `ps` after a `kill` has to be able to show the exit code — but it is not kept forever either. The manager retains the most recent `TERMINATED_RETENTION` (128) terminated records and reaps older ones oldest-first, so the table stays O(live + 128) instead of accumulating every command the session ever ran. Eviction only ever considers already-terminated pids, so a live process can never be reaped.
+
+`stats()` carries the totals the reaped records used to:
+
+```ts
+{
+  (live, retained, terminated, spawned);
+}
+```
+
+`terminated` and `spawned` are monotonic for the session and keep counting past the retention window; `retained` is how many records are actually resident. Surfaces that want to say how much work ran (the monitor's "1,435 exited this session") read the counter — a number stays true without thousands of records having to stay resident to prove it.
+
+Consequences worth knowing: `get(pid)` and `wait(pid)` on a reaped pid behave exactly like an unknown pid (`null` / reject), and `allocatePid()` may reuse a reaped pid after the uint32 space wraps.
+
 ## Where pids come from
 
 | Kind         | Spawn site                                          | argv                                    |
@@ -84,9 +100,35 @@ Layout:
 /proc/<pid>/cwd         # plain text path
 /proc/<pid>/stat        # single-line: pid (kind) state ppid exit started finished
 /proc/1/                # synthesized kernel-host anchor, ppid=0
+/proc/table             # the whole retained table as one JSON document
 ```
 
 Deliberate omissions: no `/proc/self` (would require `currentPid()` tracking which we don't do), no `environ` (would leak masked secrets), no `fd/` or `task/`. The full Linux procfs surface is out of scope; just what `ps` and `kill` need to drive their views.
+
+One deliberate ADDITION: `/proc/table` has no Linux counterpart. Linux readers walk `/proc/<pid>/` per process because a syscall-backed read is cheap; here every read crosses the VFS, so a UI refreshing the process list paid a `readDir` plus two `readFile`s per pid — thousands of VFS reads per tick against the same VFS the boot path and the terminal mount contend for. `/proc/table` collapses that to one read, and carries the `stats()` counters, which no per-pid file can express:
+
+```jsonc
+{
+  "stats": { "live": 9, "retained": 137, "terminated": 1435, "spawned": 1444 },
+  "processes": [
+    {
+      "pid": 1024,
+      "ppid": 1,
+      "kind": "shell",
+      "state": "R",
+      "status": "running",
+      "argv": "sleep 9",
+      "cwd": "/workspace",
+      "owner": "cone",
+      "startedAt": 1700000000000,
+      "finishedAt": null,
+      "exitCode": null,
+    },
+  ],
+}
+```
+
+`processes` holds every RETAINED process (live plus the retention window), so a reader that only wants live ones filters on `status` — the same choice `ps` makes by default. `argv` is space-joined here, unlike the NUL-separated `cmdline` file: this is JSON, not procfs.
 
 ## `ps` and `kill`
 

--- a/packages/webapp/src/kernel/proc-mount.ts
+++ b/packages/webapp/src/kernel/proc-mount.ts
@@ -13,6 +13,7 @@
  *   /proc/<pid>/cmdline     null-separated argv (POSIX-style)
  *   /proc/<pid>/cwd         working directory as plain text
  *   /proc/<pid>/stat        single-line procfs-style record
+ *   /proc/table             the whole table as one JSON document
  *
  * Deliberate divergences from POSIX:
  *   - No `/proc/self`: requires `currentPid()` tracking, which
@@ -22,6 +23,14 @@
  *   - No `environ`, no `fd/`, no `task/`. The full Linux procfs
  *     surface is out of scope; just what `ps` and `kill` need to
  *     drive their views.
+ *   - `/proc/table` has no Linux counterpart. Linux readers walk
+ *     `/proc/<pid>/` per process because a syscall-backed read is
+ *     cheap; here every read crosses the VFS, so a UI refreshing the
+ *     process list paid two reads per pid — ~2,900 VFS reads per tick
+ *     at the table sizes this mount used to grow to. One JSON
+ *     document collapses that to a single read, and carries the
+ *     `ProcessManager` session counters (which no per-pid file can
+ *     express) alongside the rows.
  *   - All writes throw `EACCES` ('read-only filesystem') —
  *     `FsErrorCode` doesn't have `EROFS`, so `EACCES` with the
  *     read-only message is the closest match. The mount-layer
@@ -41,7 +50,7 @@ import type {
   RefreshReport,
 } from '../fs/mount/backend.js';
 import { FsError } from '../fs/types.js';
-import type { Process, ProcessManager } from './process-manager.js';
+import type { Process, ProcessManager, ProcessTableStats } from './process-manager.js';
 
 const KERNEL_PID = 1;
 
@@ -77,9 +86,19 @@ export class ProcMountBackend implements MountBackend {
       if (!procs.some((p) => p.pid === KERNEL_PID)) {
         entries.push({ name: String(KERNEL_PID), kind: 'directory' });
       }
-      return entries.sort((a, b) => Number(a.name) - Number(b.name));
+      entries.sort((a, b) => Number(a.name) - Number(b.name));
+      entries.push({
+        name: TABLE_FILE,
+        kind: 'file',
+        size: this.renderTable().length,
+        lastModified: Date.now(),
+      });
+      return entries;
     }
     if (segments.length === 1) {
+      if (segments[0] === TABLE_FILE) {
+        throw new FsError('ENOTDIR', 'not a directory', path);
+      }
       // /proc/<pid> — fixed file set.
       const pid = parsePid(segments[0]);
       if (pid === null) throw new FsError('ENOENT', 'no such file or directory', path);
@@ -99,6 +118,9 @@ export class ProcMountBackend implements MountBackend {
   async readFile(path: string): Promise<Uint8Array> {
     this.assertOpen(path);
     const segments = splitPath(path);
+    if (segments.length === 1 && segments[0] === TABLE_FILE) {
+      return new TextEncoder().encode(this.renderTable());
+    }
     if (segments.length !== 2) {
       throw new FsError('EISDIR', 'is a directory', path);
     }
@@ -124,6 +146,9 @@ export class ProcMountBackend implements MountBackend {
       return { kind: 'directory', size: 0, mtime: 0 };
     }
     if (segments.length === 1) {
+      if (segments[0] === TABLE_FILE) {
+        return { kind: 'file', size: this.renderTable().length, mtime: Date.now() };
+      }
       const pid = parsePid(segments[0]);
       if (pid === null) throw new FsError('ENOENT', 'no such file or directory', path);
       if (!this.pidExists(pid)) throw new FsError('ENOENT', 'no such file or directory', path);
@@ -191,6 +216,31 @@ export class ProcMountBackend implements MountBackend {
     return proc.finishedAt ?? proc.startedAt;
   }
 
+  /**
+   * The whole retained table as one JSON document. Shape is
+   * {@link ProcTableDocument}; `stats` mirrors `ProcessManager.stats()`
+   * so a reader can report totals that outlive the reaped rows.
+   */
+  private renderTable(): string {
+    const doc: ProcTableDocument = {
+      stats: this.pm.stats(),
+      processes: this.pm.list().map((proc) => ({
+        pid: proc.pid,
+        ppid: proc.ppid,
+        kind: proc.kind,
+        state: stateLetter(proc.status),
+        status: proc.status,
+        argv: proc.argv.join(' '),
+        cwd: proc.cwd,
+        owner: ownerLabel(proc),
+        startedAt: proc.startedAt,
+        finishedAt: proc.finishedAt,
+        exitCode: proc.exitCode,
+      })),
+    };
+    return JSON.stringify(doc) + '\n';
+  }
+
   private renderProcFile(pid: number, name: ProcFile): string {
     if (pid === KERNEL_PID) {
       return renderKernelHost(name);
@@ -215,6 +265,32 @@ export class ProcMountBackend implements MountBackend {
 
 const PROC_FILES = ['status', 'cmdline', 'cwd', 'stat'] as const;
 type ProcFile = (typeof PROC_FILES)[number];
+
+/** Top-level aggregate file — see the divergence note in the module doc. */
+const TABLE_FILE = 'table';
+
+/** One row of {@link ProcTableDocument}. Field names are the wire contract. */
+export interface ProcTableRow {
+  pid: number;
+  ppid: number;
+  kind: Process['kind'];
+  /** procfs state letter — `R` / `S` / `Z` / `K`. */
+  state: string;
+  status: Process['status'];
+  /** argv space-joined, NOT NUL-separated — this is JSON, not `cmdline`. */
+  argv: string;
+  cwd: string;
+  owner: string;
+  startedAt: number;
+  finishedAt: number | null;
+  exitCode: number | null;
+}
+
+/** The parsed contents of `/proc/table`. */
+export interface ProcTableDocument {
+  stats: ProcessTableStats;
+  processes: ProcTableRow[];
+}
 
 function splitPath(path: string): string[] {
   return path.replace(/^\/+/, '').replace(/\/+$/, '').split('/').filter(Boolean);

--- a/packages/webapp/src/kernel/process-manager.ts
+++ b/packages/webapp/src/kernel/process-manager.ts
@@ -45,6 +45,14 @@
  *     (`kernel/realm/realm-runner.ts`) subscribes to SIGKILL via
  *     `onSignal` and calls `realm.terminate()` synchronously so
  *     `node`/`.jsh`/`python` runaways are uncatchable.
+ *   - **Bounded post-mortem retention.** Terminated processes are NOT
+ *     dropped the instant they exit — `ps` after a `kill` has to be able
+ *     to show the exit code — but they are no longer kept forever either.
+ *     The last `TERMINATED_RETENTION` of them stay readable and older ones
+ *     are reaped, so a long session's table stays O(live + 128) instead of
+ *     growing with every command ever run. `stats()` keeps the totals the
+ *     reaped entries used to carry, so "1,435 commands ran this session"
+ *     survives as a number without surviving as 1,435 records.
  */
 
 // ---------------------------------------------------------------------------
@@ -198,6 +206,18 @@ export interface Process {
 
 export type ProcessEvent = 'spawn' | 'exit';
 
+/**
+ * Session-wide process counts. `terminated` / `spawned` are monotonic and
+ * include reaped entries; `retained` is how many records are actually
+ * resident (live + up to `TERMINATED_RETENTION` dead).
+ */
+export interface ProcessTableStats {
+  live: number;
+  retained: number;
+  terminated: number;
+  spawned: number;
+}
+
 export type ProcessEventListener = (proc: Process) => void;
 
 /**
@@ -216,6 +236,18 @@ export type ProcessSignalListener = (proc: Process, sig: Signal) => void;
 
 const PID_FLOOR = 1024;
 const PID_CEIL = 0xffffffff;
+
+/**
+ * How many terminated processes stay readable after they exit.
+ *
+ * Post-mortem inspection only ever looks at the recent past — the process
+ * you just killed, the command that just failed — so a window is enough,
+ * and an unbounded table is a slow leak: every shell command, tool call and
+ * scoop turn in the session accumulates a `Process` record (with its
+ * `AbortController`, `Gate`, argv and env) that nothing will ever read
+ * again. A five-hour session had 1,444 records for 9 live processes.
+ */
+const TERMINATED_RETENTION = 128;
 
 /**
  * Conventional Unix exit codes for signals — used as the default
@@ -239,6 +271,10 @@ export class ProcessManager {
     exit: new Set(),
   };
   private readonly signalListeners = new Set<ProcessSignalListener>();
+  /** Pids of terminated-but-still-retained processes, oldest first. */
+  private readonly terminatedPids: number[] = [];
+  private spawnedTotal = 0;
+  private terminatedTotal = 0;
 
   // -------------------------------------------------------------------------
   // Lifecycle
@@ -271,6 +307,7 @@ export class ProcessManager {
       finishedAt: null,
     };
     this.processes.set(pid, proc);
+    this.spawnedTotal++;
     this.fire('spawn', proc);
     return proc;
   }
@@ -301,7 +338,12 @@ export class ProcessManager {
     // `abort.signal.aborted` after their `wait()` resolves can then
     // bail out cleanly.
     proc.gate.release();
+    this.terminatedTotal++;
+    // Fire BEFORE reaping: an `exit` listener (and `wait()`'s internal
+    // handler) is handed the `Process` object directly, so it sees a full
+    // record even if this exit is the one that evicts an older entry.
     this.fire('exit', proc);
+    this.retire(proc.pid);
   }
 
   /**
@@ -429,15 +471,46 @@ export class ProcessManager {
     return result;
   }
 
-  /** Return a snapshot of all processes. The returned array is a copy. */
+  /**
+   * Return a snapshot of every RETAINED process — live plus the most
+   * recent `TERMINATED_RETENTION` terminated ones. The returned array is
+   * a copy. Callers that only want live processes should use
+   * {@link listLive}; `ps` filters here itself because `ps -e` still
+   * wants the retained dead.
+   */
   list(): Process[] {
     return Array.from(this.processes.values());
   }
 
+  /** Only the processes that are still `pending` or `running`. */
+  listLive(): Process[] {
+    return this.list().filter((p) => p.status === 'pending' || p.status === 'running');
+  }
+
   /**
-   * Return `proc` for `pid`, or `null` if the pid was never allocated.
-   * No reaping today — terminated entries persist so `ps` after `kill`
-   * still shows the exit code.
+   * Session totals, including the processes that have already been reaped.
+   *
+   * This is what a caller should render instead of a list when it wants to
+   * say how much work ran: `terminated` keeps counting past
+   * `TERMINATED_RETENTION`, so "1,435 exited this session" stays true
+   * without 1,435 records having to stay resident to prove it.
+   */
+  stats(): ProcessTableStats {
+    const live = this.listLive().length;
+    return {
+      live,
+      retained: this.processes.size,
+      terminated: this.terminatedTotal,
+      spawned: this.spawnedTotal,
+    };
+  }
+
+  /**
+   * Return `proc` for `pid`, or `null` if the pid was never allocated —
+   * or has since been reaped. A terminated process stays readable until
+   * `TERMINATED_RETENTION` further processes terminate after it, which is
+   * ample for the post-`kill` `ps` this exists for; anything wanting a
+   * durable record should hold the `Process` handle it was given.
    */
   get(pid: number): Process | null {
     return this.processes.get(pid) ?? null;
@@ -446,7 +519,11 @@ export class ProcessManager {
   /**
    * Resolve when the process exits. If the pid is unknown, rejects
    * synchronously — there's no "wait for a future spawn of this pid"
-   * semantic; callers wait on a `Process` they were handed.
+   * semantic; callers wait on a `Process` they were handed. A pid that
+   * was reaped (see {@link get}) is indistinguishable from one that never
+   * existed, so it rejects too — waiting on a process that terminated
+   * more than `TERMINATED_RETENTION` terminations ago is a bug in the
+   * caller, not a state worth modelling.
    */
   wait(pid: number): Promise<Process> {
     const proc = this.processes.get(pid);
@@ -494,11 +571,26 @@ export class ProcessManager {
   // Internal
   // -------------------------------------------------------------------------
 
+  /**
+   * Record `pid` as terminated and evict whatever fell out of the
+   * retention window. Eviction only ever touches entries in
+   * `terminatedPids`, so a live process can never be reaped no matter how
+   * the table is ordered.
+   */
+  private retire(pid: number): void {
+    this.terminatedPids.push(pid);
+    while (this.terminatedPids.length > TERMINATED_RETENTION) {
+      const oldest = this.terminatedPids.shift() as number;
+      this.processes.delete(oldest);
+    }
+  }
+
   private allocatePid(): number {
-    // Linear probe for a free pid. The table size IS the live-process
-    // count (no reaping yet), so the probe is bounded by
-    // `processes.size`: starting from `nextPid`, we can hit at most
-    // `size` collisions before finding a hole. Anything beyond
+    // Linear probe for a free pid. Every occupied pid is a key in
+    // `processes`, so the probe is bounded by `processes.size`: starting
+    // from `nextPid`, we can hit at most `size` collisions before finding
+    // a hole. Reaping only shrinks the table, which tightens this bound
+    // and frees pids for reuse after a wrap. Anything beyond
     // that means our bookkeeping is corrupt; fail loudly. Without
     // this bound, a corrupt table could spin a multi-billion-step
     // linear probe across the uint32 space and freeze the kernel

--- a/packages/webapp/src/ui/wc/monitor-history.ts
+++ b/packages/webapp/src/ui/wc/monitor-history.ts
@@ -1,0 +1,99 @@
+/**
+ * Rolling sample buffer behind the monitor's sparklines.
+ *
+ * The monitor is a "live" panel with no time axis anywhere in its data: every
+ * source it reads (`getSessionStats`, the scoop list, `/proc/table`) answers
+ * "right now" and nothing records what "a minute ago" looked like. A
+ * sparkline needs a series, so something has to keep one.
+ *
+ * This is deliberately the smallest thing that can: an in-memory ring buffer
+ * fed by the panel's own 5s refresh. Consequences, stated rather than hidden:
+ *
+ *   - History starts when the panel opens and stops when it closes, because
+ *     that is when the refresh runs (`wc-workbench.ts`). It is not a
+ *     session-wide recorder and must not pretend to be — {@link windowLabel}
+ *     reports the span the samples ACTUALLY cover, so a 40-second-old buffer
+ *     says "last 40s" rather than claiming an hour.
+ *   - Nothing is persisted. A reload starts over. Persisting it would mean
+ *     writing to storage on a 5s timer for a decoration.
+ *   - A series with fewer than two points renders no sparkline at all
+ *     (the component's rule), so the first tick is simply plotless.
+ */
+
+/** How many samples to keep. At the panel's 5s cadence this is ~5 minutes. */
+export const MONITOR_HISTORY_CAPACITY = 60;
+
+/** One reading of the metrics the vitals tiles plot. */
+export interface MonitorSample {
+  /** `Date.now()` when the sample was taken. */
+  at: number;
+  /** Blended spend rate in USD/hour. */
+  burnRate: number;
+  /** How many work units were mid-turn. */
+  workingUnits: number;
+  /** How many kernel processes were live. */
+  liveProcesses: number;
+}
+
+type SeriesKey = 'burnRate' | 'workingUnits' | 'liveProcesses';
+
+/**
+ * A bounded, append-only series of monitor samples.
+ *
+ * Not a class with a persisted identity — the workbench owns one instance for
+ * as long as the panel wiring lives, and tests make their own.
+ */
+export class MonitorHistory {
+  readonly #samples: MonitorSample[] = [];
+  readonly #capacity: number;
+
+  constructor(capacity: number = MONITOR_HISTORY_CAPACITY) {
+    // A zero/negative capacity would make `push` a no-op and every series
+    // empty, which reads as "the metric is broken" rather than "the buffer
+    // is misconfigured". Refuse it instead.
+    this.#capacity = Math.max(2, Math.floor(capacity));
+  }
+
+  /** Append a sample, evicting the oldest once the buffer is full. */
+  push(sample: MonitorSample): void {
+    this.#samples.push(sample);
+    while (this.#samples.length > this.#capacity) this.#samples.shift();
+  }
+
+  /** How many samples are held. */
+  get size(): number {
+    return this.#samples.length;
+  }
+
+  /**
+   * The values of one metric, oldest first. Returns `undefined` below two
+   * points, which is exactly the input a sparkline can't plot — so callers
+   * can hand the result straight to `MonitorVital.series`.
+   */
+  series(key: SeriesKey): number[] | undefined {
+    if (this.#samples.length < 2) return undefined;
+    return this.#samples.map((sample) => sample[key]);
+  }
+
+  /** The largest value of one metric, or `null` when there are no samples. */
+  peak(key: SeriesKey): number | null {
+    if (this.#samples.length === 0) return null;
+    return this.#samples.reduce((max, s) => Math.max(max, s[key]), Number.NEGATIVE_INFINITY);
+  }
+
+  /**
+   * How far back the buffer actually reaches, as display copy — `last 45s`,
+   * `last 4m`. `null` below two samples, matching {@link series}.
+   *
+   * This reports the real span rather than the nominal capacity on purpose:
+   * a panel opened twenty seconds ago has twenty seconds of history, and
+   * labelling that "last 5 minutes" would be a lie told by a chart.
+   */
+  windowLabel(): string | null {
+    if (this.#samples.length < 2) return null;
+    const spanMs = this.#samples[this.#samples.length - 1].at - this.#samples[0].at;
+    const seconds = Math.max(1, Math.round(spanMs / 1000));
+    if (seconds < 90) return `last ${seconds}s`;
+    return `last ${Math.round(seconds / 60)}m`;
+  }
+}

--- a/packages/webapp/src/ui/wc/wc-live-monitor-deps.ts
+++ b/packages/webapp/src/ui/wc/wc-live-monitor-deps.ts
@@ -13,7 +13,7 @@ import {
 } from '../../scoops/tray-runtime-config.js';
 import { getConnectedFollowers } from '../../shell/supplemental-commands/host-command.js';
 import type { OffscreenClient } from '../offscreen-client.js';
-import type { MonitorDeps, MonitorTrayInfo } from './wc-monitor.js';
+import type { MonitorDeps, MonitorProcessSnapshot, MonitorTrayInfo } from './wc-monitor.js';
 
 const PROC_STATE_LETTER_TO_WORD: Record<string, string> = {
   R: 'running',
@@ -26,6 +26,35 @@ const PROC_STATE_LETTER_TO_WORD: Record<string, string> = {
 export function parseProcStatLine(statLine: string): string {
   const stateLetter = statLine.trim().split(' ')[2] ?? '';
   return PROC_STATE_LETTER_TO_WORD[stateLetter] ?? 'unknown';
+}
+
+/**
+ * Parse the `/proc/table` JSON document into the monitor's snapshot shape,
+ * keeping only live rows. The mount retains a window of terminated
+ * processes so post-mortem `ps` works; the monitor doesn't render them, and
+ * reports `stats.terminated` — the kernel's session total, which keeps
+ * counting past that window — instead.
+ *
+ * Anything malformed degrades to an empty snapshot rather than throwing:
+ * a monitor tick is not worth failing a render over.
+ */
+export function parseProcTable(raw: string): MonitorProcessSnapshot {
+  try {
+    const doc = JSON.parse(raw) as {
+      stats?: { terminated?: number };
+      processes?: { pid?: number; argv?: string; status?: string }[];
+    };
+    const processes = (doc.processes ?? [])
+      .filter((row) => row.status === 'running' || row.status === 'pending')
+      .map((row) => ({
+        pid: Number(row.pid ?? 0),
+        argv: String(row.argv ?? ''),
+        status: String(row.status ?? 'unknown'),
+      }));
+    return { processes, terminated: Number(doc.stats?.terminated ?? 0) };
+  } catch {
+    return { processes: [], terminated: 0 };
+  }
 }
 
 export function getTrayMonitorInfo(storage: Pick<Storage, 'getItem'>): MonitorTrayInfo {
@@ -130,30 +159,17 @@ export function createWcMonitorDeps(deps: {
     },
     getSessionStats: async () => client.getSessionStats?.() ?? null,
     getProcesses: async () => {
+      // One read of the `/proc/table` aggregate, not a readDir plus two
+      // readFiles per pid. The monitor refreshes every 5s, so the per-pid
+      // walk cost ~2N VFS reads a tick — several thousand on a table that
+      // had grown into the low thousands, against the same VFS the boot
+      // path and terminal mount contend for.
       try {
         const fs = await openReader();
-        const entries = await fs.readDir('/proc');
-        const processes = [];
-        for (const entry of entries.filter(
-          (candidate) => candidate.type === 'directory' && /^\d+$/.test(candidate.name)
-        )) {
-          try {
-            const stat = await fs.readFile(`/proc/${entry.name}/stat`, { encoding: 'utf-8' });
-            const cmdline = await fs.readFile(`/proc/${entry.name}/cmdline`, {
-              encoding: 'utf-8',
-            });
-            processes.push({
-              pid: Number.parseInt(entry.name, 10),
-              argv: String(cmdline).trim(),
-              status: parseProcStatLine(String(stat)),
-            });
-          } catch {
-            // Process may have exited between listing and reading.
-          }
-        }
-        return processes;
+        const raw = await fs.readFile('/proc/table', { encoding: 'utf-8' });
+        return parseProcTable(typeof raw === 'string' ? raw : new TextDecoder().decode(raw));
       } catch {
-        return [];
+        return { processes: [], terminated: 0 };
       }
     },
     getTrayInfo: () => getTrayMonitorInfo(storage),

--- a/packages/webapp/src/ui/wc/wc-monitor.ts
+++ b/packages/webapp/src/ui/wc/wc-monitor.ts
@@ -49,6 +49,26 @@ export interface OAuthProviderEntry {
   valid?: boolean;
 }
 
+/** One live process row, already narrowed to what the monitor renders. */
+export interface MonitorProcess {
+  pid: number;
+  argv: string;
+  status: string;
+}
+
+/**
+ * What the monitor knows about the process table.
+ *
+ * `processes` is LIVE processes only. `terminated` is the session total of
+ * everything that has already exited — a number the kernel keeps counting
+ * past its own retention window, so it stays true without the dead rows
+ * having to stay resident (or rendered) to prove it.
+ */
+export interface MonitorProcessSnapshot {
+  processes: MonitorProcess[];
+  terminated: number;
+}
+
 export interface MonitorTrayInfo {
   role: 'leader' | 'follower' | 'standalone';
   state: 'inactive' | 'connecting' | 'connected' | 'leader' | 'reconnecting' | 'error';
@@ -71,7 +91,7 @@ export interface MonitorDeps {
     models: { model: string; cost: number }[];
     scoops: { name: string; cost: number }[];
   } | null>;
-  getProcesses(): Promise<{ pid: number; argv: string; status: string }[]>;
+  getProcesses(): Promise<MonitorProcessSnapshot>;
   getTrayInfo(): MonitorTrayInfo;
   getConnectedFollowers(): ConnectedFollowerInfo[];
 }
@@ -149,14 +169,15 @@ export async function fetchMonitorData(deps: MonitorDeps): Promise<MonitorSectio
   const scoops = deps.getScoops();
   const tray = deps.getTrayInfo();
   const followers = deps.getConnectedFollowers();
-  const [cronTasks, webhooks, mounts, mcpServers, sessionStats, processes] = await Promise.all([
+  const [cronTasks, webhooks, mounts, mcpServers, sessionStats, procSnapshot] = await Promise.all([
     deps.getCronTasks().catch(() => [] as CronTaskEntry[]),
     deps.getWebhooks().catch(() => [] as WebhookEntry[]),
     deps.getMounts().catch(() => [] as MountMonitorRow[]),
     deps.getMcpServers().catch(() => ({}) as Record<string, { url: string; tools?: unknown[] }>),
     deps.getSessionStats().catch(() => null),
-    deps.getProcesses().catch(() => []),
+    deps.getProcesses().catch(() => ({ processes: [], terminated: 0 })),
   ]);
+  const { processes, terminated } = procSnapshot;
   const oauthProviders = deps.getOAuthProviders();
   const mcpEntries = Object.entries(mcpServers);
 
@@ -186,8 +207,18 @@ export async function fetchMonitorData(deps: MonitorDeps): Promise<MonitorSectio
     },
     {
       id: 'processes',
+      // Live processes only — the same default `ps` has ("listing them by
+      // default is noisy", ps-command.ts). Exited processes are reported as
+      // a count in `meta`, never as rows: a long session terminates
+      // thousands of them, and a list of dead pids is not something anyone
+      // reads. The count comes from the kernel's session total, so it stays
+      // right even after those records are reaped.
       label: 'Processes',
       count: processes.length,
+      meta:
+        terminated > 0
+          ? `${processes.length} live · ${terminated.toLocaleString()} exited`
+          : undefined,
       rows: processes.map((proc) => {
         const shortArgv = proc.argv.length > 40 ? proc.argv.slice(0, 37) + '...' : proc.argv;
         const statusDot = proc.status === 'running';

--- a/packages/webapp/src/ui/wc/wc-monitor.ts
+++ b/packages/webapp/src/ui/wc/wc-monitor.ts
@@ -1,10 +1,21 @@
 /**
- * Monitor surface for the WC workbench: read-only dashboard of all resources
- * managed by SLICC — tray connections, followers, scoops, cron tasks,
- * webhooks, mounts, MCP servers, and OAuth accounts.
+ * Monitor surface for the WC workbench.
+ *
+ * Builds the `<slicc-monitor>` model out of everything SLICC manages. The
+ * shape of that model is the design: vitals (rates and ratios over time),
+ * an attention feed (what is degraded), topology (named things, healthy ones
+ * collapsed to a line), and the process table. See the component doc for why
+ * those are four different vocabularies rather than one repeated card.
  */
 
-import type { MonitorSection } from '@slicc/webcomponents';
+import type {
+  MonitorAlert,
+  MonitorModel,
+  MonitorProcessRow,
+  MonitorSection,
+  MonitorStatus,
+  MonitorVital,
+} from '@slicc/webcomponents';
 import type { MountTableEntry } from '../../fs/mount-table-store.js';
 import type { CronTaskEntry, WebhookEntry } from '../../scoops/lick-manager.js';
 import type { RegisteredScoop } from '../../scoops/types.js';
@@ -17,12 +28,13 @@ import {
   followerTitle,
   shortFollowerId,
 } from '../follower-presentation.js';
+import type { MonitorHistory } from './monitor-history.js';
 
 /**
  * A persisted mount entry, augmented with the permission state as of the
  * moment this monitor render was fetched — checked fresh on every
  * `fetchMonitorData` call (initial load, the 5s auto-refresh, and manual
- * "↻ Refresh" clicks), never polled independently. `valid` is `true` for a
+ * "↻ Re-sync" clicks), never polled independently. `valid` is `true` for a
  * local mount whose handle still reports `queryPermission → 'granted'`,
  * `false` for a local mount that needs recovery, and `undefined` for
  * remote mounts (s3/da/proc) — those backends don't hold this kind of
@@ -52,8 +64,11 @@ export interface OAuthProviderEntry {
 /** One live process row, already narrowed to what the monitor renders. */
 export interface MonitorProcess {
   pid: number;
+  ppid?: number;
   argv: string;
   status: string;
+  scoop?: string;
+  startedAt?: number;
 }
 
 /**
@@ -78,6 +93,15 @@ export interface MonitorTrayInfo {
   stalled?: boolean;
 }
 
+/** The subset of the worker's `SessionStats` the monitor reads. */
+export interface MonitorSessionStats {
+  totalCost: number;
+  burnRate?: number;
+  models: { model: string; cost: number }[];
+  scoops: { name: string; cost: number }[];
+  fills?: { jid: string; fill: number }[];
+}
+
 export interface MonitorDeps {
   getScoops(): RegisteredScoop[];
   isProcessing(jid: string): boolean;
@@ -86,15 +110,15 @@ export interface MonitorDeps {
   getMounts(): Promise<MountMonitorRow[]>;
   getMcpServers(): Promise<Record<string, { url: string; tools?: unknown[] }>>;
   getOAuthProviders(): OAuthProviderEntry[];
-  getSessionStats(): Promise<{
-    totalCost: number;
-    models: { model: string; cost: number }[];
-    scoops: { name: string; cost: number }[];
-  } | null>;
+  getSessionStats(): Promise<MonitorSessionStats | null>;
   getProcesses(): Promise<MonitorProcessSnapshot>;
   getTrayInfo(): MonitorTrayInfo;
   getConnectedFollowers(): ConnectedFollowerInfo[];
 }
+
+// ---------------------------------------------------------------------------
+// Topology groups
+// ---------------------------------------------------------------------------
 
 export function buildFollowersSection(followers: ConnectedFollowerInfo[]): MonitorSection {
   const stalled = followers.filter((follower) => follower.health === 'stalled').length;
@@ -110,8 +134,9 @@ export function buildFollowersSection(followers: ConnectedFollowerInfo[]): Monit
   return {
     id: 'followers',
     label: 'Followers',
+    icon: 'radio',
     count: followers.filter((follower) => follower.peerState === 'connected').length,
-    meta: summary.join(' · ') || undefined,
+    meta: summary.join(' · ') || 'none paired',
     accent: 'cyan',
     emptyText: 'No followers connected yet. Pair a phone, tablet, or CLI follower to this tray.',
     rows: followers.map((follower) => {
@@ -130,24 +155,30 @@ export function buildFollowersSection(followers: ConnectedFollowerInfo[]): Monit
   };
 }
 
+function trayStatus(tray: MonitorTrayInfo): MonitorStatus {
+  if (tray.stalled || tray.state === 'reconnecting') return 'warn';
+  if (tray.state === 'error') return 'error';
+  if (tray.state === 'leader' || tray.state === 'connected') return 'active';
+  return 'idle';
+}
+
+function trayStateLabel(tray: MonitorTrayInfo): string {
+  if (tray.stalled) return 'stalled';
+  return tray.state === 'leader' ? 'connected' : tray.state;
+}
+
 function buildTraySection(tray: MonitorTrayInfo): MonitorSection {
-  const state = tray.stalled ? 'stalled' : tray.state === 'leader' ? 'connected' : tray.state;
-  const status =
-    tray.stalled || tray.state === 'reconnecting'
-      ? 'warn'
-      : tray.state === 'error'
-        ? 'error'
-        : tray.state === 'leader' || tray.state === 'connected'
-          ? 'active'
-          : 'idle';
+  const state = trayStateLabel(tray);
   const session = tray.sessionId ? `Session ${shortFollowerId(tray.sessionId)}` : null;
   const worker = tray.workerBaseUrl ? `Worker · ${tray.workerBaseUrl}` : null;
   return {
     id: 'tray',
     label: 'Tray',
+    icon: tray.role === 'follower' ? 'radio' : 'cloud',
     count: 1,
     meta: `${tray.role} · ${state}`,
     accent: 'waffle',
+    status: trayStatus(tray),
     rows: [
       {
         name: tray.role[0].toUpperCase() + tray.role.slice(1),
@@ -155,17 +186,390 @@ function buildTraySection(tray: MonitorTrayInfo): MonitorSection {
         meta: state,
         icon: tray.role === 'follower' ? 'radio' : 'cloud',
         badges: tray.joinUrl ? ['join URL'] : [],
-        status,
+        status: trayStatus(tray),
       },
     ],
   };
 }
 
 /**
- * Fetch monitor data and return it as `MonitorSection[]` for the
- * `<slicc-monitor>` component.
+ * Scoops as a two-level tree rather than a flat list: the cone → scoop
+ * hierarchy is real, and `parentJid` already records it, so flattening it
+ * threw away structure the reader has to reconstruct in their head.
  */
-export async function fetchMonitorData(deps: MonitorDeps): Promise<MonitorSection[]> {
+function buildScoopsSection(
+  scoops: RegisteredScoop[],
+  isProcessing: (jid: string) => boolean
+): MonitorSection {
+  const roots = scoops.filter((scoop) => isRootUnit(scoop));
+  const childrenOf = (jid: string): RegisteredScoop[] =>
+    scoops.filter((scoop) => !isRootUnit(scoop) && scoop.parentJid === jid);
+
+  const toRow = (scoop: RegisteredScoop, depth: number) => {
+    const processing = isProcessing(scoop.jid);
+    const label = isRootUnit(scoop) ? `${scoop.name || 'sliccy'} (cone)` : scoop.name;
+    return {
+      name: label,
+      meta: processing ? 'working' : 'idle',
+      active: processing,
+      depth,
+    };
+  };
+
+  const rows = roots.flatMap((root) => [
+    toRow(root, 0),
+    ...childrenOf(root.jid).map((child) => toRow(child, 1)),
+  ]);
+  // Anything whose parent isn't in the list still has to appear — a scoop the
+  // reader can see in the switcher must not vanish from the monitor because
+  // its parent was dropped.
+  const placed = new Set(rows.map((row) => row.name));
+  for (const orphan of scoops) {
+    const row = toRow(orphan, 0);
+    if (!placed.has(row.name)) rows.push(row);
+  }
+
+  const working = scoops.filter((scoop) => isProcessing(scoop.jid)).length;
+  return {
+    id: 'scoops',
+    label: 'Scoops',
+    icon: 'bot',
+    count: scoops.length,
+    meta: `${scoops.length} · ${working} working`,
+    accent: 'violet',
+    status: 'active',
+    emptyText: 'Delegate a focused task and its scoop will show up here.',
+    rows,
+  };
+}
+
+function buildMountsSection(mounts: MountMonitorRow[]): MonitorSection {
+  const broken = mounts.filter((mount) => mount.valid === false).length;
+  return {
+    id: 'mounts',
+    label: 'Mounts',
+    icon: 'hard-drive',
+    count: mounts.length,
+    meta:
+      broken > 0
+        ? `${mounts.length} · ${broken} need${broken === 1 ? 's' : ''} re-grant`
+        : `${mounts.length} · all granted`,
+    status: broken > 0 ? 'warn' : 'active',
+    emptyText: 'Mount a folder to give the workspace access to files on disk.',
+    rows: mounts.map((mount) => ({
+      name: mount.targetPath,
+      meta: mount.valid === false ? 'permission lost' : mount.descriptor.kind,
+      // valid === true  → healthy (permission confirmed as of this render)
+      // valid === false → attention (needs recovery as of this render)
+      // valid === undefined (remote backends) → neutral, no check made
+      status: mount.valid === true ? 'active' : mount.valid === false ? 'warn' : 'idle',
+    })),
+  };
+}
+
+/**
+ * MCP servers and provider accounts in one group. They were two cards with
+ * identical chrome and one row each; as a reader question they are the same
+ * one — "can SLICC still reach the things it talks to".
+ */
+function buildIntegrationsSection(
+  mcpEntries: [string, { tools?: unknown[] }][],
+  oauthProviders: OAuthProviderEntry[]
+): MonitorSection {
+  const expired = oauthProviders.filter((provider) => provider.valid === false).length;
+  const tools = mcpEntries.reduce((sum, [, entry]) => sum + (entry.tools?.length ?? 0), 0);
+  const summary = [
+    `${mcpEntries.length} server${mcpEntries.length === 1 ? '' : 's'}`,
+    `${tools} tool${tools === 1 ? '' : 's'}`,
+    expired > 0 ? `${expired} account expired` : `${oauthProviders.length} accounts valid`,
+  ].join(' · ');
+  return {
+    id: 'integrations',
+    label: 'Integrations',
+    icon: 'blocks',
+    count: mcpEntries.length + oauthProviders.length,
+    meta: summary,
+    accent: 'waffle',
+    status: expired > 0 ? 'error' : 'active',
+    emptyText: 'Connect an MCP server or a provider account to extend the workspace.',
+    rows: [
+      ...mcpEntries.map(([name, entry]) => {
+        const toolCount = entry.tools?.length ?? 0;
+        return {
+          name,
+          meta: `MCP · ${toolCount} tool${toolCount === 1 ? '' : 's'}`,
+          status: 'active' as MonitorStatus,
+        };
+      }),
+      ...oauthProviders.map((provider) => ({
+        name: provider.providerId,
+        meta: provider.valid === false ? 'session expired' : 'account',
+        status: (provider.valid === true
+          ? 'active'
+          : provider.valid === false
+            ? 'error'
+            : 'idle') as MonitorStatus,
+      })),
+    ],
+  };
+}
+
+/** Cron tasks and webhooks: both are "something else can start work here". */
+function buildAutomationsSection(
+  cronTasks: CronTaskEntry[],
+  webhooks: WebhookEntry[]
+): MonitorSection {
+  const summary = [
+    `${webhooks.length} webhook${webhooks.length === 1 ? '' : 's'}`,
+    cronTasks.length > 0
+      ? `${cronTasks.length} cron task${cronTasks.length === 1 ? '' : 's'}`
+      : 'no cron tasks',
+  ].join(' · ');
+  return {
+    id: 'automations',
+    label: 'Automations',
+    icon: 'calendar-clock',
+    count: cronTasks.length + webhooks.length,
+    meta: summary,
+    accent: 'amber',
+    emptyText: 'Scheduled tasks and webhook-driven licks will appear here.',
+    rows: [
+      ...cronTasks.map((task) => ({
+        name: task.name,
+        meta: task.cron,
+        status: (task.status === 'active' ? 'active' : 'idle') as MonitorStatus,
+      })),
+      ...webhooks.map((webhook) => ({
+        name: webhook.name,
+        meta: webhook.scoop ? `→ ${webhook.scoop}` : '→ cone',
+        status: 'idle' as MonitorStatus,
+      })),
+    ],
+  };
+}
+
+function buildCostSection(stats: MonitorSessionStats | null): MonitorSection {
+  return {
+    id: 'cost',
+    label: 'Cost',
+    icon: 'receipt',
+    count: stats?.models.length ?? 0,
+    meta: stats
+      ? `$${stats.totalCost.toFixed(2)} across ${stats.models.length} models`
+      : 'no spend yet',
+    accent: 'rose',
+    emptyText: 'Model usage will be summarized after the first turn.',
+    rows:
+      stats?.models.map((model) => ({
+        name: model.model,
+        meta: `$${model.cost.toFixed(4)}`,
+        status: 'idle' as MonitorStatus,
+      })) ?? [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Attention
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything that is degraded, expired, or failing, worst first.
+ *
+ * Derived from the same state the topology groups render — the point is not
+ * new data, it's that a reader shouldn't have to open seven groups to find
+ * out whether anything is wrong. Alerts carry `age` only where a real
+ * timestamp exists; an invented "2m ago" would be worse than none.
+ */
+export function buildAlerts(input: {
+  tray: MonitorTrayInfo;
+  followers: ConnectedFollowerInfo[];
+  mounts: MountMonitorRow[];
+  oauthProviders: OAuthProviderEntry[];
+}): MonitorAlert[] {
+  const alerts: MonitorAlert[] = [];
+
+  for (const provider of input.oauthProviders) {
+    if (provider.valid !== false) continue;
+    alerts.push({
+      id: `oauth:${provider.providerId}`,
+      severity: 'error',
+      icon: 'key-round',
+      title: `${provider.providerId} session expired`,
+      detail: 'Tool calls through this provider will fail until it is signed in again.',
+    });
+  }
+
+  const trayState = trayStatus(input.tray);
+  if (trayState === 'error' || trayState === 'warn') {
+    alerts.push({
+      id: 'tray',
+      severity: trayState === 'error' ? 'error' : 'warn',
+      icon: 'cloud-off',
+      title: `Tray ${trayStateLabel(input.tray)}`,
+      detail: input.tray.workerBaseUrl
+        ? `Worker · ${input.tray.workerBaseUrl}`
+        : 'No tray session is established.',
+    });
+  }
+
+  for (const follower of input.followers) {
+    // `followerStatus` only ever reaches 'warn' (stalled) — a follower that
+    // dropped entirely is simply absent from the list, so there is no error
+    // tier to branch on here.
+    if (followerStatus(follower) !== 'warn') continue;
+    alerts.push({
+      id: `follower:${follower.runtimeId}`,
+      severity: 'warn',
+      icon: 'radio',
+      title: `${followerTitle(follower)} stopped answering`,
+      detail: follower.motd ?? follower.runtime ?? 'No heartbeat from this follower.',
+      age: followerMeta(follower),
+    });
+  }
+
+  for (const mount of input.mounts) {
+    if (mount.valid !== false) continue;
+    alerts.push({
+      id: `mount:${mount.targetPath}`,
+      severity: 'warn',
+      icon: 'folder-lock',
+      title: `${mount.targetPath} needs re-grant`,
+      detail: 'File System Access permission is no longer granted for this handle.',
+    });
+  }
+
+  return alerts.sort((a, b) => (a.severity === b.severity ? 0 : a.severity === 'error' ? -1 : 1));
+}
+
+// ---------------------------------------------------------------------------
+// Vitals
+// ---------------------------------------------------------------------------
+
+function formatRate(rate: number): string {
+  return rate >= 100 ? `$${Math.round(rate)}` : `$${rate.toFixed(2)}`;
+}
+
+/**
+ * The vitals row: rates and ratios, not cardinalities.
+ *
+ * The figures this replaced (`TRACKED`, `ACTIVE`, `ATTENTION`) summed
+ * processes with OAuth providers and mounts. A count of unlike things is not
+ * a metric; these are the four numbers the system actually has that answer
+ * "how hard is it working, and how close to a limit".
+ */
+export function buildVitals(input: {
+  stats: MonitorSessionStats | null;
+  workingUnits: number;
+  totalUnits: number;
+  liveProcesses: number;
+  terminated: number;
+  history?: MonitorHistory;
+}): MonitorVital[] {
+  const { stats, workingUnits, totalUnits, liveProcesses, terminated, history } = input;
+  const window = history?.windowLabel();
+  const burnRate = stats?.burnRate ?? 0;
+  const fills = stats?.fills ?? [];
+  const peakFill = fills.reduce((max, f) => Math.max(max, f.fill), 0);
+
+  const vitals: MonitorVital[] = [
+    {
+      id: 'burn',
+      label: 'Burn rate',
+      value: formatRate(burnRate),
+      unit: '/hour',
+      hero: true,
+      series: history?.series('burnRate'),
+      foot: [stats ? `$${stats.totalCost.toFixed(2)} this session` : 'no spend yet', window]
+        .filter(Boolean)
+        .join(' · '),
+    },
+    {
+      id: 'load',
+      label: 'Agent load',
+      value: String(workingUnits),
+      unit: `of ${totalUnits} working`,
+      accent: 'violet',
+      series: history?.series('workingUnits'),
+      foot: window ?? undefined,
+    },
+    {
+      id: 'processes',
+      label: 'Live processes',
+      value: String(liveProcesses),
+      unit: liveProcesses === 1 ? 'process' : 'processes',
+      accent: 'cyan',
+      series: history?.series('liveProcesses'),
+      foot:
+        terminated > 0
+          ? `${terminated.toLocaleString()} exited this session`
+          : (window ?? undefined),
+    },
+  ];
+
+  // Only a real reading gets a meter. With no `fills` the honest thing is to
+  // show no tile, not a 0% bar that reads as "context is empty".
+  if (fills.length > 0) {
+    vitals.push({
+      id: 'context',
+      label: 'Context fill',
+      value: String(Math.round(peakFill * 100)),
+      unit: '%',
+      ratio: peakFill,
+      accent: peakFill >= 0.9 ? 'rose' : peakFill >= 0.7 ? 'amber' : 'green',
+      foot: `fullest of ${fills.length} context window${fills.length === 1 ? '' : 's'}`,
+    });
+  }
+
+  return vitals;
+}
+
+// ---------------------------------------------------------------------------
+// Processes
+// ---------------------------------------------------------------------------
+
+const PROC_STATE_LETTER: Record<string, string> = {
+  running: 'R',
+  pending: 'S',
+  exited: 'Z',
+  killed: 'K',
+};
+
+function formatElapsed(startedAt: number | undefined, now: number): string | undefined {
+  if (!startedAt) return undefined;
+  const seconds = Math.max(0, Math.round((now - startedAt) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}
+
+function toProcessRow(proc: MonitorProcess, now: number): MonitorProcessRow {
+  return {
+    pid: proc.pid,
+    ppid: proc.ppid,
+    state: PROC_STATE_LETTER[proc.status] ?? '?',
+    status: proc.status,
+    command: proc.argv,
+    scoop: proc.scoop,
+    started: proc.startedAt ? new Date(proc.startedAt).toTimeString().slice(0, 5) : undefined,
+    elapsed: formatElapsed(proc.startedAt, now),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch monitor data and return the `<slicc-monitor>` model.
+ *
+ * `history` is optional so callers that don't keep one (tests, the initial
+ * render) still get every tile — just without sparklines.
+ */
+export async function fetchMonitorData(
+  deps: MonitorDeps,
+  history?: MonitorHistory
+): Promise<MonitorModel> {
   const scoops = deps.getScoops();
   const tray = deps.getTrayInfo();
   const followers = deps.getConnectedFollowers();
@@ -175,119 +579,44 @@ export async function fetchMonitorData(deps: MonitorDeps): Promise<MonitorSectio
     deps.getMounts().catch(() => [] as MountMonitorRow[]),
     deps.getMcpServers().catch(() => ({}) as Record<string, { url: string; tools?: unknown[] }>),
     deps.getSessionStats().catch(() => null),
-    deps.getProcesses().catch(() => ({ processes: [], terminated: 0 })),
+    deps.getProcesses().catch(() => ({ processes: [], terminated: 0 }) as MonitorProcessSnapshot),
   ]);
   const { processes, terminated } = procSnapshot;
   const oauthProviders = deps.getOAuthProviders();
   const mcpEntries = Object.entries(mcpServers);
+  const workingUnits = scoops.filter((scoop) => deps.isProcessing(scoop.jid)).length;
+  const now = Date.now();
 
-  const sections: MonitorSection[] = [
-    buildTraySection(tray),
-    buildFollowersSection(followers),
-    {
-      id: 'cost',
-      label: 'Cost',
-      count: sessionStats?.models.length ?? 0,
-      meta: sessionStats ? `$${sessionStats.totalCost.toFixed(2)}` : undefined,
-      rows:
-        sessionStats?.models.map((m) => ({
-          name: m.model,
-          meta: `$${m.cost.toFixed(4)}`,
-        })) ?? [],
-    },
-    {
-      id: 'scoops',
-      label: 'Scoops',
-      count: scoops.length,
-      rows: scoops.map((scoop) => {
-        const label = isRootUnit(scoop) ? `${scoop.name || 'sliccy'} (cone)` : scoop.name;
-        const processing = deps.isProcessing(scoop.jid);
-        return { name: label, meta: processing ? 'processing' : 'idle', active: processing };
-      }),
-    },
-    {
-      id: 'processes',
-      // Live processes only — the same default `ps` has ("listing them by
-      // default is noisy", ps-command.ts). Exited processes are reported as
-      // a count in `meta`, never as rows: a long session terminates
-      // thousands of them, and a list of dead pids is not something anyone
-      // reads. The count comes from the kernel's session total, so it stays
-      // right even after those records are reaped.
-      label: 'Processes',
-      count: processes.length,
-      meta:
-        terminated > 0
-          ? `${processes.length} live · ${terminated.toLocaleString()} exited`
-          : undefined,
-      rows: processes.map((proc) => {
-        const shortArgv = proc.argv.length > 40 ? proc.argv.slice(0, 37) + '...' : proc.argv;
-        const statusDot = proc.status === 'running';
-        return { name: `${proc.pid}`, meta: shortArgv, active: statusDot };
-      }),
-    },
-    {
-      id: 'cron',
-      label: 'Cron Tasks',
-      count: cronTasks.length,
-      rows: cronTasks.map((task) => ({
-        name: task.name,
-        meta: task.cron,
-        active: task.status === 'active',
-      })),
-    },
-    {
-      id: 'webhooks',
-      label: 'Webhooks',
-      count: webhooks.length,
-      rows: webhooks.map((wh) => ({
-        name: wh.name,
-        meta: wh.scoop ? `→ ${wh.scoop}` : '→ cone',
-      })),
-    },
-    {
-      id: 'workflows',
-      label: 'Workflows',
-      count: 0,
-      rows: [],
-    },
-    {
-      id: 'mounts',
-      label: 'Mounts',
-      count: mounts.length,
-      rows: mounts.map((mount) => ({
-        name: mount.targetPath,
-        meta: mount.descriptor.kind,
-        // valid === true  → green (permission confirmed as of this render)
-        // valid === false → red (needs recovery as of this render)
-        // valid === undefined (remote backends) → default grey, no check made
-        active: mount.valid === true,
-        error: mount.valid === false,
-      })),
-    },
-    {
-      id: 'mcp',
-      label: 'MCP Servers',
-      count: mcpEntries.length,
-      rows: mcpEntries.map(([name, entry]) => {
-        const toolCount = entry.tools?.length ?? 0;
-        return { name, meta: `${toolCount} tool${toolCount !== 1 ? 's' : ''}` };
-      }),
-    },
-    {
-      id: 'oauth',
-      label: 'OAuth',
-      count: oauthProviders.length,
-      rows: oauthProviders.map((provider) => ({
-        name: provider.providerId,
-        meta: '',
-        // valid === true  → green (has a token, not past its expiry)
-        // valid === false → red (logged out, or token past its expiry)
-        // valid === undefined (non-OAuth / API-key account) → default grey
-        active: provider.valid === true,
-        error: provider.valid === false,
-      })),
-    },
-  ];
+  history?.push({
+    at: now,
+    burnRate: sessionStats?.burnRate ?? 0,
+    workingUnits,
+    liveProcesses: processes.length,
+  });
 
-  return sections;
+  return {
+    updated: 'Streaming · updated just now',
+    vitals: buildVitals({
+      stats: sessionStats,
+      workingUnits,
+      totalUnits: scoops.length,
+      liveProcesses: processes.length,
+      terminated,
+      history,
+    }),
+    alerts: buildAlerts({ tray, followers, mounts, oauthProviders }),
+    sections: [
+      buildTraySection(tray),
+      buildFollowersSection(followers),
+      buildScoopsSection(scoops, (jid) => deps.isProcessing(jid)),
+      buildMountsSection(mounts),
+      buildIntegrationsSection(mcpEntries, oauthProviders),
+      buildAutomationsSection(cronTasks, webhooks),
+      buildCostSection(sessionStats),
+    ],
+    processes: {
+      rows: processes.map((proc) => toProcessRow(proc, now)),
+      terminated,
+    },
+  };
 }

--- a/packages/webapp/src/ui/wc/wc-workbench.ts
+++ b/packages/webapp/src/ui/wc/wc-workbench.ts
@@ -13,6 +13,7 @@ import { toPreviewUrl } from '../../shell/supplemental-commands/shared.js';
 import { PRIMARY_WORKSPACE } from '../../work-unit/descriptor.js';
 import type { WorkUnitWorkspace } from '../../work-unit/types.js';
 import { wireFileActions } from './file-actions.js';
+import { MonitorHistory } from './monitor-history.js';
 import { buildMemoryRows } from './wc-memory.js';
 import { fetchMonitorData, type MonitorDeps } from './wc-monitor.js';
 
@@ -161,6 +162,10 @@ export function createWorkbenchActivator(deps: WcWorkbenchDeps): WorkbenchActiva
   let memorySeq = 0;
   let filesRefreshTimer: ReturnType<typeof setInterval> | null = null;
   let monitorRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  // Sparkline history for the vitals tiles. Fed by the refresh below, so it
+  // only accumulates while the panel is open — `windowLabel()` reports the
+  // span it actually covers rather than claiming more.
+  const monitorHistory = new MonitorHistory();
   let filesRefreshPending = false;
   let fileActionsWired = false;
 
@@ -219,8 +224,7 @@ export function createWorkbenchActivator(deps: WcWorkbenchDeps): WorkbenchActiva
   const refreshMonitor = (): void => {
     void (async () => {
       try {
-        const sections = await fetchMonitorData(deps.getMonitorDeps());
-        deps.monitor.sections = sections;
+        deps.monitor.model = await fetchMonitorData(deps.getMonitorDeps(), monitorHistory);
       } catch (err) {
         deps.log.error('WC monitor refresh failed', err);
       }

--- a/packages/webapp/tests/kernel/proc-mount.test.ts
+++ b/packages/webapp/tests/kernel/proc-mount.test.ts
@@ -22,8 +22,9 @@ describe('ProcMountBackend — readDir', () => {
     expect(names).toContain('1024');
     expect(names).toContain('1025');
     expect(names).toContain('1'); // kernel-host anchor
+    expect(names).toContain('table'); // the aggregate, the one non-directory
     for (const e of entries) {
-      expect(e.kind).toBe('directory');
+      expect(e.kind).toBe(e.name === 'table' ? 'file' : 'directory');
     }
   });
 
@@ -217,6 +218,55 @@ describe('ProcMountBackend — lifecycle', () => {
     const proc = new ProcMountBackend(new ProcessManager());
     await proc.close();
     await expect(proc.readDir('/')).rejects.toMatchObject({ code: 'EBADF' });
+  });
+
+  it('reads the whole table in one read, with the session counters', async () => {
+    const pm = new ProcessManager();
+    const live = pm.spawn({ kind: 'shell', argv: ['sleep', '9'], owner: { kind: 'cone' } });
+    const dead = pm.spawn({ kind: 'tool', argv: ['read_file'], owner: { kind: 'system' } });
+    pm.exit(dead.pid, 3);
+    const proc = new ProcMountBackend(pm);
+    const doc = JSON.parse(decode(await proc.readFile('/table')));
+
+    expect(doc.stats).toEqual({ live: 1, retained: 2, terminated: 1, spawned: 2 });
+    const byPid = Object.fromEntries(doc.processes.map((r: { pid: number }) => [r.pid, r]));
+    expect(byPid[live.pid]).toMatchObject({
+      ppid: 1,
+      kind: 'shell',
+      state: 'R',
+      status: 'running',
+      argv: 'sleep 9',
+      owner: 'cone',
+      exitCode: null,
+      finishedAt: null,
+    });
+    expect(byPid[dead.pid]).toMatchObject({ state: 'Z', status: 'exited', exitCode: 3 });
+    expect(byPid[dead.pid].finishedAt).toBeGreaterThan(0);
+  });
+
+  it('treats /table as a file, not a pid', async () => {
+    const proc = new ProcMountBackend(new ProcessManager());
+    expect(await proc.stat('/table')).toMatchObject({ kind: 'file' });
+    await expect(proc.readDir('/table')).rejects.toMatchObject({ code: 'ENOTDIR' });
+    // The size a `stat` advertises has to match what a read returns, or a
+    // caller sizing a buffer from `stat` truncates the document.
+    const stat = await proc.stat('/table');
+    expect(stat.size).toBe(decode(await proc.readFile('/table')).length);
+  });
+
+  it('drops reaped processes out of the table', async () => {
+    const pm = new ProcessManager();
+    for (let i = 0; i < 200; i++) {
+      const p = pm.spawn({ kind: 'shell', argv: [`cmd${i}`], owner: { kind: 'cone' } });
+      pm.exit(p.pid, 0);
+    }
+    const proc = new ProcMountBackend(pm);
+    const doc = JSON.parse(decode(await proc.readFile('/table')));
+    // 200 ran, at most the retention window is still resident, and the
+    // session total survives the eviction.
+    expect(doc.stats.terminated).toBe(200);
+    expect(doc.processes.length).toBeLessThan(200);
+    expect(doc.processes.length).toBe(doc.stats.retained);
   });
 
   it('exited processes still appear in /proc/<pid>/* until reaped', async () => {

--- a/packages/webapp/tests/kernel/process-manager.test.ts
+++ b/packages/webapp/tests/kernel/process-manager.test.ts
@@ -60,10 +60,10 @@ describe('ProcessManager — pid allocation', () => {
     const a = pm.spawn({ kind: 'shell', argv: ['a'], owner: { kind: 'cone' } });
     const b = pm.spawn({ kind: 'shell', argv: ['b'], owner: { kind: 'cone' } });
     pm.exit(a.pid, 0);
-    // Even though a exited, the next pid is still monotonic (we don't
-    // reap exited entries). The probe only kicks in if `nextPid` lands
-    // on a still-live entry, which we can't reproduce without
-    // exhausting the space — covered structurally by the dedicated
+    // Even though a exited, the next pid is still monotonic: reaping frees
+    // table slots but never rewinds `nextPid`. The probe only kicks in if
+    // `nextPid` lands on a still-live entry, which we can't reproduce
+    // without exhausting the space — covered structurally by the dedicated
     // wraparound test below.
     const c = pm.spawn({ kind: 'shell', argv: ['c'], owner: { kind: 'cone' } });
     expect(c.pid).toBe(1026);
@@ -646,5 +646,96 @@ describe('runAsProcess', () => {
     });
     expect(received).not.toBeNull();
     expect(received!.kind).toBe('tool');
+  });
+});
+
+describe('ProcessManager — retention', () => {
+  it('keeps a terminated process readable for post-mortem ps', () => {
+    const pm = makeManager();
+    const proc = pm.spawn({ kind: 'shell', argv: ['boom'], owner: { kind: 'cone' } });
+    pm.exit(proc.pid, 42);
+    expect(pm.get(proc.pid)).toMatchObject({ status: 'exited', exitCode: 42 });
+  });
+
+  it('bounds the table so a long session does not grow without limit', () => {
+    const pm = makeManager();
+    for (let i = 0; i < 1500; i++) {
+      const p = pm.spawn({ kind: 'shell', argv: [`cmd${i}`], owner: { kind: 'cone' } });
+      pm.exit(p.pid, 0);
+    }
+    // The bug this replaces: 1,500 spawn/exit pairs left 1,500 resident
+    // records. The exact window is an implementation detail; that it is
+    // bounded well below the number of processes that ran is not.
+    expect(pm.list().length).toBeLessThan(200);
+    expect(pm.stats().terminated).toBe(1500);
+    expect(pm.stats().spawned).toBe(1500);
+    expect(pm.stats().live).toBe(0);
+    expect(pm.stats().retained).toBe(pm.list().length);
+  });
+
+  it('never reaps a live process, however many others terminate', () => {
+    const pm = makeManager();
+    const survivor = pm.spawn({ kind: 'shell', argv: ['sleep'], owner: { kind: 'cone' } });
+    for (let i = 0; i < 1000; i++) {
+      const p = pm.spawn({ kind: 'tool', argv: [`t${i}`], owner: { kind: 'cone' } });
+      pm.exit(p.pid, 0);
+    }
+    expect(pm.get(survivor.pid)).not.toBeNull();
+    expect(pm.listLive()).toEqual([survivor]);
+    expect(pm.stats().live).toBe(1);
+  });
+
+  it('reaps oldest-first, so the most recent deaths stay inspectable', () => {
+    const pm = makeManager();
+    const pids: number[] = [];
+    for (let i = 0; i < 300; i++) {
+      const p = pm.spawn({ kind: 'shell', argv: [`cmd${i}`], owner: { kind: 'cone' } });
+      pm.exit(p.pid, 0);
+      pids.push(p.pid);
+    }
+    expect(pm.get(pids[0])).toBeNull();
+    expect(pm.get(pids[pids.length - 1])).not.toBeNull();
+  });
+
+  it('fires the exit listener with a full record even when that exit evicts one', () => {
+    const pm = makeManager();
+    for (let i = 0; i < 400; i++) {
+      const p = pm.spawn({ kind: 'shell', argv: [`cmd${i}`], owner: { kind: 'cone' } });
+      pm.exit(p.pid, 0);
+    }
+    const seen: Process[] = [];
+    pm.on('exit', (p) => seen.push(p));
+    const last = pm.spawn({ kind: 'shell', argv: ['last'], owner: { kind: 'cone' } });
+    pm.exit(last.pid, 7);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ pid: last.pid, exitCode: 7, status: 'exited' });
+  });
+
+  it('listLive() excludes terminated processes', () => {
+    const pm = makeManager();
+    const a = pm.spawn({ kind: 'shell', argv: ['a'], owner: { kind: 'cone' } });
+    const b = pm.spawn({ kind: 'shell', argv: ['b'], owner: { kind: 'cone' } });
+    pm.signal(b.pid, 'SIGKILL');
+    pm.exit(b.pid, null);
+    expect(pm.listLive().map((p) => p.pid)).toEqual([a.pid]);
+    expect(pm.list()).toHaveLength(2);
+  });
+
+  it('counts a killed process as terminated', () => {
+    const pm = makeManager();
+    const p = pm.spawn({ kind: 'shell', argv: ['x'], owner: { kind: 'cone' } });
+    pm.signal(p.pid, 'SIGKILL');
+    pm.exit(p.pid, null);
+    expect(pm.get(p.pid)?.status).toBe('killed');
+    expect(pm.stats().terminated).toBe(1);
+  });
+
+  it('does not double-count a repeated exit()', () => {
+    const pm = makeManager();
+    const p = pm.spawn({ kind: 'shell', argv: ['x'], owner: { kind: 'cone' } });
+    pm.exit(p.pid, 0);
+    pm.exit(p.pid, 0);
+    expect(pm.stats().terminated).toBe(1);
+    expect(pm.list()).toHaveLength(1);
   });
 });

--- a/packages/webapp/tests/ui/wc/monitor-history.test.ts
+++ b/packages/webapp/tests/ui/wc/monitor-history.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MONITOR_HISTORY_CAPACITY,
+  MonitorHistory,
+  type MonitorSample,
+} from '../../../src/ui/wc/monitor-history.js';
+
+function sample(at: number, overrides: Partial<MonitorSample> = {}): MonitorSample {
+  return { at, burnRate: 1, workingUnits: 0, liveProcesses: 2, ...overrides };
+}
+
+describe('MonitorHistory', () => {
+  it('returns no series below two points, so a sparkline never gets one', () => {
+    const history = new MonitorHistory();
+    expect(history.series('burnRate')).toBeUndefined();
+    history.push(sample(1_000));
+    expect(history.series('burnRate')).toBeUndefined();
+    history.push(sample(6_000, { burnRate: 2 }));
+    expect(history.series('burnRate')).toEqual([1, 2]);
+  });
+
+  it('keeps samples oldest-first', () => {
+    const history = new MonitorHistory();
+    history.push(sample(1_000, { workingUnits: 1 }));
+    history.push(sample(6_000, { workingUnits: 3 }));
+    history.push(sample(11_000, { workingUnits: 2 }));
+    expect(history.series('workingUnits')).toEqual([1, 3, 2]);
+  });
+
+  it('evicts the oldest sample once full', () => {
+    const history = new MonitorHistory(3);
+    for (let i = 0; i < 5; i++) history.push(sample(i * 1_000, { liveProcesses: i }));
+    expect(history.size).toBe(3);
+    expect(history.series('liveProcesses')).toEqual([2, 3, 4]);
+  });
+
+  it('refuses a capacity that would make every series unplottable', () => {
+    // A capacity below 2 can never satisfy `series()`, so a caller passing 0
+    // would silently get a monitor with no sparklines and no explanation.
+    const history = new MonitorHistory(0);
+    history.push(sample(1_000));
+    history.push(sample(6_000, { burnRate: 4 }));
+    expect(history.series('burnRate')).toEqual([1, 4]);
+  });
+
+  it('reports the peak of a metric', () => {
+    const history = new MonitorHistory();
+    expect(history.peak('workingUnits')).toBeNull();
+    history.push(sample(1_000, { workingUnits: 2 }));
+    history.push(sample(6_000, { workingUnits: 5 }));
+    history.push(sample(11_000, { workingUnits: 1 }));
+    expect(history.peak('workingUnits')).toBe(5);
+  });
+
+  it('labels the span the samples ACTUALLY cover, not the capacity', () => {
+    // The whole point: a panel opened 45 seconds ago has 45 seconds of
+    // history, and a chart claiming "last 5 minutes" would be lying.
+    const history = new MonitorHistory();
+    expect(history.windowLabel()).toBeNull();
+    history.push(sample(0));
+    expect(history.windowLabel()).toBeNull();
+    history.push(sample(45_000));
+    expect(history.windowLabel()).toBe('last 45s');
+    history.push(sample(300_000));
+    expect(history.windowLabel()).toBe('last 5m');
+  });
+
+  it('switches from seconds to minutes at 90s', () => {
+    const seconds = new MonitorHistory();
+    seconds.push(sample(0));
+    seconds.push(sample(89_000));
+    expect(seconds.windowLabel()).toBe('last 89s');
+
+    const minutes = new MonitorHistory();
+    minutes.push(sample(0));
+    minutes.push(sample(90_000));
+    expect(minutes.windowLabel()).toBe('last 2m');
+  });
+
+  it('holds roughly five minutes at the panel refresh cadence', () => {
+    // The capacity is chosen against wc-workbench's 5s monitor timer; if that
+    // timer changes, this is the assertion that should make someone re-check.
+    expect(MONITOR_HISTORY_CAPACITY * 5).toBe(300);
+  });
+});

--- a/packages/webapp/tests/ui/wc/wc-live.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-live.test.ts
@@ -23,7 +23,7 @@ import {
   toSwitcherScoops,
   type WcLiveWiring,
 } from '../../../src/ui/wc/wc-live-callbacks.js';
-import { parseProcStatLine } from '../../../src/ui/wc/wc-live-monitor-deps.js';
+import { parseProcStatLine, parseProcTable } from '../../../src/ui/wc/wc-live-monitor-deps.js';
 import {
   applyLeaderLocalThinkingChange,
   metaThinkingForScoop,
@@ -853,5 +853,43 @@ describe('wireDockTreePersistence', () => {
     expect(dockTree.setTree).toHaveBeenCalledWith(persisted);
     expect(setItemSpy).not.toHaveBeenCalled();
     setItemSpy.mockRestore();
+  });
+});
+
+describe('parseProcTable', () => {
+  const doc = JSON.stringify({
+    stats: { live: 2, retained: 4, terminated: 1435, spawned: 1437 },
+    processes: [
+      { pid: 1024, argv: 'sleep 9', status: 'running' },
+      { pid: 1025, argv: 'rg --json x', status: 'pending' },
+      { pid: 1026, argv: 'npm run lint', status: 'exited' },
+      { pid: 1027, argv: 'tsc --noEmit', status: 'killed' },
+    ],
+  });
+
+  it('keeps only live rows', () => {
+    const snapshot = parseProcTable(doc);
+    expect(snapshot.processes.map((p) => p.pid)).toEqual([1024, 1025]);
+  });
+
+  it('reports the session total, not the retained count', () => {
+    // The whole point of the counter: 1,435 exited, only 2 dead records are
+    // still resident, and the number the UI shows is the former.
+    expect(parseProcTable(doc).terminated).toBe(1435);
+  });
+
+  it('degrades to an empty snapshot on malformed input', () => {
+    expect(parseProcTable('not json')).toEqual({ processes: [], terminated: 0 });
+    expect(parseProcTable('')).toEqual({ processes: [], terminated: 0 });
+    expect(parseProcTable('{}')).toEqual({ processes: [], terminated: 0 });
+    expect(parseProcTable('null')).toEqual({ processes: [], terminated: 0 });
+  });
+
+  it('tolerates rows missing fields', () => {
+    const snapshot = parseProcTable(
+      JSON.stringify({ stats: {}, processes: [{ status: 'running' }] })
+    );
+    expect(snapshot.processes).toEqual([{ pid: 0, argv: '', status: 'running' }]);
+    expect(snapshot.terminated).toBe(0);
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-monitor.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-monitor.test.ts
@@ -5,7 +5,19 @@ import { installWcDomStubs } from './wc-dom-stubs.js';
 
 installWcDomStubs();
 
-import { fetchMonitorData, type MonitorDeps } from '../../../src/ui/wc/wc-monitor.js';
+import type { MonitorSection } from '@slicc/webcomponents';
+import { MonitorHistory } from '../../../src/ui/wc/monitor-history.js';
+import {
+  buildAlerts,
+  buildVitals,
+  fetchMonitorData,
+  type MonitorDeps,
+} from '../../../src/ui/wc/wc-monitor.js';
+
+/** The topology groups alone — most assertions here are about those. */
+async function fetchSections(deps: MonitorDeps): Promise<MonitorSection[]> {
+  return (await fetchMonitorData(deps)).sections ?? [];
+}
 
 function makeDeps(overrides: Partial<MonitorDeps> = {}): MonitorDeps {
   return {
@@ -27,13 +39,21 @@ function makeDeps(overrides: Partial<MonitorDeps> = {}): MonitorDeps {
 describe('fetchMonitorData', () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it('returns all eleven sections', async () => {
-    const sections = await fetchMonitorData(makeDeps());
-    expect(sections).toHaveLength(11);
+  it('returns seven topology groups, not eleven cards', async () => {
+    const sections = await fetchSections(makeDeps());
+    expect(sections.map((section) => section.id)).toEqual([
+      'tray',
+      'followers',
+      'scoops',
+      'mounts',
+      'integrations',
+      'automations',
+      'cost',
+    ]);
   });
 
   it('shows standalone tray state and a clear followers empty state', async () => {
-    const sections = await fetchMonitorData(makeDeps());
+    const sections = await fetchSections(makeDeps());
     const tray = sections.find((section) => section.id === 'tray')!;
     const followers = sections.find((section) => section.id === 'followers')!;
 
@@ -44,7 +64,7 @@ describe('fetchMonitorData', () => {
 
   it('shows exec and stalled followers with approved detail fields', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-03T10:10:00.000Z').getTime());
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getTrayInfo: () => ({
           role: 'leader',
@@ -100,7 +120,7 @@ describe('fetchMonitorData', () => {
   });
 
   it('shows connecting followers as idle', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getConnectedFollowers: () => [
           {
@@ -123,7 +143,7 @@ describe('fetchMonitorData', () => {
   });
 
   it('represents follower tray connection state without changing the follower placeholder', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getTrayInfo: () => ({
           role: 'follower',
@@ -140,7 +160,7 @@ describe('fetchMonitorData', () => {
   });
 
   it('shows scoop rows with status', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getScoops: () => [
           { jid: 'cone-1', name: 'sliccy', parentJid: null } as any,
@@ -157,7 +177,7 @@ describe('fetchMonitorData', () => {
   });
 
   it('shows cron task rows with schedule', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getCronTasks: async () => [
           {
@@ -173,32 +193,34 @@ describe('fetchMonitorData', () => {
         ],
       })
     );
-    const cronSection = sections.find((s) => s.id === 'cron')!;
-    expect(cronSection.count).toBe(1);
-    expect(cronSection.rows[0].name).toBe('daily-check');
-    expect(cronSection.rows[0].meta).toContain('0 9 * * *');
+    const automations = sections.find((s) => s.id === 'automations')!;
+    expect(automations.count).toBe(1);
+    expect(automations.meta).toBe('0 webhooks · 1 cron task');
+    expect(automations.rows[0].name).toBe('daily-check');
+    expect(automations.rows[0].meta).toContain('0 9 * * *');
   });
 
   it('shows empty resource sections with count 0', async () => {
-    const sections = await fetchMonitorData(makeDeps());
+    const sections = await fetchSections(makeDeps());
     for (const section of sections.filter((section) => section.id !== 'tray')) {
       expect(section.count).toBe(0);
     }
   });
 
   it('shows webhook rows', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getWebhooks: async () => [{ id: 'w1', name: 'gh-push', createdAt: '', scoop: 'cone' }],
       })
     );
-    const webhookSection = sections.find((s) => s.id === 'webhooks')!;
-    expect(webhookSection.count).toBe(1);
-    expect(webhookSection.rows[0].name).toBe('gh-push');
+    const automations = sections.find((s) => s.id === 'automations')!;
+    expect(automations.count).toBe(1);
+    expect(automations.meta).toBe('1 webhook · no cron tasks');
+    expect(automations.rows[0].name).toBe('gh-push');
   });
 
   it('shows mount rows with kind', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getMounts: async () => [
           {
@@ -216,7 +238,7 @@ describe('fetchMonitorData', () => {
   });
 
   it('shows a green dot for a local mount with confirmed permission (valid: true)', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getMounts: async () => [
           {
@@ -229,12 +251,12 @@ describe('fetchMonitorData', () => {
       })
     );
     const mountSection = sections.find((s) => s.id === 'mounts')!;
-    expect(mountSection.rows[0].active).toBe(true);
-    expect(mountSection.rows[0].error).toBe(false);
+    expect(mountSection.rows[0].status).toBe('active');
+    expect(mountSection.meta).toBe('1 · all granted');
   });
 
   it('shows a red dot for a local mount that has lost permission (valid: false)', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getMounts: async () => [
           {
@@ -247,12 +269,15 @@ describe('fetchMonitorData', () => {
       })
     );
     const mountSection = sections.find((s) => s.id === 'mounts')!;
-    expect(mountSection.rows[0].active).toBe(false);
-    expect(mountSection.rows[0].error).toBe(true);
+    expect(mountSection.rows[0].status).toBe('warn');
+    expect(mountSection.rows[0].meta).toBe('permission lost');
+    // The group rolls up to attention, which is what auto-expands it.
+    expect(mountSection.status).toBe('warn');
+    expect(mountSection.meta).toBe('1 · 1 needs re-grant');
   });
 
   it('shows the default (neither active nor error) dot for a remote mount, where `valid` is never set', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getMounts: async () => [
           {
@@ -266,70 +291,73 @@ describe('fetchMonitorData', () => {
       })
     );
     const mountSection = sections.find((s) => s.id === 'mounts')!;
-    expect(mountSection.rows[0].active).toBe(false);
-    expect(mountSection.rows[0].error).toBe(false);
+    expect(mountSection.rows[0].status).toBe('idle');
+    expect(mountSection.status).toBe('active');
   });
 
   it('shows MCP server rows with tool count', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getMcpServers: async () => ({
           github: { url: 'https://github.mcp', tools: [{}, {}, {}] } as any,
         }),
       })
     );
-    const mcpSection = sections.find((s) => s.id === 'mcp')!;
-    expect(mcpSection.count).toBe(1);
-    expect(mcpSection.rows[0].name).toBe('github');
-    expect(mcpSection.rows[0].meta).toBe('3 tools');
+    const integrations = sections.find((s) => s.id === 'integrations')!;
+    expect(integrations.count).toBe(1);
+    expect(integrations.meta).toBe('1 server · 3 tools · 0 accounts valid');
+    expect(integrations.rows[0].name).toBe('github');
+    expect(integrations.rows[0].meta).toBe('MCP · 3 tools');
   });
 
   it('shows OAuth provider rows', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getOAuthProviders: () => [{ providerId: 'adobe' }, { providerId: 'github' }],
       })
     );
-    const oauthSection = sections.find((s) => s.id === 'oauth')!;
-    expect(oauthSection.count).toBe(2);
-    expect(oauthSection.rows[0].name).toBe('adobe');
+    const integrations = sections.find((s) => s.id === 'integrations')!;
+    expect(integrations.count).toBe(2);
+    expect(integrations.rows.map((row) => row.name)).toEqual(['adobe', 'github']);
   });
 
   it('shows a green dot for a valid OAuth account', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getOAuthProviders: () => [{ providerId: 'adobe', valid: true }],
       })
     );
-    const oauthSection = sections.find((s) => s.id === 'oauth')!;
-    expect(oauthSection.rows[0].active).toBe(true);
-    expect(oauthSection.rows[0].error).toBe(false);
+    const integrations = sections.find((s) => s.id === 'integrations')!;
+    expect(integrations.rows[0].status).toBe('active');
+    expect(integrations.status).toBe('active');
   });
 
   it('shows a red dot for an expired/logged-out OAuth account', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getOAuthProviders: () => [{ providerId: 'adobe', valid: false }],
       })
     );
-    const oauthSection = sections.find((s) => s.id === 'oauth')!;
-    expect(oauthSection.rows[0].active).toBe(false);
-    expect(oauthSection.rows[0].error).toBe(true);
+    const integrations = sections.find((s) => s.id === 'integrations')!;
+    expect(integrations.rows[0].status).toBe('error');
+    expect(integrations.rows[0].meta).toBe('session expired');
+    expect(integrations.status).toBe('error');
+    expect(integrations.meta).toContain('1 account expired');
   });
 
   it('shows the default/neutral dot for a non-OAuth (API-key) account', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getOAuthProviders: () => [{ providerId: 'anthropic' }],
       })
     );
-    const oauthSection = sections.find((s) => s.id === 'oauth')!;
-    expect(oauthSection.rows[0].active).toBe(false);
-    expect(oauthSection.rows[0].error).toBe(false);
+    const integrations = sections.find((s) => s.id === 'integrations')!;
+    expect(integrations.rows[0].status).toBe('idle');
+    expect(integrations.status).toBe('active');
   });
 
   it('shows cost section with model breakdown', async () => {
-    const sections = await fetchMonitorData(
+    const sections = await fetchSections(
       makeDeps({
         getSessionStats: async () => ({
           totalCost: 1.23,
@@ -342,38 +370,50 @@ describe('fetchMonitorData', () => {
       })
     );
     const costSection = sections.find((s) => s.id === 'cost')!;
-    expect(costSection.meta).toBe('$1.23');
+    expect(costSection.meta).toBe('$1.23 across 2 models');
     expect(costSection.rows).toHaveLength(2);
     expect(costSection.rows[0].name).toBe('claude-opus-4-6');
     expect(costSection.rows[0].meta).toBe('$0.8500');
   });
 
-  it('shows processes section with pid and argv', async () => {
-    const sections = await fetchMonitorData(
+  it('renders live processes as a real table, with ps column vocabulary', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-24T18:13:00.000Z').getTime());
+    const model = await fetchMonitorData(
       makeDeps({
         getProcesses: async () => ({
           processes: [
-            { pid: 1024, argv: 'node script.js', status: 'running' },
             {
-              pid: 1025,
-              argv: 'python3 -c "print(1234567890123456789012345678901234567890)"',
-              status: 'sleeping',
+              pid: 1024,
+              ppid: 1,
+              argv: 'node script.js',
+              status: 'running',
+              scoop: 'cone',
+              startedAt: new Date('2026-08-24T18:01:00.000Z').getTime(),
             },
+            { pid: 1025, argv: 'rg --json MonitorSection', status: 'pending' },
           ],
           terminated: 0,
         }),
       })
     );
-    const processSection = sections.find((s) => s.id === 'processes')!;
-    expect(processSection.rows).toHaveLength(2);
-    expect(processSection.rows[0].name).toBe('1024');
-    expect(processSection.rows[0].meta).toBe('node script.js');
-    expect(processSection.rows[0].active).toBe(true);
-    expect(processSection.rows[1].meta).toContain('...');
+    expect(model.processes?.rows).toHaveLength(2);
+    expect(model.processes?.rows[0]).toMatchObject({
+      pid: 1024,
+      ppid: 1,
+      state: 'R',
+      status: 'running',
+      command: 'node script.js',
+      scoop: 'cone',
+      elapsed: '12m 0s',
+    });
+    // The command is NOT truncated here: the table gives it a full column and
+    // ellipsizes in CSS, so the model must not pre-cut it to 40 characters.
+    expect(model.processes?.rows[1].command).toBe('rg --json MonitorSection');
+    expect(model.processes?.rows[1].state).toBe('S');
   });
 
   it('reports exited processes as a count, never as rows', async () => {
-    const sections = await fetchMonitorData(
+    const model = await fetchMonitorData(
       makeDeps({
         getProcesses: async () => ({
           processes: [{ pid: 1024, argv: 'node script.js', status: 'running' }],
@@ -381,34 +421,162 @@ describe('fetchMonitorData', () => {
         }),
       })
     );
-    const processSection = sections.find((s) => s.id === 'processes')!;
-    expect(processSection.rows).toHaveLength(1);
-    expect(processSection.count).toBe(1);
-    expect(processSection.meta).toBe('1 live · 1,435 exited');
+    expect(model.processes?.rows).toHaveLength(1);
+    expect(model.processes?.terminated).toBe(1435);
+    expect(model.sections?.some((section) => section.id === 'processes')).toBe(false);
   });
 
-  it('omits the exited count when nothing has exited yet', async () => {
-    const sections = await fetchMonitorData(
-      makeDeps({
-        getProcesses: async () => ({
-          processes: [{ pid: 1024, argv: 'node script.js', status: 'running' }],
-          terminated: 0,
-        }),
-      })
-    );
-    expect(sections.find((s) => s.id === 'processes')!.meta).toBeUndefined();
-  });
-
-  it('degrades to an empty snapshot when the process read fails', async () => {
-    const sections = await fetchMonitorData(
+  it('degrades to an empty table when the process read fails', async () => {
+    const model = await fetchMonitorData(
       makeDeps({
         getProcesses: async () => {
           throw new Error('proc mount unavailable');
         },
       })
     );
-    const processSection = sections.find((s) => s.id === 'processes')!;
-    expect(processSection.rows).toEqual([]);
-    expect(processSection.meta).toBeUndefined();
+    expect(model.processes).toEqual({ rows: [], terminated: 0 });
+  });
+});
+
+describe('buildVitals', () => {
+  const base = {
+    stats: null,
+    workingUnits: 0,
+    totalUnits: 0,
+    liveProcesses: 0,
+    terminated: 0,
+  };
+
+  it('leads with the burn RATE, not a count of tracked things', async () => {
+    const model = await fetchMonitorData(
+      makeDeps({
+        getSessionStats: async () => ({
+          totalCost: 29.06,
+          burnRate: 1.4,
+          models: [],
+          scoops: [],
+        }),
+      })
+    );
+    const hero = model.vitals?.find((vital) => vital.hero);
+    expect(hero).toMatchObject({ id: 'burn', value: '$1.40', unit: '/hour' });
+    expect(hero?.foot).toContain('$29.06 this session');
+    // Exactly one hero — the ≥48px figure only works if it is unique.
+    expect(model.vitals?.filter((vital) => vital.hero)).toHaveLength(1);
+  });
+
+  it('reads $0.00 rather than blank when no stats have landed yet', () => {
+    const [hero] = buildVitals(base);
+    expect(hero.value).toBe('$0.00');
+    expect(hero.foot).toBe('no spend yet');
+  });
+
+  it('drops the decimals on an implausibly large rate rather than overflowing the tile', () => {
+    const [hero] = buildVitals({
+      ...base,
+      stats: { totalCost: 0, burnRate: 1234.5, models: [], scoops: [] },
+    });
+    expect(hero.value).toBe('$1235');
+  });
+
+  it('omits the context meter when there is no fill reading to show', () => {
+    const vitals = buildVitals(base);
+    expect(vitals.find((vital) => vital.id === 'context')).toBeUndefined();
+  });
+
+  it('meters the FULLEST context window, and escalates its accent', () => {
+    const withFills = (fill: number) =>
+      buildVitals({
+        ...base,
+        stats: {
+          totalCost: 0,
+          models: [],
+          scoops: [],
+          fills: [
+            { jid: 'a', fill: 0.1 },
+            { jid: 'b', fill },
+          ],
+        },
+      }).find((vital) => vital.id === 'context');
+
+    expect(withFills(0.42)).toMatchObject({ value: '42', ratio: 0.42, accent: 'green' });
+    expect(withFills(0.75)?.accent).toBe('amber');
+    expect(withFills(0.95)?.accent).toBe('rose');
+  });
+
+  it('carries no series until the history has two points to plot', () => {
+    const history = new MonitorHistory();
+    expect(buildVitals({ ...base, history })[0].series).toBeUndefined();
+    history.push({ at: 1_000, burnRate: 1, workingUnits: 0, liveProcesses: 2 });
+    expect(buildVitals({ ...base, history })[0].series).toBeUndefined();
+    history.push({ at: 6_000, burnRate: 2, workingUnits: 1, liveProcesses: 3 });
+    expect(buildVitals({ ...base, history })[0].series).toEqual([1, 2]);
+  });
+});
+
+describe('buildAlerts', () => {
+  const tray = { role: 'standalone', state: 'inactive' } as const;
+  const base = { tray, followers: [], mounts: [], oauthProviders: [] };
+
+  it('is empty on a healthy system', () => {
+    expect(buildAlerts(base)).toEqual([]);
+  });
+
+  it('names an expired account, and sorts errors above warnings', () => {
+    const alerts = buildAlerts({
+      ...base,
+      oauthProviders: [{ providerId: 'github', valid: false }],
+      mounts: [
+        {
+          targetPath: '/mnt/photos',
+          descriptor: { kind: 'local', mountId: 'm1', idbHandleKey: 'k' },
+          createdAt: 0,
+          valid: false,
+        },
+      ],
+    });
+    expect(alerts.map((alert) => alert.severity)).toEqual(['error', 'warn']);
+    expect(alerts[0].title).toBe('github session expired');
+    expect(alerts[1].title).toBe('/mnt/photos needs re-grant');
+  });
+
+  it('raises a stalled follower but not a healthy one', () => {
+    const alerts = buildAlerts({
+      ...base,
+      followers: [
+        { runtimeId: 'a', health: 'live', peerState: 'connected' },
+        { runtimeId: 'b', health: 'stalled', peerState: 'connected', motd: 'QA iPad' },
+      ],
+    });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toMatchObject({ id: 'follower:b', severity: 'warn', detail: 'QA iPad' });
+  });
+
+  it('raises a reconnecting tray as a warning and a failed one as an error', () => {
+    expect(
+      buildAlerts({ ...base, tray: { role: 'leader', state: 'reconnecting' } })[0]
+    ).toMatchObject({
+      id: 'tray',
+      severity: 'warn',
+    });
+    expect(buildAlerts({ ...base, tray: { role: 'leader', state: 'error' } })[0].severity).toBe(
+      'error'
+    );
+  });
+
+  it('does not raise a valid account or a granted mount', () => {
+    const alerts = buildAlerts({
+      ...base,
+      oauthProviders: [{ providerId: 'anthropic', valid: true }, { providerId: 'xai' }],
+      mounts: [
+        {
+          targetPath: '/mnt/ok',
+          descriptor: { kind: 'local', mountId: 'm1', idbHandleKey: 'k' },
+          createdAt: 0,
+          valid: true,
+        },
+      ],
+    });
+    expect(alerts).toEqual([]);
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-monitor.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-monitor.test.ts
@@ -17,7 +17,7 @@ function makeDeps(overrides: Partial<MonitorDeps> = {}): MonitorDeps {
     getMcpServers: async () => ({}),
     getOAuthProviders: () => [],
     getSessionStats: async () => null,
-    getProcesses: async () => [],
+    getProcesses: async () => ({ processes: [], terminated: 0 }),
     getTrayInfo: () => ({ role: 'standalone', state: 'inactive' }),
     getConnectedFollowers: () => [],
     ...overrides,
@@ -351,14 +351,17 @@ describe('fetchMonitorData', () => {
   it('shows processes section with pid and argv', async () => {
     const sections = await fetchMonitorData(
       makeDeps({
-        getProcesses: async () => [
-          { pid: 1024, argv: 'node script.js', status: 'running' },
-          {
-            pid: 1025,
-            argv: 'python3 -c "print(1234567890123456789012345678901234567890)"',
-            status: 'sleeping',
-          },
-        ],
+        getProcesses: async () => ({
+          processes: [
+            { pid: 1024, argv: 'node script.js', status: 'running' },
+            {
+              pid: 1025,
+              argv: 'python3 -c "print(1234567890123456789012345678901234567890)"',
+              status: 'sleeping',
+            },
+          ],
+          terminated: 0,
+        }),
       })
     );
     const processSection = sections.find((s) => s.id === 'processes')!;
@@ -367,5 +370,45 @@ describe('fetchMonitorData', () => {
     expect(processSection.rows[0].meta).toBe('node script.js');
     expect(processSection.rows[0].active).toBe(true);
     expect(processSection.rows[1].meta).toContain('...');
+  });
+
+  it('reports exited processes as a count, never as rows', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getProcesses: async () => ({
+          processes: [{ pid: 1024, argv: 'node script.js', status: 'running' }],
+          terminated: 1435,
+        }),
+      })
+    );
+    const processSection = sections.find((s) => s.id === 'processes')!;
+    expect(processSection.rows).toHaveLength(1);
+    expect(processSection.count).toBe(1);
+    expect(processSection.meta).toBe('1 live · 1,435 exited');
+  });
+
+  it('omits the exited count when nothing has exited yet', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getProcesses: async () => ({
+          processes: [{ pid: 1024, argv: 'node script.js', status: 'running' }],
+          terminated: 0,
+        }),
+      })
+    );
+    expect(sections.find((s) => s.id === 'processes')!.meta).toBeUndefined();
+  });
+
+  it('degrades to an empty snapshot when the process read fails', async () => {
+    const sections = await fetchMonitorData(
+      makeDeps({
+        getProcesses: async () => {
+          throw new Error('proc mount unavailable');
+        },
+      })
+    );
+    const processSection = sections.find((s) => s.id === 'processes')!;
+    expect(processSection.rows).toEqual([]);
+    expect(processSection.meta).toBeUndefined();
   });
 });

--- a/packages/webcomponents/src/index.ts
+++ b/packages/webcomponents/src/index.ts
@@ -245,9 +245,14 @@ export {
 export { SliccFileTree } from './workbench/slicc-file-tree.js';
 export {
   type MonitorAccent,
+  type MonitorAlert,
+  type MonitorModel,
+  type MonitorProcessRow,
+  type MonitorProcessTable,
   type MonitorRow,
   type MonitorSection,
   type MonitorStatus,
+  type MonitorVital,
   SliccMonitor,
 } from './workbench/slicc-monitor.js';
 export { SliccSurface } from './workbench/slicc-surface.js';

--- a/packages/webcomponents/src/workbench/slicc-monitor.stories.ts
+++ b/packages/webcomponents/src/workbench/slicc-monitor.stories.ts
@@ -1,383 +1,374 @@
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import type { MonitorSection, SliccMonitor } from './slicc-monitor.js';
+import type { MonitorModel, SliccMonitor } from './slicc-monitor.js';
 import './slicc-monitor.js';
 
 interface MonitorArgs {
-  sections?: MonitorSection[];
+  model?: MonitorModel;
 }
 
-const FULLY_POPULATED: MonitorSection[] = [
-  {
-    id: 'followers',
-    label: 'Followers',
-    count: 3,
-    meta: '2 connected · 1 stalled',
-    accent: 'cyan',
-    rows: [
-      {
-        name: 'Lars’s iPhone',
-        sublabel: 'iOS 19 · SliccFollower 1.8',
-        meta: 'connected 8m',
-        icon: 'smartphone',
-        badges: ['browser', 'files', 'camera'],
-        status: 'active',
-      },
-      {
-        name: 'Studio display',
-        sublabel: 'macOS 16 · Slicc CLI',
-        meta: 'connected 42m',
-        icon: 'monitor',
-        badges: ['browser', 'shell', 'clipboard'],
-        status: 'active',
-      },
-      {
-        name: 'QA iPad',
-        sublabel: 'iPadOS 19 · SliccFollower 1.7',
-        meta: 'stalled 2m',
-        icon: 'tablet',
-        badges: ['browser', 'camera'],
-        status: 'warn',
-      },
-    ],
-  },
-  {
-    id: 'scoops',
-    label: 'Scoops',
-    count: 3,
-    meta: '1 working',
-    accent: 'violet',
-    rows: [
-      {
-        name: 'Sliccy',
-        sublabel: 'Cone · primary workspace agent',
-        meta: '12m 18s',
-        icon: 'bot',
-        badges: ['browser', 'shell', 'memory'],
-        status: 'active',
-      },
-      {
-        name: 'Researcher',
-        sublabel: 'Scoop · source gathering',
-        meta: 'idle 4m',
-        icon: 'search',
-        badges: ['web', 'files'],
-        status: 'idle',
-      },
-      {
-        name: 'Verifier',
-        sublabel: 'Scoop · regression review',
-        meta: 'idle 11m',
-        icon: 'shield-check',
-        badges: ['shell', 'tests'],
-        status: 'idle',
-      },
-    ],
-  },
-  {
-    id: 'processes',
-    label: 'Processes',
-    count: 3,
-    meta: '2 running',
-    accent: 'green',
-    rows: [
-      {
-        name: 'Storybook',
-        sublabel: 'storybook dev · port 6006',
-        meta: 'running 18m',
-        icon: 'panels-top-left',
-        badges: ['service'],
-        status: 'active',
-      },
-      {
-        name: 'Browser tests',
-        sublabel: 'vitest · Chromium',
-        meta: 'running 36s',
-        icon: 'flask-conical',
-        badges: ['test'],
-        status: 'active',
-      },
-      {
-        name: 'Build #1842',
-        sublabel: 'webcomponents · completed',
-        meta: '2m ago',
-        icon: 'package-check',
-        badges: ['build'],
-        status: 'idle',
-      },
-    ],
-  },
-  {
-    id: 'automations',
-    label: 'Automations',
-    count: 2,
-    meta: 'next in 3m',
-    accent: 'amber',
-    rows: [
-      {
-        name: 'Health sweep',
-        sublabel: 'Every 5 minutes · cone',
-        meta: 'in 3m',
-        icon: 'heart-pulse',
-        badges: ['cron'],
-        status: 'active',
-      },
-      {
-        name: 'Daily archive',
-        sublabel: 'At 03:00 · workspace',
-        meta: 'in 9h',
-        icon: 'archive',
-        badges: ['cron', 'files'],
-        status: 'idle',
-      },
-    ],
-  },
-  {
-    id: 'integrations',
-    label: 'Integrations',
-    count: 3,
-    meta: '12 capabilities',
-    accent: 'waffle',
-    rows: [
-      {
-        name: 'GitHub',
-        sublabel: 'MCP server · repository access',
-        meta: '6 tools',
-        icon: 'github',
-        badges: ['issues', 'pulls', 'actions'],
-        status: 'active',
-      },
-      {
-        name: 'Workspace',
-        sublabel: 'MCP server · Intent space',
-        meta: '4 tools',
-        icon: 'blocks',
-        badges: ['notes', 'agents'],
-        status: 'active',
-      },
-      {
-        name: 'Cloudflare',
-        sublabel: 'OAuth · tray worker',
-        meta: '2 tools',
-        icon: 'cloud',
-        badges: ['deploy', 'logs'],
-        status: 'idle',
-      },
-    ],
-  },
-  {
-    id: 'cost',
-    label: 'Cost',
-    count: 2,
-    meta: '$1.23 this session',
-    accent: 'rose',
-    rows: [
-      {
-        name: 'claude-opus-4-6',
-        sublabel: '3.8M input · 92K output',
-        meta: '$0.87',
-        icon: 'sparkles',
-        badges: ['reasoning'],
-        status: 'active',
-      },
-      {
-        name: 'claude-sonnet-4-6',
-        sublabel: '1.1M input · 48K output',
-        meta: '$0.36',
-        icon: 'zap',
-        badges: ['fast'],
-        status: 'idle',
-      },
-    ],
-  },
+const BURN = [
+  0.9, 1.1, 0.8, 0.6, 0.7, 1.2, 1.6, 1.5, 1.1, 0.9, 1.0, 1.4, 1.9, 2.1, 1.7, 1.3, 1.1, 1.2, 1.5,
+  1.8, 1.6, 1.3, 1.35, 1.4,
 ];
+const LOAD = [1, 2, 2, 3, 1, 0, 0, 1, 2, 4, 3, 2, 2, 1, 1, 2, 3, 3, 2, 1, 1, 2, 2, 2];
+const PROCS = [4, 7, 9, 6, 3, 2, 8, 12, 15, 11, 9, 6, 5, 9, 14, 18, 16, 12, 9, 7, 11, 13, 14, 9];
 
-const ALL_EMPTY: MonitorSection[] = [
-  {
-    id: 'followers',
-    label: 'Followers',
-    count: 0,
-    rows: [],
-    accent: 'cyan',
-    emptyText: 'Pair a phone, tablet, or CLI follower to lend the cone new capabilities.',
-  },
-  {
-    id: 'scoops',
-    label: 'Scoops',
-    count: 0,
-    rows: [],
-    accent: 'violet',
-    emptyText: 'Delegate a focused task and its scoop will show up here.',
-  },
-  {
-    id: 'processes',
-    label: 'Processes',
-    count: 0,
-    rows: [],
-    accent: 'green',
-    emptyText: 'Commands and background services will appear as they start.',
-  },
-  {
-    id: 'automations',
-    label: 'Automations',
-    count: 0,
-    rows: [],
-    accent: 'amber',
-    emptyText: 'Scheduled tasks and webhook-driven licks will appear here.',
-  },
-  {
-    id: 'integrations',
-    label: 'Integrations',
-    count: 0,
-    rows: [],
-    accent: 'waffle',
-    emptyText: 'Connect an MCP server or account to extend the workspace.',
-  },
-  {
-    id: 'cost',
-    label: 'Cost',
-    count: 0,
-    rows: [],
-    accent: 'rose',
-    emptyText: 'Model usage will be summarized after the first turn.',
-  },
-];
+function vitals(): MonitorModel['vitals'] {
+  return [
+    {
+      id: 'burn',
+      label: 'Burn rate',
+      value: '$1.40',
+      unit: '/hour',
+      hero: true,
+      series: BURN,
+      foot: '$29.06 this session · last 5m',
+    },
+    {
+      id: 'load',
+      label: 'Agent load',
+      value: '2',
+      unit: 'of 4 working',
+      accent: 'violet',
+      series: LOAD,
+      foot: 'last 5m',
+    },
+    {
+      id: 'processes',
+      label: 'Live processes',
+      value: '9',
+      unit: 'processes',
+      accent: 'cyan',
+      series: PROCS,
+      foot: '1,435 exited this session',
+    },
+    {
+      id: 'context',
+      label: 'Context fill',
+      value: '61',
+      unit: '%',
+      ratio: 0.61,
+      accent: 'green',
+      foot: 'fullest of 4 context windows',
+    },
+  ];
+}
 
-const ERROR_HEAVY: MonitorSection[] = [
-  {
-    id: 'followers',
-    label: 'Followers',
-    count: 3,
-    meta: '0 connected · 3 need attention',
-    accent: 'cyan',
+function healthySections(): MonitorModel['sections'] {
+  return [
+    {
+      id: 'tray',
+      label: 'Tray',
+      icon: 'cloud',
+      count: 1,
+      meta: 'leader · connected',
+      accent: 'waffle',
+      status: 'active',
+      rows: [
+        {
+          name: 'Leader',
+          sublabel: 'Session f77471ec · Worker · tray.sliccy.ai',
+          meta: 'connected',
+          badges: ['join URL'],
+          status: 'active',
+        },
+      ],
+    },
+    {
+      id: 'followers',
+      label: 'Followers',
+      icon: 'radio',
+      count: 1,
+      meta: '1 connected',
+      accent: 'cyan',
+      rows: [
+        {
+          name: 'CLI · 2fb161d9',
+          sublabel: 'slicc-cli exec target · trieloff@',
+          meta: 'connected 5h',
+          badges: ['ssh'],
+          status: 'active',
+        },
+      ],
+    },
+    {
+      id: 'scoops',
+      label: 'Scoops',
+      icon: 'bot',
+      count: 4,
+      meta: '4 · 2 working',
+      accent: 'violet',
+      status: 'active',
+      rows: [
+        { name: 'sliccy (cone)', meta: 'working', status: 'active' },
+        { name: 'loose-ends', meta: 'idle', depth: 1 },
+        { name: 'review', meta: 'idle', depth: 1 },
+        { name: 'agent-memory-curator', meta: 'working', status: 'active', depth: 1 },
+      ],
+    },
+    {
+      id: 'mounts',
+      label: 'Mounts',
+      icon: 'hard-drive',
+      count: 2,
+      meta: '2 · all granted',
+      status: 'active',
+      rows: [
+        { name: '/mnt/da-aem', meta: 'da', status: 'idle' },
+        { name: '/mnt/photos', meta: 'local', status: 'active' },
+      ],
+    },
+    {
+      id: 'integrations',
+      label: 'Integrations',
+      icon: 'blocks',
+      count: 6,
+      meta: '3 servers · 12 tools · 3 accounts valid',
+      accent: 'waffle',
+      status: 'active',
+      rows: [
+        { name: 'github', meta: 'MCP · 6 tools', status: 'active' },
+        { name: 'context7', meta: 'MCP · 2 tools', status: 'active' },
+        { name: 'ios-simulator', meta: 'MCP · 4 tools', status: 'active' },
+        { name: 'anthropic', meta: 'account', status: 'active' },
+      ],
+    },
+    {
+      id: 'automations',
+      label: 'Automations',
+      icon: 'calendar-clock',
+      count: 4,
+      meta: '4 webhooks · no cron tasks',
+      accent: 'amber',
+      rows: [
+        { name: 'speck-lick', meta: '→ speck-worker' },
+        { name: 'review-lick', meta: '→ review' },
+      ],
+    },
+    {
+      id: 'cost',
+      label: 'Cost',
+      icon: 'receipt',
+      count: 4,
+      meta: '$29.06 across 4 models',
+      accent: 'rose',
+      rows: [
+        { name: 'claude-opus-5', meta: '$20.3407' },
+        { name: 'grok-4.6', meta: '$1.8534' },
+        { name: 'us.anthropic.claude-opus-4-6', meta: '$1.3633' },
+        { name: 'grok-4.5', meta: '$1.0678' },
+      ],
+    },
+  ];
+}
+
+function processes(): MonitorModel['processes'] {
+  return {
+    terminated: 1435,
     rows: [
       {
-        name: 'Lars’s iPhone',
-        sublabel: 'iOS 19 · heartbeat timed out',
-        meta: 'lost 4m ago',
-        icon: 'smartphone',
-        badges: ['browser', 'camera'],
-        status: 'error',
+        pid: 1,
+        ppid: 0,
+        state: 'R',
+        status: 'running',
+        started: '12:58',
+        elapsed: '5h 15m',
+        scoop: 'system',
+        command: 'kernel',
       },
       {
-        name: 'Studio display',
-        sublabel: 'macOS 16 · reconnecting',
-        meta: 'retry 3 of 5',
-        icon: 'monitor',
-        badges: ['browser', 'shell', 'clipboard'],
-        status: 'warn',
+        pid: 41822,
+        ppid: 1,
+        state: 'R',
+        status: 'running',
+        started: '18:01',
+        elapsed: '12m 18s',
+        scoop: 'cone',
+        command: 'node packages/dev-tools/tools/coverage-ratchet.mjs',
       },
       {
-        name: 'QA iPad',
-        sublabel: 'iPadOS 19 · capability sync stalled',
-        meta: 'stalled 12m',
-        icon: 'tablet',
-        badges: ['browser', 'camera'],
-        status: 'warn',
+        pid: 41830,
+        ppid: 41822,
+        state: 'R',
+        status: 'running',
+        started: '18:01',
+        elapsed: '12m 11s',
+        scoop: 'cone',
+        command: 'vitest run --coverage',
+      },
+      {
+        pid: 41904,
+        ppid: 1,
+        state: 'R',
+        status: 'running',
+        started: '18:09',
+        elapsed: '4m 02s',
+        scoop: '2fb161d9',
+        command: 'slicc-cli exec -- rg --json "MonitorSection"',
+      },
+      {
+        pid: 41911,
+        ppid: 41904,
+        state: 'S',
+        status: 'pending',
+        started: '18:09',
+        elapsed: '4m 01s',
+        scoop: '2fb161d9',
+        command: 'rg --json MonitorSection packages/',
+      },
+      {
+        pid: 42003,
+        ppid: 1,
+        state: 'R',
+        status: 'running',
+        started: '18:11',
+        elapsed: '1m 44s',
+        scoop: 'curator',
+        command: 'python3 -c "import json,sys; …"',
+      },
+      {
+        pid: 42008,
+        ppid: 42003,
+        state: 'S',
+        status: 'pending',
+        started: '18:11',
+        elapsed: '1m 43s',
+        scoop: 'curator',
+        command: 'sleep 120',
+      },
+      {
+        pid: 42044,
+        ppid: 1,
+        state: 'R',
+        status: 'running',
+        started: '18:12',
+        elapsed: '38s',
+        scoop: 'review',
+        command: 'git log --oneline -n 200',
+      },
+      {
+        pid: 42051,
+        ppid: 42044,
+        state: 'R',
+        status: 'running',
+        started: '18:13',
+        elapsed: '6s',
+        scoop: 'review',
+        command: 'gh pr view 2381 --json statusCheckRollup',
       },
     ],
-  },
-  {
-    id: 'processes',
-    label: 'Processes',
-    count: 3,
-    meta: '2 failed · 1 stalled',
-    accent: 'rose',
-    rows: [
-      {
-        name: 'Browser tests',
-        sublabel: 'vitest · Chromium could not launch',
-        meta: 'exit 1',
-        icon: 'flask-conical',
-        badges: ['test'],
-        status: 'error',
-      },
-      {
-        name: 'Tray sync',
-        sublabel: 'worker · request timeout',
-        meta: 'failed 48s ago',
-        icon: 'cloud-off',
-        badges: ['service', 'network'],
-        status: 'error',
-      },
-      {
-        name: 'Storybook',
-        sublabel: 'storybook dev · unresponsive',
-        meta: 'stalled 3m',
-        icon: 'panels-top-left',
-        badges: ['service'],
-        status: 'warn',
-      },
-    ],
-  },
-  {
-    id: 'integrations',
-    label: 'Integrations',
-    count: 2,
-    meta: 'authentication required',
-    accent: 'amber',
-    rows: [
-      {
-        name: 'GitHub',
-        sublabel: 'OAuth session expired',
-        meta: '401',
-        icon: 'github',
-        badges: ['issues', 'pulls'],
-        status: 'error',
-      },
-      {
-        name: 'Cloudflare',
-        sublabel: 'MCP handshake is taking longer than expected',
-        meta: 'retrying',
-        icon: 'cloud',
-        badges: ['deploy', 'logs'],
-        status: 'warn',
-      },
-    ],
-  },
-  {
-    id: 'automations',
-    label: 'Automations',
-    count: 2,
-    meta: 'last sweep incomplete',
-    accent: 'violet',
-    rows: [
-      {
-        name: 'Health sweep',
-        sublabel: 'Last run exceeded its 30 second limit',
-        meta: 'timed out',
-        icon: 'heart-pulse',
-        badges: ['cron'],
-        status: 'error',
-      },
-      {
-        name: 'Daily archive',
-        sublabel: 'Waiting for workspace mount',
-        meta: 'delayed 9m',
-        icon: 'archive',
-        badges: ['cron', 'files'],
-        status: 'warn',
-      },
-    ],
-  },
-];
+  };
+}
+
+const HEALTHY: MonitorModel = {
+  updated: 'Streaming · updated 2s ago',
+  vitals: vitals(),
+  alerts: [],
+  sections: healthySections(),
+  processes: processes(),
+};
+
+function degradedSections(): MonitorModel['sections'] {
+  const sections = healthySections() ?? [];
+  const followers = sections[1];
+  followers.status = 'warn';
+  followers.meta = '1 connected · 1 stalled';
+  followers.rows = [
+    ...followers.rows,
+    {
+      name: 'QA iPad · 9c31f0a2',
+      sublabel: 'iPadOS 19 · SliccFollower 1.7',
+      meta: 'stalled 12m',
+      badges: ['playwright'],
+      status: 'warn',
+    },
+  ];
+
+  const mounts = sections[3];
+  mounts.status = 'warn';
+  mounts.meta = '2 · 1 need re-grant';
+  mounts.rows[1] = { name: '/mnt/photos', meta: 'permission lost', status: 'warn' };
+
+  const integrations = sections[4];
+  integrations.status = 'error';
+  integrations.meta = '3 servers · 12 tools · 1 account expired';
+  integrations.rows[3] = { name: 'github', meta: 'session expired', status: 'error' };
+  return sections;
+}
+
+const DEGRADED: MonitorModel = {
+  updated: 'Streaming · updated 2s ago',
+  vitals: vitals(),
+  alerts: [
+    {
+      id: 'oauth:github',
+      severity: 'error',
+      icon: 'key-round',
+      title: 'github session expired',
+      detail: 'Tool calls through this provider will fail until it is signed in again.',
+    },
+    {
+      id: 'follower:qa-ipad',
+      severity: 'warn',
+      icon: 'radio',
+      title: 'QA iPad stopped answering',
+      detail: 'iPadOS 19 · SliccFollower 1.7',
+      age: 'stalled 12m',
+    },
+    {
+      id: 'mount:/mnt/photos',
+      severity: 'warn',
+      icon: 'folder-lock',
+      title: '/mnt/photos needs re-grant',
+      detail: 'File System Access permission is no longer granted for this handle.',
+    },
+  ],
+  sections: degradedSections(),
+  processes: processes(),
+};
+
+const COLD_START: MonitorModel = {
+  updated: 'Streaming · just started',
+  vitals: [
+    {
+      id: 'burn',
+      label: 'Burn rate',
+      value: '$0.00',
+      unit: '/hour',
+      hero: true,
+      foot: 'no spend yet',
+    },
+    { id: 'load', label: 'Agent load', value: '0', unit: 'of 1 working', accent: 'violet' },
+    { id: 'processes', label: 'Live processes', value: '1', unit: 'process', accent: 'cyan' },
+  ],
+  alerts: [],
+  sections: (healthySections() ?? []).map((section) => ({
+    ...section,
+    count: 0,
+    rows: [],
+    meta: undefined,
+    status: 'idle' as const,
+  })),
+  processes: { rows: [], terminated: 0 },
+};
 
 /**
- * Mount the monitor in a workbench-sized container so the scrollable dashboard
- * reads in its real context (the workbench surface).
+ * Mount the monitor in a workbench-sized container so the panel reads in its
+ * real context. Height is auto: the design's claim is that a healthy system
+ * fits without scrolling, and a fixed frame would hide whether that holds.
  */
-function buildMonitor({ sections = FULLY_POPULATED }: MonitorArgs): HTMLElement {
+function buildMonitor({ model = HEALTHY }: MonitorArgs): HTMLElement {
   const stage = document.createElement('main');
   stage.style.cssText =
     'width:100%;min-height:100vh;padding:24px;box-sizing:border-box;background:var(--bg);';
 
   const container = document.createElement('div');
   container.style.cssText =
-    'width:min(1040px,100%);height:820px;margin:0 auto;border:1px solid var(--line);' +
+    'width:min(1120px,100%);margin:0 auto;border:1px solid var(--line);' +
     'border-radius:16px;overflow:hidden;box-shadow:var(--shadow-pane);box-sizing:border-box;';
 
   const monitor = document.createElement('slicc-monitor') as SliccMonitor;
-  monitor.style.height = '100%';
-  monitor.sections = sections;
+  monitor.model = model;
 
   container.appendChild(monitor);
   stage.appendChild(container);
@@ -396,19 +387,34 @@ export default meta;
 type Story = StoryObj<MonitorArgs>;
 
 /**
- * Review target: a complete two-column dashboard. The Followers card includes
- * connection-age metadata, capability chips, device details, and a stalled row.
+ * A healthy system. Note what is absent: no summed count of unlike things, no
+ * card per resource, no list of dead processes. Attention is one "All clear"
+ * line and every healthy topology group is one line.
  */
-export const FullyPopulated: Story = {
-  args: { sections: FULLY_POPULATED },
+export const Healthy: Story = {
+  args: { model: HEALTHY },
 };
 
-/** Every section uses its own friendly, actionable empty-state message. */
-export const AllEmpty: Story = {
-  args: { sections: ALL_EMPTY },
+/**
+ * Three things wrong. The attention feed leads and names each one; the
+ * topology groups that contain them auto-expand while the healthy ones stay
+ * shut. Every status is carried by glyph shape AND a word — `--amber` is
+ * 2.09:1 on the light surface, so color alone would not clear contrast.
+ */
+export const NeedsAttention: Story = {
+  args: { model: DEGRADED },
 };
 
-/** Dense warning and failure coverage with explicit, readable state labels. */
-export const ErrorHeavy: Story = {
-  args: { sections: ERROR_HEAVY },
+/**
+ * First render of a fresh session: no history to plot, no spend, nothing
+ * mounted. Every tile still reads as a number rather than a blank, and no
+ * sparkline is drawn from a single point.
+ */
+export const ColdStart: Story = {
+  args: { model: COLD_START },
+};
+
+/** Just the process table, at the size a busy session reaches. */
+export const ProcessTable: Story = {
+  args: { model: { updated: 'Streaming', processes: processes() } },
 };

--- a/packages/webcomponents/src/workbench/slicc-monitor.ts
+++ b/packages/webcomponents/src/workbench/slicc-monitor.ts
@@ -17,10 +17,16 @@ export interface MonitorRow {
   sublabel?: string;
   badges?: string[];
   status?: MonitorStatus;
+  /** Indent level inside its group — used for the cone → scoop tree. */
+  depth?: number;
 }
 
 /**
- * A collapsible section in the monitor dashboard with count badge and rows.
+ * A topology group: one named part of the system, its rows, and a status.
+ *
+ * Rendered as a single summary LINE that expands, not as a card. A healthy
+ * group is one line; only groups that need attention open by default. See
+ * the component doc for why.
  */
 export interface MonitorSection {
   id: string;
@@ -30,6 +36,88 @@ export interface MonitorSection {
   meta?: string;
   accent?: MonitorAccent;
   emptyText?: string;
+  icon?: string;
+  /**
+   * Group-level health. When omitted it is derived from the rows — the worst
+   * row status wins — so a caller that already sets row statuses gets the
+   * roll-up for free.
+   */
+  status?: MonitorStatus;
+}
+
+/**
+ * A vitals tile: a rate, a ratio, or a headline figure.
+ *
+ * `series` (a sparkline) and `ratio` (a meter) are mutually exclusive —
+ * a rate over time and a share of a limit are different questions and get
+ * different marks. Exactly one tile per view should set `hero`.
+ */
+export interface MonitorVital {
+  id: string;
+  label: string;
+  value: string;
+  unit?: string;
+  /** Optional comparison line, already formatted (e.g. `▲ 18% vs last hour`). */
+  delta?: string;
+  /** Small print under the mark — the window, the absolute total, the peak. */
+  foot?: string;
+  /** The single ≥48px figure the panel leads with. At most one. */
+  hero?: boolean;
+  /** Time series for a sparkline. Needs at least two points to render. */
+  series?: number[];
+  /** 0..1 fill for a meter. Use for a share of a limit, never for a rate. */
+  ratio?: number;
+  accent?: MonitorAccent;
+}
+
+/**
+ * Something that is degraded, expired, or failing.
+ *
+ * The attention feed is the panel's reason to exist: a count of problems is
+ * a dead end, a list of them with enough detail to act is not.
+ */
+export interface MonitorAlert {
+  id: string;
+  title: string;
+  detail?: string;
+  /** Relative age, already formatted (`12m ago`). */
+  age?: string;
+  icon?: string;
+  severity: 'warn' | 'error';
+}
+
+/** One process in the table. Mirrors the `ps` column vocabulary. */
+export interface MonitorProcessRow {
+  pid: number;
+  ppid?: number;
+  /** procfs state letter — `R` / `S` / `Z` / `K`. */
+  state: string;
+  status: string;
+  command: string;
+  scoop?: string;
+  started?: string;
+  elapsed?: string;
+}
+
+/**
+ * The process table.
+ *
+ * `rows` is LIVE processes only. `terminated` is the session total of
+ * everything that has already exited — reported as a number, never as rows.
+ */
+export interface MonitorProcessTable {
+  rows: MonitorProcessRow[];
+  terminated: number;
+}
+
+/** Everything the panel renders, in one assignment. */
+export interface MonitorModel {
+  vitals?: MonitorVital[];
+  alerts?: MonitorAlert[];
+  sections?: MonitorSection[];
+  processes?: MonitorProcessTable | null;
+  /** Freshness line under the title (`updated 2s ago`). */
+  updated?: string;
 }
 
 const COLLAPSE_KEY = 'slicc_monitor_collapsed';
@@ -57,9 +145,9 @@ function setCollapsed(collapsed: Set<string>): void {
  * injected once into the host document (idempotent) and selected by the host
  * tag + BEM-ish hooks below.
  *
- * Lifted from the prototype monitor panel: a scrollable dashboard of collapsible
- * sections with count badges, status dots (green active, red error, grey default),
- * and a refresh toolbar. All colors come from inherited prototype tokens.
+ * Container queries, not viewport queries: the panel is a dock tile whose
+ * width comes from the layout, not the window, so a viewport query would
+ * leave a half-width tile at four columns.
  */
 const STYLE = `
 slicc-monitor {
@@ -70,369 +158,377 @@ slicc-monitor {
   color: var(--ink);
   background: var(--bg);
   overflow: auto;
-  padding: 16px;
   container: monitor / inline-size;
-  --monitor-border: color-mix(in srgb, var(--line) 55%, var(--ink));
+  --monitor-ok: var(--green);
+  --monitor-warn: var(--waffle);
+  --monitor-bad: var(--red);
 }
-.monitor-summary {
+.dark slicc-monitor,
+[data-theme="dark"] slicc-monitor {
+  /*
+   * Status hues are re-stepped for the dark surface rather than flipped:
+   * --green / --red measure 4.06:1 and 3.14:1 on #161618, both under 4.5:1
+   * for the small status text they carry. These sit at ~6-7:1.
+   */
+  --monitor-ok: #35b45c;
+  --monitor-warn: #e0a03a;
+  --monitor-bad: #ef6a52;
+}
+.monitor {
   display: grid;
-  gap: 16px;
-  padding: 16px;
-  margin: -16px -16px 16px;
-  border-bottom: 1px solid var(--line);
-  background: color-mix(in srgb, var(--canvas) 94%, var(--ctx));
-  box-shadow: var(--shadow-pane);
-  position: sticky;
-  top: -16px;
-  z-index: 2;
+  gap: 18px;
+  padding: 18px;
+  box-sizing: border-box;
 }
-.monitor-summary__topline {
+
+/* header */
+.monitor-head {
   display: flex;
   align-items: center;
   gap: 12px;
 }
-.monitor-summary__mark {
+.monitor-head__mark {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  width: 36px;
+  height: 36px;
   flex: 0 0 auto;
-  border-radius: 12px;
-  color: color-mix(in srgb, var(--ctx) 35%, var(--ink));
-  background: color-mix(in srgb, var(--ctx) 14%, var(--canvas));
-  border: 1px solid color-mix(in srgb, var(--ctx) 28%, var(--monitor-border));
+  border-radius: 11px;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--ctx) 12%, var(--canvas));
+  border: 1px solid color-mix(in srgb, var(--ctx) 26%, var(--line));
 }
-.monitor-summary__copy {
+.monitor-head__copy {
+  flex: 1 1 auto;
   min-width: 0;
 }
-.monitor-summary__title {
+.monitor-head__title {
   margin: 0;
-  color: var(--ink);
-  font-size: 16px;
-  line-height: 1.25;
+  font-size: 15px;
   font-weight: 700;
   letter-spacing: -0.01em;
 }
-.monitor-summary__subtitle {
-  margin: 2px 0 0;
+.monitor-head__sub {
+  margin: 1px 0 0;
+  font-size: 11px;
   color: var(--txt-2);
-  font-size: 12px;
-  line-height: 1.4;
 }
-.monitor-summary__refresh {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  min-height: 40px;
-  margin-left: auto;
-  font-family: var(--ui);
-  font-size: 12px;
-  font-weight: 600;
-  padding: 0 12px;
-  border: 1px solid var(--monitor-border);
-  border-radius: 8px;
-  background: var(--canvas);
-  color: var(--ink);
-  cursor: pointer;
-  transition: background-color 120ms ease, border-color 120ms ease;
-}
-.monitor-summary__refresh:hover {
-  background: var(--ghost);
-}
-.monitor-summary__refresh:active {
-  transform: translateY(1px);
-}
-.monitor-summary__refresh:focus-visible,
-.monitor-section__header:focus-visible {
-  outline: 2px solid var(--ink);
-  outline-offset: 2px;
-}
-.monitor-summary__refresh:disabled,
-.monitor-section__header:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-.monitor-summary__metrics {
+
+/* tier 1 — vitals */
+.monitor-vitals {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 8px;
-  margin: 0;
+  grid-template-columns: 1.6fr 1fr 1fr 1fr;
+  gap: 12px;
 }
-.monitor-summary__metric {
+.monitor-tile {
+  display: grid;
+  grid-template-rows: auto auto 1fr auto;
+  gap: 4px;
+  padding: 14px;
   min-width: 0;
-  padding: 8px 12px;
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--ink) 4%, var(--canvas));
   border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--canvas);
 }
-.monitor-summary__metric dt {
+.monitor-tile--hero {
+  grid-template-rows: auto auto auto 1fr auto;
+  gap: 2px;
+}
+.monitor-tile__label {
+  font-size: 11px;
+  font-weight: 600;
   color: var(--txt-2);
-  font-size: 10px;
-  line-height: 1.4;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
 }
-.monitor-summary__metric dd {
-  margin: 2px 0 0;
+.monitor-tile__figure {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+}
+.monitor-tile__value {
+  font-size: 26px;
+  line-height: 1.15;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+.monitor-tile--hero .monitor-tile__value {
+  font-size: 48px;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+}
+.monitor-tile__unit {
+  font-size: 11px;
+  color: var(--txt-2);
+}
+.monitor-tile--hero .monitor-tile__unit {
+  font-size: 14px;
+}
+.monitor-tile__delta {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--txt-2);
+}
+.monitor-tile__plot {
+  align-self: center;
+  min-width: 0;
+  margin: 6px 0 2px;
+}
+.monitor-tile__plot svg {
+  max-width: 100%;
+  height: auto;
+}
+.monitor-tile__foot {
+  font-size: 10.5px;
+  color: var(--txt-3);
+}
+.monitor-meter {
+  display: block;
+  height: 10px;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--monitor-hue) 16%, var(--canvas));
   overflow: hidden;
-  color: var(--ink);
-  font-size: 15px;
-  line-height: 1.3;
-  font-weight: 700;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
-.monitor-sections {
+.monitor-meter__fill {
+  display: block;
+  height: 100%;
+  border-radius: 5px;
+  background: var(--monitor-hue);
+}
+
+/* blocks */
+.monitor-block {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
-  align-items: start;
-  gap: 16px;
+  gap: 8px;
 }
-.monitor-section {
-  --monitor-accent: var(--ctx);
-  overflow: hidden;
-  border: 1px solid var(--monitor-border);
-  border-radius: 12px;
-  background: var(--canvas);
-  box-shadow: var(--shadow-pane);
-}
-.monitor-section[data-accent='rose'] { --monitor-accent: var(--rose); }
-.monitor-section[data-accent='cyan'] { --monitor-accent: var(--cyan); }
-.monitor-section[data-accent='violet'] { --monitor-accent: var(--violet); }
-.monitor-section[data-accent='amber'] { --monitor-accent: var(--amber); }
-.monitor-section[data-accent='waffle'] { --monitor-accent: var(--waffle); }
-.monitor-section[data-accent='green'] { --monitor-accent: var(--green); }
-.monitor-section--empty .monitor-section__count {
-  background: var(--canvas);
-}
-.monitor-section__header {
-  position: relative;
+.monitor-block__head {
   display: flex;
   align-items: center;
   gap: 8px;
-  width: 100%;
-  min-height: 48px;
-  padding: 8px 12px 8px 16px;
-  border: 0;
-  border-bottom: 1px solid var(--line);
-  border-radius: 0;
-  background: color-mix(in srgb, var(--monitor-accent) 8%, var(--canvas));
-  cursor: pointer;
-  font-family: var(--ui);
-  font-size: 13px;
-  color: var(--ink);
-  transition: background-color 120ms ease;
-  text-align: left;
 }
-.monitor-section__header::before {
-  content: '';
-  position: absolute;
-  inset: 8px auto 8px 0;
-  width: 3px;
-  border-radius: 0 3px 3px 0;
-  background: var(--monitor-accent);
+.monitor-block__title {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--txt-2);
 }
-.monitor-section__header:hover {
-  background: color-mix(in srgb, var(--monitor-accent) 13%, var(--canvas));
+.monitor-block__hint {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--txt-3);
 }
-.monitor-section__toggle {
+.monitor-pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
-  color: var(--txt-3);
-  flex-shrink: 0;
-}
-.monitor-section__heading {
-  display: grid;
-  min-width: 0;
-  gap: 1px;
-}
-.monitor-section__title {
-  font-weight: 600;
-}
-.monitor-section__meta {
-  color: var(--txt-2);
+  min-width: 20px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: 9px;
   font-size: 11px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
 }
-.monitor-section__count {
-  margin-left: auto;
-  flex-shrink: 0;
-  min-width: 24px;
-  background: color-mix(in srgb, var(--monitor-accent) 13%, var(--canvas));
-  border: 1px solid color-mix(in srgb, var(--monitor-accent) 28%, var(--line));
-  border-radius: 12px;
-  padding: 2px 7px;
-  font-size: 11px;
-  font-weight: 600;
-  color: color-mix(in srgb, var(--monitor-accent) 35%, var(--ink));
-  text-align: center;
+.monitor-pill--ok {
+  color: var(--monitor-ok);
+  background: color-mix(in srgb, var(--monitor-ok) 12%, var(--canvas));
 }
-.monitor-section__body {
-  padding: 8px;
+.monitor-pill--warn {
+  color: var(--monitor-warn);
+  background: color-mix(in srgb, var(--monitor-warn) 18%, var(--canvas));
 }
-.monitor-section__body[hidden] {
-  display: none;
+.monitor-pill--error {
+  color: var(--monitor-bad);
+  background: color-mix(in srgb, var(--monitor-bad) 12%, var(--canvas));
 }
-.monitor-section__list {
-  display: grid;
-  gap: 4px;
+
+/*
+ * Status glyphs. The shape varies with the state as well as the hue —
+ * --amber measures 2.09:1 on the light surface, so color alone would not
+ * clear contrast, and every state also carries a word.
+ */
+.monitor-glyph {
+  display: inline-flex;
+  align-items: center;
+}
+.monitor-glyph--active { color: var(--monitor-ok); }
+.monitor-glyph--warn { color: var(--monitor-warn); }
+.monitor-glyph--error { color: var(--monitor-bad); }
+.monitor-glyph--idle { color: var(--txt-3); }
+
+/* tier 2 — attention */
+.monitor-alerts {
+  list-style: none;
   margin: 0;
   padding: 0;
-  list-style: none;
+  display: grid;
+  gap: 6px;
 }
-.monitor-row {
+.monitor-alert {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 12px;
-  min-height: 56px;
-  padding: 8px;
-  border-radius: 8px;
-  transition: background-color 120ms ease;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-left-width: 3px;
+  border-radius: 12px;
+  background: var(--canvas);
 }
-.monitor-row:hover {
-  background: color-mix(in srgb, var(--monitor-accent) 5%, var(--ghost));
-}
-.monitor-row__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  flex: 0 0 auto;
-  border-radius: 8px;
-  color: color-mix(in srgb, var(--monitor-accent) 35%, var(--ink));
-  background: color-mix(in srgb, var(--monitor-accent) 10%, var(--canvas));
-  border: 1px solid color-mix(in srgb, var(--monitor-accent) 20%, var(--line));
-}
-.monitor-row__content {
+.monitor-alert[data-severity="warn"] { border-left-color: var(--monitor-warn); }
+.monitor-alert[data-severity="error"] { border-left-color: var(--monitor-bad); }
+.monitor-alert__icon { display: inline-flex; }
+.monitor-alert__copy {
   display: grid;
+  gap: 1px;
   min-width: 0;
-  gap: 3px;
 }
-.monitor-row__headline {
+.monitor-alert__title {
+  font-size: 12.5px;
+  font-weight: 650;
+}
+.monitor-alert__detail {
+  font-size: 11px;
+  color: var(--txt-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.monitor-alert__age {
+  font-size: 11px;
+  color: var(--txt-3);
+  font-variant-numeric: tabular-nums;
+}
+.monitor-clear {
   display: flex;
   align-items: center;
-  min-width: 0;
-  gap: 6px;
-  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--monitor-ok) 28%, var(--line));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--monitor-ok) 8%, var(--canvas));
+}
+.monitor-clear__title {
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--monitor-ok);
+}
+.monitor-clear__text {
+  font-size: 11.5px;
+  color: var(--txt-2);
+}
+
+/* tier 3a — topology */
+.monitor-groups {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--canvas);
+  overflow: hidden;
+}
+.monitor-group + .monitor-group {
+  border-top: 1px solid var(--line);
+}
+.monitor-row {
+  display: grid;
+  grid-template-columns: auto auto auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 0;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.monitor-row:hover {
+  background: color-mix(in srgb, var(--ink) 3%, var(--canvas));
+}
+.monitor-row__chev,
+.monitor-row__icon {
+  display: inline-flex;
+  color: var(--txt-2);
 }
 .monitor-row__name {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--ink);
-  font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  font-size: 12.5px;
+  font-weight: 650;
 }
-.monitor-row__sublabel {
-  overflow: hidden;
+.monitor-row__summary {
+  font-size: 11.5px;
   color: var(--txt-2);
-  font-size: 11px;
-  line-height: 1.4;
+  overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.monitor-row__badges {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  flex-wrap: wrap;
-}
-.monitor-row__badge {
-  display: inline-flex;
-  align-items: center;
-  min-height: 18px;
-  padding: 1px 6px;
-  border: 1px solid color-mix(in srgb, var(--monitor-accent) 24%, var(--line));
-  border-radius: 9px;
-  color: color-mix(in srgb, var(--monitor-accent) 30%, var(--ink));
-  background: color-mix(in srgb, var(--monitor-accent) 8%, var(--canvas));
-  font-size: 10px;
-  line-height: 1.3;
-  font-weight: 600;
-}
-.monitor-row__aside {
-  display: grid;
-  justify-items: end;
-  min-width: 88px;
-  gap: 3px;
-  text-align: right;
-}
-.monitor-row__meta {
-  color: var(--txt-2);
-  font-size: 11px;
-  line-height: 1.4;
   white-space: nowrap;
 }
 .monitor-row__state {
-  --monitor-status: var(--txt-2);
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  color: var(--monitor-status);
+  font-size: 11px;
+  font-weight: 600;
+}
+.monitor-children {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 6px;
+}
+.monitor-child {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  padding: 5px 12px;
+}
+.monitor-child__copy {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+.monitor-child__headline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.monitor-child__name {
+  font-size: 12px;
+  font-family: var(--mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.monitor-child__sublabel {
+  font-size: 11px;
+  color: var(--txt-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.monitor-child__meta {
+  font-size: 11px;
+  color: var(--txt-2);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.monitor-badge {
+  padding: 1px 6px;
+  border-radius: 6px;
   font-size: 10px;
-  line-height: 1.4;
-  font-weight: 700;
-}
-.monitor-row__state--active {
-  --monitor-status: color-mix(in srgb, var(--green) 35%, var(--ink));
-}
-.monitor-row__state--error {
-  --monitor-status: color-mix(in srgb, var(--red) 35%, var(--ink));
-}
-.monitor-row__state--warn {
-  --monitor-status: color-mix(in srgb, var(--amber) 35%, var(--ink));
-}
-.monitor-row__dot {
-  position: relative;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: currentColor;
-  flex-shrink: 0;
-}
-.monitor-row__state--active .monitor-row__dot::after {
-  content: '';
-  position: absolute;
-  inset: -4px;
-  border: 1px solid currentColor;
-  border-radius: 50%;
-  animation: monitor-pulse 2s ease-out infinite;
-}
-.monitor-row__state--error .monitor-row__dot {
-  border-radius: 2px;
-  transform: rotate(45deg);
-}
-.monitor-row__state--warn .monitor-row__dot {
-  width: 8px;
-  height: 8px;
-  border: 2px solid currentColor;
-  background: transparent;
+  font-weight: 600;
+  color: var(--txt-2);
+  background: var(--ghost);
+  white-space: nowrap;
 }
 .monitor-empty {
   display: grid;
   justify-items: center;
   gap: 4px;
-  padding: 24px 16px;
+  padding: 18px 16px;
   color: var(--txt-2);
   text-align: center;
-}
-.monitor-empty__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  margin-bottom: 4px;
-  border-radius: 12px;
-  color: color-mix(in srgb, var(--monitor-accent) 30%, var(--ink));
-  background: color-mix(in srgb, var(--monitor-accent) 9%, var(--canvas));
 }
 .monitor-empty__title {
   color: var(--ink);
@@ -444,38 +540,161 @@ slicc-monitor {
   font-size: 11px;
   line-height: 1.5;
 }
-@keyframes monitor-pulse {
-  from { opacity: 0.55; transform: scale(0.55); }
-  to { opacity: 0; transform: scale(1.25); }
+
+/* tier 3b — the process table */
+.monitor-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.monitor-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 30px;
+  padding: 0 10px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--ink);
+  background: var(--canvas);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+}
+.monitor-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  color: var(--txt-2);
+  white-space: nowrap;
+}
+.monitor-tablewrap {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--canvas);
+  overflow: auto;
+  max-height: 420px;
+}
+.monitor-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.monitor-th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 8px 10px;
+  text-align: left;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--txt-2);
+  background: var(--canvas);
+  border-bottom: 1px solid var(--line);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.monitor-th:hover { color: var(--ink); }
+.monitor-th__label { margin-right: 4px; }
+.monitor-tr:hover {
+  background: color-mix(in srgb, var(--ink) 3%, var(--canvas));
+}
+.monitor-td {
+  padding: 6px 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--line) 60%, var(--canvas));
+  white-space: nowrap;
+}
+.monitor-td--pid,
+.monitor-td--ppid,
+.monitor-td--started,
+.monitor-td--elapsed {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+.monitor-td--command {
+  width: 100%;
+  max-width: 0;
+  font-family: var(--mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.monitor-statcell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.monitor-stat-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--txt-2);
+  background: var(--ghost);
+}
+.monitor-stat-tag--R {
+  color: var(--monitor-ok);
+  background: color-mix(in srgb, var(--monitor-ok) 13%, var(--canvas));
+}
+.monitor-stat-tag--S {
+  color: var(--cyan);
+  background: color-mix(in srgb, var(--cyan) 15%, var(--canvas));
+}
+.monitor-stat-tag--K {
+  color: var(--monitor-bad);
+  background: color-mix(in srgb, var(--monitor-bad) 12%, var(--canvas));
+}
+.monitor-stat-word {
+  font-size: 11px;
+  color: var(--txt-2);
+}
+.monitor-empty-cell {
+  padding: 18px 12px;
+  color: var(--txt-2);
+  text-align: center;
+  white-space: normal;
+}
+
+/* buttons */
+.monitor-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 26px;
+  padding: 0 10px;
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--ink);
+  background: var(--canvas);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.12s ease;
+}
+.monitor-btn:hover { border-color: var(--txt-3); }
+
+@container monitor (max-width: 940px) {
+  .monitor-vitals { grid-template-columns: 1fr 1fr; }
+  .monitor-tile--hero,
+  .monitor-vitals > :last-child { grid-column: span 2; }
 }
 @container monitor (max-width: 560px) {
-  .monitor-summary__metrics {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-  .monitor-sections {
-    grid-template-columns: 1fr;
-  }
-  .monitor-row {
-    grid-template-columns: auto minmax(0, 1fr);
-  }
-  .monitor-row__aside {
-    grid-column: 2;
-    grid-template-columns: 1fr auto;
-    justify-items: start;
-    min-width: 0;
-    width: 100%;
-    text-align: left;
-  }
+  .monitor-vitals { grid-template-columns: 1fr; }
+  .monitor-tile--hero,
+  .monitor-vitals > :last-child { grid-column: auto; }
+  .monitor-row { grid-template-columns: auto auto minmax(0, 1fr); row-gap: 2px; }
+  .monitor-row__summary,
+  .monitor-row__state { grid-column: 3; justify-self: start; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .monitor-row__state--active .monitor-row__dot::after {
-    animation: none;
-  }
-  .monitor-summary__refresh,
-  .monitor-section__header,
-  .monitor-row {
-    transition-duration: 0.01ms;
-  }
+  .monitor-row,
+  .monitor-btn { transition-duration: 0.01ms; }
 }
 `;
 
@@ -490,6 +709,26 @@ function ensureMonitorStyle(doc: Document): void {
   (doc.head ?? doc.documentElement).appendChild(style);
 }
 
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+
+const STATUS_RANK: Record<MonitorStatus, number> = { error: 3, warn: 2, active: 1, idle: 0 };
+
+const STATUS_GLYPH: Record<MonitorStatus, string> = {
+  active: 'circle-check',
+  warn: 'triangle-alert',
+  error: 'octagon-x',
+  idle: 'circle',
+};
+
+const STATUS_LABEL: Record<MonitorStatus, string> = {
+  active: 'Healthy',
+  warn: 'Attention',
+  error: 'Failing',
+  idle: 'Idle',
+};
+
 function resolveStatus(row: MonitorRow): MonitorStatus {
   if (row.status) return row.status;
   if (row.error) return 'error';
@@ -497,56 +736,240 @@ function resolveStatus(row: MonitorRow): MonitorStatus {
   return 'idle';
 }
 
-function statusLabel(status: MonitorStatus): string {
-  if (status === 'active') return 'Active';
-  if (status === 'error') return 'Error';
-  if (status === 'warn') return 'Warning';
-  return 'Idle';
+/** Group health: explicit if set, otherwise the worst row wins. */
+function sectionStatus(section: MonitorSection): MonitorStatus {
+  if (section.status) return section.status;
+  let worst: MonitorStatus = 'idle';
+  for (const row of section.rows) {
+    const status = resolveStatus(row);
+    if (STATUS_RANK[status] > STATUS_RANK[worst]) worst = status;
+  }
+  return worst;
 }
 
-function createRow(row: MonitorRow): HTMLElement {
-  const status = resolveStatus(row);
-  const badges = h('span', { class: 'monitor-row__badges' });
-  for (const badge of row.badges ?? []) {
-    badges.appendChild(h('span', { class: 'monitor-row__badge' }, badge));
-  }
-
-  const headline = h(
-    'span',
-    { class: 'monitor-row__headline' },
-    h('span', { class: 'monitor-row__name' }, row.name)
-  );
-  if (badges.childElementCount > 0) headline.appendChild(badges);
-
-  const content = h('span', { class: 'monitor-row__content' }, headline);
-  if (row.sublabel) {
-    content.appendChild(h('span', { class: 'monitor-row__sublabel' }, row.sublabel));
-  }
-
+function statusGlyph(status: MonitorStatus): HTMLElement {
   return h(
-    'li',
-    { class: 'monitor-row', 'data-status': status },
-    h('span', { class: 'monitor-row__icon' }, iconEl(row.icon ?? 'box', { size: 16 })),
-    content,
-    h(
-      'span',
-      { class: 'monitor-row__aside' },
-      h('span', { class: 'monitor-row__meta' }, row.meta),
+    'span',
+    { class: `monitor-glyph monitor-glyph--${status}` },
+    iconEl(STATUS_GLYPH[status], { size: 14 })
+  );
+}
+
+const ACCENT_HUE: Record<MonitorAccent, string> = {
+  rose: 'var(--rose)',
+  cyan: 'var(--cyan)',
+  violet: 'var(--violet)',
+  amber: 'var(--amber)',
+  waffle: 'var(--waffle)',
+  green: 'var(--green)',
+};
+
+function accentHue(accent: MonitorAccent | undefined): string {
+  return accent ? ACCENT_HUE[accent] : 'var(--ctx)';
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1 — vitals
+// ---------------------------------------------------------------------------
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+function svgEl(tag: string, attrs: Record<string, string | number>): SVGElement {
+  const el = document.createElementNS(SVG_NS, tag);
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, String(v));
+  return el;
+}
+
+/** Project a series into `x`/`y` pairs inside a `w × h` box with a 3px inset. */
+function projectSeries(series: number[], w: number, h: number): { x: number; y: number }[] {
+  const min = Math.min(...series);
+  const max = Math.max(...series);
+  const span = max - min || 1;
+  const pad = 3;
+  return series.map((v, i) => ({
+    x: pad + (i / (series.length - 1)) * (w - pad * 2),
+    y: h - pad - ((v - min) / span) * (h - pad * 2),
+  }));
+}
+
+/**
+ * A sparkline: a 2px line, a 10%-opacity area wash, and an end marker
+ * carrying a 2px surface ring so it stays legible where it crosses the line.
+ * No axes, no gridlines, no per-point labels.
+ */
+function sparkline(series: number[], hue: string, w: number, h: number): SVGElement {
+  const pts = projectSeries(series, w, h);
+  const line = pts.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+  const last = pts[pts.length - 1];
+  const svg = svgEl('svg', {
+    width: w,
+    height: h,
+    viewBox: `0 0 ${w} ${h}`,
+    'aria-hidden': 'true',
+  });
+  svg.append(
+    svgEl('polygon', {
+      points: `${line} ${w - 3},${h} 3,${h}`,
+      fill: hue,
+      'fill-opacity': '0.1',
+    }),
+    svgEl('polyline', {
+      points: line,
+      fill: 'none',
+      stroke: hue,
+      'stroke-width': '2',
+      'stroke-linejoin': 'round',
+      'stroke-linecap': 'round',
+    }),
+    svgEl('circle', {
+      cx: last.x,
+      cy: last.y,
+      r: '4',
+      fill: hue,
+      stroke: 'var(--canvas)',
+      'stroke-width': '2',
+    })
+  );
+  return svg;
+}
+
+/** The mark for a tile: a sparkline for a rate, a meter for a share. */
+function createVitalPlot(vital: MonitorVital): HTMLElement | null {
+  const hue = accentHue(vital.accent);
+  if (vital.series && vital.series.length > 1) {
+    const size = vital.hero ? { w: 300, h: 56 } : { w: 132, h: 34 };
+    return h('div', { class: 'monitor-tile__plot' }, sparkline(vital.series, hue, size.w, size.h));
+  }
+  if (typeof vital.ratio === 'number') {
+    const pct = Math.max(0, Math.min(1, vital.ratio)) * 100;
+    return h(
+      'div',
+      { class: 'monitor-tile__plot' },
       h(
         'span',
-        { class: `monitor-row__state monitor-row__state--${status}` },
-        h('span', { class: 'monitor-row__dot', 'aria-hidden': 'true' }),
-        statusLabel(status)
+        { class: 'monitor-meter', style: `--monitor-hue:${hue}` },
+        h('span', { class: 'monitor-meter__fill', style: `width:${pct.toFixed(1)}%` })
       )
-    )
+    );
+  }
+  return null;
+}
+
+function createVitalTile(vital: MonitorVital): HTMLElement {
+  const tile = h('section', {
+    class: `monitor-tile${vital.hero ? ' monitor-tile--hero' : ''}`,
+    'data-vital': vital.id,
+  });
+  append(tile, [
+    h('span', { class: 'monitor-tile__label' }, vital.label),
+    h(
+      'div',
+      { class: 'monitor-tile__figure' },
+      h('span', { class: 'monitor-tile__value' }, vital.value),
+      vital.unit ? h('span', { class: 'monitor-tile__unit' }, vital.unit) : null
+    ),
+    vital.delta ? h('span', { class: 'monitor-tile__delta' }, vital.delta) : null,
+    createVitalPlot(vital),
+    vital.foot ? h('span', { class: 'monitor-tile__foot' }, vital.foot) : null,
+  ]);
+  return tile;
+}
+
+function createVitals(vitals: MonitorVital[]): HTMLElement {
+  return h('div', { class: 'monitor-vitals' }, ...vitals.map(createVitalTile));
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2 — attention
+// ---------------------------------------------------------------------------
+
+function createAlert(alert: MonitorAlert): HTMLElement {
+  return h(
+    'li',
+    { class: 'monitor-alert', 'data-severity': alert.severity, 'data-alert': alert.id },
+    h(
+      'span',
+      { class: `monitor-alert__icon monitor-glyph--${alert.severity}` },
+      iconEl(alert.icon ?? STATUS_GLYPH[alert.severity === 'error' ? 'error' : 'warn'], {
+        size: 16,
+      })
+    ),
+    h(
+      'span',
+      { class: 'monitor-alert__copy' },
+      h('span', { class: 'monitor-alert__title' }, alert.title),
+      alert.detail ? h('span', { class: 'monitor-alert__detail' }, alert.detail) : null
+    ),
+    alert.age ? h('span', { class: 'monitor-alert__age' }, alert.age) : null
   );
 }
 
-function createEmptyState(section: MonitorSection): HTMLElement {
+function createAllClear(): HTMLElement {
+  return h(
+    'div',
+    { class: 'monitor-clear', role: 'status' },
+    statusGlyph('active'),
+    h('span', { class: 'monitor-clear__title' }, 'All clear'),
+    h('span', { class: 'monitor-clear__text' }, 'Nothing is stalled, expired, or failing.')
+  );
+}
+
+function createAttention(alerts: MonitorAlert[]): HTMLElement {
+  const severity = alerts.some((a) => a.severity === 'error')
+    ? 'error'
+    : alerts.length > 0
+      ? 'warn'
+      : 'ok';
+  return h(
+    'section',
+    { class: 'monitor-block', 'data-block': 'attention' },
+    h(
+      'div',
+      { class: 'monitor-block__head' },
+      h('h3', { class: 'monitor-block__title' }, 'Needs attention'),
+      h('span', { class: `monitor-pill monitor-pill--${severity}` }, String(alerts.length))
+    ),
+    alerts.length === 0
+      ? createAllClear()
+      : h('ul', { class: 'monitor-alerts' }, ...alerts.map(createAlert))
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tier 3a — topology
+// ---------------------------------------------------------------------------
+
+function createChild(row: MonitorRow): HTMLElement {
+  const status = resolveStatus(row);
+  const headline = h(
+    'span',
+    { class: 'monitor-child__headline' },
+    h('span', { class: 'monitor-child__name' }, row.name)
+  );
+  for (const badge of row.badges ?? []) {
+    headline.appendChild(h('span', { class: 'monitor-badge' }, badge));
+  }
+  const copy = h('span', { class: 'monitor-child__copy' }, headline);
+  if (row.sublabel) {
+    copy.appendChild(h('span', { class: 'monitor-child__sublabel' }, row.sublabel));
+  }
+  return h(
+    'li',
+    {
+      class: 'monitor-child',
+      'data-status': status,
+      style: `padding-left:${28 + (row.depth ?? 0) * 18}px`,
+    },
+    statusGlyph(status),
+    copy,
+    h('span', { class: 'monitor-child__meta' }, row.meta)
+  );
+}
+
+function createGroupEmpty(section: MonitorSection): HTMLElement {
   return h(
     'div',
     { class: 'monitor-empty', role: 'status' },
-    h('span', { class: 'monitor-empty__icon' }, iconEl('inbox', { size: 18 })),
     h('span', { class: 'monitor-empty__title' }, `No ${section.label.toLocaleLowerCase()} yet`),
     h(
       'span',
@@ -556,110 +979,229 @@ function createEmptyState(section: MonitorSection): HTMLElement {
   );
 }
 
-function createSection(
+/**
+ * One topology group as a summary LINE that expands.
+ *
+ * Eight of the panel's groups are inventory — tray, followers, mounts, MCP,
+ * accounts, automations — and inventory that is fine needs one line, not a
+ * card. Groups needing attention open by default; the rest stay closed
+ * unless the reader (or their saved collapse state) says otherwise.
+ */
+function createGroup(
   section: MonitorSection,
   collapsed: Set<string>,
-  onToggle: (id: string) => void,
+  expanded: Set<string>,
+  onToggle: (id: string, wasOpen: boolean) => void,
   bodyId: string
 ): HTMLElement {
-  const isCollapsed = collapsed.has(section.id);
-  const sectionClass =
-    section.count === 0 ? 'monitor-section monitor-section--empty' : 'monitor-section';
+  const status = sectionStatus(section);
+  const attention = status === 'warn' || status === 'error';
+  const open = expanded.has(section.id)
+    ? true
+    : collapsed.has(section.id)
+      ? false
+      : attention && section.rows.length > 0;
 
-  const headerChildren: (string | HTMLElement)[] = [
-    h(
-      'span',
-      { class: 'monitor-section__toggle', 'aria-hidden': 'true' },
-      iconEl(isCollapsed ? 'chevron-right' : 'chevron-down', { size: 15 })
-    ),
-    h(
-      'span',
-      { class: 'monitor-section__heading' },
-      h('span', { class: 'monitor-section__title' }, section.label),
-      section.meta ? h('span', { class: 'monitor-section__meta' }, section.meta) : null
-    ),
-  ];
-
-  headerChildren.push(h('span', { class: 'monitor-section__count' }, String(section.count)));
+  const list = h('ul', { class: 'monitor-children', id: bodyId });
+  if (section.rows.length === 0) list.replaceChildren(createGroupEmpty(section));
+  else list.append(...section.rows.map(createChild));
+  if (!open) list.setAttribute('hidden', '');
 
   const header = h(
     'button',
-    { class: 'monitor-section__header', type: 'button' },
-    ...headerChildren
+    { class: 'monitor-row', type: 'button' },
+    h(
+      'span',
+      { class: 'monitor-row__chev', 'aria-hidden': 'true' },
+      iconEl(open ? 'chevron-down' : 'chevron-right', { size: 15 })
+    ),
+    h('span', { class: 'monitor-row__icon' }, iconEl(section.icon ?? 'box', { size: 16 })),
+    h('span', { class: 'monitor-row__name' }, section.label),
+    h('span', { class: 'monitor-row__summary' }, section.meta ?? `${section.count}`),
+    h(
+      'span',
+      { class: `monitor-row__state monitor-glyph--${status}` },
+      statusGlyph(status),
+      STATUS_LABEL[status]
+    )
   );
-  header.setAttribute('aria-expanded', String(!isCollapsed));
+  header.setAttribute('aria-expanded', String(open));
   header.setAttribute('aria-controls', bodyId);
-  header.addEventListener('click', () => onToggle(section.id));
+  header.addEventListener('click', () => onToggle(section.id, open));
 
-  const body = h('div', { class: 'monitor-section__body', id: bodyId });
-  if (isCollapsed) body.setAttribute('hidden', '');
+  return h(
+    'div',
+    {
+      class: 'monitor-group',
+      'data-section': section.id,
+      'data-status': status,
+      'data-accent': section.accent ?? 'neutral',
+    },
+    header,
+    list
+  );
+}
 
-  if (section.rows.length === 0) {
-    body.appendChild(createEmptyState(section));
-  } else {
-    const list = h('ul', { class: 'monitor-section__list' });
-    for (const row of section.rows) list.appendChild(createRow(row));
-    body.appendChild(list);
+// ---------------------------------------------------------------------------
+// Tier 3b — the process table
+// ---------------------------------------------------------------------------
+
+const PROCESS_COLUMNS = ['pid', 'ppid', 'state', 'started', 'elapsed', 'scoop', 'command'] as const;
+type ProcessColumn = (typeof PROCESS_COLUMNS)[number];
+
+const LIVE_STATES = new Set(['R', 'S']);
+
+function createProcessCell(row: MonitorProcessRow, column: ProcessColumn): HTMLElement {
+  if (column === 'state') {
+    return h(
+      'td',
+      { class: 'monitor-td monitor-td--state' },
+      h(
+        'span',
+        { class: 'monitor-statcell' },
+        h('span', { class: `monitor-stat-tag monitor-stat-tag--${row.state}` }, row.state),
+        h('span', { class: 'monitor-stat-word' }, row.status)
+      )
+    );
   }
+  const value = row[column];
+  return h(
+    'td',
+    { class: `monitor-td monitor-td--${column}` },
+    value == null ? '—' : String(value)
+  );
+}
+
+function createProcessRow(row: MonitorProcessRow): HTMLElement {
+  return h(
+    'tr',
+    {
+      class: 'monitor-tr',
+      'data-pid': String(row.pid),
+      'data-live': String(LIVE_STATES.has(row.state)),
+    },
+    ...PROCESS_COLUMNS.map((column) => createProcessCell(row, column))
+  );
+}
+
+function sortProcesses(
+  rows: MonitorProcessRow[],
+  column: ProcessColumn,
+  descending: boolean
+): MonitorProcessRow[] {
+  return [...rows].sort((a, b) => {
+    const av = a[column];
+    const bv = b[column];
+    const cmp =
+      typeof av === 'number' && typeof bv === 'number'
+        ? av - bv
+        : String(av ?? '').localeCompare(String(bv ?? ''));
+    return descending ? -cmp : cmp;
+  });
+}
+
+interface ProcessViewState {
+  sort: ProcessColumn;
+  descending: boolean;
+  query: string;
+}
+
+function createProcessHeader(state: ProcessViewState, redraw: () => void): HTMLElement {
+  const cells = PROCESS_COLUMNS.map((column) => {
+    const active = state.sort === column;
+    const th = h(
+      'th',
+      { class: `monitor-th monitor-td--${column}`, scope: 'col' },
+      h('span', { class: 'monitor-th__label' }, column.toUpperCase()),
+      active ? iconEl(state.descending ? 'chevron-down' : 'chevron-up', { size: 12 }) : null
+    );
+    th.setAttribute('aria-sort', active ? (state.descending ? 'descending' : 'ascending') : 'none');
+    th.addEventListener('click', () => {
+      state.descending = state.sort === column ? !state.descending : false;
+      state.sort = column;
+      redraw();
+    });
+    return th;
+  });
+  return h('tr', null, ...cells);
+}
+
+function matchesQuery(row: MonitorProcessRow, query: string): boolean {
+  if (!query) return true;
+  return (
+    row.command.toLowerCase().includes(query) ||
+    (row.scoop ?? '').toLowerCase().includes(query) ||
+    String(row.pid).includes(query)
+  );
+}
+
+/**
+ * The process table.
+ *
+ * The one part of the panel that is genuinely a table and should not share
+ * the topology vocabulary. Sortable on every column, filterable, and the
+ * exited count rides in the header rather than becoming thousands of rows —
+ * the same call `ps` makes by default.
+ */
+function createProcesses(table: MonitorProcessTable): HTMLElement {
+  const state: ProcessViewState = { sort: 'pid', descending: false, query: '' };
+  const search = h('input', {
+    class: 'monitor-input',
+    type: 'search',
+    'aria-label': 'Filter processes',
+    placeholder: 'Filter command, scoop, or pid…',
+  }) as HTMLInputElement;
+  const thead = h('thead');
+  const tbody = h('tbody');
+  const hint = h('span', { class: 'monitor-block__hint' });
+
+  const redraw = (): void => {
+    const rows = sortProcesses(table.rows, state.sort, state.descending).filter((row) =>
+      matchesQuery(row, state.query)
+    );
+    thead.replaceChildren(createProcessHeader(state, redraw));
+    if (rows.length === 0) {
+      // A bare header over nothing reads as a broken table. Say which of the
+      // two empty states this is — nothing running, or nothing matching.
+      const cell = h('td', {
+        class: 'monitor-td monitor-empty-cell',
+        colspan: PROCESS_COLUMNS.length,
+      });
+      cell.textContent = state.query
+        ? `No live process matches “${state.query}”.`
+        : 'No processes running.';
+      tbody.replaceChildren(h('tr', { class: 'monitor-tr' }, cell));
+    } else {
+      tbody.replaceChildren(...rows.map(createProcessRow));
+    }
+    const exited =
+      table.terminated > 0 ? ` · ${table.terminated.toLocaleString()} exited this session` : '';
+    hint.replaceChildren(document.createTextNode(`${table.rows.length} live${exited}`));
+  };
+
+  search.addEventListener('input', () => {
+    state.query = search.value.trim().toLowerCase();
+    redraw();
+  });
+  redraw();
 
   return h(
     'section',
-    { class: sectionClass, 'data-section': section.id, 'data-accent': section.accent ?? 'neutral' },
-    header,
-    body
-  );
-}
-
-function createMetric(label: string, value: string): HTMLElement {
-  return h('div', { class: 'monitor-summary__metric' }, h('dt', null, label), h('dd', null, value));
-}
-
-function createSummary(sections: MonitorSection[], onRefresh: () => void): HTMLElement {
-  const rows = sections.flatMap((section) => section.rows);
-  const active = rows.filter((row) => resolveStatus(row) === 'active').length;
-  const attention = rows.filter((row) => ['warn', 'error'].includes(resolveStatus(row))).length;
-  const tracked = sections.reduce(
-    (total, section) => total + (section.id === 'cost' ? 0 : section.count),
-    0
-  );
-  const cost = sections.find((section) => section.id === 'cost')?.meta ?? '—';
-  const refresh = h(
-    'button',
-    { class: 'monitor-summary__refresh', type: 'button', 'aria-label': 'Refresh monitor data' },
-    iconEl('refresh-cw', { size: 15 }),
-    h('span', null, 'Refresh')
-  );
-  refresh.addEventListener('click', onRefresh);
-
-  return h(
-    'header',
-    { class: 'monitor-summary' },
+    { class: 'monitor-block', 'data-block': 'processes' },
     h(
       'div',
-      { class: 'monitor-summary__topline' },
-      h('span', { class: 'monitor-summary__mark' }, iconEl('activity', { size: 19 })),
-      h(
-        'div',
-        { class: 'monitor-summary__copy' },
-        h('h2', { class: 'monitor-summary__title' }, 'Live monitor'),
-        h(
-          'p',
-          { class: 'monitor-summary__subtitle' },
-          'System activity and connections at a glance'
-        )
-      ),
-      refresh
+      { class: 'monitor-block__head' },
+      h('h3', { class: 'monitor-block__title' }, 'Processes'),
+      hint
     ),
-    h(
-      'dl',
-      { class: 'monitor-summary__metrics' },
-      createMetric('Tracked', String(tracked)),
-      createMetric('Active', String(active)),
-      createMetric('Attention', String(attention)),
-      createMetric('Session cost', cost)
-    )
+    h('div', { class: 'monitor-toolbar' }, search),
+    h('div', { class: 'monitor-tablewrap' }, h('table', { class: 'monitor-table' }, thead, tbody))
   );
 }
+
+// ---------------------------------------------------------------------------
+// Element
+// ---------------------------------------------------------------------------
 
 function cloneSection(section: MonitorSection): MonitorSection {
   return {
@@ -671,22 +1213,37 @@ function cloneSection(section: MonitorSection): MonitorSection {
 let monitorInstance = 0;
 
 /**
- * `<slicc-monitor>` — the monitor dashboard from the workbench. A scrollable
- * panel of collapsible sections showing scoops, processes, cron tasks, webhooks,
- * mounts, MCP servers, OAuth providers, workflows, and cost. Each section has a
- * count badge and status-dot rows (green active, red error, grey default).
+ * `<slicc-monitor>` — the workbench monitor panel.
  *
- * Light DOM (no shadow root): the host renders its toolbar and sections into
- * itself so the host app can style and slot content. The scoped stylesheet is
- * injected once into the host document.
+ * Three tiers, deliberately in three different visual vocabularies, because
+ * they answer three different questions:
+ *
+ *  1. **Vitals** — rates and ratios over time (hero figure, stat tiles with
+ *     sparklines, a meter). The only tier with a time axis, and the only
+ *     honest answer to "how hard is this thing working".
+ *  2. **Attention** — what is degraded, newest first. A count of problems is
+ *     a dead end; this is the list it should have expanded into. Healthy
+ *     state is a single "All clear" line.
+ *  3. **Body** — topology (small, stable, named things; healthy groups
+ *     collapse to one line) and a sortable, filterable process table. These
+ *     are not the same shape and do not share chrome.
+ *
+ * Status never rides on hue alone: every state carries a shape-varied glyph
+ * AND a word, because `--amber` measures 2.09:1 on the light surface.
+ *
+ * Light DOM (no shadow root): the host renders into itself so the host app
+ * can style and slot content. The scoped stylesheet is injected once into
+ * the host document.
  *
  * Collapse state persists in localStorage (`slicc_monitor_collapsed`).
  *
- * @fires slicc-monitor-refresh - the refresh button was clicked
+ * @fires slicc-monitor-refresh - the re-sync button was clicked
  */
 export class SliccMonitor extends HTMLElement {
-  #sections: MonitorSection[] = [];
+  #model: MonitorModel = {};
   #collapsed = new Set<string>();
+  /** Groups the reader opened this session, overriding the auto-collapse. */
+  #expanded = new Set<string>();
   #initialized = false;
   readonly #instanceId = ++monitorInstance;
 
@@ -696,49 +1253,127 @@ export class SliccMonitor extends HTMLElement {
       this.#collapsed = getCollapsed();
       this.#initialized = true;
     }
-    if (this.#sections.length > 0) this.#render();
+    this.#render();
   }
 
-  /** The monitor sections (returns a copy). */
-  get sections(): MonitorSection[] {
-    return this.#sections.map(cloneSection);
+  /** The full panel model (returns a copy). */
+  get model(): MonitorModel {
+    return {
+      ...this.#model,
+      vitals: this.#model.vitals?.map((v) => ({ ...v, series: v.series?.slice() })),
+      alerts: this.#model.alerts?.map((a) => ({ ...a })),
+      sections: this.#model.sections?.map(cloneSection),
+      processes: this.#model.processes
+        ? { ...this.#model.processes, rows: this.#model.processes.rows.map((r) => ({ ...r })) }
+        : this.#model.processes,
+    };
   }
 
-  set sections(value: MonitorSection[]) {
-    this.#sections = Array.isArray(value) ? value.map(cloneSection) : [];
+  set model(value: MonitorModel) {
+    this.#model = value ?? {};
     if (this.isConnected) this.#render();
   }
 
-  #render(): void {
-    const summary = createSummary(this.#sections, () => {
+  /** The topology groups (returns a copy). */
+  get sections(): MonitorSection[] {
+    return (this.#model.sections ?? []).map(cloneSection);
+  }
+
+  set sections(value: MonitorSection[]) {
+    this.#model = {
+      ...this.#model,
+      sections: Array.isArray(value) ? value.map(cloneSection) : [],
+    };
+    if (this.isConnected) this.#render();
+  }
+
+  #createHeader(): HTMLElement {
+    const refresh = h(
+      'button',
+      { class: 'monitor-btn', type: 'button', 'aria-label': 'Re-sync monitor data' },
+      iconEl('refresh-cw', { size: 14 }),
+      h('span', null, 'Re-sync')
+    );
+    refresh.addEventListener('click', () => {
       this.dispatchEvent(
-        new CustomEvent('slicc-monitor-refresh', {
-          bubbles: true,
-          composed: true,
-        })
+        new CustomEvent('slicc-monitor-refresh', { bubbles: true, composed: true })
       );
     });
-    const sections = h('div', { class: 'monitor-sections' });
+    return h(
+      'header',
+      { class: 'monitor-head' },
+      h('span', { class: 'monitor-head__mark' }, iconEl('activity', { size: 18 })),
+      h(
+        'div',
+        { class: 'monitor-head__copy' },
+        h('h2', { class: 'monitor-head__title' }, 'Live monitor'),
+        h('p', { class: 'monitor-head__sub' }, this.#model.updated ?? 'Streaming')
+      ),
+      refresh
+    );
+  }
 
-    for (const section of this.#sections) {
+  #createTopology(sections: MonitorSection[]): HTMLElement {
+    const groups = h('div', { class: 'monitor-groups' });
+    for (const section of sections) {
       const safeId = section.id.replace(/[^a-z0-9_-]/gi, '-');
-      sections.appendChild(
-        createSection(
+      groups.appendChild(
+        createGroup(
           section,
           this.#collapsed,
-          (id: string) => {
-            if (this.#collapsed.has(id)) this.#collapsed.delete(id);
-            else this.#collapsed.add(id);
-            setCollapsed(this.#collapsed);
-            this.#render();
-          },
+          this.#expanded,
+          (id: string, wasOpen: boolean) => this.#toggle(id, wasOpen),
           `monitor-${this.#instanceId}-${safeId}`
         )
       );
     }
+    return h(
+      'section',
+      { class: 'monitor-block', 'data-block': 'topology' },
+      h(
+        'div',
+        { class: 'monitor-block__head' },
+        h('h3', { class: 'monitor-block__title' }, 'Topology'),
+        h('span', { class: 'monitor-block__hint' }, 'healthy groups stay collapsed')
+      ),
+      groups
+    );
+  }
 
-    this.replaceChildren();
-    append(this, [summary, sections]);
+  /**
+   * Toggle a group, keyed off what the reader can actually SEE rather than
+   * off set membership — a degraded group opens automatically without being
+   * in either set, so membership alone would make the first click on it a
+   * no-op that re-opened what the reader just tried to shut.
+   *
+   * The two sets are not redundant: `#collapsed` persists an explicit "keep
+   * this shut" across sessions, while `#expanded` holds a this-session "keep
+   * this open" that has to outrank the automatic collapse a healthy group
+   * would otherwise get on the next 5s re-render.
+   */
+  #toggle(id: string, wasOpen: boolean): void {
+    if (wasOpen) {
+      this.#expanded.delete(id);
+      this.#collapsed.add(id);
+    } else {
+      this.#collapsed.delete(id);
+      this.#expanded.add(id);
+    }
+    setCollapsed(this.#collapsed);
+    this.#render();
+  }
+
+  #render(): void {
+    const { vitals = [], alerts, sections = [], processes } = this.#model;
+    const panel = h('div', { class: 'monitor' });
+    append(panel, [
+      this.#createHeader(),
+      vitals.length > 0 ? createVitals(vitals) : null,
+      alerts ? createAttention(alerts) : null,
+      sections.length > 0 ? this.#createTopology(sections) : null,
+      processes ? createProcesses(processes) : null,
+    ]);
+    this.replaceChildren(panel);
   }
 }
 

--- a/packages/webcomponents/tests/workbench/slicc-monitor.test.ts
+++ b/packages/webcomponents/tests/workbench/slicc-monitor.test.ts
@@ -1,12 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ensureGlobalTokens, setTheme } from '../../src/theme/tokens.js';
-import { type MonitorSection, SliccMonitor } from '../../src/workbench/slicc-monitor.js';
+import {
+  type MonitorModel,
+  type MonitorSection,
+  SliccMonitor,
+} from '../../src/workbench/slicc-monitor.js';
 
-function mount(sections?: MonitorSection[]): SliccMonitor {
+function mount(model?: MonitorModel): SliccMonitor {
   const el = document.createElement('slicc-monitor') as SliccMonitor;
-  if (sections) el.sections = sections;
+  if (model) el.model = model;
   document.body.appendChild(el);
   return el;
+}
+
+function mountSections(sections: MonitorSection[]): SliccMonitor {
+  return mount({ sections });
 }
 
 const SAMPLE_SECTIONS: MonitorSection[] = [
@@ -14,29 +22,32 @@ const SAMPLE_SECTIONS: MonitorSection[] = [
     id: 'scoops',
     label: 'Scoops',
     count: 2,
-    meta: '1 working',
+    meta: '2 · 1 working',
     accent: 'violet',
+    icon: 'bot',
+    status: 'active',
     rows: [
       {
         name: 'sliccy (cone)',
-        meta: 'processing',
+        meta: 'working',
         active: true,
         icon: 'bot',
         sublabel: 'Cone · primary workspace agent',
         badges: ['browser', 'shell'],
       },
-      { name: 'researcher', meta: 'idle' },
+      { name: 'researcher', meta: 'idle', depth: 1 },
     ],
   },
   {
-    id: 'cron',
-    label: 'Cron Tasks',
+    id: 'automations',
+    label: 'Automations',
     count: 1,
+    meta: '0 webhooks · 1 cron task',
     rows: [{ name: 'daily-backup', meta: '0 3 * * *', active: true }],
   },
   {
-    id: 'webhooks',
-    label: 'Webhooks',
+    id: 'integrations',
+    label: 'Integrations',
     count: 0,
     rows: [],
     emptyText: 'Connect a webhook to receive external events.',
@@ -56,209 +67,467 @@ describe('slicc-monitor', () => {
   });
 
   it('renders into light DOM (no shadow root)', () => {
-    const el = mount(SAMPLE_SECTIONS);
+    const el = mountSections(SAMPLE_SECTIONS);
     expect(el.shadowRoot).toBeNull();
+    expect(el.querySelector('.monitor')).not.toBeNull();
   });
 
-  it('renders a section per entry with correct data-section', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    const sections = el.querySelectorAll('[data-section]');
-    expect(sections).toHaveLength(3);
-    expect(sections[0].getAttribute('data-section')).toBe('scoops');
-    expect(sections[1].getAttribute('data-section')).toBe('cron');
-    expect(sections[2].getAttribute('data-section')).toBe('webhooks');
+  it('renders nothing but the header for an empty model', () => {
+    const el = mount({});
+    expect(el.querySelector('.monitor-head')).not.toBeNull();
+    expect(el.querySelector('.monitor-vitals')).toBeNull();
+    expect(el.querySelector('[data-block="attention"]')).toBeNull();
+    expect(el.querySelector('[data-block="topology"]')).toBeNull();
+    expect(el.querySelector('[data-block="processes"]')).toBeNull();
+  });
+});
+
+describe('slicc-monitor — vitals', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    setTheme('light');
+    document.body.replaceChildren();
+    localStorage.removeItem('slicc_monitor_collapsed');
   });
 
-  it('renders rows with name and meta text', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    const rows = el.querySelectorAll('[data-section="scoops"] .monitor-row');
-    expect(rows).toHaveLength(2);
-    expect(rows[0].querySelector('.monitor-row__name')!.textContent).toBe('sliccy (cone)');
-    expect(rows[0].querySelector('.monitor-row__meta')!.textContent).toBe('processing');
-    expect(rows[1].querySelector('.monitor-row__name')!.textContent).toBe('researcher');
+  it('renders a tile per vital, with value and unit', () => {
+    const el = mount({
+      vitals: [
+        { id: 'burn', label: 'Burn rate', value: '$1.40', unit: '/hour', hero: true },
+        { id: 'load', label: 'Agent load', value: '2', unit: 'of 6 working' },
+      ],
+    });
+    const tiles = el.querySelectorAll('.monitor-tile');
+    expect(tiles).toHaveLength(2);
+    expect(tiles[0].querySelector('.monitor-tile__value')?.textContent).toBe('$1.40');
+    expect(tiles[0].querySelector('.monitor-tile__unit')?.textContent).toBe('/hour');
   });
 
-  it('renders rich row icons, sublabels, and capability badges', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    const row = el.querySelector('[data-section="scoops"] .monitor-row')!;
-    expect(row.tagName).toBe('LI');
-    expect(row.querySelector('.monitor-row__icon svg')).not.toBeNull();
-    expect(row.querySelector('.monitor-row__sublabel')!.textContent).toBe(
+  it('marks the hero tile so it gets the large figure', () => {
+    const el = mount({
+      vitals: [
+        { id: 'burn', label: 'Burn', value: '$1.40', hero: true },
+        { id: 'load', label: 'Load', value: '2' },
+      ],
+    });
+    const hero = el.querySelector('.monitor-tile--hero') as HTMLElement;
+    expect(hero.dataset.vital).toBe('burn');
+    const heroSize = getComputedStyle(hero.querySelector('.monitor-tile__value')!).fontSize;
+    const plainSize = getComputedStyle(
+      el.querySelector('.monitor-tile:not(.monitor-tile--hero) .monitor-tile__value')!
+    ).fontSize;
+    expect(Number.parseFloat(heroSize)).toBeGreaterThan(Number.parseFloat(plainSize));
+    expect(Number.parseFloat(heroSize)).toBeGreaterThanOrEqual(48);
+  });
+
+  it('plots a sparkline for a series', () => {
+    const el = mount({
+      vitals: [{ id: 'burn', label: 'Burn', value: '$1.40', series: [1, 2, 1.5, 3] }],
+    });
+    const svg = el.querySelector('.monitor-tile__plot svg');
+    expect(svg).not.toBeNull();
+    expect(svg?.querySelector('polyline')).not.toBeNull();
+    // The end marker carries a surface ring so it stays legible over the line.
+    expect(svg?.querySelector('circle')?.getAttribute('stroke')).toBe('var(--canvas)');
+  });
+
+  it('plots no sparkline below two points — one point is not a trend', () => {
+    const el = mount({ vitals: [{ id: 'burn', label: 'Burn', value: '$1.40', series: [1] }] });
+    expect(el.querySelector('.monitor-tile__plot')).toBeNull();
+  });
+
+  it('renders a meter for a ratio, clamped to 0..1', () => {
+    const el = mount({
+      vitals: [
+        { id: 'a', label: 'A', value: '61', ratio: 0.61 },
+        { id: 'b', label: 'B', value: '200', ratio: 2 },
+        { id: 'c', label: 'C', value: '-5', ratio: -0.5 },
+      ],
+    });
+    const fills = el.querySelectorAll<HTMLElement>('.monitor-meter__fill');
+    expect(fills[0].style.width).toBe('61%');
+    expect(fills[1].style.width).toBe('100%');
+    expect(fills[2].style.width).toBe('0%');
+  });
+
+  it('prefers the sparkline when a vital carries both a series and a ratio', () => {
+    const el = mount({
+      vitals: [{ id: 'a', label: 'A', value: '1', series: [1, 2], ratio: 0.5 }],
+    });
+    expect(el.querySelector('.monitor-tile__plot svg')).not.toBeNull();
+    expect(el.querySelector('.monitor-meter')).toBeNull();
+  });
+});
+
+describe('slicc-monitor — attention', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    setTheme('light');
+    document.body.replaceChildren();
+    localStorage.removeItem('slicc_monitor_collapsed');
+  });
+
+  it('shows an all-clear line when there is nothing wrong', () => {
+    const el = mount({ alerts: [] });
+    expect(el.querySelector('.monitor-clear')).not.toBeNull();
+    expect(el.querySelector('.monitor-alert')).toBeNull();
+    expect(el.querySelector('.monitor-pill--ok')?.textContent).toBe('0');
+  });
+
+  it('renders one row per alert, with title, detail, and age', () => {
+    const el = mount({
+      alerts: [
+        {
+          id: 'oauth:github',
+          severity: 'error',
+          title: 'github session expired',
+          detail: 'Tool calls will fail',
+          age: '2m ago',
+        },
+      ],
+    });
+    const alert = el.querySelector('.monitor-alert') as HTMLElement;
+    expect(alert.dataset.severity).toBe('error');
+    expect(alert.querySelector('.monitor-alert__title')?.textContent).toBe(
+      'github session expired'
+    );
+    expect(alert.querySelector('.monitor-alert__detail')?.textContent).toBe('Tool calls will fail');
+    expect(alert.querySelector('.monitor-alert__age')?.textContent).toBe('2m ago');
+  });
+
+  it('escalates the count pill to the worst severity present', () => {
+    const warn = mount({ alerts: [{ id: 'a', severity: 'warn', title: 'a' }] });
+    expect(warn.querySelector('.monitor-pill--warn')?.textContent).toBe('1');
+    document.body.replaceChildren();
+    const error = mount({
+      alerts: [
+        { id: 'a', severity: 'warn', title: 'a' },
+        { id: 'b', severity: 'error', title: 'b' },
+      ],
+    });
+    expect(error.querySelector('.monitor-pill--error')?.textContent).toBe('2');
+  });
+
+  it('omits the block entirely when alerts are not supplied', () => {
+    const el = mount({ sections: SAMPLE_SECTIONS });
+    expect(el.querySelector('[data-block="attention"]')).toBeNull();
+  });
+});
+
+describe('slicc-monitor — topology', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    setTheme('light');
+    document.body.replaceChildren();
+    localStorage.removeItem('slicc_monitor_collapsed');
+  });
+
+  it('renders a group per section with its id and status', () => {
+    const el = mountSections(SAMPLE_SECTIONS);
+    const groups = el.querySelectorAll<HTMLElement>('.monitor-group');
+    expect(groups).toHaveLength(3);
+    expect([...groups].map((g) => g.dataset.section)).toEqual([
+      'scoops',
+      'automations',
+      'integrations',
+    ]);
+  });
+
+  it('shows the summary line, not a bare count', () => {
+    const el = mountSections(SAMPLE_SECTIONS);
+    const summaries = el.querySelectorAll('.monitor-row__summary');
+    expect(summaries[0].textContent).toBe('2 · 1 working');
+  });
+
+  it('renders rows with name, meta, sublabel, and badges', () => {
+    const el = mountSections(SAMPLE_SECTIONS);
+    const child = el.querySelector('.monitor-child') as HTMLElement;
+    expect(child.querySelector('.monitor-child__name')?.textContent).toBe('sliccy (cone)');
+    expect(child.querySelector('.monitor-child__meta')?.textContent).toBe('working');
+    expect(child.querySelector('.monitor-child__sublabel')?.textContent).toBe(
       'Cone · primary workspace agent'
     );
-    expect(
-      [...row.querySelectorAll('.monitor-row__badge')].map((badge) => badge.textContent)
-    ).toEqual(['browser', 'shell']);
-  });
-
-  it('applies active dot class for active rows', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    const states = el.querySelectorAll('[data-section="scoops"] .monitor-row__state');
-    expect(states[0].classList.contains('monitor-row__state--active')).toBe(true);
-    expect(states[0].textContent).toContain('Active');
-    expect(states[1].classList.contains('monitor-row__state--idle')).toBe(true);
-    expect(states[1].textContent).toContain('Idle');
-  });
-
-  it('applies error dot class for error rows', () => {
-    const el = mount([
-      {
-        id: 'err',
-        label: 'Errors',
-        count: 1,
-        rows: [{ name: 'broken', meta: 'err', error: true }],
-      },
+    expect([...child.querySelectorAll('.monitor-badge')].map((b) => b.textContent)).toEqual([
+      'browser',
+      'shell',
     ]);
-    const state = el.querySelector('.monitor-row__state--error');
-    expect(state).not.toBeNull();
-    expect(state!.textContent).toContain('Error');
   });
 
-  it('renders explicit warning status ahead of legacy booleans', () => {
-    const el = mount([
-      {
-        id: 'warn',
-        label: 'Warnings',
-        count: 1,
-        rows: [{ name: 'stalled', meta: '2m', active: true, status: 'warn' }],
-      },
-    ]);
-    const row = el.querySelector('.monitor-row')!;
-    expect(row.getAttribute('data-status')).toBe('warn');
-    expect(row.querySelector('.monitor-row__state--warn')!.textContent).toContain('Warning');
-  });
-
-  it('marks empty sections with --empty modifier', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    const empty = el.querySelector('[data-section="webhooks"]');
-    expect(empty!.classList.contains('monitor-section--empty')).toBe(true);
-    const notEmpty = el.querySelector('[data-section="scoops"]');
-    expect(notEmpty!.classList.contains('monitor-section--empty')).toBe(false);
-  });
-
-  it('renders custom friendly empty-state copy', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    const empty = el.querySelector('[data-section="webhooks"] .monitor-empty')!;
-    expect(empty.getAttribute('role')).toBe('status');
-    expect(empty.querySelector('.monitor-empty__title')!.textContent).toBe('No webhooks yet');
-    expect(empty.querySelector('.monitor-empty__text')!.textContent).toBe(
-      'Connect a webhook to receive external events.'
+  it('indents a nested row so the cone → scoop tree reads as one', () => {
+    const el = mountSections(SAMPLE_SECTIONS);
+    const children = el.querySelectorAll<HTMLElement>('.monitor-child');
+    expect(Number.parseFloat(getComputedStyle(children[1]).paddingLeft)).toBeGreaterThan(
+      Number.parseFloat(getComputedStyle(children[0]).paddingLeft)
     );
   });
 
-  it('applies the section accent hook', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    expect(el.querySelector('[data-section="scoops"]')!.getAttribute('data-accent')).toBe('violet');
-  });
-
-  it('shows count badges', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    const counts = el.querySelectorAll('.monitor-section__count');
-    expect(counts[0].textContent).toBe('2');
-    expect(counts[1].textContent).toBe('1');
-    expect(counts[2].textContent).toBe('0');
-  });
-
-  it('renders a refresh button in toolbar', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    const btn = el.querySelector('.monitor-summary__refresh');
-    expect(btn).not.toBeNull();
-    expect(btn!.textContent).toContain('Refresh');
-    expect(btn!.getAttribute('aria-label')).toBe('Refresh monitor data');
-  });
-
-  it('dispatches slicc-monitor-refresh on refresh click', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    const handler = vi.fn();
-    el.addEventListener('slicc-monitor-refresh', handler);
-    const btn = el.querySelector<HTMLButtonElement>('.monitor-summary__refresh')!;
-    btn.click();
-    expect(handler).toHaveBeenCalledOnce();
-  });
-
-  it('summarizes tracked, active, attention, and cost values', () => {
-    const el = mount([
-      ...SAMPLE_SECTIONS,
+  it('derives group status from the worst row when not set explicitly', () => {
+    const el = mountSections([
       {
-        id: 'alerts',
-        label: 'Alerts',
-        count: 1,
-        rows: [{ name: 'stalled', meta: '2m', status: 'warn' }],
-      },
-      {
-        id: 'cost',
-        label: 'Cost',
-        count: 1,
-        meta: '$1.23 this session',
-        rows: [{ name: 'model', meta: '$1.23' }],
+        id: 'mounts',
+        label: 'Mounts',
+        count: 2,
+        rows: [
+          { name: '/a', meta: 'ok', status: 'active' },
+          { name: '/b', meta: 'lost', status: 'warn' },
+        ],
       },
     ]);
-    const metrics = [...el.querySelectorAll('.monitor-summary__metric')].map((metric) => ({
-      label: metric.querySelector('dt')!.textContent,
-      value: metric.querySelector('dd')!.textContent,
-    }));
-    expect(metrics).toEqual([
-      { label: 'Tracked', value: '4' },
-      { label: 'Active', value: '2' },
-      { label: 'Attention', value: '1' },
-      { label: 'Session cost', value: '$1.23 this session' },
-    ]);
+    expect(el.querySelector<HTMLElement>('.monitor-group')?.dataset.status).toBe('warn');
   });
 
-  it('collapses a section on header click and persists state', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    const header = el.querySelector<HTMLButtonElement>(
-      '[data-section="scoops"] .monitor-section__header'
-    )!;
-    header.click();
-    // Re-query after re-render
-    const body = el.querySelector('[data-section="scoops"] .monitor-section__body');
-    const updatedHeader = el.querySelector<HTMLButtonElement>(
-      '[data-section="scoops"] .monitor-section__header'
-    )!;
-    expect(body!.hasAttribute('hidden')).toBe(true);
-    expect(updatedHeader.getAttribute('aria-expanded')).toBe('false');
-    expect(updatedHeader.getAttribute('aria-controls')).toBe(body!.id);
-    const stored = JSON.parse(localStorage.getItem('slicc_monitor_collapsed')!);
-    expect(stored).toContain('scoops');
+  it('prefers an explicit group status over the derived one', () => {
+    const el = mountSections([
+      {
+        id: 'tray',
+        label: 'Tray',
+        count: 1,
+        status: 'error',
+        rows: [{ name: 'Leader', meta: 'ok', status: 'active' }],
+      },
+    ]);
+    expect(el.querySelector<HTMLElement>('.monitor-group')?.dataset.status).toBe('error');
+  });
+
+  it('states every status in words, never in color alone', () => {
+    const el = mountSections([
+      { id: 'a', label: 'A', count: 1, status: 'warn', rows: [{ name: 'x', meta: 'y' }] },
+    ]);
+    expect(el.querySelector('.monitor-row__state')?.textContent).toContain('Attention');
+  });
+
+  it('collapses a healthy group and expands one that needs attention', () => {
+    const el = mountSections([
+      { id: 'ok', label: 'Ok', count: 1, status: 'active', rows: [{ name: 'a', meta: 'b' }] },
+      { id: 'bad', label: 'Bad', count: 1, status: 'warn', rows: [{ name: 'c', meta: 'd' }] },
+    ]);
+    const [healthy, degraded] = el.querySelectorAll('.monitor-group');
+    expect(healthy.querySelector('.monitor-children')?.hasAttribute('hidden')).toBe(true);
+    expect(degraded.querySelector('.monitor-children')?.hasAttribute('hidden')).toBe(false);
+  });
+
+  it('keeps a degraded group closed once the reader shuts it', () => {
+    const el = mountSections([
+      { id: 'bad', label: 'Bad', count: 1, status: 'warn', rows: [{ name: 'c', meta: 'd' }] },
+    ]);
+    (el.querySelector('.monitor-row') as HTMLElement).click();
+    expect(el.querySelector('.monitor-children')?.hasAttribute('hidden')).toBe(true);
+    expect(JSON.parse(localStorage.getItem('slicc_monitor_collapsed') ?? '[]')).toContain('bad');
+  });
+
+  it('keeps a healthy group open across a re-render once the reader opens it', () => {
+    // The 5s refresh re-renders from scratch; without the session-level
+    // "expanded" set, a group you just opened would slam shut on the next tick.
+    const sections: MonitorSection[] = [
+      { id: 'ok', label: 'Ok', count: 1, status: 'active', rows: [{ name: 'a', meta: 'b' }] },
+    ];
+    const el = mountSections(sections);
+    (el.querySelector('.monitor-row') as HTMLElement).click();
+    expect(el.querySelector('.monitor-children')?.hasAttribute('hidden')).toBe(false);
+    el.sections = sections;
+    expect(el.querySelector('.monitor-children')?.hasAttribute('hidden')).toBe(false);
   });
 
   it('restores collapsed state from localStorage', () => {
-    localStorage.setItem('slicc_monitor_collapsed', JSON.stringify(['cron']));
-    const el = mount(SAMPLE_SECTIONS);
-    const body = el.querySelector('[data-section="cron"] .monitor-section__body');
-    expect(body!.hasAttribute('hidden')).toBe(true);
+    localStorage.setItem('slicc_monitor_collapsed', JSON.stringify(['scoops']));
+    const el = mountSections(SAMPLE_SECTIONS);
+    const scoops = el.querySelector('[data-section="scoops"] .monitor-children');
+    expect(scoops?.hasAttribute('hidden')).toBe(true);
   });
 
-  it('re-renders when sections property is updated', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    expect(el.querySelectorAll('[data-section]')).toHaveLength(3);
-    el.sections = [{ id: 'only', label: 'Only', count: 0, rows: [] }];
-    expect(el.querySelectorAll('[data-section]')).toHaveLength(1);
-    expect(el.querySelector('[data-section="only"]')).not.toBeNull();
+  it('renders friendly empty-state copy for a group with no rows', () => {
+    const el = mountSections(SAMPLE_SECTIONS);
+    const empty = el.querySelector('[data-section="integrations"] .monitor-empty');
+    expect(empty?.textContent).toContain('Connect a webhook to receive external events.');
   });
 
-  it('shows section meta when provided', () => {
-    const el = mount([
-      {
-        id: 'cost',
-        label: 'Cost',
-        count: 1,
-        meta: '$1.23',
-        rows: [{ name: 'Total', meta: '$1.23' }],
-      },
+  it('wires aria-expanded and aria-controls to the group body', () => {
+    const el = mountSections([
+      { id: 'bad', label: 'Bad', count: 1, status: 'warn', rows: [{ name: 'c', meta: 'd' }] },
     ]);
-    const meta = el.querySelector('[data-section="cost"] .monitor-section__meta');
-    expect(meta).not.toBeNull();
-    expect(meta!.textContent).toBe('$1.23');
+    // A click re-renders the panel, so the header has to be re-queried —
+    // the clicked element is detached by the time the assertion runs.
+    const header = (): HTMLElement => el.querySelector('.monitor-row') as HTMLElement;
+    const body = el.querySelector('.monitor-children') as HTMLElement;
+    expect(header().getAttribute('aria-expanded')).toBe('true');
+    expect(header().getAttribute('aria-controls')).toBe(body.id);
+    header().click();
+    expect(header().getAttribute('aria-expanded')).toBe('false');
+    expect(header().getAttribute('aria-controls')).toBe(body.id);
+  });
+});
+
+describe('slicc-monitor — processes', () => {
+  const TABLE = {
+    rows: [
+      {
+        pid: 1024,
+        ppid: 1,
+        state: 'R',
+        status: 'running',
+        command: 'node script.js',
+        scoop: 'cone',
+      },
+      { pid: 1025, ppid: 1024, state: 'S', status: 'pending', command: 'rg --json x' },
+    ],
+    terminated: 1435,
+  };
+
+  beforeEach(() => {
+    ensureGlobalTokens();
+    setTheme('light');
+    document.body.replaceChildren();
+    localStorage.removeItem('slicc_monitor_collapsed');
   });
 
-  it('sections getter returns a copy (not a live reference)', () => {
-    const el = mount(SAMPLE_SECTIONS);
-    const copy = el.sections;
-    copy.push({ id: 'extra', label: 'X', count: 0, rows: [] });
-    copy[0].rows[0].badges!.push('mutated');
-    expect(el.sections).toHaveLength(3);
-    expect(el.sections[0].rows[0].badges).toEqual(['browser', 'shell']);
+  it('renders a real table, one row per live process', () => {
+    const el = mount({ processes: TABLE });
+    expect(el.querySelectorAll('.monitor-table tbody tr')).toHaveLength(2);
+    expect(el.querySelector<HTMLElement>('.monitor-tr')?.dataset.pid).toBe('1024');
+  });
+
+  it('reports the exited count in the header rather than as rows', () => {
+    const el = mount({ processes: TABLE });
+    expect(el.querySelector('[data-block="processes"] .monitor-block__hint')?.textContent).toBe(
+      '2 live · 1,435 exited this session'
+    );
+  });
+
+  it('omits the exited clause when nothing has exited', () => {
+    const el = mount({ processes: { ...TABLE, terminated: 0 } });
+    expect(el.querySelector('[data-block="processes"] .monitor-block__hint')?.textContent).toBe(
+      '2 live'
+    );
+  });
+
+  it('states the process state in a word, not only a letter tag', () => {
+    const el = mount({ processes: TABLE });
+    const cell = el.querySelector('tbody .monitor-td--state') as HTMLElement;
+    expect(cell.querySelector('.monitor-stat-tag')?.textContent).toBe('R');
+    expect(cell.querySelector('.monitor-stat-word')?.textContent).toBe('running');
+  });
+
+  it('sorts on a column header click, and flips on a second click', () => {
+    const el = mount({ processes: TABLE });
+    const pids = () =>
+      [...el.querySelectorAll<HTMLElement>('.monitor-tr')].map((tr) => tr.dataset.pid);
+    expect(pids()).toEqual(['1024', '1025']);
+    // A sort re-renders the header row, so each `th` has to be re-queried.
+    const th = (index: number): HTMLElement =>
+      el.querySelectorAll<HTMLElement>('.monitor-th')[index];
+
+    // PID is already the active sort, so the first click flips it.
+    th(0).click();
+    expect(pids()).toEqual(['1025', '1024']);
+    expect(th(0).getAttribute('aria-sort')).toBe('descending');
+    th(0).click();
+    expect(pids()).toEqual(['1024', '1025']);
+    expect(th(0).getAttribute('aria-sort')).toBe('ascending');
+
+    // A different column starts ascending rather than inheriting the flip.
+    th(6).click();
+    expect(th(6).getAttribute('aria-sort')).toBe('ascending');
+    expect(th(0).getAttribute('aria-sort')).toBe('none');
+    expect(pids()).toEqual(['1024', '1025']);
+  });
+
+  it('filters on command, scoop, and pid', () => {
+    const el = mount({ processes: TABLE });
+    const search = el.querySelector('.monitor-input') as HTMLInputElement;
+    const rowCount = () => el.querySelectorAll('.monitor-tr').length;
+
+    search.value = 'rg --json';
+    search.dispatchEvent(new Event('input'));
+    expect(rowCount()).toBe(1);
+
+    search.value = 'cone';
+    search.dispatchEvent(new Event('input'));
+    expect(rowCount()).toBe(1);
+
+    search.value = '1025';
+    search.dispatchEvent(new Event('input'));
+    expect(rowCount()).toBe(1);
+
+    search.value = '';
+    search.dispatchEvent(new Event('input'));
+    expect(rowCount()).toBe(2);
+  });
+
+  it('says the table is empty rather than showing a bare header', () => {
+    const el = mount({ processes: { rows: [], terminated: 0 } });
+    expect(el.querySelector('.monitor-empty-cell')?.textContent).toBe('No processes running.');
+  });
+
+  it('distinguishes "nothing matches the filter" from "nothing is running"', () => {
+    const el = mount({ processes: TABLE });
+    const search = el.querySelector('.monitor-input') as HTMLInputElement;
+    search.value = 'zzz-no-such-command';
+    search.dispatchEvent(new Event('input'));
+    expect(el.querySelector('.monitor-empty-cell')?.textContent).toContain(
+      'No live process matches'
+    );
+  });
+
+  it('renders a missing optional column as an em dash, not "undefined"', () => {
+    const el = mount({ processes: TABLE });
+    const secondRow = el.querySelectorAll('.monitor-tr')[1];
+    expect(secondRow.querySelector('.monitor-td--scoop')?.textContent).toBe('—');
+  });
+});
+
+describe('slicc-monitor — shell', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    setTheme('light');
+    document.body.replaceChildren();
+    localStorage.removeItem('slicc_monitor_collapsed');
+  });
+
+  it('dispatches slicc-monitor-refresh on the re-sync click', () => {
+    const el = mountSections(SAMPLE_SECTIONS);
+    const handler = vi.fn();
+    el.addEventListener('slicc-monitor-refresh', handler);
+    (el.querySelector('.monitor-head .monitor-btn') as HTMLElement).click();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the freshness line when supplied', () => {
+    const el = mount({ updated: 'Streaming · updated 2s ago' });
+    expect(el.querySelector('.monitor-head__sub')?.textContent).toBe('Streaming · updated 2s ago');
+  });
+
+  it('re-renders when the model is replaced', () => {
+    const el = mount({ sections: SAMPLE_SECTIONS });
+    expect(el.querySelectorAll('.monitor-group')).toHaveLength(3);
+    el.model = { sections: [SAMPLE_SECTIONS[0]] };
+    expect(el.querySelectorAll('.monitor-group')).toHaveLength(1);
+  });
+
+  it('sections getter returns a copy, not a live reference', () => {
+    const el = mountSections(SAMPLE_SECTIONS);
+    const first = el.sections;
+    first[0].label = 'mutated';
+    first[0].rows[0].name = 'mutated';
+    expect(el.sections[0].label).toBe('Scoops');
+    expect(el.sections[0].rows[0].name).toBe('sliccy (cone)');
+  });
+
+  it('model getter returns a copy, not a live reference', () => {
+    const el = mount({ processes: { rows: [], terminated: 3 }, vitals: [] });
+    const model = el.model;
+    model.processes!.terminated = 999;
+    expect(el.model.processes?.terminated).toBe(3);
+  });
+
+  it('re-steps the status hues for dark rather than reusing the light ones', () => {
+    // --green measures 4.06:1 on the dark surface, under 4.5:1 for the small
+    // status text it carries here; dark has to be selected, not flipped.
+    const el = mountSections([
+      { id: 'a', label: 'A', count: 1, status: 'active', rows: [{ name: 'x', meta: 'y' }] },
+    ]);
+    const light = getComputedStyle(el.querySelector('.monitor-glyph--active')!).color;
+    setTheme('dark');
+    const dark = getComputedStyle(el.querySelector('.monitor-glyph--active')!).color;
+    expect(dark).not.toBe(light);
   });
 });


### PR DESCRIPTION
> Stacked on #2386 (foundation). Review that one first — this PR's base is its branch, and the diff will shrink once it merges.

## Why

The monitor rendered **eleven visually identical cards** — label, count badge, rows of icon/name/meta/status-dot — over four structurally different kinds of data, and led with a `TRACKED` figure that summed processes with OAuth providers and mounts. A count of unlike things is not a metric, and inventory that is fine does not need a card each.

Three tiers now, in three deliberately different vocabularies, because they answer three different questions.

## 1. Vitals — rates and ratios, with a time axis

Replaces `TRACKED / ACTIVE / ATTENTION / SESSION COST`. Every number here is one the system actually has:

| Tile | Source |
|---|---|
| **Burn rate** (hero, ≥48px) | `SessionStats.burnRate` — the worker's existing blended 15/60-min USD/hour |
| **Agent load** | work units mid-turn, over the total |
| **Live processes** | the live count from #2386's snapshot |
| **Context fill** (meter) | the fullest of `SessionStats.fills`, escalating green → amber → rose |

Sparklines come from `monitor-history.ts`, a small in-memory ring buffer fed by the panel's own 5s refresh. Its limits are stated rather than hidden: history starts when the panel opens, nothing is persisted, and **`windowLabel()` reports the span the samples actually cover** (`last 45s`) instead of claiming a window it doesn't have. Below two points no sparkline is drawn at all — one point is not a trend.

The context meter only appears when there is a real reading. With no `fills`, a 0% bar would read as "context is empty", so the tile is omitted instead.

## 2. Attention — what is degraded, worst first

This is what `ATTENTION 2` should have expanded into. Derived from the same state the groups render — the point isn't new data, it's that a reader shouldn't open seven groups to learn whether anything is wrong. Expired accounts, a failing/reconnecting tray, stalled followers, mounts needing re-grant. Alerts carry `age` only where a real timestamp exists; an invented "2m ago" would be worse than none. Healthy state is one **All clear** line.

## 3. Body — topology and a real table

**Topology** collapses eight inventory cards into six groups rendered as summary *lines* (`Mounts · 2 · all granted`). Healthy groups stay shut; only groups needing attention auto-expand. MCP servers and provider accounts merge into **Integrations** — they were two cards with identical chrome and one row each, and as a reader question they are the same one. Cron and webhooks merge into **Automations**. Scoops render as the cone → scoop tree that `parentJid` already describes.

**Processes** is a table, because it is one: sortable on every column, filterable on command/scoop/pid, using the `ps` column vocabulary. It does not share the topology chrome.

## Contrast

`--amber` measures **2.09:1** against the light surface, so status can never ride on hue: every state carries a shape-varied glyph **and** a word (`⚠ Attention`, `✓ Healthy`).

Dark mode is *selected*, not flipped. `--green` and `--red` measure **4.06:1** and **3.14:1** on `#161618` — both under 4.5:1 for the small status text they carry — so the monitor re-steps them to ~6–7:1 locally. (The token file itself is untouched; a repo-wide re-step is a bigger conversation than this PR.)

## Deliberately not here

**Row actions** — kill, re-auth, reconnect, re-grant. The panel is still read-only. Each needs a real handler and its own approval story; folding them in would have doubled this diff. Worth a follow-up issue.

## Tests

- **`slicc-monitor.test.ts`** (41, real Chromium) — hero is unique and ≥48px; sparkline needs two points; meter clamps to 0..1; series wins over ratio; all-clear vs alerts and pill escalation; group status derived-vs-explicit; healthy collapses / degraded auto-expands; **a degraded group stays shut once the reader shuts it**; a healthy group stays open across a re-render; aria wiring; table sort/filter/empty-states; getters return copies; dark re-steps the hues.
- **`monitor-history.test.ts`** (8) — no series below two points, oldest-first, eviction, capacity floor, and that the window label tracks the real span.
- **`wc-monitor.test.ts`** (33) — seven groups; the merged Integrations/Automations summaries; mount and account roll-ups; `buildVitals` cold-start, large-rate, and fill-escalation cases; `buildAlerts` ordering and non-triggers; the process table's `ps` columns.

Two of these caught a real bug while being written: the group toggle keyed off set membership, so the **first click on an auto-expanded degraded group re-opened it** instead of closing it. It now keys off what the reader can actually see.

## Verification

`lint` · `typecheck` · `test` (16,820) · `test:coverage` (webapp + webcomponents, no floor regressions) · `build` · `check-touched-exemptions` — all green locally.

<sub>Note: 9 `packages/webapp/tests/shell/ipk/*` e2e files time out at the 5s default under local coverage instrumentation and pass at `--testTimeout=30000`. They are untouched by this PR and pass in the uninstrumented run.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
