### PR TITLE
refactor: pay down boy-scout debt in packages/webcomponents/src/composer/speech.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -45,6 +45,5 @@
   "packages/webapp/src/ui/main.ts": 1,
   "packages/webapp/src/ui/sprinkle-bridge.ts": 2,
   "packages/webapp/src/ui/sprinkle-renderer.ts": 3,
-  "packages/webcomponents/src/composer/speech.ts": 1,
   "packages/webcomponents/src/overlay/slicc-permissions.stories.ts": 5
 }

--- a/packages/webcomponents/src/composer/speech.ts
+++ b/packages/webcomponents/src/composer/speech.ts
@@ -122,15 +122,20 @@ interface BuiltinRecognition {
 
 type RecognitionCtor = new () => BuiltinRecognition;
 
+/**
+ * Chrome/WebKit expose the constructor on `window` under either name; neither
+ * is in every TS DOM lib set, so this is the named slice we read.
+ */
+interface WindowWithSpeechRecognition {
+  SpeechRecognition?: RecognitionCtor;
+  webkitSpeechRecognition?: RecognitionCtor;
+}
+
 /** Resolve the browser's SpeechRecognition constructor (Chrome: webkit-prefixed). */
 function recognitionCtor(): RecognitionCtor | null {
   if (typeof window === 'undefined') return null;
-  const w = window as unknown as Record<string, unknown>;
-  return (
-    (w.SpeechRecognition as RecognitionCtor) ??
-    (w.webkitSpeechRecognition as RecognitionCtor) ??
-    null
-  );
+  const w = window as unknown as WindowWithSpeechRecognition;
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
 }
 
 /** How long `stop()` waits for the recognizer's `end` event before giving up


### PR DESCRIPTION
## Summary
- Replace the `Record<string, unknown>` cast in `recognitionCtor()` with a named `WindowWithSpeechRecognition` interface for Chrome/WebKit `SpeechRecognition` constructors.
- Ratchet `record-string-unknown-baseline.json` to drop this file (debt list cleared: `record-string-unknown`).

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npm run test -w @slicc/webcomponents -- tests/composer/speech.test.ts` (14 passed)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK