### PR TITLE
fix(webapp): make the v86 loader layout-tolerant and add a live canary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21469,6 +21469,13 @@
         "base64-arraybuffer": "^1.0.2"
       }
     },
+    "node_modules/v86": {
+      "version": "0.5.424",
+      "resolved": "https://registry.npmjs.org/v86/-/v86-0.5.424.tgz",
+      "integrity": "sha512-YEFGBGKVjipcUIQskAXzC9992guXg39r3Fst3rn/jNA9kiHnu5Q/dNQxXYPk6ZlWXcqxMNDaUkdEBsNY1AIYBg==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -23015,7 +23022,8 @@
         "@types/w3c-web-serial": "1.0.8",
         "fake-indexeddb": "6.2.5",
         "jsdom": "30.0.1",
-        "puppeteer-core": "25.9.0"
+        "puppeteer-core": "25.9.0",
+        "v86": "0.5.424"
       }
     },
     "packages/webcomponents": {

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -76,6 +76,7 @@
     "@types/w3c-web-serial": "1.0.8",
     "fake-indexeddb": "6.2.5",
     "jsdom": "30.0.1",
-    "puppeteer-core": "25.9.0"
+    "puppeteer-core": "25.9.0",
+    "v86": "0.5.424"
   }
 }

--- a/packages/webapp/src/globals.d.ts
+++ b/packages/webapp/src/globals.d.ts
@@ -10,6 +10,7 @@ declare const __MAGICK_WASM_VERSION__: string;
 declare const __BIOME_WASM_WEB_VERSION__: string;
 declare const __BIOME_JS_API_VERSION__: string;
 declare const __FFMPEG_CORE_VERSION__: string;
+declare const __V86_VERSION__: string;
 
 declare module 'sql.js/dist/sql-wasm.js' {
   interface SqlJsResultSet {

--- a/packages/webapp/src/shell/supplemental-commands/v86-wasm.ts
+++ b/packages/webapp/src/shell/supplemental-commands/v86-wasm.ts
@@ -11,10 +11,18 @@
  * canonical `ipk add` guidance error which the `v86` command surfaces
  * verbatim. ZERO network in the not-installed path.
  *
- * Because the glue is not a webapp dependency, the pinned version is a
- * source literal (there is no package.json entry for Renovate to bump —
- * bumping means updating `V86_PINNED_VERSION` after re-verifying the
- * internal surfaces `v86-vm.ts` instruments).
+ * `v86` IS a webapp devDependency, but only so the version pin can be
+ * baked from `package.json` (the `__V86_VERSION__` define, same mechanism
+ * as the magick / biome / ffmpeg pins) and so the live canary
+ * (`tests/shell/supplemental-commands/v86-wasm-live.test.ts`) has a real
+ * installed package to probe. No source file may import it — that would
+ * drag the ~350 kB glue into the kernel worker's cold-boot graph — and
+ * `v86-wasm.test.ts` pins that at the source level. Bumping the
+ * devDependency is how the pin moves; the canary then checks the
+ * installed package's layout, exports and the internal surfaces
+ * `v86-vm.ts` instruments, and the agent skill's `ipk add` line must move
+ * with it, so a Renovate bump still gets a human re-verification rather
+ * than a silent auto-merge.
  */
 
 import { splitPath } from '../../fs/path-utils.js';
@@ -22,14 +30,31 @@ import { compileWasmModule } from '../../kernel/realm/wasm-compiler.js';
 import { resolve as ipkResolve, type ModuleReader } from '../ipk/resolver.js';
 import { GLOBAL_IPK_ADD, isNodeRuntime } from './shared.js';
 
-/** The npm `v86` release the command is pinned to. */
-export const V86_PINNED_VERSION = '0.5.424';
+/**
+ * The npm `v86` release the command is pinned to — the exact webapp
+ * devDependency, baked in at build time so the install guidance and the
+ * package the canary verifies can never disagree (it used to be a source
+ * literal edited by hand alongside every bump).
+ *
+ * There is deliberately no `assertMagickVersionMatch`-style guard on the
+ * version an ipk install actually carries. magick needs one because its
+ * glue is bundled here while its wasm comes from the VFS, so a bare
+ * `ipk add` mixes two releases and emscripten hangs for 30 s. v86 ships
+ * glue and wasm in the same tarball, so whatever is installed is
+ * self-consistent and boots. The only exposure of a drifted install is a
+ * release renaming one of the OPTIONAL internals `v86-vm.ts` wraps
+ * (`screen_adapter.update_buffer`, `get_text_screen`, ...): those are
+ * optional-chained, so `screenshot` / `text` would go empty rather than
+ * hang, and `v86 --version` prints the installed release to make that
+ * diagnosable.
+ */
+export const V86_PINNED_VERSION = __V86_VERSION__;
 
 export const V86_NOT_INSTALLED = `v86 is not installed in node_modules: run \`${GLOBAL_IPK_ADD} v86@${V86_PINNED_VERSION}\` (no network fallback)`;
 
 /**
  * Read-only VFS context the loader needs to read an ipk-installed
- * `v86/build/{libv86.mjs,v86.wasm}` pair. Mirrors the
+ * `v86` glue + engine pair (see `V86_LAYOUT_CANDIDATES`). Mirrors the
  * `IpkResolutionContext` shape used by `esbuild-wasm.ts` /
  * `ffmpeg-wasm.ts` so every float wires the loader the same way.
  */
@@ -164,11 +189,53 @@ export async function getV86Module(
 }
 
 /**
- * Try to read `build/libv86.mjs` + `build/v86.wasm` (and the manifest
- * version) from an ipk-installed `v86` in the VFS. Returns `null` on
- * any resolution / read miss so the caller surfaces the canonical
- * guidance error. Exported so resolution is unit-testable without
- * booting the emulator.
+ * Where the glue + engine pair lives inside an ipk-installed `v86`,
+ * relative to the package root, in probe order. Explicit so a future
+ * layout move is a one-line addition here instead of a silent "not
+ * installed" — the failure mode `@imagemagick/magick-wasm` 0.0.43 caused
+ * when it moved `magick.wasm` under `dist/x86/` and every
+ * filesystem-mocking test stayed green (PR #2744).
+ *
+ * Surveyed 2026-09-02: every official copy/v86 release on npm — 0.5.10
+ * (March 2025) through 0.5.456 — ships `build/libv86.mjs` (the manifest's
+ * `main`) next to `build/v86.wasm`. The layout has never moved. The
+ * `build/index.js` + `build/v86.wasm` shape of the 2022-2023 `v86` 0.3.x /
+ * 0.4.x publications is deliberately NOT a candidate: those were a
+ * third-party fork (giulioz/v86-module) with a different API, so
+ * resolving them would trade the clean guidance error for a constructor
+ * failure one step later. The `-debug` / `-fallback` engine variants that
+ * ship alongside are not candidates either; the emulator is always handed
+ * the primary build via `wasm_fn`.
+ */
+export const V86_LAYOUT_CANDIDATES: readonly { readonly js: string; readonly wasm: string }[] = [
+  { js: 'build/libv86.mjs', wasm: 'build/v86.wasm' },
+];
+
+/**
+ * First candidate layout whose glue AND engine both exist under `pkgDir`,
+ * or `null` for a partial install / an unknown future layout (the caller
+ * turns that into the canonical guidance error).
+ */
+async function findV86Layout(
+  pkgDir: string,
+  reader: ModuleReader
+): Promise<{ jsPath: string; wasmPath: string } | null> {
+  for (const { js, wasm } of V86_LAYOUT_CANDIDATES) {
+    const jsPath = `${pkgDir}/${js}`;
+    const wasmPath = `${pkgDir}/${wasm}`;
+    if ((await reader.exists(jsPath)) && (await reader.exists(wasmPath))) {
+      return { jsPath, wasmPath };
+    }
+  }
+  return null;
+}
+
+/**
+ * Try to read the glue + engine pair (see `V86_LAYOUT_CANDIDATES`) and
+ * the manifest version from an ipk-installed `v86` in the VFS. Returns
+ * `null` on any resolution / read miss so the caller surfaces the
+ * canonical guidance error. Exported so resolution is unit-testable
+ * without booting the emulator.
  */
 export async function tryLoadV86FromNodeModules(
   ipk: IpkResolutionContext
@@ -180,16 +247,13 @@ export async function tryLoadV86FromNodeModules(
     return null;
   }
   if (resolved.type !== 'file') return null;
-  const pkgDir = splitPath(resolved.path).dir;
-  const jsPath = `${pkgDir}/build/libv86.mjs`;
-  const wasmPath = `${pkgDir}/build/v86.wasm`;
-  if (!(await ipk.reader.exists(jsPath))) return null;
-  if (!(await ipk.reader.exists(wasmPath))) return null;
+  const layout = await findV86Layout(splitPath(resolved.path).dir, ipk.reader);
+  if (!layout) return null;
   try {
     const manifest = await ipk.reader.readFile(resolved.path);
     const version = String(JSON.parse(manifest).version ?? V86_PINNED_VERSION);
-    const jsSource = await ipk.reader.readFile(jsPath);
-    const wasmBytes = await ipk.readBytes(wasmPath);
+    const jsSource = await ipk.reader.readFile(layout.jsPath);
+    const wasmBytes = await ipk.readBytes(layout.wasmPath);
     return { jsSource, wasmBytes, version };
   } catch {
     return null;

--- a/packages/webapp/tests/shell/supplemental-commands/v86-wasm-live.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/v86-wasm-live.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Live canary for the ipk-installed `v86` engine.
+ *
+ * Every other v86 test drives the loader over a synthetic file map or a
+ * mocked engine, so all of them pass against a package whose real on-disk
+ * shape, exports or internals have changed underneath us — the failure
+ * mode that let `@imagemagick/magick-wasm` 0.0.43 ship with a green unit
+ * suite and a broken `convert` (PR #2744). `v86` is a webapp devDependency
+ * purely so this test has the REAL package to probe; the runtime never
+ * imports it (see the header of `v86-wasm.ts`). Keep this pointed at the
+ * installed copy — mocking anything here defeats the purpose.
+ *
+ * What it covers, against the installed package:
+ *   - the layout probe: `tryLoadV86FromNodeModules` resolves the glue and
+ *     engine over a VFS that mirrors the real install, byte for byte, and
+ *     the candidate it picks is the package's own `main`;
+ *   - the engine binary: the resolved bytes compile to a module whose
+ *     import surface is the single `env` object `makeWasmFn` is handed;
+ *   - the glue's exports: the real module exposes the `V86` constructor
+ *     `loadV86` picks (`glue.V86 ?? glue.default`);
+ *   - the version pin: `V86_PINNED_VERSION` equals the installed manifest
+ *     AND the `ipk add` line in the agent skill, so a Renovate bump cannot
+ *     land without the skill moving with it;
+ *   - the internals `v86-vm.ts` / `v86-command.ts` reach into
+ *     (`screen_adapter.update_buffer`, `get_text_screen`, the fetch relay,
+ *     the `emulator-loaded` bus event, ...) still exist in the glue.
+ *
+ * What it does NOT cover: booting a guest (needs BIOS blobs and seconds of
+ * CPU — the mocked-engine lifecycle tests in `v86-command.test.ts` own that
+ * surface), the `blob:` URL import in `loadV86` (browser-only; Node cannot
+ * import blob URLs), instantiating the wasm against the glue's real import
+ * object, or a SEMANTIC change to an internal that keeps its name. Cost is
+ * ~100 ms, dominated by compiling the ~2 MB engine.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+// Bare specifier on purpose: the webapp vitest project aliases `node:module`
+// to a browser stub whose `createRequire` throws.
+import { createRequire } from 'module';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { compileWasmModule } from '../../../src/kernel/realm/wasm-compiler.js';
+import {
+  tryLoadV86FromNodeModules,
+  V86_LAYOUT_CANDIDATES,
+  V86_PINNED_VERSION,
+} from '../../../src/shell/supplemental-commands/v86-wasm.js';
+
+const require = createRequire(import.meta.url);
+// Resolve through npm rather than a hardcoded `node_modules` path so the
+// test follows the package wherever the workspace hoists it.
+const PKG = dirname(require.resolve('v86/package.json'));
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../..');
+const SKILL_PATH = resolve(REPO_ROOT, 'packages/vfs-root/workspace/skills/v86/SKILL.md');
+
+const VFS_ROOT = '/workspace';
+const VFS_PKG = `${VFS_ROOT}/node_modules/v86`;
+
+/**
+ * The tarball's manifest carries the git build metadata of the release
+ * (`0.5.424+g2f1346b`), which npm strips from the version people install
+ * by. The pin is the installable form, so compare on the release part.
+ * This is also why a magick-style exact-equality version guard would have
+ * rejected every correctly pinned install.
+ */
+const releaseOf = (version: string): string => version.split('+')[0] ?? version;
+
+/**
+ * Every v86 internal the command layer touches by name. Sourced from the
+ * `V86Emulator` / `V86ScreenAdapter` / `V86NetworkAdapter` /
+ * `V86BootOptions` interfaces in `v86-wasm.ts` and the bus events
+ * `v86-vm.ts` / `v86-command.ts` subscribe to. A release that renames one
+ * of these would not fail typecheck (the interfaces are hand-written) and
+ * would not fail the lifecycle tests (they mock the engine); it would only
+ * show up as an empty screenshot or a VM that never reports ready.
+ */
+const INSTRUMENTED_INTERNALS = [
+  // Constructor options the command relies on.
+  'wasm_fn',
+  'net_device',
+  'relay_url',
+  // Emulator methods.
+  'add_listener',
+  'is_running',
+  'save_state',
+  'restore_state',
+  'keyboard_send_text',
+  'keyboard_send_scancodes',
+  'serial0_send',
+  // Bus events.
+  '"emulator-loaded"',
+  '"serial0-output-byte"',
+  // Screen adapter surface wrapped by `instrumentVm`.
+  'screen_adapter',
+  'set_mode',
+  'set_size_graphical',
+  'update_buffer',
+  'get_text_screen',
+  // VGA device reached via `emulator.v86.cpu.devices.vga`.
+  'screen_fill_buffer',
+  'graphical_mode',
+  // Fetch relay whose `fetch` the command swaps for the SLICC proxy.
+  'network_adapter',
+] as const;
+
+describe('v86 live canary (real installed package)', () => {
+  let layout: (typeof V86_LAYOUT_CANDIDATES)[number];
+  let realJs: string;
+  let realWasm: Uint8Array;
+  let loaded: NonNullable<Awaited<ReturnType<typeof tryLoadV86FromNodeModules>>>;
+
+  beforeAll(async () => {
+    const found = V86_LAYOUT_CANDIDATES.find(
+      (candidate) => existsSync(`${PKG}/${candidate.js}`) && existsSync(`${PKG}/${candidate.wasm}`)
+    );
+    expect(
+      found,
+      `no glue + engine pair under ${PKG} in any known layout ` +
+        `(${V86_LAYOUT_CANDIDATES.map((c) => `${c.js} + ${c.wasm}`).join(', ')}) — the package ` +
+        `changed shape; add the new layout to V86_LAYOUT_CANDIDATES in v86-wasm.ts`
+    ).toBeDefined();
+    layout = found as (typeof V86_LAYOUT_CANDIDATES)[number];
+
+    realJs = readFileSync(`${PKG}/${layout.js}`, 'utf8');
+    realWasm = new Uint8Array(readFileSync(`${PKG}/${layout.wasm}`));
+    const pkgJson = readFileSync(`${PKG}/package.json`, 'utf8');
+    // Mirror the real layout into the VFS the loader walks.
+    const text = new Map([
+      [`${VFS_PKG}/package.json`, pkgJson],
+      [`${VFS_PKG}/${layout.js}`, realJs],
+    ]);
+    const present = new Set([...text.keys(), `${VFS_PKG}/${layout.wasm}`]);
+    const ipk = {
+      fromDir: VFS_ROOT,
+      reader: {
+        exists: async (path: string) => present.has(path),
+        isDirectory: async (path: string) =>
+          [...present].some((file) => file.startsWith(`${path}/`)),
+        readFile: async (path: string) => {
+          const body = text.get(path);
+          if (body === undefined) throw new Error(`ENOENT: ${path}`);
+          return body;
+        },
+      },
+      readBytes: async (path: string) => {
+        if (path === `${VFS_PKG}/${layout.wasm}`) return realWasm;
+        throw new Error(`ENOENT: ${path}`);
+      },
+    };
+    const result = await tryLoadV86FromNodeModules(ipk);
+    expect(result, 'the loader could not resolve the mirrored real install').not.toBeNull();
+    loaded = result as typeof loaded;
+  });
+
+  it('resolves the real install and hands back the real glue and engine bytes', () => {
+    expect(releaseOf(loaded.version)).toBe(V86_PINNED_VERSION);
+    expect(loaded.jsSource).toBe(realJs);
+    expect(loaded.wasmBytes.byteLength).toBe(realWasm.byteLength);
+    expect(Buffer.from(loaded.wasmBytes).equals(Buffer.from(realWasm))).toBe(true);
+    // The candidate the probe picked is the package's own entry point, so a
+    // release that moves `main` elsewhere fails here even if it leaves a
+    // stale copy behind at the old path.
+    expect(require.resolve('v86')).toBe(resolve(PKG, layout.js));
+  });
+
+  it('compiles the real engine and exposes the surface makeWasmFn feeds it', async () => {
+    const mod = await compileWasmModule(loaded.wasmBytes);
+    // v86 builds its whole import object under `env`; `makeWasmFn` passes
+    // that object straight through, so a second import module would be a
+    // silent instantiate failure inside the emulator.
+    const imports = WebAssembly.Module.imports(mod);
+    expect(imports.length).toBeGreaterThan(0);
+    expect(new Set(imports.map((entry) => entry.module))).toEqual(new Set(['env']));
+    expect(WebAssembly.Module.exports(mod)).toContainEqual({ name: 'memory', kind: 'memory' });
+  });
+
+  it('exports the V86 constructor the loader picks', async () => {
+    // Node's resolver, not the blob-URL path — that is browser-only. Same
+    // file, same exports, so this is the check for a renamed/dropped export.
+    // Mirror `loadV86`'s pick exactly: the glue currently ships both a named
+    // `V86` and a default export, and either one keeps the runtime working.
+    const glue = (await import('v86')) as { V86?: unknown; default?: unknown };
+    expect(typeof (glue.V86 ?? glue.default)).toBe('function');
+  });
+
+  it('keeps V86_PINNED_VERSION in lockstep with the installed package and the agent skill', () => {
+    const pkg = JSON.parse(readFileSync(`${PKG}/package.json`, 'utf8')) as { version: string };
+    expect(V86_PINNED_VERSION).toBe(releaseOf(pkg.version));
+    // The agent-facing skill carries the install line as a literal; a bump
+    // that lands without updating it would leave agents installing the old
+    // release the canary no longer verifies.
+    const skill = readFileSync(SKILL_PATH, 'utf8');
+    expect(skill).toContain(`ipk add -g v86@${V86_PINNED_VERSION}`);
+  });
+
+  it('still ships every internal the command instruments', () => {
+    for (const internal of INSTRUMENTED_INTERNALS) {
+      expect(
+        loaded.jsSource.includes(internal),
+        `${internal} is gone from the installed glue — re-verify v86-vm.ts / v86-command.ts against v86@${loaded.version}`
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/v86-wasm.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/v86-wasm.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Resolution and contract tests for the v86 loader, over a synthetic
+ * VFS. The live canary (`v86-wasm-live.test.ts`) is what touches the real
+ * package; these pin the loader's behaviour for every supported layout
+ * and every miss path without any package on disk.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { GLOBAL_IPK_ADD } from '../../../src/shell/supplemental-commands/shared.js';
+import {
+  getV86Module,
+  resetV86ForTests,
+  tryLoadV86FromNodeModules,
+  V86_LAYOUT_CANDIDATES,
+  V86_NOT_INSTALLED,
+  V86_PINNED_VERSION,
+} from '../../../src/shell/supplemental-commands/v86-wasm.js';
+
+const VFS_ROOT = '/workspace';
+const VFS_PKG = `${VFS_ROOT}/node_modules/v86`;
+const MANIFEST = JSON.stringify({ name: 'v86', version: '0.5.999', main: 'build/libv86.mjs' });
+const GLUE = 'export class V86 {}';
+const WASM = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 1, 0, 0, 0]);
+
+/**
+ * Synthetic ipk context over an in-memory file map. `readFile` serves
+ * strings, `readBytes` serves bytes; either can be forced to throw to
+ * exercise the read-failure paths.
+ */
+function makeIpk(
+  files: Record<string, string | Uint8Array>,
+  opts: { failRead?: string; failBytes?: string } = {}
+) {
+  const paths = Object.keys(files);
+  return {
+    fromDir: VFS_ROOT,
+    reader: {
+      exists: async (path: string) => path in files,
+      isDirectory: async (path: string) => paths.some((file) => file.startsWith(`${path}/`)),
+      readFile: async (path: string) => {
+        const body = files[path];
+        if (body === undefined || path === opts.failRead) throw new Error(`ENOENT: ${path}`);
+        return typeof body === 'string' ? body : new TextDecoder().decode(body);
+      },
+    },
+    readBytes: async (path: string) => {
+      const body = files[path];
+      if (body === undefined || path === opts.failBytes) throw new Error(`ENOENT: ${path}`);
+      return typeof body === 'string' ? new TextEncoder().encode(body) : body;
+    },
+  };
+}
+
+function install(layout: { js: string; wasm: string }, manifest = MANIFEST) {
+  return {
+    [`${VFS_PKG}/package.json`]: manifest,
+    [`${VFS_PKG}/${layout.js}`]: GLUE,
+    [`${VFS_PKG}/${layout.wasm}`]: WASM,
+  };
+}
+
+describe('tryLoadV86FromNodeModules', () => {
+  it.each(V86_LAYOUT_CANDIDATES.map((layout) => [`${layout.js} + ${layout.wasm}`, layout]))(
+    'resolves the %s layout',
+    async (_label, layout) => {
+      const loaded = await tryLoadV86FromNodeModules(makeIpk(install(layout)));
+      expect(loaded).not.toBeNull();
+      expect(loaded?.jsSource).toBe(GLUE);
+      expect(loaded?.wasmBytes).toBe(WASM);
+      expect(loaded?.version).toBe('0.5.999');
+    }
+  );
+
+  it('returns null when v86 is not installed at all', async () => {
+    expect(await tryLoadV86FromNodeModules(makeIpk({}))).toBeNull();
+  });
+
+  it('returns null when the package is present in an unknown layout', async () => {
+    // The pre-0.5 fork layout: a real historical shape that is deliberately
+    // not a candidate (different publisher, different API).
+    const files = {
+      [`${VFS_PKG}/package.json`]: MANIFEST,
+      [`${VFS_PKG}/build/index.js`]: GLUE,
+      [`${VFS_PKG}/build/v86.wasm`]: WASM,
+    };
+    expect(await tryLoadV86FromNodeModules(makeIpk(files))).toBeNull();
+  });
+
+  it.each(V86_LAYOUT_CANDIDATES)(
+    'returns null when only one half of a layout is present',
+    async (layout) => {
+      const glueOnly = install(layout);
+      delete glueOnly[`${VFS_PKG}/${layout.wasm}`];
+      expect(await tryLoadV86FromNodeModules(makeIpk(glueOnly))).toBeNull();
+      const wasmOnly = install(layout);
+      delete wasmOnly[`${VFS_PKG}/${layout.js}`];
+      expect(await tryLoadV86FromNodeModules(makeIpk(wasmOnly))).toBeNull();
+    }
+  );
+
+  it('returns null when the manifest, glue, or engine cannot be read', async () => {
+    const layout = V86_LAYOUT_CANDIDATES[0]!;
+    const files = install(layout);
+    expect(
+      await tryLoadV86FromNodeModules(makeIpk(files, { failRead: `${VFS_PKG}/package.json` }))
+    ).toBeNull();
+    expect(
+      await tryLoadV86FromNodeModules(makeIpk(files, { failRead: `${VFS_PKG}/${layout.js}` }))
+    ).toBeNull();
+    expect(
+      await tryLoadV86FromNodeModules(makeIpk(files, { failBytes: `${VFS_PKG}/${layout.wasm}` }))
+    ).toBeNull();
+  });
+
+  it('falls back to the pinned version when the manifest carries none', async () => {
+    const loaded = await tryLoadV86FromNodeModules(
+      makeIpk(install(V86_LAYOUT_CANDIDATES[0]!, JSON.stringify({ name: 'v86' })))
+    );
+    expect(loaded?.version).toBe(V86_PINNED_VERSION);
+  });
+});
+
+describe('v86 loader contract', () => {
+  it('pins the install guidance to the exact devDependency version', () => {
+    expect(V86_PINNED_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(V86_NOT_INSTALLED).toContain(`${GLOBAL_IPK_ADD} v86@${V86_PINNED_VERSION}`);
+    expect(V86_NOT_INSTALLED).not.toMatch(/https?:\/\//);
+  });
+
+  it('refuses to load the engine in the Node runtime', async () => {
+    resetV86ForTests();
+    await expect(getV86Module()).rejects.toThrow(/not available in Node runtime/);
+    resetV86ForTests();
+  });
+
+  /**
+   * `v86` sits in webapp's devDependencies for the version define and the
+   * live canary only. A static or dynamic import from any v86 source module
+   * would put the ~350 kB glue into the kernel worker's cold-boot graph —
+   * a bundling-shape invariant no runtime test can see, so it is pinned at
+   * the source level like the magick import-shape test.
+   */
+  it('never imports the v86 package from source', () => {
+    const dir = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      '../../../src/shell/supplemental-commands'
+    );
+    for (const file of ['v86-wasm.ts', 'v86-vm.ts', 'v86-command.ts']) {
+      const source = readFileSync(resolve(dir, file), 'utf8');
+      expect(source, `${file} imports the v86 package`).not.toMatch(/from\s+['"]v86['"]/);
+      expect(source, `${file} imports the v86 package`).not.toMatch(/import\(\s*['"]v86['"]/);
+    }
+  });
+});

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -480,6 +480,9 @@ export default defineConfig(({ mode }) => ({
     __BIOME_WASM_WEB_VERSION__: JSON.stringify(wasmDepVersion('@biomejs/wasm-web')),
     __BIOME_JS_API_VERSION__: JSON.stringify(wasmDepVersion('@biomejs/js-api')),
     __FFMPEG_CORE_VERSION__: JSON.stringify(wasmDepVersion('@ffmpeg/core')),
+    // v86 is a devDependency purely for this pin and the live canary — nothing
+    // from it is bundled (see v86-wasm.ts).
+    __V86_VERSION__: JSON.stringify(wasmDepVersion('v86')),
     // Buffer polyfill for isomorphic-git
     global: 'globalThis',
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ const wasmVersionDefines = {
   __BIOME_WASM_WEB_VERSION__: JSON.stringify(wasmDepVersion('@biomejs/wasm-web')),
   __BIOME_JS_API_VERSION__: JSON.stringify(wasmDepVersion('@biomejs/js-api')),
   __FFMPEG_CORE_VERSION__: JSON.stringify(wasmDepVersion('@ffmpeg/core')),
+  __V86_VERSION__: JSON.stringify(wasmDepVersion('v86')),
 };
 
 const isCI = Boolean(process.env['CI']);


### PR DESCRIPTION
## Summary

Follow-up to PR #2744 (the `@imagemagick/magick-wasm` 0.0.43 layout break) for the other wasm loader whose unit tests could not see the real package: `v86-wasm.ts`.

**Facts first.** Surveyed every layout the npm `v86` package has shipped (2026-09-02):

| Publications | Publisher | Layout |
| --- | --- | --- |
| 1.0.0–1.0.5 (2019) | unrelated | n/a |
| 0.3.x–0.4.0 (2022–2023) | giulioz/v86-module fork | `build/index.js` + `build/v86.wasm` |
| 0.5.10 (2025-03) → 0.5.456 (today) | copy/v86 | `build/libv86.mjs` (the manifest `main`) + `build/v86.wasm` |

The official package's layout has **never moved**. The candidate list therefore has one entry, and the pre-0.5 fork layout is deliberately not a candidate (different API; resolving it would trade the clean guidance error for a constructor failure one step later). The list exists so a future move is a one-line change instead of a silent "not installed".

**Pin drift.** `V86_PINNED_VERSION` was a source literal with nothing tying it to any installed package. It now derives from an exact `v86` devDependency of the webapp via a `__V86_VERSION__` define, the same mechanism as the magick / biome / ffmpeg pins. Two findings from checking the drift question:

- There is no magick-style hang to guard against: v86 ships glue and wasm in one tarball, so any ipk-installed version is self-consistent. A drifted install can only lose an optional internal that `v86-vm.ts` wraps (all optional-chained), which degrades `screenshot` / `text` to empty output rather than hanging. Documented in the module; no version assertion added, on purpose.
- The tarball manifest carries git build metadata (`0.5.424+g2f1346b`) that npm strips from the installable version. A magick-style exact-equality guard would have rejected every correctly pinned install. The canary compares on the release part and says why.

## Changes

- `v86-wasm.ts`: explicit, commented `V86_LAYOUT_CANDIDATES`; resolution probes the list; pin from the define; header rewritten for the new contract (devDependency exists for the pin + canary only, never imported from source).
- `vite.config.ts` / `vitest.config.ts` / `globals.d.ts`: `__V86_VERSION__` define.
- `packages/webapp/package.json`: `v86` exact devDependency (`0.5.424`, unchanged pin).
- New `v86-wasm-live.test.ts` (live canary, ~100 ms) against the **actually installed** package: layout probe over a mirrored VFS byte-for-byte, the probed path is the package's own `main`, the real engine compiles and imports only from `env`, the real glue exports the constructor `loadV86` picks, pin == installed manifest == the `ipk add` line in the agent skill, and every internal `v86-vm.ts` / `v86-command.ts` instruments still exists in the glue. Does not boot a guest, does not exercise the browser-only `blob:` import path, does not catch semantic changes behind an unchanged name. All stated in the file header.
- New `v86-wasm.test.ts`: each supported layout resolves, unknown layout / half-installed / unreadable → `null`, version fallback, guidance string, Node refusal, and a source-level guard that no v86 module imports the package.

## Proof the tests bite

Each mutation applied, run, restored:

| Mutation | Failing test |
| --- | --- |
| Loader hardcodes `build/` again while the list says `dist/` | unit `resolves the … layout` + canary `beforeAll` |
| Real package moves `build/` → `dist/` (what magick 0.0.43 did) | canary `beforeAll` (unit suite stays green, as expected) |
| Skill install line drifts to 0.5.425 | canary lockstep |
| devDependency bumped without the install following | canary lockstep + resolve |
| `get_text_screen` renamed inside the real glue | canary internals |
| Both `V86` exports renamed in the real glue | canary exports |

## Verification

Local, on a machine shared with three sibling worktrees' builds (load average 100–400 throughout):

- `npm run verify`: all 7 checks pass
- `node packages/dev-tools/tools/check-touched-exemptions.mjs`: pass
- `npm run typecheck`: all 9 projects pass
- `npm run deadcode`: pass (pre-existing hints only)
- `npm run build` + `npm run build -w @slicc/chrome-extension` + `npm run bundle-size`: pass — first-load delta within the allowance, every size-limit budget under its cap (nothing new enters any bundle: the define is a string literal and `v86` is never imported from source)
- `npm run test`: the v86, magick, and shadow-map suites pass; the full run had 11 → 5 → 4 failures across reruns, all `Test timed out in 5000ms` / `Hook timed out` / a boot-resilience race in files untouched here (`adobe-provider`, `slicc-fs-module`, `wc-sprinkles`, `check-swift-resolved-drift`). A/B with this PR's only test-config change (the vitest define) reverted still fails the same files, so they are environmental; CI is the arbiter. The local coverage run under the same load had 95 timing failures and never evaluated its floors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
