### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/kernel/telemetry.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -12,7 +12,6 @@
   "packages/webapp/src/cdp/navigation-watcher.ts": 11,
   "packages/webapp/src/fs/mount/backend-local.ts": 1,
   "packages/webapp/src/kernel/realm/py-realm-shared.ts": 1,
-  "packages/webapp/src/kernel/telemetry.ts": 1,
   "packages/webapp/src/net/link-header.ts": 1,
   "packages/webapp/src/providers/built-in/bedrock-camp.ts": 31,
   "packages/webapp/src/providers/intercepted-oauth.ts": 4,

--- a/packages/webapp/src/kernel/telemetry.ts
+++ b/packages/webapp/src/kernel/telemetry.ts
@@ -21,6 +21,11 @@ import { setShellTelemetrySink } from '../shell/telemetry-hook.js';
 
 type SampleRUM = (checkpoint: string, data?: { source?: string; target?: string }) => void;
 
+/** Helix-rum globals on `globalThis` when no `window` exists (worker realm). */
+type RumWorkerGlobals = {
+  RUM_GENERATION?: string;
+};
+
 let sampleRUM: SampleRUM | null = null;
 let initialized = false;
 
@@ -118,7 +123,7 @@ export async function initTelemetry(): Promise<void> {
       window.RUM_GENERATION = `slicc-${mode}`;
     } else {
       // Worker realm: no Window, but rum-worker.js reads `globalThis.RUM_GENERATION`.
-      (globalThis as Record<string, unknown>).RUM_GENERATION = `slicc-${mode}`;
+      (globalThis as RumWorkerGlobals).RUM_GENERATION = `slicc-${mode}`;
     }
 
     if (mode === 'standalone-worker') {


### PR DESCRIPTION
## Summary

- Replaced `(globalThis as Record<string, unknown>).RUM_GENERATION` with a named `RumWorkerGlobals` type for the worker-realm helix-rum global.
- Cleared `packages/webapp/src/kernel/telemetry.ts` from the `record-string-unknown` debt list and ratcheted `record-string-unknown-baseline.json`.

## Debt cleared

- `record-string-unknown` — removed the sole `Record<string, unknown>` cast in `telemetry.ts`.

## Verification

- `npx biome check --write packages/webapp/src/kernel/telemetry.ts`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/ui/telemetry.test.ts packages/webapp/tests/ui/telemetry-worker.test.ts`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK (0 still on any debt list)