### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/cdp/panel-rpc-cdp-transport.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -15,7 +15,6 @@
   "packages/webapp/src/cdp/cherry-host-transport.ts": 3,
   "packages/webapp/src/cdp/har-recorder.ts": 10,
   "packages/webapp/src/cdp/navigation-watcher.ts": 11,
-  "packages/webapp/src/cdp/panel-rpc-cdp-transport.ts": 5,
   "packages/webapp/src/core/types.ts": 2,
   "packages/webapp/src/fs/mount/backend-local.ts": 1,
   "packages/webapp/src/git/commands/rebase.ts": 1,

--- a/packages/webapp/src/cdp/panel-rpc-cdp-transport.ts
+++ b/packages/webapp/src/cdp/panel-rpc-cdp-transport.ts
@@ -15,6 +15,8 @@
  * `createRemoteTransport()` → `send('Target.attachToTarget', …)`.
  */
 
+import type { CDPPayload } from '@slicc/shared-ts';
+
 import { createLogger } from '../base/logger.js';
 import {
   PANEL_RPC_DEFAULT_TIMEOUT_MS,
@@ -107,10 +109,10 @@ export class PanelRpcCdpTransport implements CDPTransport {
 
   async send(
     method: string,
-    params?: Record<string, unknown>,
+    params?: CDPPayload,
     sessionId?: string,
     timeout?: number
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CDPPayload> {
     if (this._state === 'disconnected') {
       throw new Error('Transport disconnected');
     }
@@ -160,7 +162,7 @@ export class PanelRpcCdpTransport implements CDPTransport {
     }
   }
 
-  once(event: string, timeout?: number): Promise<Record<string, unknown>> {
+  once(event: string, timeout?: number): Promise<CDPPayload> {
     return new Promise((resolve, reject) => {
       const tm = timeout ?? this.timeoutMs;
       const entry = { reject, timer: undefined as unknown as ReturnType<typeof setTimeout> };
@@ -173,7 +175,7 @@ export class PanelRpcCdpTransport implements CDPTransport {
         cleanup();
         reject(new Error(`Remote CDP event timed out: ${event}`));
       }, tm);
-      const handler = (params: Record<string, unknown>) => {
+      const handler = (params: CDPPayload) => {
         cleanup();
         resolve(params);
       };
@@ -183,7 +185,7 @@ export class PanelRpcCdpTransport implements CDPTransport {
   }
 
   /** Dispatch a page-pushed CDP event to local listeners. */
-  private handleEvent(method: string, params: Record<string, unknown>): void {
+  private handleEvent(method: string, params: CDPPayload): void {
     const listeners = this.eventListeners.get(method);
     if (!listeners) return;
     for (const cb of [...listeners]) cb(params);


### PR DESCRIPTION
## Summary
- Replace five `Record<string, unknown>` CDP param/result bags in `PanelRpcCdpTransport` with the shared `CDPPayload` alias (same shape as `CDPTransport` / `RemoteCDPTransport`).
- Ratchet `record-string-unknown-baseline.json` to drop this file (debt list cleared: `record-string-unknown`).

## Test plan
- [x] `npx biome check --write` on touched file
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/cdp/panel-rpc-cdp-transport.test.ts` (12 passing)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK