### PR TITLE
fix(webapp): close the unhandled-rejection hole in the storage-persist guard

### DIFF
--- a/packages/webapp/src/ui/boot/setup-storage-persistence.ts
+++ b/packages/webapp/src/ui/boot/setup-storage-persistence.ts
@@ -81,14 +81,19 @@ function resolveStorage(): StorageManagerLike | undefined {
 export async function requestStoragePersistence(
   storage: StorageManagerLike | undefined = resolveStorage()
 ): Promise<StoragePersistenceOutcome> {
-  if (typeof storage?.persist !== 'function') return 'unsupported';
   try {
+    // Inside the guard, not before it: a hardened or proxied
+    // `StorageManager` can throw on plain property access, and a capability
+    // check that rejects would defeat the whole point of this `try`.
+    if (typeof storage?.persist !== 'function') return 'unsupported';
     if (typeof storage.persisted === 'function' && (await storage.persisted())) {
       return 'already-persisted';
     }
     return (await storage.persist()) ? 'granted' : 'denied';
   } catch (err) {
-    log.warn('storage.persist() failed', err);
+    // Deliberately names the check rather than `persist()` — `persisted()`
+    // and the capability probe above reach this same handler.
+    log.warn('storage persistence check failed', err);
     return 'failed';
   }
 }
@@ -105,28 +110,36 @@ let requested = false;
 export function setupStoragePersistence(): void {
   if (requested) return;
   requested = true;
-  void requestStoragePersistence().then((outcome) => {
-    switch (outcome) {
-      case 'granted':
-        log.info('OPFS marked persistent — SLICC data is now exempt from disk-pressure eviction');
-        break;
-      case 'already-persisted':
-        log.debug('OPFS already persistent');
-        break;
-      case 'denied':
-        // Worth a warning: the VFS is a live eviction candidate until this
-        // flips, and `df` reports the same flag if anyone goes looking.
-        log.warn(
-          'Browser declined persistent storage — SLICC data can be evicted if the disk fills up'
-        );
-        break;
-      case 'unsupported':
-        log.debug('navigator.storage.persist() unavailable in this runtime');
-        break;
-      case 'failed':
-        break;
-    }
-  });
+  void requestStoragePersistence()
+    .then((outcome) => {
+      switch (outcome) {
+        case 'granted':
+          log.info('OPFS marked persistent — SLICC data is now exempt from disk-pressure eviction');
+          break;
+        case 'already-persisted':
+          log.debug('OPFS already persistent');
+          break;
+        case 'denied':
+          // Worth a warning: the VFS is a live eviction candidate until this
+          // flips, and `df` reports the same flag if anyone goes looking.
+          log.warn(
+            'Browser declined persistent storage — SLICC data can be evicted if the disk fills up'
+          );
+          break;
+        case 'unsupported':
+          log.debug('navigator.storage.persist() unavailable in this runtime');
+          break;
+        case 'failed':
+          // Already logged with the underlying error inside
+          // `requestStoragePersistence` — saying it twice adds nothing.
+          break;
+      }
+    })
+    // Belt and braces. `requestStoragePersistence` already fails closed, so
+    // the only way here is the logging above throwing — and an unhandled
+    // rejection on the boot path lands in `main()`'s catch and puts the user
+    // on the recovery screen over a storage hint.
+    .catch(() => {});
 }
 
 /** Test-only: clear the once-per-page latch. */

--- a/packages/webapp/src/ui/main.ts
+++ b/packages/webapp/src/ui/main.ts
@@ -96,6 +96,12 @@ async function main(): Promise<void> {
   // full disk Chromium evicts whole buckets — the entire tree, silently —
   // unless the bucket is persistent. Fire-and-forget, never prompts, and the
   // answer improves with site engagement, so it is re-requested every boot.
+  //
+  // Placed ahead of the follower / connect / extension dispatches on purpose,
+  // so it runs on every float rather than only the kernel-owning ones. The
+  // grant is per storage key, they are all SLICC-owned origins, and the ones
+  // with nothing to protect (cherry's partitioned third-party iframe) simply
+  // resolve `false`. Do not gate this behind `runtimeMode`.
   setupStoragePersistence();
 
   // Initialize RUM telemetry for the page/panel realm — `trackShellCommand`,

--- a/packages/webapp/tests/ui/boot/setup-storage-persistence.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-storage-persistence.test.ts
@@ -109,6 +109,26 @@ describe('requestStoragePersistence', () => {
     expect(persist).not.toHaveBeenCalled();
   });
 
+  /**
+   * A hardened or proxied `StorageManager` can throw on plain property
+   * access. The capability check must be inside the guard, or this function
+   * rejects — and `setupStoragePersistence` fires it without a `.catch`, so
+   * the rejection would go unhandled and contradict the "never throws" boot
+   * contract this module documents.
+   */
+  it('does not reject when property access on the storage manager throws', async () => {
+    const hostile = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('hardened');
+        },
+      }
+    ) as StorageStub;
+
+    await expect(requestStoragePersistence(hostile)).resolves.toBe('failed');
+  });
+
   it('reads navigator.storage when no argument is passed', async () => {
     const persist = vi.fn(async () => true);
     await withNavigatorStorage({ persisted: async () => false, persist }, async () => {

--- a/packages/webapp/tests/ui/main-storage-persistence.test.ts
+++ b/packages/webapp/tests/ui/main-storage-persistence.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression guard: `ui/main.ts` MUST call `setupStoragePersistence()`.
+ *
+ * The module's own unit tests exercise the helper in isolation, so deleting
+ * the call site would leave every one of them green while silently putting
+ * SLICC's entire OPFS tree back on Chromium's eviction list — the failure
+ * this whole feature exists to prevent, and one that shows up as total,
+ * silent data loss weeks later on someone's full disk.
+ *
+ * Static-text guard, not a behavior test — `main.ts` has a long async boot
+ * sequence (SW registration, provider registration, OAuth bootstrap) that is
+ * expensive to mock. Behavior lives in
+ * `webapp/tests/ui/boot/setup-storage-persistence.test.ts`. Mirrors
+ * `webapp/tests/ui/main-telemetry.test.ts`.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const mainPath = join(here, '..', '..', 'src', 'ui', 'main.ts');
+const source = readFileSync(mainPath, 'utf8');
+
+/**
+ * Offset of the live call. Anchored to the start of a line so a
+ * commented-out `// setupStoragePersistence();` cannot satisfy the ordering
+ * assertions below — that is exactly the regression they exist to catch.
+ */
+const callIdx = source.search(/^[ \t]*setupStoragePersistence\(\);/m);
+
+describe('ui/main.ts storage-persistence wiring', () => {
+  it('imports setupStoragePersistence from the boot helper', () => {
+    expect(source).toMatch(
+      /import\s+\{\s*setupStoragePersistence\s*\}\s+from\s+['"]\.\/boot\/setup-storage-persistence\.js['"]/
+    );
+  });
+
+  it('calls setupStoragePersistence()', () => {
+    expect(callIdx).toBeGreaterThan(-1);
+  });
+
+  /** The fixture surface returns before boot; a call above it never runs. */
+  it('calls setupStoragePersistence after the fixture early-return', () => {
+    const fixtureIdx = source.indexOf('isFixtureRequested(window.location.href)');
+    expect(fixtureIdx).toBeGreaterThan(-1);
+    expect(callIdx).toBeGreaterThan(-1);
+    expect(callIdx).toBeGreaterThan(fixtureIdx);
+  });
+
+  /**
+   * Ahead of the heavy boot so the request is in flight during it — the
+   * grant matters most on the run where the disk is already tight.
+   */
+  it('calls setupStoragePersistence before the heavy boot (registerProviders)', () => {
+    const providersIdx = source.indexOf('await registerProviders');
+    expect(callIdx).toBeGreaterThan(-1);
+    expect(providersIdx).toBeGreaterThan(-1);
+    expect(callIdx).toBeLessThan(providersIdx);
+  });
+
+  /**
+   * Every float shares the storage key, so the call must sit above the
+   * follower / connect / extension dispatches rather than inside one branch.
+   */
+  it('calls setupStoragePersistence before the per-float dispatches', () => {
+    // Anchored on the invocations, not the bare names — every one of these is
+    // also mentioned in main.ts's leading docblock, above the call site.
+    for (const dispatch of [
+      'mountWcUiFollower(app',
+      'mountConnectSurface(app',
+      'mountWcUiExtension(app',
+    ]) {
+      const idx = source.indexOf(dispatch);
+      expect(idx, `${dispatch} not found in main.ts`).toBeGreaterThan(-1);
+      expect(callIdx, `setupStoragePersistence must run before ${dispatch}`).toBeLessThan(idx);
+    }
+  });
+
+  /** `void`-returning by design — awaiting it would put boot behind it. */
+  it('does not await setupStoragePersistence', () => {
+    expect(source).not.toMatch(/await\s+setupStoragePersistence\(/);
+  });
+});

--- a/packages/webapp/tests/ui/main-storage-persistence.test.ts
+++ b/packages/webapp/tests/ui/main-storage-persistence.test.ts
@@ -28,7 +28,7 @@ const source = readFileSync(mainPath, 'utf8');
  * commented-out `// setupStoragePersistence();` cannot satisfy the ordering
  * assertions below — that is exactly the regression they exist to catch.
  */
-const callIdx = source.search(/^[ \t]*setupStoragePersistence\(\);/m);
+const callIdx = source.search(/^  setupStoragePersistence\(\);$/m);
 
 describe('ui/main.ts storage-persistence wiring', () => {
   it('imports setupStoragePersistence from the boot helper', () => {


### PR DESCRIPTION
Follow-up to #2696, addressing its review.

## 1. Unhandled rejection on the boot path (real bug)

`requestStoragePersistence` ran its capability check **outside** the `try`:

```ts
if (typeof storage?.persist !== 'function') return 'unsupported';   // ← outside
try { ... } catch { return 'failed'; }
```

A hardened or proxied `StorageManager` throws on plain property access. Inside an `async` function that becomes a rejected promise — and `setupStoragePersistence` fires it with `.then()` and no `.catch`. Unhandled rejection, on the boot path, contradicting the "never throws" contract the module's own docblock states. It would surface in `main()`'s catch and drop the user on the boot recovery screen.

Reproduced standalone before touching anything:

```
$ node repro.mjs
UNHANDLED REJECTION: Error: hardened
done, exitCode = 1
```

The check moves inside the guard, and the new test (`does not reject when property access on the storage manager throws`) fails on the old code and passes on the new.

Also added a `.catch` on the fire-and-forget chain — belt and braces, so a throw from the *logging* cannot become an unhandled rejection either.

## 2. Misleading log message

The catch said `storage.persist() failed` even when `persisted()` was the call that rejected and `persist()` was never reached. Both — and now the capability probe — land in the same handler, so it names the check rather than one call.

## 3. Nothing guarded the call site

Every unit test for the helper stays green if `setupStoragePersistence()` is deleted from `main.ts` — which would silently put the whole OPFS tree back on Chromium's eviction list, showing up as total, silent data loss weeks later on someone's full disk.

Adds `tests/ui/main-storage-persistence.test.ts`, mirroring the existing `main-telemetry.test.ts` static-source guard: import present, call present, after the fixture early-return, before `registerProviders`, before the per-float dispatches, never awaited.

Two things that came out of building it:

- The first version asserted ordering against `source.indexOf('mountWcUiFollower')`, which matched main.ts's **docblock** rather than the call site. Caught by the test failing; now anchored on `mountWcUiFollower(app`.
- Mutation-tested the guard rather than trusting it green: commenting out the call turns it red. That also exposed that `indexOf('setupStoragePersistence();')` still matches a *commented-out* call, so the ordering assertions now share one line-anchored `callIdx` regex.

## 4. Documented the placement

The call sits above the follower / connect / extension dispatches so it runs on every float. That is intentional — the grant is per storage key, they are all SLICC-owned origins, and cherry's partitioned third-party iframe just resolves `false`. Recorded in a comment so nobody "fixes" it into a `runtimeMode` gate.

## Verification

`npm run verify` (7/7) · `lint:ci` · `typecheck` · full vitest **18,192 passed** · webapp build · first-load **+0.0 kB**.

Note: a full-suite run initially failed `py-realm-shared.test.ts` (`expected '314.0.6' to be '314.0.5'`) — stale `node_modules` in my worktree against the pyodide bump #2698 that had just landed on main. `npm install` resolves it; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
