### PR TITLE
fix(webapp): skip cone prompt when sudo_request is already NOPASSWD-granted

### DIFF
--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -457,7 +457,11 @@ sudoers-file edit), the orchestrator re-evaluates that scoop's pending requests
 and auto-resolves as `allow` those the policy now covers with a `NOPASSWD`
 grant (`ScoopApprovalRouter.settleGrantedRequests`, #2416), so one "Always"
 approval unblocks the scoop's other queued requests for the same subtree
-instead of stalling them until each is individually approved. The timeout path
+instead of stalling them until each is individually approved. The same grant
+match also runs at request admission (`enqueueSudoRequest`): a `sudo_request`
+whose subject is already `NOPASSWD`-granted resolves `allow` immediately and
+never raises a cone prompt (#2853). The reload sweep remains for requests that
+were already pending when the grant landed. The timeout path
 tags its decision `reason: 'cone-timeout'` so the scoop is told its escalation
 went unanswered rather than refused — and, unlike the cone → user leg, is not
 told to wait for a user who was never prompted.

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -461,7 +461,8 @@ Cone-only. Update the shared global memory file (`/shared/CLAUDE.md`).
 
 Scoop-only. Ask the cone for an explicit sudo escalation before running a sensitive
 action. The call blocks until the cone resolves via `lick_confirm` / `lick_dismiss` (or
-the registry times out fail-closed).
+the registry times out fail-closed). If the scoop's sudoers already grants the subject
+with `NOPASSWD`, the call resolves `allow` immediately without a cone prompt.
 
 | Property   | Value                                                                                        |
 | ---------- | -------------------------------------------------------------------------------------------- |

--- a/packages/webapp/src/scoops/scoop-approval-router.ts
+++ b/packages/webapp/src/scoops/scoop-approval-router.ts
@@ -2,8 +2,10 @@
  * ScoopApprovalRouter - owns the cone-mediated sudo-request lifecycle.
  *
  * Implements `ConeApprovalRouter`: a non-cone scoop's `SudoBroker.requestApproval`
- * call enters here via {@link enqueueSudoRequest}, the request is registered in
- * the {@link ConeRequestRegistry}, delivered to the cone (lick chip + queued
+ * call enters here via {@link enqueueSudoRequest}. If the scoop's policy already
+ * grants the subject with `NOPASSWD`, the request resolves `allow` immediately
+ * and never reaches the cone. Otherwise it is registered in the
+ * {@link ConeRequestRegistry}, delivered to the cone (lick chip + queued
  * actionable message), and the pending promise is returned to the scoop. The
  * cone settles it via {@link resolveSudoRequest} / {@link resolveSudoRequestAndPersist};
  * unregister / shutdown drains pending requests fail-closed.
@@ -16,7 +18,7 @@
  */
 
 import { createLogger } from '../base/logger.js';
-import { matchCommand, matchPath } from '../base/sudoers.js';
+import { matchCommand, matchPath, type SudoersPolicy } from '../base/sudoers.js';
 import {
   type ConeApprovalRouter,
   ConeRequestRegistry,
@@ -151,14 +153,8 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
       if (!scoop) continue;
       if (folder !== undefined && scoop.folder !== folder) continue;
       const policy = sudoManager.getPolicyForScoop(scoop.folder);
+      if (!isNopasswdGranted(policy, pending.request)) continue;
       const { kind, detail } = pending.request;
-      const granted =
-        kind === 'command'
-          ? matchCommand(policy, detail) === 'nopasswd-allow'
-          : kind === 'read' || kind === 'write'
-            ? matchPath(policy, kind, detail) === 'nopasswd-allow'
-            : false;
-      if (!granted) continue;
       // `resolve()` deletes the registry entry, so the requester's identity
       // (and with it the owning cone) must travel with the persistence call.
       if (this.registry.resolve(pending.id, { decision: 'allow' })) {
@@ -178,6 +174,28 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
       }
     }
     return settled;
+  }
+
+  /**
+   * Admission-time counterpart of {@link settleGrantedRequests}: if the
+   * requesting scoop's live policy already grants this subject with
+   * `NOPASSWD`, return `{ decision: 'allow' }` so the caller never
+   * registers or delivers a cone prompt. Returns `null` when the cone
+   * must decide (no manager, unknown scoop, ungranted subject).
+   */
+  private admitIfAlreadyGranted(scoopJid: string, request: SudoRequest): SudoDecision | null {
+    const scoop = this.deps.getScoops().get(scoopJid);
+    const sudoManager = this.deps.getSudoManager();
+    if (!scoop || !sudoManager) return null;
+    const policy = sudoManager.getPolicyForScoop(scoop.folder);
+    if (!isNopasswdGranted(policy, request)) return null;
+    log.info('Sudo request already granted by policy — skipping cone', {
+      scoopJid,
+      folder: scoop.folder,
+      kind: request.kind,
+      detailPreview: request.detail.slice(0, 80),
+    });
+    return { decision: 'allow' };
   }
 
   async enqueueSudoRequest(
@@ -204,6 +222,13 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
       });
       return { decision: 'deny' };
     }
+
+    // Same grant match as settleGrantedRequests, but at admission: a subject
+    // the scoop's policy already NOPASSWD-grants must not raise a cone prompt
+    // (#2853). The reload sweep still covers requests that were pending when
+    // the grant landed. Identity checks above stay fail-closed first.
+    const alreadyGranted = this.admitIfAlreadyGranted(scoopJid, request);
+    if (alreadyGranted) return alreadyGranted;
 
     // The approver rides ON the registry entry, so it is retired by whichever
     // settle path fires — decision, timeout, `failScoop`, `failAll`, or a
@@ -457,6 +482,26 @@ export class ScoopApprovalRouter implements ConeApprovalRouter {
 
     await this.deps.handleMessage(msg);
   }
+}
+
+/**
+ * The grant match {@link ScoopApprovalRouter.settleGrantedRequests} uses on
+ * policy reload, and that {@link ScoopApprovalRouter.enqueueSudoRequest}
+ * uses at admission. Only a `NOPASSWD` hit short-circuits — a matching
+ * passworded rule still requires the cone. `secret` / `export` / guest
+ * kinds have no matching directive here, so they always escalate.
+ *
+ * Delegates to {@link matchPath} / {@link matchCommand} so self-protection
+ * (`/etc/sudoers`, per-scoop sudoers, layouts) stays absolute: a
+ * `NOPASSWD Write /**` cannot skip the cone for a protected write.
+ */
+function isNopasswdGranted(policy: SudoersPolicy, request: SudoRequest): boolean {
+  const { kind, detail } = request;
+  if (kind === 'command') return matchCommand(policy, detail) === 'nopasswd-allow';
+  if (kind === 'read' || kind === 'write') {
+    return matchPath(policy, kind, detail) === 'nopasswd-allow';
+  }
+  return false;
 }
 
 function formatSudoRequestNotification(

--- a/packages/webapp/src/scoops/scoop-management-tools.ts
+++ b/packages/webapp/src/scoops/scoop-management-tools.ts
@@ -862,7 +862,7 @@ function sudoRequestTool(config: ScoopManagementToolsConfig): ToolDefinition {
   return {
     name: 'sudo_request',
     description:
-      "Ask the cone for an explicit sudo escalation before running a sensitive action. Use this when you know up-front that a command, read, or write will be gated and you want a clean approval round-trip instead of letting the gate fire mid-action. Resolves with the cone's decision (allow / always / deny). 'always' durably widens your sandbox by appending a NOPASSWD rule to /scoops/<folder>/etc/sudoers. 'deny' (or a timeout / dropped cone) resolves fail-closed.",
+      "Ask the cone for an explicit sudo escalation before running a sensitive action. Use this when you know up-front that a command, read, or write will be gated and you want a clean approval round-trip instead of letting the gate fire mid-action. Resolves with the cone's decision (allow / always / deny). If your sudoers already grants the subject with NOPASSWD, this resolves allow immediately without prompting the cone. 'always' durably widens your sandbox by appending a NOPASSWD rule to /scoops/<folder>/etc/sudoers. 'deny' (or a timeout / dropped cone) resolves fail-closed.",
     inputSchema: {
       type: 'object',
       properties: {

--- a/packages/webapp/tests/scoops/orchestrator.test.ts
+++ b/packages/webapp/tests/scoops/orchestrator.test.ts
@@ -3206,6 +3206,35 @@ describe('Orchestrator.enqueueSudoRequest lick emission', () => {
     await pendingDecision;
   });
 
+  it('skips the cone when the scoop policy already grants the subject (issue #2853)', async () => {
+    const onIncoming = vi.fn();
+    const container =
+      typeof document !== 'undefined'
+        ? document.createElement('div')
+        : ({ appendChild: () => {} } as unknown as HTMLElement);
+    orch = new Orchestrator(container, {
+      onResponse: vi.fn(),
+      onResponseDone: vi.fn(),
+      onSendMessage: vi.fn(),
+      onStatusChange: vi.fn(),
+      onError: vi.fn(),
+      onIncomingMessage: onIncoming,
+      getBrowserAPI: vi.fn(() => ({}) as any),
+    });
+    await orch.init();
+
+    const emitEvent = vi.fn();
+    orch.setLickManager({ emitEvent, setScoopExistenceResolver: vi.fn() } as any);
+
+    // Default scoop sudoers includes `NOPASSWD Cmnd *`.
+    await expect(
+      orch.enqueueSudoRequest(testScoop.jid, { kind: 'command', detail: 'git status' })
+    ).resolves.toEqual({ decision: 'allow' });
+    expect(emitEvent).not.toHaveBeenCalled();
+    expect(onIncoming).not.toHaveBeenCalled();
+    expect(orch.listPendingSudoRequests()).toHaveLength(0);
+  });
+
   it.each([
     ['allow', 'confirmed'],
     ['always', 'confirmed'],
@@ -3233,10 +3262,13 @@ describe('Orchestrator.enqueueSudoRequest lick emission', () => {
       const emitEvent = vi.fn();
       orch.setLickManager({ emitEvent, setScoopExistenceResolver: vi.fn() } as any);
 
+      // Default scoop policy is `NOPASSWD Cmnd *`, so a command request is
+      // already granted and would skip the cone (#2853). Use a write outside
+      // writablePaths so this still exercises delivery + persist.
       const pendingDecision = orch.enqueueSudoRequest(testScoop.jid, {
-        kind: 'command',
-        detail: 'rm -rf /tmp/x',
-        suggestedPattern: 'rm *',
+        kind: 'write',
+        detail: '/workspace/build/output.txt',
+        suggestedPattern: '/workspace/build/**',
       });
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
@@ -3288,8 +3320,8 @@ describe('Orchestrator.enqueueSudoRequest lick emission', () => {
     // No setLickManager call — `lickManager` stays null.
 
     const pendingDecision = orch.enqueueSudoRequest(testScoop.jid, {
-      kind: 'command',
-      detail: 'rm -rf /tmp/x',
+      kind: 'write',
+      detail: '/workspace/build/output.txt',
     });
 
     await new Promise<void>((resolve) => setTimeout(resolve, 0));

--- a/packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts
+++ b/packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts
@@ -75,7 +75,10 @@ describe('ScoopApprovalRouter persistence settlement', () => {
           finishAppend = resolve;
         })
     );
-    const sudoManager = { appendScoopRule } as unknown as SudoManager;
+    const sudoManager = {
+      appendScoopRule,
+      getPolicyForScoop: () => parseSudoers(''),
+    } as unknown as SudoManager;
     const h = makeHarness(sudoManager);
     const pendingDecision = h.router.enqueueSudoRequest('scoop_a', {
       kind: 'read',
@@ -108,14 +111,22 @@ describe('ScoopApprovalRouter persistence settlement', () => {
 // covers must resolve as allow instead of stalling until individually approved
 // (which also appended duplicate rules).
 describe('ScoopApprovalRouter settleGrantedRequests (issue #2416)', () => {
-  function managerGranting(rules: string): SudoManager {
+  /** Mutable so tests can enqueue under an empty policy, then apply a grant. */
+  function managerGranting(rules: string): SudoManager & { setRules(next: string): void } {
+    let current = rules;
     return {
-      getPolicyForScoop: () => parseSudoers(rules),
-    } as unknown as SudoManager;
+      getPolicyForScoop: () => parseSudoers(current),
+      setRules(next: string) {
+        current = next;
+      },
+    } as unknown as SudoManager & { setRules(next: string): void };
   }
 
   it('resolves pending path requests now covered by a NOPASSWD grant', async () => {
-    const h = makeHarness(managerGranting('NOPASSWD Write /.playwright/**'));
+    // Enqueue first (ungranted), then widen policy — the reload sweep, not
+    // admission. Admission would short-circuit a request already granted.
+    const mgr = managerGranting('');
+    const h = makeHarness(mgr);
     const covered = h.router.enqueueSudoRequest('scoop_a', {
       kind: 'write',
       detail: '/.playwright/screenshots/x.png',
@@ -127,6 +138,7 @@ describe('ScoopApprovalRouter settleGrantedRequests (issue #2416)', () => {
     await flush();
     expect(h.router.listPendingSudoRequests()).toHaveLength(2);
 
+    mgr.setRules('NOPASSWD Write /.playwright/**');
     const settled = h.router.settleGrantedRequests('scoop_a-folder');
     await flush();
 
@@ -142,25 +154,29 @@ describe('ScoopApprovalRouter settleGrantedRequests (issue #2416)', () => {
   });
 
   it('resolves pending command requests now covered by a NOPASSWD Cmnd grant', async () => {
-    const h = makeHarness(managerGranting('NOPASSWD Cmnd git *'));
+    const mgr = managerGranting('');
+    const h = makeHarness(mgr);
     const covered = h.router.enqueueSudoRequest('scoop_a', {
       kind: 'command',
       detail: 'git status',
     });
     await flush();
 
+    mgr.setRules('NOPASSWD Cmnd git *');
     expect(h.router.settleGrantedRequests('scoop_a-folder')).toBe(1);
     await expect(covered).resolves.toEqual({ decision: 'allow' });
   });
 
   it('only settles requests from the scoop whose policy reloaded', async () => {
-    const h = makeHarness(managerGranting('NOPASSWD Write /.playwright/**'));
+    const mgr = managerGranting('');
+    const h = makeHarness(mgr);
     const other = h.router.enqueueSudoRequest('scoop_a', {
       kind: 'write',
       detail: '/.playwright/x.png',
     });
     await flush();
 
+    mgr.setRules('NOPASSWD Write /.playwright/**');
     expect(h.router.settleGrantedRequests('some-other-folder')).toBe(0);
     expect(h.router.listPendingSudoRequests()).toHaveLength(1);
     h.router.failAll();
@@ -180,6 +196,7 @@ describe('ScoopApprovalRouter settleGrantedRequests (issue #2416)', () => {
       [requester.jid, requester],
     ]);
     const store: ChannelMessage[] = [];
+    let rules = '';
     const deps: ScoopApprovalRouterDeps = {
       getScoops: () => scoops,
       // Real approver semantics: the requesting scoop's parent; the DEFAULT
@@ -188,7 +205,7 @@ describe('ScoopApprovalRouter settleGrantedRequests (issue #2416)', () => {
       findApprover: (jid) => (jid === requester.jid ? coneB : coneA),
       getSudoManager: () =>
         ({
-          getPolicyForScoop: () => parseSudoers('NOPASSWD Write /.playwright/**'),
+          getPolicyForScoop: () => parseSudoers(rules),
         }) as unknown as SudoManager,
       getLickManager: () => null,
       handleMessage: async (msg) => {
@@ -212,6 +229,7 @@ describe('ScoopApprovalRouter settleGrantedRequests (issue #2416)', () => {
     const card = store.find((m) => m.chatJid === coneB.jid);
     expect(card?.lickState).toBe('pending');
 
+    rules = 'NOPASSWD Write /.playwright/**';
     expect(router.settleGrantedRequests(requester.folder)).toBe(1);
     await flush();
 
@@ -289,8 +307,123 @@ describe('ScoopApprovalRouter settleGrantedRequests (issue #2416)', () => {
     await expect(second).resolves.toEqual({ decision: 'allow' });
     expect(h.router.listPendingSudoRequests()).toHaveLength(0);
 
+    // #2853: a NEW request for the now-granted subtree must not trouble the cone.
+    const third = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'write',
+      detail: '/.playwright/screenshots/two.png',
+    });
+    await expect(third).resolves.toEqual({ decision: 'allow' });
+    expect(h.handleMessage).toHaveBeenCalledTimes(2);
+    expect(h.router.listPendingSudoRequests()).toHaveLength(0);
+
     mgr.dispose();
     await vfs.dispose?.();
+  });
+});
+
+describe('ScoopApprovalRouter admission-time grant match (issue #2853)', () => {
+  function managerGranting(rules: string): SudoManager {
+    return {
+      getPolicyForScoop: () => parseSudoers(rules),
+    } as unknown as SudoManager;
+  }
+
+  it('resolves allow immediately for a NOPASSWD-granted write path without prompting the cone', async () => {
+    const h = makeHarness(managerGranting('NOPASSWD Write /.playwright/**'));
+    const covered = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'write',
+      detail: '/.playwright/snapshots',
+      suggestedPattern: '/.playwright/**',
+    });
+
+    await expect(covered).resolves.toEqual({ decision: 'allow' });
+    expect(h.handleMessage).not.toHaveBeenCalled();
+    expect(h.router.listPendingSudoRequests()).toHaveLength(0);
+    expect(h.store).toHaveLength(0);
+  });
+
+  it('still escalates an ungranted write path', async () => {
+    const h = makeHarness(managerGranting('NOPASSWD Write /.playwright/**'));
+    const uncovered = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'write',
+      detail: '/.nogrant-test',
+    });
+    await flush();
+
+    expect(h.handleMessage).toHaveBeenCalledOnce();
+    expect(h.router.listPendingSudoRequests()).toHaveLength(1);
+    expect(h.store[0]?.lickState).toBe('pending');
+    h.router.failAll();
+    await expect(uncovered).resolves.toEqual({ decision: 'deny' });
+  });
+
+  it('resolves allow immediately for a NOPASSWD-granted command', async () => {
+    const h = makeHarness(managerGranting('NOPASSWD Cmnd git *'));
+    const covered = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'command',
+      detail: 'git status',
+    });
+
+    await expect(covered).resolves.toEqual({ decision: 'allow' });
+    expect(h.handleMessage).not.toHaveBeenCalled();
+    expect(h.router.listPendingSudoRequests()).toHaveLength(0);
+  });
+
+  it('still escalates a matching rule that is not NOPASSWD', async () => {
+    const h = makeHarness(managerGranting('Write /.playwright/**'));
+    const pending = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'write',
+      detail: '/.playwright/x.png',
+    });
+    await flush();
+
+    expect(h.handleMessage).toHaveBeenCalledOnce();
+    expect(h.router.listPendingSudoRequests()).toHaveLength(1);
+    h.router.failAll();
+    await expect(pending).resolves.toEqual({ decision: 'deny' });
+  });
+
+  it('does not let a granted suggested_pattern smuggle an ungranted detail', async () => {
+    const h = makeHarness(managerGranting('NOPASSWD Write /.playwright/**'));
+    const pending = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'write',
+      detail: '/.nogrant-test',
+      suggestedPattern: '/.playwright/**',
+    });
+    await flush();
+
+    expect(h.handleMessage).toHaveBeenCalledOnce();
+    expect(h.router.listPendingSudoRequests()).toHaveLength(1);
+    h.router.failAll();
+    await expect(pending).resolves.toEqual({ decision: 'deny' });
+  });
+
+  it('still escalates a self-protected sudoers write despite NOPASSWD Write /**', async () => {
+    const h = makeHarness(managerGranting('NOPASSWD Write /**'));
+    const pending = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'write',
+      detail: '/scoops/scoop_a-folder/etc/sudoers',
+    });
+    await flush();
+
+    expect(h.handleMessage).toHaveBeenCalledOnce();
+    expect(h.router.listPendingSudoRequests()).toHaveLength(1);
+    h.router.failAll();
+    await expect(pending).resolves.toEqual({ decision: 'deny' });
+  });
+
+  it('still escalates a secret request even when other grants exist', async () => {
+    const h = makeHarness(managerGranting('NOPASSWD Write /**\nNOPASSWD Cmnd *'));
+    const pending = h.router.enqueueSudoRequest('scoop_a', {
+      kind: 'secret',
+      detail: 'GITHUB_TOKEN',
+    });
+    await flush();
+
+    expect(h.handleMessage).toHaveBeenCalledOnce();
+    expect(h.router.listPendingSudoRequests()).toHaveLength(1);
+    h.router.failAll();
+    await expect(pending).resolves.toEqual({ decision: 'deny' });
   });
 });
 


### PR DESCRIPTION
Closes #2853.

## Summary

A scoop that called `sudo_request` for a subject its own sudoers already granted with `NOPASSWD` (for example `NOPASSWD Write /.playwright/**`) still raised a cone escalation. The write gate already honoured the grant; the explicit tool did not. After this change, an already-granted subject resolves `allow` immediately and never troubles the cone.

## Why

`ScoopApprovalRouter.settleGrantedRequests()` already implements the right grant match, but it only ran on policy reload for *pending* requests. A new request for a subject granted earlier (an "Always" persist, a config `writablePaths` entry, a sudoers edit) arrived after that reload, so nothing consulted the policy at admission. That broke the #2455 invariant ("never prompt for pre-granted writablePaths") and `lick_confirm`'s promise that the same action will not prompt again.

**Repro**

1. Scoop sudoers contains `NOPASSWD Write /.playwright/**`.
2. `mkdir -p /.playwright/snapshots` — exit 0, no escalation.
3. `sudo_request { kind: "write", detail: "/.playwright/snapshots" }` — cone prompt was raised.

Expected: resolve `allow` without a cone prompt. Actual: cone escalation.

#2455 is cited only as the invariant this restores; it is not reopened.

## Approach / Implementation notes

- Extracted the existing `matchCommand` / `matchPath` === `nopasswd-allow` check as `isNopasswdGranted` and reuse it from both `settleGrantedRequests` (reload sweep) and `enqueueSudoRequest` (admission).
- Admission runs *after* the fail-closed identity checks (no approver / unknown scoop still deny) and *before* registry register / lick emit / cone delivery.
- The match is on `detail`, not `suggested_pattern`, so a granted pattern cannot smuggle an ungranted path.
- Self-protection is unchanged: `matchPath` still returns `require-approval` for `/etc/sudoers`, per-scoop sudoers, and layouts, even under `NOPASSWD Write /**`.
- Passworded matching rules (no `NOPASSWD`) and `secret` / guest kinds still escalate.
- Sudoers syntax and the write gate are untouched.

Out of scope (called out in the issue as a second-order effect): surfacing `SudoSettleReason` on a late `lick_confirm`. Admission no longer manufactures those phantom pending licks for already-granted subjects.

## Cross-cutting impact

- **Floats**: CLI / extension / Electron / hosted leader all share `ScoopApprovalRouter`; no per-float fork.
- **Write gate**: still checks policy before calling the broker. Admission is defense in depth for the explicit `sudo_request` tool (and any broker call that reaches enqueue).
- **Default scoop policy** includes `NOPASSWD Cmnd *`, so a command `sudo_request` on a default scoop now correctly skips the cone. Tests that needed a pending lick switched to an ungranted write (`/workspace/build/output.txt`).
- **Persisted state**: none. No sudoers rewrite, no new IndexedDB shape.
- **Bundle size**: worker first-load +0.5 kB vs merge-base (under the 5 kB allowance).

## Test plan

- [x] `npm run verify` — 8/8 (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod, autofix-drift)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists
- [x] `npm run typecheck`
- [x] `npm run test` — 19754 passed, 46 skipped, no new failures
- [x] `npm run test:coverage:webapp` — floor held (lines 85.19%)
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run bundle-size` — first-load OK; extension size-limit OK
- [x] New / changed behavior covered in `packages/webapp/tests/scoops/scoop-approval-router-settle.test.ts` and `orchestrator.test.ts`:
  - NOPASSWD-granted write path → `allow`, no cone delivery
  - ungranted path still escalates
  - passworded (non-NOPASSWD) match still escalates
  - `suggested_pattern` cannot smuggle an ungranted `detail`
  - self-protected sudoers write still escalates under `NOPASSWD Write /**`
  - secret still escalates
  - policy-reload sweep still auto-settles *pending* covered requests
  - after an `always` persist, a *new* request for the granted subtree skips the cone
  - real Orchestrator: default `NOPASSWD Cmnd *` skips the cone for a command request

## Documentation

- [x] `docs/approvals.md` — admission-time grant match next to the reload sweep
- [x] `docs/tools-reference.md` — `sudo_request` resolves immediately when already granted
- [x] `sudo_request` tool description (agent-facing schema)

## Risk & rollback

- Blast radius: cone-mediated sudo for every float. Fail-closed identity checks are unchanged; only a `nopasswd-allow` hit short-circuits.
- Rollback: revert this PR. No persisted-state migration.
- CI cannot catch a live cone-turn UX miss; the unit + orchestrator tests pin no-delivery vs delivery.

## Checklist

- [x] Commits are focused and package-local
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Linear history (rebased onto `origin/main`; no merge)
