### PR TITLE
refactor: pay down boy-scout debt in packages/cloud-core/src/operations/list.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -298,7 +298,6 @@
       "includes": [
         "packages/cherry/src/cdp-host-handlers.ts",
         "packages/chrome-extension/src/secrets-entry.ts",
-        "packages/cloud-core/src/operations/list.ts",
         "packages/cloud-core/src/operations/start.ts",
         "packages/webapp/src/kernel/realm/http-global.ts",
         "packages/webapp/src/kernel/realm/ws-router-page.ts",

--- a/packages/cloud-core/src/operations/list.ts
+++ b/packages/cloud-core/src/operations/list.ts
@@ -1,6 +1,6 @@
 import type { Registry } from '../registry.js';
 import type { SandboxSubstrate } from '../substrate.js';
-import type { ConeEntry } from '../types.js';
+import type { ConeEntry, SandboxSummary } from '../types.js';
 
 export interface ListConesDeps {
   substrate: SandboxSubstrate;
@@ -14,6 +14,188 @@ export interface ListConesOpts {
    * (sees every sandbox in the team account).
    */
   metadata?: Record<string, string>;
+}
+
+const STALE_RESERVATION_MS = 10 * 60 * 1000;
+const DEFAULT_TTL_MS = 60 * 60 * 1000;
+
+/** True when entry metadata matches every key/value in the filter (or no filter). */
+function matchesMetadataFilter(
+  entry: ConeEntry,
+  metadata: Record<string, string> | undefined
+): boolean {
+  if (!metadata) return true;
+  if (!entry.metadata) return false;
+  for (const [k, v] of Object.entries(metadata)) {
+    if (entry.metadata[k] !== v) return false;
+  }
+  return true;
+}
+
+function isStaleReservation(entry: ConeEntry): boolean {
+  // Reclaim if stale OR if reservedAt is missing (legacy/malformed entry
+  // from before commit e9011ba6 — could otherwise wedge cap forever).
+  if (!entry.reservedAt) return true;
+  return Date.now() - new Date(entry.reservedAt).getTime() > STALE_RESERVATION_MS;
+}
+
+/**
+ * Handle a reserved registry entry: reclaim if stale, otherwise keep.
+ * Returns the entry to include in the reconciled list, or null if reclaimed.
+ */
+async function reconcileReserved(entry: ConeEntry, registry: Registry): Promise<ConeEntry | null> {
+  if (!isStaleReservation(entry)) return entry;
+
+  await registry.remove(entry.sandboxId);
+  console.warn('[cloud-core] reclaimed stale reservation', {
+    sandboxId: entry.sandboxId,
+    reservedAt: entry.reservedAt ?? '(missing)',
+  });
+  return null;
+}
+
+/** Mark a missing real sandbox dead (idempotent registry write). */
+async function markDead(entry: ConeEntry, registry: Registry): Promise<ConeEntry> {
+  if (entry.state !== 'dead') {
+    await registry.update(entry.sandboxId, { state: 'dead' });
+  }
+  return { ...entry, state: 'dead' };
+}
+
+/**
+ * Reconcile one non-reserved registry entry against live substrate state.
+ * Mutates liveById (deletes matched sandbox ids).
+ */
+async function reconcileLiveEntry(
+  entry: ConeEntry,
+  liveById: Map<string, SandboxSummary>,
+  registry: Registry
+): Promise<ConeEntry> {
+  const liveEntry = liveById.get(entry.sandboxId);
+  if (!liveEntry) {
+    // Substrate doesn't know about it — mark dead unless it's a placeholder.
+    // The 'pending-' prefix is a sentinel for "no real sandbox yet" (paired
+    // with state:'reserved' by reserveSlot before substrate.create).
+    if (entry.sandboxId.startsWith('pending-')) {
+      return entry;
+    }
+    return markDead(entry, registry);
+  }
+
+  if (entry.state !== liveEntry.state) {
+    await registry.update(entry.sandboxId, { state: liveEntry.state });
+  }
+  liveById.delete(entry.sandboxId);
+  return { ...entry, state: liveEntry.state };
+}
+
+async function reconcileRegistryEntry(
+  entry: ConeEntry,
+  liveById: Map<string, SandboxSummary>,
+  registry: Registry
+): Promise<ConeEntry | null> {
+  // Reserved entries: check for stale reservations (TTL: 10 min) and reclaim.
+  // Stale reservations are from crashed operations that never completed or rolled back.
+  if (entry.state === 'reserved') {
+    return reconcileReserved(entry, registry);
+  }
+  return reconcileLiveEntry(entry, liveById, registry);
+}
+
+interface JoinRecovery {
+  joinUrl: string;
+  trayId: string | undefined;
+  lastJoinUpdatedAt: string | undefined;
+}
+
+/**
+ * Recover joinUrl from /tmp/slicc-join.json ONLY when sandbox is running.
+ * Calling substrate.connect() on a paused sandbox would RESUME it, which:
+ * (a) burns sandbox runtime silently
+ * (b) destabilizes the leader chromium mid-list
+ * Paused orphans surface with joinUrl='' — UI hides the Open button.
+ */
+async function recoverJoinFromSandbox(
+  summary: SandboxSummary,
+  substrate: SandboxSubstrate,
+  seed: JoinRecovery
+): Promise<JoinRecovery> {
+  if (seed.joinUrl || summary.state !== 'running') return seed;
+
+  try {
+    const handle = await substrate.connect(summary.sandboxId);
+    const joinData = await handle.readFile('/tmp/slicc-join.json');
+    const parsed = JSON.parse(joinData) as {
+      joinUrl?: string;
+      trayId?: string;
+      updatedAt?: string;
+    };
+    return {
+      joinUrl: parsed.joinUrl ?? '',
+      trayId: seed.trayId ?? parsed.trayId,
+      lastJoinUpdatedAt: seed.lastJoinUpdatedAt ?? parsed.updatedAt,
+    };
+  } catch (err) {
+    // File not readable (sandbox is transitioning, or file doesn't exist).
+    // Leave joinUrl empty — UI will handle gracefully.
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn('[cloud-core] orphan recovery readFile failed', {
+      sandboxId: summary.sandboxId,
+      err: msg,
+    });
+    return seed;
+  }
+}
+
+/** Rebuild a ConeEntry for a substrate sandbox missing from the registry. */
+async function recoverOrphan(
+  summary: SandboxSummary,
+  substrate: SandboxSubstrate
+): Promise<ConeEntry> {
+  const now = new Date().toISOString();
+  const recoveredJoin = await recoverJoinFromSandbox(summary, substrate, {
+    joinUrl: summary.metadata?.['joinUrl'] ?? '',
+    trayId: summary.metadata?.['trayId'],
+    lastJoinUpdatedAt: summary.metadata?.['lastJoinUpdatedAt'],
+  });
+
+  return {
+    sandboxId: summary.sandboxId,
+    substrate: 'e2b',
+    name: summary.metadata?.['name'] ?? summary.name,
+    createdAt: summary.metadata?.['createdAt'] ?? now,
+    joinUrl: recoveredJoin.joinUrl,
+    lastSeen: now,
+    state: summary.state,
+    trayId: recoveredJoin.trayId,
+    lastJoinUpdatedAt: recoveredJoin.lastJoinUpdatedAt,
+    metadata: summary.metadata,
+  };
+}
+
+/**
+ * Refresh the timeout of every running cone so active users keep their cones
+ * alive past the 1h default. Failures are non-fatal — a sandbox that
+ * disappears between substrate.list() and extendTimeout() will be discovered
+ * dead on the NEXT list call.
+ */
+async function extendRunningTimeouts(
+  cones: ConeEntry[],
+  substrate: SandboxSubstrate
+): Promise<void> {
+  await Promise.all(
+    cones
+      .filter((c) => c.state === 'running')
+      .map(async (c) => {
+        try {
+          await substrate.extendTimeout(c.sandboxId, DEFAULT_TTL_MS);
+        } catch (err) {
+          // Sandbox may have died between list and extendTimeout; ignore.
+          const msg = err instanceof Error ? err.message : String(err);
+          console.warn('[cloud-core] extendTimeout failed', { sandboxId: c.sandboxId, err: msg });
+        }
+      })
+  );
 }
 
 /**
@@ -33,16 +215,6 @@ export async function listCones(
   const live = await deps.substrate.list(opts.metadata ? { metadata: opts.metadata } : undefined);
   const liveById = new Map(live.map((s) => [s.sandboxId, s] as const));
 
-  // Helper to check if an entry matches the metadata filter
-  const matchesFilter = (entry: ConeEntry): boolean => {
-    if (!opts.metadata) return true;
-    if (!entry.metadata) return false;
-    for (const [k, v] of Object.entries(opts.metadata)) {
-      if (entry.metadata[k] !== v) return false;
-    }
-    return true;
-  };
-
   // Pass 1: walk registry; reconcile against live.
   // Reconciliation runs for EVERY registry entry regardless of metadata filter
   // — otherwise zombie entries (e.g. legacy entries without userId metadata)
@@ -51,122 +223,20 @@ export async function listCones(
   // per-user view.
   const reconciled: ConeEntry[] = [];
   for (const entry of registryEntries) {
-    // Reserved entries: check for stale reservations (TTL: 10 min) and reclaim.
-    // Stale reservations are from crashed operations that never completed or rolled back.
-    if (entry.state === 'reserved') {
-      const STALE_MS = 10 * 60 * 1000;
-      // Reclaim if stale OR if reservedAt is missing (legacy/malformed entry
-      // from before commit e9011ba6 — could otherwise wedge cap forever).
-      const isStale =
-        !entry.reservedAt || Date.now() - new Date(entry.reservedAt).getTime() > STALE_MS;
-      if (isStale) {
-        await deps.registry.remove(entry.sandboxId);
-        console.warn('[cloud-core] reclaimed stale reservation', {
-          sandboxId: entry.sandboxId,
-          reservedAt: entry.reservedAt ?? '(missing)',
-        });
-        continue;
-      }
-      // Active reservation — preserve as-is (in-flight operation holding a cap slot)
-      reconciled.push(entry);
-      continue;
-    }
-
-    const liveEntry = liveById.get(entry.sandboxId);
-    if (!liveEntry) {
-      // Substrate doesn't know about it — mark dead unless it's a placeholder.
-      // The 'pending-' prefix is a sentinel for "no real sandbox yet" (paired
-      // with state:'reserved' by reserveSlot before substrate.create).
-      if (entry.sandboxId.startsWith('pending-')) {
-        // Reservation placeholder — no real sandbox yet. Keep it alive.
-        reconciled.push(entry);
-      } else {
-        // Real sandbox is missing — mark dead
-        if (entry.state !== 'dead') {
-          await deps.registry.update(entry.sandboxId, { state: 'dead' });
-        }
-        reconciled.push({ ...entry, state: 'dead' });
-      }
-      continue;
-    }
-    if (entry.state !== liveEntry.state) {
-      await deps.registry.update(entry.sandboxId, { state: liveEntry.state });
-    }
-    reconciled.push({ ...entry, state: liveEntry.state });
-    liveById.delete(entry.sandboxId);
+    const next = await reconcileRegistryEntry(entry, liveById, deps.registry);
+    if (next) reconciled.push(next);
   }
 
   // Pass 2: any substrate entries not in registry → recover.
   for (const summary of liveById.values()) {
-    const now = new Date().toISOString();
-
-    // Try to read the real joinUrl from the sandbox. Orphans created before this
-    // fix won't have it in metadata, but we can read /tmp/slicc-join.json directly.
-    let joinUrl = summary.metadata?.['joinUrl'] ?? '';
-    let trayId = summary.metadata?.['trayId'];
-    let lastJoinUpdatedAt = summary.metadata?.['lastJoinUpdatedAt'];
-
-    // Recover joinUrl from /tmp/slicc-join.json ONLY when sandbox is running.
-    // Calling substrate.connect() on a paused sandbox would RESUME it, which:
-    // (a) burns sandbox runtime silently
-    // (b) destabilizes the leader chromium mid-list
-    // Paused orphans surface with joinUrl='' — UI hides the Open button.
-    // User explicitly resumes via /api/cloud/resume which writes a fresh joinUrl.
-    if (!joinUrl && summary.state === 'running') {
-      try {
-        const handle = await deps.substrate.connect(summary.sandboxId);
-        const joinData = await handle.readFile('/tmp/slicc-join.json');
-        const parsed = JSON.parse(joinData);
-        joinUrl = parsed.joinUrl ?? '';
-        trayId = trayId ?? parsed.trayId;
-        lastJoinUpdatedAt = lastJoinUpdatedAt ?? parsed.updatedAt;
-      } catch (err) {
-        // File not readable (sandbox is transitioning, or file doesn't exist).
-        // Leave joinUrl empty — UI will handle gracefully.
-        const msg = err instanceof Error ? err.message : String(err);
-        console.warn('[cloud-core] orphan recovery readFile failed', {
-          sandboxId: summary.sandboxId,
-          err: msg,
-        });
-      }
-    }
-
-    const recovered: ConeEntry = {
-      sandboxId: summary.sandboxId,
-      substrate: 'e2b',
-      name: summary.metadata?.['name'] ?? summary.name,
-      createdAt: summary.metadata?.['createdAt'] ?? now,
-      joinUrl,
-      lastSeen: now,
-      state: summary.state,
-      trayId,
-      lastJoinUpdatedAt,
-      metadata: summary.metadata,
-    };
+    const recovered = await recoverOrphan(summary, deps.substrate);
     await deps.registry.append(recovered);
     reconciled.push(recovered);
   }
 
-  // Refresh the timeout of every running cone so active users keep their cones
-  // alive past the 1h default. Failures are non-fatal — a sandbox that
-  // disappears between substrate.list() and extendTimeout() will be discovered
-  // dead on the NEXT list call.
-  const DEFAULT_TTL_MS = 60 * 60 * 1000;
-  await Promise.all(
-    reconciled
-      .filter((c) => c.state === 'running')
-      .map(async (c) => {
-        try {
-          await deps.substrate.extendTimeout(c.sandboxId, DEFAULT_TTL_MS);
-        } catch (err) {
-          // Sandbox may have died between list and extendTimeout; ignore.
-          const msg = err instanceof Error ? err.message : String(err);
-          console.warn('[cloud-core] extendTimeout failed', { sandboxId: c.sandboxId, err: msg });
-        }
-      })
-  );
+  await extendRunningTimeouts(reconciled, deps.substrate);
 
   // Apply the metadata filter to the RETURN value only — reconciliation
   // above ran on all entries to keep zombies from accumulating.
-  return reconciled.filter(matchesFilter);
+  return reconciled.filter((e) => matchesMetadataFilter(e, opts.metadata));
 }


### PR DESCRIPTION
## Summary
- Refactored `listCones` into focused helpers (reservation GC, live reconcile, orphan join recovery, timeout extend) so cognitive complexity stays under the biome cap.
- Removed `packages/cloud-core/src/operations/list.ts` from the `complexity.noExcessiveCognitiveComplexity: "off"` override in `biome.json`.
- Behaviour-preserving; existing `packages/cloud-core/tests/list.test.ts` still pins reconciliation, orphan recovery, reservation TTL, and metadata filtering.

## Debt cleared
- `cognitive-complexity` (biome override)

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/cloud-core/tests/list.test.ts` (14 passed)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK