### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/playwright/session-log.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -14,7 +14,6 @@
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/network-requests.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/teleport.ts": 2,
-  "packages/webapp/src/shell/supplemental-commands/playwright/session-log.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/snapshot.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/playwright/state.ts": 4,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport-storage.ts": 2,

--- a/packages/webapp/src/shell/supplemental-commands/playwright/session-log.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/session-log.ts
@@ -3,11 +3,14 @@
  * playwright-cli command family.
  */
 
-import type { BrowserAPI } from '../../../cdp/index.js';
 import type { VirtualFS } from '../../../fs/index.js';
 import { buildSnapshot } from './snapshot.js';
 import { filenameSafeTimestamp, isAlreadyExistsError } from './state.js';
-import type { CmdResult, PlaywrightState, TabSnapshot } from './types.js';
+import type { CmdResult, PlaywrightHandlerCtx, PlaywrightState, TabSnapshot } from './types.js';
+
+// Named via the handler context rather than imported from `cdp/` so this
+// module stays inside the shell layer (see layer-stack import direction).
+type BrowserAPI = PlaywrightHandlerCtx['browser'];
 
 /** Ensure /.playwright/ directories exist. */
 export async function ensureSessionDirs(vfs: VirtualFS, state: PlaywrightState): Promise<void> {


### PR DESCRIPTION
## Summary

Remove the shell→cdp layer back-edge in `session-log.ts` by typing the browser via `PlaywrightHandlerCtx['browser']` instead of importing `BrowserAPI` from `cdp/`.

## Why

Boy-scout debt cleanup (`layer-back-edge` on `session-log.ts`).

## Approach / Implementation notes

- Matches the existing pattern in `playwright/handlers/snapshot.ts` (handler-context browser type, no direct `cdp/` import).
- Ratcheted `layer-back-edge-baseline.json` via `check-layer-back-edges.mjs --update`.

## Cross-cutting impact

- **Floats exercised**: behavior unchanged; shell playwright-cli auto-snapshot/session logging only.
- No persisted-state, bundle, or security surface changes.

## Test plan

- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts packages/webapp/tests/shell/supplemental-commands/playwright/handlers/snapshot.test.ts` — 316 passing
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [ ] **New / changed behavior is covered by a unit test** — N/A (type-only refactor; existing playwright-cli tests cover auto-snapshot behavior)
- [ ] N/A — no manual smoke needed for import-direction refactor

## Documentation

- [x] No documentation changes needed

## Risk & rollback

- Low blast radius; revert cleanly restores the prior import.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
