### PR TITLE
shell(cherry-emit): reject unknown flags (#2255) + pay boy-scout debt

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -4,7 +4,6 @@
   "packages/webapp/src/fs/mount/backend-local.ts": 2,
   "packages/webapp/src/fs/mount/profile.ts": 1,
   "packages/webapp/src/shell/bsh-watchdog.ts": 3,
-  "packages/webapp/src/shell/supplemental-commands/cherry-emit-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/hid-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/host-command.ts": 7,

--- a/packages/vfs-root/workspace/skills/cherry/SKILL.md
+++ b/packages/vfs-root/workspace/skills/cherry/SKILL.md
@@ -90,6 +90,9 @@ Notes:
 
 - The event `name` is required. `--detail` must be valid JSON or the command
   errors.
+- Known flags (`--detail`, `--runtime`) are accepted in any position. Unknown
+  dash-prefixed flags exit non-zero (`cherry-emit: unknown flag: --x`). Use
+  `--` before a name that itself starts with `-`.
 - If no cherry follower runtime is connected, the command exits non-zero with
   `cherry-emit: no cherry follower runtime is connected`.
 - When more than one runtime is connected you MUST pass `--runtime <id>`; the

--- a/packages/webapp/src/shell/supplemental-commands/cherry-emit-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/cherry-emit-command.ts
@@ -1,8 +1,10 @@
+import { CHERRY_RUNTIME_TAG } from '@slicc/shared-ts';
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import { getPanelRpcClient, type PanelRpcClient } from '../../kernel/panel-rpc.js';
-import { CHERRY_RUNTIME_TAG } from '../../scoops/tray-sync-protocol.js';
 import { type ConnectedFollowerInfo, getConnectedFollowersWithFallback } from './host-command.js';
+import { parseKnownFlags } from './subcommand-flags.js';
+import { isHelpRequest } from './subcommand-help.js';
 
 /**
  * Outcome of an `emitSliccEvent` attempt. `delivered` is true once the event
@@ -144,6 +146,9 @@ Usage: cherry-emit <name> [--detail <json>] [--runtime <id>]
 
 type CommandResult = { stdout: string; stderr: string; exitCode: number };
 
+/** Value-taking flags — shared with `isHelpRequest` so a flag VALUE of `--help` is not help. */
+const CHERRY_EMIT_VALUE_FLAGS = ['--detail', '--runtime'] as const;
+
 function errResult(message: string): CommandResult {
   return { stdout: '', stderr: `cherry-emit: ${message}\n`, exitCode: 1 };
 }
@@ -156,26 +161,19 @@ interface ParsedArgs {
 
 /**
  * Parse `cherry-emit` argv into positionals plus the two flag values.
+ * Rejects unknown dash-prefixed flags (issue #2255); accepts known flags in
+ * any position and honours a `--` terminator for names that start with `-`.
  * Returns a `CommandResult` instead of `ParsedArgs` on a flag-arg error so
  * the caller can surface it without branching on multiple shapes here.
  */
 function parseArgs(args: string[]): ParsedArgs | CommandResult {
-  const parsed: ParsedArgs = { positionals: [] };
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (arg !== '--detail' && arg !== '--runtime') {
-      parsed.positionals.push(arg!);
-      continue;
-    }
-    const next = args[i + 1];
-    if (next === undefined || next.startsWith('--')) {
-      return errResult(`${arg} requires a value`);
-    }
-    if (arg === '--detail') parsed.detailJson = next;
-    else parsed.runtime = next;
-    i++;
-  }
-  return parsed;
+  const parsed = parseKnownFlags(args, { value: CHERRY_EMIT_VALUE_FLAGS });
+  if ('error' in parsed) return errResult(parsed.error);
+  return {
+    positionals: parsed.positionals,
+    detailJson: parsed.values.get('--detail'),
+    runtime: parsed.values.get('--runtime'),
+  };
 }
 
 /**
@@ -212,7 +210,7 @@ function parseDetail(detailJson: string | undefined): { detail: unknown } | Comm
 export function createCherryEmitCommand(options: CherryEmitCommandOptions = {}): Command {
   const registry = options.registry ?? buildDefaultCherryRegistry();
   return defineCommand('cherry-emit', async (args) => {
-    if (args.includes('--help') || args.includes('-h')) {
+    if (isHelpRequest(args, { valueFlags: CHERRY_EMIT_VALUE_FLAGS })) {
       return { stdout: HELP_TEXT, stderr: '', exitCode: 0 };
     }
 

--- a/packages/webapp/tests/shell/supplemental-commands/cherry-emit-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/cherry-emit-command.test.ts
@@ -1,6 +1,6 @@
+import { CHERRY_RUNTIME_TAG } from '@slicc/shared-ts';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 import type { PanelRpcClient } from '../../../src/kernel/panel-rpc.js';
-import { CHERRY_RUNTIME_TAG } from '../../../src/scoops/tray-sync-protocol.js';
 import {
   buildDefaultCherryRegistry,
   type CherryEmitResult,
@@ -122,6 +122,27 @@ describe('cherry-emit command', () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toMatch(/follower-a, follower-b/);
     expect(reg.emitSliccEvent).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown flag instead of silently ignoring it', async () => {
+    const reg = runtimeRegistry(['follower-a']);
+    const result = await createCherryEmitCommand({ registry: reg }).execute(
+      ['ping', '--bogus'],
+      createMockCtx()
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('unknown flag: --bogus');
+    expect(reg.emitSliccEvent).not.toHaveBeenCalled();
+  });
+
+  it('accepts known flags in any position and honours -- for dash-prefixed names', async () => {
+    const reg = runtimeRegistry(['follower-a']);
+    const result = await createCherryEmitCommand({ registry: reg }).execute(
+      ['--detail', '{"x":1}', '--', '--weird'],
+      createMockCtx()
+    );
+    expect(result.exitCode).toBe(0);
+    expect(reg.emitSliccEvent).toHaveBeenCalledWith('follower-a', '--weird', { x: 1 });
   });
 });
 


### PR DESCRIPTION
## Summary
- `cherry-emit` now rejects unrecognized dash-prefixed flags with a non-zero exit (`cherry-emit: unknown flag: --x`) instead of silently treating them as positionals (#2255).
- Adopts shared `parseKnownFlags` (any-position flags + `--` terminator) and pairs it with `isHelpRequest` using the same `valueFlags` (`--detail`, `--runtime`).
- Pays layer-back-edge debt: import `CHERRY_RUNTIME_TAG` from `@slicc/shared-ts` instead of `scoops/`, and ratchet the baseline.

## Test plan
- [x] `packages/webapp/tests/shell/supplemental-commands/cherry-emit-command.test.ts` — unknown flag exits non-zero; any-position flags + `--` terminator
- [x] `packages/webapp/tests/shell/supplemental-commands/subcommand-flags.test.ts` — shared helper unit coverage
- [x] `npm run verify` + `check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] Builds + `npm run bundle-size`
- [ ] CI full webapp coverage gate

Part of #2255 (`cherry-emit` only; remaining commands are separate PRs).