### PR TITLE
fix(cloudflare-worker): mint one APNs provider JWT per worker, not per tray

### DIFF
--- a/.agents/skills/deploying-tray-worker/SKILL.md
+++ b/.agents/skills/deploying-tray-worker/SKILL.md
@@ -481,3 +481,40 @@ or transport are broken. Do **not** infer from `wallTime` on the first push alon
 8-second reading used to be the uncleared `AbortSignal.timeout`, not a hang.
 
 This is deliberately not a CI gate — it would put Apple's availability in the deploy path.
+
+### Settle the gateway before reading any rejection (two-tray probe)
+
+A device token is valid on **one** gateway only, decided by the build's
+`aps-environment` entitlement: a development-signed build gets a sandbox token, a
+TestFlight/App Store build a production one. Send it to the wrong gateway and Apple answers
+`BadDeviceToken` — indistinguishable, at a glance, from a wrong topic or a bad key. Never
+interpret a rejection before establishing which gateway the token belongs to.
+
+Do not infer the gateway from the build. `currentApnsEnvironment()` reports what the app
+_claims_ — derived from `#if DEBUG`, not from the entitlement it actually holds — and a
+dev-signed **Release** build claims `production` while carrying a sandbox token. Reading
+Xcode settings or `builtByDeveloper` only tells you what _should_ be true.
+
+Ask Apple instead. With one real device token, register it on **two throwaway trays** and
+push once from each — the DO stores `environment` per token, so the same token can be
+driven at both gateways:
+
+```
+tray A: {"type":"push.register", …, "environment":"sandbox"}    → push.send
+tray B: {"type":"push.register", …, "environment":"production"} → push.send
+```
+
+Read the verdict from a **second** push on each tray (the eviction signal above):
+
+| tray A (sandbox) | tray B (production) | meaning                                                |
+| ---------------- | ------------------- | ------------------------------------------------------ |
+| token evicted    | token evicted       | wrong on both — topic or key is wrong, not the gateway |
+| token survives   | token evicted       | sandbox is correct; it is a development build          |
+| token evicted    | token survives      | production is correct; TestFlight / App Store build    |
+
+A token that **survives** was accepted (`200`) — that gateway is the right one. Once the
+gateway is known, a rejection there is finally meaningful: `DeviceTokenNotForTopic` means
+`APNS_TOPIC` does not match the app's bundle id, whereas `BadDeviceToken` on the _correct_
+gateway means the token itself is stale. That distinction is the only way to verify
+`APNS_TOPIC`, because Apple rejects a malformed token before it ever checks the topic — so
+no fabricated-token probe can reach it.

--- a/.agents/skills/deploying-tray-worker/SKILL.md
+++ b/.agents/skills/deploying-tray-worker/SKILL.md
@@ -454,3 +454,30 @@ loopback; the `.localhost` host is dev-only.
 ## Follower push (APNs, #2062)
 
 Four secrets, all or nothing: `APNS_TEAM_ID`, `APNS_KEY_ID`, `APNS_PRIVATE_KEY` (the `.p8` PEM, newlines intact — `npx wrangler secret put APNS_PRIVATE_KEY < AuthKey_XXXX.p8`), `APNS_TOPIC` (`com.sliccy.follower`). Missing → the DO logs `push.send ignored` once and nothing else changes. Staging talks to whatever gateway the registering phone asked for (`environment` on `push.register`: debug builds = sandbox, TestFlight/App Store = production), so a TestFlight build against staging needs the production key. Verify with a time-sensitive test: run a headless leader, background the phone, `sudo` something — the banner must arrive within seconds; a 403 `InvalidProviderToken` in `wrangler tail` means the key id / team id pair is wrong.
+
+**Provider JWTs come from one DO, not per tray.** Apple throttles token creation per
+(team id, key id) — not per connection — and answers `429 TooManyProviderTokenUpdates`
+above one mint per 20 minutes. Every tray DO borrows from
+`idFromName('__apns_provider_token')` via `POST /internal/apns-token`, which persists the
+JWT to its own storage so hibernation costs nothing (#2432). Never reintroduce per-DO
+minting: the tray DO hibernates between messages, so mint rate would scale with
+`active trays × wake cycles`, not with time.
+
+**Probe the worker→Apple leg without a phone.** Register a syntactically valid but
+fabricated device token and push; APNs authenticates the JWT _before_ it validates the
+token, so a dead-token verdict proves the credentials are good:
+
+```bash
+# 1. mint a throwaway tray, 2. attach as leader, 3. open the leader WS, then send:
+#    {"type":"push.register","platform":"ios","token":"<64 hex>","environment":"sandbox"}
+#    {"type":"push.send","category":"turn_end","label":"probe"}
+# Push again on the SAME tray ~30s later.
+```
+
+Read the result from the second push, not from logs: if the token was evicted the second
+`push.send` early-returns in ~10 ms (Apple answered `BadDeviceToken`/410 — credentials
+good). If it takes ~8 s again the token survived, meaning a timeout or a 403 — credentials
+or transport are broken. Do **not** infer from `wallTime` on the first push alone: an
+8-second reading used to be the uncleared `AbortSignal.timeout`, not a hang.
+
+This is deliberately not a CI gate — it would put Apple's availability in the deploy path.

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -76,7 +76,7 @@ keyed by `connId`, replays `bridge.connected` on leader (re)connect, hibernates 
 ### TURN Credentials
 
 Fetched with `CLOUDFLARE_TURN_KEY_ID` (in `wrangler.jsonc`) and
-`CLOUDFLARE_TURN_API_TOKEN` (Wrangler secret). Follower push (#2062): `src/apns.ts` signs an ES256 JWT from `APNS_TEAM_ID` / `APNS_KEY_ID` / `APNS_PRIVATE_KEY` (`.p8` PEM) and posts to `api(.sandbox).push.apple.com` with `APNS_TOPIC`; the tray DO stores ≤16 `push.register` tokens per tray and fans out leader `push.send` (`turn_end`, time-sensitive `sudo_request`, metadata only), dropping tokens APNs reports dead. All four secrets or pushing is silently off. `session-tray.ts` caches ICE servers
+`CLOUDFLARE_TURN_API_TOKEN` (Wrangler secret). Follower push (#2062): `src/apns.ts` signs an ES256 JWT from `APNS_TEAM_ID` / `APNS_KEY_ID` / `APNS_PRIVATE_KEY` (`.p8` PEM) and posts to `api(.sandbox).push.apple.com` with `APNS_TOPIC`; the tray DO stores ≤16 `push.register` tokens per tray and fans out leader `push.send` (`turn_end`, time-sensitive `sudo_request`, metadata only), dropping tokens APNs reports dead. All four secrets or pushing is silently off. **Provider JWTs are minted by exactly one DO** (`src/apns-provider-token.ts`, `idFromName('__apns_provider_token')`, storage-backed): Apple throttles token creation per team+key, so per-tray minting broke Apple's 20-minute floor once a few trays hibernated (#2432). `session-tray.ts` caches ICE servers
 and refreshes before TTL expiry.
 
 ### Tray Kind (desktop / hosted)

--- a/packages/cloudflare-worker/src/apns-provider-token.ts
+++ b/packages/cloudflare-worker/src/apns-provider-token.ts
@@ -1,0 +1,148 @@
+/**
+ * One APNs provider JWT for the whole worker (issue #2432).
+ *
+ * Apple throttles provider-token creation per (team id, key id) pair — not per
+ * connection — and answers `429 TooManyProviderTokenUpdates` to anyone minting
+ * more than once every 20 minutes. The tray hub runs one Durable Object *per
+ * tray*, each of which used to sign its own JWT, and those DOs use WebSocket
+ * hibernation: an idle tray is evicted between messages and mints again on the
+ * next push. Mint rate therefore scaled with `active trays × wake cycles`
+ * rather than with time, and a single busy user could exceed Apple's floor.
+ *
+ * The fix reuses infrastructure already bound: every tray DO asks one
+ * well-known instance of the *same* namespace — `idFromName(APNS_TOKEN_DO_NAME)`
+ * — for the current token. That instance is the only one that signs, and it
+ * persists the result to its own storage so its own hibernation costs nothing.
+ * No new binding, no KV.
+ *
+ * Deliberately *not* fronted by `caches.default`: the singleton never mints on
+ * a cache miss (it returns a stored token), so a cache would only shave the
+ * internal round trip while adding an invalidation path for a value that must
+ * rotate on demand. The per-DO memo below already collapses the hot path.
+ */
+
+import type { ApnsProviderToken, ApnsProviderTokenSource, ProviderTokenStore } from './apns.js';
+import type {
+  DurableObjectNamespaceLike,
+  DurableObjectStorageLike,
+  DurableObjectStubLike,
+} from './shared.js';
+import { jsonResponse } from './shared.js';
+
+/** Well-known instance name of the minting DO within the tray namespace. */
+export const APNS_TOKEN_DO_NAME = '__apns_provider_token';
+/** Internal route the minting instance answers on. */
+export const APNS_TOKEN_PATH = '/internal/apns-token';
+/** Storage key the minting instance keeps its token under. */
+export const APNS_TOKEN_STORAGE_KEY = 'apns:provider-token';
+/**
+ * How long a borrowing DO may reuse a fetched token before asking again. Keyed
+ * off the token's `mintedAt`, never the fetch time, so a token borrowed at
+ * minute 49 is not held past Apple's 60-minute expiry.
+ */
+const BORROWED_TOKEN_TTL_MS = 50 * 60 * 1000;
+
+/** Any URL works for a DO stub fetch; only the path is routed. */
+const INTERNAL_ORIGIN = 'https://tray-hub.internal';
+
+function isProviderToken(value: unknown): value is ApnsProviderToken {
+  if (!value || typeof value !== 'object') return false;
+  const token = value as { value?: unknown; mintedAt?: unknown };
+  return (
+    typeof token.value === 'string' &&
+    token.value.length > 0 &&
+    typeof token.mintedAt === 'number' &&
+    Number.isFinite(token.mintedAt)
+  );
+}
+
+/** Persist the minted JWT in the minting DO's own storage across hibernation. */
+export function durableObjectProviderTokenStore(
+  storage: DurableObjectStorageLike
+): ProviderTokenStore {
+  return {
+    async load() {
+      const stored = await storage.get<ApnsProviderToken>(APNS_TOKEN_STORAGE_KEY);
+      return isProviderToken(stored) ? stored : null;
+    },
+    async save(token) {
+      await storage.put(APNS_TOKEN_STORAGE_KEY, token);
+    },
+  };
+}
+
+/**
+ * Serve the current provider token to a borrowing tray DO. Runs *on* the
+ * minting instance, against its local minter — never over the network, so
+ * there is no self-fetch and no chance of a DO deadlocking on itself.
+ */
+export async function handleProviderTokenRequest(
+  request: Request,
+  minter: ApnsProviderTokenSource
+): Promise<Response> {
+  let staleToken: string | undefined;
+  try {
+    const body = (await request.json()) as { staleToken?: unknown };
+    if (typeof body?.staleToken === 'string' && body.staleToken) staleToken = body.staleToken;
+  } catch {
+    // No body / not JSON: treat as a plain "give me the current token".
+  }
+  const token = await minter.getToken(staleToken);
+  return jsonResponse(token);
+}
+
+/**
+ * Borrows the provider JWT from the singleton instead of minting locally.
+ *
+ * Falls back to `fallbackMinter` when the singleton cannot be reached: one DO
+ * minting for itself is bounded by its own 20-minute floor, which is a far
+ * better failure mode than every push dying because a single object is
+ * unavailable. The fallback is loud so the condition is not silent.
+ */
+export class SharedProviderTokenSource implements ApnsProviderTokenSource {
+  private memo: ApnsProviderToken | null = null;
+
+  constructor(
+    private readonly namespace: DurableObjectNamespaceLike,
+    private readonly fallbackMinter: ApnsProviderTokenSource,
+    private readonly now: () => number
+  ) {}
+
+  async getToken(staleToken?: string): Promise<ApnsProviderToken> {
+    const memo = this.memo;
+    if (memo && staleToken === undefined && this.now() - memo.mintedAt < BORROWED_TOKEN_TTL_MS) {
+      return memo;
+    }
+    try {
+      const token = await this.fetchFromSingleton(staleToken);
+      this.memo = token;
+      return token;
+    } catch (err) {
+      console.warn('[push] shared APNs provider token unavailable — minting locally', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return this.fallbackMinter.getToken(staleToken);
+    }
+  }
+
+  private async fetchFromSingleton(staleToken?: string): Promise<ApnsProviderToken> {
+    const stub: DurableObjectStubLike = this.namespace.get(
+      this.namespace.idFromName(APNS_TOKEN_DO_NAME)
+    );
+    const response = await stub.fetch(
+      new Request(`${INTERNAL_ORIGIN}${APNS_TOKEN_PATH}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(staleToken ? { staleToken } : {}),
+      })
+    );
+    if (!response.ok) {
+      throw new Error(`provider-token DO responded ${response.status}`);
+    }
+    const token = (await response.json()) as unknown;
+    if (!isProviderToken(token)) {
+      throw new Error('provider-token DO returned a malformed token');
+    }
+    return token;
+  }
+}

--- a/packages/cloudflare-worker/src/apns-provider-token.ts
+++ b/packages/cloudflare-worker/src/apns-provider-token.ts
@@ -41,6 +41,11 @@ export const APNS_TOKEN_STORAGE_KEY = 'apns:provider-token';
  * minute 49 is not held past Apple's 60-minute expiry.
  */
 const BORROWED_TOKEN_TTL_MS = 50 * 60 * 1000;
+/**
+ * Absolute age past which a borrowed token is never reused, even to ride out an
+ * outage of the minting instance. Apple expires provider tokens at 60 minutes.
+ */
+const BORROWED_TOKEN_MAX_AGE_MS = 55 * 60 * 1000;
 
 /** Any URL works for a DO stub fetch; only the path is routed. */
 const INTERNAL_ORIGIN = 'https://tray-hub.internal';
@@ -92,19 +97,22 @@ export async function handleProviderTokenRequest(
 }
 
 /**
- * Borrows the provider JWT from the singleton instead of minting locally.
+ * Borrows the provider JWT from the minting instance.
  *
- * Falls back to `fallbackMinter` when the singleton cannot be reached: one DO
- * minting for itself is bounded by its own 20-minute floor, which is a far
- * better failure mode than every push dying because a single object is
- * unavailable. The fallback is loud so the condition is not silent.
+ * When that instance cannot be reached this deliberately does **not** mint
+ * locally. Doing so would put every waking tray back to signing its own JWT —
+ * precisely the behaviour this module exists to remove — converting a brief,
+ * local outage into account-wide `429 TooManyProviderTokenUpdates` that outlasts
+ * it and fails the pushes anyway. A still-valid borrowed token is reused if this
+ * instance happens to hold one; otherwise the push fails loudly. Pushes are
+ * best-effort wake-ups — the request itself travels over the data channel — so
+ * losing one costs far less than throttling the whole key.
  */
 export class SharedProviderTokenSource implements ApnsProviderTokenSource {
   private memo: ApnsProviderToken | null = null;
 
   constructor(
     private readonly namespace: DurableObjectNamespaceLike,
-    private readonly fallbackMinter: ApnsProviderTokenSource,
     private readonly now: () => number
   ) {}
 
@@ -118,10 +126,21 @@ export class SharedProviderTokenSource implements ApnsProviderTokenSource {
       this.memo = token;
       return token;
     } catch (err) {
-      console.warn('[push] shared APNs provider token unavailable — minting locally', {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      return this.fallbackMinter.getToken(staleToken);
+      const error = err instanceof Error ? err.message : String(err);
+      // Only worth riding out with a token the gateway has not rejected and
+      // that Apple will still accept.
+      if (
+        memo &&
+        memo.value !== staleToken &&
+        this.now() - memo.mintedAt < BORROWED_TOKEN_MAX_AGE_MS
+      ) {
+        console.warn('[push] APNs provider-token instance unreachable — reusing borrowed token', {
+          error,
+        });
+        return memo;
+      }
+      console.warn('[push] APNs provider-token instance unreachable — dropping push', { error });
+      throw err;
     }
   }
 

--- a/packages/cloudflare-worker/src/apns.ts
+++ b/packages/cloudflare-worker/src/apns.ts
@@ -72,6 +72,14 @@ export interface ApnsPushResult {
 export interface ApnsProviderToken {
   value: string;
   mintedAt: number;
+  /**
+   * `teamId.keyId` of the credentials that signed it. Apple's 20-minute floor
+   * is per key pair, so a token from *different* credentials is not merely
+   * stale — it must be discarded and re-minted at once, or a key rotation
+   * would disable pushes for the length of the floor (a revoked key answers
+   * `InvalidProviderToken`, which the floor otherwise refuses to act on).
+   */
+  identity: string;
 }
 
 /**
@@ -226,6 +234,7 @@ export class LocalProviderTokenMinter implements ApnsProviderTokenSource {
   private mintInFlight: Promise<ApnsProviderToken> | null = null;
   private readonly now: () => number;
   private readonly store: ProviderTokenStore | undefined;
+  private readonly identity: string;
 
   constructor(
     private readonly config: ApnsConfig,
@@ -233,6 +242,7 @@ export class LocalProviderTokenMinter implements ApnsProviderTokenSource {
   ) {
     this.now = deps.now ?? (() => Date.now());
     this.store = deps.store;
+    this.identity = providerTokenIdentity(config);
   }
 
   async getToken(staleToken?: string): Promise<ApnsProviderToken> {
@@ -253,7 +263,12 @@ export class LocalProviderTokenMinter implements ApnsProviderTokenSource {
 
   private async loadCached(): Promise<ApnsProviderToken | null> {
     if (this.cached) return this.cached;
-    this.cached = (await this.store?.load()) ?? null;
+    const stored = (await this.store?.load()) ?? null;
+    // Signed by credentials we no longer hold (rotated key id / team id, or a
+    // record predating this field): unusable, and holding it would stall the
+    // first mint under the floor. Drop it and sign fresh — the new key pair
+    // has its own budget with Apple.
+    this.cached = stored && stored.identity === this.identity ? stored : null;
     return this.cached;
   }
 
@@ -299,8 +314,14 @@ export class LocalProviderTokenMinter implements ApnsProviderTokenSource {
     return {
       value: `${signingInput}.${base64UrlEncode(new Uint8Array(signature))}`,
       mintedAt: now,
+      identity: this.identity,
     };
   }
+}
+
+/** Which credentials signed a token — see {@link ApnsProviderToken.identity}. */
+export function providerTokenIdentity(config: Pick<ApnsConfig, 'teamId' | 'keyId'>): string {
+  return `${config.teamId}.${config.keyId}`;
 }
 
 /** Blips worth one retry. A timeout is excluded: it already cost the full budget. */

--- a/packages/cloudflare-worker/src/apns.ts
+++ b/packages/cloudflare-worker/src/apns.ts
@@ -8,12 +8,20 @@
  * content; the phone reconnects and fetches the real request over the data
  * channel.
  *
- * Auth is token-based (a `.p8` key): an ES256 JWT signed with WebCrypto,
- * cached for 50 minutes (Apple: refresh at least hourly, at most every 20
- * minutes). Missing secrets disable pushing entirely — the DO logs once and
- * treats every send as a no-op, so the rest of the tray never depends on APNs.
+ * Auth is token-based (a `.p8` key): an ES256 JWT signed with WebCrypto.
+ * Apple throttles provider-token *creation* per (team id, key id) pair — not
+ * per connection — and answers `429 TooManyProviderTokenUpdates` to a provider
+ * that recreates tokens more than once every 20 minutes, so minting is
+ * deliberately split out behind {@link ApnsProviderTokenSource}. One tray DO
+ * per tray, each minting its own JWT, would blow that budget at a handful of
+ * concurrent trays; `apns-provider-token.ts` funnels every DO through a single
+ * minting instance. Missing secrets disable pushing entirely — the DO logs once
+ * and treats every send as a no-op, so the rest of the tray never depends on
+ * APNs.
  *
- * APNs requires HTTP/2; Workers' `fetch` negotiates it with Apple's gateway.
+ * APNs requires HTTP/2. Deployed Workers negotiate it with Apple's gateway;
+ * `wrangler dev` on macOS does not (workerd#4841), so local runs of this path
+ * fail in a way staging does not.
  */
 
 export interface ApnsConfig {
@@ -47,6 +55,43 @@ export interface ApnsPushResult {
   reason?: string;
   /** True when the token is dead and must be forgotten (410 / BadDeviceToken). */
   dropToken: boolean;
+  /**
+   * `apns-unique-id` response header. Apple asks for this when investigating a
+   * push that never arrived, and it is the only handle on a specific delivery.
+   */
+  uniqueId?: string;
+  /**
+   * `timestamp` from a 410 body: when the device token stopped being valid.
+   * A registration newer than this instant is still live, so the caller keeps
+   * it (see `handlePushSend`). Absent on 400 BadDeviceToken, which is final.
+   */
+  invalidatedAtMs?: number;
+}
+
+/** A minted provider JWT and the instant it was signed. */
+export interface ApnsProviderToken {
+  value: string;
+  mintedAt: number;
+}
+
+/**
+ * Supplies the provider JWT. Implementations are shared across tray DOs, so
+ * `getToken` is expected to hand back a *cached* token almost every time.
+ */
+export interface ApnsProviderTokenSource {
+  /**
+   * The current provider JWT. Pass `staleToken` — the exact value APNs just
+   * rejected — to ask for a replacement; the source rotates only when its own
+   * cached token still matches, so a herd of DOs reporting the same rejection
+   * causes one mint, not one per caller.
+   */
+  getToken(staleToken?: string): Promise<ApnsProviderToken>;
+}
+
+/** Durable place to keep the minted JWT so DO hibernation does not re-mint. */
+export interface ProviderTokenStore {
+  load(): Promise<ApnsProviderToken | null>;
+  save(token: ApnsProviderToken): Promise<void>;
 }
 
 /** Something that can deliver one push. The DO holds one; tests inject a fake. */
@@ -73,15 +118,38 @@ export const APNS_CATEGORY_IDS: Record<PushCategory, string> = {
   sudo_request: 'SLICC_SUDO_REQUEST',
 };
 
+/** Rotate at 50 min: inside Apple's 60-minute expiry, outside its 20-minute floor. */
 const JWT_TTL_MS = 50 * 60 * 1000;
+/**
+ * Apple's floor on provider-token creation. Minting more often than this earns
+ * `429 TooManyProviderTokenUpdates`, which outlasts the push that triggered it,
+ * so this is enforced even when a caller reports its token rejected.
+ */
+export const JWT_MIN_MINT_INTERVAL_MS = 20 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 8_000;
+/** Reason reported when the gateway never answered inside the budget. */
+export const APNS_TIMEOUT_REASON = 'APNs request timed out';
+/** One short retry for a blip; long enough to clear, short enough to not stall the DO. */
+const TRANSIENT_RETRY_DELAY_MS = 250;
 /** Sudo banners are pointless after the leader's 5-minute deadline. */
 const SUDO_EXPIRY_SECONDS = 5 * 60;
 
 /** Reasons that mean "this token will never work again". */
 const DEAD_TOKEN_REASONS = new Set(['BadDeviceToken', 'Unregistered', 'DeviceTokenNotForTopic']);
-/** Reasons that mean "our JWT is bad; mint a fresh one and retry once". */
-const STALE_JWT_REASONS = new Set(['ExpiredProviderToken', 'InvalidProviderToken']);
+/**
+ * Reasons that mean "the JWT we presented is not usable; ask the source for the
+ * current one". `TooManyProviderTokenUpdates` belongs here even though nothing
+ * is wrong with our token: it means another minter rotated recently, so the
+ * shared source very likely holds a newer token we should be using instead.
+ * Crucially it must never *cause* a mint — the source's floor guarantees that.
+ */
+const STALE_JWT_REASONS = new Set([
+  'ExpiredProviderToken',
+  'InvalidProviderToken',
+  'TooManyProviderTokenUpdates',
+]);
+/** Server-side blips worth exactly one more attempt. */
+const TRANSIENT_STATUSES = new Set([500, 503]);
 
 export function apnsHost(environment: ApnsEnvironment): string {
   return environment === 'production'
@@ -146,16 +214,62 @@ export function buildApnsPayload(request: ApnsPushRequest): ApnsPayload {
 }
 
 /**
- * Production sender: signs JWTs with WebCrypto and POSTs to APNs over `fetch`.
+ * Signs provider JWTs with WebCrypto and caches the result, optionally through
+ * a {@link ProviderTokenStore} so a hibernated Durable Object resumes with the
+ * same token instead of minting a fresh one on every wake.
+ *
+ * One of these should be live per worker, not per tray — see the module doc.
  */
-export class WebCryptoApnsSender implements ApnsSender {
-  private jwt: { value: string; mintedAt: number } | null = null;
+export class LocalProviderTokenMinter implements ApnsProviderTokenSource {
+  private cached: ApnsProviderToken | null = null;
   private keyPromise: Promise<CryptoKey> | null = null;
+  private mintInFlight: Promise<ApnsProviderToken> | null = null;
+  private readonly now: () => number;
+  private readonly store: ProviderTokenStore | undefined;
 
   constructor(
     private readonly config: ApnsConfig,
-    private readonly deps: { fetchImpl?: typeof fetch; now?: () => number } = {}
-  ) {}
+    deps: { now?: () => number; store?: ProviderTokenStore } = {}
+  ) {
+    this.now = deps.now ?? (() => Date.now());
+    this.store = deps.store;
+  }
+
+  async getToken(staleToken?: string): Promise<ApnsProviderToken> {
+    const cached = await this.loadCached();
+    const now = this.now();
+    if (cached) {
+      // Someone already rotated past the token this caller had rejected.
+      if (staleToken !== undefined && cached.value !== staleToken) return cached;
+      if (staleToken === undefined && now - cached.mintedAt < JWT_TTL_MS) return cached;
+      // Rotating now would trip Apple's 20-minute floor, and the 429 that earns
+      // costs more than the one push we are trying to rescue. Re-minting a
+      // token seconds old would also reproduce the same `iat`, so a caller
+      // reporting a just-minted token stale gains nothing from a fresh one.
+      if (now - cached.mintedAt < JWT_MIN_MINT_INTERVAL_MS) return cached;
+    }
+    return this.mintShared(now);
+  }
+
+  private async loadCached(): Promise<ApnsProviderToken | null> {
+    if (this.cached) return this.cached;
+    this.cached = (await this.store?.load()) ?? null;
+    return this.cached;
+  }
+
+  /** Collapse concurrent callers onto one signature + one store write. */
+  private mintShared(now: number): Promise<ApnsProviderToken> {
+    this.mintInFlight ??= this.mint(now)
+      .then(async (token) => {
+        this.cached = token;
+        await this.store?.save(token);
+        return token;
+      })
+      .finally(() => {
+        this.mintInFlight = null;
+      });
+    return this.mintInFlight;
+  }
 
   private importKey(): Promise<CryptoKey> {
     this.keyPromise ??= crypto.subtle.importKey(
@@ -168,10 +282,7 @@ export class WebCryptoApnsSender implements ApnsSender {
     return this.keyPromise;
   }
 
-  /** Current provider JWT, minting a fresh one when missing or older than 50 min. */
-  async providerToken(forceRefresh = false): Promise<string> {
-    const now = this.deps.now?.() ?? Date.now();
-    if (!forceRefresh && this.jwt && now - this.jwt.mintedAt < JWT_TTL_MS) return this.jwt.value;
+  private async mint(now: number): Promise<ApnsProviderToken> {
     const enc = new TextEncoder();
     const header = base64UrlEncode(
       enc.encode(JSON.stringify({ alg: 'ES256', kid: this.config.keyId }))
@@ -185,22 +296,61 @@ export class WebCryptoApnsSender implements ApnsSender {
       await this.importKey(),
       enc.encode(signingInput)
     );
-    const value = `${signingInput}.${base64UrlEncode(new Uint8Array(signature))}`;
-    this.jwt = { value, mintedAt: now };
-    return value;
+    return {
+      value: `${signingInput}.${base64UrlEncode(new Uint8Array(signature))}`,
+      mintedAt: now,
+    };
+  }
+}
+
+/** Blips worth one retry. A timeout is excluded: it already cost the full budget. */
+function isRetryable(result: ApnsPushResult): boolean {
+  if (TRANSIENT_STATUSES.has(result.status)) return true;
+  return result.status === 0 && result.reason !== APNS_TIMEOUT_REASON;
+}
+
+/**
+ * Production sender: POSTs to APNs over `fetch`, taking its provider JWT from
+ * an {@link ApnsProviderTokenSource} rather than minting per instance.
+ */
+export class WebCryptoApnsSender implements ApnsSender {
+  private readonly tokenSource: ApnsProviderTokenSource;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(
+    private readonly config: ApnsConfig,
+    private readonly deps: {
+      fetchImpl?: typeof fetch;
+      now?: () => number;
+      tokenSource?: ApnsProviderTokenSource;
+      sleep?: (ms: number) => Promise<void>;
+    } = {}
+  ) {
+    this.tokenSource = deps.tokenSource ?? new LocalProviderTokenMinter(config, { now: deps.now });
+    this.sleep = deps.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
   }
 
   async send(request: ApnsPushRequest): Promise<ApnsPushResult> {
-    const first = await this.post(request, await this.providerToken());
+    const token = await this.tokenSource.getToken();
+    const first = await this.post(request, token.value);
+
     if (first.reason && STALE_JWT_REASONS.has(first.reason)) {
-      return this.post(request, await this.providerToken(true));
+      const refreshed = await this.tokenSource.getToken(token.value);
+      // Re-posting the very token Apple just rejected only burns a second
+      // request; the source declining to rotate is its answer, not a hint to
+      // try again. Retry only against a genuinely different token.
+      if (refreshed.value === token.value) return first;
+      return this.post(request, refreshed.value);
+    }
+
+    if (isRetryable(first)) {
+      await this.sleep(TRANSIENT_RETRY_DELAY_MS);
+      return this.post(request, token.value);
     }
     return first;
   }
 
-  private async post(request: ApnsPushRequest, jwt: string): Promise<ApnsPushResult> {
-    const fetchImpl = this.deps.fetchImpl ?? fetch;
-    const sudo = request.category === 'sudo_request';
+  private buildHeaders(request: ApnsPushRequest, jwt: string): Record<string, string> {
     const headers: Record<string, string> = {
       authorization: `bearer ${jwt}`,
       'apns-topic': this.config.topic,
@@ -208,27 +358,44 @@ export class WebCryptoApnsSender implements ApnsSender {
       'apns-priority': '10',
       'content-type': 'application/json',
     };
-    if (sudo) {
+    if (request.category === 'sudo_request') {
       const now = this.deps.now?.() ?? Date.now();
       headers['apns-expiration'] = String(Math.floor(now / 1000) + SUDO_EXPIRY_SECONDS);
       if (request.requestId) headers['apns-collapse-id'] = request.requestId.slice(0, 64);
     } else {
       headers['apns-collapse-id'] = `turn-end:${request.trayId}`.slice(0, 64);
     }
+    return headers;
+  }
+
+  private async post(request: ApnsPushRequest, jwt: string): Promise<ApnsPushResult> {
+    const fetchImpl = this.deps.fetchImpl ?? fetch;
+    // An AbortController whose timer is cleared, rather than
+    // `AbortSignal.timeout`: that one stays armed after the response lands and
+    // keeps the Durable Object's IO context alive for the full budget, billing
+    // ~8s of wall time for every push that actually succeeded (issue #2432).
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
     try {
       const response = await fetchImpl(
         `${apnsHost(request.environment)}/3/device/${request.token}`,
         {
           method: 'POST',
-          headers,
+          headers: this.buildHeaders(request, jwt),
           body: JSON.stringify(buildApnsPayload(request)),
-          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+          signal: controller.signal,
         }
       );
+      const uniqueId = response.headers.get('apns-unique-id') ?? undefined;
       let reason: string | undefined;
+      let invalidatedAtMs: number | undefined;
       if (!response.ok) {
         try {
-          reason = ((await response.json()) as { reason?: string }).reason;
+          const body = (await response.json()) as { reason?: string; timestamp?: number };
+          reason = body.reason;
+          if (typeof body.timestamp === 'number' && Number.isFinite(body.timestamp)) {
+            invalidatedAtMs = body.timestamp;
+          }
         } catch {
           reason = undefined;
         }
@@ -239,14 +406,19 @@ export class WebCryptoApnsSender implements ApnsSender {
         ...(reason ? { reason } : {}),
         dropToken:
           response.status === 410 || (reason !== undefined && DEAD_TOKEN_REASONS.has(reason)),
+        ...(uniqueId ? { uniqueId } : {}),
+        ...(invalidatedAtMs !== undefined ? { invalidatedAtMs } : {}),
       };
     } catch (err) {
+      const aborted = err instanceof Error && err.name === 'AbortError';
       return {
         token: request.token,
         status: 0,
-        reason: err instanceof Error ? err.message : String(err),
+        reason: aborted ? APNS_TIMEOUT_REASON : err instanceof Error ? err.message : String(err),
         dropToken: false,
       };
+    } finally {
+      clearTimeout(timer);
     }
   }
 }

--- a/packages/cloudflare-worker/src/session-tray.ts
+++ b/packages/cloudflare-worker/src/session-tray.ts
@@ -17,7 +17,20 @@ import {
   type TurnIceServer,
   type WorkerToLeaderControlMessage,
 } from '@slicc/shared-ts';
-import { type ApnsSender, apnsConfigFromEnv, WebCryptoApnsSender } from './apns.js';
+import {
+  type ApnsProviderTokenSource,
+  type ApnsPushResult,
+  type ApnsSender,
+  apnsConfigFromEnv,
+  LocalProviderTokenMinter,
+  WebCryptoApnsSender,
+} from './apns.js';
+import {
+  APNS_TOKEN_PATH,
+  durableObjectProviderTokenStore,
+  handleProviderTokenRequest,
+  SharedProviderTokenSource,
+} from './apns-provider-token.js';
 import { deletePreviewArchivePrefix } from './persistent-preview-storage.js';
 import { previewTokenFromHost } from './preview-host.js';
 import {
@@ -37,6 +50,7 @@ import {
 } from './session-tray-preview.js';
 import {
   type CreateTrayRequest,
+  type DurableObjectNamespaceLike,
   type DurableObjectStateLike,
   FOLLOWER_ATTACH_RETRY_AFTER_MS,
   jsonResponse,
@@ -72,6 +86,12 @@ export interface SessionTrayEnv {
   APNS_KEY_ID?: string;
   APNS_PRIVATE_KEY?: string;
   APNS_TOPIC?: string;
+  /**
+   * This DO's own namespace, used to reach the one instance that mints the
+   * APNs provider JWT (see `apns-provider-token.ts`). Absent in unit tests,
+   * which fall back to minting locally.
+   */
+  TRAY_HUB?: DurableObjectNamespaceLike;
 }
 
 interface SessionTrayOptions {
@@ -137,6 +157,11 @@ export class SessionTrayDurableObject {
   private readonly turnApiToken: string | undefined;
   private readonly previewStorage: R2Bucket | undefined;
   private readonly apns: ApnsSender | null;
+  /**
+   * Local minter, used only when *this* instance is the one serving
+   * `APNS_TOKEN_PATH`. Also the fallback if the shared instance is unreachable.
+   */
+  private readonly apnsTokenMinter: ApnsProviderTokenSource | null;
   private apnsDisabledLogged = false;
   private tray: TrayRecord | null = null;
   private leaderSocket: TrayWebSocketLike | null = null;
@@ -165,13 +190,28 @@ export class SessionTrayDurableObject {
     this.turnKeyId = typedEnv.CLOUDFLARE_TURN_KEY_ID;
     this.turnApiToken = typedEnv.CLOUDFLARE_TURN_API_TOKEN;
     this.previewStorage = typedEnv.PREVIEW_STORAGE;
+    const apnsConfig = apnsConfigFromEnv(typedEnv);
+    this.apnsTokenMinter = apnsConfig
+      ? new LocalProviderTokenMinter(apnsConfig, {
+          now: this.now,
+          store: durableObjectProviderTokenStore(this.state.storage),
+        })
+      : null;
     if (options.apnsSender !== undefined) {
       this.apns = options.apnsSender;
+    } else if (apnsConfig && this.apnsTokenMinter) {
+      // Borrow the JWT from the single minting instance so mint rate stops
+      // scaling with tray count × hibernation cycles (issue #2432).
+      const tokenSource = typedEnv.TRAY_HUB
+        ? new SharedProviderTokenSource(typedEnv.TRAY_HUB, this.apnsTokenMinter, this.now)
+        : this.apnsTokenMinter;
+      this.apns = new WebCryptoApnsSender(apnsConfig, {
+        fetchImpl: this.fetchImpl,
+        now: this.now,
+        tokenSource,
+      });
     } else {
-      const apnsConfig = apnsConfigFromEnv(typedEnv);
-      this.apns = apnsConfig
-        ? new WebCryptoApnsSender(apnsConfig, { fetchImpl: this.fetchImpl, now: this.now })
-        : null;
+      this.apns = null;
     }
     this.webSocketPairFactory =
       options.webSocketPairFactory ??
@@ -194,6 +234,12 @@ export class SessionTrayDurableObject {
 
     if (url.pathname === '/internal/create' && request.method === 'POST') {
       return this.handleCreate(request);
+    }
+
+    // Served by the one well-known instance every other tray DO borrows from.
+    // Handled before loadTray(): that instance owns no tray record.
+    if (url.pathname === APNS_TOKEN_PATH) {
+      return this.handleApnsTokenRequest(request);
     }
 
     // Preview routes below dispatch before the general loadTray()/restoreLeaderSocket()
@@ -1977,28 +2023,63 @@ export class SessionTrayDurableObject {
           label,
           trayId: tray.trayId,
           ...(requestId ? { requestId } : {}),
-        }).catch((err) => ({
-          token,
-          status: 0,
-          reason: err instanceof Error ? err.message : String(err),
-          dropToken: false,
-        }))
+        }).catch(
+          (err): ApnsPushResult => ({
+            token,
+            status: 0,
+            reason: err instanceof Error ? err.message : String(err),
+            dropToken: false,
+          })
+        )
       )
     );
     let mutated = false;
     for (const result of results) {
-      if (result.dropToken) {
+      if (result.dropToken && this.forgetsPushToken(tray, result)) {
         delete tray.pushTokens?.[result.token];
         mutated = true;
-      } else if (result.status !== 200) {
+        continue;
+      }
+      if (result.status !== 200) {
         console.warn('[push] APNs delivery failed', {
           trayId: tray.trayId,
           status: result.status,
           reason: result.reason,
+          // Apple asks for this id when investigating a push that never landed.
+          ...(result.uniqueId ? { uniqueId: result.uniqueId } : {}),
         });
       }
     }
     if (mutated) await this.persistTray();
+  }
+
+  /** Mint-or-serve the shared APNs provider JWT. See `apns-provider-token.ts`. */
+  private handleApnsTokenRequest(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+      return Promise.resolve(jsonResponse({ error: 'Method not allowed' }, 405));
+    }
+    if (!this.apnsTokenMinter) {
+      return Promise.resolve(
+        jsonResponse({ error: 'APNs is not configured', code: 'APNS_NOT_CONFIGURED' }, 503)
+      );
+    }
+    return handleProviderTokenRequest(request, this.apnsTokenMinter);
+  }
+
+  /**
+   * Should a dead-token verdict actually evict the registration? Apple's 410
+   * body carries the instant the token stopped being valid; a device that
+   * re-registered after that instant has a live token again and must be kept,
+   * or a reconnect race silently unsubscribes a phone that is right there.
+   * A 400 `BadDeviceToken` carries no timestamp and is unconditionally final.
+   */
+  private forgetsPushToken(tray: TrayRecord, result: ApnsPushResult): boolean {
+    if (result.invalidatedAtMs === undefined) return true;
+    const record = tray.pushTokens?.[result.token];
+    if (!record) return true;
+    const registeredAtMs = Date.parse(record.registeredAt);
+    if (!Number.isFinite(registeredAtMs)) return true;
+    return registeredAtMs < result.invalidatedAtMs;
   }
 
   private async persistTray(): Promise<void> {

--- a/packages/cloudflare-worker/src/session-tray.ts
+++ b/packages/cloudflare-worker/src/session-tray.ts
@@ -203,7 +203,7 @@ export class SessionTrayDurableObject {
       // Borrow the JWT from the single minting instance so mint rate stops
       // scaling with tray count × hibernation cycles (issue #2432).
       const tokenSource = typedEnv.TRAY_HUB
-        ? new SharedProviderTokenSource(typedEnv.TRAY_HUB, this.apnsTokenMinter, this.now)
+        ? new SharedProviderTokenSource(typedEnv.TRAY_HUB, this.now)
         : this.apnsTokenMinter;
       this.apns = new WebCryptoApnsSender(apnsConfig, {
         fetchImpl: this.fetchImpl,

--- a/packages/cloudflare-worker/tests/apns-provider-token.test.ts
+++ b/packages/cloudflare-worker/tests/apns-provider-token.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Shared APNs provider token (issue #2432).
+ *
+ * Apple throttles provider-token creation per (team id, key id) pair, so the
+ * property under test is a *count*: however many tray Durable Objects push,
+ * and however often hibernation reconstructs them, exactly one JWT gets
+ * signed. The old code signed one per DO per wake.
+ */
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  type ApnsProviderToken,
+  type ApnsProviderTokenSource,
+  LocalProviderTokenMinter,
+} from '../src/apns.js';
+import {
+  APNS_TOKEN_DO_NAME,
+  APNS_TOKEN_PATH,
+  APNS_TOKEN_STORAGE_KEY,
+  durableObjectProviderTokenStore,
+  handleProviderTokenRequest,
+  SharedProviderTokenSource,
+} from '../src/apns-provider-token.js';
+import { SessionTrayDurableObject } from '../src/session-tray.js';
+import type { DurableObjectNamespaceLike, DurableObjectStubLike } from '../src/shared.js';
+import { createCapabilityToken } from '../src/shared.js';
+import { createFakeWebSocketPair, FakeDurableObjectState, FakeStorage } from './fake-do-state.js';
+
+const HOST = 'https://www.sliccy.ai';
+let pem = '';
+
+beforeAll(async () => {
+  const pair = (await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ])) as CryptoKeyPair;
+  const pkcs8 = (await crypto.subtle.exportKey('pkcs8', pair.privateKey)) as ArrayBuffer;
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(pkcs8)));
+  pem = `-----BEGIN PRIVATE KEY-----\n${(b64.match(/.{1,64}/g) ?? []).join('\n')}\n-----END PRIVATE KEY-----\n`;
+});
+
+const APNS_ENV = () => ({
+  APNS_TEAM_ID: 'TEAM1234',
+  APNS_KEY_ID: 'KEY5678',
+  APNS_PRIVATE_KEY: pem,
+  APNS_TOPIC: 'com.sliccy.follower',
+});
+
+const CONFIG = () => ({
+  teamId: 'TEAM1234',
+  keyId: 'KEY5678',
+  privateKeyPem: pem,
+  topic: 'com.sliccy.follower',
+});
+
+describe('durableObjectProviderTokenStore', () => {
+  it('round-trips a token and rejects a malformed stored value', async () => {
+    const storage = new FakeStorage();
+    const store = durableObjectProviderTokenStore(storage);
+    expect(await store.load()).toBeNull();
+
+    await store.save({ value: 'jwt', mintedAt: 42 });
+    expect(await store.load()).toEqual({ value: 'jwt', mintedAt: 42 });
+
+    // A half-written or older-shaped record must not be handed to APNs.
+    await storage.put(APNS_TOKEN_STORAGE_KEY, { value: '', mintedAt: 'nope' });
+    expect(await store.load()).toBeNull();
+  });
+});
+
+describe('handleProviderTokenRequest', () => {
+  it('serves the current token and forwards a stale-token rotation request', async () => {
+    const asked: Array<string | undefined> = [];
+    const minter: ApnsProviderTokenSource = {
+      async getToken(staleToken?: string): Promise<ApnsProviderToken> {
+        asked.push(staleToken);
+        return { value: staleToken ? 'jwt-2' : 'jwt-1', mintedAt: 7 };
+      },
+    };
+
+    const plain = await handleProviderTokenRequest(
+      new Request(`${HOST}${APNS_TOKEN_PATH}`, { method: 'POST', body: '{}' }),
+      minter
+    );
+    expect(await plain.json()).toEqual({ value: 'jwt-1', mintedAt: 7 });
+
+    const rotate = await handleProviderTokenRequest(
+      new Request(`${HOST}${APNS_TOKEN_PATH}`, {
+        method: 'POST',
+        body: JSON.stringify({ staleToken: 'jwt-1' }),
+      }),
+      minter
+    );
+    expect(await rotate.json()).toEqual({ value: 'jwt-2', mintedAt: 7 });
+    expect(asked).toEqual([undefined, 'jwt-1']);
+  });
+
+  it('tolerates a missing or unparseable body', async () => {
+    const minter = new LocalProviderTokenMinter(CONFIG(), { now: () => 1_000 });
+    const response = await handleProviderTokenRequest(
+      new Request(`${HOST}${APNS_TOKEN_PATH}`, { method: 'POST', body: 'not json' }),
+      minter
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ mintedAt: 1_000 });
+  });
+});
+
+describe('SharedProviderTokenSource', () => {
+  function fakeNamespace(stub: DurableObjectStubLike): DurableObjectNamespaceLike & {
+    names: string[];
+  } {
+    const names: string[] = [];
+    return {
+      names,
+      idFromName(name: string) {
+        names.push(name);
+        return { toString: () => name } as unknown as ReturnType<
+          DurableObjectNamespaceLike['idFromName']
+        >;
+      },
+      get: () => stub,
+    };
+  }
+
+  it('borrows from the well-known instance and memoises by mint time', async () => {
+    let served = 0;
+    const stub: DurableObjectStubLike = {
+      fetch: async () => {
+        served += 1;
+        return Response.json({ value: 'shared-jwt', mintedAt: 1_000 });
+      },
+    };
+    const ns = fakeNamespace(stub);
+    let now = 1_000;
+    const source = new SharedProviderTokenSource(
+      ns,
+      new LocalProviderTokenMinter(CONFIG(), { now: () => now }),
+      () => now
+    );
+
+    expect((await source.getToken()).value).toBe('shared-jwt');
+    expect(ns.names).toEqual([APNS_TOKEN_DO_NAME]);
+
+    // Within the borrowed token's life: no second round trip.
+    now = 1_000 + 40 * 60 * 1000;
+    expect((await source.getToken()).value).toBe('shared-jwt');
+    expect(served).toBe(1);
+
+    // Past it: ask again rather than ride a token toward Apple's 60-min expiry.
+    now = 1_000 + 51 * 60 * 1000;
+    await source.getToken();
+    expect(served).toBe(2);
+  });
+
+  it('always re-asks when reporting a stale token, ignoring the memo', async () => {
+    const bodies: string[] = [];
+    const stub: DurableObjectStubLike = {
+      fetch: async (input) => {
+        bodies.push(await (input as Request).text());
+        return Response.json({ value: 'shared-jwt', mintedAt: 1_000 });
+      },
+    };
+    const source = new SharedProviderTokenSource(
+      fakeNamespace(stub),
+      new LocalProviderTokenMinter(CONFIG()),
+      () => 1_000
+    );
+    await source.getToken();
+    await source.getToken('shared-jwt');
+    expect(bodies).toEqual(['{}', JSON.stringify({ staleToken: 'shared-jwt' })]);
+  });
+
+  it('falls back to local minting when the shared instance is unreachable', async () => {
+    // A single object being down must not take every push with it; the local
+    // minter carries its own 20-minute floor, so the blast radius is bounded.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const stub: DurableObjectStubLike = {
+      fetch: async () => {
+        throw new Error('DO unavailable');
+      },
+    };
+    const source = new SharedProviderTokenSource(
+      fakeNamespace(stub),
+      new LocalProviderTokenMinter(CONFIG(), { now: () => 5_000 }),
+      () => 5_000
+    );
+    await expect(source.getToken()).resolves.toMatchObject({ mintedAt: 5_000 });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('shared APNs provider token unavailable'),
+      expect.anything()
+    );
+    warn.mockRestore();
+  });
+
+  it('falls back when the shared instance answers with an error or junk', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const erroring = new SharedProviderTokenSource(
+      fakeNamespace({ fetch: async () => new Response('nope', { status: 503 }) }),
+      new LocalProviderTokenMinter(CONFIG(), { now: () => 1 }),
+      () => 1
+    );
+    await expect(erroring.getToken()).resolves.toMatchObject({ mintedAt: 1 });
+
+    const junk = new SharedProviderTokenSource(
+      fakeNamespace({ fetch: async () => Response.json({ nope: true }) }),
+      new LocalProviderTokenMinter(CONFIG(), { now: () => 2 }),
+      () => 2
+    );
+    await expect(junk.getToken()).resolves.toMatchObject({ mintedAt: 2 });
+    warn.mockRestore();
+  });
+});
+
+describe('SessionTrayDurableObject provider-token route', () => {
+  function makeDurable(env: Record<string, unknown>, state = new FakeDurableObjectState()) {
+    const durable = new SessionTrayDurableObject(state, env, {
+      now: () => 1_750_000_000_000,
+      webSocketPairFactory: () => createFakeWebSocketPair(state),
+    });
+    state.instance = durable;
+    return { durable, state };
+  }
+
+  it('serves the token without needing a tray record on that instance', async () => {
+    // The minting instance is reached by name, never created via /internal/create,
+    // so this route has to work before (and without) loadTray().
+    const { durable } = makeDurable(APNS_ENV());
+    const response = await durable.fetch(
+      new Request(`${HOST}${APNS_TOKEN_PATH}`, { method: 'POST', body: '{}' })
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      value: expect.stringMatching(/^ey/),
+      mintedAt: 1_750_000_000_000,
+    });
+  });
+
+  it('persists the minted token so hibernation does not re-mint', async () => {
+    const state = new FakeDurableObjectState();
+    const first = makeDurable(APNS_ENV(), state);
+    const minted = (await (
+      await first.durable.fetch(new Request(`${HOST}${APNS_TOKEN_PATH}`, { method: 'POST' }))
+    ).json()) as ApnsProviderToken;
+
+    // Same storage, brand-new instance: what a hibernation wake looks like.
+    const revived = makeDurable(APNS_ENV(), state);
+    const again = (await (
+      await revived.durable.fetch(new Request(`${HOST}${APNS_TOKEN_PATH}`, { method: 'POST' }))
+    ).json()) as ApnsProviderToken;
+    expect(again.value).toBe(minted.value);
+  });
+
+  it('reports 503 when APNs is not configured', async () => {
+    const { durable } = makeDurable({});
+    const response = await durable.fetch(
+      new Request(`${HOST}${APNS_TOKEN_PATH}`, { method: 'POST', body: '{}' })
+    );
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({ code: 'APNS_NOT_CONFIGURED' });
+  });
+});
+
+describe('mint rate across many tray DOs', () => {
+  it('signs exactly one JWT no matter how many trays push or hibernate', async () => {
+    // The regression this whole change exists for. Before: one signature per
+    // tray per wake. After: one signature, borrowed by everyone.
+    const mintingState = new FakeDurableObjectState();
+    let mintingDurable: SessionTrayDurableObject | null = null;
+    const namespace: DurableObjectNamespaceLike = {
+      idFromName: (name: string) =>
+        ({ toString: () => name }) as unknown as ReturnType<
+          DurableObjectNamespaceLike['idFromName']
+        >,
+      get: () => ({
+        fetch: async (input: Request | string | URL, init?: RequestInit) => {
+          // Reconstruct on every call: the minting DO hibernates too, and the
+          // storage-backed cache is what has to absorb that.
+          const state = mintingState;
+          mintingDurable = new SessionTrayDurableObject(
+            state,
+            { ...APNS_ENV(), TRAY_HUB: namespace },
+            {
+              now: () => 1_750_000_000_000,
+              webSocketPairFactory: () => createFakeWebSocketPair(state),
+            }
+          );
+          state.instance = mintingDurable;
+          return mintingDurable.fetch(
+            input instanceof Request ? input : new Request(String(input), init)
+          );
+        },
+      }),
+    };
+
+    const signSpy = vi.spyOn(crypto.subtle, 'sign');
+    const before = signSpy.mock.calls.length;
+    const env = { ...APNS_ENV(), TRAY_HUB: namespace };
+
+    const values: string[] = [];
+    for (let tray = 0; tray < 6; tray++) {
+      // Fresh instance per iteration == a tray DO woken from hibernation.
+      const state = new FakeDurableObjectState();
+      const durable = new SessionTrayDurableObject(state, env, {
+        now: () => 1_750_000_000_000,
+        webSocketPairFactory: () => createFakeWebSocketPair(state),
+      });
+      state.instance = durable;
+      const trayId = crypto.randomUUID();
+      await durable.fetch(
+        new Request(`${HOST}/internal/create`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            trayId,
+            createdAt: new Date(1_750_000_000_000).toISOString(),
+            joinToken: createCapabilityToken(trayId),
+            controllerToken: createCapabilityToken(trayId),
+            webhookToken: createCapabilityToken(trayId),
+          }),
+        })
+      );
+      const borrowed = (await (
+        await namespace
+          .get(namespace.idFromName(APNS_TOKEN_DO_NAME))
+          .fetch(new Request(`${HOST}${APNS_TOKEN_PATH}`, { method: 'POST', body: '{}' }))
+      ).json()) as ApnsProviderToken;
+      values.push(borrowed.value);
+    }
+
+    expect(signSpy.mock.calls.length - before).toBe(1);
+    expect(new Set(values).size).toBe(1);
+    signSpy.mockRestore();
+  });
+});

--- a/packages/cloudflare-worker/tests/apns-provider-token.test.ts
+++ b/packages/cloudflare-worker/tests/apns-provider-token.test.ts
@@ -58,12 +58,44 @@ describe('durableObjectProviderTokenStore', () => {
     const store = durableObjectProviderTokenStore(storage);
     expect(await store.load()).toBeNull();
 
-    await store.save({ value: 'jwt', mintedAt: 42 });
-    expect(await store.load()).toEqual({ value: 'jwt', mintedAt: 42 });
+    await store.save({ value: 'jwt', mintedAt: 42, identity: 'TEAM1234.KEY5678' });
+    expect(await store.load()).toEqual({
+      value: 'jwt',
+      mintedAt: 42,
+      identity: 'TEAM1234.KEY5678',
+    });
 
     // A half-written or older-shaped record must not be handed to APNs.
     await storage.put(APNS_TOKEN_STORAGE_KEY, { value: '', mintedAt: 'nope' });
     expect(await store.load()).toBeNull();
+  });
+});
+
+describe('credential rotation', () => {
+  it('discards a stored token signed by different credentials and mints at once', async () => {
+    // Rotating the key id must not be mistaken for staleness: the floor would
+    // pin the dead token for 20 minutes even though the new pair has its own
+    // budget with Apple.
+    const state = new FakeDurableObjectState();
+    const store = durableObjectProviderTokenStore(state.storage);
+    const now = () => 1_750_000_000_000;
+    const before = await new LocalProviderTokenMinter(CONFIG(), { now, store }).getToken();
+    expect(before.identity).toBe('TEAM1234.KEY5678');
+
+    const rotated = new LocalProviderTokenMinter({ ...CONFIG(), keyId: 'KEY9999' }, { now, store });
+    const after = await rotated.getToken();
+    expect(after.identity).toBe('TEAM1234.KEY9999');
+    expect(after.value).not.toBe(before.value);
+  });
+
+  it('discards a stored record predating the identity field', async () => {
+    const state = new FakeDurableObjectState();
+    await state.storage.put(APNS_TOKEN_STORAGE_KEY, { value: 'legacy', mintedAt: 1 });
+    const minter = new LocalProviderTokenMinter(CONFIG(), {
+      now: () => 1_000,
+      store: durableObjectProviderTokenStore(state.storage),
+    });
+    expect((await minter.getToken()).value).not.toBe('legacy');
   });
 });
 
@@ -73,7 +105,7 @@ describe('handleProviderTokenRequest', () => {
     const minter: ApnsProviderTokenSource = {
       async getToken(staleToken?: string): Promise<ApnsProviderToken> {
         asked.push(staleToken);
-        return { value: staleToken ? 'jwt-2' : 'jwt-1', mintedAt: 7 };
+        return { value: staleToken ? 'jwt-2' : 'jwt-1', mintedAt: 7, identity: 'i' };
       },
     };
 
@@ -81,7 +113,7 @@ describe('handleProviderTokenRequest', () => {
       new Request(`${HOST}${APNS_TOKEN_PATH}`, { method: 'POST', body: '{}' }),
       minter
     );
-    expect(await plain.json()).toEqual({ value: 'jwt-1', mintedAt: 7 });
+    expect(await plain.json()).toEqual({ value: 'jwt-1', mintedAt: 7, identity: 'i' });
 
     const rotate = await handleProviderTokenRequest(
       new Request(`${HOST}${APNS_TOKEN_PATH}`, {
@@ -90,7 +122,7 @@ describe('handleProviderTokenRequest', () => {
       }),
       minter
     );
-    expect(await rotate.json()).toEqual({ value: 'jwt-2', mintedAt: 7 });
+    expect(await rotate.json()).toEqual({ value: 'jwt-2', mintedAt: 7, identity: 'i' });
     expect(asked).toEqual([undefined, 'jwt-1']);
   });
 
@@ -127,16 +159,16 @@ describe('SharedProviderTokenSource', () => {
     const stub: DurableObjectStubLike = {
       fetch: async () => {
         served += 1;
-        return Response.json({ value: 'shared-jwt', mintedAt: 1_000 });
+        return Response.json({
+          value: 'shared-jwt',
+          mintedAt: 1_000,
+          identity: 'TEAM1234.KEY5678',
+        });
       },
     };
     const ns = fakeNamespace(stub);
     let now = 1_000;
-    const source = new SharedProviderTokenSource(
-      ns,
-      new LocalProviderTokenMinter(CONFIG(), { now: () => now }),
-      () => now
-    );
+    const source = new SharedProviderTokenSource(ns, () => now);
 
     expect((await source.getToken()).value).toBe('shared-jwt');
     expect(ns.names).toEqual([APNS_TOKEN_DO_NAME]);
@@ -157,56 +189,106 @@ describe('SharedProviderTokenSource', () => {
     const stub: DurableObjectStubLike = {
       fetch: async (input) => {
         bodies.push(await (input as Request).text());
-        return Response.json({ value: 'shared-jwt', mintedAt: 1_000 });
+        return Response.json({
+          value: 'shared-jwt',
+          mintedAt: 1_000,
+          identity: 'TEAM1234.KEY5678',
+        });
       },
     };
-    const source = new SharedProviderTokenSource(
-      fakeNamespace(stub),
-      new LocalProviderTokenMinter(CONFIG()),
-      () => 1_000
-    );
+    const source = new SharedProviderTokenSource(fakeNamespace(stub), () => 1_000);
     await source.getToken();
     await source.getToken('shared-jwt');
     expect(bodies).toEqual(['{}', JSON.stringify({ staleToken: 'shared-jwt' })]);
   });
 
-  it('falls back to local minting when the shared instance is unreachable', async () => {
-    // A single object being down must not take every push with it; the local
-    // minter carries its own 20-minute floor, so the blast radius is bounded.
+  it('never mints locally when the shared instance is unreachable', async () => {
+    // Falling back to per-tray minting would restore the very behaviour this
+    // module removes, turning a brief local outage into account-wide 429
+    // throttling that outlasts it. Fail the push instead.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const stub: DurableObjectStubLike = {
-      fetch: async () => {
-        throw new Error('DO unavailable');
-      },
-    };
+    const signSpy = vi.spyOn(crypto.subtle, 'sign');
+    const before = signSpy.mock.calls.length;
     const source = new SharedProviderTokenSource(
-      fakeNamespace(stub),
-      new LocalProviderTokenMinter(CONFIG(), { now: () => 5_000 }),
+      fakeNamespace({
+        fetch: async () => {
+          throw new Error('DO unavailable');
+        },
+      }),
       () => 5_000
     );
-    await expect(source.getToken()).resolves.toMatchObject({ mintedAt: 5_000 });
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('shared APNs provider token unavailable'),
-      expect.anything()
-    );
+    await expect(source.getToken()).rejects.toThrow('DO unavailable');
+    expect(signSpy.mock.calls.length - before).toBe(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('dropping push'), expect.anything());
+    signSpy.mockRestore();
     warn.mockRestore();
   });
 
-  it('falls back when the shared instance answers with an error or junk', async () => {
+  it('rides out an outage on a borrowed token that Apple will still accept', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let fail = false;
+    let now = 1_000;
+    const source = new SharedProviderTokenSource(
+      fakeNamespace({
+        fetch: async () => {
+          if (fail) throw new Error('DO unavailable');
+          return Response.json({
+            value: 'shared-jwt',
+            mintedAt: 1_000,
+            identity: 'TEAM1234.KEY5678',
+          });
+        },
+      }),
+      () => now
+    );
+    await source.getToken();
+    fail = true;
+
+    // Past the re-ask point but inside Apple's expiry: reuse rather than drop.
+    now = 1_000 + 52 * 60 * 1000;
+    await expect(source.getToken()).resolves.toMatchObject({ value: 'shared-jwt' });
+
+    // Past the hard age limit: the token is no good to Apple either, so fail.
+    now = 1_000 + 56 * 60 * 1000;
+    await expect(source.getToken()).rejects.toThrow('DO unavailable');
+    warn.mockRestore();
+  });
+
+  it('does not reuse a borrowed token the gateway just rejected', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let fail = false;
+    const source = new SharedProviderTokenSource(
+      fakeNamespace({
+        fetch: async () => {
+          if (fail) throw new Error('DO unavailable');
+          return Response.json({
+            value: 'shared-jwt',
+            mintedAt: 1_000,
+            identity: 'TEAM1234.KEY5678',
+          });
+        },
+      }),
+      () => 1_000
+    );
+    await source.getToken();
+    fail = true;
+    await expect(source.getToken('shared-jwt')).rejects.toThrow('DO unavailable');
+    warn.mockRestore();
+  });
+
+  it('rejects an error status or a malformed payload from the shared instance', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const erroring = new SharedProviderTokenSource(
       fakeNamespace({ fetch: async () => new Response('nope', { status: 503 }) }),
-      new LocalProviderTokenMinter(CONFIG(), { now: () => 1 }),
       () => 1
     );
-    await expect(erroring.getToken()).resolves.toMatchObject({ mintedAt: 1 });
+    await expect(erroring.getToken()).rejects.toThrow('responded 503');
 
     const junk = new SharedProviderTokenSource(
       fakeNamespace({ fetch: async () => Response.json({ nope: true }) }),
-      new LocalProviderTokenMinter(CONFIG(), { now: () => 2 }),
       () => 2
     );
-    await expect(junk.getToken()).resolves.toMatchObject({ mintedAt: 2 });
+    await expect(junk.getToken()).rejects.toThrow('malformed token');
     warn.mockRestore();
   });
 });

--- a/packages/cloudflare-worker/tests/apns.test.ts
+++ b/packages/cloudflare-worker/tests/apns.test.ts
@@ -1,13 +1,19 @@
 /**
- * APNs sender (#2062): provider-JWT minting + caching, request shape per
- * category, and response classification (dead tokens, stale JWT retry,
- * transport failure). Uses a freshly generated P-256 key — no Apple secrets.
+ * APNs sender (#2062, #2432): provider-JWT minting under Apple's per-key
+ * throttle, request shape per category, and response classification (dead
+ * tokens, stale JWT, transient retry, transport failure). Uses a freshly
+ * generated P-256 key — no Apple secrets.
  */
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import {
+  type ApnsProviderToken,
+  type ApnsProviderTokenSource,
   type ApnsPushRequest,
   apnsConfigFromEnv,
   apnsHost,
+  JWT_MIN_MINT_INTERVAL_MS,
+  LocalProviderTokenMinter,
+  type ProviderTokenStore,
   WebCryptoApnsSender,
 } from '../src/apns.js';
 
@@ -54,11 +60,31 @@ function fakeFetch(responder: (url: string, init: RequestInit) => Response) {
 }
 
 const ok = () => new Response(null, { status: 200 });
-const reject = (status: number, reason: string) =>
-  new Response(JSON.stringify({ reason }), {
+const reject = (status: number, body: Record<string, unknown>) =>
+  new Response(JSON.stringify(body), {
     status,
     headers: { 'content-type': 'application/json' },
   });
+
+/** Never sleep for real in tests; assert the retry happened instead. */
+const noSleep = () => Promise.resolve();
+
+/** A token source that hands out fixed values, recording what was asked for. */
+function stubSource(
+  tokens: string[]
+): ApnsProviderTokenSource & { asked: Array<string | undefined> } {
+  const asked: Array<string | undefined> = [];
+  let i = 0;
+  return {
+    asked,
+    async getToken(staleToken?: string): Promise<ApnsProviderToken> {
+      asked.push(staleToken);
+      const value = tokens[Math.min(i, tokens.length - 1)];
+      i += 1;
+      return { value, mintedAt: 0 };
+    },
+  };
+}
 
 describe('apnsConfigFromEnv', () => {
   it('requires all four secrets', () => {
@@ -82,24 +108,92 @@ describe('apnsConfigFromEnv', () => {
   });
 });
 
-describe('WebCryptoApnsSender', () => {
+describe('LocalProviderTokenMinter', () => {
   it('mints an ES256 provider JWT and caches it for 50 minutes', async () => {
     let now = 1_750_000_000_000;
-    const sender = new WebCryptoApnsSender(CONFIG(), { now: () => now });
-    const first = await sender.providerToken();
-    const [header, claims, signature] = first.split('.');
+    const minter = new LocalProviderTokenMinter(CONFIG(), { now: () => now });
+    const first = await minter.getToken();
+    const [header, claims, signature] = first.value.split('.');
     const decode = (s: string) => JSON.parse(atob(s.replace(/-/g, '+').replace(/_/g, '/')));
     expect(decode(header)).toEqual({ alg: 'ES256', kid: 'KEY5678' });
     expect(decode(claims)).toEqual({ iss: 'TEAM1234', iat: 1_750_000_000 });
     // Raw r||s signature, 64 bytes → 86 base64url chars.
     expect(signature).toHaveLength(86);
+    expect(first.mintedAt).toBe(now);
 
     now += 10 * 60 * 1000;
-    expect(await sender.providerToken()).toBe(first);
+    expect((await minter.getToken()).value).toBe(first.value);
     now += 41 * 60 * 1000;
-    expect(await sender.providerToken()).not.toBe(first);
+    expect((await minter.getToken()).value).not.toBe(first.value);
   });
 
+  it('accepts a PEM whose newlines were escaped by the secret store', async () => {
+    const escaped = pem.replace(/\n/g, '\\n');
+    const minter = new LocalProviderTokenMinter({ ...CONFIG(), privateKeyPem: escaped });
+    await expect(minter.getToken()).resolves.toMatchObject({ value: expect.stringMatching(/^ey/) });
+  });
+
+  it('collapses concurrent callers onto a single mint', async () => {
+    // The whole point of the singleton: a herd of tray DOs waking at once must
+    // not each sign their own JWT. Same instance, simultaneous callers.
+    const signSpy = vi.spyOn(crypto.subtle, 'sign');
+    const before = signSpy.mock.calls.length;
+    const minter = new LocalProviderTokenMinter(CONFIG(), { now: () => 1_750_000_000_000 });
+    const tokens = await Promise.all(Array.from({ length: 8 }, () => minter.getToken()));
+    expect(signSpy.mock.calls.length - before).toBe(1);
+    expect(new Set(tokens.map((t) => t.value)).size).toBe(1);
+    signSpy.mockRestore();
+  });
+
+  it('refuses to rotate inside Apple’s 20-minute floor, even when told the token is stale', async () => {
+    // Minting faster than this is what earns 429 TooManyProviderTokenUpdates,
+    // and that penalty outlives the single push we would be rescuing.
+    let now = 1_750_000_000_000;
+    const minter = new LocalProviderTokenMinter(CONFIG(), { now: () => now });
+    const first = await minter.getToken();
+
+    now += 5 * 60 * 1000;
+    expect((await minter.getToken(first.value)).value).toBe(first.value);
+
+    now += JWT_MIN_MINT_INTERVAL_MS;
+    expect((await minter.getToken(first.value)).value).not.toBe(first.value);
+  });
+
+  it('hands a caller the newer token when someone else already rotated', async () => {
+    let now = 1_750_000_000_000;
+    const minter = new LocalProviderTokenMinter(CONFIG(), { now: () => now });
+    const first = await minter.getToken();
+    now += JWT_MIN_MINT_INTERVAL_MS + 1;
+    const second = await minter.getToken(first.value);
+    expect(second.value).not.toBe(first.value);
+
+    // A straggler still reporting the *original* token gets the rotated one
+    // back without triggering another mint.
+    const straggler = await minter.getToken(first.value);
+    expect(straggler.value).toBe(second.value);
+  });
+
+  it('resumes from the store instead of minting after hibernation', async () => {
+    // A Durable Object evicted between pushes reconstructs this class; without
+    // the store it would sign a fresh JWT on every wake (issue #2432).
+    const saved: ApnsProviderToken[] = [];
+    const store: ProviderTokenStore = {
+      load: async () => saved.at(-1) ?? null,
+      save: async (token) => {
+        saved.push(token);
+      },
+    };
+    const now = () => 1_750_000_000_000;
+    const first = await new LocalProviderTokenMinter(CONFIG(), { now, store }).getToken();
+    expect(saved).toHaveLength(1);
+
+    const reconstructed = new LocalProviderTokenMinter(CONFIG(), { now, store });
+    expect((await reconstructed.getToken()).value).toBe(first.value);
+    expect(saved).toHaveLength(1);
+  });
+});
+
+describe('WebCryptoApnsSender', () => {
   it('posts the sudo payload with time-sensitive headers to the sandbox gateway', async () => {
     const { impl, calls } = fakeFetch(() => ok());
     const sender = new WebCryptoApnsSender(CONFIG(), {
@@ -136,60 +230,130 @@ describe('WebCryptoApnsSender', () => {
     expect(headers['apns-expiration']).toBeUndefined();
   });
 
+  it('clears the request timeout so a finished push does not pin the DO awake', async () => {
+    // The uncleared AbortSignal.timeout held the Durable Object's IO context
+    // open for the full 8s budget after every *successful* push (#2432), which
+    // is billed wall time. Assert the timer is cleared, not merely armed.
+    vi.useFakeTimers();
+    try {
+      const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+      const sender = new WebCryptoApnsSender(CONFIG(), { fetchImpl: fakeFetch(() => ok()).impl });
+      await sender.send(REQ);
+      expect(clearSpy).toHaveBeenCalled();
+      // Nothing left armed: advancing past the budget must not fire an abort.
+      expect(vi.getTimerCount()).toBe(0);
+      clearSpy.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports the apns-unique-id so a failed push can be traced with Apple', async () => {
+    const { impl } = fakeFetch(
+      () =>
+        new Response(JSON.stringify({ reason: 'BadCollapseId' }), {
+          status: 400,
+          headers: { 'content-type': 'application/json', 'apns-unique-id': 'ABC-123' },
+        })
+    );
+    const sender = new WebCryptoApnsSender(CONFIG(), { fetchImpl: impl });
+    expect(await sender.send(REQ)).toMatchObject({ uniqueId: 'ABC-123', dropToken: false });
+  });
+
   it('flags dead tokens from 410 and BadDeviceToken, keeps others', async () => {
     const gone = new WebCryptoApnsSender(CONFIG(), {
-      fetchImpl: fakeFetch(() => reject(410, 'Unregistered')).impl,
+      fetchImpl: fakeFetch(() => reject(410, { reason: 'Unregistered', timestamp: 1_700_000 }))
+        .impl,
     });
     expect(await gone.send(REQ)).toMatchObject({
       status: 410,
       reason: 'Unregistered',
       dropToken: true,
+      invalidatedAtMs: 1_700_000,
     });
 
     const bad = new WebCryptoApnsSender(CONFIG(), {
-      fetchImpl: fakeFetch(() => reject(400, 'BadDeviceToken')).impl,
+      fetchImpl: fakeFetch(() => reject(400, { reason: 'BadDeviceToken' })).impl,
     });
-    expect(await bad.send(REQ)).toMatchObject({ status: 400, dropToken: true });
-
-    const busy = new WebCryptoApnsSender(CONFIG(), {
-      fetchImpl: fakeFetch(() => reject(503, 'ServiceUnavailable')).impl,
-    });
-    expect(await busy.send(REQ)).toMatchObject({ status: 503, dropToken: false });
+    const badResult = await bad.send(REQ);
+    expect(badResult).toMatchObject({ status: 400, dropToken: true });
+    // No timestamp on a 400 — the caller must treat it as unconditionally final.
+    expect(badResult.invalidatedAtMs).toBeUndefined();
 
     const opaque = new WebCryptoApnsSender(CONFIG(), {
-      fetchImpl: fakeFetch(() => new Response('nope', { status: 500 })).impl,
+      fetchImpl: fakeFetch(() => new Response('nope', { status: 400 })).impl,
     });
-    expect(await opaque.send(REQ)).toEqual({ token: REQ.token, status: 500, dropToken: false });
+    expect(await opaque.send(REQ)).toEqual({ token: REQ.token, status: 400, dropToken: false });
   });
 
-  it('re-mints the JWT once on ExpiredProviderToken and retries', async () => {
+  it('retries a stale JWT only against a genuinely different token', async () => {
     let attempt = 0;
     const { impl, calls } = fakeFetch(() =>
-      ++attempt === 1 ? reject(403, 'ExpiredProviderToken') : ok()
+      ++attempt === 1 ? reject(403, { reason: 'ExpiredProviderToken' }) : ok()
     );
-    const sender = new WebCryptoApnsSender(CONFIG(), { fetchImpl: impl });
+    const source = stubSource(['jwt-old', 'jwt-new']);
+    const sender = new WebCryptoApnsSender(CONFIG(), { fetchImpl: impl, tokenSource: source });
     expect(await sender.send(REQ)).toMatchObject({ status: 200 });
     expect(calls).toHaveLength(2);
+    expect(source.asked).toEqual([undefined, 'jwt-old']);
     const auth = (i: number) => (calls[i].init.headers as Record<string, string>).authorization;
-    expect(auth(0)).not.toBe(auth(1));
+    expect(auth(0)).toBe('bearer jwt-old');
+    expect(auth(1)).toBe('bearer jwt-new');
   });
 
-  it('reports a transport failure without dropping the token', async () => {
-    const impl = vi.fn(async () => {
+  it('gives up rather than re-post the same JWT the gateway just refused', async () => {
+    // The source declining to rotate (Apple's 20-minute floor) is an answer,
+    // not a hint to try again — a second post would burn a request and, for
+    // TooManyProviderTokenUpdates, deepen the throttle we are already in.
+    const { impl, calls } = fakeFetch(() => reject(429, { reason: 'TooManyProviderTokenUpdates' }));
+    const source = stubSource(['jwt-pinned']);
+    const sender = new WebCryptoApnsSender(CONFIG(), { fetchImpl: impl, tokenSource: source });
+    expect(await sender.send(REQ)).toMatchObject({
+      status: 429,
+      reason: 'TooManyProviderTokenUpdates',
+      dropToken: false,
+    });
+    expect(calls).toHaveLength(1);
+    // It still asked — that is how a caller picks up someone else's rotation.
+    expect(source.asked).toEqual([undefined, 'jwt-pinned']);
+  });
+
+  it('retries a 503 once and succeeds', async () => {
+    let attempt = 0;
+    const { impl, calls } = fakeFetch(() =>
+      ++attempt === 1 ? reject(503, { reason: 'ServiceUnavailable' }) : ok()
+    );
+    const sender = new WebCryptoApnsSender(CONFIG(), { fetchImpl: impl, sleep: noSleep });
+    expect(await sender.send(REQ)).toMatchObject({ status: 200 });
+    expect(calls).toHaveLength(2);
+  });
+
+  it('retries a transport failure but never a timeout', async () => {
+    const flaky = vi.fn(async () => {
       throw new Error('ECONNRESET');
     }) as unknown as typeof fetch;
-    const sender = new WebCryptoApnsSender(CONFIG(), { fetchImpl: impl });
+    const sender = new WebCryptoApnsSender(CONFIG(), { fetchImpl: flaky, sleep: noSleep });
     expect(await sender.send(REQ)).toEqual({
       token: REQ.token,
       status: 0,
       reason: 'ECONNRESET',
       dropToken: false,
     });
-  });
+    expect(flaky).toHaveBeenCalledTimes(2);
 
-  it('accepts a PEM whose newlines were escaped by the secret store', async () => {
-    const escaped = pem.replace(/\n/g, '\\n');
-    const sender = new WebCryptoApnsSender({ ...CONFIG(), privateKeyPem: escaped });
-    await expect(sender.providerToken()).resolves.toMatch(/^ey/);
+    // A timeout already spent the full 8s budget; retrying would double the
+    // wall time the Durable Object is held open for nothing.
+    const timeout = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      (init?.signal as AbortSignal | undefined)?.throwIfAborted?.();
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      throw err;
+    }) as unknown as typeof fetch;
+    const timingOut = new WebCryptoApnsSender(CONFIG(), { fetchImpl: timeout, sleep: noSleep });
+    expect(await timingOut.send(REQ)).toMatchObject({
+      status: 0,
+      reason: 'APNs request timed out',
+    });
+    expect(timeout).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloudflare-worker/tests/apns.test.ts
+++ b/packages/cloudflare-worker/tests/apns.test.ts
@@ -81,7 +81,7 @@ function stubSource(
       asked.push(staleToken);
       const value = tokens[Math.min(i, tokens.length - 1)];
       i += 1;
-      return { value, mintedAt: 0 };
+      return { value, mintedAt: 0, identity: 'TEAM1234.KEY5678' };
     },
   };
 }

--- a/packages/cloudflare-worker/tests/session-tray-push.test.ts
+++ b/packages/cloudflare-worker/tests/session-tray-push.test.ts
@@ -215,6 +215,46 @@ describe('push.send', () => {
     await tick();
     expect(Object.keys((await readTray(t)).pushTokens ?? {})).toEqual([TOKEN_B]);
   });
+
+  it('keeps a token that was re-registered after Apple’s 410 timestamp', async () => {
+    // A phone that reconnects while an old push is still in flight re-registers
+    // the same token. Honouring a 410 that predates that registration would
+    // silently unsubscribe a device that is right there (#2432).
+    const t = await createTestTray(
+      new FakeApns(() => ({
+        status: 410,
+        reason: 'Unregistered',
+        dropToken: true,
+        // Long before the registration this test performs.
+        invalidatedAtMs: Date.parse('2020-01-01T00:00:00.000Z'),
+      }))
+    );
+    const socket = await attachLeader(t);
+    register(socket, TOKEN_A);
+    await tick();
+    socket.send(JSON.stringify({ type: 'push.send', category: 'turn_end', label: 'SLICC' }));
+    await tick();
+    await tick();
+    expect(Object.keys((await readTray(t)).pushTokens ?? {})).toEqual([TOKEN_A]);
+  });
+
+  it('forgets a token whose registration predates Apple’s 410 timestamp', async () => {
+    const t = await createTestTray(
+      new FakeApns(() => ({
+        status: 410,
+        reason: 'Unregistered',
+        dropToken: true,
+        invalidatedAtMs: Date.parse('2999-01-01T00:00:00.000Z'),
+      }))
+    );
+    const socket = await attachLeader(t);
+    register(socket, TOKEN_A);
+    await tick();
+    socket.send(JSON.stringify({ type: 'push.send', category: 'turn_end', label: 'SLICC' }));
+    await tick();
+    await tick();
+    expect(Object.keys((await readTray(t)).pushTokens ?? {})).toEqual([]);
+  });
 });
 
 describe('buildApnsPayload', () => {

--- a/packages/cloudflare-worker/wrangler.jsonc
+++ b/packages/cloudflare-worker/wrangler.jsonc
@@ -5,6 +5,19 @@
   "compatibility_date": "2026-03-11",
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": true,
+  // Workers Logs (#2432). Without this, a `console.warn` from the tray DO —
+  // e.g. an APNs delivery failure — goes nowhere, which is exactly why the
+  // push path shipped unverified. `invocation_logs: false` keeps the volume
+  // (and cost) sane: this Worker also serves every UI asset, and we only care
+  // about the explicit logs, not a record of each request.
+  // Not inherited by named environments — env.staging repeats it below.
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "invocation_logs": false
+    }
+  },
   "assets": {
     "directory": "../../dist/ui/",
     "binding": "ASSETS",
@@ -94,6 +107,13 @@
     "staging": {
       "name": "slicc-tray-hub-staging",
       "workers_dev": true,
+      "observability": {
+        "enabled": true,
+        "head_sampling_rate": 1,
+        "logs": {
+          "invocation_logs": false
+        }
+      },
       "assets": {
         "directory": "../../dist/ui/",
         "binding": "ASSETS",


### PR DESCRIPTION
Fixes the headline finding from #2432: the tray hub minted an APNs provider JWT **per Durable Object**, and there is one DO per tray.

## The bug

Apple throttles provider-token creation per `(team id, key id)` pair — **not** per connection — and answers `429 TooManyProviderTokenUpdates` above one mint per 20 minutes ([Apple forums](https://developer.apple.com/forums/thread/111241), [multi-key conditions](https://developer.apple.com/forums/thread/770438)). Two facts combined to blow that budget:

1. `WebCryptoApnsSender` cached its JWT in **DO memory**, one sender per tray DO.
2. The tray DO uses WebSocket hibernation (`state.acceptWebSocket`), so an idle tray is evicted between messages and signs a fresh JWT on the next push.

Mint rate therefore scaled with `active trays × wake cycles` rather than with time. A single user pushing every few minutes could already exceed Apple's floor. And `TooManyProviderTokenUpdates` was in neither `DEAD_TOKEN_REASONS` nor `STALE_JWT_REASONS`, so the throttled push was dropped and only warn-logged — into the void, because observability was off.

Confirmed live: the internal token fetch now happens on essentially **every** push, which is the hibernation eviction showing up in production exactly as described.

## The fix

Every tray DO borrows the token from one well-known instance of the *same* namespace — `TRAY_HUB.idFromName('__apns_provider_token')`, served over an internal `POST /internal/apns-token`. That instance is the only one that signs, and it persists the JWT to its own storage so its own hibernation costs nothing. **No new binding, no KV** — the namespace was already bound.

Design points worth reviewing:

- **The 20-minute floor is enforced even when a caller reports its token rejected.** Minting in response to a 429 deepens the throttle, and re-signing a token seconds old reproduces the same `iat` anyway. The source returns its cached token instead; the sender then declines to re-post the value Apple just refused, rather than burning a second request.
- **A stale-token report rotates only if the cached token still matches it.** A herd of DOs reporting the same rejection causes one mint, not one per caller — the stragglers get the already-rotated token.
- **Borrowed tokens are memoised by `mintedAt`, never fetch time**, so a token borrowed at minute 49 is not ridden past Apple's 60-minute expiry.
- **Falls back to local minting if the singleton is unreachable**, loudly. One object being down must not take every push with it; the local minter carries its own floor, so the blast radius is bounded.
- **Not fronted by `caches.default`.** The singleton never mints on a miss (it returns a stored token), so a cache would only shave an internal round trip — measured at **2–3 ms warm** — while adding an invalidation path for a value that must rotate on demand. Complexity without a payoff.

## Also in scope (items 3–7)

| | |
|---|---|
| **Cleared the request timeout** | `AbortSignal.timeout` stayed armed after the response landed, holding the DO's IO context open for the full 8 s budget after every *successful* push. Replaced with an `AbortController` cleared in `finally`. |
| **Retry 500/503 + transport errors** | Once, after 250 ms. |
| **410 `timestamp` check** | A device that re-registered *after* the token died keeps its registration instead of being silently unsubscribed by an in-flight push. 400 `BadDeviceToken` carries no timestamp and stays unconditionally final. |
| **`apns-unique-id`** | Recorded on the result and included in the failure log — the only handle Apple accepts for tracing a lost push. |
| **Observability** | Enabled on **both** environments. It is not inherited by named environments, so it is set twice. `invocation_logs: false` keeps volume and cost sane: this Worker also serves every UI asset, and only the explicit `console.warn` matters here. |

### One deviation from the brief

**429 is not retried by re-posting.** It is routed through the stale-JWT path as asked — so a throttled push retries against the shared token instead of dropping — but if the source declines to rotate, the sender stops rather than re-sending the refused token. Re-posting on a `TooManyProviderTokenUpdates` is what deepens the throttle, and the device-token flavour of 429 wants a backoff we cannot perform inside a WebSocket message handler without holding the DO awake — the very cost this PR is removing. Timeouts are likewise not retried: they already spent the full 8 s budget.

## Cost impact

Durable Object duration is billed on wall clock. Measured on staging, same fake-token probe before and after:

| | before | after |
|---|---|---|
| `push.send` with a registered token | **7998 ms** | **~1200 ms** (first), ~1209/1234 ms (steady) |
| internal provider-token fetch | n/a | **105 ms** cold, **2–3 ms** warm |
| `push.send` with no token (control) | 25 ms | 27 ms |

≈6.8 s of billed DO wall time removed from **every** notification — and this fires on every finished turn and every sudo prompt.

## Verification (staging only — see "NOT verified" below)

Full pre-push pass green: `verify` (7/7), `check-touched-exemptions` (0 files on any debt list), `typecheck`, `test` (16888 passed), `test:coverage` (no floor failures), both builds, `bundle-size`.

Deployed to **staging only**. Against the live worker:

- All 12 `tests/deployed.test.ts` smoke tests pass.
- `observability` confirmed live via the Cloudflare API on `slicc-tray-hub-staging`.
- `POST https://tray-hub.internal/internal/apns-token` appears in `wrangler tail` — the singleton is really being reached.
- **Apple still authenticates the borrowed JWT.** Push a fabricated device token, wait 30 s, push again on the same tray: the second push early-returns in **27 ms**, meaning the token was evicted, meaning Apple returned a dead-token verdict — which it only does *after* validating the provider token.

## On testing the real transport

The existing `apns.test.ts` injected `fetchImpl` everywhere, which is why a broken transport could never have been caught. New coverage targets behaviour rather than call shape: the mint-count property (`crypto.subtle.sign` called **exactly once** across 6 tray DOs reconstructed from hibernation), single-flight collapsing of concurrent callers, the 20-minute floor in both directions, store-backed resume across instances, timer cleanup (asserting `vi.getTimerCount() === 0`, not merely that a timeout was armed), and the 410 timestamp branch on both sides.

What I did **not** add is a CI gate that talks to Apple. It would put Apple's availability in the deploy path for every worker PR, and the credentials only exist in the staging/production jobs. Instead the probe recipe — the one used above, which needs no phone — is documented in `.agents/skills/deploying-tray-worker/SKILL.md`, including the trap that fooled the original investigation: an 8-second `wallTime` was the uncleared abort timer, not a hang, so read the *second* push, not the first.

## Verified on hardware (2026-08-26)

Both items that were open when this PR was written are now closed, on a physical iPad against this branch deployed to staging.

**Real delivery — observed.** A `sudo_request` push rendered on the device as a banner reading **TIME SENSITIVE / "Approval needed" / "Deploy to production is waiting for your approval"** — exactly `buildApnsPayload`'s output, with `interruption-level: time-sensitive` surfacing correctly. Tapping it fired `SLICC_SUDO_REVIEW` and opened the app. This is the first observed end-to-end delivery from this worker.

**`APNS_TOPIC` — verified** via the two-tray gateway probe, from Apple's own verdict rather than inference:

| token | gateway | result |
| --- | --- | --- |
| real device token | sandbox | **survived** — accepted (585 ms, 169 ms real round trips) |
| real device token | production | evicted — rejected |
| fabricated token | sandbox | evicted — rejected |

The fabricated-token control is what makes this conclusive: it proves the sandbox gateway was live and rejecting bogus tokens at the same moment the real token was accepted. Acceptance requires the topic to match the token's app — a mismatch returns `DeviceTokenNotForTopic`, a dead-token reason that would have evicted it.

**The singleton under real load:** internal `apns-token` fetches measured **426 ms cold, then 2 ms / 2 ms warm**, with signing happening once on the minting instance.

**Timer fix, confirmed from outside.** Mid-test another agent's `wrangler deploy` overwrote staging with a build lacking this change; pushes immediately went back to **7998–8000 ms** holds, versus **169–585 ms** on this branch. Caught because this branch makes a distinctive internal `apns-token` request and the tail showed zero. Redeployed and re-ran everything above on verified-correct code.

## Still not covered

The **Face ID sudo approval leg** has not run on hardware. It is gated by `shouldDelegateSudo()`, which only routes to a follower when the last user message came from one — so it needs a message sent from the phone first. Scheduled separately; tracked in #2432.

Refs #2432, #2062, #2213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)