### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/kernel/realm/py-realm-shared.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -2,7 +2,6 @@
   "packages/node-server/src/electron-controller.ts": 13,
   "packages/webapp/providers/adobe.ts": 1,
   "packages/webapp/providers/github-copilot.ts": 2,
-  "packages/webapp/src/kernel/realm/py-realm-shared.ts": 1,
   "packages/webapp/src/providers/built-in/bedrock-camp.ts": 31,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 5,
   "packages/webapp/src/ui/dip.ts": 4,

--- a/packages/webapp/src/kernel/realm/opfs-sync-fs.ts
+++ b/packages/webapp/src/kernel/realm/opfs-sync-fs.ts
@@ -318,6 +318,15 @@ export interface OpfsSyncFsPlugin {
   stream_ops: StreamOps;
 }
 
+/**
+ * The `FS.filesystems` registry slice the OPFS plugin hangs on.
+ * Mirrors {@link MountBombFilesystems} — only the plugin we own is
+ * typed; Emscripten's built-in entries are left opaque.
+ */
+export interface OpfsSyncFilesystems {
+  OPFS_SYNC_FS?: OpfsSyncFsPlugin;
+}
+
 // ---------------------------------------------------------------------------
 // Plugin factory
 // ---------------------------------------------------------------------------

--- a/packages/webapp/src/kernel/realm/py-realm-shared.ts
+++ b/packages/webapp/src/kernel/realm/py-realm-shared.ts
@@ -37,6 +37,7 @@ import {
   createOpfsSyncFs,
   flushPendingOpfsOps,
   type OpfsMount,
+  type OpfsSyncFilesystems,
   type OpfsSyncFsPlugin,
   prewalkOpfsTree,
 } from './opfs-sync-fs.js';
@@ -959,9 +960,8 @@ export interface MountedOpfsResult {
  * reference, so re-creating it would shadow the in-flight mounts.
  */
 function ensureOpfsSyncFsRegistered(pyodide: PyodideInterface): OpfsSyncFsPlugin {
-  const filesystems = (pyodide.FS as unknown as { filesystems: Record<string, unknown> })
-    .filesystems;
-  let plugin = filesystems.OPFS_SYNC_FS as OpfsSyncFsPlugin | undefined;
+  const filesystems = (pyodide.FS as unknown as { filesystems: OpfsSyncFilesystems }).filesystems;
+  let plugin = filesystems.OPFS_SYNC_FS;
   if (!plugin) {
     plugin = createOpfsSyncFs(pyodide.FS as unknown as Parameters<typeof createOpfsSyncFs>[0]);
     filesystems.OPFS_SYNC_FS = plugin;


### PR DESCRIPTION
## Summary

- Replaced `Record<string, unknown>` on `pyodide.FS.filesystems` with the named `OpfsSyncFilesystems` interface (same pattern as `MountBombFilesystems` in `mount-bomb-fs.ts`).
- Removed the redundant `as OpfsSyncFsPlugin | undefined` cast now that the registry is typed.
- Ratcheted `record-string-unknown-baseline.json` (cleared `py-realm-shared.ts` entry).

## Debt cleared

- `record-string-unknown` — `packages/webapp/src/kernel/realm/py-realm-shared.ts`

## Verification

- `npx biome check --write` on touched files
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
- `npm run typecheck`
- `npx vitest run` on `py-realm-shared*.test.ts` and `py-realm-mount-opfs.test.ts` (51 tests)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK