### PR TITLE
fix(kernel): make the realm os shim agree with TMPDIR and HOME

### DIFF
--- a/docs/node-compat-shims.md
+++ b/docs/node-compat-shims.md
@@ -178,9 +178,16 @@ self-reference.
 
 ### `os`
 
-Static/hardcoded values: `tmpdir()` → `/tmp`, `homedir()` → `/home/user`,
-`platform` → `linux`, `arch` → `x64`, `cpus()`, `hostname()`, `type()`,
-`release()`, `EOL` → `\n`.
+**Per-realm**: `tmpdir()` and `homedir()` answer for the unit that owns the
+realm, read from the same `init.env` that backs `process.env` — so
+`os.tmpdir() === process.env.TMPDIR` and `os.homedir() === process.env.HOME`
+inside one script. A cone gets `/tmp/<folder>`, a scoop `/tmp/<cone>/<folder>`
+and `/scoops/<folder>/home`. A realm booted with no env (a host with no work
+unit behind it) falls back to the float-wide `/tmp` and `/home/user`.
+
+Static: `platform` → `linux`, `arch` → `x64`, `cpus()`, `hostname()`, `type()`,
+`release()`, `EOL` → `\n`. These deliberately mirror `process.platform` /
+`process.arch` so a script reading both sees one consistent machine.
 
 ### `stream`
 

--- a/packages/webapp/src/kernel/realm/helpers/node-os.ts
+++ b/packages/webapp/src/kernel/realm/helpers/node-os.ts
@@ -47,13 +47,19 @@ const STATIC_OS = {
  * rather than re-deriving the unit's identity through a second path.
  *
  * Both fall back to the pre-#2267 constants: a realm booted with no env is a
- * host with no unit behind it, and those were the right answers for it.
+ * host with no unit behind it, and those were the right answers for it. A
+ * non-blank value is otherwise passed through UNCHANGED — see the trim note
+ * below.
  */
 export function createNodeOs(env?: Record<string, string>): NodeOs {
   return {
     ...STATIC_OS,
     tmpdir: () => scratchDir(env),
-    homedir: () => env?.['HOME']?.trim() || DEFAULT_HOME,
+    // Trim only to DETECT blankness — the value itself is returned verbatim,
+    // or `os.homedir() !== process.env.HOME` for any path that legally begins
+    // or ends with a space, which is the one thing this module exists to
+    // guarantee.
+    homedir: () => (env?.['HOME']?.trim() ? env['HOME'] : DEFAULT_HOME),
   };
 }
 

--- a/packages/webapp/src/kernel/realm/helpers/node-os.ts
+++ b/packages/webapp/src/kernel/realm/helpers/node-os.ts
@@ -1,3 +1,5 @@
+import { scratchDir } from '../../../shell/tmpdir-env.js';
+
 export interface NodeOs {
   tmpdir(): string;
   homedir(): string;
@@ -10,9 +12,15 @@ export interface NodeOs {
   release(): string;
 }
 
-export const nodeOs: NodeOs = {
-  tmpdir: () => '/tmp',
-  homedir: () => '/home/user',
+/** Home directory of a shell that pinned no `HOME` — the cone's default. */
+export const DEFAULT_HOME = '/home/user';
+
+/**
+ * The parts of the `os` shim that do not depend on which unit is running.
+ * `process.versions`/`platform`/`arch` in `realm-node-shims.ts` mirror these
+ * on purpose, so a script reading both sees one consistent machine.
+ */
+const STATIC_OS = {
   platform: () => 'linux',
   arch: () => 'x64',
   EOL: '\n',
@@ -20,4 +28,37 @@ export const nodeOs: NodeOs = {
   hostname: () => 'slicc',
   type: () => 'Linux',
   release: () => '0.0.0',
-};
+} as const;
+
+/**
+ * Per-realm `os` module, resolved against the realm's own environment.
+ *
+ * `tmpdir()` and `homedir()` are the two answers that depend on WHO is asking.
+ * A scoop's shell pins `HOME=/scoops/<folder>/home` and every unit pins
+ * `TMPDIR` (#2267), and `process.env` in the same realm reports both — so
+ * returning the float-wide `/tmp` and `/home/user` here made
+ * `os.tmpdir() !== process.env.TMPDIR` inside one script. That is precisely
+ * the "one consistent machine" invariant `createProcessShim` documents for
+ * `platform`/`arch`, and a library that trusts `os.tmpdir()` (most of them do)
+ * silently wrote to a directory its own unit did not own.
+ *
+ * The env is the realm's `init.env`, which `jsh-executor.ts` builds from the
+ * shell's own `ctx.env` — so this reads exactly what `process.env` reads,
+ * rather than re-deriving the unit's identity through a second path.
+ *
+ * Both fall back to the pre-#2267 constants: a realm booted with no env is a
+ * host with no unit behind it, and those were the right answers for it.
+ */
+export function createNodeOs(env?: Record<string, string>): NodeOs {
+  return {
+    ...STATIC_OS,
+    tmpdir: () => scratchDir(env),
+    homedir: () => env?.['HOME']?.trim() || DEFAULT_HOME,
+  };
+}
+
+/**
+ * Envless `os` module. Retained for hosts that serve the built-in without a
+ * realm environment to read; a realm passes its own via {@link createNodeOs}.
+ */
+export const nodeOs: NodeOs = createNodeOs();

--- a/packages/webapp/src/kernel/realm/js-realm-helpers.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-helpers.ts
@@ -25,7 +25,7 @@ export type { NodeCrypto, NodeHash } from './helpers/node-crypto.js';
 export { nodeCrypto } from './helpers/node-crypto.js';
 export { nodeEvents } from './helpers/node-events.js';
 export type { NodeOs } from './helpers/node-os.js';
-export { nodeOs } from './helpers/node-os.js';
+export { createNodeOs, DEFAULT_HOME, nodeOs } from './helpers/node-os.js';
 export type { NodePath, NodePathParsed } from './helpers/node-path.js';
 export { nodePath } from './helpers/node-path.js';
 export { nodeStream } from './helpers/node-stream.js';

--- a/packages/webapp/src/kernel/realm/js-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/js-realm-shared.ts
@@ -22,7 +22,12 @@ import '../../shims/buffer-polyfill.js';
 import { readSliccVersion } from '../../base/slicc-version.js';
 import { createNodeReadline } from './helpers/node-readline.js';
 import { createHttpGlobal } from './http-global.js';
-import { createCli, createColor, createNodeChildProcess } from './js-realm-helpers.js';
+import {
+  createCli,
+  createColor,
+  createNodeChildProcess,
+  createNodeOs,
+} from './js-realm-helpers.js';
 import { createSliccyAgentModule } from './realm-agent-module.js';
 import { createBrowserBridge, serializeRequestInit } from './realm-browser-bridge.js';
 import { createExecBridge } from './realm-exec-bridge.js';
@@ -366,6 +371,9 @@ export async function runJsRealm(init: RealmInitMsg, port: RealmPortLike): Promi
     // Per-realm: question() echoes to THIS realm's stdout; onExit records a
     // process.exit(N) from a deferred 'line' handler (see createProcessShim).
     nodeReadline: createNodeReadline({ output: { write: writeStdout }, onExit: proc.recordExit }),
+    // Per-realm too: `os.tmpdir()`/`os.homedir()` read the SAME `init.env`
+    // that `process.env` exposes, so one script cannot see two machines.
+    nodeOsModule: createNodeOs(init.env),
   });
   const requireShim = moduleSystem.require;
 

--- a/packages/webapp/src/kernel/realm/realm-module-system.ts
+++ b/packages/webapp/src/kernel/realm/realm-module-system.ts
@@ -9,6 +9,7 @@ import type { NodeReadlineModule } from './helpers/node-readline.js';
 import {
   fmt,
   type NodeChildProcess,
+  type NodeOs,
   nodeAssert,
   nodeAssertStrict,
   nodeCrypto,
@@ -155,6 +156,11 @@ export function createModuleSystem(opts: {
   shimmedPackages?: RealmModuleRegistry;
   /** Per-realm `readline` module (question() echoes to THIS realm's stdout). */
   nodeReadline?: NodeReadlineModule;
+  /**
+   * Per-realm `os` module — `tmpdir()`/`homedir()` answer for THIS realm's
+   * unit (#2267). Omitted, the envless default keeps the pre-#2267 constants.
+   */
+  nodeOsModule?: NodeOs;
 }): { require: (id: string) => unknown } {
   const {
     graph,
@@ -165,6 +171,7 @@ export function createModuleSystem(opts: {
     sliccyModules,
     shimmedPackages = {},
     nodeReadline,
+    nodeOsModule = nodeOs,
   } = opts;
   const sourceByPath = new Map(graph.files.map((f) => [f.path, f.cjsSource]));
   const kindByPath = new Map(graph.files.map((f) => [f.path, f.kind]));
@@ -175,7 +182,14 @@ export function createModuleSystem(opts: {
       return { hit: true, value: resolveSliccyModule(id, sliccyModules) };
     }
     const bareId = id.startsWith('node:') ? id.slice(5) : id;
-    const served = resolveServedBuiltin(bareId, fsBridge, processShim, childProcess, nodeReadline);
+    const served = resolveServedBuiltin(
+      bareId,
+      fsBridge,
+      processShim,
+      childProcess,
+      nodeOsModule,
+      nodeReadline
+    );
     if (served.hit) return served;
     if (NODE_NATIVE_PACKAGES.has(bareId)) throw nativePackageError(id, bareId);
     if (NODE_BUILTINS_UNAVAILABLE.has(bareId)) throw unavailableBuiltinError(id, bareId);
@@ -251,6 +265,7 @@ function resolveServedBuiltin(
   fsBridge: unknown,
   processShim: unknown,
   childProcess: NodeChildProcess,
+  nodeOsModule: NodeOs,
   nodeReadline?: NodeReadlineModule
 ): { hit: boolean; value?: unknown } {
   if (bareId === 'fs') return { hit: true, value: fsBridge };
@@ -267,7 +282,7 @@ function resolveServedBuiltin(
   if (bareId === 'assert/strict') return { hit: true, value: nodeAssertStrict };
   if (bareId === 'util') return { hit: true, value: nodeUtil };
   if (bareId === 'events') return { hit: true, value: nodeEvents };
-  if (bareId === 'os') return { hit: true, value: nodeOs };
+  if (bareId === 'os') return { hit: true, value: nodeOsModule };
   if (bareId === 'tty') return { hit: true, value: nodeTty };
   if (bareId === 'stream') return { hit: true, value: nodeStream };
   if (bareId === 'url') return { hit: true, value: nodeUrl };

--- a/packages/webapp/src/shell/tmpdir-env.ts
+++ b/packages/webapp/src/shell/tmpdir-env.ts
@@ -42,7 +42,11 @@ export function scratchDir(env: TmpDirEnv): string {
     env && typeof (env as { get?: unknown }).get === 'function'
       ? (env as { get(name: string): string | undefined }).get(TMPDIR_ENV)
       : (env as Record<string, string | undefined> | undefined)?.[TMPDIR_ENV];
-  // An empty or whitespace-only value is a misconfiguration, not a request to
-  // write to `''` — POSIX `mktemp` treats it the same way.
-  return fromEnv?.trim() || SHARED_TMP_ROOT;
+  // Trim only to DETECT blankness; a non-blank value is returned verbatim.
+  // A directory name may legally begin or end with a space, and trimming one
+  // would both redirect the write and break the `process.env` equality the
+  // realm `os` shim depends on. An empty or whitespace-only value is a
+  // misconfiguration rather than a request to write to `''` — POSIX `mktemp`
+  // treats it the same way.
+  return fromEnv?.trim() ? fromEnv : SHARED_TMP_ROOT;
 }

--- a/packages/webapp/tests/kernel/realm/cjs-realm-harness.ts
+++ b/packages/webapp/tests/kernel/realm/cjs-realm-harness.ts
@@ -130,12 +130,14 @@ export function makeCtx(
     fetch?: CommandContext['fetch'];
     /** Piped stdin as a latin1 string (one JS char per byte), like a shell pipe. */
     stdin?: string;
+    /** Shell env the realm inherits — `process.env` and the `os` shim read it. */
+    env?: Record<string, string>;
   } = {}
 ): CommandContext {
   const ctx: CommandContext = {
     fs: makeTreeFs(opts.files ?? {}),
     cwd: opts.cwd ?? '/workspace',
-    env: new Map<string, string>(),
+    env: new Map<string, string>(Object.entries(opts.env ?? {})),
     stdin: unsafeBytesFromLatin1(opts.stdin ?? ''),
   };
   if (opts.exec) ctx.exec = opts.exec;

--- a/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
+++ b/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
@@ -423,6 +423,26 @@ describe('node:os shim', () => {
     ]);
   });
 
+  it('agrees with process.env even for a path padded with spaces', async () => {
+    // The equality assertion below only exercises clean values, so it would
+    // not have caught a shim that trimmed what it returned while `process.env`
+    // kept the bytes verbatim (Codex P2 on #2610).
+    const ctx = makeCtx({ env: { TMPDIR: ' /tmp/odd name ', HOME: ' /home/odd ' } });
+    const out = await runCode(
+      `const os = require('os');
+       console.log(os.tmpdir() === process.env.TMPDIR);
+       console.log(os.homedir() === process.env.HOME);
+       console.log(JSON.stringify(os.tmpdir()));`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.split('\n').filter(Boolean)).toEqual([
+      'true',
+      'true',
+      JSON.stringify(' /tmp/odd name '),
+    ]);
+  });
+
   it('agrees with process.env in the same realm — one consistent machine', async () => {
     // `createProcessShim` documents that its platform/arch mirror this shim so
     // "a script that reads both sees one consistent machine". tmpdir/homedir

--- a/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
+++ b/packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts
@@ -402,6 +402,45 @@ describe('NS3: tty built-in is served by the browser-worker shim', () => {
 });
 
 describe('node:os shim', () => {
+  it('tmpdir() and homedir() answer for the unit that owns the realm (#2267)', async () => {
+    // A scoop's shell pins HOME=/scoops/<folder>/home and every unit pins
+    // TMPDIR. Returning the float-wide constants here sent any library that
+    // trusts os.tmpdir() — most of them — into a directory its own unit did
+    // not own, and into a collision with every sibling unit.
+    const ctx = makeCtx({
+      env: { TMPDIR: '/tmp/cone-adobe/review', HOME: '/scoops/review/home' },
+    });
+    const out = await runCode(
+      `const os = require('os');
+       console.log(os.tmpdir());
+       console.log(os.homedir());`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.split('\n').filter(Boolean)).toEqual([
+      '/tmp/cone-adobe/review',
+      '/scoops/review/home',
+    ]);
+  });
+
+  it('agrees with process.env in the same realm — one consistent machine', async () => {
+    // `createProcessShim` documents that its platform/arch mirror this shim so
+    // "a script that reads both sees one consistent machine". tmpdir/homedir
+    // were the two answers that silently broke that promise.
+    const ctx = makeCtx({
+      env: { TMPDIR: '/tmp/cone-adobe', HOME: '/scoops/review/home' },
+    });
+    const out = await runCode(
+      `const os = require('os');
+       console.log(os.tmpdir() === process.env.TMPDIR);
+       console.log(os.homedir() === process.env.HOME);
+       console.log(os.platform() === process.platform, os.arch() === process.arch);`,
+      ctx
+    );
+    expect(out.exitCode).toBe(0);
+    expect(out.stdout.split('\n').filter(Boolean)).toEqual(['true', 'true', 'true true']);
+  });
+
   it('serves tmpdir, platform, arch, EOL, homedir, hostname, type, release', async () => {
     const ctx = makeCtx();
     const out = await runCode(

--- a/packages/webapp/tests/kernel/realm/node-os.test.ts
+++ b/packages/webapp/tests/kernel/realm/node-os.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { createNodeOs, DEFAULT_HOME, nodeOs } from '../../../src/kernel/realm/helpers/node-os.js';
+
+describe('createNodeOs', () => {
+  it('answers from the realm env for the two unit-dependent values', () => {
+    const os = createNodeOs({ TMPDIR: '/tmp/cone-adobe', HOME: '/scoops/review/home' });
+    expect(os.tmpdir()).toBe('/tmp/cone-adobe');
+    expect(os.homedir()).toBe('/scoops/review/home');
+  });
+
+  it('keeps the pre-#2267 constants when the realm has no env', () => {
+    // A realm booted without an env is a host with no unit behind it, and the
+    // float-wide answers were correct for that case.
+    for (const os of [createNodeOs(), createNodeOs({}), nodeOs]) {
+      expect(os.tmpdir()).toBe('/tmp');
+      expect(os.homedir()).toBe(DEFAULT_HOME);
+    }
+  });
+
+  it('treats an empty or whitespace value as unset, never as a relative path', () => {
+    // `path.join(os.tmpdir(), 'x')` on `''` yields a cwd-relative path, which
+    // is how a library ends up writing into the user's workspace.
+    const os = createNodeOs({ TMPDIR: '  ', HOME: '' });
+    expect(os.tmpdir()).toBe('/tmp');
+    expect(os.homedir()).toBe(DEFAULT_HOME);
+  });
+
+  it('reports the same machine identity as the process shim', () => {
+    // `createProcessShim` hardcodes linux/x64 and says it mirrors this module.
+    const os = createNodeOs({ TMPDIR: '/tmp/cone' });
+    expect([os.platform(), os.arch(), os.type(), os.hostname()]).toEqual([
+      'linux',
+      'x64',
+      'Linux',
+      'slicc',
+    ]);
+    expect(os.cpus().length).toBeGreaterThan(0);
+  });
+});

--- a/packages/webapp/tests/kernel/realm/node-os.test.ts
+++ b/packages/webapp/tests/kernel/realm/node-os.test.ts
@@ -17,6 +17,15 @@ describe('createNodeOs', () => {
     }
   });
 
+  it('returns a padded path verbatim — trimming would break process.env equality', () => {
+    // A directory name may legally begin or end with a space. Trimming the
+    // RETURNED value (rather than only testing it for blankness) both
+    // redirects the write and breaks the one guarantee this module makes.
+    const os = createNodeOs({ TMPDIR: ' /tmp/odd name ', HOME: ' /home/odd ' });
+    expect(os.tmpdir()).toBe(' /tmp/odd name ');
+    expect(os.homedir()).toBe(' /home/odd ');
+  });
+
   it('treats an empty or whitespace value as unset, never as a relative path', () => {
     // `path.join(os.tmpdir(), 'x')` on `''` yields a cwd-relative path, which
     // is how a library ends up writing into the user's workspace.

--- a/packages/webapp/tests/shell/tmpdir-env.test.ts
+++ b/packages/webapp/tests/shell/tmpdir-env.test.ts
@@ -23,6 +23,13 @@ describe('scratchDir', () => {
     expect(scratchDir(undefined)).toBe(SHARED_TMP_ROOT);
   });
 
+  it('returns a non-blank value verbatim, spaces and all', () => {
+    // Trimming the returned value would silently redirect the write and, via
+    // the realm `os` shim, break `os.tmpdir() === process.env.TMPDIR`.
+    expect(scratchDir(new Map([[TMPDIR_ENV, ' /tmp/odd name ']]))).toBe(' /tmp/odd name ');
+    expect(scratchDir({ [TMPDIR_ENV]: '/tmp/trailing/' })).toBe('/tmp/trailing/');
+  });
+
   it('treats an empty or whitespace value as unset, never as a relative path', () => {
     // `${''}/screenshot.png` would write to `/screenshot.png` at the VFS root.
     for (const bad of ['', '   ', '\t']) {


### PR DESCRIPTION
Refs #2267, #2568. Follow-up to #2596 — closes the gap that PR flagged as out of scope.

## Summary

`os.tmpdir()` and `os.homedir()` in a JS realm now answer for the unit that spawned it. Before: every realm got the float-wide `/tmp` and `/home/user`, no matter who was asking — while `process.env` in the *same realm* reported that unit's real `TMPDIR` and `HOME`. Now the two read the same object, so they cannot disagree.

## Why

`createProcessShim` already documents the contract this broke:

> The values mirror the `os` shim (`helpers/node-os.ts`: linux/x64) so a script that reads both sees one consistent machine.

`platform` and `arch` held that promise. `tmpdir()` and `homedir()` are the two answers that depend on *who* is asking, and they were hardcoded constants — so inside one script, `os.tmpdir() !== process.env.TMPDIR`.

The practical cost is asymmetric:

- **`tmpdir()`** — a library that trusts `os.tmpdir()` (most of them do) wrote into the shared root instead of the caller's own directory. Nothing fails; the file just lands where no cone's "New chat" disposes of it and every sibling unit collides on the same default name. That is exactly the failure mode #2574 and #2596 removed from the shell, leaking back in through the realm.
- **`homedir()`** — worse, because it *does* fail. It pointed a scoop at `/home/user`, which its `RestrictedFS` cannot even see (`buildScoopShellEnv` pins `HOME=/scoops/<folder>/home` precisely because of this). A library resolving a config path under `os.homedir()` got an EACCES rather than a wrong-but-writable location.

**Repro:**

```
$ echo 'const os=require("os");
        console.log(os.tmpdir(), process.env.TMPDIR)' > /tmp/t.js && node /tmp/t.js
/tmp  /tmp/cone-adobe        # before — two different machines
/tmp/cone-adobe  /tmp/cone-adobe   # after
```

## Approach / Implementation notes

`createNodeOs(env)` reads the realm's `init.env` — **the same object that backs `process.env`** (`createProcessShim` does `env: init.env`), which `jsh-executor.ts` builds from the shell's own `ctx.env`. Deriving both from one source means they cannot drift again by construction, rather than by two call sites agreeing to stay in step.

Served per-realm through `createModuleSystem`, mirroring `readline`, which is already per-realm for the same class of reason ("question() echoes to THIS realm's stdout"). The envless `nodeOs` export is retained for hosts that serve the builtin without a realm environment, and keeps the pre-#2267 constants.

`tmpdir()` routes through `scratchDir()` from #2596 so there is still exactly one place `$TMPDIR` becomes a path. `kernel/` is explicitly unranked in `check-layer-back-edges.mjs`, so `kernel → shell` is not a back edge; the gate confirms it.

Empty or whitespace falls back to the constants rather than through. `path.join('', 'x')` yields a cwd-relative path, which is how a library ends up writing into the user's workspace instead of failing loudly.

## Cross-cutting impact

- **Floats exercised**: all of them — the realm module system is shared by the worker, iframe and in-process realm factories. The tests drive `createInProcessJsRealmFactory`, which is the same `runJsRealm` engine the production floats use, so parity is by construction rather than by mocking.
- **Other callers**: `resolveServedBuiltin` has one caller; `createModuleSystem` has one; the `nodeOs` export is re-exported from `js-realm-helpers.ts` and unchanged for anyone importing it.
- **Behaviour change**: a realm script that hardcoded an expectation of `/tmp` or `/home/user` from `os` will now see the unit's paths. That is the point, and it aligns `os` with what `process.env` already told it.
- **Bundle**: `First-load OK (allowance 5 kB per change; total 4949 kB across both graphs)`. The new import is a dependency-free ~40-line module.

## Test plan

- [x] `npm run verify` — all 7 checks
- [x] `npm run typecheck`
- [x] `npm run build` / `npm run build -w @slicc/chrome-extension`
- [x] `check-touched-exemptions` (8 files, 0 on any debt list), `check-doc-sizes`, `check-doc-refs`, `check-first-load-size`
- [x] **New / changed behavior is covered by a unit test**:
      `npx vitest run packages/webapp/tests/kernel/realm/node-os.test.ts packages/webapp/tests/kernel/realm/cjs-require-bare-builtins.test.ts`
- [x] Guards verified by reverting: put the hardcoded constants back and confirmed the two end-to-end realm tests go red; restored.
- [x] Whole realm suite in isolation: **904 passing / 57 files**.

New coverage:

- `cjs-require-bare-builtins.test.ts` — **end-to-end through the real realm engine**: `tmpdir()`/`homedir()` reflect the shell env, and a second test asserts `os.tmpdir() === process.env.TMPDIR` / `os.homedir() === process.env.HOME` / platform+arch agreement in one script. That second one is the "consistent machine" invariant itself, so the next divergence fails rather than drifts.
- `node-os.test.ts` — unit edges: env-backed values, envless fallback to the pre-#2267 constants, empty/whitespace treated as unset, and static identity matching the process shim.

**Environment note.** This machine runs the live SLICC stack, so full runs are noisy: across three runs I saw 10, then 0, then 4 failures on identical code, almost all `shell/ipk/*` e2e timing out at the 5 s default. One run included `kernel/realm/slicc-fs-module.test.ts`, which is realm code and therefore the one candidate for being mine — it did **not** recur, the realm suite is 904/904 in isolation, and that test covers Pyodide byte marshalling with no path to `os` module resolution. Flagging it rather than burying it; CI on a clean box is the arbiter.

No UI change, so no screencast.

## Documentation

- [x] `docs/node-compat-shims.md` — the `os` section said "Static/hardcoded values: `tmpdir()` → `/tmp`, `homedir()` → `/home/user`". Rewritten to describe the per-realm resolution, the `process.env` agreement, and the envless fallback.

## Risk & rollback

- **Blast radius**: the `os` builtin in every JS realm. A wrong value yields a different writable path, not a permission wall — except for `homedir()`, where the change moves *from* an unwritable path *to* a writable one.
- **Flags / kill switches**: none. The fallback path is the old behaviour, and an envless realm still gets it.
- **Rollback**: revert cleanly. No persisted state, no migration.
- **CI cannot catch**: third-party packages that cache `os.tmpdir()` at module scope across realms. Each realm builds its own `os` module, so there is no shared instance to poison — but a package that stashes the value in a module-level const inside a *shimmed* package would keep the first realm's answer.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] Public API / shell-command changes are intentional and reflected in docs
- [x] Contract used by other floats: the realm module system is shared; tests drive the real engine
