### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/tests/cdp/cdp-client.test.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -323,7 +323,6 @@
         "packages/webapp/src/providers/built-in/bedrock-camp.ts",
         "packages/webapp/src/providers/intercepted-oauth.ts",
         "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts",
-        "packages/webapp/tests/cdp/cdp-client.test.ts",
         "packages/webapp/tests/kernel/realm/realm-runner.test.ts",
         "packages/webapp/tests/shell/di/di.test.ts",
         "packages/webapp/tests/ui/provider-settings.test.ts"

--- a/packages/webapp/tests/cdp/cdp-client.test.ts
+++ b/packages/webapp/tests/cdp/cdp-client.test.ts
@@ -214,9 +214,9 @@ describe('CDPClient', () => {
     });
 
     it('increments message IDs', async () => {
-      client.send('Method1');
-      client.send('Method2');
-      client.send('Method3');
+      const p1 = client.send('Method1');
+      const p2 = client.send('Method2');
+      const p3 = client.send('Method3');
 
       expect(ws.sent).toHaveLength(3);
       expect(JSON.parse(ws.sent[0]).id).toBe(1);
@@ -227,6 +227,7 @@ describe('CDPClient', () => {
       ws.simulateMessage({ id: 1, result: {} });
       ws.simulateMessage({ id: 2, result: {} });
       ws.simulateMessage({ id: 3, result: {} });
+      await Promise.all([p1, p2, p3]);
     });
   });
 


### PR DESCRIPTION
## Summary
- Await the three parallel `client.send()` promises in the message-ID test so they are no longer floating.
- Remove `packages/webapp/tests/cdp/cdp-client.test.ts` from the `nursery.noFloatingPromises: "off"` debt list in `biome.json`.

## Debt cleared
- `floating-promise` (biome.json override → `nursery.noFloatingPromises = off`)

## Test plan
- [x] `npx biome lint --only=nursery/noFloatingPromises packages/webapp/tests/cdp/cdp-client.test.ts`
- [x] `npx vitest run packages/webapp/tests/cdp/cdp-client.test.ts` (26 passed)
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`