### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/imgcat-command.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -8,7 +8,6 @@
   "packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/hid-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/host-command.ts": 7,
-  "packages/webapp/src/shell/supplemental-commands/imgcat-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/local-llm-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/models-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/oauth-domain-command.ts": 1,

--- a/packages/webapp/src/shell/supplemental-commands/imgcat-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/imgcat-command.ts
@@ -1,6 +1,6 @@
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
-import { getMimeType, isTerminalPreviewableMimeType } from '../../core/mime-types.js';
+import { getMimeType, isTerminalPreviewableMimeType } from '../../base/mime-types.js';
 
 export interface MediaPreviewItem {
   path: string;

--- a/packages/webapp/tests/shell/supplemental-commands/imgcat-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/imgcat-command.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createImgcatCommand,
+  type MediaPreviewItem,
+} from '../../../src/shell/supplemental-commands/imgcat-command.js';
+import { mockCommandContext } from '../helpers/mock-command-context.js';
+
+const fsStat = (isFile: boolean) => ({
+  isFile,
+  isDirectory: !isFile,
+  isSymbolicLink: false,
+  mode: 0o644,
+  size: 3,
+  mtime: new Date(0),
+});
+
+const createMockCtx = (
+  overrides: { isFile?: boolean; readFileBuffer?: (path: string) => Promise<Uint8Array> } = {}
+) =>
+  mockCommandContext({
+    fs: {
+      stat: () => Promise.resolve(fsStat(overrides.isFile ?? true)),
+      readFileBuffer:
+        overrides.readFileBuffer ?? (() => Promise.resolve(new Uint8Array([1, 2, 3]))),
+    },
+  });
+
+describe('imgcat command', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('has correct name', () => {
+    const cmd = createImgcatCommand();
+    expect(cmd.name).toBe('imgcat');
+  });
+
+  it('shows help with --help', async () => {
+    const cmd = createImgcatCommand();
+    const result = await cmd.execute(['--help'], createMockCtx());
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('imgcat - preview image and video files');
+    expect(result.stderr).toBe('');
+  });
+
+  it('shows help with -h and when no args provided', async () => {
+    const cmd = createImgcatCommand();
+    for (const args of [['-h'], [] as string[]]) {
+      const result = await cmd.execute(args, createMockCtx());
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Usage: imgcat');
+    }
+  });
+
+  it('errors when browser APIs are unavailable', async () => {
+    vi.stubGlobal('window', undefined);
+    vi.stubGlobal('document', undefined);
+
+    const cmd = createImgcatCommand({ onMediaPreview: vi.fn() });
+    const result = await cmd.execute(['/img.png'], createMockCtx());
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('browser APIs are unavailable');
+  });
+
+  it('errors when no preview handler is wired', async () => {
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('document', {});
+
+    const cmd = createImgcatCommand();
+    const result = await cmd.execute(['/img.png'], createMockCtx());
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('terminal preview is unavailable');
+  });
+
+  it('errors when target is not a file', async () => {
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('document', {});
+
+    const cmd = createImgcatCommand({ onMediaPreview: vi.fn() });
+    const result = await cmd.execute(['/dir'], createMockCtx({ isFile: false }));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('imgcat: not a file: /dir\n');
+  });
+
+  it('rejects non-previewable media types (via base mime-type helpers)', async () => {
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('document', {});
+
+    const cmd = createImgcatCommand({ onMediaPreview: vi.fn() });
+    const result = await cmd.execute(['/notes.txt'], createMockCtx());
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('imgcat: unsupported media type: /notes.txt\n');
+  });
+
+  it('forwards previewable image and video items to the handler', async () => {
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('document', {});
+
+    const captured: MediaPreviewItem[] = [];
+    const onMediaPreview = vi.fn(async (items: MediaPreviewItem[]) => {
+      captured.push(...items);
+    });
+
+    const cmd = createImgcatCommand({ onMediaPreview });
+    const result = await cmd.execute(['/pic.png', '/clip.mp4'], createMockCtx());
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(onMediaPreview).toHaveBeenCalledTimes(1);
+    expect(captured.map((i) => i.mimeType)).toEqual(['image/png', 'video/mp4']);
+    expect(captured.map((i) => i.path)).toEqual(['/pic.png', '/clip.mp4']);
+    expect(captured[0].bytes).toBeInstanceOf(Uint8Array);
+  });
+
+  it('surfaces a handler failure as a non-zero exit', async () => {
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('document', {});
+
+    const cmd = createImgcatCommand({
+      onMediaPreview: () => Promise.reject(new Error('preview tab closed')),
+    });
+    const result = await cmd.execute(['/pic.png'], createMockCtx());
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('imgcat: preview tab closed\n');
+  });
+});


### PR DESCRIPTION
## Boy-scout debt cleanup: `packages/webapp/src/shell/supplemental-commands/imgcat-command.ts`

Pays down all boy-scout debt on this one file so it is clean from every debt rule it was on.

### Debt list cleared

**1. layer-stack back-edges (`layer-back-edge`)**

- **What was wrong:** `imgcat-command.ts` (layer `shell/`, rank 1) imported `getMimeType` and `isTerminalPreviewableMimeType` from `../../core/mime-types.js` (layer `core/`, rank 4) — an up-the-stack back-edge (`shell → core`).
- **Fix:** Those two helpers are actually *defined* in `base/mime-types.ts` (rank 0, the bottom rung); `core/mime-types.ts` is merely `export * from '../base/mime-types.js'`. Switched the import to `../../base/mime-types.js`, so the dependency now points down the stack. Pure import-source change — same symbols, same runtime behaviour.
- **Entry removed:** `"packages/webapp/src/shell/supplemental-commands/imgcat-command.ts": 1` deleted from `packages/dev-tools/tools/layer-back-edge-baseline.json` via the supported command `node packages/dev-tools/tools/check-layer-back-edges.mjs --update` (not hand-edited). The baseline diff is exactly that one line removed (62 back-edges in 33 files remain).

### Tests

Added `packages/webapp/tests/shell/supplemental-commands/imgcat-command.test.ts` (previously untested). It pins the behaviour the refactor preserves — help output, browser-API / missing-handler / not-a-file / unsupported-media-type error paths, forwarding of previewable image+video items to the preview handler (exercising the `base/` mime-type helpers), and handler-failure surfacing. 9 tests pass.

### Behaviour

No observable behaviour change. The moved import resolves to the identical implementation.

### Verification

- `npx biome check --write` on all touched files — clean
- `npm run verify` — all 7 lint-gate checks pass (incl. `boy-scout-debt`)
- `npm run typecheck` — passes
- `npx vitest run` on the new test file — 9/9 pass
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — **OK (3 changed files, 0 still on any debt list)**
- `node packages/dev-tools/tools/check-layer-back-edges.mjs` — ok, no new back-edges

### Prohibitions confirmed

No exemption, `biome-ignore` / `eslint-disable` suppression, baseline entry, or `overrides` entry was added. No threshold or coverage floor was relaxed. No unsafe cast (`as any`, `as unknown as`, `@ts-expect-error`, non-null `!`) was introduced. The baseline was ratcheted only with the supported `--update` command, removing a single stale entry. No unrelated cleanup was bundled.
