### PR TITLE
Route discovery licks to the most likely cone

### DIFF
--- a/packages/webapp/src/kernel/discovery-lick-routing.ts
+++ b/packages/webapp/src/kernel/discovery-lick-routing.ts
@@ -1,0 +1,129 @@
+/**
+ * Contextual routing for untargeted discovery licks.
+ *
+ * Discovery is observed outside any work-unit conversation, so its wire event
+ * has no `targetScoop`. With multiple cones, recent conversation context is the
+ * best available ownership signal: a cone that just mentioned the discovered
+ * host or URL is more likely to be driving that browsing session.
+ */
+
+const RECENT_MESSAGE_LIMIT = 8;
+const GENERIC_URL_PARTS = new Set([
+  'com',
+  'html',
+  'http',
+  'https',
+  'json',
+  'net',
+  'org',
+  'txt',
+  'well',
+  'www',
+]);
+
+export interface DiscoveryRoute {
+  discoveryOrigin?: string;
+  discoveryUrl?: string;
+}
+
+export interface DiscoveryRouteCandidate {
+  jid: string;
+}
+
+interface WeightedNeedle {
+  text: string;
+  weight: number;
+}
+
+/**
+ * Pick the sole highest-scoring candidate from recent agent history.
+ *
+ * Returns `undefined` when no candidate mentions the discovery URL, or when
+ * the best score is tied. The caller then retains its stable default-root
+ * fallback rather than making an arbitrary routing choice.
+ */
+export function matchDiscoveryRouteCandidate<T extends DiscoveryRouteCandidate>(
+  event: DiscoveryRoute,
+  candidates: readonly T[],
+  getMessages: (candidate: T) => readonly unknown[]
+): T | undefined {
+  const needles = discoveryNeedles(event);
+  if (needles.length === 0) return undefined;
+
+  let best: T | undefined;
+  let bestScore = 0;
+  let tied = false;
+
+  for (const candidate of candidates) {
+    const score = scoreRecentMessages(getMessages(candidate), needles);
+    if (score > bestScore) {
+      best = candidate;
+      bestScore = score;
+      tied = false;
+    } else if (score > 0 && score === bestScore) {
+      tied = true;
+    }
+  }
+
+  return tied ? undefined : best;
+}
+
+function discoveryNeedles(event: DiscoveryRoute): WeightedNeedle[] {
+  const needles = new Map<string, number>();
+  addUrlNeedles(needles, event.discoveryOrigin);
+  addUrlNeedles(needles, event.discoveryUrl);
+  return [...needles].map(([text, weight]) => ({ text, weight }));
+}
+
+function addUrlNeedles(needles: Map<string, number>, value: string | undefined): void {
+  if (!value) return;
+  const normalized = value.toLowerCase().replace(/\/$/, '');
+  addNeedle(needles, normalized, 12);
+
+  try {
+    const url = new URL(value);
+    const hostname = url.hostname.toLowerCase().replace(/^www\./, '');
+    addNeedle(needles, hostname, 8);
+    for (const part of `${hostname}${url.pathname}${url.search}`
+      .split(/[^a-z0-9]+/)
+      .filter((part) => part.length >= 4 && !GENERIC_URL_PARTS.has(part))) {
+      addNeedle(needles, part, 1);
+    }
+  } catch {
+    // A malformed producer value can still match verbatim; it simply yields no
+    // hostname/path clues.
+  }
+}
+
+function addNeedle(needles: Map<string, number>, text: string, weight: number): void {
+  if (text.length === 0) return;
+  needles.set(text, Math.max(needles.get(text) ?? 0, weight));
+}
+
+function scoreRecentMessages(
+  messages: readonly unknown[],
+  needles: readonly WeightedNeedle[]
+): number {
+  const recent = messages.slice(-RECENT_MESSAGE_LIMIT);
+  let score = 0;
+  for (const [index, message] of recent.entries()) {
+    const haystack = serializeMessage(message);
+    if (haystack.length === 0) continue;
+    // A match in the newest message is up to 8x more useful than one at the
+    // edge of the window. JSON serialization deliberately includes assistant
+    // tool calls and tool results, not just visible user/assistant prose.
+    const recency = index + 1;
+    for (const needle of needles) {
+      if (haystack.includes(needle.text)) score += needle.weight * recency;
+    }
+  }
+  return score;
+}
+
+function serializeMessage(message: unknown): string {
+  try {
+    return JSON.stringify(message)?.toLowerCase() ?? '';
+  } catch {
+    return '';
+  }
+}

--- a/packages/webapp/src/kernel/discovery-lick-routing.ts
+++ b/packages/webapp/src/kernel/discovery-lick-routing.ts
@@ -9,11 +9,14 @@
 
 const RECENT_MESSAGE_LIMIT = 8;
 const GENERIC_URL_PARTS = new Set([
+  'catalog',
   'com',
   'html',
   'http',
   'https',
   'json',
+  'known',
+  'llms',
   'net',
   'org',
   'txt',
@@ -33,6 +36,7 @@ export interface DiscoveryRouteCandidate {
 interface WeightedNeedle {
   text: string;
   weight: number;
+  match: 'substring' | 'hostname';
 }
 
 /**
@@ -69,25 +73,25 @@ export function matchDiscoveryRouteCandidate<T extends DiscoveryRouteCandidate>(
 }
 
 function discoveryNeedles(event: DiscoveryRoute): WeightedNeedle[] {
-  const needles = new Map<string, number>();
+  const needles = new Map<string, WeightedNeedle>();
   addUrlNeedles(needles, event.discoveryOrigin);
   addUrlNeedles(needles, event.discoveryUrl);
-  return [...needles].map(([text, weight]) => ({ text, weight }));
+  return [...needles.values()];
 }
 
-function addUrlNeedles(needles: Map<string, number>, value: string | undefined): void {
+function addUrlNeedles(needles: Map<string, WeightedNeedle>, value: string | undefined): void {
   if (!value) return;
   const normalized = value.toLowerCase().replace(/\/$/, '');
-  addNeedle(needles, normalized, 12);
+  addNeedle(needles, normalized, 12, 'substring');
 
   try {
     const url = new URL(value);
     const hostname = url.hostname.toLowerCase().replace(/^www\./, '');
-    addNeedle(needles, hostname, 8);
+    addNeedle(needles, hostname, 8, 'hostname');
     for (const part of `${hostname}${url.pathname}${url.search}`
       .split(/[^a-z0-9]+/)
       .filter((part) => part.length >= 4 && !GENERIC_URL_PARTS.has(part))) {
-      addNeedle(needles, part, 1);
+      addNeedle(needles, part, 1, 'substring');
     }
   } catch {
     // A malformed producer value can still match verbatim; it simply yields no
@@ -95,9 +99,16 @@ function addUrlNeedles(needles: Map<string, number>, value: string | undefined):
   }
 }
 
-function addNeedle(needles: Map<string, number>, text: string, weight: number): void {
+function addNeedle(
+  needles: Map<string, WeightedNeedle>,
+  text: string,
+  weight: number,
+  match: WeightedNeedle['match']
+): void {
   if (text.length === 0) return;
-  needles.set(text, Math.max(needles.get(text) ?? 0, weight));
+  const key = `${match}:${text}`;
+  const existing = needles.get(key);
+  if (!existing || weight > existing.weight) needles.set(key, { text, weight, match });
 }
 
 function scoreRecentMessages(
@@ -112,12 +123,20 @@ function scoreRecentMessages(
     // A match in the newest message is up to 8x more useful than one at the
     // edge of the window. JSON serialization deliberately includes assistant
     // tool calls and tool results, not just visible user/assistant prose.
-    const recency = index + 1;
+    const recency = RECENT_MESSAGE_LIMIT - (recent.length - 1 - index);
     for (const needle of needles) {
-      if (haystack.includes(needle.text)) score += needle.weight * recency;
+      if (matchesNeedle(haystack, needle)) score += needle.weight * recency;
     }
   }
   return score;
+}
+
+function matchesNeedle(haystack: string, needle: WeightedNeedle): boolean {
+  if (needle.match === 'substring') return haystack.includes(needle.text);
+  const escaped = needle.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // Hostnames must stand alone (with an optional common `www.` prefix).
+  // Otherwise `ai.com` would falsely match the unrelated host `openai.com`.
+  return new RegExp(`(^|[^a-z0-9.-])(?:www\\.)?${escaped}($|[^a-z0-9.-])`).test(haystack);
 }
 
 function serializeMessage(message: unknown): string {

--- a/packages/webapp/src/kernel/host.ts
+++ b/packages/webapp/src/kernel/host.ts
@@ -79,6 +79,7 @@ import {
 import { createProxiedFetch } from '../shell/proxied-fetch.js';
 import { makeSentinel, splitSentinel } from '../shell/supplemental-commands/workflow-script.js';
 import { rootsOf } from '../work-unit/policy.js';
+import { matchDiscoveryRouteCandidate } from './discovery-lick-routing.js';
 import { ProcMountBackend } from './proc-mount.js';
 import { ProcessManager } from './process-manager.js';
 import { installSyncFsResponder } from './realm/sync-fs-responder.js';
@@ -324,14 +325,25 @@ function routeFormattedLickToCone(
   { orchestrator, log }: LickRoutingContext
 ): void {
   const scoops = orchestrator.getScoops();
+  const roots = rootsOf(scoops);
   // Two dispositions for a target that resolves to nothing, deliberately
   // different (docs/work-unit.md § Addressing licks): an UNTARGETED lick falls
-  // back to the default root — `rootsOf(scoops)[0]`, the oldest surviving one —
-  // while a TARGETED lick naming a unit that is gone (or never existed) is
-  // warned about and dropped, never silently redirected into someone else's chat.
+  // back to the default root — the oldest surviving one — while a TARGETED lick
+  // naming a unit that is gone (or never existed) is warned about and dropped,
+  // never silently redirected into someone else's chat. Discovery gets one
+  // additional ownership signal: a unique URL/domain match in a browsing root's
+  // recent agent history. No match or a tie preserves the stable fallback.
+  const contextualDiscoveryTarget =
+    event.type === 'discovery' && !event.targetScoop
+      ? matchDiscoveryRouteCandidate(
+          event,
+          roots.filter(scoopCanBrowse),
+          (root) => orchestrator.getScoopContext?.(root.jid)?.getAgentMessages() ?? []
+        )
+      : undefined;
   const resolvedTarget: RegisteredScoop | undefined = event.targetScoop
     ? matchLickTargetAlias(scoops, event.targetScoop)
-    : rootsOf(scoops)[0];
+    : (contextualDiscoveryTarget ?? roots[0]);
 
   if (!resolvedTarget) {
     log.warn('Lick target scoop not found', event.targetScoop);

--- a/packages/webapp/tests/kernel/discovery-lick-routing.test.ts
+++ b/packages/webapp/tests/kernel/discovery-lick-routing.test.ts
@@ -119,4 +119,63 @@ describe('matchDiscoveryRouteCandidate', () => {
       )
     ).toBe(beta);
   });
+
+  it('anchors the newest message at the same recency weight for short and full histories', () => {
+    const messages = new Map<string, unknown[]>([
+      [alpha.jid, [{ role: 'user', content: 'I am opening example.com now' }]],
+      [
+        beta.jid,
+        [
+          ...Array.from({ length: 6 }, (_, index) => ({
+            role: 'user',
+            content: `Unrelated message ${index}`,
+          })),
+          { role: 'assistant', content: 'Earlier I visited example.com' },
+          { role: 'assistant', content: 'Now working elsewhere' },
+        ],
+      ],
+    ]);
+
+    expect(
+      matchDiscoveryRouteCandidate(
+        { discoveryOrigin: 'https://example.com' },
+        [alpha, beta],
+        (candidate) => messages.get(candidate.jid) ?? []
+      )
+    ).toBe(alpha);
+  });
+
+  it('does not match a hostname embedded inside an unrelated hostname', () => {
+    expect(
+      matchDiscoveryRouteCandidate(
+        { discoveryOrigin: 'https://ai.com' },
+        [alpha, beta],
+        (candidate) =>
+          candidate === beta
+            ? [{ role: 'assistant', content: 'I opened https://openai.com/docs' }]
+            : []
+      )
+    ).toBeUndefined();
+  });
+
+  it('does not use fixed discovery artifact names as contextual clues', () => {
+    expect(
+      matchDiscoveryRouteCandidate(
+        {
+          discoveryOrigin: 'https://unrelated.example',
+          discoveryUrl: 'https://unrelated.example/.well-known/ai-catalog.json',
+        },
+        [alpha, beta],
+        (candidate) =>
+          candidate === beta
+            ? [
+                {
+                  role: 'user',
+                  content: 'A previous discovery mentioned llms.txt and an AI catalog',
+                },
+              ]
+            : []
+      )
+    ).toBeUndefined();
+  });
 });

--- a/packages/webapp/tests/kernel/discovery-lick-routing.test.ts
+++ b/packages/webapp/tests/kernel/discovery-lick-routing.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { matchDiscoveryRouteCandidate } from '../../src/kernel/discovery-lick-routing.js';
+
+const alpha = { jid: 'cone-alpha', name: 'Alpha' };
+const beta = { jid: 'cone-beta', name: 'Beta' };
+
+describe('matchDiscoveryRouteCandidate', () => {
+  it('routes to the cone whose recent user message mentions the discovery domain', () => {
+    const messages = new Map<string, unknown[]>([
+      [alpha.jid, [{ role: 'user', content: 'Please inspect example.com pricing' }]],
+      [beta.jid, [{ role: 'user', content: 'Review the local test failures' }]],
+    ]);
+
+    expect(
+      matchDiscoveryRouteCandidate(
+        {
+          discoveryOrigin: 'https://example.com',
+          discoveryUrl: 'https://example.com/llms.txt',
+        },
+        [alpha, beta],
+        (candidate) => messages.get(candidate.jid) ?? []
+      )
+    ).toBe(alpha);
+  });
+
+  it('considers URLs inside assistant tool calls and tool results', () => {
+    const messages = new Map<string, unknown[]>([
+      [alpha.jid, [{ role: 'assistant', content: 'I will inspect the other task.' }]],
+      [
+        beta.jid,
+        [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'toolCall',
+                name: 'browser',
+                arguments: { url: 'https://docs.acme.dev/guides/agents' },
+              },
+            ],
+          },
+          {
+            role: 'toolResult',
+            content: [{ type: 'text', text: 'Loaded docs.acme.dev' }],
+          },
+        ],
+      ],
+    ]);
+
+    expect(
+      matchDiscoveryRouteCandidate(
+        {
+          discoveryOrigin: 'https://docs.acme.dev',
+          discoveryUrl: 'https://docs.acme.dev/llms.txt',
+        },
+        [alpha, beta],
+        (candidate) => messages.get(candidate.jid) ?? []
+      )
+    ).toBe(beta);
+  });
+
+  it('uses URL path parts when the hostname alone is absent', () => {
+    const messages = new Map<string, unknown[]>([
+      [alpha.jid, [{ role: 'user', content: 'Open the frobnicator integration guide' }]],
+      [beta.jid, [{ role: 'user', content: 'Open the payments integration guide' }]],
+    ]);
+
+    expect(
+      matchDiscoveryRouteCandidate(
+        { discoveryUrl: 'https://example.com/products/frobnicator/llms.txt' },
+        [alpha, beta],
+        (candidate) => messages.get(candidate.jid) ?? []
+      )
+    ).toBe(alpha);
+  });
+
+  it('returns no match for a tie or absent context so the caller can use its stable fallback', () => {
+    const sameMessages = () => [{ role: 'user', content: 'Look at example.com' }];
+    expect(
+      matchDiscoveryRouteCandidate(
+        { discoveryOrigin: 'https://example.com' },
+        [alpha, beta],
+        sameMessages
+      )
+    ).toBeUndefined();
+
+    expect(
+      matchDiscoveryRouteCandidate(
+        { discoveryOrigin: 'https://unrelated.example' },
+        [alpha, beta],
+        () => []
+      )
+    ).toBeUndefined();
+  });
+
+  it('weights recent messages more heavily than older matches', () => {
+    const messages = new Map<string, unknown[]>([
+      [
+        alpha.jid,
+        [
+          { role: 'user', content: 'Earlier we visited example.com' },
+          { role: 'assistant', content: 'Now working on something unrelated' },
+        ],
+      ],
+      [
+        beta.jid,
+        [
+          { role: 'user', content: 'Earlier work was unrelated' },
+          { role: 'assistant', content: 'I am opening example.com now' },
+        ],
+      ],
+    ]);
+
+    expect(
+      matchDiscoveryRouteCandidate(
+        { discoveryOrigin: 'https://example.com' },
+        [alpha, beta],
+        (candidate) => messages.get(candidate.jid) ?? []
+      )
+    ).toBe(beta);
+  });
+});

--- a/packages/webapp/tests/kernel/lick-target-resolution.test.ts
+++ b/packages/webapp/tests/kernel/lick-target-resolution.test.ts
@@ -53,11 +53,22 @@ function cronLick(targetScoop?: string) {
   };
 }
 
-function routingCtx(scoops: readonly unknown[], handleMessage: ReturnType<typeof vi.fn>) {
+function routingCtx(
+  scoops: readonly unknown[],
+  handleMessage: ReturnType<typeof vi.fn>,
+  messages: ReadonlyMap<string, readonly unknown[]> = new Map()
+) {
   const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
   return {
     ctx: {
-      orchestrator: { getScoops: () => scoops, handleMessage } as never,
+      orchestrator: {
+        getScoops: () => scoops,
+        getScoopContext: (jid: string) => ({
+          getAgentMessages: () => messages.get(jid) ?? [],
+        }),
+        registerDiscoveryLick: () => 'discovery-lick-id',
+        handleMessage,
+      } as never,
       lickManager: {} as never,
       log,
     },
@@ -105,6 +116,44 @@ describe('routeFormattedLickToCone target resolution', () => {
 
     expect(handleMessage).toHaveBeenCalledWith(
       expect.objectContaining({ chatJid: 'cone-jid', channel: 'cron' })
+    );
+  });
+
+  it('routes an untargeted discovery lick to the cone with matching recent context', () => {
+    const handleMessage = vi.fn(async () => undefined);
+    const messages = new Map<string, readonly unknown[]>([
+      [primary.jid, [{ role: 'user', content: 'Investigate the local build' }]],
+      [
+        extraCone.jid,
+        [
+          {
+            role: 'assistant',
+            content: [
+              {
+                type: 'toolCall',
+                name: 'browser',
+                arguments: { url: 'https://example.com/products' },
+              },
+            ],
+          },
+        ],
+      ],
+    ]);
+    const { ctx } = routingCtx([primary, extraCone], handleMessage, messages);
+    defaultLickEventHandler(
+      {
+        type: 'discovery',
+        discoveryUrl: 'https://example.com/llms.txt',
+        discoveryOrigin: 'https://example.com',
+        discoveryKind: 'llms-txt',
+        timestamp: 't',
+        body: {},
+      } as never,
+      ctx
+    );
+
+    expect(handleMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ chatJid: 'cone-reviewer-jid', channel: 'discovery' })
     );
   });
 


### PR DESCRIPTION
## Summary
- score browsing-capable root cones against the discovery URL, origin, hostname, and meaningful URL parts
- inspect the last eight live agent messages, including assistant tool calls and tool results, with a recency bias
- preserve the oldest-root fallback when there is no contextual match or the best score is tied
- leave explicitly targeted and non-discovery licks unchanged

## Verification
- `npm run verify`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- `npm run typecheck --workspace=@slicc/webapp`
- `npm run test` (17,201 passed; 46 skipped)
- `npm run test:coverage`
- `npm run build`
- `npm run build -w @slicc/chrome-extension`
- `npm run bundle-size` (worker eager payload +1.1 kB vs base; within allowance)
