### PR TITLE
shell(webhook): reject unknown flags (#2255)

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/webhook-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/webhook-command.ts
@@ -304,11 +304,20 @@ export function createWebhookCommand(commandOptions: WebhookCommandOptions = {})
     getLeaderStatus: commandOptions.getLeaderStatus ?? (() => DEFAULT_LEADER_STATUS),
   };
   return defineCommand('webhook', async (args, ctx) => {
-    if (args.length === 0 || isHelpRequest(args, { valueFlags: CREATE_VALUE_FLAGS })) {
+    if (args.length === 0) {
       return webhookHelp();
     }
 
+    // Resolve the verb before help so create-only valueFlags do not shadow
+    // `--help` on other subcommands (`webhook list --name --help`).
     const subcommand = args[0];
+    if (
+      isHelpRequest(args, {
+        valueFlags: subcommand === 'create' ? CREATE_VALUE_FLAGS : undefined,
+      })
+    ) {
+      return webhookHelp();
+    }
 
     try {
       switch (subcommand) {

--- a/packages/webapp/src/shell/supplemental-commands/webhook-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/webhook-command.ts
@@ -3,6 +3,11 @@ import { defineCommand } from 'just-bash';
 import { getTrayWebhookUrl, getWebhookUrl } from '../../base/lick-urls.js';
 import { defaultLickTarget, type LickTargetEnv } from '../lick-target-env.js';
 import { getLickManagerSurface } from './lick-surface.js';
+import { parseKnownFlags } from './subcommand-flags.js';
+import { isHelpRequest } from './subcommand-help.js';
+
+/** Value-taking flags for `webhook create` — shared with {@link isHelpRequest}. */
+const CREATE_VALUE_FLAGS = ['--name', '--filter', '--scoop'] as const;
 
 interface WebhookLeaderStatus {
   state: string;
@@ -99,30 +104,18 @@ async function handleCreate(
   options: Required<WebhookCommandOptions>,
   env: LickTargetEnv
 ): Promise<CommandResult> {
-  let name = 'default';
-  let filter: string | undefined;
-  let scoop: string | undefined;
-
-  const nameIdx = args.indexOf('--name');
-  if (nameIdx !== -1 && args[nameIdx + 1]) {
-    name = args[nameIdx + 1];
+  const parsed = parseKnownFlags(args.slice(1), { value: CREATE_VALUE_FLAGS });
+  if ('error' in parsed) {
+    return { stdout: '', stderr: `webhook create: ${parsed.error}\n`, exitCode: 1 };
   }
 
-  const filterIdx = args.indexOf('--filter');
-  if (filterIdx !== -1 && args[filterIdx + 1]) {
-    filter = args[filterIdx + 1];
-  }
-
-  const scoopIdx = args.indexOf('--scoop');
-  if (scoopIdx !== -1 && args[scoopIdx + 1]) {
-    scoop = args[scoopIdx + 1];
-  }
-
+  const name = parsed.values.get('--name') ?? 'default';
+  const filter = parsed.values.get('--filter');
   // No `--scoop`: a non-primary cone's shell names itself (SLICC_LICK_TARGET),
   // so `webhook create` inside an extra cone routes back to that cone (#2311).
   // The default root carries no such variable, so it still has to say where
   // the callbacks go — the pre-#2311 rule, unchanged for it.
-  scoop = defaultLickTarget(scoop, env);
+  const scoop = defaultLickTarget(parsed.values.get('--scoop'), env);
 
   if (!scoop) {
     return {
@@ -166,7 +159,15 @@ async function handleCreate(
   return { stdout: output, stderr: '', exitCode: 0 };
 }
 
-async function handleList(options: Required<WebhookCommandOptions>): Promise<CommandResult> {
+async function handleList(
+  args: string[],
+  options: Required<WebhookCommandOptions>
+): Promise<CommandResult> {
+  const parsed = parseKnownFlags(args.slice(1), {});
+  if ('error' in parsed) {
+    return { stdout: '', stderr: `webhook list: ${parsed.error}\n`, exitCode: 1 };
+  }
+
   const lm = await getLickManagerSurface();
   if (!lm) return notInitializedError('list');
   const entries = await lm.listWebhooks();
@@ -202,7 +203,11 @@ async function handleList(options: Required<WebhookCommandOptions>): Promise<Com
 }
 
 async function handleDelete(args: string[]): Promise<CommandResult> {
-  const id = args[1];
+  const parsed = parseKnownFlags(args.slice(1), {});
+  if ('error' in parsed) {
+    return { stdout: '', stderr: `webhook delete: ${parsed.error}\n`, exitCode: 1 };
+  }
+  const id = parsed.positionals[0];
   if (!id) {
     return {
       stdout: '',
@@ -299,7 +304,7 @@ export function createWebhookCommand(commandOptions: WebhookCommandOptions = {})
     getLeaderStatus: commandOptions.getLeaderStatus ?? (() => DEFAULT_LEADER_STATUS),
   };
   return defineCommand('webhook', async (args, ctx) => {
-    if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    if (args.length === 0 || isHelpRequest(args, { valueFlags: CREATE_VALUE_FLAGS })) {
       return webhookHelp();
     }
 
@@ -310,7 +315,7 @@ export function createWebhookCommand(commandOptions: WebhookCommandOptions = {})
         case 'create':
           return await handleCreate(args, options, ctx.env);
         case 'list':
-          return await handleList(options);
+          return await handleList(args, options);
         case 'delete':
           return await handleDelete(args);
         default:

--- a/packages/webapp/tests/shell/supplemental-commands/webhook-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/webhook-command.test.ts
@@ -178,6 +178,14 @@ describe('webhook command — help and argument validation', () => {
     expect(result.stdout).not.toContain('usage: webhook');
     expect(lm.createWebhook).toHaveBeenCalledWith('--help', 'pr', undefined);
   });
+
+  it('shows help for list --name --help (create valueFlags stay create-scoped)', async () => {
+    const { command } = await loadCommandAndTrayLeader();
+    const result = await command.execute(['list', '--name', '--help'], {} as never);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('webhook <command>');
+    expect(result.stderr).not.toContain('unknown flag');
+  });
 });
 
 describe('webhook command — standalone mode (direct LickManager)', () => {

--- a/packages/webapp/tests/shell/supplemental-commands/webhook-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/webhook-command.test.ts
@@ -62,6 +62,7 @@ describe('webhook command — help and argument validation', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    delete (globalThis as Record<string, unknown>).__slicc_lickManager;
   });
 
   it('shows help with --help', async () => {
@@ -90,6 +91,92 @@ describe('webhook command — help and argument validation', () => {
     const result = await command.execute(['delete'], {} as never);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('delete: requires an ID');
+  });
+
+  it('rejects an unknown flag on create (#2255)', async () => {
+    const { command } = await loadCommandAndTrayLeader();
+    const result = await command.execute(
+      ['create', '--scoop', 'pr', '--name', 'github', '--bogus'],
+      {} as never
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('unknown flag');
+    expect(result.stderr).toContain('--bogus');
+  });
+
+  it('rejects an unknown flag on list (#2255)', async () => {
+    const { command } = await loadCommandAndTrayLeader();
+    const result = await command.execute(['list', '--json'], {} as never);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('unknown flag');
+    expect(result.stderr).toContain('--json');
+  });
+
+  it('rejects an unknown flag on delete (#2255)', async () => {
+    const { command } = await loadCommandAndTrayLeader();
+    const result = await command.execute(['delete', 'abc123', '--force'], {} as never);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('unknown flag');
+    expect(result.stderr).toContain('--force');
+  });
+
+  it('accepts create flags in any position (#2255)', async () => {
+    const entry: WebhookEntry = {
+      id: 'wh-any',
+      name: 'any-pos',
+      scoop: 'pr',
+      createdAt: new Date().toISOString(),
+    };
+    const lm = buildLickManagerMock({
+      createWebhook: vi.fn().mockResolvedValue(entry),
+    });
+    (globalThis as Record<string, unknown>).__slicc_lickManager = lm;
+
+    const { command } = await loadCommandAndTrayLeader();
+    const result = await command.execute(
+      ['create', '--name', 'any-pos', '--scoop', 'pr'],
+      {} as never
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(lm.createWebhook).toHaveBeenCalledWith('any-pos', 'pr', undefined);
+  });
+
+  it('honours -- so a dash-leading delete id stays reachable (#2255)', async () => {
+    const lm = buildLickManagerMock({
+      deleteWebhook: vi.fn().mockResolvedValue(true),
+    });
+    (globalThis as Record<string, unknown>).__slicc_lickManager = lm;
+
+    const { command } = await loadCommandAndTrayLeader();
+    const result = await command.execute(['delete', '--', '-weird-id'], {} as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Deleted webhook "-weird-id"');
+    expect(lm.deleteWebhook).toHaveBeenCalledWith('-weird-id');
+  });
+
+  it('does not treat a create flag value of --help as a help request', async () => {
+    const entry: WebhookEntry = {
+      id: 'wh-help-name',
+      name: '--help',
+      scoop: 'pr',
+      createdAt: new Date().toISOString(),
+    };
+    const lm = buildLickManagerMock({
+      createWebhook: vi.fn().mockResolvedValue(entry),
+    });
+    (globalThis as Record<string, unknown>).__slicc_lickManager = lm;
+
+    const { command } = await loadCommandAndTrayLeader();
+    const result = await command.execute(
+      ['create', '--name', '--help', '--scoop', 'pr'],
+      {} as never
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('usage: webhook');
+    expect(lm.createWebhook).toHaveBeenCalledWith('--help', 'pr', undefined);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adopt shared `parseKnownFlags` for `webhook create|list|delete` so unknown dash tokens exit non-zero with stderr (`unknown flag: …`) instead of being silently ignored (#2255).
- Introduce `subcommand-flags.ts` (extracted from sprinkle's walk) so later #2255 adoptions reuse one helper; covers `--` terminators and any-position flags.
- Raise `workerEagerKb` 4160 → 4161: the helper is pulled into the kernel-worker eager graph via `webhook-command`.

## Test plan
- [x] `webhook-command` + `subcommand-flags` unit tests (unknown flags on create/list/delete, any-position flags, `--` terminator)
- [x] `npm run verify` + `check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run build -w @slicc/webapp` + chrome-extension; first-load budgets OK after bump
- [ ] CI green

Closes nothing yet — gradual #2255 sweep; this is the webhook adoption only.


Made with [Cursor](https://cursor.com)