### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/ui/tray-leave-runtime.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -47,7 +47,6 @@
   "packages/webapp/src/ui/main.ts": 1,
   "packages/webapp/src/ui/sprinkle-bridge.ts": 2,
   "packages/webapp/src/ui/sprinkle-renderer.ts": 3,
-  "packages/webapp/src/ui/tray-leave-runtime.ts": 1,
   "packages/webcomponents/src/composer/speech.ts": 1,
   "packages/webcomponents/src/overlay/slicc-permissions.stories.ts": 5
 }

--- a/packages/webapp/src/ui/tray-leave-runtime.ts
+++ b/packages/webapp/src/ui/tray-leave-runtime.ts
@@ -17,9 +17,24 @@
 import type { TrayLeaveResult } from '../scoops/tray-leave.js';
 import { TRAY_JOIN_STORAGE_KEY, TRAY_WORKER_STORAGE_KEY } from '../scoops/tray-runtime-config.js';
 
+/**
+ * Structured fields attached to tray-leave failure log entries.
+ * Optional correlation / context fields callers may include together.
+ */
+export interface TrayLeaveLogMeta {
+  /** Panel/shell/worker correlation id for rapid retries. */
+  requestId?: string;
+  /** Stringified error when the failure carries one. */
+  error?: string;
+  /** Worker URL involved in a restart / switch failure. */
+  workerBaseUrl?: string;
+  /** Which storage write failed (`join-clear`, `worker-set`, …). */
+  kind?: string;
+}
+
 /** Minimal logger surface — matches `createLogger` shape but loose enough for tests. */
 export interface TrayLeaveLogger {
-  error(message: string, meta?: Record<string, unknown>): void;
+  error(message: string, meta?: TrayLeaveLogMeta): void;
 }
 
 /** Minimal storage surface — `window.localStorage` is the production target. */

--- a/packages/webapp/tests/ui/tray-leave-runtime.test.ts
+++ b/packages/webapp/tests/ui/tray-leave-runtime.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   performTrayLeave,
   type TrayLeaveDeps,
+  type TrayLeaveLogMeta,
   type TrayLeaveReadyHandle,
   type TrayLeaveStoppable,
 } from '../../src/ui/tray-leave-runtime.js';
@@ -52,8 +53,8 @@ function makeStorage(initial: Record<string, string> = {}): FakeStorage {
 }
 
 interface RecordingLog {
-  errors: Array<{ message: string; meta?: Record<string, unknown> }>;
-  error(message: string, meta?: Record<string, unknown>): void;
+  errors: Array<{ message: string; meta?: TrayLeaveLogMeta }>;
+  error(message: string, meta?: TrayLeaveLogMeta): void;
 }
 
 function makeLog(): RecordingLog {


### PR DESCRIPTION
## Summary
- Replace `Record<string, unknown>` on `TrayLeaveLogger.error` meta with a named `TrayLeaveLogMeta` covering the fields this executor actually logs (`requestId`, `error`, `workerBaseUrl`, `kind`).
- Ratchet `record-string-unknown-baseline.json` to drop `packages/webapp/src/ui/tray-leave-runtime.ts`.
- Align the focused unit test's recording logger with the named meta type.

## Debt lists cleared
- `record-string-unknown`

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/ui/tray-leave-runtime.test.ts` (14 passed)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK