### PR TITLE
docs(delegation): document browser-bridge serialization and fan-out cap

### DIFF
--- a/packages/vfs-root/workspace/skills/delegation/SKILL.md
+++ b/packages/vfs-root/workspace/skills/delegation/SKILL.md
@@ -293,15 +293,19 @@ Browser-tab handling rules (track your IDs, never close tabs you didn't open, ha
 All scoops share ONE browser, and every `playwright-cli` command runs
 **serialized** on a single global tab lock. Parallel browser-driving scoops do
 not run in parallel at the browser — they queue. An 8-way browser fan-out
-roughly doubles wall-clock time versus a capped one and adds retry overhead as
-queued commands blow past `background_after` and get killed.
+roughly doubles wall-clock time versus a capped one and adds overhead as
+queued commands blow past `background_after` and get detached — their results
+arrive later as `bash` licks, so the scoop's turn moves on before the browser
+work lands.
 
 - **Cap concurrent browser-driving scoops at 3–4.** For larger workloads, feed
   scoops in waves: feed 3–4, `scoop_wait` for them, feed the next wave.
 - When a command emits `note: browser bridge contended — ...` on stderr (total
-  lock wait + queue depth), that is back-off guidance: instruct scoops to
-  stagger or wait, never to re-run the command — it already ran; it was just
-  slow to get the lock.
+  lock wait + queue depth; ships with the bridge hardening in PR #2411 —
+  runtimes without it stay silent, but slowness under fan-out still means
+  contention), that is back-off guidance: instruct scoops to stagger or wait,
+  never to re-run the command — it already ran; it was just slow to get the
+  lock.
 - This cap applies only to scoops actively driving the browser. Scoops doing
   CPU/VFS/network work (curl, file edits, analysis) fan out freely.
 

--- a/packages/vfs-root/workspace/skills/delegation/SKILL.md
+++ b/packages/vfs-root/workspace/skills/delegation/SKILL.md
@@ -237,6 +237,19 @@ scoop_unmute({ scoop_names: ["scraper"] })
 # Tool result has the stashed summary or "No stashed completions".
 ```
 
+### Liveness: a quiet fan-out is not a finished fan-out
+
+"Files look stable and the scoops are still processing" does NOT mean the work
+is done or progressing. A common stall mode: one or more scoops are blocked on
+a pending approval (`sudo_request`) that never reached you, and the whole
+fan-out sits idle while you wait for a `scoop-wait` lick that can't arrive.
+
+When a fan-out goes quiet — no completions, no file changes, no progress
+messages — run `list_sudo_requests` before concluding anything. Resolve or
+deny each pending request, then keep waiting. Only treat a fan-out as
+complete when every scoop has actually reported completion (via `scoop_wait`
+lick or `scoop_unmute` summaries), not because output files stopped changing.
+
 ### Notes
 
 - Full response is always persisted to `/shared/scoop-notifications/<timestamp>-<folder>-<id>.md` (bounded to the 200 most recent). The summary string in the tool result is truncated at 20 000 characters; read the VFS path when you need the full output.
@@ -274,6 +287,23 @@ scoop_scoop({ name: "architect", model: "claude-opus-4-6", prompt: "Design the n
 ## Browser tabs
 
 Browser-tab handling rules (track your IDs, never close tabs you didn't open, handle "tab not found" gracefully) live in `/workspace/skills/playwright-cli/SKILL.md` under "Multi-Agent Tab Behavior". Read that skill before delegating browser work.
+
+### Browser-driving scoops serialize on one bridge
+
+All scoops share ONE browser, and every `playwright-cli` command runs
+**serialized** on a single global tab lock. Parallel browser-driving scoops do
+not run in parallel at the browser — they queue. An 8-way browser fan-out
+roughly doubles wall-clock time versus a capped one and adds retry overhead as
+queued commands blow past `background_after` and get killed.
+
+- **Cap concurrent browser-driving scoops at 3–4.** For larger workloads, feed
+  scoops in waves: feed 3–4, `scoop_wait` for them, feed the next wave.
+- When a command emits `note: browser bridge contended — ...` on stderr (total
+  lock wait + queue depth), that is back-off guidance: instruct scoops to
+  stagger or wait, never to re-run the command — it already ran; it was just
+  slow to get the lock.
+- This cap applies only to scoops actively driving the browser. Scoops doing
+  CPU/VFS/network work (curl, file edits, analysis) fan out freely.
 
 ## Model access policy
 


### PR DESCRIPTION
## Summary

Repo-side portion of #2417 (split out of the 2026-08-25 concurrent-scoop incident; runtime hardening in #2411).

Adds two pieces to `packages/vfs-root/workspace/skills/delegation/SKILL.md`:

**Browser-driving scoops serialize on one bridge** (under "Browser tabs")
- Documents that all scoops share one browser and every `playwright-cli` command runs serialized on a single global tab lock — parallel browser scoops queue, they don't parallelize.
- Recommends capping concurrent browser-driving scoops at 3–4, or feeding in waves (`scoop_wait` between waves) for larger workloads.
- Cites the `note: browser bridge contended — ...` stderr signal from #2411 as back-off guidance (stagger/wait), explicitly not a reason to re-run commands.
- Clarifies the cap applies only to browser-driving scoops; CPU/VFS/network fan-out is unaffected.

**Liveness: a quiet fan-out is not a finished fan-out** (under parallel orchestration)
- "Files stable + scoops processing" is not completion; a fan-out can stall on a pending `sudo_request` nobody surfaced.
- Instructs the cone to run `list_sudo_requests` when a fan-out goes quiet, and to treat only actual scoop completions (`scoop_wait` lick / `scoop_unmute` summaries) as done.

The externally authored `liftoff-demo` / `migrate-page` / `migrate-block` skills (issue items 1–4) don't live in this repo and stay tracked in #2417.

## Verification

Docs-only change. `check-touched-exemptions`: OK; markdown lint clean.

Closes the repo-side acceptance criterion of #2417.