### PR TITLE
fix(webapp): keep playwright-cli upload binary files byte-exact

### DIFF
--- a/docs/shell-reference.md
+++ b/docs/shell-reference.md
@@ -2100,7 +2100,7 @@ await fs.writeFile('/output.jpg', newBytes);
 
 ### Tools Supporting Binary
 
-- **playwright-cli**: `screenshot --filename=<path>` saves PNGs directly to the VFS
+- **playwright-cli**: `screenshot --filename=<path>` saves PNGs directly to the VFS; `upload` injects VFS files into a page file input as raw bytes (no UTF-8 round-trip)
 - **node** / **.jsh**: `fs.readFileBinary()`, `fs.writeFileBinary()` available
 - **bash**: Limited binary support (command output truncated at 100KB)
 

--- a/packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
+++ b/packages/vfs-root/workspace/skills/playwright-cli/SKILL.md
@@ -120,7 +120,7 @@ playwright-cli select --tab=<id> <ref> <value>                   # Select dropdo
 playwright-cli check --tab=<id> <ref>                            # Check checkbox/radio
 playwright-cli uncheck --tab=<id> <ref>                          # Uncheck checkbox/radio
 playwright-cli drag --tab=<id> <startRef> <endRef>               # Drag and drop
-playwright-cli upload --tab=<id> [ref] <file> [file...]          # Upload VFS files to file input (optional ref targets hidden inputs)
+playwright-cli upload --tab=<id> [ref] <file> [file...]          # Upload VFS files to file input as raw bytes (optional snapshot ref targets hidden inputs)
 playwright-cli drop --tab=<id> <ref> [--path=<vfs-path>] [--data=<mime/type=value>]  # Drop files/data onto element
 playwright-cli dialog-accept --tab=<id> [text]                   # Accept JS dialog
 playwright-cli dialog-dismiss --tab=<id>                         # Dismiss JS dialog
@@ -348,6 +348,7 @@ playwright-cli stop-recording <recordingId>        # Stop and save HAR
 - **Calling the app's own backend? Use `curlwright`, not `eval-file`.** It is curl's flags run by a `fetch()` inside the tab, so cookies, origin and session come along: `curlwright -s -X POST https://app.example.com/api/items -H 'X-CSRF-Token: abc' -d '{"name":"x"}' --tab=<id>`. `-o <file>` writes a **byte-exact** body, which `eval-file` cannot do at all — that is the only way to pull a binary response out of a page. Without `--tab` it uses the tab already on that origin. `curlwright --help` for the flag list.
 - `state-save` / `state-load` persist auth state (cookies + localStorage) across sessions.
 - `pdf` saves a print-layout PDF; not available in extension mode.
+- `upload` injects VFS files as **raw bytes** (a UTF-8 text round-trip would replace every byte ≥ 0x80 with `EF BF BD`). A leading `eN` / `fNeN` token is a snapshot ref, never a filename — run `snapshot` first; without a ref, focus the file input first. To upload a file named `e2`, pass `./e2` or an absolute path.
 
 ## Low-level CDP escape hatch
 

--- a/packages/webapp/src/shell/supplemental-commands/playwright/handlers/upload.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/handlers/upload.ts
@@ -2,15 +2,19 @@
  * Upload subcommand: upload [ref] <file> [file...]
  *
  * Uploads one or more VFS files to a file input element on the page using
- * DataTransfer injection. The optional leading ref (e.g. "e3") targets the
- * element directly via DOM.resolveNode + Runtime.callFunctionOn, which handles
- * the common `<label><input type="file" hidden>` pattern where clicking the
- * label opens the picker but never focuses the hidden input. When no ref is
- * given, falls back to targeting document.activeElement.
+ * DataTransfer injection. Files are read as raw bytes — a UTF-8 text round-trip
+ * substitutes U+FFFD (`EF BF BD`) for every byte >= 0x80 (#2878). The optional
+ * leading ref (e.g. "e3") targets the element directly via DOM.resolveNode +
+ * Runtime.callFunctionOn, which handles the common
+ * `<label><input type="file" hidden>` pattern where clicking the label opens
+ * the picker but never focuses the hidden input. A leading `eN` / `fNeN` token
+ * is always a ref, never a filename. When no ref is given, falls back to
+ * targeting document.activeElement.
  */
 
-import { requireTab } from '../state.js';
-import type { PlaywrightHandler } from '../types.js';
+import { uint8ToBase64 } from '@slicc/shared-ts';
+import { isElementRef, requireTab } from '../state.js';
+import type { PlaywrightHandler, PlaywrightHandlerCtx, TabSnapshot } from '../types.js';
 
 const MIME_MAP: Record<string, string> = {
   png: 'image/png',
@@ -36,13 +40,53 @@ function mimeForFilename(name: string): string {
   return MIME_MAP[ext] ?? 'application/octet-stream';
 }
 
-/** Convert a Uint8Array to a base64 string without relying on spread (avoids stack overflow for large files). */
-function uint8ToBase64(bytes: Uint8Array): string {
-  let binary = '';
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
+/**
+ * Read a VFS file as raw bytes. Never UTF-8-decodes: a text round-trip
+ * substitutes U+FFFD for every byte >= 0x80 (#2878, same family as #2818).
+ *
+ * If a backend still returns a string, refuse any payload that already
+ * contains U+FFFD rather than uploading a silently mangled File.
+ */
+export async function readUploadBytes(
+  fs: PlaywrightHandlerCtx['fs'],
+  path: string
+): Promise<Uint8Array> {
+  const content = await fs.readFile(path, { encoding: 'binary' });
+  if (content instanceof Uint8Array) return content;
+  if (typeof content !== 'string') {
+    throw new Error(`cannot represent '${path}' faithfully: unexpected file content type`);
   }
-  return btoa(binary);
+  if (content.includes('\uFFFD')) {
+    throw new Error(
+      `cannot represent '${path}' faithfully: file was read as text (contains U+FFFD). ` +
+        'Binary files must be read as bytes, not UTF-8.'
+    );
+  }
+  return new TextEncoder().encode(content);
+}
+
+function parseUploadArgs(
+  positional: string[],
+  snapshot: TabSnapshot | undefined
+): { targetRef: string | null; filePaths: string[] } | { error: string } {
+  if (positional.length === 0) {
+    return { error: 'upload requires at least one file path\n' };
+  }
+  if (!isElementRef(positional[0])) {
+    return { targetRef: null, filePaths: positional };
+  }
+  const targetRef = positional[0];
+  const filePaths = positional.slice(1);
+  if (!snapshot) {
+    return { error: 'No snapshot available. Run "snapshot" first.\n' };
+  }
+  if (!snapshot.refToBackendNodeId.has(targetRef)) {
+    return { error: `Unknown ref "${targetRef}"\n` };
+  }
+  if (filePaths.length === 0) {
+    return { error: 'upload requires at least one file path\n' };
+  }
+  return { targetRef, filePaths };
 }
 
 export const uploadHandler: PlaywrightHandler = async ({
@@ -52,37 +96,23 @@ export const uploadHandler: PlaywrightHandler = async ({
   positional,
   flags,
 }) => {
-  if (positional.length === 0) {
-    return { stdout: '', stderr: 'upload requires at least one file path\n', exitCode: 1 };
-  }
   const tab = requireTab(flags);
   if ('error' in tab) {
     return { stdout: '', stderr: tab.error, exitCode: 1 };
   }
 
-  // Detect optional leading ref argument (e.g. "e3") targeting a file input directly.
-  let targetRef: string | null = null;
-  let filePaths = positional;
-
   const snapshot = state.snapshots.get(tab.targetId);
-  if (snapshot && positional.length > 0 && snapshot.refToBackendNodeId.has(positional[0])) {
-    targetRef = positional[0];
-    filePaths = positional.slice(1);
+  const parsed = parseUploadArgs(positional, snapshot);
+  if ('error' in parsed) {
+    return { stdout: '', stderr: parsed.error, exitCode: 1 };
   }
+  const { targetRef, filePaths } = parsed;
 
-  if (filePaths.length === 0) {
-    return { stdout: '', stderr: 'upload requires at least one file path\n', exitCode: 1 };
-  }
-
-  // Read files from VFS and encode as base64.
   const files: Array<{ name: string; type: string; base64: string }> = [];
   for (const filePath of filePaths) {
-    const content = await fs.readFile(filePath);
+    const bytes = await readUploadBytes(fs, filePath);
     const name = filePath.split('/').pop() ?? filePath;
-    const type = mimeForFilename(name);
-    const bytes = typeof content === 'string' ? new TextEncoder().encode(content) : content;
-    const base64 = uint8ToBase64(bytes);
-    files.push({ name, type, base64 });
+    files.push({ name, type: mimeForFilename(name), base64: uint8ToBase64(bytes) });
   }
 
   if (targetRef) {

--- a/packages/webapp/src/shell/supplemental-commands/playwright/help.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/help.ts
@@ -101,7 +101,9 @@ Commands:
                          Supports teleport flags and --mobile emulation.
   tab-close|close --tab=<id> Close tab by targetId
   upload [ref] <file> [file...] --tab=<id>
-                         Upload VFS files to a file input (optional ref targets hidden inputs)
+                         Upload VFS files to a file input as raw bytes (optional snapshot
+                         ref targets hidden inputs; without a ref the input must be focused.
+                         A leading eN token is a ref, never a filename.)
   pdf --tab=<id> [--filename=path]
                          Save page as PDF (not available in extension mode)
   state-save [filename] --tab=<id> [--filename=path]

--- a/packages/webapp/src/shell/supplemental-commands/playwright/state.ts
+++ b/packages/webapp/src/shell/supplemental-commands/playwright/state.ts
@@ -75,6 +75,14 @@ export function getSharedState(browser: PlaywrightBrowserAPI, fs: VirtualFS): Pl
   return state;
 }
 
+/** Snapshot element ref: `e5` in the main frame, `f1e5` in a child frame. */
+export const ELEMENT_REF_RE = /^(f[0-9]+)?e[0-9]+$/;
+
+/** True when `token` is a snapshot ref (`e5`, `f1e5`), not a file path. */
+export function isElementRef(token: string): boolean {
+  return ELEMENT_REF_RE.test(token);
+}
+
 /** Parse a ref like 'f1e5' into { framePrefix: 'f1', isIframe: true } or 'e5' into { framePrefix: '', isIframe: false } */
 export function parseRef(ref: string): { framePrefix: string; isIframe: boolean } {
   const match = ref.match(/^(f[0-9]+)(e[0-9]+)$/);

--- a/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts
@@ -134,10 +134,20 @@ function createMockFS(): VirtualFS & { _files: Map<string, string | Uint8Array> 
     writeFile: vi.fn().mockImplementation(async (path: string, content: string | Uint8Array) => {
       files.set(path, content);
     }),
-    readFile: vi.fn().mockImplementation(async (path: string) => {
-      if (files.has(path)) return files.get(path)!;
-      const err = Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' as const });
-      throw err;
+    readFile: vi.fn().mockImplementation(async (path: string, options?: { encoding?: string }) => {
+      if (!files.has(path)) {
+        const err = Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' as const });
+        throw err;
+      }
+      const stored = files.get(path)!;
+      const encoding = options?.encoding ?? 'utf-8';
+      if (stored instanceof Uint8Array) {
+        if (encoding === 'binary') return stored;
+        // Match VirtualFS: default UTF-8 decode substitutes U+FFFD for high bytes.
+        return new TextDecoder('utf-8').decode(stored);
+      }
+      if (encoding === 'binary') return new TextEncoder().encode(stored);
+      return stored;
     }),
     readTextFile: vi.fn().mockImplementation(async (path: string) => {
       if (files.has(path)) return String(files.get(path)!);
@@ -3972,6 +3982,43 @@ const FRAME_HTML = `<!DOCTYPE html>
 </body>
 </html>`;
 
+/** Issue #2878 probe page: reports file.size and scans for EF BF BD. */
+const UPLOAD_HTML = `<!DOCTYPE html>
+<html>
+<head><title>Upload Probe</title></head>
+<body>
+  <input type="file" id="f" aria-label="File">
+  <pre id="out"></pre>
+  <script>
+    document.getElementById('f').addEventListener('change', async function (e) {
+      var file = e.target.files[0];
+      if (!file) return;
+      var buf = new Uint8Array(await file.arrayBuffer());
+      var replacementSeqs = 0;
+      for (var i = 0; i + 2 < buf.length; i++) {
+        if (buf[i] === 0xEF && buf[i + 1] === 0xBF && buf[i + 2] === 0xBD) {
+          replacementSeqs++;
+          i += 2;
+        }
+      }
+      var first16 = [];
+      for (var j = 0; j < Math.min(16, buf.length); j++) {
+        first16.push(buf[j].toString(16).padStart(2, '0'));
+      }
+      window.__uploadReport = {
+        name: file.name,
+        size: file.size,
+        byteLength: buf.length,
+        replacementSeqs: replacementSeqs,
+        first16: first16.join(' '),
+        bytes: Array.from(buf)
+      };
+      document.getElementById('out').textContent = JSON.stringify(window.__uploadReport);
+    });
+  </script>
+</body>
+</html>`;
+
 // -- Conditional integration tests -------------------------------------------
 
 const chromePath = findChromeExecutable();
@@ -4009,6 +4056,9 @@ describeIntegration('iframe integration', { timeout: 90_000 }, () => {
       } else if (req.url === '/frame.html') {
         res.writeHead(200, { 'Content-Type': 'text/html' });
         res.end(FRAME_HTML);
+      } else if (req.url === '/upload.html') {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(UPLOAD_HTML);
       } else {
         res.writeHead(404);
         res.end('Not found');
@@ -4295,6 +4345,68 @@ describeIntegration('iframe integration', { timeout: 90_000 }, () => {
       );
       expect(value).toBe('hello world');
     });
+  });
+
+  it('upload of 0x00..0xFF fixture is byte-exact on the page (#2878)', async () => {
+    const fixture = Uint8Array.from({ length: 256 }, (_, i) => i);
+    mockFs._files.set('/allbytes.bin', fixture);
+
+    const targetId = await browser.createPage(`http://127.0.0.1:${serverPort}/upload.html`);
+    const deadline = Date.now() + FIXTURE_LOAD_TIMEOUT_MS;
+    await browser.withTab(targetId, async () => {
+      while (Date.now() < deadline) {
+        try {
+          const ready = await browser.evaluate(
+            `document.readyState === 'complete' && Boolean(document.getElementById('f'))`
+          );
+          if (ready === true || ready === 'true') return;
+        } catch {
+          /* about:blank teardown */
+        }
+        await new Promise((r) => setTimeout(r, FIXTURE_LOAD_POLL_MS));
+      }
+      throw new Error('upload probe page did not finish loading');
+    });
+
+    const cmd = createPlaywrightCommand(
+      'playwright-cli',
+      browser as BrowserAPI,
+      mockFs as VirtualFS
+    );
+    const focus = await cmd.execute(
+      ['eval', `--tab=${targetId}`, "document.getElementById('f').focus(); 'ok'"],
+      mockCtx
+    );
+    expect(focus.exitCode).toBe(0);
+
+    const uploaded = await cmd.execute(['upload', '/allbytes.bin', `--tab=${targetId}`], mockCtx);
+    expect(uploaded.exitCode).toBe(0);
+    expect(uploaded.stdout).toContain('allbytes.bin');
+
+    const reportDeadline = Date.now() + 10_000;
+    let raw = 'null';
+    while (Date.now() < reportDeadline) {
+      const report = await cmd.execute(
+        ['eval', `--tab=${targetId}`, 'JSON.stringify(window.__uploadReport ?? null)'],
+        mockCtx
+      );
+      raw = report.stdout.trim();
+      if (raw && raw !== 'null') break;
+      await new Promise((r) => setTimeout(r, FIXTURE_LOAD_POLL_MS));
+    }
+    expect(raw).not.toBe('null');
+    const parsed = JSON.parse(raw) as {
+      name: string;
+      size: number;
+      byteLength: number;
+      replacementSeqs: number;
+      first16: string;
+      bytes: number[];
+    };
+    expect(parsed.size).toBe(256);
+    expect(parsed.byteLength).toBe(256);
+    expect(parsed.replacementSeqs).toBe(0);
+    expect(parsed.bytes).toEqual(Array.from(fixture));
   });
 });
 
@@ -5853,6 +5965,53 @@ describe('playwright-cli upload', () => {
     const result = await cmd.execute(['upload', 'e3', '--tab=tab-1'], mockCtx);
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('upload requires at least one file path');
+  });
+
+  it('does not treat a leading eN token as a file path when no snapshot exists', async () => {
+    const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
+    const result = await cmd.execute(
+      ['upload', 'e2', '/workspace/file.txt', '--tab=tab-1'],
+      mockCtx
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('No snapshot available');
+    expect(result.stderr).not.toMatch(/ENOENT/);
+  });
+
+  it('uploads the 0x00..0xFF fixture without U+FFFD substitution (#2878)', async () => {
+    const fixture = Uint8Array.from({ length: 256 }, (_, i) => i);
+    fs._files.set('/workspace/allbytes.bin', fixture);
+
+    const transportCalls: Array<{ method: string; params: Record<string, unknown> }> = [];
+    const mockTransport = {
+      send: vi.fn().mockImplementation((method: string, params: Record<string, unknown>) => {
+        transportCalls.push({ method, params });
+        return { result: { value: 1 } };
+      }),
+    };
+    (browser.getTransport as ReturnType<typeof vi.fn>).mockReturnValue(mockTransport);
+
+    const cmd = createPlaywrightCommand('playwright-cli', browser as BrowserAPI, fs as VirtualFS);
+    const result = await cmd.execute(['upload', '/workspace/allbytes.bin', '--tab=tab-1'], mockCtx);
+    expect(result.exitCode).toBe(0);
+
+    const evalCall = transportCalls.find((c) => c.method === 'Runtime.evaluate');
+    expect(evalCall).toBeDefined();
+    const expression = evalCall!.params['expression'] as string;
+    const match = expression.match(/var filesData = (\[[\s\S]*?\]);/);
+    expect(match).toBeTruthy();
+    const filesData = JSON.parse(match![1]) as Array<{ base64: string }>;
+    const decoded = Uint8Array.from(atob(filesData[0].base64), (c) => c.charCodeAt(0));
+    expect(decoded.length).toBe(256);
+    let replacements = 0;
+    for (let i = 0; i + 2 < decoded.length; i++) {
+      if (decoded[i] === 0xef && decoded[i + 1] === 0xbf && decoded[i + 2] === 0xbd) {
+        replacements++;
+        i += 2;
+      }
+    }
+    expect(replacements).toBe(0);
+    expect(Array.from(decoded)).toEqual(Array.from(fixture));
   });
 });
 

--- a/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/upload.test.ts
+++ b/packages/webapp/tests/shell/supplemental-commands/playwright/handlers/upload.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { VirtualFS } from '../../../../../src/fs/index.js';
+import {
+  readUploadBytes,
+  uploadHandler,
+} from '../../../../../src/shell/supplemental-commands/playwright/handlers/upload.js';
+import type { TabSnapshot } from '../../../../../src/shell/supplemental-commands/playwright/types.js';
+import {
+  createHandlerCtx,
+  createMockBrowser,
+  createMockTransport,
+  createPlaywrightState,
+} from '../../../helpers/playwright-harness.js';
+
+const TAB = 'tab-1';
+
+/** Issue #2878 fixture: every byte 0x00..0xFF exactly once. */
+function allBytesFixture(): Uint8Array {
+  return Uint8Array.from({ length: 256 }, (_, i) => i);
+}
+
+function countReplacementSeqs(bytes: Uint8Array): number {
+  let n = 0;
+  for (let i = 0; i + 2 < bytes.length; i++) {
+    if (bytes[i] === 0xef && bytes[i + 1] === 0xbf && bytes[i + 2] === 0xbd) {
+      n++;
+      i += 2;
+    }
+  }
+  return n;
+}
+
+function decodeUploadedBase64(base64: string): Uint8Array {
+  return Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+}
+
+function makeSnapshot(over: Partial<TabSnapshot> = {}): TabSnapshot {
+  return {
+    url: 'https://x',
+    title: 't',
+    content: '',
+    timestamp: 0,
+    refToSelector: new Map(),
+    refToBackendNodeId: new Map(),
+    refToFrameId: new Map(),
+    ...over,
+  };
+}
+
+type StoredFile = string | Uint8Array;
+
+/**
+ * VirtualFS-shaped reader: default encoding is UTF-8 with replacement, matching
+ * production `VirtualFS.readFile`. `{ encoding: 'binary' }` returns the stored
+ * bytes. A test that forgets `encoding: 'binary'` sees U+FFFD for high bytes.
+ */
+function vfsLikeReadFile(files: Map<string, StoredFile>): VirtualFS['readFile'] {
+  return (async (path: string, options?: { encoding?: string }) => {
+    const stored = files.get(path);
+    if (stored === undefined) {
+      throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' as const });
+    }
+    const encoding = options?.encoding ?? 'utf-8';
+    if (stored instanceof Uint8Array) {
+      if (encoding === 'binary') return stored;
+      return new TextDecoder('utf-8').decode(stored);
+    }
+    if (encoding === 'binary') return new TextEncoder().encode(stored);
+    return stored;
+  }) as VirtualFS['readFile'];
+}
+
+type TransportCall = { method: string; params: Record<string, unknown> };
+
+function captureTransport(): {
+  transport: ReturnType<typeof createMockTransport>;
+  calls: TransportCall[];
+} {
+  const calls: TransportCall[] = [];
+  const transport = createMockTransport((method, params) => {
+    calls.push({ method, params: (params ?? {}) as Record<string, unknown> });
+    if (method === 'DOM.resolveNode') return { object: { objectId: 'obj-file-input' } };
+    if (method === 'Runtime.callFunctionOn' || method === 'Runtime.evaluate') {
+      return { result: { value: 1 } };
+    }
+    return {};
+  });
+  return { transport, calls };
+}
+
+function filesFromTransport(calls: TransportCall[]): Array<{
+  name: string;
+  type: string;
+  base64: string;
+}> {
+  const callFn = calls.find((c) => c.method === 'Runtime.callFunctionOn');
+  if (callFn) {
+    const args = callFn.params['arguments'] as Array<{ value: unknown }> | undefined;
+    return (args?.[0]?.value ?? []) as Array<{ name: string; type: string; base64: string }>;
+  }
+  const evalCall = calls.find((c) => c.method === 'Runtime.evaluate');
+  const expression = evalCall?.params['expression'] as string | undefined;
+  if (!expression) return [];
+  const match = expression.match(/var filesData = (\[[\s\S]*?\]);/);
+  if (!match) return [];
+  return JSON.parse(match[1]) as Array<{ name: string; type: string; base64: string }>;
+}
+
+describe('readUploadBytes', () => {
+  it('returns stored bytes when encoding:binary is honoured', async () => {
+    const fixture = allBytesFixture();
+    const files = new Map<string, StoredFile>([['/allbytes.bin', fixture]]);
+    const bytes = await readUploadBytes(
+      { readFile: vfsLikeReadFile(files) } as VirtualFS,
+      '/allbytes.bin'
+    );
+    expect(bytes.length).toBe(256);
+    expect(Array.from(bytes)).toEqual(Array.from(fixture));
+    expect(countReplacementSeqs(bytes)).toBe(0);
+  });
+
+  it('fails loudly when a text decode already substituted U+FFFD', async () => {
+    const readFile = vi.fn(async () => 'ASCII\uFFFDMORE');
+    await expect(
+      readUploadBytes({ readFile } as unknown as VirtualFS, '/corrupt.bin')
+    ).rejects.toThrow(/faithfully/);
+    expect(readFile).toHaveBeenCalledWith('/corrupt.bin', { encoding: 'binary' });
+  });
+
+  it('encodes a valid UTF-8 string without substitution', async () => {
+    const readFile = vi.fn(async () => 'café');
+    const bytes = await readUploadBytes({ readFile } as unknown as VirtualFS, '/note.txt');
+    expect(new TextDecoder().decode(bytes)).toBe('café');
+    expect(countReplacementSeqs(bytes)).toBe(0);
+  });
+});
+
+describe('uploadHandler binary fidelity (#2878)', () => {
+  it('uploads the 0x00..0xFF fixture through the focused-input path without U+FFFD', async () => {
+    const fixture = allBytesFixture();
+    const files = new Map<string, StoredFile>([['/allbytes.bin', fixture]]);
+    const { transport, calls } = captureTransport();
+    const { browser } = createMockBrowser({ transport });
+
+    const result = await uploadHandler(
+      createHandlerCtx({
+        browser,
+        fs: { readFile: vfsLikeReadFile(files) },
+        positional: ['/allbytes.bin'],
+        flags: { tab: TAB },
+      })
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('allbytes.bin');
+    expect(calls.some((c) => c.method === 'Runtime.evaluate')).toBe(true);
+    expect(calls.some((c) => c.method === 'DOM.resolveNode')).toBe(false);
+
+    const uploaded = filesFromTransport(calls);
+    expect(uploaded).toHaveLength(1);
+    const decoded = decodeUploadedBase64(uploaded[0].base64);
+    expect(decoded.length).toBe(256);
+    expect(countReplacementSeqs(decoded)).toBe(0);
+    expect(Array.from(decoded)).toEqual(Array.from(fixture));
+  });
+
+  it('uploads the 0x00..0xFF fixture through a snapshot ref without U+FFFD', async () => {
+    const fixture = allBytesFixture();
+    const files = new Map<string, StoredFile>([['/allbytes.bin', fixture]]);
+    const { transport, calls } = captureTransport();
+    const { browser } = createMockBrowser({ transport });
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e2', 99]]) }));
+
+    const result = await uploadHandler(
+      createHandlerCtx({
+        browser,
+        state,
+        fs: { readFile: vfsLikeReadFile(files) },
+        positional: ['e2', '/allbytes.bin'],
+        flags: { tab: TAB },
+      })
+    );
+
+    expect(result.exitCode).toBe(0);
+    const resolveCall = calls.find((c) => c.method === 'DOM.resolveNode');
+    expect(resolveCall?.params['backendNodeId']).toBe(99);
+    expect(calls.some((c) => c.method === 'Runtime.evaluate')).toBe(false);
+
+    const uploaded = filesFromTransport(calls);
+    const decoded = decodeUploadedBase64(uploaded[0].base64);
+    expect(decoded.length).toBe(256);
+    expect(countReplacementSeqs(decoded)).toBe(0);
+    expect(Array.from(decoded)).toEqual(Array.from(fixture));
+  });
+
+  it('still uploads valid UTF-8 text files byte-exactly', async () => {
+    const text = 'hello café — ASCII plus valid UTF-8';
+    const files = new Map<string, StoredFile>([['/note.txt', text]]);
+    const { transport, calls } = captureTransport();
+    const { browser } = createMockBrowser({ transport });
+
+    const result = await uploadHandler(
+      createHandlerCtx({
+        browser,
+        fs: { readFile: vfsLikeReadFile(files) },
+        positional: ['/note.txt'],
+        flags: { tab: TAB },
+      })
+    );
+
+    expect(result.exitCode).toBe(0);
+    const uploaded = filesFromTransport(calls);
+    const decoded = decodeUploadedBase64(uploaded[0].base64);
+    expect(new TextDecoder().decode(decoded)).toBe(text);
+    expect(uploaded[0].type).toBe('text/plain');
+  });
+});
+
+describe('uploadHandler ref argv', () => {
+  it('treats a leading eN token as a ref even without a snapshot (does not ENOENT /e2)', async () => {
+    const result = await uploadHandler(
+      createHandlerCtx({
+        positional: ['e2', '/allbytes.bin'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('No snapshot available');
+    expect(result.stderr).not.toContain('ENOENT');
+  });
+
+  it('rejects an unknown snapshot ref instead of opening it as a path', async () => {
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e1', 1]]) }));
+    const result = await uploadHandler(
+      createHandlerCtx({
+        state,
+        positional: ['e2', '/allbytes.bin'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Unknown ref "e2"');
+    expect(result.stderr).not.toContain('ENOENT');
+  });
+
+  it('still requires a file path after consuming the ref', async () => {
+    const state = createPlaywrightState();
+    state.snapshots.set(TAB, makeSnapshot({ refToBackendNodeId: new Map([['e3', 44]]) }));
+    const result = await uploadHandler(
+      createHandlerCtx({
+        state,
+        positional: ['e3'],
+        flags: { tab: TAB },
+      })
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('upload requires at least one file path');
+  });
+});


### PR DESCRIPTION
Closes #2878

## Summary

`playwright-cli upload` UTF-8-decoded VFS files, so every byte `>= 0x80` became U+FFFD (`EF BF BD`). A 256-byte `0x00..0xFF` fixture arrived as 512 bytes (128 replacement sequences) and the command still exited 0 — TikTok Studio then accepted a mangled mp4. Upload now reads `Uint8Array` and builds the page `File` from those bytes. If a backend still returns a string that already contains U+FFFD, the command fails instead of substituting.

A leading `eN` / `fNeN` token is always a snapshot ref, never a filename, so `upload e2 file` no longer ENOENTs on `/e2`.

## Why

Same family as #2818 (jsh `fetch` kept a `Uint8Array` until `prepareRequestBody` wrapped it as a `Blob`). Here the hop was `VirtualFS.readFile()` (default UTF-8, replacement) → `TextEncoder.encode(string)` → base64 → page `File`.

**Repro** (from the confirming comment on #2878):

1. 256-byte file with every byte `0x00..0xFF` once.
2. `playwright-cli upload` into a page that reports `file.size` and scans for `EF BF BD`.
3. Expected: size 256, zero replacements, bytes identical.
4. Actual (before): size 512, 128 replacement sequences.

## Approach / Implementation notes

- `readUploadBytes()` calls `fs.readFile(path, { encoding: 'binary' })` and returns `Uint8Array`. A string that already contains U+FFFD throws (`cannot represent … faithfully`).
- Page-side `File` construction is unchanged: `Uint8Array.from(atob(base64), c => c.charCodeAt(0))` then `new File([bytes], name)`.
- `isElementRef()` (`e5` / `f1e5`) is applied before treating a positional as a path. Missing snapshot / unknown ref fail with the same messages as `click` / `highlight`.
- `drop --path` is **not** in this PR. A sibling thread is hunting remaining UTF-8 hops.

## Cross-cutting impact

- **Floats**: CLI and extension share this handler. No float probe.
- **Shell contexts**: same `playwright-cli` dispatcher in every float.
- Valid UTF-8 / ASCII text uploads are unchanged (pinned).
- A file whose name is a snapshot ref (`e2`) must be passed as `./e2` or an absolute path.

## Test plan

- [x] `npm run verify` — all 8 checks passed
- [x] `npm run typecheck`
- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright/` — 497 passed
- [x] `npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright/handlers/upload.test.ts` — 9 passed (256-byte fixture, UTF-8 text pin, U+FFFD fail-loud, ref argv)
- [x] `SLICC_TEST_CHROME_INTEGRATION=1 npx vitest run packages/webapp/tests/shell/supplemental-commands/playwright-command.test.ts -t "upload of 0x00"` — real Chrome page reports `file.size === 256`, `replacementSeqs === 0`, bytes identical
- [x] `npm run test:coverage:webapp` — floors held
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — no debt lists
- [x] N/A for UI / screencast

**Pre-existing failure** (unrelated): `packages/dev-tools/tools/check-touched-exemptions.test.mjs` `passes when the changed file is NOT on the float-probe debt list` fails because that test writes a fake key into `float-probe-baseline.json` and the grow-vs-base check then fires. Not caused by this change.

## Documentation

- [x] `packages/vfs-root/workspace/skills/playwright-cli/SKILL.md` — raw bytes + leading-ref contract
- [x] `packages/webapp/src/shell/supplemental-commands/playwright/help.ts` — upload `--help`
- [x] `docs/shell-reference.md` — binary tools list

## Risk & rollback

- Blast radius: every `playwright-cli upload` (CLI + extension). Hidden-input targeting now requires a snapshot, which `--help` already advertised.
- Rollback: revert this PR. No persisted state.
- CI runs the 256-byte unit fixture always; the Chrome page probe runs when `CI` or `SLICC_TEST_CHROME_INTEGRATION=1`.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets in the diff
- [x] Public `upload` contract documented
- [x] Linear history; rebased onto `origin/main`