### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/scoops/scheduler.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -331,7 +331,6 @@
         "packages/webapp/src/cdp/har-recorder.ts",
         "packages/webapp/src/providers/built-in/bedrock-camp.ts",
         "packages/webapp/src/providers/intercepted-oauth.ts",
-        "packages/webapp/src/scoops/scheduler.ts",
         "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts",
         "packages/webapp/tests/cdp/cdp-client.test.ts",
         "packages/webapp/tests/cdp/preview-bridge-cdp-transport.test.ts",

--- a/packages/webapp/src/scoops/scheduler.ts
+++ b/packages/webapp/src/scoops/scheduler.ts
@@ -39,10 +39,10 @@ export class TaskScheduler {
     // `setInterval` (no `window.` prefix) so this works in both page
     // and DedicatedWorker contexts. The standalone runtime runs the
     // scheduler in a worker; `window` is undefined there.
-    this.pollInterval = setInterval(() => this.checkTasks(), 60000);
+    this.pollInterval = setInterval(() => this.pollTasks(), 60000);
 
     // Also check immediately
-    this.checkTasks();
+    this.pollTasks();
 
     log.info('Scheduler started');
   }
@@ -140,6 +140,15 @@ export class TaskScheduler {
   /** Get all tasks */
   async getAllTasks(): Promise<ScheduledTask[]> {
     return db.getAllTasks();
+  }
+
+  /** Fire-and-forget poll wrapper — scheduler tick must not block the interval. */
+  private pollTasks(): void {
+    this.checkTasks().catch((err) => {
+      log.error('Task poll failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
   }
 
   /** Check and run due tasks */


### PR DESCRIPTION
## Summary

- Add a `pollTasks()` wrapper that explicitly `.catch()`es async scheduler ticks from `setInterval` and the immediate startup poll
- Remove `packages/webapp/src/scoops/scheduler.ts` from the `nursery.noFloatingPromises: "off"` biome override list

## Debt cleared

- **floating-promise** — `setInterval(() => this.checkTasks())` and bare `this.checkTasks()` in `start()` now route through `pollTasks()` with explicit error handling

## Verification

```bash
npx biome check --write packages/webapp/src/scoops/scheduler.ts biome.json
npm run typecheck
npx vitest run packages/webapp/tests/scoops/scheduler.test.ts
node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main
```

All passed locally (31 scheduler tests green; debt gate OK).