### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/git/commands/rebase.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -13,7 +13,6 @@
   "packages/webapp/src/cdp/har-recorder.ts": 10,
   "packages/webapp/src/cdp/navigation-watcher.ts": 11,
   "packages/webapp/src/fs/mount/backend-local.ts": 1,
-  "packages/webapp/src/git/commands/rebase.ts": 1,
   "packages/webapp/src/kernel/realm/http-global.ts": 2,
   "packages/webapp/src/kernel/realm/py-realm-shared.ts": 1,
   "packages/webapp/src/kernel/telemetry.ts": 1,

--- a/packages/webapp/src/git/commands/rebase.ts
+++ b/packages/webapp/src/git/commands/rebase.ts
@@ -17,7 +17,7 @@
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
 import { makeMergeDriver } from './merge-driver.js';
-import { expandGitError, GIT_FLAG_SPECS } from './shared.js';
+import { expandGitError, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 /** Coerce an mri flag value (string | string[] | undefined) to a string[]. */
@@ -71,7 +71,7 @@ async function startRebase(
   ctx: GitCommandContext,
   cwd: string,
   upstream: string | undefined,
-  flags: Record<string, unknown>
+  flags: GitParsedFlags
 ): Promise<GitCommandResult> {
   if (!upstream) {
     return { stdout: '', stderr: 'fatal: No upstream specified.\n', exitCode: 128 };


### PR DESCRIPTION
## Summary

- Replace `Record<string, unknown>` with `GitParsedFlags` on `startRebase`'s flags parameter, matching the pattern used by other git command handlers (`tag`, `show`, `log`, `fetch`, `clone`, etc.).
- Ratchet `record-string-unknown-baseline.json` to remove the file entry.

## Debt cleared

- `record-string-unknown` — `packages/webapp/src/git/commands/rebase.ts`

## Verification

- `npx biome check --write packages/webapp/src/git/commands/rebase.ts`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/git/git-commands.test.ts -t rebase` (13 tests passed)
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK