### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/ui/boot/setup-welcome-flow.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -31,7 +31,6 @@
   "packages/webapp/src/shell/supplemental-commands/websocat-command.ts": 1,
   "packages/webapp/src/skills/catalog.ts": 3,
   "packages/webapp/src/speech/hear.ts": 1,
-  "packages/webapp/src/ui/boot/setup-welcome-flow.ts": 13,
   "packages/webapp/src/ui/dip.ts": 4,
   "packages/webapp/src/ui/sprinkle-bridge.ts": 2,
   "packages/webapp/src/ui/sprinkle-renderer.ts": 3

--- a/packages/webapp/src/ui/boot/setup-welcome-flow.ts
+++ b/packages/webapp/src/ui/boot/setup-welcome-flow.ts
@@ -17,6 +17,8 @@
 
 import type { VirtualFS } from '../../fs/index.js';
 import type { LickEvent } from '../../scoops/lick-manager.js';
+import type { OnboardingProfile } from '../../scoops/onboarding-messages.js';
+import type { OnboardingFinalLickPayload } from './setup-onboarding-orchestrator.js';
 import type { BootStageLogger } from './types.js';
 
 /**
@@ -86,8 +88,50 @@ const WELCOME_FLOW_ACTIONS = new Set<string>([
   'shortcut-migrate',
 ]);
 
+/**
+ * Top-level body of a welcome / inline sprinkle lick. Producers set
+ * `action` and usually a nested `data` bag; extra keys are ignored.
+ */
+export interface WelcomeLickBody {
+  action?: unknown;
+  data?: unknown;
+  readonly [key: string]: unknown;
+}
+
+/** Nested `data` on `connect-attempt` from `connect-llm.shtml`. */
+export interface WelcomeConnectAttemptData {
+  provider?: unknown;
+  apiKey?: unknown;
+  baseUrl?: unknown;
+  deployment?: unknown;
+  apiVersion?: unknown;
+  model?: unknown;
+  readonly [key: string]: unknown;
+}
+
+/** Nested `data` on `oauth-attempt` from `connect-llm.shtml`. */
+export interface WelcomeOAuthAttemptData {
+  provider?: unknown;
+  baseUrl?: unknown;
+  readonly [key: string]: unknown;
+}
+
+/** Nested `data` on `device-code-decision`. */
+export interface WelcomeDeviceCodeDecisionData {
+  decision?: unknown;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Nested `data` on `onboarding-complete` — the wizard profile plus the
+ * optional extension-only mount hint.
+ */
+export interface WelcomeOnboardingCompleteData extends OnboardingProfile {
+  mountWorkspace?: unknown;
+}
+
 interface WelcomeFastForwardDispatcher {
-  fire(data: Record<string, unknown>): void;
+  fire(data: OnboardingFinalLickPayload): void;
   // Optional broadcast on fast-forward (sends `slicc-already-connected` to dips)
   broadcastAlreadyConnected(providerId: string): void;
 }
@@ -108,7 +152,7 @@ export interface WelcomeLickInterceptorDeps {
   /** Resolves the lazy onboarding orchestrator. */
   getOnboardingOrchestrator(): {
     handleFirstRun(): void;
-    handleOnboardingComplete(profile: Record<string, unknown>): Promise<unknown>;
+    handleOnboardingComplete(profile: OnboardingProfile): Promise<unknown>;
     handleConnectReady(): void;
     handleConnectAttempt(input: {
       provider: string;
@@ -159,7 +203,7 @@ export function createWelcomeLickInterceptor(
     if (event.type !== 'sprinkle') return false;
     const welcomeAction =
       event.sprinkleName === 'welcome' || event.sprinkleName === 'inline'
-        ? ((event.body as Record<string, unknown> | null)?.action as string | undefined)
+        ? ((event.body as WelcomeLickBody | null)?.action as string | undefined)
         : undefined;
     if (welcomeAction && DEDUPED_WELCOME_ACTIONS.has(welcomeAction)) {
       if (firedWelcomeActions.has(welcomeAction)) {
@@ -173,7 +217,7 @@ export function createWelcomeLickInterceptor(
     }
     if (!welcomeAction || !WELCOME_FLOW_ACTIONS.has(welcomeAction)) return false;
 
-    const body = event.body as Record<string, unknown> | null;
+    const body = event.body as WelcomeLickBody | null;
     return dispatchWelcomeBranch(welcomeAction, body, {
       getAccounts,
       getProviderConfig,
@@ -191,17 +235,17 @@ export function createWelcomeLickInterceptor(
 interface WelcomeBranchDeps
   extends Omit<WelcomeLickInterceptorDeps, 'firedWelcomeActions' | 'contextLabel'> {}
 
-type WelcomeBranchBody = Record<string, unknown> | null;
+type WelcomeBranchBody = WelcomeLickBody | null;
 
 /** Optional string field, normalized to `null` when absent/empty. */
-function optString(data: Record<string, unknown>, key: string): string | null {
+function optString(data: { readonly [key: string]: unknown }, key: string): string | null {
   const value = data[key];
   return typeof value === 'string' && value ? value : null;
 }
 
 function handleOnboardingCompleteBranch(body: WelcomeBranchBody, deps: WelcomeBranchDeps): boolean {
   const orch = deps.getOnboardingOrchestrator();
-  const profile = (body?.data as Record<string, unknown> | undefined) ?? {};
+  const profile = (body?.data as WelcomeOnboardingCompleteData | undefined) ?? {};
   if (profile.mountWorkspace && deps.applyPendingMount) {
     deps
       .applyPendingMount()
@@ -214,7 +258,7 @@ function handleOnboardingCompleteBranch(body: WelcomeBranchBody, deps: WelcomeBr
 }
 
 function handleConnectAttemptBranch(body: WelcomeBranchBody, deps: WelcomeBranchDeps): boolean {
-  const data = body?.data as Record<string, unknown> | undefined;
+  const data = body?.data as WelcomeConnectAttemptData | undefined;
   if (data) {
     void deps
       .getOnboardingOrchestrator()
@@ -232,7 +276,7 @@ function handleConnectAttemptBranch(body: WelcomeBranchBody, deps: WelcomeBranch
 }
 
 function handleOAuthAttemptBranch(body: WelcomeBranchBody, deps: WelcomeBranchDeps): boolean {
-  const data = body?.data as Record<string, unknown> | undefined;
+  const data = body?.data as WelcomeOAuthAttemptData | undefined;
   if (data) {
     void deps
       .getOnboardingOrchestrator()
@@ -250,7 +294,7 @@ const WELCOME_BRANCHES: Record<
   (body: WelcomeBranchBody, deps: WelcomeBranchDeps) => boolean
 > = {
   'device-code-decision': (body, deps) => {
-    const decision = (body?.data as { decision?: unknown } | undefined)?.decision;
+    const decision = (body?.data as WelcomeDeviceCodeDecisionData | undefined)?.decision;
     deps.resolveDeviceCodeDecision(decision === 'cancel' ? 'cancel' : 'continue');
     return true;
   },
@@ -307,7 +351,7 @@ function handleConnectReadyBranch(deps: {
 export async function fireFastForwardFinalLick(
   fs: VirtualFS | null,
   providerId: string,
-  fire: (data: Record<string, unknown>) => void
+  fire: (data: OnboardingFinalLickPayload) => void
 ): Promise<void> {
   const { hasOnboardingFinalLickInHistory } = await import('../../scoops/welcome-detection.js');
   if (await hasOnboardingFinalLickInHistory()) return;
@@ -355,10 +399,10 @@ export async function fireFastForwardFinalLick(
  * fast-forward path can hand the cone the same profile shape the
  * orchestrator would have. Returns `{}` on any failure.
  */
-async function loadPersistedProfile(fs: VirtualFS): Promise<Record<string, unknown>> {
+async function loadPersistedProfile(fs: VirtualFS): Promise<OnboardingProfile> {
   try {
     const homes = await fs.readDir('/home');
-    let best: { profile: Record<string, unknown>; mtime: number } | null = null;
+    let best: { profile: OnboardingProfile; mtime: number } | null = null;
     for (const entry of homes) {
       if (entry.type !== 'directory') continue;
       const path = `/home/${entry.name}/.welcome.json`;
@@ -369,7 +413,7 @@ async function loadPersistedProfile(fs: VirtualFS): Promise<Record<string, unkno
         const raw = await fs.readFile(path, { encoding: 'utf-8' });
         const parsed = JSON.parse(typeof raw === 'string' ? raw : new TextDecoder().decode(raw));
         if (parsed && typeof parsed === 'object') {
-          best = { profile: parsed as Record<string, unknown>, mtime };
+          best = { profile: parsed as OnboardingProfile, mtime };
         }
       } catch {
         /* skip slugs without a profile */

--- a/packages/webapp/tests/ui/boot/setup-welcome-flow.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-welcome-flow.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Pins the welcome-flow lick interceptor's named body types so the
+ * boy-scout `Record<string, unknown>` cleanup stays behaviour-preserving.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LickEvent } from '../../../src/scoops/lick-manager.js';
+import {
+  createWelcomeLickInterceptor,
+  DEDUPED_WELCOME_ACTIONS,
+  dispatchWelcomeLickOnce,
+  loadFiredWelcomeActions,
+  persistFiredWelcomeActions,
+  type WelcomeLickInterceptorDeps,
+} from '../../../src/ui/boot/setup-welcome-flow.js';
+
+vi.mock('../../../src/scoops/welcome-detection.js', () => ({
+  hasOnboardingFinalLickInHistory: vi.fn(async () => true),
+}));
+
+const LEDGER_KEY = 'slicc:welcome-flow-fired';
+
+function makeFakeStorage(initial: Record<string, string> = {}): Storage {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => {
+      store.clear();
+    },
+    key: (i: number) => [...store.keys()][i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+function welcomeLick(action: string, data?: unknown): LickEvent {
+  return {
+    type: 'sprinkle',
+    sprinkleName: 'welcome',
+    timestamp: new Date().toISOString(),
+    body: data === undefined ? { action } : { action, data },
+  };
+}
+
+function makeDeps(overrides: Partial<WelcomeLickInterceptorDeps> = {}): WelcomeLickInterceptorDeps {
+  const orch = {
+    handleFirstRun: vi.fn(),
+    handleOnboardingComplete: vi.fn(async () => true),
+    handleConnectReady: vi.fn(),
+    handleConnectAttempt: vi.fn(async () => true),
+    handleOAuthAttempt: vi.fn(async () => true),
+  };
+  return {
+    firedWelcomeActions: new Set(),
+    getAccounts: () => [],
+    getProviderConfig: () => null,
+    resolveDeviceCodeDecision: vi.fn(),
+    getOnboardingOrchestrator: () => orch,
+    fastForward: {
+      fire: vi.fn(),
+      broadcastAlreadyConnected: vi.fn(),
+    },
+    onShortcutMigrate: vi.fn(),
+    contextLabel: 'test',
+    vfs: null,
+    log: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    },
+    ...overrides,
+  };
+}
+
+describe('dispatchWelcomeLickOnce', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', makeFakeStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fires once for a deduped action and suppresses the duplicate', () => {
+    const set = new Set<string>();
+    const fire = vi.fn();
+    const log = { debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() };
+
+    dispatchWelcomeLickOnce('first-run', set, fire, 'test', log);
+    dispatchWelcomeLickOnce('first-run', set, fire, 'test', log);
+
+    expect(fire).toHaveBeenCalledTimes(1);
+    expect(set.has('first-run')).toBe(true);
+    expect(DEDUPED_WELCOME_ACTIONS.has('first-run')).toBe(true);
+    expect(log.debug).toHaveBeenCalledOnce();
+  });
+
+  it('round-trips the persistent ledger through localStorage', () => {
+    const set = new Set(['onboarding-complete']);
+    persistFiredWelcomeActions(set);
+    expect(localStorage.getItem(LEDGER_KEY)).toBe(JSON.stringify(['onboarding-complete']));
+    expect([...loadFiredWelcomeActions()]).toEqual(['onboarding-complete']);
+  });
+});
+
+describe('createWelcomeLickInterceptor', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', makeFakeStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('ignores non-sprinkle and non-welcome-flow licks', () => {
+    const deps = makeDeps();
+    const intercept = createWelcomeLickInterceptor(deps);
+
+    expect(
+      intercept({
+        type: 'cron',
+        timestamp: new Date().toISOString(),
+        body: { action: 'first-run' },
+      })
+    ).toBe(false);
+    expect(
+      intercept({
+        type: 'sprinkle',
+        sprinkleName: 'other',
+        timestamp: new Date().toISOString(),
+        body: { action: 'first-run' },
+      })
+    ).toBe(false);
+    expect(intercept(welcomeLick('not-a-welcome-action'))).toBe(false);
+  });
+
+  it('routes first-run to the orchestrator and dedupes a second fire', () => {
+    const deps = makeDeps();
+    const intercept = createWelcomeLickInterceptor(deps);
+    const orch = deps.getOnboardingOrchestrator();
+
+    expect(intercept(welcomeLick('first-run'))).toBe(true);
+    expect(orch.handleFirstRun).toHaveBeenCalledOnce();
+    expect(intercept(welcomeLick('first-run'))).toBe(true);
+    expect(orch.handleFirstRun).toHaveBeenCalledOnce();
+  });
+
+  it('passes onboarding-complete profile data and mounts when requested', async () => {
+    const applyPendingMount = vi.fn(async () => {});
+    const deps = makeDeps({ applyPendingMount });
+    const intercept = createWelcomeLickInterceptor(deps);
+    const orch = deps.getOnboardingOrchestrator();
+
+    expect(
+      intercept(
+        welcomeLick('onboarding-complete', {
+          name: 'Ada',
+          mountWorkspace: true,
+        })
+      )
+    ).toBe(true);
+
+    expect(orch.handleOnboardingComplete).toHaveBeenCalledWith({
+      name: 'Ada',
+      mountWorkspace: true,
+    });
+    expect(applyPendingMount).toHaveBeenCalledOnce();
+    await Promise.resolve();
+  });
+
+  it('forwards connect-attempt and oauth-attempt fields to the orchestrator', async () => {
+    const deps = makeDeps();
+    const intercept = createWelcomeLickInterceptor(deps);
+    const orch = deps.getOnboardingOrchestrator();
+
+    expect(
+      intercept(
+        welcomeLick('connect-attempt', {
+          provider: 'anthropic',
+          apiKey: 'sk-test',
+          baseUrl: 'https://example.test',
+          deployment: 'dep',
+          apiVersion: '2024-01-01',
+          model: 'claude-opus-4-6',
+        })
+      )
+    ).toBe(true);
+    expect(
+      intercept(
+        welcomeLick('oauth-attempt', {
+          provider: 'openai',
+          baseUrl: '',
+        })
+      )
+    ).toBe(true);
+
+    await Promise.resolve();
+    expect(orch.handleConnectAttempt).toHaveBeenCalledWith({
+      provider: 'anthropic',
+      apiKey: 'sk-test',
+      baseUrl: 'https://example.test',
+      deployment: 'dep',
+      apiVersion: '2024-01-01',
+      model: 'claude-opus-4-6',
+    });
+    expect(orch.handleOAuthAttempt).toHaveBeenCalledWith({
+      provider: 'openai',
+      baseUrl: null,
+    });
+  });
+
+  it('resolves device-code decisions and runs shortcut-migrate', () => {
+    const deps = makeDeps();
+    const intercept = createWelcomeLickInterceptor(deps);
+
+    expect(intercept(welcomeLick('device-code-decision', { decision: 'cancel' }))).toBe(true);
+    expect(deps.resolveDeviceCodeDecision).toHaveBeenCalledWith('cancel');
+
+    expect(intercept(welcomeLick('device-code-decision', { decision: 'go' }))).toBe(true);
+    expect(deps.resolveDeviceCodeDecision).toHaveBeenCalledWith('continue');
+
+    expect(intercept(welcomeLick('shortcut-migrate'))).toBe(true);
+    expect(deps.onShortcutMigrate).toHaveBeenCalledOnce();
+  });
+
+  it('calls handleConnectReady when no accounts are stored', () => {
+    const deps = makeDeps({ getAccounts: () => [] });
+    const intercept = createWelcomeLickInterceptor(deps);
+    const orch = deps.getOnboardingOrchestrator();
+
+    expect(intercept(welcomeLick('connect-ready'))).toBe(true);
+    expect(orch.handleConnectReady).toHaveBeenCalledOnce();
+    expect(deps.fastForward.broadcastAlreadyConnected).not.toHaveBeenCalled();
+  });
+
+  it('fast-forwards when an account already exists', async () => {
+    const deps = makeDeps({
+      getAccounts: () => [{ providerId: 'anthropic' }],
+    });
+    const intercept = createWelcomeLickInterceptor(deps);
+    const orch = deps.getOnboardingOrchestrator();
+
+    expect(intercept(welcomeLick('connect-ready'))).toBe(true);
+    expect(orch.handleConnectReady).not.toHaveBeenCalled();
+    expect(deps.fastForward.broadcastAlreadyConnected).toHaveBeenCalledWith('anthropic');
+    // hasOnboardingFinalLickInHistory is mocked true → fire() is skipped
+    await vi.waitFor(() => {
+      expect(deps.fastForward.fire).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Clear **record-string-unknown** debt in `packages/webapp/src/ui/boot/setup-welcome-flow.ts` by replacing every `Record<string, unknown>` with named welcome-lick payload types (`WelcomeLickBody`, connect/oauth/device-code data bags, `WelcomeOnboardingCompleteData`, plus existing `OnboardingProfile` / `OnboardingFinalLickPayload`).
- Ratchet `record-string-unknown-baseline.json` via `--update` (file entry removed).
- Add focused interceptor/dedup tests under `packages/webapp/tests/ui/boot/setup-welcome-flow.test.ts`.

## Test plan
- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/ui/boot/setup-welcome-flow.test.ts` (9 passed)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK