### PR TITLE
refactor: pay down boy-scout debt in packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -280,16 +280,6 @@
       "linter": {
         "enabled": false
       }
-    },
-    {
-      "includes": ["packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts"],
-      "linter": {
-        "rules": {
-          "nursery": {
-            "noFloatingPromises": "off"
-          }
-        }
-      }
     }
   ]
 }

--- a/packages/dev-tools/tools/layer-back-edge-baseline.json
+++ b/packages/dev-tools/tools/layer-back-edge-baseline.json
@@ -1,3 +1,1 @@
-{
-  "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 2
-}
+{}

--- a/packages/dev-tools/tools/record-string-unknown-baseline.json
+++ b/packages/dev-tools/tools/record-string-unknown-baseline.json
@@ -1,3 +1,1 @@
-{
-  "packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts": 5
-}
+{}

--- a/packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts
@@ -39,8 +39,13 @@ interface TeleportBrowserAPI {
   evaluate(expression: string): Promise<unknown>;
   sendCDP(
     method: string,
-    params?: { cookies?: CookieTeleportCookie[]; url?: string }
-  ): Promise<{ cookies?: CookieTeleportCookie[] }>;
+    params?: {
+      cookies?: CookieTeleportCookie[];
+      url?: string;
+      source?: string;
+      identifier?: string;
+    }
+  ): Promise<{ cookies?: CookieTeleportCookie[]; identifier?: unknown }>;
   createRemotePage(runtimeId: string, url: string): Promise<string>;
   closePage(targetId: string): Promise<void>;
   navigate(url: string): Promise<void>;
@@ -236,6 +241,70 @@ export function armTeleportWatcher(
 }
 
 /**
+ * One follower-poll tick: read the follower URL, advance the auth→return phase,
+ * and kick off capture once the return pattern matches. Extracted from the
+ * `setInterval` body in `triggerTeleport` to keep that function's complexity low.
+ */
+async function pollFollowerForReturn(
+  browser: TeleportBrowserAPI,
+  state: PlaywrightState,
+  watcher: TeleportWatcher,
+  followerTargetId: string,
+  runtimeId: string
+): Promise<void> {
+  if (watcher.phase !== 'waitingForAuth' && watcher.phase !== 'waitingForReturn') return;
+  try {
+    await browser.attachToPage(followerTargetId);
+    const raw = await browser.evaluate('window.location.href');
+    const href = typeof raw === 'string' ? raw : String(raw);
+    if (!href) return;
+    if (watcher.lastFollowerUrl !== href) {
+      watcher.lastFollowerUrl = href;
+      log.debug('Follower teleport navigation', { href, phase: watcher.phase });
+    }
+
+    if (watcher.phase === 'waitingForAuth') {
+      // Waiting for follower to redirect to auth (e.g. Okta)
+      if (watcher.startPattern.test(href)) {
+        watcher.phase = 'waitingForReturn';
+        log.info('Follower reached auth provider; waiting for return pattern');
+        log.debug('Follower reached auth provider details', {
+          href,
+          startPattern: watcher.startPattern.source,
+        });
+      } else {
+        log.debug('Waiting for auth redirect on follower', {
+          href,
+          startPattern: watcher.startPattern.source,
+        });
+      }
+      return; // Don't check return pattern yet
+    }
+
+    // Waiting for return from auth
+    log.debug('Polling follower tab URL for return', {
+      href,
+      returnPattern: watcher.returnPattern.source,
+    });
+    if (shouldCaptureTeleportDiagnostics(href)) {
+      await logFollowerTeleportDiagnosticsOnce(browser, watcher, 'waiting-for-return');
+    }
+    if (watcher.returnPattern.test(href)) {
+      log.info('Follower return pattern matched after auth');
+      log.debug('Follower return pattern matched after auth details', {
+        href,
+        returnPattern: watcher.returnPattern.source,
+      });
+      void captureCookiesAndComplete(browser, state, watcher, runtimeId).catch((err) => {
+        log.error('Unhandled teleport capture error', { error: String(err) });
+      });
+    }
+  } catch (err) {
+    log.warn('Error polling follower tab URL', { error: String(err) });
+  }
+}
+
+/**
  * Trigger the teleport flow: open the current URL on a follower,
  * monitor the follower for returnPattern, capture cookies, inject on leader.
  */
@@ -366,60 +435,11 @@ async function triggerTeleport(
       startPattern: watcher.startPattern.source,
     });
     watcher.pollInterval = setInterval(() => {
-      void (async () => {
-        if (watcher.phase !== 'waitingForAuth' && watcher.phase !== 'waitingForReturn') return;
-        try {
-          await browser.attachToPage(followerTargetId);
-          const raw = await browser.evaluate('window.location.href');
-          const href = typeof raw === 'string' ? raw : String(raw);
-          if (!href) return;
-          if (watcher.lastFollowerUrl !== href) {
-            watcher.lastFollowerUrl = href;
-            log.debug('Follower teleport navigation', { href, phase: watcher.phase });
-          }
-
-          if (watcher.phase === 'waitingForAuth') {
-            // Waiting for follower to redirect to auth (e.g. Okta)
-            if (watcher.startPattern.test(href)) {
-              watcher.phase = 'waitingForReturn';
-              log.info('Follower reached auth provider; waiting for return pattern');
-              log.debug('Follower reached auth provider details', {
-                href,
-                startPattern: watcher.startPattern.source,
-              });
-            } else {
-              log.debug('Waiting for auth redirect on follower', {
-                href,
-                startPattern: watcher.startPattern.source,
-              });
-            }
-            return; // Don't check return pattern yet
-          }
-
-          // Waiting for return from auth
-          log.debug('Polling follower tab URL for return', {
-            href,
-            returnPattern: watcher.returnPattern.source,
-          });
-          if (shouldCaptureTeleportDiagnostics(href)) {
-            await logFollowerTeleportDiagnosticsOnce(browser, watcher, 'waiting-for-return');
-          }
-          if (watcher.returnPattern.test(href)) {
-            log.info('Follower return pattern matched after auth');
-            log.debug('Follower return pattern matched after auth details', {
-              href,
-              returnPattern: watcher.returnPattern.source,
-            });
-            void captureCookiesAndComplete(browser, state, watcher, runtimeId).catch((err) => {
-              log.error('Unhandled teleport capture error', { error: String(err) });
-            });
-          }
-        } catch (err) {
-          log.warn('Error polling follower tab URL', { error: String(err) });
+      void pollFollowerForReturn(browser, state, watcher, followerTargetId, runtimeId).catch(
+        (err) => {
+          log.warn('Follower teleport poll failed', { error: String(err) });
         }
-      })().catch((err) => {
-        log.warn('Follower teleport poll failed', { error: String(err) });
-      });
+      );
     }, 1000);
   } catch (err) {
     log.error('Teleport trigger failed', { error: String(err) });
@@ -465,8 +485,7 @@ async function captureFollowerAuthState(
 
   const cookieResult = (await browser.sendCDP('Network.getCookies')) as NetworkGetCookiesResponse;
   const cookies = cookiesFromCdpResult(cookieResult.cookies);
-  const domainSummary =
-    cookies.length > 0 ? formatCookieDomainSummary(cookies) : 'none';
+  const domainSummary = cookies.length > 0 ? formatCookieDomainSummary(cookies) : 'none';
   log.info('Captured cookies from follower', { count: cookies.length });
   log.debug('Captured cookies from follower details', {
     count: cookies.length,
@@ -700,8 +719,7 @@ async function captureCookiesAndComplete(
     // Complete
     watcher.phase = 'done';
     cleanupTeleportWatcher(watcher);
-    const domainNote =
-      cookies.length > 0 ? ` (${formatCookieDomainSummary(cookies)})` : '';
+    const domainNote = cookies.length > 0 ? ` (${formatCookieDomainSummary(cookies)})` : '';
     const storageNote =
       followerStorageEntries > 0
         ? ` + ${followerStorageEntries} storage entr${followerStorageEntries === 1 ? 'y' : 'ies'}`

--- a/packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/teleport.ts
@@ -5,8 +5,8 @@
  * `teleport-storage.ts`.
  */
 
-import type { BrowserAPI } from '../../../cdp/index.js';
-import { createLogger } from '../../../core/logger.js';
+import type { CookieTeleportCookie } from '@slicc/shared-ts';
+import { createLogger } from '../../../base/logger.js';
 import {
   applyTeleportStorageSnapshot,
   buildTeleportStorageHydrationUrl,
@@ -29,8 +29,35 @@ import type {
   TeleportWatcher,
 } from './types.js';
 
+/**
+ * Duck type for the CDP surface teleport needs — avoids shell → cdp layer back-edges
+ * (`docs/review-patterns.md` § Layer-stack import direction). Callers pass the real
+ * `BrowserAPI`; this module only uses the methods below.
+ */
+interface TeleportBrowserAPI {
+  attachToPage(targetId: string): Promise<string>;
+  evaluate(expression: string): Promise<unknown>;
+  sendCDP(
+    method: string,
+    params?: { cookies?: CookieTeleportCookie[]; url?: string }
+  ): Promise<{ cookies?: CookieTeleportCookie[] }>;
+  createRemotePage(runtimeId: string, url: string): Promise<string>;
+  closePage(targetId: string): Promise<void>;
+  navigate(url: string): Promise<void>;
+}
+
+interface NetworkGetCookiesResponse {
+  cookies?: CookieTeleportCookie[];
+}
+
+/** Narrow CDP `Network.getCookies` result into the shared cookie shape. */
+function cookiesFromCdpResult(cookies: unknown): CookieTeleportCookie[] {
+  if (!Array.isArray(cookies)) return [];
+  return cookies as CookieTeleportCookie[];
+}
+
 interface FollowerAuthState {
-  cookies: Array<Record<string, unknown>>;
+  cookies: CookieTeleportCookie[];
   followerStorage: TeleportStorageSnapshot;
   finalUrl?: string;
 }
@@ -58,7 +85,7 @@ export function resolveConnectedFollowers(): GetConnectedFollowersFn | null {
 }
 
 export async function handleTeleportTimeout(
-  browser: BrowserAPI,
+  browser: TeleportBrowserAPI,
   watcher: TeleportWatcher
 ): Promise<void> {
   log.warn('Teleport timed out', {
@@ -124,7 +151,7 @@ export function cleanupTeleportWatcher(watcher: TeleportWatcher): void {
  * Starts monitoring navigation via polling + CDP events.
  */
 export function armTeleportWatcher(
-  browser: BrowserAPI,
+  browser: TeleportBrowserAPI,
   state: PlaywrightState,
   startPattern: RegExp,
   returnPattern: RegExp,
@@ -172,28 +199,34 @@ export function armTeleportWatcher(
   });
 
   // Start polling the leader tab URL for start pattern match
-  watcher.pollInterval = setInterval(async () => {
-    if (watcher.phase !== 'armed') return;
-    const targetId = watcher.leaderTargetId;
-    if (!targetId) return;
+  watcher.pollInterval = setInterval(() => {
+    void (async () => {
+      if (watcher.phase !== 'armed') return;
+      const targetId = watcher.leaderTargetId;
+      if (!targetId) return;
 
-    try {
-      await browser.attachToPage(targetId);
-      const raw = await browser.evaluate('window.location.href');
-      const href = typeof raw === 'string' ? raw : String(raw);
-      log.debug('Polling leader tab URL', { targetId, href, startPattern: startPattern.source });
-      if (startPattern.test(href)) {
-        log.info('Teleport start pattern matched on leader');
-        log.debug('Teleport start pattern matched on leader details', {
-          targetId,
-          href,
-          startPattern: startPattern.source,
-        });
-        triggerTeleport(browser, state, watcher, href);
+      try {
+        await browser.attachToPage(targetId);
+        const raw = await browser.evaluate('window.location.href');
+        const href = typeof raw === 'string' ? raw : String(raw);
+        log.debug('Polling leader tab URL', { targetId, href, startPattern: startPattern.source });
+        if (startPattern.test(href)) {
+          log.info('Teleport start pattern matched on leader');
+          log.debug('Teleport start pattern matched on leader details', {
+            targetId,
+            href,
+            startPattern: startPattern.source,
+          });
+          void triggerTeleport(browser, state, watcher, href).catch((err) => {
+            log.error('Unhandled teleport trigger error', { error: String(err) });
+          });
+        }
+      } catch (err) {
+        log.warn('Error polling leader tab URL', { targetId, error: String(err) });
       }
-    } catch (err) {
-      log.warn('Error polling leader tab URL', { targetId, error: String(err) });
-    }
+    })().catch((err) => {
+      log.warn('Leader teleport poll failed', { error: String(err) });
+    });
   }, 1000);
 
   if (leaderTargetId) {
@@ -207,7 +240,7 @@ export function armTeleportWatcher(
  * monitor the follower for returnPattern, capture cookies, inject on leader.
  */
 async function triggerTeleport(
-  browser: BrowserAPI,
+  browser: TeleportBrowserAPI,
   state: PlaywrightState,
   watcher: TeleportWatcher,
   triggerUrl: string
@@ -225,11 +258,14 @@ async function triggerTeleport(
 
   try {
     // 1. Capture cookies from leader tab (before switching transport)
-    let leaderCookies: Array<Record<string, unknown>> = [];
+    let leaderCookies: CookieTeleportCookie[] = [];
     let leaderStorage = EMPTY_TELEPORT_STORAGE;
     try {
-      const cookieResult = await browser.sendCDP('Network.getCookies', {});
-      leaderCookies = (cookieResult['cookies'] as Array<Record<string, unknown>>) ?? [];
+      const cookieResult = (await browser.sendCDP(
+        'Network.getCookies',
+        {}
+      )) as NetworkGetCookiesResponse;
+      leaderCookies = cookiesFromCdpResult(cookieResult.cookies);
       log.info('Captured leader cookies for follower', { count: leaderCookies.length });
     } catch (err) {
       log.warn('Could not capture leader cookies', { error: String(err) });
@@ -317,7 +353,9 @@ async function triggerTeleport(
         watcher.phase === 'waitingForAuth' ||
         watcher.phase === 'waitingForReturn'
       ) {
-        void handleTeleportTimeout(browser, watcher);
+        void handleTeleportTimeout(browser, watcher).catch((err) => {
+          log.error('Teleport timeout handler failed', { error: String(err) });
+        });
       }
     }, watcher.timeoutMs);
 
@@ -327,55 +365,61 @@ async function triggerTeleport(
     log.debug('Teleport waiting for follower auth redirect details', {
       startPattern: watcher.startPattern.source,
     });
-    watcher.pollInterval = setInterval(async () => {
-      if (watcher.phase !== 'waitingForAuth' && watcher.phase !== 'waitingForReturn') return;
-      try {
-        await browser.attachToPage(followerTargetId);
-        const raw = await browser.evaluate('window.location.href');
-        const href = typeof raw === 'string' ? raw : String(raw);
-        if (!href) return;
-        if (watcher.lastFollowerUrl !== href) {
-          watcher.lastFollowerUrl = href;
-          log.debug('Follower teleport navigation', { href, phase: watcher.phase });
-        }
-
-        if (watcher.phase === 'waitingForAuth') {
-          // Waiting for follower to redirect to auth (e.g. Okta)
-          if (watcher.startPattern.test(href)) {
-            watcher.phase = 'waitingForReturn';
-            log.info('Follower reached auth provider; waiting for return pattern');
-            log.debug('Follower reached auth provider details', {
-              href,
-              startPattern: watcher.startPattern.source,
-            });
-          } else {
-            log.debug('Waiting for auth redirect on follower', {
-              href,
-              startPattern: watcher.startPattern.source,
-            });
+    watcher.pollInterval = setInterval(() => {
+      void (async () => {
+        if (watcher.phase !== 'waitingForAuth' && watcher.phase !== 'waitingForReturn') return;
+        try {
+          await browser.attachToPage(followerTargetId);
+          const raw = await browser.evaluate('window.location.href');
+          const href = typeof raw === 'string' ? raw : String(raw);
+          if (!href) return;
+          if (watcher.lastFollowerUrl !== href) {
+            watcher.lastFollowerUrl = href;
+            log.debug('Follower teleport navigation', { href, phase: watcher.phase });
           }
-          return; // Don't check return pattern yet
-        }
 
-        // Waiting for return from auth
-        log.debug('Polling follower tab URL for return', {
-          href,
-          returnPattern: watcher.returnPattern.source,
-        });
-        if (shouldCaptureTeleportDiagnostics(href)) {
-          await logFollowerTeleportDiagnosticsOnce(browser, watcher, 'waiting-for-return');
-        }
-        if (watcher.returnPattern.test(href)) {
-          log.info('Follower return pattern matched after auth');
-          log.debug('Follower return pattern matched after auth details', {
+          if (watcher.phase === 'waitingForAuth') {
+            // Waiting for follower to redirect to auth (e.g. Okta)
+            if (watcher.startPattern.test(href)) {
+              watcher.phase = 'waitingForReturn';
+              log.info('Follower reached auth provider; waiting for return pattern');
+              log.debug('Follower reached auth provider details', {
+                href,
+                startPattern: watcher.startPattern.source,
+              });
+            } else {
+              log.debug('Waiting for auth redirect on follower', {
+                href,
+                startPattern: watcher.startPattern.source,
+              });
+            }
+            return; // Don't check return pattern yet
+          }
+
+          // Waiting for return from auth
+          log.debug('Polling follower tab URL for return', {
             href,
             returnPattern: watcher.returnPattern.source,
           });
-          captureCookiesAndComplete(browser, state, watcher, runtimeId!);
+          if (shouldCaptureTeleportDiagnostics(href)) {
+            await logFollowerTeleportDiagnosticsOnce(browser, watcher, 'waiting-for-return');
+          }
+          if (watcher.returnPattern.test(href)) {
+            log.info('Follower return pattern matched after auth');
+            log.debug('Follower return pattern matched after auth details', {
+              href,
+              returnPattern: watcher.returnPattern.source,
+            });
+            void captureCookiesAndComplete(browser, state, watcher, runtimeId).catch((err) => {
+              log.error('Unhandled teleport capture error', { error: String(err) });
+            });
+          }
+        } catch (err) {
+          log.warn('Error polling follower tab URL', { error: String(err) });
         }
-      } catch (err) {
-        log.warn('Error polling follower tab URL', { error: String(err) });
-      }
+      })().catch((err) => {
+        log.warn('Follower teleport poll failed', { error: String(err) });
+      });
     }, 1000);
   } catch (err) {
     log.error('Teleport trigger failed', { error: String(err) });
@@ -391,7 +435,7 @@ async function triggerTeleport(
  * Also runs diagnostics, removes the follower replay script, and closes the tab.
  */
 async function captureFollowerAuthState(
-  browser: BrowserAPI,
+  browser: TeleportBrowserAPI,
   watcher: TeleportWatcher
 ): Promise<FollowerAuthState> {
   // 1. Wait for redirect chain to settle
@@ -419,10 +463,10 @@ async function captureFollowerAuthState(
     log.warn('Could not read follower page content', { error: String(err) });
   }
 
-  const cookieResult = await browser.sendCDP('Network.getCookies');
-  const cookies = (cookieResult['cookies'] as Array<Record<string, unknown>>) ?? [];
+  const cookieResult = (await browser.sendCDP('Network.getCookies')) as NetworkGetCookiesResponse;
+  const cookies = cookiesFromCdpResult(cookieResult.cookies);
   const domainSummary =
-    cookies.length > 0 ? formatCookieDomainSummary(cookies as Array<{ domain?: string }>) : 'none';
+    cookies.length > 0 ? formatCookieDomainSummary(cookies) : 'none';
   log.info('Captured cookies from follower', { count: cookies.length });
   log.debug('Captured cookies from follower details', {
     count: cookies.length,
@@ -468,7 +512,7 @@ async function captureFollowerAuthState(
  * directly, then land. Falls back to an init-script replay if direct apply fails.
  */
 async function hydrateLeaderOriginThenLand(
-  browser: BrowserAPI,
+  browser: TeleportBrowserAPI,
   leaderTargetId: string,
   followerStorage: TeleportStorageSnapshot,
   hydrationUrl: string,
@@ -510,7 +554,7 @@ async function hydrateLeaderOriginThenLand(
  * leader to the landing URL with the script installed through the load.
  */
 async function replayLeaderStorageThenLand(
-  browser: BrowserAPI,
+  browser: TeleportBrowserAPI,
   watcher: TeleportWatcher,
   followerStorage: TeleportStorageSnapshot,
   landingUrl: string | undefined,
@@ -553,9 +597,9 @@ async function replayLeaderStorageThenLand(
  * landing URL the leader was navigated to (if any).
  */
 async function injectAuthStateIntoLeader(
-  browser: BrowserAPI,
+  browser: TeleportBrowserAPI,
   watcher: TeleportWatcher,
-  cookies: Array<Record<string, unknown>>,
+  cookies: CookieTeleportCookie[],
   followerStorage: TeleportStorageSnapshot,
   finalUrl: string | undefined
 ): Promise<string | undefined> {
@@ -619,7 +663,7 @@ async function injectAuthStateIntoLeader(
  * Capture cookies + app state from the follower, inject into the leader, navigate leader to the final URL.
  */
 async function captureCookiesAndComplete(
-  browser: BrowserAPI,
+  browser: TeleportBrowserAPI,
   _state: PlaywrightState,
   watcher: TeleportWatcher,
   runtimeId: string
@@ -657,9 +701,7 @@ async function captureCookiesAndComplete(
     watcher.phase = 'done';
     cleanupTeleportWatcher(watcher);
     const domainNote =
-      cookies.length > 0
-        ? ` (${formatCookieDomainSummary(cookies as Array<{ domain?: string }>)})`
-        : '';
+      cookies.length > 0 ? ` (${formatCookieDomainSummary(cookies)})` : '';
     const storageNote =
       followerStorageEntries > 0
         ? ` + ${followerStorageEntries} storage entr${followerStorageEntries === 1 ? 'y' : 'ies'}`


### PR DESCRIPTION
## Summary

- Cleared **floating-promise** debt: replaced bare `void`/fire-and-forget async calls with explicit `.catch()` handlers on teleport poll intervals, timeout timer, `triggerTeleport`, and `captureCookiesAndComplete`; removed the `noFloatingPromises` biome override for this file.
- Cleared **layer-back-edge** debt: stopped importing `cdp/` and `core/` from shell — use `base/logger` and a local `TeleportBrowserAPI` duck type (same pattern as `teleport-storage.ts`).
- Cleared **record-string-unknown** debt: replaced `Record<string, unknown>` cookie bags with `CookieTeleportCookie` from `@slicc/shared-ts` and a `cookiesFromCdpResult` narrow helper.

## Debt lists cleared

- `biome.json` → `nursery.noFloatingPromises` override
- `layer-back-edge-baseline.json`
- `record-string-unknown-baseline.json`

## Test plan

- [x] `node packages/dev-tools/tools/check-layer-back-edges.mjs --update`
- [x] Manual baseline ratchet for `record-string-unknown` (local disk full prevented biome re-run)
- [ ] CI: `check-touched-exemptions.mjs`, typecheck, tests, build
- [ ] Existing teleport tests: `packages/webapp/tests/shell/supplemental-commands/playwright/teleport-storage.test.ts`, `teleport-follower-shim.test.ts`, `playwright-command.test.ts` (teleport block cases)