### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/speech/hear.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -20,7 +20,6 @@
   "packages/webapp/src/shell/bsh-watchdog.ts": 1,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 5,
   "packages/webapp/src/shell/supplemental-commands/websocat-command.ts": 1,
-  "packages/webapp/src/speech/hear.ts": 1,
   "packages/webapp/src/ui/dip.ts": 4,
   "packages/webapp/src/ui/sprinkle-bridge.ts": 2,
   "packages/webapp/src/ui/sprinkle-renderer.ts": 3

--- a/packages/webapp/src/speech/hear.ts
+++ b/packages/webapp/src/speech/hear.ts
@@ -119,14 +119,16 @@ interface OnceRecognition {
   stop(): void;
 }
 
+/** Vendor-prefixed Web Speech API constructors on browsers that expose them on `window`. */
+interface WindowWithSpeechRecognition {
+  SpeechRecognition?: new () => OnceRecognition;
+  webkitSpeechRecognition?: new () => OnceRecognition;
+}
+
 function onceRecognitionCtor(): (new () => OnceRecognition) | null {
   if (typeof window === 'undefined') return null;
-  const w = window as unknown as Record<string, unknown>;
-  return (
-    (w.SpeechRecognition as new () => OnceRecognition) ??
-    (w.webkitSpeechRecognition as new () => OnceRecognition) ??
-    null
-  );
+  const { SpeechRecognition, webkitSpeechRecognition } = window as WindowWithSpeechRecognition;
+  return SpeechRecognition ?? webkitSpeechRecognition ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace `Record<string, unknown>` window cast in `onceRecognitionCtor()` with a named `WindowWithSpeechRecognition` interface for vendor-prefixed Web Speech API constructors (`SpeechRecognition`, `webkitSpeechRecognition`).
- Clears `record-string-unknown` debt for `packages/webapp/src/speech/hear.ts` and ratchets the baseline (135 → 134 grandfathered occurrences).

## Debt cleared

- `record-string-unknown` — `packages/webapp/src/speech/hear.ts`

## Verification

- `npx biome check --write packages/webapp/src/speech/hear.ts`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/speech/hear.test.ts packages/webapp/tests/shell/supplemental-commands/hear-command.test.ts` (18 tests)
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK