### PR TITLE
fix(webapp): request persistent storage so Chrome cannot evict the VFS

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -500,6 +500,49 @@ at the bare minimum ZenFS Viewer needs and
 copy; the patch is gone. A presence check is `typeof globalThis.__zenfs__ !==
 'undefined'`, and the version lives in the `_version` export, not on the global.
 
+## OPFS Is Evictable: Chrome Deletes It To Free Disk Space
+
+**Files**: `packages/webapp/src/ui/boot/setup-storage-persistence.ts`,
+`packages/webapp/src/shell/supplemental-commands/df-command.ts`.
+
+OPFS is **best-effort** quota storage, not durable storage. Chromium's
+`QuotaTemporaryStorageEvictor` runs every 30 minutes (first round 5 minutes
+after browser startup) and, whenever free space is below
+`min(2 GiB, 10% of the volume)`, deletes whole buckets until the shortage is
+covered — LRU by `last_accessed`, and only rows with `persistent = 0`
+(`storage/browser/quota/quota_database.cc`). "Whole bucket" means the origin's
+**entire OPFS tree**: workspace, sessions, memory, git checkouts, gone at once,
+silently, while the tab keeps running. There is no event, no partial trim, and
+nothing in the page can veto it after the fact. A second arm evicts on
+`usage > 70% of pool_size` (56% of the volume) regardless of free space.
+
+`navigator.storage.persist()` is the only lever the page has, and it is a real
+one: a granted request marks the default bucket persistent and the eviction
+query skips it outright. `setupStoragePersistence()` therefore runs from
+`main.ts` on every boot, fire-and-forget.
+
+Load-bearing details, all of them easy to get wrong:
+
+- **`persist()` is `[Exposed=Window]`.** `persisted()`, `estimate()` and
+  `getDirectory()` are also exposed to workers; `persist()` is not. It has to
+  be called from the page realm — the kernel worker cannot do it.
+- **It never prompts in Chromium.** The decision comes from site engagement,
+  bookmarks, notification permission and PWA installation. A `false` is not a
+  user refusal, so it is re-requested every boot: the answer changes as
+  engagement accumulates. (Firefox is the engine that would prompt.)
+- **Never `await` it onto the boot path.** `setupStoragePersistence()` returns
+  `void` on purpose, and swallows rejections — an unhandled one would surface
+  in `main()`'s catch and drop the user on the boot recovery screen over a
+  storage hint.
+- **Measure free space with `statvfs` / `f_bavail`** if you ever compare
+  against these thresholds from outside the browser. That is what
+  `base::SysInfo::AmountOfFreeDiskSpace` uses; macOS'
+  `volumeAvailableCapacityForImportantUsageKey` adds purgeable space the quota
+  manager never sees, so it reports headroom Chromium will not honour.
+
+`df` (and `diskutil info`) report the live flag via `storage.persisted()`, so
+that is where to look when a session is suspected of having been evicted.
+
 ## CDP Transport: Extension Mode
 
 **File**: `packages/webapp/src/cdp/extension-bridge-transport.ts`

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -37,6 +37,9 @@ Per-subsystem file paths + invariants live in
 - UI + layouts — `src/ui/` and `ui/wc/` (also `docs/layouts.md`)
 - Skills — `src/skills/`; Sprinkles + Dips — `ui/sprinkle-*.ts`, `ui/dip.ts`
 - Stale-asset recovery — `setup-preload-error-reload.ts` + `stale-asset-channel.ts`
+- Storage persistence — `boot/setup-storage-persistence.ts` (OPFS is _evictable_ best-effort
+  storage; `navigator.storage.persist()` is the only opt-out and is page-realm only —
+  `docs/pitfalls.md`)
 - File mentions / preview + base64 payload chips —
   [`docs/webapp-details.md`](../../docs/webapp-details.md) (catches: confirm-then-linkify
   only, never a streaming bubble; `getMimeType()` SERVES vs `sniffFileType()` READS)

--- a/packages/webapp/src/ui/boot/setup-storage-persistence.ts
+++ b/packages/webapp/src/ui/boot/setup-storage-persistence.ts
@@ -1,0 +1,135 @@
+/**
+ * `setup-storage-persistence.ts` — ask the browser to stop treating
+ * SLICC's filesystem as disposable.
+ *
+ * SLICC's entire VFS — workspace, sessions, memory, git checkouts — is an
+ * OPFS tree. OPFS lives in the quota manager's *best-effort* storage, so
+ * Chromium reclaims disk space by evicting whole buckets: whenever free
+ * space drops below `min(2 GiB, 10% of the volume)`,
+ * `QuotaTemporaryStorageEvictor` runs (every 30 minutes, first round 5
+ * minutes after startup) and deletes least-recently-used buckets until the
+ * shortage is covered. "Bucket" means the origin's *entire* OPFS tree,
+ * removed at once, silently, while the tab keeps running. There is no
+ * event to listen for and nothing in the page can veto it after the fact.
+ *
+ * `navigator.storage.persist()` is the one lever the page does have. A
+ * granted request marks the origin's default bucket persistent, and the
+ * eviction query skips those rows outright:
+ *
+ * ```sql
+ * SELECT id, storage_key, name FROM buckets WHERE persistent = 0 ORDER BY last_accessed
+ * ```
+ * (`storage/browser/quota/quota_database.cc`)
+ *
+ * So this is not a nice-to-have hint — it is the difference between being
+ * on the eviction list and being off it.
+ *
+ * **It never prompts.** Chromium auto-decides from site engagement,
+ * bookmarks, notification permission, and PWA installation; Firefox is the
+ * engine that would show a permission prompt, and it does not implement
+ * OPFS eviction the same way. A denial is therefore not something the user
+ * refused — it means the heuristics have not warmed up yet, so we log it
+ * and move on. Re-requesting on the next boot is exactly right: the answer
+ * changes as engagement accumulates.
+ *
+ * Fire-and-forget from `main.ts` — nothing about boot may wait on it.
+ */
+
+import { createLogger } from '../../base/logger.js';
+
+const log = createLogger('storage-persist');
+
+/** The sliver of `StorageManager` this module uses. */
+interface StorageManagerLike {
+  persisted?: () => Promise<boolean>;
+  persist?: () => Promise<boolean>;
+}
+
+/**
+ * What came back. Distinguished rather than collapsed to a boolean so the
+ * log (and the tests) can tell "the browser has no opinion yet" apart from
+ * "this browser cannot do it at all" — only the latter is permanent.
+ */
+export type StoragePersistenceOutcome =
+  | 'already-persisted'
+  | 'granted'
+  | 'denied'
+  | 'unsupported'
+  | 'failed';
+
+function resolveStorage(): StorageManagerLike | undefined {
+  try {
+    return (globalThis as { navigator?: { storage?: StorageManagerLike } }).navigator?.storage;
+  } catch {
+    // `navigator` is absent in Node/Vitest and can throw behind some
+    // hardened embedders.
+    return undefined;
+  }
+}
+
+/**
+ * Request persistence for this origin's default bucket.
+ *
+ * Checks {@link StorageManagerLike.persisted} first: a bucket that is
+ * already persistent needs nothing, and the distinction is worth logging —
+ * "granted" on every reload would otherwise hide the fact that the grant is
+ * sticky.
+ *
+ * Never throws. A storage API that rejects is a diagnostic, not a boot
+ * failure; the data is exactly as safe as it was before the call.
+ */
+export async function requestStoragePersistence(
+  storage: StorageManagerLike | undefined = resolveStorage()
+): Promise<StoragePersistenceOutcome> {
+  if (typeof storage?.persist !== 'function') return 'unsupported';
+  try {
+    if (typeof storage.persisted === 'function' && (await storage.persisted())) {
+      return 'already-persisted';
+    }
+    return (await storage.persist()) ? 'granted' : 'denied';
+  } catch (err) {
+    log.warn('storage.persist() failed', err);
+    return 'failed';
+  }
+}
+
+let requested = false;
+
+/**
+ * Kick off the request once per page. Idempotent — repeat calls are no-ops,
+ * so a runtime that boots through more than one path cannot double-request.
+ *
+ * Deliberately returns `void` rather than the promise: no caller should be
+ * able to accidentally `await` this onto the boot critical path.
+ */
+export function setupStoragePersistence(): void {
+  if (requested) return;
+  requested = true;
+  void requestStoragePersistence().then((outcome) => {
+    switch (outcome) {
+      case 'granted':
+        log.info('OPFS marked persistent — SLICC data is now exempt from disk-pressure eviction');
+        break;
+      case 'already-persisted':
+        log.debug('OPFS already persistent');
+        break;
+      case 'denied':
+        // Worth a warning: the VFS is a live eviction candidate until this
+        // flips, and `df` reports the same flag if anyone goes looking.
+        log.warn(
+          'Browser declined persistent storage — SLICC data can be evicted if the disk fills up'
+        );
+        break;
+      case 'unsupported':
+        log.debug('navigator.storage.persist() unavailable in this runtime');
+        break;
+      case 'failed':
+        break;
+    }
+  });
+}
+
+/** Test-only: clear the once-per-page latch. */
+export function __resetStoragePersistenceForTest(): void {
+  requested = false;
+}

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -30,6 +30,7 @@ import { startFreezeWatchdog } from './boot/setup-freeze-watchdog.js';
 import { setupNukeReloadListener } from './boot/setup-nuke-reload-listener.js';
 import { setupPreloadErrorReload } from './boot/setup-preload-error-reload.js';
 import { parseExtensionLeaderParams } from './boot/setup-standalone-prelude.js';
+import { setupStoragePersistence } from './boot/setup-storage-persistence.js';
 import { setupSwRegistration } from './boot/setup-sw-registration.js';
 import { applyProviderDefaults } from './provider-settings.js';
 
@@ -89,6 +90,13 @@ async function main(): Promise<void> {
   // window-context listener acts on (clearing select localStorage
   // keys, then reloading). Idempotent — safe to call across re-inits.
   setupNukeReloadListener();
+
+  // Ask the browser to mark this origin's storage persistent. SLICC's whole
+  // VFS is an OPFS tree, and OPFS is best-effort quota storage: on a nearly
+  // full disk Chromium evicts whole buckets — the entire tree, silently —
+  // unless the bucket is persistent. Fire-and-forget, never prompts, and the
+  // answer improves with site engagement, so it is re-requested every boot.
+  setupStoragePersistence();
 
   // Initialize RUM telemetry for the page/panel realm — `trackShellCommand`,
   // `trackChatSubmit`, sprinkle `viewblock`, settings `signup`, and panel JS

--- a/packages/webapp/tests/ui/boot/setup-storage-persistence.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-storage-persistence.test.ts
@@ -1,0 +1,183 @@
+/**
+ * `navigator.storage.persist()` is the only lever the page has against
+ * Chromium evicting SLICC's entire OPFS tree under disk pressure — the
+ * eviction query skips buckets with `persistent = 1`. These pin the two
+ * properties that matter: the request is actually made, and nothing about
+ * it can take the boot path down with it.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetStoragePersistenceForTest,
+  requestStoragePersistence,
+  setupStoragePersistence,
+} from '../../../src/ui/boot/setup-storage-persistence.js';
+
+interface StorageStub {
+  persisted?: () => Promise<boolean>;
+  persist?: () => Promise<boolean>;
+}
+
+/** Run `fn` with `navigator.storage` faked to `storage`. */
+async function withNavigatorStorage(storage: StorageStub | undefined, fn: () => Promise<void>) {
+  const globals = globalThis as { navigator?: { storage?: StorageStub } };
+  const had = Object.hasOwn(globals, 'navigator');
+  const previous = globals.navigator;
+  Object.defineProperty(globals, 'navigator', {
+    value: storage === undefined ? {} : { storage },
+    configurable: true,
+    writable: true,
+  });
+  try {
+    await fn();
+  } finally {
+    if (had) {
+      Object.defineProperty(globals, 'navigator', {
+        value: previous,
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      delete globals.navigator;
+    }
+  }
+}
+
+describe('requestStoragePersistence', () => {
+  beforeEach(() => {
+    __resetStoragePersistenceForTest();
+  });
+
+  it('requests persistence and reports the grant', async () => {
+    const persist = vi.fn(async () => true);
+    const outcome = await requestStoragePersistence({ persisted: async () => false, persist });
+
+    expect(outcome).toBe('granted');
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  /** The grant is sticky, so re-asking every boot would be pure noise. */
+  it('does not re-request when the bucket is already persistent', async () => {
+    const persist = vi.fn(async () => true);
+    const outcome = await requestStoragePersistence({ persisted: async () => true, persist });
+
+    expect(outcome).toBe('already-persisted');
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A denial is not a user refusal — Chromium decides from site engagement
+   * and never prompts — so it must stay distinguishable from `unsupported`,
+   * which is the only permanent answer.
+   */
+  it('reports a denial distinctly from an unsupported runtime', async () => {
+    expect(
+      await requestStoragePersistence({ persisted: async () => false, persist: async () => false })
+    ).toBe('denied');
+    expect(await requestStoragePersistence({})).toBe('unsupported');
+    expect(await requestStoragePersistence(undefined)).toBe('unsupported');
+  });
+
+  /** Older engines expose `persist()` without `persisted()`. */
+  it('still requests when only persist() is implemented', async () => {
+    const persist = vi.fn(async () => true);
+    expect(await requestStoragePersistence({ persist })).toBe('granted');
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a rejecting storage API rather than throwing at the caller', async () => {
+    const outcome = await requestStoragePersistence({
+      persisted: async () => false,
+      persist: async () => {
+        throw new Error('SecurityError');
+      },
+    });
+
+    expect(outcome).toBe('failed');
+  });
+
+  it('treats a rejecting persisted() as a failure, not a silent skip', async () => {
+    const persist = vi.fn(async () => true);
+    const outcome = await requestStoragePersistence({
+      persisted: async () => {
+        throw new Error('nope');
+      },
+      persist,
+    });
+
+    expect(outcome).toBe('failed');
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('reads navigator.storage when no argument is passed', async () => {
+    const persist = vi.fn(async () => true);
+    await withNavigatorStorage({ persisted: async () => false, persist }, async () => {
+      expect(await requestStoragePersistence()).toBe('granted');
+    });
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('setupStoragePersistence', () => {
+  beforeEach(() => {
+    __resetStoragePersistenceForTest();
+  });
+
+  it('fires the request and returns synchronously — boot never awaits it', async () => {
+    let resolvePersist: (value: boolean) => void = () => {};
+    const persist = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolvePersist = resolve;
+        })
+    );
+
+    await withNavigatorStorage({ persisted: async () => false, persist }, async () => {
+      // Returns immediately, before `persist()` has even been reached.
+      expect(setupStoragePersistence()).toBeUndefined();
+
+      // …and still returns having left the request in flight: flushing
+      // microtasks gets us past `persisted()` into a `persist()` that never
+      // settles, which is the state boot has to tolerate.
+      await vi.waitFor(() => expect(persist).toHaveBeenCalledTimes(1));
+      resolvePersist(true);
+      await Promise.resolve();
+    });
+  });
+
+  it('requests at most once per page', async () => {
+    const persist = vi.fn(async () => true);
+    await withNavigatorStorage({ persisted: async () => false, persist }, async () => {
+      setupStoragePersistence();
+      setupStoragePersistence();
+      setupStoragePersistence();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The whole point is that a browser without the API — or one that throws —
+   * costs boot nothing. An unhandled rejection here would surface as a fatal
+   * in `main()`'s catch and drop the user on the recovery screen.
+   */
+  it('does not throw or reject when the storage API is missing or hostile', async () => {
+    await withNavigatorStorage(undefined, async () => {
+      expect(() => setupStoragePersistence()).not.toThrow();
+    });
+
+    __resetStoragePersistenceForTest();
+    await withNavigatorStorage(
+      {
+        persist: () => Promise.reject(new Error('SecurityError')),
+      },
+      async () => {
+        expect(() => setupStoragePersistence()).not.toThrow();
+        await Promise.resolve();
+        await Promise.resolve();
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Problem

SLICC's entire filesystem — workspace, sessions, memory, git checkouts — is an OPFS tree. OPFS is the quota manager's **best-effort** storage, not durable storage.

Whenever free disk space drops below `min(2 GiB, 10% of the volume)`, Chromium's `QuotaTemporaryStorageEvictor` runs (every 30 min; first round 5 min after browser startup) and deletes whole buckets, LRU first, until the shortage is covered. "Whole bucket" means the origin's **entire OPFS tree**, removed at once, silently, while the tab keeps running. No event, no partial trim, nothing the page can veto after the fact.

This is not theoretical — it happened, and it takes everything.

## The fix

The eviction candidates come from one query (`storage/browser/quota/quota_database.cc`):

```sql
SELECT id, storage_key, name FROM buckets
 WHERE persistent = 0 ORDER BY last_accessed
```

A granted `navigator.storage.persist()` marks the origin's default bucket persistent, so those rows are skipped **outright**. It is the difference between being on the eviction list and being off it.

We already reported the flag through `df` / `diskutil info` — we just never set it.

`setupStoragePersistence()` now runs from `main.ts`, fire-and-forget.

## Things that are easy to get wrong here

- **`persist()` is `[Exposed=Window]`.** `persisted()`, `estimate()` and `getDirectory()` are also exposed to workers; `persist()` is not. It has to be the page realm — the kernel worker cannot do it.
- **It never prompts in Chromium.** The decision comes from site engagement, bookmarks, notification permission and PWA installation. A `false` is not a user refusal, so it is re-requested every boot as those heuristics warm up. (Firefox is the engine that would prompt.)
- **Boot never awaits it.** `setupStoragePersistence()` returns `void` on purpose and swallows rejections — an unhandled one would surface in `main()`'s catch and drop the user on the boot recovery screen over a storage hint.
- The outcome is a 5-way union rather than a boolean so `denied` (temporary, will likely flip) stays distinguishable from `unsupported` (permanent) in the logs.

## Scope

Deliberately just the `persist()` call. A launcher-side safeguard for the same failure — Sliccstart quitting SLICC's browsers before the volume reaches the eviction floor, since a Chromium that is not running evicts nothing — is a separate change and does not block this one. This is the cheaper and more general fix: it covers `npx sliccy` and the extension too, which no launcher can reach.

## Verification

`lint:ci` · `npm run verify` (7/7) · `typecheck` · full vitest (18,164 passed) · `test:coverage:webapp` · webapp build.

First-load gate: **page +0.8 kB** vs merge-base, inside the 5 kB allowance.

10 new tests covering grant / already-persisted / denied / unsupported / rejecting `persist()` / rejecting `persisted()` / once-per-page / boot-never-blocks.

Docs: `docs/pitfalls.md` gets the full durable write-up (thresholds, the exposure gotcha, why `statvfs`/`f_bavail` is the right way to measure free space against these numbers from outside the browser); `packages/webapp/CLAUDE.md` points at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
