### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/git/commands/symbolic-ref.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -32,7 +32,6 @@
   "packages/webapp/src/fs/mount/backend-local.ts": 1,
   "packages/webapp/src/git/commands/rebase.ts": 1,
   "packages/webapp/src/git/commands/shared.ts": 1,
-  "packages/webapp/src/git/commands/symbolic-ref.ts": 2,
   "packages/webapp/src/kernel/cdp-bridge.ts": 7,
   "packages/webapp/src/kernel/cdp-worker-proxy.ts": 3,
   "packages/webapp/src/kernel/port-bridge-client.ts": 2,

--- a/packages/webapp/src/git/commands/symbolic-ref.ts
+++ b/packages/webapp/src/git/commands/symbolic-ref.ts
@@ -28,15 +28,32 @@ interface SymbolicRefFlags {
 /** Opaque parseArgs flag bag before unknown-flag validation. */
 type SymbolicRefParsedFlags = ParsedArgs['flags'];
 
+/**
+ * A boolean flag's effective value. `mri` stores a repeated boolean as an array
+ * (`--short --short` → `[true, true]`), so mirror the parser's last-wins
+ * semantics and collapse to the final element before narrowing — otherwise a
+ * repeated `--short`/`--quiet` would silently drop to `undefined`.
+ */
+function effectiveBool(value: unknown): boolean | undefined {
+  const effective = Array.isArray(value) ? value[value.length - 1] : value;
+  return typeof effective === 'boolean' ? effective : undefined;
+}
+
 function symbolicRefFlagsFromParsed(flags: SymbolicRefParsedFlags): SymbolicRefFlags {
   const out: SymbolicRefFlags = {};
   if (typeof flags.m === 'string') out.m = flags.m;
-  if (flags.delete === true || flags.delete === false) out.delete = flags.delete;
-  if (flags.d === true || flags.d === false) out.d = flags.d;
-  if (flags.quiet === true || flags.quiet === false) out.quiet = flags.quiet;
-  if (flags.q === true || flags.q === false) out.q = flags.q;
-  if (flags.short === true || flags.short === false) out.short = flags.short;
-  if (flags.recurse === true || flags.recurse === false) out.recurse = flags.recurse;
+  const deleteFlag = effectiveBool(flags.delete);
+  if (deleteFlag !== undefined) out.delete = deleteFlag;
+  const d = effectiveBool(flags.d);
+  if (d !== undefined) out.d = d;
+  const quiet = effectiveBool(flags.quiet);
+  if (quiet !== undefined) out.quiet = quiet;
+  const q = effectiveBool(flags.q);
+  if (q !== undefined) out.q = q;
+  const short = effectiveBool(flags.short);
+  if (short !== undefined) out.short = short;
+  const recurse = effectiveBool(flags.recurse);
+  if (recurse !== undefined) out.recurse = recurse;
   return out;
 }
 

--- a/packages/webapp/src/git/commands/symbolic-ref.ts
+++ b/packages/webapp/src/git/commands/symbolic-ref.ts
@@ -1,7 +1,7 @@
 /** `git symbolic-ref` — read, update, and delete symbolic refs. */
 
 import * as git from 'isomorphic-git';
-import { parseArgs } from '../../shell/arg-parser.js';
+import { type ParsedArgs, parseArgs } from '../../shell/arg-parser.js';
 import { GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
@@ -13,6 +13,32 @@ type RefInspection =
   | { kind: 'symbolic'; target: string }
   | { kind: 'direct' }
   | { kind: 'missing' };
+
+/** Parsed flags for `git symbolic-ref` (see GIT_FLAG_SPECS['symbolic-ref']). */
+interface SymbolicRefFlags {
+  m?: string;
+  delete?: boolean;
+  d?: boolean;
+  quiet?: boolean;
+  q?: boolean;
+  short?: boolean;
+  recurse?: boolean;
+}
+
+/** Opaque parseArgs flag bag before unknown-flag validation. */
+type SymbolicRefParsedFlags = ParsedArgs['flags'];
+
+function symbolicRefFlagsFromParsed(flags: SymbolicRefParsedFlags): SymbolicRefFlags {
+  const out: SymbolicRefFlags = {};
+  if (typeof flags.m === 'string') out.m = flags.m;
+  if (flags.delete === true || flags.delete === false) out.delete = flags.delete;
+  if (flags.d === true || flags.d === false) out.d = flags.d;
+  if (flags.quiet === true || flags.quiet === false) out.quiet = flags.quiet;
+  if (flags.q === true || flags.q === false) out.q = flags.q;
+  if (flags.short === true || flags.short === false) out.short = flags.short;
+  if (flags.recurse === true || flags.recurse === false) out.recurse = flags.recurse;
+  return out;
+}
 
 function usage(): GitCommandResult {
   return { stdout: '', stderr: `${USAGE}\n`, exitCode: 129 };
@@ -89,7 +115,7 @@ function shortenRef(ref: string): string {
 }
 
 function validateFlags(
-  flags: Record<string, unknown>,
+  flags: SymbolicRefParsedFlags,
   deleting: boolean
 ): GitCommandResult | undefined {
   const knownFlags = new Set(['m', 'delete', 'd', 'quiet', 'q', 'short', 'recurse']);
@@ -162,7 +188,7 @@ async function printSymbolicRef(
   ctx: GitCommandContext,
   cwd: string,
   name: string,
-  flags: Record<string, unknown>
+  flags: SymbolicRefFlags
 ): Promise<GitCommandResult> {
   const target = await readSymbolicTarget(ctx, cwd, name, flags.recurse !== false);
   if (typeof target !== 'string') {
@@ -194,5 +220,5 @@ export async function symbolicRef(
   }
 
   if (positionals.length !== 1) return usage();
-  return printSymbolicRef(ctx, cwd, positionals[0], flags);
+  return printSymbolicRef(ctx, cwd, positionals[0], symbolicRefFlagsFromParsed(flags));
 }

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -2960,6 +2960,13 @@ describe('GitCommands', () => {
       expect(short).toEqual({ stdout: 'main\n', stderr: '', exitCode: 0 });
     });
 
+    it('honors a repeated boolean flag (mri stores it as an array)', async () => {
+      await git.execute(['init'], '/project');
+
+      const short = await git.execute(['symbolic-ref', '--short', '--short', 'HEAD'], '/project');
+      expect(short).toEqual({ stdout: 'main\n', stderr: '', exitCode: 0 });
+    });
+
     it('creates, updates, reads, and deletes a symbolic ref', async () => {
       await git.execute(['init'], '/project');
 
@@ -3038,6 +3045,9 @@ describe('GitCommands', () => {
       const quiet = await git.execute(['symbolic-ref', '--quiet', 'HEAD'], '/project');
       expect(quiet).toEqual({ stdout: '', stderr: '', exitCode: 1 });
       expect(await git.execute(['symbolic-ref', '-q', 'HEAD'], '/project')).toEqual(quiet);
+      expect(await git.execute(['symbolic-ref', '--quiet', '--quiet', 'HEAD'], '/project')).toEqual(
+        quiet
+      );
     });
 
     it('does not delete a direct ref', async () => {


### PR DESCRIPTION
## Summary

- Replaced two `Record<string, unknown>` flag parameters in `symbolic-ref.ts` with named types: `SymbolicRefFlags` for the known git flag shape and `SymbolicRefParsedFlags` (`ParsedArgs['flags']`) for the opaque parseArgs boundary.
- Added `symbolicRefFlagsFromParsed()` to narrow parsed flags before the read path uses them.
- Ratcheted `record-string-unknown-baseline.json` (file removed from baseline; count 2 → 0).

## Debt cleared

- **record-string-unknown** — `packages/webapp/src/git/commands/symbolic-ref.ts`

## Verification

```bash
npx biome check --write packages/webapp/src/git/commands/symbolic-ref.ts
npm run typecheck
npx vitest run packages/webapp/tests/git/git-commands.test.ts -t "symbolic-ref"
node packages/dev-tools/tools/check-record-string-unknown.mjs --update
node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main
```