### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/scoops/tray-leader/tab-teleport.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -32,7 +32,6 @@
   "packages/webapp/src/providers/intercepted-oauth.ts": 4,
   "packages/webapp/src/scoops/onboarding-orchestrator.ts": 1,
   "packages/webapp/src/scoops/tray-leader/cdp-router.ts": 5,
-  "packages/webapp/src/scoops/tray-leader/tab-teleport.ts": 3,
   "packages/webapp/src/shell/bsh-watchdog.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 5,
   "packages/webapp/src/shell/supplemental-commands/secret-backends.ts": 3,

--- a/packages/webapp/src/scoops/tray-leader/tab-teleport.ts
+++ b/packages/webapp/src/scoops/tray-leader/tab-teleport.ts
@@ -10,7 +10,7 @@
  * `teleport-storage.ts`.
  */
 
-import { isSliccAppUrl } from '@slicc/shared-ts';
+import { type CookieTeleportCookie, isSliccAppUrl } from '@slicc/shared-ts';
 import { createLogger } from '../../base/logger.js';
 import type { BrowserAPI } from '../../cdp/index.js';
 import {
@@ -66,9 +66,15 @@ export interface TabTeleportResult {
   degraded: 'none' | 'no-source-state' | 'no-source-cookies' | 'no-dest-cookies';
 }
 
+/** Narrow CDP `Network.getCookies` result into the shared cookie shape. */
+function cookiesFromCdpResult(cookies: unknown): CookieTeleportCookie[] {
+  if (!Array.isArray(cookies)) return [];
+  return cookies as CookieTeleportCookie[];
+}
+
 interface SourceCapture {
   url: string;
-  cookies: Array<Record<string, unknown>>;
+  cookies: CookieTeleportCookie[];
   cookiesCaptured: boolean;
   storage: TeleportStorageSnapshot;
 }
@@ -96,11 +102,11 @@ async function captureSourceState(
     throw new Error('refusing to teleport SLICC’s own app tab (it carries a bridge capability)');
   }
 
-  let cookies: Array<Record<string, unknown>> = [];
+  let cookies: CookieTeleportCookie[] = [];
   let cookiesCaptured = false;
   try {
     const cookieResult = await browser.sendCDP('Network.getCookies', {});
-    cookies = (cookieResult['cookies'] as Array<Record<string, unknown>>) ?? [];
+    cookies = cookiesFromCdpResult(cookieResult['cookies']);
     cookiesCaptured = true;
   } catch (err) {
     log.warn('Could not capture source cookies', { error: String(err) });


### PR DESCRIPTION
## Summary
- Replace `Record<string, unknown>` CDP cookie bags in `tab-teleport.ts` with the shared `CookieTeleportCookie` shape (via a small `cookiesFromCdpResult` narrower at the `Network.getCookies` boundary).
- Ratchet `record-string-unknown-baseline.json` to drop this file (3 occurrences cleared).

## Debt lists cleared
- `record-string-unknown`

## Test plan
- [x] `npx biome check --write packages/webapp/src/scoops/tray-leader/tab-teleport.ts`
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/scoops/tray-leader/tab-teleport.test.ts packages/webapp/tests/scoops/tray-leader/tab-teleport-router.test.ts` (14 passed)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK