### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/usb-command.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -11,6 +11,5 @@
   "packages/webapp/src/shell/supplemental-commands/rsync-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/secret-backends.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/serial-command.ts": 1,
-  "packages/webapp/src/shell/supplemental-commands/serve-command.ts": 3,
-  "packages/webapp/src/shell/supplemental-commands/usb-command.ts": 1
+  "packages/webapp/src/shell/supplemental-commands/serve-command.ts": 3
 }

--- a/packages/webapp/src/shell/supplemental-commands/usb-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/usb-command.ts
@@ -14,6 +14,7 @@
 
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
+import { getToolExecutionContext } from '../../base/tool-execution-context.js';
 import { getPanelRpcClient, hasLocalDom } from '../../kernel/panel-rpc.js';
 import {
   deviceToInfo,
@@ -24,7 +25,6 @@ import {
   type UsbDeviceFilter,
   type UsbDeviceInfo,
 } from '../../kernel/usb-device-registry.js';
-import { getToolExecutionContext } from '../../tools/tool-ui.js';
 import { parseFlagArgs } from '../arg-parser.js';
 import { stdinAsLatin1 } from '../just-bash-compat.js';
 import { runDevicePickerApproval } from './picker-approval.js';


### PR DESCRIPTION
## Summary
- Clear the grandfathered `layer-back-edge` for `usb-command.ts` by importing `getToolExecutionContext` from `base/tool-execution-context.js` (its canonical home) instead of `tools/tool-ui.js` (a shell→tools up-stack import).
- Ratchet `layer-back-edge-baseline.json` with `check-layer-back-edges.mjs --update`.

Behaviour is unchanged: both modules re-export the same stack reader.

## Debt cleared
- `layer-back-edge` (`packages/dev-tools/tools/layer-back-edge-baseline.json`)

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/usb-command.test.ts` (21 passed)
- [x] `npm run typecheck`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK