### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/cdp/cherry-host-transport.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -7,7 +7,6 @@
   "packages/webapp/providers/github-copilot.ts": 2,
   "packages/webapp/providers/github.ts": 2,
   "packages/webapp/providers/openai-codex.ts": 2,
-  "packages/webapp/src/cdp/cherry-host-transport.ts": 3,
   "packages/webapp/src/cdp/har-recorder.ts": 10,
   "packages/webapp/src/cdp/navigation-watcher.ts": 11,
   "packages/webapp/src/fs/mount/backend-local.ts": 1,

--- a/packages/webapp/src/cdp/cherry-host-transport.ts
+++ b/packages/webapp/src/cdp/cherry-host-transport.ts
@@ -51,11 +51,16 @@ interface RejectionWithExportCode {
 }
 
 function exportErrorCodeFromRejection(err: unknown): TranscriptExportErrorCode {
-  if (err instanceof TranscriptExportError) return err.code;
   const maybeCode =
-    typeof err === 'object' && err !== null && 'code' in err
-      ? (err as RejectionWithExportCode).code
-      : undefined;
+    err instanceof TranscriptExportError
+      ? err.code
+      : typeof err === 'object' && err !== null && 'code' in err
+        ? (err as RejectionWithExportCode).code
+        : undefined;
+  // Clamp to a canonical code even for TranscriptExportError instances: the
+  // declared type is not a runtime guarantee (JS callers, unchecked casts, or
+  // later mutation can carry a noncanonical `code`), so fall back to
+  // 'transfer-corrupt' — the generic "something went wrong" sentinel.
   if (
     typeof maybeCode === 'string' &&
     VALID_EXPORT_ERROR_CODES.has(maybeCode as TranscriptExportErrorCode)

--- a/packages/webapp/src/cdp/cherry-host-transport.ts
+++ b/packages/webapp/src/cdp/cherry-host-transport.ts
@@ -10,7 +10,13 @@
  * and implements the postMessage backhaul.
  */
 
-import { type TranscriptExportProgress, VALID_EXPORT_ERROR_CODES } from '@slicc/shared-ts';
+import {
+  type CDPPayload,
+  TranscriptExportError,
+  type TranscriptExportErrorCode,
+  type TranscriptExportProgress,
+  VALID_EXPORT_ERROR_CODES,
+} from '@slicc/shared-ts';
 import { createLogger } from '../base/logger.js';
 import {
   acceptEnvelope,
@@ -38,6 +44,26 @@ export interface CherryHostTransportOptions {
 }
 
 const DEFAULT_TIMEOUT = 30000;
+
+/** Wire rejection shape outside {@link TranscriptExportError} (e.g. abort handlers). */
+interface RejectionWithExportCode {
+  code?: unknown;
+}
+
+function exportErrorCodeFromRejection(err: unknown): TranscriptExportErrorCode {
+  if (err instanceof TranscriptExportError) return err.code;
+  const maybeCode =
+    typeof err === 'object' && err !== null && 'code' in err
+      ? (err as RejectionWithExportCode).code
+      : undefined;
+  if (
+    typeof maybeCode === 'string' &&
+    VALID_EXPORT_ERROR_CODES.has(maybeCode as TranscriptExportErrorCode)
+  ) {
+    return maybeCode as TranscriptExportErrorCode;
+  }
+  return 'transfer-corrupt';
+}
 
 export class CherryHostTransport extends SyntheticCdpTransport {
   private opts: CherryHostTransportOptions;
@@ -304,10 +330,10 @@ export class CherryHostTransport extends SyntheticCdpTransport {
    */
   protected async forward(
     method: string,
-    params?: Record<string, unknown>,
+    params?: CDPPayload,
     _sessionId?: string,
     timeout = DEFAULT_TIMEOUT
-  ): Promise<Record<string, unknown>> {
+  ): Promise<CDPPayload> {
     const id = this.nextId++;
     const response = this.pending.issue(
       id,
@@ -541,15 +567,7 @@ export class CherryHostTransport extends SyntheticCdpTransport {
       })
       .catch((err: unknown) => {
         this.pendingHostExports.delete(requestId);
-        const maybeCode = (err as Record<string, unknown>)?.code;
-        // Clamp to a canonical error code so the host SDK always receives a
-        // well-typed value. An unknown or non-string code falls back to
-        // 'transfer-corrupt', which is the generic "something went wrong" sentinel.
-        const code =
-          typeof maybeCode === 'string' && VALID_EXPORT_ERROR_CODES.has(maybeCode as never)
-            ? maybeCode
-            : 'transfer-corrupt';
-        this.postExportError(requestId, code);
+        this.postExportError(requestId, exportErrorCodeFromRejection(err));
       });
   }
 

--- a/packages/webapp/tests/cdp/cherry-host-transport.test.ts
+++ b/packages/webapp/tests/cdp/cherry-host-transport.test.ts
@@ -1,4 +1,4 @@
-import type { TranscriptExportProgress } from '@slicc/shared-ts';
+import { TranscriptExportError, type TranscriptExportProgress } from '@slicc/shared-ts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BrowserAPI } from '../../src/cdp/browser-api.js';
 import {
@@ -536,6 +536,31 @@ describe('CherryHostTransport', () => {
 
     const errEnv = h.posted.find((m) => m.kind === 'session.export.error');
     expect(errEnv?.requestId).toBe('req-unknown-code-1');
+    expect(errEnv?.code).toBe('transfer-corrupt');
+  });
+
+  it('clamps a TranscriptExportError whose code is noncanonical at runtime', async () => {
+    // The declared TranscriptExportErrorCode type is not a runtime guarantee:
+    // a JS caller, unchecked cast, or later mutation can carry a code outside
+    // VALID_EXPORT_ERROR_CODES. The clamp must still fall back to
+    // 'transfer-corrupt' rather than passing the noncanonical value on the wire.
+    await connectHelper(h);
+    const channelId = lastChannelId(h);
+    const err = new TranscriptExportError('permission-denied');
+    // Simulate a runtime-malformed code that TypeScript's type would forbid.
+    (err as unknown as { code: string }).code = 'not-a-real-code';
+    h.transport.onExportRequest = vi.fn().mockRejectedValue(err);
+
+    h.inbound({
+      cherry: CHERRY_PROTOCOL_VERSION,
+      channelId,
+      kind: 'session.export.request',
+      requestId: 'req-bad-typed-1',
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const errEnv = h.posted.find((m) => m.kind === 'session.export.error');
+    expect(errEnv?.requestId).toBe('req-bad-typed-1');
     expect(errEnv?.code).toBe('transfer-corrupt');
   });
 


### PR DESCRIPTION
## Summary

- Replace `Record<string, unknown>` in `CherryHostTransport.forward` with the shared `CDPPayload` type (same pattern as `PreviewBridgeCdpTransport`).
- Add `exportErrorCodeFromRejection` with a named `RejectionWithExportCode` interface for host-initiated export failures, preserving clamping of wire codes.
- Ratchet `record-string-unknown-baseline.json` (removed entry for this file).

## Debt cleared

- `record-string-unknown` — `packages/webapp/src/cdp/cherry-host-transport.ts`

## Verification

- `npx biome check --write packages/webapp/src/cdp/cherry-host-transport.ts`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/cdp/cherry-host-transport.test.ts packages/webapp/tests/cdp/cherry-host-transport-features.test.ts`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`