### PR TITLE
fix(git): renew OAuth bridge on network ops and clarify stale 401s

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Use ice cream terms in review comments and docs when they match the domain (e.g.
 - Keep commits focused and package-local when possible.
 - **Linear history**: CI rejects merge commits. Rebase onto `origin/main`; Husky enforces via `packages/dev-tools/tools/check-linear-history.sh`.
 - Do not hand-edit generated output in `dist/`.
-- Auth: `git config github.token <PAT>` or GitHub OAuth login; see [`docs/secrets.md`](docs/secrets.md).
+- Auth: GitHub OAuth login (preferred; renews the git bridge on network ops) or `git config github.token <PAT>`; see [`docs/secrets.md`](docs/secrets.md).
 
 **Requires Node >= 22** (LTS). Ports: 5710 (bridge + /api), 9222 (Chrome CDP), 9223 (Electron CDP). node-server serves no UI — the webapp loads from the hosted origin and dials back to the local `/cdp` bridge.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -49,8 +49,10 @@ Extras are stored in `localStorage` under `slicc_oauth_extra_domains` (`{provide
 
 Two clone shapes are supported. Prefer the first — the second is an escape hatch for tools that only know how to pass auth via the URL.
 
-- **Preferred (env / file-based auth):** `git clone https://github.com/owner/repo` — the fetch-proxy attaches the GitHub PAT it already has on file (`/workspace/.git/github-token`, then `GH_TOKEN` / `GITHUB_TOKEN` from the shell env) to the request at the wire boundary.
+- **Preferred (OAuth / file-based auth):** Log in via Settings → Providers → GitHub (or `oauth-token github`). That writes a masked token to `/workspace/.git/github-token`. Then `git clone https://github.com/owner/repo` — before each network op, git asks the OAuth broker for a fresh token and re-syncs that bridge file, so isomorphic-git never keeps a hand-written snapshot. Env fallbacks (`GH_TOKEN` / `GITHUB_TOKEN`) still apply when no OAuth account is logged in.
 - **Escape hatch (URL-embedded masked credential):** `git clone https://x-access-token:$(oauth-token github)@github.com/owner/repo.git` — the masked value in the URL's userinfo segment is unmasked into a synthetic `Authorization: Basic` header by the fetch-proxy (`/api/fetch-proxy` in node-server / swift-server, the `fetch-proxy.fetch` Port handler in the extension SW). The agent never sees the real PAT in either form.
+
+Do **not** treat `git config github.token "$(oauth-token github)"` as a long-lived setup. That stores a **snapshot** of the current masked value. When the broker renews, the snapshot goes stale and a bare `fatal: HTTP Error: 401 Unauthorized` used to be the only signal. Prefer leaving the bridge to OAuth login; if you must set `github.token` manually (e.g. a PAT), capture **stdout only** — never `2>&1 | tail` — and know that a 401 will trigger one silent renew+retry before surfacing an actionable hint.
 
 ### Shell-env naming convention
 

--- a/packages/webapp/providers/github.ts
+++ b/packages/webapp/providers/github.ts
@@ -556,12 +556,34 @@ function isRateLimited(res: Response): boolean {
   return res.headers.get('x-ratelimit-remaining') === '0' || res.headers.has('retry-after');
 }
 
+/**
+ * Keep `/workspace/.git/github-token` aligned with the live OAuth masked value.
+ *
+ * `git config github.token "$(oauth-token github)"` stores a snapshot that
+ * goes stale when the broker rotates the mask or renews the access token
+ * (#2777). Network ops call {@link getValidAccessToken} before talking to
+ * GitHub; syncing here — even when the access token is still fresh — means
+ * isomorphic-git never keeps using a hand-written snapshot while an OAuth
+ * account is logged in.
+ */
+async function syncGitTokenBridge(): Promise<void> {
+  const masked = getOAuthAccountInfo('github')?.maskedValue;
+  if (masked) {
+    await writeGitToken(masked);
+  }
+}
+
 async function getValidAccessToken(): Promise<string> {
   const account = getGitHubAccount();
   if (!account?.accessToken) throw new Error('Not logged in to GitHub — please log in first');
 
   const expiresIn = (account.tokenExpiresAt ?? Number.POSITIVE_INFINITY) - Date.now();
-  if (expiresIn > 60000) return account.accessToken;
+  if (expiresIn > 60000) {
+    // Fresh enough to skip renewal, but still re-sync the git bridge so a
+    // stale `git config github.token` snapshot cannot win over the broker.
+    await syncGitTokenBridge();
+    return account.accessToken;
+  }
 
   const newToken = await silentRenewBackoff.run(() => renewGitHubToken());
   if (newToken) return newToken;
@@ -570,6 +592,7 @@ async function getValidAccessToken(): Promise<string> {
   const refreshedExpiresIn =
     (refreshedAccount?.tokenExpiresAt ?? Number.POSITIVE_INFINITY) - Date.now();
   if (refreshedExpiresIn > 0 && refreshedAccount?.accessToken) {
+    await syncGitTokenBridge();
     return refreshedAccount.accessToken;
   }
 

--- a/packages/webapp/src/git/commands/clone.ts
+++ b/packages/webapp/src/git/commands/clone.ts
@@ -60,6 +60,7 @@ export async function clone(
       singleBranch,
       noCheckout: false, // Let clone handle checkout
       onAuth: ctx.getOnAuth(),
+      onAuthFailure: ctx.getOnAuthFailure(),
       onProgress: (event) => {
         if (event.phase === 'Receiving objects') {
           output += `Receiving objects: ${event.loaded}/${event.total}\n`;

--- a/packages/webapp/src/git/commands/clone.ts
+++ b/packages/webapp/src/git/commands/clone.ts
@@ -70,7 +70,7 @@ export async function clone(
   } catch (err: unknown) {
     // #1033-1: surface the real target dir, never the literal `<path>`
     // placeholder that bubbles up from the OPFS backend.
-    return formatCloneError(err, targetDir);
+    return formatCloneError(err, targetDir, url);
   }
 
   // Persist backend-owned metadata (symlink-ness + filemode) to the OPFS
@@ -159,7 +159,7 @@ async function cloneLocal(
     if (files.length > 0) output += `Checked out ${files.length} files.\n`;
     return { stdout: `${output}done.\n`, stderr: '', exitCode: 0 };
   } catch (err) {
-    return formatCloneError(err, targetDir);
+    return formatCloneError(err, targetDir, url);
   }
 }
 
@@ -187,8 +187,8 @@ async function copyLocalTree(
  * internal placeholder so the user sees the path they asked for, never the
  * literal `<path>` token from the backend (#1033-1).
  */
-function formatCloneError(err: unknown, targetDir: string): GitCommandResult {
-  const raw = expandGitError(err);
+function formatCloneError(err: unknown, targetDir: string, remoteUrl?: string): GitCommandResult {
+  const raw = expandGitError(err, remoteUrl);
   const scrubbed = raw
     .replace(/'\/__opfs__\/[^']*<path>'/g, `'${targetDir}'`)
     .replace(/\/__opfs__\/[^\s'"<]*<path>/g, targetDir)

--- a/packages/webapp/src/git/commands/clone.ts
+++ b/packages/webapp/src/git/commands/clone.ts
@@ -159,7 +159,7 @@ async function cloneLocal(
     if (files.length > 0) output += `Checked out ${files.length} files.\n`;
     return { stdout: `${output}done.\n`, stderr: '', exitCode: 0 };
   } catch (err) {
-    return formatCloneError(err, targetDir, url);
+    return formatCloneError(err, targetDir, sourceUrl);
   }
 }
 

--- a/packages/webapp/src/git/commands/fetch.ts
+++ b/packages/webapp/src/git/commands/fetch.ts
@@ -33,6 +33,7 @@ export async function fetch(
     prune,
     depth: depth ? parseInt(depth, 10) : undefined,
     onAuth: ctx.getOnAuth(),
+    onAuthFailure: ctx.getOnAuthFailure(),
     onProgress: (event) => {
       output += `${event.phase}: ${event.loaded}/${event.total}\n`;
     },

--- a/packages/webapp/src/git/commands/ls-remote.ts
+++ b/packages/webapp/src/git/commands/ls-remote.ts
@@ -2,6 +2,7 @@
 
 import * as git from 'isomorphic-git';
 import { gitHttp } from '../git-http.js';
+import { annotateGitHubAuthFailure } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function lsRemote(
@@ -24,6 +25,7 @@ export async function lsRemote(
       url,
       corsProxy: ctx.corsProxy,
       onAuth: ctx.getOnAuth(),
+      onAuthFailure: ctx.getOnAuthFailure(),
       prefix,
       symrefs: showSymrefs,
       peelTags: tags,
@@ -37,9 +39,10 @@ export async function lsRemote(
       .join('');
     return { stdout, stderr: '', exitCode: args.includes('--exit-code') && !stdout ? 2 : 0 };
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     return {
       stdout: '',
-      stderr: `fatal: ${err instanceof Error ? err.message : String(err)}\n`,
+      stderr: `fatal: ${annotateGitHubAuthFailure(message)}\n`,
       exitCode: 128,
     };
   }

--- a/packages/webapp/src/git/commands/ls-remote.ts
+++ b/packages/webapp/src/git/commands/ls-remote.ts
@@ -42,7 +42,7 @@ export async function lsRemote(
     const message = err instanceof Error ? err.message : String(err);
     return {
       stdout: '',
-      stderr: `fatal: ${annotateGitHubAuthFailure(message)}\n`,
+      stderr: `fatal: ${annotateGitHubAuthFailure(message, url)}\n`,
       exitCode: 128,
     };
   }

--- a/packages/webapp/src/git/commands/pull.ts
+++ b/packages/webapp/src/git/commands/pull.ts
@@ -33,6 +33,7 @@ export async function pull(
     fastForwardOnly: ffOnly,
     fastForward: !noFf,
     onAuth: ctx.getOnAuth(),
+    onAuthFailure: ctx.getOnAuthFailure(),
     onProgress: (event) => {
       output += `${event.phase}: ${event.loaded}/${event.total}\n`;
     },

--- a/packages/webapp/src/git/commands/push.ts
+++ b/packages/webapp/src/git/commands/push.ts
@@ -3,7 +3,7 @@
 import * as git from 'isomorphic-git';
 import { parseArgs } from '../../shell/arg-parser.js';
 import { gitHttp } from '../git-http.js';
-import { GIT_FLAG_SPECS } from './shared.js';
+import { annotateGitHubAuthFailure, GIT_FLAG_SPECS } from './shared.js';
 import type { GitCommandContext, GitCommandResult } from './types.js';
 
 export async function push(
@@ -30,6 +30,7 @@ export async function push(
     corsProxy: ctx.corsProxy,
     force,
     onAuth: ctx.getOnAuth(),
+    onAuthFailure: ctx.getOnAuthFailure(),
     onProgress: (event) => {
       output += `${event.phase}: ${event.loaded}/${event.total}\n`;
     },
@@ -58,7 +59,7 @@ export async function push(
   } else {
     return {
       stdout: '',
-      stderr: `error: failed to push to '${remote}': ${result.error}\n`,
+      stderr: `error: failed to push to '${remote}': ${annotateGitHubAuthFailure(String(result.error))}\n`,
       exitCode: 1,
     };
   }

--- a/packages/webapp/src/git/commands/push.ts
+++ b/packages/webapp/src/git/commands/push.ts
@@ -57,9 +57,11 @@ export async function push(
       output += `Branch '${branch}' set up to track remote branch '${branch}' from '${remote}'.\n`;
     }
   } else {
+    const remotes = await git.listRemotes({ fs: ctx.lfs, dir: cwd }).catch(() => []);
+    const remoteUrl = remotes.find((item) => item.remote === remote)?.url;
     return {
       stdout: '',
-      stderr: `error: failed to push to '${remote}': ${annotateGitHubAuthFailure(String(result.error))}\n`,
+      stderr: `error: failed to push to '${remote}': ${annotateGitHubAuthFailure(String(result.error), remoteUrl)}\n`,
       exitCode: 1,
     };
   }

--- a/packages/webapp/src/git/commands/shared.ts
+++ b/packages/webapp/src/git/commands/shared.ts
@@ -193,8 +193,8 @@ function packfileReadHint(message: string): string | null {
  * of the packfile `InternalError`s {@link packfileReadHint} can say something
  * useful about; non-Errors stringify.
  */
-export function expandGitError(err: unknown): string {
-  if (!(err instanceof Error)) return annotateGitHubAuthFailure(String(err));
+export function expandGitError(err: unknown, remoteUrl?: string): string {
+  if (!(err instanceof Error)) return annotateGitHubAuthFailure(String(err), remoteUrl);
   const data = err as Error & { errors?: unknown; data?: { errors?: unknown } };
   const isMultiple =
     err.name === 'MultipleGitError' ||
@@ -207,20 +207,54 @@ export function expandGitError(err: unknown): string {
         ? (data.data?.errors as unknown[])
         : [];
     if (errorsList.length > 0) {
-      return errorsList.map((inner) => expandGitError(inner)).join('\n');
+      return errorsList.map((inner) => expandGitError(inner, remoteUrl)).join('\n');
     }
   }
-  return annotateGitHubAuthFailure(packfileReadHint(err.message) ?? err.message);
+  return annotateGitHubAuthFailure(packfileReadHint(err.message) ?? err.message, remoteUrl);
 }
 
 /**
- * When GitHub answers 401, the bare isomorphic-git message
- * (`HTTP Error: 401 Unauthorized`) leaves agents guessing between wrong
- * scopes, missing push permission, revocation, and simple expiry. Point
- * them at the broker path that actually renews (#2777).
+ * True when `url` points at github.com (HTTPS, SSH, or git@ form). Used to
+ * keep the stale-`github.token` hint off non-GitHub remotes (#2777 review).
  */
-export function annotateGitHubAuthFailure(message: string): string {
+export function isGitHubRemoteUrl(url: string): boolean {
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+  try {
+    const withScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed)
+      ? trimmed
+      : trimmed.includes('@') && trimmed.includes(':')
+        ? `ssh://${trimmed.replace(':', '/')}`
+        : `https://${trimmed}`;
+    const host = new URL(withScheme).hostname.toLowerCase();
+    return host === 'github.com' || host.endsWith('.github.com');
+  } catch {
+    return /(?:^|[@/])github\.com(?:[/:]|$)/i.test(trimmed);
+  }
+}
+
+/**
+ * When a remote answers 401, the bare isomorphic-git message
+ * (`HTTP Error: 401 Unauthorized`) leaves agents guessing. For GitHub remotes,
+ * point them at the OAuth broker path that actually renews (#2777). For other
+ * hosts, leave the message alone (or use a provider-neutral hint when the
+ * host is unknown) so we do not send people to `oauth-token github` for a
+ * GitLab/Bitbucket failure.
+ */
+export function annotateGitHubAuthFailure(message: string, remoteUrl?: string): string {
   if (!/\b401\b|Unauthorized/i.test(message)) return message;
+
+  if (remoteUrl !== undefined) {
+    if (!isGitHubRemoteUrl(remoteUrl)) return message;
+  } else if (!/github\.com/i.test(message)) {
+    return (
+      `${message}\n` +
+      'hint: Authentication failed (401). Check credentials for this remote. ' +
+      'If this is GitHub, stored `git config github.token` may be a stale snapshot — ' +
+      're-run `oauth-token github` (or Settings → Providers → GitHub).'
+    );
+  }
+
   return (
     `${message}\n` +
     'hint: GitHub returned 401. Stored `git config github.token` may be a stale ' +

--- a/packages/webapp/src/git/commands/shared.ts
+++ b/packages/webapp/src/git/commands/shared.ts
@@ -194,7 +194,7 @@ function packfileReadHint(message: string): string | null {
  * useful about; non-Errors stringify.
  */
 export function expandGitError(err: unknown): string {
-  if (!(err instanceof Error)) return String(err);
+  if (!(err instanceof Error)) return annotateGitHubAuthFailure(String(err));
   const data = err as Error & { errors?: unknown; data?: { errors?: unknown } };
   const isMultiple =
     err.name === 'MultipleGitError' ||
@@ -210,7 +210,25 @@ export function expandGitError(err: unknown): string {
       return errorsList.map((inner) => expandGitError(inner)).join('\n');
     }
   }
-  return packfileReadHint(err.message) ?? err.message;
+  return annotateGitHubAuthFailure(packfileReadHint(err.message) ?? err.message);
+}
+
+/**
+ * When GitHub answers 401, the bare isomorphic-git message
+ * (`HTTP Error: 401 Unauthorized`) leaves agents guessing between wrong
+ * scopes, missing push permission, revocation, and simple expiry. Point
+ * them at the broker path that actually renews (#2777).
+ */
+export function annotateGitHubAuthFailure(message: string): string {
+  if (!/\b401\b|Unauthorized/i.test(message)) return message;
+  return (
+    `${message}\n` +
+    'hint: GitHub returned 401. Stored `git config github.token` may be a stale ' +
+    'snapshot — git renews the OAuth broker on network ops, but a hand-written ' +
+    'token is not refreshed. Re-run `oauth-token github` (or Settings → Providers → ' +
+    'GitHub). If you must set `github.token` manually, capture stdout only ' +
+    '(never `2>&1`) and prefer leaving the bridge to the OAuth login.'
+  );
 }
 
 /**

--- a/packages/webapp/src/git/commands/types.ts
+++ b/packages/webapp/src/git/commands/types.ts
@@ -22,8 +22,12 @@ export interface GitCommandsOptions {
   fs: VirtualFS;
   /** CORS proxy URL for remote operations. */
   corsProxy?: string;
-  /** Best-effort GitHub token freshness check before network operations. */
-  ensureFreshGithubToken?: () => Promise<void>;
+  /**
+   * Best-effort GitHub token freshness check before network operations.
+   * Pass `{ force: true }` from `onAuthFailure` to renew even when the
+   * locally recorded expiry has not elapsed (#2777).
+   */
+  ensureFreshGithubToken?: (opts?: { force?: boolean }) => Promise<void>;
   /** Default author name. */
   authorName?: string;
   /** Default author email. */
@@ -64,6 +68,13 @@ export interface GitCommandContext {
   readonly corsProxy?: string;
   /** onAuth callback for isomorphic-git network operations (or undefined). */
   getOnAuth(): (() => { username: string; password: string }) | undefined;
+  /**
+   * onAuthFailure: one silent renew + retry when GitHub rejects credentials
+   * (#2777). Returns undefined when already retried or no token is available.
+   */
+  getOnAuthFailure():
+    | (() => Promise<{ username: string; password: string } | undefined>)
+    | undefined;
   /** Resolve the git author identity for an operation. */
   resolveAuthor(cwd: string): Promise<{ name: string; email: string }>;
   /** The shared Global VirtualFS instance for config persistence. */

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -183,12 +183,6 @@ export class GitCommands {
    * leak across calls.
    */
   private currentConfigOverrides?: ReadonlyMap<string, string>;
-  /**
-   * Guards {@link getOnAuthFailure} so a 401 triggers at most one silent
-   * renew+retry per `execute()` (#2777). Reset at the start of every
-   * network-capable invocation.
-   */
-  private authFailureRetried = false;
 
   /**
    * Cross-command isomorphic-git object/pack cache (#2710). One per INSTANCE —
@@ -244,6 +238,10 @@ export class GitCommands {
     const lfs = CACHEABLE_COMMANDS.has(command)
       ? createCommandScopedReadCache(client.promises)
       : client.promises;
+    // Latch is closed over here — NOT on the instance — so overlapping
+    // network commands on the same GitCommands each get their own single
+    // renew+retry (#2777 Codex review).
+    const onAuthFailure = this.createOnAuthFailure();
     const ctx: GitCommandContext = {
       lfs,
       fs: this.options.fs,
@@ -254,7 +252,7 @@ export class GitCommands {
       cache: this.cacheManager.cache,
       corsProxy: this.corsProxy,
       getOnAuth: () => this.getOnAuth(),
-      getOnAuthFailure: () => this.getOnAuthFailure(),
+      getOnAuthFailure: () => onAuthFailure,
       resolveAuthor: (cwd) => this.resolveAuthor(cwd, lfs),
       getGlobalFs: () => this.getGlobalFs(),
       setGithubToken: (token) => this.setGithubToken(token),
@@ -284,20 +282,21 @@ export class GitCommands {
   }
 
   /**
-   * After GitHub rejects credentials, force one silent renew and retry with
-   * the refreshed bridge token. isomorphic-git keeps calling this as long as
-   * credentials are returned, so the {@link authFailureRetried} latch caps
-   * retries at one (#2777).
+   * Build a per-invocation onAuthFailure: after GitHub rejects credentials,
+   * force one silent renew and retry with the refreshed bridge token.
+   * isomorphic-git keeps calling as long as credentials are returned, so the
+   * closed-over latch caps retries at one for THIS command only (#2777).
    */
-  private getOnAuthFailure():
+  private createOnAuthFailure():
     | (() => Promise<{ username: string; password: string } | undefined>)
     | undefined {
     // Always install the callback when a freshness hook exists — even if the
     // first onAuth had no token, a force renew might produce one.
     if (!this.options.ensureFreshGithubToken) return undefined;
+    let retried = false;
     return async () => {
-      if (this.authFailureRetried) return undefined;
-      this.authFailureRetried = true;
+      if (retried) return undefined;
+      retried = true;
       try {
         await this.options.ensureFreshGithubToken?.({ force: true });
       } catch (err) {
@@ -479,7 +478,6 @@ export class GitCommands {
       this.cacheManager.setDeepVerification(this.shouldVerifyPackfiles());
       await this.cacheManager.beforeCommand(effectiveCwd);
       if (NETWORK_COMMANDS.has(command)) {
-        this.authFailureRetried = false;
         await this.ensureFreshGithubToken();
       }
       await this.loadGithubToken();

--- a/packages/webapp/src/git/git-commands.ts
+++ b/packages/webapp/src/git/git-commands.ts
@@ -183,6 +183,12 @@ export class GitCommands {
    * leak across calls.
    */
   private currentConfigOverrides?: ReadonlyMap<string, string>;
+  /**
+   * Guards {@link getOnAuthFailure} so a 401 triggers at most one silent
+   * renew+retry per `execute()` (#2777). Reset at the start of every
+   * network-capable invocation.
+   */
+  private authFailureRetried = false;
 
   /**
    * Cross-command isomorphic-git object/pack cache (#2710). One per INSTANCE —
@@ -248,6 +254,7 @@ export class GitCommands {
       cache: this.cacheManager.cache,
       corsProxy: this.corsProxy,
       getOnAuth: () => this.getOnAuth(),
+      getOnAuthFailure: () => this.getOnAuthFailure(),
       resolveAuthor: (cwd) => this.resolveAuthor(cwd, lfs),
       getGlobalFs: () => this.getGlobalFs(),
       setGithubToken: (token) => this.setGithubToken(token),
@@ -274,6 +281,36 @@ export class GitCommands {
       username: 'x-access-token',
       password: token,
     });
+  }
+
+  /**
+   * After GitHub rejects credentials, force one silent renew and retry with
+   * the refreshed bridge token. isomorphic-git keeps calling this as long as
+   * credentials are returned, so the {@link authFailureRetried} latch caps
+   * retries at one (#2777).
+   */
+  private getOnAuthFailure():
+    | (() => Promise<{ username: string; password: string } | undefined>)
+    | undefined {
+    // Always install the callback when a freshness hook exists — even if the
+    // first onAuth had no token, a force renew might produce one.
+    if (!this.options.ensureFreshGithubToken) return undefined;
+    return async () => {
+      if (this.authFailureRetried) return undefined;
+      this.authFailureRetried = true;
+      try {
+        await this.options.ensureFreshGithubToken?.({ force: true });
+      } catch (err) {
+        logger.warn('GitHub token force-renew after 401 failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return undefined;
+      }
+      await this.loadGithubToken();
+      const token = this.resolveAuthToken();
+      if (!token) return undefined;
+      return { username: 'x-access-token', password: token };
+    };
   }
 
   /**
@@ -321,9 +358,9 @@ export class GitCommands {
   }
 
   /** Refresh GitHub auth before network operations without making git depend on the provider. */
-  private async ensureFreshGithubToken(): Promise<void> {
+  private async ensureFreshGithubToken(opts?: { force?: boolean }): Promise<void> {
     try {
-      await this.options.ensureFreshGithubToken?.();
+      await this.options.ensureFreshGithubToken?.(opts);
     } catch (err) {
       logger.warn('GitHub token freshness check failed; continuing with existing auth', {
         error: err instanceof Error ? err.message : String(err),
@@ -442,6 +479,7 @@ export class GitCommands {
       this.cacheManager.setDeepVerification(this.shouldVerifyPackfiles());
       await this.cacheManager.beforeCommand(effectiveCwd);
       if (NETWORK_COMMANDS.has(command)) {
+        this.authFailureRetried = false;
         await this.ensureFreshGithubToken();
       }
       await this.loadGithubToken();

--- a/packages/webapp/src/shell/almost-bash-shell-headless.ts
+++ b/packages/webapp/src/shell/almost-bash-shell-headless.ts
@@ -252,8 +252,24 @@ function getFsWatcher(fs: unknown): FsWatcher | null {
   return null;
 }
 
-async function ensureFreshGithubToken(): Promise<void> {
-  await getRegisteredProviderConfig('github')?.getValidAccessToken?.();
+/**
+ * Best-effort GitHub auth refresh for git network ops.
+ *
+ * - Default: expiry-gated {@link ProviderConfig.getValidAccessToken}, which
+ *   also re-syncs `/workspace/.git/github-token` from the live OAuth mask
+ *   so a stale `git config github.token` snapshot cannot win (#2777).
+ * - `force: true`: call {@link ProviderConfig.onSilentRenew} once (used by
+ *   isomorphic-git `onAuthFailure` after a 401) so an access token that is
+ *   still inside its local expiry window but rejected upstream can rotate.
+ */
+async function ensureFreshGithubToken(opts?: { force?: boolean }): Promise<void> {
+  const github = getRegisteredProviderConfig('github');
+  if (!github) return;
+  if (opts?.force) {
+    await github.onSilentRenew?.();
+    return;
+  }
+  await github.getValidAccessToken?.();
 }
 
 type BashExecOptionsWithSignal = NonNullable<Parameters<Bash['exec']>[1]> & {

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -313,6 +313,78 @@ describe('GitCommands', () => {
     }
   });
 
+  it('onAuthFailure force-renews once and retries with the refreshed bridge token (#2777)', async () => {
+    const globalFs = await VirtualFS.create({ dbName: globalDbName });
+    await globalFs.writeFile('/workspace/.git/github-token', 'ghp_masked_stale');
+    const ensureFreshGithubToken = vi.fn(async (opts?: { force?: boolean }) => {
+      if (opts?.force) {
+        await globalFs.writeFile('/workspace/.git/github-token', 'ghp_masked_renewed');
+      }
+    });
+    const renewingGit = new GitCommands({
+      fs: vfs,
+      globalDbName,
+      ensureFreshGithubToken,
+    });
+    const cloneSpy = vi.spyOn(isoGit, 'clone').mockResolvedValue();
+    const listFilesSpy = vi.spyOn(isoGit, 'listFiles').mockResolvedValue([]);
+
+    try {
+      const result = await renewingGit.execute(
+        ['clone', 'https://github.com/example/repo.git', 'repo'],
+        '/workspace'
+      );
+      expect(result.exitCode).toBe(0);
+      expect(ensureFreshGithubToken).toHaveBeenCalled();
+      const cloneOptions = cloneSpy.mock.calls[0]?.[0] as {
+        onAuth?: () => { username: string; password: string };
+        onAuthFailure?: () => Promise<{ username: string; password: string } | undefined>;
+      };
+      expect(cloneOptions.onAuthFailure).toBeTypeOf('function');
+
+      const retryAuth = await cloneOptions.onAuthFailure?.();
+      expect(ensureFreshGithubToken).toHaveBeenCalledWith({ force: true });
+      expect(retryAuth).toEqual({
+        username: 'x-access-token',
+        password: 'ghp_masked_renewed',
+      });
+
+      // Second failure must not loop forever.
+      await expect(cloneOptions.onAuthFailure?.()).resolves.toBeUndefined();
+      expect(ensureFreshGithubToken.mock.calls.filter((c) => c[0]?.force).length).toBe(1);
+    } finally {
+      cloneSpy.mockRestore();
+      listFilesSpy.mockRestore();
+    }
+  });
+
+  it('annotates push 401 errors with an actionable GitHub-auth hint (#2777)', async () => {
+    const globalFs = await VirtualFS.create({ dbName: globalDbName });
+    await globalFs.writeFile('/workspace/.git/github-token', 'ghp_masked');
+    await git.execute(['init'], '/project');
+    await git.execute(['commit', '--allow-empty', '-m', 'init'], '/project');
+    await git.execute(
+      ['remote', 'add', 'origin', 'https://github.com/example/repo.git'],
+      '/project'
+    );
+
+    const pushSpy = vi.spyOn(isoGit, 'push').mockResolvedValue({
+      ok: false,
+      error: 'HTTP Error: 401 Unauthorized',
+      refs: {},
+    } as never);
+
+    try {
+      const result = await git.execute(['push', 'origin', 'main'], '/project');
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('HTTP Error: 401 Unauthorized');
+      expect(result.stderr).toContain('hint:');
+      expect(result.stderr).toContain('oauth-token github');
+    } finally {
+      pushSpy.mockRestore();
+    }
+  });
+
   describe('GH_TOKEN / GITHUB_TOKEN env fallback', () => {
     // Pull the onAuth callback that GitCommands hands to isomorphic-git for a
     // clone invocation. Works for both Map<string,string> and Record<string,string>

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -361,7 +361,7 @@ describe('GitCommands', () => {
   it('gives each overlapping network command its own onAuthFailure latch (#2777)', async () => {
     const globalFs = await VirtualFS.create({ dbName: globalDbName });
     await globalFs.writeFile('/workspace/.git/github-token', 'ghp_masked');
-    const ensureFreshGithubToken = vi.fn(async () => {});
+    const ensureFreshGithubToken = vi.fn(async (_opts?: { force?: boolean }) => {});
     const renewingGit = new GitCommands({
       fs: vfs,
       globalDbName,
@@ -388,7 +388,11 @@ describe('GitCommands', () => {
         username: 'x-access-token',
         password: 'ghp_masked',
       });
-      expect(ensureFreshGithubToken.mock.calls.filter((c) => c[0]?.force).length).toBe(2);
+      expect(
+        ensureFreshGithubToken.mock.calls.filter(
+          (c) => (c[0] as { force?: boolean } | undefined)?.force
+        ).length
+      ).toBe(2);
     } finally {
       cloneSpy.mockRestore();
       listFilesSpy.mockRestore();

--- a/packages/webapp/tests/git/git-commands.test.ts
+++ b/packages/webapp/tests/git/git-commands.test.ts
@@ -358,6 +358,43 @@ describe('GitCommands', () => {
     }
   });
 
+  it('gives each overlapping network command its own onAuthFailure latch (#2777)', async () => {
+    const globalFs = await VirtualFS.create({ dbName: globalDbName });
+    await globalFs.writeFile('/workspace/.git/github-token', 'ghp_masked');
+    const ensureFreshGithubToken = vi.fn(async () => {});
+    const renewingGit = new GitCommands({
+      fs: vfs,
+      globalDbName,
+      ensureFreshGithubToken,
+    });
+    const cloneSpy = vi.spyOn(isoGit, 'clone').mockResolvedValue();
+    const listFilesSpy = vi.spyOn(isoGit, 'listFiles').mockResolvedValue([]);
+
+    try {
+      await renewingGit.execute(['clone', 'https://github.com/example/a.git', 'a'], '/workspace');
+      await renewingGit.execute(['clone', 'https://github.com/example/b.git', 'b'], '/workspace');
+      const first = cloneSpy.mock.calls[0]?.[0] as {
+        onAuthFailure?: () => Promise<{ username: string; password: string } | undefined>;
+      };
+      const second = cloneSpy.mock.calls[1]?.[0] as {
+        onAuthFailure?: () => Promise<{ username: string; password: string } | undefined>;
+      };
+      expect(first.onAuthFailure).not.toBe(second.onAuthFailure);
+
+      await first.onAuthFailure?.();
+      // First latch is spent, but the second command still gets its own retry.
+      await expect(first.onAuthFailure?.()).resolves.toBeUndefined();
+      await expect(second.onAuthFailure?.()).resolves.toEqual({
+        username: 'x-access-token',
+        password: 'ghp_masked',
+      });
+      expect(ensureFreshGithubToken.mock.calls.filter((c) => c[0]?.force).length).toBe(2);
+    } finally {
+      cloneSpy.mockRestore();
+      listFilesSpy.mockRestore();
+    }
+  });
+
   it('annotates push 401 errors with an actionable GitHub-auth hint (#2777)', async () => {
     const globalFs = await VirtualFS.create({ dbName: globalDbName });
     await globalFs.writeFile('/workspace/.git/github-token', 'ghp_masked');
@@ -380,6 +417,31 @@ describe('GitCommands', () => {
       expect(result.stderr).toContain('HTTP Error: 401 Unauthorized');
       expect(result.stderr).toContain('hint:');
       expect(result.stderr).toContain('oauth-token github');
+    } finally {
+      pushSpy.mockRestore();
+    }
+  });
+
+  it('does not suggest oauth-token github for a non-GitHub push 401 (#2777)', async () => {
+    await git.execute(['init'], '/gitlab');
+    await git.execute(['commit', '--allow-empty', '-m', 'init'], '/gitlab');
+    await git.execute(
+      ['remote', 'add', 'origin', 'https://gitlab.com/example/repo.git'],
+      '/gitlab'
+    );
+
+    const pushSpy = vi.spyOn(isoGit, 'push').mockResolvedValue({
+      ok: false,
+      error: 'HTTP Error: 401 Unauthorized',
+      refs: {},
+    } as never);
+
+    try {
+      const result = await git.execute(['push', 'origin', 'main'], '/gitlab');
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('HTTP Error: 401 Unauthorized');
+      expect(result.stderr).not.toContain('oauth-token github');
+      expect(result.stderr).not.toContain('GitHub returned 401');
     } finally {
       pushSpy.mockRestore();
     }

--- a/packages/webapp/tests/git/git-error-format.test.ts
+++ b/packages/webapp/tests/git/git-error-format.test.ts
@@ -5,7 +5,11 @@
  * "There are multiple errors..." text (#1033-5).
  */
 import { describe, expect, it } from 'vitest';
-import { expandGitError } from '../../src/git/commands/shared.js';
+import {
+  annotateGitHubAuthFailure,
+  expandGitError,
+  isGitHubRemoteUrl,
+} from '../../src/git/commands/shared.js';
 
 class MultipleGitError extends Error {
   override name = 'MultipleGitError';
@@ -59,16 +63,34 @@ describe('expandGitError', () => {
     expect(expandGitError(new Error('plain failure'))).toBe('plain failure');
   });
 
-  it('annotates a bare GitHub 401 with an actionable hint (#2777)', () => {
+  it('annotates an unknown-host 401 with a provider-neutral hint (#2777)', () => {
     const message = expandGitError(new Error('HTTP Error: 401 Unauthorized'));
     expect(message).toContain('HTTP Error: 401 Unauthorized');
     expect(message).toContain('hint:');
+    expect(message).toContain('Authentication failed (401)');
+    expect(message).toContain('If this is GitHub');
+  });
+
+  it('uses the GitHub-specific hint when the remote URL is GitHub', () => {
+    const message = expandGitError(
+      new Error('HTTP Error: 401 Unauthorized'),
+      'https://github.com/example/repo.git'
+    );
+    expect(message).toContain('GitHub returned 401');
     expect(message).toContain('oauth-token github');
     expect(message).toContain('stale');
   });
 
-  it('annotates a non-Error 401 string the same way', () => {
-    expect(expandGitError('HTTP Error: 401 Unauthorized')).toContain('hint:');
+  it('does not blame GitHub OAuth for a non-GitHub remote 401', () => {
+    const message = expandGitError(
+      new Error('HTTP Error: 401 Unauthorized'),
+      'https://gitlab.com/example/repo.git'
+    );
+    expect(message).toBe('HTTP Error: 401 Unauthorized');
+  });
+
+  it('annotates a non-Error unknown-host 401 string neutrally', () => {
+    expect(expandGitError('HTTP Error: 401 Unauthorized')).toContain('Authentication failed (401)');
   });
 
   it('leaves non-auth failures alone', () => {
@@ -80,6 +102,21 @@ describe('expandGitError', () => {
   it('stringifies a non-Error value', () => {
     expect(expandGitError('boom')).toBe('boom');
     expect(expandGitError(42)).toBe('42');
+  });
+});
+
+describe('isGitHubRemoteUrl / annotateGitHubAuthFailure', () => {
+  it('recognizes common GitHub remote forms', () => {
+    expect(isGitHubRemoteUrl('https://github.com/o/r.git')).toBe(true);
+    expect(isGitHubRemoteUrl('git@github.com:o/r.git')).toBe(true);
+    expect(isGitHubRemoteUrl('ssh://git@github.com/o/r.git')).toBe(true);
+    expect(isGitHubRemoteUrl('https://gitlab.com/o/r.git')).toBe(false);
+  });
+
+  it('keeps annotateGitHubAuthFailure silent for non-GitHub URLs', () => {
+    expect(
+      annotateGitHubAuthFailure('HTTP Error: 401 Unauthorized', 'https://bitbucket.org/o/r.git')
+    ).toBe('HTTP Error: 401 Unauthorized');
   });
 });
 

--- a/packages/webapp/tests/git/git-error-format.test.ts
+++ b/packages/webapp/tests/git/git-error-format.test.ts
@@ -59,6 +59,24 @@ describe('expandGitError', () => {
     expect(expandGitError(new Error('plain failure'))).toBe('plain failure');
   });
 
+  it('annotates a bare GitHub 401 with an actionable hint (#2777)', () => {
+    const message = expandGitError(new Error('HTTP Error: 401 Unauthorized'));
+    expect(message).toContain('HTTP Error: 401 Unauthorized');
+    expect(message).toContain('hint:');
+    expect(message).toContain('oauth-token github');
+    expect(message).toContain('stale');
+  });
+
+  it('annotates a non-Error 401 string the same way', () => {
+    expect(expandGitError('HTTP Error: 401 Unauthorized')).toContain('hint:');
+  });
+
+  it('leaves non-auth failures alone', () => {
+    expect(expandGitError(new Error('remote hung up unexpectedly'))).toBe(
+      'remote hung up unexpectedly'
+    );
+  });
+
   it('stringifies a non-Error value', () => {
     expect(expandGitError('boom')).toBe('boom');
     expect(expandGitError(42)).toBe('42');

--- a/packages/webapp/tests/git/git-readonly-no-index-writes.test.ts
+++ b/packages/webapp/tests/git/git-readonly-no-index-writes.test.ts
@@ -72,6 +72,7 @@ function makeCtx(vfs: VirtualFS, lfs: IsoGitFsPromises): GitCommandContext {
     fs: vfs,
     cache: {},
     getOnAuth: () => undefined,
+    getOnAuthFailure: () => undefined,
     resolveAuthor: async () => ({ name: 'Test User', email: 'test@example.com' }),
     getGlobalFs: async () => vfs,
     setGithubToken: async () => {},

--- a/packages/webapp/tests/providers/github-token-renewal.test.ts
+++ b/packages/webapp/tests/providers/github-token-renewal.test.ts
@@ -189,6 +189,27 @@ describe('GitHub token renewal', () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  it('re-syncs the git bridge from the live OAuth mask even when the access token is still fresh (#2777)', async () => {
+    seedGitHubAccount({
+      accessToken: 'ghp_fresh',
+      refreshToken: 'ghr_fresh',
+      tokenExpiresAt: Date.now() + 3_600_000,
+      maskedValue: 'ghp_masked_live',
+    });
+    globalThis.fetch = vi.fn() as typeof fetch;
+    const { VirtualFS } = await import('../../src/fs/index.js');
+    const { GLOBAL_FS_DB_NAME } = await import('../../src/fs/global-db.js');
+    const fs = await VirtualFS.create({ dbName: GLOBAL_FS_DB_NAME });
+    await fs.writeFile('/workspace/.git/github-token', 'ghp_masked_stale_snapshot');
+    const { getValidAccessToken } = await import('../../providers/github.js');
+
+    await expect(getValidAccessToken()).resolves.toBe('ghp_fresh');
+    await expect(fs.readFile('/workspace/.git/github-token', { encoding: 'utf-8' })).resolves.toBe(
+      'ghp_masked_live'
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it('transparently renews an expiring access token', async () => {
     seedGitHubAccount({
       accessToken: 'ghp_expiring',

--- a/packages/webapp/tests/shell/almost-bash-shell.test.ts
+++ b/packages/webapp/tests/shell/almost-bash-shell.test.ts
@@ -312,6 +312,7 @@ describe('AlmostBashShellHeadless GitHub token renewal wiring', () => {
   it('uses the registered expiry-gated hook only for git network operations', async () => {
     const fs = await VirtualFS.create({ dbName: 'test-shell-github-renewal', wipe: true });
     const getValidAccessToken = vi.fn(async () => 'ghp_fresh');
+    const onSilentRenew = vi.fn(async () => 'ghp_forced');
     registerProviderConfig({
       id: 'github',
       name: 'GitHub',
@@ -319,12 +320,14 @@ describe('AlmostBashShellHeadless GitHub token renewal wiring', () => {
       requiresApiKey: false,
       requiresBaseUrl: false,
       getValidAccessToken,
+      onSilentRenew,
     });
 
     try {
       const shell = new AlmostBashShellHeadless({ fs });
       await shell.executeCommand('git fetch');
       expect(getValidAccessToken).toHaveBeenCalledTimes(1);
+      expect(onSilentRenew).not.toHaveBeenCalled();
 
       await shell.executeCommand('git status');
       expect(getValidAccessToken).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- Re-sync `/workspace/.git/github-token` from the live OAuth masked value on every network op (even when the access token is still fresh), so a hand-written `git config github.token "$(oauth-token github)"` snapshot cannot win over the broker (#2777).
- On GitHub 401, force one silent renew via `onAuthFailure` and retry once; if it still fails, annotate the error with an actionable hint pointing at `oauth-token github` / Settings → Providers → GitHub.
- Document that `github.token` snapshots are not durable and that OAuth login owns the git bridge.

Closes #2777.

## Test plan
- [x] `npm run verify`
- [x] `npm run typecheck`
- [x] `npm run test` / `npm run test:coverage`
- [x] `npm run build` + extension build + `npm run bundle-size`
- [x] Unit: fresh `getValidAccessToken` overwrites a stale bridge file
- [x] Unit: `onAuthFailure` force-renews once and does not loop
- [x] Unit: push / `expandGitError` annotate bare `401 Unauthorized`
- [ ] Manual: `oauth-token github --expire`, then `git push` renews without a bare 401
- [ ] Manual: plant a stale `git config github.token`, confirm next network op rewrites the bridge from OAuth


Made with [Cursor](https://cursor.com)