### PR TITLE
fix(fetch-proxy): expose all forwarded response headers to CORS clients

### DIFF
--- a/packages/node-server/src/bridge-security.ts
+++ b/packages/node-server/src/bridge-security.ts
@@ -125,6 +125,12 @@ const CORS_BASE_ALLOW_HEADERS = [
  * (`isProxyError` reads `X-Proxy-Error`) and the forbidden-response
  * bridge (`decodeForbiddenResponseHeaders` reads `X-Proxy-Set-Cookie`). MCP
  * clients also read protocol negotiation/session headers from proxy responses.
+ *
+ * `/api/fetch-proxy` overrides this per-response with the union of this base
+ * set and every forwarded upstream header name (see
+ * `buildFetchProxyExposeHeaders`) so agents can inspect non-CORS-safelisted
+ * headers such as Content-Security-Policy. Other `/api/*` routes keep this
+ * static list.
  */
 const CORS_EXPOSE_HEADERS =
   'Link, X-Proxy-Error, X-Proxy-Set-Cookie, X-Proxy-Content-Length, Mcp-Session-Id, MCP-Protocol-Version';

--- a/packages/node-server/src/fetch-proxy-headers.ts
+++ b/packages/node-server/src/fetch-proxy-headers.ts
@@ -67,15 +67,51 @@ export const FETCH_PROXY_SKIP_RESPONSE_HEADERS: ReadonlySet<string> = new Set([
  * middleware remains the sole CORS authority. `x-proxy-` is the proxy's
  * own response-marker namespace — never echo an upstream value.
  */
-/**
- * Proxy-set response header carrying the upstream `content-length` when it is
- * exact (identity encoding). Read by the webapp's `proxied-fetch.ts` to drive
- * determinate download progress; never copied from upstream (the `x-proxy-`
- * prefix below guarantees that).
- */
-export const FETCH_PROXY_CONTENT_LENGTH_HEADER = 'X-Proxy-Content-Length';
-
 export const FETCH_PROXY_SKIP_RESPONSE_PREFIXES: readonly string[] = [
   'access-control-',
   'x-proxy-',
 ];
+
+/**
+ * Proxy-set response header carrying the upstream `content-length` when it is
+ * exact (identity encoding). Read by the webapp's `proxied-fetch.ts` to drive
+ * determinate download progress; never copied from upstream (the `x-proxy-`
+ * prefix above guarantees that).
+ */
+export const FETCH_PROXY_CONTENT_LENGTH_HEADER = 'X-Proxy-Content-Length';
+
+/**
+ * Response headers the browser must always be allowed to read on the
+ * `/api/fetch-proxy` hop, even when the upstream response carries none of
+ * them. Kept in sync with `CORS_EXPOSE_HEADERS` in `bridge-security.ts` and
+ * `BridgeSecurity.corsExposeHeaders` in the Swift server. The route appends
+ * every forwarded upstream header name on top of this base so agents can
+ * inspect CSP / HSTS / ETag / etc. — browsers only surface non-CORS-safelisted
+ * response headers when they appear here (credentials mode forbids `*`).
+ */
+export const FETCH_PROXY_BASE_EXPOSE_HEADERS: readonly string[] = [
+  'Link',
+  'X-Proxy-Error',
+  'X-Proxy-Set-Cookie',
+  FETCH_PROXY_CONTENT_LENGTH_HEADER,
+  'Mcp-Session-Id',
+  'MCP-Protocol-Version',
+  'Cache-Control',
+];
+
+/**
+ * Build the `Access-Control-Expose-Headers` value for a proxied response:
+ * the static proxy markers plus every header name we actually forwarded.
+ * Dedupes case-insensitively while preserving the first-seen spelling.
+ */
+export function buildFetchProxyExposeHeaders(forwardedHeaderNames: Iterable<string>): string {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const name of [...FETCH_PROXY_BASE_EXPOSE_HEADERS, ...forwardedHeaderNames]) {
+    const lower = name.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    out.push(name);
+  }
+  return out.join(', ');
+}

--- a/packages/node-server/src/routes/fetch-proxy.ts
+++ b/packages/node-server/src/routes/fetch-proxy.ts
@@ -3,6 +3,7 @@ import { StringDecoder } from 'node:string_decoder';
 import { HMAC_SIGN_HEADER, isLoopbackOrigin, isTextContentType } from '@slicc/shared-ts';
 import type { Express, Request, Response } from 'express';
 import {
+  buildFetchProxyExposeHeaders,
   FETCH_PROXY_CONTENT_LENGTH_HEADER,
   FETCH_PROXY_SKIP_HEADERS,
   FETCH_PROXY_SKIP_RESPONSE_HEADERS,
@@ -184,6 +185,12 @@ function unmaskRequestBody(
  * middleware remains the sole authority on the browser→bridge hop —
  * see `FETCH_PROXY_SKIP_RESPONSE_HEADERS` / `..._PREFIXES`. All header
  * values are secret-scrubbed.
+ *
+ * After forwarding, set `Access-Control-Expose-Headers` to the union of the
+ * proxy markers and every forwarded header name. Cross-origin thin-bridge
+ * callers (sliccy.ai → localhost) run under credentials mode, so the
+ * browser otherwise only surfaces CORS-safelisted headers and agents
+ * silently miss CSP / HSTS / X-Frame-Options / ETag / etc.
  */
 function forwardUpstreamHeaders(
   res: Response,
@@ -193,6 +200,7 @@ function forwardUpstreamHeaders(
   res.status(upstream.status);
   res.setHeader('Cache-Control', 'no-store, no-cache');
 
+  const forwardedNames: string[] = [];
   const setCookieValues = upstream.headers.getSetCookie();
   upstream.headers.forEach((v, k) => {
     const lower = k.toLowerCase();
@@ -200,6 +208,7 @@ function forwardUpstreamHeaders(
     if (FETCH_PROXY_SKIP_RESPONSE_PREFIXES.some((p) => lower.startsWith(p))) return;
     // Headers are small — one-shot scrub, no per-chunk semantics.
     res.setHeader(k, secretProxy.scrubResponse(v));
+    forwardedNames.push(k);
   });
   if (setCookieValues.length > 0) {
     res.setHeader('X-Proxy-Set-Cookie', secretProxy.scrubResponse(JSON.stringify(setCookieValues)));
@@ -221,6 +230,9 @@ function forwardUpstreamHeaders(
   if (upstreamLength && !upstream.headers.get('content-encoding') && /^\d+$/.test(upstreamLength)) {
     res.setHeader(FETCH_PROXY_CONTENT_LENGTH_HEADER, upstreamLength);
   }
+  // Override the thin-bridge middleware's static expose list with the
+  // full set for this response. Credentials mode forbids `*`.
+  res.setHeader('Access-Control-Expose-Headers', buildFetchProxyExposeHeaders(forwardedNames));
 }
 
 /**

--- a/packages/node-server/tests/routes/fetch-proxy.test.ts
+++ b/packages/node-server/tests/routes/fetch-proxy.test.ts
@@ -337,7 +337,9 @@ describe('registerFetchProxyRoute', () => {
     // hub returning `access-control-allow-origin: *`) would
     // `res.setHeader`-clobber the bridge middleware's authoritative
     // ACAO, leaving the browser with an opaque `TypeError: Failed to
-    // fetch`. The route must drop the whole access-control-* family.
+    // fetch`. The route must drop the whole access-control-* family
+    // from upstream, then set its *own* Access-Control-Expose-Headers
+    // listing every forwarded header (credentials mode forbids `*`).
     await setup((_req, res) => {
       res.setHeader('access-control-allow-origin', '*');
       res.setHeader('access-control-allow-credentials', 'true');
@@ -345,6 +347,8 @@ describe('registerFetchProxyRoute', () => {
       res.setHeader('access-control-expose-headers', 'X-Custom');
       res.setHeader('access-control-max-age', '600');
       res.setHeader('content-type', 'text/plain');
+      res.setHeader('content-security-policy', "default-src 'none'");
+      res.setHeader('x-frame-options', 'DENY');
       res.end('ok');
     });
     const res = await fetch(`${proxyBase}/api/fetch-proxy`, {
@@ -354,8 +358,16 @@ describe('registerFetchProxyRoute', () => {
     expect(res.headers.get('access-control-allow-origin')).toBeNull();
     expect(res.headers.get('access-control-allow-credentials')).toBeNull();
     expect(res.headers.get('access-control-allow-methods')).toBeNull();
-    expect(res.headers.get('access-control-expose-headers')).toBeNull();
     expect(res.headers.get('access-control-max-age')).toBeNull();
+    // Upstream's expose list must not win; ours lists forwarded headers.
+    const expose = res.headers.get('access-control-expose-headers') ?? '';
+    expect(expose.toLowerCase()).not.toBe('x-custom');
+    expect(expose.toLowerCase()).toContain('content-type');
+    expect(expose.toLowerCase()).toContain('content-security-policy');
+    expect(expose.toLowerCase()).toContain('x-frame-options');
+    expect(expose.toLowerCase()).toContain('x-proxy-set-cookie');
+    expect(res.headers.get('content-security-policy')).toBe("default-src 'none'");
+    expect(res.headers.get('x-frame-options')).toBe('DENY');
   });
 
   it('strips the thin-bridge auth header before forwarding upstream', async () => {

--- a/packages/swift-server/Sources/Server/APIRoutes.swift
+++ b/packages/swift-server/Sources/Server/APIRoutes.swift
@@ -1000,6 +1000,28 @@ private func makeStreamingProxyResponse(
 
     headers[cacheControlHeader] = "no-store, no-cache"
 
+    // Expose every forwarded header plus the proxy markers so cross-origin
+    // thin-bridge browsers (credentials mode) can read non-CORS-safelisted
+    // names like Content-Security-Policy. Mirrors node-server's
+    // `buildFetchProxyExposeHeaders`. Upstream Access-Control-* was already
+    // stripped above so we own this value.
+    var exposeNames: [String] = [
+        "Link",
+        "X-Proxy-Error",
+        "X-Proxy-Set-Cookie",
+        "Mcp-Session-Id",
+        "MCP-Protocol-Version",
+        "Cache-Control",
+    ]
+    var exposeSeen = Set(exposeNames.map { $0.lowercased() })
+    for field in headers {
+        let lower = field.name.canonicalName.lowercased()
+        if exposeSeen.contains(lower) { continue }
+        exposeSeen.insert(lower)
+        exposeNames.append(field.name.canonicalName)
+    }
+    headers[HTTPField.Name("Access-Control-Expose-Headers")!] = exposeNames.joined(separator: ", ")
+
     let contentType = (headers[HTTPField.Name.contentType] ?? "").lowercased()
     let isText =
         contentType.hasPrefix("text/")

--- a/packages/swift-server/Sources/Server/BridgeSecurity.swift
+++ b/packages/swift-server/Sources/Server/BridgeSecurity.swift
@@ -107,6 +107,12 @@ enum BridgeSecurity {
     /// (`isProxyError` reads `X-Proxy-Error`) and the forbidden-response
     /// bridge (`decodeForbiddenResponseHeaders` reads `X-Proxy-Set-Cookie`). MCP
     /// clients also read protocol negotiation/session headers from proxy responses.
+    ///
+    /// `/api/fetch-proxy` overrides this per-response with the union of this
+    /// base set and every forwarded upstream header name (see
+    /// `makeStreamingProxyResponse`) so agents can inspect non-CORS-safelisted
+    /// headers such as Content-Security-Policy. Other `/api/*` routes keep
+    /// this static list.
     static let corsExposeHeaders =
         "Link, X-Proxy-Error, X-Proxy-Set-Cookie, Mcp-Session-Id, MCP-Protocol-Version"
 

--- a/packages/swift-server/Sources/Server/ThinBridgeCorsMiddleware.swift
+++ b/packages/swift-server/Sources/Server/ThinBridgeCorsMiddleware.swift
@@ -81,7 +81,20 @@ struct ThinBridgeCorsMiddleware<Context: RequestContext>: RouterMiddleware {
 
         var response = try await next(request, context)
         if let corsHeaders {
+            // `/api/fetch-proxy` (and any future route that needs to surface
+            // non-CORS-safelisted upstream headers) sets its own
+            // Access-Control-Expose-Headers after forwarding. Preserve that
+            // value — overwriting with the static BridgeSecurity list would
+            // hide CSP / HSTS / X-Frame-Options from thin-bridge browsers
+            // (credentials mode forbids `*`). Other CORS fields still come
+            // from BridgeSecurity so the bridge remains the sole ACAO/ACAC
+            // authority.
+            let exposeHeader = HTTPField.Name("Access-Control-Expose-Headers")!
+            let routeExpose = response.headers[exposeHeader]
             for field in corsHeaders {
+                if field.name == exposeHeader, routeExpose != nil {
+                    continue
+                }
                 response.headers[field.name] = field.value
             }
         }

--- a/packages/swift-server/Tests/APIRoutesTests.swift
+++ b/packages/swift-server/Tests/APIRoutesTests.swift
@@ -509,12 +509,24 @@ final class APIRoutesTests: XCTestCase {
                             "proxy must not forward upstream Access-Control-Allow-Credentials"
                         )
                         XCTAssertNil(
-                            response.headers[HTTPField.Name("Access-Control-Expose-Headers")!],
-                            "proxy must not forward upstream Access-Control-Expose-Headers"
-                        )
-                        XCTAssertNil(
                             response.headers[HTTPField.Name("Access-Control-Max-Age")!],
                             "proxy must not forward upstream Access-Control-Max-Age"
+                        )
+                        // Upstream's expose list must not win; the proxy sets its
+                        // own Access-Control-Expose-Headers listing forwarded names.
+                        let expose = response.headers[HTTPField.Name("Access-Control-Expose-Headers")!] ?? ""
+                        XCTAssertFalse(
+                            expose.lowercased() == "x-evil",
+                            "proxy must not forward upstream Access-Control-Expose-Headers verbatim"
+                        )
+                        XCTAssertTrue(
+                            expose.lowercased().contains("content-type"),
+                            "proxy must expose forwarded Content-Type"
+                        )
+                        XCTAssertTrue(
+                            expose.lowercased().contains("x-proxy-set-cookie")
+                                || expose.lowercased().contains("cache-control"),
+                            "proxy must expose its own marker headers"
                         )
                     }
                 }

--- a/packages/swift-server/Tests/ThinBridgeCorsMiddlewareTests.swift
+++ b/packages/swift-server/Tests/ThinBridgeCorsMiddlewareTests.swift
@@ -15,17 +15,27 @@ final class ThinBridgeCorsMiddlewareTests: XCTestCase {
     private static let acAllowCredentials = HTTPField.Name("Access-Control-Allow-Credentials")!
     private static let acAllowPrivateNetwork = HTTPField.Name("Access-Control-Allow-Private-Network")!
     private static let acAllowMethods = HTTPField.Name("Access-Control-Allow-Methods")!
+    private static let acExposeHeaders = HTTPField.Name("Access-Control-Expose-Headers")!
     private static let acMaxAge = HTTPField.Name("Access-Control-Max-Age")!
     private static let bridgeTokenHeader = HTTPField.Name(BridgeSecurity.bridgeTokenHeader)!
     private static let testToken = "test-bridge-token-123"
 
-    private func buildRouter(bridgeToken: String? = ThinBridgeCorsMiddlewareTests.testToken)
-        -> Router<BasicRequestContext>
-    {
+    private func buildRouter(
+        bridgeToken: String? = ThinBridgeCorsMiddlewareTests.testToken,
+        routeExposeHeaders: String? = nil
+    ) -> Router<BasicRequestContext> {
         let router = Router(context: BasicRequestContext.self)
         router.middlewares.add(ThinBridgeCorsMiddleware<BasicRequestContext>(bridgeToken: bridgeToken))
         router.get("/api/status") { _, _ in
-            Response(status: .ok, body: .init(byteBuffer: ByteBuffer(string: #"{"ok":true}"#)))
+            var headers = HTTPFields()
+            if let routeExposeHeaders {
+                headers[Self.acExposeHeaders] = routeExposeHeaders
+            }
+            return Response(
+                status: .ok,
+                headers: headers,
+                body: .init(byteBuffer: ByteBuffer(string: #"{"ok":true}"#))
+            )
         }
         return router
     }
@@ -143,6 +153,48 @@ final class ThinBridgeCorsMiddlewareTests: XCTestCase {
                 // critical assertion is "no CORS/PNA leak to disallowed origins".
                 XCTAssertNil(response.headers[Self.acAllowOrigin])
                 XCTAssertNil(response.headers[Self.acAllowPrivateNetwork])
+            }
+        }
+    }
+
+    func testPreservesRouteProvidedAccessControlExposeHeaders() async throws {
+        // Regression for the fetch-proxy dynamic expose list: the middleware
+        // must not clobber a route-set Access-Control-Expose-Headers with the
+        // static BridgeSecurity list, or thin-bridge browsers never see CSP.
+        let routeExpose =
+            "Link, X-Proxy-Error, X-Proxy-Set-Cookie, Cache-Control, content-security-policy, x-frame-options"
+        let app = Application(
+            responder: self.buildRouter(routeExposeHeaders: routeExpose).buildResponder()
+        )
+        try await app.test(.router) { client in
+            try await client.execute(
+                uri: "/api/status",
+                method: .get,
+                headers: [.origin: "https://www.sliccy.ai", Self.bridgeTokenHeader: Self.testToken]
+            ) { response in
+                XCTAssertEqual(response.status, .ok)
+                XCTAssertEqual(response.headers[Self.acAllowOrigin], "https://www.sliccy.ai")
+                XCTAssertEqual(response.headers[Self.acAllowCredentials], "true")
+                let expose = response.headers[Self.acExposeHeaders] ?? ""
+                XCTAssertEqual(expose, routeExpose)
+                XCTAssertTrue(expose.lowercased().contains("content-security-policy"))
+                XCTAssertTrue(expose.lowercased().contains("x-frame-options"))
+            }
+        }
+    }
+
+    func testAppliesStaticExposeHeadersWhenRouteOmitsThem() async throws {
+        let app = Application(responder: self.buildRouter().buildResponder())
+        try await app.test(.router) { client in
+            try await client.execute(
+                uri: "/api/status",
+                method: .get,
+                headers: [.origin: "https://www.sliccy.ai", Self.bridgeTokenHeader: Self.testToken]
+            ) { response in
+                XCTAssertEqual(
+                    response.headers[Self.acExposeHeaders],
+                    BridgeSecurity.corsExposeHeaders
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary

`curl -i` / `-I` in the thin-bridge shell only surfaced CORS-safelisted response headers (plus `Link` / `X-Proxy-Set-Cookie`), so agents concluded servers had no CSP/HSTS/X-Frame-Options when they did. Root cause: `/api/fetch-proxy` responses kept the static `Access-Control-Expose-Headers` list from the thin-bridge CORS middleware, and credentials mode forbids `*`.

Stock just-bash (Node) already returns the full header set — see vercel-labs/just-bash#388 / #389 for `-D`. This PR fixes the SLICC-only half.

## Why

**Repro (thin-bridge / sliccy.ai → localhost proxy):**
1. `curl -s -I https://github.com/ | grep -i content-security-policy`
2. Expected: CSP header present
3. Actual: missing (only safelisted + statically exposed names)

Cross-origin `fetch()` to `/api/fetch-proxy` filters unexposed headers. Extension Port streaming was unaffected; CLI thin-bridge path was.

## Approach / Implementation notes

- After forwarding upstream headers, set `Access-Control-Expose-Headers` to the union of proxy markers (`Link`, `X-Proxy-*`, MCP headers, `Cache-Control`) and every forwarded upstream header name (`buildFetchProxyExposeHeaders`).
- Still strip upstream `access-control-*` so the bridge owns CORS; we replace expose-headers with our list rather than echoing the upstream value.
- Mirrored in Swift `makeStreamingProxyResponse` for Sliccstart parity.
- Layering: `packages/node-server` fetch-proxy route + `packages/swift-server` APIRoutes; static CORS middleware list unchanged for other `/api/*` routes.

## Cross-cutting impact

- **Floats exercised:** CLI thin-bridge (`/api/fetch-proxy`), Sliccstart Swift proxy. Chrome extension Port path already delivered full headers (no CORS).
- **Shell contexts:** AlmostBashShell via `createProxiedFetch` CLI mode — headers become visible to `curl -i/-I` and in-shell `fetch()`.
- **Security:** Still strips upstream CORS headers and `www-authenticate` / hop-by-hop; only expands what the browser may *read* from headers we already forward.

## Test plan

- [x] `npx vitest run --project node-server tests/routes/fetch-proxy.test.ts tests/bridge-security.test.ts` — 62 passing
- [x] Updated CORS strip test asserts dynamic expose list includes CSP / X-Frame-Options
- [ ] Swift `APIRoutesTests.testFetchProxyStripsUpstreamAccessControlHeaders` (updated expectations)
- [ ] Manual thin-bridge: `curl -s -I https://github.com/` shows `content-security-policy` and `strict-transport-security`
- [x] No documentation changes needed

## Documentation

- [x] No documentation changes needed

## Risk & rollback

- Blast radius: thin-bridge + Sliccstart fetch-proxy response headers only.
- Rollback: revert this PR.
- Reviewer note: confirm a real thin-bridge session sees full headers; Node unit tests do not exercise browser CORS filtering.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs (N/A — internal proxy header exposure)
