### PR TITLE
refactor: pay down boy-scout debt in packages/node-server/src/routes/oauth-callback.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -16,7 +16,6 @@
   "packages/node-server/src/electron-runtime.ts": 1,
   "packages/node-server/src/electron-tray-follower.ts": 16,
   "packages/node-server/src/file-logger.ts": 1,
-  "packages/node-server/src/routes/oauth-callback.ts": 1,
   "packages/node-server/src/sudo/electron-backend.ts": 1,
   "packages/shared-ts/src/transcript-export.ts": 18,
   "packages/webapp/providers/adobe.ts": 1,

--- a/packages/node-server/src/routes/oauth-callback.ts
+++ b/packages/node-server/src/routes/oauth-callback.ts
@@ -1,5 +1,16 @@
 import express, { type Express, type Request, type Response } from 'express';
 
+/** Inbound JSON from the OAuth callback page POST to `/api/oauth-result`. */
+export interface OAuthResultPostBody {
+  redirectUrl?: unknown;
+  error?: unknown;
+}
+
+export interface PendingOAuthResult {
+  redirectUrl: string;
+  error?: string;
+}
+
 /**
  * Generic OAuth redirect target for OAuth providers (implicit + PKCE).
  *
@@ -18,7 +29,7 @@ import express, { type Express, type Request, type Response } from 'express';
  */
 export function registerOAuthCallbackRoutes(app: Express): void {
   // Pending OAuth result for server-side relay (Electron overlay can't use window.opener)
-  let pendingOAuthResult: { redirectUrl: string; error?: string } | null = null;
+  let pendingOAuthResult: PendingOAuthResult | null = null;
 
   app.get('/auth/callback', (_req: Request, res: Response) => {
     res.send(`<!DOCTYPE html><html><body><script>
@@ -58,7 +69,7 @@ export function registerOAuthCallbackRoutes(app: Express): void {
   });
 
   app.post('/api/oauth-result', express.json(), (req: Request, res: Response) => {
-    const body = req.body as Record<string, unknown>;
+    const body = req.body as OAuthResultPostBody;
     const redirectUrl = typeof body.redirectUrl === 'string' ? body.redirectUrl : '';
     if (!redirectUrl) {
       console.warn('[oauth-result] Received callback with empty redirectUrl');


### PR DESCRIPTION
## Summary

- Replaced `Record<string, unknown>` in the OAuth result POST handler with named `OAuthResultPostBody` and `PendingOAuthResult` types (matching the `HandoffPayload` boundary-narrowing pattern).
- Cleared `packages/node-server/src/routes/oauth-callback.ts` from `record-string-unknown-baseline.json` via `check-record-string-unknown.mjs --update`.

## Debt lists cleared

- `record-string-unknown` (1 occurrence removed)

## Verification

- `npx biome check --write packages/node-server/src/routes/oauth-callback.ts`
- `npm run typecheck`
- `npx vitest run packages/node-server/tests/routes/oauth-callback.test.ts` (11 tests)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`


Made with [Cursor](https://cursor.com)