### PR TITLE
refactor: pay down boy-scout debt in packages/node-server/src/electron-runtime.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -3,7 +3,6 @@
   "packages/cloud-core/src/cone-config/index.ts": 6,
   "packages/dev-tools/tools/extension-smoke-test.ts": 6,
   "packages/node-server/src/electron-controller.ts": 13,
-  "packages/node-server/src/electron-runtime.ts": 1,
   "packages/shared-ts/src/transcript-export.ts": 18,
   "packages/webapp/providers/adobe.ts": 1,
   "packages/webapp/providers/github-copilot.ts": 2,

--- a/packages/node-server/src/electron-runtime.ts
+++ b/packages/node-server/src/electron-runtime.ts
@@ -314,6 +314,16 @@ export function getElectronOverlayEntryDistPath(projectRoot: string): string {
   return resolve(projectRoot, 'dist/ui/electron-overlay-entry.js');
 }
 
+/** Payload passed to `window.__SLICC_ELECTRON_OVERLAY__.inject()` — mirrors spoon's `InjectSliccLauncherOptions`. */
+export interface ElectronOverlayInjectionPayload {
+  appUrl: string;
+  open?: boolean;
+  activeTab?: string;
+  /** Empty-viewport message for the status-only overlay (apps that block the
+   *  embedded panel, e.g. Signal). Only meaningful when `appUrl` is empty. */
+  statusMessage?: string;
+}
+
 export function buildElectronOverlayInjectionCall(options: {
   appUrl: string;
   open?: boolean;
@@ -322,18 +332,18 @@ export function buildElectronOverlayInjectionCall(options: {
    *  embedded panel, e.g. Signal). Only meaningful when `appUrl` is empty. */
   statusMessage?: string;
 }): string {
-  const payload: Record<string, unknown> = {
+  const payload: ElectronOverlayInjectionPayload = {
     appUrl: options.appUrl,
   };
 
   if (typeof options.open === 'boolean') {
-    payload['open'] = options.open;
+    payload.open = options.open;
   }
   if (options.activeTab) {
-    payload['activeTab'] = options.activeTab;
+    payload.activeTab = options.activeTab;
   }
   if (options.statusMessage !== undefined) {
-    payload['statusMessage'] = options.statusMessage;
+    payload.statusMessage = options.statusMessage;
   }
 
   // Wait for document.body before injecting — Runtime.evaluate and


### PR DESCRIPTION
## Summary

- Replaced `Record<string, unknown>` in `buildElectronOverlayInjectionCall` with a named `ElectronOverlayInjectionPayload` interface that mirrors spoon's `InjectSliccLauncherOptions`.
- Ratcheted `record-string-unknown-baseline.json` to remove the file entry.

## Debt cleared

- `record-string-unknown` — `packages/node-server/src/electron-runtime.ts`

## Verification

- `npx biome check --write packages/node-server/src/electron-runtime.ts`
- `npm run typecheck`
- `npx vitest run packages/node-server/tests/electron-runtime.test.ts` (24 tests)
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK