### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/core/feature-flags-remote.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -36,7 +36,6 @@
   "packages/webapp/src/cdp/remote-cdp-transport.ts": 7,
   "packages/webapp/src/cdp/synthetic-cdp-transport.ts": 10,
   "packages/webapp/src/cdp/types.ts": 4,
-  "packages/webapp/src/core/feature-flags-remote.ts": 1,
   "packages/webapp/src/core/types.ts": 2,
   "packages/webapp/src/fs/mount/backend-local.ts": 1,
   "packages/webapp/src/fs/sidecar-merge.ts": 2,

--- a/packages/webapp/src/core/feature-flags-remote.ts
+++ b/packages/webapp/src/core/feature-flags-remote.ts
@@ -2,6 +2,7 @@ import {
   type FeatureFlagFloat,
   type FeatureFlagValues,
   initFeatureFlags,
+  type UntrustedFlagValues,
 } from './feature-flags.js';
 import {
   type FeatureFlagsRemoteStorage,
@@ -93,11 +94,13 @@ async function fetchFlags(
 }
 
 function readFlagsPayload(value: unknown): FeatureFlagValues | null {
-  if (!isRecord(value) || !isRecord(value.flags)) return null;
-  if (Object.values(value.flags).some((flagValue) => typeof flagValue !== 'string')) return null;
-  return value.flags as FeatureFlagValues;
+  if (!isPlainObject(value)) return null;
+  const flags = value.flags;
+  if (!isPlainObject(flags)) return null;
+  if (Object.values(flags).some((flagValue) => typeof flagValue !== 'string')) return null;
+  return flags as FeatureFlagValues;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isPlainObject(value: unknown): value is UntrustedFlagValues {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## Summary

- Replaced `Record<string, unknown>` in remote flag payload parsing with the existing `UntrustedFlagValues` type from `feature-flags.ts`, aligning with `feature-flags-cache.ts`.
- Renamed the local guard to `isPlainObject` and narrowed the envelope/`flags` fields explicitly before validating string values.
- Ratcheted `record-string-unknown-baseline.json` via `check-record-string-unknown.mjs --update`.

## Debt cleared

- `record-string-unknown` — removed `packages/webapp/src/core/feature-flags-remote.ts` from the baseline.

## Verification

- `npx biome check --write packages/webapp/src/core/feature-flags-remote.ts`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/core/feature-flags-remote.test.ts`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`

Made with [Cursor](https://cursor.com)