### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/playwright/state.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -4,7 +4,6 @@
   "packages/webapp/src/shell/bsh-watchdog.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/hid-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/interaction.ts": 1,
-  "packages/webapp/src/shell/supplemental-commands/playwright/state.ts": 4,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/rsync-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/secret-backends.ts": 2,

--- a/packages/webapp/src/shell/supplemental-commands/playwright/state.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/state.ts
@@ -40,10 +40,12 @@ interface PlaywrightBrowserAPI {
 
 /**
  * Canonical string values live in `scoops/tray-runtime-config.ts`; inlined here
- * so shell does not import up into scoops.
+ * so shell does not import up into scoops. Exported so a test can assert they
+ * stay byte-identical to the canonical source (see `state.test.ts`) without
+ * reintroducing the runtime back-edge.
  */
-const TRAY_WORKER_STORAGE_KEY = 'slicc.trayWorkerBaseUrl';
-const TRAY_JOIN_STORAGE_KEY = 'slicc.trayJoinUrl';
+export const TRAY_WORKER_STORAGE_KEY = 'slicc.trayWorkerBaseUrl';
+export const TRAY_JOIN_STORAGE_KEY = 'slicc.trayJoinUrl';
 
 const sharedStateByBrowser = new WeakMap<object, WeakMap<VirtualFS, PlaywrightState>>();
 const log = createLogger('playwright');

--- a/packages/webapp/src/shell/supplemental-commands/playwright/state.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/state.ts
@@ -4,23 +4,51 @@
  */
 
 import { base64ToUint8 } from '@slicc/shared-ts';
-import type { BrowserAPI } from '../../../cdp/index.js';
-import type { FrameInfo, PageInfo } from '../../../cdp/types.js';
-import { createLogger } from '../../../core/logger.js';
+import { createLogger } from '../../../base/logger.js';
 import { FsError, type VirtualFS } from '../../../fs/index.js';
 import { getPanelRpcClient } from '../../../kernel/panel-rpc.js';
-import {
-  TRAY_JOIN_STORAGE_KEY,
-  TRAY_WORKER_STORAGE_KEY,
-} from '../../../scoops/tray-runtime-config.js';
 import type { PlaywrightState } from './types.js';
 
 export const PLAYWRIGHT_COMMAND_NAMES = ['playwright-cli', 'playwright', 'puppeteer'] as const;
 
-const sharedStateByBrowser = new WeakMap<BrowserAPI, WeakMap<VirtualFS, PlaywrightState>>();
+/**
+ * Duck types for the CDP surface this module needs — avoids shell → cdp
+ * layer back-edges (`docs/review-patterns.md` § Layer-stack import direction).
+ * Callers pass the real `BrowserAPI`; only the methods/fields below are used.
+ */
+interface PlaywrightPageInfo {
+  targetId: string;
+  title: string;
+  url: string;
+}
+
+interface PlaywrightFrameInfo {
+  frameId: string;
+  parentFrameId?: string;
+  url: string;
+  name: string;
+  securityOrigin?: string;
+}
+
+interface PlaywrightBrowserAPI {
+  evaluate(expression: string): Promise<unknown>;
+  getFrameTree(): Promise<PlaywrightFrameInfo[]>;
+  listPages(): Promise<PlaywrightPageInfo[]>;
+  listAllTargets?: () => Promise<PlaywrightPageInfo[]>;
+  withTab<T>(targetId: string, fn: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * Canonical string values live in `scoops/tray-runtime-config.ts`; inlined here
+ * so shell does not import up into scoops.
+ */
+const TRAY_WORKER_STORAGE_KEY = 'slicc.trayWorkerBaseUrl';
+const TRAY_JOIN_STORAGE_KEY = 'slicc.trayJoinUrl';
+
+const sharedStateByBrowser = new WeakMap<object, WeakMap<VirtualFS, PlaywrightState>>();
 const log = createLogger('playwright');
 
-export function getSharedState(browser: BrowserAPI, fs: VirtualFS): PlaywrightState {
+export function getSharedState(browser: PlaywrightBrowserAPI, fs: VirtualFS): PlaywrightState {
   let statesByFs = sharedStateByBrowser.get(browser);
   if (!statesByFs) {
     statesByFs = new WeakMap();
@@ -165,7 +193,7 @@ export const CLEAR_FOCUSABLE_ELEMENT_FUNCTION = `function() {
 }`;
 
 export async function getCurrentPageLocation(
-  browser: BrowserAPI
+  browser: PlaywrightBrowserAPI
 ): Promise<{ href: string; hostname: string; pathname: string }> {
   const raw = await browser.evaluate(
     `JSON.stringify({ href: location.href, hostname: location.hostname, pathname: location.pathname })`
@@ -273,9 +301,9 @@ export function requireTab(
 
 /** Resolve and validate an optional --frame ID against the currently attached tab. */
 export async function resolveFrame(
-  browser: BrowserAPI,
+  browser: PlaywrightBrowserAPI,
   flags: Record<string, string>
-): Promise<FrameInfo | null> {
+): Promise<PlaywrightFrameInfo | null> {
   const frameId = flags['frame'];
   if (!frameId) return null;
 
@@ -300,7 +328,9 @@ function isTrayConfigured(): boolean {
 }
 
 /** List local targets plus any remote tray/follower targets visible through panel RPC. */
-export async function listAllTargetsWithRemote(browser: BrowserAPI): Promise<PageInfo[]> {
+export async function listAllTargetsWithRemote(
+  browser: PlaywrightBrowserAPI
+): Promise<PlaywrightPageInfo[]> {
   if (typeof browser.listAllTargets !== 'function') return browser.listPages();
 
   const pages = await browser.listAllTargets();
@@ -321,7 +351,9 @@ export async function listAllTargetsWithRemote(browser: BrowserAPI): Promise<Pag
   return pages;
 }
 
-async function listTargetsForFrameSearch(browser: BrowserAPI): Promise<PageInfo[]> {
+async function listTargetsForFrameSearch(
+  browser: PlaywrightBrowserAPI
+): Promise<PlaywrightPageInfo[]> {
   try {
     return await listAllTargetsWithRemote(browser);
   } catch {
@@ -331,7 +363,7 @@ async function listTargetsForFrameSearch(browser: BrowserAPI): Promise<PageInfo[
 
 /** Explain a failed --tab attachment when the supplied target ID is actually a frame ID. */
 export async function frameIdUsedAsTabError(
-  browser: BrowserAPI,
+  browser: PlaywrightBrowserAPI,
   targetId: string,
   attachmentError: unknown
 ): Promise<string | null> {

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/state.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/state.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FsError } from '../../../../src/fs/index.js';
+import {
+  filenameSafeTimestamp,
+  frameIdUsedAsTabError,
+  getCurrentPageLocation,
+  getSharedState,
+  isAlreadyExistsError,
+  listAllTargetsWithRemote,
+  parseFlags,
+  parseRef,
+  requireTab,
+  resolveFrame,
+} from '../../../../src/shell/supplemental-commands/playwright/state.js';
+
+describe('playwright state helpers', () => {
+  it('parses main-frame and iframe refs', () => {
+    expect(parseRef('e5')).toEqual({ framePrefix: '', isIframe: false });
+    expect(parseRef('f1e5')).toEqual({ framePrefix: 'f1', isIframe: true });
+    expect(parseRef('not-a-ref')).toEqual({ framePrefix: '', isIframe: false });
+  });
+
+  it('formats ISO timestamps for filenames', () => {
+    expect(filenameSafeTimestamp(new Date('2026-08-29T12:34:56.789Z'))).toBe(
+      '2026-08-29T12-34-56.789Z'
+    );
+  });
+
+  it('detects EEXIST from FsError, code bags, and message text', () => {
+    expect(isAlreadyExistsError(new FsError('EEXIST', 'exists'))).toBe(true);
+    expect(isAlreadyExistsError({ code: 'EEXIST' })).toBe(true);
+    expect(isAlreadyExistsError(new Error('EEXIST: file exists'))).toBe(true);
+    expect(isAlreadyExistsError(new Error('ENOENT'))).toBe(false);
+    expect(isAlreadyExistsError('plain')).toBe(false);
+  });
+
+  it('parses flags including the --no-iframes rewrite', () => {
+    expect(parseFlags(['click', 'e5', '--tab=t1', '--no-iframes'])).toEqual({
+      positional: ['click', 'e5'],
+      flags: { tab: 't1', 'no-iframes': 'true' },
+    });
+    expect(parseFlags(['--full-page', '--fg'])).toEqual({
+      positional: [],
+      flags: {
+        'full-page': 'true',
+        fullPage: 'true',
+        fg: 'true',
+        foreground: 'true',
+      },
+    });
+  });
+
+  it('requires --tab', () => {
+    expect(requireTab({})).toEqual({
+      error: "Error: --tab <targetId> is required. Run 'playwright-cli tab-list' to get tab IDs.\n",
+    });
+    expect(requireTab({ tab: 't1' })).toEqual({ targetId: 't1' });
+  });
+
+  it('shares PlaywrightState per browser+fs pair', () => {
+    const browser = {};
+    const fsA = {} as never;
+    const fsB = {} as never;
+    const a1 = getSharedState(browser as never, fsA);
+    const a2 = getSharedState(browser as never, fsA);
+    const b1 = getSharedState(browser as never, fsB);
+    expect(a1).toBe(a2);
+    expect(a1).not.toBe(b1);
+    expect(a1.snapshots).toBeInstanceOf(Map);
+  });
+});
+
+describe('playwright browser helpers', () => {
+  it('reads the current page location from evaluate JSON', async () => {
+    const browser = {
+      evaluate: vi
+        .fn()
+        .mockResolvedValue(
+          JSON.stringify({ href: 'https://ex.test/p', hostname: 'ex.test', pathname: '/p' })
+        ),
+      getFrameTree: vi.fn(),
+      listPages: vi.fn(),
+      withTab: vi.fn(),
+    };
+    await expect(getCurrentPageLocation(browser)).resolves.toEqual({
+      href: 'https://ex.test/p',
+      hostname: 'ex.test',
+      pathname: '/p',
+    });
+  });
+
+  it('resolves --frame against the frame tree or throws', async () => {
+    const frames = [
+      { frameId: 'main', url: 'https://a', name: '' },
+      { frameId: 'child', parentFrameId: 'main', url: 'https://b', name: 'f' },
+    ];
+    const browser = {
+      evaluate: vi.fn(),
+      getFrameTree: vi.fn().mockResolvedValue(frames),
+      listPages: vi.fn(),
+      withTab: vi.fn(),
+    };
+    await expect(resolveFrame(browser, {})).resolves.toBeNull();
+    await expect(resolveFrame(browser, { frame: 'child' })).resolves.toEqual(frames[1]);
+    await expect(resolveFrame(browser, { frame: 'missing', tab: 't1' })).rejects.toThrow(
+      /Unknown frame ID "missing" for tab t1/
+    );
+  });
+
+  it('lists local pages when listAllTargets is absent', async () => {
+    const pages = [{ targetId: 't1', title: 'One', url: 'https://a' }];
+    const browser = {
+      evaluate: vi.fn(),
+      getFrameTree: vi.fn(),
+      listPages: vi.fn().mockResolvedValue(pages),
+      withTab: vi.fn(),
+    };
+    await expect(listAllTargetsWithRemote(browser)).resolves.toEqual(pages);
+    expect(browser.listPages).toHaveBeenCalledOnce();
+  });
+
+  it('returns listAllTargets pages when no tray is configured', async () => {
+    const pages = [{ targetId: 't1', title: 'One', url: 'https://a' }];
+    const browser = {
+      evaluate: vi.fn(),
+      getFrameTree: vi.fn(),
+      listPages: vi.fn(),
+      listAllTargets: vi.fn().mockResolvedValue(pages),
+      withTab: vi.fn(),
+    };
+    await expect(listAllTargetsWithRemote(browser)).resolves.toEqual(pages);
+  });
+
+  it('explains when a frame ID was used as --tab', async () => {
+    const browser = {
+      evaluate: async () => undefined as unknown,
+      getFrameTree: async () => [{ frameId: 'frame-1', url: 'https://a', name: '' }],
+      listPages: async () => [{ targetId: 'tab-1', title: 'T', url: 'https://a' }],
+      withTab: async <T>(_id: string, fn: () => Promise<T>): Promise<T> => fn(),
+    };
+    await expect(
+      frameIdUsedAsTabError(browser, 'frame-1', new Error('No target with given id found'))
+    ).resolves.toContain('is a frame ID, not a tab target ID');
+    await expect(
+      frameIdUsedAsTabError(browser, 'frame-1', new Error('something else'))
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/state.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/state.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { FsError } from '../../../../src/fs/index.js';
 import {
+  TRAY_JOIN_STORAGE_KEY as CANONICAL_TRAY_JOIN_STORAGE_KEY,
+  TRAY_WORKER_STORAGE_KEY as CANONICAL_TRAY_WORKER_STORAGE_KEY,
+} from '../../../../src/scoops/tray-runtime-config.js';
+import {
   filenameSafeTimestamp,
   frameIdUsedAsTabError,
   getCurrentPageLocation,
@@ -11,9 +15,19 @@ import {
   parseRef,
   requireTab,
   resolveFrame,
+  TRAY_JOIN_STORAGE_KEY,
+  TRAY_WORKER_STORAGE_KEY,
 } from '../../../../src/shell/supplemental-commands/playwright/state.js';
 
 describe('playwright state helpers', () => {
+  it('keeps inlined tray storage keys byte-identical to the canonical source', () => {
+    // The keys are inlined in state.ts to avoid a shell → scoops back-edge; this
+    // test imports both copies (allowed in tests) to catch silent drift if the
+    // canonical values in scoops/tray-runtime-config.ts ever change.
+    expect(TRAY_WORKER_STORAGE_KEY).toBe(CANONICAL_TRAY_WORKER_STORAGE_KEY);
+    expect(TRAY_JOIN_STORAGE_KEY).toBe(CANONICAL_TRAY_JOIN_STORAGE_KEY);
+  });
+
   it('parses main-frame and iframe refs', () => {
     expect(parseRef('e5')).toEqual({ framePrefix: '', isIframe: false });
     expect(parseRef('f1e5')).toEqual({ framePrefix: 'f1', isIframe: true });


### PR DESCRIPTION
## Summary
- Cleared the **layer-back-edge** debt on `packages/webapp/src/shell/supplemental-commands/playwright/state.ts` (4 grandfathered shell → cdp/core/scoops imports).
- Replaced CDP type imports with a local `PlaywrightBrowserAPI` duck type, switched logging to `base/logger`, and inlined tray storage key strings so shell no longer imports upward.
- Ratched `layer-back-edge-baseline.json` to drop this file; added focused Vitest coverage for the preserved helpers.

## Test plan
- [x] `npx biome check` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright/state.test.ts`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`
- [ ] CI green on this PR