### PR TITLE
shell(discover): reject unknown flags (#2255) + pay boy-scout debt

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -78,7 +78,6 @@
   "packages/webapp/src/shell/plugins/store.ts": 2,
   "packages/webapp/src/shell/plugins/types.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/biome-configuration.ts": 1,
-  "packages/webapp/src/shell/supplemental-commands/discover-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/jsh-biome-source.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/kill-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/open-command.ts": 1,

--- a/packages/webapp/src/shell/supplemental-commands/discover-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/discover-command.ts
@@ -28,11 +28,31 @@
 import { SLICC_HOSTED_ORIGIN } from '@slicc/shared-ts';
 import type { Command, SecureFetch } from 'just-bash';
 import { defineCommand } from 'just-bash';
+import type { DiscoveryResult } from '../../net/discover-links.js';
 import { discoverLinks } from '../../net/discover-links.js';
+import type { HandoffMatch } from '../../net/handoff-link.js';
 import { extractHandoff } from '../../net/handoff-link.js';
+import type { ParsedLink } from '../../net/link-header.js';
 import { parseLinkHeader } from '../../net/link-header.js';
 import { createProxiedFetch } from '../proxied-fetch.js';
 import { normalizeHeadersInit } from '../proxy-headers.js';
+import { parseKnownFlags } from './subcommand-flags.js';
+import { isHelpRequest } from './subcommand-help.js';
+
+/** JSON payload printed by `discover` (always pretty-printed). */
+interface DiscoverOutput {
+  url: string;
+  status: number;
+  links: ParsedLink[];
+  handoff: HandoffMatch | null;
+  discovery?: Pick<
+    DiscoveryResult,
+    'catalog' | 'serviceDesc' | 'serviceMeta' | 'status' | 'llmsTxt' | 'failures'
+  >;
+}
+
+/** Boolean flags `discover` accepts (no value-taking flags today). */
+const DISCOVER_BOOL_FLAGS = ['--follow'] as const;
 
 /**
  * Wrap a `SecureFetch` so it can stand in for the Web Fetch API. Used to
@@ -86,20 +106,28 @@ Examples:
 
 export function createDiscoverCommand(): Command {
   return defineCommand('discover', async (args) => {
-    if (args.includes('--help') || args.includes('-h') || args.length === 0) {
+    if (args.length === 0 || isHelpRequest(args)) {
       return { stdout: helpText(), stderr: '', exitCode: 0 };
     }
 
-    const follow = args.includes('--follow');
-    const positional = args.filter((a) => !a.startsWith('-'));
-    if (positional.length !== 1) {
+    const parsed = parseKnownFlags(args, { bool: DISCOVER_BOOL_FLAGS });
+    if ('error' in parsed) {
+      return {
+        stdout: '',
+        stderr: `discover: ${parsed.error}\n`,
+        exitCode: 1,
+      };
+    }
+
+    const follow = parsed.bools.has('--follow');
+    if (parsed.positionals.length !== 1) {
       return {
         stdout: '',
         stderr: 'discover: expected exactly one URL argument\n',
         exitCode: 2,
       };
     }
-    const url = positional[0];
+    const url = parsed.positionals[0];
 
     const fetchProxied = createProxiedFetch();
     let response: Awaited<ReturnType<typeof fetchProxied>>;
@@ -122,7 +150,7 @@ export function createDiscoverCommand(): Command {
     const links = parseLinkHeader(linkValues, url);
     const handoff = extractHandoff(links);
 
-    const result: Record<string, unknown> = {
+    const result: DiscoverOutput = {
       url,
       status: response.status,
       links,

--- a/packages/webapp/tests/shell/supplemental-commands/discover-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/discover-command.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Flag-parsing and help behaviour for `discover`. Fetch routing is covered
+ * in `tests/net/discover-links.test.ts`; these tests stay cheap and mock
+ * the proxied fetch only when a happy path needs a response.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockCommandContext } from '../helpers/mock-command-context.js';
+
+const hoisted = vi.hoisted(() => ({
+  proxied: vi.fn(async (_url: string, _options?: unknown) => ({
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    body: '',
+  })),
+}));
+
+vi.mock('../../../src/shell/proxied-fetch.js', () => ({
+  createProxiedFetch: () => hoisted.proxied,
+}));
+
+import { createDiscoverCommand } from '../../../src/shell/supplemental-commands/discover-command.js';
+
+describe('discover command', () => {
+  beforeEach(() => {
+    hoisted.proxied.mockClear();
+    hoisted.proxied.mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      body: '',
+    });
+  });
+
+  it('shows help with no args, --help, and -h', async () => {
+    const cmd = createDiscoverCommand();
+    for (const args of [[], ['--help'], ['-h']]) {
+      const result = await cmd.execute(args, mockCommandContext());
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('discover — fetch a URL');
+    }
+    expect(hoisted.proxied).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown flag instead of ignoring it', async () => {
+    // Previously `args.filter((a) => !a.startsWith('-'))` dropped `--bogus`
+    // and exited 0 after fetching the URL (issue #2255).
+    const result = await createDiscoverCommand().execute(
+      ['--bogus', 'https://example.com/'],
+      mockCommandContext()
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('unknown flag: --bogus');
+    expect(hoisted.proxied).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown flag after the URL (any-position)', async () => {
+    const result = await createDiscoverCommand().execute(
+      ['https://example.com/', '--json'],
+      mockCommandContext()
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('unknown flag: --json');
+    expect(hoisted.proxied).not.toHaveBeenCalled();
+  });
+
+  it('accepts --follow before or after the URL', async () => {
+    for (const args of [
+      ['--follow', 'https://example.com/'],
+      ['https://example.com/', '--follow'],
+    ]) {
+      hoisted.proxied.mockClear();
+      const result = await createDiscoverCommand().execute(args, mockCommandContext());
+      expect(result.exitCode).toBe(0);
+      expect(hoisted.proxied).toHaveBeenCalledWith('https://example.com/', { method: 'GET' });
+      const body = JSON.parse(result.stdout) as { url: string };
+      expect(body.url).toBe('https://example.com/');
+    }
+  });
+
+  it('honours -- so a dash-prefixed URL stays positional', async () => {
+    const result = await createDiscoverCommand().execute(
+      ['--', '--not-a-flag.example'],
+      mockCommandContext()
+    );
+    expect(result.exitCode).toBe(0);
+    expect(hoisted.proxied).toHaveBeenCalledWith('--not-a-flag.example', { method: 'GET' });
+  });
+
+  it('does not treat --help after -- as a help request', async () => {
+    const result = await createDiscoverCommand().execute(['--', '--help'], mockCommandContext());
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('Usage:');
+    expect(hoisted.proxied).toHaveBeenCalledWith('--help', { method: 'GET' });
+  });
+
+  it('errors when the URL argument is missing', async () => {
+    const result = await createDiscoverCommand().execute(['--follow'], mockCommandContext());
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('expected exactly one URL argument');
+    expect(hoisted.proxied).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- **Audit (#2255):** `discover` silent-swallowed unknowns via `args.filter((a) => !a.startsWith('-'))` and exited 0 after fetching the URL.
- **Fix:** parse argv with shared `parseKnownFlags` (any-position flags + `--` terminator); unknown dash tokens → `discover: unknown flag: …`, exit 1. Help goes through `isHelpRequest`.
- **Boy-scout debt:** replace `Record<string, unknown>` output bag with named `DiscoverOutput`; ratchet `record-string-unknown-baseline.json`.

Contributes to #2255.

## Test plan
- [x] `npm run test -w @slicc/webapp -- tests/shell/supplemental-commands/discover-command.test.ts tests/net/discover-links.test.ts`
- [x] `npm run typecheck`
- [x] Pre-push lint gate (`npm run verify` equivalent) — passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK after rebase onto latest main
- [ ] CI coverage / build jobs


Made with [Cursor](https://cursor.com)