### PR TITLE
fix(boot): never lose the race against a slow-but-advancing kernel boot

### DIFF
--- a/docs/mounts.md
+++ b/docs/mounts.md
@@ -160,7 +160,7 @@ The server serves each mapped folder over its local `/api/hostfs` bridge (loopba
 
 - **Live view**: reads/writes go straight to the host filesystem, so external edits are visible immediately — no `mount refresh` needed (it's a no-op on these mounts).
 - **Containment**: only paths under a mapped folder are reachable; `..` traversal and symlinks pointing outside the folder are refused, and the mount root itself cannot be removed.
-- **Config-owned**: the table is the single source of truth. Entries are not persisted in the browser; edit the table and relaunch to change them. `mount unmount` removes one for the session only.
+- **Config-owned**: the table is the single source of truth. Entries are not persisted in the browser; edit the table and relaunch to change them. `mount unmount` removes one for the session only. A persisted picker/S3 row at the same target is not just skipped for the boot — it is **purged from the store**, so a later launch without the table entry can't silently fall back to a stale FS-Access handle and walk a tree you thought was config-owned.
 - **Missing folders are skipped** at server start (with a warning) rather than failing the launch.
 - **Webapp-initiated mounts are untouched**: `mount <path>` still opens the picker and still asks for permission on each reload — the table never widens what a picker grant allowed.
 - Not available in the extension float or hosted/cloud mode: there is no local launcher to serve the folders.
@@ -206,6 +206,8 @@ Two environment variables override the defaults. Each must parse to a positive i
 | `SLICC_MOUNT_INDEX_MAX_ENTRIES` | max total entries   | `2,000,000` |
 
 (The worker / browser float has no OS env, so the defaults always apply there; the overrides are read once at construction in CLI / Electron mode.)
+
+**Boot-time session restore uses a smaller budget** (`RESTORED_MOUNT_INDEX_LIMITS`: depth 100, 100,000 entries). The interactive defaults suit a folder the user just picked and is waiting on; at boot the same budget let a huge or cloud-backed tree (an iCloud folder full of dataless files) grind the kernel worker's I/O for minutes while the kernel-ready watchdog ran (2026-08-24 incident). A restored mount that hits the bound stays fully usable — only the fast-discovery index is truncated (`entries-exceeded`), and re-mounting interactively re-indexes with the full budget.
 
 `mount list` renders a distinct, actionable line per skip cause:
 

--- a/packages/webapp/src/fs/auto-mount-table.ts
+++ b/packages/webapp/src/fs/auto-mount-table.ts
@@ -95,6 +95,24 @@ export function withoutHostMountedTargets<T extends { targetPath: string }>(
 }
 
 /**
+ * The complement of {@link withoutHostMountedTargets}: the persisted rows a
+ * configured host mount now shadows. The caller purges these from the store
+ * for good, not just for this boot — a shadowed row left armed means the
+ * first boot where the launcher stops advertising the target silently falls
+ * back to the persisted FS-Access handle, and a boot-time index walk of a
+ * tree the user thought was config-owned (2026-08-24: an iCloud
+ * `~/Desktop/kb` behind a hostfs mapping).
+ */
+export function hostShadowedEntries<T extends { targetPath: string }>(
+  entries: T[],
+  mounted: readonly AutoMountMapping[]
+): T[] {
+  if (mounted.length === 0) return [];
+  const owned = new Set(mounted.map((m) => m.path));
+  return entries.filter((entry) => owned.has(entry.targetPath.replace(/\/+$/, '') || '/'));
+}
+
+/**
  * Mount every table entry that is not already mounted. Failures are
  * per-entry (one bad mapping must not block the rest) and logged, never
  * thrown — boot continues without the mount, exactly like a missing

--- a/packages/webapp/src/fs/mount-index.ts
+++ b/packages/webapp/src/fs/mount-index.ts
@@ -119,6 +119,22 @@ export interface MountIndexLimits {
 }
 
 /**
+ * Walk bounds for mounts restored WITHOUT a user gesture (boot-time session
+ * restore in `mount-recovery.ts`). The interactive defaults (400 deep, 2M
+ * entries) suit a folder the user just picked and is waiting on; at boot the
+ * same budget lets a huge or cloud-backed tree (an iCloud folder full of
+ * dataless files — the 2026-08-24 `~/Desktop/kb` hazard) grind the kernel
+ * worker's I/O for minutes while the kernel-ready watchdog runs. A restored
+ * mount stays fully usable past the bound — only the fast-discovery index is
+ * truncated (`abortCause: 'entries-exceeded'`), and a later interactive re-mount
+ * re-indexes with the full budget.
+ */
+export const RESTORED_MOUNT_INDEX_LIMITS: MountIndexLimits = {
+  maxDepth: 100,
+  maxEntries: 100_000,
+};
+
+/**
  * The env shapes `resolveMountIndexLimits` accepts. The shell threads just-bash's
  * `CommandContext.env` (a `Map`, populated by `export`); plain records are still
  * accepted for non-shell callers and tests.

--- a/packages/webapp/src/fs/mount-recovery.ts
+++ b/packages/webapp/src/fs/mount-recovery.ts
@@ -44,6 +44,7 @@ import {
   RemoteMountCache,
   S3MountBackend,
 } from './mount/index.js';
+import { type MountIndexLimits, RESTORED_MOUNT_INDEX_LIMITS } from './mount-index.js';
 import type { BackendDescriptor, MountTableEntry } from './mount-table-store.js';
 import { loadMountHandle } from './mount-table-store.js';
 
@@ -69,7 +70,11 @@ export interface MountRecoveryResult {
 
 /** Minimal FS surface needed to re-mount a backend — lets tests stub this. */
 export interface MountRecoveryFS {
-  mount(path: string, backend: MountBackend): Promise<void> | void;
+  mount(
+    path: string,
+    backend: MountBackend,
+    opts?: { limits?: MountIndexLimits }
+  ): Promise<void> | void;
 }
 
 /** Logger surface accepted by `recoverMounts`. Everything is optional. */
@@ -132,7 +137,12 @@ async function recoverLocalMount(
 
   try {
     const backend = LocalMountBackend.fromHandle(handle, { mountId: descriptor.mountId });
-    await fs.mount(targetPath, backend);
+    // Boot-time restore runs with no user watching and shares the kernel
+    // worker with the rest of boot: index with the bounded restore budget
+    // so a huge or cloud-backed tree (iCloud dataless files) can't grind
+    // boot I/O for minutes. The mount itself is complete either way; a
+    // later interactive re-mount re-indexes with the full budget.
+    await fs.mount(targetPath, backend, { limits: RESTORED_MOUNT_INDEX_LIMITS });
     log?.info?.('Restored mount from previous session', { path: targetPath, name: dirName });
     return { entry, ok: true };
   } catch (err) {

--- a/packages/webapp/src/fs/sidecar-repair.ts
+++ b/packages/webapp/src/fs/sidecar-repair.ts
@@ -94,7 +94,8 @@ interface MutableEntry {
  */
 export async function repairSidecarDocument(
   doc: SidecarIndexJson,
-  probe: SidecarProbe
+  probe: SidecarProbe,
+  onEntry?: () => void
 ): Promise<SidecarRepairSummary> {
   const summary: SidecarRepairSummary = {
     kindFixed: [],
@@ -107,6 +108,11 @@ export async function repairSidecarDocument(
   };
   const entries = doc.entries ?? {};
   for (const [path, raw] of Object.entries(entries)) {
+    // Liveness tick per entry scanned (probed or skipped) — the boot
+    // heartbeat uses it to prove the O(tree) repair is advancing, so a
+    // multi-minute pass on a cold or I/O-starved disk is not mistaken for
+    // a wedge (2026-08-24 field incident: ~8 minutes over 22k entries).
+    onEntry?.();
     if (path === '/' || typeof raw !== 'object' || raw === null) continue;
     // A sidecar must never track itself: writing it changes its own size, so
     // any recorded `/.metadata.json` size is stale on the retry mount and the
@@ -297,7 +303,8 @@ export async function resolveWithSidecarRepair<T>(
  * absent sidecar itself, and `initOpfsBackend` seeds an empty one).
  */
 export async function repairOpfsMetadataSidecar(
-  handle: FileSystemDirectoryHandle
+  handle: FileSystemDirectoryHandle,
+  onEntry?: () => void
 ): Promise<SidecarRepairSummary | null> {
   let doc: SidecarIndexJson;
   try {
@@ -310,7 +317,7 @@ export async function repairOpfsMetadataSidecar(
   } catch {
     return null;
   }
-  const summary = await repairSidecarDocument(doc, makeOpfsProbe(handle));
+  const summary = await repairSidecarDocument(doc, makeOpfsProbe(handle), onEntry);
   if (!summary.changed) return summary;
   const fh = await handle.getFileHandle('.metadata.json', { create: true });
   const writable = await fh.createWritable();

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -21,7 +21,12 @@ import { findDirtyKindFlips, memoryKindOfMode, shouldReconcileKind } from './kin
 import type { MountBackend, RefreshReport } from './mount/backend.js';
 import type { HostFsMountBackend } from './mount/backend-hostfs.js';
 import { LocalMountBackend } from './mount/backend-local.js';
-import { MountIndex, type MountIndexEnv, resolveMountIndexLimits } from './mount-index.js';
+import {
+  MountIndex,
+  type MountIndexEnv,
+  type MountIndexLimits,
+  resolveMountIndexLimits,
+} from './mount-index.js';
 import type { BackendDescriptor, MountTableEntry } from './mount-table-store.js';
 import {
   clearMountEntries,
@@ -92,6 +97,15 @@ export interface VirtualFsOptions {
    * `backend` overrides resolution.
    */
   backend?: VfsBackend;
+  /**
+   * Liveness tick fired once per sidecar entry scanned by the pre-boot
+   * repair (#2146) — the O(tree) phase with no milestones of its own.
+   * The boot mount heartbeat (`scoops/mount-heartbeat.ts`) feeds these
+   * ticks into the page's kernel-ready watchdog so a multi-minute repair
+   * on a cold or I/O-starved disk is treated as advancing, not wedged
+   * (2026-08-24 field incident). OPFS backend only; memory ignores it.
+   */
+  onRepairProgress?: () => void;
 }
 
 /**
@@ -247,13 +261,19 @@ export class VirtualFS {
    */
   private static writeChains = new Map<string, Promise<void>>();
 
+  /** See {@link VirtualFsOptions.onRepairProgress}. */
+  private readonly onRepairProgress: (() => void) | undefined;
+
   private constructor(
     dbName: string,
     wipe?: boolean,
     backend?: VfsBackend,
-    opfsHandle?: FileSystemDirectoryHandle
+    opfsHandle?: FileSystemDirectoryHandle,
+    onRepairProgress?: () => void
   ) {
     this.dbName = dbName;
+    // Assigned before `_ready` kicks off `initOpfsBackend`, which reads it.
+    this.onRepairProgress = onRepairProgress;
     // Default to InMemory for any non-'opfs' value (including `undefined`)
     // so callers that bypass `VirtualFS.create` and reach the constructor
     // directly (a handful of test fixtures) come up on the Node-safe
@@ -398,7 +418,9 @@ export class VirtualFS {
       // up BEFORE ZenFS parses it costs one metadata-only probe per entry per
       // cold boot and heals sidecars already poisoned in the field.
       try {
-        const preboot = await vfs.withWriteLock(() => repairOpfsMetadataSidecar(handle));
+        const preboot = await vfs.withWriteLock(() =>
+          repairOpfsMetadataSidecar(handle, vfs.onRepairProgress)
+        );
         if (preboot?.changed) {
           console.warn('[virtual-fs] repaired metadata sidecar before mount (#2146)', {
             dbName: vfs.dbName,
@@ -419,7 +441,7 @@ export class VirtualFS {
         // context of the origin: run it under the same cross-context Web
         // Lock as `writeOpfsMetadataSidecarUnlocked`, so a realm that is
         // already booted and flushing cannot be clobbered mid-repair.
-        () => vfs.withWriteLock(() => repairOpfsMetadataSidecar(handle)),
+        () => vfs.withWriteLock(() => repairOpfsMetadataSidecar(handle, vfs.onRepairProgress)),
         (summary) =>
           console.warn('[virtual-fs] repaired poisoned metadata sidecar; retrying mount', {
             dbName: vfs.dbName,
@@ -751,7 +773,7 @@ export class VirtualFS {
     const dbName = options?.dbName ?? 'browser-fs';
     const wipe = options?.wipe === true;
     const backend: VfsBackend = options?.backend ?? resolveVfsBackendFromEnv();
-    const vfs = new VirtualFS(dbName, wipe, backend);
+    const vfs = new VirtualFS(dbName, wipe, backend, undefined, options?.onRepairProgress);
     await vfs._ready;
     if (wipe) {
       await clearMountEntries().catch(() => {});
@@ -1274,7 +1296,7 @@ export class VirtualFS {
   async mount(
     absolutePath: string,
     backend: MountBackend,
-    opts?: { env?: MountIndexEnv }
+    opts?: { env?: MountIndexEnv; limits?: MountIndexLimits }
   ): Promise<void> {
     const normalized = normalizePath(absolutePath);
     if (this.mountPoints.has(normalized)) {
@@ -1313,10 +1335,12 @@ export class VirtualFS {
     // so fast directory walks work. Remote backends have their own
     // listing cache (RemoteMountCache); MountIndex stays local-only.
     if (backend.kind === 'local') {
-      // Resolve the index walk bounds from the shell env threaded down by the
-      // `mount` command (SLICC_MOUNT_INDEX_MAX_DEPTH / _MAX_ENTRIES via `export`);
-      // non-shell callers (peer sync, reload/restore) get the defaults.
-      const limits = resolveMountIndexLimits(opts?.env ?? {});
+      // Resolve the index walk bounds: explicit `limits` win (boot-time
+      // session restore passes RESTORED_MOUNT_INDEX_LIMITS so a huge or
+      // cloud-backed tree can't grind boot-time I/O), else the shell env
+      // threaded down by the `mount` command (SLICC_MOUNT_INDEX_MAX_DEPTH /
+      // _MAX_ENTRIES via `export`); non-shell callers get the defaults.
+      const limits = opts?.limits ?? resolveMountIndexLimits(opts?.env ?? {});
       this.mountIndex.registerMount(normalized, (backend as LocalMountBackend).getHandle(), limits);
     }
     // Build the persistence/sync descriptor.

--- a/packages/webapp/src/kernel/host.ts
+++ b/packages/webapp/src/kernel/host.ts
@@ -808,16 +808,27 @@ function scheduleMountRecovery(
 ): void {
   void (async () => {
     try {
-      const { getAllMountEntries } = await import('../fs/mount-table-store.js');
+      const { getAllMountEntries, removeMountEntry } = await import('../fs/mount-table-store.js');
       const { recoverMounts } = await import('../fs/mount-recovery.js');
       // Config-owned host mounts first (mount table via /api/hostfs): fully
       // automatic, no picker, no permission prompt, never persisted to IDB.
-      const { mountConfiguredHostMounts, withoutHostMountedTargets } = await import(
-        '../fs/auto-mount-table.js'
-      );
+      const { hostShadowedEntries, mountConfiguredHostMounts, withoutHostMountedTargets } =
+        await import('../fs/auto-mount-table.js');
       const hostMounted = await mountConfiguredHostMounts(sharedFs, log);
       // Stale persisted rows at a now-config-owned target would only EEXIST.
-      const entries = withoutHostMountedTargets(await getAllMountEntries(), hostMounted);
+      const allEntries = await getAllMountEntries();
+      const entries = withoutHostMountedTargets(allEntries, hostMounted);
+      // Purge the shadowed rows for good, not just for this boot — see
+      // `hostShadowedEntries`. Best-effort per row; a failed delete just
+      // re-shadows next boot.
+      for (const stale of hostShadowedEntries(allEntries, hostMounted)) {
+        void removeMountEntry(stale.targetPath).catch((err) => {
+          log.warn('failed to purge host-owned mount row', {
+            path: stale.targetPath,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
       if (entries.length === 0) return;
       const { needsRecovery } = await recoverMounts(entries, sharedFs, log);
       if (needsRecovery.length === 0) return;

--- a/packages/webapp/src/kernel/spawn.ts
+++ b/packages/webapp/src/kernel/spawn.ts
@@ -150,6 +150,20 @@ export interface KernelWorkerSpawnOptions<TClient> {
    *  load-failure ErrorEvent is often opaque, and the shared guarded reload makes
    *  even an unrelated worker error reload at most once. (#1330) */
   onWorkerScriptError?: () => void;
+  /** See {@link KernelWorkerBootstrapOptions.onReadyStall}. */
+  onReadyStall?: (info: ReadyStallInfo) => void;
+  /** See {@link KernelWorkerBootstrapOptions.readyStallLimit}. */
+  readyStallLimit?: number;
+  /** See {@link KernelWorkerBootstrapOptions.onLateReady}. */
+  onLateReady?: () => void;
+}
+
+/** Passed to {@link KernelWorkerBootstrapOptions.onReadyStall} per watchdog fire. */
+export interface ReadyStallInfo {
+  /** Wall-clock ms since the worker was handed its init message. */
+  elapsedMs: number;
+  /** Consecutive watchdog fires with zero boot progress (1-based). */
+  stalls: number;
 }
 
 export interface KernelWorkerBootstrapOptions<TClient> {
@@ -185,6 +199,32 @@ export interface KernelWorkerBootstrapOptions<TClient> {
    *  load-failure ErrorEvent is often opaque, and the shared guarded reload makes
    *  even an unrelated worker error reload at most once. (#1330) */
   onWorkerScriptError?: () => void;
+  /**
+   * Fired when the ready watchdog expires but the boot is given another
+   * window instead of failing (see {@link readyStallLimit}). The page uses
+   * this to surface a non-destructive "still starting" state over the
+   * already-wired shell — everything except the final `ready` await is set
+   * up before the worker replies, so a late `kernel-worker-ready` resumes
+   * the normal boot path with no reload (2026-08-24 field wedge: an 8-minute
+   * sidecar repair finished AFTER the page had already bricked itself).
+   */
+  onReadyStall?: (info: ReadyStallInfo) => void;
+  /**
+   * Consecutive zero-progress watchdog windows tolerated before `ready`
+   * rejects for real. Any `kernel-worker-boot-progress` resets the count —
+   * the limit bounds SILENCE, not boot time. Defaults to 3 when
+   * {@link onReadyStall} is provided (stall UI exists, so waiting is safe)
+   * and 1 otherwise (legacy single-window behavior).
+   */
+  readyStallLimit?: number;
+  /**
+   * Fired if `kernel-worker-ready` arrives AFTER `ready` already rejected.
+   * When set, the rejection path keeps the ready listener attached instead
+   * of tearing it down, so a worker that finishes booting behind a recovery
+   * screen is heard rather than discarded. The listener is removed once
+   * this fires (or on `dispose()`).
+   */
+  onLateReady?: () => void;
 }
 
 /**
@@ -224,6 +264,123 @@ export interface SpawnedKernelHost<TClient> {
 // ---------------------------------------------------------------------------
 
 /**
+ * Watch the kernel port for the boot handshake and arm the ready watchdog.
+ *
+ * Single cleanup path: `cleanup()` removes the listener AND clears whichever
+ * timer is armed. Called from the success branch, the hard-timeout branch,
+ * the late-ready branch, AND from the host's `dispose()` so a caller that
+ * disposes before the worker replies doesn't leave the listener attached for
+ * the worker's lifetime.
+ */
+function watchKernelReady(
+  port: MessagePort,
+  options: Pick<
+    KernelWorkerBootstrapOptions<unknown>,
+    'onReadyStall' | 'readyStallLimit' | 'onLateReady'
+  >,
+  readyTimeoutMs: number
+): { ready: Promise<void>; cleanup: () => void } {
+  let cleanupReady: () => void = () => {};
+  const ready = new Promise<void>((resolve, reject) => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let listener: ((event: MessageEvent) => void) | null = null;
+
+    const clearTimer = (): void => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+    };
+    // Stall accounting: the watchdog bounds SILENCE, not total boot time.
+    // Each zero-progress window is one stall; boot progress resets the
+    // count. Only after `readyStallLimit` consecutive stalls does `ready`
+    // reject — and with `onLateReady` set, even that keeps the listener
+    // attached so a worker that finishes booting late is still heard.
+    const readyStallLimit = Math.max(1, options.readyStallLimit ?? (options.onReadyStall ? 3 : 1));
+    const startedAt = Date.now();
+    let stalls = 0;
+    let timedOut = false;
+    // Arm the boot-ready clock.
+    const armReadyTimeout = (): void => {
+      clearTimer();
+      timeoutId = setTimeout(() => {
+        stalls += 1;
+        if (stalls < readyStallLimit) {
+          options.onReadyStall?.({ elapsedMs: Date.now() - startedAt, stalls });
+          armReadyTimeout();
+          return;
+        }
+        if (options.onLateReady) {
+          // Keep the listener attached for a late `kernel-worker-ready`;
+          // only the timer dies here.
+          clearTimer();
+        } else {
+          cleanupReady();
+        }
+        timedOut = true;
+        reject(
+          new Error(
+            `Kernel worker did not signal ready within ${readyTimeoutMs * readyStallLimit}ms`
+          )
+        );
+      }, readyTimeoutMs);
+    };
+
+    cleanupReady = (): void => {
+      if (listener !== null) {
+        port.removeEventListener('message', listener as EventListener);
+        listener = null;
+      }
+      clearTimer();
+    };
+    listener = (event: MessageEvent): void => {
+      const data = event.data as
+        | Partial<KernelWorkerReadyMsg>
+        | Partial<KernelWorkerBootErrorMsg>
+        | Partial<KernelWorkerBootProgressMsg>
+        | null;
+      // #2007: a boot-progress heartbeat means the worker is still
+      // advancing (orchestrator up, a scoop restored, cone bootstrapped,
+      // …) — re-arm the clock so the timeout is a stall watchdog, not a
+      // hard cap on a slow-but-healthy boot.
+      if (data?.type === 'kernel-worker-boot-progress') {
+        stalls = 0;
+        armReadyTimeout();
+        return;
+      }
+      if (data?.type === 'kernel-worker-ready') {
+        cleanupReady();
+        if (timedOut) {
+          // `ready` already rejected — the page moved on (recovery screen /
+          // stall UI). Report the late arrival instead of resolving into a
+          // settled promise nobody is awaiting.
+          options.onLateReady?.();
+          return;
+        }
+        resolve();
+        return;
+      }
+      // Boot failed with a known cause: reject NOW with the real error
+      // instead of letting the 30s timeout produce a generic message next
+      // to the recovery screen's data-wipe button (#1984). `.code` rides
+      // along so future recovery UI can special-case storage-shaped
+      // failures.
+      if (data?.type === 'kernel-worker-boot-error') {
+        cleanupReady();
+        const detail = (data as Partial<KernelWorkerBootErrorMsg>).message ?? 'unknown error';
+        const code = (data as Partial<KernelWorkerBootErrorMsg>).code;
+        const error = new Error(`Kernel worker boot failed: ${detail}`);
+        if (code) (error as Error & { code?: string }).code = code;
+        reject(error);
+      }
+    };
+    port.addEventListener('message', listener as EventListener);
+    armReadyTimeout();
+  });
+  return { ready, cleanup: () => cleanupReady() };
+}
+
+/**
  * Wire up an existing Worker-like instance to a kernel host. Used by
  * `spawnKernelWorker` and by tests with a mock worker.
  */
@@ -254,77 +411,13 @@ export function bootstrapKernelWorker<TClient>(
   const stopForwarder = startPageCdpForwarder(cdpChannel.port1, realCdpTransport);
 
   // Wait for `kernel-worker-ready` on the kernel port. The OffscreenClient
-  // already started this port via its onMessage subscription; we just add
-  // a second listener that resolves on the boot signal.
-  //
-  // Single cleanup path: `cleanupReady()` removes the listener AND clears
-  // whichever timer is armed. Called from the success branch, the timeout
-  // branch, AND from `dispose()` so a caller that disposes before the
-  // worker replies doesn't leave the listener attached for the worker's
-  // lifetime.
-  let cleanupReady: (() => void) | null = null;
-  const ready = new Promise<void>((resolve, reject) => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    let listener: ((event: MessageEvent) => void) | null = null;
-
-    const clearTimer = (): void => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        timeoutId = null;
-      }
-    };
-    // Arm the boot-ready clock.
-    const armReadyTimeout = (): void => {
-      clearTimer();
-      timeoutId = setTimeout(() => {
-        cleanupReady?.();
-        reject(new Error(`Kernel worker did not signal ready within ${readyTimeoutMs}ms`));
-      }, readyTimeoutMs);
-    };
-
-    cleanupReady = (): void => {
-      if (listener !== null) {
-        kernelChannel.port1.removeEventListener('message', listener as EventListener);
-        listener = null;
-      }
-      clearTimer();
-    };
-    listener = (event: MessageEvent): void => {
-      const data = event.data as
-        | Partial<KernelWorkerReadyMsg>
-        | Partial<KernelWorkerBootErrorMsg>
-        | Partial<KernelWorkerBootProgressMsg>
-        | null;
-      // #2007: a boot-progress heartbeat means the worker is still
-      // advancing (orchestrator up, a scoop restored, cone bootstrapped,
-      // …) — re-arm the clock so the timeout is a stall watchdog, not a
-      // hard cap on a slow-but-healthy boot.
-      if (data?.type === 'kernel-worker-boot-progress') {
-        armReadyTimeout();
-        return;
-      }
-      if (data?.type === 'kernel-worker-ready') {
-        cleanupReady?.();
-        resolve();
-        return;
-      }
-      // Boot failed with a known cause: reject NOW with the real error
-      // instead of letting the 30s timeout produce a generic message next
-      // to the recovery screen's data-wipe button (#1984). `.code` rides
-      // along so future recovery UI can special-case storage-shaped
-      // failures.
-      if (data?.type === 'kernel-worker-boot-error') {
-        cleanupReady?.();
-        const detail = (data as Partial<KernelWorkerBootErrorMsg>).message ?? 'unknown error';
-        const code = (data as Partial<KernelWorkerBootErrorMsg>).code;
-        const error = new Error(`Kernel worker boot failed: ${detail}`);
-        if (code) (error as Error & { code?: string }).code = code;
-        reject(error);
-      }
-    };
-    kernelChannel.port1.addEventListener('message', listener as EventListener);
-    armReadyTimeout();
-  });
+  // already started this port via its onMessage subscription; the watcher
+  // adds a second listener that resolves on the boot signal.
+  const { ready, cleanup: cleanupReady } = watchKernelReady(
+    kernelChannel.port1,
+    options,
+    readyTimeoutMs
+  );
 
   // Hand the worker its ports. After `postMessage` with a transferable
   // list, the page can no longer use port2 of either channel — that's
@@ -360,7 +453,7 @@ export function bootstrapKernelWorker<TClient>(
       // callback racing in flight gets removed, not orphaned. The
       // timeout fires the rejection if `ready` is still pending; we
       // don't resolve it here.
-      cleanupReady?.();
+      cleanupReady();
       stopForwarder();
       try {
         worker.postMessage({ type: 'kernel-worker-shutdown' });
@@ -422,5 +515,8 @@ export function spawnKernelWorker<TClient>(
     extensionDelegateId: options.extensionDelegateId,
     flagFloat: options.flagFloat,
     onWorkerScriptError: options.onWorkerScriptError,
+    onReadyStall: options.onReadyStall,
+    readyStallLimit: options.readyStallLimit,
+    onLateReady: options.onLateReady,
   });
 }

--- a/packages/webapp/src/scoops/mount-heartbeat.ts
+++ b/packages/webapp/src/scoops/mount-heartbeat.ts
@@ -1,5 +1,6 @@
 /**
- * `mount-heartbeat.ts` — bounded liveness heartbeat for the shared-FS mount.
+ * `mount-heartbeat.ts` — progress-aware liveness heartbeat for the shared-FS
+ * mount.
  *
  * The OPFS mount is the one boot phase with no natural milestones: ZenFS
  * parses the multi-megabyte metadata sidecar and the unconditional pre-boot
@@ -10,49 +11,74 @@
  * the leader bricked with "Kernel worker did not signal ready within
  * 30000ms" on every restart, while a warm reload squeaked under the limit.
  *
- * The watchdog is a STALL detector, so the beat must not run forever — a
- * genuinely wedged mount (deadlocked web lock, hung OPFS handle) has to
- * stop beating and let the timeout fire. Hence the cap: up to
- * {@link MOUNT_HEARTBEAT_MAX_BEATS} interval beats (~2 minutes of mount
- * grace), then silence, and the watchdog rules again.
+ * The original beat was TIME-capped (~2 minutes, then silence), which
+ * conflated "slow" with "wedged": in the 2026-08-24 field wedge the same
+ * repair took ~8 minutes on an I/O-starved disk, outlived the cap, and the
+ * watchdog killed a boot that was provably advancing. The beat is now
+ * PROGRESS-aware: `work` receives a `tick()` the mount calls per unit of
+ * real progress (one sidecar entry probed — see
+ * `VirtualFsOptions.onRepairProgress`), and the cap counts consecutive
+ * QUIET intervals, not total intervals. While ticks advance, beats flow
+ * indefinitely; once ticks stop for {@link MOUNT_HEARTBEAT_MAX_BEATS}
+ * intervals in a row the beat goes silent and the watchdog rules again — a
+ * genuinely wedged mount (deadlocked web lock, hung OPFS handle) produces
+ * no ticks, so it still times out exactly as before.
  */
 
 /** Beat cadence while the mount is in flight. */
 export const MOUNT_HEARTBEAT_INTERVAL_MS = 5_000;
 /**
- * Beats before the heartbeat goes quiet: 24 × 5s ≈ 2 minutes of grace for
- * an O(tree) mount, after which a still-pending mount is treated as wedged
- * (the page watchdog then fires one timeout-window later).
+ * Consecutive tick-less intervals before the heartbeat goes quiet:
+ * 24 × 5s ≈ 2 minutes of grace for the mount phases that carry no tick
+ * instrumentation (ZenFS sidecar parse, crossCopy), after which a mount
+ * that is neither ticking nor finishing is treated as wedged (the page
+ * watchdog then fires one timeout-window later). Any tick resets the run.
  */
 export const MOUNT_HEARTBEAT_MAX_BEATS = 24;
 
 /**
  * Run `work` while emitting `onProgress` liveness beats
- * (`shared-fs-mount:start`, then `shared-fs-mount:<n>` per interval, capped
- * at {@link MOUNT_HEARTBEAT_MAX_BEATS}). The timer is cleared on resolve
- * AND reject; the work's outcome passes through untouched. With no
- * `onProgress` this is a plain passthrough.
+ * (`shared-fs-mount:start`, then `shared-fs-mount:<n>` per interval).
+ * `work` receives a `tick()` callback to report fine-grained progress;
+ * each interval with at least one new tick resets the quiet run, so an
+ * actively-advancing mount beats for as long as it needs. Intervals with
+ * no new ticks count against `maxBeats`; once exceeded, beating stops for
+ * good. The timer is cleared on resolve AND reject; the work's outcome
+ * passes through untouched. With no `onProgress` this is a plain
+ * passthrough (the tick is a no-op).
  */
 export async function withMountHeartbeat<T>(
-  work: () => Promise<T>,
+  work: (tick: () => void) => Promise<T>,
   onProgress?: (stage: string) => void,
   options: { intervalMs?: number; maxBeats?: number } = {}
 ): Promise<T> {
-  if (!onProgress) return work();
+  if (!onProgress) return work(() => {});
   const intervalMs = options.intervalMs ?? MOUNT_HEARTBEAT_INTERVAL_MS;
   const maxBeats = options.maxBeats ?? MOUNT_HEARTBEAT_MAX_BEATS;
   onProgress('shared-fs-mount:start');
   let beats = 0;
+  let quietBeats = 0;
+  let ticks = 0;
+  let seenTicks = 0;
+  const tick = (): void => {
+    ticks += 1;
+  };
   const timer = setInterval(() => {
-    beats += 1;
-    if (beats > maxBeats) {
-      clearInterval(timer);
-      return;
+    if (ticks > seenTicks) {
+      seenTicks = ticks;
+      quietBeats = 0;
+    } else {
+      quietBeats += 1;
+      if (quietBeats > maxBeats) {
+        clearInterval(timer);
+        return;
+      }
     }
+    beats += 1;
     onProgress(`shared-fs-mount:${beats}`);
   }, intervalMs);
   try {
-    return await work();
+    return await work(tick);
   } finally {
     clearInterval(timer);
   }

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -431,11 +431,13 @@ export class Orchestrator implements ConeApprovalRouter {
     // sidecar and runs the unconditional pre-boot repair (#2146) — O(tree
     // size) with no milestones of its own, 25-30s+ on a COLD boot of a
     // large tree (2026-08-18 restart brick: "did not signal ready" on
-    // every fresh Chrome start, warm reloads passed). The bounded
-    // heartbeat keeps the page's kernel-ready watchdog (#2007) armed
-    // while the mount provably advances.
+    // every fresh Chrome start, warm reloads passed; 2026-08-24: ~8
+    // minutes on an I/O-starved disk). The heartbeat keeps the page's
+    // kernel-ready watchdog (#2007) armed while the mount provably
+    // advances: the repair ticks per sidecar entry probed, so beats flow
+    // for as long as the scan moves and go quiet only when it stalls.
     this.sharedFs = await withMountHeartbeat(
-      () => VirtualFS.create({ dbName: 'slicc-fs' }),
+      (tick) => VirtualFS.create({ dbName: 'slicc-fs', onRepairProgress: tick }),
       onBootProgress
     );
     this.sessionStore = new SessionStore();

--- a/packages/webapp/src/ui/boot/boot-stall-overlay.ts
+++ b/packages/webapp/src/ui/boot/boot-stall-overlay.ts
@@ -1,0 +1,76 @@
+/**
+ * `boot-stall-overlay.ts` — non-destructive "still starting" surface for a
+ * slow kernel boot.
+ *
+ * Shown when the kernel-ready watchdog fires but the boot is allowed to keep
+ * waiting (`onReadyStall` in `kernel/spawn.ts`). Unlike the recovery screen
+ * it does NOT replace the app's DOM: the wc shell is fully wired before
+ * `host.ready` resolves, so tearing it down would turn a slow-but-healthy
+ * boot into a brick (the 2026-08-24 field wedge — an 8-minute sidecar repair
+ * finished after the page had already given up). The overlay floats above
+ * the shell and is removed the moment `ready` resolves.
+ *
+ * Rendered with `createElement`/`textContent` (never `innerHTML`), mirroring
+ * `recovery-screen.ts`. Deliberately offers only a plain Reload — the
+ * destructive wipe stays on the real recovery screen, which still renders if
+ * the boot exhausts its stall budget.
+ */
+
+const OVERLAY_ID = 'slicc-boot-stall-overlay';
+
+/** Injectable seam so tests can assert the reload without navigating. */
+export interface BootStallOverlayDeps {
+  reload?: () => void;
+}
+
+/**
+ * Show (or update, when already shown) the stall overlay on `doc`.
+ * Idempotent per document: repeat calls only refresh the elapsed time.
+ */
+export function showBootStallOverlay(
+  doc: Document,
+  info: { elapsedMs: number },
+  deps: BootStallOverlayDeps = {}
+): void {
+  const elapsedSec = Math.max(1, Math.round(info.elapsedMs / 1000));
+  const message =
+    `Still starting — the kernel is taking longer than expected (${elapsedSec}s). ` +
+    'Waiting is safe; your data is untouched.';
+
+  const existing = doc.getElementById(OVERLAY_ID);
+  if (existing) {
+    const p = existing.querySelector('p');
+    if (p) p.textContent = message;
+    return;
+  }
+
+  const box = doc.createElement('div');
+  box.id = OVERLAY_ID;
+  box.style.cssText =
+    'position:fixed;left:50%;bottom:1.5rem;transform:translateX(-50%);z-index:2147483000;' +
+    'display:flex;gap:0.75rem;align-items:center;padding:0.75rem 1rem;border-radius:8px;' +
+    'font-family:system-ui;font-size:0.875rem;max-width:min(90vw,34rem);' +
+    'background:var(--s2-background-elevated, #1e1e1e);color:var(--s2-content, #eee);' +
+    'border:1px solid var(--s2-content-tertiary, #717171);box-shadow:0 4px 16px rgba(0,0,0,0.4);';
+
+  const p = doc.createElement('p');
+  p.style.cssText = 'margin:0;';
+  p.textContent = message;
+
+  const reloadBtn = doc.createElement('button');
+  reloadBtn.type = 'button';
+  reloadBtn.textContent = 'Reload';
+  reloadBtn.style.cssText =
+    'padding:0.35rem 0.75rem;cursor:pointer;border:1px solid var(--s2-content-tertiary, #717171);' +
+    'background:transparent;color:inherit;border-radius:4px;flex-shrink:0;';
+  const reload = deps.reload ?? ((): void => location.reload());
+  reloadBtn.addEventListener('click', () => reload());
+
+  box.append(p, reloadBtn);
+  doc.body.appendChild(box);
+}
+
+/** Remove the overlay if present. Safe to call when it never rendered. */
+export function removeBootStallOverlay(doc: Document): void {
+  doc.getElementById(OVERLAY_ID)?.remove();
+}

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -1274,9 +1274,15 @@ export async function mountWcUiLive(
   const { setupSudoStandalone } = await import('../boot/setup-sudo.js');
   await setupSudoStandalone({ log });
 
-  await host.ready;
-  if (stallOverlayShown) {
-    void import('../boot/boot-stall-overlay.js').then((m) => m.removeBootStallOverlay(document));
+  try {
+    await host.ready;
+  } finally {
+    // The overlay hangs off document.body, not #app — on a rejection the
+    // recovery screen replaces only #app, so a success-path-only removal
+    // would leave "Still starting" floating over the failure UI.
+    if (stallOverlayShown) {
+      void import('../boot/boot-stall-overlay.js').then((m) => m.removeBootStallOverlay(document));
+    }
   }
   // `host.ready` resolves on `kernel-worker-ready`, which the worker posts
   // AFTER its VfsRpcHost attaches — unlike the first scoop-list (the

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -1221,6 +1221,7 @@ export async function mountWcUiLive(
   // a fast boot-time failure.
   if (instanceId) installWorkerStaleAssetReloadListener(instanceId);
   const { syncFsBridgeEnabled, syncFsChannelNonce } = setupSyncFsBootNonce();
+  let stallOverlayShown = false;
   const host = spawnKernelWorker({
     realCdpTransport,
     instanceId,
@@ -1234,6 +1235,24 @@ export async function mountWcUiLive(
     // The worker adopts this float's cached remote flags at boot (#2003).
     flagFloat: runtimeMode,
     onWorkerScriptError: () => {
+      guardedReload();
+    },
+    // Slow-boot tolerance (#2007 follow-up, 2026-08-24 field wedge): each
+    // zero-progress watchdog window short of the stall limit surfaces a
+    // non-destructive overlay instead of bricking to the recovery screen.
+    // The shell above is fully wired before `host.ready`, so a late
+    // `kernel-worker-ready` resumes the normal boot path with no reload.
+    onReadyStall: (info) => {
+      stallOverlayShown = true;
+      void import('../boot/boot-stall-overlay.js').then((m) =>
+        m.showBootStallOverlay(document, info)
+      );
+    },
+    // The worker finished booting AFTER the stall budget ran out and the
+    // recovery screen rendered. One guarded reload enters the now-warm
+    // session; the guard (shared with the stale-asset path) caps it so a
+    // pathological boot can't reload-loop.
+    onLateReady: () => {
       guardedReload();
     },
   });
@@ -1256,6 +1275,9 @@ export async function mountWcUiLive(
   await setupSudoStandalone({ log });
 
   await host.ready;
+  if (stallOverlayShown) {
+    void import('../boot/boot-stall-overlay.js').then((m) => m.removeBootStallOverlay(document));
+  }
   // `host.ready` resolves on `kernel-worker-ready`, which the worker posts
   // AFTER its VfsRpcHost attaches — unlike the first scoop-list (the
   // callbacks' onReady), which fires mid-boot while VFS RPCs still fan out

--- a/packages/webapp/tests/fs/auto-mount-table.test.ts
+++ b/packages/webapp/tests/fs/auto-mount-table.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { AutoMountFS } from '../../src/fs/auto-mount-table.js';
 import {
   fetchAutoMounts,
+  hostShadowedEntries,
   isCanonicalAbsoluteTarget,
   mountConfiguredHostMounts,
   withoutHostMountedTargets,
@@ -134,5 +135,27 @@ describe('withoutHostMountedTargets', () => {
       { targetPath: '/mnt/other' },
     ]);
     expect(withoutHostMountedTargets(entries, [])).toEqual(entries);
+  });
+});
+
+describe('hostShadowedEntries', () => {
+  it('returns exactly the rows a configured host mount shadows', () => {
+    const entries = [
+      { targetPath: '/mnt/kb' },
+      { targetPath: '/mnt/kb/' }, // trailing slash still matches the target
+      { targetPath: '/mnt/other' },
+    ];
+    const mounted = [{ path: '/mnt/kb', hostPath: '/Users/me/Desktop/kb' }];
+    // Complement invariant: shadowed + kept === all, with no overlap — the
+    // purge must delete precisely what withoutHostMountedTargets filters.
+    expect(hostShadowedEntries(entries, mounted)).toEqual([
+      { targetPath: '/mnt/kb' },
+      { targetPath: '/mnt/kb/' },
+    ]);
+    expect(withoutHostMountedTargets(entries, mounted)).toEqual([{ targetPath: '/mnt/other' }]);
+  });
+
+  it('returns [] with no configured host mounts', () => {
+    expect(hostShadowedEntries([{ targetPath: '/mnt/kb' }], [])).toEqual([]);
   });
 });

--- a/packages/webapp/tests/fs/mount-recovery.test.ts
+++ b/packages/webapp/tests/fs/mount-recovery.test.ts
@@ -21,6 +21,7 @@ vi.mock('../../src/fs/mount-table-store.js', async () => {
 import type { MountBackend } from '../../src/fs/mount/backend.js';
 import { LocalMountBackend } from '../../src/fs/mount/backend-local.js';
 import { newMountId } from '../../src/fs/mount/mount-id.js';
+import { RESTORED_MOUNT_INDEX_LIMITS } from '../../src/fs/mount-index.js';
 import {
   formatMountRecoveryPrompt,
   type MountRecoveryEntry,
@@ -449,5 +450,29 @@ describe('mdInlineCode', () => {
   it('collapses CR/LF to a single space', () => {
     expect(mdInlineCode('line1\nline2')).toBe('`line1 line2`');
     expect(mdInlineCode('a\r\nb')).toBe('`a b`');
+  });
+});
+
+describe('boot-time restore index budget', () => {
+  beforeEach(() => {
+    handleByKey.clear();
+  });
+
+  // A boot-time restore runs with no user watching and shares the kernel
+  // worker with the rest of boot: the default interactive walk budget (2M
+  // entries) let an iCloud-backed tree grind boot I/O for minutes
+  // (2026-08-24 `~/Desktop/kb` hazard). Restores must index with the
+  // bounded budget; interactive `mount` keeps the full one.
+  it('restores local mounts with RESTORED_MOUNT_INDEX_LIMITS', async () => {
+    const a = seedLocalEntry('/mnt/kb', mockHandle({ name: 'kb', permission: 'granted' }));
+    const captured: Array<{ path: string; limits: unknown }> = [];
+    const fs: MountRecoveryFS = {
+      mount: (path, _backend, opts) => {
+        captured.push({ path, limits: opts?.limits });
+      },
+    };
+    const result = await recoverMounts([a], fs);
+    expect(result.restored).toHaveLength(1);
+    expect(captured).toEqual([{ path: '/mnt/kb', limits: RESTORED_MOUNT_INDEX_LIMITS }]);
   });
 });

--- a/packages/webapp/tests/fs/sidecar-repair.test.ts
+++ b/packages/webapp/tests/fs/sidecar-repair.test.ts
@@ -317,3 +317,40 @@ describe('resolveWithSidecarRepair', () => {
     expect(resolve).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('repair progress ticks', () => {
+  // The boot mount heartbeat feeds these ticks into the page's
+  // kernel-ready watchdog: an O(tree) repair on a cold or I/O-starved
+  // disk (2026-08-24: ~8 minutes over 22k entries) must read as
+  // advancing, not wedged. One tick per entry SCANNED — probed, healthy,
+  // root, or dropped alike — so the tick rate tracks the loop, not the
+  // damage.
+  it('ticks once per entry scanned, including root and untouched entries', async () => {
+    const doc: SidecarIndexJson = {
+      version: 1,
+      entries: {
+        '/': dir(),
+        '/a': file(1),
+        '/gone': file(2),
+        '/link': symlink(),
+      },
+    };
+    const onEntry = vi.fn();
+    await repairSidecarDocument(
+      doc,
+      probeFrom({ '/a': { kind: 'file', size: 1 } }), // '/gone' is missing → dropped
+      onEntry
+    );
+    expect(onEntry).toHaveBeenCalledTimes(4);
+  });
+
+  it('is optional — omitting the tick leaves the repair result unaffected', async () => {
+    const doc: SidecarIndexJson = { entries: { '/a': file(1) } };
+    const summary = await repairSidecarDocument(
+      doc,
+      probeFrom({ '/a': { kind: 'file', size: 1 } })
+    );
+    expect(summary.dropped).toBe(0);
+    expect(doc.entries?.['/a']).toBeDefined();
+  });
+});

--- a/packages/webapp/tests/kernel/spawn.test.ts
+++ b/packages/webapp/tests/kernel/spawn.test.ts
@@ -347,3 +347,109 @@ describe('bootstrapKernelWorker', () => {
     });
   });
 });
+
+describe('slow-boot stall tolerance (2026-08-24 field wedge)', () => {
+  /** Post init and expose the worker-side kernel port for manual driving. */
+  function makeManualWorker(): { worker: WorkerLike; port: () => MessagePort } {
+    let kernelPort: MessagePort | null = null;
+    const worker: WorkerLike = {
+      postMessage: (message: unknown) => {
+        const data = message as { type?: string; kernelPort?: MessagePort };
+        if (data?.type !== 'kernel-worker-init' || !data.kernelPort) return;
+        kernelPort = data.kernelPort;
+        kernelPort.start();
+      },
+      terminate: () => {},
+    };
+    return { worker, port: () => kernelPort! };
+  }
+
+  function bootstrap(
+    worker: WorkerLike,
+    opts: {
+      readyTimeoutMs: number;
+      onReadyStall?: (info: { elapsedMs: number; stalls: number }) => void;
+      readyStallLimit?: number;
+      onLateReady?: () => void;
+    }
+  ) {
+    return bootstrapKernelWorker({
+      worker,
+      realCdpTransport: makeStubCdpTransport(),
+      makeClient: (transport) => new OffscreenClient(makeStubCallbacks(), transport),
+      ...opts,
+    });
+  }
+
+  it('onReadyStall fires per quiet window and a late ready still resolves', async () => {
+    const { worker, port } = makeManualWorker();
+    const stalls: number[] = [];
+    const host = bootstrap(worker, {
+      readyTimeoutMs: 60,
+      onReadyStall: (info) => stalls.push(info.stalls),
+      readyStallLimit: 5,
+    });
+    // Two quiet windows pass; the boot is stalled but not dead.
+    await new Promise((r) => setTimeout(r, 150));
+    expect(stalls.length).toBeGreaterThanOrEqual(2);
+    // The worker comes up late — well past the base window — and ready
+    // resolves normally: no reload, no recovery screen.
+    port().postMessage({ type: 'kernel-worker-ready' });
+    await expect(host.ready).resolves.toBeUndefined();
+    host.dispose();
+  });
+
+  it('boot progress resets the stall count', async () => {
+    const { worker, port } = makeManualWorker();
+    const stalls: number[] = [];
+    const host = bootstrap(worker, {
+      readyTimeoutMs: 60,
+      onReadyStall: (info) => stalls.push(info.stalls),
+      readyStallLimit: 3,
+    });
+    // One stall accrues…
+    await new Promise((r) => setTimeout(r, 90));
+    expect(stalls).toEqual([1]);
+    // …then progress lands: the count restarts from 1 on the next stall
+    // instead of marching to the limit.
+    port().postMessage({ type: 'kernel-worker-boot-progress', stage: 'shared-fs-mount:9' });
+    await new Promise((r) => setTimeout(r, 90));
+    expect(stalls).toEqual([1, 1]);
+    port().postMessage({ type: 'kernel-worker-ready' });
+    await expect(host.ready).resolves.toBeUndefined();
+    host.dispose();
+  });
+
+  it('rejects after the stall limit, then a late ready fires onLateReady exactly once', async () => {
+    const { worker, port } = makeManualWorker();
+    const onLateReady = vi.fn();
+    const host = bootstrap(worker, {
+      readyTimeoutMs: 40,
+      onReadyStall: () => {},
+      readyStallLimit: 2,
+      onLateReady,
+    });
+    await expect(host.ready).rejects.toThrow(/did not signal ready within 80ms/);
+    expect(onLateReady).not.toHaveBeenCalled();
+    // The worker finishes booting behind the recovery screen: the listener
+    // must still be attached and report the late arrival.
+    port().postMessage({ type: 'kernel-worker-ready' });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(onLateReady).toHaveBeenCalledTimes(1);
+    // Cleanup ran when the late ready fired — a duplicate ready is inert.
+    port().postMessage({ type: 'kernel-worker-ready' });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(onLateReady).toHaveBeenCalledTimes(1);
+    host.dispose();
+  });
+
+  it('without the new options the first quiet window still rejects (legacy)', async () => {
+    const { worker } = makeManualWorker();
+    const started = Date.now();
+    const host = bootstrap(worker, { readyTimeoutMs: 50 });
+    await expect(host.ready).rejects.toThrow(/did not signal ready within 50ms/);
+    // One window, not three: no onReadyStall means no silent extra waiting.
+    expect(Date.now() - started).toBeLessThan(140);
+    host.dispose();
+  });
+});

--- a/packages/webapp/tests/scoops/mount-heartbeat.test.ts
+++ b/packages/webapp/tests/scoops/mount-heartbeat.test.ts
@@ -76,4 +76,71 @@ describe('withMountHeartbeat', () => {
     await expect(withMountHeartbeat(async () => 42)).resolves.toBe(42);
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it('hands the work a callable no-op tick even with no callback', async () => {
+    // The orchestrator always threads the tick into VirtualFS.create; it
+    // must be safe to call when there is no onProgress consumer.
+    await expect(
+      withMountHeartbeat(async (tick) => {
+        tick();
+        tick();
+        return 'ok';
+      })
+    ).resolves.toBe('ok');
+  });
+
+  // 2026-08-24 field wedge: the same repair took ~8 minutes on an
+  // I/O-starved disk — far past the old TIME cap — while provably
+  // advancing entry by entry. Ticks must keep the beats flowing.
+  it('beats past the cap for as long as ticks keep advancing', async () => {
+    const stages: string[] = [];
+    let tick: () => void = () => {};
+    const never = new Promise<never>(() => {});
+    void withMountHeartbeat(
+      (t) => {
+        tick = t;
+        return never;
+      },
+      (s) => stages.push(s)
+    );
+    const rounds = MOUNT_HEARTBEAT_MAX_BEATS * 3;
+    for (let i = 0; i < rounds; i += 1) {
+      tick(); // at least one unit of progress per interval
+      await vi.advanceTimersByTimeAsync(MOUNT_HEARTBEAT_INTERVAL_MS);
+    }
+    // start + one beat per advancing interval — no cap applied.
+    expect(stages).toHaveLength(1 + rounds);
+    expect(stages.at(-1)).toBe(`shared-fs-mount:${rounds}`);
+  });
+
+  it('a tick resets the quiet run, then the cap counts silence only', async () => {
+    const stages: string[] = [];
+    let tick: () => void = () => {};
+    const never = new Promise<never>(() => {});
+    void withMountHeartbeat(
+      (t) => {
+        tick = t;
+        return never;
+      },
+      (s) => stages.push(s)
+    );
+    // Nearly exhaust the quiet budget…
+    await vi.advanceTimersByTimeAsync(
+      MOUNT_HEARTBEAT_INTERVAL_MS * (MOUNT_HEARTBEAT_MAX_BEATS - 1)
+    );
+    expect(stages).toHaveLength(1 + (MOUNT_HEARTBEAT_MAX_BEATS - 1));
+    // …then one unit of progress restores the full quiet budget: one
+    // reset beat + MAX quiet beats before silence…
+    tick();
+    await vi.advanceTimersByTimeAsync(
+      MOUNT_HEARTBEAT_INTERVAL_MS * (MOUNT_HEARTBEAT_MAX_BEATS + 1)
+    );
+    const expected = 1 + (MOUNT_HEARTBEAT_MAX_BEATS - 1) + (MOUNT_HEARTBEAT_MAX_BEATS + 1);
+    expect(stages).toHaveLength(expected);
+    // …and once the budget is spent with no further ticks, the beat stays
+    // quiet: the watchdog regains authority.
+    await vi.advanceTimersByTimeAsync(MOUNT_HEARTBEAT_INTERVAL_MS * 10);
+    expect(stages).toHaveLength(expected);
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/packages/webapp/tests/ui/boot/boot-stall-overlay.test.ts
+++ b/packages/webapp/tests/ui/boot/boot-stall-overlay.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  removeBootStallOverlay,
+  showBootStallOverlay,
+} from '../../../src/ui/boot/boot-stall-overlay.js';
+
+describe('boot stall overlay', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it('renders once and updates the elapsed time on repeat calls', () => {
+    showBootStallOverlay(document, { elapsedMs: 30_000 });
+    const overlay = document.getElementById('slicc-boot-stall-overlay');
+    expect(overlay).toBeTruthy();
+    expect(overlay?.textContent).toContain('30s');
+    expect(overlay?.textContent).toContain('your data is untouched');
+
+    showBootStallOverlay(document, { elapsedMs: 90_000 });
+    // Still exactly one overlay, refreshed in place — the stall callback
+    // fires per watchdog window and must not stack banners.
+    expect(document.querySelectorAll('#slicc-boot-stall-overlay')).toHaveLength(1);
+    expect(document.getElementById('slicc-boot-stall-overlay')?.textContent).toContain('90s');
+  });
+
+  it('does not replace the app DOM — the wired shell must survive a stall', () => {
+    const shell = document.createElement('main');
+    shell.id = 'app';
+    document.body.appendChild(shell);
+    showBootStallOverlay(document, { elapsedMs: 30_000 });
+    expect(document.getElementById('app')).toBe(shell);
+  });
+
+  it('offers a plain Reload and no destructive action', () => {
+    const reload = vi.fn();
+    showBootStallOverlay(document, { elapsedMs: 30_000 }, { reload });
+    const buttons = [...document.querySelectorAll('#slicc-boot-stall-overlay button')];
+    expect(buttons.map((b) => b.textContent)).toEqual(['Reload']);
+    (buttons[0] as HTMLButtonElement).click();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('removeBootStallOverlay clears it and is safe when never shown', () => {
+    removeBootStallOverlay(document); // no-op
+    showBootStallOverlay(document, { elapsedMs: 30_000 });
+    removeBootStallOverlay(document);
+    expect(document.getElementById('slicc-boot-stall-overlay')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Boot must never lose the race against its own watchdog. In the 2026-08-24 field incident (following #2007, #2146, #2172), the unconditional pre-boot sidecar repair took ~8 minutes over a 22,355-entry `.metadata.json` on an I/O-starved disk. The mount heartbeat's time cap (~2 min) expired, the page's 30 s kernel-ready watchdog fired, and the leader bricked to the recovery screen — while the kernel worker kept booting and finished successfully behind it. The page threw away a healthy boot.

Three independent legs, each of which alone would have prevented the wedge:

### 1. Late-ready recovery (`kernel/spawn.ts`, `ui/wc/wc-live.ts`, new `ui/boot/boot-stall-overlay.ts`)

The ready watchdog now bounds **silence**, not boot time:

- Each zero-progress window short of a stall limit (default 3 when the caller opts in) fires `onReadyStall` instead of rejecting. wc-live renders a non-destructive "Still starting…" overlay **over** the already-wired shell — everything except the final `ready` await is set up before the worker replies, so a late `kernel-worker-ready` resumes the normal boot path with no reload.
- Boot progress resets the stall count, so the limit caps consecutive silence only.
- Past the limit, `ready` rejects and the recovery screen renders exactly as before — but with `onLateReady` set, the listener stays attached: a worker that finishes booting behind the recovery screen triggers one guarded reload (shared reload guard with the stale-asset path, so no reload loops) into the now-warm session.
- Without the new options the behavior is bit-identical to today (single window, same error message) — all existing spawn tests pass unchanged.

### 2. Progress-based heartbeat (`scoops/mount-heartbeat.ts`, `fs/sidecar-repair.ts`, `fs/virtual-fs.ts`, `scoops/orchestrator.ts`)

The shared-FS mount heartbeat was time-capped (24×5 s, then silence), which conflates "slow" with "wedged". The #2146 repair now ticks once per sidecar entry scanned (`VirtualFsOptions.onRepairProgress`, threaded from `withMountHeartbeat`), and the cap counts consecutive **quiet** intervals: while the scan advances, beats flow indefinitely; a genuinely wedged mount (deadlocked web lock, hung OPFS handle) produces no ticks and goes silent after the same ~2 minutes as before.

### 3. Mount hygiene (`fs/auto-mount-table.ts`, `kernel/host.ts`, `fs/mount-recovery.ts`, `fs/mount-index.ts`)

- Persisted picker rows shadowed by a configured hostfs mount-table target are now **purged from IDB** (`hostShadowedEntries` + `removeMountEntry`), not just filtered per boot. Previously the row stayed armed forever: the first launch without the table entry would silently fall back to the stale FS-Access handle and index-walk a tree the user thought was config-owned (the live instance carries exactly this trap for an iCloud-backed `~/Desktop/kb`).
- Boot-time FS-Access restores index with a bounded budget (`RESTORED_MOUNT_INDEX_LIMITS`: depth 100 / 100 k entries) instead of the interactive 400 / 2 M. The mount stays fully usable past the bound — only the fast-discovery index truncates (`entries-exceeded`), and an interactive re-mount re-indexes with the full budget.

## Live reproductions (2026-08-24, both on the same instance)

1. Cold boot under disk pressure: sidecar repair ~8 min → watchdog fired at ~2.5 min → recovery screen; worker finished booting behind it.
2. Warm reload under load average ~260 (concurrent coverage + build runs): same brick, same completed-but-unheard worker. A quiet-machine reload booted in 5 s.

Leg 1 self-heals both cases; leg 2 prevents the watchdog firing in the first place while the repair advances.

## Tests

- `spawn.test.ts`: stall callback per quiet window + late-ready resolve, progress resets the stall count, hard reject after the limit + `onLateReady` fires exactly once (duplicate-ready inert), legacy single-window rejection pinned.
- `mount-heartbeat.test.ts`: beats continue past the cap while ticks advance; a tick restores the full quiet budget; tick-less behavior identical to before (existing tests unchanged).
- `sidecar-repair.test.ts`: one tick per entry scanned; tick optional.
- `mount-recovery.test.ts`: restored local mounts pass `RESTORED_MOUNT_INDEX_LIMITS`.
- `auto-mount-table.test.ts`: `hostShadowedEntries` is the exact complement of `withoutHostMountedTargets`.
- `boot-stall-overlay.test.ts` (jsdom): idempotent render/update, shell DOM untouched, Reload-only (no destructive action), removal safe.

## Docs

`docs/mounts.md`: config-owned purge semantics + the boot-time restore index budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
