### PR TITLE
fix(playwright-cli): harden the browser bridge under concurrent scoop access

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -13,7 +13,6 @@
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/interaction.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/network-requests.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts": 2,
-  "packages/webapp/src/shell/supplemental-commands/playwright/handlers/snapshot.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/teleport.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/playwright/session-log.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/snapshot.ts": 3,

--- a/packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
+++ b/packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
@@ -168,6 +168,21 @@ playwright-cli screenshot --tab=<id> --fullPage                  # Full scrollab
 playwright-cli screenshot --tab=<id> --max-width=800             # Downscale to a max width
 ```
 
+An element screenshot (`screenshot e5`) returns **that element's crop or fails**
+(exit 1) — typically because the snapshot went stale after a navigation or
+layout change. Re-run `snapshot` and retry with a fresh ref; it never silently
+substitutes a full-viewport frame.
+
+A `resize` sticks to its tab: the viewport override is re-applied automatically
+whenever the tab is re-attached, so another driver switching tabs cannot reset
+it.
+
+All playwright-cli commands share one browser and run **serialized**. When
+concurrent callers (e.g. parallel scoops) queue up, commands may emit a
+`note: browser bridge contended — ...` line on stderr with the total lock wait
+and queue depth — treat it as a signal to stagger callers or reduce fan-out
+rather than re-running commands.
+
 ### Save As
 
 ```bash

--- a/packages/webapp/src/cdp/browser-api.ts
+++ b/packages/webapp/src/cdp/browser-api.ts
@@ -83,6 +83,10 @@ export class BrowserAPI {
   private _frameContextCache = new Map<string, number>();
   private _mainWorldContextCache = new Map<string, number>();
   private _tabLock: Promise<void> = Promise.resolve();
+  private _viewportOverrides = new Map<string, { width: number; height: number }>();
+  private _tabLockQueueDepth = 0;
+  private _tabLockTotalWaitMs = 0;
+  private _tabLockAcquisitions = 0;
   private _onSessionChange?: ((sessionId: string, transport: CDPTransport) => void) | undefined;
   /**
    * Last-used connect options (url + protocols) captured on the first
@@ -221,12 +225,75 @@ export class BrowserAPI {
     });
     const prev = this._tabLock;
     this._tabLock = next;
+    this._tabLockQueueDepth += 1;
+    const waitStart = Date.now();
     await prev;
+    this._tabLockTotalWaitMs += Date.now() - waitStart;
+    this._tabLockAcquisitions += 1;
     try {
       const sessionId = await this.attachToPage(targetId);
       return await fn(sessionId);
     } finally {
+      this._tabLockQueueDepth -= 1;
       release!();
+    }
+  }
+
+  /**
+   * Contention metrics for the tab lock that serializes all `withTab` work.
+   *
+   * `queueDepth` counts callers currently holding or waiting for the lock,
+   * `totalWaitMs` accumulates time spent queued across all callers, and
+   * `acquisitions` counts completed lock grants. Callers snapshot the stats
+   * before and after an operation to attribute contention observed while it
+   * ran (e.g. `playwright-cli` surfaces it on stderr so concurrent agents can
+   * back off deliberately instead of guessing).
+   */
+  getTabLockStats(): { queueDepth: number; totalWaitMs: number; acquisitions: number } {
+    return {
+      queueDepth: this._tabLockQueueDepth,
+      totalWaitMs: this._tabLockTotalWaitMs,
+      acquisitions: this._tabLockAcquisitions,
+    };
+  }
+
+  /**
+   * Apply a viewport emulation override to a tab and remember it per target.
+   *
+   * CDP device-metrics overrides live on the CDP *session*, but `attachToPage`
+   * creates a fresh session whenever a caller re-attaches after another tab was
+   * attached in between — so with concurrent drivers, a plain
+   * `Emulation.setDeviceMetricsOverride` silently evaporates and screenshots
+   * get captured at whatever width the window happens to have. Recording the
+   * override per target lets {@link attachToPage} re-apply it on every fresh
+   * session, making a tab's viewport stable no matter which driver measured it
+   * last. Cleared by {@link closePage}.
+   */
+  async setViewportOverride(targetId: string, width: number, height: number): Promise<void> {
+    const sessionId = await this.attachToPage(targetId);
+    await this.client.send(
+      'Emulation.setDeviceMetricsOverride',
+      { width, height, deviceScaleFactor: 1, mobile: false },
+      sessionId
+    );
+    this._viewportOverrides.set(targetId, { width, height });
+  }
+
+  /** Re-apply a recorded viewport override after a fresh attach (best-effort). */
+  private async reapplyViewportOverride(targetId: string, sessionId: string): Promise<void> {
+    const vp = this._viewportOverrides.get(targetId);
+    if (!vp) return;
+    try {
+      await this.client.send(
+        'Emulation.setDeviceMetricsOverride',
+        { width: vp.width, height: vp.height, deviceScaleFactor: 1, mobile: false },
+        sessionId
+      );
+    } catch (err) {
+      log.warn('Failed to re-apply viewport override on re-attach', {
+        targetId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 
@@ -359,6 +426,7 @@ export class BrowserAPI {
    */
   async closePage(targetId: string): Promise<void> {
     await this.ensureConnected();
+    this._viewportOverrides.delete(targetId);
 
     // Check if this is a remote tray target (format: "runtimeId:localTargetId")
     if (this.trayTargetProvider?.createRemoteTransport && targetId.includes(':')) {
@@ -475,6 +543,7 @@ export class BrowserAPI {
         this.sessionId = result['sessionId'] as string;
         this.attachedTargetId = targetId;
         await this.client.send('Page.enable', {}, this.sessionId);
+        await this.reapplyViewportOverride(targetId, this.sessionId);
         this._onSessionChange?.(this.sessionId, this.client);
         return this.sessionId;
       }
@@ -502,6 +571,7 @@ export class BrowserAPI {
     // Keep Page events available so unexpected dialogs can be auto-dismissed
     // before they stall the current CDP command.
     await this.localClient.send('Page.enable', {}, this.sessionId);
+    await this.reapplyViewportOverride(targetId, this.sessionId);
     this._onSessionChange?.(this.sessionId, this.localClient);
     return this.sessionId;
   }

--- a/packages/webapp/src/kernel/realm/realm-host.ts
+++ b/packages/webapp/src/kernel/realm/realm-host.ts
@@ -1131,13 +1131,10 @@ async function dispatchBrowser(
       const targetId = args[0] as string;
       const width = args[1] as number;
       const height = args[2] as number;
+      // Recorded per target so BrowserAPI re-applies it on every fresh attach —
+      // parity with the playwright-cli `resize` handler.
       return browser.withTab(targetId, async () => {
-        await browser.sendCDP('Emulation.setDeviceMetricsOverride', {
-          width,
-          height,
-          deviceScaleFactor: 1,
-          mobile: false,
-        });
+        await browser.setViewportOverride(targetId, width, height);
       });
     }
     case 'navigateTab': {

--- a/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
@@ -85,6 +85,36 @@ function knownFlagSpecForWalk(spec: KnownFlagSpec): KnownFlagSpec {
   };
 }
 
+/**
+ * Tab-lock wait accumulated across the bridge while one command ran before the
+ * command's stderr carries a contention note. All `playwright-cli` callers
+ * share one serialized browser, so the note is bridge-wide: it tells a fanned-
+ * out agent that siblings are queuing, and to back off deliberately instead of
+ * guessing why calls are slow (or detached past `background_after`).
+ */
+const CONTENTION_NOTE_THRESHOLD_MS = 2000;
+
+function tabLockStatsSnapshot(browser: PlaywrightBrowser): { totalWaitMs: number } | undefined {
+  return typeof browser.getTabLockStats === 'function' ? browser.getTabLockStats() : undefined;
+}
+
+function withContentionNote(
+  browser: PlaywrightBrowser,
+  before: { totalWaitMs: number } | undefined,
+  result: CmdResult
+): CmdResult {
+  if (!before || typeof browser.getTabLockStats !== 'function') return result;
+  const after = browser.getTabLockStats();
+  const waitedMs = after.totalWaitMs - before.totalWaitMs;
+  if (waitedMs < CONTENTION_NOTE_THRESHOLD_MS) return result;
+  const waited = (waitedMs / 1000).toFixed(1);
+  const note =
+    `note: browser bridge contended — tab-lock waits totaled ${waited}s while this command ran ` +
+    `(queue depth ${after.queueDepth}). playwright-cli commands share one browser and run ` +
+    'serialized; stagger concurrent callers or reduce fan-out.\n';
+  return { ...result, stderr: result.stderr + note };
+}
+
 async function commandErrorResult(
   browser: PlaywrightBrowser,
   flags: Record<string, string>,
@@ -191,6 +221,8 @@ export function createPlaywrightCommand(
     // Note: Per-tab teleport blocking is now handled within command handlers
     // via requireTab() -> browser.withTab() serialization
 
+    const lockStatsBefore = tabLockStatsSnapshot(browser);
+
     let result: CmdResult;
     const handler = playwrightHandlers.get(subcommand);
     if (!handler) {
@@ -227,6 +259,6 @@ export function createPlaywrightCommand(
       // Session logging is best-effort — never fail the command
     }
 
-    return result;
+    return withContentionNote(browser, lockStatsBefore, result);
   });
 }

--- a/packages/webapp/src/shell/supplemental-commands/playwright/handlers/snapshot.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/handlers/snapshot.ts
@@ -2,13 +2,21 @@
  * Page inspection subcommands: snapshot, frames, screenshot.
  */
 
-import type { BrowserAPI } from '../../../../cdp/index.js';
-import type { FrameInfo } from '../../../../cdp/types.js';
-import { isExtensionRealm } from '../../../../core/runtime-env.js';
+import { isExtensionRealm } from '../../../../base/runtime-env.js';
 import { ensureSessionDirs } from '../session-log.js';
 import { renderNode, takeSnapshot } from '../snapshot.js';
 import { base64ToBytes, filenameSafeTimestamp, requireTab, resolveFrame } from '../state.js';
-import type { PlaywrightHandler, PlaywrightState, TabSnapshot } from '../types.js';
+import type {
+  PlaywrightHandler,
+  PlaywrightHandlerCtx,
+  PlaywrightState,
+  TabSnapshot,
+} from '../types.js';
+
+// Named via the handler context rather than imported from `cdp/` so this
+// module stays inside the shell layer (see layer-stack import direction).
+type BrowserAPI = PlaywrightHandlerCtx['browser'];
+type FrameInfo = Awaited<ReturnType<BrowserAPI['getFrameTree']>>[number];
 
 type ScreenshotClip = { x: number; y: number; width: number; height: number };
 
@@ -194,9 +202,10 @@ export const screenshotHandler: PlaywrightHandler = async ({
   if ('error' in tab) {
     return { stdout: '', stderr: tab.error, exitCode: 1 };
   }
-  let screenshotStderr = '';
   const output = await browser.withTab(tab.targetId, async () => {
-    // Ref-based screenshot
+    // Ref-based screenshot: the requested element's crop or a loud failure.
+    // Silently substituting the full viewport corrupts downstream visual
+    // comparisons with a 0 exit code — worse than any error.
     let clip: ScreenshotClip | undefined;
     if (positional[0]?.startsWith('e')) {
       const snapshot = state.snapshots.get(tab.targetId);
@@ -204,8 +213,13 @@ export const screenshotHandler: PlaywrightHandler = async ({
         throw new Error('No snapshot available. Run "snapshot" first.');
       }
       clip = await resolveElementClip(browser, snapshot, positional[0]);
-      if (!clip) {
-        screenshotStderr += `Warning: could not clip to element ${positional[0]}, capturing full viewport\n`;
+      if (!clip || clip.width <= 0 || clip.height <= 0) {
+        return {
+          error:
+            `could not resolve element ${positional[0]} to a visible box — the snapshot is ` +
+            'likely stale (navigation, reload, or layout change). Re-run "snapshot" and retry ' +
+            'with a fresh ref, or omit the ref to capture the viewport deliberately.',
+        };
       }
     }
 
@@ -227,7 +241,10 @@ export const screenshotHandler: PlaywrightHandler = async ({
       // Best-effort
     }
     const sizeKB = Math.round(bytes.length / 1024);
-    return `Screenshot saved to ${savePath} (${sizeKB} KB)`;
+    return { message: `Screenshot saved to ${savePath} (${sizeKB} KB)` };
   });
-  return { stdout: output + '\n', stderr: screenshotStderr, exitCode: 0 };
+  if ('error' in output) {
+    return { stdout: '', stderr: `screenshot: ${output.error}\n`, exitCode: 1 };
+  }
+  return { stdout: output.message + '\n', stderr: '', exitCode: 0 };
 };

--- a/packages/webapp/src/shell/supplemental-commands/playwright/handlers/tabs.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/handlers/tabs.ts
@@ -214,19 +214,10 @@ export const resizeHandler: PlaywrightHandler = async ({ browser, state, positio
       exitCode: 1,
     };
   }
+  // Recorded per target so BrowserAPI re-applies it on every fresh attach —
+  // a sibling driver switching tabs must not reset this tab's viewport.
   await browser.withTab(tab.targetId, async () => {
-    const transport = browser.getTransport();
-    const sessionId = browser.getSessionId();
-    await transport.send(
-      'Emulation.setDeviceMetricsOverride',
-      {
-        width: w,
-        height: h,
-        deviceScaleFactor: 1,
-        mobile: false,
-      },
-      sessionId!
-    );
+    await browser.setViewportOverride(tab.targetId, w, h);
   });
   state.snapshots.delete(tab.targetId);
   return { stdout: `Resized viewport to ${w}x${h}\n`, stderr: '', exitCode: 0 };

--- a/packages/webapp/tests/cdp/browser-api.test.ts
+++ b/packages/webapp/tests/cdp/browser-api.test.ts
@@ -1109,7 +1109,93 @@ describe('BrowserAPI', () => {
     });
   });
 
+  describe('viewport override persistence', () => {
+    function attachCounting() {
+      let sessCount = 0;
+      (mockClient.send as ReturnType<typeof vi.fn>).mockImplementation(async (method: string) =>
+        method === 'Target.attachToTarget' ? { sessionId: `sess-${++sessCount}` } : {}
+      );
+    }
+
+    function emulationCalls() {
+      return (mockClient.send as ReturnType<typeof vi.fn>).mock.calls.filter(
+        ([method]) => method === 'Emulation.setDeviceMetricsOverride'
+      );
+    }
+
+    it('sets and records a viewport override for a tab', async () => {
+      attachCounting();
+      await api.withTab('t1', async () => {
+        await api.setViewportOverride('t1', 1440, 900);
+      });
+      expect(emulationCalls()).toEqual([
+        [
+          'Emulation.setDeviceMetricsOverride',
+          { width: 1440, height: 900, deviceScaleFactor: 1, mobile: false },
+          'sess-1',
+        ],
+      ]);
+    });
+
+    it('re-applies the override when re-attaching to the tab after a sibling switched away', async () => {
+      attachCounting();
+      await api.withTab('t1', async () => {
+        await api.setViewportOverride('t1', 1440, 900);
+      });
+      await api.withTab('t2', async () => {});
+      await api.withTab('t1', async () => {});
+      const calls = emulationCalls();
+      // Initial set on sess-1, then re-applied on the fresh re-attach session
+      expect(calls).toHaveLength(2);
+      expect(calls[1]).toEqual([
+        'Emulation.setDeviceMetricsOverride',
+        { width: 1440, height: 900, deviceScaleFactor: 1, mobile: false },
+        'sess-3',
+      ]);
+    });
+
+    it('drops the override when the tab is closed', async () => {
+      attachCounting();
+      await api.withTab('t1', async () => {
+        await api.setViewportOverride('t1', 1440, 900);
+      });
+      await api.closePage('t1');
+      await api.withTab('t2', async () => {});
+      await api.withTab('t1', async () => {});
+      expect(emulationCalls()).toHaveLength(1);
+    });
+  });
+
   describe('withTab mutex', () => {
+    it('tracks queue depth and cumulative wait in getTabLockStats', async () => {
+      (mockClient.send as ReturnType<typeof vi.fn>).mockImplementation(async () => ({
+        sessionId: 'sess-x',
+      }));
+
+      let releaseFirst: () => void;
+      const gate = new Promise<void>((r) => {
+        releaseFirst = r;
+      });
+      const p1 = api.withTab('target-1', async () => {
+        await gate;
+        return 1;
+      });
+      await new Promise((r) => setTimeout(r, 5));
+      const p2 = api.withTab('target-2', async () => 2);
+      await new Promise((r) => setTimeout(r, 20));
+
+      // p1 holds the lock, p2 queued behind it
+      expect(api.getTabLockStats().queueDepth).toBe(2);
+
+      releaseFirst!();
+      await Promise.all([p1, p2]);
+
+      const stats = api.getTabLockStats();
+      expect(stats.queueDepth).toBe(0);
+      expect(stats.acquisitions).toBe(2);
+      expect(stats.totalWaitMs).toBeGreaterThanOrEqual(10);
+    });
+
     it('serializes two concurrent withTab calls with different targetIds', async () => {
       const order: string[] = [];
 

--- a/packages/webapp/tests/kernel/realm/playwright-host-ops.test.ts
+++ b/packages/webapp/tests/kernel/realm/playwright-host-ops.test.ts
@@ -136,6 +136,14 @@ function makeMockBrowser(state: MockBrowserState): BrowserAPI {
       state.viewportCalls.push({ method, params });
       return {};
     },
+    // Mirror the real BrowserAPI.setViewportOverride: send the emulation
+    // override and record it per target.
+    async setViewportOverride(_targetId: string, width: number, height: number): Promise<void> {
+      state.viewportCalls.push({
+        method: 'Emulation.setDeviceMetricsOverride',
+        params: { width, height, deviceScaleFactor: 1, mobile: false },
+      });
+    },
   };
   return api as unknown as BrowserAPI;
 }

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -106,6 +106,17 @@ function createMockBrowser(overrides: Partial<BrowserAPI> = {}): BrowserAPI {
     // overrides apply).
     createHarRecorder: vi.fn((fs: VirtualFS) => new HarRecorder(browser.getTransport(), fs)),
     getSessionId: vi.fn().mockReturnValue('session-1'),
+    // Mirror the real BrowserAPI.setViewportOverride: send the emulation
+    // override on the tab's session and record it per target.
+    setViewportOverride: vi.fn(async (_targetId: string, width: number, height: number) => {
+      await browser
+        .getTransport()
+        .send(
+          'Emulation.setDeviceMetricsOverride',
+          { width, height, deviceScaleFactor: 1, mobile: false },
+          'session-1'
+        );
+    }),
     withTab: vi
       .fn()
       .mockImplementation(async (_targetId: string, fn: (s: string) => Promise<unknown>) => {
@@ -1056,6 +1067,42 @@ describe('playwright-cli tab management', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('Test Page');
     expect(result.stdout).toContain('https://example.com');
+  });
+
+  it('appends a contention note when tab-lock waits accumulate during a command', async () => {
+    const stats = [
+      { queueDepth: 5, totalWaitMs: 0, acquisitions: 0 },
+      { queueDepth: 5, totalWaitMs: 7000, acquisitions: 3 },
+    ];
+    const contendedBrowser = createMockBrowser({
+      getTabLockStats: vi.fn(
+        () => stats.shift() ?? { queueDepth: 0, totalWaitMs: 7000, acquisitions: 3 }
+      ),
+    } as unknown as Partial<BrowserAPI>);
+    const cmd = createPlaywrightCommand(
+      'playwright-cli',
+      contendedBrowser as BrowserAPI,
+      fs as VirtualFS
+    );
+    const result = await cmd.execute(['tab-list'], mockCtx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toContain('browser bridge contended');
+    expect(result.stderr).toContain('7.0s');
+    expect(result.stderr).toContain('queue depth 5');
+  });
+
+  it('stays quiet when tab-lock waits are negligible', async () => {
+    const uncontendedBrowser = createMockBrowser({
+      getTabLockStats: vi.fn(() => ({ queueDepth: 1, totalWaitMs: 10, acquisitions: 1 })),
+    } as unknown as Partial<BrowserAPI>);
+    const cmd = createPlaywrightCommand(
+      'playwright-cli',
+      uncontendedBrowser as BrowserAPI,
+      fs as VirtualFS
+    );
+    const result = await cmd.execute(['tab-list'], mockCtx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain('contended');
   });
 
   it('tab-list filters Chrome internal UI targets and keeps only actionable tabs', async () => {
@@ -4788,8 +4835,9 @@ describe('playwright-cli flag additions (Task 5)', () => {
     expect(browser.screenshot).toHaveBeenCalledWith(expect.objectContaining({ fullPage: true }));
   });
 
-  // 10. screenshot with unresolvable element ref warns on stderr
-  it('screenshot with unresolvable element ref emits warning on stderr and still succeeds', async () => {
+  // 10. screenshot with unresolvable element ref fails loudly — a silent
+  // full-viewport substitute corrupts downstream visual comparisons
+  it('screenshot with unresolvable element ref fails instead of capturing the viewport', async () => {
     // Make DOM.resolveNode return no objectId so clipFromBackendNode returns undefined
     const mockTransport = {
       send: vi.fn().mockImplementation((method: string) => {
@@ -4804,10 +4852,9 @@ describe('playwright-cli flag additions (Task 5)', () => {
     await cmd.execute(['snapshot', '--tab=tab-1'], mockCtx);
 
     const result = await cmd.execute(['screenshot', 'e1', '--tab=tab-1'], mockCtx);
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('Screenshot saved to');
-    expect(result.stderr).toContain('Warning: could not clip to element e1');
-    expect(result.stderr).toContain('capturing full viewport');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('could not resolve element e1');
+    expect(browser.screenshot).not.toHaveBeenCalled();
   });
 });
 
@@ -5847,9 +5894,14 @@ describe('playwright-cli argv validation (#2405)', () => {
   });
 
   it('screenshot still accepts a real ref', async () => {
+    // The transport must return a real objectId so resolveElementClip can
+    // measure the element's bounding box.  A missing objectId now causes an
+    // explicit error (no silent viewport fallback) — see screenshotHandler.
     const mockTransport = {
       send: vi.fn().mockImplementation((method: string) => {
-        if (method === 'DOM.resolveNode') return { object: {} };
+        if (method === 'DOM.resolveNode') return { object: { objectId: 'obj-1' } };
+        if (method === 'Runtime.callFunctionOn')
+          return { result: { value: { x: 10, y: 10, width: 100, height: 50 } } };
         return {};
       }),
     };

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/snapshot.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/snapshot.test.ts
@@ -257,14 +257,37 @@ describe('screenshotHandler', () => {
     );
   });
 
-  it('warns when the element clip cannot be resolved', async () => {
-    const { browser } = makeBrowser({ evaluateResult: null });
+  it('fails loudly when the element clip cannot be resolved — never a silent viewport frame', async () => {
+    const { browser, screenshot } = makeBrowser({ evaluateResult: null });
     const state = createPlaywrightState();
     state.snapshots.set(TAB, makeSnapshot({ refToSelector: new Map([['e5', '#a']]) }));
     const r = await screenshotHandler(
       createHandlerCtx({ browser, state, positional: ['e5'], flags: { tab: TAB }, fs: okFs() })
     );
-    expect(r.stderr).toContain('could not clip to element e5');
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('could not resolve element e5');
+    expect(r.stderr).toContain('snapshot');
+    expect(screenshot).not.toHaveBeenCalled();
+  });
+
+  it('fails loudly when the resolved element box has zero size', async () => {
+    const { browser, screenshot } = makeBrowser({
+      sendImpl: (m) => {
+        if (m === 'DOM.resolveNode') return { object: { objectId: 'o1' } };
+        if (m === 'Runtime.callFunctionOn') {
+          return { result: { value: { x: 1, y: 2, width: 0, height: 0 } } };
+        }
+        return {};
+      },
+    });
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e5', 9]]) }));
+    const r = await screenshotHandler(
+      createHandlerCtx({ browser, state, positional: ['e5'], flags: { tab: TAB }, fs: okFs() })
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('could not resolve element e5');
+    expect(screenshot).not.toHaveBeenCalled();
   });
 
   it('throws when a ref screenshot has no snapshot', async () => {


### PR DESCRIPTION
## Summary

When N scoops drive `playwright-cli` concurrently (N=8 observed in a `liftoff-demo` run against frescopa.coffee, 2026-08-25), the browser bridge degraded three ways: element screenshots silently returned full-viewport frames with exit 0, viewport resizes evaporated when a sibling driver switched tabs, and commands queued invisibly on the global tab lock until they blew past `background_after` and were killed (`exit 124`, `bash: execution aborted`). All 8 scoops independently diagnosed contention; 3 of 9 verification crops were the wrong image with no error signal.

This PR fixes the three runtime failure modes.

## Changes

**Element screenshots fail loudly** — `playwright/handlers/snapshot.ts`
- `screenshot <ref>` returns the element's crop or exits 1 with a stale-snapshot hint (re-run `snapshot`). It no longer substitutes a full-viewport frame with a stderr-only warning and a 0 exit code, and it rejects zero-size boxes. Wrong data that looks like success corrupted downstream visual comparisons.

**Per-tab viewport overrides survive re-attach** — `cdp/browser-api.ts`, `playwright/handlers/tabs.ts`, `kernel/realm/realm-host.ts`
- CDP device-metrics overrides live on the session, and `attachToPage` mints a fresh session whenever a sibling attached in between — so a plain `Emulation.setDeviceMetricsOverride` silently reset under concurrency (scoops instructed to verify at 1440 measured 1720/1425/1360). `BrowserAPI.setViewportOverride` records the override per target and `attachToPage` re-applies it on every fresh session (local and remote tray branches); `closePage` drops the record. The shell `resize` and realm `setViewport` share the mechanism (follower/realm parity).

**Contention signal** — `cdp/browser-api.ts`, `playwright-command.ts`
- `withTab` tracks queue depth, cumulative wait, and acquisitions (`getTabLockStats()`). The dispatcher snapshots the stats around each command and appends a stderr note when bridge-wide lock waits exceeded 2s while the command ran, so fanned-out agents can back off deliberately instead of guessing why calls are slow or detached.

**Debt + docs**
- Pays off `handlers/snapshot.ts`'s 3 layer back-edges (cdp/core imports replaced with handler-context types and the `base/` runtime-env source); baseline ratcheted 63 → 60.
- Documents the three contracts in the `playwright-cli` agent skill.

## Tests

- 8 new tests: loud-failure + zero-size clip (handler and command level), tab-lock stats under concurrency, viewport override set / re-apply-on-re-attach / drop-on-close, contention note emitted and suppressed.
- 3 existing tests updated to the new contracts (old silent-fallback expectation, resize via `setViewportOverride`, realm `setViewport`).
- Full local pass: `verify`, `check-touched-exemptions`, `typecheck`, `test` (16859 passed; the 6 `iframe integration` failures also fail on pristine main in this environment — they need the live-browser harness), both builds, `bundle-size`.

## Not in scope (follow-ups from the same incident report)

- Partial-output recovery for killed background bash jobs (needs `just-bash` to surface accumulated output on `ExecutionAbortedError`).
- Approval/sudo duplicate-grant + global serialization interaction (separate report).