### PR TITLE
refactor: pay down boy-scout debt in packages/webcomponents/src/primitives/slicc-image-preview.stories.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -340,8 +340,7 @@
         "packages/webapp/tests/fs/internal-mount.test.ts",
         "packages/webapp/tests/kernel/realm/realm-runner.test.ts",
         "packages/webapp/tests/shell/di/di.test.ts",
-        "packages/webapp/tests/ui/provider-settings.test.ts",
-        "packages/webcomponents/src/primitives/slicc-image-preview.stories.ts"
+        "packages/webapp/tests/ui/provider-settings.test.ts"
       ],
       "linter": {
         "rules": {

--- a/packages/webcomponents/src/primitives/slicc-image-preview.stories.ts
+++ b/packages/webcomponents/src/primitives/slicc-image-preview.stories.ts
@@ -113,9 +113,13 @@ export const StaticHelper: Story = {
 
     btn.addEventListener('click', () => {
       // Lazily import the class only here to mirror the runtime helper path.
-      import('./slicc-image-preview.js').then(({ SliccImagePreview }) => {
-        SliccImagePreview.show(SAMPLE_SRC, btn);
-      });
+      import('./slicc-image-preview.js')
+        .then(({ SliccImagePreview }) => {
+          SliccImagePreview.show(SAMPLE_SRC, btn);
+        })
+        .catch((err: unknown) => {
+          console.error('Failed to load SliccImagePreview for StaticHelper story', err);
+        });
     });
 
     return wrap;


### PR DESCRIPTION
## Summary
- Handle the `StaticHelper` story’s lazy `import(...).then(...)` with an explicit `.catch()` so the dynamic-load rejection is not dropped.
- Remove `packages/webcomponents/src/primitives/slicc-image-preview.stories.ts` from the `nursery.noFloatingPromises: "off"` biome override (`floating-promise` debt list).

## Test plan
- [x] `npx biome check` on touched files
- [x] `npm run typecheck`
- [x] `npm run test -w @slicc/webcomponents -- tests/primitives/slicc-image-preview.test.ts` (14 passed)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK