### PR TITLE
shell(cost): reject unknown flags (#2255)

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/cost-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/cost-command.ts
@@ -1,6 +1,11 @@
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import type { FrozenSessionIndexEntry } from '../../transcript/frozen-archive-format.js';
+import { parseKnownFlags } from './subcommand-flags.js';
+import { isHelpRequest } from './subcommand-help.js';
+
+/** Boolean flags accepted by `cost` (any position). */
+const COST_BOOL_FLAGS = ['--all', '--json'] as const;
 
 export type SessionCostScope = 'live' | 'all';
 
@@ -209,22 +214,27 @@ function formatTable(data: ScoopCostData[]): string {
 
 export function createCostCommand(): Command {
   return defineCommand('cost', async (args) => {
-    if (args.includes('--help') || args.includes('-h')) {
+    if (isHelpRequest(args)) {
       return { stdout: helpText(), stderr: '', exitCode: 0 };
+    }
+
+    const parsed = parseKnownFlags(args, { bool: COST_BOOL_FLAGS });
+    if ('error' in parsed) {
+      return { stdout: '', stderr: `cost: ${parsed.error}\n`, exitCode: 1 };
     }
 
     if (!sessionCostsProvider) {
       return { stdout: '', stderr: 'Cost data not available.\n', exitCode: 1 };
     }
 
-    const scope: SessionCostScope = args.includes('--all') ? 'all' : 'live';
+    const scope: SessionCostScope = parsed.bools.has('--all') ? 'all' : 'live';
     const data = await sessionCostsProvider(scope);
 
     if (data.length === 0) {
       return { stdout: 'No session cost data yet.\n', stderr: '', exitCode: 0 };
     }
 
-    if (args.includes('--json')) {
+    if (parsed.bools.has('--json')) {
       return { stdout: JSON.stringify(data, null, 2) + '\n', stderr: '', exitCode: 0 };
     }
 

--- a/packages/webapp/tests/shell/supplemental-commands/cost-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/cost-command.test.ts
@@ -101,6 +101,32 @@ describe('cost command', () => {
     expect(result.stdout).toContain('cost');
   });
 
+  it('rejects an unknown flag instead of silently ignoring it', async () => {
+    registerSessionCostsProvider(() => mockCosts);
+    const result = await createCostCommand().execute(['--bogus'], ctx);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('unknown flag: --bogus');
+    expect(result.stdout).toBe('');
+  });
+
+  it('accepts known flags in any order', async () => {
+    const scopes: SessionCostScope[] = [];
+    registerScopedProvider(scopes);
+    const result = await createCostCommand().execute(['--json', '--all'], ctx);
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed).toHaveLength(4);
+    expect(scopes).toEqual(['all']);
+  });
+
+  it('treats tokens after -- as positional, not flags', async () => {
+    registerSessionCostsProvider(() => mockCosts);
+    const result = await createCostCommand().execute(['--', '--json'], ctx);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Session Cost Breakdown');
+    expect(result.stdout).not.toContain('"name"');
+  });
+
   it('returns error when no provider registered', async () => {
     const result = await createCostCommand().execute([], ctx);
     expect(result.exitCode).toBe(1);


### PR DESCRIPTION
## Summary
- Teach `cost` to reject unknown flags with a non-zero exit and stderr (`cost: unknown flag: …`), instead of silently ignoring them and exiting 0 (#2255).
- Extract shared `parseKnownFlags` into `subcommand-flags.ts` (from sprinkle’s walk) so flags work in any position and `--` stays positional; point sprinkle at the shared helper to avoid a duplicated walk.
- Add tests for unknown-flag rejection, flag-order independence, and `--` terminator behaviour.

## Test plan
- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/cost-command.test.ts packages/webapp/tests/shell/supplemental-commands/sprinkle-command.test.ts` — 56 passing
- [x] `npm run verify` — 7/7
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK
- [x] `npm run typecheck`
- [x] `npm run build` + `npm run build -w @slicc/chrome-extension` + `npm run bundle-size`
- [ ] Manual: `cost --bogus` → exit 1; `cost --json --all` still works

Fixes #2255 (cost adoption; other commands remain for follow-up PRs).


Made with [Cursor](https://cursor.com)