### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/playwright/snapshot.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -5,7 +5,6 @@
   "packages/webapp/src/shell/supplemental-commands/hid-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/host-command.ts": 7,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/interaction.ts": 1,
-  "packages/webapp/src/shell/supplemental-commands/playwright/snapshot.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/playwright/state.ts": 4,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/rsync-command.ts": 1,

--- a/packages/webapp/src/base/normalize-accessibility-text.ts
+++ b/packages/webapp/src/base/normalize-accessibility-text.ts
@@ -1,0 +1,17 @@
+/**
+ * Normalizes accessibility tree values into stable snapshot-friendly strings.
+ * Lives in `base/` so both `cdp/` and `shell/` can use it without a layer back-edge.
+ */
+export function normalizeAccessibilityText(value: unknown, fallback = ''): string {
+  if (value == null) return fallback;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  try {
+    const json = JSON.stringify(value);
+    return json ?? fallback;
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/webapp/src/cdp/normalize-accessibility-text.ts
+++ b/packages/webapp/src/cdp/normalize-accessibility-text.ts
@@ -1,16 +1,5 @@
 /**
- * Normalizes accessibility tree values into stable snapshot-friendly strings.
+ * Re-export from `base/` — kept so existing `cdp/` import sites stay stable.
+ * New callers outside `cdp/` should import from `base/normalize-accessibility-text.js`.
  */
-export function normalizeAccessibilityText(value: unknown, fallback = ''): string {
-  if (value == null) return fallback;
-  if (typeof value === 'string') return value;
-  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
-    return String(value);
-  }
-  try {
-    const json = JSON.stringify(value);
-    return json ?? fallback;
-  } catch {
-    return String(value);
-  }
-}
+export { normalizeAccessibilityText } from '../base/normalize-accessibility-text.js';

--- a/packages/webapp/src/shell/supplemental-commands/playwright/snapshot.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/snapshot.ts
@@ -3,12 +3,17 @@
  * playwright-cli command family.
  */
 
-import type { BrowserAPI, PageInfo } from '../../../cdp/index.js';
-import { normalizeAccessibilityText } from '../../../cdp/normalize-accessibility-text.js';
-import type { AccessibilityNode } from '../../../cdp/types.js';
+import { normalizeAccessibilityText } from '../../../base/normalize-accessibility-text.js';
 import { getPanelRpcClient } from '../../../kernel/panel-rpc.js';
 import { listAllTargetsWithRemote } from './state.js';
-import type { PlaywrightState, TabSnapshot } from './types.js';
+import type { PlaywrightHandlerCtx, PlaywrightState, TabSnapshot } from './types.js';
+
+// BrowserAPI / PageInfo / AccessibilityNode are named via PlaywrightHandlerCtx
+// (same shell layer) rather than imported from `cdp/`, so this module stays
+// inside the shell layer (see layer-stack import direction).
+type BrowserAPI = PlaywrightHandlerCtx['browser'];
+type PageInfo = Awaited<ReturnType<BrowserAPI['listPages']>>[number];
+type AccessibilityNode = Awaited<ReturnType<BrowserAPI['getAccessibilityTree']>>;
 
 export function escapeYaml(str: string): string {
   return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');

--- a/packages/webapp/tests/cdp/normalize-accessibility-text.test.ts
+++ b/packages/webapp/tests/cdp/normalize-accessibility-text.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeAccessibilityText } from '../../src/cdp/normalize-accessibility-text.js';
+import { normalizeAccessibilityText } from '../../src/base/normalize-accessibility-text.js';
 
 describe('normalizeAccessibilityText', () => {
   it('returns fallback for nullish values', () => {

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/snapshot.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/snapshot.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  escapeCssAttr,
+  escapeYaml,
+  renderNode,
+} from '../../../../src/shell/supplemental-commands/playwright/snapshot.js';
+
+describe('playwright snapshot pure helpers', () => {
+  it('escapes YAML special characters', () => {
+    expect(escapeYaml('a"b\\c\nd')).toBe('a\\"b\\\\c\\nd');
+  });
+
+  it('escapes CSS attribute values', () => {
+    expect(escapeCssAttr('say "hi"\\')).toBe('say \\"hi\\"\\\\');
+  });
+
+  it('assigns refs and selectors for actionable nodes', () => {
+    const refToSelector = new Map<string, string>();
+    const refToBackendNodeId = new Map<string, number>();
+    const lines = renderNode(
+      {
+        role: 'button',
+        name: 'Save',
+        backendNodeId: 42,
+        children: [{ role: 'presentation', name: '', children: [] }],
+      },
+      refToSelector,
+      refToBackendNodeId,
+      { value: 0 }
+    );
+
+    expect(lines).toEqual(['- button "Save" [ref=e1]', '  - presentation']);
+    expect(refToSelector.get('e1')).toContain('button[aria-label="Save"]');
+    expect(refToBackendNodeId.get('e1')).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary
- Clear the `layer-back-edge` debt on `packages/webapp/src/shell/supplemental-commands/playwright/snapshot.ts` (3 grandfathered shell→cdp imports).
- Move pure `normalizeAccessibilityText` into `base/` (cdp keeps a re-export); derive `BrowserAPI` / page / a11y types from shell-layer `PlaywrightHandlerCtx` instead of importing `cdp/`.
- Ratchet `layer-back-edge-baseline.json` via `--update`; add focused pure-helper tests.

## Debt lists cleared
- `layer-back-edge` (`packages/dev-tools/tools/layer-back-edge-baseline.json`)

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run` focused snapshot + normalize-accessibility-text tests
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`