### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/biome-configuration.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -53,7 +53,6 @@
   "packages/webapp/src/shell/arg-parser.ts": 2,
   "packages/webapp/src/shell/bsh-watchdog.ts": 1,
   "packages/webapp/src/shell/mcp/store.ts": 2,
-  "packages/webapp/src/shell/supplemental-commands/biome-configuration.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/jsh-biome-source.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/picker-popup.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/console.ts": 1,

--- a/packages/webapp/src/shell/supplemental-commands/biome-configuration.ts
+++ b/packages/webapp/src/shell/supplemental-commands/biome-configuration.ts
@@ -1,6 +1,16 @@
 import { joinPath, normalizePath, splitPath } from '../../fs/path-utils.js';
 
-export type BiomeConfiguration = Record<string, unknown>;
+/** Scalar JSON values in biome configuration files. */
+type BiomeJsonScalar = string | number | boolean | null;
+
+/** Recursive JSON nodes accepted anywhere in a biome configuration document. */
+export type BiomeJsonValue = BiomeJsonScalar | BiomeJsonValue[] | { [key: string]: BiomeJsonValue };
+
+/** Path-based or inline plugin reference from biome.json `plugins`. */
+export type BiomePluginEntry = string | { path: string; [key: string]: BiomeJsonValue };
+
+/** Parsed biome.json / biome.jsonc root object for `@biomejs/js-api` `applyConfiguration`. */
+export type BiomeConfiguration = { [key: string]: BiomeJsonValue };
 
 const BIOME_JS_API_VERSION = __BIOME_JS_API_VERSION__;
 
@@ -115,26 +125,32 @@ function stripTrailingCommas(source: string): string {
   return output;
 }
 
+function isBiomeConfiguration(value: unknown): value is BiomeConfiguration {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 export function parseBiomeJsonc(source: string): BiomeConfiguration {
   const withoutBom = source.charCodeAt(0) === 0xfeff ? source.slice(1) : source;
-  const parsed = JSON.parse(stripTrailingCommas(stripJsonComments(withoutBom))) as unknown;
-  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+  const parsed: unknown = JSON.parse(stripTrailingCommas(stripJsonComments(withoutBom)));
+  if (!isBiomeConfiguration(parsed)) {
     throw new Error('configuration must contain a JSON object');
   }
-  return parsed as BiomeConfiguration;
+  return parsed;
+}
+
+function pluginPath(plugin: BiomeJsonValue): string | null {
+  if (typeof plugin === 'string') return plugin;
+  if (plugin === null || typeof plugin !== 'object' || Array.isArray(plugin)) return null;
+  const path = plugin.path;
+  return typeof path === 'string' ? path : null;
 }
 
 function firstPathPlugin(configuration: BiomeConfiguration): string | null {
-  if (!Array.isArray(configuration.plugins)) return null;
-  for (const plugin of configuration.plugins) {
-    if (typeof plugin === 'string') return plugin;
-    if (
-      plugin !== null &&
-      typeof plugin === 'object' &&
-      typeof (plugin as { path?: unknown }).path === 'string'
-    ) {
-      return (plugin as { path: string }).path;
-    }
+  const plugins = configuration.plugins;
+  if (!Array.isArray(plugins)) return null;
+  for (const plugin of plugins) {
+    const path = pluginPath(plugin);
+    if (path !== null) return path;
   }
   return null;
 }


### PR DESCRIPTION
## Summary

- Replaced `Record<string, unknown>` in `biome-configuration.ts` with named `BiomeJsonValue`, `BiomePluginEntry`, and `BiomeConfiguration` types.
- Added `isBiomeConfiguration` boundary guard for parsed JSONC and `pluginPath` helper for plugin path extraction without unsafe casts.
- Ratcheted `record-string-unknown-baseline.json` (removed this file from the debt list).

## Debt cleared

- `record-string-unknown` — `packages/webapp/src/shell/supplemental-commands/biome-configuration.ts`

## Verification

- `npx biome check --write packages/webapp/src/shell/supplemental-commands/biome-configuration.ts`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/biome-command.test.ts`
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`