### PR TITLE
fix(webapp): narrow migrateLegacyConeMemory read-catch to ENOENT

### DIFF
--- a/packages/webapp/src/scoops/cone-memory-store.ts
+++ b/packages/webapp/src/scoops/cone-memory-store.ts
@@ -226,12 +226,16 @@ export class ConeMemoryStore {
     try {
       const raw = await fs.readFile('/workspace/CLAUDE.md', { encoding: 'utf-8' });
       coneContent = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
-    } catch {
-      try {
-        await fs.mkdir('/workspace', { recursive: true });
-      } catch {
-        // Already exists
-      }
+    } catch (err) {
+      // Only treat "file doesn't exist yet" as empty. Anything else (transient
+      // OPFS fault, RestrictedFS EACCES, mount-backed I/O error) MUST propagate
+      // — otherwise the unconditional writeFile below would clobber the existing
+      // durable /workspace/CLAUDE.md with just the freshly-migrated blocks, and
+      // the sentinel written afterwards would make that loss permanent. Letting
+      // a genuine fault throw leaves the sentinel unwritten so the migration
+      // retries next boot with the file intact. Mirrors `appendConeMemory`.
+      if (!(err instanceof FsError) || err.code !== 'ENOENT') throw err;
+      await fs.mkdir('/workspace', { recursive: true });
     }
     const separator = coneContent.length === 0 || coneContent.endsWith('\n') ? '' : '\n';
     const merged = coneContent + separator + '\n' + blocks.join('\n\n') + '\n';

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -7,6 +7,7 @@
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import 'fake-indexeddb/auto';
+import { FsError } from '../../src/fs/index.js';
 import {
   clearAllMessages,
   getAllScoops,
@@ -2822,6 +2823,59 @@ describe('Orchestrator legacy cone-memory migration', () => {
     expect(await readUtf8(fs, '/cones/cone-beta/CLAUDE.md')).not.toContain(
       '- primary learned something'
     );
+  });
+
+  // #2400: a transient/non-ENOENT read fault on /workspace/CLAUDE.md must NOT
+  // be swallowed as "empty base" — otherwise the unconditional merge-write
+  // would clobber existing durable cone memory, and the sentinel written
+  // afterwards would make that loss permanent. The fault must propagate so the
+  // migration retries next boot with the file intact.
+  it('does not clobber /workspace/CLAUDE.md (or drop the sentinel) on a non-ENOENT read fault', async () => {
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(container, noopCallbacks());
+    await orch.init();
+
+    const fs = orch.getSharedFS()!;
+
+    // Durable, user-curated cone memory that MUST survive a failed migration.
+    const durable = '# My cone notes\n\nImportant stuff I wrote.\n';
+    await fs.writeFile('/workspace/CLAUDE.md', durable);
+
+    // A shared file with an auto-block so the migration reaches the
+    // read-modify-write of /workspace/CLAUDE.md, and re-run the migration.
+    await fs.writeFile(
+      '/shared/CLAUDE.md',
+      '## Auto-extracted (2024-01-01, compaction)\n\n- legacy bullet\n'
+    );
+    await fs.rm('/workspace/.cone-memory-migrated').catch(() => {});
+
+    // Make ONLY the /workspace/CLAUDE.md read fail with a transient (non-ENOENT)
+    // fault; every other read passes through to the real VFS.
+    const realReadFile = fs.readFile.bind(fs);
+    const readSpy = vi
+      .spyOn(fs, 'readFile')
+      .mockImplementation((path: string, ...rest: unknown[]) => {
+        if (path === '/workspace/CLAUDE.md') {
+          throw new FsError('EIO', 'transient VFS fault', path);
+        }
+        return (realReadFile as (...args: unknown[]) => unknown)(path, ...rest) as ReturnType<
+          typeof fs.readFile
+        >;
+      });
+
+    await expect(
+      (orch as unknown as MigrationPrivate).memoryStore.migrateLegacyConeMemory()
+    ).rejects.toBeInstanceOf(FsError);
+
+    readSpy.mockRestore();
+
+    // The durable file is intact — it was NOT overwritten with just the block.
+    expect(await readUtf8(fs, '/workspace/CLAUDE.md')).toBe(durable);
+    // The sentinel was NOT dropped, so the migration retries next boot.
+    await expect(fs.stat('/workspace/.cone-memory-migrated')).rejects.toBeDefined();
   });
 });
 


### PR DESCRIPTION
Closes #2400

## What changed

`ConeMemoryStore.migrateLegacyConeMemory()` read the destination
`/workspace/CLAUDE.md` inside a bare `catch {}` that treated **any**
failure as "file is empty". A transient, non-ENOENT read fault
(OPFS glitch, `RestrictedFS` `EACCES`, mount-backed I/O error) therefore
downgraded to an empty base, and the subsequent unconditional
merge-`writeFile` clobbered the cone's existing durable memory with only
the freshly-migrated blocks. Because the migration writes a one-shot
sentinel (`/workspace/.cone-memory-migrated`) immediately afterward, that
loss was **permanent** — no retry, no surfaced error.

The catch is now narrowed to ENOENT (mirroring the sibling
`appendConeMemory`, hardened in #1500/#1357): "file doesn't exist yet"
still means an empty base and creates `/workspace`, but every other error
rethrows. A genuine fault propagates, leaving the sentinel **unwritten**,
so the migration retries on the next boot with `/workspace/CLAUDE.md`
intact rather than destroyed.

`FsError` was already imported in the module; only the catch block
changed.

## Test

Added a focused case to the existing `Orchestrator legacy cone-memory
migration` suite in `packages/webapp/tests/scoops/orchestrator.test.ts`.
It seeds durable cone memory, forces a non-ENOENT (`EIO`) `readFile`
fault on `/workspace/CLAUDE.md` only, and asserts that
`migrateLegacyConeMemory()` rejects, the durable file is byte-for-byte
unchanged, and the sentinel was **not** dropped.

## Verification

- `npx biome check --write` on both touched files — clean
- `npm run typecheck` — passes
- `npx vitest run tests/scoops/orchestrator.test.ts -t "legacy cone-memory migration"` — 8/8 pass (new case included)
- `npm run verify` — all 7 checks pass
- `npm run test:coverage:webapp` — passes
