### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/providers/xai-grok.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -313,7 +313,6 @@
         "packages/webapp/cloud/app.js",
         "packages/webapp/providers/adobe.ts",
         "packages/webapp/providers/openai-codex.ts",
-        "packages/webapp/providers/xai-grok.ts",
         "packages/webapp/src/cdp/har-recorder.ts",
         "packages/webapp/src/providers/built-in/bedrock-camp.ts",
         "packages/webapp/src/providers/intercepted-oauth.ts",

--- a/packages/webapp/providers/xai-grok.ts
+++ b/packages/webapp/providers/xai-grok.ts
@@ -259,63 +259,79 @@ function withGrokConvHeader(
   return { ...(base ?? {}), 'x-grok-conv-id': sessionId };
 }
 
+type XaiEventStream = ReturnType<typeof createAssistantMessageEventStream>;
+
+function logStreamError(error: unknown): void {
+  console.error('[xai-grok] Stream error:', error instanceof Error ? error.message : String(error));
+}
+
+async function pumpXaiStream(
+  stream: XaiEventStream,
+  model: Model<Api>,
+  context: Context,
+  options: ProviderStreamOptions
+): Promise<void> {
+  try {
+    const accessToken = await getValidAccessToken();
+    const sessionId = (options as { sessionId?: string }).sessionId;
+    const nativeModel = resolveNativeXaiModel(model);
+    const forwardedOptions = {
+      ...options,
+      apiKey: accessToken,
+      headers: withGrokConvHeader(options.headers, sessionId),
+    };
+    const inner =
+      nativeModel.api === 'openai-responses'
+        ? streamOpenAIResponses(nativeModel, context, forwardedOptions)
+        : streamOpenAICompletions(nativeModel, context, forwardedOptions);
+    for await (const event of inner) stream.push(event);
+    stream.end();
+  } catch (error) {
+    logStreamError(error);
+    stream.push(makeErrorOutput(model, error));
+    stream.end();
+  }
+}
+
+async function pumpSimpleXaiStream(
+  stream: XaiEventStream,
+  model: Model<Api>,
+  context: Context,
+  options?: SimpleStreamOptions
+): Promise<void> {
+  try {
+    const accessToken = await getValidAccessToken();
+    const sessionId = (options as { sessionId?: string } | undefined)?.sessionId;
+    const nativeModel = resolveNativeXaiModel(model);
+    const forwardedOptions: SimpleStreamOptions = {
+      ...options,
+      apiKey: accessToken,
+      headers: withGrokConvHeader(options?.headers, sessionId),
+    };
+    const inner =
+      nativeModel.api === 'openai-responses'
+        ? streamSimpleOpenAIResponses(nativeModel, context, forwardedOptions)
+        : streamSimpleOpenAICompletions(nativeModel, context, forwardedOptions);
+    for await (const event of inner) stream.push(event);
+    stream.end();
+  } catch (error) {
+    logStreamError(error);
+    stream.push(makeErrorOutput(model, error));
+    stream.end();
+  }
+}
+
 const streamXai = (model: Model<Api>, context: Context, options: ProviderStreamOptions = {}) => {
   const stream = createAssistantMessageEventStream();
-  (async () => {
-    try {
-      const accessToken = await getValidAccessToken();
-      const sessionId = (options as { sessionId?: string }).sessionId;
-      const nativeModel = resolveNativeXaiModel(model);
-      const forwardedOptions = {
-        ...options,
-        apiKey: accessToken,
-        headers: withGrokConvHeader(options.headers, sessionId),
-      };
-      const inner =
-        nativeModel.api === 'openai-responses'
-          ? streamOpenAIResponses(nativeModel, context, forwardedOptions)
-          : streamOpenAICompletions(nativeModel, context, forwardedOptions);
-      for await (const event of inner) stream.push(event);
-      stream.end();
-    } catch (error) {
-      console.error(
-        '[xai-grok] Stream error:',
-        error instanceof Error ? error.message : String(error)
-      );
-      stream.push(makeErrorOutput(model, error));
-      stream.end();
-    }
-  })();
+  // Fire-and-forget pump — callers consume the returned event stream.
+  pumpXaiStream(stream, model, context, options).catch(logStreamError);
   return stream;
 };
 
 const streamSimpleXai = (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => {
   const stream = createAssistantMessageEventStream();
-  (async () => {
-    try {
-      const accessToken = await getValidAccessToken();
-      const sessionId = (options as { sessionId?: string } | undefined)?.sessionId;
-      const nativeModel = resolveNativeXaiModel(model);
-      const forwardedOptions: SimpleStreamOptions = {
-        ...options,
-        apiKey: accessToken,
-        headers: withGrokConvHeader(options?.headers, sessionId),
-      };
-      const inner =
-        nativeModel.api === 'openai-responses'
-          ? streamSimpleOpenAIResponses(nativeModel, context, forwardedOptions)
-          : streamSimpleOpenAICompletions(nativeModel, context, forwardedOptions);
-      for await (const event of inner) stream.push(event);
-      stream.end();
-    } catch (error) {
-      console.error(
-        '[xai-grok] Stream error:',
-        error instanceof Error ? error.message : String(error)
-      );
-      stream.push(makeErrorOutput(model, error));
-      stream.end();
-    }
-  })();
+  // Fire-and-forget pump — callers consume the returned event stream.
+  pumpSimpleXaiStream(stream, model, context, options).catch(logStreamError);
   return stream;
 };
 


### PR DESCRIPTION
## Summary

- Replaced inline async IIFEs in `streamXai` / `streamSimpleXai` with named `pumpXaiStream` / `pumpSimpleXaiStream` helpers that attach `.catch(logStreamError)` for intentional fire-and-forget streaming.
- Removed `packages/webapp/providers/xai-grok.ts` from the `nursery.noFloatingPromises: "off"` biome override list.

## Debt cleared

- **floating-promise** — all promises in the file are now awaited, returned, or explicitly handled.

## Verification

- `npx biome check --write packages/webapp/providers/xai-grok.ts biome.json`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/providers/xai-grok.test.ts`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK