### PR TITLE
docs(vfs-root): cut /shared/CLAUDE.md to constitutional invariants

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -23,7 +23,7 @@ This file covers the documentation surface in `docs/`.
 | ------------------------------------------------------- | ------ | ----- | ------------------------ |
 | `CLAUDE.md` (root)                                      | 15,000 | chars | enforced                 |
 | `packages/*/CLAUDE.md`                                  | 20,000 | chars | enforced                 |
-| `packages/vfs-root/shared/CLAUDE.md`                    | 3,000  | bytes | bundled into the VFS     |
+| `packages/vfs-root/shared/CLAUDE.md`                    | 2,048  | bytes | bundled into the VFS     |
 | `.github/copilot-instructions.md` + `*.instructions.md` | 4,000  | chars | Copilot truncation limit |
 
 All package `CLAUDE.md` files are now within the 20,000-char cap. The grandfathered

--- a/docs/dev-tools-details.md
+++ b/docs/dev-tools-details.md
@@ -73,7 +73,7 @@ Two details that are easy to get wrong and are therefore pinned by tests:
   (`PACKAGE_CLAUDE_MAX_CHARS`, via `lint:docs`); the compactor's policy is
   10,000 → 9,500 across _every_ tracked `CLAUDE.md`. A 12,000-char guide passes
   `lint:docs` and is still compaction work. `packages/vfs-root/shared/CLAUDE.md`
-  (3,000 **bytes**, bundled into the VFS) is excluded by construction. Sizes are
+  (2,048 **bytes**, bundled into the VFS) is excluded by construction. Sizes are
   measured with `String.length`, never bytes. Every oversized guide fans out
   as its own Claude job (largest first; `max_guides` caps N, default all); a
   `--check` miss still publishes a **partial** shard when that guide actually

--- a/packages/dev-tools/claude-md-compactor/lib.mjs
+++ b/packages/dev-tools/claude-md-compactor/lib.mjs
@@ -89,7 +89,7 @@ export function computeMaxTurns(worklist, { targetChars = COMPACTOR_TARGET_CHARS
  * Guides the compactor must never select, whatever their length.
  *
  * `packages/vfs-root/shared/CLAUDE.md` is the agent-facing runtime guide. It is
- * bundled into the VFS and budgeted at AGENT_CLAUDE_MAX_BYTES = 3,000 BYTES by
+ * bundled into the VFS and budgeted at AGENT_CLAUDE_MAX_BYTES = 2,048 BYTES by
  * `packages/dev-tools/tools/check-doc-sizes.mjs` — an order of magnitude
  * stricter than this policy, measured in bytes rather than characters, and it
  * already sits close to its cap. It can therefore never be oversized at a

--- a/packages/dev-tools/tools/check-doc-sizes.mjs
+++ b/packages/dev-tools/tools/check-doc-sizes.mjs
@@ -33,11 +33,12 @@ const Filename = fileURLToPath(import.meta.url);
 const repoRoot = resolve(dirname(Filename), '..', '..', '..');
 
 const ROOT_CLAUDE_MAX_CHARS = 15000;
-// Raised from 3000 in the markdown-media change: the file had 5 bytes of
-// headroom, and inline image/video syntax has no other discovery path (there
-// is no `--help` for markdown). Everything still in the file is a deliberate
-// instruction, so the budget moved rather than the guidance being thinned.
-const AGENT_CLAUDE_MAX_BYTES = 3300;
+// Lowered from 3300: the file is injected verbatim into every work unit's
+// system prompt, so anything the prompt assembler, the injected skill index, or
+// `man` already states is paid for on every turn. It now holds only what those
+// do not say. Headroom is deliberate — the previous cap ran at 5 bytes and had
+// to be raised to document one new capability.
+const AGENT_CLAUDE_MAX_BYTES = 2048;
 const COPILOT_INSTRUCTIONS_MAX_CHARS = 4000;
 
 const measureChars = (text) => text.length;

--- a/packages/vfs-root/CLAUDE.md
+++ b/packages/vfs-root/CLAUDE.md
@@ -117,9 +117,9 @@ apply` merge) would prompt the owner to approve the default already in force (#2
 ## External Handoffs
 
 - Mechanism: RFC 8288 `Link` response header carrying `https://www.sliccy.ai/rel/handoff` or `https://www.sliccy.ai/rel/upskill` on a main-frame document response → `navigate` lick → cone approval card.
-- Agent-facing flow: `packages/vfs-root/workspace/skills/handoff/SKILL.md` (bundled to `/workspace/skills/handoff/SKILL.md`) and the trigger line in `shared/CLAUDE.md` (bundled to `/shared/CLAUDE.md`).
+- Agent-facing flow: `packages/vfs-root/workspace/skills/handoff/SKILL.md` (bundled to `/workspace/skills/handoff/SKILL.md`); the agent reaches it through the injected skill index, not through `shared/CLAUDE.md`, which only states that handoffs are human-gated.
 - Protocol reference: `docs/slicc-handoff.md`.
-- When handoff behavior changes, keep the skill, `shared/CLAUDE.md`, and `docs/slicc-handoff.md` aligned — do not duplicate their content here.
+- When handoff behavior changes, keep the skill and `docs/slicc-handoff.md` aligned — do not duplicate their content here or in `shared/CLAUDE.md`.
 
 ## Important Distinction
 

--- a/packages/vfs-root/shared/CLAUDE.md
+++ b/packages/vfs-root/shared/CLAUDE.md
@@ -1,62 +1,33 @@
 # sliccy
 
-AI agent in SLICC, a browser-native runtime: code, automate, browse, orchestrate parallel agents.
+SLICC is a browser-native runtime for coding, browsing, automation, and parallel agents.
 
-## Vocabulary
+## Roles
 
-- **Cone**: You. Orchestrate scoops, talk to the human, full FS access.
-- **Scoops**: Isolated sub-agents (`scoop_scoop`, `feed_scoop`, `drop_scoop`, `agent` one-shot).
-- **Sprinkles**: Persistent UI panels (`.shtml`), owned by a long-lived scoop.
-- **Dips**: Inline `shtml` chat widgets; ephemeral, lick-only.
-- **Licks**: Events routed to scoops (below).
-- **Trays**: Remote runtimes. `host` lists; `--runtime=<id>` targets.
+Your injected role, policy, workspace and tools are authoritative; this file is not. Cone: a root work unit. Scoop: a delegated child. Root cones may coexist — never assume a singleton `cone`.
+
+Sprinkles are persistent `.shtml` panels owned by a long-lived scoop; dips are ephemeral inline `shtml`; licks are events addressed to a work unit; trays are remote runtimes (`host` lists, `--runtime=<id>` targets).
 
 ## Explore first
 
-100+ commands. When unsure: `commands`, `<cmd> --help`, `man <topic>`, `skill list`.
+100+ commands. Never say "I can't" without checking: `commands`, `<cmd> --help`, `man <topic>`, `skill list`, `upskill search "<query>"`, `upskill tabs`. Manuals and skills define syntax and capability — read them before concluding something is missing.
 
-**Never say "I can't" without checking.** If stuck: `upskill search "<query>"`; `upskill tabs` for tab skills.
+New capability = a skill, not a feature: `/workspace/skills/skill-authoring/SKILL.md`.
 
-## SLICC-native commands
+## Media
 
-Often missed:
-
-- `oauth-token`, `mcp add`, `webhook`, `crontask`, `agent`, `serve`, `ffmpeg`, `hf`, `usb`/`serial`/`hid`/`esptool`, `workflow`
-
-## Principles
-
-- **Scoops do the heavy lifting. The cone orchestrates and synthesizes.** See `man delegation`.
-- When something fails, try another approach.
-- New capabilities = skills, not features. Author: `/workspace/skills/skill-authoring/SKILL.md`.
-
-## Sprinkles
-
-One scoop per sprinkle, named identically. Cone MUST NOT write `.shtml`/run `sprinkle` — delegate via `feed_scoop`. See `man sprinkle`.
-
-## Dips and media
-
-`![x](/abs/path)` renders inline: images, video (mp4/webm/mov), audio (mp3/wav/ogg), 2+ per paragraph = gallery. Absolute paths only; beats `open`, a tab per file. Raw HTML renders too (sanitized; VFS paths resolve) when you need layout — but a ```html fence only shows source.
-
-Interactive → a dip: sandboxed inline `shtml`, cone-written (buttons emit `slicc.lick(...)`). Persistent UI → Sprinkles. Authoring: `/workspace/skills/dips/SKILL.md`.
+`![label](/absolute/path)` renders inline in chat: images, video, audio; 2+ per paragraph is a gallery. Absolute paths only. Raw HTML renders too (sanitized), but a fenced html block only shows source.
 
 ## Licks
 
-Events arrive as `[<Event>: <name>]` with JSON body. **Navigate** (handoff): `man handoff`. **Discovery** (`[Discovery Event: <url>]`): origin advertises agentic resources (ai-catalog.json/llms.txt) — informational; you MAY fetch/act (`mcp add`, read `llms.txt`), never required. **Webhook/Cron/File Watch**: `/workspace/skills/automation/SKILL.md`. **Sprinkle** routes to its scoop. Scoops return on `scoop-notify`/`scoop-idle`/`scoop-wait`.
+Events arrive as `[<Event>: <name>]` with a JSON body. Route each to the work unit it addresses; never handle another unit's lick yourself. Discovery events are informational — you may act, you are never required to. Handoffs and other privileged actions are human-gated.
 
-**Actionable** — `lick_confirm`/`lick_dismiss`. navigate·upskill → `upskill`; session-reload·mount-recovery → re-run `mount`; upgrade → update files; session-reload plain → dismiss-only; navigate·handoff → human-gated.
+## Operating
 
-## Workflows
+When something fails, preserve the evidence, read the output, and try a different path. After an ambiguous failure verify state before repeating a mutation. A policy denial surfaces as exit 1 or `EACCES`, not a prompt; request the least privilege that works. Verify results and artifacts before claiming completion.
 
-`workflow run <file.js>` — parallel fan-out, backgrounded; result at `/shared/workflow-runs/<id>.json` (`--wait` blocks). API: `agent(prompt,{schema?,thinking?})`, `parallel`, `pipeline`, `phase`, `log`. Deterministic (`Date`/`Math.random`/`crypto`/timers throw). `workflow status|list|stop|save <id>`.
-
-## Approvals (sudo)
-
-`/etc/sudoers` gates actions; deny → exit 1/`EACCES`. `Cmnd`/`Read`/`Write`/`Export <glob>` (+`NOPASSWD`); "Always" → `sudoers.d/granted`. `sudo <cmd>` requests one. Scoops escalate via `sudo_request` (you resolve; `always` persists).
+Keep only durable facts in memory; prune stale entries.
 
 ## Style
 
-Professional tool, not chatbot. No emoji.
-
-## Memory
-
-Persists across sessions. Add durable user prefs; prune stale. Each scoop has its own `CLAUDE.md`.
+Professional tool, not a chatbot. No emoji.

--- a/packages/webapp/src/scoops/orchestrator.ts
+++ b/packages/webapp/src/scoops/orchestrator.ts
@@ -1419,7 +1419,7 @@ export class Orchestrator implements ConeApprovalRouter {
     return this.messageRouter.handleMessage(message);
   }
 
-  /** Delegate a prompt directly to a scoop's agent. Used by the delegate_to_scoop tool. */
+  /** Delegate a prompt directly to a scoop's agent. Used by the feed_scoop tool. */
   delegateToScoop(scoopJid: string, prompt: string, senderName: string): Promise<void> {
     return this.messageRouter.delegateToScoop(scoopJid, prompt, senderName);
   }

--- a/packages/webapp/src/scoops/scoop-context/system-prompt.ts
+++ b/packages/webapp/src/scoops/scoop-context/system-prompt.ts
@@ -63,7 +63,7 @@ ${policy.canWriteSharedMemory ? '- **update_global_memory**: Update the global C
 }
 ## Delegating to Scoops
 
-Use the **delegate_to_scoop** tool to send work to scoops. IMPORTANT:
+Use the **feed_scoop** tool to send work to scoops. IMPORTANT:
 - The scoop has NO access to your conversation history
 - You MUST write a **complete, self-contained prompt** with ALL context, instructions, file paths, URLs, etc.
 - If the user says "do the same" or references earlier work, YOU must expand that into explicit instructions

--- a/packages/webapp/src/scoops/scoop-message-router.ts
+++ b/packages/webapp/src/scoops/scoop-message-router.ts
@@ -162,12 +162,12 @@ export class ScoopMessageRouter {
     await this.deps.db.saveMessage(message);
 
     // Route to the direct target (chatJid) only.
-    // No @mention scanning — the cone delegates to scoops via the delegate_to_scoop tool,
+    // No @mention scanning — the cone delegates to scoops via the feed_scoop tool,
     // which lets it add context/clarification before routing.
     await this.routeToScoop(message);
   }
 
-  /** Delegate a prompt directly to a scoop's agent. Used by the delegate_to_scoop tool. */
+  /** Delegate a prompt directly to a scoop's agent. Used by the feed_scoop tool. */
   async delegateToScoop(scoopJid: string, prompt: string, senderName: string): Promise<void> {
     const scoop = this.deps.getScoops().get(scoopJid);
     if (!scoop) throw new Error(`Scoop not found: ${scoopJid}`);


### PR DESCRIPTION
Fixes #2860

## Summary

Cuts `packages/vfs-root/shared/CLAUDE.md` from 3,253 to **1,826 bytes** and lowers `AGENT_CLAUDE_MAX_BYTES` from 3300 to **2048**. The file keeps only what the prompt assembler does not already say; the duplicated command catalogue, lick dispatch table, workflow API, and sudo grammar are gone.

Before: every scoop read `- **Cone**: You. Orchestrate scoops, talk to the human, full FS access.` in its own system prompt. Now the file defines Cone and Scoop as structural terms and asserts no identity, deferring to the injected role.

## Why

`/shared/CLAUDE.md` is injected verbatim into **every** work unit's system prompt as the `GLOBAL MEMORY` block, so every byte is paid for on every turn of every cone and every scoop. It had drifted from constitutional invariants into a duplicated manual.

It also carried a live defect. `scoop-context/memories.ts::loadMemories` returns the shared file for every unit unconditionally — the `canWriteSharedMemory` check only gates the write-back mirror — so every scoop read "Cone: **You**" one screen after `buildScoopSystemPrompt` (`system-prompt.ts:34`) had already told it it is "a scoop assistant". Roles are derived from the parent edge (`work-unit/types.ts:39` — "never stored") and root cones may coexist (#1666), so the singleton framing was wrong twice over.

## Approach / Implementation notes

What remains is only what the assembler does *not* say: the explore-before-refusing imperative, the dip / lick / tray vocabulary, the markdown media syntax (no `--help` exists for markdown — the reason #2854 raised the cap), lick routing to the addressed unit, and tone.

Dropped content and where it stays reachable:

| Dropped | Destination |
| --- | --- |
| "Cone: You" + scoop tool names | `system-prompt.ts:34`, `:51-62` (policy-gated) |
| SLICC-native command list | `commands` (`help-command.ts`) |
| Delegation principle | `system-prompt.ts:64-74`; `delegation` skill; `man delegation` |
| Sprinkle ownership rules | `sprinkles/SKILL.md:219-229`; `man sprinkle` |
| Dip authoring pointer | injected `AVAILABLE SKILLS` entry for `dips` |
| Lick dispatch table | `automation/SKILL.md`; `man lick`; `lick_confirm`/`lick_dismiss` tool schemas |
| Workflow API | `workflows/SKILL.md`; `man workflow`; `workflow --help` |
| Sudo grammar | `man sudo`; `docs/approvals.md`; readable `/etc/sudoers` |
| Memory hierarchy | `system-prompt.ts:84-92` |

Two fixes ride along:

1. **`system-prompt.ts:66` advertised a `delegate_to_scoop` tool that is not registered anywhere.** The real tool is `feed_scoop` (`scoop-management-tools.ts:894`); the only other hits for the old name are comments. The policy guard cited in the issue governs the capability *gate*, not the tool *name* — and this mattered the moment the shared file stopped naming the real one.
2. **The cap was documented in three places, two already stale at 3,000** — `docs/CLAUDE.md`, `claude-md-compactor/lib.mjs`, `docs/dev-tools-details.md`. All three now say 2,048.

`packages/vfs-root/CLAUDE.md` also cited a "trigger line in `shared/CLAUDE.md`" for handoffs that this change deletes; it now points at the skill.

Deliberate choices:

- **2,048, not a hard 2,000.** The issue's draft lands at exactly 2,000 bytes. Zero headroom is what forced 3,000 → 3,300 in #2854; this ships at 1,826 with 222 bytes to spare.
- **`man` topics are singular.** `man` is a network fetch to `www.sliccy.com/man/<topic>.plain.html` (`man-command.ts:48`). Verified live: `commands`, `delegation`, `sprinkle`, `handoff`, `sudo`, `workflow`, `lick` → 200; the plurals `sprinkles`, `workflows`, `licks` → 404. The file does not *depend* on `man` — "Explore first" lists local paths too, since egress-blocked floats cannot reach it.
- **Left out the issue's "keep at most 3-4 active browser drivers" line.** That number is an operator observation with no source in `cdp/` or `docs/`. Enshrining an unmeasured limit in a constitutional file contradicts the issue's own thesis. Worth raising separately, as a comment near the bridge, if it holds.

## Cross-cutting impact

- **Floats**: the file is bundled into the VFS, so all floats (CLI, extension, Electron, Sliccstart, worker) get the new text identically. No float-specific path touched.
- **Every work unit's prompt changes** — that is the point. Cones lose the false-but-harmless "you are the cone" restatement; scoops lose a line that actively contradicted their injected role.
- **`system-prompt.ts` tool-name fix** affects the delegation instructions in every unit with `canManageChildren`. It replaces a name that resolves to nothing with the name that does.
- **No persisted state, no data shape, no migration.** `session-freezer` already excludes this file; the orchestrator's legacy `## Auto-extracted` migration reads the bundled default dynamically rather than by content.
- **Bundle size**: vfs-root docs inline into the kernel-worker bundle verbatim, so this is a ~1.4 kB reduction. `npm run size` reports worker −0.0 kB, 68 kB under ceiling.

## Test plan

- [x] `npx prettier --check` on every changed markdown file — clean
- [x] `npm run typecheck` — clean (all 9 projects)
- [x] `npm run test` — **19,740 passed, 52 skipped, 0 failed**
- [x] `npm run build`
- [x] `npm run build -w @slicc/chrome-extension`
- [x] `npm run lint` and `npm run lint:docs` — green; gate reports `shared/CLAUDE.md is 1826/2048 bytes`
- [x] `npm run size -w @slicc/webapp` — First-load OK
- [x] 8/8 pre-push checks
- [x] **Guard inverted rather than assumed**: padded the file to 2,126 bytes → `check-doc-sizes` exits 1 with the expected error; restored to 1,826. A green gate you have not seen fail proves nothing.

No new unit test: this PR changes prose in a bundled asset and one string in a prompt template, and no test asserts either literally. `orchestrator.test.ts:2577` reads the bundled default dynamically, `upgrade-command.test.ts` writes its own content, `session-freezer.test.ts` asserts absence. The `# sliccy` H1 is preserved because `.agents/skills/cdp-smoke-test/tier1-infrastructure.md:43` documents `head -1 /shared/CLAUDE.md` as a smoke-test assertion.

**Not verified locally** — worth a reviewer's eye on a live instance: that a scoop's `GLOBAL MEMORY` block no longer claims the reader is the cone.

**Pre-existing failures**: none observed; the suite was fully green.

## Documentation

- [x] Relevant `CLAUDE.md` (developer / package architecture) — `docs/CLAUDE.md` size-budget table, `packages/vfs-root/CLAUDE.md` handoff section
- [x] `docs/` (agent reference) — `docs/dev-tools-details.md` compactor exclusion note
- [x] `packages/vfs-root/shared/CLAUDE.md` (agent-facing) — this is the change

## Risk & rollback

- **Blast radius**: all floats, but only the agent's instruction text. No runtime behavior, no persisted state, no migration. Reverts cleanly as a single commit.
- **The real risk is discovery**, not breakage: an agent that would have skimmed the dropped command list must now run `commands`, `--help`, or `skill list`. That is why the explore-before-refusing paragraph stayed and got *stronger* wording rather than being trimmed with the rest.
- **Skill descriptions are only injected when the skill is loaded** (`loadSkills` over `SKILLS_LIBRARY_DIR`). A unit with a restricted `skillsFs` loses that discovery path; the local-first `commands` / `--help` guidance is the fallback.
- **CI cannot catch a prompt-quality regression.** If delegation, sprinkle handling, or lick routing gets noticeably worse in practice, the fix is to add the specific missing invariant back — there are 222 bytes of headroom — not to restore the manual.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, OAuth client secrets, or tokens in the diff
- [x] Public API / tool / shell-command / lick-channel changes are intentional and reflected in docs
- [x] If this changes a contract used by other floats, I checked the followers/leader/offscreen paths — the file is bundled identically for every float; no float-specific handling exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)
