### PR TITLE
ci(dev-tools): stop npm run lint re-dirtying the tree on main

### DIFF
--- a/.agents/skills/verifying-before-push/SKILL.md
+++ b/.agents/skills/verifying-before-push/SKILL.md
@@ -33,7 +33,8 @@ separate `check-touched-exemptions.mjs` command: `npm run verify` does not inclu
 The `.husky/pre-push` hook runs the full CI lint gate automatically before every
 push to a feature branch. It mirrors every check from the CI `lint` job —
 biome, prettier, custom lint scripts, complexity gate, manifest justifications,
-and knip dead-code detection — all in parallel (~6 s wall-clock).
+and knip dead-code detection — all in parallel (~6 s wall-clock), then the
+autofix-drift check (below) serially, because it writes.
 
 You can also run it manually:
 
@@ -79,6 +80,12 @@ xcodegen `project.yml` must overlap — see `packages/dev-tools/swift-pin-reconc
 
 CI runs the check-only/strict equivalents (`npm run lint:ci`) as a hard gate and will reject
 any unformatted code. **This is the most common CI failure — do not skip it.**
+
+CI then runs `npm run lint:autofix-drift`, which fails if `biome check --write` changes any
+file. `biome check` only fails on errors, but `--write` applies every safe fix, including
+those of warn/info rules, so a violation of one of those passes `lint:ci` yet gets rewritten by
+every local `npm run lint` — re-dirtying every worktree. Such violations land through commits
+that skip the pre-commit hook (GitHub web UI, Copilot Autofix). Fix: `npm run lint`, commit.
 
 ## Duplicate-code gate (`lint:duplication`)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,14 @@ jobs:
       # than in the macOS Swift jobs — no toolchain required.
       - name: Lint (biome + prettier + CLAUDE.md sizes + tessl skill lint)
         run: npm run lint:ci
+      - name: Autofix drift (npm run lint must be a no-op)
+        # `biome check` above only fails on errors, but `npm run lint` runs
+        # `biome check --write`, which applies every safe fix even for
+        # warn/info rules. A violation of one of those is green here yet
+        # rewritten by every local `npm run lint`, re-dirtying every worktree.
+        # They land via commits that skip the pre-commit hook (GitHub web UI,
+        # Copilot Autofix).
+        run: npm run lint:autofix-drift
       - name: Debt boy-scout gate (biome rules + layer back-edges)
         # Fail when this PR touches a file that is still on a debt list —
         # a per-rule biome.json exemption list or the layer back-edge

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "prepare": "husky",
     "lint:no-raw-chrome-runtime-id": "node packages/dev-tools/tools/check-no-raw-chrome-runtime-id.mjs",
     "lint:hosted-origin": "node packages/dev-tools/tools/check-hosted-origin-literal.mjs",
+    "lint:autofix-drift": "bash packages/dev-tools/tools/check-autofix-drift.sh",
     "verify": "bash packages/dev-tools/tools/pre-push-lint-gate.sh"
   },
   "dependencies": {

--- a/packages/dev-tools/CLAUDE.md
+++ b/packages/dev-tools/CLAUDE.md
@@ -18,6 +18,7 @@ Bare script names below live under `tools/` unless a fuller path is given.
 - **Doc gates** (`npm run lint:docs`, `.husky/pre-commit`): `tools/check-doc-sizes.mjs` + `check-doc-refs.mjs` (each + `-lib`). [details](../../docs/dev-tools-details.md#doc-dead-reference-gate).
 - **Hugging Face caching mirror** (`tools/hf-cache-mirror.mjs`): zero-dep local `huggingface.co` mirror; e2e CI caches `.cache/hf-mirror` and sets `HF_ENDPOINT` for warm-run Kokoro weights.
 - **Linear-history check**: `bash packages/dev-tools/tools/check-linear-history.sh [base-ref] [head-ref]`. `linear-history` CI job.
+- **Autofix-drift gate** (`npm run lint:autofix-drift`): `tools/check-autofix-drift.sh` — `biome check --write` must be a no-op; catches safe fixes of warn/info rules that `biome check` (lint:ci) accepts. CI `lint` job + pre-push gate.
 - **Skill lint** (`npm run lint:skills`): `tools/lint-skills.mjs` — `tessl skill lint` via `@tessl/cli`; warns locally, fails under `--strict`/CI.
 - **Patch reconcile** (`npm run lint:patches`): `packages/dev-tools/patch-reconcile/check-patches.mjs` + `reconcile-context.mjs`. See `patches/README.md`.
 - **Developer-skill sync** (`npm run lint:skill-router`): `tools/check-skill-router-sync.sh` — keeps root router, `.agents/skills/`, `.claude/skills/` in sync.

--- a/packages/dev-tools/tools/check-autofix-drift.sh
+++ b/packages/dev-tools/tools/check-autofix-drift.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Guard against autofix drift: `npm run lint` must be a no-op on a committed
+# tree.
+#
+# `npm run lint` runs `biome check --write`, which applies every *safe* fix
+# regardless of the rule's severity. CI runs `biome check` (no `--write`),
+# which only fails on *errors*. Biome ships ~30 recommended rules at
+# warn/info severity with a safe fix (`noAdjacentSpacesInRegex`,
+# `useNumericLiterals`, `noUselessEscapeInRegex`, ...), so a violation of any
+# of them is green in CI yet gets rewritten by every local `npm run lint` —
+# re-dirtying every worktree until someone commits the rewrite by hand.
+# lint-staged normally applies the fix at commit time, but commits made
+# outside the hook (GitHub web UI, Copilot Autofix, `--no-verify`) skip it.
+#
+# Runs the writing linter and fails if it changed anything. Compares the
+# working-tree diff before and after instead of demanding a clean tree, so an
+# on-demand `npm run verify` on a dirty checkout still works; the pre-push
+# hook already guarantees the tree matches the pushed commit. On a dirty tree
+# the `--stat` below lists pre-existing local edits too.
+#
+# Usage: bash packages/dev-tools/tools/check-autofix-drift.sh
+# Fix:   npm run lint, then commit the rewrites.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+BIOME="$REPO_ROOT/node_modules/.bin/biome"
+if [[ ! -x "$BIOME" ]]; then
+  echo "check-autofix-drift: biome not found in node_modules/.bin — run 'npm ci' first." >&2
+  exit 2
+fi
+
+snapshot() {
+  git diff | git hash-object --stdin
+}
+
+before="$(snapshot)"
+# Warnings are expected (naming convention, noExplicitAny, unused
+# suppressions); only a non-zero exit — an unfixable error — fails here, and
+# `biome check` in lint:ci already reports those with full context.
+if ! out="$("$BIOME" check --write . 2>&1)"; then
+  printf '%s\n' "$out" >&2
+  echo "check-autofix-drift: biome check --write failed." >&2
+  exit 1
+fi
+after="$(snapshot)"
+
+if [[ "$before" != "$after" ]]; then
+  echo "::error::'biome check --write' rewrote files that 'biome check' accepted:" >&2
+  git diff --stat >&2
+  git diff >&2
+  echo "Run 'npm run lint' and commit the result." >&2
+  exit 1
+fi
+echo "check-autofix-drift: npm run lint is a no-op on this tree."

--- a/packages/dev-tools/tools/check-autofix-drift.sh
+++ b/packages/dev-tools/tools/check-autofix-drift.sh
@@ -12,11 +12,13 @@
 # lint-staged normally applies the fix at commit time, but commits made
 # outside the hook (GitHub web UI, Copilot Autofix, `--no-verify`) skip it.
 #
-# Runs the writing linter and fails if it changed anything. Compares the
-# working-tree diff before and after instead of demanding a clean tree, so an
-# on-demand `npm run verify` on a dirty checkout still works; the pre-push
-# hook already guarantees the tree matches the pushed commit. On a dirty tree
-# the `--stat` below lists pre-existing local edits too.
+# Runs the writing linter and fails if it changed anything. Compares a
+# working-tree snapshot before and after instead of demanding a clean tree, so
+# an on-demand `npm run verify` on a dirty checkout still works; the pre-push
+# hook already guarantees the tree matches the pushed commit. The snapshot
+# covers untracked (non-ignored) files too: Biome scans them as well, and
+# `git diff` alone would miss a rewrite there. On a dirty tree the status and
+# diff below list pre-existing local edits too.
 #
 # Usage: bash packages/dev-tools/tools/check-autofix-drift.sh
 # Fix:   npm run lint, then commit the rewrites.
@@ -33,7 +35,10 @@ if [[ ! -x "$BIOME" ]]; then
 fi
 
 snapshot() {
-  git diff | git hash-object --stdin
+  {
+    git diff
+    git ls-files --others --exclude-standard | git hash-object --stdin-paths
+  } | git hash-object --stdin
 }
 
 before="$(snapshot)"
@@ -49,7 +54,7 @@ after="$(snapshot)"
 
 if [[ "$before" != "$after" ]]; then
   echo "::error::'biome check --write' rewrote files that 'biome check' accepted:" >&2
-  git diff --stat >&2
+  git status --short >&2
   git diff >&2
   echo "Run 'npm run lint' and commit the result." >&2
   exit 1

--- a/packages/dev-tools/tools/pre-push-lint-gate.sh
+++ b/packages/dev-tools/tools/pre-push-lint-gate.sh
@@ -100,6 +100,20 @@ for pid in "${CHECK_PIDS[@]}"; do
 	i=$((i + 1))
 done
 
+# ── autofix drift (serial — it writes) ───────────────────────────────────────
+# Mirrors the CI "Autofix drift" step: `biome check --write` must be a no-op.
+# Runs after the parallel checks so its writes cannot race their reads. If it
+# fails, the rewrites are already in the working tree — commit them.
+name="autofix-drift"
+if bash packages/dev-tools/tools/check-autofix-drift.sh >"$tmp/$name.log" 2>&1; then
+	echo "${G}✓${Z} $name"
+else
+	echo "${R}✗${Z} ${B}$name${Z}"
+	sed 's/^/  │ /' "$tmp/$name.log"
+	failures=$((failures + 1))
+fi
+CHECK_NAMES+=("$name")
+
 # ── summary ──────────────────────────────────────────────────────────────────
 total=${#CHECK_NAMES[@]}
 

--- a/packages/webapp/tests/ui/main-storage-persistence.test.ts
+++ b/packages/webapp/tests/ui/main-storage-persistence.test.ts
@@ -28,7 +28,7 @@ const source = readFileSync(mainPath, 'utf8');
  * commented-out `// setupStoragePersistence();` cannot satisfy the ordering
  * assertions below — that is exactly the regression they exist to catch.
  */
-const callIdx = source.search(/^  setupStoragePersistence\(\);$/m);
+const callIdx = source.search(/^ {2}setupStoragePersistence\(\);$/m);
 
 describe('ui/main.ts storage-persistence wiring', () => {
   it('imports setupStoragePersistence from the boot helper', () => {


### PR DESCRIPTION
## Problem

On a clean checkout of `main`, `npm run lint` rewrites a tracked file:

```diff
-const callIdx = source.search(/^  setupStoragePersistence\(\);$/m);
+const callIdx = source.search(/^ {2}setupStoragePersistence\(\);$/m);
```

CI's lint job stays green, so it never gets fixed and re-dirties every worktree (bit #2744 and #2761).

## Why the writing and checking linters disagree

- `npm run lint` runs `biome check --write .`, which applies every **safe** fix regardless of rule severity.
- `lint:ci` runs `biome check .`, which only fails on **errors**. Warnings exit 0.
- `noAdjacentSpacesInRegex` is a recommended rule at **warn** severity with a **safe** fix. Its violation is a warning to CI and a rewrite to the local linter.

It is not one stale rule. Auditing Biome 2.5.10 with `biome explain` finds **34 recommended rules** that pair a safe fix with warn/info severity (`useNumericLiterals`, `noUselessEscapeInRegex`, `noUselessRename`, ...). Any of them can put the tree back in this state.

How it slipped past `lint-staged`: the regex landed in f7d03aa95, a Copilot Autofix commit made through the GitHub web UI, which never runs the pre-commit hook. Server-side commits mean only a CI gate can hold the line.

## Fix

1. **Apply the one pending rewrite** (`test(webapp)` commit). `/^  setup/m` and `/^ {2}setup/m` match identically. Verified the guard still fails (3 of 6 assertions) when the call in `ui/main.ts` is commented out.
2. **Gate the whole class** (`ci(dev-tools)` commit). New `packages/dev-tools/tools/check-autofix-drift.sh` runs `biome check --write .` and fails if the working-tree diff changed. Wired as:
   - a CI step right after `lint:ci` (`npm run lint:autofix-drift`), with the diff in the failure output;
   - a serial step at the end of the pre-push gate, after the parallel readers, since it writes.
   
   It snapshots `git diff` before/after rather than demanding a clean tree, so an on-demand `npm run verify` on a dirty checkout still works. On failure the rewrites are already in the tree; `npm run lint` + commit is the fix.

Pinning `noAdjacentSpacesInRegex` to `error` was the alternative. It would clear today's diff but leave the other 33 rules latent, so the structural gate is the recurrence fix.

## Verification

- `check-autofix-drift.sh` fails on the unfixed tree with the exact diff above, passes after the rewrite.
- `npm run verify` (all 8 checks, incl. the new one) green; `check-touched-exemptions.mjs origin/main` green; `npm run typecheck` green.
- `npm run test`: 5 load-flake failures in 4 files unrelated to this change (timing races such as the hung-VFS-walk guard in `wc-sprinkles.test.ts`), on a host at load average >180. The touched test file passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
