### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/cdp/remote-cdp-transport.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -30,7 +30,6 @@
   "packages/webapp/src/cdp/navigation-watcher.ts": 11,
   "packages/webapp/src/cdp/panel-rpc-cdp-transport.ts": 5,
   "packages/webapp/src/cdp/preview-bridge-cdp-transport.ts": 3,
-  "packages/webapp/src/cdp/remote-cdp-transport.ts": 7,
   "packages/webapp/src/cdp/synthetic-cdp-transport.ts": 10,
   "packages/webapp/src/cdp/types.ts": 4,
   "packages/webapp/src/core/types.ts": 2,

--- a/packages/webapp/src/cdp/remote-cdp-transport.ts
+++ b/packages/webapp/src/cdp/remote-cdp-transport.ts
@@ -3,7 +3,7 @@
  * to a remote runtime that owns the target browser tab.
  */
 
-import { reassembleCDPResponse } from '@slicc/shared-ts';
+import { type CDPPayload, reassembleCDPResponse } from '@slicc/shared-ts';
 import { PendingRequestTable, waitForEvent } from './pending-request-table.js';
 import type { CDPTransport } from './transport.js';
 import type { CDPEventListener, ConnectionState } from './types.js';
@@ -13,12 +13,7 @@ import type { CDPEventListener, ConnectionState } from './types.js';
  * Implemented by FollowerSyncManager and LeaderSyncManager.
  */
 export interface RemoteCDPSender {
-  sendCDPRequest(
-    requestId: string,
-    method: string,
-    params?: Record<string, unknown>,
-    sessionId?: string
-  ): void;
+  sendCDPRequest(requestId: string, method: string, params?: CDPPayload, sessionId?: string): void;
 }
 
 export class RemoteCDPTransport implements CDPTransport {
@@ -51,10 +46,10 @@ export class RemoteCDPTransport implements CDPTransport {
 
   async send(
     method: string,
-    params?: Record<string, unknown>,
+    params?: CDPPayload,
     sessionId?: string,
     timeout?: number
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CDPPayload> {
     if (this._state === 'disconnected') {
       throw new Error('Transport disconnected');
     }
@@ -82,8 +77,8 @@ export class RemoteCDPTransport implements CDPTransport {
     this.eventListeners.get(event)?.delete(listener);
   }
 
-  once(event: string, timeout?: number): Promise<Record<string, unknown>> {
-    return waitForEvent<Record<string, unknown>>(
+  once(event: string, timeout?: number): Promise<CDPPayload> {
+    return waitForEvent<CDPPayload>(
       (handler) => {
         this.on(event, handler);
         return () => this.off(event, handler);
@@ -96,7 +91,7 @@ export class RemoteCDPTransport implements CDPTransport {
   /** Called by the sync manager when a cdp.response arrives for this transport. */
   handleResponse(
     requestId: string,
-    result?: Record<string, unknown>,
+    result?: CDPPayload,
     error?: string,
     chunkData?: string,
     chunkIndex?: number,
@@ -122,7 +117,7 @@ export class RemoteCDPTransport implements CDPTransport {
   }
 
   /** Called by the sync manager when a CDP event arrives for this transport. */
-  handleEvent(method: string, params: Record<string, unknown>): void {
+  handleEvent(method: string, params: CDPPayload): void {
     const listeners = this.eventListeners.get(method);
     if (listeners) {
       for (const cb of listeners) cb(params);


### PR DESCRIPTION
## Summary

Replace all `Record<string, unknown>` in `remote-cdp-transport.ts` with `CDPPayload` from `@slicc/shared-ts`, matching `CDPTransport` and `pending-request-table.ts`. Ratchet `record-string-unknown-baseline.json` to remove the file entry (7 occurrences cleared).

## Why

Boy-scout debt cleanup: untyped string-keyed bags should use the shared CDP wire payload type at tray-sync boundaries.

## Approach / Implementation notes

- Import `CDPPayload` alongside existing `reassembleCDPResponse` from `@slicc/shared-ts`.
- No behaviour change; type-only refactor on params, results, and event payloads.

## Cross-cutting impact

- **Floats exercised:** N/A — type-only change in webapp CDP transport layer.
- **Other callers:** `RemoteCDPSender` interface signature unchanged semantically (`CDPPayload` is the canonical alias).

## Test plan

- [x] `npx biome check --write packages/webapp/src/cdp/remote-cdp-transport.ts`
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/cdp/remote-cdp-transport.test.ts` — 22 passed
- [x] `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK
- [ ] N/A — explain below

**Pre-existing failures** (verified against `main`, unrelated to this PR):

## Documentation

- [x] No documentation changes needed

## Risk & rollback

- Blast radius: single file type refactor; revert PR cleanly.
- No feature flags, kill switches, or env knobs introduced.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the follower/leader/offscreen paths
