### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/hid-command.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -2,7 +2,6 @@
   "packages/webapp/src/cdp/har-recorder.ts": 1,
   "packages/webapp/src/fs/mount/backend-local.ts": 2,
   "packages/webapp/src/shell/bsh-watchdog.ts": 3,
-  "packages/webapp/src/shell/supplemental-commands/hid-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/interaction.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/state.ts": 4,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 2,

--- a/packages/webapp/src/shell/supplemental-commands/hid-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/hid-command.ts
@@ -20,6 +20,7 @@
 
 import type { Command } from 'just-bash';
 import { defineCommand } from 'just-bash';
+import { getToolExecutionContext } from '../../base/tool-execution-context.js';
 import {
   getNavigatorHid,
   getSharedHidRegistry,
@@ -28,7 +29,6 @@ import {
   MAX_HID_REPORT_BYTES,
 } from '../../kernel/hid-device-registry.js';
 import { getPanelRpcClient, hasLocalDom } from '../../kernel/panel-rpc.js';
-import { getToolExecutionContext } from '../../tools/tool-ui.js';
 import { parseFlagArgs } from '../arg-parser.js';
 import { stdinAsLatin1 } from '../just-bash-compat.js';
 import { type HidBackend, type HidInputReport, resolveHidBackend } from './hid-backends.js';


### PR DESCRIPTION
## Summary

- Import `getToolExecutionContext` from `base/tool-execution-context.js` instead of `tools/tool-ui.js`, removing the shell→tools layer back-edge in `hid-command.ts` (same pattern as the recent `usb-command.ts` cleanup).
- Ratchet `layer-back-edge-baseline.json` via `check-layer-back-edges.mjs --update`.

## Debt cleared

- `layer-back-edge` — `packages/webapp/src/shell/supplemental-commands/hid-command.ts`

## Verification

- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/hid-command.test.ts` (25 tests)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK