### PR TITLE
refactor: pay down boy-scout debt in packages/chrome-extension/capture-popup.js

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -313,7 +313,6 @@
     },
     {
       "includes": [
-        "packages/chrome-extension/capture-popup.js",
         "packages/chrome-extension/src/secrets-entry.ts",
         "packages/webapp/cloud/app.js",
         "packages/webapp/providers/adobe.ts",

--- a/packages/chrome-extension/capture-popup.js
+++ b/packages/chrome-extension/capture-popup.js
@@ -65,6 +65,12 @@ function fail(error) {
   setTimeout(() => window.close(), 1200);
 }
 
+/** Outer rejection handler for fire-and-forget capture runners. */
+function reportUnhandledCaptureError(err) {
+  if (settled) return;
+  fail(describeMediaError(err));
+}
+
 function succeed(bytes, mimeType, width, height, durationMs) {
   settled = true;
   const msg = {
@@ -114,7 +120,7 @@ if (!request) {
 } else if (request.kind === 'screen') {
   setupScreenButton();
 } else {
-  runCameraCapture();
+  runCameraCapture().catch(reportUnhandledCaptureError);
 }
 
 // ---------- screen capture ----------
@@ -126,7 +132,7 @@ function setupScreenButton() {
   action.textContent = 'Capture screen';
   action.addEventListener('click', () => {
     action.disabled = true;
-    runScreenCapture();
+    runScreenCapture().catch(reportUnhandledCaptureError);
   });
 }
 


### PR DESCRIPTION
## Summary
- Handle fire-and-forget `runCameraCapture()` / `runScreenCapture()` with an explicit `.catch(reportUnhandledCaptureError)` so unexpected rejections still call `fail()` when the popup has not already settled.
- Remove `packages/chrome-extension/capture-popup.js` from the biome `nursery.noFloatingPromises: "off"` debt-list override.

## Debt cleared
- `floating-promise` (`biome.json` `overrides` → `nursery.noFloatingPromises = off`)

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK
- [x] Pre-push gate (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode)