### PR TITLE
fix(webapp): count thinkingSignature and provider usage in compaction trigger

### DIFF
--- a/packages/webapp/src/core/context-compaction.ts
+++ b/packages/webapp/src/core/context-compaction.ts
@@ -16,7 +16,7 @@
  */
 
 import type { AgentMessage } from '@earendil-works/pi-agent-core';
-import type { Api, Model, UserMessage } from '@earendil-works/pi-ai';
+import type { Api, Model, Usage, UserMessage } from '@earendil-works/pi-ai';
 import { completeSimple } from '@earendil-works/pi-ai/compat';
 // Deep import to the compaction submodule — the main entry re-exports 113 Node-only
 // modules that would break Vite's browser bundle. The compaction submodule itself
@@ -33,10 +33,13 @@ import { completeSimple } from '@earendil-works/pi-ai/compat';
 //   - branchSummary / compactionSummary: summary length
 // Verified against node_modules/@earendil-works/pi-coding-agent/dist/core/compaction/
 // compaction.js (function `estimateTokens`). Tool-result text payloads — including
-// the multi-megabyte blobs that `open --view` can emit — ARE counted, so no wrapper
-// is required here. The regression guard lives in
-// tests/core/context-compaction-real-estimator.test.ts which exercises the un-mocked
-// estimator end-to-end.
+// the multi-megabyte blobs that `open --view` can emit — ARE counted.
+//
+// What it does NOT count is `thinkingSignature` (see `estimateMessageTokens`),
+// which is why every local call site goes through that wrapper rather than
+// calling `estimateTokens` directly. The regression guards live in
+// tests/core/context-compaction-real-estimator.test.ts which exercises the
+// un-mocked estimator end-to-end.
 import {
   DEFAULT_COMPACTION_SETTINGS,
   estimateTokens,
@@ -432,7 +435,7 @@ function elideOversizedMessages(
   let elidedBytes = 0;
 
   const out = messages.map((msg) => {
-    const tokens = estimateTokens(msg);
+    const tokens = estimateMessageTokens(msg);
     if (tokens <= perMessageThreshold) return msg;
     const role = (msg as { role: string }).role;
     if (role !== 'toolResult' && role !== 'assistant') return msg;
@@ -493,13 +496,104 @@ function elideHopelessMessages(
   };
 }
 
+/**
+ * Characters of `thinkingSignature` carried by a message's thinking blocks.
+ *
+ * Anthropic returns every thinking block with an opaque signature that MUST be
+ * echoed back on the next request for multi-turn continuity, so it occupies
+ * real context on every subsequent turn. pi-coding-agent's `estimateTokens`
+ * walks only `block.thinking`, so the signature is invisible to it — and on a
+ * long thinking-heavy conversation the signatures dominate. A production
+ * `interview-me` scoop carried 1,099,252 signature chars against 1,933,000
+ * counted chars, so the local estimate came in at 496k while the provider
+ * reported 985k of a 1M window: the compaction trigger never armed and the
+ * scoop was heading for a hard context-overflow instead.
+ *
+ * Redacted thinking blocks have no `thinking` text at all — the whole payload
+ * lives in the signature — so for those this is the only thing to count.
+ */
+function thinkingSignatureChars(message: AgentMessage): number {
+  if (!hasRole(message, 'assistant')) return 0;
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) return 0;
+  let chars = 0;
+  for (const block of content) {
+    const b = block as { type?: string; thinkingSignature?: string };
+    if (b.type === 'thinking' && typeof b.thinkingSignature === 'string') {
+      chars += b.thinkingSignature.length;
+    }
+  }
+  return chars;
+}
+
+/**
+ * Estimated tokens for one message: the upstream heuristic plus the content it
+ * structurally cannot see. Every local call site uses this instead of
+ * `estimateTokens` so the trigger, the oversized-message threshold, and the
+ * cut-point walk all price a message the same way.
+ */
+function estimateMessageTokens(message: AgentMessage): number {
+  return estimateTokens(message) + Math.ceil(thinkingSignatureChars(message) / 4);
+}
+
 /** Sum the estimated token cost of a message list. */
 function estimateTotalTokens(messages: AgentMessage[]): number {
   let total = 0;
   for (const msg of messages) {
-    total += estimateTokens(msg);
+    total += estimateMessageTokens(msg);
   }
   return total;
+}
+
+/**
+ * Index of the last assistant message carrying usage the provider actually
+ * reported. Mirrors pi-coding-agent's own skip rules: an aborted or errored
+ * turn, or an all-zero usage record, tells us nothing about context size.
+ */
+function lastReportedUsageIndex(messages: AgentMessage[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (!hasRole(messages[i], 'assistant')) continue;
+    const m = messages[i] as { stopReason?: string; usage?: Usage };
+    if (m.stopReason === 'aborted' || m.stopReason === 'error') continue;
+    const u = m.usage;
+    if (!u) continue;
+    if (contextTokensFromUsage(u) > 0) return i;
+  }
+  return -1;
+}
+
+/** Prompt size the provider reported for a turn. */
+function contextTokensFromUsage(usage: Usage): number {
+  return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+}
+
+/**
+ * Context size for the compaction trigger: the provider's own accounting when
+ * we have it, the chars/4 heuristic otherwise.
+ *
+ * The heuristic is structurally optimistic — it can only count fields it knows
+ * about, and it divides by a constant 4 that runs generous for the code and
+ * JSON that fills an agent transcript. The last assistant turn's `usage` is the
+ * provider stating exactly how large the prompt it just read was, so prefer it
+ * for the prefix it covers and estimate only the messages appended since.
+ *
+ * Taking `max` with the pure heuristic keeps the answer monotone in what we can
+ * see: a stale, missing, or under-reported usage can never make the total look
+ * smaller than the messages themselves.
+ *
+ * Only the trigger uses this. Everything downstream re-measures with the
+ * heuristic on purpose — once elision has rewritten messages, a usage record
+ * describing the pre-elision prefix is stale and would overstate the result.
+ */
+function estimateContextTokens(messages: AgentMessage[]): number {
+  const heuristic = estimateTotalTokens(messages);
+  const index = lastReportedUsageIndex(messages);
+  if (index === -1) return heuristic;
+  let reported = contextTokensFromUsage((messages[index] as { usage: Usage }).usage);
+  for (let i = index + 1; i < messages.length; i++) {
+    reported += estimateMessageTokens(messages[i]);
+  }
+  return Math.max(heuristic, reported);
 }
 
 /** Whether compaction changed the message sequence rather than returning a true no-op. */
@@ -671,7 +765,7 @@ function selectCompactionSlices(
   let keptTokens = 0;
   let cutIndex = workingMessages.length;
   for (let i = workingMessages.length - 1; i >= 0; i--) {
-    const msgTokens = estimateTokens(workingMessages[i]);
+    const msgTokens = estimateMessageTokens(workingMessages[i]);
     if (keptTokens + msgTokens > keepRecentTokens && cutIndex < workingMessages.length) {
       break;
     }
@@ -840,7 +934,7 @@ export function createCompactContext(
   ): Promise<AgentMessage[]> => {
     if (messages.length === 0) return messages;
 
-    const totalTokens = estimateTotalTokens(messages);
+    const totalTokens = estimateContextTokens(messages);
     if (!options?.force && !shouldCompact(totalTokens, contextWindow, settings)) {
       return messages;
     }
@@ -973,7 +1067,7 @@ export async function compactContext(messages: AgentMessage[]): Promise<AgentMes
   // Estimate total tokens
   let totalTokens = 0;
   for (const msg of messages) {
-    totalTokens += estimateTokens(msg);
+    totalTokens += estimateMessageTokens(msg);
   }
 
   // Use default settings for threshold check
@@ -987,7 +1081,7 @@ export async function compactContext(messages: AgentMessage[]): Promise<AgentMes
   let keptTokens = 0;
   let cutIndex = messages.length;
   for (let i = messages.length - 1; i >= 0; i--) {
-    const msgTokens = estimateTokens(messages[i]);
+    const msgTokens = estimateMessageTokens(messages[i]);
     if (keptTokens + msgTokens > keepRecentTokens && cutIndex < messages.length) {
       break;
     }

--- a/packages/webapp/tests/core/context-compaction-real-estimator.test.ts
+++ b/packages/webapp/tests/core/context-compaction-real-estimator.test.ts
@@ -63,6 +63,54 @@ function createAssistantWithToolCall(text: string, toolCallId: string): AgentMes
   } as unknown as AgentMessage;
 }
 
+/**
+ * Assistant turn whose bulk lives in `thinkingSignature` — the opaque blob
+ * Anthropic returns with every thinking block and requires echoed back on the
+ * next request. It occupies real context but pi-coding-agent's `estimateTokens`
+ * walks only `block.thinking`.
+ */
+function createThinkingTurn(signatureChars: number, thinking = 'brief'): AgentMessage {
+  return {
+    role: 'assistant',
+    content: [
+      { type: 'thinking' as const, thinking, thinkingSignature: 's'.repeat(signatureChars) },
+      { type: 'text' as const, text: 'ok' },
+    ],
+    timestamp: 0,
+  } as unknown as AgentMessage;
+}
+
+/** Assistant turn carrying counted text, optionally with a provider usage record. */
+function createTextTurn(
+  text: string,
+  usage?: Record<string, unknown>,
+  stopReason?: string
+): AgentMessage {
+  return {
+    role: 'assistant',
+    content: [{ type: 'text' as const, text }],
+    timestamp: 0,
+    ...(usage ? { usage } : {}),
+    ...(stopReason ? { stopReason } : {}),
+  } as unknown as AgentMessage;
+}
+
+function usageRecord(totalTokens: number) {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: totalTokens,
+    cacheWrite: 0,
+    totalTokens,
+    cost: {},
+  };
+}
+
+/** What the upstream heuristic alone would report for a message list. */
+function upstreamTotal(messages: AgentMessage[]): number {
+  return messages.reduce((total, message) => total + estimateTokens(message), 0);
+}
+
 function llmResponse(text: string) {
   return {
     role: 'assistant',
@@ -145,5 +193,179 @@ describe('createCompactContext with the real estimator', () => {
 
     await createCompactContext(mockConfig)(messages);
     expect(mockCompleteSimple).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Regression guard for the `interview-me` scoop (2026-08-31), read live off the
+ * production instance over CDP: 1,696 messages, provider reporting 985,427 of a
+ * 1,000,000-token window (98.5% full), while `estimateTotalTokens` reported
+ * 496,129 — barely half the 983,616 trigger. The scoop was ~16 turns from a hard
+ * context-overflow that proactive compaction should have prevented.
+ *
+ * Two independent causes, one per describe block below:
+ *
+ *  1. 1,099,252 chars of `thinkingSignature` across 471 thinking blocks that
+ *     upstream's `estimateTokens` does not walk at all.
+ *  2. Even with those counted the heuristic lands near 771k, because chars/4 runs
+ *     generous for code and JSON. The provider already told us the real number in
+ *     the last turn's `usage`; the trigger now believes it.
+ */
+describe('thinkingSignature accounting', () => {
+  const mockModel = { id: 'test-model' } as unknown as Model<Api>;
+  const mockConfig = {
+    model: mockModel,
+    getApiKey: () => 'test-key' as string | undefined,
+    contextWindow: 100_000,
+  };
+  // contextWindow - DEFAULT_COMPACTION_SETTINGS.reserveTokens
+  const threshold = 100_000 - 16_384;
+
+  beforeEach(() => {
+    mockCompleteSimple.mockReset();
+    mockCompleteSimple.mockResolvedValue(llmResponse('summary'));
+  });
+
+  it('upstream estimateTokens does not count thinkingSignature', () => {
+    // Tripwire, not an endorsement: if a future pi-coding-agent starts counting
+    // the signature this fails, and `estimateMessageTokens` can drop its wrapper.
+    const turn = createThinkingTurn(400_000, 'brief');
+    expect(estimateTokens(turn)).toBeLessThan(100);
+  });
+
+  it('triggers compaction when thinkingSignature blobs fill the window', async () => {
+    // 6 turns x 80,000 signature chars = 120,000 tokens once counted.
+    const messages: AgentMessage[] = [];
+    for (let i = 0; i < 6; i++) {
+      messages.push(createUser(`step ${i}`), createThinkingTurn(80_000));
+    }
+
+    // The premise: upstream's heuristic alone would never arm compaction here.
+    expect(upstreamTotal(messages)).toBeLessThan(threshold);
+
+    const result = await createCompactContext(mockConfig)(messages);
+
+    expect(mockCompleteSimple).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(result[0])).toContain('<context-summary>');
+    expect(result.length).toBeLessThan(messages.length);
+  });
+
+  it('does NOT trigger when the same turns carry no signature', async () => {
+    const messages: AgentMessage[] = [];
+    for (let i = 0; i < 6; i++) {
+      messages.push(createUser(`step ${i}`), {
+        role: 'assistant',
+        content: [{ type: 'thinking', thinking: 'brief' }],
+        timestamp: 0,
+      } as unknown as AgentMessage);
+    }
+
+    const result = await createCompactContext(mockConfig)(messages);
+
+    expect(mockCompleteSimple).not.toHaveBeenCalled();
+    expect(result).toBe(messages);
+  });
+
+  it('prices the kept tail by signature weight too', async () => {
+    // keepRecentTokens is 20,000; one 80,000-char signature turn is 20,000 tokens
+    // on its own, so the cut must keep exactly that turn — not a tail that is
+    // nominally 20,000 tokens but really four times that.
+    const messages: AgentMessage[] = [];
+    for (let i = 0; i < 6; i++) {
+      messages.push(createUser(`step ${i}`), createThinkingTurn(80_000));
+    }
+
+    const result = await createCompactContext(mockConfig)(messages);
+
+    // [summary, last assistant turn]
+    expect(result).toHaveLength(2);
+    expect(result[1]).toBe(messages[messages.length - 1]);
+  });
+});
+
+describe('provider-reported usage in the compaction trigger', () => {
+  const mockModel = { id: 'test-model' } as unknown as Model<Api>;
+  const mockConfig = {
+    model: mockModel,
+    getApiKey: () => 'test-key' as string | undefined,
+    contextWindow: 100_000,
+  };
+  const threshold = 100_000 - 16_384;
+
+  /**
+   * Heuristic total ~40,000 (under the threshold) and long enough that a cut
+   * point exists. `usage` on the final assistant turn is what decides.
+   */
+  function conversation(usage?: Record<string, unknown>, stopReason?: string): AgentMessage[] {
+    const body = 'a'.repeat(40_000); // 10,000 tokens each
+    return [
+      createUser('one'),
+      createTextTurn(body),
+      createUser('two'),
+      createTextTurn(body),
+      createUser('three'),
+      createTextTurn(body),
+      createUser('four'),
+      createTextTurn(body, usage, stopReason),
+    ];
+  }
+
+  beforeEach(() => {
+    mockCompleteSimple.mockReset();
+    mockCompleteSimple.mockResolvedValue(llmResponse('summary'));
+  });
+
+  it('trusts the reported usage over the optimistic heuristic', async () => {
+    const messages = conversation(usageRecord(95_000));
+    expect(upstreamTotal(messages)).toBeLessThan(threshold);
+
+    const result = await createCompactContext(mockConfig)(messages);
+
+    expect(mockCompleteSimple).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(result[0])).toContain('<context-summary>');
+  });
+
+  it('ignores usage from an errored or aborted turn', async () => {
+    for (const stopReason of ['error', 'aborted']) {
+      mockCompleteSimple.mockClear();
+      const messages = conversation(usageRecord(95_000), stopReason);
+      // The record is present but meaningless — fall back to the heuristic.
+      const result = await createCompactContext(mockConfig)(messages);
+      expect(mockCompleteSimple, stopReason).not.toHaveBeenCalled();
+      expect(result).toBe(messages);
+    }
+  });
+
+  it('ignores an all-zero usage record', async () => {
+    const messages = conversation(usageRecord(0));
+    const result = await createCompactContext(mockConfig)(messages);
+    expect(mockCompleteSimple).not.toHaveBeenCalled();
+    expect(result).toBe(messages);
+  });
+
+  it('still triggers when the heuristic exceeds a stale small usage', async () => {
+    // A usage record that predates the tail must never suppress the trigger:
+    // the estimate is the max of the two, not a replacement.
+    const messages: AgentMessage[] = [];
+    for (let i = 0; i < 6; i++) {
+      messages.push(createUser(`step ${i}`), createThinkingTurn(80_000));
+    }
+    (messages[messages.length - 1] as unknown as { usage: unknown }).usage = usageRecord(500);
+
+    await createCompactContext(mockConfig)(messages);
+
+    expect(mockCompleteSimple).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts messages appended after the last reported usage', async () => {
+    // Usage 80,000 is just under the 83,616 threshold; the turn appended after
+    // it carries the total over.
+    const messages = [...conversation(usageRecord(80_000))];
+    expect(upstreamTotal(messages)).toBeLessThan(threshold);
+    messages.push(createUser('x'.repeat(40_000)));
+
+    await createCompactContext(mockConfig)(messages);
+
+    expect(mockCompleteSimple).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

Proactive context compaction was blind to roughly half the context it was
supposed to measure, so on a long thinking-heavy conversation it never armed and
the unit ran into a hard provider context-overflow instead. This teaches the
trigger to count `thinkingSignature` bytes and to believe the provider's own
reported `usage` when it has one.

## Why

Found live on the production instance (CDP `:9222`, 2026-08-31) while looking at
the `interview-me` scoop:

| | |
|---|---|
| model | `adobe:claude-sonnet-5`, contextWindow 1,000,000 |
| messages | 1,696 |
| **provider-reported, last turn** | **985,427 (98.5% full)** |
| **`estimateTotalTokens`** | **496,129** |
| compaction threshold | 983,616 (`contextWindow - reserveTokens`) |

The scoop was ~16 turns (~3.5 min at its observed burn) from a hard overflow that
proactive compaction exists to prevent. The estimate was growing at about half the
real rate, so it would have needed ~1,100 more turns to reach its own trigger — it
was never going to fire.

Two causes, both fixed here.

**1. `thinkingSignature` is uncounted.** pi-coding-agent's `estimateTokens` walks
`block.thinking` but not `block.thinkingSignature` — the opaque blob Anthropic
returns with every thinking block and requires echoed back on the next request, so
it occupies real context on every subsequent turn. Field-level accounting of the
live conversation:

| field | chars | counted? |
|---|---:|---|
| `assistant.thinking.thinkingSignature` | 1,099,252 | **no** |
| `toolResult.text.text` | 816,004 | yes |
| `assistant.toolCall.arguments` | 675,371 | yes |
| `assistant.thinking.thinking` | 307,104 | yes |
| `assistant.text.text` | 78,056 | yes |
| `user.text.text` | 49,759 | yes |
| `toolResult.image.data` | 991,528 | proxied at 4,800 chars/image |

Counted total: 1,983,949 chars / 4 = 495,987 — which is the 496,129 the estimator
reported, so the accounting is fully explained.

**2. chars/4 is generous for this content.** Counting the signature alone moves the
estimate to ~771k, still under the 983,616 trigger: base64 and dense JSON tokenize
nearer 3.3 chars/token than 4. The provider already told us the true number in the
last turn's `usage` — and `estimateContextFill` (which drives the UI chip pupils)
already reads it, which is exactly why the UI showed 98% while the compactor
believed 50%. The two estimators disagreed and the usage-based one was right.

Reactive `OverflowRecovery` would eventually have caught this (force-compaction on
the overflow error), but only after a wasted provider round-trip, and it surfaces
as an error-shaped event mid-tool-loop rather than a clean checkpoint.

## Approach / Implementation notes

All in `packages/webapp/src/core/context-compaction.ts`.

- `estimateMessageTokens(msg)` = upstream `estimateTokens` + `ceil(signatureChars/4)`.
  **Every** local call site now goes through it — the trigger, the
  `elideOversizedMessages` per-message threshold, the `selectCompactionSlices`
  cut-point walk, and legacy `compactContext` — so a message is priced identically
  everywhere. The cut-point one matters on its own: without it the "20,000-token"
  kept tail was really four times that.
- `estimateContextTokens(messages)` = `max(heuristic, reportedUsage + heuristic of
  messages appended since)`. Used by the trigger only.
  - `max`, not replacement, keeps the answer monotone in what we can see: a stale,
    missing or under-reported usage can never make the total look *smaller* than the
    messages themselves.
  - Usage from an `aborted`/`error` turn or an all-zero record is skipped, mirroring
    pi-coding-agent's own `getAssistantUsage` rules.
  - Implemented locally rather than importing upstream's `estimateContextTokens`:
    the local ambient `declare module` shadows upstream's `.d.ts` (see the hazard
    documented in `types/pi-coding-agent-compaction.contract.ts`), and upstream's
    version would use the signature-blind estimator for the trailing messages.
- **Everything downstream of the trigger deliberately keeps re-measuring with the
  pure heuristic.** Once elision has rewritten messages, a usage record describing
  the pre-elision prefix is stale and would overstate the result. In the common path
  (`elidedCount === 0`) `applyHopelessElision` returns the true no-op branch, so the
  usage-aware total never reaches the post-elision recompute at all.

## Cross-cutting impact

- **Behavioral direction is one-way: compaction fires *earlier*, never later.** Both
  changes can only raise the trigger estimate.
- **Other callers of the changed helpers**: `estimateTotalTokens` is module-private;
  its four call sites (`applyHopelessElision` post-elision recompute, the
  `elideTailImages` loop, and the two above) are all in this file and all reviewed.
  `createCompactContext` is consumed by `scoops/scoop-context/session-helpers.ts`
  (per-unit) and the "New session" freezer via `runOneOffCompactionCall`, whose
  contract is unchanged.
- **`hopelessMultiplier`**: `isHopeless` compares against `contextWindow * 4`; a
  provider-reported usage is capped at the window by construction, so it cannot
  push a conversation into the hopeless branch spuriously.
- **Floats**: pure `core/` logic, no realm/DOM/wire surface — identical in CLI,
  extension, Electron, cloud and Cherry. No persisted state, no new deps, no
  localStorage keys, no bundle impact.

## Test plan

`packages/webapp/tests/core/context-compaction-real-estimator.test.ts` (the file that
already guards the un-mocked upstream estimator) gains 9 cases:

- upstream `estimateTokens` returns <100 tokens for a 400,000-char signature — a
  **tripwire**, not an endorsement: if pi-coding-agent starts counting it, this fails
  and the wrapper can be dropped.
- signature blobs alone drive compaction, with an explicit assertion that the
  upstream heuristic on the same list is *below* the threshold — that assertion is
  the scenario.
- the cut point prices the kept tail by signature weight too.
- provider usage triggers compaction over an optimistic heuristic; usage from
  `error`/`aborted` turns and all-zero records is ignored; a stale small usage does
  not suppress a heuristic that exceeds it; messages appended after the last usage
  are added on top.
- controls that must NOT compact (no signature, ignored usage) assert the identity
  `result === messages`, so they can't pass vacuously.

**A/B verified**: with the `src` change reverted, 5 of the new tests fail and the
controls still pass. With it, 13/13 pass.

- [x] `npm run verify` — 7/7 checks (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck` — all 9 projects
- [x] `npm run test` — **18,129 passing**, 52 skipped, 0 failures
- [x] `npm run test:coverage` — exit 0 (statements 79.57%, lines 81.63%)
- [x] `npm run build` — webapp / cherry / node-server / worker all built
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — First-load OK, 4955 kB total; extension 100.74 kB of 105 kB
- [x] New behavior covered by unit tests: `npx vitest run packages/webapp/tests/core/context-compaction-real-estimator.test.ts`
- [x] N/A for UI smoke — no UI surface changed

**Pre-existing failure** (unrelated to this PR): `npm run build` fails in
`@slicc/swift-server` at `swift build -c release` with

```
error: 'webrtc': Revision 3e43fa9b8d149d2f8adb9bb1e53152cb955ec72b for webrtc
remoteSourceControl https://github.com/stasel/WebRTC.git version 151.0.0 does not
match previously recorded value 19aa8c1fc7120d50df987b7111f42d5024df3d54
```

`packages/swift-server/Package.resolved` pins `19aa8c1…` from `2a378ad60 chore(deps):
update dependency stasel/webrtc to v151`, but the upstream `151.0.0` tag now resolves
to `3e43fa9b…`. Tracked files, untouched by this PR; every JS/TS build target
succeeded.

## Documentation

- [x] Relevant `CLAUDE.md` — none needed; the module header comment in
      `context-compaction.ts` (which previously stated "no wrapper is required here")
      is corrected in this diff to point at `estimateMessageTokens`.
- [x] No other documentation changes needed

## Risk & rollback

Blast radius is one module. The only behavioral change is that compaction arms
sooner on conversations the old estimate under-measured — a conversation whose
heuristic already exceeded the threshold behaves exactly as before. No flags, no
migration; a clean revert of this commit fully restores the old behavior.

The residual known gap, deliberately left alone: chars/4 stays the divisor for the
no-usage fallback (pre-first-turn, and post-elision recomputation). Changing the
divisor globally would shift compaction timing for every conversation and risks
premature compaction, which is a policy change rather than a correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
