### PR TITLE
shell(kill): reject unknown flags + pay boy-scout debt (#2255)

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -78,7 +78,6 @@
   "packages/webapp/src/shell/plugins/types.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/biome-configuration.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/jsh-biome-source.ts": 1,
-  "packages/webapp/src/shell/supplemental-commands/kill-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/picker-popup.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/console.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/cookies.ts": 4,

--- a/packages/webapp/src/shell/supplemental-commands/kill-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/kill-command.ts
@@ -80,9 +80,13 @@ export function createKillCommand(options: KillCommandOptions = {}): Command {
 // Internal
 // ---------------------------------------------------------------------------
 
+/** Globals the kernel host publishes for commands that need the live PM. */
+interface KernelGlobals {
+  __slicc_pm?: unknown;
+}
+
 function lookupGlobalPm(): ProcessManager | null {
-  const g = globalThis as Record<string, unknown>;
-  const pm = g.__slicc_pm;
+  const pm = (globalThis as KernelGlobals).__slicc_pm;
   return pm instanceof Object && typeof (pm as ProcessManager).signal === 'function'
     ? (pm as ProcessManager)
     : null;

--- a/packages/webapp/tests/shell/supplemental-commands/kill-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/kill-command.test.ts
@@ -133,6 +133,17 @@ describe('kill command', () => {
     expect(result.stderr).toContain('invalid pid');
   });
 
+  // issue #2255: dash-prefixed unknowns must exit non-zero (not silent-swallow)
+  it('rejects an unknown flag instead of treating it as a pid', async () => {
+    const pm = new ProcessManager();
+    const proc = pm.spawn({ kind: 'shell', argv: ['s'], owner: { kind: 'cone' } });
+    const cmd = createKillCommand({ processManager: pm });
+    const result = await cmd.execute(['--bogus', String(proc.pid)], mockCtx);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/unknown/i);
+    expect(proc.terminatedBy).toBeFalsy();
+  });
+
   it('--help prints usage', async () => {
     const cmd = createKillCommand({ processManager: new ProcessManager() });
     const result = await cmd.execute(['--help'], mockCtx);


### PR DESCRIPTION
## Summary
- Lock in #2255 for `kill`: dash-prefixed unknowns already exit non-zero via the signal parser; add a regression test so silent-swallow cannot return.
- Pay boy-scout debt on `kill-command.ts`: replace `Record<string, unknown>` with a named `KernelGlobals` shape and ratchet `record-string-unknown-baseline.json` via `--update`.

`parseKnownFlags` / `subcommand-flags.ts` is not adopted here — `kill`'s POSIX short-signal grammar (`-INT`, `-9`, `-s NAME`) does not match the boolean/value flag walk used by sprinkle-style commands.

## Test plan
- [x] `kill-command` unit tests (incl. unknown `--bogus` → non-zero + stderr)
- [x] `npm run verify` + `check-touched-exemptions.mjs`
- [x] `npm run typecheck` + `npm run test`
- [x] `npm run build` + chrome-extension build + `bundle-size`
- [ ] CI green

Part of #2255.


Made with [Cursor](https://cursor.com)