### PR TITLE
refactor: pay down boy-scout debt in packages/node-server/src/cloud/registry-file.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -10,7 +10,6 @@
   "packages/cloudflare-worker/src/oauth-exchange.ts": 1,
   "packages/dev-tools/tools/extension-smoke-test.ts": 6,
   "packages/node-server/src/cdp-proxy/session-url-tracker.ts": 3,
-  "packages/node-server/src/cloud/registry-file.ts": 1,
   "packages/node-server/src/electron-controller.ts": 13,
   "packages/node-server/src/electron-federated-cdp.ts": 5,
   "packages/node-server/src/electron-runtime.ts": 1,

--- a/packages/node-server/src/cloud/registry-file.ts
+++ b/packages/node-server/src/cloud/registry-file.ts
@@ -8,7 +8,7 @@ interface RegistryFile {
 
 function isConeEntry(x: unknown): x is ConeEntry {
   if (typeof x !== 'object' || x === null) return false;
-  const e = x as Record<string, unknown>;
+  const e = x as Partial<Record<keyof ConeEntry, unknown>>;
   return (
     typeof e.substrate === 'string' &&
     typeof e.sandboxId === 'string' &&

--- a/packages/node-server/tests/cloud/registry.test.ts
+++ b/packages/node-server/tests/cloud/registry.test.ts
@@ -74,6 +74,36 @@ describe('FileRegistry', () => {
     await expect(reg.remove('missing-id')).resolves.toBeUndefined();
   });
 
+  it('skips malformed entries and returns only valid sessions', async () => {
+    await fs.writeFile(
+      file,
+      JSON.stringify({
+        sessions: [
+          {
+            substrate: 'e2b',
+            sandboxId: 'good',
+            createdAt: '2026-05-22T00:00:00Z',
+            joinUrl: 'https://w/join/good',
+            lastSeen: '2026-05-22T00:00:00Z',
+            state: 'running',
+          },
+          { substrate: 'e2b', sandboxId: 'bad' },
+          'not-an-object',
+        ],
+      })
+    );
+    const reg = new FileRegistry(file);
+    const sessions = await reg.list();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.sandboxId).toBe('good');
+  });
+
+  it('treats a malformed registry file as empty', async () => {
+    await fs.writeFile(file, JSON.stringify({ notSessions: [] }));
+    const reg = new FileRegistry(file);
+    expect(await reg.list()).toEqual([]);
+  });
+
   it('findByNameOrId resolves both name and sandboxId', async () => {
     const reg = new FileRegistry(file);
     await reg.append({


### PR DESCRIPTION
## Summary

Replace `Record<string, unknown>` in `isConeEntry` with `Partial<Record<keyof ConeEntry, unknown>>` and ratchet the record-string-unknown baseline for `packages/node-server/src/cloud/registry-file.ts`. Add tests for malformed registry parsing.

## Why

Boy-scout debt cleanup: the file was on the `record-string-unknown` debt list. Typed narrowing at the JSON boundary matches the existing pattern in `cloud-status.ts`.

## Approach / Implementation notes

- `isConeEntry` now casts parsed JSON to `Partial<Record<keyof ConeEntry, unknown>>` instead of an open bag.
- Baseline updated via `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`.
- Two focused tests added for skipping malformed entries and treating a malformed top-level file as empty.

## Cross-cutting impact

- **Floats exercised**: CLI only (`--cloud` file-backed registry). No behavior change.
- **Other callers**: unchanged; only the internal type guard cast changed.

## Test plan

- [x] `npx biome check --write packages/node-server/src/cloud/registry-file.ts packages/node-server/tests/cloud/registry.test.ts`
- [x] `npm run typecheck`
- [x] `npx vitest run packages/node-server/tests/cloud/registry.test.ts` — 8 passing
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK
- [ ] `npm run build` — not required for this node-server-only type refactor
- [ ] Manual smoke (CLI): N/A — behavior-preserving

## Documentation

- [x] No documentation changes needed

## Risk & rollback

Low risk. Revert this PR cleanly if needed; no migrations or persisted schema changes beyond the existing on-disk JSON validation path.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
