### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/plugins/store.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -58,7 +58,6 @@
   "packages/webapp/src/shell/arg-parser.ts": 2,
   "packages/webapp/src/shell/bsh-watchdog.ts": 1,
   "packages/webapp/src/shell/mcp/store.ts": 2,
-  "packages/webapp/src/shell/plugins/store.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/biome-configuration.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/jsh-biome-source.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/picker-popup.ts": 3,

--- a/packages/webapp/src/shell/plugins/store.ts
+++ b/packages/webapp/src/shell/plugins/store.ts
@@ -45,20 +45,45 @@ function emptyFile(): PluginsFile {
   return { version: CURRENT_VERSION, plugins: {} };
 }
 
+/** Untrusted `plugins.json` root before validation. */
+interface UntrustedPluginsFile {
+  readonly version?: unknown;
+  readonly plugins?: unknown;
+}
+
+/** Untrusted plugin-name map before per-entry validation. */
+interface UntrustedPluginsMap {
+  readonly [pluginName: string]: unknown;
+}
+
+/** Untrusted installed-plugin entry before validation. */
+interface UntrustedInstalledPluginEntry {
+  readonly root?: unknown;
+  readonly version?: unknown;
+  readonly description?: unknown;
+  readonly installedAt?: unknown;
+  readonly mcpServerNames?: unknown;
+  readonly source?: unknown;
+}
+
+function isPlainObject(value: unknown): value is object {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 function normalizeEntry(raw: unknown): InstalledPluginEntry | null {
-  if (!raw || typeof raw !== 'object') return null;
-  const entry = raw as Record<string, unknown>;
+  if (!isPlainObject(raw)) return null;
+  const entry = raw as UntrustedInstalledPluginEntry;
   if (typeof entry.root !== 'string') return null;
   return entry as unknown as InstalledPluginEntry;
 }
 
 function normalize(raw: unknown): PluginsFile {
-  if (!raw || typeof raw !== 'object') return emptyFile();
-  const obj = raw as Partial<PluginsFile> & { plugins?: unknown };
+  if (!isPlainObject(raw)) return emptyFile();
+  const obj = raw as UntrustedPluginsFile;
   const version = typeof obj.version === 'number' ? obj.version : CURRENT_VERSION;
   const plugins: Record<string, InstalledPluginEntry> = {};
-  if (obj.plugins && typeof obj.plugins === 'object') {
-    for (const [name, entry] of Object.entries(obj.plugins as Record<string, unknown>)) {
+  if (isPlainObject(obj.plugins)) {
+    for (const [name, entry] of Object.entries(obj.plugins as UntrustedPluginsMap)) {
       const normalized = normalizeEntry(entry);
       if (normalized) plugins[name] = normalized;
     }


### PR DESCRIPTION
## Summary

- Replace `Record<string, unknown>` casts in `plugins/store.ts` with named untrusted JSON interfaces (`UntrustedPluginsFile`, `UntrustedPluginsMap`, `UntrustedInstalledPluginEntry`) and a shared `isPlainObject` guard when parsing `plugins.json`.
- Ratchet `record-string-unknown-baseline.json` via `check-record-string-unknown.mjs --update` (cleared `packages/webapp/src/shell/plugins/store.ts`).

## Debt cleared

- **record-string-unknown** — removed both baseline occurrences from `store.ts`.

## Verification

```bash
npx biome check --write packages/webapp/src/shell/plugins/store.ts
npm run typecheck
npx vitest run packages/webapp/tests/shell/supplemental-commands/plugin-command.test.ts
node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main
```

All passed locally; pre-push lint gate green.