### PR TITLE
refactor(cloudflare-worker): split SessionTrayDurableObject god class

### DIFF
--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -9,8 +9,19 @@ Deep reference: [`docs/cloudflare-worker-details.md`](../../docs/cloudflare-work
 ## Main Files
 
 - `src/index.ts` — entry + public HTTP routing
-- `src/session-tray.ts` — `SessionTrayDurableObject`: controller WS (leader), follower
-  WebRTC signaling, preview bridge WS
+- `src/session-tray.ts` — `SessionTrayDurableObject`: the per-tray coordinator. Owns
+  the tray record, leader election + controller WS, the join surface, route dispatch.
+  Every other concern is a collaborator behind a `*Deps` seam (issue #2674), so it is
+  unit-testable without a DO harness:
+  - `src/session-tray-bootstrap.ts` — `BootstrapCoordinator`: follower WebRTC
+    signaling state machine (offer/answer/ICE, event log, retry, pruning)
+  - `src/session-tray-bridge.ts` — `BridgeRelay`: preview-bridge CDP relay,
+    `window.slicc.emit()` attribution, per-conn emit rate limit
+  - `src/session-tray-preview.ts` — preview mint/resolve/revoke + response assembly
+  - `src/session-tray-biscotto.ts` — guest seat lifecycle + `/internal/biscotto/*`
+  - `src/session-tray-webhook.ts` — `WebhookRelay`: forwarding + #2524 receipts
+  - `src/session-tray-push.ts` — `PushCoordinator`: APNs device registry + fan-out
+  - `src/session-tray-requests.ts` — pure request parsing / wire-shape guards
 - `src/turn-credentials.ts` — Cloudflare TURN credential fetcher
 - `src/shared.ts` — capability tokens; `reclaimMsForTray`;
   `TRAY_RECLAIM_TTL_MS`/`HOSTED_TRAY_RECLAIM_TTL_MS`
@@ -82,8 +93,8 @@ keyed by `connId`, replays `bridge.connected` on leader (re)connect, hibernates 
 returns `{ trust: 'full' }` for the tray join token, `{ trust: 'biscotto' }` for
 a live seat, and `null` for anything else (including revoked/expired seats,
 which are compared before being filtered so their existence does not leak by
-timing). Mint/revoke/list live in `src/session-tray-biscotto.ts` and are gated on
-the **controller** token — a seat is never an issuing authority.
+timing). Mint/revoke/list (and the `/internal/biscotto/*` dispatcher) live in
+`src/session-tray-biscotto.ts` and are gated on the **controller** token — a seat is never an issuing authority.
 
 **Trust travels on the controller socket, never on the peer's `hello`.** The DO
 stamps `trust` + `biscotto` onto `follower.join_requested`, which only the leader

--- a/packages/cloudflare-worker/src/session-tray-biscotto.ts
+++ b/packages/cloudflare-worker/src/session-tray-biscotto.ts
@@ -20,6 +20,7 @@ import {
   type BiscottoGates,
   type BiscottoRecord,
   createCapabilityToken,
+  jsonResponse,
   MAX_BISCOTTI_PER_TRAY,
   normalizeBiscottoGate,
   type TrayRecord,
@@ -243,4 +244,87 @@ function summarize(record: BiscottoRecord, now: number): BiscottoSummary {
     gates: record.gates,
     active: isBiscottoActive(record, now),
   };
+}
+
+/**
+ * `/internal/biscotto/{mint,stop,list}` — the DO half of `biscotto-routes.ts`,
+ * dispatched here rather than in `session-tray.ts` so the durable object keeps
+ * one `handleInternalRoute` line per concern (mirrors `dispatchPreviewRoute`).
+ *
+ * Every branch reads the controller token out of the body and hands it to the
+ * lifecycle helper, which is what actually authenticates it. A thrown
+ * {@link BiscottoRouteError} carries the status; anything else is a 500 with no
+ * detail, so an internal failure never describes the tray to a caller that did
+ * not authenticate.
+ *
+ * `announceRevocation` is the caller's leader socket: revoking a seat only
+ * tombstones the token, and a guest that is already connected holds a data
+ * channel this module cannot reach.
+ */
+export async function dispatchBiscottoRoute(
+  url: URL,
+  request: Request,
+  deps: BiscottoDeps,
+  announceRevocation: (biscottoId: string) => boolean
+): Promise<Response> {
+  if (request.method !== 'POST') {
+    return jsonResponse({ error: 'method not allowed' }, 405);
+  }
+  let body: {
+    controllerToken?: string;
+    label?: string;
+    id?: string;
+    ttlMs?: number;
+    gates?: Partial<BiscottoGates>;
+    workerBaseUrl?: string;
+  };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return jsonResponse({ error: 'invalid body' }, 400);
+  }
+  const controllerToken = typeof body.controllerToken === 'string' ? body.controllerToken : '';
+  try {
+    switch (url.pathname) {
+      case '/internal/biscotto/mint':
+        return jsonResponse(
+          await mintBiscotto(
+            {
+              controllerToken,
+              label: body.label ?? '',
+              ttlMs: body.ttlMs,
+              gates: body.gates,
+              workerBaseUrl: body.workerBaseUrl ?? '',
+            },
+            deps
+          )
+        );
+      case '/internal/biscotto/stop': {
+        const revoked = await revokeBiscotto({ controllerToken, id: body.id ?? '' }, deps);
+        // Tombstoning the token only stops future joins. A live guest holds a
+        // direct data channel to the leader that this DO cannot reach, so the
+        // eviction has to be delegated to the one process that can — and if
+        // that message did not land, the seat is revoked for FUTURE joins
+        // while whoever is already connected keeps their channel. Reporting
+        // plain success there would tell an owner the guest is out when they
+        // are not, so the outcome says which happened.
+        const evicted = announceRevocation(revoked.id);
+        if (!evicted) {
+          console.warn('[tray] biscotto revoked but the leader could not be told', {
+            biscottoId: revoked.id,
+          });
+        }
+        return jsonResponse({ ...revoked, evicted });
+      }
+      case '/internal/biscotto/list':
+        return jsonResponse({ biscotti: await listBiscotti({ controllerToken }, deps) });
+      default:
+        return jsonResponse({ error: 'not found' }, 404);
+    }
+  } catch (error) {
+    if (error instanceof BiscottoRouteError) {
+      return jsonResponse({ error: error.message }, error.status);
+    }
+    return jsonResponse({ error: 'biscotto request failed' }, 500);
+  }
 }

--- a/packages/cloudflare-worker/src/session-tray-bootstrap.ts
+++ b/packages/cloudflare-worker/src/session-tray-bootstrap.ts
@@ -1,0 +1,592 @@
+/**
+ * Follower WebRTC bootstrap — the signaling state machine of the tray hub.
+ *
+ * A follower cannot talk to the leader directly until a peer connection
+ * exists, so the DO brokers one: the follower attaches, the leader is told to
+ * make an offer, and offer / answer / ICE candidates are exchanged through
+ * this coordinator. Followers poll over HTTP (`action: 'poll'`) with a cursor
+ * into a per-bootstrap event log; the leader pushes over its control socket.
+ *
+ * Extracted from `SessionTrayDurableObject` behind a {@link BootstrapDeps}
+ * seam (issue #2674), mirroring `session-tray-preview.ts` and
+ * `session-tray-biscotto.ts`. Everything the coordinator needs about the tray
+ * arrives through `deps`; it never reaches into the DO.
+ *
+ * State lives on the tray record (`tray.bootstraps`), not on this object, so it
+ * survives DO hibernation. The coordinator is therefore free to be re-created
+ * per instance.
+ */
+
+import {
+  type FollowerBiscottoIdentity,
+  type FollowerBootstrapRequest,
+  type FollowerBootstrapResponse,
+  type FollowerTrust,
+  type LeaderToWorkerControlMessage,
+  TRAY_BOOTSTRAP_MAX_RETRIES,
+  TRAY_BOOTSTRAP_RETRY_AFTER_MS,
+  TRAY_BOOTSTRAP_TIMEOUT_MS,
+  type TrayBootstrapEvent,
+  type TrayBootstrapFailure,
+  type TrayBootstrapStatus,
+  type TrayIceCandidate,
+  type TrayLeaderSummary,
+  type TraySessionDescription,
+  type TurnIceServer,
+  type WorkerToLeaderControlMessage,
+} from '@slicc/shared-ts';
+import { isIceCandidate, isSessionDescription } from './session-tray-requests.js';
+import {
+  jsonResponse,
+  normalizeBiscottoGate,
+  type TrayBootstrapRecord,
+  type TrayRecord,
+  type TrayWebSocketLike,
+} from './shared.js';
+
+// Grace period after a bootstrap reaches a terminal state before it is pruned.
+// Gives the follower time to poll the final failure before the record vanishes.
+const BOOTSTRAP_TERMINAL_GRACE_MS = 5 * 60 * 1000;
+// Maximum bootstrap events kept per record. The follower polls via a cursor so
+// only recent events matter; old SDP payloads (kilobytes each) are dropped.
+const MAX_BOOTSTRAP_EVENTS = 20;
+
+type TrayBootstrapEventInput =
+  | { type: 'bootstrap.offer'; offer: TraySessionDescription }
+  | { type: 'bootstrap.ice_candidate'; candidate: TrayIceCandidate }
+  | { type: 'bootstrap.failed'; failure: TrayBootstrapFailure };
+
+/** The slice of the durable object this coordinator needs. */
+export interface BootstrapDeps {
+  requireTray(): TrayRecord;
+  persistTray(): Promise<void>;
+  now(): number;
+  isoNow(): string;
+  hasLiveLeader(): boolean;
+  sendToLeader(message: WorkerToLeaderControlMessage): boolean;
+  getIceServers(): Promise<TurnIceServer[] | undefined>;
+  leaderSummary(): Promise<TrayLeaderSummary | null>;
+}
+
+function bootstrapNotFound(): Response {
+  return jsonResponse({ error: 'Bootstrap not found', code: 'BOOTSTRAP_NOT_FOUND' }, 404);
+}
+
+export class BootstrapCoordinator {
+  constructor(private readonly deps: BootstrapDeps) {}
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Follower-facing HTTP surface (`POST /join/:token` with an `action`)
+  // ──────────────────────────────────────────────────────────────────────
+
+  handleRequest(request: FollowerBootstrapRequest): Promise<Response> {
+    switch (request.action) {
+      case 'poll':
+        return this.handlePoll(request.controllerId, request.bootstrapId, request.cursor ?? 0);
+      case 'answer':
+        return this.handleAnswer(request.controllerId, request.bootstrapId, request.answer);
+      case 'ice-candidate':
+        return this.handleIceCandidate(
+          request.controllerId,
+          request.bootstrapId,
+          request.candidate
+        );
+      case 'retry':
+        return this.handleRetry(request.controllerId, request.bootstrapId, request.runtime);
+      default:
+        return Promise.resolve(
+          jsonResponse(
+            { error: 'Invalid bootstrap request', code: 'INVALID_BOOTSTRAP_REQUEST' },
+            400
+          )
+        );
+    }
+  }
+
+  private async handlePoll(
+    controllerId: string | undefined,
+    bootstrapId: string | undefined,
+    cursor: number
+  ): Promise<Response> {
+    const bootstrap = this.find(controllerId, bootstrapId);
+    if (!bootstrap) return bootstrapNotFound();
+
+    this.refreshState(bootstrap);
+    await this.deps.persistTray();
+    return await this.buildResponse(bootstrap, eventsAfter(bootstrap, cursor));
+  }
+
+  private async handleAnswer(
+    controllerId: string | undefined,
+    bootstrapId: string | undefined,
+    answer: TraySessionDescription | undefined
+  ): Promise<Response> {
+    if (!isSessionDescription(answer, 'answer')) {
+      return jsonResponse(
+        { error: 'A valid bootstrap answer is required', code: 'INVALID_BOOTSTRAP_REQUEST' },
+        400
+      );
+    }
+    return this.relayToLeader(controllerId, bootstrapId, (bootstrap) => ({
+      type: 'bootstrap.answer',
+      trayId: this.deps.requireTray().trayId,
+      controllerId: bootstrap.controllerId,
+      bootstrapId: bootstrap.bootstrapId,
+      answer,
+    }));
+  }
+
+  private async handleIceCandidate(
+    controllerId: string | undefined,
+    bootstrapId: string | undefined,
+    candidate: TrayIceCandidate | undefined
+  ): Promise<Response> {
+    if (!isIceCandidate(candidate)) {
+      return jsonResponse(
+        { error: 'A valid ICE candidate is required', code: 'INVALID_BOOTSTRAP_REQUEST' },
+        400
+      );
+    }
+    return this.relayToLeader(controllerId, bootstrapId, (bootstrap) => ({
+      type: 'bootstrap.ice_candidate',
+      trayId: this.deps.requireTray().trayId,
+      controllerId: bootstrap.controllerId,
+      bootstrapId: bootstrap.bootstrapId,
+      candidate,
+    }));
+  }
+
+  /**
+   * Shared body of `answer` and `ice-candidate`: resolve the bootstrap, refuse
+   * once it has failed, hand the signal to the leader, and fail the bootstrap
+   * (retryably, if attempts remain) when the control channel is gone. The only
+   * difference is the message built for the leader and — for `answer` — the
+   * transition to `connected`, which the caller expresses by the message type.
+   */
+  private async relayToLeader(
+    controllerId: string | undefined,
+    bootstrapId: string | undefined,
+    build: (bootstrap: TrayBootstrapRecord) => WorkerToLeaderControlMessage
+  ): Promise<Response> {
+    const bootstrap = this.find(controllerId, bootstrapId);
+    if (!bootstrap) return bootstrapNotFound();
+
+    this.refreshState(bootstrap);
+    if (bootstrap.state === 'failed') {
+      await this.deps.persistTray();
+      return await this.buildResponse(bootstrap, [], 409);
+    }
+
+    const message = build(bootstrap);
+    if (!this.deps.sendToLeader(message)) {
+      const retryable = this.canRetry(bootstrap);
+      this.fail(bootstrap, {
+        code: 'LEADER_NOT_CONNECTED',
+        message: 'Leader control channel is not connected',
+        retryable,
+        retryAfterMs: retryable ? TRAY_BOOTSTRAP_RETRY_AFTER_MS : null,
+      });
+      await this.deps.persistTray();
+      return await this.buildResponse(bootstrap, [], 409);
+    }
+
+    // An answer completes the handshake; a trickled candidate only refreshes it.
+    if (message.type === 'bootstrap.answer') {
+      bootstrap.state = 'connected';
+      bootstrap.failure = null;
+    }
+    bootstrap.updatedAt = this.deps.isoNow();
+    await this.deps.persistTray();
+    return await this.buildResponse(bootstrap, []);
+  }
+
+  private async handleRetry(
+    controllerId: string | undefined,
+    bootstrapId: string | undefined,
+    runtime: string | undefined
+  ): Promise<Response> {
+    const bootstrap = this.find(controllerId, bootstrapId);
+    if (!bootstrap) return bootstrapNotFound();
+
+    this.refreshState(bootstrap);
+    if (
+      bootstrap.state !== 'failed' ||
+      !bootstrap.failure?.retryable ||
+      !this.canRetry(bootstrap) ||
+      !this.deps.hasLiveLeader()
+    ) {
+      await this.deps.persistTray();
+      return await this.buildResponse(bootstrap, [], 409);
+    }
+
+    this.pruneTerminal();
+    const retried = this.create(
+      bootstrap.controllerId,
+      runtime ?? bootstrap.runtime,
+      bootstrap.retryCount + 1,
+      bootstrap.maxRetries,
+      // Carry the seat forward: a retried bootstrap that dropped `biscottoId`
+      // would be announced to the leader as a full-trust follower.
+      bootstrap.biscottoId
+    );
+    this.deps.requireTray().bootstraps[retried.bootstrapId] = retried;
+    this.notifyLeaderJoinRequested(retried, await this.deps.getIceServers());
+    await this.deps.persistTray();
+    return await this.buildResponse(retried, []);
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Leader-facing control-socket surface
+  // ──────────────────────────────────────────────────────────────────────
+
+  /**
+   * Resolve a bootstrap named by a leader control message, telling the leader
+   * when it does not exist so it stops signaling into a record we dropped.
+   */
+  private findForLeader(
+    socket: TrayWebSocketLike,
+    controllerId: string,
+    bootstrapId: string
+  ): TrayBootstrapRecord | null {
+    const bootstrap = this.find(controllerId, bootstrapId);
+    if (!bootstrap) {
+      socket.send(JSON.stringify({ type: 'error', code: 'BOOTSTRAP_NOT_FOUND', bootstrapId }));
+      return null;
+    }
+    this.refreshState(bootstrap);
+    return bootstrap;
+  }
+
+  onLeaderOffer(
+    socket: TrayWebSocketLike,
+    message: LeaderToWorkerControlMessage & { type: 'bootstrap.offer' }
+  ): void {
+    const bootstrap = this.findForLeader(socket, message.controllerId, message.bootstrapId);
+    if (!bootstrap || bootstrap.state === 'failed') return;
+    this.appendEvent(bootstrap, { type: 'bootstrap.offer', offer: message.offer });
+    bootstrap.state = 'offered';
+    bootstrap.failure = null;
+  }
+
+  onLeaderIceCandidate(
+    socket: TrayWebSocketLike,
+    message: LeaderToWorkerControlMessage & { type: 'bootstrap.ice_candidate' }
+  ): void {
+    const bootstrap = this.findForLeader(socket, message.controllerId, message.bootstrapId);
+    if (!bootstrap || bootstrap.state === 'failed') return;
+    this.appendEvent(bootstrap, {
+      type: 'bootstrap.ice_candidate',
+      candidate: message.candidate,
+    });
+  }
+
+  onLeaderFailed(
+    socket: TrayWebSocketLike,
+    message: LeaderToWorkerControlMessage & { type: 'bootstrap.failed' }
+  ): void {
+    const bootstrap = this.find(message.controllerId, message.bootstrapId);
+    if (!bootstrap) {
+      socket.send(
+        JSON.stringify({
+          type: 'error',
+          code: 'BOOTSTRAP_NOT_FOUND',
+          bootstrapId: message.bootstrapId,
+        })
+      );
+      return;
+    }
+    this.fail(bootstrap, {
+      code: message.code,
+      message: message.message,
+      retryable: message.retryable ?? this.canRetry(bootstrap),
+      retryAfterMs:
+        message.retryable === false
+          ? null
+          : (message.retryAfterMs ?? TRAY_BOOTSTRAP_RETRY_AFTER_MS),
+    });
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Record lifecycle
+  // ──────────────────────────────────────────────────────────────────────
+
+  /**
+   * The bootstrap a freshly-attached follower should use, minting one (and
+   * asking the leader for an offer) when there is nothing reusable.
+   */
+  async ensure(
+    controllerId: string,
+    runtime: string | undefined,
+    biscottoId?: string
+  ): Promise<TrayBootstrapRecord> {
+    this.pruneTerminal();
+    const existing = this.find(controllerId);
+    // Reuse ONLY within the same capability. `controllerId` is client-supplied
+    // and a non-terminal bootstrap outlives its controller record (the DO
+    // prunes stale controllers, `pruneTerminal` only reaps terminal
+    // bootstraps), so a guest presenting a pruned full follower's controllerId
+    // would otherwise adopt that follower's `biscottoId: undefined` bootstrap
+    // and be announced as `trust: 'full'` — straight past the allowlist.
+    // Mismatched capability ⇒ mint a fresh one.
+    if (existing && existing.biscottoId === biscottoId) {
+      this.refreshState(existing);
+      return existing;
+    }
+
+    const bootstrap = this.create(controllerId, runtime, 0, TRAY_BOOTSTRAP_MAX_RETRIES, biscottoId);
+    this.deps.requireTray().bootstraps[bootstrap.bootstrapId] = bootstrap;
+    this.notifyLeaderJoinRequested(bootstrap, await this.deps.getIceServers());
+    return bootstrap;
+  }
+
+  private create(
+    controllerId: string,
+    runtime: string | undefined,
+    retryCount = 0,
+    maxRetries = TRAY_BOOTSTRAP_MAX_RETRIES,
+    biscottoId?: string
+  ): TrayBootstrapRecord {
+    const createdAt = this.deps.isoNow();
+    return {
+      controllerId,
+      bootstrapId: crypto.randomUUID(),
+      runtime,
+      attempt: retryCount + 1,
+      retryCount,
+      maxRetries,
+      createdAt,
+      updatedAt: createdAt,
+      expiresAt: new Date(this.deps.now() + TRAY_BOOTSTRAP_TIMEOUT_MS).toISOString(),
+      state: 'pending',
+      failure: null,
+      events: [],
+      nextSequence: 1,
+      biscottoId,
+    };
+  }
+
+  private notifyLeaderJoinRequested(
+    bootstrap: TrayBootstrapRecord,
+    iceServers?: TurnIceServer[]
+  ): void {
+    const message: WorkerToLeaderControlMessage = {
+      type: 'follower.join_requested',
+      trayId: this.deps.requireTray().trayId,
+      controllerId: bootstrap.controllerId,
+      runtime: bootstrap.runtime,
+      bootstrapId: bootstrap.bootstrapId,
+      attempt: bootstrap.attempt,
+      expiresAt: bootstrap.expiresAt,
+      // The leader's controller socket is the ONLY authenticated channel that
+      // can tell it what a peer is; the peer's own `hello` cannot be believed.
+      ...this.biscottoAnnouncement(bootstrap),
+    };
+    if (iceServers) {
+      (message as { iceServers?: TurnIceServer[] }).iceServers = iceServers;
+    }
+    this.deps.sendToLeader(message);
+  }
+
+  /**
+   * Trust fields for a `follower.join_requested`. A bootstrap with no
+   * `biscottoId` is a full follower and gets `trust: 'full'` stated
+   * explicitly — silence would be ambiguous with an older hub.
+   *
+   * A seat that was revoked between attach and announcement resolves to no
+   * record; that announces as a biscotto with its stored id and empty label
+   * rather than falling back to `full`, because failing toward MORE trust here
+   * would turn a revocation race into a privilege escalation.
+   */
+  private biscottoAnnouncement(bootstrap: TrayBootstrapRecord): {
+    trust: FollowerTrust;
+    biscotto?: FollowerBiscottoIdentity;
+  } {
+    if (!bootstrap.biscottoId) return { trust: 'full' };
+    const record = (this.deps.requireTray().biscotti ?? []).find(
+      (entry) => entry.id === bootstrap.biscottoId
+    );
+    return {
+      trust: 'biscotto',
+      biscotto: {
+        id: bootstrap.biscottoId,
+        label: record?.label ?? '',
+        expiresAt: record?.expiresAt,
+        gates: {
+          message: normalizeBiscottoGate(record?.gates.message),
+          tool: normalizeBiscottoGate(record?.gates.tool),
+        },
+      },
+    };
+  }
+
+  private find(controllerId?: string, bootstrapId?: string): TrayBootstrapRecord | null {
+    const tray = this.deps.requireTray();
+
+    if (bootstrapId) {
+      const bootstrap = tray.bootstraps[bootstrapId] ?? null;
+      if (!bootstrap) {
+        return null;
+      }
+      return controllerId && bootstrap.controllerId !== controllerId ? null : bootstrap;
+    }
+
+    if (!controllerId) {
+      return null;
+    }
+
+    return (
+      Object.values(tray.bootstraps)
+        .filter((bootstrap) => bootstrap.controllerId === controllerId)
+        .sort(
+          (left, right) =>
+            right.attempt - left.attempt || Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
+        )[0] ?? null
+    );
+  }
+
+  /**
+   * Move a still-open bootstrap to `failed` when the world moved on under it:
+   * the leader's control channel dropped, or the attempt outlived its window.
+   */
+  private refreshState(bootstrap: TrayBootstrapRecord): void {
+    if (bootstrap.state === 'failed' || bootstrap.state === 'connected') {
+      return;
+    }
+
+    const retryable = this.canRetry(bootstrap);
+    const retryAfterMs = retryable ? TRAY_BOOTSTRAP_RETRY_AFTER_MS : null;
+
+    if (!this.deps.hasLiveLeader()) {
+      this.fail(bootstrap, {
+        code: 'LEADER_NOT_CONNECTED',
+        message: 'Leader control channel disconnected before bootstrap completed',
+        retryable,
+        retryAfterMs,
+      });
+      return;
+    }
+
+    if (this.deps.now() > Date.parse(bootstrap.expiresAt)) {
+      this.fail(bootstrap, {
+        code: 'BOOTSTRAP_TIMEOUT',
+        message: `Bootstrap attempt timed out after ${TRAY_BOOTSTRAP_TIMEOUT_MS}ms`,
+        retryable,
+        retryAfterMs,
+      });
+    }
+  }
+
+  private fail(
+    bootstrap: TrayBootstrapRecord,
+    failure: Omit<TrayBootstrapFailure, 'failedAt'> & { failedAt?: string }
+  ): void {
+    if (bootstrap.state === 'failed') {
+      return;
+    }
+
+    const failedAt = failure.failedAt ?? this.deps.isoNow();
+    const normalizedFailure: TrayBootstrapFailure = { ...failure, failedAt };
+    bootstrap.state = 'failed';
+    bootstrap.failure = normalizedFailure;
+    bootstrap.expiresAt = failedAt;
+    this.appendEvent(bootstrap, { type: 'bootstrap.failed', failure: normalizedFailure }, failedAt);
+  }
+
+  private appendEvent(
+    bootstrap: TrayBootstrapRecord,
+    event: TrayBootstrapEventInput,
+    sentAt = this.deps.isoNow()
+  ): void {
+    const nextEvent = {
+      ...event,
+      sequence: bootstrap.nextSequence,
+      sentAt,
+    } as TrayBootstrapEvent;
+    bootstrap.nextSequence += 1;
+    bootstrap.updatedAt = sentAt;
+    bootstrap.events.push(nextEvent);
+    // Cap events to avoid unbounded growth from SDP payloads (KB each).
+    // The follower polls via cursor so only the tail matters, but the offer
+    // is only carried in the events stream — preserve it at the head so a
+    // burst of ICE candidates can't drop it and force a timeout+retry.
+    if (bootstrap.events.length > MAX_BOOTSTRAP_EVENTS) {
+      const offer = bootstrap.events.find((e) => e.type === 'bootstrap.offer');
+      const tailSize = offer ? MAX_BOOTSTRAP_EVENTS - 1 : MAX_BOOTSTRAP_EVENTS;
+      const tail = bootstrap.events.slice(-tailSize);
+      bootstrap.events = offer && !tail.includes(offer) ? [offer, ...tail] : tail;
+    }
+  }
+
+  private canRetry(bootstrap: TrayBootstrapRecord): boolean {
+    return bootstrap.retryCount < bootstrap.maxRetries;
+  }
+
+  /**
+   * Remove bootstrap records in a terminal state whose grace window has
+   * elapsed. Called opportunistically when bootstraps are mutated.
+   */
+  private pruneTerminal(): void {
+    const tray = this.deps.requireTray();
+    const nowMs = this.deps.now();
+    for (const [id, bootstrap] of Object.entries(tray.bootstraps)) {
+      const isTerminal =
+        bootstrap.state === 'connected' ||
+        (bootstrap.state === 'failed' && !this.canRetry(bootstrap));
+      if (!isTerminal) continue;
+      const deadlineMs = Date.parse(bootstrap.expiresAt) + BOOTSTRAP_TERMINAL_GRACE_MS;
+      if (nowMs > deadlineMs) {
+        delete tray.bootstraps[id];
+      }
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Response shaping
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** The follower-facing view of a bootstrap. Also embedded in the attach response. */
+  buildStatus(bootstrap: TrayBootstrapRecord): TrayBootstrapStatus {
+    return {
+      controllerId: bootstrap.controllerId,
+      bootstrapId: bootstrap.bootstrapId,
+      attempt: bootstrap.attempt,
+      state: bootstrap.state,
+      expiresAt: bootstrap.expiresAt,
+      cursor: Math.max(0, bootstrap.nextSequence - 1),
+      maxRetries: bootstrap.maxRetries,
+      retriesRemaining: Math.max(0, bootstrap.maxRetries - bootstrap.retryCount),
+      retryAfterMs: bootstrap.failure?.retryable
+        ? (bootstrap.failure.retryAfterMs ?? TRAY_BOOTSTRAP_RETRY_AFTER_MS)
+        : null,
+      failure: bootstrap.failure,
+    };
+  }
+
+  private async buildResponse(
+    bootstrap: TrayBootstrapRecord,
+    events: TrayBootstrapEvent[],
+    status = 200
+  ): Promise<Response> {
+    const tray = this.deps.requireTray();
+    const iceServers = await this.deps.getIceServers();
+    const payload: FollowerBootstrapResponse = {
+      trayId: tray.trayId,
+      controllerId: bootstrap.controllerId,
+      role: 'follower',
+      leader: await this.deps.leaderSummary(),
+      participantCount: Object.keys(tray.controllers).length,
+      bootstrap: this.buildStatus(bootstrap),
+      events,
+    };
+    if (iceServers) {
+      payload.iceServers = iceServers;
+    }
+    return jsonResponse(payload, status);
+  }
+}
+
+/** Events strictly after `cursor`. A non-finite or negative cursor replays everything. */
+function eventsAfter(bootstrap: TrayBootstrapRecord, cursor: number): TrayBootstrapEvent[] {
+  const normalizedCursor = Number.isFinite(cursor) ? Math.max(0, Math.trunc(cursor)) : 0;
+  return bootstrap.events.filter((event) => event.sequence > normalizedCursor);
+}

--- a/packages/cloudflare-worker/src/session-tray-bridge.ts
+++ b/packages/cloudflare-worker/src/session-tray-bridge.ts
@@ -1,0 +1,345 @@
+/**
+ * Preview-bridge WebSocket relay.
+ *
+ * A driveable preview (`serve --bridge`) loads a shim that dials
+ * `wss://<token>.sliccy.now/__slicc/bridge`. Each visitor tab gets one socket
+ * on the tray DO, and this relay shuttles CDP requests leader→tab, CDP
+ * responses and events tab→leader, and attributed `window.slicc.emit()` calls
+ * tab→leader as webhook events.
+ *
+ * **Everything arriving on a bridge socket is untrusted third-party traffic.**
+ * Frames are parsed defensively (a throw out of a hibernatable handler resets
+ * the DO and drops the tray), emits are size- and rate-bounded before they can
+ * reach the agent's context, and a frame whose socket attachment lost its
+ * `connId` is dropped rather than guessed at.
+ *
+ * Extracted from `SessionTrayDurableObject` behind a {@link BridgeDeps} seam
+ * (issue #2674), mirroring `session-tray-preview.ts`.
+ */
+
+import type {
+  CDPPayload,
+  LeaderBridgeCdpRequest,
+  WorkerToLeaderControlMessage,
+} from '@slicc/shared-ts';
+import {
+  jsonResponse,
+  type PreviewRecord,
+  type TrayRecord,
+  type TrayWebSocketLike,
+  websocketResponse,
+} from './shared.js';
+
+/** Socket tag every bridge visitor socket carries, alongside `tok:` and `conn:`. */
+export const BRIDGE_WS_TAG = 'bridge';
+
+// Untrusted `window.slicc.emit()` frames arrive over the bridge WS and are
+// forwarded verbatim into the cone's context. Bound both the per-frame size and
+// the per-connection rate so a hostile preview visitor can't flood the agent
+// with attacker-controlled text (token DoS / prompt-injection amplifier). The
+// counter is per live DO instance — good enough because an active flood keeps
+// the DO awake, and an idle reset between floods is harmless.
+const MAX_BRIDGE_EMIT_BYTES = 16 * 1024;
+const BRIDGE_EMIT_WINDOW_MS = 10_000;
+const MAX_BRIDGE_EMITS_PER_WINDOW = 20;
+
+/** Metadata stamped onto a bridge socket at accept time and read back after hibernation. */
+interface BridgeAttachment {
+  connId?: string;
+  previewToken?: string;
+  origin?: string;
+  userAgent?: string;
+  connectedAt?: string;
+}
+
+/** A frame from a visitor tab. Every field is re-validated before use. */
+interface BridgeFrame {
+  t?: string;
+  id: number;
+  result?: CDPPayload;
+  error?: { code: number; message: string };
+  name?: string;
+  detail?: unknown;
+}
+
+/** The slice of the durable object this relay needs. */
+export interface BridgeDeps {
+  /** Live sockets carrying `tag`. Empty when the runtime has no hibernation API. */
+  socketsWithTag(tag: string): TrayWebSocketLike[];
+  tagsFor(ws: TrayWebSocketLike): string[];
+  acceptWebSocket(ws: TrayWebSocketLike, tags: string[]): void;
+  newWebSocketPair(): { client: unknown; server: TrayWebSocketLike };
+  ensureAutoResponse(): void;
+  loadTray(): Promise<void>;
+  /** Re-attach the hibernation-evicted leader socket before relaying to it. */
+  restoreLeaderSocket(): void;
+  getTray(): TrayRecord | null;
+  sendToLeader(message: WorkerToLeaderControlMessage): boolean;
+  resolvePreview(previewToken: string): Promise<PreviewRecord | null>;
+  isoNow(): string;
+  now(): number;
+}
+
+function attachmentOf(ws: TrayWebSocketLike): BridgeAttachment {
+  return (ws.deserializeAttachment?.() ?? {}) as BridgeAttachment;
+}
+
+export class BridgeRelay {
+  /**
+   * Per-bridge-connection emit rate-limiter (fixed window), keyed by connId.
+   * Evicted when the bridge socket closes/errors.
+   */
+  private readonly emitWindows = new Map<string, { windowStart: number; count: number }>();
+
+  constructor(private readonly deps: BridgeDeps) {}
+
+  /** Accept a visitor tab's bridge socket, or refuse it. */
+  async handleWebSocket(previewToken: string, request: Request): Promise<Response> {
+    const record = await this.deps.resolvePreview(previewToken);
+    if (!record?.bridge) {
+      return jsonResponse({ error: 'Bridge not enabled', code: 'BRIDGE_DISABLED' }, 403);
+    }
+    const existing = this.socketsForPreview(previewToken);
+    if (existing.length >= (record.maxTabs ?? 20)) {
+      return jsonResponse({ error: 'Too many bridged tabs', code: 'BRIDGE_CAP' }, 429);
+    }
+
+    const { client, server } = this.deps.newWebSocketPair();
+    const connId = crypto.randomUUID();
+    this.deps.acceptWebSocket(server, [BRIDGE_WS_TAG, `tok:${previewToken}`, `conn:${connId}`]);
+    const origin = request.headers.get('origin') ?? '';
+    const userAgent = request.headers.get('user-agent') ?? '';
+    const connectedAt = this.deps.isoNow();
+    server.serializeAttachment?.({ connId, previewToken, origin, userAgent, connectedAt });
+    this.deps.ensureAutoResponse();
+    server.send(JSON.stringify({ t: 'welcome', connId }));
+    // Ensure tray and leader socket are available before sending notification
+    await this.deps.loadTray();
+    this.deps.restoreLeaderSocket();
+    this.deps.sendToLeader({
+      type: 'bridge.connected',
+      connId,
+      previewToken,
+      origin,
+      userAgent,
+      connectedAt,
+    });
+    return websocketResponse(client);
+  }
+
+  /**
+   * An inbound frame on a bridge socket. Relays CDP responses/events and
+   * attributed `window.slicc.emit()` events to the leader; silently drops
+   * anything malformed.
+   */
+  async handleMessage(ws: TrayWebSocketLike, message: string | ArrayBuffer): Promise<void> {
+    await this.deps.loadTray();
+    this.deps.restoreLeaderSocket();
+    const { connId, previewToken } = attachmentOf(ws);
+    // The attachment must carry the connId (set at accept time); without it we
+    // can't route the frame back to the right leader-side transport. Drop it.
+    if (!connId) return;
+    const data = typeof message === 'string' ? message : new TextDecoder().decode(message);
+    // A malformed / non-JSON frame must not throw out of this hibernatable
+    // handler — that would reset the DO and drop the tray.
+    let frame: BridgeFrame;
+    try {
+      frame = JSON.parse(data);
+    } catch {
+      return;
+    }
+
+    if (frame.t === 'cdp.res') {
+      this.deps.sendToLeader({
+        type: 'bridge.cdp.response',
+        connId,
+        id: frame.id,
+        result: frame.result,
+        error: frame.error,
+      });
+    } else if (frame.t === 'emit') {
+      this.handleEmit(frame, data, connId, previewToken);
+    }
+  }
+
+  /**
+   * `window.slicc.emit()` over the bridge WS. The DO knows the origin
+   * connection (connId + previewToken from the socket attachment), so it
+   * ATTRIBUTES the event: routed as the record's webhook.event with the
+   * preview identity in headers, so the cone knows which tab fired it (the
+   * matching drive target is `preview:<token>:<connId>`) and can tell a
+   * preview event apart from a plain webhook. Unattributed beacon emits (the
+   * page-unload fallback) go through handlePreviewEmit instead.
+   *
+   * Bound size + rate first: this is untrusted third-party traffic that lands
+   * verbatim in the agent's context.
+   */
+  private handleEmit(
+    frame: BridgeFrame,
+    data: string,
+    connId: string,
+    previewToken: string | undefined
+  ): void {
+    if (data.length > MAX_BRIDGE_EMIT_BYTES) {
+      console.warn('[bridge] emit dropped: payload too large', {
+        connId,
+        previewToken,
+        bytes: data.length,
+      });
+      return;
+    }
+    if (!this.allowEmit(connId)) {
+      console.warn('[bridge] emit dropped: rate limit exceeded', { connId, previewToken });
+      return;
+    }
+    const record = previewToken ? this.deps.getTray()?.previews?.[previewToken] : undefined;
+    if (!record?.webhookId) {
+      // No webhook to route to: the preview was revoked mid-flight (revoke
+      // deletes the webhook and closes sockets, but an in-flight frame can still
+      // arrive) or was never bridged with a provisioned webhook. The sibling
+      // beacon path returns 400 here; a WS frame can only be logged.
+      console.warn('[bridge] emit dropped: preview has no webhookId', {
+        connId,
+        previewToken,
+        hasRecord: Boolean(record),
+      });
+      return;
+    }
+    const delivered = this.deps.sendToLeader({
+      type: 'webhook.event',
+      webhookId: record.webhookId,
+      headers: {
+        'x-slicc-preview-conn': connId,
+        'x-slicc-preview-token': previewToken ?? '',
+      },
+      body: { name: frame.name, detail: frame.detail },
+      timestamp: new Date(this.deps.now()).toISOString(),
+    });
+    // A WS frame has no response channel, so unlike the beacon path (which
+    // returns 502) we can't signal the page. Log the drop — this is the only
+    // trace when a live leader momentarily vanishes mid-session.
+    if (!delivered) {
+      console.warn('[bridge] emit dropped: no live leader', { connId, previewToken });
+    }
+  }
+
+  /**
+   * Fixed-window rate limit for `window.slicc.emit()` frames from one bridge
+   * connection. Returns false (drop) once a connection exceeds
+   * MAX_BRIDGE_EMITS_PER_WINDOW within BRIDGE_EMIT_WINDOW_MS.
+   */
+  private allowEmit(connId: string): boolean {
+    const now = this.deps.now();
+    const win = this.emitWindows.get(connId);
+    if (!win || now - win.windowStart >= BRIDGE_EMIT_WINDOW_MS) {
+      this.emitWindows.set(connId, { windowStart: now, count: 1 });
+      return true;
+    }
+    if (win.count >= MAX_BRIDGE_EMITS_PER_WINDOW) return false;
+    win.count += 1;
+    return true;
+  }
+
+  /**
+   * A bridge visitor socket ended (close or error). Notify the leader so it
+   * drops the phantom `preview:` target, and evict the per-conn emit-rate window.
+   */
+  async handleSocketGone(ws: TrayWebSocketLike): Promise<void> {
+    await this.deps.loadTray();
+    this.deps.restoreLeaderSocket();
+    const { connId } = attachmentOf(ws);
+    if (connId) this.forget(connId);
+  }
+
+  /**
+   * Leader→bridge: route a CDP request to the matching bridge socket by its
+   * `conn:<connId>` tag (indexed lookup, not an O(n) scan). When the visitor tab
+   * is gone (closed / revoked), fail the leader's pending call fast instead of
+   * letting it burn the full CDP timeout, so it can drop the phantom transport.
+   */
+  relayCdpRequest(message: LeaderBridgeCdpRequest): void {
+    const target = this.socketForConn(message.connId);
+    if (!target) {
+      this.deps.sendToLeader({
+        type: 'bridge.cdp.response',
+        connId: message.connId,
+        id: message.id,
+        error: { code: -32000, message: 'Preview bridge connection is gone' },
+      });
+      return;
+    }
+    target.send(
+      JSON.stringify({
+        t: 'cdp.req',
+        id: message.id,
+        method: message.method,
+        params: message.params,
+        sessionId: message.sessionId,
+      })
+    );
+  }
+
+  /**
+   * The leader closed a preview target: close that visitor's bridge socket and
+   * tell the leader it's gone (a server-initiated close won't re-fire
+   * webSocketClose in workerd, so we can't rely on the close handler).
+   */
+  closeConnection(connId: string): void {
+    const target = this.socketForConn(connId);
+    this.forget(connId);
+    target?.close(1000, 'closed by leader');
+  }
+
+  /**
+   * Send a `bridge.connected` for every live bridge socket to a specific leader
+   * socket. Metadata comes from the socket attachment stamped at accept time
+   * (connId / previewToken / origin / userAgent / connectedAt).
+   */
+  replayConnectionsToLeader(leaderWs: TrayWebSocketLike): void {
+    for (const ws of this.deps.socketsWithTag(BRIDGE_WS_TAG)) {
+      const att = attachmentOf(ws);
+      if (!att.connId || !att.previewToken) continue;
+      leaderWs.send(
+        JSON.stringify({
+          type: 'bridge.connected',
+          connId: att.connId,
+          previewToken: att.previewToken,
+          origin: att.origin ?? '',
+          userAgent: att.userAgent ?? '',
+          connectedAt: att.connectedAt ?? this.deps.isoNow(),
+          replay: true,
+        })
+      );
+    }
+  }
+
+  /** Tear down every visitor socket bridged to a preview that was just revoked. */
+  closeSocketsForPreview(previewToken: string): void {
+    for (const ws of this.socketsForPreview(previewToken)) {
+      // A server-initiated `ws.close()` does NOT re-invoke webSocketClose in
+      // workerd, so notify the leader and evict per-conn state HERE. Otherwise the
+      // leader keeps a phantom `preview:` target that hangs every CDP call for the
+      // 30s timeout. (A duplicate bridge.disconnected, should webSocketClose also
+      // fire, is a harmless no-op on the leader's `if (!entry) return` path.)
+      const { connId } = attachmentOf(ws);
+      if (connId) this.forget(connId);
+      ws.close(1000, 'preview revoked');
+    }
+  }
+
+  /** Drop per-connection state and tell the leader the target is gone. */
+  private forget(connId: string): void {
+    this.emitWindows.delete(connId);
+    this.deps.sendToLeader({ type: 'bridge.disconnected', connId });
+  }
+
+  private socketForConn(connId: string): TrayWebSocketLike | undefined {
+    return this.deps.socketsWithTag(`conn:${connId}`)[0];
+  }
+
+  private socketsForPreview(previewToken: string): TrayWebSocketLike[] {
+    return this.deps
+      .socketsWithTag(BRIDGE_WS_TAG)
+      .filter((ws) => this.deps.tagsFor(ws).includes(`tok:${previewToken}`));
+  }
+}

--- a/packages/cloudflare-worker/src/session-tray-push.ts
+++ b/packages/cloudflare-worker/src/session-tray-push.ts
@@ -1,0 +1,164 @@
+/**
+ * APNs push fan-out for the tray durable object (issue #2062).
+ *
+ * The leader owns the decision to push; this coordinator owns the *device
+ * registry* and the fan-out. It is the trust boundary for what the DO stores,
+ * so a `push.register` arriving over the leader socket is re-validated here
+ * even though the leader already checked its shape.
+ *
+ * Structured like `session-tray-preview.ts` / `session-tray-biscotto.ts`: the
+ * coordinator takes explicit dependencies rather than reaching into the DO, so
+ * it is unit-testable without a DO harness. It is a class rather than a set of
+ * functions purely because the "APNs is not configured" warning must be logged
+ * once per instance, not once per push.
+ */
+
+import type { ApnsPushResult, ApnsSender } from './apns.js';
+import type { TrayRecord } from './shared.js';
+
+/** Cap on registered push devices per tray; oldest registrations are evicted. */
+export const MAX_PUSH_TOKENS_PER_TRAY = 16;
+
+/** The slice of the durable object this coordinator needs. */
+export interface PushDeps {
+  requireTray(): TrayRecord;
+  persistTray(): Promise<void>;
+  isoNow(): string;
+  /** `null` when APNs secrets are absent — pushing is disabled, not an error. */
+  apns: ApnsSender | null;
+}
+
+/** A `push.register` as it arrives over the leader socket. Every field is untyped on purpose. */
+export interface PushRegisterMessage {
+  bootstrapId?: unknown;
+  platform?: unknown;
+  token?: unknown;
+  environment?: unknown;
+}
+
+/** A `push.send` as it arrives over the leader socket. */
+export interface PushSendMessage {
+  category?: unknown;
+  label?: unknown;
+  requestId?: unknown;
+}
+
+/**
+ * Should a dead-token verdict actually evict the registration? Apple's 410
+ * body carries the instant the token stopped being valid; a device that
+ * re-registered after that instant has a live token again and must be kept,
+ * or a reconnect race silently unsubscribes a phone that is right there.
+ * A 400 `BadDeviceToken` carries no timestamp and is unconditionally final.
+ */
+export function forgetsPushToken(tray: TrayRecord, result: ApnsPushResult): boolean {
+  if (result.invalidatedAtMs === undefined) return true;
+  const record = tray.pushTokens?.[result.token];
+  if (!record) return true;
+  const registeredAtMs = Date.parse(record.registeredAt);
+  if (!Number.isFinite(registeredAtMs)) return true;
+  return registeredAtMs < result.invalidatedAtMs;
+}
+
+export class PushCoordinator {
+  private disabledLogged = false;
+
+  constructor(private readonly deps: PushDeps) {}
+
+  /**
+   * A follower registered a push token via the leader. Bounded per tray;
+   * re-registering the same token just refreshes it. Silently ignores anything
+   * that is not a plausible iOS device token — a bad registration is a client
+   * bug, not something to surface on the leader's control socket.
+   */
+  register(message: PushRegisterMessage): void {
+    const tray = this.deps.requireTray();
+    const token = typeof message.token === 'string' ? message.token.trim() : '';
+    if (message.platform !== 'ios' || !/^[0-9a-fA-F]{32,400}$/.test(token)) return;
+    const environment = message.environment === 'production' ? 'production' : 'sandbox';
+    const bootstrapId = typeof message.bootstrapId === 'string' ? message.bootstrapId : '';
+    tray.pushTokens ??= {};
+    tray.pushTokens[token] = {
+      platform: 'ios',
+      environment,
+      bootstrapId,
+      registeredAt: this.deps.isoNow(),
+    };
+    const entries = Object.entries(tray.pushTokens);
+    if (entries.length > MAX_PUSH_TOKENS_PER_TRAY) {
+      const evict = entries
+        .sort((a, b) => a[1].registeredAt.localeCompare(b[1].registeredAt))
+        .slice(0, entries.length - MAX_PUSH_TOKENS_PER_TRAY);
+      for (const [dead] of evict) delete tray.pushTokens[dead];
+    }
+  }
+
+  /**
+   * Fan a leader push out to every registered device. Dead tokens (410 /
+   * BadDeviceToken) are forgotten and the record persisted; transport errors
+   * are logged and the token kept. Never throws into the leader socket loop.
+   */
+  async send(message: PushSendMessage): Promise<void> {
+    const tray = this.deps.requireTray();
+    const tokens = Object.entries(tray.pushTokens ?? {});
+    if (tokens.length === 0) return;
+    const apns = this.deps.apns;
+    if (!apns) {
+      if (!this.disabledLogged) {
+        this.disabledLogged = true;
+        console.warn('[push] APNs secrets not configured — push.send ignored', {
+          trayId: tray.trayId,
+        });
+      }
+      return;
+    }
+    if (message.category !== 'sudo_request' && message.category !== 'turn_end') return;
+    const category = message.category;
+    const label =
+      typeof message.label === 'string' && message.label.trim()
+        ? message.label.trim().slice(0, 80)
+        : 'SLICC';
+    const requestId =
+      typeof message.requestId === 'string' && message.requestId ? message.requestId : undefined;
+
+    const results = await Promise.all(
+      tokens.map(([token, record]) =>
+        apns
+          .send({
+            token,
+            environment: record.environment,
+            category,
+            label,
+            trayId: tray.trayId,
+            ...(requestId ? { requestId } : {}),
+          })
+          .catch(
+            (err): ApnsPushResult => ({
+              token,
+              status: 0,
+              reason: err instanceof Error ? err.message : String(err),
+              dropToken: false,
+            })
+          )
+      )
+    );
+
+    let mutated = false;
+    for (const result of results) {
+      if (result.dropToken && forgetsPushToken(tray, result)) {
+        delete tray.pushTokens?.[result.token];
+        mutated = true;
+        continue;
+      }
+      if (result.status !== 200) {
+        console.warn('[push] APNs delivery failed', {
+          trayId: tray.trayId,
+          status: result.status,
+          reason: result.reason,
+          // Apple asks for this id when investigating a push that never landed.
+          ...(result.uniqueId ? { uniqueId: result.uniqueId } : {}),
+        });
+      }
+    }
+    if (mutated) await this.deps.persistTray();
+  }
+}

--- a/packages/cloudflare-worker/src/session-tray-requests.ts
+++ b/packages/cloudflare-worker/src/session-tray-requests.ts
@@ -1,0 +1,182 @@
+/**
+ * Request parsing and wire-shape guards for the tray durable object.
+ *
+ * Everything here is PURE — no tray record, no leader socket, no storage. That
+ * is the point: these are the functions that turn an untrusted `Request` (or a
+ * loosely-typed body that already crossed the wire) into a narrow, validated
+ * shape, and they should be readable and testable without a DO harness.
+ *
+ * The guards deliberately re-validate fields the leader "already checked": the
+ * DO is the trust boundary for what it stores and relays, so a shape that only
+ * a well-behaved client would produce is never assumed.
+ */
+
+import type {
+  FollowerBootstrapRequest,
+  TrayIceCandidate,
+  TraySessionDescription,
+} from '@slicc/shared-ts';
+
+/** Query/body shape for `POST /controller/:token` and the plain follower attach. */
+export interface ControllerAttachRequest {
+  controllerId?: string;
+  leaderKey?: string;
+  runtime?: string;
+}
+
+/** Either a plain attach or one of the WebRTC bootstrap signaling actions. */
+export type JoinRequest = ControllerAttachRequest | FollowerBootstrapRequest;
+
+/** Loosely-typed follower bootstrap POST body; every field is re-validated below. */
+interface FollowerBootstrapBody {
+  action?: unknown;
+  controllerId?: unknown;
+  bootstrapId?: unknown;
+  runtime?: unknown;
+  cursor?: unknown;
+  answer?: unknown;
+  candidate?: unknown;
+}
+
+/**
+ * Bootstrap signaling body → a narrowed {@link FollowerBootstrapRequest}, or
+ * `null` when `action` is not one of the four signaling verbs (i.e. this is a
+ * plain attach). Split out of {@link readJoinRequest} so that function stays a
+ * short "where do the fields come from" reader.
+ */
+function bootstrapRequestFromBody(
+  body: FollowerBootstrapBody,
+  controllerId: string | undefined,
+  bootstrapId: string | undefined,
+  runtime: string | undefined
+): FollowerBootstrapRequest | null {
+  switch (body.action) {
+    case 'poll':
+      return {
+        action: 'poll',
+        controllerId,
+        bootstrapId,
+        cursor: typeof body.cursor === 'number' ? body.cursor : undefined,
+      };
+    case 'answer':
+      return {
+        action: 'answer',
+        controllerId,
+        bootstrapId,
+        answer: body.answer as TraySessionDescription | undefined,
+      };
+    case 'ice-candidate':
+      return {
+        action: 'ice-candidate',
+        controllerId,
+        bootstrapId,
+        candidate: body.candidate as TrayIceCandidate | undefined,
+      };
+    case 'retry':
+      return { action: 'retry', controllerId, bootstrapId, runtime };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Read a `/join/:token` request. Query parameters are the floor; a JSON POST
+ * body overrides them. A body that is missing, non-JSON or malformed degrades
+ * to the query-only attach rather than failing the join — the follower's first
+ * contact should not hinge on a body it may not have sent.
+ */
+export async function readJoinRequest(request: Request, url: URL): Promise<JoinRequest> {
+  const queryAttach: ControllerAttachRequest = {
+    controllerId: url.searchParams.get('controllerId') ?? undefined,
+    runtime: url.searchParams.get('runtime') ?? undefined,
+  };
+
+  if (request.method !== 'POST') {
+    return queryAttach;
+  }
+
+  const contentType = request.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    return queryAttach;
+  }
+
+  try {
+    const body = (await request.json()) as FollowerBootstrapBody;
+    const controllerId =
+      typeof body.controllerId === 'string' ? body.controllerId : queryAttach.controllerId;
+    const bootstrapId = typeof body.bootstrapId === 'string' ? body.bootstrapId : undefined;
+    const runtime = typeof body.runtime === 'string' ? body.runtime : queryAttach.runtime;
+
+    return (
+      bootstrapRequestFromBody(body, controllerId, bootstrapId, runtime) ?? {
+        controllerId,
+        runtime,
+      }
+    );
+  } catch {
+    return queryAttach;
+  }
+}
+
+/** Same query-then-body reading for the controller attach route. */
+export async function readAttachRequest(
+  request: Request,
+  url: URL
+): Promise<ControllerAttachRequest> {
+  const queryAttach: ControllerAttachRequest = {
+    controllerId: url.searchParams.get('controllerId') ?? undefined,
+    leaderKey: url.searchParams.get('leaderKey') ?? undefined,
+    runtime: url.searchParams.get('runtime') ?? undefined,
+  };
+
+  if (request.method !== 'POST') {
+    return queryAttach;
+  }
+
+  const contentType = request.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    return queryAttach;
+  }
+
+  try {
+    const body = (await request.json()) as ControllerAttachRequest;
+    return {
+      controllerId: body.controllerId ?? queryAttach.controllerId,
+      leaderKey: body.leaderKey ?? queryAttach.leaderKey,
+      runtime: body.runtime ?? queryAttach.runtime,
+    };
+  } catch {
+    return queryAttach;
+  }
+}
+
+export function isBootstrapRequest(request: JoinRequest): request is FollowerBootstrapRequest {
+  return 'action' in request;
+}
+
+/** The request's controller id, or a fresh one so an error response can still name a controller. */
+export function joinRequestControllerId(request: JoinRequest): string {
+  return request.controllerId ?? crypto.randomUUID();
+}
+
+export function isSessionDescription(
+  value: TraySessionDescription | undefined,
+  expectedType: TraySessionDescription['type']
+): value is TraySessionDescription {
+  return Boolean(value && value.type === expectedType && typeof value.sdp === 'string');
+}
+
+export function isIceCandidate(value: TrayIceCandidate | undefined): value is TrayIceCandidate {
+  return Boolean(value && typeof value.candidate === 'string');
+}
+
+/** The `wss://` form of the controller route, carrying the leader's credentials as query params. */
+export function buildLeaderWebSocketUrl(url: URL, controllerId: string, leaderKey: string): string {
+  const webSocketUrl = new URL(
+    url.pathname,
+    `${url.protocol === 'https:' ? 'wss:' : 'ws:'}//${url.host}`
+  );
+  webSocketUrl.searchParams.set('controllerId', controllerId);
+  webSocketUrl.searchParams.set('leaderKey', leaderKey);
+  return webSocketUrl.toString();
+}

--- a/packages/cloudflare-worker/src/session-tray-webhook.ts
+++ b/packages/cloudflare-worker/src/session-tray-webhook.ts
@@ -1,0 +1,218 @@
+/**
+ * Webhook relay for the tray durable object.
+ *
+ * An external service POSTs `/webhook/:webhookToken/:webhookId`; the DO relays
+ * the event to the leader over the control socket and waits (briefly) for the
+ * leader's `webhook.delivery` so the HTTP receipt reflects what actually
+ * happened to the event (issue #2524).
+ *
+ * Extracted from `session-tray.ts` behind a {@link WebhookDeps} seam, like
+ * `session-tray-preview.ts` / `session-tray-biscotto.ts`. A class rather than
+ * free functions because the pending-delivery map and the delivery-id counter
+ * are per-DO-instance state that belongs with this concern, not on the DO.
+ */
+
+import type { LeaderWebhookDelivery, WebhookDeliveryDisposition } from '@slicc/shared-ts';
+import { jsonResponse, type TrayRecord } from './shared.js';
+
+/**
+ * How long a webhook POST waits for the leader's `webhook.delivery` before the
+ * receipt falls back to the pre-#2524 `202 accepted`. Short on purpose: the
+ * leader's answer is synchronous once the message lands, and the caller is an
+ * external service on a request budget of its own.
+ */
+export const WEBHOOK_DELIVERY_WAIT_MS = 3_000;
+
+/** The slice of the durable object this relay needs. */
+export interface WebhookDeps {
+  requireTray(): TrayRecord;
+  matchesToken(received: string, expected: string): boolean;
+  hasLiveLeader(): boolean;
+  sendToLeader(message: unknown): boolean;
+  isoNow(): string;
+  now(): number;
+}
+
+/**
+ * Turn the leader's disposition into the webhook POST's receipt. `delivered`,
+ * `filtered` and "no answer" all keep the pre-#2524 `202 accepted` — a
+ * `--filter` dropping an event is the filter doing its job, and silence is not
+ * evidence of a drop. The other two used to be reported as success too, which
+ * made a black-holed webhook indistinguishable from a healthy one.
+ */
+export function webhookDeliveryResponse(
+  webhookId: string,
+  disposition: WebhookDeliveryDisposition | null
+): Response {
+  const cors = { 'access-control-allow-origin': '*' };
+  if (disposition === 'unknown-webhook') {
+    return jsonResponse(
+      {
+        ok: false,
+        accepted: false,
+        error: `Webhook "${webhookId}" is not registered with this leader`,
+        code: 'WEBHOOK_NOT_REGISTERED',
+      },
+      404,
+      cors
+    );
+  }
+  if (disposition === 'unresolved-target') {
+    return jsonResponse(
+      {
+        ok: false,
+        accepted: false,
+        error: `Webhook "${webhookId}" targets a scoop or cone that does not exist — the event was dropped`,
+        code: 'WEBHOOK_TARGET_UNRESOLVED',
+      },
+      422,
+      cors
+    );
+  }
+  return jsonResponse({ ok: true, accepted: true }, 202, cors);
+}
+
+/**
+ * Read the POST body as JSON where possible, falling back to `{ raw: text }`
+ * so a plain-text or form payload still reaches the cone instead of 400ing.
+ */
+async function readWebhookBody(request: Request): Promise<unknown> {
+  try {
+    const contentType = request.headers.get('content-type') ?? '';
+    if (contentType.includes('application/json')) {
+      return await request.json();
+    }
+    const text = await request.text();
+    try {
+      return JSON.parse(text);
+    } catch {
+      return { raw: text };
+    }
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Forwardable request headers. Cloudflare-internal headers and `host` are
+ * noise; the reserved `x-slicc-preview-*` headers are how the DO attributes a
+ * bridge-WS emit to a specific preview tab (rendered as a trusted "Preview
+ * Event"). Only the DO's own emit path may set them — a public webhook POST
+ * carrying them would otherwise forge tab attribution into the cone.
+ */
+function forwardableHeaders(request: Request): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const [key, value] of request.headers.entries()) {
+    if (key.startsWith('cf-') || key === 'host' || key.startsWith('x-slicc-preview-')) {
+      continue;
+    }
+    headers[key] = value;
+  }
+  return headers;
+}
+
+export class WebhookRelay {
+  /**
+   * Webhook POSTs whose HTTP response is waiting on the leader's disposition,
+   * keyed by deliveryId. Populated by {@link handle}; drained by {@link settle}
+   * when the leader answers, or by the wait budget.
+   */
+  private readonly pending = new Map<
+    string,
+    (disposition: WebhookDeliveryDisposition | null) => void
+  >();
+  private counter = 0;
+
+  constructor(
+    private readonly deps: WebhookDeps,
+    /**
+     * Ack budget override (tests). A fake leader that never acks would
+     * otherwise sit out the full production budget.
+     */
+    private readonly waitMs: number = WEBHOOK_DELIVERY_WAIT_MS
+  ) {}
+
+  async handle(token: string, request: Request, webhookId?: string): Promise<Response> {
+    const cors = { 'access-control-allow-origin': '*' };
+    if (!this.deps.matchesToken(token, this.deps.requireTray().webhookToken)) {
+      return jsonResponse(
+        { error: 'Invalid webhook capability', code: 'INVALID_WEBHOOK_CAPABILITY' },
+        403,
+        cors
+      );
+    }
+
+    if (!webhookId) {
+      return jsonResponse(
+        {
+          error: 'Webhook ID is required. Use POST /webhook/{token}/{webhookId}',
+          code: 'WEBHOOK_ID_REQUIRED',
+        },
+        400,
+        cors
+      );
+    }
+
+    if (!this.deps.hasLiveLeader()) {
+      return jsonResponse(
+        { error: 'No live leader is connected for this tray', code: 'NO_LIVE_LEADER' },
+        410,
+        cors
+      );
+    }
+
+    const body = await readWebhookBody(request);
+    const headers = forwardableHeaders(request);
+
+    // Forward to leader via the control WebSocket, asking for the disposition
+    // so a dropped delivery does not get a success receipt (issue #2524).
+    const deliveryId = `wd-${++this.counter}-${this.deps.now()}`;
+    const settled = new Promise<WebhookDeliveryDisposition | null>((resolve) => {
+      this.pending.set(deliveryId, resolve);
+    });
+    const sent = this.deps.sendToLeader({
+      type: 'webhook.event',
+      webhookId,
+      headers,
+      body,
+      timestamp: this.deps.isoNow(),
+      deliveryId,
+    });
+
+    if (!sent) {
+      this.pending.delete(deliveryId);
+      return jsonResponse(
+        { error: 'Failed to forward webhook to leader', code: 'LEADER_SEND_FAILED' },
+        502,
+        cors
+      );
+    }
+
+    const disposition = await this.awaitDelivery(deliveryId, settled);
+    return webhookDeliveryResponse(webhookId, disposition);
+  }
+
+  /** Hand a leader-reported disposition to the waiting webhook POST, if any. */
+  settle(message: LeaderWebhookDelivery): void {
+    const resolve = this.pending.get(message.deliveryId);
+    if (!resolve) return;
+    this.pending.delete(message.deliveryId);
+    resolve(message.disposition);
+  }
+
+  /**
+   * Wait out the leader's `webhook.delivery` for `deliveryId`, resolving `null`
+   * once the wait budget passes. A leader that predates #2524 never answers, so
+   * `null` must keep the pre-#2524 receipt: we know the event was forwarded,
+   * and nothing more.
+   */
+  private awaitDelivery(
+    deliveryId: string,
+    settled: Promise<WebhookDeliveryDisposition | null>
+  ): Promise<WebhookDeliveryDisposition | null> {
+    return Promise.race([
+      settled,
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), this.waitMs)),
+    ]).finally(() => this.pending.delete(deliveryId));
+  }
+}

--- a/packages/cloudflare-worker/src/session-tray.ts
+++ b/packages/cloudflare-worker/src/session-tray.ts
@@ -1,30 +1,38 @@
+/**
+ * `SessionTrayDurableObject` — the tray hub's per-tray coordinator.
+ *
+ * One durable object per tray. It owns the things that are genuinely about
+ * *this tray as a whole*: the tray record and its persistence, the leader's
+ * controller WebSocket (election, reclaim, staleness), the join/attach surface,
+ * and route dispatch.
+ *
+ * Everything else is a collaborator behind a `*Deps` seam, so each concern is
+ * unit-testable without a DO harness and this file stays a coordinator rather
+ * than a god class (issue #2674):
+ *
+ * - `session-tray-bootstrap.ts` — follower WebRTC signaling state machine
+ * - `session-tray-bridge.ts` — preview-bridge CDP relay + `slicc.emit()`
+ * - `session-tray-preview.ts` — preview mint/resolve/revoke + response assembly
+ * - `session-tray-biscotto.ts` — guest seat lifecycle
+ * - `session-tray-webhook.ts` — webhook relay + delivery receipts
+ * - `session-tray-push.ts` — APNs device registry + fan-out
+ * - `session-tray-requests.ts` — pure request parsing / wire-shape guards
+ */
+
 import {
-  type CDPPayload,
   type FollowerAttachResponse,
   type FollowerAttachResult,
-  type FollowerBiscottoIdentity,
-  type FollowerBootstrapRequest,
-  type FollowerBootstrapResponse,
   type FollowerTrust,
-  type LeaderBridgeCdpRequest,
   type LeaderToWorkerControlMessage,
-  type LeaderWebhookDelivery,
   TRAY_BOOTSTRAP_MAX_RETRIES,
   TRAY_BOOTSTRAP_RETRY_AFTER_MS,
   TRAY_BOOTSTRAP_TIMEOUT_MS,
-  type TrayBootstrapEvent,
-  type TrayBootstrapFailure,
-  type TrayBootstrapStatus,
-  type TrayIceCandidate,
   type TrayLeaderSummary,
-  type TraySessionDescription,
   type TurnIceServer,
-  type WebhookDeliveryDisposition,
   type WorkerToLeaderControlMessage,
 } from '@slicc/shared-ts';
 import {
   type ApnsProviderTokenSource,
-  type ApnsPushResult,
   type ApnsSender,
   apnsConfigFromEnv,
   LocalProviderTokenMinter,
@@ -39,13 +47,9 @@ import {
 import { supersededLinkHeaders } from './links.js';
 import { deletePreviewArchivePrefix } from './persistent-preview-storage.js';
 import { previewTokenFromHost } from './preview-host.js';
-import {
-  type BiscottoDeps,
-  BiscottoRouteError,
-  listBiscotti as listBiscottiImpl,
-  mintBiscotto as mintBiscottoImpl,
-  revokeBiscotto as revokeBiscottoImpl,
-} from './session-tray-biscotto.js';
+import { type BiscottoDeps, dispatchBiscottoRoute } from './session-tray-biscotto.js';
+import { BootstrapCoordinator, type BootstrapDeps } from './session-tray-bootstrap.js';
+import { BRIDGE_WS_TAG, type BridgeDeps, BridgeRelay } from './session-tray-bridge.js';
 import {
   dispatchPreviewRoute,
   expirePersistentPreviews,
@@ -61,38 +65,33 @@ import {
   resolvePreview as resolvePreviewImpl,
   revokePreview as revokePreviewImpl,
 } from './session-tray-preview.js';
+import { PushCoordinator, type PushDeps } from './session-tray-push.js';
 import {
-  type BiscottoGates,
+  buildLeaderWebSocketUrl,
+  type ControllerAttachRequest,
+  isBootstrapRequest,
+  type JoinRequest,
+  joinRequestControllerId,
+  readAttachRequest,
+  readJoinRequest,
+} from './session-tray-requests.js';
+import { type WebhookDeps, WebhookRelay } from './session-tray-webhook.js';
+import {
   type CreateTrayRequest,
   type DurableObjectNamespaceLike,
   type DurableObjectStateLike,
   FOLLOWER_ATTACH_RETRY_AFTER_MS,
   type JoinCapability,
   jsonResponse,
-  normalizeBiscottoGate,
   type PreviewRecord,
   reclaimMsForTray,
   resolveJoinCapability,
-  type TrayBootstrapRecord,
   type TrayRecord,
   type TrayWebSocketLike,
   websocketResponse,
 } from './shared.js';
 import { timingSafeEqual } from './timing-safe-equal.js';
 import { fetchTURNCredentials, TURN_CREDENTIAL_TTL_MS } from './turn-credentials.js';
-
-interface ControllerAttachRequest {
-  controllerId?: string;
-  leaderKey?: string;
-  runtime?: string;
-}
-
-type JoinRequest = ControllerAttachRequest | FollowerBootstrapRequest;
-
-type TrayBootstrapEventInput =
-  | { type: 'bootstrap.offer'; offer: TraySessionDescription }
-  | { type: 'bootstrap.ice_candidate'; candidate: TrayIceCandidate }
-  | { type: 'bootstrap.failed'; failure: TrayBootstrapFailure };
 
 export interface SessionTrayEnv {
   CLOUDFLARE_TURN_KEY_ID?: string;
@@ -118,51 +117,21 @@ interface SessionTrayOptions {
   /** Push sender seam (tests). Defaults to APNs from env, or disabled. */
   apnsSender?: ApnsSender | null;
   /**
-   * Override the webhook-delivery ack budget (tests). Defaults to
-   * {@link WEBHOOK_DELIVERY_WAIT_MS}; a test with a fake leader that never acks
-   * would otherwise sit out the full production budget.
+   * Override the webhook-delivery ack budget (tests). Defaults to the relay's
+   * own production budget; a test with a fake leader that never acks would
+   * otherwise sit out the full wait.
    */
   webhookDeliveryWaitMs?: number;
 }
 
-/** Loosely-typed follower bootstrap POST body; every field is re-validated below. */
-interface FollowerBootstrapBody {
-  action?: unknown;
-  controllerId?: unknown;
-  bootstrapId?: unknown;
-  runtime?: unknown;
-  cursor?: unknown;
-  answer?: unknown;
-  candidate?: unknown;
-}
-
-/** Cap on registered push devices per tray; oldest registrations are evicted. */
-const MAX_PUSH_TOKENS_PER_TRAY = 16;
-
 const TRAY_STORAGE_KEY = 'tray';
 const TURN_CREDENTIAL_REFRESH_MARGIN_MS = 5 * 60 * 1000;
 const LEADER_WS_TAG = 'leader';
-const BRIDGE_WS_TAG = 'bridge';
-// Untrusted `window.slicc.emit()` frames arrive over the bridge WS and are
-// forwarded verbatim into the cone's context. Bound both the per-frame size and
-// the per-connection rate so a hostile preview visitor can't flood the agent
-// with attacker-controlled text (token DoS / prompt-injection amplifier). The
-// counter is per live DO instance — good enough because an active flood keeps
-// the DO awake, and an idle reset between floods is harmless.
-const MAX_BRIDGE_EMIT_BYTES = 16 * 1024;
-const BRIDGE_EMIT_WINDOW_MS = 10_000;
-const MAX_BRIDGE_EMITS_PER_WINDOW = 20;
 // Pure-relay leader messages (CDP request relay, preview chunk pumping) only
 // bump `leader.lastSeenAt`; persisting the whole tray record on each one would
 // be a storage write per CDP command on the hot drive path. Debounce those
 // liveness-only writes to at most once per window.
 const LEADER_SEEN_PERSIST_MS = 30_000;
-// Grace period after a bootstrap reaches a terminal state before it is pruned.
-// Gives the follower time to poll the final failure before the record vanishes.
-const BOOTSTRAP_TERMINAL_GRACE_MS = 5 * 60 * 1000;
-// Maximum bootstrap events kept per record. The follower polls via a cursor so
-// only recent events matter; old SDP payloads (kilobytes each) are dropped.
-const MAX_BOOTSTRAP_EVENTS = 20;
 // Controllers whose `lastSeenAt` is older than this are pruned. Set to 2×
 // the desktop reclaim TTL so a controller always survives a leader reclaim.
 const CONTROLLER_STALE_MS = 2 * 60 * 60 * 1000;
@@ -171,55 +140,17 @@ const CONTROLLER_STALE_MS = 2 * 60 * 60 * 1000;
 // ghost leaders whose sockets linger after a network drop — workerd's
 // setWebSocketAutoResponse keeps responding to pings, but real messages stop.
 const LEADER_STALE_MS = 2 * 60 * 1000;
-// How long a webhook POST waits for the leader's `webhook.delivery` before the
-// receipt falls back to the pre-#2524 `202 accepted` (issue #2524). Short on
-// purpose: the leader's answer is synchronous once the message lands, and the
-// caller is an external service on a request budget of its own.
-const WEBHOOK_DELIVERY_WAIT_MS = 3_000;
-
-/**
- * Turn the leader's disposition into the webhook POST's receipt. `delivered`,
- * `filtered` and "no answer" all keep the pre-#2524 `202 accepted` — a
- * `--filter` dropping an event is the filter doing its job, and silence is not
- * evidence of a drop. The other two used to be reported as success too, which
- * made a black-holed webhook indistinguishable from a healthy one.
- */
-function webhookDeliveryResponse(
-  webhookId: string,
-  disposition: WebhookDeliveryDisposition | null
-): Response {
-  const cors = { 'access-control-allow-origin': '*' };
-  if (disposition === 'unknown-webhook') {
-    return jsonResponse(
-      {
-        ok: false,
-        accepted: false,
-        error: `Webhook "${webhookId}" is not registered with this leader`,
-        code: 'WEBHOOK_NOT_REGISTERED',
-      },
-      404,
-      cors
-    );
-  }
-  if (disposition === 'unresolved-target') {
-    return jsonResponse(
-      {
-        ok: false,
-        accepted: false,
-        error: `Webhook "${webhookId}" targets a scoop or cone that does not exist — the event was dropped`,
-        code: 'WEBHOOK_TARGET_UNRESOLVED',
-      },
-      422,
-      cors
-    );
-  }
-  return jsonResponse({ ok: true, accepted: true }, 202, cors);
-}
 
 interface CachedIceServers {
   iceServers: TurnIceServer[];
   expiresAtMs: number;
 }
+
+const CORS_PREFLIGHT_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'POST, OPTIONS',
+  'access-control-allow-headers': 'content-type',
+};
 
 export class SessionTrayDurableObject {
   private readonly now: () => number;
@@ -234,14 +165,10 @@ export class SessionTrayDurableObject {
    * `APNS_TOKEN_PATH`. Also the fallback if the shared instance is unreachable.
    */
   private readonly apnsTokenMinter: ApnsProviderTokenSource | null;
-  private apnsDisabledLogged = false;
   private tray: TrayRecord | null = null;
   private leaderSocket: TrayWebSocketLike | null = null;
   private cachedIceServers: CachedIceServers | null = null;
   private autoResponseSet = false;
-  // Per-bridge-connection emit rate-limiter (fixed window), keyed by connId.
-  // Evicted when the bridge socket closes/errors.
-  private readonly bridgeEmitWindows = new Map<string, { windowStart: number; count: number }>();
   // Last time a pure-relay leader message flushed `leader.lastSeenAt` to storage
   // (see LEADER_SEEN_PERSIST_MS). Debounces the hot CDP-relay path.
   private lastLeaderSeenPersistMs = 0;
@@ -250,15 +177,13 @@ export class SessionTrayDurableObject {
   // when the matching `preview.response` arrives (single chunk today, future-
   // proof for chunked binary).
   private readonly pendingPreviews = new Map<string, PreviewAssembler>();
-  // Webhook POSTs whose HTTP response is waiting on the leader's disposition
-  // (issue #2524), keyed by deliveryId. Populated by `handleWebhook`; drained by
-  // `handleLeaderMessage` on `webhook.delivery`, or by the wait budget.
-  private readonly pendingWebhookDeliveries = new Map<
-    string,
-    (disposition: WebhookDeliveryDisposition | null) => void
-  >();
-  private webhookDeliveryCounter = 0;
-  private readonly webhookDeliveryWaitMs: number;
+
+  // Extracted concerns. Each holds only its own state; anything durable lives
+  // on the tray record so it survives hibernation.
+  private readonly bootstrap: BootstrapCoordinator;
+  private readonly bridge: BridgeRelay;
+  private readonly webhooks: WebhookRelay;
+  private readonly push: PushCoordinator;
 
   constructor(
     private readonly state: DurableObjectStateLike,
@@ -267,7 +192,6 @@ export class SessionTrayDurableObject {
   ) {
     this.now = options.now ?? (() => Date.now());
     this.fetchImpl = options.fetchImpl ?? fetch;
-    this.webhookDeliveryWaitMs = options.webhookDeliveryWaitMs ?? WEBHOOK_DELIVERY_WAIT_MS;
     const typedEnv = (env && typeof env === 'object' ? env : {}) as SessionTrayEnv;
     this.turnKeyId = typedEnv.CLOUDFLARE_TURN_KEY_ID;
     this.turnApiToken = typedEnv.CLOUDFLARE_TURN_API_TOKEN;
@@ -309,7 +233,16 @@ export class SessionTrayDurableObject {
           server: pair[1] as TrayWebSocketLike,
         };
       });
+
+    this.bootstrap = new BootstrapCoordinator(this.bootstrapDeps());
+    this.bridge = new BridgeRelay(this.bridgeDeps());
+    this.webhooks = new WebhookRelay(this.webhookDeps(), options.webhookDeliveryWaitMs);
+    this.push = new PushCoordinator(this.pushDeps());
   }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Route dispatch
+  // ──────────────────────────────────────────────────────────────────────
 
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
@@ -342,7 +275,7 @@ export class SessionTrayDurableObject {
     ) {
       const hostResult = previewTokenFromHost(url.host);
       if (hostResult) {
-        return this.handleBridgeWebSocket(hostResult.token, request);
+        return this.bridge.handleWebSocket(hostResult.token, request);
       }
     }
 
@@ -358,14 +291,7 @@ export class SessionTrayDurableObject {
     const joinMatch = url.pathname.match(/^\/join\/([^/]+)$/);
     if (joinMatch) {
       if (request.method === 'OPTIONS') {
-        return new Response(null, {
-          status: 204,
-          headers: {
-            'access-control-allow-origin': '*',
-            'access-control-allow-methods': 'POST, OPTIONS',
-            'access-control-allow-headers': 'content-type',
-          },
-        });
+        return new Response(null, { status: 204, headers: CORS_PREFLIGHT_HEADERS });
       }
       const response = await this.handleJoin(request, joinMatch[1], url);
       response.headers.set('access-control-allow-origin', '*');
@@ -387,26 +313,51 @@ export class SessionTrayDurableObject {
 
     const webhookMatch = url.pathname.match(/^\/webhook\/([^/]+?)(?:\/([^/]+))?$/);
     if (webhookMatch) {
-      if (request.method === 'OPTIONS') {
-        return new Response(null, {
-          status: 204,
-          headers: {
-            'access-control-allow-origin': '*',
-            'access-control-allow-methods': 'POST, OPTIONS',
-            'access-control-allow-headers': 'content-type',
-          },
-        });
-      }
-      if (request.method !== 'POST') {
-        return jsonResponse({ error: 'Method not allowed', code: 'METHOD_NOT_ALLOWED' }, 405, {
-          allow: 'POST, OPTIONS',
-        });
-      }
-      return this.handleWebhook(webhookMatch[1], request, webhookMatch[2]);
+      return this.handleWebhookRoute(request, webhookMatch[1], webhookMatch[2]);
     }
 
     return jsonResponse({ error: 'Not found', code: 'NOT_FOUND' }, 404);
   }
+
+  private handleWebhookRoute(
+    request: Request,
+    token: string,
+    webhookId: string | undefined
+  ): Promise<Response> {
+    if (request.method === 'OPTIONS') {
+      return Promise.resolve(new Response(null, { status: 204, headers: CORS_PREFLIGHT_HEADERS }));
+    }
+    if (request.method !== 'POST') {
+      return Promise.resolve(
+        jsonResponse({ error: 'Method not allowed', code: 'METHOD_NOT_ALLOWED' }, 405, {
+          allow: 'POST, OPTIONS',
+        })
+      );
+    }
+    return this.webhooks.handle(token, request, webhookId);
+  }
+
+  /**
+   * Leader-only `/internal/*` control routes reached through the DO stub, i.e.
+   * never from the public edge. Grouped into one dispatcher so adding a route
+   * costs a line here rather than another branch in `fetch`, which sits at the
+   * cognitive-complexity ceiling.
+   */
+  private async handleInternalRoute(url: URL, request: Request): Promise<Response | null> {
+    if (url.pathname === '/internal/supersede' && request.method === 'POST') {
+      return this.handleSupersede(request);
+    }
+    if (url.pathname.startsWith('/internal/biscotto/')) {
+      return dispatchBiscottoRoute(url, request, this.biscottoDeps(), (id) =>
+        this.announceBiscottoRevocation(id)
+      );
+    }
+    return null;
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // WebSocket lifecycle
+  // ──────────────────────────────────────────────────────────────────────
 
   async webSocketMessage(ws: TrayWebSocketLike, message: string | ArrayBuffer): Promise<void> {
     if (!this.tray) {
@@ -414,147 +365,23 @@ export class SessionTrayDurableObject {
     }
 
     // Role-branch: bridge sockets carry preview→leader traffic (CDP responses,
-    // events, and window.slicc.emit); dispatch them in a dedicated method so
-    // this handler stays simple. Everything else is the leader controller WS.
-    const tags = this.state.getTags?.(ws) ?? [];
-    if (tags.includes(BRIDGE_WS_TAG)) {
-      await this.handleBridgeMessage(ws, message);
+    // events, and window.slicc.emit); the bridge relay owns that half.
+    // Everything else is the leader controller WS.
+    if (this.tagsFor(ws).includes(BRIDGE_WS_TAG)) {
+      await this.bridge.handleMessage(ws, message);
       return;
     }
 
-    // Leader socket: existing handler
     this.leaderSocket = ws;
     const data = typeof message === 'string' ? message : new TextDecoder().decode(message);
     await this.handleLeaderMessage(ws, data);
   }
 
-  /**
-   * Handle an inbound message on a bridge socket (a driveable-preview visitor
-   * tab). Parses defensively (untrusted third-party traffic) and relays CDP
-   * responses/events + attributed `window.slicc.emit()` events to the leader.
-   * Extracted from `webSocketMessage` to keep that dispatcher under the
-   * cognitive-complexity gate.
-   */
-  private async handleBridgeMessage(
-    ws: TrayWebSocketLike,
-    message: string | ArrayBuffer
-  ): Promise<void> {
-    if (!this.tray) {
-      await this.loadTray();
-    }
-    this.restoreLeaderSocket();
-    const { connId, previewToken } = (ws.deserializeAttachment?.() ?? {}) as {
-      connId?: string;
-      previewToken?: string;
-    };
-    // The attachment must carry the connId (set at accept time); without it we
-    // can't route the frame back to the right leader-side transport. Drop it.
-    if (!connId) return;
-    const data = typeof message === 'string' ? message : new TextDecoder().decode(message);
-    // Bridge sockets carry UNTRUSTED third-party visitor-tab traffic. A
-    // malformed / non-JSON frame must not throw out of this hibernatable handler
-    // (that would reset the DO and drop the tray). Silently drop invalid frames.
-    let msg: {
-      t?: string;
-      id: number;
-      result?: CDPPayload;
-      error?: { code: number; message: string };
-      name?: string;
-      detail?: unknown;
-    };
-    try {
-      msg = JSON.parse(data);
-    } catch {
-      return;
-    }
-
-    if (msg.t === 'cdp.res') {
-      this.sendToLeader({
-        type: 'bridge.cdp.response',
-        connId,
-        id: msg.id,
-        result: msg.result,
-        error: msg.error,
-      });
-    } else if (msg.t === 'emit') {
-      // window.slicc.emit() over the bridge WS. The DO knows the origin
-      // connection (connId + previewToken from the socket attachment), so it
-      // ATTRIBUTES the event: routed as the record's webhook.event with the
-      // preview identity in headers, so the cone knows which tab fired it (the
-      // matching drive target is `preview:<token>:<connId>`) and can tell a
-      // preview event apart from a plain webhook. Unattributed beacon emits (the
-      // page-unload fallback) go through handlePreviewEmit instead.
-      //
-      // Bound size + rate first: this is untrusted third-party traffic that
-      // lands verbatim in the agent's context.
-      if (data.length > MAX_BRIDGE_EMIT_BYTES) {
-        console.warn('[bridge] emit dropped: payload too large', {
-          connId,
-          previewToken,
-          bytes: data.length,
-        });
-        return;
-      }
-      if (!this.allowBridgeEmit(connId)) {
-        console.warn('[bridge] emit dropped: rate limit exceeded', { connId, previewToken });
-        return;
-      }
-      const record = previewToken ? this.tray?.previews?.[previewToken] : undefined;
-      if (record?.webhookId) {
-        const delivered = this.sendToLeader({
-          type: 'webhook.event',
-          webhookId: record.webhookId,
-          headers: {
-            'x-slicc-preview-conn': connId,
-            'x-slicc-preview-token': previewToken ?? '',
-          },
-          body: { name: msg.name, detail: msg.detail },
-          timestamp: new Date(this.now()).toISOString(),
-        });
-        // A WS frame has no response channel, so unlike the beacon path (which
-        // returns 502) we can't signal the page. Log the drop — this is the only
-        // trace when a live leader momentarily vanishes mid-session.
-        if (!delivered) {
-          console.warn('[bridge] emit dropped: no live leader', { connId, previewToken });
-        }
-      } else {
-        // No webhook to route to: the preview was revoked mid-flight (revoke
-        // deletes the webhook and closes sockets, but an in-flight frame can still
-        // arrive) or was never bridged with a provisioned webhook. The sibling
-        // beacon path returns 400 here; a WS frame can only be logged.
-        console.warn('[bridge] emit dropped: preview has no webhookId', {
-          connId,
-          previewToken,
-          hasRecord: Boolean(record),
-        });
-      }
-    }
-  }
-
-  /**
-   * Fixed-window rate limit for `window.slicc.emit()` frames from one bridge
-   * connection. Returns false (drop) once a connection exceeds
-   * MAX_BRIDGE_EMITS_PER_WINDOW within BRIDGE_EMIT_WINDOW_MS.
-   */
-  private allowBridgeEmit(connId: string): boolean {
-    const now = this.now();
-    const win = this.bridgeEmitWindows.get(connId);
-    if (!win || now - win.windowStart >= BRIDGE_EMIT_WINDOW_MS) {
-      this.bridgeEmitWindows.set(connId, { windowStart: now, count: 1 });
-      return true;
-    }
-    if (win.count >= MAX_BRIDGE_EMITS_PER_WINDOW) return false;
-    win.count += 1;
-    return true;
-  }
-
   async webSocketClose(ws: TrayWebSocketLike): Promise<void> {
-    const tags = this.state.getTags?.(ws) ?? [];
-    if (tags.includes(BRIDGE_WS_TAG)) {
-      await this.handleBridgeSocketGone(ws);
+    if (this.tagsFor(ws).includes(BRIDGE_WS_TAG)) {
+      await this.bridge.handleSocketGone(ws);
       return;
     }
-    // Leader socket: existing handler
     await this.handleLeaderSocketGone(ws);
   }
 
@@ -562,22 +389,6 @@ export class SessionTrayDurableObject {
     // A socket error ends the socket exactly like a close: same bridge/leader
     // teardown, so delegate rather than duplicate.
     await this.webSocketClose(ws);
-  }
-
-  /**
-   * A bridge visitor socket ended (close or error). Notify the leader so it
-   * drops the phantom `preview:` target, and evict the per-conn emit-rate window.
-   */
-  private async handleBridgeSocketGone(ws: TrayWebSocketLike): Promise<void> {
-    if (!this.tray) {
-      await this.loadTray();
-    }
-    this.restoreLeaderSocket();
-    const { connId } = (ws.deserializeAttachment?.() ?? {}) as { connId?: string };
-    if (connId) {
-      this.bridgeEmitWindows.delete(connId);
-      this.sendToLeader({ type: 'bridge.disconnected', connId });
-    }
   }
 
   // A close/error for the leader socket may be delivered after a newer leader
@@ -615,6 +426,26 @@ export class SessionTrayDurableObject {
       this.leaderSocket = socket;
     }
   }
+
+  private socketsWithTag(tag: string): TrayWebSocketLike[] {
+    return (this.state.getWebSockets?.(tag) ?? []) as TrayWebSocketLike[];
+  }
+
+  private tagsFor(ws: TrayWebSocketLike): string[] {
+    return this.state.getTags?.(ws) ?? [];
+  }
+
+  private ensureWebSocketAutoResponse(): void {
+    if (this.autoResponseSet) return;
+    if (typeof WebSocketRequestResponsePair !== 'undefined') {
+      this.state.setWebSocketAutoResponse?.(new WebSocketRequestResponsePair('ping', 'pong'));
+    }
+    this.autoResponseSet = true;
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Tray record lifecycle
+  // ──────────────────────────────────────────────────────────────────────
 
   private async handleCreate(request: Request): Promise<Response> {
     const payload = (await request.json()) as CreateTrayRequest;
@@ -676,9 +507,73 @@ export class SessionTrayDurableObject {
     );
   }
 
+  private async loadTray(): Promise<void> {
+    if (this.tray) {
+      return;
+    }
+    const storedTray = (await this.state.storage.get<TrayRecord>(TRAY_STORAGE_KEY)) ?? null;
+    this.tray = storedTray
+      ? {
+          ...storedTray,
+          bootstraps: storedTray.bootstraps ?? {},
+        }
+      : null;
+  }
+
+  private async persistTray(): Promise<void> {
+    if (!this.tray) {
+      return;
+    }
+    await this.state.storage.put(TRAY_STORAGE_KEY, this.tray);
+  }
+
+  private requireTray(): TrayRecord {
+    if (!this.tray) {
+      throw new Error('Tray not loaded');
+    }
+    return this.tray;
+  }
+
+  private async ensureTrayIsActive(): Promise<Response | null> {
+    const tray = this.requireTray();
+
+    if (tray.expiredAt) {
+      return jsonResponse({ error: 'Tray expired', code: 'TRAY_EXPIRED' }, 410);
+    }
+
+    if (tray.leader?.connected && !this.leaderSocket) {
+      tray.leader.connected = false;
+      tray.leader.disconnectedAt ??= this.isoNow();
+      await this.persistTray();
+    }
+
+    if (!tray.leader?.disconnectedAt || tray.leader.connected) {
+      return null;
+    }
+
+    const expiresAt = Date.parse(tray.leader.disconnectedAt) + reclaimMsForTray(tray);
+    if (this.now() <= expiresAt) {
+      return null;
+    }
+
+    tray.expiredAt = this.isoNow();
+    await this.persistTray();
+    return jsonResponse(
+      {
+        error: 'Tray expired because the leader did not reclaim it in time',
+        code: 'TRAY_EXPIRED',
+      },
+      410
+    );
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Join surface (followers and guests)
+  // ──────────────────────────────────────────────────────────────────────
+
   private async handleJoin(request: Request, token: string, url: URL): Promise<Response> {
     const tray = this.requireTray();
-    const joinRequest = request.method === 'POST' ? await this.readJoinRequest(request, url) : null;
+    const joinRequest = request.method === 'POST' ? await readJoinRequest(request, url) : null;
     // Single default-deny point for the whole join surface: either the tray's
     // own join token (full follower) or a live biscotto seat (guest). Anything
     // else — including a revoked or expired seat — is an invalid capability.
@@ -688,7 +583,7 @@ export class SessionTrayDurableObject {
     if (!capability) {
       if (joinRequest) {
         return await this.buildFollowerAttachResponse(
-          this.getJoinRequestControllerId(joinRequest),
+          joinRequestControllerId(joinRequest),
           {
             action: 'fail',
             code: 'INVALID_JOIN_CAPABILITY',
@@ -704,46 +599,20 @@ export class SessionTrayDurableObject {
     }
 
     // The leader abandoned this tray in favor of a fresh one (see
-    // `/internal/supersede` below) — this tray's leader socket will never
+    // `/internal/supersede` above) — this tray's leader socket will never
     // reconnect, so point the follower at the replacement instead of leaving
     // it to retry FOLLOWER_JOIN_NOT_READY / TRAY_EXPIRED forever. Checked
     // before the expiry gate: a superseded tray is a more actionable signal
     // than a generic expiry, and supersession can be set before expiry hits.
     if (tray.supersededByJoinUrl) {
-      const joinUrl = tray.supersededByJoinUrl;
-      const error = 'This session moved to a new tray after the leader reconnected';
-      // Step 1 of #1957: the status and body stay exactly as shipped clients
-      // parse them; the RFC 5829 `successor-version` link is the additive
-      // machine-readable form of the same redirect. Clients that don't know
-      // the rel ignore the header.
-      const linkHeaders = supersededLinkHeaders(joinUrl);
-      if (joinRequest) {
-        return await this.buildFollowerAttachResponse(
-          this.getJoinRequestControllerId(joinRequest),
-          { action: 'fail', code: 'TRAY_SUPERSEDED', error, joinUrl },
-          409,
-          undefined,
-          linkHeaders
-        );
-      }
-      return jsonResponse(
-        {
-          trayId: tray.trayId,
-          capability: 'join',
-          error,
-          code: 'TRAY_SUPERSEDED',
-          joinUrl,
-        },
-        409,
-        linkHeaders
-      );
+      return await this.supersededResponse(tray.supersededByJoinUrl, joinRequest);
     }
 
     const expiration = await this.ensureTrayIsActive();
     if (expiration) {
       if (joinRequest) {
         return await this.buildFollowerAttachResponse(
-          this.getJoinRequestControllerId(joinRequest),
+          joinRequestControllerId(joinRequest),
           {
             action: 'fail',
             code: 'TRAY_EXPIRED',
@@ -756,12 +625,21 @@ export class SessionTrayDurableObject {
     }
 
     if (joinRequest) {
-      if (this.isBootstrapRequest(joinRequest)) {
-        return this.handleBootstrapRequest(joinRequest);
+      if (isBootstrapRequest(joinRequest)) {
+        return this.bootstrap.handleRequest(joinRequest);
       }
       return this.handleFollowerAttach(joinRequest, capability);
     }
 
+    return this.handleJoinProbe(tray);
+  }
+
+  /**
+   * `GET /join/:token` — the pre-attach probe. Reports whether signaling can
+   * begin at all, so a follower does not open a peer connection against a tray
+   * whose leader has not connected yet.
+   */
+  private async handleJoinProbe(tray: TrayRecord): Promise<Response> {
     const payload = {
       trayId: tray.trayId,
       capability: 'join',
@@ -793,6 +671,41 @@ export class SessionTrayDurableObject {
     });
   }
 
+  /**
+   * The 409 that redirects a follower to the tray that replaced this one.
+   * Step 1 of #1957: the status and body stay exactly as shipped clients
+   * parse them; the RFC 5829 `successor-version` link is the additive
+   * machine-readable form of the same redirect. Clients that don't know the
+   * rel ignore the header.
+   */
+  private async supersededResponse(
+    joinUrl: string,
+    joinRequest: JoinRequest | null
+  ): Promise<Response> {
+    const error = 'This session moved to a new tray after the leader reconnected';
+    const linkHeaders = supersededLinkHeaders(joinUrl);
+    if (joinRequest) {
+      return await this.buildFollowerAttachResponse(
+        joinRequestControllerId(joinRequest),
+        { action: 'fail', code: 'TRAY_SUPERSEDED', error, joinUrl },
+        409,
+        undefined,
+        linkHeaders
+      );
+    }
+    return jsonResponse(
+      {
+        trayId: this.requireTray().trayId,
+        capability: 'join',
+        error,
+        code: 'TRAY_SUPERSEDED',
+        joinUrl,
+      },
+      409,
+      linkHeaders
+    );
+  }
+
   private async handleFollowerAttach(
     attach: ControllerAttachRequest,
     capability: JoinCapability
@@ -801,42 +714,13 @@ export class SessionTrayDurableObject {
       const tray = this.requireTray();
       this.pruneStaleControllers();
       const controllerId = attach.controllerId ?? crypto.randomUUID();
-      const nowIso = this.isoNow();
       const biscottoId = capability.trust === 'biscotto' ? capability.biscotto.id : undefined;
 
-      if (!tray.controllers[controllerId]) {
-        tray.controllers[controllerId] = {
-          controllerId,
-          firstSeenAt: nowIso,
-          lastSeenAt: nowIso,
-          runtime: attach.runtime,
-          biscottoId,
-        };
-      } else {
-        const known = tray.controllers[controllerId];
-        // `controllerId` is client-supplied. Trust is always re-derived from
-        // the presented token above; this only catches the case where the same
-        // id is replayed under a DIFFERENT capability. Rejecting both
-        // directions keeps a guest from inheriting a full follower's id (the
-        // attack) and a full follower from being shadowed by a guest that
-        // guessed its id (the denial).
-        if (known.biscottoId !== biscottoId) {
-          return jsonResponse(
-            {
-              error: 'Controller id was already attached with a different capability',
-              code: 'JOIN_CAPABILITY_MISMATCH',
-            },
-            409
-          );
-        }
-        known.lastSeenAt = nowIso;
-        if (attach.runtime) {
-          known.runtime = attach.runtime;
-        }
-      }
+      const mismatch = this.recordFollowerController(controllerId, attach.runtime, biscottoId);
+      if (mismatch) return mismatch;
 
       if (capability.trust === 'biscotto') {
-        capability.biscotto.lastSeenAt = nowIso;
+        capability.biscotto.lastSeenAt = this.isoNow();
       }
 
       let iceServers: TurnIceServer[] | undefined;
@@ -844,8 +728,8 @@ export class SessionTrayDurableObject {
         ? {
             action: 'signal',
             code: 'LEADER_CONNECTED',
-            bootstrap: this.buildBootstrapStatus(
-              await this.ensureBootstrap(controllerId, attach.runtime, biscottoId)
+            bootstrap: this.bootstrap.buildStatus(
+              await this.bootstrap.ensure(controllerId, attach.runtime, biscottoId)
             ),
           }
         : {
@@ -874,39 +758,101 @@ export class SessionTrayDurableObject {
     }
   }
 
-  private async handleBootstrapRequest(request: FollowerBootstrapRequest): Promise<Response> {
-    switch (request.action) {
-      case 'poll':
-        return this.handleBootstrapPoll(
-          request.controllerId,
-          request.bootstrapId,
-          request.cursor ?? 0
-        );
-      case 'answer':
-        return this.handleBootstrapAnswer(
-          request.controllerId,
-          request.bootstrapId,
-          request.answer
-        );
-      case 'ice-candidate':
-        return this.handleBootstrapIceCandidate(
-          request.controllerId,
-          request.bootstrapId,
-          request.candidate
-        );
-      case 'retry':
-        return this.handleBootstrapRetry(
-          request.controllerId,
-          request.bootstrapId,
-          request.runtime
-        );
-      default:
-        return jsonResponse(
-          { error: 'Invalid bootstrap request', code: 'INVALID_BOOTSTRAP_REQUEST' },
-          400
-        );
+  /**
+   * Upsert the controller record for an attaching follower, or return the 409
+   * that refuses a replayed `controllerId`.
+   *
+   * `controllerId` is client-supplied. Trust is always re-derived from the
+   * presented token by the caller; this only catches the case where the same
+   * id is replayed under a DIFFERENT capability. Rejecting both directions
+   * keeps a guest from inheriting a full follower's id (the attack) and a full
+   * follower from being shadowed by a guest that guessed its id (the denial).
+   */
+  private recordFollowerController(
+    controllerId: string,
+    runtime: string | undefined,
+    biscottoId: string | undefined
+  ): Response | null {
+    const tray = this.requireTray();
+    const nowIso = this.isoNow();
+    const known = tray.controllers[controllerId];
+    if (!known) {
+      tray.controllers[controllerId] = {
+        controllerId,
+        firstSeenAt: nowIso,
+        lastSeenAt: nowIso,
+        runtime,
+        biscottoId,
+      };
+      return null;
+    }
+    if (known.biscottoId !== biscottoId) {
+      return jsonResponse(
+        {
+          error: 'Controller id was already attached with a different capability',
+          code: 'JOIN_CAPABILITY_MISMATCH',
+        },
+        409
+      );
+    }
+    known.lastSeenAt = nowIso;
+    if (runtime) {
+      known.runtime = runtime;
+    }
+    return null;
+  }
+
+  private async buildFollowerAttachResponse(
+    controllerId: string,
+    result: FollowerAttachResult,
+    status = 200,
+    iceServers?: TurnIceServer[],
+    headers?: HeadersInit
+  ): Promise<Response> {
+    const tray = this.requireTray();
+    const payload: FollowerAttachResponse = {
+      trayId: tray.trayId,
+      controllerId,
+      role: 'follower',
+      trust: this.trustForController(controllerId),
+      leader: await this.leaderSummary(),
+      participantCount: Object.keys(tray.controllers).length,
+      result,
+    };
+    if (iceServers) {
+      payload.iceServers = iceServers;
+    }
+    return jsonResponse(payload, status, headers);
+  }
+
+  /**
+   * Advisory trust for a follower-facing response body, read back off the
+   * controller record stamped at attach time. Purely so a guest page can
+   * render itself honestly; the leader never reads this back.
+   */
+  private trustForController(controllerId: string): FollowerTrust {
+    return this.requireTray().controllers[controllerId]?.biscottoId ? 'biscotto' : 'full';
+  }
+
+  /**
+   * Remove controller entries whose `lastSeenAt` is older than the stale
+   * threshold. Never prunes the current leader's controller.
+   */
+  private pruneStaleControllers(): void {
+    const tray = this.requireTray();
+    const cutoff = new Date(this.now() - CONTROLLER_STALE_MS).toISOString();
+    const leaderControllerId = tray.leader?.controllerId;
+    for (const [id, controller] of Object.entries(tray.controllers)) {
+      if (id === leaderControllerId) continue;
+      if (controller.lastSeenAt < cutoff) {
+        delete tray.controllers[id];
+      }
     }
   }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Leader election + controller socket
+  // ──────────────────────────────────────────────────────────────────────
 
   private async handleControllerAttach(
     request: Request,
@@ -921,7 +867,7 @@ export class SessionTrayDurableObject {
       );
     }
 
-    const attach = await this.readAttachRequest(request, url);
+    const attach = await readAttachRequest(request, url);
     this.pruneStaleControllers();
     const controllerId = attach.controllerId ?? crypto.randomUUID();
     const nowIso = this.isoNow();
@@ -985,9 +931,7 @@ export class SessionTrayDurableObject {
       leader: await this.leaderSummary(),
       websocket:
         role === 'leader' && leaderKey
-          ? {
-              url: this.buildLeaderWebSocketUrl(url, controllerId, leaderKey),
-            }
+          ? { url: buildLeaderWebSocketUrl(url, controllerId, leaderKey) }
           : null,
     });
   }
@@ -1022,28 +966,7 @@ export class SessionTrayDurableObject {
       );
     }
     if (tray.leader.connected && this.leaderSocket) {
-      // We only reach here after the auth check above proved this is the
-      // ELECTED leader (matching controllerId + leaderKey) reconnecting. A
-      // stale `leaderSocket` therefore means the DO is still holding the
-      // previous leader connection — a ghost socket whose close never fired
-      // (workerd doesn't reliably deliver webSocketClose on a dropped/half-open
-      // socket, and a DO eviction can drop it entirely) or a superseded
-      // duplicate tab. 409-rejecting the rightful leader here deadlocks its
-      // reconnect (it retries the same session, exhausts its attempts, and the
-      // follower never gets a tray). Last key-holder wins: close the old socket
-      // and accept the new one. A DIFFERENT controller was already 403'd above,
-      // so this can never kick a leader that holds a different key.
-      // Null `this.leaderSocket` BEFORE close() so the stale socket's
-      // (possibly synchronous) webSocketClose fires as a no-op — its guard is
-      // `socket !== this.leaderSocket`, so it must not still point at the stale
-      // socket or it would clear the freshly-accepted leader below.
-      const staleSocket = this.leaderSocket;
-      this.leaderSocket = null;
-      try {
-        staleSocket.close(1000, 'superseded by leader reconnect');
-      } catch {
-        // Best-effort — the old socket may already be dead.
-      }
+      this.evictSupersededLeaderSocket();
     }
 
     const { client, server } = this.webSocketPairFactory();
@@ -1078,9 +1001,38 @@ export class SessionTrayDurableObject {
     // in-memory bridge registry. A leader page reload wipes that map while the
     // DO's bridge sockets stay open — without this, those tabs would be
     // permanently invisible and undriveable until each visitor reloaded.
-    this.replayBridgeConnectionsToLeader(server);
+    this.bridge.replayConnectionsToLeader(server);
 
     return websocketResponse(client);
+  }
+
+  /**
+   * Close the socket the rightful leader is replacing.
+   *
+   * Only reached after the auth check proved this is the ELECTED leader
+   * (matching controllerId + leaderKey) reconnecting. A stale `leaderSocket`
+   * therefore means the DO is still holding the previous leader connection — a
+   * ghost socket whose close never fired (workerd doesn't reliably deliver
+   * webSocketClose on a dropped/half-open socket, and a DO eviction can drop it
+   * entirely) or a superseded duplicate tab. 409-rejecting the rightful leader
+   * here deadlocks its reconnect (it retries the same session, exhausts its
+   * attempts, and the follower never gets a tray). Last key-holder wins. A
+   * DIFFERENT controller was already 403'd, so this can never kick a leader
+   * that holds a different key.
+   *
+   * Null `this.leaderSocket` BEFORE close() so the stale socket's (possibly
+   * synchronous) webSocketClose fires as a no-op — its guard is
+   * `socket !== this.leaderSocket`, so it must not still point at the stale
+   * socket or it would clear the freshly-accepted leader.
+   */
+  private evictSupersededLeaderSocket(): void {
+    const staleSocket = this.leaderSocket;
+    this.leaderSocket = null;
+    try {
+      staleSocket?.close(1000, 'superseded by leader reconnect');
+    } catch {
+      // Best-effort — the old socket may already be dead.
+    }
   }
 
   private replayPreviewStatesToLeader(leaderWs: TrayWebSocketLike): void {
@@ -1097,307 +1049,6 @@ export class SessionTrayDurableObject {
     }
   }
 
-  /**
-   * Send a `bridge.connected` for every live bridge socket to a specific leader
-   * socket. Metadata comes from the socket attachment stamped at accept time
-   * (connId / previewToken / origin / userAgent / connectedAt).
-   */
-  private replayBridgeConnectionsToLeader(leaderWs: TrayWebSocketLike): void {
-    const bridgeSockets = (this.state.getWebSockets?.(BRIDGE_WS_TAG) ?? []) as TrayWebSocketLike[];
-    for (const ws of bridgeSockets) {
-      const att = (ws.deserializeAttachment?.() ?? {}) as {
-        connId?: string;
-        previewToken?: string;
-        origin?: string;
-        userAgent?: string;
-        connectedAt?: string;
-      };
-      if (!att.connId || !att.previewToken) continue;
-      leaderWs.send(
-        JSON.stringify({
-          type: 'bridge.connected',
-          connId: att.connId,
-          previewToken: att.previewToken,
-          origin: att.origin ?? '',
-          userAgent: att.userAgent ?? '',
-          connectedAt: att.connectedAt ?? this.isoNow(),
-          replay: true,
-        })
-      );
-    }
-  }
-
-  private async handleBridgeWebSocket(previewToken: string, request: Request): Promise<Response> {
-    const record = await this.resolvePreview(previewToken);
-    if (!record?.bridge) {
-      return jsonResponse({ error: 'Bridge not enabled', code: 'BRIDGE_DISABLED' }, 403);
-    }
-    const existing = (this.state.getWebSockets?.(BRIDGE_WS_TAG) ?? []).filter((w) =>
-      this.state.getTags?.(w)?.includes(`tok:${previewToken}`)
-    );
-    if (existing.length >= (record.maxTabs ?? 20)) {
-      return jsonResponse({ error: 'Too many bridged tabs', code: 'BRIDGE_CAP' }, 429);
-    }
-    const { client, server } = this.webSocketPairFactory();
-    const connId = crypto.randomUUID();
-    this.state.acceptWebSocket!(server, [BRIDGE_WS_TAG, `tok:${previewToken}`, `conn:${connId}`]);
-    const origin = request.headers.get('origin') ?? '';
-    const userAgent = request.headers.get('user-agent') ?? '';
-    const connectedAt = this.isoNow();
-    server.serializeAttachment?.({ connId, previewToken, origin, userAgent, connectedAt });
-    this.ensureWebSocketAutoResponse();
-    server.send(JSON.stringify({ t: 'welcome', connId }));
-    // Ensure tray and leader socket are available before sending notification
-    await this.loadTray();
-    this.restoreLeaderSocket();
-    this.sendToLeader({
-      type: 'bridge.connected',
-      connId,
-      previewToken,
-      origin,
-      userAgent,
-      connectedAt,
-    });
-    return websocketResponse(client);
-  }
-
-  private ensureWebSocketAutoResponse(): void {
-    if (this.autoResponseSet) return;
-    if (typeof WebSocketRequestResponsePair !== 'undefined') {
-      this.state.setWebSocketAutoResponse?.(new WebSocketRequestResponsePair('ping', 'pong'));
-    }
-    this.autoResponseSet = true;
-  }
-
-  private async handleWebhook(
-    token: string,
-    request: Request,
-    webhookId?: string
-  ): Promise<Response> {
-    if (!this.matchesToken(token, this.requireTray().webhookToken)) {
-      return jsonResponse(
-        { error: 'Invalid webhook capability', code: 'INVALID_WEBHOOK_CAPABILITY' },
-        403,
-        {
-          'access-control-allow-origin': '*',
-        }
-      );
-    }
-
-    if (!webhookId) {
-      return jsonResponse(
-        {
-          error: 'Webhook ID is required. Use POST /webhook/{token}/{webhookId}',
-          code: 'WEBHOOK_ID_REQUIRED',
-        },
-        400,
-        { 'access-control-allow-origin': '*' }
-      );
-    }
-
-    if (!this.hasLiveLeader()) {
-      return jsonResponse(
-        {
-          error: 'No live leader is connected for this tray',
-          code: 'NO_LIVE_LEADER',
-        },
-        410,
-        { 'access-control-allow-origin': '*' }
-      );
-    }
-
-    // Read the request body
-    let body: unknown;
-    try {
-      const contentType = request.headers.get('content-type') ?? '';
-      if (contentType.includes('application/json')) {
-        body = await request.json();
-      } else {
-        const text = await request.text();
-        try {
-          body = JSON.parse(text);
-        } catch {
-          body = { raw: text };
-        }
-      }
-    } catch {
-      body = {};
-    }
-
-    // Collect relevant headers (skip Cloudflare-internal headers and host).
-    // Strip reserved `x-slicc-preview-*` headers: those are how the DO attributes
-    // a bridge-WS emit to a specific preview tab (rendered as a trusted "Preview
-    // Event"). Only the DO's own emit path may set them — a public webhook POST
-    // carrying them would otherwise forge tab attribution into the cone.
-    const headers: Record<string, string> = {};
-    for (const [key, value] of request.headers.entries()) {
-      if (key.startsWith('cf-') || key === 'host' || key.startsWith('x-slicc-preview-')) {
-        continue;
-      }
-      headers[key] = value;
-    }
-
-    // Forward to leader via the control WebSocket, asking for the disposition
-    // so a dropped delivery does not get a success receipt (issue #2524).
-    const deliveryId = `wd-${++this.webhookDeliveryCounter}-${this.now()}`;
-    const settled = new Promise<WebhookDeliveryDisposition | null>((resolve) => {
-      this.pendingWebhookDeliveries.set(deliveryId, resolve);
-    });
-    const sent = this.sendToLeader({
-      type: 'webhook.event',
-      webhookId,
-      headers,
-      body,
-      timestamp: this.isoNow(),
-      deliveryId,
-    });
-
-    if (!sent) {
-      this.pendingWebhookDeliveries.delete(deliveryId);
-      return jsonResponse(
-        {
-          error: 'Failed to forward webhook to leader',
-          code: 'LEADER_SEND_FAILED',
-        },
-        502,
-        { 'access-control-allow-origin': '*' }
-      );
-    }
-
-    const disposition = await this.awaitWebhookDelivery(deliveryId, settled);
-    return webhookDeliveryResponse(webhookId, disposition);
-  }
-
-  /**
-   * Wait out the leader's `webhook.delivery` for `deliveryId`, resolving `null`
-   * once {@link WEBHOOK_DELIVERY_WAIT_MS} passes. A leader that predates #2524
-   * never answers, so `null` must keep the pre-#2524 receipt: we know the event
-   * was forwarded, and nothing more.
-   */
-  private awaitWebhookDelivery(
-    deliveryId: string,
-    settled: Promise<WebhookDeliveryDisposition | null>
-  ): Promise<WebhookDeliveryDisposition | null> {
-    return Promise.race([
-      settled,
-      new Promise<null>((resolve) => setTimeout(() => resolve(null), this.webhookDeliveryWaitMs)),
-    ]).finally(() => this.pendingWebhookDeliveries.delete(deliveryId));
-  }
-
-  /**
-   * Leader→bridge: route a CDP request to the matching bridge socket by its
-   * `conn:<connId>` tag (indexed lookup, not an O(n) scan). When the visitor tab
-   * is gone (closed / revoked), fail the leader's pending call fast instead of
-   * letting it burn the full CDP timeout, so it can drop the phantom transport.
-   */
-  private relayCdpRequestToBridge(message: LeaderBridgeCdpRequest): void {
-    const target = (this.state.getWebSockets?.(`conn:${message.connId}`) ?? [])[0] as
-      | TrayWebSocketLike
-      | undefined;
-    if (!target) {
-      this.sendToLeader({
-        type: 'bridge.cdp.response',
-        connId: message.connId,
-        id: message.id,
-        error: { code: -32000, message: 'Preview bridge connection is gone' },
-      });
-      return;
-    }
-    target.send(
-      JSON.stringify({
-        t: 'cdp.req',
-        id: message.id,
-        method: message.method,
-        params: message.params,
-        sessionId: message.sessionId,
-      })
-    );
-  }
-
-  /** Hand a leader-reported disposition to the waiting webhook POST, if any. */
-  private settleWebhookDelivery(message: LeaderWebhookDelivery): void {
-    const resolve = this.pendingWebhookDeliveries.get(message.deliveryId);
-    if (!resolve) return;
-    this.pendingWebhookDeliveries.delete(message.deliveryId);
-    resolve(message.disposition);
-  }
-
-  private handleLeaderBootstrapOffer(
-    socket: TrayWebSocketLike,
-    message: LeaderToWorkerControlMessage & { type: 'bootstrap.offer' }
-  ): void {
-    const bootstrap = this.findBootstrap(message.controllerId, message.bootstrapId);
-    if (!bootstrap) {
-      socket.send(
-        JSON.stringify({
-          type: 'error',
-          code: 'BOOTSTRAP_NOT_FOUND',
-          bootstrapId: message.bootstrapId,
-        })
-      );
-      return;
-    }
-    this.refreshBootstrapState(bootstrap);
-    if (bootstrap.state !== 'failed') {
-      this.appendBootstrapEvent(bootstrap, {
-        type: 'bootstrap.offer',
-        offer: message.offer,
-      });
-      bootstrap.state = 'offered';
-      bootstrap.failure = null;
-    }
-  }
-
-  private handleLeaderBootstrapIceCandidate(
-    socket: TrayWebSocketLike,
-    message: LeaderToWorkerControlMessage & { type: 'bootstrap.ice_candidate' }
-  ): void {
-    const bootstrap = this.findBootstrap(message.controllerId, message.bootstrapId);
-    if (!bootstrap) {
-      socket.send(
-        JSON.stringify({
-          type: 'error',
-          code: 'BOOTSTRAP_NOT_FOUND',
-          bootstrapId: message.bootstrapId,
-        })
-      );
-      return;
-    }
-    this.refreshBootstrapState(bootstrap);
-    if (bootstrap.state !== 'failed') {
-      this.appendBootstrapEvent(bootstrap, {
-        type: 'bootstrap.ice_candidate',
-        candidate: message.candidate,
-      });
-    }
-  }
-
-  private handleLeaderBootstrapFailed(
-    socket: TrayWebSocketLike,
-    message: LeaderToWorkerControlMessage & { type: 'bootstrap.failed' }
-  ): void {
-    const bootstrap = this.findBootstrap(message.controllerId, message.bootstrapId);
-    if (!bootstrap) {
-      socket.send(
-        JSON.stringify({
-          type: 'error',
-          code: 'BOOTSTRAP_NOT_FOUND',
-          bootstrapId: message.bootstrapId,
-        })
-      );
-      return;
-    }
-    this.failBootstrap(bootstrap, {
-      code: message.code,
-      message: message.message,
-      retryable: message.retryable ?? this.canRetryBootstrap(bootstrap),
-      retryAfterMs:
-        message.retryable === false
-          ? null
-          : (message.retryAfterMs ?? TRAY_BOOTSTRAP_RETRY_AFTER_MS),
-    });
-  }
-
   private async handleLeaderMessage(socket: TrayWebSocketLike, raw: string): Promise<void> {
     if (socket !== this.leaderSocket || !this.tray?.leader) {
       return;
@@ -1410,48 +1061,7 @@ export class SessionTrayDurableObject {
       // Pure-relay branches mutate only `lastSeenAt`; everything else changes
       // persistent tray state and must flush. Tracked so the hot CDP-relay path
       // doesn't storage.put the whole record per command (see below).
-      let persistentMutation = true;
-
-      if (message.type === 'ping') {
-        socket.send(JSON.stringify({ type: 'pong', trayId: this.tray.trayId }));
-        persistentMutation = false;
-      } else if (message.type === 'bootstrap.offer') {
-        this.handleLeaderBootstrapOffer(socket, message);
-      } else if (message.type === 'bootstrap.ice_candidate') {
-        this.handleLeaderBootstrapIceCandidate(socket, message);
-      } else if (message.type === 'bootstrap.failed') {
-        this.handleLeaderBootstrapFailed(socket, message);
-      } else if (message.type === 'preview.response') {
-        pushPreviewResponseChunk(this.pendingPreviews, message as unknown as PreviewResponseChunk);
-        persistentMutation = false;
-      } else if (message.type === 'preview.state.update') {
-        const record = this.tray.previews?.[message.previewToken];
-        if (record) record.announced = message.announced;
-      } else if (message.type === 'preview.purge') {
-        await handlePreviewPurge(message.previewToken, this.previewDeps());
-      } else if (message.type === 'bridge.cdp.request') {
-        this.relayCdpRequestToBridge(message);
-        persistentMutation = false;
-      } else if (message.type === 'webhook.delivery') {
-        this.settleWebhookDelivery(message);
-        persistentMutation = false;
-      } else if (message.type === 'push.register') {
-        this.handlePushRegister(message);
-      } else if (message.type === 'push.send') {
-        await this.handlePushSend(message);
-        persistentMutation = false;
-      } else if (message.type === 'bridge.close') {
-        // Leader closed a preview target: close that visitor's bridge socket and
-        // tell the leader it's gone (a server-initiated close won't re-fire
-        // webSocketClose in workerd, so we can't rely on the close handler).
-        const target = (this.state.getWebSockets?.(`conn:${message.connId}`) ?? [])[0] as
-          | TrayWebSocketLike
-          | undefined;
-        this.bridgeEmitWindows.delete(message.connId);
-        this.sendToLeader({ type: 'bridge.disconnected', connId: message.connId });
-        target?.close(1000, 'closed by leader');
-        persistentMutation = false;
-      }
+      const persistentMutation = await this.dispatchLeaderMessage(socket, message);
 
       // Flush real state changes immediately; debounce liveness-only writes so a
       // busy CDP drive loop doesn't storage.put the tray record per command.
@@ -1469,6 +1079,61 @@ export class SessionTrayDurableObject {
     }
   }
 
+  /**
+   * Route one decoded leader control message to the concern that owns it.
+   * Returns whether the branch mutated persistent tray state — see
+   * {@link handleLeaderMessage} for why that matters.
+   */
+  private async dispatchLeaderMessage(
+    socket: TrayWebSocketLike,
+    message: LeaderToWorkerControlMessage
+  ): Promise<boolean> {
+    switch (message.type) {
+      case 'ping':
+        socket.send(JSON.stringify({ type: 'pong', trayId: this.requireTray().trayId }));
+        return false;
+      case 'bootstrap.offer':
+        this.bootstrap.onLeaderOffer(socket, message);
+        return true;
+      case 'bootstrap.ice_candidate':
+        this.bootstrap.onLeaderIceCandidate(socket, message);
+        return true;
+      case 'bootstrap.failed':
+        this.bootstrap.onLeaderFailed(socket, message);
+        return true;
+      case 'preview.response':
+        pushPreviewResponseChunk(this.pendingPreviews, message as unknown as PreviewResponseChunk);
+        return false;
+      case 'preview.state.update': {
+        const record = this.tray?.previews?.[message.previewToken];
+        if (record) record.announced = message.announced;
+        return true;
+      }
+      case 'preview.purge':
+        await handlePreviewPurge(message.previewToken, this.previewDeps());
+        return true;
+      case 'bridge.cdp.request':
+        this.bridge.relayCdpRequest(message);
+        return false;
+      case 'bridge.close':
+        this.bridge.closeConnection(message.connId);
+        return false;
+      case 'webhook.delivery':
+        this.webhooks.settle(message);
+        return false;
+      case 'push.register':
+        this.push.register(message);
+        return true;
+      case 'push.send':
+        await this.push.send(message);
+        return false;
+      default:
+        // Unknown message types still count as leader liveness, but there is
+        // nothing to persist.
+        return true;
+    }
+  }
+
   private async markLeaderDisconnected(socket: TrayWebSocketLike): Promise<void> {
     if (socket !== this.leaderSocket || !this.tray?.leader) {
       return;
@@ -1480,6 +1145,19 @@ export class SessionTrayDurableObject {
     this.tray.leader.lastSeenAt = this.tray.leader.disconnectedAt;
     failAllPendingPreviews(this.pendingPreviews);
     await this.persistTray();
+  }
+
+  private sendToLeader(message: WorkerToLeaderControlMessage): boolean {
+    if (!this.hasLiveLeader() || !this.leaderSocket) {
+      return false;
+    }
+
+    try {
+      this.leaderSocket.send(JSON.stringify(message));
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private hasLiveLeader(): boolean {
@@ -1542,824 +1220,20 @@ export class SessionTrayDurableObject {
     };
   }
 
-  private async handleBootstrapPoll(
-    controllerId: string | undefined,
-    bootstrapId: string | undefined,
-    cursor: number
-  ): Promise<Response> {
-    const bootstrap = this.findBootstrap(controllerId, bootstrapId);
-    if (!bootstrap) {
-      return jsonResponse({ error: 'Bootstrap not found', code: 'BOOTSTRAP_NOT_FOUND' }, 404);
-    }
-
-    this.refreshBootstrapState(bootstrap);
-    await this.persistTray();
-    return await this.buildFollowerBootstrapResponse(
-      bootstrap,
-      this.getBootstrapEventsAfter(bootstrap, cursor)
-    );
+  private createLeaderKey(): string {
+    return crypto.randomUUID();
   }
 
-  private async handleBootstrapAnswer(
-    controllerId: string | undefined,
-    bootstrapId: string | undefined,
-    answer: TraySessionDescription | undefined
-  ): Promise<Response> {
-    if (!this.isSessionDescription(answer, 'answer')) {
-      return jsonResponse(
-        { error: 'A valid bootstrap answer is required', code: 'INVALID_BOOTSTRAP_REQUEST' },
-        400
-      );
-    }
-
-    const bootstrap = this.findBootstrap(controllerId, bootstrapId);
-    if (!bootstrap) {
-      return jsonResponse({ error: 'Bootstrap not found', code: 'BOOTSTRAP_NOT_FOUND' }, 404);
-    }
-
-    this.refreshBootstrapState(bootstrap);
-    if (bootstrap.state === 'failed') {
-      await this.persistTray();
-      return await this.buildFollowerBootstrapResponse(bootstrap, [], 409);
-    }
-
-    if (
-      !this.sendToLeader({
-        type: 'bootstrap.answer',
-        trayId: this.requireTray().trayId,
-        controllerId: bootstrap.controllerId,
-        bootstrapId: bootstrap.bootstrapId,
-        answer,
-      })
-    ) {
-      this.failBootstrap(bootstrap, {
-        code: 'LEADER_NOT_CONNECTED',
-        message: 'Leader control channel is not connected',
-        retryable: this.canRetryBootstrap(bootstrap),
-        retryAfterMs: this.canRetryBootstrap(bootstrap) ? TRAY_BOOTSTRAP_RETRY_AFTER_MS : null,
-      });
-      await this.persistTray();
-      return await this.buildFollowerBootstrapResponse(bootstrap, [], 409);
-    }
-
-    bootstrap.state = 'connected';
-    bootstrap.failure = null;
-    bootstrap.updatedAt = this.isoNow();
-    await this.persistTray();
-    return await this.buildFollowerBootstrapResponse(bootstrap, []);
-  }
-
-  private async handleBootstrapIceCandidate(
-    controllerId: string | undefined,
-    bootstrapId: string | undefined,
-    candidate: TrayIceCandidate | undefined
-  ): Promise<Response> {
-    if (!this.isIceCandidate(candidate)) {
-      return jsonResponse(
-        { error: 'A valid ICE candidate is required', code: 'INVALID_BOOTSTRAP_REQUEST' },
-        400
-      );
-    }
-
-    const bootstrap = this.findBootstrap(controllerId, bootstrapId);
-    if (!bootstrap) {
-      return jsonResponse({ error: 'Bootstrap not found', code: 'BOOTSTRAP_NOT_FOUND' }, 404);
-    }
-
-    this.refreshBootstrapState(bootstrap);
-    if (bootstrap.state === 'failed') {
-      await this.persistTray();
-      return await this.buildFollowerBootstrapResponse(bootstrap, [], 409);
-    }
-
-    if (
-      !this.sendToLeader({
-        type: 'bootstrap.ice_candidate',
-        trayId: this.requireTray().trayId,
-        controllerId: bootstrap.controllerId,
-        bootstrapId: bootstrap.bootstrapId,
-        candidate,
-      })
-    ) {
-      this.failBootstrap(bootstrap, {
-        code: 'LEADER_NOT_CONNECTED',
-        message: 'Leader control channel is not connected',
-        retryable: this.canRetryBootstrap(bootstrap),
-        retryAfterMs: this.canRetryBootstrap(bootstrap) ? TRAY_BOOTSTRAP_RETRY_AFTER_MS : null,
-      });
-      await this.persistTray();
-      return await this.buildFollowerBootstrapResponse(bootstrap, [], 409);
-    }
-
-    bootstrap.updatedAt = this.isoNow();
-    await this.persistTray();
-    return await this.buildFollowerBootstrapResponse(bootstrap, []);
-  }
-
-  private async handleBootstrapRetry(
-    controllerId: string | undefined,
-    bootstrapId: string | undefined,
-    runtime: string | undefined
-  ): Promise<Response> {
-    const bootstrap = this.findBootstrap(controllerId, bootstrapId);
-    if (!bootstrap) {
-      return jsonResponse({ error: 'Bootstrap not found', code: 'BOOTSTRAP_NOT_FOUND' }, 404);
-    }
-
-    this.refreshBootstrapState(bootstrap);
-    if (
-      bootstrap.state !== 'failed' ||
-      !bootstrap.failure?.retryable ||
-      !this.canRetryBootstrap(bootstrap) ||
-      !this.hasLiveLeader()
-    ) {
-      await this.persistTray();
-      return await this.buildFollowerBootstrapResponse(bootstrap, [], 409);
-    }
-
-    this.pruneTerminalBootstraps();
-    const retried = this.createBootstrap(
-      bootstrap.controllerId,
-      runtime ?? bootstrap.runtime,
-      bootstrap.retryCount + 1,
-      bootstrap.maxRetries,
-      // Carry the seat forward: a retried bootstrap that dropped `biscottoId`
-      // would be announced to the leader as a full-trust follower.
-      bootstrap.biscottoId
-    );
-    this.requireTray().bootstraps[retried.bootstrapId] = retried;
-    const iceServers = await this.getIceServers();
-    this.notifyLeaderJoinRequested(retried, iceServers);
-    await this.persistTray();
-    return await this.buildFollowerBootstrapResponse(retried, []);
-  }
-
-  private async ensureBootstrap(
-    controllerId: string,
-    runtime: string | undefined,
-    biscottoId?: string
-  ): Promise<TrayBootstrapRecord> {
-    this.pruneTerminalBootstraps();
-    const existing = this.findBootstrap(controllerId);
-    // Reuse ONLY within the same capability. `controllerId` is client-supplied
-    // and a non-terminal bootstrap outlives its controller record
-    // (`pruneStaleControllers` prunes controllers, `pruneTerminalBootstraps`
-    // only reaps terminal bootstraps), so a guest presenting a pruned full
-    // follower's controllerId would otherwise adopt that follower's
-    // `biscottoId: undefined` bootstrap and be announced as `trust: 'full'` —
-    // straight past the allowlist. Mismatched capability ⇒ mint a fresh one.
-    if (existing && existing.biscottoId === biscottoId) {
-      this.refreshBootstrapState(existing);
-      return existing;
-    }
-
-    const bootstrap = this.createBootstrap(
-      controllerId,
-      runtime,
-      0,
-      TRAY_BOOTSTRAP_MAX_RETRIES,
-      biscottoId
-    );
-    this.requireTray().bootstraps[bootstrap.bootstrapId] = bootstrap;
-    const iceServers = await this.getIceServers();
-    this.notifyLeaderJoinRequested(bootstrap, iceServers);
-    return bootstrap;
-  }
-
-  private createBootstrap(
-    controllerId: string,
-    runtime: string | undefined,
-    retryCount = 0,
-    maxRetries = TRAY_BOOTSTRAP_MAX_RETRIES,
-    biscottoId?: string
-  ): TrayBootstrapRecord {
-    const createdAt = this.isoNow();
-    return {
-      controllerId,
-      bootstrapId: crypto.randomUUID(),
-      runtime,
-      attempt: retryCount + 1,
-      retryCount,
-      maxRetries,
-      createdAt,
-      updatedAt: createdAt,
-      expiresAt: new Date(this.now() + TRAY_BOOTSTRAP_TIMEOUT_MS).toISOString(),
-      state: 'pending',
-      failure: null,
-      events: [],
-      nextSequence: 1,
-      biscottoId,
-    };
-  }
-
-  private notifyLeaderJoinRequested(
-    bootstrap: TrayBootstrapRecord,
-    iceServers?: TurnIceServer[]
-  ): void {
-    const message: WorkerToLeaderControlMessage = {
-      type: 'follower.join_requested',
-      trayId: this.requireTray().trayId,
-      controllerId: bootstrap.controllerId,
-      runtime: bootstrap.runtime,
-      bootstrapId: bootstrap.bootstrapId,
-      attempt: bootstrap.attempt,
-      expiresAt: bootstrap.expiresAt,
-      // The leader's controller socket is the ONLY authenticated channel that
-      // can tell it what a peer is; the peer's own `hello` cannot be believed.
-      ...this.biscottoAnnouncement(bootstrap),
-    };
-    if (iceServers) {
-      (message as { iceServers?: TurnIceServer[] }).iceServers = iceServers;
-    }
-    this.sendToLeader(message);
-  }
-
-  /**
-   * Trust fields for a `follower.join_requested`. A bootstrap with no
-   * `biscottoId` is a full follower and gets `trust: 'full'` stated
-   * explicitly — silence would be ambiguous with an older hub.
-   *
-   * A seat that was revoked between attach and announcement resolves to no
-   * record; that announces as a biscotto with its stored id and empty label
-   * rather than falling back to `full`, because failing toward MORE trust here
-   * would turn a revocation race into a privilege escalation.
-   */
-  private biscottoAnnouncement(bootstrap: TrayBootstrapRecord): {
-    trust: FollowerTrust;
-    biscotto?: FollowerBiscottoIdentity;
-  } {
-    if (!bootstrap.biscottoId) return { trust: 'full' };
-    const record = (this.requireTray().biscotti ?? []).find(
-      (entry) => entry.id === bootstrap.biscottoId
-    );
-    return {
-      trust: 'biscotto',
-      biscotto: {
-        id: bootstrap.biscottoId,
-        label: record?.label ?? '',
-        expiresAt: record?.expiresAt,
-        gates: {
-          message: normalizeBiscottoGate(record?.gates.message),
-          tool: normalizeBiscottoGate(record?.gates.tool),
-        },
-      },
-    };
-  }
-
-  private sendToLeader(message: WorkerToLeaderControlMessage): boolean {
-    if (!this.hasLiveLeader() || !this.leaderSocket) {
-      return false;
-    }
-
-    try {
-      this.leaderSocket.send(JSON.stringify(message));
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private findBootstrap(controllerId?: string, bootstrapId?: string): TrayBootstrapRecord | null {
-    const tray = this.requireTray();
-    const values = Object.values(tray.bootstraps);
-
-    if (bootstrapId) {
-      const bootstrap = tray.bootstraps[bootstrapId] ?? null;
-      if (!bootstrap) {
-        return null;
-      }
-      return controllerId && bootstrap.controllerId !== controllerId ? null : bootstrap;
-    }
-
-    if (!controllerId) {
-      return null;
-    }
-
-    return (
-      values
-        .filter((bootstrap) => bootstrap.controllerId === controllerId)
-        .sort(
-          (left, right) =>
-            right.attempt - left.attempt || Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
-        )[0] ?? null
-    );
-  }
-
-  private refreshBootstrapState(bootstrap: TrayBootstrapRecord): void {
-    if (bootstrap.state === 'failed' || bootstrap.state === 'connected') {
-      return;
-    }
-
-    if (!this.hasLiveLeader()) {
-      this.failBootstrap(bootstrap, {
-        code: 'LEADER_NOT_CONNECTED',
-        message: 'Leader control channel disconnected before bootstrap completed',
-        retryable: this.canRetryBootstrap(bootstrap),
-        retryAfterMs: this.canRetryBootstrap(bootstrap) ? TRAY_BOOTSTRAP_RETRY_AFTER_MS : null,
-      });
-      return;
-    }
-
-    if (this.now() > Date.parse(bootstrap.expiresAt)) {
-      this.failBootstrap(bootstrap, {
-        code: 'BOOTSTRAP_TIMEOUT',
-        message: `Bootstrap attempt timed out after ${TRAY_BOOTSTRAP_TIMEOUT_MS}ms`,
-        retryable: this.canRetryBootstrap(bootstrap),
-        retryAfterMs: this.canRetryBootstrap(bootstrap) ? TRAY_BOOTSTRAP_RETRY_AFTER_MS : null,
-      });
-    }
-  }
-
-  private failBootstrap(
-    bootstrap: TrayBootstrapRecord,
-    failure: Omit<TrayBootstrapFailure, 'failedAt'> & { failedAt?: string }
-  ): void {
-    if (bootstrap.state === 'failed') {
-      return;
-    }
-
-    const failedAt = failure.failedAt ?? this.isoNow();
-    const normalizedFailure: TrayBootstrapFailure = {
-      ...failure,
-      failedAt,
-    };
-    bootstrap.state = 'failed';
-    bootstrap.failure = normalizedFailure;
-    bootstrap.expiresAt = failedAt;
-    this.appendBootstrapEvent(
-      bootstrap,
-      {
-        type: 'bootstrap.failed',
-        failure: normalizedFailure,
-      },
-      failedAt
-    );
-  }
-
-  private appendBootstrapEvent(
-    bootstrap: TrayBootstrapRecord,
-    event: TrayBootstrapEventInput,
-    sentAt = this.isoNow()
-  ): TrayBootstrapEvent {
-    const nextEvent = {
-      ...event,
-      sequence: bootstrap.nextSequence,
-      sentAt,
-    } as TrayBootstrapEvent;
-    bootstrap.nextSequence += 1;
-    bootstrap.updatedAt = sentAt;
-    bootstrap.events.push(nextEvent);
-    // Cap events to avoid unbounded growth from SDP payloads (KB each).
-    // The follower polls via cursor so only the tail matters, but the offer
-    // is only carried in the events stream — preserve it at the head so a
-    // burst of ICE candidates can't drop it and force a timeout+retry.
-    if (bootstrap.events.length > MAX_BOOTSTRAP_EVENTS) {
-      const offer = bootstrap.events.find((e) => e.type === 'bootstrap.offer');
-      const tailSize = offer ? MAX_BOOTSTRAP_EVENTS - 1 : MAX_BOOTSTRAP_EVENTS;
-      const tail = bootstrap.events.slice(-tailSize);
-      bootstrap.events = offer && !tail.includes(offer) ? [offer, ...tail] : tail;
-    }
-    return nextEvent;
-  }
-
-  private getBootstrapEventsAfter(
-    bootstrap: TrayBootstrapRecord,
-    cursor: number
-  ): TrayBootstrapEvent[] {
-    const normalizedCursor = Number.isFinite(cursor) ? Math.max(0, Math.trunc(cursor)) : 0;
-    return bootstrap.events.filter((event) => event.sequence > normalizedCursor);
-  }
-
-  private buildBootstrapStatus(bootstrap: TrayBootstrapRecord): TrayBootstrapStatus {
-    return {
-      controllerId: bootstrap.controllerId,
-      bootstrapId: bootstrap.bootstrapId,
-      attempt: bootstrap.attempt,
-      state: bootstrap.state,
-      expiresAt: bootstrap.expiresAt,
-      cursor: Math.max(0, bootstrap.nextSequence - 1),
-      maxRetries: bootstrap.maxRetries,
-      retriesRemaining: Math.max(0, bootstrap.maxRetries - bootstrap.retryCount),
-      retryAfterMs: bootstrap.failure?.retryable
-        ? (bootstrap.failure.retryAfterMs ?? TRAY_BOOTSTRAP_RETRY_AFTER_MS)
-        : null,
-      failure: bootstrap.failure,
-    };
-  }
-
-  private async buildFollowerBootstrapResponse(
-    bootstrap: TrayBootstrapRecord,
-    events: TrayBootstrapEvent[],
-    status = 200
-  ): Promise<Response> {
-    const tray = this.requireTray();
-    const iceServers = await this.getIceServers();
-    const payload: FollowerBootstrapResponse = {
-      trayId: tray.trayId,
-      controllerId: bootstrap.controllerId,
-      role: 'follower',
-      leader: await this.leaderSummary(),
-      participantCount: Object.keys(tray.controllers).length,
-      bootstrap: this.buildBootstrapStatus(bootstrap),
-      events,
-    };
-    if (iceServers) {
-      payload.iceServers = iceServers;
-    }
-    return jsonResponse(payload, status);
-  }
-
-  private canRetryBootstrap(bootstrap: TrayBootstrapRecord): boolean {
-    return bootstrap.retryCount < bootstrap.maxRetries;
-  }
-
-  /**
-   * Remove bootstrap records in a terminal state whose grace window has
-   * elapsed. Called opportunistically when bootstraps are mutated.
-   */
-  private pruneTerminalBootstraps(): void {
-    const tray = this.requireTray();
-    const nowMs = this.now();
-    for (const [id, bootstrap] of Object.entries(tray.bootstraps)) {
-      const isTerminal =
-        bootstrap.state === 'connected' ||
-        (bootstrap.state === 'failed' && !this.canRetryBootstrap(bootstrap));
-      if (!isTerminal) continue;
-      const deadlineMs = Date.parse(bootstrap.expiresAt) + BOOTSTRAP_TERMINAL_GRACE_MS;
-      if (nowMs > deadlineMs) {
-        delete tray.bootstraps[id];
-      }
-    }
-  }
-
-  /**
-   * Remove controller entries whose `lastSeenAt` is older than the stale
-   * threshold. Never prunes the current leader's controller.
-   */
-  private pruneStaleControllers(): void {
-    const tray = this.requireTray();
-    const cutoff = new Date(this.now() - CONTROLLER_STALE_MS).toISOString();
-    const leaderControllerId = tray.leader?.controllerId;
-    for (const [id, controller] of Object.entries(tray.controllers)) {
-      if (id === leaderControllerId) continue;
-      if (controller.lastSeenAt < cutoff) {
-        delete tray.controllers[id];
-      }
-    }
-  }
-
-  private async buildFollowerAttachResponse(
-    controllerId: string,
-    result: FollowerAttachResult,
-    status = 200,
-    iceServers?: TurnIceServer[],
-    headers?: HeadersInit
-  ): Promise<Response> {
-    const tray = this.requireTray();
-    const payload: FollowerAttachResponse = {
-      trayId: tray.trayId,
-      controllerId,
-      role: 'follower',
-      trust: this.trustForController(controllerId),
-      leader: await this.leaderSummary(),
-      participantCount: Object.keys(tray.controllers).length,
-      result,
-    };
-    if (iceServers) {
-      payload.iceServers = iceServers;
-    }
-    return jsonResponse(payload, status, headers);
-  }
-
-  private async ensureTrayIsActive(): Promise<Response | null> {
-    const tray = this.requireTray();
-
-    if (tray.expiredAt) {
-      return jsonResponse({ error: 'Tray expired', code: 'TRAY_EXPIRED' }, 410);
-    }
-
-    if (tray.leader?.connected && !this.leaderSocket) {
-      tray.leader.connected = false;
-      tray.leader.disconnectedAt ??= this.isoNow();
-      await this.persistTray();
-    }
-
-    if (!tray.leader?.disconnectedAt || tray.leader.connected) {
-      return null;
-    }
-
-    const expiresAt = Date.parse(tray.leader.disconnectedAt) + reclaimMsForTray(tray);
-    if (this.now() <= expiresAt) {
-      return null;
-    }
-
-    tray.expiredAt = this.isoNow();
-    await this.persistTray();
-    return jsonResponse(
-      {
-        error: 'Tray expired because the leader did not reclaim it in time',
-        code: 'TRAY_EXPIRED',
-      },
-      410
-    );
-  }
-
-  private async readJoinRequest(request: Request, url: URL): Promise<JoinRequest> {
-    const queryAttach: ControllerAttachRequest = {
-      controllerId: url.searchParams.get('controllerId') ?? undefined,
-      runtime: url.searchParams.get('runtime') ?? undefined,
-    };
-
-    if (request.method !== 'POST') {
-      return queryAttach;
-    }
-
-    const contentType = request.headers.get('content-type') ?? '';
-    if (!contentType.includes('application/json')) {
-      return queryAttach;
-    }
-
-    try {
-      const body = (await request.json()) as FollowerBootstrapBody;
-      const controllerId =
-        typeof body['controllerId'] === 'string' ? body['controllerId'] : queryAttach.controllerId;
-      const bootstrapId = typeof body['bootstrapId'] === 'string' ? body['bootstrapId'] : undefined;
-      const runtime = typeof body['runtime'] === 'string' ? body['runtime'] : queryAttach.runtime;
-
-      switch (body['action']) {
-        case 'poll':
-          return {
-            action: 'poll',
-            controllerId,
-            bootstrapId,
-            cursor: typeof body['cursor'] === 'number' ? body['cursor'] : undefined,
-          };
-        case 'answer':
-          return {
-            action: 'answer',
-            controllerId,
-            bootstrapId,
-            answer: body['answer'] as TraySessionDescription | undefined,
-          };
-        case 'ice-candidate':
-          return {
-            action: 'ice-candidate',
-            controllerId,
-            bootstrapId,
-            candidate: body['candidate'] as TrayIceCandidate | undefined,
-          };
-        case 'retry':
-          return {
-            action: 'retry',
-            controllerId,
-            bootstrapId,
-            runtime,
-          };
-      }
-
-      return {
-        controllerId:
-          typeof body?.['controllerId'] === 'string'
-            ? body['controllerId']
-            : queryAttach.controllerId,
-        runtime: typeof body?.['runtime'] === 'string' ? body['runtime'] : queryAttach.runtime,
-      };
-    } catch {
-      return queryAttach;
-    }
-  }
-
-  private async readAttachRequest(request: Request, url: URL): Promise<ControllerAttachRequest> {
-    const queryAttach: ControllerAttachRequest = {
-      controllerId: url.searchParams.get('controllerId') ?? undefined,
-      leaderKey: url.searchParams.get('leaderKey') ?? undefined,
-      runtime: url.searchParams.get('runtime') ?? undefined,
-    };
-
-    if (request.method !== 'POST') {
-      return queryAttach;
-    }
-
-    const contentType = request.headers.get('content-type') ?? '';
-    if (!contentType.includes('application/json')) {
-      return queryAttach;
-    }
-
-    try {
-      const body = (await request.json()) as ControllerAttachRequest;
-      return {
-        controllerId: body.controllerId ?? queryAttach.controllerId,
-        leaderKey: body.leaderKey ?? queryAttach.leaderKey,
-        runtime: body.runtime ?? queryAttach.runtime,
-      };
-    } catch {
-      return queryAttach;
-    }
-  }
-
-  private isBootstrapRequest(request: JoinRequest): request is FollowerBootstrapRequest {
-    return 'action' in request;
-  }
-
-  private getJoinRequestControllerId(request: JoinRequest): string {
-    return request.controllerId ?? crypto.randomUUID();
-  }
-
-  private isSessionDescription(
-    value: TraySessionDescription | undefined,
-    expectedType: TraySessionDescription['type']
-  ): value is TraySessionDescription {
-    return Boolean(value && value.type === expectedType && typeof value.sdp === 'string');
-  }
-
-  private isIceCandidate(value: TrayIceCandidate | undefined): value is TrayIceCandidate {
-    return Boolean(value && typeof value.candidate === 'string');
-  }
-
-  private buildLeaderWebSocketUrl(url: URL, controllerId: string, leaderKey: string): string {
-    const webSocketUrl = new URL(
-      url.pathname,
-      `${url.protocol === 'https:' ? 'wss:' : 'ws:'}//${url.host}`
-    );
-    webSocketUrl.searchParams.set('controllerId', controllerId);
-    webSocketUrl.searchParams.set('leaderKey', leaderKey);
-    return webSocketUrl.toString();
-  }
-
-  /**
-   * Advisory trust for a follower-facing response body, read back off the
-   * controller record stamped at attach time. Purely so a guest page can
-   * render itself honestly; the leader never reads this back.
-   */
-  private trustForController(controllerId: string): FollowerTrust {
-    return this.requireTray().controllers[controllerId]?.biscottoId ? 'biscotto' : 'full';
-  }
+  // ──────────────────────────────────────────────────────────────────────
+  // Shared primitives
+  // ──────────────────────────────────────────────────────────────────────
 
   private matchesToken(received: string, expected: string): boolean {
     return timingSafeEqual(received, expected);
   }
 
-  private createLeaderKey(): string {
-    return crypto.randomUUID();
-  }
-
-  private async loadTray(): Promise<void> {
-    if (this.tray) {
-      return;
-    }
-    const storedTray = (await this.state.storage.get<TrayRecord>(TRAY_STORAGE_KEY)) ?? null;
-    this.tray = storedTray
-      ? {
-          ...storedTray,
-          bootstraps: storedTray.bootstraps ?? {},
-        }
-      : null;
-  }
-
-  /**
-   * A follower registered a push token via the leader (issue #2062). The
-   * leader already validated the shape; re-check here because the DO is the
-   * trust boundary for what it stores. Bounded per tray; re-registering the
-   * same token just refreshes it.
-   */
-  private handlePushRegister(message: {
-    bootstrapId?: unknown;
-    platform?: unknown;
-    token?: unknown;
-    environment?: unknown;
-  }): void {
-    const tray = this.requireTray();
-    const token = typeof message.token === 'string' ? message.token.trim() : '';
-    if (message.platform !== 'ios' || !/^[0-9a-fA-F]{32,400}$/.test(token)) return;
-    const environment = message.environment === 'production' ? 'production' : 'sandbox';
-    const bootstrapId = typeof message.bootstrapId === 'string' ? message.bootstrapId : '';
-    tray.pushTokens ??= {};
-    tray.pushTokens[token] = {
-      platform: 'ios',
-      environment,
-      bootstrapId,
-      registeredAt: this.isoNow(),
-    };
-    const entries = Object.entries(tray.pushTokens);
-    if (entries.length > MAX_PUSH_TOKENS_PER_TRAY) {
-      const evict = entries
-        .sort((a, b) => a[1].registeredAt.localeCompare(b[1].registeredAt))
-        .slice(0, entries.length - MAX_PUSH_TOKENS_PER_TRAY);
-      for (const [dead] of evict) delete tray.pushTokens[dead];
-    }
-  }
-
-  /**
-   * Fan a leader push out to every registered device. Dead tokens (410 /
-   * BadDeviceToken) are forgotten and the record persisted; transport errors
-   * are logged and the token kept. Never throws into the leader socket loop.
-   */
-  private async handlePushSend(message: {
-    category?: unknown;
-    label?: unknown;
-    requestId?: unknown;
-  }): Promise<void> {
-    const tray = this.requireTray();
-    const tokens = Object.entries(tray.pushTokens ?? {});
-    if (tokens.length === 0) return;
-    if (!this.apns) {
-      if (!this.apnsDisabledLogged) {
-        this.apnsDisabledLogged = true;
-        console.warn('[push] APNs secrets not configured — push.send ignored', {
-          trayId: tray.trayId,
-        });
-      }
-      return;
-    }
-    const category = message.category === 'sudo_request' ? 'sudo_request' : 'turn_end';
-    if (message.category !== 'sudo_request' && message.category !== 'turn_end') return;
-    const label =
-      typeof message.label === 'string' && message.label.trim()
-        ? message.label.trim().slice(0, 80)
-        : 'SLICC';
-    const requestId =
-      typeof message.requestId === 'string' && message.requestId ? message.requestId : undefined;
-
-    const results = await Promise.all(
-      tokens.map(([token, record]) =>
-        this.apns!.send({
-          token,
-          environment: record.environment,
-          category,
-          label,
-          trayId: tray.trayId,
-          ...(requestId ? { requestId } : {}),
-        }).catch(
-          (err): ApnsPushResult => ({
-            token,
-            status: 0,
-            reason: err instanceof Error ? err.message : String(err),
-            dropToken: false,
-          })
-        )
-      )
-    );
-    let mutated = false;
-    for (const result of results) {
-      if (result.dropToken && this.forgetsPushToken(tray, result)) {
-        delete tray.pushTokens?.[result.token];
-        mutated = true;
-        continue;
-      }
-      if (result.status !== 200) {
-        console.warn('[push] APNs delivery failed', {
-          trayId: tray.trayId,
-          status: result.status,
-          reason: result.reason,
-          // Apple asks for this id when investigating a push that never landed.
-          ...(result.uniqueId ? { uniqueId: result.uniqueId } : {}),
-        });
-      }
-    }
-    if (mutated) await this.persistTray();
-  }
-
-  /** Mint-or-serve the shared APNs provider JWT. See `apns-provider-token.ts`. */
-  private handleApnsTokenRequest(request: Request): Promise<Response> {
-    if (request.method !== 'POST') {
-      return Promise.resolve(jsonResponse({ error: 'Method not allowed' }, 405));
-    }
-    if (!this.apnsTokenMinter) {
-      return Promise.resolve(
-        jsonResponse({ error: 'APNs is not configured', code: 'APNS_NOT_CONFIGURED' }, 503)
-      );
-    }
-    return handleProviderTokenRequest(request, this.apnsTokenMinter);
-  }
-
-  /**
-   * Should a dead-token verdict actually evict the registration? Apple's 410
-   * body carries the instant the token stopped being valid; a device that
-   * re-registered after that instant has a live token again and must be kept,
-   * or a reconnect race silently unsubscribes a phone that is right there.
-   * A 400 `BadDeviceToken` carries no timestamp and is unconditionally final.
-   */
-  private forgetsPushToken(tray: TrayRecord, result: ApnsPushResult): boolean {
-    if (result.invalidatedAtMs === undefined) return true;
-    const record = tray.pushTokens?.[result.token];
-    if (!record) return true;
-    const registeredAtMs = Date.parse(record.registeredAt);
-    if (!Number.isFinite(registeredAtMs)) return true;
-    return registeredAtMs < result.invalidatedAtMs;
-  }
-
-  private async persistTray(): Promise<void> {
-    if (!this.tray) {
-      return;
-    }
-    await this.state.storage.put(TRAY_STORAGE_KEY, this.tray);
-  }
-
-  private requireTray(): TrayRecord {
-    if (!this.tray) {
-      throw new Error('Tray not loaded');
-    }
-    return this.tray;
+  private isoNow(): string {
+    return new Date(this.now()).toISOString();
   }
 
   private async getIceServers(): Promise<TurnIceServer[] | undefined> {
@@ -2389,35 +1263,26 @@ export class SessionTrayDurableObject {
     }
   }
 
-  private isoNow(): string {
-    return new Date(this.now()).toISOString();
+  // ──────────────────────────────────────────────────────────────────────
+  // Push (APNs)
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** Mint-or-serve the shared APNs provider JWT. See `apns-provider-token.ts`. */
+  private handleApnsTokenRequest(request: Request): Promise<Response> {
+    if (request.method !== 'POST') {
+      return Promise.resolve(jsonResponse({ error: 'Method not allowed' }, 405));
+    }
+    if (!this.apnsTokenMinter) {
+      return Promise.resolve(
+        jsonResponse({ error: 'APNs is not configured', code: 'APNS_NOT_CONFIGURED' }, 503)
+      );
+    }
+    return handleProviderTokenRequest(request, this.apnsTokenMinter);
   }
 
-  private previewDeps(): PreviewDeps {
-    return {
-      loadTray: () => this.loadTray(),
-      getTray: () => this.tray,
-      persistTray: () => this.persistTray(),
-      isoNow: () => this.isoNow(),
-      hasLiveLeader: () => this.hasLiveLeader(),
-      sendToLeader: (msg) => this.sendToLeader(msg as WorkerToLeaderControlMessage),
-      matchesToken: (r, e) => this.matchesToken(r, e),
-      pendingPreviews: this.pendingPreviews,
-      now: () => this.now(),
-      archiveAvailable: () => this.previewStorage !== undefined,
-      deleteArchivePrefix: async (prefix) => {
-        if (!this.previewStorage) throw new Error('persistent preview storage unavailable');
-        await deletePreviewArchivePrefix(this.previewStorage, prefix);
-      },
-      scheduleExpiry: async (timestamp) => {
-        if (timestamp === null) {
-          await this.state.storage.deleteAlarm?.();
-        } else {
-          await this.state.storage.setAlarm?.(timestamp);
-        }
-      },
-    };
-  }
+  // ──────────────────────────────────────────────────────────────────────
+  // Previews
+  // ──────────────────────────────────────────────────────────────────────
 
   private async handleInternalPreviewRoute(url: URL, request: Request): Promise<Response | null> {
     // For the stop route, we need to close bridge sockets after the preview is revoked.
@@ -2433,119 +1298,11 @@ export class SessionTrayDurableObject {
       }
       const response = await dispatchPreviewRoute(url, request, this.previewDeps());
       if (response && response.status === 200 && previewToken) {
-        this.closeBridgeSocketsForPreview(previewToken);
+        this.bridge.closeSocketsForPreview(previewToken);
       }
       return response;
     }
     return dispatchPreviewRoute(url, request, this.previewDeps());
-  }
-
-  /**
-   * Leader-only `/internal/*` control routes reached through the DO stub, i.e.
-   * never from the public edge. Grouped into one dispatcher so adding a route
-   * costs a line here rather than another branch in `fetch`, which sits at the
-   * cognitive-complexity ceiling.
-   */
-  private async handleInternalRoute(url: URL, request: Request): Promise<Response | null> {
-    if (url.pathname === '/internal/supersede' && request.method === 'POST') {
-      return this.handleSupersede(request);
-    }
-    if (url.pathname.startsWith('/internal/biscotto/')) {
-      return this.handleInternalBiscottoRoute(url, request);
-    }
-    return null;
-  }
-
-  private biscottoDeps(): BiscottoDeps {
-    return {
-      loadTray: () => this.loadTray(),
-      getTray: () => this.tray,
-      persistTray: () => this.persistTray(),
-      isoNow: () => this.isoNow(),
-      now: () => this.now(),
-      matchesToken: (r, e) => this.matchesToken(r, e),
-    };
-  }
-
-  /**
-   * `/internal/biscotto/{mint,stop,list}` — the DO half of `biscotto-routes.ts`.
-   *
-   * Every branch reads the controller token out of the body and hands it to the
-   * lifecycle helper, which is what actually authenticates it. A thrown
-   * {@link BiscottoRouteError} carries the status; anything else is a 500 with
-   * no detail, so an internal failure never describes the tray to a caller that
-   * did not authenticate.
-   */
-  private async handleInternalBiscottoRoute(url: URL, request: Request): Promise<Response> {
-    if (request.method !== 'POST') {
-      return jsonResponse({ error: 'method not allowed' }, 405);
-    }
-    let body: {
-      controllerToken?: string;
-      label?: string;
-      id?: string;
-      ttlMs?: number;
-      gates?: Partial<BiscottoGates>;
-      workerBaseUrl?: string;
-    };
-    try {
-      body = (await request.json()) as typeof body;
-    } catch {
-      return jsonResponse({ error: 'invalid body' }, 400);
-    }
-    const controllerToken = typeof body.controllerToken === 'string' ? body.controllerToken : '';
-    try {
-      switch (url.pathname) {
-        case '/internal/biscotto/mint':
-          return jsonResponse(
-            await mintBiscottoImpl(
-              {
-                controllerToken,
-                label: body.label ?? '',
-                ttlMs: body.ttlMs,
-                gates: body.gates,
-                workerBaseUrl: body.workerBaseUrl ?? '',
-              },
-              this.biscottoDeps()
-            )
-          );
-        case '/internal/biscotto/stop': {
-          const revoked = await revokeBiscottoImpl(
-            { controllerToken, id: body.id ?? '' },
-            this.biscottoDeps()
-          );
-          // Tombstoning the token only stops future joins. A live guest holds a
-          // direct data channel to the leader that this DO cannot reach, so the
-          // eviction has to be delegated to the one process that can — and if
-          // that message did not land, the seat is revoked for FUTURE joins
-          // while whoever is already connected keeps their channel. Reporting
-          // plain success there would tell an owner the guest is out when they
-          // are not, so the outcome says which happened.
-          const evicted = this.sendToLeader({
-            type: 'biscotto.revoked',
-            trayId: this.requireTray().trayId,
-            biscottoId: revoked.id,
-          });
-          if (!evicted) {
-            console.warn('[tray] biscotto revoked but the leader could not be told', {
-              biscottoId: revoked.id,
-            });
-          }
-          return jsonResponse({ ...revoked, evicted });
-        }
-        case '/internal/biscotto/list':
-          return jsonResponse({
-            biscotti: await listBiscottiImpl({ controllerToken }, this.biscottoDeps()),
-          });
-        default:
-          return jsonResponse({ error: 'not found' }, 404);
-      }
-    } catch (error) {
-      if (error instanceof BiscottoRouteError) {
-        return jsonResponse({ error: error.message }, error.status);
-      }
-      return jsonResponse({ error: 'biscotto request failed' }, 500);
-    }
   }
 
   async mintPreview(req: {
@@ -2576,20 +1333,116 @@ export class SessionTrayDurableObject {
     await expirePersistentPreviews(this.previewDeps());
   }
 
-  private closeBridgeSocketsForPreview(previewToken: string): void {
-    for (const ws of (this.state.getWebSockets?.(BRIDGE_WS_TAG) ?? []) as TrayWebSocketLike[]) {
-      if (!this.state.getTags?.(ws)?.includes(`tok:${previewToken}`)) continue;
-      // A server-initiated `ws.close()` does NOT re-invoke webSocketClose in
-      // workerd, so notify the leader and evict per-conn state HERE. Otherwise the
-      // leader keeps a phantom `preview:` target that hangs every CDP call for the
-      // 30s timeout. (A duplicate bridge.disconnected, should webSocketClose also
-      // fire, is a harmless no-op on the leader's `if (!entry) return` path.)
-      const { connId } = (ws.deserializeAttachment?.() ?? {}) as { connId?: string };
-      if (connId) {
-        this.bridgeEmitWindows.delete(connId);
-        this.sendToLeader({ type: 'bridge.disconnected', connId });
-      }
-      ws.close(1000, 'preview revoked');
-    }
+  // ──────────────────────────────────────────────────────────────────────
+  // Biscotti (guest seats)
+  // ──────────────────────────────────────────────────────────────────────
+
+  /**
+   * Tell the leader to evict a guest whose seat was just revoked, reporting
+   * whether the message landed. Only the leader holds the guest's data
+   * channel, so this DO cannot end a live session on its own.
+   */
+  private announceBiscottoRevocation(biscottoId: string): boolean {
+    return this.sendToLeader({
+      type: 'biscotto.revoked',
+      trayId: this.requireTray().trayId,
+      biscottoId,
+    });
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Dependency seams
+  // ──────────────────────────────────────────────────────────────────────
+
+  private bootstrapDeps(): BootstrapDeps {
+    return {
+      requireTray: () => this.requireTray(),
+      persistTray: () => this.persistTray(),
+      now: () => this.now(),
+      isoNow: () => this.isoNow(),
+      hasLiveLeader: () => this.hasLiveLeader(),
+      sendToLeader: (msg) => this.sendToLeader(msg),
+      getIceServers: () => this.getIceServers(),
+      leaderSummary: () => this.leaderSummary(),
+    };
+  }
+
+  private bridgeDeps(): BridgeDeps {
+    return {
+      socketsWithTag: (tag) => this.socketsWithTag(tag),
+      tagsFor: (ws) => this.tagsFor(ws),
+      acceptWebSocket: (ws, tags) => {
+        if (typeof this.state.acceptWebSocket !== 'function') {
+          throw new Error('Durable Object runtime does not support WebSocket hibernation');
+        }
+        this.state.acceptWebSocket(ws, tags);
+      },
+      newWebSocketPair: () => this.webSocketPairFactory(),
+      ensureAutoResponse: () => this.ensureWebSocketAutoResponse(),
+      loadTray: () => this.loadTray(),
+      restoreLeaderSocket: () => this.restoreLeaderSocket(),
+      getTray: () => this.tray,
+      sendToLeader: (msg) => this.sendToLeader(msg),
+      resolvePreview: (token) => this.resolvePreview(token),
+      isoNow: () => this.isoNow(),
+      now: () => this.now(),
+    };
+  }
+
+  private webhookDeps(): WebhookDeps {
+    return {
+      requireTray: () => this.requireTray(),
+      matchesToken: (r, e) => this.matchesToken(r, e),
+      hasLiveLeader: () => this.hasLiveLeader(),
+      sendToLeader: (msg) => this.sendToLeader(msg as WorkerToLeaderControlMessage),
+      isoNow: () => this.isoNow(),
+      now: () => this.now(),
+    };
+  }
+
+  private pushDeps(): PushDeps {
+    return {
+      requireTray: () => this.requireTray(),
+      persistTray: () => this.persistTray(),
+      isoNow: () => this.isoNow(),
+      apns: this.apns,
+    };
+  }
+
+  private previewDeps(): PreviewDeps {
+    return {
+      loadTray: () => this.loadTray(),
+      getTray: () => this.tray,
+      persistTray: () => this.persistTray(),
+      isoNow: () => this.isoNow(),
+      hasLiveLeader: () => this.hasLiveLeader(),
+      sendToLeader: (msg) => this.sendToLeader(msg as WorkerToLeaderControlMessage),
+      matchesToken: (r, e) => this.matchesToken(r, e),
+      pendingPreviews: this.pendingPreviews,
+      now: () => this.now(),
+      archiveAvailable: () => this.previewStorage !== undefined,
+      deleteArchivePrefix: async (prefix) => {
+        if (!this.previewStorage) throw new Error('persistent preview storage unavailable');
+        await deletePreviewArchivePrefix(this.previewStorage, prefix);
+      },
+      scheduleExpiry: async (timestamp) => {
+        if (timestamp === null) {
+          await this.state.storage.deleteAlarm?.();
+        } else {
+          await this.state.storage.setAlarm?.(timestamp);
+        }
+      },
+    };
+  }
+
+  private biscottoDeps(): BiscottoDeps {
+    return {
+      loadTray: () => this.loadTray(),
+      getTray: () => this.tray,
+      persistTray: () => this.persistTray(),
+      isoNow: () => this.isoNow(),
+      now: () => this.now(),
+      matchesToken: (r, e) => this.matchesToken(r, e),
+    };
   }
 }

--- a/packages/cloudflare-worker/tests/session-tray-bootstrap.test.ts
+++ b/packages/cloudflare-worker/tests/session-tray-bootstrap.test.ts
@@ -1,0 +1,523 @@
+/**
+ * `BootstrapCoordinator` — the follower WebRTC signaling state machine
+ * extracted from the tray DO (issue #2674). Driven directly through its
+ * `BootstrapDeps` seam, so the error and retry paths that a full DO handshake
+ * never reaches are reachable here.
+ */
+
+import type {
+  TrayBootstrapEvent,
+  TurnIceServer,
+  WorkerToLeaderControlMessage,
+} from '@slicc/shared-ts';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { BootstrapCoordinator, type BootstrapDeps } from '../src/session-tray-bootstrap.js';
+import type { TrayBootstrapRecord, TrayRecord, TrayWebSocketLike } from '../src/shared.js';
+
+const NOW = Date.parse('2026-08-31T12:00:00.000Z');
+const ANSWER = { type: 'answer' as const, sdp: 'v=0' };
+const OFFER = { type: 'offer' as const, sdp: 'v=0' };
+const CANDIDATE = { candidate: 'candidate:1 1 udp 1 127.0.0.1 1 typ host' };
+
+interface Harness {
+  deps: BootstrapDeps;
+  coordinator: BootstrapCoordinator;
+  tray: TrayRecord;
+  sent: WorkerToLeaderControlMessage[];
+  persisted: number;
+  nowMs: number;
+  leaderLive: boolean;
+  leaderReachable: boolean;
+  iceServers: TurnIceServer[] | undefined;
+}
+
+function createTray(overrides: Partial<TrayRecord> = {}): TrayRecord {
+  return {
+    trayId: 'tray-1',
+    createdAt: new Date(NOW).toISOString(),
+    joinToken: 'tray-1.join',
+    controllerToken: 'tray-1.controller',
+    webhookToken: 'tray-1.webhook',
+    controllers: {},
+    bootstraps: {},
+    leader: null,
+    ...overrides,
+  };
+}
+
+function createHarness(tray = createTray()): Harness {
+  const harness: Harness = {
+    tray,
+    sent: [],
+    persisted: 0,
+    nowMs: NOW,
+    leaderLive: true,
+    // A live leader whose socket send still fails — the case that turns a
+    // signaling relay into a bootstrap failure.
+    leaderReachable: true,
+    iceServers: undefined,
+    deps: undefined as unknown as BootstrapDeps,
+    coordinator: undefined as unknown as BootstrapCoordinator,
+  };
+  harness.deps = {
+    requireTray: () => harness.tray,
+    persistTray: async () => {
+      harness.persisted += 1;
+    },
+    now: () => harness.nowMs,
+    isoNow: () => new Date(harness.nowMs).toISOString(),
+    hasLiveLeader: () => harness.leaderLive,
+    sendToLeader: (message) => {
+      if (!harness.leaderLive || !harness.leaderReachable) return false;
+      harness.sent.push(message);
+      return true;
+    },
+    getIceServers: async () => harness.iceServers,
+    leaderSummary: async () => null,
+  };
+  harness.coordinator = new BootstrapCoordinator(harness.deps);
+  return harness;
+}
+
+/** A socket that only records what the coordinator wrote to it. */
+function fakeSocket(): TrayWebSocketLike & { sent: string[] } {
+  const sent: string[] = [];
+  return {
+    sent,
+    send: (data: string) => sent.push(data),
+    close: () => {},
+  } as unknown as TrayWebSocketLike & { sent: string[] };
+}
+
+describe('BootstrapCoordinator.handleRequest', () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = createHarness();
+  });
+
+  it('rejects an unrecognized signaling action', async () => {
+    const response = await h.coordinator.handleRequest({ action: 'teleport' } as never);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ code: 'INVALID_BOOTSTRAP_REQUEST' });
+  });
+
+  it.each(['poll', 'answer', 'ice-candidate', 'retry'] as const)(
+    '404s a %s for a bootstrap that does not exist',
+    async (action) => {
+      const response = await h.coordinator.handleRequest({
+        action,
+        controllerId: 'ghost',
+        bootstrapId: 'nope',
+        answer: ANSWER,
+        candidate: CANDIDATE,
+      } as never);
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toMatchObject({ code: 'BOOTSTRAP_NOT_FOUND' });
+    }
+  );
+
+  it('400s an answer that is not a valid session description', async () => {
+    for (const answer of [undefined, OFFER, { type: 'answer' }]) {
+      const response = await h.coordinator.handleRequest({
+        action: 'answer',
+        controllerId: 'c1',
+        answer,
+      } as never);
+      expect(response.status).toBe(400);
+    }
+  });
+
+  it('400s an ICE candidate without a candidate string', async () => {
+    const response = await h.coordinator.handleRequest({
+      action: 'ice-candidate',
+      controllerId: 'c1',
+      candidate: {},
+    } as never);
+    expect(response.status).toBe(400);
+  });
+});
+
+describe('BootstrapCoordinator.ensure', () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = createHarness();
+  });
+
+  it('mints a bootstrap and announces a full-trust follower to the leader', async () => {
+    h.iceServers = [{ urls: ['turn:example'], username: 'u', credential: 'c' }];
+    const bootstrap = await h.coordinator.ensure('c1', 'ios');
+
+    expect(h.tray.bootstraps[bootstrap.bootstrapId]).toBe(bootstrap);
+    expect(bootstrap).toMatchObject({ state: 'pending', attempt: 1, retryCount: 0 });
+    expect(h.sent).toHaveLength(1);
+    expect(h.sent[0]).toMatchObject({
+      type: 'follower.join_requested',
+      controllerId: 'c1',
+      runtime: 'ios',
+      trust: 'full',
+      iceServers: h.iceServers,
+    });
+  });
+
+  it('reuses an open bootstrap for the same capability', async () => {
+    const first = await h.coordinator.ensure('c1', 'ios');
+    const second = await h.coordinator.ensure('c1', 'ios');
+    expect(second).toBe(first);
+    expect(h.sent).toHaveLength(1);
+  });
+
+  it('mints a fresh bootstrap when the same controllerId arrives under a different capability', async () => {
+    const full = await h.coordinator.ensure('c1', 'ios');
+    const guest = await h.coordinator.ensure('c1', 'ios', 'seat1');
+    expect(guest.bootstrapId).not.toBe(full.bootstrapId);
+    expect(guest.biscottoId).toBe('seat1');
+  });
+
+  it('announces a guest seat with its label and gates', async () => {
+    h.tray.biscotti = [
+      {
+        id: 'seat1',
+        token: 'tray-1.seat',
+        label: 'Anna',
+        createdAt: new Date(NOW).toISOString(),
+        expiresAt: new Date(NOW + 1000).toISOString(),
+        gates: { message: { approver: 'cone' }, tool: { approver: 'user' } },
+      },
+    ];
+    await h.coordinator.ensure('c1', 'ios', 'seat1');
+    expect(h.sent[0]).toMatchObject({
+      trust: 'biscotto',
+      biscotto: {
+        id: 'seat1',
+        label: 'Anna',
+        gates: { message: { approver: 'cone' }, tool: { approver: 'user' } },
+      },
+    });
+  });
+
+  it('still announces a seat revoked between attach and announcement as a guest, not as full trust', async () => {
+    await h.coordinator.ensure('c1', 'ios', 'vanished');
+    expect(h.sent[0]).toMatchObject({
+      trust: 'biscotto',
+      biscotto: { id: 'vanished', label: '' },
+    });
+  });
+});
+
+describe('BootstrapCoordinator signaling relay', () => {
+  let h: Harness;
+  let bootstrap: TrayBootstrapRecord;
+
+  beforeEach(async () => {
+    h = createHarness();
+    bootstrap = await h.coordinator.ensure('c1', 'ios');
+    h.sent.length = 0;
+  });
+
+  it('relays an answer and moves the bootstrap to connected', async () => {
+    const response = await h.coordinator.handleRequest({
+      action: 'answer',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+      answer: ANSWER,
+    });
+    expect(response.status).toBe(200);
+    expect(h.sent[0]).toMatchObject({ type: 'bootstrap.answer', answer: ANSWER });
+    expect(bootstrap.state).toBe('connected');
+  });
+
+  it('relays a trickled ICE candidate without completing the handshake', async () => {
+    const response = await h.coordinator.handleRequest({
+      action: 'ice-candidate',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+      candidate: CANDIDATE,
+    });
+    expect(response.status).toBe(200);
+    expect(h.sent[0]).toMatchObject({ type: 'bootstrap.ice_candidate', candidate: CANDIDATE });
+    expect(bootstrap.state).toBe('pending');
+  });
+
+  it('fails the bootstrap retryably when the leader send does not land', async () => {
+    h.leaderReachable = false;
+    const response = await h.coordinator.handleRequest({
+      action: 'answer',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+      answer: ANSWER,
+    });
+    expect(response.status).toBe(409);
+    expect(bootstrap.state).toBe('failed');
+    expect(bootstrap.failure).toMatchObject({ code: 'LEADER_NOT_CONNECTED', retryable: true });
+  });
+
+  it('409s further signaling once the bootstrap has failed', async () => {
+    h.leaderLive = false;
+    // The first poll notices the dead control channel and fails the record.
+    const failed = await h.coordinator.handleRequest({
+      action: 'poll',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+    });
+    expect(failed.status).toBe(200);
+    expect(bootstrap.state).toBe('failed');
+
+    const answer = await h.coordinator.handleRequest({
+      action: 'answer',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+      answer: ANSWER,
+    });
+    expect(answer.status).toBe(409);
+  });
+
+  it('fails an attempt that outlived its window', async () => {
+    h.nowMs = NOW + 10 * 60 * 1000;
+    await h.coordinator.handleRequest({
+      action: 'poll',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+    });
+    expect(bootstrap.failure).toMatchObject({ code: 'BOOTSTRAP_TIMEOUT' });
+  });
+});
+
+describe('BootstrapCoordinator.handleRequest retry', () => {
+  let h: Harness;
+  let bootstrap: TrayBootstrapRecord;
+
+  beforeEach(async () => {
+    h = createHarness();
+    bootstrap = await h.coordinator.ensure('c1', 'ios', 'seat1');
+    h.sent.length = 0;
+  });
+
+  it('409s a retry while the attempt is still open', async () => {
+    const response = await h.coordinator.handleRequest({
+      action: 'retry',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+    });
+    expect(response.status).toBe(409);
+  });
+
+  it('mints the next attempt and carries the guest seat forward', async () => {
+    h.leaderReachable = false;
+    await h.coordinator.handleRequest({
+      action: 'answer',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+      answer: ANSWER,
+    });
+    h.leaderReachable = true;
+
+    const response = await h.coordinator.handleRequest({
+      action: 'retry',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+      runtime: 'macos',
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { bootstrap: { attempt: number; bootstrapId: string } };
+    expect(body.bootstrap.attempt).toBe(2);
+    expect(body.bootstrap.bootstrapId).not.toBe(bootstrap.bootstrapId);
+    expect(h.tray.bootstraps[body.bootstrap.bootstrapId]).toMatchObject({
+      retryCount: 1,
+      runtime: 'macos',
+      biscottoId: 'seat1',
+    });
+    expect(h.sent.at(-1)).toMatchObject({ trust: 'biscotto', attempt: 2 });
+  });
+
+  it('refuses a retry once the leader is gone', async () => {
+    h.leaderLive = false;
+    await h.coordinator.handleRequest({
+      action: 'poll',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+    });
+    const response = await h.coordinator.handleRequest({
+      action: 'retry',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+    });
+    expect(response.status).toBe(409);
+  });
+
+  it('stops retrying once the attempt budget is spent', async () => {
+    const spent = await h.coordinator.ensure('c2', 'ios');
+    spent.retryCount = spent.maxRetries;
+    h.leaderReachable = false;
+    await h.coordinator.handleRequest({
+      action: 'answer',
+      controllerId: 'c2',
+      bootstrapId: spent.bootstrapId,
+      answer: ANSWER,
+    });
+    expect(spent.failure).toMatchObject({ retryable: false, retryAfterMs: null });
+    expect(h.coordinator.buildStatus(spent)).toMatchObject({
+      retriesRemaining: 0,
+      retryAfterMs: null,
+    });
+  });
+});
+
+describe('BootstrapCoordinator leader control messages', () => {
+  let h: Harness;
+  let bootstrap: TrayBootstrapRecord;
+  let socket: ReturnType<typeof fakeSocket>;
+
+  beforeEach(async () => {
+    h = createHarness();
+    bootstrap = await h.coordinator.ensure('c1', 'ios');
+    socket = fakeSocket();
+  });
+
+  it('records the leader offer and advances the state', () => {
+    h.coordinator.onLeaderOffer(socket, {
+      type: 'bootstrap.offer',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+      offer: OFFER,
+    });
+    expect(bootstrap.state).toBe('offered');
+    expect(bootstrap.events).toHaveLength(1);
+  });
+
+  it.each(['bootstrap.offer', 'bootstrap.ice_candidate', 'bootstrap.failed'] as const)(
+    'tells the leader when %s names a bootstrap that is gone',
+    (type) => {
+      const message = {
+        type,
+        controllerId: 'c1',
+        bootstrapId: 'vanished',
+        offer: OFFER,
+        candidate: CANDIDATE,
+        code: 'PEER_FAILED',
+        message: 'gone',
+      } as never;
+      if (type === 'bootstrap.offer') h.coordinator.onLeaderOffer(socket, message);
+      else if (type === 'bootstrap.ice_candidate')
+        h.coordinator.onLeaderIceCandidate(socket, message);
+      else h.coordinator.onLeaderFailed(socket, message);
+
+      expect(JSON.parse(socket.sent[0])).toMatchObject({
+        code: 'BOOTSTRAP_NOT_FOUND',
+        bootstrapId: 'vanished',
+      });
+    }
+  );
+
+  it('honours an explicit non-retryable failure from the leader', () => {
+    h.coordinator.onLeaderFailed(socket, {
+      type: 'bootstrap.failed',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+      code: 'PEER_UNSUPPORTED',
+      message: 'no webrtc',
+      retryable: false,
+    });
+    expect(bootstrap.failure).toMatchObject({ retryable: false, retryAfterMs: null });
+  });
+
+  it('ignores leader signaling for an already-failed bootstrap', () => {
+    h.leaderLive = false;
+    h.coordinator.onLeaderIceCandidate(socket, {
+      type: 'bootstrap.ice_candidate',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+      candidate: CANDIDATE,
+    });
+    // The refresh failed it; only the synthesized failure event was recorded.
+    expect(bootstrap.state).toBe('failed');
+    expect(bootstrap.events.map((event) => event.type)).toEqual(['bootstrap.failed']);
+  });
+
+  it('caps the event log but keeps the offer at the head', () => {
+    h.coordinator.onLeaderOffer(socket, {
+      type: 'bootstrap.offer',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+      offer: OFFER,
+    });
+    for (let i = 0; i < 40; i++) {
+      h.coordinator.onLeaderIceCandidate(socket, {
+        type: 'bootstrap.ice_candidate',
+        controllerId: 'c1',
+        bootstrapId: bootstrap.bootstrapId,
+        candidate: { candidate: `candidate:${i}` },
+      });
+    }
+    expect(bootstrap.events.length).toBeLessThanOrEqual(20);
+    expect(bootstrap.events[0]?.type).toBe('bootstrap.offer');
+  });
+});
+
+describe('BootstrapCoordinator record selection and pruning', () => {
+  it('resolves a controller to its highest attempt', async () => {
+    const h = createHarness();
+    const first = await h.coordinator.ensure('c1', 'ios');
+    first.state = 'failed';
+    first.failure = {
+      code: 'X',
+      message: 'x',
+      retryable: true,
+      retryAfterMs: 1,
+      failedAt: new Date(NOW).toISOString(),
+    };
+    const retried = await h.coordinator.handleRequest({
+      action: 'retry',
+      controllerId: 'c1',
+      bootstrapId: first.bootstrapId,
+    });
+    const body = (await retried.json()) as { bootstrap: { bootstrapId: string; attempt: number } };
+    expect(body.bootstrap.attempt).toBe(2);
+
+    // A poll that names only the controller must find the newest attempt.
+    const polled = await h.coordinator.handleRequest({ action: 'poll', controllerId: 'c1' });
+    const polledBody = (await polled.json()) as { bootstrap: { bootstrapId: string } };
+    expect(polledBody.bootstrap.bootstrapId).toBe(body.bootstrap.bootstrapId);
+  });
+
+  it('refuses a bootstrapId that belongs to a different controller', async () => {
+    const h = createHarness();
+    const bootstrap = await h.coordinator.ensure('c1', 'ios');
+    const response = await h.coordinator.handleRequest({
+      action: 'poll',
+      controllerId: 'someone-else',
+      bootstrapId: bootstrap.bootstrapId,
+    });
+    expect(response.status).toBe(404);
+  });
+
+  it('reaps terminal bootstraps once the grace window has passed', async () => {
+    const h = createHarness();
+    const bootstrap = await h.coordinator.ensure('c1', 'ios');
+    bootstrap.state = 'connected';
+    h.nowMs = NOW + 6 * 60 * 1000;
+    await h.coordinator.ensure('c2', 'ios');
+    expect(h.tray.bootstraps[bootstrap.bootstrapId]).toBeUndefined();
+  });
+
+  it('replays only the events after the follower cursor', async () => {
+    const h = createHarness();
+    const bootstrap = await h.coordinator.ensure('c1', 'ios');
+    const socket = fakeSocket();
+    for (let i = 0; i < 3; i++) {
+      h.coordinator.onLeaderIceCandidate(socket, {
+        type: 'bootstrap.ice_candidate',
+        controllerId: 'c1',
+        bootstrapId: bootstrap.bootstrapId,
+        candidate: { candidate: `candidate:${i}` },
+      });
+    }
+    const response = await h.coordinator.handleRequest({
+      action: 'poll',
+      controllerId: 'c1',
+      bootstrapId: bootstrap.bootstrapId,
+      cursor: 2,
+    });
+    const body = (await response.json()) as { events: TrayBootstrapEvent[] };
+    expect(body.events.map((event) => event.sequence)).toEqual([3]);
+  });
+});

--- a/packages/cloudflare-worker/tests/session-tray-requests.test.ts
+++ b/packages/cloudflare-worker/tests/session-tray-requests.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Request parsing / wire-shape guards extracted from the tray DO (issue #2674).
+ * These are pure, so they are tested directly rather than through a DO harness.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildLeaderWebSocketUrl,
+  isBootstrapRequest,
+  isIceCandidate,
+  isSessionDescription,
+  joinRequestControllerId,
+  readAttachRequest,
+  readJoinRequest,
+} from '../src/session-tray-requests.js';
+
+function jsonPost(body: unknown, url = 'https://hub.example/join/tok'): [Request, URL] {
+  return [
+    new Request(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    new URL(url),
+  ];
+}
+
+describe('readJoinRequest', () => {
+  it('reads controllerId and runtime from the query string on GET', async () => {
+    const url = new URL('https://hub.example/join/tok?controllerId=c1&runtime=ios');
+    const request = new Request(url.toString());
+    expect(await readJoinRequest(request, url)).toEqual({ controllerId: 'c1', runtime: 'ios' });
+  });
+
+  it('lets the JSON body override the query string', async () => {
+    const url = new URL('https://hub.example/join/tok?controllerId=fromQuery&runtime=web');
+    const request = new Request(url.toString(), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ controllerId: 'fromBody' }),
+    });
+    expect(await readJoinRequest(request, url)).toEqual({
+      controllerId: 'fromBody',
+      runtime: 'web',
+    });
+  });
+
+  it.each([
+    ['poll', { action: 'poll', controllerId: 'c1', bootstrapId: 'b1', cursor: 3 }],
+    ['retry', { action: 'retry', controllerId: 'c1', bootstrapId: 'b1', runtime: 'ios' }],
+  ])('narrows the %s signaling action', async (_action, body) => {
+    const parsed = await readJoinRequest(...jsonPost(body));
+    expect(isBootstrapRequest(parsed)).toBe(true);
+    expect(parsed).toMatchObject(body);
+  });
+
+  it('carries answer and candidate payloads through untouched', async () => {
+    const answer = { type: 'answer', sdp: 'v=0' };
+    const candidate = { candidate: 'candidate:1 1 udp' };
+    expect(await readJoinRequest(...jsonPost({ action: 'answer', answer }))).toMatchObject({
+      action: 'answer',
+      answer,
+    });
+    expect(
+      await readJoinRequest(...jsonPost({ action: 'ice-candidate', candidate }))
+    ).toMatchObject({ action: 'ice-candidate', candidate });
+  });
+
+  it('treats an unknown action as a plain attach', async () => {
+    const parsed = await readJoinRequest(...jsonPost({ action: 'teleport', controllerId: 'c1' }));
+    expect(isBootstrapRequest(parsed)).toBe(false);
+    expect(parsed).toEqual({ controllerId: 'c1', runtime: undefined });
+  });
+
+  it('ignores non-string fields rather than trusting the wire', async () => {
+    const parsed = await readJoinRequest(
+      ...jsonPost({ action: 'poll', controllerId: 42, bootstrapId: null, cursor: 'nope' })
+    );
+    expect(parsed).toMatchObject({
+      action: 'poll',
+      controllerId: undefined,
+      bootstrapId: undefined,
+      cursor: undefined,
+    });
+  });
+
+  it('degrades to the query-only attach for a malformed body', async () => {
+    const url = new URL('https://hub.example/join/tok?controllerId=c1');
+    const request = new Request(url.toString(), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{not json',
+    });
+    expect(await readJoinRequest(request, url)).toEqual({
+      controllerId: 'c1',
+      runtime: undefined,
+    });
+  });
+
+  it('ignores a body that is not declared as JSON', async () => {
+    const url = new URL('https://hub.example/join/tok');
+    const request = new Request(url.toString(), {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+      body: JSON.stringify({ action: 'poll', controllerId: 'c1' }),
+    });
+    expect(await readJoinRequest(request, url)).toEqual({
+      controllerId: undefined,
+      runtime: undefined,
+    });
+  });
+});
+
+describe('readAttachRequest', () => {
+  it('reads the leader key from the query string', async () => {
+    const url = new URL('https://hub.example/controller/tok?controllerId=c1&leaderKey=k1');
+    expect(await readAttachRequest(new Request(url.toString()), url)).toEqual({
+      controllerId: 'c1',
+      leaderKey: 'k1',
+      runtime: undefined,
+    });
+  });
+
+  it('prefers body fields but falls back to the query per field', async () => {
+    const url = new URL('https://hub.example/controller/tok?controllerId=c1&leaderKey=k1');
+    const request = new Request(url.toString(), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ leaderKey: 'k2', runtime: 'electron' }),
+    });
+    expect(await readAttachRequest(request, url)).toEqual({
+      controllerId: 'c1',
+      leaderKey: 'k2',
+      runtime: 'electron',
+    });
+  });
+
+  it('degrades to the query-only attach for a malformed body', async () => {
+    const url = new URL('https://hub.example/controller/tok?leaderKey=k1');
+    const request = new Request(url.toString(), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{',
+    });
+    expect(await readAttachRequest(request, url)).toMatchObject({ leaderKey: 'k1' });
+  });
+});
+
+describe('joinRequestControllerId', () => {
+  it('returns the supplied id', () => {
+    expect(joinRequestControllerId({ controllerId: 'c1' })).toBe('c1');
+  });
+
+  it('mints one when the request did not name a controller', () => {
+    const id = joinRequestControllerId({});
+    expect(id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});
+
+describe('wire-shape guards', () => {
+  it('accepts only a session description of the expected type', () => {
+    expect(isSessionDescription({ type: 'answer', sdp: 'v=0' }, 'answer')).toBe(true);
+    expect(isSessionDescription({ type: 'offer', sdp: 'v=0' }, 'answer')).toBe(false);
+    expect(isSessionDescription(undefined, 'answer')).toBe(false);
+    expect(isSessionDescription({ type: 'answer' } as never, 'answer')).toBe(false);
+  });
+
+  it('requires a string candidate', () => {
+    expect(isIceCandidate({ candidate: 'candidate:1' })).toBe(true);
+    expect(isIceCandidate({} as never)).toBe(false);
+    expect(isIceCandidate(undefined)).toBe(false);
+  });
+});
+
+describe('buildLeaderWebSocketUrl', () => {
+  it('upgrades https to wss and carries the leader credentials', () => {
+    const url = new URL('https://hub.example/controller/tok?ignored=1');
+    expect(buildLeaderWebSocketUrl(url, 'c1', 'k1')).toBe(
+      'wss://hub.example/controller/tok?controllerId=c1&leaderKey=k1'
+    );
+  });
+
+  it('uses ws for a plaintext origin', () => {
+    const url = new URL('http://localhost:8787/controller/tok');
+    expect(buildLeaderWebSocketUrl(url, 'c1', 'k1')).toBe(
+      'ws://localhost:8787/controller/tok?controllerId=c1&leaderKey=k1'
+    );
+  });
+});

--- a/packages/cloudflare-worker/tests/session-tray-webhook.test.ts
+++ b/packages/cloudflare-worker/tests/session-tray-webhook.test.ts
@@ -1,0 +1,224 @@
+/**
+ * `WebhookRelay` — the webhook forwarding + delivery-receipt half of the tray
+ * DO, extracted in issue #2674. Driven through its `WebhookDeps` seam so the
+ * disposition mapping from #2524 is asserted without standing up a leader.
+ */
+
+import type { WebhookDeliveryDisposition, WorkerToLeaderControlMessage } from '@slicc/shared-ts';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { type WebhookDeps, WebhookRelay } from '../src/session-tray-webhook.js';
+import type { TrayRecord } from '../src/shared.js';
+
+const NOW = Date.parse('2026-08-31T12:00:00.000Z');
+const TOKEN = 'tray-1.webhooksecret';
+
+interface Harness {
+  relay: WebhookRelay;
+  sent: WorkerToLeaderControlMessage[];
+  leaderLive: boolean;
+  leaderReachable: boolean;
+}
+
+function createTray(): TrayRecord {
+  return {
+    trayId: 'tray-1',
+    createdAt: new Date(NOW).toISOString(),
+    joinToken: 'tray-1.join',
+    controllerToken: 'tray-1.controller',
+    webhookToken: TOKEN,
+    controllers: {},
+    bootstraps: {},
+    leader: null,
+  };
+}
+
+function createHarness(waitMs = 20): Harness {
+  const harness: Harness = {
+    sent: [],
+    leaderLive: true,
+    leaderReachable: true,
+    relay: undefined as unknown as WebhookRelay,
+  };
+  const tray = createTray();
+  const deps: WebhookDeps = {
+    requireTray: () => tray,
+    // Plain equality stands in for the DO's timing-safe comparison.
+    matchesToken: (received, expected) => received === expected,
+    hasLiveLeader: () => harness.leaderLive,
+    sendToLeader: (message) => {
+      if (!harness.leaderReachable) return false;
+      harness.sent.push(message as WorkerToLeaderControlMessage);
+      return true;
+    },
+    isoNow: () => new Date(NOW).toISOString(),
+    now: () => NOW,
+  };
+  harness.relay = new WebhookRelay(deps, waitMs);
+  return harness;
+}
+
+function post(body: string, headers: Record<string, string> = {}): Request {
+  return new Request('https://hub.example/webhook/t/build-done', {
+    method: 'POST',
+    headers,
+    body,
+  });
+}
+
+/**
+ * Wait for the relay to forward the pending POST. `handle` reads the request
+ * body before sending, so a single microtask tick is not enough.
+ */
+async function forwarded(h: Harness, count = h.sent.length + 1): Promise<{ deliveryId: string }> {
+  for (let i = 0; i < 50 && h.sent.length < count; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return h.sent.at(-1) as unknown as { deliveryId: string };
+}
+
+/** Answer the relay's forwarded event with a disposition, as a live leader would. */
+async function ack(h: Harness, disposition: WebhookDeliveryDisposition): Promise<void> {
+  const { deliveryId } = await forwarded(h);
+  h.relay.settle({ type: 'webhook.delivery', deliveryId, disposition });
+}
+
+describe('WebhookRelay.handle', () => {
+  let h: Harness;
+  beforeEach(() => {
+    h = createHarness();
+  });
+
+  it('rejects a bad webhook capability', async () => {
+    const response = await h.relay.handle('wrong', post('{}'), 'build-done');
+    expect(response.status).toBe(403);
+    expect(response.headers.get('access-control-allow-origin')).toBe('*');
+    await expect(response.json()).resolves.toMatchObject({
+      code: 'INVALID_WEBHOOK_CAPABILITY',
+    });
+  });
+
+  it('requires a webhook id', async () => {
+    const response = await h.relay.handle(TOKEN, post('{}'), undefined);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ code: 'WEBHOOK_ID_REQUIRED' });
+  });
+
+  it('410s when no leader is connected', async () => {
+    h.leaderLive = false;
+    const response = await h.relay.handle(TOKEN, post('{}'), 'build-done');
+    expect(response.status).toBe(410);
+    await expect(response.json()).resolves.toMatchObject({ code: 'NO_LIVE_LEADER' });
+  });
+
+  it('502s when the leader socket refuses the send', async () => {
+    h.leaderReachable = false;
+    const response = await h.relay.handle(TOKEN, post('{}'), 'build-done');
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({ code: 'LEADER_SEND_FAILED' });
+  });
+
+  it('parses a JSON body and forwards it with the webhook id', async () => {
+    const pending = h.relay.handle(
+      TOKEN,
+      post(JSON.stringify({ ref: 'main' }), { 'content-type': 'application/json' }),
+      'build-done'
+    );
+    await forwarded(h);
+    expect(h.sent[0]).toMatchObject({
+      type: 'webhook.event',
+      webhookId: 'build-done',
+      body: { ref: 'main' },
+    });
+    expect((await pending).status).toBe(202);
+  });
+
+  it('parses an undeclared JSON body, and wraps anything else as raw text', async () => {
+    const parsed = h.relay.handle(TOKEN, post(JSON.stringify({ a: 1 })), 'build-done');
+    await forwarded(h);
+    expect(h.sent.at(-1)).toMatchObject({ body: { a: 1 } });
+    await ack(h, 'delivered');
+    await parsed;
+
+    const raw = h.relay.handle(TOKEN, post('hello there'), 'build-done');
+    await forwarded(h);
+    expect(h.sent.at(-1)).toMatchObject({ body: { raw: 'hello there' } });
+    await ack(h, 'delivered');
+    await raw;
+  });
+
+  it('strips cf-, host and reserved preview-attribution headers', async () => {
+    const pending = h.relay.handle(
+      TOKEN,
+      post('{}', {
+        'content-type': 'application/json',
+        'cf-connecting-ip': '1.2.3.4',
+        'x-slicc-preview-conn': 'forged',
+        'x-slicc-preview-token': 'forged',
+        'x-github-event': 'push',
+      }),
+      'build-done'
+    );
+    await forwarded(h);
+    const headers = (h.sent[0] as { headers: Record<string, string> }).headers;
+    expect(headers['x-github-event']).toBe('push');
+    expect(Object.keys(headers).some((key) => key.startsWith('x-slicc-preview-'))).toBe(false);
+    expect(headers['cf-connecting-ip']).toBeUndefined();
+    expect(headers['host']).toBeUndefined();
+    await ack(h, 'delivered');
+    await pending;
+  });
+});
+
+describe('WebhookRelay delivery receipts', () => {
+  it.each([
+    ['delivered', 202, true],
+    ['filtered', 202, true],
+  ] as const)('reports %s as %i', async (disposition, status, accepted) => {
+    const h = createHarness();
+    const pending = h.relay.handle(TOKEN, post('{}'), 'build-done');
+    await ack(h, disposition);
+    const response = await pending;
+    expect(response.status).toBe(status);
+    await expect(response.json()).resolves.toMatchObject({ accepted });
+  });
+
+  it('reports an unregistered webhook as 404 rather than a success', async () => {
+    const h = createHarness();
+    const pending = h.relay.handle(TOKEN, post('{}'), 'build-done');
+    await ack(h, 'unknown-webhook');
+    const response = await pending;
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      code: 'WEBHOOK_NOT_REGISTERED',
+    });
+  });
+
+  it('reports a dropped event as 422 rather than a success', async () => {
+    const h = createHarness();
+    const pending = h.relay.handle(TOKEN, post('{}'), 'build-done');
+    await ack(h, 'unresolved-target');
+    const response = await pending;
+    expect(response.status).toBe(422);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      code: 'WEBHOOK_TARGET_UNRESOLVED',
+    });
+  });
+
+  it('keeps the pre-#2524 202 when the leader never answers', async () => {
+    const h = createHarness(5);
+    const response = await h.relay.handle(TOKEN, post('{}'), 'build-done');
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({ ok: true, accepted: true });
+  });
+
+  it('ignores a disposition for a delivery that already settled', async () => {
+    const h = createHarness();
+    const pending = h.relay.handle(TOKEN, post('{}'), 'build-done');
+    await ack(h, 'delivered');
+    await pending;
+    // A duplicate ack must not throw or resolve anything a second time.
+    expect(() => ack(h, 'unknown-webhook')).not.toThrow();
+  });
+});


### PR DESCRIPTION
<!-- Closes #2674 — auto-closes on merge. -->

Closes #2674.

## Summary

Splits the 2,595-line `SessionTrayDurableObject` into a thin per-tray coordinator plus five collaborator modules behind `*Deps` seams. Behaviour is unchanged — the existing 535 cloudflare-worker tests pass **untouched**. `session-tray.ts` goes to **1,448 lines (−44%)**, with no resulting file above 600.

## Why

`packages/cloudflare-worker/src/session-tray.ts` was the largest genuine code file in the repo: one class with ~70 methods spanning a dozen tray-hub concerns (leader signaling, follower WebRTC bootstrap, preview-bridge CDP relay, webhook delivery, APNs push, TURN credentials, tray persistence), and heavily churned — ~30 commits in 4 months — so every contributor working on the hub paid the bloat again. The concerns are only weakly coupled: most communicate through the tray record and the leader socket.

The codebase already demonstrates the remediation. `session-tray-preview.ts` and `session-tray-biscotto.ts` take explicit dependencies instead of reaching into `this`, so they are unit-testable without a DO harness while the DO keeps thin delegation. This PR continues that decomposition, largest cluster first, as [#2674](https://github.com/ai-ecoverse/slicc/issues/2674) proposes. Same shape as the previously-filed-and-fixed #1679 (`tray-leader-sync.ts`) and #2019 (`kernel/facade.ts`).

## Approach / Implementation notes

**Layering.** Each new module owns its own state and reaches the DO only through an interface it declares. Nothing durable moved off the tray record, so hibernation semantics are untouched.

| New module | Owns |
|---|---|
| `session-tray-bootstrap.ts` — `BootstrapCoordinator` | Follower WebRTC signaling state machine: offer/answer/ICE relay, per-bootstrap event log + cursor, retry budget, terminal pruning, trust announcement. The biggest cluster (~24 methods). |
| `session-tray-bridge.ts` — `BridgeRelay` | Preview-bridge CDP relay, attributed `window.slicc.emit()`, per-connection emit size/rate bounds, socket replay and teardown. |
| `session-tray-webhook.ts` — `WebhookRelay` | Webhook forwarding plus the #2524 delivery-disposition receipts, owning the pending-delivery map and id counter. |
| `session-tray-push.ts` — `PushCoordinator` | APNs device registry (`push.register`) and fan-out (`push.send`), plus the dead-token eviction rule. |
| `session-tray-requests.ts` | Pure request parsing and wire-shape guards — `readJoinRequest`, `readAttachRequest`, `isSessionDescription`, `isIceCandidate`, `buildLeaderWebSocketUrl`. |

`dispatchBiscottoRoute` also moves into `session-tray-biscotto.ts`, mirroring `dispatchPreviewRoute`, so `handleInternalRoute` costs one line per concern.

The DO retains what is genuinely about *this tray as a whole*: the tray record and its persistence, leader election and the controller WebSocket (reclaim, staleness, last-key-holder-wins), the join/attach surface, and route dispatch.

**Three deliberate consolidations** — everything else is a move:

- `handleBootstrapAnswer` and `handleBootstrapIceCandidate` were near-identical; they now share `relayToLeader`, which branches on the built message type for the `answer`-only transition to `connected`.
- `handleLeaderMessage`'s if/else chain became a `switch` in `dispatchLeaderMessage` that *returns* whether the branch mutated persistent state, instead of threading a mutable `persistentMutation` flag through the body. The `LEADER_SEEN_PERSIST_MS` debounce on the hot CDP-relay path is byte-for-byte the same policy: real mutations flush immediately, pure-relay branches flush at most once per window.
- The two identical inline CORS-preflight header objects (join, webhook) became one `CORS_PREFLIGHT_HEADERS` constant.

**Rejected alternative.** Extracting the leader controller socket too (13 methods) would have shrunk the DO further, but that *is* the WebSocket lifecycle the issue explicitly asks the coordinator to retain, and it is the one cluster genuinely coupled to `state.acceptWebSocket` / `getWebSockets`.

**No new dependencies.** No wire-protocol, storage-shape or route changes — no migration.

## Cross-cutting impact

- **Floats exercised**: worker only. The DO's public surface (`fetch`, `webSocketMessage`/`Close`/`Error`, `alarm`, `mintPreview`/`resolvePreview`/`revokePreview`/`listPreviews`) is unchanged, so `src/index.ts`, `preview-worker.ts`, `biscotto-routes.ts` and `preview-routes.ts` needed no edits. Leader (webapp `scoops/tray-leader/`) and follower (iOS, slicc-cli, extension) wire formats are untouched.
- **Routes-mirror rule**: no routes added or removed, so the `index.ts` routes array and both routes-list assertions are unchanged.
- **Other callers of changed contracts**: none — every extracted method was `private`. No test file imported anything below `SessionTrayDurableObject`, which is why the existing suite needed no adaptation.
- **Persisted state**: none. `tray.bootstraps`, `tray.previews`, `tray.biscotti`, `tray.pushTokens` keep their shapes and their storage key.
- **Security-sensitive invariants preserved and now directly tested**: the reserved `x-slicc-preview-*` header strip on public webhook POSTs (forged tab attribution), the bridge emit size/rate bound on untrusted visitor traffic, the defensive JSON parse that must not throw out of a hibernatable handler, and the "a seat revoked between attach and announcement announces as `trust: 'biscotto'`, never falling back to `full`" escalation guard.
- **Bundle size**: worker-side only; no UI bundle impact.

## Test plan

- [x] `npx prettier --write <changed-files>` / `npx biome check --write` — clean
- [x] `npm run lint:ci` — pass
- [x] `npm run typecheck` — pass (all 9 projects, including the full-typecheck-only-at-release ones)
- [x] `npm run test` — **18,084 passing**, 52 skipped, no new failures
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run test:coverage:cloudflare-worker` — gate passes; package coverage **rises**
- [x] `npx wrangler deploy --dry-run --config packages/cloudflare-worker/wrangler.jsonc` — pass (25 MiB per-asset cap gate)
- [x] `check-touched-exemptions.mjs` (boy-scout debt gate) — pass; no new file is on any debt list
- [x] **New / changed behavior is covered by a unit test** in `packages/cloudflare-worker/tests/`

The 535 pre-existing worker tests are the primary safety net here and were **not modified**.

63 new cases exercise the extracted seams directly — the error, retry and failure paths a full DO handshake never reaches:

- `tests/session-tray-bootstrap.test.ts` (32) — unknown actions, not-found signaling, invalid SDP/candidate, failed-relay → retryable failure, retry budget exhaustion, guest-seat carry-forward across a retry, the revoked-seat escalation guard, event-cap-preserves-the-offer, cursor replay, terminal pruning, cross-controller `bootstrapId` refusal.
- `tests/session-tray-webhook.test.ts` (13) — the full #2524 disposition mapping (404 / 422 / 202), the no-answer fallback, header stripping, duplicate-ack idempotence.
- `tests/session-tray-requests.test.ts` (18) — query/body precedence, non-string field rejection, malformed-body degradation, `wss:`/`ws:` URL building.

Coverage, `packages/cloudflare-worker`:

| | before | after |
|---|---|---|
| statements | 88.61% | **89.75%** |
| branches | 79.53% | **81%** |
| functions | 94.47% | **95.09%** |
| `session-tray-bootstrap.ts` | 78.7% | **98.06%** |

**Pre-existing failures**: none.

## Documentation

- [x] Relevant `CLAUDE.md` — `packages/cloudflare-worker/CLAUDE.md` "Main Files" now maps `session-tray.ts` to its collaborators, and the Biscotti section notes the dispatcher moved.
- [x] `README.md` — not needed (no user-facing behavior change)
- [x] `docs/` — not needed (no tool, command or route change)

## Risk & rollback

- **Blast radius**: the tray hub worker only. A regression would surface as follower join / signaling failures, so the join and bootstrap paths are the ones to look hardest at in review.
- **Flags / kill switches**: none introduced.
- **Rollback**: revert this PR cleanly. No persisted state migration to undo, no wire-format change, so a rollback needs no follower coordination.
- **What CI cannot catch**: a real leader/follower WebRTC handshake against the deployed hub. CI covers signaling at the HTTP/message level, and the e2e leg does not stand up a real peer connection — worth a staging deploy (`--env staging`) plus one live follower join before production, per the `deploying-tray-worker` skill.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs — none changed
- [x] If this changes a contract used by other floats (CLI ↔ extension ↔ tray), I checked the followers/leader/offscreen paths — no contract changed; every extracted method was private

🤖 Generated with [Claude Code](https://claude.com/claude-code)
