### PR TITLE
refactor(webapp): replace bash tokenizer with just-bash AST for no-match heuristic

### DIFF
--- a/packages/webapp/src/tools/bash-tool.ts
+++ b/packages/webapp/src/tools/bash-tool.ts
@@ -249,11 +249,17 @@ function literalWordText(word: WordNode): string | null {
  * rather than a hand-rolled tokenizer: assignment prefixes (`VAR=1 grep`) live
  * in `assignments` and never reach the name, and the one `command` builtin
  * prefix the heuristic honours (`command rg …`) is unwrapped to its target.
+ *
+ * A negated pipeline (`! grep needle file`) is disqualified: there exit 1 means
+ * the search *found* a match (grep's 0 flipped by `!`), the exact opposite of
+ * the no-match signal this exemption suppresses — so we return `null` rather
+ * than let the command name alone earn the exemption.
  */
 function lastCommandName(ast: ScriptNode): string | null {
   const stmt = ast.statements[ast.statements.length - 1];
   const pipeline = stmt?.pipelines[stmt.pipelines.length - 1];
-  const cmd = pipeline?.commands[pipeline.commands.length - 1];
+  if (!pipeline || pipeline.negated) return null;
+  const cmd = pipeline.commands[pipeline.commands.length - 1];
   if (cmd?.type !== 'SimpleCommand' || !cmd.name) return null;
   const name = literalWordText(cmd.name);
   if (name !== 'command') return name;

--- a/packages/webapp/src/tools/bash-tool.ts
+++ b/packages/webapp/src/tools/bash-tool.ts
@@ -11,6 +11,7 @@ import {
   truncateTail,
 } from '@earendil-works/pi-coding-agent/dist/core/tools/truncate.js';
 import type { LickEvent } from '@slicc/shared-ts';
+import type { ScriptNode, WordNode } from 'just-bash';
 import { classifyImageMarkers } from '../base/image-markers.js';
 import { createLogger } from '../base/logger.js';
 import type { VirtualFS } from '../fs/index.js';
@@ -210,83 +211,73 @@ async function boundBashOutput(
   }
 }
 
-const SEARCH_COMMAND_PREFIX =
-  /^(?:[A-Za-z_][A-Za-z0-9_]*=[^\s]+\s+)*(?:command\s+)?(?:grep|egrep|fgrep|rg)\b/;
+/** Search commands whose exit 1 means "no match", not "error". */
+const SEARCH_COMMANDS = new Set(['grep', 'egrep', 'fgrep', 'rg']);
 
 /**
- * Split a command line into its top-level segments, honoring quotes and
- * escapes. Segments are separated by `;`, `|`, `&&`, and `||`; a lone `&`
- * (background) is not treated as a separator. Raw (untrimmed) segments are
- * returned, including any empty trailing segment after a final separator.
- *
- * Shared by `getLastCommandSegment` (search-output heuristic) and the
- * command-level sudo guard, which matches each non-empty segment against the
- * `Cmnd` policy.
+ * Literal text of a word built only from literal/quoted/escaped parts, else
+ * `null`. A command name carrying an expansion (`$grep`, `` `echo grep` ``)
+ * is not a static search invocation, so it fails the heuristic — which is the
+ * conservative answer.
  */
-export function splitCommandSegments(command: string): string[] {
-  const segments: string[] = [];
-  let current = '';
-  let quote: '"' | "'" | null = null;
-  let escaped = false;
-
-  const flush = () => {
-    segments.push(current);
-    current = '';
-  };
-
-  for (let i = 0; i < command.length; i++) {
-    const char = command[i];
-
-    if (escaped) {
-      current += char;
-      escaped = false;
-      continue;
+function literalWordText(word: WordNode): string | null {
+  let out = '';
+  for (const part of word.parts) {
+    switch (part.type) {
+      case 'Literal':
+      case 'SingleQuoted':
+      case 'Escaped':
+        out += part.value;
+        break;
+      case 'DoubleQuoted': {
+        for (const p of part.parts) {
+          if (p.type !== 'Literal' && p.type !== 'Escaped') return null;
+          out += p.value;
+        }
+        break;
+      }
+      default:
+        return null;
     }
-
-    if (char === '\\') {
-      current += char;
-      escaped = true;
-      continue;
-    }
-
-    if (quote) {
-      current += char;
-      if (char === quote) quote = null;
-      continue;
-    }
-
-    if (char === '"' || char === "'") {
-      current += char;
-      quote = char;
-      continue;
-    }
-
-    if ((char === '&' || char === '|') && command[i + 1] === char) {
-      flush();
-      i++;
-      continue;
-    }
-
-    if (char === ';' || char === '|') {
-      flush();
-      continue;
-    }
-
-    current += char;
   }
-
-  flush();
-  return segments;
+  return out;
 }
 
-function getLastCommandSegment(command: string): string {
-  const segments = splitCommandSegments(command);
-  return (segments[segments.length - 1] ?? '').trim();
+/**
+ * Name of the last top-level command a line runs, or `null` when it is not a
+ * static simple command. Uses just-bash's own AST (already parsed for `exec`)
+ * rather than a hand-rolled tokenizer: assignment prefixes (`VAR=1 grep`) live
+ * in `assignments` and never reach the name, and the one `command` builtin
+ * prefix the heuristic honours (`command rg …`) is unwrapped to its target.
+ */
+function lastCommandName(ast: ScriptNode): string | null {
+  const stmt = ast.statements[ast.statements.length - 1];
+  const pipeline = stmt?.pipelines[stmt.pipelines.length - 1];
+  const cmd = pipeline?.commands[pipeline.commands.length - 1];
+  if (cmd?.type !== 'SimpleCommand' || !cmd.name) return null;
+  const name = literalWordText(cmd.name);
+  if (name !== 'command') return name;
+  const target = cmd.args[0];
+  return target ? literalWordText(target) : null;
 }
 
-function isExpectedNoMatchSearch(command: string, exitCode: number, stderr: string): boolean {
+export function isExpectedNoMatchSearch(
+  shell: AlmostBashShellHeadless,
+  command: string,
+  exitCode: number,
+  stderr: string
+): boolean {
   if (exitCode !== 1 || stderr.trim()) return false;
-  return SEARCH_COMMAND_PREFIX.test(getLastCommandSegment(command));
+  let name: string | null;
+  try {
+    // `transform()` re-parses (cheap), same access pattern as `script-progress`.
+    // A parse error just means "not a recognised search" — the conservative
+    // answer keeps the non-zero exit flagged as an error.
+    name = lastCommandName(shell.getBash().transform(command).ast);
+  } catch {
+    return false;
+  }
+  return name !== null && SEARCH_COMMANDS.has(name);
 }
 
 /**
@@ -845,7 +836,8 @@ async function foregroundResult(
   return {
     content: await boundBashOutput(output, ctx.fs, ctx.tempDir, ctx.nextOutputSeq),
     isError:
-      result.exitCode !== 0 && !isExpectedNoMatchSearch(command, result.exitCode, result.stderr),
+      result.exitCode !== 0 &&
+      !isExpectedNoMatchSearch(ctx.shell, command, result.exitCode, result.stderr),
   };
 }
 

--- a/packages/webapp/tests/tools/bash-tool.test.ts
+++ b/packages/webapp/tests/tools/bash-tool.test.ts
@@ -5,39 +5,58 @@ import { AlmostBashShellHeadless } from '../../src/shell/almost-bash-shell-headl
 import {
   createBashTool,
   DEFAULT_BASH_BACKGROUND_AFTER_SECONDS,
-  splitCommandSegments,
+  isExpectedNoMatchSearch,
 } from '../../src/tools/bash-tool.js';
 import type { BashJobHost, ToolDefinition } from '../../src/tools/types.js';
 
-describe('splitCommandSegments', () => {
-  it('splits on ;, |, && and ||', () => {
-    const segments = splitCommandSegments('a | b && c || d ; e')
-      .map((s) => s.trim())
-      .filter(Boolean);
-    expect(segments).toEqual(['a', 'b', 'c', 'd', 'e']);
+describe('isExpectedNoMatchSearch', () => {
+  let fs: VirtualFS;
+  let shell: AlmostBashShellHeadless;
+  let counter = 0;
+
+  beforeEach(async () => {
+    fs = await VirtualFS.create({ dbName: `test-nomatch-${counter++}`, wipe: true });
+    shell = new AlmostBashShellHeadless({ fs });
   });
 
-  it('splits "a || b" into two segments with no spurious empty segment', () => {
-    expect(splitCommandSegments('a || b').map((s) => s.trim())).toEqual(['a', 'b']);
+  const ok = (command: string) => isExpectedNoMatchSearch(shell, command, 1, '');
+
+  it('treats a grep/rg family exit 1 with empty stderr as a no-match, not an error', () => {
+    expect(ok('grep foo file')).toBe(true);
+    expect(ok('egrep foo file')).toBe(true);
+    expect(ok('fgrep foo file')).toBe(true);
+    expect(ok('rg foo')).toBe(true);
   });
 
-  it('does not split a lone & (background)', () => {
-    expect(splitCommandSegments('git push & echo done').map((s) => s.trim())).toEqual([
-      'git push & echo done',
-    ]);
+  it('honours the last top-level command in a chain or pipeline', () => {
+    expect(ok('echo hi && grep foo file')).toBe(true);
+    expect(ok('cat file | rg foo')).toBe(true);
+    expect(ok('ls; grep foo file')).toBe(true);
+    // The search is NOT the last command: exit 1 is a real error.
+    expect(ok('grep foo file | wc -l')).toBe(false);
   });
 
-  it('ignores separators inside quotes and after escapes', () => {
-    expect(splitCommandSegments('echo "a | b" ; ls').map((s) => s.trim())).toEqual([
-      'echo "a | b"',
-      'ls',
-    ]);
-    expect(splitCommandSegments('echo a\\|b').map((s) => s.trim())).toEqual(['echo a\\|b']);
+  it('sees through assignment prefixes and the `command` builtin', () => {
+    expect(ok('GREP_COLOR=1 grep foo file')).toBe(true);
+    expect(ok('command rg foo')).toBe(true);
   });
 
-  it('returns a trailing empty segment after a final separator', () => {
-    const segs = splitCommandSegments('ls |');
-    expect((segs[segs.length - 1] ?? '').trim()).toBe('');
+  it('does not treat a non-search command as a no-match', () => {
+    expect(ok('cat missing')).toBe(false);
+    expect(ok('false')).toBe(false);
+    // `grep` reached via an expansion is not a static search invocation.
+    expect(ok('$tool foo')).toBe(false);
+  });
+
+  it('only fires on exit 1 with empty stderr', () => {
+    expect(isExpectedNoMatchSearch(shell, 'grep foo file', 2, '')).toBe(false);
+    expect(isExpectedNoMatchSearch(shell, 'grep foo file', 1, 'grep: file: No such file')).toBe(
+      false
+    );
+  });
+
+  it('stays conservative when the command line does not parse', () => {
+    expect(ok('grep foo "unterminated')).toBe(false);
   });
 });
 

--- a/packages/webapp/tests/tools/bash-tool.test.ts
+++ b/packages/webapp/tests/tools/bash-tool.test.ts
@@ -55,6 +55,14 @@ describe('isExpectedNoMatchSearch', () => {
     );
   });
 
+  it('does not exempt a negated search pipeline (exit 1 means a match was found)', () => {
+    // `! grep needle file` exits 1 when grep DID match — a genuine signal the
+    // exemption must not suppress. The command is still named `grep`.
+    expect(ok('! grep foo file')).toBe(false);
+    expect(ok('! rg foo')).toBe(false);
+    expect(ok('echo hi && ! grep foo file')).toBe(false);
+  });
+
   it('stays conservative when the command line does not parse', () => {
     expect(ok('grep foo "unterminated')).toBe(false);
   });


### PR DESCRIPTION
Closes #2428

## What changed

The `bash` tool carried a bespoke 55-line quote/escape-aware shell tokenizer
(`splitCommandSegments`) whose only job was to grab the last top-level command
so a `grep`/`rg` exit 1 could be classified as a no-match rather than an error.
The docstring also claimed a second consumer (the sudo command guard) that does
not exist — that guard does no splitting of its own.

This replaces the hand-rolled lexer with just-bash's own AST, the same parser
already in the build and already used two directories over in
`shell/progress/script-progress.ts` (`bash.transform(command).ast`):

- `lastCommandName(ast)` walks to the final statement → final pipeline → final
  command and returns its literal name. Assignment prefixes (`VAR=1 grep`) live
  in `assignments` and never reach the name; the `command` builtin prefix
  (`command rg …`) is unwrapped to its target — both handled by the parser
  instead of a regex.
- `isExpectedNoMatchSearch(shell, …)` now pulls the AST via
  `shell.getBash().transform()` and tests the name against the
  `grep`/`egrep`/`fgrep`/`rg` set. A parse error or any non-static command
  (e.g. `$tool foo`) yields the conservative answer — the non-zero exit stays
  flagged as an error.

The bespoke tokenizer, its `getLastCommandSegment` helper, the
`SEARCH_COMMAND_PREFIX` regex, and the stale "shared with the sudo guard"
docstring are all deleted.

## Tests

Replaced the `splitCommandSegments` unit tests with focused
`isExpectedNoMatchSearch` tests covering: the grep/rg family, last-command
selection in chains/pipelines (`grep … | wc -l` is correctly NOT a no-match),
assignment prefixes and `command`, non-search commands, expansion-named
commands, the exit-1/empty-stderr gate, and the parse-error fallback.

## Verification

- `npx biome check --write` (touched files) — clean
- `npm run typecheck` — pass
- `npx vitest run packages/webapp/tests/tools/bash-tool.test.ts` — 60 passed
- `npm run verify` — all 7 checks pass (incl. boy-scout-debt, deadcode)
- `npm run test:coverage:webapp` — pass
- `npm run build -w @slicc/webapp` and `-w @slicc/chrome-extension` — pass
- `npm run bundle-size` — within budgets
