### PR TITLE
feat(worker): add successor-version Link header to tray supersede responses

### DIFF
--- a/docs/cloudflare-worker-details.md
+++ b/docs/cloudflare-worker-details.md
@@ -21,7 +21,7 @@ Every route below must also appear in `src/index.ts`, `tests/index.test.ts`, and
 | `GET /llms.txt`                       | LLM markdown digest                                                                                                                        |
 | `GET\|HEAD /privacy`                  | 301 to www.sliccy.com/privacy (App Store Connect link)                                                                                     |
 | `GET\|HEAD /status`                   | Public health document (`{ status, service, timestamp, version }`); no auth, `Cache-Control: no-store`                                     |
-| `GET /rel/:name`                      | Dereferenceable docs for SLICC custom rel URIs                                                                                             |
+| `GET /rel/:name`                      | Dereferenceable docs for SLICC rel URIs (`handoff`, `upskill`, `successor-version`)                                                        |
 | `GET\|POST /join/:token`              | Follower join and bootstrap polling (HTTP poll/answer/ice-candidate/retry actions)                                                         |
 | `GET\|POST /controller/:token`        | Leader attach and WS upgrade                                                                                                               |
 | `POST /webhook/:token/:webhookId`     | Forward webhook events into the live leader                                                                                                |
@@ -65,6 +65,16 @@ start/resume flows:
   [`deploying-tray-worker` skill](../.agents/skills/deploying-tray-worker/SKILL.md).
 - Followers attach via the join capability; bootstrap over HTTP poll
   (poll/answer/ice-candidate/retry actions).
+- **Superseded tray** (`POST /api/tray/:trayId/supersede`, leader-only): once a tray is
+  marked superseded, both `/join/:token` shapes answer `409` +
+  `code: "TRAY_SUPERSEDED"` with the replacement's `joinUrl` in the body, plus an
+  RFC 8288 `Link: <joinUrl>; rel="successor-version"` header (RFC 5829) carrying the
+  same redirect in machine-readable form (issue #1957, step 1 — additive; the status
+  and body are unchanged for shipped followers). The header target is normalized
+  through `URL` so a stored join URL can't inject a header delimiter, and
+  `Access-Control-Expose-Headers: Link` is set on the capability CORS surface so a
+  cross-origin follower can read it. Step 2 (flip to `308` + `Location`) is gated on
+  a client capability opt-in.
 - Preview bridge tabs (`serve --bridge`) attach via `/__slicc/bridge` WS. DO relays
   `bridge.cdp.request`/`bridge.cdp.response` between leader and each bridge socket,
   keyed by `connId`. On leader (re)connect the DO replays `bridge.connected` for every

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -474,6 +474,10 @@ export function capabilityCorsHeaders(request: Request, env: WorkerEnv): Record<
     headers['Access-Control-Allow-Origin'] = origin;
     headers['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS';
     headers['Access-Control-Allow-Headers'] = 'content-type';
+    // Without this a cross-origin follower can't read the RFC 8288 `Link`
+    // header at all — including the `successor-version` link a superseded
+    // tray answers with (#1957).
+    headers['Access-Control-Expose-Headers'] = 'Link';
   }
   return headers;
 }

--- a/packages/cloudflare-worker/src/links.ts
+++ b/packages/cloudflare-worker/src/links.ts
@@ -44,3 +44,37 @@ export function applySliccLinks(response: Response, request: Request): Response 
     headers,
   });
 }
+
+/**
+ * RFC 8288 `Link` header value pointing at the tray that replaced a
+ * superseded one, using the `successor-version` relation registered by
+ * RFC 5829 §3.4 ("points to a resource containing the successor version in
+ * the version history").
+ *
+ * Emitted alongside the existing 409 + JSON body on supersede responses
+ * (issue #1957) so a follower can read one header instead of pattern-matching
+ * a `fail` code out of the body. Purely additive — clients that don't know the
+ * rel ignore it.
+ *
+ * The target is normalized through `URL` before it is embedded so a stored
+ * join URL can never smuggle a header delimiter (`>`, CR/LF) into the field
+ * value. Returns `null` when the stored value doesn't parse as a URL, in which
+ * case the caller emits no header at all.
+ */
+export function successorVersionLink(joinUrl: string): string | null {
+  try {
+    return `<${new URL(joinUrl).href}>; rel="successor-version"`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Headers to merge into a tray-supersede response: the `successor-version`
+ * link, or nothing when the replacement URL is unusable. Status and body are
+ * the caller's business and stay untouched.
+ */
+export function supersededLinkHeaders(joinUrl: string): Record<string, string> {
+  const link = successorVersionLink(joinUrl);
+  return link ? { Link: link } : {};
+}

--- a/packages/cloudflare-worker/src/rel-docs.ts
+++ b/packages/cloudflare-worker/src/rel-docs.ts
@@ -26,6 +26,12 @@ const RELS: Record<string, RelInfo> = {
       'Used by SLICC to install a skill from a public GitHub repository. The link target is the GitHub repo URL.',
     example: `Link: &lt;https://github.com/slicc/skills-extra&gt;; rel="${SLICC_HOSTED_ORIGIN}/rel/upskill"`,
   },
+  'successor-version': {
+    title: 'rel: successor-version',
+    summary:
+      'Emitted by the tray hub when a tray has been superseded — the leader reconnected, minted a fresh tray, and abandoned this one. The link target is the replacement tray\'s join URL: followers should re-attach there instead of retrying this tray. Unlike <code>handoff</code> and <code>upskill</code>, this is not a SLICC extension rel — <code>successor-version</code> is registered by RFC 5829 §3.4 and appears as the bare token; this page documents how SLICC uses it. The response also keeps its existing <code>409</code> status and JSON body (<code>code: "TRAY_SUPERSEDED"</code>, <code>joinUrl</code>) for clients that predate the header.',
+    example: `Link: &lt;${SLICC_HOSTED_ORIGIN}/join/fresh-tray.deadbeef&gt;; rel="successor-version"`,
+  },
 };
 
 function pageHtml(name: string, info: RelInfo): string {
@@ -57,7 +63,7 @@ function pageHtml(name: string, info: RelInfo): string {
     <p>${info.summary}</p>
     <p>Example header value:</p>
     <pre>${info.example}</pre>
-    <p>Spec context: <a href="https://www.rfc-editor.org/rfc/rfc8288">RFC 8288</a> (Web Linking) and <a href="https://www.rfc-editor.org/rfc/rfc8187">RFC 8187</a> (parameter ext-value).</p>
+    <p>Spec context: <a href="https://www.rfc-editor.org/rfc/rfc8288">RFC 8288</a> (Web Linking), <a href="https://www.rfc-editor.org/rfc/rfc8187">RFC 8187</a> (parameter ext-value), and <a href="https://www.rfc-editor.org/rfc/rfc5829">RFC 5829</a> (version-history relations).</p>
     <p>SLICC overview: <a href="https://github.com/ai-ecoverse/slicc/blob/main/docs/slicc-handoff.md">docs/slicc-handoff.md</a>.</p>
   </main>
 </body>

--- a/packages/cloudflare-worker/src/session-tray.ts
+++ b/packages/cloudflare-worker/src/session-tray.ts
@@ -31,6 +31,7 @@ import {
   handleProviderTokenRequest,
   SharedProviderTokenSource,
 } from './apns-provider-token.js';
+import { supersededLinkHeaders } from './links.js';
 import { deletePreviewArchivePrefix } from './persistent-preview-storage.js';
 import { previewTokenFromHost } from './preview-host.js';
 import {
@@ -630,11 +631,18 @@ export class SessionTrayDurableObject {
     if (tray.supersededByJoinUrl) {
       const joinUrl = tray.supersededByJoinUrl;
       const error = 'This session moved to a new tray after the leader reconnected';
+      // Step 1 of #1957: the status and body stay exactly as shipped clients
+      // parse them; the RFC 5829 `successor-version` link is the additive
+      // machine-readable form of the same redirect. Clients that don't know
+      // the rel ignore the header.
+      const linkHeaders = supersededLinkHeaders(joinUrl);
       if (joinRequest) {
         return await this.buildFollowerAttachResponse(
           this.getJoinRequestControllerId(joinRequest),
           { action: 'fail', code: 'TRAY_SUPERSEDED', error, joinUrl },
-          409
+          409,
+          undefined,
+          linkHeaders
         );
       }
       return jsonResponse(
@@ -645,7 +653,8 @@ export class SessionTrayDurableObject {
           code: 'TRAY_SUPERSEDED',
           joinUrl,
         },
-        409
+        409,
+        linkHeaders
       );
     }
 
@@ -1803,7 +1812,8 @@ export class SessionTrayDurableObject {
     controllerId: string,
     result: FollowerAttachResult,
     status = 200,
-    iceServers?: TurnIceServer[]
+    iceServers?: TurnIceServer[],
+    headers?: HeadersInit
   ): Promise<Response> {
     const tray = this.requireTray();
     const payload: FollowerAttachResponse = {
@@ -1817,7 +1827,7 @@ export class SessionTrayDurableObject {
     if (iceServers) {
       payload.iceServers = iceServers;
     }
-    return jsonResponse(payload, status);
+    return jsonResponse(payload, status, headers);
   }
 
   private async ensureTrayIsActive(): Promise<Response | null> {

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -1462,9 +1462,9 @@ describe('tray worker skeleton', () => {
     expect(body).toContain('/rel/handoff');
   });
 
-  it('serves dereferenceable rel docs at /rel/handoff and /rel/upskill', async () => {
+  it('serves dereferenceable rel docs at /rel/handoff, /rel/upskill and /rel/successor-version', async () => {
     const { env } = createTestHarness();
-    for (const name of ['handoff', 'upskill']) {
+    for (const name of ['handoff', 'upskill', 'successor-version']) {
       const response = await handleWorkerRequest(
         new Request(`https://www.sliccy.ai/rel/${name}`),
         env
@@ -1941,6 +1941,7 @@ describe('POST /api/tray/:trayId/supersede', () => {
     );
 
     expect(followerAttach.status).toBe(409);
+    expect(followerAttach.headers.get('Link')).toBe(`<${freshJoinUrl}>; rel="successor-version"`);
     await expect(followerAttach.json()).resolves.toMatchObject({
       trayId,
       controllerId: 'follow-1',
@@ -1975,12 +1976,77 @@ describe('POST /api/tray/:trayId/supersede', () => {
     const probe = await handleWorkerRequest(new Request(probeUrl), env);
 
     expect(probe.status).toBe(409);
+    expect(probe.headers.get('Link')).toBe(`<${freshJoinUrl}>; rel="successor-version"`);
     await expect(probe.json()).resolves.toMatchObject({
       trayId,
       capability: 'join',
       code: 'TRAY_SUPERSEDED',
       joinUrl: freshJoinUrl,
     });
+  });
+
+  it('normalizes the successor-version target so a join URL cannot inject a header', async () => {
+    const { env } = createTestHarness();
+    const { trayId, controllerToken, joinUrl } = await setupTrayWithLeader(env);
+    // `>` would close the RFC 8288 URI-Reference early if it were emitted raw.
+    const hostileJoinUrl = 'https://www.sliccy.ai/join/fresh>evil.deadbeef';
+
+    await handleWorkerRequest(
+      new Request(`https://www.sliccy.ai/api/tray/${trayId}/supersede`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${controllerToken}`,
+        },
+        body: JSON.stringify({ joinUrl: hostileJoinUrl }),
+      }),
+      env
+    );
+
+    const followerAttach = await handleWorkerRequest(
+      new Request(joinUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ controllerId: 'follow-1', runtime: 'electron' }),
+      }),
+      env
+    );
+
+    expect(followerAttach.status).toBe(409);
+    expect(followerAttach.headers.get('Link')).toBe(
+      '<https://www.sliccy.ai/join/fresh%3Eevil.deadbeef>; rel="successor-version"'
+    );
+    // The body keeps the value verbatim — only the header target is normalized.
+    await expect(followerAttach.json()).resolves.toMatchObject({
+      result: { code: 'TRAY_SUPERSEDED', joinUrl: hostileJoinUrl },
+    });
+  });
+
+  it('keeps the successor-version link alongside the standard rel set through worker.fetch', async () => {
+    const { env } = createTestHarness();
+    const { trayId, controllerToken, joinUrl } = await setupTrayWithLeader(env);
+    const freshJoinUrl = 'https://www.sliccy.ai/join/fresh-tray.deadbeef';
+
+    await handleWorkerRequest(
+      new Request(`https://www.sliccy.ai/api/tray/${trayId}/supersede`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${controllerToken}`,
+        },
+        body: JSON.stringify({ joinUrl: freshJoinUrl }),
+      }),
+      env
+    );
+
+    const probeUrl = new URL(joinUrl);
+    probeUrl.searchParams.set('json', 'true');
+    const probe = await worker.fetch(new Request(probeUrl), env);
+
+    expect(probe.status).toBe(409);
+    const link = probe.headers.get('Link') ?? '';
+    expect(link).toContain(`<${freshJoinUrl}>; rel="successor-version"`);
+    expect(link).toContain('rel="api-catalog"');
   });
 });
 
@@ -2009,6 +2075,17 @@ describe('standard Link header set', () => {
     expect(applySliccLinks(redirect, req).headers.get('Link')).toBeNull();
     const ok = new Response('hi', { status: 200 });
     expect(applySliccLinks(ok, req).headers.get('Link')).toContain('rel="api-catalog"');
+  });
+
+  it('successorVersionLink emits no header for a target that is not a URL', async () => {
+    const { successorVersionLink, supersededLinkHeaders } = await import('../src/links.js');
+    expect(successorVersionLink('https://www.sliccy.ai/join/t.secret')).toBe(
+      '<https://www.sliccy.ai/join/t.secret>; rel="successor-version"'
+    );
+    // A tray persisted before the absolute-URL guard (or by a future writer)
+    // must degrade to "no header", never to a malformed one.
+    expect(successorVersionLink('not-a-url')).toBeNull();
+    expect(supersededLinkHeaders('not-a-url')).toEqual({});
   });
 });
 
@@ -3259,6 +3336,9 @@ describe('capability-route CORS', () => {
     expect(allowed['Access-Control-Allow-Origin']).toBe(ALLOWED_ORIGIN);
     expect(allowed['Access-Control-Allow-Headers']).toBe('content-type');
     expect(allowed['Access-Control-Allow-Methods']).toContain('OPTIONS');
+    // A cross-origin follower must be able to read the `successor-version`
+    // link a superseded tray answers with (#1957).
+    expect(allowed['Access-Control-Expose-Headers']).toBe('Link');
     expect(allowed.Vary).toBe('Origin');
 
     const blocked = capabilityCorsHeaders(
@@ -3266,6 +3346,7 @@ describe('capability-route CORS', () => {
       env
     );
     expect(blocked['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(blocked['Access-Control-Expose-Headers']).toBeUndefined();
     expect(blocked.Vary).toBe('Origin');
   });
 


### PR DESCRIPTION
Part of #1957 (step 1 of 2 — this does not close it).

## Summary

A superseded tray (leader reconnected, minted a fresh tray, abandoned this one) now also answers with an RFC 8288 `Link` header pointing at the replacement:

```
Link: <https://www.sliccy.ai/join/fresh-tray.deadbeef>; rel="successor-version"
```

Purely additive. The status stays `409`, the JSON body is byte-identical, and no client code changes here — shipped followers that pattern-match `result.code === 'TRAY_SUPERSEDED'` keep working unchanged.

## Why

409 says the opposite of what happened: nothing is retryable and there is no conflict to resolve, the resource moved and the body says where. Burying the redirect inside `action: "fail"` is what caused #1956 — four independent implementations (browser `tray-webrtc.ts`, Go `conn.go`, iOS `SupersedeRedirect.swift`, native `SessionReachability.swift`) each re-derive "this `fail` is actually a `follow`", and the one that got it wrong stayed wrong until something finally exercised it.

`successor-version` is registered by RFC 5829 §3.4 and means exactly this. New clients can read one header instead of pattern-matching a failure code; old clients ignore it. Flipping the status to `308` + `Location` is step 2 in #1957 and needs a client capability gate, so it is deliberately not here.

## Approach / Implementation notes

- **`src/links.ts`** — `successorVersionLink()` / `supersededLinkHeaders()`. The target is normalized through `URL` before it is embedded, so a stored join URL can never smuggle a header delimiter (`>`, CR/LF) into the field value; `new URL(…).href` percent-encodes `>` and strips CR/LF. An unparseable value yields *no* header rather than a malformed one. The body keeps the stored value verbatim — only the header target is normalized, so nothing about the existing contract shifts.
- **`src/session-tray.ts`** — both supersede sites (POST attach and the GET status probe) stamp the header. `buildFollowerAttachResponse` gained an optional trailing `headers` argument; every other caller is untouched.
- **`src/index.ts`** — `Access-Control-Expose-Headers: Link` on the capability CORS surface. Without it a cross-origin follower cannot read `Link` at all, so step 1 would be invisible to exactly the clients it targets. Allowlisted origins only, alongside the existing `Allow-*` triple; non-allowlisted origins still get only `Vary: Origin`.
- **`src/rel-docs.ts`** — `/rel/successor-version` documents SLICC's use, and is explicit that unlike `handoff`/`upskill` this is the registered bare token, not a SLICC extension URI (the header does not dereference to this page). RFC 5829 added to the spec-context line on all three rel pages.

## Cross-cutting impact

- **Floats exercised**: worker only. No client-side change in this PR — browser, Go CLI, iOS, and the native probe all keep their current control flow and keep reading `result.code`.
- **Other callers of the changed contract**: `buildFollowerAttachResponse` has 4 other call sites; all pass no `headers` and are byte-identical in output. `capabilityCorsHeaders` feeds `/tray`, `/join`, `/controller` — the added header is response-only and does not widen who may call these routes.
- **Security**: the join URL carries the session secret, so this moves it from the body into a response header. Response headers are not in default Cloudflare access logs, but if any hop in front of the worker records them this is a wider exposure than the body alone. Worth settling before step 2, where `Location` is the header proxies and CDNs are *most* likely to log. Flagging rather than deciding — the issue raises the same point.
- **Persisted state**: none. `TrayRecord.supersededByJoinUrl` is unchanged in shape and value.

## Test plan

- [x] `npm run lint` — clean (includes `prettier --check`)
- [x] `npm run typecheck` — all 9 projects, 0 errors
- [x] `npm run verify` — 7/7 checks
- [x] `npm run test` — 17,242 passing, 0 assertion failures
- [x] `npm run build` — exit 0
- [x] `npm run test:coverage:cloudflare-worker` — floors met; `links.ts` 94% stmts / 100% lines
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK (6 changed files, 0 on any debt list)
- [x] **New behavior covered** in `packages/cloudflare-worker/tests/index.test.ts`: the two pinned supersede tests now assert the exact header; new tests for (a) a hostile `>` in the join URL normalizing in the header while the body keeps it verbatim, (b) the link surviving alongside the standard rel set through `worker.fetch`, (c) `successorVersionLink` returning `null` for a non-URL target, (d) `/rel/successor-version` serving, (e) `Access-Control-Expose-Headers` present for allowlisted and absent for non-allowlisted origins.
- [ ] Manual smoke — not run. Exercising it live needs a leader reconnect against a deployed worker; the header is asserted end-to-end through `worker.fetch` in tests instead.

**Pre-existing failures** (unrelated to this PR): `packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts` is flagged failed by an unhandled rejection from a real Chrome launch on the dev machine ("Chrome exited with code null before reporting CDP port") — 0 assertion failures in that file.

## Documentation

- [x] `docs/` — `docs/cloudflare-worker-details.md`: supersede bullet in the Signaling section (header, normalization, CORS exposure, step-2 gate) and the `/rel/:name` route row now names all three rels.
- [ ] No other tier applies — no user-facing behavior change, no new package convention.

## Risk & rollback

Blast radius is one response header on one DO branch plus one CORS header on the capability routes. No flag or kill switch; revert is clean and touches nothing persisted. Nothing here needs hand-verification against a real browser — the one thing CI cannot answer is whether a hop in front of the worker logs `Link`, which is the security note above and a step-2 decision.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API changes are intentional and reflected in docs
- [x] Contract used by other floats: checked — this PR deliberately changes nothing shipped followers parse, so leader/follower paths need no coordinated update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
