### PR TITLE
refactor: pay down boy-scout debt in packages/cloudflare-worker/src/oauth-exchange.ts

### DIFF
--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -769,7 +769,7 @@ async function tryHandleOAuthRoutes(
   return null;
 }
 
-/** The env view the OAuth exchange handlers declare (`EnvRecord` in oauth-exchange.ts). */
+/** The env view the OAuth exchange handlers declare (`OAuthCredentialEnv`). */
 type OAuthHandlerEnv = Parameters<typeof handleOAuthToken>[1];
 
 /** Dev-harness override vars that are deliberately absent from `WorkerEnv`. */

--- a/packages/cloudflare-worker/src/oauth-exchange.ts
+++ b/packages/cloudflare-worker/src/oauth-exchange.ts
@@ -51,14 +51,24 @@ export function handleOAuthMethodNotAllowed(request: Request): Response {
 
 // ── Credential resolution ──────────────────────────────────────────
 
-type EnvRecord = Record<string, unknown>;
+/**
+ * Worker env bindings that hold OAuth client credentials.
+ * Keys match each provider's `clientIdEnvKey` / `clientSecretEnvKey` in
+ * {@link OAUTH_PROVIDERS}. Extend this when registering a new provider.
+ */
+export interface OAuthCredentialEnv {
+  GITHUB_CLIENT_ID?: string;
+  GITHUB_CLIENT_SECRET?: string;
+}
 
 function resolveCredentials(
-  env: EnvRecord,
+  env: OAuthCredentialEnv,
   def: OAuthProviderDef
 ): { clientId: string; clientSecret: string } | null {
-  const clientId = env[def.clientIdEnvKey];
-  const clientSecret = env[def.clientSecretEnvKey];
+  // Registry keys are strings; look up via Reflect so new providers need only
+  // extend {@link OAuthCredentialEnv} + the registry entry.
+  const clientId = Reflect.get(env, def.clientIdEnvKey);
+  const clientSecret = Reflect.get(env, def.clientSecretEnvKey);
   if (typeof clientId !== 'string' || !clientId) return null;
   if (typeof clientSecret !== 'string' || !clientSecret) return null;
   return { clientId, clientSecret };
@@ -68,7 +78,7 @@ function resolveCredentials(
 
 export async function handleOAuthToken(
   request: Request,
-  env: EnvRecord,
+  env: OAuthCredentialEnv,
   fetchImpl: typeof fetch = fetch
 ): Promise<Response> {
   const cors = oauthCorsHeaders(request);
@@ -162,7 +172,7 @@ export async function handleOAuthToken(
 
 export async function handleOAuthRevoke(
   request: Request,
-  env: EnvRecord,
+  env: OAuthCredentialEnv,
   fetchImpl: typeof fetch = fetch
 ): Promise<Response> {
   const cors = oauthCorsHeaders(request);

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -4,7 +4,6 @@
   "packages/cherry/src/protocol.ts": 5,
   "packages/chrome-extension/src/bridge-sw.ts": 17,
   "packages/cloud-core/src/cone-config/index.ts": 6,
-  "packages/cloudflare-worker/src/oauth-exchange.ts": 1,
   "packages/dev-tools/tools/extension-smoke-test.ts": 6,
   "packages/node-server/src/electron-controller.ts": 13,
   "packages/node-server/src/electron-federated-cdp.ts": 5,


### PR DESCRIPTION
## Summary
- Replace `Record<string, unknown>` `EnvRecord` in `oauth-exchange.ts` with a named `OAuthCredentialEnv` interface for the GitHub OAuth client bindings.
- Credential lookup still goes through the provider registry keys via `Reflect.get`, with the same string/empty narrowing as before.
- Ratchet `record-string-unknown-baseline.json` to drop this file (clears the `record-string-unknown` debt list entry).

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/cloudflare-worker/tests/index.test.ts -t "generic OAuth"` (10 passed)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`
- [ ] CI green on the PR