### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/net/discovery-link.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -48,7 +48,6 @@
   "packages/webapp/src/kernel/realm/skill-global.ts": 7,
   "packages/webapp/src/kernel/realm/ws-router-page.ts": 7,
   "packages/webapp/src/kernel/telemetry.ts": 1,
-  "packages/webapp/src/net/discovery-link.ts": 1,
   "packages/webapp/src/net/handoff-link.ts": 1,
   "packages/webapp/src/net/link-header.ts": 1,
   "packages/webapp/src/providers/adaptive-thinking.ts": 1,

--- a/packages/webapp/src/net/discovery-link.ts
+++ b/packages/webapp/src/net/discovery-link.ts
@@ -29,6 +29,12 @@ import {
 /** The bare ARD relation token that advertises an `ai-catalog.json` manifest. */
 export const AI_CATALOG_REL = 'ai-catalog';
 
+/**
+ * CDP `Network.Response.headers` bag. Header names map to string values;
+ * same-name headers are joined with `\n`.
+ */
+export type CdpResponseHeaders = Record<string, string>;
+
 export interface CatalogMatch {
   /** Always `'ai-catalog'` for a `Link`-header match. */
   kind: DiscoveryKind;
@@ -77,7 +83,7 @@ export function discoveryFingerprint(input: {
 /* ────────── header-shape adapters that go straight to a catalog match ────────── */
 
 export function extractCatalogFromCdpHeaders(
-  headers: Record<string, unknown> | undefined,
+  headers: CdpResponseHeaders | undefined,
   baseUrl?: string
 ): { match: CatalogMatch | null; links: ParsedLink[] } {
   const values = getLinkHeaderValuesFromCdp(headers);


### PR DESCRIPTION
## Summary

Replace `Record<string, unknown>` in `extractCatalogFromCdpHeaders` with a named `CdpResponseHeaders` type for CDP `Network.Response.headers` bags, and ratchet the `record-string-unknown` baseline.

## Why

Boy-scout debt cleanup for `packages/webapp/src/net/discovery-link.ts` (record-string-unknown list). The CDP header bag only carries string values at the call sites we accept, so an open bag was unnecessary.

## Approach / Implementation notes

- Added exported `CdpResponseHeaders = Record<string, string>` documenting the CDP header shape.
- Updated `extractCatalogFromCdpHeaders` parameter type; behavior unchanged (`getLinkHeaderValuesFromCdp` still narrows at runtime).
- Ran `node packages/dev-tools/tools/check-record-string-unknown.mjs --update` to remove the baseline entry.

## Cross-cutting impact

- **Floats exercised**: none (type-only refactor in pure net helper).
- **Other callers**: `extractCatalogFromCdpHeaders` is only referenced from unit tests; extension discovery uses `extractCatalogFromWebRequest`.

## Test plan

- [x] `npx biome check --write packages/webapp/src/net/discovery-link.ts`
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/net/discovery-link.test.ts` — 13 passing
- [ ] `npm run build`
- [ ] `npm run build -w @slicc/chrome-extension`
- [x] **New / changed behavior is covered by a unit test** — existing `discovery-link.test.ts` covers CDP adapter
- [ ] Manual smoke — N/A (no runtime behavior change)
- [x] N/A — no UI change

**Pre-existing failures**: none checked beyond focused tests.

## Documentation

- [ ] `README.md` (user-facing behavior)
- [ ] Relevant `CLAUDE.md` (developer / package architecture)
- [ ] `docs/` (agent reference: tools, commands, skills, patterns)
- [ ] `packages/vfs-root/shared/CLAUDE.md` or `packages/vfs-root/workspace/skills/<skill>/SKILL.md` (agent-facing)
- [x] No documentation changes needed

## Risk & rollback

Type-only refactor; revert cleanly. No persisted state or float parity impact.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths

Made with [Cursor](https://cursor.com)