### PR TITLE
refactor: pay down boy-scout debt in packages/cloudflare-worker/src/cloud/auth.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -300,7 +300,6 @@
         "packages/chrome-extension/src/secrets-entry.ts",
         "packages/cloud-core/src/operations/list.ts",
         "packages/cloud-core/src/operations/start.ts",
-        "packages/cloudflare-worker/src/cloud/auth.ts",
         "packages/webapp/src/kernel/realm/http-global.ts",
         "packages/webapp/src/kernel/realm/ws-router-page.ts",
         "packages/webapp/src/net/link-header.ts",

--- a/packages/cloudflare-worker/src/cloud/auth.ts
+++ b/packages/cloudflare-worker/src/cloud/auth.ts
@@ -111,70 +111,112 @@ export interface ValidateBearerEnv {
   REQUIRE_OWNER_ORG: string;
 }
 
-export async function validateBearer(token: string, env: ValidateBearerEnv): Promise<AuthResult> {
-  const proxyConfig = await getProxyConfig(env);
-  const environment = proxyConfig.imsEnvironment || 'prod';
-  const expectedIssuer = getImsHost(environment);
-  const jwks = getJWKS(environment);
+function isJwksUpstreamError(err: unknown): boolean {
+  return (
+    err instanceof errors.JWKSTimeout ||
+    err instanceof errors.JWKSNoMatchingKey ||
+    err instanceof errors.JWKSInvalid ||
+    err instanceof errors.JWKSMultipleMatchingKeys
+  );
+}
 
-  let payload: JWTPayload;
-  try {
-    const { payload: p } = await jwtVerify(token, jwks);
-    payload = p as JWTPayload;
-  } catch (err) {
-    // Discriminate upstream failures (JWKS fetch issues) from token validity issues.
-    // JWKS errors → 503 UPSTREAM_UNAVAILABLE (transient, retry later).
-    // Token errors → 401 INVALID_TOKEN (client must re-authenticate).
-    if (
-      err instanceof errors.JWKSTimeout ||
-      err instanceof errors.JWKSNoMatchingKey ||
-      err instanceof errors.JWKSInvalid ||
-      err instanceof errors.JWKSMultipleMatchingKeys
-    ) {
-      throw new AuthError(
-        'UPSTREAM_UNAVAILABLE',
-        `JWKS service unavailable: ${err instanceof Error ? err.message : String(err)}`
-      );
-    }
-    // Check for fetch errors from jose's createRemoteJWKSet (network issues).
-    const msg = err instanceof Error ? err.message : String(err);
-    if (/fetch failed|network|ECONNREFUSED|ETIMEDOUT/i.test(msg)) {
-      throw new AuthError('UPSTREAM_UNAVAILABLE', `IMS JWKS unreachable: ${msg}`);
-    }
-    // Token validity errors → INVALID_TOKEN.
-    throw new AuthError('INVALID_TOKEN', `JWT verification failed: ${msg}`);
+function isNetworkFetchError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /fetch failed|network|ECONNREFUSED|ETIMEDOUT/i.test(msg);
+}
+
+function mapJwtVerifyError(err: unknown): AuthError {
+  if (isJwksUpstreamError(err)) {
+    return new AuthError(
+      'UPSTREAM_UNAVAILABLE',
+      `JWKS service unavailable: ${err instanceof Error ? err.message : String(err)}`
+    );
   }
+  if (isNetworkFetchError(err)) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return new AuthError('UPSTREAM_UNAVAILABLE', `IMS JWKS unreachable: ${msg}`);
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return new AuthError('INVALID_TOKEN', `JWT verification failed: ${msg}`);
+}
 
+async function verifyJwtPayload(
+  token: string,
+  jwks: ReturnType<typeof createRemoteJWKSet>
+): Promise<JWTPayload> {
+  try {
+    const { payload } = await jwtVerify(token, jwks);
+    return payload as JWTPayload;
+  } catch (err) {
+    throw mapJwtVerifyError(err);
+  }
+}
+
+function validatePayloadClaims(
+  payload: JWTPayload,
+  expectedIssuer: string,
+  clientId: string
+): void {
   if (payload.iss && payload.iss !== expectedIssuer) {
     throw new AuthError('INVALID_TOKEN', `issuer mismatch: ${payload.iss}`);
   }
-  if (payload.client_id !== proxyConfig.clientId) {
+  if (payload.client_id !== clientId) {
     throw new AuthError('INVALID_TOKEN', `client_id mismatch: ${payload.client_id}`);
   }
   if (payload.type !== 'access_token') {
     throw new AuthError('INVALID_TOKEN', `token type is not access_token: ${payload.type}`);
   }
+}
 
+function needsImsProfile(
+  email: string | undefined,
+  ownerOrg: string | undefined,
+  env: ValidateBearerEnv
+): boolean {
+  return !email || (env.REQUIRE_OWNER_ORG === 'true' && !ownerOrg);
+}
+
+async function resolveIdentityFromPayload(
+  payload: JWTPayload,
+  token: string,
+  environment: string,
+  env: ValidateBearerEnv
+): Promise<{ email: string; ownerOrg?: string; userName: string }> {
   let email = payload.email;
   let ownerOrg = payload.ownerOrg;
   let userName = '';
-  if (!email || (env.REQUIRE_OWNER_ORG === 'true' && !ownerOrg)) {
+
+  if (needsImsProfile(email, ownerOrg, env)) {
     const profile = await fetchImsProfile(token, environment);
     email = email || profile.email;
     ownerOrg = ownerOrg || profile.ownerOrg;
     userName = profile.displayName || profile.name || '';
   }
-  if (!email) throw new AuthError('INVALID_TOKEN', 'no email in token or profile');
+
+  if (!email) {
+    throw new AuthError('INVALID_TOKEN', 'no email in token or profile');
+  }
   if (env.REQUIRE_OWNER_ORG === 'true' && !ownerOrg) {
     throw new AuthError('NOT_ALLOWED', `no ownerOrg for ${email}`);
   }
 
+  if (!userName) {
+    const given = payload.given_name ?? '';
+    const family = payload.family_name ?? '';
+    userName = [given, family].filter(Boolean).join(' ') || email;
+  }
+
+  return { email, ownerOrg, userName };
+}
+
+function assertEmailAllowed(email: string, env: ValidateBearerEnv): void {
   const allowedDomains = (env.ALLOWED_EMAIL_DOMAIN || 'adobe.com').split(',').map((d) => d.trim());
-  if (!allowedDomains.includes('*')) {
-    const emailDomain = email.split('@')[1]?.toLowerCase();
-    if (!emailDomain || !allowedDomains.includes(emailDomain)) {
-      throw new AuthError('NOT_ALLOWED', `email domain not allowed: ${email}`);
-    }
+  if (allowedDomains.includes('*')) {
+    return;
+  }
+  const emailDomain = email.split('@')[1]?.toLowerCase();
+  if (!emailDomain || !allowedDomains.includes(emailDomain)) {
+    throw new AuthError('NOT_ALLOWED', `email domain not allowed: ${email}`);
   }
 
   const blocked = (env.BLOCKED_EMAILS || '')
@@ -184,12 +226,24 @@ export async function validateBearer(token: string, env: ValidateBearerEnv): Pro
   if (blocked.includes(email.toLowerCase())) {
     throw new AuthError('NOT_ALLOWED', `email access denied: ${email}`);
   }
+}
 
-  if (!userName) {
-    const given = payload.given_name ?? '';
-    const family = payload.family_name ?? '';
-    userName = [given, family].filter(Boolean).join(' ') || email;
-  }
+export async function validateBearer(token: string, env: ValidateBearerEnv): Promise<AuthResult> {
+  const proxyConfig = await getProxyConfig(env);
+  const environment = proxyConfig.imsEnvironment || 'prod';
+  const expectedIssuer = getImsHost(environment);
+  const jwks = getJWKS(environment);
+
+  const payload = await verifyJwtPayload(token, jwks);
+  validatePayloadClaims(payload, expectedIssuer, proxyConfig.clientId);
+
+  const { email, ownerOrg, userName } = await resolveIdentityFromPayload(
+    payload,
+    token,
+    environment,
+    env
+  );
+  assertEmailAllowed(email, env);
 
   return {
     userId: (payload.sub ?? payload.user_id ?? email) as string,

--- a/packages/cloudflare-worker/src/cloud/auth.ts
+++ b/packages/cloudflare-worker/src/cloud/auth.ts
@@ -211,12 +211,12 @@ async function resolveIdentityFromPayload(
 
 function assertEmailAllowed(email: string, env: ValidateBearerEnv): void {
   const allowedDomains = (env.ALLOWED_EMAIL_DOMAIN || 'adobe.com').split(',').map((d) => d.trim());
-  if (allowedDomains.includes('*')) {
-    return;
-  }
-  const emailDomain = email.split('@')[1]?.toLowerCase();
-  if (!emailDomain || !allowedDomains.includes(emailDomain)) {
-    throw new AuthError('NOT_ALLOWED', `email domain not allowed: ${email}`);
+  // Wildcard bypasses only the domain check; the email blocklist below still runs.
+  if (!allowedDomains.includes('*')) {
+    const emailDomain = email.split('@')[1]?.toLowerCase();
+    if (!emailDomain || !allowedDomains.includes(emailDomain)) {
+      throw new AuthError('NOT_ALLOWED', `email domain not allowed: ${email}`);
+    }
   }
 
   const blocked = (env.BLOCKED_EMAILS || '')

--- a/packages/cloudflare-worker/tests/cloud-auth.test.ts
+++ b/packages/cloudflare-worker/tests/cloud-auth.test.ts
@@ -116,6 +116,23 @@ describe('validateBearer', () => {
     ).rejects.toMatchObject({ code: 'NOT_ALLOWED' });
   });
 
+  it('rejects a denylisted email even when domain is wildcarded', async () => {
+    const token = await makeToken({
+      iss: 'https://ims-na1.adobelogin.com',
+      sub: 'usr-3b',
+      client_id: 'test-client',
+      type: 'access_token',
+      email: 'banned@example.com',
+    });
+    await expect(
+      validateBearer(token, {
+        ...ENV,
+        ALLOWED_EMAIL_DOMAIN: '*',
+        BLOCKED_EMAILS: 'banned@example.com',
+      })
+    ).rejects.toMatchObject({ code: 'NOT_ALLOWED' });
+  });
+
   it('rejects a token without ownerOrg when REQUIRE_OWNER_ORG=true', async () => {
     const token = await makeToken({
       iss: 'https://ims-na1.adobelogin.com',


### PR DESCRIPTION
## Summary

- Refactor `validateBearer` in `packages/cloudflare-worker/src/cloud/auth.ts` by extracting helpers for JWT verification/error mapping, payload claim checks, IMS profile identity resolution, and email allowlist enforcement.
- Remove `packages/cloudflare-worker/src/cloud/auth.ts` from the `complexity.noExcessiveCognitiveComplexity: off` debt override in `biome.json`.

## Debt cleared

- **cognitive-complexity** — all functions now under the biome cap (25).

## Verification

- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/cloudflare-worker/tests/cloud-auth.test.ts` (9 tests)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK
- Pre-push lint gate (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode)