### PR TITLE
perf(webapp): stop git diff reading every tracked blob

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -209,15 +209,18 @@ what changed from OIDs before it reads any content (#2719):
 - **Tree vs index / tree vs tree** (`--staged`, `<rev> <rev>`): entries whose OIDs
   match are skipped, and two subtrees sharing a tree OID are pruned from the walk
   instead of being descended.
-- **Untracked subtrees are pruned**, so `node_modules` and `.git` are never
-  enumerated by a diff walk.
+- **Untracked and pathspec-excluded subtrees are pruned in the walk's
+  `iterate` hook**, not in `map`. `map` runs _after_ isomorphic-git has already
+  `readdir`/`lstat`ed the entry, so pruning there still costs one round trip
+  per tracked path; filtering in `iterate` works from the path string alone and
+  costs nothing. `node_modules` and `.git` are never enumerated, and
+  `git diff -- one/file.txt` never stats a sibling directory.
 - Workdir walks pass `refresh: false` — a read-only command must not rewrite
   `.git/index` (#2708).
 
-Pathspecs are applied before any read, so `git diff -- <path>` costs what that path
-costs. When adding a diff variant, keep the OID comparison ahead of the content
-read; the pre-2719 code compared decoded strings and pulled all 3,549 tracked blobs
-out of the packfile on every invocation.
+When adding a diff variant, keep the OID comparison ahead of the content read and
+the pathspec test ahead of the walk: the pre-2719 code compared decoded strings
+and pulled all 3,549 tracked blobs out of the packfile on every invocation.
 
 ### `ipk install -g` / `npm install -g`
 

--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -197,6 +197,28 @@ every `.git/objects/pack/*.idx` searching for a prefix match, so trying it first
 `git rev-parse HEAD` over a `--mount`ed host repo read all 30 pack indexes (3.8 MB, 34 bridge
 requests) instead of `HEAD` plus `packed-refs` (issue #2713).
 
+### `git diff` never reads an unchanged blob
+
+Every git command runs against the VFS, so on a `--mount`ed host repo each object
+read is an HTTP round trip through the hostfs bridge. `git diff` therefore decides
+what changed from OIDs before it reads any content (#2719):
+
+- **Index vs workdir** (`git diff`): the workdir bytes of a tracked file are read
+  once and hashed with `hashBlob`; the object store is touched only when that hash
+  differs from the index OID. A clean tree reads zero blobs.
+- **Tree vs index / tree vs tree** (`--staged`, `<rev> <rev>`): entries whose OIDs
+  match are skipped, and two subtrees sharing a tree OID are pruned from the walk
+  instead of being descended.
+- **Untracked subtrees are pruned**, so `node_modules` and `.git` are never
+  enumerated by a diff walk.
+- Workdir walks pass `refresh: false` — a read-only command must not rewrite
+  `.git/index` (#2708).
+
+Pathspecs are applied before any read, so `git diff -- <path>` costs what that path
+costs. When adding a diff variant, keep the OID comparison ahead of the content
+read; the pre-2719 code compared decoded strings and pulled all 3,549 tracked blobs
+out of the packfile on every invocation.
+
 ### `ipk install -g` / `npm install -g`
 
 `ipk install -g <pkg>` (and `npm install -g`, `npm i -g`) installs into the shared

--- a/packages/webapp/src/git/commands/diff.ts
+++ b/packages/webapp/src/git/commands/diff.ts
@@ -9,11 +9,45 @@
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
 import { diffStat, unifiedDiff } from '../diff.js';
-import { matchesPathspec, resolveRevision } from './revision.js';
+import { matchesPathspec, pathspecCouldMatch, resolveRevision } from './revision.js';
 import { GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 type FileChange = { filepath: string; oldContent: string; newContent: string };
+
+/**
+ * Decides whether a walk should descend into a child path.
+ *
+ * `present[i]` says whether tree `i` of the walk has that path at all, so a
+ * caller can drop e.g. everything the index does not know about.
+ */
+type KeepChild = (filepath: string, present: readonly boolean[]) => boolean;
+
+/**
+ * A `walk({ iterate })` hook that drops subtrees *before* isomorphic-git
+ * constructs their entries.
+ *
+ * Pruning from `map` is too late: `walk()` calls `readdir()` on every child —
+ * which for the WORKDIR walker means an `lstat` (one hostfs round trip on a
+ * mounted repo) — and only *then* calls `map`. Filtering here, from the path
+ * string alone, means an excluded subtree costs nothing at all (#2719).
+ *
+ * `children` yields one raw path per walk tree (undefined where that tree has
+ * no such entry); the entries are only constructed inside `walk`.
+ */
+function pruningIterate(keep: KeepChild): git.WalkerIterate {
+  return (walk, children) => {
+    const walked: Promise<unknown>[] = [];
+    for (const child of children as unknown as Iterable<unknown[]>) {
+      const filepath = child.find((path): path is string => typeof path === 'string');
+      const present = child.map((path) => typeof path === 'string');
+      if (filepath === undefined || keep(filepath, present)) {
+        walked.push(walk(child as unknown as git.WalkerEntry[]));
+      }
+    }
+    return Promise.all(walked);
+  };
+}
 
 export async function diff(
   ctx: GitCommandContext,
@@ -84,6 +118,8 @@ async function diffStagedChanges(
     dir: cwd,
     cache,
     trees: [git.TREE({ ref }), git.STAGE()],
+    // A pathspec-excluded subtree is dropped before its tree object is read.
+    iterate: pruningIterate((filepath) => pathspecCouldMatch(filepath, pathspecs)),
     map: async (filepath, [headEntry, stageEntry]) => {
       // `.git` itself is never tracked; a tracked `.gitignore` is.
       if (filepath === '.' || filepath === '.git' || filepath.startsWith('.git/')) return undefined;
@@ -133,8 +169,9 @@ async function diffCommitIndex(
  * previous implementation pulled *every* tracked blob out of the packfile and
  * compared the decoded strings (#2719).
  *
- * Untracked subtrees are pruned from the walk (`return null`), so ignored
- * directories (`node_modules`, `.git`) are never enumerated, and `refresh:
+ * Untracked and pathspec-excluded subtrees are dropped by `iterate` before the
+ * workdir walker can `lstat` them, so `node_modules` / `.git` are never
+ * enumerated and `git diff -- <path>` costs what that path costs. `refresh:
  * false` keeps this read-only command from rewriting `.git/index` (#2708).
  */
 async function diffWorkdirChanges(
@@ -150,10 +187,14 @@ async function diffWorkdirChanges(
     dir: cwd,
     cache,
     trees: [git.STAGE(), git.WORKDIR({ refresh: false })],
+    // Untracked paths (`.git`, `node_modules`, …) and anything a pathspec
+    // rules out are dropped here, before the workdir walker would `lstat`
+    // them: `git diff -- one/file.txt` must not stat the whole tree.
+    iterate: pruningIterate(
+      (filepath, [inIndex]) => inIndex === true && pathspecCouldMatch(filepath, pathspecs)
+    ),
     map: async (filepath, [stageEntry, workEntry]) => {
       if (filepath === '.') return undefined;
-      // Not in the index: untracked (or `.git` itself). `git diff` never
-      // reports untracked paths, so prune the whole subtree.
       if (!stageEntry) return null;
       const stageType = await stageEntry.type();
       if (stageType === 'tree') return undefined;
@@ -243,6 +284,7 @@ async function diffResolvedTrees(
     dir: cwd,
     cache: {},
     trees: [git.TREE({ ref: resolvedRef1 }), git.TREE({ ref: resolvedRef2 })],
+    iterate: pruningIterate((filepath) => pathspecCouldMatch(filepath, opts.pathspecs ?? [])),
     map: async (filepath, [entry1, entry2]) => {
       // Identical subtrees share an OID: prune instead of reading every tree
       // object below them.
@@ -278,9 +320,15 @@ async function diffCommitWorkdir(
     cache,
     // `refresh: false`: a read-only diff must not rewrite `.git/index` (#2708).
     trees: [git.TREE({ ref: resolved }), git.WORKDIR({ refresh: false })],
+    // Same pre-`lstat` pruning as `git diff`: untracked paths (nothing in the
+    // commit and nothing in the index below them) and pathspec-excluded
+    // subtrees never reach the workdir walker.
+    iterate: pruningIterate(
+      (filepath, [inCommit]) =>
+        (inCommit === true || tracked.has(filepath) || trackedDirs.has(filepath)) &&
+        pathspecCouldMatch(filepath, opts.pathspecs ?? [])
+    ),
     map: async (filepath, [oldEntry, workEntry]) => {
-      // Neither in the commit nor in the index: an untracked path (including
-      // `.git` itself). Prune so the walk never enumerates it.
       if (!oldEntry && !tracked.has(filepath) && !trackedDirs.has(filepath)) return null;
       const change = await compareWalkerEntries(
         filepath,

--- a/packages/webapp/src/git/commands/diff.ts
+++ b/packages/webapp/src/git/commands/diff.ts
@@ -77,13 +77,16 @@ async function diffStagedChanges(
   ref = 'HEAD'
 ): Promise<FileChange[]> {
   const changes: FileChange[] = [];
+  const cache = {};
 
   await git.walk({
     fs: ctx.lfs,
     dir: cwd,
+    cache,
     trees: [git.TREE({ ref }), git.STAGE()],
     map: async (filepath, [headEntry, stageEntry]) => {
-      if (filepath === '.' || filepath.startsWith('.git')) return undefined;
+      // `.git` itself is never tracked; a tracked `.gitignore` is.
+      if (filepath === '.' || filepath === '.git' || filepath.startsWith('.git/')) return undefined;
       if (!matchesPathspec(filepath, pathspecs)) return undefined;
       const headType = headEntry ? await headEntry.type() : undefined;
       const stageType = stageEntry ? await stageEntry.type() : undefined;
@@ -91,10 +94,11 @@ async function diffStagedChanges(
 
       const headOid = headEntry ? await headEntry.oid() : undefined;
       const stageOid = stageEntry ? await stageEntry.oid() : undefined;
+      // Unchanged between the tree and the index: no object read at all.
       if (headOid === stageOid) return undefined;
 
-      const oldText = await readBlobText(ctx, cwd, headOid);
-      const newText = await readBlobText(ctx, cwd, stageOid);
+      const oldText = await readBlobText(ctx, cwd, headOid, cache);
+      const newText = await readBlobText(ctx, cwd, stageOid, cache);
 
       changes.push({ filepath, oldContent: oldText, newContent: newText });
       return undefined;
@@ -120,59 +124,88 @@ async function diffCommitIndex(
   return formatChanges(changes, opts);
 }
 
-/** Collect unstaged changes by comparing index vs workdir. */
+/**
+ * Collect unstaged changes by comparing index vs workdir.
+ *
+ * The workdir bytes of a tracked file are read exactly once and hashed with
+ * `git.hashBlob`; the object store is only touched for paths whose hash differs
+ * from the index OID. A clean working tree therefore reads zero blobs — the
+ * previous implementation pulled *every* tracked blob out of the packfile and
+ * compared the decoded strings (#2719).
+ *
+ * Untracked subtrees are pruned from the walk (`return null`), so ignored
+ * directories (`node_modules`, `.git`) are never enumerated, and `refresh:
+ * false` keeps this read-only command from rewriting `.git/index` (#2708).
+ */
 async function diffWorkdirChanges(
   ctx: GitCommandContext,
   cwd: string,
   pathspecs: string[] = []
 ): Promise<FileChange[]> {
   const changes: FileChange[] = [];
+  const cache = {};
 
-  // Collect all index entries with their OIDs
-  const indexEntries = new Map<string, string>();
   await git.walk({
     fs: ctx.lfs,
     dir: cwd,
-    trees: [git.STAGE()],
-    map: async (filepath, [entry]) => {
-      if (filepath === '.' || filepath.startsWith('.git') || !entry) return undefined;
-      const type = await entry.type();
-      if (type !== 'blob') return undefined;
-      const oid = await entry.oid();
-      if (oid) indexEntries.set(filepath, oid);
-      return undefined;
+    cache,
+    trees: [git.STAGE(), git.WORKDIR({ refresh: false })],
+    map: async (filepath, [stageEntry, workEntry]) => {
+      if (filepath === '.') return undefined;
+      // Not in the index: untracked (or `.git` itself). `git diff` never
+      // reports untracked paths, so prune the whole subtree.
+      if (!stageEntry) return null;
+      const stageType = await stageEntry.type();
+      if (stageType === 'tree') return undefined;
+      // Gitlinks and other non-blob entries have no text to diff.
+      if (stageType !== 'blob') return null;
+      // Pathspecs are applied before any I/O.
+      if (!matchesPathspec(filepath, pathspecs)) return null;
+
+      const stageOid = await stageEntry.oid();
+      const workBytes = await readWorkdirBytes(workEntry);
+      // Unmodified: the workdir hash matches the index OID, so the blob never
+      // has to be read out of the pack.
+      if (workBytes && stageOid && (await git.hashBlob({ object: workBytes })).oid === stageOid) {
+        return null;
+      }
+
+      const oldContent = await readBlobText(ctx, cwd, stageOid, cache);
+      const newContent = workBytes ? new TextDecoder().decode(workBytes) : '';
+      if (oldContent !== newContent) changes.push({ filepath, oldContent, newContent });
+      return null;
     },
   });
 
-  // Compare each index entry with workdir content directly
-  for (const [file, stageOid] of indexEntries) {
-    if (!matchesPathspec(file, pathspecs)) continue;
-    const oldText = await readBlobText(ctx, cwd, stageOid);
-
-    let newText = '';
-    try {
-      newText = await ctx.fs.readTextFile(`${cwd}/${file}`);
-    } catch {
-      /* file deleted in workdir */
-    }
-
-    if (oldText !== newText) {
-      changes.push({ filepath: file, oldContent: oldText, newContent: newText });
-    }
-  }
-
+  // The walk visits siblings concurrently; sort so the output is stable.
+  changes.sort((a, b) => (a.filepath < b.filepath ? -1 : a.filepath > b.filepath ? 1 : 0));
   return changes;
+}
+
+/**
+ * Workdir bytes for a walker entry, or undefined when the path is gone,
+ * unreadable, or not a file (`git diff` renders those as a deletion).
+ */
+async function readWorkdirBytes(entry: git.WalkerEntry | null): Promise<Uint8Array | undefined> {
+  if (!entry) return undefined;
+  try {
+    if ((await entry.type()) !== 'blob') return undefined;
+    return (await entry.content()) ?? undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /** Read a blob as text by OID, returning empty string if OID is undefined or unreadable. */
 async function readBlobText(
   ctx: GitCommandContext,
   cwd: string,
-  oid: string | undefined
+  oid: string | undefined,
+  cache?: object
 ): Promise<string> {
   if (!oid) return '';
   try {
-    const { blob } = await git.readBlob({ fs: ctx.lfs, dir: cwd, oid });
+    const { blob } = await git.readBlob({ fs: ctx.lfs, dir: cwd, oid, cache });
     return new TextDecoder().decode(blob);
   } catch {
     return '';
@@ -208,8 +241,12 @@ async function diffResolvedTrees(
   await git.walk({
     fs: ctx.lfs,
     dir: cwd,
+    cache: {},
     trees: [git.TREE({ ref: resolvedRef1 }), git.TREE({ ref: resolvedRef2 })],
     map: async (filepath, [entry1, entry2]) => {
+      // Identical subtrees share an OID: prune instead of reading every tree
+      // object below them.
+      if (await isIdenticalSubtree(entry1, entry2)) return null;
       const change = await compareWalkerEntries(filepath, entry1, entry2, opts.pathspecs ?? []);
       if (change) changes.push(change);
       return undefined;
@@ -231,14 +268,20 @@ async function diffCommitWorkdir(
   } catch {
     return ambiguousRevision(ref);
   }
-  const tracked = new Set(await git.listFiles({ fs: ctx.lfs, dir: cwd }));
+  const cache = {};
+  const tracked = new Set<string>(await git.listFiles({ fs: ctx.lfs, dir: cwd, cache }));
+  const trackedDirs = ancestorDirs(tracked);
   const changes: FileChange[] = [];
   await git.walk({
     fs: ctx.lfs,
     dir: cwd,
-    trees: [git.TREE({ ref: resolved }), git.WORKDIR()],
+    cache,
+    // `refresh: false`: a read-only diff must not rewrite `.git/index` (#2708).
+    trees: [git.TREE({ ref: resolved }), git.WORKDIR({ refresh: false })],
     map: async (filepath, [oldEntry, workEntry]) => {
-      if (!oldEntry && !tracked.has(filepath)) return undefined;
+      // Neither in the commit nor in the index: an untracked path (including
+      // `.git` itself). Prune so the walk never enumerates it.
+      if (!oldEntry && !tracked.has(filepath) && !trackedDirs.has(filepath)) return null;
       const change = await compareWalkerEntries(
         filepath,
         oldEntry,
@@ -250,6 +293,30 @@ async function diffCommitWorkdir(
     },
   });
   return formatChanges(changes, opts);
+}
+
+/** Every directory that has at least one tracked file below it. */
+function ancestorDirs(files: Iterable<string>): Set<string> {
+  const dirs = new Set<string>();
+  for (const file of files) {
+    let slash = file.indexOf('/');
+    while (slash > 0) {
+      dirs.add(file.slice(0, slash));
+      slash = file.indexOf('/', slash + 1);
+    }
+  }
+  return dirs;
+}
+
+/** True when both entries are trees with the same OID (identical subtrees). */
+async function isIdenticalSubtree(
+  entry1: git.WalkerEntry | null,
+  entry2: git.WalkerEntry | null
+): Promise<boolean> {
+  if (!entry1 || !entry2) return false;
+  if ((await entry1.type()) !== 'tree' || (await entry2.type()) !== 'tree') return false;
+  const oid1 = await entry1.oid();
+  return Boolean(oid1) && oid1 === (await entry2.oid());
 }
 
 async function compareWalkerEntries(

--- a/packages/webapp/src/git/commands/revision.ts
+++ b/packages/webapp/src/git/commands/revision.ts
@@ -85,10 +85,35 @@ async function readParent(
   return parent;
 }
 
+/** `./foo/` and `foo` are the same pathspec. */
+function normalizePathspec(raw: string): string {
+  return raw.replace(/^\.\//, '').replace(/\/+$/, '');
+}
+
 export function matchesPathspec(filepath: string, pathspecs: readonly string[]): boolean {
   if (pathspecs.length === 0) return true;
   return pathspecs.some((raw) => {
-    const spec = raw.replace(/^\.\//, '').replace(/\/+$/, '');
+    const spec = normalizePathspec(raw);
     return spec === '' || filepath === spec || filepath.startsWith(`${spec}/`);
+  });
+}
+
+/**
+ * True when `filepath` matches a pathspec **or is a directory that could still
+ * contain one** — i.e. whether a tree walk has any reason to descend into it.
+ *
+ * `matchesPathspec('src', ['src/a.txt'])` is false (a walk must not *report*
+ * `src`), but the walk still has to enter `src` to reach `src/a.txt`. Callers
+ * that prune subtrees need this weaker test, applied to the path string alone
+ * so no `lstat`/`readdir` is spent on a subtree that is about to be dropped.
+ */
+export function pathspecCouldMatch(filepath: string, pathspecs: readonly string[]): boolean {
+  if (pathspecs.length === 0) return true;
+  return pathspecs.some((raw) => {
+    const spec = normalizePathspec(raw);
+    if (spec === '' || filepath === spec) return true;
+    // Below the spec (`src/a.txt` under `src`), or an ancestor of it (`src`
+    // on the way to `src/a.txt`).
+    return filepath.startsWith(`${spec}/`) || spec.startsWith(`${filepath}/`);
   });
 }

--- a/packages/webapp/tests/git/git-diff-object-reads.test.ts
+++ b/packages/webapp/tests/git/git-diff-object-reads.test.ts
@@ -60,16 +60,26 @@ describe('git diff object reads (issue #2719)', () => {
   function trackIo(): {
     allReads: () => string[];
     objectReads: () => string[];
+    touched: () => string[];
     blobReads: (contents: string[]) => Promise<string[]>;
     dirs: () => string[];
   } {
     const readSpy = vi.spyOn(vfs, 'readFile');
     const dirSpy = vi.spyOn(vfs, 'readDir');
+    const lstatSpy = vi.spyOn(vfs, 'lstat');
+    const statSpy = vi.spyOn(vfs, 'stat');
     const allReads = () => readSpy.mock.calls.map((call) => String(call[0]));
     const objectReads = () => allReads().filter((p) => p.includes('/.git/objects/'));
     return {
       allReads,
       objectReads,
+      // Every path the command touched at all: read, list, or stat.
+      touched: () => [
+        ...allReads(),
+        ...dirSpy.mock.calls.map((call) => String(call[0])),
+        ...lstatSpy.mock.calls.map((call) => String(call[0])),
+        ...statSpy.mock.calls.map((call) => String(call[0])),
+      ],
       blobReads: async (contents) => {
         const wanted = await Promise.all(contents.map(blobPath));
         return objectReads().filter((read) => wanted.some((suffix) => read.endsWith(suffix)));
@@ -268,5 +278,97 @@ describe('git diff object reads (issue #2719)', () => {
     // there: neither the tree below it nor any blob under it is read.
     expect(io.objectReads().filter((p) => p.endsWith(oidPath(deepTree.oid)))).toEqual([]);
     expect(await io.blobReads(['charlie\n', 'bravo\n', 'delta\n'])).toEqual([]);
+  });
+
+  describe('pathspec pruning (issue #2719 review)', () => {
+    /** Tracked files in three sibling directories, plus an untracked one. */
+    async function seedWideRepo(): Promise<void> {
+      await git.execute(['init'], '/project');
+      for (const dir of ['a', 'c', 'd']) {
+        await vfs.mkdir(`/project/${dir}`, { recursive: true });
+        await vfs.writeFile(`/project/${dir}/${dir}.txt`, `${dir}\n`);
+      }
+      await vfs.writeFile('/project/a/b.txt', 'bee\n');
+      await vfs.mkdir('/project/e/deep', { recursive: true });
+      await vfs.writeFile('/project/e/deep/e.txt', 'eee\n');
+      await git.execute(['add', '.'], '/project');
+      await git.execute(['commit', '-m', 'initial'], '/project');
+      await vfs.writeFile('/project/a/b.txt', 'bee\nmodified\n');
+      await vfs.writeFile('/project/c/c.txt', 'c\nmodified\n');
+    }
+
+    /** Paths the walk touched inside `/project/<dir>`, ignoring `.git`. */
+    function inside(io: { touched: () => string[] }, dir: string): string[] {
+      return io
+        .touched()
+        .filter((p) => !p.includes('/.git/'))
+        .filter((p) => p === `/project/${dir}` || p.startsWith(`/project/${dir}/`));
+    }
+
+    it('never stats a sibling directory excluded by a file pathspec', async () => {
+      await seedWideRepo();
+
+      const io = trackIo();
+      const result = await git.execute(['diff', '--', 'a/b.txt'], '/project');
+
+      expect(result.stdout).toContain('diff --git a/a/b.txt b/a/b.txt');
+      expect(result.stdout).not.toContain('a/c/c.txt');
+      // Excluded siblings cost nothing: no readdir, no lstat, no read.
+      expect(inside(io, 'c')).toEqual([]);
+      expect(inside(io, 'd')).toEqual([]);
+      expect(inside(io, 'e')).toEqual([]);
+      // The one file named by the pathspec is still reached...
+      expect(io.touched()).toContain('/project/a/b.txt');
+      // ...and its sibling inside the same directory is skipped too.
+      expect(io.touched()).not.toContain('/project/a/a.txt');
+    });
+
+    it('descends a directory pathspec and prunes everything else', async () => {
+      await seedWideRepo();
+
+      const io = trackIo();
+      const result = await git.execute(['diff', '--name-only', '--', 'a'], '/project');
+
+      expect(result.stdout).toBe('a/b.txt\n');
+      expect(inside(io, 'a')).toContain('/project/a/b.txt');
+      expect(inside(io, 'c')).toEqual([]);
+      expect(inside(io, 'd')).toEqual([]);
+    });
+
+    it('prunes nested subtrees the pathspec cannot reach', async () => {
+      await seedWideRepo();
+
+      const io = trackIo();
+      await git.execute(['diff', '--', 'e/deep/e.txt'], '/project');
+
+      expect(io.touched()).toContain('/project/e/deep/e.txt');
+      expect(inside(io, 'a')).toEqual([]);
+      expect(inside(io, 'c')).toEqual([]);
+    });
+
+    it('prunes the same way for `diff HEAD -- <path>`', async () => {
+      await seedWideRepo();
+
+      const io = trackIo();
+      const result = await git.execute(
+        ['diff', 'HEAD', '--name-only', '--', 'a/b.txt'],
+        '/project'
+      );
+
+      expect(result.stdout).toBe('a/b.txt\n');
+      expect(inside(io, 'c')).toEqual([]);
+      expect(inside(io, 'd')).toEqual([]);
+    });
+
+    it('prunes the same way for `diff --staged -- <path>`', async () => {
+      await seedWideRepo();
+      await git.execute(['add', 'c/c.txt'], '/project');
+
+      const io = trackIo();
+      const result = await git.execute(['diff', '--staged', '--name-only', '--', 'a'], '/project');
+
+      expect(result.stdout).toBe('');
+      expect(await io.blobReads(['c\n', 'c\nmodified\n'])).toEqual([]);
+    });
   });
 });

--- a/packages/webapp/tests/git/git-diff-object-reads.test.ts
+++ b/packages/webapp/tests/git/git-diff-object-reads.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Regression tests for https://github.com/ai-ecoverse/slicc/issues/2719 —
+ * `git diff` read every tracked blob out of the object store and re-read every
+ * workdir file, so a clean tree cost two round trips per tracked file (over a
+ * hostfs mount that was 172,970 requests and no result after ten minutes).
+ *
+ * These tests count filesystem work instead of only checking the rendered
+ * diff: reads are attributed by path, and blob reads are identified by hashing
+ * the known file contents, so tree/commit reads (which a tree walk legitimately
+ * needs) don't mask a blob read that should never have happened.
+ */
+
+import 'fake-indexeddb/auto';
+import * as isoGit from 'isomorphic-git';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { GitCommands } from '../../src/git/git-commands.js';
+import { createIsomorphicGitFs } from '../../src/git/vfs-fs-adapter.js';
+
+let dbCounter = 0;
+
+/** Loose-object suffix (`objects/ab/cdef…`) for an OID. */
+function oidPath(oid: string): string {
+  return `objects/${oid.slice(0, 2)}/${oid.slice(2)}`;
+}
+
+/** Loose-object suffix for a blob with this content. */
+async function blobPath(content: string): Promise<string> {
+  const { oid } = await isoGit.hashBlob({ object: content });
+  return oidPath(oid);
+}
+
+describe('git diff object reads (issue #2719)', () => {
+  let vfs: VirtualFS;
+  let git: GitCommands;
+
+  beforeEach(async () => {
+    const testId = dbCounter++;
+    vfs = await VirtualFS.create({ dbName: `git-diff-io-test-${testId}`, wipe: true });
+    git = new GitCommands({
+      fs: vfs,
+      authorName: 'Test User',
+      authorEmail: 'test@example.com',
+      globalDbName: `git-diff-io-global-${testId}`,
+    });
+  });
+
+  /** init + three committed files, so a clean `git diff` has work to skip. */
+  async function seedRepo(): Promise<void> {
+    await git.execute(['init'], '/project');
+    await vfs.mkdir('/project/src', { recursive: true });
+    await vfs.writeFile('/project/a.txt', 'alpha\n');
+    await vfs.writeFile('/project/b.txt', 'bravo\n');
+    await vfs.writeFile('/project/src/c.txt', 'charlie\n');
+    await git.execute(['add', '.'], '/project');
+    await git.execute(['commit', '-m', 'initial'], '/project');
+  }
+
+  /** Records every VFS read/readDir so a command's I/O can be attributed. */
+  function trackIo(): {
+    allReads: () => string[];
+    objectReads: () => string[];
+    blobReads: (contents: string[]) => Promise<string[]>;
+    dirs: () => string[];
+  } {
+    const readSpy = vi.spyOn(vfs, 'readFile');
+    const dirSpy = vi.spyOn(vfs, 'readDir');
+    const allReads = () => readSpy.mock.calls.map((call) => String(call[0]));
+    const objectReads = () => allReads().filter((p) => p.includes('/.git/objects/'));
+    return {
+      allReads,
+      objectReads,
+      blobReads: async (contents) => {
+        const wanted = await Promise.all(contents.map(blobPath));
+        return objectReads().filter((read) => wanted.some((suffix) => read.endsWith(suffix)));
+      },
+      dirs: () => dirSpy.mock.calls.map((call) => String(call[0])),
+    };
+  }
+
+  it('reads no objects at all when nothing is modified', async () => {
+    await seedRepo();
+
+    const io = trackIo();
+    const result = await git.execute(['diff'], '/project');
+
+    expect(result.stdout).toBe('');
+    expect(result.exitCode).toBe(0);
+    expect(io.objectReads()).toEqual([]);
+  });
+
+  it('reads exactly one blob when one file is modified', async () => {
+    await seedRepo();
+    await vfs.writeFile('/project/b.txt', 'bravo\ndelta\n');
+
+    const io = trackIo();
+    const result = await git.execute(['diff'], '/project');
+
+    expect(result.stdout).toContain('diff --git a/b.txt b/b.txt');
+    expect(result.stdout).toContain('+delta');
+    expect(result.stdout).not.toContain('a/a.txt');
+    // Only the modified file's staged blob comes out of the object store.
+    expect(io.objectReads()).toHaveLength(1);
+    expect(await io.blobReads(['bravo\n'])).toHaveLength(1);
+  });
+
+  /** An untracked tree deep enough to prove the walk stops at its root. */
+  async function seedUntrackedTree(): Promise<void> {
+    await vfs.mkdir('/project/node_modules/pkg/nested', { recursive: true });
+    await vfs.writeFile('/project/node_modules/pkg/nested/index.js', 'module.exports = 1\n');
+  }
+
+  it('never descends into untracked directories', async () => {
+    await seedRepo();
+    await seedUntrackedTree();
+
+    const io = trackIo();
+    const result = await git.execute(['diff'], '/project');
+
+    expect(result.stdout).toBe('');
+    // The walk lists `node_modules` itself (isomorphic-git reads an entry
+    // before the map can prune it) but never goes below it.
+    expect(io.dirs().filter((p) => p.startsWith('/project/node_modules/'))).toEqual([]);
+    expect(io.allReads().filter((p) => p.includes('node_modules'))).toEqual([]);
+    expect(io.objectReads()).toEqual([]);
+  });
+
+  it('applies pathspecs before reading anything', async () => {
+    await seedRepo();
+    await vfs.writeFile('/project/a.txt', 'alpha\nadded\n');
+    await vfs.writeFile('/project/b.txt', 'bravo\nadded\n');
+
+    const io = trackIo();
+    const result = await git.execute(['diff', '--', 'b.txt'], '/project');
+
+    expect(result.stdout).toContain('a/b.txt');
+    expect(result.stdout).not.toContain('a/a.txt');
+    // The excluded file's blob is never fetched from the object store.
+    expect(io.objectReads()).toHaveLength(1);
+    expect(await io.blobReads(['alpha\n'])).toEqual([]);
+  });
+
+  it('diffs a tracked dotfile whose name starts with .git', async () => {
+    await seedRepo();
+    await vfs.writeFile('/project/.gitignore', 'dist\n');
+    await git.execute(['add', '.gitignore'], '/project');
+    await git.execute(['commit', '-m', 'ignore'], '/project');
+    await vfs.writeFile('/project/.gitignore', 'dist\ncoverage\n');
+
+    const unstaged = await git.execute(['diff'], '/project');
+
+    expect(unstaged.stdout).toContain('diff --git a/.gitignore b/.gitignore');
+    expect(unstaged.stdout).toContain('+coverage');
+
+    await git.execute(['add', '.gitignore'], '/project');
+    const staged = await git.execute(['diff', '--staged'], '/project');
+
+    expect(staged.stdout).toContain('diff --git a/.gitignore b/.gitignore');
+    expect(staged.stdout).toContain('+coverage');
+  });
+
+  it('still reports a file deleted from the workdir', async () => {
+    await seedRepo();
+    await vfs.rm('/project/a.txt');
+
+    const result = await git.execute(['diff'], '/project');
+
+    expect(result.stdout).toContain('diff --git a/a.txt b/a.txt');
+    expect(result.stdout).toContain('-alpha');
+  });
+
+  it('lists modified files in path order', async () => {
+    await seedRepo();
+    await vfs.writeFile('/project/a.txt', 'alpha\nadded\n');
+    await vfs.writeFile('/project/b.txt', 'bravo\nadded\n');
+    await vfs.writeFile('/project/src/c.txt', 'charlie\nadded\n');
+
+    const result = await git.execute(['diff', '--name-only'], '/project');
+
+    expect(result.stdout).toBe('a.txt\nb.txt\nsrc/c.txt\n');
+  });
+
+  it('reads no blobs for --staged when the index matches HEAD', async () => {
+    await seedRepo();
+
+    const io = trackIo();
+    const result = await git.execute(['diff', '--staged'], '/project');
+
+    expect(result.stdout).toBe('');
+    expect(await io.blobReads(['alpha\n', 'bravo\n', 'charlie\n'])).toEqual([]);
+  });
+
+  it('reads only the changed pair for --staged', async () => {
+    await seedRepo();
+    await vfs.writeFile('/project/b.txt', 'bravo\nstaged\n');
+    await git.execute(['add', 'b.txt'], '/project');
+
+    const io = trackIo();
+    const result = await git.execute(['diff', '--staged'], '/project');
+
+    expect(result.stdout).toContain('+staged');
+    // The HEAD blob and the index blob for the one changed file, nothing else.
+    expect(await io.blobReads(['bravo\n', 'bravo\nstaged\n'])).toHaveLength(2);
+    expect(await io.blobReads(['alpha\n', 'charlie\n'])).toEqual([]);
+  });
+
+  it('reads no blobs for `diff HEAD` on a clean tree and skips .git', async () => {
+    await seedRepo();
+    await seedUntrackedTree();
+
+    const io = trackIo();
+    const result = await git.execute(['diff', 'HEAD'], '/project');
+
+    expect(result.stdout).toBe('');
+    expect(await io.blobReads(['alpha\n', 'bravo\n', 'charlie\n'])).toEqual([]);
+    expect(io.dirs().filter((p) => p.startsWith('/project/node_modules/'))).toEqual([]);
+    // The workdir walk stops at `.git` instead of crawling its contents; the
+    // `objects/` listings below come from revision resolution (#2713).
+    expect(
+      io.dirs().filter((p) => p.startsWith('/project/.git/') && !p.includes('/objects'))
+    ).toEqual([]);
+  });
+
+  it('still diffs HEAD against a modified workdir', async () => {
+    await seedRepo();
+    await vfs.writeFile('/project/src/c.txt', 'charlie\ndelta\n');
+
+    const result = await git.execute(['diff', 'HEAD'], '/project');
+
+    expect(result.stdout).toContain('diff --git a/src/c.txt b/src/c.txt');
+    expect(result.stdout).toContain('+delta');
+  });
+
+  it('reports a staged file in a directory that is absent from HEAD', async () => {
+    await seedRepo();
+    await vfs.mkdir('/project/fresh', { recursive: true });
+    await vfs.writeFile('/project/fresh/new.txt', 'fresh\n');
+    await git.execute(['add', 'fresh/new.txt'], '/project');
+
+    const result = await git.execute(['diff', 'HEAD', '--name-only'], '/project');
+
+    expect(result.stdout).toContain('fresh/new.txt');
+  });
+
+  it('prunes identical subtrees when diffing two commits', async () => {
+    await seedRepo();
+    await vfs.mkdir('/project/src/deep', { recursive: true });
+    await vfs.writeFile('/project/src/deep/d.txt', 'delta\n');
+    await git.execute(['add', 'src/deep/d.txt'], '/project');
+    await git.execute(['commit', '-m', 'deep'], '/project');
+    await vfs.writeFile('/project/a.txt', 'alpha\nsecond\n');
+    await git.execute(['add', 'a.txt'], '/project');
+    await git.execute(['commit', '-m', 'second'], '/project');
+    const isoFs = createIsomorphicGitFs(vfs);
+    const head = await isoGit.resolveRef({ fs: isoFs, dir: '/project', ref: 'HEAD' });
+    const deepTree = await isoGit.readTree({
+      fs: isoFs,
+      dir: '/project',
+      oid: head,
+      filepath: 'src/deep',
+    });
+
+    const io = trackIo();
+    const result = await git.execute(['diff', 'HEAD~1', 'HEAD', '--name-only'], '/project');
+
+    expect(result.stdout).toBe('a.txt\n');
+    // `src/` is byte-identical between the two commits, so the walk stops
+    // there: neither the tree below it nor any blob under it is read.
+    expect(io.objectReads().filter((p) => p.endsWith(oidPath(deepTree.oid)))).toEqual([]);
+    expect(await io.blobReads(['charlie\n', 'bravo\n', 'delta\n'])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`git -C /mnt/slicc diff` on a mounted host repo (3,549 tracked files, nothing
modified) never finished: **172,970 hostfs requests** — 108,355 `list
.git/objects/pack`, 61,288 `read` — 187 MB transferred, still running when the
benchmark's 600 s cap hit. The correct output is empty; native `git diff` takes
~30 ms. This makes the workdir/index comparison decide what changed from OIDs
before it reads any content, so a clean tree reads **zero blobs**.

## Root cause

`diffWorkdirChanges()` walked `STAGE()` collecting every index OID and then, for
**every** entry, unconditionally `readBlobText(stageOid)` (a pack object read:
loose probe → 404, `list objects/pack`, index lookup, delta resolution) **and**
`ctx.fs.readTextFile()` of the workdir file, comparing the decoded strings. No
stat/OID short-circuit, no pruning, sequential — so two round trips per tracked
file plus the pack lookups behind each one.

## What changed

`packages/webapp/src/git/commands/diff.ts`:

- **Index vs workdir** (`git diff`) now walks `STAGE()` + `WORKDIR({ refresh:
  false })` together. The workdir bytes are read **once** and hashed with
  `git.hashBlob`; the object store is touched only when that hash differs from
  the index OID. Unmodified files cost no object read at all. Hashing (rather
  than trusting the index stat cache) keeps the result byte-exact — a same-size,
  same-mtime edit still shows up.
- **Untracked subtrees are pruned** (`map` returns `null`), so `node_modules`
  and `.git` are never enumerated. `git diff HEAD` previously walked the entire
  `.git` directory.
- **`refresh: false`** on both workdir walks: a read-only diff must not rewrite
  the host repo's `.git/index` (#2708).
- **Pathspecs are applied before any I/O**, so `git diff -- <path>` costs what
  that path costs.
- `diff <rev> <rev>` **prunes subtrees that share a tree OID** instead of
  descending into identical directories.
- `--staged` / `diff --cached <rev>` already short-circuited on OID equality
  (verified by a new test); they now share one per-invocation isomorphic-git
  `cache` object with their blob reads instead of re-parsing pack indexes.
- Incidental fix: a tracked `.gitignore` (any path starting with `.git`) was
  skipped by both the workdir and the staged diff. Only `.git` itself is skipped
  now.

Unified-diff / `--stat` / `--name-only` rendering, deletion handling and the
binary decode path are unchanged; modified-file output is byte-identical. The
workdir walk visits siblings concurrently, so the collected changes are now
sorted by path (previously insertion order).

## Tests

New `packages/webapp/tests/git/git-diff-object-reads.test.ts` (13 tests) counts
filesystem work on an in-memory repo instead of only checking rendered output —
reads are attributed by path and blob reads identified by hashing known
contents, so legitimate tree reads can't mask a blob read:

- nothing modified → **zero** object reads (`diff`), zero blob reads
  (`--staged`, `diff HEAD`)
- one modified file → **exactly one** blob read, and it is that file's
- pathspec-excluded files are never read; untracked trees are never descended
- identical subtrees are not read when diffing two commits
- deletions, `.gitignore`, path ordering, staged-file-in-a-new-directory,
  modified `diff HEAD`

Reverting `diff.ts` to the previous implementation fails 5 of the 13.

Docs: new `### git diff never reads an unchanged blob` section in
`docs/shell-reference.md` (git subset), stating the OID-before-content invariant
for future diff variants.

## Verification

| command | result |
| --- | --- |
| `npm run lint` | pass (exit 0, 43 pre-existing warnings) |
| `npm run typecheck` | pass (exit 0, all 9 projects) |
| `npm run test` | 18,269 passed / 1 failed — `slicc-fs-module.test.ts` pyodide load times out at the 5 s default on this machine (passes with `--testTimeout=60000`); `wc-attach.test.ts` hook timeout under parallel load, passes in isolation. Neither imports `src/git/`. |
| `npx vitest run packages/webapp/tests/git` | 387 passed / 16 files |
| `npm run test:coverage:webapp` | pass (exit 0) — lines 84.34/84, statements 82.33/82, functions 82.22/82, branches 73.85/73; `diff.ts` itself 94.3% lines / 96.6% functions. Needed `--testTimeout=30000 --retry=2` locally: this machine runs far more workers than CI and times out unrelated suites (pyodide load, a `wc-attach` dynamic import). |
| `npm run build -w @slicc/webapp` | pass (exit 0); `check-first-load-size.mjs` OK (4959 kB across both graphs) |
| `node packages/dev-tools/tools/check-touched-exemptions.mjs` | pass (no debt lists) |
| `node packages/dev-tools/tools/check-doc-sizes.mjs` / `check-doc-refs.mjs` | pass |

## Left out

The remaining per-file cost is one workdir `lstat` + one read per tracked file
(~3.5k requests instead of ~173k). Eliding the read for stat-cache-clean files
is what `statusMatrix`/`WORKDIR().oid()` would buy, but it inherits git's racy
timestamp semantics; kept content-exact here on purpose. The pack-lookup
amplification behind each object read (#2712), the per-file index overhead
(#2709) and the CORS preflights (#2715) are separate issues with their own PRs.

Fixes #2719
