### PR TITLE
docs(webapp): say why curlwright is outside the #2255 flag sweep

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/curlwright/parse-args.ts
+++ b/packages/webapp/src/shell/supplemental-commands/curlwright/parse-args.ts
@@ -12,6 +12,19 @@
  * quietly dropped, because the whole point of the command is that the
  * request goes out *exactly* as written.
  *
+ * The same reasoning excludes the shared `parseKnownFlags` walk added for
+ * issue #2255, and this command is NOT part of that sweep: it already
+ * rejects unknown flags by name, which is what #2255 is trying to
+ * achieve. That helper collects values into a `Map`, so a repeated flag
+ * overwrites — `-H` and `-d` here are repeatable AND order-sensitive —
+ * and it has no notion of bundled short booleans, attached short values,
+ * or a `-X`/`--request` alias pair, so `-sS` and `-XPOST` would both come
+ * back as unknown flags. Its single `unknown flag: --x` message also
+ * cannot carry the per-option reason (`--cert` vs `-x` vs `--compressed`)
+ * that makes a rejection here actionable. The enforcement is not this
+ * comment: `curlwright-args.test.ts` pins `-sS`, `-XPOST` and the ordered
+ * repeat of `-H`/`-d`, so a migration to the helper fails there first.
+ *
  * Parsing is pure: `@file` references are recorded, never read. The
  * command resolves them against the VFS afterwards (see `body.ts`), so
  * this module stays trivially testable.


### PR DESCRIPTION
## What

A comment in `curlwright/parse-args.ts` saying why `curlwright` is not part of the #2255 flag-strictness sweep. Comment only — no behavior change, one file.

## Why now

#2431 landed `parseKnownFlags`, and the per-command adoptions (#2430, #2433–#2438) are in flight. `curlwright` is the obvious next candidate on a grep and is the wrong one, so the reason belongs where someone would go looking rather than in a closed PR thread.

#2255 asks the sweep to state its exclusions explicitly "so a future reader does not 'fix' them." This is that note for `curlwright`.

## The substance

`curlwright` already meets #2255's contract — an unknown flag exits non-zero, named, with a test. It cannot use the helper, checked against `subcommand-flags.ts` as merged:

- `values` is a `Map`, so `values.set(name, value)` makes a repeated flag overwrite. `-H` and `-d` are repeatable **and order-sensitive** (`-d a -d b` → `a&b`).
- No bundled short booleans: `-sS` takes the `name = arg` path and returns `unknown flag: -sS`.
- No attached short values: `-XPOST` and `-oout.bin` the same way.
- No alias pairing, so `-X` and `--request` would be unrelated keys.
- One generic `unknown flag: ${name}` cannot carry the per-option reason that makes rejecting `--cert` vs `-x` vs `--compressed` actionable — which is the point of the rejection list, not decoration on it.

The comment also names what actually enforces this: `curlwright-args.test.ts` pins `-sS`, `-XPOST` and the ordered `-H`/`-d` repeat, so a migration to the helper fails there before it reaches review. A comment alone would rot; the tests are the guard.

## Verification

`npm run verify` (7/7), `npm run typecheck`, 68 curlwright tests, `check-touched-exemptions` (1 file, 0 on any debt list).

Follows #2422 (merged). Refs #2255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
