### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/scoops/tray-leader/cdp-router.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -9,7 +9,6 @@
   "packages/webapp/src/fs/mount/backend-local.ts": 1,
   "packages/webapp/src/kernel/realm/py-realm-shared.ts": 1,
   "packages/webapp/src/providers/built-in/bedrock-camp.ts": 31,
-  "packages/webapp/src/scoops/tray-leader/cdp-router.ts": 5,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 5,
   "packages/webapp/src/shell/supplemental-commands/websocat-command.ts": 1,
   "packages/webapp/src/ui/dip.ts": 4,

--- a/packages/webapp/src/scoops/tray-leader/cdp-router.ts
+++ b/packages/webapp/src/scoops/tray-leader/cdp-router.ts
@@ -1,4 +1,4 @@
-import { reassembleCDPResponse, sendCDPResponse } from '@slicc/shared-ts';
+import { type CDPPayload, reassembleCDPResponse, sendCDPResponse } from '@slicc/shared-ts';
 import { type RemoteCDPSender, RemoteCDPTransport } from '../../cdp/remote-cdp-transport.js';
 import type { CDPTransport } from '../../cdp/transport.js';
 import type { FollowerToLeaderMessage } from '../tray-sync-protocol.js';
@@ -77,7 +77,7 @@ export class CDPRouter {
     requestId: string,
     localTargetId: string,
     method: string,
-    params: Record<string, unknown> | undefined,
+    params: CDPPayload | undefined,
     sessionId: string | undefined,
     requesterBootstrapId: string
   ): Promise<void> {
@@ -112,9 +112,9 @@ export class CDPRouter {
   private async executeFollowerBringToFront(
     transport: CDPTransport,
     localTargetId: string,
-    params: Record<string, unknown> | undefined,
+    params: CDPPayload | undefined,
     sessionId: string | undefined
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CDPPayload> {
     const generation = this.previewGeneration;
     const sequence = ++this.previewSequence;
     this.previewRequestsInFlight++;
@@ -308,7 +308,7 @@ export class CDPRouter {
     targetRuntimeId: string,
     localTargetId: string,
     method: string,
-    params: Record<string, unknown> | undefined,
+    params: CDPPayload | undefined,
     sessionId: string | undefined,
     requesterBootstrapId: string
   ): void {
@@ -367,7 +367,7 @@ export class CDPRouter {
   handleCDPEvent(
     bootstrapId: string,
     method: string,
-    params: Record<string, unknown>,
+    params: CDPPayload,
     sessionId?: string
   ): void {
     const followerRuntimeId = this.context.followers.runtimeIdForBootstrap(bootstrapId);


### PR DESCRIPTION
## Summary

- Replace five explicit `Record<string, unknown>` uses in `cdp-router.ts` with the shared `CDPPayload` alias from `@slicc/shared-ts` (same type used by `CDPTransport` and tray-sync CDP messages).
- Ratchet `record-string-unknown-baseline.json` to remove the file entry (5 → 0 grandfathered occurrences).

## Debt cleared

- `record-string-unknown` — `packages/webapp/src/scoops/tray-leader/cdp-router.ts`

## Verification

- `npx biome check --write packages/webapp/src/scoops/tray-leader/cdp-router.ts`
- `npm run typecheck -w @slicc/webapp`
- `npx vitest run packages/webapp/tests/scoops/tray-leader/cdp-router.test.ts`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`