### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/tests/providers/adobe-provider.test.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -326,10 +326,7 @@
       }
     },
     {
-      "includes": [
-        "packages/webapp/providers/adobe.ts",
-        "packages/webapp/tests/providers/adobe-provider.test.ts"
-      ],
+      "includes": ["packages/webapp/providers/adobe.ts"],
       "linter": {
         "rules": {
           "nursery": {

--- a/packages/webapp/tests/providers/adobe-provider.test.ts
+++ b/packages/webapp/tests/providers/adobe-provider.test.ts
@@ -309,7 +309,7 @@ describe('Renewal deduplication pattern', () => {
     let renewalInProgress: Promise<string | null> | null = null;
 
     function silentRenew(): Promise<string | null> {
-      if (renewalInProgress) return renewalInProgress;
+      if (renewalInProgress !== null) return renewalInProgress;
       renewalInProgress = (async () => {
         try {
           callCount++;
@@ -344,7 +344,7 @@ describe('Renewal deduplication pattern', () => {
     let callCount = 0;
 
     function silentRenew(): Promise<string | null> {
-      if (renewalInProgress) return renewalInProgress;
+      if (renewalInProgress !== null) return renewalInProgress;
       renewalInProgress = (async () => {
         try {
           callCount++;


### PR DESCRIPTION
## Summary

- Fix `nursery.noMisusedPromises` violations in the renewal deduplication pattern tests by using explicit `!== null` checks instead of truthiness on `Promise | null` slots.
- Remove `packages/webapp/tests/providers/adobe-provider.test.ts` from the `noMisusedPromises: "off"` biome override (left `packages/webapp/providers/adobe.ts` on the list).

## Debt cleared

- `misused-promise`

## Verification

- `npx biome check --write packages/webapp/tests/providers/adobe-provider.test.ts biome.json`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/providers/adobe-provider.test.ts` (46 tests)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`