### PR TITLE
fix(fs): materialize process-substitution fds inside a scoop sandbox

### DIFF
--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -173,6 +173,17 @@ Unlike `/tmp`, this space is **private per sandbox and never enters the tree**:
 - a descriptor that was never written raises `ENOENT` on read, the same loud
   failure the cone gives for an unopened fd.
 
+The exemption covers exactly what process substitution needs — a content write,
+the read back (including as either end of a `copyFile`, which is how `cp <(…)`
+arrives), and the release (`rm`). Every **tree-shape** op on a descriptor path is
+refused with `EACCES` by `RestrictedFS.refuseDescriptorTreeOp`: `mkdir`,
+`symlink`, `rename` and `mount`/`unmount`/`refreshMount`. That refusal is the
+containment for those ops, and it has to live in the ACL layer, because the
+policy layer deliberately answers `nopasswd-allow` rather than raising a prompt.
+Without it, a `mkdir /dev/fd/63` in a `sudo-delegated` sandbox would fall through
+to the shared `VirtualFS` and create exactly the cone-visible, cross-scoop
+`/dev/fd` entry the private store exists to prevent.
+
 This is not a widening of the sandbox: a scoop can already express the same data
 flow with a temp file under `/tmp`, which is unconditionally writable, so gating
 `<(...)` bought no containment — it only broke the ergonomic spelling. It is

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -140,6 +140,46 @@ Two consequences worth knowing:
   independently, so both layers must agree or the write is walled underneath
   the grant.
 
+### Ephemeral shell descriptors — `/dev/fd/<n>` (never gated)
+
+Process substitution (`<(cmd)` / `>(cmd)`) is modelled on a backing file at
+`/dev/fd/<n>`, numbered downward from 63 exactly as bash numbers it: the body's
+stdout is written there during word expansion, the outer command reads the path
+back, and the descriptor is released when that command ends.
+
+Those paths are **never a policy subject**. `matchPath` resolves them to
+`nopasswd-allow` for both reads and writes (`isEphemeralFdPath` in
+`packages/webapp/src/fs/virtual-device-paths.ts`), before any rule is consulted —
+self-protection is still checked first and stays absolute. The reason is that
+there is nothing for a prompt to be _about_: the path is minted by the shell for
+the duration of one command, the fd number changes every invocation (so no
+"Always" grant could ever pre-empt the prompt), and the only reader is the
+consuming command in the same pipeline. A sandboxed scoop that hit such a prompt
+stalled indefinitely, because only the cone can clear it (#2502).
+
+The matching ACL exemption is the private `EphemeralFdStore` held by each
+`RestrictedFS` (`packages/webapp/src/fs/ephemeral-fd-store.ts`). As with `/tmp`,
+`SudoFS` and `RestrictedFS` gate independently, so both layers have to agree:
+granting only in the policy leaves the consumer's open walled to `ENOENT` while
+the write lands _outside_ the sandbox, and exempting only in the ACL leaves the
+approval prompt in place.
+
+Unlike `/tmp`, this space is **private per sandbox and never enters the tree**:
+
+- descriptors are not addressable across scoops, commands or turns, and nothing
+  is written to `/dev/fd` in the shared VFS;
+- `/dev` and `/dev/fd` remain non-existent in a scoop's view — no listing, no
+  `stat`, no `readDir` entry;
+- a descriptor that was never written raises `ENOENT` on read, the same loud
+  failure the cone gives for an unopened fd.
+
+This is not a widening of the sandbox: a scoop can already express the same data
+flow with a temp file under `/tmp`, which is unconditionally writable, so gating
+`<(...)` bought no containment — it only broke the ergonomic spelling. It is
+also deliberately **not** modelled as a no-op device write like `/dev/null`: a
+descriptor's payload is read back, so discarding it would turn `cat <(echo hi)`
+from an error into silently empty output.
+
 ### Live reload
 
 `SudoManager` watches `/etc` via the shared `FsWatcher` and re-reads + re-merges

--- a/packages/webapp/src/base/sudoers.ts
+++ b/packages/webapp/src/base/sudoers.ts
@@ -379,6 +379,14 @@ export function matchPath(
   // the write is the one that escalates today, but an explicit `Read` rule
   // must not be able to gate the consumer's open either. Self-protection is
   // checked first and stays absolute.
+  //
+  // Unlike the `/dev/null` exemption above, this one is deliberately NOT
+  // limited to content writes: a prompt is the wrong answer for a descriptor
+  // whatever the op is. Containment for the STRUCTURAL ops (`mkdir`, `symlink`,
+  // `rename`, `mount`) lives in the other layer instead, where it belongs —
+  // `RestrictedFS.refuseDescriptorTreeOp` rejects them outright, so the two
+  // layers still agree that no op on a descriptor path may create a shared-tree
+  // entry.
   if (isEphemeralFdPath(normalized)) return 'nopasswd-allow';
   return resolve(op === 'read' ? policy.read : policy.write, normalized);
 }

--- a/packages/webapp/src/base/sudoers.ts
+++ b/packages/webapp/src/base/sudoers.ts
@@ -15,7 +15,7 @@
  */
 
 import { normalizePath, pathGlobToRegExp } from '../fs/path-utils.js';
-import { isNoOpWriteDevicePath } from '../fs/virtual-device-paths.js';
+import { isEphemeralFdPath, isNoOpWriteDevicePath } from '../fs/virtual-device-paths.js';
 import { createLogger } from './logger.js';
 
 export { pathGlobToRegExp } from '../fs/path-utils.js';
@@ -371,5 +371,14 @@ export function matchPath(
     if (isSelfProtectedWrite(normalized)) return 'require-approval';
     if (opts?.isContentWrite && isNoOpWriteDevicePath(normalized)) return 'nopasswd-allow';
   }
+  // The shell's ephemeral descriptors (`/dev/fd/<n>`, minted per command by
+  // process substitution) are never a policy subject: the fd number changes
+  // every invocation, so no "Always" grant could pre-empt the prompt, and an
+  // unattended scoop would stall forever on a cone approval for a path its
+  // own next command would read straight back (#2502). Exempt for BOTH ops —
+  // the write is the one that escalates today, but an explicit `Read` rule
+  // must not be able to gate the consumer's open either. Self-protection is
+  // checked first and stays absolute.
+  if (isEphemeralFdPath(normalized)) return 'nopasswd-allow';
   return resolve(op === 'read' ? policy.read : policy.write, normalized);
 }

--- a/packages/webapp/src/fs/ephemeral-fd-store.ts
+++ b/packages/webapp/src/fs/ephemeral-fd-store.ts
@@ -1,0 +1,109 @@
+/**
+ * EphemeralFdStore — private byte backing for the shell's `/dev/fd/<n>` paths.
+ *
+ * just-bash models process substitution (`<(cmd)` / `>(cmd)`) on a real file at
+ * `/dev/fd/<n>`: the body's stdout is written there during word expansion, the
+ * outer command reads the path back, and the entry is `rm`'d when the command
+ * finishes. The cone runs that against an unrestricted `VirtualFS`, where it is
+ * simply an ordinary file.
+ *
+ * A sandboxed scoop must NOT resolve those writes against the shared tree. Two
+ * things go wrong when it does (#2502): the write lands at `/dev/fd/<n>` OUTSIDE
+ * the scoop's grants — visible to the cone and to sibling scoops, and clobbered
+ * by whichever scoop reaches fd 63 next — while the consumer's read is filtered
+ * back to `ENOENT` by the sandbox ACL, so the shell is told the write succeeded
+ * and the payload is then unreachable.
+ *
+ * This store is the sandbox's answer instead: one instance per `RestrictedFS`,
+ * so a descriptor is
+ *
+ *   - readable and writable without a sudoers match (an fd number varies per
+ *     invocation, so no grant could pre-empt an approval prompt anyway);
+ *   - private to one sandbox — nothing is addressable across scoops;
+ *   - absent from every directory listing, because it lives beside the tree
+ *     rather than in it (`/dev` and `/dev/fd` stay non-existent in a scoop's
+ *     view, exactly as they were before this store existed);
+ *   - bounded — just-bash allocates fds 63 downward to 10 and releases each
+ *     one at the end of the command whose expansion opened it, so at most a few
+ *     dozen entries can be live, each capped by the interpreter's own
+ *     `maxStringLength`.
+ *
+ * A descriptor that was never written stays absent, so a read of it raises
+ * `ENOENT` — the same loud failure the cone gives for an unopened fd.
+ */
+
+import { normalizePath } from './path-utils.js';
+import type { FileContent, ReadFileOptions, Stats } from './types.js';
+import { FsError } from './types.js';
+import { isEphemeralFdPath } from './virtual-device-paths.js';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder('utf-8', { fatal: false });
+
+/** One live descriptor's bytes plus the timestamps `stat` has to answer with. */
+interface FdEntry {
+  bytes: Uint8Array;
+  mtime: number;
+  ctime: number;
+}
+
+export class EphemeralFdStore {
+  private entries = new Map<string, FdEntry>();
+
+  /** Whether `path` is an ephemeral descriptor this store answers for. */
+  static handles(path: string): boolean {
+    return isEphemeralFdPath(normalizePath(path));
+  }
+
+  /** Whether a descriptor has been written (and not yet released). */
+  has(path: string): boolean {
+    return this.entries.has(normalizePath(path));
+  }
+
+  /**
+   * Replace a descriptor's bytes. Strings are UTF-8 encoded: the shell's own
+   * writes arrive as `Uint8Array` from `VfsAdapter` (which has already resolved
+   * the latin1-vs-UTF-8 question for binary payloads), so this branch only
+   * covers direct callers passing text.
+   */
+  write(path: string, content: FileContent): void {
+    const key = normalizePath(path);
+    const bytes = typeof content === 'string' ? encoder.encode(content) : new Uint8Array(content);
+    const now = Date.now();
+    const existing = this.entries.get(key);
+    this.entries.set(key, { bytes, mtime: now, ctime: existing?.ctime ?? now });
+  }
+
+  /** Read a descriptor, honoring the `VirtualFS` default of UTF-8 text. */
+  read(path: string, options?: ReadFileOptions): FileContent {
+    const entry = this.require(path);
+    if ((options?.encoding ?? 'utf-8') === 'utf-8') return decoder.decode(entry.bytes);
+    return new Uint8Array(entry.bytes);
+  }
+
+  /** Read a descriptor as text. */
+  readText(path: string): string {
+    return decoder.decode(this.require(path).bytes);
+  }
+
+  /** Metadata for a live descriptor. A descriptor is never a directory. */
+  stat(path: string): Stats {
+    const entry = this.require(path);
+    return { type: 'file', size: entry.bytes.length, mtime: entry.mtime, ctime: entry.ctime };
+  }
+
+  /**
+   * Release a descriptor. Missing entries are reported so the caller can honor
+   * `rm`'s `force` semantics itself rather than guessing.
+   */
+  remove(path: string): boolean {
+    return this.entries.delete(normalizePath(path));
+  }
+
+  private require(path: string): FdEntry {
+    const key = normalizePath(path);
+    const entry = this.entries.get(key);
+    if (!entry) throw new FsError('ENOENT', 'no such file or directory', key);
+    return entry;
+  }
+}

--- a/packages/webapp/src/fs/restricted-fs.ts
+++ b/packages/webapp/src/fs/restricted-fs.ts
@@ -642,7 +642,32 @@ export class RestrictedFS {
     return this.vfs.writeFile(path, content, options);
   }
 
+  /**
+   * Refuse a TREE-SHAPE op on a descriptor path.
+   *
+   * The descriptor exemption covers exactly the two things process substitution
+   * needs — a content write and the read back — plus the release (`rm`). Every
+   * other op names a tree node, and a descriptor is not one: it has no parent
+   * directory, no siblings and no inode to relink. This is not merely
+   * meaningless, it is load-bearing. Under `sudo-delegated` enforcement
+   * `checkWrite` is a no-op, so without this refusal a `mkdir /dev/fd/63` or
+   * `mv x /dev/fd/63` would fall through to the SHARED VirtualFS and
+   * materialize the very cone-visible, cross-scoop `/dev/fd` entry the private
+   * store exists to prevent — and the sudoers layer cannot stop it, because it
+   * deliberately answers `nopasswd-allow` for these paths rather than raising
+   * a prompt no "Always" grant could pre-empt.
+   *
+   * `EACCES` (not `ENOENT`) because the op is refused, not the path missing:
+   * the shell owns these paths, the sandbox does not.
+   */
+  private refuseDescriptorTreeOp(path: string): void {
+    if (EphemeralFdStore.handles(path)) {
+      throw new FsError('EACCES', 'permission denied', normalizePath(path));
+    }
+  }
+
   async mkdir(path: string, options?: MkdirOptions): Promise<void> {
+    this.refuseDescriptorTreeOp(path);
     this.checkWrite(path);
     await this.checkParentRealpathEscape(path);
     return this.vfs.mkdir(path, options);
@@ -679,6 +704,8 @@ export class RestrictedFS {
   }
 
   async rename(oldPath: string, newPath: string): Promise<void> {
+    this.refuseDescriptorTreeOp(oldPath);
+    this.refuseDescriptorTreeOp(newPath);
     this.checkWrite(oldPath);
     this.checkWrite(newPath);
     // Resolve symlinks in both paths to prevent escape
@@ -688,6 +715,27 @@ export class RestrictedFS {
   }
 
   async copyFile(src: string, dest: string): Promise<void> {
+    // A descriptor is a legitimate end of a copy — `cp <(echo hi) out` reaches
+    // here through `VfsAdapter.cp`, and `cp in >(consumer)` has to land in the
+    // store so the writer body sees the bytes. Each end is resolved
+    // independently: the descriptor end through the store (no ACL, it is not a
+    // tree path), the tree end through the ordinary checks below.
+    if (EphemeralFdStore.handles(src)) {
+      const content = this.ephemeralFds.read(src, { encoding: 'binary' });
+      await this.writeFile(dest, content);
+      return;
+    }
+    if (EphemeralFdStore.handles(dest)) {
+      if (!this.isAllowed(src)) {
+        throw new FsError('ENOENT', 'no such file or directory', normalizePath(src));
+      }
+      const resolvedSource = await this.resolveAndCheckRead(src);
+      this.ephemeralFds.write(
+        dest,
+        await this.vfs.readFile(resolvedSource, { encoding: 'binary' })
+      );
+      return;
+    }
     // Read from anywhere allowed, write only to allowed
     if (!this.isAllowed(src)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(src));
@@ -712,6 +760,7 @@ export class RestrictedFS {
   // ── Symlink operations ───────────────────────────────────────────────
 
   async symlink(target: string, linkPath: string): Promise<void> {
+    this.refuseDescriptorTreeOp(linkPath);
     this.checkWrite(linkPath);
     await this.checkParentRealpathEscape(linkPath);
     return this.vfs.symlink(target, linkPath);
@@ -806,12 +855,14 @@ export class RestrictedFS {
     backend: MountBackend,
     opts?: { env?: MountIndexEnv }
   ): Promise<void> {
+    this.refuseDescriptorTreeOp(absolutePath);
     this.checkWrite(absolutePath);
     await this.checkParentRealpathEscape(absolutePath);
     return this.vfs.mount(absolutePath, backend, opts);
   }
 
   async unmount(absolutePath: string): Promise<void> {
+    this.refuseDescriptorTreeOp(absolutePath);
     this.checkWrite(absolutePath);
     await this.checkParentRealpathEscape(absolutePath);
     return this.vfs.unmount(absolutePath);
@@ -829,6 +880,7 @@ export class RestrictedFS {
     absolutePath: string,
     opts?: { bodies?: boolean; env?: MountIndexEnv }
   ): Promise<RefreshReport> {
+    this.refuseDescriptorTreeOp(absolutePath);
     this.checkWrite(absolutePath);
     return this.vfs.refreshMount(absolutePath, opts);
   }

--- a/packages/webapp/src/fs/restricted-fs.ts
+++ b/packages/webapp/src/fs/restricted-fs.ts
@@ -18,6 +18,7 @@
  *     in place either way.
  */
 
+import { EphemeralFdStore } from './ephemeral-fd-store.js';
 import type { FsWatchCallback, FsWatchFilter } from './fs-watcher.js';
 import type { MountBackend, RefreshReport } from './mount/backend.js';
 import type { MountIndexEnv } from './mount-index.js';
@@ -78,10 +79,37 @@ const VIRTUAL_DEVICES: Record<string, VirtualDevice> = {
  * They are deliberately NOT part of the per-scoop config grants — those are
  * compiled from each scoop's own `ScoopConfig`, while `/tmp` applies to every
  * scoop unconditionally.
+ *
+ * This list is for TREE locations only. The shell's `/dev/fd/<n>` descriptors
+ * are also writable in every sandbox, but they are not here and must not be:
+ * see {@link RestrictedFS.ephemeralFds} for why they are answered beside the
+ * tree instead, and why widening this list to `/dev/` would be the wrong fix.
  */
 const ALWAYS_WRITABLE_PREFIXES = ['/tmp/'];
 
 export class RestrictedFS {
+  /**
+   * Private backing for the shell's `/dev/fd/<n>` process-substitution
+   * descriptors. They are answered here — beside the tree, never in it —
+   * rather than through the ACL, because a descriptor is minted by the shell
+   * for one command and its bytes are read straight back by the consuming
+   * command in the same pipeline (#2502).
+   *
+   * Deliberately NOT an `ALWAYS_WRITABLE_PREFIXES` entry: widening that list
+   * to `/dev/` would permit writes to every future device path, including ones
+   * with observable effects, and would resolve them against the SHARED tree,
+   * where a scoop's descriptor is visible to the cone and to sibling scoops.
+   * Deliberately not a `VIRTUAL_DEVICES` entry either — a no-op write would
+   * discard a payload that is about to be read back.
+   *
+   * The matching sudoers exemption is `isEphemeralFdPath` in `matchPath`
+   * (`base/sudoers.ts`). Both layers gate independently, so both have to agree:
+   * granting only here leaves a scoop write escalating to a cone approval
+   * prompt no "Always" grant can pre-empt (the fd number changes per
+   * invocation); exempting only there leaves the consumer's open walled to
+   * `ENOENT` while the write silently lands outside the sandbox.
+   */
+  private readonly ephemeralFds = new EphemeralFdStore();
   private vfs: VirtualFS;
   private allowedPrefixes: string[];
   private readOnlyPrefixes: string[];
@@ -206,7 +234,10 @@ export class RestrictedFS {
    * the resolved cwd as a writable prefix anyway.
    */
   canWrite(path: string): boolean {
-    return this.isWritable(path);
+    // Ephemeral descriptors are writable without being part of the ACL — see
+    // {@link ephemeralFds}. Reporting them as writable keeps this predicate
+    // honest about what `writeFile` will actually accept.
+    return EphemeralFdStore.handles(path) || this.isWritable(path);
   }
 
   /**
@@ -326,6 +357,7 @@ export class RestrictedFS {
   async readFile(path: string, options?: ReadFileOptions): Promise<FileContent> {
     const devRead = VIRTUAL_DEVICES[normalizePath(path)];
     if (devRead) return devRead.read(options);
+    if (EphemeralFdStore.handles(path)) return this.ephemeralFds.read(path, options);
     if (!this.isAllowedStrict(path)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
     }
@@ -360,6 +392,7 @@ export class RestrictedFS {
   async stat(path: string): Promise<Stats> {
     const dev = VIRTUAL_DEVICES[normalizePath(path)];
     if (dev) return dev.stat();
+    if (EphemeralFdStore.handles(path)) return this.ephemeralFds.stat(path);
     if (!this.isAllowed(path)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
     }
@@ -435,6 +468,12 @@ export class RestrictedFS {
   statSync(path: string): Stats | null {
     const dev = VIRTUAL_DEVICES[normalizePath(path)];
     if (dev) return dev.stat();
+    // An ephemeral descriptor lives outside the tree, so the sync fast path can
+    // answer for it directly; `null` for one that was never written falls back
+    // to the async `stat`, which raises the ENOENT the caller expects.
+    if (EphemeralFdStore.handles(path)) {
+      return this.ephemeralFds.has(path) ? this.ephemeralFds.stat(path) : null;
+    }
     if (!this.isAllowedStrict(path)) return null;
     // Scan ancestors AND leaf: `statSync` follows symlinks (via
     // `resolveSymlinksSync`), so a symlink anywhere in the path can
@@ -456,6 +495,9 @@ export class RestrictedFS {
   lstatSync(path: string): Stats | null {
     const dev = VIRTUAL_DEVICES[normalizePath(path)];
     if (dev) return dev.stat();
+    if (EphemeralFdStore.handles(path)) {
+      return this.ephemeralFds.has(path) ? this.ephemeralFds.stat(path) : null;
+    }
     if (!this.isAllowed(path)) return null;
     const scan = this.scanPathForSymlinks(path, false);
     if (scan !== false) return null;
@@ -503,6 +545,15 @@ export class RestrictedFS {
    * VAL-FS-019 symlink-escape semantics).
    */
   async realpath(path: string): Promise<string> {
+    // A descriptor is its own canonical path — it is not a tree entry, so there
+    // is no symlink to resolve and no ACL scope to escape.
+    if (EphemeralFdStore.handles(path)) {
+      const normalized = normalizePath(path);
+      if (!this.ephemeralFds.has(normalized)) {
+        throw new FsError('ENOENT', 'no such file or directory', normalized);
+      }
+      return normalized;
+    }
     let resolved: string;
     try {
       resolved = await this.vfs.realpath(path);
@@ -518,6 +569,7 @@ export class RestrictedFS {
 
   async exists(path: string): Promise<boolean> {
     if (VIRTUAL_DEVICES[normalizePath(path)]) return true;
+    if (EphemeralFdStore.handles(path)) return this.ephemeralFds.has(path);
     if (!this.isAllowed(path)) return false;
     if (this.isAllowedStrict(path)) {
       try {
@@ -532,6 +584,7 @@ export class RestrictedFS {
   async readTextFile(path: string): Promise<string> {
     const devText = VIRTUAL_DEVICES[normalizePath(path)];
     if (devText) return devText.readText();
+    if (EphemeralFdStore.handles(path)) return this.ephemeralFds.readText(path);
     if (!this.isAllowedStrict(path)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
     }
@@ -568,6 +621,12 @@ export class RestrictedFS {
       devWrite.write(content);
       return;
     }
+    // Ephemeral descriptor: keep the payload (it is read back by the consuming
+    // command) but keep it out of the shared tree.
+    if (EphemeralFdStore.handles(path)) {
+      this.ephemeralFds.write(path, content);
+      return;
+    }
     this.checkWrite(path);
     await this.checkParentRealpathEscape(path);
     // Also check if destination itself is a symlink pointing outside sandbox
@@ -590,6 +649,18 @@ export class RestrictedFS {
   }
 
   async rm(path: string, options?: RmOptions): Promise<void> {
+    // Releasing a descriptor is how the shell ends a process substitution, so
+    // it has to reach the store rather than the tree. A descriptor that was
+    // never written raises ENOENT, exactly as the VFS does for a missing file:
+    // the interpreter's own release swallows that, and `rm -f` is resolved by
+    // the shell's `rm` command before it reaches this layer (the VFS `RmOptions`
+    // carries no `force` flag).
+    if (EphemeralFdStore.handles(path)) {
+      if (!this.ephemeralFds.remove(path)) {
+        throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
+      }
+      return;
+    }
     this.checkWrite(path);
     // For symlinks, check only the link path (not target) — we're removing the link node
     try {
@@ -668,6 +739,8 @@ export class RestrictedFS {
   async lstat(path: string): Promise<Stats> {
     const dev = VIRTUAL_DEVICES[normalizePath(path)];
     if (dev) return dev.stat();
+    // A descriptor can never be a symlink, so `lstat` answers exactly as `stat`.
+    if (EphemeralFdStore.handles(path)) return this.ephemeralFds.stat(path);
     if (!this.isAllowed(path)) {
       throw new FsError('ENOENT', 'no such file or directory', normalizePath(path));
     }

--- a/packages/webapp/src/fs/virtual-device-paths.ts
+++ b/packages/webapp/src/fs/virtual-device-paths.ts
@@ -1,4 +1,11 @@
 /**
+ * Synthetic `/dev/*` paths the filesystem layers answer for themselves, in two
+ * strictly separate flavors: paths whose write is a genuine no-op
+ * ({@link NO_OP_WRITE_DEVICE_PATHS}) and the shell's ephemeral descriptors
+ * ({@link isEphemeralFdPath}), whose payload is read back and therefore must
+ * never be discarded. Keep them apart — the whole point of the split is that a
+ * single list would be wrong for one of the two.
+ *
  * Canonical list of virtual device files (`/dev/*`) whose write is a genuine
  * no-op. This is the single source of truth shared by two consumers that would
  * otherwise hardcode the same literals and drift:
@@ -25,6 +32,44 @@
 
 /** The canonical `/dev/null` path (its write discards all input). */
 export const DEV_NULL = '/dev/null';
+
+/**
+ * Matches `/dev/fd/<n>`, a decimal descriptor number under the directory that
+ * holds the shell's ephemeral file descriptors — the backing paths just-bash
+ * hands to the outer command for process substitution (`<(cmd)`, `>(cmd)`),
+ * numbered downward from 63 exactly as bash numbers them.
+ */
+const DEV_FD_PATH = /^\/dev\/fd\/(0|[1-9][0-9]*)$/;
+
+/**
+ * Whether `path` (already-normalized) is an ephemeral shell descriptor.
+ *
+ * This is a deliberate SIBLING of {@link NO_OP_WRITE_DEVICE_PATHS}, not a
+ * member of it: a process-substitution descriptor's payload is NOT discarded —
+ * the consuming command in the same pipeline reads it straight back, so
+ * treating it as a no-op write would turn `cat <(echo hi)` from an error into
+ * silently empty output. What the two concepts share is only the reason they
+ * bypass the sudoers policy: the path is minted by the shell for the duration
+ * of one command, so there is no user-meaningful subject for an approval prompt
+ * to be about, and a scoop stalling on one is a harness bug (#2502).
+ *
+ * Consumers:
+ *   - The sudoers matcher (`base/sudoers.ts`) resolves these paths to
+ *     `nopasswd-allow` for BOTH ops, so a sandboxed scoop's default
+ *     `require-approval` disposition can never escalate a descriptor write to
+ *     the cone (an fd number varies per invocation, so no "Always" grant could
+ *     ever pre-empt the prompt).
+ *   - `RestrictedFS` (`restricted-fs.ts`) backs them with a private
+ *     `EphemeralFdStore` (`ephemeral-fd-store.ts`) instead of the sandboxed
+ *     tree, so the bytes are readable back inside the sandbox without
+ *     `/dev/fd` becoming a real, listable, cross-sandbox-visible VFS location.
+ *
+ * The cone runs against an unrestricted `VirtualFS` and is unaffected by both:
+ * it already writes and reads these paths as ordinary files.
+ */
+export function isEphemeralFdPath(path: string): boolean {
+  return DEV_FD_PATH.test(path);
+}
 
 /** All virtual-device paths whose `write` is a no-op. */
 export const NO_OP_WRITE_DEVICE_PATHS = [DEV_NULL] as const;

--- a/packages/webapp/tests/base/sudoers.test.ts
+++ b/packages/webapp/tests/base/sudoers.test.ts
@@ -322,6 +322,55 @@ describe('no-op virtual-device write invariant', () => {
   }
 });
 
+describe('ephemeral shell descriptor invariant', () => {
+  // Rules that would otherwise gate the descriptor: a require-approval Write
+  // covering it, plus a require-approval Read (an fd number varies per
+  // invocation, so no grant can pre-empt either prompt).
+  const withRules = parseSudoers('Write /dev/**\nRead /dev/**\nWrite /workspace/**');
+
+  for (const fdPath of ['/dev/fd/63', '/dev/fd/62', '/dev/fd/10']) {
+    it(`never gates a write to ${fdPath}, empty policy or not`, () => {
+      expect(matchPath(emptyPolicy(), 'write', fdPath)).toBe('nopasswd-allow');
+      expect(matchPath(withRules, 'write', fdPath)).toBe('nopasswd-allow');
+      expect(matchPath(withRules, 'write', fdPath, { isContentWrite: true })).toBe(
+        'nopasswd-allow'
+      );
+    });
+
+    it(`never gates a read of ${fdPath}, empty policy or not`, () => {
+      expect(matchPath(emptyPolicy(), 'read', fdPath)).toBe('nopasswd-allow');
+      expect(matchPath(withRules, 'read', fdPath)).toBe('nopasswd-allow');
+    });
+
+    it(`survives the default-disposition upgrade for ${fdPath}`, () => {
+      // The sandbox path a scoop actually takes: an unmatched write would be
+      // upgraded to a cone approval, which is what stalled the scoop (#2502).
+      expect(
+        applyDefaultDisposition(
+          matchPath(emptyPolicy(), 'write', fdPath, { isContentWrite: true }),
+          'require-approval'
+        )
+      ).toBe('nopasswd-allow');
+    });
+  }
+
+  it('normalizes before exempting', () => {
+    expect(matchPath(emptyPolicy(), 'write', '/dev/fd/./63')).toBe('nopasswd-allow');
+  });
+
+  it('exempts only numbered descriptors, not the directory or a named child', () => {
+    for (const path of ['/dev/fd', '/dev/fd/', '/dev/fd/name', '/dev/fd/63/x', '/dev/fdx/63']) {
+      expect(matchPath(emptyPolicy(), 'write', path)).toBe('no-match');
+    }
+  });
+
+  it('cannot override self-protection', () => {
+    // Belt-and-braces: the sudoers files are not under /dev/fd, but the
+    // self-protection check must stay ordered first regardless.
+    expect(matchPath(emptyPolicy(), 'write', SUDOERS_FILE)).toBe('require-approval');
+  });
+});
+
 describe('applyDefaultDisposition', () => {
   it('upgrades no-match to require-approval when default is require-approval', () => {
     expect(applyDefaultDisposition('no-match', 'require-approval')).toBe('require-approval');

--- a/packages/webapp/tests/fs/ephemeral-fd-store.test.ts
+++ b/packages/webapp/tests/fs/ephemeral-fd-store.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for the private backing of the shell's `/dev/fd/<n>` descriptors.
+ * The sandbox-level behavior lives in `restricted-fs.test.ts`; the cone/scoop
+ * equivalence guard lives in `shell/process-substitution-sandbox.test.ts`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { EphemeralFdStore } from '../../src/fs/ephemeral-fd-store.js';
+import { isEphemeralFdPath } from '../../src/fs/virtual-device-paths.js';
+
+describe('isEphemeralFdPath', () => {
+  it('matches numbered descriptors', () => {
+    for (const path of ['/dev/fd/0', '/dev/fd/10', '/dev/fd/62', '/dev/fd/63']) {
+      expect(isEphemeralFdPath(path)).toBe(true);
+    }
+  });
+
+  it('rejects everything else, including the directory itself', () => {
+    for (const path of [
+      '/dev/fd',
+      '/dev/fd/',
+      '/dev/fd/name',
+      '/dev/fd/63/child',
+      '/dev/fd/007',
+      '/dev/fd/-1',
+      '/dev/fdx/63',
+      '/dev/null',
+      '/proc/self/fd/63',
+      '/scoops/s/dev/fd/63',
+    ]) {
+      expect(isEphemeralFdPath(path)).toBe(false);
+    }
+  });
+});
+
+describe('EphemeralFdStore', () => {
+  it('answers only for numbered descriptor paths', () => {
+    expect(EphemeralFdStore.handles('/dev/fd/63')).toBe(true);
+    // Normalization happens before the test, so a traversal cannot dodge it.
+    expect(EphemeralFdStore.handles('/dev/fd/./63')).toBe(true);
+    expect(EphemeralFdStore.handles('/dev/fd/62/../63')).toBe(true);
+    expect(EphemeralFdStore.handles('/dev/null')).toBe(false);
+    expect(EphemeralFdStore.handles('/workspace/fd/63')).toBe(false);
+  });
+
+  it('round-trips text and bytes', () => {
+    const store = new EphemeralFdStore();
+    store.write('/dev/fd/63', 'alpha\n');
+    expect(store.has('/dev/fd/63')).toBe(true);
+    expect(store.readText('/dev/fd/63')).toBe('alpha\n');
+    expect(store.read('/dev/fd/63')).toBe('alpha\n');
+    expect(store.read('/dev/fd/63', { encoding: 'binary' })).toEqual(
+      new TextEncoder().encode('alpha\n')
+    );
+
+    store.write('/dev/fd/62', new Uint8Array([0x00, 0xff, 0x41]));
+    expect(store.read('/dev/fd/62', { encoding: 'binary' })).toEqual(
+      new Uint8Array([0x00, 0xff, 0x41])
+    );
+  });
+
+  it('does not hand out a mutable view of its bytes', () => {
+    const store = new EphemeralFdStore();
+    const source = new Uint8Array([1, 2, 3]);
+    store.write('/dev/fd/63', source);
+    source[0] = 9;
+    const read = store.read('/dev/fd/63', { encoding: 'binary' }) as Uint8Array;
+    read[1] = 9;
+    expect(store.read('/dev/fd/63', { encoding: 'binary' })).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it('overwrites in place and keeps the creation time', () => {
+    const store = new EphemeralFdStore();
+    store.write('/dev/fd/63', 'first');
+    const created = store.stat('/dev/fd/63').ctime;
+    store.write('/dev/fd/63', 'second-and-longer');
+    expect(store.readText('/dev/fd/63')).toBe('second-and-longer');
+    expect(store.stat('/dev/fd/63')).toMatchObject({
+      type: 'file',
+      size: 'second-and-longer'.length,
+      ctime: created,
+    });
+  });
+
+  it('normalizes the key so one descriptor is one entry', () => {
+    const store = new EphemeralFdStore();
+    store.write('/dev/fd/63', 'once');
+    store.write('/dev/fd/./63', 'twice');
+    expect(store.readText('/dev/fd/63')).toBe('twice');
+    expect(store.remove('/dev/fd/62/../63')).toBe(true);
+    expect(store.has('/dev/fd/63')).toBe(false);
+  });
+
+  it('raises ENOENT for a descriptor that was never written', () => {
+    const store = new EphemeralFdStore();
+    expect(store.has('/dev/fd/63')).toBe(false);
+    expect(() => store.read('/dev/fd/63')).toThrow(/no such file or directory/);
+    expect(() => store.readText('/dev/fd/63')).toThrow(/no such file or directory/);
+    expect(() => store.stat('/dev/fd/63')).toThrow(/no such file or directory/);
+  });
+
+  it('reports whether a release actually removed anything', () => {
+    const store = new EphemeralFdStore();
+    store.write('/dev/fd/63', 'x');
+    expect(store.remove('/dev/fd/63')).toBe(true);
+    expect(store.remove('/dev/fd/63')).toBe(false);
+  });
+});

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -690,6 +690,9 @@ describe('RestrictedFS ephemeral shell descriptors', () => {
   beforeEach(async () => {
     vfs = await VirtualFS.create({ dbName: `test-restricted-fs-fd-${fdDbCounter++}`, wipe: true });
     await vfs.mkdir('/scoops/fd-scoop', { recursive: true });
+    // A real out-of-sandbox file, so an ENOENT below is the ACL filtering it
+    // rather than the path simply not existing.
+    await vfs.writeFile('/scoops/other-scoop/secret.txt', 'secret', { recursive: true });
     restricted = new RestrictedFS(vfs, ['/scoops/fd-scoop/']);
   });
 
@@ -750,6 +753,59 @@ describe('RestrictedFS ephemeral shell descriptors', () => {
 
   it('reports a descriptor as writable', () => {
     expect(restricted.canWrite('/dev/fd/63')).toBe(true);
+  });
+
+  it('copies a descriptor into the tree and a tree file into a descriptor', async () => {
+    // `cp <(echo hi) out` and `cp in >(consumer)` both land here via
+    // `VfsAdapter.cp`, so each end has to be resolved independently.
+    await restricted.writeFile('/dev/fd/63', 'from-descriptor');
+    await restricted.copyFile('/dev/fd/63', '/scoops/fd-scoop/out.txt');
+    expect(await restricted.readTextFile('/scoops/fd-scoop/out.txt')).toBe('from-descriptor');
+
+    await restricted.writeFile('/scoops/fd-scoop/in.txt', 'from-tree');
+    await restricted.copyFile('/scoops/fd-scoop/in.txt', '/dev/fd/62');
+    expect(await restricted.readTextFile('/dev/fd/62')).toBe('from-tree');
+    // The descriptor end never becomes a tree entry, in either direction.
+    expect(await vfs.exists('/dev/fd/62')).toBe(false);
+  });
+
+  it('keeps the ACL on the tree end of a descriptor copy', async () => {
+    await restricted.writeFile('/dev/fd/63', 'payload');
+    await expect(restricted.copyFile('/dev/fd/63', '/elsewhere/out.txt')).rejects.toThrow(
+      /permission denied/
+    );
+    await expect(
+      restricted.copyFile('/scoops/other-scoop/secret.txt', '/dev/fd/62')
+    ).rejects.toThrow(/no such file/);
+    expect(await restricted.exists('/dev/fd/62')).toBe(false);
+  });
+
+  it('refuses tree-shape ops on a descriptor path', async () => {
+    // The exemption covers a content write, the read back and the release —
+    // not tree shape. Under `sudo-delegated` enforcement these would otherwise
+    // fall through to the shared VFS, which is what the private store prevents.
+    await restricted.writeFile('/scoops/fd-scoop/src.txt', 'x');
+    await expect(restricted.mkdir('/dev/fd/63')).rejects.toThrow(/permission denied/);
+    await expect(restricted.symlink('/scoops/fd-scoop/src.txt', '/dev/fd/63')).rejects.toThrow(
+      /permission denied/
+    );
+    await expect(restricted.rename('/scoops/fd-scoop/src.txt', '/dev/fd/63')).rejects.toThrow(
+      /permission denied/
+    );
+    await expect(restricted.rename('/dev/fd/63', '/scoops/fd-scoop/moved.txt')).rejects.toThrow(
+      /permission denied/
+    );
+    expect(await vfs.exists('/dev')).toBe(false);
+    expect(await vfs.exists('/dev/fd/63')).toBe(false);
+  });
+
+  it('refuses a mount at a descriptor path', async () => {
+    await expect(restricted.mount('/dev/fd/63', fakeMountBackend())).rejects.toThrow(
+      /permission denied/
+    );
+    await expect(restricted.unmount('/dev/fd/63')).rejects.toThrow(/permission denied/);
+    await expect(restricted.refreshMount('/dev/fd/63')).rejects.toThrow(/permission denied/);
+    expect(await vfs.exists('/dev')).toBe(false);
   });
 
   it('does not expose the descriptors as a directory', async () => {

--- a/packages/webapp/tests/fs/restricted-fs.test.ts
+++ b/packages/webapp/tests/fs/restricted-fs.test.ts
@@ -2,7 +2,7 @@
  * Tests for RestrictedFS path access control.
  */
 
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import 'fake-indexeddb/auto';
 import type { MountBackend } from '../../src/fs/mount/backend.js';
 import { RestrictedFS } from '../../src/fs/restricted-fs.js';
@@ -677,5 +677,99 @@ describe('RestrictedFS /tmp exemption', () => {
       /permission denied/
     );
     await expect(restricted.readTextFile('/tmpfoo/decoy.txt')).rejects.toThrow();
+  });
+});
+
+/** Per-test db name counter — descriptor state must not leak between cases. */
+let fdDbCounter = 0;
+
+describe('RestrictedFS ephemeral shell descriptors', () => {
+  let vfs: VirtualFS;
+  let restricted: RestrictedFS;
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({ dbName: `test-restricted-fs-fd-${fdDbCounter++}`, wipe: true });
+    await vfs.mkdir('/scoops/fd-scoop', { recursive: true });
+    restricted = new RestrictedFS(vfs, ['/scoops/fd-scoop/']);
+  });
+
+  it('accepts a descriptor write and reads the payload back', async () => {
+    await restricted.writeFile('/dev/fd/63', 'alpha\n');
+    expect(await restricted.readTextFile('/dev/fd/63')).toBe('alpha\n');
+    expect(await restricted.readFile('/dev/fd/63')).toBe('alpha\n');
+    expect(await restricted.readFile('/dev/fd/63', { encoding: 'binary' })).toEqual(
+      new TextEncoder().encode('alpha\n')
+    );
+  });
+
+  it('keeps each descriptor separate (diff needs both 63 and 62)', async () => {
+    await restricted.writeFile('/dev/fd/63', 'alpha');
+    await restricted.writeFile('/dev/fd/62', 'beta');
+    expect(await restricted.readTextFile('/dev/fd/63')).toBe('alpha');
+    expect(await restricted.readTextFile('/dev/fd/62')).toBe('beta');
+  });
+
+  it('never writes the descriptor into the shared tree', async () => {
+    await restricted.writeFile('/dev/fd/63', 'private');
+    expect(await vfs.exists('/dev/fd/63')).toBe(false);
+    expect(await vfs.exists('/dev')).toBe(false);
+  });
+
+  it('is private per sandbox — a sibling sees nothing', async () => {
+    const sibling = new RestrictedFS(vfs, ['/scoops/other-scoop/']);
+    await restricted.writeFile('/dev/fd/63', 'mine');
+    expect(await sibling.exists('/dev/fd/63')).toBe(false);
+    await expect(sibling.readTextFile('/dev/fd/63')).rejects.toThrow(/no such file/);
+  });
+
+  it('reports metadata for a live descriptor and ENOENT for an unopened one', async () => {
+    await restricted.writeFile('/dev/fd/63', 'abc');
+    expect(await restricted.stat('/dev/fd/63')).toMatchObject({ type: 'file', size: 3 });
+    expect(await restricted.lstat('/dev/fd/63')).toMatchObject({ type: 'file', size: 3 });
+    expect(restricted.statSync('/dev/fd/63')).toMatchObject({ type: 'file', size: 3 });
+    expect(restricted.lstatSync('/dev/fd/63')).toMatchObject({ type: 'file', size: 3 });
+    expect(await restricted.realpath('/dev/fd/63')).toBe('/dev/fd/63');
+    expect(await restricted.exists('/dev/fd/63')).toBe(true);
+
+    expect(await restricted.exists('/dev/fd/42')).toBe(false);
+    expect(restricted.statSync('/dev/fd/42')).toBeNull();
+    expect(restricted.lstatSync('/dev/fd/42')).toBeNull();
+    await expect(restricted.stat('/dev/fd/42')).rejects.toThrow(/no such file/);
+    await expect(restricted.readFile('/dev/fd/42')).rejects.toThrow(/no such file/);
+    await expect(restricted.realpath('/dev/fd/42')).rejects.toThrow(/no such file/);
+  });
+
+  it('releases a descriptor on rm and reports a missing one as ENOENT', async () => {
+    // Mirrors the VFS contract for a missing file. The interpreter's own
+    // release swallows it; `rm -f` never reaches this layer.
+    await restricted.writeFile('/dev/fd/63', 'abc');
+    await restricted.rm('/dev/fd/63');
+    expect(await restricted.exists('/dev/fd/63')).toBe(false);
+    await expect(restricted.rm('/dev/fd/63')).rejects.toThrow(/no such file/);
+  });
+
+  it('reports a descriptor as writable', () => {
+    expect(restricted.canWrite('/dev/fd/63')).toBe(true);
+  });
+
+  it('does not expose the descriptors as a directory', async () => {
+    await restricted.writeFile('/dev/fd/63', 'abc');
+    expect(await restricted.readDir('/dev/fd')).toEqual([]);
+    expect(await restricted.exists('/dev/fd')).toBe(false);
+    await expect(restricted.stat('/dev/fd')).rejects.toThrow(/no such file/);
+  });
+
+  it('does not extend the exemption to other /dev paths', async () => {
+    // Only numbered descriptors are exempt; `/dev/` at large stays gated so a
+    // future device path with observable effects is not silently writable.
+    await expect(restricted.writeFile('/dev/fd/name', 'nope')).rejects.toThrow(/permission denied/);
+    await expect(restricted.writeFile('/dev/sda', 'nope')).rejects.toThrow(/permission denied/);
+    expect(restricted.canWrite('/dev/fd/name')).toBe(false);
+  });
+
+  it('leaves /dev/null a no-op write with empty reads', async () => {
+    await expect(restricted.writeFile('/dev/null', 'discarded')).resolves.toBeUndefined();
+    expect(await restricted.readTextFile('/dev/null')).toBe('');
+    expect(await restricted.exists('/dev/null')).toBe(true);
   });
 });

--- a/packages/webapp/tests/shell/process-substitution-sandbox.test.ts
+++ b/packages/webapp/tests/shell/process-substitution-sandbox.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Cone/scoop equivalence for process substitution (`<(...)`, #2502).
+ *
+ * The guard that matters is EQUIVALENCE, not correctness in isolation: the cone
+ * has always worked, so a cone-only assertion passed for this bug's whole life.
+ * Every case here runs the same command twice — once against an unrestricted
+ * `VirtualFS` (the cone) and once against the production scoop stack
+ * (`RestrictedFS` in `sudo-delegated` mode wrapped in `SudoFS` with the
+ * non-cone `require-approval` default disposition) — and compares stdout and
+ * exit code.
+ *
+ * The broker assertion is the second half of the same bug: on 6.96.2 the scoop
+ * raised a cone `sudo` prompt for `write /dev/fd/63`, which stalls an
+ * unattended scoop indefinitely and which no "Always" grant can pre-empt
+ * because the fd number changes per invocation. Making the fds work while
+ * leaving a path that can still prompt would just restore that variant, so
+ * "the broker was never called" is asserted explicitly.
+ */
+
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { emptyPolicy, mergePolicies, parseSudoers } from '../../src/base/sudoers.js';
+import { VirtualFS } from '../../src/fs/index.js';
+import { RestrictedFS } from '../../src/fs/restricted-fs.js';
+import { createSudoFs } from '../../src/fs/sudo-fs.js';
+import { AlmostBashShellHeadless } from '../../src/shell/almost-bash-shell-headless.js';
+import type { SudoBroker } from '../../src/sudo/types.js';
+
+interface Harness {
+  cone: AlmostBashShellHeadless;
+  scoop: AlmostBashShellHeadless;
+  /** The scoop's underlying (cone-wide) VFS, for leak assertions. */
+  sharedFs: VirtualFS;
+  requestApproval: ReturnType<typeof vi.fn>;
+}
+
+let dbCounter = 0;
+
+/**
+ * Build a cone shell and a scoop shell over separate VFS instances.
+ *
+ * The scoop mirrors `ScoopLifecycleManager.createTab` + `initShellAndSkills`:
+ * writable `/scoops/probe/`, visible `/shared/`, `sudo-delegated` enforcement,
+ * and a `SudoFS` whose default disposition escalates unmatched writes. The
+ * broker would ALLOW if asked — a denying broker hides the bug, because the
+ * resulting `EACCES` makes just-bash fall back to its own private in-memory
+ * `/dev/fd` and the command then succeeds by accident.
+ */
+async function harness(): Promise<Harness> {
+  const coneFs = await VirtualFS.create({ dbName: `procsub-cone-${dbCounter++}`, wipe: true });
+  await coneFs.mkdir('/workspace', { recursive: true });
+
+  const sharedFs = await VirtualFS.create({ dbName: `procsub-scoop-${dbCounter++}`, wipe: true });
+  await sharedFs.mkdir('/scoops/probe/workspace', { recursive: true });
+  await sharedFs.mkdir('/shared', { recursive: true });
+
+  const requestApproval = vi.fn(async () => ({ decision: 'allow' as const }));
+  const restricted = new RestrictedFS(sharedFs, ['/scoops/probe/'], ['/shared/'], 'sudo-delegated');
+  const gated = createSudoFs(restricted, {
+    broker: { requestApproval } as unknown as SudoBroker,
+    getPolicy: () => mergePolicies(emptyPolicy(), parseSudoers('')),
+    defaultDisposition: 'require-approval',
+  }) as unknown as VirtualFS;
+
+  return {
+    cone: new AlmostBashShellHeadless({ fs: coneFs, cwd: '/workspace' }),
+    scoop: new AlmostBashShellHeadless({ fs: gated, cwd: '/scoops/probe/workspace' }),
+    sharedFs,
+    requestApproval,
+  };
+}
+
+describe('process substitution: cone/scoop equivalence', () => {
+  let h: Harness;
+
+  beforeEach(async () => {
+    h = await harness();
+  });
+
+  it.each([
+    [
+      'one substitution consumed by cat',
+      'cat <(echo hello-from-procsub)',
+      'hello-from-procsub\n',
+      0,
+    ],
+    ['two substitutions consumed by diff', 'diff <(echo alpha) <(echo beta)', undefined, 1],
+    [
+      'a substitution whose path is echoed back',
+      'wc -l <(echo one; echo two)',
+      '2 /dev/fd/63\n',
+      0,
+    ],
+  ])('%s matches the cone', async (_name, command, stdout, exitCode) => {
+    const cone = await h.cone.executeCommand(command);
+    const scoop = await h.scoop.executeCommand(command);
+
+    expect(scoop.stdout).toBe(cone.stdout);
+    expect(scoop.exitCode).toBe(cone.exitCode);
+    expect(scoop.stderr).toBe('');
+    expect(scoop.exitCode).toBe(exitCode);
+    if (stdout !== undefined) expect(scoop.stdout).toBe(stdout);
+  });
+
+  it('diff exercises the SECOND descriptor, not just /dev/fd/63', async () => {
+    // A fix that only materializes the first fd passes a one-substitution test.
+    const scoop = await h.scoop.executeCommand('diff <(echo alpha) <(echo beta)');
+    expect(scoop.stdout).toContain('--- /dev/fd/63');
+    expect(scoop.stdout).toContain('+++ /dev/fd/62');
+    expect(scoop.stdout).toContain('-alpha');
+    expect(scoop.stdout).toContain('+beta');
+    expect(scoop.exitCode).toBe(1);
+  });
+
+  it('never asks for a sudo approval (the 6.96.2 stall variant)', async () => {
+    for (const command of [
+      'cat <(echo hi)',
+      'diff <(echo alpha) <(echo beta)',
+      'wc -l <(echo one; echo two)',
+    ]) {
+      await h.scoop.executeCommand(command);
+    }
+    expect(h.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it('a descriptor write is readable back, never a silent discard', async () => {
+    // Producer and consumer are separate code paths: the write used to report
+    // exit 0 while the payload landed outside the sandbox, and the read of the
+    // very same path then said ENOENT.
+    const written = await h.scoop.executeCommand('echo probe > /dev/fd/63');
+    const read = await h.scoop.executeCommand('cat /dev/fd/63');
+
+    expect(written).toMatchObject({ exitCode: 0, stderr: '' });
+    expect(read).toMatchObject({ exitCode: 0, stdout: 'probe\n' });
+    expect(h.requestApproval).not.toHaveBeenCalled();
+
+    const cone = await h.cone.executeCommand('echo probe > /dev/fd/63');
+    expect(cone.exitCode).toBe(written.exitCode);
+    expect((await h.cone.executeCommand('cat /dev/fd/63')).stdout).toBe(read.stdout);
+  });
+
+  it('a descriptor that was never written fails loudly', async () => {
+    const result = await h.scoop.executeCommand('cat /dev/fd/42');
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('/dev/fd/42');
+  });
+
+  it.each([['rm /dev/fd/42'], ['rm -f /dev/fd/42'], ['rm /dev/fd/63']])(
+    '%s behaves as it does in the cone',
+    async (command) => {
+      // The release path: `rm` of an unopened descriptor, with and without -f.
+      const cone = await h.cone.executeCommand(command);
+      const scoop = await h.scoop.executeCommand(command);
+      expect(scoop.exitCode).toBe(cone.exitCode);
+      expect(scoop.stdout).toBe(cone.stdout);
+      expect(h.requestApproval).not.toHaveBeenCalled();
+    }
+  );
+
+  it('leaves no descriptor behind in the shared filesystem', async () => {
+    await h.scoop.executeCommand('cat <(echo hi)');
+    await h.scoop.executeCommand('echo probe > /dev/fd/63');
+    // The sandbox's descriptors are private: nothing lands at /dev/fd in the
+    // VFS the cone and sibling scoops share.
+    expect(await h.sharedFs.exists('/dev/fd/63')).toBe(false);
+    expect(await h.sharedFs.exists('/dev')).toBe(false);
+  });
+
+  it('does not turn /dev into a listable directory in the sandbox', async () => {
+    await h.scoop.executeCommand('cat <(echo hi)');
+    for (const command of ['ls -la /dev/', 'ls -la /dev/fd/']) {
+      const result = await h.scoop.executeCommand(command);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stdout).toBe('');
+    }
+  });
+
+  it('keeps /dev/null a no-op write in the sandbox', async () => {
+    const result = await h.scoop.executeCommand('echo x > /dev/null');
+    expect(result).toMatchObject({ exitCode: 0, stdout: '', stderr: '' });
+    expect(h.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it('still gates an ordinary out-of-sandbox write', async () => {
+    // The exemption is descriptor-shaped, not a hole in the sandbox.
+    await h.scoop.executeCommand('echo nope > /elsewhere/file.txt');
+    expect(h.requestApproval).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'write', detail: '/elsewhere/file.txt' })
+    );
+  });
+});

--- a/packages/webapp/tests/shell/process-substitution-sandbox.test.ts
+++ b/packages/webapp/tests/shell/process-substitution-sandbox.test.ts
@@ -19,11 +19,12 @@
 
 import 'fake-indexeddb/auto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { emptyPolicy, mergePolicies, parseSudoers } from '../../src/base/sudoers.js';
+import { builtinScoopGrants, mergePolicies, parseSudoers } from '../../src/base/sudoers.js';
 import { VirtualFS } from '../../src/fs/index.js';
 import { RestrictedFS } from '../../src/fs/restricted-fs.js';
 import { createSudoFs } from '../../src/fs/sudo-fs.js';
 import { AlmostBashShellHeadless } from '../../src/shell/almost-bash-shell-headless.js';
+import { generateScoopSudoers } from '../../src/sudo/sudo-manager.js';
 import type { SudoBroker } from '../../src/sudo/types.js';
 
 interface Harness {
@@ -55,10 +56,21 @@ async function harness(): Promise<Harness> {
   await sharedFs.mkdir('/shared', { recursive: true });
 
   const requestApproval = vi.fn(async () => ({ decision: 'allow' as const }));
-  const restricted = new RestrictedFS(sharedFs, ['/scoops/probe/'], ['/shared/'], 'sudo-delegated');
+  const config = { writablePaths: ['/scoops/probe/'], visiblePaths: ['/shared/'] };
+  const restricted = new RestrictedFS(
+    sharedFs,
+    [...config.writablePaths],
+    [...config.visiblePaths],
+    'sudo-delegated'
+  );
+  // Mirror `SudoManager.getPolicyForScoop`: the built-in `/tmp` grants plus the
+  // config-derived sandbox grants. Compiling the REAL grants matters — under a
+  // bare policy every in-sandbox write prompts as well, which would mask which
+  // operation a descriptor case is actually responsible for.
+  const policy = mergePolicies(builtinScoopGrants(), parseSudoers(generateScoopSudoers(config)));
   const gated = createSudoFs(restricted, {
     broker: { requestApproval } as unknown as SudoBroker,
-    getPolicy: () => mergePolicies(emptyPolicy(), parseSudoers('')),
+    getPolicy: () => policy,
     defaultDisposition: 'require-approval',
   }) as unknown as VirtualFS;
 
@@ -153,6 +165,35 @@ describe('process substitution: cone/scoop equivalence', () => {
       const scoop = await h.scoop.executeCommand(command);
       expect(scoop.exitCode).toBe(cone.exitCode);
       expect(scoop.stdout).toBe(cone.stdout);
+      expect(h.requestApproval).not.toHaveBeenCalled();
+    }
+  );
+
+  it('cp consumes a substitution as its source, like the cone', async () => {
+    // `cp` reaches `copyFile`, a different consumer path from the `cat`/`diff`
+    // open — a descriptor has to work as either end of a copy.
+    const command = 'cp <(echo copied-payload) ./out.txt && cat ./out.txt';
+    const cone = await h.cone.executeCommand(command);
+    const scoop = await h.scoop.executeCommand(command);
+    expect(scoop.stdout).toBe(cone.stdout);
+    expect(scoop.stdout).toBe('copied-payload\n');
+    expect(scoop.exitCode).toBe(0);
+    expect(h.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it.each([['mkdir -p /dev/fd/63'], ['mv ./src.txt /dev/fd/63'], ['ln -s ./src.txt /dev/fd/63']])(
+    '%s cannot materialize a shared-tree entry, and never prompts',
+    async (command) => {
+      // The exemption covers a content write and the read back, not tree shape.
+      // Under `sudo-delegated` enforcement these would otherwise fall through to
+      // the SHARED VirtualFS and create the cone-visible `/dev/fd` the private
+      // store exists to prevent.
+      await h.scoop.executeCommand('echo x > ./src.txt');
+      const result = await h.scoop.executeCommand(command);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(await h.sharedFs.exists('/dev/fd/63')).toBe(false);
+      expect(await h.sharedFs.exists('/dev')).toBe(false);
       expect(h.requestApproval).not.toHaveBeenCalled();
     }
   );


### PR DESCRIPTION
## Summary

Process substitution (`<(cmd)` / `>(cmd)`) worked in the cone and was broken inside a scoop: the consuming command failed with `ENOENT` on `/dev/fd/63`, and a bare redirect to the same path reported exit 0 while the payload became unreachable. Descriptors are now answered by the sandbox itself, in both gating layers, so a scoop's output matches the cone's byte for byte and no approval prompt is ever raised.

Fixes #2502.

## Root cause as actually found (measured, not inferred)

I reproduced all four symptoms in a test harness shaped like the production scoop stack (`RestrictedFS` in `sudo-delegated` mode wrapped in `SudoFS` with the non-cone `require-approval` default), and the localisation matches the issue's updated comment: **the block is the write-permission decision, not materialization.**

just-bash models a substitution on a real backing file at `/dev/fd/<n>` (`interpreter/process-substitution.ts`) — the body's stdout is written there during word expansion, the outer command reads the path back, and the entry is released when the command ends. So yes, it genuinely writes a VFS file; it does not merely *name* the path.

- **Cone:** the write hits an unrestricted `VirtualFS`, which auto-creates parents, so `/dev/fd/63` is an ordinary file and the read works.
- **Scoop:** `RestrictedFS` in `sudo-delegated` mode makes `checkWrite` a no-op, so the decision falls to `SudoFS`, whose `require-approval` default has no rule to match → **a cone approval for `write /dev/fd/63`**. Once permitted, the write passes *through* to the shared tree, at a path outside the scoop's grants, and `RestrictedFS` then filters the consumer's open back to `ENOENT`. That is both reported symptoms from one cause, and it explains the write/read asymmetry exactly: the producer's write succeeded (somewhere the scoop cannot see), the consumer's open was walled.

Two findings worth recording:

1. **A denying broker hides the bug.** just-bash self-heals — if the descriptor write *throws*, it mounts a private in-memory FS at `/dev/fd` and retries (`processSubstitutionFsMounted`, designed for read-only sandboxes). So a scoop whose approval is denied or times out ends up working *by accident*, ~5 minutes late. Only the permitted path fails. My first probe passed for this reason; a test written with a denying broker would be worthless as a guard.
2. **Any code path that can still prompt is a live bug**, not just an annoyance: I reproduced 1–2 broker calls *per command* (`/dev/fd/63` and `/dev/fd/62` separately), which is the 6.96.2 stall variant.

## What changed

Both gating layers had to agree — this is the failure mode the `ALWAYS_WRITABLE_PREFIXES` comment already predicted ("either re-introduces the approval prompt or walls the write underneath it").

- **`fs/virtual-device-paths.ts`** — new `isEphemeralFdPath()` predicate (`/dev/fd/<n>`, numbered descriptors only). A deliberate **sibling** of `NO_OP_WRITE_DEVICE_PATHS`, explicitly *not* a member: a descriptor's payload is read back by the consuming command, so discarding it would turn `cat <(echo hi)` from an error into silently empty output. The module still imports nothing, so the pure sudoers matcher can use it.
- **`base/sudoers.ts`** — `matchPath` resolves an ephemeral descriptor to `nopasswd-allow` for **both** ops, before any rule is consulted, so the `require-approval` default disposition can never escalate one. Self-protection is still checked first and stays absolute.
- **`fs/ephemeral-fd-store.ts`** (new) — a private, in-memory byte store; one instance per `RestrictedFS`. Backs read / readText / write / stat / lstat / statSync / lstatSync / exists / realpath / rm for descriptor paths, beside the tree rather than in it.
- **`fs/restricted-fs.ts`** — descriptor paths route to that store. `canWrite` reports them as writable so the predicate stays honest about what `writeFile` accepts.
- **`docs/approvals.md`** — new "Ephemeral shell descriptors — `/dev/fd/<n>` (never gated)" section next to the `/tmp` grant, documenting the two-layer rule and the private/ephemeral semantics. The three touched source doc comments (`virtual-device-paths.ts`, the `ALWAYS_WRITABLE_PREFIXES` block, `matchPath`) were updated to match, since a stale comment here is what makes this area easy to break.

Explicitly **not** done: `/dev/fd/*` was not added to `NO_OP_WRITE_DEVICE_PATHS` or `VIRTUAL_DEVICES`, and `ALWAYS_WRITABLE_PREFIXES` was not widened to `/dev/` (that would permit writes to any future device path, including ones with observable effects, and would resolve them against the shared tree).

## Why the sandbox posture is unchanged

- The path is minted by the shell for the duration of one command, not named by the agent.
- Its read end is the same pipeline, so it is not an exfiltration channel out of the sandbox.
- It is not addressable across commands, scoops or turns: the store is per-`RestrictedFS` and private, and **nothing is written to `/dev/fd` in the shared VFS** — asserted in tests. This is strictly *tighter* than the previous behaviour, where a permitted descriptor write landed in the shared tree where the cone and sibling scoops could see and clobber it.
- A scoop can already express the identical data flow with a temp file under `/tmp/`, which is unconditionally writable — so gating `<(...)` bought no containment, it only broke the ergonomic spelling.
- `/dev` and `/dev/fd` remain non-existent in a scoop's view: no listing, no `stat`, no `readDir` entry. Nothing materializes a real, listable `/dev/fd/` directory.
- Only numbered descriptors are exempt: `/dev/fd/name`, `/dev/fd`, `/dev/fdx/63` and `/dev/sda` all still gate normally, and an ordinary out-of-sandbox write still escalates (both asserted).
- `/dev/null` semantics are untouched, and the cone is untouched — every equivalence case compares scoop output *against a live cone run* in the same test.

## Before/after (default scoop sandbox)

| command | before | after |
| --- | --- | --- |
| `cat <(echo hello-from-procsub)` | `cat: /dev/fd/63: No such file or directory`, exit 1, **+1 sudo prompt** | `hello-from-procsub`, exit 0, no prompt |
| `diff <(echo alpha) <(echo beta)` | `diff: /dev/fd/63: No such file or directory`, exit 2, **+2 sudo prompts** (`/dev/fd/63`, `/dev/fd/62`) | `--- /dev/fd/63` / `+++ /dev/fd/62` / `-alpha` / `+beta`, exit 1, no prompt |
| `wc -l <(echo one; echo two)` | `wc: /dev/fd/63: No such file or directory`, exit 1, **+1 sudo prompt** | `2 /dev/fd/63`, exit 0, no prompt |
| `echo probe > /dev/fd/63` then `cat /dev/fd/63` | exit 0 (payload landed outside the sandbox), then `cat: /dev/fd/63: No such file or directory`, exit 1 | exit 0, then `probe`, exit 0, no prompt |
| `ls -la /dev/` · `ls -la /dev/fd/` | `No such file or directory`, exit 2 | unchanged (`No such file or directory`, exit 2) |
| `echo x > /dev/null` | exit 0 | unchanged (exit 0) |

Cone output for every row above is identical before and after.

## How it was tested

New `packages/webapp/tests/shell/process-substitution-sandbox.test.ts` (14 cases) is the guard that matters: each case runs the command **twice** — once on an unrestricted cone `VirtualFS`, once on the production scoop stack — and compares stdout and exit code, because a cone-only test would have passed for this bug's entire life. It covers one substitution via `cat`, two via `diff` (asserting `/dev/fd/62` specifically, so a first-fd-only fix fails), one via `wc -l`, the write→read pair, `rm` / `rm -f` of an unopened descriptor, the no-leak-into-the-shared-VFS assertion, `/dev` still not listable, `/dev/null` still a no-op, an out-of-sandbox write still gating, and **`expect(requestApproval).not.toHaveBeenCalled()`**. The broker is wired to *allow* on purpose — a denying broker makes the bug disappear behind just-bash's self-heal.

I verified the guards by reverting only the `src/` changes and re-running: **7 of 14 fail**, including all three command shapes and the no-approval assertion. Also added `tests/fs/ephemeral-fd-store.test.ts` (9 cases: predicate boundaries, byte/text round-trip, no mutable view of stored bytes, normalization, ENOENT for an unopened descriptor), 10 `RestrictedFS` cases (per-sandbox isolation, metadata surfaces, no tree leak, exemption does not extend to other `/dev` paths, `/dev/null` intact) and 15 `matchPath` invariant cases.

Full pass, all green on this branch: `npm run verify` (7/7), `check-touched-exemptions.mjs`, `npm run typecheck`, `npm run test` (17,290 passed), `npm run test:coverage`, `npm run build`, `npm run build -w @slicc/chrome-extension`, `npm run bundle-size`.

## Deliberately left out

- **`packages/webapp/CLAUDE.md` was not touched.** It sits at 19,998/20,000 chars, so the `/tmp` never-rule could not be extended to mention `/dev/fd` without trimming unrelated content. The invariant is documented in `docs/approvals.md` and in the source doc comments on both gating layers instead.
- **No upstream change to just-bash.** The self-heal fallback stays as-is; this fix means the sandbox no longer needs it.
- **A cone/scoop divergence is retained on purpose:** the cone lists a live descriptor under `ls /dev/fd` (it is a real file there), a scoop does not. Making a scoop list them would mean materializing a real `/dev/fd/` directory, which #2502 explicitly asks not to do; the reverse (hiding them in the cone) would change cone behaviour, which it also asks not to do.
- No change to `docs/shell-reference.md`: it does not document `<(...)` today (grep finds no mention), so there was nothing to correct.
