### PR TITLE
refactor(webapp): resolve @ffmpeg/core through an explicit layout list and add a live canary

### DIFF
--- a/packages/webapp/src/shell/supplemental-commands/ffmpeg-wasm.ts
+++ b/packages/webapp/src/shell/supplemental-commands/ffmpeg-wasm.ts
@@ -49,7 +49,8 @@ export const FFMPEG_CORE_MT_PACKAGE = '@ffmpeg/core-mt';
 
 /**
  * Read-only VFS context the loader needs to read an ipk-installed
- * `@ffmpeg/core/dist/esm/{ffmpeg-core.js,ffmpeg-core.wasm}` pair.
+ * `@ffmpeg/core` glue + wasm pair (see {@link FFMPEG_CORE_LAYOUTS} for
+ * where inside the package they live).
  * Mirrors the {@link IpkResolutionContext} shape used by
  * `esbuild-wasm.ts` and `biome-command.ts` so every float
  * (standalone/hosted/extension/Node) wires the loader the same way.
@@ -83,6 +84,71 @@ export interface LoadedFfmpegCore {
 }
 
 const FFMPEG_CORE_PACKAGE = '@ffmpeg/core';
+
+/**
+ * Directories inside an ipk-installed core package that hold the
+ * `ffmpeg-core.{js,wasm}` pair (plus `ffmpeg-core.worker.js` for the -mt
+ * core), relative to the package root, newest layout first. The first
+ * layout whose required files all exist wins.
+ *
+ * Verified against the registry with `npm pack`, not assumed: every 0.12.x
+ * release from 0.12.0 through the pinned 0.12.10 ships the identical
+ * `dist/esm/` + `dist/umd/` pair, for `@ffmpeg/core` and `@ffmpeg/core-mt`
+ * alike. So there is exactly one supported layout today. The list exists
+ * so the next reorganisation is a one-line change here, with
+ * `ffmpeg-wasm-live.test.ts` (which resolves the REAL installed package)
+ * failing to say so — instead of the silent "not installed" that the
+ * magick 0.0.43 bump produced (PR #2744) while every filesystem-mocking
+ * test stayed green.
+ *
+ * Two layouts that HAVE shipped are deliberately not candidates:
+ *
+ * - `dist/umd/` (0.12.x, the package's `main`). The `@ffmpeg/ffmpeg`
+ *   wrapper always spawns a module worker, whose `importScripts` throws, so
+ *   it loads the glue with `(await import(coreURL)).default`. The UMD build
+ *   has no default export (it assigns `module.exports` / `define`), so the
+ *   wrapper would throw its import-failure error from inside the worker —
+ *   worse than the clean install guidance the caller surfaces on `null`.
+ * - flat `dist/` (0.11.x and earlier: `dist/ffmpeg-core.{js,wasm,worker.js}`).
+ *   That core speaks the pre-0.12 `createFFmpeg` protocol and cannot be
+ *   driven by the bundled 0.12 wrapper at all; an `ipk add @ffmpeg/core@0.11`
+ *   is a version mismatch, not a layout the loader should paper over.
+ */
+const FFMPEG_CORE_LAYOUTS = ['dist/esm'] as const;
+
+/** Absolute VFS paths of one core install's files, resolved against one layout. */
+interface FfmpegCoreFiles {
+  core: string;
+  wasm: string;
+  /** Pthread worker — required for (and only present with) the -mt core. */
+  worker: string | null;
+}
+
+/**
+ * First layout under `pkgDir` whose glue + wasm (+ pthread worker for the
+ * -mt core) all exist, or null when none does — a partial/pruned install
+ * or a layout this loader does not know. The -mt core is unusable without
+ * its worker, so a layout missing it is a miss rather than a broken boot.
+ */
+async function findFfmpegCoreFiles(
+  pkgDir: string,
+  pkg: LoadedFfmpegCore['pkg'],
+  reader: ModuleReader
+): Promise<FfmpegCoreFiles | null> {
+  for (const layout of FFMPEG_CORE_LAYOUTS) {
+    const dir = `${pkgDir}/${layout}`;
+    const files: FfmpegCoreFiles = {
+      core: `${dir}/ffmpeg-core.js`,
+      wasm: `${dir}/ffmpeg-core.wasm`,
+      worker: pkg === FFMPEG_CORE_MT_PACKAGE ? `${dir}/ffmpeg-core.worker.js` : null,
+    };
+    if (!(await reader.exists(files.core))) continue;
+    if (!(await reader.exists(files.wasm))) continue;
+    if (files.worker && !(await reader.exists(files.worker))) continue;
+    return files;
+  }
+  return null;
+}
 
 let ffmpegPromise: Promise<FFmpeg> | null = null;
 
@@ -165,12 +231,13 @@ async function loadFfmpeg(
 }
 
 /**
- * Try to read `@ffmpeg/core`'s `dist/esm/ffmpeg-core.{js,wasm}` from
- * an ipk-installed `@ffmpeg/core` in the VFS. Resolves
+ * Try to read `@ffmpeg/core`'s `ffmpeg-core.{js,wasm}` from an
+ * ipk-installed `@ffmpeg/core` in the VFS. Resolves
  * `@ffmpeg/core/package.json` through the shared resolver (so the
  * standard `node_modules` walk and resolution rules apply), derives
- * the package directory from the resolved file, and reads the
- * sibling JS source + wasm bytes. Returns `null` on any resolution
+ * the package directory from the resolved file, locates the glue + wasm
+ * in a supported layout (see `FFMPEG_CORE_LAYOUTS`), and reads the JS
+ * source + wasm bytes. Returns `null` on any resolution
  * / read miss so the caller surfaces the canonical guidance error.
  * Exported so the loader's resolution behavior is unit-testable
  * without booting the heavy wasm runtime.
@@ -194,20 +261,12 @@ export async function tryLoadFfmpegCoreFromNodeModules(
     return null;
   }
   if (resolved.type !== 'file') return null;
-  const pkgDir = splitPath(resolved.path).dir;
-  const corePath = `${pkgDir}/dist/esm/ffmpeg-core.js`;
-  const wasmPath = `${pkgDir}/dist/esm/ffmpeg-core.wasm`;
-  // The -mt core is unusable without its pthread worker — treat a missing
-  // worker file as not-installed rather than booting a broken core.
-  const workerPath =
-    pkg === FFMPEG_CORE_MT_PACKAGE ? `${pkgDir}/dist/esm/ffmpeg-core.worker.js` : null;
-  if (!(await ipk.reader.exists(corePath))) return null;
-  if (!(await ipk.reader.exists(wasmPath))) return null;
-  if (workerPath && !(await ipk.reader.exists(workerPath))) return null;
+  const files = await findFfmpegCoreFiles(splitPath(resolved.path).dir, pkg, ipk.reader);
+  if (!files) return null;
   try {
-    const coreSource = await ipk.reader.readFile(corePath);
-    const wasmBytes = await ipk.readBytes(wasmPath);
-    const workerSource = workerPath ? await ipk.reader.readFile(workerPath) : undefined;
+    const coreSource = await ipk.reader.readFile(files.core);
+    const wasmBytes = await ipk.readBytes(files.wasm);
+    const workerSource = files.worker ? await ipk.reader.readFile(files.worker) : undefined;
     return { pkg, coreSource, wasmBytes, ...(workerSource !== undefined ? { workerSource } : {}) };
   } catch {
     return null;

--- a/packages/webapp/tests/shell/supplemental-commands/ffmpeg-wasm-layouts.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/ffmpeg-wasm-layouts.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Resolution rules of the `@ffmpeg/core` loader over synthetic installs:
+ * which package layouts it accepts and which misses come back `null` (so the
+ * command surfaces the install guidance instead of booting a broken core).
+ * Everything here is a file map; the check against the REAL installed
+ * package is `ffmpeg-wasm-live.test.ts`.
+ */
+import { posix } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  type IpkResolutionContext,
+  tryLoadFfmpegCoreFromNodeModules,
+} from '../../../src/shell/supplemental-commands/ffmpeg-wasm.js';
+
+const ROOT = '/workspace';
+const WASM = new Uint8Array([0x00, 0x61, 0x73, 0x6d]);
+const GLUE = '/* glue */ export default function () {}';
+const WORKER = '/* pthread worker */';
+
+/**
+ * ipk context over one synthetic install of `pkg`. `files` are paths
+ * relative to the package root, so a test states the layout it is probing
+ * verbatim (`dist/esm/ffmpeg-core.js`) rather than through a helper that
+ * already assumes one.
+ */
+function installed(
+  pkg: string,
+  files: Record<string, string | Uint8Array>,
+  opts: { readBytesFails?: boolean } = {}
+): IpkResolutionContext {
+  const pkgDir = `${ROOT}/node_modules/${pkg}`;
+  const entries = new Map<string, string | Uint8Array>([
+    [`${pkgDir}/package.json`, JSON.stringify({ name: pkg, version: '0.12.10' })],
+  ]);
+  for (const [rel, content] of Object.entries(files)) entries.set(`${pkgDir}/${rel}`, content);
+  const dirs = new Set<string>();
+  for (const path of entries.keys()) {
+    for (let dir = posix.dirname(path); dir !== '/' && !dirs.has(dir); dir = posix.dirname(dir)) {
+      dirs.add(dir);
+    }
+  }
+  return {
+    fromDir: ROOT,
+    reader: {
+      exists: async (path) => entries.has(path) || dirs.has(path),
+      isDirectory: async (path) => dirs.has(path),
+      readFile: async (path) => {
+        const value = entries.get(path);
+        if (typeof value !== 'string') throw new Error(`ENOENT: ${path}`);
+        return value;
+      },
+    },
+    readBytes: async (path) => {
+      const value = entries.get(path);
+      if (opts.readBytesFails || !(value instanceof Uint8Array)) throw new Error(`EIO: ${path}`);
+      return value;
+    },
+  };
+}
+
+describe('tryLoadFfmpegCoreFromNodeModules layouts', () => {
+  it('resolves the dist/esm layout every 0.12.x release ships', async () => {
+    const loaded = await tryLoadFfmpegCoreFromNodeModules(
+      installed('@ffmpeg/core', {
+        'dist/esm/ffmpeg-core.js': GLUE,
+        'dist/esm/ffmpeg-core.wasm': WASM,
+        'dist/umd/ffmpeg-core.js': '/* umd */',
+        'dist/umd/ffmpeg-core.wasm': WASM,
+      }),
+      '@ffmpeg/core'
+    );
+    expect(loaded).toEqual({ pkg: '@ffmpeg/core', coreSource: GLUE, wasmBytes: WASM });
+  });
+
+  it('resolves the -mt core when its pthread worker sits in the same layout', async () => {
+    const loaded = await tryLoadFfmpegCoreFromNodeModules(
+      installed('@ffmpeg/core-mt', {
+        'dist/esm/ffmpeg-core.js': GLUE,
+        'dist/esm/ffmpeg-core.wasm': WASM,
+        'dist/esm/ffmpeg-core.worker.js': WORKER,
+      }),
+      '@ffmpeg/core-mt'
+    );
+    expect(loaded?.pkg).toBe('@ffmpeg/core-mt');
+    expect(loaded?.workerSource).toBe(WORKER);
+  });
+
+  it('treats an -mt layout without its pthread worker as a miss', async () => {
+    const loaded = await tryLoadFfmpegCoreFromNodeModules(
+      installed('@ffmpeg/core-mt', {
+        'dist/esm/ffmpeg-core.js': GLUE,
+        'dist/esm/ffmpeg-core.wasm': WASM,
+      }),
+      '@ffmpeg/core-mt'
+    );
+    expect(loaded).toBeNull();
+  });
+
+  // The UMD build is a real shipped layout (the package's `main`), excluded
+  // on purpose: the wrapper's module worker `import()`s the glue and needs a
+  // default export, which UMD has none of.
+  it('does not fall back to dist/umd when dist/esm is absent', async () => {
+    const loaded = await tryLoadFfmpegCoreFromNodeModules(
+      installed('@ffmpeg/core', {
+        'dist/umd/ffmpeg-core.js': '/* umd */',
+        'dist/umd/ffmpeg-core.wasm': WASM,
+      }),
+      '@ffmpeg/core'
+    );
+    expect(loaded).toBeNull();
+  });
+
+  // The flat layout is what 0.11.x and earlier shipped; those cores speak
+  // the pre-0.12 protocol the bundled wrapper cannot drive.
+  it('does not accept the flat dist/ layout of 0.11.x cores', async () => {
+    const loaded = await tryLoadFfmpegCoreFromNodeModules(
+      installed('@ffmpeg/core', {
+        'dist/ffmpeg-core.js': GLUE,
+        'dist/ffmpeg-core.wasm': WASM,
+        'dist/ffmpeg-core.worker.js': WORKER,
+      }),
+      '@ffmpeg/core'
+    );
+    expect(loaded).toBeNull();
+  });
+
+  it('returns null when the layout has the glue but not the wasm, or vice versa', async () => {
+    const glueOnly = await tryLoadFfmpegCoreFromNodeModules(
+      installed('@ffmpeg/core', { 'dist/esm/ffmpeg-core.js': GLUE }),
+      '@ffmpeg/core'
+    );
+    const wasmOnly = await tryLoadFfmpegCoreFromNodeModules(
+      installed('@ffmpeg/core', { 'dist/esm/ffmpeg-core.wasm': WASM }),
+      '@ffmpeg/core'
+    );
+    expect(glueOnly).toBeNull();
+    expect(wasmOnly).toBeNull();
+  });
+
+  it('returns null when the files exist but the wasm bytes cannot be read', async () => {
+    const loaded = await tryLoadFfmpegCoreFromNodeModules(
+      installed(
+        '@ffmpeg/core',
+        { 'dist/esm/ffmpeg-core.js': GLUE, 'dist/esm/ffmpeg-core.wasm': WASM },
+        { readBytesFails: true }
+      ),
+      '@ffmpeg/core'
+    );
+    expect(loaded).toBeNull();
+  });
+});

--- a/packages/webapp/tests/shell/supplemental-commands/ffmpeg-wasm-live.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/ffmpeg-wasm-live.test.ts
@@ -22,8 +22,8 @@
  * fakes. `@ffmpeg/core-mt` is not covered either: it is not a devDependency,
  * and its pthread pool needs real workers too.
  *
- * Cost is ~100 ms: Node compiles the 31 MB wasm lazily and the encode is a
- * 10 ms silent clip.
+ * Cost is ~1 s under vitest (~100 ms in bare Node): the 31 MB wasm is read
+ * once and compiled lazily, and the encode is a 10 ms silent clip.
  */
 import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, posix, resolve } from 'node:path';

--- a/packages/webapp/tests/shell/supplemental-commands/ffmpeg-wasm-live.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/ffmpeg-wasm-live.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Live canary for the ipk-installed `@ffmpeg/core` the `ffmpeg` command boots.
+ *
+ * Every other ffmpeg test drives the loader over a synthetic file map, so
+ * they all keep passing when the real package changes shape underneath us —
+ * exactly how the magick 0.0.43 bump (PR #2744) shipped a broken `convert`
+ * behind a green unit suite. This test walks the REAL installed
+ * `node_modules/@ffmpeg/core`, mirrors whatever files it actually contains
+ * into a VFS `ipk` context (nothing here hardcodes `dist/esm`), runs the
+ * loader's real resolution over it, then boots the glue + wasm the loader
+ * handed back and runs a real encode through them.
+ *
+ * What it covers: the package's on-disk layout against `FFMPEG_CORE_LAYOUTS`,
+ * the ESM glue's default export the wrapper worker relies on, the glue/wasm
+ * pairing (a real `-f lavfi` → WAV encode plus `-version`), and the core API
+ * surface `@ffmpeg/ffmpeg`'s worker calls (`exec`, `ffprobe`, `setLogger`,
+ * `setProgress`, `setTimeout`, `reset`, `FS`, `ret`).
+ *
+ * What it does NOT cover: the `@ffmpeg/ffmpeg` wrapper itself. It needs a
+ * real `Worker`, which Node lacks, so `getFfmpeg` (blob-URL materialization,
+ * postMessage plumbing) is not on this path and stays unit-tested with
+ * fakes. `@ffmpeg/core-mt` is not covered either: it is not a devDependency,
+ * and its pthread pool needs real workers too.
+ *
+ * Cost is ~100 ms: Node compiles the 31 MB wasm lazily and the encode is a
+ * 10 ms silent clip.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, posix, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  BUNDLED_FFMPEG_CORE_VERSION,
+  type IpkResolutionContext,
+  type LoadedFfmpegCore,
+  selectFfmpegCore,
+} from '../../../src/shell/supplemental-commands/ffmpeg-wasm.js';
+
+const PKG_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../../node_modules/@ffmpeg/core'
+);
+
+const VFS_ROOT = '/workspace';
+const VFS_PKG = `${VFS_ROOT}/node_modules/@ffmpeg/core`;
+
+/** The slice of the emscripten `Module` that `@ffmpeg/ffmpeg`'s worker drives. */
+interface FfmpegCore {
+  exec(...args: string[]): number;
+  ffprobe(...args: string[]): number;
+  setLogger(logger: (log: { type: string; message: string }) => void): void;
+  setProgress(handler: (progress: { progress: number; time: number }) => void): void;
+  setTimeout(timeout: number): void;
+  reset(): void;
+  ret: number;
+  FS: {
+    writeFile(path: string, data: Uint8Array): void;
+    readFile(path: string): Uint8Array;
+    unlink(path: string): void;
+  };
+}
+
+/** Every file under `dir` as a path relative to it, e.g. `dist/esm/ffmpeg-core.js`. */
+function walk(dir: string, prefix = ''): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) =>
+    entry.isDirectory()
+      ? walk(join(dir, entry.name), `${prefix}${entry.name}/`)
+      : [`${prefix}${entry.name}`]
+  );
+}
+
+/**
+ * Mirror the real install into the VFS the loader walks, file for file. The
+ * file list comes from the disk, not from this test, so a package that moves
+ * its assets is reflected faithfully and the loader is the only thing left
+ * that can be wrong about where they are.
+ */
+function mirrorInstalledPackage(): { ipk: IpkResolutionContext; files: string[] } {
+  const files = walk(PKG_DIR);
+  const vfsFiles = new Set(files.map((file) => `${VFS_PKG}/${file}`));
+  const dirs = new Set([VFS_ROOT, `${VFS_ROOT}/node_modules`, `${VFS_ROOT}/node_modules/@ffmpeg`]);
+  for (const file of vfsFiles) {
+    for (let dir = posix.dirname(file); !dirs.has(dir); dir = posix.dirname(dir)) dirs.add(dir);
+  }
+  const onDisk = (vfsPath: string) => join(PKG_DIR, vfsPath.slice(VFS_PKG.length + 1));
+  const mustExist = (vfsPath: string) => {
+    if (!vfsFiles.has(vfsPath)) throw new Error(`ENOENT: ${vfsPath}`);
+  };
+  return {
+    files,
+    ipk: {
+      fromDir: VFS_ROOT,
+      reader: {
+        exists: async (path) => vfsFiles.has(path) || dirs.has(path),
+        isDirectory: async (path) => dirs.has(path),
+        readFile: async (path) => {
+          mustExist(path);
+          return readFileSync(onDisk(path), 'utf8');
+        },
+      },
+      readBytes: async (path) => {
+        mustExist(path);
+        return new Uint8Array(readFileSync(onDisk(path)));
+      },
+    },
+  };
+}
+
+describe('ffmpeg-core live boot (real installed package)', () => {
+  let loaded: LoadedFfmpegCore;
+  let core: FfmpegCore;
+  const logs: { type: string; message: string }[] = [];
+
+  beforeAll(async () => {
+    const { ipk, files } = mirrorInstalledPackage();
+    const resolved = await selectFfmpegCore(ipk, false);
+    expect(
+      resolved,
+      `the loader found no usable @ffmpeg/core in the installed package; it contains ` +
+        `[${files.join(', ')}] — the package changed shape; update FFMPEG_CORE_LAYOUTS in ` +
+        `ffmpeg-wasm.ts to match`
+    ).not.toBeNull();
+    loaded = resolved as LoadedFfmpegCore;
+
+    // The glue is compiled for `ENVIRONMENT=worker` only: at import it reads
+    // `self.location.href` for its script directory. Give it a `self` that
+    // falls through to Node's globals and carries a location; `wasmBinary`
+    // below keeps it from ever fetching against that location.
+    const workerSelf: { location: { href: string } } = Object.create(globalThis);
+    workerSelf.location = { href: 'blob:ffmpeg-wasm-live' };
+    vi.stubGlobal('self', workerSelf);
+
+    // The loader hands the wrapper a `blob:` URL of `coreSource`. Node cannot
+    // import `blob:` but does import `data:`, which is the same idea — the
+    // module text the loader produced, not a path back into node_modules — so
+    // this is the exact source the wrapper worker would `import()`.
+    const glueUrl = `data:text/javascript;base64,${Buffer.from(loaded.coreSource).toString('base64')}`;
+    const glue = (await import(/* @vite-ignore */ glueUrl)) as {
+      default?: (options: { wasmBinary: Uint8Array }) => Promise<FfmpegCore>;
+    };
+    // Exactly what `@ffmpeg/ffmpeg/dist/esm/worker.js` does after `import()`;
+    // a UMD-shaped glue fails here, not deep inside the worker.
+    expect(typeof glue.default, 'ffmpeg-core.js has no default export').toBe('function');
+    core = await (glue.default as NonNullable<typeof glue.default>)({
+      wasmBinary: loaded.wasmBytes,
+    });
+    core.setLogger((log) => logs.push(log));
+  }, 60_000);
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('resolves the single-threaded core at the version the install guidance pins', async () => {
+    expect(loaded.pkg).toBe('@ffmpeg/core');
+    expect(loaded.workerSource).toBeUndefined();
+    const manifest = JSON.parse(readFileSync(join(PKG_DIR, 'package.json'), 'utf8')) as {
+      version: string;
+    };
+    expect(manifest.version).toBe(BUNDLED_FFMPEG_CORE_VERSION);
+  });
+
+  it('runs a real encode through the real wasm', () => {
+    logs.length = 0;
+    const versionRet = core.exec('-version');
+    expect(versionRet).toBe(0);
+    expect(logs[0]?.message).toMatch(/^ffmpeg version /);
+
+    // No input file: lavfi synthesizes 10 ms of silence, the muxer writes a
+    // WAV into the emscripten FS. That exercises the demuxer/encoder/muxer
+    // pipeline and the FS the wrapper's `readFile` reads results from.
+    core.reset();
+    const encodeRet = core.exec(
+      '-f',
+      'lavfi',
+      '-i',
+      'anullsrc=r=8000:cl=mono',
+      '-t',
+      '0.01',
+      '-f',
+      'wav',
+      'out.wav'
+    );
+    expect(encodeRet).toBe(0);
+    const wav = core.FS.readFile('out.wav');
+    core.FS.unlink('out.wav');
+    const ascii = (offset: number) => String.fromCharCode(...wav.subarray(offset, offset + 4));
+    expect(ascii(0)).toBe('RIFF');
+    expect(ascii(8)).toBe('WAVE');
+  });
+
+  it('exposes the core API surface the @ffmpeg/ffmpeg worker calls', () => {
+    for (const member of ['exec', 'ffprobe', 'setLogger', 'setProgress', 'setTimeout', 'reset']) {
+      expect(typeof core[member as keyof FfmpegCore], `core.${member} is not a function`).toBe(
+        'function'
+      );
+    }
+    for (const member of ['writeFile', 'readFile', 'unlink']) {
+      expect(typeof core.FS[member as keyof FfmpegCore['FS']], `core.FS.${member}`).toBe(
+        'function'
+      );
+    }
+    // The worker reads `ret` after every exec and clears it with `reset`.
+    core.reset();
+    expect(core.ret).toBe(-1);
+  });
+});


### PR DESCRIPTION
Follow-up to #2744 (magick 0.0.43 layout break + `magick-wasm-live.test.ts`), applying the same pattern to `ffmpeg-wasm.ts`.

## Summary

`ffmpeg-wasm.ts` hardcoded where `@ffmpeg/core` keeps `ffmpeg-core.{js,wasm}` inside the package. The location is now an explicit, commented layout list (`FFMPEG_CORE_LAYOUTS`, one entry today, exclusions spelled out), and a live canary test boots the REAL installed package so a dependency that changes shape, exports, or ABI fails a test instead of shipping a silent "not installed".

## Why

Same exposure as #2744: every existing ffmpeg test drives the loader over a synthetic file map, so a reorganised `dist/` would keep the whole suite green while `ffmpeg` reports `@ffmpeg/core is not installed`.

**Facts first**, checked with `npm pack` against the registry rather than assumed:

| Versions | Layout | Usable with the bundled `@ffmpeg/ffmpeg` 0.12.15? |
| --- | --- | --- |
| 0.12.0 … 0.12.10 (pinned) | `dist/esm/` + `dist/umd/`; `@ffmpeg/core-mt` identical plus `ffmpeg-core.worker.js` | `dist/esm/` yes. `dist/umd/` no: the wrapper always spawns a module worker, `importScripts` throws, it falls back to `(await import(coreURL)).default`, and the UMD build has no default export |
| ≤ 0.11.x | flat `dist/ffmpeg-core.{js,wasm,worker.js}` | No: pre-0.12 `createFFmpeg` protocol. A version mismatch, not a layout to paper over |

So the layout moved exactly once (0.11 → 0.12) and has been identical across every 0.12.x release. There is one supported layout; the list exists so the next move is a one-line edit with the canary saying where. No evidence-free candidates were added.

## Approach / Implementation notes

- `FFMPEG_CORE_LAYOUTS` + a private `findFfmpegCoreFiles(pkgDir, pkg, reader)`; `tryLoadFfmpegCoreFromNodeModules` now resolves through it. Loader caching, `selectFfmpegCore`, the command surface and `ffmpeg-command.ts` are untouched.
- The canary cannot go through `getFfmpeg`: the `@ffmpeg/ffmpeg` wrapper needs a real `Worker`, which Node lacks. It goes one level down instead: real `selectFfmpegCore` over a file-for-file mirror of the installed package (the file list comes from disk, nothing in the test hardcodes `dist/esm`), then boots the returned glue + wasm exactly the way the wrapper worker does (`import()` → `.default` → `createFFmpegCore({ wasmBinary })`) and runs `-version` plus a real `-f lavfi` → WAV encode. The glue is compiled worker-only, so the test stubs `self` with a `location`; the source is imported via a `data:` URL, Node's analogue of the loader's `blob:` URL.
- Stated in the file header: not covered are the wrapper's blob-URL/postMessage plumbing (unit-tested with fakes) and `@ffmpeg/core-mt` (not a devDependency; pthreads need real workers).

## Cross-cutting impact

- **Floats exercised**: none at runtime. Behavior for a correctly installed 0.12.x core is byte-identical; only a partial install or unknown layout still returns `null` as before.
- **Other callers**: `ffmpeg-command.ts`'s `-version` gate and `selectFfmpegCore` call the same exported function with the same contract.
- **Bundle size**: no new imports on the kernel-worker eager path.

## Test plan

- [x] `npm run verify` — 7/7 checks passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs origin/main`
- [x] `npm run typecheck`
- [x] `npm run test` — full suite 18691 tests; every failure in the saturated run was a load timeout in an unrelated file (see below)
- [x] `npm run test:coverage:webapp -- --maxWorkers=8` — 14944 passed, 0 failed; statements 82.64 (floor 82), lines 84.65 (floor 84)
- [x] `npm run build` and `npm run build -w @slicc/chrome-extension`, then `npm run bundle-size`
- [x] New behavior covered: `tests/shell/supplemental-commands/ffmpeg-wasm-layouts.test.ts` (7 resolution cases: `dist/esm` hit for both cores, -mt worker requirement, `null` for `dist/umd`-only, flat 0.11 layout, glue-without-wasm and wasm-without-glue, failing `readBytes`) and `ffmpeg-wasm-live.test.ts` (3 tests, ~1 s).
- [x] **Proof the guards bite** (each mutation reverted afterwards):
  1. Source pointed at a wrong layout (`dist/es`): 2 resolution tests + the canary fail.
  2. Real package moved on disk (`dist/esm` → `dist/esm-next`), source untouched: all 64 existing mocked ffmpeg tests stay green, only the canary fails, listing the files it actually found and pointing at `FFMPEG_CORE_LAYOUTS`. That is the #2744 scenario, caught.
- [x] N/A — no UI change, no manual smoke needed (no runtime behavior change for a healthy install)

**Pre-existing failures** (load-induced, unrelated to this PR): the dev box was shared with several other sessions' vitest/build jobs (load average 200–430). Under that load 14 unrelated files timed out (`Test timed out in 5000ms` / `Hook timed out`, e.g. the Pyodide load in `slicc-fs-module.test.ts`, `git init` in `check-swift-resolved-drift.test.mjs`, the 1 s race in `wc-sprinkles.test.ts`). Every one of them passed when re-run once load fell; the failing set shrank monotonically with load (16 → 5 → 3 → 2 → 0). The uncapped coverage run alone pushes this many-core box past load 150, hence the `--maxWorkers=8` run above, which is faster and clean.

## Documentation

- [x] No documentation changes needed — no doc outside `ffmpeg-wasm.ts` records the layout; the source comments carry the evidence and exclusions.

## Risk & rollback

Blast radius is the `ffmpeg` command's not-installed path only. Clean revert. The canary adds a ~32 MB wasm read to the webapp unit run (~1 s), no network.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs (none)
- [x] No cross-float contract changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
