### PR TITLE
fix(webapp): follow the WC shell's light marker in the S2 token overrides

### DIFF
--- a/packages/vfs-root/workspace/skills/sprinkles/style-guide.md
+++ b/packages/vfs-root/workspace/skills/sprinkles/style-guide.md
@@ -743,7 +743,7 @@ slicc.on('update', function (data) {
 
 ## Light & dark mode
 
-All sprinkles inherit the parent's theme automatically. The parent injects its S2 tokens and toggles a `.theme-light` class on the sprinkle root — the iframe's `<html>` in full-document mode, or the outermost container injected into the sidebar in fragment mode — whenever the user flips themes. Every `var(--s2-*)` token below swaps with it. **Never hard-code colors for one theme**, and **do not use `@media (prefers-color-scheme: ...)`** for colors that should mirror the app theme (it desyncs from the parent's class-based toggle).
+All sprinkles inherit the parent's theme automatically. In full-document mode the parent injects its S2 tokens and toggles a `.theme-light` class on the iframe's `<html>` whenever the user flips themes; a fragment sprinkle renders into the page DOM and inherits the tokens straight from the host shell's own light/dark marker. Either way every `var(--s2-*)` token below swaps with the theme. **Never hard-code colors for one theme**, and **do not use `@media (prefers-color-scheme: ...)`** for colors that should mirror the app theme (it desyncs from the parent's class-based toggle).
 
 For one-off colors that aren't covered by an S2 token, use CSS `light-dark()`:
 

--- a/packages/webapp/src/ui/styles/tokens.css
+++ b/packages/webapp/src/ui/styles/tokens.css
@@ -179,9 +179,14 @@
 
 /* ================================================================== */
 /* Spectrum 2 Design Tokens — Light Theme                             */
-/* Applied via .theme-light class on <html> by src/ui/theme.ts        */
+/* Applied via .theme-light class on <html> by src/ui/theme.ts, OR by    */
+/* the WC shell's body[data-theme="light"] marker (@slicc/webcomponents  */
+/* setTheme), which deliberately never touches .theme-light. Inline      */
+/* (fragment) sprinkles and dips render into the page DOM, so they only  */
+/* follow a light WC shell if both markers select these values.          */
 /* ================================================================== */
-:root.theme-light {
+:root.theme-light,
+:root:has(body[data-theme="light"]) {
   /* ── S2 Gray Scale (Light Theme — from Figma UXC) ─────────── */
   --s2-gray-25: #ffffff;
   --s2-gray-50: #f8f8f8;
@@ -242,36 +247,47 @@
     0 2px 8px rgba(0, 0, 0, 0.08), 0 1px 4px rgba(0, 0, 0, 0.04), 0 0px 1px rgba(0, 0, 0, 0.08);
 }
 
-/* Syntax tokens — light theme overrides */
-.theme-light .tok-keyword {
+/* Syntax tokens — light theme overrides. Both light markers again: the WC
+   shell renders markdown through the same `message-renderer.ts`, so these
+   spans exist there too. */
+.theme-light .tok-keyword,
+:root:has(body[data-theme="light"]) .tok-keyword {
   color: #8839ef;
 }
-.theme-light .tok-string {
+.theme-light .tok-string,
+:root:has(body[data-theme="light"]) .tok-string {
   color: #40a02b;
 }
-.theme-light .tok-number {
+.theme-light .tok-number,
+:root:has(body[data-theme="light"]) .tok-number {
   color: #d05d1a;
 }
-.theme-light .tok-comment {
+.theme-light .tok-comment,
+:root:has(body[data-theme="light"]) .tok-comment {
   color: var(--s2-gray-500);
 }
-.theme-light .tok-punct {
+.theme-light .tok-punct,
+:root:has(body[data-theme="light"]) .tok-punct {
   color: #1e66f5;
 }
-.theme-light .tok-fn {
+.theme-light .tok-fn,
+:root:has(body[data-theme="light"]) .tok-fn {
   color: #2b6cb0;
 }
 
 /* Tooltip inverts in light mode */
-.theme-light .s2-tooltip {
+.theme-light .s2-tooltip,
+:root:has(body[data-theme="light"]) .s2-tooltip {
   background: var(--s2-gray-900);
   color: var(--s2-gray-25);
 }
 
 /* Scrollbar lighter */
-.theme-light ::-webkit-scrollbar-thumb {
+.theme-light ::-webkit-scrollbar-thumb,
+:root:has(body[data-theme="light"]) ::-webkit-scrollbar-thumb {
   background: var(--s2-gray-300);
 }
-.theme-light ::-webkit-scrollbar-thumb:hover {
+.theme-light ::-webkit-scrollbar-thumb:hover,
+:root:has(body[data-theme="light"]) ::-webkit-scrollbar-thumb:hover {
   background: var(--s2-gray-400);
 }

--- a/packages/webapp/src/ui/styles/tokens.css
+++ b/packages/webapp/src/ui/styles/tokens.css
@@ -184,9 +184,15 @@
 /* setTheme), which deliberately never touches .theme-light. Inline      */
 /* (fragment) sprinkles and dips render into the page DOM, so they only  */
 /* follow a light WC shell if both markers select these values.          */
+/*                                                                       */
+/* The :has() sits inside :where() so the WC marker stays SPECIFICITY-   */
+/* NEUTRAL — plain :root (0,1,0), same as the dark block above, winning  */
+/* on order alone. Without :where() it would score (0,2,1) and outrank   */
+/* the `:root` block theme-engine.ts injects for the active preset,      */
+/* replacing a light preset's tokens with these defaults.                */
 /* ================================================================== */
 :root.theme-light,
-:root:has(body[data-theme="light"]) {
+:root:where(:has(body[data-theme="light"])) {
   /* ── S2 Gray Scale (Light Theme — from Figma UXC) ─────────── */
   --s2-gray-25: #ffffff;
   --s2-gray-50: #f8f8f8;
@@ -251,43 +257,43 @@
    shell renders markdown through the same `message-renderer.ts`, so these
    spans exist there too. */
 .theme-light .tok-keyword,
-:root:has(body[data-theme="light"]) .tok-keyword {
+:root:where(:has(body[data-theme="light"])) .tok-keyword {
   color: #8839ef;
 }
 .theme-light .tok-string,
-:root:has(body[data-theme="light"]) .tok-string {
+:root:where(:has(body[data-theme="light"])) .tok-string {
   color: #40a02b;
 }
 .theme-light .tok-number,
-:root:has(body[data-theme="light"]) .tok-number {
+:root:where(:has(body[data-theme="light"])) .tok-number {
   color: #d05d1a;
 }
 .theme-light .tok-comment,
-:root:has(body[data-theme="light"]) .tok-comment {
+:root:where(:has(body[data-theme="light"])) .tok-comment {
   color: var(--s2-gray-500);
 }
 .theme-light .tok-punct,
-:root:has(body[data-theme="light"]) .tok-punct {
+:root:where(:has(body[data-theme="light"])) .tok-punct {
   color: #1e66f5;
 }
 .theme-light .tok-fn,
-:root:has(body[data-theme="light"]) .tok-fn {
+:root:where(:has(body[data-theme="light"])) .tok-fn {
   color: #2b6cb0;
 }
 
 /* Tooltip inverts in light mode */
 .theme-light .s2-tooltip,
-:root:has(body[data-theme="light"]) .s2-tooltip {
+:root:where(:has(body[data-theme="light"])) .s2-tooltip {
   background: var(--s2-gray-900);
   color: var(--s2-gray-25);
 }
 
 /* Scrollbar lighter */
 .theme-light ::-webkit-scrollbar-thumb,
-:root:has(body[data-theme="light"]) ::-webkit-scrollbar-thumb {
+:root:where(:has(body[data-theme="light"])) ::-webkit-scrollbar-thumb {
   background: var(--s2-gray-300);
 }
 .theme-light ::-webkit-scrollbar-thumb:hover,
-:root:has(body[data-theme="light"]) ::-webkit-scrollbar-thumb:hover {
+:root:where(:has(body[data-theme="light"])) ::-webkit-scrollbar-thumb:hover {
   background: var(--s2-gray-400);
 }

--- a/packages/webapp/src/ui/theme.ts
+++ b/packages/webapp/src/ui/theme.ts
@@ -30,6 +30,11 @@ export function setThemePreference(pref: ThemePreference): void {
  * set and only flip light when this returns true, so it must honor whichever
  * scheme is active — otherwise the WC shell (which never sets `.theme-light`)
  * leaves every embedded surface stuck dark.
+ *
+ * `styles/tokens.css` mirrors both markers in CSS for the same reason: an
+ * iframe surface gets `.theme-light` from this function, but an INLINE
+ * (fragment) sprinkle stays in the page DOM and can only follow the shell's
+ * own marker.
  */
 export function isThemeLight(): boolean {
   if (document.documentElement.classList.contains('theme-light')) return true;

--- a/packages/webapp/tests/ui/sprinkle-theme-tokens.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-theme-tokens.test.ts
@@ -14,13 +14,22 @@ const stylesDir = resolve(here, '../../src/ui/styles');
 const tokensCss = readFileSync(resolve(stylesDir, 'tokens.css'), 'utf8');
 const sprinkleCss = readFileSync(resolve(stylesDir, 'sprinkle-components.css'), 'utf8');
 
-/** Body of a top-level rule whose selector matches exactly. */
+/**
+ * The top-level rule whose selector LIST contains `selector` — the light
+ * values are shared by two markers, so an exact-selector lookup would miss
+ * them (see the WC-marker test below).
+ */
+function rule(css: string, selector: string): { selectors: string[]; body: string } {
+  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  for (const m of withoutComments.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    const selectors = m[1].split(',').map((s) => s.trim());
+    if (selectors.includes(selector)) return { selectors, body: m[2] };
+  }
+  expect.fail(`missing rule ${selector}`);
+}
+
 function ruleBody(css: string, selector: string): string {
-  const start = css.indexOf(`\n${selector} {`);
-  expect(start, `missing rule ${selector}`).toBeGreaterThan(-1);
-  const open = css.indexOf('{', start);
-  const close = css.indexOf('\n}', open);
-  return css.slice(open + 1, close);
+  return rule(css, selector).body;
 }
 
 function tokensIn(body: string): Map<string, string> {
@@ -44,7 +53,11 @@ function contrast(a: string, b: string): number {
 }
 
 const darkTokens = tokensIn(ruleBody(tokensCss, ':root'));
-const lightTokens = tokensIn(ruleBody(tokensCss, ':root.theme-light'));
+const lightRule = rule(tokensCss, ':root.theme-light');
+const lightTokens = tokensIn(lightRule.body);
+
+/** The WC shell's light marker — it never sets `.theme-light` on <html>. */
+const WC_LIGHT_MARKER = ':root:has(body[data-theme="light"])';
 
 const SUBTLE_HUES = [
   'yellow',
@@ -98,6 +111,27 @@ describe('uxc subtle palette is theme-aware', () => {
       const bg = tokens.get('--uxc-neutral-subtle-bg') as string;
       const gray700 = tokens.get('--s2-gray-700') as string;
       expect(contrast(bg, gray700), `neutral in ${theme}`).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+});
+
+describe('light overrides reach both shells', () => {
+  it('declares the light token block under the WC body marker too', () => {
+    // Inline (fragment) sprinkles and dips render into the page DOM, so in the
+    // WC shell — which marks `body[data-theme="light"]` and never touches
+    // `.theme-light` — a `.theme-light`-only block would leave them dark.
+    expect(lightRule.selectors).toContain(WC_LIGHT_MARKER);
+  });
+
+  it('pairs every .theme-light descendant rule with the WC marker', () => {
+    const withoutComments = tokensCss.replace(/\/\*[\s\S]*?\*\//g, '');
+    for (const m of withoutComments.matchAll(/([^{}]+)\{[^{}]*\}/g)) {
+      const selectors = m[1].split(',').map((s) => s.trim());
+      const themeLight = selectors.filter((s) => s.startsWith('.theme-light '));
+      for (const sel of themeLight) {
+        const suffix = sel.slice('.theme-light '.length);
+        expect(selectors, `${sel} has no WC-marker twin`).toContain(`${WC_LIGHT_MARKER} ${suffix}`);
+      }
     }
   });
 });

--- a/packages/webapp/tests/ui/sprinkle-theme-tokens.test.ts
+++ b/packages/webapp/tests/ui/sprinkle-theme-tokens.test.ts
@@ -56,8 +56,12 @@ const darkTokens = tokensIn(ruleBody(tokensCss, ':root'));
 const lightRule = rule(tokensCss, ':root.theme-light');
 const lightTokens = tokensIn(lightRule.body);
 
-/** The WC shell's light marker — it never sets `.theme-light` on <html>. */
-const WC_LIGHT_MARKER = ':root:has(body[data-theme="light"])';
+/**
+ * The WC shell's light marker — it never sets `.theme-light` on <html>. The
+ * `:has()` is wrapped in `:where()` to keep the selector at plain `:root`
+ * specificity; see the specificity test below.
+ */
+const WC_LIGHT_MARKER = ':root:where(:has(body[data-theme="light"]))';
 
 const SUBTLE_HUES = [
   'yellow',
@@ -133,6 +137,22 @@ describe('light overrides reach both shells', () => {
         expect(selectors, `${sel} has no WC-marker twin`).toContain(`${WC_LIGHT_MARKER} ${suffix}`);
       }
     }
+  });
+
+  it('keeps the WC marker specificity-neutral so an active theme still wins', () => {
+    // `theme-engine.ts` injects the selected preset's tokens into a LATER
+    // `:root { … }` block. A bare `:root:has(body[data-theme="light"])` scores
+    // (0,2,1) and would outrank it, so a light preset would render these
+    // defaults instead of its own tokens. `:where()` contributes nothing,
+    // leaving plain `:root` (0,1,0), which wins over the dark block above on
+    // order alone and still loses to the injected theme.
+    const withoutComments = tokensCss.replace(/\/\*[\s\S]*?\*\//g, '');
+    for (const m of withoutComments.matchAll(/:root[^,{\s]*:has\(/g)) {
+      expect(m[0], 'unwrapped :has() raises specificity above the injected theme').toBe(
+        ':root:where(:has('
+      );
+    }
+    expect(withoutComments).toContain(WC_LIGHT_MARKER);
   });
 });
 


### PR DESCRIPTION
<!-- Follow-up to #2741 (already merged). Issue: #2740. -->

## Summary

Inline (fragment) sprinkles stayed on the dark token values when the WC shell was in light mode: badges and action-card icons rendered as dark fills on a light canvas. Every light override in `tokens.css` now also matches the WC shell's own light marker, so inline surfaces follow the shell in both light and dark.

## Why

`tokens.css` declared its light values under `:root.theme-light` only. The WC shell themes `<body>` through `@slicc/webcomponents` `setTheme` (`body[data-theme="light"]`, `body.dark`) and **deliberately never touches `.theme-light`** — that asymmetry is exactly what `theme.ts:isThemeLight()` exists to paper over on the JS side.

Full-document sprinkles and dips were unaffected: they get `.theme-light` mirrored onto the iframe's `<html>`. A fragment sprinkle renders into the page DOM, so it resolved the dark `:root` block instead. #2741 made it visible: with `--uxc-*-subtle-*` correctly split per theme, the pastel fills that previously looked right by accident in a light WC shell became dark. Reported by the Codex review on #2741.

Repro (before this change):

1. Open the WC shell with a light OS theme (`?ui=wc`), so `<body data-theme="light">`.
2. Render a fragment sprinkle containing `<span class="sprinkle-badge sprinkle-badge--subtle sprinkle-badge--negative">`.
   - Expected: pastel fill matching the light shell.
   - Actual: dark `#2e1920` fill on the light canvas.

## Approach / Implementation notes

- Every light override gains `:root:has(body[data-theme="light"])` alongside `.theme-light`: the token block (grays, backgrounds, accent, semantic colors, shadows, subtle palette) and the `.theme-light`-scoped rules (`.tok-*` — the WC shell renders markdown through the same `message-renderer.ts` — plus `.s2-tooltip` and the scrollbar thumbs).
- `:root:where(:has(body[data-theme="light"]))` was chosen over a bare `body[data-theme="light"]` so the declaration lands on `:root` and custom properties resolve for `<html>` too. The `:has()` is wrapped in `:where()` to keep it **specificity-neutral** — plain `:root` (0,1,0), the same as the dark block above, so light wins on source order alone. Without the wrap it would score (0,2,1) and outrank the `:root` block `theme-engine.ts` injects for the active theme, replacing a light preset's tokens with these defaults (caught in review; guarded by a test).
- A dark WC shell (`body[data-theme="dark"]`) matches neither marker and keeps the dark `:root` values; the legacy shell sets no `data-theme` at all and is unchanged.

## Cross-cutting impact

- **Floats**: CSS-only, so it applies to every float that loads `tokens.css` (CLI, extension side panel, Electron, cloud). No JS behavior change; `isThemeLight()` already handled both markers.
- **Iframe surfaces**: `collectThemeCSS()` copies theme rules verbatim into sprinkle/dip iframes. It matches a rule when *any* comma-separated part is a theme selector, so the new lists are still collected; the extra `body[...]` part simply never matches inside an iframe, where `.theme-light` governs.
- **Persisted state**: none touched.
- No new dependencies; no meaningful bundle movement (a few bytes of CSS — the first-load gate reports OK).

## Test plan

- [x] `npm run verify` — 6 of 7 green; the biome step reports one **pre-existing** error, see below
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 18418 passing, no new failures
- [x] `npm run test:coverage`
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load OK, all size limits under budget
- [x] **New behavior is covered by a unit test**: `npx vitest run packages/webapp/tests/ui/sprinkle-theme-tokens.test.ts` — two new guards (the light token block must list the WC marker; every `.theme-light <descendant>` rule must have a WC-marker twin). Verified both fail when the corresponding marker is removed, then restored.
- [ ] No screencast: the change is token plumbing with no new UI surface, and the assertion that matters (which values resolve per theme) is measured in the test rather than eyeballed.

**Pre-existing failures** (verified against `main`, unrelated to this PR): the biome step of `npm run verify` fails on `packages/webapp/tests/ui/main-storage-persistence.test.ts:31` (`lint/complexity/noAdjacentSpacesInRegex`), a file this PR does not touch. The pre-push lint gate passes.

## Documentation

- [x] `packages/vfs-root/workspace/skills/sprinkles/style-guide.md` — the "Light & dark mode" section claimed fragment mode gets a `.theme-light` class on its container, which was never true; it now describes inheriting from the host shell's marker.
- [x] `src/ui/theme.ts` — the `isThemeLight()` doc comment now points at the CSS side of the same asymmetry.

## Risk & rollback

- Blast radius: theming only, all floats. A mistake shows up as wrong-theme colors, not broken behavior.
- No flags, no persisted-state migration — revert this PR cleanly to restore the previous selectors.
- CI cannot see color: worth a reviewer glance at a fragment sprinkle in a light WC shell (`?ui=wc` with a light OS theme) to confirm badges now match the canvas.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] Public API / tool / shell-command changes: none
- [x] Contract shared across floats: CSS markers only; the iframe collection path was checked (see Cross-cutting impact)
