### PR TITLE
fix(deps): repoint Swift pins at live upstream releases

### DIFF
--- a/packages/ios-app/Package.resolved
+++ b/packages/ios-app/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9682f865547126ffcb52cee5f7bd189ed644f57d00820ff9a509b2f8bd134b49",
+  "originHash" : "92fb43ac6b20f4bc14d68b3994c9f544665ac45cb95e4e0bf57a895fcacde15b",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lakr233/libghostty-spm",
       "state" : {
-        "revision" : "356f730bec03281fc7b83666a129b0246137ea26",
-        "version" : "1.4.0"
+        "revision" : "e6255b49fa697a41d8fbcce07f999d84a6c56dcb",
+        "version" : "1.5.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lakr233/MSDisplayLink.git",
       "state" : {
-        "revision" : "1ba3e769b734e456317fa7e45321fa7f53eefb67",
-        "version" : "2.1.0"
+        "revision" : "87eb0af130744c8cbe2e31b6e1a5bcd659f1c220",
+        "version" : "2.2.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stasel/WebRTC.git",
       "state" : {
-        "revision" : "19aa8c1fc7120d50df987b7111f42d5024df3d54",
-        "version" : "151.0.0"
+        "revision" : "1d04692697cb642bfebf6ad2dd99fe52649c3d6d",
+        "version" : "152.0.0"
       }
     }
   ],

--- a/packages/ios-app/Package.swift
+++ b/packages/ios-app/Package.swift
@@ -17,11 +17,11 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/Lakr233/libghostty-spm", exact: "1.4.0"),
+        .package(url: "https://github.com/Lakr233/libghostty-spm", exact: "1.5.1"),
         .package(
             url: "https://github.com/huggingface/swift-huggingface",
             .upToNextMinor(from: "0.9.0")),
-        .package(url: "https://github.com/stasel/WebRTC.git", .upToNextMajor(from: "151.0.0")),
+        .package(url: "https://github.com/stasel/WebRTC.git", .upToNextMajor(from: "152.0.0")),
         .package(path: "../swift-traysession"),
         .package(path: "../swift-trayfollower"),
         .package(path: "../swift-traykit"),

--- a/packages/ios-app/SliccFollower.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/ios-app/SliccFollower.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "02785617df776313e432a69fe9471eef0178337b2fc37f290416f643b12ad695",
+  "originHash" : "d49c8af03fb09697f8a4e7439e06a02c08609e455f52205272b2ebcdde8c1ee1",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lakr233/libghostty-spm",
       "state" : {
-        "revision" : "356f730bec03281fc7b83666a129b0246137ea26",
-        "version" : "1.4.0"
+        "revision" : "e6255b49fa697a41d8fbcce07f999d84a6c56dcb",
+        "version" : "1.5.1"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stasel/WebRTC.git",
       "state" : {
-        "revision" : "19aa8c1fc7120d50df987b7111f42d5024df3d54",
-        "version" : "151.0.0"
+        "revision" : "1d04692697cb642bfebf6ad2dd99fe52649c3d6d",
+        "version" : "152.0.0"
       }
     }
   ],

--- a/packages/ios-app/project.yml
+++ b/packages/ios-app/project.yml
@@ -247,13 +247,13 @@ schemes:
 packages:
   GhosttyTerminal:
     url: https://github.com/Lakr233/libghostty-spm
-    exactVersion: 1.4.0
+    exactVersion: 1.5.1
   HuggingFace:
     url: https://github.com/huggingface/swift-huggingface
     minorVersion: 0.9.0
   WebRTC:
     url: https://github.com/stasel/WebRTC.git
-    exactVersion: 151.0.0
+    exactVersion: 152.0.0
   SliccTraySession:
     path: ../swift-traysession
   SliccTrayFollower:

--- a/packages/swift-launcher/Package.resolved
+++ b/packages/swift-launcher/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stasel/WebRTC.git",
       "state" : {
-        "revision" : "19aa8c1fc7120d50df987b7111f42d5024df3d54",
-        "version" : "151.0.0"
+        "revision" : "1d04692697cb642bfebf6ad2dd99fe52649c3d6d",
+        "version" : "152.0.0"
       }
     }
   ],

--- a/packages/swift-launcher/project.yml
+++ b/packages/swift-launcher/project.yml
@@ -71,7 +71,7 @@ schemes:
 packages:
   WebRTC:
     url: https://github.com/stasel/WebRTC.git
-    exactVersion: 151.0.0
+    exactVersion: 152.0.0
   SliccTrayVFS:
     path: ../swift-traykit
   SliccWidgetKit:

--- a/packages/swift-server/Package.resolved
+++ b/packages/swift-server/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "361aceff2ce53165a8fb41a0bdac3728a40ace8f36c0c12950cc62f650c9c4f2",
+  "originHash" : "da859a0007f8d435771f6693c09cdfaf060e8876ffdf4ca8c177bf64e46fb865",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stasel/WebRTC.git",
       "state" : {
-        "revision" : "19aa8c1fc7120d50df987b7111f42d5024df3d54",
-        "version" : "151.0.0"
+        "revision" : "1d04692697cb642bfebf6ad2dd99fe52649c3d6d",
+        "version" : "152.0.0"
       }
     },
     {

--- a/packages/swift-trayfollower/CLAUDE.md
+++ b/packages/swift-trayfollower/CLAUDE.md
@@ -4,7 +4,7 @@ This file covers the shared tray-follower transport library in `packages/swift-t
 
 ## Scope
 
-`SliccTrayFollower` is the headless tray-follower transport (signalling + WebRTC + tray-sync protocol mirror + chunk framing), shared by the iOS app (`packages/ios-app`, the `SliccFollower` app) and swift-server (`packages/swift-server`, Sliccstart, for egress-blocked Electron apps like Signal). It exists so those two consumers share **one** copy of the transport source on **one** `stasel/WebRTC` (151.x) — the framework and the source are not double-shipped. It is deliberately a **separate package** from `packages/swift-traysession` so that Foundation-only consumers (`swift-launcher`) never pull in WebRTC. Supports `.macOS(.v14)` and `.iOS("18.0")`.
+`SliccTrayFollower` is the headless tray-follower transport (signalling + WebRTC + tray-sync protocol mirror + chunk framing), shared by the iOS app (`packages/ios-app`, the `SliccFollower` app) and swift-server (`packages/swift-server`, Sliccstart, for egress-blocked Electron apps like Signal). It exists so those two consumers share **one** copy of the transport source on **one** `stasel/WebRTC` (152.x) — the framework and the source are not double-shipped. It is deliberately a **separate package** from `packages/swift-traysession` so that Foundation-only consumers (`swift-launcher`) never pull in WebRTC. Supports `.macOS(.v14)` and `.iOS("18.0")`.
 
 It is **CDP-agnostic**: a consumer layers its own servicing on top of `TrayFollowerConnector`'s `didConnect(channelSend:)` / `didReceiveData:` surface — the iOS app renders chat/sprinkles/CDP; swift-server relays the attached app's raw CDP ("CDP over CDP"). The follower is always the **answerer** (the leader creates the offer + the data channel).
 

--- a/packages/swift-trayfollower/Package.resolved
+++ b/packages/swift-trayfollower/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "0a105d13f7dfb0309ebf5a202a705cd899401264c8563e72883ff966f00005ef",
+  "originHash" : "54585c12f01c35851e39e1debaad192298039b02f2fde18cb7036b228eff57e0",
   "pins" : [
     {
       "identity" : "webrtc",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stasel/WebRTC.git",
       "state" : {
-        "revision" : "19aa8c1fc7120d50df987b7111f42d5024df3d54",
-        "version" : "151.0.0"
+        "revision" : "1d04692697cb642bfebf6ad2dd99fe52649c3d6d",
+        "version" : "152.0.0"
       }
     }
   ],

--- a/packages/swift-trayfollower/Package.swift
+++ b/packages/swift-trayfollower/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "SliccTrayFollower", targets: ["SliccTrayFollower"])
     ],
     dependencies: [
-        .package(url: "https://github.com/stasel/WebRTC.git", .upToNextMajor(from: "151.0.0"))
+        .package(url: "https://github.com/stasel/WebRTC.git", .upToNextMajor(from: "152.0.0"))
     ],
     targets: [
         .target(

--- a/packages/swift-traykit/Package.resolved
+++ b/packages/swift-traykit/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "bc9d59d471641d34c2cbea19d7b1e98ae9545cd5a6b8e7cc603868bbd25174c6",
+  "originHash" : "afa2f66a863f27d135f2add81a39b436c54d373fdf8bf6ae2eef8b031fe9e5a0",
   "pins" : [
     {
       "identity" : "webrtc",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stasel/WebRTC.git",
       "state" : {
-        "revision" : "19aa8c1fc7120d50df987b7111f42d5024df3d54",
-        "version" : "151.0.0"
+        "revision" : "1d04692697cb642bfebf6ad2dd99fe52649c3d6d",
+        "version" : "152.0.0"
       }
     }
   ],

--- a/packages/swift-traykit/Package.swift
+++ b/packages/swift-traykit/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "SliccTrayVFS", targets: ["SliccTrayVFS"])
     ],
     dependencies: [
-        .package(url: "https://github.com/stasel/WebRTC.git", .upToNextMajor(from: "151.0.0")),
+        .package(url: "https://github.com/stasel/WebRTC.git", .upToNextMajor(from: "152.0.0")),
         .package(path: "../swift-trayfollower"),
     ],
     targets: [


### PR DESCRIPTION
## Problem

Two upstream releases this repo pins were **deleted by their maintainers**, breaking every `ios-app` and `swift-*` CI job:

| dependency | pinned | upstream state now |
|---|---|---|
| `stasel/WebRTC` | `151.0.0` | release **deleted**; `WebRTC-M151.xcframework.zip` returns 404 |
| `Lakr233/libghostty-spm` | `1.4.0` | tag **deleted**; the whole `1.4.x` line is gone |

Observed failures:

```
error: failed downloading '.../releases/download/151.0.0/WebRTC-M151.xcframework.zip'
  which is required by binary target 'WebRTC': badResponseStatusCode(404)

xcodebuild: error: Could not resolve package dependencies:
  no versions of 'libghostty-spm' match the requirement 1.4.0
```

This is latent repo-wide but only *surfaces* on PRs whose path filters run the Swift jobs — which is why it showed up on #2685 (a one-line coverage-floor change) rather than everywhere at once.

## Why 152.0.0 and not 151.0.1

`stasel/WebRTC` recut `151.0.0` as `151.0.1`, then published `152.0.0`. **`151.0.1` is a dead tag** — its own `Package.swift` still points at the deleted `151.0.0` asset URL, so it 404s identically:

```swift
// stasel/WebRTC @ 151.0.1 -- Package.swift
url: "https://github.com/stasel/WebRTC/releases/download/151.0.0/WebRTC-M151.xcframework.zip"
```

`152.0.0` is the only live version, so the otherwise-preferable patch-level bump is not available.

## Changes

- WebRTC `151.0.0` -> `152.0.0` (`exactVersion` in the two `project.yml`s, `.upToNextMajor(from:)` in three `Package.swift`s, all five lockfiles)
- libghostty-spm `1.4.0` -> `1.5.1`
- MSDisplayLink `2.1.0` -> `2.2.0`, forced transitively (libghostty 1.5.1 requires `>= 2.2.0`)

No other pins move. Lockfiles were regenerated with a targeted resolve, not a bare `swift package update` (which over-updates EventSource and drops four pins).

## Verification

- `swift build -c release` passes: `swift-trayfollower`, `swift-traykit`, `swift-server`, `swift-launcher`
- `xcodebuild build` succeeds for `ios-app` on `generic/platform=iOS Simulator` **and** `generic/platform=iOS`
- `npm run lint:swift-pins` -- 3 dual-pinned packages in sync
- `check-swift-resolved-drift.mjs` -- clean on both ios-app lockfiles

The full ios-app XCUITest matrix is left to CI.

## Follow-up worth considering

This is the **second** tag-mutation outage from these two upstreams in three days (the first silently drifted `webrtc`'s revision and dequeued #2685 on Aug 31). `exactVersion` pins plus a committed lockfile did not protect against either, because a deleted tag fails resolution before the lockfile is consulted. Pinning these two by revision, or vendoring the xcframework, would end the recurrence.
