### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/providers/adaptive-thinking.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -44,7 +44,6 @@
   "packages/webapp/src/kernel/telemetry.ts": 1,
   "packages/webapp/src/net/handoff-link.ts": 1,
   "packages/webapp/src/net/link-header.ts": 1,
-  "packages/webapp/src/providers/adaptive-thinking.ts": 1,
   "packages/webapp/src/providers/built-in/azure-openai.ts": 2,
   "packages/webapp/src/providers/built-in/bedrock-camp.ts": 31,
   "packages/webapp/src/providers/built-in/local-llm.ts": 2,

--- a/packages/webapp/src/providers/adaptive-thinking.ts
+++ b/packages/webapp/src/providers/adaptive-thinking.ts
@@ -100,8 +100,31 @@ export function thinkingLevelToEffort(
   return clampXhighEffort(base, model?.id, model?.name);
 }
 
-type Params = Record<string, unknown>;
-type PayloadHook = (params: Params, model: unknown) => Params | Promise<Params>;
+/** Thinking block while inspecting or rewriting an Anthropic stream body. */
+interface AdaptiveThinkingBlock {
+  type?: string;
+  display?: string;
+  budget_tokens?: number;
+}
+
+/** Bedrock adaptive-thinking effort on the stream body. */
+interface AdaptiveOutputConfig {
+  effort?: string;
+}
+
+/** Fields this shim reads or rewrites; other Anthropic body keys pass through unchanged. */
+export interface AdaptiveThinkingPayload {
+  thinking?: AdaptiveThinkingBlock;
+  output_config?: AdaptiveOutputConfig;
+  model?: string;
+  max_tokens?: number;
+  tagged?: boolean;
+}
+
+type PayloadHook = (
+  params: AdaptiveThinkingPayload,
+  model: unknown
+) => AdaptiveThinkingPayload | Promise<AdaptiveThinkingPayload>;
 
 /**
  * Build an `onPayload` hook that converts pi-ai's legacy enabled-thinking body
@@ -114,13 +137,13 @@ type PayloadHook = (params: Params, model: unknown) => Params | Promise<Params>;
 export function adaptiveThinkingPayloadHook(effort: string, prior?: PayloadHook): PayloadHook {
   return async (params, model) => {
     const base = prior ? ((await prior(params, model)) ?? params) : params;
-    const thinking = base.thinking as { type?: string; display?: string } | undefined;
+    const thinking = base.thinking;
     if (thinking && thinking.type === 'enabled') {
       base.thinking = {
         type: 'adaptive',
         ...(thinking.display !== undefined ? { display: thinking.display } : {}),
       };
-      base.output_config = { ...((base.output_config as object) ?? {}), effort };
+      base.output_config = { ...(base.output_config ?? {}), effort };
     }
     return base;
   };

--- a/packages/webapp/tests/providers/adaptive-thinking.test.ts
+++ b/packages/webapp/tests/providers/adaptive-thinking.test.ts
@@ -1,22 +1,23 @@
 import { describe, expect, it } from 'vitest';
 
+import {
+  type AdaptiveThinkingPayload,
+  adaptiveThinkingPayloadHook,
+  modelNeedsAdaptiveThinkingShim,
+  thinkingLevelToEffort,
+  withAdaptiveThinkingShim,
+} from '../../src/providers/adaptive-thinking.js';
+
 /** Option bag whose type carries the onPayload the shim may attach. */
 type ShimOptions = {
   reasoning?: string;
   effort?: string;
   apiKey?: string;
   onPayload?: (
-    payload: Record<string, unknown>,
+    payload: AdaptiveThinkingPayload,
     model: never
-  ) => Record<string, unknown> | Promise<Record<string, unknown>>;
+  ) => AdaptiveThinkingPayload | Promise<AdaptiveThinkingPayload>;
 };
-
-import {
-  adaptiveThinkingPayloadHook,
-  modelNeedsAdaptiveThinkingShim,
-  thinkingLevelToEffort,
-  withAdaptiveThinkingShim,
-} from '../../src/providers/adaptive-thinking.js';
 
 describe('modelNeedsAdaptiveThinkingShim', () => {
   it.each([
@@ -158,7 +159,7 @@ describe('adaptiveThinkingPayloadHook', () => {
   });
 
   it('composes with a prior onPayload (prior runs first)', async () => {
-    const prior = (p: Record<string, unknown>) => ({ ...p, tagged: true });
+    const prior = (p: AdaptiveThinkingPayload) => ({ ...p, tagged: true });
     const hook = adaptiveThinkingPayloadHook('medium', prior);
     const out = await hook({ thinking: { type: 'enabled', budget_tokens: 1024 } }, {} as never);
     expect(out.tagged).toBe(true);


### PR DESCRIPTION
## Summary

- Replace `Record<string, unknown>` in `adaptive-thinking.ts` with named types (`AdaptiveThinkingBlock`, `AdaptiveOutputConfig`, exported `AdaptiveThinkingPayload`) for the `onPayload` hook.
- Update tests to use the exported payload type instead of open bags.
- Ratchet `record-string-unknown-baseline.json` (removed the single grandfathered occurrence for this file).

## Debt cleared

- **record-string-unknown** — `packages/webapp/src/providers/adaptive-thinking.ts`

## Verification

- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/providers/adaptive-thinking.test.ts` (40 tests)
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK