### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/upskill/tabs.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -17,6 +17,5 @@
   "packages/webapp/src/shell/supplemental-commands/secret-backends.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/serial-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/serve-command.ts": 3,
-  "packages/webapp/src/shell/supplemental-commands/upskill/tabs.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/usb-command.ts": 1
 }

--- a/packages/webapp/src/shell/supplemental-commands/upskill/tabs.ts
+++ b/packages/webapp/src/shell/supplemental-commands/upskill/tabs.ts
@@ -11,7 +11,6 @@
  */
 
 import type { SecureFetch } from 'just-bash';
-import type { BrowserAPI, PageInfo } from '../../../cdp/index.js';
 import type { VirtualFS } from '../../../fs/index.js';
 import { extractHandoff, UPSKILL_REL } from '../../../net/handoff-link.js';
 import { parseLinkHeader } from '../../../net/link-header.js';
@@ -25,6 +24,24 @@ import type {
 } from './types.js';
 
 export { normalizeHostname };
+
+/**
+ * Duck type for the CDP surface `upskill tabs` needs — avoids a shell → cdp
+ * layer back-edge (`docs/review-patterns.md` § Layer-stack import direction).
+ * Callers pass the real `BrowserAPI`; this module only reads listPages /
+ * listAllTargets and the PageInfo fields below.
+ */
+interface TabsPageInfo {
+  targetId: string;
+  title: string;
+  url: string;
+  active?: boolean;
+}
+
+interface TabsBrowserAPI {
+  listPages(): Promise<TabsPageInfo[]>;
+  listAllTargets(): Promise<TabsPageInfo[]>;
+}
 
 /**
  * Build the install-hint shell line for an origin-advertised upskill rel.
@@ -153,7 +170,7 @@ function formatTabText(tab: TabUpskillResult): string {
 export async function handleTabs(
   fs: VirtualFS,
   fetchFn: SecureFetch,
-  browser: BrowserAPI | undefined,
+  browser: TabsBrowserAPI | undefined,
   jsonMode: boolean
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   if (!browser) {
@@ -164,7 +181,7 @@ export async function handleTabs(
     };
   }
 
-  let pages: PageInfo[];
+  let pages: TabsPageInfo[];
   try {
     pages = await browser.listPages();
   } catch {


### PR DESCRIPTION
## Summary
- Cleared the **layer-back-edge** debt for `packages/webapp/src/shell/supplemental-commands/upskill/tabs.ts` by replacing the `shell → cdp` type import (`BrowserAPI` / `PageInfo`) with a local duck type that only exposes `listPages` / `listAllTargets` and the page fields this command reads.
- Ratcheted `layer-back-edge-baseline.json` via `check-layer-back-edges.mjs --update` (removed this file only).

## Debt lists cleared
- `layer-back-edge` (`packages/dev-tools/tools/layer-back-edge-baseline.json`)

## Verification
- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/upskill/tabs.test.ts` (10 passed)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK

## Test plan
- [ ] CI lint / typecheck / test green
- [ ] Confirm `check-touched-exemptions` passes on the PR
- [ ] Smoke: `upskill tabs` still lists open tabs / catalog matches when a browser API is injected