### PR TITLE
feat(webapp): refresh the files panel from VFS change events, not a 3 s poll

### DIFF
--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -253,10 +253,12 @@ per-scoop sudoers.
   manager is in reach.
 - **The UI follows the selection.** The workbench file tree and the memory
   panel take their roots from the cone that owns the current selection, so
-  switching cones re-points both (`WcWorkbenchDeps.getWorkspace`). The tree
-  re-reads on its own 3 s poll; memory has no poller, so a selection change
-  pushes `WorkbenchActivator.refreshMemory()` — otherwise an open panel would
-  keep showing the previous cone's memory indefinitely.
+  switching cones re-points both (`WcWorkbenchDeps.getWorkspace`). Neither has
+  a poller to correct it — the tree refreshes on VFS change events (#2409) and
+  memory once per activation — so a selection change pushes
+  `WorkbenchActivator.refreshFiles()` + `refreshMemory()`. A selection change
+  is not a filesystem change, and without the push an open panel would keep
+  showing the previous cone's files and memory indefinitely.
 - **Memory**: the sink path is bound by `ScoopLifecycleManager` from the unit's
   own record (`workspaceFor(scoop).memoryPath`), never from the caller's meta,
   so an extra cone's compaction pass cannot append to the primary's file. The

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -46,7 +46,6 @@
   "packages/webapp/src/git/commands/symbolic-ref.ts": 2,
   "packages/webapp/src/kernel/cdp-bridge.ts": 7,
   "packages/webapp/src/kernel/cdp-worker-proxy.ts": 3,
-  "packages/webapp/src/kernel/kernel-worker.ts": 2,
   "packages/webapp/src/kernel/port-bridge-client.ts": 2,
   "packages/webapp/src/kernel/realm/helpers/node-assert.ts": 5,
   "packages/webapp/src/kernel/realm/helpers/node-zlib.ts": 3,

--- a/packages/webapp/src/fs/error-rebrand.ts
+++ b/packages/webapp/src/fs/error-rebrand.ts
@@ -34,6 +34,7 @@ const KNOWN_CODES: FsErrorCode[] = [
   'EBUSY',
   'EFBIG',
   'EBADF',
+  'ENOSYS',
   'EIO',
 ];
 

--- a/packages/webapp/src/fs/fs-watcher.ts
+++ b/packages/webapp/src/fs/fs-watcher.ts
@@ -1,15 +1,11 @@
 import { createLogger } from '../base/logger.js';
-import type { EntryType } from './types.js';
+import type { FsChangeEvent } from './types.js';
 
 const log = createLogger('fs-watcher');
 
-export type FsChangeType = 'create' | 'modify' | 'delete';
-
-export interface FsChangeEvent {
-  type: FsChangeType;
-  path: string;
-  entryType?: EntryType;
-}
+// Defined in `types.ts` (see the note there) and re-exported here, where
+// every existing consumer already imports them from.
+export type { FsChangeEvent, FsChangeType } from './types.js';
 
 export type FsWatchFilter = (path: string) => boolean;
 export type FsWatchCallback = (events: FsChangeEvent[]) => void;

--- a/packages/webapp/src/fs/types.ts
+++ b/packages/webapp/src/fs/types.ts
@@ -55,6 +55,23 @@ export interface ReadFileOptions {
 }
 
 /** Filesystem error codes, mirroring common POSIX errno values. */
+/** What happened to a path. Consumed by `FsWatcher` and its subscribers. */
+export type FsChangeType = 'create' | 'modify' | 'delete';
+
+/**
+ * One filesystem change, as `VirtualFS` reports it to a watcher.
+ *
+ * Lives here rather than in `fs-watcher.ts` because consumers as far out as
+ * the kernel's `LocalVfsClient` name it, and `fs-watcher.ts` has a value
+ * import of the logger — which drags the `__DEV__` global into tsconfigs that
+ * do not declare it (`packages/webcomponents`). `types.ts` imports nothing.
+ */
+export interface FsChangeEvent {
+  type: FsChangeType;
+  path: string;
+  entryType?: EntryType;
+}
+
 export type FsErrorCode =
   | 'ENOENT' // No such file or directory
   | 'EEXIST' // File/dir already exists
@@ -67,6 +84,7 @@ export type FsErrorCode =
   | 'EBUSY' // Resource busy — used for 412 concurrent-write conflicts on remote mounts
   | 'EFBIG' // File too large — used when remote-mount body exceeds maxBodyBytes
   | 'EBADF' // Bad file descriptor — used when an op runs against a closed/unmounted backend
+  | 'ENOSYS' // Not implemented — the backend genuinely lacks the capability (e.g. no FsWatcher)
   | 'EIO'; // I/O error — used for transient network failures, 5xx, AbortError-from-timeout
 
 /**

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -16,7 +16,7 @@
  */
 
 import { convertError, rebrandFsError } from './error-rebrand.js';
-import type { FsWatcher } from './fs-watcher.js';
+import type { FsChangeEvent, FsWatcher } from './fs-watcher.js';
 import { findDirtyKindFlips, memoryKindOfMode, shouldReconcileKind } from './kind-reconcile.js';
 import type { MountBackend, RefreshReport } from './mount/backend.js';
 import type { HostFsMountBackend } from './mount/backend-hostfs.js';
@@ -1103,6 +1103,27 @@ export class VirtualFS {
   /** Get the attached watcher, or null. */
   getWatcher(): FsWatcher | null {
     return this.watcher;
+  }
+
+  /**
+   * Subscribe to changes under each of `basePaths` — the `LocalVfsClient`
+   * watch contract, so an in-process reader (no kernel RPC in between) gets
+   * the same event-driven refresh the panel does (#2409).
+   *
+   * Rejects when no watcher is attached: a silently dead subscription would
+   * leave the caller waiting on events that cannot arrive, where a rejection
+   * tells it to fall back to polling.
+   */
+  async watch(
+    basePaths: readonly string[],
+    callback: (events: FsChangeEvent[]) => void
+  ): Promise<() => void> {
+    const watcher = this.watcher;
+    if (!watcher) throw new FsError('ENOSYS', 'no FsWatcher attached to this VirtualFS');
+    const unsubs = basePaths.map((basePath) => watcher.watch(basePath, () => true, callback));
+    return () => {
+      for (const off of unsubs) off();
+    };
   }
 
   /**

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -1598,6 +1598,11 @@ export class VirtualFS {
     if (backend.kind === 'local') {
       await this.mountIndex.refreshMount(normalized, resolveMountIndexLimits(opts?.env ?? {}));
     }
+    // A refresh exists BECAUSE the remote side changed outside the VFS — the
+    // one mutation no per-write notify can announce. Report it as a change to
+    // the mount root: watchers rebuild that subtree, which is the only honest
+    // granularity available (the refresh does not enumerate what moved).
+    this.watcher?.notify([{ type: 'modify', path: normalized, entryType: 'directory' }]);
     return report;
   }
 
@@ -1967,13 +1972,16 @@ export class VirtualFS {
    * writeFile}, and {@link symlink} so parent-ensure-then-write is one
    * critical section (and so re-entrant lock acquisition can't deadlock).
    */
-  private async mkdirRecursiveUnlocked(normalized: string): Promise<void> {
+  /** @returns the paths this call actually created, parents first. */
+  private async mkdirRecursiveUnlocked(normalized: string): Promise<string[]> {
     const parts = normalized.split('/').filter(Boolean);
+    const created: string[] = [];
     let current = '';
     for (const part of parts) {
       current += '/' + part;
       try {
         await this.lfs.mkdir(current);
+        created.push(current);
       } catch (err: unknown) {
         if (err instanceof Error && !err.message.includes('EEXIST')) {
           throw convertError(err, current);
@@ -1995,6 +2003,7 @@ export class VirtualFS {
         }
       }
     }
+    return created;
   }
 
   /**
@@ -2025,10 +2034,23 @@ export class VirtualFS {
     if (options?.recursive) {
       // Create all parent directories under the write lock so a concurrent
       // writeFile/symlink can't observe a half-materialized path.
-      await this.withWriteLock(() => {
+      const created = await this.withWriteLock(() => {
         this.markSidecarDirty(normalized);
         return this.mkdirRecursiveUnlocked(normalized);
       });
+      // One event per directory this call actually created — an already
+      // existing component is not a change. Without this, `mkdir -p` was
+      // invisible to watchers, so an event-driven consumer (the workbench
+      // file tree, #2409) never saw a new empty directory appear.
+      if (created.length > 0) {
+        this.watcher?.notify(
+          created.map((path) => ({
+            type: 'create' as const,
+            path,
+            entryType: 'directory' as const,
+          }))
+        );
+      }
     } else {
       await this.withWriteLock(async () => {
         this.markSidecarDirty(normalized);

--- a/packages/webapp/src/kernel/kernel-worker.ts
+++ b/packages/webapp/src/kernel/kernel-worker.ts
@@ -48,12 +48,13 @@ import {
   setExtensionDelegateId,
   setLocalApiBaseUrl,
 } from '../shell/proxied-fetch.js';
+import type { SprinkleManagerProxySurface } from '../shell/sprinkle-manager-handle.js';
 import { WorkerCdpProxy } from './cdp-worker-proxy.js';
 import { Bridge } from './facade.js';
 import { createKernelHost, type KernelHost } from './host.js';
 import { makeSameOriginBypassFetch } from './kernel-worker-fetch-bypass.js';
 import { makeKernelWorkerInitGuard } from './kernel-worker-init-guard.js';
-import { getPanelRpcClient } from './panel-rpc.js';
+import { getPanelRpcClient, type PanelRpcClient } from './panel-rpc.js';
 import { createPanelTerminalHost } from './panel-terminal-host.js';
 import { setSyncFsBridgeEnabled } from './realm/sync-fs-enabled.js';
 import type { SyncFsNonce } from './realm/sync-fs-wire.js';
@@ -289,7 +290,19 @@ let host: KernelHost | null = null;
 let stopTerminalHost: (() => void) | null = null;
 let stopVfsRpcHost: (() => void) | null = null;
 let stopSpeechAssetsResponder: (() => void) | null = null;
-let panelRpcClient: { dispose: () => void } | null = null;
+let panelRpcClient: PanelRpcClient | null = null;
+
+/**
+ * Globals the worker publishes for shell commands to discover.
+ *
+ * Named rather than a `Record<string, unknown>` bag: these two keys are the
+ * whole contract, and the consumers (`panel-rpc.ts` callers, the `sprinkle` /
+ * `open` / `upskill` commands) read them back expecting exactly these shapes.
+ */
+interface KernelWorkerGlobals {
+  __slicc_sprinkleManager?: SprinkleManagerProxySurface;
+  __slicc_panelRpc?: PanelRpcClient;
+}
 
 /**
  * Wire the init listener using a double-init guard. Exported via
@@ -444,7 +457,7 @@ async function boot(init: KernelWorkerInitMsg): Promise<void> {
       '../scoops/sprinkle-bridge-channel.js'
     );
     const sprinkleProxy = createSprinkleManagerProxyOverChannel({ instanceId: init.instanceId });
-    (globalThis as Record<string, unknown>).__slicc_sprinkleManager = sprinkleProxy;
+    (globalThis as KernelWorkerGlobals).__slicc_sprinkleManager = sprinkleProxy;
 
     // Auto-reload open sprinkles when their .shtml file changes in the VFS.
     const watcher = host.sharedFs?.getWatcher();
@@ -486,7 +499,7 @@ async function boot(init: KernelWorkerInitMsg): Promise<void> {
     // and the panel AlmostBashShell renders the preview locally.
     const { createPanelRpcClient } = await import('./panel-rpc.js');
     panelRpcClient = createPanelRpcClient({ instanceId: init.instanceId });
-    (globalThis as Record<string, unknown>).__slicc_panelRpc = panelRpcClient;
+    (globalThis as KernelWorkerGlobals).__slicc_panelRpc = panelRpcClient;
 
     // Give the worker BrowserAPI a tray target provider so the cone can
     // *drive* federated tray/cherry targets, not just list them. The
@@ -593,6 +606,11 @@ async function startSharedFsSurfaces(deps: {
     transport: deps.transport,
     client: sharedFs,
     writableClient: sharedFs,
+    // Read per subscription, not captured here: the orchestrator attaches the
+    // watcher during its own init, which can land after this surface starts.
+    // Every VFS mutation already notifies it, which is what lets the panel's
+    // file tree drop its 3 s poll (#2409).
+    getWatcher: () => sharedFs.getWatcher(),
     logger: console,
   });
   const stopSpeechAssetsResponder = await startSpeechAssetsResponder(sharedFs, deps.instanceId);

--- a/packages/webapp/src/kernel/local-vfs-client.ts
+++ b/packages/webapp/src/kernel/local-vfs-client.ts
@@ -16,7 +16,7 @@
  * `panel.someWrite(...)` call fail at compile time.
  */
 
-import type { DirEntry, ReadFileOptions, Stats } from '../fs/types.js';
+import type { DirEntry, FsChangeEvent, ReadFileOptions, Stats } from '../fs/types.js';
 
 export interface LocalVfsClient {
   /**
@@ -35,6 +35,19 @@ export interface LocalVfsClient {
    * Stat a path. Throws `FsError(ENOENT)` if missing.
    */
   stat(path: string): Promise<Stats>;
+
+  /**
+   * Subscribe to changes under each of `basePaths`; resolves to an
+   * unsubscribe. OPTIONAL because it is the one method a reader may
+   * genuinely not have — a client whose backend exposes no `FsWatcher`
+   * (an unwired `VirtualFS`, a read-only host) cannot honestly offer
+   * one, and a caller that gets `undefined` here knows to fall back to
+   * polling rather than wait on events that will never arrive (#2409).
+   */
+  watch?(
+    basePaths: readonly string[],
+    callback: (events: FsChangeEvent[]) => void
+  ): Promise<() => void>;
 }
 
 /**
@@ -46,9 +59,13 @@ export interface LocalVfsClient {
  * you want the type system to catch accidental writes.
  */
 export function createLocalVfsClient(source: LocalVfsClient): LocalVfsClient {
+  const watch = source.watch?.bind(source);
   return {
     readDir: (path) => source.readDir(path),
     readFile: (path, options) => source.readFile(path, options),
     stat: (path) => source.stat(path),
+    // Forwarded only when the source actually has it: leaving the key off
+    // is the signal callers branch on.
+    ...(watch ? { watch } : {}),
   };
 }

--- a/packages/webapp/src/kernel/messages.ts
+++ b/packages/webapp/src/kernel/messages.ts
@@ -778,6 +778,61 @@ export type VfsWriteResultMsg =
   | VfsFlushResultMsg
   | VfsListMountPointsResultMsg;
 
+// ---------------------------------------------------------------------------
+// VFS watch subscription
+// ---------------------------------------------------------------------------
+// Push channel that replaces the panel's 3 s file-tree poll (#2409). The
+// worker owns the VFS and its `FsWatcher` already sees every mutation, so
+// the panel subscribes to the roots it renders and rebuilds on change
+// instead of re-reading an unchanged tree twice a minute.
+//
+// Unlike the request/response RPCs above, a `vfs-watch` acknowledges once
+// and then pushes `vfs-watch-event` envelopes carrying the SAME
+// `subscriptionId` until the panel sends `vfs-unwatch` (or the host is
+// disposed). Mirrored, not imported, for the same tsconfig reason as the
+// read envelopes.
+
+/** Wire mirror of `FsChangeEvent` from `webapp/src/fs/fs-watcher.ts`. */
+export interface VfsChangeEventEnvelope {
+  type: 'create' | 'modify' | 'delete';
+  path: string;
+  entryType?: 'file' | 'directory' | 'symlink';
+}
+
+/** Panel → worker: subscribe to changes under each of `basePaths`. */
+export interface VfsWatchRequestMsg {
+  type: 'vfs-watch';
+  /** Subscription id — echoed on the ack AND on every pushed event. */
+  subscriptionId: string;
+  basePaths: string[];
+}
+
+/** Panel → worker: drop the subscription. Unknown ids are a no-op. */
+export interface VfsUnwatchRequestMsg {
+  type: 'vfs-unwatch';
+  subscriptionId: string;
+}
+
+export type VfsWatchControlMsg = VfsWatchRequestMsg | VfsUnwatchRequestMsg;
+
+/**
+ * Worker → panel: ack for `vfs-watch`. The failure branch (no watcher
+ * wired on the host) is what tells the panel to fall back to polling
+ * rather than sit on a subscription that will never fire.
+ */
+export type VfsWatchResultMsg =
+  | { type: 'vfs-watch-result'; subscriptionId: string; ok: true }
+  | { type: 'vfs-watch-result'; subscriptionId: string; ok: false; error: VfsErrorEnvelope };
+
+/** Worker → panel: a batch of changes matching a live subscription. */
+export interface VfsWatchEventMsg {
+  type: 'vfs-watch-event';
+  subscriptionId: string;
+  events: VfsChangeEventEnvelope[];
+}
+
+export type VfsWatchPushMsg = VfsWatchResultMsg | VfsWatchEventMsg;
+
 // Detached popout messages — panel ↔ SW coordination.
 // See docs/superpowers/specs/2026-05-13-extension-detached-popout-design.md.
 
@@ -871,6 +926,10 @@ export type PanelToOffscreenMessage =
   // host replies with an EACCES failure envelope. Ignored by
   // `Bridge`.
   | VfsWriteRequestMsg
+  // Panel-driven VFS watch subscription control. Routed by the worker's
+  // `VfsRpcHost` when a watcher is wired; otherwise `vfs-watch` is
+  // answered with an ENOSYS failure ack. Ignored by `Bridge`.
+  | VfsWatchControlMsg
   | DetachedPopoutRequestMsg
   | DetachedClaimMsg;
 
@@ -1281,7 +1340,10 @@ export type OffscreenToPanelMessage =
   | VfsReadResultMsg
   // VFS write RPC responses emitted by the worker's `VfsRpcHost`.
   // Defined above as `VfsWriteResultMsg`.
-  | VfsWriteResultMsg;
+  | VfsWriteResultMsg
+  // VFS watch acks and pushed change batches emitted by the worker's
+  // `VfsRpcHost`. Defined above as `VfsWatchPushMsg`.
+  | VfsWatchPushMsg;
 
 // ---------------------------------------------------------------------------
 // Offscreen ↔ Service Worker (CDP proxy)

--- a/packages/webapp/src/kernel/remote-vfs-client.ts
+++ b/packages/webapp/src/kernel/remote-vfs-client.ts
@@ -12,6 +12,10 @@
  *   readDir(path)            → `vfs-read-dir`  → `vfs-read-dir-result`
  *   readFile(path, opts?)    → `vfs-read-file` → `vfs-read-file-result`
  *   stat(path)               → `vfs-stat`      → `vfs-stat-result`
+ *   watch(basePaths, cb)     → `vfs-watch`     → `vfs-watch-result` ack,
+ *                              then a `vfs-watch-event` push per change
+ *                              batch until the returned unsubscribe sends
+ *                              `vfs-unwatch` (#2409).
  *
  * Failure-branch responses are translated back into `FsError(code, …)`
  * so callers see the same throw shape they would from `VirtualFS`.
@@ -22,7 +26,7 @@
  * host, and VFS host all coexist on a single port.
  */
 
-import type { DirEntry, ReadFileOptions, Stats } from '../fs/types.js';
+import type { DirEntry, FsChangeEvent, ReadFileOptions, Stats } from '../fs/types.js';
 import { FsError, type FsErrorCode } from '../fs/types.js';
 import type { LocalVfsClient } from './local-vfs-client.js';
 import type {
@@ -34,6 +38,10 @@ import type {
   VfsReadFileResultMsg,
   VfsStatRequestMsg,
   VfsStatResultMsg,
+  VfsUnwatchRequestMsg,
+  VfsWatchEventMsg,
+  VfsWatchRequestMsg,
+  VfsWatchResultMsg,
 } from './messages.js';
 import type { KernelTransport } from './types.js';
 
@@ -75,6 +83,15 @@ export interface RemoteVfsClientOptions {
 }
 
 export interface RemoteVfsClientHandle extends LocalVfsClient {
+  /**
+   * Always present here (unlike the optional `LocalVfsClient.watch`): the
+   * host either has a watcher or fails the ack, and either way the caller
+   * gets an answer rather than a missing method.
+   */
+  watch(
+    basePaths: readonly string[],
+    callback: (events: FsChangeEvent[]) => void
+  ): Promise<() => void>;
   /** Tear down the transport subscription. Pending requests reject. */
   dispose(): void;
 }
@@ -116,14 +133,34 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
  */
 const READ_REQUEST_ID_PREFIX = 'vfs-r-';
 
+/**
+ * Subscription-id namespace for `watch`. Disjoint from the request-id
+ * namespaces above — watch envelopes carry `subscriptionId`, not
+ * `requestId`, so they can never collide, but a distinct prefix keeps
+ * a logged id self-describing.
+ */
+const WATCH_SUBSCRIPTION_ID_PREFIX = 'vfs-sub-';
+
+/** How long to wait for the `vfs-watch` ack before giving up (ms). */
+const WATCH_ACK_TIMEOUT_MS = 10_000;
+
+interface PendingWatch {
+  callback: (events: FsChangeEvent[]) => void;
+}
+
 class RemoteVfsClient implements RemoteVfsClientHandle {
   private readonly transport: KernelTransport<ExtensionMessage, PanelToOffscreenMessage>;
   private readonly log: NonNullable<RemoteVfsClientOptions['logger']>;
   private readonly genId: () => string;
   private readonly requestTimeoutMs: number;
   private readonly pending = new Map<string, PendingRequest>();
+  /** Live `watch` subscriptions, keyed by subscription id. */
+  private readonly watches = new Map<string, PendingWatch>();
+  /** Resolvers for `vfs-watch` acks still in flight, keyed the same way. */
+  private readonly watchAcks = new Map<string, (result: VfsWatchResultMsg) => void>();
   private unsubscribe: (() => void) | null = null;
   private counter = 0;
+  private watchCounter = 0;
 
   constructor(opts: RemoteVfsClientOptions) {
     this.transport = opts.transport;
@@ -140,6 +177,10 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
       if (!isExtensionEnvelope(envelope)) return;
       if (envelope.source !== 'offscreen') return;
       const payload = envelope.payload as { type?: string; requestId?: string };
+      if (isVfsWatchPush(payload)) {
+        this.handleWatchPush(payload as unknown as VfsWatchResultMsg | VfsWatchEventMsg);
+        return;
+      }
       if (!isVfsResult(payload)) return;
       this.handleResult(payload as ResultMsg);
     });
@@ -168,9 +209,87 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
     return this.request<Stats>(requestId, 'vfs-stat-result', path, req);
   }
 
+  /**
+   * Subscribe to VFS changes under `basePaths`. Resolves once the worker
+   * acks, to an unsubscribe that drops the worker-side registration too —
+   * so an unsubscribed panel costs the worker nothing, not just the page.
+   *
+   * Rejects when the host has no watcher wired (`ENOSYS`) or the ack never
+   * lands, which is the caller's cue to fall back to polling.
+   */
+  async watch(
+    basePaths: readonly string[],
+    callback: (events: FsChangeEvent[]) => void
+  ): Promise<() => void> {
+    this.watchCounter = (this.watchCounter + 1) >>> 0;
+    const rand = Math.random().toString(36).slice(2, 8);
+    const subscriptionId = `${WATCH_SUBSCRIPTION_ID_PREFIX}${this.watchCounter.toString(36)}-${rand}`;
+    // Registered BEFORE the ack: the worker may push a batch between
+    // sending the ack and the page processing it, and a dropped first
+    // batch is exactly the change the caller subscribed to see.
+    this.watches.set(subscriptionId, { callback });
+    const unsubscribe = (): void => {
+      if (!this.watches.delete(subscriptionId)) return;
+      const req: VfsUnwatchRequestMsg = { type: 'vfs-unwatch', subscriptionId };
+      try {
+        this.transport.send(req as PanelToOffscreenMessage);
+      } catch (err) {
+        this.log.debug?.('[remote-vfs-client] unwatch send failed', err);
+      }
+    };
+    const ack = new Promise<VfsWatchResultMsg>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.watchAcks.delete(subscriptionId);
+        reject(new FsError('EIO', `vfs-watch ack timed out after ${WATCH_ACK_TIMEOUT_MS}ms`));
+      }, WATCH_ACK_TIMEOUT_MS);
+      this.watchAcks.set(subscriptionId, (result) => {
+        clearTimeout(timer);
+        this.watchAcks.delete(subscriptionId);
+        resolve(result);
+      });
+    });
+    const req: VfsWatchRequestMsg = {
+      type: 'vfs-watch',
+      subscriptionId,
+      basePaths: [...basePaths],
+    };
+    try {
+      this.transport.send(req as PanelToOffscreenMessage);
+    } catch (err) {
+      this.watches.delete(subscriptionId);
+      this.watchAcks.delete(subscriptionId);
+      throw err;
+    }
+    let result: VfsWatchResultMsg;
+    try {
+      result = await ack;
+    } catch (err) {
+      this.watches.delete(subscriptionId);
+      throw err;
+    }
+    if (result.ok === false) {
+      this.watches.delete(subscriptionId);
+      throw toFsError(result.error.code, result.error.message, result.error.path);
+    }
+    return unsubscribe;
+  }
+
   dispose(): void {
     this.unsubscribe?.();
     this.unsubscribe = null;
+    // Drop subscriptions on the worker side too — a disposed client whose
+    // registrations survive would have the host pushing events at nobody
+    // for the rest of the session.
+    for (const [subscriptionId] of this.watches) {
+      const req: VfsUnwatchRequestMsg = { type: 'vfs-unwatch', subscriptionId };
+      try {
+        this.transport.send(req as PanelToOffscreenMessage);
+      } catch {
+        // Transport already gone — nothing to release.
+      }
+    }
+    this.watches.clear();
+    this.watchAcks.clear();
     // Reject any in-flight requests so callers don't hang forever after
     // teardown (e.g. panel-detach mid-readDir refresh).
     for (const [, p] of this.pending) {
@@ -222,6 +341,16 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
         reject(err);
       }
     });
+  }
+
+  private handleWatchPush(msg: VfsWatchResultMsg | VfsWatchEventMsg): void {
+    if (msg.type === 'vfs-watch-result') {
+      this.watchAcks.get(msg.subscriptionId)?.(msg);
+      return;
+    }
+    const sub = this.watches.get(msg.subscriptionId);
+    if (!sub) return;
+    sub.callback(msg.events as FsChangeEvent[]);
   }
 
   private handleResult(msg: ResultMsg): void {
@@ -289,6 +418,10 @@ function isVfsResult(payload: { type?: string; requestId?: string }): boolean {
   return t === 'vfs-read-dir-result' || t === 'vfs-read-file-result' || t === 'vfs-stat-result';
 }
 
+function isVfsWatchPush(payload: { type?: string }): boolean {
+  return payload.type === 'vfs-watch-result' || payload.type === 'vfs-watch-event';
+}
+
 function toFsError(code: string, message: string, path: string | undefined): FsError {
   // The wire carries a string; narrow to the typed `FsErrorCode` set
   // and fall back to `EIO` for any code the page doesn't know.
@@ -304,6 +437,7 @@ function toFsError(code: string, message: string, path: string | undefined): FsE
     'EBUSY',
     'EFBIG',
     'EBADF',
+    'ENOSYS',
     'EIO',
   ];
   const narrowed: FsErrorCode = known.includes(code as FsErrorCode) ? (code as FsErrorCode) : 'EIO';

--- a/packages/webapp/src/kernel/remote-vfs-client.ts
+++ b/packages/webapp/src/kernel/remote-vfs-client.ts
@@ -148,6 +148,13 @@ interface PendingWatch {
   callback: (events: FsChangeEvent[]) => void;
 }
 
+interface PendingWatchAck {
+  settle: (result: VfsWatchResultMsg) => void;
+  /** Rejects the caller on dispose, so a teardown mid-subscribe fails fast. */
+  fail: (err: unknown) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
 class RemoteVfsClient implements RemoteVfsClientHandle {
   private readonly transport: KernelTransport<ExtensionMessage, PanelToOffscreenMessage>;
   private readonly log: NonNullable<RemoteVfsClientOptions['logger']>;
@@ -156,8 +163,8 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
   private readonly pending = new Map<string, PendingRequest>();
   /** Live `watch` subscriptions, keyed by subscription id. */
   private readonly watches = new Map<string, PendingWatch>();
-  /** Resolvers for `vfs-watch` acks still in flight, keyed the same way. */
-  private readonly watchAcks = new Map<string, (result: VfsWatchResultMsg) => void>();
+  /** Acks still in flight, keyed the same way. Settled on dispose. */
+  private readonly watchAcks = new Map<string, PendingWatchAck>();
   private unsubscribe: (() => void) | null = null;
   private counter = 0;
   private watchCounter = 0;
@@ -242,10 +249,18 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
         this.watchAcks.delete(subscriptionId);
         reject(new FsError('EIO', `vfs-watch ack timed out after ${WATCH_ACK_TIMEOUT_MS}ms`));
       }, WATCH_ACK_TIMEOUT_MS);
-      this.watchAcks.set(subscriptionId, (result) => {
-        clearTimeout(timer);
-        this.watchAcks.delete(subscriptionId);
-        resolve(result);
+      this.watchAcks.set(subscriptionId, {
+        settle: (result) => {
+          clearTimeout(timer);
+          this.watchAcks.delete(subscriptionId);
+          resolve(result);
+        },
+        fail: (err) => {
+          clearTimeout(timer);
+          this.watchAcks.delete(subscriptionId);
+          reject(err);
+        },
+        timer,
       });
     });
     const req: VfsWatchRequestMsg = {
@@ -289,6 +304,12 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
       }
     }
     this.watches.clear();
+    // Settle in-flight subscribes rather than dropping their resolvers: an
+    // abandoned ack promise would leave the caller hanging for the full
+    // 10 s ack timeout AFTER teardown, and then reject into a dead panel.
+    for (const [, ack] of [...this.watchAcks]) {
+      ack.fail(new FsError('EBADF', 'RemoteVfsClient disposed'));
+    }
     this.watchAcks.clear();
     // Reject any in-flight requests so callers don't hang forever after
     // teardown (e.g. panel-detach mid-readDir refresh).
@@ -345,7 +366,7 @@ class RemoteVfsClient implements RemoteVfsClientHandle {
 
   private handleWatchPush(msg: VfsWatchResultMsg | VfsWatchEventMsg): void {
     if (msg.type === 'vfs-watch-result') {
-      this.watchAcks.get(msg.subscriptionId)?.(msg);
+      this.watchAcks.get(msg.subscriptionId)?.settle(msg);
       return;
     }
     const sub = this.watches.get(msg.subscriptionId);

--- a/packages/webapp/src/kernel/vfs-rpc-host.ts
+++ b/packages/webapp/src/kernel/vfs-rpc-host.ts
@@ -30,6 +30,14 @@
  *   `vfs-flush`      → `writableClient.flush()`           → `vfs-flush-result`
  *   `vfs-list-mount-points` → `writableClient.listMountPoints()`
  *
+ * Plus one long-lived subscription (#2409):
+ *   `vfs-watch`   → `watcher.watch(basePath, …)` per base path
+ *                   → `vfs-watch-result` ack, then a `vfs-watch-event`
+ *                     push per notified batch until `vfs-unwatch`.
+ *   `vfs-unwatch` → drops the registrations for that subscription id.
+ * This is what lets the panel's file tree react to writes instead of
+ * re-reading the whole tree on a timer.
+ *
  * Errors thrown by the underlying VFS backend are serialised onto the
  * failure branch of the discriminated response. `FsError` (POSIX
  * `code` + `message` + `path`) round-trips with the `code` preserved;
@@ -44,6 +52,7 @@
  * types fan out into nobody — existing behavior is unchanged.
  */
 
+import type { FsWatcher } from '../fs/fs-watcher.js';
 import { FsError } from '../fs/types.js';
 import type { LocalVfsClient } from './local-vfs-client.js';
 import type {
@@ -68,6 +77,11 @@ import type {
   VfsStatRequestMsg,
   VfsStatResultMsg,
   VfsStatsEnvelope,
+  VfsUnwatchRequestMsg,
+  VfsWatchControlMsg,
+  VfsWatchEventMsg,
+  VfsWatchRequestMsg,
+  VfsWatchResultMsg,
   VfsWriteFileRequestMsg,
   VfsWriteFileResultMsg,
   VfsWriteRequestMsg,
@@ -106,6 +120,18 @@ export interface VfsRpcHostOptions {
    */
   writableClient?: WritableVfsBackend;
   /**
+   * Resolves the VFS change watcher, or `null` when none is attached.
+   *
+   * A CALLBACK rather than a value because the host starts before the
+   * orchestrator has finished wiring `sharedFs.setWatcher(...)` — resolving
+   * per subscription means the first panel to open its file tree gets the
+   * live watcher instead of a `null` captured at boot. When it resolves
+   * `null`, `vfs-watch` is answered with an `ENOSYS` failure ack so the
+   * panel falls back to polling instead of waiting on events that will
+   * never arrive.
+   */
+  getWatcher?: () => FsWatcher | null;
+  /**
    * Optional logger. Defaults to `console`. Override in tests to
    * silence expected warnings.
    */
@@ -138,13 +164,17 @@ class VfsRpcHost {
   private readonly transport: KernelTransport<ExtensionMessage, OffscreenToPanelMessage>;
   private readonly client: LocalVfsClient;
   private readonly writableClient: WritableVfsBackend | null;
+  private readonly getWatcher: (() => FsWatcher | null) | null;
   private readonly log: NonNullable<VfsRpcHostOptions['logger']>;
   private unsubscribe: (() => void) | null = null;
+  /** Live watch subscriptions, keyed by the panel's subscription id. */
+  private readonly watches = new Map<string, Array<() => void>>();
 
   constructor(options: VfsRpcHostOptions) {
     this.transport = options.transport;
     this.client = options.client;
     this.writableClient = options.writableClient ?? null;
+    this.getWatcher = options.getWatcher ?? null;
     this.log = options.logger ?? console;
   }
 
@@ -169,12 +199,86 @@ class VfsRpcHost {
         });
         return;
       }
+      if (isVfsWatchControl(payload)) {
+        this.handleWatchControl(payload);
+        return;
+      }
     });
   }
 
   dispose(): void {
     this.unsubscribe?.();
     this.unsubscribe = null;
+    for (const [, unsubs] of this.watches) for (const off of unsubs) off();
+    this.watches.clear();
+  }
+
+  // -------------------------------------------------------------------------
+  // Watch subscriptions (#2409)
+  // -------------------------------------------------------------------------
+
+  private handleWatchControl(req: VfsWatchControlMsg): void {
+    if (req.type === 'vfs-watch') this.handleWatch(req);
+    else this.handleUnwatch(req);
+  }
+
+  private handleWatch(req: VfsWatchRequestMsg): void {
+    // Re-subscribing under a live id replaces it (the panel re-points its
+    // roots when the selected cone changes) — otherwise the old roots would
+    // keep pushing events forever.
+    this.dropWatch(req.subscriptionId);
+    const watcher = this.getWatcher?.() ?? null;
+    if (!watcher) {
+      this.sendWatchAck({
+        type: 'vfs-watch-result',
+        subscriptionId: req.subscriptionId,
+        ok: false,
+        error: { code: 'ENOSYS', message: 'vfs-rpc-host has no watcher wired' },
+      });
+      return;
+    }
+    const unsubs = req.basePaths.map((basePath) =>
+      watcher.watch(
+        basePath,
+        () => true,
+        (events) => {
+          // The subscription may have been dropped between the watcher's
+          // `notify` loop starting and this callback running.
+          if (!this.watches.has(req.subscriptionId)) return;
+          const msg: VfsWatchEventMsg = {
+            type: 'vfs-watch-event',
+            subscriptionId: req.subscriptionId,
+            events: events.map((e) => ({
+              type: e.type,
+              path: e.path,
+              ...(e.entryType ? { entryType: e.entryType } : {}),
+            })),
+          };
+          this.transport.send(msg);
+        }
+      )
+    );
+    this.watches.set(req.subscriptionId, unsubs);
+    this.sendWatchAck({
+      type: 'vfs-watch-result',
+      subscriptionId: req.subscriptionId,
+      ok: true,
+    });
+  }
+
+  private handleUnwatch(req: VfsUnwatchRequestMsg): void {
+    this.dropWatch(req.subscriptionId);
+  }
+
+  private dropWatch(subscriptionId: string): void {
+    const unsubs = this.watches.get(subscriptionId);
+    if (!unsubs) return;
+    this.watches.delete(subscriptionId);
+    for (const off of unsubs) off();
+  }
+
+  private sendWatchAck(msg: VfsWatchResultMsg): void {
+    this.transport.send(msg);
   }
 
   // -------------------------------------------------------------------------
@@ -578,6 +682,12 @@ function isVfsWriteRequest(payload: unknown): payload is VfsWriteRequestMsg {
     t === 'vfs-flush' ||
     t === 'vfs-list-mount-points'
   );
+}
+
+function isVfsWatchControl(payload: unknown): payload is VfsWatchControlMsg {
+  if (typeof payload !== 'object' || payload === null) return false;
+  const t = (payload as { type?: unknown }).type;
+  return t === 'vfs-watch' || t === 'vfs-unwatch';
 }
 
 function writeResultTypeFor(

--- a/packages/webapp/src/kernel/writable-vfs-client.ts
+++ b/packages/webapp/src/kernel/writable-vfs-client.ts
@@ -448,6 +448,7 @@ function toFsError(code: string, message: string, path: string | undefined): FsE
     'EBUSY',
     'EFBIG',
     'EBADF',
+    'ENOSYS',
     'EIO',
   ];
   const narrowed: FsErrorCode = known.includes(code as FsErrorCode) ? (code as FsErrorCode) : 'EIO';

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -240,10 +240,10 @@ export function prepareWcShell(app: HTMLElement, floatLabel: string): WcShellBoo
     // roster/status event or the 15s stats poll would, which is long enough to
     // read as the strip ignoring the click.
     wiring.refreshScoops?.();
-    // The memory panel shows the memory of the cone that owns the selection
-    // (#2271) and reads once per activation, so an open panel has to be told
-    // the selection moved. The file tree re-points itself on its next poll.
+    // Both panels show the cone that owns the selection (#2271) and neither
+    // polls (#2409) — a selection change is not a change to their content.
     workbench?.refreshMemory();
+    workbench?.refreshFiles();
   };
 
   const wiring: WcLiveWiring = {

--- a/packages/webapp/src/ui/wc/wc-workbench.ts
+++ b/packages/webapp/src/ui/wc/wc-workbench.ts
@@ -194,6 +194,12 @@ interface FileTreeController {
  * state (#2408). The 3 s poll survives only as the fallback for a reader that
  * cannot watch (no `FsWatcher` behind it) — without it such a panel would go
  * permanently stale.
+ *
+ * There is deliberately NO slow reconciliation sweep behind the subscription:
+ * a path that can change without reaching `watcher.notify` is a gap in the
+ * NOTIFICATION, and the fix belongs there. `mkdir -p` and `refreshMount` were
+ * two such gaps and now emit events; a future one should be fixed the same
+ * way rather than papered over by re-reading the tree on a timer.
  */
 function createFileTreeController(deps: WcWorkbenchDeps): FileTreeController {
   let pollTimer: ReturnType<typeof setInterval> | null = null;

--- a/packages/webapp/src/ui/wc/wc-workbench.ts
+++ b/packages/webapp/src/ui/wc/wc-workbench.ts
@@ -121,8 +121,9 @@ export interface WcWorkbenchDeps {
   insertReference(path: string): void;
   /**
    * Filesystem coordinates of the cone whose files the workbench shows — the
-   * root that owns the current selection (#2271). Read per refresh, so
-   * switching cones re-points the tree on the next poll.
+   * root that owns the current selection (#2271). Read per refresh; switching
+   * cones re-points the tree via `refreshFiles()`, which also re-aims the
+   * change subscription at the new roots.
    */
   getWorkspace(): WorkUnitWorkspace;
   log: { error(message: string, ...data: unknown[]): void };
@@ -130,52 +131,96 @@ export interface WcWorkbenchDeps {
 
 /** Per-panel lifecycle handle returned by {@link createWorkbenchActivator}. */
 export interface WorkbenchActivator {
-  /** Open (or re-open) a panel — starts its poller / mounts its content. */
+  /** Open (or re-open) a panel — starts its subscription / poller / content. */
   activate(surfaceId: string): void;
-  /** Panel left the tree (closed/removed) — stops its poller, if any. */
+  /** Panel left the tree (closed/removed) — stops its subscription / poller. */
   deactivate(surfaceId: string): void;
   /**
    * Re-read the memory panel because the SELECTION moved (#2271). The panel's
-   * rows come from the cone that owns the selection, and — unlike the file
-   * tree, which its 3 s poller re-points on its own — memory reads once per
+   * rows come from the cone that owns the selection and memory reads once per
    * activation, so an open panel would otherwise keep showing the previous
    * cone's memory indefinitely. No-op while the panel is closed.
    */
   refreshMemory(): void;
+  /**
+   * Re-point the file tree because the SELECTION moved (#2271). Rebuilds from
+   * the newly selected cone's roots and re-aims the change subscription at
+   * them — a selection change is not a filesystem change, so no event will
+   * announce it. No-op while the panel is closed.
+   */
+  refreshFiles(): void;
 }
 
 /**
- * Independent workbench panel lifecycle: since every tool panel is now its
- * own permanently-mounted, independently open/closeable dock-tree leaf (no
- * more show-one swapping), each panel's poller runs only while THAT panel is
- * open — activating one panel never stops another's. The file tree
- * auto-refreshes every 3 s and the monitor every 5 s while open; the terminal
- * mounts once on first `term` activation and is never torn down (matches the
- * old show-one behavior — the worker-shell session persists regardless of
- * panel visibility). Memory has no poller: it refreshes once per activation
- * and once per selection change (`refreshMemory`), which is every moment its
- * content can actually differ.
+ * Coalescing window for filesystem change events (ms).
+ *
+ * A single `upskill` install or `git checkout` produces hundreds of change
+ * events; each one alone would rebuild the whole tree. Trailing-edge debounce
+ * turns a burst into one rebuild, and 200 ms is below the threshold where a
+ * panel stops reading as live.
  */
-export function createWorkbenchActivator(deps: WcWorkbenchDeps): WorkbenchActivator {
-  let terminalMounted = false;
-  let memoryOpen = false;
-  let memorySeq = 0;
-  let filesRefreshTimer: ReturnType<typeof setInterval> | null = null;
-  let monitorRefreshTimer: ReturnType<typeof setInterval> | null = null;
-  // Sparkline history for the vitals tiles. Fed by the refresh below, so it
-  // only accumulates while the panel is open — `windowLabel()` reports the
-  // span it actually covers rather than claiming more.
-  const monitorHistory = new MonitorHistory();
-  let filesRefreshPending = false;
-  let fileActionsWired = false;
+const FILES_DEBOUNCE_MS = 200;
 
-  const refreshFileTree = (): void => {
+/**
+ * Hard ceiling on how long the debounce may defer a rebuild (ms).
+ *
+ * A write loop that keeps ticking faster than {@link FILES_DEBOUNCE_MS} would
+ * otherwise reset the timer forever and the tree would never repaint while the
+ * agent is busy — which is exactly when the user is watching it.
+ */
+const FILES_DEBOUNCE_MAX_WAIT_MS = 1000;
+
+/** Fallback poll interval for a reader that cannot watch (ms). */
+const FILES_FALLBACK_POLL_MS = 3000;
+
+/** File-tree panel lifecycle, owned by {@link createFileTreeController}. */
+interface FileTreeController {
+  /** Panel opened: build once, then subscribe to the roots it renders. */
+  open(): void;
+  /** Panel closed: drop the subscription (and any fallback poller). */
+  close(): void;
+  /** Selection moved: rebuild from the new roots and re-aim the watch. */
+  repoint(): void;
+}
+
+/**
+ * The file tree's refresh lifecycle — EVENT-DRIVEN (#2409).
+ *
+ * SLICC owns the filesystem and every `VirtualFS` mutation notifies the
+ * kernel's `FsWatcher`, so the panel subscribes to the roots it renders and
+ * rebuilds on a debounced change instead of re-reading an unchanged tree
+ * every 3 s. An idle filesystem costs nothing and touches no DOM, which is
+ * also what stops the periodic rebuild from resetting scroll and expansion
+ * state (#2408). The 3 s poll survives only as the fallback for a reader that
+ * cannot watch (no `FsWatcher` behind it) — without it such a panel would go
+ * permanently stale.
+ */
+function createFileTreeController(deps: WcWorkbenchDeps): FileTreeController {
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let kernelReadyPending = false;
+  let actionsWired = false;
+  let open = false;
+  /** Bumped on every open/close, so a late subscribe from a closed panel dies. */
+  let watchSeq = 0;
+  /** Same guard for rebuilds — an older tree must never repaint over a newer. */
+  let buildSeq = 0;
+  let unwatch: (() => void) | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  /** When the currently deferred burst started, for the max-wait ceiling. */
+  let debounceStartedAt = 0;
+
+  const rebuild = (): void => {
+    const seq = ++buildSeq;
     void deps
       .openFs()
       .then(async (fs) => {
-        deps.fileTree.items = await buildVfsTreeItems(fs, deps.getWorkspace().root);
-        if (!fileActionsWired) {
-          fileActionsWired = true;
+        const items = await buildVfsTreeItems(fs, deps.getWorkspace().root);
+        // Two rebuilds can overlap (a change landing mid-read); the later one
+        // owns the tree regardless of which read finishes first.
+        if (seq !== buildSeq) return;
+        deps.fileTree.items = items;
+        if (!actionsWired) {
+          actionsWired = true;
           wireFileActions({
             fileTree: deps.fileTree,
             openFs: deps.openFs,
@@ -189,13 +234,130 @@ export function createWorkbenchActivator(deps: WcWorkbenchDeps): WorkbenchActiva
       .catch((err) => deps.log.error('WC file tree refresh failed', err));
   };
 
-  const stopFilesRefresh = (): void => {
-    filesRefreshPending = false;
-    if (filesRefreshTimer != null) {
-      clearInterval(filesRefreshTimer);
-      filesRefreshTimer = null;
+  /** Debounced rebuild — the only thing a change event triggers. */
+  const scheduleRebuild = (): void => {
+    if (!open) return;
+    const now = Date.now();
+    if (debounceTimer == null) debounceStartedAt = now;
+    else if (now - debounceStartedAt >= FILES_DEBOUNCE_MAX_WAIT_MS) {
+      // The burst has outrun the ceiling — repaint now and start a new window
+      // rather than deferring again behind a write loop that may not stop.
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+      rebuild();
+      return;
+    }
+    if (debounceTimer != null) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      rebuild();
+    }, FILES_DEBOUNCE_MS);
+  };
+
+  /** Last resort for a reader with no watcher behind it (see above). */
+  const startPoll = (): void => {
+    if (pollTimer != null) return;
+    pollTimer = setInterval(rebuild, FILES_FALLBACK_POLL_MS);
+  };
+
+  /**
+   * Subscribe to the roots the tree currently renders. Re-callable: an
+   * existing subscription is dropped first, which is how a cone switch
+   * re-aims the watch without leaking the previous cone's registration.
+   */
+  const startWatch = (): void => {
+    const seq = ++watchSeq;
+    unwatch?.();
+    unwatch = null;
+    const roots = [deps.getWorkspace().root, SHARED_TREE_ROOT];
+    void deps
+      .openFs()
+      .then(async (fs) => {
+        if (!fs.watch) {
+          if (seq === watchSeq && open) startPoll();
+          return;
+        }
+        const off = await fs.watch(roots, scheduleRebuild);
+        // The panel may have closed (or re-pointed) while the ack was in
+        // flight — drop the subscription we just took rather than keep a
+        // registration nobody reads.
+        if (seq !== watchSeq || !open) {
+          off();
+          return;
+        }
+        unwatch = off;
+      })
+      .catch((err) => {
+        deps.log.error('WC file tree watch failed — falling back to polling', err);
+        if (seq === watchSeq && open) startPoll();
+      });
+  };
+
+  const close = (): void => {
+    kernelReadyPending = false;
+    open = false;
+    watchSeq++;
+    unwatch?.();
+    unwatch = null;
+    if (debounceTimer != null) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+    if (pollTimer != null) {
+      clearInterval(pollTimer);
+      pollTimer = null;
     }
   };
+
+  return {
+    open(): void {
+      close();
+      open = true;
+      kernelReadyPending = true;
+      // VFS reads are worker RPCs — nothing may go out before the kernel is up.
+      deps.onKernelReady(() => {
+        if (!kernelReadyPending) return;
+        kernelReadyPending = false;
+        rebuild();
+        startWatch();
+      });
+    },
+    close,
+    repoint(): void {
+      // Still waiting on the kernel: the pending first build will read the new
+      // roots itself, and rebuilding now would only race it.
+      if (!open || kernelReadyPending) return;
+      rebuild();
+      startWatch();
+    },
+  };
+}
+
+/**
+ * Independent workbench panel lifecycle: since every tool panel is now its
+ * own permanently-mounted, independently open/closeable dock-tree leaf (no
+ * more show-one swapping), each panel's refresh runs only while THAT panel is
+ * open — activating one panel never stops another's.
+ *
+ * The file tree refreshes on VFS change events (see
+ * {@link createFileTreeController}). The monitor genuinely polls (5 s): it
+ * samples "right now" metrics with no event source. The terminal mounts once
+ * on first `term` activation and is never torn down (matches the old show-one
+ * behavior — the worker-shell session persists regardless of panel
+ * visibility). Memory refreshes once per activation and once per selection
+ * change (`refreshMemory`), which is every moment its content can actually
+ * differ.
+ */
+export function createWorkbenchActivator(deps: WcWorkbenchDeps): WorkbenchActivator {
+  let terminalMounted = false;
+  let memoryOpen = false;
+  let memorySeq = 0;
+  let monitorRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  // Sparkline history for the vitals tiles. Fed by the refresh below, so it
+  // only accumulates while the panel is open — `windowLabel()` reports the
+  // span it actually covers rather than claiming more.
+  const monitorHistory = new MonitorHistory();
+  const fileTree = createFileTreeController(deps);
 
   const stopMonitorRefresh = (): void => {
     if (monitorRefreshTimer != null) {
@@ -208,7 +370,7 @@ export function createWorkbenchActivator(deps: WcWorkbenchDeps): WorkbenchActiva
     // Last-write-wins by SEQUENCE, not by completion order: switching cones
     // while a read is in flight starts a second one, and the two files differ
     // in size, so cone A's slower read could land after cone B's and leave the
-    // panel showing A indefinitely (no poller corrects it).
+    // panel showing A indefinitely (nothing else corrects it).
     const seq = ++memorySeq;
     void deps
       .openFs()
@@ -235,14 +397,7 @@ export function createWorkbenchActivator(deps: WcWorkbenchDeps): WorkbenchActiva
   return {
     activate(surfaceId: string): void {
       if (surfaceId === 'files') {
-        stopFilesRefresh();
-        filesRefreshPending = true;
-        deps.onKernelReady(() => {
-          if (!filesRefreshPending) return;
-          filesRefreshPending = false;
-          refreshFileTree();
-          filesRefreshTimer = setInterval(refreshFileTree, 3000);
-        });
+        fileTree.open();
         return;
       }
       if (surfaceId === 'memory') {
@@ -265,12 +420,15 @@ export function createWorkbenchActivator(deps: WcWorkbenchDeps): WorkbenchActiva
       }
     },
     deactivate(surfaceId: string): void {
-      if (surfaceId === 'files') stopFilesRefresh();
+      if (surfaceId === 'files') fileTree.close();
       else if (surfaceId === 'monitor') stopMonitorRefresh();
       else if (surfaceId === 'memory') memoryOpen = false;
     },
     refreshMemory(): void {
       if (memoryOpen) refreshMemory();
+    },
+    refreshFiles(): void {
+      fileTree.repoint();
     },
   };
 }

--- a/packages/webapp/tests/fs/virtual-fs.mount.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs.mount.test.ts
@@ -38,6 +38,31 @@ describe('VirtualFS mount interactions with script discovery', () => {
     });
   });
 
+  // Codex review on #2423: a `mount refresh` exists BECAUSE the remote side
+  // changed outside the VFS — the one mutation no per-write notify announces.
+  // Without an event, an event-driven consumer (the workbench file tree,
+  // #2409) would sit on the pre-refresh listing indefinitely.
+  it('refreshMount notifies watchers that the mount subtree changed', async () => {
+    const { FsWatcher } = await import('../../src/fs/fs-watcher.js');
+    await vfs.mkdir('/mnt', { recursive: true });
+    await vfs.mount('/mnt', backendOf(createDirectoryHandle({ 'a.txt': 'a' })));
+    await waitForTerminalState(vfs, '/mnt', 2000);
+
+    const watcher = new FsWatcher();
+    vfs.setWatcher(watcher);
+    const events: { type: string; path: string }[] = [];
+    watcher.watch(
+      '/mnt',
+      () => true,
+      (batch) => events.push(...batch)
+    );
+
+    await vfs.refreshMount('/mnt');
+
+    expect(events).toEqual([{ type: 'modify', path: '/mnt', entryType: 'directory' }]);
+    vfs.setWatcher(null);
+  });
+
   it('rejects mounting over a non-empty directory so existing scripts stay visible', async () => {
     await vfs.writeFile('/workspace/skills/test-skill/run.jsh', 'console.log("run");');
 

--- a/packages/webapp/tests/fs/virtual-fs.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs.test.ts
@@ -509,6 +509,37 @@ describe('VirtualFS', () => {
 
       vfs.setWatcher(null as any);
     });
+
+    // #2409: the `LocalVfsClient.watch` contract, so an in-process reader
+    // (no kernel RPC in between) gets the same event-driven refresh the
+    // panel does.
+    it('watch() subscribes to every base path and unsubscribes them all', async () => {
+      const { FsWatcher } = await import('../../src/fs/fs-watcher.js');
+      const watcher = new FsWatcher();
+      vfs.setWatcher(watcher);
+      const callback = vi.fn();
+
+      const off = await vfs.watch(['/a', '/b'], callback);
+      expect(watcher.size).toBe(2);
+      await vfs.mkdir('/a', { recursive: true });
+      await vfs.writeFile('/a/file.txt', 'x');
+      expect(callback).toHaveBeenCalled();
+
+      callback.mockClear();
+      off();
+      expect(watcher.size).toBe(0);
+      await vfs.writeFile('/a/after.txt', 'y');
+      expect(callback).not.toHaveBeenCalled();
+
+      vfs.setWatcher(null as any);
+    });
+
+    it('watch() rejects with ENOSYS when no watcher is attached', async () => {
+      vfs.setWatcher(null as any);
+      // A silently dead subscription would leave the caller waiting on
+      // events that cannot arrive; the throw is what tells it to poll.
+      await expect(vfs.watch(['/'], vi.fn())).rejects.toMatchObject({ code: 'ENOSYS' });
+    });
   });
 
   describe('canWrite', () => {

--- a/packages/webapp/tests/fs/virtual-fs.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs.test.ts
@@ -534,6 +534,30 @@ describe('VirtualFS', () => {
       vfs.setWatcher(null as any);
     });
 
+    // Codex review on #2423: `mkdir -p` used to complete without notifying,
+    // so an event-driven consumer never saw a new empty directory appear.
+    it('mkdir recursive notifies once per directory it actually created', async () => {
+      const { FsWatcher } = await import('../../src/fs/fs-watcher.js');
+      const watcher = new FsWatcher();
+      await vfs.mkdir('/deep');
+      vfs.setWatcher(watcher);
+      const callback = vi.fn();
+      watcher.watch('/', () => true, callback);
+
+      await vfs.mkdir('/deep/a/b', { recursive: true });
+      const events = callback.mock.calls.flatMap((c) => c[0]);
+      // `/deep` already existed — an existing component is not a change.
+      expect(events.map((e: { path: string }) => e.path)).toEqual(['/deep/a', '/deep/a/b']);
+      expect(events.every((e: { type: string }) => e.type === 'create')).toBe(true);
+
+      // Re-running it creates nothing, so it announces nothing.
+      callback.mockClear();
+      await vfs.mkdir('/deep/a/b', { recursive: true });
+      expect(callback).not.toHaveBeenCalled();
+
+      vfs.setWatcher(null as any);
+    });
+
     it('watch() rejects with ENOSYS when no watcher is attached', async () => {
       vfs.setWatcher(null as any);
       // A silently dead subscription would leave the caller waiting on

--- a/packages/webapp/tests/kernel/local-vfs-client.test.ts
+++ b/packages/webapp/tests/kernel/local-vfs-client.test.ts
@@ -55,6 +55,25 @@ describe('LocalVfsClient', () => {
     expect(s.size).toBe(42);
   });
 
+  // #2409: `watch` is the one optional method, and the facade must not
+  // invent one — a caller branches on its ABSENCE to fall back to polling.
+  it('omits watch when the source cannot watch', () => {
+    const stub = makeStubVfs();
+    const client = createLocalVfsClient(stub.vfs);
+    expect(client.watch).toBeUndefined();
+  });
+
+  it('forwards watch (bound to the source) when the source has one', async () => {
+    const stub = makeStubVfs();
+    const unwatch = vi.fn();
+    const watch = vi.fn(async () => unwatch);
+    const client = createLocalVfsClient({ ...stub.vfs, watch });
+    const cb = vi.fn();
+    const off = await client.watch?.(['/workspace'], cb);
+    expect(watch).toHaveBeenCalledWith(['/workspace'], cb);
+    expect(off).toBe(unwatch);
+  });
+
   it('the facade has no write methods (compile-time check)', () => {
     const stub = makeStubVfs();
     const client = createLocalVfsClient(stub.vfs);

--- a/packages/webapp/tests/kernel/remote-vfs-client.test.ts
+++ b/packages/webapp/tests/kernel/remote-vfs-client.test.ts
@@ -17,6 +17,8 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import type { FsChangeEvent } from '../../src/fs/fs-watcher.js';
+import { FsWatcher } from '../../src/fs/fs-watcher.js';
 import type { DirEntry, ReadFileOptions, Stats } from '../../src/fs/types.js';
 import { FsError } from '../../src/fs/types.js';
 import type { LocalVfsClient } from '../../src/kernel/local-vfs-client.js';
@@ -59,13 +61,14 @@ interface RoundTripCtx {
   stop: () => void;
 }
 
-function setupRoundTrip(): RoundTripCtx {
+function setupRoundTrip(getWatcher?: () => FsWatcher | null): RoundTripCtx {
   const channel = new MessageChannel();
   const bridge = createBridgeMessageChannelTransport(channel.port2);
   const vfs = makeStubVfs();
   const hostHandle = startVfsRpcHost({
     transport: bridge,
     client: vfs.client,
+    ...(getWatcher ? { getWatcher } : {}),
     logger: { warn: vi.fn(), debug: vi.fn() },
   });
   const panel = createPanelMessageChannelTransport(channel.port1);
@@ -340,5 +343,67 @@ describe('RemoteVfsClient — dispose semantics', () => {
     await tick(0);
     client.dispose();
     await expect(p).rejects.toMatchObject({ name: 'FsError', code: 'EBADF' });
+  });
+});
+
+/**
+ * `watch()` (#2409) — the subscription the file panel uses instead of a
+ * poll. End-to-end against a real host + `FsWatcher`, because the value
+ * of the feature is precisely that a VFS mutation reaches the page.
+ */
+describe('RemoteVfsClient — watch', () => {
+  it('delivers change batches for the subscribed roots', async () => {
+    const watcher = new FsWatcher();
+    const ctx = setupRoundTrip(() => watcher);
+    const seen: FsChangeEvent[][] = [];
+    const unwatch = await ctx.client.watch(['/workspace', '/shared'], (events) =>
+      seen.push(events)
+    );
+
+    watcher.notify([{ type: 'create', path: '/workspace/new.txt', entryType: 'file' }]);
+    await tick(10);
+    expect(seen).toEqual([[{ type: 'create', path: '/workspace/new.txt', entryType: 'file' }]]);
+
+    // A path under neither root never reaches the page.
+    watcher.notify([{ type: 'create', path: '/etc/hosts', entryType: 'file' }]);
+    await tick(10);
+    expect(seen).toHaveLength(1);
+
+    unwatch();
+    ctx.stop();
+  });
+
+  it('unsubscribe releases the host-side registration (no listener leak)', async () => {
+    const watcher = new FsWatcher();
+    const ctx = setupRoundTrip(() => watcher);
+    // Ten open/close cycles — the panel being opened and closed repeatedly is
+    // exactly the shape that leaks registrations if unwatch is page-only.
+    for (let i = 0; i < 10; i++) {
+      const unwatch = await ctx.client.watch(['/workspace'], () => undefined);
+      expect(watcher.size).toBe(1);
+      unwatch();
+      await tick(5);
+      expect(watcher.size).toBe(0);
+    }
+    ctx.stop();
+  });
+
+  it('rejects with ENOSYS when the host has no watcher wired', async () => {
+    const ctx = setupRoundTrip();
+    await expect(ctx.client.watch(['/workspace'], () => undefined)).rejects.toMatchObject({
+      code: 'ENOSYS',
+    });
+    ctx.stop();
+  });
+
+  it('dispose drops host-side subscriptions too', async () => {
+    const watcher = new FsWatcher();
+    const ctx = setupRoundTrip(() => watcher);
+    await ctx.client.watch(['/workspace'], () => undefined);
+    expect(watcher.size).toBe(1);
+    ctx.client.dispose();
+    await tick(10);
+    expect(watcher.size).toBe(0);
+    ctx.stop();
   });
 });

--- a/packages/webapp/tests/kernel/remote-vfs-client.test.ts
+++ b/packages/webapp/tests/kernel/remote-vfs-client.test.ts
@@ -396,6 +396,26 @@ describe('RemoteVfsClient — watch', () => {
     ctx.stop();
   });
 
+  // Codex review on #2423: a dispose mid-subscribe used to abandon the ack
+  // promise, leaving the caller hanging for the full 10 s ack timeout AFTER
+  // teardown and then rejecting into a dead panel.
+  it('rejects an in-flight subscribe when the client is disposed', async () => {
+    const channel = new MessageChannel();
+    // No host on the far end: the ack never arrives, so the only thing that
+    // can settle this promise is the dispose.
+    const panel = createPanelMessageChannelTransport(channel.port1);
+    const client = createRemoteVfsClient({
+      transport: panel,
+      logger: { warn: vi.fn(), debug: vi.fn() },
+    });
+    const pending = client.watch(['/workspace'], () => undefined);
+    const settled = expect(pending).rejects.toMatchObject({ code: 'EBADF' });
+    client.dispose();
+    await settled;
+    channel.port1.close();
+    channel.port2.close();
+  });
+
   it('dispose drops host-side subscriptions too', async () => {
     const watcher = new FsWatcher();
     const ctx = setupRoundTrip(() => watcher);

--- a/packages/webapp/tests/kernel/vfs-rpc-host.test.ts
+++ b/packages/webapp/tests/kernel/vfs-rpc-host.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import { FsWatcher } from '../../src/fs/fs-watcher.js';
 import type { DirEntry, ReadFileOptions, Stats } from '../../src/fs/types.js';
 import { FsError } from '../../src/fs/types.js';
 import type { LocalVfsClient } from '../../src/kernel/local-vfs-client.js';
@@ -24,6 +25,8 @@ import type {
   VfsReadFileResultMsg,
   VfsReadRequestMsg,
   VfsStatResultMsg,
+  VfsWatchEventMsg,
+  VfsWatchResultMsg,
 } from '../../src/kernel/messages.js';
 import type { KernelTransport } from '../../src/kernel/transport.js';
 import {
@@ -93,13 +96,17 @@ function noop(): unknown {
   return null;
 }
 
-function setupRoundTrip(client?: LocalVfsClient): RoundTripCtx {
+function setupRoundTrip(
+  client?: LocalVfsClient,
+  getWatcher?: () => FsWatcher | null
+): RoundTripCtx {
   const channel = new MessageChannel();
   const bridgeTransport = createBridgeMessageChannelTransport(channel.port2);
   const vfs = client ? { ...makeStubVfs(), client } : makeStubVfs();
   const handle = startVfsRpcHost({
     transport: bridgeTransport,
     client: vfs.client,
+    ...(getWatcher ? { getWatcher } : {}),
     logger: { warn: vi.fn(), debug: vi.fn() },
   });
   const panelTransport = createPanelMessageChannelTransport(channel.port1);
@@ -499,5 +506,100 @@ describe('VfsRpcHost — transfer list', () => {
     expect(sends).toHaveLength(1);
     expect(sends[0].transfer).toBeUndefined();
     handle.stop();
+  });
+});
+
+/**
+ * Watch subscriptions (#2409) — the push channel that replaced the file
+ * panel's 3 s poll. What matters here is that the panel can subscribe,
+ * that unsubscribing actually releases the worker-side registration, and
+ * that a host with no watcher says so instead of going quiet.
+ */
+describe('VfsRpcHost watch subscriptions', () => {
+  it('acks vfs-watch and pushes matching change batches', async () => {
+    const watcher = new FsWatcher();
+    const ctx = setupRoundTrip(undefined, () => watcher);
+    ctx.panelTransport.send({
+      type: 'vfs-watch',
+      subscriptionId: 's1',
+      basePaths: ['/workspace', '/shared'],
+    });
+    await waitForResponses(ctx, 1);
+    const ack = ctx.responses[0] as VfsWatchResultMsg;
+    expect(ack.type).toBe('vfs-watch-result');
+    expect(ack.ok).toBe(true);
+    expect(watcher.size).toBe(2);
+
+    watcher.notify([{ type: 'create', path: '/workspace/new.txt', entryType: 'file' }]);
+    await waitForResponses(ctx, 2);
+    const push = ctx.responses[1] as VfsWatchEventMsg;
+    expect(push.type).toBe('vfs-watch-event');
+    expect(push.subscriptionId).toBe('s1');
+    expect(push.events).toEqual([
+      { type: 'create', path: '/workspace/new.txt', entryType: 'file' },
+    ]);
+
+    // Outside every subscribed base path — the watcher itself filters it.
+    watcher.notify([{ type: 'create', path: '/elsewhere/x', entryType: 'file' }]);
+    await tick(10);
+    expect(ctx.responses).toHaveLength(2);
+    ctx.stop();
+  });
+
+  it('vfs-unwatch releases the worker-side registrations', async () => {
+    const watcher = new FsWatcher();
+    const ctx = setupRoundTrip(undefined, () => watcher);
+    ctx.panelTransport.send({ type: 'vfs-watch', subscriptionId: 's2', basePaths: ['/workspace'] });
+    await waitForResponses(ctx, 1);
+    expect(watcher.size).toBe(1);
+
+    ctx.panelTransport.send({ type: 'vfs-unwatch', subscriptionId: 's2' });
+    await tick(10);
+    expect(watcher.size).toBe(0);
+    watcher.notify([{ type: 'modify', path: '/workspace/a.txt' }]);
+    await tick(10);
+    // Only the original ack — no pushes after the unsubscribe.
+    expect(ctx.responses).toHaveLength(1);
+    ctx.stop();
+  });
+
+  it('re-subscribing under a live id replaces its roots (cone switch)', async () => {
+    const watcher = new FsWatcher();
+    const ctx = setupRoundTrip(undefined, () => watcher);
+    ctx.panelTransport.send({ type: 'vfs-watch', subscriptionId: 's3', basePaths: ['/workspace'] });
+    await waitForResponses(ctx, 1);
+    ctx.panelTransport.send({
+      type: 'vfs-watch',
+      subscriptionId: 's3',
+      basePaths: ['/cones/beta/workspace'],
+    });
+    await waitForResponses(ctx, 2);
+    // Replaced, not accumulated — the old root must stop pushing.
+    expect(watcher.size).toBe(1);
+    watcher.notify([{ type: 'modify', path: '/workspace/a.txt' }]);
+    await tick(10);
+    expect(ctx.responses).toHaveLength(2);
+    ctx.stop();
+  });
+
+  it('fails the ack with ENOSYS when no watcher is wired', async () => {
+    const ctx = setupRoundTrip();
+    ctx.panelTransport.send({ type: 'vfs-watch', subscriptionId: 's4', basePaths: ['/workspace'] });
+    await waitForResponses(ctx, 1);
+    const ack = ctx.responses[0] as VfsWatchResultMsg;
+    expect(ack.ok).toBe(false);
+    if (!ack.ok) expect(ack.error.code).toBe('ENOSYS');
+    ctx.stop();
+  });
+
+  it('dispose drops every live subscription', async () => {
+    const watcher = new FsWatcher();
+    const ctx = setupRoundTrip(undefined, () => watcher);
+    ctx.panelTransport.send({ type: 'vfs-watch', subscriptionId: 's5', basePaths: ['/workspace'] });
+    ctx.panelTransport.send({ type: 'vfs-watch', subscriptionId: 's6', basePaths: ['/shared'] });
+    await waitForResponses(ctx, 2);
+    expect(watcher.size).toBe(2);
+    ctx.stop();
+    expect(watcher.size).toBe(0);
   });
 });

--- a/packages/webapp/tests/ui/wc/wc-boot.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-boot.test.ts
@@ -421,7 +421,12 @@ describe('URL state sync (live boot)', () => {
       boot.refs.dockTree as unknown as { placeSurface(id: string, zone: string): void }
     ).placeSurface('files', 'right');
     const activate = vi.fn();
-    boot.setActivateSurface({ activate, deactivate: vi.fn(), refreshMemory: vi.fn() });
+    boot.setActivateSurface({
+      activate,
+      deactivate: vi.fn(),
+      refreshMemory: vi.fn(),
+      refreshFiles: vi.fn(),
+    });
     // The re-fire is gated behind kernel ready (VFS RPCs need the worker).
     expect(activate).not.toHaveBeenCalled();
     boot.wiring.notifyReady?.();
@@ -430,7 +435,12 @@ describe('URL state sync (live boot)', () => {
     // Without any tool panel placed, the assignment stays passive.
     (boot.refs.dockTree as unknown as { removeSurface(id: string): void }).removeSurface('files');
     const idle = vi.fn();
-    boot.setActivateSurface({ activate: idle, deactivate: vi.fn(), refreshMemory: vi.fn() });
+    boot.setActivateSurface({
+      activate: idle,
+      deactivate: vi.fn(),
+      refreshMemory: vi.fn(),
+      refreshFiles: vi.fn(),
+    });
     boot.wiring.notifyReady?.();
     expect(idle).not.toHaveBeenCalled();
   });

--- a/packages/webapp/tests/ui/wc/wc-workbench.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-workbench.test.ts
@@ -11,7 +11,9 @@ import { installWcDomStubs } from './wc-dom-stubs.js';
 installWcDomStubs();
 
 import type { SliccFileTree } from '@slicc/webcomponents';
+import { FsWatcher } from '../../../src/fs/fs-watcher.js';
 import { VirtualFS } from '../../../src/fs/virtual-fs.js';
+import type { LocalVfsClient } from '../../../src/kernel/local-vfs-client.js';
 import {
   buildVfsTreeItems,
   createWorkbenchActivator,
@@ -116,6 +118,23 @@ describe('buildVfsTreeItems', () => {
   });
 });
 
+/**
+ * A watch-capable reader: the seeded VFS plus the `LocalVfsClient.watch`
+ * contract, driven by a real `FsWatcher`. Mirrors what the page gets from
+ * `RemoteVfsClient` — the panel cannot tell the two apart.
+ */
+async function watchableFs(): Promise<{
+  fs: LocalVfsClient;
+  watcher: FsWatcher;
+  base: VirtualFS;
+}> {
+  const base = await seededFs();
+  const watcher = new FsWatcher();
+  base.setWatcher(watcher);
+  const fs = Object.create(base) as VirtualFS & LocalVfsClient;
+  return { fs, watcher, base };
+}
+
 describe('createWorkbenchActivator', () => {
   function makeDeps() {
     const fileTree = document.createElement('slicc-file-tree') as SliccFileTree;
@@ -150,8 +169,12 @@ describe('createWorkbenchActivator', () => {
     await vi.waitFor(() => {
       expect(deps.fileTree.items?.length).toBeGreaterThan(0);
     });
+    // Re-activation rebuilds and re-subscribes; `openFs` is memoized in
+    // production, so the exact call count is not the contract — being asked
+    // again at all is.
+    const beforeReactivate = deps.openFs.mock.calls.length;
     activator.activate('files');
-    expect(deps.openFs).toHaveBeenCalledTimes(2);
+    expect(deps.openFs.mock.calls.length).toBeGreaterThan(beforeReactivate);
     expect(deps.mountTerminal).not.toHaveBeenCalled();
   });
 
@@ -282,7 +305,10 @@ describe('createWorkbenchActivator', () => {
     await vi.waitFor(() => expect(deps.log.error).toHaveBeenCalled());
   });
 
-  it('polls the file tree every 3 s while files surface is active', async () => {
+  // #2409: a reader with no watcher behind it (an unwired `VirtualFS`, a
+  // read-only host) keeps the 3 s poll — it is the only thing standing
+  // between that panel and permanent staleness.
+  it('falls back to polling every 3 s when the reader cannot watch', async () => {
     vi.useFakeTimers();
     const deps = makeDeps();
     const activator = createWorkbenchActivator(deps);
@@ -293,7 +319,7 @@ describe('createWorkbenchActivator', () => {
     vi.useRealTimers();
   });
 
-  it('activating a second independent panel does not stop the first panel poller (both are permanent leaves now)', async () => {
+  it('activating a second independent panel does not stop the first panel refresh (both are permanent leaves now)', async () => {
     vi.useFakeTimers();
     const deps = makeDeps();
     const activator = createWorkbenchActivator(deps);
@@ -307,7 +333,7 @@ describe('createWorkbenchActivator', () => {
     vi.useRealTimers();
   });
 
-  it('deactivate stops the files poller (leaf closed)', async () => {
+  it('deactivate stops the files fallback poller (leaf closed)', async () => {
     vi.useFakeTimers();
     const deps = makeDeps();
     const activator = createWorkbenchActivator(deps);
@@ -318,5 +344,137 @@ describe('createWorkbenchActivator', () => {
     await vi.advanceTimersByTimeAsync(6000);
     expect(deps.openFs.mock.calls.length).toBe(callsAfterFirst);
     vi.useRealTimers();
+  });
+});
+
+/**
+ * #2409 — the file tree reacts to VFS change events instead of rebuilding
+ * every 3 s. The poll was both a per-minute cost paid to learn nothing and
+ * the mechanism behind the scroll reset in #2408.
+ */
+describe('createWorkbenchActivator — event-driven file tree (#2409)', () => {
+  function makeWatchDeps(fs: LocalVfsClient) {
+    const fileTree = document.createElement('slicc-file-tree') as SliccFileTree;
+    const deps = {
+      fileTree,
+      termSurface: document.createElement('div'),
+      memoryHost: Object.assign(document.createElement('div'), { setRows: vi.fn() }),
+      monitor: document.createElement('slicc-monitor'),
+      openFs: vi.fn(async () => fs),
+      openWriter: vi.fn(async () => fs),
+      mountTerminal: vi.fn(async () => undefined),
+      onKernelReady: vi.fn((fn: () => void) => fn()),
+      insertReference: vi.fn(),
+      getWorkspace: vi.fn(() => PRIMARY_WORKSPACE),
+      log: { error: vi.fn() },
+    };
+    return deps as unknown as WcWorkbenchDeps & typeof deps;
+  }
+
+  it('rebuilds on a change event and issues no timer traffic while idle', async () => {
+    const { fs, watcher, base } = await watchableFs();
+    const deps = makeWatchDeps(fs);
+    const activator = createWorkbenchActivator(deps);
+
+    activator.activate('files');
+    await vi.waitFor(() => expect(deps.fileTree.items?.length).toBeGreaterThan(0));
+    await vi.waitFor(() => expect(watcher.size).toBe(2)); // workspace + /shared
+    const afterFirstBuild = deps.openFs.mock.calls.length;
+
+    // Idle: nothing wakes the panel. The old 3 s poll would have rebuilt
+    // twenty times over this window.
+    await new Promise((r) => setTimeout(r, 400));
+    expect(deps.openFs.mock.calls.length).toBe(afterFirstBuild);
+
+    await base.writeFile('/workspace/appeared.txt', 'x');
+    await vi.waitFor(() => {
+      const root = deps.fileTree.items?.find((i) => 'id' in i && i.id === '/workspace');
+      expect(
+        root?.kind === 'dir' &&
+          root.children.some((c) => 'id' in c && c.id === '/workspace/appeared.txt')
+      ).toBe(true);
+    });
+  });
+
+  it('coalesces a burst of writes into a small number of rebuilds', async () => {
+    const { fs, watcher } = await watchableFs();
+    const deps = makeWatchDeps(fs);
+    const activator = createWorkbenchActivator(deps);
+    activator.activate('files');
+    await vi.waitFor(() => expect(watcher.size).toBe(2));
+    const afterFirstBuild = deps.openFs.mock.calls.length;
+
+    for (let i = 0; i < 500; i++) {
+      watcher.notify([{ type: 'create', path: `/workspace/f${i}.txt`, entryType: 'file' }]);
+    }
+    await vi.waitFor(() => expect(deps.openFs.mock.calls.length).toBeGreaterThan(afterFirstBuild));
+    await new Promise((r) => setTimeout(r, 300));
+    // 500 events, a handful of rebuilds — not 500.
+    expect(deps.openFs.mock.calls.length - afterFirstBuild).toBeLessThan(5);
+  });
+
+  it('never lets the debounce defer a rebuild indefinitely under a write loop', async () => {
+    const { fs, watcher } = await watchableFs();
+    const deps = makeWatchDeps(fs);
+    const activator = createWorkbenchActivator(deps);
+    activator.activate('files');
+    await vi.waitFor(() => expect(watcher.size).toBe(2));
+    const afterFirstBuild = deps.openFs.mock.calls.length;
+
+    // A write every 50 ms — faster than the 200 ms debounce, so a pure
+    // trailing debounce would never fire while the loop runs.
+    const stopAt = Date.now() + 1400;
+    while (Date.now() < stopAt) {
+      watcher.notify([{ type: 'modify', path: '/workspace/busy.txt', entryType: 'file' }]);
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(deps.openFs.mock.calls.length).toBeGreaterThan(afterFirstBuild);
+  });
+
+  it('unsubscribes on deactivate and leaks nothing across 10 open/close cycles', async () => {
+    const { fs, watcher } = await watchableFs();
+    const deps = makeWatchDeps(fs);
+    const activator = createWorkbenchActivator(deps);
+
+    for (let i = 0; i < 10; i++) {
+      activator.activate('files');
+      await vi.waitFor(() => expect(watcher.size).toBe(2));
+      activator.deactivate('files');
+      expect(watcher.size).toBe(0);
+    }
+
+    // A change after the last close touches nothing.
+    const calls = deps.openFs.mock.calls.length;
+    watcher.notify([{ type: 'create', path: '/workspace/late.txt', entryType: 'file' }]);
+    await new Promise((r) => setTimeout(r, 300));
+    expect(deps.openFs.mock.calls.length).toBe(calls);
+  });
+
+  it('re-points the tree and the subscription when the selection moves (#2271)', async () => {
+    const { fs, watcher } = await watchableFs();
+    const deps = makeWatchDeps(fs);
+    const activator = createWorkbenchActivator(deps);
+    activator.activate('files');
+    await vi.waitFor(() => expect(watcher.size).toBe(2));
+
+    deps.getWorkspace.mockReturnValue(workspaceFor({ parentJid: null, folder: 'cone-beta' }));
+    activator.refreshFiles();
+    await vi.waitFor(() => {
+      expect(deps.fileTree.items?.map((i) => ('id' in i ? i.id : ''))).toEqual([
+        '/cones/cone-beta/workspace',
+        '/shared',
+      ]);
+    });
+    // Re-aimed, not accumulated: the previous cone's roots are gone.
+    await vi.waitFor(() => expect(watcher.size).toBe(2));
+  });
+
+  it('ignores a selection change while the files panel is closed', async () => {
+    const { fs } = await watchableFs();
+    const deps = makeWatchDeps(fs);
+    const activator = createWorkbenchActivator(deps);
+    activator.refreshFiles();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(deps.openFs).not.toHaveBeenCalled();
   });
 });

--- a/packages/webcomponents/src/workbench/slicc-file-tree.ts
+++ b/packages/webcomponents/src/workbench/slicc-file-tree.ts
@@ -260,6 +260,14 @@ export class SliccFileTree extends HTMLElement {
   #selecting = false;
   /** Expanded paths survive a refresh, so a background poll can't re-open dirs. */
   #expanded: string[] | null = null;
+  /**
+   * The container `#wireActivation` last bound to.
+   *
+   * An in-place update keeps the library's container element, so re-wiring it
+   * unconditionally would stack a second dblclick/keydown listener on every
+   * refresh and open the previewer twice per activation.
+   */
+  #wiredContainer: HTMLElement | null = null;
 
   static get observedAttributes(): string[] {
     return ['selected'];
@@ -278,6 +286,7 @@ export class SliccFileTree extends HTMLElement {
   disconnectedCallback(): void {
     this.#tree?.unmount();
     this.#tree = null;
+    this.#wiredContainer = null;
   }
 
   attributeChangedCallback(name: string, _old: string | null, value: string | null): void {
@@ -409,8 +418,29 @@ export class SliccFileTree extends HTMLElement {
     this.#captureExpansion();
     const expanded = this.#expanded ?? initiallyOpen;
 
+    // Update the MOUNTED tree in place when there is one. Tearing it down and
+    // building a new one throws away the scroll offset with the scroller —
+    // which is what made a refresh yank a scrolled-down user back to the top
+    // (#2408). `resetPaths` swaps the path set inside the live instance, so
+    // the scroll container, focus, selection and search session all survive;
+    // expansion is re-seeded from the snapshot above. Now that the workbench
+    // refreshes on VFS change events rather than a 3 s timer (#2409), the
+    // refreshes that remain are exactly the ones a user is watching happen.
+    if (this.#tree && paths.length > 0) {
+      this.#tree.resetPaths({
+        preparedInput: prepareFileTreeInput(paths),
+        initialExpandedPaths: expanded,
+      });
+      // Decorations read `#meta` live, but git lanes are the library's own
+      // state — it no-ops when the list is unchanged.
+      this.#tree.setGitStatus(this.#gitStatus);
+      this.#wireActivation();
+      return;
+    }
+
     this.#tree?.unmount();
     this.#mount.replaceChildren();
+    this.#wiredContainer = null;
 
     if (paths.length === 0) {
       this.#tree = null;
@@ -490,7 +520,8 @@ export class SliccFileTree extends HTMLElement {
    */
   #wireActivation(): void {
     const container = this.#tree?.getFileTreeContainer();
-    if (!container) return;
+    if (!container || container === this.#wiredContainer) return;
+    this.#wiredContainer = container;
 
     const activateFocused = (): void => {
       // Keyboard activation acts on the focused row; a double-click acts on the

--- a/packages/webcomponents/tests/workbench/slicc-file-tree.test.ts
+++ b/packages/webcomponents/tests/workbench/slicc-file-tree.test.ts
@@ -433,6 +433,130 @@ describe('slicc-file-tree', () => {
     });
   });
 
+  /**
+   * #2408: a refresh used to unmount the tree and build a new one, which threw
+   * away the scroll offset along with the scroller. Now that the workbench
+   * refreshes on VFS change events rather than a 3 s timer (#2409), the
+   * refreshes that remain are the ones a user is actively watching — landing
+   * them back at the top of the tree is exactly when it is most disruptive.
+   */
+  describe('refresh preserves the view', () => {
+    /** Enough rows to overflow the fixed-height mount and make scrolling real. */
+    function tallTree(extra = 0): FileTreeItem[] {
+      return [
+        {
+          kind: 'dir',
+          id: '/workspace',
+          label: 'workspace',
+          open: true,
+          children: Array.from({ length: 120 + extra }, (_, i) => ({
+            kind: 'file' as const,
+            id: `/workspace/f${String(i).padStart(3, '0')}.txt`,
+            label: `f${String(i).padStart(3, '0')}.txt`,
+            path: `/workspace/f${String(i).padStart(3, '0')}.txt`,
+          })),
+        },
+      ];
+    }
+
+    /** The library's scrolling element, whatever it decided to call it. */
+    function scroller(tree: SliccFileTree): HTMLElement | null {
+      const root = tree.querySelector('file-tree-container')?.shadowRoot;
+      const candidates = [...(root?.querySelectorAll('*') ?? [])] as HTMLElement[];
+      return candidates.find((el) => el.scrollHeight > el.clientHeight + 1) ?? null;
+    }
+
+    it('keeps the scroll position across a refresh', async () => {
+      const tree = await mount(tallTree());
+      const el = scroller(tree);
+      expect(el).not.toBeNull();
+      if (!el) return;
+
+      el.scrollTop = 600;
+      el.dispatchEvent(new Event('scroll', { bubbles: true }));
+      await settle();
+      const before = el.scrollTop;
+      expect(before).toBeGreaterThan(0);
+
+      // A change lands: one more file, everything else identical.
+      tree.items = tallTree(1);
+      await settle();
+
+      // The SAME scroller is still there — an in-place update, not a rebuild.
+      expect(scroller(tree)).toBe(el);
+      expect(el.scrollTop).toBe(before);
+    });
+
+    it('keeps a user-expanded directory expanded across a refresh', async () => {
+      const items: FileTreeItem[] = [
+        {
+          kind: 'dir',
+          id: '/workspace',
+          label: 'workspace',
+          open: true,
+          children: [
+            {
+              kind: 'dir',
+              id: '/workspace/deep',
+              label: 'deep',
+              children: [
+                {
+                  kind: 'file',
+                  id: '/workspace/deep/a.txt',
+                  label: 'a.txt',
+                  path: '/workspace/deep/a.txt',
+                },
+              ],
+            },
+          ],
+        },
+      ];
+      const tree = await mount(items);
+      tree.toggleDir('/workspace/deep');
+      await settle();
+      expect(tree.isDirOpen('/workspace/deep')).toBe(true);
+
+      tree.items = items;
+      await settle();
+      // The seed says collapsed; the user says otherwise, and the user wins.
+      expect(tree.isDirOpen('/workspace/deep')).toBe(true);
+      expect(renderedText(tree)).toContain('a.txt');
+    });
+
+    it('does not stack row listeners across refreshes', async () => {
+      const tree = await mount(SAMPLE);
+      // The in-place update keeps the library's container, so re-wiring it per
+      // refresh would open the previewer once per refresh that had happened.
+      for (let i = 0; i < 3; i++) {
+        tree.items = SAMPLE;
+        await settle();
+      }
+      const seen: string[] = [];
+      tree.addEventListener('file-preview', (e) => {
+        seen.push((e as CustomEvent<{ path: string }>).detail.path);
+      });
+
+      const root = tree.querySelector('file-tree-container')?.shadowRoot;
+      const target = [...(root?.querySelectorAll('button') ?? [])].find(
+        (b) => b.getAttribute('aria-label') === 'bb.jsh'
+      );
+      target?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+      await settle();
+      target?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, composed: true }));
+      await settle();
+
+      expect(seen).toEqual(['/workspace/bb.jsh']);
+    });
+
+    it('still tears down when a refresh empties the tree', async () => {
+      const tree = await mount(SAMPLE);
+      expect(renderedText(tree)).toContain('bb.jsh');
+      tree.items = [];
+      await settle();
+      expect(renderedText(tree)).not.toContain('bb.jsh');
+    });
+  });
+
   describe('lifecycle', () => {
     it('tears the tree down on disconnect', async () => {
       const tree = await mount(SAMPLE);


### PR DESCRIPTION
## Summary

The workbench file tree rebuilt itself every 3 seconds. It did not need to: SLICC owns the filesystem, and every `VirtualFS` mutation already notifies an `FsWatcher` — the same infrastructure `fswatch`, the sprinkle manager and the scoop orchestrator use. The panel now subscribes to the roots it renders instead of polling them.

That removes ~7,000 VFS ops a minute spent producing a byte-identical tree, and with it the periodic `replaceChildren()` that resets scroll and expansion state (#2408).

## What changed

- **Wire** (`kernel/messages.ts`): `vfs-watch` / `vfs-unwatch` control, plus a `vfs-watch-result` ack and `vfs-watch-event` pushes on the existing VFS RPC channel.
- **Host** (`vfs-rpc-host.ts`): resolves the watcher **per subscription** rather than capturing it at boot (the orchestrator attaches it after the host starts), replaces a re-subscribed id in place so a cone switch cannot leak the previous roots, and answers `ENOSYS` when no watcher is wired.
- **Contract** (`local-vfs-client.ts`): `watch` is **optional** on purpose — a reader with no `FsWatcher` behind it cannot honestly offer one, and its absence is what tells the panel to fall back to the 3 s poll rather than wait on events that will never arrive. `VirtualFS` and `RemoteVfsClient` both implement it.
- **Panel** (`wc-workbench.ts`): the new `createFileTreeController` builds once on open, then rebuilds on a 200 ms-debounced change with a 1 s max-wait ceiling (so a write loop cannot defer the repaint forever), and unsubscribes on close. A cone switch pushes `refreshFiles()` — a selection change is not a filesystem change, so no event announces it.
- `FsChangeEvent` moves to `fs/types.ts` (re-exported from `fs-watcher.ts`): the kernel clients name it, and `fs-watcher.ts`'s logger import drags `__DEV__` into tsconfigs that do not declare it.

The monitor panel's 5 s poll is untouched — it samples "right now" metrics with no event source, as the issue notes.

## Live verification

Tier-1 CDP harness (isolated `:5715` lane), production `:5710`/`:9222` untouched:

| Acceptance criterion | Result |
| --- | --- |
| 1. Idle 60 s → zero `childList` mutations, no timer traffic | **0 mutations over 66.5 s** with the panel open |
| 2. New file appears within ~250 ms, no interaction | **224 ms** for a real write (`CLAUDE_copy.md` via the tree's Duplicate action) |
| 3. 500 writes → a small number of rebuilds | **500 events → 1 rebuild** (2 `childList` records) |
| 4. 10 open/close cycles leave no registrations | watcher count returns to the same baseline (21 open / 19 closed, each cycle) |
| 5. Scroll + expansion untouched by refresh | no refresh happens while idle at all |

Console watcher clean.

<img width="900" alt="Files panel showing the live tree" src="https://slicc--ai-ecoverse.agentbin.net/3ec8704cfba3490992c83bc73f9ae2e8788e3336a40fbae5364d7e860815738b.png" />

## Verification

`lint`, `typecheck` (all 9 projects), `test`, `test:coverage:webapp` (81.9/73.1/82.05/83.94 — all above floors), both builds, and the touched-file debt gate all pass. `kernel-worker.ts` was on the `Record<string, unknown>` debt list; its two occurrences are now a named `KernelWorkerGlobals` and the baseline is ratcheted down.

New tests cover the host (subscribe / unsubscribe / re-point / ENOSYS / dispose), the page client (delivery, no listener leak across 10 cycles, dispose), `VirtualFS.watch`, and the panel (event-driven rebuild, idle silence, burst coalescing, max-wait, unsubscribe, re-point).

Fixes #2409

🤖 Generated with [Claude Code](https://claude.com/claude-code)
