### PR TITLE
fix(webapp): give VFS stats an inode identity so `split` can commit

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -371,6 +371,49 @@ All paths in VirtualFS must follow these rules:
 
 **Normalization**: Use `normalizePath(path)` from `packages/webapp/src/fs/path-utils.ts` before any VFS operation.
 
+## Stat Identity: A File Is Not Its Path
+
+**Files**: `packages/webapp/src/fs/types.ts` (`Stats.ino`),
+`packages/webapp/src/fs/virtual-fs.ts`, `packages/webapp/src/shell/vfs-adapter.ts`
+(`toIdentity`).
+
+`Stats` carries an optional **`ino`**, and `VfsAdapter` forwards it to just-bash
+as `FsStat.identity`. It is not decoration: several just-bash commands run as
+transactions — stage every output, re-identify the input and the outputs, then
+commit — and `identitiesMatch()` **fails closed** for an existing entry with no
+identity:
+
+```js
+e.existence === 'existing'
+  ? e.stableIdentity !== undefined && e.stableIdentity === t.stableIdentity
+  : ...
+```
+
+`undefined !== undefined` is `false`, so a missing identity does not degrade to a
+path comparison — it reads as "this file changed under me". While the adapter
+returned no `dev`/`ino`/`identity`, `split FILE PREFIX` therefore threw
+`input identity changed during split` against a file nothing had touched, rolled
+its staged chunks back, and printed only the generic `split: failed to write
+output`. Every size, every path, every time; the stdin form (`split -b N -
+PREFIX`) worked, because there is no input file to re-identify.
+
+Consequences for anyone touching this layer:
+
+- **Never drop `ino` when reshaping a `Stats`.** All four VFS surfaces
+  (`stat`, `lstat`, `statSync`, `lstatSync`) carry it, and `RestrictedFS` passes
+  `Stats` through untouched — a new wrapper that rebuilds the object by hand is
+  how this silently comes back.
+- **Inode 0 is deliberately unnamed.** ZenFS pins `/` to 0, and a sidecar
+  poisoned the way #2146 describes hands out 0 for many entries until the
+  pre-boot repair renumbers them. A collided identity is worse than none.
+- **Mount-backed subtrees have no identity.** hostfs and the remote backends
+  expose `{kind, size, mtime}` and nothing inode-shaped, so `split` on a path
+  under a mount still fails this way. Synthesizing a token from the path would
+  claim a guarantee the backend cannot keep; the fix belongs in the backends.
+- `identity` rather than `dev` + `ino`: just-bash accepts the inode pair only
+  when both halves are present, and one adapter can span backends whose inode
+  spaces are unrelated — there is no honest single `dev`.
+
 ## OPFS Writes: Serialize Per Mount, Across Contexts
 
 **Files**: `packages/webapp/src/fs/virtual-fs.ts` (`withWriteLock`),

--- a/packages/webapp/src/fs/types.ts
+++ b/packages/webapp/src/fs/types.ts
@@ -23,6 +23,19 @@ export interface Stats {
   isSymlink?: boolean;
   /** Raw symlink target path (only set when isSymlink is true). */
   symlinkTarget?: string;
+  /**
+   * Backing inode number, when the backend can name one. ZenFS allocates a
+   * unique `ino` per entry that survives rewrites, so it is the one field
+   * that distinguishes "the same file" from "the same path" — which is what
+   * TOCTOU-hardened commands need (`split` refuses to commit unless the
+   * input it read is still the file it identified; without an inode it
+   * cannot tell and fails closed — see `shell/vfs-adapter.ts#toIdentity`).
+   *
+   * Absent for mount-backed subtrees (hostfs and the remote backends expose
+   * only `{kind, size, mtime}`) and for the synthetic `/dev` entries, so
+   * consumers must treat it as best-effort, never as a required key.
+   */
+  ino?: number;
 }
 
 /** A single entry returned by readDir. */
@@ -97,6 +110,8 @@ export interface FsStatsLike {
   mode: number;
   mtimeMs: number;
   ctimeMs: number;
+  /** Inode number. Optional: LightningFS' legacy shape omits it, ZenFS sets it. */
+  ino?: number;
   isFile(): boolean;
   isDirectory(): boolean;
   isSymbolicLink(): boolean;

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -1232,6 +1232,7 @@ export class VirtualFS {
           size: s.size,
           mtime: s.mtimeMs,
           ctime: s.ctimeMs,
+          ino: s.ino,
         };
       } catch {
         return null;
@@ -1256,6 +1257,7 @@ export class VirtualFS {
           size: s.size,
           mtime: s.mtimeMs,
           ctime: s.ctimeMs,
+          ino: s.ino,
         };
       }
       let target: string;
@@ -1290,6 +1292,7 @@ export class VirtualFS {
           ctime: s.ctimeMs,
           isSymlink: true,
           symlinkTarget: target,
+          ino: s.ino,
         };
       }
       return {
@@ -1297,6 +1300,7 @@ export class VirtualFS {
         size: s.size,
         mtime: s.mtimeMs,
         ctime: s.ctimeMs,
+        ino: s.ino,
       };
     } catch {
       return null;
@@ -2187,6 +2191,7 @@ export class VirtualFS {
         size: s.size,
         mtime: s.mtimeMs,
         ctime: s.ctimeMs,
+        ino: s.ino,
       };
     } catch (err) {
       throw convertError(err, normalized);
@@ -2457,6 +2462,7 @@ export class VirtualFS {
           ctime: s.ctimeMs,
           isSymlink: true,
           symlinkTarget: target,
+          ino: s.ino,
         };
       }
       return {
@@ -2464,6 +2470,7 @@ export class VirtualFS {
         size: s.size,
         mtime: s.mtimeMs,
         ctime: s.ctimeMs,
+        ino: s.ino,
       };
     } catch (err) {
       throw convertError(err, normalized);

--- a/packages/webapp/src/shell/vfs-adapter.ts
+++ b/packages/webapp/src/shell/vfs-adapter.ts
@@ -48,6 +48,35 @@ interface DirentEntry {
   isSymbolicLink: boolean;
 }
 
+/**
+ * Map a VFS inode onto just-bash's optional `FsStat.identity` — the token it
+ * uses to decide whether two stats name the same file rather than the same path.
+ *
+ * Commands that mutate through a staging file re-identify their inputs and
+ * outputs before committing, and `identitiesMatch()` fails closed for an
+ * EXISTING entry whose identity is `undefined`:
+ *
+ *     e.existence === "existing"
+ *       ? e.stableIdentity !== undefined && e.stableIdentity === t.stableIdentity
+ *       : ...
+ *
+ * With no identity that comparison is `undefined !== undefined` → `false`, so
+ * `split FILE PREFIX` threw `input identity changed during split` against a
+ * file nothing had touched, rolled its staged chunks back, and reported the
+ * generic `split: failed to write output`. It could never succeed in SLICC.
+ * (`split - PREFIX` reading stdin was unaffected: no input file to re-identify.)
+ *
+ * `identity` rather than `dev`/`ino`: just-bash only accepts the inode pair
+ * when BOTH halves are present, and one VfsAdapter can span several backends
+ * whose inode spaces are unrelated — there is no honest single `dev`. Only
+ * positive inodes qualify: ZenFS pins `/` to 0, and a sidecar poisoned the way
+ * #2146 describes can hand out 0 for many entries before the pre-boot repair
+ * re-numbers them. A collided identity is worse than none, so 0 stays absent.
+ */
+function toIdentity(ino: number | undefined): string | undefined {
+  return typeof ino === 'number' && Number.isInteger(ino) && ino > 0 ? `vfs-ino:${ino}` : undefined;
+}
+
 export class VfsAdapter implements IFileSystem {
   private registeredCommandsFn: (() => string[]) | null = null;
 
@@ -315,6 +344,7 @@ export class VfsAdapter implements IFileSystem {
           mode: fast.type === 'directory' ? 0o755 : 0o644,
           size: fast.size,
           mtime: new Date(fast.mtime),
+          identity: toIdentity(fast.ino),
         };
       }
       const s = await this.vfs.stat(normalized);
@@ -325,6 +355,7 @@ export class VfsAdapter implements IFileSystem {
         mode: s.type === 'directory' ? 0o755 : 0o644,
         size: s.size,
         mtime: new Date(s.mtime),
+        identity: toIdentity(s.ino),
       };
     });
   }
@@ -347,6 +378,7 @@ export class VfsAdapter implements IFileSystem {
           mode: fast.type === 'directory' ? 0o755 : fast.type === 'symlink' ? 0o777 : 0o644,
           size: fast.size,
           mtime: new Date(fast.mtime),
+          identity: toIdentity(fast.ino),
         };
       }
       const s = await this.vfs.lstat(normalized);
@@ -357,6 +389,7 @@ export class VfsAdapter implements IFileSystem {
         mode: s.type === 'directory' ? 0o755 : s.type === 'symlink' ? 0o777 : 0o644,
         size: s.size,
         mtime: new Date(s.mtime),
+        identity: toIdentity(s.ino),
       };
     });
   }

--- a/packages/webapp/tests/fs/virtual-fs-inode.test.ts
+++ b/packages/webapp/tests/fs/virtual-fs-inode.test.ts
@@ -1,0 +1,77 @@
+/**
+ * `Stats.ino` — the one field that tells "the same file" from "the same path".
+ *
+ * VirtualFS reported `{type, size, mtime, ctime}` and dropped the inode ZenFS
+ * had already allocated. Path was therefore the only identity the layers above
+ * could see, which silently disarmed every consumer that re-identifies a file
+ * before committing to it — see `tests/shell/split-inode-identity.test.ts` for
+ * the command this actually broke.
+ *
+ * Mount-backed subtrees stay identity-less on purpose: hostfs and the remote
+ * backends expose `{kind, size, mtime}` and nothing inode-shaped, and inventing
+ * a token that only encodes the path would claim a guarantee we cannot keep.
+ */
+import 'fake-indexeddb/auto';
+import { describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../src/fs/index.js';
+
+let dbCounter = 0;
+
+async function makeFs(): Promise<VirtualFS> {
+  const fs = await VirtualFS.create({ dbName: `vfs-inode-${dbCounter++}`, wipe: true });
+  await fs.mkdir('/workspace', { recursive: true });
+  await fs.writeFile('/workspace/a.txt', 'aaa');
+  await fs.writeFile('/workspace/b.txt', 'bbb');
+  return fs;
+}
+
+describe('VirtualFS — inode identity', () => {
+  it('stat reports an inode for a regular file', async () => {
+    const fs = await makeFs();
+    const st = await fs.stat('/workspace/a.txt');
+    expect(st.ino).toBeGreaterThan(0);
+  });
+
+  it('gives two different files two different inodes', async () => {
+    const fs = await makeFs();
+    const [a, b] = [await fs.stat('/workspace/a.txt'), await fs.stat('/workspace/b.txt')];
+    expect(a.ino).not.toBe(b.ino);
+  });
+
+  it('keeps the inode stable across a rewrite — same file, new contents', async () => {
+    const fs = await makeFs();
+    const before = await fs.stat('/workspace/a.txt');
+    await fs.writeFile('/workspace/a.txt', 'a much longer body than before');
+    const after = await fs.stat('/workspace/a.txt');
+    expect(after.ino).toBe(before.ino);
+    expect(after.size).not.toBe(before.size);
+  });
+
+  it('agrees between the async and the sync fast path', async () => {
+    const fs = await makeFs();
+    const async = await fs.stat('/workspace/a.txt');
+    expect(fs.statSync('/workspace/a.txt')?.ino).toBe(async.ino);
+  });
+
+  it('agrees between stat and lstat on a non-symlink', async () => {
+    const fs = await makeFs();
+    const [st, lst] = [await fs.stat('/workspace/a.txt'), await fs.lstat('/workspace/a.txt')];
+    expect(lst.ino).toBe(st.ino);
+    expect(fs.lstatSync('/workspace/a.txt')?.ino).toBe(st.ino);
+  });
+
+  it('distinguishes a symlink from its target — lstat is not stat', async () => {
+    const fs = await makeFs();
+    await fs.symlink('/workspace/a.txt', '/workspace/link.txt');
+    const link = await fs.lstat('/workspace/link.txt');
+    const target = await fs.stat('/workspace/link.txt');
+    expect(link.type).toBe('symlink');
+    expect(target.ino).toBe((await fs.stat('/workspace/a.txt')).ino);
+    expect(link.ino).not.toBe(target.ino);
+  });
+
+  it('reports a directory inode too', async () => {
+    const fs = await makeFs();
+    expect((await fs.stat('/workspace')).ino).toBeGreaterThan(0);
+  });
+});

--- a/packages/webapp/tests/shell/split-inode-identity.test.ts
+++ b/packages/webapp/tests/shell/split-inode-identity.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression guard: `split FILE PREFIX` could never succeed in SLICC.
+ *
+ * just-bash runs `split` as a transaction — every chunk is written to a hidden
+ * staging file, then the input and the outputs are re-identified, and only then
+ * are the staged files moved into place. The re-check calls `identitiesMatch()`,
+ * which fails closed when an EXISTING entry has no stable identity:
+ *
+ *     e.existence === "existing"
+ *       ? e.stableIdentity !== undefined && e.stableIdentity === t.stableIdentity
+ *       : ...
+ *
+ * `VfsAdapter.stat()` returned no `dev`/`ino`/`identity`, so `stableIdentity`
+ * was always `undefined`, the comparison was `undefined !== undefined` → false,
+ * and split threw `input identity changed during split` against a file nothing
+ * had touched. The rollback removed every staged chunk and reported the generic:
+ *
+ *     $ split -b 30000 IN706358.b64 chunk_
+ *     split: failed to write output
+ *     $ ls chunk_*
+ *     ls: chunk_*: No such file or directory
+ *
+ * Size-independent and reproducible on any file. The stdin form
+ * (`split -b N - PREFIX`) always worked — no input file to re-identify — which
+ * is why it is pinned here too: it is the workaround, and the fix must not
+ * trade one form for the other.
+ */
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../src/shell/almost-bash-shell-headless.js';
+import { VfsAdapter } from '../../src/shell/vfs-adapter.js';
+
+let dbCounter = 0;
+let vfs: VirtualFS;
+let shell: AlmostBashShellHeadless;
+
+// 129_200 bytes — the length of the base64 payload from the field report, so
+// the chunk arithmetic below matches what a real caller saw.
+const BODY = 'A'.repeat(129_200);
+
+/** Names under /workspace with the given prefix. Read from the VFS rather than
+ *  parsed out of `ls`, so the guard cannot drift with `ls`' formatting. */
+async function named(prefix: string): Promise<string[]> {
+  const entries = await vfs.readDir('/workspace');
+  return entries
+    .map((e) => e.name)
+    .filter((n) => n.startsWith(prefix))
+    .sort();
+}
+
+beforeEach(async () => {
+  vfs = await VirtualFS.create({ dbName: `split-identity-${dbCounter++}`, wipe: true });
+  await vfs.mkdir('/workspace', { recursive: true });
+  await vfs.writeFile('/workspace/payload.b64', BODY);
+  shell = new AlmostBashShellHeadless({ fs: vfs });
+});
+
+describe('split — file form', () => {
+  it('writes its chunks instead of rolling them back', async () => {
+    const r = await shell.executeCommand('cd /workspace && split -b 30000 payload.b64 chunk_');
+    expect(r.stderr).not.toContain('failed to write output');
+    expect(r.exitCode).toBe(0);
+    // ceil(129200 / 30000) = 5
+    expect(await named('chunk_')).toEqual([
+      'chunk_aa',
+      'chunk_ab',
+      'chunk_ac',
+      'chunk_ad',
+      'chunk_ae',
+    ]);
+    expect((await vfs.stat('/workspace/chunk_aa')).size).toBe(30000);
+    expect((await vfs.stat('/workspace/chunk_ae')).size).toBe(129200 - 4 * 30000);
+  });
+
+  it('reassembles to the original byte-for-byte', async () => {
+    const r = await shell.executeCommand(
+      'cd /workspace && split -b 30000 payload.b64 chunk_ && cat chunk_* > rejoined.b64'
+    );
+    expect(r.exitCode).toBe(0);
+    expect(await vfs.readTextFile('/workspace/rejoined.b64')).toBe(BODY);
+  });
+
+  it('leaves the input untouched', async () => {
+    await shell.executeCommand('cd /workspace && split -b 30000 payload.b64 chunk_');
+    expect(await vfs.readTextFile('/workspace/payload.b64')).toBe(BODY);
+  });
+
+  it('still refuses to overwrite its own input', async () => {
+    // The identity plumbing feeds this check — it must not weaken it. `xab` is
+    // the classic collision: splitting it with the default prefix `x` would
+    // emit `xaa`, `xab`, … and the second output IS the input.
+    await vfs.writeFile('/workspace/xab', 'A'.repeat(200));
+    const r = await shell.executeCommand('cd /workspace && split -b 100 xab');
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('would overwrite input');
+    expect(await vfs.readTextFile('/workspace/xab')).toBe('A'.repeat(200));
+    expect(await named('xa')).toEqual(['xab']);
+  });
+});
+
+describe('split — stdin form (the workaround, still intact)', () => {
+  it('writes its chunks', async () => {
+    const r = await shell.executeCommand(
+      'cd /workspace && cat payload.b64 | split -b 30000 - piped_'
+    );
+    expect(r.exitCode).toBe(0);
+    expect(await named('piped_')).toHaveLength(5);
+  });
+});
+
+describe('VfsAdapter — stat identity', () => {
+  it('names the file, not the path', async () => {
+    const adapter = new VfsAdapter(vfs);
+    await vfs.writeFile('/workspace/other.b64', 'other');
+    const a = await adapter.stat('/workspace/payload.b64');
+    const b = await adapter.stat('/workspace/other.b64');
+    expect(a.identity).toBeDefined();
+    expect(a.identity).not.toBe(b.identity);
+  });
+
+  it('survives a rewrite — same file, new contents', async () => {
+    const adapter = new VfsAdapter(vfs);
+    const before = await adapter.stat('/workspace/payload.b64');
+    await vfs.writeFile('/workspace/payload.b64', 'replaced');
+    expect((await adapter.stat('/workspace/payload.b64')).identity).toBe(before.identity);
+  });
+
+  it('agrees between stat and lstat', async () => {
+    const adapter = new VfsAdapter(vfs);
+    const [st, lst] = [
+      await adapter.stat('/workspace/payload.b64'),
+      await adapter.lstat('/workspace/payload.b64'),
+    ];
+    expect(lst.identity).toBe(st.identity);
+  });
+
+  it('withholds an identity where none can be trusted', async () => {
+    // ZenFS pins `/` to inode 0, and a sidecar poisoned the way #2146 describes
+    // hands out 0 for many entries until the pre-boot repair renumbers them. A
+    // collided identity is worse than none, so inode 0 stays unnamed — as do
+    // the synthetic /usr entries, which have no VFS entry at all.
+    const adapter = new VfsAdapter(vfs);
+    expect((await adapter.stat('/')).identity).toBeUndefined();
+    expect((await adapter.stat('/usr/bin')).identity).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

`split FILE PREFIX` could never succeed in SLICC — any file, any size, any path. It reported `split: failed to write output` and left no chunks behind. Now it writes them. Diagnosed from a field report where a 129,200-byte base64 payload produced zero chunks:

```
$ split -b 30000 /workspace/cfpdf/IN706358.b64 /workspace/cfpdf/chunk_
split: failed to write output
$ ls /workspace/cfpdf/chunk_*
ls: /workspace/cfpdf/chunk_*: No such file or directory
```

## Why

just-bash runs `split` as a transaction: stage every chunk to a hidden `.<name>.just-bash-split-stage-N` file, re-identify the input and the outputs, then `mv` them into place. The re-check calls `identitiesMatch()`, which **fails closed** for an existing entry with no stable identity:

```js
e.existence === 'existing'
  ? e.stableIdentity !== undefined && e.stableIdentity === t.stableIdentity
  : ...
```

`stableIdentity` comes from `stat().identity`, or `stat().dev` + `stat().ino`. `VfsAdapter.stat()` returned only `{isFile, isDirectory, isSymbolicLink, mode, size, mtime}` — none of the three. So the comparison was `undefined !== undefined` → `false`, split threw `input identity changed during split` against a file nothing had touched, the rollback deleted every staged chunk, and the only thing the user saw was the generic write failure. Every invocation, deterministically.

**Repro** (in any SLICC shell, before this PR):

1. `printf 'A%.0s' {1..1000} > /workspace/f.txt`
2. `split -b 300 /workspace/f.txt /workspace/chunk_`

Expected: `chunk_aa` … `chunk_ad`.
Actual: `split: failed to write output`, exit 1, no chunks.

I confirmed the mechanism against just-bash 3.4.2's own `InMemoryFs`, with and without identity fields on `stat`:

```
WITH IDENT: exit 0, ls → chunk_aa chunk_ab chunk_ac chunk_ad chunk_ae f.b64
STRIPPED  : exit 1, "split: failed to write output", ls → f.b64
```

`dev`/`ino`/`identity` are all optional in just-bash's `FileStats`, so the adapter was within contract — `split` is simply the one command that hard-requires them. I checked `cp`, `mv`, `sort -o`, `tee`, and `tac` under the same identity-less `stat`: all fine, because they degrade to a canonical-path comparison. `split` is the only casualty.

## Approach / Implementation notes

ZenFS already allocates a unique, rewrite-stable `ino` per entry — VirtualFS was dropping it on the floor.

- `fs/types.ts` — `Stats` gains an optional `ino`; `FsStatsLike` gains it too (LightningFS' legacy shape omits it, ZenFS sets it).
- `fs/virtual-fs.ts` — threaded through all four surfaces: `stat`, `lstat`, `statSync`, `lstatSync`. `RestrictedFS` passes `Stats` through untouched, so sandboxed scoops get it for free.
- `shell/vfs-adapter.ts` — one `toIdentity()` helper maps it onto just-bash's `FsStat.identity` in both the sync fast path and the async path of `stat` and `lstat`.

Two choices worth a reviewer's attention:

- **`identity` rather than `dev` + `ino`.** just-bash accepts the inode pair only when *both* halves are present, and one `VfsAdapter` can span backends whose inode spaces are unrelated — there is no honest single `dev` to report.
- **Inode 0 stays unnamed.** ZenFS pins `/` to 0, and a sidecar poisoned the way #2146 describes hands out 0 for many entries until the pre-boot repair renumbers them. A *collided* identity is worse than none, so `toIdentity` only names positive integers.

**Known gap, deliberately not closed here:** mount-backed subtrees (hostfs, S3/DA/AEM) expose `{kind, size, mtime}` and nothing inode-shaped, so `split` on a path under a mount still fails this way. Synthesizing a token from the path would claim a guarantee the backend cannot keep — the fix belongs in the backends, and hostfs would need the host inode carried over `/api/hostfs`. Happy to file a follow-up issue if you want it tracked.

## Cross-cutting impact

- **Floats exercised**: the change is in the shared webapp VFS/shell layer, so it lands identically in CLI, extension, Electron, Sliccstart, and the kernel worker. No float-specific code paths.
- **Other consumers of `Stats`**: `ino` is purely additive and optional. `RestrictedFS` forwards the object; the `/dev/*` stub and the synthetic `/usr/bin` entries produce no `ino` and therefore no identity, which is correct — neither is a real file.
- **Other consumers of `FsStat.identity`**: just-bash's `identify()` also feeds `sameFile()` / `isInside()`, which previously fell back to canonical-path comparison and now get a strictly better answer. `cp`, `mv`, `tar` and friends keep working (full suite green).
- **Security**: this *strengthens* a TOCTOU check rather than relaxing one. `split`'s "would overwrite input" refusal is pinned by a test so the plumbing cannot be mistaken for a way around it.
- **Bundle size**: first-load gate reports `worker +0.2 kB vs base` — inside the 4 kB per-change allowance, 114 kB under the ceiling.
- **Persisted state**: none. `ino` is read from the backend, never written.

## Test plan

- [x] `npm run verify` — all 7 checks passed (prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod)
- [x] `npm run typecheck` — all 9 projects
- [x] `npm run test` — 17,268 passing / 46 skipped, no new failures
- [x] `npm run test:coverage:webapp` — 84.21 lines / 82.15 statements / 82.32 functions / 73.39 branches, all above floors (83 / 81 / 81 / 72)
- [x] `npm run build` (includes `-w @slicc/chrome-extension`)
- [x] `node packages/dev-tools/tools/check-first-load-size.mjs` — OK, +0.2 kB
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — OK (4 changed files, 0 on any debt list)
- [x] **New behavior covered by unit tests**:
      `npx vitest run packages/webapp/tests/shell/split-inode-identity.test.ts` (9 tests — end-to-end `split` through `AlmostBashShellHeadless`, byte-for-byte reassembly, the stdin form, the overwrite-input refusal, and the adapter's identity contract) and
      `packages/webapp/tests/fs/virtual-fs-inode.test.ts` (7 tests — uniqueness, rewrite stability, async/sync agreement, symlink vs target)
- [x] **Guard verified by reverting the fix**: with `toIdentity` stubbed to return `undefined`, 4 of the new tests fail — including on the literal string `split: failed to write output`. Restored before committing.
- [x] N/A — no UI change, so no screencast

**Pre-existing failures**: none.

## Documentation

- [x] `docs/` — new `## Stat Identity: A File Is Not Its Path` section in `docs/pitfalls.md` (next to the VFS path rules), covering the fail-closed semantics, the inode-0 rule, and the mount gap
- [ ] `packages/webapp/CLAUDE.md` — deliberately **not** touched: it is at 19,998/20,000 chars and `lint:docs` would fail

## Risk & rollback

Low blast radius: one optional field added to a stat shape, plus one mapping in the shell adapter. Nothing reads `ino` except `toIdentity`. No flags, no migration — a clean revert of this PR restores the previous behavior exactly (including the bug).

Nothing here needs hand-verification in a real browser: the failure mode is deterministic, backend-independent, and reproduced in the test suite against the same ZenFS backend production uses.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command changes are intentional and reflected in docs
- [x] Contract shared across floats — checked: the adapter is constructed at exactly one site (`almost-bash-shell-headless.ts`) and is the only `IFileSystem` implementation in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
