### PR TITLE
fix(webapp): make sprinkle text fields and the subtle palette theme-aware

### DIFF
--- a/packages/vfs-root/workspace/skills/sprinkles/style-guide.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/style-guide.md
@@ -801,6 +801,8 @@ background: color-mix(in srgb, var(--s2-notice) 10%, transparent); /* amber tint
 background: color-mix(in srgb, var(--s2-accent) 6%, transparent); /* blue tint */
 ```
 
+The badge/icon fills also expose theme-aware `--uxc-<hue>-subtle-bg` / `--uxc-<hue>-subtle-text` pairs (`yellow`, `purple`, `cyan`, `magenta`, `indigo`, `gray`, `positive`, `notice`, `negative`, `accent`). Always use a `-bg` with its matching `-text`: each pair is contrast-checked as a pair in both themes.
+
 ### Shadows
 
 | Token                   | Usage                   |

--- a/packages/webapp/src/ui/styles/sprinkle-components.css
+++ b/packages/webapp/src/ui/styles/sprinkle-components.css
@@ -199,7 +199,8 @@
   background: var(--s2-accent);
   color: #fff; /* Fixed white: gray-25 inverts to dark in dark mode, failing AA on blue (3.60) */
 }
-/* Subtle fills — Figma pastel backgrounds with dark text */
+/* Subtle fills — theme-aware token pairs (pastel + dark text in light mode,
+   desaturated dark fill + light text in dark mode) */
 .sprinkle-badge--subtle {
   background: var(--uxc-neutral-subtle-bg);
   color: var(--s2-gray-700);
@@ -224,7 +225,7 @@
   background: var(--uxc-accent-subtle-bg);
   color: var(--uxc-accent-subtle-text);
 }
-/* Color fills — Figma pastel palette (project badges in table) */
+/* Color fills — theme-aware hue palette (project badges in table) */
 .sprinkle-badge--yellow {
   background: var(--uxc-yellow-subtle-bg);
   color: var(--uxc-yellow-subtle-text);
@@ -283,12 +284,12 @@
   font-size: var(--s2-font-size-75);
   font-weight: 500;
   color: var(--s2-gray-800);
-  background: white;
+  background: var(--s2-bg-layer-1);
   cursor: default;
   transition: background var(--s2-transition-default);
 }
 .sprinkle-chip:hover {
-  background: var(--s2-gray-50);
+  background: var(--s2-gray-100);
 }
 .sprinkle-chip svg {
   width: 14px;
@@ -414,8 +415,8 @@
   flex-shrink: 0;
 }
 .sprinkle-action-card__icon--yellow {
-  background: #fff197;
-  color: #9e6600;
+  background: var(--uxc-yellow-subtle-bg);
+  color: var(--uxc-yellow-subtle-text);
 }
 .sprinkle-action-card__icon--blue {
   background: var(--uxc-accent-subtle-bg);
@@ -427,7 +428,7 @@
 }
 .sprinkle-action-card__icon--indigo {
   background: var(--uxc-indigo-subtle-bg);
-  color: #5424db;
+  color: var(--uxc-indigo-subtle-text);
 }
 /* Header meta (subtitle text) */
 .sprinkle-action-card__meta {
@@ -857,7 +858,7 @@ dl.sprinkle-kv-list dd:last-of-type {
   font-size: var(--s2-font-size-100);
   font-family: var(--s2-font-family);
   color: var(--s2-content-default);
-  background: white;
+  background: var(--s2-bg-layer-1);
   border: 1px solid var(--s2-gray-200);
   border-radius: var(--s2-radius-default);
   outline: none;
@@ -865,7 +866,7 @@ dl.sprinkle-kv-list dd:last-of-type {
   box-sizing: border-box;
 }
 .sprinkle-text-field::placeholder {
-  color: var(--s2-gray-600); /* Figma: #717171 */
+  color: var(--s2-content-secondary);
 }
 .sprinkle-text-field:hover {
   border-color: var(--s2-gray-700);

--- a/packages/webapp/src/ui/styles/tokens.css
+++ b/packages/webapp/src/ui/styles/tokens.css
@@ -136,28 +136,31 @@
   /* ── Header height ───────────────────────────────────────── */
   --s2-header-height: 56px;
 
-  /* ── UXC Subtle Fills (from Figma Alias/background/) ──── */
-  --uxc-yellow-subtle-bg: #fff197;
-  --uxc-yellow-subtle-text: #9e6600;
-  --uxc-purple-subtle-bg: #f4ebfc;
-  --uxc-purple-subtle-text: #9a47e2;
-  --uxc-cyan-subtle-bg: #d9f4fd;
-  --uxc-cyan-subtle-text: #0b78b3;
-  --uxc-magenta-subtle-bg: #ffe8f0;
-  --uxc-magenta-subtle-text: #d92361;
-  --uxc-indigo-subtle-bg: #ebeeff;
-  --uxc-indigo-subtle-text: #5424db;
-  --uxc-gray-subtle-bg: #efefef;
-  --uxc-gray-subtle-text: #292929;
-  --uxc-positive-subtle-bg: #d7f7e1;
-  --uxc-positive-subtle-text: #079355;
-  --uxc-notice-subtle-bg: #ffeccf;
-  --uxc-notice-subtle-text: #d45b00;
-  --uxc-negative-subtle-bg: #ffe8f0;
-  --uxc-negative-subtle-text: #d92361;
-  --uxc-accent-subtle-bg: #e5f0fe;
-  --uxc-accent-subtle-text: #3b63fb;
-  --uxc-neutral-subtle-bg: #f3f3f3;
+  /* ── UXC Subtle Fills (Dark) ───────────────────────────── */
+  /* Dark, desaturated fill + light hue text; every pair clears AA (>= 5:1).
+     The Figma pastels live in `:root.theme-light` — keep both sides in step,
+     `tests/ui/sprinkle-theme-tokens.test.ts` asserts parity and contrast. */
+  --uxc-yellow-subtle-bg: #2e2719;
+  --uxc-yellow-subtle-text: #df9b20;
+  --uxc-purple-subtle-bg: #24192e;
+  --uxc-purple-subtle-text: #b170e9;
+  --uxc-cyan-subtle-bg: #19272e;
+  --uxc-cyan-subtle-text: #209cdf;
+  --uxc-magenta-subtle-bg: #2e1920;
+  --uxc-magenta-subtle-text: #e5618e;
+  --uxc-indigo-subtle-bg: #1f192e;
+  --uxc-indigo-subtle-text: #977ae9;
+  --uxc-gray-subtle-bg: #292929;
+  --uxc-gray-subtle-text: #cfcfcf;
+  --uxc-positive-subtle-bg: #192e25;
+  --uxc-positive-subtle-text: #20df8a;
+  --uxc-notice-subtle-bg: #2e2219;
+  --uxc-notice-subtle-text: #e07829;
+  --uxc-negative-subtle-bg: #2e1920;
+  --uxc-negative-subtle-text: #e5618e;
+  --uxc-accent-subtle-bg: #191d2e;
+  --uxc-accent-subtle-text: #6d87ea;
+  --uxc-neutral-subtle-bg: #252525;
 
   /* ── UXC Layout ────────────────────────────────────────── */
   --uxc-nav-rail-width: 58px;
@@ -206,6 +209,31 @@
   --s2-negative: #d92361;
   --s2-positive: #05834e;
   --s2-notice: #d45b00;
+
+  /* ── UXC Subtle Fills (Light — from Figma Alias/background/) ── */
+  /* Figma pastel fills; text darkened from the raw Figma hues so each pair
+     clears AA (the shipped values measured 3.4–4.2:1 against these fills). */
+  --uxc-yellow-subtle-bg: #fff197;
+  --uxc-yellow-subtle-text: #8e5b00;
+  --uxc-purple-subtle-bg: #f4ebfc;
+  --uxc-purple-subtle-text: #8d30de;
+  --uxc-cyan-subtle-bg: #d9f4fd;
+  --uxc-cyan-subtle-text: #0a6ba0;
+  --uxc-magenta-subtle-bg: #ffe8f0;
+  --uxc-magenta-subtle-text: #c01f56;
+  --uxc-indigo-subtle-bg: #ebeeff;
+  --uxc-indigo-subtle-text: #5424db;
+  --uxc-gray-subtle-bg: #efefef;
+  --uxc-gray-subtle-text: #292929;
+  --uxc-positive-subtle-bg: #d7f7e1;
+  --uxc-positive-subtle-text: #067443;
+  --uxc-notice-subtle-bg: #ffeccf;
+  --uxc-notice-subtle-text: #a74800;
+  --uxc-negative-subtle-bg: #ffe8f0;
+  --uxc-negative-subtle-text: #c01f56;
+  --uxc-accent-subtle-bg: #e5f0fe;
+  --uxc-accent-subtle-text: #2350fb;
+  --uxc-neutral-subtle-bg: #f3f3f3;
 
   /* ── S2 Shadows (Light — from Figma UXC) ─────────────────── */
   --s2-shadow-elevated:

--- a/packages/webapp/tests/ui/sprinkle-theme-tokens.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-theme-tokens.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Sprinkle framework CSS is inherited by EVERY sprinkle, so a light-only
+ * colour there is unreadable in dark mode for every author at once (#2740).
+ * These tests read the stylesheets as text — jsdom resolves no `var()` and
+ * computes no contrast, so a rendered assertion would prove nothing.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const stylesDir = resolve(here, '../../src/ui/styles');
+const tokensCss = readFileSync(resolve(stylesDir, 'tokens.css'), 'utf8');
+const sprinkleCss = readFileSync(resolve(stylesDir, 'sprinkle-components.css'), 'utf8');
+
+/** Body of a top-level rule whose selector matches exactly. */
+function ruleBody(css: string, selector: string): string {
+  const start = css.indexOf(`\n${selector} {`);
+  expect(start, `missing rule ${selector}`).toBeGreaterThan(-1);
+  const open = css.indexOf('{', start);
+  const close = css.indexOf('\n}', open);
+  return css.slice(open + 1, close);
+}
+
+function tokensIn(body: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const m of body.matchAll(/(--[\w-]+):\s*([^;]+);/g)) map.set(m[1], m[2].trim());
+  return map;
+}
+
+function relativeLuminance(hex: string): number {
+  const n = Number.parseInt(hex.slice(1), 16);
+  const channels = [(n >> 16) & 255, (n >> 8) & 255, n & 255].map((v) => {
+    const c = v / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrast(a: string, b: string): number {
+  const [x, y] = [relativeLuminance(a), relativeLuminance(b)];
+  return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
+}
+
+const darkTokens = tokensIn(ruleBody(tokensCss, ':root'));
+const lightTokens = tokensIn(ruleBody(tokensCss, ':root.theme-light'));
+
+const SUBTLE_HUES = [
+  'yellow',
+  'purple',
+  'cyan',
+  'magenta',
+  'indigo',
+  'gray',
+  'positive',
+  'notice',
+  'negative',
+  'accent',
+] as const;
+
+describe('uxc subtle palette is theme-aware', () => {
+  it('declares every subtle token in both :root (dark) and :root.theme-light', () => {
+    const darkSubtle = [...darkTokens.keys()].filter((k) => k.includes('-subtle-')).sort();
+    expect(darkSubtle.length).toBeGreaterThanOrEqual(21);
+    expect([...lightTokens.keys()].filter((k) => k.includes('-subtle-')).sort()).toEqual(
+      darkSubtle
+    );
+  });
+
+  it('gives each subtle token a different value per theme', () => {
+    for (const key of darkTokens.keys()) {
+      if (!key.includes('-subtle-')) continue;
+      expect(lightTokens.get(key), `${key} is theme-invariant`).not.toBe(darkTokens.get(key));
+    }
+  });
+
+  it.each(SUBTLE_HUES)('%s subtle bg/text pair clears AA in both themes', (hue) => {
+    for (const [theme, tokens] of [
+      ['dark', darkTokens],
+      ['light', lightTokens],
+    ] as const) {
+      const bg = tokens.get(`--uxc-${hue}-subtle-bg`) as string;
+      const text = tokens.get(`--uxc-${hue}-subtle-text`) as string;
+      expect(bg, `${hue}/${theme} bg`).toMatch(/^#[0-9a-f]{6}$/);
+      expect(text, `${hue}/${theme} text`).toMatch(/^#[0-9a-f]{6}$/);
+      expect(contrast(bg, text), `${hue} in ${theme}`).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it('pairs the neutral subtle fill with gray-700 above AA in both themes', () => {
+    // `.sprinkle-badge--subtle` (no modifier) uses gray-700 as its text colour,
+    // so the neutral fill has no `-text` sibling to check it against.
+    for (const [theme, tokens] of [
+      ['dark', darkTokens],
+      ['light', lightTokens],
+    ] as const) {
+      const bg = tokens.get('--uxc-neutral-subtle-bg') as string;
+      const gray700 = tokens.get('--s2-gray-700') as string;
+      expect(contrast(bg, gray700), `neutral in ${theme}`).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+});
+
+describe('sprinkle framework CSS uses theme-aware surfaces', () => {
+  it('never hardcodes a light background on a themed control', () => {
+    for (const selector of ['.sprinkle-text-field', '.sprinkle-chip']) {
+      const body = ruleBody(sprinkleCss, selector);
+      expect(body, selector).not.toMatch(/background:\s*(white|#fff(fff)?)\b/i);
+      expect(body, selector).toMatch(/background:\s*var\(--s2-/);
+    }
+  });
+
+  it('gives the text-field placeholder a theme-aware content token', () => {
+    const body = ruleBody(sprinkleCss, '.sprinkle-text-field::placeholder');
+    expect(body).toMatch(/color:\s*var\(--s2-content-/);
+  });
+
+  it('routes subtle-fill consumers through the uxc tokens, not raw hexes', () => {
+    for (const m of sprinkleCss.matchAll(
+      /\.sprinkle-[\w-]*(?:badge|action-card__icon)[^{]*\{([^}]*)\}/g
+    )) {
+      const body = m[1];
+      if (!body.includes('-subtle-bg')) continue;
+      expect(body, body).not.toMatch(/color:\s*#[0-9a-f]{3,6}/i);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #2740.

Two theming bugs in the bundled sprinkle stylesheet made UI unreadable in dark mode. Both are framework CSS, so they hit every sprinkle.

## Bug 1 — hardcoded light field background

`.sprinkle-text-field` set `background: white` next to a theme-aware `color`, so dark mode paired light text with a white field (measured 1.23:1), and `::placeholder` used a fixed gray (3.45:1 in dark). Now:

- `background: var(--s2-bg-layer-1)` → 13.61:1 dark / 17.5:1 light
- `::placeholder { color: var(--s2-content-secondary) }` → 6.45:1 dark / 7.59:1 light

`.sprinkle-chip` had the identical `background: white` + themed `color` defect, so it is fixed the same way (its hover moves from `gray-50`, now equal to the base, to `gray-100`).

## Bug 2 — the `--uxc-*-subtle-*` palette was light-only

All 11 background/text pairs were declared only in `:root`, which holds the **dark** values, and `:root.theme-light` overrode none of them — so the Figma pastels rendered in dark mode. Several pairs also missed AA *in both themes* (negative 4.14:1, positive/notice 3.4:1).

- `:root` now carries dark desaturated fills with light hue text.
- The pastels moved to `:root.theme-light`, with the text hues darkened so each pair clears 5:1.
- Every pair (plus the neutral fill against its `gray-700` text) now measures ≥ 5:1 in both themes.
- Two `.sprinkle-action-card__icon--*` variants that inlined the pastel hexes now use the tokens.

## Tests

`packages/webapp/tests/ui/sprinkle-theme-tokens.test.ts` reads the stylesheets and asserts, for every subtle token, that it is declared in both theme blocks, that its value actually differs per theme, and that each bg/text pair clears AA — plus that the framework controls take no hardcoded light background. jsdom resolves no `var()` and computes no contrast, so a rendered assertion would prove nothing here.

## Verification

`npm run verify`, `check-touched-exemptions`, `typecheck`, `test` (18332 passed), `test:coverage`, both builds, `bundle-size` — all green.