### PR TITLE
feat(shell): give every unit its own $TMPDIR under the shared /tmp

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -14,9 +14,23 @@ WASM enters only for specific runtime-heavy commands, which fetch and cache thei
 
 **Entry point**: Via the `bash` agent tool. All shell features available to agents.
 
-### Shared `/tmp` scratch space
+### Shared `/tmp` scratch space and `$TMPDIR`
 
-The virtual `/tmp` directory is shared, disposable scratch space for the cone and scoops; it is not the host operating system's temporary directory. Its cleanup boundary is the explicit **New session** control: **Save & start new**, **New chat — skip memory**, and **Erase & start new** each remove ordinary `/tmp` entries before the cone chat is cleared. Active mount roots below `/tmp` and the directories containing them stay attached and are never traversed, so mounted Local, S3, and DA contents are not treated as scratch data. Page reload, app restart, and scoop creation do not clear `/tmp`.
+The virtual `/tmp` directory is shared, disposable scratch space for the cone and scoops; it is not the host operating system's temporary directory. It stays readable and writable by every unit.
+
+**Write to `$TMPDIR`, not to `/tmp`.** Every unit's shell publishes `$TMPDIR` pointing at a scratch directory of its own, created before the first turn:
+
+| unit                                 | `$TMPDIR`                |
+| ------------------------------------ | ------------------------ |
+| cone `cone`                          | `/tmp/cone`              |
+| cone `cone-adobe`                    | `/tmp/cone-adobe`        |
+| scoop `review` owned by `cone-adobe` | `/tmp/cone-adobe/review` |
+
+A scoop's directory nests inside its owning cone's, so a cone can still read back what its scoop wrote (`agent … >> "$TMPDIR/out.txt"`) and disposing of a cone's scratch disposes of its scoops' too. `mktemp` resolves against `$TMPDIR`. A `.profile` `export TMPDIR=…` overrides it per shell; a secret named `TMPDIR` does not.
+
+This is a **convention, not a sandbox** — one unit can still read and write another's scratch, exactly as on a real POSIX system. What it buys is a directory nothing else _routinely_ touches.
+
+Its cleanup boundary is the explicit **New session** control: **Save & start new**, **New chat — skip memory**, and **Erase & start new** each remove the entries under the selected cone's own `$TMPDIR` before its chat is cleared — a sibling cone's scratch is never in the blast radius. Active mount roots below it and the directories containing them stay attached and are never traversed, so mounted Local, S3, and DA contents are not treated as scratch data. Page reload, app restart, and scoop creation do not clear `/tmp`.
 
 ---
 

--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -223,15 +223,33 @@ file, system prompt), `ConeMemoryStore` / `appendConeMemory`, `scoop_scoop`'s
 and the `agent` command's path defaults, and through those the generated
 per-scoop sudoers.
 
-| Unit                         | Workspace                    | Memory                       | Scratch            |
-| ---------------------------- | ---------------------------- | ---------------------------- | ------------------ |
-| primary cone (folder `cone`) | `/workspace`                 | `/workspace/CLAUDE.md`       | `/tmp`             |
-| extra cone (`cone-<slug>`)   | `/cones/<folder>/workspace`  | `/cones/<folder>/CLAUDE.md`  | `/tmp`             |
-| scoop                        | `/scoops/<folder>/workspace` | `/scoops/<folder>/CLAUDE.md` | `/scoops/<folder>` |
+| Unit                         | Workspace                    | Memory                       | Scratch (`workspaceFor`) | `$TMPDIR` (`tmpDirFor`) |
+| ---------------------------- | ---------------------------- | ---------------------------- | ------------------------ | ----------------------- |
+| primary cone (folder `cone`) | `/workspace`                 | `/workspace/CLAUDE.md`       | `/tmp`                   | `/tmp/cone`             |
+| extra cone (`cone-<slug>`)   | `/cones/<folder>/workspace`  | `/cones/<folder>/CLAUDE.md`  | `/tmp`                   | `/tmp/<folder>`         |
+| scoop                        | `/scoops/<folder>/workspace` | `/scoops/<folder>/CLAUDE.md` | `/scoops/<folder>`       | `/tmp/<cone>/<folder>`  |
+
+`workspaceFor().scratch` is the unit's private _storage_ root (bash overflow,
+agent archives, the per-scoop sudoers). `tmpDirFor()` is the _shell-visible_
+`$TMPDIR` that `mktemp` resolves against. They are deliberately different
+questions and deliberately different answers.
 
 - **The primary cone never moves.** `/workspace` is named by mounts, deep
   links, skills, `upskill`, workflow discovery and every existing profile;
   `isPrimaryRoot` (folder `cone`) keeps it exactly where it was.
+- **Per-unit `$TMPDIR`, under a still-shared `/tmp`** ([#2267](https://github.com/ai-ecoverse/slicc/issues/2267), [#2568](https://github.com/ai-ecoverse/slicc/issues/2568)). Every unit's shell
+  publishes `$TMPDIR` pointing at a directory of its own, created by
+  `ensureDirectoryStructure` before the first turn, and a scoop's nests inside
+  its owning cone's. Living UNDER `/tmp` is the point: `ALWAYS_WRITABLE_PREFIXES`
+  (`fs/restricted-fs.ts`), `BUILTIN_SCOOP_GRANTS` (`base/sudoers.ts`) and every
+  scoop record already persisted with `writablePaths: ['/tmp/']` all keep
+  working untouched, where a path beside the workspace would have needed new
+  prefixes in two layers that gate independently. **It is a convention, not a
+  sandbox** — the grants still expose all of `/tmp` to everyone; narrowing them
+  is a separate decision. What it buys is a disposal boundary: "New chat" on a
+  cone sweeps that cone's subtree (its scoops included) instead of the shared
+  root a sibling cone may be writing to right now, which is the design cause of
+  the incident fixed in [#2566](https://github.com/ai-ecoverse/slicc/pull/2566).
 - **Shared by design**: `/shared`, `/tmp` (the float-wide scratch space
   `builtinScoopGrants` already grants every scoop), `/mnt`, `/scoops`,
   `/sessions`, and the skills library at `/workspace/skills`

--- a/packages/webapp/src/scoops/scoop-context.ts
+++ b/packages/webapp/src/scoops/scoop-context.ts
@@ -47,7 +47,7 @@ import type { AlmostBashShellHeadless } from '../shell/almost-bash-shell-headles
 import type { SudoManager } from '../sudo/sudo-manager.js';
 import { conversationKeyFor, workspaceIdFor } from '../work-unit/conversation/key.js';
 import type { WorkUnitConversationStore } from '../work-unit/conversation/store.js';
-import { toDescriptor } from '../work-unit/descriptor.js';
+import { tmpDirFor, toDescriptor } from '../work-unit/descriptor.js';
 import { rootsOf } from '../work-unit/policy.js';
 import { chatSessionIdFor, processOwnerKindFor } from '../work-unit/record.js';
 import type { WorkUnitDescriptor } from '../work-unit/types.js';
@@ -277,6 +277,16 @@ export class ScoopContext {
     return ownLickTargetFor(this.unit, this.scoop, rootsOf(this.callbacks.getScoops())[0]?.jid);
   }
 
+  /**
+   * This unit's `$TMPDIR`, resolved against the LIVE roster for the same
+   * reason {@link ownLickTarget} is: a scoop's scratch nests under the cone
+   * that owns it, and that edge is a roster lookup, not a field on the
+   * record.
+   */
+  private ownTmpDir(): string {
+    return tmpDirFor(this.callbacks.getScoops(), this.scoop);
+  }
+
   getStructuredOutput() {
     return { captured: this.structuredOutputCaptured, value: this.structuredOutputValue };
   }
@@ -306,6 +316,7 @@ export class ScoopContext {
         coneJid: this.coneJid,
         getTurnPid: () => this.currentTurnProcess?.pid,
         getLickTarget: () => this.ownLickTarget(),
+        getTmpDir: () => this.ownTmpDir(),
         getEffortOverride: () => this.activeEffortOverride,
         isDisposed: () => this.disposed,
         onShellReady: (shell) => {

--- a/packages/webapp/src/scoops/scoop-context/directory-structure.ts
+++ b/packages/webapp/src/scoops/scoop-context/directory-structure.ts
@@ -13,6 +13,7 @@
 import { createLogger } from '../../core/index.js';
 import type { VirtualFS } from '../../fs/index.js';
 import type { RestrictedFS } from '../../fs/restricted-fs.js';
+import { TMP_ROOT } from '../../work-unit/descriptor.js';
 import type { WorkUnitDescriptor } from '../../work-unit/types.js';
 import type { RegisteredScoop } from '../types.js';
 
@@ -21,7 +22,14 @@ const log = createLogger('scoop-context');
 export async function ensureDirectoryStructure(
   fs: VirtualFS | RestrictedFS | null,
   scoop: RegisteredScoop,
-  unit: WorkUnitDescriptor
+  unit: WorkUnitDescriptor,
+  /**
+   * This unit's `$TMPDIR` (`tmpDirFor`). Created eagerly: a shell that
+   * publishes the variable and a `mktemp` that resolves against it both need
+   * the directory to exist before the first turn, and `mkdir -p` is not
+   * something an agent should have to remember (#2267).
+   */
+  tmpDir: string
 ): Promise<void> {
   if (!fs) return;
 
@@ -30,7 +38,7 @@ export async function ensureDirectoryStructure(
   // float-wide directories every unit shares.
   const dirs =
     unit.policy.filesystem.kind === 'full-workspace'
-      ? [unit.workspace.root, '/shared', '/scoops', '/home', '/home/user', '/tmp', '/mnt']
+      ? [unit.workspace.root, '/shared', '/scoops', '/home', '/home/user', TMP_ROOT, tmpDir, '/mnt']
       : [
           `/scoops/${scoop.folder}`,
           `/scoops/${scoop.folder}/workspace`,
@@ -39,8 +47,10 @@ export async function ensureDirectoryStructure(
           '/shared',
           // Shared global scratch space (see `builtinScoopGrants`). Normally
           // the cone has already created it, but a scoop must not depend on
-          // that ordering.
-          '/tmp',
+          // that ordering — and `tmpDir` nests under the OWNING cone's, which
+          // may not have been created yet either. `recursive` covers both.
+          TMP_ROOT,
+          tmpDir,
         ];
 
   for (const dir of dirs) {

--- a/packages/webapp/src/scoops/scoop-context/runtime-init.ts
+++ b/packages/webapp/src/scoops/scoop-context/runtime-init.ts
@@ -51,6 +51,8 @@ export interface RuntimeInitDeps {
   getTurnPid: () => number | undefined;
   /** Live, because the roster it derives from changes as roots come and go. */
   getLickTarget: () => string | undefined;
+  /** Live for the same reason: a scoop's scratch nests under its owning cone's. */
+  getTmpDir: () => string;
   /** Live, because the stream wrapper reads it per request. */
   getEffortOverride: () => string | undefined;
   isDisposed: () => boolean;
@@ -80,13 +82,15 @@ export type ScoopRuntime =
 export async function buildScoopRuntime(deps: RuntimeInitDeps): Promise<ScoopRuntime> {
   const { scoop, unit, fs, callbacks } = deps;
 
+  const tmpDir = deps.getTmpDir();
   log.info('Filesystem ready', { folder: scoop.folder });
-  await ensureDirectoryStructure(fs, scoop, unit);
+  await ensureDirectoryStructure(fs, scoop, unit, tmpDir);
 
   const { shell, gatedFs, skills } = await initShellAndSkills({
     scoop,
     unit,
     fs,
+    tmpDir,
     skillsFs: deps.skillsFs,
     getBrowserAPI: callbacks.getBrowserAPI,
     sudoManager: deps.sudoManager,

--- a/packages/webapp/src/scoops/scoop-context/shell-and-skills.ts
+++ b/packages/webapp/src/scoops/scoop-context/shell-and-skills.ts
@@ -47,6 +47,8 @@ export interface ShellAndSkillsDeps {
   getTurnPid: () => number | undefined;
   /** `SLICC_LICK_TARGET` for this unit, or `undefined` for the default root. */
   lickTarget: string | undefined;
+  /** `$TMPDIR` for this unit (`tmpDirFor`, `work-unit/descriptor.ts`). */
+  tmpDir: string;
 }
 
 export interface ShellAndSkills {
@@ -96,12 +98,13 @@ export async function initShellAndSkills(deps: ShellAndSkillsDeps): Promise<Shel
       : fs
   ) as VirtualFS;
 
-  const shellEnv = buildScoopShellEnv(
-    unit.policy.filesystem.kind === 'full-workspace',
-    scoop.folder,
+  const shellEnv = buildScoopShellEnv({
+    isCone: unit.policy.filesystem.kind === 'full-workspace',
+    folder: scoop.folder,
     secretEnv,
-    deps.lickTarget
-  );
+    tmpDir: deps.tmpDir,
+    ...(deps.lickTarget ? { lickTarget: deps.lickTarget } : {}),
+  });
   const shell = new AlmostBashShellHeadless({
     fs: gatedFs,
     cwd,

--- a/packages/webapp/src/scoops/scoop-context/shell-env.ts
+++ b/packages/webapp/src/scoops/scoop-context/shell-env.ts
@@ -15,8 +15,23 @@ import { LICK_TARGET_ENV } from '../../shell/lick-target-env.js';
 import type { WorkUnitDescriptor } from '../../work-unit/types.js';
 import type { RegisteredScoop } from '../types.js';
 
+export interface ScoopShellEnvOptions {
+  /** `true` for a root unit — a cone pins no HOME/USER/PATH. */
+  isCone: boolean;
+  folder: string;
+  secretEnv: Record<string, string>;
+  /**
+   * This unit's own scratch directory (`tmpDirFor`, `work-unit/descriptor.ts`).
+   * Every unit gets one, cones included — unlike the other pins, which only a
+   * scoop needs.
+   */
+  tmpDir: string;
+  /** Folder this unit's untargeted licks default to (`SLICC_LICK_TARGET`). */
+  lickTarget?: string;
+}
+
 /**
- * The env a scoop's shell starts with (#2085). Non-cone scoops pin:
+ * The env a unit's shell starts with (#2085). Non-cone scoops pin:
  *
  * - HOME to their per-scoop home (created by ensureDirectoryStructure) — it
  *   is inside their writable ACL, unlike `/home`, which their RestrictedFS
@@ -26,10 +41,23 @@ import type { RegisteredScoop } from '../types.js';
  *   scoop-local commands win a basename conflict (mirroring the old scan
  *   order, bounded to declared roots).
  *
- * The cone pins nothing — its shell resolves onboarding's `/home/<slug>`.
+ * The cone pins no HOME/USER/PATH — its shell resolves onboarding's
+ * `/home/<slug>`.
+ *
+ * **TMPDIR is the exception: every unit pins it, cone included** (#2267).
+ * `echo $TMPDIR` printed empty in cone and scoop alike, so nothing could
+ * discover a scratch root at all, and agents reaching for `mktemp` got a
+ * cascade of misleading errors rather than a clean one. It is also the
+ * mechanism the whole per-unit scratch scheme rests on: a cone's `$TMPDIR` is
+ * its own subtree, so "New chat" disposes of that subtree instead of the
+ * shared `/tmp` a sibling cone may be writing to right now
+ * ([#2568](https://github.com/ai-ecoverse/slicc/issues/2568)).
+ *
  * Secrets spread FIRST: a user-created secret can carry any POSIX name —
- * including PATH/HOME/USER — and must not override the isolation pins
- * (Codex P2 on #2143), nor the lick target. Exported for tests.
+ * including PATH/HOME/USER/TMPDIR — and must not override the isolation pins
+ * (Codex P2 on #2143), nor the lick target. A `.profile` `export TMPDIR=…`
+ * still wins, per shell, which is the POSIX contract and deliberate.
+ * Exported for tests.
  *
  * **Every unit that has a target carries it, scoops included** (Codex P1 on
  * #2525). `ownLickTargetFor` already answers `scoop.folder` for a child and
@@ -40,18 +68,14 @@ import type { RegisteredScoop } from '../types.js';
  * delivered a scoop's own callbacks into an unrelated cone's chat. Whoever
  * set the watcher up is who hears about it.
  */
-export function buildScoopShellEnv(
-  isCone: boolean,
-  folder: string,
-  secretEnv: Record<string, string>,
-  /** Folder this unit's untargeted licks default to (`SLICC_LICK_TARGET`). */
-  lickTarget?: string
-): Record<string, string> {
+export function buildScoopShellEnv(options: ScoopShellEnvOptions): Record<string, string> {
+  const { isCone, folder, secretEnv, tmpDir, lickTarget } = options;
   const lickTargetEnv: Record<string, string> = lickTarget ? { [LICK_TARGET_ENV]: lickTarget } : {};
-  if (isCone) return { ...secretEnv, ...lickTargetEnv };
+  if (isCone) return { ...secretEnv, TMPDIR: tmpDir, ...lickTargetEnv };
   return {
     ...secretEnv,
     HOME: `/scoops/${folder}/home`,
+    TMPDIR: tmpDir,
     USER: folder,
     PATH: [
       '/usr/bin',

--- a/packages/webapp/src/shell/almost-bash-shell-headless.ts
+++ b/packages/webapp/src/shell/almost-bash-shell-headless.ts
@@ -475,6 +475,10 @@ export class AlmostBashShellHeadless implements HeadlessShellLike {
       PATH: DEFAULT_SHELL_PATH,
       USER: 'user',
       SHELL: '/bin/bash',
+      // Floor value for a shell with no work unit behind it (the panel
+      // terminal, tests). A unit's own scratch directory is pinned over it by
+      // `buildScoopShellEnv` via `options.env`, which spreads last (#2267).
+      TMPDIR: '/tmp',
       PWD: initialCwd,
       ...options.env,
     };

--- a/packages/webapp/src/ui/new-session.ts
+++ b/packages/webapp/src/ui/new-session.ts
@@ -323,25 +323,39 @@ async function removeDirectoryEntries(
   }
 }
 
-/** Remove all shared scratch data while leaving `/tmp` ready for the next session. */
-export async function resetNewSessionTmp(vfs: NewSessionTmpVfs): Promise<void> {
+/**
+ * Dispose of ONE unit's scratch subtree, leaving it ready for the next
+ * session. `tmpDir` is that unit's `$TMPDIR` (`tmpDirFor`) — a cone's own
+ * `/tmp/<folder>`, which contains its scoops' scratch as well, so a cone's
+ * "New chat" still disposes of everything it owns.
+ *
+ * Scoping this is the fix for a real incident: it used to sweep the whole
+ * shared `/tmp`, so clicking "New chat" on one cone deleted a *sibling*
+ * cone's live working directory. The sibling in that case was mid-`npm
+ * install`, which both lost data and raced the sweep into an `ENOENT` that
+ * aborted the clear (#2566). A unit can now only ever delete its own subtree.
+ *
+ * Mount roots at or under `tmpDir` are preserved exactly as before — a
+ * mounted Local/S3/DA tree is not scratch data.
+ */
+export async function resetNewSessionTmp(vfs: NewSessionTmpVfs, tmpDir: string): Promise<void> {
   const mountRoots = new Set(
     (await vfs.listMountPoints())
       .map(({ path }) => path)
-      .filter((path) => path === '/tmp' || path.startsWith('/tmp/'))
+      .filter((path) => path === tmpDir || path.startsWith(`${tmpDir}/`))
   );
-  if (mountRoots.has('/tmp')) return;
+  if (mountRoots.has(tmpDir)) return;
 
   let entries: DirEntry[];
   try {
-    entries = await vfs.readDir('/tmp');
+    entries = await vfs.readDir(tmpDir);
   } catch (err) {
     if ((err as { code?: string } | null)?.code !== 'ENOENT') throw err;
-    await vfs.mkdir('/tmp', { recursive: true });
+    await vfs.mkdir(tmpDir, { recursive: true });
     return;
   }
-  await removeDirectoryEntries(vfs, '/tmp', entries, mountRoots);
-  await vfs.mkdir('/tmp', { recursive: true });
+  await removeDirectoryEntries(vfs, tmpDir, entries, mountRoots);
+  await vfs.mkdir(tmpDir, { recursive: true });
 }
 
 /** Outcome of the enrichment-vs-timer race. */

--- a/packages/webapp/src/ui/new-session.ts
+++ b/packages/webapp/src/ui/new-session.ts
@@ -295,6 +295,18 @@ function isAlreadyGone(err: unknown): boolean {
   return (err as { code?: string } | null)?.code === 'ENOENT';
 }
 
+/**
+ * `true` when `ancestor` is `path` or a directory containing it.
+ *
+ * The trailing separator is what stops `/tmp/cone` from claiming
+ * `/tmp/cone-adobe`, and the `'/'` special case keeps a root mount an
+ * ancestor of everything rather than of nothing.
+ */
+function containsPath(ancestor: string, path: string): boolean {
+  if (ancestor === path) return true;
+  return path.startsWith(ancestor.endsWith('/') ? ancestor : `${ancestor}/`);
+}
+
 async function removeDirectoryEntries(
   vfs: NewSessionTmpVfs,
   parentPath: string,
@@ -335,16 +347,18 @@ async function removeDirectoryEntries(
  * install`, which both lost data and raced the sweep into an `ENOENT` that
  * aborted the clear (#2566). A unit can now only ever delete its own subtree.
  *
- * Mount roots at or under `tmpDir` are preserved exactly as before — a
- * mounted Local/S3/DA tree is not scratch data.
+ * A mounted Local/S3/DA tree is never scratch data, in either direction:
+ * mounts BELOW `tmpDir` are skipped along with the directories containing
+ * them, and a mount AT OR ABOVE `tmpDir` means the whole scratch tree lives
+ * inside somebody's external storage, so nothing is traversed or created at
+ * all. The second case only became reachable once the sweep root moved from
+ * `/tmp` down to `/tmp/<cone>`: an ancestor mount at `/tmp` used to BE the
+ * sweep root and stop it, and would otherwise now be walked straight through.
  */
 export async function resetNewSessionTmp(vfs: NewSessionTmpVfs, tmpDir: string): Promise<void> {
-  const mountRoots = new Set(
-    (await vfs.listMountPoints())
-      .map(({ path }) => path)
-      .filter((path) => path === tmpDir || path.startsWith(`${tmpDir}/`))
-  );
-  if (mountRoots.has(tmpDir)) return;
+  const mounts = (await vfs.listMountPoints()).map(({ path }) => path);
+  if (mounts.some((mount) => containsPath(mount, tmpDir))) return;
+  const mountRoots = new Set(mounts.filter((path) => path.startsWith(`${tmpDir}/`)));
 
   let entries: DirEntry[];
   try {

--- a/packages/webapp/src/ui/wc/wc-live-freezer.ts
+++ b/packages/webapp/src/ui/wc/wc-live-freezer.ts
@@ -1,5 +1,6 @@
 import { isFeatureEnabled } from '../../core/feature-flags.js';
 import type { RegisteredScoop } from '../../scoops/types.js';
+import { tmpDirFor } from '../../work-unit/descriptor.js';
 import type { BootStageLogger } from '../boot/types.js';
 import type { OffscreenClient } from '../offscreen-client.js';
 import type { FrozenSession } from '../session-freezer.js';
@@ -122,6 +123,8 @@ interface ClearConeSessionDeps {
   getController(): WcChatController | null;
   log: BootStageLogger;
   resetNewSessionTmp: typeof import('../new-session.js').resetNewSessionTmp;
+  /** The cone's own `$TMPDIR` — the only subtree this clear may dispose of. */
+  tmpDir: string;
 }
 
 /**
@@ -137,7 +140,7 @@ interface ClearConeSessionDeps {
  */
 async function clearConeSession(deps: ClearConeSessionDeps): Promise<void> {
   try {
-    await deps.resetNewSessionTmp(deps.writer);
+    await deps.resetNewSessionTmp(deps.writer, deps.tmpDir);
   } catch (err) {
     deps.log.warn('WC new session /tmp reset failed — clearing anyway', err);
   }
@@ -239,7 +242,18 @@ export function wireFreezerRail(deps: FreezerRailDeps): FreezerRailHandles {
             runNewSessionFreezeQuick,
           });
         }
-        await clearConeSession({ writer, root, client, getController, log, resetNewSessionTmp });
+        // Scoped to the cone we are clearing (#2568): its own `$TMPDIR`
+        // subtree, which contains its scoops' scratch too. A sibling cone's
+        // working directory is no longer in the blast radius.
+        await clearConeSession({
+          writer,
+          root,
+          client,
+          getController,
+          log,
+          resetNewSessionTmp,
+          tmpDir: tmpDirFor(client.getScoops(), root),
+        });
         refreshFreezer();
         // Stay on the cone we just cleared — its record may have been
         // replaced by a roster refresh, so re-resolve by jid.

--- a/packages/webapp/src/work-unit/descriptor.ts
+++ b/packages/webapp/src/work-unit/descriptor.ts
@@ -56,6 +56,55 @@ export function workspaceFor(
 }
 
 /**
+ * Root of the float-wide scratch tree. Stays shared and stays writable by
+ * everyone — `ALWAYS_WRITABLE_PREFIXES` (`fs/restricted-fs.ts`) and
+ * `BUILTIN_SCOOP_GRANTS` (`base/sudoers.ts`) both key off this literal, and
+ * every persisted `writablePaths: ['/tmp/']` on disk names it.
+ */
+export const TMP_ROOT = '/tmp';
+
+/**
+ * A unit's own scratch directory — what its shell publishes as `$TMPDIR` and
+ * what `mktemp` resolves against (#2267).
+ *
+ * ```
+ * cone  cone         /tmp/cone
+ * cone  cone-adobe   /tmp/cone-adobe
+ * scoop review       /tmp/cone/review      ← nested inside its owning cone's
+ * ```
+ *
+ * **This is a convention, not a sandbox.** `/tmp` remains shared and writable
+ * by every unit; what a unit gets here is a directory it can call its own, not
+ * one nobody else can reach. Enforcing the boundary would mean narrowing the
+ * grant in `restricted-fs.ts` AND `sudoers.ts` together, which is a separate
+ * decision — see [#2568](https://github.com/ai-ecoverse/slicc/issues/2568).
+ *
+ * Two things follow from living UNDER `/tmp` rather than beside the unit's
+ * workspace (the alternative weighed in #2568):
+ *
+ * - the two grant layers keep working untouched, and so does every scoop
+ *   record already persisted with `writablePaths: ['/tmp/']`;
+ * - a scoop's scratch is INSIDE its cone's, so "New chat" on a cone disposes
+ *   of its children's scratch in the same subtree delete, and the documented
+ *   `agent /tmp "…" >> "$TMPDIR/out.txt"` handoff still lets the cone read
+ *   back what its scoop wrote.
+ *
+ * Folders are globally unique (`uniqueFolder`), so nesting cannot collide.
+ * A scoop whose ownership edge is dangling falls back to the default (oldest)
+ * root, then to the primary cone — never to a bare `/tmp`, which would hand it
+ * the whole shared tree as its own.
+ */
+export function tmpDirFor<
+  T extends Pick<RegisteredScoop, 'jid' | 'parentJid' | 'folder' | 'addedAt'>,
+>(units: Iterable<T>, unit: T | undefined): string {
+  if (!unit) return `${TMP_ROOT}/${PRIMARY_CONE_FOLDER}`;
+  if (isRootUnit(unit)) return `${TMP_ROOT}/${unit.folder}`;
+  const all = [...units];
+  const owner = rootOwnerOf(all, unit) ?? rootsOf(all)[0];
+  return `${TMP_ROOT}/${owner?.folder ?? PRIMARY_CONE_FOLDER}/${unit.folder}`;
+}
+
+/**
  * Coordinates of the primary cone. The historical layout, and the fallback
  * for the float-wide paths that predate multiple cones (the freezer's
  * `session-cone` archive + its memory extraction, the legacy shared-memory

--- a/packages/webapp/tests/scoops/scoop-context.cone-workspace.test.ts
+++ b/packages/webapp/tests/scoops/scoop-context.cone-workspace.test.ts
@@ -12,6 +12,7 @@ import { VirtualFS } from '../../src/fs/virtual-fs.js';
 import { ensureDirectoryStructure } from '../../src/scoops/scoop-context/directory-structure.js';
 import { ScoopContext, type ScoopContextCallbacks } from '../../src/scoops/scoop-context.js';
 import type { RegisteredScoop } from '../../src/scoops/types.js';
+import { tmpDirFor } from '../../src/work-unit/descriptor.js';
 
 let dbCounter = 0;
 const open: VirtualFS[] = [];
@@ -55,7 +56,12 @@ function callbacks(): ScoopContextCallbacks {
 /** Seed the skeleton directly (#2334); init() would need an LLM + shell. */
 function seedDirs(ctx: ScoopContext): Promise<void> {
   const inner = ctx as unknown as { fs: VirtualFS; scoop: RegisteredScoop; unit: never };
-  return ensureDirectoryStructure(inner.fs, inner.scoop, inner.unit);
+  return ensureDirectoryStructure(
+    inner.fs,
+    inner.scoop,
+    inner.unit,
+    tmpDirFor([inner.scoop], inner.scoop)
+  );
 }
 
 async function exists(fs: VirtualFS, path: string): Promise<boolean> {

--- a/packages/webapp/tests/scoops/scoop-shell-env.test.ts
+++ b/packages/webapp/tests/scoops/scoop-shell-env.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for buildScoopShellEnv (#2085 + Codex P2 on #2143): scoop shells pin
- * HOME/USER/PATH, and user-created secrets must never override those pins.
+ * HOME/USER/PATH, every unit pins TMPDIR (#2267), and user-created secrets
+ * must never override any of those pins.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -10,7 +11,12 @@ import { LICK_TARGET_ENV } from '../../src/shell/lick-target-env.js';
 
 describe('buildScoopShellEnv', () => {
   it('pins HOME, USER, and PATH for a non-cone scoop', () => {
-    const env = buildScoopShellEnv(false, 'research', {});
+    const env = buildScoopShellEnv({
+      isCone: false,
+      folder: 'research',
+      secretEnv: {},
+      tmpDir: '/tmp/cone/research',
+    });
     expect(env.HOME).toBe('/scoops/research/home');
     expect(env.USER).toBe('research');
     expect(env.PATH).toBe(
@@ -29,7 +35,13 @@ describe('buildScoopShellEnv', () => {
     // env-driven producers (`fswatch`/`crontask`/`webhook`) in the SAME shell
     // fall through to `rootsOf(scoops)[0]` and deliver a scoop's callbacks
     // into an unrelated cone's chat.
-    const env = buildScoopShellEnv(false, 'helper-scoop', {}, 'helper-scoop');
+    const env = buildScoopShellEnv({
+      isCone: false,
+      folder: 'helper-scoop',
+      secretEnv: {},
+      tmpDir: '/tmp/cone/helper-scoop',
+      lickTarget: 'helper-scoop',
+    });
     expect(env[LICK_TARGET_ENV]).toBe('helper-scoop');
     // The isolation pins still hold alongside it.
     expect(env.HOME).toBe('/scoops/helper-scoop/home');
@@ -38,31 +50,88 @@ describe('buildScoopShellEnv', () => {
 
   it('a secret cannot spoof a scoop lick target either', () => {
     expect(
-      buildScoopShellEnv(false, 'helper-scoop', { [LICK_TARGET_ENV]: 'cone' }, 'helper-scoop')[
-        LICK_TARGET_ENV
-      ]
+      buildScoopShellEnv({
+        isCone: false,
+        folder: 'helper-scoop',
+        secretEnv: { [LICK_TARGET_ENV]: 'cone' },
+        tmpDir: '/tmp/cone/helper-scoop',
+        lickTarget: 'helper-scoop',
+      })[LICK_TARGET_ENV]
     ).toBe('helper-scoop');
   });
 
+  it('every unit pins TMPDIR — a scoop under its owning cone (#2267)', () => {
+    // `echo $TMPDIR` printed empty in cone and scoop alike, so nothing could
+    // discover a scratch root at all and `mktemp` had no sane default.
+    expect(
+      buildScoopShellEnv({
+        isCone: false,
+        folder: 'research',
+        secretEnv: {},
+        tmpDir: '/tmp/cone-adobe/research',
+      }).TMPDIR
+    ).toBe('/tmp/cone-adobe/research');
+  });
+
+  it('a secret named TMPDIR cannot redirect a unit onto another cone scratch root', () => {
+    // Same class as the PATH/HOME/USER spoof (Codex P2 on #2143): secrets
+    // spread first so an isolation pin always wins.
+    expect(
+      buildScoopShellEnv({
+        isCone: true,
+        folder: 'cone-adobe',
+        secretEnv: { TMPDIR: '/tmp/cone' },
+        tmpDir: '/tmp/cone-adobe',
+      }).TMPDIR
+    ).toBe('/tmp/cone-adobe');
+  });
+
   it('a scoop with no target stays untargeted rather than inventing one', () => {
-    expect(buildScoopShellEnv(false, 'research', {})[LICK_TARGET_ENV]).toBeUndefined();
+    expect(
+      buildScoopShellEnv({
+        isCone: false,
+        folder: 'research',
+        secretEnv: {},
+        tmpDir: '/tmp/cone/research',
+      })[LICK_TARGET_ENV]
+    ).toBeUndefined();
   });
 
   it('the cone pins nothing — only secrets pass through', () => {
-    const env = buildScoopShellEnv(true, 'main', { API_KEY: 'masked' });
-    expect(env).toEqual({ API_KEY: 'masked' });
+    const env = buildScoopShellEnv({
+      isCone: true,
+      folder: 'main',
+      secretEnv: { API_KEY: 'masked' },
+      tmpDir: '/tmp/main',
+    });
+    // TMPDIR is the one pin every unit carries (#2267) — a cone has to be
+    // able to discover its own scratch root too.
+    expect(env).toEqual({ API_KEY: 'masked', TMPDIR: '/tmp/main' });
   });
 
   it('an extra cone carries SLICC_LICK_TARGET so its licks come back to it (#2272)', () => {
-    expect(buildScoopShellEnv(true, 'cone-research', { API_KEY: 'k' }, 'cone-research')).toEqual({
+    expect(
+      buildScoopShellEnv({
+        isCone: true,
+        folder: 'cone-research',
+        secretEnv: { API_KEY: 'k' },
+        tmpDir: '/tmp/cone-research',
+        lickTarget: 'cone-research',
+      })
+    ).toEqual({
       API_KEY: 'k',
+      TMPDIR: '/tmp/cone-research',
       [LICK_TARGET_ENV]: 'cone-research',
     });
     // A secret cannot spoof the target.
     expect(
-      buildScoopShellEnv(true, 'cone-research', { [LICK_TARGET_ENV]: 'cone' }, 'cone-research')[
-        LICK_TARGET_ENV
-      ]
+      buildScoopShellEnv({
+        isCone: true,
+        folder: 'cone-research',
+        secretEnv: { [LICK_TARGET_ENV]: 'cone' },
+        tmpDir: '/tmp/cone-research',
+        lickTarget: 'cone-research',
+      })[LICK_TARGET_ENV]
     ).toBe('cone-research');
   });
 });
@@ -101,16 +170,23 @@ describe('ownLickTargetFor', () => {
   });
 
   it('a secret named PATH/HOME/USER cannot override the scoop pins (Codex P2)', () => {
-    const env = buildScoopShellEnv(false, 'research', {
-      PATH: '/evil',
-      HOME: '/evil-home',
-      USER: 'root',
-      API_KEY: 'masked',
+    const env = buildScoopShellEnv({
+      isCone: false,
+      folder: 'research',
+      secretEnv: {
+        PATH: '/evil',
+        HOME: '/evil-home',
+        USER: 'root',
+        TMPDIR: '/evil-tmp',
+        API_KEY: 'masked',
+      },
+      tmpDir: '/tmp/cone/research',
     });
     expect(env.PATH).toContain('/scoops/research/workspace/skills');
     expect(env.PATH).not.toContain('/evil');
     expect(env.HOME).toBe('/scoops/research/home');
     expect(env.USER).toBe('research');
+    expect(env.TMPDIR).toBe('/tmp/cone/research');
     // Ordinary secrets still pass through.
     expect(env.API_KEY).toBe('masked');
   });

--- a/packages/webapp/tests/ui/new-session.test.ts
+++ b/packages/webapp/tests/ui/new-session.test.ts
@@ -607,7 +607,7 @@ describe('resetNewSessionTmp', () => {
       await vfs.writeFile(`${root}/keep.txt`, 'preserve');
     }
 
-    await resetNewSessionTmp(vfs);
+    await resetNewSessionTmp(vfs, '/tmp');
 
     expect(await vfs.readDir('/tmp')).toEqual([]);
     for (const root of preserved) {
@@ -621,7 +621,7 @@ describe('resetNewSessionTmp', () => {
     await vfs.writeFile('/workspace/project/keep.txt', 'preserve');
     await vfs.symlink('/workspace/project', '/tmp/link');
 
-    await resetNewSessionTmp(vfs);
+    await resetNewSessionTmp(vfs, '/tmp');
 
     expect(await vfs.readDir('/tmp')).toEqual([]);
     await expect(vfs.lstat('/tmp/link')).rejects.toMatchObject({ code: 'ENOENT' });
@@ -639,7 +639,7 @@ describe('resetNewSessionTmp', () => {
     await vfs.writeFile('/tmp/job/scratch.txt', 'discard');
     await vfs.writeFile('/tmp/top.txt', 'discard');
 
-    await resetNewSessionTmp(vfs);
+    await resetNewSessionTmp(vfs, '/tmp');
 
     expect((await vfs.readDir('/tmp')).map(({ name }) => name)).toEqual(['job']);
     expect((await vfs.readDir('/tmp/job')).map(({ name }) => name)).toEqual(['mounted']);
@@ -655,7 +655,7 @@ describe('resetNewSessionTmp', () => {
       })
     );
 
-    await resetNewSessionTmp(vfs);
+    await resetNewSessionTmp(vfs, '/tmp');
 
     expect(await vfs.readTextFile('/tmp/keep.txt')).toBe('preserve');
   });
@@ -668,7 +668,7 @@ describe('resetNewSessionTmp', () => {
       await vfs.mount(`/tmp/${kind}`, backend);
       await vfs.writeFile('/tmp/scratch.txt', 'discard');
 
-      await resetNewSessionTmp(vfs);
+      await resetNewSessionTmp(vfs, '/tmp');
 
       expect((await vfs.readDir('/tmp')).map(({ name }) => name)).toEqual([kind]);
       expect(await vfs.readTextFile(`/tmp/${kind}/keep.txt`)).toBe('preserve');
@@ -676,11 +676,66 @@ describe('resetNewSessionTmp', () => {
     }
   );
 
+  it('wipes only the named cone subtree, leaving a sibling cone untouched', async () => {
+    // The incident this scoping exists for: "New chat" on one cone deleted a
+    // SIBLING cone's live working directory out from under it (#2566, #2568).
+    const vfs = await createVfs();
+    await vfs.mkdir('/tmp/cone/work', { recursive: true });
+    await vfs.writeFile('/tmp/cone/work/scratch.txt', 'discard');
+    await vfs.mkdir('/tmp/cone-adobe/rv/node_modules', { recursive: true });
+    await vfs.writeFile('/tmp/cone-adobe/rv/node_modules/pkg.json', 'preserve');
+
+    await resetNewSessionTmp(vfs, '/tmp/cone');
+
+    expect(await vfs.readDir('/tmp/cone')).toEqual([]);
+    expect(await vfs.readTextFile('/tmp/cone-adobe/rv/node_modules/pkg.json')).toBe('preserve');
+  });
+
+  it('a cone sweep still takes its own scoops with it', async () => {
+    // A scoop's scratch nests INSIDE its cone's, so "New chat" disposes of
+    // everything the cone owns without reaching outside it.
+    const vfs = await createVfs();
+    await vfs.mkdir('/tmp/cone-adobe/review', { recursive: true });
+    await vfs.writeFile('/tmp/cone-adobe/review/notes.md', 'discard');
+    await vfs.mkdir('/tmp/cone', { recursive: true });
+    await vfs.writeFile('/tmp/cone/keep.txt', 'preserve');
+
+    await resetNewSessionTmp(vfs, '/tmp/cone-adobe');
+
+    expect(await vfs.readDir('/tmp/cone-adobe')).toEqual([]);
+    expect(await vfs.readTextFile('/tmp/cone/keep.txt')).toBe('preserve');
+  });
+
+  it('does not treat a name-prefixed sibling as part of the subtree', async () => {
+    // `/tmp/cone` is a string prefix of `/tmp/cone-adobe`. Without the
+    // separator this sweep would eat the other cone's tree.
+    const vfs = await createVfs();
+    await vfs.mkdir('/tmp/cone', { recursive: true });
+    await vfs.writeFile('/tmp/cone/gone.txt', 'discard');
+    await vfs.mkdir('/tmp/cone-adobe', { recursive: true });
+    await vfs.writeFile('/tmp/cone-adobe/kept.txt', 'preserve');
+
+    await resetNewSessionTmp(vfs, '/tmp/cone');
+
+    expect(await vfs.readTextFile('/tmp/cone-adobe/kept.txt')).toBe('preserve');
+  });
+
+  it('recreates an absent cone subtree without touching the shared root', async () => {
+    const vfs = await createVfs();
+    await vfs.mkdir('/tmp/cone-adobe', { recursive: true });
+    await vfs.writeFile('/tmp/cone-adobe/keep.txt', 'preserve');
+
+    await resetNewSessionTmp(vfs, '/tmp/cone');
+
+    expect(await vfs.readDir('/tmp/cone')).toEqual([]);
+    expect(await vfs.readTextFile('/tmp/cone-adobe/keep.txt')).toBe('preserve');
+  });
+
   it('recreates an absent /tmp directory', async () => {
     const vfs = await createVfs();
     if (await vfs.exists('/tmp')) await vfs.rm('/tmp', { recursive: true });
 
-    await resetNewSessionTmp(vfs);
+    await resetNewSessionTmp(vfs, '/tmp');
 
     expect(await vfs.readDir('/tmp')).toEqual([]);
   });
@@ -695,7 +750,7 @@ describe('resetNewSessionTmp', () => {
       mkdir: vi.fn(async () => undefined),
     };
 
-    await resetNewSessionTmp(vfs);
+    await resetNewSessionTmp(vfs, '/tmp');
 
     expect(vfs.rm).not.toHaveBeenCalled();
     expect(vfs.mkdir).toHaveBeenCalledWith('/tmp', { recursive: true });
@@ -769,7 +824,7 @@ describe('resetNewSessionTmp', () => {
       mkdir: vi.fn(async () => undefined),
     };
 
-    await expect(resetNewSessionTmp(vfs)).rejects.toMatchObject({ code: 'EIO' });
+    await expect(resetNewSessionTmp(vfs, '/tmp')).rejects.toMatchObject({ code: 'EIO' });
     expect(vfs.mkdir).not.toHaveBeenCalled();
   });
 
@@ -783,7 +838,7 @@ describe('resetNewSessionTmp', () => {
       mkdir: vi.fn(async () => undefined),
     };
 
-    await expect(resetNewSessionTmp(vfs)).rejects.toMatchObject({ code: 'EIO' });
+    await expect(resetNewSessionTmp(vfs, '/tmp')).rejects.toMatchObject({ code: 'EIO' });
     expect(vfs.readDir).not.toHaveBeenCalled();
     expect(vfs.rm).not.toHaveBeenCalled();
   });

--- a/packages/webapp/tests/ui/new-session.test.ts
+++ b/packages/webapp/tests/ui/new-session.test.ts
@@ -803,7 +803,7 @@ describe('resetNewSessionTmp', () => {
       mkdir: vi.fn(async () => undefined),
     };
 
-    await expect(resetNewSessionTmp(vfs)).resolves.toBeUndefined();
+    await expect(resetNewSessionTmp(vfs, '/tmp')).resolves.toBeUndefined();
 
     expect(vfs.rm).toHaveBeenCalledWith('/tmp/survivor.txt');
     expect(vfs.mkdir).toHaveBeenCalledWith('/tmp', { recursive: true });
@@ -824,7 +824,7 @@ describe('resetNewSessionTmp', () => {
       mkdir: vi.fn(async () => undefined),
     };
 
-    await expect(resetNewSessionTmp(vfs)).resolves.toBeUndefined();
+    await expect(resetNewSessionTmp(vfs, '/tmp')).resolves.toBeUndefined();
 
     expect(vfs.rm).toHaveBeenCalledWith('/tmp/survivor.txt');
     expect(vfs.rm).not.toHaveBeenCalledWith('/tmp/gone');
@@ -842,7 +842,7 @@ describe('resetNewSessionTmp', () => {
       mkdir: vi.fn(async () => undefined),
     };
 
-    await expect(resetNewSessionTmp(vfs)).rejects.toMatchObject({ code: 'EIO' });
+    await expect(resetNewSessionTmp(vfs, '/tmp')).rejects.toMatchObject({ code: 'EIO' });
     expect(vfs.mkdir).not.toHaveBeenCalled();
   });
 

--- a/packages/webapp/tests/ui/new-session.test.ts
+++ b/packages/webapp/tests/ui/new-session.test.ts
@@ -676,6 +676,38 @@ describe('resetNewSessionTmp', () => {
     }
   );
 
+  it('never traverses a cone subtree that sits INSIDE a mount (Codex P1 on #2574)', async () => {
+    // The sweep root moved from `/tmp` down to `/tmp/<cone>`, so a mount at
+    // `/tmp` stopped being the sweep root that halted it and became an
+    // ANCESTOR the filter dropped. Walking through it deletes the user's real
+    // Local/S3/DA files.
+    const vfs = await createVfs();
+    await vfs.mount(
+      '/tmp',
+      LocalMountBackend.fromHandle(createDirectoryHandle({ cone: { 'keep.txt': 'preserve' } }), {
+        mountId: 'new-session-ancestor',
+      })
+    );
+
+    await resetNewSessionTmp(vfs, '/tmp/cone');
+
+    expect(await vfs.readTextFile('/tmp/cone/keep.txt')).toBe('preserve');
+  });
+
+  it('does not conjure a directory inside a mount when the cone subtree is absent', async () => {
+    // The other half of the same bug: with nothing at `/tmp/<cone>` the sweep
+    // falls through to `mkdir(tmpDir, { recursive: true })`, which would
+    // create a directory in the user's mounted external storage.
+    const vfs = await createVfs();
+    const remote = createRemoteMountBackend('s3');
+    await vfs.mount('/tmp', remote.backend);
+
+    await resetNewSessionTmp(vfs, '/tmp/cone');
+
+    expect(remote.remove).not.toHaveBeenCalled();
+    expect(remote.backend.mkdir).not.toHaveBeenCalled();
+  });
+
   it('wipes only the named cone subtree, leaving a sibling cone untouched', async () => {
     // The incident this scoping exists for: "New chat" on one cone deleted a
     // SIBLING cone's live working directory out from under it (#2566, #2568).

--- a/packages/webapp/tests/ui/session-freezer.test.ts
+++ b/packages/webapp/tests/ui/session-freezer.test.ts
@@ -1117,7 +1117,7 @@ describe('freezeConeSession', () => {
       const frozen = await freezeConeSession({ sessionStore: store, vfs, mode });
       expect(frozen).not.toBeNull();
 
-      await resetNewSessionTmp(vfs);
+      await resetNewSessionTmp(vfs, '/tmp');
 
       const raw = await vfs.readTextFile(`/sessions/${frozen!.filename}`);
       const thawed = parseFrozenArchive(raw);
@@ -1304,7 +1304,7 @@ describe('freezeConeSession', () => {
       expect(frozen).not.toBeNull();
       vfs.readFile = originalReadFile;
       vfs.readDir = originalReadDir;
-      await resetNewSessionTmp(vfs);
+      await resetNewSessionTmp(vfs, '/tmp');
 
       const raw = await vfs.readTextFile(`/sessions/${frozen!.filename}`);
       expect(raw).not.toContain(failingPath);

--- a/packages/webapp/tests/work-unit/descriptor.test.ts
+++ b/packages/webapp/tests/work-unit/descriptor.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   PRIMARY_WORKSPACE,
   SKILLS_LIBRARY_DIR,
+  TMP_ROOT,
+  tmpDirFor,
   toDescriptor,
   workspaceFor,
 } from '../../src/work-unit/descriptor.js';
@@ -94,5 +96,52 @@ describe('work-unit descriptor', () => {
     if (d.policy.filesystem.kind === 'restricted') {
       expect(d.policy.filesystem.writablePaths).not.toBe(record.config?.writablePaths);
     }
+  });
+});
+
+describe('tmpDirFor — per-unit scratch under the shared /tmp (#2267, #2568)', () => {
+  const primary = rootRecord();
+  const adobe = rootRecord({ jid: 'cone_2', folder: 'cone-adobe' });
+  const review = childRecord('cone_2', { folder: 'review' });
+  const roster = [primary, adobe, review];
+
+  it('gives every cone its own subtree, primary included', () => {
+    // No special case for the primary cone: nothing is aliased, so there is
+    // no compatibility argument for leaving one unit on the bare root.
+    expect(tmpDirFor(roster, primary)).toBe('/tmp/cone');
+    expect(tmpDirFor(roster, adobe)).toBe('/tmp/cone-adobe');
+  });
+
+  it('nests a scoop inside the cone that owns it, not beside it', () => {
+    // This is what lets a cone dispose of its children's scratch in one
+    // subtree delete, and what keeps the documented
+    // `agent … >> "$TMPDIR/out.txt"` handoff readable by the parent.
+    expect(tmpDirFor(roster, review)).toBe('/tmp/cone-adobe/review');
+    expect(tmpDirFor(roster, review).startsWith(`${tmpDirFor(roster, adobe)}/`)).toBe(true);
+  });
+
+  it('never hands the shared root itself to a unit', () => {
+    // A dangling ownership edge must not resolve to `/tmp`: that would give
+    // one scoop the whole shared tree as "its own" and make a New chat on it
+    // wipe every cone's scratch.
+    const orphan = childRecord('cone_gone', { folder: 'orphan' });
+    for (const unit of [...roster, orphan, undefined]) {
+      expect(tmpDirFor(roster, unit)).not.toBe(TMP_ROOT);
+      expect(tmpDirFor(roster, unit).startsWith(`${TMP_ROOT}/`)).toBe(true);
+    }
+  });
+
+  it('falls back to the oldest root when the ownership edge is dangling', () => {
+    const orphan = childRecord('cone_gone', { folder: 'orphan' });
+    expect(tmpDirFor(roster, orphan)).toBe('/tmp/cone/orphan');
+    // With no roster at all it still lands somewhere addressable.
+    expect(tmpDirFor([], orphan)).toBe('/tmp/cone/orphan');
+  });
+
+  it('keeps sibling cones disjoint, so one cone cannot prefix-match another', () => {
+    // `cone` is a prefix of `cone-adobe` as a STRING; the trailing separator
+    // is what stops a `startsWith` sweep of `/tmp/cone` from eating
+    // `/tmp/cone-adobe`.
+    expect(`${tmpDirFor(roster, adobe)}/`.startsWith(`${tmpDirFor(roster, primary)}/`)).toBe(false);
   });
 });


### PR DESCRIPTION
Refs #2267, #2568

Rebased onto `main` after #2566 landed. Both source conflicts were mechanical (that PR extracted `clearConeSession`; this one threads `tmpDir` through its deps, and the two error helpers are additive). Worth flagging that the rebase reported success and the result still did not typecheck: #2566 brought three of its own tests calling the pre-rebase one-arg `resetNewSessionTmp`, which no conflict marker surfaces. Fixed in the third commit.

## Summary

Every unit's shell now publishes `$TMPDIR` pointing at a scratch directory of its own, and "New chat" sweeps that directory instead of the whole shared `/tmp`. Before: `echo $TMPDIR` printed empty in cone and scoop alike, and clearing one cone's chat deleted every other cone's scratch. Now: each cone gets `/tmp/<folder>`, each scoop gets `/tmp/<owning-cone>/<folder>`, and a cone's "New chat" only ever touches its own subtree.

## Why

Two problems that turn out to have one answer.

**`$TMPDIR` did not exist** (#2267). Nothing could discover a scratch root, so agents reaching for `mktemp` got a cascade of misleading errors — command substitution swallows the first failure, so the agent learns "`>` into a variable is a directory", concludes its scratch strategy is wrong, and improvises a path it does not own. One measured memory-curator pass spent three of its ten minutes on this.

**"New chat" swept the shared `/tmp`** — the design cause behind #2566. Clicking it on one cone deleted a *sibling* cone's live working directory. In the incident that motivated this, the sibling was mid-`npm install`, which both lost data and raced the sweep into an `ENOENT` that aborted the clear. #2566 contains the crash; this contains the blast radius.

**Repro** (needs two cones):

1. On cone A, write something into `/tmp` and leave it there.
2. Click **New chat** on cone B.
3. Expected: cone A's files survive.
4. Actual on `main`: they are gone.

## Approach / Implementation notes

`tmpDirFor(units, unit)` in `work-unit/descriptor.ts` is the one place the layout is decided, next to `workspaceFor`:

| unit | `$TMPDIR` |
| --- | --- |
| cone `cone` | `/tmp/cone` |
| cone `cone-adobe` | `/tmp/cone-adobe` |
| scoop `review` owned by `cone-adobe` | `/tmp/cone-adobe/review` |

**Living under `/tmp` rather than beside the unit's workspace is the load-bearing choice**, and it is where this diverges from the design sketched in #2568 (which proposed `/cones/<folder>/tmp` reached through a path-aliasing `ScopedTmpFS` decorator):

- `ALWAYS_WRITABLE_PREFIXES` (`fs/restricted-fs.ts:88`), `BUILTIN_SCOOP_GRANTS` (`base/sudoers.ts:265`) and every scoop record already persisted with `writablePaths: ['/tmp/']` (`agent-bridge.ts:749`) keep working **untouched**. A path beside the workspace needs new prefixes in two layers that gate independently and that `packages/webapp/CLAUDE.md` warns must change together.
- A scoop's scratch nests **inside** its cone's, so one subtree delete disposes of a cone and its children, and the documented `agent … >> "$TMPDIR/out.txt"` handoff still lets the parent read back what its scoop wrote.
- Nothing is aliased, so `realpath` stays honest, `walk()` needs no un-rewriting, and no decorator goes near the `MONKEYPATCH_UNSAFE_FS` sudo proxy. Those were the three highest-rated risks in #2568.

**This is a convention, not a sandbox.** The grants still expose all of `/tmp` to every unit — one can still read and write another's scratch, exactly as on a real POSIX system. What it buys is a *disposal boundary* and a directory nothing else routinely touches. Narrowing the grants to `$TMPDIR` would be real enforcement and is a separate decision, deliberately not taken here: enforcing a boundary nothing respects yet would only break agents.

Folders are globally unique (`uniqueFolder`), so nesting cannot collide. A dangling ownership edge falls back to the default (oldest) root, then to the primary cone — **never to a bare `/tmp`**, which would hand one unit the whole shared tree as "its own" and make its New chat wipe everything.

`buildScoopShellEnv` moves to an options object. It was at four positional arguments, three of them interchangeable strings, and this adds a fifth.

### Relationship to #2269 and upstream

Picks up the `TMPDIR`-pinning **mechanism** from #2269 — pinned per shell, spread after `secretEnv` so a user secret named `TMPDIR` cannot override it, while a `.profile` `export TMPDIR=…` still can — with per-unit values instead of `/tmp` + `/scoops/<folder>/tmp`.

The `mktemp` shim from that PR is **not** included. The command is generic POSIX and belongs upstream in `just-bash` (vercel-labs/just-bash#377, open and mergeable since 21 Aug); once it lands it resolves its default from `$TMPDIR`, which is exactly what this establishes. Shipping the shim here would mean writing a second implementation to delete later.

`/scoops/<folder>/tmp` is still created and still what `workspaceFor().scratch` names for a scoop — that is the unit's private *storage* root (bash overflow, agent archives, per-scoop sudoers), a different question from the shell-visible `$TMPDIR`. Both are now in the `docs/work-unit.md` layout table so the distinction is written down.

## Cross-cutting impact

- **Floats exercised**: the pin is set in `buildScoopShellEnv` (every unit, every float) with a floor value in `AlmostBashShellHeadless` for shells that have no work unit behind them — the panel terminal and tests. The sweep change is in `wc-live-freezer.ts`, the shared WC shell that the standalone CLI leader, the extension's hosted leader tab, and a follower's forwarded `LEADER_RUN_NEW_SESSION_EVENT` all run.
- **Other callers of the changed contract**: `resetNewSessionTmp` has one production call site; the other two call sites are in `session-freezer.test.ts`. `ensureDirectoryStructure` has one production call site. `buildScoopShellEnv` has one. All updated.
- **Persisted state**: nothing migrates. `/tmp` itself is untouched — existing scratch stays where it is and stays reachable; units simply stop *defaulting* there.
- **Bundle size**: `First-load OK (allowance 4 kB per change; total 4944 kB across both graphs)`.

**Behaviour change:** a cone's "New chat" no longer clears loose files at the `/tmp` root, only its own subtree. Anything written to the literal `/tmp` by an agent that ignores `$TMPDIR` now accumulates until a reload. That is the trade for not deleting other cones' work, and it is what the ephemeral-`/tmp` follow-up in #2568 addresses properly.

## Test plan

- [x] `npx prettier --write <changed-files>`
- [x] `npm run typecheck`
- [x] `npm run test` — 17,726 passing, 46 skipped, **0 failures** (post-rebase, composed with #2566)
- [x] `npm run test:coverage` — exit 0, no floor regressions
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run verify` — all 7 checks
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — 16 changed files, 0 on any debt list
- [x] **New / changed behavior is covered by a unit test**:
      `npx vitest run packages/webapp/tests/work-unit/descriptor.test.ts packages/webapp/tests/ui/new-session.test.ts packages/webapp/tests/scoops/scoop-shell-env.test.ts`
- [x] Guards verified by reverting: stubbed `resetNewSessionTmp` back to a hardcoded `/tmp` and confirmed **4 red**; separately reverted the ancestor-mount fix and confirmed its **2** regression tests red. Restored both.

New coverage:

- `descriptor.test.ts` — every cone gets its own subtree (no primary special case); a scoop nests inside its owner; **never resolves to the bare `/tmp` root** for any input including `undefined` and a dangling edge; a dangling edge falls back to the oldest root; sibling cones stay disjoint under prefix matching (`/tmp/cone` vs `/tmp/cone-adobe`).
- `new-session.test.ts` — wiping cone A leaves cone B's tree intact; a cone sweep still takes its own scoops with it; a name-prefixed sibling is not eaten; an absent cone subtree is recreated without touching the shared root.
- `scoop-shell-env.test.ts` — every unit pins `TMPDIR` including the cone; a secret named `TMPDIR` cannot redirect a unit onto another cone's scratch root (same class as the PATH/HOME/USER spoof from Codex P2 on #2143).
- `new-session.test.ts` (Codex P1, second commit) — a cone subtree sitting **inside** a mount is never traversed, and an absent one is not conjured inside the mounted backend. Scoping the sweep from `/tmp` to `/tmp/<cone>` turned a mount at `/tmp` from the sweep root that halted it into an ancestor the filter dropped; `containsPath` now bails on any mount at or above `tmpDir`.

No manual smoke: the behaviour needs two cones racing on `/tmp`, which the unit tests reproduce deterministically. No UI change, so no screencast.

**Pre-existing failures**: none.

## Documentation

- [x] `docs/` — `docs/shell-reference.md` (the `$TMPDIR` table, "write to `$TMPDIR`, not `/tmp`", and the narrowed cleanup boundary); `docs/work-unit.md` (layout table gains a `$TMPDIR` column, plus why it lives under `/tmp` and why it is not enforcement)
- [ ] `packages/webapp/CLAUDE.md` — **deliberately not touched**: it is at 19,995 of its frozen 20,000-char cap, and the `/tmp`-is-shared never-rule there is still accurate.
- [ ] `vfs-root/workspace/skills/*/SKILL.md` — 12 hardcoded `/tmp` occurrences should become `$TMPDIR`. Left for a follow-up: they are prose that goes into model context, they are correct-but-suboptimal as written, and mixing a skills sweep into this diff would bury the runtime change.

## Risk & rollback

- **Blast radius**: every unit's shell env and the "New chat" sweep, all floats. The failure mode if `tmpDirFor` were wrong is a unit writing to an unexpected-but-writable directory, not a permission wall — `/tmp` is granted wholesale either way.
- **Flags / kill switches**: none. The behaviour is not flagged because the old behaviour is the bug.
- **Rollback**: revert cleanly. No persisted-state migration, and existing `/tmp` contents are never moved.
- **CI cannot catch**: whether real agents actually pick up `$TMPDIR` rather than continuing to hardcode `/tmp`. That is a prose/skills question, and the reason the grants are deliberately left wide for now.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] Public API / shell-command changes are intentional and reflected in docs — `$TMPDIR` is new agent-visible surface, documented in `docs/shell-reference.md`
- [x] Contract used by other floats: checked leader / follower / offscreen paths (one shared WC shell, one shell-env builder)
