### PR TITLE
ci(worker): sign staging APNs pushes with a staging-only key (#2452)

### DIFF
--- a/.github/workflows/worker-staging.yml
+++ b/.github/workflows/worker-staging.yml
@@ -8,6 +8,18 @@ on:
       - 'packages/cloud-core/**'
       - 'packages/webapp/src/providers/**'
       - 'packages/webapp/providers/**'
+      # This workflow is the ONLY place staging's APNs secrets are uploaded
+      # (ci.yml's staging deploy pushes just TURN/GitHub/E2B). Without this
+      # path a change to the secret wiring below never takes effect until some
+      # unrelated worker PR happens to trigger a run — so staging would keep
+      # signing with whatever key was last uploaded.
+      - '.github/workflows/worker-staging.yml'
+  # Deliberately no `workflow_dispatch`: every deploy step here is gated on
+  # `github.event.pull_request.head.repo` (fork guard) and the deployment
+  # record reads `context.payload.pull_request.head.sha`, so a manual run
+  # would skip the deploy and report success having uploaded nothing. Rotating
+  # a secret therefore goes through a PR that touches this file — which the
+  # path above now guarantees runs.
 
 # Serialize across ALL PRs: this job mutates two shared singletons — the
 # `slicc-staging` e2b template alias (build overwrites it) and the

--- a/.github/workflows/worker-staging.yml
+++ b/.github/workflows/worker-staging.yml
@@ -168,9 +168,15 @@ jobs:
         env:
           CLOUDFLARE_TURN_API_TOKEN: ${{ secrets.CLOUDFLARE_TURN_API_TOKEN }}
           GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET_STAGING }}
+          # APNs: staging signs with its OWN key (#2452). Apple throttles
+          # provider-token creation per (team id, key id) — not per worker or
+          # environment — so sharing production's key would let the two
+          # singleton minters (#2448) collide inside Apple's 20-minute floor and
+          # silently drop a push. TEAM_ID and TOPIC stay shared: same Apple team,
+          # same bundle id. Key: "SLICC APNs Staging" (96Y3MN5LY9).
           APNS_TEAM_ID: ${{ secrets.APNS_TEAM_ID }}
-          APNS_KEY_ID: ${{ secrets.APNS_KEY_ID }}
-          APNS_PRIVATE_KEY: ${{ secrets.APNS_PRIVATE_KEY }}
+          APNS_KEY_ID: ${{ secrets.APNS_KEY_ID_STAGING }}
+          APNS_PRIVATE_KEY: ${{ secrets.APNS_PRIVATE_KEY_STAGING }}
           APNS_TOPIC: ${{ secrets.APNS_TOPIC }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
 
@@ -212,9 +218,15 @@ jobs:
         env:
           CLOUDFLARE_TURN_API_TOKEN: ${{ secrets.CLOUDFLARE_TURN_API_TOKEN }}
           GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_GITHUB_SECRET_STAGING }}
+          # APNs: staging signs with its OWN key (#2452). Apple throttles
+          # provider-token creation per (team id, key id) — not per worker or
+          # environment — so sharing production's key would let the two
+          # singleton minters (#2448) collide inside Apple's 20-minute floor and
+          # silently drop a push. TEAM_ID and TOPIC stay shared: same Apple team,
+          # same bundle id. Key: "SLICC APNs Staging" (96Y3MN5LY9).
           APNS_TEAM_ID: ${{ secrets.APNS_TEAM_ID }}
-          APNS_KEY_ID: ${{ secrets.APNS_KEY_ID }}
-          APNS_PRIVATE_KEY: ${{ secrets.APNS_PRIVATE_KEY }}
+          APNS_KEY_ID: ${{ secrets.APNS_KEY_ID_STAGING }}
+          APNS_PRIVATE_KEY: ${{ secrets.APNS_PRIVATE_KEY_STAGING }}
           APNS_TOPIC: ${{ secrets.APNS_TOPIC }}
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
 


### PR DESCRIPTION
Closes #2452.

Staging and production both read the repository-level `APNS_KEY_ID` / `APNS_PRIVATE_KEY`, so the two workers signed with the same Apple key.

Apple throttles provider-token creation per `(team id, key id)` — not per worker, per connection, or per environment. After #2448 each worker has its own singleton minter, so two uncoordinated minters shared one key pair and could land two mints inside Apple's 20-minute floor. The loser gets `429 TooManyProviderTokenUpdates` and the push is silently dropped.

This mirrors how `GITHUB_CLIENT_SECRET` already takes `OAUTH_GITHUB_SECRET_STAGING` in this same file — the separation pattern existed, it just had not been applied to Apple's key.

## What changed

Staging now signs with its own key. `APNS_TEAM_ID` and `APNS_TOPIC` stay shared: same Apple team, same bundle id. Only the signing key differs.

## Ops actions already completed

- **New key registered**: "SLICC APNs Staging", Key ID `96Y3MN5LY9`, on team `S8LB56P782`.
- **Config**: Sandbox & Production, Team Scoped (All Topics) — deliberately mirroring production key `AZS5W4GRMD`. A sandbox-only staging key would be tighter, but it would break the two-tray gateway probe that runs on staging and has to register the same token against both environments. The APNs configuration is immutable once saved, so this was not a reversible choice.
- **Secrets set**: `APNS_KEY_ID_STAGING` and `APNS_PRIVATE_KEY_STAGING` are present on the repository. The blocking precondition in the commit message is therefore satisfied — this is safe to merge.

Apple's two-key cap is per *service*, not per account: the team's other key (`75YM6KK373`, Media Services/MusicKit) does not consume an APNs slot, so no existing key had to be revoked.

## Verification

- YAML parses; both deploy-attempt blocks updated (the file retries staging deploys, so the secret list appears twice — missing one would leave a retry signing with production's key).
- Touched-file debt gate: clean.
- Not run locally: full lint/typecheck/test — this worktree has no `node_modules` and the change touches no source. CI covers it.

## Residual risk

Production and staging remain on the same `APNS_TEAM_ID` and `APNS_TOPIC`, which is correct — they are the same app. Nothing else shares the signing key now.

Refs #2448, #2062.
