### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/cdp/types.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -30,7 +30,6 @@
   "packages/webapp/src/cdp/panel-rpc-cdp-transport.ts": 5,
   "packages/webapp/src/cdp/preview-bridge-cdp-transport.ts": 3,
   "packages/webapp/src/cdp/synthetic-cdp-transport.ts": 10,
-  "packages/webapp/src/cdp/types.ts": 4,
   "packages/webapp/src/core/types.ts": 2,
   "packages/webapp/src/fs/mount/backend-local.ts": 1,
   "packages/webapp/src/fs/sidecar-merge.ts": 2,

--- a/packages/webapp/src/cdp/types.ts
+++ b/packages/webapp/src/cdp/types.ts
@@ -2,18 +2,22 @@
  * Chrome DevTools Protocol message types.
  */
 
+import type { CDPPayload } from '@slicc/shared-ts';
+
 /** Outgoing CDP command message. */
 export interface CDPCommand {
   id: number;
   method: string;
-  params?: Record<string, unknown>;
+  /** Per-method CDP params; shape is known only to the caller that issued the method. */
+  params?: CDPPayload;
   sessionId?: string;
 }
 
 /** Incoming CDP response for a command. */
 export interface CDPResponse {
   id: number;
-  result?: Record<string, unknown>;
+  /** Per-method CDP result; shape is known only to the caller that issued the method. */
+  result?: CDPPayload;
   error?: {
     code: number;
     message: string;
@@ -25,7 +29,8 @@ export interface CDPResponse {
 /** Incoming CDP event notification. */
 export interface CDPEvent {
   method: string;
-  params?: Record<string, unknown>;
+  /** Per-method CDP event params; shape depends on `method`. */
+  params?: CDPPayload;
   sessionId?: string;
 }
 
@@ -36,7 +41,7 @@ export type CDPMessage = CDPResponse | CDPEvent;
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected';
 
 /** Listener callback for CDP events. */
-export type CDPEventListener = (params: Record<string, unknown>) => void;
+export type CDPEventListener = (params: CDPPayload) => void;
 
 /** Target info returned by Target.getTargets. */
 export interface TargetInfo {


### PR DESCRIPTION
## Summary

Replace four `Record<string, unknown>` CDP params/result bags in `packages/webapp/src/cdp/types.ts` with the existing shared `CDPPayload` alias (`@slicc/shared-ts`), and ratchet the `record-string-unknown` baseline.

## Why

Boy-scout debt cleanup for `packages/webapp/src/cdp/types.ts` (`record-string-unknown` list). CDP method params/results are already named as `CDPPayload` elsewhere in the CDP layer (`transport.ts`, `remote-cdp-transport.ts`); this aligns the message types with that boundary type so the open bag lives once at the shared definition (with its documented ignore), not inline in every field.

## Approach / Implementation notes

- Import `CDPPayload` from `@slicc/shared-ts` into `cdp/types.ts`.
- Use it for `CDPCommand.params`, `CDPResponse.result`, `CDPEvent.params`, and `CDPEventListener`.
- Ran `node packages/dev-tools/tools/check-record-string-unknown.mjs --update` to remove this file from the baseline.

## Cross-cutting impact

- **Floats exercised:** N/A — type-only refactor; no runtime behavior change.
- **Other callers:** Existing consumers already accept `CDPPayload` / structural equivalents; typecheck clean.

## Test plan

- [x] `npx biome check --write packages/webapp/src/cdp/types.ts`
- [x] `npm run typecheck`
- [x] `npx vitest run` focused CDP tests — 64 passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK
- [x] No documentation changes needed

## Risk & rollback

Type-only refactor; revert cleanly.

Made with [Cursor](https://cursor.com)