### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/kernel/realm/helpers/node-zlib.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -43,7 +43,6 @@
   "packages/webapp/src/kernel/cdp-worker-proxy.ts": 3,
   "packages/webapp/src/kernel/port-bridge-client.ts": 2,
   "packages/webapp/src/kernel/realm/helpers/node-assert.ts": 5,
-  "packages/webapp/src/kernel/realm/helpers/node-zlib.ts": 3,
   "packages/webapp/src/kernel/realm/http-global.ts": 2,
   "packages/webapp/src/kernel/realm/mount-bomb-fs.ts": 2,
   "packages/webapp/src/kernel/realm/py-realm-shared.ts": 1,

--- a/packages/webapp/src/kernel/realm/helpers/node-zlib.ts
+++ b/packages/webapp/src/kernel/realm/helpers/node-zlib.ts
@@ -8,7 +8,7 @@ interface ZlibOptions {
   memLevel?: number;
   strategy?: number;
 }
-type PakoFn = (data: Uint8Array, opts?: Record<string, unknown>) => Uint8Array;
+type PakoFn = (data: Uint8Array, opts?: ZlibOptions) => Uint8Array;
 type ZlibCallback = (error: Error | null, result?: Buffer) => void;
 
 function zlibToBytes(data: ZlibInput): Uint8Array {
@@ -18,8 +18,8 @@ function zlibToBytes(data: ZlibInput): Uint8Array {
     : new Uint8Array(data);
 }
 
-function zlibPakoOpts(opts?: ZlibOptions): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
+function zlibPakoOpts(opts?: ZlibOptions): ZlibOptions {
+  const out: ZlibOptions = {};
   if (opts) {
     if (typeof opts.level === 'number') out['level'] = opts.level;
     if (typeof opts.windowBits === 'number') out['windowBits'] = opts.windowBits;


### PR DESCRIPTION
## Summary

- Replaced three `Record<string, unknown>` usages in `node-zlib.ts` with the existing `ZlibOptions` interface for Pako function signatures and the `zlibPakoOpts` helper.
- Cleared `packages/webapp/src/kernel/realm/helpers/node-zlib.ts` from `record-string-unknown-baseline.json` (371 grandfathered occurrences remain repo-wide).

## Debt cleared

- `record-string-unknown` — all three `Record<string, unknown>` occurrences in the target file

## Verification

- `npx biome check --write packages/webapp/src/kernel/realm/helpers/node-zlib.ts`
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts -t zlib`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`

Made with [Cursor](https://cursor.com)