### PR TITLE
fix(webapp): route a dip's lick to the cone that raised it

### DIFF
--- a/docs/work-unit.md
+++ b/docs/work-unit.md
@@ -573,10 +573,27 @@ cannot matter.)
 **Two dispositions for a target that resolves to nothing, deliberately
 different:**
 
-| Lick                                       | Disposition                                                       |
-| ------------------------------------------ | ----------------------------------------------------------------- |
-| **untargeted** (no `targetScoop`)          | the default root — `rootsOf(scoops)[0]`, the oldest surviving one |
-| **targeted at a unit that does not exist** | `log.warn('Lick target scoop not found', …)` and **drop**         |
+| Lick                                       | Disposition                                                                                     |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| **untargeted** (no `targetScoop`)          | the raising unit's root, else the default root — `rootsOf(scoops)[0]`, the oldest surviving one |
+| **targeted at a unit that does not exist** | `log.warn('Lick target scoop not found', …)` and **drop**                                       |
+
+**A sprinkle/dip lick carries the unit that RAISED it**, and that beats the
+oldest-root fallback (`SprinkleLickOrigin.unitJid` → `Bridge.routeSprinkleLick`,
+`kernel/facade.ts`). A dip lives in one transcript, so its buttons belong to that
+transcript's cone; without the stamp every inline-dip click went to the oldest
+cone, so with a second cone open the cone that wrote the card saw nothing while a
+bystander was handed the lick — and handed it again when the user re-clicked a
+button that looked dead. A scoop's transcript resolves to its owning cone
+(`rootOwnerOf`), the same ownership rule interactive cards use
+(`ownerRootOrDefault`, #2312), and an origin the roster no longer knows falls
+back to the default root rather than dropping the lick. Both sides of the stamp
+are the LEADER's own answer: the page stamps the unit it rendered the dip into
+(captured at render, not read at click time, so a later selection cannot steal
+the lick), and a follower-forwarded lick is stamped from the selection the leader
+already records for that peer — never from a follower claim. `routeFormattedLickToCone`
+(`kernel/host.ts`) is unchanged: an event observed outside any conversation has
+no raising unit, and `discovery` keeps its own recent-history heuristic.
 
 A dropped targeted lick is not a bug to be papered over: the cone or scoop it
 named is gone (or was misspelled), and silently redirecting it would post

--- a/packages/webapp/src/kernel/facade.ts
+++ b/packages/webapp/src/kernel/facade.ts
@@ -33,7 +33,7 @@ import type { ChannelMessage, RegisteredScoop, ScoopTabState } from '../scoops/t
 import { getSprinkleRoute } from '../shell/sprinkle-routes.js';
 import { TOOL_UI_MOUNTED_ACTION, toolUIRegistry } from '../tools/tool-ui.js';
 import { buildWorkUnitRecord } from '../work-unit/manager.js';
-import { isRootUnit, rootsOf } from '../work-unit/policy.js';
+import { isRootUnit, rootOwnerOf, rootsOf } from '../work-unit/policy.js';
 import {
   chatSessionIdFor,
   coneFolderFor,
@@ -62,6 +62,7 @@ import type {
   ScoopStatusMsg,
   SetScoopModelMsg,
   SetThinkingLevelMsg,
+  SprinkleLickOrigin,
   StateSnapshotMsg,
   ToolUIActionMsg,
   TrayRuntimeStatusMsg,
@@ -669,9 +670,10 @@ export class Bridge implements KernelFacade {
   /**
    * Route a sprinkle-lick event into the orchestrator. Resolves
    * `targetScoop` by name/folder/`${folder}-scoop`, falling back to the
-   * cone when no match is found (or `targetScoop` is omitted). Builds a
-   * `ChannelMessage`, appends a buffered lick entry, persists, and
-   * dispatches via `orchestrator.handleMessage`.
+   * unit that RAISED the lick (`origin.unitJid`, resolved to its root
+   * owner) and only then to the default root. Builds a `ChannelMessage`,
+   * appends a buffered lick entry, persists, and dispatches via
+   * `orchestrator.handleMessage`.
    *
    * Extracted from the `sprinkle-lick` envelope handler so leader-side
    * `onSprinkleLick` callbacks can share the same routing logic without
@@ -682,7 +684,7 @@ export class Bridge implements KernelFacade {
     sprinkleName: string,
     body: unknown,
     targetScoop?: string,
-    originLabel?: string
+    origin?: SprinkleLickOrigin
   ): Promise<void> {
     if (!this.orchestrator) return;
     // Human-gated navigate·handoff licks: when the user resolves the approval
@@ -710,7 +712,13 @@ export class Bridge implements KernelFacade {
     // long-lived and a stale entry must not silence a live panel.
     let target = resolvedTarget ? matchLickTargetAlias(scoops, resolvedTarget) : undefined;
     if (!target) {
-      target = rootsOf(scoops)[0];
+      // A dip lives in ONE unit's transcript, so its clicks belong to that
+      // unit's cone. Falling straight through to the default root sent every
+      // inline-dip lick to the OLDEST cone: with a second cone open, the cone
+      // that rendered the dip saw nothing while a bystander cone was handed a
+      // lick for a card it never wrote (and, on a retried click, twice). Same
+      // ownership rule as `ownerRootOrDefault` (#2312) for interactive cards.
+      target = this.originRootOf(scoops, origin?.unitJid) ?? rootsOf(scoops)[0];
     }
     if (!target) return;
     const msgId = `sprinkle-${sprinkleName}-${Date.now()}`;
@@ -719,7 +727,7 @@ export class Bridge implements KernelFacade {
       sprinkleName,
       timestamp: new Date().toISOString(),
       body,
-      originLabel,
+      originLabel: origin?.label,
     } as Parameters<typeof formatLickEventForCone>[0]);
     const content =
       formatted?.content ??
@@ -744,6 +752,22 @@ export class Bridge implements KernelFacade {
     });
     this.persistScoop(target.jid);
     await this.orchestrator.handleMessage(channelMsg);
+  }
+
+  /**
+   * The root that owns `jid` — itself when it IS a root. A jid the roster no
+   * longer knows (a closed cone, a stale panel) resolves to `undefined` so the
+   * caller keeps its default-root fallback rather than dropping the lick.
+   */
+  private originRootOf(
+    scoops: readonly RegisteredScoop[],
+    jid: string | undefined
+  ): RegisteredScoop | undefined {
+    if (!jid) return undefined;
+    return rootOwnerOf(
+      scoops,
+      scoops.find((scoop) => scoop.jid === jid)
+    );
   }
 
   /**
@@ -1933,15 +1957,17 @@ export class Bridge implements KernelFacade {
    * Predicate is `followerActive` (sticky across reconnects) not
    * `followerSync` (transiently null during WebRTC reconnects) so a
    * flicker doesn't reroute us back to the local model-less cone.
-   * `originLabel` is intentionally not forwarded — the leader is the
-   * origin authority and re-stamps it from the connection on receive
-   * (see `tray-leader-sync.ts case 'sprinkle.lick'`).
+   * `origin` is intentionally not forwarded — the leader is the origin
+   * authority and re-stamps the label from the connection on receive
+   * (see `tray-leader-sync.ts case 'sprinkle.lick'`), and the raising
+   * unit is the leader's own, which it resolves from that connection's
+   * selection rather than from the follower's claim.
    */
   private async handleSprinkleLickMsg(lickMsg: {
     sprinkleName: string;
     body: unknown;
     targetScoop?: string;
-    originLabel?: string;
+    origin?: SprinkleLickOrigin;
   }): Promise<void> {
     if (this.followerActive) {
       if (this.followerSync) {
@@ -1957,7 +1983,7 @@ export class Bridge implements KernelFacade {
       lickMsg.sprinkleName,
       lickMsg.body,
       lickMsg.targetScoop,
-      lickMsg.originLabel
+      lickMsg.origin
     );
   }
 

--- a/packages/webapp/src/kernel/messages.ts
+++ b/packages/webapp/src/kernel/messages.ts
@@ -393,6 +393,22 @@ export interface OAuthRequestMsg {
   interactive?: boolean;
 }
 
+/**
+ * Where a sprinkle/dip lick came from, as opposed to where it is addressed.
+ *
+ * `unitJid` is the ROUTING fallback for an untargeted lick: a dip lives in one
+ * unit's transcript, so its clicks belong to that unit's cone and not to the
+ * oldest root the default fallback would pick (#2312's rule, applied to licks).
+ * `label` is presentation only — the "Forwarded from …" line a follower's lick
+ * carries into the cone's message.
+ */
+export interface SprinkleLickOrigin {
+  /** Origin label for follower-forwarded licks. */
+  label?: string;
+  /** Work-unit jid whose transcript raised the lick; routes to its root owner. */
+  unitJid?: string;
+}
+
 /** Sprinkle lick event from side panel to offscreen agent. */
 export interface SprinkleLickMsg {
   type: 'sprinkle-lick';
@@ -400,8 +416,8 @@ export interface SprinkleLickMsg {
   body: unknown;
   /** Optional target scoop for routed sprinkle lick events. */
   targetScoop?: string;
-  /** Optional origin label for follower-forwarded licks. */
-  originLabel?: string;
+  /** Optional origin of the lick (forwarding label, raising unit). */
+  origin?: SprinkleLickOrigin;
 }
 
 /**

--- a/packages/webapp/src/kernel/types.ts
+++ b/packages/webapp/src/kernel/types.ts
@@ -36,6 +36,7 @@ import type {
   ScoopListMsg,
   ScoopMessagesReplacedMsg,
   ScoopStatusMsg,
+  SprinkleLickOrigin,
   StateSnapshotMsg,
   TrayFollowerStatusSnapshot,
   TrayLeaderStatusSnapshot,
@@ -261,7 +262,7 @@ export interface KernelClientFacade {
     sprinkleName: string,
     body: unknown,
     targetScoop?: string,
-    originLabel?: string
+    origin?: SprinkleLickOrigin
   ): void;
   setSprinkleOpHandler(handler: (payload: unknown) => void): void;
 
@@ -289,6 +290,7 @@ export type {
   ScoopListMsg,
   ScoopMessagesReplacedMsg,
   ScoopStatusMsg,
+  SprinkleLickOrigin,
   StateSnapshotMsg,
   TrayFollowerStatusSnapshot,
   TrayLeaderStatusSnapshot,

--- a/packages/webapp/src/scoops/tray-leader-sync.ts
+++ b/packages/webapp/src/scoops/tray-leader-sync.ts
@@ -117,12 +117,19 @@ export interface LeaderSyncManagerOptions {
   ) => void | Promise<unknown>;
   /** Resolve a sprinkle's raw .shtml content for follower-side rendering. */
   readSprinkleContent?: (sprinkleName: string) => Promise<string | null> | string | null;
-  /** Forward a sprinkle lick (from a follower's open or inline sprinkle) to the leader's lick router. */
+  /**
+   * Forward a sprinkle lick (from a follower's open or inline sprinkle) to the
+   * leader's lick router. `originUnitJid` is the unit that follower was looking
+   * at — the leader's own `scoops.select` record for the peer, not a follower
+   * claim — so an untargeted dip lick lands in the cone whose transcript
+   * rendered the dip rather than in the leader's oldest cone.
+   */
   onSprinkleLick?: (
     sprinkleName: string,
     body: unknown,
     targetScoop?: string,
-    originLabel?: string
+    originLabel?: string,
+    originUnitJid?: string
   ) => void;
   /**
    * Handle a generic lick (e.g. `navigate`) forwarded by a follower.

--- a/packages/webapp/src/scoops/tray-leader/follower-dispatch.ts
+++ b/packages/webapp/src/scoops/tray-leader/follower-dispatch.ts
@@ -472,7 +472,8 @@ export class FollowerDispatch {
         message.sprinkleName,
         message.body,
         message.targetScoop,
-        originLabel
+        originLabel,
+        follower?.selectedScoopJid
       );
     } catch (err) {
       this.context.log.warn('onSprinkleLick handler threw', {

--- a/packages/webapp/src/ui/offscreen-client.ts
+++ b/packages/webapp/src/ui/offscreen-client.ts
@@ -32,6 +32,7 @@ import type {
   SessionStatsMsg,
   SetScoopModelAckMsg,
   SetThinkingLevelAckMsg,
+  SprinkleLickOrigin,
   StateSnapshotMsg,
   SudoApprovalMsg,
   TrayFollowerStatusSnapshot,
@@ -757,19 +758,25 @@ export class OffscreenClient implements KernelClientFacade {
   private sprinkleOpHandler: ((payload: unknown) => void) | null = null;
   private forwardLickHandler: ((event: LickEvent) => void) | null = null;
 
-  /** Send a sprinkle lick event to the offscreen orchestrator. */
+  /**
+   * Send a sprinkle lick event to the offscreen orchestrator. `origin` names
+   * where the lick came from — the forwarding label for a follower-relayed
+   * lick, and the work unit whose transcript raised it, which is how an
+   * untargeted inline-dip lick reaches the cone that rendered the dip instead
+   * of the oldest one.
+   */
   sendSprinkleLick(
     sprinkleName: string,
     body: unknown,
     targetScoop?: string,
-    originLabel?: string
+    origin?: SprinkleLickOrigin
   ): void {
     this.send({
       type: 'sprinkle-lick',
       sprinkleName,
       body,
       targetScoop,
-      originLabel,
+      origin,
     } as PanelToOffscreenMessage);
   }
 

--- a/packages/webapp/src/ui/wc/wc-chat-host.ts
+++ b/packages/webapp/src/ui/wc/wc-chat-host.ts
@@ -40,11 +40,20 @@ export interface WcChatHost {
   /**
    * Route an inline dip's lick (a ```shtml block's button) to the cone.
    *
+   * `originUnitId` is the unit whose transcript the dip was rendered in. An
+   * untargeted lick without it falls back to the OLDEST cone, so with two cones
+   * open the clicks landed in a bystander's chat (#2312's rule for cards).
+   *
    * LEADER-ONLY in the sense that only a leader can HANDLE it; a follower
    * still forwards one over the tray, which is why its host implements this
    * rather than dropping it.
    */
-  sendSprinkleLick(name: string, body: unknown, targetScoop?: string): void;
+  sendSprinkleLick(
+    name: string,
+    body: unknown,
+    targetScoop?: string,
+    originUnitId?: WorkUnitId
+  ): void;
   /** Answer a tool-UI card's button. A follower renders those read-only. */
   sendToolUiAction(requestId: string, action: string, data: unknown): void;
   /**
@@ -172,7 +181,13 @@ export function createLeaderChatHost(
   let turnIdle: (() => void) | null = null;
   return {
     onAgentEvent: (listener) => kernelEvents.onEvent(listener),
-    sendSprinkleLick: (name, body, targetScoop) => client.sendSprinkleLick(name, body, targetScoop),
+    sendSprinkleLick: (name, body, targetScoop, originUnitId) =>
+      client.sendSprinkleLick(
+        name,
+        body,
+        targetScoop,
+        originUnitId ? { unitJid: originUnitId } : undefined
+      ),
     sendToolUiAction: (requestId, action, data) => client.sendToolUiAction(requestId, action, data),
     deleteQueuedMessage: (unitId, messageId) => client.deleteQueuedMessage(unitId, messageId),
     emitAgentError: (error) => client.emitAgentError(error),
@@ -230,7 +245,10 @@ export function createFollowerChatHost(deps: {
 }): WcChatHost {
   return {
     onAgentEvent: deps.onAgentEvent,
-    // Forwarded, not handled: the cone's lick router runs on the leader.
+    // Forwarded, not handled: the cone's lick router runs on the leader. The
+    // raising unit is deliberately NOT sent — the leader stamps it from the
+    // selection it already records for this peer (`follower-dispatch.ts`),
+    // which is the same authority that re-stamps the origin label.
     sendSprinkleLick: (name, body, targetScoop) =>
       deps.getSync()?.sendSprinkleLick(name, body, targetScoop),
     // A follower has no `installLeaderPermissionsSurface` and no tool-UI

--- a/packages/webapp/src/ui/wc/wc-live-controller.ts
+++ b/packages/webapp/src/ui/wc/wc-live-controller.ts
@@ -57,13 +57,20 @@ export function createWcController(
     units = next;
   });
 
+  /**
+   * The unit the SHELL says it is showing. A follower narrows this: until its
+   * leader has named a unit for this session there is nothing to address, and a
+   * send would be dropped after the bubble was already rendered (see
+   * `WcChatHost.addressableUnitId`).
+   *
+   * Shared by the composer and by a dip's lick, because a dip's button is the
+   * same conversation the composer writes to.
+   */
+  const addressedUnitId = () =>
+    host.addressableUnitId ? host.addressableUnitId() : (getSelected()?.id ?? null);
+
   const agentHandle = createWorkUnitAgentHandle(workUnits, {
-    // The unit the SHELL says it is showing. A follower narrows this: until
-    // its leader has named a unit for this session there is nothing to
-    // address, and a send would be dropped after the bubble was already
-    // rendered (see `WcChatHost.addressableUnitId`).
-    getSelectedId: () =>
-      host.addressableUnitId ? host.addressableUnitId() : (getSelected()?.id ?? null),
+    getSelectedId: addressedUnitId,
     onError: (error) => host.emitAgentError(error),
     onEvent: (listener) => host.onAgentEvent(listener),
   });
@@ -142,6 +149,10 @@ export function createWcController(
       // Before hydration on purpose: a float that replaces a dip wants the
       // replacement instead of the live one, not on top of it.
       host.onMessageRendered?.(messageHost);
+      // Captured AT RENDER, not read at click time: the dip belongs to the
+      // transcript it was rendered into, and a lick must not follow a later
+      // selection into a cone that never wrote the card.
+      const originUnitId = addressedUnitId() ?? undefined;
       dipInstances.set(
         message.id,
         hydrateDips(messageHost, (action, data) => {
@@ -152,7 +163,7 @@ export function createWcController(
             body: { action, data },
           };
           if (welcome?.intercept?.(event)) return;
-          host.sendSprinkleLick('inline', { action, data });
+          host.sendSprinkleLick('inline', { action, data }, undefined, originUnitId);
         })
       );
     },

--- a/packages/webapp/src/ui/wc/wc-tray.ts
+++ b/packages/webapp/src/ui/wc/wc-tray.ts
@@ -846,8 +846,11 @@ export function createLeaderOptionsFactory(
         return null;
       }
     },
-    onSprinkleLick: (name, body, targetScoop, originLabel) =>
-      client.sendSprinkleLick(name, body, targetScoop, originLabel),
+    onSprinkleLick: (name, body, targetScoop, originLabel, originUnitJid) =>
+      client.sendSprinkleLick(name, body, targetScoop, {
+        label: originLabel,
+        unitJid: originUnitJid,
+      }),
     onSprinkleInstancesChanged: () => mirrorSprinkleInstances(state),
     onFollowerMessage: (text, messageId, attachments, options) =>
       deliverFollowerMessage(deps, state, text, messageId, attachments, options),

--- a/packages/webapp/tests/kernel/bridge.test.ts
+++ b/packages/webapp/tests/kernel/bridge.test.ts
@@ -1734,12 +1734,92 @@ describe('Bridge.routeSprinkleLick', () => {
   });
 
   it('includes the forwarded origin label in the lick content', async () => {
-    await bridge.routeSprinkleLick('welcome', { action: 'go' }, 'helper', 'iOS follower');
+    await bridge.routeSprinkleLick('welcome', { action: 'go' }, 'helper', {
+      label: 'iOS follower',
+    });
     expect(mockOrchestrator.handleMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining('Forwarded from iOS follower'),
       })
     );
+  });
+
+  /**
+   * A dip lives in ONE unit's transcript, so an untargeted lick belongs to that
+   * unit's cone. It used to fall straight through to the oldest root: with a
+   * second cone open, the cone that rendered the dip saw nothing and a
+   * bystander cone was handed a lick for a card it never wrote.
+   */
+  describe('origin unit routing', () => {
+    /** Two roots — the oldest first, so a bad fallback is visible. */
+    beforeEach(() => {
+      mockOrchestrator.getScoops = vi.fn(() => [
+        {
+          jid: 'cone-1',
+          name: 'sliccy',
+          folder: 'cone',
+          isCone: true,
+          parentJid: null,
+          addedAt: '2024-01-01T00:00:00.000Z',
+          assistantLabel: 'sliccy',
+        },
+        {
+          jid: 'cone-2',
+          name: 'landlording',
+          folder: 'cone-landlording',
+          isCone: true,
+          parentJid: null,
+          addedAt: '2024-06-01T00:00:00.000Z',
+          assistantLabel: 'sliccy',
+        },
+        {
+          jid: 'scoop-2',
+          name: 'helper',
+          folder: 'helper',
+          isCone: false,
+          parentJid: 'cone-2',
+          addedAt: '2024-07-01T00:00:00.000Z',
+          assistantLabel: 'helper',
+        },
+      ]);
+    });
+
+    it('routes an untargeted lick to the cone that raised it, not the oldest one', async () => {
+      await bridge.routeSprinkleLick('inline', { action: 'go' }, undefined, {
+        unitJid: 'cone-2',
+      });
+      expect(mockOrchestrator.handleMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ chatJid: 'cone-2' })
+      );
+    });
+
+    it('routes a lick raised in a scoop transcript to the scoop’s owning cone', async () => {
+      await bridge.routeSprinkleLick('inline', { action: 'go' }, undefined, {
+        unitJid: 'scoop-2',
+      });
+      expect(mockOrchestrator.handleMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ chatJid: 'cone-2' })
+      );
+    });
+
+    it('keeps the default-root fallback for an origin the roster no longer knows', async () => {
+      // A closed cone or a stale panel must not silence the lick.
+      await bridge.routeSprinkleLick('inline', { action: 'go' }, undefined, {
+        unitJid: 'cone-gone',
+      });
+      expect(mockOrchestrator.handleMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ chatJid: 'cone-1' })
+      );
+    });
+
+    it('prefers an explicit targetScoop over the raising unit', async () => {
+      await bridge.routeSprinkleLick('inline', { action: 'go' }, 'helper', {
+        unitJid: 'cone-2',
+      });
+      expect(mockOrchestrator.handleMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ chatJid: 'scoop-2' })
+      );
+    });
   });
 });
 

--- a/packages/webapp/tests/scoops/tray-leader-sync.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader-sync.test.ts
@@ -2452,11 +2452,15 @@ describe('LeaderSyncManager', () => {
         targetScoop: 'scoop-1',
       });
 
+      // Fifth arg is the unit this peer is reading, as the LEADER recorded it
+      // (the join snapshot pins it to the active unit until a `scoops.select`
+      // moves it) — never a follower claim.
       expect(onSprinkleLick).toHaveBeenCalledWith(
         'welcome',
         { action: 'click' },
         'scoop-1',
-        'iOS follower'
+        'iOS follower',
+        'cone'
       );
     });
 

--- a/packages/webapp/tests/scoops/tray-leader/follower-dispatch.test.ts
+++ b/packages/webapp/tests/scoops/tray-leader/follower-dispatch.test.ts
@@ -448,11 +448,15 @@ describe('FollowerDispatch', () => {
       sprinkleName: 'status',
       body: { action: 'refresh' },
     });
+    // Fifth arg is the unit THIS peer is looking at (its `scoops.select`
+    // above): an untargeted dip lick belongs to the cone whose transcript
+    // rendered the dip, not to the leader's oldest cone.
     expect(options.onSprinkleLick).toHaveBeenCalledWith(
       'status',
       { action: 'refresh' },
       undefined,
-      'extension follower'
+      'extension follower',
+      'scoop'
     );
     dispatch.dispatch('follower', {
       type: 'lick',

--- a/packages/webapp/tests/ui/wc/wc-dip-lick-routing.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-dip-lick-routing.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+/**
+ * Where an inline dip's lick goes.
+ *
+ * A dip is rendered into ONE unit's transcript, so its buttons belong to that
+ * unit's conversation. The lick used to carry no origin at all, and the kernel's
+ * untargeted fallback is the OLDEST root: with a second cone open, clicking a
+ * card the newer cone had just written sent the lick to the older cone, which
+ * had never seen the dip (and saw it twice when the user re-clicked a button
+ * that appeared to do nothing).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { installWcDomStubs } from './wc-dom-stubs.js';
+
+installWcDomStubs();
+
+/** Captures the `onLick` the controller hands each rendered message. */
+const dipHydration: { lastOnLick: ((action: string, data: unknown) => void) | null } = {
+  lastOnLick: null,
+};
+
+vi.mock('../../../src/ui/dip.js', () => ({
+  disposeDips: () => undefined,
+  hydrateDips: (_host: HTMLElement, onLick: (action: string, data: unknown) => void) => {
+    dipHydration.lastOnLick = onLick;
+    return [];
+  },
+  mountDip: () => ({ dispose: () => undefined }),
+}));
+
+import type { ChatMessage } from '../../../src/ui/types.js';
+import { attachWcChat } from '../../../src/ui/wc/wc-chat.js';
+import type { WcChatHost } from '../../../src/ui/wc/wc-chat-host.js';
+import { prepareWcShell } from '../../../src/ui/wc/wc-live.js';
+import type {
+  Unsubscribe,
+  WorkUnitClient,
+  WorkUnitSnapshot,
+  WorkUnitSummary,
+} from '../../../src/work-unit/client/types.js';
+
+function unit(over: Partial<WorkUnitSummary> & { id: string }): WorkUnitSummary {
+  return {
+    assistantLabel: 'sliccy',
+    fill: 0,
+    folder: 'cone',
+    name: 'sliccy',
+    parentId: null,
+    role: 'primary',
+    state: 'idle',
+    ...over,
+  };
+}
+
+const OLDEST = unit({ id: 'cone-1' });
+const NEWER = unit({ id: 'cone-2', folder: 'cone-landlording', name: 'landlording' });
+
+/** One rendered assistant message — enough for the dip pipeline to run. */
+const DIP_MESSAGE: ChatMessage = {
+  id: 'm1',
+  role: 'assistant',
+  content: '```shtml\n<button data-action="go">Go</button>\n```',
+  timestamp: Date.now(),
+};
+
+/**
+ * A client whose `subscribe` replays the transcript immediately, which is what
+ * the shell renders from (the snapshot request is the ASK; the subscription is
+ * the answer — see `createUnitWatcher`).
+ */
+function fakeClient(): WorkUnitClient {
+  const units = [OLDEST, NEWER];
+  const snapshot = { messages: [DIP_MESSAGE] } as unknown as WorkUnitSnapshot;
+  return {
+    currentUnits: () => units,
+    list: () => Promise.resolve(units),
+    send: () => Promise.resolve(),
+    setModel: () => Promise.resolve(true),
+    signal: () => Promise.resolve(),
+    snapshot: () => Promise.resolve(snapshot),
+    subscribe: (_id, listener): Unsubscribe => {
+      listener({ type: 'snapshot', snapshot } as never);
+      return () => undefined;
+    },
+    subscribeList: (listener): Unsubscribe => {
+      listener(units);
+      return () => undefined;
+    },
+  };
+}
+
+/** Mount the shared chat surface, select `unitId`, and render its transcript. */
+async function mountAndSelect(unitId: string, host: WcChatHost) {
+  const app = document.createElement('div');
+  document.body.append(app);
+  const boot = prepareWcShell(app, 'test');
+  attachWcChat(boot, fakeClient(), host);
+  boot.refs.switcher.dispatchEvent(
+    new CustomEvent('slicc-scoop-select', { detail: { key: unitId } })
+  );
+  // The snapshot is a promise; the render (and with it the hydration) lands on
+  // its microtask.
+  await Promise.resolve();
+  await Promise.resolve();
+  return boot;
+}
+
+function testHost(sendSprinkleLick: WcChatHost['sendSprinkleLick']): WcChatHost {
+  return {
+    deleteQueuedMessage: () => Promise.resolve(),
+    emitAgentError: () => undefined,
+    onAgentEvent: () => () => undefined,
+    sendSprinkleLick,
+    sendToolUiAction: () => undefined,
+  };
+}
+
+describe('inline dip lick routing', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    dipHydration.lastOnLick = null;
+  });
+
+  it('stamps the unit whose transcript rendered the dip', async () => {
+    const sent = vi.fn();
+    await mountAndSelect('cone-2', testHost(sent));
+    expect(dipHydration.lastOnLick).toBeTypeOf('function');
+
+    dipHydration.lastOnLick?.('go', { v: 1 });
+    expect(sent).toHaveBeenCalledWith(
+      'inline',
+      { action: 'go', data: { v: 1 } },
+      undefined,
+      'cone-2'
+    );
+  });
+
+  it('keeps the render-time unit when the selection has moved on', async () => {
+    // The lick must not follow a later selection into a cone that never wrote
+    // the card: the dip belongs to the transcript it was rendered into.
+    const sent = vi.fn();
+    const boot = await mountAndSelect('cone-2', testHost(sent));
+    const licked = dipHydration.lastOnLick;
+    boot.refs.switcher.dispatchEvent(
+      new CustomEvent('slicc-scoop-select', { detail: { key: 'cone-1' } })
+    );
+    licked?.('go', null);
+    expect(sent).toHaveBeenCalledWith('inline', { action: 'go', data: null }, undefined, 'cone-2');
+  });
+});


### PR DESCRIPTION
## The bug

Observed live with two cones open: the landlording cone wrote a dip, the button did nothing when clicked, and the re-click landed as a second lick in the **sliccy** cone, which had never been focused and had no idea what the card was.

An inline dip's lick carried no origin at all — `wc-live-controller.ts` sent `sendSprinkleLick('inline', { action, data })` with no target — and `Bridge.routeSprinkleLick` resolves an untargeted lick to `rootsOf(scoops)[0]`, the **oldest** root. So every dip click went to the oldest cone regardless of which cone rendered the dip, and the cone that wrote the card never heard back.

The orchestrator already fixed this ownership rule for interactive cards (`ownerRootOrDefault`, #2312). Licks were the surface that never got it.

## The fix

- `SprinkleLickMsg` carries a `SprinkleLickOrigin { label?, unitJid? }` (the flat `originLabel` moves inside it).
- `routeSprinkleLick` resolves: explicit `targetScoop` → configured sprinkle route → **the raising unit's root owner** (`rootOwnerOf`) → default root. A dip raised in a scoop's read-only transcript therefore lands in that scoop's owning cone.
- An origin the roster no longer knows (closed cone, stale panel) keeps the default-root fallback rather than dropping the lick.
- The page stamps the unit it rendered the dip into, **captured at render time**, so switching cones after the card is drawn cannot make its button post into a cone that never wrote it.
- Follower parity: a follower-forwarded lick is stamped from the selection the *leader* already records for that peer (`follower-dispatch.ts`) — the same authority that re-stamps the origin label — never from a follower claim.
- `routeFormattedLickToCone` (`kernel/host.ts`) is untouched: an event observed outside any conversation has no raising unit, and `discovery` keeps its own recent-history heuristic.

## Tests

- New `tests/ui/wc/wc-dip-lick-routing.test.ts`: the stamp is the rendering unit, and it survives a later selection change.
- 4 new `Bridge.routeSprinkleLick` cases: raising cone beats oldest root, scoop origin → owning cone, unknown origin → default root, explicit `targetScoop` still wins.
- Follower-dispatch and tray-leader-sync tests now assert the peer-selection stamp.

## Docs

`docs/work-unit.md` § "Addressing licks to a cone": the untargeted disposition row now names the raising unit, with a paragraph on why both sides of the stamp are the leader's own answer.

## Verification

`npm run verify` · `check-touched-exemptions.mjs` · `typecheck` · `npm run test` (19,569 passed) · `test:coverage` · `npm run build` · `build -w @slicc/chrome-extension` · `bundle-size`. One unrelated flake under the coverage run (`slicc-fs-module.test.ts`, a pyodide load timeout) passes in isolation and in `npm run test`.

Not verified against the live instance on CDP 9222 — it serves a hosted build, so it keeps the old routing until that build refreshes.
