### PR TITLE
fix(webcomponents): log and degrade never-restored WebGL context

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -1623,11 +1623,17 @@ as an init failure and reflect the CSS fallback, rather than parking on dead han
 behind a transparent canvas — a frozen field that claims to be working is worse than
 a visible gradient.
 
-Note the two recovery paths are distinct and both are needed: `webglcontextrestored`
-handles a UA-driven loss on a _live_ canvas (same context object, relink in place),
-while the fresh-canvas swap handles re-init after a teardown-driven loss.
+Note the recovery paths are distinct and all are needed:
+
+- `webglcontextrestored` handles a UA-driven loss on a _live_ canvas (same
+  context object, relink in place).
+- A fresh-canvas swap handles re-init after a teardown-driven loss.
+- A one-shot restore watchdog (`CONTEXT_RESTORE_TIMEOUT_MS`) degrades to the
+  CSS gradient if the UA never dispatches `webglcontextrestored` — permitted
+  by the spec, and otherwise leaves a blank field with no signal beyond the
+  loss-time `console.warn`.
 
 **Related Files**
 
-- `packages/webcomponents/src/freezer/slicc-shader.ts` — `#initGl` / `#replaceCanvas` / `#dispose`
-- `packages/webcomponents/tests/freezer/slicc-shader.test.ts` — remount regression test
+- `packages/webcomponents/src/freezer/slicc-shader.ts` — `#initGl` / `#replaceCanvas` / `#dispose` / restore watchdog
+- `packages/webcomponents/tests/freezer/slicc-shader.test.ts` — remount + never-restored regression tests

--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -19,7 +19,9 @@ import { advanceFrameTs, BURST_MS, shouldRender } from './frame-budget.js';
  * strictly one frame per wake). Pauses on disconnect — releasing the GL context
  * — and re-acquires a fresh one (on a fresh canvas) when it is mounted again, so
  * a field that comes back after a tab switch resumes instead of staying frozen.
- * Falls back to a per-mode CSS gradient when WebGL is absent.
+ * Falls back to a per-mode CSS gradient when WebGL is absent, when a restored
+ * context cannot rebuild, or when a lost context is never restored (UA may
+ * omit `webglcontextrestored`).
  *
  * @attr mode - `cone` (default) | `scoop` | `freezer`
  * @attr tint - CSS color washed into the scoop field / event glow (the active accent)
@@ -300,6 +302,14 @@ const MAX_DPR_CAP = 2;
 
 /** Fraction of the chat scroll the field pans by (1 = attached, 0 = static). */
 const SCROLL_PARALLAX = 0.35;
+
+/**
+ * How long to wait for `webglcontextrestored` after a UA-driven loss before
+ * degrading to the CSS gradient. Spec permits never restoring; without a
+ * watchdog the field stays blank indefinitely. One-shot only — not a frame
+ * scheduler (those stay on rAF; see docs/webcomponents-details.md).
+ */
+export const CONTEXT_RESTORE_TIMEOUT_MS = 3_000;
 const UNIFORMS = [
   'u_res',
   'u_scroll',
@@ -379,6 +389,8 @@ export class SliccShader extends HTMLElement {
   #lastFrameTs = Number.NEGATIVE_INFINITY;
   #burstUntil = 0;
   #contextLost = false;
+  /** One-shot watchdog after context loss; 0 when idle. */
+  #restoreTimeout = 0;
   #ro: ResizeObserver | null = null;
   #reduced = false;
   // Cached CSS-derived uniforms. Resolved on connect / `tint` change / theme
@@ -434,6 +446,7 @@ export class SliccShader extends HTMLElement {
     this.#start = performance.now() / 1000;
     this.#lastFrameTs = Number.NEGATIVE_INFINITY;
     this.#contextLost = false;
+    this.#clearRestoreTimeout();
     this.#wake();
   }
 
@@ -803,7 +816,9 @@ export class SliccShader extends HTMLElement {
   /**
    * On context loss the cached programs/shaders/buffer are invalid GPU handles,
    * so drop the whole cache; on restore the same context is reusable, so relink
-   * (rebuilding the cache lazily) and resume the loop.
+   * (rebuilding the cache lazily) and resume the loop. If the UA never restores
+   * (permitted), a one-shot watchdog degrades to the CSS gradient so the field
+   * does not stay blank indefinitely.
    */
   #installContextHandlers(cv: HTMLCanvasElement): void {
     this.#removeContextHandlers(cv);
@@ -816,8 +831,13 @@ export class SliccShader extends HTMLElement {
       this.#builtMode = null;
       this.#loc = {};
       this.#buffer = null;
+      // Single diagnostic so a never-restored blank field is attributable
+      // (issue #2233). The restore watchdog below is the permanent degrade.
+      console.warn('[slicc-shader] WebGL context lost; waiting for restore');
+      this.#armRestoreWatchdog();
     };
     this.#onContextRestored = () => {
+      this.#clearRestoreTimeout();
       if (!this.isConnected || !this.#gl) return;
       this.#programs = {};
       if (!this.#setupGlResources()) {
@@ -825,10 +845,7 @@ export class SliccShader extends HTMLElement {
         // buffers) must degrade to the CSS gradient exactly like the initial
         // #initGl failure path — never leave the field parked and blank with
         // #contextLost stuck true and no signal.
-        this.#contextLost = false;
-        console.error('[slicc-shader] GL restore failed; falling back to CSS gradient');
-        this.setAttribute('no-webgl', '');
-        this.#dispose();
+        this.#degradeToCssFallback('GL restore failed; falling back to CSS gradient');
         return;
       }
       this.#contextLost = false;
@@ -846,6 +863,35 @@ export class SliccShader extends HTMLElement {
       cv.removeEventListener('webglcontextrestored', this.#onContextRestored);
     this.#onContextLost = null;
     this.#onContextRestored = null;
+  }
+
+  /** Park a one-shot timer that degrades if restore never arrives. */
+  #armRestoreWatchdog(): void {
+    this.#clearRestoreTimeout();
+    this.#restoreTimeout = window.setTimeout(() => {
+      this.#restoreTimeout = 0;
+      if (!this.isConnected || !this.#contextLost) return;
+      this.#degradeToCssFallback('WebGL context not restored; falling back to CSS gradient');
+    }, CONTEXT_RESTORE_TIMEOUT_MS);
+  }
+
+  #clearRestoreTimeout(): void {
+    if (this.#restoreTimeout) {
+      clearTimeout(this.#restoreTimeout);
+      this.#restoreTimeout = 0;
+    }
+  }
+
+  /**
+   * Permanent degrade: reflect `no-webgl`, dispose GL, leave the CSS gradient.
+   * Shared by failed-restore and never-restored watchdog paths.
+   */
+  #degradeToCssFallback(reason: string): void {
+    this.#clearRestoreTimeout();
+    this.#contextLost = false;
+    console.error(`[slicc-shader] ${reason}`);
+    this.setAttribute('no-webgl', '');
+    this.#dispose();
   }
 
   #resize(): void {
@@ -968,6 +1014,7 @@ export class SliccShader extends HTMLElement {
   }
 
   #dispose(): void {
+    this.#clearRestoreTimeout();
     const gl = this.#gl;
     const cv = this.#canvas;
     if (cv) this.#removeContextHandlers(cv);

--- a/packages/webcomponents/src/freezer/slicc-shader.ts
+++ b/packages/webcomponents/src/freezer/slicc-shader.ts
@@ -885,12 +885,23 @@ export class SliccShader extends HTMLElement {
   /**
    * Permanent degrade: reflect `no-webgl`, dispose GL, leave the CSS gradient.
    * Shared by failed-restore and never-restored watchdog paths.
+   *
+   * Swap out the canvas *before* disposing so a late UA `webglcontextrestored`
+   * (after we remove listeners and null `#gl`) cannot leave a live GPU context
+   * on a DOM-retained, CSS-hidden canvas this component can neither use nor
+   * release. Detaching the poisoned element cancels that pending restore.
    */
   #degradeToCssFallback(reason: string): void {
     this.#clearRestoreTimeout();
     this.#contextLost = false;
     console.error(`[slicc-shader] ${reason}`);
     this.setAttribute('no-webgl', '');
+    const poisoned = this.#canvas;
+    if (poisoned) {
+      // #replaceCanvas removes handlers and installs a fresh element; we never
+      // acquire GL on the placeholder — #dispose below only frees #gl.
+      this.#replaceCanvas(poisoned);
+    }
     this.#dispose();
   }
 

--- a/packages/webcomponents/tests/freezer/slicc-shader.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-shader.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  CONTEXT_RESTORE_TIMEOUT_MS,
   SHADER_FRAGMENTS,
   SliccShader,
   SUGAR_GLASS_PRESETS,
@@ -429,6 +430,7 @@ describe('slicc-shader', () => {
       const gl = canvas.getContext('webgl') as WebGLRenderingContext;
       const lose = gl.getExtension('WEBGL_lose_context');
       if (!lose) return; // extension unavailable: nothing to exercise
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
       lose.loseContext();
       await wait(100); // let the webglcontextlost event land
       const spy = spyDraws();
@@ -603,6 +605,7 @@ describe('slicc-shader', () => {
       const gl = canvas.getContext('webgl') as WebGLRenderingContext;
       const lose = gl.getExtension('WEBGL_lose_context');
       if (!lose) return;
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
       lose.loseContext();
       await wait(100); // let webglcontextlost land
       const spy = spyDraws();
@@ -619,6 +622,7 @@ describe('slicc-shader', () => {
       const gl = canvas.getContext('webgl') as WebGLRenderingContext;
       const lose = gl.getExtension('WEBGL_lose_context');
       if (!lose) return;
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
       lose.loseContext();
       await wait(100);
       const spy = spyDraws();
@@ -636,6 +640,7 @@ describe('slicc-shader', () => {
       const gl = canvas.getContext('webgl') as WebGLRenderingContext;
       const lose = gl.getExtension('WEBGL_lose_context');
       if (!lose) return;
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
       lose.loseContext();
       await wait(100);
       // Force #setupGlResources() to fail on restore (Fix e001cb5b4 degrade path).
@@ -649,6 +654,47 @@ describe('slicc-shader', () => {
       );
       expect(spy.mock.calls.length).toBe(0);
       expect(errSpy).toHaveBeenCalled(); // emitted a diagnostic, not silent
+    });
+
+    it('warns on context loss so a blank field is attributable', async () => {
+      const el = mount({ mode: 'scoop' });
+      if (el.noWebgl) return;
+      await wait(100);
+      const canvas = el.shadowRoot?.querySelector('canvas') as HTMLCanvasElement;
+      const gl = canvas.getContext('webgl') as WebGLRenderingContext;
+      const lose = gl.getExtension('WEBGL_lose_context');
+      if (!lose) return;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      lose.loseContext();
+      await wait(100);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('WebGL context lost'));
+      // Restore promptly so the never-restored watchdog does not fire in this test.
+      await restoreThen(lose, canvas, async () => {});
+    });
+
+    it('degrades to the CSS fallback when a lost context is never restored', {
+      // Watchdog + quiet settle; keep above CONTEXT_RESTORE_TIMEOUT_MS.
+      timeout: CONTEXT_RESTORE_TIMEOUT_MS + 5_000,
+    }, async () => {
+      const el = mount({ mode: 'scoop' });
+      if (el.noWebgl) return;
+      await wait(100);
+      const canvas = el.shadowRoot?.querySelector('canvas') as HTMLCanvasElement;
+      const gl = canvas.getContext('webgl') as WebGLRenderingContext;
+      const lose = gl.getExtension('WEBGL_lose_context');
+      if (!lose) return;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      // preventDefault was already called by the handler; do not restore.
+      lose.loseContext();
+      await wait(100);
+      expect(warnSpy).toHaveBeenCalled();
+      expect(el.noWebgl).toBe(false); // still waiting
+      await vi.waitFor(() => expect(el.noWebgl).toBe(true), {
+        timeout: CONTEXT_RESTORE_TIMEOUT_MS + 2_000,
+        interval: 50,
+      });
+      expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('not restored'));
     });
 
     it('reduced motion renders one frame per wake and stops', async () => {

--- a/packages/webcomponents/tests/freezer/slicc-shader.test.ts
+++ b/packages/webcomponents/tests/freezer/slicc-shader.test.ts
@@ -695,6 +695,12 @@ describe('slicc-shader', () => {
         interval: 50,
       });
       expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('not restored'));
+      // Poisoned canvas was swapped out so a late UA restore cannot leave a live
+      // GPU context on a CSS-hidden element (#gl already nulled).
+      const after = el.shadowRoot?.querySelector('canvas') as HTMLCanvasElement;
+      expect(after).not.toBe(canvas);
+      expect(after.isConnected).toBe(true);
+      expect(canvas.isConnected).toBe(false);
     });
 
     it('reduced motion renders one frame per wake and stops', async () => {


### PR DESCRIPTION
Fixes #2233

## Summary

When `<slicc-shader>` loses its WebGL context and the UA never dispatches `webglcontextrestored`, the field stayed blank indefinitely with no diagnostic. This emits a `console.warn` at loss time and, after a 3s restore watchdog, degrades to the existing CSS gradient (same path as failed-restore).

## Why

Split out from PR #2214 round-2 review. Spec permits never restoring; without a signal the blank decorative background was unattributable. Failed-restore already had diagnostic + CSS degrade; this covers the never-restored path.

## Approach / Implementation notes

- Loss handler: `console.warn` + arm `CONTEXT_RESTORE_TIMEOUT_MS` (3s) one-shot watchdog
- Watchdog / failed-restore share `#degradeToCssFallback` (`no-webgl` + dispose)
- Watchdog cleared on restore, dispose, and reconnect — not a frame scheduler (those stay on rAF)

## Cross-cutting impact

- **Floats**: any float hosting `slicc-shader` (CLI / extension / Electron / hosted leader) — decorative background only
- No shell / OAuth / persistence changes

## Test plan

- [x] `npm run verify` — 7/7
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK
- [x] `npm run typecheck -w @slicc/webcomponents`
- [x] `npm test -w @slicc/webcomponents -- tests/freezer/slicc-shader.test.ts` — 55/55
- [x] `npm run test:coverage:webcomponents` — floors met
- [x] New tests: warn-on-loss; never-restored → `no-webgl` + error diagnostic
- [x] N/A UI screencast — diagnostic/fallback path, no visual redesign

## Documentation

- [x] `docs/pitfalls.md` — never-restored watchdog noted with the other WebGL recovery paths

## Risk & rollback

- Blast radius: decorative background only; worst case earlier CSS fallback after GPU loss
- Rollback: revert this PR

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited `dist/`
- [x] No secrets in the diff
