### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/providers/built-in/azure-openai.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -17,7 +17,6 @@
   "packages/webapp/src/kernel/realm/py-realm-shared.ts": 1,
   "packages/webapp/src/kernel/telemetry.ts": 1,
   "packages/webapp/src/net/link-header.ts": 1,
-  "packages/webapp/src/providers/built-in/azure-openai.ts": 2,
   "packages/webapp/src/providers/built-in/bedrock-camp.ts": 31,
   "packages/webapp/src/providers/built-in/local-llm.ts": 2,
   "packages/webapp/src/providers/intercepted-oauth.ts": 4,

--- a/packages/webapp/src/providers/built-in/azure-openai.ts
+++ b/packages/webapp/src/providers/built-in/azure-openai.ts
@@ -30,6 +30,7 @@ import type {
   ChatCompletionMessageParam,
   ChatCompletionTool,
 } from 'openai/resources/chat/completions';
+import type { FunctionParameters } from 'openai/resources/shared';
 import { getApiVersionForProvider, getDeploymentForProvider } from '../account-store.js';
 import type { ProviderConfig } from '../types.js';
 
@@ -81,7 +82,7 @@ interface ContentBlock {
   data?: string;
   id?: string;
   name?: string;
-  arguments?: Record<string, unknown>;
+  arguments?: ToolCall['arguments'];
   toolCallId?: string;
   isError?: boolean;
   content?: ContentBlock[];
@@ -161,7 +162,7 @@ function convertTools(tools: Context['tools']): ChatCompletionTool[] | undefined
     function: {
       name: t.name,
       description: t.description,
-      parameters: t.parameters as Record<string, unknown>,
+      parameters: t.parameters as FunctionParameters,
     },
   }));
 }


### PR DESCRIPTION
## Summary

- Replace `Record<string, unknown>` in `azure-openai.ts` with named types: `ToolCall['arguments']` for transformed tool-call args and OpenAI `FunctionParameters` for chat tool schemas.
- Ratchet `record-string-unknown-baseline.json` (removed the file’s 2 grandfathered occurrences).

## Debt cleared

- `record-string-unknown` — `packages/webapp/src/providers/built-in/azure-openai.ts`

## Verification

- `npx biome check --write packages/webapp/src/providers/built-in/azure-openai.ts`
- `npm run typecheck`
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK