### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/tests/shell/di/di.test.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -322,7 +322,6 @@
         "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts",
         "packages/webapp/tests/cdp/cdp-client.test.ts",
         "packages/webapp/tests/kernel/realm/realm-runner.test.ts",
-        "packages/webapp/tests/shell/di/di.test.ts",
         "packages/webapp/tests/ui/provider-settings.test.ts"
       ],
       "linter": {


### PR DESCRIPTION
## Summary
- Cleared the **floating-promise** boy-scout debt entry for `packages/webapp/tests/shell/di/di.test.ts`.
- The suite already awaits (or returns) every promise; no behavioural change — only removed its stale `nursery.noFloatingPromises: "off"` override in `biome.json` so the rule now enforces the file.

## Test plan
- [x] `npx biome check --write biome.json packages/webapp/tests/shell/di/di.test.ts`
- [x] `npx biome check --only=nursery/noFloatingPromises packages/webapp/tests/shell/di/di.test.ts` (clean after exemption removal)
- [x] `npx vitest run packages/webapp/tests/shell/di/di.test.ts` (16 passed)
- [x] `npm run typecheck`
- [x] `CHANGED_FILES=packages/webapp/tests/shell/di/di.test.ts,biome.json node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK