### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/playwright/teleport-storage.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -10,7 +10,6 @@
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/playwright/snapshot.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/playwright/state.ts": 4,
-  "packages/webapp/src/shell/supplemental-commands/playwright/teleport-storage.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/rsync-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/secret-backends.ts": 2,

--- a/packages/webapp/src/shell/supplemental-commands/playwright/teleport-storage.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/teleport-storage.ts
@@ -3,11 +3,25 @@
  * storage snapshotting, init-script installation, and page diagnostics.
  */
 
-import type { BrowserAPI } from '../../../cdp/index.js';
-import { createLogger } from '../../../core/logger.js';
+import { createLogger } from '../../../base/logger.js';
 import type { TeleportPageDiagnostics, TeleportStorageSnapshot, TeleportWatcher } from './types.js';
 
 const log = createLogger('playwright-teleport');
+
+/**
+ * Duck type for the CDP surface teleport-storage needs — avoids a shell → cdp
+ * layer back-edge (`docs/review-patterns.md` § Layer-stack import direction).
+ * Callers pass the real `BrowserAPI`; this module only uses evaluate / sendCDP /
+ * attachToPage.
+ */
+interface TeleportStorageBrowserAPI {
+  evaluate(expression: string): Promise<unknown>;
+  sendCDP(
+    method: string,
+    params?: { source?: string; identifier?: string }
+  ): Promise<{ identifier?: unknown }>;
+  attachToPage(targetId: string): Promise<string>;
+}
 
 export const EMPTY_TELEPORT_STORAGE: TeleportStorageSnapshot = {
   origin: '',
@@ -63,7 +77,7 @@ export function chooseTeleportLeaderLandingUrl(
 }
 
 export async function captureTeleportStorageSnapshot(
-  browser: BrowserAPI,
+  browser: TeleportStorageBrowserAPI,
   label: 'leader' | 'follower'
 ): Promise<TeleportStorageSnapshot> {
   const raw = await browser.evaluate(`(() => {
@@ -145,7 +159,7 @@ export function buildTeleportStorageApplyScript(snapshot: TeleportStorageSnapsho
 }
 
 export async function applyTeleportStorageSnapshot(
-  browser: BrowserAPI,
+  browser: TeleportStorageBrowserAPI,
   snapshot: TeleportStorageSnapshot,
   target: 'leader' | 'follower'
 ): Promise<void> {
@@ -167,7 +181,7 @@ export async function applyTeleportStorageSnapshot(
 }
 
 export async function installTeleportStorageInitScript(
-  browser: BrowserAPI,
+  browser: TeleportStorageBrowserAPI,
   snapshot: TeleportStorageSnapshot,
   targetId: string,
   target: 'leader' | 'follower'
@@ -205,7 +219,7 @@ export async function installTeleportStorageInitScript(
 }
 
 export async function captureTeleportPageDiagnostics(
-  browser: BrowserAPI
+  browser: TeleportStorageBrowserAPI
 ): Promise<TeleportPageDiagnostics> {
   const raw = await browser.evaluate(`(() => JSON.stringify({
     url: window.location.href,
@@ -237,7 +251,7 @@ export function shouldCaptureTeleportDiagnostics(href: string): boolean {
 }
 
 export async function logFollowerTeleportDiagnosticsOnce(
-  browser: BrowserAPI,
+  browser: TeleportStorageBrowserAPI,
   watcher: TeleportWatcher,
   reason: string
 ): Promise<void> {

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/teleport-storage.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/teleport-storage.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  applyTeleportStorageSnapshot,
+  buildTeleportStorageApplyScript,
+  buildTeleportStorageHydrationUrl,
+  buildTeleportStorageInitScript,
+  captureTeleportPageDiagnostics,
+  captureTeleportStorageSnapshot,
+  chooseTeleportLeaderLandingUrl,
+  countTeleportStorageEntries,
+  EMPTY_TELEPORT_STORAGE,
+  formatCookieDomainSummary,
+  installTeleportStorageInitScript,
+  shouldCaptureTeleportDiagnostics,
+  tryGetTeleportUrlOrigin,
+} from '../../../../src/shell/supplemental-commands/playwright/teleport-storage.js';
+import type { TeleportStorageSnapshot } from '../../../../src/shell/supplemental-commands/playwright/types.js';
+
+const sampleSnapshot: TeleportStorageSnapshot = {
+  origin: 'https://example.com',
+  localStorage: { a: '1' },
+  sessionStorage: { b: '2' },
+};
+
+describe('teleport-storage pure helpers', () => {
+  it('formats cookie domain counts descending', () => {
+    expect(
+      formatCookieDomainSummary([
+        { domain: '.a.com' },
+        { domain: '.b.com' },
+        { domain: '.a.com' },
+        {},
+      ])
+    ).toBe('2 .a.com, 1 .b.com, 1 unknown');
+  });
+
+  it('counts storage entries and treats empty as zero', () => {
+    expect(countTeleportStorageEntries(EMPTY_TELEPORT_STORAGE)).toBe(0);
+    expect(countTeleportStorageEntries(sampleSnapshot)).toBe(2);
+  });
+
+  it('parses origins and builds hydration URLs safely', () => {
+    expect(tryGetTeleportUrlOrigin()).toBeNull();
+    expect(tryGetTeleportUrlOrigin('not a url')).toBeNull();
+    expect(tryGetTeleportUrlOrigin('https://example.com/path')).toBe('https://example.com');
+    expect(buildTeleportStorageHydrationUrl('https://example.com')).toBe(
+      'https://example.com/favicon.ico'
+    );
+    expect(buildTeleportStorageHydrationUrl('not-an-origin')).toBe('not-an-origin');
+  });
+
+  it('chooses a landing URL whose origin matches storage', () => {
+    expect(
+      chooseTeleportLeaderLandingUrl(
+        'https://example.com',
+        'https://example.com/start',
+        'https://other.com/end'
+      )
+    ).toBe('https://example.com/start');
+    expect(
+      chooseTeleportLeaderLandingUrl(
+        'https://example.com',
+        'https://other.com/start',
+        'https://example.com/end'
+      )
+    ).toBe('https://example.com/end');
+    expect(chooseTeleportLeaderLandingUrl('https://example.com')).toBe('https://example.com');
+    expect(chooseTeleportLeaderLandingUrl('', 'https://fallback.test')).toBe(
+      'https://fallback.test'
+    );
+  });
+
+  it('embeds the snapshot into init and apply scripts', () => {
+    const init = buildTeleportStorageInitScript(sampleSnapshot);
+    const apply = buildTeleportStorageApplyScript(sampleSnapshot);
+    expect(init).toContain('"origin":"https://example.com"');
+    expect(init).toContain('__slicc_teleport_storage_applied__');
+    expect(apply).toContain('Teleport storage origin mismatch');
+    expect(apply).toContain('"a":"1"');
+  });
+
+  it('detects diagnostic-worthy callback URLs', () => {
+    expect(shouldCaptureTeleportDiagnostics('https://idp/callback')).toBe(true);
+    expect(shouldCaptureTeleportDiagnostics('https://idp/authorize/resume')).toBe(true);
+    expect(shouldCaptureTeleportDiagnostics('https://idp/error')).toBe(true);
+    expect(shouldCaptureTeleportDiagnostics('https://app.example/home')).toBe(false);
+  });
+});
+
+describe('teleport-storage browser helpers', () => {
+  it('parses a storage snapshot from evaluate JSON', async () => {
+    const browser = {
+      evaluate: vi.fn().mockResolvedValue(JSON.stringify(sampleSnapshot)),
+      sendCDP: vi.fn(),
+      attachToPage: vi.fn(),
+    };
+    await expect(captureTeleportStorageSnapshot(browser, 'leader')).resolves.toEqual(
+      sampleSnapshot
+    );
+  });
+
+  it('returns empty storage when evaluate is non-string or unparseable', async () => {
+    const browser = {
+      evaluate: vi.fn().mockResolvedValue(42),
+      sendCDP: vi.fn(),
+      attachToPage: vi.fn(),
+    };
+    await expect(captureTeleportStorageSnapshot(browser, 'follower')).resolves.toEqual(
+      EMPTY_TELEPORT_STORAGE
+    );
+
+    browser.evaluate.mockResolvedValue('{not-json');
+    await expect(captureTeleportStorageSnapshot(browser, 'follower')).resolves.toEqual(
+      EMPTY_TELEPORT_STORAGE
+    );
+  });
+
+  it('skips apply and init when the snapshot has no entries', async () => {
+    const browser = {
+      evaluate: vi.fn(),
+      sendCDP: vi.fn(),
+      attachToPage: vi.fn(),
+    };
+    await applyTeleportStorageSnapshot(browser, EMPTY_TELEPORT_STORAGE, 'leader');
+    await expect(
+      installTeleportStorageInitScript(browser, EMPTY_TELEPORT_STORAGE, 't1', 'leader')
+    ).resolves.toBeNull();
+    expect(browser.evaluate).not.toHaveBeenCalled();
+    expect(browser.sendCDP).not.toHaveBeenCalled();
+  });
+
+  it('applies storage and installs a removable init script', async () => {
+    const browser = {
+      evaluate: vi.fn().mockResolvedValue('{"ok":true}'),
+      sendCDP: vi.fn().mockResolvedValue({ identifier: 'script-1' }),
+      attachToPage: vi.fn().mockResolvedValue('session'),
+    };
+
+    await applyTeleportStorageSnapshot(browser, sampleSnapshot, 'follower');
+    expect(browser.evaluate).toHaveBeenCalledOnce();
+
+    const remove = await installTeleportStorageInitScript(
+      browser,
+      sampleSnapshot,
+      'target-1',
+      'follower'
+    );
+    expect(browser.sendCDP).toHaveBeenCalledWith('Page.addScriptToEvaluateOnNewDocument', {
+      source: expect.stringContaining('https://example.com'),
+    });
+    expect(remove).toBeTypeOf('function');
+
+    await remove?.();
+    expect(browser.attachToPage).toHaveBeenCalledWith('target-1');
+    expect(browser.sendCDP).toHaveBeenCalledWith('Page.removeScriptToEvaluateOnNewDocument', {
+      identifier: 'script-1',
+    });
+  });
+
+  it('captures page diagnostics from evaluate JSON', async () => {
+    const browser = {
+      evaluate: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          url: 'https://example.com/callback',
+          title: 'Done',
+          bodySnippet: 'ok',
+        })
+      ),
+      sendCDP: vi.fn(),
+      attachToPage: vi.fn(),
+    };
+    await expect(captureTeleportPageDiagnostics(browser)).resolves.toEqual({
+      url: 'https://example.com/callback',
+      title: 'Done',
+      bodySnippet: 'ok',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Cleared the **layer-back-edge** debt for `packages/webapp/src/shell/supplemental-commands/playwright/teleport-storage.ts` by replacing the `shell → cdp` type import (`BrowserAPI`) with a local duck type (`evaluate` / `sendCDP` / `attachToPage`) and switching `createLogger` to `base/logger`.
- Ratcheted `layer-back-edge-baseline.json` via `check-layer-back-edges.mjs --update` (removed this file only).
- Added focused unit tests for pure helpers and browser capture/apply/init paths.

## Debt lists cleared
- `layer-back-edge` (`packages/dev-tools/tools/layer-back-edge-baseline.json`)

## Verification
- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright/teleport-storage.test.ts` (11 passed)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK

## Test plan
- [ ] CI lint / typecheck / test green
- [ ] Confirm `check-touched-exemptions` passes on the PR
- [ ] Smoke: teleport auth capture/replay and tab-teleport storage init still work with a real BrowserAPI