### PR TITLE
shell(plugin): reject unknown flags (#2255)

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/plugin-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/plugin-command.ts
@@ -27,6 +27,7 @@ import type { Command, SecureFetch } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import type { VirtualFS } from '../../fs/index.js';
 import type { LoadedPlugin, PluginDiagnostic, PluginLoadResult } from '../plugins/types.js';
+import { parseKnownFlags } from './subcommand-flags.js';
 import { isHelpRequest } from './subcommand-help.js';
 
 /** Managed extraction root for GitHub-sourced plugins. */
@@ -52,6 +53,21 @@ function ok(stdout: string): ExecResult {
 
 function err(message: string, code = 1): ExecResult {
   return { stdout: '', stderr: `${message}\n`, exitCode: code };
+}
+
+/**
+ * `plugin` owns no value/bool flags today — only positionals. Still run the
+ * shared known-flag walk so a stray `--json` / `--runtime=…` fails loudly
+ * instead of being filtered as "not a path" and exiting 0 (issue #2255).
+ * Callers answer `isHelpRequest` before this so `--help` never reaches here.
+ */
+function parsePluginArgs(
+  sub: string,
+  args: readonly string[]
+): { ok: true; positionals: string[] } | ExecResult {
+  const parsed = parseKnownFlags(args, {});
+  if ('error' in parsed) return err(`plugin ${sub}: ${parsed.error}`);
+  return { ok: true, positionals: parsed.positionals };
 }
 
 function helpText(): string {
@@ -237,7 +253,7 @@ async function cmdInstall(
   cwd: string,
   deps: PluginCommandDeps
 ): Promise<ExecResult> {
-  if (args.includes('--help') || args.includes('-h')) {
+  if (isHelpRequest(args)) {
     return ok(`usage: plugin install <path|repo>
 
 Loads the Agent Plugins package at <path>, or downloads it from a GitHub
@@ -251,11 +267,12 @@ standard skills discovery, and each supported streamable-http MCP server
 is registered in the MCP store as "<plugin>:<server>".
 `);
   }
-  const positional = args.filter((a) => !a.startsWith('--'));
-  if (positional.length < 1) return err('plugin install: expected <path|repo>');
+  const parsed = parsePluginArgs('install', args);
+  if (!('ok' in parsed)) return parsed;
+  if (parsed.positionals.length < 1) return err('plugin install: expected <path|repo>');
 
   const fs = await openVfs(deps);
-  const source = await resolveSource(positional[0], cwd, fs);
+  const source = await resolveSource(parsed.positionals[0], cwd, fs);
   if (source.kind === 'error') return err(`plugin install: ${source.message}`);
 
   let root: string;
@@ -434,9 +451,11 @@ async function bridgeMcpServers(
 // ── list ────────────────────────────────────────────────────────────
 
 async function cmdList(args: string[], deps: PluginCommandDeps): Promise<ExecResult> {
-  if (args.includes('--help') || args.includes('-h')) {
+  if (isHelpRequest(args)) {
     return ok('usage: plugin list\n');
   }
+  const parsed = parsePluginArgs('list', args);
+  if (!('ok' in parsed)) return parsed;
   const { listInstalledPlugins } = await import('../plugins/store.js');
   const plugins = await listInstalledPlugins(deps.fs);
   const names = Object.keys(plugins).sort();
@@ -456,12 +475,13 @@ async function cmdList(args: string[], deps: PluginCommandDeps): Promise<ExecRes
 // ── info ────────────────────────────────────────────────────────────
 
 async function cmdInfo(args: string[], deps: PluginCommandDeps): Promise<ExecResult> {
-  if (args.length === 0 || isHelpRequest(args)) {
-    return args.length === 0
-      ? err('plugin info: expected <name>')
-      : ok('usage: plugin info <name>\n');
+  if (isHelpRequest(args)) {
+    return ok('usage: plugin info <name>\n');
   }
-  const name = args[0];
+  const parsed = parsePluginArgs('info', args);
+  if (!('ok' in parsed)) return parsed;
+  if (parsed.positionals.length < 1) return err('plugin info: expected <name>');
+  const name = parsed.positionals[0];
   const { getInstalledPlugin } = await import('../plugins/store.js');
   const entry = await getInstalledPlugin(name, deps.fs);
   if (!entry) return err(`plugin info: no installed plugin named "${name}"`);
@@ -506,13 +526,14 @@ async function cmdValidate(
   cwd: string,
   deps: PluginCommandDeps
 ): Promise<ExecResult> {
-  if (args.length === 0 || isHelpRequest(args)) {
-    return args.length === 0
-      ? err('plugin validate: expected <path|repo>')
-      : ok('usage: plugin validate <path|repo>\n');
+  if (isHelpRequest(args)) {
+    return ok('usage: plugin validate <path|repo>\n');
   }
+  const parsed = parsePluginArgs('validate', args);
+  if (!('ok' in parsed)) return parsed;
+  if (parsed.positionals.length < 1) return err('plugin validate: expected <path|repo>');
   const fs = await openVfs(deps);
-  const source = await resolveSource(args[0], cwd, fs);
+  const source = await resolveSource(parsed.positionals[0], cwd, fs);
   if (source.kind === 'error') return err(`plugin validate: ${source.message}`);
 
   let root: string;
@@ -562,12 +583,13 @@ async function cmdValidate(
 // ── remove ──────────────────────────────────────────────────────────
 
 async function cmdRemove(args: string[], deps: PluginCommandDeps): Promise<ExecResult> {
-  if (args.length === 0 || isHelpRequest(args)) {
-    return args.length === 0
-      ? err('plugin remove: expected <name>')
-      : ok('usage: plugin remove <name>\n');
+  if (isHelpRequest(args)) {
+    return ok('usage: plugin remove <name>\n');
   }
-  const name = args[0];
+  const parsed = parsePluginArgs('remove', args);
+  if (!('ok' in parsed)) return parsed;
+  if (parsed.positionals.length < 1) return err('plugin remove: expected <name>');
+  const name = parsed.positionals[0];
   const { getInstalledPlugin, deleteInstalledPlugin } = await import('../plugins/store.js');
   const entry = await getInstalledPlugin(name, deps.fs);
   if (!entry) return err(`plugin remove: no installed plugin named "${name}"`);

--- a/packages/webapp/tests/shell/supplemental-commands/plugin-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/plugin-command.test.ts
@@ -84,6 +84,37 @@ describe('plugin command', () => {
     expect(bogus.stderr).toContain('unknown subcommand');
   });
 
+  it('rejects unknown flags instead of silently ignoring them (#2255)', async () => {
+    // The pre-fix install path filtered any `--*` token out of positionals
+    // and still exited 0 when a path remained — indistinguishable from honouring
+    // the flag. list ignored unknowns entirely.
+    const install = await runCmd(['install', '--json', 'reports-plugin']);
+    expect(install.exitCode).toBe(1);
+    expect(install.stderr).toContain('unknown flag: --json');
+
+    const list = await runCmd(['list', '--all']);
+    expect(list.exitCode).toBe(1);
+    expect(list.stderr).toContain('unknown flag: --all');
+
+    const info = await runCmd(['info', 'reports-plugin', '--bogus']);
+    expect(info.exitCode).toBe(1);
+    expect(info.stderr).toContain('unknown flag: --bogus');
+
+    // `--` still lets a dash-prefixed path through as positional.
+    await fs.mkdir('/workspace/-dash-plugin', { recursive: true });
+    await fs.writeFile(
+      '/workspace/-dash-plugin/plugin.json',
+      JSON.stringify({
+        $schema: PLUGIN_MANIFEST_SCHEMA_ID,
+        name: 'dash-plugin',
+        version: '1.0.0',
+      })
+    );
+    const viaTerminator = await runCmd(['validate', '--', '-dash-plugin']);
+    expect(viaTerminator.exitCode).toBe(0);
+    expect(viaTerminator.stdout).toContain('OK');
+  });
+
   it('install: registers a valid plugin and surfaces its skills via discovery', async () => {
     await writeFixturePlugin();
     const r = await runCmd(['install', 'reports-plugin']);


### PR DESCRIPTION
Part of #2255 (`plugin` command surface only). Sibling to #2429 (playwright).

## Summary

Before, `plugin install` filtered any `--*` token out of positionals and still exited 0 when a path remained, and `plugin list` ignored unknown flags entirely — so a probe like `plugin list --all` looked successful. Now every subcommand runs the shared `parseKnownFlags` walk and exits 1 with `unknown flag: …` on stderr.

## Why

Issue #2255 / the sprinkle false-confidence pattern (#2166): silent unknown-flag swallowing is worse than not supporting the flag.

**Repro (before):**
1. `plugin list --all`
2. Expected: exit 1, stderr mentions unknown flag
3. Actual: exit 0

## Approach / Implementation notes

- Added shared `parseKnownFlags` in `subcommand-flags.ts` (extracted sprinkle walk; same API as #2429 — merge-safe if that lands first).
- `plugin` owns no value/bool flags today — empty spec still rejects any dash token; `--` keeps dash-prefixed paths as positionals.
- Help answered via `isHelpRequest` before the flag walk so `--help` never reaches it.

## Cross-cutting impact

- **Floats exercised**: all floats that run the virtual shell (`plugin`) — same command registration path.
- **Other callers**: `parseKnownFlags` is new; sprinkle still has its local copy until a follow-up adopts the helper (identical API).
- No persisted state, security, or bundle-size impact.

## Test plan

- [x] Pre-push lint gate (`npm run verify`) — passed
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/plugin-command.test.ts packages/webapp/tests/shell/supplemental-commands/subcommand-flags.test.ts` — 29 passing
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK (4 files, 0 on debt lists)
- [x] `npm run build -w @slicc/webapp` + `npm run build -w @slicc/chrome-extension` + `npm run bundle-size` — passed
- [x] **New / changed behavior covered by unit tests** (unknown-flag test + helper suite)
- [x] N/A for UI screencast — shell argv parsing only

## Documentation

- [x] No documentation changes needed (internal CLI honesty; `--help` text unchanged)

## Risk & rollback

- Blast radius: `plugin` argv only; revert this PR to roll back.
- Technically breaking for any skill/script that passed a stray flag and relied on exit 0.
- CI catches regression via the new unknown-flag tests.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Shell-command behavior change is intentional (#2255)

Made with [Cursor](https://cursor.com)