### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/transcript/strict-secret-client.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -79,7 +79,6 @@
   "packages/webapp/src/tools/file-tools.ts": 3,
   "packages/webapp/src/transcript/normalize.ts": 2,
   "packages/webapp/src/transcript/redact.ts": 4,
-  "packages/webapp/src/transcript/strict-secret-client.ts": 2,
   "packages/webapp/src/ui/boot/setup-onboarding-orchestrator.ts": 1,
   "packages/webapp/src/ui/boot/setup-welcome-flow.ts": 13,
   "packages/webapp/src/ui/dip.ts": 4,

--- a/packages/webapp/src/transcript/strict-secret-client.ts
+++ b/packages/webapp/src/transcript/strict-secret-client.ts
@@ -17,6 +17,10 @@ import type { KnownSecretBatchRedactor } from './redact.js';
 
 type RedactExportResponse = { texts: string[]; redactionCount: number };
 
+function responseHasError(resp: object): boolean {
+  return 'error' in resp;
+}
+
 function fail(): never {
   throw new TranscriptExportError('redaction-unavailable');
 }
@@ -78,11 +82,7 @@ function extensionMessageRedactor(): KnownSecretBatchRedactor {
       } catch {
         fail();
       }
-      if (
-        typeof resp === 'object' &&
-        resp !== null &&
-        'error' in (resp as Record<string, unknown>)
-      ) {
+      if (typeof resp === 'object' && resp !== null && responseHasError(resp)) {
         fail();
       }
       return validateResponse(resp, texts.length);
@@ -100,7 +100,7 @@ function extensionBridgeRedactor(): KnownSecretBatchRedactor {
         fail();
       }
       if (resp === undefined || resp === null) fail();
-      if (typeof resp === 'object' && 'error' in (resp as Record<string, unknown>)) {
+      if (typeof resp === 'object' && resp !== null && responseHasError(resp)) {
         fail();
       }
       return validateResponse(resp, texts.length);


### PR DESCRIPTION
## Summary

Replace two `Record<string, unknown>` casts in `strict-secret-client.ts` with a `responseHasError()` helper; ratchet the record-string-unknown baseline.

## Why

Boy-scout debt cleanup: the file was grandfathered on the `record-string-unknown` list. Named narrowing replaces open bags without changing fail-closed redaction behavior.

## Approach / Implementation notes

- Added `responseHasError(resp: object)` using `'error' in resp` after narrowing to non-null object.
- Removed the file from `record-string-unknown-baseline.json` via `check-record-string-unknown.mjs --update`.

## Cross-cutting impact

- **Floats exercised:** CLI (node-rest), Chrome extension (extension-direct / extension-delegate), connect (rejecting redactor) — behavior unchanged; existing tests cover all branches.
- **Security:** Fail-closed semantics preserved; error responses still throw `TranscriptExportError('redaction-unavailable')`.

## Test plan

- [x] `npx biome check --write packages/webapp/src/transcript/strict-secret-client.ts`
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/transcript/strict-secret-client.test.ts` — 19 passing
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK

## Documentation

- [x] No documentation changes needed

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff