### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/cdp/transport.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -35,7 +35,6 @@
   "packages/webapp/src/cdp/preview-bridge-cdp-transport.ts": 3,
   "packages/webapp/src/cdp/remote-cdp-transport.ts": 7,
   "packages/webapp/src/cdp/synthetic-cdp-transport.ts": 10,
-  "packages/webapp/src/cdp/transport.ts": 3,
   "packages/webapp/src/cdp/types.ts": 4,
   "packages/webapp/src/core/feature-flags-remote.ts": 1,
   "packages/webapp/src/core/types.ts": 2,

--- a/packages/webapp/src/cdp/transport.ts
+++ b/packages/webapp/src/cdp/transport.ts
@@ -8,6 +8,8 @@
  * (federated tray targets driven from the kernel worker).
  */
 
+import type { CDPPayload } from '@slicc/shared-ts';
+
 import type { CDPConnectOptions, CDPEventListener, ConnectionState } from './types.js';
 
 export interface CDPTransport {
@@ -20,10 +22,10 @@ export interface CDPTransport {
   /** Send a CDP command and wait for the response. */
   send(
     method: string,
-    params?: Record<string, unknown>,
+    params?: CDPPayload,
     sessionId?: string,
     timeout?: number
-  ): Promise<Record<string, unknown>>;
+  ): Promise<CDPPayload>;
 
   /** Subscribe to a CDP event. */
   on(event: string, listener: CDPEventListener): void;
@@ -32,7 +34,7 @@ export interface CDPTransport {
   off(event: string, listener: CDPEventListener): void;
 
   /** Wait for a specific CDP event to fire once. */
-  once(event: string, timeout?: number): Promise<Record<string, unknown>>;
+  once(event: string, timeout?: number): Promise<CDPPayload>;
 
   /** Current connection state. */
   readonly state: ConnectionState;


### PR DESCRIPTION
## Summary

- Replace three `Record<string, unknown>` occurrences in `CDPTransport` with the existing `CDPPayload` named type from `@slicc/shared-ts`.
- Ratchet `record-string-unknown-baseline.json` to remove `packages/webapp/src/cdp/transport.ts`.

## Debt cleared

- `record-string-unknown` (was 3 occurrences)

## Verification

- `npx biome check --write packages/webapp/src/cdp/transport.ts`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/cdp/cdp-client.test.ts packages/webapp/tests/cdp/extension-bridge-transport.test.ts packages/webapp/tests/cdp/panel-rpc-cdp-transport.test.ts`
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`

Made with [Cursor](https://cursor.com)