### PR TITLE
refactor: pay down boy-scout debt in packages/cloudflare-worker/src/cloud/handlers.ts

### DIFF
--- a/packages/cloudflare-worker/src/cloud/handlers.ts
+++ b/packages/cloudflare-worker/src/cloud/handlers.ts
@@ -32,10 +32,30 @@ function getDoStub(env: CloudEnv, userId: string): DurableObjectStubLike {
   return env.CLOUD_SESSIONS.get(id);
 }
 
+/** JSON body forwarded to a CloudSessionsDurableObject RPC endpoint. */
+type CloudDoRpcBody =
+  | {
+      bearer: string;
+      name?: string;
+      coneConfig?: unknown;
+      userId: string;
+      workerOrigin: string;
+    }
+  | { userId: string }
+  | { sandboxId: string }
+  | {
+      bearer: string;
+      sandboxId: string;
+      coneConfigDelta?: unknown;
+      localSliccVersion: string;
+      userId: string;
+    }
+  | { sandboxId: string; userId: string };
+
 async function forwardToDo(
   stub: DurableObjectStubLike,
   endpoint: string,
-  body: Record<string, unknown>
+  body: CloudDoRpcBody
 ): Promise<Response> {
   try {
     return await stub.fetch(`https://do${endpoint}`, {

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -4,7 +4,6 @@
   "packages/cherry/src/protocol.ts": 5,
   "packages/chrome-extension/src/bridge-sw.ts": 17,
   "packages/cloud-core/src/cone-config/index.ts": 6,
-  "packages/cloudflare-worker/src/cloud/handlers.ts": 1,
   "packages/cloudflare-worker/src/oauth-exchange.ts": 1,
   "packages/dev-tools/tools/extension-smoke-test.ts": 6,
   "packages/node-server/src/electron-controller.ts": 13,


### PR DESCRIPTION
## Summary
- Replace `Record<string, unknown>` on `forwardToDo` with a named `CloudDoRpcBody` union matching the CloudSessionsDurableObject RPC payloads (start/list/pause/resume/kill/cone-config).
- Ratchet `record-string-unknown-baseline.json` to drop this file (behavior-preserving type cleanup only).

## Debt cleared
- `record-string-unknown` (1 occurrence)

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/cloudflare-worker/tests/cloud-handlers.test.ts packages/cloudflare-worker/tests/cone-config-handler.test.ts`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`