### PR TITLE
test(webapp): live canary for the real esbuild-wasm package

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/esbuild-wasm.ts
+++ b/packages/webapp/src/shell/supplemental-commands/esbuild-wasm.ts
@@ -25,6 +25,18 @@
  * `wasmURL` / `wasmModule` / `worker` options on `initialize`.
  * The Node path therefore must not call `initialize` at all —
  * `esbuild.build()` lazily boots the service on first call.
+ *
+ * The glue is a namespace import on purpose, unlike `magick-wasm.ts`,
+ * where named bindings shave ~100 kB of unused dual glue off the kernel
+ * worker's cold-boot graph. Vite resolves `esbuild-wasm` through its
+ * `browser` field to `lib/browser.js`, which is CommonJS: the bundle
+ * carries it as one opaque interop closure that no import style can
+ * tree-shake, and the package ships a single service with no dual glue
+ * to drop anyway. Named imports were measured at +163 B on the worker
+ * graph (the wrapper object), not a saving. The module sits in that
+ * eager graph for a functional reason — `realm-host.ts` needs
+ * `getEsbuild` for realm `require()` of ESM — so hoisting
+ * `ESBUILD_VERSION` into a leaf would not detach it either.
  */
 
 import * as esbuild from 'esbuild-wasm';
@@ -137,6 +149,12 @@ export interface EsbuildWasmBinary {
  * apply), derives the package directory from the resolved file, and
  * reads sibling `esbuild.wasm` bytes. Returns `null` on any miss —
  * the caller surfaces a clean "not installed" error.
+ *
+ * The binary has lived at the package root in every `esbuild-wasm`
+ * release since 0.5.0, so there is deliberately no candidate list here.
+ * A release that moves it would still pass every mocked test in this
+ * tree; `esbuild-wasm-live.test.ts` reads the real installed package
+ * and is the check that catches that.
  *
  * Exported so the loader's resolution behavior is unit-testable
  * without booting the heavy WASM service.

--- a/packages/webapp/tests/shell/supplemental-commands/esbuild-wasm-live.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/esbuild-wasm-live.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Live canary for the bundled `esbuild-wasm` glue.
+ *
+ * Every other esbuild test drives the loader over a synthetic file map or a
+ * mocked `esbuild-wasm`, so all of them stay green when the real package
+ * changes shape underneath us — the failure mode PR #2744 hit with
+ * `@imagemagick/magick-wasm` (see `magick-wasm-live.test.ts`). The loader
+ * reads `esbuild.wasm` from ONE hardcoded place inside the installed
+ * package, and a release that moves it would make `esbuild` report "not
+ * installed" while the unit suite passes.
+ *
+ * This test uses the REAL installed package — its actual layout, its actual
+ * `esbuild.wasm`, its actual browser glue — and runs one real transform and
+ * one real bundle through `getEsbuild`. It is the check that fails when a
+ * dependency update changes the package's shape, its exports, or its ABI.
+ * Keep it pointed at the installed copy.
+ *
+ * Two things are deliberately redirected, and both point AT the production
+ * path rather than away from it:
+ *
+ * - `isNodeRuntime` is forced false so the loader takes the browser branch
+ *   (compile bytes to a `WebAssembly.Module`, `initialize({ wasmModule,
+ *   worker: false })`) — the path every SLICC float actually runs.
+ * - `esbuild-wasm` is resolved to `lib/browser.js`, the file Vite picks
+ *   through the package's `browser` field for the kernel-worker bundle.
+ *   Under vitest the bare specifier resolves to `lib/main.js` (the `main`
+ *   field), whose Node service spawns a wasm subprocess and REJECTS the
+ *   `wasmModule` / `worker` options outright — it cannot exercise the
+ *   browser branch at all.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type * as EsbuildNs from 'esbuild-wasm';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/shell/supplemental-commands/shared.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isNodeRuntime: () => false,
+}));
+
+// `lib/browser.js` is CommonJS; its exports object is the `default` of the
+// interop namespace.
+vi.mock('esbuild-wasm', async () => {
+  const glue = await import('esbuild-wasm/lib/browser.js');
+  return (glue as { default?: typeof EsbuildNs }).default ?? glue;
+});
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PKG = resolve(HERE, '../../../../../node_modules/esbuild-wasm');
+const WEBAPP_PKG_JSON = resolve(HERE, '../../../package.json');
+
+/**
+ * The one location the loader reads (`tryLoadEsbuildWasmFromNodeModules`).
+ * Every `esbuild-wasm` release from 0.5.0 through the pinned version has
+ * shipped the binary here; a release that moves it fails the precondition
+ * below by name instead of surfacing as a mysterious "not installed".
+ */
+const WASM_RELATIVE_PATH = 'esbuild.wasm';
+
+const VFS_ROOT = '/workspace';
+const VFS_PKG = `${VFS_ROOT}/node_modules/esbuild-wasm`;
+
+describe('esbuild-wasm live round-trip (real installed package)', () => {
+  let esbuild: typeof EsbuildNs;
+  let installedVersion: string;
+
+  beforeAll(async () => {
+    // The in-thread (`worker: false`) service snapshots its globals off
+    // `self`, which every browser realm has and Node does not. Alias it so
+    // the glue sees the same host it sees inside the kernel worker.
+    vi.stubGlobal('self', globalThis);
+    expect(
+      existsSync(`${PKG}/${WASM_RELATIVE_PATH}`),
+      `no ${WASM_RELATIVE_PATH} under ${PKG} — esbuild-wasm changed its on-disk layout; ` +
+        'update tryLoadEsbuildWasmFromNodeModules in esbuild-wasm.ts to match'
+    ).toBe(true);
+
+    const wasm = new Uint8Array(readFileSync(`${PKG}/${WASM_RELATIVE_PATH}`));
+    const pkgJson = readFileSync(`${PKG}/package.json`, 'utf8');
+    installedVersion = (JSON.parse(pkgJson) as { version: string }).version;
+    // Mirror the real layout into the VFS the loader walks.
+    const present = new Set([`${VFS_PKG}/package.json`, `${VFS_PKG}/${WASM_RELATIVE_PATH}`]);
+    const ipk = {
+      fromDir: VFS_ROOT,
+      reader: {
+        exists: async (path: string) => present.has(path),
+        isDirectory: async (path: string) =>
+          [...present].some((file) => file.startsWith(`${path}/`)),
+        readFile: async (path: string) => {
+          if (path === `${VFS_PKG}/package.json`) return pkgJson;
+          throw new Error(`ENOENT: ${path}`);
+        },
+      },
+      readBytes: async (path: string) =>
+        path.endsWith('package.json') ? new TextEncoder().encode(pkgJson) : wasm,
+    };
+    const { getEsbuild } = await import('../../../src/shell/supplemental-commands/esbuild-wasm.js');
+    esbuild = await getEsbuild({ ipk });
+  }, 60_000);
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('advertises the installed version, which is the version the bootstrap hint pins', async () => {
+    const { ESBUILD_VERSION } = await import(
+      '../../../src/shell/supplemental-commands/esbuild-wasm.js'
+    );
+    // `ipk add esbuild-wasm@<ESBUILD_VERSION>` must name the same release the
+    // bundled glue came from, or the VFS install and the glue drift apart.
+    expect(ESBUILD_VERSION).toBe(installedVersion);
+    const webappPkg = JSON.parse(readFileSync(WEBAPP_PKG_JSON, 'utf8')) as {
+      dependencies: Record<string, string>;
+    };
+    expect(webappPkg.dependencies['esbuild-wasm']?.replace(/^[\^~]/, '')).toBe(ESBUILD_VERSION);
+  });
+
+  it('transforms TypeScript to JavaScript through the in-thread wasm service', async () => {
+    const result = await esbuild.transform('const answer: number = 42; export { answer };', {
+      loader: 'ts',
+      format: 'cjs',
+    });
+    // Type annotation stripped and the export lowered — a real transform, not
+    // a passthrough.
+    expect(result.code).toContain('const answer = 42');
+    expect(result.code).not.toContain(': number');
+    expect(result.code).toContain('exports');
+  });
+
+  it('bundles a virtual import graph through the plugin API', async () => {
+    const result = await esbuild.build({
+      stdin: { contents: 'import { leaf } from "virtual:leaf"; console.log(leaf);' },
+      bundle: true,
+      write: false,
+      format: 'esm',
+      plugins: [
+        {
+          name: 'virtual',
+          setup(build) {
+            build.onResolve({ filter: /^virtual:/ }, (args) => ({
+              path: args.path,
+              namespace: 'virtual',
+            }));
+            build.onLoad({ filter: /.*/, namespace: 'virtual' }, () => ({
+              contents: 'export const leaf = "LEAF_MARKER";',
+            }));
+          },
+        },
+      ],
+    });
+    expect(result.errors).toEqual([]);
+    const output = result.outputFiles?.[0]?.text ?? '';
+    // The import was resolved and inlined, not left for a runtime loader.
+    expect(output).toContain('LEAF_MARKER');
+    expect(output).not.toMatch(/from\s+["']virtual:leaf["']/);
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/esbuild-wasm.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/esbuild-wasm.test.ts
@@ -5,6 +5,7 @@ import {
   ESBUILD_VERSION,
   getEsbuild,
   resetEsbuildForTests,
+  tryLoadEsbuildWasmFromNodeModules,
 } from '../../../src/shell/supplemental-commands/esbuild-wasm.js';
 import { GLOBAL_IPK_ADD } from '../../../src/shell/supplemental-commands/shared.js';
 
@@ -48,5 +49,81 @@ describe('getEsbuild browser recovery guidance', () => {
         ` (searched from /workspace: /workspace/node_modules, /node_modules, ${GLOBAL_NODE_MODULES})`
     );
     expect((error as Error).message).not.toContain('ipx esbuild');
+  });
+});
+
+/**
+ * Resolution of the binary inside an ipk-installed package. The loader reads
+ * `esbuild.wasm` from exactly one place — the package root, where every
+ * release since 0.5.0 has shipped it — and answers `null` for every miss so
+ * `getEsbuild` can raise its "not installed" guidance. Mocked filesystem, so
+ * this pins the walk and the miss handling; `esbuild-wasm-live.test.ts` is
+ * what proves the hardcoded location still matches the real package.
+ */
+describe('tryLoadEsbuildWasmFromNodeModules', () => {
+  const PKG_DIR = '/workspace/node_modules/esbuild-wasm';
+  const WASM = new Uint8Array([0x00, 0x61, 0x73, 0x6d]);
+
+  function installedReader(files: string[]): ModuleReader {
+    const present = new Set(files);
+    return {
+      exists: async (p) => present.has(p) || [...present].some((f) => f.startsWith(`${p}/`)),
+      isDirectory: async (p) => [...present].some((f) => f.startsWith(`${p}/`)),
+      readFile: async (p) => {
+        if (p === `${PKG_DIR}/package.json`) {
+          return JSON.stringify({ name: 'esbuild-wasm', version: ESBUILD_VERSION });
+        }
+        throw new Error(`ENOENT: ${p}`);
+      },
+    };
+  }
+
+  it('walks up from a nested cwd and reads the binary beside package.json', async () => {
+    const readBytes = vi.fn(async () => WASM);
+    const binary = await tryLoadEsbuildWasmFromNodeModules({
+      reader: installedReader([`${PKG_DIR}/package.json`, `${PKG_DIR}/esbuild.wasm`]),
+      readBytes,
+      fromDir: '/workspace/src/deep',
+    });
+
+    expect(binary).toEqual({ packageDir: PKG_DIR, bytes: WASM });
+    expect(readBytes).toHaveBeenCalledWith(`${PKG_DIR}/esbuild.wasm`);
+  });
+
+  it('answers null when the package resolves but the binary is not where the loader looks', async () => {
+    // A release that moves the binary (the magick 0.0.43 shape) resolves the
+    // package fine and must still surface as "not installed", never as a
+    // read of a path that does not exist.
+    const readBytes = vi.fn(async () => WASM);
+    const binary = await tryLoadEsbuildWasmFromNodeModules({
+      reader: installedReader([`${PKG_DIR}/package.json`, `${PKG_DIR}/dist/esbuild.wasm`]),
+      readBytes,
+      fromDir: '/workspace',
+    });
+
+    expect(binary).toBeNull();
+    expect(readBytes).not.toHaveBeenCalled();
+  });
+
+  it('answers null when no esbuild-wasm is installed on the walk', async () => {
+    const binary = await tryLoadEsbuildWasmFromNodeModules({
+      reader: installedReader([]),
+      readBytes: async () => WASM,
+      fromDir: '/workspace',
+    });
+
+    expect(binary).toBeNull();
+  });
+
+  it('answers null when the binary exists but cannot be read', async () => {
+    const binary = await tryLoadEsbuildWasmFromNodeModules({
+      reader: installedReader([`${PKG_DIR}/package.json`, `${PKG_DIR}/esbuild.wasm`]),
+      readBytes: async () => {
+        throw new Error('EIO');
+      },
+      fromDir: '/workspace',
+    });
+
+    expect(binary).toBeNull();
   });
 });


### PR DESCRIPTION
Follow-up to the magick-wasm live canary (`c6d29ea`, the PR #2744 fallout), applying the same audit to `esbuild-wasm.ts`.

## Summary

Adds a live canary that runs a real esbuild transform and bundle through the **actually installed** `esbuild-wasm` package, plus unit coverage for the binary-resolution walk. The loader itself is unchanged apart from two `why` comments: the binary layout has never moved, and the namespace import measured as the right choice.

## Why

PR #2744 shipped a broken `convert` with a green unit suite because every magick test drove the loader over a synthetic file map and nothing exercised the real package. `esbuild-wasm.ts` has the same exposure: it reads `esbuild.wasm` from one hardcoded location and every test in the tree mocks either the filesystem or `esbuild-wasm` itself. A release that moves the binary, renames an export, or changes the ABI would make `esbuild` (and the realm's ESM `require()` transpile) report "not installed" while CI stays green.

## Approach / Implementation notes

**1. Binary layout: never moved, so no candidate list.** Checked the published layouts on unpkg: every `esbuild-wasm` release from 0.5.0 (the first with a wasm binary) through the pinned 0.28.2 (also `latest`) ships `esbuild.wasm` at the package root. Inventing candidates for layouts that never existed would be guesswork, so the loader keeps its single path and the canary is the guard.

**2. `import * as esbuild`: measured, left alone.**

| Build | worker eager graph | `esbuild-wasm-*.js` chunk |
| --- | ---: | ---: |
| baseline | 4 301 115 B | 70 585 B |
| named imports | 4 301 278 B | 70 748 B |
| delta | **+163 B** | +163 B |

Named imports save nothing and cost a wrapper object. Vite resolves `esbuild-wasm` through its `browser` field to `lib/browser.js`, which is **CommonJS**: the chunk carries it as one opaque rolldown interop closure that no import style can tree-shake, and the package ships a single service with no dual glue anyway. The header now records this so nobody "fixes" it by analogy with magick.

Hoisting `ESBUILD_VERSION` into a leaf module was assessed too: the kernel worker chunk imports the `getEsbuild` binding directly (the ESM transpiler factory `realm-host.ts` pulls in calls it), so the module is eager for a functional reason and the hoist would detach nothing. Not built.

**3. Canary design.** Two redirections, both pointing *at* the production path: `isNodeRuntime` is forced false so the loader takes the browser branch (`WebAssembly.Module` + `initialize({ wasmModule, worker: false })`), and `esbuild-wasm` is resolved to `lib/browser.js`, the exact file the kernel-worker bundle uses. Vitest's default resolution picks `lib/main.js`, whose Node service spawns a subprocess and rejects `wasmModule`/`worker` outright, so it cannot exercise the browser branch at all. The in-thread service snapshots globals off `self`, so the test aliases it to `globalThis` as a Worker realm would. Runs in ~1.5 s.

## Cross-cutting impact

- **Floats exercised**: none at runtime; source changes are comments only. The canary runs under vitest.
- **Bundle size**: no change (comments). Baseline and named-import numbers above.
- **Other callers**: `ESBUILD_VERSION` consumers (`builtin-shadow-map.ts`, `bsh-watchdog.ts`, `biome-command.ts`, `esbuild-command.ts`) untouched; the canary now pins that constant to the installed version and to the webapp `package.json` dependency so the `ipk add` bootstrap hint cannot drift from the bundled glue.

## Test plan

- [x] `npm run verify` — all 7 checks pass
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main` — nothing to gate
- [x] `npm run typecheck`
- [x] `npm run test` — see thread
- [x] `npm run test:coverage`
- [x] `npm run build` + `npm run build -w @slicc/chrome-extension` + `npm run bundle-size`
- [x] **Bite proof**: with the loader temporarily pointed at `dist/esbuild.wasm`, the canary fails with the production "esbuild-wasm is not installed" error and two resolver unit tests fail; restored, all nine pass.
- [x] New tests: `packages/webapp/tests/shell/supplemental-commands/esbuild-wasm-live.test.ts` (3), `esbuild-wasm.test.ts` (+4 for `tryLoadEsbuildWasmFromNodeModules`)

## Documentation

- [x] No documentation changes needed — behavior is unchanged; the rationale lives in the module header and the test file headers, matching `magick-wasm.ts`.

## Risk & rollback

Zero runtime blast radius: no executable source change. The canary reads ~10 MB from `node_modules` and compiles it once per run; if CI ever finds it too slow it can be gated like `esbuild-command.live.test.ts`, but it was kept ungated on purpose so a dependency bump cannot dodge it. Revert cleanly.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes: none
- [x] No cross-float contract change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
