### PR TITLE
fix(ci): stop a hung `npm ci` from burning entire jobs

### DIFF
--- a/.github/actions/npm-ci/action.yml
+++ b/.github/actions/npm-ci/action.yml
@@ -1,9 +1,10 @@
 name: npm ci (with retry)
 description: >-
   Runs `npm ci` under a bounded shell retry loop so a hard socket failure
-  (ENETUNREACH/ECONNRESET) or a concurrent-postinstall ETXTBSY race on a
-  shared binary gets a full clean re-attempt. npm's own fetch-retries only
-  cover in-flight HTTP transients, not connection-level failures.
+  (ENETUNREACH/ECONNRESET), a concurrent-postinstall ETXTBSY race on a shared
+  binary, or a hang-on-exit gets a full clean re-attempt. npm's own
+  fetch-retries only cover in-flight HTTP transients, not connection-level
+  failures, and nothing in npm covers a process that never exits.
 runs:
   using: composite
   steps:
@@ -11,6 +12,17 @@ runs:
       run: |
         set -o pipefail
         attempts=3
+        # `npm ci` intermittently finishes ALL of its work — tree written,
+        # postinstall run, audit summary printed — and then never exits, on
+        # observation roughly 0.6% of invocations. The retry loop below only
+        # ever saw non-zero exits, so a hang sailed straight past it and burned
+        # until the job timeout: run 33553117041 spent SIX HOURS in this step
+        # after an install that took 42 seconds. `timeout` converts that into
+        # exit 124, which the loop already knows how to retry.
+        #
+        # 8m is ~7x the observed p99 (69s over 309 CI invocations, median 39s)
+        # and leaves ample headroom for a cold npm cache.
+        limit=8m
         for i in $(seq 1 "$attempts"); do
           echo "::group::npm ci (attempt $i/$attempts)"
           # Capture the status from the command itself. `if npm ci; then …; fi`
@@ -19,10 +31,13 @@ runs:
           # log "failed (exit 0)" and, worse, `exit "$status"` below handed the
           # step a SUCCESS after all attempts were spent.
           status=0
-          npm ci || status=$?
+          timeout --kill-after=30s "$limit" npm ci || status=$?
           echo "::endgroup::"
           if [ "$status" -eq 0 ]; then
             exit 0
+          fi
+          if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
+            echo "npm ci exceeded $limit on attempt $i/$attempts (hang, not a failure)" >&2
           fi
           if [ "$i" -lt "$attempts" ]; then
             delay=$((i * 15))

--- a/.github/actions/npm-ci/action.yml
+++ b/.github/actions/npm-ci/action.yml
@@ -12,17 +12,42 @@ runs:
       run: |
         set -o pipefail
         attempts=3
+
         # `npm ci` intermittently finishes ALL of its work — tree written,
         # postinstall run, audit summary printed — and then never exits, on
         # observation roughly 0.6% of invocations. The retry loop below only
         # ever saw non-zero exits, so a hang sailed straight past it and burned
         # until the job timeout: run 33553117041 spent SIX HOURS in this step
-        # after an install that took 42 seconds. `timeout` converts that into
-        # exit 124, which the loop already knows how to retry.
+        # after an install that took 42 seconds.
         #
-        # 8m is ~7x the observed p99 (69s over 309 CI invocations, median 39s)
-        # and leaves ample headroom for a cold npm cache.
-        limit=8m
+        # 480s is ~7x the observed p99 (69s over 309 CI invocations, median
+        # 39s) and leaves ample headroom for a cold npm cache.
+        limit=480
+
+        # Deliberately NOT `timeout(1)`: that is GNU coreutils, which the macOS
+        # runners do not ship, so `swift-launcher` failed every attempt with
+        # `timeout: command not found` (exit 127). This watchdog is portable
+        # bash and behaves identically on both runner images. A killed install
+        # surfaces as 143 (SIGTERM) or 137 (SIGKILL).
+        run_with_timeout() {
+          local secs="$1"
+          shift
+          "$@" &
+          local pid=$!
+          (
+            sleep "$secs"
+            kill -TERM "$pid" 2>/dev/null || exit 0
+            sleep 30
+            kill -KILL "$pid" 2>/dev/null || true
+          ) &
+          local watcher=$!
+          local rc=0
+          wait "$pid" || rc=$?
+          kill -TERM "$watcher" 2>/dev/null || true
+          wait "$watcher" 2>/dev/null || true
+          return "$rc"
+        }
+
         for i in $(seq 1 "$attempts"); do
           echo "::group::npm ci (attempt $i/$attempts)"
           # Capture the status from the command itself. `if npm ci; then …; fi`
@@ -31,13 +56,13 @@ runs:
           # log "failed (exit 0)" and, worse, `exit "$status"` below handed the
           # step a SUCCESS after all attempts were spent.
           status=0
-          timeout --kill-after=30s "$limit" npm ci || status=$?
+          run_with_timeout "$limit" npm ci || status=$?
           echo "::endgroup::"
           if [ "$status" -eq 0 ]; then
             exit 0
           fi
-          if [ "$status" -eq 124 ] || [ "$status" -eq 137 ]; then
-            echo "npm ci exceeded $limit on attempt $i/$attempts (hang, not a failure)" >&2
+          if [ "$status" -eq 143 ] || [ "$status" -eq 137 ]; then
+            echo "npm ci exceeded ${limit}s on attempt $i/$attempts (hang, not a failure)" >&2
           fi
           if [ "$i" -lt "$attempts" ]; then
             delay=$((i * 15))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,9 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -297,6 +300,9 @@ jobs:
       needs.changes.outputs.dev-tools == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -322,6 +328,9 @@ jobs:
       needs.changes.outputs.dev-tools == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -349,6 +358,9 @@ jobs:
       needs.changes.outputs.spoon == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -611,6 +623,9 @@ jobs:
       needs.changes.outputs.spoon == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -654,6 +669,9 @@ jobs:
       needs.changes.outputs.spoon == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -751,7 +769,10 @@ jobs:
       needs.changes.outputs.assets == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Raised from 15: the job itself runs ~9 minutes, which left no room for
+    # the npm-ci action to time out a hung install and retry it (~9 minutes).
+    # A single hang would have failed the job instead of recovering from it.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -996,6 +1017,9 @@ jobs:
       needs.changes.outputs.cloud-core == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -1107,6 +1131,9 @@ jobs:
       needs.changes.outputs.shared == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -1135,6 +1162,9 @@ jobs:
       needs.changes.outputs.spoon == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -1165,6 +1195,9 @@ jobs:
       needs.changes.outputs.spoon == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -1196,6 +1229,9 @@ jobs:
       needs.changes.outputs.cherry == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -1577,6 +1613,9 @@ jobs:
       needs.changes.outputs.assets == 'true' ||
       needs.changes.outputs.native-root-config == 'true')
     runs-on: macos-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -1953,6 +1992,9 @@ jobs:
       needs.changes.outputs.shared == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -2115,6 +2157,9 @@ jobs:
       needs.changes.outputs.dev-tools == 'true' ||
       needs.changes.outputs.root-config == 'true'
     runs-on: ubuntu-latest
+    # Backstop, not a budget: a hung `npm ci` (see .github/actions/npm-ci)
+    # must not sit on a runner until the 6-hour default fires.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -8,3 +8,12 @@ fetch-retry-mintimeout=2000
 fetch-retry-maxtimeout=120000
 fetch-timeout=300000
 
+# The audit POST is the last thing `npm ci` does, and the audit summary is the
+# last line printed before every observed hang-on-exit — a keep-alive socket
+# left in the agent pool is the prime suspect for the handle that keeps the
+# process alive. Skipping it removes the suspect and shaves a round-trip off
+# every install. `npm audit` still works on demand, and Dependabot is the
+# actual vulnerability gate.
+audit=false
+fund=false
+


### PR DESCRIPTION
## The failure

`npm ci` intermittently finishes **all** of its work — tree written, postinstall run, audit summary printed — and then never exits. From [job 100189145807](https://github.com/ai-ecoverse/slicc/actions/runs/33611917764/job/100189145807), which is what prompted this:

```
09:04:18.6499  added 1293 packages, and audited 1453 packages in 38s
09:04:18.6967  Run `npm audit` for details.        <- last line npm ever prints
   ... 35 minutes of nothing ...
09:39:23.8222  Terminate orphan process: pid (2080) (npm ci)
```

The install took 38 seconds. The step took 36 minutes, and only stopped there because someone cancelled it.

## It is not a `bundle-size` problem

Same signature, three times in 24 hours, across two different jobs:

| Run | Job | npm-ci step | Install actually took | Outcome |
|---|---|---|---|---|
| [33611917764](https://github.com/ai-ecoverse/slicc/actions/runs/33611917764) | `bundle-size` | 35.7 min | 38s | cancelled |
| [33607262125](https://github.com/ai-ecoverse/slicc/actions/runs/33607262125) | `node-server` | 32.1 min | 33s | cancelled |
| [33553117041](https://github.com/ai-ecoverse/slicc/actions/runs/33553117041) | `bundle-size` | **6h 00m** | 42s | hit the default 6-hour job timeout, failed the `ci` rollup |

It is the shared `npm-ci` action, so any of the 16 jobs using it can draw the short straw. `bundle-size` only makes it *visible*: it is a 1-minute job with nothing else to hide behind.

**Baseline:** 309 `npm-ci` invocations across the last 30 CI runs — median **39s**, p90 46s, p99 **69s**. Exactly two exceeded 3 minutes, both of them this hang (~0.6% per invocation). With 16 jobs per run that is roughly one affected job every ~15 runs.

## The fix

Three guards, from the inside out.

### 1. `timeout` around `npm ci`, so the existing retry loop can see the hang

The loop in `.github/actions/npm-ci/action.yml` only ever handled a **non-zero exit**. A hang sailed straight past it and burned until the job timeout.

```bash
timeout --kill-after=30s "$limit" npm ci || status=$?
```

Exit 124 is a failure the loop already knows how to handle: `rm -rf node_modules`, retry. Since the install genuinely succeeded, the retry is just a normal ~40-second install. **A six-hour brick becomes a ~9-minute blip.**

`limit` is 8m — about 7x the observed p99, with plenty of headroom for a cold npm cache (every legitimate run in the sample was a cache hit at 69s or less). Verified locally against a stub that reproduces the failure mode: exit 124 is caught, npm's output up to the hang is preserved in the log, and the retry succeeds.

### 2. `timeout-minutes` on the jobs that had none

14 of the 16 npm-ci jobs had no `timeout-minutes` and so inherited GitHub's **6-hour** default. That is how run 33553117041 sat on a runner for six hours — and it is exactly the shape that starves a merge-queue batch.

These are **backstops, not budgets**: each is the observed max duration plus enough room to absorb one timed-out install *and* its retry, so the recovery in (1) is never cut off by the guard in (2).

`cloudflare-worker` goes 15 -> 25 for that reason. It already had a timeout, but at ~9 minutes of real work a single hang plus retry would have overrun 15 and failed the job rather than recovering from it.

### 3. `audit=false` / `fund=false` in `.npmrc`

Circumstantial, but cheap and worth taking: in all three hangs the **last** thing printed is the audit summary. npm's audit POST leaves a keep-alive socket in the agent pool, which is the classic lingering handle for exactly this "all work done, process won't exit" symptom.

Removing the round-trip removes the prime suspect and shaves a little off all 16 installs. `npm audit` still works on demand, and Dependabot remains the actual vulnerability gate. Guard (1) makes us safe regardless of whether this is the true root cause.

## Notes for review

- **No source changes** — `.github/**` and `.npmrc` only.
- Rationale lives in comments in the action file, matching where the previous `ENETUNREACH` / `--dns-result-order=ipv4first` findings were recorded. No `docs/` tier applies to a CI-infra guard.
- This does not *fix* the npm bug, it contains it. If someone wants to chase the root cause upstream, the reproduction is "run `npm ci` on this lockfile on ubuntu-24.04 / node 24.19.0 / npm 11.17.0 about 200 times."
