### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/secret-backends.ts

### DIFF
--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -5,6 +5,5 @@
   "packages/webapp/src/shell/supplemental-commands/hid-command.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/handlers/interaction.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 2,
-  "packages/webapp/src/shell/supplemental-commands/secret-backends.ts": 2,
   "packages/webapp/src/shell/supplemental-commands/serve-command.ts": 3
 }

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -23,7 +23,6 @@
   "packages/webapp/src/scoops/tray-leader/cdp-router.ts": 5,
   "packages/webapp/src/shell/bsh-watchdog.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 5,
-  "packages/webapp/src/shell/supplemental-commands/secret-backends.ts": 3,
   "packages/webapp/src/shell/supplemental-commands/websocat-command.ts": 1,
   "packages/webapp/src/skills/catalog.ts": 3,
   "packages/webapp/src/speech/hear.ts": 1,

--- a/packages/webapp/src/core/secrets-bridge-client.ts
+++ b/packages/webapp/src/core/secrets-bridge-client.ts
@@ -1,62 +1,9 @@
 /**
- * Bridge client for the `secrets.crud` Port (EXT7, thin-extension topology).
- *
- * In the hosted-leader tab / kernel worker the agent realm cannot use the
- * same-extension `chrome.runtime.sendMessage` path (no `chrome.runtime.id`), so
- * secret-CRUD / feed / scrub control messages are routed to the extension over
- * an externally-connectable `chrome.runtime.connect(<delegateId>, { name:
- * 'secrets.crud' })` Port — the SW side mirrors the `fetch-proxy.fetch` handler.
- *
- * The transport skeleton (cached Port, correlation, panel-RPC fallback) lives
- * in `kernel/port-bridge-client.ts`; this file only owns the per-call-site
- * policy: `secrets.crud` Port name, 10s timeout, best-effort semantics (secrets
- * never block boot — unavailable / timeout / no panel-RPC client resolve
- * `undefined`), and the Port message shape `{ id, type, ...payload }`.
- *
- * Payloads are secret-adjacent — only the control `type` is ever logged.
+ * Back-compat re-export. The secrets bridge client lives in the shell transport
+ * layer because extension-delegate routing is configured by `proxied-fetch.ts`.
+ * Existing core call sites keep importing `callSecretsBridge` from here unchanged.
  */
-
-import { createPortBridgeClient } from '../kernel/port-bridge-client.js';
-
-/** Per-call timeout; multi-MB downloads aren't on this path, so 10s is ample. */
-const CALL_TIMEOUT_MS = 10_000;
-
-/**
- * The fields of a `secrets.crud` control message beyond its `type`. Genuinely
- * untyped at this layer: the shape is whatever the named SW secrets handler
- * declares, and the bridge relays it without inspecting — mirroring the
- * `secrets-bridge` payload in `kernel/panel-rpc.ts`.
- */
-// biome-ignore lint/plugin: the fields are whatever the named SW secrets handler declares; the bridge relays them without inspecting.
-export type SecretsBridgePayload = Record<string, unknown>;
-
-interface SecretsBridgeRequest {
-  type: string;
-  payload?: SecretsBridgePayload;
-}
-
-const call = createPortBridgeClient<SecretsBridgeRequest, unknown>({
-  portName: 'secrets.crud',
-  panelRpcOp: 'secrets-bridge',
-  timeoutMs: CALL_TIMEOUT_MS,
-  onUnavailable: 'resolve-undefined',
-  makeError: (message) => new Error(message),
-  logNamespace: 'secrets-bridge',
-  toPortMessage: ({ type, payload }) => ({ type, ...payload }),
-  toPanelRpcPayload: ({ type, payload }) => ({ type, payload }),
-});
-
-/**
- * Dispatch a `secrets.crud` control message and await the correlated reply.
- * Realm-aware — see `createPortBridgeClient`. Resolves with the handler's
- * `response` shape, or `undefined` when the bridge is unavailable or the call
- * times out (best-effort). Rejects only if the Port disconnects mid-flight or
- * `postMessage` throws — the Wave 2 call sites map both to their existing safe
- * defaults.
- */
-export function callSecretsBridge<T = unknown>(
-  type: string,
-  payload?: SecretsBridgePayload
-): Promise<T> {
-  return call({ type, payload }) as Promise<T>;
-}
+export {
+  callSecretsBridge,
+  type SecretsBridgePayload,
+} from '../shell/secrets-bridge-client.js';

--- a/packages/webapp/src/shell/secrets-bridge-client.ts
+++ b/packages/webapp/src/shell/secrets-bridge-client.ts
@@ -1,0 +1,62 @@
+/**
+ * Bridge client for the `secrets.crud` Port (EXT7, thin-extension topology).
+ *
+ * In the hosted-leader tab / kernel worker the agent realm cannot use the
+ * same-extension `chrome.runtime.sendMessage` path (no `chrome.runtime.id`), so
+ * secret-CRUD / feed / scrub control messages are routed to the extension over
+ * an externally-connectable `chrome.runtime.connect(<delegateId>, { name:
+ * 'secrets.crud' })` Port — the SW side mirrors the `fetch-proxy.fetch` handler.
+ *
+ * The transport skeleton (cached Port, correlation, panel-RPC fallback) lives
+ * in `kernel/port-bridge-client.ts`; this file only owns the per-call-site
+ * policy: `secrets.crud` Port name, 10s timeout, best-effort semantics (secrets
+ * never block boot — unavailable / timeout / no panel-RPC client resolve
+ * `undefined`), and the Port message shape `{ id, type, ...payload }`.
+ *
+ * Payloads are secret-adjacent — only the control `type` is ever logged.
+ */
+
+import { createPortBridgeClient } from '../kernel/port-bridge-client.js';
+
+/** Per-call timeout; multi-MB downloads aren't on this path, so 10s is ample. */
+const CALL_TIMEOUT_MS = 10_000;
+
+/**
+ * The fields of a `secrets.crud` control message beyond its `type`. Genuinely
+ * untyped at this layer: the shape is whatever the named SW secrets handler
+ * declares, and the bridge relays it without inspecting — mirroring the
+ * `secrets-bridge` payload in `kernel/panel-rpc.ts`.
+ */
+// biome-ignore lint/plugin: the fields are whatever the named SW secrets handler declares; the bridge relays them without inspecting.
+export type SecretsBridgePayload = Record<string, unknown>;
+
+interface SecretsBridgeRequest {
+  type: string;
+  payload?: SecretsBridgePayload;
+}
+
+const call = createPortBridgeClient<SecretsBridgeRequest, unknown>({
+  portName: 'secrets.crud',
+  panelRpcOp: 'secrets-bridge',
+  timeoutMs: CALL_TIMEOUT_MS,
+  onUnavailable: 'resolve-undefined',
+  makeError: (message) => new Error(message),
+  logNamespace: 'secrets-bridge',
+  toPortMessage: ({ type, payload }) => ({ type, ...payload }),
+  toPanelRpcPayload: ({ type, payload }) => ({ type, payload }),
+});
+
+/**
+ * Dispatch a `secrets.crud` control message and await the correlated reply.
+ * Realm-aware — see `createPortBridgeClient`. Resolves with the handler's
+ * `response` shape, or `undefined` when the bridge is unavailable or the call
+ * times out (best-effort). Rejects only if the Port disconnects mid-flight or
+ * `postMessage` throws — the Wave 2 call sites map both to their existing safe
+ * defaults.
+ */
+export function callSecretsBridge<T = unknown>(
+  type: string,
+  payload?: SecretsBridgePayload
+): Promise<T> {
+  return call({ type, payload }) as Promise<T>;
+}

--- a/packages/webapp/src/shell/supplemental-commands/secret-backends.ts
+++ b/packages/webapp/src/shell/supplemental-commands/secret-backends.ts
@@ -14,9 +14,9 @@
  * no extra headers.
  */
 
-import type { SecretTopology } from '../../core/secret-topology.js';
-import { callSecretsBridge } from '../../core/secrets-bridge-client.js';
+import type { FloatTopology } from '../float-topology.js';
 import { apiHeaders, resolveApiUrl } from '../proxied-fetch.js';
+import { callSecretsBridge } from '../secrets-bridge-client.js';
 
 /** A secret's identity + scope, without its value. */
 export interface SecretRecord {
@@ -63,7 +63,18 @@ export interface SecretBackend {
   delete(name: string): Promise<DeleteResult>;
 }
 
-function swSendMessage<T>(msg: Record<string, unknown>): Promise<T> {
+/** Control messages routed to SECRETS_HANDLERS in the service worker. */
+type SecretsControlMessage =
+  | { type: 'secrets.list' }
+  | { type: 'secrets.session.list' }
+  | { type: 'secrets.list-masked-entries' }
+  | { type: 'secrets.peek'; name: string }
+  | { type: 'secrets.session.set'; name: string; value: string; domains: string[] }
+  | { type: 'secrets.set'; name: string; value: string; domains: string[] }
+  | { type: 'secrets.set-domains'; name: string; domains: string[] }
+  | { type: 'secrets.delete'; name: string };
+
+function swSendMessage<T>(msg: SecretsControlMessage): Promise<T> {
   return new Promise((resolve, reject) => {
     chrome.runtime.sendMessage(msg, (response: unknown) => {
       const err = chrome.runtime.lastError;
@@ -156,9 +167,9 @@ export function createCliSecretBackend(): SecretBackend {
  * optional-chaining/error handling below are identical across both.
  */
 function createMessageSecretBackend(
-  send: (msg: Record<string, unknown>) => Promise<unknown>
+  send: (msg: SecretsControlMessage) => Promise<unknown>
 ): SecretBackend {
-  const call = <T>(msg: Record<string, unknown>): Promise<T> => send(msg) as Promise<T>;
+  const call = <T>(msg: SecretsControlMessage): Promise<T> => send(msg) as Promise<T>;
   return {
     async list() {
       const [persisted, session] = await Promise.all([
@@ -268,7 +279,7 @@ function errOf(data: unknown): string | undefined {
  * same-extension SW path; everything else (CLI / Electron / swift / connect)
  * talks to the node-server REST surface.
  */
-export function createDefaultSecretBackend(topology: SecretTopology): SecretBackend {
+export function createDefaultSecretBackend(topology: FloatTopology): SecretBackend {
   switch (topology) {
     case 'extension-direct':
       return createExtensionSecretBackend();


### PR DESCRIPTION
## Summary

- Moved `secrets-bridge-client` into the shell transport layer (same pattern as `float-topology`) and re-exported from `core/` for back-compat, removing two layer-back-edge imports from `secret-backends.ts`.
- Replaced three `Record<string, unknown>` message bags with a named `SecretsControlMessage` discriminated union.
- Ratcheted `layer-back-edge-baseline.json` and `record-string-unknown-baseline.json` to drop `secret-backends.ts`.

## Debt cleared

- `layer-back-edge` (2 back-edges: `core/secret-topology`, `core/secrets-bridge-client`)
- `record-string-unknown` (3 occurrences)

## Verification

- `npx biome check --write` on touched files
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/shell/supplemental-commands/secret-backends.test.ts packages/webapp/tests/core/secrets-bridge-client.test.ts`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK