### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/tsc-command.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -28,7 +28,6 @@
   "packages/webapp/src/shell/bsh-watchdog.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 5,
   "packages/webapp/src/shell/supplemental-commands/secret-backends.ts": 3,
-  "packages/webapp/src/shell/supplemental-commands/tsc-command.ts": 4,
   "packages/webapp/src/shell/supplemental-commands/websocat-command.ts": 1,
   "packages/webapp/src/skills/catalog.ts": 3,
   "packages/webapp/src/speech/hear.ts": 1,

--- a/packages/webapp/src/shell/supplemental-commands/tsc-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/tsc-command.ts
@@ -168,40 +168,59 @@ export async function findTsconfigPath(
   return null;
 }
 
+/** Named shape for the `compilerOptions` bag this command passes to `transpileModule`. */
+type TscCompilerOptions = import('typescript-js').CompilerOptions;
+
 interface ResolvedTscConfig {
-  compilerOptions: Record<string, unknown>;
+  compilerOptions: TscCompilerOptions;
 }
 
-const DEFAULT_COMPILER_OPTIONS: Record<string, unknown> = {
-  target: 'ES2022',
-  module: 'ESNext',
-  moduleResolution: 'Bundler',
-  esModuleInterop: true,
-  allowSyntheticDefaultImports: true,
-  isolatedModules: true,
-};
+/**
+ * Parsed `tsconfig.json` body from `parseConfigFileTextToJson`. Only
+ * `compilerOptions` is read; other top-level keys are ignored.
+ */
+interface ParsedTsconfigJson {
+  compilerOptions?: TscCompilerOptions;
+}
+
+/** Defaults mirrored from the prior string form (`ES2022`/`ESNext`/`Bundler`). */
+function defaultCompilerOptions(ts: TypeScriptModule): TscCompilerOptions {
+  return {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    esModuleInterop: true,
+    allowSyntheticDefaultImports: true,
+    isolatedModules: true,
+  };
+}
+
+function compilerOptionsFromParsedConfig(config: unknown): TscCompilerOptions {
+  if (config === null || typeof config !== 'object') return {};
+  const { compilerOptions } = config as ParsedTsconfigJson;
+  return compilerOptions ?? {};
+}
 
 export async function loadTsconfig(
   fs: CommandContext['fs'],
   ts: TypeScriptModule,
   startDir: string
 ): Promise<ResolvedTscConfig> {
+  const defaults = defaultCompilerOptions(ts);
   const path = await findTsconfigPath(fs, startDir);
-  if (!path) return { compilerOptions: { ...DEFAULT_COMPILER_OPTIONS } };
+  if (!path) return { compilerOptions: { ...defaults } };
   let raw: string;
   try {
     raw = await fs.readFile(path);
   } catch {
-    return { compilerOptions: { ...DEFAULT_COMPILER_OPTIONS } };
+    return { compilerOptions: { ...defaults } };
   }
   const { config, error } = ts.parseConfigFileTextToJson(path, raw);
-  if (error || !config) return { compilerOptions: { ...DEFAULT_COMPILER_OPTIONS } };
-  const compilerOptions =
-    (config as { compilerOptions?: Record<string, unknown> }).compilerOptions ?? {};
+  if (error || !config) return { compilerOptions: { ...defaults } };
   return {
     compilerOptions: {
-      ...DEFAULT_COMPILER_OPTIONS,
-      ...compilerOptions,
+      ...defaults,
+      ...compilerOptionsFromParsedConfig(config),
     },
   };
 }
@@ -239,11 +258,11 @@ function transpileOne(
   ts: TypeScriptModule,
   source: string,
   fileName: string,
-  compilerOptions: Record<string, unknown>,
+  compilerOptions: TscCompilerOptions,
   reportDiagnostics: boolean
 ): TranspileOneResult {
   const result = ts.transpileModule(source, {
-    compilerOptions: compilerOptions as import('typescript-js').CompilerOptions,
+    compilerOptions,
     fileName,
     reportDiagnostics,
   });


### PR DESCRIPTION
## Summary
- Replace four `Record<string, unknown>` compiler-option bags in `tsc-command.ts` with named `TscCompilerOptions` (`typescript-js` `CompilerOptions`) and a `ParsedTsconfigJson` boundary type.
- Build default target/module/moduleResolution from the loaded TypeScript enums (`ES2022` / `ESNext` / `Bundler`) so behaviour stays the same without string-to-enum casts at the call site.
- Ratchet `record-string-unknown-baseline.json` to drop this file (clears the `record-string-unknown` debt list entry).

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/tsc-command.test.ts` (24 passed)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK