### PR TITLE
fix(webcomponents): plot monitor sparklines full-width over a fixed time window

### DIFF
--- a/packages/webapp/src/ui/wc/monitor-history.ts
+++ b/packages/webapp/src/ui/wc/monitor-history.ts
@@ -6,8 +6,16 @@
  * "right now" and nothing records what "a minute ago" looked like. A
  * sparkline needs a series, so something has to keep one.
  *
- * This is deliberately the smallest thing that can: an in-memory ring buffer
- * fed by the panel's own 5s refresh. Consequences, stated rather than hidden:
+ * This is deliberately the smallest thing that can: an in-memory buffer fed by
+ * the panel's own 5s refresh, bounded by a fixed TIME window rather than by a
+ * sample count. The window is what makes two glances a minute apart
+ * comparable — samples are placed on the x axis by timestamp, so a pause in
+ * the cadence (panel closed, tab backgrounded and its timers throttled) shows
+ * as a gap instead of being drawn as if it never happened, and a buffer that
+ * only covers forty seconds draws forty seconds' worth of trace rather than
+ * stretching it across the whole tile.
+ *
+ * Consequences, stated rather than hidden:
  *
  *   - History starts when the panel opens and stops when it closes, because
  *     that is when the refresh runs (`wc-workbench.ts`). It is not a
@@ -20,8 +28,24 @@
  *     (the component's rule), so the first tick is simply plotless.
  */
 
-/** How many samples to keep. At the panel's 5s cadence this is ~5 minutes. */
-export const MONITOR_HISTORY_CAPACITY = 60;
+import type { MonitorSeries } from '@slicc/webcomponents';
+
+/**
+ * How far back the sparklines reach. One hour: long enough that the panel can
+ * say "the burn rate has been climbing since I opened it" and mean something,
+ * short enough that a 5s cadence fits in ~720 samples.
+ */
+export const MONITOR_HISTORY_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * Hard cap on retained samples, as a memory bound rather than a policy.
+ *
+ * Eviction is by AGE — this only stops a pathologically fast feeder (a
+ * caller ticking far below the panel's 5s cadence) from growing the buffer
+ * without limit. At the panel's cadence the window fills at ~720 samples, so
+ * this never binds in normal use.
+ */
+export const MONITOR_HISTORY_CAPACITY = 2_000;
 
 /** One reading of the metrics the vitals tiles plot. */
 export interface MonitorSample {
@@ -38,25 +62,46 @@ export interface MonitorSample {
 type SeriesKey = 'burnRate' | 'workingUnits' | 'liveProcesses';
 
 /**
- * A bounded, append-only series of monitor samples.
+ * A time-bounded, append-only series of monitor samples.
  *
  * Not a class with a persisted identity — the workbench owns one instance for
  * as long as the panel wiring lives, and tests make their own.
  */
 export class MonitorHistory {
   readonly #samples: MonitorSample[] = [];
+  readonly #windowMs: number;
   readonly #capacity: number;
 
-  constructor(capacity: number = MONITOR_HISTORY_CAPACITY) {
-    // A zero/negative capacity would make `push` a no-op and every series
-    // empty, which reads as "the metric is broken" rather than "the buffer
-    // is misconfigured". Refuse it instead.
+  constructor(
+    windowMs: number = MONITOR_HISTORY_WINDOW_MS,
+    capacity: number = MONITOR_HISTORY_CAPACITY
+  ) {
+    // A zero/negative window would evict every sample the moment it lands and
+    // leave every series empty, which reads as "the metric is broken" rather
+    // than "the buffer is misconfigured". Refuse it instead.
+    this.#windowMs = Math.max(1, Math.floor(windowMs));
+    // Likewise a capacity below 2 can never satisfy `series()`.
     this.#capacity = Math.max(2, Math.floor(capacity));
   }
 
-  /** Append a sample, evicting the oldest once the buffer is full. */
+  /** The span the sparklines plot into, in ms. */
+  get windowMs(): number {
+    return this.#windowMs;
+  }
+
+  /**
+   * Append a sample, dropping everything that has fallen out of the window.
+   *
+   * Age is measured against the NEWEST sample rather than `Date.now()` so the
+   * buffer stays a pure function of what was pushed into it: a test can push
+   * a synthetic timeline, and a reader that stops for an hour and resumes
+   * doesn't have its whole history vanish between two ticks of the same
+   * refresh.
+   */
   push(sample: MonitorSample): void {
     this.#samples.push(sample);
+    const cutoff = sample.at - this.#windowMs;
+    while (this.#samples.length > 0 && this.#samples[0].at < cutoff) this.#samples.shift();
     while (this.#samples.length > this.#capacity) this.#samples.shift();
   }
 
@@ -66,13 +111,20 @@ export class MonitorHistory {
   }
 
   /**
-   * The values of one metric, oldest first. Returns `undefined` below two
-   * points, which is exactly the input a sparkline can't plot — so callers
-   * can hand the result straight to `MonitorVital.series`.
+   * One metric as a plottable series — values WITH their timestamps, plus the
+   * window they are drawn in, which is what lets the component place them by
+   * elapsed time instead of by index.
+   *
+   * Returns `undefined` below two points, which is exactly the input a
+   * sparkline can't plot — so callers can hand the result straight to
+   * `MonitorVital.series`.
    */
-  series(key: SeriesKey): number[] | undefined {
+  series(key: SeriesKey): MonitorSeries | undefined {
     if (this.#samples.length < 2) return undefined;
-    return this.#samples.map((sample) => sample[key]);
+    return {
+      points: this.#samples.map((sample) => ({ at: sample.at, value: sample[key] })),
+      windowMs: this.#windowMs,
+    };
   }
 
   /** The largest value of one metric, or `null` when there are no samples. */
@@ -83,17 +135,20 @@ export class MonitorHistory {
 
   /**
    * How far back the buffer actually reaches, as display copy — `last 45s`,
-   * `last 4m`. `null` below two samples, matching {@link series}.
+   * `last 4m`, `last 2h`. `null` below two samples, matching {@link series}.
    *
-   * This reports the real span rather than the nominal capacity on purpose:
+   * This reports the real span rather than the nominal window on purpose:
    * a panel opened twenty seconds ago has twenty seconds of history, and
-   * labelling that "last 5 minutes" would be a lie told by a chart.
+   * labelling that "last hour" would be a lie told by a chart. The plot agrees
+   * with it — a short history draws a short trace.
    */
   windowLabel(): string | null {
     if (this.#samples.length < 2) return null;
     const spanMs = this.#samples[this.#samples.length - 1].at - this.#samples[0].at;
     const seconds = Math.max(1, Math.round(spanMs / 1000));
     if (seconds < 90) return `last ${seconds}s`;
-    return `last ${Math.round(seconds / 60)}m`;
+    const minutes = Math.round(seconds / 60);
+    if (minutes < 90) return `last ${minutes}m`;
+    return `last ${Math.round(minutes / 60)}h`;
   }
 }

--- a/packages/webapp/tests/ui/wc/monitor-history.test.ts
+++ b/packages/webapp/tests/ui/wc/monitor-history.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import {
   MONITOR_HISTORY_CAPACITY,
+  MONITOR_HISTORY_WINDOW_MS,
   MonitorHistory,
   type MonitorSample,
 } from '../../../src/ui/wc/monitor-history.js';
 
 function sample(at: number, overrides: Partial<MonitorSample> = {}): MonitorSample {
   return { at, burnRate: 1, workingUnits: 0, liveProcesses: 2, ...overrides };
+}
+
+/** The values of a series, dropping the timestamps — for value-only asserts. */
+function values(history: MonitorHistory, key: 'burnRate' | 'workingUnits' | 'liveProcesses') {
+  return history.series(key)?.points.map((p) => p.value);
 }
 
 describe('MonitorHistory', () => {
@@ -16,7 +22,23 @@ describe('MonitorHistory', () => {
     history.push(sample(1_000));
     expect(history.series('burnRate')).toBeUndefined();
     history.push(sample(6_000, { burnRate: 2 }));
-    expect(history.series('burnRate')).toEqual([1, 2]);
+    expect(history.series('burnRate')).toEqual({
+      points: [
+        { at: 1_000, value: 1 },
+        { at: 6_000, value: 2 },
+      ],
+      windowMs: MONITOR_HISTORY_WINDOW_MS,
+    });
+  });
+
+  it('carries the timestamps, so the plot can space points by elapsed time', () => {
+    // The whole point of the shape: an index-spaced chart draws a 90-second
+    // gap and a 5-second one identically.
+    const history = new MonitorHistory();
+    history.push(sample(0, { burnRate: 1 }));
+    history.push(sample(5_000, { burnRate: 2 }));
+    history.push(sample(95_000, { burnRate: 3 }));
+    expect(history.series('burnRate')?.points.map((p) => p.at)).toEqual([0, 5_000, 95_000]);
   });
 
   it('keeps samples oldest-first', () => {
@@ -24,23 +46,40 @@ describe('MonitorHistory', () => {
     history.push(sample(1_000, { workingUnits: 1 }));
     history.push(sample(6_000, { workingUnits: 3 }));
     history.push(sample(11_000, { workingUnits: 2 }));
-    expect(history.series('workingUnits')).toEqual([1, 3, 2]);
+    expect(values(history, 'workingUnits')).toEqual([1, 3, 2]);
   });
 
-  it('evicts the oldest sample once full', () => {
-    const history = new MonitorHistory(3);
-    for (let i = 0; i < 5; i++) history.push(sample(i * 1_000, { liveProcesses: i }));
-    expect(history.size).toBe(3);
-    expect(history.series('liveProcesses')).toEqual([2, 3, 4]);
+  it('evicts by AGE — samples that fall out of the window are dropped', () => {
+    // A 10s window, samples 1s apart: the buffer scrolls a fixed span rather
+    // than compressing an ever-longer history into the same pixels.
+    const history = new MonitorHistory(10_000);
+    for (let i = 0; i <= 20; i++) history.push(sample(i * 1_000, { liveProcesses: i }));
+    expect(values(history, 'liveProcesses')).toEqual([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
   });
 
-  it('refuses a capacity that would make every series unplottable', () => {
-    // A capacity below 2 can never satisfy `series()`, so a caller passing 0
-    // would silently get a monitor with no sparklines and no explanation.
-    const history = new MonitorHistory(0);
+  it('keeps a short history whole — a 40s buffer in a 1h window loses nothing', () => {
+    const history = new MonitorHistory();
+    for (let i = 0; i <= 8; i++) history.push(sample(i * 5_000, { liveProcesses: i }));
+    expect(history.size).toBe(9);
+    expect(history.series('liveProcesses')?.windowMs).toBe(MONITOR_HISTORY_WINDOW_MS);
+  });
+
+  it('caps retained samples so a fast feeder cannot grow the buffer without limit', () => {
+    // Eviction is by age; the capacity is only a memory bound.
+    const history = new MonitorHistory(MONITOR_HISTORY_WINDOW_MS, 5);
+    for (let i = 0; i < 20; i++) history.push(sample(i * 10, { liveProcesses: i }));
+    expect(history.size).toBe(5);
+    expect(values(history, 'liveProcesses')).toEqual([15, 16, 17, 18, 19]);
+  });
+
+  it('refuses a window or capacity that would make every series unplottable', () => {
+    // A zero window would evict each sample as it lands, and a capacity below
+    // 2 can never satisfy `series()` — either would silently give a monitor
+    // with no sparklines and no explanation.
+    const history = new MonitorHistory(0, 0);
     history.push(sample(1_000));
-    history.push(sample(6_000, { burnRate: 4 }));
-    expect(history.series('burnRate')).toEqual([1, 4]);
+    history.push(sample(1_000, { burnRate: 4 }));
+    expect(values(history, 'burnRate')).toEqual([1, 4]);
   });
 
   it('reports the peak of a metric', () => {
@@ -77,9 +116,18 @@ describe('MonitorHistory', () => {
     expect(minutes.windowLabel()).toBe('last 2m');
   });
 
-  it('holds roughly five minutes at the panel refresh cadence', () => {
-    // The capacity is chosen against wc-workbench's 5s monitor timer; if that
-    // timer changes, this is the assertion that should make someone re-check.
-    expect(MONITOR_HISTORY_CAPACITY * 5).toBe(300);
+  it('switches from minutes to hours at 90m', () => {
+    const history = new MonitorHistory(3 * 60 * 60 * 1000);
+    history.push(sample(0));
+    history.push(sample(2 * 60 * 60 * 1000));
+    expect(history.windowLabel()).toBe('last 2h');
+  });
+
+  it('holds an hour, with room for the panel cadence to spare', () => {
+    // The window is chosen against wc-workbench's 5s monitor timer; if that
+    // timer changes, this is the assertion that should make someone re-check
+    // that a full window still fits under the memory cap.
+    expect(MONITOR_HISTORY_WINDOW_MS).toBe(60 * 60 * 1000);
+    expect(MONITOR_HISTORY_WINDOW_MS / 5_000).toBeLessThan(MONITOR_HISTORY_CAPACITY);
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-monitor.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-monitor.test.ts
@@ -510,7 +510,10 @@ describe('buildVitals', () => {
     history.push({ at: 1_000, burnRate: 1, workingUnits: 0, liveProcesses: 2 });
     expect(buildVitals({ ...base, history })[0].series).toBeUndefined();
     history.push({ at: 6_000, burnRate: 2, workingUnits: 1, liveProcesses: 3 });
-    expect(buildVitals({ ...base, history })[0].series).toEqual([1, 2]);
+    expect(buildVitals({ ...base, history })[0].series?.points).toEqual([
+      { at: 1_000, value: 1 },
+      { at: 6_000, value: 2 },
+    ]);
   });
 });
 

--- a/packages/webcomponents/src/index.ts
+++ b/packages/webcomponents/src/index.ts
@@ -251,6 +251,8 @@ export {
   type MonitorProcessTable,
   type MonitorRow,
   type MonitorSection,
+  type MonitorSeries,
+  type MonitorSeriesPoint,
   type MonitorStatus,
   type MonitorVital,
   SliccMonitor,

--- a/packages/webcomponents/src/workbench/slicc-monitor.stories.ts
+++ b/packages/webcomponents/src/workbench/slicc-monitor.stories.ts
@@ -1,9 +1,45 @@
 import type { Meta, StoryObj } from '@storybook/web-components-vite';
-import type { MonitorModel, SliccMonitor } from './slicc-monitor.js';
+import type { MonitorModel, MonitorSeries, SliccMonitor } from './slicc-monitor.js';
 import './slicc-monitor.js';
 
 interface MonitorArgs {
   model?: MonitorModel;
+}
+
+/** The sparkline window the live panel uses. Stories mirror it. */
+const WINDOW_MS = 60 * 60 * 1000;
+/** The panel's own refresh cadence. */
+const STEP_MS = 5_000;
+/** A fixed anchor so story screenshots are byte-stable across runs. */
+const NOW = 1_800_000_000_000;
+
+/**
+ * Space values at the panel's 5s cadence, ending "now" — the shape the live
+ * buffer produces. Values are spaced by TIME, so a story that wants to show a
+ * sampling gap just widens one step.
+ */
+function series(values: number[], step = STEP_MS): MonitorSeries {
+  const last = values.length - 1;
+  return {
+    points: values.map((value, i) => ({ at: NOW - (last - i) * step, value })),
+    windowMs: WINDOW_MS,
+  };
+}
+
+/**
+ * The same values, but with the tab backgrounded for 80 seconds in the
+ * middle — the sampling gap a throttled timer leaves behind.
+ */
+function gappedSeries(values: number[]): MonitorSeries {
+  const half = Math.floor(values.length / 2);
+  const last = values.length - 1;
+  return {
+    points: values.map((value, i) => ({
+      at: NOW - (last - i) * STEP_MS - (i < half ? 80_000 : 0),
+      value,
+    })),
+    windowMs: WINDOW_MS,
+  };
 }
 
 const BURN = [
@@ -21,7 +57,7 @@ function vitals(): MonitorModel['vitals'] {
       value: '$1.40',
       unit: '/hour',
       hero: true,
-      series: BURN,
+      series: series(BURN),
       foot: '$29.06 this session · last 5m',
     },
     {
@@ -30,7 +66,7 @@ function vitals(): MonitorModel['vitals'] {
       value: '2',
       unit: 'of 4 working',
       accent: 'violet',
-      series: LOAD,
+      series: series(LOAD),
       foot: 'last 5m',
     },
     {
@@ -39,7 +75,7 @@ function vitals(): MonitorModel['vitals'] {
       value: '9',
       unit: 'processes',
       accent: 'cyan',
-      series: PROCS,
+      series: series(PROCS),
       foot: '1,435 exited this session',
     },
     {
@@ -412,6 +448,54 @@ export const NeedsAttention: Story = {
  */
 export const ColdStart: Story = {
   args: { model: COLD_START },
+};
+
+/**
+ * A panel opened two minutes ago, with a gap where the tab was backgrounded
+ * and its timers were throttled.
+ *
+ * The traces hug the RIGHT edge and cover only the slice of the hour they
+ * actually hold — a short history draws a short trace instead of stretching
+ * two minutes across the tile — and the throttled stretch shows as a long
+ * flat run between two samples rather than being drawn as if it never
+ * happened.
+ */
+export const PartialWindow: Story = {
+  args: {
+    model: {
+      updated: 'Streaming · updated just now',
+      vitals: [
+        {
+          id: 'burn',
+          label: 'Burn rate',
+          value: '$1.40',
+          unit: '/hour',
+          hero: true,
+          series: gappedSeries(BURN.slice(0, 12)),
+          foot: '$2.71 this session · last 2m',
+        },
+        {
+          id: 'load',
+          label: 'Agent load',
+          value: '2',
+          unit: 'of 4 working',
+          accent: 'violet',
+          series: gappedSeries(LOAD.slice(0, 12)),
+          foot: 'last 2m',
+        },
+        {
+          id: 'processes',
+          label: 'Live processes',
+          value: '9',
+          unit: 'processes',
+          accent: 'cyan',
+          series: gappedSeries(PROCS.slice(0, 12)),
+          foot: 'last 2m',
+        },
+      ],
+      alerts: [],
+    },
+  },
 };
 
 /** Just the process table, at the size a busy session reaches. */

--- a/packages/webcomponents/src/workbench/slicc-monitor.ts
+++ b/packages/webcomponents/src/workbench/slicc-monitor.ts
@@ -45,6 +45,33 @@ export interface MonitorSection {
   status?: MonitorStatus;
 }
 
+/** One reading of a metric, with the wall-clock instant it was taken. */
+export interface MonitorSeriesPoint {
+  /** `Date.now()` when the sample was taken. */
+  at: number;
+  value: number;
+}
+
+/**
+ * A time series for a sparkline: samples plus the width of the window they
+ * are drawn in.
+ *
+ * The window is what makes the chart readable across two glances. `points`
+ * are placed by TIMESTAMP inside a fixed `windowMs` span whose right edge is
+ * the newest sample, so a buffer covering forty seconds of a one-hour window
+ * draws a short trace hugging the right edge rather than stretching forty
+ * seconds across the whole tile. The alternative — spacing points evenly by
+ * index — silently rescales the x axis as the buffer fills, so the same event
+ * looks steeper or shallower depending on how long the panel has been open,
+ * and a gap in the sampling cadence is drawn as if it never happened.
+ */
+export interface MonitorSeries {
+  /** Samples, oldest first. Needs at least two points to render. */
+  points: MonitorSeriesPoint[];
+  /** The span the x axis covers, in ms. The right edge is the newest point. */
+  windowMs: number;
+}
+
 /**
  * A vitals tile: a rate, a ratio, or a headline figure.
  *
@@ -64,7 +91,7 @@ export interface MonitorVital {
   /** The single ≥48px figure the panel leads with. At most one. */
   hero?: boolean;
   /** Time series for a sparkline. Needs at least two points to render. */
-  series?: number[];
+  series?: MonitorSeries;
   /** 0..1 fill for a meter. Use for a share of a limit, never for a rate. */
   ratio?: number;
   accent?: MonitorAccent;
@@ -274,8 +301,12 @@ slicc-monitor {
   margin: 6px 0 2px;
 }
 .monitor-tile__plot svg {
-  max-width: 100%;
-  height: auto;
+  display: block;
+  /*
+   * The end marker sits ON the right edge (see projectSeries), so its ring
+   * would be sliced by the SVG box. The tile's 14px padding absorbs it.
+   */
+  overflow: visible;
 }
 .monitor-tile__foot {
   font-size: 10.5px;
@@ -780,15 +811,46 @@ function svgEl(tag: string, attrs: Record<string, string | number>): SVGElement 
   return el;
 }
 
-/** Project a series into `x`/`y` pairs inside a `w × h` box with a 3px inset. */
-function projectSeries(series: number[], w: number, h: number): { x: number; y: number }[] {
-  const min = Math.min(...series);
-  const max = Math.max(...series);
+/** Stroke width of the sparkline, and half of it — the horizontal edge inset. */
+const SPARK_STROKE = 2;
+const SPARK_EDGE_INSET = SPARK_STROKE / 2;
+/**
+ * Vertical inset: the end marker's radius plus its ring, so a sample at the
+ * top or bottom of its range is not sliced by the box.
+ */
+const SPARK_MARKER_RADIUS = 4;
+const SPARK_VERTICAL_INSET = SPARK_MARKER_RADIUS + SPARK_STROKE / 2;
+
+/**
+ * Project a series into `x`/`y` pairs inside a `w × h` box.
+ *
+ * `x` comes from the sample's TIMESTAMP: the newest point lands at
+ * `w - SPARK_EDGE_INSET` — the right edge, inset only by the stroke's half
+ * width so the line is not clipped — and everything else is placed by how far
+ * back it is inside `series.windowMs`. Uneven sampling therefore reads as
+ * uneven spacing, which is the truth. Points older than the window are
+ * clamped to the left edge rather than drawn off-box.
+ *
+ * The one exception is a series whose samples all carry the same instant:
+ * there is no time information to place them by, so they fall back to even
+ * index spacing rather than collapsing into a single column.
+ */
+function projectSeries(series: MonitorSeries, w: number, h: number): { x: number; y: number }[] {
+  const points = series.points;
+  const values = points.map((p) => p.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
   const span = max - min || 1;
-  const pad = 3;
-  return series.map((v, i) => ({
-    x: pad + (i / (series.length - 1)) * (w - pad * 2),
-    y: h - pad - ((v - min) / span) * (h - pad * 2),
+  const right = w - SPARK_EDGE_INSET;
+  const usable = Math.max(0, w - SPARK_EDGE_INSET * 2);
+  const newest = points[points.length - 1].at;
+  const windowMs = series.windowMs > 0 ? series.windowMs : 1;
+  const timed = newest - points[0].at > 0;
+  return points.map((p, i) => ({
+    x: timed
+      ? Math.max(SPARK_EDGE_INSET, right - Math.min(1, (newest - p.at) / windowMs) * usable)
+      : SPARK_EDGE_INSET + (i / (points.length - 1)) * usable,
+    y: h - SPARK_VERTICAL_INSET - ((p.value - min) / span) * (h - SPARK_VERTICAL_INSET * 2),
   }));
 }
 
@@ -796,11 +858,16 @@ function projectSeries(series: number[], w: number, h: number): { x: number; y: 
  * A sparkline: a 2px line, a 10%-opacity area wash, and an end marker
  * carrying a 2px surface ring so it stays legible where it crosses the line.
  * No axes, no gridlines, no per-point labels.
+ *
+ * The wash closes on the FIRST and LAST projected x rather than on constants,
+ * so line, wash and marker all terminate at the same place no matter how wide
+ * the tile is or how much of the window the samples cover.
  */
-function sparkline(series: number[], hue: string, w: number, h: number): SVGElement {
+function sparkline(series: MonitorSeries, hue: string, w: number, h: number): SVGElement {
   const pts = projectSeries(series, w, h);
   const line = pts.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
   const last = pts[pts.length - 1];
+  const first = pts[0];
   const svg = svgEl('svg', {
     width: w,
     height: h,
@@ -809,7 +876,7 @@ function sparkline(series: number[], hue: string, w: number, h: number): SVGElem
   });
   svg.append(
     svgEl('polygon', {
-      points: `${line} ${w - 3},${h} 3,${h}`,
+      points: `${line} ${last.x.toFixed(1)},${h} ${first.x.toFixed(1)},${h}`,
       fill: hue,
       'fill-opacity': '0.1',
     }),
@@ -817,28 +884,80 @@ function sparkline(series: number[], hue: string, w: number, h: number): SVGElem
       points: line,
       fill: 'none',
       stroke: hue,
-      'stroke-width': '2',
+      'stroke-width': String(SPARK_STROKE),
       'stroke-linejoin': 'round',
       'stroke-linecap': 'round',
     }),
     svgEl('circle', {
-      cx: last.x,
-      cy: last.y,
-      r: '4',
+      cx: last.x.toFixed(1),
+      cy: last.y.toFixed(1),
+      r: String(SPARK_MARKER_RADIUS),
       fill: hue,
       stroke: 'var(--canvas)',
-      'stroke-width': '2',
+      'stroke-width': String(SPARK_STROKE),
     })
   );
   return svg;
 }
 
+/**
+ * Plot height, and the width used until the box has been measured.
+ *
+ * The width is a FALLBACK, not the design: the chart is drawn at whatever
+ * width its container actually has (see {@link createSparklinePlot}), because
+ * a fixed 300px in a 700px tile leaves the newest — and only still-true —
+ * sample stranded two thirds of the way across.
+ */
+const SPARK_SIZE = {
+  hero: { w: 300, h: 56 },
+  tile: { w: 132, h: 34 },
+} as const;
+
+/**
+ * A sparkline that fills its container and redraws when that container
+ * resizes.
+ *
+ * The SVG is re-projected at the measured width rather than scaled to it: a
+ * `viewBox` stretch would distort the 2px stroke and turn the round end
+ * marker into an ellipse. The observer is handed back to the element so it
+ * can be disconnected on the next render — otherwise every 5s refresh leaves
+ * one behind.
+ */
+function createSparklinePlot(
+  series: MonitorSeries,
+  hue: string,
+  size: { w: number; h: number },
+  observers: ResizeObserver[]
+): HTMLElement {
+  const host = h('div', { class: 'monitor-tile__plot' });
+  let drawn = 0;
+  const draw = (width: number): void => {
+    const w = Math.round(width);
+    if (w <= 0 || w === drawn) return;
+    drawn = w;
+    host.replaceChildren(sparkline(series, hue, w, size.h));
+  };
+  draw(size.w);
+  if (typeof ResizeObserver === 'function') {
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) draw(entry.contentRect.width);
+    });
+    observer.observe(host);
+    observers.push(observer);
+  }
+  return host;
+}
+
 /** The mark for a tile: a sparkline for a rate, a meter for a share. */
-function createVitalPlot(vital: MonitorVital): HTMLElement | null {
+function createVitalPlot(vital: MonitorVital, observers: ResizeObserver[]): HTMLElement | null {
   const hue = accentHue(vital.accent);
-  if (vital.series && vital.series.length > 1) {
-    const size = vital.hero ? { w: 300, h: 56 } : { w: 132, h: 34 };
-    return h('div', { class: 'monitor-tile__plot' }, sparkline(vital.series, hue, size.w, size.h));
+  if (vital.series && vital.series.points.length > 1) {
+    return createSparklinePlot(
+      vital.series,
+      hue,
+      vital.hero ? SPARK_SIZE.hero : SPARK_SIZE.tile,
+      observers
+    );
   }
   if (typeof vital.ratio === 'number') {
     const pct = Math.max(0, Math.min(1, vital.ratio)) * 100;
@@ -855,7 +974,7 @@ function createVitalPlot(vital: MonitorVital): HTMLElement | null {
   return null;
 }
 
-function createVitalTile(vital: MonitorVital): HTMLElement {
+function createVitalTile(vital: MonitorVital, observers: ResizeObserver[]): HTMLElement {
   const tile = h('section', {
     class: `monitor-tile${vital.hero ? ' monitor-tile--hero' : ''}`,
     'data-vital': vital.id,
@@ -869,14 +988,18 @@ function createVitalTile(vital: MonitorVital): HTMLElement {
       vital.unit ? h('span', { class: 'monitor-tile__unit' }, vital.unit) : null
     ),
     vital.delta ? h('span', { class: 'monitor-tile__delta' }, vital.delta) : null,
-    createVitalPlot(vital),
+    createVitalPlot(vital, observers),
     vital.foot ? h('span', { class: 'monitor-tile__foot' }, vital.foot) : null,
   ]);
   return tile;
 }
 
-function createVitals(vitals: MonitorVital[]): HTMLElement {
-  return h('div', { class: 'monitor-vitals' }, ...vitals.map(createVitalTile));
+function createVitals(vitals: MonitorVital[], observers: ResizeObserver[]): HTMLElement {
+  return h(
+    'div',
+    { class: 'monitor-vitals' },
+    ...vitals.map((vital) => createVitalTile(vital, observers))
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -1220,7 +1343,10 @@ let monitorInstance = 0;
  *
  *  1. **Vitals** — rates and ratios over time (hero figure, stat tiles with
  *     sparklines, a meter). The only tier with a time axis, and the only
- *     honest answer to "how hard is this thing working".
+ *     honest answer to "how hard is this thing working". That axis is a
+ *     FIXED window anchored at the newest sample and drawn at the tile's real
+ *     width (`MonitorSeries`), so two glances a minute apart are comparable
+ *     and "now" is always flush against the right edge.
  *  2. **Attention** — what is degraded, newest first. A count of problems is
  *     a dead end; this is the list it should have expanded into. Healthy
  *     state is a single "All clear" line.
@@ -1246,6 +1372,13 @@ export class SliccMonitor extends HTMLElement {
   #expanded = new Set<string>();
   #initialized = false;
   readonly #instanceId = ++monitorInstance;
+  /**
+   * One `ResizeObserver` per sparkline, so each plot can redraw at its
+   * container's real width. Dropped on every re-render and on disconnect —
+   * the panel re-renders every 5s, so leaking them would accumulate an
+   * observer per tile per refresh.
+   */
+  #plotObservers: ResizeObserver[] = [];
 
   connectedCallback(): void {
     ensureMonitorStyle(this.ownerDocument);
@@ -1256,11 +1389,25 @@ export class SliccMonitor extends HTMLElement {
     this.#render();
   }
 
+  disconnectedCallback(): void {
+    this.#disconnectPlots();
+  }
+
+  #disconnectPlots(): void {
+    for (const observer of this.#plotObservers) observer.disconnect();
+    this.#plotObservers = [];
+  }
+
   /** The full panel model (returns a copy). */
   get model(): MonitorModel {
     return {
       ...this.#model,
-      vitals: this.#model.vitals?.map((v) => ({ ...v, series: v.series?.slice() })),
+      vitals: this.#model.vitals?.map((v) => ({
+        ...v,
+        series: v.series
+          ? { ...v.series, points: v.series.points.map((p) => ({ ...p })) }
+          : v.series,
+      })),
       alerts: this.#model.alerts?.map((a) => ({ ...a })),
       sections: this.#model.sections?.map(cloneSection),
       processes: this.#model.processes
@@ -1365,10 +1512,11 @@ export class SliccMonitor extends HTMLElement {
 
   #render(): void {
     const { vitals = [], alerts, sections = [], processes } = this.#model;
+    this.#disconnectPlots();
     const panel = h('div', { class: 'monitor' });
     append(panel, [
       this.#createHeader(),
-      vitals.length > 0 ? createVitals(vitals) : null,
+      vitals.length > 0 ? createVitals(vitals, this.#plotObservers) : null,
       alerts ? createAttention(alerts) : null,
       sections.length > 0 ? this.#createTopology(sections) : null,
       processes ? createProcesses(processes) : null,

--- a/packages/webcomponents/tests/workbench/slicc-monitor.test.ts
+++ b/packages/webcomponents/tests/workbench/slicc-monitor.test.ts
@@ -3,8 +3,39 @@ import { ensureGlobalTokens, setTheme } from '../../src/theme/tokens.js';
 import {
   type MonitorModel,
   type MonitorSection,
+  type MonitorSeries,
   SliccMonitor,
 } from '../../src/workbench/slicc-monitor.js';
+
+/** A one-hour window, the span the live panel plots into. */
+const HOUR_MS = 60 * 60 * 1000;
+const NOW = 1_800_000_000_000;
+
+/** Values at a fixed cadence, ending at `NOW` — the live buffer's shape. */
+function evenSeries(values: number[], stepMs = 5_000, windowMs = HOUR_MS): MonitorSeries {
+  const last = values.length - 1;
+  return {
+    points: values.map((value, i) => ({ at: NOW - (last - i) * stepMs, value })),
+    windowMs,
+  };
+}
+
+/** Values at explicit ages (ms before `NOW`), oldest first. */
+function agedSeries(pairs: [ageMs: number, value: number][], windowMs = HOUR_MS): MonitorSeries {
+  return { points: pairs.map(([age, value]) => ({ at: NOW - age, value })), windowMs };
+}
+
+const BURN = [0.9, 1.1, 0.8, 0.6, 0.7, 1.2, 1.6, 1.5, 1.1, 0.9, 1.0, 1.4];
+
+function polylinePoints(svg: Element): { x: number; y: number }[] {
+  return (svg.querySelector('polyline')?.getAttribute('points') ?? '')
+    .split(' ')
+    .filter(Boolean)
+    .map((pair) => {
+      const [x, y] = pair.split(',').map(Number);
+      return { x, y };
+    });
+}
 
 function mount(model?: MonitorModel): SliccMonitor {
   const el = document.createElement('slicc-monitor') as SliccMonitor;
@@ -122,7 +153,7 @@ describe('slicc-monitor — vitals', () => {
 
   it('plots a sparkline for a series', () => {
     const el = mount({
-      vitals: [{ id: 'burn', label: 'Burn', value: '$1.40', series: [1, 2, 1.5, 3] }],
+      vitals: [{ id: 'burn', label: 'Burn', value: '$1.40', series: evenSeries([1, 2, 1.5, 3]) }],
     });
     const svg = el.querySelector('.monitor-tile__plot svg');
     expect(svg).not.toBeNull();
@@ -132,7 +163,9 @@ describe('slicc-monitor — vitals', () => {
   });
 
   it('plots no sparkline below two points — one point is not a trend', () => {
-    const el = mount({ vitals: [{ id: 'burn', label: 'Burn', value: '$1.40', series: [1] }] });
+    const el = mount({
+      vitals: [{ id: 'burn', label: 'Burn', value: '$1.40', series: evenSeries([1]) }],
+    });
     expect(el.querySelector('.monitor-tile__plot')).toBeNull();
   });
 
@@ -152,10 +185,161 @@ describe('slicc-monitor — vitals', () => {
 
   it('prefers the sparkline when a vital carries both a series and a ratio', () => {
     const el = mount({
-      vitals: [{ id: 'a', label: 'A', value: '1', series: [1, 2], ratio: 0.5 }],
+      vitals: [{ id: 'a', label: 'A', value: '1', series: evenSeries([1, 2]), ratio: 0.5 }],
     });
     expect(el.querySelector('.monitor-tile__plot svg')).not.toBeNull();
     expect(el.querySelector('.monitor-meter')).toBeNull();
+  });
+
+  it("draws the sparkline at the tile's full content width, not a fixed 300px", async () => {
+    // The panel is wider than the old hard-coded 300px hero plot, so a chart
+    // that ignores its box leaves a dead strip exactly where "now" lives.
+    const el = mount({
+      vitals: [{ id: 'burn', label: 'Burn', value: '$1.40', hero: true, series: evenSeries(BURN) }],
+    });
+    const plot = el.querySelector('.monitor-tile__plot') as HTMLElement;
+    expect(plot.clientWidth).toBeGreaterThan(300);
+    await vi.waitFor(() => {
+      const svg = plot.querySelector('svg') as SVGElement;
+      expect(svg.getBoundingClientRect().width).toBeCloseTo(plot.clientWidth, 0);
+    });
+  });
+
+  it('redraws at the new width when the tile resizes', async () => {
+    const host = document.createElement('div');
+    host.style.width = '900px';
+    document.body.appendChild(host);
+    const el = document.createElement('slicc-monitor') as SliccMonitor;
+    el.model = {
+      vitals: [{ id: 'burn', label: 'Burn', value: '$1.40', hero: true, series: evenSeries(BURN) }],
+    };
+    host.appendChild(el);
+    const plot = el.querySelector('.monitor-tile__plot') as HTMLElement;
+    await vi.waitFor(() => {
+      expect(plot.querySelector('svg')?.getBoundingClientRect().width).toBeCloseTo(
+        plot.clientWidth,
+        0
+      );
+    });
+    host.style.width = '480px';
+    await vi.waitFor(() => {
+      expect(plot.querySelector('svg')?.getBoundingClientRect().width).toBeCloseTo(
+        plot.clientWidth,
+        0
+      );
+    });
+    host.remove();
+  });
+
+  it('lands the newest sample on the right edge, with line, wash and marker agreeing', () => {
+    const el = mount({
+      vitals: [{ id: 'burn', label: 'Burn', value: '$1.40', series: evenSeries([1, 2, 1.5, 3]) }],
+    });
+    const svg = el.querySelector('.monitor-tile__plot svg') as SVGElement;
+    const width = Number(svg.getAttribute('width'));
+    const pts = polylinePoints(svg);
+    const marker = svg.querySelector('circle') as SVGElement;
+    const strokeHalf = Number(marker.getAttribute('stroke-width')) / 2;
+
+    // The end marker's CENTRE is at the right edge, inset only by the stroke's
+    // half width — not at an independently chosen `w - 3`.
+    expect(pts[pts.length - 1].x).toBeCloseTo(width - strokeHalf, 5);
+    expect(Number(marker.getAttribute('cx'))).toBeCloseTo(width - strokeHalf, 1);
+    // ...and the wash closes on the same x the line ends at.
+    const wash = (svg.querySelector('polygon')?.getAttribute('points') ?? '').split(' ');
+    expect(Number(wash[wash.length - 2].split(',')[0])).toBeCloseTo(width - strokeHalf, 1);
+    expect(Number(wash[wash.length - 1].split(',')[0])).toBeCloseTo(pts[0].x, 1);
+  });
+
+  it('spaces points by elapsed time, so a sampling gap reads as a gap', () => {
+    // 5s, 90s, 5s apart in a 100s window: the middle gap must be eighteen
+    // times the others, not one uniform step like an index-spaced chart. The
+    // window is short so the gaps are tens of pixels — at an hour they'd be
+    // fractions of one, and the 0.1px coordinate rounding would dominate.
+    const el = mount({
+      vitals: [
+        {
+          id: 'burn',
+          label: 'Burn',
+          value: '$1.40',
+          series: agedSeries(
+            [
+              [100_000, 1],
+              [95_000, 2],
+              [5_000, 1.5],
+              [0, 3],
+            ],
+            100_000
+          ),
+        },
+      ],
+    });
+    const pts = polylinePoints(el.querySelector('.monitor-tile__plot svg') as SVGElement);
+    const gaps = [pts[1].x - pts[0].x, pts[2].x - pts[1].x, pts[3].x - pts[2].x];
+    expect(gaps[1] / gaps[0]).toBeCloseTo(18, 1);
+    expect(gaps[1] / gaps[2]).toBeCloseTo(18, 1);
+  });
+
+  it('renders a short history as a short trace on the right, not a full-width one', () => {
+    // 40 seconds inside a one-hour window is ~1% of the axis. The old
+    // index-spaced chart stretched it across the whole tile.
+    const el = mount({
+      vitals: [
+        {
+          id: 'burn',
+          label: 'Burn',
+          value: '$1.40',
+          series: agedSeries([
+            [40_000, 1],
+            [20_000, 2],
+            [0, 3],
+          ]),
+        },
+      ],
+    });
+    const svg = el.querySelector('.monitor-tile__plot svg') as SVGElement;
+    const width = Number(svg.getAttribute('width'));
+    const pts = polylinePoints(svg);
+    const covered = pts[pts.length - 1].x - pts[0].x;
+    expect(covered / width).toBeGreaterThan(0);
+    expect(covered / width).toBeLessThan(0.03);
+    // Still anchored at the right edge — "now" never floats.
+    expect(pts[pts.length - 1].x).toBeCloseTo(width - 1, 5);
+  });
+
+  it('drops the plot resize observers when the panel is removed', () => {
+    const observed: Element[] = [];
+    const disconnected: ResizeObserver[] = [];
+    const Native = globalThis.ResizeObserver;
+    class SpyObserver extends Native {
+      observe(target: Element, options?: ResizeObserverOptions): void {
+        observed.push(target);
+        super.observe(target, options);
+      }
+      disconnect(): void {
+        disconnected.push(this);
+        super.disconnect();
+      }
+    }
+    globalThis.ResizeObserver = SpyObserver as unknown as typeof ResizeObserver;
+    try {
+      const el = mount({
+        vitals: [
+          { id: 'burn', label: 'Burn', value: '$1', series: evenSeries([1, 2]) },
+          { id: 'load', label: 'Load', value: '2', series: evenSeries([2, 3]) },
+        ],
+      });
+      expect(observed).toHaveLength(2);
+      // A re-render (the panel refreshes every 5s) drops the previous batch.
+      el.model = {
+        vitals: [{ id: 'burn', label: 'Burn', value: '$1', series: evenSeries([1, 3]) }],
+      };
+      expect(disconnected).toHaveLength(2);
+      el.remove();
+      expect(disconnected).toHaveLength(3);
+    } finally {
+      globalThis.ResizeObserver = Native;
+    }
   });
 });
 


### PR DESCRIPTION
## What

The Live monitor's vitals sparklines distorted exactly the reading they invite. Two causes, both fixed here.

**1. The plot stopped short of the right edge.** The SVG was created at a hard-coded `300 × 56` / `132 × 34`, and the only responsive rule (`max-width: 100%`) can shrink it but never grow it — so in a wide panel the hero trace ended roughly two thirds of the way across and left a dead strip exactly where "now" lives.

The plot is now drawn at its container's **measured** width via a `ResizeObserver`, re-projected rather than scaled (a `viewBox` stretch would distort the 2px stroke and turn the round end marker into an ellipse). The fixed sizes survive only as the width used before the box has been measured. The newest sample lands at `width - strokeHalf`, and line, wash and marker all terminate on the same x — the polygon used to close at an independently chosen `w - 3` that agreed with the line only by coincidence. The SVG gets `overflow: visible` so the marker's ring is not sliced by the box; the tile's 14px padding absorbs it. Observers are disconnected on every re-render and on disconnect — the panel refreshes every 5s, so leaking them would accumulate one per tile per tick.

**2. The timeline compressed instead of cropping.** The x axis was sample *index* over a buffer bounded by sample *count*, so the visible span silently rescaled as the buffer filled: the same event looked steeper or shallower depending on how long the panel had been open, and two glances a minute apart were not comparable. Any interruption in the 5s cadence — panel closed and reopened, or the tab backgrounded where browsers throttle timers hard — left samples minutes apart at one end and 5s apart at the other, drawn as if uniformly spaced.

`MonitorHistory` now evicts by **age** inside a fixed one-hour window and hands over timestamps with the values (`MonitorSeries { points: [{ at, value }], windowMs }`). The component places each point by elapsed time inside that window, anchored at the newest sample. A buffer covering forty seconds draws a short trace hugging the right edge instead of stretching forty seconds across the tile, and uneven sampling reads as uneven spacing — which is the truth. `windowLabel()` still reports the span the samples *actually* cover, and now the geometry agrees with it.

`MONITOR_HISTORY_CAPACITY` survives as a pure memory bound (a pathologically fast feeder can't grow the buffer without limit); it is no longer the policy.

## Acceptance criteria

| # | Criterion | Covered by |
|---|---|---|
| 1 | Hero sparkline spans the tile's content width; `svg.getBoundingClientRect().width` equals the plot container's width | `draws the sparkline at the tile's full content width, not a fixed 300px` + `redraws at the new width when the tile resizes` |
| 2 | End marker centre at `width - strokeHalf`; line, wash and marker terminate at the same x | `lands the newest sample on the right edge, with line, wash and marker agreeing` |
| 3 | Unevenly spaced samples (5s, 90s, 5s) render proportionally to elapsed time | `spaces points by elapsed time, so a sampling gap reads as a gap` |
| 4 | Samples older than the window are dropped by age; a 40s buffer in a 1h window renders a short trace on the right | `renders a short history as a short trace on the right, not a full-width one` + `evicts by AGE — samples that fall out of the window are dropped` |

Plus a lifecycle test that the resize observers are dropped on re-render and on removal.

## Screenshots

A new `Workbench/Monitor → PartialWindow` story renders a panel opened two minutes ago with a gap where the tab was backgrounded — the traces hug the right edge, cover only the slice of the hour they hold, and the throttled stretch shows as a long flat run instead of vanishing. The existing stories now carry real timestamps. Storybook screenshots ride the usual sticky comment.

## Verification

`lint` · `typecheck` (all 9 projects) · `test` · `build` (all workspaces) · `build -w @slicc/chrome-extension` · `check-touched-exemptions` — all clean. The webcomponents browser suite passes in full (47 monitor tests); the only failures seen locally are pre-existing load flakes (`slicc-input-card` focus-within, `slicc-agent-tabs`, and the ipk e2e 5s timeouts) that reproduce with these changes excluded and pass in isolation.

Fixes #2407
