### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/tools/file-tools.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -47,7 +47,6 @@
   "packages/webapp/src/shell/supplemental-commands/websocat-command.ts": 1,
   "packages/webapp/src/skills/catalog.ts": 3,
   "packages/webapp/src/speech/hear.ts": 1,
-  "packages/webapp/src/tools/file-tools.ts": 3,
   "packages/webapp/src/transcript/normalize.ts": 2,
   "packages/webapp/src/transcript/redact.ts": 4,
   "packages/webapp/src/ui/boot/setup-onboarding-orchestrator.ts": 1,

--- a/packages/webapp/src/tools/file-tools.ts
+++ b/packages/webapp/src/tools/file-tools.ts
@@ -19,6 +19,35 @@ import type { ToolDefinition, ToolResult } from './types.js';
 
 const log = createLogger('tool:fs');
 
+/**
+ * Arguments for `read_file` — its `inputSchema` is the contract. Values arrive
+ * from the model, so each is cast at the boundary rather than trusted.
+ */
+export interface ReadFileInput {
+  path?: unknown;
+  offset?: unknown;
+  limit?: unknown;
+}
+
+/**
+ * Arguments for `write_file` — its `inputSchema` is the contract. Values arrive
+ * from the model, so each is cast at the boundary rather than trusted.
+ */
+export interface WriteFileInput {
+  path?: unknown;
+  content?: unknown;
+}
+
+/**
+ * Arguments for `edit_file` — its `inputSchema` is the contract. Values arrive
+ * from the model, so each is cast at the boundary rather than trusted.
+ */
+export interface EditFileInput {
+  path?: unknown;
+  old_string?: unknown;
+  new_string?: unknown;
+}
+
 /** Create all file tools bound to a VirtualFS instance. */
 export function createFileTools(fs: VirtualFS): ToolDefinition[] {
   return [createReadFileTool(fs), createWriteFileTool(fs), createEditFileTool(fs)];
@@ -61,10 +90,10 @@ function createReadFileTool(fs: VirtualFS): ToolDefinition {
       },
       required: ['path'],
     },
-    async execute(input: Record<string, unknown>): Promise<ToolResult> {
-      const path = input['path'] as string;
-      const offset = (input['offset'] as number | undefined) ?? 1;
-      const limit = input['limit'] as number | undefined;
+    async execute(input: ReadFileInput): Promise<ToolResult> {
+      const path = input.path as string;
+      const offset = (input.offset as number | undefined) ?? 1;
+      const limit = input.limit as number | undefined;
       log.debug('Read', { path, offset, limit });
 
       try {
@@ -158,9 +187,9 @@ function createWriteFileTool(fs: VirtualFS): ToolDefinition {
       },
       required: ['path', 'content'],
     },
-    async execute(input: Record<string, unknown>): Promise<ToolResult> {
-      const path = input['path'] as string;
-      const content = input['content'] as string;
+    async execute(input: WriteFileInput): Promise<ToolResult> {
+      const path = input.path as string;
+      const content = input.content as string;
       log.debug('Write', { path, contentLength: content.length });
 
       try {
@@ -198,10 +227,10 @@ function createEditFileTool(fs: VirtualFS): ToolDefinition {
       },
       required: ['path', 'old_string', 'new_string'],
     },
-    async execute(input: Record<string, unknown>): Promise<ToolResult> {
-      const path = input['path'] as string;
-      const oldString = input['old_string'] as string;
-      const newString = input['new_string'] as string;
+    async execute(input: EditFileInput): Promise<ToolResult> {
+      const path = input.path as string;
+      const oldString = input.old_string as string;
+      const newString = input.new_string as string;
       log.debug('Edit', { path, oldLength: oldString.length, newLength: newString.length });
 
       try {


### PR DESCRIPTION
## Summary
- Named `ReadFileInput`, `WriteFileInput`, and `EditFileInput` for each file-tool argument bag (same pattern as `BashToolInput`), replacing three `Record<string, unknown>` execute parameters.
- Ratcheted `record-string-unknown-baseline.json` to drop `packages/webapp/src/tools/file-tools.ts`.

## Debt lists cleared
- record-string-unknown

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/tools/file-tools.test.ts` (20 passed)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK