### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/playwright/types.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -13,7 +13,6 @@
   "packages/webapp/src/shell/supplemental-commands/playwright/state.ts": 4,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport-storage.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 2,
-  "packages/webapp/src/shell/supplemental-commands/playwright/types.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/rsync-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/secret-backends.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/serial-command.ts": 1,

--- a/packages/webapp/src/shell/supplemental-commands/playwright/types.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/types.ts
@@ -2,10 +2,20 @@
  * Shared types for the playwright-cli command family.
  */
 
-import type { HarRecorder } from '../../../cdp/index.js';
 import type { HandoffMatch } from '../../../net/handoff-link.js';
 import type { ParsedLink } from '../../../net/link-header.js';
-import type { FloatType } from '../../../scoops/tray-leader-sync.js';
+// BrowserAPI / HarRecorder are named via `createServeCommand`'s parameter
+// (same shell layer) rather than imported from `cdp/`, so this module stays
+// inside the shell layer (see layer-stack import direction). FloatType is
+// declared here for the same reason — importing it from `scoops/` would be a
+// back-edge; the string union is identical to the scoops definition.
+import type { createServeCommand } from '../serve-command.js';
+
+type BrowserAPI = NonNullable<Parameters<typeof createServeCommand>[0]>;
+type HarRecorder = ReturnType<BrowserAPI['createHarRecorder']>;
+
+/** Runtime float kind; mirrors scoops/tray-leader without importing up-stack. */
+export type FloatType = 'standalone' | 'extension' | 'electron' | 'ios' | 'unknown';
 
 export type CmdResult = { stdout: string; stderr: string; exitCode: number };
 
@@ -206,7 +216,7 @@ export interface PlaywrightDiscoveryResult {
 
 /** Per-handler context shared by every playwright subcommand handler. */
 export interface PlaywrightHandlerCtx {
-  browser: import('../../../cdp/index.js').BrowserAPI;
+  browser: BrowserAPI;
   fs: import('../../../fs/index.js').VirtualFS;
   state: PlaywrightState;
   positional: string[];


### PR DESCRIPTION
## Summary
- Clear the 3 layer-stack back-edges in `playwright/types.ts` (shell → cdp ×2, shell → scoops ×1) without changing behaviour.
- Name `BrowserAPI` / `HarRecorder` via `Parameters<typeof createServeCommand>` (same shell-layer pattern as `supplemental-commands/index.ts`) and declare `FloatType` locally so the module no longer imports up-stack.
- Ratchet `layer-back-edge-baseline.json` with `--update` (entry removed).

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright` (426 tests)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK