### PR TITLE
refactor: pay down boy-scout debt in packages/node-server/src/sudo/electron-backend.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -15,7 +15,6 @@
   "packages/node-server/src/electron-runtime.ts": 1,
   "packages/node-server/src/electron-tray-follower.ts": 16,
   "packages/node-server/src/file-logger.ts": 1,
-  "packages/node-server/src/sudo/electron-backend.ts": 1,
   "packages/shared-ts/src/transcript-export.ts": 18,
   "packages/webapp/providers/adobe.ts": 1,
   "packages/webapp/providers/github-copilot.ts": 2,

--- a/packages/node-server/src/sudo/electron-backend.ts
+++ b/packages/node-server/src/sudo/electron-backend.ts
@@ -19,6 +19,14 @@ interface MessageBoxResult {
   response: number;
 }
 
+/** Options for the transient offscreen `BrowserWindow` used by {@link defaultPromptInput}. */
+interface OffscreenPromptWindowOptions {
+  show: boolean;
+  width: number;
+  height: number;
+  webPreferences: { offscreen: boolean };
+}
+
 /** Injection seams. */
 export interface ElectronBackendDeps {
   /** Raise a modal message box; resolves the clicked button index. */
@@ -96,7 +104,7 @@ async function defaultShowMessageBox(options: {
 async function defaultPromptInput(message: string, defaultValue: string): Promise<string | null> {
   const electron = (await import('electron')) as unknown as {
     BrowserWindow: new (
-      opts: Record<string, unknown>
+      opts: OffscreenPromptWindowOptions
     ) => {
       loadURL(url: string): Promise<void>;
       webContents: { executeJavaScript(code: string): Promise<unknown> };


### PR DESCRIPTION
## Summary

- Replaced `Record<string, unknown>` in `defaultPromptInput`'s lazy Electron import with a named `OffscreenPromptWindowOptions` interface matching the offscreen `BrowserWindow` options actually passed (`show`, `width`, `height`, `webPreferences.offscreen`).
- Ratcheted `record-string-unknown-baseline.json` to remove the entry for this file.

## Debt cleared

- `record-string-unknown` — `packages/node-server/src/sudo/electron-backend.ts`

## Verification

- `npx biome check --write packages/node-server/src/sudo/electron-backend.ts`
- `npm run typecheck`
- `npx vitest run packages/node-server/tests/sudo/electron-backend.test.ts`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`

Made with [Cursor](https://cursor.com)