### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/providers/built-in/local-llm.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -17,7 +17,6 @@
   "packages/webapp/src/net/link-header.ts": 1,
   "packages/webapp/src/providers/built-in/azure-openai.ts": 2,
   "packages/webapp/src/providers/built-in/bedrock-camp.ts": 31,
-  "packages/webapp/src/providers/built-in/local-llm.ts": 2,
   "packages/webapp/src/providers/intercepted-oauth.ts": 4,
   "packages/webapp/src/scoops/onboarding-orchestrator.ts": 1,
   "packages/webapp/src/scoops/tray-leader/cdp-router.ts": 5,

--- a/packages/webapp/src/providers/built-in/local-llm.ts
+++ b/packages/webapp/src/providers/built-in/local-llm.ts
@@ -277,6 +277,29 @@ export interface LocalLlmConnectionResult {
   };
 }
 
+/** LM Studio native `/api/v0/models` probe shape (`object: 'list'`). */
+interface LmStudioModelsProbe {
+  object: 'list';
+}
+
+/** llama.cpp `llama-server` `/props` probe shape. */
+interface LlamaCppPropsProbe {
+  build_info?: { version?: string };
+}
+
+function isLmStudioModelsProbe(value: unknown): value is LmStudioModelsProbe {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'object' in value &&
+    (value as LmStudioModelsProbe).object === 'list'
+  );
+}
+
+function isLlamaCppPropsProbe(value: unknown): value is LlamaCppPropsProbe {
+  return typeof value === 'object' && value !== null && 'build_info' in value;
+}
+
 /** Return the origin (scheme://host:port) of an OpenAI base URL.
  *  e.g. "http://localhost:11434/v1" -> "http://localhost:11434". */
 export function originOf(baseUrl: string): string {
@@ -340,14 +363,13 @@ export async function detectRuntime(
   // to LM Studio's known response shape (`{ object: 'list', data: [...] }`)
   // so any random JSON-200 at that path doesn't get misidentified.
   const lmstudio = await tryJson(`${origin}/api/v0/models`, signal);
-  if (lmstudio && (lmstudio as Record<string, unknown>).object === 'list') {
+  if (isLmStudioModelsProbe(lmstudio)) {
     return { kind: 'lmstudio' };
   }
   // llama.cpp's llama-server exposes /props with build_info etc.
   const llamacpp = await tryJson(`${origin}/props`, signal);
-  if (llamacpp && 'build_info' in (llamacpp as Record<string, unknown>)) {
-    const build = (llamacpp as { build_info?: { version?: string } }).build_info;
-    return { kind: 'llamacpp', version: build?.version };
+  if (isLlamaCppPropsProbe(llamacpp)) {
+    return { kind: 'llamacpp', version: llamacpp.build_info?.version };
   }
   // Heuristic fallback by port — best-effort, never wrong-blocks the user.
   const port = safePort(baseUrl);


### PR DESCRIPTION
## Summary

- Replaced two `Record<string, unknown>` runtime fingerprint casts in `detectRuntime()` with named probe types (`LmStudioModelsProbe`, `LlamaCppPropsProbe`) and dedicated type guards.
- Ratcheted `record-string-unknown-baseline.json` (removed the `local-llm.ts` entry).

## Debt cleared

- `record-string-unknown` — `packages/webapp/src/providers/built-in/local-llm.ts`

## Test plan

- [x] `npx biome check --write packages/webapp/src/providers/built-in/local-llm.ts`
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/providers/local-llm-provider.test.ts packages/webapp/tests/providers/local-llm-stream.test.ts`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`