### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/tests/kernel/realm/realm-runner.test.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -318,7 +318,6 @@
         "packages/webapp/src/providers/built-in/bedrock-camp.ts",
         "packages/webapp/src/providers/intercepted-oauth.ts",
         "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts",
-        "packages/webapp/tests/kernel/realm/realm-runner.test.ts",
         "packages/webapp/tests/ui/provider-settings.test.ts"
       ],
       "linter": {

--- a/packages/webapp/tests/kernel/realm/realm-runner.test.ts
+++ b/packages/webapp/tests/kernel/realm/realm-runner.test.ts
@@ -422,7 +422,7 @@ describe('runInRealm', () => {
   it('process is registered with kind:"jsh" before the realm replies', async () => {
     const pm = new ProcessManager();
     const realm = makeMockRealm();
-    runInRealm({
+    const promise = runInRealm({
       pm,
       realmFactory: async () => realm,
       owner: { kind: 'system' },
@@ -443,6 +443,13 @@ describe('runInRealm', () => {
     expect(proc.cwd).toBe('/workspace');
     expect(proc.ppid).toBe(5000);
     expect(proc.status).toBe('running');
+    realm.fireMessage({
+      type: 'realm-done',
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+    } satisfies RealmDoneMsg);
+    await promise;
   });
 
   it('honors procKind override (e.g. for a future kind:py)', async () => {


### PR DESCRIPTION
## Summary

- Store and await the `runInRealm` promise in the "process registered before realm replies" test (was a floating promise).
- Complete the realm with `realm-done` after assertions so the test cleans up properly.
- Remove `packages/webapp/tests/kernel/realm/realm-runner.test.ts` from the `nursery.noFloatingPromises: off` biome override.

## Debt cleared

- `floating-promise` (biome `noFloatingPromises` override entry removed)

## Verification

- `npx biome check --write packages/webapp/tests/kernel/realm/realm-runner.test.ts biome.json`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/kernel/realm/realm-runner.test.ts` (15 tests)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` → OK