### PR TITLE
fix(ffmpeg): recycle the wasm core after a trap instead of poisoning the realm

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -205,10 +205,30 @@ package without entering wasm — so the command looked healthy.
 promise _and_ `terminate()` the worker (terminating is what actually releases
 the dead heap), then let the next call boot a clean core.
 
+Three things the recycle path has to get right:
+
+- **Retire a generation, not "the cache".** Callers share the instance, so a
+  slow run can unwind from a core that a faster retry has already replaced.
+  Pass the faulting instance in and no-op unless it is still the current one,
+  or the late unwind terminates the healthy core the retry just booted.
+- **Revoke the `blob:` URLs.** `terminate()` does not. The core JS + wasm are
+  ~31 MB per generation, so a recyclable loader that never revokes feeds the
+  memory pressure that caused the fault.
+- **Cover every entry point into the shared core.** In `ffmpeg-command.ts` that
+  is the main command path _and_ `transcodeCapturedBytes` (the webcam
+  post-capture pass), which uses the same cached instance.
+
 Distinguish a fault from an ordinary failure: these commands report bad flags
 and unsupported inputs as a **non-zero exit code**, so a _throw_ out of the
 WASM call path is already exceptional and is the right trigger. Skip MEMFS
 cleanup afterwards — every `deleteFile` would re-enter the trapped module.
+
+Two traps for that heuristic. The core can return a stale exit 0 after an
+internal `Aborted()`, so the real trap surfaces on the **readback** — catching
+it locally as "produced no output" leaves the poisoned instance cached. And
+keep non-WASM work (writing the artifact back to the VFS) outside the fault
+`catch`, or a read-only mount gets reported as a core fault and costs a
+needless reboot.
 
 | Site                                         | Status                                                                           |
 | -------------------------------------------- | -------------------------------------------------------------------------------- |

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -184,6 +184,38 @@ the closure returns.
 | `core/image-processor.ts`                        | Snapshots via `new Uint8Array(data)`                                               |
 | `cdp/browser-api.ts`                             | Consumes the view inside the callback to build base64 (no escape)                  |
 
+## A WASM Trap Poisons the Cached Instance, Not Just the Call
+
+A WebAssembly trap — `RuntimeError: memory access out of bounds`,
+`unreachable`, an emscripten `Aborted(…)` — is terminal for the **instance**.
+Linear memory is left inconsistent, so every later entry into the module
+re-traps immediately. Any loader that memoizes one instance per realm
+therefore turns a single bad call into a dead command for the rest of the
+session.
+
+`ffmpeg-wasm.ts` had exactly this shape: `getFfmpeg` caches one
+`ffmpegPromise`, and its `.catch()` covers only a _load_ failure — which never
+produced an instance in the first place. On a live leader, a 10 MB `.ts` remux
+blew the heap; from then on a 64x64 `lavfi` encode **with no inputs at all**
+failed with the identical trap, and `ffmpeg` stayed dead until the tab was
+reloaded. `ffmpeg -version` kept answering, because that gate resolves the core
+package without entering wasm — so the command looked healthy.
+
+**The rule**: a memoized WASM instance needs a recycle path. Drop the cached
+promise _and_ `terminate()` the worker (terminating is what actually releases
+the dead heap), then let the next call boot a clean core.
+
+Distinguish a fault from an ordinary failure: these commands report bad flags
+and unsupported inputs as a **non-zero exit code**, so a _throw_ out of the
+WASM call path is already exceptional and is the right trigger. Skip MEMFS
+cleanup afterwards — every `deleteFile` would re-enter the trapped module.
+
+| Site                                         | Status                                                                           |
+| -------------------------------------------- | -------------------------------------------------------------------------------- |
+| `shell/supplemental-commands/ffmpeg-wasm.ts` | `recycleFfmpeg()` drops the promise + terminates; tests in `ffmpeg-wasm.test.ts` |
+| `shell/supplemental-commands/magick-wasm.ts` | Same memoized shape — not yet recycled                                           |
+| `shell/supplemental-commands/v86-wasm.ts`    | Same memoized shape — not yet recycled                                           |
+
 ## Python Realm: Mounts Are Async-Only Via `slicc.fs`
 
 **Files**: `packages/webapp/src/kernel/realm/py-realm-shared.ts`,

--- a/packages/webapp/src/shell/supplemental-commands/ffmpeg-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/ffmpeg-command.ts
@@ -1039,6 +1039,7 @@ async function transcodeCapturedBytes(args: {
     args.onLog(event.message);
   };
   ffmpeg.on('log', logHandler);
+  let faulted = false;
   try {
     await ffmpeg.writeFile(inputName, args.bytes);
     const argv: string[] = ['-i', inputName, ...args.outputOpts, outputName];
@@ -1050,21 +1051,33 @@ async function transcodeCapturedBytes(args: {
     if (out instanceof Uint8Array) return out;
     if (typeof out === 'string') return new TextEncoder().encode(out);
     throw new Error('ffmpeg-core returned an unknown payload type');
+  } catch (err) {
+    // Shares the realm-cached core with `runWasmFfmpeg`, so a trap
+    // here poisons `ffmpeg` for the whole session too. The non-zero
+    // exit above is our own throw and leaves the core healthy, so
+    // only genuine faults retire the instance.
+    if (isCoreFault(err)) {
+      faulted = true;
+      recycleFfmpeg(ffmpeg);
+    }
+    throw err;
   } finally {
     try {
       ffmpeg.off('log', logHandler);
     } catch {
       /* noop */
     }
-    try {
-      await ffmpeg.deleteFile(inputName);
-    } catch {
-      /* noop */
-    }
-    try {
-      await ffmpeg.deleteFile(outputName);
-    } catch {
-      /* noop */
+    if (!faulted) {
+      try {
+        await ffmpeg.deleteFile(inputName);
+      } catch {
+        /* noop */
+      }
+      try {
+        await ffmpeg.deleteFile(outputName);
+      } catch {
+        /* noop */
+      }
     }
   }
 }
@@ -1157,6 +1170,37 @@ function buildFinalFfmpegArgs(
 }
 
 /**
+ * True when an error out of the core is unrecoverable for the
+ * *instance*, not merely for the call: a WebAssembly trap, an
+ * emscripten abort, or an allocation the runtime could not satisfy.
+ * All of them leave linear memory inconsistent, so the instance has
+ * to be retired instead of reused.
+ */
+function isCoreFault(err: unknown): boolean {
+  if (typeof WebAssembly !== 'undefined' && err instanceof WebAssembly.RuntimeError) return true;
+  if (err instanceof RangeError) return true;
+  const message = err instanceof Error ? err.message : String(err);
+  return /RuntimeError|memory access out of bounds|unreachable|Aborted|out of memory|allocation failed|table index is out of bounds|function signature mismatch/i.test(
+    message
+  );
+}
+
+/**
+ * Copy every staged input into the core's MEMFS. Virtual (lavfi)
+ * inputs are synthesized by ffmpeg itself, so they carry no bytes and
+ * are skipped.
+ */
+async function stageInputsIntoMemfs(
+  ffmpeg: Awaited<ReturnType<typeof getFfmpeg>>,
+  resolvedInputs: ResolvedInput[]
+): Promise<void> {
+  for (const input of resolvedInputs) {
+    if (input.bytes === null) continue;
+    await ffmpeg.writeFile(input.ffmpegName, input.bytes);
+  }
+}
+
+/**
  * Best-effort MEMFS cleanup so repeated invocations don't pile up
  * megabytes of stale media in the wasm heap. Swallow each
  * `deleteFile` error individually.
@@ -1180,6 +1224,55 @@ async function cleanupMemfs(
   } catch {
     /* noop */
   }
+}
+
+/**
+ * Read the encoded artifact back out of MEMFS.
+ *
+ * `@ffmpeg/core` can report exit 0 even when the encode aborted
+ * internally — a WASM `Aborted()` leaves the return code stale — so
+ * the artifact is trusted over the code, and a missing or empty file
+ * is a failure.
+ *
+ * A *trap* during readback is different in kind: the core died
+ * mid-encode. Reporting that as "produced no output" would leave the
+ * poisoned instance cached and let cleanup re-enter the dead module —
+ * exactly the session-wide failure this is meant to prevent — so it
+ * is rethrown for the caller's recycling handler.
+ */
+async function readEncodedOutput(
+  ffmpeg: Awaited<ReturnType<typeof getFfmpeg>>,
+  outputName: string,
+  outputPath: string,
+  stderr: string
+): Promise<{ bytes: Uint8Array } | { error: CmdResult }> {
+  let outputData: Awaited<ReturnType<typeof ffmpeg.readFile>>;
+  try {
+    outputData = await ffmpeg.readFile(outputName);
+  } catch (err) {
+    if (isCoreFault(err)) throw err;
+    return {
+      error: {
+        stdout: '',
+        stderr: stderr || `ffmpeg: produced no output file for ${outputPath}\n`,
+        exitCode: 1,
+      },
+    };
+  }
+  const bytes =
+    outputData instanceof Uint8Array
+      ? outputData
+      : new TextEncoder().encode(typeof outputData === 'string' ? outputData : '');
+  if (bytes.byteLength === 0) {
+    return {
+      error: {
+        stdout: '',
+        stderr: stderr || `ffmpeg: produced an empty output file for ${outputPath}\n`,
+        exitCode: 1,
+      },
+    };
+  }
+  return { bytes };
 }
 
 async function runWasmFfmpeg(
@@ -1217,65 +1310,34 @@ async function runWasmFfmpeg(
   };
   ffmpeg.on('log', logHandler);
   let faulted = false;
+  let early: CmdResult | null = null;
+  let outputBytes: Uint8Array | null = null;
   try {
-    // Stage inputs into MEMFS. Virtual (lavfi) inputs have no bytes
-    // and are synthesized by the core itself, so skip them.
-    for (const input of resolvedInputs) {
-      if (input.bytes === null) continue;
-      await ffmpeg.writeFile(input.ffmpegName, input.bytes);
-    }
+    await stageInputsIntoMemfs(ffmpeg, resolvedInputs);
 
     const finalArgs = buildFinalFfmpegArgs(parsed, resolvedInputs, outputName);
     const exitCode = await ffmpeg.exec(finalArgs);
     if (exitCode !== 0) {
-      return {
+      early = {
         stdout: '',
         stderr: stderr || `ffmpeg: exited with code ${exitCode}\n`,
         exitCode: exitCode || 1,
       };
+    } else {
+      const read = await readEncodedOutput(ffmpeg, outputName, outputPath, stderr);
+      if ('error' in read) early = read.error;
+      else outputBytes = read.bytes;
     }
-
-    // Secondary success check: @ffmpeg/core can report exit 0 even
-    // when the encode aborted internally (a WASM `Aborted()` leaves
-    // the return code stale), so trust the artifact, not the code.
-    // A missing or empty output file is a failure — surface a
-    // non-zero exit instead of silently "succeeding" with no output.
-    let outputData: Awaited<ReturnType<typeof ffmpeg.readFile>>;
-    try {
-      outputData = await ffmpeg.readFile(outputName);
-    } catch {
-      return {
-        stdout: '',
-        stderr: stderr || `ffmpeg: produced no output file for ${outputPath}\n`,
-        exitCode: 1,
-      };
-    }
-    const outputBytes =
-      outputData instanceof Uint8Array
-        ? outputData
-        : new TextEncoder().encode(typeof outputData === 'string' ? outputData : '');
-    if (outputBytes.byteLength === 0) {
-      return {
-        stdout: '',
-        stderr: stderr || `ffmpeg: produced an empty output file for ${outputPath}\n`,
-        exitCode: 1,
-      };
-    }
-
-    const resolvedOutput = ctx.fs.resolvePath(ctx.cwd, outputPath);
-    await ctx.fs.writeFile(resolvedOutput, outputBytes);
-
-    return { stdout: '', stderr, exitCode: 0 };
   } catch (err) {
     // A *throw* out of the wasm path is not an ordinary ffmpeg
     // failure — bad flags and unsupported codecs come back as a
     // non-zero exit code, handled above. What lands here is the core
     // itself faulting, which leaves the realm-shared instance
-    // unusable for every later command. Recycle it so the damage is
-    // scoped to this invocation.
+    // unusable for every later command. Retire that generation so the
+    // damage is scoped to this invocation.
     faulted = true;
-    recycleFfmpeg();
-    return {
+    recycleFfmpeg(ffmpeg);
+    early = {
       stdout: '',
       stderr:
         `${stderr}ffmpeg: ${err instanceof Error ? err.message : String(err)}\n` +
@@ -1293,4 +1355,24 @@ async function runWasmFfmpeg(
     // `deleteFile` would re-enter the trapped module.
     if (!faulted) await cleanupMemfs(ffmpeg, resolvedInputs, outputName);
   }
+  if (early) return early;
+
+  // Deliberately OUTSIDE the wasm try/catch. A read-only mount or an
+  // exhausted quota makes this throw while the core is perfectly
+  // healthy; blaming that on the core would cost a needless ~31 MB
+  // reboot and tell the user the wrong thing.
+  try {
+    await ctx.fs.writeFile(
+      ctx.fs.resolvePath(ctx.cwd, outputPath),
+      outputBytes ?? new Uint8Array()
+    );
+  } catch (err) {
+    return {
+      stdout: '',
+      stderr: `${stderr}ffmpeg: cannot write ${outputPath}: ${err instanceof Error ? err.message : String(err)}\n`,
+      exitCode: 1,
+    };
+  }
+
+  return { stdout: '', stderr, exitCode: 0 };
 }

--- a/packages/webapp/src/shell/supplemental-commands/ffmpeg-command.ts
+++ b/packages/webapp/src/shell/supplemental-commands/ffmpeg-command.ts
@@ -40,6 +40,7 @@ import {
   FFMPEG_CORE_NOT_INSTALLED,
   getFfmpeg,
   type IpkResolutionContext,
+  recycleFfmpeg,
   tryLoadFfmpegCoreFromNodeModules,
 } from './ffmpeg-wasm.js';
 
@@ -1215,6 +1216,7 @@ async function runWasmFfmpeg(
     stderr += `${event.message}\n`;
   };
   ffmpeg.on('log', logHandler);
+  let faulted = false;
   try {
     // Stage inputs into MEMFS. Virtual (lavfi) inputs have no bytes
     // and are synthesized by the core itself, so skip them.
@@ -1265,9 +1267,20 @@ async function runWasmFfmpeg(
 
     return { stdout: '', stderr, exitCode: 0 };
   } catch (err) {
+    // A *throw* out of the wasm path is not an ordinary ffmpeg
+    // failure — bad flags and unsupported codecs come back as a
+    // non-zero exit code, handled above. What lands here is the core
+    // itself faulting, which leaves the realm-shared instance
+    // unusable for every later command. Recycle it so the damage is
+    // scoped to this invocation.
+    faulted = true;
+    recycleFfmpeg();
     return {
       stdout: '',
-      stderr: `${stderr}ffmpeg: ${err instanceof Error ? err.message : String(err)}\n`,
+      stderr:
+        `${stderr}ffmpeg: ${err instanceof Error ? err.message : String(err)}\n` +
+        'ffmpeg: the wasm core faulted and was recycled; retry the command ' +
+        '(a large input may need to be split into smaller passes)\n',
       exitCode: 1,
     };
   } finally {
@@ -1276,6 +1289,8 @@ async function runWasmFfmpeg(
     } catch {
       /* noop */
     }
-    await cleanupMemfs(ffmpeg, resolvedInputs, outputName);
+    // A terminated worker has no MEMFS left to tidy, and every
+    // `deleteFile` would re-enter the trapped module.
+    if (!faulted) await cleanupMemfs(ffmpeg, resolvedInputs, outputName);
   }
 }

--- a/packages/webapp/src/shell/supplemental-commands/ffmpeg-wasm.ts
+++ b/packages/webapp/src/shell/supplemental-commands/ffmpeg-wasm.ts
@@ -241,9 +241,47 @@ function stringToBlobUrl(source: string, contentType: string): string {
 }
 
 /**
- * Drop the cached `FFmpeg` instance promise so the next `getFfmpeg`
- * call rebuilds from scratch. Test-only — production callers share
- * the single loaded instance for the lifetime of the realm.
+ * Drop the cached instance after an unrecoverable fault so the next
+ * `getFfmpeg` boots a fresh core.
+ *
+ * A WebAssembly trap (`RuntimeError: memory access out of bounds`,
+ * `unreachable`, an emscripten `Aborted(…)`) is terminal for the
+ * *instance*, not just the call that hit it — linear memory is left
+ * inconsistent and every later entry re-traps immediately. Because
+ * {@link ffmpegPromise} is realm-scoped, one trap used to poison
+ * `ffmpeg` for the lifetime of the tab: after a 10 MB remux blew the
+ * heap, a 64x64 `lavfi` encode with no inputs at all failed with the
+ * identical trap. Recycling makes a fault cost one command instead
+ * of the whole session.
+ *
+ * `terminate()` is what actually reclaims the dead core's heap; the
+ * `catch` above in {@link getFfmpeg} only covers a *load* failure,
+ * which never produced an instance to begin with.
+ */
+export function recycleFfmpeg(): void {
+  const stale = ffmpegPromise;
+  ffmpegPromise = null;
+  if (!stale) return;
+  // Settle out-of-band: the promise may still be pending, and a
+  // rejected one must not resurface here as an unhandled rejection.
+  void stale.then(
+    (ffmpeg) => {
+      try {
+        ffmpeg.terminate();
+      } catch {
+        /* worker already gone */
+      }
+    },
+    () => {
+      /* load failed — there is no worker to terminate */
+    }
+  );
+}
+
+/**
+ * Drop the cached `FFmpeg` instance promise without touching the
+ * worker. Test-only — production recycling goes through
+ * {@link recycleFfmpeg}.
  */
 export function resetFfmpegForTests(): void {
   ffmpegPromise = null;

--- a/packages/webapp/src/shell/supplemental-commands/ffmpeg-wasm.ts
+++ b/packages/webapp/src/shell/supplemental-commands/ffmpeg-wasm.ts
@@ -87,6 +87,32 @@ const FFMPEG_CORE_PACKAGE = '@ffmpeg/core';
 let ffmpegPromise: Promise<FFmpeg> | null = null;
 
 /**
+ * The instance {@link ffmpegPromise} currently resolves to, tracked
+ * separately so {@link recycleFfmpeg} can identify the *generation*
+ * being retired without awaiting. `null` while a load is in flight.
+ */
+let currentFfmpeg: FFmpeg | null = null;
+
+/**
+ * `blob:` URLs backing the loaded core (~31 MB of JS + wasm, plus the
+ * pthread worker for `-mt`). Terminating the wrapper worker does not
+ * revoke them, so a recycled generation would pin its assets until the
+ * tab closed — feeding the very memory pressure that forced the
+ * recycle. Retired alongside the instance.
+ */
+let currentAssetUrls: string[] = [];
+
+function revokeAssetUrls(urls: string[]): void {
+  for (const url of urls) {
+    try {
+      URL.revokeObjectURL(url);
+    } catch {
+      /* no URL registry in this realm */
+    }
+  }
+}
+
+/**
  * Public entry point. Idempotent across calls within a session —
  * the loaded `FFmpeg` instance is shared. Subsequent `ffmpeg`
  * invocations reuse the same wasm-backed worker.
@@ -116,14 +142,25 @@ async function loadFfmpeg(
   const log = onProgress ?? (() => {});
   const ffmpeg = new FFmpeg();
   const assets = await resolveAssetUrls(ipk, log);
+  const urls = [assets.coreURL, assets.wasmURL, assets.workerURL, assets.classWorkerURL].filter(
+    (u): u is string => typeof u === 'string'
+  );
   log('initializing ffmpeg-core...');
-  await ffmpeg.load({
-    coreURL: assets.coreURL,
-    wasmURL: assets.wasmURL,
-    ...(assets.workerURL ? { workerURL: assets.workerURL } : {}),
-    ...(assets.classWorkerURL ? { classWorkerURL: assets.classWorkerURL } : {}),
-  });
+  try {
+    await ffmpeg.load({
+      coreURL: assets.coreURL,
+      wasmURL: assets.wasmURL,
+      ...(assets.workerURL ? { workerURL: assets.workerURL } : {}),
+      ...(assets.classWorkerURL ? { classWorkerURL: assets.classWorkerURL } : {}),
+    });
+  } catch (err) {
+    // A core that never booted still allocated its blob URLs.
+    revokeAssetUrls(urls);
+    throw err;
+  }
   log('ffmpeg ready');
+  currentFfmpeg = ffmpeg;
+  currentAssetUrls = urls;
   return ffmpeg;
 }
 
@@ -258,24 +295,29 @@ function stringToBlobUrl(source: string, contentType: string): string {
  * `catch` above in {@link getFfmpeg} only covers a *load* failure,
  * which never produced an instance to begin with.
  */
-export function recycleFfmpeg(): void {
-  const stale = ffmpegPromise;
+export function recycleFfmpeg(faulted?: FFmpeg): void {
+  // Retire only the generation that actually faulted. Shell runs share
+  // the cached core, so a slow run can unwind from an instance that a
+  // faster retry has already replaced — without this guard it would
+  // terminate the healthy core the retry just booted. A `null`
+  // `currentFfmpeg` means a fresh load is in flight, which by
+  // definition is not the instance that faulted.
+  if (faulted !== undefined && currentFfmpeg !== faulted) return;
+
+  const stale = currentFfmpeg;
+  const staleUrls = currentAssetUrls;
   ffmpegPromise = null;
-  if (!stale) return;
-  // Settle out-of-band: the promise may still be pending, and a
-  // rejected one must not resurface here as an unhandled rejection.
-  void stale.then(
-    (ffmpeg) => {
-      try {
-        ffmpeg.terminate();
-      } catch {
-        /* worker already gone */
-      }
-    },
-    () => {
-      /* load failed — there is no worker to terminate */
+  currentFfmpeg = null;
+  currentAssetUrls = [];
+
+  if (stale) {
+    try {
+      stale.terminate();
+    } catch {
+      /* worker already gone */
     }
-  );
+  }
+  revokeAssetUrls(staleUrls);
 }
 
 /**
@@ -285,4 +327,6 @@ export function recycleFfmpeg(): void {
  */
 export function resetFfmpegForTests(): void {
   ffmpegPromise = null;
+  currentFfmpeg = null;
+  currentAssetUrls = [];
 }

--- a/packages/webapp/tests/shell/supplemental-commands/ffmpeg-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/ffmpeg-command.test.ts
@@ -17,6 +17,7 @@ import {
   BUNDLED_FFMPEG_CORE_VERSION,
   FFMPEG_CORE_NOT_INSTALLED,
   getFfmpeg,
+  recycleFfmpeg,
   selectFfmpegCore,
   tryLoadFfmpegCoreFromNodeModules,
 } from '../../../src/shell/supplemental-commands/ffmpeg-wasm.js';
@@ -30,7 +31,7 @@ vi.mock('../../../src/shell/supplemental-commands/ffmpeg-wasm.js', async () => {
   const actual = await vi.importActual<
     typeof import('../../../src/shell/supplemental-commands/ffmpeg-wasm.js')
   >('../../../src/shell/supplemental-commands/ffmpeg-wasm.js');
-  return { ...actual, getFfmpeg: vi.fn() };
+  return { ...actual, getFfmpeg: vi.fn(), recycleFfmpeg: vi.fn() };
 });
 
 // The page-realm branch of `requestCapturePermission` looks up the
@@ -970,6 +971,93 @@ describe('runWasmFfmpeg output validation (NS2a)', () => {
     const result = await createFfmpegCommand().execute(['-i', 'in.mp4', 'out.gif'], ctx);
     expect(result.exitCode).toBe(0);
     expect(writeFile).toHaveBeenCalledWith('/home/out.gif', expect.any(Uint8Array));
+  });
+});
+
+describe('runWasmFfmpeg core-fault recycling', () => {
+  beforeEach(() => {
+    vi.mocked(getFfmpeg).mockReset();
+    vi.mocked(recycleFfmpeg).mockReset();
+  });
+
+  /** A core that traps on `exec`, the way a blown wasm heap does. */
+  function trappingFfmpeg(): FakeFfmpeg {
+    const fake = makeFakeFfmpeg({ exitCode: 0 });
+    fake.exec.mockRejectedValue(new WebAssembly.RuntimeError('memory access out of bounds'));
+    return fake;
+  }
+
+  it('recycles the shared core when the wasm module traps', async () => {
+    useFakeFfmpeg(trappingFfmpeg());
+    const result = await createFfmpegCommand().execute(
+      ['-i', 'in.mp4', 'out.mp4'],
+      createMockCtx()
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/memory access out of bounds/);
+    expect(recycleFfmpeg).toHaveBeenCalledTimes(1);
+  });
+
+  it('tells the caller the core was recycled so a retry is worth it', async () => {
+    useFakeFfmpeg(trappingFfmpeg());
+    const result = await createFfmpegCommand().execute(
+      ['-i', 'in.mp4', 'out.mp4'],
+      createMockCtx()
+    );
+
+    expect(result.stderr).toMatch(/faulted and was recycled; retry the command/);
+  });
+
+  it('skips MEMFS cleanup against a core that just faulted', async () => {
+    const fake = trappingFfmpeg();
+    useFakeFfmpeg(fake);
+    await createFfmpegCommand().execute(['-i', 'in.mp4', 'out.mp4'], createMockCtx());
+
+    // Every deleteFile would re-enter the trapped module.
+    expect(fake.deleteFile).not.toHaveBeenCalled();
+  });
+
+  it('recycles when staging an input into MEMFS throws', async () => {
+    const fake = makeFakeFfmpeg({ exitCode: 0 });
+    fake.writeFile.mockRejectedValue(new Error('FS error: out of memory'));
+    useFakeFfmpeg(fake);
+
+    const result = await createFfmpegCommand().execute(
+      ['-i', 'in.mp4', 'out.mp4'],
+      createMockCtx()
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(recycleFfmpeg).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the core alone for an ordinary non-zero exit', async () => {
+    // Bad flags and unsupported codecs are reported as an exit code,
+    // not a throw — the instance is still healthy.
+    const fake = makeFakeFfmpeg({ exitCode: 69 });
+    useFakeFfmpeg(fake);
+
+    const result = await createFfmpegCommand().execute(
+      ['-i', 'in.mp4', 'out.mp4'],
+      createMockCtx()
+    );
+
+    expect(result.exitCode).toBe(69);
+    expect(recycleFfmpeg).not.toHaveBeenCalled();
+    expect(fake.deleteFile).toHaveBeenCalled();
+  });
+
+  it('leaves the core alone when the output file is missing or empty', async () => {
+    useFakeFfmpeg(makeFakeFfmpeg({ exitCode: 0, readFile: () => new Uint8Array() }));
+
+    const result = await createFfmpegCommand().execute(
+      ['-i', 'in.mp4', 'out.mp4'],
+      createMockCtx()
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(recycleFfmpeg).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/webapp/tests/shell/supplemental-commands/ffmpeg-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/ffmpeg-command.test.ts
@@ -1061,6 +1061,76 @@ describe('runWasmFfmpeg core-fault recycling', () => {
   });
 });
 
+describe('runWasmFfmpeg fault classification', () => {
+  beforeEach(() => {
+    vi.mocked(getFfmpeg).mockReset();
+    vi.mocked(recycleFfmpeg).mockReset();
+  });
+
+  it('recycles when the trap only surfaces on readback', async () => {
+    // `exec` can return a stale 0 after an internal Aborted(); the
+    // trap then lands on readFile. Treating that as "no output" would
+    // leave the poisoned instance cached — the very bug being fixed.
+    const fake = makeFakeFfmpeg({ exitCode: 0 });
+    fake.readFile.mockRejectedValue(new WebAssembly.RuntimeError('memory access out of bounds'));
+    useFakeFfmpeg(fake);
+
+    const result = await createFfmpegCommand().execute(
+      ['-i', 'in.mp4', 'out.mp4'],
+      createMockCtx()
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(recycleFfmpeg).toHaveBeenCalledTimes(1);
+    expect(result.stderr).toMatch(/faulted and was recycled/);
+    expect(fake.deleteFile).not.toHaveBeenCalled();
+  });
+
+  it('still reports a merely missing output without recycling', async () => {
+    const fake = makeFakeFfmpeg({ exitCode: 0 });
+    fake.readFile.mockRejectedValue(new Error('FS error: no such file or directory'));
+    useFakeFfmpeg(fake);
+
+    const result = await createFfmpegCommand().execute(
+      ['-i', 'in.mp4', 'out.mp4'],
+      createMockCtx()
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/produced no output file/i);
+    expect(recycleFfmpeg).not.toHaveBeenCalled();
+  });
+
+  it('passes the faulting instance to recycleFfmpeg', async () => {
+    // Without the identity, a slow run could retire a healthy core
+    // that a faster retry had already installed.
+    const fake = makeFakeFfmpeg({ exitCode: 0 });
+    fake.exec.mockRejectedValue(new WebAssembly.RuntimeError('memory access out of bounds'));
+    useFakeFfmpeg(fake);
+
+    await createFfmpegCommand().execute(['-i', 'in.mp4', 'out.mp4'], createMockCtx());
+
+    expect(recycleFfmpeg).toHaveBeenCalledWith(fake);
+  });
+
+  it('does not blame the core when the VFS write fails', async () => {
+    // A read-only mount or an exhausted quota is not a wasm fault:
+    // no recycle, no 31 MB reboot, and MEMFS still gets tidied.
+    const fake = makeFakeFfmpeg({ exitCode: 0, readFile: () => new Uint8Array([1, 2, 3]) });
+    useFakeFfmpeg(fake);
+    const writeFile = vi.fn().mockRejectedValue(new Error('EROFS: read-only file system'));
+    const ctx = createMockCtx({ fs: { writeFile } });
+
+    const result = await createFfmpegCommand().execute(['-i', 'in.mp4', 'out.mp4'], ctx);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/cannot write out\.mp4: EROFS/);
+    expect(result.stderr).not.toMatch(/faulted and was recycled/);
+    expect(recycleFfmpeg).not.toHaveBeenCalled();
+    expect(fake.deleteFile).toHaveBeenCalled();
+  });
+});
+
 describe('runWasmFfmpeg lavfi/virtual inputs (NS2b)', () => {
   beforeEach(() => {
     vi.mocked(getFfmpeg).mockReset();

--- a/packages/webapp/tests/shell/supplemental-commands/ffmpeg-wasm.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/ffmpeg-wasm.test.ts
@@ -77,12 +77,26 @@ function makeCoreIpk(): IpkResolutionContext {
   };
 }
 
+const created: string[] = [];
+const revoked: string[] = [];
+
 describe('recycleFfmpeg', () => {
   beforeEach(() => {
     instances.length = 0;
     loadImpl.value = async () => {};
     resetFfmpegForTests();
-    Object.assign(URL, { createObjectURL: vi.fn(() => 'blob:core'), revokeObjectURL: vi.fn() });
+    created.length = 0;
+    revoked.length = 0;
+    Object.assign(URL, {
+      createObjectURL: vi.fn(() => {
+        const url = `blob:core-${created.length}`;
+        created.push(url);
+        return url;
+      }),
+      revokeObjectURL: vi.fn((url: string) => {
+        revoked.push(url);
+      }),
+    });
   });
   afterEach(() => {
     resetFfmpegForTests();
@@ -130,6 +144,46 @@ describe('recycleFfmpeg', () => {
     expect(() => recycleFfmpeg()).not.toThrow();
     await Promise.resolve();
     expect(instances[0].terminate).not.toHaveBeenCalled();
+  });
+
+  it('only retires the generation that faulted', async () => {
+    const ipk = makeCoreIpk();
+    const first = await getFfmpeg({ ipk });
+    recycleFfmpeg(first);
+    const second = await getFfmpeg({ ipk });
+    expect(second).not.toBe(first);
+
+    // A slow run unwinding from the ALREADY retired instance must not
+    // take the healthy core its retry just installed.
+    recycleFfmpeg(first);
+
+    expect(await getFfmpeg({ ipk })).toBe(second);
+    expect(instances).toHaveLength(2);
+    expect(instances[1].terminate).not.toHaveBeenCalled();
+  });
+
+  it('revokes the retired generation\u2019s blob URLs', async () => {
+    const ipk = makeCoreIpk();
+    await getFfmpeg({ ipk });
+    expect(created.length).toBeGreaterThan(0);
+    const firstGen = [...created];
+
+    recycleFfmpeg();
+
+    // Terminating the worker does not free the ~31 MB asset set; only
+    // revoking does, and a recycled core would otherwise pin it until
+    // the tab closed.
+    expect([...revoked].sort()).toEqual([...firstGen].sort());
+  });
+
+  it('revokes assets when the core fails to boot', async () => {
+    const ipk = makeCoreIpk();
+    loadImpl.value = async () => {
+      throw new Error('core boot failed');
+    };
+    await expect(getFfmpeg({ ipk })).rejects.toThrow('core boot failed');
+    expect(revoked.length).toBeGreaterThan(0);
+    expect([...revoked].sort()).toEqual([...created].sort());
   });
 
   it('tolerates a worker that is already gone', async () => {

--- a/packages/webapp/tests/shell/supplemental-commands/ffmpeg-wasm.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/ffmpeg-wasm.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Lifecycle of the realm-shared `FFmpeg` instance. `getFfmpeg` caches
+ * one instance per realm, so the interesting behavior is not loading
+ * but *un*loading: a wasm trap poisons the instance, and without
+ * `recycleFfmpeg` every later `ffmpeg` in the session re-traps.
+ *
+ * The heavy core never boots here — `@ffmpeg/ffmpeg` is mocked, so
+ * `load()` resolves instantly and `terminate()` is observable.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { instances, loadImpl } = vi.hoisted(() => ({
+  instances: [] as Array<{ load: ReturnType<typeof vi.fn>; terminate: ReturnType<typeof vi.fn> }>,
+  loadImpl: { value: async (): Promise<void> => {} },
+}));
+
+vi.mock('@ffmpeg/ffmpeg', () => ({
+  FFmpeg: class {
+    load = vi.fn(async () => loadImpl.value());
+    terminate = vi.fn();
+    constructor() {
+      instances.push(this as unknown as (typeof instances)[number]);
+    }
+  },
+}));
+
+// The loader refuses to boot under Node; pretend we are in a browser
+// realm so `resolveAssetUrls` takes the real ipk path.
+vi.mock('../../../src/shell/supplemental-commands/shared.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../src/shell/supplemental-commands/shared.js')
+  >('../../../src/shell/supplemental-commands/shared.js');
+  return { ...actual, isNodeRuntime: () => false };
+});
+
+import {
+  getFfmpeg,
+  type IpkResolutionContext,
+  recycleFfmpeg,
+  resetFfmpegForTests,
+} from '../../../src/shell/supplemental-commands/ffmpeg-wasm.js';
+
+/** Fake ipk context with `@ffmpeg/core` installed under /workspace. */
+function makeCoreIpk(): IpkResolutionContext {
+  const root = '/workspace/node_modules/@ffmpeg/core';
+  const sources = new Map<string, string>([
+    [`${root}/package.json`, JSON.stringify({ name: '@ffmpeg/core', version: '0.12.10' })],
+    [`${root}/dist/esm/ffmpeg-core.js`, '/* core glue */'],
+  ]);
+  const bytes = new Map<string, Uint8Array>([
+    [`${root}/dist/esm/ffmpeg-core.wasm`, new Uint8Array([0x00, 0x61, 0x73, 0x6d])],
+  ]);
+  const dirs = new Set<string>([
+    '/workspace',
+    '/workspace/node_modules',
+    '/workspace/node_modules/@ffmpeg',
+    root,
+    `${root}/dist`,
+    `${root}/dist/esm`,
+  ]);
+  return {
+    reader: {
+      exists: async (path: string) => sources.has(path) || bytes.has(path) || dirs.has(path),
+      isDirectory: async (path: string) => dirs.has(path),
+      readFile: async (path: string) => {
+        const v = sources.get(path);
+        if (v === undefined) throw new Error(`ENOENT: ${path}`);
+        return v;
+      },
+    },
+    readBytes: async (path: string) => {
+      const v = bytes.get(path);
+      if (!v) throw new Error(`ENOENT: ${path}`);
+      return v;
+    },
+    fromDir: '/workspace',
+  };
+}
+
+describe('recycleFfmpeg', () => {
+  beforeEach(() => {
+    instances.length = 0;
+    loadImpl.value = async () => {};
+    resetFfmpegForTests();
+    Object.assign(URL, { createObjectURL: vi.fn(() => 'blob:core'), revokeObjectURL: vi.fn() });
+  });
+  afterEach(() => {
+    resetFfmpegForTests();
+  });
+
+  it('shares one instance across calls until it is recycled', async () => {
+    const ipk = makeCoreIpk();
+    const first = await getFfmpeg({ ipk });
+    expect(await getFfmpeg({ ipk })).toBe(first);
+    expect(instances).toHaveLength(1);
+
+    recycleFfmpeg();
+
+    const second = await getFfmpeg({ ipk });
+    expect(second).not.toBe(first);
+    expect(instances).toHaveLength(2);
+  });
+
+  it('terminates the stale worker so the trapped core releases its heap', async () => {
+    const ipk = makeCoreIpk();
+    await getFfmpeg({ ipk });
+
+    recycleFfmpeg();
+    // Termination is scheduled off the settled promise, not inline.
+    await Promise.resolve();
+
+    expect(instances[0].terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when nothing has been loaded', async () => {
+    expect(() => recycleFfmpeg()).not.toThrow();
+    await Promise.resolve();
+    expect(instances).toHaveLength(0);
+  });
+
+  it('survives recycling a load that failed, without an unhandled rejection', async () => {
+    const ipk = makeCoreIpk();
+    loadImpl.value = async () => {
+      throw new Error('core boot failed');
+    };
+    await expect(getFfmpeg({ ipk })).rejects.toThrow('core boot failed');
+
+    // The failed load already cleared the cache, so there is no
+    // instance left to terminate — recycling must stay quiet.
+    expect(() => recycleFfmpeg()).not.toThrow();
+    await Promise.resolve();
+    expect(instances[0].terminate).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a worker that is already gone', async () => {
+    const ipk = makeCoreIpk();
+    await getFfmpeg({ ipk });
+    instances[0].terminate.mockImplementation(() => {
+      throw new Error('worker already terminated');
+    });
+
+    recycleFfmpeg();
+    await Promise.resolve();
+
+    // Swallowed — and the cache is still cleared for the next call.
+    const next = await getFfmpeg({ ipk });
+    expect(instances).toHaveLength(2);
+    expect(next).toBe(instances[1]);
+  });
+});


### PR DESCRIPTION
## Problem

`getFfmpeg` memoizes one `FFmpeg` instance per realm, and the `.catch()` that clears the cache covers only a **load** failure — a path that never produced an instance in the first place. So a trap raised from inside an already-loaded core is permanent: WebAssembly linear memory is left inconsistent, every later entry re-traps at once, and the cached promise keeps handing the dead instance to every subsequent `ffmpeg`.

Found on a live leader. After a 10 MB `.ts` remux blew the heap at 15:13, every later `ffmpeg` failed instantly (4–130 ms, versus 11–126 s for real work) with the same message:

```
ffmpeg: RuntimeError: memory access out of bounds
```

Including a 64x64 synthetic encode with **no input file at all**:

```
$ ffmpeg -f lavfi -i testsrc=duration=1:size=64x64:rate=5 /tmp/syn.mp4
ffmpeg: RuntimeError: memory access out of bounds
```

Six commands over the next 12 minutes produced zero output and the session never recovered — only a tab reload would have cleared it. `ffmpeg -version` kept answering the whole time, because that gate resolves the core package without entering wasm, so the command looked healthy.

The heap pressure is cumulative rather than size-based: a 10.17 MB `.ts` remuxed fine at 15:12, and the near-identical 10.28 MB `.ts` trapped a minute later. `cleanupMemfs` deletes staged files but cannot reclaim heap the encoder grew.

## Fix

`recycleFfmpeg()` drops the cached promise and `terminate()`s the worker — terminating is what actually releases the dead core's heap. `runWasmFfmpeg` calls it when the wasm path throws.

A throw is already the right trigger: bad flags and unsupported codecs come back as a non-zero **exit code**, which is left alone. MEMFS cleanup is skipped after a fault, since every `deleteFile` would re-enter the trapped module. The caller gets told the core was recycled so a retry is worth trying.

This does not stop a large job from exhausting the heap — it stops one exhausted job from taking the rest of the session with it.

## Tests

`ffmpeg-wasm.test.ts` is new (mocks `@ffmpeg/ffmpeg`, so no core boots): instance sharing until recycle, `terminate()` on the stale worker, no-op when nothing is loaded, no unhandled rejection when recycling a failed load, and tolerance of an already-dead worker.

`ffmpeg-command.test.ts` covers the policy: recycle on a trap and on a staging throw, the retry hint, cleanup skipped after a fault, and **no** recycle for an ordinary non-zero exit or a missing/empty output. Reverting the source makes 3 of them fail.

## Verification

`verify` · `typecheck` · `test` (18,622) · `test:coverage` · both builds · `bundle-size` + first-load · `check-touched-exemptions` — all green. `ffmpeg-wasm.ts` statement coverage 91%.

Docs: new `docs/pitfalls.md` section — `magick-wasm.ts` and `v86-wasm.ts` have the same memoized shape and are listed as not yet recycled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Live verification (added after the first push)

Ran on an isolated local harness (bridge `:5715`, own wrangler `:8797`, ephemeral Chromium profile; production `:5710`/`:9222` PIDs verified unchanged before and after) against a build of this branch composed with #2767.

A real heap exhaustion was induced rather than simulated — a ~3 GB rawvideo encode:

```
$ ffmpeg -f lavfi -i testsrc=duration=40:size=1920x1080:rate=25 \
         -c:v rawvideo -pix_fmt yuv420p -f rawvideo big.yuv
frame=  623 fps= 51 q=-0.0 size= 1892352kB time=00:00:24.92 ...
ffmpeg: RangeError: Array buffer allocation failed
ffmpeg: the wasm core faulted and was recycled; retry the command (a large input may need to be split into smaller passes)
```

The core died at 1.89 GB — the same class of fault as the production incident, reached by a different route (`RangeError` on the JS side rather than a `RuntimeError` trap inside wasm; the recycle policy keys on the throw, not the message, so both are covered).

**The next commands succeed.** On the unpatched production leader this is exactly where everything stopped working for the rest of the session:

| Command run immediately after the fault | Result |
| --- | --- |
| `ffmpeg -f lavfi -i testsrc=duration=1:size=64x64:rate=5 syn.mp4` | 2835 B ✅ (this is the invocation that failed forever in the field) |
| `ffmpeg -f concat -safe 0 -i list.txt -c copy j3.mp4` | 16503 B ✅ |

Console watcher clean across the run.