### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -342,7 +342,6 @@
       "includes": [
         "packages/webapp/providers/adobe.ts",
         "packages/webapp/src/kernel/cdp-worker-proxy.ts",
-        "packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts",
         "packages/webapp/tests/providers/adobe-provider.test.ts"
       ],
       "linter": {

--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -7,7 +7,6 @@
   "packages/webapp/src/shell/supplemental-commands/host-command.ts": 7,
   "packages/webapp/src/shell/supplemental-commands/picker-popup.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/interaction.ts": 1,
-  "packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/playwright/snapshot.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/playwright/state.ts": 4,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport-storage.ts": 2,

--- a/packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/handlers/routing.ts
@@ -7,12 +7,20 @@
  * Commands: route, route-list, unroute
  */
 
-import type { BrowserAPI } from '../../../../cdp/index.js';
-import { createLogger } from '../../../../core/logger.js';
+import { createLogger } from '../../../../base/logger.js';
 import { requireTab } from '../state.js';
-import type { PlaywrightHandler, PlaywrightState, RouteEntry } from '../types.js';
+import type {
+  PlaywrightHandler,
+  PlaywrightHandlerCtx,
+  PlaywrightState,
+  RouteEntry,
+} from '../types.js';
 
 const log = createLogger('playwright-route');
+
+// Named via the handler context rather than imported from `cdp/` so this
+// module stays inside the shell layer (see layer-stack import direction).
+type BrowserAPI = PlaywrightHandlerCtx['browser'];
 
 function utf8ToBase64(str: string): string {
   const bytes = new TextEncoder().encode(str);
@@ -30,6 +38,59 @@ export function patternToRegex(pattern: string): RegExp {
   return new RegExp(`^${re}$`);
 }
 
+type FetchTransport = ReturnType<BrowserAPI['getTransport']>;
+
+/** Fulfil or continue a single Fetch.requestPaused event. */
+async function handleRequestPaused(
+  transport: FetchTransport,
+  sessionId: string,
+  state: PlaywrightState,
+  targetId: string,
+  params: unknown
+): Promise<void> {
+  if ((params as { sessionId?: string })['sessionId'] !== sessionId) return;
+
+  const { requestId, request } = params as {
+    requestId: string;
+    request: { url: string; headers: Record<string, string> };
+  };
+
+  const routes = state.routes.get(targetId) ?? [];
+  const match = routes.find((r) => r.regex.test(request.url));
+
+  if (!match) {
+    await transport
+      .send('Fetch.continueRequest', { requestId }, sessionId)
+      .catch((err: unknown) => {
+        log.warn('Fetch.continueRequest failed — intercepted request may hang', {
+          requestId,
+          err,
+        });
+      });
+    return;
+  }
+
+  const responseHeaders: Array<{ name: string; value: string }> = [
+    { name: 'Content-Type', value: match.contentType },
+    ...Object.entries(match.headers).map(([name, value]) => ({ name, value })),
+  ];
+
+  await transport
+    .send(
+      'Fetch.fulfillRequest',
+      {
+        requestId,
+        responseCode: match.status,
+        responseHeaders,
+        body: match.body ? utf8ToBase64(match.body) : undefined,
+      },
+      sessionId
+    )
+    .catch((err: unknown) => {
+      log.warn('Fetch.fulfillRequest failed', { requestId, url: request.url, err });
+    });
+}
+
 /** Enable CDP Fetch domain interception for a tab and register the event handler. */
 async function enableFetchInterception(
   browser: BrowserAPI,
@@ -45,48 +106,9 @@ async function enableFetchInterception(
       sessionId
     );
 
-    const handler = async (params: unknown) => {
-      if ((params as { sessionId?: string })['sessionId'] !== sessionId) return;
-
-      const { requestId, request } = params as {
-        requestId: string;
-        request: { url: string; headers: Record<string, string> };
-      };
-
-      const routes = state.routes.get(targetId) ?? [];
-      const match = routes.find((r) => r.regex.test(request.url));
-
-      if (!match) {
-        await transport
-          .send('Fetch.continueRequest', { requestId }, sessionId)
-          .catch((err: unknown) => {
-            log.warn('Fetch.continueRequest failed — intercepted request may hang', {
-              requestId,
-              err,
-            });
-          });
-        return;
-      }
-
-      const responseHeaders: Array<{ name: string; value: string }> = [
-        { name: 'Content-Type', value: match.contentType },
-        ...Object.entries(match.headers).map(([name, value]) => ({ name, value })),
-      ];
-
-      await transport
-        .send(
-          'Fetch.fulfillRequest',
-          {
-            requestId,
-            responseCode: match.status,
-            responseHeaders,
-            body: match.body ? utf8ToBase64(match.body) : undefined,
-          },
-          sessionId
-        )
-        .catch((err: unknown) => {
-          log.warn('Fetch.fulfillRequest failed', { requestId, url: request.url, err });
-        });
+    // Sync listener — async work is fire-and-forget via void (noMisusedPromises).
+    const handler = (params: unknown): void => {
+      void handleRequestPaused(transport, sessionId, state, targetId, params);
     };
 
     // Set cleanup BEFORE registering the event handler to avoid a race where


### PR DESCRIPTION
## Summary
- Cleared **misused-promise** debt: extracted `handleRequestPaused` and registered a sync `Fetch.requestPaused` listener that fire-and-forgets with `void` (same pattern as #2532).
- Cleared **layer-back-edge** debt: switched `createLogger` to `base/logger` and named `BrowserAPI` via `PlaywrightHandlerCtx['browser']` instead of importing `cdp/` (same pattern as snapshot handlers / #2584).
- Removed the file from the `nursery.noMisusedPromises: "off"` biome override and ratcheted `layer-back-edge-baseline.json` via `--update`.

## Debt lists cleared
- `misused-promise` (`biome.json` overrides)
- `layer-back-edge` (`packages/dev-tools/tools/layer-back-edge-baseline.json`)

## Verification
- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright/handlers/routing.test.ts` (13 passed)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK

## Test plan
- [ ] CI lint / typecheck / test green
- [ ] Confirm `check-touched-exemptions` passes on the PR
- [ ] Smoke: `playwright-cli route` / `route-list` / `unroute` still mock and clean up Fetch interception