### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/providers/github.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -5,7 +5,6 @@
   "packages/shared-ts/src/transcript-export.ts": 18,
   "packages/webapp/providers/adobe.ts": 1,
   "packages/webapp/providers/github-copilot.ts": 2,
-  "packages/webapp/providers/github.ts": 2,
   "packages/webapp/providers/openai-codex.ts": 2,
   "packages/webapp/src/cdp/har-recorder.ts": 10,
   "packages/webapp/src/fs/mount/backend-local.ts": 1,

--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -55,6 +55,55 @@ const githubConfig: GitHubConfig = configFiles['/packages/webapp/providers/githu
   scopes: 'repo,read:user,user:email',
 };
 
+/** OAuth relay `state` envelope for extension logins. */
+export type GithubOAuthStateExtension = {
+  source: 'extension';
+  extensionId: string;
+  path: '/github';
+  nonce: string;
+};
+
+/** OAuth relay `state` envelope when the interactive hop runs on a follower (#1915). */
+export type GithubOAuthStateOpener = {
+  source: 'opener';
+  path: '/auth/callback';
+  nonce: string;
+};
+
+/** OAuth relay `state` envelope for localhost bounce via registered relay. */
+export type GithubOAuthStateLocal = {
+  source: 'local';
+  port: number;
+  path: '/auth/callback';
+  nonce: string;
+};
+
+/** OAuth relay `state` envelope for remote connect-mode bounce via registered relay. */
+export type GithubOAuthStateRemote = {
+  source: 'remote';
+  origin: string;
+  path: '/auth/callback';
+  nonce: string;
+};
+
+/** Standalone CLI relay bounce — no `source` discriminator (legacy shape). */
+export type GithubOAuthStateStandaloneCli = {
+  port: number;
+  path: '/auth/callback';
+  nonce: string;
+};
+
+export type GithubOAuthState =
+  | GithubOAuthStateExtension
+  | GithubOAuthStateOpener
+  | GithubOAuthStateLocal
+  | GithubOAuthStateRemote
+  | GithubOAuthStateStandaloneCli;
+
+type ConnectModeGlobal = {
+  __slicc_connect_mode?: unknown;
+};
+
 // ── Runtime config (fetches correct client ID per environment) ──────
 
 let runtimeClientId: string | null = null;
@@ -106,7 +155,7 @@ export function resolveGithubOAuthRedirect(opts: {
   delegated?: boolean;
   extensionId: string;
   nonce: string;
-}): { redirectUri: string; state: Record<string, unknown> } {
+}): { redirectUri: string; state: GithubOAuthState } {
   const {
     isExtension,
     isConnectMode,
@@ -513,7 +562,7 @@ export const config: ProviderConfig = {
       : '';
     const { redirectUri, state: stateData } = resolveGithubOAuthRedirect({
       isExtension,
-      isConnectMode: !!(globalThis as Record<string, unknown>).__slicc_connect_mode,
+      isConnectMode: !!(globalThis as ConnectModeGlobal).__slicc_connect_mode,
       workerBaseUrl: getWorkerBaseUrl(),
       runtimeWorkerBaseUrl,
       pageOrigin: pageInfo?.origin ?? null,

--- a/packages/webapp/tests/providers/github-oauth-login.test.ts
+++ b/packages/webapp/tests/providers/github-oauth-login.test.ts
@@ -626,7 +626,7 @@ describe('resolveGithubOAuthRedirect (per-runtime redirect_uri + state)', () => 
     });
     expect(r.redirectUri).toBe('https://www.sliccy.ai/auth/callback');
     expect(r.state).toMatchObject({ port: 5710, path: '/auth/callback' });
-    expect(r.state.source).toBeUndefined();
+    expect(r.state).not.toHaveProperty('source');
   });
 
   it('worker-served thin-bridge → relay + source:local with BRIDGE port (5710), not page port (8787)', async () => {
@@ -653,6 +653,9 @@ describe('resolveGithubOAuthRedirect (per-runtime redirect_uri + state)', () => 
     // routing to :8787 hits wrangler's capture page which only postMessages the
     // opener (severed by GitHub COOP). :5710 hits node-server's callback which
     // POSTs to its same-origin loopback `/api/oauth-result`.
+    if (!('source' in r.state) || r.state.source !== 'local') {
+      throw new Error('expected local OAuth state');
+    }
     expect(r.state.port).toBe(5710);
     expect(r.state.port).not.toBe(8787);
   });
@@ -672,7 +675,7 @@ describe('resolveGithubOAuthRedirect (per-runtime redirect_uri + state)', () => 
     // Legacy fall-through uses the page port (8787) and the legacy state shape
     // (no `source` field).
     expect(r.state).toMatchObject({ port: 8787, path: '/auth/callback' });
-    expect(r.state.source).toBeUndefined();
+    expect(r.state).not.toHaveProperty('source');
   });
 
   it('worker-served thin-bridge with a non-localhost bridgeApiBaseUrl → falls through to legacy branch', async () => {
@@ -689,7 +692,7 @@ describe('resolveGithubOAuthRedirect (per-runtime redirect_uri + state)', () => 
     // The hostname guard rejects non-loopback bridges; legacy branch fires
     // with the page port.
     expect(r.state).toMatchObject({ port: 8787, path: '/auth/callback' });
-    expect(r.state.source).toBeUndefined();
+    expect(r.state).not.toHaveProperty('source');
   });
 
   it('non-worker-served page with bridgeApiBaseUrl → still takes legacy CLI branch (no ?bridge param)', async () => {
@@ -705,6 +708,6 @@ describe('resolveGithubOAuthRedirect (per-runtime redirect_uri + state)', () => 
       bridgeApiBaseUrl: 'http://localhost:5710',
     });
     expect(r.state).toMatchObject({ port: 5710, path: '/auth/callback' });
-    expect(r.state.source).toBeUndefined();
+    expect(r.state).not.toHaveProperty('source');
   });
 });


### PR DESCRIPTION
## Summary

- Replace `Record<string, unknown>` in `packages/webapp/providers/github.ts` with named `GithubOAuthState` union types for each OAuth relay branch (extension, opener, local, remote, standalone CLI).
- Use a local `ConnectModeGlobal` cast for `__slicc_connect_mode` detection (same pattern as `float-topology.ts` / `main.ts`).
- Ratchet `record-string-unknown-baseline.json` via `check-record-string-unknown.mjs --update`.
- Narrow union access in `github-oauth-login.test.ts` tests.

## Debt cleared

- `record-string-unknown` baseline entry for `packages/webapp/providers/github.ts` (2 occurrences)

## Verification

```bash
npx biome check --write packages/webapp/providers/github.ts packages/webapp/tests/providers/github-oauth-login.test.ts
npm run typecheck
npx vitest run packages/webapp/tests/providers/github-oauth-login.test.ts packages/webapp/tests/providers/github-provider.test.ts
node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main
```