### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/local-llm-command.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -302,7 +302,6 @@
         "packages/webapp/src/kernel/realm/http-global.ts",
         "packages/webapp/src/kernel/realm/ws-router-page.ts",
         "packages/webapp/src/net/link-header.ts",
-        "packages/webapp/src/shell/supplemental-commands/local-llm-command.ts",
         "packages/webapp/src/shell/supplemental-commands/websocat-command.ts"
       ],
       "linter": {

--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -5,7 +5,6 @@
   "packages/webapp/src/shell/bsh-watchdog.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/hid-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/host-command.ts": 7,
-  "packages/webapp/src/shell/supplemental-commands/local-llm-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/picker-popup.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/interaction.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts": 2,

--- a/packages/webapp/src/shell/supplemental-commands/local-llm-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/local-llm-command.ts
@@ -18,11 +18,14 @@
 
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
+import type { LocalLlmConnectionResult } from '../../providers/built-in/local-llm.js';
 import { config as localLlmConfig } from '../../providers/built-in/local-llm.js';
 
 // Single source of truth: the provider config owns the ID, the command
 // reads it. Keeps the two files from drifting if the ID is ever renamed.
 const PROVIDER_ID = localLlmConfig.id;
+
+type CmdResult = { stdout: string; stderr: string; exitCode: number };
 
 function helpText(): string {
   return `local-llm — inspect and configure the Local LLM provider
@@ -47,16 +50,56 @@ Common base URLs:
 `;
 }
 
+/** Format `kind` / `kind (version)` / `kind version` for status lines. */
+function runtimeLabel(runtime: LocalLlmConnectionResult['runtime'], paren: boolean): string {
+  if (!runtime.version) return runtime.kind;
+  return paren ? `${runtime.kind} (${runtime.version})` : `${runtime.kind} ${runtime.version}`;
+}
+
+function modelBulletLines(models: string[]): string[] {
+  return models.map((m) => `    • ${m}`);
+}
+
+function unreachableResult(baseUrl: string, result: LocalLlmConnectionResult): CmdResult {
+  const lines = [
+    `✗ Could not reach ${baseUrl}`,
+    `  runtime: ${runtimeLabel(result.runtime, true)}`,
+    `  error:   ${result.error?.message ?? 'unknown'}`,
+  ];
+  if (result.error?.hint) lines.push(`  hint:    ${result.error.hint}`);
+  return { stdout: '', stderr: lines.join('\n') + '\n', exitCode: 1 };
+}
+
+function statusResult(baseUrl: string, result: LocalLlmConnectionResult): CmdResult {
+  const lines = [
+    `✓ ${baseUrl}`,
+    `  runtime: ${runtimeLabel(result.runtime, true)}`,
+    `  models:  ${result.models.length}`,
+    ...modelBulletLines(result.models),
+  ];
+  return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
+}
+
+function discoverSavedResult(baseUrl: string, result: LocalLlmConnectionResult): CmdResult {
+  const n = result.models.length;
+  const lines = [
+    `✓ ${baseUrl} (${runtimeLabel(result.runtime, false)})`,
+    `  Saved ${n} model${n === 1 ? '' : 's'} to Settings:`,
+    ...modelBulletLines(result.models),
+  ];
+  return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
+}
+
 export function createLocalLlmCommand(): Command {
   return defineCommand(PROVIDER_ID, async (args) => {
     if (args.includes('--help') || args.includes('-h')) {
       return { stdout: helpText(), stderr: '', exitCode: 0 };
     }
 
-    // Lazy imports — same pattern as other supplemental commands that
-    // reach into the browser settings layer.
+    // Lazy imports — account-store (not ui/provider-settings) so shell stays
+    // below the ui layer; providers/ is unranked and safe for shell to load.
     const { getApiKeyForProvider, getRawApiKeyForProvider, getBaseUrlForProvider, addAccount } =
-      await import('../../ui/provider-settings.js');
+      await import('../../providers/account-store.js');
     const { verifyConnection } = await import('../../providers/built-in/local-llm.js');
 
     const sub = args[0] ?? 'status';
@@ -81,15 +124,7 @@ export function createLocalLlmCommand(): Command {
 
     const result = await verifyConnection(baseUrl, apiKey);
 
-    if (!result.ok) {
-      const lines = [
-        `✗ Could not reach ${baseUrl}`,
-        `  runtime: ${result.runtime.kind}${result.runtime.version ? ` (${result.runtime.version})` : ''}`,
-        `  error:   ${result.error?.message ?? 'unknown'}`,
-      ];
-      if (result.error?.hint) lines.push(`  hint:    ${result.error.hint}`);
-      return { stdout: '', stderr: lines.join('\n') + '\n', exitCode: 1 };
-    }
+    if (!result.ok) return unreachableResult(baseUrl, result);
 
     if (sub === 'discover') {
       // Upsert the deployment field with the freshly discovered list.
@@ -100,21 +135,9 @@ export function createLocalLlmCommand(): Command {
       // edit in Settings and shadowing the optionalApiKey fallback path.
       const rawKey = getRawApiKeyForProvider(PROVIDER_ID) ?? '';
       addAccount(PROVIDER_ID, rawKey, baseUrl, result.models.join(', '));
-      const lines = [
-        `✓ ${baseUrl} (${result.runtime.kind}${result.runtime.version ? ` ${result.runtime.version}` : ''})`,
-        `  Saved ${result.models.length} model${result.models.length === 1 ? '' : 's'} to Settings:`,
-        ...result.models.map((m) => `    • ${m}`),
-      ];
-      return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
+      return discoverSavedResult(baseUrl, result);
     }
 
-    // status
-    const lines = [
-      `✓ ${baseUrl}`,
-      `  runtime: ${result.runtime.kind}${result.runtime.version ? ` (${result.runtime.version})` : ''}`,
-      `  models:  ${result.models.length}`,
-      ...result.models.map((m) => `    • ${m}`),
-    ];
-    return { stdout: lines.join('\n') + '\n', stderr: '', exitCode: 0 };
+    return statusResult(baseUrl, result);
   });
 }

--- a/packages/webapp/tests/shell/supplemental-commands/local-llm-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/local-llm-command.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../../../src/ui/provider-settings.js', () => ({
+vi.mock('../../../src/providers/account-store.js', () => ({
   getApiKeyForProvider: vi.fn(),
   getRawApiKeyForProvider: vi.fn(),
   getBaseUrlForProvider: vi.fn(),
@@ -14,14 +14,14 @@ vi.mock('../../../src/providers/built-in/local-llm.js', () => ({
   config: { id: 'local-llm' },
 }));
 
-import { verifyConnection } from '../../../src/providers/built-in/local-llm.js';
-import { createLocalLlmCommand } from '../../../src/shell/supplemental-commands/local-llm-command.js';
 import {
   addAccount,
   getApiKeyForProvider,
   getBaseUrlForProvider,
   getRawApiKeyForProvider,
-} from '../../../src/ui/provider-settings.js';
+} from '../../../src/providers/account-store.js';
+import { verifyConnection } from '../../../src/providers/built-in/local-llm.js';
+import { createLocalLlmCommand } from '../../../src/shell/supplemental-commands/local-llm-command.js';
 import { mockCommandContext } from '../helpers/mock-command-context.js';
 
 const mockGetApiKey = vi.mocked(getApiKeyForProvider);


### PR DESCRIPTION
## Summary

Pays down boy-scout debt on `packages/webapp/src/shell/supplemental-commands/local-llm-command.ts` (cognitive-complexity + layer-back-edge).

- **Layer back-edge:** lazy-import `providers/account-store` instead of `ui/provider-settings` (same accessors; UI was only a re-export). Shell no longer imports up the stack.
- **Cognitive complexity:** extract `runtimeLabel`, `unreachableResult`, `statusResult`, and `discoverSavedResult` helpers; remove the file from the biome complexity exemption list.
- Ratchet `layer-back-edge-baseline.json` via `--update` (entry removed only).

## Test plan

- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/local-llm-command.test.ts`
- [x] `npx biome check` on touched files
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`
- [x] `npm run lint:layer-back-edges`