### PR TITLE
shell(which): reject unknown flags (#2255)

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/which-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/which-command.ts
@@ -4,6 +4,8 @@ import type { VirtualFS } from '../../fs/index.js';
 import { discoverJshCommands, pathToScanRoots } from '../jsh-discovery.js';
 import type { ScriptCatalog } from '../script-catalog.js';
 import { discoverWorkflowCommands, type WorkflowCommandEntry } from '../workflow-discovery.js';
+import { parseKnownFlags } from './subcommand-flags.js';
+import { isHelpRequest } from './subcommand-help.js';
 
 export interface WhichCommandOptions {
   fs?: VirtualFS;
@@ -82,10 +84,7 @@ export function createWhichCommand(options: WhichCommandOptions | VirtualFS = {}
         ? ({ fs: options as VirtualFS } satisfies WhichCommandOptions)
         : {};
 
-  return defineCommand('which', async (args, ctx) => {
-    if (args.includes('--help') || args.includes('-h')) {
-      return {
-        stdout: `which - locate a command
+  const HELP = `which - locate a command
 
 Usage: which <command> [command...]
 
@@ -94,13 +93,19 @@ Prints the path of the given command(s).
   - .jsh scripts resolve to their actual VFS path
 
 Exit code 0 if all commands found, 1 if any not found.
-`,
-        stderr: '',
-        exitCode: 0,
-      };
+`;
+
+  return defineCommand('which', async (args, ctx) => {
+    if (isHelpRequest(args)) {
+      return { stdout: HELP, stderr: '', exitCode: 0 };
     }
 
-    if (args.length === 0) {
+    const parsed = parseKnownFlags(args, {});
+    if ('error' in parsed) {
+      return { stdout: '', stderr: `which: ${parsed.error}\n`, exitCode: 1 };
+    }
+
+    if (parsed.positionals.length === 0) {
       return {
         stdout: '',
         stderr: 'which: missing argument\n',
@@ -126,7 +131,7 @@ Exit code 0 if all commands found, 1 if any not found.
     const stdoutLines: string[] = [];
     let allFound = true;
 
-    for (const name of args) {
+    for (const name of parsed.positionals) {
       const jshPath = jshCommands.get(name);
       const wf = workflowCommands.get(name);
       const result = resolveCommandPath(

--- a/packages/webapp/tests/shell/supplemental-commands/which-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/which-command.test.ts
@@ -46,6 +46,20 @@ describe('which command', () => {
     expect(result.stderr).toContain('missing argument');
   });
 
+  it('rejects unknown flags with a non-zero exit (#2255)', async () => {
+    const cmd = createWhichCommand();
+    const result = await cmd.execute(['--bogus', 'node'], createMockCtx());
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('which: unknown flag: --bogus\n');
+  });
+
+  it('honours -- so a dash-prefixed command name is not treated as a flag', async () => {
+    const cmd = createWhichCommand();
+    const result = await cmd.execute(['--', '--help'], createMockCtx());
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+  });
+
   it('resolves built-in command to /usr/bin/<name>', async () => {
     const cmd = createWhichCommand();
     const result = await cmd.execute(['node'], createMockCtx());


### PR DESCRIPTION
## Summary

- Route `which` argv through shared `isHelpRequest` and `parseKnownFlags` so unknown dash-prefixed tokens exit 1 with `which: unknown flag: --x` instead of being silently ignored.
- Honour `--` so command names that start with a dash are not mistaken for flags.

Fixes #2255 (which command only).

## Test plan

- [x] `npm run test -w @slicc/webapp -- packages/webapp/tests/shell/supplemental-commands/which-command.test.ts`
- [x] `npm run verify`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`


Made with [Cursor](https://cursor.com)