### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/playwright/handlers/cookies.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -63,7 +63,6 @@
   "packages/webapp/src/shell/supplemental-commands/jsh-biome-source.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/picker-popup.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/console.ts": 1,
-  "packages/webapp/src/shell/supplemental-commands/playwright/handlers/cookies.ts": 4,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/network-requests.ts": 5,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 5,
   "packages/webapp/src/shell/supplemental-commands/secret-backends.ts": 3,

--- a/packages/webapp/src/shell/supplemental-commands/playwright/handlers/cookies.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/handlers/cookies.ts
@@ -6,6 +6,71 @@
 import { getCurrentPageLocation, requireTab } from '../state.js';
 import type { PlaywrightHandler } from '../types.js';
 
+/** CDP Network.Cookie fields used by cookie-list / cookie-get output. */
+interface CdpCookie {
+  name?: string;
+  value?: string;
+  domain?: string;
+  path?: string;
+  secure?: boolean;
+  httpOnly?: boolean;
+  expires?: number;
+}
+
+interface NetworkGetCookiesResponse {
+  cookies?: CdpCookie[];
+}
+
+interface NetworkSetCookieParams {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  secure?: boolean;
+  httpOnly?: boolean;
+  expires?: number;
+  sameSite?: string;
+  url?: string;
+}
+
+interface NetworkDeleteCookiesParams {
+  name: string;
+  domain?: string;
+  path?: string;
+  url?: string;
+}
+
+function cookiesFromCdpResponse(response: NetworkGetCookiesResponse): CdpCookie[] {
+  return response.cookies ?? [];
+}
+
+function formatCookieLine(c: CdpCookie): string {
+  return `${c.name}=${c.value}\tDomain=${c.domain}\tPath=${c.path}\tSecure=${c.secure}\tHttpOnly=${c.httpOnly}\tExpires=${c.expires}`;
+}
+
+function toSetCookieCdpParams(params: NetworkSetCookieParams) {
+  return {
+    name: params.name,
+    value: params.value,
+    ...(params.domain !== undefined ? { domain: params.domain } : {}),
+    ...(params.path !== undefined ? { path: params.path } : {}),
+    ...(params.secure !== undefined ? { secure: params.secure } : {}),
+    ...(params.httpOnly !== undefined ? { httpOnly: params.httpOnly } : {}),
+    ...(params.expires !== undefined ? { expires: params.expires } : {}),
+    ...(params.sameSite !== undefined ? { sameSite: params.sameSite } : {}),
+    ...(params.url !== undefined ? { url: params.url } : {}),
+  };
+}
+
+function toDeleteCookiesCdpParams(params: NetworkDeleteCookiesParams) {
+  return {
+    name: params.name,
+    ...(params.domain !== undefined ? { domain: params.domain } : {}),
+    ...(params.path !== undefined ? { path: params.path } : {}),
+    ...(params.url !== undefined ? { url: params.url } : {}),
+  };
+}
+
 export const cookieListHandler: PlaywrightHandler = async ({ browser, flags }) => {
   const tab = requireTab(flags);
   if ('error' in tab) {
@@ -14,23 +79,20 @@ export const cookieListHandler: PlaywrightHandler = async ({ browser, flags }) =
   const domain = flags['domain'];
   const path = flags['path'];
   const output = await browser.withTab(tab.targetId, async () => {
-    const cdpCookies = await browser.sendCDP('Network.getCookies');
-    const cookies = (cdpCookies['cookies'] as Array<Record<string, unknown>>) ?? [];
+    const cdpCookies = (await browser.sendCDP('Network.getCookies')) as NetworkGetCookiesResponse;
+    const cookies = cookiesFromCdpResponse(cdpCookies);
     const filtered =
       domain || path
         ? cookies.filter(
             (c) =>
-              (!domain || String(c['domain'] ?? '').includes(domain)) &&
-              (!path || String(c['path'] ?? '').startsWith(path))
+              (!domain || String(c.domain ?? '').includes(domain)) &&
+              (!path || String(c.path ?? '').startsWith(path))
           )
         : cookies;
     if (filtered.length === 0) {
       return 'No cookies';
     }
-    const lines = filtered.map(
-      (c) =>
-        `${c['name']}=${c['value']}\tDomain=${c['domain']}\tPath=${c['path']}\tSecure=${c['secure']}\tHttpOnly=${c['httpOnly']}\tExpires=${c['expires']}`
-    );
+    const lines = filtered.map(formatCookieLine);
     return lines.join('\n');
   });
   return { stdout: output + '\n', stderr: '', exitCode: 0 };
@@ -46,16 +108,15 @@ export const cookieGetHandler: PlaywrightHandler = async ({ browser, positional,
   }
   const cookieName = positional[0];
   const output = await browser.withTab(tab.targetId, async () => {
-    const cdpGetCookies = await browser.sendCDP('Network.getCookies');
-    const cookies = (cdpGetCookies['cookies'] as Array<Record<string, unknown>>) ?? [];
-    const matched = cookies.filter((c) => c['name'] === cookieName);
+    const cdpGetCookies = (await browser.sendCDP(
+      'Network.getCookies'
+    )) as NetworkGetCookiesResponse;
+    const cookies = cookiesFromCdpResponse(cdpGetCookies);
+    const matched = cookies.filter((c) => c.name === cookieName);
     if (matched.length === 0) {
       throw new Error(`Cookie "${cookieName}" not found`);
     }
-    const lines = matched.map(
-      (c) =>
-        `${c['name']}=${c['value']}\tDomain=${c['domain']}\tPath=${c['path']}\tSecure=${c['secure']}\tHttpOnly=${c['httpOnly']}\tExpires=${c['expires']}`
-    );
+    const lines = matched.map(formatCookieLine);
     return lines.join('\n');
   });
   return { stdout: output + '\n', stderr: '', exitCode: 0 };
@@ -71,20 +132,20 @@ export const cookieSetHandler: PlaywrightHandler = async ({ browser, positional,
   }
   await browser.withTab(tab.targetId, async () => {
     const pageLocation = await getCurrentPageLocation(browser);
-    const params: Record<string, unknown> = {
+    const params: NetworkSetCookieParams = {
       name: positional[0],
       value: positional[1],
     };
-    if (flags['domain']) params['domain'] = flags['domain'];
-    if (flags['path']) params['path'] = flags['path'];
-    if (flags['secure'] === 'true') params['secure'] = true;
-    if (flags['httpOnly'] === 'true') params['httpOnly'] = true;
-    if (flags['expires']) params['expires'] = parseFloat(flags['expires']);
-    if (flags['sameSite']) params['sameSite'] = flags['sameSite'];
-    if (!params['domain'] && !params['path']) {
-      params['url'] = pageLocation.href;
+    if (flags['domain']) params.domain = flags['domain'];
+    if (flags['path']) params.path = flags['path'];
+    if (flags['secure'] === 'true') params.secure = true;
+    if (flags['httpOnly'] === 'true') params.httpOnly = true;
+    if (flags['expires']) params.expires = parseFloat(flags['expires']);
+    if (flags['sameSite']) params.sameSite = flags['sameSite'];
+    if (!params.domain && !params.path) {
+      params.url = pageLocation.href;
     }
-    await browser.sendCDP('Network.setCookie', params);
+    await browser.sendCDP('Network.setCookie', toSetCookieCdpParams(params));
   });
   return { stdout: `Cookie "${positional[0]}" set\n`, stderr: '', exitCode: 0 };
 };
@@ -98,14 +159,14 @@ export const cookieDeleteHandler: PlaywrightHandler = async ({ browser, position
     return { stdout: '', stderr: tab.error, exitCode: 1 };
   }
   await browser.withTab(tab.targetId, async () => {
-    const delParams: Record<string, unknown> = { name: positional[0] };
-    if (flags['domain']) delParams['domain'] = flags['domain'];
-    if (flags['path']) delParams['path'] = flags['path'];
-    if (!delParams['domain'] && !delParams['path']) {
+    const delParams: NetworkDeleteCookiesParams = { name: positional[0] };
+    if (flags['domain']) delParams.domain = flags['domain'];
+    if (flags['path']) delParams.path = flags['path'];
+    if (!delParams.domain && !delParams.path) {
       const pageLocation = await getCurrentPageLocation(browser);
-      delParams['url'] = pageLocation.href;
+      delParams.url = pageLocation.href;
     }
-    await browser.sendCDP('Network.deleteCookies', delParams);
+    await browser.sendCDP('Network.deleteCookies', toDeleteCookiesCdpParams(delParams));
   });
   return { stdout: `Cookie "${positional[0]}" deleted\n`, stderr: '', exitCode: 0 };
 };


### PR DESCRIPTION
## Summary

- Replaced four `Record<string, unknown>` uses in `cookies.ts` with named CDP types (`CdpCookie`, `NetworkGetCookiesResponse`, `NetworkSetCookieParams`, `NetworkDeleteCookiesParams`) and small boundary helpers for formatting and CDP param mapping.
- Cleared `record-string-unknown` debt for this file and ratcheted the baseline (-4).

## Verification

- `npx biome check --write packages/webapp/src/shell/supplemental-commands/playwright/handlers/cookies.ts`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts -t "cookie-"` (14 tests)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK