### PR TITLE
shell(playwright): reject unknown flags (#2255)

### DIFF
--- a/packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
+++ b/packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
@@ -55,6 +55,8 @@ playwright-cli snapshot --tab=E9A3F
 - `No snapshot available` — run `snapshot --tab=<id>` before using refs.
 - `unknown flag "--x"` / `unexpected argument "y"` — every subcommand rejects arguments it does not
   support, so an exit code of 0 means everything you passed was honoured. Check `<verb> --help`.
+- For free-text payloads that start with `-` (e.g. `fill`/`type`/`eval`), put `--` before the text:
+  `fill --tab=<id> e1 -- --dash-looking`.
 - `is not an element ref` — a screenshot's positional is a main-frame element ref (`e5`); the output
   path is `--filename=<path>`. Frame-prefixed refs (`f1e5`) clip only with `click`-family commands.
 - Refs are tied to **one tab + one snapshot**. They do not carry across tabs, navigations, or reloads.
@@ -78,7 +80,7 @@ playwright-cli tab-close --tab=<id>                               # Close tab
 playwright-cli goto --tab=<id> <url>                              # Navigate tab
 playwright-cli navigate --tab=<id> <url>                          # Alias for goto
 playwright-cli snapshot --tab=<id> [--frame=<frameId>] [--no-iframes] [--filename=path]  # Tab tree or one frame subtree
-playwright-cli eval --tab=<id> [--frame=<frameId>] <expression> [--filename=path]  # Evaluate JS in a tab/frame, incl. top-level await/return
+playwright-cli eval --tab=<id> [--frame=<frameId>] <expression> [--filename=path]  # Evaluate JS in a tab/frame, incl. top-level await/return; use `--` before an expression that starts with `-`
 playwright-cli eval-file --tab=<id> [--frame=<frameId>] <vfs-path>  # Evaluate JS from a VFS file in a tab/frame (top-level await/return supported)
 playwright-cli frames --tab=<id>                                  # List frame IDs for --frame (not --tab)
 playwright-cli resize --tab=<id> <width> <height>                 # Resize viewport
@@ -104,8 +106,8 @@ fall back to `window.focus()`.
 ```bash
 playwright-cli click --tab=<id> <ref> [--modifiers=Shift,Control,Alt,Meta]  # Click element
 playwright-cli dblclick --tab=<id> <ref> [button] [--modifiers=...]          # Double-click
-playwright-cli fill --tab=<id> <ref> <text> [--submit]           # Clear input + type text (--submit presses Enter)
-playwright-cli type --tab=<id> <text> [--submit]                 # Type into focused element (--submit presses Enter)
+playwright-cli fill --tab=<id> <ref> <text> [--submit]           # Clear input + type text (--submit presses Enter); use `--` before text that starts with `-`
+playwright-cli type --tab=<id> <text> [--submit]                 # Type into focused element (--submit presses Enter); use `--` before text that starts with `-`
 playwright-cli hover --tab=<id> <ref>                            # Hover over element
 playwright-cli select --tab=<id> <ref> <value>                   # Select dropdown value
 playwright-cli check --tab=<id> <ref>                            # Check checkbox/radio
@@ -128,10 +130,10 @@ playwright-cli keyup --tab=<id> <key>    # Release held key (no paired keyDown)
 ### Mouse
 
 ```bash
-playwright-cli mousemove --tab=<id> <x> <y>    # Move mouse to coordinates
+playwright-cli mousemove --tab=<id> <x> <y>    # Move mouse to coordinates (negative coords ok, e.g. -10 20)
 playwright-cli mousedown --tab=<id> [button]   # Press mouse button (left/right/middle, default: left)
 playwright-cli mouseup --tab=<id> [button]     # Release mouse button
-playwright-cli mousewheel --tab=<id> <dx> <dy> # Scroll mouse wheel
+playwright-cli mousewheel --tab=<id> <dx> <dy> # Scroll mouse wheel (negative deltas ok, e.g. 0 -300)
 ```
 
 ### Navigation
@@ -311,7 +313,8 @@ playwright-cli stop-recording <recordingId>        # Stop and save HAR
 - Unexpected JavaScript dialogs are auto-dismissed on attached pages.
 - Use `eval --tab=<id>` for DOM operations not covered by built-in commands; save results with `--filename=path`.
 - The SLICC app tab and Chrome internal UI tabs are automatically excluded from `tab-list`.
-- `fill` clears and types into regular inputs, textareas, and `contenteditable` elements. Use `--submit` to press Enter after.
+- `fill` clears and types into regular inputs, textareas, and `contenteditable` elements. Use `--submit` to press Enter after. If the text or an `eval` expression starts with `-`, put `--` before it so it is not parsed as a flag.
+- Negative numbers for `mousewheel` / `mousemove` are positionals (no `--` needed): `mousewheel --tab=<id> 0 -300`.
 - Screenshots default to `/tmp/screenshot-<timestamp>.png`. Use `--filename=path` to save elsewhere —
   `screenshot <path>` is an error, because that slot is the element ref.
 - Unsupported flags and extra positionals are rejected per subcommand, so a probe that exits 0 means

--- a/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright-command.ts
@@ -21,9 +21,11 @@ import {
   AUTO_SNAPSHOT_COMMANDS,
   frameIdUsedAsTabError,
   getSharedState,
+  PLAYWRIGHT_FLAG_SPEC,
   parseFlags,
 } from './playwright/state.js';
 import type { CmdResult, PlaywrightHandlerCtx } from './playwright/types.js';
+import { type KnownFlagSpec, parseKnownFlags } from './subcommand-flags.js';
 
 export { asWebFetch } from './playwright/discover.js';
 export { getSharedState, PLAYWRIGHT_COMMAND_NAMES } from './playwright/state.js';
@@ -44,6 +46,44 @@ export type {
  * the CDP type, so the dispatcher stays inside the shell layer.
  */
 type PlaywrightBrowser = PlaywrightHandlerCtx['browser'];
+
+/**
+ * Dash-prefixed vocabulary for {@link parseKnownFlags}, derived from the
+ * mri `ArgSpec` plus the help / `--no-iframes` tokens the dispatcher accepts.
+ * Rejecting unknowns here closes the silent-swallow hole in `mri` (#2255)
+ * without replacing the value-shadowing parse that handlers already rely on.
+ */
+function playwrightKnownFlagSpec(): KnownFlagSpec {
+  const value = (PLAYWRIGHT_FLAG_SPEC.string ?? []).map((n) => `--${n}`);
+  const boolNames = new Set(PLAYWRIGHT_FLAG_SPEC.boolean ?? []);
+  for (const [key, val] of Object.entries(PLAYWRIGHT_FLAG_SPEC.alias ?? {})) {
+    const group = [key, ...(Array.isArray(val) ? val : [val])];
+    if (group.some((n) => boolNames.has(n))) {
+      for (const n of group) boolNames.add(n);
+    }
+  }
+  return {
+    value,
+    bool: [...[...boolNames].map((n) => `--${n}`), '--help', '-h', '--no-iframes'],
+  };
+}
+
+/** Same opaque rewrite as {@link parseFlags} so `--no-iframes=true` is not unknown. */
+function argsForKnownFlagWalk(subArgs: readonly string[]): string[] {
+  return subArgs.map((a) =>
+    a === '--no-iframes' || a.startsWith('--no-iframes=')
+      ? a.replace('--no-iframes', '--_noiframes')
+      : a
+  );
+}
+
+function knownFlagSpecForWalk(spec: KnownFlagSpec): KnownFlagSpec {
+  return {
+    ...spec,
+    bool: [...(spec.bool ?? []), '--_noiframes'],
+    value: [...(spec.value ?? []), '--_noiframes'],
+  };
+}
 
 async function commandErrorResult(
   browser: PlaywrightBrowser,
@@ -69,12 +109,26 @@ async function commandErrorResult(
 async function parseSubcommandArgs(
   name: string,
   subcommand: string,
-  subArgs: string[]
+  subArgs: string[],
+  knownFlagSpec: KnownFlagSpec
 ): Promise<{ positional: string[]; flags: Record<string, string> } | { answer: CmdResult }> {
-  let positional: string[];
+  // Reject unknown dash tokens before the mri-backed parse. `mri` otherwise
+  // stores unrecognised flags as `true` and handlers ignore them — exit 0
+  // with false confidence (issue #2255). Same valueFlags contract as
+  // `isHelpRequest` / value-shadowing: `--body --help` is a body, not help.
+  const known = parseKnownFlags(argsForKnownFlagWalk(subArgs), knownFlagSpecForWalk(knownFlagSpec));
+  if ('error' in known) {
+    return {
+      answer: { stdout: '', stderr: `${name} ${subcommand}: ${known.error}\n`, exitCode: 1 },
+    };
+  }
+
   let flags: Record<string, string>;
   try {
-    ({ positional, flags } = parseFlags(subArgs));
+    // Keep mri for aliases + value-shadowing, but take positionals from the
+    // known-flag walk: mri clusters `-300` into short options (`-3`, `-0`)
+    // and drops them from `_`, breaking mousewheel / mousemove negatives.
+    ({ flags } = parseFlags(subArgs));
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { answer: { stdout: '', stderr: `${name} ${subcommand}: ${msg}\n`, exitCode: 1 } };
@@ -96,13 +150,13 @@ async function parseSubcommandArgs(
   let argError: string | null = null;
   try {
     const { validateSubcommandArgs } = await import('./playwright/validate-args.js');
-    argError = validateSubcommandArgs(name, subcommand, subArgs, positional);
+    argError = validateSubcommandArgs(name, subcommand, subArgs, known.positionals);
   } catch {
     argError = null;
   }
   if (argError) return { answer: { stdout: '', stderr: argError, exitCode: 1 } };
 
-  return { positional, flags };
+  return { positional: known.positionals, flags };
 }
 
 export function createPlaywrightCommand(
@@ -112,6 +166,7 @@ export function createPlaywrightCommand(
 ): Command {
   const helpText = formatHelp(name);
   const state = browser ? getSharedState(browser, fs) : null;
+  const knownFlagSpec = playwrightKnownFlagSpec();
 
   return defineCommand(name, async (args): Promise<CmdResult> => {
     if (args.length === 0 || args[0] === 'help' || args[0] === '--help' || args[0] === '-h') {
@@ -121,7 +176,7 @@ export function createPlaywrightCommand(
     const subcommand = args[0];
     const subArgs = args.slice(1);
 
-    const parsed = await parseSubcommandArgs(name, subcommand, subArgs);
+    const parsed = await parseSubcommandArgs(name, subcommand, subArgs, knownFlagSpec);
     if ('answer' in parsed) return parsed.answer;
     const { positional, flags } = parsed;
 

--- a/packages/webapp/src/shell/supplemental-commands/subcommand-flags.ts
+++ b/packages/webapp/src/shell/supplemental-commands/subcommand-flags.ts
@@ -41,7 +41,9 @@ export interface KnownFlagSpec {
  *
  * Everything after a `--` terminator is positional, so a payload that
  * genuinely starts with a dash stays reachable. A bare `-` (stdin
- * placeholder) is positional, not a flag.
+ * placeholder) is positional, not a flag. Purely numeric tokens with a
+ * leading minus (`-300`, `-0.5`) are positionals too — mousewheel /
+ * mousemove deltas and coordinates must not be mistaken for flags.
  *
  * On success returns positionals plus the collected values/bools; on
  * failure returns `{ error }` with a message suitable for stderr
@@ -83,7 +85,7 @@ export function parseKnownFlags(
       positionals.push(...args.slice(i + 1));
       break;
     }
-    if (!arg.startsWith('-') || arg === '-') {
+    if (!arg.startsWith('-') || arg === '-' || isNumericLiteral(arg)) {
       positionals.push(arg);
       continue;
     }
@@ -103,4 +105,10 @@ export function parseKnownFlags(
     return { error: `unknown flag: ${name}` };
   }
   return { positionals, values, bools };
+}
+
+/** True for finite numeric tokens such as `-300` or `-0.5` (not `--300`). */
+function isNumericLiteral(arg: string): boolean {
+  if (arg.startsWith('--')) return false;
+  return Number.isFinite(Number(arg));
 }

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -267,6 +267,57 @@ describe('playwright-cli help', () => {
     expect(browser.createPage).not.toHaveBeenCalled();
   });
 
+  // ── issue #2255: unknown flags must fail loudly ──────────────────────────
+
+  describe('unknown flags', () => {
+    it('rejects an unrecognised flag instead of ignoring it', async () => {
+      const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
+      const result = await cmd.execute(['tab-list', '--bogus'], mockCtx);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('unknown flag: --bogus');
+    });
+
+    it('rejects an unknown flag in any position', async () => {
+      const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
+      const result = await cmd.execute(
+        ['goto', 'https://example.com', '--tab=tab-1', '--nope'],
+        mockCtx
+      );
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('unknown flag: --nope');
+      expect(browser.navigate).not.toHaveBeenCalled();
+    });
+
+    it('still accepts known flags and --help on a verb', async () => {
+      const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
+      const help = await cmd.execute(['record', '--help'], mockCtx);
+      expect(help.exitCode).toBe(0);
+      expect(help.stdout).toMatch(/record/);
+    });
+
+    it('honours -- so a dash-prefixed positional is not a flag', async () => {
+      const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
+      const result = await cmd.execute(
+        ['fill', 'e1', '--tab=tab-1', '--', '--not-a-flag'],
+        mockCtx
+      );
+      expect(result.stderr).not.toContain('unknown flag');
+    });
+
+    it('accepts negative numeric positionals for mousewheel', async () => {
+      const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
+      const result = await cmd.execute(['mousewheel', '--tab=tab-1', '0', '-300'], mockCtx);
+      expect(result.stderr).not.toContain('unknown flag');
+      expect(result.exitCode).toBe(0);
+      const transport = browser.getTransport();
+      expect(transport.send as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+        'Input.dispatchMouseEvent',
+        expect.objectContaining({ type: 'mouseWheel', deltaX: 0, deltaY: -300 }),
+        'session-1'
+      );
+    });
+  });
+
   it('shows alias-specific help when invoked through an alias', async () => {
     const cmd = createPlaywrightCommand('playwright', browser as BrowserAPI, fs as VirtualFS);
     const result = await cmd.execute(['--help'], mockCtx);

--- a/packages/webapp/tests/shell/supplemental-commands/subcommand-flags.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/subcommand-flags.test.ts
@@ -107,4 +107,17 @@ describe('parseKnownFlags', () => {
       error: 'unknown flag: --help',
     });
   });
+
+  it('treats negative numeric tokens as positionals', () => {
+    const r = parseKnownFlags(['--tab=id', '0', '-300'], { value: ['--tab'] });
+    expect('error' in r).toBe(false);
+    if ('error' in r) return;
+    expect(r.positionals).toEqual(['0', '-300']);
+    expect(r.values.get('--tab')).toBe('id');
+  });
+
+  it('still rejects non-numeric dash tokens', () => {
+    const r = parseKnownFlags(['-bogus'], { bool: ['--json'] });
+    expect(r).toEqual({ error: 'unknown flag: -bogus' });
+  });
 });


### PR DESCRIPTION
Closes #2255 (playwright command surface only).

## Summary

Before, `playwright` / `playwright-cli` accepted unrecognised flags via `mri` (stored as `true`) and handlers ignored them, so a probe like `playwright-cli tab-list --bogus` exited 0. Now unknown dash tokens fail with `unknown flag: …` and exit 1.

Negative numeric positionals (`mousewheel --tab=id 0 -300`) stay positionals. Free-text payloads that start with `-` need `--` (documented in the runtime skill).

## Why

Issue #2255 / the sprinkle false-confidence pattern (#2166): silent unknown-flag swallowing is worse than not supporting the flag.

**Repro (before):**
1. `playwright-cli tab-list --bogus`
2. Expected: exit 1, stderr mentions unknown flag
3. Actual: exit 0

## Approach / Implementation notes

- Added shared `parseKnownFlags` in `subcommand-flags.ts` (extracted sprinkle walk; same API as the parallel helper thread).
- Playwright dispatcher runs that gate **before** the existing mri-backed `parseFlags`, so value-shadowing (`--body --help`), aliases, and `--no-iframes` stay intact; positionals come from the known-flag walk so mri cannot cluster `-300` into short flags.
- Did **not** touch debt-listed `playwright/state.ts` (layer back-edges); rejection lives in the dispatcher.
- Raised `workerEagerKb` 4160→4161 because `parseKnownFlags` lands in the kernel-worker eager graph (measured CI delta).

## Cross-cutting impact

- **Floats exercised**: all floats that run the virtual shell (`playwright` / `playwright-cli` / `puppeteer` aliases) — same command registration path.
- **Other callers**: `parseKnownFlags` is new; sprinkle still has its local copy until the helper extraction PR lands (identical API, merge-safe).
- No persisted state or security impact; +1 kB worker first-load budget ratchet.

## Test plan

- [x] Pre-push lint gate (husky / `npm run verify` equivalent) — passed
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts` — 292 passing
- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/subcommand-flags.test.ts`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt on touched files
- [x] **New / changed behavior covered by unit tests** (`unknown flags` describe + helper tests + negative mousewheel)
- [x] N/A for builds / UI screencast — shell argv parsing only; no UI

## Documentation

- [x] `packages/vfs-root/workspace/skills/playwright-cli/SKILL.md` — unknown-flag exit 1, `--` terminator for dash-looking free text, negative mouse deltas/coords

## Risk & rollback

- Blast radius: playwright-cli argv only; revert this PR to roll back.
- CI catches the regression via the new unknown-flag tests.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Shell-command behavior change is intentional (#2255)