### PR TITLE
test: fix local test-suite flakiness (5s timeout budget + a keep-alive port race)

### DIFF
--- a/.agents/skills/writing-slicc-tests/SKILL.md
+++ b/.agents/skills/writing-slicc-tests/SKILL.md
@@ -451,6 +451,48 @@ Rules for changing this:
 - Never enable retries locally. `CI_RETRIES` in `vitest.config.ts` resolves to `0` without
   `CI`, so `npm run test` on a laptop reports the first failure.
 
+## Keep Tests Inside the Timeout Budget
+
+`testTimeout` is vitest's default **5000ms**; the root config never raises it. A test that
+deterministically spends 2-3s of that budget passes on an idle laptop and fails on a loaded
+one, in a _different file each run_. That moving target is the signature of budget exhaustion,
+not of a shared-resource race — the victim is whichever slow test met peak contention.
+
+Two patterns burn the budget without asserting anything.
+
+**1. Heavy `await import()` inside a test body.** Vitest charges module transform and
+evaluation to whichever test triggers it, so the _first_ test in a file pays for the whole
+graph and the rest cost nothing. In `packages/webapp/tests/shell/ipk/`, `newShell()` imported
+`VirtualFS` and `AlmostBashShellHeadless` lazily: the first call cost **1347ms**, every later
+one 0ms. Hoist them to static top-level imports — `vi.mock()` factories are hoisted above
+imports so mocks still apply, and the cost moves to the collection phase, which no per-test
+timeout covers.
+
+```ts
+// Wrong — the first test in the file absorbs the entire module graph.
+async function newShell() {
+  const { VirtualFS } = await import('../../../src/fs/index.js');
+}
+
+// Right — collection pays for it; no test does.
+import { VirtualFS } from '../../../src/fs/index.js';
+```
+
+Keep the dynamic form only where the test needs a genuinely fresh module instance, i.e. it
+calls `vi.resetModules()` (see `tests/ui/wc/wc-follower.test.ts`). Give those an explicit
+per-test timeout instead.
+
+**2. Real production backoff in a test that is not testing backoff.** Retry schedules are
+injectable for exactly this reason: `setupStandalonePrelude` takes `sleep`, and
+`SessionTrayDurableObject` takes `webhookDeliveryWaitMs`. Omit them and the test sits out the
+full production budget — 3.1s (`CDP_BRIDGE_CONNECT_RETRY_DELAYS_MS`) and 3s
+(`WEBHOOK_DELIVERY_WAIT_MS`) — inside a 5s timeout. Inject the fast value, and leave the
+timing assertion to the dedicated unit test (`connectWithBoundedRetry`, which takes `delays`).
+
+Never answer either pattern by raising `testTimeout`: that makes the failure rarer and harder
+to read without removing the wasted seconds. Audit with the timing JSON below — nothing in the
+default suite should sit near a second without an explicit, justified per-test timeout.
+
 ## Read Test Timing
 
 When `CI` is set, the root `test.reporters` adds vitest's `json` reporter and writes

--- a/.agents/skills/writing-slicc-tests/SKILL.md
+++ b/.agents/skills/writing-slicc-tests/SKILL.md
@@ -489,6 +489,19 @@ full production budget — 3.1s (`CDP_BRIDGE_CONNECT_RETRY_DELAYS_MS`) and 3s
 (`WEBHOOK_DELIVERY_WAIT_MS`) — inside a 5s timeout. Inject the fast value, and leave the
 timing assertion to the dedicated unit test (`connectWithBoundedRetry`, which takes `delays`).
 
+**3. Spawning a real browser from the default suite.** `playwright-command.test.ts`'s
+`iframe integration` block launches real headless Chrome. Under memory/CPU pressure the OS
+SIGKILLs it mid-launch and the whole suite fails with `Chrome exited with code null before
+reporting CDP port` — a machine-state failure that says nothing about the code under test. It
+is gated on `CI || SLICC_TEST_CHROME_INTEGRATION=1`, so CI (ubuntu-latest ships Chrome and
+sets `SLICC_CDP_LAUNCH_TIMEOUT_MS`) keeps it as a real gate while `npm run test` on a laptop
+does not spawn browsers. Run it locally with:
+
+```bash
+SLICC_TEST_CHROME_INTEGRATION=1 npx vitest run \
+  packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+```
+
 Never answer either pattern by raising `testTimeout`: that makes the failure rarer and harder
 to read without removing the wasted seconds. Audit with the timing JSON below — nothing in the
 default suite should sit near a second without an explicit, justified per-test timeout.

--- a/packages/cloudflare-worker/tests/index.test.ts
+++ b/packages/cloudflare-worker/tests/index.test.ts
@@ -3175,7 +3175,13 @@ describe('SessionTrayDurableObject — hibernation', () => {
     const first = new SessionTrayDurableObject(
       state,
       {},
-      { now: () => now, webSocketPairFactory: createFakeWebSocketPair }
+      {
+        now: () => now,
+        webSocketPairFactory: createFakeWebSocketPair,
+        // Fake leader never acks, so without this the webhook POST sits out the
+        // full 3s production delivery budget inside a 5s test timeout.
+        webhookDeliveryWaitMs: 5,
+      }
     );
     state.instance = first;
 
@@ -3212,7 +3218,13 @@ describe('SessionTrayDurableObject — hibernation', () => {
     const revived = new SessionTrayDurableObject(
       state,
       {},
-      { now: () => now, webSocketPairFactory: createFakeWebSocketPair }
+      {
+        now: () => now,
+        webSocketPairFactory: createFakeWebSocketPair,
+        // Fake leader never acks, so without this the webhook POST sits out the
+        // full 3s production delivery budget inside a 5s test timeout.
+        webhookDeliveryWaitMs: 5,
+      }
     );
     state.instance = revived;
 

--- a/packages/node-server/tests/cloud-status.test.ts
+++ b/packages/node-server/tests/cloud-status.test.ts
@@ -34,6 +34,12 @@ async function makeRequest(
     }
     return await fetch(url, options);
   } finally {
+    // Destroy keep-alive sockets before closing. `close()` alone leaves them
+    // pooled in the fetch client while the OS is free to recycle this
+    // ephemeral port onto the NEXT test's server — the client then reuses a
+    // socket pointing at the wrong server and reads a crossed response
+    // (observed: `HTTPParserError: Expected HTTP/` and a stray 404).
+    server.closeAllConnections?.();
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 }

--- a/packages/node-server/tests/fetch-proxy-dav.test.ts
+++ b/packages/node-server/tests/fetch-proxy-dav.test.ts
@@ -119,6 +119,10 @@ describe('fetch-proxy WebDAV / CalDAV verb pass-through', () => {
   });
 
   afterEach(async () => {
+    // See the note in cloud-status.test.ts: keep-alive sockets outliving a
+    // recycled ephemeral port cross a later client onto the wrong server.
+    proxyServer.closeAllConnections?.();
+    upstream.server.closeAllConnections?.();
     await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
     await new Promise<void>((resolve) => upstream.server.close(() => resolve()));
   });

--- a/packages/node-server/tests/handoff-api.test.ts
+++ b/packages/node-server/tests/handoff-api.test.ts
@@ -35,6 +35,12 @@ async function postJson(app: express.Express, body: unknown): Promise<Response> 
       body: JSON.stringify(body),
     });
   } finally {
+    // Destroy keep-alive sockets before closing. `close()` alone leaves them
+    // pooled in the fetch client while the OS is free to recycle this
+    // ephemeral port onto the NEXT test's server — the client then reuses a
+    // socket pointing at the wrong server and reads a crossed response
+    // (observed: `HTTPParserError: Expected HTTP/` and a stray 404).
+    server.closeAllConnections?.();
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 }

--- a/packages/node-server/tests/hosted-bootstrap.test.ts
+++ b/packages/node-server/tests/hosted-bootstrap.test.ts
@@ -40,6 +40,12 @@ async function getEndpoint(secretStore: SecretStore, addr: string): Promise<Resp
     const port = (listening.address() as { port: number }).port;
     return await fetch(`http://${addr}:${port}/api/hosted-bootstrap`);
   } finally {
+    // Destroy keep-alive sockets before closing. `close()` alone leaves them
+    // pooled in the fetch client while the OS is free to recycle this
+    // ephemeral port onto the NEXT test's server — the client then reuses a
+    // socket pointing at the wrong server and reads a crossed response
+    // (observed: `HTTPParserError: Expected HTTP/` and a stray 404).
+    listening.closeAllConnections?.();
     await new Promise<void>((r) => listening.close(() => r()));
   }
 }

--- a/packages/node-server/tests/hostfs.test.ts
+++ b/packages/node-server/tests/hostfs.test.ts
@@ -37,7 +37,13 @@ beforeAll(async () => {
   const listening = app.listen(0);
   const port = (listening.address() as { port: number }).port;
   baseUrl = `http://127.0.0.1:${port}`;
-  close = () => new Promise((r) => listening.close(() => r()));
+  close = () =>
+    new Promise<void>((r) => {
+      // See the note in cloud-status.test.ts: a pooled keep-alive socket plus a
+      // recycled ephemeral port crosses one test's client onto another's server.
+      listening.closeAllConnections?.();
+      listening.close(() => r());
+    });
 });
 
 afterAll(async () => {

--- a/packages/node-server/tests/links-middleware.test.ts
+++ b/packages/node-server/tests/links-middleware.test.ts
@@ -26,6 +26,12 @@ async function fetchInProcess(app: express.Express, path: string): Promise<Respo
     const port = addr.port;
     return await fetch(`http://localhost:${port}${path}`);
   } finally {
+    // Destroy keep-alive sockets before closing. `close()` alone leaves them
+    // pooled in the fetch client while the OS is free to recycle this
+    // ephemeral port onto the NEXT test's server — the client then reuses a
+    // socket pointing at the wrong server and reads a crossed response
+    // (observed: `HTTPParserError: Expected HTTP/` and a stray 404).
+    server.closeAllConnections?.();
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 }

--- a/packages/node-server/tests/sudo/endpoint.test.ts
+++ b/packages/node-server/tests/sudo/endpoint.test.ts
@@ -21,6 +21,12 @@ async function makeRequest(app: express.Express, body?: unknown): Promise<Respon
     }
     return await fetch(url, options);
   } finally {
+    // Destroy keep-alive sockets before closing. `close()` alone leaves them
+    // pooled in the fetch client while the OS is free to recycle this
+    // ephemeral port onto the NEXT test's server — the client then reuses a
+    // socket pointing at the wrong server and reads a crossed response
+    // (observed: `HTTPParserError: Expected HTTP/` and a stray 404).
+    server.closeAllConnections?.();
     await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 }

--- a/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
+++ b/packages/webapp/src/ui/boot/setup-standalone-prelude.ts
@@ -48,6 +48,20 @@ export interface StandalonePreludeDeps {
   envBaseUrl: string | null;
   window: Window;
   log: BootStageLogger;
+  /**
+   * Backoff sleep for the bounded CDP-connect retry on the standalone/bridge
+   * path (the `new BrowserAPI()` branch below — NOT the extension-leader
+   * transport, which builds its own browser and always uses the real timer).
+   * Defaults to a real timer.
+   *
+   * Tests that exercise a branch *around* the connect rather than the retry
+   * itself inject an instant sleep: otherwise every such case burns the full
+   * `CDP_BRIDGE_CONNECT_RETRY_DELAYS_MS` budget (3.1s) of pure wall clock
+   * inside a 5s test timeout, which is most of a default-suite flake budget.
+   * The retry schedule itself is covered by the `connectWithBoundedRetry`
+   * unit tests, which inject `delays` directly.
+   */
+  sleep?: (ms: number) => Promise<void>;
 }
 
 /**
@@ -280,7 +294,7 @@ async function createExtensionLeaderBrowser(
 export async function setupStandalonePrelude(
   deps: StandalonePreludeDeps
 ): Promise<StandalonePreludeResult> {
-  const { runtimeMode, envBaseUrl, window: win, log } = deps;
+  const { runtimeMode, envBaseUrl, window: win, log, sleep } = deps;
   const isElectronOverlay = runtimeMode === 'electron-overlay';
   // This prelude only builds the page-side runtime (BrowserAPI + CDP). The
   // kernel worker, if any, is spawned later by mountWcUiLive — the follower /
@@ -409,7 +423,7 @@ export async function setupStandalonePrelude(
       // very first connect can lose to the bridge by a few hundred ms.
       // Retry with capped backoff so we recover from the boot race without
       // hanging boot if the bridge truly never comes up.
-      await connectWithBoundedRetry(browser, connectOpts, log);
+      await connectWithBoundedRetry(browser, connectOpts, log, undefined, sleep);
       // If another SLICC tab/window later seizes the single CDP proxy slot, the
       // reconnect guard stops this tab from re-dialing (which would restart the
       // eviction war). Surface that to the user with a banner rather than letting

--- a/packages/webapp/tests/kernel/host-lick-ws-gate.test.ts
+++ b/packages/webapp/tests/kernel/host-lick-ws-gate.test.ts
@@ -2,6 +2,14 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+// Static, not `await import()` inside each test: `src/kernel/host.js` pulls a
+// large graph, and vitest charges that transform+evaluation to whichever test
+// triggers it — the first one here measured >1.2s of a 5s budget and timed out
+// under load. Both gates below read `globalThis.chrome` / the delegate id at
+// CALL time (`resolveFloatTopology`), never at module scope, so importing
+// ahead of the per-test global stubbing is behaviour-preserving.
+import { shouldStartLickWsBridge } from '../../src/kernel/host.js';
+import { setExtensionDelegateId } from '../../src/shell/proxied-fetch.js';
 
 describe('shouldStartLickWsBridge (kernel host lick-ws gate)', () => {
   let originalChrome: unknown;
@@ -15,31 +23,24 @@ describe('shouldStartLickWsBridge (kernel host lick-ws gate)', () => {
   afterEach(async () => {
     (globalThis as { chrome?: unknown }).chrome = originalChrome;
     (globalThis as Record<string, unknown>).__slicc_connect_mode = originalConnectMode;
-    const { setExtensionDelegateId } = await import('../../src/shell/proxied-fetch.js');
     setExtensionDelegateId(null);
   });
 
   it('starts the bridge for node-rest', async () => {
     (globalThis as { chrome?: unknown }).chrome = undefined;
-    const { setExtensionDelegateId } = await import('../../src/shell/proxied-fetch.js');
     setExtensionDelegateId(null);
-    const { shouldStartLickWsBridge } = await import('../../src/kernel/host.js');
     expect(shouldStartLickWsBridge()).toBe(true);
   });
 
   it('does NOT start the bridge for extension-delegate', async () => {
     (globalThis as { chrome?: unknown }).chrome = { runtime: { connect: () => undefined } };
-    const { setExtensionDelegateId } = await import('../../src/shell/proxied-fetch.js');
     setExtensionDelegateId('delegate-id');
-    const { shouldStartLickWsBridge } = await import('../../src/kernel/host.js');
     expect(shouldStartLickWsBridge()).toBe(false);
   });
 
   it('does NOT start the bridge for extension-direct', async () => {
     (globalThis as { chrome?: unknown }).chrome = { runtime: { id: 'real-ext-id' } };
-    const { setExtensionDelegateId } = await import('../../src/shell/proxied-fetch.js');
     setExtensionDelegateId(null);
-    const { shouldStartLickWsBridge } = await import('../../src/kernel/host.js');
     expect(shouldStartLickWsBridge()).toBe(false);
   });
 });

--- a/packages/webapp/tests/kernel/process-manager.test.ts
+++ b/packages/webapp/tests/kernel/process-manager.test.ts
@@ -52,7 +52,9 @@ describe('ProcessManager — pid allocation', () => {
     // d should land at the first hole after [a,b,c], regardless of
     // exact value. The key invariant is FAST allocation.
     expect(d.pid).toBe(c.pid + 1);
-    expect(elapsedMs).toBeLessThan(50); // sanity: no multi-second scan
+    // sanity: no multi-second scan. Bound states that intent literally; 50ms
+    // was measuring machine load, not allocation strategy.
+    expect(elapsedMs).toBeLessThan(500);
   });
 
   it('does not reuse a live pid (linear probe)', () => {

--- a/packages/webapp/tests/kernel/realm/realm-runner-sigkill.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-runner-sigkill.test.ts
@@ -56,9 +56,10 @@ describe('runInRealm SIGKILL', () => {
     const result = await promise;
     const elapsed = Date.now() - start;
     expect(result.exitCode).toBe(137);
-    // 50 ms budget for the kernel-side cleanup. In-process
-    // factories settle synchronously after the SIGKILL fires.
-    expect(elapsed).toBeLessThan(150);
+    // Anti-hang bound for the kernel-side cleanup: in-process factories settle
+    // synchronously after the SIGKILL fires, so the regression is a kill that
+    // never settles. 150ms was measuring machine load.
+    expect(elapsed).toBeLessThan(500);
     expect(proc.terminatedBy).toBe('SIGKILL');
     expect(proc.exitCode).toBe(137);
     expect(proc.status).toBe('killed');

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -1969,7 +1969,10 @@ describe('Orchestrator scoop-notify onIncomingMessage visibility', () => {
     const started = Date.now();
     const results = await orch.waitForScoops([scoop.jid], 0);
     const elapsed = Date.now() - started;
-    expect(elapsed).toBeLessThan(100);
+    // Anti-hang bound, not a perf budget: the regression is `timeout 0` being
+    // treated as "no timeout" and waiting indefinitely. 100ms only held on an
+    // idle machine (observed 117ms under load).
+    expect(elapsed).toBeLessThan(500);
     expect(results[0].timedOut).toBe(true);
     expect(results[0].summary).toBeNull();
   });
@@ -2067,8 +2070,10 @@ describe('Orchestrator scoop-notify onIncomingMessage visibility', () => {
     const start = Date.now();
     const ack = orch.scheduleScoopWait([a.jid, b.jid], 2000);
     const elapsed = Date.now() - start;
-    // Sync return — must not have done any actual waiting.
-    expect(elapsed).toBeLessThan(50);
+    // Sync return — must not have done any actual waiting. The regression is
+    // awaiting the 2000ms budget above, so 500ms still catches it while
+    // tolerating a loaded machine.
+    expect(elapsed).toBeLessThan(500);
     expect(ack.scheduled).toEqual([a.jid, b.jid]);
     expect(ack.unknown).toEqual([]);
     // Mute is installed synchronously by waitForScoops' sync setup.

--- a/packages/webapp/tests/scoops/scoop-management-tools.test.ts
+++ b/packages/webapp/tests/scoops/scoop-management-tools.test.ts
@@ -522,7 +522,10 @@ describe('scoop_mute / scoop_unmute / scoop_wait tools', () => {
     const result = await tool!.execute({ scoop_names: ['alpha-scoop'], timeout_ms: 1000 });
     const elapsed = Date.now() - start;
 
-    expect(elapsed).toBeLessThan(50);
+    // Anti-hang bound, not a perf budget: the regression this guards is the
+    // tool AWAITING the 1000ms wait above, so anything well under that proves
+    // the point. 50ms only held on an idle machine.
+    expect(elapsed).toBeLessThan(500);
     expect(onScheduleScoopWait).toHaveBeenCalledWith([targetScoop.jid], 1000);
     expect(result.content).toContain('scoop_wait scheduled for: alpha-scoop');
     expect(result.content).toContain('timeout: 1000ms');

--- a/packages/webapp/tests/shell/ipk/cjs-require-exit-code-e2e.test.ts
+++ b/packages/webapp/tests/shell/ipk/cjs-require-exit-code-e2e.test.ts
@@ -21,14 +21,12 @@
  */
 import 'fake-indexeddb/auto';
 import { describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 let dbCounter = 0;
 
 async function newShell() {
-  const { VirtualFS } = await import('../../../src/fs/index.js');
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   const fs = await VirtualFS.create({
     dbName: `test-require-exit-${dbCounter++}`,
     wipe: true,

--- a/packages/webapp/tests/shell/ipk/cjs-resolution-paths-e2e.test.ts
+++ b/packages/webapp/tests/shell/ipk/cjs-resolution-paths-e2e.test.ts
@@ -10,14 +10,12 @@
  */
 import 'fake-indexeddb/auto';
 import { describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 let dbCounter = 0;
 
 async function newShell() {
-  const { VirtualFS } = await import('../../../src/fs/index.js');
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   const fs = await VirtualFS.create({ dbName: `test-cjs-resolve-${dbCounter++}`, wipe: true });
   await fs.mkdir('/work', { recursive: true });
   const shell = new AlmostBashShellHeadless({ fs, cwd: '/work' });

--- a/packages/webapp/tests/shell/ipk/esm-cjs-interop-e2e.test.ts
+++ b/packages/webapp/tests/shell/ipk/esm-cjs-interop-e2e.test.ts
@@ -15,6 +15,8 @@ import 'fake-indexeddb/auto';
 import { gzipSync } from 'fflate';
 import type { SecureFetch } from 'just-bash';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 /** just-bash does not re-export SecureFetchOptions from its root entry. */
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -146,10 +148,6 @@ vi.mock('../../../src/shell/proxied-fetch.js', async (importOriginal) => {
 let dbCounter = 0;
 
 async function newShell() {
-  const { VirtualFS } = await import('../../../src/fs/index.js');
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   const fs = await VirtualFS.create({ dbName: `test-esm-interop-${dbCounter++}`, wipe: true });
   await fs.mkdir('/work', { recursive: true });
   const shell = new AlmostBashShellHeadless({ fs, cwd: '/work' });

--- a/packages/webapp/tests/shell/ipk/esm-real-path-e2e.test.ts
+++ b/packages/webapp/tests/shell/ipk/esm-real-path-e2e.test.ts
@@ -21,6 +21,8 @@ import 'fake-indexeddb/auto';
 import { gzipSync } from 'fflate';
 import type { SecureFetch } from 'just-bash';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 /** just-bash does not re-export SecureFetchOptions from its root entry. */
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -151,10 +153,6 @@ vi.mock('../../../src/shell/proxied-fetch.js', async (importOriginal) => {
 let dbCounter = 0;
 
 async function newShell() {
-  const { VirtualFS } = await import('../../../src/fs/index.js');
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   const fs = await VirtualFS.create({ dbName: `test-esm-real-${dbCounter++}`, wipe: true });
   await fs.mkdir('/work', { recursive: true });
   const shell = new AlmostBashShellHeadless({ fs, cwd: '/work' });

--- a/packages/webapp/tests/shell/ipk/esm-schemes-jsh-e2e.test.ts
+++ b/packages/webapp/tests/shell/ipk/esm-schemes-jsh-e2e.test.ts
@@ -11,14 +11,12 @@
  */
 import 'fake-indexeddb/auto';
 import { describe, expect, it } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 let dbCounter = 0;
 
 async function newShell() {
-  const { VirtualFS } = await import('../../../src/fs/index.js');
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   const fs = await VirtualFS.create({ dbName: `test-esm-schemes-jsh-${dbCounter++}`, wipe: true });
   await fs.mkdir('/work', { recursive: true });
   const shell = new AlmostBashShellHeadless({ fs, cwd: '/work' });

--- a/packages/webapp/tests/shell/ipk/install-require-lifecycle-e2e.test.ts
+++ b/packages/webapp/tests/shell/ipk/install-require-lifecycle-e2e.test.ts
@@ -25,6 +25,8 @@ import 'fake-indexeddb/auto';
 import { gzipSync } from 'fflate';
 import type { SecureFetch } from 'just-bash';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 /** just-bash does not re-export SecureFetchOptions from its root entry. */
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -196,15 +198,11 @@ vi.mock('../../../src/shell/proxied-fetch.js', async (importOriginal) => {
 let dbCounter = 0;
 
 async function newVfs(dbName: string, wipe: boolean) {
-  const { VirtualFS } = await import('../../../src/fs/index.js');
   const fs = await VirtualFS.create({ dbName, wipe });
   return fs;
 }
 
 async function newShell() {
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   const dbName = `test-lifecycle-${dbCounter++}`;
   const fs = await newVfs(dbName, true);
   await fs.mkdir('/work', { recursive: true });
@@ -213,9 +211,6 @@ async function newShell() {
 }
 
 async function shellOn(fs: Awaited<ReturnType<typeof newVfs>>, cwd = '/work') {
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   return new AlmostBashShellHeadless({ fs, cwd });
 }
 

--- a/packages/webapp/tests/shell/ipk/ipk-global-bin-e2e.test.ts
+++ b/packages/webapp/tests/shell/ipk/ipk-global-bin-e2e.test.ts
@@ -5,6 +5,8 @@ import 'fake-indexeddb/auto';
 import { gzipSync } from 'fflate';
 import type { SecureFetch } from 'just-bash';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 import { GLOBAL_BIN_DIR, GLOBAL_NODE_MODULES } from '../../../src/shell/ipk/global-prefix.js';
 
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -173,10 +175,6 @@ describe('global ipk bins via PATH (AlmostBashShellHeadless)', () => {
   });
 
   async function newShell(cwd = '/work') {
-    const { VirtualFS } = await import('../../../src/fs/index.js');
-    const { AlmostBashShellHeadless } = await import(
-      '../../../src/shell/almost-bash-shell-headless.js'
-    );
     const fs = await VirtualFS.create({
       dbName: `test-ipk-global-bin-${dbCounter++}`,
       wipe: true,

--- a/packages/webapp/tests/shell/ipk/ipk-no-arg-shell.test.ts
+++ b/packages/webapp/tests/shell/ipk/ipk-no-arg-shell.test.ts
@@ -15,6 +15,8 @@ import 'fake-indexeddb/auto';
 import { gzipSync } from 'fflate';
 import type { SecureFetch } from 'just-bash';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 /** just-bash does not re-export SecureFetchOptions from its root entry. */
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -190,10 +192,6 @@ vi.mock('../../../src/shell/proxied-fetch.js', async (importOriginal) => {
 
 let dbCounter = 0;
 async function newShell() {
-  const { VirtualFS } = await import('../../../src/fs/index.js');
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   const fs = await VirtualFS.create({
     dbName: `test-ipk-no-arg-shell-${dbCounter++}`,
     wipe: true,

--- a/packages/webapp/tests/shell/ipk/ipk-require-e2e.test.ts
+++ b/packages/webapp/tests/shell/ipk/ipk-require-e2e.test.ts
@@ -11,6 +11,8 @@ import 'fake-indexeddb/auto';
 import { gzipSync } from 'fflate';
 import type { SecureFetch } from 'just-bash';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 /** just-bash does not re-export SecureFetchOptions from its root entry. */
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -154,10 +156,6 @@ vi.mock('../../../src/shell/proxied-fetch.js', async (importOriginal) => {
 let dbCounter = 0;
 
 async function newShell() {
-  const { VirtualFS } = await import('../../../src/fs/index.js');
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   const fs = await VirtualFS.create({ dbName: `test-ipk-require-${dbCounter++}`, wipe: true });
   await fs.mkdir('/work', { recursive: true });
   const shell = new AlmostBashShellHeadless({ fs, cwd: '/work' });

--- a/packages/webapp/tests/shell/ipk/ipk-shell-integration.test.ts
+++ b/packages/webapp/tests/shell/ipk/ipk-shell-integration.test.ts
@@ -7,6 +7,8 @@ import 'fake-indexeddb/auto';
 import { gzipSync } from 'fflate';
 import type { SecureFetch } from 'just-bash';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 /** just-bash does not re-export SecureFetchOptions from its root entry. */
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -180,10 +182,6 @@ describe('ipk via real AlmostBashShellHeadless', () => {
   });
 
   async function newShell() {
-    const { VirtualFS } = await import('../../../src/fs/index.js');
-    const { AlmostBashShellHeadless } = await import(
-      '../../../src/shell/almost-bash-shell-headless.js'
-    );
     const fs = await VirtualFS.create({
       dbName: `test-ipk-shell-${dbCounter++}`,
       wipe: true,

--- a/packages/webapp/tests/shell/ipk/ipx-autoinstall-e2e.test.ts
+++ b/packages/webapp/tests/shell/ipk/ipx-autoinstall-e2e.test.ts
@@ -13,6 +13,8 @@ import 'fake-indexeddb/auto';
 import { gzipSync } from 'fflate';
 import type { SecureFetch } from 'just-bash';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 /** just-bash does not re-export SecureFetchOptions from its root entry. */
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -151,10 +153,6 @@ vi.mock('../../../src/shell/proxied-fetch.js', async (importOriginal) => {
 let dbCounter = 0;
 
 async function newShell() {
-  const { VirtualFS } = await import('../../../src/fs/index.js');
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   const fs = await VirtualFS.create({ dbName: `test-ipx-auto-${dbCounter++}`, wipe: true });
   await fs.mkdir('/work', { recursive: true });
   const shell = new AlmostBashShellHeadless({ fs, cwd: '/work' });

--- a/packages/webapp/tests/shell/ipk/ipx-errors-and-usage.test.ts
+++ b/packages/webapp/tests/shell/ipk/ipx-errors-and-usage.test.ts
@@ -14,6 +14,8 @@ import 'fake-indexeddb/auto';
 import { gzipSync } from 'fflate';
 import type { SecureFetch } from 'just-bash';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 /** just-bash does not re-export SecureFetchOptions from its root entry. */
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -150,10 +152,6 @@ vi.mock('../../../src/shell/proxied-fetch.js', async (importOriginal) => {
 let dbCounter = 0;
 
 async function newShell() {
-  const { VirtualFS } = await import('../../../src/fs/index.js');
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   const fs = await VirtualFS.create({ dbName: `test-ipx-err-${dbCounter++}`, wipe: true });
   await fs.mkdir('/work', { recursive: true });
   const shell = new AlmostBashShellHeadless({ fs, cwd: '/work' });

--- a/packages/webapp/tests/shell/ipk/ipx-run-installed-e2e.test.ts
+++ b/packages/webapp/tests/shell/ipk/ipx-run-installed-e2e.test.ts
@@ -14,6 +14,8 @@ import 'fake-indexeddb/auto';
 import { gzipSync } from 'fflate';
 import type { SecureFetch } from 'just-bash';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 /** just-bash does not re-export SecureFetchOptions from its root entry. */
 type SecureFetchOptions = NonNullable<Parameters<SecureFetch>[1]>;
@@ -149,10 +151,6 @@ vi.mock('../../../src/shell/proxied-fetch.js', async (importOriginal) => {
 let dbCounter = 0;
 
 async function newShell() {
-  const { VirtualFS } = await import('../../../src/fs/index.js');
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   const fs = await VirtualFS.create({ dbName: `test-ipx-${dbCounter++}`, wipe: true });
   await fs.mkdir('/work', { recursive: true });
   const shell = new AlmostBashShellHeadless({ fs, cwd: '/work' });

--- a/packages/webapp/tests/shell/ipk/npm-run-shell.test.ts
+++ b/packages/webapp/tests/shell/ipk/npm-run-shell.test.ts
@@ -9,15 +9,12 @@
  */
 import 'fake-indexeddb/auto';
 import { beforeEach, describe, expect, it } from 'vitest';
-import type { VirtualFS } from '../../../src/fs/index.js';
+import { VirtualFS } from '../../../src/fs/index.js';
+import { AlmostBashShellHeadless } from '../../../src/shell/almost-bash-shell-headless.js';
 
 let dbCounter = 0;
 
 async function newShell() {
-  const { VirtualFS } = await import('../../../src/fs/index.js');
-  const { AlmostBashShellHeadless } = await import(
-    '../../../src/shell/almost-bash-shell-headless.js'
-  );
   const fs = await VirtualFS.create({ dbName: `test-npm-run-shell-${dbCounter++}`, wipe: true });
   await fs.mkdir('/work', { recursive: true });
   const shell = new AlmostBashShellHeadless({ fs, cwd: '/work' });

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -3975,7 +3975,20 @@ const FRAME_HTML = `<!DOCTYPE html>
 // -- Conditional integration tests -------------------------------------------
 
 const chromePath = findChromeExecutable();
-const describeIntegration = chromePath ? describe : describe.skip;
+// Spawning a real Chrome inside the DEFAULT unit suite is irreducibly
+// environmental: under memory/CPU pressure the OS SIGKILLs it during launch and
+// the whole suite fails with `Chrome exited with code null before reporting CDP
+// port` — a machine-state failure, not a playwright-command regression. It also
+// only ever ran on machines that happen to have Chrome, so it was never a
+// uniform local gate.
+//
+// It stays a REAL gate in CI: the `test` job runs on ubuntu-latest, whose image
+// ships Google Chrome at /usr/bin/google-chrome, and sets
+// SLICC_CDP_LAUNCH_TIMEOUT_MS=60000 precisely for this suite's cold start.
+// Locally, opt in with SLICC_TEST_CHROME_INTEGRATION=1.
+const chromeIntegrationEnabled =
+  Boolean(process.env['CI']) || process.env['SLICC_TEST_CHROME_INTEGRATION'] === '1';
+const describeIntegration = chromePath && chromeIntegrationEnabled ? describe : describe.skip;
 const INTEGRATION_CDP_LAUNCH_TIMEOUT_MS = Math.max(getDefaultCdpLaunchTimeoutMs(), 60_000);
 
 describeIntegration('iframe integration', { timeout: 90_000 }, () => {

--- a/packages/webapp/tests/ui/boot/setup-standalone-prelude.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-standalone-prelude.test.ts
@@ -26,6 +26,14 @@ import type { BootStageLogger } from '../../../src/ui/boot/types.js';
  * attempts — so the real 3.1s `CDP_BRIDGE_CONNECT_RETRY_DELAYS_MS` budget was
  * pure wall clock burnt inside a 5s test timeout. The retry schedule itself is
  * covered by the `connectWithBoundedRetry` suite above, which injects `delays`.
+ *
+ * It is a deliberate NO-OP on the extension-leader transport branch:
+ * `createExtensionLeaderBrowser` builds its own browser and calls
+ * `connectWithBoundedRetry` without the seam, so those cases keep the real
+ * timer. They cost nothing anyway — their stubbed `connect` succeeds on the
+ * first attempt, so no backoff ever fires. Passing it uniformly keeps the
+ * deps literal identical across suites rather than making the reader work out
+ * which branch each case takes.
  */
 const instantSleep = async (): Promise<void> => {};
 

--- a/packages/webapp/tests/ui/boot/setup-standalone-prelude.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-standalone-prelude.test.ts
@@ -19,6 +19,16 @@ import {
 } from '../../../src/ui/boot/setup-standalone-prelude.js';
 import type { BootStageLogger } from '../../../src/ui/boot/types.js';
 
+/**
+ * Instant stand-in for the prelude's bounded-retry backoff. These suites
+ * assert what the prelude decides *around* the CDP connect (transport branch,
+ * `hasLocalCdpSurface`, tray seeding) — never how long it waits between
+ * attempts — so the real 3.1s `CDP_BRIDGE_CONNECT_RETRY_DELAYS_MS` budget was
+ * pure wall clock burnt inside a 5s test timeout. The retry schedule itself is
+ * covered by the `connectWithBoundedRetry` suite above, which injects `delays`.
+ */
+const instantSleep = async (): Promise<void> => {};
+
 function createLog(): BootStageLogger & {
   warnCalls: unknown[][];
   infoCalls: unknown[][];
@@ -206,6 +216,7 @@ describe('setupStandalonePrelude — extension leader transport selection', () =
     (globalThis as { chrome?: unknown }).chrome = { runtime: { connect } };
 
     const result = await setupStandalonePrelude({
+      sleep: instantSleep,
       runtimeMode: 'standalone',
       envBaseUrl: null,
       window: createFakeWindow('?slicc=leader&ext=test-ext-id'),
@@ -256,6 +267,7 @@ describe('setupStandalonePrelude — extension leader transport selection', () =
     (globalThis as { chrome?: unknown }).chrome = { runtime: { connect } };
 
     const result = await setupStandalonePrelude({
+      sleep: instantSleep,
       runtimeMode: 'standalone',
       envBaseUrl: null,
       window: createFakeWindow('?slicc=leader&ext=test-ext-id'),
@@ -328,6 +340,7 @@ describe('setupStandalonePrelude — extension leader transport selection', () =
     (globalThis as { chrome?: unknown }).chrome = { runtime: { connect } };
 
     const result = await setupStandalonePrelude({
+      sleep: instantSleep,
       runtimeMode: 'standalone',
       envBaseUrl: null,
       window: createFakeWindow('?slicc=leader&ext=test-ext-id'),
@@ -407,6 +420,7 @@ describe('setupStandalonePrelude — thin-bridge runtime-config origin', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const result = await setupStandalonePrelude({
+      sleep: instantSleep,
       runtimeMode: 'electron-overlay',
       envBaseUrl: null,
       window: createFakeWindow(search),
@@ -451,6 +465,7 @@ describe('setupStandalonePrelude — thin-bridge runtime-config origin', () => {
 
     try {
       await setupStandalonePrelude({
+        sleep: instantSleep,
         runtimeMode: 'electron-overlay',
         envBaseUrl: null,
         window: createFakeWindow(search),
@@ -484,6 +499,7 @@ describe('setupStandalonePrelude — thin-bridge runtime-config origin', () => {
 
     const fakeWindow = createFakeWindow(search);
     await setupStandalonePrelude({
+      sleep: instantSleep,
       runtimeMode: 'hosted-leader',
       envBaseUrl: null,
       window: fakeWindow,
@@ -541,6 +557,7 @@ describe('setupStandalonePrelude — hasLocalCdpSurface', () => {
     );
 
     const result = await setupStandalonePrelude({
+      sleep: instantSleep,
       runtimeMode: 'follower',
       envBaseUrl: null,
       window: createFakeWindow('?ws=files'),
@@ -557,6 +574,7 @@ describe('setupStandalonePrelude — hasLocalCdpSurface', () => {
     );
 
     const result = await setupStandalonePrelude({
+      sleep: instantSleep,
       runtimeMode: 'follower',
       envBaseUrl: null,
       window: createFakeWindow(
@@ -575,6 +593,7 @@ describe('setupStandalonePrelude — hasLocalCdpSurface', () => {
     );
 
     const result = await setupStandalonePrelude({
+      sleep: instantSleep,
       runtimeMode: 'follower',
       envBaseUrl: null,
       window: createFakeWindow('?bridge=ws%3A%2F%2Flocalhost%3A5710%2Fcdp'),

--- a/packages/webapp/tests/ui/panel-rpc-device-handlers.test.ts
+++ b/packages/webapp/tests/ui/panel-rpc-device-handlers.test.ts
@@ -448,7 +448,10 @@ describe('createStandalonePanelRpcHandlers — Web Serial', () => {
       handle,
       maxBytes: 10,
       until: new Uint8Array([0x0a]).buffer,
-      timeoutMs: 50,
+      // Budget for the mocked reader to deliver, not the behaviour under test:
+      // this asserts the bytes are FORWARDED. At 50ms a loaded machine could
+      // expire the read before the (async) mock resolved and return no bytes.
+      timeoutMs: 5000,
     });
     expect(new Uint8Array(read.bytes)).toEqual(new Uint8Array([1, 2, 3]));
     const w = await handlers['serial-write']!({

--- a/packages/webapp/tests/ui/wc/wc-follower.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-follower.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 // @vitest-environment-options { "url": "https://www.sliccy.ai/join/tray-1.cap-token" }
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { StartPageFollowerTrayOptions } from '../../../src/ui/page-follower-tray.js';
 import { installWcDomStubs } from './wc-dom-stubs.js';
 
@@ -95,6 +95,16 @@ function setCherryLocation(ancestorOrigin: string): void {
 }
 
 describe('mountWcUiFollower', () => {
+  // Warm the module graph ONCE, outside any test's budget. Every case here
+  // re-imports `wc-follower.js` after `vi.resetModules()` (deliberate — each
+  // needs a fresh instance), but `resetModules` only drops evaluated modules,
+  // never vitest's transform cache. So the FIRST importer paid the whole
+  // transform: ~2.9s idle, and >10s under load, which timed the first test out.
+  // Paying it in a hook keeps the one-time setup cost out of a per-test budget.
+  beforeAll(async () => {
+    await import('../../../src/ui/wc/wc-follower.js');
+  }, 60_000);
+
   beforeEach(() => {
     spawnSpy.mockClear();
     startFollowerSpy.mockClear();


### PR DESCRIPTION
## Summary

`npm run test` failed roughly once per run on a loaded 16-core laptop, always with `Test timed out in 5000ms` and always in a **different file**, while every failure passed in isolation. That moving target is timeout-budget exhaustion, not a single broken test: the victim is whichever already-slow test met peak contention.

Four independent causes, each measured rather than assumed. Nothing is skipped in CI, no `testTimeout` is raised, and production behaviour is unchanged.

## Why

The leading hypothesis was that `packages/webapp/tests/shell/ipk/*` hit the live npm registry. **It does not.** `createProxiedFetch` is `vi.mock`'d and the "nanoid"/"uuid"/"escape-string-regexp" packages are `.tgz` fixtures synthesized in-memory. There is no network dependency to gate and no real-path coverage at risk.

The actual causes:

1. **Heavy `await import()` inside a test body.** Vitest charges module transform + evaluation to whichever test triggers it, so the *first* test in a file paid for the whole graph and the rest cost nothing. Instrumented directly in `esm-schemes-jsh-e2e.test.ts`: first `newShell()` call **1347ms**, every later call **0ms**. Static imports move that to the collection phase, which no per-test timeout covers. This was already the convention next door in `discoverability.test.ts` and the `installer*` suites.

2. **Real production backoff in tests that assert something else.** `CDP_BRIDGE_CONNECT_RETRY_DELAYS_MS` is `[100, 200, 400, 800, 1600]` = **exactly 3100ms**, matching four `setup-standalone-prelude` tests measured at ~3130ms. They assert `hasLocalCdpSurface`, never retry timing — which `connectWithBoundedRetry`'s own suite already covers by injecting `delays`. Same story for the tray hibernation test, whose `webhookDeliveryWaitMs` seam has a docstring literally warning that a fake leader "would otherwise sit out the full production budget".

3. **Wall-clock assertions that only hold on an idle machine.** `expect(elapsed).toBeLessThan(50|100|150)` — observed failing at 117ms against a 100ms bound.

4. **A genuine shared-resource race** (this was asked about explicitly). Not a shared temp dir or a fixed port, but ephemeral-port recycling plus HTTP keep-alive pooling. `app.listen(0)` takes an ephemeral port; `server.close()` stops accepting but leaves established keep-alive sockets alive, pooled by the fetch client per `127.0.0.1:<port>`. The OS then recycles that port onto the next test's server and a pooled socket points at the wrong one. The tell is `hosted-bootstrap`:

   ```
   HTTPParserError: Response does not match the HTTP/1.1 protocol
     (Expected HTTP/, RTSP/ or ICE/)
   data: {"ok":false,"error":"Invalid JSON"}
   ```

   The client read a JSON body where a status line belongs, and that body belongs to no endpoint in the failing test. Three symptoms, one cause: `cloud-status` `expected 404 to be 200`, `hosted-bootstrap` crossed response, `fetch-proxy-dav` 5s timeout. (`requireLoopback` was ruled out as the 404's source — it answers 403.)

### Why CI never caught this

CI runs on `ubuntu-latest` (4 cores) versus this machine's 16 — far less parallelism, not a longer timeout. There is no `testTimeout` override anywhere; the default 5000ms applies in both.

### On the `iframe integration` failures

Worth correcting: these are **not** 5000ms test timeouts. That block has carried a 90s suite timeout since June (`74095fa4c`), and suite-level timeouts do cascade in Vitest 4.1.11 (verified with a scratch probe). The real signature, captured twice under load, is `Chrome exited with code null before reporting CDP port` — the OS SIGKILLing Chrome mid-launch. That fails the *suite*, so its 6 tests report as **skipped**, which reads a lot like "4 tests timed out".

## Approach / Implementation notes

- **`sleep` seam on `StandalonePreludeDeps` is optional and unused in production.** Neither `wc-live.ts` nor `wc-follower.ts` passes it, so the real timer still applies. It is deliberately scoped to the standalone/bridge branch and *not* threaded into `createExtensionLeaderBrowser`: that call sits inside `setupStandalonePrelude`, which is already at the 150-line biome cap, and that branch is not a backoff hotspot. The JSDoc says so explicitly.
- **`wc-follower.test.ts` imports were NOT hoisted.** It calls `vi.resetModules()` in every case, so the dynamic imports are load-bearing. But `resetModules` drops evaluated modules, never vitest's transform cache — so a `beforeAll` warm-up moves the one-time transform (~2.9s idle, >10s loaded) out of a per-test budget without changing isolation.
- **Real-Chrome gating keeps CI coverage.** `iframe integration` is now gated on `CI || SLICC_TEST_CHROME_INTEGRATION=1`. CI remains a real gate: `ubuntu-latest` ships Chrome at `/usr/bin/google-chrome`, and the `test` job already sets `SLICC_CDP_LAUNCH_TIMEOUT_MS=60000` specifically for this suite's cold start. Verified three ways — opt-in **301 tests**, `CI=1` **301 tests**, default **295 + 6 skipped**. The webapp coverage floor still passes with those 6 skipped.
- **Widened bounds keep their teeth.** Every one guards a regression worth >= 1000ms (awaiting a 1000/2000ms budget, a multi-second pid scan, a kill that never settles), so 500ms still catches it.
- `closeAllConnections()` is already the remedy used by `chrome-launch.test.ts` in the same package.

## Cross-cutting impact

- **Floats exercised**: none behaviourally. The only `src/` change is one optional field on `StandalonePreludeDeps` plus passing it through; both production callers omit it.
- **Coverage**: webapp, node-server and cloudflare-worker floors all pass, including with the 6 iframe tests skipped locally. No floor was touched.
- **Local vs CI divergence**: `npm run test` on a laptop no longer spawns a browser. This is the one deliberate behaviour change for developers, documented in the skill with the opt-in command.

## Test plan

- [x] `npm run verify` — 7/7
- [x] `npm run lint:ci`
- [x] `npm run typecheck` — all 9 projects
- [x] `npm run test` — 17962 passing, 0 failing
- [x] `npm run test:coverage:webapp` / `:node-server` / `:cloudflare-worker`
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — 33 files, 0 on any debt list

### Flake verification (the actual point of this PR)

A single green run proves nothing here, so this was measured as an A/B under identical synthetic load (24 CPU hogs on 16 cores, load average ~950), fix reverted vs applied via the same patch:

| arm | runs with a failure |
| --- | --- |
| before (fix reverted) | **7 / 8** |
| after round 1-2 | 4 / 10 |
| after round 3 | 2 / 10 |
| **after round 4 (this PR)** | **0 / 12** |
| unloaded, default concurrency | **0 / 5** |

**17/17 green.** Each intermediate arm is reported because each one surfaced the next-weakest link — the 4/10 arm is how `host-lick-ws-gate.test.ts` and the wall-clock class were found at all.

### Coverage was not silently lost

Every change was mutation-tested — the guarded behaviour was deliberately broken to confirm the tests still fail:

| mutation | result |
| --- | --- |
| ipk installs land in a bogus dir | **70 tests / 13 files fail** |
| `hasLocalCdpSurface` forced `true` | 2 prelude tests fail (in 19ms / 15ms, vs 3.13s before) |
| hibernation recovery returns no sockets | 2 cloudflare tests fail |
| `waitForScoops` regressed into a real wait | fails with `expected 1004 to be less than 500` |

**Pre-existing / unrelated:** `zenfs-dom-truncate-upstream.test.ts` failed after rebasing until `npm install` picked up main's `@zenfs/dom` 1.2.11 bump (`1b8732f2a`, `2ed19fc7d`). That guard test was correctly detecting a stale `node_modules`, not a regression here.

## Documentation

- [x] `.agents/skills/writing-slicc-tests/SKILL.md` — new **"Keep Tests Inside the Timeout Budget"** section covering all three test-authoring patterns, with the measured numbers and the Chrome opt-in command.

## Risk & rollback

- Blast radius is test-only apart from one optional, unused-in-production dependency field. Reverts cleanly; no persisted state, no migration.
- **Known, not fixed:** `makeRequest` in `cloud-status.test.ts` reads `server.address()` without awaiting the `listening` event. That is a latent bug in the helper independent of the race fixed here; I did not conflate the two.
- Worth a reviewer's judgement: making `iframe integration` opt-in locally is a real (if deliberate) reduction in default local coverage. The argument for it is that it was never a uniform gate — it silently skipped on any machine without Chrome — and its failure mode is the OS killing a process, which no amount of test hardening can prevent.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] No public API / tool / shell-command / lick-channel changes
- [x] No cross-float contract changes
