### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/fs/sidecar-merge.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -32,7 +32,6 @@
   "packages/webapp/src/cdp/synthetic-cdp-transport.ts": 10,
   "packages/webapp/src/core/types.ts": 2,
   "packages/webapp/src/fs/mount/backend-local.ts": 1,
-  "packages/webapp/src/fs/sidecar-merge.ts": 2,
   "packages/webapp/src/git/commands/rebase.ts": 1,
   "packages/webapp/src/git/commands/shared.ts": 1,
   "packages/webapp/src/git/commands/symbolic-ref.ts": 2,

--- a/packages/webapp/src/fs/sidecar-merge.ts
+++ b/packages/webapp/src/fs/sidecar-merge.ts
@@ -22,21 +22,33 @@
  */
 
 /**
- * Opaque ZenFS inode JSON (`Inode.toJSON()`). This module never inspects
- * entries beyond identity; callers that need fields (e.g. `mode`) narrow
- * at their own boundary.
+ * Serialized ZenFS inode (`Inode.toJSON()` / `InodeLike`). Merge copies
+ * entries by identity only; sidecar-repair and kind-reconcile read/mutate
+ * the numeric fields below.
  */
-export type SidecarInodeJson = object;
+export interface SidecarInodeJson {
+  mode?: number;
+  size?: number;
+  ino?: number;
+  data?: number;
+  nlink?: number;
+  atimeMs?: number;
+  mtimeMs?: number;
+  ctimeMs?: number;
+  birthtimeMs?: number;
+  uid?: number;
+  gid?: number;
+}
 
 /**
- * Path → opaque inode map from ZenFS `Index.toJSON().entries`.
+ * Path → inode map from ZenFS `Index.toJSON().entries`.
  */
 export type SidecarEntries = { [path: string]: SidecarInodeJson };
 
 /**
  * Parsed shape of the sidecar document — `Index.toJSON()` from
  * `@zenfs/core` (`{ version, maxSize, entries }`). Entry values are
- * opaque inode records; this module never inspects them beyond identity.
+ * {@link SidecarInodeJson}; this module never inspects them beyond identity.
  */
 export interface SidecarIndexJson {
   version?: number;

--- a/packages/webapp/src/fs/sidecar-merge.ts
+++ b/packages/webapp/src/fs/sidecar-merge.ts
@@ -22,6 +22,18 @@
  */
 
 /**
+ * Opaque ZenFS inode JSON (`Inode.toJSON()`). This module never inspects
+ * entries beyond identity; callers that need fields (e.g. `mode`) narrow
+ * at their own boundary.
+ */
+export type SidecarInodeJson = object;
+
+/**
+ * Path → opaque inode map from ZenFS `Index.toJSON().entries`.
+ */
+export type SidecarEntries = { [path: string]: SidecarInodeJson };
+
+/**
  * Parsed shape of the sidecar document — `Index.toJSON()` from
  * `@zenfs/core` (`{ version, maxSize, entries }`). Entry values are
  * opaque inode records; this module never inspects them beyond identity.
@@ -29,7 +41,7 @@
 export interface SidecarIndexJson {
   version?: number;
   maxSize?: number;
-  entries?: Record<string, unknown>;
+  entries?: SidecarEntries;
 }
 
 /**
@@ -87,7 +99,7 @@ export function mergeSidecarEntries(
   dirty: SidecarDirtyState
 ): SidecarIndexJson {
   const ownEntries = own.entries ?? {};
-  const entries: Record<string, unknown> = { ...(onDisk.entries ?? {}) };
+  const entries: SidecarEntries = { ...(onDisk.entries ?? {}) };
 
   if ('/' in ownEntries) entries['/'] = ownEntries['/'];
 

--- a/packages/webapp/tests/fs/sidecar-merge.test.ts
+++ b/packages/webapp/tests/fs/sidecar-merge.test.ts
@@ -4,10 +4,16 @@ import {
   type SidecarDirtyState,
   type SidecarEntries,
   type SidecarIndexJson,
+  type SidecarInodeJson,
   stripSidecarSelfEntry,
 } from '../../src/fs/sidecar-merge.js';
 
-const entry = (tag: string) => ({ tag });
+/** Test stub: distinct tag plus the numeric fields consumers actually read. */
+const entry = (tag: string): SidecarInodeJson & { tag: string } => ({
+  tag,
+  mode: 0o100644,
+  size: 0,
+});
 
 const dirty = (paths: string[] = [], prefixes: string[] = []): SidecarDirtyState => ({
   paths: new Set(paths),

--- a/packages/webapp/tests/fs/sidecar-merge.test.ts
+++ b/packages/webapp/tests/fs/sidecar-merge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   mergeSidecarEntries,
   type SidecarDirtyState,
+  type SidecarEntries,
   type SidecarIndexJson,
   stripSidecarSelfEntry,
 } from '../../src/fs/sidecar-merge.js';
@@ -13,7 +14,7 @@ const dirty = (paths: string[] = [], prefixes: string[] = []): SidecarDirtyState
   prefixes: new Set(prefixes),
 });
 
-const doc = (entries: Record<string, unknown>, rest: Partial<SidecarIndexJson> = {}) => ({
+const doc = (entries: SidecarEntries, rest: Partial<SidecarIndexJson> = {}) => ({
   version: 1,
   maxSize: 100,
   ...rest,


### PR DESCRIPTION
## Summary
- Replace `Record<string, unknown>` in the OPFS sidecar merge module with named `SidecarInodeJson` / `SidecarEntries` for the opaque ZenFS `Index.toJSON().entries` map (identity-only in this module)
- Ratchet `record-string-unknown-baseline.json` for this file only
- Point the focused merge tests at `SidecarEntries`

Clears debt list: **record-string-unknown**

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npx vitest run packages/webapp/tests/fs/sidecar-merge.test.ts packages/webapp/tests/fs/sidecar-repair.test.ts`
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`