### PR TITLE
fix(sudo): seed /etc/APPROVALS.md so upgrades stop prompting for it

### DIFF
--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -33,8 +33,9 @@ other developer docs link here instead of restating the model.
 - **Panel terminal is the human approver.** Commands typed in the panel terminal are
   not sudo-gated and the keystroke itself is the gesture for browser pickers; this
   is the only context where the human is _already_ approving.
-- **Self-protection is hardcoded.** Writes to `/etc/sudoers` and `/etc/sudoers.d/**`
-  always require approval; no `NOPASSWD` rule can override this.
+- **Self-protection is hardcoded.** Writes to `/etc/sudoers`, `/etc/sudoers.d/**`
+  and `/etc/APPROVALS.md` always require approval; no `NOPASSWD` rule can override
+  this.
 - **Credentials never reach the agent.** S3 / DA mounts have no approval card because
   the trust boundary lives at the credential resolver (node-server / SW), not in chat.
 
@@ -108,10 +109,23 @@ their current policy.
 
 ### Self-protection (always on)
 
-Writes to `/etc/sudoers` and anything under `/etc/sudoers.d/` **always** require
-approval — a `NOPASSWD` rule cannot override this. It is hardcoded in `matchPath`
-(`packages/webapp/src/base/sudoers.ts`), independent of the loaded policy.
-Reads of those files are allowed (visudo-style).
+Writes to `/etc/sudoers`, anything under `/etc/sudoers.d/`, and
+`/etc/APPROVALS.md` (the approver agent's instructions — it decides what a
+biscotto GUEST may do, so a cone acting on that guest's message must not be able
+to rewrite it) **always** require approval — a `NOPASSWD` rule cannot override
+this. It is hardcoded in `matchPath` (`packages/webapp/src/base/sudoers.ts`),
+independent of the loaded policy. Reads of those files are allowed
+(visudo-style).
+
+Both bundled defaults are seeded by `SudoManager.ensureDefaults()` on every boot
+when the file is absent, through the manager's **ungated** handle. Shipping a
+default is not a policy edit, and an absent file holds no owner decision to
+protect. Seeding is also what keeps the upgrade merge quiet: `upgrade apply`
+runs on the FS-gated handle, so a self-protected path it had to _create_ would
+prompt the owner to approve content identical to the default already in force —
+an approval with no diff to show (#2686). With the file seeded, the merge
+classifies it `unchanged` (or `kept-local` after an owner edit) and writes
+nothing.
 
 ### Built-in scoop grants — `/tmp` (always on)
 

--- a/packages/vfs-root/CLAUDE.md
+++ b/packages/vfs-root/CLAUDE.md
@@ -62,6 +62,10 @@ This file covers the default virtual filesystem payload in `packages/vfs-root/`.
 
 - `etc/APPROVALS.md` is the single source for the runner's build-time fallback and
   the seeded `/etc/APPROVALS.md`, exactly like `shared/MEMORY.md` is for the curator.
+  `SudoManager.ensureDefaults()` does the seeding, when absent, on the ungated
+  handle — the same place `/etc/sudoers` is seeded, and for the same reason: the
+  file is self-protected, so anything else that had to create it (the `upgrade
+apply` merge) would prompt the owner to approve the default already in force (#2686).
 - It lives in `/etc/` because it is POLICY, next to `sudoers` — not in `/shared/`,
   which is agent-visible content. Writes to it are self-protected in
   `base/sudoers.ts` (`isSelfProtectedWrite`) for the same reason writes to

--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -88,7 +88,10 @@ Invariants a reviewer must catch; mechanism in `docs/webapp-details.md` + the li
   gate = origin allowlist + `MessageEvent.source` identity + per-mount `channelId` nonce.
   `packages/cherry/src/protocol.ts` mirrors it — keep in sync.
 - **Sudo self-protection** (`docs/approvals.md`): writes to `/etc/sudoers` +
-  `/etc/sudoers.d/*` always require approval (hardcoded in `matchPath`). Page realm can
+  `/etc/sudoers.d/*` + `/etc/APPROVALS.md` always require approval (hardcoded in
+  `matchPath`). Their bundled defaults are seeded ungated by
+  `SudoManager.ensureDefaults()` when absent — a self-protected file the upgrade
+  merge has to CREATE would otherwise prompt for a no-op (#2686). Page realm can
   reassign `globalThis.confirm`, so `sudo/panel-responder.ts` captures natives at init and
   approval chrome mounts via `ui/wc/trusted-layer.ts`, never `document.body`. `reason` is a
   FIELD on a `deny`, never a fourth `decision` (a new variant fails open).

--- a/packages/webapp/src/sudo/sudo-manager.ts
+++ b/packages/webapp/src/sudo/sudo-manager.ts
@@ -40,7 +40,6 @@ import type { FsWatcher } from '../fs/fs-watcher.js';
 import type { VirtualFS } from '../fs/index.js';
 import { GRANTED_FILE } from '../fs/sudo-fs.js';
 import { FsError } from '../fs/types.js';
-import { DEFAULT_APPROVALS_MD } from '../scoops/approver-agent.js';
 import type { ScoopConfig } from '../scoops/types.js';
 import type { ShellSudoConfig } from '../shell/almost-bash-shell-headless.js';
 import { createSudoBroker } from './index.js';
@@ -529,10 +528,7 @@ export class SudoManager {
     } catch {
       /* already exists */
     }
-    // Both self-protected policy files are seeded here, when absent, through
-    // the manager's UNGATED handle: shipping a default is not a policy edit,
-    // and a file that does not exist yet carries no owner decision to protect.
-    //
+    await this.seedWhenAbsent(SUDOERS_FILE, () => sudoersDefault);
     // `/etc/APPROVALS.md` MUST be seeded here rather than left to `upgrade
     // apply`'s three-way merge of `packages/vfs-root/etc/`. That merge runs on
     // the FS-gated handle, so on a profile predating the file it trips
@@ -541,20 +537,45 @@ export class SudoManager {
     // approval prompt for a no-op, with no diff to show (#2686). Seeding first
     // makes the merge classify the path `unchanged` (or `kept-local` once the
     // owner edits it), which writes nothing and prompts for nothing.
-    for (const [path, content] of [
-      [SUDOERS_FILE, sudoersDefault],
-      [APPROVALS_FILE, DEFAULT_APPROVALS_MD],
-    ] as const) {
-      try {
-        if (await this.fs.exists(path)) continue;
-        await this.fs.writeFile(path, content);
-        log.info('Seeded bundled policy default', { path });
-      } catch (err) {
-        log.warn('Failed to seed bundled policy default', {
-          path,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
+    //
+    // The import is deliberately DYNAMIC, and `seedWhenAbsent` only calls it on
+    // the boot that actually seeds. A static one would pull `approver-agent`
+    // and its bundled instructions into `sudo-manager`'s graph, and
+    // `sudo-manager` is boot-critical — that hoists ~10 kB into the kernel
+    // worker's eager first-load closure, over the bundle-size gate's per-change
+    // allowance, to carry a string needed once per profile.
+    await this.seedWhenAbsent(
+      APPROVALS_FILE,
+      async () => (await import('../scoops/approver-agent.js')).DEFAULT_APPROVALS_MD
+    );
+  }
+
+  /**
+   * Write a bundled policy default to `path` when it is absent, through the
+   * manager's UNGATED handle.
+   *
+   * Ungated is safe for both self-protected policy files: shipping a default is
+   * not a policy edit, and a file that does not exist yet carries no owner
+   * decision to protect. Seeding never overwrites, so an owner's edits survive
+   * every later boot.
+   *
+   * `load` is invoked only when the write is actually going to happen, so a
+   * lazily-imported default costs nothing on the overwhelmingly common boot
+   * where the file already exists. A seed failure is logged and swallowed:
+   * neither file is required for the policy to load (both fall back — an absent
+   * sudoers parses to the empty policy, an absent APPROVALS.md to the bundled
+   * instructions), and one failing must not skip the other.
+   */
+  private async seedWhenAbsent(path: string, load: () => string | Promise<string>): Promise<void> {
+    try {
+      if (await this.fs.exists(path)) return;
+      await this.fs.writeFile(path, await load());
+      log.info('Seeded bundled policy default', { path });
+    } catch (err) {
+      log.warn('Failed to seed bundled policy default', {
+        path,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/packages/webapp/src/sudo/sudo-manager.ts
+++ b/packages/webapp/src/sudo/sudo-manager.ts
@@ -4,8 +4,10 @@
  * One manager is created per orchestrator (so per float) once the shared VFS
  * and its `FsWatcher` exist. It:
  *
- *   1. Seeds a fully commented-out default `/etc/sudoers` template on a fresh
- *      VFS (self-protection still applies even with no rules).
+ *   1. Seeds the bundled defaults for the self-protected policy files when they
+ *      are absent — a fully commented-out `/etc/sudoers` template
+ *      (self-protection still applies even with no rules) and the approver
+ *      agent's `/etc/APPROVALS.md` instructions.
  *   2. Loads + merges `/etc/sudoers` and every `/etc/sudoers.d/*` drop-in into
  *      a single live `SudoersPolicy`.
  *   3. Re-reads that policy whenever those files change (after an approved
@@ -20,6 +22,7 @@
 import sudoersDefault from '../../../vfs-root/etc/sudoers?raw';
 import { createLogger } from '../base/logger.js';
 import {
+  APPROVALS_FILE,
   builtinScoopGrants,
   type Directive,
   directiveForKind,
@@ -37,6 +40,7 @@ import type { FsWatcher } from '../fs/fs-watcher.js';
 import type { VirtualFS } from '../fs/index.js';
 import { GRANTED_FILE } from '../fs/sudo-fs.js';
 import { FsError } from '../fs/types.js';
+import { DEFAULT_APPROVALS_MD } from '../scoops/approver-agent.js';
 import type { ScoopConfig } from '../scoops/types.js';
 import type { ShellSudoConfig } from '../shell/almost-bash-shell-headless.js';
 import { createSudoBroker } from './index.js';
@@ -525,15 +529,32 @@ export class SudoManager {
     } catch {
       /* already exists */
     }
-    try {
-      if (!(await this.fs.exists(SUDOERS_FILE))) {
-        await this.fs.writeFile(SUDOERS_FILE, sudoersDefault);
-        log.info('Seeded default /etc/sudoers template');
+    // Both self-protected policy files are seeded here, when absent, through
+    // the manager's UNGATED handle: shipping a default is not a policy edit,
+    // and a file that does not exist yet carries no owner decision to protect.
+    //
+    // `/etc/APPROVALS.md` MUST be seeded here rather than left to `upgrade
+    // apply`'s three-way merge of `packages/vfs-root/etc/`. That merge runs on
+    // the FS-gated handle, so on a profile predating the file it trips
+    // self-protection and asks the owner to approve a write whose content is
+    // the very fallback the approver agent was already running under — an
+    // approval prompt for a no-op, with no diff to show (#2686). Seeding first
+    // makes the merge classify the path `unchanged` (or `kept-local` once the
+    // owner edits it), which writes nothing and prompts for nothing.
+    for (const [path, content] of [
+      [SUDOERS_FILE, sudoersDefault],
+      [APPROVALS_FILE, DEFAULT_APPROVALS_MD],
+    ] as const) {
+      try {
+        if (await this.fs.exists(path)) continue;
+        await this.fs.writeFile(path, content);
+        log.info('Seeded bundled policy default', { path });
+      } catch (err) {
+        log.warn('Failed to seed bundled policy default', {
+          path,
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
-    } catch (err) {
-      log.warn('Failed to seed default /etc/sudoers', {
-        error: err instanceof Error ? err.message : String(err),
-      });
     }
   }
 

--- a/packages/webapp/tests/sudo/sudo-manager.test.ts
+++ b/packages/webapp/tests/sudo/sudo-manager.test.ts
@@ -1,7 +1,8 @@
 /**
  * Tests for `SudoManager` — the live sudoers policy store.
  *
- * Covers default-template seeding on a fresh VFS, merge of `/etc/sudoers` +
+ * Covers bundled policy-default seeding on a fresh VFS (`/etc/sudoers` and
+ * `/etc/APPROVALS.md`), merge of `/etc/sudoers` +
  * `/etc/sudoers.d/*`, live reload via the `FsWatcher` when those files change,
  * the command-grant sink (used by the shell on "Always"), and watcher teardown.
  */
@@ -9,6 +10,7 @@
 import 'fake-indexeddb/auto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  APPROVALS_FILE,
   matchCommand,
   matchPath,
   parseSudoers,
@@ -18,6 +20,7 @@ import {
 import { FsWatcher } from '../../src/fs/fs-watcher.js';
 import { VirtualFS } from '../../src/fs/index.js';
 import { FsError } from '../../src/fs/types.js';
+import { DEFAULT_APPROVALS_MD } from '../../src/scoops/approver-agent.js';
 import { generateScoopSudoers, SudoManager } from '../../src/sudo/sudo-manager.js';
 import type { SudoBroker } from '../../src/sudo/types.js';
 
@@ -51,6 +54,35 @@ describe('SudoManager', () => {
     expect(seeded).toContain('SLICC agent approval policy');
     // Every rule in the template is commented out → no active command gating.
     expect(matchCommand(mgr.getPolicy(), 'git push origin main')).toBe('no-match');
+    mgr.dispose();
+  });
+
+  // #2686: `/etc/APPROVALS.md` is self-protected, so the only other thing that
+  // could create it — `upgrade apply`'s three-way merge, which runs on the
+  // FS-gated handle — would raise a sudo prompt asking the owner to approve
+  // content identical to the fallback the approver was already using. Seeding
+  // it here, ungated and only when absent, is what keeps that prompt away.
+  it('seeds the bundled /etc/APPROVALS.md when absent', async () => {
+    const mgr = new SudoManager({ fs: vfs, watcher, broker });
+    await mgr.init();
+
+    const seeded = (await vfs.readFile(APPROVALS_FILE, { encoding: 'utf-8' })) as string;
+    expect(seeded).toBe(DEFAULT_APPROVALS_MD);
+    // Seeding does not weaken self-protection: editing it still needs approval.
+    expect(matchPath(mgr.getPolicy(), 'write', APPROVALS_FILE)).toBe('require-approval');
+    mgr.dispose();
+  });
+
+  it('leaves an existing /etc/APPROVALS.md untouched', async () => {
+    await vfs.mkdir('/etc', { recursive: true });
+    await vfs.writeFile(APPROVALS_FILE, '# owner-tuned approver policy\n');
+
+    const mgr = new SudoManager({ fs: vfs, watcher, broker });
+    await mgr.init();
+
+    expect(await vfs.readFile(APPROVALS_FILE, { encoding: 'utf-8' })).toBe(
+      '# owner-tuned approver policy\n'
+    );
     mgr.dispose();
   });
 


### PR DESCRIPTION
Fixes #2686

## Summary

`/etc/APPROVALS.md` was never seeded, so the only thing that ever created it on an existing profile was `upgrade apply`'s three-way merge — which runs on the FS-gated handle and trips self-protection. The user saw a sudo prompt asking them to approve a privileged write with no explanation and no diff. Now `SudoManager.ensureDefaults()` seeds the bundled default alongside `/etc/sudoers`, ungated and only when absent, and the upgrade merge has nothing left to write.

## Why

Self-protection on `/etc/APPROVALS.md` is correct and stays: the file decides what a biscotto **guest** may do, so a cone acting on that guest's (attacker-authored) message must not be able to rewrite the rules gating that same guest. This PR does not touch that invariant.

The bug is that the file had no seeder. `/etc/sudoers` gets one in `SudoManager.ensureDefaults()`, on the manager's ungated handle, on every boot; `/etc/models`, `/etc/llmstxtignore` and `/etc/slicc/keys.json` are each seeded by their own consumer. `createApproverRunner` instead just falls back to the bundled `DEFAULT_APPROVALS_MD` in memory and never writes anything — even though `packages/vfs-root/CLAUDE.md` already documented "the seeded `/etc/APPROVALS.md`" as a thing that exists.

So on a profile predating 6.108.0 the file's first appearance came from `upgrade apply`, whose merge scope includes `packages/vfs-root/etc/`. That write hits `isSelfProtectedWrite` and prompts the owner to approve content **byte-identical to the default the approver was already running under** — an approval for a semantic no-op, which is also why there was no meaningful diff to show them.

**Repro** (from the issue):

1. Start SLICC on a version < 6.108.0, shut down.
2. Restart on 6.108.0+ and take the upgrade card.

- Expected: no prompt — the effective approver policy is unchanged.
- Actual (before): a sudo prompt for a privileged write to `/etc/APPROVALS.md`.

## Approach / Implementation notes

- **Where**: `SudoManager.ensureDefaults()`, the existing seed point for the *other* self-protected policy file. Both are now seeded from one loop over `[SUDOERS_FILE, sudoersDefault]` / `[APPROVALS_FILE, DEFAULT_APPROVALS_MD]`, each guarded by its own `exists` check and its own try/catch (a failed seed of one must not skip the other).
- **Why ungated is safe here**: `this.fs` is the manager's pre-gate handle. Shipping a default is not a policy edit, and a file that does not exist yet carries no owner decision to protect — which is exactly the argument that already justifies seeding `/etc/sudoers` this way.
- **Why this kills the prompt**: with the file present, `buildPlan` takes the `!base && ours` branch and classifies it `unchanged` (identical) or `kept-local` (owner edited it). Neither carries `content`, so `commitPlans` writes nothing and the gate is never reached.
- **Alternative rejected**: exempting the write in the sudo gate when the content equals the bundled default. That needs content + existence inside `matchPath`, which only takes a path, and it puts a content comparison in the authorization matcher. Seeding needs no exemption at all.
- **Constant reuse, loaded lazily**: reuses the already-exported `DEFAULT_APPROVALS_MD` from `scoops/approver-agent.ts` rather than adding a second `?raw` import of the same file, so the seeded content and the runtime fallback cannot drift — but via a **dynamic** import, invoked by `seedWhenAbsent` only on the boot that actually seeds. A static import failed the bundle-size gate: `sudo-manager` is boot-critical, so it hoisted `approver-agent` and its bundled instructions into the kernel worker's eager first-load closure (+10.3 kB, over the 5 kB per-change allowance) to carry a string needed once per profile. Lazy brings that to +0.2 kB vs the merge-base.

## Cross-cutting impact

- **Floats**: none are float-specific — `SudoManager.init()` runs the same everywhere. Verified via unit tests; not smoke-tested per float.
- **Security**: no change to the authorization surface. `isSelfProtectedWrite` is untouched, so every *edit* to `/etc/APPROVALS.md` still requires approval and no `NOPASSWD` rule can override it. A test asserts this explicitly after seeding.
- **Persisted state**: creates one file in the VFS that the runtime already treats as present-or-default. An owner-edited `/etc/APPROVALS.md` is left alone (covered by a test).
- **Other callers**: `ensureDefaults` is private and called only from `init()`. Its `/etc/sudoers` behavior is byte-for-byte the same; only the log message changed (`Seeded default /etc/sudoers template` → `Seeded bundled policy default { path }`), and no test or code asserted on it.

## Test plan

- [x] `npx prettier --write <changed-files>` + `npm run verify` — all 7 checks pass
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 18187 passing, 0 failures
- [x] `npm run build -w @slicc/webapp`
- [x] **New behavior covered by unit tests** — `npx vitest run packages/webapp/tests/sudo/sudo-manager.test.ts` (48 passing), two new cases: seeds the bundled default when absent *and* leaves self-protection in force, and leaves an owner-edited file untouched.
- [ ] Manual smoke of the real <6.108.0 → 6.108.0+ upgrade — not run; the prompt path is covered by the classification argument above rather than by a live upgrade.
- [x] `npm run build -w @slicc/chrome-extension` + `npm run bundle-size` — first-load OK: page +0.0 kB, worker +0.2 kB vs merge-base; extension size-limit budgets unchanged.

**Pre-existing failures**: none in the final run. An earlier full-suite run hit two timeouts in `packages/webapp/tests/kernel/realm/slicc-fs-module.test.ts` (pyodide `write_bytes` / `write_text` exceeding 5000 ms on a cold pyodide load); they pass on a warm cache and are unrelated to this change.

## Documentation

- [x] Relevant `CLAUDE.md` — `packages/webapp/CLAUDE.md` and `packages/vfs-root/CLAUDE.md` (which already claimed the file was seeded; now it is, and it names the seeder).
- [x] `docs/` — `docs/approvals.md`: the "Self-protection (always on)" section listed only `/etc/sudoers` + `/etc/sudoers.d/`, omitting `/etc/APPROVALS.md`, which `matchPath` has protected all along. Added it, plus the seeding rationale.

## Risk & rollback

Blast radius is one file write at `SudoManager.init()`. No flag, no migration; revert the commit to undo. A profile that already ran this version keeps a `/etc/APPROVALS.md` identical to the bundled default, which is exactly what the approver would have used anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
