### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/ui/main.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -44,7 +44,6 @@
   "packages/webapp/src/transcript/redact.ts": 4,
   "packages/webapp/src/ui/boot/setup-welcome-flow.ts": 13,
   "packages/webapp/src/ui/dip.ts": 4,
-  "packages/webapp/src/ui/main.ts": 1,
   "packages/webapp/src/ui/sprinkle-bridge.ts": 2,
   "packages/webapp/src/ui/sprinkle-renderer.ts": 3,
   "packages/webapp/src/ui/tray-leave-runtime.ts": 1,

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -35,6 +35,15 @@ import { applyProviderDefaults } from './provider-settings.js';
 
 const log = createLogger('main');
 
+/**
+ * Page-realm flag read by `shell/float-topology.ts` (and providers that
+ * mirror it). Named so the connect-mode boot path casts through a known
+ * shape instead of an open string-keyed bag.
+ */
+type ConnectModeGlobal = {
+  __slicc_connect_mode?: unknown;
+};
+
 /** `?ui-fixture` (any value) selects the design-time chat fixture. */
 function isFixtureRequested(href: string): boolean {
   try {
@@ -145,7 +154,7 @@ async function main(): Promise<void> {
   ]);
 
   if (runtimeMode === 'connect') {
-    (globalThis as Record<string, unknown>).__slicc_connect_mode = true;
+    (globalThis as ConnectModeGlobal).__slicc_connect_mode = true;
     const { loadLegacyStyles } = await import('./legacy-styles.js');
     await loadLegacyStyles();
     const { mountConnectSurface } = await import('./connect-surface.js');

--- a/packages/webapp/tests/ui/main-telemetry.test.ts
+++ b/packages/webapp/tests/ui/main-telemetry.test.ts
@@ -50,4 +50,12 @@ describe('ui/main.ts telemetry wiring', () => {
   it('gates initTelemetry on a non-connect runtime mode', () => {
     expect(source).toMatch(/runtimeMode\s*!==\s*['"]connect['"][\s\S]{0,200}initTelemetry\(\)/);
   });
+
+  it('marks connect mode via a named ConnectModeGlobal cast', () => {
+    expect(source).toMatch(
+      /type ConnectModeGlobal\s*=\s*\{[\s\S]*?__slicc_connect_mode\?: unknown;/
+    );
+    expect(source).toMatch(/\(globalThis as ConnectModeGlobal\)\.__slicc_connect_mode\s*=\s*true/);
+    expect(source).not.toMatch(/Record<\s*string\s*,\s*unknown\s*>/);
+  });
 });


### PR DESCRIPTION
## Summary
- Replace the `?connect=1` boot path's `globalThis as Record<string, unknown>` cast with a named `ConnectModeGlobal` shape (same pattern as `shell/float-topology.ts`).
- Ratchet `record-string-unknown-baseline.json` to drop `packages/webapp/src/ui/main.ts`.
- Extend the static `main-telemetry` guard so the named cast stays in place.

## Debt cleared
- `record-string-unknown` (`packages/dev-tools/tools/record-string-unknown-baseline.json`)

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npx vitest run packages/webapp/tests/ui/main-telemetry.test.ts packages/webapp/tests/ui/main-cherry.test.ts`
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK