### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/scoops/tray-leader/oauth-cdp-login.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -40,7 +40,6 @@
   "packages/webapp/src/providers/intercepted-oauth.ts": 4,
   "packages/webapp/src/scoops/onboarding-orchestrator.ts": 1,
   "packages/webapp/src/scoops/tray-leader/cdp-router.ts": 5,
-  "packages/webapp/src/scoops/tray-leader/oauth-cdp-login.ts": 1,
   "packages/webapp/src/scoops/tray-leader/tab-teleport.ts": 3,
   "packages/webapp/src/shell/bsh-watchdog.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/picker-popup.ts": 3,

--- a/packages/webapp/src/scoops/tray-leader/oauth-cdp-login.ts
+++ b/packages/webapp/src/scoops/tray-leader/oauth-cdp-login.ts
@@ -25,6 +25,8 @@
  * this applies it across the tray.
  */
 
+import type { CDPPayload } from '@slicc/shared-ts';
+
 import { createLogger } from '../../base/logger.js';
 import type { BrowserAPI } from '../../cdp/browser-api.js';
 
@@ -46,6 +48,22 @@ export interface DelegatedCdpLoginDeps {
   authorizeUrl: string;
   signal?: AbortSignal;
   timeoutMs?: number;
+}
+
+/**
+ * Fields of CDP `Page.frameNavigated.frame` that this login driver reads.
+ * The full CDP frame object has more, but we only settle on main-frame URL.
+ */
+interface NavigatedFrame {
+  url?: string;
+  parentId?: string;
+}
+
+/** Read the navigated frame from a CDP event payload, or undefined if absent. */
+function navigatedFrameFrom(params: CDPPayload): NavigatedFrame | undefined {
+  const raw = params.frame;
+  if (raw === null || typeof raw !== 'object') return undefined;
+  return raw as NavigatedFrame;
 }
 
 /**
@@ -180,8 +198,8 @@ export async function runDelegatedCdpLogin(deps: DelegatedCdpLoginDeps): Promise
 
         // Primary signal: navigation commit, before the page's own script runs.
         const transport = browser.getTransport();
-        const onNavigated = (params: Record<string, unknown>): void => {
-          const frame = (params as { frame?: { url?: string; parentId?: string } }).frame;
+        const onNavigated = (params: CDPPayload): void => {
+          const frame = navigatedFrameFrom(params);
           if (!frame?.url || frame.parentId) return; // main frame only
           if (isCallback(frame.url)) {
             log.info('Delegated login reached the callback', { via: 'frameNavigated' });


### PR DESCRIPTION
## Summary
- Replace the sole `Record<string, unknown>` in `oauth-cdp-login.ts` (CDP `Page.frameNavigated` handler) with shared `CDPPayload` plus a named `NavigatedFrame` shape read via `navigatedFrameFrom`.
- Ratchet `record-string-unknown-baseline.json` so this file is no longer grandfathered.

## Debt cleared
- `record-string-unknown` (1 occurrence)

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npx vitest run packages/webapp/tests/scoops/tray-leader/oauth-cdp-login.test.ts` (15 passed)
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK