### PR TITLE
test(webapp): cover the storage-persist terminal catch, and fix two wrong comments

### DIFF
--- a/packages/webapp/src/ui/boot/setup-storage-persistence.ts
+++ b/packages/webapp/src/ui/boot/setup-storage-persistence.ts
@@ -135,10 +135,14 @@ export function setupStoragePersistence(): void {
           break;
       }
     })
-    // Belt and braces. `requestStoragePersistence` already fails closed, so
-    // the only way here is the logging above throwing — and an unhandled
-    // rejection on the boot path lands in `main()`'s catch and puts the user
-    // on the recovery screen over a storage hint.
+    // Belt and braces: `requestStoragePersistence` already fails closed, so
+    // the only way to reach here is the logging above throwing.
+    //
+    // This promise is detached — `main.ts` calls `setupStoragePersistence()`
+    // without awaiting it — so a rejection does NOT reach `main()`'s catch.
+    // It surfaces as a global `unhandledrejection` instead: console noise on
+    // every boot, and an error beacon that would misattribute a storage hint
+    // as a page fault. Cheap to prevent, invisible to diagnose.
     .catch(() => {});
 }
 

--- a/packages/webapp/tests/ui/boot/setup-storage-persistence.test.ts
+++ b/packages/webapp/tests/ui/boot/setup-storage-persistence.test.ts
@@ -111,10 +111,10 @@ describe('requestStoragePersistence', () => {
 
   /**
    * A hardened or proxied `StorageManager` can throw on plain property
-   * access. The capability check must be inside the guard, or this function
-   * rejects — and `setupStoragePersistence` fires it without a `.catch`, so
-   * the rejection would go unhandled and contradict the "never throws" boot
-   * contract this module documents.
+   * access. The capability check has to sit inside the guard, or this
+   * function rejects instead of resolving `'failed'` — breaking the
+   * never-reject contract its own docblock states, which every caller
+   * (including the fire-and-forget boot path) relies on.
    */
   it('does not reject when property access on the storage manager throws', async () => {
     const hostile = new Proxy(
@@ -176,6 +176,51 @@ describe('setupStoragePersistence', () => {
     });
 
     expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * Covers the terminal `.catch()` on the fire-and-forget chain, which
+   * nothing else reaches: every other path resolves an outcome *inside*
+   * `requestStoragePersistence`, so deleting that catch left the suite green.
+   *
+   * The failure channel is a global `unhandledrejection`, not `main()`'s
+   * catch — the promise is detached, so it cannot propagate to the caller.
+   * This asserts against that channel directly.
+   */
+  it('does not leak an unhandled rejection when the outcome logger throws', async () => {
+    vi.resetModules();
+    vi.doMock('../../../src/base/logger.js', () => ({
+      createLogger: () => ({
+        debug: () => {},
+        info: () => {
+          throw new Error('logger blew up');
+        },
+        warn: () => {},
+        error: () => {},
+      }),
+    }));
+
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => rejections.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const mod = await import('../../../src/ui/boot/setup-storage-persistence.js');
+      await withNavigatorStorage(
+        { persisted: async () => false, persist: async () => true },
+        async () => {
+          mod.setupStoragePersistence();
+          // `unhandledRejection` fires a tick after the microtask queue
+          // drains, so a microtask flush is not enough to observe it.
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+      );
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+      vi.doUnmock('../../../src/base/logger.js');
+      vi.resetModules();
+    }
+
+    expect(rejections).toEqual([]);
   });
 
   /**


### PR DESCRIPTION
Follow-up to #2702, from its review. No behavior change — one test and two comment corrections.

## 1. The terminal `.catch()` had no coverage

Copilot's point was exact: every other path resolves an outcome **inside** `requestStoragePersistence`, so the `.catch()` on the fire-and-forget chain was never reached by a test. Deleting it left the whole suite green.

Adds a test that mocks the logger into throwing and asserts against the real failure channel — a global `unhandledrejection`. Mutation-verified rather than trusted:

```
# with `.catch(() => {})` removed
×  does not leak an unhandled rejection when the outcome logger throws
   Tests  1 failed | 11 passed (12)

# restored
   Tests  12 passed (12)
```

## 2. My `.catch()` comment was wrong about the failure channel

It claimed an unhandled rejection "lands in `main()`'s catch and puts the user on the recovery screen." Copilot said that cannot happen because the promise is detached. Checked rather than assumed:

```
main() resolved to : main finished normally
main().catch() saw : null
global handler saw : Error: logger blew up
```

`main.ts` calls `setupStoragePersistence()` without awaiting it, so a rejection in that chain never reaches the caller. `main()` resolves normally and it goes to the global handler.

The catch is still worth having — console noise on every boot, and an error beacon that would misattribute a storage hint as a page fault — just not for the reason the comment gave. Corrected, and the correction is now the interesting part of the comment.

## 3. Stale test docblock

The hostile-Proxy test still said `setupStoragePersistence` "fires it without a `.catch`", which stopped being true in #2702. Now describes the helper's own never-reject contract instead.

## On the third finding

Copilot's indentation finding was auto-fixed and merged as f7d03aa (`^[ \t]*` → `^  …$`). I mutation-tested it rather than assuming it worked — moving the call into the follower branch now fails three assertions, where before it passed all six. It is genuinely fixed, so nothing to do here.

## Verification

`npm run verify` (7/7) · `lint:ci` · `typecheck` · full vitest **18,264 passed** · `test:coverage:webapp` · webapp build · first-load **+0.0 kB**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
