### PR TITLE
fix(boot): heartbeat the orchestrator init tail — the boot's other silent stretch

### DIFF
--- a/packages/webapp/src/scoops/mount-heartbeat.ts
+++ b/packages/webapp/src/scoops/mount-heartbeat.ts
@@ -50,12 +50,16 @@ export const MOUNT_HEARTBEAT_MAX_BEATS = 24;
 export async function withMountHeartbeat<T>(
   work: (tick: () => void) => Promise<T>,
   onProgress?: (stage: string) => void,
-  options: { intervalMs?: number; maxBeats?: number } = {}
+  options: { intervalMs?: number; maxBeats?: number; stagePrefix?: string } = {}
 ): Promise<T> {
   if (!onProgress) return work(() => {});
   const intervalMs = options.intervalMs ?? MOUNT_HEARTBEAT_INTERVAL_MS;
   const maxBeats = options.maxBeats ?? MOUNT_HEARTBEAT_MAX_BEATS;
-  onProgress('shared-fs-mount:start');
+  // The prefix names the covered boot phase in the beat stream (visible to
+  // the page-side watchdog and in boot traces). Default preserved for the
+  // original consumer, the shared-FS mount.
+  const stagePrefix = options.stagePrefix ?? 'shared-fs-mount';
+  onProgress(`${stagePrefix}:start`);
   let beats = 0;
   let quietBeats = 0;
   let ticks = 0;
@@ -75,7 +79,7 @@ export async function withMountHeartbeat<T>(
       }
     }
     beats += 1;
-    onProgress(`shared-fs-mount:${beats}`);
+    onProgress(`${stagePrefix}:${beats}`);
   }, intervalMs);
   try {
     return await work(tick);

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -417,6 +417,57 @@ export class Orchestrator implements ConeApprovalRouter {
     return this.processManager;
   }
 
+  /**
+   * The init tail is the boot's OTHER silent stretch (2026-08-24 x-ray:
+   * ~50s of OPFS-stat I/O-wait between the mount finishing and the first
+   * scoop restore, with zero progress messages — enough to blow the
+   * kernel-ready watchdog on its own). Root-structure seeding, the sudo
+   * policy, the /etc caches, and the scoop-record load all do per-entry
+   * VFS I/O with no milestones of their own, so they get the same
+   * heartbeat under their own stage prefix: interval beats keep the
+   * watchdog armed through one slow step, ticks between steps reset the
+   * quiet budget, and a genuinely wedged step still goes quiet and times
+   * out.
+   */
+  private async initPolicyLayerAndLoadRecords(
+    sharedFs: VirtualFS,
+    fsWatcher: FsWatcher,
+    onBootProgress?: (stage: string) => void
+  ): Promise<Record<string, RegisteredScoop>> {
+    return withMountHeartbeat(
+      async (tick) => {
+        await this.ensureRootStructure();
+        tick();
+
+        // Stand up the sudo policy manager: seeds the default /etc/sudoers
+        // template, loads + merges the live policy, and watches for changes
+        // so edits (and "Always" grants) take effect with no restart. The
+        // same manager is threaded into every ScoopContext below.
+        this.sudoManager = new SudoManager({
+          fs: sharedFs,
+          watcher: fsWatcher,
+          onPolicyReload: (folder) => this.lifecycle.syncReadGrants(folder),
+        });
+        await this.sudoManager.init();
+        tick();
+        this.llmsTxtIgnorePolicy = new LlmsTxtIgnorePolicy(sharedFs, fsWatcher);
+        await this.llmsTxtIgnorePolicy.init();
+        tick();
+        // Seed + load `/etc/models` BEFORE any scoop is restored: the policy
+        // gates which provider a scoop may be spawned against, and an
+        // unloaded policy is closed (own catalogue only), so loading late
+        // would reject valid spawns.
+        this.modelPolicyFile = new ModelPolicyFile(sharedFs, fsWatcher);
+        await this.modelPolicyFile.init();
+        tick();
+
+        return db.getAllScoops();
+      },
+      onBootProgress,
+      { stagePrefix: 'orchestrator-init' }
+    );
+  }
+
   /** Initialize orchestrator and load saved scoops */
   /**
    * @param onBootProgress Optional heartbeat fired after each restored
@@ -447,27 +498,12 @@ export class Orchestrator implements ConeApprovalRouter {
     this.fsWatcher = new FsWatcher();
     this.sharedFs.setWatcher(this.fsWatcher);
     (globalThis as SliccGlobalHooks).__slicc_fs_watcher = this.fsWatcher;
-    await this.ensureRootStructure();
 
-    // Stand up the sudo policy manager: seeds the default /etc/sudoers
-    // template, loads + merges the live policy, and watches for changes so
-    // edits (and "Always" grants) take effect with no restart. The same
-    // manager is threaded into every ScoopContext below.
-    this.sudoManager = new SudoManager({
-      fs: this.sharedFs,
-      watcher: this.fsWatcher,
-      onPolicyReload: (folder) => this.lifecycle.syncReadGrants(folder),
-    });
-    await this.sudoManager.init();
-    this.llmsTxtIgnorePolicy = new LlmsTxtIgnorePolicy(this.sharedFs, this.fsWatcher);
-    await this.llmsTxtIgnorePolicy.init();
-    // Seed + load `/etc/models` BEFORE any scoop is restored: the policy gates
-    // which provider a scoop may be spawned against, and an unloaded policy is
-    // closed (own catalogue only), so loading late would reject valid spawns.
-    this.modelPolicyFile = new ModelPolicyFile(this.sharedFs, this.fsWatcher);
-    await this.modelPolicyFile.init();
-
-    const savedScoops = await db.getAllScoops();
+    const savedScoops = await this.initPolicyLayerAndLoadRecords(
+      this.sharedFs,
+      this.fsWatcher,
+      onBootProgress
+    );
     // Legacy records predate the ownership edge; the deleted `isCone` field
     // is the only root signal they carry, so it anchors the backfill once,
     // here — through `legacyRecordIsCone`, the one sanctioned read.

--- a/packages/webapp/tests/scoops/mount-heartbeat.test.ts
+++ b/packages/webapp/tests/scoops/mount-heartbeat.test.ts
@@ -143,4 +143,21 @@ describe('withMountHeartbeat', () => {
     expect(stages).toHaveLength(expected);
     expect(vi.getTimerCount()).toBe(0);
   });
+
+  it('names the beats after the stagePrefix option', async () => {
+    const stages: string[] = [];
+    let resolveWork: (v: string) => void = () => {};
+    const work = new Promise<string>((r) => {
+      resolveWork = r;
+    });
+    const p = withMountHeartbeat(
+      () => work,
+      (s) => stages.push(s),
+      { stagePrefix: 'orchestrator-init' }
+    );
+    await vi.advanceTimersByTimeAsync(MOUNT_HEARTBEAT_INTERVAL_MS);
+    expect(stages).toEqual(['orchestrator-init:start', 'orchestrator-init:1']);
+    resolveWork('done');
+    await expect(p).resolves.toBe('done');
+  });
 });

--- a/packages/webapp/tests/scoops/orchestrator-boot-progress.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator-boot-progress.test.ts
@@ -89,6 +89,11 @@ describe('orchestrator boot-progress heartbeat (#2007)', () => {
     // The mount phase is the boot's silent O(tree) stretch — the heartbeat
     // must announce it so the kernel-ready watchdog re-arms (#2007).
     expect(stages).toContain('shared-fs-mount:start');
+    // The init tail (root structure, sudo policy, /etc caches, scoop-record
+    // load) was the boot's OTHER silent stretch — ~50s of OPFS-stat I/O with
+    // no progress messages in the 2026-08-24 field wedge. Its heartbeat must
+    // announce itself under its own prefix.
+    expect(stages).toContain('orchestrator-init:start');
   });
 
   it('is optional — init() with no callback still boots', async () => {


### PR DESCRIPTION
## Summary

Re-lands #2391 on `main`. The original PR was based on `bb/kernel-ready-slow-boot-recovery-thr_hjr5x2ck4f` (#2390's branch) and was merged into *that* branch after #2390 had already merged to `main`, so the fix never reached `main` — it is stranded on a topic branch that is now 27 commits behind. Only the queue-covered path counts, and a PR into a topic branch is neither queue-covered nor `ci`-gated (#2391's head had `classify` + `gated-review` and three skipped `reconcile` runs, and nothing else).

This is the same commit, cherry-picked onto `origin/main` on top of #2390's merged form (clean, no conflicts).

Original PR body follows.

---

Follow-up to #2390, covering the boot's **other** silent stretch. The 2026-08-24 boot x-ray showed the live wedge wasn't only the sidecar repair: between the shared-FS mount finishing (~+23 s) and the first scoop restore (~+74 s) the kernel worker spent ~50 s I/O-waiting on OPFS stats (profiler: 22 k idle samples, top frame `stat` in the ZenFS bundle) while emitting **zero** boot-progress messages. That stretch alone blows the 30 s kernel-ready watchdog — it is why the live instance kept losing a 75-second boot to a 53-second deadline even after #2390's repair ticks.

## Change

- `withMountHeartbeat` gains a `stagePrefix` option (default `shared-fs-mount`, unchanged for the existing consumer).
- `Orchestrator.init`'s tail — root-structure seeding, `SudoManager.init`, `LlmsTxtIgnorePolicy.init`, `ModelPolicyFile.init`, and the scoop-record load — moves into `initPolicyLayerAndLoadRecords`, wrapped in the same heartbeat under `orchestrator-init:*`. Interval beats keep the watchdog armed through one slow step; ticks between steps reset the quiet budget; a genuinely wedged step still goes quiet after the cap and times out.

## Tests

- `mount-heartbeat.test.ts`: `stagePrefix` names the beat stream.
- `orchestrator-boot-progress.test.ts`: `init()` emits `orchestrator-init:start` alongside the existing mount and per-scoop beats.

## Verification

`lint`, `typecheck`, `test` (16839 passed / 0 failed), `check-touched-exemptions` (4 changed files, 0 on any debt list), production build + chrome-extension build — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
