### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/fs/mount/profile.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -2,7 +2,6 @@
   "packages/webapp/src/cdp/har-recorder.ts": 1,
   "packages/webapp/src/fs/mount-picker-popup.ts": 2,
   "packages/webapp/src/fs/mount/backend-local.ts": 2,
-  "packages/webapp/src/fs/mount/profile.ts": 1,
   "packages/webapp/src/shell/bsh-watchdog.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/hid-command.ts": 1,

--- a/packages/webapp/src/fs/mount/profile.ts
+++ b/packages/webapp/src/fs/mount/profile.ts
@@ -12,7 +12,7 @@
  * Profile name is accepted for symmetry but only `default` has meaning.
  */
 
-import { apiHeaders, resolveApiUrl } from '../../shell/proxied-fetch.js';
+import { apiHeaders, resolveApiUrl } from '../../base/api-endpoint.js';
 
 /**
  * The minimal SecretStore surface this module needs. Any concrete store


### PR DESCRIPTION
## Summary

- Removed the `fs → shell` layer back-edge in `profile.ts` by importing `apiHeaders` and `resolveApiUrl` from `base/api-endpoint.js` instead of `shell/proxied-fetch.js` (same helpers, already used by sibling mount modules).
- Ratcheted `layer-back-edge-baseline.json` (removed the grandfathered entry for this file).

## Debt cleared

- **layer-back-edge**: `packages/webapp/src/fs/mount/profile.ts`

## Verification

- `npx biome check --write packages/webapp/src/fs/mount/profile.ts`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/fs/mount/profile.test.ts`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`
- `node packages/dev-tools/tools/check-layer-back-edges.mjs --update`