### PR TITLE
shell(di): reject unknown flags (#2255)

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/di-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/di-command.ts
@@ -4,7 +4,8 @@
  * Thin argv + dispatch + error-formatting wrapper; all business logic lives in
  * `../di/`. Supported verbs are `add` and `list`; every other verb (including
  * real-uv subcommands like `pip` / `venv` / `tool` / `run`) exits non-zero with
- * a "not implemented in SLICC's di/uv subset" pointer to `di --help`.
+ * a "not implemented in SLICC's di/uv subset" pointer to `di --help`. Unknown
+ * dash-prefixed flags are rejected (issue #2255) rather than silently dropped.
  *
  * Registered twice (`di` and `uv`) with the same handler so `uv add numpy`
  * behaves identically to `di add numpy`.
@@ -14,12 +15,16 @@ import type { Command, CommandContext, ExecResult, SecureFetch } from 'just-bash
 import { defineCommand } from 'just-bash';
 import type { VirtualFS } from '../../fs/index.js';
 import { diAdd, diList, type ListRow } from '../di/index.js';
+import { parseKnownFlags } from './subcommand-flags.js';
 import { isHelpRequest } from './subcommand-help.js';
 
 export interface DiCommandDeps {
   fs: VirtualFS;
   fetch: SecureFetch;
 }
+
+/** di owns no value-taking flags; keep in sync with `parseKnownFlags` / `isHelpRequest`. */
+const DI_VALUE_FLAGS: readonly string[] = [];
 
 function usage(name: string): string {
   return `${name} - minimal Python package manager (pure-Python + Pyodide wheels)
@@ -66,7 +71,11 @@ async function runAdd(
   ctx: CommandContext,
   deps: DiCommandDeps
 ): Promise<ExecResult> {
-  const specs = args.filter((a) => !a.startsWith('-'));
+  const parsed = parseKnownFlags(args, { value: DI_VALUE_FLAGS });
+  if ('error' in parsed) {
+    return { stdout: '', stderr: `${name}: ${parsed.error}\n`, exitCode: 1 };
+  }
+  const specs = parsed.positionals;
   if (specs.length === 0) {
     return { stdout: '', stderr: `${name}: add requires at least one package\n`, exitCode: 1 };
   }
@@ -96,9 +105,15 @@ async function runAdd(
 
 async function runList(
   name: string,
+  args: string[],
   ctx: CommandContext,
   deps: DiCommandDeps
 ): Promise<ExecResult> {
+  const parsed = parseKnownFlags(args, { value: DI_VALUE_FLAGS });
+  if ('error' in parsed) {
+    return { stdout: '', stderr: `${name}: ${parsed.error}\n`, exitCode: 1 };
+  }
+
   const rows = await diList(deps.fs, ctx.cwd);
   if (rows === null) {
     return {
@@ -118,14 +133,15 @@ export function createDiCommand(name: string, deps: DiCommandDeps): Command {
     if (args.length === 0) {
       return { stdout: usage(name), stderr: `${name}: missing verb\n`, exitCode: 1 };
     }
-    if (isHelpRequest(args)) {
+    // Answer help before parseKnownFlags so `--help` is not reported as unknown.
+    if (isHelpRequest(args, { valueFlags: DI_VALUE_FLAGS })) {
       return { stdout: usage(name), stderr: '', exitCode: 0 };
     }
 
     const verb = args[0];
     const rest = args.slice(1);
     if (verb === 'add') return runAdd(name, rest, ctx, deps);
-    if (verb === 'list') return runList(name, ctx, deps);
+    if (verb === 'list') return runList(name, rest, ctx, deps);
     return notImplemented(name, verb);
   });
 }

--- a/packages/webapp/tests/shell/supplemental-commands/di-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/di-command.test.ts
@@ -105,6 +105,32 @@ describe('di-command argv surface', () => {
     expect(r.stderr).toMatch(/requires at least one package/);
   });
 
+  it('rejects an unknown flag instead of silently ignoring it', async () => {
+    const { fs, fetch } = await fixtureFs([{ name: 'micropip', version: '0.6.0' }]);
+    const cmd = createDiCommand('di', { fs, fetch });
+    const add = await cmd.execute(['add', 'micropip', '--bogus'], ctx());
+    expect(add.exitCode).toBe(1);
+    expect(add.stderr).toContain('unknown flag: --bogus');
+    expect(add.stdout).toBe('');
+    const list = await cmd.execute(['list', '--json'], ctx());
+    expect(list.exitCode).toBe(1);
+    expect(list.stderr).toContain('unknown flag: --json');
+  });
+
+  it('treats tokens after -- as package specs, not flags', async () => {
+    const { fs, fetch } = await fixtureFs([{ name: 'micropip', version: '0.6.0' }]);
+    const cmd = createDiCommand('di', { fs, fetch });
+    // Without `--`, a dash-prefixed token is an unknown flag; with `--` it is a spec.
+    const rejected = await cmd.execute(['add', '--micropip'], ctx());
+    expect(rejected.exitCode).toBe(1);
+    expect(rejected.stderr).toContain('unknown flag: --micropip');
+    // Real package names do not start with `-`; the terminator still keeps
+    // dash-looking tokens reachable for callers that need them.
+    const viaTerminator = await cmd.execute(['add', '--', 'micropip'], ctx());
+    expect(viaTerminator.exitCode).toBe(0);
+    expect(viaTerminator.stdout).toMatch(/micropip==0.6.0/);
+  });
+
   it('di list prints recorded packages', async () => {
     const { fs, fetch } = await fixtureFs([{ name: 'micropip', version: '0.6.0' }]);
     const cmd = createDiCommand('di', { fs, fetch });


### PR DESCRIPTION
## Summary
- Fix silent unknown-flag swallowing in `di`/`uv` (`add`/`list`): dash-prefixed tokens are rejected with `di: unknown flag: …` and exit 1 instead of being filtered away and exiting 0 (#2255).
- Add shared `parseKnownFlags` helper (same API as #2431) and adopt it for `di` only; honour `--` terminator and keep `isHelpRequest` aligned via empty `DI_VALUE_FLAGS`.
- Tests cover unknown flags on `add`/`list` and `--` package-spec pass-through.

## Test plan
- [x] `vitest` `di-command.test.ts` + `subcommand-flags.test.ts` (17 tests)
- [x] `npm run verify` + `check-touched-exemptions.mjs` (di not on any debt list)
- [x] `npm run typecheck`, `npm run build`, extension build, `npm run bundle-size`
- [ ] CI full suite (local Node 26 hits unrelated ipk/wc-follower timeouts also seen on sibling worktrees; CI uses Node 24)

Closes #2255 (for `di` only). Helper also proposed in #2431 — if that lands first, rebase drops the duplicated helper files.


Made with [Cursor](https://cursor.com)