### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/scoops/onboarding-orchestrator.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -13,7 +13,6 @@
   "packages/webapp/src/kernel/telemetry.ts": 1,
   "packages/webapp/src/net/link-header.ts": 1,
   "packages/webapp/src/providers/built-in/bedrock-camp.ts": 31,
-  "packages/webapp/src/scoops/onboarding-orchestrator.ts": 1,
   "packages/webapp/src/scoops/tray-leader/cdp-router.ts": 5,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 5,
   "packages/webapp/src/shell/supplemental-commands/websocat-command.ts": 1,

--- a/packages/webapp/src/scoops/onboarding-orchestrator.ts
+++ b/packages/webapp/src/scoops/onboarding-orchestrator.ts
@@ -113,6 +113,24 @@ export interface OAuthLaunchResult {
   message?: string;
 }
 
+/** Nested `data` on the cone's final onboarding lick. */
+export interface OnboardingCompleteWithProviderData {
+  profile: OnboardingProfile;
+  provider: string;
+  model: string | null;
+  modelLabel: string | null;
+  validation: string;
+}
+
+/**
+ * Payload fired to the cone once a provider is wired up
+ * (`onboarding-complete-with-provider` per welcome/SKILL.md).
+ */
+export interface OnboardingCompleteWithProviderLick {
+  action: 'onboarding-complete-with-provider';
+  data: OnboardingCompleteWithProviderData;
+}
+
 export interface OrchestratorDeps {
   /** Shared filesystem for profile + welcomed-marker writes. */
   fs: VirtualFS;
@@ -140,7 +158,7 @@ export interface OrchestratorDeps {
   /** Send a message into the open `connect-llm` dip. */
   broadcastToDip: (payload: { type: string; [k: string]: unknown }) => void;
   /** Fire the FINAL onboarding-complete-with-provider lick to the cone. */
-  fireFinalLick: (data: Record<string, unknown>) => void;
+  fireFinalLick: (data: OnboardingCompleteWithProviderLick) => void;
   /**
    * Notify the host that the persisted accounts/model changed so the
    * UI can re-sync its model picker, identity badge, and pi-ai

--- a/packages/webapp/src/ui/boot/setup-onboarding-orchestrator.ts
+++ b/packages/webapp/src/ui/boot/setup-onboarding-orchestrator.ts
@@ -12,6 +12,7 @@
 import type { VirtualFS } from '../../fs/index.js';
 import type { DeviceCodePrompter } from '../../providers/types.js';
 import type {
+  OnboardingCompleteWithProviderLick,
   OnboardingOrchestrator,
   ProviderCatalogue,
   ProviderEntry,
@@ -86,19 +87,16 @@ export interface OnboardingFinalLickData {
   model?: string | null;
   modelLabel?: string | null;
   validation?: string;
-  readonly [key: string]: unknown;
 }
 
 /**
  * Body of the welcome sprinkle's final lick. Callers (e.g. WC onboarding)
  * read `action` for dedup and forward the whole bag to
- * `sendSprinkleLick('welcome', …)`. The open index signature only admits
- * extra top-level keys; known fields stay typed.
+ * `sendSprinkleLick('welcome', …)`.
  */
 export interface OnboardingFinalLickPayload {
   action?: string;
   data?: OnboardingFinalLickData;
-  readonly [key: string]: unknown;
 }
 
 /**
@@ -251,7 +249,7 @@ export async function createOnboardingOrchestratorSetup(
         }
       },
       broadcastToDip: (payload) => deps.broadcastToDip(payload),
-      fireFinalLick: (data) => deps.onFireFinalLick(narrowOnboardingFinalLickPayload(data)),
+      fireFinalLick: (data: OnboardingCompleteWithProviderLick) => deps.onFireFinalLick(data),
       onAccountsChanged: deps.onAccountsChanged ? () => deps.onAccountsChanged?.() : undefined,
       launchOAuth: async (providerId, baseUrl) =>
         await launchOnboardingOAuth(providerId, baseUrl ?? null, deps),

--- a/packages/webapp/src/ui/wc/wc-onboarding.ts
+++ b/packages/webapp/src/ui/wc/wc-onboarding.ts
@@ -66,9 +66,7 @@ export interface WelcomeFinalLickData {
     model?: string | null;
     modelLabel?: string | null;
     validation?: string;
-    readonly [key: string]: unknown;
   };
-  readonly [key: string]: unknown;
 }
 
 /**

--- a/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/onboarding-orchestrator.test.ts
@@ -3,6 +3,7 @@ import 'fake-indexeddb/auto';
 import { VirtualFS } from '../../src/fs/index.js';
 import { __test__ as messageTest } from '../../src/scoops/onboarding-messages.js';
 import {
+  type OnboardingCompleteWithProviderLick,
   OnboardingOrchestrator,
   type ProviderCatalogue,
 } from '../../src/scoops/onboarding-orchestrator.js';
@@ -16,8 +17,6 @@ type AccountSnapshot = {
 };
 
 type DipMessage = Record<string, unknown> & { type: string };
-
-type FinalLickPayload = { action: string; data: Record<string, unknown> };
 
 function fakeFetch(impl: (url: string) => Response | Promise<Response>) {
   return vi.fn(async (input: RequestInfo | URL) => {
@@ -70,7 +69,7 @@ function makeHarness(
   const systemMessages: string[] = [];
   const dipRefs: string[] = [];
   const dipInbox: DipMessage[] = [];
-  const finalLicks: FinalLickPayload[] = [];
+  const finalLicks: OnboardingCompleteWithProviderLick[] = [];
   const accounts: AccountSnapshot[] = [];
   const selectedModels: string[] = [];
   const orchestrator = new OnboardingOrchestrator({
@@ -83,7 +82,7 @@ function makeHarness(
     setSelectedModel: (id) => selectedModels.push(id),
     resolveModelLabel: (_p, m) => m.toUpperCase(),
     broadcastToDip: (msg) => dipInbox.push(msg),
-    fireFinalLick: (data) => finalLicks.push(data as FinalLickPayload),
+    fireFinalLick: (data) => finalLicks.push(data),
     fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
     rand: () => 0,
   });
@@ -272,7 +271,7 @@ describe('OnboardingOrchestrator', () => {
       const fetchImpl = fakeFetch(() => new Response('{"error":"bad"}', { status: 401 }));
       const fs = VirtualFS._createSyncForTests('reject-' + Math.random());
       const accounts: AccountSnapshot[] = [];
-      const finalLicks: FinalLickPayload[] = [];
+      const finalLicks: OnboardingCompleteWithProviderLick[] = [];
       const dipInbox: DipMessage[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
@@ -282,7 +281,7 @@ describe('OnboardingOrchestrator', () => {
         saveAccount: (id, key) => accounts.push({ id, key }),
         setSelectedModel: () => {},
         broadcastToDip: (msg) => dipInbox.push(msg),
-        fireFinalLick: (data) => finalLicks.push(data as FinalLickPayload),
+        fireFinalLick: (data) => finalLicks.push(data),
         fetchImpl,
         rand: () => 0,
       });
@@ -303,7 +302,7 @@ describe('OnboardingOrchestrator', () => {
       }) as unknown as typeof fetch;
       const fs = VirtualFS._createSyncForTests('skipped-' + Math.random());
       const accounts: AccountSnapshot[] = [];
-      const finalLicks: FinalLickPayload[] = [];
+      const finalLicks: OnboardingCompleteWithProviderLick[] = [];
       const dipInbox: DipMessage[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
@@ -313,7 +312,7 @@ describe('OnboardingOrchestrator', () => {
         saveAccount: (id, key) => accounts.push({ id, key }),
         setSelectedModel: () => {},
         broadcastToDip: (msg) => dipInbox.push(msg),
-        fireFinalLick: (data) => finalLicks.push(data as FinalLickPayload),
+        fireFinalLick: (data) => finalLicks.push(data),
         fetchImpl,
         rand: () => 0,
       });
@@ -351,7 +350,7 @@ describe('OnboardingOrchestrator', () => {
     it('leaves the selected model untouched when the catalogue has no models for the provider', async () => {
       const fs = VirtualFS._createSyncForTests('no-models-' + Math.random());
       const selectedModels: string[] = [];
-      const finalLicks: FinalLickPayload[] = [];
+      const finalLicks: OnboardingCompleteWithProviderLick[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
         postSystemMessage: () => {},
@@ -363,7 +362,7 @@ describe('OnboardingOrchestrator', () => {
         saveAccount: () => {},
         setSelectedModel: (id) => selectedModels.push(id),
         broadcastToDip: () => {},
-        fireFinalLick: (data) => finalLicks.push(data as FinalLickPayload),
+        fireFinalLick: (data) => finalLicks.push(data),
         fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
         rand: () => 0,
       });
@@ -440,7 +439,7 @@ describe('OnboardingOrchestrator', () => {
       const fs = VirtualFS._createSyncForTests('catalogue-throw-' + Math.random());
       const accounts: AccountSnapshot[] = [];
       const dipInbox: DipMessage[] = [];
-      const finalLicks: { action: string; data: Record<string, unknown> }[] = [];
+      const finalLicks: OnboardingCompleteWithProviderLick[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
         postSystemMessage: () => {},
@@ -451,7 +450,7 @@ describe('OnboardingOrchestrator', () => {
         saveAccount: (id, key) => accounts.push({ id, key }),
         setSelectedModel: () => {},
         broadcastToDip: (msg) => dipInbox.push(msg),
-        fireFinalLick: (data) => finalLicks.push(data as FinalLickPayload),
+        fireFinalLick: (data) => finalLicks.push(data),
         fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
         rand: () => 0,
       });
@@ -528,7 +527,7 @@ describe('OnboardingOrchestrator', () => {
       // reload because nothing dispatched `slicc:accounts-changed`.
       const fs = VirtualFS._createSyncForTests('changed-ok-' + Math.random());
       const onAccountsChanged = vi.fn();
-      const finalLicks: FinalLickPayload[] = [];
+      const finalLicks: OnboardingCompleteWithProviderLick[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
         postSystemMessage: () => {},
@@ -537,7 +536,7 @@ describe('OnboardingOrchestrator', () => {
         saveAccount: () => {},
         setSelectedModel: () => {},
         broadcastToDip: () => {},
-        fireFinalLick: (data) => finalLicks.push(data as FinalLickPayload),
+        fireFinalLick: (data) => finalLicks.push(data),
         fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
         rand: () => 0,
         onAccountsChanged,
@@ -585,7 +584,7 @@ describe('OnboardingOrchestrator', () => {
     it('swallows onAccountsChanged exceptions without rolling back the save', async () => {
       const fs = VirtualFS._createSyncForTests('changed-throw-' + Math.random());
       const accounts: AccountSnapshot[] = [];
-      const finalLicks: FinalLickPayload[] = [];
+      const finalLicks: OnboardingCompleteWithProviderLick[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
         postSystemMessage: () => {},
@@ -594,7 +593,7 @@ describe('OnboardingOrchestrator', () => {
         saveAccount: (id, key) => accounts.push({ id, key }),
         setSelectedModel: () => {},
         broadcastToDip: () => {},
-        fireFinalLick: (data) => finalLicks.push(data as FinalLickPayload),
+        fireFinalLick: (data) => finalLicks.push(data),
         fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
         rand: () => 0,
         onAccountsChanged: () => {
@@ -616,7 +615,7 @@ describe('OnboardingOrchestrator', () => {
     it('sets the model and fires the final lick on successful OAuth with a model', async () => {
       const fs = VirtualFS._createSyncForTests('oauth-ok-' + Math.random());
       const selectedModels: string[] = [];
-      const finalLicks: FinalLickPayload[] = [];
+      const finalLicks: OnboardingCompleteWithProviderLick[] = [];
       const dipInbox: DipMessage[] = [];
       const launchOAuth = vi.fn(async () => ({ ok: true, model: 'adobe:claude-sonnet-4-6' }));
       const orch = new OnboardingOrchestrator({
@@ -628,7 +627,7 @@ describe('OnboardingOrchestrator', () => {
         setSelectedModel: (id) => selectedModels.push(id),
         resolveModelLabel: (_p, m) => m.toUpperCase(),
         broadcastToDip: (msg) => dipInbox.push(msg),
-        fireFinalLick: (data) => finalLicks.push(data as FinalLickPayload),
+        fireFinalLick: (data) => finalLicks.push(data),
         fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
         rand: () => 0,
         launchOAuth,
@@ -648,7 +647,7 @@ describe('OnboardingOrchestrator', () => {
     it('fires the final lick but does not call setSelectedModel when OAuth returns no model', async () => {
       const fs = VirtualFS._createSyncForTests('oauth-nomodel-' + Math.random());
       const selectedModels: string[] = [];
-      const finalLicks: FinalLickPayload[] = [];
+      const finalLicks: OnboardingCompleteWithProviderLick[] = [];
       const dipInbox: DipMessage[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
@@ -658,7 +657,7 @@ describe('OnboardingOrchestrator', () => {
         saveAccount: () => {},
         setSelectedModel: (id) => selectedModels.push(id),
         broadcastToDip: (msg) => dipInbox.push(msg),
-        fireFinalLick: (data) => finalLicks.push(data as FinalLickPayload),
+        fireFinalLick: (data) => finalLicks.push(data),
         fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
         rand: () => 0,
         launchOAuth: async () => ({ ok: true, model: null }),
@@ -674,7 +673,7 @@ describe('OnboardingOrchestrator', () => {
 
     it('broadcasts an error and keeps stage at awaiting-connect when OAuth fails', async () => {
       const fs = VirtualFS._createSyncForTests('oauth-fail-' + Math.random());
-      const finalLicks: FinalLickPayload[] = [];
+      const finalLicks: OnboardingCompleteWithProviderLick[] = [];
       const dipInbox: DipMessage[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
@@ -684,7 +683,7 @@ describe('OnboardingOrchestrator', () => {
         saveAccount: () => {},
         setSelectedModel: () => {},
         broadcastToDip: (msg) => dipInbox.push(msg),
-        fireFinalLick: (data) => finalLicks.push(data as FinalLickPayload),
+        fireFinalLick: (data) => finalLicks.push(data),
         fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
         rand: () => 0,
         launchOAuth: async () => ({ ok: false, message: 'Login cancelled.' }),
@@ -700,7 +699,7 @@ describe('OnboardingOrchestrator', () => {
 
     it('broadcasts an error and keeps stage at awaiting-connect when launchOAuth throws', async () => {
       const fs = VirtualFS._createSyncForTests('oauth-throw-' + Math.random());
-      const finalLicks: FinalLickPayload[] = [];
+      const finalLicks: OnboardingCompleteWithProviderLick[] = [];
       const dipInbox: DipMessage[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
@@ -710,7 +709,7 @@ describe('OnboardingOrchestrator', () => {
         saveAccount: () => {},
         setSelectedModel: () => {},
         broadcastToDip: (msg) => dipInbox.push(msg),
-        fireFinalLick: (data) => finalLicks.push(data as FinalLickPayload),
+        fireFinalLick: (data) => finalLicks.push(data),
         fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
         rand: () => 0,
         launchOAuth: async () => {
@@ -728,7 +727,7 @@ describe('OnboardingOrchestrator', () => {
 
     it('is a no-op when launchOAuth is not provided by the runtime', async () => {
       const fs = VirtualFS._createSyncForTests('oauth-noop-' + Math.random());
-      const finalLicks: FinalLickPayload[] = [];
+      const finalLicks: OnboardingCompleteWithProviderLick[] = [];
       const dipInbox: DipMessage[] = [];
       const orch = new OnboardingOrchestrator({
         fs,
@@ -738,7 +737,7 @@ describe('OnboardingOrchestrator', () => {
         saveAccount: () => {},
         setSelectedModel: () => {},
         broadcastToDip: (msg) => dipInbox.push(msg),
-        fireFinalLick: (data) => finalLicks.push(data as FinalLickPayload),
+        fireFinalLick: (data) => finalLicks.push(data),
         fetchImpl: fakeFetch(() => new Response('{}', { status: 200 })),
         rand: () => 0,
         // launchOAuth intentionally omitted

--- a/packages/webapp/tests/ui/boot/setup-onboarding-orchestrator.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-onboarding-orchestrator.test.ts
@@ -87,7 +87,6 @@ describe('narrowOnboardingFinalLickPayload', () => {
     });
 
     expect(narrowed.action).toBe('onboarding-complete-with-provider');
-    expect(narrowed.extra).toBe(true);
     expect(narrowed.data).toEqual({
       profile: { name: 'Ada' },
       provider: 'anthropic',


### PR DESCRIPTION
## Summary

- Replace `Record<string, unknown>` on `fireFinalLick` with named `OnboardingCompleteWithProviderLick` / `OnboardingCompleteWithProviderData` types in `onboarding-orchestrator.ts`.
- Align setup/wc onboarding payload types and tests with the stricter contract.
- Ratchet `record-string-unknown-baseline.json` (removed the onboarding-orchestrator entry).

## Debt cleared

- `record-string-unknown` for `packages/webapp/src/scoops/onboarding-orchestrator.ts`

## Test plan

- [x] `npx biome check --write` on touched files
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/scoops/onboarding-orchestrator.test.ts packages/webapp/tests/ui/boot/setup-onboarding-orchestrator.test.ts`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`