### PR TITLE
test(webapp): wait for the iframe fixture to load instead of sleeping

### DIFF
--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -4062,10 +4062,19 @@ describeIntegration('iframe integration', { timeout: 90_000 }, () => {
     } catch {
       /* ignore */
     }
-    if (chromeProcess) {
+    if (chromeProcess && chromeProcess.exitCode === null && chromeProcess.signalCode === null) {
+      // Wait for the real exit (bounded) rather than a guessed 500 ms: the
+      // profile-dir rmSync below races a Chrome that is still tearing down.
+      const exited = new Promise<void>((resolve) => chromeProcess.once('exit', () => resolve()));
       chromeProcess.kill('SIGKILL');
-      // Wait a bit for process to exit
-      await new Promise((r) => setTimeout(r, 500));
+      let fallback: ReturnType<typeof setTimeout> | undefined;
+      await Promise.race([
+        exited,
+        new Promise<void>((resolve) => {
+          fallback = setTimeout(resolve, 5_000);
+        }),
+      ]);
+      clearTimeout(fallback);
     }
     server?.close();
     try {
@@ -4075,17 +4084,79 @@ describeIntegration('iframe integration', { timeout: 90_000 }, () => {
     }
   });
 
-  async function navigateAndWait(targetId: string, url: string): Promise<void> {
+  // `createPage()` returns as soon as `Target.createTarget` does: the new tab
+  // is still on its initial `about:blank` document and the fixture (plus its
+  // child iframe) loads in the background. A fixed sleep here was a guess at
+  // how long that takes, and on a contended CI runner (merge_group run
+  // 33633701671) the guess lost — the snapshot captured `Page URL: about:blank`
+  // and a green PR was dequeued. Poll for the DOM state the assertions below
+  // depend on instead, with a deadline that reports what was observed.
+  const FIXTURE_LOAD_TIMEOUT_MS = 30_000;
+  const FIXTURE_LOAD_POLL_MS = 50;
+  // Parent and child frame are same-origin, so the parent document can read
+  // the child's document directly. Note that an iframe's INITIAL about:blank
+  // document already reports `readyState === 'complete'`, so the probe checks
+  // the child's URL and a known element, not just its readyState.
+  const FIXTURE_READY_PROBE = `(() => {
+    const frameDoc = document.getElementById('child-frame')?.contentDocument ?? null;
+    return JSON.stringify({
+      href: location.href,
+      readyState: document.readyState,
+      frameHref: frameDoc ? frameDoc.location.href : null,
+      frameReadyState: frameDoc ? frameDoc.readyState : null,
+      frameHasButton: Boolean(frameDoc?.getElementById('frame-btn')),
+    });
+  })()`;
+
+  interface FixtureProbe {
+    href: string;
+    readyState: string;
+    frameHref: string | null;
+    frameReadyState: string | null;
+    frameHasButton: boolean;
+  }
+
+  function fixtureIsLoaded(probe: FixtureProbe): boolean {
+    return (
+      probe.href.endsWith('/main.html') &&
+      probe.readyState === 'complete' &&
+      (probe.frameHref?.endsWith('/frame.html') ?? false) &&
+      probe.frameReadyState === 'complete' &&
+      probe.frameHasButton
+    );
+  }
+
+  async function waitForFixtureLoaded(targetId: string): Promise<void> {
+    const deadline = Date.now() + FIXTURE_LOAD_TIMEOUT_MS;
+    let lastObserved = 'no probe result yet';
     await browser.withTab(targetId, async () => {
-      await browser.navigate(url);
-      // Wait for the page and iframes to load
-      await new Promise((r) => setTimeout(r, 1500));
+      while (Date.now() < deadline) {
+        try {
+          const raw = await browser.evaluate(FIXTURE_READY_PROBE);
+          lastObserved = String(raw);
+          if (fixtureIsLoaded(JSON.parse(lastObserved) as FixtureProbe)) return;
+        } catch (err) {
+          // The about:blank execution context is torn down when main.html
+          // commits; an evaluate that lands in that window throws. Keep polling.
+          lastObserved = `probe threw: ${err instanceof Error ? err.message : String(err)}`;
+        }
+        await new Promise((r) => setTimeout(r, FIXTURE_LOAD_POLL_MS));
+      }
+      throw new Error(
+        `iframe fixture did not finish loading within ${FIXTURE_LOAD_TIMEOUT_MS}ms ` +
+          `(last observed: ${lastObserved})`
+      );
     });
   }
 
-  it('snapshot includes iframe content with frame-prefixed refs', async () => {
+  async function openMainPage(): Promise<string> {
     const targetId = await browser.createPage(`http://127.0.0.1:${serverPort}/main.html`);
-    await new Promise((r) => setTimeout(r, 2000));
+    await waitForFixtureLoaded(targetId);
+    return targetId;
+  }
+
+  it('snapshot includes iframe content with frame-prefixed refs', async () => {
+    const targetId = await openMainPage();
     const cmd = createPlaywrightCommand(
       'playwright-cli',
       browser as BrowserAPI,
@@ -4104,8 +4175,7 @@ describeIntegration('iframe integration', { timeout: 90_000 }, () => {
   });
 
   it('snapshot --no-iframes shows placeholder only', async () => {
-    const targetId = await browser.createPage(`http://127.0.0.1:${serverPort}/main.html`);
-    await new Promise((r) => setTimeout(r, 2000));
+    const targetId = await openMainPage();
     const cmd = createPlaywrightCommand(
       'playwright-cli',
       browser as BrowserAPI,
@@ -4122,8 +4192,7 @@ describeIntegration('iframe integration', { timeout: 90_000 }, () => {
   });
 
   it('frames lists main and child frames', async () => {
-    const targetId = await browser.createPage(`http://127.0.0.1:${serverPort}/main.html`);
-    await new Promise((r) => setTimeout(r, 2000));
+    const targetId = await openMainPage();
     const cmd = createPlaywrightCommand(
       'playwright-cli',
       browser as BrowserAPI,
@@ -4138,8 +4207,7 @@ describeIntegration('iframe integration', { timeout: 90_000 }, () => {
   });
 
   it('eval --frame sees globals defined by the frame page', async () => {
-    const targetId = await browser.createPage(`http://127.0.0.1:${serverPort}/main.html`);
-    await new Promise((r) => setTimeout(r, 2000));
+    const targetId = await openMainPage();
     const cmd = createPlaywrightCommand(
       'playwright-cli',
       browser as BrowserAPI,
@@ -4159,8 +4227,7 @@ describeIntegration('iframe integration', { timeout: 90_000 }, () => {
   });
 
   it('click on iframe element works', async () => {
-    const targetId = await browser.createPage(`http://127.0.0.1:${serverPort}/main.html`);
-    await new Promise((r) => setTimeout(r, 2000));
+    const targetId = await openMainPage();
     const cmd = createPlaywrightCommand(
       'playwright-cli',
       browser as BrowserAPI,
@@ -4191,8 +4258,7 @@ describeIntegration('iframe integration', { timeout: 90_000 }, () => {
   });
 
   it('fill in iframe input works', async () => {
-    const targetId = await browser.createPage(`http://127.0.0.1:${serverPort}/main.html`);
-    await new Promise((r) => setTimeout(r, 2000));
+    const targetId = await openMainPage();
     const cmd = createPlaywrightCommand(
       'playwright-cli',
       browser as BrowserAPI,


### PR DESCRIPTION
Closes #2770.

## What

The `iframe integration` suite in `packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts` drives a real headless Chrome over CDP. All six tests did `createPage(main.html)` and then slept a fixed 2 s before running the command under test. `createPage()` returns as soon as `Target.createTarget` does, so the tab is still on `about:blank` and the fixture loads in the background. On a contended runner the 2 s guess lost: `merge_group` run 33633701671 captured `Page URL: about:blank`, failed one test of 18,666, and dequeued the otherwise green PR #2753.

This PR replaces the sleeps with a poll on the state the assertions actually need:

- main document is on `/main.html` and `readyState === 'complete'`
- child frame is on `/frame.html`, `complete`, and its `#frame-btn` exists (an iframe's initial `about:blank` document already reports `complete`, so URL + element are checked, not just readyState)

The probe runs from the parent document (same origin), polls every 50 ms with a 30 s deadline, tolerates the execution-context teardown that happens when `main.html` commits, and on timeout throws with the last observed state instead of leaving a bare `about:blank` assertion.

Also:

- the six duplicated `createPage + sleep` blocks collapse into one `openMainPage()` helper
- the never-called `navigateAndWait()` (1.5 s sleep) is deleted
- teardown waits for Chrome's real `exit` event (bounded at 5 s) instead of a guessed 500 ms before `rmSync` on the profile dir

Not done, deliberately: no constants raised, no skip, no quarantine, no retry wrapper.

## What was proved, and what was not

**Organic reproduction failed.** On this 16-core Mac I could not make the old code produce `about:blank` under load, in 74 runs across three load shapes (busy loops at 40 to 150, the test process at `nice 19`, 6 to 16 vitest instances in parallel each spawning its own Chrome). The suite is CI-only and the Linux runner starves Chrome differently. So the A/B under organic load is not, on its own, evidence that the fix changes anything.

**Deterministic reproduction succeeded.** Delaying the fixture server's `/main.html` response by 3 s (a scratch copy of the test, not committed) makes the OLD code fail all six tests with exactly the CI signature:

```
AssertionError: expected 'Page URL: about:blank\nPage Title: \n…' to contain 'Main Content'
```

With the fix applied to that same delayed copy, all six pass, each finishing at ~3.1 s, i.e. the wait tracks the real load time instead of a constant.

**Mutation test.** Making `fixtureIsLoaded()` return `true` unconditionally on the delayed copy brings back all six failures with the same `about:blank` signature, so the new wait is load-bearing rather than merely slower.

### A/B numbers (organic load, same three shapes for both arms)

| arm | runs | passed | `about:blank` | other failures |
| --- | ---: | ---: | ---: | --- |
| old code | 74 | 73 | 0 | 1 × `Chrome exited with code null before reporting CDP port` |
| new code | 74 | 71 | 0 | 3 × `Chrome exited with code null before reporting CDP port` |

The `Chrome exited` failures are the pre-existing, documented launch kill under memory pressure in `beforeAll` (see the comment above `chromeIntegrationEnabled`); the new-code arms happened to run concurrently with `npm run typecheck` and `npm run verify`, which added pressure. They are not the race this PR addresses and are unaffected by it.

Median duration of the first test dropped from ~2.3 s (sleep-bound) to ~1.5 s.

**Honest status:** the mechanism is confirmed (the failure is exactly "snapshot ran before `main.html` committed", and the poll provably waits for it), but the fix was not observed against a naturally occurring CI-runner stall. Treat it as a well-supported hypothesis until the merge queue has run it for a while.

## Verification

- `npm run verify` (7/7 incl. boy-scout debt gate)
- `npm run typecheck`
- `npm run test`, `npm run test:coverage`
- `npm run build`, `npm run build -w @slicc/chrome-extension`, `npm run bundle-size`
- `SLICC_TEST_CHROME_INTEGRATION=1 npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts -t 'iframe integration'`

Leaving for @trieloff to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
