### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -132,7 +132,7 @@
   },
   "swift": {
     "swift-server": {
-      "lines": 65,
+      "lines": 66,
       "functions": 63,
       "regions": 62
     },


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.