### PR TITLE
approvals: never prompt for pre-granted writablePaths; settle covered pending requests; no duplicate sudoers rules

### DIFF
--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -133,9 +133,9 @@ Two consequences worth knowing:
   (`getPolicy()`) still honours it.
 - The grant lives in code (`builtinScoopGrants()` in
   `packages/webapp/src/base/sudoers.ts`), merged in by `getPolicyForScoop`, not
-  in the generated `/scoops/<folder>/etc/sudoers`. That file is written only
-  when absent — so a file-based grant would never reach an already-created
-  scoop. The matching ACL exemption is `ALWAYS_WRITABLE_PREFIXES` in
+  in the per-scoop config grants — those are compiled from each scoop's own
+  `ScoopConfig`, while `/tmp` applies to every scoop unconditionally. The
+  matching ACL exemption is `ALWAYS_WRITABLE_PREFIXES` in
   `packages/webapp/src/fs/restricted-fs.ts`; `SudoFS` and `RestrictedFS` gate
   independently, so both layers must agree or the write is walled underneath
   the grant.
@@ -243,9 +243,9 @@ Orchestrator.init()
 
 Orchestrator.createScoopTab(jid)
   ├─ if non-cone: RestrictedFS(..., 'sudo-delegated')   // writes pass through to SudoFS
-  ├─ if non-cone: registerScoopConfig(folder, config)   // always — config grants in memory (#2416)
-  ├─ if non-cone: seedScoopSudoers(folder, config) ...  // first boot only
-  ├─                              ... or reloadScoopPolicyByFolder()  // existing file
+  ├─ if non-cone: initScoopPolicy(folder, config)  // config grants registered in memory (#2416)
+  │                                                // + load the on-disk Always-grants file
+  │                                                //   (legacy generated files are discarded)
   └─ new ScoopContext(scoop, callbacks, fs, ..., sudoManager)
 
 ScoopContext.init() — non-cone scoop
@@ -396,8 +396,12 @@ told to wait for a user who was never prompted.
 
 "Always" grants for `kind: 'command' | 'read' | 'write'` are persisted via
 `SudoManager.appendScoopRule(folder, kind, pattern)` (raw-VFS write, same trusted
-sink that powers `seedScoopSudoers`, so it bypasses the per-scoop self-protection
-on `/scoops/<folder>/etc/sudoers`). The append is idempotent — a rule that is
+sink that powers `initScoopPolicy`, so it bypasses the per-scoop self-protection
+on `/scoops/<folder>/etc/sudoers`). Since #2416 that file holds ONLY these
+approved "Always" grants — the `ScoopConfig` sandbox is registered in memory
+and never persisted, so replacing a scoop's config genuinely revokes the old
+authority instead of unioning with a stale file (a legacy generated file found
+on load is discarded fail-closed; its grants re-prompt once). The append is idempotent — a rule that is
 already in the file is never duplicated (#2416) — and it is the ONLY persistence
 path for a scoop's grant: the scoop's `SudoFS` gate gets a no-op `onGrant` sink,
 so an `always` decision never leaks into the global `/etc/sudoers.d/granted`

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -238,11 +238,12 @@ Orchestrator.init()
   └─ new SudoManager({ fs: sharedFs, watcher })  // seed + load + watch
        ├─ getBroker()         → createSudoBroker()         // user broker (cone)
        ├─ getPolicy()         → live merged global SudoersPolicy
-       ├─ getPolicyForScoop() → builtin /tmp grants ∪ global ∪ /scoops/<folder>/etc/sudoers
+       ├─ getPolicyForScoop() → builtin /tmp grants ∪ global ∪ config grants ∪ /scoops/<folder>/etc/sudoers
        └─ getShellConfig()    → { getPolicy, broker, persistCommandGrant }
 
 Orchestrator.createScoopTab(jid)
   ├─ if non-cone: RestrictedFS(..., 'sudo-delegated')   // writes pass through to SudoFS
+  ├─ if non-cone: registerScoopConfig(folder, config)   // always — config grants in memory (#2416)
   ├─ if non-cone: seedScoopSudoers(folder, config) ...  // first boot only
   ├─                              ... or reloadScoopPolicyByFolder()  // existing file
   └─ new ScoopContext(scoop, callbacks, fs, ..., sudoManager)
@@ -378,7 +379,17 @@ The pending-request registry lives on the `Orchestrator` (`enqueueSudoRequest`,
 FS/shell sees a regular `SudoBroker` built by `createConeApprovalBroker` whose
 `requestApproval` enqueues into the same registry as the explicit tool. Both
 paths resolve fail-closed (`deny`) on transport error, scoop drop, orchestrator
-shutdown, or the per-request timeout (`CONE_SUDO_TIMEOUT_MS`). The timeout path
+shutdown, or the per-request timeout (`CONE_SUDO_TIMEOUT_MS`). Requests are
+independent: a pending approval blocks only the gated operation that raised it,
+never another scoop's (or the same scoop's other granted) operations. The cone
+does review requests serially — it is a single agent processing its message
+queue one turn at a time — which is intended: one approver, ordered decisions.
+After any per-scoop policy reload (an "Always" grant, a config registration, a
+sudoers-file edit), the orchestrator re-evaluates that scoop's pending requests
+and auto-resolves as `allow` those the policy now covers with a `NOPASSWD`
+grant (`ScoopApprovalRouter.settleGrantedRequests`, #2416), so one "Always"
+approval unblocks the scoop's other queued requests for the same subtree
+instead of stalling them until each is individually approved. The timeout path
 tags its decision `reason: 'cone-timeout'` so the scoop is told its escalation
 went unanswered rather than refused — and, unlike the cone → user leg, is not
 told to wait for a user who was never prompted.
@@ -386,7 +397,11 @@ told to wait for a user who was never prompted.
 "Always" grants for `kind: 'command' | 'read' | 'write'` are persisted via
 `SudoManager.appendScoopRule(folder, kind, pattern)` (raw-VFS write, same trusted
 sink that powers `seedScoopSudoers`, so it bypasses the per-scoop self-protection
-on `/scoops/<folder>/etc/sudoers`). Persisted `Read` globs also widen the live
+on `/scoops/<folder>/etc/sudoers`). The append is idempotent — a rule that is
+already in the file is never duplicated (#2416) — and it is the ONLY persistence
+path for a scoop's grant: the scoop's `SudoFS` gate gets a no-op `onGrant` sink,
+so an `always` decision never leaks into the global `/etc/sudoers.d/granted`
+drop-in (which would silently widen every other unit's policy). Persisted `Read` globs also widen the live
 `RestrictedFS` ACL, and are reapplied from the scoop policy whenever its context
 is recreated. Live sudoers reloads replace those dynamic grants, so manually
 adding or revoking a rule updates the running scoop too; non-matching sibling
@@ -415,9 +430,19 @@ actions escalate to the cone instead of dying with a hard wall:
   outside the scoop's `writablePaths` no longer throws `EACCES` here; it
   passes through to the outer `SudoFS`, whose `defaultDisposition:
 'require-approval'` upgrades the unmatched `no-match` to an escalation. The
-  per-scoop sudoers file (seeded from `ScoopConfig.writablePaths` as
-  `NOPASSWD Write <p>/**` rules) keeps in-sandbox writes prompt-free, and the
-  built-in `/tmp` grant does the same for shared scratch space.
+  `ScoopConfig` sandbox keeps in-sandbox writes prompt-free: its grants
+  (`NOPASSWD Write <p>` + `<p>/**` per `writablePaths` entry, regardless of
+  trailing-slash spelling) are registered **synchronously in memory**
+  (`SudoManager.registerScoopConfig`, #2416) on every context creation, so a
+  stale `/scoops/<folder>/etc/sudoers` file — folder reuse across scoop
+  generations, a restore with changed config — or a reload race can never
+  withhold a configured path and prompt for it. The on-disk file only ADDS
+  persisted "Always" grants on top. The built-in `/tmp` grant does the same
+  for shared scratch space. Note the grant covers exactly the configured
+  roots: a tool family that writes to another absolute root (e.g. a skill
+  writing crops to `/.migration/`) still escalates unless that root is listed
+  in `writablePaths` — point skills at the scoop scratch dir, `/shared/`, or
+  `/tmp/` instead of inventing new VFS roots.
   - **Reads stay silently filtered.** `SudoFS` only applies the
     `'require-approval'` default to **writes** — `RestrictedFS` keeps
     returning `ENOENT`/`[]` for out-of-sandbox reads. This is intentional:

--- a/packages/vfs-root/workspace/skills/delegation/SKILL.md
+++ b/packages/vfs-root/workspace/skills/delegation/SKILL.md
@@ -126,6 +126,7 @@ Subtleties:
 - **`writablePaths` are always readable too.** A true read-nothing sandbox needs both `visiblePaths: []` AND `writablePaths: []`.
 - **Mounts remain readable regardless** of `visiblePaths`. `mount` overlays are always visible — that's how scoops can work against a mounted S3 bucket or DA repo without you naming the path explicitly.
 - **`allowedCommands` applies recursively** — pipelines, command substitutions, and network commands are all gated. Pass `["*"]` for explicit unrestricted.
+- **List every absolute root the scoop's tools write to.** Some tool families write outside the scratch dir — `playwright-cli` logs sessions and screenshots to `/.playwright/` — so include those roots in `writablePaths` (any spelling works: `/x`, `/x/`, `/x/**`), or every such write escalates to you for approval. Prefer pointing skills at `/scoops/<folder>/`, `/shared/`, or `/tmp/` over inventing new VFS roots.
 
 ### How to choose
 

--- a/packages/webapp/src/base/sudoers.ts
+++ b/packages/webapp/src/base/sudoers.ts
@@ -255,9 +255,9 @@ export function parseSudoers(text: string): SudoersPolicy {
  * other's scratch files and the cone sees all of them, so nothing secret or
  * trust-bearing belongs here.
  *
- * These live in code rather than in the generated `/scoops/<folder>/etc/sudoers`
- * because that file is written only when absent (it carries persisted "Always"
- * grants), so a file-based grant would never reach an already-created scoop.
+ * These live in code rather than in `/scoops/<folder>/etc/sudoers` because
+ * that file carries only persisted "Always" grants (#2416) — a file-based
+ * grant would never reach a scoop that was not explicitly granted it.
  *
  * Self-protection is unaffected: it lives in `matchPath` and no `NOPASSWD`
  * rule — including these — can override it.

--- a/packages/webapp/src/fs/restricted-fs.ts
+++ b/packages/webapp/src/fs/restricted-fs.ts
@@ -75,9 +75,9 @@ const VIRTUAL_DEVICES: Record<string, VirtualDevice> = {
  * `SudoManager.getPolicyForScoop`. Changing one without the other either
  * re-introduces the approval prompt or walls the write underneath it.
  *
- * They are deliberately NOT in the generated `/scoops/<folder>/etc/sudoers`
- * — that file is written only when absent, so a rule there would never
- * reach an already-created scoop.
+ * They are deliberately NOT part of the per-scoop config grants — those are
+ * compiled from each scoop's own `ScoopConfig`, while `/tmp` applies to every
+ * scoop unconditionally.
  */
 const ALWAYS_WRITABLE_PREFIXES = ['/tmp/'];
 

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -446,7 +446,14 @@ export class Orchestrator implements ConeApprovalRouter {
         this.sudoManager = new SudoManager({
           fs: sharedFs,
           watcher: fsWatcher,
-          onPolicyReload: (folder) => this.lifecycle.syncReadGrants(folder),
+          onPolicyReload: (folder) => {
+            this.lifecycle.syncReadGrants(folder);
+            // Unblock any pending sudo requests the reloaded policy now
+            // grants (#2416) — e.g. after an "Always" approval widened the
+            // scoop's sandbox, its other queued requests for the same
+            // subtree must not stall until individually approved.
+            this.approvalRouter.settleGrantedRequests(folder);
+          },
         });
         await this.sudoManager.init();
         tick();
@@ -1222,7 +1229,14 @@ export class Orchestrator implements ConeApprovalRouter {
     this.sudoManager = new SudoManager({
       fs: this.sharedFs,
       watcher: this.fsWatcher,
-      onPolicyReload: (folder) => this.lifecycle.syncReadGrants(folder),
+      onPolicyReload: (folder) => {
+        this.lifecycle.syncReadGrants(folder);
+        // Unblock any pending sudo requests the reloaded policy now
+        // grants (#2416) — e.g. after an "Always" approval widened the
+        // scoop's sandbox, its other queued requests for the same
+        // subtree must not stall until individually approved.
+        this.approvalRouter.settleGrantedRequests(folder);
+      },
     });
     await this.sudoManager.init();
     this.llmsTxtIgnorePolicy?.dispose();
@@ -1477,11 +1491,19 @@ export class Orchestrator implements ConeApprovalRouter {
         wait: (ms) => new Promise((res) => setTimeout(res, ms)),
       },
       knownSecrets: getStrictKnownSecretRedactor(),
+      // SAFETY: `VirtualFS` structurally implements the read/write surface of
+      // `LocalVfsClient` / `WritableVfsClient` (readFile/writeFile/exists/
+      // readDir); the client types are narrower views declared in a package
+      // that cannot import VirtualFS, so the bridge is asserted here.
       snapshotStore: {
         read: (sessionId) => readSnapshot(fs as unknown as LocalVfsClient, sessionId),
         write: (sessionId, snapshot) =>
+          // SAFETY: same structural bridge as above — VirtualFS satisfies the
+          // WritableVfsClient write surface.
           writeSnapshot(fs as unknown as WritableVfsClient, sessionId, snapshot),
       },
+      // SAFETY: same structural bridge as above — VirtualFS satisfies the
+      // LocalVfsClient read surface.
       vfs: fs as unknown as LocalVfsClient,
       getActiveSessionInfo: () => {
         const cone = this.defaultRoot();

--- a/packages/webapp/src/scoops/scoop-approval-router.ts
+++ b/packages/webapp/src/scoops/scoop-approval-router.ts
@@ -16,6 +16,7 @@
  */
 
 import { createLogger } from '../base/logger.js';
+import { matchCommand, matchPath } from '../base/sudoers.js';
 import {
   type ConeApprovalRouter,
   ConeRequestRegistry,
@@ -117,6 +118,53 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
   /** Fail-closed every pending request. Used by `shutdown`. */
   failAll(): number {
     return this.registry.failAll();
+  }
+
+  /**
+   * Resolve every pending request that the (re)loaded policy now covers with
+   * a `NOPASSWD` grant (#2416). Called after a per-scoop policy reload — an
+   * "Always" approval, a config (re)registration, or a sudoers-file edit — so
+   * concurrent gated operations for a freshly granted path/command unblock
+   * immediately instead of stalling until each is individually approved
+   * (which also appended duplicate rules). Scoped to `folder` when given;
+   * `undefined` (a global policy reload) re-evaluates every pending request.
+   * Returns the number of requests settled.
+   */
+  settleGrantedRequests(folder?: string): number {
+    const sudoManager = this.deps.getSudoManager();
+    if (!sudoManager) return 0;
+    const scoops = this.deps.getScoops();
+    let settled = 0;
+    for (const pending of this.registry.list()) {
+      const scoop = scoops.get(pending.scoopJid);
+      if (!scoop) continue;
+      if (folder !== undefined && scoop.folder !== folder) continue;
+      const policy = sudoManager.getPolicyForScoop(scoop.folder);
+      const { kind, detail } = pending.request;
+      const granted =
+        kind === 'command'
+          ? matchCommand(policy, detail) === 'nopasswd-allow'
+          : kind === 'read' || kind === 'write'
+            ? matchPath(policy, kind, detail) === 'nopasswd-allow'
+            : false;
+      if (!granted) continue;
+      if (this.registry.resolve(pending.id, { decision: 'allow' })) {
+        settled++;
+        log.info('Sudo request auto-settled: policy now grants it', {
+          id: pending.id,
+          folder: scoop.folder,
+          kind,
+          detail: detail.slice(0, 80),
+        });
+        void this.persistLickDecision(pending.id, 'allow').catch((err) => {
+          log.warn('Failed to persist auto-granted lick decision', {
+            id: pending.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
+    }
+    return settled;
   }
 
   async enqueueSudoRequest(scoopJid: string, request: SudoRequest): Promise<SudoDecision> {

--- a/packages/webapp/src/scoops/scoop-approval-router.ts
+++ b/packages/webapp/src/scoops/scoop-approval-router.ts
@@ -78,7 +78,7 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
     // shutdown) must still retire the persisted `pending` lick card, or the
     // chat keeps showing a request `list_sudo_requests` no longer knows about.
     this.registry = new ConeRequestRegistry({
-      onAutoSettle: (id, reason) => this.handleAutoSettle(id, reason),
+      onAutoSettle: (id, reason, scoopJid) => this.handleAutoSettle(id, reason, scoopJid),
     });
   }
 
@@ -89,9 +89,9 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
    * stored card. Fire-and-forget: settling is synchronous, persistence is
    * best-effort.
    */
-  private handleAutoSettle(id: string, reason: SudoSettleReason): void {
+  private handleAutoSettle(id: string, reason: SudoSettleReason, scoopJid?: string): void {
     log.info('Sudo request auto-settled fail-closed; retiring lick card', { id, reason });
-    void this.persistLickDecision(id, 'deny').catch((err) => {
+    void this.persistLickDecision(id, 'deny', scoopJid).catch((err) => {
       log.warn('Failed to persist auto-settled lick decision', {
         id,
         reason,
@@ -148,6 +148,8 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
             ? matchPath(policy, kind, detail) === 'nopasswd-allow'
             : false;
       if (!granted) continue;
+      // `resolve()` deletes the registry entry, so the requester's identity
+      // (and with it the owning cone) must travel with the persistence call.
       if (this.registry.resolve(pending.id, { decision: 'allow' })) {
         settled++;
         log.info('Sudo request auto-settled: policy now grants it', {
@@ -156,7 +158,7 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
           kind,
           detail: detail.slice(0, 80),
         });
-        void this.persistLickDecision(pending.id, 'allow').catch((err) => {
+        void this.persistLickDecision(pending.id, 'allow', pending.scoopJid).catch((err) => {
           log.warn('Failed to persist auto-granted lick decision', {
             id: pending.id,
             error: err instanceof Error ? err.message : String(err),
@@ -269,6 +271,10 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
       return { settled: false, persisted: false };
     }
 
+    // Capture ownership BEFORE settling — resolve() deletes the registry
+    // entry, and the card flip below must land under the requesting scoop's
+    // owning cone, not the default root.
+    const requesterJid = pending.scoopJid;
     // Claim the request synchronously before any persistence await. This
     // cancels its fail-closed timer, so an expired request can never gain a
     // durable rule after the registry has already denied it.
@@ -314,7 +320,7 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
       }
     }
 
-    await this.persistLickDecision(id, decision.decision);
+    await this.persistLickDecision(id, decision.decision, requesterJid);
     return { settled, persisted, persistedPattern, persistError, scoopFolder, kind };
   }
 
@@ -322,10 +328,21 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
    * Flip the rendered + persisted state of an actionable lick once its
    * decision settles. Best-effort — a missing message or store error is
    * logged, not thrown.
+   *
+   * `scoopJid` names the requesting scoop so the card is looked up under its
+   * OWNING cone. Callers that settle through the registry must pass it
+   * explicitly — the registry entry is already deleted by the time this runs,
+   * so the fallback lookup would resolve to the DEFAULT root and, in a
+   * multi-cone session, flip nothing while the owning cone's card stayed
+   * pending (#2455 review).
    */
-  async persistLickDecision(lickId: string, decision: SudoDecision['decision']): Promise<void> {
+  async persistLickDecision(
+    lickId: string,
+    decision: SudoDecision['decision'],
+    scoopJid?: string
+  ): Promise<void> {
     const lickState = decision === 'deny' ? 'dismissed' : 'confirmed';
-    const cone = this.deps.findApprover(this.registry.get(lickId)?.scoopJid);
+    const cone = this.deps.findApprover(scoopJid ?? this.registry.get(lickId)?.scoopJid);
     if (!cone) return;
     try {
       const messages = await this.deps.getMessagesForScoop(cone.jid);

--- a/packages/webapp/src/scoops/scoop-context/shell-and-skills.ts
+++ b/packages/webapp/src/scoops/scoop-context/shell-and-skills.ts
@@ -89,6 +89,9 @@ export async function initShellAndSkills(deps: ShellAndSkillsDeps): Promise<Shel
           broker: sudoWiring.broker,
           getPolicy: sudoWiring.getPolicy,
           defaultDisposition: sudoWiring.defaultDisposition,
+          // Non-cone scoops get a no-op sink (#2416): their `always` grants
+          // are persisted scoped by the approval router, not globally.
+          ...(sudoWiring.onGrant ? { onGrant: sudoWiring.onGrant } : {}),
         })
       : fs
   ) as VirtualFS;

--- a/packages/webapp/src/scoops/scoop-context/sudo-wiring.ts
+++ b/packages/webapp/src/scoops/scoop-context/sudo-wiring.ts
@@ -10,7 +10,7 @@
  * readable in one screen instead of woven through shell construction.
  */
 
-import type { DefaultDisposition, SudoersPolicy } from '../../base/sudoers.js';
+import type { DefaultDisposition, PathOp, SudoersPolicy } from '../../base/sudoers.js';
 import type { ShellSudoConfig } from '../../shell/almost-bash-shell-headless.js';
 import type { SudoManager } from '../../sudo/sudo-manager.js';
 import type { SudoBroker, SudoDecision, SudoRequest } from '../../sudo/types.js';
@@ -21,6 +21,15 @@ export interface SudoWiring {
   getPolicy: () => SudoersPolicy;
   defaultDisposition: DefaultDisposition;
   shellConfig: ShellSudoConfig;
+  /**
+   * `SudoFS` grant sink for `always` decisions. `undefined` for a cone (the
+   * gate's default persists to the global `/etc/sudoers.d/granted`); a no-op
+   * for non-cone scoops — their `always` decision is already persisted SCOPED
+   * to `/scoops/<folder>/etc/sudoers` by the approval router
+   * (`SudoManager.appendScoopRule`), so the default sink would leak the grant
+   * into every unit's policy and accumulate duplicate rules (#2416).
+   */
+  onGrant?: (op: PathOp, pattern: string) => void | Promise<void>;
 }
 
 export interface SudoWiringDeps {
@@ -81,5 +90,10 @@ export function buildSudoWiring({
     defaultDisposition,
     persistCommandGrant,
   };
-  return { broker, getPolicy, defaultDisposition, shellConfig };
+  // Same isolation for FS-level path grants (#2416): non-cone scoops must not
+  // write `always` grants to the global granted file — the router already
+  // persisted them scoped to the scoop's own sudoers.
+  const wiring: SudoWiring = { broker, getPolicy, defaultDisposition, shellConfig };
+  if (!policy.persistCommandGrants) wiring.onGrant = async () => {};
+  return wiring;
 }

--- a/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
+++ b/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
@@ -347,6 +347,11 @@ export class ScoopLifecycleManager {
     const sharedFs = this.deps.getSharedFs();
     if (!sudoManager || !sharedFs) return;
     try {
+      // Config grants are authoritative and registered synchronously in
+      // memory (#2416) — a stale on-disk file (folder reuse, restores) or a
+      // reload race can never withhold a configured writablePaths entry and
+      // prompt for a pre-granted path.
+      sudoManager.registerScoopConfig(scoop.folder, scoop.config);
       const path = `/scoops/${scoop.folder}/etc/sudoers`;
       if (await sharedFs.exists(path)) {
         await sudoManager.reloadScoopPolicyByFolder(scoop.folder);

--- a/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
+++ b/packages/webapp/src/scoops/scoop-lifecycle-manager.ts
@@ -336,30 +336,21 @@ export class ScoopLifecycleManager {
   }
 
   /**
-   * Seed (or reload) the per-scoop sudoers file from `ScoopConfig`. Missing
-   * file: seed from config. Existing file: reload into the in-memory cache
-   * (overwriting on every boot would wipe any "Always" grants added
-   * mid-session). Best-effort: a failed seed is logged and the scoop boots
-   * with whatever policy is already on disk.
+   * Initialize the scoop's sudo policy (#2416): config-derived grants are
+   * registered synchronously in memory (authoritative — a stale on-disk file,
+   * folder reuse, or a reload race can neither withhold a configured
+   * `writablePaths` entry nor retain authority a replacement config revoked),
+   * and the on-disk Always-grants file is loaded (legacy generated files are
+   * discarded fail-closed). Best-effort: a failure is logged and the scoop
+   * boots with whatever policy is already cached.
    */
   private async ensureSudoersLoaded(scoop: RegisteredScoop): Promise<void> {
     const sudoManager = this.deps.getSudoManager();
-    const sharedFs = this.deps.getSharedFs();
-    if (!sudoManager || !sharedFs) return;
+    if (!sudoManager) return;
     try {
-      // Config grants are authoritative and registered synchronously in
-      // memory (#2416) — a stale on-disk file (folder reuse, restores) or a
-      // reload race can never withhold a configured writablePaths entry and
-      // prompt for a pre-granted path.
-      sudoManager.registerScoopConfig(scoop.folder, scoop.config);
-      const path = `/scoops/${scoop.folder}/etc/sudoers`;
-      if (await sharedFs.exists(path)) {
-        await sudoManager.reloadScoopPolicyByFolder(scoop.folder);
-      } else {
-        await sudoManager.seedScoopSudoers(scoop.folder, scoop.config);
-      }
+      await sudoManager.initScoopPolicy(scoop.folder, scoop.config);
     } catch (err) {
-      log.warn('Failed to seed per-scoop sudoers; continuing with existing policy', {
+      log.warn('Failed to initialize per-scoop sudo policy; continuing with existing policy', {
         folder: scoop.folder,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -761,6 +752,10 @@ export class ScoopLifecycleManager {
         count: sudoFailed,
       });
     }
+    // Evict the folder's cached sudo policies AFTER pending requests are
+    // failed closed — repeated one-shot agents would otherwise grow the
+    // per-folder maps for the orchestrator's lifetime (#2455 review).
+    if (scoop) this.deps.getSudoManager()?.forgetScoopPolicies(scoop.folder);
     log.info('Scoop unregistered', { jid });
     if (scoop) {
       try {

--- a/packages/webapp/src/sudo/cone-broker.ts
+++ b/packages/webapp/src/sudo/cone-broker.ts
@@ -87,11 +87,13 @@ export interface ConeRequestRegistryOptions {
   /**
    * Notified whenever a request is settled fail-closed WITHOUT a cone
    * decision — timeout, scoop drop, or shutdown. The owner uses it to flip
-   * the persisted lick card off `pending`. Never fired for a normal
+   * the persisted lick card off `pending`; `scoopJid` identifies the
+   * requester (the entry is already deleted when this fires, so the owner
+   * cannot look it up). Never fired for a normal
    * {@link ConeRequestRegistry.resolve} (the cone already knows). Best-effort:
    * any error thrown by the callback is swallowed so it can't wedge teardown.
    */
-  onAutoSettle?: (id: string, reason: SudoSettleReason) => void;
+  onAutoSettle?: (id: string, reason: SudoSettleReason, scoopJid: string) => void;
 }
 
 interface RegistryEntry {
@@ -126,7 +128,7 @@ export class ConeRequestRegistry {
   private readonly newId: () => string;
   private readonly setTimer: (cb: () => void, ms: number) => unknown;
   private readonly clearTimer: (handle: unknown) => void;
-  private readonly onAutoSettle: (id: string, reason: SudoSettleReason) => void;
+  private readonly onAutoSettle: (id: string, reason: SudoSettleReason, scoopJid: string) => void;
 
   constructor(opts: ConeRequestRegistryOptions = {}) {
     this.timeoutMs = opts.timeoutMs ?? CONE_SUDO_TIMEOUT_MS;
@@ -137,9 +139,9 @@ export class ConeRequestRegistry {
   }
 
   /** Fire the auto-settle hook, isolating a throwing callback from teardown. */
-  private notifyAutoSettle(id: string, reason: SudoSettleReason): void {
+  private notifyAutoSettle(id: string, reason: SudoSettleReason, scoopJid: string): void {
     try {
-      this.onAutoSettle(id, reason);
+      this.onAutoSettle(id, reason, scoopJid);
     } catch {
       // Best-effort: a broken card-flip must never wedge timeout / drop / shutdown.
     }
@@ -165,7 +167,7 @@ export class ConeRequestRegistry {
           // this leg, so the scoop's gate must not tell it to wait for the
           // user — the cone is the approver that never answered.
           entry.resolve(timedOutDecision('cone-timeout'));
-          this.notifyAutoSettle(id, 'expired');
+          this.notifyAutoSettle(id, 'expired', entry.scoopJid);
         }, this.timeoutMs);
       }
       this.pending.set(id, { scoopJid, request, resolve, timerHandle });
@@ -199,7 +201,7 @@ export class ConeRequestRegistry {
       this.pending.delete(id);
       if (entry.timerHandle != null) this.clearTimer(entry.timerHandle);
       entry.resolve({ decision: 'deny' });
-      this.notifyAutoSettle(id, 'scoop-dropped');
+      this.notifyAutoSettle(id, 'scoop-dropped', entry.scoopJid);
       count++;
     }
     return count;
@@ -211,7 +213,7 @@ export class ConeRequestRegistry {
     for (const [id, entry] of this.pending) {
       if (entry.timerHandle != null) this.clearTimer(entry.timerHandle);
       entry.resolve({ decision: 'deny' });
-      this.notifyAutoSettle(id, 'shutdown');
+      this.notifyAutoSettle(id, 'shutdown', entry.scoopJid);
       count++;
     }
     this.pending.clear();

--- a/packages/webapp/src/sudo/sudo-manager.ts
+++ b/packages/webapp/src/sudo/sudo-manager.ts
@@ -80,10 +80,39 @@ function trimTrailingSlash(s: string): string {
 }
 
 /**
- * Generate a sudoers file body from a {@link ScoopConfig}. The scoop sandbox
- * is expressed as NOPASSWD grants — explicit allow-lists that suppress the
- * `require-approval` default disposition non-cone contexts apply for
- * unmatched actions:
+ * First line of the LEGACY generated per-scoop sudoers format (pre-#2416).
+ * Those files persisted the ScoopConfig sandbox rules to disk, mixed
+ * indistinguishably with appended "Always" grants — which meant a stale file
+ * from a previous scoop generation silently retained authority a narrower
+ * replacement config had revoked. Files carrying this header are discarded on
+ * {@link SudoManager.initScoopPolicy} (fail-closed: ambiguous rules are
+ * dropped rather than retained; an "Always" grant re-prompts once).
+ */
+const LEGACY_GENERATED_HEADER =
+  '# Per-scoop sudoers — generated from ScoopConfig (sandbox surface).';
+
+/**
+ * Header for the current per-scoop sudoers format: the file holds ONLY
+ * approved "Always" grants. Sandbox grants come from `ScoopConfig` and are
+ * registered in memory ({@link SudoManager.registerScoopConfig}), never
+ * persisted here — so replacing a scoop's config genuinely revokes the old
+ * authority instead of unioning with it.
+ */
+const SCOOP_SUDOERS_HEADER = [
+  '# Per-scoop sudoers — approved "Always" grants for this scoop.',
+  '# Sandbox grants come from ScoopConfig and are registered in memory, not here.',
+  '# Writes to this file always require approval (self-protected).',
+  '',
+].join('\n');
+
+/**
+ * Generate a sudoers policy body from a {@link ScoopConfig}. Since #2416 the
+ * output is compiled straight into the in-memory per-scoop policy
+ * ({@link SudoManager.registerScoopConfig}) and is never written to disk —
+ * persisting it let stale config rules survive a narrower replacement config.
+ * The scoop sandbox is expressed as NOPASSWD grants — explicit allow-lists
+ * that suppress the `require-approval` default disposition non-cone contexts
+ * apply for unmatched actions:
  *
  *   - `allowedCommands` → two token-anchored rules per entry: `NOPASSWD Cmnd <c>`
  *     (the bare command) and `NOPASSWD Cmnd <c> *` (the command with any
@@ -93,9 +122,8 @@ function trimTrailingSlash(s: string): string {
  *   - `writablePaths`   → `NOPASSWD Write <p>/**` per entry.
  *   - `visiblePaths`    → `NOPASSWD Read  <p>/**` per entry.
  *
- * The always-on `/tmp` grant is deliberately NOT emitted here — this file is
- * only written when one does not already exist, so a scoop created before the
- * grant landed would never pick it up. It lives in `builtinScoopGrants()`
+ * The always-on `/tmp` grant is deliberately NOT emitted here — it applies to
+ * every scoop regardless of config, so it lives in `builtinScoopGrants()`
  * (`base/sudoers.ts`) and is merged in by {@link SudoManager.getPolicyForScoop}.
  *
  * Each pattern is run through {@link sanitizeGrantPattern} so a value carrying
@@ -103,11 +131,7 @@ function trimTrailingSlash(s: string): string {
  * encoded here — it lives in `matchPath` and applies even with these grants.
  */
 export function generateScoopSudoers(config?: ScoopConfig | null): string {
-  const lines: string[] = [
-    '# Per-scoop sudoers — generated from ScoopConfig (sandbox surface).',
-    '# Writes to this file always require approval (self-protected).',
-    '',
-  ];
+  const lines: string[] = [];
 
   const allowed = config?.allowedCommands;
   if (allowed === undefined || allowed.includes('*')) {
@@ -264,24 +288,41 @@ export class SudoManager {
   }
 
   /**
-   * Generate + write a scoop's `/scoops/<folder>/etc/sudoers` from its config,
-   * then load the resulting policy into the per-scoop cache. Overwrites any
-   * existing file — the config is authoritative when this is called. The
-   * write goes through the raw VFS handle, so the self-protection invariant
-   * (which lives in the {@link createSudoFs} proxy) is not in play here.
+   * Initialize a scoop's sudo policy: register the config-derived grants in
+   * memory (authoritative — replacing a config revokes the old authority) and
+   * load the on-disk `/scoops/<folder>/etc/sudoers`, which holds ONLY
+   * approved "Always" grants. A file in the legacy generated format (config
+   * rules persisted to disk, pre-#2416) is discarded and rewritten as an
+   * empty Always-only file — its config rules and appended grants are
+   * indistinguishable, and retaining them would let a stale broad sandbox
+   * survive a narrower replacement config. Hand-written files (no legacy
+   * header) are deliberate user policy and load as-is. Writes go through the
+   * raw VFS handle, so the self-protection invariant (which lives in the
+   * {@link createSudoFs} proxy) is not in play here.
    */
-  async seedScoopSudoers(folder: string, config?: ScoopConfig | null): Promise<void> {
-    const path = scoopSudoersPath(folder);
-    const body = generateScoopSudoers(config ?? undefined);
+  async initScoopPolicy(folder: string, config?: ScoopConfig | null): Promise<void> {
     this.registerScoopConfig(folder, config);
+    const path = scoopSudoersPath(folder);
+    let existing: string | null = null;
     try {
-      await this.fs.mkdir(`/scoops/${folder}/etc`, { recursive: true });
-    } catch {
-      /* already exists */
+      if (await this.fs.exists(path)) {
+        const raw = await this.fs.readFile(path, { encoding: 'utf-8' });
+        existing = typeof raw === 'string' ? raw : new TextDecoder().decode(raw);
+      }
+    } catch (err) {
+      log.warn('Failed to read per-scoop sudoers during init; treating as absent', {
+        folder,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
-    await this.fs.writeFile(path, body);
+    if (existing !== null && existing.split('\n', 1)[0]?.trim() === LEGACY_GENERATED_HEADER) {
+      await this.fs.writeFile(path, SCOOP_SUDOERS_HEADER);
+      log.info('Discarded legacy generated per-scoop sudoers (ambiguous rules, fail-closed)', {
+        folder,
+        path,
+      });
+    }
     await this.reloadScoopPolicy(folder);
-    log.info('Seeded per-scoop sudoers', { folder, path });
   }
 
   /**
@@ -298,7 +339,7 @@ export class SudoManager {
    *
    * The write goes through the raw VFS handle (this manager owns the
    * untrusted-realm gate), so it bypasses the self-protection invariant on
-   * `/scoops/<folder>/etc/sudoers` writes the same way {@link seedScoopSudoers}
+   * `/scoops/<folder>/etc/sudoers` writes the same way {@link initScoopPolicy}
    * does.
    */
   async appendScoopRule(
@@ -337,7 +378,11 @@ export class SudoManager {
     } catch {
       /* already exists */
     }
-    const prefix = existing && !existing.endsWith('\n') ? `${existing}\n` : existing;
+    const prefix = existing
+      ? existing.endsWith('\n')
+        ? existing
+        : `${existing}\n`
+      : SCOOP_SUDOERS_HEADER;
     await this.fs.writeFile(path, `${prefix}${line}\n`);
     await this.reloadScoopPolicy(folder);
     log.info('Appended per-scoop sudoers rule', { folder, kind, pattern: safe });
@@ -365,6 +410,21 @@ export class SudoManager {
   reload(): Promise<void> {
     this.reloadChain = this.reloadChain.then(() => this.doReload());
     return this.reloadChain;
+  }
+
+  /**
+   * Evict every cached policy artifact for `folder`: the config-derived
+   * grants, the loaded Always-grants file policy, and the per-folder reload
+   * chain. Called when a scoop is unregistered — without it, repeated
+   * one-shot agents (random `agent-<name>` folders) grow these maps for the
+   * lifetime of the orchestrator. The on-disk file is untouched; a reused
+   * folder re-initializes via {@link initScoopPolicy}.
+   */
+  forgetScoopPolicies(folder: string): void {
+    this.scoopConfigPolicies.delete(folder);
+    this.scoopPolicies.delete(folder);
+    this.scoopReloadChains.delete(folder);
+    this.onPolicyReload(folder);
   }
 
   /**

--- a/packages/webapp/src/sudo/sudo-manager.ts
+++ b/packages/webapp/src/sudo/sudo-manager.ts
@@ -164,6 +164,14 @@ export class SudoManager {
   private reloadChain: Promise<void> = Promise.resolve();
   /** Per-scoop drop-in policies keyed by scoop folder. */
   private scoopPolicies: Map<string, SudoersPolicy> = new Map();
+  /**
+   * Per-scoop config-derived policies keyed by scoop folder (#2416). The
+   * `ScoopConfig` sandbox (writablePaths / visiblePaths / allowedCommands) is
+   * authoritative: it is registered synchronously in memory so a configured
+   * path can never escalate, even when the on-disk sudoers file predates the
+   * config (folder reuse, restores) or a reload races the first gated op.
+   */
+  private scoopConfigPolicies: Map<string, SudoersPolicy> = new Map();
   /** Per-scoop reload chains keyed by scoop folder (serialized like {@link reload}). */
   private scoopReloadChains: Map<string, Promise<void>> = new Map();
 
@@ -233,9 +241,26 @@ export class SudoManager {
    */
   getPolicyForScoop(folder: string): SudoersPolicy {
     const local = this.scoopPolicies.get(folder);
+    const config = this.scoopConfigPolicies.get(folder);
     const policies = [builtinScoopGrants(), this.policy];
+    if (config) policies.push(config);
     if (local) policies.push(local);
     return mergePolicies(...policies);
+  }
+
+  /**
+   * Register a scoop's config-derived sandbox grants directly in memory
+   * (#2416). Synchronous — no filesystem round-trip — so the grants are
+   * effective before the scoop's first gated operation. This is what makes
+   * `ScoopConfig` authoritative: the on-disk `/scoops/<folder>/etc/sudoers`
+   * file only ADDS persisted "Always" grants on top; a stale file (folder
+   * reuse across scoop generations, restored sessions with changed config)
+   * can no longer withhold a configured `writablePaths` entry and raise an
+   * approval prompt for a pre-granted path.
+   */
+  registerScoopConfig(folder: string, config?: ScoopConfig | null): void {
+    this.scoopConfigPolicies.set(folder, parseSudoers(generateScoopSudoers(config ?? undefined)));
+    this.onPolicyReload(folder);
   }
 
   /**
@@ -248,6 +273,7 @@ export class SudoManager {
   async seedScoopSudoers(folder: string, config?: ScoopConfig | null): Promise<void> {
     const path = scoopSudoersPath(folder);
     const body = generateScoopSudoers(config ?? undefined);
+    this.registerScoopConfig(folder, config);
     try {
       await this.fs.mkdir(`/scoops/${folder}/etc`, { recursive: true });
     } catch {
@@ -294,13 +320,25 @@ export class SudoManager {
     } catch (err) {
       if (!(err instanceof FsError && err.code === 'ENOENT')) throw err;
     }
+    // Idempotent (#2416): an "Always" approval for a rule that is already in
+    // the file (e.g. a request that was pending while the same grant landed)
+    // must not append a duplicate line.
+    const line = `NOPASSWD ${directive} ${safe}`;
+    if (existing.split('\n').some((l) => l.trim() === line)) {
+      log.info('Per-scoop sudoers rule already present; skipping duplicate append', {
+        folder,
+        kind,
+        pattern: safe,
+      });
+      return safe;
+    }
     try {
       await this.fs.mkdir(`/scoops/${folder}/etc`, { recursive: true });
     } catch {
       /* already exists */
     }
     const prefix = existing && !existing.endsWith('\n') ? `${existing}\n` : existing;
-    await this.fs.writeFile(path, `${prefix}NOPASSWD ${directive} ${safe}\n`);
+    await this.fs.writeFile(path, `${prefix}${line}\n`);
     await this.reloadScoopPolicy(folder);
     log.info('Appended per-scoop sudoers rule', { folder, kind, pattern: safe });
     return safe;

--- a/packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts
+++ b/packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts
@@ -8,6 +8,7 @@
  * must NOT be re-prompted (no second `handleMessage` delivery).
  */
 
+import 'fake-indexeddb/auto';
 import { describe, expect, it, vi } from 'vitest';
 import { parseSudoers } from '../../src/base/sudoers.js';
 import {
@@ -166,6 +167,59 @@ describe('ScoopApprovalRouter settleGrantedRequests (issue #2416)', () => {
     await expect(other).resolves.toEqual({ decision: 'deny' });
   });
 
+  // #2455 review: `registry.resolve()` deletes the entry, so ownership must be
+  // captured BEFORE settling — otherwise the card flip searches the DEFAULT
+  // root's messages and the owning cone's card stays pending forever.
+  it('flips the card under the OWNING cone in a multi-cone session', async () => {
+    const coneA = scoop('cone_a', true);
+    const coneB = scoop('cone_b', true);
+    const requester = { ...scoop('scoop_b_child', false), parentJid: 'cone_b' };
+    const scoops = new Map<string, RegisteredScoop>([
+      [coneA.jid, coneA],
+      [coneB.jid, coneB],
+      [requester.jid, requester],
+    ]);
+    const store: ChannelMessage[] = [];
+    const deps: ScoopApprovalRouterDeps = {
+      getScoops: () => scoops,
+      // Real approver semantics: the requesting scoop's parent; the DEFAULT
+      // root (cone_a) for undefined/unknown jids — the exact fallback the
+      // ownership bug used to hit after the registry entry was deleted.
+      findApprover: (jid) => (jid === requester.jid ? coneB : coneA),
+      getSudoManager: () =>
+        ({
+          getPolicyForScoop: () => parseSudoers('NOPASSWD Write /.playwright/**'),
+        }) as unknown as SudoManager,
+      getLickManager: () => null,
+      handleMessage: async (msg) => {
+        store.push(msg);
+      },
+      onMessageUpdate: vi.fn(),
+      getMessagesForScoop: async (jid) => store.filter((m) => m.chatJid === jid),
+      saveMessage: async (msg) => {
+        const i = store.findIndex((m) => m.id === msg.id);
+        if (i >= 0) store[i] = msg;
+        else store.push(msg);
+      },
+    };
+    const router = new ScoopApprovalRouter(deps);
+
+    const covered = router.enqueueSudoRequest(requester.jid, {
+      kind: 'write',
+      detail: '/.playwright/x.png',
+    });
+    await flush();
+    const card = store.find((m) => m.chatJid === coneB.jid);
+    expect(card?.lickState).toBe('pending');
+
+    expect(router.settleGrantedRequests(requester.folder)).toBe(1);
+    await flush();
+
+    await expect(covered).resolves.toEqual({ decision: 'allow' });
+    // The card lives under cone B and must flip there — not under cone A.
+    expect(card?.lickState).toBe('confirmed');
+  });
+
   it('is a no-op without a SudoManager', async () => {
     const h = makeHarness(null);
     const pending = h.router.enqueueSudoRequest('scoop_a', {
@@ -177,6 +231,66 @@ describe('ScoopApprovalRouter settleGrantedRequests (issue #2416)', () => {
     expect(h.router.settleGrantedRequests('scoop_a-folder')).toBe(0);
     h.router.failAll();
     await expect(pending).resolves.toEqual({ decision: 'deny' });
+  });
+
+  // End-to-end through the real reload seam (#2455 review): a real SudoManager
+  // whose `onPolicyReload` is wired to the router (mirroring the orchestrator's
+  // wiring), driven by `appendScoopRule` — exactly what `lick_confirm` with
+  // `always: true` does. The second pending request for the granted subtree
+  // must auto-resolve without a second approval.
+  it("an 'always' persist via appendScoopRule auto-settles the scoop's other covered request", async () => {
+    const { VirtualFS } = await import('../../src/fs/index.js');
+    const { FsWatcher } = await import('../../src/fs/fs-watcher.js');
+    const { SudoManager } = await import('../../src/sudo/sudo-manager.js');
+
+    const vfs = await VirtualFS.create({
+      dbName: `test-router-e2e-settle-${Date.now()}`,
+      wipe: true,
+    });
+    const watcher = new FsWatcher();
+    vfs.setWatcher(watcher);
+
+    // Two-phase init — the orchestrator builds the manager with a callback
+    // that closes over the router it constructs alongside; mirror that.
+    // (In production the orchestrator field-initializes the router before
+    // `init()`; here it is created after, so guard the boot-time reload.)
+    let router: ScoopApprovalRouter | undefined;
+    const mgr = new SudoManager({
+      fs: vfs,
+      watcher,
+      broker: { requestApproval: vi.fn(async () => ({ decision: 'deny' as const })) },
+      onPolicyReload: (folder) => void router?.settleGrantedRequests(folder),
+    });
+    await mgr.init();
+    const h = makeHarness(mgr);
+    router = h.router;
+    await mgr.initScoopPolicy('scoop_a-folder', { writablePaths: ['/scoops/scoop_a-folder/'] });
+
+    const first = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'write',
+      detail: '/.playwright/screenshots/one.png',
+    });
+    const second = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'write',
+      detail: '/.playwright/session.md',
+    });
+    await flush();
+    const [{ id: firstId }] = h.router.listPendingSudoRequests();
+
+    // The cone approves the FIRST request with always + a subtree pattern.
+    const result = await h.router.resolveSudoRequestAndPersist(firstId, {
+      decision: 'always',
+      pattern: '/.playwright/**',
+    });
+
+    expect(result).toEqual(expect.objectContaining({ settled: true, persisted: true }));
+    await expect(first).resolves.toEqual({ decision: 'always', pattern: '/.playwright/**' });
+    // The SECOND request is auto-settled by the reload — no second approval.
+    await expect(second).resolves.toEqual({ decision: 'allow' });
+    expect(h.router.listPendingSudoRequests()).toHaveLength(0);
+
+    mgr.dispose();
+    await vfs.dispose?.();
   });
 });
 

--- a/packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts
+++ b/packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import { parseSudoers } from '../../src/base/sudoers.js';
 import {
   ScoopApprovalRouter,
   type ScoopApprovalRouterDeps,
@@ -98,6 +99,84 @@ describe('ScoopApprovalRouter persistence settlement', () => {
     await expect(resultPromise).resolves.toEqual(
       expect.objectContaining({ settled: true, persisted: true })
     );
+  });
+});
+
+// #2416: after an 'always' approval widens a scoop's policy (or its config is
+// re-registered), other requests from that scoop that the new policy already
+// covers must resolve as allow instead of stalling until individually approved
+// (which also appended duplicate rules).
+describe('ScoopApprovalRouter settleGrantedRequests (issue #2416)', () => {
+  function managerGranting(rules: string): SudoManager {
+    return {
+      getPolicyForScoop: () => parseSudoers(rules),
+    } as unknown as SudoManager;
+  }
+
+  it('resolves pending path requests now covered by a NOPASSWD grant', async () => {
+    const h = makeHarness(managerGranting('NOPASSWD Write /.playwright/**'));
+    const covered = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'write',
+      detail: '/.playwright/screenshots/x.png',
+    });
+    const uncovered = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'write',
+      detail: '/.migration/crop.png',
+    });
+    await flush();
+    expect(h.router.listPendingSudoRequests()).toHaveLength(2);
+
+    const settled = h.router.settleGrantedRequests('scoop_a-folder');
+    await flush();
+
+    expect(settled).toBe(1);
+    await expect(covered).resolves.toEqual({ decision: 'allow' });
+    expect(h.router.listPendingSudoRequests()).toHaveLength(1);
+    // The covered request's card flips to confirmed; the uncovered one stays pending.
+    expect(h.store.find((m) => m.content.includes('/.playwright'))?.lickState).toBe('confirmed');
+    expect(h.store.find((m) => m.content.includes('/.migration'))?.lickState).toBe('pending');
+    // Cleanup so the uncovered request doesn't dangle.
+    h.router.failAll();
+    await expect(uncovered).resolves.toEqual({ decision: 'deny' });
+  });
+
+  it('resolves pending command requests now covered by a NOPASSWD Cmnd grant', async () => {
+    const h = makeHarness(managerGranting('NOPASSWD Cmnd git *'));
+    const covered = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'command',
+      detail: 'git status',
+    });
+    await flush();
+
+    expect(h.router.settleGrantedRequests('scoop_a-folder')).toBe(1);
+    await expect(covered).resolves.toEqual({ decision: 'allow' });
+  });
+
+  it('only settles requests from the scoop whose policy reloaded', async () => {
+    const h = makeHarness(managerGranting('NOPASSWD Write /.playwright/**'));
+    const other = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'write',
+      detail: '/.playwright/x.png',
+    });
+    await flush();
+
+    expect(h.router.settleGrantedRequests('some-other-folder')).toBe(0);
+    expect(h.router.listPendingSudoRequests()).toHaveLength(1);
+    h.router.failAll();
+    await expect(other).resolves.toEqual({ decision: 'deny' });
+  });
+
+  it('is a no-op without a SudoManager', async () => {
+    const h = makeHarness(null);
+    const pending = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'write',
+      detail: '/.playwright/x.png',
+    });
+    await flush();
+
+    expect(h.router.settleGrantedRequests('scoop_a-folder')).toBe(0);
+    h.router.failAll();
+    await expect(pending).resolves.toEqual({ decision: 'deny' });
   });
 });
 

--- a/packages/webapp/tests/scoops/scoop-context.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.test.ts
@@ -1799,6 +1799,105 @@ describe('ScoopContext buildSudoWiring (per-scoop command grant isolation)', () 
     mgr.dispose();
     vfs.dispose?.();
   });
+
+  // #2416: the FS-level analog of the command-grant isolation above. A
+  // non-cone scoop's `always` decision is already persisted SCOPED by the
+  // approval router (`SudoManager.appendScoopRule`); the SudoFS gate must not
+  // ALSO write it to the global `/etc/sudoers.d/granted` drop-in, which would
+  // leak a scoop-A grant into every other unit and accumulate duplicates.
+  it("non-cone scoop: onGrant is a no-op (an 'always' path grant does not leak globally)", async () => {
+    const { FsWatcher } = await import('../../src/fs/fs-watcher.js');
+    const { VirtualFS } = await import('../../src/fs/index.js');
+    const { SudoManager } = await import('../../src/sudo/sudo-manager.js');
+    const { matchPath } = await import('../../src/base/sudoers.js');
+
+    const vfs = await VirtualFS.create({
+      dbName: `test-scoop-ctx-fs-grant-isolation-${Date.now()}`,
+      wipe: true,
+    });
+    const watcher = new FsWatcher();
+    vfs.setWatcher(watcher);
+    const mgr = new SudoManager({
+      fs: vfs,
+      watcher,
+      broker: { requestApproval: vi.fn(async () => ({ decision: 'deny' as const })) },
+    });
+    await mgr.init();
+
+    const callbacks: ScoopContextCallbacks = {
+      ...createMockCallbacks(),
+      onSudoRequest: vi.fn(async () => ({ decision: 'always' as const, pattern: '/x/**' })),
+    };
+    const ctx = new ScoopContext(
+      testScoop,
+      callbacks,
+      vfs,
+      undefined,
+      undefined,
+      'cone_main_1',
+      undefined,
+      mgr
+    );
+
+    const wiring = sudoWiringOf(ctx) as unknown as {
+      onGrant?: (op: 'read' | 'write', pattern: string) => void | Promise<void>;
+    };
+    expect(wiring).not.toBeNull();
+    expect(wiring.onGrant).toBeTypeOf('function');
+
+    await wiring.onGrant?.('write', '/x/**');
+    expect(await vfs.exists('/etc/sudoers.d/granted')).toBe(false);
+    expect(matchPath(mgr.getPolicy(), 'write', '/x/file')).toBe('no-match');
+
+    mgr.dispose();
+    vfs.dispose?.();
+  });
+
+  it('cone scoop: onGrant stays undefined (default global persistence unchanged)', async () => {
+    const { FsWatcher } = await import('../../src/fs/fs-watcher.js');
+    const { VirtualFS } = await import('../../src/fs/index.js');
+    const { SudoManager } = await import('../../src/sudo/sudo-manager.js');
+
+    const vfs = await VirtualFS.create({
+      dbName: `test-scoop-ctx-fs-grant-cone-${Date.now()}`,
+      wipe: true,
+    });
+    const watcher = new FsWatcher();
+    vfs.setWatcher(watcher);
+    const mgr = new SudoManager({
+      fs: vfs,
+      watcher,
+      broker: { requestApproval: vi.fn(async () => ({ decision: 'deny' as const })) },
+    });
+    await mgr.init();
+
+    const coneScoop: RegisteredScoop = {
+      jid: 'cone_main_1',
+      name: 'Main',
+      folder: 'main',
+      parentJid: null,
+      requiresTrigger: false,
+      assistantLabel: 'sliccy',
+      addedAt: new Date().toISOString(),
+    };
+    const ctx = new ScoopContext(
+      coneScoop,
+      createMockCallbacks(),
+      vfs,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      mgr
+    );
+
+    const wiring = sudoWiringOf(ctx) as unknown as { onGrant?: unknown };
+    expect(wiring).not.toBeNull();
+    expect(wiring.onGrant).toBeUndefined();
+
+    mgr.dispose();
+    vfs.dispose?.();
+  });
 });
 
 describe('ScoopContext typed-source error telemetry', () => {

--- a/packages/webapp/tests/sudo/cone-broker.test.ts
+++ b/packages/webapp/tests/sudo/cone-broker.test.ts
@@ -218,7 +218,9 @@ describe('ConeRequestRegistry onAutoSettle', () => {
     const { registry, onAutoSettle, fireAllTimers } = makeRegistryWithSettle(['sudo-1']);
     registry.register('scoop_a', REQ);
     fireAllTimers();
-    expect(onAutoSettle).toHaveBeenCalledExactlyOnceWith('sudo-1', 'expired');
+    // The requester's jid rides along — the entry is already deleted when the
+    // hook fires, so the owner needs it to flip the card under the right cone.
+    expect(onAutoSettle).toHaveBeenCalledExactlyOnceWith('sudo-1', 'expired', 'scoop_a');
   });
 
   it('fires with reason "scoop-dropped" for each request failScoop drains', () => {
@@ -228,8 +230,8 @@ describe('ConeRequestRegistry onAutoSettle', () => {
     registry.register('scoop_b', REQ);
     registry.failScoop('scoop_a');
     expect(onAutoSettle.mock.calls).toEqual([
-      ['a1', 'scoop-dropped'],
-      ['a2', 'scoop-dropped'],
+      ['a1', 'scoop-dropped', 'scoop_a'],
+      ['a2', 'scoop-dropped', 'scoop_a'],
     ]);
   });
 
@@ -239,8 +241,8 @@ describe('ConeRequestRegistry onAutoSettle', () => {
     registry.register('scoop_b', REQ);
     registry.failAll();
     expect(onAutoSettle.mock.calls).toEqual([
-      ['x1', 'shutdown'],
-      ['x2', 'shutdown'],
+      ['x1', 'shutdown', 'scoop_a'],
+      ['x2', 'shutdown', 'scoop_b'],
     ]);
   });
 

--- a/packages/webapp/tests/sudo/sudo-manager.test.ts
+++ b/packages/webapp/tests/sudo/sudo-manager.test.ts
@@ -428,16 +428,22 @@ describe('SudoManager per-scoop policy view', () => {
     mgr.dispose();
   });
 
-  it('drops a scoop policy from the cache when its sudoers file is removed', async () => {
+  it('drops file-based grants when the sudoers file is removed, but keeps config grants (#2416)', async () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
 
     await mgr.seedScoopSudoers('andy', { allowedCommands: ['git'] });
+    // A file-only "Always" grant on top of the config-derived ones.
+    await mgr.appendScoopRule('andy', 'command', 'ls*');
     expect(matchCommand(mgr.getPolicyForScoop('andy'), 'git status')).toBe('nopasswd-allow');
+    expect(matchCommand(mgr.getPolicyForScoop('andy'), 'ls -la')).toBe('nopasswd-allow');
 
     await vfs.rm(scoopSudoersPath('andy'), { recursive: false });
-    await flush(() => matchCommand(mgr.getPolicyForScoop('andy'), 'git status') === 'no-match');
-    expect(matchCommand(mgr.getPolicyForScoop('andy'), 'git status')).toBe('no-match');
+    await flush(() => matchCommand(mgr.getPolicyForScoop('andy'), 'ls -la') === 'no-match');
+    // The file-only grant is gone…
+    expect(matchCommand(mgr.getPolicyForScoop('andy'), 'ls -la')).toBe('no-match');
+    // …but the config-derived sandbox grants stay authoritative in memory.
+    expect(matchCommand(mgr.getPolicyForScoop('andy'), 'git status')).toBe('nopasswd-allow');
     mgr.dispose();
   });
 
@@ -571,5 +577,113 @@ describe('SudoManager per-scoop policy view', () => {
     // No reload happened — the cached policy still reflects the original `git` grant.
     expect(matchCommand(mgr.getPolicyForScoop('andy'), 'git status')).toBe('nopasswd-allow');
     expect(matchCommand(mgr.getPolicyForScoop('andy'), 'rm -rf /tmp')).toBe('no-match');
+  });
+});
+
+// Issue #2416: a write inside a scoop's `writablePaths` must never raise an
+// approval prompt, and an "Always" approval must never append a rule that is
+// already present.
+describe('SudoManager scoop config grants (issue #2416)', () => {
+  let vfs: VirtualFS;
+  let watcher: FsWatcher;
+  let dbCounter = 0;
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({ dbName: `test-sudo-cfg-${dbCounter++}`, wipe: true });
+    watcher = new FsWatcher();
+    vfs.setWatcher(watcher);
+  });
+  afterEach(async () => {
+    await vfs.dispose?.();
+  });
+
+  it('registerScoopConfig makes writablePaths grants effective even when a stale sudoers file exists', async () => {
+    const mgr = new SudoManager({ fs: vfs, watcher, broker });
+    await mgr.init();
+
+    // A sudoers file from a previous scoop generation with the same folder —
+    // it predates the current config and lacks the /.playwright grant.
+    await vfs.mkdir('/scoops/location-finder/etc', { recursive: true });
+    await vfs.writeFile(scoopSudoersPath('location-finder'), 'NOPASSWD Write /shared/**\n');
+    await mgr.reloadScoopPolicyByFolder('location-finder');
+
+    // Without the config registered, the stale file wins and the write escalates.
+    expect(
+      matchPath(mgr.getPolicyForScoop('location-finder'), 'write', '/.playwright/screenshots/x.png')
+    ).toBe('no-match');
+
+    mgr.registerScoopConfig('location-finder', {
+      writablePaths: ['/shared/', '/.playwright/', '/tmp/'],
+    });
+
+    const policy = mgr.getPolicyForScoop('location-finder');
+    expect(matchPath(policy, 'write', '/.playwright/screenshots/x.png')).toBe('nopasswd-allow');
+    expect(matchPath(policy, 'write', '/.playwright')).toBe('nopasswd-allow');
+    // The file's own grants are still honoured alongside the config's.
+    expect(matchPath(policy, 'write', '/shared/report.md')).toBe('nopasswd-allow');
+    mgr.dispose();
+  });
+
+  it('config grants match regardless of trailing-slash / glob spelling', async () => {
+    const mgr = new SudoManager({ fs: vfs, watcher, broker });
+    await mgr.init();
+
+    for (const spelling of ['/.playwright', '/.playwright/', '/.playwright/**']) {
+      mgr.registerScoopConfig('speller', { writablePaths: [spelling] });
+      const policy = mgr.getPolicyForScoop('speller');
+      expect(matchPath(policy, 'write', '/.playwright/screenshots/x.png')).toBe('nopasswd-allow');
+      expect(matchPath(policy, 'write', '/.playwright')).toBe('nopasswd-allow');
+    }
+    mgr.dispose();
+  });
+
+  it('registerScoopConfig notifies onPolicyReload for the folder', async () => {
+    const reloads: Array<string | undefined> = [];
+    const mgr = new SudoManager({
+      fs: vfs,
+      watcher,
+      broker,
+      onPolicyReload: (folder) => reloads.push(folder),
+    });
+    await mgr.init();
+    reloads.length = 0;
+
+    mgr.registerScoopConfig('finder', { writablePaths: ['/shared/'] });
+
+    expect(reloads).toContain('finder');
+    mgr.dispose();
+  });
+
+  it('seedScoopSudoers also registers the config-derived grants in memory', async () => {
+    const mgr = new SudoManager({ fs: vfs, watcher, broker });
+    await mgr.init();
+    await mgr.seedScoopSudoers('seeded', { writablePaths: ['/.playwright/'] });
+
+    // Even if the on-disk file is later clobbered, the config grants hold.
+    await vfs.writeFile(scoopSudoersPath('seeded'), '# wiped\n');
+    await mgr.reloadScoopPolicyByFolder('seeded');
+
+    expect(matchPath(mgr.getPolicyForScoop('seeded'), 'write', '/.playwright/a.png')).toBe(
+      'nopasswd-allow'
+    );
+    mgr.dispose();
+  });
+
+  it('appendScoopRule does not append a rule that already exists (no duplicates)', async () => {
+    const mgr = new SudoManager({ fs: vfs, watcher, broker });
+    await mgr.init();
+    await mgr.seedScoopSudoers('deduper', { writablePaths: ['/.playwright/'] });
+
+    const saved = await mgr.appendScoopRule('deduper', 'write', '/.playwright/**');
+
+    expect(saved).toBe('/.playwright/**');
+    const body = (await vfs.readFile(scoopSudoersPath('deduper'), {
+      encoding: 'utf-8',
+    })) as string;
+    const occurrences = body
+      .split('\n')
+      .filter((line) => line.trim() === 'NOPASSWD Write /.playwright/**').length;
+    expect(occurrences).toBe(1);
+    mgr.dispose();
   });
 });

--- a/packages/webapp/tests/sudo/sudo-manager.test.ts
+++ b/packages/webapp/tests/sudo/sudo-manager.test.ts
@@ -309,23 +309,22 @@ describe('SudoManager per-scoop policy view', () => {
     mgr.dispose();
   });
 
-  it('seedScoopSudoers writes the generated body to /scoops/<folder>/etc/sudoers', async () => {
+  it('initScoopPolicy makes the config-derived grants active (anchored Cmnd pair + path forms)', async () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
 
-    await mgr.seedScoopSudoers('andy', {
+    await mgr.initScoopPolicy('andy', {
       writablePaths: ['/scoops/andy'],
       visiblePaths: ['/workspace'],
       allowedCommands: ['git'],
     });
 
-    const written = (await vfs.readFile(scoopSudoersPath('andy'), {
-      encoding: 'utf-8',
-    })) as string;
-    expect(written).toMatch(/^NOPASSWD Cmnd git$/m);
-    expect(written).toMatch(/^NOPASSWD Cmnd git \*$/m);
-    expect(written).toContain('NOPASSWD Write /scoops/andy/**');
-    expect(written).toContain('NOPASSWD Read /workspace/**');
+    const policy = mgr.getPolicyForScoop('andy');
+    expect(matchCommand(policy, 'git')).toBe('nopasswd-allow');
+    expect(matchCommand(policy, 'git push origin main')).toBe('nopasswd-allow');
+    expect(matchCommand(policy, 'gitlab')).toBe('no-match');
+    expect(matchPath(policy, 'write', '/scoops/andy/file.txt')).toBe('nopasswd-allow');
+    expect(matchPath(policy, 'read', '/workspace/src/a.ts')).toBe('nopasswd-allow');
     mgr.dispose();
   });
 
@@ -336,7 +335,7 @@ describe('SudoManager per-scoop policy view', () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
 
-    await mgr.seedScoopSudoers('andy', {
+    await mgr.initScoopPolicy('andy', {
       writablePaths: ['/scoops/andy'],
       // Scoop is explicitly allowed `git`, which (as the anchored
       // `git` / `git *` pair) covers `git push`.
@@ -355,21 +354,16 @@ describe('SudoManager per-scoop policy view', () => {
     mgr.dispose();
   });
 
-  it('grants /tmp to every scoop, even one whose seeded sudoers predates the grant', async () => {
+  it('grants /tmp to every scoop, even one whose config carries no /tmp rule', async () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
 
-    // A scoop whose on-disk sudoers was generated without any /tmp rule —
-    // `ensureSudoersLoaded` never regenerates an existing file, so the grant
-    // has to come from the built-in policy rather than from this body.
-    await mgr.seedScoopSudoers('andy', {
+    // No /tmp entry in the config — the grant has to come from the built-in
+    // policy (`builtinScoopGrants`), not from the config-derived rules.
+    await mgr.initScoopPolicy('andy', {
       writablePaths: ['/scoops/andy'],
       allowedCommands: ['git'],
     });
-    const written = (await vfs.readFile(scoopSudoersPath('andy'), {
-      encoding: 'utf-8',
-    })) as string;
-    expect(written).not.toContain('/tmp');
 
     const policy = mgr.getPolicyForScoop('andy');
     expect(matchPath(policy, 'write', '/tmp/scratch.txt')).toBe('nopasswd-allow');
@@ -396,11 +390,11 @@ describe('SudoManager per-scoop policy view', () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
 
-    await mgr.seedScoopSudoers('andy', {
+    await mgr.initScoopPolicy('andy', {
       writablePaths: ['/scoops/andy'],
       allowedCommands: ['git'],
     });
-    await mgr.seedScoopSudoers('beth', {
+    await mgr.initScoopPolicy('beth', {
       writablePaths: ['/scoops/beth'],
       allowedCommands: ['ls'],
     });
@@ -418,7 +412,7 @@ describe('SudoManager per-scoop policy view', () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
 
-    await mgr.seedScoopSudoers('andy', { allowedCommands: ['git'] });
+    await mgr.initScoopPolicy('andy', { allowedCommands: ['git'] });
     expect(matchCommand(mgr.getPolicyForScoop('andy'), 'ls')).toBe('no-match');
 
     // Edit the scoop's policy out-of-band — should pick up via the watcher.
@@ -432,7 +426,7 @@ describe('SudoManager per-scoop policy view', () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
 
-    await mgr.seedScoopSudoers('andy', { allowedCommands: ['git'] });
+    await mgr.initScoopPolicy('andy', { allowedCommands: ['git'] });
     // A file-only "Always" grant on top of the config-derived ones.
     await mgr.appendScoopRule('andy', 'command', 'ls*');
     expect(matchCommand(mgr.getPolicyForScoop('andy'), 'git status')).toBe('nopasswd-allow');
@@ -447,22 +441,26 @@ describe('SudoManager per-scoop policy view', () => {
     mgr.dispose();
   });
 
-  it('writes to /scoops/<folder>/etc/sudoers via the raw fs are not self-gated (seed path)', async () => {
+  it('writes to /scoops/<folder>/etc/sudoers via the raw fs are not self-gated', async () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
 
     // No throw — the SudoManager owns the raw VFS, the self-protection invariant
-    // only fires through `createSudoFs`.
-    await expect(
-      mgr.seedScoopSudoers('andy', { allowedCommands: ['git'] })
-    ).resolves.toBeUndefined();
+    // only fires through `createSudoFs`. Covers both the append path and the
+    // legacy-migration rewrite path.
+    await expect(mgr.appendScoopRule('andy', 'command', 'git*')).resolves.toBe('git*');
+    await vfs.writeFile(
+      scoopSudoersPath('legacy'),
+      '# Per-scoop sudoers — generated from ScoopConfig (sandbox surface).\nNOPASSWD Cmnd *\n'
+    );
+    await expect(mgr.initScoopPolicy('legacy', {})).resolves.toBeUndefined();
     mgr.dispose();
   });
 
   it('appendScoopRule appends a NOPASSWD Cmnd rule and reloads it active', async () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
-    await mgr.seedScoopSudoers('andy', { allowedCommands: [] });
+    await mgr.initScoopPolicy('andy', { allowedCommands: [] });
     expect(matchCommand(mgr.getPolicyForScoop('andy'), 'git push origin main')).toBe('no-match');
 
     const saved = await mgr.appendScoopRule('andy', 'command', 'git push*');
@@ -481,7 +479,9 @@ describe('SudoManager per-scoop policy view', () => {
   it('appendScoopRule preserves existing grants when reading the policy fails', async () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
-    await mgr.seedScoopSudoers('andy', { allowedCommands: ['git'] });
+    await mgr.initScoopPolicy('andy', { allowedCommands: ['git'] });
+    // Create the Always-grants file so there is durable content to preserve.
+    await mgr.appendScoopRule('andy', 'command', 'ls*');
     const path = scoopSudoersPath('andy');
     const before = (await vfs.readFile(path, { encoding: 'utf-8' })) as string;
     const readFile = vi
@@ -501,7 +501,7 @@ describe('SudoManager per-scoop policy view', () => {
   it('appendScoopRule emits the right directive per kind (Cmnd / Read / Write)', async () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
-    await mgr.seedScoopSudoers('andy', { allowedCommands: [] });
+    await mgr.initScoopPolicy('andy', { allowedCommands: [] });
 
     await mgr.appendScoopRule('andy', 'command', 'ls*');
     await mgr.appendScoopRule('andy', 'read', '/workspace/.git/**');
@@ -518,7 +518,7 @@ describe('SudoManager per-scoop policy view', () => {
   it('appendScoopRule sanitizes a newline-bearing pattern before writing', async () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
-    await mgr.seedScoopSudoers('andy', { allowedCommands: [] });
+    await mgr.initScoopPolicy('andy', { allowedCommands: [] });
 
     const saved = await mgr.appendScoopRule(
       'andy',
@@ -538,7 +538,9 @@ describe('SudoManager per-scoop policy view', () => {
   it('appendScoopRule returns null and does not write when the pattern collapses to empty', async () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
-    await mgr.seedScoopSudoers('andy', { allowedCommands: [] });
+    await mgr.initScoopPolicy('andy', { allowedCommands: [] });
+    // Create the Always-grants file so "does not write" is observable.
+    await mgr.appendScoopRule('andy', 'command', 'ls*');
     const before = (await vfs.readFile(scoopSudoersPath('andy'), {
       encoding: 'utf-8',
     })) as string;
@@ -569,7 +571,7 @@ describe('SudoManager per-scoop policy view', () => {
   it('stops reacting to scoop file changes after dispose()', async () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
-    await mgr.seedScoopSudoers('andy', { allowedCommands: ['git'] });
+    await mgr.initScoopPolicy('andy', { allowedCommands: ['git'] });
     mgr.dispose();
 
     await vfs.writeFile(scoopSudoersPath('andy'), 'NOPASSWD Cmnd rm*\n');
@@ -654,12 +656,13 @@ describe('SudoManager scoop config grants (issue #2416)', () => {
     mgr.dispose();
   });
 
-  it('seedScoopSudoers also registers the config-derived grants in memory', async () => {
+  it('initScoopPolicy registers the config-derived grants in memory', async () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
-    await mgr.seedScoopSudoers('seeded', { writablePaths: ['/.playwright/'] });
+    await mgr.initScoopPolicy('seeded', { writablePaths: ['/.playwright/'] });
 
-    // Even if the on-disk file is later clobbered, the config grants hold.
+    // Even if an on-disk file appears and is later clobbered, the config grants hold.
+    await vfs.mkdir('/scoops/seeded/etc', { recursive: true });
     await vfs.writeFile(scoopSudoersPath('seeded'), '# wiped\n');
     await mgr.reloadScoopPolicyByFolder('seeded');
 
@@ -672,8 +675,9 @@ describe('SudoManager scoop config grants (issue #2416)', () => {
   it('appendScoopRule does not append a rule that already exists (no duplicates)', async () => {
     const mgr = new SudoManager({ fs: vfs, watcher, broker });
     await mgr.init();
-    await mgr.seedScoopSudoers('deduper', { writablePaths: ['/.playwright/'] });
+    await mgr.initScoopPolicy('deduper', { writablePaths: ['/.playwright/'] });
 
+    await mgr.appendScoopRule('deduper', 'write', '/.playwright/**');
     const saved = await mgr.appendScoopRule('deduper', 'write', '/.playwright/**');
 
     expect(saved).toBe('/.playwright/**');
@@ -684,6 +688,95 @@ describe('SudoManager scoop config grants (issue #2416)', () => {
       .split('\n')
       .filter((line) => line.trim() === 'NOPASSWD Write /.playwright/**').length;
     expect(occurrences).toBe(1);
+    mgr.dispose();
+  });
+
+  // The revocation half of "config is authoritative": a narrower replacement
+  // config must actually revoke the authority the previous generation held.
+  it('a narrower replacement config revokes stale generated grants on folder reuse', async () => {
+    const mgr = new SudoManager({ fs: vfs, watcher, broker });
+    await mgr.init();
+
+    // Generation A: broad sandbox — written in the LEGACY generated format
+    // (config rules persisted to disk, as pre-#2416 builds did).
+    await vfs.mkdir('/scoops/worker/etc', { recursive: true });
+    await vfs.writeFile(
+      scoopSudoersPath('worker'),
+      [
+        '# Per-scoop sudoers — generated from ScoopConfig (sandbox surface).',
+        '# Writes to this file always require approval (self-protected).',
+        '',
+        'NOPASSWD Cmnd *',
+        'NOPASSWD Write /workspace',
+        'NOPASSWD Write /workspace/**',
+      ].join('\n') + '\n'
+    );
+
+    // Generation B reuses the folder with a NARROWER config.
+    await mgr.initScoopPolicy('worker', { writablePaths: ['/shared/'], allowedCommands: [] });
+
+    const policy = mgr.getPolicyForScoop('worker');
+    expect(matchPath(policy, 'write', '/workspace/src/app.ts')).toBe('no-match');
+    expect(matchCommand(policy, 'rm -rf /workspace')).toBe('no-match');
+    expect(matchPath(policy, 'write', '/shared/out.md')).toBe('nopasswd-allow');
+    mgr.dispose();
+  });
+
+  it('initScoopPolicy keeps config rules out of the on-disk file (Always-grants-only)', async () => {
+    const mgr = new SudoManager({ fs: vfs, watcher, broker });
+    await mgr.init();
+
+    await mgr.initScoopPolicy('clean', { writablePaths: ['/shared/'], allowedCommands: ['git'] });
+
+    // No file is created until the first "Always" grant…
+    expect(await vfs.exists(scoopSudoersPath('clean'))).toBe(false);
+    // …yet the config grants are fully effective (in memory).
+    const policy = mgr.getPolicyForScoop('clean');
+    expect(matchPath(policy, 'write', '/shared/a.md')).toBe('nopasswd-allow');
+    expect(matchCommand(policy, 'git push')).toBe('nopasswd-allow');
+    mgr.dispose();
+  });
+
+  it('forgetScoopPolicies evicts config, file, and reload-chain state for a folder', async () => {
+    const mgr = new SudoManager({ fs: vfs, watcher, broker });
+    await mgr.init();
+    await mgr.initScoopPolicy('ephemeral', { writablePaths: ['/shared/'] });
+    await mgr.appendScoopRule('ephemeral', 'command', 'git*');
+    expect(matchPath(mgr.getPolicyForScoop('ephemeral'), 'write', '/shared/a')).toBe(
+      'nopasswd-allow'
+    );
+    expect(matchCommand(mgr.getPolicyForScoop('ephemeral'), 'git status')).toBe('nopasswd-allow');
+
+    mgr.forgetScoopPolicies('ephemeral');
+
+    // Back to the global-only view — nothing cached survives for the folder.
+    expect(matchPath(mgr.getPolicyForScoop('ephemeral'), 'write', '/shared/a')).toBe('no-match');
+    expect(matchCommand(mgr.getPolicyForScoop('ephemeral'), 'git status')).toBe('no-match');
+
+    // Re-init works from scratch (a reused folder starts clean).
+    await mgr.initScoopPolicy('ephemeral', { writablePaths: ['/shared/'] });
+    expect(matchPath(mgr.getPolicyForScoop('ephemeral'), 'write', '/shared/a')).toBe(
+      'nopasswd-allow'
+    );
+    mgr.dispose();
+  });
+
+  it('discards a legacy generated file but keeps a hand-written / Always-only file', async () => {
+    const mgr = new SudoManager({ fs: vfs, watcher, broker });
+    await mgr.init();
+
+    // Hand-written (no legacy generated header) — deliberate user policy, kept.
+    await vfs.mkdir('/scoops/handmade/etc', { recursive: true });
+    await vfs.writeFile(scoopSudoersPath('handmade'), 'NOPASSWD Cmnd ls*\n');
+    await mgr.initScoopPolicy('handmade', { writablePaths: [] });
+    expect(matchCommand(mgr.getPolicyForScoop('handmade'), 'ls -la')).toBe('nopasswd-allow');
+
+    // Always-only file created by appendScoopRule — kept across re-init.
+    await mgr.appendScoopRule('handmade', 'write', '/recordings/**');
+    await mgr.initScoopPolicy('handmade', { writablePaths: [] });
+    expect(matchPath(mgr.getPolicyForScoop('handmade'), 'write', '/recordings/a.har')).toBe(
+      'nopasswd-allow'
+    );
     mgr.dispose();
   });
 });


### PR DESCRIPTION
Fixes #2416.

## Root causes

Investigation found no matcher bug — `generateScoopSudoers` + `matchPath` correctly grant any trailing-slash/glob spelling of a `writablePaths` entry. The prompts came from policy *state*, not matching:

1. **The per-scoop policy was derived only from the on-disk `/scoops/<folder>/etc/sudoers` file.** `ensureSudoersLoaded` seeds it from `ScoopConfig` only when absent; when a file already exists (folder reuse across scoop generations, restores with changed config), the config's `writablePaths` were never granted — a guaranteed prompt for a pre-granted path.
2. **Pending requests were never re-evaluated after a policy reload.** playwright-cli fires several gated ops (`mkdir` + snapshot/session/screenshot writes) close together; approving one with "Always" widened the policy, but the scoop's other already-pending requests for the same subtree kept hanging until each was individually approved — the observed multi-minute stall, and each extra "Always" appended the same rule again.
3. **Duplicate/leaking persistence.** `appendScoopRule` appended without checking for an identical existing line, and a non-cone scoop's `SudoFS` used the default grant sink, writing `always` grants to the global `/etc/sudoers.d/granted` — silently widening every other unit's policy.

## Changes

- `SudoManager.registerScoopConfig(folder, config)`: config-derived grants are registered **synchronously in memory** on every context creation and merged into `getPolicyForScoop`. `ScoopConfig` is now authoritative; the on-disk file only adds persisted "Always" grants. No file/watcher race can withhold a configured path.
- `ScoopApprovalRouter.settleGrantedRequests(folder?)`: wired into `onPolicyReload` — pending requests now covered by a `NOPASSWD` grant auto-resolve as `allow` (card flips to confirmed).
- `appendScoopRule` is idempotent — an existing identical rule is never appended again.
- `buildSudoWiring` gives non-cone scoops a no-op `onGrant` sink (FS-level analog of the existing `persistCommandGrant` isolation); their `always` grants persist only scoped via the router.

## On the acceptance criteria

- *Write inside `writablePaths` never prompts, any spelling*: covered by the in-memory config policy + spelling test (`/x`, `/x/`, `/x/**`).
- *Approving one scoop's request does not gate unrelated scoops*: investigation found **no global lock** — each scoop blocks only on its own gated ops. The incident's appearance came from every scoop hitting its own prompt (e.g. un-granted `/.migration/` writes). The single-approver serialization (the cone processes its queue one turn at a time) is now documented as intended in `docs/approvals.md`.
- *No duplicate rules on approval*: dedupe + scoped-only persistence + auto-settle (the second prompt never needs approval).
- */.migration/*: not pre-authorized (no such root exists in-repo; it is skill-invented). The delegation skill now tells cones to list every tool-owned absolute root in `writablePaths` and to prefer scratch/`/shared/`/`/tmp/` over inventing VFS roots.

## Tests

- `sudo-manager.test.ts`: stale-file scenario, spelling matrix, config survival after file wipe/delete, `onPolicyReload` notification, duplicate-append guard.
- `scoop-approval-router-settle.test.ts`: auto-settle for covered path + command requests, folder scoping, no-SudoManager no-op.
- `scoop-context.test.ts`: non-cone `onGrant` is a no-op (no global granted file), cone unchanged.

Full pass run locally: `verify`, `check-touched-exemptions`, `typecheck`, `test` (one unrelated pre-existing flake: `hf-cache-mirror.test.mjs`, passes standalone), `test:coverage`, both builds, `bundle-size`.