### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/ui/remote-cdp-page-bridge.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -77,7 +77,6 @@
   "packages/webapp/src/ui/boot/setup-welcome-flow.ts": 13,
   "packages/webapp/src/ui/dip.ts": 4,
   "packages/webapp/src/ui/main.ts": 1,
-  "packages/webapp/src/ui/remote-cdp-page-bridge.ts": 2,
   "packages/webapp/src/ui/sprinkle-bridge.ts": 2,
   "packages/webapp/src/ui/sprinkle-renderer.ts": 3,
   "packages/webapp/src/ui/tray-leave-runtime.ts": 1,

--- a/packages/webapp/src/ui/remote-cdp-page-bridge.ts
+++ b/packages/webapp/src/ui/remote-cdp-page-bridge.ts
@@ -11,6 +11,8 @@
  * and `docs/superpowers/specs/2026-06-03-standalone-remote-cdp-bridge-design.md`.
  */
 
+import type { CDPPayload } from '@slicc/shared-ts';
+
 import type { CDPTransport } from '../cdp/transport.js';
 import type { CDPEventListener } from '../cdp/types.js';
 
@@ -33,10 +35,10 @@ export interface RemoteCdpPageBridge {
     runtimeId: string;
     localTargetId: string;
     method: string;
-    params?: Record<string, unknown>;
+    params?: CDPPayload;
     sessionId?: string;
     timeout?: number;
-  }): Promise<Record<string, unknown>>;
+  }): Promise<CDPPayload>;
   subscribe(p: { runtimeId: string; localTargetId: string; event: string }): Promise<{
     ok: true;
   }>;


### PR DESCRIPTION
## Summary

- Replace `Record<string, unknown>` with `CDPPayload` for `RemoteCdpPageBridge.send` params and return type, matching `CDPTransport` and `panel-rpc` conventions.
- Clears the `record-string-unknown` debt entry for `packages/webapp/src/ui/remote-cdp-page-bridge.ts` (baseline ratcheted down by 1).

## Test plan

- [x] `npx biome check --write packages/webapp/src/ui/remote-cdp-page-bridge.ts`
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/ui/remote-cdp-page-bridge.test.ts packages/webapp/tests/cdp/standalone-remote-cdp-bridge.integration.test.ts`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`