### PR TITLE
perf(webapp): carry readDir stat fields so consumers stop re-stating entries

### DIFF
--- a/docs/mounts.md
+++ b/docs/mounts.md
@@ -204,6 +204,28 @@ The stable dispatcher owns its body end to end: it is excluded from node-server'
 
 A bridge that predates the stable endpoint answers `POST /api/hostfs` with a framework 404 carrying no errno `code`; `HostFsMountBackend` treats exactly that as "no stable endpoint" and falls back to the per-op routes for the rest of the mount's life, at a cost of one wasted request. Every error the real route emits carries a `code`, so a genuine `ENOENT` never triggers the downgrade.
 
+### Listings carry stats (no re-stat per entry)
+
+`list` stats every dirent server-side, so a listing already knows each file's `size`, `lastModified` and — since [#2708](https://github.com/ai-ecoverse/slicc/issues/2708) — its `ctime`, `ino`, `uid`, `gid` and `mode`. Those fields ride all the way up: `HostFsMountBackend.readDir` → `MountDirEntry` → `VirtualFS.readDir` → `DirEntry` (all optional, all best-effort), and the panel-side `vfs-read-dir` RPC mirrors them.
+
+They exist so a consumer never stats what it just listed ([#2716](https://github.com/ai-ecoverse/slicc/issues/2716) — `git branch` spent 100 of its 125 requests on stats of 29 refs):
+
+- **isomorphic-git** (`git/vfs-fs-adapter.ts`): `readdir` primes a stat cache that `stat`/`lstat` answer from, cleared by `GitCommands.execute` at the end of every command and dropped for any path the adapter writes.
+- **Shell** (`shell/vfs-adapter.ts`): `ls -l` and `du` are a `readdir` plus a stat per name (just-bash's `DirentEntry` has no size), so a listing answers stats of its own entries for 1 s and any write through the adapter drops the table.
+- **Files panel** (`ui/wc/wc-workbench.ts`): reads `entry.size` and stats only the entries a listing left unknown.
+
+Three rules keep this honest:
+
+- **The backend opts in.** `MountBackend.listingStatsMatchStat` means "my listing reports the same numbers my `stat()` would" — consumers use them _instead of_ a stat and cannot tell the difference. Only `hostfs` (both bridges stat each dirent inside `list`) and `local` (both paths read `FileSystemFileHandle.getFile()`) set it. **S3 and AEM deliberately do not**: both answer `stat` from the body cache when they have one, where `mtime` is `cachedAt` — when the body was cached, not the object's mtime — and AEM reports the _decoded_ size there while a Source Bus listing carries the stored (compressed) one. Aligning those two sources is a separate change; until then their listings stay `{name, type}` and consumers pay the stat rather than getting a different number. `VirtualFS.readDir` drops the fields for any backend that has not opted in.
+- **A partial entry is never promoted.** A raced file the bridge could not stat comes back as a bare `{name, kind}` and costs a real stat, because answering with zeroed placeholders is exactly what makes isomorphic-git call a file stale and rewrite `.git/index` per file (#2708). Both bridges omit `size`/`lastModified` rather than sending zeros — including for a dangling symlink, whose `stat` op answers ENOENT.
+- **Symlinks are never promoted.** The listing describes the link, a `stat` describes its target.
+
+The last two are enforced in one place: `statsFromDirEntry` in `fs/types.ts`.
+
+Both consumer caches are bounded, because a TTL limits how long an entry may be _reused_, not how long it is _retained_: the shell's table sweeps what has expired whenever it primes and holds at most 20,000 entries, the git adapter's at most 100,000, and a single listing larger than the cap primes nothing at all rather than blowing past it.
+
+Directories over hostfs carry no stat fields today (both bridges send `{name, kind}` for them), so a consumer that needs a directory's size or mtime still stats it.
+
 ## Common error patterns
 
 | Error                                                                                         | What it means                                                                                 | Fix                                                                                              |

--- a/packages/swift-server/Sources/Server/HostFSRoutes.swift
+++ b/packages/swift-server/Sources/Server/HostFSRoutes.swift
@@ -453,13 +453,35 @@ enum HostFSRoutes {
         let entries: [LickSystem.JSONValue] = names.map { name in
             let full = dir + "/" + name
             var isDirectory: ObjCBool = false
-            FileManager.default.fileExists(atPath: full, isDirectory: &isDirectory)
-            if isDirectory.boolValue {
+            // Follows symlinks, like node's `stat(resolve(target, d.name))`:
+            // a link to a directory classifies as a directory, and a DANGLING
+            // link (or an entry deleted since `contentsOfDirectory`) does not
+            // resolve at all.
+            let resolves = FileManager.default.fileExists(atPath: full, isDirectory: &isDirectory)
+            if resolves && isDirectory.boolValue {
                 return .object(["name": .string(name), "kind": .string("directory")])
             }
-            let attrs = try? FileManager.default.attributesOfItem(atPath: full)
-            let size = (attrs?[.size] as? NSNumber)?.doubleValue ?? 0
-            let mtime = (attrs?[.modificationDate] as? Date).map { $0.timeIntervalSince1970 * 1000 } ?? 0
+            // An entry we could not measure reports the NAME ONLY — never
+            // `size: 0, lastModified: 0`, and never the dangling LINK's own
+            // attributes (`attributesOfItem` does not follow links, so it
+            // would happily describe a target that isn't there, for a path
+            // whose `stat` op answers ENOENT).
+            //
+            // The webapp uses a listing's numbers in place of a stat (issue
+            // #2716), where zeros are indistinguishable from a real empty
+            // file at the epoch: isomorphic-git would call that file stale
+            // forever and rewrite `.git/index` once per file (#2708), and
+            // `ls -l` would print them. node-server's `listOp` omits them for
+            // exactly this reason — the two bridges have to agree.
+            guard resolves,
+                let attrs = try? FileManager.default.attributesOfItem(atPath: full),
+                let size = (attrs[.size] as? NSNumber)?.doubleValue,
+                let mtime = (attrs[.modificationDate] as? Date).map({
+                    $0.timeIntervalSince1970 * 1000
+                })
+            else {
+                return .object(["name": .string(name), "kind": .string("file")])
+            }
             var entry: [String: LickSystem.JSONValue] = [
                 "name": .string(name),
                 "kind": .string("file"),

--- a/packages/swift-server/Tests/HostFSRoutesTests.swift
+++ b/packages/swift-server/Tests/HostFSRoutesTests.swift
@@ -611,6 +611,56 @@ final class HostFSRoutesTests: XCTestCase {
         XCTAssertEqual(BridgeSecurity.preflightMaxAge("/api/hostfs-admin"), "600")
     }
 
+    /// An entry the bridge cannot measure must report the NAME ONLY.
+    ///
+    /// The webapp uses a listing's `size`/`lastModified` in place of a stat
+    /// (issue #2716), so `size: 0, lastModified: 0` is not a safe stand-in
+    /// for "unknown" — it is indistinguishable from a real empty file at the
+    /// epoch. node-server's `listOp` omits both on failure; this bridge has
+    /// to match, including for a dangling symlink, whose `stat` op answers
+    /// ENOENT while `attributesOfItem` would happily describe the link.
+    func testListOmitsMetadataForAnEntryItCannotStat() async throws {
+        try FileManager.default.createSymbolicLink(
+            atPath: root + "/dangling", withDestinationPath: root + "/not-there")
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/api/hostfs/list?mount=%2Fmnt%2Fproj&path=", method: .get
+            ) { response in
+                XCTAssertEqual(response.status, .ok)
+                guard case .object(let body) = try self.decode(response.body),
+                    case .array(let entries)? = body["entries"]
+                else { return XCTFail("bad list shape") }
+                let dangling = entries.first { entry in
+                    guard case .object(let e) = entry, case .string("dangling")? = e["name"]
+                    else { return false }
+                    return true
+                }
+                guard case .object(let e)? = dangling else { return XCTFail("no dangling entry") }
+                // Still listed, still named — but nothing measured.
+                XCTAssertEqual(e["kind"], .string("file"))
+                XCTAssertNil(e["size"])
+                XCTAssertNil(e["lastModified"])
+                XCTAssertNil(e["ctime"])
+                XCTAssertNil(e["ino"])
+                XCTAssertNil(e["mode"])
+                // The measurable sibling is unaffected.
+                let hello = entries.first { entry in
+                    guard case .object(let h) = entry, case .string("hello.txt")? = h["name"]
+                    else { return false }
+                    return true
+                }
+                guard case .object(let h)? = hello else { return XCTFail("no hello.txt entry") }
+                XCTAssertEqual(h["size"], .number(10))
+            }
+            // And the listing agrees with the stat op: both refuse the path.
+            try await client.execute(
+                uri: "/api/hostfs/stat?mount=%2Fmnt%2Fproj&path=dangling", method: .get
+            ) { response in
+                XCTAssertEqual(response.status, .notFound)
+            }
+        }
+    }
+
     func testResolveWithinRootLexicalRules() throws {
         XCTAssertEqual(try HostFSRoutes.resolveWithinRoot(root: root, relPath: ""), root)
         XCTAssertEqual(

--- a/packages/webapp/src/fs/index.ts
+++ b/packages/webapp/src/fs/index.ts
@@ -21,6 +21,6 @@ export type {
   Stats,
   WriteFileOptions,
 } from './types.js';
-export { FsError } from './types.js';
+export { FsError, statsFromDirEntry } from './types.js';
 export type { VfsBackend, VirtualFsOptions } from './virtual-fs.js';
 export { resolveVfsBackendFromEnv, VirtualFS } from './virtual-fs.js';

--- a/packages/webapp/src/fs/mount/backend-hostfs.ts
+++ b/packages/webapp/src/fs/mount/backend-hostfs.ts
@@ -239,6 +239,13 @@ export interface HostFsMountBackendOptions {
 
 export class HostFsMountBackend implements MountBackend {
   readonly kind = 'hostfs' as const;
+  /**
+   * Both bridges stat every dirent inside `list` and answer `stat` from the
+   * same syscall, so a listing's numbers are the ones `stat` would report
+   * (issue #2716). A file the bridge could not stat comes back as a bare
+   * `{name, kind}` and is not promoted — see `statsFromDirEntry`.
+   */
+  readonly listingStatsMatchStat = true;
   readonly source: string;
   readonly mountId: string;
 

--- a/packages/webapp/src/fs/mount/backend-local.ts
+++ b/packages/webapp/src/fs/mount/backend-local.ts
@@ -49,6 +49,12 @@ const DEFAULT_DIR_CACHE_MAX = 512;
 
 export class LocalMountBackend implements MountBackend {
   readonly kind = 'local' as const;
+  /**
+   * `readDir` and `stat` both read `FileSystemFileHandle.getFile()`, so the
+   * listing's `size`/`lastModified` are the same values `stat` returns
+   * (issue #2716). Directories carry neither, on both paths.
+   */
+  readonly listingStatsMatchStat = true;
   readonly source = undefined;
   readonly profile = undefined;
   readonly mountId: string;

--- a/packages/webapp/src/fs/mount/backend.ts
+++ b/packages/webapp/src/fs/mount/backend.ts
@@ -112,6 +112,26 @@ export interface MountDescription {
 
 export interface MountBackend {
   readonly kind: MountKind;
+  /**
+   * Opt-in: this backend's `readDir` reports the SAME numbers its `stat`
+   * would report for the same path, so `VirtualFS` may carry them up on the
+   * `DirEntry` and consumers may use them in place of a stat (issue #2716).
+   *
+   * Default (absent/false) keeps the historical `{name, type}` listing. The
+   * flag exists because two backends deliberately answer `stat` from a
+   * different source than their listing, and promoting their listing fields
+   * would silently change what `stat` reports:
+   *   - S3 answers `stat` from the body cache when it has one, whose `mtime`
+   *     is `cachedAt` — when the body was cached, not the object's mtime.
+   *   - AEM does the same AND reports the *decoded* size there, while a
+   *     Source Bus listing carries the stored (compressed) size.
+   *
+   * `hostfs` (both bridges stat each dirent server-side) and `local` (both
+   * paths read `FileSystemFileHandle.getFile()`) do guarantee equivalence
+   * and set it. Aligning S3/AEM's two sources is a separate change; until
+   * then they keep costing a stat rather than answering a different number.
+   */
+  readonly listingStatsMatchStat?: boolean;
   /** URL form: 's3://bucket/prefix', 'da://org/repo', 'aem://org/site', undefined for local. */
   readonly source: string | undefined;
   readonly profile?: string;

--- a/packages/webapp/src/fs/types.ts
+++ b/packages/webapp/src/fs/types.ts
@@ -59,10 +59,76 @@ export interface Stats {
   mode?: number;
 }
 
+/**
+ * Stat fields a backend reported ALONGSIDE the directory listing, so a
+ * consumer that needs them does not have to stat the entry it just listed.
+ *
+ * Every field is optional and best-effort: the hostfs bridge reports the full
+ * set for files (and nothing but the name for a directory or a raced entry),
+ * the FSA/local path reports what `lstat` gave it, and the remote mounts
+ * report only what their listing carries. A consumer that finds a field
+ * missing must fall back to a real `stat()` — never to a placeholder.
+ *
+ * The contract a backend has to keep is that these numbers are the SAME ones
+ * its `stat()` would report for that path. Consumers (the isomorphic-git
+ * adapter's readdir-primed cache, the shell's `ls -l`, the Files panel) use
+ * them IN PLACE OF a stat, so a listing that disagrees with `stat` is a bug
+ * in the backend, not something the consumer can detect. See
+ * {@link statsFromDirEntry}, which is the one place that decides whether a
+ * listing carries enough to stand in for a stat.
+ */
+export interface DirEntryStats {
+  size?: number;
+  /** Last modification time (ms since epoch). */
+  mtime?: number;
+  /** Inode-change time (ms since epoch). */
+  ctime?: number;
+  ino?: number;
+  uid?: number;
+  gid?: number;
+  /** Full POSIX `st_mode`, type bits included. */
+  mode?: number;
+}
+
 /** A single entry returned by readDir. */
-export interface DirEntry {
+export interface DirEntry extends DirEntryStats {
   name: string;
   type: EntryType;
+}
+
+/**
+ * Promote a {@link DirEntry} to the {@link Stats} a `stat()` of that path
+ * would have returned, or `undefined` when the listing did not carry enough.
+ *
+ * This is the N+1 fix for issue #2716: `/api/hostfs/list` already stats every
+ * entry server-side, so a consumer that re-stats each listed name pays a full
+ * bridge round trip (plus a CORS preflight) per file — 100 stats for a 29-ref
+ * `git branch`, one per file for the Files panel, one per entry for `ls -l`.
+ *
+ * Two entry classes deliberately yield `undefined`:
+ *   - **symlinks**, because the listing describes the LINK and a `stat()`
+ *     would describe its target — they are not interchangeable; and
+ *   - anything without both `size` and `mtime`, because the historical
+ *     placeholders (`0`) are exactly what makes isomorphic-git call a file
+ *     stale and rewrite `.git/index` per file (issue #2708). Falling through
+ *     to a real stat is slow; answering with zeros is wrong.
+ *
+ * `ctime` falls back to `mtime`, matching what `VirtualFS.stat` does for a
+ * backend with no inode behind the entry.
+ */
+export function statsFromDirEntry(entry: DirEntry): Stats | undefined {
+  if (entry.type === 'symlink') return undefined;
+  if (entry.size === undefined || entry.mtime === undefined) return undefined;
+  return {
+    type: entry.type,
+    size: entry.size,
+    mtime: entry.mtime,
+    ctime: entry.ctime ?? entry.mtime,
+    ...(entry.ino !== undefined ? { ino: entry.ino } : {}),
+    ...(entry.uid !== undefined ? { uid: entry.uid } : {}),
+    ...(entry.gid !== undefined ? { gid: entry.gid } : {}),
+    ...(entry.mode !== undefined ? { mode: entry.mode } : {}),
+  };
 }
 
 /** Options for writeFile. */

--- a/packages/webapp/src/fs/virtual-fs.ts
+++ b/packages/webapp/src/fs/virtual-fs.ts
@@ -18,7 +18,7 @@
 import { convertError, rebrandFsError } from './error-rebrand.js';
 import type { FsChangeEvent, FsWatcher } from './fs-watcher.js';
 import { findDirtyKindFlips, memoryKindOfMode, shouldReconcileKind } from './kind-reconcile.js';
-import type { MountBackend, RefreshReport } from './mount/backend.js';
+import type { MountBackend, MountDirEntry, RefreshReport } from './mount/backend.js';
 import type { HostFsMountBackend } from './mount/backend-hostfs.js';
 import { LocalMountBackend } from './mount/backend-local.js';
 import {
@@ -138,6 +138,39 @@ interface FsSyncLike {
   statSync?(path: string): FsStatsLike;
   lstatSync?(path: string): FsStatsLike;
   readlinkSync?(path: string): string;
+}
+
+/**
+ * Project one backend listing entry onto a {@link DirEntry}, carrying the
+ * stat fields the backend already paid for.
+ *
+ * `/api/hostfs/list` stats every dirent server-side, so `size`/`lastModified`
+ * (and, since #2708, `ctime`/`ino`/`uid`/`gid`/`mode`) arrive with the
+ * listing. Dropping them here is what forced every consumer to re-stat each
+ * entry it had just listed — one bridge round trip per file (issue #2716).
+ * Fields the backend did not report stay absent; consumers fall back to a
+ * real `stat()` rather than to a placeholder.
+ *
+ * `withStats` is the backend's {@link MountBackend.listingStatsMatchStat}
+ * opt-in. A backend that answers `stat` from a different source than its
+ * listing (S3/AEM read the body cache first) keeps the historical
+ * `{name, type}` entry, because a consumer using these fields IN PLACE OF a
+ * stat must not get a different number than the stat would have returned.
+ */
+function dirEntryFromMount(entry: MountDirEntry, withStats: boolean): DirEntry {
+  const type = entry.kind === 'directory' ? 'directory' : 'file';
+  if (!withStats) return { name: entry.name, type };
+  return {
+    name: entry.name,
+    type,
+    ...(entry.size !== undefined ? { size: entry.size } : {}),
+    ...(entry.lastModified !== undefined ? { mtime: entry.lastModified } : {}),
+    ...(entry.ctime !== undefined ? { ctime: entry.ctime } : {}),
+    ...(entry.ino !== undefined ? { ino: entry.ino } : {}),
+    ...(entry.uid !== undefined ? { uid: entry.uid } : {}),
+    ...(entry.gid !== undefined ? { gid: entry.gid } : {}),
+    ...(entry.mode !== undefined ? { mode: entry.mode } : {}),
+  };
 }
 
 /**
@@ -1197,7 +1230,24 @@ export class VirtualFS {
             : s.isDirectory()
               ? 'directory'
               : 'file';
-          entries.push({ name, type });
+          // Same stat fields the async path carries (#2716) — this loop
+          // already lstat'd the entry, so a consumer never has to repeat it.
+          // Symlink entries stay bare: they describe the link, not its target.
+          entries.push(
+            type === 'symlink'
+              ? { name, type }
+              : {
+                  name,
+                  type,
+                  size: s.size,
+                  mtime: s.mtimeMs,
+                  ctime: s.ctimeMs,
+                  ...(s.ino !== undefined ? { ino: s.ino } : {}),
+                  ...(s.uid !== undefined ? { uid: s.uid } : {}),
+                  ...(s.gid !== undefined ? { gid: s.gid } : {}),
+                  mode: s.mode,
+                }
+          );
         } catch {
           /* skip entries we can't stat */
         }
@@ -1894,11 +1944,9 @@ export class VirtualFS {
       rebrandFsError(err, normalized);
     }
     const entries = new Map<string, DirEntry>();
+    const withStats = mount.backend.listingStatsMatchStat === true;
     for (const entry of dirEntries) {
-      entries.set(entry.name, {
-        name: entry.name,
-        type: entry.kind === 'directory' ? 'directory' : 'file',
-      });
+      entries.set(entry.name, dirEntryFromMount(entry, withStats));
     }
     this.addNestedMountEntries(entries, normalized);
     return [...entries.values()];
@@ -1924,13 +1972,31 @@ export class VirtualFS {
     }
   }
 
-  /** Stat a single directory entry, returning null if it cannot be stat'd. */
+  /**
+   * Stat a single directory entry, returning null if it cannot be stat'd.
+   *
+   * The stat fields ride along on the entry: this path already pays for an
+   * `lstat` per name, so reporting what it learned costs nothing and spares
+   * every consumer a second one (issue #2716). A symlink carries none of
+   * them — the numbers describe the LINK, while a consumer's `stat()` would
+   * describe its target, so they are not interchangeable.
+   */
   private async statDirEntry(parentResolved: string, name: string): Promise<DirEntry | null> {
     const childPath = parentResolved === '/' ? `/${name}` : `${parentResolved}/${name}`;
     try {
       const s = await this.lfs.lstat(childPath);
       if (s.isSymbolicLink()) return { name, type: 'symlink' };
-      return { name, type: s.isDirectory() ? 'directory' : 'file' };
+      return {
+        name,
+        type: s.isDirectory() ? 'directory' : 'file',
+        size: s.size,
+        mtime: s.mtimeMs,
+        ctime: s.ctimeMs,
+        ...(s.ino !== undefined ? { ino: s.ino } : {}),
+        ...(s.uid !== undefined ? { uid: s.uid } : {}),
+        ...(s.gid !== undefined ? { gid: s.gid } : {}),
+        mode: s.mode,
+      };
     } catch {
       return null;
     }

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -57,7 +57,11 @@ import type { GitCommandContext, GitCommandResult, GitCommandsOptions } from './
 import { createCommandScopedReadCache } from './fs-command-cache.js';
 import { GitCacheManager } from './git-cache.js';
 import { readGlobalGitConfigValue } from './git-config.js';
-import { createIsomorphicGitFs, type IsoGitFsPromises } from './vfs-fs-adapter.js';
+import {
+  createIsomorphicGitFs,
+  type IsoGitFsClient,
+  type IsoGitFsPromises,
+} from './vfs-fs-adapter.js';
 
 export type { GitCommandResult, GitCommandsOptions } from './commands/types.js';
 
@@ -146,6 +150,18 @@ export class GitCommands {
    * here is ever a cached adapter, because instance state is shared by
    * concurrent invocations and a memo must not be.
    */
+  /**
+   * The BARE adapter {@link GitCacheManager} samples the repository through:
+   * no object memo (#2712), no readdir-primed stat cache (#2716), and never a
+   * command's read memo (#2709).
+   *
+   * `packSignature` is an INVALIDATION sampler — it lists `objects/pack` and
+   * lstats `packed-refs` to decide whether the packs it is holding are still
+   * the packs on disk. Answering either from a memo is a cache validating
+   * itself against its own memory. `statCacheMax: 0` and the absent
+   * `objectCache` make that structural instead of a property of who calls
+   * what.
+   */
   private readonly lfs: IsoGitFsPromises;
   private corsProxy?: string;
   private authorName: string;
@@ -182,7 +198,7 @@ export class GitCommands {
     // points (File System Access API) the same way shell/agent tools do.
     // See packages/webapp/src/git/vfs-fs-adapter.ts. This uncached instance
     // backs the class's own config reads; each `execute()` builds its own.
-    this.lfs = createIsomorphicGitFs(options.fs).promises;
+    this.lfs = createIsomorphicGitFs(options.fs, { statCacheMax: 0 }).promises;
     this.corsProxy = options.corsProxy;
     this.authorName = options.authorName ?? 'User';
     this.authorEmail = options.authorEmail ?? 'user@example.com';
@@ -217,10 +233,12 @@ export class GitCommands {
    * in time never share either one, and both are unreachable — and therefore
    * collected — as soon as the command returns.
    */
-  private contextFor(command: string): GitCommandContext {
-    const base = createIsomorphicGitFs(this.options.fs, { objectCache: true }).promises;
-    const lfs = CACHEABLE_COMMANDS.has(command) ? createCommandScopedReadCache(base) : base;
-    return {
+  private contextFor(command: string): { ctx: GitCommandContext; client: IsoGitFsClient } {
+    const client = createIsomorphicGitFs(this.options.fs, { objectCache: true });
+    const lfs = CACHEABLE_COMMANDS.has(command)
+      ? createCommandScopedReadCache(client.promises)
+      : client.promises;
+    const ctx: GitCommandContext = {
       lfs,
       fs: this.options.fs,
       // The object/pack cache is the instance's, NOT the invocation's (#2710):
@@ -242,6 +260,7 @@ export class GitCommands {
       },
       getConfigOverrides: () => this.currentConfigOverrides,
     };
+    return { ctx, client };
   }
 
   /**
@@ -414,7 +433,7 @@ export class GitCommands {
     // One context — and with it one view of `.git/objects` (#2712) plus, for a
     // cacheable subcommand, one read memo (#2709) — per invocation, so nothing
     // a command reads is visible to any other.
-    const ctx = this.contextFor(command);
+    const { ctx, client } = this.contextFor(command);
     try {
       // Object/pack cache housekeeping (#2710). The verification switch is
       // per-invocation (it reads the shell env), and `beforeCommand` re-samples
@@ -526,6 +545,12 @@ export class GitCommands {
       });
       this.currentEnv = undefined;
       this.currentConfigOverrides = undefined;
+      // The adapter is per-invocation, so its readdir-primed stat cache
+      // (#2716) dies with this call anyway — but a listing must never answer a
+      // stat issued by the NEXT command, which can run after the host
+      // filesystem moved on, so the scope boundary is stated rather than
+      // inferred from who happens to hold a reference to `ctx`.
+      client.clearStatCache();
     }
   }
 

--- a/packages/webapp/src/git/vfs-fs-adapter.ts
+++ b/packages/webapp/src/git/vfs-fs-adapter.ts
@@ -10,10 +10,29 @@
  * paths via the (now-removed) `getLightningFS()` escape hatch. The
  * fast-path shortcut is gone; `VirtualFS` itself owns symlink
  * resolution and watcher notification for every op.
+ *
+ * ## The readdir-primed stat cache (issue #2716)
+ *
+ * isomorphic-git's `readdir` contract is names-only, but almost every caller
+ * immediately stats what it listed: `FileSystem.readdirDeep` stats each name
+ * to decide whether to recurse, `GitWalkerFs` lstats every workdir entry.
+ * Over a hostfs mount each of those is a bridge round trip (plus a CORS
+ * preflight) for metadata the `list` response already carried — `git branch`
+ * cost 125 requests for 29 refs, 100 of them stats.
+ *
+ * So every real listing primes a stat cache from the `DirEntry` fields
+ * `VirtualFS` now carries, and `stat`/`lstat` answer from it. Its lifetime is
+ * the adapter's, which `GitCommands.contextFor` builds per `execute()` — the
+ * same scope as the `objectCache` memo below and #2709's read cache above.
+ * Any write through this adapter drops the affected path. What it can never
+ * do is INVENT a stat: a file is only cached when the listing carried both
+ * `size` and `mtime`, because zeroed placeholders are exactly what make
+ * `compareStats` call a file stale and rewrite `.git/index` per file (#2708).
  */
 
 import type { VirtualFS } from '../fs/index.js';
-import { FsError, type Stats } from '../fs/types.js';
+import { normalizePath } from '../fs/path-utils.js';
+import { type DirEntry, FsError, type Stats, statsFromDirEntry } from '../fs/types.js';
 
 export type PromiseFsClient = { promises: IsoGitFsPromises };
 
@@ -35,6 +54,60 @@ export interface IsoGitFsOptions {
    * object created mid-command is visible to the next read.
    */
   objectCache?: boolean;
+  /**
+   * Hard cap on entries primed by a listing for the readdir-primed stat cache
+   * (issue #2716; default {@link MAX_CACHED_ENTRIES}). `0` builds the
+   * historical BARE adapter — every listing is oversized, so nothing is ever
+   * primed and every `stat` goes to the filesystem. Two callers want that: a
+   * test measuring the uncached baseline its own assertions are calibrated
+   * against, and `GitCacheManager`'s invalidation sampler, which must see the
+   * filesystem rather than a memo.
+   */
+  statCacheMax?: number;
+}
+
+/**
+ * What {@link createIsomorphicGitFs} returns: the `PromiseFsClient`
+ * isomorphic-git takes, plus control over the readdir-primed stat cache.
+ */
+export interface IsoGitFsClient extends PromiseFsClient {
+  /**
+   * Drop everything a listing primed. The adapter is already built per git
+   * command, so this states the scope boundary rather than creating it — the
+   * cache is a within-command optimization, not a filesystem view.
+   */
+  clearStatCache(): void;
+  /**
+   * How many entries are primed right now. A diagnostic: it is what makes
+   * the cap assertable, since a bounded cache and an unbounded one behave
+   * identically until the worker runs out of memory.
+   */
+  statCacheSize(): number;
+}
+
+/**
+ * Default cap on primed entries — a hard ceiling, never a soft target. A
+ * single command lists at most the directories it walks, so this is a
+ * backstop against a pathological tree.
+ *
+ * Overflow drops the cache rather than growing it: a listing that would push
+ * it past the cap clears first (keeping the newest listing rather than
+ * pinning the oldest), and a SINGLE listing bigger than the cap clears and
+ * primes nothing at all — the cap is the memory budget, so it has to hold
+ * even for one 200k-entry directory.
+ */
+const MAX_CACHED_ENTRIES = 100_000;
+
+/**
+ * One cached listing entry. `stats` is absent for a directory the backend
+ * described by name only (what the hostfs bridge sends) — enough for the
+ * `isDirectory()` question every caller asks of a directory, and directories
+ * never appear in `.git/index`, so no stat comparison can see the
+ * placeholders {@link toStats} fills in.
+ */
+interface CachedEntry {
+  type: 'file' | 'dir';
+  stats?: Stats;
 }
 
 export interface IsoGitFsPromises {
@@ -187,16 +260,95 @@ const PACK_DIR_SUFFIX = '/objects/pack';
 const LOOSE_OBJECT_PATH = /^(.*\/objects)\/([0-9a-f]{2})\/[0-9a-f]{38,}$/;
 
 /** Build an isomorphic-git-compatible PromiseFsClient over a VirtualFS. */
+function cacheableEntry(entry: DirEntry): CachedEntry | undefined {
+  const stats = statsFromDirEntry(entry);
+  if (entry.type === 'directory') return stats ? { type: 'dir', stats } : { type: 'dir' };
+  return stats ? { type: 'file', stats } : undefined;
+}
+
+/** The readdir-primed stat cache of one adapter (issue #2716). */
+interface StatCache {
+  /** Record what a fresh listing of `dir` reported about each entry. */
+  prime(dir: string, entries: DirEntry[]): void;
+  /** The answer for `path`, or undefined to go to the filesystem. */
+  get(path: string): NodeLikeStats | undefined;
+  drop(path: string): void;
+  clear(): void;
+  size(): number;
+}
+
+/**
+ * Build the cache. `maxEntries` is a hard ceiling: `0` disables priming
+ * entirely (every listing counts as oversized), which is what a bare adapter
+ * and the pack-cache invalidation sampler want.
+ *
+ * Keys are normalized so a caller that spells the same path differently
+ * (`a//b`, `a/./b`) still hits — `VirtualFS` normalizes every path it is
+ * handed, so this is the same identity it uses.
+ */
+function createStatCache(maxEntries: number): StatCache {
+  const entriesByPath = new Map<string, CachedEntry>();
+  return {
+    prime(dir, entries) {
+      // One listing bigger than the whole budget: drop everything and prime
+      // nothing. Clearing to "make room" and inserting anyway would still
+      // leave `entries.length` behind — no cap for the directory needing one.
+      if (entries.length > maxEntries) {
+        entriesByPath.clear();
+        return;
+      }
+      if (entriesByPath.size + entries.length > maxEntries) entriesByPath.clear();
+      const base = normalizePath(dir);
+      const prefix = base === '/' ? '/' : `${base}/`;
+      for (const entry of entries) {
+        const cached = cacheableEntry(entry);
+        // A stale hit is worse than a miss: an entry we cannot cache honestly
+        // (symlink, half-reported file) also drops what was cached for it.
+        if (cached) entriesByPath.set(`${prefix}${entry.name}`, cached);
+        else entriesByPath.delete(`${prefix}${entry.name}`);
+      }
+    },
+    get(path) {
+      const cached = entriesByPath.get(normalizePath(path));
+      if (!cached) return undefined;
+      // `stat` and `lstat` share this: the entries that would differ between
+      // them (symlinks) are never cached.
+      return toStats(cached.type, cached.stats ? fromVfsStats(cached.stats) : {});
+    },
+    drop(path) {
+      entriesByPath.delete(normalizePath(path));
+    },
+    clear() {
+      entriesByPath.clear();
+    },
+    size() {
+      return entriesByPath.size;
+    },
+  };
+}
+
 export function createIsomorphicGitFs(
   vfs: VirtualFS,
   options: IsoGitFsOptions = {}
-): PromiseFsClient {
+): IsoGitFsClient {
   const scope: ObjectScope | undefined = options.objectCache
     ? { packDirs: new Map(), fanouts: new Map() }
     : undefined;
 
-  const listNames = async (path: string): Promise<string[]> =>
-    (await vfs.readDir(path)).map((e) => e.name);
+  const statCache = createStatCache(Math.max(0, options.statCacheMax ?? MAX_CACHED_ENTRIES));
+
+  /**
+   * Every REAL listing this adapter takes, whoever asked for it: the object
+   * memo's `objects/pack` and fan-out listings included. Each one primes the
+   * stat cache with the fields the backend already reported (#2716); a
+   * listing served from the object memo does not, because no new listing was
+   * taken.
+   */
+  const listNames = async (path: string): Promise<string[]> => {
+    const entries = await vfs.readDir(path);
+    statCache.prime(path, entries);
+    return entries.map((e) => e.name);
+  };
 
   /**
    * Names of the loose fan-out directories under `objectsDir`, listed once per
@@ -237,6 +389,16 @@ export function createIsomorphicGitFs(
   };
 
   /**
+   * Run a mutation of ONE path with both memos dropped around it: the object
+   * scope (a write may add a pack or a loose object) and that path's primed
+   * stat (its size and mtime just changed).
+   */
+  const mutatePath = async <T>(path: string, op: () => Promise<T>): Promise<T> => {
+    statCache.drop(path);
+    return await mutate(op);
+  };
+
+  /**
    * Run a mutation with the memo dropped on BOTH sides of it. Dropping it only
    * up front is not enough: a concurrent reader can repopulate the maps while
    * the write is still in flight, and that listing — taken before the write
@@ -272,11 +434,11 @@ export function createIsomorphicGitFs(
     },
 
     async writeFile(path, data, _options) {
-      await mutate(() => vfs.writeFile(path, data));
+      await mutatePath(path, () => vfs.writeFile(path, data));
     },
 
     async unlink(path) {
-      await mutate(() => vfs.rm(path));
+      await mutatePath(path, () => vfs.rm(path));
     },
 
     async readdir(path) {
@@ -291,21 +453,28 @@ export function createIsomorphicGitFs(
 
     async mkdir(path, options) {
       const opts = (options ?? undefined) as { recursive?: boolean } | undefined;
-      await mutate(() =>
+      await mutatePath(path, () =>
         vfs.mkdir(path, opts?.recursive !== undefined ? { recursive: opts.recursive } : undefined)
       );
     },
 
     async rmdir(path) {
+      // `vfs.rm` takes the whole subtree with it, so dropping just this key
+      // would leave primed answers for children that no longer exist.
+      statCache.clear();
       await mutate(() => vfs.rm(path));
     },
 
     async stat(path) {
+      const primed = statCache.get(path);
+      if (primed) return primed;
       const s = await vfs.stat(path);
       return toStats(s.type === 'directory' ? 'dir' : 'file', fromVfsStats(s));
     },
 
     async lstat(path) {
+      const primed = statCache.get(path);
+      if (primed) return primed;
       const s = await vfs.lstat(path);
       const type: 'file' | 'dir' | 'symlink' =
         s.type === 'directory' ? 'dir' : s.type === 'symlink' ? 'symlink' : 'file';
@@ -323,9 +492,17 @@ export function createIsomorphicGitFs(
       if (vfs.isPathUnderMount(path)) {
         throw new FsError('EINVAL', 'symlinks not supported on mounted filesystems', path);
       }
-      await mutate(() => vfs.symlink(target, path));
+      await mutatePath(path, () => vfs.symlink(target, path));
     },
   };
 
-  return { promises };
+  return {
+    promises,
+    clearStatCache() {
+      statCache.clear();
+    },
+    statCacheSize() {
+      return statCache.size();
+    },
+  };
 }

--- a/packages/webapp/src/kernel/messages.ts
+++ b/packages/webapp/src/kernel/messages.ts
@@ -576,10 +576,27 @@ export interface LocalStorageClearMsg {
 // `vfs-rpc-host.ts` casts between the wire shape and the real `Stats` /
 // `DirEntry` types.
 
-/** Wire mirror of `DirEntry` from `webapp/src/fs/types.ts`. */
+/**
+ * Wire mirror of `DirEntry` from `webapp/src/fs/types.ts`.
+ *
+ * The stat fields are optional and additive (#2716): a backend that reported
+ * them with the listing sends them along so the panel does not have to stat
+ * every entry it just listed, and an older peer that omits them is answered
+ * exactly as before.
+ */
 export interface VfsDirEntryEnvelope {
   name: string;
   type: 'file' | 'directory' | 'symlink';
+  size?: number;
+  /** Last modification time (ms since epoch). */
+  mtime?: number;
+  /** Inode-change time (ms since epoch). */
+  ctime?: number;
+  ino?: number;
+  uid?: number;
+  gid?: number;
+  /** Full POSIX `st_mode`, type bits included. */
+  mode?: number;
 }
 
 /** Wire mirror of `Stats` from `webapp/src/fs/types.ts`. */

--- a/packages/webapp/src/shell/vfs-adapter.ts
+++ b/packages/webapp/src/shell/vfs-adapter.ts
@@ -15,8 +15,8 @@ import type {
   RmOptions,
 } from 'just-bash';
 import * as justBash from 'just-bash';
-import type { VirtualFS } from '../fs/index.js';
-import { FsError, joinPath, normalizePath } from '../fs/index.js';
+import type { DirEntry, Stats, VirtualFS } from '../fs/index.js';
+import { FsError, joinPath, normalizePath, statsFromDirEntry } from '../fs/index.js';
 import { consumeCachedBinary } from './binary-cache.js';
 
 // just-bash v3 ships `DefenseInDepthBox` from `security/index.js` (re-exported
@@ -77,10 +77,142 @@ function toIdentity(ino: number | undefined): string | undefined {
   return typeof ino === 'number' && Number.isInteger(ino) && ino > 0 ? `vfs-ino:${ino}` : undefined;
 }
 
+/**
+ * How long a directory listing may answer a `stat` of an entry it just
+ * reported (issue #2716).
+ *
+ * `ls -l` is one `readdir` followed by a `stat` per name, and `du` one
+ * `readdir` followed by an `lstat` per name — just-bash's `DirentEntry`
+ * carries no size, so there is no way to hand the sizes over except through
+ * the filesystem surface it calls next. Over a hostfs mount each of those
+ * stats is a bridge round trip for numbers the `list` response already
+ * carried (a 91-entry directory cost 91 of them).
+ *
+ * A second is far longer than the microseconds between the listing and the
+ * stats that follow it, and far shorter than a person's next command — and
+ * any write through this adapter drops the whole table anyway. It bounds the
+ * one case the adapter cannot see: a change made outside it (the host
+ * filesystem, another realm) between the listing and the stat.
+ */
+const LISTING_STAT_TTL_MS = 1000;
+
+/**
+ * Hard cap on primed entries — a memory budget, not a soft target.
+ *
+ * The TTL alone bounds how long an entry may be REUSED, not how long it is
+ * RETAINED: expiry is only noticed when that exact path is looked up again,
+ * so a `du -sh` or `ls -R` over a big mount would pile every directory it
+ * ever walked into a map that lives as long as the shell does. Priming
+ * therefore sweeps what has expired and, when the cap would still be
+ * exceeded, drops the table instead of growing it.
+ *
+ * 20,000 entries is far more than the listing-plus-stats burst this exists
+ * to serve, and small enough that the worst case is a few MB.
+ */
+const MAX_LISTING_STATS = 20_000;
+
+/** Injection points for the listing cache — tests pin small ones. */
+export interface VfsAdapterOptions {
+  /** Hard cap on primed entries (default 20,000). */
+  listingStatsMax?: number;
+  /** How long a listing may answer a stat, in ms (default 1000). */
+  listingStatsTtlMs?: number;
+}
+
 export class VfsAdapter implements IFileSystem {
   private registeredCommandsFn: (() => string[]) | null = null;
+  /**
+   * Stat answers primed by the last `readdir`/`readdirWithFileTypes`, keyed
+   * by normalized absolute path. Only entries whose listing carried the full
+   * set land here — see {@link statsFromDirEntry}.
+   *
+   * Insertion order is age order: priming DELETES a key before re-setting it
+   * (a plain `set` on an existing key keeps its old position), which is what
+   * lets {@link sweepExpiredListingStats} stop at the first live entry
+   * instead of walking the whole map.
+   */
+  private readonly listingStats = new Map<string, { stats: Stats; at: number }>();
+  private readonly listingStatsMax: number;
+  private readonly listingStatsTtlMs: number;
 
-  constructor(private vfs: VirtualFS) {}
+  constructor(
+    private vfs: VirtualFS,
+    opts?: VfsAdapterOptions
+  ) {
+    this.listingStatsMax = Math.max(1, opts?.listingStatsMax ?? MAX_LISTING_STATS);
+    this.listingStatsTtlMs = opts?.listingStatsTtlMs ?? LISTING_STAT_TTL_MS;
+  }
+
+  /** Entries primed right now. A diagnostic — an unbounded cache and a
+   * bounded one behave identically until the worker runs out of memory, so
+   * this is what makes the cap assertable. */
+  get listingStatsSize(): number {
+    return this.listingStats.size;
+  }
+
+  /**
+   * Remember what a listing reported about each entry.
+   *
+   * Entries the listing did not fully describe (a directory over hostfs, a
+   * symlink, a raced entry the bridge could not stat) are DROPPED rather
+   * than half-cached, so a later `stat` of one goes to the filesystem.
+   */
+  private primeListingStats(dir: string, entries: DirEntry[]): void {
+    const at = Date.now();
+    // One listing bigger than the whole budget: drop everything and prime
+    // nothing. Making room first and then inserting would still leave
+    // `entries.length` entries behind — no cap at all for exactly the
+    // directory that needs one.
+    if (entries.length > this.listingStatsMax) {
+      this.listingStats.clear();
+      return;
+    }
+    this.sweepExpiredListingStats(at);
+    if (this.listingStats.size + entries.length > this.listingStatsMax) {
+      this.listingStats.clear();
+    }
+    const prefix = dir === '/' ? '/' : `${dir}/`;
+    for (const entry of entries) {
+      const stats = statsFromDirEntry(entry);
+      const path = `${prefix}${entry.name}`;
+      // Delete first either way: it drops a half-described entry's stale
+      // answer AND keeps insertion order equal to age order for the sweep.
+      this.listingStats.delete(path);
+      if (stats) this.listingStats.set(path, { stats, at });
+    }
+  }
+
+  /**
+   * Evict everything already past the TTL. Cheap because insertion order is
+   * age order — the first live entry ends the scan, so the walk costs one
+   * step per entry actually removed.
+   */
+  private sweepExpiredListingStats(now: number): void {
+    for (const [path, hit] of this.listingStats) {
+      if (now - hit.at <= this.listingStatsTtlMs) break;
+      this.listingStats.delete(path);
+    }
+  }
+
+  /** The primed stats for `path`, if a recent listing reported them. */
+  private primedStats(path: string): Stats | undefined {
+    const hit = this.listingStats.get(path);
+    if (!hit) return undefined;
+    if (Date.now() - hit.at > this.listingStatsTtlMs) {
+      this.listingStats.delete(path);
+      return undefined;
+    }
+    return hit.stats;
+  }
+
+  /**
+   * Forget every primed listing. Called by every mutation this adapter
+   * performs — blunt on purpose: a shell command that writes is not the one
+   * paying the N+1, so there is nothing to lose by starting over.
+   */
+  private dropListingStats(): void {
+    this.listingStats.clear();
+  }
 
   /**
    * Set a function that returns the list of registered command names.
@@ -226,6 +358,7 @@ export class VfsAdapter implements IFileSystem {
     content: FileContent,
     _options?: WriteFileOptions | BufferEncoding
   ): Promise<void> {
+    this.dropListingStats();
     return this.trusted(async () => {
       const normalized = normalizePath(path);
       if (typeof content === 'string') {
@@ -270,6 +403,7 @@ export class VfsAdapter implements IFileSystem {
     content: FileContent,
     _options?: WriteFileOptions | BufferEncoding
   ): Promise<void> {
+    this.dropListingStats();
     return this.trusted(async () => {
       const normalized = normalizePath(path);
       // Enforce POSIX EISDIR for the append target — ZenFS' InMemory backend
@@ -347,7 +481,9 @@ export class VfsAdapter implements IFileSystem {
           identity: toIdentity(fast.ino),
         };
       }
-      const s = await this.vfs.stat(normalized);
+      // What the directory listing just reported, when it reported it
+      // (#2716) — never a symlink, so `stat` and `lstat` share the answer.
+      const s = this.primedStats(normalized) ?? (await this.vfs.stat(normalized));
       return {
         isFile: s.type === 'file',
         isDirectory: s.type === 'directory',
@@ -381,7 +517,7 @@ export class VfsAdapter implements IFileSystem {
           identity: toIdentity(fast.ino),
         };
       }
-      const s = await this.vfs.lstat(normalized);
+      const s = this.primedStats(normalized) ?? (await this.vfs.lstat(normalized));
       return {
         isFile: s.type === 'file',
         isDirectory: s.type === 'directory',
@@ -395,6 +531,7 @@ export class VfsAdapter implements IFileSystem {
   }
 
   async mkdir(path: string, options?: MkdirOptions): Promise<void> {
+    this.dropListingStats();
     return this.trusted(async () => {
       await this.vfs.mkdir(normalizePath(path), options);
     });
@@ -409,6 +546,8 @@ export class VfsAdapter implements IFileSystem {
       const fast = this.vfs.readDirSync(normalized);
       if (fast !== null) return fast.map((e) => e.name);
       const entries = await this.vfs.readDir(normalized);
+      // `ls -l` stats every name this just returned (#2716).
+      this.primeListingStats(normalized, entries);
       return entries.map((e) => e.name);
     });
   }
@@ -441,6 +580,7 @@ export class VfsAdapter implements IFileSystem {
 
       // Slow path: async VirtualFS readDir for mounted paths.
       const entries = await this.vfs.readDir(normalized);
+      this.primeListingStats(normalized, entries);
       return this.mapAsyncEntriesToDirents(entries);
     });
   }
@@ -481,12 +621,14 @@ export class VfsAdapter implements IFileSystem {
   }
 
   async rm(path: string, options?: RmOptions): Promise<void> {
+    this.dropListingStats();
     return this.trusted(async () => {
       await this.vfs.rm(normalizePath(path), options);
     });
   }
 
   async cp(src: string, dest: string, options?: CpOptions): Promise<void> {
+    this.dropListingStats();
     return this.trusted(async () => {
       const normalizedSrc = normalizePath(src);
       const normalizedDest = normalizePath(dest);
@@ -519,6 +661,7 @@ export class VfsAdapter implements IFileSystem {
   }
 
   async mv(src: string, dest: string): Promise<void> {
+    this.dropListingStats();
     return this.trusted(async () => {
       await this.vfs.rename(normalizePath(src), normalizePath(dest));
     });
@@ -540,6 +683,7 @@ export class VfsAdapter implements IFileSystem {
   }
 
   async symlink(target: string, linkPath: string): Promise<void> {
+    this.dropListingStats();
     return this.trusted(async () => {
       await this.vfs.symlink(target, normalizePath(linkPath));
     });
@@ -566,6 +710,7 @@ export class VfsAdapter implements IFileSystem {
   }
 
   invalidatePaths(paths: string[]): void {
+    this.dropListingStats();
     const vfs = this.vfs as { invalidatePaths?: (paths: string[]) => void };
     if (vfs.invalidatePaths) {
       vfs.invalidatePaths(paths);

--- a/packages/webapp/src/ui/wc/wc-workbench.ts
+++ b/packages/webapp/src/ui/wc/wc-workbench.ts
@@ -44,11 +44,20 @@ async function dirChildren(
 
   const capped = [...dirs, ...files].slice(0, MAX_ENTRIES_PER_DIR);
 
-  // Stat all files in parallel; failures degrade gracefully to no size.
-  const filePaths = capped.filter((e) => e.type === 'file').map((e) => `${dir}/${e.name}`);
-  const stats = await Promise.allSettled(filePaths.map((p) => fs.stat(p)));
+  // Sizes come from the listing when the backend reported them there
+  // (#2716) — over a hostfs mount, stat'ing what we just listed is one
+  // bridge round trip per file. Only the entries a listing left unknown
+  // are stat'd, in parallel; failures degrade gracefully to no size.
   const sizeMap = new Map<string, number>();
-  filePaths.forEach((p, i) => {
+  const unsized: string[] = [];
+  for (const entry of capped) {
+    if (entry.type !== 'file') continue;
+    const path = `${dir}/${entry.name}`;
+    if (entry.size !== undefined) sizeMap.set(path, entry.size);
+    else unsized.push(path);
+  }
+  const stats = await Promise.allSettled(unsized.map((p) => fs.stat(p)));
+  unsized.forEach((p, i) => {
     const r = stats[i];
     if (r?.status === 'fulfilled') sizeMap.set(p, r.value.size);
   });

--- a/packages/webapp/tests/fs/dir-entry-stats.test.ts
+++ b/packages/webapp/tests/fs/dir-entry-stats.test.ts
@@ -1,0 +1,224 @@
+/**
+ * `readDir` carries the stat fields the backend already paid for — issue #2716.
+ *
+ * `/api/hostfs/list` stats every dirent server-side, so `size`/`lastModified`
+ * (plus the #2708 identity fields) arrive with the listing. VirtualFS used to
+ * drop everything but `{name, type}`, which is what forced every consumer to
+ * re-stat each entry it had just listed: one bridge round trip per file.
+ *
+ * These tests pin the plumbing (mount slow path, local async path, local sync
+ * path) and the one rule that decides whether a listing may stand in for a
+ * stat at all — `statsFromDirEntry`.
+ */
+
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type {
+  MountBackend,
+  MountDescription,
+  MountDirEntry,
+  MountStat,
+  RefreshReport,
+} from '../../src/fs/mount/backend.js';
+import { FsError, statsFromDirEntry } from '../../src/fs/types.js';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+
+let dbCounter = 0;
+
+/** A bridge-shaped mount: full stat fields for files, bare names for dirs. */
+class ListingBackend implements MountBackend {
+  readonly kind = 'hostfs' as const;
+  readonly source = 'hostfs:///listing';
+  readonly mountId = 'listing-backend';
+  readonly listingStatsMatchStat: boolean;
+
+  constructor(
+    private readonly entries: MountDirEntry[],
+    listingStatsMatchStat = true
+  ) {
+    this.listingStatsMatchStat = listingStatsMatchStat;
+  }
+
+  async readDir(): Promise<MountDirEntry[]> {
+    return this.entries;
+  }
+
+  async readFile(): Promise<Uint8Array> {
+    return new Uint8Array();
+  }
+
+  async writeFile(): Promise<void> {}
+
+  async stat(path: string): Promise<MountStat> {
+    const name = path.replace(/^\/+/, '');
+    const entry = this.entries.find((e) => e.name === name);
+    if (!entry) throw new FsError('ENOENT', 'no such file', path);
+    return { kind: entry.kind, size: entry.size ?? 0, mtime: entry.lastModified ?? 0 };
+  }
+
+  async mkdir(): Promise<void> {}
+
+  async remove(): Promise<void> {}
+
+  async refresh(): Promise<RefreshReport> {
+    return { added: [], removed: [], changed: [], unchanged: 0, errors: [] };
+  }
+
+  describe(): MountDescription {
+    return { displayName: 'listing' };
+  }
+
+  async close(): Promise<void> {}
+
+  getHostPath(): string {
+    return '/listing';
+  }
+}
+
+describe('statsFromDirEntry', () => {
+  it('promotes a fully reported entry to the stats a stat() would return', () => {
+    const stats = statsFromDirEntry({
+      name: 'a.txt',
+      type: 'file',
+      size: 12,
+      mtime: 1_700_000_000_000,
+      ctime: 1_700_000_500_000,
+      ino: 42,
+      uid: 501,
+      gid: 20,
+      mode: 0o100755,
+    });
+    expect(stats).toEqual({
+      type: 'file',
+      size: 12,
+      mtime: 1_700_000_000_000,
+      ctime: 1_700_000_500_000,
+      ino: 42,
+      uid: 501,
+      gid: 20,
+      mode: 0o100755,
+    });
+  });
+
+  it('falls ctime back to mtime, as VirtualFS.stat does for an inode-less backend', () => {
+    expect(statsFromDirEntry({ name: 'a', type: 'file', size: 1, mtime: 7 })?.ctime).toBe(7);
+  });
+
+  it('refuses an entry the listing only half described', () => {
+    // What the bridge sends for a raced entry it could not stat: name + kind.
+    expect(statsFromDirEntry({ name: 'gone', type: 'file' })).toBeUndefined();
+    expect(statsFromDirEntry({ name: 'partial', type: 'file', size: 3 })).toBeUndefined();
+    expect(statsFromDirEntry({ name: 'partial', type: 'file', mtime: 3 })).toBeUndefined();
+  });
+
+  it('refuses a symlink — the listing describes the link, stat() the target', () => {
+    expect(
+      statsFromDirEntry({ name: 'link', type: 'symlink', size: 9, mtime: 1, ino: 3 })
+    ).toBeUndefined();
+  });
+});
+
+describe('VirtualFS.readDir carries listing stats (#2716)', () => {
+  let vfs: VirtualFS;
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({ dbName: `dir-entry-stats-${dbCounter++}`, wipe: true });
+  });
+
+  it('passes a mount listing’s size, mtime and identity fields through', async () => {
+    await vfs.mkdir('/mnt/host', { recursive: true });
+    await vfs.mount(
+      '/mnt/host',
+      new ListingBackend([
+        {
+          name: 'script.sh',
+          kind: 'file',
+          size: 10,
+          lastModified: 1_700_000_000_000,
+          ctime: 1_700_000_500_000,
+          ino: 987_654,
+          uid: 501,
+          gid: 20,
+          mode: 0o100755,
+        },
+        // A directory: the bridge sends nothing but the name and kind.
+        { name: 'sub', kind: 'directory' },
+      ])
+    );
+
+    const entries = await vfs.readDir('/mnt/host');
+    const script = entries.find((e) => e.name === 'script.sh');
+    expect(script).toEqual({
+      name: 'script.sh',
+      type: 'file',
+      size: 10,
+      mtime: 1_700_000_000_000,
+      ctime: 1_700_000_500_000,
+      ino: 987_654,
+      uid: 501,
+      gid: 20,
+      mode: 0o100755,
+    });
+    // Nothing is invented for what the backend did not report.
+    expect(entries.find((e) => e.name === 'sub')).toEqual({ name: 'sub', type: 'directory' });
+  });
+
+  // #2716 / review: S3 answers `stat` from its body cache (`mtime` is
+  // `cachedAt`, not the object's mtime) and AEM reports the DECODED size
+  // there while its listing carries the stored one. A consumer using a
+  // listing in place of a stat would silently get a different number, so
+  // those backends do not opt in and their listings stay bare.
+  it('drops the listing fields for a backend whose listing and stat disagree', async () => {
+    await vfs.mkdir('/mnt/remote', { recursive: true });
+    await vfs.mount(
+      '/mnt/remote',
+      new ListingBackend(
+        [{ name: 'page.html', kind: 'file', size: 512, lastModified: 1_700_000_000_000 }],
+        false
+      )
+    );
+
+    const [entry] = await vfs.readDir('/mnt/remote');
+    expect(entry).toEqual({ name: 'page.html', type: 'file' });
+    // …and the consumer rule agrees: nothing to promote, so it stats.
+    expect(statsFromDirEntry(entry!)).toBeUndefined();
+  });
+
+  it('reports the local filesystem’s own size, mtime and inode', async () => {
+    await vfs.mkdir('/dir');
+    await vfs.writeFile('/dir/hello.txt', 'hello\n');
+    const [entry] = await vfs.readDir('/dir');
+    expect(entry?.size).toBe(6);
+    expect(entry?.mtime).toBeGreaterThan(0);
+    expect(entry?.ctime).toBeGreaterThan(0);
+    expect(entry?.ino).toBeGreaterThan(0);
+    expect(entry?.mode).toBeGreaterThan(0);
+    // The listing agrees with a stat of the same path — the invariant every
+    // consumer of these fields depends on.
+    const stats = await vfs.stat('/dir/hello.txt');
+    expect(statsFromDirEntry(entry!)).toEqual(expect.objectContaining({ size: stats.size }));
+    expect(entry?.mtime).toBe(stats.mtime);
+    expect(entry?.ino).toBe(stats.ino);
+  });
+
+  it('leaves a local symlink entry bare', async () => {
+    await vfs.writeFile('/target.txt', 'target\n');
+    await vfs.symlink('/target.txt', '/link.txt');
+    const link = (await vfs.readDir('/')).find((e) => e.name === 'link.txt');
+    expect(link).toEqual({ name: 'link.txt', type: 'symlink' });
+  });
+
+  it('carries the same fields on the synchronous fast path', async () => {
+    await vfs.mkdir('/sync');
+    await vfs.writeFile('/sync/a.txt', 'abc');
+    await vfs.symlink('/sync/a.txt', '/sync/link');
+    const entries = vfs.readDirSync('/sync');
+    // The memory backend supports sync ops; OPFS returns null and callers
+    // fall back to the async path, which is covered above.
+    expect(entries).not.toBeNull();
+    const file = entries?.find((e) => e.name === 'a.txt');
+    expect(file?.size).toBe(3);
+    expect(file?.mtime).toBeGreaterThan(0);
+    expect(entries?.find((e) => e.name === 'link')).toEqual({ name: 'link', type: 'symlink' });
+  });
+});

--- a/packages/webapp/tests/git/fs-command-cache.test.ts
+++ b/packages/webapp/tests/git/fs-command-cache.test.ts
@@ -394,7 +394,11 @@ describe('GitCommands read caching end to end (issue #2709)', () => {
     // repo. If these ever drop to 1 on their own, the tests below stop
     // proving anything.
     await git.statusMatrix({
-      fs: createIsomorphicGitFs(counting.fs),
+      // `statCacheMax: 0` is the BARE adapter: no readdir-primed stat cache
+      // either (#2716), which would otherwise answer some of these lstats
+      // from the listing of `.git` and understate the baseline these numbers
+      // exist to describe.
+      fs: createIsomorphicGitFs(counting.fs, { statCacheMax: 0 }),
       dir: CWD,
       refresh: false,
     });

--- a/packages/webapp/tests/git/git-command-fs-memos.test.ts
+++ b/packages/webapp/tests/git/git-command-fs-memos.test.ts
@@ -111,7 +111,14 @@ describe('per-invocation git fs memos (#2709 read cache over #2712 object memo)'
   it('pays both costs without either memo (control)', async () => {
     // Guards the assertions below: this is what a bare adapter does, and if
     // these numbers ever fall on their own the tests stop proving anything.
-    await isoGit.statusMatrix({ fs: createIsomorphicGitFs(counting.fs), dir: CWD, refresh: false });
+    // `statCacheMax: 0` keeps it bare in the third dimension too — without it
+    // the readdir-primed stat cache (#2716) answers some of these lstats from
+    // the listing of `.git` and understates the baseline.
+    await isoGit.statusMatrix({
+      fs: createIsomorphicGitFs(counting.fs, { statCacheMax: 0 }),
+      dir: CWD,
+      refresh: false,
+    });
 
     expect(countOf(`lstat ${INDEX}`)).toBeGreaterThan(5);
     // One listing per object `_readObject` resolves (3 here: the commit and
@@ -119,11 +126,26 @@ describe('per-invocation git fs memos (#2709 read cache over #2712 object memo)'
     expect(countOf(`readDir ${PACK_DIR}`)).toBeGreaterThan(1);
   });
 
-  it('gives one command BOTH the read cache and the object memo', async () => {
+  it('gives one command the read cache, the object memo AND the stat cache', async () => {
     const result = await commands.execute(['status', '--short'], CWD);
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('?? untracked-0.txt');
+    // #2716: the workdir walk lstats every entry it just listed, and the
+    // listing already carried size/mtime/ino — so not one of those reaches
+    // the filesystem. This is the fourth seam in the same stack: it sits
+    // UNDER the read cache and beside the object memo, and if the read cache
+    // stopped delegating through to the adapter it would go to 10.
+    for (let i = 0; i < 6; i++) {
+      expect(countOf(`lstat ${CWD}/tracked-${i}.txt`)).toBe(0);
+      expect(countOf(`stat ${CWD}/tracked-${i}.txt`)).toBe(0);
+    }
+    for (let i = 0; i < 4; i++) {
+      expect(countOf(`lstat ${CWD}/untracked-${i}.txt`)).toBe(0);
+    }
+    // …and it never answered a stat nobody listed: the walk still had to see
+    // the working tree.
+    expect(countOf(`readDir ${CWD}`)).toBeGreaterThan(0);
     // #2709: the index is stat'ed once for the whole walk, not once per file.
     expect(countOf(`lstat ${INDEX}`)).toBe(1);
     // #2712: TWO listings of `objects/pack` for the whole command, not one per
@@ -139,12 +161,19 @@ describe('per-invocation git fs memos (#2709 read cache over #2712 object memo)'
     ).toEqual([]);
   });
 
-  it('carries neither memo across two sequential commands', async () => {
+  it('carries none of the per-invocation memos across two sequential commands', async () => {
     await commands.execute(['status', '--short'], CWD);
     await commands.execute(['status', '--short'], CWD);
 
     expect(countOf(`lstat ${INDEX}`)).toBe(2);
     expect(countOf(`readDir ${PACK_DIR}`)).toBe(4);
+    // #2716's stat cache is per-invocation for the same reason, and the way
+    // to see that is the listing it primes from: the second command re-lists
+    // the working tree rather than answering from the first command's view of
+    // it. (That the adapter itself is rebuilt per call — the only thing that
+    // could let a listing outlive its command — is asserted directly in
+    // `git-commands-stat-cache.test.ts`.)
+    expect(countOf(`readDir ${CWD}`)).toBe(2);
   });
 
   it('shares neither memo between two commands running at once', async () => {

--- a/packages/webapp/tests/git/git-commands-stat-cache.test.ts
+++ b/packages/webapp/tests/git/git-commands-stat-cache.test.ts
@@ -1,0 +1,201 @@
+/**
+ * How the readdir-primed stat cache (#2716) composes with the command-scoped
+ * read memo (#2709), and how both are scoped.
+ *
+ * Two caches now sit between isomorphic-git and the VirtualFS:
+ * `GitCommands.contextFor` builds a fresh adapter per `execute()` and, for a
+ * cacheable subcommand, wraps it in `createCommandScopedReadCache`. They have
+ * to compose in both directions — the wrapper must delegate through to the
+ * adapter (or the listing never primes anything), and the adapter must be
+ * per-invocation (or a listing outlives the command that took it and answers
+ * a stat issued after the host filesystem moved on).
+ *
+ * The first half of this file asserts the STRUCTURE through the factory (one
+ * adapter built and cleared per command, success or failure); the second half
+ * asserts the BEHAVIOR through a counting VirtualFS, which is what actually
+ * proves the two layers are stacked and not shadowing each other.
+ */
+
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DirEntry, Stats } from '../../src/fs/types.js';
+// Type-only: the VALUE comes from the dynamic import below, after `vi.mock`.
+import type { VirtualFS as Vfs } from '../../src/fs/virtual-fs.js';
+
+type AdapterOpts = { statCacheMax?: number; objectCache?: boolean } | undefined;
+
+const builds: { count: number; opts: AdapterOpts[] } = {
+  count: 0,
+  opts: [],
+};
+const clears = { count: 0 };
+
+vi.mock('../../src/git/vfs-fs-adapter.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/git/vfs-fs-adapter.js')>();
+  return {
+    ...actual,
+    createIsomorphicGitFs: (
+      vfs: Parameters<typeof actual.createIsomorphicGitFs>[0],
+      opts?: Parameters<typeof actual.createIsomorphicGitFs>[1]
+    ) => {
+      builds.count++;
+      builds.opts.push(opts);
+      const client = actual.createIsomorphicGitFs(vfs, opts);
+      return {
+        ...client,
+        clearStatCache: () => {
+          clears.count++;
+          client.clearStatCache();
+        },
+      };
+    },
+  };
+});
+
+const { VirtualFS } = await import('../../src/fs/virtual-fs.js');
+const { GitCommands } = await import('../../src/git/git-commands.js');
+
+let dbCounter = 0;
+const CWD = '/workspace';
+
+describe('GitCommands scopes the adapter stat cache to one command (#2716)', () => {
+  let git: InstanceType<typeof GitCommands>;
+  /** Adapters built while the constructor ran, i.e. before any command. */
+  let constructorOpts: AdapterOpts[];
+
+  beforeEach(async () => {
+    const id = dbCounter++;
+    const vfs = await VirtualFS.create({ dbName: `git-stat-cache-${id}`, wipe: true });
+    await vfs.mkdir(CWD, { recursive: true });
+    builds.opts.length = 0;
+    git = new GitCommands({ fs: vfs, globalDbName: `git-stat-cache-global-${id}` });
+    constructorOpts = builds.opts.slice();
+    builds.count = 0;
+    builds.opts.length = 0;
+    clears.count = 0;
+  });
+
+  it('builds and clears one adapter per command that succeeds', async () => {
+    const result = await git.execute(['init'], CWD);
+    expect(result.exitCode).toBe(0);
+    expect(builds.count).toBe(1);
+    expect(clears.count).toBe(1);
+  });
+
+  it('clears after a command that fails', async () => {
+    // No repository here, so `status` bails out — the listing must go anyway.
+    const result = await git.execute(['status'], CWD);
+    expect(result.exitCode).not.toBe(0);
+    expect(clears.count).toBe(1);
+  });
+
+  it('never shares one adapter between two commands', async () => {
+    await git.execute(['init'], CWD);
+    await git.execute(['status'], CWD);
+    // A cache built in the constructor would be built once and shared by
+    // every command — including two that overlap in time (#2709 review).
+    expect(builds.count).toBe(2);
+    expect(clears.count).toBe(2);
+  });
+
+  it('gives a command’s adapter both memos, and the pack sampler neither', async () => {
+    // `GitCacheManager` (#2710) validates its cached packs by re-listing
+    // `objects/pack` and lstat'ing `packed-refs`. A validator must not
+    // validate against a memo — so the adapter it samples through is built
+    // BARE: no object memo (#2712, which would memoize that very listing) and
+    // no stat cache (#2716, which would memoize that very lstat).
+    expect(constructorOpts).toEqual([{ statCacheMax: 0 }]);
+
+    // A command's own adapter is the opposite: both memos on, for one call.
+    await git.execute(['init'], CWD);
+    expect(builds.opts).toEqual([{ objectCache: true }]);
+  });
+});
+
+/**
+ * A VirtualFS that counts the metadata questions reaching it. Anything the
+ * two caches answer never gets here, which is the whole point.
+ */
+function countingVfs(inner: Vfs): {
+  fs: Vfs;
+  counts: Map<string, number>;
+} {
+  const counts = new Map<string, number>();
+  const bump = (key: string) => counts.set(key, (counts.get(key) ?? 0) + 1);
+  const fs = new Proxy(inner, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, target);
+      if (typeof value !== 'function') return value;
+      if (prop === 'stat' || prop === 'lstat' || prop === 'readDir') {
+        return (path: string, ...rest: unknown[]) => {
+          bump(`${String(prop)} ${path}`);
+          return (value as (...a: unknown[]) => unknown).call(target, path, ...rest);
+        };
+      }
+      return (...args: unknown[]) => (value as (...a: unknown[]) => unknown).apply(target, args);
+    },
+  }) as Vfs;
+  return { fs, counts };
+}
+
+describe('the two caches compose over one command (#2716 + #2709)', () => {
+  let vfs: Vfs;
+  let counting: ReturnType<typeof countingVfs>;
+  let git: InstanceType<typeof GitCommands>;
+
+  beforeEach(async () => {
+    const id = dbCounter++;
+    vfs = await VirtualFS.create({ dbName: `git-stat-compose-${id}`, wipe: true });
+    const setup = new GitCommands({ fs: vfs, globalDbName: `git-stat-compose-global-${id}` });
+    await vfs.mkdir(CWD, { recursive: true });
+    await setup.execute(['init'], CWD);
+    for (let i = 0; i < 6; i++) {
+      await vfs.writeFile(`${CWD}/tracked-${i}.txt`, `file ${i}\n`);
+    }
+    expect((await setup.execute(['add', '.'], CWD)).exitCode).toBe(0);
+    expect((await setup.execute(['commit', '-m', 'first'], CWD)).exitCode).toBe(0);
+
+    counting = countingVfs(vfs);
+    git = new GitCommands({ fs: counting.fs, globalDbName: `git-stat-compose-global-${id}` });
+    counting.counts.clear();
+  });
+
+  it('stats none of the working-tree files a cacheable command listed', async () => {
+    // `status` is on CACHEABLE_COMMANDS, so its adapter is wrapped in the
+    // #2709 read memo. The wrapper has to delegate through to the adapter for
+    // the listing to prime anything at all — if it shadowed `readdir`, or if
+    // the adapter were built without the listing fields, every one of these
+    // would be a round trip (on a hostfs mount, an HTTP request each).
+    const result = await git.execute(['status'], CWD);
+    expect(result.exitCode).toBe(0);
+
+    expect(counting.counts.get(`readDir ${CWD}`) ?? 0).toBeGreaterThan(0);
+    for (let i = 0; i < 6; i++) {
+      expect(counting.counts.get(`lstat ${CWD}/tracked-${i}.txt`) ?? 0).toBe(0);
+      expect(counting.counts.get(`stat ${CWD}/tracked-${i}.txt`) ?? 0).toBe(0);
+    }
+  });
+
+  it('keeps the #2709 memo working underneath (index stat’d once)', async () => {
+    const result = await git.execute(['ls-files'], CWD);
+    expect(result.exitCode).toBe(0);
+    // The read memo still collapses the per-file `.git/index` re-stat; adding
+    // a second cache under it must not have knocked that out.
+    expect(counting.counts.get(`lstat ${CWD}/.git/index`) ?? 0).toBeLessThanOrEqual(1);
+  });
+});
+
+/** The listing fields the whole stack depends on, at their source. */
+describe('the listing a command primes from', () => {
+  it('carries what a stat would report', async () => {
+    const vfs = await VirtualFS.create({ dbName: `git-stat-src-${dbCounter++}`, wipe: true });
+    await vfs.mkdir(CWD, { recursive: true });
+    await vfs.writeFile(`${CWD}/a.txt`, 'abc');
+    const entries: DirEntry[] = await vfs.readDir(CWD);
+    const entry = entries.find((e) => e.name === 'a.txt');
+    const stats: Stats = await vfs.stat(`${CWD}/a.txt`);
+    expect(entry?.size).toBe(stats.size);
+    expect(entry?.mtime).toBe(stats.mtime);
+    expect(entry?.ino).toBe(stats.ino);
+  });
+});

--- a/packages/webapp/tests/git/vfs-fs-adapter-readdir-cache.test.ts
+++ b/packages/webapp/tests/git/vfs-fs-adapter-readdir-cache.test.ts
@@ -1,0 +1,376 @@
+/**
+ * The isomorphic-git adapter answers a stat from the listing it just read —
+ * issue #2716.
+ *
+ * `FileSystem.readdirDeep` (what `git branch` walks `refs/` with) stats every
+ * name it lists to decide whether to recurse, and `GitWalkerFs` lstats every
+ * workdir entry. Over a hostfs mount that is one bridge round trip per entry
+ * for metadata the `list` response already carried: `git branch` cost 125
+ * requests for 29 refs, 100 of them stats.
+ *
+ * The counting backend below is the whole point of these tests — they assert
+ * REQUESTS, not values. Value fidelity (#2708) is pinned by
+ * `vfs-fs-adapter-stats.test.ts`; what must not regress here is that a cached
+ * answer is byte-identical to the stat it replaced.
+ */
+
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type {
+  MountBackend,
+  MountDescription,
+  MountDirEntry,
+  MountStat,
+  RefreshReport,
+} from '../../src/fs/mount/backend.js';
+import { FsError } from '../../src/fs/types.js';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { createIsomorphicGitFs } from '../../src/git/vfs-fs-adapter.js';
+
+let dbCounter = 0;
+
+/** One host entry as the bridge would report it. */
+interface HostEntry {
+  kind: 'file' | 'directory';
+  size?: number;
+  mtime?: number;
+}
+
+/**
+ * Stands in for the hostfs bridge: every `list`/`stat` is a request, and the
+ * listing carries exactly what `/api/hostfs/list` carries — full stats for a
+ * file it could stat, name + kind for a directory.
+ */
+class CountingBackend implements MountBackend {
+  readonly kind = 'hostfs' as const;
+  readonly source = 'hostfs:///counting';
+  readonly mountId = 'counting-backend';
+  /** Its listing numbers are what its stat reports — see #2716. */
+  readonly listingStatsMatchStat = true;
+  lists = 0;
+  stats = 0;
+  reads = 0;
+  rangedReads = 0;
+
+  constructor(private readonly tree: Map<string, HostEntry>) {}
+
+  reset(): void {
+    this.lists = 0;
+    this.stats = 0;
+    this.reads = 0;
+    this.rangedReads = 0;
+  }
+
+  private entryStat(rel: string, entry: HostEntry): MountDirEntry {
+    const name = rel.slice(rel.lastIndexOf('/') + 1);
+    if (entry.kind === 'directory') return { name, kind: 'directory' };
+    // A file the bridge could not stat comes back as a bare name + kind.
+    if (entry.size === undefined || entry.mtime === undefined) return { name, kind: 'file' };
+    return {
+      name,
+      kind: 'file',
+      size: entry.size,
+      lastModified: entry.mtime,
+      ctime: entry.mtime,
+      ino: 1000 + rel.length,
+      uid: 501,
+      gid: 20,
+      mode: 0o100644,
+    };
+  }
+
+  async readDir(path: string): Promise<MountDirEntry[]> {
+    this.lists++;
+    const dir = path.replace(/^\/+|\/+$/g, '');
+    const prefix = dir === '' || dir === '/' ? '' : `${dir}/`;
+    const entries: MountDirEntry[] = [];
+    for (const [rel, entry] of this.tree) {
+      if (!rel.startsWith(prefix)) continue;
+      const rest = rel.slice(prefix.length);
+      if (rest === '' || rest.includes('/')) continue;
+      entries.push(this.entryStat(rel, entry));
+    }
+    return entries;
+  }
+
+  async readFile(path: string): Promise<Uint8Array> {
+    this.reads++;
+    const rel = path.replace(/^\/+/, '');
+    const entry = this.tree.get(rel);
+    if (!entry) throw new FsError('ENOENT', 'no such file', path);
+    return new Uint8Array(entry.size ?? 0).fill(7);
+  }
+
+  /** #2752: a window over the same bytes, without pulling the whole file. */
+  async readFileRange(path: string, start: number, end: number): Promise<Uint8Array> {
+    this.rangedReads++;
+    return (await this.readFile(path)).subarray(start, end);
+  }
+
+  async writeFile(): Promise<void> {}
+
+  async stat(path: string): Promise<MountStat> {
+    this.stats++;
+    const rel = path.replace(/^\/+/, '');
+    const entry = this.tree.get(rel);
+    if (!entry) throw new FsError('ENOENT', 'no such file', path);
+    if (entry.kind === 'directory') return { kind: 'directory', size: 0, mtime: entry.mtime ?? 0 };
+    return {
+      kind: 'file',
+      size: entry.size ?? 0,
+      mtime: entry.mtime ?? 0,
+      ctime: entry.mtime ?? 0,
+      ino: 1000 + rel.length,
+      uid: 501,
+      gid: 20,
+      mode: 0o100644,
+    };
+  }
+
+  async mkdir(): Promise<void> {}
+
+  async remove(): Promise<void> {}
+
+  async refresh(): Promise<RefreshReport> {
+    return { added: [], removed: [], changed: [], unchanged: 0, errors: [] };
+  }
+
+  describe(): MountDescription {
+    return { displayName: 'counting' };
+  }
+
+  async close(): Promise<void> {}
+
+  getHostPath(): string {
+    return '/counting';
+  }
+}
+
+/** `FileSystem.readdirDeep` — list a directory, then stat each name. */
+async function readdirDeep(
+  fs: {
+    readdir(p: string): Promise<string[]>;
+    stat(p: string): Promise<{ isDirectory(): boolean }>;
+  },
+  dir: string
+): Promise<string[]> {
+  const names = await fs.readdir(dir);
+  const nested = await Promise.all(
+    names.map(async (name) => {
+      const child = `${dir}/${name}`;
+      return (await fs.stat(child)).isDirectory() ? readdirDeep(fs, child) : [child];
+    })
+  );
+  return nested.flat();
+}
+
+describe('isomorphic-git adapter readdir-primed stat cache (#2716)', () => {
+  let vfs: VirtualFS;
+  let backend: CountingBackend;
+
+  /** A `refs/heads` shaped tree: two ref files plus a nested namespace. */
+  async function mountRefs(): Promise<void> {
+    backend = new CountingBackend(
+      new Map<string, HostEntry>([
+        ['main', { kind: 'file', size: 41, mtime: 1_700_000_000_000 }],
+        ['next', { kind: 'file', size: 41, mtime: 1_700_000_100_000 }],
+        ['feature', { kind: 'directory' }],
+        ['feature/one', { kind: 'file', size: 41, mtime: 1_700_000_200_000 }],
+        ['feature/two', { kind: 'file', size: 41, mtime: 1_700_000_300_000 }],
+      ])
+    );
+    await vfs.mkdir('/mnt/refs', { recursive: true });
+    await vfs.mount('/mnt/refs', backend);
+  }
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({ dbName: `readdir-cache-${dbCounter++}`, wipe: true });
+  });
+
+  it('walks a listed tree with zero stat requests', async () => {
+    await mountRefs();
+    const client = createIsomorphicGitFs(vfs);
+    backend.reset();
+
+    const files = await readdirDeep(client.promises, '/mnt/refs');
+
+    expect(files.sort()).toEqual([
+      '/mnt/refs/feature/one',
+      '/mnt/refs/feature/two',
+      '/mnt/refs/main',
+      '/mnt/refs/next',
+    ]);
+    // One list per directory — and not a single stat, where the walk used to
+    // spend one round trip per entry.
+    expect(backend.lists).toBe(2);
+    expect(backend.stats).toBe(0);
+  });
+
+  it('answers exactly what the stat it replaced would have', async () => {
+    await mountRefs();
+    const client = createIsomorphicGitFs(vfs);
+    const uncached = await client.promises.lstat('/mnt/refs/main');
+    client.clearStatCache();
+    backend.reset();
+
+    await client.promises.readdir('/mnt/refs');
+    const cached = await client.promises.lstat('/mnt/refs/main');
+
+    expect(backend.stats).toBe(0);
+    // Everything `compareStats` looks at (#2708) survives the shortcut.
+    expect(cached.size).toBe(uncached.size);
+    expect(cached.mtimeMs).toBe(uncached.mtimeMs);
+    expect(cached.ctimeMs).toBe(uncached.ctimeMs);
+    expect(cached.ino).toBe(uncached.ino);
+    expect(cached.uid).toBe(uncached.uid);
+    expect(cached.gid).toBe(uncached.gid);
+    expect(cached.mode).toBe(uncached.mode);
+    expect(cached.isFile()).toBe(true);
+  });
+
+  it('does not answer for an entry the listing only half described', async () => {
+    // A raced entry: the bridge could not stat it, so it sent name + kind.
+    backend = new CountingBackend(new Map([['racy', { kind: 'file' as const }]]));
+    await vfs.mkdir('/mnt/racy', { recursive: true });
+    await vfs.mount('/mnt/racy', backend);
+    const client = createIsomorphicGitFs(vfs);
+    backend.reset();
+
+    await client.promises.readdir('/mnt/racy');
+    await client.promises.stat('/mnt/racy/racy');
+
+    // Zeroed placeholders are what make compareStats call a file stale
+    // forever (#2708) — a half-known entry must cost a real stat.
+    expect(backend.stats).toBe(1);
+  });
+
+  it('clears between git commands', async () => {
+    await mountRefs();
+    const client = createIsomorphicGitFs(vfs);
+    await client.promises.readdir('/mnt/refs');
+    client.clearStatCache();
+    backend.reset();
+
+    await client.promises.stat('/mnt/refs/main');
+
+    expect(backend.stats).toBe(1);
+  });
+
+  it('drops a path it wrote through', async () => {
+    await mountRefs();
+    const client = createIsomorphicGitFs(vfs);
+    await client.promises.readdir('/mnt/refs');
+    backend.reset();
+
+    await client.promises.writeFile('/mnt/refs/main', 'deadbeef\n');
+    const afterWrite = backend.stats;
+    await client.promises.stat('/mnt/refs/main');
+
+    // The write dropped the primed entry, so the stat goes to the bridge.
+    expect(backend.stats).toBe(afterWrite + 1);
+  });
+
+  it('normalizes cache keys, so a differently spelled path still hits', async () => {
+    await mountRefs();
+    const client = createIsomorphicGitFs(vfs);
+    backend.reset();
+
+    await client.promises.readdir('/mnt/refs/');
+    await client.promises.stat('/mnt/refs//main');
+    await client.promises.stat('/mnt/refs/feature/../main');
+
+    expect(backend.stats).toBe(0);
+  });
+
+  it('never answers a local symlink from the listing', async () => {
+    await vfs.writeFile('/target.txt', 'target\n');
+    await vfs.symlink('/target.txt', '/link.txt');
+    const client = createIsomorphicGitFs(vfs);
+
+    await client.promises.readdir('/');
+    const link = await client.promises.lstat('/link.txt');
+    const target = await client.promises.stat('/link.txt');
+
+    // lstat sees the link, stat follows it — a single cached answer could
+    // not be both.
+    expect(link.isSymbolicLink()).toBe(true);
+    expect(target.isFile()).toBe(true);
+    expect(target.size).toBe(7);
+  });
+
+  it('caps what it retains, dropping the oldest listing rather than growing', async () => {
+    await mountRefs();
+    const client = createIsomorphicGitFs(vfs, { statCacheMax: 3 });
+
+    await client.promises.readdir('/mnt/refs/feature'); // 2 files
+    await client.promises.readdir('/mnt/refs'); // 2 files + 1 dir
+    expect(client.statCacheSize()).toBeLessThanOrEqual(3);
+  });
+
+  it('primes nothing for a single listing bigger than the cap', async () => {
+    await mountRefs();
+    const client = createIsomorphicGitFs(vfs, { statCacheMax: 2 });
+    backend.reset();
+
+    await client.promises.readdir('/mnt/refs'); // 3 entries > cap of 2
+
+    // Clearing to "make room" and then inserting everything anyway would
+    // leave 3 entries behind — no cap for exactly the directory needing one.
+    expect(client.statCacheSize()).toBe(0);
+    await client.promises.stat('/mnt/refs/main');
+    expect(backend.stats).toBe(1);
+  });
+
+  // #2752 wired `readFile(path, {start, end})` through to the backend's
+  // ranged read. A read is not a write: it must neither invalidate what a
+  // listing primed nor leave anything behind for a path it never described.
+  it('leaves the stat cache alone across a ranged read', async () => {
+    await mountRefs();
+    const client = createIsomorphicGitFs(vfs);
+    await client.promises.readdir('/mnt/refs');
+    const before = await client.promises.stat('/mnt/refs/main');
+    backend.reset();
+
+    const slice = await client.promises.readFile('/mnt/refs/main', { start: 4, end: 12 });
+
+    expect(slice).toBeInstanceOf(Uint8Array);
+    expect((slice as Uint8Array).byteLength).toBe(8);
+    expect(backend.rangedReads).toBe(1);
+    // Still primed, still the same answer — the read went around the cache,
+    // not through it.
+    const after = await client.promises.stat('/mnt/refs/main');
+    expect(backend.stats).toBe(0);
+    expect(after.size).toBe(before.size);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+    expect(after.ino).toBe(before.ino);
+  });
+
+  it('does not let a ranged read stand in for a stat', async () => {
+    await mountRefs();
+    const client = createIsomorphicGitFs(vfs);
+    backend.reset();
+
+    // Nothing listed this path in this command, so reading part of it must
+    // not conjure metadata for it.
+    await client.promises.readFile('/mnt/refs/main', { start: 0, end: 4 });
+    await client.promises.stat('/mnt/refs/main');
+
+    expect(backend.stats).toBe(1);
+  });
+
+  it('caches local listings too, and keeps them honest', async () => {
+    await vfs.mkdir('/local');
+    await vfs.writeFile('/local/a.txt', 'abc');
+    const client = createIsomorphicGitFs(vfs);
+
+    const direct = await client.promises.lstat('/local/a.txt');
+    client.clearStatCache();
+    await client.promises.readdir('/local');
+    const primed = await client.promises.lstat('/local/a.txt');
+
+    expect(primed.size).toBe(direct.size);
+    expect(primed.mtimeMs).toBe(direct.mtimeMs);
+    expect(primed.ino).toBe(direct.ino);
+    expect(primed.mode).toBe(direct.mode);
+  });
+});

--- a/packages/webapp/tests/kernel/vfs-rpc-host.test.ts
+++ b/packages/webapp/tests/kernel/vfs-rpc-host.test.ts
@@ -153,6 +153,44 @@ describe('VfsRpcHost round-trip over MessageChannel', () => {
     ctx.stop();
   });
 
+  // #2716: the listing's stat fields are what spare the panel a stat per
+  // entry, so they have to survive the wire. They are optional, so a peer
+  // that sends none is answered exactly as before (the test above).
+  it('readDir carries the listing stat fields across the wire', async () => {
+    const ctx = setupRoundTrip();
+    ctx.vfs.readDir.mockResolvedValue([
+      {
+        name: 'a.txt',
+        type: 'file',
+        size: 11,
+        mtime: 1_700_000_000_000,
+        ctime: 1_700_000_500_000,
+        ino: 42,
+        uid: 501,
+        gid: 20,
+        mode: 0o100644,
+      },
+    ] satisfies DirEntry[]);
+    ctx.panelTransport.send({ type: 'vfs-read-dir', requestId: 'r-stats', path: '/mnt/host' });
+    await waitForResponses(ctx);
+    const resp = ctx.responses[0] as VfsReadDirResultMsg;
+    expect(resp.ok).toBe(true);
+    if (resp.ok) {
+      expect(resp.entries[0]).toEqual({
+        name: 'a.txt',
+        type: 'file',
+        size: 11,
+        mtime: 1_700_000_000_000,
+        ctime: 1_700_000_500_000,
+        ino: 42,
+        uid: 501,
+        gid: 20,
+        mode: 0o100644,
+      });
+    }
+    ctx.stop();
+  });
+
   it('readFile utf-8 returns the string payload', async () => {
     const ctx = setupRoundTrip();
     ctx.vfs.readFile.mockResolvedValue('hello world');

--- a/packages/webapp/tests/shell/vfs-adapter-listing-stats.test.ts
+++ b/packages/webapp/tests/shell/vfs-adapter-listing-stats.test.ts
@@ -1,0 +1,345 @@
+/**
+ * `ls -l` over a mount costs one listing, not one round trip per entry —
+ * issue #2716.
+ *
+ * just-bash's `DirentEntry` carries no size, so `ls -l` is a `readdir`
+ * followed by a `stat` per name (and `du` an `lstat` per name). Over a hostfs
+ * mount each of those was a bridge request for numbers the `list` response
+ * already carried — a 91-entry directory cost 91 of them.
+ *
+ * The counting backend asserts REQUESTS; the values are asserted against what
+ * an uncached stat returns, because a faster wrong answer is not a fix.
+ */
+
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../src/fs/index.js';
+import type {
+  MountBackend,
+  MountDescription,
+  MountDirEntry,
+  MountStat,
+  RefreshReport,
+} from '../../src/fs/mount/backend.js';
+import { FsError } from '../../src/fs/types.js';
+import { VfsAdapter } from '../../src/shell/vfs-adapter.js';
+
+let dbCounter = 0;
+
+/** Stands in for the hostfs bridge, counting every list and stat. */
+class CountingBackend implements MountBackend {
+  readonly kind = 'hostfs' as const;
+  readonly source = 'hostfs:///counting';
+  readonly mountId = 'counting-shell-backend';
+  /** Its listing numbers are what its stat reports — see #2716. */
+  readonly listingStatsMatchStat = true;
+  lists = 0;
+  stats = 0;
+
+  constructor(protected readonly files: Map<string, { size: number; mtime: number }>) {}
+
+  /** Subclass access to the fixture without widening `files` to public. */
+  protected entries(): Iterable<[string, { size: number; mtime: number }]> {
+    return this.files;
+  }
+
+  reset(): void {
+    this.lists = 0;
+    this.stats = 0;
+  }
+
+  async readDir(_path: string): Promise<MountDirEntry[]> {
+    this.lists++;
+    return [...this.files].map(([name, f]) => ({
+      name,
+      kind: 'file' as const,
+      size: f.size,
+      lastModified: f.mtime,
+      ctime: f.mtime,
+      ino: 700 + name.length,
+      uid: 501,
+      gid: 20,
+      mode: 0o100644,
+    }));
+  }
+
+  async readFile(): Promise<Uint8Array> {
+    return new Uint8Array();
+  }
+
+  async writeFile(): Promise<void> {}
+
+  async stat(path: string): Promise<MountStat> {
+    this.stats++;
+    const name = path.replace(/^\/+/, '');
+    const file = this.files.get(name);
+    if (!file) throw new FsError('ENOENT', 'no such file', path);
+    return {
+      kind: 'file',
+      size: file.size,
+      mtime: file.mtime,
+      ctime: file.mtime,
+      ino: 700 + name.length,
+      uid: 501,
+      gid: 20,
+      mode: 0o100644,
+    };
+  }
+
+  async mkdir(): Promise<void> {}
+
+  async remove(): Promise<void> {}
+
+  async refresh(): Promise<RefreshReport> {
+    return { added: [], removed: [], changed: [], unchanged: 0, errors: [] };
+  }
+
+  describe(): MountDescription {
+    return { displayName: 'counting' };
+  }
+
+  async close(): Promise<void> {}
+
+  getHostPath(): string {
+    return '/counting';
+  }
+}
+
+/**
+ * Same counting contract, but path-aware: it holds a `d<N>/f<M>.txt` tree so
+ * a walk can list many directories in a row.
+ */
+class TreeBackend extends CountingBackend {
+  override async readDir(path: string): Promise<MountDirEntry[]> {
+    this.lists++;
+    const dir = path.replace(/^\/+|\/+$/g, '');
+    const prefix = dir === '' ? '' : `${dir}/`;
+    const out: MountDirEntry[] = [];
+    for (const [rel, f] of this.entries()) {
+      if (!rel.startsWith(prefix)) continue;
+      const rest = rel.slice(prefix.length);
+      if (rest === '' || rest.includes('/')) continue;
+      out.push({
+        name: rest,
+        kind: 'file',
+        size: f.size,
+        lastModified: f.mtime,
+        ctime: f.mtime,
+        ino: 700 + rel.length,
+        uid: 501,
+        gid: 20,
+        mode: 0o100644,
+      });
+    }
+    return out;
+  }
+}
+
+describe('VfsAdapter listing-primed stats (#2716)', () => {
+  let vfs: VirtualFS;
+  let adapter: VfsAdapter;
+  let backend: CountingBackend;
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({ dbName: `vfs-adapter-listing-${dbCounter++}`, wipe: true });
+    adapter = new VfsAdapter(vfs);
+    backend = new CountingBackend(
+      new Map([
+        ['a.txt', { size: 11, mtime: 1_700_000_000_000 }],
+        ['b.txt', { size: 22, mtime: 1_700_000_100_000 }],
+        ['c.txt', { size: 33, mtime: 1_700_000_200_000 }],
+      ])
+    );
+    await vfs.mkdir('/mnt/host', { recursive: true });
+    await vfs.mount('/mnt/host', backend);
+  });
+
+  /** What `ls -l` does: one readdir, then a stat per name. */
+  async function lsLong(dir: string): Promise<{ name: string; size: number; mtime: number }[]> {
+    const names = await adapter.readdir(dir);
+    const rows = [];
+    for (const name of names) {
+      const stat = await adapter.stat(`${dir}/${name}`);
+      rows.push({ name, size: stat.size, mtime: stat.mtime.getTime() });
+    }
+    return rows;
+  }
+
+  it('stats nothing over the bridge for an `ls -l`', async () => {
+    backend.reset();
+    const rows = await lsLong('/mnt/host');
+
+    expect(rows).toEqual([
+      { name: 'a.txt', size: 11, mtime: 1_700_000_000_000 },
+      { name: 'b.txt', size: 22, mtime: 1_700_000_100_000 },
+      { name: 'c.txt', size: 33, mtime: 1_700_000_200_000 },
+    ]);
+    expect(backend.lists).toBe(1);
+    expect(backend.stats).toBe(0);
+  });
+
+  it('answers exactly what the stat it replaced would have', async () => {
+    const uncached = await adapter.stat('/mnt/host/a.txt');
+    await adapter.readdir('/mnt/host');
+    backend.reset();
+    const cached = await adapter.stat('/mnt/host/a.txt');
+
+    expect(backend.stats).toBe(0);
+    expect(cached).toEqual(uncached);
+  });
+
+  it('serves `du`’s lstat from the same listing', async () => {
+    await adapter.readdirWithFileTypes('/mnt/host');
+    backend.reset();
+    const stat = await adapter.lstat('/mnt/host/b.txt');
+
+    expect(backend.stats).toBe(0);
+    expect(stat.size).toBe(22);
+    expect(stat.isSymbolicLink).toBe(false);
+  });
+
+  it('goes back to the bridge once the listing is older than the TTL', async () => {
+    vi.useFakeTimers();
+    try {
+      await adapter.readdir('/mnt/host');
+      backend.reset();
+      vi.advanceTimersByTime(1001);
+      await adapter.stat('/mnt/host/a.txt');
+      expect(backend.stats).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('forgets the listing as soon as the shell writes', async () => {
+    await adapter.readdir('/mnt/host');
+    await adapter.writeFile('/mnt/host/a.txt', 'rewritten');
+    backend.reset();
+
+    await adapter.stat('/mnt/host/b.txt');
+
+    // Blunt on purpose: a write invalidates the whole table, not one path.
+    expect(backend.stats).toBe(1);
+  });
+
+  it('still stats a path no listing reported', async () => {
+    await adapter.readdir('/mnt/host');
+    backend.reset();
+
+    await expect(adapter.stat('/mnt/host/never-listed.txt')).rejects.toThrow();
+
+    // Nothing is invented for a name the listing did not carry.
+    expect(backend.stats).toBe(1);
+  });
+
+  it('keeps lstat and stat apart for a symlink', async () => {
+    // The listing path never caches a symlink, so these two must still
+    // disagree: lstat describes the link, stat follows it.
+    await vfs.writeFile('/target.txt', 'target\n');
+    await vfs.symlink('/target.txt', '/link.txt');
+
+    await adapter.readdir('/');
+    const link = await adapter.lstat('/link.txt');
+    const target = await adapter.stat('/link.txt');
+
+    expect(link.isSymbolicLink).toBe(true);
+    expect(target.isFile).toBe(true);
+    expect(target.size).toBe(7);
+  });
+});
+
+/**
+ * The TTL bounds how long an entry may be REUSED, not how long it is
+ * RETAINED — expiry is only noticed when that exact path is looked up again.
+ * Without a cap, an `ls -R` / `du -sh` over a big mount would pile every
+ * directory it ever walked into a map that lives as long as the shell.
+ */
+describe('VfsAdapter listing cache stays bounded (#2716)', () => {
+  let vfs: VirtualFS;
+  let dbId = 0;
+
+  /** A mount whose directories each hold `perDir` measurable files. */
+  async function mountTree(dirs: number, perDir: number): Promise<CountingBackend> {
+    const files = new Map<string, { size: number; mtime: number }>();
+    for (let d = 0; d < dirs; d++) {
+      for (let f = 0; f < perDir; f++) {
+        files.set(`d${d}/f${f}.txt`, { size: f + 1, mtime: 1_700_000_000_000 + f });
+      }
+    }
+    const backend = new TreeBackend(files);
+    await vfs.mkdir('/mnt/tree', { recursive: true });
+    await vfs.mount('/mnt/tree', backend);
+    return backend;
+  }
+
+  beforeEach(async () => {
+    vfs = await VirtualFS.create({ dbName: `vfs-adapter-bounded-${dbId++}`, wipe: true });
+  });
+
+  it('never retains more than the cap while walking a big tree', async () => {
+    const adapter = new VfsAdapter(vfs, { listingStatsMax: 10 });
+    await mountTree(20, 4);
+
+    for (let d = 0; d < 20; d++) {
+      await adapter.readdir(`/mnt/tree/d${d}`);
+      expect(adapter.listingStatsSize).toBeLessThanOrEqual(10);
+    }
+
+    // 80 entries walked, at most one cap's worth retained.
+    expect(adapter.listingStatsSize).toBeLessThanOrEqual(10);
+  });
+
+  it('primes nothing for a single listing bigger than the cap', async () => {
+    const adapter = new VfsAdapter(vfs, { listingStatsMax: 3 });
+    const backend = await mountTree(1, 8);
+
+    await adapter.readdir('/mnt/tree/d0');
+
+    // Clearing to "make room" and then inserting anyway would leave 8
+    // entries behind — i.e. no cap for exactly the directory that needs one.
+    expect(adapter.listingStatsSize).toBe(0);
+    backend.reset();
+    await adapter.stat('/mnt/tree/d0/f0.txt');
+    expect(backend.stats).toBe(1);
+  });
+
+  it('sweeps entries that expired while other directories were listed', async () => {
+    vi.useFakeTimers();
+    try {
+      const adapter = new VfsAdapter(vfs, { listingStatsMax: 1000, listingStatsTtlMs: 1000 });
+      await mountTree(3, 4);
+
+      await adapter.readdir('/mnt/tree/d0');
+      expect(adapter.listingStatsSize).toBe(4);
+      vi.advanceTimersByTime(1001);
+
+      // Priming an unrelated directory evicts what expired, instead of
+      // waiting for someone to look d0's entries up again.
+      await adapter.readdir('/mnt/tree/d1');
+      expect(adapter.listingStatsSize).toBe(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps live entries when it sweeps', async () => {
+    vi.useFakeTimers();
+    try {
+      const adapter = new VfsAdapter(vfs, { listingStatsMax: 1000, listingStatsTtlMs: 1000 });
+      const backend = await mountTree(2, 2);
+
+      await adapter.readdir('/mnt/tree/d0');
+      vi.advanceTimersByTime(500);
+      await adapter.readdir('/mnt/tree/d1');
+      expect(adapter.listingStatsSize).toBe(4);
+      backend.reset();
+
+      // Both listings are still inside the TTL, so neither costs a stat.
+      await adapter.stat('/mnt/tree/d0/f0.txt');
+      await adapter.stat('/mnt/tree/d1/f0.txt');
+      expect(backend.stats).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/webapp/tests/ui/wc/wc-workbench.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-workbench.test.ts
@@ -112,9 +112,55 @@ describe('buildVfsTreeItems', () => {
     const wsChildren = wsRoot?.kind === 'dir' ? wsRoot.children : [];
     const claudeMd = wsChildren.find((i) => i.kind === 'file' && i.id === '/workspace/CLAUDE.md');
     expect(claudeMd?.kind).toBe('file');
-    // size comes from stat(); the content is '# memory' (9 bytes).
+    // size comes from the listing; the content is '# memory' (9 bytes).
     expect(claudeMd?.kind === 'file' && typeof claudeMd.size).toBe('number');
     expect(claudeMd?.kind === 'file' && (claudeMd.size ?? 0) > 0).toBe(true);
+  });
+
+  // #2716: over a hostfs mount, stat'ing every listed file is one bridge
+  // round trip per file. The listing already carries the size.
+  it('takes sizes from the listing instead of stat’ing every file', async () => {
+    const base = await seededFs();
+    let stats = 0;
+    const counting: LocalVfsClient = {
+      readDir: (path) => base.readDir(path),
+      readFile: (path, options) => base.readFile(path, options),
+      stat: (path) => {
+        stats++;
+        return base.stat(path);
+      },
+    };
+
+    const items = await buildVfsTreeItems(counting);
+
+    const wsRoot = items.find((i) => i.kind === 'dir' && i.id === '/workspace');
+    const wsChildren = wsRoot?.kind === 'dir' ? wsRoot.children : [];
+    const claudeMd = wsChildren.find((i) => i.kind === 'file' && i.id === '/workspace/CLAUDE.md');
+    expect(claudeMd?.kind === 'file' && claudeMd.size).toBe(8);
+    expect(stats).toBe(0);
+  });
+
+  it('still stats a file whose listing carried no size', async () => {
+    const base = await seededFs();
+    let stats = 0;
+    const stripped: LocalVfsClient = {
+      // What a backend that reports nothing but names looks like.
+      readDir: async (path) =>
+        (await base.readDir(path)).map((e) => ({ name: e.name, type: e.type })),
+      readFile: (path, options) => base.readFile(path, options),
+      stat: (path) => {
+        stats++;
+        return base.stat(path);
+      },
+    };
+
+    const items = await buildVfsTreeItems(stripped);
+
+    const wsRoot = items.find((i) => i.kind === 'dir' && i.id === '/workspace');
+    const wsChildren = wsRoot?.kind === 'dir' ? wsRoot.children : [];
+    const claudeMd = wsChildren.find((i) => i.kind === 'file' && i.id === '/workspace/CLAUDE.md');
+    expect(claudeMd?.kind === 'file' && claudeMd.size).toBe(8);
+    expect(stats).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary

`readDir` now carries the stat fields the backend already paid for, and the three consumers that were re-stat'ing every entry they had just listed use them.

## Root cause

`/api/hostfs/list` stats every dirent server-side, so `size` + `lastModified` (and, since #2708, `ctime`/`ino`/`uid`/`gid`/`mode`) arrive with the listing, and `HostFsMountBackend.readDir` parses them into `MountDirEntry`. `VirtualFS.readDirMounted` then kept only `{name, type}` and the isomorphic-git adapter reduced that to names — so every consumer that needed a type or a size issued one `/api/hostfs/stat` per entry, each a full HTTP request plus a CORS preflight (#2715):

- `git branch`: 125 requests for 29 refs — 22 `list` + **100 `stat`** (`FileSystem.readdirDeep` stats every name to decide whether to recurse)
- Files panel (`dirChildren`): one stat per file, purely for its size
- `ls -l` / `du`: one stat per entry (just-bash's `DirentEntry` carries no size)

## What changed

**`fs/types.ts`** — `DirEntry` extends a new `DirEntryStats` (all optional: `size`, `mtime`, `ctime`, `ino`, `uid`, `gid`, `mode`), plus `statsFromDirEntry()`: the single rule for when a listing may stand in for a stat. It refuses a **symlink** (the listing describes the link, a `stat` describes its target) and anything missing `size`/`mtime`, because zeroed placeholders are exactly what make `compareStats` call a file stale and rewrite `.git/index` per file (#2708). `ctime` falls back to `mtime`, matching `VirtualFS.stat`.

**`fs/virtual-fs.ts`** — `readDirMounted` projects `MountDirEntry` onto `DirEntry` with the fields the backend reported; `statDirEntry` and `readDirSync` report what the `lstat` they already do returned (free), leaving symlink entries bare.

**`git/vfs-fs-adapter.ts`** — `readdir` primes a stat cache that `stat`/`lstat` answer from. A file is cached only when the listing carried the full set; a directory is cached type-only (all `readdirDeep`/`GitWalkerFs` ask of one, and directories never appear in `.git/index`). Any write through the adapter drops the path, `rmdir` drops the whole table (subtree), keys are normalized, and `GitCommands.execute` clears the cache in a `finally` so a listing never answers the *next* command.

**`shell/vfs-adapter.ts`** — `readdir`/`readdirWithFileTypes` prime the same kind of table for the mount slow path; `stat`/`lstat` answer from it for 1 s (`LISTING_STAT_TTL_MS`), and every mutation through the adapter clears it. That bounds the one case the adapter cannot see: a change made outside it between the listing and the stat.

**`ui/wc/wc-workbench.ts`** — reads `entry.size` from the listing, stats only the entries a listing left unknown.

**`kernel/messages.ts`** — `VfsDirEntryEnvelope` mirrors the optional fields. Additive: a peer that sends none is answered exactly as before.

**`docs/mounts.md`** — new "Listings carry stats (no re-stat per entry)" section under the wire shape, including the two invariants a backend has to keep.

Not in scope: both bridges still send a bare `{name, kind}` for directories, so a consumer that needs a directory's size or mtime still stats it (noted in the doc). `MountIndex`'s fast path (FSA mounts only) stores paths, not sizes, and is unchanged.

## How verified

- `npm run lint` — **exit 0** (43 pre-existing warnings, no errors)
- `npm run typecheck` — **pass** (all 9 projects)
- `npm run test` — **18463 passed, 3 failed**; the 3 are pre-existing and unrelated (2× `slicc-fs-module.test.ts` pyodide `loadPyodide` 5 s timeout — reproduced identically on a stashed, clean tree; 1× `service-worker-mount-sign-and-forward-port.test.ts`, passes on re-run). Touched suites (`tests/fs`, `tests/git`, `tests/shell`, `tests/kernel`, `tests/ui/wc/wc-workbench`) are green.
- `npm run test:coverage:webapp` — **exit 0** (821 files / 14810 tests; statements 82.45%, branches 74.04%, functions 82.33%, lines 84.47%)
- `npm run build -w @slicc/webapp` — **exit 0**
- `node packages/dev-tools/tools/check-first-load-size.mjs` — **OK**, worker +2.1 kB vs base, 82 kB under ceiling (allowance 5 kB)
- `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists (both baselines empty); commit hook re-ran the layer-back-edge and `Record<string, unknown>` gates: ok
- `npm run deadcode -- --no-progress --reporter compact` and `npm run deadcode:production-files …` — **exit 0**

New tests (counting backends assert **requests**, not just values):

- `tests/fs/dir-entry-stats.test.ts` — `statsFromDirEntry` rules; mount/local/sync `readDir` carry the fields; a listing agrees with `stat` for the same path.
- `tests/git/vfs-fs-adapter-readdir-cache.test.ts` — a `readdirDeep`-shaped walk of a `refs/heads` tree costs **2 lists, 0 stats**; a cached answer is field-for-field the stat it replaced; a half-described entry, a `clearStatCache()`, and a write each cost a real stat; symlinks are never served from the cache.
- `tests/git/git-commands-stat-cache.test.ts` — `GitCommands.execute` clears the cache on both the success and the failure path.
- `tests/shell/vfs-adapter-listing-stats.test.ts` — `ls -l` over a mount = **1 list, 0 stats**, identical values; `du`'s `lstat` too; TTL expiry, write invalidation and an unlisted path all fall back.
- `tests/ui/wc/wc-workbench.test.ts` — the panel stats **0** files when the listing carries sizes, and still stats when it does not.
- `tests/kernel/vfs-rpc-host.test.ts` — the fields survive the `vfs-read-dir` round trip.

Fixes #2716

🤖 Generated with [Claude Code](https://claude.com/claude-code)
