### PR TITLE
fix(webapp): narrow appendLlmsTxtIgnoreHost read catch to ENOENT

### DIFF
--- a/packages/webapp/src/scoops/llms-txt-ignore.ts
+++ b/packages/webapp/src/scoops/llms-txt-ignore.ts
@@ -1,6 +1,7 @@
 import llmsTxtIgnoreDefault from '../../../vfs-root/etc/llmstxtignore?raw';
 import { createLogger } from '../base/logger.js';
 import type { FsWatcher, RestrictedFS, VirtualFS } from '../fs/index.js';
+import { FsError } from '../fs/index.js';
 import type { LickEvent } from './lick-manager.js';
 import type { RegisteredScoop } from './types.js';
 
@@ -79,8 +80,14 @@ export async function appendLlmsTxtIgnoreHost(
   let existing = '';
   try {
     existing = (await fs.readFile(LLMS_TXT_IGNORE_FILE, { encoding: 'utf-8' })) as string;
-  } catch {
-    existing = '';
+  } catch (err) {
+    // Only treat "file not created yet" as empty. Any other fault (EACCES, a
+    // transient OPFS/IndexedDB-backed VFS hiccup, a decode/corruption error)
+    // MUST propagate — otherwise the unconditional writeFile below clobbers the
+    // entire suppression policy with a single-line file, fail-open data loss on
+    // a security-relevant surface. Mirrors the ENOENT-only pattern in
+    // scoops/cone-memory-store.ts.
+    if (!(err instanceof FsError) || err.code !== 'ENOENT') throw err;
   }
   if (matchesLlmsTxtIgnore(normalized, parseLlmsTxtIgnore(existing))) return false;
   const separator = existing.length > 0 && !existing.endsWith('\n') ? '\n' : '';

--- a/packages/webapp/tests/scoops/llms-txt-ignore.test.ts
+++ b/packages/webapp/tests/scoops/llms-txt-ignore.test.ts
@@ -1,6 +1,6 @@
 import 'fake-indexeddb/auto';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { FsWatcher, VirtualFS } from '../../src/fs/index.js';
+import { FsError, FsWatcher, VirtualFS } from '../../src/fs/index.js';
 import {
   appendLlmsTxtIgnoreHost,
   discoveryHostname,
@@ -83,6 +83,53 @@ describe('/etc/llmstxtignore', () => {
         (entry) => entry === 'example.com'
       )
     ).toHaveLength(1);
+  });
+
+  it('starts from empty when the policy file does not exist yet (ENOENT)', async () => {
+    let written = '';
+    const stub = {
+      readFile: async () => {
+        throw new FsError('ENOENT', 'no such file', LLMS_TXT_IGNORE_FILE);
+      },
+      writeFile: async (_path: string, data: string) => {
+        written = data;
+      },
+    } as never;
+    expect(await appendLlmsTxtIgnoreHost(stub, 'example.com')).toBe(true);
+    expect(written).toBe('example.com\n');
+  });
+
+  it('aborts the append instead of clobbering the policy on a transient read fault', async () => {
+    // Seed a multi-host policy, then fail the read with a non-ENOENT fault.
+    await fs.writeFile(LLMS_TXT_IGNORE_FILE, 'github.com\napp.slack.com\n');
+    let wrote = false;
+    const stub = {
+      readFile: async () => {
+        throw new FsError('EIO', 'transient VFS fault', LLMS_TXT_IGNORE_FILE);
+      },
+      writeFile: async () => {
+        wrote = true;
+      },
+    } as never;
+    await expect(appendLlmsTxtIgnoreHost(stub, 'evil.example')).rejects.toBeInstanceOf(FsError);
+    expect(wrote).toBe(false);
+    // The on-disk policy is untouched — no host was silently dropped.
+    expect(parseLlmsTxtIgnore(await fs.readTextFile(LLMS_TXT_IGNORE_FILE))).toEqual([
+      'github.com',
+      'app.slack.com',
+    ]);
+  });
+
+  it('propagates a non-FsError read fault rather than treating it as empty', async () => {
+    const stub = {
+      readFile: async () => {
+        throw new TypeError('unexpected');
+      },
+      writeFile: async () => {
+        throw new Error('writeFile must not be reached');
+      },
+    } as never;
+    await expect(appendLlmsTxtIgnoreHost(stub, 'example.com')).rejects.toBeInstanceOf(TypeError);
   });
 
   it('classifies browser-capable scoops without leaking discovery to restricted ones', () => {


### PR DESCRIPTION
Closes #2703

## What changed

`appendLlmsTxtIgnoreHost()` in `packages/webapp/src/scoops/llms-txt-ignore.ts`
read the existing `/etc/llmstxtignore` policy inside a bare `catch {}` that
mapped **every** read error to an empty string. Because the next step is an
unconditional `writeFile` of `existing + newHost`, a transient/permission read
fault (`EACCES`, `EIO`, `EBUSY`, a decode error) caused the entire suppression
policy to be overwritten with a single-line file containing only the just-added
host — silently re-opening `llms-txt` discovery for every previously-ignored
host, and still returning `true` as if it succeeded.

The catch is now narrowed to the expected `ENOENT` (file-not-created-yet) case;
any other error propagates so the append aborts instead of clobbering the
policy. This mirrors the ENOENT-only pattern already used in
`scoops/cone-memory-store.ts`.

## Why

`/etc/llmstxtignore` is a security-relevant policy consulted by
`LlmsTxtIgnorePolicy.ignores()` before a discovery event becomes a lick.
Truncating it is a fail-**open** data loss. The read error is real information
the caller needs, not a signal to start from empty.

## How verified

- `npx biome check --write` on both touched files — clean.
- `npm run typecheck` — passes.
- `npm run verify` (full pre-push lint gate) — all 7 checks pass.
- `node packages/dev-tools/tools/check-touched-exemptions.mjs` — clean.
- `npx vitest run packages/webapp/tests/scoops/llms-txt-ignore.test.ts` — 9
  tests pass, including three new ones:
  - starts from empty when the file does not exist (ENOENT) and still creates it;
  - aborts and leaves the on-disk multi-host policy untouched on a transient
    (`EIO`) read fault, and never calls `writeFile`;
  - propagates a non-`FsError` read fault rather than treating it as empty.
