### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/kernel/realm/mount-bomb-fs.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -25,7 +25,6 @@
   "packages/webapp/src/kernel/cdp-worker-proxy.ts": 3,
   "packages/webapp/src/kernel/realm/helpers/node-assert.ts": 5,
   "packages/webapp/src/kernel/realm/http-global.ts": 2,
-  "packages/webapp/src/kernel/realm/mount-bomb-fs.ts": 2,
   "packages/webapp/src/kernel/realm/py-realm-shared.ts": 1,
   "packages/webapp/src/kernel/realm/ws-router-page.ts": 7,
   "packages/webapp/src/kernel/telemetry.ts": 1,

--- a/packages/webapp/src/kernel/realm/mount-bomb-fs.ts
+++ b/packages/webapp/src/kernel/realm/mount-bomb-fs.ts
@@ -45,6 +45,27 @@ export interface MountBombFsPlugin {
 }
 
 /**
+ * The slice of `pyodide.FS.filesystems` this module reads and writes.
+ * Pyodide's bag also holds MEMFS / NODEFS / …; we only register
+ * `MOUNT_BOMB_FS` and leave the rest alone.
+ */
+export interface MountBombFilesystems {
+  MOUNT_BOMB_FS?: MountBombFsPlugin;
+}
+
+/**
+ * The subset of `pyodide.FS` that {@link installMountBombs} needs:
+ * the Emscripten node helpers plus `stat` / `mkdirTree` / `mount`
+ * and the filesystems registry we hang the plugin on.
+ */
+export interface MountBombPyodideFs extends EmscriptenFsApi {
+  stat: (path: string) => unknown;
+  mkdirTree: (path: string) => void;
+  mount: (plugin: MountBombFsPlugin, opts: MountBombOpts, dir: string) => unknown;
+  filesystems: MountBombFilesystems;
+}
+
+/**
  * Build the actionable bomb message used by every thrown error.
  * Names the path verbatim and directs the caller at the two
  * documented escape hatches: `await slicc.fs.<op>(<path>)` for
@@ -178,10 +199,10 @@ function getMountPath(node: FsNode): string {
  * stable. Mirrors `ensureOpfsSyncFsRegistered` in `py-realm-shared.ts`.
  */
 export function ensureMountBombFsRegistered(
-  filesystems: Record<string, unknown>,
+  filesystems: MountBombFilesystems,
   Fs: EmscriptenFsApi
 ): MountBombFsPlugin {
-  let plugin = filesystems.MOUNT_BOMB_FS as MountBombFsPlugin | undefined;
+  let plugin = filesystems.MOUNT_BOMB_FS;
   if (!plugin) {
     plugin = createMountBombFs(Fs);
     filesystems.MOUNT_BOMB_FS = plugin;
@@ -202,17 +223,7 @@ export function ensureMountBombFsRegistered(
  * placeholder under that path instead of the bomb.
  */
 export function installMountBombs(
-  pyodideFs: {
-    stat: (path: string) => unknown;
-    mkdirTree: (path: string) => void;
-    mount: (plugin: unknown, opts: unknown, dir: string) => unknown;
-    filesystems: Record<string, unknown>;
-    createNode(parent: FsNode | null, name: string, mode: number, dev?: number): FsNode;
-    isDir(mode: number): boolean;
-    isFile(mode: number): boolean;
-    isLink(mode: number): boolean;
-    ErrnoError: new (errno: number) => Error & { errno: number };
-  },
+  pyodideFs: MountBombPyodideFs,
   mountPaths: readonly string[],
   pushWarning: (message: string) => void = () => {}
 ): void {

--- a/packages/webapp/tests/kernel/realm/mount-bomb-fs.test.ts
+++ b/packages/webapp/tests/kernel/realm/mount-bomb-fs.test.ts
@@ -14,6 +14,10 @@ import {
   createMountBombFs,
   formatBombMessage,
   installMountBombs,
+  type MountBombFilesystems,
+  type MountBombFsPlugin,
+  type MountBombOpts,
+  type MountBombPyodideFs,
 } from '../../../src/kernel/realm/mount-bomb-fs.js';
 import type { EmscriptenFsApi, FsNode } from '../../../src/kernel/realm/opfs-sync-fs.js';
 
@@ -46,22 +50,17 @@ function makeFakeFsApi(): EmscriptenFsApi {
 }
 
 function makeFakePyFs(): {
-  filesystems: Record<string, unknown>;
-  mounts: { plugin: unknown; opts: unknown; dir: string }[];
+  filesystems: MountBombFilesystems;
+  mounts: { plugin: MountBombFsPlugin; opts: MountBombOpts; dir: string }[];
   mkdirs: string[];
-  api: EmscriptenFsApi & {
-    stat: (p: string) => unknown;
-    mkdirTree: (p: string) => void;
-    mount: (plugin: unknown, opts: unknown, dir: string) => unknown;
-    filesystems: Record<string, unknown>;
-  };
+  api: MountBombPyodideFs;
 } {
   const fsApi = makeFakeFsApi();
-  const filesystems: Record<string, unknown> = {};
-  const mounts: { plugin: unknown; opts: unknown; dir: string }[] = [];
+  const filesystems: MountBombFilesystems = {};
+  const mounts: { plugin: MountBombFsPlugin; opts: MountBombOpts; dir: string }[] = [];
   const mkdirs: string[] = [];
   const dirs = new Set<string>(['/']);
-  const api = {
+  const api: MountBombPyodideFs = {
     ...fsApi,
     filesystems,
     stat: (path: string): unknown => {
@@ -76,7 +75,7 @@ function makeFakePyFs(): {
         dirs.add(cursor);
       }
     },
-    mount: (plugin: unknown, opts: unknown, dir: string): unknown => {
+    mount: (plugin: MountBombFsPlugin, opts: MountBombOpts, dir: string): unknown => {
       mounts.push({ plugin, opts, dir });
       dirs.add(dir);
       return {};
@@ -138,8 +137,8 @@ describe('installMountBombs', () => {
     expect(py.mounts).toHaveLength(2);
     expect(py.mounts[0].dir).toBe('/mnt/kb');
     expect(py.mounts[1].dir).toBe('/workspace/repo');
-    expect((py.mounts[0].opts as { mountPath: string }).mountPath).toBe('/mnt/kb');
-    expect((py.mounts[1].opts as { mountPath: string }).mountPath).toBe('/workspace/repo');
+    expect(py.mounts[0].opts.mountPath).toBe('/mnt/kb');
+    expect(py.mounts[1].opts.mountPath).toBe('/workspace/repo');
   });
 
   it('creates missing parent directories via mkdirTree', () => {
@@ -167,9 +166,9 @@ describe('installMountBombs', () => {
   it('per-path failure surfaces a warning and continues with the next path', () => {
     const py = makeFakePyFs();
     let mountCalls = 0;
-    const api = {
+    const api: MountBombPyodideFs = {
       ...py.api,
-      mount: (plugin: unknown, opts: unknown, dir: string): unknown => {
+      mount: (plugin: MountBombFsPlugin, opts: MountBombOpts, dir: string): unknown => {
         mountCalls++;
         if (dir === '/mnt/a') throw new Error('EBUSY');
         py.mounts.push({ plugin, opts, dir });


### PR DESCRIPTION
## Summary
- Replace `Record<string, unknown>` on the Pyodide `FS.filesystems` bag with named `MountBombFilesystems` / `MountBombPyodideFs` types (and tighten `mount` opts to `MountBombOpts`)
- Point the focused mount-bomb tests at those types
- Ratchet `record-string-unknown-baseline.json` for this file only

Clears debt list: **record-string-unknown**

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npx vitest run packages/webapp/tests/kernel/realm/mount-bomb-fs.test.ts`
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`