### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/playwright/handlers/teleport.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -12,7 +12,6 @@
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/interaction.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/network-requests.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts": 2,
-  "packages/webapp/src/shell/supplemental-commands/playwright/handlers/teleport.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/playwright/snapshot.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/playwright/state.ts": 4,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport-storage.ts": 2,

--- a/packages/webapp/src/shell/supplemental-commands/playwright/handlers/teleport.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/handlers/teleport.ts
@@ -3,8 +3,8 @@
  * state machine itself lives in `../teleport.ts`.
  */
 
-import { createLogger } from '../../../../core/logger.js';
-import { CHERRY_RUNTIME_TAG } from '../../../../scoops/tray-sync-protocol.js';
+import { CHERRY_RUNTIME_TAG } from '@slicc/shared-ts';
+import { createLogger } from '../../../../base/logger.js';
 import { requireTab } from '../state.js';
 import {
   armTeleportWatcher,


### PR DESCRIPTION
## Summary

- Cleared **layer-back-edge** debt in the playwright teleport subcommand handler by replacing two upward imports:
  - `core/logger.js` → `base/logger.js` (same pattern as `handlers/tabs.ts` and `handlers/navigation.ts`)
  - `scoops/tray-sync-protocol.js` → `@slicc/shared-ts` for `CHERRY_RUNTIME_TAG` (same pattern as `cherry-emit-command.ts`)
- Ratcheted `layer-back-edge-baseline.json` via `check-layer-back-edges.mjs --update` (removed the handler entry; no other baseline changes).

## Debt cleared

| File | List |
|------|------|
| `packages/webapp/src/shell/supplemental-commands/playwright/handlers/teleport.ts` | layer-back-edge |

## Verification

- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright/teleport-follower-shim.test.ts`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK
- `node packages/dev-tools/tools/check-layer-back-edges.mjs` → OK

Behavior unchanged: same logger namespace, same cherry-runtime rejection logic.