### PR TITLE
chore(coverage): ratchet coverage floors

### DIFF
--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -73,7 +73,7 @@
       "lines": 84,
       "statements": 82,
       "functions": 82,
-      "branches": 73,
+      "branches": 74,
       "coverageExclude": [
         "**/node_modules/**",
         "**/dist/**",
@@ -134,7 +134,7 @@
     "swift-server": {
       "lines": 65,
       "functions": 64,
-      "regions": 62
+      "regions": 63
     },
     "swift-launcher": {
       "lines": 80,


### PR DESCRIPTION
Automated nightly bump of `coverage-thresholds.json` toward measured coverage. Floors only ever rise (>=1pp steps, <1% headroom); no PR is opened when nothing changed.