### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/cdp/preview-bridge-cdp-transport.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -26,7 +26,6 @@
   "packages/webapp/src/cdp/har-recorder.ts": 10,
   "packages/webapp/src/cdp/navigation-watcher.ts": 11,
   "packages/webapp/src/cdp/panel-rpc-cdp-transport.ts": 5,
-  "packages/webapp/src/cdp/preview-bridge-cdp-transport.ts": 3,
   "packages/webapp/src/cdp/synthetic-cdp-transport.ts": 10,
   "packages/webapp/src/core/types.ts": 2,
   "packages/webapp/src/fs/mount/backend-local.ts": 1,

--- a/packages/webapp/src/cdp/preview-bridge-cdp-transport.ts
+++ b/packages/webapp/src/cdp/preview-bridge-cdp-transport.ts
@@ -7,7 +7,11 @@
  * bridge.cdp.request messages.
  */
 
-import type { LeaderToWorkerControlMessage } from '@slicc/shared-ts';
+import type {
+  CDPPayload,
+  LeaderToWorkerControlMessage,
+  WorkerBridgeCdpResponse,
+} from '@slicc/shared-ts';
 import { PendingRequestTable } from './pending-request-table.js';
 import type { SyntheticCdpTransportOptions } from './synthetic-cdp-transport.js';
 import { SyntheticCdpTransport } from './synthetic-cdp-transport.js';
@@ -70,10 +74,10 @@ export class PreviewBridgeCdpTransport extends SyntheticCdpTransport {
    */
   protected async forward(
     method: string,
-    params?: Record<string, unknown>,
+    params?: CDPPayload,
     sessionId?: string,
     timeout = DEFAULT_TIMEOUT
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CDPPayload> {
     const id = this.nextId++;
 
     const response = this.pending.issue(
@@ -100,10 +104,7 @@ export class PreviewBridgeCdpTransport extends SyntheticCdpTransport {
    * the UNWRAPPED result (payload.result ?? {}), matching CherryHostTransport
    * and the shape BrowserAPI expects.
    */
-  deliverResponse(
-    id: number,
-    payload: { result?: Record<string, unknown>; error?: { code: number; message: string } }
-  ): void {
+  deliverResponse(id: number, payload: Pick<WorkerBridgeCdpResponse, 'result' | 'error'>): void {
     if (payload.error) {
       this.pending.reject(
         id,


### PR DESCRIPTION
## Summary

- Replaced three `Record<string, unknown>` occurrences in `preview-bridge-cdp-transport.ts` with named types: `CDPPayload` for CDP params/results and `Pick<WorkerBridgeCdpResponse, 'result' | 'error'>` for `deliverResponse` payloads.
- Removed the file from `record-string-unknown-baseline.json` (3 → 0 grandfathered occurrences).

## Debt cleared

- `record-string-unknown` — `packages/webapp/src/cdp/preview-bridge-cdp-transport.ts`

## Verification

- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/cdp/preview-bridge-cdp-transport.test.ts` (9 tests)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK

Made with [Cursor](https://cursor.com)