### PR TITLE
fix(shell): let `webhook create` omit --scoop like crontask/fswatch

### DIFF
--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -322,7 +322,7 @@ own.
 - `wc-live-freezer.ts` resolves the target once, up front, with `rootForSelection(scoops, selected)` (`ui/wc/wc-unit-context.ts`): a selected root is itself, a selected scoop walks `parentJid` up to the root that owns it, nothing selected falls back to `defaultRootOf`. The resolution happens BEFORE the freeze's awaits, so a roster refresh mid-freeze cannot move the target between archive and clear, and the same root is re-selected afterwards.
 - `freezeConeSession` / `runNewSessionFreeze` take a `cone: { folder, label? }` (`FreezerConeRef`). Omitted, they target the primary cone — every pre-#2272 caller is unchanged.
 - The rail's expanded action row (`<slicc-freezer-new>`, `expanded`) is one fixed-height line of icon buttons with tooltips: **New chat** (freeze + extract memories, same cone), **New chat, fast** (freeze, memories extracted later), **Discard** (no freezer, no memories, same cone), then **New cone** / **Drop cone** under the flag. Collapsed, the single badge keeps its click / double-click / long-press gesture. Under `agentic-memory` the fast action is hidden (`no-skip`).
-- Licks a cone produces come back to it: every root except the untargeted default carries `SLICC_LICK_TARGET=<folder>` in its shell (`buildScoopShellEnv`), and every producer a cone's shell can start falls back to it — see "Addressing licks to a cone" below. That default is `rootsOf(scoops)[0]` — the **oldest** root, which is what `routeFormattedLickToCone` falls back to — resolved by jid against the live roster, _not_ by asking who holds the reserved `cone` folder: after the original primary is dropped, `coneFolderFor` hands that freed folder to the next new cone, which would then look primary while an older root is still the untargeted destination.
+- Licks a cone produces come back to it: every unit except the untargeted default carries `SLICC_LICK_TARGET=<folder>` in its shell (`buildScoopShellEnv`), and every producer a unit's shell can start falls back to it — see "Addressing licks to a cone" below. That default is `rootsOf(scoops)[0]` — the **oldest** root, which is what `routeFormattedLickToCone` falls back to — resolved by jid against the live roster, _not_ by asking who holds the reserved `cone` folder: after the original primary is dropped, `coneFolderFor` hands that freed folder to the next new cone, which would then look primary while an older root is still the untargeted destination.
 - `clear-chat` carries an optional `scoopJid`; `Bridge.handleClearChat` clears that root's live context and deletes `chatSessionIdFor(target)`. An unknown or absent jid falls back to the default root and `session-cone`.
 - Archives record their provenance: `cone` (the folder) plus `coneLabel` for extra cones only, in both the index entry and the archive frontmatter — so a rebuild from `/sessions/*.md` recovers it and the enrichment rename preserves it. `memorySkipped` rides the frontmatter for the same reason: `pendingEnrichment` comes back from the `pending-` filename, so an index-only marker would be dropped by a rebuild and the next catch-up would mine a chat that opted out. There is **one Freezer for all cones**: the rail card never names the cone; the thawed chat log opens with a `Frozen chat · from cone Research` caption (`frozenProvenanceEl`, a `<slicc-day-separator>` prepended to the thread column). The primary cone and legacy archives with no `cone` field read `Frozen chat` and are treated as the primary cone's.
 - Thawing stays read-only, so it can never overwrite another cone's view; when a thaw fails, the fallback selection goes to the cone the archive named (`rootForConeFolder`), not blindly to the primary one.
@@ -457,8 +457,9 @@ where it came from. The `discovery` guard sits after resolution and before the
 lick id is minted, so a non-browsing scoop never leaves a dangling registry
 entry.
 
-**Every producer a cone's shell can start follows the invoking unit**, so an
-extra cone's events come back to it rather than to the oldest root:
+**Every producer a unit's shell can start follows the invoking unit**, so an
+extra cone's (or a scoop's) events come back to it rather than to the oldest
+root:
 
 | Producer            | How it picks a target                                                               |
 | ------------------- | ----------------------------------------------------------------------------------- |
@@ -467,7 +468,7 @@ extra cone's events come back to it rather than to the oldest root:
 | `crontask create`   | `--scoop`, else `defaultLickTarget(…, ctx.env)`                                     |
 | `webhook create`    | `--scoop`, else `defaultLickTarget(…, ctx.env)` (#2525)                             |
 | workflow completion | `getStartingRoot(parentJid)` in `kernel/host.ts` stamps the starting root's folder  |
-| `sprinkle open`     | claims an **unrouted** sprinkle for the opening cone; an existing route always wins |
+| `sprinkle open`     | claims an **unrouted** sprinkle for the opening unit; an existing route always wins |
 
 **All three lick-producing commands treat an omitted `--scoop` the same way**,
 and that uniformity is the contract callers write against. `webhook create`
@@ -480,15 +481,25 @@ to whoever asked — inexpressible for webhooks, which pushed skills into
 hardcoding the literal folder `cone` and delivering another cone's callbacks
 into the default root's chat.
 
-`SLICC_LICK_TARGET` is absent from the default root's shell on purpose — its
-folder is not worth spending as an alias when an untargeted lick already lands
-there, and reading it from a folder test rather than from the live roster is
-the bug described in the bullet above. So a caller with no target at all (the
-default root, or a scoop, whose licks are the cone's business) omits `--scoop`,
-gets `undefined`, and `routeFormattedLickToCone` delivers to
+`SLICC_LICK_TARGET` is absent from **exactly one** shell, the default root's —
+its folder is not worth spending as an alias when an untargeted lick already
+lands there, and reading it from a folder test rather than from the live roster
+is the bug described in the bullet above. Only that shell omits `--scoop` and
+gets `undefined`, whereupon `routeFormattedLickToCone` delivers to
 `rootsOf(scoops)[0]`. Skills should never hardcode `cone`: that folder is
 reassigned to the next new cone once the original primary is dropped, so the
 literal names the wrong unit in exactly the workspaces where naming matters.
+
+**Scoops carry it too** (Codex P1 on #2525). `ownLickTargetFor` has always
+answered `scoop.folder` for a child, and `tools.ts` has always stamped that on
+the licks background `bash` produces — but `buildScoopShellEnv` used to drop it
+for a non-cone unit, so the env-driven producers in the SAME shell disagreed
+with `bash` in it: `fswatch`/`crontask`/`webhook` fell through to the default
+root and delivered a scoop's own callbacks into an unrelated cone's chat,
+payload included. Whoever set the watcher up is who hears about it. This is
+distinct from "users never talk to a scoop" (#2312), which governs what a scoop
+needs from a **human** — that still escalates to the owning cone; an automation
+event is work for the scoop that registered it, not a question for anyone.
 
 **From outside the cone's shell**, the same handles work as an explicit flag:
 `webhook create --scoop <cone>`, `crontask create --scoop <cone>`,

--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -460,19 +460,35 @@ entry.
 **Every producer a cone's shell can start follows the invoking unit**, so an
 extra cone's events come back to it rather than to the oldest root:
 
-| Producer            | How it picks a target                                                                   |
-| ------------------- | --------------------------------------------------------------------------------------- |
-| background `bash`   | `ownLickTargetFor` stamps `targetScoop` (#2272)                                         |
-| `fswatch create`    | `--scoop`, else `defaultLickTarget(…, ctx.env)` (#2272)                                 |
-| `crontask create`   | `--scoop`, else `defaultLickTarget(…, ctx.env)`                                         |
-| `webhook create`    | `--scoop`, else `defaultLickTarget(…, ctx.env)`; still required when neither is present |
-| workflow completion | `getStartingRoot(parentJid)` in `kernel/host.ts` stamps the starting root's folder      |
-| `sprinkle open`     | claims an **unrouted** sprinkle for the opening cone; an existing route always wins     |
+| Producer            | How it picks a target                                                               |
+| ------------------- | ----------------------------------------------------------------------------------- |
+| background `bash`   | `ownLickTargetFor` stamps `targetScoop` (#2272)                                     |
+| `fswatch create`    | `--scoop`, else `defaultLickTarget(…, ctx.env)` (#2272)                             |
+| `crontask create`   | `--scoop`, else `defaultLickTarget(…, ctx.env)`                                     |
+| `webhook create`    | `--scoop`, else `defaultLickTarget(…, ctx.env)` (#2525)                             |
+| workflow completion | `getStartingRoot(parentJid)` in `kernel/host.ts` stamps the starting root's folder  |
+| `sprinkle open`     | claims an **unrouted** sprinkle for the opening cone; an existing route always wins |
+
+**All three lick-producing commands treat an omitted `--scoop` the same way**,
+and that uniformity is the contract callers write against. `webhook create`
+alone used to reject it (`--scoop is required`), a rule inherited from a time
+when an untargeted lick had nowhere to go and would have been silently dropped;
+#2311 gave untargeted licks a destination and left the rejection behind
+(#2525). Its only remaining effect was to make the one gesture that is correct
+in a multi-cone workspace — name no target, let the runtime route the lick back
+to whoever asked — inexpressible for webhooks, which pushed skills into
+hardcoding the literal folder `cone` and delivering another cone's callbacks
+into the default root's chat.
 
 `SLICC_LICK_TARGET` is absent from the default root's shell on purpose — its
 folder is not worth spending as an alias when an untargeted lick already lands
 there, and reading it from a folder test rather than from the live roster is
-the bug described in the bullet above.
+the bug described in the bullet above. So a caller with no target at all (the
+default root, or a scoop, whose licks are the cone's business) omits `--scoop`,
+gets `undefined`, and `routeFormattedLickToCone` delivers to
+`rootsOf(scoops)[0]`. Skills should never hardcode `cone`: that folder is
+reassigned to the next new cone once the original primary is dropped, so the
+literal names the wrong unit in exactly the workspaces where naming matters.
 
 **From outside the cone's shell**, the same handles work as an explicit flag:
 `webhook create --scoop <cone>`, `crontask create --scoop <cone>`,

--- a/packages/vfs-root/workspace/skills/automation/SKILL.md
+++ b/packages/vfs-root/workspace/skills/automation/SKILL.md
@@ -19,9 +19,9 @@ SLICC's automation primitives turn external or VFS-internal events into **licks*
 | `crontask` | Cron schedule                | Recurring background work         |
 | `fswatch`  | VFS create / modify / delete | React to authored content changes |
 
-All three take `--scoop <target>`, which names **a unit, not a species**: a scoop name, a cone name, or a folder (`cone-<slug>`, `<name>-scoop`). Omit it and events come back to the cone you are in. A target naming no live unit is dropped, never re-routed.
+All three take `--scoop <target>`, which names **a unit, not a species**: a scoop name, a cone name, or a folder (`cone-<slug>`, `<name>-scoop`). Omit it and events come back to whichever unit you are — the cone you are in, or the scoop itself if you are one. A target naming no live unit is dropped, never re-routed.
 
-**If you want your own events, omit `--scoop` — never hardcode `cone`.** All three commands behave identically here, so omitting the flag is always available. The literal folder `cone` is not a synonym for "me": it belongs to whichever cone currently holds it, and it is handed to the next new cone after the original one is dropped. A skill that hardcodes it delivers its callbacks into another cone's chat in exactly the multi-cone workspaces where the target matters.
+**If you want your own events, omit `--scoop` — never hardcode `cone`.** All three commands behave identically here, so omitting the flag is always available, and it works the same whether you are a cone or a scoop. The literal folder `cone` is not a synonym for "me": it belongs to whichever cone currently holds it, and it is handed to the next new cone after the original one is dropped. A skill that hardcodes it delivers its callbacks into another cone's chat in exactly the multi-cone workspaces where the target matters.
 
 ## `webhook`
 

--- a/packages/vfs-root/workspace/skills/automation/SKILL.md
+++ b/packages/vfs-root/workspace/skills/automation/SKILL.md
@@ -21,6 +21,8 @@ SLICC's automation primitives turn external or VFS-internal events into **licks*
 
 All three take `--scoop <target>`, which names **a unit, not a species**: a scoop name, a cone name, or a folder (`cone-<slug>`, `<name>-scoop`). Omit it and events come back to the cone you are in. A target naming no live unit is dropped, never re-routed.
 
+**If you want your own events, omit `--scoop` — never hardcode `cone`.** All three commands behave identically here, so omitting the flag is always available. The literal folder `cone` is not a synonym for "me": it belongs to whichever cone currently holds it, and it is handed to the next new cone after the original one is dropped. A skill that hardcodes it delivers its callbacks into another cone's chat in exactly the multi-cone workspaces where the target matters.
+
 ## `webhook`
 
 Receive HTTP callbacks. The lick carries the request method, path, headers, and body; `create` allocates a path and prints the URL.
@@ -28,12 +30,13 @@ Receive HTTP callbacks. The lick carries the request method, path, headers, and 
 ```bash
 webhook create --scoop pr-watcher --name gh-prs
 webhook create --scoop Research --name inbox   # a cone, by name
+webhook create --name inbox                    # your own cone
 webhook list && webhook delete wh-1
 ```
 
 Flags:
 
-- `--scoop <target>` — scoop name, cone name, or folder. Required for webhooks.
+- `--scoop <target>` — scoop name, cone name, or folder. Omit for your own cone.
 - `--name <label>` — label shown in `webhook list`.
 - `--filter <js>` — JS expression per request; falsy drops the event before the agent sees it.
 

--- a/packages/webapp/src/scoops/scoop-context/shell-env.ts
+++ b/packages/webapp/src/scoops/scoop-context/shell-env.ts
@@ -29,16 +29,26 @@ import type { RegisteredScoop } from '../types.js';
  * The cone pins nothing — its shell resolves onboarding's `/home/<slug>`.
  * Secrets spread FIRST: a user-created secret can carry any POSIX name —
  * including PATH/HOME/USER — and must not override the isolation pins
- * (Codex P2 on #2143). Exported for tests.
+ * (Codex P2 on #2143), nor the lick target. Exported for tests.
+ *
+ * **Every unit that has a target carries it, scoops included** (Codex P1 on
+ * #2525). `ownLickTargetFor` already answers `scoop.folder` for a child and
+ * `tools.ts` already stamps that answer on the licks background `bash`
+ * produces — but this function used to drop it for a non-cone unit, so the
+ * env-driven producers (`fswatch`, `crontask`, `webhook`) in the SAME shell
+ * disagreed with `bash` in it: they fell through to `rootsOf(scoops)[0]` and
+ * delivered a scoop's own callbacks into an unrelated cone's chat. Whoever
+ * set the watcher up is who hears about it.
  */
 export function buildScoopShellEnv(
   isCone: boolean,
   folder: string,
   secretEnv: Record<string, string>,
-  /** Folder a non-primary cone's untargeted licks default to (`SLICC_LICK_TARGET`). */
+  /** Folder this unit's untargeted licks default to (`SLICC_LICK_TARGET`). */
   lickTarget?: string
 ): Record<string, string> {
-  if (isCone) return { ...secretEnv, ...(lickTarget ? { [LICK_TARGET_ENV]: lickTarget } : {}) };
+  const lickTargetEnv: Record<string, string> = lickTarget ? { [LICK_TARGET_ENV]: lickTarget } : {};
+  if (isCone) return { ...secretEnv, ...lickTargetEnv };
   return {
     ...secretEnv,
     HOME: `/scoops/${folder}/home`,
@@ -49,6 +59,7 @@ export function buildScoopShellEnv(
       `/scoops/${folder}/workspace/bin`,
       ...DEFAULT_JSH_SEARCH_ROOTS,
     ].join(':'),
+    ...lickTargetEnv,
   };
 }
 

--- a/packages/webapp/src/shell/lick-target-env.ts
+++ b/packages/webapp/src/shell/lick-target-env.ts
@@ -4,11 +4,15 @@
  * Untargeted licks (no `--scoop`, no `targetScoop`) route to the **default
  * root** — `rootsOf(scoops)[0]`, the oldest one. That is right for the
  * default root itself and for scoops (their licks are the cone's business),
- * but a second cone registering a watcher or a cron task from its own shell
- * expects the events back in *its* chat — so every other root's shell
- * carries its folder here, and the lick-producing
- * command (`fswatch`; `crontask` follows in #2311, its file sits behind the
- * boy-scout debt gate) falls back to it when `--scoop` is absent (#2272).
+ * but a second cone registering a watcher, a cron task or a webhook from its
+ * own shell expects the events back in *its* chat — so every other root's
+ * shell carries its folder here, and every lick-producing command
+ * (`fswatch`, `crontask`, `webhook`) falls back to it when `--scoop` is
+ * absent (#2272, #2311, #2525).
+ *
+ * Absent both, the value is `undefined` and the lick is untargeted, which is
+ * a routable answer rather than an error — omitting `--scoop` is how a caller
+ * says "whoever I am" without knowing who that is (#2525).
  */
 export const LICK_TARGET_ENV = 'SLICC_LICK_TARGET';
 

--- a/packages/webapp/src/shell/lick-target-env.ts
+++ b/packages/webapp/src/shell/lick-target-env.ts
@@ -2,17 +2,20 @@
  * The shell variable that names the unit an untargeted lick should go to.
  *
  * Untargeted licks (no `--scoop`, no `targetScoop`) route to the **default
- * root** — `rootsOf(scoops)[0]`, the oldest one. That is right for the
- * default root itself and for scoops (their licks are the cone's business),
- * but a second cone registering a watcher, a cron task or a webhook from its
- * own shell expects the events back in *its* chat — so every other root's
- * shell carries its folder here, and every lick-producing command
- * (`fswatch`, `crontask`, `webhook`) falls back to it when `--scoop` is
- * absent (#2272, #2311, #2525).
+ * root** — `rootsOf(scoops)[0]`, the oldest one. That is right for the default
+ * root itself, but a second cone (or a scoop) registering a watcher, a cron
+ * task or a webhook from its own shell expects the events back in *its* own
+ * chat — so every unit EXCEPT that default root carries its folder here
+ * (`ownLickTargetFor` decides, `buildScoopShellEnv` stamps), and every
+ * lick-producing command (`fswatch`, `crontask`, `webhook`) falls back to it
+ * when `--scoop` is absent (#2272, #2311, #2525).
  *
- * Absent both, the value is `undefined` and the lick is untargeted, which is
- * a routable answer rather than an error — omitting `--scoop` is how a caller
- * says "whoever I am" without knowing who that is (#2525).
+ * So the variable is missing from exactly one shell — the default root's,
+ * whose folder is not worth spending as an alias when an untargeted lick
+ * already lands there. Absent both, the value is `undefined` and the lick is
+ * untargeted, which is a routable answer rather than an error: omitting
+ * `--scoop` is how a caller says "whoever I am" without knowing who that
+ * is (#2525).
  */
 export const LICK_TARGET_ENV = 'SLICC_LICK_TARGET';
 

--- a/packages/webapp/src/shell/supplemental-commands/webhook-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/webhook-command.ts
@@ -31,11 +31,12 @@ Commands:
   delete <id>                                                  Delete a webhook by ID
 
 Options:
-  --scoop <target>  Scoop name, cone name, or folder. Required outside a cone.
+  --scoop <target>  Scoop name, cone name, or folder. Omit for your own cone.
   --filter <code>   JS filter function: (event) => false (drop), true (keep), or object (transform)
                     The event has: type, webhookId, webhookName, timestamp, headers, body
 
 Examples:
+  webhook create --name inbox
   webhook create --scoop click-handler --name clicks
   webhook create --scoop pr-reviewer --name github --filter "(e) => e.body.action === 'opened'"
   webhook create --scoop slack-relay --name slack --filter "(e) => ({ text: e.body.text, user: e.body.user })"
@@ -112,19 +113,15 @@ async function handleCreate(
   const name = parsed.values.get('--name') ?? 'default';
   const filter = parsed.values.get('--filter');
   // No `--scoop`: a non-primary cone's shell names itself (SLICC_LICK_TARGET),
-  // so `webhook create` inside an extra cone routes back to that cone (#2311).
-  // The default root carries no such variable, so it still has to say where
-  // the callbacks go — the pre-#2311 rule, unchanged for it.
+  // exactly as `crontask` and `fswatch` do, so an extra cone's callbacks come
+  // back to its own chat (#2311). A shell with no target at all (the default
+  // root, a scoop) leaves this `undefined` and the event routes to the default
+  // root in `routeFormattedLickToCone` — omitting the flag is how a caller says
+  // "whoever I am" without having to know the answer (#2525). `webhook create`
+  // used to reject that, from a time before untargeted licks had a
+  // destination; they have had one since #2311, so the rejection only blocked
+  // the one spelling that is correct in a multi-cone workspace.
   const scoop = defaultLickTarget(parsed.values.get('--scoop'), env);
-
-  if (!scoop) {
-    return {
-      stdout: '',
-      stderr:
-        "webhook create: --scoop is required (name a scoop or a cone; an extra cone's shell supplies its own)\n",
-      exitCode: 1,
-    };
-  }
 
   // Filter compilation requires dynamic JS evaluation; Chrome
   // extension CSP forbids it. crontask has the same gate. Users

--- a/packages/webapp/tests/scoops/scoop-shell-env.test.ts
+++ b/packages/webapp/tests/scoops/scoop-shell-env.test.ts
@@ -23,6 +23,31 @@ describe('buildScoopShellEnv', () => {
     );
   });
 
+  it('a scoop carries SLICC_LICK_TARGET too, so its own licks come back to it (Codex P1 on #2525)', () => {
+    // `ownLickTargetFor` answers `scoop.folder` for a child and `tools.ts`
+    // already stamps it on background-`bash` licks. Dropping it here made the
+    // env-driven producers (`fswatch`/`crontask`/`webhook`) in the SAME shell
+    // fall through to `rootsOf(scoops)[0]` and deliver a scoop's callbacks
+    // into an unrelated cone's chat.
+    const env = buildScoopShellEnv(false, 'helper-scoop', {}, 'helper-scoop');
+    expect(env[LICK_TARGET_ENV]).toBe('helper-scoop');
+    // The isolation pins still hold alongside it.
+    expect(env.HOME).toBe('/scoops/helper-scoop/home');
+    expect(env.USER).toBe('helper-scoop');
+  });
+
+  it('a secret cannot spoof a scoop lick target either', () => {
+    expect(
+      buildScoopShellEnv(false, 'helper-scoop', { [LICK_TARGET_ENV]: 'cone' }, 'helper-scoop')[
+        LICK_TARGET_ENV
+      ]
+    ).toBe('helper-scoop');
+  });
+
+  it('a scoop with no target stays untargeted rather than inventing one', () => {
+    expect(buildScoopShellEnv(false, 'research', {})[LICK_TARGET_ENV]).toBeUndefined();
+  });
+
   it('the cone pins nothing — only secrets pass through', () => {
     const env = buildScoopShellEnv(true, 'main', { API_KEY: 'masked' });
     expect(env).toEqual({ API_KEY: 'masked' });

--- a/packages/webapp/tests/shell/supplemental-commands/webhook-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/webhook-command.test.ts
@@ -72,11 +72,39 @@ describe('webhook command — help and argument validation', () => {
     expect(result.stdout).toContain('webhook <command>');
   });
 
-  it('rejects create without --scoop', async () => {
+  it('help documents the omitted --scoop, matching crontask (#2525)', async () => {
+    // The help text is what a skill author reads before hardcoding a target,
+    // so it has to state the same rule the code now follows. `crontask` is the
+    // reference wording; a divergence here is how #2525 stayed invisible.
+    const { command } = await loadCommandAndTrayLeader();
+    const { createCrontaskCommand } = await import(
+      '../../../src/shell/supplemental-commands/crontask-command.js'
+    );
+    const webhookHelp = await command.execute(['--help'], {} as never);
+    const crontaskHelp = await createCrontaskCommand().execute(['--help'], {} as never);
+    const rule = '--scoop <target>  Scoop name, cone name, or folder. Omit for your own cone.';
+    expect(webhookHelp.stdout).toContain(rule);
+    expect(crontaskHelp.stdout).toContain(rule);
+    expect(webhookHelp.stdout).not.toContain('Required outside a cone');
+  });
+
+  it('accepts create without --scoop, leaving the webhook untargeted (#2525)', async () => {
+    // The pre-#2525 rule was `--scoop is required`, inherited from a time when
+    // an untargeted lick had nowhere to go. It has had a destination since
+    // #2311, so an omitted flag is a routable answer, not an error.
+    const createWebhook = vi.fn().mockResolvedValue({
+      id: 'wh-2525',
+      name: 'test',
+      createdAt: new Date().toISOString(),
+    } satisfies WebhookEntry);
+    (globalThis as Record<string, unknown>).__slicc_lickManager = buildLickManagerMock({
+      createWebhook,
+    });
     const { command } = await loadCommandAndTrayLeader();
     const result = await command.execute(['create', '--name', 'test'], {} as never);
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain('--scoop is required');
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain('--scoop is required');
+    expect(createWebhook).toHaveBeenCalledWith('test', undefined, undefined);
   });
 
   it('rejects unknown subcommand', async () => {
@@ -900,10 +928,32 @@ describe('webhook create — default lick target (#2311)', () => {
     expect(createWebhook).toHaveBeenCalledWith('inbox', 'pr-reviewer', undefined);
   });
 
-  it('still requires --scoop in a shell that carries no target', async () => {
+  it('passes undefined through in a shell that carries no target (#2525)', async () => {
+    // The default root's shell and a scoop's shell both carry no
+    // SLICC_LICK_TARGET by design, so this is the "route to whoever I am"
+    // gesture — `routeFormattedLickToCone` resolves it to `rootsOf(scoops)[0]`.
+    // Matches `crontask create` / `fswatch create`, which never rejected it.
+    const { result, createWebhook } = await createWithEnv(['create', '--name', 'inbox'], {});
+    expect(result.exitCode).toBe(0);
+    expect(createWebhook).toHaveBeenCalledWith('inbox', undefined, undefined);
+  });
+
+  it('omits the Scoop: line for an untargeted webhook (#2525)', async () => {
+    // `entry.scoop` is undefined, so the receipt must not print a routing line
+    // it cannot name — the same shape `crontask create` prints.
     const { result } = await createWithEnv(['create', '--name', 'inbox'], {});
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain('--scoop is required');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Created webhook "inbox"');
+    expect(result.stdout).not.toContain('Scoop:');
+  });
+
+  it('an empty --scoop falls through to the shell default rather than erroring', async () => {
+    const { result, createWebhook } = await createWithEnv(
+      ['create', '--name', 'inbox', '--scoop', ''],
+      { SLICC_LICK_TARGET: 'cone-research' }
+    );
+    expect(result.exitCode).toBe(0);
+    expect(createWebhook).toHaveBeenCalledWith('inbox', 'cone-research', undefined);
   });
 
   it('accepts a cone name as --scoop', async () => {


### PR DESCRIPTION
Fixes #2525

## Summary

`webhook create` now accepts an omitted `--scoop`, exactly as `crontask create` and `fswatch create` already do. All three lick-producing commands resolve a target the same way: `--scoop`, else `defaultLickTarget(…, ctx.env)`, else untargeted.

Before: `webhook create --name probe` from the default root's shell exited 1 with `--scoop is required`. Now it succeeds, creates an untargeted webhook, and the callbacks route to the default root — the same shape `crontask create` has always printed.

A second commit fixes the related hole a review found: a **scoop's** shell was not carrying `SLICC_LICK_TARGET` at all, so its own automation events went to an unrelated cone. See "Review follow-up" below.

## Why

Omitting `--scoop` is the gesture that is *correct* in a multi-cone workspace: don't name a target, let the runtime route the lick back to whoever is asking. It worked for two of the three lick-producing commands and failed for the third, so a skill that wanted cone-correct routing could not simply omit the flag — it had to name a target, and the only target it could hardcode was the default root's. That is exactly how licks end up in the wrong cone's chat. #2525 reports it happening live: the `slack` skill hardcodes `const DEFAULT_WATCH_SCOOP = 'cone'`, `cone-helix` posted a DM, and both replies woke the default root instead.

**Repro** (from the default root's shell, where `SLICC_LICK_TARGET` is unset by design):

1. `webhook create --name probe-notarget --filter '() => false'`
2. `crontask create --name probe-notarget2 --cron "5 4 1 1 *" --filter '() => false'`

Expected: both succeed and route to the default root.
Actual (before this PR): (1) exits 1 with `--scoop is required`; (2) succeeds.

### Was there a deliberate rationale for the strict check?

The issue asked me to check for one before removing it, on the theory that a webhook URL is externally reachable in a way a cron task is not, so an unattended endpoint silently defaulting into someone's chat may have been judged genuinely more dangerous. **I looked, and there is no rationale that still holds.**

The branch was introduced in 229bb6ee ("Implement worker-backed webhook forwarding and require --scoop on create", landed as part of the large tray PR #90). Its stated reason is one sentence:

> Also makes --scoop mandatory on `webhook create` to prevent events from being **silently dropped** when no routing target is specified.

The concern is *dropped events*, not external reachability — and it was correct when written, because in March 2026 an untargeted lick had nowhere to go. #2311 then gave untargeted licks a destination: `routeFormattedLickToCone` (`kernel/host.ts:332`) resolves a missing `targetScoop` to `rootsOf(scoops)[0]`, and deliberately distinguishes that from a *targeted* lick naming a unit that is gone, which is warned about and dropped. So the premise the rejection rested on was removed two releases ago and the check outlived its reason.

That leaves nothing to reconcile: the original rationale is now satisfied more directly by the routing fallback than by the error. Nothing in the commit, the PR, or the surrounding code argues for treating webhooks differently from cron tasks on reachability grounds. Had the rationale been about reachability I would have proposed the issue's alternative (keep the error, add a spelling for "route to whoever I am") — but omitting the flag is already that spelling in the other two commands, so inventing a second one would only move the divergence somewhere new.

The hardcoded literal is also wrong in a second, subtler way worth recording: per the contract doc in `lick-target-env.ts`, the default root is the *oldest* root, deliberately **not** the holder of the reserved `cone` folder, because that folder is handed to the next new cone once the original primary is dropped. So `'cone'` names the wrong unit in exactly the workspaces where naming matters. The docs and the agent-facing skill now say so explicitly.

## Review follow-up: scoops now carry their own lick target

Codex raised a P1 on the omission path — with a scoop, not a cone, and it was right. I verified it rather than taking it at face value, and the cause turned out to be a **dropped stamp rather than a decision**:

- `ownLickTargetFor` already answers `scoop.folder` for a child (`display.role === 'child'`).
- `runtime-init.ts` already passes that answer into `buildScoopShellEnv` as `lickTarget`.
- `tools.ts:96` already stamps the same value as `targetScoop` on the licks background `bash` produces.
- But `buildScoopShellEnv` **threw it away in its non-cone branch** — it only spread `LICK_TARGET_ENV` in the `isCone` path.

So two producers in the *same* scoop shell disagreed: `bash` licks came back to the scoop, while the env-driven ones (`fswatch`, `crontask`, `webhook`) fell through to `rootsOf(scoops)[0]` and delivered a scoop's own callbacks — payload included — into an unrelated cone's chat. `buildScoopShellEnv`'s own doc comment names "`fswatch`/`crontask` via `SLICC_LICK_TARGET`" as the consumer, so honouring the value is what the function always meant to do. Fixed by spreading it in both branches, after `secretEnv` so a secret still cannot spoof it (same ordering rule as the Codex P2 on #2143).

**One deliberate divergence from the suggestion: the target is the scoop itself, not its owning cone.** `ownLickTargetFor` already answers `scoop.folder` for children, so resolving to the owning cone would contradict an existing documented function and make `bash` and `fswatch` disagree in a new way instead of an old one. An automation event is work for the scoop that registered it, and scoops are first-class lick targets already (`webhook create --scoop pr-reviewer` is the primary documented use). The rule Codex cited — "users never talk to a scoop", #2312 — governs what a scoop needs from a **human**; that still escalates to the owning cone through the approval router and is untouched. The core concern (payload landing in an unrelated conversation) is addressed either way.

This was **pre-existing for `fswatch`/`crontask`** and not introduced by the `webhook` change, so the fix repairs them too. I treated it as in scope anyway, because the agent-facing `automation` SKILL.md in this same diff now tells every unit to omit the flag — which would have actively steered scoops onto the broken path.

## Approach / Implementation notes

- The `webhook` half of the change is deleting the `if (!scoop)` branch in `handleCreate`. `createWebhook(name, scoop?, filter?)` already took `scoop` as optional at every layer (`lick-manager.ts`, `lick-manager-proxy.ts`, `lick-surface.ts`), and the receipt already gated its `Scoop:` line on `entry.scoop`, so nothing downstream needed a change.
- **`--scoop` present but unresolvable is untouched** — that is #2524, running in parallel. The two diffs are disjoint: this one deletes an argument-validation branch and adds an env stamp, and never goes near `matchLickTargetAlias` or its drop path. Expect to rebase.
- I checked for a cone-vs-scoop distinction to preserve in the *command* and there was none: `defaultLickTarget` reads only `SLICC_LICK_TARGET`. The right place to make a scoop name itself was the env stamp, not a caller-species check inside one of three commands — which would have re-created the divergence this PR removes.

## Cross-cutting impact

- **Floats**: the command change is float-agnostic argument parsing in `webapp/src/shell/`, so CLI, extension side panel, offscreen, Electron and hosted-leader all pick it up identically. The extension path was checked specifically: `lick-manager-proxy.ts` already forwards a `scoop` of `undefined` over `BroadcastChannel` and resolution happens once in the kernel host. Covered by an existing proxy round-trip test.
- **The env stamp reaches every producer that reads `SLICC_LICK_TARGET`**, which is the point, so it also changes two neighbours for a scoop's shell: `fswatch`/`crontask` now come back to the scoop instead of the default root (the fix), and `sprinkle open` now claims an unrouted sprinkle for the opening scoop rather than leaving it unrouted. Both align with background `bash` in the same shell.
- **Other callers of the changed contract**: `buildScoopShellEnv` has one production call site (`shell-and-skills.ts`), which already computed and passed `lickTarget`; no signature change.
- **Persisted state**: `WebhookEntry.scoop` was already optional and already persisted as such. An untargeted entry is the same shape a pre-#2311 entry could have; no migration.
- **Security**: no change to who can reach a webhook URL, how one is minted, or what is logged. The deleted check gated *routing*, not exposure. The env stamp strictly narrows exposure — a scoop's payloads stop being delivered into another unit's conversation — and is spread after `secretEnv` so a user secret cannot spoof it.

## Test plan

- [x] `npx prettier --write <changed-files>` — CI runs `prettier --check .` as a lint gate
- [x] `npm run verify` — 7/7 (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod)
- [x] `npm run typecheck`
- [x] `npm run test` — 17,329 passing, 46 skipped, no new failures
- [x] `npm run build`
- [x] **New / changed behavior is covered by unit tests** in `packages/webapp/tests/shell/supplemental-commands/webhook-command.test.ts` and `packages/webapp/tests/scoops/scoop-shell-env.test.ts`
- [ ] Manual smoke — not run; the change is exercised by the unit suite through the same seam the shell uses

`webhook-command.test.ts`: the two tests that asserted the rejection are inverted, plus new coverage for untargeted create passing `undefined` to `createWebhook`, the receipt omitting the `Scoop:` line it cannot name, an empty `--scoop` falling through to the shell default, and a test pinning the help wording to `crontask`'s so the two cannot drift again.

`scoop-shell-env.test.ts`: three new cases — a scoop carries its target, a secret cannot spoof it, and a unit with no target stays untargeted rather than inventing one.

### On `multiple-cones-licks.test.ts`

I checked whether it should cover the webhook case, and **did not extend it**, for a topology reason rather than a judgement call. There is no e2e coverage for `webhook` or `crontask` at all today; that file covers `fswatch` only. Extending it needs a real HTTP POST to arrive, and in the harness's standalone topology it cannot: the webapp is served by `wrangler dev` on the leader origin, so the URL `webhook create` prints is `${wranglerOrigin}/webhooks/<id>`, while the receiver for that path (`POST /webhooks/:id`) lives on the node-server bridge on another port; the worker only serves the token-scoped tray form `POST /webhook/:token/:webhookId`. So webhook delivery is exercisable only under `tray: true` — new harness infrastructure, orthogonal to this change, and I would rather not add an e2e I cannot run in the same pass. What the command change touches is argument validation, not routing, and the routing path is shared with `fswatch` and already covered there. The webhook e2e gap is real, pre-existing, and worth its own issue.

**Pre-existing failures**: none observed.

## Documentation

- [x] `docs/` — `work-unit.md` producer table recorded the divergence as "still required when neither is present"; now records the uniform rule, why the strict check existed, and that scoops carry their own target
- [x] `packages/vfs-root/workspace/skills/automation/SKILL.md` (agent-facing) — told skill authors `--scoop` was "Required for webhooks", the surface that pushed them toward the hardcoded target. Now documents the omission and warns explicitly against hardcoding `cone` (review category 12, agent skill freshness)
- [x] `webhook --help` gained the untargeted example and matches `crontask`'s wording (category 14)
- [x] Swept the stale `lick-target-env.ts` comment claiming `crontask` "follows in #2311, its file sits behind the boy-scout debt gate"
- [ ] `README.md` — no user-facing surface named the flag's strictness

## Risk & rollback

- **Blast radius**: the command change only turns a former exit-1 into a success; every previously-working invocation resolves to the identical value it did before. The env stamp is the wider of the two — it redirects a scoop's untargeted `fswatch`/`crontask`/`webhook` events from the default root to the scoop itself. That is the bug fix, and it moves delivery *toward* the unit that asked, but it is the change to watch. No flags, kill switches, or env knobs added.
- **Rollback**: revert cleanly. No persisted-state migration — `WebhookEntry.scoop` was already optional, so an untargeted entry created under this PR still loads and deletes fine on a reverted build.
- **Worth a reviewer's own eye**: whether a scoop's automation events belong to the scoop or to its owning cone. I argued for the scoop above (it is what `ownLickTargetFor` already answers, and what background `bash` already does), but it is the judgement call in this PR.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths — the extension proxy forwards an absent `scoop` verbatim and resolution stays in the kernel host
