### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/git/commands/shared.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -28,7 +28,6 @@
   "packages/webapp/src/core/types.ts": 2,
   "packages/webapp/src/fs/mount/backend-local.ts": 1,
   "packages/webapp/src/git/commands/rebase.ts": 1,
-  "packages/webapp/src/git/commands/shared.ts": 1,
   "packages/webapp/src/kernel/cdp-bridge.ts": 7,
   "packages/webapp/src/kernel/cdp-worker-proxy.ts": 3,
   "packages/webapp/src/kernel/port-bridge-client.ts": 2,

--- a/packages/webapp/src/git/commands/clone.ts
+++ b/packages/webapp/src/git/commands/clone.ts
@@ -4,7 +4,7 @@ import * as git from 'isomorphic-git';
 import { joinPath, normalizePath } from '../../fs/path-utils.js';
 import { parseArgs } from '../../shell/arg-parser.js';
 import { gitHttp } from '../git-http.js';
-import { expandGitError, flagString, GIT_FLAG_SPECS } from './shared.js';
+import { expandGitError, flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function clone(
@@ -15,7 +15,8 @@ export async function clone(
   // Parse flags first so the url/dir come from positionals — leading flags like
   // `clone --branch X --single-branch <url> <dir>` must round-trip (not treat
   // `--branch` as the URL). Mirrors fetch.ts's positional handling (#1033-3).
-  const { flags, positionals } = parseArgs(args, GIT_FLAG_SPECS.clone);
+  const { flags: rawFlags, positionals } = parseArgs(args, GIT_FLAG_SPECS.clone);
+  const flags = rawFlags as GitParsedFlags;
 
   if (positionals.length === 0) {
     return {

--- a/packages/webapp/src/git/commands/commit.ts
+++ b/packages/webapp/src/git/commands/commit.ts
@@ -2,7 +2,7 @@
 
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
-import { flagString, GIT_FLAG_SPECS } from './shared.js';
+import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function commit(
@@ -12,7 +12,7 @@ export async function commit(
 ): Promise<GitCommandResult> {
   // Handle combined -am "message" form: expand to -a -m "message"
   const expandedArgs = expandCombinedFlags(args);
-  const { flags } = parseArgs(expandedArgs, GIT_FLAG_SPECS.commit);
+  const flags = parseArgs(expandedArgs, GIT_FLAG_SPECS.commit).flags as GitParsedFlags;
 
   const message = flagString(flags, 'message');
 

--- a/packages/webapp/src/git/commands/fetch.ts
+++ b/packages/webapp/src/git/commands/fetch.ts
@@ -3,7 +3,7 @@
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
 import { gitHttp } from '../git-http.js';
-import { flagString, GIT_FLAG_SPECS } from './shared.js';
+import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function fetch(
@@ -13,7 +13,8 @@ export async function fetch(
 ): Promise<GitCommandResult> {
   // Positional ref must round-trip: `fetch --depth 1 origin main` →
   // remote=origin, ref=main (NOT remote=1) — #1033-3.
-  const { flags, positionals } = parseArgs(args, GIT_FLAG_SPECS.fetch);
+  const { flags: rawFlags, positionals } = parseArgs(args, GIT_FLAG_SPECS.fetch);
+  const flags = rawFlags as GitParsedFlags;
   const remote = positionals[0] ?? 'origin';
   const ref = positionals[1];
   const prune = flags.prune === true;

--- a/packages/webapp/src/git/commands/init.ts
+++ b/packages/webapp/src/git/commands/init.ts
@@ -2,7 +2,7 @@
 
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
-import { flagString, GIT_FLAG_SPECS } from './shared.js';
+import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function init(
@@ -10,7 +10,7 @@ export async function init(
   cwd: string,
   args: string[]
 ): Promise<GitCommandResult> {
-  const { flags } = parseArgs(args, GIT_FLAG_SPECS.init);
+  const flags = parseArgs(args, GIT_FLAG_SPECS.init).flags as GitParsedFlags;
   // Precedence (matches real git): explicit `--initial-branch`/`-b` flag
   // wins over a per-invocation `-c init.defaultBranch=…` override, which
   // wins over the built-in `main` default.

--- a/packages/webapp/src/git/commands/log.ts
+++ b/packages/webapp/src/git/commands/log.ts
@@ -4,7 +4,7 @@ import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
 import { diffCommits, diffInitialCommit } from './diff.js';
 import { matchesPathspec } from './revision.js';
-import { flagString, GIT_FLAG_SPECS } from './shared.js';
+import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function log(
@@ -12,7 +12,8 @@ export async function log(
   cwd: string,
   args: string[]
 ): Promise<GitCommandResult> {
-  const { flags, positionals, doubleDashRest } = parseArgs(args, GIT_FLAG_SPECS.log);
+  const { flags: rawFlags, positionals, doubleDashRest } = parseArgs(args, GIT_FLAG_SPECS.log);
+  const flags = rawFlags as GitParsedFlags;
   const depth = flagString(flags, 'max-count');
   const oneline = flags.oneline === true;
   const showStat = flags.stat === true;

--- a/packages/webapp/src/git/commands/shared.ts
+++ b/packages/webapp/src/git/commands/shared.ts
@@ -137,11 +137,14 @@ export const GIT_FLAG_SPECS: Record<string, ArgSpec> = {
 export type GitFlagScalar = string | number | boolean;
 
 /**
- * Parsed git subcommand flags from `parseArgs` / mri. Values are typically
- * {@link GitFlagScalar} or a repeated array; {@link flagString} narrows at read time.
+ * Parsed git subcommand flags from `parseArgs` / mri. Each flag is a
+ * {@link GitFlagScalar}, a repeated array of them, or absent (`undefined`).
+ * This is the explicit boundary type callers cast the opaque
+ * `Record<string, unknown>` from `parseArgs` to; {@link flagString} narrows a
+ * single value at read time.
  */
 export interface GitParsedFlags {
-  readonly [flag: string]: unknown;
+  readonly [flag: string]: GitFlagScalar | readonly GitFlagScalar[] | undefined;
 }
 
 /** Read a value-flag as a string, treating empty (`--flag` with no value) as undefined. */

--- a/packages/webapp/src/git/commands/shared.ts
+++ b/packages/webapp/src/git/commands/shared.ts
@@ -133,8 +133,19 @@ export const GIT_FLAG_SPECS: Record<string, ArgSpec> = {
   },
 };
 
+/** Scalar value mri may store for a parsed CLI flag. */
+export type GitFlagScalar = string | number | boolean;
+
+/**
+ * Parsed git subcommand flags from `parseArgs` / mri. Values are typically
+ * {@link GitFlagScalar} or a repeated array; {@link flagString} narrows at read time.
+ */
+export interface GitParsedFlags {
+  readonly [flag: string]: unknown;
+}
+
 /** Read a value-flag as a string, treating empty (`--flag` with no value) as undefined. */
-export function flagString(flags: Record<string, unknown>, name: string): string | undefined {
+export function flagString(flags: GitParsedFlags, name: string): string | undefined {
   const value = flags[name];
   if (value === undefined) return undefined;
   const str = Array.isArray(value) ? String(value[value.length - 1]) : String(value);

--- a/packages/webapp/src/git/commands/show.ts
+++ b/packages/webapp/src/git/commands/show.ts
@@ -3,7 +3,7 @@
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
 import { diffCommits, diffInitialCommit } from './diff.js';
-import { flagString, GIT_FLAG_SPECS } from './shared.js';
+import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function show(
@@ -11,7 +11,8 @@ export async function show(
   cwd: string,
   args: string[]
 ): Promise<GitCommandResult> {
-  const { flags, positionals } = parseArgs(args, GIT_FLAG_SPECS.show);
+  const { flags: rawFlags, positionals } = parseArgs(args, GIT_FLAG_SPECS.show);
+  const flags = rawFlags as GitParsedFlags;
   const stat = flags.stat === true;
   const format = flagString(flags, 'format');
   const ref = positionals[0];

--- a/packages/webapp/src/git/commands/tag.ts
+++ b/packages/webapp/src/git/commands/tag.ts
@@ -2,7 +2,7 @@
 
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
-import { flagString, GIT_FLAG_SPECS } from './shared.js';
+import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function tag(
@@ -10,7 +10,8 @@ export async function tag(
   cwd: string,
   args: string[]
 ): Promise<GitCommandResult> {
-  const { flags, positionals: positional } = parseArgs(args, GIT_FLAG_SPECS.tag);
+  const { flags: rawFlags, positionals: positional } = parseArgs(args, GIT_FLAG_SPECS.tag);
+  const flags = rawFlags as GitParsedFlags;
   const deleteFlag = flags.delete === true;
   const listPattern = flagString(flags, 'list');
   const annotate = flags.annotate === true;

--- a/packages/webapp/tests/git/git-commands-shared.test.ts
+++ b/packages/webapp/tests/git/git-commands-shared.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { flagString, type GitParsedFlags } from '../../src/git/commands/shared.js';
+
+describe('flagString', () => {
+  it('returns undefined for a missing flag', () => {
+    const flags: GitParsedFlags = {};
+    expect(flagString(flags, 'message')).toBeUndefined();
+  });
+
+  it('coerces a string value', () => {
+    expect(flagString({ message: 'hello' }, 'message')).toBe('hello');
+  });
+
+  it('coerces a numeric value', () => {
+    expect(flagString({ depth: 3 }, 'depth')).toBe('3');
+  });
+
+  it('uses the last repeated value from an array', () => {
+    expect(flagString({ message: ['first', 'second'] }, 'message')).toBe('second');
+  });
+
+  it('treats an empty string as undefined', () => {
+    expect(flagString({ message: '' }, 'message')).toBeUndefined();
+  });
+
+  it('treats an empty array element as undefined', () => {
+    expect(flagString({ message: [''] }, 'message')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Replace `Record<string, unknown>` on `flagString` with named `GitParsedFlags` / `GitFlagScalar` types so parsed git CLI flags have an explicit boundary type.
- Add focused unit tests for `flagString` (scalar, repeated, empty-value edge cases).
- Ratchet `record-string-unknown-baseline.json` to remove `packages/webapp/src/git/commands/shared.ts`.

## Debt cleared

- `record-string-unknown` — `packages/webapp/src/git/commands/shared.ts`

## Verification

- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/git/git-commands-shared.test.ts packages/webapp/tests/git/git-error-format.test.ts`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`