### PR TITLE
shell(crontask): reject unknown flags (#2255)

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/crontask-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/crontask-command.ts
@@ -4,6 +4,8 @@ import { hasLocalNodeServer } from '../float-topology.js';
 import { defaultLickTarget, type LickTargetEnv } from '../lick-target-env.js';
 import { apiHeaders, resolveApiUrl } from '../proxied-fetch.js';
 import { getLickManagerSurface } from './lick-surface.js';
+import { parseKnownFlags } from './subcommand-flags.js';
+import { isHelpRequest } from './subcommand-help.js';
 
 type CommandResult = { stdout: string; stderr: string; exitCode: number };
 
@@ -86,31 +88,21 @@ async function apiCall(
   return { ok: resp.ok, status: resp.status, data };
 }
 
+/** `create`'s flags all take a value — same names for `isHelpRequest`. */
+const CREATE_VALUE_FLAGS = ['--name', '--cron', '--filter', '--scoop'] as const;
+
+function flagError(message: string): CommandResult {
+  return { stdout: '', stderr: `crontask: ${message}\n`, exitCode: 1 };
+}
+
 async function handleCreate(args: string[], env: LickTargetEnv): Promise<CommandResult> {
-  let name: string | undefined;
-  let cron: string | undefined;
-  let filter: string | undefined;
-  let scoop: string | undefined;
+  const parsed = parseKnownFlags(args.slice(1), { value: CREATE_VALUE_FLAGS });
+  if ('error' in parsed) return flagError(parsed.error);
 
-  const nameIdx = args.indexOf('--name');
-  if (nameIdx !== -1 && args[nameIdx + 1]) {
-    name = args[nameIdx + 1];
-  }
-
-  const cronIdx = args.indexOf('--cron');
-  if (cronIdx !== -1 && args[cronIdx + 1]) {
-    cron = args[cronIdx + 1];
-  }
-
-  const filterIdx = args.indexOf('--filter');
-  if (filterIdx !== -1 && args[filterIdx + 1]) {
-    filter = args[filterIdx + 1];
-  }
-
-  const scoopIdx = args.indexOf('--scoop');
-  if (scoopIdx !== -1 && args[scoopIdx + 1]) {
-    scoop = args[scoopIdx + 1];
-  }
+  const name = parsed.values.get('--name');
+  const cron = parsed.values.get('--cron');
+  const filter = parsed.values.get('--filter');
+  let scoop = parsed.values.get('--scoop');
   // No `--scoop`: a non-primary cone's shell names itself (SLICC_LICK_TARGET),
   // exactly as `fswatch` does, so its ticks come back to its own chat (#2311).
   scoop = defaultLickTarget(scoop, env);
@@ -182,7 +174,10 @@ function formatTaskList(tasks: CronTaskInfo[]): string {
   return output;
 }
 
-async function handleList(): Promise<CommandResult> {
+async function handleList(args: string[]): Promise<CommandResult> {
+  const parsed = parseKnownFlags(args.slice(1), {});
+  if ('error' in parsed) return flagError(parsed.error);
+
   if (!hasLocalNodeServer()) {
     const lm = await getLickManagerSurface();
     if (!lm) return notInitializedError('list');
@@ -211,7 +206,10 @@ async function handleList(): Promise<CommandResult> {
 
 async function handleDelete(args: string[]): Promise<CommandResult> {
   const subcommand = args[0];
-  const id = args[1];
+  const parsed = parseKnownFlags(args.slice(1), {});
+  if ('error' in parsed) return flagError(parsed.error);
+
+  const id = parsed.positionals[0];
   if (!id) {
     return { stdout: '', stderr: `crontask: ${subcommand} requires an ID\n`, exitCode: 1 };
   }
@@ -244,18 +242,17 @@ async function handleDelete(args: string[]): Promise<CommandResult> {
 
 export function createCrontaskCommand(): Command {
   return defineCommand('crontask', async (args, ctx) => {
-    if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    const subcommand = args[0];
+    if (!subcommand || isHelpRequest(args, { valueFlags: CREATE_VALUE_FLAGS })) {
       return crontaskHelp();
     }
-
-    const subcommand = args[0];
 
     try {
       switch (subcommand) {
         case 'create':
           return await handleCreate(args, ctx.env);
         case 'list':
-          return await handleList();
+          return await handleList(args);
         case 'delete':
         case 'kill':
           return await handleDelete(args);

--- a/packages/webapp/tests/shell/supplemental-commands/crontask-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/crontask-command.test.ts
@@ -78,6 +78,62 @@ describe('crontask command - CLI mode', () => {
   });
 
   describe('create subcommand', () => {
+    it('rejects unknown flags with a non-zero exit (#2255)', async () => {
+      const result = await run(['create', '--name', 'my-task', '--cron', '0 * * * *', '--bogus']);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('unknown flag: --bogus');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('honours -- when delete id starts with a dash', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const result = await run(['delete', '--', '-task123']);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Deleted cron task "-task123"');
+      expect(mockFetch).toHaveBeenCalledWith('/api/crontasks/-task123', expect.any(Object));
+    });
+
+    it('accepts --filter values that start with a dash via --flag=value', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'task-dash',
+          name: 'dash-filter',
+          cron: '0 * * * *',
+          filter: '--not-a-flag',
+          status: 'active',
+          createdAt: '2026-03-16T00:00:00Z',
+        }),
+      });
+
+      const result = await run([
+        'create',
+        '--name',
+        'dash-filter',
+        '--cron',
+        '0 * * * *',
+        '--filter=--not-a-flag',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/crontasks',
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'dash-filter',
+            cron: '0 * * * *',
+            filter: '--not-a-flag',
+            scoop: undefined,
+          }),
+        })
+      );
+    });
+
     it('requires --name argument', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -482,6 +538,12 @@ describe('crontask command - Extension mode', () => {
   };
 
   describe('help output', () => {
+    it('shows help with create --help', async () => {
+      const result = await run(['create', '--help']);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('usage: crontask');
+    });
+
     it('shows help with no args in extension mode', async () => {
       const result = await run([]);
       expect(result.exitCode).toBe(0);


### PR DESCRIPTION
## Summary

- Wire `crontask` through shared `parseKnownFlags` and `isHelpRequest` so unknown dash-prefixed flags exit 1 with `crontask: unknown flag: --x` instead of being silently ignored (fixes #2255).
- Honour `--` for delete IDs that start with `-`; accept dash-prefixed `--filter` values via `--flag=value`.
- Add tests for unknown flags, `--` terminator, and subcommand `--help`.

## Test plan

- [x] `npm run test -w @slicc/webapp -- packages/webapp/tests/shell/supplemental-commands/crontask-command.test.ts` (59 tests)
- [x] `npm run verify`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`