### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/cdp/cdp-ws-page-bridge.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -17,7 +17,6 @@
   "packages/webapp/providers/github.ts": 2,
   "packages/webapp/providers/openai-codex.ts": 2,
   "packages/webapp/src/cdp/cdp-client.ts": 4,
-  "packages/webapp/src/cdp/cdp-ws-page-bridge.ts": 2,
   "packages/webapp/src/cdp/cherry-host-protocol.ts": 5,
   "packages/webapp/src/cdp/cherry-host-transport.ts": 3,
   "packages/webapp/src/cdp/extension-bridge-protocol.ts": 5,

--- a/packages/webapp/src/cdp/cdp-ws-page-bridge.ts
+++ b/packages/webapp/src/cdp/cdp-ws-page-bridge.ts
@@ -30,6 +30,30 @@ const log = createLogger('cdp-ws-page-bridge');
 /** Page-side binding name. Must match `__sliccWsRouterReport` in `ws-router-page.ts`. */
 const BINDING_NAME = '__sliccWsRouterReport';
 
+/**
+ * CDP `Runtime.bindingCalled` params we read. Extra CDP fields may be
+ * present; we only narrow `name` and `payload`.
+ */
+interface RuntimeBindingCalledParams {
+  name?: unknown;
+  payload?: unknown;
+}
+
+/** JSON envelope the page-side router posts through the binding. */
+interface WsRouterBindingReport {
+  subId?: unknown;
+  payload?: unknown;
+}
+
+/**
+ * Patch forwarded to `window.__sliccWsRouter.update`. Tri-state fields:
+ * omit = leave unchanged, `null` = clear, value = set.
+ */
+interface WsRouterUpdatePatch {
+  urlMatch?: string | null;
+  filter?: WsSelector | null;
+}
+
 export interface CdpWsPageBridgeOptions {
   browser: BrowserAPI;
 }
@@ -41,9 +65,9 @@ export class CdpWsPageBridge implements WsPageBridge {
   private frameHandler: ((subId: string, payload: unknown) => void) | null = null;
   private bindingListenerAttached = false;
 
-  private readonly onBindingCalled = (params: Record<string, unknown>): void => {
-    if (params['name'] !== BINDING_NAME) return;
-    const payload = params['payload'];
+  private readonly onBindingCalled = (params: RuntimeBindingCalledParams): void => {
+    if (params.name !== BINDING_NAME) return;
+    const payload = params.payload;
     if (typeof payload !== 'string') return;
     let parsed: unknown;
     try {
@@ -52,9 +76,10 @@ export class CdpWsPageBridge implements WsPageBridge {
       return;
     }
     if (typeof parsed !== 'object' || parsed === null) return;
-    const subId = (parsed as { subId?: unknown }).subId;
+    const report = parsed as WsRouterBindingReport;
+    const subId = report.subId;
     if (typeof subId !== 'string') return;
-    const projection = (parsed as { payload?: unknown }).payload;
+    const projection = report.payload;
     try {
       this.frameHandler?.(subId, projection);
     } catch (err) {
@@ -119,11 +144,11 @@ export class CdpWsPageBridge implements WsPageBridge {
       // `delete` the field, and any value sets it. Without the explicit
       // clear directive, `sub.update({ filter: null })` would leave the
       // page-side router matching with stale criteria.
-      const patch: Record<string, unknown> = {};
-      if (urlMatch === null) patch['urlMatch'] = null;
-      else if (urlMatch !== undefined) patch['urlMatch'] = urlMatch;
-      if (filter === null) patch['filter'] = null;
-      else if (filter !== undefined) patch['filter'] = filter;
+      const patch: WsRouterUpdatePatch = {};
+      if (urlMatch === null) patch.urlMatch = null;
+      else if (urlMatch !== undefined) patch.urlMatch = urlMatch;
+      if (filter === null) patch.filter = null;
+      else if (filter !== undefined) patch.filter = filter;
       const expr = `window.__sliccWsRouter && window.__sliccWsRouter.update(${JSON.stringify(subId)}, ${JSON.stringify(patch)})`;
       await this.browser.sendCDP('Runtime.evaluate', { expression: expr, returnByValue: true });
     });

--- a/packages/webapp/tests/cdp/cdp-ws-page-bridge.test.ts
+++ b/packages/webapp/tests/cdp/cdp-ws-page-bridge.test.ts
@@ -167,4 +167,47 @@ describe('CdpWsPageBridge', () => {
     expect(exprs[2]).toContain('.unregister(');
     bridge.dispose();
   });
+
+  it('forwards explicit null clears in updateSelector patches and omits undefined fields', async () => {
+    const transport = new FakeTransport();
+    const browser = makeFakeBrowser(transport);
+    const bridge = new CdpWsPageBridge({ browser });
+
+    await bridge.installRouter('target-1');
+    transport.sent.length = 0;
+    await bridge.updateSelector('target-1', 'sub-1', null, undefined);
+    await bridge.updateSelector('target-1', 'sub-1', undefined, null);
+    const exprs = transport.sent
+      .filter((c) => c.method === 'Runtime.evaluate')
+      .map((c) => String(c.params?.['expression']));
+    expect(exprs[0]).toContain('"urlMatch":null');
+    expect(exprs[0]).not.toContain('"filter"');
+    expect(exprs[1]).toContain('"filter":null');
+    expect(exprs[1]).not.toContain('"urlMatch"');
+    bridge.dispose();
+  });
+
+  it('ignores malformed Runtime.bindingCalled payloads', async () => {
+    const transport = new FakeTransport();
+    const browser = makeFakeBrowser(transport);
+    const bridge = new CdpWsPageBridge({ browser });
+    const seen: Array<{ subId: string; payload: unknown }> = [];
+    bridge.onMatchedFrame((subId, payload) => {
+      seen.push({ subId, payload });
+    });
+    await bridge.installRouter('target-1');
+
+    transport.emit('Runtime.bindingCalled', { name: '__sliccWsRouterReport', payload: 'not-json' });
+    transport.emit('Runtime.bindingCalled', {
+      name: '__sliccWsRouterReport',
+      payload: JSON.stringify({ payload: { ok: true } }),
+    });
+    transport.emit('Runtime.bindingCalled', {
+      name: '__sliccWsRouterReport',
+      payload: JSON.stringify({ subId: 42, payload: { ok: true } }),
+    });
+    await Promise.resolve();
+    expect(seen).toEqual([]);
+    bridge.dispose();
+  });
 });


### PR DESCRIPTION
## Summary
- Replace the two `Record<string, unknown>` bags in `cdp-ws-page-bridge.ts` with named types (`RuntimeBindingCalledParams`, `WsRouterBindingReport`, `WsRouterUpdatePatch`).
- Clear the file from `record-string-unknown-baseline.json` via the supported `--update` ratchet.
- Extend focused tests for tri-state `updateSelector` null clears and malformed binding payloads.

## Debt lists cleared
- `record-string-unknown` (`packages/dev-tools/tools/record-string-unknown-baseline.json`)

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/cdp/cdp-ws-page-bridge.test.ts`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`
- [ ] CI green on this PR