### PR TITLE
fix(webapp): skip noise dirs by default in MountIndex

### DIFF
--- a/docs/mounts.md
+++ b/docs/mounts.md
@@ -265,10 +265,13 @@ The cache holds handles, not data: Chrome re-resolves a handle against the live 
 
 Each mount is indexed in the background so file discovery (`.jsh` / `.bsh` / skills) and listings are fast once ready. The walk is bounded so a pathologically deep, huge, or self-referential mount can't peg or OOM the kernel worker. When a bound is hit the index is **skipped** for that mount — reads still work through the slow per-`readDir` fallback, just without the fast index.
 
+By default the index also **skips noise directories** — `node_modules`, `dist`, `build`, `coverage`, and any dot-directory (`.git`, `.build`, `.venv`, …) — sharing the same `shouldSkipNoiseDir` / `DEFAULT_SKIP_DIRS` list as sprinkle discovery (`bounded-walk.ts`). Skipped subtrees are omitted from the index entirely; an absolute-path listing of a skipped directory falls through to the slow backend path rather than appearing empty. Pass `skipNoiseDirs: false` on `MountIndexLimits` when a caller genuinely needs every path indexed.
+
 Defaults (raised 10× in #1186):
 
 - Max directory depth: **400**
 - Max total entries: **2,000,000**
+- Skip noise directories: **yes**
 
 Two environment variables override the defaults. Each must parse to a positive integer; a non-numeric, zero, negative, or `NaN` value is ignored — the default is used and a warning is logged.
 
@@ -279,7 +282,7 @@ Two environment variables override the defaults. Each must parse to a positive i
 
 (The worker / browser float has no OS env, so the defaults always apply there; the overrides are read once at construction in CLI / Electron mode.)
 
-**Boot-time session restore uses a smaller budget** (`RESTORED_MOUNT_INDEX_LIMITS`: depth 100, 100,000 entries). The interactive defaults suit a folder the user just picked and is waiting on; at boot the same budget let a huge or cloud-backed tree (an iCloud folder full of dataless files) grind the kernel worker's I/O for minutes while the kernel-ready watchdog ran (2026-08-24 incident). A restored mount that hits the bound stays fully usable — only the fast-discovery index is truncated (`entries-exceeded`), and re-mounting interactively re-indexes with the full budget.
+**Boot-time session restore uses a smaller budget** (`RESTORED_MOUNT_INDEX_LIMITS`: depth 100, 100,000 entries, noise dirs still skipped). The interactive defaults suit a folder the user just picked and is waiting on; at boot the same budget let a huge or cloud-backed tree (an iCloud folder full of dataless files) grind the kernel worker's I/O for minutes while the kernel-ready watchdog ran (2026-08-24 incident). A restored mount that hits the bound stays fully usable — only the fast-discovery index is truncated (`entries-exceeded`), and re-mounting interactively re-indexes with the full budget.
 
 `mount list` renders a distinct, actionable line per skip cause:
 

--- a/packages/webapp/src/fs/bounded-walk.ts
+++ b/packages/webapp/src/fs/bounded-walk.ts
@@ -20,6 +20,22 @@
 import type { DirEntry, EntryType } from './types.js';
 import { MAX_WALK_DEPTH, MAX_WALK_ENTRIES } from './walker.js';
 
+/**
+ * Directory basenames never entered by default discovery walks (sprinkle
+ * scan, MountIndex). Dot-directories (`.git`, `.build`, `.venv`, …) are
+ * skipped separately via {@link shouldSkipNoiseDir}. Shared so callers do
+ * not grow a third copy of the same list (issue #2764 / #2717).
+ */
+export const DEFAULT_SKIP_DIRS = new Set(['node_modules', 'dist', 'build', 'coverage']);
+
+/**
+ * True for build-output directory names and any dot-directory. Used as the
+ * default `skip` predicate for bounded walks and MountIndex ingestion.
+ */
+export function shouldSkipNoiseDir(name: string): boolean {
+  return name.startsWith('.') || DEFAULT_SKIP_DIRS.has(name);
+}
+
 /** Minimal read surface the bounded walker needs. */
 export interface BoundedWalkReader {
   readDir(path: string): Promise<DirEntry[]>;

--- a/packages/webapp/src/fs/mount-index.ts
+++ b/packages/webapp/src/fs/mount-index.ts
@@ -17,6 +17,7 @@
  */
 
 import { createLogger } from '../base/logger.js';
+import { shouldSkipNoiseDir } from './bounded-walk.js';
 
 const log = createLogger('mount-index');
 
@@ -116,6 +117,13 @@ async function isSameEntrySafe(
 export interface MountIndexLimits {
   maxDepth: number;
   maxEntries: number;
+  /**
+   * When true (the default), skip `node_modules` / `dist` / `build` /
+   * `coverage` and any dot-directory (`.git`, `.build`, …) while indexing —
+   * the same list sprinkle discovery uses via {@link shouldSkipNoiseDir}.
+   * Set `false` when a caller genuinely needs every path indexed.
+   */
+  skipNoiseDirs: boolean;
 }
 
 /**
@@ -132,6 +140,7 @@ export interface MountIndexLimits {
 export const RESTORED_MOUNT_INDEX_LIMITS: MountIndexLimits = {
   maxDepth: 100,
   maxEntries: 100_000,
+  skipNoiseDirs: true,
 };
 
 /**
@@ -183,6 +192,7 @@ export function resolveMountIndexLimits(env: MountIndexEnv): MountIndexLimits {
   return {
     maxDepth: resolveLimit(env, ENV_MAX_DEPTH, MAX_INDEX_DEPTH),
     maxEntries: resolveLimit(env, ENV_MAX_ENTRIES, MAX_INDEX_ENTRIES),
+    skipNoiseDirs: true,
   };
 }
 
@@ -380,9 +390,15 @@ export class MountIndex {
     }
 
     const children = data.childrenByDirectory.get(dirPath);
-    if (!children) return [];
-
-    return [...children].map(([name, type]) => ({ name, type }));
+    if (children) {
+      return [...children].map(([name, type]) => ({ name, type }));
+    }
+    // Walked directories always get an (possibly empty) child bucket via
+    // `ensureDirectoryChildren`. A missing bucket means this path was never
+    // indexed — e.g. a skipped `node_modules` reached by absolute path —
+    // so return undefined and let the caller use the slow backend path
+    // instead of claiming the directory is empty.
+    return undefined;
   }
 
   /**
@@ -777,6 +793,14 @@ export class MountIndex {
         this.addPathToChildIndex(data, childPath, 'file');
         data.state.indexed++;
       } else if (childHandle.kind === 'directory') {
+        // Default: do not ingest noise dirs (node_modules, .git, build
+        // output, …). They are omitted from the index entirely — not listed
+        // as empty children — so discovery stays O(useful files) and a
+        // later absolute-path listing falls through to the slow backend
+        // path via the missing-bucket contract in getDirectoryEntries.
+        if (data.limits.skipNoiseDirs && shouldSkipNoiseDir(name)) {
+          continue;
+        }
         this.addPathToChildIndex(data, childPath, 'directory');
         await this.walkHandle(
           childPath,

--- a/packages/webapp/src/fs/mount-index.ts
+++ b/packages/webapp/src/fs/mount-index.ts
@@ -424,6 +424,11 @@ export class MountIndex {
     const data = this.mounts.get(mountPath);
     if (data?.state.status !== 'ready') return;
 
+    // Do not partially populate a noise subtree the walk skipped — a child
+    // bucket created here would look complete to getDirectoryEntries and hide
+    // every sibling that still exists only on the backend.
+    if (this.isSkippedNoisePath(mountPath, absolutePath, data, 'file')) return;
+
     data.files.add(absolutePath);
     this.addPathToChildIndex(data, absolutePath, 'file');
 
@@ -448,6 +453,8 @@ export class MountIndex {
 
     const data = this.mounts.get(mountPath);
     if (data?.state.status !== 'ready') return;
+
+    if (this.isSkippedNoisePath(mountPath, absolutePath, data, 'unknown')) return;
 
     // Remove the path and all children
     data.files.delete(absolutePath);
@@ -483,8 +490,24 @@ export class MountIndex {
     const data = this.mounts.get(mountPath);
     if (data?.state.status !== 'ready') return;
 
+    const kind: 'file' | 'directory' | 'unknown' = data.files.has(oldPath)
+      ? 'file'
+      : data.directories.has(oldPath)
+        ? 'directory'
+        : 'unknown';
+    if (kind === 'unknown') return;
+
+    // Renames that stay inside (or land in) a skipped noise subtree must not
+    // invent partial child buckets. Dropping an indexed path that moves *into*
+    // noise is fine — the destination stays on the slow path.
+    if (this.isSkippedNoisePath(mountPath, oldPath, data, kind)) return;
+    if (this.isSkippedNoisePath(mountPath, newPath, data, kind)) {
+      this.notifyDelete(oldPath);
+      return;
+    }
+
     // Handle file rename
-    if (data.files.has(oldPath)) {
+    if (kind === 'file') {
       data.files.delete(oldPath);
       data.files.add(newPath);
       this.removePathFromChildIndex(data, oldPath);
@@ -493,38 +516,36 @@ export class MountIndex {
     }
 
     // Handle directory rename (move all children)
-    if (data.directories.has(oldPath)) {
-      data.directories.delete(oldPath);
-      data.directories.add(newPath);
+    data.directories.delete(oldPath);
+    data.directories.add(newPath);
 
-      const oldPrefix = oldPath + '/';
-      const newPrefix = newPath + '/';
+    const oldPrefix = oldPath + '/';
+    const newPrefix = newPath + '/';
 
-      for (const path of [...data.files]) {
-        if (path.startsWith(oldPrefix)) {
-          data.files.delete(path);
-          data.files.add(newPrefix + path.slice(oldPrefix.length));
-        }
+    for (const path of [...data.files]) {
+      if (path.startsWith(oldPrefix)) {
+        data.files.delete(path);
+        data.files.add(newPrefix + path.slice(oldPrefix.length));
       }
-      for (const path of [...data.directories]) {
-        if (path.startsWith(oldPrefix)) {
-          data.directories.delete(path);
-          data.directories.add(newPrefix + path.slice(oldPrefix.length));
-        }
+    }
+    for (const path of [...data.directories]) {
+      if (path.startsWith(oldPrefix)) {
+        data.directories.delete(path);
+        data.directories.add(newPrefix + path.slice(oldPrefix.length));
       }
+    }
 
-      this.removePathFromChildIndex(data, oldPath);
-      this.addPathToChildIndex(data, newPath, 'directory');
-      const movedDirectories = [...data.childrenByDirectory.entries()].filter(
-        ([path]) => path === oldPath || path.startsWith(oldPrefix)
-      );
-      for (const [path] of movedDirectories) {
-        data.childrenByDirectory.delete(path);
-      }
-      for (const [path, children] of movedDirectories) {
-        const renamedPath = path === oldPath ? newPath : newPrefix + path.slice(oldPrefix.length);
-        data.childrenByDirectory.set(renamedPath, children);
-      }
+    this.removePathFromChildIndex(data, oldPath);
+    this.addPathToChildIndex(data, newPath, 'directory');
+    const movedDirectories = [...data.childrenByDirectory.entries()].filter(
+      ([path]) => path === oldPath || path.startsWith(oldPrefix)
+    );
+    for (const [path] of movedDirectories) {
+      data.childrenByDirectory.delete(path);
+    }
+    for (const [path, children] of movedDirectories) {
+      const renamedPath = path === oldPath ? newPath : newPrefix + path.slice(oldPrefix.length);
+      data.childrenByDirectory.set(renamedPath, children);
     }
   }
 
@@ -564,6 +585,43 @@ export class MountIndex {
   private parentPath(absolutePath: string): string {
     const lastSlash = absolutePath.lastIndexOf('/');
     return lastSlash <= 0 ? '/' : absolutePath.slice(0, lastSlash);
+  }
+
+  /**
+   * True when indexing would have refused to enter a directory on this path
+   * (or the path itself, when it names a noise directory). File basenames are
+   * never treated as skip dirs — a top-level `.env` file is still indexed —
+   * matching {@link walkChildren}'s directory-only skip.
+   */
+  private isSkippedNoisePath(
+    mountPath: string,
+    absolutePath: string,
+    data: MountData,
+    pathKind: 'file' | 'directory' | 'unknown'
+  ): boolean {
+    if (!data.limits.skipNoiseDirs) return false;
+    if (!absolutePath.startsWith(`${mountPath}/`)) return false;
+
+    const segments = absolutePath.slice(mountPath.length + 1).split('/');
+    const kind =
+      pathKind !== 'unknown'
+        ? pathKind
+        : data.files.has(absolutePath)
+          ? 'file'
+          : data.directories.has(absolutePath)
+            ? 'directory'
+            : 'unknown';
+
+    for (let i = 0; i < segments.length; i++) {
+      const isLeaf = i === segments.length - 1;
+      if (isLeaf && kind === 'file') continue;
+      // Directory leaf, or unknown leaf whose name is itself a skip dir
+      // (unindexed `node_modules` / `.git` delete). Unknown non-skip leaves
+      // (e.g. a never-indexed normal file) are not noise.
+      if (isLeaf && kind === 'unknown' && !shouldSkipNoiseDir(segments[i]!)) continue;
+      if (shouldSkipNoiseDir(segments[i]!)) return true;
+    }
+    return false;
   }
 
   /**

--- a/packages/webapp/src/ui/sprinkle-discovery.ts
+++ b/packages/webapp/src/ui/sprinkle-discovery.ts
@@ -13,7 +13,7 @@
  */
 
 import { SPRINKLE_ROOTS } from '../base/sprinkle-roots.js';
-import { walkBounded } from '../fs/bounded-walk.js';
+import { shouldSkipNoiseDir, walkBounded } from '../fs/bounded-walk.js';
 import type { VirtualFS } from '../fs/index.js';
 
 /**
@@ -38,18 +38,6 @@ const MAX_SCAN_DEPTH = 6;
  * boot crawl out without limit.
  */
 const MAX_SCAN_DIRS = 500;
-
-/**
- * Directory names never entered. Dot-directories (`.git`, `.build`,
- * `.venv`, `.next`, …) are skipped wholesale — a sprinkle is a
- * user-authored panel, never build output or VCS metadata.
- */
-const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', 'coverage']);
-
-/** `skip` predicate for {@link walkBounded}: build output and dot-dirs. */
-function skipDir(name: string): boolean {
-  return name.startsWith('.') || SKIP_DIRS.has(name);
-}
 
 /**
  * Sprinkle names that are part of the deterministic onboarding flow
@@ -101,7 +89,7 @@ export async function discoverSprinkles(fs: VirtualFS): Promise<Map<string, Spri
 /**
  * Walk one root and collect `.shtml` files into the map (first wins).
  * Bounded by {@link MAX_SCAN_DEPTH}, {@link MAX_SCAN_DIRS} and
- * {@link skipDir} — see the module header for why.
+ * {@link shouldSkipNoiseDir} — see the module header for why.
  */
 async function scanDir(
   fs: VirtualFS,
@@ -111,7 +99,7 @@ async function scanDir(
   const walk = walkBounded(fs, root, {
     maxDepth: MAX_SCAN_DEPTH,
     maxDirs: MAX_SCAN_DIRS,
-    skip: skipDir,
+    skip: shouldSkipNoiseDir,
   });
   for await (const filePath of walk) {
     if (!filePath.endsWith('.shtml')) continue;

--- a/packages/webapp/tests/fs/bounded-walk.test.ts
+++ b/packages/webapp/tests/fs/bounded-walk.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { walkBounded } from '../../src/fs/bounded-walk.js';
+import { DEFAULT_SKIP_DIRS, shouldSkipNoiseDir, walkBounded } from '../../src/fs/bounded-walk.js';
 import type { DirEntry, Stats } from '../../src/fs/types.js';
 import { FsError } from '../../src/fs/types.js';
 
@@ -29,6 +29,18 @@ async function collect(gen: AsyncGenerator<string>): Promise<string[]> {
   for await (const p of gen) out.push(p);
   return out.sort();
 }
+
+describe('shouldSkipNoiseDir', () => {
+  it('skips the shared build-output set and every dot-directory', () => {
+    for (const name of DEFAULT_SKIP_DIRS) {
+      expect(shouldSkipNoiseDir(name)).toBe(true);
+    }
+    expect(shouldSkipNoiseDir('.git')).toBe(true);
+    expect(shouldSkipNoiseDir('.build')).toBe(true);
+    expect(shouldSkipNoiseDir('src')).toBe(false);
+    expect(shouldSkipNoiseDir('README.md')).toBe(false);
+  });
+});
 
 describe('walkBounded', () => {
   it('yields files and recurses into directories', async () => {

--- a/packages/webapp/tests/fs/mount-index.test.ts
+++ b/packages/webapp/tests/fs/mount-index.test.ts
@@ -437,4 +437,37 @@ describe('MountIndex noise-directory skip', () => {
     expect(unfiltered.getState('/mnt/blow')?.abortCause).toBe('entries-exceeded');
     unfiltered.unregisterMount('/mnt/blow');
   }, 9000);
+
+  it('does not partially populate skipped subtrees on write/rename/delete', async () => {
+    const index = new MountIndex();
+    index.registerMount('/mnt/repo', makeNoisyProjectHandle());
+    expect(await waitForTerminalState(index, '/mnt/repo', 4000)).toBe('ready');
+
+    // A post-index write under node_modules must leave the subtree unindexed
+    // so getDirectoryEntries keeps falling back to the slow path.
+    index.notifyWrite('/mnt/repo/node_modules/pkg-0.js');
+    index.notifyWrite('/mnt/repo/.git/config');
+    expect(index.hasPath('/mnt/repo', '/mnt/repo/node_modules/pkg-0.js')).toBe(false);
+    expect(index.getDirectoryEntries('/mnt/repo', '/mnt/repo/node_modules')).toBeUndefined();
+    expect(index.getDirectoryEntries('/mnt/repo', '/mnt/repo')?.map((e) => e.name)).not.toContain(
+      'node_modules'
+    );
+
+    // Dot-files at the mount root are still files, not skipped directories.
+    index.notifyWrite('/mnt/repo/.env');
+    expect(index.hasPath('/mnt/repo', '/mnt/repo/.env')).toBe(true);
+
+    // Rename into noise drops the indexed source; destination stays unindexed.
+    index.notifyRename('/mnt/repo/README.md', '/mnt/repo/node_modules/README.md');
+    expect(index.hasPath('/mnt/repo', '/mnt/repo/README.md')).toBe(false);
+    expect(index.hasPath('/mnt/repo', '/mnt/repo/node_modules/README.md')).toBe(false);
+    expect(index.getDirectoryEntries('/mnt/repo', '/mnt/repo/node_modules')).toBeUndefined();
+
+    // Mutations that stay inside noise are no-ops on the index.
+    index.notifyDelete('/mnt/repo/node_modules/pkg-0.js');
+    index.notifyRename('/mnt/repo/.git/HEAD', '/mnt/repo/.git/ORIG_HEAD');
+    expect(index.getDirectoryEntries('/mnt/repo', '/mnt/repo/.git')).toBeUndefined();
+
+    index.unregisterMount('/mnt/repo');
+  }, 9000);
 });

--- a/packages/webapp/tests/fs/mount-index.test.ts
+++ b/packages/webapp/tests/fs/mount-index.test.ts
@@ -157,7 +157,7 @@ describe('MountIndex cycle safety', () => {
     } as unknown as FileSystemDirectoryHandle;
 
     const index = new MountIndex();
-    index.registerMount('/mnt/flat', flat, { maxDepth: 400, maxEntries: 5 });
+    index.registerMount('/mnt/flat', flat, { maxDepth: 400, maxEntries: 5, skipNoiseDirs: true });
 
     const status = await waitForTerminalState(index, '/mnt/flat', 4000);
     const state = index.getState('/mnt/flat');
@@ -316,7 +316,7 @@ describe('resolveMountIndexLimits', () => {
       SLICC_MOUNT_INDEX_MAX_DEPTH: '12',
       SLICC_MOUNT_INDEX_MAX_ENTRIES: '500',
     });
-    expect(limits).toEqual({ maxDepth: 12, maxEntries: 500 });
+    expect(limits).toEqual({ maxDepth: 12, maxEntries: 500, skipNoiseDirs: true });
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
@@ -325,13 +325,21 @@ describe('resolveMountIndexLimits', () => {
       SLICC_MOUNT_INDEX_MAX_DEPTH: '-5',
       SLICC_MOUNT_INDEX_MAX_ENTRIES: 'not-a-number',
     });
-    expect(limits).toEqual({ maxDepth: DEFAULT_MAX_DEPTH, maxEntries: DEFAULT_MAX_ENTRIES });
+    expect(limits).toEqual({
+      maxDepth: DEFAULT_MAX_DEPTH,
+      maxEntries: DEFAULT_MAX_ENTRIES,
+      skipNoiseDirs: true,
+    });
     expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 
   it('uses defaults silently when the env vars are absent', () => {
     const limits = resolveMountIndexLimits({});
-    expect(limits).toEqual({ maxDepth: DEFAULT_MAX_DEPTH, maxEntries: DEFAULT_MAX_ENTRIES });
+    expect(limits).toEqual({
+      maxDepth: DEFAULT_MAX_DEPTH,
+      maxEntries: DEFAULT_MAX_ENTRIES,
+      skipNoiseDirs: true,
+    });
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
@@ -342,7 +350,91 @@ describe('resolveMountIndexLimits', () => {
         ['SLICC_MOUNT_INDEX_MAX_ENTRIES', '500'],
       ])
     );
-    expect(limits).toEqual({ maxDepth: 12, maxEntries: 500 });
+    expect(limits).toEqual({ maxDepth: 12, maxEntries: 500, skipNoiseDirs: true });
     expect(warnSpy).not.toHaveBeenCalled();
   });
+});
+
+describe('MountIndex noise-directory skip', () => {
+  const fileHandle = { kind: 'file' as const } as FileSystemHandle;
+
+  /** Project tree with useful files plus huge noise under node_modules and .git. */
+  function makeNoisyProjectHandle(): FileSystemDirectoryHandle {
+    const noiseFiles: Array<[string, FileSystemHandle]> = [];
+    for (let i = 0; i < 20; i++) {
+      noiseFiles.push([`pkg-${i}.js`, fileHandle]);
+    }
+    return makeDirectoryHandle([
+      ['README.md', fileHandle],
+      ['src', makeDirectoryHandle([['app.ts', fileHandle]])],
+      ['node_modules', makeDirectoryHandle(noiseFiles)],
+      [
+        '.git',
+        makeDirectoryHandle([
+          ['HEAD', fileHandle],
+          ['config', fileHandle],
+        ]),
+      ],
+      ['dist', makeDirectoryHandle([['bundle.js', fileHandle]])],
+    ]);
+  }
+
+  it('skips node_modules, .git, and build output by default', async () => {
+    const index = new MountIndex();
+    index.registerMount('/mnt/repo', makeNoisyProjectHandle());
+    expect(await waitForTerminalState(index, '/mnt/repo', 4000)).toBe('ready');
+
+    expect(index.getFiles('/mnt/repo')?.sort()).toEqual([
+      '/mnt/repo/README.md',
+      '/mnt/repo/src/app.ts',
+    ]);
+    expect(index.hasPath('/mnt/repo', '/mnt/repo/node_modules')).toBe(false);
+    expect(index.hasPath('/mnt/repo', '/mnt/repo/.git')).toBe(false);
+    expect(index.hasPath('/mnt/repo', '/mnt/repo/dist')).toBe(false);
+    expect(
+      index
+        .getDirectoryEntries('/mnt/repo', '/mnt/repo')
+        ?.map((e) => e.name)
+        .sort()
+    ).toEqual(['README.md', 'src']);
+    // Absolute path into a skipped subtree must not pretend the dir is empty.
+    expect(index.getDirectoryEntries('/mnt/repo', '/mnt/repo/node_modules')).toBeUndefined();
+    index.unregisterMount('/mnt/repo');
+  }, 9000);
+
+  it('indexes noise directories when skipNoiseDirs is false', async () => {
+    const index = new MountIndex();
+    index.registerMount('/mnt/repo', makeNoisyProjectHandle(), {
+      ...resolveMountIndexLimits({}),
+      skipNoiseDirs: false,
+    });
+    expect(await waitForTerminalState(index, '/mnt/repo', 4000)).toBe('ready');
+
+    expect(index.hasPath('/mnt/repo', '/mnt/repo/node_modules/pkg-0.js')).toBe(true);
+    expect(index.hasPath('/mnt/repo', '/mnt/repo/.git/HEAD')).toBe(true);
+    expect(index.hasPath('/mnt/repo', '/mnt/repo/dist/bundle.js')).toBe(true);
+    index.unregisterMount('/mnt/repo');
+  }, 9000);
+
+  it('reaches the entry budget later when noise dirs are skipped', async () => {
+    // Same tree, tight budget: with skip the useful files fit; without skip,
+    // node_modules alone blows the budget before src is reached.
+    const tight = { maxDepth: 400, maxEntries: 8, skipNoiseDirs: true as const };
+
+    const skipped = new MountIndex();
+    skipped.registerMount('/mnt/fit', makeNoisyProjectHandle(), tight);
+    expect(await waitForTerminalState(skipped, '/mnt/fit', 4000)).toBe('ready');
+    expect(skipped.hasPath('/mnt/fit', '/mnt/fit/src/app.ts')).toBe(true);
+    skipped.unregisterMount('/mnt/fit');
+
+    const unfiltered = new MountIndex();
+    unfiltered.registerMount('/mnt/blow', makeNoisyProjectHandle(), {
+      ...tight,
+      skipNoiseDirs: false,
+    });
+    const status = await waitForTerminalState(unfiltered, '/mnt/blow', 4000);
+    expect(status).toBe('error');
+    expect(unfiltered.getState('/mnt/blow')?.abortCause).toBe('entries-exceeded');
+    unfiltered.unregisterMount('/mnt/blow');
+  }, 9000);
 });


### PR DESCRIPTION
## Summary

MountIndex no longer indexes `node_modules`, `dist`, `build`, `coverage`, or dot-directories (`.git`, `.build`, …) by default. That stops a real project mount from ingesting hundreds of thousands of useless entries and hitting `entries-exceeded`.

The skip list is shared with sprinkle discovery via `shouldSkipNoiseDir` / `DEFAULT_SKIP_DIRS` in `bounded-walk.ts`. Callers that need a full index can pass `skipNoiseDirs: false` on `MountIndexLimits`.

## Why

Fixes #2764 (follow-up to #2734 / #2759). Indexing still walked every path under a mount; noise dirs dominated the walk cost and the entry budget.

## Approach / Implementation notes

- Export `DEFAULT_SKIP_DIRS` + `shouldSkipNoiseDir` from `bounded-walk.ts`; sprinkle discovery imports them instead of keeping a private copy.
- `MountIndexLimits.skipNoiseDirs` defaults to `true` via `resolveMountIndexLimits` / `RESTORED_MOUNT_INDEX_LIMITS`.
- Skipped dirs are omitted from the index (not listed as empty children). `getDirectoryEntries` returns `undefined` for never-indexed paths so absolute-path listings fall back to the slow backend path instead of appearing empty.
- Depth / entry abort semantics are unchanged.

## Cross-cutting impact

- **Floats**: all floats that use local mounts (CLI picker, extension, Electron) — index is smaller and ready sooner; `readDir` via the fast path no longer lists noise dirs at the parent.
- Direct backend reads / slow path for unindexed absolute paths still work.
- No persisted schema changes.

## Test plan

- [x] `npm run verify`
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 18715 passed
- [x] `npm run test:coverage:webapp`
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size`
- [x] `npx vitest run packages/webapp/tests/fs/mount-index.test.ts packages/webapp/tests/fs/bounded-walk.test.ts` — skip / opt-in / budget tests

## Documentation

- [x] `docs/mounts.md` — noise-dir skip defaults

## Risk & rollback

- Blast radius: local-mount discovery and index-backed `readDir` only.
- Kill switch: pass `skipNoiseDirs: false` when registering/refreshing a mount.
- Clean revert of this PR undoes the behavior.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Closes #2764


Made with [Cursor](https://cursor.com)