### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/cdp/synthetic-cdp-transport.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -21,7 +21,6 @@
   "packages/webapp/src/cdp/har-recorder.ts": 10,
   "packages/webapp/src/cdp/navigation-watcher.ts": 11,
   "packages/webapp/src/cdp/panel-rpc-cdp-transport.ts": 5,
-  "packages/webapp/src/cdp/synthetic-cdp-transport.ts": 10,
   "packages/webapp/src/core/types.ts": 2,
   "packages/webapp/src/fs/mount/backend-local.ts": 1,
   "packages/webapp/src/git/commands/rebase.ts": 1,

--- a/packages/webapp/src/cdp/synthetic-cdp-transport.ts
+++ b/packages/webapp/src/cdp/synthetic-cdp-transport.ts
@@ -9,6 +9,7 @@
  * - PreviewBridgeCdpTransport (postMessage to the preview bridge bootstrap)
  */
 
+import type { CDPPayload } from '@slicc/shared-ts';
 import { waitForEvent } from './pending-request-table.js';
 import type { CDPTransport } from './transport.js';
 import type { CDPConnectOptions, CDPEventListener, ConnectionState } from './types.js';
@@ -93,10 +94,10 @@ export abstract class SyntheticCdpTransport implements CDPTransport {
 
   async send(
     method: string,
-    params?: Record<string, unknown>,
+    params?: CDPPayload,
     sessionId?: string,
     timeout = DEFAULT_TIMEOUT
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CDPPayload> {
     if (this._state !== 'connected') throw new Error('Transport is not connected');
 
     const synthetic = this.handleSynthetic(method, params);
@@ -127,8 +128,8 @@ export abstract class SyntheticCdpTransport implements CDPTransport {
     }
   }
 
-  once(event: string, timeout = DEFAULT_TIMEOUT): Promise<Record<string, unknown>> {
-    return waitForEvent<Record<string, unknown>>(
+  once(event: string, timeout = DEFAULT_TIMEOUT): Promise<CDPPayload> {
+    return waitForEvent<CDPPayload>(
       (handler) => {
         this.on(event, handler);
         return () => this.off(event, handler);
@@ -144,15 +145,15 @@ export abstract class SyntheticCdpTransport implements CDPTransport {
    */
   protected abstract forward(
     method: string,
-    params?: Record<string, unknown>,
+    params?: CDPPayload,
     sessionId?: string,
     timeout?: number
-  ): Promise<Record<string, unknown>>;
+  ): Promise<CDPPayload>;
 
   /**
    * Emit a CDP event to registered listeners.
    */
-  protected emit(method: string, params: Record<string, unknown>): void {
+  protected emit(method: string, params: CDPPayload): void {
     const set = this.listeners.get(method);
     if (!set) return;
     for (const l of set) {
@@ -165,10 +166,7 @@ export abstract class SyntheticCdpTransport implements CDPTransport {
   }
 
   /** Methods the transport answers locally to satisfy BrowserAPI's session setup. */
-  private handleSynthetic(
-    method: string,
-    _params?: Record<string, unknown>
-  ): Promise<Record<string, unknown>> | null {
+  private handleSynthetic(method: string, _params?: CDPPayload): Promise<CDPPayload> | null {
     switch (method) {
       case 'Target.getTargets':
         return Promise.resolve({
@@ -225,10 +223,7 @@ export abstract class SyntheticCdpTransport implements CDPTransport {
     }
   }
 
-  private synthesizeNavigationLifecycle(
-    navResult: Record<string, unknown>,
-    navigatedUrl?: string
-  ): void {
+  private synthesizeNavigationLifecycle(navResult: CDPPayload, navigatedUrl?: string): void {
     const frameId = (navResult.frameId as string) ?? this.syntheticIds.frame;
     const url = navigatedUrl ?? this.getCurrentUrl();
     // Advance the last-known URL so subsequent getTargets/getFrameTree report the

--- a/packages/webapp/tests/cdp/synthetic-cdp-transport.test.ts
+++ b/packages/webapp/tests/cdp/synthetic-cdp-transport.test.ts
@@ -1,3 +1,4 @@
+import type { CDPPayload } from '@slicc/shared-ts';
 import { describe, expect, it } from 'vitest';
 import { SyntheticCdpTransport } from '../../src/cdp/synthetic-cdp-transport.js';
 
@@ -5,7 +6,9 @@ import { SyntheticCdpTransport } from '../../src/cdp/synthetic-cdp-transport.js'
  * Trivial subclass with a stub forward that forwards real methods.
  */
 class TestTransport extends SyntheticCdpTransport {
-  public forwarded: Array<[string, any, string | undefined, number | undefined]> = [];
+  public forwarded: Array<
+    [string, CDPPayload | undefined, string | undefined, number | undefined]
+  > = [];
   public closeTargetCalls = 0;
 
   async connect(): Promise<void> {
@@ -22,10 +25,10 @@ class TestTransport extends SyntheticCdpTransport {
 
   protected async forward(
     method: string,
-    params?: Record<string, unknown>,
+    params?: CDPPayload,
     sessionId?: string,
     timeout?: number
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CDPPayload> {
     this.forwarded.push([method, params, sessionId, timeout]);
     return { ok: true };
   }


### PR DESCRIPTION
## Summary
- Replace every `Record<string, unknown>` in `synthetic-cdp-transport.ts` with the shared `CDPPayload` type (params, results, events, and the subclass `forward` hook), matching `CDPTransport` / `remote-cdp-transport.ts`
- Ratchet `record-string-unknown-baseline.json` for this file only
- Point the focused transport test stub at `CDPPayload`

Clears debt list: **record-string-unknown**

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npx vitest run packages/webapp/tests/cdp/synthetic-cdp-transport.test.ts`
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`