### PR TITLE
refactor: pay down boy-scout debt in packages/node-server/src/cdp-proxy/session-url-tracker.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -7,7 +7,6 @@
   "packages/cloudflare-worker/src/cloud/handlers.ts": 1,
   "packages/cloudflare-worker/src/oauth-exchange.ts": 1,
   "packages/dev-tools/tools/extension-smoke-test.ts": 6,
-  "packages/node-server/src/cdp-proxy/session-url-tracker.ts": 3,
   "packages/node-server/src/electron-controller.ts": 13,
   "packages/node-server/src/electron-federated-cdp.ts": 5,
   "packages/node-server/src/electron-runtime.ts": 1,

--- a/packages/node-server/src/cdp-proxy/session-url-tracker.ts
+++ b/packages/node-server/src/cdp-proxy/session-url-tracker.ts
@@ -26,14 +26,41 @@ export interface CdpSessionUrlTracker {
   clear(): void;
 }
 
+/** Subset of CDP TargetInfo fields read by the session URL tracker. */
+interface CdpTargetInfoSlice {
+  targetId?: string;
+  url?: string;
+  type?: string;
+}
+
+/** Subset of CDP Frame fields read by Page.frameNavigated handling. */
+interface CdpFrameSlice {
+  id?: string;
+  parentId?: string;
+  url?: string;
+}
+
+/** Params bag for the CDP events this tracker observes (narrowed per handler). */
+interface SessionUrlTrackerFrameParams {
+  sessionId?: string;
+  targetInfo?: unknown;
+  frame?: unknown;
+}
+
 interface ParsedFrame {
   method?: string;
   sessionId?: string;
-  params?: Record<string, unknown>;
+  params?: SessionUrlTrackerFrameParams;
 }
 
-function asObject(v: unknown): Record<string, unknown> | null {
-  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+function asTargetInfo(v: unknown): CdpTargetInfoSlice | null {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return null;
+  return v as CdpTargetInfoSlice;
+}
+
+function asFrameInfo(v: unknown): CdpFrameSlice | null {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return null;
+  return v as CdpFrameSlice;
 }
 
 function parseHostname(url: string | undefined | null): string | null {
@@ -65,12 +92,12 @@ export function createCdpSessionUrlTracker(): CdpSessionUrlTracker {
   function handleAttached(frame: ParsedFrame): void {
     const params = frame.params;
     if (!params) return;
-    const sessionId = params['sessionId'];
+    const sessionId = params.sessionId;
     if (typeof sessionId !== 'string') return;
-    const info = asObject(params['targetInfo']);
+    const info = asTargetInfo(params.targetInfo);
     if (!info) return;
-    const targetId = info['targetId'];
-    const url = info['url'];
+    const targetId = info.targetId;
+    const url = info.url;
     if (typeof targetId === 'string') {
       sessionToTarget.set(sessionId, targetId);
       if (typeof url === 'string') targetToUrl.set(targetId, url);
@@ -79,17 +106,17 @@ export function createCdpSessionUrlTracker(): CdpSessionUrlTracker {
   }
 
   function handleDetached(frame: ParsedFrame): void {
-    const sessionId = frame.params?.['sessionId'];
+    const sessionId = frame.params?.sessionId;
     if (typeof sessionId !== 'string') return;
     sessionToUrl.delete(sessionId);
     sessionToTarget.delete(sessionId);
   }
 
   function handleTargetInfoChanged(frame: ParsedFrame): void {
-    const info = asObject(frame.params?.['targetInfo']);
+    const info = asTargetInfo(frame.params?.targetInfo);
     if (!info) return;
-    const targetId = info['targetId'];
-    const url = info['url'];
+    const targetId = info.targetId;
+    const url = info.url;
     if (typeof targetId !== 'string' || typeof url !== 'string') return;
     targetToUrl.set(targetId, url);
     for (const [sid, tid] of sessionToTarget.entries()) {
@@ -101,11 +128,11 @@ export function createCdpSessionUrlTracker(): CdpSessionUrlTracker {
     // sessionId is at the wire-frame top level for routed events.
     const sessionId = frame.sessionId;
     if (typeof sessionId !== 'string') return;
-    const inner = asObject(frame.params?.['frame']);
+    const inner = asFrameInfo(frame.params?.frame);
     if (!inner) return;
     // Only the root frame (no parentId) drives the per-tab URL.
-    if (typeof inner['parentId'] === 'string') return;
-    const url = inner['url'];
+    if (typeof inner.parentId === 'string') return;
+    const url = inner.url;
     if (typeof url === 'string') setSessionUrl(sessionId, url);
   }
 


### PR DESCRIPTION
## Summary

- Replace three `Record<string, unknown>` usages in `session-url-tracker.ts` with named CDP slice types (`CdpTargetInfoSlice`, `CdpFrameSlice`, `SessionUrlTrackerFrameParams`) and typed narrowing helpers (`asTargetInfo`, `asFrameInfo`).
- Ratchet `record-string-unknown-baseline.json` to remove the file from the debt list (3 → 0 occurrences).

## Debt cleared

- `record-string-unknown` — `packages/node-server/src/cdp-proxy/session-url-tracker.ts`

## Verification

- `npx biome check --write packages/node-server/src/cdp-proxy/session-url-tracker.ts`
- `npm run typecheck`
- `npx vitest run packages/node-server/tests/cdp-proxy/session-url-tracker.test.ts packages/node-server/tests/cdp-proxy/cdp-unmask.test.ts` (16 tests pass)
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK