### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/tests/fs/internal-mount.test.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -336,7 +336,6 @@
         "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts",
         "packages/webapp/tests/cdp/cdp-client.test.ts",
         "packages/webapp/tests/cdp/preview-bridge-cdp-transport.test.ts",
-        "packages/webapp/tests/fs/internal-mount.test.ts",
         "packages/webapp/tests/kernel/realm/realm-runner.test.ts",
         "packages/webapp/tests/shell/di/di.test.ts",
         "packages/webapp/tests/ui/provider-settings.test.ts"

--- a/packages/webapp/tests/fs/internal-mount.test.ts
+++ b/packages/webapp/tests/fs/internal-mount.test.ts
@@ -24,8 +24,10 @@ describe('mountInternal', () => {
     indexedDB.deleteDatabase('test-internal-mount');
     vfs = await VirtualFS.create({ dbName: 'test-internal-mount', wipe: true });
   });
-  afterEach(() => {
-    vfs.dispose?.();
+  afterEach(async () => {
+    // Awaited so the IDB handle is closed before the next test's `wipe: true`
+    // create — a floating dispose races the delete and flakes the suite.
+    await vfs.dispose?.();
   });
 
   it('listMounts() excludes internal mounts', async () => {


### PR DESCRIPTION
## Summary
- Await `vfs.dispose?.()` in `afterEach` so the floating-promise lint rule can apply to this test file
- Remove `packages/webapp/tests/fs/internal-mount.test.ts` from the `nursery.noFloatingPromises: "off"` biome override

## Debt cleared
- floating-promise

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npx vitest run packages/webapp/tests/fs/internal-mount.test.ts` (8 passed)
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK