### PR TITLE
fix(webapp): long-press maximize for right-rail tool panels

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -476,13 +476,15 @@ gone from `<slicc-chatpane>`.
 
 Rail gestures: a click on a dock launcher opens/collapses its leaf
 (`wireWcSprinkles`' `slicc-dock-select`/`slicc-dock-collapse` listeners); a
-click-and-hold on a SPRINKLE launcher takes its surface into browser
-fullscreen. The dock emits `slicc-dock-select` BEFORE `slicc-dock-longpress`
+click-and-hold on a sprinkle or fixed tool-panel launcher (files / term /
+memory / monitor) takes its surface into browser fullscreen — the same
+placement gate keyboard `z` uses (`requestPlacedSurfaceFullscreen`). The dock
+emits `slicc-dock-select` BEFORE `slicc-dock-longpress`
 (`selectItem` inside `#handleChildLongpress`), so the select listener owns the
 one activation; the long-press listener only waits (bounded) for that
 activation's placement to land and then fullscreens it — never a second
-`manager.activate` (double-open race), and never against a parked
-(`display:none`) surface, where `requestFullscreen()` rejects.
+`manager.activate` / `placeSurface` (double-open race), and never against a
+parked (`display:none`) surface, where `requestFullscreen()` rejects.
 
 Drag-drop: every unlocked leaf reveals a `.dock-tree__tile-move` button on hover
 over its top-left corner; hovering another tile computes a `DropRegion`

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -478,7 +478,9 @@ Rail gestures: a click on a dock launcher opens/collapses its leaf
 (`wireWcSprinkles`' `slicc-dock-select`/`slicc-dock-collapse` listeners); a
 click-and-hold on a sprinkle or fixed tool-panel launcher (files / term /
 memory / monitor) takes its surface into browser fullscreen — the same
-placement gate keyboard `z` uses (`requestPlacedSurfaceFullscreen`). The dock
+placement gate keyboard `z` uses (`requestPlacedSurfaceFullscreen`, looked
+up from the live shell `frame` so the gesture still works after
+`panelizeShell` removes the dock-tree). The dock
 emits `slicc-dock-select` BEFORE `slicc-dock-longpress`
 (`selectItem` inside `#handleChildLongpress`), so the select listener owns the
 one activation; the long-press listener only waits (bounded) for that

--- a/packages/webapp/src/ui/wc/surface-fullscreen.ts
+++ b/packages/webapp/src/ui/wc/surface-fullscreen.ts
@@ -1,0 +1,28 @@
+/**
+ * Browser-fullscreen a dock-tree surface that is already placed (not parked).
+ *
+ * Shared by the keyboard `z` command (#2692) and the right-rail long-press
+ * gesture: both need the real Fullscreen API against a visible
+ * `[surface-id=…]` leaf. A parked surface is `display:none`, and
+ * `requestFullscreen()` on a hidden element rejects — so this returns `false`
+ * without trying when the leaf is still in `.dock-tree__parking`.
+ */
+
+/** Escape a surface id for a double-quoted attribute selector (jsdom lacks CSS.escape). */
+function quoteSurfaceId(id: string): string {
+  return id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Request browser fullscreen on the placed surface with `surfaceId`.
+ * @returns `true` if a placed surface was found and fullscreen was requested
+ *   (the promise may still reject — denial / gesture expiry is swallowed).
+ */
+export function requestPlacedSurfaceFullscreen(root: ParentNode, surfaceId: string): boolean {
+  const surface = root.querySelector<HTMLElement>(`[surface-id="${quoteSurfaceId(surfaceId)}"]`);
+  if (!surface || surface.closest('.dock-tree__parking')) return false;
+  void surface.requestFullscreen?.()?.catch(() => {
+    // Denied, unsupported, or the activation expired — the panel stays open.
+  });
+  return true;
+}

--- a/packages/webapp/src/ui/wc/surface-fullscreen.ts
+++ b/packages/webapp/src/ui/wc/surface-fullscreen.ts
@@ -1,17 +1,24 @@
 /**
- * Browser-fullscreen a dock-tree surface that is already placed (not parked).
+ * Browser-fullscreen a workbench surface that is already placed (not parked).
  *
  * Shared by the keyboard `z` command (#2692) and the right-rail long-press
  * gesture: both need the real Fullscreen API against a visible
  * `[surface-id=…]` leaf. A parked surface is `display:none`, and
  * `requestFullscreen()` on a hidden element rejects — so this returns `false`
- * without trying when the leaf is still in `.dock-tree__parking`.
+ * without trying when the leaf is still in dock-tree or layout parking.
+ *
+ * Callers must pass a **live** root that still contains the surface after
+ * `panelizeShell` reparents leaves into `<slicc-layout>` and removes the
+ * dock-tree — typically `refs.frame`, not the (then-detached) `refs.dockTree`.
  */
 
 /** Escape a surface id for a double-quoted attribute selector (jsdom lacks CSS.escape). */
 function quoteSurfaceId(id: string): string {
   return id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
+
+/** Dock-tree and panel-layout offstage hosts — both keep leaves `display:none`. */
+const PARKING_SELECTOR = '.dock-tree__parking, .slicc-layout__parking';
 
 /**
  * Request browser fullscreen on the placed surface with `surfaceId`.
@@ -20,7 +27,7 @@ function quoteSurfaceId(id: string): string {
  */
 export function requestPlacedSurfaceFullscreen(root: ParentNode, surfaceId: string): boolean {
   const surface = root.querySelector<HTMLElement>(`[surface-id="${quoteSurfaceId(surfaceId)}"]`);
-  if (!surface || surface.closest('.dock-tree__parking')) return false;
+  if (!surface || surface.closest(PARKING_SELECTOR)) return false;
   void surface.requestFullscreen?.()?.catch(() => {
     // Denied, unsupported, or the activation expired — the panel stays open.
   });

--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -359,9 +359,10 @@ function buildWorkbench(): {
  * and sprinkles) is owned entirely by `wireWcSprinkles`' own
  * `slicc-dock-select`/`slicc-dock-collapse`/`slicc-dock-longpress` listeners,
  * which compose leaves directly into the dock-tree (the long-press activates
- * a sprinkle THROUGH the manager and then fullscreens its placed surface —
- * fullscreen on an unplaced surface rejects, the element is `display:none`
- * in parking). This listener only defends the overlay carve-out.
+ * through the select path and then fullscreens the placed surface — sprinkle
+ * or tool panel — via `requestPlacedSurfaceFullscreen`; fullscreen on an
+ * unplaced surface rejects, the element is `display:none` in parking). This
+ * listener only defends the overlay carve-out.
  */
 function wireDockToWorkbench(dock: HTMLElement, overlaySurfaces: ReadonlySet<string>): void {
   dock.addEventListener('slicc-dock-select', (event) => {

--- a/packages/webapp/src/ui/wc/wc-shell.ts
+++ b/packages/webapp/src/ui/wc/wc-shell.ts
@@ -495,6 +495,7 @@ export function mountWcShell(root: HTMLElement, options: WcShellOptions): WcShel
     composer,
     inputCard,
     thread,
+    frame,
     dockTree,
     fileTree: tree,
     memoryHost,

--- a/packages/webapp/src/ui/wc/wc-shortcut-surfaces.ts
+++ b/packages/webapp/src/ui/wc/wc-shortcut-surfaces.ts
@@ -18,6 +18,7 @@
  * copy row on this screen".
  */
 
+import { requestPlacedSurfaceFullscreen } from './surface-fullscreen.js';
 import {
   type ShortcutComposerMeta,
   type ShortcutDock,
@@ -209,19 +210,12 @@ export function focusApproval(deps: ShortcutSurfaceDeps): void {
  * transient user activation, and the keystroke only counts as one while its
  * handler is still on the stack. A surface still parked (`display:none`)
  * would reject, so an unplaced one is left alone rather than made to fail.
+ * Placement gate + request live in {@link requestPlacedSurfaceFullscreen}.
  */
 export function zoomSurface(deps: ShortcutSurfaceDeps): void {
   const id = deps.dock.active;
   if (!id) return;
-  // CSS.escape is for identifiers and jsdom does not ship it, so escape for a
-  // double-quoted attribute selector by hand (a surface id can carry a colon:
-  // `sprinkle:name`).
-  const quoted = id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  const surface = deps.dockTree.querySelector<HTMLElement>(`[surface-id="${quoted}"]`);
-  if (!surface || surface.closest('.dock-tree__parking')) return;
-  void surface.requestFullscreen?.()?.catch(() => {
-    // Denied, unsupported, or the activation expired — the panel stays open.
-  });
+  requestPlacedSurfaceFullscreen(deps.dockTree, id);
 }
 
 /**

--- a/packages/webapp/src/ui/wc/wc-shortcut-surfaces.ts
+++ b/packages/webapp/src/ui/wc/wc-shortcut-surfaces.ts
@@ -43,7 +43,14 @@ export interface ShortcutSurfaceDeps {
   inputCard: HTMLElement;
   /** The transcript: approval cards and the copy row are rendered into it. */
   thread: HTMLElement;
-  /** The workbench tree, for the surface `zoom` fullscreens. */
+  /**
+   * Live shell frame that still contains workbench surfaces after
+   * `panelizeShell` replaces the dock-tree with `<slicc-layout>`. When
+   * omitted (unit harnesses that only mount a tree), {@link dockTree} is
+   * the lookup root instead.
+   */
+  frame?: ParentNode;
+  /** The workbench tree (classic layout); also the zoom fallback root. */
   dockTree: HTMLElement;
   /** The dock rail, read for which surface is open. */
   dock: { readonly active: string | null };
@@ -211,11 +218,13 @@ export function focusApproval(deps: ShortcutSurfaceDeps): void {
  * handler is still on the stack. A surface still parked (`display:none`)
  * would reject, so an unplaced one is left alone rather than made to fail.
  * Placement gate + request live in {@link requestPlacedSurfaceFullscreen}.
+ * Prefer `frame` over `dockTree` so panelized layouts (dock-tree removed)
+ * still resolve the live leaf.
  */
 export function zoomSurface(deps: ShortcutSurfaceDeps): void {
   const id = deps.dock.active;
   if (!id) return;
-  requestPlacedSurfaceFullscreen(deps.dockTree, id);
+  requestPlacedSurfaceFullscreen(deps.frame ?? deps.dockTree, id);
 }
 
 /**

--- a/packages/webapp/src/ui/wc/wc-sprinkles.ts
+++ b/packages/webapp/src/ui/wc/wc-sprinkles.ts
@@ -526,7 +526,11 @@ function wireRailLongPressFullscreen(refs: WcShellRefs): void {
     // leaf — only sprinkles and the four fixed tool panels do.
     if (sprinkleNameFromId(id) === null && !isToolPanelId(id)) return;
     const tryFullscreen = (framesLeft: number): void => {
-      if (requestPlacedSurfaceFullscreen(refs.dockTree, id)) return;
+      // Prefer `frame` over `dockTree`: with `panel-layouts` on, panelizeShell
+      // moves surfaces into `<slicc-layout>` and removes the dock-tree, so the
+      // detached tree never finds files/term/memory/monitor (or sprinkles).
+      // Fixture harnesses that omit `frame` fall back to the tree.
+      if (requestPlacedSurfaceFullscreen(refs.frame ?? refs.dockTree, id)) return;
       if (framesLeft <= 0) return;
       requestAnimationFrame(() => tryFullscreen(framesLeft - 1));
     };

--- a/packages/webapp/src/ui/wc/wc-sprinkles.ts
+++ b/packages/webapp/src/ui/wc/wc-sprinkles.ts
@@ -13,6 +13,7 @@ import type { SprinkleSendTarget } from '../../shell/sprinkle-manager-handle.js'
 import type { BootStageLogger } from '../boot/types.js';
 import type { OffscreenClient } from '../offscreen-client.js';
 import type { SprinkleAddOptions, SprinkleManagerCallbacks } from '../sprinkle-manager.js';
+import { requestPlacedSurfaceFullscreen } from './surface-fullscreen.js';
 import type { WcShellRefs } from './wc-shell.js';
 import { defaultRootOf } from './wc-unit-context.js';
 
@@ -491,20 +492,24 @@ export interface WcSprinklesHandle {
 /**
  * Frame budget for the long-press placement wait: ~3s at 60Hz — generous
  * headroom for a cold sprinkle `open()` (VFS read) while staying inside the
- * ~5s transient-user-activation window `requestFullscreen` needs.
+ * ~5s transient-user-activation window `requestFullscreen` needs. Tool-panel
+ * placement is sync, but the same budget covers both so the gesture stays one
+ * path.
  */
 const LONGPRESS_PLACEMENT_FRAMES = 180;
 
 /**
- * Click-and-hold on a sprinkle launcher: its surface goes into BROWSER
- * fullscreen (the real Fullscreen API — the long-press release is the user
- * gesture that authorizes it; Esc / the UA chrome exits natively).
+ * Click-and-hold on a right-rail launcher (sprinkle or fixed tool panel): its
+ * surface goes into BROWSER fullscreen (the real Fullscreen API — the
+ * long-press release is the user gesture that authorizes it; Esc / the UA
+ * chrome exits natively). Same placement gate as keyboard `z`
+ * ({@link requestPlacedSurfaceFullscreen}).
  *
- * This handler does NOT activate the sprinkle itself: the dock's
+ * This handler does NOT activate the surface itself: the dock's
  * `#handleChildLongpress` calls `selectItem(id)` — emitting
  * `slicc-dock-select` — BEFORE re-emitting the long-press, so the select
- * listener above has already started `manager.activate`. Starting a second
- * activation here would race two `open()` calls into competing
+ * listener above has already started `manager.activate` / `placeSurface`.
+ * Starting a second activation here would race two opens into competing
  * containers/renderers. Instead, poll (bounded) until the activation's
  * placement lands in the dock-tree, then fullscreen: a not-yet-placed
  * surface sits parked at `display:none`, and `requestFullscreen()` on a
@@ -513,22 +518,15 @@ const LONGPRESS_PLACEMENT_FRAMES = 180;
  * outlives the frame budget (or the element denies fullscreen), the surface
  * stays open in the tree, just not fullscreen.
  */
-function wireSprinkleLongPressFullscreen(refs: WcShellRefs): void {
+function wireRailLongPressFullscreen(refs: WcShellRefs): void {
   refs.dock.addEventListener('slicc-dock-longpress', (event) => {
     const id = (event as CustomEvent<{ id?: string }>).detail?.id;
-    if (!id || sprinkleNameFromId(id) === null) return;
-    // Escape for a double-quoted attribute selector (CSS.escape is for
-    // identifiers, and jsdom lacks it).
-    const quoted = id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    if (!id) return;
+    // Overlay launchers (e.g. browser/tab switcher) never place a dock-tree
+    // leaf — only sprinkles and the four fixed tool panels do.
+    if (sprinkleNameFromId(id) === null && !isToolPanelId(id)) return;
     const tryFullscreen = (framesLeft: number): void => {
-      const surface = refs.dockTree.querySelector<HTMLElement>(`[surface-id="${quoted}"]`);
-      const placed = surface && !surface.closest('.dock-tree__parking');
-      if (placed) {
-        void surface.requestFullscreen?.()?.catch(() => {
-          // Denied / unsupported / gesture expired — the surface stays open.
-        });
-        return;
-      }
+      if (requestPlacedSurfaceFullscreen(refs.dockTree, id)) return;
       if (framesLeft <= 0) return;
       requestAnimationFrame(() => tryFullscreen(framesLeft - 1));
     };
@@ -655,7 +653,7 @@ export async function wireWcSprinkles(deps: WireWcSprinklesDeps): Promise<WcSpri
     const name = sprinkleNameFromId(id);
     if (name) manager.minimize(name);
   });
-  wireSprinkleLongPressFullscreen(refs);
+  wireRailLongPressFullscreen(refs);
 
   let enriching = false;
   const resync = async (): Promise<void> => {

--- a/packages/webapp/tests/ui/wc/surface-fullscreen.test.ts
+++ b/packages/webapp/tests/ui/wc/surface-fullscreen.test.ts
@@ -42,6 +42,21 @@ describe('requestPlacedSurfaceFullscreen', () => {
     expect(requestFullscreen).not.toHaveBeenCalled();
   });
 
+  it('treats slicc-layout parking the same as dock-tree parking', () => {
+    const root = document.createElement('div');
+    const parking = document.createElement('div');
+    parking.className = 'slicc-layout__parking';
+    const surface = document.createElement('div');
+    surface.setAttribute('surface-id', 'files');
+    const requestFullscreen = vi.fn(() => Promise.resolve());
+    Object.assign(surface, { requestFullscreen });
+    parking.appendChild(surface);
+    root.appendChild(parking);
+
+    expect(requestPlacedSurfaceFullscreen(root, 'files')).toBe(false);
+    expect(requestFullscreen).not.toHaveBeenCalled();
+  });
+
   it('returns false when the surface is missing', () => {
     expect(requestPlacedSurfaceFullscreen(document.createElement('div'), 'memory')).toBe(false);
   });

--- a/packages/webapp/tests/ui/wc/surface-fullscreen.test.ts
+++ b/packages/webapp/tests/ui/wc/surface-fullscreen.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { requestPlacedSurfaceFullscreen } from '../../../src/ui/wc/surface-fullscreen.js';
+
+describe('requestPlacedSurfaceFullscreen', () => {
+  it('requests fullscreen on a placed surface', () => {
+    const root = document.createElement('div');
+    const surface = document.createElement('div');
+    surface.setAttribute('surface-id', 'files');
+    const requestFullscreen = vi.fn(() => Promise.resolve());
+    Object.assign(surface, { requestFullscreen });
+    root.appendChild(surface);
+
+    expect(requestPlacedSurfaceFullscreen(root, 'files')).toBe(true);
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it('escapes colon-bearing sprinkle ids in the attribute selector', () => {
+    const root = document.createElement('div');
+    const surface = document.createElement('div');
+    surface.setAttribute('surface-id', 'sprinkle:notes');
+    const requestFullscreen = vi.fn(() => Promise.resolve());
+    Object.assign(surface, { requestFullscreen });
+    root.appendChild(surface);
+
+    expect(requestPlacedSurfaceFullscreen(root, 'sprinkle:notes')).toBe(true);
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false and does not request fullscreen for a parked surface', () => {
+    const root = document.createElement('div');
+    const parking = document.createElement('div');
+    parking.className = 'dock-tree__parking';
+    const surface = document.createElement('div');
+    surface.setAttribute('surface-id', 'term');
+    const requestFullscreen = vi.fn(() => Promise.resolve());
+    Object.assign(surface, { requestFullscreen });
+    parking.appendChild(surface);
+    root.appendChild(parking);
+
+    expect(requestPlacedSurfaceFullscreen(root, 'term')).toBe(false);
+    expect(requestFullscreen).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the surface is missing', () => {
+    expect(requestPlacedSurfaceFullscreen(document.createElement('div'), 'memory')).toBe(false);
+  });
+
+  it('swallows a rejected requestFullscreen promise', () => {
+    const root = document.createElement('div');
+    const surface = document.createElement('div');
+    surface.setAttribute('surface-id', 'monitor');
+    Object.assign(surface, {
+      requestFullscreen: vi.fn(() => Promise.reject(new Error('denied'))),
+    });
+    root.appendChild(surface);
+
+    expect(() => requestPlacedSurfaceFullscreen(root, 'monitor')).not.toThrow();
+  });
+});

--- a/packages/webapp/tests/ui/wc/wc-shortcut-surfaces.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-shortcut-surfaces.test.ts
@@ -235,6 +235,21 @@ describe('zoomSurface', () => {
     expect(requestFullscreen).toHaveBeenCalledTimes(1);
   });
 
+  it('resolves surfaces from the live frame when the dock-tree has been detached', () => {
+    // Mirrors panelizeShell: surfaces live under the frame's layout; dockTree
+    // is no longer in the document.
+    const { deps, dockTree } = harness({ activeDock: 'term' });
+    const frame = document.createElement('div');
+    const layout = document.createElement('div');
+    const { requestFullscreen } = surface(layout, 'term');
+    frame.append(layout);
+    document.body.append(frame);
+    dockTree.remove();
+    deps.frame = frame;
+    zoomSurface(deps);
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+  });
+
   it('escapes an id with a colon in it, as every sprinkle has', () => {
     const { deps, dockTree } = harness({ activeDock: 'sprinkle:notes' });
     const { requestFullscreen } = surface(dockTree, 'sprinkle:notes');

--- a/packages/webapp/tests/ui/wc/wc-sprinkles.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-sprinkles.test.ts
@@ -52,12 +52,15 @@ function makeDockTreeRef(tilesMovable = false) {
 }
 
 function makeRefs(tilesMovable = false): WcShellRefs {
+  const frame = document.createElement('div');
+  frame.className = 'wcui-frame';
   const shell = document.createElement('slicc-shell');
   const dockTree = makeDockTreeRef(tilesMovable);
   const dock = document.createElement('slicc-dock') as WcShellRefs['dock'];
   shell.append(dockTree, dock);
-  document.body.append(shell);
-  return { shell, dockTree, dock } as unknown as WcShellRefs;
+  frame.append(shell);
+  document.body.append(frame);
+  return { frame, shell, dockTree, dock } as unknown as WcShellRefs;
 }
 
 function dockIds(refs: WcShellRefs): string[] {
@@ -722,6 +725,47 @@ describe('WcSprinkleZone / wireWcSprinkles tool panels (independent leaves)', ()
 
     expect(treeSpies(refs).placeSurface).toHaveBeenCalledTimes(1);
     expect(treeSpies(refs).placeSurface).toHaveBeenCalledWith('term', DEFAULT_TOOL_ZONE);
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it('a dock long-press finds tool panels via the live frame after the dock-tree is detached (panelize)', async () => {
+    // panelizeShell moves surfaces into <slicc-layout> and replaceWith-removes
+    // the shell (and its dock-tree). Looking only at refs.dockTree then never
+    // finds files/term — the review finding on this PR.
+    const refs = makeRefs();
+    const fs = {
+      exists: async () => false,
+      async *walk(): AsyncGenerator<string> {
+        /* empty */
+      },
+      readFile: async () => '',
+    } as unknown as VirtualFS;
+    const client = {
+      sendSprinkleLick: () => {},
+      getScoops: () => [],
+      stopScoop: () => {},
+    } as unknown as OffscreenClient;
+    const log = { info() {}, warn() {}, error() {}, debug() {} } as unknown as BootStageLogger;
+    await wireWcSprinkles({ refs, client, fs, log });
+
+    const layout = document.createElement('div');
+    layout.className = 'slicc-layout';
+    const surface = document.createElement('div');
+    surface.setAttribute('surface-id', 'files');
+    const requestFullscreen = vi.fn(() => Promise.resolve());
+    Object.assign(surface, { requestFullscreen });
+    layout.appendChild(surface);
+    refs.frame.appendChild(layout);
+    // Detach the classic tree the way panelizeShell does via replaceWith.
+    (refs.dockTree as unknown as HTMLElement).remove();
+
+    refs.dock.dispatchEvent(
+      new CustomEvent('slicc-dock-longpress', { detail: { id: 'files' }, bubbles: true })
+    );
+    for (let i = 0; i < 3; i++) {
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+    }
+
     expect(requestFullscreen).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/webapp/tests/ui/wc/wc-sprinkles.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-sprinkles.test.ts
@@ -678,6 +678,53 @@ describe('WcSprinkleZone / wireWcSprinkles tool panels (independent leaves)', ()
     expect(requestFullscreen).toHaveBeenCalledTimes(1);
   });
 
+  it('a dock long-press fullscreens a fixed tool panel after select places it', async () => {
+    // Tool panels ride the same long-press → fullscreen path as sprinkles
+    // (stacked on keyboard `z` / requestPlacedSurfaceFullscreen from #2692).
+    // Select places via zone.placeSurface; long-press must NOT place again —
+    // it only waits for the leaf and fullscreens.
+    const refs = makeRefs();
+    const fs = {
+      exists: async () => false,
+      async *walk(): AsyncGenerator<string> {
+        /* empty */
+      },
+      readFile: async () => '',
+    } as unknown as VirtualFS;
+    const client = {
+      sendSprinkleLick: () => {},
+      getScoops: () => [],
+      stopScoop: () => {},
+    } as unknown as OffscreenClient;
+    const log = { info() {}, warn() {}, error() {}, debug() {} } as unknown as BootStageLogger;
+    await wireWcSprinkles({ refs, client, fs, log });
+
+    const surface = document.createElement('div');
+    surface.setAttribute('surface-id', 'term');
+    const requestFullscreen = vi.fn(() => Promise.resolve());
+    Object.assign(surface, { requestFullscreen });
+    // Model placeSurface landing the leaf on the next frame (select owns it).
+    treeSpies(refs).placeSurface.mockImplementation(() => {
+      requestAnimationFrame(() => {
+        (refs.dockTree as unknown as HTMLElement).appendChild(surface);
+      });
+    });
+
+    refs.dock.dispatchEvent(
+      new CustomEvent('slicc-dock-select', { detail: { id: 'term' }, bubbles: true })
+    );
+    refs.dock.dispatchEvent(
+      new CustomEvent('slicc-dock-longpress', { detail: { id: 'term' }, bubbles: true })
+    );
+    for (let i = 0; i < 4; i++) {
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+    }
+
+    expect(treeSpies(refs).placeSurface).toHaveBeenCalledTimes(1);
+    expect(treeSpies(refs).placeSurface).toHaveBeenCalledWith('term', DEFAULT_TOOL_ZONE);
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+  });
+
   it('a dock long-press never fullscreens a surface that stays PARKED (placement is the gate)', async () => {
     const refs = makeRefs();
     const fs = {


### PR DESCRIPTION
<!-- Stacked on / follow-up to: Stacked on top of #2692 (keyboard map v2 / zoomSurface). Already merged. -->

## Summary

Right-rail long-press only fullscreened sprinkle launchers; fixed tool panels (files / term / memory / monitor) opened but never maximized. They now share the same browser-fullscreen path as sprinkles and keyboard `z`.

## Why

Long-press maximize felt broken for the top of the right rail. Keyboard map v2 (#2692) already fullscreens any active surface via `z`; the dock gesture still gated on sprinkle ids only (`sprinkleNameFromId(id) === null` → return).

**Repro**
1. Open SLICC, long-press Terminal (or Files / Memory / Monitor) on the right rail.
2. Expected: panel opens and enters browser fullscreen.
3. Actual: panel opens (or toggles) but never fullscreens.

## Approach / Implementation notes

- Extracted `requestPlacedSurfaceFullscreen` from the #2692 `zoomSurface` placement gate so keyboard and rail long-press cannot drift.
- `wireRailLongPressFullscreen` now accepts sprinkle **or** `isToolPanelId` launchers; select still owns open/`placeSurface`; long-press only waits (bounded) then fullscreens.
- Overlay launchers (e.g. browser/tab switcher) stay excluded — they never place a dock-tree leaf.

## Cross-cutting impact

- **Floats exercised**: webapp dock-tree path (CLI / hosted leader / extension panel). No follower, Electron, or iOS changes.
- **Other callers**: `zoomSurface` now delegates to the shared helper — behavior unchanged (same parked check + swallowed rejection).
- **Persisted state**: none — fullscreen is ephemeral UA state.
- **Bundle size**: tiny pure helper; no new deps.

## Test plan

- [x] `npm run verify`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size`
- [x] Unit tests: `packages/webapp/tests/ui/wc/surface-fullscreen.test.ts`, tool-panel long-press case in `wc-sprinkles.test.ts`, existing `zoomSurface` cases still pass
- [ ] Manual smoke: long-press term/files/memory/monitor → fullscreen; long-press sprinkle still works; `z` still works; Esc exits

## Documentation

- [x] `docs/layouts.md` (rail gesture wording)
- [ ] README / CLAUDE.md — N/A (developer/agent detail only)

## Risk & rollback

- Low blast radius: UI gesture wiring only; fullscreen failures still leave the panel open.
- Roll back by reverting this PR.
- CI cannot prove real Fullscreen API gesture timing in a browser — manual smoke recommended.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff

Made with [Cursor](https://cursor.com)