### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -3,7 +3,6 @@
   "packages/webapp/src/fs/mount-picker-popup.ts": 2,
   "packages/webapp/src/fs/mount/backend-local.ts": 2,
   "packages/webapp/src/shell/bsh-watchdog.ts": 3,
-  "packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/hid-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/host-command.ts": 7,
   "packages/webapp/src/shell/supplemental-commands/local-llm-command.ts": 1,

--- a/packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts
+++ b/packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts
@@ -18,7 +18,7 @@
  * unchanged.
  */
 
-import { isExtensionRealm } from '../../core/runtime-env.js';
+import { isExtensionRealm } from '../../base/runtime-env.js';
 
 /** Camera / mic capture request forwarded to the popup. */
 export interface PopupCameraCaptureRequest {


### PR DESCRIPTION
## Summary

- Remove the layer-stack back-edge in `extension-media-capture.ts` by importing `isExtensionRealm` from `base/runtime-env` instead of `core/runtime-env` (same symbol, correct layer direction).
- Ratchet `layer-back-edge-baseline.json` — file removed from the debt list (49 → 48 grandfathered back-edges).

## Debt cleared

- **layer-back-edge** (`packages/webapp/src/shell/supplemental-commands/extension-media-capture.ts`)

## Verification

- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/screencapture-command.test.ts packages/webapp/tests/shell/supplemental-commands/ffmpeg-command.test.ts` (78 tests)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK