### PR TITLE
fix(bash): tee detached job output so timeout kills keep it

### DIFF
--- a/docs/kernel/process-model.md
+++ b/docs/kernel/process-model.md
@@ -153,6 +153,7 @@ Every `bash` tool call registers a `kind:'shell'` job (`ScoopContext.spawnBashJo
 | `timeout` reached                     | SIGKILL the job pid (fan-out terminates realm descendants) + cooperative abort; record reaped with the derived signal exit code |
 | `background_after` reached            | The agent stops waiting; the job record stays `running`, so `ps` lists it and `kill <pid>` reaches it                           |
 | Detached job finishes                 | Record reaped with the command's exit code; a `bash` lick carries the code, a preview, `resultPath`, and the pid                |
+| Detached job killed by `timeout`      | Same reaping; `resultPath` keeps pre-kill teed output plus a `--- killed after <N>s (exit 124) ---` trailer (#2415)             |
 | Normal turn end (`pm.exit(turnPid)`)  | No cascade — a detached job survives to deliver its lick                                                                        |
 | Turn cancel / `stop()` / `drop_scoop` | Those SIGNAL the turn pid, so the fan-out reaps the job and its realm descendants                                               |
 | `ScoopContext.dispose()`              | SIGKILLs every pid still in `liveBashJobPids` (see below), then tears the context down                                          |

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -146,13 +146,19 @@ default.
   that started it (`targetScoop`; unset for the cone, which is the default lick
   target) carrying the exit code and a 2 KB tail preview. A dropped scoop's job
   lick is logged and discarded.
-- Output is only available at completion — `just-bash` has no incremental stream
-  — so a detach result carries no partial output.
+- Output is teed to that path as each registry-dispatched command settles, so a
+  job killed by `timeout` (or otherwise aborted) still leaves its pre-kill
+  output readable, followed by a trailer like
+  `--- killed after <N>s (exit 124) ---`. The lick preview shows that same tail
+  (not just `bash: execution aborted`). Mid-command output from a single
+  long-running realm command that is SIGKILLed before it returns is still lost —
+  the tee is per command boundary (#2415).
 - A detached job's output is secret-scrubbed by the tool itself (`scrubOutput`,
-  wired from `getToolResultScrubber()`) before the file is written and the preview
-  is cut: it never crosses the `adaptTools` tool-result boundary that scrubs a
-  normal `bash` result. A scrub failure withholds the output rather than passing
-  it through; the lick still reports the exit code.
+  wired from `getToolResultScrubber()`) before every file write (including
+  partial tees) and before the preview is cut: it never crosses the `adaptTools`
+  tool-result boundary that scrubs a normal `bash` result. A scrub failure
+  withholds the output rather than passing it through; the lick still reports
+  the exit code.
 - A still-running job is SIGKILLed when its scoop context is disposed
   (`drop_scoop`, one-shot `agent` teardown, shutdown), since the scoop directory
   its output would land in goes away with it.

--- a/packages/webapp/src/shell/almost-bash-shell-headless.ts
+++ b/packages/webapp/src/shell/almost-bash-shell-headless.ts
@@ -208,12 +208,24 @@ export interface HeadlessShellLike {
     command: string,
     signal?: AbortSignal,
     shellPid?: number,
-    stdin?: ByteString
+    stdin?: ByteString,
+    options?: ExecuteCommandOptions
   ): Promise<{ stdout: string; stderr: string; exitCode: number }>;
   executeScriptFile(
     scriptPath: string,
     args?: string[]
   ): Promise<{ stdout: string; stderr: string; exitCode: number }>;
+}
+
+/** Optional knobs for {@link HeadlessShellLike.executeCommand}. */
+export interface ExecuteCommandOptions {
+  /**
+   * Called with each registry-dispatched command's stdout+stderr as that
+   * command settles — the incremental tee used by the agent `bash` tool so a
+   * detached job killed by `timeout` still has its pre-kill output on disk
+   * (#2415). Concurrent runs on one shell are demuxed via an internal env tag.
+   */
+  onOutput?: (chunk: string) => void;
 }
 
 export type { BashExecResult };
@@ -265,6 +277,14 @@ const log = createLogger('almost-bash-shell');
  */
 const RUN_PID_ENV = '__SLICC_RUN_PID';
 
+/**
+ * Env var demuxing an incremental output tee across concurrent `executeCommand`
+ * runs on one shell (#2415). Same channel as {@link RUN_PID_ENV}: just-bash
+ * still passes `env` through per-exec, and a nested exec inherits it. Stripped
+ * from the env written back onto the shell so it never outlives its run.
+ */
+const OUTPUT_TEE_ENV = '__SLICC_OUTPUT_TEE__';
+
 /** Read the run's parent pid back out of a command's environment. */
 function runPidFromEnv(runEnv?: ReadonlyMap<string, string>): number | undefined {
   const raw = runEnv?.get(RUN_PID_ENV);
@@ -273,10 +293,10 @@ function runPidFromEnv(runEnv?: ReadonlyMap<string, string>): number | undefined
   return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
 }
 
-/** Copy of `env` without the internal per-run tag. */
+/** Copy of `env` without the internal per-run tags. */
 function stripRunPid(env: Record<string, string>): Record<string, string> {
-  if (!(RUN_PID_ENV in env)) return { ...env };
-  const { [RUN_PID_ENV]: _runPid, ...rest } = env;
+  if (!(RUN_PID_ENV in env) && !(OUTPUT_TEE_ENV in env)) return { ...env };
+  const { [RUN_PID_ENV]: _runPid, [OUTPUT_TEE_ENV]: _tee, ...rest } = env;
   return rest;
 }
 
@@ -372,6 +392,13 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
 
   /** Registry command names, for the script planner's "is this a dispatch" test. */
   private registryNames: ReadonlySet<string> = new Set();
+
+  /**
+   * Incremental stdout/stderr tees keyed by {@link OUTPUT_TEE_ENV} (#2415).
+   * Populated for the duration of an `executeCommand` that requested `onOutput`.
+   */
+  private readonly outputTees = new Map<string, (chunk: string) => void>();
+  private nextOutputTeeId = 0;
 
   /**
    * Per-run parent pid, carried to realm-backed commands through the run's
@@ -710,15 +737,18 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
     command: string,
     signal?: AbortSignal,
     shellPid?: number,
-    stdin: ByteString = EMPTY_BYTES
+    stdin: ByteString = EMPTY_BYTES,
+    options?: ExecuteCommandOptions
   ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
     const previousShellPid = this.activeShellPid;
     if (shellPid !== undefined) this.activeShellPid = shellPid;
+    const teeId = options?.onOutput ? `tee-${(this.nextOutputTeeId += 1)}` : undefined;
+    if (teeId && options?.onOutput) this.outputTees.set(teeId, options.onOutput);
     try {
       // `shellPid` also rides this run's env, so a run that outlives the call
       // (the bash tool's detached jobs) still parents its realm children
       // correctly once `activeShellPid` has moved on to a later command.
-      const result = await this.runCommand(command, signal, shellPid, stdin);
+      const result = await this.runCommand(command, signal, shellPid, stdin, teeId);
       return {
         stdout: result.stdout,
         stderr: result.stderr,
@@ -726,6 +756,7 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
       };
     } finally {
       this.activeShellPid = previousShellPid;
+      if (teeId) this.outputTees.delete(teeId);
     }
   }
 
@@ -899,7 +930,8 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
     command: string,
     signal?: AbortSignal,
     runPid?: number,
-    stdin: ByteString = EMPTY_BYTES
+    stdin: ByteString = EMPTY_BYTES,
+    outputTeeId?: string
   ): Promise<BashExecResult> {
     const commandName = command.trim().split(/\s+/)[0] || 'unknown';
     emitShellCommand(commandName);
@@ -929,10 +961,15 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
     // just-bash's published ExecOptions type does not yet expose
     // AbortSignal, but we still forward it so external callers and
     // terminal Ctrl+C keep a consistent cancellation path.
+    const taggedEnv: Record<string, string> = {
+      ...this.lastEnv,
+      ...(runPid === undefined ? {} : { [RUN_PID_ENV]: String(runPid) }),
+      ...(outputTeeId === undefined ? {} : { [OUTPUT_TEE_ENV]: outputTeeId }),
+    };
     const execOptions: BashExecOptionsWithSignal = {
       // Tagged per run so realm-backed commands can recover THIS run's parent
       // pid from their own `ctx.env` under concurrency (see `RUN_PID_ENV`).
-      env: runPid === undefined ? this.lastEnv : { ...this.lastEnv, [RUN_PID_ENV]: String(runPid) },
+      env: taggedEnv,
       cwd: this.cwd,
       signal,
       ...(stdin !== EMPTY_BYTES
@@ -1024,6 +1061,8 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
         ? wrapTimeoutForProgress(inner, this.progress)
         : wrapCommandForProgress(inner, this.progress);
     const onSettled = () => this.scriptRun?.stepDone();
+    const teeOutput = (env: ReadonlyMap<string, string> | undefined, result: ExecResult) =>
+      this.teeCommandOutput(env, result);
     return {
       ...wrapped,
       async execute(args, ctx) {
@@ -1032,12 +1071,33 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
         // the script bar advances when a step finishes, not when it starts.
         // O(1) when no script unit is active.
         try {
-          return await wrapped.execute(args, ctx);
+          const result = await wrapped.execute(args, ctx);
+          // Incremental tee for the agent bash tool (#2415): emit each
+          // command's output as it settles so a later timeout kill still has
+          // the pre-kill payload on disk.
+          teeOutput(ctx.env, result);
+          return result;
         } finally {
           onSettled();
         }
       },
     };
+  }
+
+  /**
+   * Forward a settled command's stdout+stderr to the run's optional output tee.
+   * No-op when the run did not request one (human terminal, most tool calls).
+   */
+  private teeCommandOutput(
+    env: ReadonlyMap<string, string> | undefined,
+    result: { stdout?: string; stderr?: string }
+  ): void {
+    const teeId = env?.get(OUTPUT_TEE_ENV);
+    if (!teeId) return;
+    const tee = this.outputTees.get(teeId);
+    if (!tee) return;
+    const chunk = [result.stdout, result.stderr].filter(Boolean).join('');
+    if (chunk) tee(chunk);
   }
 
   /** Open the script-level progress unit for a script about to run. */

--- a/packages/webapp/src/tools/bash-tool.ts
+++ b/packages/webapp/src/tools/bash-tool.ts
@@ -495,6 +495,9 @@ function startRun(
   let persistJobId: string | undefined;
   let persistChain: Promise<void> = Promise.resolve();
 
+  // Full rewrite (not append): scrubbers may match secrets that span chunk
+  // boundaries, so each persist re-scrubs the whole buffer. Background path
+  // only — chatty jobs pay O(n²) across chunk count × output size.
   const persistTeed = (): void => {
     if (persistPath === undefined || persistJobId === undefined) return;
     const path = persistPath;
@@ -672,14 +675,17 @@ async function scrubJobOutput(ctx: BashRunContext, jobId: string, output: string
  * `{ exitCode: 124, stderr: "bash: execution aborted\n", stdout: "" }` and
  * drops any prior output — the tee is what recovers it.
  *
- * Match the abort *message*, not bare exit 124: a successful `timeout(1)` /
- * other command that exits 124 must keep its real output and must not get a
- * kill trailer. A generic thrown `"aborted"` (external `kill <pid>`) is NOT
- * this path — that is handled below with optional teed prefix.
+ * Require BOTH exit 124 and the abort message on the settled-ok path:
+ * - bare exit 124 (e.g. GNU `timeout`) must keep its real output / no trailer
+ * - a command that merely *prints* "execution aborted" on stderr while exiting
+ *   0 must not be reclassified as a kill
+ *
+ * A generic thrown `"aborted"` (external `kill <pid>`) is NOT this path —
+ * that is handled below with optional teed prefix.
  */
 function isJustBashExecutionAbort(settled: SettledRun): boolean {
   if (!settled.ok) return /execution aborted/i.test(settled.error);
-  return /execution aborted/i.test(settled.result.stderr);
+  return settled.result.exitCode === 124 && /execution aborted/i.test(settled.result.stderr);
 }
 
 /** Trailer appended to a killed detached job's durable output (#2415). */

--- a/packages/webapp/src/tools/bash-tool.ts
+++ b/packages/webapp/src/tools/bash-tool.ts
@@ -376,6 +376,21 @@ interface StartedRun {
   settled: Promise<SettledRun>;
   /** Drops the TURN's abort listener (kept out of `finally` on the detach path). */
   releaseTurnSignal: () => void;
+  /**
+   * Raw stdout/stderr accumulated from each registry-dispatched command as it
+   * settles (#2415). Survives a timeout kill that just-bash reports as an
+   * empty abort result.
+   */
+  getTeedOutput: () => string;
+  /**
+   * Begin rewriting the durable output path with scrubbed teed content on each
+   * new chunk. Called once from {@link detachRun}.
+   */
+  startPersisting: (outputPath: string, jobId: string) => void;
+  /** Wait for any in-flight persist writes before a final settle write. */
+  flushPersist: () => Promise<void>;
+  /** Set when {@link hardKill} fires for a detached job's timeout ceiling. */
+  killedByTimeout: boolean;
 }
 
 /** Read an optional non-negative number argument; invalid values are ignored. */
@@ -471,6 +486,34 @@ function startRun(
     else job.signal.addEventListener('abort', () => controller.abort(), { once: true });
   }
 
+  // Incremental tee (#2415): each registry-dispatched command's stdout/stderr
+  // is appended here as it settles. just-bash's abort settlement discards
+  // accumulated output (exit 124 + "bash: execution aborted"), so this buffer
+  // is what a killed detached job still has to show.
+  const teedChunks: string[] = [];
+  let persistPath: string | undefined;
+  let persistJobId: string | undefined;
+  let persistChain: Promise<void> = Promise.resolve();
+
+  const persistTeed = (): void => {
+    if (persistPath === undefined || persistJobId === undefined) return;
+    const path = persistPath;
+    const jobId = persistJobId;
+    const raw = teedChunks.join('');
+    persistChain = persistChain
+      .then(async () => {
+        const scrubbed = await scrubJobOutput(ctx, jobId, raw);
+        await ctx.fs.writeFile(path, scrubbed);
+      })
+      .catch((err) =>
+        log.warn('Failed to tee background bash output', {
+          jobId,
+          outputPath: path,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      );
+  };
+
   // Never rejects: both branches of the race read this, and an unobserved
   // rejection from a detached run would surface as an unhandled rejection in
   // the kernel worker.
@@ -480,7 +523,12 @@ function startRun(
   // a descendant of THIS job rather than of the whole turn. That is what makes
   // the SIGKILL below reach it.
   const settled: Promise<SettledRun> = ctx.shell
-    .executeCommand(command, controller.signal, job?.pid)
+    .executeCommand(command, controller.signal, job?.pid, undefined, {
+      onOutput: (chunk) => {
+        teedChunks.push(chunk);
+        persistTeed();
+      },
+    })
     .then(
       (result) => ({ ok: true, result }) as SettledRun,
       (err) =>
@@ -492,6 +540,14 @@ function startRun(
     controller,
     settled,
     releaseTurnSignal: () => turnSignal?.removeEventListener('abort', onTurnAbort),
+    getTeedOutput: () => teedChunks.join(''),
+    startPersisting: (outputPath, jobId) => {
+      persistPath = outputPath;
+      persistJobId = jobId;
+      persistTeed();
+    },
+    flushPersist: () => persistChain,
+    killedByTimeout: false,
   };
 }
 
@@ -502,7 +558,8 @@ function startRun(
  * abort is still raised for the in-worker just-bash path, which has no worker to
  * terminate and can only stop at a statement boundary.
  */
-function hardKill(run: StartedRun): void {
+function hardKill(run: StartedRun, reason?: 'timeout'): void {
+  if (reason === 'timeout') run.killedByTimeout = true;
   run.job?.kill();
   run.controller.abort();
   run.job?.exit(null);
@@ -543,8 +600,7 @@ function detachedResult(
       `Still running after ${waitSeconds}s — detached as background job ${jobId}. ` +
       'This turn is NOT blocked on it: continue with other work, and do not re-run the command. ' +
       'A "Background Command" lick will arrive with the exit code and a preview once it finishes, ' +
-      `and its full output will be written to ${outputPath}.${pidNote}${killNote} ` +
-      'No output is available before it completes.',
+      `and its full output is being written to ${outputPath} as it runs.${pidNote}${killNote}`,
   };
 }
 
@@ -610,19 +666,69 @@ async function scrubJobOutput(ctx: BashRunContext, jobId: string, output: string
   }
 }
 
+/**
+ * True when just-bash settled as a cooperatively aborted run (timeout / signal
+ * abort inside the interpreter). just-bash 3.4.x returns
+ * `{ exitCode: 124, stderr: "bash: execution aborted\n", stdout: "" }` and
+ * drops any prior output — the tee is what recovers it.
+ *
+ * Match the abort *message*, not bare exit 124: a successful `timeout(1)` /
+ * other command that exits 124 must keep its real output and must not get a
+ * kill trailer. A generic thrown `"aborted"` (external `kill <pid>`) is NOT
+ * this path — that is handled below with optional teed prefix.
+ */
+function isJustBashExecutionAbort(settled: SettledRun): boolean {
+  if (!settled.ok) return /execution aborted/i.test(settled.error);
+  return /execution aborted/i.test(settled.result.stderr);
+}
+
+/** Trailer appended to a killed detached job's durable output (#2415). */
+function killTrailer(timeoutSeconds: number | undefined, exitCode: number): string {
+  if (timeoutSeconds === undefined) {
+    return `--- killed (exit ${exitCode}) ---\n`;
+  }
+  return `--- killed after ${timeoutSeconds}s (exit ${exitCode}) ---\n`;
+}
+
 async function deliverBackgroundJob(
   ctx: BashRunContext,
   jobId: string,
   pid: number | undefined,
   command: string,
   outputPath: string,
-  settled: SettledRun
+  settled: SettledRun,
+  run: StartedRun,
+  timeoutSeconds: number | undefined
 ): Promise<void> {
-  const raw = settled.ok
-    ? [settled.result.stdout, settled.result.stderr].filter(Boolean).join('') ||
-      `(exit code: ${settled.result.exitCode})`
-    : `Shell error: ${settled.error}`;
-  const exitCode = settled.ok ? settled.result.exitCode : 1;
+  await run.flushPersist();
+
+  const timeoutAbort = run.killedByTimeout || isJustBashExecutionAbort(settled);
+  let raw: string;
+  let exitCode: number;
+  if (timeoutAbort) {
+    // Prefer the incremental tee over just-bash's empty abort settlement —
+    // that is the whole point of #2415.
+    const teed = run.getTeedOutput();
+    exitCode = 124;
+    const body = teed.endsWith('\n') || teed.length === 0 ? teed : `${teed}\n`;
+    raw = `${body}${killTrailer(timeoutSeconds, exitCode)}`;
+  } else if (settled.ok) {
+    raw =
+      [settled.result.stdout, settled.result.stderr].filter(Boolean).join('') ||
+      `(exit code: ${settled.result.exitCode})`;
+    exitCode = settled.result.exitCode;
+  } else {
+    // Thrown error (e.g. external `kill <pid>` → "aborted"): keep any teed
+    // output ahead of the error string so a mid-flight kill is not silent.
+    const teed = run.getTeedOutput();
+    exitCode = 1;
+    if (teed) {
+      const body = teed.endsWith('\n') ? teed : `${teed}\n`;
+      raw = `${body}Shell error: ${settled.error}`;
+    } else {
+      raw = `Shell error: ${settled.error}`;
+    }
+  }
   // Scrub BEFORE the write, so the persisted file the agent is told to `cat` is
   // masked too — a `preview`-only scrub would just move the leak to disk.
   const output = await scrubJobOutput(ctx, jobId, raw);
@@ -682,15 +788,30 @@ function detachRun(
   const jobId = ctx.nextJobId();
   const pid = run.job?.pid;
   const outputPath = `${ctx.tempDir}/bash-${jobId}.txt`;
+  // Start teeing to disk immediately so a kill before the next command settles
+  // still leaves whatever already landed in the buffer.
+  run.startPersisting(outputPath, jobId);
   const killAfter = timeoutSeconds === undefined ? undefined : timeoutSeconds - backgroundAfter;
   const killTimer =
-    killAfter === undefined ? undefined : setTimeout(() => hardKill(run), killAfter * 1000);
+    killAfter === undefined
+      ? undefined
+      : setTimeout(() => hardKill(run, 'timeout'), killAfter * 1000);
 
   void run.settled
     .then((settled) => {
       if (killTimer !== undefined) clearTimeout(killTimer);
-      finishJob(run, settled.ok ? settled.result.exitCode : 1);
-      return deliverBackgroundJob(ctx, jobId, pid, command, outputPath, settled);
+      const exitCode = run.killedByTimeout ? 124 : settled.ok ? settled.result.exitCode : 1;
+      finishJob(run, exitCode);
+      return deliverBackgroundJob(
+        ctx,
+        jobId,
+        pid,
+        command,
+        outputPath,
+        settled,
+        run,
+        timeoutSeconds
+      );
     })
     .catch((err) => log.error('Background bash delivery failed', { jobId, error: err }));
 
@@ -753,7 +874,7 @@ async function runBashCommand(
     const outcome = await Promise.race([run.settled, elapsed]);
 
     if (outcome === 'elapsed' && timeoutFirst) {
-      hardKill(run);
+      hardKill(run, 'timeout');
       log.warn('Bash command timed out', {
         command,
         timeoutSeconds: waitSeconds,

--- a/packages/webapp/tests/tools/bash-tool.test.ts
+++ b/packages/webapp/tests/tools/bash-tool.test.ts
@@ -739,6 +739,29 @@ describe('Bash Tool background_after / timeout', () => {
       'timed out cleanly\n'
     );
   });
+
+  // A command that merely prints "execution aborted" while exiting 0 must keep
+  // its real exit code — require exit 124 + abort message together.
+  it('does not invent a kill trailer when stderr only mentions execution aborted (#2415)', async () => {
+    const { shell, settle } = pendingShell();
+    const fireLick = vi.fn();
+    const bash = createBashTool(shell, fs, '/tmp', { fireLick });
+
+    await bash.execute({ command: 'grep -n "execution aborted" log.txt', background_after: 0 });
+    settle({
+      stdout: 'match\n',
+      stderr: 'note: saw "bash: execution aborted" in a fixture\n',
+      exitCode: 0,
+    });
+    await vi.waitFor(() => expect(fireLick).toHaveBeenCalledTimes(1));
+
+    const event = fireLick.mock.calls[0][0];
+    expect(event.bashExitCode).toBe(0);
+    expect(event.preview).toContain('match');
+    expect(event.preview).toContain('execution aborted');
+    expect(event.preview).not.toMatch(/killed after/);
+    expect(await fs.readFile('/tmp/bash-bg-1.txt', { encoding: 'utf-8' })).toContain('match\n');
+  });
 });
 
 describe('Bash Tool timeout-kill e2e (real shell tee)', () => {

--- a/packages/webapp/tests/tools/bash-tool.test.ts
+++ b/packages/webapp/tests/tools/bash-tool.test.ts
@@ -360,12 +360,20 @@ describe('Bash Tool', () => {
 function pendingShell() {
   const signals: (AbortSignal | undefined)[] = [];
   const shellPids: (number | undefined)[] = [];
+  const outputCallbacks: (((chunk: string) => void) | undefined)[] = [];
   let settle!: (result: { stdout: string; stderr: string; exitCode: number }) => void;
   let fail!: (err: Error) => void;
   const shell = {
-    executeCommand: (_command: string, signal?: AbortSignal, shellPid?: number) => {
+    executeCommand: (
+      _command: string,
+      signal?: AbortSignal,
+      shellPid?: number,
+      _stdin?: unknown,
+      options?: { onOutput?: (chunk: string) => void }
+    ) => {
       signals.push(signal);
       shellPids.push(shellPid);
+      outputCallbacks.push(options?.onOutput);
       return new Promise<{ stdout: string; stderr: string; exitCode: number }>((res, rej) => {
         settle = res;
         fail = rej;
@@ -376,6 +384,11 @@ function pendingShell() {
     shell: shell as unknown as AlmostBashShellHeadless,
     signals,
     shellPids,
+    /** Emit a chunk through the most recent run's `onOutput` tee (if any). */
+    emitOutput: (chunk: string) => {
+      const onOutput = outputCallbacks[outputCallbacks.length - 1];
+      onOutput?.(chunk);
+    },
     settle: (result: { stdout: string; stderr: string; exitCode: number }) => settle(result),
     fail: (err: Error) => fail(err),
   };
@@ -659,6 +672,106 @@ describe('Bash Tool background_after / timeout', () => {
     controller.abort();
 
     expect(signals[0]?.aborted).toBe(false);
+  });
+
+  // #2415: just-bash settles a timeout kill as exit 124 with empty stdout and
+  // "bash: execution aborted". Without an incremental tee the durable file and
+  // lick preview would only carry that error string.
+  it('keeps pre-kill teed output when a detached job is killed by timeout (#2415)', async () => {
+    const { shell, emitOutput, settle } = pendingShell();
+    const fireLick = vi.fn();
+    const bash = createBashTool(shell, fs, '/tmp', { fireLick });
+
+    await bash.execute({ command: 'echo pre-kill; sleep 999', timeout: 0.05, background_after: 0 });
+    emitOutput('pre-kill-line\n');
+    // Simulate just-bash's abort settlement (empty stdout, exit 124).
+    settle({ stdout: '', stderr: 'bash: execution aborted\n', exitCode: 124 });
+    await vi.waitFor(() => expect(fireLick).toHaveBeenCalledTimes(1));
+
+    const event = fireLick.mock.calls[0][0];
+    expect(event.bashExitCode).toBe(124);
+    expect(event.preview).toContain('pre-kill-line');
+    expect(event.preview).toMatch(/killed after 0\.05s \(exit 124\)/);
+    expect(event.preview).not.toMatch(/^Shell error:/);
+    const file = await fs.readFile('/tmp/bash-bg-1.txt', { encoding: 'utf-8' });
+    expect(file).toContain('pre-kill-line');
+    expect(file).toMatch(/killed after 0\.05s \(exit 124\)/);
+  });
+
+  it('scrubs secrets in the partial-output path of a killed job (#2415 / #2210)', async () => {
+    const { shell, emitOutput, settle } = pendingShell();
+    const fireLick = vi.fn();
+    const scrubOutput = vi.fn(async (text: string) => text.replaceAll('sk-live-secret', '***'));
+    const bash = createBashTool(shell, fs, '/tmp', { fireLick, scrubOutput });
+
+    await bash.execute({
+      command: 'printenv TOKEN; sleep 999',
+      timeout: 0.05,
+      background_after: 0,
+    });
+    emitOutput('TOKEN=sk-live-secret\n');
+    settle({ stdout: '', stderr: 'bash: execution aborted\n', exitCode: 124 });
+    await vi.waitFor(() => expect(fireLick).toHaveBeenCalledTimes(1));
+
+    expect(fireLick.mock.calls[0][0].preview).not.toContain('sk-live-secret');
+    expect(fireLick.mock.calls[0][0].preview).toContain('TOKEN=***');
+    expect(await fs.readFile('/tmp/bash-bg-1.txt', { encoding: 'utf-8' })).not.toContain(
+      'sk-live-secret'
+    );
+    expect(await fs.readFile('/tmp/bash-bg-1.txt', { encoding: 'utf-8' })).toContain('TOKEN=***');
+  });
+
+  // Bare exit 124 (e.g. GNU `timeout`) must not be treated as an execution abort.
+  it('does not invent a kill trailer for a clean exit 124 (#2415)', async () => {
+    const { shell, settle } = pendingShell();
+    const fireLick = vi.fn();
+    const bash = createBashTool(shell, fs, '/tmp', { fireLick });
+
+    await bash.execute({ command: 'timeout 1 sleep 10', background_after: 0 });
+    settle({ stdout: 'timed out cleanly\n', stderr: '', exitCode: 124 });
+    await vi.waitFor(() => expect(fireLick).toHaveBeenCalledTimes(1));
+
+    const event = fireLick.mock.calls[0][0];
+    expect(event.bashExitCode).toBe(124);
+    expect(event.preview).toContain('timed out cleanly');
+    expect(event.preview).not.toMatch(/killed after/);
+    expect(await fs.readFile('/tmp/bash-bg-1.txt', { encoding: 'utf-8' })).toBe(
+      'timed out cleanly\n'
+    );
+  });
+});
+
+describe('Bash Tool timeout-kill e2e (real shell tee)', () => {
+  let fs: VirtualFS;
+  let dbCounter = 0;
+
+  beforeEach(async () => {
+    fs = await VirtualFS.create({ dbName: `test-bash-tee-e2e-${dbCounter++}`, wipe: true });
+  });
+
+  it('leaves pre-kill output + trailer at resultPath when timeout kills a detached job', async () => {
+    const fireLick = vi.fn();
+    const bash = createBashTool(new AlmostBashShellHeadless({ fs }), fs, '/tmp', { fireLick });
+
+    // Produce output, then sleep past the ceiling. Detach immediately so the
+    // kill lands on the background path (not the foreground timeoutResult).
+    await bash.execute({
+      command: 'echo pre-kill-line; sleep 30',
+      background_after: 0,
+      timeout: 0.3,
+    });
+
+    await vi.waitFor(() => expect(fireLick).toHaveBeenCalledTimes(1), { timeout: 5000 });
+
+    const event = fireLick.mock.calls[0][0];
+    expect(event.bashExitCode).toBe(124);
+    expect(event.resultPath).toBe('/tmp/bash-bg-1.txt');
+    expect(event.preview).toContain('pre-kill-line');
+    expect(event.preview).toMatch(/killed after 0\.3s \(exit 124\)/);
+
+    const file = await fs.readFile('/tmp/bash-bg-1.txt', { encoding: 'utf-8' });
+    expect(file).toContain('pre-kill-line');
+    expect(file).toMatch(/killed after 0\.3s \(exit 124\)/);
   });
 });
 


### PR DESCRIPTION
Fixes #2415

## Summary

Detached `bash` jobs killed by `timeout` were writing only `bash: execution aborted` to the durable output file and lick preview — any stdout/stderr produced before the kill was discarded. This implements option 1 from the issue: tee registry-command output to the result path as each command settles, then append a clear kill trailer on abort.

## Why

Under bridge contention, killed background jobs looked empty, so agents re-ran them and orchestrators misread scoops as idle. See #2415 (split from the concurrent-scoop incident / #2411).

**Repro (before):**
1. `bash` with `background_after: 0`, `timeout: 0.3`, command `echo pre-kill-line; sleep 30`
2. Wait for the Background Command lick
3. Expected: `resultPath` contains `pre-kill-line` + kill trailer; preview shows that tail + exit 124
4. Actual: file/preview only had the abort error string (or empty payload)

## Approach / Implementation notes

- **Shell**: `executeCommand(..., { onOutput })` demuxes concurrent runs via `__SLICC_OUTPUT_TEE__`; each registry-dispatched command emits stdout+stderr as it settles (`almost-bash-shell-headless.ts`).
- **Tool**: detached jobs start persisting scrubbed teed content immediately; on timeout/abort settle, prefer the tee over just-bash’s empty abort result and append `--- killed after <N>s (exit 124) ---`.
- **Secrets**: `scrubJobOutput` still runs before every write (partial tees included) and before the lick preview (#2210 contract).
- **Not option 2**: no just-bash change; mid-command output from a single SIGKILLed realm command before it returns is still lost (tee is per command boundary).
- Bare exit 124 without `execution aborted` (e.g. GNU `timeout`) is not treated as a kill.

## Cross-cutting impact

- **Floats**: agent `bash` tool path (cone + scoops). Human terminal `executeCommand` unchanged (no `onOutput`).
- **Other callers**: existing `executeCommand` arity is backward-compatible (new optional 5th arg).
- **Security**: scrub before partial writes and final persist/preview.

## Test plan

- [x] `npx vitest run --project webapp packages/webapp/tests/tools/bash-tool.test.ts` — 58 passing (includes unit + real-shell e2e tee/kill cases)
- [x] Pre-push hooks: biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode
- [ ] `npm run typecheck` / full `npm run test` / build — not run in this turn (targeted coverage above)
- [x] Docs: `docs/tools-reference.md`, `docs/kernel/process-model.md`

## Documentation

- [x] `docs/` (tools-reference + process-model)

## Risk & rollback

- Blast radius: detached bash job delivery only. Revert this PR to restore prior settle-once write behavior.
- No persisted schema / migration changes.

## Checklist

- [x] Commits are focused
- [x] No hand-edited `dist/`
- [x] No secrets in the diff
- [x] Public tool behavior change reflected in docs

Made with [Cursor](https://cursor.com)