### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/cdp/cdp-client.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -15,7 +15,6 @@
   "packages/webapp/providers/github-copilot.ts": 2,
   "packages/webapp/providers/github.ts": 2,
   "packages/webapp/providers/openai-codex.ts": 2,
-  "packages/webapp/src/cdp/cdp-client.ts": 4,
   "packages/webapp/src/cdp/cherry-host-protocol.ts": 5,
   "packages/webapp/src/cdp/cherry-host-transport.ts": 3,
   "packages/webapp/src/cdp/extension-bridge-protocol.ts": 5,

--- a/packages/webapp/src/cdp/cdp-client.ts
+++ b/packages/webapp/src/cdp/cdp-client.ts
@@ -7,6 +7,8 @@
  * - Session management for target-specific commands
  */
 
+import type { CDPPayload } from '@slicc/shared-ts';
+
 import { createLogger } from '../base/logger.js';
 import { PendingRequestTable, waitForEvent } from './pending-request-table.js';
 import type { CDPTransport } from './transport.js';
@@ -129,10 +131,10 @@ export class CDPClient implements CDPTransport {
    */
   async send(
     method: string,
-    params?: Record<string, unknown>,
+    params?: CDPPayload,
     sessionId?: string,
     timeout = 30000
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CDPPayload> {
     if (this._state !== 'connected' || !this.ws) {
       throw new Error('CDP client is not connected');
     }
@@ -179,8 +181,8 @@ export class CDPClient implements CDPTransport {
   /**
    * Wait for a specific CDP event to fire once.
    */
-  once(event: string, timeout = 30000): Promise<Record<string, unknown>> {
-    return waitForEvent<Record<string, unknown>>(
+  once(event: string, timeout = 30000): Promise<CDPPayload> {
+    return waitForEvent<CDPPayload>(
       (handler) => {
         this.on(event, handler);
         return () => this.off(event, handler);


### PR DESCRIPTION
## Summary
- Replace `Record<string, unknown>` on `CDPClient.send` / `once` with the shared `CDPPayload` type (same shape already used by `CDPTransport` and sibling CDP transports).
- Ratchet `record-string-unknown-baseline.json` to drop this file (4 occurrences cleared).

## Debt lists cleared
- `record-string-unknown`

## Test plan
- [x] `npx biome check --write packages/webapp/src/cdp/cdp-client.ts`
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/cdp/cdp-client.test.ts` (26 passed)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK
- [x] Pre-push verify gate (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode)