### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/providers/cerebras.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -318,7 +318,6 @@
         "packages/chrome-extension/src/secrets-entry.ts",
         "packages/webapp/cloud/app.js",
         "packages/webapp/providers/adobe.ts",
-        "packages/webapp/providers/cerebras.ts",
         "packages/webapp/providers/openai-codex.ts",
         "packages/webapp/providers/xai-grok.ts",
         "packages/webapp/src/cdp/har-recorder.ts",

--- a/packages/webapp/providers/cerebras.ts
+++ b/packages/webapp/providers/cerebras.ts
@@ -197,33 +197,42 @@ function makeErrorOutput(model: Model<Api>, error: unknown) {
 
 // ── Stream functions ───────────────────────────────────────────────
 
+function logStreamError(error: unknown): void {
+  console.error('[cerebras] Stream error:', error instanceof Error ? error.message : String(error));
+}
+
 const streamCerebras = (
   model: Model<Api>,
   context: Context,
   options: ProviderStreamOptions = {}
 ) => {
   const stream = createAssistantMessageEventStream();
-  (async () => {
-    try {
-      const proxyModel = {
-        ...model,
-        baseUrl: CEREBRAS_BASE_URL,
-        api: OPENAI_COMPLETIONS_API,
-      } as Model<'openai-completions'>;
-      const inner = streamOpenAICompletions(proxyModel, context, options);
-      for await (const event of inner) stream.push(event);
-      stream.end();
-    } catch (error) {
-      console.error(
-        '[cerebras] Stream error:',
-        error instanceof Error ? error.message : String(error)
-      );
-      stream.push(makeErrorOutput(model, error) as never);
-      stream.end();
-    }
-  })();
+  // Fire-and-forget pump — callers consume the returned event stream.
+  pumpCerebrasCompletions(stream, model, context, options).catch(logStreamError);
   return stream;
 };
+
+async function pumpCerebrasCompletions(
+  stream: ReturnType<typeof createAssistantMessageEventStream>,
+  model: Model<Api>,
+  context: Context,
+  options: ProviderStreamOptions
+): Promise<void> {
+  try {
+    const proxyModel = {
+      ...model,
+      baseUrl: CEREBRAS_BASE_URL,
+      api: OPENAI_COMPLETIONS_API,
+    } as Model<'openai-completions'>;
+    const inner = streamOpenAICompletions(proxyModel, context, options);
+    for await (const event of inner) stream.push(event);
+    stream.end();
+  } catch (error) {
+    logStreamError(error);
+    stream.push(makeErrorOutput(model, error) as never);
+    stream.end();
+  }
+}
 
 const streamSimpleCerebras = (
   model: Model<Api>,
@@ -231,27 +240,32 @@ const streamSimpleCerebras = (
   options?: SimpleStreamOptions
 ) => {
   const stream = createAssistantMessageEventStream();
-  (async () => {
-    try {
-      const proxyModel = {
-        ...model,
-        baseUrl: CEREBRAS_BASE_URL,
-        api: OPENAI_COMPLETIONS_API,
-      } as Model<'openai-completions'>;
-      const inner = streamSimpleOpenAICompletions(proxyModel, context, options);
-      for await (const event of inner) stream.push(event);
-      stream.end();
-    } catch (error) {
-      console.error(
-        '[cerebras] Stream error:',
-        error instanceof Error ? error.message : String(error)
-      );
-      stream.push(makeErrorOutput(model, error) as never);
-      stream.end();
-    }
-  })();
+  // Fire-and-forget pump — callers consume the returned event stream.
+  pumpSimpleCerebrasCompletions(stream, model, context, options).catch(logStreamError);
   return stream;
 };
+
+async function pumpSimpleCerebrasCompletions(
+  stream: ReturnType<typeof createAssistantMessageEventStream>,
+  model: Model<Api>,
+  context: Context,
+  options?: SimpleStreamOptions
+): Promise<void> {
+  try {
+    const proxyModel = {
+      ...model,
+      baseUrl: CEREBRAS_BASE_URL,
+      api: OPENAI_COMPLETIONS_API,
+    } as Model<'openai-completions'>;
+    const inner = streamSimpleOpenAICompletions(proxyModel, context, options);
+    for await (const event of inner) stream.push(event);
+    stream.end();
+  } catch (error) {
+    logStreamError(error);
+    stream.push(makeErrorOutput(model, error) as never);
+    stream.end();
+  }
+}
 
 // ── Provider config ────────────────────────────────────────────────
 

--- a/packages/webapp/tests/providers/cerebras.test.ts
+++ b/packages/webapp/tests/providers/cerebras.test.ts
@@ -2,18 +2,25 @@
  * Tests for the Cerebras provider.
  *
  * Verifies the three-layer model catalog (live cache → localStorage → seed),
- * refreshModels() fetching behaviour, and register() API wiring.
+ * refreshModels() fetching behaviour, register() API wiring, and the
+ * fire-and-forget stream pumps (explicit .catch so noFloatingPromises is clean).
  */
 
+import type { Api, Model } from '@earendil-works/pi-ai';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const streamMocks = vi.hoisted(() => ({
+  streamOpenAICompletions: vi.fn(),
+  streamSimpleOpenAICompletions: vi.fn(),
+}));
 
 vi.mock('@earendil-works/pi-ai/compat', async (importOriginal) => {
   const original = await importOriginal<typeof import('@earendil-works/pi-ai/compat')>();
   return {
     ...original,
     registerApiProvider: vi.fn(),
-    streamOpenAICompletions: vi.fn(),
-    streamSimpleOpenAICompletions: vi.fn(),
+    streamOpenAICompletions: streamMocks.streamOpenAICompletions,
+    streamSimpleOpenAICompletions: streamMocks.streamSimpleOpenAICompletions,
   };
 });
 
@@ -35,7 +42,10 @@ vi.stubGlobal('localStorage', {
   clear: () => storage.clear(),
 });
 
-import { registerApiProvider } from '@earendil-works/pi-ai/compat';
+import {
+  createAssistantMessageEventStream,
+  registerApiProvider,
+} from '@earendil-works/pi-ai/compat';
 import { config, register } from '../../providers/cerebras.js';
 
 // Reset module-level cache between tests by reloading the module each time
@@ -43,10 +53,39 @@ import { config, register } from '../../providers/cerebras.js';
 // tests that depend on a clean cache run before any refreshModels() call.
 
 const STORAGE_KEY = 'slicc-cerebras-models';
+const CEREBRAS_API = 'cerebras-openai' as Api;
+const context = { systemPrompt: '', messages: [], tools: [] };
+
+function endedStream() {
+  const stream = createAssistantMessageEventStream();
+  queueMicrotask(() => stream.end());
+  return stream;
+}
+
+async function collectEvents(
+  stream: ReturnType<typeof createAssistantMessageEventStream>
+): Promise<unknown[]> {
+  const events: unknown[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+function sampleModel(): Model<Api> {
+  return {
+    id: 'gpt-oss-120b',
+    name: 'GPT OSS 120B',
+    api: CEREBRAS_API,
+    provider: 'cerebras',
+  } as Model<Api>;
+}
 
 beforeEach(() => {
   storage.clear();
   vi.mocked(registerApiProvider).mockClear();
+  streamMocks.streamOpenAICompletions.mockReset();
+  streamMocks.streamSimpleOpenAICompletions.mockReset();
+  streamMocks.streamOpenAICompletions.mockImplementation(endedStream);
+  streamMocks.streamSimpleOpenAICompletions.mockImplementation(endedStream);
 });
 
 // ── Provider config ────────────────────────────────────────────────
@@ -264,5 +303,73 @@ describe('register()', () => {
     expect(call.api).toBe('cerebras-openai');
     expect(call.stream).toBeTypeOf('function');
     expect(call.streamSimple).toBeTypeOf('function');
+  });
+});
+
+// ── Stream pumps ──────────────────────────────────────────────────
+
+describe('stream pumps', () => {
+  it('stream routes through openai-completions at the Cerebras base URL', async () => {
+    register();
+    const call = vi.mocked(registerApiProvider).mock.calls[0]![0];
+    const events = await collectEvents(
+      call.stream(sampleModel(), context, {}) as ReturnType<
+        typeof createAssistantMessageEventStream
+      >
+    );
+    expect(events).toEqual([]);
+    expect(streamMocks.streamOpenAICompletions).toHaveBeenCalledOnce();
+    const proxyModel = streamMocks.streamOpenAICompletions.mock.calls[0]![0] as {
+      baseUrl: string;
+      api: string;
+    };
+    expect(proxyModel.baseUrl).toBe('https://api.cerebras.ai/v1');
+    expect(proxyModel.api).toBe('openai-completions');
+  });
+
+  it('streamSimple routes through openai-completions at the Cerebras base URL', async () => {
+    register();
+    const call = vi.mocked(registerApiProvider).mock.calls[0]![0];
+    const events = await collectEvents(
+      call.streamSimple!(sampleModel(), context) as ReturnType<
+        typeof createAssistantMessageEventStream
+      >
+    );
+    expect(events).toEqual([]);
+    expect(streamMocks.streamSimpleOpenAICompletions).toHaveBeenCalledOnce();
+    const proxyModel = streamMocks.streamSimpleOpenAICompletions.mock.calls[0]![0] as {
+      baseUrl: string;
+      api: string;
+    };
+    expect(proxyModel.baseUrl).toBe('https://api.cerebras.ai/v1');
+    expect(proxyModel.api).toBe('openai-completions');
+  });
+
+  it('stream surfaces inner failures as error events without rejecting', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    streamMocks.streamOpenAICompletions.mockImplementation(() => {
+      throw new Error('upstream boom');
+    });
+    register();
+    const call = vi.mocked(registerApiProvider).mock.calls[0]![0];
+    const events = await collectEvents(
+      call.stream(sampleModel(), context, {}) as ReturnType<
+        typeof createAssistantMessageEventStream
+      >
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual(
+      expect.objectContaining({
+        type: 'error',
+        reason: 'error',
+        error: expect.objectContaining({
+          errorMessage: 'upstream boom',
+          provider: 'cerebras',
+          model: 'gpt-oss-120b',
+        }),
+      })
+    );
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Refactor Cerebras stream pumps to named async helpers with an explicit `.catch()` so fire-and-forget streaming no longer trips `nursery.noFloatingPromises`.
- Remove `packages/webapp/providers/cerebras.ts` from the biome floating-promise exemption list.
- Add focused stream tests covering success routing and error-event surfacing.

## Debt cleared
- `floating-promise` (`biome.json` `nursery.noFloatingPromises: "off"` override)

## Test plan
- [x] `npx biome check` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/providers/cerebras.test.ts`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK