### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/tests/kernel/realm/js-realm-drain.test.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -350,7 +350,6 @@
         "packages/webapp/providers/adobe.ts",
         "packages/webapp/src/kernel/cdp-worker-proxy.ts",
         "packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts",
-        "packages/webapp/tests/kernel/realm/js-realm-drain.test.ts",
         "packages/webapp/tests/providers/adobe-provider.test.ts"
       ],
       "linter": {

--- a/packages/webapp/tests/kernel/realm/js-realm-drain.test.ts
+++ b/packages/webapp/tests/kernel/realm/js-realm-drain.test.ts
@@ -48,52 +48,60 @@ function makePortPair(): { realm: PortLike; host: PortLike } {
   return { realm, host };
 }
 
+async function handleFakeHostMessage(
+  host: PortLike,
+  event: MessageEvent,
+  opts: { delayMs?: number; hangPaths?: Set<string> }
+): Promise<void> {
+  const data = event.data as { type?: string };
+  if (data?.type !== 'realm-rpc-req') return;
+  const req = data as {
+    type: 'realm-rpc-req';
+    id: number;
+    channel: string;
+    op: string;
+    args: unknown[];
+  };
+  if (req.channel === 'vfs' && req.op === 'readFile') {
+    const path = req.args[0] as string;
+    if (opts.hangPaths?.has(path)) {
+      // Never respond — the drain ceiling must cut this off.
+      return;
+    }
+    if (opts.delayMs && opts.delayMs > 0) {
+      await new Promise((r) => setTimeout(r, opts.delayMs));
+    }
+    host.postMessage({
+      type: 'realm-rpc-res',
+      id: req.id,
+      result: 'hello-' + path,
+    });
+    return;
+  }
+  if (req.channel === 'module' && req.op === 'buildGraph') {
+    // These scripts only `require('fs')` (a builtin the realm shim serves),
+    // so the real host would return an empty graph; mirror that here.
+    host.postMessage({
+      type: 'realm-rpc-res',
+      id: req.id,
+      result: { files: [], entryMap: {}, edges: {}, errors: {} },
+    });
+    return;
+  }
+  // Unknown ops — just echo an error so the realm doesn't hang.
+  host.postMessage({
+    type: 'realm-rpc-res',
+    id: req.id,
+    error: `unknown op ${req.channel}.${req.op}`,
+  });
+}
+
 function attachFakeHost(
   host: PortLike,
   opts: { delayMs?: number; hangPaths?: Set<string> } = {}
 ): void {
-  host.addEventListener('message', async (event: MessageEvent) => {
-    const data = event.data as { type?: string };
-    if (data?.type !== 'realm-rpc-req') return;
-    const req = data as {
-      type: 'realm-rpc-req';
-      id: number;
-      channel: string;
-      op: string;
-      args: unknown[];
-    };
-    if (req.channel === 'vfs' && req.op === 'readFile') {
-      const path = req.args[0] as string;
-      if (opts.hangPaths?.has(path)) {
-        // Never respond — the drain ceiling must cut this off.
-        return;
-      }
-      if (opts.delayMs && opts.delayMs > 0) {
-        await new Promise((r) => setTimeout(r, opts.delayMs));
-      }
-      host.postMessage({
-        type: 'realm-rpc-res',
-        id: req.id,
-        result: 'hello-' + path,
-      });
-      return;
-    }
-    if (req.channel === 'module' && req.op === 'buildGraph') {
-      // These scripts only `require('fs')` (a builtin the realm shim serves),
-      // so the real host would return an empty graph; mirror that here.
-      host.postMessage({
-        type: 'realm-rpc-res',
-        id: req.id,
-        result: { files: [], entryMap: {}, edges: {}, errors: {} },
-      });
-      return;
-    }
-    // Unknown ops — just echo an error so the realm doesn't hang.
-    host.postMessage({
-      type: 'realm-rpc-res',
-      id: req.id,
-      error: `unknown op ${req.channel}.${req.op}`,
-    });
+  host.addEventListener('message', (event: MessageEvent) => {
+    void handleFakeHostMessage(host, event, opts);
   });
 }
 


### PR DESCRIPTION
## Summary

- Extracted `handleFakeHostMessage` from the fake-host `message` listener and invoke it with `void`, fixing `nursery.noMisusedPromises` without changing test behavior.
- Removed `packages/webapp/tests/kernel/realm/js-realm-drain.test.ts` from the `noMisusedPromises: "off"` biome override.

## Debt cleared

- **misused-promise** — async callback in `addEventListener` replaced with sync wrapper + explicit `void` on the async helper.

## Verification

- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/kernel/realm/js-realm-drain.test.ts` (3 tests pass)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK