### PR TITLE
refactor(cloud-core): hoist cloud DEFAULT_CONE_MODEL to one canonical export

### DIFF
--- a/packages/cloud-core/src/cone-config/index.ts
+++ b/packages/cloud-core/src/cone-config/index.ts
@@ -52,6 +52,15 @@ export interface ConeConfigIndex {
 /** Max serialized bundle size (bytes) accepted as a preboot env payload. */
 export const MAX_CONE_CONFIG_BYTES = 256 * 1024;
 
+/**
+ * Canonical default model id for a cloud-hosted cone when no client bundle
+ * pins one. The three cloud-lifecycle consumers (cloud-core resume, node-server
+ * hosted-bootstrap, cloudflare-worker cone-config-bridge) and the webapp hosted
+ * boot path all seed this model, so it lives here — one definition — instead of
+ * being copy-pasted per float where it can silently drift. See #2633.
+ */
+export const DEFAULT_CONE_MODEL = 'adobe:claude-opus-4-6';
+
 /** Untrusted cone-config bundle before validation. */
 interface UntrustedConeConfig {
   readonly model?: unknown;

--- a/packages/cloud-core/src/operations/resume.ts
+++ b/packages/cloud-core/src/operations/resume.ts
@@ -5,6 +5,7 @@ import {
   type ConeConfig,
   type ConeConfigDelta,
   type ConeConfigIndex,
+  DEFAULT_CONE_MODEL,
   mergeConeConfig,
   validateConeConfig,
 } from '../cone-config/index.js';
@@ -42,8 +43,6 @@ export interface ResumeConeOpts {
 const KICK_CMD =
   'curl -sS -X POST http://localhost:5710/api/leader-restart -o /dev/null -w "%{http_code}"';
 
-const DEFAULT_MODEL = 'adobe:claude-opus-4-6';
-
 /**
  * Merge `delta` over the existing files; returns new file contents + names index.
  * When `coneConfigJson` is null (a pre-feature cone), synthesizes a degenerate
@@ -67,13 +66,13 @@ export function applyConeConfigDelta(
       );
     }
     base = validateConeConfig({
-      model: parsed.model ?? DEFAULT_MODEL,
+      model: parsed.model ?? DEFAULT_CONE_MODEL,
       accounts: parsed.accounts ?? [],
       secrets: pairEnvEntriesToSecrets(parseEnvFilePreservingValues(secretsEnv)),
     });
   } else {
     base = {
-      model: DEFAULT_MODEL,
+      model: DEFAULT_CONE_MODEL,
       accounts: [],
       secrets: pairEnvEntriesToSecrets(parseEnvFilePreservingValues(secretsEnv)),
     };

--- a/packages/cloud-core/tests/cone-config/cone-config.test.ts
+++ b/packages/cloud-core/tests/cone-config/cone-config.test.ts
@@ -3,6 +3,7 @@ import {
   bundleIndex,
   bundleToFiles,
   type ConeConfig,
+  DEFAULT_CONE_MODEL,
   decodeBundleEnv,
   encodeBundleEnv,
   imsTokenExpiry,
@@ -36,6 +37,16 @@ const base: ConeConfig = {
   ],
   secrets: [{ name: 'GITHUB_TOKEN', value: 'gt', domains: ['api.github.com', 'github.com'] }],
 };
+
+describe('DEFAULT_CONE_MODEL', () => {
+  // Canonical cloud-cone default. Pinned here (#2633) so the three backend
+  // consumers (resume, hosted-bootstrap, cone-config-bridge) and the webapp
+  // hosted boot path share one definition instead of copy-pasted literals.
+  it('is the Adobe Opus default and is a provider-prefixed id', () => {
+    expect(DEFAULT_CONE_MODEL).toBe('adobe:claude-opus-4-6');
+    expect(DEFAULT_CONE_MODEL).toMatch(/^[a-z]+:/);
+  });
+});
 
 describe('validateConeConfig', () => {
   it('accepts a well-formed bundle', () => {

--- a/packages/cloudflare-worker/src/cloud/cone-config-bridge.ts
+++ b/packages/cloudflare-worker/src/cloud/cone-config-bridge.ts
@@ -1,6 +1,7 @@
 import {
   bundleToFiles,
   type ConeConfig,
+  DEFAULT_CONE_MODEL,
   imsTokenExpiry,
   validateConeConfig,
 } from '@slicc/cloud-core/cone-config';
@@ -8,7 +9,6 @@ import {
 // Import the existing ADOBE_TOKEN_DOMAINS constant (will export it from cloud-sessions-do)
 import { ADOBE_TOKEN_DOMAINS } from './cloud-sessions-do.js';
 
-const DEFAULT_MODEL = 'adobe:claude-opus-4-6';
 const AUTH_OPTIONAL_PROVIDERS = new Set<string>(['local']);
 
 /** Narrow F6 re-validation: the model's provider must have an account (unless auth-optional). */
@@ -29,7 +29,7 @@ export function coneConfigToBundle(input: unknown, bearer: string): ConeConfig {
     // window-less getValidAccessToken path as node-server's legacy branch).
     const expiresAt = imsTokenExpiry(bearer);
     return {
-      model: DEFAULT_MODEL,
+      model: DEFAULT_CONE_MODEL,
       accounts: [
         {
           providerId: 'adobe',

--- a/packages/node-server/src/hosted-bootstrap.ts
+++ b/packages/node-server/src/hosted-bootstrap.ts
@@ -17,7 +17,7 @@ import { readFileSync } from 'node:fs';
 // Import from the package root (not the './cone-config' subpath): node-server's
 // inline-workspaces packaging only rewrites the bare '@slicc/cloud-core'
 // specifier, so a subpath import leaks an un-inlined workspace reference.
-import { type Account, imsTokenExpiry } from '@slicc/cloud-core';
+import { type Account, DEFAULT_CONE_MODEL, imsTokenExpiry } from '@slicc/cloud-core';
 import type { Express } from 'express';
 import { requireLoopback } from './cloud-status.js';
 import type { SecretStore } from './secrets/types.js';
@@ -28,7 +28,6 @@ import type { SecretStore } from './secrets/types.js';
 export { imsTokenExpiry };
 
 const CONE_CONFIG_PATH = '/slicc/cone-config.json';
-const DEFAULT_MODEL = 'adobe:claude-opus-4-6';
 
 export interface HostedBootstrapPayload {
   model?: string;
@@ -61,7 +60,7 @@ export function buildHostedBootstrapPayload(sources: BootstrapSources): HostedBo
   if (legacy) {
     const expiresAt = imsTokenExpiry(legacy);
     return {
-      model: DEFAULT_MODEL,
+      model: DEFAULT_CONE_MODEL,
       accounts: [
         {
           providerId: 'adobe',

--- a/packages/webapp/src/ui/boot/setup-standalone-tray-init-hosted.ts
+++ b/packages/webapp/src/ui/boot/setup-standalone-tray-init-hosted.ts
@@ -13,6 +13,7 @@
  * an id pi-ai doesn't know resolves against a cold default).
  */
 
+import { DEFAULT_CONE_MODEL } from '@slicc/cloud-core/cone-config';
 import { apiHeaders, resolveApiUrl } from '../../shell/proxied-fetch.js';
 import { removeAccount, saveOAuthAccount } from '../provider-settings.js';
 import type { BootStageLogger } from './types.js';
@@ -43,7 +44,7 @@ export async function runHostedBootstrap(deps: RunHostedBootstrapDeps): Promise<
         : []);
     if (boot.model) localStorage.setItem('selected-model', boot.model);
     else if (!localStorage.getItem('selected-model'))
-      localStorage.setItem('selected-model', 'adobe:claude-opus-4-6');
+      localStorage.setItem('selected-model', DEFAULT_CONE_MODEL);
     if (boot.effortLevel) localStorage.setItem('slicc_locked_effort_level', boot.effortLevel);
     else localStorage.removeItem('slicc_locked_effort_level');
     const [{ applyHostedAccounts, prewarmHostedModels }, ps] = await Promise.all([


### PR DESCRIPTION
Closes #2633

## What

The cloud default-model id `adobe:claude-opus-4-6` was a copy-pasted constant declared independently in four production source files, and had already begun drifting against the UI display default (`claude-opus-4-8`):

- `packages/cloud-core/src/operations/resume.ts` — `const DEFAULT_MODEL`
- `packages/node-server/src/hosted-bootstrap.ts` — `const DEFAULT_MODEL`
- `packages/cloudflare-worker/src/cloud/cone-config-bridge.ts` — `const DEFAULT_MODEL`
- `packages/webapp/src/ui/boot/setup-standalone-tray-init-hosted.ts` — a bare inline literal

This adds a single canonical export, `DEFAULT_CONE_MODEL`, to `@slicc/cloud-core/cone-config` (next to `imsTokenExpiry`, which all three cloud consumers already import from there), and has all four consumers import it instead of redeclaring the literal. The next model bump is now a one-line change that cannot drift across floats.

## Scope

Deliberately limited to the four backend copies the issue flagged as string-identical. The webcomponents UI display default (`Opus 4.8` / `claude-opus-4-8`) is a different value and reconciling it (deciding which wins) is a product decision, not a mechanical dedup, so it is left untouched here. No behavior changes — the seeded value is byte-identical to before.

## Verification

- `npm run verify` — all 7 lint-gate checks pass
- `npm run typecheck` — pass (all tsconfig projects)
- Focused tests pass: cone-config, resume, resume-cone-config, hosted-bootstrap, cloud-sessions-cone-config, setup-standalone-tray-init-hosted (74 tests)
- `npm run test:coverage:cloud-core` — floors met
- Added a focused test pinning `DEFAULT_CONE_MODEL` in `packages/cloud-core/tests/cone-config/cone-config.test.ts`
