### PR TITLE
fix(transcript): stop export redaction from corrupting schema-controlled fields

### DIFF
--- a/docs/transcript-export.md
+++ b/docs/transcript-export.md
@@ -170,6 +170,25 @@ Redaction is **fail-closed**: if the redactor cannot initialize, the export abor
 Each redaction entry in `privacy.redactions[]` records the detector, category, and JSON
 Pointer to the redacted location. `privacy.redactionCounts` gives per-category totals.
 
+#### Schema-controlled fields are never redacted
+
+Both detectors run over every _content-bearing_ string in the document — `session.title`,
+conversation names and folders, message text, tool-call `input`, message `error`, and
+`attachments[].originalName` — plus the text attachments themselves.
+
+They deliberately skip the **schema-controlled** fields: enum discriminators
+(`session.state`, `conversations[].kind`, message `role`, content-block `type`,
+`attachments[].handling`), ISO timestamps, SHA-256 hexes, bundle paths, and the ids the
+relational checks join on. Those are machine-generated and cannot carry a secret, while
+known-secret redaction is plain substring replacement — so a stored secret value that merely
+_occurs_ inside one of them would rewrite it into something `validateTranscriptDocumentV1`
+rejects, failing the whole export instead of the one field. A one-character secret makes that
+certain: it turns `"active"` into `"acti⟦REDACTED:…⟧e"`.
+
+The list lives in `isStructuralTranscriptPointer()`
+(`packages/shared-ts/src/transcript-export.ts`), next to the validator that constrains the same
+fields. A field that gains a constraint in the validator needs an entry there too.
+
 ### Binary attachments — unchanged and potentially sensitive
 
 Text attachments (`text/*` MIME types) are redacted inline before export. Binary attachments
@@ -358,15 +377,15 @@ Any export can be cancelled via `AbortSignal`. On cancellation:
 
 ### Stable error codes
 
-| Code                    | Cause                                                                                                                                                            | Retry?                                                                                                                           |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `permission-denied`     | User denied the approval dialog. In the cloud float this also covers a delegated prompt that timed out (120 s), was never shown, or whose follower disconnected. | Only after a new approval.                                                                                                       |
-| `redaction-unavailable` | Redactor failed to initialize.                                                                                                                                   | Not useful — log and report.                                                                                                     |
-| `session-not-found`     | The export service is not registered, or the frozen session ID does not exist.                                                                                   | Wait for boot to complete, or check the session ID.                                                                              |
-| `transfer-aborted`      | Cancelled or disconnected mid-stream.                                                                                                                            | Retry from start — no partial resume.                                                                                            |
-| `transfer-corrupt`      | Byte length or SHA-256 mismatch.                                                                                                                                 | Retry from start — the entire transfer must be re-run.                                                                           |
-| `schema-invalid`        | The assembled transcript failed v1 validation.                                                                                                                   | Report as a bug.                                                                                                                 |
-| `attachment-unreadable` | A text attachment could not be decoded or redacted (fail-closed safety guard).                                                                                   | Do not retry — report as a bug. Binary or missing files do NOT throw this error; they complete as partial with `present: false`. |
+| Code                    | Cause                                                                                                                                                                                                     | Retry?                                                                                                                           |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `permission-denied`     | User denied the approval dialog. In the cloud float this also covers a delegated prompt that timed out (120 s), was never shown, or whose follower disconnected.                                          | Only after a new approval.                                                                                                       |
+| `redaction-unavailable` | Redactor failed to initialize.                                                                                                                                                                            | Not useful — log and report.                                                                                                     |
+| `session-not-found`     | The export service is not registered, or the frozen session ID does not exist.                                                                                                                            | Wait for boot to complete, or check the session ID.                                                                              |
+| `transfer-aborted`      | Cancelled or disconnected mid-stream.                                                                                                                                                                     | Retry from start — no partial resume.                                                                                            |
+| `transfer-corrupt`      | Byte length or SHA-256 mismatch.                                                                                                                                                                          | Retry from start — the entire transfer must be re-run.                                                                           |
+| `schema-invalid`        | The assembled transcript failed v1 validation. The thrown error's `detail` carries the validator's own message (e.g. `session.state must be "active" or "frozen"`); the wire code stays `schema-invalid`. | Report as a bug, with the `detail`.                                                                                              |
+| `attachment-unreadable` | A text attachment could not be decoded or redacted (fail-closed safety guard).                                                                                                                            | Do not retry — report as a bug. Binary or missing files do NOT throw this error; they complete as partial with `present: false`. |
 
 ### Retry semantics
 

--- a/docs/transcript-export.md
+++ b/docs/transcript-export.md
@@ -172,22 +172,33 @@ Pointer to the redacted location. `privacy.redactionCounts` gives per-category t
 
 #### Schema-controlled fields are never redacted
 
-Both detectors run over every _content-bearing_ string in the document — `session.title`,
-conversation names and folders, message text, tool-call `input`, message `error`, and
-`attachments[].originalName` — plus the text attachments themselves.
+Both detectors run over every string in the document **except** two narrow categories, so
+redaction is fail-closed by default — `session.title`, conversation names and folders, message
+text, message `error`, `source`, `channel`, `stopReason`, `model.*`, tool-call `input`, and
+`attachments[].originalName` / `.mimeType` are all still redacted, as are the text attachments.
 
-They deliberately skip the **schema-controlled** fields: enum discriminators
-(`session.state`, `conversations[].kind`, message `role`, content-block `type`,
-`attachments[].handling`), ISO timestamps, SHA-256 hexes, bundle paths, and the ids the
-relational checks join on. Those are machine-generated and cannot carry a secret, while
-known-secret redaction is plain substring replacement — so a stored secret value that merely
-_occurs_ inside one of them would rewrite it into something `validateTranscriptDocumentV1`
-rejects, failing the whole export instead of the one field. A one-character secret makes that
-certain: it turns `"active"` into `"acti⟦REDACTED:…⟧e"`.
+The two exempt categories:
+
+1. **Validator-constrained** — corrupting them fails `validateTranscriptDocumentV1`: the enum
+   discriminators (`session.state`, `session.completeness.status`, `export.format`,
+   `export.producer.application`, `conversations[].kind`, message `role`, content-block `type`,
+   `attachments[].handling` / `.missingReason`), the ISO message `timestamp`, the SHA-256 hex,
+   the bundle `path`, the non-empty tool-call `id` / `name`, and the ids the relational checks
+   join on.
+2. **Join mirrors** — `session.id` and `conversations[].parentConversationId` are not themselves
+   constrained, but each holds a copy of a `conversations[].id` from category 1. Redacting one
+   side and not the other would silently desync the link.
+
+The reason these have to be exempt: known-secret redaction is plain substring replacement, so a
+stored secret value that merely _occurs_ inside one of them would rewrite it into something the
+validator rejects, failing the whole export instead of the one field. A one-character secret makes
+that certain — it turns `"active"` into `"acti⟦REDACTED:…⟧e"`.
 
 The list lives in `isStructuralTranscriptPointer()`
 (`packages/shared-ts/src/transcript-export.ts`), next to the validator that constrains the same
-fields. A field that gains a constraint in the validator needs an entry there too.
+fields. Adding an entry is fail-open, so category 1 must stay in step with the validator: a field
+that gains a constraint there needs an entry here, and a field that loses one should lose its
+entry.
 
 ### Binary attachments — unchanged and potentially sensitive
 

--- a/packages/shared-ts/src/transcript-export.ts
+++ b/packages/shared-ts/src/transcript-export.ts
@@ -188,57 +188,52 @@ export interface TranscriptDocumentV1 {
 // ---------------------------------------------------------------------------
 
 /**
- * RFC 6901 pointers of every string field this schema *constrains* — with
- * array indices normalized to `*`.
- *
- * These are machine-generated: enum discriminators, ISO timestamps, SHA-256
- * hexes, bundle paths and the ids the relational checks below join on. None of
- * them can carry a user or model secret, and all of them are validated by
- * {@link validateTranscriptDocumentV1}.
+ * RFC 6901 pointers of the string fields export redaction must leave
+ * byte-for-byte intact — with array indices normalized to a wildcard segment.
  *
  * Export redaction substitutes known-secret values by plain substring
- * replacement, so any secret value that happens to occur inside one of these
- * fields rewrites it into something the validator then rejects — failing the
- * whole export rather than the one field (#2845). A one-character secret makes
- * that a certainty: `"active"` becomes `"acti⟦REDACTED:…⟧e"` and
+ * replacement, so a secret value that happens to occur inside one of these
+ * fields would rewrite it and break the document (#2845). A one-character
+ * secret makes that a certainty: `"active"` becomes `"acti⟦REDACTED:…⟧e"` and
  * `session.state` no longer matches its enum.
  *
- * Content-bearing siblings are deliberately ABSENT and stay fully redacted:
- * `session.title`, `conversations[].name` / `.folder`, message `.error`,
- * content-block `.text`, tool-call `.input`, and `attachments[].originalName`.
+ * Two categories, and nothing else — every other field stays redacted, so
+ * export remains fail-closed by default:
  *
- * Keep this list in step with the validator: a field that gains a constraint
+ *  1. **Validator-constrained.** Corrupting these fails
+ *     {@link validateTranscriptDocumentV1}: enum discriminators, the ISO
+ *     message timestamp, the SHA-256 hex, the bundle path, non-empty
+ *     tool-call ids, and the ids its relational checks join on.
+ *  2. **Join mirrors.** `conversations[].parentConversationId` and
+ *     `session.id` are not constrained beyond being strings, but each holds a
+ *     copy of a `conversations[].id` from category 1 — `session.id` is the
+ *     cone's own id on the active path. Redacting one side and not the other
+ *     would silently desync the link, so they follow the id they mirror.
+ *
+ * Deliberately ABSENT and still fully redacted: `session.title`,
+ * `conversations[].name` / `.folder`, message `.error` / `.source` /
+ * `.channel` / `.stopReason` / `.model.*`, content-block `.text`, tool-call
+ * `.input`, `attachments[].originalName` / `.mimeType` (redacted metadata by
+ * design — the handling and path decisions read the pre-redaction pending
+ * record), and every unvalidated `createdAt` / `updatedAt` / `generatedAt`.
+ *
+ * Keep category 1 in step with the validator: a field that gains a constraint
  * there needs an entry here, or a secret occurring inside it fails the export.
  */
 const STRUCTURAL_TRANSCRIPT_POINTERS: ReadonlySet<string> = new Set([
-  '/export/id',
-  '/export/generatedAt',
   '/export/format',
   '/export/producer/application',
-  '/export/producer/version',
   '/session/id',
   '/session/state',
-  '/session/createdAt',
-  '/session/updatedAt',
-  '/session/frozenAt',
-  '/session/snapshotAt',
   '/session/completeness/status',
   '/session/completeness/missing/*',
   '/conversations/*/id',
   '/conversations/*/kind',
   '/conversations/*/parentConversationId',
-  '/conversations/*/createdAt',
-  '/conversations/*/updatedAt',
   '/conversations/*/messages/*/id',
   '/conversations/*/messages/*/role',
   '/conversations/*/messages/*/timestamp',
   '/conversations/*/messages/*/toolCallId',
-  '/conversations/*/messages/*/source',
-  '/conversations/*/messages/*/channel',
-  '/conversations/*/messages/*/stopReason',
-  '/conversations/*/messages/*/model/provider',
-  '/conversations/*/messages/*/model/id',
-  '/conversations/*/messages/*/model/api',
   '/conversations/*/messages/*/content/*/type',
   '/conversations/*/messages/*/content/*/id',
   '/conversations/*/messages/*/content/*/name',
@@ -246,10 +241,8 @@ const STRUCTURAL_TRANSCRIPT_POINTERS: ReadonlySet<string> = new Set([
   '/delegations/*/sourceConversationId',
   '/delegations/*/targetConversationId',
   '/delegations/*/toolCallId',
-  '/delegations/*/timestamp',
   '/attachments/*/id',
   '/attachments/*/path',
-  '/attachments/*/mimeType',
   '/attachments/*/sha256',
   '/attachments/*/sourceConversationId',
   '/attachments/*/sourceMessageId',

--- a/packages/shared-ts/src/transcript-export.ts
+++ b/packages/shared-ts/src/transcript-export.ts
@@ -184,12 +184,114 @@ export interface TranscriptDocumentV1 {
 }
 
 // ---------------------------------------------------------------------------
+// Structural (schema-controlled) field pointers
+// ---------------------------------------------------------------------------
+
+/**
+ * RFC 6901 pointers of every string field this schema *constrains* — with
+ * array indices normalized to `*`.
+ *
+ * These are machine-generated: enum discriminators, ISO timestamps, SHA-256
+ * hexes, bundle paths and the ids the relational checks below join on. None of
+ * them can carry a user or model secret, and all of them are validated by
+ * {@link validateTranscriptDocumentV1}.
+ *
+ * Export redaction substitutes known-secret values by plain substring
+ * replacement, so any secret value that happens to occur inside one of these
+ * fields rewrites it into something the validator then rejects — failing the
+ * whole export rather than the one field (#2845). A one-character secret makes
+ * that a certainty: `"active"` becomes `"acti⟦REDACTED:…⟧e"` and
+ * `session.state` no longer matches its enum.
+ *
+ * Content-bearing siblings are deliberately ABSENT and stay fully redacted:
+ * `session.title`, `conversations[].name` / `.folder`, message `.error`,
+ * content-block `.text`, tool-call `.input`, and `attachments[].originalName`.
+ *
+ * Keep this list in step with the validator: a field that gains a constraint
+ * there needs an entry here, or a secret occurring inside it fails the export.
+ */
+const STRUCTURAL_TRANSCRIPT_POINTERS: ReadonlySet<string> = new Set([
+  '/export/id',
+  '/export/generatedAt',
+  '/export/format',
+  '/export/producer/application',
+  '/export/producer/version',
+  '/session/id',
+  '/session/state',
+  '/session/createdAt',
+  '/session/updatedAt',
+  '/session/frozenAt',
+  '/session/snapshotAt',
+  '/session/completeness/status',
+  '/session/completeness/missing/*',
+  '/conversations/*/id',
+  '/conversations/*/kind',
+  '/conversations/*/parentConversationId',
+  '/conversations/*/createdAt',
+  '/conversations/*/updatedAt',
+  '/conversations/*/messages/*/id',
+  '/conversations/*/messages/*/role',
+  '/conversations/*/messages/*/timestamp',
+  '/conversations/*/messages/*/toolCallId',
+  '/conversations/*/messages/*/source',
+  '/conversations/*/messages/*/channel',
+  '/conversations/*/messages/*/stopReason',
+  '/conversations/*/messages/*/model/provider',
+  '/conversations/*/messages/*/model/id',
+  '/conversations/*/messages/*/model/api',
+  '/conversations/*/messages/*/content/*/type',
+  '/conversations/*/messages/*/content/*/id',
+  '/conversations/*/messages/*/content/*/name',
+  '/conversations/*/messages/*/content/*/attachmentId',
+  '/delegations/*/sourceConversationId',
+  '/delegations/*/targetConversationId',
+  '/delegations/*/toolCallId',
+  '/delegations/*/timestamp',
+  '/attachments/*/id',
+  '/attachments/*/path',
+  '/attachments/*/mimeType',
+  '/attachments/*/sha256',
+  '/attachments/*/sourceConversationId',
+  '/attachments/*/sourceMessageId',
+  '/attachments/*/handling',
+  '/attachments/*/missingReason',
+]);
+
+/**
+ * True when `pointer` addresses a schema-controlled string field that export
+ * redaction must leave byte-for-byte intact.
+ *
+ * `pointer` is an RFC 6901 pointer into a {@link TranscriptDocumentV1}, as
+ * produced by the transcript redactor's leaf walk. Array indices are
+ * normalized to a wildcard segment before lookup, so
+ * `/conversations/0/messages/7/role` matches the wildcard entry above.
+ *
+ * Arbitrary tool-call `input` payloads are walked with the same pointers, but
+ * every entry above is rooted at a fixed prefix that `input` never occurs
+ * under, so a numeric-keyed input object cannot alias onto one.
+ */
+export function isStructuralTranscriptPointer(pointer: string): boolean {
+  return STRUCTURAL_TRANSCRIPT_POINTERS.has(pointer.replace(/\/\d+(?=\/|$)/g, '/*'));
+}
+
+// ---------------------------------------------------------------------------
 // Error class
 // ---------------------------------------------------------------------------
 
 export class TranscriptExportError extends Error {
-  constructor(public readonly code: TranscriptExportErrorCode) {
-    super(code);
+  /**
+   * @param code   Canonical wire code. Every consumer (Cherry transport, tray
+   *               sync, `session export`) reads `.code`, never `.message`.
+   * @param detail Optional human-readable reason, folded into `.message` only.
+   *               A bare `schema-invalid` is undiagnosable from a console log,
+   *               so the throw site should pass the validator's own message
+   *               (#2845). Never widen the wire code to carry it.
+   */
+  constructor(
+    public readonly code: TranscriptExportErrorCode,
+    public readonly detail?: string
+  ) {
+    super(detail ? `${code}: ${detail}` : code);
     this.name = 'TranscriptExportError';
   }
 }

--- a/packages/shared-ts/tests/transcript-export.test.ts
+++ b/packages/shared-ts/tests/transcript-export.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isStructuralTranscriptPointer,
   SLICC_TRANSCRIPT_FORMAT,
   TRANSCRIPT_SCHEMA_VERSION,
   type TranscriptDocumentV1,
@@ -1796,5 +1797,52 @@ describe('validateTranscriptDocumentV1 — tool-result toolCallId enforcement', 
         })
       )
     ).toEqual({ ok: true });
+  });
+});
+
+describe('isStructuralTranscriptPointer', () => {
+  it('matches schema-controlled fields, with array indices normalized', () => {
+    for (const pointer of [
+      '/session/state',
+      '/session/completeness/status',
+      '/session/completeness/missing/0',
+      '/export/format',
+      '/export/producer/application',
+      '/conversations/0/kind',
+      '/conversations/12/messages/7/role',
+      '/conversations/0/messages/0/timestamp',
+      '/conversations/0/messages/0/content/2/type',
+      '/conversations/0/messages/0/content/2/id',
+      '/delegations/0/targetConversationId',
+      '/attachments/3/sha256',
+      '/attachments/3/path',
+      '/attachments/3/handling',
+    ]) {
+      expect(isStructuralTranscriptPointer(pointer)).toBe(true);
+    }
+  });
+
+  it('does not match content-bearing fields, which must stay redactable', () => {
+    for (const pointer of [
+      '/session/title',
+      '/conversations/0/name',
+      '/conversations/0/folder',
+      '/conversations/0/messages/0/content/0/text',
+      '/conversations/0/messages/0/error',
+      '/attachments/0/originalName',
+    ]) {
+      expect(isStructuralTranscriptPointer(pointer)).toBe(false);
+    }
+  });
+
+  it('does not let a numeric-keyed tool-call input alias onto a structural entry', () => {
+    // Arbitrary tool input is walked with the same pointers; every structural
+    // entry is rooted at a prefix `input` never occurs under.
+    expect(isStructuralTranscriptPointer('/conversations/0/messages/0/content/0/input/type')).toBe(
+      false
+    );
+    expect(isStructuralTranscriptPointer('/conversations/0/messages/0/content/0/input/0/id')).toBe(
+      false
+    );
   });
 });

--- a/packages/shared-ts/tests/transcript-export.test.ts
+++ b/packages/shared-ts/tests/transcript-export.test.ts
@@ -1835,6 +1835,63 @@ describe('isStructuralTranscriptPointer', () => {
     }
   });
 
+  it('does not match unconstrained fields — the set is not "everything machine-written"', () => {
+    // Exempting a field is fail-OPEN, so the set holds only what the validator
+    // constrains plus the ids those constrained fields join on. `source` and
+    // `channel` are free-form (a scoop name), `mimeType` is redacted metadata
+    // by design, and these timestamps are never parsed by the validator.
+    for (const pointer of [
+      '/conversations/0/messages/0/source',
+      '/conversations/0/messages/0/channel',
+      '/conversations/0/messages/0/stopReason',
+      '/conversations/0/messages/0/model/id',
+      '/conversations/0/messages/0/model/provider',
+      '/attachments/0/mimeType',
+      '/session/createdAt',
+      '/session/frozenAt',
+      '/conversations/0/updatedAt',
+      '/export/id',
+      '/export/generatedAt',
+      '/export/producer/version',
+      '/delegations/0/timestamp',
+    ]) {
+      expect(isStructuralTranscriptPointer(pointer)).toBe(false);
+    }
+  });
+
+  it('every category-1 pointer names a field the validator actually constrains', () => {
+    // Pins the JSDoc claim: break a constrained field and validation must
+    // fail. If a pointer here stops being constrained it belongs out of the
+    // set (or documented as a join mirror), not silently exempt.
+    const cases: Array<[string, (d: TranscriptDocumentV1) => void]> = [
+      ['session.state', (d) => Object.assign(d.session, { state: 'acti\u27e6X\u27e7e' })],
+      [
+        'session.completeness.status',
+        (d) => Object.assign(d.session.completeness, { status: 'x' }),
+      ],
+      ['export.format', (d) => Object.assign(d.export, { format: 'x' })],
+      [
+        'export.producer.application',
+        (d) => Object.assign(d.export.producer, { application: 'x' }),
+      ],
+      ['conversations[].kind', (d) => Object.assign(d.conversations[0]!, { kind: 'x' })],
+      ['messages[].role', (d) => Object.assign(d.conversations[0]!.messages[0]!, { role: 'x' })],
+      [
+        'messages[].timestamp',
+        (d) => Object.assign(d.conversations[0]!.messages[0]!, { timestamp: 'x' }),
+      ],
+      [
+        'content[].type',
+        (d) => Object.assign(d.conversations[0]!.messages[0]!.content[0]!, { type: 'x' }),
+      ],
+    ];
+    for (const [label, corrupt] of cases) {
+      const doc = completeDocument();
+      corrupt(doc);
+      expect(validateTranscriptDocumentV1(doc), label).toMatchObject({ ok: false });
+    }
+  });
+
   it('does not let a numeric-keyed tool-call input alias onto a structural entry', () => {
     // Arbitrary tool input is walked with the same pointers; every structural
     // entry is rooted at a prefix `input` never occurs under.

--- a/packages/webapp/src/transcript/export-service.ts
+++ b/packages/webapp/src/transcript/export-service.ts
@@ -163,7 +163,10 @@ function buildTranscriptMessages(
 function assertValid(document: TranscriptDocumentV1): void {
   const validation = validateTranscriptDocumentV1(document);
   if (!validation.ok) {
-    throw new TranscriptExportError('schema-invalid');
+    // Carry the validator's own message into the error `detail` (#2845). The
+    // wire code stays `schema-invalid`; without the detail a failed export is
+    // a bare code in the console and the offending field is unknowable.
+    throw new TranscriptExportError('schema-invalid', validation.error);
   }
 }
 

--- a/packages/webapp/src/transcript/redact.ts
+++ b/packages/webapp/src/transcript/redact.ts
@@ -9,6 +9,7 @@
  *   5. TranscriptRedaction records and redactionCounts population.
  */
 import {
+  isStructuralTranscriptPointer,
   redactCredentialPatterns,
   type TranscriptDocumentV1,
   TranscriptExportError,
@@ -280,8 +281,19 @@ export async function redactTranscript(
   // overridden unconditionally at the end, so sending it to knownSecrets wastes
   // quota/bandwidth without any correctness benefit.
   const { privacy: _privacy, ...docWithoutPrivacy } = document;
-  const docLeaves: StringLeaf[] = [];
-  collectLeaves(docWithoutPrivacy, '', docLeaves);
+  const allDocLeaves: StringLeaf[] = [];
+  collectLeaves(docWithoutPrivacy, '', allDocLeaves);
+
+  // Drop the schema-controlled leaves (#2845). Known-secret redaction is plain
+  // substring replacement, so a secret value occurring inside an enum, an ISO
+  // timestamp, a SHA-256 hex, a bundle path or a relational id rewrites that
+  // field into something `validateTranscriptDocumentV1` rejects — and the whole
+  // export then fails with a bare `schema-invalid`. A degenerate one-character
+  // secret makes that certain: it turns `"active"` into `"acti⟦REDACTED:…⟧e"`.
+  // These fields are machine-generated and cannot carry a secret; every
+  // content-bearing field (titles, names, message text, tool-call input,
+  // attachment original names) is absent from the set and still redacted.
+  const docLeaves = allDocLeaves.filter((leaf) => !isStructuralTranscriptPointer(leaf.pointer));
 
   // Collect attachment strings in stable order
   const attEntries = [...textAttachments.entries()];

--- a/packages/webapp/src/ui/wc/wc-live.ts
+++ b/packages/webapp/src/ui/wc/wc-live.ts
@@ -1313,6 +1313,11 @@ export function attachWcClient(
         await downloadTranscriptBlob(blob, filename);
       } catch (err) {
         log.error('Transcript export failed', err);
+        // A failed export is silent by construction: no download arrives and
+        // the console is the only witness. Put the reason on screen (#2845).
+        void import('./wc-transcript-export.js')
+          .then(({ showTranscriptExportFailure }) => showTranscriptExportFailure(err))
+          .catch((noticeErr) => log.error('Transcript export notice failed', noticeErr));
       } finally {
         exportInFlight = false;
       }

--- a/packages/webapp/src/ui/wc/wc-transcript-export.ts
+++ b/packages/webapp/src/ui/wc/wc-transcript-export.ts
@@ -4,11 +4,11 @@
  *
  * - `transcriptZipToBlob`: streams + verifies a TranscriptZipResult.
  * - `downloadTranscriptBlob`: anchor-based browser download.
- * - `openTranscriptExportApproval`: shows a slicc-dialog with Allow/Deny.
+ * - `showTranscriptExportFailure`: tells the user an export produced no file.
  * - `runTranscriptExportForFollower`: creates a ZIP for an approved follower
  *   export using the registered TranscriptExportService.
  */
-import type { TranscriptExportSelector } from '@slicc/shared-ts';
+import { TranscriptExportError, type TranscriptExportSelector } from '@slicc/shared-ts';
 import { makeExportSpool } from '../../transcript/export-spool.js';
 import type { TranscriptZipResult } from '../../transcript/zip-stream.js';
 import type { OffscreenClient } from '../offscreen-client.js';
@@ -79,8 +79,51 @@ export async function downloadTranscriptBlob(blob: Blob, filename: string): Prom
 }
 
 // ---------------------------------------------------------------------------
-// Leader approval dialog
+// Failure notice
 // ---------------------------------------------------------------------------
+
+/** One-line reason for a failed export, safe to render verbatim. */
+function exportFailureReason(err: unknown): string {
+  if (err instanceof TranscriptExportError) {
+    return err.detail ? `${err.code}: ${err.detail}` : err.code;
+  }
+  return err instanceof Error && err.message ? err.message : 'unknown error';
+}
+
+/**
+ * Tell the user an export produced no file.
+ *
+ * A failed export is otherwise completely silent: the caller logs and
+ * swallows, the download never arrives, and the only signal is a console line
+ * the user will never open (#2845). This puts the reason on screen.
+ *
+ * Reuses the `<slicc-dialog>` primitive the rest of the WC shell uses. If that
+ * element is not defined (an embedded float, or a failure so early the shell
+ * never registered it), this is a no-op — the caller's log line stands alone,
+ * exactly as before.
+ */
+export function showTranscriptExportFailure(err: unknown): void {
+  if (typeof document === 'undefined' || !customElements.get('slicc-dialog')) return;
+  const dialog = document.createElement('slicc-dialog') as HTMLElement & { show?: () => void };
+  dialog.setAttribute('heading', 'Export failed');
+
+  const body = document.createElement('p');
+  body.style.cssText = 'margin:0;padding:0.25rem 0;font-size:0.9375rem;line-height:1.5;';
+  body.textContent = `No transcript was written — ${exportFailureReason(err)}.`;
+  dialog.append(body);
+
+  const close = document.createElement('button');
+  close.setAttribute('slot', 'footer');
+  close.type = 'button';
+  close.dataset.transcriptExportAction = 'close';
+  close.textContent = 'Close';
+  close.addEventListener('click', () => dialog.remove());
+  dialog.append(close);
+
+  dialog.addEventListener('slicc-dialog-close', () => dialog.remove());
+  document.body.appendChild(dialog);
+  dialog.show?.();
+}
 
 // ---------------------------------------------------------------------------
 // Leader-side ZIP factory for follower exports

--- a/packages/webapp/tests/transcript/redact.test.ts
+++ b/packages/webapp/tests/transcript/redact.test.ts
@@ -1,4 +1,9 @@
-import { redactCredentialPatterns, TranscriptExportError } from '@slicc/shared-ts';
+import {
+  redactCredentialPatterns,
+  type TranscriptDocumentV1,
+  TranscriptExportError,
+  validateTranscriptDocumentV1,
+} from '@slicc/shared-ts';
 import { describe, expect, it, vi } from 'vitest';
 import { redactTranscript } from '../../src/transcript/redact.js';
 import { makeTranscriptDocument } from './fixtures.js';
@@ -229,5 +234,96 @@ describe('redactCredentialPatterns — bearer-token case-insensitive', () => {
     expect(result.document.privacy.redactions.some((r) => r.category === 'bearer-token')).toBe(
       true
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: redacted output must still satisfy the schema (#2845)
+// ---------------------------------------------------------------------------
+
+/**
+ * A known-secret redactor that behaves exactly like the real one
+ * (`SecretsPipeline.redactForExport`): plain `replaceAll` of the secret's
+ * value, with no regard for where in the document that value happens to occur.
+ *
+ * A stored secret shorter than `MIN_MASKABLE_SECRET_LENGTH` is deliberately
+ * still substituted on the export path, so `value` can legitimately be one
+ * character — which is what turned a developer's transcript export into a bare
+ * `schema-invalid` (#2845). CI never saw it because CI's secret store is empty.
+ */
+function substringRedactor(value: string): {
+  redact: (texts: readonly string[]) => Promise<string[]>;
+} {
+  return {
+    redact: async (texts: readonly string[]) =>
+      texts.map((t) => t.replaceAll(value, '⟦REDACTED:known-secret:k1⟧')),
+  };
+}
+
+/** Fixture document extended with the constrained fields the base one omits. */
+function documentWithAttachment(text: string): TranscriptDocumentV1 {
+  const doc = makeTranscriptDocument({ text });
+  return {
+    ...doc,
+    attachments: [
+      {
+        id: 'att-bin-1',
+        path: 'attachments/att-bin-1.bin',
+        originalName: 'fixture.bin',
+        mimeType: 'application/octet-stream',
+        byteLength: 8,
+        sha256: '0'.repeat(64),
+        sourceConversationId: 'cone',
+        sourceMessageId: 'cone-msg-000001',
+        handling: 'binary-unchanged',
+        present: true,
+      },
+    ],
+  };
+}
+
+describe('redactTranscript schema stability (#2845)', () => {
+  it('leaves session.state intact when a one-character secret occurs inside it', async () => {
+    // 'v' occurs in "active" — the exact failure seen locally, where the
+    // redactor rewrote session.state to 'acti⟦REDACTED:…⟧e'.
+    const doc = makeTranscriptDocument({ text: 'no match here' });
+    const result = await redactTranscript(doc, new Map(), substringRedactor('v'));
+    expect(result.document.session.state).toBe('active');
+    expect(validateTranscriptDocumentV1(result.document)).toEqual({ ok: true });
+  });
+
+  it('keeps enums, ids, timestamps, paths and hashes valid against a degenerate secret', async () => {
+    // '0' occurs in every ISO timestamp, in the SHA-256 hex, in the message ids
+    // and in the attachment path — i.e. in every constrained field at once.
+    const doc = documentWithAttachment('nothing to redact');
+    const result = await redactTranscript(doc, new Map(), substringRedactor('0'));
+    const validation = validateTranscriptDocumentV1(result.document);
+    expect(validation).toEqual({ ok: true });
+
+    const att = result.document.attachments[0]!;
+    expect(att.sha256).toBe('0'.repeat(64));
+    expect(att.path).toBe('attachments/att-bin-1.bin');
+    const conv = result.document.conversations[0]!;
+    expect(conv.kind).toBe('cone');
+    expect(conv.messages[0]!.id).toBe('cone-msg-000001');
+    expect(conv.messages[1]!.content[1]).toMatchObject({ type: 'tool-call', id: 'call-1' });
+  });
+
+  it('still redacts every content-bearing field the same secret reaches', async () => {
+    // Fail-closed is preserved: sparing the schema fields must not spare
+    // titles, conversation names, message text, tool input or attachment names.
+    const doc = documentWithAttachment('the vault token is vvv');
+    const result = await redactTranscript(
+      { ...doc, session: { ...doc.session, title: 'v-titled session' } },
+      new Map([['att-bin-1', 'v-bearing attachment text']]),
+      substringRedactor('v')
+    );
+    expect(result.document.session.title).not.toContain('v');
+    expect(result.document.conversations[0]!.messages[1]!.content[0]).toEqual({
+      type: 'text',
+      text: 'the ⟦REDACTED:known-secret:k1⟧ault token is ⟦REDACTED:known-secret:k1⟧⟦REDACTED:known-secret:k1⟧⟦REDACTED:known-secret:k1⟧',
+    });
+    expect(result.textAttachments.get('att-bin-1')).not.toContain('v');
+    expect(validateTranscriptDocumentV1(result.document)).toEqual({ ok: true });
   });
 });

--- a/packages/webapp/tests/transcript/redact.test.ts
+++ b/packages/webapp/tests/transcript/redact.test.ts
@@ -309,6 +309,30 @@ describe('redactTranscript schema stability (#2845)', () => {
     expect(conv.messages[1]!.content[1]).toMatchObject({ type: 'tool-call', id: 'call-1' });
   });
 
+  it('still redacts free-form message metadata (source, channel)', async () => {
+    // `source`/`channel` are unconstrained and can hold a scoop name — the same
+    // kind of content kept redactable as conversations[].name. Exempting them
+    // would be fail-open, so they must not be in the structural set.
+    const base = makeTranscriptDocument({ text: 'nothing' });
+    const doc: TranscriptDocumentV1 = {
+      ...base,
+      conversations: [
+        {
+          ...base.conversations[0]!,
+          messages: [
+            { ...base.conversations[0]!.messages[0]!, source: 'vault-scoop', channel: 'vpn' },
+            ...base.conversations[0]!.messages.slice(1),
+          ],
+        },
+      ],
+    };
+    const result = await redactTranscript(doc, new Map(), substringRedactor('v'));
+    const msg = result.document.conversations[0]!.messages[0]!;
+    expect(msg.source).not.toContain('v');
+    expect(msg.channel).not.toContain('v');
+    expect(validateTranscriptDocumentV1(result.document)).toEqual({ ok: true });
+  });
+
   it('still redacts every content-bearing field the same secret reaches', async () => {
     // Fail-closed is preserved: sparing the schema fields must not spare
     // titles, conversation names, message text, tool input or attachment names.

--- a/packages/webapp/tests/ui/wc/wc-transcript-export.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-transcript-export.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TranscriptZipResult } from '../../../src/transcript/zip-stream.js';
 import {
   downloadTranscriptBlob,
+  showTranscriptExportFailure,
   transcriptZipToBlob,
 } from '../../../src/ui/wc/wc-transcript-export.js';
 
@@ -145,5 +146,62 @@ describe('downloadTranscriptBlob', () => {
     expect(document.querySelectorAll('a[data-transcript-dl]').length).toBe(0);
 
     clickSpy.mockRestore();
+  });
+});
+
+describe('showTranscriptExportFailure', () => {
+  class StubDialog extends HTMLElement {
+    shown = false;
+    show(): void {
+      this.shown = true;
+    }
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('is a no-op when <slicc-dialog> is not registered', () => {
+    // jsdom's registry is per-realm and this spec's realm may not have the
+    // shell's elements; assert the guard rather than throwing into the void.
+    if (customElements.get('slicc-dialog')) return;
+    showTranscriptExportFailure(new TranscriptExportError('schema-invalid'));
+    expect(document.body.querySelector('slicc-dialog')).toBeNull();
+  });
+
+  it('shows the code and the validator detail when the dialog exists', () => {
+    if (!customElements.get('slicc-dialog')) {
+      customElements.define('slicc-dialog', StubDialog);
+    }
+    showTranscriptExportFailure(
+      new TranscriptExportError('schema-invalid', 'session.state must be "active" or "frozen"')
+    );
+    const dialog = document.body.querySelector('slicc-dialog');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.getAttribute('heading')).toBe('Export failed');
+    expect(dialog?.textContent).toContain('schema-invalid');
+    expect(dialog?.textContent).toContain('session.state must be "active" or "frozen"');
+    expect((dialog as unknown as StubDialog).shown).toBe(true);
+  });
+
+  it('falls back to the message for a non-TranscriptExportError', () => {
+    if (!customElements.get('slicc-dialog')) {
+      customElements.define('slicc-dialog', StubDialog);
+    }
+    showTranscriptExportFailure(new Error('disk full'));
+    expect(document.body.querySelector('slicc-dialog')?.textContent).toContain('disk full');
+  });
+
+  it('removes itself when the close button is clicked', () => {
+    if (!customElements.get('slicc-dialog')) {
+      customElements.define('slicc-dialog', StubDialog);
+    }
+    showTranscriptExportFailure(new TranscriptExportError('transfer-aborted'));
+    const close = document.body.querySelector<HTMLButtonElement>(
+      'button[data-transcript-export-action="close"]'
+    );
+    expect(close).not.toBeNull();
+    close!.click();
+    expect(document.body.querySelector('slicc-dialog')).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #2845

## Summary

Transcript export corrupted its own document and then failed validation. Before: a user with a
short secret in their secret store clicked "Export transcript" and nothing happened — no file, no
message, only a bare `TranscriptExportError: schema-invalid` in the console. Now: the export
succeeds, and if one ever does fail the console names the offending field and the UI says so.

**Which of the two outcomes in the issue this is: outcome 2 — a real validator/builder mismatch
that CI is masking.** Not a build-freshness artefact; the issue's strongest lead is disproven
under "What was ruled out".

## Why

The issue's first ask was to stop guessing and capture the reason. Carrying `validation.error`
into the thrown error turns the console line into the whole answer:

```
error [main] Transcript export failed
  TranscriptExportError: schema-invalid: session.state must be "active" or "frozen"
```

**Root cause.** Export known-secret redaction (`SecretsPipeline.redactForExport`) is a plain
`replaceAll` of each stored secret's value across every string leaf of the transcript document.
Nothing kept it away from the fields the schema *constrains*.

Secrets shorter than `MIN_MASKABLE_SECRET_LENGTH` are deliberately still substituted on the
export path — three tests in `secrets-pipeline.test.ts` pin that, since export must not leak even
a short secret. So a one-character secret rewrites unrelated text. Probed against the real local
secret store on the reporting machine, through the same `/api/secrets/redact-export` endpoint the
webapp uses:

```
POST /api/secrets/redact-export  {"texts":["active","frozen","complete", ...]}
-> {"texts":["acti⟦REDACTED:known-secret:k4⟧e","frozen","complete", ...]}
```

`session.state` becomes `"acti⟦REDACTED:known-secret:k4⟧e"`, `validateTranscriptDocumentV1`
rejects it, `assertValid` throws, and `onExportTranscript` logs and swallows — so the only
user-visible symptom is a download that never arrives.

This is not confined to enums. The same walk covers ISO timestamps, SHA-256 hexes, bundle paths
and the ids the relational checks join on, so any secret value occurring inside one of them fails
the entire export.

**Repro** (needs a secret in the local store whose value occurs in a schema field — a
one-character secret guarantees it):

```
SLICC_E2E_WRANGLER_PORT=8827 SLICC_E2E_WRANGLER_SUPERVISOR_PORT=8828 \
SLICC_E2E_BRIDGE_PORT=5745 SLICC_E2E_CDP_PORT=9262 SLICC_E2E_FAKE_LLM_PORT=5805 \
npx playwright test --config packages/webapp/tests/e2e/playwright.config.ts transcript-export
```

Expected: ZIP downloads. Actual (before this PR): times out waiting for `download`, console shows
`schema-invalid`.

## Approach / Implementation notes

- `isStructuralTranscriptPointer()` lives in `packages/shared-ts/src/transcript-export.ts`, next
  to the validator that constrains the same fields — deliberately co-located so the coupling is
  visible: a field that gains a constraint in the validator needs an entry there too. The
  redactor filters those leaves out of its walk.
- **Redaction stays fail-closed.** Every content-bearing field is deliberately absent from the
  set and is still fully redacted: `session.title`, conversation `name`/`folder`, message text,
  message `error`, tool-call `input`, `attachments[].originalName`, and the text attachments
  themselves. A test asserts exactly that.
- **Alternative rejected:** dropping short secrets from `redactForExport` (aligning it with the
  masking path, which already refuses them for this exact collision reason). That reverses a
  deliberate, tested security decision — three tests pin that export redacts short secrets — so
  it is not mine to make unilaterally. Skipping fields that cannot contain a secret achieves the
  fix without weakening the guarantee.
- `TranscriptExportError` gains an optional `detail` folded into `.message` only. The wire code is
  unchanged.

## Cross-cutting impact

- **Other callers of the changed contract:** every consumer of `TranscriptExportError` reads
  `.code`, never `.message` — checked `cherry-host-transport.ts` (`exportErrorCodeFromRejection`),
  `tray-follower-sync.ts` (`handleExportError`), `scoops/tray-leader/transcript-export.ts`, and
  `session-command.ts` (which prints `err.code`). Nothing parses the message, so widening it is
  safe. The `transcript.export.error` wire envelope still carries only the canonical code.
- **Floats:** the redaction change is in `packages/webapp/src/transcript/`, shared by every float
  that exports (CLI, extension, Electron, cloud leader, and the tray follower path, which goes
  through the same service). `redactForExport` itself is untouched, so the extension service
  worker and node-server REST paths behave identically.
- **Security:** narrows *what* is redacted, never *whether*. Only machine-generated fields are
  skipped; the change cannot cause a secret to be emitted from a content field. No secret value
  appears in the new `detail` — it carries the validator's own field-name message.
- **Bundle size:** `npm run bundle-size` → First-load OK. The UI notice rides the already-lazy
  `wc-transcript-export.js` chunk, so nothing is added to the boot bundle.
- **Persisted state:** none. No schema, IndexedDB, or storage-key change.

## What was ruled out

- **Build freshness (the issue's strongest lead): disproven.** `packages/webapp/vite.config.ts`
  aliases `@slicc/shared-ts` to `packages/shared-ts/src/index.ts`, so the browser bundle always
  compiles the validator from source. A stale `shared-ts/dist/` cannot desynchronise the builder
  from the validator in the webapp — only node-server consumes the built `dist/`.
- **CI hiding a retry: disproven.** The `e2e` job log for `0be5ada8b` shows the spec passing on
  its first attempt (`✓ 27 … (28.6s)`, `26 passed`), no flaky/retry marker.
- **Machine speed / scoop-flush race: not the cause.** The failure is deterministic and the
  validator names a field, not a missing conversation.

## Test plan

- [x] `npm run verify` — clean (the `suppressions/unused` warnings on `packages/cherry/**`,
      `chrome-extension/**`, `cloudflare-worker/**` reproduce on untouched files locally: the
      GritQL `lint/plugin` is not loaded in this local invocation. Unrelated to this PR.)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 19560 passing, 0 failures
- [x] `npm run test:coverage` — no floor lowered
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — First-load OK
- [x] **New behavior covered by unit tests** —
      `npx vitest run packages/webapp/tests/transcript/redact.test.ts packages/shared-ts/tests/transcript-export.test.ts packages/webapp/tests/ui/wc/wc-transcript-export.test.ts`
- [x] E2E A/B on the reporting machine, both arms on a freshly started harness:

| arm | result |
|---|---|
| fix reverted | `✘ … TranscriptExportError: schema-invalid: session.state must be "active" or "frozen"` |
| fix applied | `✓ transcript-export.test.ts:170 … (4.9s)` |

The three new tests in `packages/webapp/tests/transcript/redact.test.ts` pin redactor output
against `validateTranscriptDocumentV1` using a redactor that reproduces `redactForExport`'s
substring behaviour for a degenerate secret. All three were confirmed to **fail** with the fix
reverted, so this regression is now caught in the fast suite rather than only in e2e.

**Pre-existing failures:** none.

**No screencast:** the second commit adds a dialog that only appears on a failed export, which no
longer reproduces once the first commit lands. Happy to record one against an artificially failed
export if a reviewer wants it.

## Documentation

- [x] `docs/` — `docs/transcript-export.md` gains a "Schema-controlled fields are never redacted"
      subsection and an updated `schema-invalid` row in the error table.
- [ ] `README.md` — no user-facing behavior change beyond the bug going away.

## Risk & rollback

- **Blast radius:** transcript export only, all floats. If the pointer set is wrong in the
  *conservative* direction (a content field listed by mistake) a secret could survive into that
  field — the set was written field-by-field against the schema and is asserted by a test that
  every listed pointer is one the validator constrains.
- **Rollback:** revert cleanly, both commits. No persisted-state migration.
- **CI cannot catch this class:** CI's secret store is empty, so no CI job can exercise the
  interaction between real stored secrets and the export document. The unit tests substitute a
  fake degenerate redactor precisely to close that gap.

## Note for whoever debugs the e2e next

Unrelated to this bug, but it cost a debugging cycle: the Playwright `webServer` entries use
`reuseExistingServer: !CI`, and a reused `wrangler dev` keeps serving the **asset snapshot from
its own start-up**. Rebuilding `dist/ui` between local runs does not reach the browser — it loads
the previous build's hashed chunks, so a fix appears not to work. Kill the harness ports between
builds when iterating on e2e locally.

## Checklist

- [x] Commits are focused and package-local where possible (fix + UI notice are separate commits)
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] Public API changes are intentional and reflected in docs (`TranscriptExportError.detail` is
      additive; the wire code is unchanged)
- [x] Contract used by other floats checked — see "Cross-cutting impact"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
