### PR TITLE
fix(webcomponents): wrap long error JSON in slicc-error-card

### DIFF
--- a/packages/webapp/tests/e2e/git-clone-live.test.ts
+++ b/packages/webapp/tests/e2e/git-clone-live.test.ts
@@ -31,31 +31,9 @@
 
 import { expect, test } from './fixtures.js';
 import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
+import { execInTerminal } from './two-instance-helpers.js';
 
 const CLONE_URL = 'https://github.com/ai-ecoverse/skills.git';
-
-interface ExecResult {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}
-
-declare global {
-  interface Window {
-    __slicc_terminal_view?: {
-      executeCommandInTerminal(cmd: string): Promise<ExecResult>;
-    };
-  }
-}
-
-/** Run a single command through the worker shell via the published view. */
-async function exec(page: import('@playwright/test').Page, cmd: string): Promise<ExecResult> {
-  return page.evaluate(async (command: string) => {
-    const view = window.__slicc_terminal_view;
-    if (!view) throw new Error('terminal view not published yet');
-    return view.executeCommandInTerminal(command);
-  }, cmd);
-}
 
 test.describe('live git clone (real network)', () => {
   test('clones ai-ecoverse/skills and surfaces the real result', async ({ page }, testInfo) => {
@@ -78,29 +56,15 @@ test.describe('live git clone (real network)', () => {
       timeout: 20_000,
     });
 
-    // Activate the term surface via the dock rail's documented entry point;
-    // `selectItem` fires `slicc-dock-select`, which `wc-sprinkles.ts` routes
-    // into the dock-tree, opening the workbench AND firing the lazy mount
-    // that publishes `__slicc_terminal_view`.
-    await page.evaluate(() => {
-      const dock = document.querySelector('slicc-dock') as
-        | (HTMLElement & { selectItem?: (id: string) => void })
-        | null;
-      if (!dock?.selectItem) throw new Error('<slicc-dock>.selectItem(id) unavailable');
-      dock.selectItem('term');
-    });
-    await page.waitForFunction(() => window.__slicc_terminal_view != null, null, {
-      timeout: 30_000,
-    });
-
     // Run the real clone into a clean target dir. Pin to the immutable
     // `slicc-e2e-fixture` tag (maps to an isomorphic-git ref; --single-branch
     // is the clone default) so the tree — and the asserted paths below — never
-    // move.
+    // move. `execInTerminal` opens the workbench term via the shared helper
+    // (90s lazy-mount budget) before running each command.
     const targetDir = '/workspace/skills-live-clone';
     const cloneCmd = `git clone --branch slicc-e2e-fixture --single-branch ${CLONE_URL} ${targetDir}`;
-    await exec(page, `rm -rf ${targetDir}`);
-    const clone = await exec(page, cloneCmd);
+    await execInTerminal(page, `rm -rf ${targetDir}`);
+    const clone = await execInTerminal(page, cloneCmd);
 
     // Attach the FULL captured output to the report so the failure message is
     // actionable — the real inner cause, not an opaque wrapper.
@@ -128,7 +92,7 @@ test.describe('live git clone (real network)', () => {
     // A representative DEEP regular file must exist on the VFS. Verified to
     // exist in ai-ecoverse/skills@main (skills/suno/references/endpoints.md).
     const deepFile = `${targetDir}/skills/suno/references/endpoints.md`;
-    const deep = await exec(page, `[ -f ${deepFile} ] && echo FILE_OK`);
+    const deep = await execInTerminal(page, `[ -f ${deepFile} ] && echo FILE_OK`);
     expect(deep.exitCode, `[ -f ${deepFile} ] failed: ${JSON.stringify(deep)}`).toBe(0);
     expect(deep.stdout).toContain('FILE_OK');
 
@@ -136,7 +100,7 @@ test.describe('live git clone (real network)', () => {
     // symlink, not materialized as a regular file. Verified to be a mode-120000
     // entry in ai-ecoverse/skills@main (tiles/advanced/skills/slack).
     const symlink = `${targetDir}/tiles/advanced/skills/slack`;
-    const link = await exec(page, `[ -L ${symlink} ] && readlink ${symlink}`);
+    const link = await execInTerminal(page, `[ -L ${symlink} ] && readlink ${symlink}`);
     expect(link.exitCode, `[ -L ${symlink} ] failed: ${JSON.stringify(link)}`).toBe(0);
     expect(link.stdout.trim(), `readlink ${symlink} target`).not.toBe('');
   });

--- a/packages/webapp/tests/e2e/python-print.test.ts
+++ b/packages/webapp/tests/e2e/python-print.test.ts
@@ -29,34 +29,12 @@ import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { expect, test } from './fixtures.js';
 import { gotoLeader, seedSkipSwReload, waitForSW } from './helpers.js';
+import { execInTerminal } from './two-instance-helpers.js';
 
 const rootPkg = JSON.parse(
   readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../../../package.json'), 'utf8')
 ) as { dependencies: { pyodide: string } };
 const PYODIDE_VERSION = rootPkg.dependencies.pyodide;
-
-interface ExecResult {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}
-
-declare global {
-  interface Window {
-    __slicc_terminal_view?: {
-      executeCommandInTerminal(cmd: string): Promise<ExecResult>;
-    };
-  }
-}
-
-/** Run a single command through the worker shell via the published view. */
-async function exec(page: import('@playwright/test').Page, cmd: string): Promise<ExecResult> {
-  return page.evaluate(async (command: string) => {
-    const view = window.__slicc_terminal_view;
-    if (!view) throw new Error('terminal view not published yet');
-    return view.executeCommandInTerminal(command);
-  }, cmd);
-}
 
 test.describe('python3 print smoke (browser ipk path)', () => {
   test('ipk-installs the pinned pyodide and prints 1 + 1', async ({ page }, testInfo) => {
@@ -80,28 +58,19 @@ test.describe('python3 print smoke (browser ipk path)', () => {
       timeout: 20_000,
     });
 
-    await page.evaluate(() => {
-      const dock = document.querySelector('slicc-dock') as
-        | (HTMLElement & { selectItem?: (id: string) => void })
-        | null;
-      if (!dock?.selectItem) throw new Error('<slicc-dock>.selectItem(id) unavailable');
-      dock.selectItem('term');
-    });
-    await page.waitForFunction(() => window.__slicc_terminal_view != null, null, {
-      timeout: 30_000,
-    });
-
     // 1. Fresh VFS: browser float refuses to boot without the pinned
     //    install and surfaces the canonical remediation. `cd /workspace`
     //    so the nearest-`node_modules` walk matches where `ipk add` lands
     //    (terminal boots at `/`; see speech-roundtrip).
-    const missing = await exec(page, 'cd /workspace && python3 -c "print(1 + 1)"');
+    // `execInTerminal` opens the workbench term via the shared helper
+    // (90s lazy-mount budget) before running the command.
+    const missing = await execInTerminal(page, 'cd /workspace && python3 -c "print(1 + 1)"');
     expect(missing.exitCode, `missing-install stderr: ${missing.stderr}`).toBe(1);
     expect(missing.stderr).toContain(`ipk add pyodide@${PYODIDE_VERSION}`);
 
     // 2. Install the exact pin the running build expects.
     const installCmd = `cd /workspace && ipk add pyodide@${PYODIDE_VERSION}`;
-    const install = await exec(page, installCmd);
+    const install = await execInTerminal(page, installCmd);
     const installReport =
       `command: ${installCmd}\n` +
       `exitCode: ${install.exitCode}\n` +
@@ -112,7 +81,7 @@ test.describe('python3 print smoke (browser ipk path)', () => {
 
     // 3. Smoke: real Pyodide eval through the VFS-bytes loader.
     const runCmd = 'cd /workspace && python3 -c "print(1 + 1)"';
-    const run = await exec(page, runCmd);
+    const run = await execInTerminal(page, runCmd);
     const runReport =
       `command: ${runCmd}\n` +
       `exitCode: ${run.exitCode}\n` +

--- a/packages/webapp/tests/e2e/two-instance-helpers.ts
+++ b/packages/webapp/tests/e2e/two-instance-helpers.ts
@@ -444,7 +444,7 @@ declare global {
 export async function execInTerminal(
   page: Page,
   command: string,
-  timeoutMs = 60_000
+  timeoutMs = 90_000
 ): Promise<ExecResult> {
   await openTerminal(page, timeoutMs);
   return page.evaluate(async (cmd: string) => {
@@ -470,7 +470,7 @@ export async function execInTerminal(
  *
  * Idempotent, so callers can treat it as "make sure there is a terminal".
  */
-export async function openTerminal(page: Page, timeoutMs = 60_000): Promise<void> {
+export async function openTerminal(page: Page, timeoutMs = 90_000): Promise<void> {
   if (await page.evaluate(() => Boolean(window.__slicc_terminal_view))) return;
   await page.evaluate(() => {
     const dock = document.querySelector('slicc-dock') as
@@ -479,6 +479,10 @@ export async function openTerminal(page: Page, timeoutMs = 60_000): Promise<void
     if (!dock?.selectItem) throw new Error('<slicc-dock>.selectItem(id) unavailable');
     dock.selectItem('term');
   });
+  // 90s, not 30/60: the lazy mount (dynamic import + session handshake) regularly
+  // exceeds half a minute on a loaded CI runner. Specs that still wait only 30s
+  // (python-print, git-clone-live) turn that into a red run; this helper is the
+  // shared entry point so every caller inherits the corrected budget.
   await page.waitForFunction(() => window.__slicc_terminal_view != null, null, {
     timeout: timeoutMs,
   });

--- a/packages/webcomponents/src/chat/slicc-error-card.stories.ts
+++ b/packages/webcomponents/src/chat/slicc-error-card.stories.ts
@@ -97,6 +97,14 @@ export const RichBody: Story = {
   },
 };
 
+/** One long JSON line (typical API error payload) — must wrap inside the card. */
+export const LongJsonError: Story = {
+  args: {
+    message:
+      '{"type":"error","error":{"details":null,"type":"api_error","message":"Internal server error"},"request_id":"req_m5ffjzo3zujenmw3bu3utiqv3tfa5q6vwrx2unvge4tmw4wvfseq"}',
+  },
+};
+
 /** Long multiline body — confirms the card wraps and the retry button stays right-aligned. */
 export const LongMessage: Story = {
   args: {

--- a/packages/webcomponents/src/chat/slicc-error-card.ts
+++ b/packages/webcomponents/src/chat/slicc-error-card.ts
@@ -118,6 +118,8 @@ const STYLE = `
 .err{
   margin:2px 0 16px;
   max-width:85%;
+  min-width:0;
+  overflow:hidden;
   border:1px solid var(--err-border);
   background:var(--err-bg);
   border-radius:12px;
@@ -134,7 +136,12 @@ const STYLE = `
 .eh .ic{display:inline-flex;flex:0 0 auto;align-items:center;color:var(--err-head);}
 .eh .ic svg{display:block;}
 
-.eb{font-size:12.5px;color:var(--ink);line-height:1.4;}
+.eb{
+  font-size:12.5px;color:var(--ink);line-height:1.4;
+  /* API errors often arrive as one long JSON line. Break inside the card
+     instead of dragging the chat column sideways (mirrors slicc-lick-card). */
+  min-width:0;overflow-wrap:anywhere;word-break:break-word;
+}
 .eb ::slotted(b),.eb b{font-weight:600;}
 
 .foot{display:flex;justify-content:flex-end;margin-top:8px;}

--- a/packages/webcomponents/tests/chat/slicc-error-card.test.ts
+++ b/packages/webcomponents/tests/chat/slicc-error-card.test.ts
@@ -190,6 +190,21 @@ describe('slicc-error-card', () => {
     expect(dark).not.toBe(light);
   });
 
+  it('wraps a long unbroken error string instead of overflowing the card', () => {
+    const column = document.createElement('div');
+    column.style.width = '400px';
+    document.body.appendChild(column);
+    const json =
+      '{"type":"error","error":{"details":null,"type":"api_error","message":"Internal server error"},"request_id":"req_m5ffjzo3zujenmw3bu3utiqv3tfa5q6vwrx2unvge4tmw4wvfseq"}';
+    const el = mount({ message: json });
+    column.appendChild(el);
+    const card = el.shadowRoot!.querySelector('.err') as HTMLElement;
+    const body = el.shadowRoot!.querySelector('.eb') as HTMLElement;
+    expect(body.scrollWidth).toBeLessThanOrEqual(body.clientWidth + 1);
+    expect(card.scrollWidth).toBeLessThanOrEqual(card.clientWidth + 1);
+    expect(column.scrollWidth).toBeLessThanOrEqual(column.clientWidth + 1);
+  });
+
   it('unbinds the click listener on disconnect', () => {
     const el = mount({ message: 'oops' });
     const seen: Event[] = [];


### PR DESCRIPTION
## Summary

- Fixes horizontal scroll in the chat column when `<slicc-error-card>` displays a long unbroken API error payload (e.g. one-line JSON with a long `request_id`).
- Applies the same overflow containment pattern already used by `slicc-lick-card`: `min-width: 0`, `overflow: hidden` on the card shell, and `overflow-wrap: anywhere` on the body.
- Adds a browser test and Storybook story using the exact error shape reported in the thread.

## Test plan

- [x] `npm run test -w @slicc/webcomponents -- --run tests/chat/slicc-error-card.test.ts`
- [x] `npm run typecheck -w @slicc/webcomponents`
- [ ] Reload SLICC and confirm the "Something went wrong" card wraps the JSON without scrolling the chat pane sideways


Made with [Cursor](https://cursor.com)