### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -22,8 +22,8 @@
     "node-server": {
       "lines": 83,
       "statements": 81,
-      "functions": 84,
-      "branches": 71,
+      "functions": 85,
+      "branches": 72,
       "coverageExclude": [
         "**/node_modules/**",
         "**/dist/**",


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.