### PR TITLE
chore(docs): compact CLAUDE.md guides for weekly headroom

### DIFF
--- a/docs/cloudflare-worker-details.md
+++ b/docs/cloudflare-worker-details.md
@@ -120,3 +120,14 @@ All `/api/cloud/*` require `Authorization: Bearer <ims-access-token>` and route 
 | `POST /api/cloud/kill`        | Kill a cone (idempotent)                                                    |
 | `POST /api/cloud/sign-out`    | Invalidate auth cache for the bearer                                        |
 | `GET /api/cloud/admin/stats`  | Admin-gated by `ADMIN_USER_IDS`                                             |
+
+## <a name="v1-v2-expansion"></a>v1 → v2 Expansion
+
+Flip an existing deployment from open-domain (`ALLOWED_EMAIL_DOMAIN` allows
+anyone) to ownerOrg-gated access:
+
+```bash
+npx wrangler secret put REQUIRE_OWNER_ORG  # value: true
+# update ALLOWED_EMAIL_DOMAIN in wrangler.jsonc to "*"
+npx wrangler deploy
+```

--- a/docs/dev-tools-details.md
+++ b/docs/dev-tools-details.md
@@ -459,7 +459,64 @@ unknown>).chrome = …` is idiomatic scaffolding, and `biome.json` already
 exempts tests from `noExplicitAny` and the complexity rules for the same
 reason. Chained into `npm run lint` and `lint:ci`.
 
+## hf-cache-mirror
+
+`packages/dev-tools/tools/hf-cache-mirror.mjs` is a zero-dep local
+`huggingface.co` mirror with an on-disk store. The e2e CI job runs it, persists
+`.cache/hf-mirror` with `actions/cache`, and hands `HF_ENDPOINT` to the virtual
+shell's `hf download` so the Kokoro weights come off disk on warm runs.
+
+## ios-ui-test-exclusion-registry
+
+`npm run lint:ios-ui-tests` (`packages/dev-tools/tools/ios-ui-test-exclusions.mjs` +
+`packages/ios-app/ui-test-exclusions.json`). `ios-app-tests` runs the **whole**
+`SliccFollowerUITests` bundle on the GA cells and subtracts this registry, so a
+new class is gated the day it lands. The gate rejects an entry with no reason
+or one naming a class/method that no longer exists.
+
+## swiftpm-lockfile-drift
+
+`packages/dev-tools/tools/check-swift-resolved-drift.mjs` — run AFTER a resolve
+step (the `ios-app` CI job). `xcodebuild -resolvePackageDependencies` rewrites
+`Package.resolved` in place and builds against what it wrote, so a floated
+**transitive** pin lands with no diff; `lint:swift-pins` only sees direct pins.
+Compares identity/version/revision, ignoring `originHash` and key order (both
+move with the toolchain).
+
+## first-load-size-gate
+
+Part of `npm run size -w @slicc/webapp`. `packages/dev-tools/tools/check-first-load-size.mjs`
+(+ `first-load-size-lib.mjs`, `first-load-baseline.mjs`) measures the eager
+import closures of the page entry (via `.vite/manifest.json`) and the
+kernel-worker entry (parsed from emitted chunks). Guards cold-boot payload,
+not per-file size.
+
+**Relative**: it builds the merge-base in a throwaway worktree (workspace
+packages re-pointed at the worktree's own source, then the root `postinstall`
+prerequisite builds — borrowing the caller's would mask a webcomponents-side
+regression) (`--baseline=<ref>`, default `origin/main`; `--baseline=none` to
+skip, `--json` to just measure) and fails on a change's own growth past
+`maxDeltaKb`, so it never fires on inherited state and cancels the ~1 kB
+Linux-vs-macOS build difference.
+
+On `merge_group` the delta is skipped (a queue branch is cumulative — its
+delta is the batch sum, and a per-change allowance would fail on queue
+depth); ceilings only, no baseline build. That split is only safe because a
+CI `pull_request` run treats an unmeasurable baseline as a hard failure
+rather than degrading — otherwise a PR could clear both stages unmeasured.
+Local runs still degrade to ceilings with a note.
+
+The absolute `*EagerCeilingKb` values in
+`packages/webapp/first-load-budget.json` are the backstop against many small
+under-threshold changes creeping upward — human-owned, not numbers to nudge
+when a build goes red.
+
 ## storybook-screenshots-upload
+
+Capture: `storybook-affected-screenshots.mjs` (+
+`storybook-affected-stories-lib.mjs`) takes light/dark shots of affected
+webcomponents stories; pair with `npm run build-storybook -w @slicc/webcomponents`.
+iOS PR shots: `ios-screenshots.mjs` (+ `ios-screenshots-lib.mjs`).
 
 `storybook-screenshots-upload.mjs` (+ `storybook-screenshots-upload-lib.mjs`)
 uploads the affected-story manifest to the `slicc-pr-screenshots` R2
@@ -557,6 +614,17 @@ to report per-test results); tested by
 `swift-coverage-runner-retry.test.mjs`. Set `SLICC_IOS_SIM_UDID` to a
 worktree-owned simulator UDID to override automatic selection locally;
 when unset or empty, existing SDK-runtime selection remains unchanged.
+
+## optional-binary-guard
+
+`run-if-installed.mjs <binary> [args...]` runs iff the binary is on `PATH`,
+else warns and exits 0. Used by the root `lint-staged` Swift/Go globs so a
+missing toolchain does not fail a commit that only touches those files.
+
+## skill-lint
+
+`lint-skills.mjs` (`npm run lint:skills`) shells out to `tessl skill lint`
+via `@tessl/cli`. Warns locally; fails under `--strict`/CI.
 
 ## fresh-dev-harnesses
 

--- a/docs/ios-app-details.md
+++ b/docs/ios-app-details.md
@@ -282,3 +282,20 @@ Outputs land in `.build/coverage/`. The gate runs only `SliccFollowerTests`, dis
 `scripts/testflight-distribute.mjs` (gated on `SLICC_TF_EXTERNAL_GROUP`; unset = upload-only) waits for processing, sets What to Test notes, submits Beta App Review, and attaches the build to that group. **Submission and attach are independent** — only a `fatal` submit aborts; `deferred` (review quota) warns and still attaches, so the build ships once review clears. Tests: `testflight-distribute.test.mjs`.
 
 What to Test copy comes from `composeWhatsNew()`: the release workflow's `analyze` job drafts end-user highlights from the last week of `feat`/`fix`/`perf`/revert commits touching `packages/ios-app` + the swift tray packages (path-selected, not scope-selected — cross-cutting tray work rarely carries an `ios` scope) via headless `claude -p` on Bedrock (not `claude-code-action` — it rejects push-triggered workflows) and passes them as `SLICC_TF_WHATS_NEW`; the static onboarding copy (session-join instructions, appending `SLICC_TF_DEMO_JOIN_URL`) always follows, and highlights are capped at 3,000 code points so the footer survives the ASC 4,000-char limit. The draft is **best-effort by design** — no iOS commits, a model outage, or empty output all leave `SLICC_TF_WHATS_NEW` unset and the static copy ships alone; the draft must never block a release.
+
+## App Icon
+
+`Assets.xcassets/AppIcon.appiconset` carries three 1024s: `Icon-Default`, `Icon-Dark`, `Icon-Tinted`.
+
+`Icon-Tinted` is **hand-authored, not a desaturation of the colour icon** — master at `packages/assets/logos/slicc-icon-tinted-master-1024.png`. iOS tinted mode maps the asset's _luminance_ onto the user's tint, so an asset confined to the top of the range can only render as a flat blob. The previous `Icon-Tinted` was byte-identical to the Icon Composer `TintedLight` export and never dropped below 39% grey (min 100/255, σ 39); the current one spans the full range (min 0, σ 81) by seating a bright swirl in a near-black tub. Re-check `min`/`stddev` before replacing it:
+
+```bash
+magick Icon-Tinted.png -alpha remove -colorspace Gray \
+  -format "min=%[fx:minima*255] sd=%[fx:standard_deviation*255]\n" info:
+```
+
+It is full-bleed square (iOS applies its own superellipse mask), unlike `Icon-Dark`, which still carries pre-rounded transparent corners. The macOS side does **not** consume this PNG — Sliccstart derives its tinted appearance from `macos-icon.icon`; see [swift-launcher](../packages/swift-launcher/CLAUDE.md#app-icon).
+
+## Related
+
+Canonical wire: `packages/shared-ts/src/tray-sync-protocol.ts`. Leader/follower: `packages/webapp/src/scoops/tray-leader-sync.ts`, `packages/webapp/src/scoops/tray-follower-sync.ts`. Sprinkles: `packages/webapp/src/ui/sprinkle-follower-controller.ts`. Matrix: `docs/architecture.md` "Multi-Browser Sync (Tray) Architecture". Simulator QA: [`docs/ios-simulator-qa.md`](ios-simulator-qa.md).

--- a/docs/swift-launcher-details.md
+++ b/docs/swift-launcher-details.md
@@ -65,3 +65,55 @@ The iCloud store is readable only by this signed, iCloud-entitled binary, so the
 `Models/LaunchRecordStore.swift` persists a `PersistedLaunchRecord` JSON (servePort, CDP port, electronAppPath, target name, target type, joinUrl, bridgeToken) at `~/Library/Application Support/Sliccstart/launch-records.json`, plus `CDPLiveProbe` for liveness checks via `/json/version`. No PID is stored — process identity isn't needed for reattach because the CDP port answering `/json/version` is what decides whether the previous browser is still alive. The `bridgeToken` is persisted because the surviving browser tab carries it in its launch URL (`?bridgeToken=<token>`); reattach re-forwards the same token so the re-spawned `--serve-only` slicc-server keeps gating `/cdp` against the secret the tab already has, instead of a freshly-minted static one. Legacy records carrying a `staticRoot` key still decode; the extra key is ignored, and a missing `bridgeToken`/`joinUrl` key loads as nil.
 
 Reattach also has to recover `leaderJoinUrl`, because that single value gates every Electron/terminal row (`isLeaderReady()`) and all iCloud session advertising. `reattach` therefore calls `startLeaderProbe` — **after** `spawn` has registered the launch record, not before. The probe loop's per-round decision is the pure `SliccProcess.leaderProbeStep`: it probes while a `chromiumBrowser` record is live, stops once a join URL lands or a record it had already seen goes away, and — the part that matters here — _waits_ (bounded by `leaderProbeRecordWaitRounds` × `leaderProbeRecordWaitDelay`, ~6 s) for a record that has never appeared yet. `reattachPersistedRecords` is nonisolated `async`, so the probe's first main-actor hop can beat the record insertion; treating that as terminal left `leaderJoinUrl` nil for the entire session after a smooth update, which showed up as every desktop app stuck on "Start a browser first" with a perfectly healthy leader. Tests: `SliccProcessLeaderProbeTests`.
+
+## swiftui-testing
+
+`SliccstartTests/ViewHosting.swift` renders a view off-screen with `ImageRenderer` and returns a digest of the bitmap, so a test can assert that two states of a view **render differently** (`assertRendersDifferently`) — the only way to reach `AppListView` / `SettingsView` body branches from a unit test.
+
+- **No interaction.** Headless SwiftUI on macOS builds no AppKit control tree and no accessibility tree, so buttons cannot be pressed. Button _actions_ are tested through the plain types they delegate to (`BrowserLaunchAction`, `TerminalLaunchDecision`, `AppRow.statusDot`, …) — keep new view logic in such a type rather than inline in a closure. The exception is `.borderless` buttons, which do materialize as `NSButton`s (`ViewHosting.hostedButtons`, used for `TraySessionRow`).
+- **CI runs an older macOS than your Mac** (`macos-latest` is still macOS 15). How much of an AppKit-hosted subtree — `Table`, and anything overlaid on one — an off-screen render produces differs between them, so a render comparison that passes locally is not evidence it passes in CI. Compare only over plain SwiftUI content.
+- **Vary exactly one thing per comparison.** Two states that differ in more than one way render differently whether or not the feature under test exists. Pin everything else (`subtitleOverride:`, identical messages, an empty `Secret`), or assert the underlying rule (`AppListView.updateAffordance`, `SecretEditorSheet.validationMessage`) instead of writing a comparison that cannot fail. Mutate the source and watch the test go red before trusting it.
+- **`Table`, `Toggle` and `.borderless` buttons draw nothing** (`NSTableView`/`NSSwitch`-backed), so table cells, switch knobs, and anything styled by tint on a borderless button are asserted against their model types instead.
+
+Views take their non-injectable state as init seams: `AppListView(isBundledBuild:)` (the whole update footer is otherwise unreachable outside a packaged `.app`), `MountsSettingsView(rows:)`, `SecretsSettingsView(secrets:unlocked:selection:)` (never touches the Keychain).
+
+**The window is a model, not a `Scene`.** An `App`'s `Scene` cannot be rendered, so anything living inside `WindowGroup` is untestable by construction. `SliccstartApp` is therefore only wiring: the window's behavior is **`Models/LauncherModel.swift`** (launch decisions, dialogs, debug builds, update-check outcomes, the 2 s tick, leader publish/withdraw) and its content is **`Views/RootView.swift`**. `SliccstartAppDelegate` is the composition root, with every collaborator defaulted-but-injectable so the two quit paths (stop-everything vs detach-for-update) are testable. Put new window behavior on `LauncherModel`, not in a `WindowGroup` closure. Tests: `LauncherModelTests`, `RootViewRenderTests`, `AppDelegateLifecycleTests`.
+
+**Launch paths** go through `SliccProcess.SpawnServices` — resolve-binary, run-process, is-port-in-use. Injected so `launchStandalone` / `launchBrowserFollower` / `launchWithElectronApp` are testable without starting a browser or binding 5710/9222; the stub runs `/bin/sleep` in the server's place so records, pids and termination handling stay real. Tests: `SliccProcessLaunchPathTests`.
+
+**Auto-launch requires an installed app.** `StartupPreference.shouldAutoLaunch` is `resolveEnabled && isInstalledLocation` — a copy running from a build directory, `~/Downloads`, or Gatekeeper's translocated path never starts a browser, so a dev/CI run of the launcher cannot take over the screen. The preference is untouched and the Startup tab explains the refusal.
+
+`SliccProcess`, `SliccBootstrapper` and `AppManagementPermission` are deliberately **not `final`** — they are the app's side-effecting collaborators (spawning browsers, running git/npm, opening System Settings), and `@testable` lets a test subclass stand in for them.
+
+## app-icon
+
+Two artefacts, both written by `build-app-icon.mjs`:
+
+- **`AppIcon.icns`** — one flat image from `packages/assets/logos/macos-icon-iOS-Default-1024x1024@1x.png`, via `sips` + `iconutil` (both ship with macOS). `CFBundleIconFile`.
+- **`Assets.car`** — `actool`-compiled from `packages/assets/logos/macos-icon.icon` (Icon Composer). Adds the `NSAppearanceNameAqua` / `NSAppearanceNameDarkAqua` / `ISAppearanceTintable` icon stacks macOS 26 picks between. `CFBundleIconName`, emitted into `Info.plist` only when the compile succeeds.
+
+`buildIconAssetCatalog` **degrades instead of throwing** on all three failure modes — the bundle still gets its `.icns`, just with no Dark/Tinted appearance:
+
+1. `actool` absent (it lives in Xcode, not the Command Line Tools);
+2. `actool` present but too old to compile the `.icon` — **this is the common case in CI**, whose `swift-launcher` job runs on `macos-latest` (still macOS 15 / Xcode 16.x); only `release.yml` pins `macos-26`;
+3. `actool` exits 0 but writes no `Assets.car`.
+
+A green `swift-launcher` CI build is **not** proof the appearance variants shipped — only the `macos-26` release job produces them. Watch for the `WARNING: appearance-keyed app icon skipped` line if a build's icon stops adapting, and confirm what actually shipped with `xcrun assetutil --info <app>/Contents/Resources/Assets.car`.
+
+A classic `AppIcon.appiconset` cannot replace the `.icon` here: `actool` honours the `appearances` key on iOS idioms only and reports macOS ones as "unassigned children", dropping them without failing the build. Per-appearance _custom artwork_ (`image-name-specializations`) exists in the `.icon` format but is authored in Icon Composer — hand-written variants of that key are silently ignored, so the macOS Tinted icon is **system-derived** from the layer artwork. Its contrast is therefore a property of `macos-icon.icon`'s layer, not something a separate PNG can override. Tests: `build-app-icon.test.mjs`.
+
+## packaging
+
+- `npm run build` assembles the `.app` from pre-built artifacts; `sign-and-package.sh` is the distributable path.
+- Expects `packages/swift-server/.build/release/slicc-server` to be pre-built. Webapp is **not** bundled — `assemble-app.mjs` writes an empty `Contents/Resources/slicc` marker dir.
+- **`WebRTC.framework` ships next to `slicc-server`**: `sign-and-package.sh` re-signs **innermost-first** — else dyld fails and every spawned server dies as "start failed".
+- Electron overlay bootstrap `dist/ui/electron-overlay-entry.js` is produced by **`@ai-ecoverse/spoon`** (`npm run build -w @ai-ecoverse/spoon`) and must be built before `assemble-app.mjs`; a `packages/spoon/**` change re-triggers this CI job.
+- Packaging emits only the full `Sliccstart-<v>.zip`.
+
+## ordering-mounts-browser
+
+`Models/AppOrdering.swift` holds default `browserBundlePriority` / `terminalBundlePriority`; user drag-reorder via `AppOrderStore` UserDefaults wins. `browserFollowerArgs(cdpPort:joinUrl:)` passes `--join=<url>` vs `--lead`; `launchBrowserFollower` flags `isFollower`. `BrowserLaunchAction` and the lead-or-attach dialog count only attachable iCloud sessions (no confirmed-unreachable `SessionReachability` verdict) — all-dead lists launch standalone with no dialog. `Models/StartupPreference.swift`: launch starts the top-ordered browser (`AppOrdering.topBrowser`). Tests: `AppOrderingTests`, `StartupPreferenceTests`, `SliccProcessLaunchArgsTests`.
+
+`Models/MountTablePreference.swift`: newline-separated `autoMountTable` UserDefault of `os-path:slicc-path` mappings (parse mirrors swift-server `ServerConfig.parseMountMapping`: last-colon split, `~` expansion, dedup by target), emitted as `--mount=<os>:<vfs>` by `standaloneBrowserArgs(cdpPort:mounts:)` and `reattachArgs(...mounts:)` (browsers only). Mapped folders are served by swift-server's `/api/hostfs` and auto-mounted by the webapp — no picker, no permission prompt. `Views/SettingsView.swift` → `MountsSettingsView`. Tests: `MountTablePreferenceTests`, `SliccProcessLaunchArgsTests`. Behaviour: [`docs/mounts.md`](mounts.md#auto-mounted-host-folders-the-mount-table).
+
+Sliccstart can hold the macOS http/https handler role (Settings → Startup). `Models/DefaultBrowserRegistration.swift` claims it; `assemble-app.mjs`'s `CFBundleURLTypes` is the precondition; `Models/IncomingURLRouter.swift` opens each link over CDP. See [`docs/sliccstart-browser.md`](sliccstart-browser.md).

--- a/docs/transcript-export.md
+++ b/docs/transcript-export.md
@@ -384,4 +384,4 @@ after reconnection.
 - `packages/vfs-root/workspace/skills/transcript-export/SKILL.md` — agent-facing skill.
 - `packages/shared-ts/src/transcript-export.ts` — TypeScript schema types and runtime validator.
 - `packages/cherry/CLAUDE.md` — Cherry SDK wiring for transcript export.
-- `packages/webapp/CLAUDE.md` — Frozen Sessions section for session state details.
+- [`webapp-details.md`](webapp-details.md) — Frozen Sessions for session state details.

--- a/docs/webapp-details.md
+++ b/docs/webapp-details.md
@@ -13,18 +13,20 @@ Overflow from `packages/webapp/CLAUDE.md`. Each section is the deep reference fo
 ## Orchestrator
 
 - Path: `packages/webapp/src/scoops/`
-- `orchestrator.ts` owns scoop lifecycle, routing, shared state, and pre-removal `onScoopUnregistered` snapshots. `scoop-context.ts` owns per-scoop prompt execution and FS/tool isolation — it is a ~620-line coordinator over `scoops/scoop-context/`, one module per reason to change (#2334): `runtime-init.ts` (boot sequence) · `turn-runner.ts` (attempt/retry) · `turn-process.ts` (the turn's pid + exit code) · `run-bounds.ts` (#1972 ceilings) · `agent-event-router.ts` + `agent-end-dispatch.ts` (event plumbing and what a terminal `agent_end` means) · `overflow-recovery.ts` / `image-recovery.ts` · `session-persistence.ts` (#1987) · `bash-job-reaper.ts` (#1166) · `live-updates.ts` (hot-swaps onto a running agent) · `shell-and-skills.ts`, `tools.ts`, `agent-factory.ts`, `session-helpers.ts`, `system-prompt.ts`, `directory-structure.ts`, `memories.ts`, `sudo-wiring.ts` (assembly) · `model-resolution.ts`, `thinking-level.ts`, `shell-env.ts`, `error-classification.ts` (record-level, no agent needed) · `callbacks.ts` (the owner's contract). Each module's header states what it owns; add a responsibility as a new module, not a method on the facade. `agent-bridge.ts` exposes `globalThis.__slicc_agent` (defaults: writable `[cwd, /shared/, <scratch>/, /tmp/]`, visible `[/workspace/, invokingCwd]`; `--read-only` replaces).
+- `orchestrator.ts` owns scoop lifecycle, routing, shared state, and pre-removal `onScoopUnregistered` snapshots. `scoop-context.ts` owns per-scoop prompt execution and FS/tool isolation — it is a ~620-line coordinator over `scoops/scoop-context/`, one module per reason to change (#2334): `runtime-init.ts` (boot sequence) · `turn-runner.ts` (attempt/retry) · `turn-process.ts` (the turn's pid + exit code) · `run-bounds.ts` (#1972 ceilings) · `agent-event-router.ts` + `agent-end-dispatch.ts` (event plumbing and what a terminal `agent_end` means) · `overflow-recovery.ts` / `image-recovery.ts` · `session-persistence.ts` (#1987) · `bash-job-reaper.ts` (#1166) · `live-updates.ts` (hot-swaps onto a running agent) · `shell-and-skills.ts`, `tools.ts`, `agent-factory.ts`, `session-helpers.ts`, `system-prompt.ts`, `directory-structure.ts`, `memories.ts`, `sudo-wiring.ts` (assembly) · `model-resolution.ts`, `thinking-level.ts`, `shell-env.ts`, `error-classification.ts` (record-level, no agent needed) · `callbacks.ts` (the owner's contract). Each module's header states what it owns; add a responsibility as a new module, not a method on the facade. `agent-bridge.ts` exposes `globalThis.__slicc_agent` (defaults: writable `[cwd, /shared/, <scratch>/, /tmp/]`, visible `[...defaultChildVisibleRoots(owning cone), invokingCwd]`; `--read-only` replaces).
 - `scoop-message-router.ts`: licks use `SCOOP_QUEUE_DEBOUNCE_MS` (1 s) bounded by `SCOOP_QUEUE_MAX_COALESCE_MS` (3 s); pure-lick batches defer while `ScoopContext.isBusy` without queue/watermark loss; `SCOOP_DEFERRAL_STARVATION_MS` reports backpressure once after 5 min. User `web` bypasses the window (immediate/awaited, prevents deferral).
 - `transcript-limits.ts` caps bridge/event transcripts at 64 KB — never canonical `agent-sessions` history or compaction input.
 
 ## VirtualFS
 
 - Path: `packages/webapp/src/fs/`. `virtual-fs.ts` POSIX-like FS backed by OPFS (in-memory in Node tests). `restricted-fs.ts` path ACLs. `mount-commands.ts` parses `--source`/`--profile`/`--no-probe`; `path-utils.ts` normalization.
+- Prefer absolute VFS paths (`/workspace/...`, `/shared/...`). `VirtualFS.create({ dbName, wipe })` is the entry point for isolated testable instances. Mounted directories bridge directly to `FileSystemDirectoryHandle`; do not copy large trees into IndexedDB unless you mean to. Use `fs.walk()` and `path-utils.ts` instead of ad hoc path splitting. `RestrictedFS` is the correct boundary when code should not see the whole VFS.
 - `mount/` — `MountBackend` + `backend-local.ts` / `backend-s3.ts` / `backend-da.ts` and shared `RemoteMountCache` (TTL+ETag, IDB). Browser-naive signing: CLI → `/api/s3-sign-and-forward`, extension → SW. `mount-table-store.ts` / `mount-recovery.ts` persist and restore. See `docs/mounts.md`.
 
 ## Shell
 
 - Path: `packages/webapp/src/shell/`. `almost-bash-shell.ts` is the just-bash runtime; `supplemental-commands/` built-ins live under `docs/shell-reference.md`. `script-catalog.ts` is the shared `.jsh`/`.bsh` discovery for the shell and `which`, cached per `$PATH` root set; the `FsWatcher` cache is bypassed only for root sets a mount overlaps (external changes there are invisible). `vfs-adapter.ts` bridges shell → VFS and forwards `canWrite` (duck-typed for `VirtualFS`/`RestrictedFS`).
+- Bash progress overlay (`shell/progress/`): one `ScriptRun` unit per tool call. `planScriptProgress` counts registry dispatches from `bash.transform().ast`; steps tick at `wrapCommandForDispatch` on completion. `sleep`/`timeout` tickers, `wrapCommandForProgress` start/end, and `createFetchProgressObserver` bytes (fed by `proxied-fetch.ts` + node-server `X-Proxy-Content-Length`) fold in via `emitter.setAggregator` (≤4 events/s per id). Events ride `ToolExecutionContext.onUpdate` as `progress` partials → `tool_progress` agent event → `applyToolProgress` (icon fill, 3-dot badge, body top bar) + send-button `progress` ring. Design: `docs/exploration/bash-progress-overlay.md`.
 - `typescript` v7 (native) runs checks/builds; `typescript-js` (JS v6) powers browser `tsc`/`test`/`esm-transpile` because v7 has no browser/WASM API. `builtin-shadow-map.ts` is authoritative for `ipx`/`npx` → built-in redirects. Raw scans: `jsh-discovery.ts` / `bsh-discovery.ts`.
 
 ## Speech
@@ -34,6 +36,7 @@ Overflow from `packages/webapp/CLAUDE.md`. Each section is the deep reference fo
 - Asset staging (`ensure-speech-assets.ts` via `kernel/speech-assets-bridge.ts`) is **single-flight**: the worker responder coalesces concurrent page requests (`hear --warmup`, `say --warmup`, the composer warmup) onto one run and fans progress/result out to every caller — never run two stagers over the same tree. `hf download` skips a present file only at the **listed byte length** (a torn write is re-fetched), and the ort install is gated on the required jsep + plain threaded builds only — optional `asyncify`/`jspi` variants missing must not trigger a `dist/` rewrite under a loading engine.
 - ort-web threads (`transformers-env.ts` `resolveOrtNumThreads`, #2042): set explicitly, never auto-detected. Isolated leader (Document-Isolation-Policy) → `min(4, hardwareConcurrency)`; any non-isolated float → `1`. `localStorage.slicc_ort_num_threads` overrides (clamped to `[1, min(4, cores)]`, isolated only) for A/B timing — it **persists** until removed and logs a `console.warn` whenever it is in effect; `whisper transcribe` / `kokoro synthesize` log lines carry `elapsedMs` + `numThreads`.
 - **Extension `uiOnly` side panel**: Chrome denies `getUserMedia` (mic prompt keys on extension origin, ungrantable from cross-origin iframe), so `wc-follower.ts` skips `ptt` and drops "Take a photo". Voice/camera live in the leader tab or detached popout.
+- The kernel-worker build stubs `speech/speak.ts` + `speech/hear.ts` (`stubPageRealmSpeechPlugin`, `worker.plugins` only). `say`/`hear` keep their local and panel-RPC branches in one module; the local branch is gated on `speechSynthesis`, so in a worker it is dead code that would drag `kokoro-js` + `@huggingface/transformers` into a build the page graph already covers. Same reason `speech/model-ids.ts` exists — a model-id constant must never be imported from an engine. See `docs/pitfalls.md`.
 
 ## MCP Servers
 
@@ -100,7 +103,7 @@ One roster, three renderings, one vocabulary — `ui/follower-presentation.ts` o
 
 ## Frozen Sessions ("New session" flow)
 
-- Path: `ui/session-freezer.ts`, `ui/new-session.ts`. **Save**, **Skip memory**, and **Erase** clear cone chat and non-mount `/tmp`, not scoops. Archives in `/sessions/<timestamp>-<slug>.md` + `index.json`. Idle boot recovers pending markers serially (≤3 times) through the **bounded** legacy enrichment call — never the unbounded curator (`timeoutSeconds` cannot stop it). Agentic Save: quick snapshot then clear; title (`skipMemory`) + curator in background. The curator edits a staged draft under `/sessions/.curation/<archive>/` that the agent bridge three-way-merges onto the live memory file on exit 0 (`mergeOnSuccess`; concurrent live edits survive, conflicts resolve to the curator); the bridge also writes `status.json` there on both exit paths (`outcomeReceiptPath`), and the index entry records `memoryCuratedAt` on success / `memoryFailed` on failure or retry exhaustion — the durable which-sessions-curated ledger. Cone-only `OffscreenClient.clearAllMessages()` awaits `clear-chat-ack` before panel reload.
+- Path: `ui/session-freezer.ts`, `ui/new-session.ts`. **Save**, **Skip memory**, and **Erase** clear the **selected** cone's chat and non-mount `/tmp`, not scoops. The freezer, `clear-chat` and boot hydration all resolve their root through `ui/wc/wc-unit-context.ts` (`rootForSelection`, `rootFolderForContext`) and key the session with `chatSessionIdFor`, never the literal `session-cone`. Archives in `/sessions/<timestamp>-<slug>.md` + `index.json` record `cone` / `coneLabel` so a card names its cone and a thaw can route back to it. The welcome flow is the one deliberate exception — it stays primary-cone-only. Idle boot recovers pending markers serially (≤3 times) through the **bounded** legacy enrichment call — never the unbounded curator (`timeoutSeconds` cannot stop it). Agentic Save: quick snapshot then clear; title (`skipMemory`) + curator in background. The curator edits a staged draft under `/sessions/.curation/<archive>/` that the agent bridge three-way-merges onto the live memory file on exit 0 (`mergeOnSuccess`; concurrent live edits survive, conflicts resolve to the curator); the bridge also writes `status.json` there on both exit paths (`outcomeReceiptPath`), and the index entry records `memoryCuratedAt` on success / `memoryFailed` on failure or retry exhaustion — the durable which-sessions-curated ledger. Cone-only `OffscreenClient.clearAllMessages()` awaits `clear-chat-ack` before panel reload.
 
 ## UI
 
@@ -112,9 +115,32 @@ One roster, three renderings, one vocabulary — `ui/follower-presentation.ts` o
 - **Cherry `?cherry=1&ui-only=1`** (extension side panel): suppresses CDP target advertisement, skips `ptt`, drops "Take a photo" (mic denied in cross-origin side panel). Login/onboarding hand-off to the leader tab is gated to `isExtensionSidePanel` only.
 - **Cloud cone config** (`ui/hosted-config-apply.ts`): `applyHostedAccounts` reconciles accounts from `/api/hosted-bootstrap`, removing only providers tracked in `localStorage['slicc_cloud_managed']` — never user-added ones. `?connect=1` is a login-only surface (`ui/connect-surface.ts`) with no kernel.
 
+## File mentions + preview
+
+Clicking a file name the agent wrote in chat. Five modules, deliberately split so the guessing and the verifying stay separate:
+
+- `core/file-mentions.ts` — the heuristic. Pure; finds CANDIDATES in prose and knows nothing about the VFS.
+- `core/tool-call-paths.ts` — harvests the paths a tool call's parameters named (bash redirects, `path`-ish fields), so prose can be read against what the agent already did.
+- `core/file-mention-resolver.ts` — checks candidates against the VFS via a lazily built, bounded basename index, with those paths as hints.
+- `ui/file-mention-linker.ts` — walks a rendered message and links only what resolved.
+- `ui/wc/wire-file-mentions.ts` — lifecycle: observes the thread, waits for streaming to finish, opens the preview.
+
+Plus `core/file-type.ts` (content sniffing) and `ui/git-preview-source.ts` (the HEAD blob for diff mode). `ui/wc/file-actions.ts` owns `openFilePreview`, the single entry point both the file tree and a clicked mention go through.
+
+Non-obvious rules:
+
+- **Confirm, then linkify.** Nothing is decorated optimistically — the heuristic is permissive precisely BECAUSE verification gates it. A candidate that does not resolve stays plain text.
+- **Never linkify a streaming bubble.** A half-arrived path resolves to nothing; bubbles are processed only once `streaming` clears.
+- **`getMimeType()` (`core/mime-types.ts`) is for SERVING, `sniffFileType()` (`core/file-type.ts`) is for READING.** Never swap them: sniffing a type you then put in a `Content-Type` header is how MIME-confusion bugs happen, and serving's conservative `application/octet-stream` fallback is exactly what made `.jsh` unpreviewable. Precedence is magic bytes → extension → UTF-8 decodability.
+- **`isomorphic-git` is imported lazily** in `git-preview-source.ts`; the UI layer must not pull the `src/git/` stack for a preview. Its fs shim is read-only ON PURPOSE — a preview surface must never be able to write to a repo.
+- **Hints come from the typed `ToolCall`, not from parsed markup.** `wc-message-view.ts` stamps each rendered tool row with `data-file-paths` (JSON) at render time; `wire-file-mentions.ts` reads the rows that PRECEDE a bubble in document order — chronological in a transcript — capped at the most recent 40. A hint is believed only after `stat()` confirms it, which is what lets it resolve a file outside the indexed roots (`/home/lars/foo.md`) without ever inventing a link.
+- **A hint without a directory is dropped.** The whole value of a hint is the path segment prose does not carry; a bare basename tells the resolver nothing the index did not already know, and would only cost a `stat()`.
+- **Markdown is detected by EXTENSION, on purpose** (`richPreviewKind` in `core/file-type.ts`). It has no magic bytes and is byte-identical to plain text — the name is the only declaration there is, and being wrong changes only which view opens first. Markdown is converted by `ui/message-renderer.ts` (DOMPurify-sanitized) and mounted inline; **raw HTML is never sanitized and never mounted inline** — it goes to Quick Look's sandboxed iframe. Documents over 512 KB get no rendered view (synchronous conversion would freeze the overlay).
+- **The mention resolver's index is bounded** (`maxEntries`, `maxDepth`, skipped `node_modules`-class directories). A mention that would only resolve past the ceiling stays plain text; stalling the transcript to prove otherwise is worse.
+
 ## Base64 payload previews
 
-A payload PASTED into chat — a `data:` URL, the output of `base64 < key.pem` — collapses to a `<slicc-blob-chip>` that opens it in Quick Look. Same four roles as file mentions (`packages/webapp/CLAUDE.md`), and reusing the same machinery rather than growing a second copy of it.
+A payload PASTED into chat — a `data:` URL, the output of `base64 < key.pem` — collapses to a `<slicc-blob-chip>` that opens it in Quick Look. Same four roles as file mentions (see File mentions + preview above), and reusing the same machinery rather than growing a second copy of it.
 
 - Path: `core/base64-mentions.ts` (heuristic, pure) → `core/base64-payload.ts` (decode + identify) → `ui/base64-preview-linker.ts` (DOM swap) → `ui/wc/wire-base64-previews.ts` (lifecycle + Quick Look, wired from `mountWcShell`). Chip: `<slicc-blob-chip>` in `@slicc/webcomponents`.
 - **Consolidated, not duplicated.** The base64 grammar is `normalizeBase64` in `@slicc/shared-ts` (shared with `base/image-markers.ts`); decoding is `base64ToUint8`; identification composes `sniffMagicBytes` / `looksLikeText` / `isTextMimeType` from `core/file-type.ts`; the synthetic filename comes from `extensionForMimeType` in `base/mime-types.ts` (reverse index of the SAME table `getMimeType` reads); the rendered view is `file-actions.ts`'s `buildRenderedView`, so the 512 KB cap and the inline-vs-sandbox rule have one home; the chip's short type label is `@slicc/webcomponents/quick-look/mime-label`, shared with Quick Look's header chip.
@@ -138,6 +164,7 @@ A payload PASTED into chat — a `data:` URL, the output of `base64 < key.pem` �
 - Sprinkles: `ui/sprinkle-renderer.ts`, `sprinkle-manager.ts`, `sprinkle-discovery.ts`. `.shtml` panels discovered from VFS. CLI: fragments/full docs in `srcdoc` iframes. Extension renders in the hosted `?cherry=1` follower — no extension sandbox.
 - Sprinkle delivery + routing (issue #2166): one store, many documents. `SprinkleManager.sendToSprinkle` returns a `SprinkleSendReport` (`shell/sprinkle-manager-handle.ts`) instead of void, and its broadcast hook fires even when the sprinkle is CLOSED on the leader — a follower can still be rendering it. Targeted delivery goes `sprinkle send --runtime` → hook → `tray-leader/broadcast.ts#broadcastSprinkleUpdate` → `resolveFollowerByRuntimeId`; an unresolvable runtime comes back as `unknownRuntime`, never as a silent broadcast. Followers report rendered documents with `sprinkle.instances`; the leader keeps them per-follower in `FollowerRegistry` and `wc-tray.ts` mirrors them into `slicc.leaderSprinkleInstances` so the worker-side `sprinkle list` can read them (same shim pattern as `host`). **Route resolution belongs to the leader**: `KernelFacade.routeSprinkleLick` falls back to `getSprinkleRoute(name)` when the caller stamped no `targetScoop`, which is the only thing that applies a route to follower-forwarded licks.
 - Dips: `ui/dip.ts` hydrates assistant `shtml` code blocks into sandboxed iframes after streaming completes. Minimal lick bridge; auto-height via ResizeObserver.
+- Sprinkle element bundles ride the app chunk graph (`docs/pitfalls.md` "Bundle Graphs"): `<slicc-diff>` / `<slicc-editor>` are Rollup entries; `dist/ui/slicc-diff.js` / `slicc-editor.js` are stable-name loader shims. Elements must adopt pre-upgrade properties (`ui/upgrade-own-properties.ts`); sprinkles awaiting a method API use `window.__SLICC_SPRINKLE_ASSETS__['slicc-diff.js']`.
 
 ## Stale-asset recovery (post-deploy)
 
@@ -159,3 +186,17 @@ A payload PASTED into chat — a `data:` URL, the output of `base64 < key.pem` �
 ## Secret-Aware Fetch Proxy
 
 `createProxiedFetch()` (`packages/webapp/src/shell/proxied-fetch.ts`) routes agent-initiated HTTP through the fetch proxy. Extension mode uses a Port-based path (`chrome.runtime.connect({ name: 'fetch-proxy.fetch' })`). Shell-env population: `secret-env.ts` filters secret names to POSIX-valid identifiers (`/^[A-Za-z_][A-Za-z0-9_]*$/`) so dot-namespaced internal secrets stay out of `$ENV`. See `docs/secrets.md` for OAuth bootstrap, silent renewal, and per-provider extra domains.
+
+## Tool-output images
+
+`<img:data:…>` markers are parsed in exactly one place (`base/image-markers.ts`) so every consumer agrees on what is an image — the bash tool exempts markers from its 40KB cap, `core/tool-adapter.ts` turns them into image content blocks, `scoops/transcript-limits.ts` strips them, and `ui/wc/wc-message-view.ts` renders them inline. Marker-shaped prose and markers sliced mid-payload stay inert text everywhere.
+
+## Agent-avatar host wiring
+
+Channel vocabulary: [`docs/webcomponents-details.md`](webcomponents-details.md).
+
+The face's activity comes from the descriptors (`toSwitcherScoops` → `awaiting`
+for the scoop whose turn just ended, cleared on submit or any non-`ready`
+status). Transients are host calls on `refs.switcher`: `scrutinize()` + `wake()`
+per composer `input`, `glower()` on a `tool_result` with `isError`. Wiring:
+`ui/wc/wc-live-callbacks.ts`, `wc-live-composer.ts`, `wc-live-controller.ts`.

--- a/docs/webcomponents-details.md
+++ b/docs/webcomponents-details.md
@@ -91,7 +91,7 @@ Extended notes for `slicc-dock-tree` (`src/workbench/slicc-dock-tree.ts`).
   source doc comments.
 - **Chat as a movable panel**: `CHAT_SURFACE_ID = 'chat'` is the reserved
   surfaceId the webapp composes the live `<slicc-chatpane>` into at boot (see
-  `packages/webapp/CLAUDE.md`'s Layouts section). `labelForSurface(surfaceId)`
+  [`docs/layouts.md`](layouts.md)). `labelForSurface(surfaceId)`
   derives a tile's friendly label — `'Chat'` for `CHAT_SURFACE_ID`, otherwise
   the id with any `sprinkle:` prefix stripped — surfaced as the move button's
   `title`/`aria-label`, not a visible text bar. `setPinned(surfaceIds:
@@ -104,7 +104,7 @@ string[])` marks leaves as pinned (runtime-only — never serialized by
   resize, and `removeSurface` for the affected node(s). A locked leaf renders
   no move button at all — there's nothing to click, matching "cannot drag"
   literally. Used by embedders (e.g. Cherry) to push a fixed, unmovable
-  arrangement — see `packages/webapp/CLAUDE.md`'s Layouts section.
+  arrangement — see [`docs/layouts.md`](layouts.md).
 - **Drag-drop interaction**: `tilesMovable` / `tiles-movable` defaults off and
   locking still wins. It remains an opt-in embedder/test contract but is
   dormant in the shipped webapp: flag-off keeps it off, while flag-on replaces
@@ -121,7 +121,7 @@ string[])` marks leaves as pinned (runtime-only — never serialized by
   `removeSurface` mutates the tree; `dock-tree-resize` (same shape) fires on
   divider-drag `pointerup` or a `setSurfaceSize` call that actually changed
   something. Neither event persists anything itself — see
-  `packages/webapp/CLAUDE.md`'s Layouts section for the webapp's
+  [`docs/layouts.md`](layouts.md) for the webapp's
   `wireDockTreePersistence` listener. `dock-tree-render` (composed + bubbling,
   `detail: { placed: string[] }`) fires after EVERY render — the deliberately
   change-silent `setTree` restore included — and is display-only:
@@ -373,3 +373,76 @@ so uploads run through an injectable `r2` client with bounded concurrency
 retries up to 5 times with jittered exponential backoff, since R2
 rate-limits upload bursts with `429` / code 971. Driven by the workflow's
 "Upload screenshots to Cloudflare R2" step.
+
+## File tree + Quick Look (Pierre libraries)
+
+Two components delegate rendering to [pierre.computer](https://pierre.computer)
+libraries. Both are wrapped by an adapter that keeps SLICC's existing public
+contract, so hosts did not change.
+
+- **`slicc-file-tree`** renders through **`@pierre/trees`** (trees.software).
+  The `FileTreeItem` input shape, the `items` / `selected` accessors and the
+  `file-select` / `file-preview` / `file-reference` / `file-download` /
+  `file-overflow` / `dir-toggle` events are unchanged; `gitStatus` is new.
+  Search, inline rename, drag-and-drop, virtualization and git lanes come from
+  the library.
+- **`slicc-quick-look`** renders text through **`@pierre/diffs`** (diffs.com),
+  shows a unified diff instead of the file when the caller supplies
+  `baseContent`, and shows a rendered document when the caller supplies
+  `rendered`. The header toggle exposes whichever of Preview / Source / Diff
+  exist.
+
+Non-obvious rules:
+
+- **The library builds hierarchy from PATHS, not from `children` nesting.** A
+  `FileTreeItem` whose `id` is a bare name renders at the root no matter where
+  it sits in the literal — ids must be full paths (which is what
+  `buildVfsTreeItems` produces).
+- **Strip the leading slash before handing paths to `@pierre/trees`**
+  (`toTreePath`). A leading `/` becomes an empty first segment:
+  `['/a.ts', '/b.ts']` renders ONE blank row and no files (verified against
+  `1.0.0-beta.6`). Events convert back, so absolute VFS paths stay absolute at
+  the component boundary.
+- **`renderRowDecoration` returns text or an icon only** — no interactive
+  elements. That is why the old per-row hover buttons (Preview / Reference /
+  Download) now live in the row context menu, whose `onOpen` re-emits SLICC's
+  `file-overflow` so `SliccOverflowMenu` still draws the menu.
+- **Selection echoes.** `selectFile()` reflects to the `selected` attribute,
+  which tells the library to select the row, which calls back through
+  `onSelectionChange` — guard with the `#selecting` flag or one click emits
+  two `file-select` events.
+- **Quick Look renders text twice on purpose**: a synchronous `<pre>` first,
+  then the `@pierre/diffs` view once that lazily-imported chunk arrives
+  (~628 KB, so it must never block the overlay). If the import fails the
+  `<pre>` stays — a degraded preview, not a broken one. A `#generation`
+  counter drops an upgrade that resolves after the overlay moved to another
+  file.
+- **Quick Look converts nothing.** A `rendered` payload arrives as HTML from
+  the host: `inline` must already be sanitized (the webapp runs markdown
+  through `message-renderer.ts`) and mounts via `createContextualFragment`,
+  the same no-innerHTML path as `setBodyHtml`; `sandbox` mounts in an iframe
+  with an EMPTY `sandbox` attribute (no `allow-scripts`, no
+  `allow-same-origin`) and is the only treatment raw HTML ever gets. That
+  document is wrapped in a base stylesheet (`sandboxDocument`) stating
+  `color-scheme` + `Canvas`/`CanvasText`, because an iframe starts transparent
+  with black text and knows nothing about the app's `data-theme` — an unstyled
+  report rendered near-black on the dark panel. The base goes AFTER any
+  doctype (before it means quirks mode) and BEFORE the file's own markup, so
+  author rules outrank it. Keeping conversion in the host is what keeps a
+  markdown parser out of this library.
+- **A rendered form opens FIRST, ahead of the diff.** Someone who clicked a
+  `.md` name meant to read the file; a modified README is still a README.
+  Files without a rendered form keep the old diff-first behavior. Views are
+  rebuilt on switch, never kept mounted in parallel.
+- **`@pierre/trees` `sideEffects` is mispathed** in `1.0.0-beta.6`
+  (`./dist/components/web-components.js` vs the real `dist/web-components.js`),
+  so `import '@pierre/trees/web-components'` tree-shakes to nothing. Importing
+  `FileTree` from the package root is unaffected — it pulls the element
+  registration itself.
+- **Both libraries are in `optimizeDeps.include`** (`vitest.config.ts`).
+  Discovering them mid-run makes Vite re-optimize and reload; a reload after a
+  custom element is defined leaves the tag bound to the pre-reload class, and
+  every tree/preview test then fails as if the component were broken.
+- **Tests assert the contract, not the markup** — accessible row names and
+  events, since the DOM belongs to the library now. Synthetic events need
+  `composed: true` to cross its shadow boundary.

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -166,7 +166,8 @@ start (Adobe default if empty) and merges `coneConfigDelta` on resume (`POST
 Vars: `ADOBE_PROXY_ENDPOINT`; `ALLOWED_EMAIL_DOMAIN` (CSV, default `adobe.com`; `*` =
 any); `BLOCKED_EMAILS` (CSV); `REQUIRE_OWNER_ORG` (`true` expands to ownerOrg-holders);
 `CONE_CAP_RUNNING`, `CONE_CAP_PAUSED` (default 1/5); `ADMIN_USER_IDS` (CSV of IMS
-userIds). Secret: `E2B_API_KEY` (worker-only).
+userIds). Secret: `E2B_API_KEY` (worker-only). Open-domain → ownerOrg-gated
+runbook: [docs/cloudflare-worker-details.md § v1 → v2 Expansion](../../docs/cloudflare-worker-details.md#v1-v2-expansion).
 
 ### Stable API Contract (worker ↔ sandbox)
 

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -34,18 +34,8 @@ leader/follower state, reconnect windows, and cached ICE servers.
 
 ### Public Routes
 
-Route inventory: `POST /tray`, `GET /handoff`, `GET /install-cli`,
-`GET /install-cli.ps1`, `GET /download/slicc-cli/:target`,
-`GET /.well-known/api-catalog`, `GET /llms.txt`, `GET|HEAD /privacy`,
-`GET|HEAD /status`, `GET /rel/:name`, `GET|POST /join/:token`,
-`GET|POST /controller/:token`, `POST /webhook/:token/:webhookId`,
-`POST /api/tray/:trayId/preview`, `POST /api/tray/:trayId/preview/stop`,
-`GET /api/tray/:trayId/previews`, `POST /api/tray/:trayId/biscotto`,
-`POST /api/tray/:trayId/biscotto/stop`, `GET /api/tray/:trayId/biscotti`,
-`GET <token>.sliccy.now/*`,
-`GET __slicc/preview-bridge.js`, `WS __slicc/bridge`, `POST __slicc/emit`,
-`GET /auth/callback`, `GET /auth/mcp-callback`, `GET /api/flags`. Per-route semantics:
-[docs/cloudflare-worker-details.md § Public Routes](../../docs/cloudflare-worker-details.md#public-routes).
+Route inventory lives in `src/index.ts` (the default `GET /` body). Per-route
+semantics: [docs/cloudflare-worker-details.md § Public Routes](../../docs/cloudflare-worker-details.md#public-routes).
 
 **Routes-mirror rule:** every new route MUST appear in
 
@@ -57,11 +47,11 @@ Missing any of these fails CI.
 
 ### Feature Flag Configuration
 
-`FEATURE_FLAGS` in `wrangler.jsonc` is a JSON var
+`FEATURE_FLAGS` in `wrangler.jsonc`:
 `{ base: Record<string,string>, floats: Record<string, Record<string,string>> }`.
-Floats overlay `base`; invalid profiles → `{ float: "default", flags: base }`. Keep
-production and `env.staging` aligned. 5-min cache; config changes need deploy. Keep
-`/api/flags` in the routes array + both routes-list assertions.
+Floats overlay `base`; invalid profiles fall back to `base`. 5-min cache;
+config changes need deploy. Keep `/api/flags` in the routes array + both
+routes-list assertions. Align production and `env.staging`.
 
 ### Signaling Model
 
@@ -78,27 +68,29 @@ keyed by `connId`, replays `bridge.connected` on leader (re)connect, hibernates 
 ### Biscotti (guest seats)
 
 `TrayRecord.biscotti` holds revocable guest seats. `resolveJoinCapability`
-(`src/shared.ts`) is the **single default-deny point** for `/join/:token`: it
-returns `{ trust: 'full' }` for the tray join token, `{ trust: 'biscotto' }` for
-a live seat, and `null` for anything else (including revoked/expired seats,
-which are compared before being filtered so their existence does not leak by
-timing). Mint/revoke/list live in `src/session-tray-biscotto.ts` and are gated on
-the **controller** token — a seat is never an issuing authority.
+(`src/shared.ts`) is the **single default-deny point** for `/join/:token`:
+`{ trust: 'full' }` / `{ trust: 'biscotto' }` / `null` (revoked seats are
+compared before filter so existence does not leak by timing). Mint/revoke/list
+in `src/session-tray-biscotto.ts`, gated on the **controller** token.
 
-**Trust travels on the controller socket, never on the peer's `hello`.** The DO
-stamps `trust` + `biscotto` onto `follower.join_requested`, which only the leader
-can receive. `controllerId` is client-supplied, so trust is re-derived from the
-presented token on every request and a mismatch against the stored
-`ControllerRecord.biscottoId` is a 409 `JOIN_CAPABILITY_MISMATCH` — in both
-directions, so a guest cannot inherit a full follower's id and a full follower
-cannot be shadowed by a guessed one. Enforcement of what a seat may _send_ is
-leader-side (`packages/webapp/src/scoops/tray-leader/biscotto-gate.ts`).
+**Trust travels on the controller socket, never the peer's `hello`.** The DO
+stamps `trust` + `biscotto` onto `follower.join_requested`. `controllerId` is
+client-supplied, so trust is re-derived from the presented token; mismatch vs
+`ControllerRecord.biscottoId` → 409 `JOIN_CAPABILITY_MISMATCH` both ways.
+What a seat may _send_ is leader-side (`biscotto-gate.ts`).
 
 ### TURN Credentials
 
-Fetched with `CLOUDFLARE_TURN_KEY_ID` (in `wrangler.jsonc`) and
-`CLOUDFLARE_TURN_API_TOKEN` (Wrangler secret). Follower push (#2062): `src/apns.ts` signs an ES256 JWT from `APNS_TEAM_ID` / `APNS_KEY_ID` / `APNS_PRIVATE_KEY` (`.p8` PEM) and posts to `api(.sandbox).push.apple.com` with `APNS_TOPIC`; the tray DO stores ≤16 `push.register` tokens per tray and fans out leader `push.send` (`turn_end`, time-sensitive `sudo_request`, metadata only), dropping tokens APNs reports dead. All four secrets or pushing is silently off. **Provider JWTs are minted by exactly one DO** (`src/apns-provider-token.ts`, `idFromName('__apns_provider_token')`, storage-backed): Apple throttles token creation per team+key, so per-tray minting broke Apple's 20-minute floor once a few trays hibernated (#2432). `session-tray.ts` caches ICE servers
-and refreshes before TTL expiry.
+Fetched with `CLOUDFLARE_TURN_KEY_ID` (`wrangler.jsonc`) and
+`CLOUDFLARE_TURN_API_TOKEN` (Wrangler secret). Follower push: `src/apns.ts`
+signs an ES256 JWT (`APNS_TEAM_ID` / `APNS_KEY_ID` / `APNS_PRIVATE_KEY`) and
+posts to `api(.sandbox).push.apple.com` (`APNS_TOPIC`). The tray DO stores
+≤16 `push.register` tokens and fans out leader `push.send` (`turn_end`,
+time-sensitive `sudo_request`, metadata only), dropping tokens APNs reports
+dead. All four secrets or pushing is silently off. **Provider JWTs are minted
+by exactly one DO** (`src/apns-provider-token.ts`,
+`idFromName('__apns_provider_token')`): Apple throttles per team+key.
+`session-tray.ts` caches ICE servers and refreshes before TTL expiry.
 
 ### Tray Kind (desktop / hosted)
 
@@ -109,17 +101,15 @@ optional `kind`. Reclaim TTL branches through `reclaimMsForTray(tray)` in `share
 
 ### Static Assets & R2
 
-Worker serves `dist/ui/` via Static Assets (`ASSETS`); `?json=true`/POST/WS → API,
-else SPA. **Cherry embed (`?cherry=1`):** `frame-ancestors` from
-`ALLOWED_CHERRY_HOST_ORIGINS` (bare `*` also enumerates `chrome-extension://` origins);
-non-cherry → `frame-ancestors 'none'`; cherry sets `Cache-Control: no-store` +
-`Vary: Sec-Fetch-Dest`. **Non-cherry, non-electron SPA responses also carry
-`Document-Isolation-Policy: isolate-and-credentialless`** — per-document
-cross-origin isolation (SAB for vpod guest networking) without COOP/COEP;
-cherry/electron branches must stay header-free (embedded, never need SAB). **25 MiB per-asset cap** — CI runs `wrangler deploy --dry-run`
-as a hard gate. `ASSET_ARCHIVE` (R2) retains hashed `/assets/*` across deploys;
-`serveAssetWithArchiveFallback` tries `ASSETS` → R2 → stale-asset reload; bucket GC
-14 days. Full rules:
+Worker serves `dist/ui/` via `ASSETS`; `?json=true`/POST/WS → API, else SPA.
+**Cherry (`?cherry=1`):** `frame-ancestors` from `ALLOWED_CHERRY_HOST_ORIGINS`
+(`*` also enumerates `chrome-extension://`); non-cherry → `'none'`; cherry
+sets `Cache-Control: no-store` + `Vary: Sec-Fetch-Dest`. Non-cherry,
+non-electron SPA also sets `Document-Isolation-Policy:
+isolate-and-credentialless` (SAB for vpod without COOP/COEP) — cherry/electron
+must stay header-free. **25 MiB per-asset cap** (`wrangler deploy --dry-run`).
+`ASSET_ARCHIVE` (R2) keeps hashed `/assets/*`; fallback `ASSETS` → R2 →
+stale-reload; GC 14 days. Full rules:
 [docs/cloudflare-worker-details.md § Static Assets](../../docs/cloudflare-worker-details.md#static-assets);
 ops: [deploying-tray-worker skill](../../.agents/skills/deploying-tray-worker/SKILL.md).
 
@@ -139,10 +129,9 @@ Extension testing with the worker: `npm run start:extension`.
 
 ## CI and Deployment
 
-`release-native.mjs --gate=worker` gates production. Hub + preview configs deploy as a
-pair (shared DO/token format); R2 uploads always precede deploy. Routes-only failures
-are non-fatal. Required: `CLOUDFLARE_API_TOKEN` (Workers Edit, R2 R/W, Zone Routes
-Edit) + account ID. Retry logic, staging deploy, local `serve --bridge`:
+`release-native.mjs --gate=worker` gates production. Hub + preview configs deploy
+as a pair; R2 uploads precede deploy. Routes-only failures are non-fatal.
+Token: Workers Edit, R2 R/W, Zone Routes Edit. Retry / staging / `serve --bridge`:
 [deploying-tray-worker skill](../../.agents/skills/deploying-tray-worker/SKILL.md).
 
 ## Operational Notes
@@ -165,13 +154,11 @@ Shipped via Plan D. All `/api/cloud/*` require
 
 ### Cone Configuration
 
-`ConeConfig` = `{ model, accounts[], secrets[] }` (in `@slicc/cloud-core/cone-config`);
-`src/cloud/cone-config-bridge.ts` handles start (writes `/slicc/secrets.env` +
-`/slicc/cone-config.json`; no-config synthesizes Adobe default) and resume (merges
-`coneConfigDelta`, reloads leader via `POST /api/secrets/reload` → `Page.reload`).
-Adobe `{kind:'oauth'}` accounts stamp `tokenExpiresAt` via `imsTokenExpiry` (IMS JWT
-`created_at + expires_in`). `CloudSessionsDurableObject` persists a **names-only**
-`coneConfigIndex` — never values. Detail:
+`ConeConfig` = `{ model, accounts[], secrets[] }` (`@slicc/cloud-core/cone-config`).
+`cone-config-bridge.ts` writes `/slicc/secrets.env` + `/slicc/cone-config.json` on
+start (Adobe default if empty) and merges `coneConfigDelta` on resume (`POST
+/api/secrets/reload` → `Page.reload`). OAuth accounts stamp `tokenExpiresAt` via
+`imsTokenExpiry`. The DO persists a **names-only** `coneConfigIndex`. Detail:
 [docs/cloudflare-worker-details.md § Cone Configuration](../../docs/cloudflare-worker-details.md#cone-configuration).
 
 ### Wrangler Config (cloud)
@@ -180,14 +167,6 @@ Vars: `ADOBE_PROXY_ENDPOINT`; `ALLOWED_EMAIL_DOMAIN` (CSV, default `adobe.com`; 
 any); `BLOCKED_EMAILS` (CSV); `REQUIRE_OWNER_ORG` (`true` expands to ownerOrg-holders);
 `CONE_CAP_RUNNING`, `CONE_CAP_PAUSED` (default 1/5); `ADMIN_USER_IDS` (CSV of IMS
 userIds). Secret: `E2B_API_KEY` (worker-only).
-
-### v1 → v2 Expansion
-
-```bash
-npx wrangler secret put REQUIRE_OWNER_ORG  # value: true
-# update ALLOWED_EMAIL_DOMAIN in wrangler.jsonc to "*"
-npx wrangler deploy
-```
 
 ### Stable API Contract (worker ↔ sandbox)
 

--- a/packages/dev-tools/CLAUDE.md
+++ b/packages/dev-tools/CLAUDE.md
@@ -1,50 +1,48 @@
 # CLAUDE.md
 
-Developer-tooling surface for `packages/dev-tools/`. Long-form notes: [`docs/dev-tools-details.md`](../../docs/dev-tools-details.md).
+Developer-tooling surface for `packages/dev-tools/`. Scripts live in `packages/dev-tools/tools/` unless a package subdirectory is named. Long-form notes: [`docs/dev-tools-details.md`](../../docs/dev-tools-details.md).
 
 ## Key Tooling Areas
 
-- **playwright-cli gap sync**: `packages/dev-tools/tools/playwright-cli-sync.mjs` — diffs Slicc's playwright-cli against `@playwright/cli`. Ref: [`docs/playwright-cli-sync.md`](../../docs/playwright-cli-sync.md).
+- **playwright-cli gap sync**: `playwright-cli-sync.mjs` — diffs Slicc's playwright-cli against `@playwright/cli`. Ref: [`docs/playwright-cli-sync.md`](../../docs/playwright-cli-sync.md).
 - **Dev-only VFS skills** (`packages/dev-tools/vfs-dev-skills/`): `__DEV__`-gated `import.meta.glob` in `packages/webapp/src/scoops/skills.ts`, remapped to `/workspace/skills/`. Contains `playwright-cli-e2e`.
 - **Build configs**: `packages/webapp/vite.config.ts`, `packages/chrome-extension/vite.config.ts`, `biome.json`.
 - **QA setup**: `packages/node-server/src/qa-setup.ts` plus root `npm run qa:*` scripts. Visual/integration helper: `packages/webapp/tests/test-dips.mjs`.
-- **RUM error triage**: `packages/dev-tools/rum-error-triage/triage-rum-errors.mjs`, nightly via `.github/workflows/rum-error-triage.yml`.
-- **Scheduled agentic workflows** (selector `.mjs` + `claude-code-action`): `boy-scout-debt/`, `pr-fix-dispatcher/`, `claude-md-compactor/`, `flaky-ci-hunter/`, `backlog-dispatcher/`. Deep ref: [dev-tools-details.md#scheduled-agentic-workflows](../../docs/dev-tools-details.md#scheduled-agentic-workflows).
-- **Review responder** (event-driven sibling): `packages/dev-tools/review-responder/` + `.github/workflows/review-responder.yml` — answers reviewer feedback on `automation/*` PRs. Deep ref: [dev-tools-details.md#review-responder](../../docs/dev-tools-details.md#review-responder).
-- **Bedrock model scout** (weekly canary, no Claude): `packages/dev-tools/model-scout/` + `.github/workflows/model-scout.yml` — probes every `*_BEDROCK_MODEL` ID the workflows can reach and files an issue on a dead one. Deep ref: [dev-tools-details.md#model-scout](../../docs/dev-tools-details.md#model-scout).
-- **AI comment detection**: `packages/dev-tools/ai-comment-detection/` — labels `ai-generated`/`human-in-the-loop` via `.github/workflows/ai-comment-detection.yml`. Deep ref: [dev-tools-details.md#ai-comment-detection](../../docs/dev-tools-details.md#ai-comment-detection).
-- **Doc gates** (`npm run lint:docs`, `.husky/pre-commit`): `packages/dev-tools/tools/check-doc-sizes.mjs` (+ `check-doc-sizes-lib.mjs`) and `check-doc-refs.mjs` (+ `check-doc-refs-lib.mjs`). Deep ref: [dev-tools-details.md#doc-dead-reference-gate](../../docs/dev-tools-details.md#doc-dead-reference-gate).
-- **Hugging Face caching mirror** (`packages/dev-tools/tools/hf-cache-mirror.mjs`): zero-dep local `huggingface.co` mirror with an on-disk store; the e2e CI job runs it, persists `.cache/hf-mirror` with `actions/cache`, and hands `HF_ENDPOINT` to the virtual shell's `hf download` so the Kokoro weights come off disk on warm runs.
+- **RUM error triage**: `packages/dev-tools/rum-error-triage/triage-rum-errors.mjs`, nightly `.github/workflows/rum-error-triage.yml`.
+- **Scheduled agentic workflows** (selector `.mjs` + `claude-code-action`): `boy-scout-debt/`, `pr-fix-dispatcher/`, `claude-md-compactor/`, `flaky-ci-hunter/`, `backlog-dispatcher/`. [details](../../docs/dev-tools-details.md#scheduled-agentic-workflows).
+- **Review responder** (event-driven): `packages/dev-tools/review-responder/` + `.github/workflows/review-responder.yml`. [details](../../docs/dev-tools-details.md#review-responder).
+- **Bedrock model scout** (weekly canary, no Claude): `packages/dev-tools/model-scout/` + `.github/workflows/model-scout.yml`. [details](../../docs/dev-tools-details.md#model-scout).
+- **AI comment detection**: `packages/dev-tools/ai-comment-detection/` + `.github/workflows/ai-comment-detection.yml` (`ai-generated`/`human-in-the-loop`). [details](../../docs/dev-tools-details.md#ai-comment-detection).
+- **Doc gates** (`npm run lint:docs`, `.husky/pre-commit`): `check-doc-sizes.mjs` and `check-doc-refs.mjs` (+ `-lib.mjs`). [details](../../docs/dev-tools-details.md#doc-dead-reference-gate).
+- **Hugging Face caching mirror** (`hf-cache-mirror.mjs`): local `huggingface.co` mirror; e2e CI caches `.cache/hf-mirror` and sets `HF_ENDPOINT` so `hf download` (Kokoro) hits disk on warm runs.
 - **Linear-history check**: `bash packages/dev-tools/tools/check-linear-history.sh [base-ref] [head-ref]`. `linear-history` CI job.
-- **Skill lint** (`npm run lint:skills`): `packages/dev-tools/tools/lint-skills.mjs` — `tessl skill lint` via `@tessl/cli`. Warns locally; fails under `--strict`/CI.
-- **Developer-skill sync** (`npm run lint:skill-router`): `packages/dev-tools/tools/check-skill-router-sync.sh` — keeps root router, `.agents/skills/`, `.claude/skills/` aliases in sync.
-- **Patch reconcile** (`npm run lint:patches`): `packages/dev-tools/patch-reconcile/check-patches.mjs` + `reconcile-context.mjs`. See `patches/README.md`.
-- **SPM ↔ xcodegen pin reconcile** (`npm run lint:swift-pins`): `packages/dev-tools/swift-pin-reconcile/`. Dual-pinned GitHub packages (Package.swift + project.yml) must overlap; `renovate-swift-pin-reconcile.yml` raises the stale side on `swift-pin` Renovate PRs. See the folder README.
-- **iOS UI-test exclusion registry** (`npm run lint:ios-ui-tests`): `packages/dev-tools/tools/ios-ui-test-exclusions.mjs` + `packages/ios-app/ui-test-exclusions.json`. `ios-app-tests` runs the WHOLE `SliccFollowerUITests` bundle on the GA cells and subtracts this registry, so a new class is gated the day it lands; the gate rejects an entry with no reason or one naming a class/method that no longer exists.
-- **SwiftPM lockfile drift gate**: `packages/dev-tools/tools/check-swift-resolved-drift.mjs` — run AFTER a resolve step (the `ios-app` CI job). `xcodebuild -resolvePackageDependencies` rewrites `Package.resolved` in place and builds against what it wrote, so a floated **transitive** pin lands with no diff; `lint:swift-pins` only sees direct pins. Compares identity/version/revision, ignoring `originHash` and key order (both move with the toolchain).
-- **innerHTML guard** (`npm run lint:no-innerhtml`): `packages/dev-tools/tools/check-no-innerhtml.mjs` bans `.innerHTML =`, `.outerHTML =`, `insertAdjacentHTML()` in `@slicc/webcomponents` (stories/tests exempt).
-- **Providers boundary** (`npm run lint:no-ui-in-providers`): `packages/dev-tools/tools/check-no-ui-imports-in-providers.mjs` bans `from '…ui/…'` in `providers/built-in/`.
-- **Layer back-edge ratchet** (`npm run lint:layer-back-edges`): `packages/dev-tools/tools/check-layer-back-edges.mjs`; baseline `layer-back-edge-baseline.json` (`--update`). Deep ref: [dev-tools-details.md#layer-back-edge-ratchet](../../docs/dev-tools-details.md#layer-back-edge-ratchet).
-- **`Record<string, unknown>` ratchet** (`npm run lint:record-string-unknown`): `packages/dev-tools/tools/check-record-string-unknown.mjs`; detection is the GritQL plugin `.biome-plugins/no-record-string-unknown.grit` run through `biome.record-gate.json`. Baseline `record-string-unknown-baseline.json` (`--update`). Deep ref: [dev-tools-details.md#record-string-unknown-ratchet](../../docs/dev-tools-details.md#record-string-unknown-ratchet).
-- **Hosted-origin literal guard**: `packages/dev-tools/tools/check-hosted-origin-literal.mjs` — TS must import `SLICC_HOSTED_ORIGIN` from `@slicc/shared-ts`.
-- **Chrome runtime.id guard**: `packages/dev-tools/tools/check-no-raw-chrome-runtime-id.mjs` — use `isChromeExtensionRealm()` from `@slicc/shared-ts` (tests exempt).
-- **AGENTS.md symlink guard**: `packages/dev-tools/tools/check-agents-symlinks.mjs` — every `packages/*/CLAUDE.md` needs an `AGENTS.md` sibling symlink.
-- **iOS PR screenshots**: `packages/dev-tools/tools/ios-screenshots.mjs` (+ `ios-screenshots-lib.mjs`) reads `packages/ios-app/screenshot-screens.json`, emits Storybook `manifest.json`. Driven by `.github/workflows/ios-screenshots.yml`.
-- **Storybook PR screenshots**: `packages/dev-tools/tools/storybook-affected-screenshots.mjs` (+ `storybook-affected-stories-lib.mjs`) — light/dark shots of affected webcomponents stories; pair with `npm run build-storybook -w @slicc/webcomponents`. Driven by `.github/workflows/storybook-screenshots.yml`. Upload: `storybook-screenshots-upload.mjs` (+ `-lib.mjs`) to R2. Deep ref: [dev-tools-details.md#storybook-screenshots-upload](../../docs/dev-tools-details.md#storybook-screenshots-upload).
-- **Dead code (production files)** (`npm run deadcode:production-files`): `knip --production --include files`; config `knip.json`. Deep ref: [dev-tools-details.md#knip-production-suffix-discipline](../../docs/dev-tools-details.md#knip-production-suffix-discipline).
-- **Swift unused-dependency gate** (`npm run lint:swift-deps`): `packages/dev-tools/tools/check-swift-unused-deps.mjs` (+ `-lib.mjs`) — SPM parity with knip (TS) and `make tidy-check` (Go); diffs every `packages/*/Package.swift` against the modules its targets import. Waiver: `// unused-dep-ok: <reason>`. Deep ref: [dev-tools-details.md#swift-unused-dependency-gate](../../docs/dev-tools-details.md#swift-unused-dependency-gate).
-- **Debt boy-scout gate**: `node packages/dev-tools/tools/check-touched-exemptions.mjs [base-ref]` (+ `size-exemption-lib.mjs`) — enforces `biome.json` debt overrides plus `layer-back-edge-baseline.json` and `record-string-unknown-baseline.json`. See [verifying-before-push skill](../../.agents/skills/verifying-before-push/SKILL.md).
-- **First-load size gate** (part of `npm run size -w @slicc/webapp`): `packages/dev-tools/tools/check-first-load-size.mjs` (+ `first-load-size-lib.mjs`, `first-load-baseline.mjs`) — measures the eager import closures of the page entry (via `.vite/manifest.json`) and the kernel-worker entry (parsed from emitted chunks). Guards cold-boot payload, not per-file size. **Relative**: it builds the merge-base in a throwaway worktree (workspace packages re-pointed at the worktree's own source, then the root `postinstall` prerequisite builds — borrowing the caller's would mask a webcomponents-side regression) (`--baseline=<ref>`, default `origin/main`; `--baseline=none` to skip, `--json` to just measure) and fails on a change's own growth past `maxDeltaKb`, so it never fires on inherited state and cancels the ~1 kB Linux-vs-macOS build difference. On `merge_group` the delta is skipped (a queue branch is cumulative — its delta is the batch sum, and a per-change allowance would fail on queue depth); ceilings only, no baseline build. That split is only safe because a CI `pull_request` run treats an unmeasurable baseline as a hard failure rather than degrading — otherwise a PR could clear both stages unmeasured. Local runs still degrade to ceilings with a note. The absolute `*EagerCeilingKb` values in `packages/webapp/first-load-budget.json` are the backstop against many small under-threshold changes creeping upward — human-owned, not numbers to nudge when a build goes red.
-- **Coverage gate + ratchet**: `packages/dev-tools/tools/coverage-gate.mjs` + `coverage-ratchet.mjs` (`coverage-thresholds.json`). Swift: `swift-coverage-check.sh` + `swift-coverage-runner-retry.sh`; `SLICC_IOS_SIM_UDID` overrides. Deep ref: [dev-tools-details.md#swift-coverage-retry](../../docs/dev-tools-details.md#swift-coverage-retry).
-- **Optional-binary guard**: `packages/dev-tools/tools/run-if-installed.mjs <binary> [args...]` — runs iff on `PATH`, else warns and exits 0. Used by the root `lint-staged` Swift/Go globs.
-- **Cross-impl vectors**: `packages/dev-tools/tools/gen-mask-vectors.mjs` (TS/Swift mask parity) and `gen-theme-vectors.mjs` (via `npx tsx`; regenerate after `theme-engine.ts` changes, asserted by `packages/webapp/tests/ui/theme-vectors.test.ts` + `ThemeEngineTests.swift`).
-- **Preflight deps check**: `packages/dev-tools/tools/preflight-deps.mjs` — wired via `pretypecheck`/`pretest`.
-- **Release gating**: `packages/dev-tools/tools/release-plan.mjs` (Linux preflight) + `release-native.mjs` — gates macOS/iOS packaging, `slicc` Go CLI (`packages/slicc-cli/sign-and-package.sh`), Chrome Web Store/worker publish, `@ai-ecoverse/biome-jsh` (`--gate=biome-jsh-version`/`--gate=biome-jsh`).
-
-### SLICC CDP Debug + Screencast
-
-- `packages/dev-tools/tools/slicc-debug.mjs` — CDP diagnostic CLI (`targets`, `logs`, `vfs ls/cat`, `eval`, `shell`; `--url`/`--url-pattern`/`--file`). `node packages/dev-tools/tools/slicc-debug.mjs --help`.
-- `packages/dev-tools/tools/slicc-screencast.mjs` (+ `-lib.mjs`, `-video.mjs`) — `Page.startScreencast` frames + `manifest.json`; `--video` via ffmpeg. Skill: `demo-recording`.
+- **Skill lint** (`npm run lint:skills`): `lint-skills.mjs` — `tessl skill lint`. Warns locally; fails under `--strict`/CI.
+- **Developer-skill sync** (`npm run lint:skill-router`): `check-skill-router-sync.sh` — root router, `.agents/skills/`, `.claude/skills/` aliases.
+- **Patch reconcile** (`npm run lint:patches`): `packages/dev-tools/patch-reconcile/check-patches.mjs` + `reconcile-context.mjs`. `patches/README.md`.
+- **SPM ↔ xcodegen pin reconcile** (`npm run lint:swift-pins`): `packages/dev-tools/swift-pin-reconcile/`. Dual-pinned GitHub packages (Package.swift + project.yml) must overlap; `renovate-swift-pin-reconcile.yml` raises the stale side on `swift-pin` PRs.
+- **iOS UI-test exclusion registry** (`npm run lint:ios-ui-tests`): `ios-ui-test-exclusions.mjs` + `packages/ios-app/ui-test-exclusions.json`. [details](../../docs/dev-tools-details.md#ios-ui-test-exclusion-registry).
+- **SwiftPM lockfile drift gate**: `check-swift-resolved-drift.mjs` — AFTER a resolve step (`ios-app` CI). [details](../../docs/dev-tools-details.md#swiftpm-lockfile-drift).
+- **innerHTML guard** (`npm run lint:no-innerhtml`): `check-no-innerhtml.mjs` bans `.innerHTML =`, `.outerHTML =`, `insertAdjacentHTML()` in `@slicc/webcomponents` (stories/tests exempt).
+- **Providers boundary** (`npm run lint:no-ui-in-providers`): `check-no-ui-imports-in-providers.mjs` bans `from '…ui/…'` in `providers/built-in/`.
+- **Layer back-edge ratchet** (`npm run lint:layer-back-edges`): `check-layer-back-edges.mjs`; baseline `layer-back-edge-baseline.json` (`--update`). [details](../../docs/dev-tools-details.md#layer-back-edge-ratchet).
+- **`Record<string, unknown>` ratchet** (`npm run lint:record-string-unknown`): `check-record-string-unknown.mjs` via `biome.record-gate.json`; baseline `record-string-unknown-baseline.json` (`--update`). [details](../../docs/dev-tools-details.md#record-string-unknown-ratchet).
+- **Hosted-origin literal guard**: `check-hosted-origin-literal.mjs` — TS must import `SLICC_HOSTED_ORIGIN` from `@slicc/shared-ts`.
+- **Chrome runtime.id guard**: `check-no-raw-chrome-runtime-id.mjs` — `isChromeExtensionRealm()` from `@slicc/shared-ts` (tests exempt).
+- **AGENTS.md symlink guard**: `check-agents-symlinks.mjs` — every `packages/*/CLAUDE.md` needs an `AGENTS.md` sibling symlink.
+- **iOS PR screenshots**: `ios-screenshots.mjs` reads `packages/ios-app/screenshot-screens.json`, emits Storybook `manifest.json`. `.github/workflows/ios-screenshots.yml`.
+- **Storybook PR screenshots**: `storybook-affected-screenshots.mjs` — light/dark affected-story shots; pair with `npm run build-storybook -w @slicc/webcomponents`. `.github/workflows/storybook-screenshots.yml`; R2 upload `storybook-screenshots-upload.mjs`. [details](../../docs/dev-tools-details.md#storybook-screenshots-upload).
+- **Dead code (production files)** (`npm run deadcode:production-files`): `knip --production --include files`; `knip.json`. [details](../../docs/dev-tools-details.md#knip-production-suffix-discipline).
+- **Swift unused-dependency gate** (`npm run lint:swift-deps`): `check-swift-unused-deps.mjs` (+ `-lib.mjs`). Waiver: `// unused-dep-ok: <reason>`. [details](../../docs/dev-tools-details.md#swift-unused-dependency-gate).
+- **Debt boy-scout gate**: `node packages/dev-tools/tools/check-touched-exemptions.mjs [base-ref]` (+ `size-exemption-lib.mjs`) — `biome.json` debt overrides plus `layer-back-edge-baseline.json` and `record-string-unknown-baseline.json`. [verifying-before-push](../../.agents/skills/verifying-before-push/SKILL.md).
+- **First-load size gate** (`npm run size -w @slicc/webapp`): `check-first-load-size.mjs` — eager page/worker closures vs merge-base; `--baseline=<ref>` (default `origin/main`), `--baseline=none`, `--json`. [details](../../docs/dev-tools-details.md#first-load-size-gate).
+- **Coverage gate + ratchet**: `coverage-gate.mjs` + `coverage-ratchet.mjs` (`coverage-thresholds.json`). Swift: `swift-coverage-check.sh` + `swift-coverage-runner-retry.sh`; `SLICC_IOS_SIM_UDID` overrides. [details](../../docs/dev-tools-details.md#swift-coverage-retry).
+- **Optional-binary guard**: `run-if-installed.mjs <binary> [args...]` — runs iff on `PATH`, else warns and exits 0.
+- **Cross-impl vectors**: `gen-mask-vectors.mjs` (TS/Swift mask parity) and `gen-theme-vectors.mjs` (`npx tsx`; regenerate after `theme-engine.ts` changes; asserted by `packages/webapp/tests/ui/theme-vectors.test.ts` + `ThemeEngineTests.swift`).
+- **Preflight deps check**: `preflight-deps.mjs` — `pretypecheck`/`pretest`.
+- **Release gating**: `release-plan.mjs` (Linux preflight) + `release-native.mjs` — macOS/iOS packaging, `slicc` Go CLI (`packages/slicc-cli/sign-and-package.sh`), Chrome Web Store/worker publish, `@ai-ecoverse/biome-jsh` (`--gate=biome-jsh-version`/`--gate=biome-jsh`).
+- **CDP debug**: `slicc-debug.mjs` (`targets`, `logs`, `vfs ls/cat`, `eval`, `shell`; `--url`/`--url-pattern`/`--file`). `node packages/dev-tools/tools/slicc-debug.mjs --help`.
+- **Screencast**: `slicc-screencast.mjs` (+ `-lib.mjs`, `-video.mjs`) — `Page.startScreencast` frames + `manifest.json`; `--video` via ffmpeg. Skill: `demo-recording`.
+- **e2b template**: `packages/dev-tools/e2b-template/`. See `packages/cloud-core/CLAUDE.md`.
 
 ### Fresh Dev Harnesses
 
@@ -58,19 +56,9 @@ Five isolated harnesses on distinct ports; reaping is opt-in (`SLICC_FRESH_REAP=
 | Electron-Node  | `dev-electron-node-fresh.sh`  | `:5730`                | `:9225` | External Electron app (default: Slack)      |
 | Electron-Swift | `dev-electron-swift-fresh.sh` | `:5740`                | `:9226` | Swift backend, external Electron app        |
 
-Isolated lane: `PORT=5715 WRANGLER_PORT=8787 npm run dev:standalone:fresh`; never touch production bridge `:5710` or Chrome CDP `:9222`. Also `npm run dev:swift:fresh`, `dev:extension:fresh`, `dev:electron:node:fresh`, `dev:electron:swift:fresh`, with `PORT=…`/`ELECTRON_APP=…` overrides. Lifecycle + reaping: [`docs/development.md`](../../docs/development.md); [dev-tools-details.md#fresh-dev-harnesses](../../docs/dev-tools-details.md#fresh-dev-harnesses).
+Isolated lane: `PORT=5715 WRANGLER_PORT=8787 npm run dev:standalone:fresh`. Never production `:5710` or Chrome CDP `:9222`. Also `npm run dev:swift:fresh`, `dev:extension:fresh`, `dev:electron:node:fresh`, `dev:electron:swift:fresh` (`PORT=`/`ELECTRON_APP=`). Lifecycle: [`docs/development.md`](../../docs/development.md); [details](../../docs/dev-tools-details.md#fresh-dev-harnesses).
 
-### Supporting Utilities
+- **Labeled Chrome clone**: `clone-labeled-chrome.sh` — APFS COW-clone with distinct `CFBundleName`/`CFBundleIdentifier` (⌘-Tab per harness); ad-hoc re-signed, top-level only. No-op on non-darwin.
+- **Dev cert**: `bash packages/dev-tools/tools/setup-dev-cert.sh` — one-time self-signed `SLICC Dev Code Signing`. `dev-swift-fresh.sh` picks it up.
 
-- **Labeled Chrome clone**: `clone-labeled-chrome.sh` — APFS COW-clone with distinct `CFBundleName`/`CFBundleIdentifier` (distinct ⌘-Tab entries per harness); ad-hoc re-signed, top-level only. No-op on non-darwin.
-- **Stable dev code-signing identity**: `bash packages/dev-tools/tools/setup-dev-cert.sh` — one-time; creates persistent self-signed `SLICC Dev Code Signing`. `dev-swift-fresh.sh` picks it up automatically.
-
-## e2b Template
-
-Hosted-leader cloud float runs in an e2b sandbox; template in `packages/dev-tools/e2b-template/`. See `packages/cloud-core/CLAUDE.md`.
-
-## Usage Notes
-
-- Prefer root npm scripts when a helper already has one.
-- Keep dev-only configs and utilities out of runtime packages unless required at runtime.
-- When adding new tooling, document both file location and entry command.
+New tooling: document location + entry command.

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -1,65 +1,55 @@
 # CLAUDE.md
 
-iOS follower app in `packages/ios-app/` — native iOS 26 SwiftUI SPM project (`Package.swift`), not an npm workspace. **Follower only**: connects to a SLICC leader over WebRTC (chat + sprinkles + limited federated CDP); no agent runtime. Deep reference: [`docs/ios-app-details.md`](../../docs/ios-app-details.md).
+iOS follower in `packages/ios-app/` — iOS 26 SwiftUI SPM (`Package.swift`, not npm). **Follower only**: WebRTC to a SLICC leader (chat + sprinkles + limited federated CDP); no agent runtime. Deep reference: [`docs/ios-app-details.md`](../../docs/ios-app-details.md) ([related](../../docs/ios-app-details.md#related)).
+
+SPM on macOS is a no-op; **Xcode project generated from `project.yml`, not committed** — `xcodegen generate` after clone and on source changes.
 
 ## Layout
 
-- `SliccFollower/App/` — `SliccFollowerApp` (+ `SliccAppDelegate` for APNs callbacks), `@MainActor AppState` (`AppState+SudoApproval` = Face ID gate + push registration); inbound coordinator (`InboundActions`, `AppGroupInbox`, `OpenInSliccIntents`) + `SliccShareExtension/` funnel `slicc://open|prompt` (+`x-callback-url`), `sliccy.ai/app/*` universal links, App Intents, share URLs in `group.ai.sliccy.follower`. Deep links confirm via card (fail-closed).
-  - **App Intents entities**: `SliccConversationEntity` (`IndexedEntity`, projected from the WIDGET SNAPSHOT — queries run with the app cold, where `AppState` does not exist) and `SliccTabEntity` (`@AppEntity(schema: .browser.tab)`, live `CDPBridge` state via `SliccTabRegistry`). `OpenSliccConversationIntent` routes through the coordinator's `pendingSelection` slot. Spotlight donation rides `publishWidgetSnapshot()`. `OpenInSliccBrowserIntent` deliberately carries NO intent schema — `browser.createTab` demands a `TabEntity` return and this intent only enqueues. The whole schema catalog is identical in the iOS 26 and 27 SDKs, so only View Annotations (`View.sliccEntityAnnotation`, gated on `canImport(AppIntentsTypeSupport)`) needs the 27 SDK. Why each choice: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#app-intents-entities-and-schemas).
-- `SliccFollower/Models/` — `ScoopStatus`; `UnitRole` (the read-only rule, below); `ICloudSessionList` + `SliccFollower.entitlements` (iCloud via `SliccTraySession` + KVS); `*Avatar*`.
-- `SliccFollower/Notifications/` — `NotificationCoordinator`: `UNUserNotificationCenter` delegate, categories `SLICC_TURN_END` / `SLICC_SUDO_REQUEST` (mirrors the hub's `apns.ts`), local fallbacks, lock-screen Deny.
-- `SliccFollower/Sync/` — `Keepalive` (`DataChannelKeepalive`); `TerminalClient` (single-flight `exec.*`); `ConnectionSettle` (`ConnectionHealth` + `ConnectionSettler`, the blip hold behind `AppState.settledConnection`).
-- `SliccFollower/CDP/` — `CDPBridge` + `CDPTarget` host WKWebViews as CDP targets.
-- `SliccFollower/Views/` — `ChatView`/`MessageListView`/`MarkdownText`/`TranscriptText` (`ChatPresentationState`; compact workbench sets `toolbarSuppressed`; http(s) links open in-app unless Settings → Advanced `openLinksInBuiltInBrowser` off); `SprinkleWebView`/`InlineSprinkleView`/`SprinkleDetailView` (`.shtml`); `DockModel`/`DockRail`/`WorkbenchHost`/`LucideIcon` (48pt rail); `TerminalView`/`TerminalViewModel`; `TabsCarouselView` (full-screen hides rail via `AppState.browserViewingTabId`); `ToolProgressChrome` (bash-progress row treatment — icon fill, dots, open-body bar — off `AppState.toolProgress`).
-  - **Read-only scoop**: selecting a scoop opens a read-only transcript — `ConversationView` renders no `InputBar`, so send / dictation / attachment affordances and the reserved band all go with it, and a scoop's `tool_ui` never mounts a card (#2367, parity with the web's #2312). The rule is stated ONCE in `Models/UnitRole.swift` (`UnitRole.isReadOnly`, mirroring `isReadOnlyRole`) and reached via `AppState.selectedUnitIsReadOnly`; `ScoopSummary.isRootUnit` derives the role from the `parentId` edge and falls back to `isCone` only for leaders that predate it. Why + hooks: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#read-only-scoop-view).
-  - **Transcript short actions**: every actionable span carries a tap default and a long-press menu — web links to Sliccy's browser, other schemes to the system, phone numbers to **Messages**, inline `code` to Copy (Share on long press) and fenced blocks to Copy/Share, confirmed file mentions and base64 chips to the preview sheet (`FilePreviewSheet`: sniffed text renders as themed selectable monospace, everything else Quick Look can handle — images, PDFs, media — goes to `QLPreviewController`). Every menu is a UIKit menu — a SwiftUI `confirmationDialog` on tap reads as a different feature next to six contextual menus. Prose/list/blockquote runs paint through `Views/TranscriptText.swift` (`UITextView`) because SwiftUI `Text` has no per-span long press; headings and table cells stay on `Text` and knowingly have no menu. Entity detection mirrors the web (`Models/FileMentions.swift`, `Base64Mentions.swift`, `Base64Payload.swift`, `TranscriptInline.swift`); `FileMentionResolver` confirms a mention with ONE leader `stat` (absolute path, or a `ToolCallPathHints` match) and never walks. Why each piece is shaped that way, and the ICU-vs-JS regex trap: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#transcript-short-actions).
-  - **Markdown tables**: `MarkdownText.tableView` follows the web's `slicc-agent-message .body table` contract — a hairline-ruled card that **hugs its content** and scrolls inside itself, never a full-width band. Column widths are resolved up front in `Models/MarkdownTableLayout.swift` (`Grid` both stretches and squeezes inside a horizontal `ScrollView`); why each piece is shaped that way: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#markdown-tables).
-  - **Reading column**: the regular-width cap (`MessageListLayout.maximumReadableWidth`) is applied **per row** via `readableTranscriptColumn()`, never as a frame around the transcript's `LazyVStack` (that stack carries `scrollTargetLayout()` and cancels any wrapping centering offset). Covered by `SliccFollowerUITests/TranscriptColumnUITests`; why: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#reading-column).
-- `SliccTrayFollower/` (`swift-trayfollower`, re-exported via `TrayFollowerExports.swift`) — `Models/SyncProtocol.swift` (partial `Codable` mirror of `packages/shared-ts/src/tray-sync-protocol.ts`), `Models/{ChatMessage,TrayTypes,TrayChunkFraming}.swift`, `Networking/{TraySignaling,TrayFollowerConnector,WebRTCManager}.swift`.
-- `SliccWidgets/` — the **Cones & Scoops** home-screen widget extension (`com.sliccy.follower.widgets`, families incl. lock-screen/StandBy accessories). Four lines of `@main` + `Widget`; every pixel comes from **`packages/swift-widgetkit`** (`SliccWidgetKit`). It reads a `WidgetSnapshot` JSON from `group.ai.sliccy.follower` — a widget cannot hold a tray connection, so the app captures and the widget renders. Capture lives in `App/AppState+WidgetSnapshot.swift`: `AppState` publishes on `scoops.list`, on connection/stall flips and on `turn_end`, and clears the store when the user detaches. It reads the **settled** connection health, never the raw state, and the instance label is the display name or the join URL's HOST — never the join URL. The Developer-portal step gates TestFlight: [`docs/widgets.md`](../../docs/widgets.md).
-- `SliccTrayKit/FileProvider/` + `SliccFileProvider/` — Files.app provider for leader VFS (logic in **`packages/swift-traykit`** / `SliccTrayVFS`, re-exported via `TrayVFSExports.swift`). Appex Info.plist MUST set `NSExtensionFileProviderSupportsEnumeration` or Files hides the domain (`userEnabled=false`).
+- `SliccFollower/App/` — `SliccFollowerApp` + `SliccAppDelegate` (APNs); `@MainActor AppState` (`AppState+SudoApproval` = Face ID + push). `InboundActions` / `AppGroupInbox` / `OpenInSliccIntents` + `SliccShareExtension/` funnel `slicc://open|prompt` (+`x-callback-url`), `sliccy.ai/app/*` universal links, App Intents, share URLs in `group.ai.sliccy.follower`. Deep links confirm via card (fail-closed).
+- `SliccFollower/{Models,Notifications,Sync,CDP}/` — `ScoopStatus`; `UnitRole`; `ICloudSessionList` + entitlements (`SliccTraySession` + KVS); `*Avatar*`. `NotificationCoordinator`: `SLICC_TURN_END` / `SLICC_SUDO_REQUEST` (hub `apns.ts`), local fallbacks, lock-screen Deny. `Keepalive`; `TerminalClient` (single-flight `exec.*`); `ConnectionSettle` behind `AppState.settledConnection`. `CDPBridge` + `CDPTarget` host WKWebViews as CDP targets.
+- `SliccFollower/Views/` — chat / sprinkles (`.shtml`) / 48pt dock / terminal / tabs (`browserViewingTabId` hides rail) / `ToolProgressChrome`. Compact workbench sets `toolbarSuppressed`; http(s) in-app unless Settings → Advanced `openLinksInBuiltInBrowser` off.
+- `SliccTrayFollower/` — `swift-trayfollower` (`TrayFollowerExports.swift`); `SyncProtocol.swift` (see Protocol).
+- `SliccWidgets/` — **Cones & Scoops** (`com.sliccy.follower.widgets`); pixels from **`packages/swift-widgetkit`**. Snapshot JSON in `group.ai.sliccy.follower` (widget cannot hold a tray). Publish on `scoops.list`, connection/stall, `turn_end`; clear on detach. **Settled** health; label is display name or join URL HOST — **never the join URL**. [`docs/widgets.md`](../../docs/widgets.md).
+- `SliccTrayKit/FileProvider/` + `SliccFileProvider/` — Files.app provider (`packages/swift-traykit` / `SliccTrayVFS`). Appex Info.plist MUST set `NSExtensionFileProviderSupportsEnumeration` or Files hides the domain (`userEnabled=false`).
 
-Plain SPM commands do nothing on a macOS host; build/test go through XcodeGen. **Xcode project generated from `project.yml`, not committed** — run `xcodegen generate` after clone and whenever sources change.
+Gotchas — App Intents from the **widget snapshot** (cold, no `AppState`); `OpenInSliccBrowserIntent` has **no** schema; View Annotations need 27 SDK (`canImport(AppIntentsTypeSupport)`): [intents](../../docs/ios-app-details.md#app-intents-entities-and-schemas). Read-only scoop: no `InputBar`, no scoop `tool_ui` card (`UnitRole.isReadOnly`): [read-only](../../docs/ios-app-details.md#read-only-scoop-view). Transcript: UIKit long-press (not `confirmationDialog`), phones → **Messages**, one `stat` never a walk; tables hug content; reading column **per row**: [short actions](../../docs/ios-app-details.md#transcript-short-actions) · [tables](../../docs/ios-app-details.md#markdown-tables) · [column](../../docs/ios-app-details.md#reading-column).
 
 ## App Icon
 
-`Assets.xcassets/AppIcon.appiconset` carries three 1024s: `Icon-Default`, `Icon-Dark` and `Icon-Tinted`.
-
-`Icon-Tinted` is **hand-authored, not a desaturation of the colour icon** — master at `packages/assets/logos/slicc-icon-tinted-master-1024.png`. iOS tinted mode maps the asset's _luminance_ onto the user's tint, so an asset confined to the top of the range can only render as a flat blob. The previous `Icon-Tinted` was byte-identical to the Icon Composer `TintedLight` export and never dropped below 39% grey (min 100/255, σ 39); the current one spans the full range (min 0, σ 81) by seating a bright swirl in a near-black tub. Re-check `min`/`stddev` before replacing it:
+Three 1024s in `Assets.xcassets/AppIcon.appiconset`. `Icon-Tinted` is **hand-authored** (master `packages/assets/logos/slicc-icon-tinted-master-1024.png`) — iOS maps luminance onto the tint. Full-bleed square; `Icon-Dark` has pre-rounded corners. macOS does **not** consume this PNG ([swift-launcher](../swift-launcher/CLAUDE.md#app-icon)). [stats](../../docs/ios-app-details.md#app-icon).
 
 ```bash
 magick Icon-Tinted.png -alpha remove -colorspace Gray \
   -format "min=%[fx:minima*255] sd=%[fx:standard_deviation*255]\n" info:
 ```
 
-It is full-bleed square (iOS applies its own superellipse mask), unlike `Icon-Dark`, which still carries pre-rounded transparent corners. The macOS side does **not** consume this PNG — Sliccstart derives its tinted appearance from `macos-icon.icon`; see [swift-launcher](../swift-launcher/CLAUDE.md#app-icon).
-
 ## Protocol Mirror Invariant
 
-`SliccTrayFollower/Models/SyncProtocol.swift` mirrors a **subset** of `packages/shared-ts/src/tray-sync-protocol.ts`; the matrix in `docs/architecture.md` is source of truth. iOS-local:
+`SliccTrayFollower/Models/SyncProtocol.swift` mirrors a **subset** of `packages/shared-ts/src/tray-sync-protocol.ts`; matrix in `docs/architecture.md` is source of truth. iOS-local:
 
 - `preview.open` → `CDPBridge.handleTabOpen`, acks `tab.opened`.
 - iOS never originates transcript export; those prompts decode to `.unknown` / `undecodable`.
-- `sudo.approve.request` / `.cancel` → `SudoApprovalController` (SliccTrayKit/Sudo); reply `sudo.approve.response`. Allow / Always pass `LAContext` `.deviceOwnerAuthentication` first, Deny never does. `hello` advertises `sudoApproval: true` and `biometric: true` iff the device can authenticate its owner. `push.register` carries the APNs token on every connect. Details: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#sudo-approval-and-push).
-- `capabilities.exec: true`; `handleExecMessage` accepts only `open [--universal|--x-callback] <url>`, scoped-approval gated. URL validation + tombstoning: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#exec-capability); `--x-callback` nonces, JSON result shape, 16-param / 16-KiB caps: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#x-callback-exec).
+- `sudo.approve.request` / `.cancel` → `SudoApprovalController` (SliccTrayKit/Sudo); reply `sudo.approve.response`. Allow / Always pass `LAContext` `.deviceOwnerAuthentication` first, Deny never does. `hello` advertises `sudoApproval: true` and `biometric: true` iff the device can authenticate its owner. `push.register` carries the APNs token on every connect. [sudo + push](../../docs/ios-app-details.md#sudo-approval-and-push).
+- `capabilities.exec: true`; `handleExecMessage` accepts only `open [--universal|--x-callback] <url>`, scoped-approval gated. [exec](../../docs/ios-app-details.md#exec-capability); `--x-callback` nonces, JSON result, 16-param / 16-KiB caps: [x-callback](../../docs/ios-app-details.md#x-callback-exec).
 
-Adding a variant is a fixed six-step order ending in the corpus + architecture matrix: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#protocol-variant-checklist).
+New variants: six-step order ending in corpus + architecture matrix: [checklist](../../docs/ios-app-details.md#protocol-variant-checklist).
 
 ## Follower on `AppState`
 
-Lifecycle `connect`/`disconnect`/`dataChannelOpened`/`handleDisconnect`; `Keepalive` splits **stalled** vs **dead** (`lastError`=transport, `leaderError`=cone); dispatch via `handleDataChannelMessage`. Swipe arbitration freezes edge state at drag start and fails closed. Settle, VFS, lick and `tool_ui` invariants: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#follower-state-invariants); swipe detail: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#transcript-swipe-arbitration).
+Lifecycle `connect`/`disconnect`/`dataChannelOpened`/`handleDisconnect`; `Keepalive` splits **stalled** vs **dead** (`lastError`=transport, `leaderError`=cone); dispatch via `handleDataChannelMessage`. Swipe arbitration freezes edge state at drag start and fails closed. [invariants](../../docs/ios-app-details.md#follower-state-invariants) · [swipe](../../docs/ios-app-details.md#transcript-swipe-arbitration).
 
 ## iCloud Sessions
 
-`AppState.sessionStore` uses **`packages/swift-traysession`**; launcher publishes, `SettingsView` joins. Liveness requires a connected leader. KVS `S8LB56P782.ai.sliccy.trays` MUST match macOS. Unprovisioned builds have no cache; `SLICC_IOS_NO_ICLOUD=1` omits iCloud. **Never expose `joinUrl`.** Attach loops after reconnect must follow `TRAY_SUPERSEDED` / `SupersedeRedirect`: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#icloud-tray-supersede-chain).
+`AppState.sessionStore` uses **`packages/swift-traysession`**; launcher publishes, `SettingsView` joins. Liveness requires a connected leader. KVS `S8LB56P782.ai.sliccy.trays` MUST match macOS. Unprovisioned builds have no cache; `SLICC_IOS_NO_ICLOUD=1` omits iCloud. **Never expose `joinUrl`.** Attach loops after reconnect follow `TRAY_SUPERSEDED` / `SupersedeRedirect`: [supersede](../../docs/ios-app-details.md#icloud-tray-supersede-chain).
 
-**Recent joins**: `AppState.recentJoinStore` (`RecentJoinStore`) records the join URL on `dataChannelOpened` — every path (paste, deep link, iCloud row, stored credentials), after any supersede hop, never at dial time — and syncs it, so a URL pasted on one device reaches the others. `SettingsView` renders the "Recent" section from `ICloudSessionList.recentRows` (live sessions excluded, `RecentJoinStore.rank` order, five rows); rows show label-or-`displayHost` and **never the join URL**. Replaced the device-local `joinUrlHistory`. Hooks: `-uiTestRecentJoinsFixture/Empty`.
+**Recent joins**: record on `dataChannelOpened` (after supersede, never at dial time); rows show label-or-`displayHost`, **never the join URL**. Hook: `-uiTestRecentJoinsFixture/Empty`. [recent](../../docs/ios-app-details.md#recent-joins).
 
-**Frozen sessions**: `FrozenSessions.swift` mirrors `transcript/frozen-archive-format.ts`; opens saved transcripts read-only. Hook: `-uiTestFrozenFixture/Empty`.
+**Frozen sessions**: `FrozenSessions.swift` mirrors `transcript/frozen-archive-format.ts` (read-only). Hook: `-uiTestFrozenFixture/Empty`.
 
 ## Push to Talk
 
-Hold empty composer to dictate (`PttController` + `Dictation`/`SFSpeechRecognizer`); release calls `InputBar.submit(_:dictated:)`. Only dictated replies speak: English uses Kokoro, others `AVSpeechSynthesizer`; typed turns silent. `AudioSessionCoordinator` solely owns `AVAudioSession`. Hooks: `-uiTestSpeechPermission/Script`, `-uiTestPttStage`. Kokoro pack (~83 MB, Wi-Fi consent; replies never provision): [`docs/ios-app-details.md`](../../docs/ios-app-details.md#local-kokoro-models). QA: [`docs/ios-simulator-qa.md`](../../docs/ios-simulator-qa.md).
+Hold empty composer to dictate (`PttController` + `Dictation`/`SFSpeechRecognizer`); release calls `InputBar.submit(_:dictated:)`. Only dictated replies speak (Kokoro for English, else `AVSpeechSynthesizer`); typed turns silent. `AudioSessionCoordinator` solely owns `AVAudioSession`. Hooks: `-uiTestSpeechPermission/Script`, `-uiTestPttStage`. Kokoro (~83 MB, Wi-Fi consent; replies never provision): [Kokoro](../../docs/ios-app-details.md#local-kokoro-models). QA: [`docs/ios-simulator-qa.md`](../../docs/ios-simulator-qa.md).
 
 ## Terminal
 
@@ -67,13 +57,7 @@ Hold empty composer to dictate (`PttController` + `Dictation`/`SFSpeechRecognize
 
 ## Agent Avatar
 
-`SliccAgentAvatarView` mirrors the browser `<slicc-agent-avatar>`. Fullness = pupil size only, never ring/gauge/badge/text; recoverable state stays in avatar/composer (no banner row). Header layout, static treatment, a11y phrase and fixtures: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#agent-avatar-chrome).
-
-The home-screen widget carries a **static** copy of this geometry AND of the expression grammar in `packages/swift-widgetkit` (`UnitAvatarGeometry` / `UnitAvatarFace`) — a widget process has no sensors, no frame callback and a hard memory budget, so it gets each phase at the pose `settle` lands on and none of the integrator. Parity is pinned by `UnitAvatarGeometryTests` against the values `SliccAgentAvatarGeometryTests` asserts here; changing a ratio in this file means changing it there. Why they are not one type: [`docs/widgets.md`](../../docs/widgets.md#the-avatar).
-
-**Expression kit**: `Models/AvatarExpression.swift` (UI-free grammar, band units) + `Models/AvatarExpressionEngine.swift` (integrator; time is a parameter, never ambient) drive shape morph, brows, chord-cut lids and gaze. `SliccAgentAvatarGeometry.activity == nil` keeps the legacy face; `expressionScale` is the only band→points bridge. **The brows paint outside the tile crop**: `.clipShape` wraps the tile layer only, `ExpressiveAvatarBrows` rides over it in band space, so hosts must not clip an avatar (~3pt of overhang at 26pt) and a blink no longer folds the brows onto the eyeball. Precedence: **local derivation > wire refinement > state** — `AppState.localExpressionSignals` owns the FOCUSED scoop, `ScoopSummary.activity` drives every other tab, `state` stays the closed four-value union so older followers are untouched. Parity gated by `Fixtures/expression-vectors.json` (both suites).
-
-Trouble reaches the surface only after `ConnectionSettler.holdDuration` (recovery lands at once), and **no connection state may reach the composer's first-responder layer** — not `.disabled`, not `allowsHitTesting`, not mounting anything above the editor. Only sending is gated; a regression test must stage a blip that HEALS. Details: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#agent-avatar-treatment).
+`SliccAgentAvatarView` mirrors `<slicc-agent-avatar>`. Fullness = pupil size only; recoverable state stays in avatar/composer (no banner). Widget is a **static** copy in `packages/swift-widgetkit` — change a ratio here, change it there ([avatar](../../docs/widgets.md#the-avatar)). Expression kit: time is a parameter, never ambient. **Brows paint outside the tile crop** (~3pt overhang at 26pt — hosts must not clip). Precedence: **local > wire > state**. **No connection state on the composer's first-responder layer**; only sending is gated; a regression test must stage a blip that HEALS. [treatment](../../docs/ios-app-details.md#agent-avatar-treatment).
 
 ## Build
 
@@ -88,27 +72,21 @@ swiftlint lint
 
 ## Test + coverage
 
-Run `xcodebuild test` on a simulator. Coverage gate boots an iPhone matching the simulator SDK, retries infra failures, enforces `coverage-thresholds.json`. Override via worktree-owned `SLICC_IOS_SIM_UDID`. **Never pass `CODE_SIGNING_ALLOWED=NO` to tests** (XCTest needs ad-hoc signing).
+Run `xcodebuild test` on a simulator. Coverage gate (`SliccFollowerTests` only, `.build/coverage/`) boots an iPhone matching the simulator SDK, retries infra failures, enforces `coverage-thresholds.json`. Override via worktree-owned `SLICC_IOS_SIM_UDID`. **Never pass `CODE_SIGNING_ALLOWED=NO` to tests** (XCTest needs ad-hoc signing). [coverage](../../docs/ios-app-details.md#coverage-gate-details).
 
 ```bash
 ./packages/dev-tools/tools/swift-coverage-check.sh \
   --xcodebuild SliccFollower packages/ios-app SliccFollower
 ```
 
-Outputs in `.build/coverage/`; the gate runs only `SliccFollowerTests`. Object selection, the `SliccFileProvider/` exclusion, and the memory-bound File Provider read limit: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#coverage-gate-details).
-
 ## UI tests (`SliccFollowerUITests`)
 
-`bundle.ui-testing` stays in the scheme; the unit gate excludes it. No test needs a leader — every fixture runs off a `#if DEBUG` launch-argument hook. **CI runs the whole bundle** on both GA cells of `ios-app-tests`, minus `ui-test-exclusions.json` — so a new class is gated the day it lands, and leaving CI takes an entry in that registry with a written reason (`npm run lint:ios-ui-tests` rejects stale ones). Hook list: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#ui-test-hooks); authoring rules: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#ui-test-details).
+`bundle.ui-testing` stays in the scheme; the unit gate excludes it. No test needs a leader — fixtures are `#if DEBUG` launch-argument hooks. **CI runs the whole bundle** on both GA cells of `ios-app-tests`, minus `ui-test-exclusions.json` (new class is gated on land; leaving CI needs a written reason — `npm run lint:ios-ui-tests` rejects stale entries). [hooks](../../docs/ios-app-details.md#ui-test-hooks) · [authoring](../../docs/ios-app-details.md#ui-test-details).
 
 ## Linting
 
-SwiftLint + `swift format` inherit repo-root configs; only `error` severity fails CI. Run `npm run lint:swift:format` / `format:swift` from repo root. Details: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#linting-details).
+SwiftLint + `swift format` inherit repo-root configs; only `error` fails CI. `npm run lint:swift:format` / `format:swift` from repo root. [lint](../../docs/ios-app-details.md#linting-details).
 
 ## TestFlight
 
-Releases run `scripts/package-and-upload-testflight.sh` (secrets via `setup-testflight-secrets.sh`), path-gated by `release-native.mjs`. Script **soft-skips with exit 0** when `SLICC_SKIP_TESTFLIGHT=1`, an Apple secret is missing/`-`, or default Xcode < 26 (a green release is not proof an ipa shipped). Distribution + What to Test copy: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#testflight-distribute).
-
-## Related
-
-`packages/shared-ts/src/tray-sync-protocol.ts` (canonical), `packages/webapp/src/scoops/tray-leader-sync.ts`, `packages/webapp/src/scoops/tray-follower-sync.ts`, `packages/webapp/src/ui/sprinkle-follower-controller.ts`; `docs/architecture.md` "Multi-Browser Sync (Tray) Architecture"; `docs/ios-simulator-qa.md`; `docs/ios-app-details.md`.
+Releases run `scripts/package-and-upload-testflight.sh` (secrets via `setup-testflight-secrets.sh`), path-gated by `release-native.mjs`. Script **soft-skips with exit 0** when `SLICC_SKIP_TESTFLIGHT=1`, an Apple secret is missing/`-`, or default Xcode < 26 (a green release is not proof an ipa shipped). [distribute](../../docs/ios-app-details.md#testflight-distribute).

--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -77,52 +77,33 @@ JSON and update Go structs + `corpus_test.go` alongside TS + Swift mirrors.
 ## Diagnostics vs user-facing output
 
 - **User-facing** — `prompt`/`exec`/`watch` write leader bytes to stdout,
-  status to stderr. **Never route through the logger**; the CLI is pipeable.
-- **Diagnostics** — signaling retries, supersede redirects (`OnJoinURLChanged`
-  persists the replacement across `follow`/`watch` reconnects), ICE failures,
-  unparseable frames go through `internal/logging` (`log/slog` `diagLogger`
-  in `commands.go`, to stderr); `debugLogf` adapts to `tray.Options.Logf`.
-- **pion's own records** — `Conn.pionLoggerFactory` installs
-  `logging.PionFactory` on `SettingEngine.LoggerFactory`. **Required**: left
-  nil, webrtc installs pion's default factory, which writes error records
-  straight to `os.Stderr` — TURN refresh churn (`turnc ERROR: Fail to refresh
-permissions`) then buries the CLI's own output and no log level of ours can
-  quiet it. Warn-and-above records are tallied into the status bar
-  (`tray.Options.OnLinkDiag`) instead of printed.
+  status to stderr. Never through the logger (the CLI is pipeable).
+- **Diagnostics** — retries, supersede redirects (`OnJoinURLChanged`), ICE
+  failures, unparseable frames → `internal/logging` on stderr.
+- **pion** — `Conn.pionLoggerFactory` **must** install `logging.PionFactory`.
+  Left nil, pion writes TURN refresh errors straight to `os.Stderr` and no
+  log level of ours can quiet it. Warn-and-above go to the status bar
+  (`OnLinkDiag`) instead.
 
-Off by default. `SLICC_DEBUG=1` (legacy = `SLICC_LOG_LEVEL=debug`) or
-`SLICC_LOG_LEVEL=debug|info|warn|error`; `SLICC_LOG_FORMAT=json` swaps
-`slog.TextHandler` for `slog.JSONHandler`.
+Off by default. `SLICC_DEBUG=1` / `SLICC_LOG_LEVEL=…`; `SLICC_LOG_FORMAT=json`
+for JSON.
 
 ## Terminal presentation (`internal/ui`)
 
-`follow`/`watch` render through `internal/ui` (stdlib + `golang.org/x/sys`, raw
-ANSI — no TUI framework). On an interactive terminal `follow` keeps a **sticky
-one-line status bar** below the log: state badge (connect spinner, live retry
-countdown), uptime, `♥` age of the last frame from the leader (fed by
-`tray.Options.OnActivity`, which fires on _every_ inbound frame — the leader
-answers pings rather than sending them, so keepalives alone would never
-populate it), exec + reconnect counts, suppressed link diagnostics,
-`user@host · runner`, and a per-5s connection-history strip.
-Event lines are stamped, colored and glyph-marked; an identical repeat folds in
-place as `(×N)`, or into a compact `↺ repeated (×N)` row when the event cannot
-be rewritten safely (too tall, soft-wrapped, or holding text whose cell width we
-cannot be sure of — emoji, CJK, invalid bytes). So a reconnect loop no longer
-scrolls the screen away.
+`follow`/`watch` use `internal/ui` (stdlib + `golang.org/x/sys`, raw ANSI).
+Interactive `follow` keeps a **sticky one-line status bar** (state, uptime,
+`♥` last-frame age via `OnActivity` on every inbound frame — the leader
+answers pings rather than sending them). Repeats fold as `(×N)`.
 
-**The bar must own the last row**, so it is dropped (colors kept) when anything
-else writes to the same stream: `watch` when **stdout** is also a terminal (its
-transcript arrives in partial lines), and any verb once the diagnostic logger is
-turned up (`SLICC_DEBUG=1` and friends write to **stderr** directly). Both
-decisions live in `commands.go` — `watchModes` and `stickyUnlessLogging`.
+**The bar must own the last row** — dropped (colors kept) when anything else
+writes the same stream: `watch` with terminal stdout, or any verb once
+diagnostics go to stderr (`SLICC_DEBUG=1`). See `watchModes` /
+`stickyUnlessLogging` in `commands.go`.
 
-**Plain mode is the contract**: with no terminal attached, output is
-byte-for-byte the pre-TUI `slicc <verb>: <msg>` text, escape-free, with every
-occurrence kept. Cursor control is never written to a non-terminal.
-`--plain` / `SLICC_NO_TUI=1` force plain; `NO_COLOR` keeps the bar without
-color; `FORCE_COLOR`/`CLICOLOR_FORCE` colors a redirected stream (still not
-sticky); `COLUMNS` overrides the detected width. Design notes + the glyph/ASCII
-fallback rules: [details](../../docs/slicc-cli-details.md).
+**Plain mode is the contract**: no terminal → pre-TUI `slicc <verb>: <msg>`,
+escape-free, no cursor control. `--plain` / `SLICC_NO_TUI=1` force it.
+`NO_COLOR` / `FORCE_COLOR` / `COLUMNS` as usual. Glyph/ASCII fallback:
+[details](../../docs/slicc-cli-details.md).
 
 ## Exec safety (`follow`)
 
@@ -140,30 +121,21 @@ footgun; MOTD (`hello.motd`, `followMotd`) surfaces via the leader's
 
 ## follow `--eval` (persistent REPL)
 
-`execrun.EvalSession` spawns the runner ONCE; responses framed by **output
-quiescence** (`--eval-quiet`, default 500 ms) — REPLs never signal
-completion. **Session outlives connections and drops**: cancelled
-per-connection contexts run `interruptProcess` (SIGINT to the group; no-op
-on Windows) but never kill the REPL; only `Close` and leader-sent
-SIGTERM/SIGKILL do. `req.Cwd`/`req.Env` ignored; exec exit codes 0 while
-REPL lives. `follow.NewEvalSession` routes `exec.request` in; MOTD
-advertises a REPL target. Banner warns about `node` without `-i`.
-[Details](../../docs/slicc-cli-details.md).
+`execrun.EvalSession` spawns the runner once; responses framed by output
+quiescence (`--eval-quiet`, default 500 ms). The REPL outlives reconnects
+(SIGINT interrupts the group, does not kill it; only `Close` / leader
+SIGTERM/SIGKILL do). `req.Cwd`/`req.Env` ignored; exec exit 0 while the REPL
+lives. [Details](../../docs/slicc-cli-details.md).
 
 ## Self-update (`slicc update`)
 
-`internal/update` scans GitHub releases newest→oldest for the first with
-this platform's `slicc-<os>-<arch>[.exe]` asset — releases are **sparse**
-(CLI binaries only attach when `packages/slicc-cli` changed); same bounded
-pagination as the worker's `/download/slicc-cli` route (30/page, 5 pages
-max). `Apply` downloads, sanity-gates via `--version`, then atomically
-renames over the running binary (Windows parks the old at `.old`).
-`startUpdateNotice()` (`update.go`) refreshes
-`<user-cache-dir>/slicc/update-check.json` at most once per 24 h.
-`SLICC_NO_UPDATE_CHECK=1` disables it; `IsReleaseVersion` gates both notice
-and self-replace, so **`slicc update` refuses to clobber a local build
-ahead of the latest tag** (`dev`, `git describe`). `SLICC_UPDATE_API_BASE`
-overrides the API base. [Details](../../docs/slicc-cli-details.md).
+`internal/update` scans GitHub releases for this platform's
+`slicc-<os>-<arch>[.exe]` (sparse: only when `packages/slicc-cli` changed;
+30/page, 5 pages). `Apply` downloads, `--version`-gates, then atomically
+renames (Windows parks `.old`). Notice at most once per 24 h
+(`SLICC_NO_UPDATE_CHECK=1` disables). `IsReleaseVersion` gates notice and
+replace — **`slicc update` refuses to clobber a local `dev`/`git describe`
+build**. [Details](../../docs/slicc-cli-details.md).
 
 ## Telemetry
 
@@ -196,14 +168,9 @@ make dist           # cross-compiled static binaries → dist/
 the `slicc-cli` CI job: staticcheck/errcheck/unused + funlen/gocyclo/
 gocognit; `make tidy-check` (Go analogue of TS knip); `COVER_MIN` floor.
 
-Release binaries cut **atomically with semantic-release** and only when
-`packages/slicc-cli/` changed since the last tag: `release-native.mjs`
-(prepareCmd gate) invokes `sign-and-package.sh` when `decideSliccCliGating`
-opens, cross-compiling every target on the macOS runner, Developer
-ID-signing + notarizing the darwin binaries (`APPLE_CERTIFICATE_BASE64` +
-`APPLE_API_KEY_*`), staging `artifacts/release/slicc-*` for
-`@semantic-release/github`. **A bare CLI binary can't be stapled**;
-Gatekeeper verifies notarization online. Without cert (fork/local): stages
-unsigned instead of failing. Full pipeline + OS-matrix rationale
-(`testRunner()`, `integration_test.go` pion↔pion loopback):
+Release binaries cut **atomically with semantic-release** only when
+`packages/slicc-cli/` changed: `release-native.mjs` → `sign-and-package.sh`,
+cross-compile on macOS, Developer ID + notarize darwin
+(`APPLE_CERTIFICATE_BASE64` + `APPLE_API_KEY_*`). **A bare CLI binary can't
+be stapled.** No cert → unsigned, don't fail. Pipeline:
 [details](../../docs/slicc-cli-details.md).

--- a/packages/swift-launcher/CLAUDE.md
+++ b/packages/swift-launcher/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Native macOS launcher `Sliccstart` in `packages/swift-launcher/`. SwiftUI app: finds browsers, Electron apps, and terminals; starts the right SLICC runtime; creates debug-friendly Electron builds. Deep reference: [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md).
+Native macOS launcher `Sliccstart`. SwiftUI app: finds browsers, Electron apps, and terminals; starts the right SLICC runtime; creates debug-friendly Electron builds. Deep reference: [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md).
 
 ## Build and Test Commands
 
@@ -14,9 +14,7 @@ npm run lint -w @slicc/swift-launcher   # SwiftLint
 ./sign-and-package.sh
 ```
 
-## Linting and Formatting
-
-`.swiftlint.yml` inherits repo-root `.swiftlint.yml` via `parent_config` and excludes `.build`; only `error`-severity violations fail CI. Auto-fix: `npm run lint:fix -w @slicc/swift-launcher`. Formatting is `swift format` (Swift 6+) against the single repo-root `.swift-format`.
+`.swiftlint.yml` inherits repo-root via `parent_config` and excludes `.build`; only `error` fails CI. Auto-fix: `npm run lint:fix -w @slicc/swift-launcher`. `swift format` (Swift 6+) uses the repo-root `.swift-format`.
 
 ```bash
 npm run lint:format -w @slicc/swift-launcher   # swift format lint --strict (CI gate)
@@ -25,175 +23,60 @@ npm run format -w @slicc/swift-launcher        # swift format --in-place
 
 ## Layout
 
-`Sliccstart/` — SwiftUI app (`SliccstartApp.swift` boots UI; `Models/AppScanner.swift` finds Chromium/CDP apps; `Models/SliccBootstrapper.swift` + `Models/SliccProcess.swift` handle launch/lifecycle; `Views/`). `SliccstartTests/` — tests. `assemble-app.mjs` — assembles `.app` bundle; `build-app-icon.mjs` — app-icon artefacts. `sign-and-package.sh` — signing/packaging.
+`Sliccstart/` — SwiftUI app (`SliccstartApp.swift` boots UI; `Models/AppScanner.swift` finds Chromium/CDP apps; `Models/SliccBootstrapper.swift` + `Models/SliccProcess.swift` handle launch/lifecycle; `Views/`). `SliccstartTests/` — tests. `assemble-app.mjs` — `.app`; `build-app-icon.mjs` — icons; `sign-and-package.sh` — signing.
 
 ## Runtime Refresh Budget
 
-`SliccstartApp` ticks `refreshRuntimeStates` every 2 s and `runtimeState(for:)` runs on every SwiftUI render, so anything on that path must be O(1) and filesystem-free in the steady state. Electron liveness uses the launch record's `observedAppPID` (`kill(pid, 0)`) first; the `NSWorkspace.runningApplications` scan (`candidateBundlePaths` + `appMatches`, pure string compares) is a fallback only. Do not reintroduce per-app `resolvingSymlinksInPath()` — with ~270 running apps it pinned the launcher at ~40% CPU. Tests: `ElectronAppMatchingTests`.
+`refreshRuntimeStates` ticks every 2 s and `runtimeState(for:)` runs on every SwiftUI render — that path must be O(1) and filesystem-free in the steady state. Electron liveness uses the launch record's `observedAppPID` (`kill(pid, 0)`) first; `NSWorkspace.runningApplications` (`candidateBundlePaths` + `appMatches`, string compares) is fallback only. **Do not reintroduce per-app `resolvingSymlinksInPath()`** — ~270 running apps pinned the launcher at ~40% CPU. Tests: `ElectronAppMatchingTests`.
 
-## Testing the SwiftUI Surfaces
+## Testing SwiftUI Surfaces
 
-`SliccstartTests/ViewHosting.swift` renders a view off-screen with
-`ImageRenderer` and returns a digest of the bitmap, so a test can assert that
-two states of a view **render differently** (`assertRendersDifferently`) — the
-only way to reach `AppListView` / `SettingsView` body branches from a unit
-test. Two hard limits, both worked around rather than fought:
+`ViewHosting.swift` (`assertRendersDifferently`) reaches `AppListView` / `SettingsView` body branches. An `App` `Scene` cannot be rendered — put window behavior on `LauncherModel`, content on `RootView`; `SliccstartAppDelegate` is the injectable composition root (stop-everything vs detach-for-update). Launch paths inject `SliccProcess.SpawnServices` (`/bin/sleep`; no 5710/9222). Auto-launch is `resolveEnabled && isInstalledLocation`. `SliccProcess`, `SliccBootstrapper`, `AppManagementPermission` are **not `final`**. Constraints: [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md#swiftui-testing). Tests: `LauncherModelTests`, `RootViewRenderTests`, `AppDelegateLifecycleTests`, `SliccProcessLaunchPathTests`.
 
-- **No interaction.** Headless SwiftUI on macOS builds no AppKit control tree
-  and no accessibility tree, so buttons cannot be pressed. Button _actions_ are
-  tested through the plain types they delegate to (`BrowserLaunchAction`,
-  `TerminalLaunchDecision`, `AppRow.statusDot`, …) — keep new view logic in
-  such a type rather than inline in a closure. The exception is `.borderless`
-  buttons, which do materialize as `NSButton`s (`ViewHosting.hostedButtons`,
-  used for `TraySessionRow`).
-- **CI runs an older macOS than your Mac** (`macos-latest` is still macOS 15).
-  How much of an AppKit-hosted subtree — `Table`, and anything overlaid on one
-  — an off-screen render produces differs between them, so a render comparison
-  that passes locally is not evidence it passes in CI. Compare only over
-  plain SwiftUI content.
-- **Vary exactly one thing per comparison.** Two states that differ in more
-  than one way render differently whether or not the feature under test
-  exists — a review found eight such tests here. Pin everything else
-  (`subtitleOverride:`, identical messages, an empty `Secret`), or assert the
-  underlying rule (`AppListView.updateAffordance`,
-  `SecretEditorSheet.validationMessage`) instead of writing a comparison that
-  cannot fail. Mutate the source and watch the test go red before trusting it.
-- **`Table`, `Toggle` and `.borderless` buttons draw nothing** (both are `NSTableView`/`NSSwitch`-
-  backed), so table cells, switch knobs, and anything styled by tint on a
-  borderless button are asserted against their model types instead.
+## OpTel, scanning, terminals
 
-Views take their non-injectable state as init seams for this:
-`AppListView(isBundledBuild:)` (the whole update footer is otherwise
-unreachable outside a packaged `.app`), `MountsSettingsView(rows:)`,
-`SecretsSettingsView(secrets:unlocked:selection:)` (never touches the
-Keychain).
+`.optelAutoInstrument(appID:)` once (`com.slicc.sliccstart` → `helix-225321.helix_rum.cluster`). `LauncherErrorReport`: `source = sliccstart:<operation>` is a wire contract; `target` redacts URLs → `<url>`, paths → `<path>`, `token`/`secret`/`password`/`key` → `<redacted>`. **Never report `AUError.cancelled`.** Identifiers: `get-extension`, `rescan`, `check-for-updates`, `restart-to-update`, `update`, `app-row-<Name>`. [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md#optel).
 
-**The window is a model, not a `Scene`.** An `App`'s `Scene` cannot be
-rendered, so anything living inside `WindowGroup` is untestable by
-construction. `SliccstartApp` is therefore only wiring: the window's behavior
-is **`Models/LauncherModel.swift`** (launch decisions, dialogs, debug builds,
-update-check outcomes, the 2 s tick, leader publish/withdraw) and its content
-is **`Views/RootView.swift`**. `SliccstartAppDelegate` is the composition
-root, with every collaborator defaulted-but-injectable so the two quit paths
-(stop-everything vs detach-for-update) are testable. Put new window behavior
-on `LauncherModel`, not in a `WindowGroup` closure. Tests:
-`LauncherModelTests`, `RootViewRenderTests`, `AppDelegateLifecycleTests`.
+Scan: Chromium by bundle ID; `/Applications` for Electron/WebView2 with CDP frameworks; `~/Applications` first so `* Debug.app` wins; Terminal.app, iTerm2, Ghostty, WezTerm, kitty, Alacritty by bundle ID.
 
-**Launch paths** go through `SliccProcess.SpawnServices` — resolve-binary,
-run-process, is-port-in-use. Injected so `launchStandalone` /
-`launchBrowserFollower` / `launchWithElectronApp` are testable without
-starting a browser or binding 5710/9222; the stub runs `/bin/sleep` in the
-server's place so records, pids and termination handling stay real. Tests:
-`SliccProcessLaunchPathTests`.
+Terminal rows: `slicc <join-url> follow`. **Disabled until `leaderJoinUrl` is known; never auto-start a leader. CLI never bundled.** Download asks first; Developer ID + team `S8LB56P782`; `https://www.sliccy.ai/download/slicc-cli/darwin-<arch>`. Locator + Gatekeeper: [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md#terminal-followers), [`docs/pitfalls.md`](../../docs/pitfalls.md) § "Downloaded `slicc` CLI". Terminal.app/iTerm2: Apple Events (`com.apple.security.automation.apple-events`).
 
-**Auto-launch requires an installed app.** `StartupPreference.shouldAutoLaunch`
-is `resolveEnabled && isInstalledLocation` — a copy running from a build
-directory, `~/Downloads`, or Gatekeeper's translocated path never starts a
-browser, so a dev/CI run of the launcher cannot take over the screen. The
-preference is untouched and the Startup tab explains the refusal.
+## Finder File Provider, Widgets
 
-`SliccProcess`, `SliccBootstrapper` and `AppManagementPermission` are
-deliberately **not `final`** — they are the app's side-effecting collaborators
-(spawning browsers, running git/npm, opening System Settings), and `@testable`
-lets a test subclass stand in for them.
+`SliccFileProvider.appex` (XcodeGen `project.yml` + `xcodebuild` → `Contents/PlugIns/`) **embeds its own `WebRTC.framework` and `AppIcon.icns`**. Join URL in an app-group file, not keychain. Clean quit withdraws the domain (update/detach does not). Enable once: System Settings → Login Items & Extensions → File Provider. Shared: **`packages/swift-traykit`**. [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md#finder-file-provider). Tests: `FileProviderCoordinatorTests`, `stage-file-provider-appex.test.mjs`.
 
-## Operational Telemetry (OpTel)
-
-`SliccstartApp.swift`'s `WindowGroup` root calls `.optelAutoInstrument(appID:)` from `@slicc/swift-optel` once; on macOS that activates `enter`, global `click`, `navigate`, and `error` (uncaught `NSException`). `appID = Bundle.main.bundleIdentifier` (`com.slicc.sliccstart`); beacons land in `helix-225321.helix_rum.cluster`.
-
-Swift errors are values and cannot be intercepted globally, so `do/catch` boundaries report through **`Models/LauncherErrorReport.swift`**. `source = sliccstart:<operation>` is a wire contract (RUM filters on `Operation` enum strings). `target` is **redacted**: URLs → `<url>`, paths → `<path>`, `token`/`secret`/`password`/`key` → `<redacted>`. **Never report `AUError.cancelled`** — that is the normal up-to-date outcome.
-
-Key controls carry stable `.accessibilityIdentifier` values (`get-extension`, `rescan`, `check-for-updates`, `restart-to-update`, `update`, `app-row-<Name>`).
-
-## App Scanning
-
-Chromium browsers by bundle ID; `/Applications` for Electron/WebView2 bundles with CDP frameworks; `~/Applications` scanned first so `* Debug.app` wins over originals; Terminal.app, iTerm2, Ghostty, WezTerm, kitty, Alacritty by bundle ID.
-
-## Terminal Followers
-
-Terminal rows attach the selected terminal to the current leader via `slicc <join-url> follow`. **Disabled until `leaderJoinUrl` is known; never auto-start a leader.**
-
-`SliccCliLocator` order: managed `~/Library/Application Support/Sliccstart/bin/slicc`, repo `make build`, arch-specific `make dist`, `/usr/local/bin`, `~/.local/bin`, `/opt/homebrew/bin`. **The CLI is never bundled in `Sliccstart.app`.** If none is found, the launcher **asks before** downloading from `https://www.sliccy.ai/download/slicc-cli/darwin-<arch>`, validates Developer ID signature and team `S8LB56P782` before making executable, then atomically installs. Bare Mach-Os carry no stapled ticket — see [`docs/pitfalls.md`](../../docs/pitfalls.md) § "Downloaded `slicc` CLI".
-
-Terminal.app and iTerm2 launch through Apple Events; `sign-and-package.sh` signs with `Sliccstart.entitlements` including `com.apple.security.automation.apple-events`.
-
-## Finder File Provider (leader VFS)
-
-Shared provider logic in **`packages/swift-traykit`** (`SliccTrayVFS`). `SliccFileProvider.appex` is built via XcodeGen (`project.yml`) + `xcodebuild`, then `stageFileProviderAppex` copies it into `Contents/PlugIns/` **with its own `WebRTC.framework` and `AppIcon.icns`** — a sandboxed appex cannot load the host `Resources/` copy, and Finder Locations uses the appex icon. `FileProviderCoordinator` saves the join URL to an app-group file (not keychain) when `leaderJoinUrl` is set; Settings → Startup toggles Finder integration. Clean quit withdraws the domain (update/detach does not). The appex is App Sandbox + network client/server, notarized alongside the main app; enable once in System Settings → Login Items & Extensions → File Provider. Coverage: `FileProviderCoordinatorTests`, `stage-file-provider-appex.test.mjs`, `packages/swift-traykit` provider tests.
-
-## Widget Extension (Cones & Scoops)
-
-`SliccstartWidgets.appex` (`com.slicc.sliccstart.widgets`) shows the connected instance's cones and scoops in Notification Centre / on the desktop. Views live in **`packages/swift-widgetkit`**; this package owns only the `@main` bundle and the build wiring — XcodeGen (`project.yml`, `SliccstartWidgets` scheme) → `stageWidgetAppex` into `Contents/PlugIns/` → `sign-and-package.sh` signs it with `SliccstartWidgets.entitlements` (sandbox + app group, no framework to embed, unlike the File Provider appex).
-
-Capture is `Models/WidgetTrayObserver.swift`: Sliccstart holds no cone/scoop state of its own (it is a launcher; state is client-side in the leader tab and the local server is a stateless relay that cannot answer either), so it runs a small **read-only tray follower** off `leaderJoinUrl`, listens for `scoops.list`, and asks for a transcript snapshot at most every 30 s. It is **gated on the widget actually being installed** (`WidgetInstallationQuery`) — a launcher holding a WebRTC participant slot open forever to feed a tile nobody added is a bad citizen in someone else's session. Wired from `SliccstartApp`'s `leaderJoinUrl` observer, next to `FileProviderCoordinator`. Details: [`docs/widgets.md`](../../docs/widgets.md#capture).
+`SliccstartWidgets.appex` (`com.slicc.sliccstart.widgets`): views in **`packages/swift-widgetkit`**; this package owns `@main` + wiring (`SliccstartWidgets` → `stageWidgetAppex` → sandbox + app group, **no** nested framework). `WidgetTrayObserver` is a **read-only tray follower** off `leaderJoinUrl`, **gated on `WidgetInstallationQuery`**. [`docs/widgets.md`](../../docs/widgets.md#capture).
 
 ## iCloud Sync (Tray Sessions)
 
-Shared models in **`packages/swift-traysession`**. **Secret-bearing join URLs sync only through same-Apple-ID, encrypted iCloud KVS.** `SessionReachability` follows bounded `TRAY_SUPERSEDED` chains; only HTTP 200 with `leader.connected == true` is live. `SliccstartApp` publishes non-nil `leaderJoinUrl`; clean quit withdraws, update/detach does not. Coverage: `TraySessionLauncherTests`.
+**`packages/swift-traysession`**. **Join URLs sync only through same-Apple-ID, encrypted iCloud KVS.** Live = HTTP 200 + `leader.connected == true` on bounded `TRAY_SUPERSEDED` chains. Publish non-nil `leaderJoinUrl`; clean quit withdraws, update/detach does not. Advertise-now: [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md#keeping-the-advertised-join-url-true).
 
-**Advertise what is true now, not what was true at launch.** The _browser_ mints the tray, so a reload or a supersede re-mints it and the URL `startLeaderProbe` found once names a tray with no leader. `startLeaderJoinUrlWatch()` re-reads `/api/tray-status` every 60 s and adopts a change; `leaderJoinUrlChanged(_:previous:)` withdraws the entry it supersedes (sessions are keyed by `SHA256(joinUrl)`, so a re-mint otherwise _adds_ a dead row for 12 h); `republishLeaderSession()` re-reads before stamping `lastSeenAt` and publishes nothing when the leader is silent. Why each half is load-bearing: [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md#keeping-the-advertised-join-url-true). Tests: `SliccProcessLeaderProbeTests`, `LauncherModelTests`.
+**`leaderJoinUrl` is the single gate** for Electron/terminal rows _and_ iCloud. `reattach` must `startLeaderProbe` **after** `spawn` registers the record; `leaderProbeStep` waits (bounded) for a never-seen record (`reattachPersistedRecords` is nonisolated `async`). Wrong order → "Start a browser first" after every smooth update. Tests: `SliccProcessLeaderProbeTests`, `LauncherModelTests`, `TraySessionLauncherTests`.
 
-**`leaderJoinUrl` is the single gate** for Electron/terminal rows _and_ iCloud advertising. `reattach` must call `startLeaderProbe` **after** `spawn` registers the launch record, and the loop's `leaderProbeStep` must keep waiting for a record it has never seen (bounded grace) — `reattachPersistedRecords` is nonisolated `async`, so the probe can outrun the record. Getting this wrong strands the launcher on "Start a browser first" after every smooth update. Tests: `SliccProcessLeaderProbeTests`.
+**`Sliccstart --list-sessions`**: `main.swift` **before** SwiftUI. JSON, **metadata only** (`joinUrl` redacted). `--reveal-urls` needs `NSAlert`; headless/SSH **denied** (exit 3). `TraySessionCLI` / `TraySessionCLIRunner`.
 
-**Headless CLI (`Sliccstart --list-sessions`)** — parsed in `main.swift` **before** SwiftUI boots. Prints JSON, **metadata only** (`joinUrl` redacted). `--reveal-urls` gates behind `NSAlert`; headless/SSH callers **denied** (exit 3). Pure logic in `Models/TraySessionCLI.swift`; glue in `TraySessionCLIRunner`.
+## Ordering, mounts, default browser
 
-## App Ordering, Browser Followers, Startup
+`AppOrdering` (`browserBundlePriority`/`terminalBundlePriority`; `AppOrderStore` UserDefaults wins). `browserFollowerArgs` passes `--join=<url>` vs `--lead`; `launchBrowserFollower` flags `isFollower`. Lead-or-attach counts only attachable iCloud sessions — all-dead lists launch standalone. `StartupPreference` starts `AppOrdering.topBrowser`. Tests: `AppOrderingTests`, `StartupPreferenceTests`, `SliccProcessLaunchArgsTests`.
 
-`Models/AppOrdering.swift` (default `browserBundlePriority`/`terminalBundlePriority`; user drag-reorder via `AppOrderStore` UserDefaults wins). `browserFollowerArgs(cdpPort:joinUrl:)` passes `--join=<url>` vs `--lead`; `launchBrowserFollower` flags `isFollower`. `BrowserLaunchAction` and the lead-or-attach dialog count only attachable iCloud sessions (no confirmed-unreachable `SessionReachability` verdict) — all-dead lists launch standalone with no dialog. `Models/StartupPreference.swift`: launch starts top-ordered browser (`AppOrdering.topBrowser`). Tests: `AppOrderingTests`, `StartupPreferenceTests`, `SliccProcessLaunchArgsTests`.
+`MountTablePreference`: `autoMountTable` of `os-path:slicc-path` (last-colon split, `~` expansion, dedup by target), emitted as `--mount=<os>:<vfs>` (browsers only). `/api/hostfs` + webapp auto-mount — no picker. Tests: `MountTablePreferenceTests`. [`docs/mounts.md`](../../docs/mounts.md#auto-mounted-host-folders-the-mount-table).
 
-## Mount Table (Settings → Mounts)
-
-`Models/MountTablePreference.swift`: newline-separated `autoMountTable` UserDefault of `os-path:slicc-path` mappings (parse mirrors swift-server `ServerConfig.parseMountMapping`: last-colon split, `~` expansion, dedup by target), emitted as `--mount=<os>:<vfs>` by `standaloneBrowserArgs(cdpPort:mounts:)` and `reattachArgs(...mounts:)` (browsers only). Mapped folders are served by swift-server's `/api/hostfs` and auto-mounted by the webapp — no picker, no permission prompt. `Views/SettingsView.swift` → `MountsSettingsView`. Tests: `MountTablePreferenceTests`, `SliccProcessLaunchArgsTests`. Behaviour: [`docs/mounts.md`](../../docs/mounts.md#auto-mounted-host-folders-the-mount-table).
-
-## Default Browser Role
-
-Sliccstart can hold the macOS http/https handler role (Settings → Startup). `Models/DefaultBrowserRegistration.swift` claims it; `assemble-app.mjs`'s `CFBundleURLTypes` is the precondition; `Models/IncomingURLRouter.swift` opens each link over CDP. See [`docs/sliccstart-browser.md`](../../docs/sliccstart-browser.md).
+Default http/https handler: `DefaultBrowserRegistration`; `CFBundleURLTypes` precondition; `IncomingURLRouter` opens links over CDP. [`docs/sliccstart-browser.md`](../../docs/sliccstart-browser.md).
 
 ## iCloud Provisioning (Developer ID app)
 
 Sync needs an iCloud KVS entitlement backed by an _embedded_ provisioning profile — **Developer ID signing alone does not authorize iCloud.** `sign-and-package.sh` gates on optional **`PROVISION_PROFILE`**: unset → signs `Sliccstart.entitlements` only, `NSUbiquitousKeyValueStore` degrades to a local cache; set → embeds the profile and signs a merged file. CI exports `PROVISION_PROFILE` and `KVSTORE_IDENTIFIER` (releases ship `S8LB56P782.ai.sliccy.trays`, **which the iOS follower must match**). Signing contract: `macos-permissions.test.mjs`.
 
-## Debug Build Creation
-
-`Models/DebugBuildCreator.swift` creates Electron debug builds by: (1) copying into `~/Applications/<Name> Debug.app`, (2) patching Electron fuses for remote debugging, (3) unpacking/patching `app.asar` JS checks that block CDP, (4) ad-hoc signing, (5) removing quarantine attributes. Use when an Electron app disables remote debugging in production.
-
 ## App Icon
 
-Two artefacts, both written by `build-app-icon.mjs`:
+`DebugBuildCreator`: copy to `~/Applications/<Name> Debug.app`, patch Electron fuses, unpack/patch `app.asar` CDP blocks, ad-hoc sign, drop quarantine.
 
-- **`AppIcon.icns`** — one flat image from `packages/assets/logos/macos-icon-iOS-Default-1024x1024@1x.png`, via `sips` + `iconutil` (both ship with macOS). `CFBundleIconFile`.
-- **`Assets.car`** — `actool`-compiled from `packages/assets/logos/macos-icon.icon` (Icon Composer). Adds the `NSAppearanceNameAqua` / `NSAppearanceNameDarkAqua` / `ISAppearanceTintable` icon stacks macOS 26 picks between. `CFBundleIconName`, emitted into `Info.plist` only when the compile succeeds.
+`build-app-icon.mjs` writes `AppIcon.icns` (`sips`+`iconutil`) and `Assets.car` (`actool` from `macos-icon.icon`). Degrades if `actool` is missing/too old (CI `macos-latest` = macOS 15; only `release.yml` pins `macos-26`) — a green CI build is **not** proof appearance variants shipped. Watch `WARNING: appearance-keyed app icon skipped`; `xcrun assetutil --info <app>/Contents/Resources/Assets.car`. [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md#app-icon). Tests: `build-app-icon.test.mjs`.
 
-`buildIconAssetCatalog` **degrades instead of throwing** on all three failure modes — the bundle still gets its `.icns`, just with no Dark/Tinted appearance:
-
-1. `actool` absent (it lives in Xcode, not the Command Line Tools);
-2. `actool` present but too old to compile the `.icon` — **this is the common case in CI**, whose `swift-launcher` job runs on `macos-latest` (still macOS 15 / Xcode 16.x); only `release.yml` pins `macos-26`;
-3. `actool` exits 0 but writes no `Assets.car`.
-
-So a green `swift-launcher` CI build is **not** proof the appearance variants shipped — only the `macos-26` release job produces them. Watch for the `WARNING: appearance-keyed app icon skipped` line if a build's icon stops adapting, and confirm what actually shipped with `xcrun assetutil --info <app>/Contents/Resources/Assets.car`.
-
-A classic `AppIcon.appiconset` cannot replace the `.icon` here: `actool` honours the `appearances` key on iOS idioms only and reports macOS ones as "unassigned children", dropping them without failing the build. Per-appearance _custom artwork_ (`image-name-specializations`) exists in the `.icon` format but is authored in Icon Composer — hand-written variants of that key are silently ignored, so the macOS Tinted icon is **system-derived** from the layer artwork. Its contrast is therefore a property of `macos-icon.icon`'s layer, not something a separate PNG can override. Tests: `build-app-icon.test.mjs`.
-
-## Packaging Notes
-
-- `npm run build` assembles the `.app` from pre-built artifacts; `sign-and-package.sh` is the distributable path.
-- Expects `packages/swift-server/.build/release/slicc-server` to be pre-built. Webapp is **not** bundled — `assemble-app.mjs` writes an empty `Contents/Resources/slicc` marker dir.
-- **`WebRTC.framework` ships next to `slicc-server`**: `sign-and-package.sh` re-signs **innermost-first** — else dyld fails and every spawned server dies as "start failed".
-- Electron overlay bootstrap `dist/ui/electron-overlay-entry.js` is produced by **`@ai-ecoverse/spoon`** (`npm run build -w @ai-ecoverse/spoon`) and must be built before `assemble-app.mjs`; a `packages/spoon/**` change re-triggers this CI job.
-- Packaging emits only the full `Sliccstart-<v>.zip`.
+Packaging: `npm run build` from pre-built artifacts; `sign-and-package.sh` is the distributable path. Needs `slicc-server`. Webapp **not** bundled. **Re-sign `WebRTC.framework` innermost-first.** Overlay from **`@ai-ecoverse/spoon`** (`npm run build -w @ai-ecoverse/spoon`) before `assemble-app.mjs`. Emits only `Sliccstart-<v>.zip`. [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md#packaging).
 
 ## Updates
 
-**Full-app-only**, driven by external `AppUpdater` SPM package. `SliccstartApp.swift` owns an `AppUpdater` `@StateObject`; `checkForUpdates()` records outcome in `UpdateCheckStatus`. On `.downloaded`, `AppListView.fullUpdateButton` surfaces `restart-to-update` → `appUpdater.install(bundle)`. The 2 s timer polls `/api/agent-activity`; `AgentActivityProbe` fails open after 1 s.
+**Full-app-only** (`AppUpdater` SPM). `checkForUpdates()` → `UpdateCheckStatus`; `.downloaded` → `restart-to-update` → `appUpdater.install(bundle)`. 2 s timer polls `/api/agent-activity`; `AgentActivityProbe` fails open after 1 s. `--update-host=<url>` / `SLICC_UPDATE_HOST` (default `https://api.github.com`). `TolerantGithubReleaseProvider`: `Sliccstart-<version>.zip`/`.tar`; `per_page=100`; RFC 8288 `rel="next"` (same host, HTTP(S) only). `LaunchRecordStore` + `CDPLiveProbe` (`/json/version`): **no PID**; persist `bridgeToken`. `detachAll()` / `reattachPersistedRecords()`. **Thin-bridge `slicc-server` only — no `--static-root`.** [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md#updates).
 
-- `Models/UpdateCheckStatus.swift` — `idle`, `checking`, `upToDate`, `noInstallableRelease`, `translocated`, `failed(message)`.
-- `Models/UpdateHostConfiguration.swift` — `--update-host=<url>` / `SLICC_UPDATE_HOST` (default `https://api.github.com`).
-- `Models/TolerantGithubReleaseProvider.swift` — filters releases lacking `Sliccstart-<version>.zip`/`.tar`; `per_page=100`; follows RFC 8288 `Link: rel="next"` (same host, HTTP(S) only) until viable release or `currentVersion`.
-- `Models/LaunchRecordStore.swift` — `PersistedLaunchRecord` JSON at `~/Library/Application Support/Sliccstart/launch-records.json` + `CDPLiveProbe` (`/json/version`). **No PID stored.** `bridgeToken` persisted so reattach re-forwards the same secret the surviving tab has.
-- `Models/SliccProcess.swift`: `detachAll()`, `reattachPersistedRecords()`. **The launcher only ever spawns thin-bridge `slicc-server` — no `--static-root` / overlay plumbing.**
-
-## Update Tests
-
-`UpdateHostConfigurationTests.swift`, `UpdateCheckIntegrationTests.swift` (real GitHub API — needs `GH_TOKEN` from `${{ github.token }}` in `ci.yml`), `ReleaseFetchPaginationTests.swift`, `UpdateCheckStatusTests.swift`, `AgentActivityProbeTests.swift`, `LauncherErrorReportTests.swift`.
-
-Deep reference for every section above: [`docs/swift-launcher-details.md`](../../docs/swift-launcher-details.md).
+Tests: `UpdateHostConfigurationTests`, `UpdateCheckIntegrationTests` (real GitHub API — `GH_TOKEN` from `${{ github.token }}` in `ci.yml`), `ReleaseFetchPaginationTests`, `UpdateCheckStatusTests`, `AgentActivityProbeTests`, `LauncherErrorReportTests`.

--- a/packages/swift-server/CLAUDE.md
+++ b/packages/swift-server/CLAUDE.md
@@ -47,13 +47,9 @@ npm run format -w @slicc/swift-server        # swift format --in-place
 
 ## Electron `--join` — egress decides the attach route
 
-Egress-ALLOWED apps attach via the overlay itself: the LEADER-role overlay URL carries `tray=<join url>` (the Chrome join path's `?tray=` contract), so the pinned first tab boots as a tray follower instead of minting its own. In-app auto-follow tabs carry an explicitly EMPTY `tray=`, blocking the webapp's stored-join-URL fallback at the shared sliccy.ai origin — one app, one follower.
+Egress-allowed apps: the LEADER-role overlay URL carries `tray=<join url>` (Chrome's `?tray=` contract) so the pinned first tab boots as a tray follower. In-app auto-follow tabs get an empty `tray=`, blocking the stored-join-URL fallback — one app, one follower.
 
-## Egress-blocked Electron apps (Signal) — CDP over CDP
-
-Signal-class Electron apps deny **all** renderer egress at the main process (`net::ERR_ACCESS_DENIED`), beneath `Page.setBypassCSP` / CDP Fetch. `ElectronOverlayEgress.swift` detects this via `Network.loadingFailed` on the overlay iframe and shows a **status-only** overlay (mirrors node-server `electron-controller.ts`).
-
-When blocked AND a `--join` tray URL is given, swift-server exposes the app's CDP to the leader via a headless WebRTC tray follower (`Sources/Follower/`): `ElectronTrayFollower.swift` routes `tray-control`; `FederatedCDPServicer.swift` speaks raw browser CDP with `sendCDPResponse`-compatible chunking. Mirrors node-server's `electron-tray-follower.ts` / `electron-federated-cdp.ts`; Swift uses `stasel/WebRTC` via `packages/swift-trayfollower`.
+Egress-blocked apps (Signal): renderer egress is denied at the main process (`net::ERR_ACCESS_DENIED`), beneath CSP bypass / CDP Fetch. `ElectronOverlayEgress.swift` detects `Network.loadingFailed` on the overlay iframe and shows a **status-only** overlay (mirrors node-server `electron-controller.ts`). With `--join`, a headless WebRTC tray follower (`Sources/Follower/`) exposes the app's CDP: `ElectronTrayFollower.swift` routes `tray-control`; `FederatedCDPServicer.swift` speaks raw browser CDP. Mirrors `electron-tray-follower.ts` / `electron-federated-cdp.ts`; Swift uses `stasel/WebRTC` via `packages/swift-trayfollower`.
 
 ## Server Overview
 
@@ -70,12 +66,12 @@ When blocked AND a `--join` tray URL is given, swift-server exposes the app's CD
 - `GET /api/runtime-config`, `/api/tray-status`, `/auth/callback`, `GET|POST /api/oauth-result`, `GET|POST|DELETE /api/webhooks...`, `/api/crontasks...`
 - `POST /api/handoff` (`Sources/Server/Handoff.swift`) — validates payload, broadcasts `navigate_event` on lick WebSocket.
 - `GET /api/secrets`, `GET|POST /api/secrets/session`, `/api/secrets/masked`, `/api/secrets/peek`, `POST /api/secrets/scope`, session-first `DELETE /api/secrets/:name`. Session records are process-memory only; persisted/OAuth records keep masking precedence on name collisions.
-- `POST /api/secrets/scrub` (via `SecretInjector.scrub(text:)`). Intentionally no persisted `POST /api/secrets` route.
-- `POST /api/s3-sign-and-forward`, `/api/da-sign-and-forward` (`Sources/Server/SignAndForward.swift`) — S3 creds from Keychain, transient IMS bearer for DA.
-- `POST /api/sudo-approve` (`Sources/Server/SudoApprove.swift`) — native `osascript` via `Process`; loopback-only; fail-closed to `{ decision: "deny" }`.
-- `ALL /api/fetch-proxy` — HTTP verbs plus WebDAV/CalDAV (`PROPFIND`, `PROPPATCH`, `MKCOL`, `MKCALENDAR`, `REPORT`, `COPY`, `MOVE`, `LOCK`, `UNLOCK`). Unknown → AsyncHTTPClient via `HTTPMethod.RAW(value:)`.
+- `POST /api/secrets/scrub` (`SecretInjector.scrub(text:)`). No persisted `POST /api/secrets`.
+- `POST /api/s3-sign-and-forward`, `/api/da-sign-and-forward` — Keychain S3 creds; transient IMS bearer for DA.
+- `POST /api/sudo-approve` — loopback-only `osascript`; fail-closed `{ decision: "deny" }`.
+- `ALL /api/fetch-proxy` — HTTP + WebDAV/CalDAV; unknown verbs → `HTTPMethod.RAW`.
 
-WebSocket routes install separately for CDP and lick. `LickSystem` (actor) tracks clients + pending requests; `LickWebSocketRoute` exposes `/licks-ws`. Browser-originated messages resolve pending requests or broadcast events into the runtime.
+WebSocket routes for CDP and lick install separately (`/licks-ws`).
 
 ## Tab Session Restore
 

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -1,23 +1,30 @@
 # CLAUDE.md
 
-Browser app guide for `packages/webapp/`. Extension-only behavior lives in `packages/chrome-extension/CLAUDE.md`; runtime/server details in float-specific guides.
+Browser app (`packages/webapp/`). Extension-only behavior:
+[`packages/chrome-extension/CLAUDE.md`](../chrome-extension/CLAUDE.md).
+Runtime/server: float-specific guides. Overflow:
+[`docs/webapp-details.md`](../../docs/webapp-details.md).
 
-## Scope
+## Commands
 
-`packages/webapp/src/` contains the browser app core: VFS, shell, git, CDP, tools, providers, skills, scoops, and the UI.
+```bash
+npm run build -w @slicc/webapp           # Vite → dist/ui/
+npm run test  -w @slicc/webapp           # vitest --project webapp
+npm run typecheck                        # repo-wide tsc
+npx vitest run packages/webapp/tests/<file>.ts
+```
+
+Payload: `npm run size -w @slicc/webapp`. Workflows: `docs/development.md`.
 
 ## Architecture
 
-### Layer Stack
+Imports only downward. Consumed by node-server and chrome-extension floats.
 
 ```text
 Virtual Filesystem (fs/) → RestrictedFS → Shell (shell/) + Git (git/)
   → CDP (cdp/) → Tools (tools/) → Core Agent (core/)
     → Scoops Orchestrator (scoops/) → UI (ui/)
-      → consumed by node-server and chrome-extension floats
 ```
-
-### Data Flow
 
 ```text
 User → ChatPanel → Orchestrator → ScoopContext.prompt() → pi-agent-core → LLM API
@@ -25,250 +32,155 @@ User → ChatPanel → Orchestrator → ScoopContext.prompt() → pi-agent-core 
   → results → agent loop → UI updates / scoop routing
 ```
 
-## Key Subsystems
+## Subsystems
 
-Per-subsystem file paths + non-obvious invariants live in
-[`docs/webapp-details.md`](../../docs/webapp-details.md). Root paths only here; the
-never-rules below flag what a reviewer must recognise.
+Paths under `packages/webapp/src/`. File maps: `docs/webapp-details.md`.
 
-- Kernel host — `packages/webapp/src/kernel/` (also `docs/kernel/process-model.md`)
-- Orchestrator + tray — `packages/webapp/src/scoops/`
-- WorkUnit runtime (cone/scoop as roles) — `packages/webapp/src/work-unit/`
-  (also `docs/work-unit.md`)
-- VirtualFS + mounts — `packages/webapp/src/fs/` (also `docs/mounts.md`)
-- Shell (`.jsh`/`.bsh`, MCP) — `packages/webapp/src/shell/`
-  (also `docs/shell-reference.md`)
-- Speech (mic/TTS) — `packages/webapp/src/speech/`
-- CDP + cherry — `packages/webapp/src/cdp/`
-- Tools (file/`bash`/scoop helpers) — `packages/webapp/src/tools/`; browser
-  automation routes through shell commands, not a separate tool family
-- Sudo — `packages/webapp/src/sudo/` + `fs/sudo-fs.ts` + `shell/sudo/`
-- Bash progress overlay — `shell/progress/` (one `ScriptRun` unit per tool call: `planScriptProgress` counts registry dispatches from `bash.transform().ast`, steps tick at `wrapCommandForDispatch` on completion; `sleep`/`timeout` tickers, `wrapCommandForProgress` start/end and `createFetchProgressObserver` bytes (fed by `proxied-fetch.ts` + node-server `X-Proxy-Content-Length`) fold into it via `emitter.setAggregator`; ≤4 events/s per id); events ride `ToolExecutionContext.onUpdate` as `progress` partials → `tool_progress` agent event → `applyToolProgress` (icon fill, 3-dot badge, body top bar) + send-button `progress` ring. Design: `docs/exploration/bash-progress-overlay.md`
-  (also `docs/approvals.md`)
-- Core agent — `packages/webapp/src/core/` (pi-agent-core + pi-ai;
-  `tool-adapter.ts` bridges legacy tools; feature flags, context compaction)
-- UI + layouts — `packages/webapp/src/ui/` and `ui/wc/` (also `docs/layouts.md`)
-- Skills — `packages/webapp/src/skills/`
+- Kernel host — `kernel/` — `docs/kernel/process-model.md`
+- Orchestrator + tray — `scoops/`
+- WorkUnit — `work-unit/` — `docs/work-unit.md`
+- VirtualFS + mounts — `fs/` — `docs/mounts.md`
+- Shell (`.jsh`/`.bsh`, MCP) — `shell/` — `docs/shell-reference.md`
+- Speech — `speech/`
+- CDP + cherry — `cdp/`
+- Tools — `tools/` (browser automation is shell commands, not a tool family)
+- Sudo — `sudo/` + `fs/sudo-fs.ts` + `shell/sudo/` — `docs/approvals.md`
+- Bash progress — `shell/progress/` — `docs/exploration/bash-progress-overlay.md`
+- Core agent — `core/` — pi-agent-core + pi-ai; `tool-adapter.ts`; flags; compaction
+- UI + layouts — `ui/`, `ui/wc/` — `docs/layouts.md`
+- Skills — `skills/`
 - Sprinkles + Dips — `ui/sprinkle-*.ts`, `ui/dip.ts`
-- Stale-asset recovery — `setup-preload-error-reload.ts` + `stale-asset-channel.ts`
+- Stale-asset recovery — `ui/boot/setup-preload-error-reload.ts` + `core/stale-asset-channel.ts`
 
 ## File mentions + preview
 
-Clicking a file name the agent wrote in chat. Five modules, deliberately split so the guessing and the verifying stay separate:
-
-- `core/file-mentions.ts` — the heuristic. Pure; finds CANDIDATES in prose and knows nothing about the VFS.
-- `core/tool-call-paths.ts` — harvests the paths a tool call's parameters named (bash redirects, `path`-ish fields), so prose can be read against what the agent already did.
-- `core/file-mention-resolver.ts` — checks candidates against the VFS via a lazily built, bounded basename index, with those paths as hints.
-- `ui/file-mention-linker.ts` — walks a rendered message and links only what resolved.
-- `ui/wc/wire-file-mentions.ts` — lifecycle: observes the thread, waits for streaming to finish, opens the preview.
-
-Plus `core/file-type.ts` (content sniffing) and `ui/git-preview-source.ts` (the HEAD blob for diff mode). `ui/wc/file-actions.ts` owns `openFilePreview`, the single entry point both the file tree and a clicked mention go through.
-
-Non-obvious rules:
-
-- **Confirm, then linkify.** Nothing is decorated optimistically — the heuristic is permissive precisely BECAUSE verification gates it. A candidate that does not resolve stays plain text.
-- **Never linkify a streaming bubble.** A half-arrived path resolves to nothing; bubbles are processed only once `streaming` clears.
-- **`getMimeType()` (`core/mime-types.ts`) is for SERVING, `sniffFileType()` (`core/file-type.ts`) is for READING.** Never swap them: sniffing a type you then put in a `Content-Type` header is how MIME-confusion bugs happen, and serving's conservative `application/octet-stream` fallback is exactly what made `.jsh` unpreviewable. Precedence is magic bytes → extension → UTF-8 decodability.
-- **`isomorphic-git` is imported lazily** in `git-preview-source.ts`; the UI layer must not pull the `src/git/` stack for a preview. Its fs shim is read-only ON PURPOSE — a preview surface must never be able to write to a repo.
-- **Hints come from the typed `ToolCall`, not from parsed markup.** `wc-message-view.ts` stamps each rendered tool row with `data-file-paths` (JSON) at render time; `wire-file-mentions.ts` reads the rows that PRECEDE a bubble in document order — chronological in a transcript — capped at the most recent 40. A hint is believed only after `stat()` confirms it, which is what lets it resolve a file outside the indexed roots (`/home/lars/foo.md`) without ever inventing a link.
-- **A hint without a directory is dropped.** The whole value of a hint is the path segment prose does not carry; a bare basename tells the resolver nothing the index did not already know, and would only cost a `stat()`.
-- **Markdown is detected by EXTENSION, on purpose** (`richPreviewKind` in `core/file-type.ts`). It has no magic bytes and is byte-identical to plain text — the name is the only declaration there is, and being wrong changes only which view opens first. Markdown is converted by `ui/message-renderer.ts` (DOMPurify-sanitized) and mounted inline; **raw HTML is never sanitized and never mounted inline** — it goes to Quick Look's sandboxed iframe. Documents over 512 KB get no rendered view (synchronous conversion would freeze the overlay).
-- **The mention resolver's index is bounded** (`maxEntries`, `maxDepth`, skipped `node_modules`-class directories). A mention that would only resolve past the ceiling stays plain text; stalling the transcript to prove otherwise is worse.
+Heuristic and VFS stay split. Confirm, then linkify; never decorate a streaming
+bubble. `getMimeType()` (`core/mime-types.ts`) is for **serving**;
+`sniffFileType()` (`core/file-type.ts`) is for **reading** — never swap them.
+Raw HTML is never sanitized or mounted inline (Quick Look iframe). Remaining
+rules: `docs/webapp-details.md` (File mentions).
 
 ## Never-Rules
 
-- **Kernel realms**: `runInRealm()` spawns per-task `DedicatedWorker`; SIGKILL → exit 137. Sync `readFileSync`/`writeFileSync` and
-  `child_process.execSync`/`execFileSync`/`spawnSync` from realm scripts go through
-  `realm/sync-{xhr,fs-*,exec-*}.ts` + `ui/sync-fs-sw-handler.ts` with per-realm
-  capability tokens; never bypass. On an isolated leader the same dispatchers are
-  reached over `realm/sync-sab-*.ts` (Atomics/SharedArrayBuffer on the realm's
-  own port) — only for `Realm.isolatedThread` realms; the in-process factory must
-  never get a SAB (self-deadlock). Deep reference: `docs/kernel/process-model.md`.
-- **Cone and scoop are roles over one `WorkUnit`** (#1666): `RegisteredScoop.parentJid`
-  is required — `null` is THE root test (`isRootUnit`). The record carries no role:
-  `isCone`/`type` were deleted in #2279, so the **compiler** is the ratchet for every
-  record read — a role branch no longer has a field to read. `isCone` survives only on the
-  follower wire, write-only leader-side (projected from `isRootUnit`); reading it back
-  is a follower fallback for a pre-`parentId` leader (`summaryIsRoot`, `coneJidFromWire`). New `scoops/` and `kernel/` code asks `orchestrator.getWorkUnits()` (`getParent`, `getChildren`,
-  `resolveDefaultRoot`) or the unit's `policy.*`. Every creation path sets `parentJid`
-  explicitly; restore backfills and persists it (`legacyRecordIsCone` reads the
-  pre-#2279 field once, there, and `normalizeScoopRecord` strips it). Several roots may
-  exist: UI code resolves "the cone" via `ui/wc/wc-unit-context.ts` (`defaultRootOf`,
-  `threadContextFor`, `switcherLabelFor`); ONE strip ordering, both shells:
-  `work-unit/client/presentation.ts`, over the `WorkUnitClient` protocol (#2274).
-  Chat sessions: `session-<folder>`
-  (`chatSessionIdFor`). Cone add/drop lives in `ui/wc/wc-cone-actions.ts`
-  behind `<slicc-freezer-new>`'s action row (`<slicc-dialog>`, never inline);
-  the strip is the only switcher.
-  Directory layout comes from `workspaceFor` ALONE — primary cone
-  `/workspace`, extra cone `/cones/<folder>/workspace` + its own `CLAUDE.md`,
-  scoop `/scoops/<folder>/workspace`; `/shared`, `/tmp` and the skills library
-  (`SKILLS_LIBRARY_DIR`) stay shared. Never hardcode `/workspace` for a unit's
-  root, memory file or spawn default. Memory is per cone on both paths. A unit's CONVERSATION is one canonical,
-  append-only record too (#2275, `work-unit/conversation/`): Pi history, the UI
-  projection and transcripts are DERIVATIONS, never parallel writes. The legacy stores are still written (a read-old/write-new window),
-  so anything deriving to nothing falls back — never make a canonical read
-  fatal or delete a legacy record (#2006).
-  **Users never talk to a scoop** (#2312): a selected scoop is READ-ONLY
-  (`isReadOnlyUnit` — one rule) and anything it needs from a
-  human goes to the OWNING cone, never `defaultRoot()`.
-  See `docs/work-unit.md`.
-- **Scoop queue**: pure-lick batches defer while `ScoopContext.isBusy` without
-  queue/watermark loss; user `web` bypasses the window (immediate/awaited,
-  prevents deferral). `transcript-limits.ts` caps bridge/event transcripts at 64 KB
-  — never the canonical `agent-sessions` history or compaction input.
-- **Agent bridge defaults** (`agent-bridge.ts`): writable
+- **Kernel realms**: `runInRealm()` → per-task `DedicatedWorker`; SIGKILL → 137. Sync fs/exec go through `realm/sync-{xhr,fs-*,exec-*}.ts` +
+  `ui/sync-fs-sw-handler.ts` with per-realm tokens; never bypass. Isolated
+  leader: `realm/sync-sab-*.ts` (Atomics/SAB) only for `Realm.isolatedThread`
+  — the in-process factory must never get a SAB (self-deadlock).
+  `docs/kernel/process-model.md`.
+- **Cone/scoop are roles over one `WorkUnit`**: `parentJid === null` is the
+  root test (`isRootUnit`). No `isCone`/`type` on the record; `isCone` is
+  follower-wire only. New `scoops/`/`kernel/` code asks
+  `orchestrator.getWorkUnits()` or `policy.*`. Directory layout from
+  `workspaceFor` alone — never hardcode `/workspace`. Users never talk to a
+  scoop (`isReadOnlyUnit`); human input goes to the owning cone, never
+  `defaultRoot()`. Conversation is one append-only canonical record;
+  Pi/UI/transcripts are derivations. Never make a canonical read fatal or
+  delete a legacy record. `docs/work-unit.md`.
+- **Scoop queue**: pure-lick batches defer while `ScoopContext.isBusy`
+  without queue/watermark loss; user `web` bypasses (immediate/awaited).
+  `transcript-limits.ts` caps **bridge** transcripts at 64 KB — never
+  `agent-sessions` history or compaction input.
+- **Agent bridge** (`agent-bridge.ts`): writable
   `[cwd, /shared/, <scratch>/, /tmp/]`, visible
   `[...defaultChildVisibleRoots(owning cone), invokingCwd]`; `--read-only`
   replaces them.
 - **Mount signing is browser-naive**: CLI → `/api/s3-sign-and-forward`,
-  extension → SW. Never sign in the browser. See `docs/mounts.md`.
+  extension → SW. Never sign in the browser. `docs/mounts.md`.
 - **Shell/mount cache**: `script-catalog.ts` caches per `$PATH` root set;
-  the `FsWatcher` cache is bypassed only for root sets a mount overlaps
-  (external changes there are invisible). `.jsh` lookup follows `$PATH` —
-  never reintroduce a full-VFS scan (#2085).
-- **`typescript` v7 has no browser/WASM API** — use `typescript-js` (v6) for browser
-  `tsc`/`test`/`esm-transpile`. `builtin-shadow-map.ts` is authoritative for
-  `ipx`/`npx` → built-in redirects.
-- **`esbuild.initialize` needs `worker: false` + a bounded wait** in every browser
-  float: with `worker: true` it settles only on a nested `blob:` Worker's first
-  message (no `onerror`, no timeout), so a blocked blob worker hangs forever
-  (#2200). Never cache a load promise that can stay pending — `esbuild-wasm.ts`
-  records a stall instead. See `docs/pitfalls.md`.
-- **Speech is page-realm only** (mic, AudioContext); kernel worker bridges via
-  `hear-*` panel-RPC. Extension `uiOnly` side panel: Chrome denies `getUserMedia`
-  from a cross-origin iframe, so `wc-follower.ts` skips `ptt` and drops
-  "Take a photo".
-- **Sprinkle element bundles ride the app's chunk graph.** `<slicc-diff>` /
-  `<slicc-editor>` are Rollup entries (`build.rollupOptions.input`), and
-  `dist/ui/slicc-diff.js` / `slicc-editor.js` are stable-name loader shims that
-  dynamic-import the hashed entry — so Shiki, `@pierre/diffs`, and CM6 are the
-  SAME chunks the app ships, not a second eager copy (`slicc-diff.js` alone was
-  5.8 MB as an esbuild IIFE, because esbuild inlines dynamic imports). Loading
-  is async: elements must adopt pre-upgrade properties
-  (`ui/upgrade-own-properties.ts`), and sprinkles awaiting a method API use
-  `window.__SLICC_SPRINKLE_ASSETS__['slicc-diff.js']`.
-- **The kernel-worker build stubs `speech/speak.ts` + `speech/hear.ts`**
-  (`stubPageRealmSpeechPlugin`, `worker.plugins` only). `say`/`hear` keep their
-  local and panel-RPC branches in one module; the local branch is gated on
-  `speechSynthesis`, so in a worker it is dead code that was dragging
-  `kokoro-js` + `@huggingface/transformers` (~1.8 MB) into a build the page
-  graph already covers. Same reason `speech/model-ids.ts` exists — a model-id
-  constant must never be imported from an engine.
-- **Cherry origin detection** (`cherry-host-transport.ts`): `resolveParentOrigin()`
-  prefers `location.ancestorOrigins[0]` (unforgeable); `document.referrer` alone
-  breaks when Referer is stripped or in HTTP-in-HTTPS dev embeds.
-- **Cherry envelope gate** (`cherry-host-protocol.ts`): three factors — origin
-  allowlist + `MessageEvent.source` identity + per-mount `channelId` nonce.
-  `packages/cherry/src/protocol.ts` is a structural mirror; keep in sync.
-- **Sudo self-protection**: writes to `/etc/sudoers` + `/etc/sudoers.d/*` always
-  require approval, hardcoded in `matchPath`. Deep reference: `docs/approvals.md`.
-- **`/tmp` is granted to every scoop, sandbox or not** — `builtinScoopGrants()`
-  (`base/sudoers.ts`, merged by `getPolicyForScoop`) + `ALWAYS_WRITABLE_PREFIXES`
-  (`fs/restricted-fs.ts`). Both layers gate independently, so change them
-  together. The space is SHARED across scoops: never put a secret there; private
-  scratch is `/scoops/<folder>/tmp`.
-- **"Agent can't self-approve" does NOT cover page-realm code** (which can reassign
-  `globalThis.confirm`): `sudo/panel-responder.ts` captures natives at module
-  init; approval chrome mounts via `ui/wc/trusted-layer.ts`, never `document.body`.
-  The panel terminal is intentionally NOT gated.
-- **Sudo brokers** are float-specific (`createSudoBroker`): extension-delegate
-  relays via hosted leader tab; standalone/Electron POSTs `/api/sudo-approve`.
-  All of them are wrapped in `withApprovalTimeout` — an unanswered prompt
-  settles after 5 min as `{ decision: 'deny', reason: 'user-timeout' }` (the
-  scoop → cone leg uses `cone-timeout`; different approver, different recovery)
-  so the blocked turn is released. `reason` is a FIELD, never a fourth
-  `decision` value: every gate branches on `deny`, so a new variant would fail
-  open. The wrapper also aborts `SudoRequestOptions.signal` before resolving, so
-  a broker whose `suggest` outlived the budget cannot raise a stale prompt.
-- **Frozen-session recovery** must go through the **bounded** legacy enrichment
-  call — never the unbounded curator (`timeoutSeconds` cannot stop it). Save /
-  Skip memory / Erase clear the SELECTED cone's chat and non-mount `/tmp`, not
-  scoops: the freezer, `clear-chat` and boot hydration all resolve their root
-  through `ui/wc/wc-unit-context.ts` (`rootForSelection`, `rootFolderForContext`)
-  and key the session with `chatSessionIdFor`, never the literal `session-cone`.
-  Archives record `cone` / `coneLabel` so a card names its cone and a thaw can
-  route back to it. The welcome flow is the one deliberate exception — it stays
-  primary-cone-only (#2272). See `docs/work-unit.md`.
-- **Layouts** (`docs/layouts.md`): behind `panel-layouts` flag. `panelize-shell.ts`
-  RE-PARENTS what `mountWcShell` built, so `WcShellRefs` stays valid.
-  `setPanelVisible` must add an unplaced panel but never duplicate a placed one;
-  `sanitizeLayoutName` guards the path a name becomes.
-- **Cloud cone config** (`ui/hosted-config-apply.ts`): `applyHostedAccounts`
-  removes only providers tracked in `localStorage['slicc_cloud_managed']` — never
-  user-added ones. `?connect=1` is login-only (`ui/connect-surface.ts`), no kernel.
-- **Never monkeypatch a method on a get/set-asymmetric Proxy.** The sudo-fs Proxy
-  advertises `MONKEYPATCH_UNSAFE_FS` (a `Symbol.for` marker);
-  `getCompatibilitySkillCandidates` skips hooks and cache for it. Reassigning a
-  gated method creates an `override↔wrapper` async recursion that OOMs the kernel
-  worker.
-- **Adobe `X-Session-Id` invariant**: every LLM call to the Adobe proxy must attach
-  the `X-Session-Id` header. `scoop-context.ts` wires it for the agent `streamFn`
-  and compaction `headers`; new call sites (`streamSimple`/`completeSimple`,
-  pi-coding-agent helpers) must attach it explicitly.
-  `providers/adobe.ts`'s `ensureSessionIdHeader` is defense-in-depth
-  (daily-rotated sentinel UUID + warning), not the fix location. See
+  bypass `FsWatcher` cache only for root sets a mount overlaps. `.jsh`
+  lookup follows `$PATH` — never a full-VFS scan.
+- **`typescript` v7 has no browser/WASM API** — `typescript-js` (v6) for
+  browser `tsc`/`test`/`esm-transpile`. `builtin-shadow-map.ts` is
+  authoritative for `ipx`/`npx` redirects.
+- **`esbuild.initialize` needs `worker: false` + a bounded wait** in every
+  browser float. Never cache a load promise that can stay pending.
   `docs/pitfalls.md`.
-- **Claude Bedrock capability shims** (temperature rejected by Opus ≥ 4.7;
-  adaptive thinking for Opus/Sonnet ≥ 4.6): fix at the provider layer via
-  `src/providers/claude-model-version.ts` (`parseClaudeVersion` + predicate
-  helpers), never at the call site. See `docs/pitfalls.md`.
+- **Speech is page-realm only** (mic, AudioContext); kernel worker uses
+  `hear-*` panel-RPC. Extension `uiOnly` side panel: skip `ptt` and drop
+  "Take a photo". Worker build stubs `speech/speak.ts` + `speech/hear.ts`
+  (`stubPageRealmSpeechPlugin`); never import a model-id constant from an
+  engine (`speech/model-ids.ts`). Bundle rules: `docs/pitfalls.md`.
+- **Sprinkle element bundles ride the app chunk graph.** `<slicc-diff>` /
+  `<slicc-editor>` are Rollup entries; `dist/ui/slicc-diff.js` /
+  `slicc-editor.js` are stable-name shims. Adopt pre-upgrade properties
+  (`ui/upgrade-own-properties.ts`); method APIs await
+  `window.__SLICC_SPRINKLE_ASSETS__['slicc-diff.js']`.
+- **Cherry origin** (`cherry-host-transport.ts`): `resolveParentOrigin()`
+  prefers `location.ancestorOrigins[0]`. Envelope gate
+  (`cherry-host-protocol.ts`): origin allowlist + `MessageEvent.source` +
+  per-mount `channelId`. Keep `packages/cherry/src/protocol.ts` in sync.
+- **Sudo**: writes to `/etc/sudoers` + `/etc/sudoers.d/*` always need
+  approval (`matchPath`). Capture natives at module init
+  (`sudo/panel-responder.ts`); mount chrome via `ui/wc/trusted-layer.ts`,
+  never `document.body`. Panel terminal is **not** gated. Brokers:
+  `createSudoBroker` + `withApprovalTimeout` (5 min
+  `{ decision: 'deny', reason: 'user-timeout' }`; scoop→cone uses
+  `cone-timeout`). `reason` is a field, never a fourth `decision` value.
+  `docs/approvals.md`.
+- **`/tmp` is granted to every scoop** — `builtinScoopGrants()`
+  (`base/sudoers.ts`) + `ALWAYS_WRITABLE_PREFIXES` (`fs/restricted-fs.ts`).
+  Change both layers together. Shared: never put a secret there; private
+  scratch is `/scoops/<folder>/tmp`.
+- **Frozen-session recovery** uses the **bounded** legacy enrichment call —
+  never the unbounded curator (`timeoutSeconds` cannot stop it). Save /
+  Skip memory / Erase clear the **selected** cone's chat and non-mount
+  `/tmp`, not scoops, keyed by `chatSessionIdFor`. Welcome flow is
+  primary-cone-only.
+- **Layouts**: `panel-layouts` flag. `panelize-shell.ts` re-parents
+  `mountWcShell` so `WcShellRefs` stays valid. `setPanelVisible` adds an
+  unplaced panel but never duplicates a placed one; `sanitizeLayoutName`
+  guards the path. `docs/layouts.md`.
+- **Cloud cone config** (`ui/hosted-config-apply.ts`): `applyHostedAccounts`
+  removes only `localStorage['slicc_cloud_managed']` providers. `?connect=1`
+  is login-only (`ui/connect-surface.ts`), no kernel.
+- **Never monkeypatch a method on a get/set-asymmetric Proxy**
+  (`MONKEYPATCH_UNSAFE_FS`). Reassigning a gated method OOMs the kernel
+  worker.
+- **Adobe `X-Session-Id`**: every Adobe-proxy LLM call must attach it.
+  `scoop-context.ts` wires agent `streamFn` + compaction; new sites
+  (`streamSimple`/`completeSimple`) must attach it. `ensureSessionIdHeader`
+  is defense-in-depth, not the fix location.
+- **Claude Bedrock shims** (temperature rejected by Opus ≥ 4.7; adaptive
+  thinking for Opus/Sonnet ≥ 4.6): fix in
+  `packages/webapp/src/providers/claude-model-version.ts`, never at the
+  call site. Both: `docs/pitfalls.md`.
 
-## Key Conventions
+## Conventions
 
-- **Two type systems**: legacy `tools/` + pi-compatible `core/`; bridge via
+- Two type systems: legacy `tools/` + pi-compatible `core/`; bridge via
   `tool-adapter.ts`.
-- **Logging**: `createLogger('namespace')` (`base/logger.ts`).
-- **Extension detection**: `isExtensionRealm()` from `base/runtime-env.ts`.
-- **Tool-output images**: `<img:data:…>` markers are parsed in exactly one place
-  (`base/image-markers.ts`) so every consumer agrees on what is an image — the
-  bash tool exempts markers from its 40KB cap, `core/tool-adapter.ts` turns them
-  into image content blocks, `scoops/transcript-limits.ts` strips them, and
-  `ui/wc/wc-message-view.ts` renders them inline. Marker-shaped prose and
-  markers sliced mid-payload stay inert text everywhere.
-- **Dual-mode compatibility**: features must work in both standalone/CLI and
-  extension. The thin extension runs no dynamic code itself — realms, WASM, and
-  sprinkles/dips run in the hosted leader tab / kernel worker.
-- **Agent-avatar expressions** (`ui/wc/wc-live-callbacks.ts`,
-  `wc-live-composer.ts`, `wc-live-controller.ts`): the face's activity comes from
-  the descriptors (`toSwitcherScoops` → `awaiting` for the scoop whose turn just
-  ended, cleared on submit or any non-`ready` status). Transients are host calls
-  on `refs.switcher`: `scrutinize()` + `wake()` per composer `input`, `glower()`
-  on a `tool_result` with `isError`. Channels:
+- Logging: `createLogger('namespace')` (`base/logger.ts`).
+- Extension detection: `isExtensionRealm()` from `base/runtime-env.ts`
+  (re-export of `isChromeExtensionRealm`).
+- Dual-mode: CLI and extension. The thin extension runs no dynamic code —
+  realms, WASM, sprinkles/dips run in the hosted leader tab / kernel worker.
+- Model IDs: pi-ai aliases (`claude-opus-4-6`), not dated snapshots.
+- Per-cone model lives on the work-unit record (`modelFor` / `setUnitModel`).
+  Picker changes only the selected cone. Seed (`scoops/model-seed.ts`) waits
+  for an account. `docs/work-unit.md`.
+- Provider merge: pi-ai → `modelOverrides` → `getModelIds()`. Filter:
+  `packages/dev-tools/providers.build.json`.
+- Tool-output images: parse `<img:data:…>` only in `base/image-markers.ts`.
+- Agent-avatar host wiring: `docs/webapp-details.md`; channels:
   `docs/webcomponents-details.md`.
-- **Model IDs**: pi-ai aliases such as `claude-opus-4-6`, not dated snapshots.
-- **Per-cone model (#2310)**: the model lives on the work-unit record
-  (`RegisteredScoop.model = { provider, id }`, with `thinking` beside it), not in
-  page localStorage. Read it through `work-unit/record.ts`
-  (`modelFor` / `modelIdFor` / `modelProviderFor` / `thinkingFor`) and write it
-  through `setUnitModel` / `setUnitThinking` — `config.modelId` /
-  `config.thinkingLevel` are legacy creation input that `normalizeScoopRecord`
-  lifts onto the record. The picker changes ONLY the selected cone
-  (`Orchestrator.setScoopModel`); `refreshModels()` re-resolves each context
-  against its own record after an account change and retargets nothing. A new
-  cone inherits the selected cone's model, a scoop copies its creator's once.
-  The global `selected-model` survives only as the first-boot seed / migration
-  source (`scoops/model-seed.ts`), and only once the selected provider has an
-  account — seeding the built-in default would pin the primary cone to a
-  provider the user may never add. Details: `docs/work-unit.md`.
-- **Provider composition**: pi-ai auto-discovered + `src/providers/built-in/` +
-  `providers/`; merge order pi-ai → `modelOverrides` → `getModelIds()`. Build
-  filtering: `packages/dev-tools/providers.build.json`.
+- Prefer absolute VFS paths (`/workspace/...`, `/shared/...`).
+  `VirtualFS.create({ dbName, wipe })` for isolated tests. Mounts use
+  `FileSystemDirectoryHandle` — do not copy large trees into IndexedDB
+  unless you mean to. `fs.walk()` + `path-utils.ts`; `RestrictedFS` when
+  code must not see the whole VFS.
 
-## VFS API Patterns
+## Layouts
 
-- Prefer absolute VFS paths: `/workspace/...` and `/shared/...`.
-- `VirtualFS.create({ dbName, wipe })` is the entry point for isolated testable
-  instances.
-- Mounted directories bridge directly to `FileSystemDirectoryHandle`; do not copy
-  large trees into IndexedDB unless you mean to.
-- Use `fs.walk()` and `path-utils.ts` helpers instead of ad hoc path splitting.
-- `RestrictedFS` is the correct boundary when code should not see the whole VFS.
+See `docs/layouts.md`. Dock-tree persistence (`wireDockTreePersistence`) is
+the pre-panel default; `panel-layouts` on replaces the dock with
+`<slicc-layout>`.
 
-## Related Guides
+## Frozen Sessions
 
-- [`docs/webapp-details.md`](../../docs/webapp-details.md) — full subsystem detail
-- `packages/chrome-extension/CLAUDE.md`, `packages/node-server/CLAUDE.md` — float guides
-- `docs/architecture.md`, `docs/shell-reference.md`, `docs/mounts.md`, `docs/secrets.md`
-- `docs/kernel/process-model.md`, `docs/transcript-export.md`, `docs/approvals.md`
-- `docs/layouts.md`, `docs/pitfalls.md`
+See Frozen Sessions in `docs/webapp-details.md`. Export:
+`docs/transcript-export.md`.
+
+## Related
+
+`docs/architecture.md`, `docs/secrets.md`,
+[`packages/node-server/CLAUDE.md`](../node-server/CLAUDE.md).

--- a/packages/webcomponents/CLAUDE.md
+++ b/packages/webcomponents/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — `@slicc/webcomponents`
 
-Standalone library extracting `proto/StellarRubySwift.html` into reusable, individually testable web components. **Webapp wiring underway**: `?ui=wc` mounts the migration shell from `packages/webapp/src/ui/wc/` (live boots the kernel worker; `&ui-fixture` renders the design-time fixture). Webapp imports the barrel; `ui/press-button.ts` is a shim over `slicc-press-button`. Tested functionally (`@vitest/browser`) + visually (Storybook).
+Standalone library extracting `proto/StellarRubySwift.html` into reusable web components. **Webapp wiring underway**: `?ui=wc` mounts the migration shell from `packages/webapp/src/ui/wc/` (live boots the kernel worker; `&ui-fixture` renders the design-time fixture). Webapp imports the barrel; `ui/press-button.ts` is a shim over `slicc-press-button`. Internals: `docs/webcomponents-details.md`.
 
 ## Layout
 
@@ -19,64 +19,49 @@ tests/**/<name>.test.ts    co-located browser tests, mirroring src/ subsystem
 
 ## Panel system (`src/panel/`)
 
-**`SliccPanel` + `<slicc-layout>` are the layout API going forward**; `slicc-dock-tree` (below) is the shipping default until the `panel-layouts` flag flips. Model, locking, Cherry wire: `docs/layouts.md`; rationale: `docs/panel-system-design.md`; internals: `docs/webcomponents-details.md`.
+**`SliccPanel` + `<slicc-layout>` are the layout API going forward**; `slicc-dock-tree` is the shipping default until `panel-layouts` flips. Model/locking/Cherry: `docs/layouts.md`; rationale: `docs/panel-system-design.md`.
 
-Non-obvious invariants:
-
-- **`SliccPanel` is light-DOM**; shared stylesheet keys on a `data-slicc-panel` marker (must cover runtime-registered subclasses). **Panels default VISIBLE** (opposite of `<slicc-surface>`).
-- **DOM-free subpaths** `@slicc/webcomponents/panel/meta` and `@slicc/webcomponents/internal/html` are safe for webapp + kernel worker; barrel is not (needs `CSSStyleSheet`).
-- **Layout schema** — `docks[]` (fixed chrome pinned to an edge at exact size; fr-only zones can't say `"44px"`) + `zones` (five BorderLayout regions, `ZoneName`: top/left/center/right/bottom); variants REPLACE a section, `panels` overrides merge per id.
-- **Slot pitfall — overlays + pointer capture live on the HOST, not a slot**: slots rebuild every render; a captured element removed from the DOM loses capture per spec.
-- **`<slicc-layout>` parks unplaced panels offstage** (not destroyed), preserving scroll / live terminal session across variant switches. Re-resolves on HOST resize (not window), rAF-debounced. Rebuilds target a stable inner root (replacing the host's own children re-enters its `MutationObserver`).
-- Panel stories (`panel/*.stories.ts`) are required for PR screenshots to cover panels.
+- Light-DOM; stylesheet keys on `data-slicc-panel`. **Panels default VISIBLE** (opposite of `<slicc-surface>`).
+- DOM-free: `@slicc/webcomponents/panel/meta`, `@slicc/webcomponents/internal/html`. Barrel is not (needs `CSSStyleSheet`).
+- Schema: `docks[]` (exact-size chrome; fr-only zones can't say `"44px"`) + `zones` (top/left/center/right/bottom). Variants REPLACE a section; `panels` overrides merge per id.
+- Overlays + pointer capture on the HOST, not a slot (slots rebuild; capture is lost if the element is removed).
+- Unplaced panels park offstage (not destroyed). Re-resolve on HOST resize, rAF-debounced. Rebuild a stable inner root — replacing host children re-enters `MutationObserver`.
+- `panel/*.stories.ts` required for PR screenshots.
 
 ## Dock-tree (the shipping default)
 
-**`slicc-dock-tree` (`src/workbench/slicc-dock-tree.ts`) is what a default install boots** — superseded by the panel system above, not yet removed. Driven by the webapp's `layout` shell command (`docs/shell-reference.md`, `docs/layouts.md`). Light DOM: `<slicc-surface>` children match leaves by identity (`surface-id`/`data-s`/`id`) and are MOVED, not cloned; unmatched park offstage. `slicc-shell` hosts it beside the dock rail. Internals: `docs/webcomponents-details.md`.
+**`slicc-dock-tree` (`src/workbench/slicc-dock-tree.ts`)** is the default boot — superseded, not removed. Driven by webapp `layout` (`docs/shell-reference.md`, `docs/layouts.md`). Light DOM: `<slicc-surface>` children match leaves by identity (`surface-id`/`data-s`/`id`) and are MOVED, not cloned; unmatched park offstage. `slicc-shell` hosts it beside the dock rail.
 
-Non-obvious rules:
-
-- `CHAT_SURFACE_ID = 'chat'` is reserved; `setPinned([...])` marks leaves runtime-only (never serialized by `getTree()`) so pinned `removeSurface` is a no-op. `moveSurfaceToZone` bypasses the pinned guard (needed for chat).
-- `DockTreeSpec.locked`/`DockNode.locked` (inherited) block drag, resize, `removeSurface`; locked leaves render no move button. Cherry uses this — see `packages/webapp/CLAUDE.md`'s Layouts section.
-- `tilesMovable`/`tiles-movable` defaults off; flag-on replaces the dock-tree with `<slicc-layout>`. Full `DropRegion` contracts: `docs/layouts.md`.
-- Divider resize clamps to 2% of pair's combined weight (floor `setSurfaceSize` enforces). **Pointer capture is held on the host, not the divider**.
-- `dock-tree-change`/`dock-tree-resize` (composed + bubbling, `detail: { tree }`) never persist — see `packages/webapp/CLAUDE.md`'s `wireDockTreePersistence`.
-- Non-chat tiles carry the rounded workbench-pane chrome (`.dock-tree__tile--chrome`); the reserved chat leaf renders flat. `dock-tree-render` (`detail: { placed }`) fires after EVERY render — the change-silent `setTree` included — and is display-only: `slicc-shell` keys the chatpane's `narrow` re-theming (never its width) off it, and it must never feed persistence.
+- `CHAT_SURFACE_ID = 'chat'` reserved. `setPinned([...])` is runtime-only (never in `getTree()`); pinned `removeSurface` is a no-op. `moveSurfaceToZone` bypasses the pinned guard.
+- `DockTreeSpec.locked`/`DockNode.locked` (inherited) block drag, resize, `removeSurface`; no move button. Cherry: `packages/webapp/CLAUDE.md` Layouts.
+- `tilesMovable`/`tiles-movable` defaults off; flag-on swaps in `<slicc-layout>`. `DropRegion`: `docs/layouts.md`.
+- Resize floor: 2% of pair weight (`setSurfaceSize`). **Pointer capture on the host, not the divider**.
+- `dock-tree-change`/`dock-tree-resize` (`detail: { tree }`) never persist (`wireDockTreePersistence` in webapp). `dock-tree-render` (`detail: { placed }`) fires after EVERY render including silent `setTree` — display-only (chatpane `narrow` re-theme, never width); never persistence.
+- Non-chat tiles: `.dock-tree__tile--chrome`; chat leaf is flat.
 
 ## File tree + Quick Look (Pierre libraries)
 
-Two components delegate their rendering to [pierre.computer](https://pierre.computer) libraries. Both are wrapped by an adapter that keeps SLICC's existing public contract, so hosts did not change.
+Adapters keep SLICC's public contract ([pierre.computer](https://pierre.computer)). Rules: `docs/webcomponents-details.md`.
 
-- **`slicc-file-tree`** renders through **`@pierre/trees`** (trees.software). The `FileTreeItem` input shape, the `items` / `selected` accessors and the `file-select` / `file-preview` / `file-reference` / `file-download` / `file-overflow` / `dir-toggle` events are unchanged; `gitStatus` is new. Search, inline rename, drag-and-drop, virtualization and git lanes come from the library.
-- **`slicc-quick-look`** renders text through **`@pierre/diffs`** (diffs.com), shows a unified diff instead of the file when the caller supplies `baseContent`, and shows a rendered document when the caller supplies `rendered`. The header toggle exposes whichever of Preview / Source / Diff exist.
+- **`slicc-file-tree`** → `@pierre/trees`. `FileTreeItem`, `items`/`selected`, and `file-select`/`file-preview`/`file-reference`/`file-download`/`file-overflow`/`dir-toggle` unchanged; `gitStatus` is new.
+- **`slicc-quick-look`** → `@pierre/diffs`. Diff when `baseContent` is set; rendered document when `rendered` is set.
 
-Non-obvious rules:
+- Hierarchy from **PATHS**, not `children`. Strip leading `/` (`toTreePath`) or `['/a.ts']` is one blank row. Guard `selectFile()` with `#selecting`.
+- Quick Look **converts nothing**. Host sanitizes; `inline` via `createContextualFragment`; `sandbox` iframe with EMPTY `sandbox` (no `allow-scripts`, no `allow-same-origin`). `sandboxDocument` goes AFTER doctype (else quirks mode), BEFORE file markup. Rendered form opens first.
+- `@pierre/trees` `sideEffects` mispathed in `1.0.0-beta.6` — import `FileTree` from the package root. Both libs in `optimizeDeps.include` (`vitest.config.ts`). Tests assert contract, not markup (`composed: true`).
 
-- **The library builds hierarchy from PATHS, not from `children` nesting.** A `FileTreeItem` whose `id` is a bare name renders at the root no matter where it sits in the literal — ids must be full paths (which is what `buildVfsTreeItems` produces).
-- **Strip the leading slash before handing paths to `@pierre/trees`** (`toTreePath`). A leading `/` becomes an empty first segment: `['/a.ts', '/b.ts']` renders ONE blank row and no files (verified against `1.0.0-beta.6`). Events convert back, so absolute VFS paths stay absolute at the component boundary.
-- **`renderRowDecoration` returns text or an icon only** — no interactive elements. That is why the old per-row hover buttons (Preview / Reference / Download) now live in the row context menu, whose `onOpen` re-emits SLICC's `file-overflow` so `SliccOverflowMenu` still draws the menu.
-- **Selection echoes.** `selectFile()` reflects to the `selected` attribute, which tells the library to select the row, which calls back through `onSelectionChange` — guard with the `#selecting` flag or one click emits two `file-select` events.
-- **Quick Look renders text twice on purpose**: a synchronous `<pre>` first, then the `@pierre/diffs` view once that lazily-imported chunk arrives (~628 KB, so it must never block the overlay). If the import fails the `<pre>` stays — a degraded preview, not a broken one. A `#generation` counter drops an upgrade that resolves after the overlay moved to another file.
-- **Quick Look converts nothing.** A `rendered` payload arrives as HTML from the host: `inline` must already be sanitized (the webapp runs markdown through `message-renderer.ts`) and mounts via `createContextualFragment`, the same no-innerHTML path as `setBodyHtml`; `sandbox` mounts in an iframe with an EMPTY `sandbox` attribute (no `allow-scripts`, no `allow-same-origin`) and is the only treatment raw HTML ever gets. That document is wrapped in a base stylesheet (`sandboxDocument`) stating `color-scheme` + `Canvas`/`CanvasText`, because an iframe starts transparent with black text and knows nothing about the app's `data-theme` — an unstyled report rendered near-black on the dark panel. The base goes AFTER any doctype (before it means quirks mode) and BEFORE the file's own markup, so author rules outrank it. Keeping conversion in the host is what keeps a markdown parser out of this library.
-- **A rendered form opens FIRST, ahead of the diff.** Someone who clicked a `.md` name meant to read the file; a modified README is still a README. Files without a rendered form keep the old diff-first behavior. Views are rebuilt on switch, never kept mounted in parallel.
-- **`@pierre/trees` `sideEffects` is mispathed** in `1.0.0-beta.6` (`./dist/components/web-components.js` vs the real `dist/web-components.js`), so `import '@pierre/trees/web-components'` tree-shakes to nothing. Importing `FileTree` from the package root is unaffected — it pulls the element registration itself.
-- **Both libraries are in `optimizeDeps.include`** (`vitest.config.ts`). Discovering them mid-run makes Vite re-optimize and reload; a reload after a custom element is defined leaves the tag bound to the pre-reload class, and every tree/preview test then fails as if the component were broken.
-- **Tests assert the contract, not the markup** — accessible row names and events, since the DOM belongs to the library now. Synthetic events need `composed: true` to cross its shadow boundary.
+## Conventions
 
-## Conventions (every component MUST follow)
-
-- **Vanilla web components**, no framework. One element per file, `slicc-*` tag, `Slicc*` class. Register via `define(tag, ctor)` at module bottom (self-guards double-registration); add an `HTMLElementTagNameMap` augmentation.
-- **No `innerHTML` — build the DOM.** Use `internal/dom.ts` (`h()`, `frag()`, `append()`) + `replaceChildren()`; `h()` children / `textContent` is DOM-escaped. Render lucide glyphs with `iconEl(name, opts)`. Shadow components share one constructable stylesheet: `const SHEET = sheet(STYLE)` module-scope, `this.#root.adoptedStyleSheets = [SHEET]` in ctor (no `<style>` node). Light-DOM hosts keep document `<style>` injection but build the subtree with `h()`. Reference: `src/primitives/slicc-logo.ts`. **Enforced** by `lint:no-innerhtml` on `src/**/*.ts` (stories/tests exempt).
-- **NodeNext imports:** relative imports MUST carry `.js` (`./foo.js`), including stories/tests. tsc enforces this.
-- **Shadow vs light vs iframe** — shadow DOM for self-contained chips (pill, add-menu, tag, icon-button, logo); light DOM for layout/gesture/slotting hosts (nav, composer, shell, file-tree, press-button); `slicc-dip` stays **iframe-isolated** (webapp `dip.ts` trusted-source boundary — shadow DOM is NOT a security boundary).
-- **Slotted subtrees need a document sheet.** `::slotted()` matches only the slot's TOP-LEVEL children — never a `<pre>` / `<table>` nested inside a slotted wrapper. A shadow component that accepts rendered markdown (`slicc-lick-card`) therefore ships its containment rules (`white-space:pre-wrap`, `overflow-wrap:anywhere`, capped tables/images) as an idempotent document `<style>` selected by the host tag, alongside its `adoptedStyleSheets`. Without it an unwrapped `<pre>` bursts the card and scrolls the whole chat column sideways.
-- **Chat prose must contain unbroken runs.** `slicc-user-message`'s `.b` and `slicc-agent-message`'s `.body` carry `overflow-wrap: anywhere`. A pasted base64 payload is one token with no break opportunity, so a `max-width` cap does not contain it — the box stays capped and the TEXT spills out of it, scrolling the whole chat column. Fenced code opts back OUT (`pre code`): a code block is its own scroll container, and mangling source is worse than scrolling it. Test this with `scrollWidth` vs `clientWidth`; a box-width assertion passes either way and proves nothing. The webapp collapses recognized payloads into `<slicc-blob-chip>` on top of this (`packages/webapp/CLAUDE.md`), but the wrap rule is what has to hold for everything else.
-- **Theming:** reference prototype tokens (`var(--canvas)`, `--ink`, `--ctx`, `--rainbow`, `--ctl-h`, …); they inherit through shadow roots — don't re-declare. Light default; dark is `body.dark`/`.dark`/`[data-theme="dark"]`. Preserve `::part` hooks on lifted elements exactly.
-- **Animation loops must not force reflow — and must carry a frame budget.** A `requestAnimationFrame` loop must never read computed style/layout per frame; resolve CSS-derived values once and cache, invalidating on attribute + theme changes. Decorative/ambient loops render at `AMBIENT_FPS` (15) with an 800 ms full-rate burst on interaction, and stop entirely when the field is static (`src/freezer/frame-budget.ts` is the shared gate; `slicc-shader` is the reference consumer). Never schedule frames with timers — rAF is the only scheduler that pauses when the page hides. Pattern: `docs/webcomponents-details.md`.
-- **Public API:** export the class; expose attributes (reflected to properties), `::part` hooks, named slots, `CustomEvent`s (composed + bubbling) — never reach into another component's internals.
-- **Agent-avatar expression kit:** `<slicc-agent-avatar activity>` adds shape morph, brows, lids and gaze on top of the four original channels; every channel is a point, scalar or event (SwiftUI-mirrorable), grammar in `switcher/avatar-expression.ts`. No `activity` attribute = the legacy pointer-tracking face; static outranks every channel. **The brows paint outside the tile:** `.crop` owns the roundrect, `.brow-layer` re-applies the same zoom/pan above it, so hosts must not clip the avatar (~3 px of overhang at 26 px) and both layers must keep identical transforms. Table + constants: `docs/webcomponents-details.md`.
-- **Monitor meter markers:** a `MonitorVital` whose `ratio` summarises many contributors also takes `markers` (`MonitorMeterMarker[]`) — one dot per contributor along the same track, so the bar's aggregate does not hide the spread. `color` is a resolved CSS color the HOST supplies (the webapp passes `scoopColor()`, the switcher-chip hash, so a unit is one hue everywhere); dots paint lowest-first so the peak lands on top; the rail is one `role="img"` naming every reading, dots are `aria-hidden` with pointer-only `title`, and never focusable (the panel re-renders every 5s). Rules: `docs/webcomponents-details.md`.
-- **Composer push-to-talk:** `<slicc-composer ptt>` owns the hold-to-dictate gesture but not the audio stack — hosts inject a `ComposerSpeech` via `speech` (`composer/speech.ts`, exported DOM-free as `@slicc/webcomponents/composer/speech`). Dictated submits carry `detail.source === 'dictation'`. Contract, stages, whisper upgrade: `docs/webcomponents-details.md`.
+- **Vanilla web components.** One element per file, `slicc-*` tag, `Slicc*` class. Register via `define(tag, ctor)` at module bottom (self-guards double-registration); add an `HTMLElementTagNameMap` augmentation.
+- **No `innerHTML` — build the DOM.** `internal/dom.ts` (`h()`, `frag()`, `append()`) + `replaceChildren()`. Lucide: `iconEl(name, opts)`. Shadow: `const SHEET = sheet(STYLE)`, `this.#root.adoptedStyleSheets = [SHEET]` in ctor. Light-DOM hosts inject document `<style>` but still build with `h()`. **Enforced** by `lint:no-innerhtml` on `src/**/*.ts` (stories/tests exempt).
+- **NodeNext:** relative imports MUST carry `.js` (`./foo.js`), including stories/tests.
+- **Shadow vs light vs iframe** — shadow for chips (pill, add-menu, tag, icon-button, logo); light for layout/gesture/slotting hosts (nav, composer, shell, file-tree, press-button); `slicc-dip` stays **iframe-isolated** (webapp `dip.ts` trusted-source boundary — shadow DOM is NOT a security boundary).
+- **Slotted subtrees need a document sheet.** `::slotted()` matches only TOP-LEVEL children. Markdown hosts (`slicc-lick-card`) ship containment (`white-space:pre-wrap`, `overflow-wrap:anywhere`, capped tables/images) as an idempotent document `<style>` selected by the host tag.
+- **Chat prose must contain unbroken runs.** `slicc-user-message` `.b` and `slicc-agent-message` `.body` use `overflow-wrap: anywhere`. A pasted base64 payload is one token; `max-width` does not contain it. Fenced code opts OUT (`pre code`). Test `scrollWidth` vs `clientWidth` — a box-width assertion proves nothing.
+- **Theming:** prototype tokens (`var(--canvas)`, `--ink`, `--ctx`, `--rainbow`, `--ctl-h`, …) inherit through shadow roots — don't re-declare. Light default; dark is `body.dark`/`.dark`/`[data-theme="dark"]`. Preserve `::part` hooks exactly.
+- **Animation loops must not force reflow — and must carry a frame budget.** Never read computed style/layout per rAF frame. Ambient: `AMBIENT_FPS` (15) with 800 ms full-rate burst; stop when static (`src/freezer/frame-budget.ts`; `slicc-shader`). Never schedule with timers — only rAF pauses when the page hides.
+- **Public API:** class + reflected attributes, `::part`, named slots, composed+bubbling `CustomEvent`s — never another component's internals.
+- **Avatar / meters / PTT** — `docs/webcomponents-details.md`. `<slicc-agent-avatar activity>` is SwiftUI-mirrorable (`switcher/avatar-expression.ts`); no `activity` = legacy pointer face; static outranks every channel; brows paint outside the tile (~3 px at 26 px). Meter `markers`: HOST-resolved CSS `color` (`scoopColor()`); dots never focusable. `<slicc-composer ptt>` owns the gesture — inject `ComposerSpeech` via `speech` (`@slicc/webcomponents/composer/speech`); dictated submits `detail.source === 'dictation'`.
 
 ## Tests (`@vitest/browser`, real Chromium)
 
@@ -88,9 +73,9 @@ Non-obvious rules:
 - `src/<area>/<name>.stories.ts`. Cover the **state matrix**: variant/state × light/dark × screen size (theme + viewport toolbars). `render` returns a constructed element or HTML string.
 - Run: `npm run storybook -w @slicc/webcomponents`; build: `npm run build-storybook`.
 
-## Storybook PR screenshots (visual spot-check)
+## Storybook PR screenshots
 
-PRs touching `packages/webcomponents/**` get a sticky comment with light + dark screenshots of **affected** stories at 1280×900, driven by `.github/workflows/storybook-screenshots.yml` (capture + resolver under `packages/dev-tools/tools/`). PNGs upload to R2 bucket `slicc-pr-screenshots`; fork PRs fall back to a workflow artifact. Heuristic, manifest v1, R2 dedupe/retry, secrets/vars: `docs/webcomponents-details.md`.
+PRs touching `packages/webcomponents/**` get light+dark screenshots of **affected** stories at 1280×900 (`.github/workflows/storybook-screenshots.yml`). PNGs → R2 `slicc-pr-screenshots`; forks fall back to a workflow artifact. Heuristic, manifest v1, R2, secrets: `docs/webcomponents-details.md`.
 
 **Running it locally** (flags are `--flag=value` only; manifest is always `<out>/manifest.json`; empty diff → empty `shots[]` + a "no affected stories" comment):
 


### PR DESCRIPTION
## Summary

Rewrite the eight tracked `CLAUDE.md` guides that were at or above 10,000 characters down to at most 9,500. Overflow moved into existing `docs/` files rather than truncated.

| Guide | Before | After |
| --- | --- | --- |
| `packages/webapp/CLAUDE.md` | 19,998 | 9,317 |
| `packages/swift-launcher/CLAUDE.md` | 19,533 | 9,471 |
| `packages/ios-app/CLAUDE.md` | 17,332 | 9,471 |
| `packages/webcomponents/CLAUDE.md` | 16,364 | 9,482 |
| `packages/dev-tools/CLAUDE.md` | 13,438 | 9,488 |
| `packages/slicc-cli/CLAUDE.md` | 11,687 | 9,184 |
| `packages/cloudflare-worker/CLAUDE.md` | 11,040 | 9,160 |
| `packages/swift-server/CLAUDE.md` | 10,199 | 9,448 |

## Why

The weekly compactor's Saturday run and a live `workflow_dispatch` on #2676 both asked Claude to compact these guides; both times the files came back unchanged, so `--check` failed and (after #2676) `--progress` correctly refused a no-shrinkage PR. This PR is the compaction the cron is supposed to produce.

Stacked with #2676 (the recover-path workflow change). Merge either first; they do not depend on each other. #2676 still edits `docs/dev-tools-details.md` in a different section.

## Approach / Implementation notes

- Commands, architecture, safety rules, and gotchas stay in the package files.
- Long-form that did not fit moved into existing `docs/*-details.md` with a one-line link behind.
- No size-gate constants changed. The 20,000-char `lint:docs` gate is untouched; this is the stricter 10,000 → 9,500 compactor policy.

## Cross-cutting impact

Docs only. No runtime, float, or CI workflow change (that is #2676).

## Test plan

- [x] `npm run lint:docs` — sizes, AGENTS.md symlinks, `check-doc-refs`
- [x] `WORKLIST=<eight paths> node packages/dev-tools/claude-md-compactor/measure-claude-guides.mjs --check` — all 24 guides below 10,000; the eight rewritten guides at or below 9,500
- [x] `npx prettier --write` on the changed markdown (CI `prettier --check`)

## Verification

```
npm run lint:docs
node packages/dev-tools/claude-md-compactor/measure-claude-guides.mjs --check
```