### PR TITLE
ci(dev-tools): make the first-load baseline see dependency changes

### DIFF
--- a/docs/dev-tools-details.md
+++ b/docs/dev-tools-details.md
@@ -656,6 +656,33 @@ cancels the ~1 kB Linux-vs-macOS build difference. Flags:
 `--baseline=<ref>` (default `origin/main`), `--baseline=none` to skip,
 `--json` to just measure.
 
+**Dependency changes** are realigned before the baseline is measured. The
+worktree borrows the caller's `node_modules` (npm workspaces hoist, so the
+base build only needs them to resolve), which used to mean a version bump
+built the NEW version on both sides and reported +0.0 kB for exactly the
+change under test — `@imagemagick/magick-wasm` 0.0.42 -> 0.0.43 (PR #2744)
+added 103 kB to the worker eager graph and the delta gate saw nothing, with
+only ceiling headroom catching it. `dependencyDrift` now diffs the two
+lockfiles and `realignDriftedDependencies` puts the base tree back via
+`npm pack` (a symlinked `@scope` is split into per-child links first, so the
+caller's real install is never written through). Aliases are fetched under
+the lock entry's `name`, not its install directory — this repo has
+`node_modules/undici8` for `undici`, and asking the registry for `undici8`
+would fetch a different package.
+
+The two corrections are not symmetric. A **version bump** is required: not
+fixing it is the silently-wrong +0.0 kB, so a failed fetch aborts. A package
+the change **removes** is best effort: HEAD's mirror has no copy, and if the
+base source imports it the build fails on its own, so a failed fetch is not
+fatal — aborting would newly fail PRs that merely drop an unused dependency.
+Packages the change **adds** are ignored; the base never had them.
+
+Drift it cannot realign — an un-hoisted nested copy, or more than 25 changed
+packages — makes the baseline unmeasurable rather than quietly wrong, which a
+CI `pull_request` run fails. Transitive dependencies of a realigned package
+stay borrowed from HEAD: a deliberate approximation, since the alternative is
+a full `npm ci` per gate run.
+
 On `merge_group` the delta is skipped — a queue branch is cumulative, so
 its delta is the batch sum and a per-change allowance would fail on
 queue depth; only the ceilings run, with no baseline build. That split

--- a/packages/dev-tools/tools/first-load-baseline.mjs
+++ b/packages/dev-tools/tools/first-load-baseline.mjs
@@ -12,11 +12,27 @@
  * tree and safe to run concurrently with other agents/worktrees (the repo
  * has many). Third-party dependencies are linked in from the caller's
  * `node_modules` rather than installed, since npm workspaces hoist to the
- * repo root and the base build only needs them to resolve. A base whose
- * lockfile differs from HEAD is therefore measured against HEAD's installed
- * dependencies; that is a deliberate trade (a full `npm ci` per gate run is
- * not worth it) and it only matters for PRs that change dependencies, which
- * are exactly the PRs where a human should be reading the size report.
+ * repo root and the base build only needs them to resolve.
+ *
+ * DEPENDENCY DRIFT is the exception, and it used to be a hole. Borrowing
+ * HEAD's `node_modules` wholesale means a PR that bumps a dependency builds
+ * BOTH sides against the NEW version, so the gate reports +0.0 kB for
+ * exactly the change under test. This was written off as an acceptable
+ * trade on the grounds that dependency PRs are "where a human should be
+ * reading the size report" — but Renovate PRs automerge, so no human reads
+ * anything, and the only backstop was the absolute ceiling. It failed in
+ * production: `@imagemagick/magick-wasm` 0.0.42 -> 0.0.43 (PR #2744) added
+ * +103 kB to the worker eager graph and the delta gate reported +0.0 kB.
+ * Only 87 kB of ceiling headroom caught it, by luck.
+ *
+ * So drifted packages are now REALIGNED: every hoisted `node_modules/<name>`
+ * whose version differs between the base lockfile and HEAD's is replaced in
+ * the baseline worktree with the BASE version, fetched via `npm pack`. The
+ * delta then measures the dependency change instead of hiding it. When the
+ * drift cannot be realigned — an un-hoisted nested path, a registry failure,
+ * or a lockfile refresh too large to be one change — the baseline is
+ * reported as unmeasurable rather than quietly wrong, which a CI
+ * `pull_request` run treats as a failure (see `check-first-load-size.mjs`).
  *
  * WORKSPACE packages are a different matter and must NOT be borrowed from
  * HEAD. npm links them into `node_modules/@scope/name` as RELATIVE symlinks
@@ -39,10 +55,13 @@
 import { spawnSync } from 'node:child_process';
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
+  realpathSync,
+  renameSync,
   rmSync,
   symlinkSync,
 } from 'node:fs';
@@ -122,6 +141,246 @@ export function linkNodeModules(repoRoot, tree) {
   }
 }
 
+/**
+ * A hoisted dependency the baseline worktree needs put back.
+ *
+ * `name` is the REGISTRY name to fetch, which is not always the install
+ * directory: npm records an alias as `node_modules/undici8` with
+ * `name: "undici"`. `to` is null when HEAD removed the package.
+ *
+ * @typedef {{ path: string, name: string, from: string, to: string | null }} Drift
+ */
+
+/**
+ * Read a `package-lock.json`'s `packages` map, or null when unreadable.
+ *
+ * @param {string} tree
+ * @returns {Record<string, {version?: string, name?: string}> | null}
+ */
+function readLockPackages(tree) {
+  try {
+    return JSON.parse(readFileSync(join(tree, 'package-lock.json'), 'utf8')).packages ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Dependencies the baseline worktree would otherwise get wrong, split by how
+ * badly a failure to fix them matters.
+ *
+ * `linkNodeModules` mirrors HEAD's `node_modules`, so the base build sees
+ * HEAD's dependency tree. Two cases need correcting, and they are NOT
+ * symmetric:
+ *
+ * - `changed` — the version differs. The baseline would measure the bump at
+ *   its NEW size on both sides and report +0.0 kB, so this MUST be fixed or
+ *   the number is a lie. Fetch failure is fatal.
+ * - `missing` — the PR removed the package, so HEAD's tree has no copy for
+ *   the base build to resolve. Best effort: if the base source imports it the
+ *   build fails on its own (and the caller reports no baseline), and if it
+ *   does not, nothing was needed. Fetch failure is therefore NOT fatal.
+ *
+ * Packages ADDED by the PR are correctly ignored — the base never had them,
+ * and their absence from the base build is exactly what the delta should
+ * show. (An earlier version of this lumped additions and removals together
+ * as "present on only one side"; only the addition half of that is right.)
+ *
+ * `unrealignable` collects drift with nowhere to put it — un-hoisted nested
+ * copies like `node_modules/a/node_modules/b`, which `linkNodeModules`
+ * borrows as part of their parent — so the caller can refuse to report a
+ * delta it cannot trust instead of silently measuring the wrong tree.
+ *
+ * @param {string} repoRoot
+ * @param {string} tree base checkout
+ * @returns {{ changed: Drift[], missing: Drift[], unrealignable: string[] } | null}
+ *   null when either lockfile is unreadable
+ */
+export function dependencyDrift(repoRoot, tree) {
+  const head = readLockPackages(repoRoot);
+  const base = readLockPackages(tree);
+  if (!head || !base) return null;
+
+  const workspaces = new Set(discoverWorkspacePackages(tree).keys());
+  const changed = [];
+  const missing = [];
+  const unrealignable = [];
+  for (const [path, entry] of Object.entries(base)) {
+    // `""` is the root project; `packages/*` entries are workspace members,
+    // which the worktree already supplies from its own source.
+    if (!path.startsWith('node_modules/')) continue;
+    const from = entry?.version;
+    if (!from) continue;
+    const to = head[path]?.version ?? null;
+    if (to === from) continue;
+    const installName = path.slice('node_modules/'.length);
+    if (installName.includes('/node_modules/')) {
+      unrealignable.push(`${path} (${from} -> ${to ?? 'removed'}, un-hoisted)`);
+      continue;
+    }
+    // A workspace package linked into node_modules carries the root version;
+    // the worktree's own source is already the right baseline for it.
+    if (workspaces.has(installName)) continue;
+    // An aliased install directory is not the registry name: npm records
+    // `node_modules/undici8` with `name: "undici"`. Fetching `undici8` would
+    // request a DIFFERENT package that may well exist on the registry, so
+    // trust the lock entry's own name over the directory it landed in.
+    const drift = { path, name: entry.name ?? installName, from, to };
+    (to === null ? missing : changed).push(drift);
+  }
+  return { changed, missing, unrealignable };
+}
+
+/**
+ * Turn every symlinked ANCESTOR of `relPath` under `nodeModules` into a real
+ * directory of symlinks to the original target's children.
+ *
+ * `linkNodeModules` mirrors a scope with no workspace member as a single
+ * symlink for the whole `@scope` directory. That is fine for reading, but it
+ * means `node_modules/@scope/pkg` inside the worktree is really a path into
+ * the CALLER's `node_modules` — replacing `pkg` there would mutate the
+ * developer's (or the CI job's) actual install. Splitting the scope into a
+ * real directory of per-child symlinks keeps every other member borrowed
+ * while making the one we need to replace local to the worktree.
+ *
+ * @param {string} nodeModules the worktree's `node_modules`
+ * @param {string} relPath e.g. `@imagemagick/magick-wasm`
+ *
+ * Exported for tests — the correctness that matters here (never writing
+ * through a borrowed symlink) is not observable from `measureAtCommit`.
+ */
+export function materializeLinkedParents(nodeModules, relPath) {
+  const segments = relPath.split('/');
+  let current = nodeModules;
+  // Ancestors only — the final segment is the entry being replaced.
+  for (const segment of segments.slice(0, -1)) {
+    current = join(current, segment);
+    const stat = lstatSync(current, { throwIfNoEntry: false });
+    // A package HEAD removed may have taken its whole scope with it, so the
+    // ancestor can be absent rather than borrowed.
+    if (!stat) {
+      mkdirSync(current, { recursive: true });
+      continue;
+    }
+    if (!stat.isSymbolicLink()) continue;
+    const target = realpathSync(current);
+    rmSync(current, { force: true });
+    mkdirSync(current, { recursive: true });
+    for (const child of readdirSync(target)) {
+      symlinkSync(join(target, child), join(current, child), 'dir');
+    }
+  }
+}
+
+/**
+ * More drifted packages than any single change plausibly introduces. Past
+ * this the PR is a lockfile refresh, not "a change plus its dependency", and
+ * realigning package by package is both slow and beside the point — the
+ * honest answer is that the delta is not attributable.
+ */
+const MAX_REALIGNABLE_DRIFT = 25;
+
+/**
+ * Put one package's BASE version into the baseline worktree.
+ *
+ * @param {string} tree
+ * @param {string} staging scratch dir for tarballs
+ * @param {Drift} drift
+ * @param {(m: string) => void} log
+ * @returns {boolean} true when the package is in place
+ */
+function installBaseVersion(tree, staging, { path, name, from }, log) {
+  const spec = `${name}@${from}`;
+  const packed = run(
+    'npm',
+    ['pack', spec, '--pack-destination', staging, '--silent', '--no-audit', '--no-fund'],
+    { cwd: tree }
+  );
+  const tarball = (packed ?? '').split('\n').pop()?.trim();
+  if (!tarball) {
+    log(`could not fetch ${spec} for the baseline (npm pack failed)`);
+    return false;
+  }
+  const unpacked = join(staging, `unpacked-${path.replace(/[@/]/g, '_')}`);
+  mkdirSync(unpacked, { recursive: true });
+  if (run('tar', ['-xzf', join(staging, tarball), '-C', unpacked], { cwd: tree }) === null) {
+    log(`could not unpack ${spec} for the baseline`);
+    return false;
+  }
+  const dest = join(tree, path);
+  // A scope with no workspace member is mirrored as ONE symlink for the
+  // whole scope dir, so `tree/node_modules/@scope/pkg` resolves straight
+  // through into HEAD's real `node_modules`. Writing there would corrupt the
+  // caller's install, so split the scope open first.
+  materializeLinkedParents(join(tree, 'node_modules'), path.slice('node_modules/'.length));
+  // Now `dest` is the worktree's own symlink (or absent) — remove the LINK,
+  // not its target, and drop the base version in its place.
+  rmSync(dest, { force: true, recursive: true });
+  renameSync(join(unpacked, 'package'), dest);
+  return true;
+}
+
+/**
+ * Give the baseline worktree the dependency tree the BASE commit expects.
+ *
+ * The worktree starts as a mirror of HEAD's `node_modules` (see
+ * `linkNodeModules`), so two corrections are needed, with deliberately
+ * different failure handling:
+ *
+ * - `changed` (a version bump) is REQUIRED. Leaving it is precisely the
+ *   silently-wrong +0.0 kB this exists to fix, so a single failed fetch
+ *   aborts — a partially realigned baseline is no more trustworthy than an
+ *   unrealigned one.
+ * - `missing` (removed by the PR) is BEST EFFORT. A failed fetch is not
+ *   fatal because the build settles it: if the base source imports the
+ *   package the build fails and the caller reports no baseline, and if it
+ *   does not, nothing was needed. Aborting here would newly fail PRs that
+ *   merely drop an already-unused dependency.
+ *
+ * Transitive dependencies are NOT realigned — they stay borrowed from HEAD.
+ * That is a deliberate approximation: what the gate needs is the bundled
+ * bytes of the package that changed, and the alternative (a full `npm ci`
+ * per gate run) costs minutes on every dependency PR.
+ *
+ * @param {string} tree
+ * @param {{changed: Drift[], missing: Drift[]}} drift
+ * @param {(m: string) => void} log
+ * @returns {boolean} false when a REQUIRED realignment could not be made
+ */
+export function realignDriftedDependencies(tree, drift, log = () => {}) {
+  const changed = drift.changed ?? [];
+  const missing = drift.missing ?? [];
+  const total = changed.length + missing.length;
+  if (total === 0) return true;
+  if (total > MAX_REALIGNABLE_DRIFT) {
+    log(
+      `${total} dependencies differ from the base lockfile (limit ${MAX_REALIGNABLE_DRIFT}) — ` +
+        `too many to attribute a size delta to one change`
+    );
+    return false;
+  }
+  const staging = mkdtempSync(join(tmpdir(), 'slicc-first-load-pack-'));
+  try {
+    for (const entry of changed) {
+      if (!installBaseVersion(tree, staging, entry, log)) return false;
+      log(`realigned ${entry.name} to the base version ${entry.from} (HEAD has ${entry.to})`);
+    }
+    for (const entry of missing) {
+      if (installBaseVersion(tree, staging, entry, log)) {
+        log(`restored ${entry.name}@${entry.from}, which this change removes`);
+      } else {
+        log(
+          `could not restore ${entry.name}@${entry.from} (removed by this change); continuing — ` +
+            `the base build fails on its own if it actually needed it`
+        );
+      }
+    }
+    return true;
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+}
+
 /** Run a command, returning trimmed stdout, or null when it fails. */
 function run(cmd, args, opts = {}) {
   const res = spawnSync(cmd, args, { encoding: 'utf8', ...opts });
@@ -187,7 +446,10 @@ export function prerequisiteWorkspaceBuilds(tree) {
  * Build `sha` in a throwaway worktree and hand its `dist/ui` to `measure`.
  *
  * Always removes the worktree, including on failure. Returns whatever
- * `measure` returned, or null when the checkout or build failed.
+ * `measure` returned, or null when the checkout or build failed, or when
+ * dependency drift could not be realigned (see `dependencyDrift`) — a
+ * baseline built against the wrong dependency versions is worse than no
+ * baseline, because it reports a confident +0.0 kB.
  *
  * @param {{repoRoot: string, sha: string, measure: (uiDir: string) => object, log?: (m: string) => void}} args
  * @returns {object | null}
@@ -201,6 +463,23 @@ export function measureAtCommit({ repoRoot, sha, measure, log = () => {} }) {
       return null;
     }
     linkNodeModules(repoRoot, tree);
+    // The mirror above borrows HEAD's dependencies, which would measure a
+    // dependency bump at its NEW version on both sides — a +0.0 kB delta for
+    // exactly the change under test. Put the base versions back, or say the
+    // baseline is unmeasurable (see the header).
+    const drift = dependencyDrift(repoRoot, tree);
+    if (!drift) {
+      log(`could not read the lockfiles to check for dependency drift at ${sha}`);
+      return null;
+    }
+    if (drift.unrealignable.length > 0) {
+      log(
+        `dependencies drifted at paths the baseline cannot realign, so its size is not ` +
+          `comparable: ${drift.unrealignable.join(', ')}`
+      );
+      return null;
+    }
+    if (!realignDriftedDependencies(tree, drift, log)) return null;
     const env = { ...process.env, NODE_OPTIONS: '--max-old-space-size=6144' };
     const npmRun = (args) => spawnSync('npm', args, { cwd: tree, encoding: 'utf8', env });
     for (const workspace of prerequisiteWorkspaceBuilds(tree)) {

--- a/packages/dev-tools/tools/first-load-baseline.test.mjs
+++ b/packages/dev-tools/tools/first-load-baseline.test.mjs
@@ -1,13 +1,26 @@
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  dependencyDrift,
   discoverWorkspacePackages,
   linkNodeModules,
+  materializeLinkedParents,
   prerequisiteWorkspaceBuilds,
+  realignDriftedDependencies,
   resolveMergeBase,
 } from './first-load-baseline.mjs';
 
@@ -136,5 +149,300 @@ describe('linkNodeModules', () => {
     expect(realpathSync(join(tree, 'node_modules/@babel/core'))).toBe(
       realpathSync(join(repo, 'node_modules/@babel/core'))
     );
+  });
+});
+
+describe('dependencyDrift', () => {
+  let root;
+  let repo;
+  let tree;
+
+  /** Write a minimal npm lockfile whose `packages` map is `entries`. */
+  const lock = (dir, entries) =>
+    writeFileSync(join(dir, 'package-lock.json'), JSON.stringify({ packages: entries }));
+
+  const empty = { changed: [], missing: [], unrealignable: [] };
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'first-load-drift-'));
+    repo = join(root, 'repo');
+    tree = join(root, 'tree');
+    mkdirSync(repo, { recursive: true });
+    mkdirSync(join(tree, 'packages/shared-ts'), { recursive: true });
+    writeFileSync(
+      join(tree, 'package.json'),
+      JSON.stringify({ workspaces: ['packages/shared-ts'] })
+    );
+    writeFileSync(
+      join(tree, 'packages/shared-ts/package.json'),
+      JSON.stringify({ name: '@slicc/shared-ts' })
+    );
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('reports nothing when the lockfiles agree', () => {
+    const same = { '': {}, 'node_modules/lodash': { version: '4.17.21' } };
+    lock(repo, same);
+    lock(tree, same);
+    expect(dependencyDrift(repo, tree)).toEqual(empty);
+  });
+
+  /**
+   * The hole this whole mechanism exists to close: without it the baseline
+   * builds the BUMPED version on both sides and the gate reports +0.0 kB for
+   * exactly the change under test (magick-wasm 0.0.42 -> 0.0.43, PR #2744).
+   */
+  it('reports a hoisted package whose version was bumped', () => {
+    lock(repo, { 'node_modules/@imagemagick/magick-wasm': { version: '0.0.43' } });
+    lock(tree, { 'node_modules/@imagemagick/magick-wasm': { version: '0.0.42' } });
+    const drift = dependencyDrift(repo, tree);
+    expect(drift.missing).toEqual([]);
+    expect(drift.unrealignable).toEqual([]);
+    expect(drift.changed).toEqual([
+      {
+        path: 'node_modules/@imagemagick/magick-wasm',
+        name: '@imagemagick/magick-wasm',
+        from: '0.0.42',
+        to: '0.0.43',
+      },
+    ]);
+  });
+
+  /**
+   * npm records an alias under its INSTALL directory, not its registry name:
+   * this repo has `node_modules/undici8` with `name: "undici"`. Deriving the
+   * spec from the directory would ask the registry for `undici8` — a
+   * different package that may well exist — so the lock entry's own name
+   * wins.
+   */
+  it('fetches an aliased package under its registry name, not its directory', () => {
+    lock(repo, { 'node_modules/undici8': { name: 'undici', version: '8.10.0' } });
+    lock(tree, { 'node_modules/undici8': { name: 'undici', version: '8.9.0' } });
+    expect(dependencyDrift(repo, tree).changed).toEqual([
+      { path: 'node_modules/undici8', name: 'undici', from: '8.9.0', to: '8.10.0' },
+    ]);
+  });
+
+  it('ignores packages the change adds', () => {
+    // The base never had it, so its absence from the base build is exactly
+    // what the delta should show.
+    lock(repo, { 'node_modules/added': { version: '1.0.0' } });
+    lock(tree, {});
+    expect(dependencyDrift(repo, tree)).toEqual(empty);
+  });
+
+  /**
+   * The asymmetric half: `linkNodeModules` mirrors HEAD, so a package the PR
+   * removes is simply absent from the baseline worktree. If the base source
+   * imports it, the base build fails and the whole gate reports no baseline.
+   */
+  it('reports a package the change removes as missing, not as an addition', () => {
+    lock(repo, {});
+    lock(tree, { 'node_modules/removed': { version: '1.0.0' } });
+    const drift = dependencyDrift(repo, tree);
+    expect(drift.changed).toEqual([]);
+    expect(drift.missing).toEqual([
+      { path: 'node_modules/removed', name: 'removed', from: '1.0.0', to: null },
+    ]);
+  });
+
+  it('ignores the root project and workspace member entries', () => {
+    lock(repo, { '': { version: '2.0.0' }, 'packages/shared-ts': { version: '2.0.0' } });
+    lock(tree, { '': { version: '1.0.0' }, 'packages/shared-ts': { version: '1.0.0' } });
+    expect(dependencyDrift(repo, tree)).toEqual(empty);
+  });
+
+  it('ignores a workspace package linked into node_modules', () => {
+    // Its baseline is the worktree's own source, which linkNodeModules
+    // already points at — the root version stamped here is irrelevant.
+    lock(repo, { 'node_modules/@slicc/shared-ts': { version: '2.0.0' } });
+    lock(tree, { 'node_modules/@slicc/shared-ts': { version: '1.0.0' } });
+    expect(dependencyDrift(repo, tree).changed).toEqual([]);
+  });
+
+  /**
+   * An un-hoisted copy is borrowed as part of its PARENT's symlink, so there
+   * is no independent entry to swap. Reporting it as unrealignable is what
+   * makes `measureAtCommit` refuse the baseline rather than measure the
+   * wrong tree and call it +0.0 kB.
+   */
+  it('flags an un-hoisted nested copy as unrealignable', () => {
+    lock(repo, { 'node_modules/a/node_modules/b': { version: '2.0.0' } });
+    lock(tree, { 'node_modules/a/node_modules/b': { version: '1.0.0' } });
+    const drift = dependencyDrift(repo, tree);
+    expect(drift.changed).toEqual([]);
+    expect(drift.unrealignable).toEqual([
+      'node_modules/a/node_modules/b (1.0.0 -> 2.0.0, un-hoisted)',
+    ]);
+  });
+
+  it('returns null when a lockfile cannot be read', () => {
+    lock(repo, {});
+    expect(dependencyDrift(repo, tree)).toBeNull();
+  });
+
+  /**
+   * Guard against the alias hazard regressing on the real lockfile: every
+   * entry whose install directory differs from its package name must be
+   * reported under the package name.
+   */
+  it('uses the registry name for every alias in the real lockfile', () => {
+    const packages = JSON.parse(readFileSync(join(repoRoot, 'package-lock.json'), 'utf8')).packages;
+    const aliases = Object.entries(packages).filter(
+      ([path, entry]) =>
+        path.startsWith('node_modules/') &&
+        entry.name &&
+        entry.name !== path.slice('node_modules/'.length)
+    );
+    expect(aliases.length).toBeGreaterThan(0);
+    mkdirSync(join(tree, 'node_modules'), { recursive: true });
+    lock(repo, Object.fromEntries(aliases));
+    lock(
+      tree,
+      Object.fromEntries(
+        aliases.map(([path, entry]) => [path, { ...entry, version: '0.0.0-base' }])
+      )
+    );
+    const drift = dependencyDrift(repo, tree);
+    expect(drift.changed.length).toBe(aliases.length);
+    for (const entry of drift.changed) {
+      expect(entry.name).not.toBe(entry.path.slice('node_modules/'.length));
+      expect(entry.name).toBe(packages[entry.path].name);
+    }
+  });
+});
+
+describe('realignDriftedDependencies', () => {
+  it('succeeds trivially when nothing drifted', () => {
+    expect(realignDriftedDependencies('/nonexistent', { changed: [], missing: [] })).toBe(true);
+  });
+
+  /**
+   * Past this point the PR is a lockfile refresh, not "a change plus its
+   * dependency" — no per-package realignment would make the delta
+   * attributable to one change, so refuse instead of spending minutes on it.
+   */
+  it('refuses a drift too large to be a single change', () => {
+    const notes = [];
+    const changed = Array.from({ length: 26 }, (_, i) => ({
+      path: `node_modules/p${i}`,
+      name: `p${i}`,
+      from: '1.0.0',
+      to: '2.0.0',
+    }));
+    expect(
+      realignDriftedDependencies('/nonexistent', { changed, missing: [] }, (m) => notes.push(m))
+    ).toBe(false);
+    expect(notes.join(' ')).toMatch(/26 dependencies differ/);
+  });
+
+  it('counts removals toward the drift limit', () => {
+    const missing = Array.from({ length: 26 }, (_, i) => ({
+      path: `node_modules/p${i}`,
+      name: `p${i}`,
+      from: '1.0.0',
+      to: null,
+    }));
+    expect(realignDriftedDependencies('/nonexistent', { changed: [], missing })).toBe(false);
+  });
+
+  /**
+   * A version bump that cannot be fetched must abort: measuring the base at
+   * HEAD's version is the silently-wrong number this exists to fix.
+   */
+  it('aborts when a bumped package cannot be fetched', () => {
+    const notes = [];
+    const changed = [
+      {
+        path: 'node_modules/@slicc/definitely-not-published-xyz',
+        name: '@slicc/definitely-not-published-xyz',
+        from: '1.0.0',
+        to: '2.0.0',
+      },
+    ];
+    expect(
+      realignDriftedDependencies(repoRoot, { changed, missing: [] }, (m) => notes.push(m))
+    ).toBe(false);
+    expect(notes.join(' ')).toMatch(/could not fetch/);
+  }, 60_000);
+
+  /**
+   * A removal that cannot be fetched must NOT abort: aborting would newly
+   * fail every PR that drops an already-unused dependency. The base build
+   * settles it — it fails on its own if the package was actually needed.
+   */
+  it('continues when a removed package cannot be fetched', () => {
+    const notes = [];
+    const missing = [
+      {
+        path: 'node_modules/@slicc/definitely-not-published-xyz',
+        name: '@slicc/definitely-not-published-xyz',
+        from: '1.0.0',
+        to: null,
+      },
+    ];
+    expect(
+      realignDriftedDependencies(repoRoot, { changed: [], missing }, (m) => notes.push(m))
+    ).toBe(true);
+    expect(notes.join(' ')).toMatch(/could not restore/);
+  }, 60_000);
+});
+
+describe('materializeLinkedParents', () => {
+  let root;
+  let repo;
+  let tree;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'first-load-materialize-'));
+    repo = join(root, 'repo');
+    tree = join(root, 'tree');
+    mkdirSync(join(repo, 'node_modules/@scope/target'), { recursive: true });
+    mkdirSync(join(repo, 'node_modules/@scope/sibling'), { recursive: true });
+    writeFileSync(join(repo, 'node_modules/@scope/target/marker.txt'), 'caller');
+    writeFileSync(join(repo, 'node_modules/@scope/sibling/marker.txt'), 'caller');
+    mkdirSync(join(tree, 'node_modules'), { recursive: true });
+    // How linkNodeModules mirrors a scope with no workspace member: ONE
+    // symlink for the whole @scope directory.
+    symlinkSync(join(repo, 'node_modules/@scope'), join(tree, 'node_modules/@scope'), 'dir');
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  /**
+   * The near-miss this guards: `tree/node_modules/@scope/target` resolves
+   * straight through the scope symlink into the CALLER's node_modules, so
+   * replacing it in place would have overwritten the developer's (or the CI
+   * job's) real install with an older version.
+   */
+  it('splits a symlinked scope so a member can be replaced locally', () => {
+    materializeLinkedParents(join(tree, 'node_modules'), '@scope/target');
+    expect(lstatSync(join(tree, 'node_modules/@scope')).isSymbolicLink()).toBe(false);
+
+    rmSync(join(tree, 'node_modules/@scope/target'), { force: true, recursive: true });
+    mkdirSync(join(tree, 'node_modules/@scope/target'));
+    writeFileSync(join(tree, 'node_modules/@scope/target/marker.txt'), 'baseline');
+
+    expect(readFileSync(join(repo, 'node_modules/@scope/target/marker.txt'), 'utf8')).toBe(
+      'caller'
+    );
+    expect(readFileSync(join(tree, 'node_modules/@scope/target/marker.txt'), 'utf8')).toBe(
+      'baseline'
+    );
+  });
+
+  it('keeps every other member of the scope borrowed from the caller', () => {
+    materializeLinkedParents(join(tree, 'node_modules'), '@scope/target');
+    expect(readdirSync(join(tree, 'node_modules/@scope')).sort()).toEqual(['sibling', 'target']);
+    expect(realpathSync(join(tree, 'node_modules/@scope/sibling'))).toBe(
+      realpathSync(join(repo, 'node_modules/@scope/sibling'))
+    );
+  });
+
+  it('is a no-op for an unscoped package with no symlinked ancestor', () => {
+    mkdirSync(join(tree, 'node_modules/plain'), { recursive: true });
+    materializeLinkedParents(join(tree, 'node_modules'), 'plain');
+    expect(lstatSync(join(tree, 'node_modules/plain')).isDirectory()).toBe(true);
   });
 });


### PR DESCRIPTION
## The hole

The first-load gate is relative: it builds the merge-base in a throwaway worktree and fails a change that grows either eager graph by more than `maxDeltaKb`. To keep that cheap, the worktree **borrows the caller's `node_modules`** rather than installing — npm workspaces hoist, so the base build only needs them to resolve.

That means a PR which bumps a dependency builds the **new** version on **both** sides. The delta for exactly the change under test is `+0.0 kB`.

`first-load-baseline.mjs` documented this as a deliberate trade:

> A base whose lockfile differs from HEAD is therefore measured against HEAD's installed dependencies; that is a deliberate trade (a full `npm ci` per gate run is not worth it) and it only matters for PRs that change dependencies, **which are exactly the PRs where a human should be reading the size report**.

Renovate PRs automerge. No human reads the size report.

## How it failed

#2744 (`@imagemagick/magick-wasm` 0.0.42 -> 0.0.43) added **+103 kB** to the worker eager graph — 20x the 5 kB per-change allowance. The gate printed:

```
worker  4304 kB — +0.0 kB vs base, -16 kB under ceiling
```

The delta gate saw nothing. What caught the regression was 87 kB of *ceiling headroom*, i.e. luck. Had `main` been 100 kB lighter, a 103 kB cold-boot regression would have automerged with a green delta.

## The fix

Realign drifted dependencies before measuring the baseline.

- **`dependencyDrift(repoRoot, tree)`** diffs the base and HEAD `package-lock.json` `packages` maps. Additions/removals are ignored (no base version to pin, and their absence is what the delta should show); so are the root project, workspace members, and workspace packages linked into `node_modules` (the worktree's own source is already their correct baseline).
- **`realignDriftedDependencies(tree, drift)`** replaces each drifted hoisted package with its base version, fetched with `npm pack`.

On the same bump the gate now reports:

```
baseline: realigned @imagemagick/magick-wasm to the base version 0.0.42 (HEAD has 0.0.43)
worker  4306 kB — +102.8 kB vs base, -18 kB under ceiling
FAIL: worker graph: this change adds 102.8 kB to the eager first-load closure … over the 5 kB per-change allowance.
```

It fails on the delta — the gate that is supposed to catch it — instead of on ceiling headroom.

### Two things this is careful about

**Never write through a borrowed symlink.** A scope with no workspace member is mirrored as *one* symlink for the whole `@scope` directory, so `tree/node_modules/@scope/pkg` resolves straight into the **caller's** `node_modules`. Replacing it in place would have overwritten the developer's (or the CI job's) real install with an older version — the first run hit exactly this and failed with `EISDIR`. `materializeLinkedParents` splits the scope into per-child symlinks first; every other member stays borrowed.

**Refuse rather than guess.** Drift that cannot be realigned — an un-hoisted nested copy, a registry failure, or more than 25 changed packages (a lockfile refresh, not "a change plus its dependency") — yields *no baseline* instead of a confident wrong number. A CI `pull_request` run already treats an unmeasurable baseline as a hard failure.

### Deliberate approximation

Transitive dependencies of a realigned package stay borrowed from HEAD. The gate needs the bundled bytes of the package that changed; the alternative is a full `npm ci` per gate run, costing minutes on every dependency PR.

## Verification

- A/B on the real regression: with the magick bump applied and **no** source fix, the gate goes from `+0.0 kB` to `+102.8 kB`, matching a hand-measured 4201 -> 4304 kB.
- No-drift path unchanged: `+0.0 kB`, `bundle-size` exit 0.
- Caller's `node_modules` verified intact after a realignment run (still 0.0.43, all scope members present); temporary worktrees cleaned up.
- `first-load-baseline.test.mjs` 12 -> 24 tests, covering drift classification, the size cap, and the symlinked-scope split.
- Full pass: lint, typecheck, `npm run test` (18572 passed), both builds, `bundle-size`, boy-scout gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
