### PR TITLE
perf(webapp): resolve git refs before expanding oids

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -182,10 +182,13 @@ Use `--depth <n>` to request a different history depth.
 
 ### Git revision resolution
 
-Every revision argument resolves through one helper, `resolveRevision()` in
-`packages/webapp/src/git/commands/revision.ts`, so `show`, `ls-tree`, `cherry-pick`, `revert`,
-`rebase`, `diff`, `log`, `merge-base` and `rev-parse` all accept the same tokens: a ref
+`show`, `ls-tree`, `cherry-pick`, `revert`, `rebase`, `diff`, `merge-base` and `rev-parse`
+resolve their revision arguments through one helper, `resolveRevision()` in
+`packages/webapp/src/git/commands/revision.ts`, so they all accept the same tokens: a ref
 (`HEAD`, `main`, `origin/main`, a tag), a full or abbreviated oid, and `~`/`^` suffixes.
+
+`log` is the exception — it hands its revision straight to `git.log()`, so it takes whatever
+isomorphic-git accepts and not the suffix forms above.
 
 Resolution order matters for performance, not just precedence. A ref is looked up first —
 matching git, where a branch named `deadbeef` wins over the oid prefix `deadbeef` — and

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -180,6 +180,20 @@ git checkout -b feature origin/feature
 
 Use `--depth <n>` to request a different history depth.
 
+### Git revision resolution
+
+Every revision argument resolves through one helper, `resolveRevision()` in
+`packages/webapp/src/git/commands/revision.ts`, so `show`, `ls-tree`, `cherry-pick`, `revert`,
+`rebase`, `diff`, `log`, `merge-base` and `rev-parse` all accept the same tokens: a ref
+(`HEAD`, `main`, `origin/main`, a tag), a full or abbreviated oid, and `~`/`^` suffixes.
+
+Resolution order matters for performance, not just precedence. A ref is looked up first —
+matching git, where a branch named `deadbeef` wins over the oid prefix `deadbeef` — and
+`expandOid()` is only attempted for tokens that match `/^[0-9a-f]{4,40}$/i`. `expandOid()` reads
+every `.git/objects/pack/*.idx` searching for a prefix match, so trying it first made
+`git rev-parse HEAD` over a `--mount`ed host repo read all 30 pack indexes (3.8 MB, 34 bridge
+requests) instead of `HEAD` plus `packed-refs` (issue #2713).
+
 ### `ipk install -g` / `npm install -g`
 
 `ipk install -g <pkg>` (and `npm install -g`, `npm i -g`) installs into the shared

--- a/packages/webapp/src/git/commands/cherry-pick.ts
+++ b/packages/webapp/src/git/commands/cherry-pick.ts
@@ -11,6 +11,7 @@
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
 import { makeMergeDriver } from './merge-driver.js';
+import { tryResolveRevision } from './revision.js';
 import { expandGitError, GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
@@ -28,16 +29,10 @@ export async function cherryPick(
     return { stdout: '', stderr: 'error: empty commit set passed\n', exitCode: 128 };
   }
 
-  // Resolve <commit> to a full oid: try refs first, then a short/full oid.
-  let oid: string;
-  try {
-    oid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref });
-  } catch {
-    try {
-      oid = await git.expandOid({ fs: ctx.lfs, dir: cwd, oid: ref });
-    } catch {
-      return { stdout: '', stderr: `fatal: bad revision '${ref}'\n`, exitCode: 128 };
-    }
+  // Resolve <commit> to a full oid: refs first, then a short/full oid.
+  const oid = await tryResolveRevision(ctx, cwd, ref);
+  if (oid === undefined) {
+    return { stdout: '', stderr: `fatal: bad revision '${ref}'\n`, exitCode: 128 };
   }
 
   try {

--- a/packages/webapp/src/git/commands/ls-tree.ts
+++ b/packages/webapp/src/git/commands/ls-tree.ts
@@ -11,6 +11,7 @@
 
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import { tryResolveRevision } from './revision.js';
 import { GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
@@ -43,19 +44,13 @@ export async function lsTree(
 
   // Resolve tree-ish (branch/tag → oid, then short oid). readTree peels
   // commits to their tree internally, so a commit oid works as-is.
-  let oid: string;
-  try {
-    oid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref: treeIsh });
-  } catch {
-    try {
-      oid = await git.expandOid({ fs: ctx.lfs, dir: cwd, oid: treeIsh });
-    } catch {
-      return {
-        stdout: '',
-        stderr: `fatal: Not a valid object name ${treeIsh}\n`,
-        exitCode: 128,
-      };
-    }
+  const oid = await tryResolveRevision(ctx, cwd, treeIsh);
+  if (oid === undefined) {
+    return {
+      stdout: '',
+      stderr: `fatal: Not a valid object name ${treeIsh}\n`,
+      exitCode: 128,
+    };
   }
 
   let rootTree: TreeEntry[];

--- a/packages/webapp/src/git/commands/rebase.ts
+++ b/packages/webapp/src/git/commands/rebase.ts
@@ -17,6 +17,7 @@
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
 import { makeMergeDriver } from './merge-driver.js';
+import { tryResolveRevision } from './revision.js';
 import { expandGitError, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
@@ -253,15 +254,7 @@ async function resolveCommit(
   cwd: string,
   ref: string
 ): Promise<string | undefined> {
-  try {
-    return await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref });
-  } catch {
-    try {
-      return await git.expandOid({ fs: ctx.lfs, dir: cwd, oid: ref });
-    } catch {
-      return undefined;
-    }
-  }
+  return await tryResolveRevision(ctx, cwd, ref);
 }
 
 /**

--- a/packages/webapp/src/git/commands/revert.ts
+++ b/packages/webapp/src/git/commands/revert.ts
@@ -15,6 +15,7 @@
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
 import { threeWayMerge } from '../merge-file-core.js';
+import { tryResolveRevision } from './revision.js';
 import { expandGitError, GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
@@ -31,15 +32,9 @@ export async function revert(
     return { stdout: '', stderr: 'error: empty commit set passed\n', exitCode: 128 };
   }
 
-  let oid: string;
-  try {
-    oid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref });
-  } catch {
-    try {
-      oid = await git.expandOid({ fs: ctx.lfs, dir: cwd, oid: ref });
-    } catch {
-      return { stdout: '', stderr: `fatal: bad revision '${ref}'\n`, exitCode: 128 };
-    }
+  const oid = await tryResolveRevision(ctx, cwd, ref);
+  if (oid === undefined) {
+    return { stdout: '', stderr: `fatal: bad revision '${ref}'\n`, exitCode: 128 };
   }
 
   let headOid: string;

--- a/packages/webapp/src/git/commands/revision.ts
+++ b/packages/webapp/src/git/commands/revision.ts
@@ -37,12 +37,39 @@ function parseRevision(revision: string): { base: string; steps: RevisionStep[] 
   return { base, steps };
 }
 
+/**
+ * Resolve `revision` like {@link resolveRevision}, but report an unresolvable
+ * token as `undefined` so callers can emit their own `fatal:` wording.
+ */
+export async function tryResolveRevision(
+  ctx: GitCommandContext,
+  cwd: string,
+  revision: string
+): Promise<string | undefined> {
+  try {
+    return await resolveRevision(ctx, cwd, revision);
+  } catch {
+    return undefined;
+  }
+}
+
+/** An abbreviated or full object id — git accepts 4 to 40 hex characters. */
+const ABBREVIATED_OID = /^[0-9a-f]{4,40}$/i;
+
+/**
+ * Refs win over hex prefixes, which is git's own precedence, and `expandOid` —
+ * which reads every `.git/objects/pack/*.idx` looking for a prefix match — is
+ * only attempted for tokens that could be an abbreviated oid. Resolving `HEAD`
+ * over a mounted host repo used to read all 30 pack indexes (3.8 MB, 34
+ * requests); it now reads `HEAD` and `packed-refs` (#2713).
+ */
 async function resolveBase(ctx: GitCommandContext, cwd: string, ref: string): Promise<string> {
   try {
-    return await git.expandOid({ fs: ctx.lfs, dir: cwd, oid: ref });
-  } catch {
     return await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref });
+  } catch (error) {
+    if (!ABBREVIATED_OID.test(ref)) throw error;
   }
+  return await git.expandOid({ fs: ctx.lfs, dir: cwd, oid: ref });
 }
 
 async function readParent(

--- a/packages/webapp/src/git/commands/show.ts
+++ b/packages/webapp/src/git/commands/show.ts
@@ -3,6 +3,7 @@
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
 import { diffCommits, diffInitialCommit } from './diff.js';
+import { tryResolveRevision } from './revision.js';
 import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
@@ -23,20 +24,13 @@ export async function show(
   }
 
   const commitRef = ref ?? 'HEAD';
-  let oid: string;
-  try {
-    oid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref: commitRef });
-  } catch {
-    // Try expanding as a short OID
-    try {
-      oid = await git.expandOid({ fs: ctx.lfs, dir: cwd, oid: commitRef });
-    } catch {
-      return {
-        stdout: '',
-        stderr: `fatal: bad object ${commitRef}\n`,
-        exitCode: 128,
-      };
-    }
+  const oid = await tryResolveRevision(ctx, cwd, commitRef);
+  if (oid === undefined) {
+    return {
+      stdout: '',
+      stderr: `fatal: bad object ${commitRef}\n`,
+      exitCode: 128,
+    };
   }
 
   const { commit } = await git.readCommit({ fs: ctx.lfs, dir: cwd, oid });
@@ -66,7 +60,10 @@ async function showFileAtCommit(
   const colonIdx = refPath.indexOf(':');
   const commitRef = refPath.slice(0, colonIdx) || 'HEAD';
   const filepath = refPath.slice(colonIdx + 1);
-  const oid = await git.resolveRef({ fs: ctx.lfs, dir: cwd, ref: commitRef });
+  const oid = await tryResolveRevision(ctx, cwd, commitRef);
+  if (oid === undefined) {
+    return { stdout: '', stderr: `fatal: bad object ${commitRef}\n`, exitCode: 128 };
+  }
   const result = await git.readBlob({ fs: ctx.lfs, dir: cwd, oid, filepath });
   const content = new TextDecoder().decode(result.blob);
   return { stdout: content, stderr: '', exitCode: 0 };

--- a/packages/webapp/tests/git/git-revision-resolution.test.ts
+++ b/packages/webapp/tests/git/git-revision-resolution.test.ts
@@ -106,15 +106,18 @@ describe('git revision resolution (#2713)', () => {
     expect(paths.some((p) => p.includes('objects/pack'))).toBe(true);
   });
 
-  it('prefers a ref over a hex-looking branch name', async () => {
+  it('prefers a ref over a genuinely colliding oid prefix', async () => {
     const [first, second] = await seedHistory();
-    // A branch whose name is also a valid oid prefix. Git resolves the ref.
-    await git.execute(['checkout', '-b', 'deadbeef', first], '/project');
+    // A real collision: the branch name IS the second commit's oid prefix, but
+    // it points at the first commit. Git resolves the ref, so `first` wins;
+    // expandOid-first would answer `second`.
+    const collidingName = second.slice(0, 8);
+    await git.execute(['checkout', '-b', collidingName, first], '/project');
     await git.execute(['checkout', 'main'], '/project');
+    expect(second).not.toBe(first);
 
     const paths = recordPaths();
-    expect((await git.execute(['rev-parse', 'deadbeef'], '/project')).stdout.trim()).toBe(first);
-    expect(second).not.toBe(first);
+    expect((await git.execute(['rev-parse', collidingName], '/project')).stdout.trim()).toBe(first);
     expect(paths.filter((p) => p.includes('objects/pack'))).toEqual([]);
   });
 

--- a/packages/webapp/tests/git/git-revision-resolution.test.ts
+++ b/packages/webapp/tests/git/git-revision-resolution.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Revision resolution order (#2713).
+ *
+ * `resolveRevision` used to try `expandOid` before `resolveRef`, so every
+ * `HEAD` / branch lookup scanned all `.git/objects/pack/*.idx` files — 34
+ * requests and 3.8 MB over a `--mount`ed host repo. Refs must win over hex
+ * prefixes (git's own precedence), and `expandOid` may only be attempted for
+ * tokens that could be an abbreviated oid.
+ */
+
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { GitCommands } from '../../src/git/git-commands.js';
+
+describe('git revision resolution (#2713)', () => {
+  let vfs: VirtualFS;
+  let git: GitCommands;
+  let dbCounter = 0;
+
+  beforeEach(async () => {
+    const testId = dbCounter++;
+    vfs = await VirtualFS.create({ dbName: `git-revision-test-${testId}`, wipe: true });
+    git = new GitCommands({
+      fs: vfs,
+      authorName: 'Test User',
+      authorEmail: 'test@example.com',
+      globalDbName: `git-revision-global-${testId}`,
+    });
+  });
+
+  /** Two commits on `main`; returns [firstOid, secondOid]. */
+  async function seedHistory(): Promise<[string, string]> {
+    await git.execute(['init'], '/project');
+    const oids: string[] = [];
+    for (const version of ['one', 'two']) {
+      await vfs.writeFile('/project/file.txt', version);
+      await git.execute(['add', 'file.txt'], '/project');
+      await git.execute(['commit', '-m', version], '/project');
+      oids.push((await git.execute(['rev-parse', 'HEAD'], '/project')).stdout.trim());
+    }
+    return [oids[0], oids[1]];
+  }
+
+  /**
+   * Record every VFS path the git command touches. The isomorphic-git adapter
+   * calls these methods on the live instance, so spying after construction is
+   * enough.
+   */
+  function recordPaths(): string[] {
+    const paths: string[] = [];
+    for (const method of ['readFile', 'readDir', 'stat', 'lstat'] as const) {
+      const original = vfs[method].bind(vfs);
+      vi.spyOn(vfs, method).mockImplementation((async (...args: unknown[]) => {
+        // Config lookups pass a null path; only real reads are interesting.
+        if (typeof args[0] === 'string') paths.push(args[0]);
+        return await (original as (...args: unknown[]) => Promise<unknown>)(...args);
+      }) as never);
+    }
+    return paths;
+  }
+
+  it('resolves HEAD, a branch, a full oid and an abbreviated oid to the same commit', async () => {
+    const [, second] = await seedHistory();
+    await git.execute(['branch', 'feature'], '/project');
+
+    for (const revision of ['HEAD', 'main', 'feature', second, second.slice(0, 7)]) {
+      expect(await git.execute(['rev-parse', revision], '/project')).toEqual({
+        stdout: `${second}\n`,
+        stderr: '',
+        exitCode: 0,
+      });
+    }
+  });
+
+  it('never reads objects/pack when resolving a symbolic ref', async () => {
+    await seedHistory();
+    await git.execute(['branch', 'feature'], '/project');
+
+    const paths = recordPaths();
+    for (const revision of ['HEAD', 'main', 'feature']) {
+      expect((await git.execute(['rev-parse', revision], '/project')).exitCode).toBe(0);
+    }
+
+    expect(paths.filter((p) => p.includes('objects/pack'))).toEqual([]);
+    expect(paths.length).toBeGreaterThan(0);
+  });
+
+  it('never reads objects/pack when resolving a full oid', async () => {
+    const [, second] = await seedHistory();
+
+    const paths = recordPaths();
+    expect((await git.execute(['rev-parse', second], '/project')).stdout.trim()).toBe(second);
+
+    expect(paths.filter((p) => p.includes('objects/pack'))).toEqual([]);
+  });
+
+  it('still scans the pack indexes for an abbreviated oid', async () => {
+    const [, second] = await seedHistory();
+
+    const paths = recordPaths();
+    expect((await git.execute(['rev-parse', second.slice(0, 7)], '/project')).stdout.trim()).toBe(
+      second
+    );
+
+    expect(paths.some((p) => p.includes('objects/pack'))).toBe(true);
+  });
+
+  it('prefers a ref over a hex-looking branch name', async () => {
+    const [first, second] = await seedHistory();
+    // A branch whose name is also a valid oid prefix. Git resolves the ref.
+    await git.execute(['checkout', '-b', 'deadbeef', first], '/project');
+    await git.execute(['checkout', 'main'], '/project');
+
+    const paths = recordPaths();
+    expect((await git.execute(['rev-parse', 'deadbeef'], '/project')).stdout.trim()).toBe(first);
+    expect(second).not.toBe(first);
+    expect(paths.filter((p) => p.includes('objects/pack'))).toEqual([]);
+  });
+
+  it('reports an unresolvable revision without scanning the pack indexes', async () => {
+    await seedHistory();
+
+    const paths = recordPaths();
+    expect(await git.execute(['rev-parse', 'no-such-ref'], '/project')).toEqual({
+      stdout: '',
+      stderr: "fatal: ambiguous argument 'no-such-ref'\n",
+      exitCode: 128,
+    });
+
+    expect(paths.filter((p) => p.includes('objects/pack'))).toEqual([]);
+  });
+
+  describe('callers share the revision resolver', () => {
+    it('show accepts a relative revision', async () => {
+      const [first] = await seedHistory();
+      const result = await git.execute(['show', 'HEAD~1'], '/project');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(first);
+      expect(result.stdout).toContain('one');
+    });
+
+    it('show <rev>:<path> accepts a relative revision', async () => {
+      await seedHistory();
+      const result = await git.execute(['show', 'HEAD~1:file.txt'], '/project');
+      expect(result).toEqual({ stdout: 'one', stderr: '', exitCode: 0 });
+    });
+
+    it('show reports a bad object for an unresolvable <rev>:<path>', async () => {
+      await seedHistory();
+      const result = await git.execute(['show', 'no-such-ref:file.txt'], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('bad object no-such-ref');
+    });
+
+    it('ls-tree accepts a relative revision', async () => {
+      await seedHistory();
+      const result = await git.execute(['ls-tree', 'HEAD~1'], '/project');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('file.txt');
+    });
+
+    it('ls-tree does not scan the pack indexes for a symbolic ref', async () => {
+      await seedHistory();
+      const paths = recordPaths();
+      expect((await git.execute(['ls-tree', 'HEAD'], '/project')).exitCode).toBe(0);
+      expect(paths.filter((p) => p.includes('objects/pack'))).toEqual([]);
+    });
+
+    it('revert accepts a relative revision', async () => {
+      await seedHistory();
+      const result = await git.execute(['revert', '--no-edit', 'HEAD~0'], '/project');
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('cherry-pick still reports a bad revision for an unknown token', async () => {
+      await seedHistory();
+      const result = await git.execute(['cherry-pick', 'does-not-exist'], '/project');
+      expect(result.exitCode).toBe(128);
+      expect(result.stderr).toContain('bad revision');
+    });
+  });
+});


### PR DESCRIPTION
<!-- Linked issue -->

Fixes #2713. Part of #2707.

## Summary

`git rev-parse HEAD` over a `--mount`ed host repo made **38 requests / 3.83 MB** — 34 of them reads of every `.git/objects/pack/*.idx` — where native git reads two small files. Ref resolution now tries `resolveRef` first and only reaches for `expandOid` when the token could actually be an abbreviated oid, so resolving `HEAD` reads `HEAD` + `packed-refs` and nothing else.

## Why

`packages/webapp/src/git/commands/revision.ts` `resolveBase()` called `git.expandOid` **first** for every token and only fell back to `git.resolveRef` when it threw:

```ts
try {
  return await git.expandOid({ fs, dir, oid: ref });   // scans every pack index
} catch {
  return await git.resolveRef({ fs, dir, ref });
}
```

`expandOid` iterates all `.idx` files (`readPackIndex` per file) hunting for an abbreviated-oid prefix match — and `HEAD` / `main` / `origin/foo` are never valid hex prefixes, so that scan was pure waste on every command that resolves a revision (`rev-parse`, `show`, `diff <rev>`, `log <rev>`, `merge-base`, `~`/`^` suffixes).

**Repro** (from the #2707 benchmark harness):

1. `PORT=5715 npm run dev:standalone:fresh -- --mount=<a repo with packfiles>:/mnt/slicc`
2. `git -C /mnt/slicc rev-parse HEAD`

Expected: two small file reads (`HEAD`, `packed-refs`), ~31 ms native.
Actual (before): 38 hostfs requests, 3.83 MB, 205 ms — 34 of them pack-index reads, on both cold and warm runs.

## Approach / Implementation notes

- **`revision.ts`** — `resolveBase()` tries `git.resolveRef` first, and only attempts `git.expandOid` when the token matches `/^[0-9a-f]{4,40}$/i`. That is also git's own precedence: a branch literally named `deadbeef` wins over the oid prefix `deadbeef`.
- **New `tryResolveRevision()`** export — the same resolver, reporting an unresolvable token as `undefined` so each caller keeps its own `fatal:` wording rather than a shared error shape.
- **`show.ts`, `ls-tree.ts`, `cherry-pick.ts`, `revert.ts`, `rebase.ts`** each carried their own copy of the `resolveRef`/`expandOid` dance. They now call `tryResolveRevision()`, so there is one resolver and one order.

Rejected alternative: leaving the four other copies alone and only patching `revision.ts`. They were already `resolveRef`-first, so they were not the hot path — but they would still scan every pack index for a *non-hex* miss, and keeping five copies is how the orders drifted apart in the first place.

## Cross-cutting impact

- **Other callers of the changed contract**: `resolveRevision()` is used by `rev-parse`, `diff` (4 call sites), and `merge-base`; all pass through `resolveBase()` and keep their existing error handling. The five converted commands keep their exact `fatal:` strings and exit codes (128), covered by pre-existing tests in `git-commands.test.ts` (`bad revision`, `Not a valid object name`) which still pass.
- **Behavior gained**: the converted commands now accept `~`/`^` suffixes — `git show HEAD~1` used to fail. `show <rev>:<path>`, which previously only did `resolveRef`, now also accepts short oids and suffixes.
- **No change for full 40-char oids**: `resolveRef` short-circuits on a complete SHA, which is what the old `expandOid`→`resolveRef` fallback produced anyway (including for an oid that does not exist).
- **Floats**: pure `packages/webapp/src/git/` logic, identical in CLI / extension / Electron / worker. No persisted state, no new deps, no bundle growth (`check-first-load-size.mjs` passes).

## Test plan

New `packages/webapp/tests/git/git-revision-resolution.test.ts` — 13 tests against a real in-memory repo (`VirtualFS` + `git init` + commits), with a spy recording every VFS path the command touches:

- `HEAD`, a branch name, a full oid and an abbreviated oid all resolve to the same commit.
- Resolving `HEAD` / `main` / `feature` / a full oid / an unresolvable token reads **no** `objects/pack` path (the recorded reads are exactly `packed-refs`, `HEAD`, `refs/heads/main`).
- An abbreviated oid **still** scans the pack indexes — the hex gate is a gate, not a removal.
- A branch named `deadbeef` resolves as a ref, without touching `objects/pack`.
- `ls-tree HEAD` reads no pack index; `show` / `ls-tree` / `revert` accept relative revisions; `show` / `cherry-pick` keep their existing `fatal:` messages for unknown tokens.

**Mutation-checked**: reverting `resolveBase()` to the old `expandOid`-first order fails 5 of the 13 tests (the four `objects/pack` guards plus the ref-precedence one), so the guards actually bite rather than passing vacuously.

- [x] `npm run lint` — exit 0
- [x] `npm run verify` (pre-push gate) — 7/7 passed (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod)
- [x] `npm run typecheck` — exit 0 (all 9 projects)
- [x] `npm run test` — **18276 passed**, 52 skipped, 0 failed (1026 files passed, 4 skipped)
- [x] `npm run test:coverage:webapp` — exit 0, no threshold touched. 14645 tests passed. `revision.ts` 93.18% stmts / 100% funcs, `show.ts` 100% / 100%, `ls-tree.ts` 94.54%, `revert.ts` 95.52%, `cherry-pick.ts` 92.1%, `rebase.ts` 88.16%
- [x] `npm run build -w @slicc/webapp` — exit 0
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — exit 0
- [x] `node packages/dev-tools/tools/check-first-load-size.mjs` — "First-load OK (allowance 5 kB per change; total 4957 kB across both graphs)"
- [x] `node packages/dev-tools/tools/check-doc-refs.mjs` / `check-doc-sizes.mjs` — exit 0
- [x] `npx vitest run packages/webapp/tests/git/git-revision-resolution.test.ts` — 13/13 passed
- [ ] Manual smoke against a live `--mount`ed host repo — **not re-run**; the request-count claim is enforced by the new path-recording tests rather than a second benchmark pass. Anyone re-running the #2707 harness should see `rev-parse HEAD` drop from 38 requests to ~4.

**Pre-existing failures**: none — the full suite is green.

## Documentation

- [x] `docs/` — new "Git revision resolution" section in `docs/shell-reference.md`: the single resolver, the token forms every revision argument accepts, and why ref-before-hex matters for request count.
- [x] Relevant `CLAUDE.md` — no change needed; `packages/webapp/CLAUDE.md` routes git detail to `docs/`.

## Risk & rollback

- Blast radius: browser-side git only, all floats equally. No feature flag, no persisted state, no migration — `git revert` of this PR is clean.
- The one semantic change a reviewer should eyeball: for a token that is *both* a valid ref and a valid oid prefix, the answer flips from the oid to the ref. That is what git does, and the ambiguity is otherwise unresolvable.
- Nothing here needs real-Chrome/CDP verification; the fix is in pure FS-access ordering.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] Public shell-command behavior changes are intentional and reflected in `docs/shell-reference.md`
- [x] No cross-float contract changed
