### PR TITLE
perf(git): persist pack caches across commands

### DIFF
--- a/packages/webapp/src/git/cached-isomorphic-git.ts
+++ b/packages/webapp/src/git/cached-isomorphic-git.ts
@@ -1,0 +1,149 @@
+/**
+ * isomorphic-git facade with a persistent object/pack cache per repository.
+ *
+ * The upstream API creates a new cache object whenever a caller omits one.
+ * GitCommands binds its per-repository cache to the filesystem view for each
+ * invocation; cache-aware calls below then receive it automatically.
+ */
+
+import * as upstream from 'isomorphic-git';
+import { normalizePath } from '../fs/path-utils.js';
+import type { IsoGitFsPromises } from './vfs-fs-adapter.js';
+
+export * from 'isomorphic-git';
+
+const cacheForFs = new WeakMap<object, () => Promise<object>>();
+
+interface CacheEntry {
+  fingerprint: string;
+  cache: object;
+}
+
+/** Stable missing-file errors; any other failure disables reuse for safety. */
+const MISSING_CODES = new Set(['ENOENT', 'ENOTDIR']);
+
+function errorCodeOf(error: unknown): string | undefined {
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+async function statFingerprint(fs: IsoGitFsPromises, path: string): Promise<string | null> {
+  try {
+    const stat = await fs.stat(path);
+    return `${stat.mtimeMs}:${stat.size}`;
+  } catch (error) {
+    return MISSING_CODES.has(errorCodeOf(error) ?? '') ? '-' : null;
+  }
+}
+
+async function directoryFingerprint(fs: IsoGitFsPromises, path: string): Promise<string | null> {
+  try {
+    return (await fs.readdir(path)).slice().sort().join('\u0000');
+  } catch (error) {
+    return MISSING_CODES.has(errorCodeOf(error) ?? '') ? '-' : null;
+  }
+}
+
+async function repositoryFingerprint(
+  fs: IsoGitFsPromises,
+  dir: string
+): Promise<string | undefined> {
+  const root = normalizePath(dir);
+  const gitdir = root === '/' ? '/.git' : `${root}/.git`;
+  const packDir = `${gitdir}/objects/pack`;
+  const parts = await Promise.all([
+    directoryFingerprint(fs, packDir),
+    statFingerprint(fs, packDir),
+    statFingerprint(fs, `${gitdir}/packed-refs`),
+  ]);
+  return parts.some((part) => part === null) ? undefined : parts.join('\n');
+}
+
+/**
+ * Owns cache lifetime for one GitCommands instance.
+ *
+ * Pack/index filenames are content-addressed. Their directory listing and
+ * metadata, plus packed-refs metadata, cheaply detect repository changes. If
+ * validation itself fails, a fresh unretained cache preserves correctness.
+ */
+export class GitObjectCache {
+  private readonly entries = new Map<string, CacheEntry>();
+
+  /** Bind lazily: commands that only resolve a ref never inspect objects/pack. */
+  bind(fs: IsoGitFsPromises, dir: string): void {
+    let pending: Promise<object> | undefined;
+    cacheForFs.set(fs, () => {
+      pending ??= this.resolve(fs, dir);
+      return pending;
+    });
+  }
+
+  private async resolve(fs: IsoGitFsPromises, dir: string): Promise<object> {
+    const key = normalizePath(dir);
+    const fingerprint = await repositoryFingerprint(fs, key);
+    if (fingerprint === undefined) {
+      this.entries.delete(key);
+      return {};
+    }
+
+    const current = this.entries.get(key);
+    if (current?.fingerprint === fingerprint) return current.cache;
+
+    const next = { fingerprint, cache: {} };
+    this.entries.set(key, next);
+    return next.cache;
+  }
+}
+
+async function withPersistentCache<T extends { fs: unknown; cache?: object }>(
+  options: T
+): Promise<T> {
+  if ((typeof options.fs !== 'object' && typeof options.fs !== 'function') || !options.fs) {
+    return options;
+  }
+  const cache = await cacheForFs.get(options.fs)?.();
+  return cache ? { ...options, cache } : options;
+}
+
+function cached<TOptions extends { fs: unknown; cache?: object }, TResult>(
+  operation: () => (options: TOptions) => Promise<TResult>
+): (options: TOptions) => Promise<TResult> {
+  return async (options) => operation()(await withPersistentCache(options));
+}
+
+// Resolve the upstream property at call time so Vitest spies installed after
+// module evaluation still observe command calls.
+export const abortMerge = cached(() => upstream.abortMerge);
+export const add = cached(() => upstream.add);
+export const addNote = cached(() => upstream.addNote);
+export const annotatedTag = cached(() => upstream.annotatedTag);
+export const checkout = cached(() => upstream.checkout);
+export const cherryPick = cached(() => upstream.cherryPick);
+export const clone = cached(() => upstream.clone);
+export const commit = cached(() => upstream.commit);
+export const expandOid = cached(() => upstream.expandOid);
+export const fastForward = cached(() => upstream.fastForward);
+export const fetch = cached(() => upstream.fetch);
+export const findMergeBase = cached(() => upstream.findMergeBase);
+export const indexPack = cached(() => upstream.indexPack);
+export const isDescendent = cached(() => upstream.isDescendent);
+export const listFiles = cached(() => upstream.listFiles);
+export const listNotes = cached(() => upstream.listNotes);
+export const log = cached(() => upstream.log);
+export const merge = cached(() => upstream.merge);
+export const packObjects = cached(() => upstream.packObjects);
+export const pull = cached(() => upstream.pull);
+export const push = cached(() => upstream.push);
+export const readBlob = cached(() => upstream.readBlob);
+export const readCommit = cached(() => upstream.readCommit);
+export const readNote = cached(() => upstream.readNote);
+export const readObject = cached(() => upstream.readObject);
+export const readTag = cached(() => upstream.readTag);
+export const readTree = cached(() => upstream.readTree);
+export const remove = cached(() => upstream.remove);
+export const removeNote = cached(() => upstream.removeNote);
+export const resetIndex = cached(() => upstream.resetIndex);
+export const status = cached(() => upstream.status);
+export const statusMatrix = cached(() => upstream.statusMatrix);
+export const tag = cached(() => upstream.tag);
+export const walk = cached(() => upstream.walk);

--- a/packages/webapp/src/git/commands/add.ts
+++ b/packages/webapp/src/git/commands/add.ts
@@ -1,6 +1,6 @@
 /** `git add` and its staging-mode helpers. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function add(

--- a/packages/webapp/src/git/commands/branch.ts
+++ b/packages/webapp/src/git/commands/branch.ts
@@ -1,6 +1,6 @@
 /** `git branch` — list, create, or delete branches. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function branch(

--- a/packages/webapp/src/git/commands/checkout.ts
+++ b/packages/webapp/src/git/commands/checkout.ts
@@ -1,6 +1,6 @@
 /** `git checkout` — switch branches, create branches, or restore files. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import { expandGitError } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 

--- a/packages/webapp/src/git/commands/cherry-pick.ts
+++ b/packages/webapp/src/git/commands/cherry-pick.ts
@@ -8,8 +8,8 @@
  * are rejected natively by `cherryPick`; we format those into git-style errors.
  */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { makeMergeDriver } from './merge-driver.js';
 import { tryResolveRevision } from './revision.js';
 import { expandGitError, GIT_FLAG_SPECS } from './shared.js';

--- a/packages/webapp/src/git/commands/clean.ts
+++ b/packages/webapp/src/git/commands/clean.ts
@@ -8,8 +8,8 @@
  * that safety default so `git clean` alone doesn't silently delete anything.
  */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { CLEAN_SPEC, NO_INDEX_REFRESH } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 

--- a/packages/webapp/src/git/commands/clone.ts
+++ b/packages/webapp/src/git/commands/clone.ts
@@ -1,8 +1,8 @@
 /** `git clone` plus its target-dir error formatter. */
 
-import * as git from 'isomorphic-git';
 import { joinPath, normalizePath } from '../../fs/path-utils.js';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { gitHttp } from '../git-http.js';
 import { expandGitError, flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';

--- a/packages/webapp/src/git/commands/commit.ts
+++ b/packages/webapp/src/git/commands/commit.ts
@@ -1,7 +1,7 @@
 /** `git commit` plus auto-staging and combined-flag expansion helpers. */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 

--- a/packages/webapp/src/git/commands/config.ts
+++ b/packages/webapp/src/git/commands/config.ts
@@ -1,6 +1,6 @@
 /** `git config` — get, set, unset, and list repo/global config. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import {
   GLOBAL_GITCONFIG_PATH,
   readGlobalGitConfigValue,

--- a/packages/webapp/src/git/commands/diff.ts
+++ b/packages/webapp/src/git/commands/diff.ts
@@ -6,8 +6,8 @@
  * the stat formatter stay module-local.
  */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { diffStat, unifiedDiff } from '../diff.js';
 import { matchesPathspec, pathspecCouldMatch, resolveRevision } from './revision.js';
 import { GIT_FLAG_SPECS, NO_INDEX_REFRESH } from './shared.js';

--- a/packages/webapp/src/git/commands/fetch.ts
+++ b/packages/webapp/src/git/commands/fetch.ts
@@ -1,7 +1,7 @@
 /** `git fetch`. */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { gitHttp } from '../git-http.js';
 import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';

--- a/packages/webapp/src/git/commands/init.ts
+++ b/packages/webapp/src/git/commands/init.ts
@@ -1,7 +1,7 @@
 /** `git init`. */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 

--- a/packages/webapp/src/git/commands/log.ts
+++ b/packages/webapp/src/git/commands/log.ts
@@ -1,7 +1,7 @@
 /** `git log` plus its all-branches, formatting, and per-commit stat helpers. */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { diffCommits, diffInitialCommit } from './diff.js';
 import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';

--- a/packages/webapp/src/git/commands/ls-files.ts
+++ b/packages/webapp/src/git/commands/ls-files.ts
@@ -1,6 +1,6 @@
 /** `git ls-files` — list tracked / modified / deleted / other files. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import { NO_INDEX_REFRESH } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 

--- a/packages/webapp/src/git/commands/ls-remote.ts
+++ b/packages/webapp/src/git/commands/ls-remote.ts
@@ -1,6 +1,6 @@
 /** `git ls-remote` — inspect advertised refs without fetching objects. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import { gitHttp } from '../git-http.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 

--- a/packages/webapp/src/git/commands/ls-tree.ts
+++ b/packages/webapp/src/git/commands/ls-tree.ts
@@ -9,8 +9,8 @@
  * pathspec are descended silently so nested targets are reachable.
  */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { tryResolveRevision } from './revision.js';
 import { GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';

--- a/packages/webapp/src/git/commands/merge-base.ts
+++ b/packages/webapp/src/git/commands/merge-base.ts
@@ -1,6 +1,6 @@
 /** `git merge-base` and `--is-ancestor`. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import { resolveRevision } from './revision.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 

--- a/packages/webapp/src/git/commands/merge.ts
+++ b/packages/webapp/src/git/commands/merge.ts
@@ -1,7 +1,7 @@
 /** `git merge` and its error formatter. */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { makeMergeDriver } from './merge-driver.js';
 import { GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';

--- a/packages/webapp/src/git/commands/mv.ts
+++ b/packages/webapp/src/git/commands/mv.ts
@@ -1,6 +1,6 @@
 /** `git mv` — move or rename a file. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function mv(

--- a/packages/webapp/src/git/commands/pull.ts
+++ b/packages/webapp/src/git/commands/pull.ts
@@ -1,7 +1,7 @@
 /** `git pull`. */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { gitHttp } from '../git-http.js';
 import { GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';

--- a/packages/webapp/src/git/commands/push.ts
+++ b/packages/webapp/src/git/commands/push.ts
@@ -1,7 +1,7 @@
 /** `git push`. */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { gitHttp } from '../git-http.js';
 import { GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';

--- a/packages/webapp/src/git/commands/rebase.ts
+++ b/packages/webapp/src/git/commands/rebase.ts
@@ -14,8 +14,8 @@
  * merge commits are out of scope and rejected clearly.
  */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { makeMergeDriver } from './merge-driver.js';
 import { tryResolveRevision } from './revision.js';
 import { expandGitError, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';

--- a/packages/webapp/src/git/commands/remote.ts
+++ b/packages/webapp/src/git/commands/remote.ts
@@ -1,6 +1,6 @@
 /** `git remote` — add, remove, or list remotes. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function remote(

--- a/packages/webapp/src/git/commands/reset.ts
+++ b/packages/webapp/src/git/commands/reset.ts
@@ -1,6 +1,6 @@
 /** `git reset` — unstage, or move HEAD/index/workdir (soft/mixed/hard). */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function reset(

--- a/packages/webapp/src/git/commands/rev-parse.ts
+++ b/packages/webapp/src/git/commands/rev-parse.ts
@@ -1,6 +1,6 @@
 /** `git rev-parse`. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import { resolveRevision } from './revision.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 

--- a/packages/webapp/src/git/commands/revert.ts
+++ b/packages/webapp/src/git/commands/revert.ts
@@ -12,8 +12,8 @@
  * without committing. Merge commits are rejected like real git.
  */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { threeWayMerge } from '../merge-file-core.js';
 import { tryResolveRevision } from './revision.js';
 import { expandGitError, GIT_FLAG_SPECS } from './shared.js';

--- a/packages/webapp/src/git/commands/revision.ts
+++ b/packages/webapp/src/git/commands/revision.ts
@@ -1,6 +1,6 @@
 /** Shared Git revision resolution, including first-parent suffixes. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import type { GitCommandContext } from './types.js';
 
 type RevisionStep = { kind: 'first-parent' | 'parent'; count: number };

--- a/packages/webapp/src/git/commands/rm.ts
+++ b/packages/webapp/src/git/commands/rm.ts
@@ -1,6 +1,6 @@
 /** `git rm` — remove files from the working tree and index. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function rm(

--- a/packages/webapp/src/git/commands/show-ref.ts
+++ b/packages/webapp/src/git/commands/show-ref.ts
@@ -1,6 +1,6 @@
 /** `git show-ref` — list branch and tag references. */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function showRef(

--- a/packages/webapp/src/git/commands/show.ts
+++ b/packages/webapp/src/git/commands/show.ts
@@ -1,7 +1,7 @@
 /** `git show` — commit details and diff, or `<commit>:<path>` file content. */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { diffCommits, diffInitialCommit } from './diff.js';
 import { tryResolveRevision } from './revision.js';
 import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';

--- a/packages/webapp/src/git/commands/stash.ts
+++ b/packages/webapp/src/git/commands/stash.ts
@@ -3,7 +3,7 @@
  * as a chained commit history (each stash's second parent is the previous one).
  */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import { threeWayMerge } from '../merge-file-core.js';
 import { diffCommits } from './diff.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';

--- a/packages/webapp/src/git/commands/status.ts
+++ b/packages/webapp/src/git/commands/status.ts
@@ -1,6 +1,6 @@
 /** `git status` (long and short/porcelain forms). */
 
-import * as git from 'isomorphic-git';
+import * as git from '../cached-isomorphic-git.js';
 import { matchesPathspec } from './revision.js';
 import { NO_INDEX_REFRESH } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';

--- a/packages/webapp/src/git/commands/symbolic-ref.ts
+++ b/packages/webapp/src/git/commands/symbolic-ref.ts
@@ -1,7 +1,7 @@
 /** `git symbolic-ref` — read, update, and delete symbolic refs. */
 
-import * as git from 'isomorphic-git';
 import { type ParsedArgs, parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 

--- a/packages/webapp/src/git/commands/tag.ts
+++ b/packages/webapp/src/git/commands/tag.ts
@@ -1,7 +1,7 @@
 /** `git tag` — create (lightweight/annotated), list, or delete tags. */
 
-import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
+import * as git from '../cached-isomorphic-git.js';
 import { flagString, GIT_FLAG_SPECS, type GitParsedFlags } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -14,11 +14,12 @@
 // Buffer polyfill must be imported before isomorphic-git
 import '../shims/buffer-polyfill.js';
 
-import * as git from 'isomorphic-git';
 import { createLogger } from '../base/logger.js';
 import { GLOBAL_FS_DB_NAME } from '../fs/global-db.js';
 import { VirtualFS } from '../fs/index.js';
 import { type ArgSpec, parseArgs } from '../shell/arg-parser.js';
+import * as git from './cached-isomorphic-git.js';
+import { GitObjectCache } from './cached-isomorphic-git.js';
 import { add } from './commands/add.js';
 import { branch } from './commands/branch.js';
 import { checkout } from './commands/checkout.js';
@@ -137,11 +138,11 @@ export class GitCommands {
 
   /**
    * The uncached adapter over the repo's VirtualFS. `execute()` derives a
-   * per-invocation view of it (see {@link GitCommands.contextFor}); nothing
-   * here is ever a cached adapter, because instance state is shared by
-   * concurrent invocations and a memo must not be.
+   * per-invocation filesystem view while the object cache remains shared.
    */
   private readonly lfs: IsoGitFsPromises;
+  /** Parsed pack indexes, pack bodies, and verification state retained per repository. */
+  private readonly objectCache = new GitObjectCache();
   private corsProxy?: string;
   private authorName: string;
   private authorEmail: string;
@@ -177,14 +178,17 @@ export class GitCommands {
   /**
    * Build the context for ONE `execute()` call.
    *
-   * `lfs` is the only per-invocation part: a cacheable subcommand gets a fresh
-   * `createCommandScopedReadCache` wrapper that it alone can see, so two
-   * commands overlapping in time never share a memo and a command that writes
-   * outside the adapter never gets one at all (issue #2709 review). The memo
-   * is unreachable — and therefore collected — as soon as the command returns.
+   * Filesystem metadata/content reads remain command-scoped (issue #2709),
+   * while isomorphic-git's object cache survives commands until the pack
+   * listing or packed-refs metadata changes (issue #2710).
    */
-  private contextFor(command: string): GitCommandContext {
-    const lfs = CACHEABLE_COMMANDS.has(command) ? createCommandScopedReadCache(this.lfs) : this.lfs;
+  private contextFor(command: string, cwd: string): GitCommandContext {
+    // Even uncached commands get a distinct adapter object so concurrent
+    // invocations bind their repository cache without overwriting each other.
+    const lfs = CACHEABLE_COMMANDS.has(command)
+      ? createCommandScopedReadCache(this.lfs)
+      : { ...this.lfs };
+    this.objectCache.bind(lfs, cwd);
     return {
       lfs,
       fs: this.options.fs,
@@ -371,9 +375,9 @@ export class GitCommands {
 
     this.currentEnv = env;
     this.currentConfigOverrides = parsed.configOverrides;
-    // One context — and, for a cacheable subcommand, one read memo — per
-    // invocation, so nothing a command reads is visible to any other (#2709).
-    const ctx = this.contextFor(command);
+    // Filesystem reads stay per-invocation; only the validated object/pack
+    // cache is shared across commands.
+    const ctx = this.contextFor(command, effectiveCwd);
     try {
       if (NETWORK_COMMANDS.has(command)) {
         await this.ensureFreshGithubToken();

--- a/packages/webapp/tests/git/git-object-cache.test.ts
+++ b/packages/webapp/tests/git/git-object-cache.test.ts
@@ -1,0 +1,139 @@
+import 'fake-indexeddb/auto';
+import * as isoGit from 'isomorphic-git';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualFS } from '../../src/fs/virtual-fs.js';
+import { GitCommands } from '../../src/git/git-commands.js';
+import { createIsomorphicGitFs } from '../../src/git/vfs-fs-adapter.js';
+
+const CWD = '/project';
+const OID = 'e50bab9f4a88d23a42e1ffce02e9d890ae70d7ee';
+const PACK_NAME = 'pack-febb9dd16f11567e4ff36b7386b7f0cb8de5ec08';
+const PACK_BASE64 =
+  'UEFDSwAAAAIAAAADlwl4nI2LQQrCMBBF9znF7AWZ6phOQIqH6AWSzBdFQ0sdweObI/Qt3uLB8w2gBJhJ' +
+  '5CFrxtlsqFxwL3ZJY9GoJxGVWtIY8tcfy0YzPk5X777hl9v6xrEubaIkMaooMx24E3psT3fsP8Ka6wsW' +
+  '/vSZLde5AXicy0jNyclXSCvKz1UoSEzOTk1RyE/KSk0u4QIAecsJEqUCeJwzNDAwMzFRyEjNycnXK6ko' +
+  'YVg20zVvR/V6MWcGS1Prj1/vLf47IxAA7aUPFf67ndFvEVZ+T/Nrc4a38MuN5ewI';
+const IDX_BASE64 =
+  '/3RPYwAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +
+  'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +
+  'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +
+  'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +
+  'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +
+  'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +
+  'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +
+  'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +
+  'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +
+  'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' +
+  'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAQAAAAEAAAAB' +
+  'AAAAAQAAAAEAAAABAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAAC' +
+  'AAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAAC' +
+  'AAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAAC' +
+  'AAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAAC' +
+  'AAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAwAAAAMAAAADAAAAAwAAAAMAAAADAAAAAwAAAAMAAAAD' +
+  'AAAAAwAAAAMAAAADAAAAAwAAAAMAAAADAAAAAwAAAAMAAAADAAAAAwAAAAMAAAADAAAAAwAAAAMAAAAD' +
+  'AAAAAwAAAAMAAAADnu3UYBqK490cC++9WXuGgkSEy5emmUVuuHuvFkMAOTU78fXeo/2YUeULq59KiNI6' +
+  'QuH/zgLp2JCucNfu3saGsy3RteJI876DAAAAoAAAAH0AAAAM/rud0W8RVn5P82tzhrfwy43l7AhdeTR5' +
+  'NOLcref/yJd7EQOBATQAJQ==';
+
+function decode(value: string): Uint8Array {
+  return new Uint8Array(Buffer.from(value, 'base64'));
+}
+
+const PACK = decode(PACK_BASE64);
+const INDEX = decode(IDX_BASE64);
+const PACK_PATH = `${CWD}/.git/objects/pack/${PACK_NAME}.pack`;
+const INDEX_PATH = `${CWD}/.git/objects/pack/${PACK_NAME}.idx`;
+
+async function seedPackedRepository(vfs: VirtualFS, commands: GitCommands): Promise<void> {
+  expect((await commands.execute(['init'], CWD)).exitCode).toBe(0);
+  await vfs.mkdir(`${CWD}/.git/objects/pack`, { recursive: true });
+  await vfs.mkdir(`${CWD}/.git/refs/heads`, { recursive: true });
+  await vfs.writeFile(PACK_PATH, PACK);
+  await vfs.writeFile(INDEX_PATH, INDEX);
+  await vfs.writeFile(`${CWD}/.git/refs/heads/main`, `${OID}\n`);
+  await vfs.writeFile(`${CWD}/.git/packed-refs`, '# pack-refs with: peeled\n');
+}
+
+describe('GitCommands object cache (issues #2710 and #2735)', () => {
+  let vfs: VirtualFS;
+  let commands: GitCommands;
+  let id = 0;
+
+  beforeEach(async () => {
+    const suffix = id++;
+    vfs = await VirtualFS.create({ dbName: `git-object-cache-${suffix}`, wipe: true });
+    commands = new GitCommands({
+      fs: vfs,
+      globalDbName: `git-object-cache-global-${suffix}`,
+    });
+    await seedPackedRepository(vfs, commands);
+  });
+
+  it('reuses parsed indexes, pack bytes, and completed verification across commands', async () => {
+    const read = vi.spyOn(vfs, 'readFile');
+
+    const first = await commands.execute(['log', '--oneline'], CWD);
+    expect(first.exitCode).toBe(0);
+    expect(first.stdout).toContain('packed');
+    const packReads = read.mock.calls.filter(([path]) => path === PACK_PATH).length;
+    const indexReads = read.mock.calls.filter(([path]) => path === INDEX_PATH).length;
+    expect(packReads).toBe(1);
+    expect(indexReads).toBe(1);
+
+    const second = await commands.execute(['show', '--format=%s'], CWD);
+    expect(second.exitCode).toBe(0);
+    expect(second.stdout).toContain('packed');
+    expect(read.mock.calls.filter(([path]) => path === PACK_PATH)).toHaveLength(packReads);
+    expect(read.mock.calls.filter(([path]) => path === INDEX_PATH)).toHaveLength(indexReads);
+  });
+
+  it('invalidates the cache and verifies changed pack data before reading it', async () => {
+    expect((await commands.execute(['log', '--oneline'], CWD)).exitCode).toBe(0);
+
+    const corrupted = PACK.slice();
+    corrupted[100] ^= 0xff;
+    await vfs.writeFile(PACK_PATH, corrupted);
+    // A packed-refs metadata change is one of the cache invalidation signals.
+    await vfs.writeFile(`${CWD}/.git/packed-refs`, '# pack-refs changed and enlarged\n');
+
+    const result = await commands.execute(['log', '--oneline'], CWD);
+    expect(result.exitCode).toBe(128);
+    expect(result.stderr).toContain('Packfile payload corrupted');
+  });
+
+  it('shares one in-flight SHA-1 verification across concurrent object readers', async () => {
+    const fs = createIsomorphicGitFs(vfs);
+    const cache = {};
+    const originalDigest = crypto.subtle.digest.bind(crypto.subtle);
+    let payloadDigests = 0;
+    let release!: () => void;
+    let markStarted!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const digest = vi.spyOn(crypto.subtle, 'digest').mockImplementation((algorithm, data) => {
+      if (data.byteLength === PACK.byteLength - 20) {
+        payloadDigests++;
+        markStarted();
+        return gate.then(() => originalDigest(algorithm, data));
+      }
+      return originalDigest(algorithm, data);
+    });
+
+    const reads = Array.from({ length: 8 }, () =>
+      isoGit.readCommit({ fs, dir: CWD, oid: OID, cache })
+    );
+    await started;
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    try {
+      expect(payloadDigests).toBe(1);
+    } finally {
+      release();
+    }
+    await Promise.all(reads);
+    digest.mockRestore();
+  });
+});

--- a/packages/webapp/tests/git/git-revision-resolution.test.ts
+++ b/packages/webapp/tests/git/git-revision-resolution.test.ts
@@ -163,11 +163,13 @@ describe('git revision resolution (#2713)', () => {
       expect(result.stdout).toContain('file.txt');
     });
 
-    it('ls-tree does not scan the pack indexes for a symbolic ref', async () => {
+    it('ls-tree does not read pack indexes for a loose symbolic ref', async () => {
       await seedHistory();
       const paths = recordPaths();
       expect((await git.execute(['ls-tree', 'HEAD'], '/project')).exitCode).toBe(0);
-      expect(paths.filter((p) => p.includes('objects/pack'))).toEqual([]);
+      // The persistent object cache validates the pack directory once, but a
+      // loose object must not make revision resolution read an index or pack.
+      expect(paths.filter((p) => p.endsWith('.idx') || p.endsWith('.pack'))).toEqual([]);
     });
 
     it('revert accepts a relative revision', async () => {

--- a/patches/isomorphic-git+1.41.9.patch
+++ b/patches/isomorphic-git+1.41.9.patch
@@ -1,0 +1,96 @@
+diff --git a/node_modules/isomorphic-git/index.js b/node_modules/isomorphic-git/index.js
+index bbdc7f0..18a1f07 100644
+--- a/node_modules/isomorphic-git/index.js
++++ b/node_modules/isomorphic-git/index.js
+@@ -3448,11 +3448,12 @@ class GitPackIndex {
+     this.pack = null;
+   }
+ 
+-  async read({ oid }) {
++  async read({ oid, getExternalRefDelta }) {
+     if (!this.offsets.get(oid)) {
+-      if (this.getExternalRefDelta) {
++      const readExternal = getExternalRefDelta || this.getExternalRefDelta;
++      if (readExternal) {
+         this.externalReadDepth++;
+-        return this.getExternalRefDelta(oid)
++        return readExternal(oid)
+       } else {
+         throw new InternalError(`Could not read object ${oid} from packfile`)
+       }
+@@ -3613,36 +3614,48 @@ async function readObjectPacked({
+       }
+ 
+       // === Packfile Integrity Verification ===
+-      // Performance optimization: use _checksumVerified flag to verify only once per packfile
++      // Share the in-flight verification as well as its completed state. Tree
++      // walks fan out object reads concurrently; a boolean set after `await`
++      // lets every queued reader hash the complete pack independently.
+       if (!p._checksumVerified) {
+-        const expectedShaFromIndex = p.packfileSha;
+-
+-        // 1. Fast Check: Verify packfile trailer matches index record
+-        // Use subarray instead of slice to avoid memory copy (zero-copy for large packfiles)
+-        const packTrailer = pack.subarray(-20);
+-        const packTrailerSha = Array.from(packTrailer)
+-          .map(b => b.toString(16).padStart(2, '0'))
+-          .join('');
+-        if (packTrailerSha !== expectedShaFromIndex) {
+-          throw new InternalError(
+-            `Packfile trailer mismatch: expected ${expectedShaFromIndex}, got ${packTrailerSha}. The packfile may be corrupted.`
+-          )
+-        }
++        p._checksumVerification ||= (async () => {
++          const expectedShaFromIndex = p.packfileSha;
++
++          // 1. Fast Check: Verify packfile trailer matches index record
++          // Use subarray instead of slice to avoid memory copy (zero-copy for large packfiles)
++          const packTrailer = pack.subarray(-20);
++          const packTrailerSha = Array.from(packTrailer)
++            .map(b => b.toString(16).padStart(2, '0'))
++            .join('');
++          if (packTrailerSha !== expectedShaFromIndex) {
++            throw new InternalError(
++              `Packfile trailer mismatch: expected ${expectedShaFromIndex}, got ${packTrailerSha}. The packfile may be corrupted.`
++            )
++          }
+ 
+-        // 2. Deep Integrity Check: Calculate actual SHA-1 of packfile payload.
+-        // The Node package build swaps in a chunked implementation for large packs.
+-        const actualPayloadSha = await shasumRange(pack, {
+-          start: 0,
+-          end: pack.length - 20,
+-        });
+-        if (actualPayloadSha !== expectedShaFromIndex) {
+-          throw new InternalError(
+-            `Packfile payload corrupted: calculated ${actualPayloadSha} but expected ${expectedShaFromIndex}. The packfile may have been tampered with.`
+-          )
+-        }
++          // 2. Deep Integrity Check: Calculate actual SHA-1 of packfile payload.
++          // The Node package build swaps in a chunked implementation for large packs.
++          const actualPayloadSha = await shasumRange(pack, {
++            start: 0,
++            end: pack.length - 20,
++          });
++          if (actualPayloadSha !== expectedShaFromIndex) {
++            throw new InternalError(
++              `Packfile payload corrupted: calculated ${actualPayloadSha} but expected ${expectedShaFromIndex}. The packfile may have been tampered with.`
++            )
++          }
+ 
+-        // Mark as verified to prevent performance regression on subsequent reads
+-        p._checksumVerified = true;
++          // Mark as verified to prevent performance regression on subsequent reads
++          p._checksumVerified = true;
++        })();
++        try {
++          await p._checksumVerification;
++        } catch (err) {
++          // Keep transient crypto failures retryable without allowing any
++          // reader to continue past a failed integrity check.
++          p._checksumVerification = null;
++          throw err
++        }
+       }
+ 
+       const result = await p.read({ oid, getExternalRefDelta });

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -24,6 +24,14 @@
     "removeWhen": "Remove once kerium bounds its log backlog upstream (ring buffer or opt-in retention).",
     "verify": "npm run test -w @slicc/webapp -- kerium-log-cap-patch"
   },
+  "isomorphic-git": {
+    "patchedVersion": "1.41.9",
+    "upstream": "https://github.com/isomorphic-git/isomorphic-git",
+    "issue": "https://github.com/ai-ecoverse/slicc/issues/2710",
+    "reason": "#2710/#2735: share in-flight pack SHA-1 verification across concurrent readers and use each call's external-delta reader so a persistent pack cache neither re-hashes a pack nor retains a stale command-scoped filesystem closure.",
+    "removeWhen": "Remove once isomorphic-git memoizes in-flight pack verification and GitPackIndex.read uses the current call's external-delta reader.",
+    "verify": "npm run test -w @slicc/webapp -- git-object-cache"
+  },
   "just-bash": {
     "patchedVersion": "3.4.2",
     "upstream": "https://github.com/vercel-labs/just-bash",

--- a/renovate.json
+++ b/renovate.json
@@ -64,7 +64,7 @@
     },
     {
       "description": "Packages we carry a patch-package patch for (see patches/ and patches/patches.json). A bump orphans the version-pinned patch, so route these into one group, label them, and never automerge — the renovate-patch-reconcile workflow regenerates or removes the patch first, and the lint:patches guard blocks the merge until the patch matches the installed version. Keep this list in sync with patches/.",
-      "matchPackageNames": ["@zenfs/core", "@zenfs/dom", "just-bash", "kerium"],
+      "matchPackageNames": ["@zenfs/core", "@zenfs/dom", "isomorphic-git", "just-bash", "kerium"],
       "groupName": "patched dependencies",
       "groupSlug": "patched-deps",
       "addLabels": ["patched-dependency"],


### PR DESCRIPTION
Closes #2710

Requested by: [@trieloff](https://github.com/trieloff)

## Solution
Retain isomorphic-git's pack cache per repository, invalidating it when pack or packed-ref metadata changes; concurrent readers still complete one shared SHA-1 integrity check.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01M1GP0W8YF6WWYQQ380DCGABK&panel=chat)