### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/transcript/normalize.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -36,7 +36,6 @@
   "packages/webapp/src/shell/supplemental-commands/websocat-command.ts": 1,
   "packages/webapp/src/skills/catalog.ts": 3,
   "packages/webapp/src/speech/hear.ts": 1,
-  "packages/webapp/src/transcript/normalize.ts": 2,
   "packages/webapp/src/ui/boot/setup-welcome-flow.ts": 13,
   "packages/webapp/src/ui/dip.ts": 4,
   "packages/webapp/src/ui/sprinkle-bridge.ts": 2,

--- a/packages/webapp/src/transcript/normalize.ts
+++ b/packages/webapp/src/transcript/normalize.ts
@@ -54,6 +54,22 @@ type UserContentRaw =
   | string
   | Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
 
+/**
+ * Pi assistant content fields we read while normalizing. Tool-call `arguments`
+ * are forwarded as TranscriptContentBlock tool-call `input` (`unknown`); the
+ * per-tool shape is declared by each tool's JSON Schema, not nameable here.
+ */
+interface AssistantContentBlockRaw {
+  type: string;
+  text?: string;
+  thinking?: string;
+  id?: string;
+  name?: string;
+  arguments?: unknown;
+  data?: string;
+  mimeType?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Internal result shape for per-message normalizers
 // ---------------------------------------------------------------------------
@@ -121,16 +137,7 @@ function normalizeUserContent(
  * and canonical image data keyed by attachmentId.
  */
 function normalizeAssistantContent(
-  content: Array<{
-    type: string;
-    text?: string;
-    thinking?: string;
-    id?: string;
-    name?: string;
-    arguments?: Record<string, unknown>;
-    data?: string;
-    mimeType?: string;
-  }>,
+  content: AssistantContentBlockRaw[],
   msgId: string
 ): {
   blocks: TranscriptContentBlock[];
@@ -217,16 +224,7 @@ function normalizeAssistant(
 ): MessageNormalizeResult {
   const id = messageId(conversationId, sequence);
   const { blocks, excluded, images } = normalizeAssistantContent(
-    message.content as Array<{
-      type: string;
-      text?: string;
-      thinking?: string;
-      id?: string;
-      name?: string;
-      arguments?: Record<string, unknown>;
-      data?: string;
-      mimeType?: string;
-    }>,
+    message.content as AssistantContentBlockRaw[],
     id
   );
   const normalized: TranscriptMessage = {


### PR DESCRIPTION
## Summary
- Replace the two `Record<string, unknown>` tool-call `arguments` bags in `packages/webapp/src/transcript/normalize.ts` with `arguments?: unknown` on a named `AssistantContentBlockRaw` type (matches `TranscriptContentBlock` tool-call `input: unknown`).
- Ratchet `record-string-unknown-baseline.json` to drop this file (2 occurrences).

## Debt cleared
- `record-string-unknown` (`packages/dev-tools/tools/record-string-unknown-baseline.json`)

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/transcript/normalize.test.ts` (31 passed)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK
- [ ] CI green on PR