### PR TITLE
chore(docs): compact CLAUDE.md guides for weekly headroom

### DIFF
--- a/docs/cloudflare-worker-details.md
+++ b/docs/cloudflare-worker-details.md
@@ -98,6 +98,10 @@ start/resume flows:
 - **25 MiB per-asset cap:** Cloudflare rejects any `dist/ui/` file over 25 MiB; the CI
   `cloudflare-worker` job runs `npm run build -w @slicc/cloudflare-worker`
   (`wrangler deploy --dry-run`) as a hard gate.
+- **`Document-Isolation-Policy: isolate-and-credentialless`** is set on non-cherry,
+  non-electron SPA responses — per-document cross-origin isolation (SharedArrayBuffer
+  for vpod guest networking) without COOP/COEP. The cherry and electron branches must
+  stay header-free: they are always embedded and never need SAB.
 - `ASSET_ARCHIVE` (R2) retains hashed `/assets/*` across deploys;
   `serveAssetWithArchiveFallback` tries `ASSETS`, then R2, then stale-asset reload;
   bucket GC is 14 days.

--- a/docs/dev-tools-details.md
+++ b/docs/dev-tools-details.md
@@ -580,3 +580,74 @@ Reaping semantics (also enforced in the harness scripts):
 
 Labeled Chrome bundle clones (`clone-labeled-chrome.sh`) provide
 distinct ⌘-Tab entries.
+
+## ios-ui-test-exclusion-registry
+
+`npm run lint:ios-ui-tests`
+(`packages/dev-tools/tools/ios-ui-test-exclusions.mjs` +
+`packages/ios-app/ui-test-exclusions.json`) exists because the
+`ios-app-tests` CI job runs the WHOLE `SliccFollowerUITests` bundle on
+the GA cells and then subtracts this registry, so a newly added test
+class is gated the day it lands rather than needing to be opted in. The
+gate rejects a registry entry that has no reason, or one naming a
+class/method that no longer exists in the bundle.
+
+## swiftpm-lockfile-drift-gate
+
+`packages/dev-tools/tools/check-swift-resolved-drift.mjs` runs AFTER a
+resolve step (the `ios-app` CI job).
+`xcodebuild -resolvePackageDependencies` rewrites `Package.resolved` in
+place and then builds against what it wrote, so a floated **transitive**
+pin lands with no diff; `lint:swift-pins` only inspects direct pins. The
+gate compares identity/version/revision while ignoring `originHash` and
+key order (both move with the toolchain), catching the transitive drift
+`lint:swift-pins` cannot see.
+
+## source-guards
+
+Source-shape guards under `packages/dev-tools/tools/`, each wired to its
+own lint script:
+
+- `check-no-innerhtml.mjs` (`npm run lint:no-innerhtml`) bans
+  `.innerHTML =`, `.outerHTML =`, and `insertAdjacentHTML()` in
+  `@slicc/webcomponents` (stories/tests exempt).
+- `check-no-ui-imports-in-providers.mjs`
+  (`npm run lint:no-ui-in-providers`) bans `from '…ui/…'` imports in
+  `providers/built-in/`.
+- `check-hosted-origin-literal.mjs` — TS must import
+  `SLICC_HOSTED_ORIGIN` from `@slicc/shared-ts` rather than hardcoding
+  the origin.
+- `check-no-raw-chrome-runtime-id.mjs` — use `isChromeExtensionRealm()`
+  from `@slicc/shared-ts` instead of a raw `chrome.runtime.id` check
+  (tests exempt).
+- `check-agents-symlinks.mjs` — every `packages/*/CLAUDE.md` needs an
+  `AGENTS.md` sibling symlink.
+
+## first-load-size-gate
+
+`packages/dev-tools/tools/check-first-load-size.mjs` (+
+`first-load-size-lib.mjs`, `first-load-baseline.mjs`), part of
+`npm run size -w @slicc/webapp`, measures the eager import closures of
+the page entry (via `.vite/manifest.json`) and the kernel-worker entry
+(parsed from emitted chunks). It guards cold-boot payload, not per-file
+size.
+
+It is **relative**: it builds the merge-base in a throwaway worktree
+(workspace packages re-pointed at the worktree's own source, then the
+root `postinstall` prerequisite builds — borrowing the caller's build
+would mask a webcomponents-side regression) and fails on a change's own
+growth past `maxDeltaKb`, so it never fires on inherited state and
+cancels the ~1 kB Linux-vs-macOS build difference. Flags:
+`--baseline=<ref>` (default `origin/main`), `--baseline=none` to skip,
+`--json` to just measure.
+
+On `merge_group` the delta is skipped — a queue branch is cumulative, so
+its delta is the batch sum and a per-change allowance would fail on
+queue depth; only the ceilings run, with no baseline build. That split
+is only safe because a CI `pull_request` run treats an unmeasurable
+baseline as a hard failure rather than degrading, so a PR can never
+clear both stages unmeasured. Local runs still degrade to ceilings with
+a note. The absolute `*EagerCeilingKb` values in
+`packages/webapp/first-load-budget.json` are the backstop against many
+small under-threshold changes creeping upward — human-owned, not
+numbers to nudge when a build goes red.

--- a/docs/ios-app-details.md
+++ b/docs/ios-app-details.md
@@ -36,6 +36,14 @@ iCloud discovery only covers what the macOS launcher advertises, so a join URL p
 
 Display is `ICloudSessionList.recentRows`: trays the live iCloud list already shows are filtered out by the shared one-way id (one tray, one row), then `RecentJoinStore.rank` sorts reachable-first, newest-connected second, and caps at five — the cap after the ranking, so a session that still answers can displace a fresher dead one. Rows render the label, or the host when a pasted URL has none; the path carries the session secret and never reaches the screen. Swipe-to-Remove and Clear Stored Data clear only this device's key, so a row another device recorded can sync back. Both lists probe on `onAppear` **and** on store change: iCloud can push a row in while the sheet is open, and an unprobed id counts as presumed-reachable, so it would sort above known-live rows and hide its "not responding" note until the sheet was reopened.
 
+## Terminal
+
+`InMemoryTerminalSession` + `TerminalClient` exec against the leader shell (`hello.capabilities.exec`); one virtual shell per connection, Ctrl-C → `SIGINT` until `exec.response`.
+
+## Push to talk
+
+Hold the empty composer to dictate (`PttController` + `SFSpeechRecognizer`); release calls `InputBar.submit(_:dictated:)`. Only dictated replies speak (English → Kokoro, else `AVSpeechSynthesizer`; typed turns stay silent). `AudioSessionCoordinator` solely owns `AVAudioSession`. UI-test hooks `-uiTestSpeechPermission/Script`, `-uiTestPttStage`.
+
 ## Local Kokoro models
 
 Settings downloads the anonymous, revision-pinned ~83 MB Hugging Face pack after Wi-Fi consent with progress, cancel, retry, and removal; replies never provision. Pack: nine CoreML stages, two vocabularies, `af_heart`. Marker/cache delete together; weights are not committed. Live-simulator QA: [`docs/ios-simulator-qa.md`](ios-simulator-qa.md).
@@ -272,6 +280,17 @@ Outputs land in `.build/coverage/`. The gate runs only `SliccFollowerTests`, dis
 - **Sharding across the matrix was tried and is not worth it.** Observed on a full run: a GA cell is **26-28 min** for the whole bundle (iPhone also carries the unit suite), and the two run concurrently, so the iOS legs cost ~28 min of wall clock. Roughly 10 min of that is the build, and the build is paid **per cell** — so a 4-way split trades ~15 min of test time for three extra builds, and the `macos-latest` pool is shared with the seven `swift-*` jobs anyway (peak 4 concurrent), so eight cells queue in waves. It worked out to ~38 min wall clock for ~152 runner-minutes against ~84. If this ever does need to come down, the lever is fewer builds, not more cells: `build-for-testing` once plus `test-without-building` per cell. (And beware measuring pool concurrency from one job's cells alone — that reads its _share_ of a contended pool, not the pool.)
 - **Getting a test out of CI** means adding it to that registry with a written reason, and an issue if it is debt rather than a permanent runner limitation. `npm run lint:ios-ui-tests` rejects an entry naming a class or method that no longer exists, so the escape hatch cannot rot into suppressing nothing. Currently excluded: `ComposerKeyboardUITests` (drives `typeKey`, needs a hardware keyboard), two `FixtureConversationUITests` cases that fail on main, and `InboundActionsUITests`.
 - **The unit suite dirties the simulator for the UI suite.** `InboundActionsUITests` passes on a clean device and fails once `SliccFollowerTests` has run there — which is why it is red on the iPhone GA cell (coverage step then UI step, same simulator), green on iPad (no unit step), and green on any developer Mac running the UI bundle alone. The state persists across app launches, so `-retry-tests-on-failure` cannot rescue it. When a UI test fails **only in CI**, suspect this before suspecting flake: reproduce with `simctl erase`, then the unit suite, then the UI class.
+
+## App icon
+
+`Assets.xcassets/AppIcon.appiconset` carries three 1024s: `Icon-Default`, `Icon-Dark`, `Icon-Tinted`. `Icon-Tinted` is **hand-authored, not a desaturation of the colour icon** — master at `packages/assets/logos/slicc-icon-tinted-master-1024.png`. iOS tinted mode maps the asset's _luminance_ onto the user's tint, so an asset confined to the top of the range can only render as a flat blob; the current one spans the full range (min 0, σ 81) by seating a bright swirl in a near-black tub. Re-check `min`/`stddev` before replacing it:
+
+```bash
+magick Icon-Tinted.png -alpha remove -colorspace Gray \
+  -format "min=%[fx:minima*255] sd=%[fx:standard_deviation*255]\n" info:
+```
+
+`Icon-Tinted` is full-bleed square (iOS applies its own superellipse mask), unlike `Icon-Dark` (pre-rounded transparent corners). The macOS side does **not** consume this PNG — Sliccstart derives its tinted appearance from `macos-icon.icon`; see [swift-launcher](../packages/swift-launcher/CLAUDE.md#app-icon).
 
 ## Exec capability
 

--- a/docs/webcomponents-details.md
+++ b/docs/webcomponents-details.md
@@ -132,6 +132,78 @@ string[])` marks leaves as pinned (runtime-only — never serialized by
   14px radius, elevated shadow, 12px margin, `overflow: hidden`); the reserved
   `chat` leaf renders flat/full-bleed over the shader.
 
+## File tree + Quick Look (Pierre libraries)
+
+Extended reference for the summary in the package guide. Two components delegate
+rendering to [pierre.computer](https://pierre.computer) libraries, each wrapped
+by an adapter that keeps SLICC's existing public contract, so hosts did not
+change.
+
+- **`slicc-file-tree`** renders through **`@pierre/trees`** (trees.software). The
+  `FileTreeItem` input shape, the `items` / `selected` accessors and the
+  `file-select` / `file-preview` / `file-reference` / `file-download` /
+  `file-overflow` / `dir-toggle` events are unchanged; `gitStatus` is new.
+  Search, inline rename, drag-and-drop, virtualization and git lanes come from
+  the library.
+- **`slicc-quick-look`** renders text through **`@pierre/diffs`** (diffs.com),
+  shows a unified diff instead of the file when the caller supplies
+  `baseContent`, and shows a rendered document when the caller supplies
+  `rendered`. The header toggle exposes whichever of Preview / Source / Diff
+  exist.
+
+Non-obvious rules:
+
+- **The library builds hierarchy from PATHS, not from `children` nesting.** A
+  `FileTreeItem` whose `id` is a bare name renders at the root no matter where it
+  sits in the literal — ids must be full paths (which is what `buildVfsTreeItems`
+  produces).
+- **Strip the leading slash before handing paths to `@pierre/trees`**
+  (`toTreePath`). A leading `/` becomes an empty first segment: `['/a.ts',
+'/b.ts']` renders ONE blank row and no files (verified against
+  `1.0.0-beta.6`). Events convert back, so absolute VFS paths stay absolute at
+  the component boundary.
+- **`renderRowDecoration` returns text or an icon only** — no interactive
+  elements. That is why the old per-row hover buttons (Preview / Reference /
+  Download) now live in the row context menu, whose `onOpen` re-emits SLICC's
+  `file-overflow` so `SliccOverflowMenu` still draws the menu.
+- **Selection echoes.** `selectFile()` reflects to the `selected` attribute,
+  which tells the library to select the row, which calls back through
+  `onSelectionChange` — guard with the `#selecting` flag or one click emits two
+  `file-select` events.
+- **Quick Look renders text twice on purpose**: a synchronous `<pre>` first, then
+  the `@pierre/diffs` view once that lazily-imported chunk arrives (~628 KB, so
+  it must never block the overlay). If the import fails the `<pre>` stays — a
+  degraded preview, not a broken one. A `#generation` counter drops an upgrade
+  that resolves after the overlay moved to another file.
+- **Quick Look converts nothing.** A `rendered` payload arrives as HTML from the
+  host: `inline` must already be sanitized (the webapp runs markdown through
+  `message-renderer.ts`) and mounts via `createContextualFragment`, the same
+  no-innerHTML path as `setBodyHtml`; `sandbox` mounts in an iframe with an EMPTY
+  `sandbox` attribute (no `allow-scripts`, no `allow-same-origin`) and is the
+  only treatment raw HTML ever gets. That document is wrapped in a base
+  stylesheet (`sandboxDocument`) stating `color-scheme` + `Canvas`/`CanvasText`,
+  because an iframe starts transparent with black text and knows nothing about
+  the app's `data-theme` — an unstyled report renders near-black on the dark
+  panel. The base goes AFTER any doctype (before it means quirks mode) and BEFORE
+  the file's own markup, so author rules outrank it. Keeping conversion in the
+  host is what keeps a markdown parser out of this library.
+- **A rendered form opens FIRST, ahead of the diff.** Someone who clicked a `.md`
+  name meant to read the file; a modified README is still a README. Files without
+  a rendered form keep the old diff-first behavior. Views are rebuilt on switch,
+  never kept mounted in parallel.
+- **`@pierre/trees` `sideEffects` is mispathed** in `1.0.0-beta.6`
+  (`./dist/components/web-components.js` vs the real `dist/web-components.js`), so
+  `import '@pierre/trees/web-components'` tree-shakes to nothing. Importing
+  `FileTree` from the package root is unaffected — it pulls the element
+  registration itself.
+- **Both libraries are in `optimizeDeps.include`** (`vitest.config.ts`).
+  Discovering them mid-run makes Vite re-optimize and reload; a reload after a
+  custom element is defined leaves the tag bound to the pre-reload class, and
+  every tree/preview test then fails as if the component were broken.
+- **Tests assert the contract, not the markup** — accessible row names and
+  events, since the DOM belongs to the library now. Synthetic events need
+  `composed: true` to cross its shadow boundary.
+
 ## Composer push-to-talk
 
 Extended reference for the `<slicc-composer ptt>` bullet in the package guide.
@@ -272,6 +344,29 @@ Non-obvious rules:
   spread alone leaves the nested array shared, so a caller splicing
   `monitor.model` markers would mutate component state.
 
+## Slotted containment + chat-prose wrapping
+
+Extended reference for two related Conventions bullets in the package guide.
+
+- **Slotted subtrees need a document sheet.** `::slotted()` matches only the
+  slot's TOP-LEVEL children — never a `<pre>` / `<table>` nested inside a slotted
+  wrapper. A shadow component that accepts rendered markdown (`slicc-lick-card`)
+  therefore ships its containment rules (`white-space:pre-wrap`,
+  `overflow-wrap:anywhere`, capped tables/images) as an idempotent document
+  `<style>` selected by the host tag, alongside its `adoptedStyleSheets`. Without
+  it an unwrapped `<pre>` bursts the card and scrolls the whole chat column
+  sideways.
+- **Chat prose must contain unbroken runs.** `slicc-user-message`'s `.b` and
+  `slicc-agent-message`'s `.body` carry `overflow-wrap: anywhere`. A pasted
+  base64 payload is one token with no break opportunity, so a `max-width` cap
+  does not contain it — the box stays capped and the TEXT spills out, scrolling
+  the whole chat column. Fenced code opts back OUT (`pre code`): a code block is
+  its own scroll container, and mangling source is worse than scrolling it. Test
+  this with `scrollWidth` vs `clientWidth`; a box-width assertion passes either
+  way and proves nothing. The webapp collapses recognized payloads into
+  `<slicc-blob-chip>` on top of this, but the wrap rule is what has to hold for
+  everything else.
+
 ## Animation loops: no forced reflow, and a frame budget
 
 A `requestAnimationFrame` loop must never call `getComputedStyle` or read
@@ -304,6 +399,20 @@ Extended reference for the workflow summary in the package guide.
 `packages/webcomponents/**`, its screenshot tooling, and the workflow
 definition on a `pull_request` to `main`. Unrelated PRs do not start the
 workflow.
+
+**Running it locally** (flags are `--flag=value` only; manifest is always
+`<out>/manifest.json`; empty diff → empty `shots[]` + a "no affected stories"
+comment):
+
+```bash
+npm run build-storybook -w @slicc/webcomponents
+git diff --name-only main... > /tmp/changed.txt
+npx playwright install chromium   # once
+node packages/dev-tools/tools/storybook-affected-screenshots.mjs \
+  --changed-files=/tmp/changed.txt \
+  --storybook-static=packages/webcomponents/storybook-static \
+  --out=/tmp/sb-shots
+```
 
 **Affected-story heuristic** (directory-level, intentionally coarse — easy to
 reason about, no module-graph plumbing):

--- a/packages/cloudflare-worker/CLAUDE.md
+++ b/packages/cloudflare-worker/CLAUDE.md
@@ -1,148 +1,125 @@
 # CLAUDE.md
 
-Tray hub worker in `packages/cloudflare-worker/`: tray session coordination,
-capability-token routing, TURN credential lookup, and leader/follower signaling for
-tray-connected SLICC runtimes; also serves the built webapp as static assets.
+Tray hub worker: tray session coordination, capability-token routing, TURN credential
+lookup, leader/follower signaling for tray-connected SLICC runtimes; also serves the
+built webapp as static assets.
 
 Deep reference: [`docs/cloudflare-worker-details.md`](../../docs/cloudflare-worker-details.md).
 
 ## Main Files
 
 - `src/index.ts` — entry + public HTTP routing
-- `src/session-tray.ts` — `SessionTrayDurableObject`: the per-tray coordinator. Owns
-  the tray record, leader election + controller WS, the join surface, route dispatch.
-  Every other concern is a collaborator behind a `*Deps` seam (issue #2674), so it is
-  unit-testable without a DO harness:
-  - `src/session-tray-bootstrap.ts` — `BootstrapCoordinator`: follower WebRTC
-    signaling state machine (offer/answer/ICE, event log, retry, pruning)
-  - `src/session-tray-bridge.ts` — `BridgeRelay`: preview-bridge CDP relay,
-    `window.slicc.emit()` attribution, per-conn emit rate limit
-  - `src/session-tray-preview.ts` — preview mint/resolve/revoke + response assembly
-  - `src/session-tray-biscotto.ts` — guest seat lifecycle + `/internal/biscotto/*`
-  - `src/session-tray-webhook.ts` — `WebhookRelay`: forwarding + #2524 receipts
-  - `src/session-tray-push.ts` — `PushCoordinator`: APNs device registry + fan-out
-  - `src/session-tray-requests.ts` — pure request parsing / wire-shape guards
-- `src/turn-credentials.ts` — Cloudflare TURN credential fetcher
+- `src/session-tray.ts` — `SessionTrayDurableObject`: controller WS (leader), follower
+  WebRTC signaling, preview bridge WS
+- `src/turn-credentials.ts` — TURN credential fetcher
 - `src/shared.ts` — capability tokens; `reclaimMsForTray`;
   `TRAY_RECLAIM_TTL_MS`/`HOSTED_TRAY_RECLAIM_TTL_MS`
 - `src/links.ts` — `applySliccLinks` (RFC 8288 `Link` rel set on every response)
-- `src/handoff-page.ts`, `src/api-catalog.ts`, `src/install-cli.ts`, `src/llms-txt.ts`,
-  `src/privacy.ts`, `src/rel-docs.ts`, `src/flags.ts` — public route handlers
-- `src/oauth-exchange.ts`, `src/oauth-registry.ts`, `src/auth/cloud-callback.ts` —
-  OAuth relays (`/auth/callback`, `/auth/cloud-callback`)
-- `src/cloud/*` — `/api/cloud/*` handlers, `CloudSessionsDurableObject`, IMS auth,
-  `checkCapsForRun` cone caps, DO-backed `Registry`, Adobe proxy `/v1/config` sync,
-  `rate-limit.ts`, `error-envelope.ts`
+- Public route handlers: `handoff-page.ts`, `api-catalog.ts`, `install-cli.ts`,
+  `llms-txt.ts`, `privacy.ts`, `rel-docs.ts`, `flags.ts`
+- OAuth relays (`/auth/callback`, `/auth/cloud-callback`): `oauth-exchange.ts`,
+  `oauth-registry.ts`, `auth/cloud-callback.ts`
 - `wrangler.jsonc` — bindings (`TRAY_HUB`, `CLOUD_SESSIONS`, `ASSETS`, `ASSET_ARCHIVE`,
   `CF_VERSION_METADATA`), staging env, feature flags
+- `src/cloud/*` — `/api/cloud/*` handlers, `CloudSessionsDurableObject`, IMS auth,
+  `checkCapsForRun` cone caps, DO-backed `Registry`, Adobe `/v1/config` sync,
+  `rate-limit.ts`, `error-envelope.ts`
 
 Sandbox lifecycle lives in `@slicc/cloud-core`; `src/cloud/` is adapter glue.
 
 ## Tray Hub Architecture
 
 `TRAY_HUB` maps each tray to one `SessionTrayDurableObject`, tracking capabilities,
-leader/follower state, reconnect windows, and cached ICE servers.
+leader/follower state, reconnect windows, cached ICE servers.
 
 ### Public Routes
 
-Route inventory: `POST /tray`, `GET /handoff`, `GET /install-cli`,
-`GET /install-cli.ps1`, `GET /download/slicc-cli/:target`,
-`GET /.well-known/api-catalog`, `GET /llms.txt`, `GET|HEAD /privacy`,
-`GET|HEAD /status`, `GET /rel/:name`, `GET|POST /join/:token`,
-`GET|POST /controller/:token`, `POST /webhook/:token/:webhookId`,
-`POST /api/tray/:trayId/preview`, `POST /api/tray/:trayId/preview/stop`,
-`GET /api/tray/:trayId/previews`, `POST /api/tray/:trayId/biscotto`,
-`POST /api/tray/:trayId/biscotto/stop`, `GET /api/tray/:trayId/biscotti`,
-`GET <token>.sliccy.now/*`,
-`GET __slicc/preview-bridge.js`, `WS __slicc/bridge`, `POST __slicc/emit`,
-`GET /auth/callback`, `GET /auth/mcp-callback`, `GET /api/flags`. Per-route semantics:
-[docs/cloudflare-worker-details.md § Public Routes](../../docs/cloudflare-worker-details.md#public-routes).
+Full route inventory + per-route semantics:
+[docs § Public Routes](../../docs/cloudflare-worker-details.md#public-routes) — covers
+`/tray`, `/handoff`, `/join/:token`, `/controller/:token`, `/webhook/*`,
+`/api/tray/:trayId/*`, `<token>.sliccy.now/*`, `__slicc/*`, `/auth/*`, `/api/flags`.
 
-**Routes-mirror rule:** every new route MUST appear in
-
-1. `src/index.ts` routes array (the default `GET /` body)
-2. `tests/index.test.ts` routes-list assertion
-3. `tests/deployed.test.ts` routes-list assertion
-
-Missing any of these fails CI.
+**Routes-mirror rule:** every new route MUST appear in all three or CI fails —
+`src/index.ts` routes array (the default `GET /` body), and the routes-list assertions
+in `tests/index.test.ts` and `tests/deployed.test.ts`.
 
 ### Feature Flag Configuration
 
-`FEATURE_FLAGS` in `wrangler.jsonc` is a JSON var
+`FEATURE_FLAGS` (`wrangler.jsonc`) is a JSON var
 `{ base: Record<string,string>, floats: Record<string, Record<string,string>> }`.
 Floats overlay `base`; invalid profiles → `{ float: "default", flags: base }`. Keep
-production and `env.staging` aligned. 5-min cache; config changes need deploy. Keep
-`/api/flags` in the routes array + both routes-list assertions.
+production and `env.staging` aligned; 5-min cache, config changes need deploy.
 
 ### Signaling Model
 
 Leader attaches via controller capability + WS to the DO. **Last-key-holder-wins
-reconnect** — a leader reconnect with matching credentials closes the stale socket;
-rejecting deadlocks on workerd's unreliable `webSocketClose`. Followers attach via the
-join capability and bootstrap over HTTP poll. Preview bridge tabs (`serve --bridge`)
-attach via `/__slicc/bridge` WS; DO relays `bridge.cdp.request`/`bridge.cdp.response`
+reconnect** — a matching-credential reconnect closes the stale socket; rejecting
+deadlocks on workerd's unreliable `webSocketClose`. Followers attach via the join
+capability, bootstrap over HTTP poll. Preview bridge tabs (`serve --bridge`) attach
+via `/__slicc/bridge` WS; the DO relays `bridge.cdp.request`/`bridge.cdp.response`
 keyed by `connId`, replays `bridge.connected` on leader (re)connect, hibernates via
 `setWebSocketAutoResponse`. Ghost-leader analysis + full protocol:
-[docs/cloudflare-worker-details.md § Signaling](../../docs/cloudflare-worker-details.md#signaling),
+[docs § Signaling](../../docs/cloudflare-worker-details.md#signaling),
 [deploying-tray-worker skill](../../.agents/skills/deploying-tray-worker/SKILL.md).
 
 ### Biscotti (guest seats)
 
 `TrayRecord.biscotti` holds revocable guest seats. `resolveJoinCapability`
-(`src/shared.ts`) is the **single default-deny point** for `/join/:token`: it
-returns `{ trust: 'full' }` for the tray join token, `{ trust: 'biscotto' }` for
-a live seat, and `null` for anything else (including revoked/expired seats,
-which are compared before being filtered so their existence does not leak by
-timing). Mint/revoke/list (and the `/internal/biscotto/*` dispatcher) live in
-`src/session-tray-biscotto.ts` and are gated on the **controller** token — a seat is never an issuing authority.
+(`src/shared.ts`) is the **single default-deny point** for `/join/:token`:
+`{ trust: 'full' }` for the tray join token, `{ trust: 'biscotto' }` for a live seat,
+`null` otherwise (revoked/expired seats are compared before filtering so their
+existence does not leak by timing). Mint/revoke/list (`src/session-tray-biscotto.ts`)
+are gated on the **controller** token — a seat is never an issuing authority.
 
-**Trust travels on the controller socket, never on the peer's `hello`.** The DO
-stamps `trust` + `biscotto` onto `follower.join_requested`, which only the leader
-can receive. `controllerId` is client-supplied, so trust is re-derived from the
-presented token on every request and a mismatch against the stored
-`ControllerRecord.biscottoId` is a 409 `JOIN_CAPABILITY_MISMATCH` — in both
-directions, so a guest cannot inherit a full follower's id and a full follower
-cannot be shadowed by a guessed one. Enforcement of what a seat may _send_ is
-leader-side (`packages/webapp/src/scoops/tray-leader/biscotto-gate.ts`).
+**Trust travels on the controller socket, never the peer's `hello`.** The DO stamps
+`trust` + `biscotto` onto `follower.join_requested` (leader-only). Since
+`controllerId` is client-supplied, trust is re-derived from the presented token every
+request; a mismatch against stored `ControllerRecord.biscottoId` is a 409
+`JOIN_CAPABILITY_MISMATCH` both directions (a guest cannot inherit a full follower's
+id, nor a full follower be shadowed by a guessed one). What a seat may _send_ is
+enforced leader-side (`packages/webapp/src/scoops/tray-leader/biscotto-gate.ts`).
 
-### TURN Credentials
+### TURN Credentials & Follower Push
 
-Fetched with `CLOUDFLARE_TURN_KEY_ID` (in `wrangler.jsonc`) and
-`CLOUDFLARE_TURN_API_TOKEN` (Wrangler secret). Follower push (#2062): `src/apns.ts` signs an ES256 JWT from `APNS_TEAM_ID` / `APNS_KEY_ID` / `APNS_PRIVATE_KEY` (`.p8` PEM) and posts to `api(.sandbox).push.apple.com` with `APNS_TOPIC`; the tray DO stores ≤16 `push.register` tokens per tray and fans out leader `push.send` (`turn_end`, time-sensitive `sudo_request`, metadata only), dropping tokens APNs reports dead. All four secrets or pushing is silently off. **Provider JWTs are minted by exactly one DO** (`src/apns-provider-token.ts`, `idFromName('__apns_provider_token')`, storage-backed): Apple throttles token creation per team+key, so per-tray minting broke Apple's 20-minute floor once a few trays hibernated (#2432). `session-tray.ts` caches ICE servers
-and refreshes before TTL expiry.
+TURN fetched with `CLOUDFLARE_TURN_KEY_ID` (`wrangler.jsonc`) +
+`CLOUDFLARE_TURN_API_TOKEN` (secret); `session-tray.ts` caches ICE servers, refreshes
+before TTL. Push (`src/apns.ts`): ES256 JWT from `APNS_TEAM_ID` / `APNS_KEY_ID` /
+`APNS_PRIVATE_KEY` (`.p8` PEM) posted to `api(.sandbox).push.apple.com` with
+`APNS_TOPIC`. The tray DO stores ≤16 `push.register` tokens per tray and fans out
+leader `push.send` (`turn_end`, time-sensitive `sudo_request`, metadata only),
+dropping tokens APNs reports dead; missing any secret → push silently off. **Provider
+JWTs are minted by exactly one DO** (`src/apns-provider-token.ts`,
+`idFromName('__apns_provider_token')`, storage-backed) — Apple throttles token
+creation per team+key, so per-tray minting broke Apple's 20-min floor once trays
+hibernated.
 
 ### Tray Kind (desktop / hosted)
 
-`TrayRecord.kind` is `'desktop' | 'hosted'` (default `'desktop'`). `POST /tray` reads
-optional `kind`. Reclaim TTL branches through `reclaimMsForTray(tray)` in `shared.ts`:
-`HOSTED_TRAY_RECLAIM_TTL_MS = 30 days` (hosted), `TRAY_RECLAIM_TTL_MS = 1 hour`
-(desktop).
+`TrayRecord.kind` is `'desktop' | 'hosted'` (default `'desktop'`); `POST /tray` reads
+optional `kind`. Reclaim TTL branches via `reclaimMsForTray(tray)` (`shared.ts`):
+`HOSTED_TRAY_RECLAIM_TTL_MS` = 30 days, `TRAY_RECLAIM_TTL_MS` = 1 hour (desktop).
 
 ### Static Assets & R2
 
 Worker serves `dist/ui/` via Static Assets (`ASSETS`); `?json=true`/POST/WS → API,
 else SPA. **Cherry embed (`?cherry=1`):** `frame-ancestors` from
-`ALLOWED_CHERRY_HOST_ORIGINS` (bare `*` also enumerates `chrome-extension://` origins);
-non-cherry → `frame-ancestors 'none'`; cherry sets `Cache-Control: no-store` +
-`Vary: Sec-Fetch-Dest`. **Non-cherry, non-electron SPA responses also carry
-`Document-Isolation-Policy: isolate-and-credentialless`** — per-document
-cross-origin isolation (SAB for vpod guest networking) without COOP/COEP;
-cherry/electron branches must stay header-free (embedded, never need SAB). **25 MiB per-asset cap** — CI runs `wrangler deploy --dry-run`
-as a hard gate. `ASSET_ARCHIVE` (R2) retains hashed `/assets/*` across deploys;
-`serveAssetWithArchiveFallback` tries `ASSETS` → R2 → stale-asset reload; bucket GC
-14 days. Full rules:
-[docs/cloudflare-worker-details.md § Static Assets](../../docs/cloudflare-worker-details.md#static-assets);
+`ALLOWED_CHERRY_HOST_ORIGINS` (bare `*` also enumerates `chrome-extension://`);
+non-cherry → `frame-ancestors 'none'`. Non-cherry, non-electron SPA responses carry
+`Document-Isolation-Policy: isolate-and-credentialless` (SAB for vpod guest networking
+without COOP/COEP); cherry/electron stay header-free. **25 MiB per-asset cap** — CI
+`wrangler deploy --dry-run` gates it. `ASSET_ARCHIVE` (R2) retains hashed `/assets/*`
+across deploys via `serveAssetWithArchiveFallback` (`ASSETS` → R2 → stale reload).
+Full rules:
+[docs § Static Assets](../../docs/cloudflare-worker-details.md#static-assets);
 ops: [deploying-tray-worker skill](../../.agents/skills/deploying-tray-worker/SKILL.md).
 
 ## Commands
 
 ```bash
-# Build webapp first (required for static assets)
-npm run build -w @slicc/webapp
-
-npx wrangler dev --config packages/cloudflare-worker/wrangler.jsonc
-npx wrangler deploy --env staging --config packages/cloudflare-worker/wrangler.jsonc
-npx wrangler deploy --config packages/cloudflare-worker/wrangler.jsonc
+npm run build -w @slicc/webapp   # build webapp first (static assets)
+CFG=packages/cloudflare-worker/wrangler.jsonc
+npx wrangler dev --config "$CFG"
+npx wrangler deploy --env staging --config "$CFG"   # drop --env staging for prod
 cd packages/cloudflare-worker && WORKER_BASE_URL=https://... npm test -- tests/deployed.test.ts
 ```
 
@@ -151,64 +128,56 @@ Extension testing with the worker: `npm run start:extension`.
 ## CI and Deployment
 
 `release-native.mjs --gate=worker` gates production. Hub + preview configs deploy as a
-pair (shared DO/token format); R2 uploads always precede deploy. Routes-only failures
-are non-fatal. Required: `CLOUDFLARE_API_TOKEN` (Workers Edit, R2 R/W, Zone Routes
-Edit) + account ID. Retry logic, staging deploy, local `serve --bridge`:
-[deploying-tray-worker skill](../../.agents/skills/deploying-tray-worker/SKILL.md).
+pair (shared DO/token format); R2 uploads precede deploy; routes-only failures
+non-fatal. Needs `CLOUDFLARE_API_TOKEN` (Workers Edit, R2 R/W, Zone Routes Edit) +
+account ID. Retry logic, staging deploy, local `serve --bridge`:
+[deploying-tray-worker](../../.agents/skills/deploying-tray-worker/SKILL.md).
 
 ## Operational Notes
 
-- Worker is coordination infrastructure, not canonical session storage.
+- Worker is coordination infrastructure, not canonical session store.
 - `GET /status`: post-deploy liveness probe; `version` from `CF_VERSION_METADATA`
-  binding (declared for default + `staging`; `unknown` when unbound). Unauthenticated
-  — body is exactly `{ status, service, timestamp, version }`, never config/binding
-  names. Signals: [`docs/operational-telemetry.md`](../../docs/operational-telemetry.md).
-- `/handoff` is stateless; query params → single RFC 8288 `Link` header.
-- Every response is wrapped by `applySliccLinks` (`src/links.ts`).
+  (declared for default + `staging`; `unknown` when unbound). Unauthenticated — body
+  is exactly `{ status, service, timestamp, version }`, never config/binding names.
+  Signals: [`docs/operational-telemetry.md`](../../docs/operational-telemetry.md).
+- `/handoff` is stateless; query params → single RFC 8288 `Link` header. Every response
+  is wrapped by `applySliccLinks` (`src/links.ts`).
 - Keep signaling protocol changes aligned with `packages/webapp/src/scoops/`.
 
 ## Cloud Cones (sliccy.ai/cloud)
 
-Shipped via Plan D. All `/api/cloud/*` require
-`Authorization: Bearer <ims-access-token>` and route to
+All `/api/cloud/*` require `Authorization: Bearer <ims-access-token>` and route to
 `env.CLOUD_SESSIONS.idFromName(userId)` for per-user state. Route table:
-[docs/cloudflare-worker-details.md § Cloud Routes](../../docs/cloudflare-worker-details.md#cloud-routes).
+[docs § Cloud Routes](../../docs/cloudflare-worker-details.md#cloud-routes).
 
 ### Cone Configuration
 
-`ConeConfig` = `{ model, accounts[], secrets[] }` (in `@slicc/cloud-core/cone-config`);
+`ConeConfig` = `{ model, accounts[], secrets[] }` (`@slicc/cloud-core/cone-config`);
 `src/cloud/cone-config-bridge.ts` handles start (writes `/slicc/secrets.env` +
-`/slicc/cone-config.json`; no-config synthesizes Adobe default) and resume (merges
+`/slicc/cone-config.json`; no-config → Adobe default) and resume (merges
 `coneConfigDelta`, reloads leader via `POST /api/secrets/reload` → `Page.reload`).
-Adobe `{kind:'oauth'}` accounts stamp `tokenExpiresAt` via `imsTokenExpiry` (IMS JWT
-`created_at + expires_in`). `CloudSessionsDurableObject` persists a **names-only**
-`coneConfigIndex` — never values. Detail:
-[docs/cloudflare-worker-details.md § Cone Configuration](../../docs/cloudflare-worker-details.md#cone-configuration).
+Adobe `{kind:'oauth'}` accounts stamp `tokenExpiresAt` via `imsTokenExpiry`.
+`CloudSessionsDurableObject` persists a **names-only** `coneConfigIndex` — never
+values.
+[docs § Cone Configuration](../../docs/cloudflare-worker-details.md#cone-configuration).
 
 ### Wrangler Config (cloud)
 
-Vars: `ADOBE_PROXY_ENDPOINT`; `ALLOWED_EMAIL_DOMAIN` (CSV, default `adobe.com`; `*` =
-any); `BLOCKED_EMAILS` (CSV); `REQUIRE_OWNER_ORG` (`true` expands to ownerOrg-holders);
-`CONE_CAP_RUNNING`, `CONE_CAP_PAUSED` (default 1/5); `ADMIN_USER_IDS` (CSV of IMS
+Vars: `ADOBE_PROXY_ENDPOINT`; `ALLOWED_EMAIL_DOMAIN` (CSV, default `adobe.com`, `*` =
+any); `BLOCKED_EMAILS` (CSV); `REQUIRE_OWNER_ORG` (`true` → ownerOrg-holders);
+`CONE_CAP_RUNNING`/`CONE_CAP_PAUSED` (default 1/5); `ADMIN_USER_IDS` (CSV of IMS
 userIds). Secret: `E2B_API_KEY` (worker-only).
 
 ### v1 → v2 Expansion
 
-```bash
-npx wrangler secret put REQUIRE_OWNER_ORG  # value: true
-# update ALLOWED_EMAIL_DOMAIN in wrangler.jsonc to "*"
-npx wrangler deploy
-```
+`npx wrangler secret put REQUIRE_OWNER_ORG` (`true`), set `ALLOWED_EMAIL_DOMAIN` to `"*"`
+in `wrangler.jsonc`, then `npx wrangler deploy`.
 
 ### Stable API Contract (worker ↔ sandbox)
 
-Deprecation obligation — paused cones from older templates cannot be patched
-in-place:
+Deprecation obligation — paused cones from older templates cannot be patched in-place:
 
-- `POST /api/leader-restart` (loopback in sandbox)
-- `GET /api/hosted-bootstrap` (loopback in sandbox)
-- `POST /api/cloud-status` (loopback in sandbox)
-- `/slicc/secrets.env` — sandbox file the worker writes via SDK
-- `/tmp/slicc-join.json` — sandbox file the worker reads via SDK
-- `ADOBE_IMS_TOKEN`, `ADOBE_IMS_TOKEN_DOMAINS`, `SLICC_TRAY_WORKER_BASE_URL` — envs
-  consumed by `start.sh`
+- Sandbox loopback: `POST /api/leader-restart`, `GET /api/hosted-bootstrap`,
+  `POST /api/cloud-status`
+- `/slicc/secrets.env` (worker writes via SDK); `/tmp/slicc-join.json` (worker reads)
+- `ADOBE_IMS_TOKEN`, `ADOBE_IMS_TOKEN_DOMAINS`, `SLICC_TRAY_WORKER_BASE_URL` — `start.sh` envs

--- a/packages/dev-tools/CLAUDE.md
+++ b/packages/dev-tools/CLAUDE.md
@@ -4,73 +4,67 @@ Developer-tooling surface for `packages/dev-tools/`. Long-form notes: [`docs/dev
 
 ## Key Tooling Areas
 
-- **playwright-cli gap sync**: `packages/dev-tools/tools/playwright-cli-sync.mjs` — diffs Slicc's playwright-cli against `@playwright/cli`. Ref: [`docs/playwright-cli-sync.md`](../../docs/playwright-cli-sync.md).
-- **Dev-only VFS skills** (`packages/dev-tools/vfs-dev-skills/`): `__DEV__`-gated `import.meta.glob` in `packages/webapp/src/scoops/skills.ts`, remapped to `/workspace/skills/`. Contains `playwright-cli-e2e`.
+Bare script names below live under `tools/` unless a fuller path is given.
+
+- **playwright-cli gap sync**: `tools/playwright-cli-sync.mjs` — diffs Slicc's playwright-cli vs `@playwright/cli`. Ref: [`docs/playwright-cli-sync.md`](../../docs/playwright-cli-sync.md).
+- **Dev-only VFS skills** (`packages/dev-tools/vfs-dev-skills/`): `__DEV__`-gated `import.meta.glob` in `packages/webapp/src/scoops/skills.ts`, remapped to `/workspace/skills/`.
 - **Build configs**: `packages/webapp/vite.config.ts`, `packages/chrome-extension/vite.config.ts`, `biome.json`.
-- **QA setup**: `packages/node-server/src/qa-setup.ts` plus root `npm run qa:*` scripts. Visual/integration helper: `packages/webapp/tests/test-dips.mjs`.
-- **RUM error triage**: `packages/dev-tools/rum-error-triage/triage-rum-errors.mjs`, nightly via `.github/workflows/rum-error-triage.yml`.
-- **Scheduled agentic workflows** (selector `.mjs` + `claude-code-action`): `boy-scout-debt/`, `pr-fix-dispatcher/`, `claude-md-compactor/`, `flaky-ci-hunter/`, `backlog-dispatcher/`. Deep ref: [dev-tools-details.md#scheduled-agentic-workflows](../../docs/dev-tools-details.md#scheduled-agentic-workflows).
-- **Review responder** (event-driven sibling): `packages/dev-tools/review-responder/` + `.github/workflows/review-responder.yml` — answers reviewer feedback on `automation/*` PRs. Deep ref: [dev-tools-details.md#review-responder](../../docs/dev-tools-details.md#review-responder).
-- **Bedrock model scout** (weekly canary, no Claude): `packages/dev-tools/model-scout/` + `.github/workflows/model-scout.yml` — probes every `*_BEDROCK_MODEL` ID the workflows can reach and files an issue on a dead one. Deep ref: [dev-tools-details.md#model-scout](../../docs/dev-tools-details.md#model-scout).
-- **AI comment detection**: `packages/dev-tools/ai-comment-detection/` — labels `ai-generated`/`human-in-the-loop` via `.github/workflows/ai-comment-detection.yml`. Deep ref: [dev-tools-details.md#ai-comment-detection](../../docs/dev-tools-details.md#ai-comment-detection).
-- **Doc gates** (`npm run lint:docs`, `.husky/pre-commit`): `packages/dev-tools/tools/check-doc-sizes.mjs` (+ `check-doc-sizes-lib.mjs`) and `check-doc-refs.mjs` (+ `check-doc-refs-lib.mjs`). Deep ref: [dev-tools-details.md#doc-dead-reference-gate](../../docs/dev-tools-details.md#doc-dead-reference-gate).
-- **Hugging Face caching mirror** (`packages/dev-tools/tools/hf-cache-mirror.mjs`): zero-dep local `huggingface.co` mirror with an on-disk store; the e2e CI job runs it, persists `.cache/hf-mirror` with `actions/cache`, and hands `HF_ENDPOINT` to the virtual shell's `hf download` so the Kokoro weights come off disk on warm runs.
+- **QA setup**: `packages/node-server/src/qa-setup.ts` + root `npm run qa:*`; visual helper `packages/webapp/tests/test-dips.mjs`.
+- **RUM error triage**: `packages/dev-tools/rum-error-triage/triage-rum-errors.mjs`, nightly via workflow `rum-error-triage.yml`.
+- **Scheduled agentic workflows** (selector `.mjs` + `claude-code-action`): `boy-scout-debt/`, `pr-fix-dispatcher/`, `claude-md-compactor/`, `flaky-ci-hunter/`, `backlog-dispatcher/`; event-driven sibling **review responder** (`review-responder/`) answers `automation/*` PR feedback. Deep refs: [workflows](../../docs/dev-tools-details.md#scheduled-agentic-workflows), [responder](../../docs/dev-tools-details.md#review-responder).
+- **Bedrock model scout** (weekly canary, no Claude): `packages/dev-tools/model-scout/` + workflow `model-scout.yml` — probes reachable `*_BEDROCK_MODEL` IDs, files an issue on a dead one. [details](../../docs/dev-tools-details.md#model-scout).
+- **AI comment detection**: `packages/dev-tools/ai-comment-detection/` + workflow `ai-comment-detection.yml` — labels `ai-generated`/`human-in-the-loop`. [details](../../docs/dev-tools-details.md#ai-comment-detection).
+- **Doc gates** (`npm run lint:docs`, `.husky/pre-commit`): `tools/check-doc-sizes.mjs` + `check-doc-refs.mjs` (each + `-lib`). [details](../../docs/dev-tools-details.md#doc-dead-reference-gate).
+- **Hugging Face caching mirror** (`tools/hf-cache-mirror.mjs`): zero-dep local `huggingface.co` mirror; e2e CI runs it, caches `.cache/hf-mirror` via `actions/cache`, and sets `HF_ENDPOINT` for warm-run Kokoro weights.
 - **Linear-history check**: `bash packages/dev-tools/tools/check-linear-history.sh [base-ref] [head-ref]`. `linear-history` CI job.
-- **Skill lint** (`npm run lint:skills`): `packages/dev-tools/tools/lint-skills.mjs` — `tessl skill lint` via `@tessl/cli`. Warns locally; fails under `--strict`/CI.
-- **Developer-skill sync** (`npm run lint:skill-router`): `packages/dev-tools/tools/check-skill-router-sync.sh` — keeps root router, `.agents/skills/`, `.claude/skills/` aliases in sync.
+- **Skill lint** (`npm run lint:skills`): `tools/lint-skills.mjs` — `tessl skill lint` via `@tessl/cli`; warns locally, fails under `--strict`/CI.
 - **Patch reconcile** (`npm run lint:patches`): `packages/dev-tools/patch-reconcile/check-patches.mjs` + `reconcile-context.mjs`. See `patches/README.md`.
-- **SPM ↔ xcodegen pin reconcile** (`npm run lint:swift-pins`): `packages/dev-tools/swift-pin-reconcile/`. Dual-pinned GitHub packages (Package.swift + project.yml) must overlap; `renovate-swift-pin-reconcile.yml` raises the stale side on `swift-pin` Renovate PRs. See the folder README.
-- **iOS UI-test exclusion registry** (`npm run lint:ios-ui-tests`): `packages/dev-tools/tools/ios-ui-test-exclusions.mjs` + `packages/ios-app/ui-test-exclusions.json`. `ios-app-tests` runs the WHOLE `SliccFollowerUITests` bundle on the GA cells and subtracts this registry, so a new class is gated the day it lands; the gate rejects an entry with no reason or one naming a class/method that no longer exists.
-- **SwiftPM lockfile drift gate**: `packages/dev-tools/tools/check-swift-resolved-drift.mjs` — run AFTER a resolve step (the `ios-app` CI job). `xcodebuild -resolvePackageDependencies` rewrites `Package.resolved` in place and builds against what it wrote, so a floated **transitive** pin lands with no diff; `lint:swift-pins` only sees direct pins. Compares identity/version/revision, ignoring `originHash` and key order (both move with the toolchain).
-- **innerHTML guard** (`npm run lint:no-innerhtml`): `packages/dev-tools/tools/check-no-innerhtml.mjs` bans `.innerHTML =`, `.outerHTML =`, `insertAdjacentHTML()` in `@slicc/webcomponents` (stories/tests exempt).
-- **Providers boundary** (`npm run lint:no-ui-in-providers`): `packages/dev-tools/tools/check-no-ui-imports-in-providers.mjs` bans `from '…ui/…'` in `providers/built-in/`.
-- **Layer back-edge ratchet** (`npm run lint:layer-back-edges`): `packages/dev-tools/tools/check-layer-back-edges.mjs`; baseline `layer-back-edge-baseline.json` (`--update`). Deep ref: [dev-tools-details.md#layer-back-edge-ratchet](../../docs/dev-tools-details.md#layer-back-edge-ratchet).
-- **`Record<string, unknown>` ratchet** (`npm run lint:record-string-unknown`): `packages/dev-tools/tools/check-record-string-unknown.mjs`; detection is the GritQL plugin `.biome-plugins/no-record-string-unknown.grit` run through `biome.record-gate.json`. Baseline `record-string-unknown-baseline.json` (`--update`). Deep ref: [dev-tools-details.md#record-string-unknown-ratchet](../../docs/dev-tools-details.md#record-string-unknown-ratchet).
-- **Hosted-origin literal guard**: `packages/dev-tools/tools/check-hosted-origin-literal.mjs` — TS must import `SLICC_HOSTED_ORIGIN` from `@slicc/shared-ts`.
-- **Chrome runtime.id guard**: `packages/dev-tools/tools/check-no-raw-chrome-runtime-id.mjs` — use `isChromeExtensionRealm()` from `@slicc/shared-ts` (tests exempt).
-- **AGENTS.md symlink guard**: `packages/dev-tools/tools/check-agents-symlinks.mjs` — every `packages/*/CLAUDE.md` needs an `AGENTS.md` sibling symlink.
-- **iOS PR screenshots**: `packages/dev-tools/tools/ios-screenshots.mjs` (+ `ios-screenshots-lib.mjs`) reads `packages/ios-app/screenshot-screens.json`, emits Storybook `manifest.json`. Driven by `.github/workflows/ios-screenshots.yml`.
-- **Storybook PR screenshots**: `packages/dev-tools/tools/storybook-affected-screenshots.mjs` (+ `storybook-affected-stories-lib.mjs`) — light/dark shots of affected webcomponents stories; pair with `npm run build-storybook -w @slicc/webcomponents`. Driven by `.github/workflows/storybook-screenshots.yml`. Upload: `storybook-screenshots-upload.mjs` (+ `-lib.mjs`) to R2. Deep ref: [dev-tools-details.md#storybook-screenshots-upload](../../docs/dev-tools-details.md#storybook-screenshots-upload).
-- **Dead code (production files)** (`npm run deadcode:production-files`): `knip --production --include files`; config `knip.json`. Deep ref: [dev-tools-details.md#knip-production-suffix-discipline](../../docs/dev-tools-details.md#knip-production-suffix-discipline).
-- **Swift unused-dependency gate** (`npm run lint:swift-deps`): `packages/dev-tools/tools/check-swift-unused-deps.mjs` (+ `-lib.mjs`) — SPM parity with knip (TS) and `make tidy-check` (Go); diffs every `packages/*/Package.swift` against the modules its targets import. Waiver: `// unused-dep-ok: <reason>`. Deep ref: [dev-tools-details.md#swift-unused-dependency-gate](../../docs/dev-tools-details.md#swift-unused-dependency-gate).
-- **Debt boy-scout gate**: `node packages/dev-tools/tools/check-touched-exemptions.mjs [base-ref]` (+ `size-exemption-lib.mjs`) — enforces `biome.json` debt overrides plus `layer-back-edge-baseline.json` and `record-string-unknown-baseline.json`. See [verifying-before-push skill](../../.agents/skills/verifying-before-push/SKILL.md).
-- **First-load size gate** (part of `npm run size -w @slicc/webapp`): `packages/dev-tools/tools/check-first-load-size.mjs` (+ `first-load-size-lib.mjs`, `first-load-baseline.mjs`) — measures the eager import closures of the page entry (via `.vite/manifest.json`) and the kernel-worker entry (parsed from emitted chunks). Guards cold-boot payload, not per-file size. **Relative**: it builds the merge-base in a throwaway worktree (workspace packages re-pointed at the worktree's own source, then the root `postinstall` prerequisite builds — borrowing the caller's would mask a webcomponents-side regression) (`--baseline=<ref>`, default `origin/main`; `--baseline=none` to skip, `--json` to just measure) and fails on a change's own growth past `maxDeltaKb`, so it never fires on inherited state and cancels the ~1 kB Linux-vs-macOS build difference. On `merge_group` the delta is skipped (a queue branch is cumulative — its delta is the batch sum, and a per-change allowance would fail on queue depth); ceilings only, no baseline build. That split is only safe because a CI `pull_request` run treats an unmeasurable baseline as a hard failure rather than degrading — otherwise a PR could clear both stages unmeasured. Local runs still degrade to ceilings with a note. The absolute `*EagerCeilingKb` values in `packages/webapp/first-load-budget.json` are the backstop against many small under-threshold changes creeping upward — human-owned, not numbers to nudge when a build goes red.
-- **Coverage gate + ratchet**: `packages/dev-tools/tools/coverage-gate.mjs` + `coverage-ratchet.mjs` (`coverage-thresholds.json`). Swift: `swift-coverage-check.sh` + `swift-coverage-runner-retry.sh`; `SLICC_IOS_SIM_UDID` overrides. Deep ref: [dev-tools-details.md#swift-coverage-retry](../../docs/dev-tools-details.md#swift-coverage-retry).
-- **Optional-binary guard**: `packages/dev-tools/tools/run-if-installed.mjs <binary> [args...]` — runs iff on `PATH`, else warns and exits 0. Used by the root `lint-staged` Swift/Go globs.
-- **Cross-impl vectors**: `packages/dev-tools/tools/gen-mask-vectors.mjs` (TS/Swift mask parity) and `gen-theme-vectors.mjs` (via `npx tsx`; regenerate after `theme-engine.ts` changes, asserted by `packages/webapp/tests/ui/theme-vectors.test.ts` + `ThemeEngineTests.swift`).
-- **Preflight deps check**: `packages/dev-tools/tools/preflight-deps.mjs` — wired via `pretypecheck`/`pretest`.
-- **Release gating**: `packages/dev-tools/tools/release-plan.mjs` (Linux preflight) + `release-native.mjs` — gates macOS/iOS packaging, `slicc` Go CLI (`packages/slicc-cli/sign-and-package.sh`), Chrome Web Store/worker publish, `@ai-ecoverse/biome-jsh` (`--gate=biome-jsh-version`/`--gate=biome-jsh`).
+- **Developer-skill sync** (`npm run lint:skill-router`): `tools/check-skill-router-sync.sh` — keeps root router + `.agents/skills/` + `.claude/skills/` in sync.
+- **SPM ↔ xcodegen pin reconcile** (`npm run lint:swift-pins`): `packages/dev-tools/swift-pin-reconcile/`. Dual-pinned GitHub packages (Package.swift + project.yml) must overlap; `renovate-swift-pin-reconcile.yml` raises the stale side on `swift-pin` PRs. See its README.
+- **iOS UI-test exclusion registry** (`npm run lint:ios-ui-tests`): `tools/ios-ui-test-exclusions.mjs` + `packages/ios-app/ui-test-exclusions.json`. [details](../../docs/dev-tools-details.md#ios-ui-test-exclusion-registry).
+- **SwiftPM lockfile drift gate** (`ios-app` CI): `tools/check-swift-resolved-drift.mjs` — catches floated transitive pins `lint:swift-pins` misses. [details](../../docs/dev-tools-details.md#swiftpm-lockfile-drift-gate).
+- **Source-shape guards** (`tools/`): `check-no-innerhtml.mjs` (`lint:no-innerhtml`), `check-no-ui-imports-in-providers.mjs` (`lint:no-ui-in-providers`), `check-hosted-origin-literal.mjs`, `check-no-raw-chrome-runtime-id.mjs`, `check-agents-symlinks.mjs`. [details](../../docs/dev-tools-details.md#source-guards).
+- **Layer back-edge ratchet** (`npm run lint:layer-back-edges`): `tools/check-layer-back-edges.mjs`; baseline `layer-back-edge-baseline.json` (`--update`). [details](../../docs/dev-tools-details.md#layer-back-edge-ratchet).
+- **`Record<string, unknown>` ratchet** (`npm run lint:record-string-unknown`): `tools/check-record-string-unknown.mjs` + `.biome-plugins/no-record-string-unknown.grit` (`biome.record-gate.json`); baseline `record-string-unknown-baseline.json` (`--update`). [details](../../docs/dev-tools-details.md#record-string-unknown-ratchet).
+- **Swift unused-dependency gate** (`npm run lint:swift-deps`): `tools/check-swift-unused-deps.mjs` (+ `-lib.mjs`) — SPM parity with knip (TS) / `make tidy-check` (Go). Waiver `// unused-dep-ok: <reason>`. [details](../../docs/dev-tools-details.md#swift-unused-dependency-gate).
+- **iOS PR screenshots**: `tools/ios-screenshots.mjs` (+ `-lib.mjs`) reads `packages/ios-app/screenshot-screens.json`, emits Storybook `manifest.json`. Workflow `ios-screenshots.yml`.
+- **Storybook PR screenshots**: `tools/storybook-affected-screenshots.mjs` (+ `storybook-affected-stories-lib.mjs`) — light/dark shots of affected stories; pair with `npm run build-storybook -w @slicc/webcomponents`; workflow `storybook-screenshots.yml`; R2 upload `storybook-screenshots-upload.mjs` (+ `-lib`). [details](../../docs/dev-tools-details.md#storybook-screenshots-upload).
+- **Dead code (production files)** (`npm run deadcode:production-files`): `knip --production --include files`; `knip.json`. [details](../../docs/dev-tools-details.md#knip-production-suffix-discipline).
+- **Debt boy-scout gate**: `node packages/dev-tools/tools/check-touched-exemptions.mjs [base-ref]` (+ `size-exemption-lib.mjs`) — enforces `biome.json` debt overrides + the two `*-baseline.json`. See [verifying-before-push](../../.agents/skills/verifying-before-push/SKILL.md).
+- **Coverage gate + ratchet** (`tools/`): `coverage-gate.mjs` + `coverage-ratchet.mjs` (`coverage-thresholds.json`); Swift `swift-coverage-check.sh` + `swift-coverage-runner-retry.sh` (`SLICC_IOS_SIM_UDID` override). [details](../../docs/dev-tools-details.md#swift-coverage-retry).
+- **First-load size gate** (part of `npm run size -w @slicc/webapp`): `tools/check-first-load-size.mjs` (+ `first-load-size-lib.mjs`, `first-load-baseline.mjs`) — relative cold-boot payload guard vs `origin/main` (`--baseline=<ref>|none`, `--json`); ceilings in `packages/webapp/first-load-budget.json`. [details](../../docs/dev-tools-details.md#first-load-size-gate).
+- **Cross-impl vectors**: `tools/gen-mask-vectors.mjs` (TS/Swift mask parity), `gen-theme-vectors.mjs` (`npx tsx`; regen after `theme-engine.ts` edits, asserted by `theme-vectors.test.ts` + `ThemeEngineTests.swift`).
+- **Preflight deps check**: `tools/preflight-deps.mjs` — wired via `pretypecheck`/`pretest`.
+- **Release gating**: `tools/release-plan.mjs` (Linux preflight) + `release-native.mjs` — gates macOS/iOS packaging, `slicc` Go CLI (`packages/slicc-cli/sign-and-package.sh`), Chrome Web Store/worker publish, `@ai-ecoverse/biome-jsh` (`--gate=biome-jsh-version|biome-jsh`).
+- **Optional-binary guard**: `tools/run-if-installed.mjs <binary> [args...]` — runs iff on `PATH`, else warns and exits 0; used by root `lint-staged` Swift/Go globs.
+- **e2b template**: `packages/dev-tools/e2b-template/` — hosted-leader cloud float's e2b sandbox. See `packages/cloud-core/CLAUDE.md`.
 
 ### SLICC CDP Debug + Screencast
 
-- `packages/dev-tools/tools/slicc-debug.mjs` — CDP diagnostic CLI (`targets`, `logs`, `vfs ls/cat`, `eval`, `shell`; `--url`/`--url-pattern`/`--file`). `node packages/dev-tools/tools/slicc-debug.mjs --help`.
-- `packages/dev-tools/tools/slicc-screencast.mjs` (+ `-lib.mjs`, `-video.mjs`) — `Page.startScreencast` frames + `manifest.json`; `--video` via ffmpeg. Skill: `demo-recording`.
+- `tools/slicc-debug.mjs` — CDP diagnostic CLI (`targets`, `logs`, `vfs ls/cat`, `eval`, `shell`; `--url`/`--url-pattern`/`--file`; `--help`).
+- `tools/slicc-screencast.mjs` (+ `-lib.mjs`, `-video.mjs`) — `Page.startScreencast` frames + `manifest.json`; `--video` via ffmpeg. Skill `demo-recording`.
 
 ### Fresh Dev Harnesses
 
-Five isolated harnesses on distinct ports; reaping is opt-in (`SLICC_FRESH_REAP=1`) and port-scoped.
+Five isolated harnesses on distinct ports; reaping is opt-in (`SLICC_FRESH_REAP=1`), port-scoped.
 
-| Harness        | Script                        | Bridge                 | CDP     | Notes                                       |
-| -------------- | ----------------------------- | ---------------------- | ------- | ------------------------------------------- |
-| Standalone     | `dev-standalone-fresh.sh`     | `:$PORT` (use `:5715`) | auto    | Fails on occupied bridge; self-builds UI    |
-| Swift          | `dev-swift-fresh.sh`          | `:5720`                | `:9224` | Native; auto-signs with stable dev cert     |
-| Extension      | `dev-extension-fresh.sh`      | (SW)                   | `:9333` | MV3 extension IS the bridge; LaunchServices |
-| Electron-Node  | `dev-electron-node-fresh.sh`  | `:5730`                | `:9225` | External Electron app (default: Slack)      |
-| Electron-Swift | `dev-electron-swift-fresh.sh` | `:5740`                | `:9226` | Swift backend, external Electron app        |
+| Harness (script under `tools/`)              | Bridge             | CDP     | Notes                                    |
+| -------------------------------------------- | ------------------ | ------- | ---------------------------------------- |
+| Standalone `dev-standalone-fresh.sh`         | `:$PORT` (`:5715`) | auto    | fails on occupied bridge; self-builds UI |
+| Swift `dev-swift-fresh.sh`                   | `:5720`            | `:9224` | native; auto-signs with dev cert         |
+| Extension `dev-extension-fresh.sh`           | (SW)               | `:9333` | MV3 extension IS the bridge              |
+| Electron-Node `dev-electron-node-fresh.sh`   | `:5730`            | `:9225` | external Electron app (Slack)            |
+| Electron-Swift `dev-electron-swift-fresh.sh` | `:5740`            | `:9226` | Swift backend + external Electron        |
 
-Isolated lane: `PORT=5715 WRANGLER_PORT=8787 npm run dev:standalone:fresh`; never touch production bridge `:5710` or Chrome CDP `:9222`. Also `npm run dev:swift:fresh`, `dev:extension:fresh`, `dev:electron:node:fresh`, `dev:electron:swift:fresh`, with `PORT=…`/`ELECTRON_APP=…` overrides. Lifecycle + reaping: [`docs/development.md`](../../docs/development.md); [dev-tools-details.md#fresh-dev-harnesses](../../docs/dev-tools-details.md#fresh-dev-harnesses).
+Isolated lane: `PORT=5715 WRANGLER_PORT=8787 npm run dev:standalone:fresh` (also `dev:swift:fresh`, `dev:extension:fresh`, `dev:electron:{node,swift}:fresh`; `PORT=…`/`ELECTRON_APP=…`). Never touch production bridge `:5710` or Chrome CDP `:9222`. Lifecycle + reaping: [`docs/development.md`](../../docs/development.md), [details](../../docs/dev-tools-details.md#fresh-dev-harnesses).
 
 ### Supporting Utilities
 
-- **Labeled Chrome clone**: `clone-labeled-chrome.sh` — APFS COW-clone with distinct `CFBundleName`/`CFBundleIdentifier` (distinct ⌘-Tab entries per harness); ad-hoc re-signed, top-level only. No-op on non-darwin.
-- **Stable dev code-signing identity**: `bash packages/dev-tools/tools/setup-dev-cert.sh` — one-time; creates persistent self-signed `SLICC Dev Code Signing`. `dev-swift-fresh.sh` picks it up automatically.
-
-## e2b Template
-
-Hosted-leader cloud float runs in an e2b sandbox; template in `packages/dev-tools/e2b-template/`. See `packages/cloud-core/CLAUDE.md`.
+- **Labeled Chrome clone**: `clone-labeled-chrome.sh` — APFS COW-clone with distinct `CFBundleName`/`CFBundleIdentifier` for per-harness ⌘-Tab entries; ad-hoc re-signed. No-op on non-darwin.
+- **Stable dev code-signing identity**: `bash tools/setup-dev-cert.sh` — one-time; creates persistent self-signed `SLICC Dev Code Signing`, picked up by `dev-swift-fresh.sh`.
 
 ## Usage Notes
 
 - Prefer root npm scripts when a helper already has one.
-- Keep dev-only configs and utilities out of runtime packages unless required at runtime.
-- When adding new tooling, document both file location and entry command.
+- Keep dev-only configs/utilities out of runtime packages unless required at runtime.
+- When adding tooling, document its file location and entry command.

--- a/packages/dev-tools/CLAUDE.md
+++ b/packages/dev-tools/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Developer-tooling surface for `packages/dev-tools/`. Long-form notes: [`docs/dev-tools-details.md`](../../docs/dev-tools-details.md).
+Developer tooling in `packages/dev-tools/`. Long-form notes: [`docs/dev-tools-details.md`](../../docs/dev-tools-details.md).
 
 ## Key Tooling Areas
 
@@ -8,18 +8,19 @@ Bare script names below live under `tools/` unless a fuller path is given.
 
 - **playwright-cli gap sync**: `tools/playwright-cli-sync.mjs` — diffs Slicc's playwright-cli vs `@playwright/cli`. Ref: [`docs/playwright-cli-sync.md`](../../docs/playwright-cli-sync.md).
 - **Dev-only VFS skills** (`packages/dev-tools/vfs-dev-skills/`): `__DEV__`-gated `import.meta.glob` in `packages/webapp/src/scoops/skills.ts`, remapped to `/workspace/skills/`.
-- **Build configs**: `packages/webapp/vite.config.ts`, `packages/chrome-extension/vite.config.ts`, `biome.json`.
-- **QA setup**: `packages/node-server/src/qa-setup.ts` + root `npm run qa:*`; visual helper `packages/webapp/tests/test-dips.mjs`.
+- **Build configs**: `webapp/vite.config.ts`, `chrome-extension/vite.config.ts`, `biome.json`.
+- **QA setup**: `packages/node-server/src/qa-setup.ts` + root `npm run qa:*`; visual helper `webapp/tests/test-dips.mjs`.
 - **RUM error triage**: `packages/dev-tools/rum-error-triage/triage-rum-errors.mjs`, nightly via workflow `rum-error-triage.yml`.
 - **Scheduled agentic workflows** (selector `.mjs` + `claude-code-action`): `boy-scout-debt/`, `pr-fix-dispatcher/`, `claude-md-compactor/`, `flaky-ci-hunter/`, `backlog-dispatcher/`; event-driven sibling **review responder** (`review-responder/`) answers `automation/*` PR feedback. Deep refs: [workflows](../../docs/dev-tools-details.md#scheduled-agentic-workflows), [responder](../../docs/dev-tools-details.md#review-responder).
 - **Bedrock model scout** (weekly canary, no Claude): `packages/dev-tools/model-scout/` + workflow `model-scout.yml` — probes reachable `*_BEDROCK_MODEL` IDs, files an issue on a dead one. [details](../../docs/dev-tools-details.md#model-scout).
+- **e2b template**: `packages/dev-tools/e2b-template/` — hosted-leader cloud float's e2b sandbox. See `cloud-core/CLAUDE.md`.
 - **AI comment detection**: `packages/dev-tools/ai-comment-detection/` + workflow `ai-comment-detection.yml` — labels `ai-generated`/`human-in-the-loop`. [details](../../docs/dev-tools-details.md#ai-comment-detection).
 - **Doc gates** (`npm run lint:docs`, `.husky/pre-commit`): `tools/check-doc-sizes.mjs` + `check-doc-refs.mjs` (each + `-lib`). [details](../../docs/dev-tools-details.md#doc-dead-reference-gate).
-- **Hugging Face caching mirror** (`tools/hf-cache-mirror.mjs`): zero-dep local `huggingface.co` mirror; e2e CI runs it, caches `.cache/hf-mirror` via `actions/cache`, and sets `HF_ENDPOINT` for warm-run Kokoro weights.
+- **Hugging Face caching mirror** (`tools/hf-cache-mirror.mjs`): zero-dep local `huggingface.co` mirror; e2e CI caches `.cache/hf-mirror` and sets `HF_ENDPOINT` for warm-run Kokoro weights.
 - **Linear-history check**: `bash packages/dev-tools/tools/check-linear-history.sh [base-ref] [head-ref]`. `linear-history` CI job.
 - **Skill lint** (`npm run lint:skills`): `tools/lint-skills.mjs` — `tessl skill lint` via `@tessl/cli`; warns locally, fails under `--strict`/CI.
 - **Patch reconcile** (`npm run lint:patches`): `packages/dev-tools/patch-reconcile/check-patches.mjs` + `reconcile-context.mjs`. See `patches/README.md`.
-- **Developer-skill sync** (`npm run lint:skill-router`): `tools/check-skill-router-sync.sh` — keeps root router + `.agents/skills/` + `.claude/skills/` in sync.
+- **Developer-skill sync** (`npm run lint:skill-router`): `tools/check-skill-router-sync.sh` — keeps root router, `.agents/skills/`, `.claude/skills/` in sync.
 - **SPM ↔ xcodegen pin reconcile** (`npm run lint:swift-pins`): `packages/dev-tools/swift-pin-reconcile/`. Dual-pinned GitHub packages (Package.swift + project.yml) must overlap; `renovate-swift-pin-reconcile.yml` raises the stale side on `swift-pin` PRs. See its README.
 - **iOS UI-test exclusion registry** (`npm run lint:ios-ui-tests`): `tools/ios-ui-test-exclusions.mjs` + `packages/ios-app/ui-test-exclusions.json`. [details](../../docs/dev-tools-details.md#ios-ui-test-exclusion-registry).
 - **SwiftPM lockfile drift gate** (`ios-app` CI): `tools/check-swift-resolved-drift.mjs` — catches floated transitive pins `lint:swift-pins` misses. [details](../../docs/dev-tools-details.md#swiftpm-lockfile-drift-gate).
@@ -28,16 +29,15 @@ Bare script names below live under `tools/` unless a fuller path is given.
 - **`Record<string, unknown>` ratchet** (`npm run lint:record-string-unknown`): `tools/check-record-string-unknown.mjs` + `.biome-plugins/no-record-string-unknown.grit` (`biome.record-gate.json`); baseline `record-string-unknown-baseline.json` (`--update`). [details](../../docs/dev-tools-details.md#record-string-unknown-ratchet).
 - **Swift unused-dependency gate** (`npm run lint:swift-deps`): `tools/check-swift-unused-deps.mjs` (+ `-lib.mjs`) — SPM parity with knip (TS) / `make tidy-check` (Go). Waiver `// unused-dep-ok: <reason>`. [details](../../docs/dev-tools-details.md#swift-unused-dependency-gate).
 - **iOS PR screenshots**: `tools/ios-screenshots.mjs` (+ `-lib.mjs`) reads `packages/ios-app/screenshot-screens.json`, emits Storybook `manifest.json`. Workflow `ios-screenshots.yml`.
-- **Storybook PR screenshots**: `tools/storybook-affected-screenshots.mjs` (+ `storybook-affected-stories-lib.mjs`) — light/dark shots of affected stories; pair with `npm run build-storybook -w @slicc/webcomponents`; workflow `storybook-screenshots.yml`; R2 upload `storybook-screenshots-upload.mjs` (+ `-lib`). [details](../../docs/dev-tools-details.md#storybook-screenshots-upload).
+- **Storybook PR screenshots**: `tools/storybook-affected-screenshots.mjs` (+ `storybook-affected-stories-lib.mjs`) — light/dark shots of affected stories; pair with `build-storybook -w @slicc/webcomponents`; workflow `storybook-screenshots.yml`; R2 upload `storybook-screenshots-upload.mjs` (+ `-lib`). [details](../../docs/dev-tools-details.md#storybook-screenshots-upload).
 - **Dead code (production files)** (`npm run deadcode:production-files`): `knip --production --include files`; `knip.json`. [details](../../docs/dev-tools-details.md#knip-production-suffix-discipline).
-- **Debt boy-scout gate**: `node packages/dev-tools/tools/check-touched-exemptions.mjs [base-ref]` (+ `size-exemption-lib.mjs`) — enforces `biome.json` debt overrides + the two `*-baseline.json`. See [verifying-before-push](../../.agents/skills/verifying-before-push/SKILL.md).
-- **Coverage gate + ratchet** (`tools/`): `coverage-gate.mjs` + `coverage-ratchet.mjs` (`coverage-thresholds.json`); Swift `swift-coverage-check.sh` + `swift-coverage-runner-retry.sh` (`SLICC_IOS_SIM_UDID` override). [details](../../docs/dev-tools-details.md#swift-coverage-retry).
+- **Debt boy-scout gate**: `node packages/dev-tools/tools/check-touched-exemptions.mjs [base-ref]` (+ `size-exemption-lib.mjs`) — enforces `biome.json` debt overrides + the two `*-baseline.json`. See [verifying](../../.agents/skills/verifying-before-push/SKILL.md).
+- **Coverage gate + ratchet** (`tools/`): `coverage-gate.mjs` + `coverage-ratchet.mjs` (`coverage-thresholds.json`); Swift `swift-coverage-check.sh` + `-runner-retry.sh` (`SLICC_IOS_SIM_UDID` override). [details](../../docs/dev-tools-details.md#swift-coverage-retry).
 - **First-load size gate** (part of `npm run size -w @slicc/webapp`): `tools/check-first-load-size.mjs` (+ `first-load-size-lib.mjs`, `first-load-baseline.mjs`) — relative cold-boot payload guard vs `origin/main` (`--baseline=<ref>|none`, `--json`); ceilings in `packages/webapp/first-load-budget.json`. [details](../../docs/dev-tools-details.md#first-load-size-gate).
 - **Cross-impl vectors**: `tools/gen-mask-vectors.mjs` (TS/Swift mask parity), `gen-theme-vectors.mjs` (`npx tsx`; regen after `theme-engine.ts` edits, asserted by `theme-vectors.test.ts` + `ThemeEngineTests.swift`).
 - **Preflight deps check**: `tools/preflight-deps.mjs` — wired via `pretypecheck`/`pretest`.
 - **Release gating**: `tools/release-plan.mjs` (Linux preflight) + `release-native.mjs` — gates macOS/iOS packaging, `slicc` Go CLI (`packages/slicc-cli/sign-and-package.sh`), Chrome Web Store/worker publish, `@ai-ecoverse/biome-jsh` (`--gate=biome-jsh-version|biome-jsh`).
-- **Optional-binary guard**: `tools/run-if-installed.mjs <binary> [args...]` — runs iff on `PATH`, else warns and exits 0; used by root `lint-staged` Swift/Go globs.
-- **e2b template**: `packages/dev-tools/e2b-template/` — hosted-leader cloud float's e2b sandbox. See `packages/cloud-core/CLAUDE.md`.
+- **Optional-binary guard**: `tools/run-if-installed.mjs <binary> [args...]` — runs iff on `PATH`, else warns and exits 0; used by `lint-staged` Swift/Go globs.
 
 ### SLICC CDP Debug + Screencast
 
@@ -46,7 +46,7 @@ Bare script names below live under `tools/` unless a fuller path is given.
 
 ### Fresh Dev Harnesses
 
-Five isolated harnesses on distinct ports; reaping is opt-in (`SLICC_FRESH_REAP=1`), port-scoped.
+Five isolated harnesses on distinct ports; reaping opt-in (`SLICC_FRESH_REAP=1`), port-scoped.
 
 | Harness (script under `tools/`)              | Bridge             | CDP     | Notes                                    |
 | -------------------------------------------- | ------------------ | ------- | ---------------------------------------- |
@@ -56,15 +56,15 @@ Five isolated harnesses on distinct ports; reaping is opt-in (`SLICC_FRESH_REAP=
 | Electron-Node `dev-electron-node-fresh.sh`   | `:5730`            | `:9225` | external Electron app (Slack)            |
 | Electron-Swift `dev-electron-swift-fresh.sh` | `:5740`            | `:9226` | Swift backend + external Electron        |
 
-Isolated lane: `PORT=5715 WRANGLER_PORT=8787 npm run dev:standalone:fresh` (also `dev:swift:fresh`, `dev:extension:fresh`, `dev:electron:{node,swift}:fresh`; `PORT=…`/`ELECTRON_APP=…`). Never touch production bridge `:5710` or Chrome CDP `:9222`. Lifecycle + reaping: [`docs/development.md`](../../docs/development.md), [details](../../docs/dev-tools-details.md#fresh-dev-harnesses).
+Isolated lane: `PORT=5715 WRANGLER_PORT=8787 npm run dev:standalone:fresh` (also `dev:swift:fresh`, `dev:extension:fresh`, `dev:electron:{node,swift}:fresh`; `PORT=…`/`ELECTRON_APP=…`). Never touch production bridge `:5710` or CDP `:9222`. [development.md](../../docs/development.md), [details](../../docs/dev-tools-details.md#fresh-dev-harnesses).
 
 ### Supporting Utilities
 
-- **Labeled Chrome clone**: `clone-labeled-chrome.sh` — APFS COW-clone with distinct `CFBundleName`/`CFBundleIdentifier` for per-harness ⌘-Tab entries; ad-hoc re-signed. No-op on non-darwin.
-- **Stable dev code-signing identity**: `bash tools/setup-dev-cert.sh` — one-time; creates persistent self-signed `SLICC Dev Code Signing`, picked up by `dev-swift-fresh.sh`.
+- **Labeled Chrome clone**: `clone-labeled-chrome.sh` — APFS COW-clone with distinct `CFBundleName`/`CFBundleIdentifier` for per-harness ⌘-Tab entries; ad-hoc re-signed. Darwin-only.
+- **Stable dev code-signing identity**: `bash tools/setup-dev-cert.sh` — one-time; creates self-signed `SLICC Dev Code Signing`, picked up by `dev-swift-fresh.sh`.
 
 ## Usage Notes
 
 - Prefer root npm scripts when a helper already has one.
-- Keep dev-only configs/utilities out of runtime packages unless required at runtime.
+- Keep dev-only configs/utilities out of runtime packages unless needed at runtime.
 - When adding tooling, document its file location and entry command.

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -1,79 +1,60 @@
 # CLAUDE.md
 
-iOS follower app in `packages/ios-app/` — native iOS 26 SwiftUI SPM project (`Package.swift`), not an npm workspace. **Follower only**: connects to a SLICC leader over WebRTC (chat + sprinkles + limited federated CDP); no agent runtime. Deep reference: [`docs/ios-app-details.md`](../../docs/ios-app-details.md).
+iOS follower app in `packages/ios-app/` — native iOS 26 SwiftUI SPM project (`Package.swift`), not an npm workspace. **Follower only**: connects to a SLICC leader over WebRTC (chat + sprinkles + limited federated CDP), no agent runtime. Deep reference: [`docs`](../../docs/ios-app-details.md).
+
+Plain SPM commands do nothing — build/test go through XcodeGen. **The Xcode project is generated from `project.yml`, not committed**: `xcodegen generate` after clone and whenever sources change.
 
 ## Layout
 
-- `SliccFollower/App/` — `SliccFollowerApp` (+ `SliccAppDelegate` for APNs callbacks), `@MainActor AppState` (`AppState+SudoApproval` = Face ID gate + push registration); inbound coordinator (`InboundActions`, `AppGroupInbox`, `OpenInSliccIntents`) + `SliccShareExtension/` funnel `slicc://open|prompt` (+`x-callback-url`), `sliccy.ai/app/*` universal links, App Intents, share URLs in `group.ai.sliccy.follower`. Deep links confirm via card (fail-closed).
-  - **App Intents entities**: `SliccConversationEntity` (`IndexedEntity`, projected from the WIDGET SNAPSHOT — queries run with the app cold, where `AppState` does not exist) and `SliccTabEntity` (`@AppEntity(schema: .browser.tab)`, live `CDPBridge` state via `SliccTabRegistry`). `OpenSliccConversationIntent` routes through the coordinator's `pendingSelection` slot. Spotlight donation rides `publishWidgetSnapshot()`. `OpenInSliccBrowserIntent` deliberately carries NO intent schema — `browser.createTab` demands a `TabEntity` return and this intent only enqueues. The whole schema catalog is identical in the iOS 26 and 27 SDKs, so only View Annotations (`View.sliccEntityAnnotation`, gated on `canImport(AppIntentsTypeSupport)`) needs the 27 SDK. Why each choice: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#app-intents-entities-and-schemas).
-- `SliccFollower/Models/` — `ScoopStatus`; `UnitRole` (the read-only rule, below); `ICloudSessionList` + `SliccFollower.entitlements` (iCloud via `SliccTraySession` + KVS); `*Avatar*`.
-- `SliccFollower/Notifications/` — `NotificationCoordinator`: `UNUserNotificationCenter` delegate, categories `SLICC_TURN_END` / `SLICC_SUDO_REQUEST` (mirrors the hub's `apns.ts`), local fallbacks, lock-screen Deny.
-- `SliccFollower/Sync/` — `Keepalive` (`DataChannelKeepalive`); `TerminalClient` (single-flight `exec.*`); `ConnectionSettle` (`ConnectionHealth` + `ConnectionSettler`, the blip hold behind `AppState.settledConnection`).
-- `SliccFollower/CDP/` — `CDPBridge` + `CDPTarget` host WKWebViews as CDP targets.
-- `SliccFollower/Views/` — `ChatView`/`MessageListView`/`MarkdownText`/`TranscriptText` (`ChatPresentationState`; compact workbench sets `toolbarSuppressed`; http(s) links open in-app unless Settings → Advanced `openLinksInBuiltInBrowser` off); `SprinkleWebView`/`InlineSprinkleView`/`SprinkleDetailView` (`.shtml`); `DockModel`/`DockRail`/`WorkbenchHost`/`LucideIcon` (48pt rail); `TerminalView`/`TerminalViewModel`; `TabsCarouselView` (full-screen hides rail via `AppState.browserViewingTabId`); `ToolProgressChrome` (bash-progress row treatment — icon fill, dots, open-body bar — off `AppState.toolProgress`).
-  - **Read-only scoop**: selecting a scoop opens a read-only transcript — `ConversationView` renders no `InputBar`, so send / dictation / attachment affordances and the reserved band all go with it, and a scoop's `tool_ui` never mounts a card (#2367, parity with the web's #2312). The rule is stated ONCE in `Models/UnitRole.swift` (`UnitRole.isReadOnly`, mirroring `isReadOnlyRole`) and reached via `AppState.selectedUnitIsReadOnly`; `ScoopSummary.isRootUnit` derives the role from the `parentId` edge and falls back to `isCone` only for leaders that predate it. Why + hooks: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#read-only-scoop-view).
-  - **Transcript short actions**: every actionable span carries a tap default and a long-press menu — web links to Sliccy's browser, other schemes to the system, phone numbers to **Messages**, inline `code` to Copy (Share on long press) and fenced blocks to Copy/Share, confirmed file mentions and base64 chips to the preview sheet (`FilePreviewSheet`: sniffed text renders as themed selectable monospace, everything else Quick Look can handle — images, PDFs, media — goes to `QLPreviewController`). Every menu is a UIKit menu — a SwiftUI `confirmationDialog` on tap reads as a different feature next to six contextual menus. Prose/list/blockquote runs paint through `Views/TranscriptText.swift` (`UITextView`) because SwiftUI `Text` has no per-span long press; headings and table cells stay on `Text` and knowingly have no menu. Entity detection mirrors the web (`Models/FileMentions.swift`, `Base64Mentions.swift`, `Base64Payload.swift`, `TranscriptInline.swift`); `FileMentionResolver` confirms a mention with ONE leader `stat` (absolute path, or a `ToolCallPathHints` match) and never walks. Why each piece is shaped that way, and the ICU-vs-JS regex trap: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#transcript-short-actions).
-  - **Markdown tables**: `MarkdownText.tableView` follows the web's `slicc-agent-message .body table` contract — a hairline-ruled card that **hugs its content** and scrolls inside itself, never a full-width band. Column widths are resolved up front in `Models/MarkdownTableLayout.swift` (`Grid` both stretches and squeezes inside a horizontal `ScrollView`); why each piece is shaped that way: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#markdown-tables).
-  - **Reading column**: the regular-width cap (`MessageListLayout.maximumReadableWidth`) is applied **per row** via `readableTranscriptColumn()`, never as a frame around the transcript's `LazyVStack` (that stack carries `scrollTargetLayout()` and cancels any wrapping centering offset). Covered by `SliccFollowerUITests/TranscriptColumnUITests`; why: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#reading-column).
-- `SliccTrayFollower/` (`swift-trayfollower`, re-exported via `TrayFollowerExports.swift`) — `Models/SyncProtocol.swift` (partial `Codable` mirror of `packages/shared-ts/src/tray-sync-protocol.ts`), `Models/{ChatMessage,TrayTypes,TrayChunkFraming}.swift`, `Networking/{TraySignaling,TrayFollowerConnector,WebRTCManager}.swift`.
-- `SliccWidgets/` — the **Cones & Scoops** home-screen widget extension (`com.sliccy.follower.widgets`, families incl. lock-screen/StandBy accessories). Four lines of `@main` + `Widget`; every pixel comes from **`packages/swift-widgetkit`** (`SliccWidgetKit`). It reads a `WidgetSnapshot` JSON from `group.ai.sliccy.follower` — a widget cannot hold a tray connection, so the app captures and the widget renders. Capture lives in `App/AppState+WidgetSnapshot.swift`: `AppState` publishes on `scoops.list`, on connection/stall flips and on `turn_end`, and clears the store when the user detaches. It reads the **settled** connection health, never the raw state, and the instance label is the display name or the join URL's HOST — never the join URL. The Developer-portal step gates TestFlight: [`docs/widgets.md`](../../docs/widgets.md).
-- `SliccTrayKit/FileProvider/` + `SliccFileProvider/` — Files.app provider for leader VFS (logic in **`packages/swift-traykit`** / `SliccTrayVFS`, re-exported via `TrayVFSExports.swift`). Appex Info.plist MUST set `NSExtensionFileProviderSupportsEnumeration` or Files hides the domain (`userEnabled=false`).
-
-Plain SPM commands do nothing on a macOS host; build/test go through XcodeGen. **Xcode project generated from `project.yml`, not committed** — run `xcodegen generate` after clone and whenever sources change.
+- `SliccFollower/App/` — `SliccFollowerApp` (+ `SliccAppDelegate` for APNs), `@MainActor AppState` (`AppState+SudoApproval` = Face ID gate + push); the inbound coordinator + `SliccShareExtension/` funnel `slicc://open|prompt` (+`x-callback-url`), `sliccy.ai/app/*` universal links, App Intents + share URLs via `group.ai.sliccy.follower`. Deep links confirm via card (fail-closed). App Intents entities & schemas (`SliccConversationEntity` cold off the snapshot): [`docs`](../../docs/ios-app-details.md#app-intents-entities-and-schemas).
+- `SliccFollower/Models/` — `ScoopStatus`; `UnitRole` (read-only rule, below); `ICloudSessionList` + `.entitlements`; `*Avatar*`.
+- `SliccFollower/Notifications/` — `NotificationCoordinator`: `UNUserNotificationCenter` delegate, categories `SLICC_TURN_END` / `SLICC_SUDO_REQUEST` (mirror hub `apns.ts`), local fallbacks + lock-screen Deny.
+- `SliccFollower/Sync/` — `Keepalive`; `TerminalClient` (single-flight `exec.*`); `ConnectionSettle` (`ConnectionHealth` + `ConnectionSettler` = blip hold behind `settledConnection`). `SliccFollower/CDP/` — `CDPBridge` + `CDPTarget` host WKWebViews as CDP targets.
+- `SliccFollower/Views/` — chat (compact workbench sets `toolbarSuppressed`; http(s) links open in-app unless `openLinksInBuiltInBrowser` off), sprinkles (`.shtml`), dock (48pt rail), `TerminalView`, `TabsCarouselView` (full-screen hides rail via `browserViewingTabId`), `ToolProgressChrome`. Invariants:
+  - **Read-only scoop** — a scoop transcript renders no `InputBar` and its `tool_ui` never mounts a card. Rule lives ONCE in `Models/UnitRole.swift` (`UnitRole.isReadOnly`), via `selectedUnitIsReadOnly`: [`docs`](../../docs/ios-app-details.md#read-only-scoop-view)
+  - **Transcript rendering** — short actions paint through `Views/TranscriptText.swift` (`UITextView`); `FileMentionResolver` confirms with ONE leader `stat`, never walks; the reading column caps **per row** (`readableTranscriptColumn()`), never around the `LazyVStack`. [`docs`](../../docs/ios-app-details.md#transcript-short-actions)
+- `SliccTrayFollower/` (`swift-trayfollower`, via `TrayFollowerExports.swift`) — sync/networking; `Models/SyncProtocol.swift` is a partial `Codable` mirror of `tray-sync-protocol.ts` (below).
+- `SliccWidgets/` — **Cones & Scoops** widget extension (`com.sliccy.follower.widgets`, incl. lock-screen/StandBy); pixels from **`packages/swift-widgetkit`** (`SliccWidgetKit`). A widget holds no tray connection, so the app captures a `WidgetSnapshot` into `group.ai.sliccy.follower` (`App/AppState+WidgetSnapshot.swift`) reading **settled** health; label is name or HOST, **never the join URL**. [`docs/widgets.md`](../../docs/widgets.md).
+- `SliccTrayKit/FileProvider/` + `SliccFileProvider/` — Files.app provider for leader VFS (logic in **`packages/swift-traykit`**/`SliccTrayVFS`, via `TrayVFSExports.swift`). Appex Info.plist MUST set `NSExtensionFileProviderSupportsEnumeration` or Files hides the domain.
 
 ## App Icon
 
-`Assets.xcassets/AppIcon.appiconset` carries three 1024s: `Icon-Default`, `Icon-Dark` and `Icon-Tinted`.
-
-`Icon-Tinted` is **hand-authored, not a desaturation of the colour icon** — master at `packages/assets/logos/slicc-icon-tinted-master-1024.png`. iOS tinted mode maps the asset's _luminance_ onto the user's tint, so an asset confined to the top of the range can only render as a flat blob. The previous `Icon-Tinted` was byte-identical to the Icon Composer `TintedLight` export and never dropped below 39% grey (min 100/255, σ 39); the current one spans the full range (min 0, σ 81) by seating a bright swirl in a near-black tub. Re-check `min`/`stddev` before replacing it:
-
-```bash
-magick Icon-Tinted.png -alpha remove -colorspace Gray \
-  -format "min=%[fx:minima*255] sd=%[fx:standard_deviation*255]\n" info:
-```
-
-It is full-bleed square (iOS applies its own superellipse mask), unlike `Icon-Dark`, which still carries pre-rounded transparent corners. The macOS side does **not** consume this PNG — Sliccstart derives its tinted appearance from `macos-icon.icon`; see [swift-launcher](../swift-launcher/CLAUDE.md#app-icon).
+`Icon-Tinted` (in `AppIcon.appiconset`) is **hand-authored, not a desaturation** and must span the full luminance range (iOS masks luminance onto the tint). Master, `min`/`stddev` re-check: [`docs`](../../docs/ios-app-details.md#app-icon).
 
 ## Protocol Mirror Invariant
 
-`SliccTrayFollower/Models/SyncProtocol.swift` mirrors a **subset** of `packages/shared-ts/src/tray-sync-protocol.ts`; the matrix in `docs/architecture.md` is source of truth. iOS-local:
+`SliccTrayFollower/Models/SyncProtocol.swift` mirrors a **subset** of `packages/shared-ts/src/tray-sync-protocol.ts`; the `docs/architecture.md` matrix is canonical. iOS-local:
 
-- `preview.open` → `CDPBridge.handleTabOpen`, acks `tab.opened`.
-- iOS never originates transcript export; those prompts decode to `.unknown` / `undecodable`.
-- `sudo.approve.request` / `.cancel` → `SudoApprovalController` (SliccTrayKit/Sudo); reply `sudo.approve.response`. Allow / Always pass `LAContext` `.deviceOwnerAuthentication` first, Deny never does. `hello` advertises `sudoApproval: true` and `biometric: true` iff the device can authenticate its owner. `push.register` carries the APNs token on every connect. Details: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#sudo-approval-and-push).
-- `capabilities.exec: true`; `handleExecMessage` accepts only `open [--universal|--x-callback] <url>`, scoped-approval gated. URL validation + tombstoning: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#exec-capability); `--x-callback` nonces, JSON result shape, 16-param / 16-KiB caps: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#x-callback-exec).
+- `preview.open` → `CDPBridge.handleTabOpen`, acks `tab.opened`. iOS never originates transcript export (prompts decode `.unknown`/`undecodable`).
+- `sudo.approve.request` / `.cancel` → `SudoApprovalController` (SliccTrayKit/Sudo): Allow/Always gate on `LAContext` `.deviceOwnerAuthentication`, Deny never does; `hello` advertises `sudoApproval`/`biometric`, `push.register` carries the APNs token. [`docs`](../../docs/ios-app-details.md#sudo-approval-and-push)
+- `capabilities.exec: true`; `handleExecMessage` accepts only `open [--universal|--x-callback] <url>`, scoped-approval gated. Validation, tombstoning, nonces/caps: [`docs`](../../docs/ios-app-details.md#exec-capability)
 
-Adding a variant is a fixed six-step order ending in the corpus + architecture matrix: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#protocol-variant-checklist).
+Adding a variant is a fixed six-step order: [`docs`](../../docs/ios-app-details.md#protocol-variant-checklist)
 
 ## Follower on `AppState`
 
-Lifecycle `connect`/`disconnect`/`dataChannelOpened`/`handleDisconnect`; `Keepalive` splits **stalled** vs **dead** (`lastError`=transport, `leaderError`=cone); dispatch via `handleDataChannelMessage`. Swipe arbitration freezes edge state at drag start and fails closed. Settle, VFS, lick and `tool_ui` invariants: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#follower-state-invariants); swipe detail: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#transcript-swipe-arbitration).
+`Keepalive` splits **stalled** vs **dead** (`lastError`=transport, `leaderError`=cone); dispatch via `handleDataChannelMessage` (the only iOS switch). Swipe arbitration freezes edge state at drag start, fails closed. Settle, VFS, lick, `tool_ui`, swipe: [`docs`](../../docs/ios-app-details.md#follower-state-invariants).
 
 ## iCloud Sessions
 
-`AppState.sessionStore` uses **`packages/swift-traysession`**; launcher publishes, `SettingsView` joins. Liveness requires a connected leader. KVS `S8LB56P782.ai.sliccy.trays` MUST match macOS. Unprovisioned builds have no cache; `SLICC_IOS_NO_ICLOUD=1` omits iCloud. **Never expose `joinUrl`.** Attach loops after reconnect must follow `TRAY_SUPERSEDED` / `SupersedeRedirect`: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#icloud-tray-supersede-chain).
+`AppState.sessionStore` uses **`packages/swift-traysession`**; launcher publishes, `SettingsView` joins. Liveness needs a connected leader. KVS `S8LB56P782.ai.sliccy.trays` MUST match macOS; `SLICC_IOS_NO_ICLOUD=1` omits iCloud. **Never expose `joinUrl`.** Reconnect attach loops must follow `TRAY_SUPERSEDED`/`SupersedeRedirect`: [`docs`](../../docs/ios-app-details.md#icloud-tray-supersede-chain).
 
-**Recent joins**: `AppState.recentJoinStore` (`RecentJoinStore`) records the join URL on `dataChannelOpened` — every path (paste, deep link, iCloud row, stored credentials), after any supersede hop, never at dial time — and syncs it, so a URL pasted on one device reaches the others. `SettingsView` renders the "Recent" section from `ICloudSessionList.recentRows` (live sessions excluded, `RecentJoinStore.rank` order, five rows); rows show label-or-`displayHost` and **never the join URL**. Replaced the device-local `joinUrlHistory`. Hooks: `-uiTestRecentJoinsFixture/Empty`.
-
-**Frozen sessions**: `FrozenSessions.swift` mirrors `transcript/frozen-archive-format.ts`; opens saved transcripts read-only. Hook: `-uiTestFrozenFixture/Empty`.
+**Recent joins**: `RecentJoinStore` records + syncs on `dataChannelOpened` (never at dial time); `SettingsView` shows label-or-`displayHost`, **never the join URL** (hooks `-uiTestRecentJoinsFixture/Empty`): [`docs`](../../docs/ios-app-details.md#recent-joins). **Frozen sessions**: `FrozenSessions.swift` mirrors `transcript/frozen-archive-format.ts`, opening saved transcripts read-only (`-uiTestFrozenFixture/Empty`).
 
 ## Push to Talk
 
-Hold empty composer to dictate (`PttController` + `Dictation`/`SFSpeechRecognizer`); release calls `InputBar.submit(_:dictated:)`. Only dictated replies speak: English uses Kokoro, others `AVSpeechSynthesizer`; typed turns silent. `AudioSessionCoordinator` solely owns `AVAudioSession`. Hooks: `-uiTestSpeechPermission/Script`, `-uiTestPttStage`. Kokoro pack (~83 MB, Wi-Fi consent; replies never provision): [`docs/ios-app-details.md`](../../docs/ios-app-details.md#local-kokoro-models). QA: [`docs/ios-simulator-qa.md`](../../docs/ios-simulator-qa.md).
+Hold empty composer to dictate; only dictated replies speak (typed turns silent). `AudioSessionCoordinator` solely owns `AVAudioSession`. Mechanism + hooks: [`docs`](../../docs/ios-app-details.md#push-to-talk); Kokoro pack (~83 MB, Wi-Fi consent): [`docs`](../../docs/ios-app-details.md#local-kokoro-models).
 
 ## Terminal
 
-`InMemoryTerminalSession` + `TerminalClient` exec against the leader shell (`hello.capabilities.exec`). One virtual shell per connection; Ctrl-C → `SIGINT` until `exec.response`.
+`InMemoryTerminalSession` + `TerminalClient` exec against the leader shell (`hello.capabilities.exec`), one shell per connection. [`docs`](../../docs/ios-app-details.md#terminal)
 
 ## Agent Avatar
 
-`SliccAgentAvatarView` mirrors the browser `<slicc-agent-avatar>`. Fullness = pupil size only, never ring/gauge/badge/text; recoverable state stays in avatar/composer (no banner row). Header layout, static treatment, a11y phrase and fixtures: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#agent-avatar-chrome).
+`SliccAgentAvatarView` mirrors the browser `<slicc-agent-avatar>`; fullness = pupil size only, recoverable state stays in avatar/composer (no banner row). Chrome, expression kit, fixtures: [`docs`](../../docs/ios-app-details.md#agent-avatar-chrome). Two invariants:
 
-The home-screen widget carries a **static** copy of this geometry AND of the expression grammar in `packages/swift-widgetkit` (`UnitAvatarGeometry` / `UnitAvatarFace`) — a widget process has no sensors, no frame callback and a hard memory budget, so it gets each phase at the pose `settle` lands on and none of the integrator. Parity is pinned by `UnitAvatarGeometryTests` against the values `SliccAgentAvatarGeometryTests` asserts here; changing a ratio in this file means changing it there. Why they are not one type: [`docs/widgets.md`](../../docs/widgets.md#the-avatar).
-
-**Expression kit**: `Models/AvatarExpression.swift` (UI-free grammar, band units) + `Models/AvatarExpressionEngine.swift` (integrator; time is a parameter, never ambient) drive shape morph, brows, chord-cut lids and gaze. `SliccAgentAvatarGeometry.activity == nil` keeps the legacy face; `expressionScale` is the only band→points bridge. **The brows paint outside the tile crop**: `.clipShape` wraps the tile layer only, `ExpressiveAvatarBrows` rides over it in band space, so hosts must not clip an avatar (~3pt of overhang at 26pt) and a blink no longer folds the brows onto the eyeball. Precedence: **local derivation > wire refinement > state** — `AppState.localExpressionSignals` owns the FOCUSED scoop, `ScoopSummary.activity` drives every other tab, `state` stays the closed four-value union so older followers are untouched. Parity gated by `Fixtures/expression-vectors.json` (both suites).
-
-Trouble reaches the surface only after `ConnectionSettler.holdDuration` (recovery lands at once), and **no connection state may reach the composer's first-responder layer** — not `.disabled`, not `allowsHitTesting`, not mounting anything above the editor. Only sending is gated; a regression test must stage a blip that HEALS. Details: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#agent-avatar-treatment).
+- The widget holds a **static** copy of this geometry + expression grammar in `packages/swift-widgetkit` (`UnitAvatarGeometry`/`UnitAvatarFace`); parity is pinned by `UnitAvatarGeometryTests` against `SliccAgentAvatarGeometryTests` here — a ratio change here means changing it there. [`docs/widgets.md`](../../docs/widgets.md#the-avatar).
+- Trouble surfaces only after `ConnectionSettler.holdDuration` (recovery lands at once), and **no connection state may reach the composer's first-responder layer** (not `.disabled`, `allowsHitTesting`, or anything mounted above the editor). Only sending is gated; a regression test must stage a blip that heals.
 
 ## Build
 
@@ -88,27 +69,27 @@ swiftlint lint
 
 ## Test + coverage
 
-Run `xcodebuild test` on a simulator. Coverage gate boots an iPhone matching the simulator SDK, retries infra failures, enforces `coverage-thresholds.json`. Override via worktree-owned `SLICC_IOS_SIM_UDID`. **Never pass `CODE_SIGNING_ALLOWED=NO` to tests** (XCTest needs ad-hoc signing).
+Run `xcodebuild test` on a simulator. The coverage gate boots a matching iPhone, retries infra failures, enforces `coverage-thresholds.json` (`SliccFollowerTests` only); override with `SLICC_IOS_SIM_UDID`. **Never pass `CODE_SIGNING_ALLOWED=NO` to tests** (XCTest needs ad-hoc signing).
 
 ```bash
 ./packages/dev-tools/tools/swift-coverage-check.sh \
   --xcodebuild SliccFollower packages/ios-app SliccFollower
 ```
 
-Outputs in `.build/coverage/`; the gate runs only `SliccFollowerTests`. Object selection, the `SliccFileProvider/` exclusion, and the memory-bound File Provider read limit: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#coverage-gate-details).
+Object selection, `SliccFileProvider/` exclusion: [`docs`](../../docs/ios-app-details.md#coverage-gate-details).
 
 ## UI tests (`SliccFollowerUITests`)
 
-`bundle.ui-testing` stays in the scheme; the unit gate excludes it. No test needs a leader — every fixture runs off a `#if DEBUG` launch-argument hook. **CI runs the whole bundle** on both GA cells of `ios-app-tests`, minus `ui-test-exclusions.json` — so a new class is gated the day it lands, and leaving CI takes an entry in that registry with a written reason (`npm run lint:ios-ui-tests` rejects stale ones). Hook list: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#ui-test-hooks); authoring rules: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#ui-test-details).
+`bundle.ui-testing` stays in the scheme; the unit gate excludes it. No test needs a leader — every fixture runs off a `#if DEBUG` launch-argument hook. **CI runs the whole bundle** (both `ios-app-tests` GA cells) minus `ui-test-exclusions.json`; leaving CI takes an entry there with a reason (`npm run lint:ios-ui-tests` rejects stale). Hooks + rules: [`docs`](../../docs/ios-app-details.md#ui-test-details).
 
 ## Linting
 
-SwiftLint + `swift format` inherit repo-root configs; only `error` severity fails CI. Run `npm run lint:swift:format` / `format:swift` from repo root. Details: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#linting-details).
+SwiftLint + `swift format` inherit repo-root configs; only `error` severity fails CI. `npm run lint:swift:format`/`format:swift` from repo root. [`docs`](../../docs/ios-app-details.md#linting-details).
 
 ## TestFlight
 
-Releases run `scripts/package-and-upload-testflight.sh` (secrets via `setup-testflight-secrets.sh`), path-gated by `release-native.mjs`. Script **soft-skips with exit 0** when `SLICC_SKIP_TESTFLIGHT=1`, an Apple secret is missing/`-`, or default Xcode < 26 (a green release is not proof an ipa shipped). Distribution + What to Test copy: [`docs/ios-app-details.md`](../../docs/ios-app-details.md#testflight-distribute).
+Releases run `scripts/package-and-upload-testflight.sh` (secrets via `setup-testflight-secrets.sh`), path-gated by `release-native.mjs`. It **soft-skips with exit 0** when `SLICC_SKIP_TESTFLIGHT=1`, an Apple secret is missing/`-`, or default Xcode < 26 — green is no proof an ipa shipped. Distribution: [`docs`](../../docs/ios-app-details.md#testflight-distribute).
 
 ## Related
 
-`packages/shared-ts/src/tray-sync-protocol.ts` (canonical), `packages/webapp/src/scoops/tray-leader-sync.ts`, `packages/webapp/src/scoops/tray-follower-sync.ts`, `packages/webapp/src/ui/sprinkle-follower-controller.ts`; `docs/architecture.md` "Multi-Browser Sync (Tray) Architecture"; `docs/ios-simulator-qa.md`; `docs/ios-app-details.md`.
+`packages/shared-ts/src/tray-sync-protocol.ts` (canonical), `packages/webapp/src/scoops/{tray-leader-sync,tray-follower-sync}.ts`, `packages/webapp/src/ui/sprinkle-follower-controller.ts`; `docs/architecture.md` "Multi-Browser Sync (Tray)"; [`docs`](../../docs/ios-simulator-qa.md).

--- a/packages/ios-app/CLAUDE.md
+++ b/packages/ios-app/CLAUDE.md
@@ -27,7 +27,7 @@ Plain SPM commands do nothing — build/test go through XcodeGen. **The Xcode pr
 
 - `preview.open` → `CDPBridge.handleTabOpen`, acks `tab.opened`. iOS never originates transcript export (prompts decode `.unknown`/`undecodable`).
 - `sudo.approve.request` / `.cancel` → `SudoApprovalController` (SliccTrayKit/Sudo): Allow/Always gate on `LAContext` `.deviceOwnerAuthentication`, Deny never does; `hello` advertises `sudoApproval`/`biometric`, `push.register` carries the APNs token. [`docs`](../../docs/ios-app-details.md#sudo-approval-and-push)
-- `capabilities.exec: true`; `handleExecMessage` accepts only `open [--universal|--x-callback] <url>`, scoped-approval gated. Validation, tombstoning, nonces/caps: [`docs`](../../docs/ios-app-details.md#exec-capability)
+- `capabilities.exec: true`; `handleExecMessage` accepts only `open [--universal|--x-callback] <url>`, scoped-approval gated. Validation + tombstoning: [`docs`](../../docs/ios-app-details.md#exec-capability); `--x-callback` nonces, JSON result, 16-param/16-KiB caps: [`docs`](../../docs/ios-app-details.md#x-callback-exec)
 
 Adding a variant is a fixed six-step order: [`docs`](../../docs/ios-app-details.md#protocol-variant-checklist)
 

--- a/packages/slicc-cli/CLAUDE.md
+++ b/packages/slicc-cli/CLAUDE.md
@@ -1,184 +1,152 @@
 # slicc-cli
 
-`slicc` — headless SLICC **follower** CLI in Go, joining a leader over the
-same WebRTC tray-control data channel as browser + iOS followers. **Go
-module, not an npm workspace** (like `packages/ios-app`) — built with
-`go`/`make`, not `npm`. Deep-dive:
-[`docs/slicc-cli-details.md`](../../docs/slicc-cli-details.md).
+`slicc` — headless SLICC **follower** CLI in Go, joining a leader over the same
+WebRTC tray-control data channel as browser + iOS followers. **Go module, not an
+npm workspace** (like `packages/ios-app`) — built with `go`/`make`, not `npm`.
+Deep-dive: [`docs/slicc-cli-details.md`](../../docs/slicc-cli-details.md).
 
 ```
 slicc <join-url> prompt "<text>"                Stream one assistant turn, then exit
 slicc <join-url> exec "<command>"               Run a command in the leader's shell, stream output
 slicc <join-url> watch [--plain] [scoop]        Tail the leader's live agent output, read-only
 slicc <join-url> follow [--no-banner] [--plain] [runner]
-                                                Stay connected; run leader-issued commands via <runner>
-slicc <join-url> follow --eval [repl]           Same, into ONE persistent REPL (state persists; see README)
+                                                Stay connected; run leader commands via <runner>
+slicc <join-url> follow --eval [repl]           Same, into ONE persistent REPL
 slicc update [--check]                          Self-update to the newest released CLI binary
-slicc list-sessions [--json]                    List iCloud-synced tray sessions (macOS only; no join URLs)
-slicc <verb>-cloud [--index N|--session <id>]   Resolve a session's join URL from iCloud, then run <verb>
+slicc list-sessions [--json]                    List iCloud tray sessions (macOS; no join URLs)
+slicc <verb>-cloud [--index N|--session <id>]   Resolve a session's join URL from iCloud, run <verb>
 ```
 
 - `watch` — passive `tail -f` mirror; sends nothing, reconnects with backoff.
-  **Does NOT filter by scoop by default** — the cone's `scoopJid` is a
-  generated uid (not `"cone"`); pass a scoop jid to filter. Render map:
-  [details](../../docs/slicc-cli-details.md).
+  **Does NOT filter by scoop by default** — the cone's `scoopJid` is a generated
+  uid (not `"cone"`); pass a scoop jid to filter.
+  [Render](../../docs/slicc-cli-details.md#watch-rendering).
 - `<text>`/`<command>` is curl-style: literal, `@path` (file), `-` / `@-`
-  (stdin) — e.g. `git log | slicc <url> exec -`,
-  `slicc <url> prompt @brief.md`. `readTextArg` (`main.go`) only fires for a
-  single `@…`/`-` arg; multi-word prompts join verbatim.
+  (stdin) — e.g. `git log | slicc <url> exec -`, `slicc <url> prompt @brief.md`.
+  `readTextArg` only fires for a single `@…`/`-` arg; multi-word prompts join
+  verbatim.
 - The trailing argv of `follow` is the **runner** — each leader command is
-  appended as the final arg: `follow bash -c`, `follow sh -c`,
-  `follow docker exec -i sandbox sh -c`, a multiplexer,
-  `flatpak-spawn --host …`. **With no runner, `follow` refuses every command.**
+  appended as the final arg (`follow bash -c`, `follow docker exec -i sandbox
+sh -c`). **With no runner, `follow` refuses every command.**
 
 ## iCloud tray sessions (`list-sessions`, `<verb>-cloud`)
 
 macOS only. `internal/cloud` **shells out** to `Sliccstart --list-sessions`
 (cgo + entitlements would break `CGO_ENABLED=0`); `LocateExecutable` tries
-`$SLICCSTART_APP` → `mdfind` (bundle id `com.slicc.sliccstart`) →
-`/Applications` → `~/Applications`. Off macOS: `ErrUnsupported`.
+`$SLICCSTART_APP` → `mdfind` → `/Applications` → `~/Applications`. Off macOS:
+`ErrUnsupported`.
 
 - `list-sessions [--json]` — **metadata only** (opaque id, label, device,
   age), **never a join URL** — safe to pipe/log.
-- `<verb>-cloud` (`follow`/`prompt`/`exec`/`watch`) resolves a session's
-  **join URL** via `--reveal-urls` (Mac consent prompt; denied over SSH
-  until granted once from the screen) then dispatches. **URL never printed.**
-  Newest by default; `--index N` / `--session <id-prefix>` (`ParseSelector`)
-  picks another; remaining argv verbatim.
+- `<verb>-cloud` (`follow`/`prompt`/`exec`/`watch`) resolves a session's **join
+  URL** via `--reveal-urls` (Mac consent prompt; denied over SSH until granted
+  once from the screen) then dispatches. **URL never printed.** Newest by
+  default; `--index N` / `--session <id-prefix>` picks another; remaining argv
+  verbatim.
 
-Pure logic (`ParseSessions`, `ParseSelector`, `Select`, `FormatTable`) is
+Pure logic (`ParseSessions`/`ParseSelector`/`Select`/`FormatTable`) is
 platform-independent + unit-tested; darwin-only exec/locate lives in
-`resolve_darwin.go`; the `cloudList` seam in `cloud.go` is overridden in
-tests.
+`resolve_darwin.go` (`cloudList` seam overridden in tests).
 
 ## Why Go + pion
 
-`github.com/pion/webrtc/v4` is pure Go — the follower cross-compiles to a
-single static binary for macOS/Linux/Windows × amd64/arm64 with
-`CGO_ENABLED=0` (`dist` target). Interoperates with browser leaders +
-Cloudflare TURN. No native toolchain.
+`github.com/pion/webrtc/v4` is pure Go — the follower cross-compiles to a single
+static binary for macOS/Linux/Windows × amd64/arm64 (`CGO_ENABLED=0`, `dist`
+target), interoperating with browser leaders + Cloudflare TURN.
 
 ## Layout
 
 `main.go` (argv + dispatch), `commands.go` (`prompt`/`exec`/`follow`),
 `cloud.go` (`list-sessions` + `<verb>-cloud`), `update.go`, `telemetry.go`,
-`internal/{protocol,signaling,tray,cloud,execrun,update,logging,ui}/`. Full
-per-file map: [details](../../docs/slicc-cli-details.md#layout).
+`internal/{protocol,signaling,tray,cloud,execrun,update,logging,ui}/`. Per-file
+map: [details](../../docs/slicc-cli-details.md#layout).
 
 ## Protocol parity
 
-`internal/protocol` mirrors a subset of the canonical TS union. The golden
-corpus (`packages/webapp/src/scoops/tray-sync-protocol-corpus.ts` →
+`internal/protocol` mirrors a subset of the canonical TS union. A golden corpus
+(`packages/webapp/src/scoops/tray-sync-protocol-corpus.ts` →
 `packages/ios-app/SliccFollower/Tests/SliccFollowerTests/Fixtures/tray-sync-corpus.json`)
-is decoded by `internal/protocol/corpus_test.go` for `exec.*`/`hello`/`status`;
-a wire change breaks `go test`. On protocol changes, regenerate the corpus
-JSON and update Go structs + `corpus_test.go` alongside TS + Swift mirrors.
+is decoded by `internal/protocol/corpus_test.go` for `exec.*`/`hello`/`status`,
+so a wire change breaks `go test`. On protocol changes, regenerate the corpus
+JSON and update the Go structs alongside the TS + Swift mirrors.
 
 ## Diagnostics vs user-facing output
 
-- **User-facing** — `prompt`/`exec`/`watch` write leader bytes to stdout,
-  status to stderr. **Never route through the logger**; the CLI is pipeable.
+- **User-facing** — `prompt`/`exec`/`watch` write leader bytes to stdout, status
+  to stderr. **Never route through the logger**; the CLI is pipeable.
 - **Diagnostics** — signaling retries, supersede redirects (`OnJoinURLChanged`
   persists the replacement across `follow`/`watch` reconnects), ICE failures,
-  unparseable frames go through `internal/logging` (`log/slog` `diagLogger`
-  in `commands.go`, to stderr); `debugLogf` adapts to `tray.Options.Logf`.
-- **pion's own records** — `Conn.pionLoggerFactory` installs
-  `logging.PionFactory` on `SettingEngine.LoggerFactory`. **Required**: left
-  nil, webrtc installs pion's default factory, which writes error records
-  straight to `os.Stderr` — TURN refresh churn (`turnc ERROR: Fail to refresh
-permissions`) then buries the CLI's own output and no log level of ours can
-  quiet it. Warn-and-above records are tallied into the status bar
-  (`tray.Options.OnLinkDiag`) instead of printed.
+  and unparseable frames go through `internal/logging` (`diagLogger` → stderr);
+  `debugLogf` adapts to `tray.Options.Logf`.
+- **pion's own records** — `Conn.pionLoggerFactory` installs `logging.PionFactory`
+  on `SettingEngine.LoggerFactory`. **Required**: left nil, webrtc's default
+  factory writes errors to `os.Stderr` and TURN churn buries the CLI's output.
+  [Why + `LogWanted`](../../docs/slicc-cli-details.md#pions-own-logging).
 
-Off by default. `SLICC_DEBUG=1` (legacy = `SLICC_LOG_LEVEL=debug`) or
-`SLICC_LOG_LEVEL=debug|info|warn|error`; `SLICC_LOG_FORMAT=json` swaps
-`slog.TextHandler` for `slog.JSONHandler`.
+Off by default. `SLICC_DEBUG=1` (= `SLICC_LOG_LEVEL=debug`) or
+`SLICC_LOG_LEVEL=debug|info|warn|error`; `SLICC_LOG_FORMAT=json` selects the
+JSON handler.
 
 ## Terminal presentation (`internal/ui`)
 
 `follow`/`watch` render through `internal/ui` (stdlib + `golang.org/x/sys`, raw
 ANSI — no TUI framework). On an interactive terminal `follow` keeps a **sticky
-one-line status bar** below the log: state badge (connect spinner, live retry
-countdown), uptime, `♥` age of the last frame from the leader (fed by
-`tray.Options.OnActivity`, which fires on _every_ inbound frame — the leader
-answers pings rather than sending them, so keepalives alone would never
-populate it), exec + reconnect counts, suppressed link diagnostics,
-`user@host · runner`, and a per-5s connection-history strip.
-Event lines are stamped, colored and glyph-marked; an identical repeat folds in
-place as `(×N)`, or into a compact `↺ repeated (×N)` row when the event cannot
-be rewritten safely (too tall, soft-wrapped, or holding text whose cell width we
-cannot be sure of — emoji, CJK, invalid bytes). So a reconnect loop no longer
-scrolls the screen away.
+one-line status bar** below the log (connection state, uptime, `♥` leader-frame
+age, exec/reconnect counts, link diagnostics, `user@host · runner`, history
+strip); identical event repeats fold in place as `(×N)`. **The bar must own the
+last row**, so it is dropped (colors kept) whenever another writer shares the
+stream — `watch` on a terminal **stdout**, or any verb once the diagnostic
+logger is up (`SLICC_DEBUG=1` → stderr); both decided in `commands.go`.
 
-**The bar must own the last row**, so it is dropped (colors kept) when anything
-else writes to the same stream: `watch` when **stdout** is also a terminal (its
-transcript arrives in partial lines), and any verb once the diagnostic logger is
-turned up (`SLICC_DEBUG=1` and friends write to **stderr** directly). Both
-decisions live in `commands.go` — `watchModes` and `stickyUnlessLogging`.
-
-**Plain mode is the contract**: with no terminal attached, output is
-byte-for-byte the pre-TUI `slicc <verb>: <msg>` text, escape-free, with every
-occurrence kept. Cursor control is never written to a non-terminal.
-`--plain` / `SLICC_NO_TUI=1` force plain; `NO_COLOR` keeps the bar without
-color; `FORCE_COLOR`/`CLICOLOR_FORCE` colors a redirected stream (still not
-sticky); `COLUMNS` overrides the detected width. Design notes + the glyph/ASCII
-fallback rules: [details](../../docs/slicc-cli-details.md).
+**Plain mode is the contract**: with no terminal, output is byte-for-byte the
+pre-TUI `slicc <verb>: <msg>` text, escape-free, every occurrence kept; cursor
+control never hits a non-terminal. `--plain`/`SLICC_NO_TUI=1` force plain;
+`NO_COLOR`, `FORCE_COLOR`/`CLICOLOR_FORCE`, and `COLUMNS` tune the rest.
+[Details](../../docs/slicc-cli-details.md#terminal-presentation-internalui).
 
 ## Exec safety (`follow`)
 
 A `follow` with a runner advertises `hello.capabilities.exec = true`; each
-command runs as `<runner> <command>` (runner sandboxes the exec surface),
-as the user who started `slicc`, echoed to stderr (`follow.Session` writes a
-bare `exec: <command>`; the console owns the prefix and styling). **A `follow` with no
-runner advertises no capability and refuses every `exec.request` with an
-error.** Banner + safety warning on start (`--no-banner` drops art, keeps
-warning); `runnerExecWarning` flags the `follow bash` vs `follow bash -c`
-footgun; MOTD (`hello.motd`, `followMotd`) surfaces via the leader's
-`ssh --list` (`tray-leader-sync.ts` tags `[ssh]` / `[playwright]` in
-`host`). Additive + optional on the wire.
-[Details](../../docs/slicc-cli-details.md).
+command runs as `<runner> <command>` (runner sandboxes the exec surface), as the
+user who started `slicc`, echoed to stderr. **A `follow` with no runner
+advertises no capability and refuses every `exec.request`.** On start a banner +
+safety warning prints (`--no-banner` drops the art); `runnerExecWarning` flags
+the `follow bash` vs `follow bash -c` footgun; the MOTD surfaces via `ssh --list`
+(tagged `[ssh]`/`[playwright]`).
+[Wiring](../../docs/slicc-cli-details.md#follow-startup-ergonomics).
 
 ## follow `--eval` (persistent REPL)
 
 `execrun.EvalSession` spawns the runner ONCE; responses framed by **output
-quiescence** (`--eval-quiet`, default 500 ms) — REPLs never signal
-completion. **Session outlives connections and drops**: cancelled
-per-connection contexts run `interruptProcess` (SIGINT to the group; no-op
-on Windows) but never kill the REPL; only `Close` and leader-sent
-SIGTERM/SIGKILL do. `req.Cwd`/`req.Env` ignored; exec exit codes 0 while
-REPL lives. `follow.NewEvalSession` routes `exec.request` in; MOTD
-advertises a REPL target. Banner warns about `node` without `-i`.
-[Details](../../docs/slicc-cli-details.md).
+quiescence** (`--eval-quiet`, default 500 ms) since REPLs never signal
+completion. **Session outlives connections and drops**: a cancelled
+per-connection context interrupts the in-flight computation (SIGINT; no-op on
+Windows) but never kills the REPL — only `Close` and leader-sent SIGTERM/SIGKILL
+do. `req.Cwd`/`req.Env` ignored; exec exit codes 0 while the REPL lives.
+[Lifecycle](../../docs/slicc-cli-details.md#follow---eval-persistent-repl-lifecycle).
 
 ## Self-update (`slicc update`)
 
-`internal/update` scans GitHub releases newest→oldest for the first with
-this platform's `slicc-<os>-<arch>[.exe]` asset — releases are **sparse**
-(CLI binaries only attach when `packages/slicc-cli` changed); same bounded
-pagination as the worker's `/download/slicc-cli` route (30/page, 5 pages
-max). `Apply` downloads, sanity-gates via `--version`, then atomically
-renames over the running binary (Windows parks the old at `.old`).
-`startUpdateNotice()` (`update.go`) refreshes
-`<user-cache-dir>/slicc/update-check.json` at most once per 24 h.
-`SLICC_NO_UPDATE_CHECK=1` disables it; `IsReleaseVersion` gates both notice
-and self-replace, so **`slicc update` refuses to clobber a local build
-ahead of the latest tag** (`dev`, `git describe`). `SLICC_UPDATE_API_BASE`
-overrides the API base. [Details](../../docs/slicc-cli-details.md).
+`internal/update` scans GitHub releases newest→oldest for the first with this
+platform's `slicc-<os>-<arch>[.exe]` asset — releases are **sparse** (CLI
+binaries attach only when `packages/slicc-cli` changed), so `releases/latest`
+won't do. `startUpdateNotice()` refreshes a cached notice at most once per 24 h;
+`SLICC_NO_UPDATE_CHECK=1` disables it. `IsReleaseVersion` gates both notice and
+self-replace, so **`slicc update` refuses to clobber a local build ahead of the
+latest tag**. `SLICC_UPDATE_API_BASE` overrides the API base.
+[Details](../../docs/slicc-cli-details.md#self-update-mechanics).
 
 ## Telemetry
 
-`telemetry.go` wires `packages/go-optel` (sibling Go module via local
-`replace`) into two checkpoints: `enter` on launch (`initTelemetry` from
-`main.go`'s `run()`) and `error` on operational failure
-(`reportRuntimeError(source, err)` from dial-error branches in
-`commands.go` and update-check/apply branches in `update.go`). **`source`
-is always one of a fixed set (`dial`, `watch`, `follow`, `update`) — never
-user-typed input** (join URL, exec/prompt text); `classifySubcommand`
-allowlists the `enter` beacon's subcommand. `SLICC_NO_TELEMETRY=1` opts
-out; `update.IsReleaseVersion(version)` means a `dev`/git-describe build
-never configures a client. See `packages/go-optel/CLAUDE.md` for why
-`Sanitize()` is **mandatory** — CLI error strings can embed a bearer-token
-join URL — and `docs/operational-telemetry.md` ("CLI Telemetry").
+`telemetry.go` wires `packages/go-optel` (sibling Go module via local `replace`)
+into two checkpoints: `enter` on launch and `error` on operational failure. **The
+`error` `source` and the `enter` subcommand are always drawn from a fixed
+allowlist (`dial`/`watch`/`follow`/`update`, `classifySubcommand`) — never
+user-typed input.** `SLICC_NO_TELEMETRY=1` opts out; a `dev`/git-describe build
+never configures a client. `Sanitize()` is **mandatory** (CLI error strings can
+embed a bearer-token join URL): see `packages/go-optel/CLAUDE.md`,
+`docs/operational-telemetry.md`, and the
+[rationale](../../docs/slicc-cli-details.md#telemetry-design-rationale).
 
 ## Build / test / release
 
@@ -186,24 +154,18 @@ join URL — and `docs/operational-telemetry.md` ("CLI Telemetry").
 make build          # → bin/slicc
 make check          # CI gate: gofmt + tidy-check + vet + golangci-lint + race + coverage floor
 make lint           # golangci-lint (.golangci.yml)
-make tidy-check     # fail when go.mod/go.sum drift from imports
+make tidy-check     # fail when go.mod/go.sum drift from imports (Go analogue of TS knip)
 make cover          # race tests + COVER_MIN floor (default 58%)
 make test-json      # per-test timings → test-report.json (CI artifact)
 make dist           # cross-compiled static binaries → dist/
 ```
 
-**No retry wrapper**: every test is hermetic. Gates via `make check` in
-the `slicc-cli` CI job: staticcheck/errcheck/unused + funlen/gocyclo/
-gocognit; `make tidy-check` (Go analogue of TS knip); `COVER_MIN` floor.
+`make check` is the CI gate; every test is hermetic — **no retry wrapper**.
 
 Release binaries cut **atomically with semantic-release** and only when
 `packages/slicc-cli/` changed since the last tag: `release-native.mjs`
-(prepareCmd gate) invokes `sign-and-package.sh` when `decideSliccCliGating`
-opens, cross-compiling every target on the macOS runner, Developer
-ID-signing + notarizing the darwin binaries (`APPLE_CERTIFICATE_BASE64` +
-`APPLE_API_KEY_*`), staging `artifacts/release/slicc-*` for
-`@semantic-release/github`. **A bare CLI binary can't be stapled**;
-Gatekeeper verifies notarization online. Without cert (fork/local): stages
-unsigned instead of failing. Full pipeline + OS-matrix rationale
-(`testRunner()`, `integration_test.go` pion↔pion loopback):
-[details](../../docs/slicc-cli-details.md).
+(prepareCmd gate) invokes `sign-and-package.sh` when `decideSliccCliGating` opens
+— cross-compiling on the macOS runner, Developer ID-signing + notarizing the
+darwin binaries (unsigned without a cert). Full pipeline + OS-matrix rationale:
+[signing](../../docs/slicc-cli-details.md#release-signing--notarization-pipeline),
+[OS matrix](../../docs/slicc-cli-details.md#os-matrix-and-integration-test).

--- a/packages/swift-server/CLAUDE.md
+++ b/packages/swift-server/CLAUDE.md
@@ -4,15 +4,15 @@ Native macOS server in `packages/swift-server/`.
 
 ## Scope
 
-A Hummingbird standalone server: launches Chrome/Electron, proxies CDP, exposes the lick WebSocket/event surface, and owns the `/api` bridge (fetch-proxy, sign-and-forward, OAuth callback, secrets). Serves **no** UI in any mode (matching node-server — thin-bridge in **every** mode): no `--dev` flag, no bundled `dist/ui`, no `StaticFileMiddleware` / `--static-root`.
+A Hummingbird standalone server: launches Chrome/Electron, proxies CDP, exposes the lick WebSocket/event surface, and owns the `/api` bridge (fetch-proxy, sign-and-forward, OAuth callback, secrets). Serves **no** UI in any mode (like node-server — thin-bridge everywhere): no `--dev`, no bundled `dist/ui`, no `StaticFileMiddleware` / `--static-root`.
 
 ## Thin-bridge parity
 
-Swift-server and `packages/node-server/` are byte-for-byte compatible bridges. Chrome/Electron pages load the hosted webapp (`https://www.sliccy.ai` or `http://localhost:8787` in wrangler dev) with local bridge via `?bridge=ws://localhost:<cdpPort>/cdp&bridgeToken=<token>` (Electron: `/electron?...&role=leader|follower`). `CDPProxy.swift` echoes `slicc.bridge.v1.<token>` per RFC 6455. See [`docs/architecture.md`](../../docs/architecture.md#thin-bridge-architecture).
+Swift-server and `packages/node-server/` are byte-for-byte compatible bridges. Chrome/Electron pages load the hosted webapp (`https://www.sliccy.ai`, or `http://localhost:8787` in wrangler dev) with local bridge via `?bridge=ws://localhost:<cdpPort>/cdp&bridgeToken=<token>` (Electron: `/electron?...&role=leader|follower`). `CDPProxy.swift` echoes `slicc.bridge.v1.<token>` per RFC 6455. See [`docs/architecture.md`](../../docs/architecture.md#thin-bridge-architecture).
 
-Both launchers (`ChromeLauncher.buildLaunchArgs` here, node-server's `chrome-launch.ts` — kept byte-identical) disable Chromium local-network-access checks and every background-throttling feature, so a backgrounded leader is never frozen. Flag list and rationale: [`docs/swift-server-details.md`](../../docs/swift-server-details.md#chrome-launch-flags), [`docs/pitfalls.md`](../../docs/pitfalls.md).
+Both launchers (`ChromeLauncher.buildLaunchArgs` here, node-server's `chrome-launch.ts` — byte-identical) disable Chromium local-network-access checks and every background-throttling feature, so a backgrounded leader is never frozen. Flags/rationale: [`docs/swift-server-details.md`](../../docs/swift-server-details.md#chrome-launch-flags), [`docs/pitfalls.md`](../../docs/pitfalls.md).
 
-The Electron overlay (`Sources/Browser/ElectronLauncher.swift`) is **thin-bridge only** (legacy Path A bundled overlay retired). Bootstrap `window.__SLICC_ELECTRON_OVERLAY__.inject()` embeds from `dist/ui/electron-overlay-entry.js` (in `Contents/Resources/slicc/`), built by `@ai-ecoverse/spoon` (`node packages/spoon/build.mjs`); node-server reads the same file. Internals: [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
+The Electron overlay (`ElectronLauncher.swift`) is **thin-bridge only**. Bootstrap `window.__SLICC_ELECTRON_OVERLAY__.inject()` embeds `dist/ui/electron-overlay-entry.js` (in `Contents/Resources/slicc/`), built by `@ai-ecoverse/spoon` (`node packages/spoon/build.mjs`); node-server reads the same file. Internals: [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
 
 ## Build and Test Commands
 
@@ -26,9 +26,7 @@ npm run lint -w @slicc/swift-server   # SwiftLint
 
 ## Linting & Formatting
 
-`.swiftlint.yml` inherits repo-root via `parent_config` and excludes `.build`; only `error` fails CI. Formatting is `swift format` (Swift 6+) against repo-root `.swift-format` — no per-package copy.
-
-Version-sensitive keys and the multi-line-interpolation footgun: [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
+`.swiftlint.yml` inherits repo-root via `parent_config` and excludes `.build`; only `error` fails CI. Formatting is `swift format` (Swift 6+) against repo-root `.swift-format` — no per-package copy. Version-sensitive keys + the multi-line-interpolation footgun: [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
 
 ```bash
 npm run lint:fix -w @slicc/swift-server      # swiftlint --fix
@@ -42,65 +40,57 @@ npm run format -w @slicc/swift-server        # swift format --in-place
 - `Sources/CLI/` — `ServerCommand` arg parsing / bootstrap.
 - `Sources/Follower/` — headless CDP-over-CDP follower for egress-blocked Electron apps.
 - `Sources/Server/` — HTTP routes, thin-bridge CORS, logging, shutdown.
-- `Sources/Signing/` — `SigV4Signer` (mirrors JS signers byte-for-byte vs AWS canonical vectors).
-- `Sources/WebSocket/` — CDP proxy and lick WebSocket.
+- `Sources/Signing/` — `SigV4Signer` (mirrors JS signers vs AWS vectors). `Sources/WebSocket/` — CDP proxy + lick WS.
 
 ## Electron `--join` — egress decides the attach route
 
-Egress-ALLOWED apps attach via the overlay itself: the LEADER-role overlay URL carries `tray=<join url>` (the Chrome join path's `?tray=` contract), so the pinned first tab boots as a tray follower instead of minting its own. In-app auto-follow tabs carry an explicitly EMPTY `tray=`, blocking the webapp's stored-join-URL fallback at the shared sliccy.ai origin — one app, one follower.
+Two routes, chosen by whether the app allows renderer egress:
 
-## Egress-blocked Electron apps (Signal) — CDP over CDP
+- **Egress allowed**: the LEADER-role overlay URL carries `tray=<join url>` (the Chrome join path's `?tray=` contract), so the pinned first tab boots as a tray follower instead of minting its own. In-app auto-follow tabs carry an explicitly EMPTY `tray=`, blocking the webapp's stored-join-URL fallback at the shared sliccy.ai origin — one app, one follower.
+- **Egress blocked** (Signal-class): the app denies **all** renderer egress at the main process (`net::ERR_ACCESS_DENIED`), beneath `Page.setBypassCSP` / CDP Fetch. `ElectronOverlayEgress.swift` detects it via `Network.loadingFailed` on the overlay iframe and shows a **status-only** overlay (mirrors `electron-controller.ts`). When blocked AND a `--join` tray URL is given, swift-server exposes the app's CDP to the leader via a headless WebRTC tray follower in `Sources/Follower/` (`ElectronTrayFollower.swift` + `FederatedCDPServicer.swift`, `stasel/WebRTC` via `swift-trayfollower`; mirrors `electron-tray-follower.ts` / `electron-federated-cdp.ts`).
 
-Signal-class Electron apps deny **all** renderer egress at the main process (`net::ERR_ACCESS_DENIED`), beneath `Page.setBypassCSP` / CDP Fetch. `ElectronOverlayEgress.swift` detects this via `Network.loadingFailed` on the overlay iframe and shows a **status-only** overlay (mirrors node-server `electron-controller.ts`).
-
-When blocked AND a `--join` tray URL is given, swift-server exposes the app's CDP to the leader via a headless WebRTC tray follower (`Sources/Follower/`): `ElectronTrayFollower.swift` routes `tray-control`; `FederatedCDPServicer.swift` speaks raw browser CDP with `sendCDPResponse`-compatible chunking. Mirrors node-server's `electron-tray-follower.ts` / `electron-federated-cdp.ts`; Swift uses `stasel/WebRTC` via `packages/swift-trayfollower`.
+Full route + follower internals: [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
 
 ## Server Overview
 
 - `CLI/ServerCommand.swift` — entry; mirrors Node runtime flags; launches/attaches to a browser. Root mounts only `ThinBridgeCorsMiddleware` (`shouldMountThinBridgeCors`); `--serve-only` / `--electron` mount none. Gate: `isThinBridgeMode = !serveOnly && !electron`.
-- `WebSocket/CDPProxy.swift` — CDP proxy; one browser WebSocket, ordered bounded async pump.
-- `WebSocket/LickSystem.swift` — tracks clients, request/response, lick-event broadcast.
+- `WebSocket/CDPProxy.swift` — CDP proxy; one browser WebSocket, ordered bounded pump.
+- `WebSocket/LickSystem.swift` (actor) — tracks clients + pending requests, lick-event broadcast; `LickWebSocketRoute` exposes `/licks-ws`. Browser messages resolve pending requests or broadcast events.
 
 ## API Routes
 
 `Sources/Server/APIRoutes.swift` — main registry. Handlers mirror `packages/node-server/`; full contracts: [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
 
-- `GET /api/status` — `service: "slicc-server"` labels the floatbar `sliccstart` (vs `npx` for Node CLI).
-- `GET /api/agent-activity` — non-OPTIONS `/api/fetch-proxy` within the 60s window.
-- `GET /api/runtime-config`, `/api/tray-status`, `/auth/callback`, `GET|POST /api/oauth-result`, `GET|POST|DELETE /api/webhooks...`, `/api/crontasks...`
-- `POST /api/handoff` (`Sources/Server/Handoff.swift`) — validates payload, broadcasts `navigate_event` on lick WebSocket.
-- `GET /api/secrets`, `GET|POST /api/secrets/session`, `/api/secrets/masked`, `/api/secrets/peek`, `POST /api/secrets/scope`, session-first `DELETE /api/secrets/:name`. Session records are process-memory only; persisted/OAuth records keep masking precedence on name collisions.
-- `POST /api/secrets/scrub` (via `SecretInjector.scrub(text:)`). Intentionally no persisted `POST /api/secrets` route.
-- `POST /api/s3-sign-and-forward`, `/api/da-sign-and-forward` (`Sources/Server/SignAndForward.swift`) — S3 creds from Keychain, transient IMS bearer for DA.
-- `POST /api/sudo-approve` (`Sources/Server/SudoApprove.swift`) — native `osascript` via `Process`; loopback-only; fail-closed to `{ decision: "deny" }`.
-- `ALL /api/fetch-proxy` — HTTP verbs plus WebDAV/CalDAV (`PROPFIND`, `PROPPATCH`, `MKCOL`, `MKCALENDAR`, `REPORT`, `COPY`, `MOVE`, `LOCK`, `UNLOCK`). Unknown → AsyncHTTPClient via `HTTPMethod.RAW(value:)`.
+- `GET /api/status` — `service: "slicc-server"` labels the floatbar `sliccstart` (vs `npx` for Node CLI). `GET /api/agent-activity` — non-OPTIONS `/api/fetch-proxy` within 60s.
+- `GET /api/runtime-config`, `/api/tray-status`, `/auth/callback`, `GET|POST /api/oauth-result`, `GET|POST|DELETE /api/webhooks...` / `/api/crontasks...`
+- `POST /api/handoff` (`Handoff.swift`) — validates payload, broadcasts `navigate_event` on the lick WS.
+- Secrets: `GET /api/secrets`, `GET|POST /api/secrets/session`, `/api/secrets/masked`, `/api/secrets/peek`, `POST /api/secrets/scope`, session-first `DELETE /api/secrets/:name`, `POST /api/secrets/scrub`. See below.
+- `POST /api/s3-sign-and-forward`, `/api/da-sign-and-forward` (`SignAndForward.swift`) — S3 creds from Keychain, transient IMS bearer for DA.
+- `POST /api/sudo-approve` (`SudoApprove.swift`) — native `osascript` via `Process`; loopback-only; fail-closed to `deny`.
+- `ALL /api/fetch-proxy` — HTTP verbs plus WebDAV/CalDAV (`PROPFIND`, `MKCOL`, `MKCALENDAR`, `REPORT`, `COPY`, `MOVE`, `LOCK`, …). Unknown → AsyncHTTPClient via `HTTPMethod.RAW(value:)`.
 
-WebSocket routes install separately for CDP and lick. `LickSystem` (actor) tracks clients + pending requests; `LickWebSocketRoute` exposes `/licks-ws`. Browser-originated messages resolve pending requests or broadcast events into the runtime.
+CDP and lick WS routes install separately (see Server Overview).
 
 ## Tab Session Restore
 
-Chrome reopens previous session tabs minus the SLICC tab (dead token; `clearChromeSessionRestore` prevents `/cdp` eviction wars). URL-only snapshot in `Sources/Browser/TabSessionStore.swift` — sanitized on save **and** load (each entry is a Chrome argv slot) — fed by `TabSessionRecorder.swift`, replayed via `ChromeLaunchConfig.restoreUrls`. Not wired for `--serve-only` / `--electron`; no node-server equivalent. See [`docs/sliccstart-browser.md`](../../docs/sliccstart-browser.md).
+Chrome reopens previous session tabs minus the SLICC tab (dead token; `clearChromeSessionRestore` prevents `/cdp` eviction wars). URL-only snapshot in `TabSessionStore.swift` — sanitized on save **and** load (each entry is a Chrome argv slot) — fed by `TabSessionRecorder.swift`, replayed via `ChromeLaunchConfig.restoreUrls`. Not wired for `--serve-only` / `--electron`; no node-server twin. See [`docs/sliccstart-browser.md`](../../docs/sliccstart-browser.md).
 
 ## Mount table (`--mount`)
 
-Repeatable `--mount <os-path>:<slicc-path>` (`ServerCommand.mount` → `ServerConfig.mounts`, parsed by `ServerConfig.parseMountMapping`; parity with node-server's `parseMountTableMapping`). `Sources/Server/HostFSRoutes.swift` serves the mapped folders over `/api/hostfs`, mirroring node-server's `hostfs.ts` byte-for-byte (routes, `{ code, message }` errno JSON, traversal/symlink containment, mount-root delete refusal, 100 MiB body cap). Advertised as `autoMounts` (`{ path, hostPath }[]`) on `GET /api/runtime-config`; the webapp auto-mounts at boot, no picker/permission. Sliccstart feeds the flags from Settings → Mounts (`MountTablePreference`). Docs: [`docs/mounts.md`](../../docs/mounts.md#auto-mounted-host-folders-the-mount-table).
+Repeatable `--mount <os-path>:<slicc-path>` (`ServerCommand.mount` → `ServerConfig.mounts`, parsed by `parseMountMapping`; parity with node-server's `parseMountTableMapping`). `HostFSRoutes.swift` serves mapped folders over `/api/hostfs`, mirroring `hostfs.ts` byte-for-byte (routes, errno JSON, traversal/symlink containment, mount-root delete refusal, 100 MiB body cap). Advertised as `autoMounts` on `GET /api/runtime-config`; the webapp auto-mounts at boot, no picker/permission. Sliccstart feeds the flags from Settings → Mounts (`MountTablePreference`). Docs: [`docs/mounts.md`](../../docs/mounts.md#auto-mounted-host-folders-the-mount-table).
 
 ## Secrets Architecture
 
-`OAuthSecretStore.swift` handles OAuth replicas via `POST /api/secrets/oauth-update` and `DELETE /api/secrets/oauth/:providerId`. `SessionSecretStore.swift` owns process-memory session records for the session/list/peek/scope/delete APIs. Pipeline `Sources/Keychain/SecretInjector.swift` layers sessions after persisted/env/OAuth data without letting a session collision shadow those sources. Masks match `@slicc/shared-ts` byte-for-byte via `Tests/CrossImplementationTests.swift`. `SecretStore.swift` reads `ai.sliccy.slicc / __envfile__` at startup via `SecItemCopyMatching`.
+`OAuthSecretStore.swift` handles OAuth replicas (`POST /api/secrets/oauth-update`, `DELETE /api/secrets/oauth/:providerId`). `SessionSecretStore.swift` owns process-memory session records for the session/list/peek/scope/delete APIs. Pipeline `SecretInjector.swift` layers sessions after persisted/env/OAuth data without a session collision shadowing those sources (so persisted/OAuth keep masking precedence on name collisions; no persisted `POST /api/secrets` route). Masks match `@slicc/shared-ts` byte-for-byte (`Tests/CrossImplementationTests.swift`). `SecretStore.swift` reads `ai.sliccy.slicc / __envfile__` at startup via `SecItemCopyMatching`.
 
-**Trust model (why the prompt recurs).** The default ACL trusts only the creating binary's cdhash; ad-hoc signatures get a new cdhash every `swift build`, re-raising the "allow access" dialog. Durable fix: `packages/dev-tools/tools/setup-dev-cert.sh` installs a stable code-signing identity so one **"Always Allow"** survives rebuilds — the identity must be **trusted** via `security add-trusted-cert -p codeSign`, not just imported. Deep-dive: [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
-
-`SLICC_KEYCHAIN_NONINTERACTIVE=1` (dev harness) is an **anti-hang guard only**: `readBlob` passes `kSecUseAuthenticationUIFail`, so headless launches fail fast with `errSecInteractionNotAllowed` instead of hanging. Already-granted items read; otherwise continues **without** Keychain secrets — never silent success.
+**Trust model (why the prompt recurs).** The default ACL trusts only the creating binary's cdhash; ad-hoc signatures get a new cdhash every `swift build`, re-raising the "allow access" dialog. Durable fix: `packages/dev-tools/tools/setup-dev-cert.sh` installs a stable code-signing identity so one **"Always Allow"** survives rebuilds — the identity must be **trusted** via `security add-trusted-cert -p codeSign`, not just imported. `SLICC_KEYCHAIN_NONINTERACTIVE=1` (dev harness) is an **anti-hang guard only**: headless launches fail fast rather than hang, continuing **without** Keychain secrets — never silent success. Deep-dive: [`docs/swift-server-details.md`](../../docs/swift-server-details.md).
 
 ## Graceful Shutdown and Detach
 
-`Sources/Server/GracefulShutdown.swift` handles `SIGINT`/`SIGTERM` (full shutdown, `closeBrowser: true`) and `SIGUSR1` (`detach()`, `closeBrowser: false` — HTTP + CDP stop, browser stays open). Sliccstart uses `detach()` for binary swaps without killing the user's session (see `packages/swift-launcher/CLAUDE.md` "Smooth-Update Modules"). A second signal after `detach()` no-ops via `shuttingDown`.
+`GracefulShutdown.swift` handles `SIGINT`/`SIGTERM` (full shutdown, `closeBrowser: true`) and `SIGUSR1` (`detach()`, `closeBrowser: false` — HTTP + CDP stop, browser stays open). Sliccstart uses `detach()` for binary swaps without killing the user's session (see `packages/swift-launcher/CLAUDE.md` "Smooth-Update Modules"). A second signal after `detach()` no-ops via `shuttingDown`.
 
 ## Related Guides
 
-- `packages/node-server/CLAUDE.md` — parallel Node runtime
-- `packages/shared-ts/CLAUDE.md` — masking primitives
-- `docs/development.md` — run/debug workflow
-- `docs/transcript-export.md` — transcript export (webapp; swift-server transparent)
+- `packages/node-server/CLAUDE.md` — parallel Node runtime · `packages/shared-ts/CLAUDE.md` — masking
+- `docs/development.md` — run/debug workflow · `docs/transcript-export.md` — export (webapp; swift-server transparent)
 - [`docs/swift-server-details.md`](../../docs/swift-server-details.md) — extended internals

--- a/packages/webcomponents/CLAUDE.md
+++ b/packages/webcomponents/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — `@slicc/webcomponents`
 
-Standalone library extracting `proto/StellarRubySwift.html` into reusable, individually testable web components. **Webapp wiring underway**: `?ui=wc` mounts the migration shell from `packages/webapp/src/ui/wc/` (live boots the kernel worker; `&ui-fixture` renders the design-time fixture). Webapp imports the barrel; `ui/press-button.ts` is a shim over `slicc-press-button`. Tested functionally (`@vitest/browser`) + visually (Storybook).
+Standalone library extracting `proto/StellarRubySwift.html` into reusable, individually testable web components. **Webapp wiring underway**: `?ui=wc` mounts the migration shell from `packages/webapp/src/ui/wc/` (live boots the kernel worker; `&ui-fixture` renders the design-time fixture).
 
 ## Layout
 
@@ -11,101 +11,60 @@ src/
   primitives/    token-only leaves (logo, tag, icon-button, send-button, eyes, …)
   pill/ add-menu/  shadow-DOM elements lifted verbatim from the prototype
   chat/          message/card/dip composites + verbatim pure modules
-  overlay/       slicc-dialog (modal shell) and other viewport overlays
+  overlay/       slicc-dialog (modal shell) + other viewport overlays
   composer/ switcher/ workbench/ dock/ freezer/ nav/ shell/ memory/ showcase/
-src/**/<name>.stories.ts   co-located Storybook stories (excluded from dist)
-tests/**/<name>.test.ts    co-located browser tests, mirroring src/ subsystem
 ```
+
+Co-located `src/**/<name>.stories.ts` (dist-excluded) + `tests/**/<name>.test.ts` (mirrors `src/`). Deep per-subsystem internals: `docs/webcomponents-details.md`.
 
 ## Panel system (`src/panel/`)
 
-**`SliccPanel` + `<slicc-layout>` are the layout API going forward**; `slicc-dock-tree` (below) is the shipping default until the `panel-layouts` flag flips. Model, locking, Cherry wire: `docs/layouts.md`; rationale: `docs/panel-system-design.md`; internals: `docs/webcomponents-details.md`.
+**`SliccPanel` + `<slicc-layout>` are the layout API going forward**; `slicc-dock-tree` (below) is the shipping default until the `panel-layouts` flag flips. Model, locking, Cherry wire: `docs/layouts.md`; rationale: `docs/panel-system-design.md`. Invariants:
 
-Non-obvious invariants:
-
-- **`SliccPanel` is light-DOM**; shared stylesheet keys on a `data-slicc-panel` marker (must cover runtime-registered subclasses). **Panels default VISIBLE** (opposite of `<slicc-surface>`).
-- **DOM-free subpaths** `@slicc/webcomponents/panel/meta` and `@slicc/webcomponents/internal/html` are safe for webapp + kernel worker; barrel is not (needs `CSSStyleSheet`).
-- **Layout schema** — `docks[]` (fixed chrome pinned to an edge at exact size; fr-only zones can't say `"44px"`) + `zones` (five BorderLayout regions, `ZoneName`: top/left/center/right/bottom); variants REPLACE a section, `panels` overrides merge per id.
-- **Slot pitfall — overlays + pointer capture live on the HOST, not a slot**: slots rebuild every render; a captured element removed from the DOM loses capture per spec.
-- **`<slicc-layout>` parks unplaced panels offstage** (not destroyed), preserving scroll / live terminal session across variant switches. Re-resolves on HOST resize (not window), rAF-debounced. Rebuilds target a stable inner root (replacing the host's own children re-enters its `MutationObserver`).
-- Panel stories (`panel/*.stories.ts`) are required for PR screenshots to cover panels.
+- **`SliccPanel` is light-DOM**; shared stylesheet keys on a `data-slicc-panel` marker (must cover runtime-registered subclasses). **Panels default VISIBLE** (opposite of `<slicc-surface>`). DOM-free subpaths `.../panel/meta` and `.../internal/html` are safe for webapp + kernel worker; the barrel is not (needs `CSSStyleSheet`).
+- **Layout schema** — `docks[]` (fixed chrome pinned to an edge at exact size; fr-only zones can't say `"44px"`) + `zones` (five BorderLayout `ZoneName` regions: top/left/center/right/bottom); variants REPLACE a section, `panels` overrides merge per id.
+- **Overlays + pointer capture live on the HOST, not a slot** (slots rebuild every render; a removed captured element loses capture). **`<slicc-layout>` parks unplaced panels offstage** (preserving scroll / live terminal), re-resolves on HOST resize (rAF-debounced), rebuilds a stable inner root. `panel/*.stories.ts` are required for PR screenshots to cover panels.
 
 ## Dock-tree (the shipping default)
 
-**`slicc-dock-tree` (`src/workbench/slicc-dock-tree.ts`) is what a default install boots** — superseded by the panel system above, not yet removed. Driven by the webapp's `layout` shell command (`docs/shell-reference.md`, `docs/layouts.md`). Light DOM: `<slicc-surface>` children match leaves by identity (`surface-id`/`data-s`/`id`) and are MOVED, not cloned; unmatched park offstage. `slicc-shell` hosts it beside the dock rail. Internals: `docs/webcomponents-details.md`.
+**`slicc-dock-tree` (`src/workbench/slicc-dock-tree.ts`) is what a default install boots** — superseded by the panel system above, not yet removed. Driven by the webapp's `layout` shell command (`docs/shell-reference.md`, `docs/layouts.md`). Light DOM: `<slicc-surface>` children match leaves by identity (`surface-id`/`data-s`/`id`) and are MOVED not cloned (unmatched park offstage); `slicc-shell` hosts it beside the dock rail. Model, API, drag-drop, events: `docs/webcomponents-details.md`. Non-obvious rules:
 
-Non-obvious rules:
-
-- `CHAT_SURFACE_ID = 'chat'` is reserved; `setPinned([...])` marks leaves runtime-only (never serialized by `getTree()`) so pinned `removeSurface` is a no-op. `moveSurfaceToZone` bypasses the pinned guard (needed for chat).
-- `DockTreeSpec.locked`/`DockNode.locked` (inherited) block drag, resize, `removeSurface`; locked leaves render no move button. Cherry uses this — see `packages/webapp/CLAUDE.md`'s Layouts section.
-- `tilesMovable`/`tiles-movable` defaults off; flag-on replaces the dock-tree with `<slicc-layout>`. Full `DropRegion` contracts: `docs/layouts.md`.
-- Divider resize clamps to 2% of pair's combined weight (floor `setSurfaceSize` enforces). **Pointer capture is held on the host, not the divider**.
-- `dock-tree-change`/`dock-tree-resize` (composed + bubbling, `detail: { tree }`) never persist — see `packages/webapp/CLAUDE.md`'s `wireDockTreePersistence`.
-- Non-chat tiles carry the rounded workbench-pane chrome (`.dock-tree__tile--chrome`); the reserved chat leaf renders flat. `dock-tree-render` (`detail: { placed }`) fires after EVERY render — the change-silent `setTree` included — and is display-only: `slicc-shell` keys the chatpane's `narrow` re-theming (never its width) off it, and it must never feed persistence.
+- `CHAT_SURFACE_ID = 'chat'` is reserved; `setPinned([...])` marks leaves runtime-only (never serialized) so pinned `removeSurface` is a no-op, and `moveSurfaceToZone` bypasses the pinned guard (needed for chat). `DockTreeSpec.locked`/`DockNode.locked` (inherited) block drag/resize/`removeSurface` and render no move button (Cherry uses this).
+- **Pointer capture is held on the host, not the divider** (resize clamps to 2%). `dock-tree-change`/`-resize`/`-render` (composed + bubbling) never persist — `slicc-shell` keys chatpane `narrow` re-theming off `dock-tree-render`; persistence is the webapp's `wireDockTreePersistence`. Non-chat tiles carry rounded workbench-pane chrome; the reserved chat leaf renders flat.
 
 ## File tree + Quick Look (Pierre libraries)
 
-Two components delegate their rendering to [pierre.computer](https://pierre.computer) libraries. Both are wrapped by an adapter that keeps SLICC's existing public contract, so hosts did not change.
+`slicc-file-tree` renders through **`@pierre/trees`** and `slicc-quick-look` through **`@pierre/diffs`**, each wrapped by an adapter preserving SLICC's public contract (input shapes, accessors, events) so hosts stay unchanged. **Read `docs/webcomponents-details.md` before touching either adapter.** Load-bearing gotchas:
 
-- **`slicc-file-tree`** renders through **`@pierre/trees`** (trees.software). The `FileTreeItem` input shape, the `items` / `selected` accessors and the `file-select` / `file-preview` / `file-reference` / `file-download` / `file-overflow` / `dir-toggle` events are unchanged; `gitStatus` is new. Search, inline rename, drag-and-drop, virtualization and git lanes come from the library.
-- **`slicc-quick-look`** renders text through **`@pierre/diffs`** (diffs.com), shows a unified diff instead of the file when the caller supplies `baseContent`, and shows a rendered document when the caller supplies `rendered`. The header toggle exposes whichever of Preview / Source / Diff exist.
-
-Non-obvious rules:
-
-- **The library builds hierarchy from PATHS, not from `children` nesting.** A `FileTreeItem` whose `id` is a bare name renders at the root no matter where it sits in the literal — ids must be full paths (which is what `buildVfsTreeItems` produces).
-- **Strip the leading slash before handing paths to `@pierre/trees`** (`toTreePath`). A leading `/` becomes an empty first segment: `['/a.ts', '/b.ts']` renders ONE blank row and no files (verified against `1.0.0-beta.6`). Events convert back, so absolute VFS paths stay absolute at the component boundary.
-- **`renderRowDecoration` returns text or an icon only** — no interactive elements. That is why the old per-row hover buttons (Preview / Reference / Download) now live in the row context menu, whose `onOpen` re-emits SLICC's `file-overflow` so `SliccOverflowMenu` still draws the menu.
-- **Selection echoes.** `selectFile()` reflects to the `selected` attribute, which tells the library to select the row, which calls back through `onSelectionChange` — guard with the `#selecting` flag or one click emits two `file-select` events.
-- **Quick Look renders text twice on purpose**: a synchronous `<pre>` first, then the `@pierre/diffs` view once that lazily-imported chunk arrives (~628 KB, so it must never block the overlay). If the import fails the `<pre>` stays — a degraded preview, not a broken one. A `#generation` counter drops an upgrade that resolves after the overlay moved to another file.
-- **Quick Look converts nothing.** A `rendered` payload arrives as HTML from the host: `inline` must already be sanitized (the webapp runs markdown through `message-renderer.ts`) and mounts via `createContextualFragment`, the same no-innerHTML path as `setBodyHtml`; `sandbox` mounts in an iframe with an EMPTY `sandbox` attribute (no `allow-scripts`, no `allow-same-origin`) and is the only treatment raw HTML ever gets. That document is wrapped in a base stylesheet (`sandboxDocument`) stating `color-scheme` + `Canvas`/`CanvasText`, because an iframe starts transparent with black text and knows nothing about the app's `data-theme` — an unstyled report rendered near-black on the dark panel. The base goes AFTER any doctype (before it means quirks mode) and BEFORE the file's own markup, so author rules outrank it. Keeping conversion in the host is what keeps a markdown parser out of this library.
-- **A rendered form opens FIRST, ahead of the diff.** Someone who clicked a `.md` name meant to read the file; a modified README is still a README. Files without a rendered form keep the old diff-first behavior. Views are rebuilt on switch, never kept mounted in parallel.
-- **`@pierre/trees` `sideEffects` is mispathed** in `1.0.0-beta.6` (`./dist/components/web-components.js` vs the real `dist/web-components.js`), so `import '@pierre/trees/web-components'` tree-shakes to nothing. Importing `FileTree` from the package root is unaffected — it pulls the element registration itself.
-- **Both libraries are in `optimizeDeps.include`** (`vitest.config.ts`). Discovering them mid-run makes Vite re-optimize and reload; a reload after a custom element is defined leaves the tag bound to the pre-reload class, and every tree/preview test then fails as if the component were broken.
-- **Tests assert the contract, not the markup** — accessible row names and events, since the DOM belongs to the library now. Synthetic events need `composed: true` to cross its shadow boundary.
+- **Hierarchy comes from PATHS, not `children` nesting** — `FileTreeItem` ids must be full paths, **stripped of the leading slash** before `@pierre/trees` (`toTreePath`) or the tree renders one blank row. `selectFile()` echoes back, so guard with `#selecting` or one click emits two `file-select`s.
+- **Quick Look converts nothing**: `rendered` HTML must arrive pre-sanitized; `inline` mounts via `createContextualFragment`, `sandbox` in an empty-`sandbox` iframe. A rendered form opens ahead of the diff; text renders twice (`<pre>`, then the lazily-imported `@pierre/diffs` view).
+- **`@pierre/trees` `sideEffects` is mispathed** in `1.0.0-beta.6` — import `FileTree` from the package root, not `/web-components`; both libraries must stay in `optimizeDeps.include` or a mid-run Vite reload unbinds the elements.
 
 ## Conventions (every component MUST follow)
 
-- **Vanilla web components**, no framework. One element per file, `slicc-*` tag, `Slicc*` class. Register via `define(tag, ctor)` at module bottom (self-guards double-registration); add an `HTMLElementTagNameMap` augmentation.
-- **No `innerHTML` — build the DOM.** Use `internal/dom.ts` (`h()`, `frag()`, `append()`) + `replaceChildren()`; `h()` children / `textContent` is DOM-escaped. Render lucide glyphs with `iconEl(name, opts)`. Shadow components share one constructable stylesheet: `const SHEET = sheet(STYLE)` module-scope, `this.#root.adoptedStyleSheets = [SHEET]` in ctor (no `<style>` node). Light-DOM hosts keep document `<style>` injection but build the subtree with `h()`. Reference: `src/primitives/slicc-logo.ts`. **Enforced** by `lint:no-innerhtml` on `src/**/*.ts` (stories/tests exempt).
-- **NodeNext imports:** relative imports MUST carry `.js` (`./foo.js`), including stories/tests. tsc enforces this.
-- **Shadow vs light vs iframe** — shadow DOM for self-contained chips (pill, add-menu, tag, icon-button, logo); light DOM for layout/gesture/slotting hosts (nav, composer, shell, file-tree, press-button); `slicc-dip` stays **iframe-isolated** (webapp `dip.ts` trusted-source boundary — shadow DOM is NOT a security boundary).
-- **Slotted subtrees need a document sheet.** `::slotted()` matches only the slot's TOP-LEVEL children — never a `<pre>` / `<table>` nested inside a slotted wrapper. A shadow component that accepts rendered markdown (`slicc-lick-card`) therefore ships its containment rules (`white-space:pre-wrap`, `overflow-wrap:anywhere`, capped tables/images) as an idempotent document `<style>` selected by the host tag, alongside its `adoptedStyleSheets`. Without it an unwrapped `<pre>` bursts the card and scrolls the whole chat column sideways.
-- **Chat prose must contain unbroken runs.** `slicc-user-message`'s `.b` and `slicc-agent-message`'s `.body` carry `overflow-wrap: anywhere`. A pasted base64 payload is one token with no break opportunity, so a `max-width` cap does not contain it — the box stays capped and the TEXT spills out of it, scrolling the whole chat column. Fenced code opts back OUT (`pre code`): a code block is its own scroll container, and mangling source is worse than scrolling it. Test this with `scrollWidth` vs `clientWidth`; a box-width assertion passes either way and proves nothing. The webapp collapses recognized payloads into `<slicc-blob-chip>` on top of this (`packages/webapp/CLAUDE.md`), but the wrap rule is what has to hold for everything else.
-- **Theming:** reference prototype tokens (`var(--canvas)`, `--ink`, `--ctx`, `--rainbow`, `--ctl-h`, …); they inherit through shadow roots — don't re-declare. Light default; dark is `body.dark`/`.dark`/`[data-theme="dark"]`. Preserve `::part` hooks on lifted elements exactly.
-- **Animation loops must not force reflow — and must carry a frame budget.** A `requestAnimationFrame` loop must never read computed style/layout per frame; resolve CSS-derived values once and cache, invalidating on attribute + theme changes. Decorative/ambient loops render at `AMBIENT_FPS` (15) with an 800 ms full-rate burst on interaction, and stop entirely when the field is static (`src/freezer/frame-budget.ts` is the shared gate; `slicc-shader` is the reference consumer). Never schedule frames with timers — rAF is the only scheduler that pauses when the page hides. Pattern: `docs/webcomponents-details.md`.
+- **Vanilla web components**, no framework. One element per file, `slicc-*` tag, `Slicc*` class. Register via `define(tag, ctor)` at module bottom (self-guards double-registration) + an `HTMLElementTagNameMap` augmentation. **NodeNext imports** MUST carry `.js`, incl. stories/tests (tsc enforces).
+- **No `innerHTML` — build the DOM** with `internal/dom.ts` (`h()`, `frag()`, `append()`) + `replaceChildren()` (`h()` children / `textContent` is DOM-escaped); lucide glyphs via `iconEl(name, opts)`. Shadow components share one module-scope constructable stylesheet (`sheet(STYLE)` → `adoptedStyleSheets`); light-DOM hosts keep document `<style>` injection. Ref `src/primitives/slicc-logo.ts`. **Enforced** by `lint:no-innerhtml` on `src/**/*.ts` (stories/tests exempt).
+- **Shadow vs light vs iframe** — shadow DOM for self-contained chips (pill, tag, icon-button, logo); light DOM for layout/gesture/slotting hosts (nav, composer, shell, file-tree); `slicc-dip` stays **iframe-isolated** (trusted-source boundary — shadow DOM is NOT a security boundary).
+- **Slotted subtrees + chat prose need containment.** `::slotted()` matches only a slot's TOP-LEVEL children, so a shadow component accepting rendered markdown (`slicc-lick-card`) ships containment as an idempotent document `<style>` keyed to the host tag; chat message bodies carry `overflow-wrap: anywhere` (fenced code opts OUT via `pre code`). Rationale: `docs/webcomponents-details.md`.
+- **Animation loops:** a `requestAnimationFrame` loop must never read computed style/layout per frame (cache CSS values once) and must carry a frame budget — ambient `AMBIENT_FPS` (15), an 800 ms full-rate burst on interaction, stopping when static (`src/freezer/frame-budget.ts`; `slicc-shader` reference). Never a timer (only rAF pauses when hidden). Rationale: `docs/webcomponents-details.md`.
 - **Public API:** export the class; expose attributes (reflected to properties), `::part` hooks, named slots, `CustomEvent`s (composed + bubbling) — never reach into another component's internals.
-- **Agent-avatar expression kit:** `<slicc-agent-avatar activity>` adds shape morph, brows, lids and gaze on top of the four original channels; every channel is a point, scalar or event (SwiftUI-mirrorable), grammar in `switcher/avatar-expression.ts`. No `activity` attribute = the legacy pointer-tracking face; static outranks every channel. **The brows paint outside the tile:** `.crop` owns the roundrect, `.brow-layer` re-applies the same zoom/pan above it, so hosts must not clip the avatar (~3 px of overhang at 26 px) and both layers must keep identical transforms. Table + constants: `docs/webcomponents-details.md`.
-- **Monitor meter markers:** a `MonitorVital` whose `ratio` summarises many contributors also takes `markers` (`MonitorMeterMarker[]`) — one dot per contributor along the same track, so the bar's aggregate does not hide the spread. `color` is a resolved CSS color the HOST supplies (the webapp passes `scoopColor()`, the switcher-chip hash, so a unit is one hue everywhere); dots paint lowest-first so the peak lands on top; the rail is one `role="img"` naming every reading, dots are `aria-hidden` with pointer-only `title`, and never focusable (the panel re-renders every 5s). Rules: `docs/webcomponents-details.md`.
-- **Composer push-to-talk:** `<slicc-composer ptt>` owns the hold-to-dictate gesture but not the audio stack — hosts inject a `ComposerSpeech` via `speech` (`composer/speech.ts`, exported DOM-free as `@slicc/webcomponents/composer/speech`). Dictated submits carry `detail.source === 'dictation'`. Contract, stages, whisper upgrade: `docs/webcomponents-details.md`.
+- **Theming:** reference prototype tokens (`var(--canvas)`, `--ink`, `--ctx`, `--rainbow`, …); they inherit through shadow roots — don't re-declare. Light default; dark is `body.dark`/`.dark`/`[data-theme="dark"]`.
 
-## Tests (`@vitest/browser`, real Chromium)
+Three specialized components carry non-obvious host contracts — full tables/rules in `docs/webcomponents-details.md`:
 
-- `tests/<area>/<name>.test.ts`, `globals: true`. Assert registration, attribute↔property reflection, shadow structure, events, lifecycle cleanup, and (via real browser) `getComputedStyle`/geometry. Stub `ResizeObserver`/`IntersectionObserver` only when asserting reflow directly.
-- Run: `npm run test -w @slicc/webcomponents` (browser mode via `vitest.config.ts`; needs `npx playwright install chromium`). Kept OUT of root `vitest run` projects so `npm test` stays browser-free.
+- **Agent-avatar expression kit** (`<slicc-agent-avatar activity>`): shape/brows/lids/gaze over four channels (point/scalar/event; grammar in `switcher/avatar-expression.ts`). No `activity` = legacy pointer-tracking face; static outranks every channel; brows paint OUTSIDE the tile crop, so hosts must not clip the avatar.
+- **Monitor meter markers**: a `MonitorVital` `ratio` also takes `markers` (`MonitorMeterMarker[]`), one dot each; `color` is a resolved CSS color the HOST supplies (webapp passes `scoopColor()`). Deep-copied by the `model` getter.
+- **Composer push-to-talk** (`<slicc-composer ptt>`): owns the hold-to-dictate gesture, not the audio stack — hosts inject a `ComposerSpeech` via `speech` (DOM-free subpath `.../composer/speech`); dictated submits carry `detail.source === 'dictation'`.
 
-## Stories (Storybook, `@storybook/web-components-vite`)
+## Tests + Stories
 
-- `src/<area>/<name>.stories.ts`. Cover the **state matrix**: variant/state × light/dark × screen size (theme + viewport toolbars). `render` returns a constructed element or HTML string.
-- Run: `npm run storybook -w @slicc/webcomponents`; build: `npm run build-storybook`.
+- **Tests** (`@vitest/browser`, real Chromium): `tests/<area>/<name>.test.ts`, `globals: true`. Assert registration, attribute↔property reflection, shadow structure, events, lifecycle cleanup, and (real browser) `getComputedStyle`/geometry; stub `ResizeObserver`/`IntersectionObserver` only when asserting reflow. `npm run test -w @slicc/webcomponents` (needs `npx playwright install chromium`); kept OUT of root `vitest run` so `npm test` stays browser-free.
+- **Stories** (Storybook, `@storybook/web-components-vite`): `src/<area>/<name>.stories.ts`, covering the **state matrix** variant/state × light/dark × size. `npm run storybook`, build `npm run build-storybook` (`-w @slicc/webcomponents`).
 
-## Storybook PR screenshots (visual spot-check)
+## Storybook PR screenshots
 
-PRs touching `packages/webcomponents/**` get a sticky comment with light + dark screenshots of **affected** stories at 1280×900, driven by `.github/workflows/storybook-screenshots.yml` (capture + resolver under `packages/dev-tools/tools/`). PNGs upload to R2 bucket `slicc-pr-screenshots`; fork PRs fall back to a workflow artifact. Heuristic, manifest v1, R2 dedupe/retry, secrets/vars: `docs/webcomponents-details.md`.
-
-**Running it locally** (flags are `--flag=value` only; manifest is always `<out>/manifest.json`; empty diff → empty `shots[]` + a "no affected stories" comment):
-
-```bash
-npm run build-storybook -w @slicc/webcomponents
-git diff --name-only main... > /tmp/changed.txt
-npx playwright install chromium   # once
-node packages/dev-tools/tools/storybook-affected-screenshots.mjs \
-  --changed-files=/tmp/changed.txt \
-  --storybook-static=packages/webcomponents/storybook-static \
-  --out=/tmp/sb-shots
-```
+PRs touching `packages/webcomponents/**` get a sticky comment with light + dark screenshots of **affected** stories at 1280×900 (`.github/workflows/storybook-screenshots.yml`; capture + resolver under `packages/dev-tools/tools/`). PNGs upload to R2 `slicc-pr-screenshots`; fork PRs fall back to a workflow artifact. Heuristic, manifest, dedupe/retry, secrets, local-run recipe: `docs/webcomponents-details.md`.
 
 ## Build / typecheck
 
-- `npm run build` → `tsc -p tsconfig.build.json` (emits `dist/`, excludes stories).
-- `npm run typecheck` → `tsc --noEmit -p tsconfig.json` (src + tests, DOM libs).
-- Wired into root `build`, `typecheck`, `postinstall` chains before `@slicc/webapp`. Coverage floor in root `coverage-thresholds.json` under `typescript.webcomponents`.
+`npm run build` → `tsc -p tsconfig.build.json` (emits `dist/`, excludes stories); `npm run typecheck` → `tsc --noEmit -p tsconfig.json` (src + tests, DOM libs). Wired into root `build`/`typecheck`/`postinstall` before `@slicc/webapp`; coverage floor in `coverage-thresholds.json` under `typescript.webcomponents`.


### PR DESCRIPTION
CLAUDE.md compaction. Selected guides are at or below 9,500 chars (oversized at 10,000).

All selected guides are at or below 9,500 chars.

| Guide | Before | After | Δ | Status |
| --- | --- | --- | --- | --- |
| `packages/cloudflare-worker/CLAUDE.md` | 11,040 | 9,500 | -1,540 | compacted |
| `packages/dev-tools/CLAUDE.md` | 13,438 | 9,386 | -4,052 | compacted |
| `packages/ios-app/CLAUDE.md` | 17,332 | 9,490 | -7,842 | compacted |
| `packages/slicc-cli/CLAUDE.md` | 11,687 | 9,427 | -2,260 | compacted |
| `packages/swift-server/CLAUDE.md` | 10,199 | 9,489 | -710 | compacted |
| `packages/webcomponents/CLAUDE.md` | 16,364 | 9,496 | -6,868 | compacted |

## Validation

- `npm run lint:docs`
- `node packages/dev-tools/claude-md-compactor/measure-claude-guides.mjs --check`
- `npx prettier --check <each changed markdown file>`
- `npx vitest run --project dev-tools`
