### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/ui/oauth-bootstrap.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -311,8 +311,7 @@
         "packages/webapp/src/shell/supplemental-commands/local-llm-command.ts",
         "packages/webapp/src/shell/supplemental-commands/pdftk-command.ts",
         "packages/webapp/src/shell/supplemental-commands/websocat-command.ts",
-        "packages/webapp/src/skills/install-from-drop.ts",
-        "packages/webapp/src/ui/oauth-bootstrap.ts"
+        "packages/webapp/src/skills/install-from-drop.ts"
       ],
       "linter": {
         "rules": {

--- a/packages/webapp/src/ui/oauth-bootstrap.ts
+++ b/packages/webapp/src/ui/oauth-bootstrap.ts
@@ -8,6 +8,7 @@
  */
 
 import { createLogger } from '../core/logger.js';
+import type { Account } from '../providers/account-store.js';
 import { getRegisteredProviderConfig } from '../providers/index.js';
 import { getAccounts, saveOAuthAccount } from './provider-settings.js';
 
@@ -17,7 +18,11 @@ const log = createLogger('oauth-bootstrap');
 // 60s aligns with getValidAccessToken's freshness threshold.
 const RENEW_BUFFER_MS = 60_000;
 
-export async function bootstrapOAuthReplicas(): Promise<void> {
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function ensureMcpProvidersForBootstrap(): Promise<void> {
   // MCP providers are lazy-registered by the first `mcp` subcommand
   // (see `shell/mcp/provider.ts:ensureMcpProviderRegistered`), so on
   // a fresh page load `mcp:<name>` configs aren't in the registry
@@ -37,67 +42,85 @@ export async function bootstrapOAuthReplicas(): Promise<void> {
     }
   } catch (err) {
     log.warn('Failed to pre-register MCP providers for OAuth bootstrap', {
-      error: err instanceof Error ? err.message : String(err),
+      error: errorMessage(err),
     });
   }
+}
+
+function accountNeedsRenewal(account: Account): boolean {
+  const expiresIn = (account.tokenExpiresAt ?? Infinity) - Date.now();
+  return expiresIn <= RENEW_BUFFER_MS;
+}
+
+async function trySilentRenewal(account: Account): Promise<void> {
+  const cfg = getRegisteredProviderConfig(account.providerId);
+  if (!cfg?.onSilentRenew) {
+    log.debug('Skipping expired account (no silent-renew hook)', {
+      providerId: account.providerId,
+    });
+    return;
+  }
+
+  try {
+    const renewed = await cfg.onSilentRenew();
+    if (renewed) {
+      // onSilentRenew already calls saveOAuthAccount internally — no
+      // need to re-push the replica here.
+      log.info('Silently renewed OAuth token', { providerId: account.providerId });
+      return;
+    }
+    log.warn('Silent renewal yielded no token; user must re-authenticate', {
+      providerId: account.providerId,
+    });
+  } catch (err) {
+    log.warn('Silent renewal failed', {
+      providerId: account.providerId,
+      error: errorMessage(err),
+    });
+  }
+}
+
+async function bootstrapAccountReplica(account: Account, accessToken: string): Promise<void> {
+  try {
+    await saveOAuthAccount({
+      providerId: account.providerId,
+      accessToken,
+      refreshToken: account.refreshToken,
+      tokenExpiresAt: account.tokenExpiresAt,
+      userName: account.userName,
+      userAvatar: account.userAvatar,
+    });
+    log.debug('Bootstrapped OAuth replica', { providerId: account.providerId });
+  } catch (err) {
+    log.error('OAuth bootstrap failed', {
+      providerId: account.providerId,
+      error: errorMessage(err),
+    });
+  }
+}
+
+async function bootstrapAccount(account: Account): Promise<void> {
+  const accessToken = account.accessToken;
+  if (!accessToken) {
+    log.debug('Skipping account without token', { providerId: account.providerId });
+    return;
+  }
+
+  if (accountNeedsRenewal(account)) {
+    await trySilentRenewal(account);
+    return;
+  }
+
+  await bootstrapAccountReplica(account, accessToken);
+}
+
+export async function bootstrapOAuthReplicas(): Promise<void> {
+  await ensureMcpProvidersForBootstrap();
 
   const accounts = getAccounts();
   log.info('Bootstrap OAuth replicas', { count: accounts.length });
 
-  for (const a of accounts) {
-    // Skip accounts without tokens
-    if (!a.accessToken) {
-      log.debug('Skipping account without token', { providerId: a.providerId });
-      continue;
-    }
-
-    const expiresIn = (a.tokenExpiresAt ?? Infinity) - Date.now();
-    const needsRenewal = expiresIn <= RENEW_BUFFER_MS;
-
-    if (needsRenewal) {
-      const cfg = getRegisteredProviderConfig(a.providerId);
-      if (cfg?.onSilentRenew) {
-        try {
-          const renewed = await cfg.onSilentRenew();
-          if (renewed) {
-            // onSilentRenew already calls saveOAuthAccount internally — no
-            // need to re-push the replica here.
-            log.info('Silently renewed OAuth token', { providerId: a.providerId });
-            continue;
-          }
-          log.warn('Silent renewal yielded no token; user must re-authenticate', {
-            providerId: a.providerId,
-          });
-          continue;
-        } catch (err) {
-          log.warn('Silent renewal failed', {
-            providerId: a.providerId,
-            error: err instanceof Error ? err.message : String(err),
-          });
-          continue;
-        }
-      }
-      log.debug('Skipping expired account (no silent-renew hook)', {
-        providerId: a.providerId,
-      });
-      continue;
-    }
-
-    try {
-      await saveOAuthAccount({
-        providerId: a.providerId,
-        accessToken: a.accessToken,
-        refreshToken: a.refreshToken,
-        tokenExpiresAt: a.tokenExpiresAt,
-        userName: a.userName,
-        userAvatar: a.userAvatar,
-      });
-      log.debug('Bootstrapped OAuth replica', { providerId: a.providerId });
-    } catch (err) {
-      log.error('OAuth bootstrap failed', {
-        providerId: a.providerId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
+  for (const account of accounts) {
+    await bootstrapAccount(account);
   }
 }


### PR DESCRIPTION
## Summary

- Refactored `bootstrapOAuthReplicas` in `packages/webapp/src/ui/oauth-bootstrap.ts` by extracting focused helpers (`ensureMcpProvidersForBootstrap`, `accountNeedsRenewal`, `trySilentRenewal`, `bootstrapAccountReplica`, `bootstrapAccount`) to bring cognitive complexity under the biome cap (≤25).
- Removed `packages/webapp/src/ui/oauth-bootstrap.ts` from the `complexity.noExcessiveCognitiveComplexity: "off"` exemption list in `biome.json`.

## Debt cleared

- `cognitive-complexity`

## Verification

- `npx biome check --write packages/webapp/src/ui/oauth-bootstrap.ts biome.json`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/providers/oauth-sync.test.ts` (16 passed)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK


Made with [Cursor](https://cursor.com)