### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/providers/oauth-code-exchange.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -55,7 +55,6 @@
   "packages/webapp/src/providers/built-in/bedrock-camp.ts": 31,
   "packages/webapp/src/providers/built-in/local-llm.ts": 2,
   "packages/webapp/src/providers/intercepted-oauth.ts": 4,
-  "packages/webapp/src/providers/oauth-code-exchange.ts": 2,
   "packages/webapp/src/scoops/onboarding-orchestrator.ts": 1,
   "packages/webapp/src/scoops/tray-follower.ts": 5,
   "packages/webapp/src/scoops/tray-leader/cdp-router.ts": 5,

--- a/packages/webapp/src/providers/oauth-code-exchange.ts
+++ b/packages/webapp/src/providers/oauth-code-exchange.ts
@@ -33,29 +33,53 @@ export interface TokenResponse {
   expires_in?: number;
 }
 
+/**
+ * JSON body from the worker `/oauth/token` broker — success fields and/or
+ * RFC 6749 error fields (GitHub also returns errors with HTTP 200).
+ */
+interface OAuthTokenEndpointBody {
+  access_token?: string;
+  token_type?: string;
+  scope?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  error?: string;
+  error_description?: string;
+}
+
+function toTokenResponse(body: OAuthTokenEndpointBody): TokenResponse {
+  // Callers historically received the parsed body via cast; keep the same
+  // field set (including a missing access_token) after the error checks above.
+  return {
+    access_token: body.access_token as string,
+    token_type: body.token_type,
+    scope: body.scope,
+    refresh_token: body.refresh_token,
+    expires_in: body.expires_in,
+  };
+}
+
 async function parseTokenResponse(res: Response): Promise<TokenResponse> {
-  let body: Record<string, unknown>;
+  let body: OAuthTokenEndpointBody;
   try {
-    body = (await res.json()) as Record<string, unknown>;
+    body = (await res.json()) as OAuthTokenEndpointBody;
   } catch {
     throw new Error(`Token exchange failed (HTTP ${res.status}): non-JSON response`);
   }
 
   if (!res.ok && res.status !== 200) {
     const msg =
-      (body.error_description as string) ??
-      (body.error as string) ??
-      `Token exchange failed (HTTP ${res.status})`;
+      body.error_description ?? body.error ?? `Token exchange failed (HTTP ${res.status})`;
     throw new Error(msg);
   }
 
   // GitHub returns 200 even for errors — check for error field
   if (body.error) {
-    const msg = (body.error_description as string) ?? (body.error as string);
+    const msg = body.error_description ?? body.error;
     throw new Error(msg);
   }
 
-  return body as unknown as TokenResponse;
+  return toTokenResponse(body);
 }
 
 /**

--- a/packages/webapp/tests/providers/oauth-code-exchange.test.ts
+++ b/packages/webapp/tests/providers/oauth-code-exchange.test.ts
@@ -106,6 +106,24 @@ describe('exchangeOAuthCode', () => {
     ).rejects.toThrow('Not configured');
   });
 
+  it('falls back to error code when error_description is absent', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 200 })
+    );
+
+    await expect(
+      exchangeOAuthCode({ provider: 'github', code: 'c', redirectUri: 'r' })
+    ).rejects.toThrow('invalid_grant');
+  });
+
+  it('throws a generic message when an HTTP error body has no error fields', async () => {
+    mockFetch.mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 503 }));
+
+    await expect(
+      exchangeOAuthCode({ provider: 'github', code: 'c', redirectUri: 'r' })
+    ).rejects.toThrow('Token exchange failed (HTTP 503)');
+  });
+
   it('throws with useful message on non-JSON response', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response('<html>Bad Gateway</html>', {


### PR DESCRIPTION
## Summary
- Replace `Record<string, unknown>` in `parseTokenResponse` with a named `OAuthTokenEndpointBody` for the worker `/oauth/token` success/error JSON shape
- Map the success path through `toTokenResponse` (no `as unknown as`) and ratchet `record-string-unknown-baseline.json` for this file only
- Extend focused tests for error-message fallbacks (`error` without `error_description`, HTTP error with empty body)

Clears debt list: **record-string-unknown**

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npx vitest run packages/webapp/tests/providers/oauth-code-exchange.test.ts`
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`


Made with [Cursor](https://cursor.com)