### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/rsync-command.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -6,7 +6,6 @@
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/interaction.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/state.ts": 4,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 2,
-  "packages/webapp/src/shell/supplemental-commands/rsync-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/secret-backends.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/serial-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/serve-command.ts": 3

--- a/packages/webapp/src/shell/supplemental-commands/rsync-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/rsync-command.ts
@@ -12,11 +12,15 @@
  *   --help, -h   Show usage
  */
 
-import { base64ToUint8, uint8ToBase64 } from '@slicc/shared-ts';
+import {
+  base64ToUint8,
+  type TrayFsRequest,
+  type TrayFsResponse,
+  uint8ToBase64,
+} from '@slicc/shared-ts';
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
 import type { VirtualFS } from '../../fs/index.js';
-import type { TrayFsRequest, TrayFsResponse } from '../../scoops/tray-sync-protocol.js';
 import { computeRsyncDiff, type RsyncEntry } from './rsync-diff.js';
 
 // ---------------------------------------------------------------------------

--- a/packages/webapp/tests/shell/supplemental-commands/rsync-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/rsync-command.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import 'fake-indexeddb/auto';
+import type { TrayFsRequest, TrayFsResponse } from '@slicc/shared-ts';
 import { VirtualFS } from '../../../src/fs/virtual-fs.js';
-import type { TrayFsRequest, TrayFsResponse } from '../../../src/scoops/tray-sync-protocol.js';
 import {
   createRsyncCommand,
   parseRsyncArgs,


### PR DESCRIPTION
## Summary

- Remove the shell→scoops layer back-edge in `rsync-command.ts` by importing `TrayFsRequest` / `TrayFsResponse` from `@slicc/shared-ts` (their canonical home) instead of `scoops/tray-sync-protocol.js`.
- Align the rsync test imports with the same source.
- Ratchet `layer-back-edge-baseline.json` (21 → 20 grandfathered back-edges).

## Debt cleared

- **layer-back-edge** — `packages/webapp/src/shell/supplemental-commands/rsync-command.ts`

## Verification

- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/rsync-command.test.ts` (18 tests)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK
- Pre-push hooks: biome, custom-lints, boy-scout-debt, deadcode