### PR TITLE
fix(webapp): unmask Adobe OAuth tokens for api.aem.live

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -31,7 +31,7 @@ Each secret needs two lines: `NAME=value` and `NAME_DOMAINS=domain1,domain2`. A 
 
 ### Extending OAuth-token allowed domains
 
-Each provider hardcodes a sane default list of domains its OAuth token may be unmasked for (e.g. Adobe defaults to `*.adobelogin.com`, `*.adobe.io`, `firefall.adobe.io`). To use that token against other services — for example, `admin.da.live` for Document Authoring — you can **layer extra domains on top per-provider** without code changes. Provider defaults remain immutable.
+Each provider hardcodes a sane default list of domains its OAuth token may be unmasked for (e.g. Adobe defaults to `*.adobelogin.com`, `*.adobe.io`, `firefall.adobe.io`, the Helix admin hosts, and `api.aem.live` for the Helix 6 Source Bus). To use that token against other services — for example, `admin.da.live` for Document Authoring — you can **layer extra domains on top per-provider** without code changes. Provider defaults remain immutable.
 
 Manage with the `oauth-domain` shell command:
 

--- a/packages/webapp/providers/adobe.ts
+++ b/packages/webapp/providers/adobe.ts
@@ -275,6 +275,7 @@ export const config: ProviderConfig = {
     'admin.hlx.live',
     'admin.aem.page',
     'admin.aem.live',
+    'api.aem.live',
   ],
 
   getModelIds: () => {

--- a/packages/webapp/tests/providers/oauth-config.test.ts
+++ b/packages/webapp/tests/providers/oauth-config.test.ts
@@ -14,5 +14,6 @@ describe('OAuth provider domain config', () => {
     expect(adobeProvider.oauthTokenDomains).toContain('admin.hlx.live');
     expect(adobeProvider.oauthTokenDomains).toContain('admin.aem.page');
     expect(adobeProvider.oauthTokenDomains).toContain('admin.aem.live');
+    expect(adobeProvider.oauthTokenDomains).toContain('api.aem.live');
   });
 });


### PR DESCRIPTION
## Summary

Add `api.aem.live` to Adobe's default `oauthTokenDomains` so the fetch proxy unmasks `$(oauth-token adobe)` when calling the Helix 6 Source Bus.

Mounts already attached the IMS bearer to `https://api.aem.live` via sign-and-forward. A `curl` with the masked Adobe token did not, because `admin.aem.live` is an exact host and does not cover `api.aem.live`.

## Why

`api.aem.live` is the Helix 6 Source Bus. It uses the same Adobe IMS bearer as `admin.da.live`. Without this host on the unmask list, agent HTTP to the Source Bus kept the masked token (or 403'd on header unmask) unless the user ran `oauth-domain add adobe api.aem.live`.

## Approach / Implementation notes

- Exact host `api.aem.live`, not `*.aem.live` — a wildcard would unmask the IMS token for customer delivery hosts.
- Sign-and-forward's `DA_ALLOWED_ORIGINS` already included this origin; this change only covers the fetch-proxy unmask path.

## Cross-cutting impact

- **Floats exercised**: CLI and Chrome extension fetch-proxy unmask (same `oauthTokenDomains` merge). Mount backends unchanged.
- **Security**: closed allowlist grows by one first-party Adobe host. Existing extras via `oauth-domain` still layer on top.

## Test plan

- [x] `npm run verify` — 8/8 lint-gate checks passed
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists
- [x] `npm run typecheck`
- [x] `npm run test` — 19081 passed, 46 skipped
- [x] `npm run test:coverage`
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load +0.0 kB vs merge-base
- [x] `npx vitest run packages/webapp/tests/providers/oauth-config.test.ts` — asserts `api.aem.live` is in Adobe defaults
- [ ] N/A — no UI change; no screencast

## Documentation

- [x] `docs/secrets.md` — Adobe default-domain example now names `api.aem.live`

## Risk & rollback

- Blast radius: Adobe OAuth unmask only. Revert this PR to drop the host again.
- Existing `oauth-domain add adobe api.aem.live` extras remain valid (deduped case-insensitively).

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs