### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/providers/github-copilot.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -1,6 +1,5 @@
 {
   "packages/node-server/src/electron-controller.ts": 13,
-  "packages/webapp/providers/github-copilot.ts": 2,
   "packages/webapp/src/providers/built-in/bedrock-camp.ts": 31,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 5,
   "packages/webapp/src/ui/dip.ts": 4

--- a/packages/webapp/providers/github-copilot.ts
+++ b/packages/webapp/providers/github-copilot.ts
@@ -37,7 +37,13 @@
  *   then delegate.
  */
 
-import type { Api, Context, Model } from '@earendil-works/pi-ai';
+import type {
+  Api,
+  Context,
+  Model,
+  ProviderStreamOptions,
+  SimpleStreamOptions,
+} from '@earendil-works/pi-ai';
 import {
   createAssistantMessageEventStream,
   getModel,
@@ -765,7 +771,7 @@ async function pumpCopilotStream(
   stream: CopilotEventStream,
   model: Model<Api>,
   context: Context,
-  options: Record<string, unknown>,
+  options: ProviderStreamOptions | SimpleStreamOptions,
   simple: boolean
 ): Promise<void> {
   try {
@@ -796,8 +802,18 @@ async function pumpCopilotStream(
   }
 }
 
+function createCopilotStreamWrapper(
+  simple: false
+): (model: Model<Api>, context: Context, options?: ProviderStreamOptions) => CopilotEventStream;
+function createCopilotStreamWrapper(
+  simple: true
+): (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => CopilotEventStream;
 function createCopilotStreamWrapper(simple: boolean) {
-  return (model: Model<Api>, context: Context, options: Record<string, unknown> = {}) => {
+  return (
+    model: Model<Api>,
+    context: Context,
+    options: ProviderStreamOptions | SimpleStreamOptions = {}
+  ) => {
     const stream = createAssistantMessageEventStream();
     void pumpCopilotStream(stream, model, context, options, simple);
     return stream;


### PR DESCRIPTION
## Summary

- Replaced two `Record<string, unknown>` stream option parameters in `packages/webapp/providers/github-copilot.ts` with pi-ai's `ProviderStreamOptions` and `SimpleStreamOptions`.
- Added overloads on `createCopilotStreamWrapper` so the non-simple and simple stream entry points keep the correct public signatures.
- Ratcheted `record-string-unknown-baseline.json` (2 → 0 occurrences for this file).

## Debt cleared

- `record-string-unknown` — `packages/webapp/providers/github-copilot.ts`

## Verification

```bash
npx biome check --write packages/webapp/providers/github-copilot.ts
npm run typecheck
node packages/dev-tools/tools/check-record-string-unknown.mjs --update
node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main
```