### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/ui/sprinkle-bridge.ts

### DIFF
--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -5,6 +5,5 @@
   "packages/webapp/src/kernel/realm/py-realm-shared.ts": 1,
   "packages/webapp/src/providers/built-in/bedrock-camp.ts": 31,
   "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 5,
-  "packages/webapp/src/ui/dip.ts": 4,
-  "packages/webapp/src/ui/sprinkle-bridge.ts": 2
+  "packages/webapp/src/ui/dip.ts": 4
 }

--- a/packages/webapp/src/ui/sprinkle-bridge.ts
+++ b/packages/webapp/src/ui/sprinkle-bridge.ts
@@ -11,6 +11,8 @@ import {
   type HidDeviceInfo,
 } from '../kernel/hid-device-registry.js';
 import * as hidOps from '../kernel/hid-operations.js';
+import type { HttpQueryParams } from '../kernel/realm/http-global.js';
+import type { BrowserFetchOptions } from '../kernel/realm/realm-browser-fetch.js';
 import * as serialOps from '../kernel/serial-operations.js';
 import {
   getNavigatorSerial,
@@ -98,7 +100,7 @@ export interface SprinkleFetchResult {
 
 /** Per-request options accepted by the `slicc.http` client methods. */
 export interface SprinkleHttpRequestOpts {
-  params?: Record<string, unknown>;
+  params?: HttpQueryParams;
   headers?: Record<string, string>;
   body?: unknown;
 }
@@ -149,7 +151,7 @@ export interface SprinkleBrowserApi {
   evalAsync(tab: unknown, code: string): Promise<unknown>;
   cookie(tab: unknown, name: string): Promise<string | null>;
   localStorage(tab: unknown, key: string): Promise<string | null>;
-  fetch(tab: unknown, url: string, opts?: Record<string, unknown>): Promise<unknown>;
+  fetch(tab: unknown, url: string, opts?: BrowserFetchOptions): Promise<unknown>;
 }
 
 /** Callable `slicc.exec` with the array-form `spawn` companion. */

--- a/packages/webapp/src/ui/sprinkle-bridge.ts
+++ b/packages/webapp/src/ui/sprinkle-bridge.ts
@@ -12,7 +12,10 @@ import {
 } from '../kernel/hid-device-registry.js';
 import * as hidOps from '../kernel/hid-operations.js';
 import type { HttpQueryParams } from '../kernel/realm/http-global.js';
-import type { BrowserFetchOptions } from '../kernel/realm/realm-browser-fetch.js';
+import type {
+  BrowserFetchOptions,
+  JsonEncodableObject,
+} from '../kernel/realm/realm-browser-fetch.js';
 import * as serialOps from '../kernel/serial-operations.js';
 import {
   getNavigatorSerial,
@@ -139,6 +142,20 @@ export interface SprinkleHttp {
 }
 
 /**
+ * Bridge-safe subset of {@link BrowserFetchOptions} for `slicc.browser.fetch`.
+ * The realm-side type admits `URLSearchParams` / `ArrayBuffer` / `Blob` /
+ * `FormData` bodies, but the sprinkle bridge serializes every arg with
+ * `JSON.stringify` (see {@link buildJshNodeScript}), which collapses those
+ * to `{}` before the realm's body serializer ever runs. So `body` is
+ * narrowed here to only the JSON-safe shapes that round-trip cleanly —
+ * mirroring {@link SprinkleFetchInit}. Pass a string (or pre-encoded
+ * payload) for anything binary; non-serializable bodies are out of scope.
+ */
+export interface SprinkleBrowserFetchOptions extends Omit<BrowserFetchOptions, 'body'> {
+  body?: string | JsonEncodableObject | unknown[] | number | boolean | null;
+}
+
+/**
  * `slicc.browser` — Playwright-style CDP surface mirroring the realm
  * `browser` global. Trusted-only (sprinkles + trusted dips). `eval` /
  * `evalAsync` take a code string (functions can't cross the bridge);
@@ -151,7 +168,7 @@ export interface SprinkleBrowserApi {
   evalAsync(tab: unknown, code: string): Promise<unknown>;
   cookie(tab: unknown, name: string): Promise<string | null>;
   localStorage(tab: unknown, key: string): Promise<string | null>;
-  fetch(tab: unknown, url: string, opts?: BrowserFetchOptions): Promise<unknown>;
+  fetch(tab: unknown, url: string, opts?: SprinkleBrowserFetchOptions): Promise<unknown>;
 }
 
 /** Callable `slicc.exec` with the array-form `spawn` companion. */


### PR DESCRIPTION
## Summary

- Replaced two `Record<string, unknown>` bags in `sprinkle-bridge.ts` with named types from the realm modules they mirror:
  - `SprinkleHttpRequestOpts.params` → `HttpQueryParams` (`kernel/realm/http-global.ts`)
  - `SprinkleBrowserApi.fetch` opts → `BrowserFetchOptions` (`kernel/realm/realm-browser-fetch.ts`)
- Ratcheted `record-string-unknown-baseline.json` (file removed from baseline)

## Debt cleared

- `record-string-unknown` — `packages/webapp/src/ui/sprinkle-bridge.ts`

## Verification

- `npx biome check --write packages/webapp/src/ui/sprinkle-bridge.ts`
- `npm run typecheck`
- `npx vitest run packages/webapp/tests/ui/sprinkle-bridge.test.ts packages/webapp/tests/ui/sprinkle-bridge-devices.test.ts` (51 tests)
- `node packages/dev-tools/tools/check-record-string-unknown.mjs --update`
- `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — OK