### PR TITLE
shell(oauth-domain): reject unknown flags (#2255) + pay boy-scout debt

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -309,7 +309,6 @@
         "packages/webapp/src/net/link-header.ts",
         "packages/webapp/src/shell/supplemental-commands/afplay-command.ts",
         "packages/webapp/src/shell/supplemental-commands/local-llm-command.ts",
-        "packages/webapp/src/shell/supplemental-commands/oauth-domain-command.ts",
         "packages/webapp/src/shell/supplemental-commands/pdftk-command.ts",
         "packages/webapp/src/shell/supplemental-commands/ps-command.ts",
         "packages/webapp/src/shell/supplemental-commands/screencapture-command.ts",

--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -8,7 +8,6 @@
   "packages/webapp/src/shell/supplemental-commands/hid-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/host-command.ts": 7,
   "packages/webapp/src/shell/supplemental-commands/local-llm-command.ts": 1,
-  "packages/webapp/src/shell/supplemental-commands/oauth-domain-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/picker-popup.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/console.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/interaction.ts": 1,

--- a/packages/webapp/src/shell/supplemental-commands/oauth-domain-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/oauth-domain-command.ts
@@ -1,5 +1,10 @@
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
+import { parseKnownFlags } from './subcommand-flags.js';
+import { isHelpRequest } from './subcommand-help.js';
+
+type CommandResult = { stdout: string; stderr: string; exitCode: number };
+type DomainSettings = typeof import('../../providers/account-store.js');
 
 function helpText(): string {
   return `oauth-domain — manage extra allowed domains for OAuth-issued tokens
@@ -30,120 +35,154 @@ Examples:
 `;
 }
 
+function fail(message: string): CommandResult {
+  return { stdout: '', stderr: `oauth-domain: ${message}\n`, exitCode: 1 };
+}
+
+function listDomains(settings: DomainSettings, providerId: string | undefined): CommandResult {
+  if (providerId) {
+    const list = settings.getExtraOAuthDomains(providerId);
+    if (list.length === 0) {
+      return {
+        stdout: `(no extra domains configured for ${providerId})\n`,
+        stderr: '',
+        exitCode: 0,
+      };
+    }
+    return { stdout: `${list.join('\n')}\n`, stderr: '', exitCode: 0 };
+  }
+
+  const entries = Object.entries(settings.getAllExtraOAuthDomains()).filter(
+    ([, domains]) => domains.length > 0
+  );
+  if (entries.length === 0) {
+    return { stdout: '(no extra OAuth domains configured)\n', stderr: '', exitCode: 0 };
+  }
+  const lines = entries.map(([provider, domains]) => `${provider}: ${domains.join(', ')}`);
+  return { stdout: `${lines.join('\n')}\n`, stderr: '', exitCode: 0 };
+}
+
+async function addDomain(
+  settings: DomainSettings,
+  providerId: string | undefined,
+  domain: string | undefined
+): Promise<CommandResult> {
+  if (!providerId || !domain) {
+    return {
+      stdout: '',
+      stderr: 'oauth-domain add: requires <providerId> and <domain>\n',
+      exitCode: 1,
+    };
+  }
+  const current = settings.getExtraOAuthDomains(providerId);
+  const lower = domain.toLowerCase();
+  if (current.some((entry) => entry.toLowerCase() === lower)) {
+    return {
+      stdout: `(${domain} already in ${providerId} extras)\n`,
+      stderr: '',
+      exitCode: 0,
+    };
+  }
+  await settings.setExtraOAuthDomainsAsync(providerId, [...current, domain]);
+  return {
+    stdout: `Added ${domain} to ${providerId}. Reload the page to apply.\n`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+async function removeDomain(
+  settings: DomainSettings,
+  providerId: string | undefined,
+  domain: string | undefined
+): Promise<CommandResult> {
+  if (!providerId || !domain) {
+    return {
+      stdout: '',
+      stderr: 'oauth-domain remove: requires <providerId> and <domain>\n',
+      exitCode: 1,
+    };
+  }
+  const current = settings.getExtraOAuthDomains(providerId);
+  const lower = domain.toLowerCase();
+  const next = current.filter((entry) => entry.toLowerCase() !== lower);
+  if (next.length === current.length) {
+    return {
+      stdout: `(${domain} not found in ${providerId} extras)\n`,
+      stderr: '',
+      exitCode: 0,
+    };
+  }
+  await settings.setExtraOAuthDomainsAsync(providerId, next);
+  return {
+    stdout: `Removed ${domain} from ${providerId}. Reload the page to apply.\n`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+async function clearDomains(
+  settings: DomainSettings,
+  providerId: string | undefined
+): Promise<CommandResult> {
+  if (!providerId) {
+    return {
+      stdout: '',
+      stderr: 'oauth-domain clear: requires <providerId>\n',
+      exitCode: 1,
+    };
+  }
+  await settings.setExtraOAuthDomainsAsync(providerId, []);
+  return {
+    stdout: `Cleared extra domains for ${providerId}. Reload the page to apply.\n`,
+    stderr: '',
+    exitCode: 0,
+  };
+}
+
+async function runSubcommand(
+  settings: DomainSettings,
+  subcommand: string | undefined,
+  providerId: string | undefined,
+  domain: string | undefined
+): Promise<CommandResult> {
+  switch (subcommand) {
+    case 'list':
+      return listDomains(settings, providerId);
+    case 'add':
+      return addDomain(settings, providerId, domain);
+    case 'remove':
+      return removeDomain(settings, providerId, domain);
+    case 'clear':
+      return clearDomains(settings, providerId);
+    default:
+      return {
+        stdout: '',
+        stderr: `oauth-domain: unknown subcommand "${subcommand}"\n${helpText()}`,
+        exitCode: 1,
+      };
+  }
+}
+
 export function createOAuthDomainCommand(): Command {
   return defineCommand('oauth-domain', async (args) => {
-    if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    if (args.length === 0 || isHelpRequest(args)) {
       return { stdout: helpText(), stderr: '', exitCode: 0 };
     }
 
-    const { getExtraOAuthDomains, setExtraOAuthDomainsAsync, getAllExtraOAuthDomains } =
-      await import('../../ui/provider-settings.js');
+    // No value/bool flags today — any dash token is unknown (issue #2255).
+    const parsed = parseKnownFlags(args);
+    if ('error' in parsed) {
+      return fail(parsed.error);
+    }
 
-    const [subcommand, providerId, domain] = args;
+    const [subcommand, providerId, domain] = parsed.positionals;
+    const settings = await import('../../providers/account-store.js');
 
     try {
-      switch (subcommand) {
-        case 'list': {
-          if (providerId) {
-            const list = getExtraOAuthDomains(providerId);
-            if (list.length === 0) {
-              return {
-                stdout: `(no extra domains configured for ${providerId})\n`,
-                stderr: '',
-                exitCode: 0,
-              };
-            }
-            return { stdout: list.join('\n') + '\n', stderr: '', exitCode: 0 };
-          }
-          const all = getAllExtraOAuthDomains();
-          const entries = Object.entries(all).filter(([, v]) => v.length > 0);
-          if (entries.length === 0) {
-            return { stdout: '(no extra OAuth domains configured)\n', stderr: '', exitCode: 0 };
-          }
-          const lines = entries.map(([k, v]) => `${k}: ${v.join(', ')}`);
-          return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
-        }
-
-        case 'add': {
-          if (!providerId || !domain) {
-            return {
-              stdout: '',
-              stderr: 'oauth-domain add: requires <providerId> and <domain>\n',
-              exitCode: 1,
-            };
-          }
-          const current = getExtraOAuthDomains(providerId);
-          const lower = domain.toLowerCase();
-          if (current.some((d) => d.toLowerCase() === lower)) {
-            return {
-              stdout: `(${domain} already in ${providerId} extras)\n`,
-              stderr: '',
-              exitCode: 0,
-            };
-          }
-          await setExtraOAuthDomainsAsync(providerId, [...current, domain]);
-          return {
-            stdout: `Added ${domain} to ${providerId}. Reload the page to apply.\n`,
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
-        case 'remove': {
-          if (!providerId || !domain) {
-            return {
-              stdout: '',
-              stderr: 'oauth-domain remove: requires <providerId> and <domain>\n',
-              exitCode: 1,
-            };
-          }
-          const current = getExtraOAuthDomains(providerId);
-          const lower = domain.toLowerCase();
-          const next = current.filter((d) => d.toLowerCase() !== lower);
-          if (next.length === current.length) {
-            return {
-              stdout: `(${domain} not found in ${providerId} extras)\n`,
-              stderr: '',
-              exitCode: 0,
-            };
-          }
-          await setExtraOAuthDomainsAsync(providerId, next);
-          return {
-            stdout: `Removed ${domain} from ${providerId}. Reload the page to apply.\n`,
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
-        case 'clear': {
-          if (!providerId) {
-            return {
-              stdout: '',
-              stderr: 'oauth-domain clear: requires <providerId>\n',
-              exitCode: 1,
-            };
-          }
-          await setExtraOAuthDomainsAsync(providerId, []);
-          return {
-            stdout: `Cleared extra domains for ${providerId}. Reload the page to apply.\n`,
-            stderr: '',
-            exitCode: 0,
-          };
-        }
-
-        default:
-          return {
-            stdout: '',
-            stderr: `oauth-domain: unknown subcommand "${subcommand}"\n${helpText()}`,
-            exitCode: 1,
-          };
-      }
+      return await runSubcommand(settings, subcommand, providerId, domain);
     } catch (err) {
-      return {
-        stdout: '',
-        stderr: `oauth-domain: ${err instanceof Error ? err.message : String(err)}\n`,
-        exitCode: 1,
-      };
+      return fail(err instanceof Error ? err.message : String(err));
     }
   });
 }

--- a/packages/webapp/tests/shell/supplemental-commands/oauth-domain-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/oauth-domain-command.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock the provider-settings module so the command exercises its
+// Mock the account-store module so the command exercises its
 // public surface (getExtraOAuthDomains / setExtraOAuthDomainsAsync /
 // getAllExtraOAuthDomains) without touching real localStorage. This
 // is the layer that issue #701 broke: the command was calling the
@@ -8,18 +8,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // disappeared. Locking the command-level call shape to the async
 // setter prevents a future refactor from dropping the `await` and
 // re-introducing the same bug silently.
-vi.mock('../../../src/ui/provider-settings.js', () => ({
+vi.mock('../../../src/providers/account-store.js', () => ({
   getExtraOAuthDomains: vi.fn(),
   setExtraOAuthDomainsAsync: vi.fn(),
   getAllExtraOAuthDomains: vi.fn(),
 }));
 
-import { createOAuthDomainCommand } from '../../../src/shell/supplemental-commands/oauth-domain-command.js';
 import {
   getAllExtraOAuthDomains,
   getExtraOAuthDomains,
   setExtraOAuthDomainsAsync,
-} from '../../../src/ui/provider-settings.js';
+} from '../../../src/providers/account-store.js';
+import { createOAuthDomainCommand } from '../../../src/shell/supplemental-commands/oauth-domain-command.js';
 import { mockCommandContext } from '../helpers/mock-command-context.js';
 
 const mockGetExtraOAuthDomains = vi.mocked(getExtraOAuthDomains);
@@ -191,5 +191,27 @@ describe('oauth-domain command', () => {
     const result = await createOAuthDomainCommand().execute(['frobnicate'], createMockCtx());
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('unknown subcommand');
+  });
+
+  it('rejects an unknown flag instead of silently ignoring it', async () => {
+    const result = await createOAuthDomainCommand().execute(
+      ['list', 'adobe', '--bogus'],
+      createMockCtx()
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('unknown flag: --bogus');
+    expect(result.stdout).toBe('');
+    expect(mockGetExtraOAuthDomains).not.toHaveBeenCalled();
+  });
+
+  it('treats tokens after -- as positional, not flags', async () => {
+    mockGetExtraOAuthDomains.mockReturnValue([]);
+    const result = await createOAuthDomainCommand().execute(
+      ['add', 'adobe', '--', '--evil.example'],
+      createMockCtx()
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Added --evil.example');
+    expect(mockSetExtraOAuthDomainsAsync).toHaveBeenCalledWith('adobe', ['--evil.example']);
   });
 });


### PR DESCRIPTION
## Summary
- `oauth-domain` now rejects unknown dash-prefixed flags (exit 1 / stderr) via shared `parseKnownFlags`, accepting flags in any position and honouring `--` for dash-leading domains (#2255).
- Loads extras from `providers/account-store` instead of `ui/provider-settings`, clearing the shell→ui layer back-edge; drops the cognitive-complexity biome exemption after splitting handlers.
- Adds `subcommand-flags.ts` (+ unit tests) extracted from sprinkle’s known-flag walk for this adoption (and sibling #2255 work).

## Test plan
- [x] `oauth-domain-command` + `subcommand-flags` unit tests (unknown flag, `--` terminator)
- [x] `npm run verify` + `check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run build` + chrome-extension build + `bundle-size`
- [ ] Full `test:coverage:webapp` (local run hit unrelated UI/ipk flakes; targeted coverage for changed files passed)

Closes #2255 (for this command only)


Made with [Cursor](https://cursor.com)