### PR TITLE
fix(upskill): report skills skipped for missing provenance in the update sweep

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -690,7 +690,9 @@ Every path is classified with the vocabulary `upgrade apply` uses for bundled wo
 | `removed`    | Upstream dropped a file **this command installed** (tracked in `.upskill`). |
 | `kept-local` | A dotfile, or a file upskill never installed — left untouched.              |
 
-`--dry-run` reports the classification and writes nothing. `--json` emits `{ ok, dryRun, results[] }` for scripted callers.
+**The no-argument sweep names what it could not check.** An installed skill with no `.upskill` record cannot be updated, so the sweep lists it under `Skipped <n> skills with no install provenance` and scopes its closing line to the skills it actually checked (`All 13 skills with provenance are current.`). This is informational, not a failure: it stays off stderr and the exit code stays 0, because runtime-bundled skills legitimately have no record (`upgrade apply` keeps those current) and the rest only need a source recorded once with `upskill update <skill> --from <owner>/<repo>`. With nothing skipped, the closing line is the unqualified `All skills are current.`
+
+`--dry-run` reports the classification and writes nothing. `--json` emits `{ ok, dryRun, results[], skipped[] }` for scripted callers — `skipped` is the name-sorted list of unattributed skills and does not affect `ok`.
 
 ### What upskill never touches
 

--- a/packages/vfs-root/workspace/skills/upgrade/SKILL.md
+++ b/packages/vfs-root/workspace/skills/upgrade/SKILL.md
@@ -95,6 +95,7 @@ Notes worth knowing:
 - **Dotfiles are never touched.** `upskill` will not modify or delete a dotfile in a skill directory, so credentials (`scripts/.config`) and the `.upskill` record survive updates and `--force` reinstalls. Never hand-copy a credential file "to be safe" — it is already safe, and moving it can break the skill.
 - **`kept-local` is not a failure.** It marks dotfiles and files the user added themselves; leaving them is the correct outcome.
 - A skill installed before provenance tracking reports `no install provenance`. If the user knows where it came from, record it in place — `upskill update <skill> --from <owner>/<repo> --dry-run` first, then without `--dry-run`. That first update never deletes anything, because nothing is attributable to a previous install yet.
+- **The sweep tells you what it did not check.** Skills with no `.upskill` record are listed under `Skipped <n> skills with no install provenance` and the closing line is scoped to the ones it checked (`All 13 skills with provenance are current.`). That is not a failure and the exit code stays 0: the runtime-bundled skills legitimately have no record and `upgrade apply` keeps those current. Pass the rest on to the user — one `--from` per skill is all it takes for the sweep to cover them from then on. Do not read an unqualified `All skills are current.` into a run that printed a skipped list.
 
 ## Do not
 

--- a/packages/webapp/src/shell/supplemental-commands/upskill/provenance.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill/provenance.ts
@@ -86,23 +86,41 @@ export async function writeProvenance(
   }
 }
 
-/** Every installed skill that carries a provenance record, name-sorted. */
-export async function listProvenancedSkills(
-  fs: VirtualFS
-): Promise<Array<{ name: string; provenance: UpskillProvenance }>> {
+export interface SkillProvenanceScan {
+  /** Installed skills carrying a provenance record, name-sorted. */
+  provenanced: Array<{ name: string; provenance: UpskillProvenance }>;
+  /**
+   * Installed skills with no readable record, name-sorted. Runtime-bundled
+   * skills legitimately land here; so does anything hand-installed. Reported
+   * rather than dropped, so a no-argument `upskill update` cannot claim to have
+   * checked a skill it never looked at.
+   */
+  unattributed: string[];
+}
+
+/** Partition the installed skills by whether they carry a provenance record. */
+export async function scanSkillProvenance(fs: VirtualFS): Promise<SkillProvenanceScan> {
   let entries: Array<{ name: string; type: 'file' | 'directory' }>;
   try {
     entries = (await fs.readDir(SKILLS_DIR)) as Array<{ name: string; type: 'file' | 'directory' }>;
   } catch {
-    return [];
+    return { provenanced: [], unattributed: [] };
   }
-  const found: Array<{ name: string; provenance: UpskillProvenance }> = [];
+  const scan: SkillProvenanceScan = { provenanced: [], unattributed: [] };
   for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
     if (entry.type !== 'directory') continue;
     const provenance = await readProvenance(fs, entry.name);
-    if (provenance) found.push({ name: entry.name, provenance });
+    if (provenance) scan.provenanced.push({ name: entry.name, provenance });
+    else scan.unattributed.push(entry.name);
   }
-  return found;
+  return scan;
+}
+
+/** Every installed skill that carries a provenance record, name-sorted. */
+export async function listProvenancedSkills(
+  fs: VirtualFS
+): Promise<Array<{ name: string; provenance: UpskillProvenance }>> {
+  return (await scanSkillProvenance(fs)).provenanced;
 }
 
 /**

--- a/packages/webapp/src/shell/supplemental-commands/upskill/update.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill/update.ts
@@ -21,9 +21,9 @@ import { fetchGitHubDirFiles, fetchRepoZip, stripZipPrefix } from './github/gith
 import { runPostInstallHooks } from './install-pipeline.js';
 import type { UpskillProvenance } from './provenance.js';
 import {
-  listProvenancedSkills,
   readProvenance,
   resolveCommitSha,
+  scanSkillProvenance,
   writeProvenance,
 } from './provenance.js';
 import { prepareBrowseShSkill, stripBrowseShPreamble } from './registries/browse-sh.js';
@@ -491,6 +491,12 @@ function provenanceFromFlag(
  *
  * `missing` distinguishes its two causes so the error can point at the actual
  * problem — a typo'd name is not the same as an installed-but-unrecorded skill.
+ *
+ * `skipped` is the no-argument sweep's own category, deliberately separate from
+ * `missing`: a skill nobody asked for by name and that carries no record is not
+ * a failed request, so it must not reach stderr or the exit code. It is still
+ * reported, because the alternative — dropping it silently — is what let the
+ * sweep close with "All skills are current" over an unchecked majority.
  */
 async function resolveTargets(
   fs: VirtualFS,
@@ -499,9 +505,11 @@ async function resolveTargets(
 ): Promise<{
   targets: Array<{ name: string; provenance: UpskillProvenance }>;
   missing: Array<{ name: string; reason: 'not-installed' | 'no-provenance' }>;
+  skipped: string[];
 }> {
   if (names.length === 0) {
-    return { targets: await listProvenancedSkills(fs), missing: [] };
+    const scan = await scanSkillProvenance(fs);
+    return { targets: scan.provenanced, missing: [], skipped: scan.unattributed };
   }
   const targets: Array<{ name: string; provenance: UpskillProvenance }> = [];
   const missing: Array<{ name: string; reason: 'not-installed' | 'no-provenance' }> = [];
@@ -523,7 +531,7 @@ async function resolveTargets(
     if (supplied) targets.push({ name, provenance: supplied });
     else missing.push({ name, reason: 'no-provenance' });
   }
-  return { targets, missing };
+  return { targets, missing, skipped: [] };
 }
 
 /** The stderr line for a skill that could not be resolved to a source. */
@@ -536,23 +544,56 @@ function missingMessage(entry: { name: string; reason: string }): string {
 `;
 }
 
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+/**
+ * The informational block for skills the sweep could not attribute. Not an
+ * error: the bundled half legitimately has no record, and the rest only needs a
+ * source recorded once. Names are name-sorted by the scan, so the block diffs.
+ *
+ * The bundled skills are described in prose rather than classified, because
+ * there is no offline manifest of them — `upgrade` discovers them from the
+ * release tree over the network, which a dry run must not have to do.
+ */
+function formatSkipped(skipped: string[]): string {
+  return (
+    `\nSkipped ${plural(skipped.length, 'skill')} with no install provenance — not checked:\n` +
+    `  ${skipped.join(', ')}\n` +
+    '  Runtime-bundled skills have no record by design; `upgrade apply` keeps those current.\n' +
+    '  For the rest, record a source once with `upskill update <skill> --from <owner>/<repo> --dry-run`,\n' +
+    '  after which a bare `upskill update` sweeps them too.\n'
+  );
+}
+
 /**
  * `clean` gates the closing line: with a failed or unresolvable skill in the
  * batch, "all skills are current" would contradict the errors on stderr and
  * the non-zero exit.
+ *
+ * `skipped` scopes it. An unattributable skill is not a failure, so it leaves
+ * `clean` alone — but an unqualified "all skills are current" over a batch that
+ * never contained it is a false all-clear, so the count says what was checked.
  */
 function formatReport(
   results: SkillUpdateResult[],
   dryRun: boolean,
   applied: boolean,
-  clean: boolean
+  clean: boolean,
+  skipped: string[]
 ): string {
   let stdout = dryRun ? 'Skill update (dry run — nothing written):\n' : 'Skill update:\n';
   for (const result of results) stdout += formatResult(result, dryRun);
-  if (!applied && clean) {
+  if (skipped.length > 0) stdout += formatSkipped(skipped);
+  if (!applied && clean && results.length > 0) {
+    const scope =
+      skipped.length > 0
+        ? `all ${plural(results.length, 'skill')} with provenance ${results.length === 1 ? 'is' : 'are'}`
+        : 'all skills are';
     stdout += dryRun
-      ? '\nAll skills are current.\n'
-      : '\nNothing to update — all skills are current.\n';
+      ? `\n${scope.charAt(0).toUpperCase()}${scope.slice(1)} current.\n`
+      : `\nNothing to update — ${scope} current.\n`;
   }
   return stdout;
 }
@@ -570,9 +611,21 @@ export async function handleUpskillUpdate(
     return { stdout: '', stderr: `${parsed.error}\n`, exitCode: 1 };
   }
 
-  const { targets, missing } = await resolveTargets(fs, parsed.skills, parsed);
+  const { targets, missing, skipped } = await resolveTargets(fs, parsed.skills, parsed);
 
   if (targets.length === 0) {
+    // A sweep that found skills but could attribute none of them has nothing to
+    // check and nothing to blame: report what it skipped and exit 0, the same
+    // way it would with one attributable skill alongside them.
+    if (missing.length === 0 && skipped.length > 0) {
+      return {
+        stdout: parsed.json
+          ? `${JSON.stringify({ ok: true, dryRun: parsed.dryRun, results: [], skipped })}\n`
+          : formatReport([], parsed.dryRun, false, true, skipped),
+        stderr: '',
+        exitCode: 0,
+      };
+    }
     const stderr = missing.length
       ? missing.map(missingMessage).join('')
       : 'upskill: no skill has install provenance yet — reinstall a skill, or run `upskill update <skill> --from <owner>/<repo>`, to record its source\n';
@@ -605,17 +658,19 @@ export async function handleUpskillUpdate(
     missing.map(missingMessage).join('') +
     failures.map((r) => `upskill: ${r.skill}: ${r.error}\n`).join('');
 
+  // `skipped` stays out of `clean` on purpose: it drives no stderr line and no
+  // exit code, so an agent volunteering `--dry-run` still sees a 0.
   const clean = failures.length === 0 && missing.length === 0;
   if (parsed.json) {
     return {
-      stdout: `${JSON.stringify({ ok: clean, dryRun: parsed.dryRun, results })}\n`,
+      stdout: `${JSON.stringify({ ok: clean, dryRun: parsed.dryRun, results, skipped })}\n`,
       stderr,
       exitCode: clean ? 0 : 1,
     };
   }
 
   return {
-    stdout: formatReport(results, parsed.dryRun, applied, clean),
+    stdout: formatReport(results, parsed.dryRun, applied, clean, skipped),
     stderr,
     exitCode: clean ? 0 : 1,
   };

--- a/packages/webapp/tests/shell/supplemental-commands/upskill/update.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/upskill/update.test.ts
@@ -359,6 +359,62 @@ describe('upskill update', () => {
     expect(provenance?.files).not.toContain('scripts/gone.sh');
   });
 
+  it('reports the skills a bare sweep skipped, and still exits 0', async () => {
+    await installAlpha(fs, V1);
+    // Two unattributed skills — a runtime-bundled one and a hand-installed one.
+    for (const name of ['zeta', 'bundled']) {
+      await fs.mkdir(`/workspace/skills/${name}`, { recursive: true });
+      await fs.writeFile(`/workspace/skills/${name}/SKILL.md`, `# ${name}\n`);
+    }
+
+    const cmd = createUpskillCommand(fs, repoFetch(V1) as unknown as SecureFetch);
+    const result = await cmd.execute(['update', '--dry-run'], createMockCtx() as never);
+
+    // Not a failure: nothing on stderr, exit 0.
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('alpha: already current');
+    expect(result.stdout).toContain('Skipped 2 skills with no install provenance');
+    // Name-sorted and deterministic.
+    expect(result.stdout).toContain('bundled, zeta');
+    expect(result.stdout).toContain('upgrade apply');
+    expect(result.stdout).toContain('--from <owner>/<repo>');
+    // The closing line no longer claims more than it checked.
+    expect(result.stdout).toContain('All 1 skill with provenance is current.');
+    expect(result.stdout).not.toContain('All skills are current');
+  });
+
+  it('says nothing was checked when no installed skill has provenance', async () => {
+    await fs.mkdir('/workspace/skills/legacy', { recursive: true });
+    await fs.writeFile('/workspace/skills/legacy/SKILL.md', '# Legacy\n');
+
+    const fetchMock = repoFetch(V1);
+    const cmd = createUpskillCommand(fs, fetchMock as unknown as SecureFetch);
+    const result = await cmd.execute(['update', '--dry-run'], createMockCtx() as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('Skipped 1 skill with no install provenance');
+    expect(result.stdout).toContain('legacy');
+    // Nothing was checked, so there is no all-clear of any scope.
+    expect(result.stdout).not.toMatch(/skills are current|with provenance is current/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('adds no skipped noise when every installed skill has provenance', async () => {
+    await installAlpha(fs, V1);
+
+    const cmd = createUpskillCommand(fs, repoFetch(V1) as unknown as SecureFetch);
+    const result = await cmd.execute(['update', '--dry-run'], createMockCtx() as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(
+      'Skill update (dry run — nothing written):\n' +
+        `  alpha: already current (github:octo/skills)\n` +
+        '\nAll skills are current.\n'
+    );
+  });
+
   it('--json emits the classification for scripted callers', async () => {
     await installAlpha(fs, V1);
 
@@ -384,6 +440,30 @@ describe('upskill update', () => {
     expect(parsed.results[0].changes).toContainEqual({ path: 'SKILL.md', status: 'updated' });
     // An existing dotfile is reported, never rewritten.
     expect(parsed.results[0].changes).toContainEqual({ path: '.gitignore', status: 'kept-local' });
+  });
+
+  it('--json keeps its existing keys and adds the skipped names', async () => {
+    await installAlpha(fs, V1);
+    await fs.mkdir('/workspace/skills/legacy', { recursive: true });
+    await fs.writeFile('/workspace/skills/legacy/SKILL.md', '# Legacy\n');
+
+    const cmd = createUpskillCommand(fs, repoFetch(V1) as unknown as SecureFetch);
+    const result = await cmd.execute(['update', '--dry-run', '--json'], createMockCtx() as never);
+
+    const parsed = JSON.parse(result.stdout) as {
+      ok: boolean;
+      dryRun: boolean;
+      results: Array<{ skill: string; outcome: string }>;
+      skipped: string[];
+    };
+    expect(result.exitCode).toBe(0);
+    // Pre-existing keys keep their meaning: an unattributed skill is not a failure.
+    expect(parsed.ok).toBe(true);
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.results).toEqual([
+      expect.objectContaining({ skill: 'alpha', outcome: 'current' }),
+    ]);
+    expect(parsed.skipped).toEqual(['legacy']);
   });
 
   it('honors --branch as a one-off override of the recorded ref', async () => {


### PR DESCRIPTION
## Summary

A bare `upskill update [--dry-run]` printed `All skills are current.` after checking only the skills that carry an `.upskill` provenance record. Installed skills without one were dropped inside `listProvenancedSkills()` and never surfaced — not as errors, not as warnings, not as a count. On the workspace in #2500 that was a confident all-clear covering **13 of 70** installed skills.

The sweep now names what it did not check, and scopes its closing line to what it did.

Fixes #2500

## What changed

- `provenance.ts`: new `scanSkillProvenance()` returns both halves of the directory walk — `provenanced` and the name-sorted `unattributed` names that were previously discarded. `listProvenancedSkills()` is now a thin wrapper over it, so every existing call site is untouched.
- `update.ts`: `resolveTargets()` returns a third collection, `skipped`, populated only on the no-argument path. `formatReport()` prints an informational block (count, sorted names, one line of guidance) and scopes the closing line — `All 13 skills with provenance are current.` — whenever anything was skipped.
- A sweep that finds skills but can attribute none of them now reports the skipped list and exits 0 instead of failing with `no skill has install provenance yet`. That message is retained for the genuinely-empty case (no skills installed at all).
- `--json` gains `skipped: string[]`. `ok`, `dryRun`, and `results[]` keep their exact meanings and types; `skipped` does not feed `ok`.
- Docs: `docs/shell-reference.md` and the agent-facing `upgrade/SKILL.md` describe the skipped block and warn against reading an unqualified all-clear into a run that printed one.

## Structural choice for the skipped set, and why

A **separate `skipped: string[]` collection**, not a third `reason` value on `missing`.

`missing` has exactly one consumer contract: every entry becomes a `missingMessage()` line on **stderr** and pushes `clean` to false, which makes the exit code 1. An unattributed skill nobody named is not a failed request — and `upgrade/SKILL.md` documents `upskill update --dry-run` as a read-only check an agent volunteers, so a non-zero exit there trades a false negative for a false alarm. Reusing `missing` would have meant threading a "do not count this one" exception through `clean`, the stderr join, and both exit-code sites; a separate collection expresses the same thing by construction and keeps `missing`'s invariant (every entry is a user-visible error) intact. It also gave `--json` a naturally additive field.

The named-argument path is unchanged: `upskill update <skill>` on a skill with no record still emits the same `no install provenance for "<skill>"` line on stderr and still exits 1.

## Before / after

Mixed fixture — one skill with provenance (`alpha`), four without (`aem`, `jira`, `upgrade`, `zeta`).

Before:

```
$ upskill update --dry-run
Skill update (dry run — nothing written):
  alpha: already current (github:octo/skills)

All skills are current.
(exit 0, stderr empty)
```

After:

```
$ upskill update --dry-run
Skill update (dry run — nothing written):
  alpha: already current (github:octo/skills)

Skipped 4 skills with no install provenance — not checked:
  aem, jira, upgrade, zeta
  Runtime-bundled skills have no record by design; `upgrade apply` keeps those current.
  For the rest, record a source once with `upskill update <skill> --from <owner>/<repo> --dry-run`,
  after which a bare `upskill update` sweeps them too.

All 1 skill with provenance is current.
(exit 0, stderr empty)
```

## How I tested

Five new cases in `packages/webapp/tests/shell/supplemental-commands/upskill/update.test.ts` (reusing the existing `test-helpers.ts` fixtures):

1. mixed workspace → skipped skills reported, names sorted, closing line scoped, **stderr empty, exit 0**;
2. every installed skill unattributed → skipped list, no all-clear of any scope, exit 0, and no network call;
3. every skill attributed → stdout asserted **byte-for-byte** equal to the current output (the regression guard against new noise in the clean case);
4. the named path with no provenance → unchanged message and unchanged exit 1 (pre-existing tests still green);
5. `--json` → `ok`/`dryRun`/`results[]` unchanged plus `skipped: ['legacy']`.

Full local pass, all green: `npm run verify`, `check-touched-exemptions.mjs`, `npm run typecheck`, `npm run test` (17,249 passing), `npm run test:coverage:webapp`, `npm run build`, `npm run build -w @slicc/chrome-extension`.

## Deliberately left out

- **Provenance inference by upstream blob matching** (the optional idea in #2500). It needs network access during what is advertised as a read-only dry run and deserves its own discussion; not attempted here.
- **No hardcoded list of bundled skill names.** There is no offline manifest — `upgrade-command.ts` discovers bundled files from the GitHub tree at a release ref over the network — so the guidance line explains the bundled case in prose rather than classifying it, and cannot rot at the next release.
- The install path, the dotfile-preservation logic, and `resolveCommitSha`'s token gate are untouched.
