### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/tests/cdp/preview-bridge-cdp-transport.test.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -329,7 +329,6 @@
         "packages/webapp/src/providers/intercepted-oauth.ts",
         "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts",
         "packages/webapp/tests/cdp/cdp-client.test.ts",
-        "packages/webapp/tests/cdp/preview-bridge-cdp-transport.test.ts",
         "packages/webapp/tests/kernel/realm/realm-runner.test.ts",
         "packages/webapp/tests/shell/di/di.test.ts",
         "packages/webapp/tests/ui/provider-settings.test.ts"

--- a/packages/webapp/tests/cdp/preview-bridge-cdp-transport.test.ts
+++ b/packages/webapp/tests/cdp/preview-bridge-cdp-transport.test.ts
@@ -125,14 +125,19 @@ describe('PreviewBridgeCdpTransport', () => {
 
       await transport.connect();
 
-      transport.send('Runtime.evaluate', { expression: '1' });
-      transport.send('Runtime.evaluate', { expression: '2' });
+      const first = transport.send('Runtime.evaluate', { expression: '1' });
+      const second = transport.send('Runtime.evaluate', { expression: '2' });
 
       const requests = sent.filter((m) => m.type === 'bridge.cdp.request') as Array<
         LeaderToWorkerControlMessage & { id: number }
       >;
       expect(requests).toHaveLength(2);
       expect(requests[0].id).toBeLessThan(requests[1].id);
+
+      // Settle the pending sends so they are not floating promises.
+      transport.deliverResponse(requests[0].id, { result: { value: 1 } });
+      transport.deliverResponse(requests[1].id, { result: { value: 2 } });
+      await Promise.all([first, second]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix floating `transport.send()` promises in the request-ID increment test by delivering responses and awaiting them.
- Remove `packages/webapp/tests/cdp/preview-bridge-cdp-transport.test.ts` from the `nursery.noFloatingPromises: "off"` biome exemption list.

## Debt cleared
- `floating-promise` (`biome.json` override for `nursery.noFloatingPromises`)

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npx vitest run packages/webapp/tests/cdp/preview-bridge-cdp-transport.test.ts` (9/9 pass)
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK