### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/kernel/cdp-bridge.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -27,7 +27,6 @@
   "packages/webapp/src/core/types.ts": 2,
   "packages/webapp/src/fs/mount/backend-local.ts": 1,
   "packages/webapp/src/git/commands/rebase.ts": 1,
-  "packages/webapp/src/kernel/cdp-bridge.ts": 7,
   "packages/webapp/src/kernel/cdp-worker-proxy.ts": 3,
   "packages/webapp/src/kernel/port-bridge-client.ts": 2,
   "packages/webapp/src/kernel/realm/helpers/node-assert.ts": 5,

--- a/packages/webapp/src/kernel/cdp-bridge.ts
+++ b/packages/webapp/src/kernel/cdp-bridge.ts
@@ -17,6 +17,8 @@
  * itself a leaf module).
  */
 
+import type { CDPPayload } from '@slicc/shared-ts';
+
 import { PendingRequestTable, waitForEvent } from '../cdp/pending-request-table.js';
 import type { CDPTransport } from '../cdp/transport.js';
 import type { CDPConnectOptions, CDPEventListener, ConnectionState } from '../cdp/types.js';
@@ -24,14 +26,16 @@ import type { CDPConnectOptions, CDPEventListener, ConnectionState } from '../cd
 /** Decoded form of a CDP response, regardless of envelope shape. */
 export interface ParsedCdpResponse {
   id: number;
-  result?: Record<string, unknown>;
+  /** Per-method CDP result; shape is known only to the caller that issued the method. */
+  result?: CDPPayload;
   error?: string;
 }
 
 /** Decoded form of a CDP event, regardless of envelope shape. */
 export interface ParsedCdpEvent {
   method: string;
-  params?: Record<string, unknown>;
+  /** Per-method CDP event params; shape depends on `method`. */
+  params?: CDPPayload;
 }
 
 export interface CdpBridgeOptions {
@@ -42,7 +46,7 @@ export interface CdpBridgeOptions {
   buildCommandEnvelope: (
     id: number,
     method: string,
-    params?: Record<string, unknown>,
+    params?: CDPPayload,
     sessionId?: string
   ) => unknown;
 
@@ -145,10 +149,10 @@ export class CdpTransportBridge implements CDPTransport {
 
   async send(
     method: string,
-    params?: Record<string, unknown>,
+    params?: CDPPayload,
     sessionId?: string,
     timeout = 30000
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CDPPayload> {
     if (this._state !== 'connected') {
       throw new Error(`${this.label} is not connected`);
     }
@@ -195,8 +199,8 @@ export class CdpTransportBridge implements CDPTransport {
     }
   }
 
-  once(event: string, timeout = 30000): Promise<Record<string, unknown>> {
-    return waitForEvent<Record<string, unknown>>(
+  once(event: string, timeout = 30000): Promise<CDPPayload> {
+    return waitForEvent<CDPPayload>(
       (handler) => {
         this.on(event, handler);
         return () => this.off(event, handler);


### PR DESCRIPTION
## Summary
- Replace every `Record<string, unknown>` in `packages/webapp/src/kernel/cdp-bridge.ts` with the existing `CDPPayload` alias from `@slicc/shared-ts` (same type used by `CDPTransport` / `PendingRequestTable`).
- Ratchet `record-string-unknown-baseline.json` to drop this file (7 grandfathered hits cleared).
- Behaviour-preserving type-only change; no runtime logic changed.

## Debt lists cleared
- `record-string-unknown`

## Test plan
- [x] `npx biome check` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/kernel/cdp-worker-proxy.test.ts`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK