### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/serial-command.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -8,6 +8,5 @@
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/rsync-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/secret-backends.ts": 2,
-  "packages/webapp/src/shell/supplemental-commands/serial-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/serve-command.ts": 3
 }

--- a/packages/webapp/src/shell/supplemental-commands/serial-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/serial-command.ts
@@ -14,6 +14,7 @@
 
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
+import { getToolExecutionContext } from '../../base/tool-execution-context.js';
 import { getPanelRpcClient, hasLocalDom } from '../../kernel/panel-rpc.js';
 import type {
   SerialDeviceInfo,
@@ -28,7 +29,6 @@ import {
   MAX_SERIAL_TRANSFER_BYTES,
   deviceToInfo as serialPortToInfo,
 } from '../../kernel/serial-port-registry.js';
-import { getToolExecutionContext } from '../../tools/tool-ui.js';
 import { parseFlagArgs } from '../arg-parser.js';
 import { stdinAsLatin1 } from '../just-bash-compat.js';
 import { runDevicePickerApproval } from './picker-approval.js';


### PR DESCRIPTION
## Summary

- Remove the `shell → tools` layer back-edge in `serial-command.ts` by importing `getToolExecutionContext` from `base/tool-execution-context.js` instead of `tools/tool-ui.js` (same pattern as `usb-command.ts` and `mount-commands.ts`).
- Ratchet `layer-back-edge-baseline.json` via `check-layer-back-edges.mjs --update` (cleared `serial-command.ts` entry).

## Debt cleared

- `layer-back-edge` — 1 back-edge removed

## Verification

- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/serial-command.test.ts` (20 tests)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK