### PR TITLE
feat(keyboard): floating key caps on the chrome + a personalised help sheet

### DIFF
--- a/packages/webapp/CLAUDE.md
+++ b/packages/webapp/CLAUDE.md
@@ -35,6 +35,14 @@ Per-subsystem file paths + invariants live in
 - Core agent — `src/core/` (pi-agent-core + pi-ai; `tool-adapter.ts` bridges legacy tools;
   feature flags + context compaction)
 - UI + layouts — `src/ui/` and `ui/wc/` (also `docs/layouts.md`)
+- Keyboard mode — `ui/wc/wc-shortcuts.ts` (keymap + modal grammar + the help sheet),
+  `wc-shortcut-surfaces.ts` (the DOM-reached commands), `wc-shortcut-caps.ts` (a floating
+  `<slicc-keycap>` per control, in one fixed click-through layer over measured ghosts —
+  deliberately NOT the transcript, whose mutation rate is the hot path),
+  `wc-shortcut-usage.ts` (session-only counts behind the sheet's "your frequent actions";
+  counts POINTER use off the surfaces' own events, which is the point — it tells you the
+  key for what you have been CLICKING). Help sections come from `Command.group`, never
+  from the keymap, so a rebind never reshuffles the sheet.
 - Skills — `src/skills/`; Sprinkles + Dips — `ui/sprinkle-*.ts`, `ui/dip.ts`
 - Stale-asset recovery — `setup-preload-error-reload.ts` + `stale-asset-channel.ts`
 - Storage persistence — `boot/setup-storage-persistence.ts` (OPFS is _evictable_ best-effort

--- a/packages/webapp/src/ui/wc/wc-shortcut-caps.ts
+++ b/packages/webapp/src/ui/wc/wc-shortcut-caps.ts
@@ -1,0 +1,436 @@
+/**
+ * The floating key caps: a `<slicc-keycap>` on every control keyboard mode can
+ * reach, up with the mode and down with it.
+ *
+ * ## Why this exists as well as the HUD and the help sheet
+ *
+ * The HUD answers "did that keystroke go anywhere?" after the fact. The help
+ * sheet answers "what is there?" in a list you have to open, and remember.
+ * Neither answers the question the mode actually leaves you with, which is
+ * *what can I press at the thing I am looking at* — and that is the question
+ * that decides whether the mode is ever discovered at all. `f` opening the
+ * file rail is unguessable from a folder icon; a cap on the folder icon makes
+ * it obvious and then makes the sheet unnecessary.
+ *
+ * ## Why the caps float in a layer instead of living inside the controls
+ *
+ * A `<slicc-keycap>` normally pins to its parent — put it inside a positioned
+ * control and it is done, no wiring. That is exactly what the shell CANNOT do
+ * here. Every control worth capping is a shadow component, and a child
+ * appended to one lands in its light DOM, where `<slicc-icon-button>` treats
+ * it as a replacement for the glyph and `<slicc-dock>` throws it away on its
+ * next `replaceChildren`. Wrapping is worse: the composer's toolbar controls
+ * are SLOTTED, so moving one into a wrapper unassigns it from its slot and it
+ * stops rendering at all.
+ *
+ * So the caps live in one fixed, click-through layer over the document, each
+ * one positioned on a measured ghost of its control. Nobody's DOM is touched,
+ * a component may re-render as often as it likes, and the cap's own placement
+ * geometry still works because the ghost really is a box of the right size in
+ * the right place. `keycap.anchor` then points the hover press back at the
+ * REAL control, so hovering the folder icon still presses its `f`.
+ *
+ * ## Which controls get one, and which cannot yet
+ *
+ * The persistent chrome, which is where the unguessable letters are: the rail
+ * launchers, the composer band, the switcher, and the caret's way home.
+ *
+ * Deliberately NOT the transcript (the copy row, approval cards) — that is the
+ * one part of the shell that mutates on every streamed token, and keeping a
+ * cap glued to a moving row would put an observer on the hot path for two of
+ * the most guessable bindings in the map.
+ *
+ * Not the tab strip's DIGITS either, though the strip itself is capped: the
+ * digits would be the precise answer and cannot be drawn, because
+ * `<slicc-agent-tabs>` clips its own track (that is how overflowing tabs hide
+ * behind the "more" button) and a cap overhanging a segment is cut in half.
+ * The arrows beside the track say the same thing better anyway — once for the
+ * strip instead of nine times, and the digits are the one binding a user
+ * already expects. Drawing the digits properly would mean the component
+ * rendering them itself, which is a change to `<slicc-agent-tabs>`.
+ *
+ * Not the model and thinking pills, for a plainer reason: they are inside
+ * `<slicc-composer-meta>`'s shadow root, where the shell cannot put anything
+ * and `::part` can style a part but cannot add a child to one.
+ */
+
+import type { ShortcutCaps } from './wc-shortcuts.js';
+import { type CommandId, commandKeyLabel, commandSurfaceId } from './wc-shortcuts.js';
+
+/**
+ * Under `<slicc-dialog>` (100), over the rails. A cap is chrome, not an
+ * overlay: it must never sit on top of a modal that has taken the keyboard.
+ */
+const LAYER_Z = 40;
+
+/**
+ * How far a cap sticks out past its control's corner, near enough — the
+ * element's own `placement` insets plus its width, in the 11px base it draws
+ * at, taken from the FURTHEST of them (the side placements, which clear the
+ * control entirely rather than overhanging a corner).
+ *
+ * Only ever used to ask "would this one fall off the screen?", so an estimate
+ * is the right shape of answer, and erring high is the right direction: a cap
+ * that flips a few pixels early is invisible, one that never flips is cut in
+ * half by the window edge.
+ */
+const OVERHANG_PX = 56;
+
+const LAYER_CLASS = 'wcsc-caps';
+const GHOST_CLASS = 'wcsc-caps__ghost';
+const STYLE_ID = 'wcsc-caps-style';
+
+/**
+ * `fixed`, so a measured `getBoundingClientRect()` is usable as-is: viewport
+ * coordinates in, viewport coordinates out, with no offset-parent arithmetic
+ * to get wrong when the shell is inside a transformed panel.
+ */
+const LAYER_CSS = `
+.${LAYER_CLASS}{position:fixed;inset:0;z-index:${LAYER_Z};pointer-events:none;}
+.${GHOST_CLASS}{position:absolute;pointer-events:none;}
+`;
+
+/** What the caps need from the shell: the roots its controls live under. */
+export interface ShortcutCapDeps {
+  /** The composer's input card — the add menu and the send button are in it. */
+  inputCard: HTMLElement;
+  /**
+   * The tab strip, for its COUNT. `←` / `→` walk a cycle, and a cycle of one
+   * is a key that does nothing — so with a single unit the arrows earn no cap.
+   */
+  switcher: { readonly scoops: ReadonlyArray<unknown> };
+  /**
+   * A node in the live document. Used only to reach `ownerDocument`: the rail
+   * is looked up document-wide because a float has exactly one of it, and
+   * because `panelizeShell` moves it out from under any frame we could hold.
+   */
+  root: HTMLElement;
+}
+
+/**
+ * One capped control: the command whose key it names, and how to find it.
+ *
+ * The KEY is not in here — it is read from the live keymap through
+ * {@link commandKeyLabel} at show time, so a cap can never name a binding a
+ * user's `keys.json` has moved or unbound.
+ */
+interface CapSpec {
+  /**
+   * The command(s) whose keys this cap names. More than one where the control
+   * has more than one key and they are ONE affordance — the tab strip's two
+   * arrows, which sit adjacent on a real keyboard and are drawn adjacent here
+   * for exactly that reason. Commands nothing is bound to drop out, so a cap
+   * with a rebound half still names the half that works.
+   */
+  commands: readonly CommandId[];
+  find(deps: ShortcutCapDeps): HTMLElement | null;
+  placement?: string;
+}
+
+/** The legend for a spec: every bound key it names, or `null` for none. */
+function labelFor(spec: CapSpec, keymap: Readonly<Record<string, CommandId>>): string | null {
+  const keys = spec.commands
+    .map((command) => commandKeyLabel(keymap, command))
+    .filter((key) => key !== null);
+  return keys.length === 0 ? null : keys.join(' ');
+}
+
+/** The rail item a dock command opens, by the id the command itself declares. */
+function railItem(command: CommandId): CapSpec {
+  return {
+    commands: [command],
+    find: (deps) => {
+      const id = commandSurfaceId(command);
+      return id
+        ? deps.root.ownerDocument.querySelector<HTMLElement>(
+            `slicc-dock-item[item-id="${escapeAttr(id)}"]`
+          )
+        : null;
+    },
+  };
+}
+
+/** `CSS.escape`, with a fallback for realms that predate it. */
+function escapeAttr(value: string): string {
+  return typeof globalThis.CSS?.escape === 'function'
+    ? globalThis.CSS.escape(value)
+    : value.replace(/["\\]/g, '\\$&');
+}
+
+/**
+ * The capped controls, in sweep order — the order the entry stagger runs in,
+ * so the caps land top-to-bottom down the rail and then along the band rather
+ * than in whatever order a query happened to return them.
+ */
+const SPECS: readonly CapSpec[] = [
+  {
+    /*
+     * The switcher, named on the strip as a whole rather than per segment.
+     *
+     * The digits (1-9) would be the precise answer and they cannot be drawn:
+     * `<slicc-agent-tabs>` clips its own track — that is how overflowing tabs
+     * hide behind the "more" button — so a cap overhanging a segment is cut in
+     * half. The arrows are the better answer anyway: they say "this strip
+     * moves" once, instead of nine times, and the digits are the one binding
+     * a user already expects.
+     *
+     * Anchored to the TRACK, not to the host: the host is mostly empty space
+     * (it stretches to fill the nav bar), so a cap on its edge would float
+     * unattached to anything. And anchored from OUTSIDE, which is why the
+     * track's clip does not apply — the cap is in the layer, not in the track.
+     */
+    commands: ['prevAgent', 'nextAgent'],
+    find: (deps) =>
+      // With one unit the arrows cycle back to where they started, so there is
+      // nothing to say — and saying it anyway would put a dead key on the
+      // busiest chrome in the shell, since one cone and no scoops is the
+      // COMMON case, not an edge one.
+      deps.switcher.scoops.length > 1
+        ? deps.root.ownerDocument.querySelector<HTMLElement>(
+            'slicc-agent-tabs [part="track-frame"]'
+          )
+        : null,
+    placement: 'end',
+  },
+  railItem('tabs'),
+  railItem('files'),
+  railItem('terminal'),
+  railItem('memory'),
+  railItem('monitor'),
+  {
+    // `e` opens the FIRST sprinkle, so the first launcher is the honest place
+    // to say so — there is no fixed id for it, the rail's sprinkles are
+    // whatever the agent has installed.
+    commands: ['sprinkles'],
+    find: (deps) =>
+      deps.root.ownerDocument.querySelector<HTMLElement>('slicc-dock-item[kind="sprinkle"]'),
+  },
+  {
+    /*
+     * The left rail's collapse toggle — the control `[` drives, and the one
+     * piece of chrome in the shell that had no hint at all.
+     *
+     * `]` has no cap on purpose: it toggles the RIGHT panel, whose rail items
+     * already carry their own letters, and it means "close whatever is open"
+     * rather than naming any one control. A cap on the rail as a whole next to
+     * five that name individual panels would read as a sixth panel.
+     */
+    commands: ['leftRail'],
+    find: (deps) =>
+      deps.root.ownerDocument.querySelector<HTMLElement>('slicc-freezer [part="toggle"]'),
+  },
+  {
+    commands: ['attach'],
+    find: (deps) => deps.inputCard.querySelector<HTMLElement>('slicc-add-menu'),
+    // The add menu sits at the band's left edge; a cap on its right corner
+    // would reach into the textarea.
+    placement: 'top-start',
+  },
+  {
+    // The send button IS the stop button while a turn runs, which is the only
+    // time `s` does anything — the same control, so the same cap.
+    commands: ['stop'],
+    find: (deps) => deps.inputCard.querySelector<HTMLElement>('slicc-send-button'),
+  },
+  {
+    /*
+     * The way back to typing, on the thing you would type into.
+     *
+     * The most important key in the mode and the one the HUD already spends
+     * words on ("[i] or [⏎] to type"), because the mode is the RESTING state:
+     * "how do I type again?" is the question it has to answer, and answering
+     * it at the caret's own corner beats answering it in a strip at the
+     * bottom of the column.
+     *
+     * On the textarea rather than the card, so it lands at the corner of the
+     * text rather than out on the card's padding — and reachable without
+     * touching a shadow root, because `<slicc-input-card>` keeps its textarea
+     * in the light DOM.
+     */
+    commands: ['composer'],
+    find: (deps) => deps.inputCard.querySelector<HTMLElement>('textarea'),
+    placement: 'top-start',
+  },
+];
+
+/**
+ * Keep a cap on screen: a control against the right edge of the window gets
+ * its cap on the left corner instead, and vice versa. Only the horizontal
+ * axis flips — the vertical overhang is a few pixels and the chrome it hangs
+ * off is never flush with the top of the window.
+ */
+function flip(placement: string, rect: DOMRect, width = globalThis.innerWidth): string {
+  // Suffix rather than equality, so the bare side placements (`start` / `end`,
+  // which clear the control) flip on the same rule as the corner ones.
+  if (placement.endsWith('end') && rect.right + OVERHANG_PX > width) {
+    return placement.replace(/end$/, 'start');
+  }
+  if (placement.endsWith('start') && rect.left - OVERHANG_PX < 0) {
+    return placement.replace(/start$/, 'end');
+  }
+  return placement;
+}
+
+/** A `<slicc-keycap>`, as far as this module needs it. */
+type KeycapElement = HTMLElement & { anchor?: HTMLElement | null };
+
+function ensureStyle(doc: Document): void {
+  if (doc.getElementById(STYLE_ID)) return;
+  const style = doc.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = LAYER_CSS;
+  (doc.head ?? doc.documentElement)?.append(style);
+}
+
+/**
+ * Install the floating key caps over a mounted shell.
+ *
+ * Returns the handle {@link ShortcutCaps} the mode drives: `show` on entering
+ * the mode, `hide` on leaving, `destroy` when the wiring goes away.
+ */
+export function createShortcutCaps(deps: ShortcutCapDeps): ShortcutCaps {
+  const doc = deps.root.ownerDocument;
+  const view = doc.defaultView;
+
+  let layer: HTMLElement | null = null;
+  let keymap: Readonly<Record<string, CommandId>> = {};
+  /** The live cap per spec index, so `sync` updates rather than rebuilds. */
+  const mounted = new Map<number, { ghost: HTMLElement; cap: KeycapElement }>();
+
+  let frame = 0;
+  let resizeObserver: ResizeObserver | null = null;
+  let mutationObserver: MutationObserver | null = null;
+
+  /** Coalesce every trigger into one measured pass per frame. */
+  const schedule = (): void => {
+    if (!layer || frame !== 0 || !view) return;
+    frame = view.requestAnimationFrame(() => {
+      frame = 0;
+      if (layer) sync();
+    });
+  };
+
+  const drop = (index: number): void => {
+    const live = mounted.get(index);
+    if (!live) return;
+    // Cut the anchor first: the cap holds listeners on a control that is
+    // outliving it, and a removed node's `disconnectedCallback` is the only
+    // thing that would otherwise release them.
+    live.cap.anchor = null;
+    live.ghost.remove();
+    mounted.delete(index);
+  };
+
+  /**
+   * Re-measure, and re-resolve while we are at it: the rail rebuilds its
+   * items wholesale (`<slicc-dock>` calls `replaceChildren`), so a target
+   * held from last time may be a detached node by now.
+   */
+  function sync(): void {
+    if (!layer) return;
+    SPECS.forEach((spec, index) => {
+      const label = labelFor(spec, keymap);
+      const target = label === null ? null : spec.find(deps);
+      const rect = target?.getBoundingClientRect();
+      // A control with no box is one the float does not have: a follower
+      // hides rail items it has no feature for, and a collapsed rail has no
+      // launchers at all. No box, no cap — the HUD still names the key.
+      if (label === null || !target || !rect || rect.width === 0 || rect.height === 0) {
+        drop(index);
+        return;
+      }
+
+      let live = mounted.get(index);
+      if (!live) {
+        const ghost = doc.createElement('div');
+        ghost.className = GHOST_CLASS;
+        const cap = doc.createElement('slicc-keycap') as KeycapElement;
+        cap.setAttribute('stagger', String(index));
+        ghost.append(cap);
+        layer?.append(ghost);
+        live = { ghost, cap };
+        mounted.set(index, live);
+      }
+
+      /*
+       * Which corner it hangs off, decided against the viewport rather than
+       * written down. The dock rail is flush with the right edge of the
+       * window, so its caps would hang off the SCREEN — and which edge the
+       * rail is on is a layout choice (`panelizeShell` can put the rail in
+       * any zone), so a hard-coded corner would only be right for today's
+       * default. Measured, it is right for every layout and every window.
+       */
+      const placement = flip(spec.placement ?? 'top-end', rect);
+      if (live.cap.getAttribute('placement') !== placement) {
+        live.cap.setAttribute('placement', placement);
+      }
+
+      // Only ever written when it CHANGES: `cap` re-renders on every write,
+      // and this runs on a resize drag.
+      if (live.cap.getAttribute('cap') !== label) live.cap.setAttribute('cap', label);
+      // Points the hover press at the real control rather than at the ghost,
+      // which is `pointer-events: none` and could never be hovered.
+      if (live.cap.anchor !== target) live.cap.anchor = target;
+
+      const style = live.ghost.style;
+      style.left = `${rect.left}px`;
+      style.top = `${rect.top}px`;
+      style.width = `${rect.width}px`;
+      style.height = `${rect.height}px`;
+
+      resizeObserver?.observe(target);
+    });
+  }
+
+  const show = (next: Readonly<Record<string, CommandId>>): void => {
+    keymap = next;
+    if (layer) {
+      sync();
+      return;
+    }
+    ensureStyle(doc);
+    layer = doc.createElement('div');
+    layer.className = LAYER_CLASS;
+    // The same marker the HUD carries, so everything keyboard mode puts in
+    // the document answers one query when you are looking for it.
+    layer.dataset.wcShortcuts = 'caps';
+    doc.body.append(layer);
+
+    if (view?.ResizeObserver) resizeObserver = new view.ResizeObserver(schedule);
+    // The rail rebuilds its items; the band swaps its send button for a stop
+    // button. Both are small, static subtrees — and neither is the transcript,
+    // which is the whole reason the transcript has no caps.
+    if (view?.MutationObserver) {
+      mutationObserver = new view.MutationObserver(schedule);
+      mutationObserver.observe(deps.inputCard, { childList: true, subtree: true });
+      const dock = doc.querySelector('slicc-dock');
+      if (dock) mutationObserver.observe(dock, { childList: true, subtree: true });
+    }
+    // A panel opening reflows the rail without mutating it, and a scrolled
+    // page moves every fixed-layer coordinate at once.
+    view?.addEventListener('resize', schedule);
+    doc.addEventListener('scroll', schedule, { capture: true, passive: true });
+    resizeObserver?.observe(doc.documentElement);
+
+    sync();
+  };
+
+  const hide = (): void => {
+    if (!layer) return;
+    if (frame !== 0) {
+      view?.cancelAnimationFrame(frame);
+      frame = 0;
+    }
+    for (const index of [...mounted.keys()]) drop(index);
+    resizeObserver?.disconnect();
+    resizeObserver = null;
+    mutationObserver?.disconnect();
+    mutationObserver = null;
+    view?.removeEventListener('resize', schedule);
+    doc.removeEventListener('scroll', schedule, { capture: true });
+    layer.remove();
+    layer = null;
+  };
+
+  return { show, hide, destroy: hide };
+}

--- a/packages/webapp/src/ui/wc/wc-shortcut-surfaces.ts
+++ b/packages/webapp/src/ui/wc/wc-shortcut-surfaces.ts
@@ -19,6 +19,8 @@
  */
 
 import { requestPlacedSurfaceFullscreen } from './surface-fullscreen.js';
+import { createShortcutCaps } from './wc-shortcut-caps.js';
+import { createShortcutUsage } from './wc-shortcut-usage.js';
 import {
   type ShortcutComposerMeta,
   type ShortcutDock,
@@ -336,5 +338,22 @@ export function wireShellKeyboard(deps: ShellKeyboardDeps): ShortcutHandles {
     zoomSurface: () => zoomSurface(deps),
     peekTabs: () => peekTabs(deps),
     lists: shortcutLists(deps),
+    /**
+     * The floating key caps. Built here rather than in the mode for the same
+     * reason the six DOM-reached commands are: finding the rail item a letter
+     * drives is knowledge of this shell's markup, and the mode has none.
+     */
+    caps: createShortcutCaps({
+      inputCard: deps.inputCard,
+      root: deps.chatPane,
+      switcher: deps.switcher,
+    }),
+    /**
+     * What the user has done this session, for the help sheet's personalised
+     * section. Created here because it listens to the SURFACES' own events —
+     * the same markup knowledge this file already owns — and because a click
+     * on a rail item has to count exactly as much as the key that opens it.
+     */
+    usage: createShortcutUsage(deps.chatPane.ownerDocument),
   });
 }

--- a/packages/webapp/src/ui/wc/wc-shortcut-usage.ts
+++ b/packages/webapp/src/ui/wc/wc-shortcut-usage.ts
@@ -16,6 +16,28 @@
  * A rail item opened by pointer and one opened by `f` are indistinguishable
  * here, which is exactly right: they are the same action.
  *
+ * ## One action, one count — which is the whole subtlety
+ *
+ * That same doctrine is also the trap. A KEYED command is recorded once by the
+ * dispatcher and then reaches its surface through the very event this module
+ * listens for, so the naive version counts a keystroke twice and ranks keyed
+ * panel opens 2:1 against clicked ones — precisely the bias the feature exists
+ * to remove.
+ *
+ * So a keyed record OWNS the rest of its synchronous turn: any surface event
+ * the command goes on to dispatch is the same action arriving by its other
+ * name, and is ignored. That rule needs no list of which commands route
+ * through a heard event, so it cannot drift as commands are added — and it
+ * also fixes the attribution, which a suppression list would not have: `r`
+ * forces the left rail open to show archived chats, firing `freezer-toggle`,
+ * and the key is what the user actually pressed, so `sessions` is what gets
+ * the count rather than `leftRail`.
+ *
+ * It rests on one fact worth stating: a command dispatches its surface event
+ * SYNCHRONOUSLY from `run()` (`slicc-dock.selectItem` and the freezer's
+ * toggle both call `dispatchEvent` directly), so the turn is still open when
+ * the event lands.
+ *
  * ## Session-scoped, and deliberately not persisted
  *
  * "Since you started" is the honest window for "what have you been doing", and
@@ -34,7 +56,11 @@ export interface UsageEntry {
 }
 
 export interface ShortcutUsage {
-  /** Count one use — by key or by pointer, which are the same thing here. */
+  /**
+   * Count one use, from the KEYBOARD — and claim the rest of this synchronous
+   * turn, so the surface event the command is about to dispatch is not counted
+   * as a second use of the same action.
+   */
   record(id: CommandId): void;
   /** Has this been used at all this session? */
   used(id: CommandId): boolean;
@@ -75,11 +101,33 @@ export function createShortcutUsage(doc: Document): ShortcutUsage {
   const lastAt = new Map<CommandId, number>();
   let tick = 0;
 
-  const record = (id: CommandId): void => {
+  const count = (id: CommandId): void => {
     if (!isCommandId(id)) return;
     counts.set(id, (counts.get(id) ?? 0) + 1);
     tick += 1;
     lastAt.set(id, tick);
+  };
+
+  /**
+   * Set while a keyed command is still running, so the surface event it is
+   * about to dispatch is recognised as the same action rather than a second
+   * one. Cleared on the microtask after the keystroke's synchronous work.
+   */
+  let keyedTurn = false;
+
+  const record = (id: CommandId): void => {
+    count(id);
+    if (keyedTurn) return;
+    keyedTurn = true;
+    queueMicrotask(() => {
+      keyedTurn = false;
+    });
+  };
+
+  /** A use observed at the surface — ignored when a key already claimed it. */
+  const fromSurface = (id: CommandId): void => {
+    if (keyedTurn) return;
+    count(id);
   };
 
   const onDockSelect = (event: Event): void => {
@@ -89,9 +137,9 @@ export function createShortcutUsage(doc: Document): ShortcutUsage {
     // A sprinkle launcher has no fixed surface id of its own, and `sprinkles`
     // is the command that opens the first one — so any launcher that is not a
     // named tool counts as a use of it.
-    record(id ?? 'sprinkles');
+    fromSurface(id ?? 'sprinkles');
   };
-  const onFreezerToggle = (): void => record('leftRail');
+  const onFreezerToggle = (): void => fromSurface('leftRail');
 
   doc.addEventListener(DOCK_SELECT, onDockSelect, true);
   doc.addEventListener(FREEZER_TOGGLE, onFreezerToggle, true);

--- a/packages/webapp/src/ui/wc/wc-shortcut-usage.ts
+++ b/packages/webapp/src/ui/wc/wc-shortcut-usage.ts
@@ -1,0 +1,113 @@
+/**
+ * What this user actually does, this session — the data that turns the help
+ * sheet from a reference into a cheat sheet.
+ *
+ * ## Why it counts CLICKS, not keystrokes
+ *
+ * A list of the shortcuts you already use is worthless: you know those. The
+ * useful sheet is the one that says *you opened Files eleven times today —
+ * press `f`*, and that means counting what the user does with the MOUSE, on
+ * the surfaces they have never once reached from the keyboard.
+ *
+ * Keyboard mode's own doctrine makes this cheap. Every command reaches its
+ * surface through the event a click on that surface produces, so the click and
+ * the key are literally the same event — listen for it once and both are
+ * counted, with no per-command wiring and no way for the two paths to drift.
+ * A rail item opened by pointer and one opened by `f` are indistinguishable
+ * here, which is exactly right: they are the same action.
+ *
+ * ## Session-scoped, and deliberately not persisted
+ *
+ * "Since you started" is the honest window for "what have you been doing", and
+ * it needs no storage, no migration and no privacy question — a record of
+ * every panel a user opens is not something to write to disk for a cheat
+ * sheet. It also self-corrects: the counts describe the work in front of you
+ * rather than an average of every session you have ever had.
+ */
+
+import { type CommandId, commandForSurfaceId, isCommandId } from './wc-shortcuts.js';
+
+/** One command's usage this session. */
+export interface UsageEntry {
+  id: CommandId;
+  count: number;
+}
+
+export interface ShortcutUsage {
+  /** Count one use — by key or by pointer, which are the same thing here. */
+  record(id: CommandId): void;
+  /** Has this been used at all this session? */
+  used(id: CommandId): boolean;
+  /**
+   * Every command used at least once, most-used first, ties broken by most
+   * recent — so a run of one-offs is ordered by what you did last rather than
+   * by an arbitrary insertion order.
+   */
+  ranked(): UsageEntry[];
+  dispose(): void;
+}
+
+/**
+ * The surface events that mean "the user did this thing", whichever way they
+ * did it. Each is the event the command itself dispatches, so a shortcut and a
+ * click land here identically.
+ */
+const DOCK_SELECT = 'slicc-dock-select';
+const FREEZER_TOGGLE = 'freezer-toggle';
+
+/** `detail.id` off a dock select, whatever shape the float sends. */
+function selectedSurfaceId(event: Event): string | null {
+  const detail = (event as CustomEvent<{ id?: unknown }>).detail;
+  return typeof detail?.id === 'string' ? detail.id : null;
+}
+
+/**
+ * Start counting.
+ *
+ * Listens in the CAPTURE phase on the document: the rails live in different
+ * parts of the tree depending on the layout (`panelizeShell` re-parents them),
+ * and a listener that had to find them first would miss everything until they
+ * mounted.
+ */
+export function createShortcutUsage(doc: Document): ShortcutUsage {
+  const counts = new Map<CommandId, number>();
+  /** Insertion clock, not a wall clock: only the ORDER is ever compared. */
+  const lastAt = new Map<CommandId, number>();
+  let tick = 0;
+
+  const record = (id: CommandId): void => {
+    if (!isCommandId(id)) return;
+    counts.set(id, (counts.get(id) ?? 0) + 1);
+    tick += 1;
+    lastAt.set(id, tick);
+  };
+
+  const onDockSelect = (event: Event): void => {
+    const surfaceId = selectedSurfaceId(event);
+    if (surfaceId === null) return;
+    const id = commandForSurfaceId(surfaceId);
+    // A sprinkle launcher has no fixed surface id of its own, and `sprinkles`
+    // is the command that opens the first one — so any launcher that is not a
+    // named tool counts as a use of it.
+    record(id ?? 'sprinkles');
+  };
+  const onFreezerToggle = (): void => record('leftRail');
+
+  doc.addEventListener(DOCK_SELECT, onDockSelect, true);
+  doc.addEventListener(FREEZER_TOGGLE, onFreezerToggle, true);
+
+  return {
+    record,
+    used: (id) => counts.has(id),
+    ranked: () =>
+      [...counts.entries()]
+        .map(([id, count]) => ({ id, count }))
+        .sort((a, b) => b.count - a.count || (lastAt.get(b.id) ?? 0) - (lastAt.get(a.id) ?? 0)),
+    dispose: () => {
+      doc.removeEventListener(DOCK_SELECT, onDockSelect, true);
+      doc.removeEventListener(FREEZER_TOGGLE, onFreezerToggle, true);
+      counts.clear();
+      lastAt.clear();
+    },
+  };
+}

--- a/packages/webapp/src/ui/wc/wc-shortcuts.ts
+++ b/packages/webapp/src/ui/wc/wc-shortcuts.ts
@@ -240,8 +240,37 @@ export interface ShortcutDeps {
    * and "the caret is somewhere you cannot see".
    */
   composerBand?: HTMLElement;
+  /**
+   * The floating key caps: one per reachable control, mounted with the mode
+   * and taken down with it.
+   *
+   * Optional, and supplied by `wc-shortcut-surfaces.ts` for the same reason
+   * the six DOM-reached commands are — finding the rail item a letter drives
+   * is markup knowledge, and this module has none. A float that hands over no
+   * caps simply has none; the HUD and the help sheet still name every key.
+   */
+  caps?: ShortcutCaps;
+  /**
+   * What the user has done this session, for the help sheet's personalised
+   * section. Counts POINTER use as well as keys, which is the whole point —
+   * the sheet's job is to tell you the shortcut for the thing you have been
+   * clicking. Optional: a float without one gets the reference sheet.
+   */
+  usage?: HelpUsage & { record?(id: CommandId): void };
   /** Injected for tests; defaults to the switcher's own document. */
   doc?: Document;
+}
+
+/**
+ * The floating key caps, as the mode drives them: up with the mode, down with
+ * it. The keymap is passed at show time rather than held, because the config
+ * load is deliberately late — the caps must name the keys in force when they
+ * appear, not the defaults the shell wired itself with.
+ */
+export interface ShortcutCaps {
+  show(keymap: Readonly<Record<string, CommandId>>): void;
+  hide(): void;
+  destroy(): void;
 }
 
 /** Actions the shell cannot reach on its own, registered by later wiring. */
@@ -290,19 +319,58 @@ type ModalElement = HTMLElement & { show?: () => void; hide?: () => void };
 export interface ShortcutRow {
   keys: string[];
   description: string;
+  /** The section this row belongs under. */
+  group: CommandGroup;
+  /**
+   * The command it runs, when it is one. Absent for the two rows that are the
+   * MODE rather than a binding — Escape, and the digits that address the tab
+   * strip positionally — which is also why neither can be personalised: there
+   * is no command id to count.
+   */
+  id?: CommandId;
 }
 
 const STYLE_ID = 'slicc-shortcuts-style';
 const CSS = `
-slicc-dialog.wcsc-dialog::part(dialog){width:min(440px,92vw);}
-.wcsc{display:flex;flex-direction:column;gap:2px;font-family:var(--ui);color:var(--ink);}
-.wcsc__note{font-size:12px;color:var(--txt-3);padding:0 2px 8px;line-height:1.5;}
-.wcsc__row{display:flex;align-items:center;gap:12px;padding:7px 2px;border-bottom:1px solid var(--line);}
+/* The sheet grows a column at a time as the viewport allows, and the dialog
+   grows with it — one alphabetical column of thirty-odd rows is a reference
+   you read; three short labelled ones are a cheat sheet you scan. Capped at
+   three because a fourth makes the eye travel further than the list is long. */
+slicc-dialog.wcsc-dialog::part(dialog){width:min(460px,92vw);}
+@media (min-width:900px){slicc-dialog.wcsc-dialog::part(dialog){width:min(860px,94vw);}}
+@media (min-width:1280px){slicc-dialog.wcsc-dialog::part(dialog){width:min(1180px,94vw);}}
+.wcsc{font-family:var(--ui);color:var(--ink);}
+.wcsc__note{font-size:12px;color:var(--txt-3);padding:0 2px 10px;line-height:1.5;}
+
+/* CSS columns rather than a grid: the sections are different heights, and
+   columns flow them into balanced tracks without anyone having to decide
+   which group goes where. 'break-inside' is what keeps a section whole. */
+.wcsc__cols{columns:1;column-gap:30px;}
+@media (min-width:900px){.wcsc__cols{columns:2;}}
+@media (min-width:1280px){.wcsc__cols{columns:3;}}
+.wcsc__group{break-inside:avoid;page-break-inside:avoid;margin:0 0 16px;}
+.wcsc__title{font:600 10.5px/1 var(--ui);letter-spacing:.09em;text-transform:uppercase;color:var(--txt-3);padding:0 2px 6px;}
+
+.wcsc__row{display:flex;align-items:center;gap:12px;padding:6px 4px;border-bottom:1px solid var(--line);border-radius:6px;}
 .wcsc__row:last-child{border-bottom:0;}
 .wcsc__desc{flex:1;min-width:0;font-size:12.5px;}
 .wcsc__keys{display:flex;align-items:center;gap:4px;flex:0 0 auto;}
 .wcsc__key{font:600 11px/1 var(--mono,ui-monospace,monospace);color:var(--txt-2);background:var(--ghost);border:1px solid var(--line);border-bottom-width:2px;border-radius:5px;padding:4px 6px;white-space:nowrap;}
 .wcsc__sep{font-size:11px;color:var(--txt-3);}
+
+/* Used this session. A tinted row rather than a badge or a bolder weight:
+   the point is to make the handful you already touched findable at a glance
+   in a wall of rows, not to shout at you about them. */
+.wcsc__row[data-used]{background:color-mix(in srgb,var(--ctx) 9%,transparent);}
+.wcsc__row[data-used] .wcsc__desc{color:var(--ink);}
+.wcsc__row[data-used] .wcsc__key{color:var(--ink);border-color:color-mix(in srgb,var(--ctx) 34%,var(--line));}
+
+/* The personalised section leads, and is the one thing on the sheet allowed
+   to look different from the reference below it. */
+.wcsc__group--yours{border:1px solid color-mix(in srgb,var(--ctx) 26%,var(--line));border-radius:10px;padding:10px 10px 4px;background:color-mix(in srgb,var(--ctx) 5%,transparent);}
+.wcsc__group--yours .wcsc__title{color:color-mix(in srgb,var(--ctx) 55%,var(--ink));}
+.wcsc__group--yours .wcsc__row{border-bottom-color:color-mix(in srgb,var(--ctx) 16%,var(--line));}
+.wcsc__count{font:500 10.5px/1 var(--ui);color:var(--txt-3);flex:0 0 auto;}
 `;
 
 /**
@@ -540,6 +608,26 @@ interface ModeState {
 }
 
 /**
+ * The sections of the help sheet, in reading order.
+ *
+ * These are the groups the shipped keymap was always organised into — the
+ * comments in {@link DEFAULT_KEYMAP} said "Anchors / Units / The turn /
+ * Panels / Rare" long before anything read them. Promoting them from comments
+ * to data is what lets the sheet be a cheat sheet: thirty-odd rows in one
+ * alphabetical column is a reference, five short labelled lists is something
+ * you can scan.
+ */
+export const COMMAND_GROUPS = [
+  'Getting around',
+  'Agents',
+  'The turn',
+  'Panels',
+  'Settings',
+] as const;
+
+export type CommandGroup = (typeof COMMAND_GROUPS)[number];
+
+/**
  * One binding. `holdsMode` is the whole modal grammar in a boolean: a command
  * that navigates — or that toggles chrome, like the two rails — keeps keyboard
  * mode; a command that hands focus to a surface gives it up (the mode is
@@ -556,6 +644,24 @@ interface Command {
    * the chords.
    */
   list?: ChordListId;
+  /**
+   * The dock surface this command opens, when it opens one. Declared here for
+   * the same reason {@link Command.list} is: it is a fact about the COMMAND,
+   * and anything else that needs it — the floating key caps, which have to
+   * find the rail item a letter drives — reads it from this table instead of
+   * keeping a second copy that could quietly disagree.
+   */
+  surfaceId?: string;
+  /**
+   * Which part of the app the command belongs to — the sections the help
+   * sheet reads as a cheat sheet rather than as one long list.
+   *
+   * On the COMMAND for the same reason {@link Command.list} and
+   * {@link Command.surfaceId} are: a user who rebinds `files` to `q` should
+   * find it under Panels, where it has always been, and not have the sheet's
+   * shape depend on the keymap.
+   */
+  group: CommandGroup;
   /**
    * Runs the command, and MAY report the index it activated in its list — the
    * seed the step keys page on from, so `e` (which opens the first sprinkle)
@@ -641,6 +747,8 @@ function surfaceCommand(id: string, description: string, list?: ChordListId): Co
   return {
     holdsMode: !!list,
     description,
+    group: 'Panels',
+    surfaceId: id,
     ...(list ? { list } : {}),
     run: ({ deps, state }) => {
       state.lastDockSurface = id;
@@ -658,6 +766,7 @@ function freezerCommand(type: string, description: string): Command {
   return {
     holdsMode: false,
     description,
+    group: 'Agents',
     run: ({ deps }) => {
       deps.freezer?.dispatchEvent(new CustomEvent(type, { bubbles: true }));
     },
@@ -675,6 +784,7 @@ function freezerCommand(type: string, description: string): Command {
 const COMMANDS: Readonly<Record<CommandId, Command>> = {
   nextAgent: {
     holdsMode: true,
+    group: 'Agents',
     description: 'Next agent, looping',
     run: ({ deps }) => {
       const next = nextInCycle(
@@ -686,6 +796,7 @@ const COMMANDS: Readonly<Record<CommandId, Command>> = {
   },
   prevAgent: {
     holdsMode: true,
+    group: 'Agents',
     description: 'Previous agent, looping',
     run: ({ deps }) => {
       const prev = prevInCycle(
@@ -697,12 +808,14 @@ const COMMANDS: Readonly<Record<CommandId, Command>> = {
   },
   composer: {
     holdsMode: false,
+    group: 'Getting around',
     description: 'Back to the composer',
     run: ({ deps }) => deps.focusComposer?.(),
   },
   stop: {
     // Stopping keeps you where you are: the turn ends, the keyboard stays.
     holdsMode: true,
+    group: 'The turn',
     description: 'Stop the running turn',
     run: ({ deps }) => deps.stopTurn?.(),
   },
@@ -714,22 +827,26 @@ const COMMANDS: Readonly<Record<CommandId, Command>> = {
      * keeps its Enter; see {@link isActivationTarget}).
      */
     holdsMode: true,
+    group: 'The turn',
     description: 'Go to the pending approval',
     run: ({ deps }) => deps.focusApproval?.(),
   },
   attach: {
     // The menu opens with its search field ready, so the mode is leaving.
     holdsMode: false,
+    group: 'The turn',
     description: 'Attach a file or skill',
     run: ({ deps }) => deps.openAttachMenu?.(),
   },
   copyReply: {
     holdsMode: true,
+    group: 'The turn',
     description: 'Copy the last reply',
     run: ({ deps }) => deps.copyReply?.(),
   },
   copyChat: {
     holdsMode: true,
+    group: 'The turn',
     description: 'Copy the whole chat',
     run: ({ deps }) => deps.copyChat?.(),
   },
@@ -743,21 +860,25 @@ const COMMANDS: Readonly<Record<CommandId, Command>> = {
      * Holds the mode, because the key that ends the turn is this same key.
      */
     holdsMode: true,
+    group: 'The turn',
     description: 'Dictate — again to send',
     run: ({ deps }) => deps.toggleVoice?.(),
   },
   nextItem: {
     holdsMode: true,
+    group: 'Getting around',
     description: 'Next message — or, after a list key, the next entry',
     run: (ctx) => stepList(ctx, 1),
   },
   prevItem: {
     holdsMode: true,
+    group: 'Getting around',
     description: 'Previous message — or the previous entry',
     run: (ctx) => stepList(ctx, -1),
   },
   newConversation: {
     holdsMode: false,
+    group: 'Agents',
     description: 'New conversation',
     // The event the rail's action row fires on a single click: save the
     // chat, extract memories, start a new one.
@@ -770,6 +891,7 @@ const COMMANDS: Readonly<Record<CommandId, Command>> = {
   dropCone: freezerCommand('drop-cone', 'Drop this cone'),
   sessions: {
     holdsMode: true,
+    group: 'Agents',
     description: 'Archived chats (with 1-9 / j / k: restore that one)',
     list: 'sessions',
     // Force the rail OPEN rather than toggling it: this is the one key whose
@@ -778,11 +900,13 @@ const COMMANDS: Readonly<Record<CommandId, Command>> = {
   },
   leftRail: {
     holdsMode: true,
+    group: 'Getting around',
     description: 'Toggle the left rail',
     run: ({ deps }) => deps.freezer?.toggle(),
   },
   rightRail: {
     holdsMode: true,
+    group: 'Getting around',
     description: 'Toggle the right panel',
     /**
      * The dock's own toggle: clicking the ACTIVE rail item collapses its
@@ -820,6 +944,7 @@ const COMMANDS: Readonly<Record<CommandId, Command>> = {
      * shell knowing anything about tabs.
      */
     holdsMode: true,
+    group: 'Panels',
     description: 'Peek a tab (then 1-9: show it and come back)',
     run: ({ deps }) => deps.peekTabs?.(),
   },
@@ -837,6 +962,7 @@ const COMMANDS: Readonly<Record<CommandId, Command>> = {
      * that completes the chord has to arrive with the keyboard still live.
      */
     holdsMode: true,
+    group: 'Panels',
     description: 'Sprinkles (with 1-9 / j / k: open that one)',
     list: 'sprinkles',
     run: ({ deps, state }) => {
@@ -854,6 +980,7 @@ const COMMANDS: Readonly<Record<CommandId, Command>> = {
   },
   zoom: {
     holdsMode: true,
+    group: 'Getting around',
     description: 'Full screen the open panel',
     /**
      * Runs synchronously inside the keydown on purpose: `requestFullscreen()`
@@ -864,6 +991,7 @@ const COMMANDS: Readonly<Record<CommandId, Command>> = {
   },
   model: {
     holdsMode: false,
+    group: 'Settings',
     description: 'Model picker',
     /**
      * `openMenu()` is the pill's own programmatic click — and, exactly like a
@@ -883,6 +1011,7 @@ const COMMANDS: Readonly<Record<CommandId, Command>> = {
   },
   cycleModel: {
     holdsMode: true,
+    group: 'Settings',
     description: 'Next model',
     run: ({ deps, actions }) => {
       const meta = deps.composerMeta;
@@ -896,16 +1025,19 @@ const COMMANDS: Readonly<Record<CommandId, Command>> = {
   },
   cycleThinking: {
     holdsMode: true,
+    group: 'Settings',
     description: 'Next thinking level',
     run: ({ deps }) => deps.composerMeta?.cycleThinking?.(),
   },
   accounts: {
     holdsMode: false,
+    group: 'Settings',
     description: 'Accounts',
     run: ({ actions }) => actions.accounts?.(),
   },
   help: {
     holdsMode: true,
+    group: 'Getting around',
     description: 'This help',
     run: (ctx) => ctx.toggleHelp(),
   },
@@ -917,6 +1049,30 @@ export const COMMAND_IDS = Object.keys(COMMANDS) as CommandId[];
 /** Is `value` a command a keymap may point at? */
 export function isCommandId(value: unknown): value is CommandId {
   return typeof value === 'string' && Object.hasOwn(COMMANDS, value);
+}
+
+/**
+ * The dock surface `id` opens, or `null` for a command that opens none.
+ *
+ * The one fact about the command table the floating key caps need: which rail
+ * item a letter drives. Exported rather than re-derived so a dock id that
+ * moves moves in exactly one place.
+ */
+export function commandSurfaceId(id: CommandId): string | null {
+  return COMMANDS[id].surfaceId ?? null;
+}
+
+/**
+ * The command that opens dock surface `surfaceId`, or `null` for a surface no
+ * command opens.
+ *
+ * The inverse of {@link commandSurfaceId}, and the reason the usage log can
+ * count a CLICK on a rail item as the same action as the key that opens it —
+ * which is the whole point: the help sheet learns what you do, not what you
+ * do with the keyboard.
+ */
+export function commandForSurfaceId(surfaceId: string): CommandId | null {
+  return COMMAND_IDS.find((id) => COMMANDS[id].surfaceId === surfaceId) ?? null;
 }
 
 /**
@@ -1038,16 +1194,28 @@ function keyLabel(key: string): string {
  * than no list. A command nobody has a key for is dropped.
  */
 /**
- * The key the badge should tell a new user to press for help — the first one
- * bound to `help`, as it prints, or `null` when a config has unbound it.
+ * The first key bound to `id`, as it prints, or `null` when nothing is.
  *
  * Derived rather than written out for the same reason {@link shortcutRows} is:
- * the mode's own hint must never name a key that does nothing, which is
- * exactly what it did when the shipped map moved help off `h`.
+ * nothing the mode draws may name a key that does nothing, which is exactly
+ * what the badge did when the shipped map moved help off `h`. The floating key
+ * caps read the same way — a cap on the files rail item says whatever the live
+ * keymap has bound to `files`, and disappears if a config unbinds it.
+ *
+ * FIRST, not all: a control has room for one legend, and the keymap's own
+ * order is the honest tiebreak.
  */
-export function helpKeyLabel(keymap: Readonly<Record<string, CommandId>>): string | null {
-  const key = Object.keys(keymap).find((k) => keymap[k] === 'help');
+export function commandKeyLabel(
+  keymap: Readonly<Record<string, CommandId>>,
+  id: CommandId
+): string | null {
+  const key = Object.keys(keymap).find((k) => keymap[k] === id);
   return key === undefined ? null : keyLabel(key);
+}
+
+/** The key the badge should tell a new user to press for help. */
+export function helpKeyLabel(keymap: Readonly<Record<string, CommandId>>): string | null {
+  return commandKeyLabel(keymap, 'help');
 }
 
 /**
@@ -1083,11 +1251,18 @@ export function shortcutRows(
     {
       keys: ['Esc'],
       description: 'Leave the composer for keyboard mode (again: exit full screen)',
+      group: 'Getting around' as const,
     },
-    { keys: ['1 – 9'], description: 'Switch to that agent in the tab strip (9 = last)' },
+    {
+      keys: ['1 – 9'],
+      description: 'Switch to that agent in the tab strip (9 = last)',
+      group: 'Agents' as const,
+    },
     ...COMMAND_IDS.filter((id) => byCommand.has(id)).map((id) => ({
       keys: byCommand.get(id) ?? [],
       description: COMMANDS[id].description,
+      group: COMMANDS[id].group,
+      id,
     })),
   ];
 }
@@ -1101,10 +1276,111 @@ function ensureStyle(doc: Document): void {
 }
 
 /** The overlay body: a lead line, then one row per binding. */
+/** How many of your own actions the personalised section leads with. */
+const FREQUENT_ROWS = 5;
+
+/**
+ * What the sheet needs from the usage log, structurally — so this module,
+ * which `wc-shortcut-usage.ts` imports FROM, never imports it back.
+ */
+export interface HelpUsage {
+  ranked(): ReadonlyArray<{ id: CommandId; count: number }>;
+}
+
+/** A row plus what the sheet knows about your use of it. */
+interface HelpRow extends ShortcutRow {
+  count: number;
+}
+
+/** One `<kbd>` per key, `+` between a chord's parts is the row's own business. */
+function keyNodes(doc: Document, row: ShortcutRow): HTMLElement {
+  const keys = doc.createElement('div');
+  keys.className = 'wcsc__keys';
+  for (const key of row.keys) {
+    const kbd = doc.createElement('kbd');
+    kbd.className = 'wcsc__key';
+    kbd.textContent = key;
+    keys.append(kbd);
+  }
+  return keys;
+}
+
+/**
+ * One line of the sheet. `data-used` is the highlight: something you have
+ * already done this session, tinted so the few you touched are findable in a
+ * wall of rows.
+ */
+function helpRow(doc: Document, row: HelpRow, showCount = false): HTMLElement {
+  const line = doc.createElement('div');
+  line.className = 'wcsc__row';
+  if (row.count > 0) line.dataset.used = String(row.count);
+
+  const desc = doc.createElement('div');
+  desc.className = 'wcsc__desc';
+  desc.textContent = row.description;
+  line.append(desc);
+
+  if (showCount) {
+    const count = doc.createElement('div');
+    count.className = 'wcsc__count';
+    count.textContent = `×${row.count}`;
+    line.append(count);
+  }
+  line.append(keyNodes(doc, row));
+  return line;
+}
+
+function helpGroup(doc: Document, title: string, rows: readonly HelpRow[]): HTMLElement {
+  const group = doc.createElement('div');
+  group.className = 'wcsc__group';
+  const heading = doc.createElement('div');
+  heading.className = 'wcsc__title';
+  heading.textContent = title;
+  group.append(heading);
+  for (const row of rows) group.append(helpRow(doc, row));
+  return group;
+}
+
+/**
+ * **Your frequent actions** — the section that makes the sheet worth opening
+ * twice.
+ *
+ * Ordered by what you have actually done, counting POINTER use as well as
+ * keys (see `wc-shortcut-usage.ts`), so its whole job is to tell you the
+ * shortcut for the thing you have been clicking. A user who has done nothing
+ * yet gets no section at all rather than an empty box — the sheet has to work
+ * on the first press too.
+ */
+function frequentGroup(doc: Document, rows: readonly HelpRow[]): HTMLElement | null {
+  const top = rows
+    .filter((row) => row.count > 0)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, FREQUENT_ROWS);
+  if (top.length === 0) return null;
+
+  const group = doc.createElement('div');
+  group.className = 'wcsc__group wcsc__group--yours';
+  const heading = doc.createElement('div');
+  heading.className = 'wcsc__title';
+  heading.textContent = 'Your frequent actions';
+  group.append(heading);
+  for (const row of top) group.append(helpRow(doc, row, true));
+  return group;
+}
+
+/**
+ * The help sheet: a personalised header, then the whole keymap in labelled
+ * sections that flow into as many columns as the viewport allows.
+ *
+ * Sections come from the COMMAND table rather than from the keymap
+ * ({@link Command.group}), so rebinding a key never reshuffles the sheet, and
+ * a group nobody has a binding for simply does not appear.
+ */
 function buildHelpBody(
   doc: Document,
   rows: readonly ShortcutRow[],
-  trigger: KeyboardTrigger
+  trigger: KeyboardTrigger,
+  usage?: HelpUsage
 ): HTMLElement {
   const list = doc.createElement('div');
   list.className = 'wcsc';
@@ -1117,23 +1393,22 @@ function buildHelpBody(
         ? 'Press Esc to enter keyboard mode. Put the caret back in the composer to type — nothing is intercepted there.'
         : 'Keyboard mode is on whenever nothing is focused for typing (and you are not clicking composer chrome), so these keys are live by default. Put the caret back in the composer to type — nothing is intercepted there.';
   list.append(note);
-  for (const row of rows) {
-    const line = doc.createElement('div');
-    line.className = 'wcsc__row';
-    const desc = doc.createElement('div');
-    desc.className = 'wcsc__desc';
-    desc.textContent = row.description;
-    const keys = doc.createElement('div');
-    keys.className = 'wcsc__keys';
-    for (const key of row.keys) {
-      const kbd = doc.createElement('kbd');
-      kbd.className = 'wcsc__key';
-      kbd.textContent = key;
-      keys.append(kbd);
-    }
-    line.append(desc, keys);
-    list.append(line);
+
+  const counts = new Map((usage?.ranked() ?? []).map((entry) => [entry.id, entry.count]));
+  const counted: HelpRow[] = rows.map((row) => ({
+    ...row,
+    count: (row.id === undefined ? undefined : counts.get(row.id)) ?? 0,
+  }));
+
+  const cols = doc.createElement('div');
+  cols.className = 'wcsc__cols';
+  const yours = frequentGroup(doc, counted);
+  if (yours) cols.append(yours);
+  for (const group of COMMAND_GROUPS) {
+    const inGroup = counted.filter((row) => row.group === group);
+    if (inGroup.length > 0) cols.append(helpGroup(doc, group, inGroup));
   }
+  list.append(cols);
   return list;
 }
 
@@ -1232,7 +1507,8 @@ function createHud(
 function createHelp(
   doc: Document,
   readKeymap: () => Readonly<Record<string, CommandId>>,
-  readTrigger: () => KeyboardTrigger
+  readTrigger: () => KeyboardTrigger,
+  usage?: HelpUsage
 ): {
   show(): void;
   hide(): void;
@@ -1254,7 +1530,10 @@ function createHelp(
     dialog.className = 'wcsc-dialog';
     dialog.setAttribute('heading', 'Keyboard mode');
     dialog.dataset.wcShortcuts = 'help';
-    dialog.append(buildHelpBody(doc, shortcutRows(readKeymap()), readTrigger()));
+    // Read at OPEN time: the sheet is a snapshot of what you have done so
+    // far, and a sheet built at wire time would always say you had done
+    // nothing.
+    dialog.append(buildHelpBody(doc, shortcutRows(readKeymap()), readTrigger(), usage));
     // The dialog dismisses itself on Escape / ✕ / backdrop; drop our handle
     // so the next `?` builds a fresh one instead of toggling a dead node.
     dialog.addEventListener('slicc-dialog-close', () => {
@@ -1303,6 +1582,7 @@ function createMode(
   doc: Document,
   keymap: () => Readonly<Record<string, CommandId>>,
   hudHost: () => HTMLElement,
+  caps: ShortcutCaps | undefined,
   onToggle: (on: boolean) => void
 ): {
   on(): boolean;
@@ -1324,6 +1604,7 @@ function createMode(
       if (!next) {
         hud?.destroy();
         hud = null;
+        caps?.hide();
         return;
       }
       ensureStyle(doc);
@@ -1331,6 +1612,9 @@ function createMode(
       // shell wired itself (the config load is deliberately late) is the one
       // the hint names.
       hud = createHud(doc, hudHost(), keymap());
+      // Same keymap, same moment, for the same reason: a cap that named a key
+      // the config had already rebound would be worse than no cap at all.
+      caps?.show(keymap());
       // The caret would otherwise keep blinking in a composer that no longer
       // receives what is typed.
       const focused = doc.activeElement as HTMLElement | null;
@@ -1595,11 +1879,16 @@ interface Dispatch {
  */
 function runCommand(
   command: Command,
+  id: CommandId,
   event: KeyboardEvent,
   armed: ArmedChord | null,
   ctx: Dispatch
 ): void {
   event.preventDefault();
+  // Counted here rather than inside each command: this is the one place every
+  // keyed command passes through. The pointer half is counted by the usage
+  // log itself, off the surfaces' own events.
+  ctx.deps.usage?.record?.(id);
   if (!command.holdsMode) ctx.mode.set(false);
   const at = command.run({
     deps: ctx.deps,
@@ -1758,7 +2047,7 @@ function handleModeKeyDown(
     helpOpen: () => boolean;
     deps: ShortcutDeps;
     dispatch: Dispatch;
-    commandFor: (key: string) => Command | undefined;
+    commandIdFor: (key: string) => CommandId | undefined;
     trigger: KeyboardTrigger;
   }
 ): void {
@@ -1777,7 +2066,11 @@ function handleModeKeyDown(
   // the digit the prefix was waiting for unless it is consumed below.
   const armed = ctx.chord.take();
 
-  const command = ctx.commandFor(event.key);
+  // Resolved as an ID, because the id is what the usage log counts — deriving
+  // it again at the bottom of this function would read the keymap twice for
+  // one keystroke.
+  const commandId = ctx.commandIdFor(event.key);
+  const command = commandId ? COMMANDS[commandId] : undefined;
   if (suspendedByModal(ctx.doc, command, ctx.helpOpen())) {
     // Suspended, not ignored: the cap lands dimmed, so a key pressed at a
     // dialog reads as "not now" rather than as a dead keyboard.
@@ -1801,7 +2094,7 @@ function handleModeKeyDown(
 
   ctx.mode.record(describeKey(event), !!command);
   // An unbound key is not an exit: the mode is sticky, like vim's.
-  if (command) runCommand(command, event, armed, ctx.dispatch);
+  if (command && commandId) runCommand(command, commandId, event, armed, ctx.dispatch);
 }
 
 /**
@@ -1891,15 +2184,24 @@ export function wireKeyboardShortcuts(deps: ShortcutDeps): ShortcutHandles {
   const actions: ShortcutActions = {};
   let keymap: Readonly<Record<string, CommandId>> = DEFAULT_KEYMAP;
   let trigger: KeyboardTrigger = DEFAULT_TRIGGER;
+  /*
+   * What the user has done this session, counting POINTER use as well as
+   * keys — the data behind the sheet's "your frequent actions". Supplied by
+   * the shell where there is one; a float that hands over none simply gets
+   * the reference sheet.
+   */
+  const usage = deps.usage;
   const help = createHelp(
     doc,
     () => keymap,
-    () => trigger
+    () => trigger,
+    usage
   );
   const mode = createMode(
     doc,
     () => keymap,
     () => deps.hudHost ?? doc.body,
+    deps.caps,
     (on) => {
       // The strip's tablist walk and the mode both want ←/→, and the strip is
       // closer to the key. It stands aside for as long as the mode is up.
@@ -1908,10 +2210,7 @@ export function wireKeyboardShortcuts(deps: ShortcutDeps): ShortcutHandles {
     }
   );
   const state: ModeState = { lastDockSurface: 'files' };
-  const commandFor = (key: string): Command | undefined => {
-    const id = keymap[key];
-    return id ? COMMANDS[id] : undefined;
-  };
+  const commandIdFor = (key: string): CommandId | undefined => keymap[key];
   const composerPointer = { value: false };
   const settler = createSettler(
     doc,
@@ -1941,7 +2240,7 @@ export function wireKeyboardShortcuts(deps: ShortcutDeps): ShortcutHandles {
       helpOpen: () => !!help.element(),
       deps,
       dispatch,
-      commandFor,
+      commandIdFor,
       trigger,
     });
 
@@ -2009,6 +2308,10 @@ export function wireKeyboardShortcuts(deps: ShortcutDeps): ShortcutHandles {
       chord.clear();
       mode.set(false);
       help.hide();
+      // After `mode.set(false)`, which has already taken the caps down —
+      // this releases the observers that were watching for the chrome to
+      // rebuild underneath them.
+      deps.caps?.destroy();
       // Only if we are still the live one: a remount disposes the old handle
       // AFTER installing itself would be wrong, so `wireKeyboardShortcuts`
       // disposes first — but a caller disposing an already-replaced handle

--- a/packages/webapp/tests/ui/wc/wc-shortcut-caps.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-shortcut-caps.test.ts
@@ -1,0 +1,374 @@
+// @vitest-environment jsdom
+/**
+ * The floating key caps: one `<slicc-keycap>` per reachable control, floated
+ * over a measured ghost of it because none of those controls can host a child.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createShortcutCaps } from '../../../src/ui/wc/wc-shortcut-caps.js';
+import { DEFAULT_KEYMAP } from '../../../src/ui/wc/wc-shortcuts.js';
+
+const RAIL_IDS = ['browser', 'files', 'term', 'memory', 'monitor'] as const;
+
+/**
+ * A rail + a composer band, the two places caps go. jsdom lays nothing out, so
+ * every element is stubbed with a real box — a zero rect is the module's own
+ * signal for "this float does not have this control", and without the stub
+ * every cap would correctly refuse to mount.
+ */
+function harness(
+  options: { railIds?: readonly string[]; sprinkle?: boolean; scoops?: number } = {}
+): {
+  inputCard: HTMLElement;
+  root: HTMLElement;
+  dock: HTMLElement;
+  track: HTMLElement;
+  switcher: { scoops: unknown[] };
+} {
+  const dock = document.createElement('slicc-dock');
+  for (const id of options.railIds ?? RAIL_IDS) {
+    const item = document.createElement('slicc-dock-item');
+    item.setAttribute('item-id', id);
+    box(item);
+    dock.append(item);
+  }
+  if (options.sprinkle) {
+    const item = document.createElement('slicc-dock-item');
+    item.setAttribute('item-id', 'sprinkle-hello');
+    item.setAttribute('kind', 'sprinkle');
+    box(item);
+    dock.append(item);
+  }
+
+  // Real-ish coordinates, because placement is decided against the viewport:
+  // a control stubbed hard against an edge legitimately flips its cap, which
+  // is behaviour worth testing on purpose rather than tripping over.
+  const inputCard = document.createElement('slicc-input-card');
+  box(inputCard, { left: 113, right: 793, width: 680, top: 400, height: 107 });
+  for (const [tag, left] of [
+    ['slicc-add-menu', 130],
+    ['slicc-send-button', 750],
+    ['textarea', 130],
+  ] as const) {
+    const el = document.createElement(tag);
+    box(el, { left, right: left + 30 });
+    inputCard.append(el);
+  }
+
+  const tabs = document.createElement('slicc-agent-tabs');
+  const track = document.createElement('div');
+  track.setAttribute('part', 'track-frame');
+  box(track, { left: 100, width: 70, right: 170 });
+  tabs.append(track);
+
+  const freezer = document.createElement('slicc-freezer');
+  const railToggle = document.createElement('button');
+  railToggle.setAttribute('part', 'toggle');
+  box(railToggle, { left: 8, right: 38 });
+  freezer.append(railToggle);
+
+  const root = document.createElement('div');
+  document.body.append(dock, inputCard, tabs, freezer, root);
+  // Two units by default: the arrows only earn a cap when there is somewhere
+  // for them to go.
+  const switcher = { scoops: Array.from({ length: options.scoops ?? 2 }, (_, i) => i) };
+  return { inputCard, root, dock, track, switcher };
+}
+
+/** Give an element a box, since jsdom measures everything as 0×0. */
+function box(el: Element, rect: Partial<DOMRect> = {}): void {
+  const value = { x: 10, y: 20, width: 30, height: 30, top: 20, left: 10, ...rect } as DOMRect;
+  el.getBoundingClientRect = () => value;
+}
+
+function caps(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLElement>('.wcsc-caps slicc-keycap')];
+}
+
+function capFor(key: string): HTMLElement | undefined {
+  return caps().find((cap) => cap.getAttribute('cap') === key);
+}
+
+describe('wc-shortcut-caps', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('mounts nothing until the mode turns on, and nothing after it turns off', () => {
+    const deps = harness();
+    const handle = createShortcutCaps(deps);
+    expect(document.querySelector('.wcsc-caps')).toBeNull();
+
+    handle.show(DEFAULT_KEYMAP);
+    expect(caps().length).toBeGreaterThan(0);
+
+    handle.hide();
+    expect(document.querySelector('.wcsc-caps')).toBeNull();
+    expect(caps()).toEqual([]);
+  });
+
+  it('caps each rail launcher with the key its command is bound to', () => {
+    const deps = harness();
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+
+    // The shipped map: b browser, f files, t terminal, m memory, g monitor.
+    for (const key of ['b', 'f', 't', 'm', 'g']) expect(capFor(key)).toBeDefined();
+    // The composer band's two toolbar controls, and the way back to typing.
+    for (const key of ['u', 's', 'i']) expect(capFor(key)).toBeDefined();
+    handle.hide();
+  });
+
+  /**
+   * The tab strip's DIGITS cannot be drawn — `<slicc-agent-tabs>` clips its own
+   * track — so the switcher is named once, on the track, by the two arrows that
+   * drive it. They are one affordance and sit adjacent on a real keyboard, so
+   * they are one cap with two legends.
+   */
+  it('names the switcher with both arrows, on the track, clear of it', () => {
+    const deps = harness();
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+
+    const cap = capFor('← →') as HTMLElement & { anchor?: HTMLElement | null };
+    expect(cap).toBeDefined();
+    expect(cap.anchor).toBe(deps.track);
+    // `end` clears the control rather than overhanging its corner.
+    expect(cap.getAttribute('placement')).toBe('end');
+    handle.hide();
+  });
+
+  /**
+   * `←` / `→` walk a cycle, and a cycle of one is a key that does nothing.
+   * One cone and no scoops is the COMMON case, so a cap there would be a
+   * permanent lie on the busiest piece of chrome in the shell.
+   */
+  it('has no switcher cap when there is only one unit', () => {
+    const deps = harness({ scoops: 1 });
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+    expect(capFor('← →')).toBeUndefined();
+    handle.hide();
+  });
+
+  it('grows the switcher cap once a second unit exists', () => {
+    const deps = harness({ scoops: 1 });
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+    expect(capFor('← →')).toBeUndefined();
+
+    deps.switcher.scoops.push(1);
+    handle.show(DEFAULT_KEYMAP);
+    expect(capFor('← →')).toBeDefined();
+    handle.hide();
+  });
+
+  /** The one piece of chrome that had no hint at all. */
+  it('caps the left rail toggle', () => {
+    const deps = harness();
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+
+    const cap = capFor('[') as HTMLElement & { anchor?: HTMLElement | null };
+    expect(cap).toBeDefined();
+    expect(cap.anchor).toBe(document.querySelector('slicc-freezer [part="toggle"]'));
+    handle.hide();
+  });
+
+  it('keeps the half of a pair that is still bound', () => {
+    const deps = harness();
+    const handle = createShortcutCaps(deps);
+    const { ArrowLeft: _unbound, ...rest } = DEFAULT_KEYMAP;
+    handle.show(rest);
+
+    expect(capFor('→')).toBeDefined();
+    expect(capFor('← →')).toBeUndefined();
+    handle.hide();
+  });
+
+  /** The caret's way home goes on the text, not on the card around it. */
+  it('puts the composer key on the textarea', () => {
+    const deps = harness();
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+
+    const cap = capFor('i') as HTMLElement & { anchor?: HTMLElement | null };
+    expect(cap.anchor).toBe(deps.inputCard.querySelector('textarea'));
+    expect(cap.getAttribute('placement')).toBe('top-start');
+    handle.hide();
+  });
+
+  /**
+   * Which corner a cap hangs off is measured, not written down: the dock rail
+   * is flush with the right edge of the window, so a cap overhanging to the
+   * right would hang off the SCREEN. And which edge the rail is on is a layout
+   * choice, so a hard-coded corner would only ever be right for one layout.
+   */
+  it('flips a cap that would hang off the edge of the window', () => {
+    const deps = harness();
+    const item = deps.dock.querySelector('slicc-dock-item[item-id="files"]');
+    // The rail, where it really sits: hard against the right edge.
+    if (item) box(item, { left: globalThis.innerWidth - 34, right: globalThis.innerWidth - 4 });
+
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+    expect(capFor('f')?.getAttribute('placement')).toBe('top-start');
+
+    // And back again once it is nowhere near an edge.
+    if (item) box(item, { left: 400, right: 430 });
+    handle.show(DEFAULT_KEYMAP);
+    expect(capFor('f')?.getAttribute('placement')).toBe('top-end');
+    handle.hide();
+  });
+
+  /**
+   * The whole reason the key is read from the keymap rather than written into
+   * the spec table: a cap that named a binding a user had moved would be worse
+   * than no cap.
+   */
+  it('follows a rebound key and drops a cap the config unbinds', () => {
+    const deps = harness();
+    const handle = createShortcutCaps(deps);
+    const { f: _dropped, ...withoutFiles } = DEFAULT_KEYMAP;
+    handle.show({ ...withoutFiles, q: 'files' });
+
+    expect(capFor('q')).toBeDefined();
+    expect(capFor('f')).toBeUndefined();
+    handle.hide();
+  });
+
+  it('leaves a rail item this float does not have uncapped', () => {
+    // A follower hides the launchers whose features it lacks (wc-follower.ts).
+    const deps = harness({ railIds: ['files', 'term'] });
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+
+    expect(capFor('f')).toBeDefined();
+    expect(capFor('m')).toBeUndefined();
+    handle.hide();
+  });
+
+  /** No box means the control is not on this screen — a collapsed rail, say. */
+  it('drops a cap whose control has no box', () => {
+    const deps = harness();
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+    expect(capFor('f')).toBeDefined();
+
+    const item = deps.dock.querySelector('slicc-dock-item[item-id="files"]');
+    if (item) box(item, { width: 0, height: 0 });
+    handle.show(DEFAULT_KEYMAP);
+
+    expect(capFor('f')).toBeUndefined();
+    handle.hide();
+  });
+
+  it('positions each cap on a ghost of its control, in viewport coordinates', () => {
+    const deps = harness();
+    const item = deps.dock.querySelector('slicc-dock-item[item-id="files"]');
+    if (item) box(item, { left: 120, top: 240, width: 30, height: 34 });
+
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+
+    const ghost = capFor('f')?.parentElement;
+    expect(ghost?.style.left).toBe('120px');
+    expect(ghost?.style.top).toBe('240px');
+    expect(ghost?.style.width).toBe('30px');
+    expect(ghost?.style.height).toBe('34px');
+    handle.hide();
+  });
+
+  /**
+   * The ghost is `pointer-events: none` and could never be hovered, so the cap
+   * is pointed back at the real control — otherwise the hover press would
+   * belong to a box nobody can touch.
+   */
+  it('anchors the hover to the real control, not to the ghost', () => {
+    const deps = harness();
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+
+    const cap = capFor('f') as HTMLElement & { anchor?: HTMLElement | null };
+    expect(cap.anchor).toBe(deps.dock.querySelector('slicc-dock-item[item-id="files"]'));
+    handle.hide();
+  });
+
+  /** `<slicc-dock>` rebuilds its items wholesale; a held target goes stale. */
+  it('re-points a cap at a rebuilt control', () => {
+    const deps = harness();
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+
+    deps.dock.replaceChildren();
+    const rebuilt = document.createElement('slicc-dock-item');
+    rebuilt.setAttribute('item-id', 'files');
+    box(rebuilt, { left: 300, top: 60 });
+    deps.dock.append(rebuilt);
+    handle.show(DEFAULT_KEYMAP);
+
+    const cap = capFor('f') as HTMLElement & { anchor?: HTMLElement | null };
+    expect(cap.anchor).toBe(rebuilt);
+    expect(cap.parentElement?.style.left).toBe('300px');
+    handle.hide();
+  });
+
+  it('caps the first sprinkle launcher, which is the one the key opens', () => {
+    const deps = harness({ sprinkle: true });
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+
+    const cap = capFor('e') as HTMLElement & { anchor?: HTMLElement | null };
+    expect(cap?.anchor).toBe(deps.dock.querySelector('slicc-dock-item[kind="sprinkle"]'));
+    handle.hide();
+  });
+
+  it('has no sprinkle cap on a rail with no sprinkles installed', () => {
+    const deps = harness();
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+    expect(capFor('e')).toBeUndefined();
+    handle.hide();
+  });
+
+  it('stays on one cap per control across repeated shows', () => {
+    const deps = harness();
+    const handle = createShortcutCaps(deps);
+    handle.show(DEFAULT_KEYMAP);
+    const first = caps().length;
+    handle.show(DEFAULT_KEYMAP);
+    handle.show(DEFAULT_KEYMAP);
+    expect(caps().length).toBe(first);
+    handle.hide();
+  });
+
+  it('is safe to hide, destroy, or hide twice without a show', () => {
+    const handle = createShortcutCaps(harness());
+    expect(() => {
+      handle.hide();
+      handle.destroy();
+    }).not.toThrow();
+
+    handle.show(DEFAULT_KEYMAP);
+    handle.hide();
+    expect(() => handle.hide()).not.toThrow();
+    expect(document.querySelector('.wcsc-caps')).toBeNull();
+  });
+
+  /** Caps are chrome; a modal that has taken the keyboard outranks them. */
+  it('mounts the layer below the dialog stacking level', () => {
+    const handle = createShortcutCaps(harness());
+    handle.show(DEFAULT_KEYMAP);
+    const layer = document.querySelector<HTMLElement>('.wcsc-caps');
+    const style = document.getElementById('wcsc-caps-style')?.textContent ?? '';
+    expect(layer).not.toBeNull();
+    expect(style).toContain('position:fixed');
+    // `<slicc-dialog>` sits at 100.
+    const z = Number(/z-index:(\d+)/.exec(style)?.[1]);
+    expect(z).toBeLessThan(100);
+    handle.hide();
+  });
+});

--- a/packages/webapp/tests/ui/wc/wc-shortcut-usage.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-shortcut-usage.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+/**
+ * The session usage log: what the user actually does, counted off the
+ * SURFACES' own events so a click counts exactly as much as the key.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createShortcutUsage } from '../../../src/ui/wc/wc-shortcut-usage.js';
+
+function dockSelect(id: string): void {
+  document.body.dispatchEvent(
+    new CustomEvent('slicc-dock-select', { detail: { id }, bubbles: true, composed: true })
+  );
+}
+
+describe('wc-shortcut-usage', () => {
+  let usage: ReturnType<typeof createShortcutUsage>;
+
+  beforeEach(() => {
+    document.body.replaceChildren();
+    usage = createShortcutUsage(document);
+  });
+
+  afterEach(() => usage.dispose());
+
+  it('starts empty, so a first-run sheet shows no personalised section', () => {
+    expect(usage.ranked()).toEqual([]);
+    expect(usage.used('files')).toBe(false);
+  });
+
+  it('counts a keyed command', () => {
+    usage.record('files');
+    usage.record('files');
+    expect(usage.used('files')).toBe(true);
+    expect(usage.ranked()).toEqual([{ id: 'files', count: 2 }]);
+  });
+
+  /**
+   * The whole point: a list of shortcuts you already use is worthless. The
+   * sheet has to learn from the surfaces you reach for with the MOUSE.
+   */
+  it('counts a click on a rail item as the same action as its key', () => {
+    dockSelect('files');
+    dockSelect('files');
+    usage.record('files');
+    expect(usage.ranked()).toEqual([{ id: 'files', count: 3 }]);
+  });
+
+  it('maps every dock surface back to the command that opens it', () => {
+    dockSelect('browser');
+    dockSelect('term');
+    dockSelect('memory');
+    dockSelect('monitor');
+    expect(
+      usage
+        .ranked()
+        .map((entry) => entry.id)
+        .sort()
+    ).toEqual(['memory', 'monitor', 'tabs', 'terminal']);
+  });
+
+  /** A sprinkle launcher has no fixed id; `sprinkles` is what opens one. */
+  it('counts an unnamed launcher as a sprinkle', () => {
+    dockSelect('sprinkle-hello');
+    expect(usage.ranked()).toEqual([{ id: 'sprinkles', count: 1 }]);
+  });
+
+  it('counts the left rail toggle, however it was toggled', () => {
+    document.body.dispatchEvent(new CustomEvent('freezer-toggle', { bubbles: true }));
+    expect(usage.used('leftRail')).toBe(true);
+  });
+
+  it('ranks by count, breaking ties on what was done most recently', () => {
+    usage.record('files');
+    usage.record('files');
+    usage.record('memory');
+    usage.record('terminal');
+    expect(usage.ranked()).toEqual([
+      { id: 'files', count: 2 },
+      { id: 'terminal', count: 1 },
+      { id: 'memory', count: 1 },
+    ]);
+  });
+
+  it('ignores a select with no usable id', () => {
+    document.body.dispatchEvent(
+      new CustomEvent('slicc-dock-select', { detail: {}, bubbles: true, composed: true })
+    );
+    expect(usage.ranked()).toEqual([]);
+  });
+
+  it('stops counting once disposed', () => {
+    usage.dispose();
+    dockSelect('files');
+    expect(usage.ranked()).toEqual([]);
+  });
+});

--- a/packages/webapp/tests/ui/wc/wc-shortcuts.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-shortcuts.test.ts
@@ -6,7 +6,9 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  COMMAND_GROUPS,
   COMMAND_IDS,
+  type CommandId,
   DEFAULT_KEYMAP,
   deepActiveElement,
   deepTarget,
@@ -48,6 +50,11 @@ function harness(
     /** Rows the `files` / `sessions` chord lists report. */
     files?: string[];
     sessions?: string[];
+    /** The session usage log the help sheet personalises from. */
+    usage?: {
+      ranked(): ReadonlyArray<{ id: CommandId; count: number }>;
+      record?(id: CommandId): void;
+    };
   } = {}
 ) {
   const keys = options.tabs ?? ['cone_1', 'cone_2', 'scoop_a'];
@@ -153,6 +160,7 @@ function harness(
       files: { size: () => files.length, selectAt: (i) => selectFile(files[i]) },
       sessions: { size: () => sessions.length, selectAt: (i) => selectSession(sessions[i]) },
     },
+    ...(options.usage ? { usage: options.usage } : {}),
     ...(options.noDock ? {} : { dock }),
     ...(options.noFreezer ? {} : { freezer }),
     ...(options.noComposer ? {} : { focusComposer }),
@@ -749,6 +757,83 @@ describe('inside keyboard mode', () => {
     expect(overlay?.querySelectorAll('.wcsc__row')).toHaveLength(shortcutRows().length);
     press({ key, code: 'Slash', shiftKey: true });
     expect(handles.helpOverlay()).toBeNull();
+  });
+
+  /**
+   * The sheet is a cheat sheet, not a reference: labelled sections that flow
+   * into columns, so you can scan for the thing you want instead of reading
+   * thirty rows in one alphabetical list.
+   */
+  it('groups the sheet into sections in command-table order', () => {
+    const { handles } = harness();
+    handles.showHelp();
+    const titles = [...(handles.helpOverlay()?.querySelectorAll('.wcsc__title') ?? [])].map(
+      (t) => t.textContent
+    );
+    expect(titles).toEqual([...COMMAND_GROUPS]);
+  });
+
+  it('puts every row in exactly one section', () => {
+    const { handles } = harness();
+    handles.showHelp();
+    const overlay = handles.helpOverlay();
+    expect(overlay?.querySelectorAll('.wcsc__group')).toHaveLength(COMMAND_GROUPS.length);
+    expect(overlay?.querySelectorAll('.wcsc__row')).toHaveLength(shortcutRows().length);
+  });
+
+  /** A sheet has to work on the FIRST press, before you have done anything. */
+  it('shows no personalised section until something has been used', () => {
+    const { handles } = harness();
+    handles.showHelp();
+    expect(handles.helpOverlay()?.querySelector('.wcsc__group--yours')).toBeNull();
+    expect(handles.helpOverlay()?.querySelectorAll('.wcsc__row[data-used]')).toHaveLength(0);
+  });
+
+  /**
+   * The point of the whole thing: it learns from what you have DONE — pointer
+   * included — and tells you the key for it.
+   */
+  it('leads with your frequent actions, most-used first', () => {
+    const usage = {
+      entries: [
+        { id: 'memory' as const, count: 2 },
+        { id: 'files' as const, count: 7 },
+      ],
+      ranked() {
+        return this.entries;
+      },
+      record() {},
+    };
+    const { handles } = harness({ usage });
+    handles.showHelp();
+    const yours = handles.helpOverlay()?.querySelector('.wcsc__group--yours');
+    expect(yours?.querySelector('.wcsc__title')?.textContent).toBe('Your frequent actions');
+    const rows = [...(yours?.querySelectorAll('.wcsc__row') ?? [])].map((r) => [
+      r.querySelector('.wcsc__desc')?.textContent,
+      r.querySelector('.wcsc__count')?.textContent,
+    ]);
+    expect(rows[0]?.[1]).toBe('×7');
+    expect(rows[0]?.[0]).toContain('File browser');
+    expect(rows[1]?.[1]).toBe('×2');
+  });
+
+  it('highlights a used row in the reference section too', () => {
+    const usage = { ranked: () => [{ id: 'files' as const, count: 3 }], record() {} };
+    const { handles } = harness({ usage });
+    handles.showHelp();
+    const used = [...(handles.helpOverlay()?.querySelectorAll('.wcsc__row[data-used]') ?? [])];
+    // Once in the personalised section, once in Panels where it lives.
+    expect(used).toHaveLength(2);
+    expect(used.every((row) => row.getAttribute('data-used') === '3')).toBe(true);
+  });
+
+  it('counts a keyed command as a use', () => {
+    const seen: string[] = [];
+    const usage = { ranked: () => [], record: (id: string) => seen.push(id) };
+    harness({ usage });
+    escape();
+    press({ key: 'f' });
+    expect(seen).toContain('files');
   });
 
   it('forgets an overlay that dismissed itself', () => {

--- a/packages/webapp/tests/ui/wc/wc-shortcuts.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-shortcuts.test.ts
@@ -5,6 +5,7 @@
  * out of the way of typing.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createShortcutUsage } from '../../../src/ui/wc/wc-shortcut-usage.js';
 import {
   COMMAND_GROUPS,
   COMMAND_IDS,
@@ -55,6 +56,12 @@ function harness(
       ranked(): ReadonlyArray<{ id: CommandId; count: number }>;
       record?(id: CommandId): void;
     };
+    /**
+     * Make `selectItem` / `toggle` dispatch the surface events the real
+     * components emit, so a test can see what a keystroke actually costs end
+     * to end. The default mocks stay silent, as most tests want.
+     */
+    liveDock?: boolean;
   } = {}
 ) {
   const keys = options.tabs ?? ['cone_1', 'cone_2', 'scoop_a'];
@@ -109,7 +116,14 @@ function harness(
   } = {
     items: options.dockItems ?? [{ id: 'files', kind: 'tool' as const }],
     active: options.activeDock ?? null,
-    selectItem,
+    selectItem: options.liveDock
+      ? (vi.fn((id: string) => {
+          selectItem(id);
+          document.body.dispatchEvent(
+            new CustomEvent('slicc-dock-select', { detail: { id }, bubbles: true, composed: true })
+          );
+        }) as unknown as typeof selectItem)
+      : selectItem,
     collapse,
   };
   const openMenu = vi.fn();
@@ -121,7 +135,20 @@ function harness(
     cycleModel,
     cycleThinking,
   };
-  const freezer = Object.assign(document.createElement('div'), { toggle });
+  const freezer = Object.assign(document.createElement('div'), {
+    toggle: options.liveDock
+      ? (force?: boolean) => {
+          toggle(force);
+          freezer.dispatchEvent(
+            new CustomEvent('freezer-toggle', {
+              detail: { open: force ?? true },
+              bubbles: true,
+              composed: true,
+            })
+          );
+        }
+      : toggle,
+  });
   document.body.append(freezer);
   const newChat = vi.fn();
   const erase = vi.fn();
@@ -834,6 +861,57 @@ describe('inside keyboard mode', () => {
     escape();
     press({ key: 'f' });
     expect(seen).toContain('files');
+  });
+
+  /**
+   * A keystroke is ONE use, even though it reaches its surface through the
+   * same event a click produces — which the usage log is also listening for.
+   * Without this, keyed panel opens rank 2:1 against clicked ones and the
+   * personalised section is biased towards the keyboard, which is the exact
+   * bias the feature exists to avoid.
+   */
+  it('counts a keyed panel open once, not once per path', () => {
+    const usage = createShortcutUsage(document);
+    const { dock } = harness({ usage, liveDock: true });
+    escape();
+    press({ key: 'f' });
+    expect(dock.selectItem).toHaveBeenCalledWith('files');
+    expect(usage.ranked()).toEqual([{ id: 'files', count: 1 }]);
+    usage.dispose();
+  });
+
+  it('counts a clicked panel open once, and the same as a keyed one', () => {
+    const usage = createShortcutUsage(document);
+    harness({ usage, liveDock: true });
+    document.body.dispatchEvent(
+      new CustomEvent('slicc-dock-select', { detail: { id: 'files' }, bubbles: true })
+    );
+    expect(usage.ranked()).toEqual([{ id: 'files', count: 1 }]);
+    usage.dispose();
+  });
+
+  /**
+   * `r` forces the left rail OPEN to show the archived chats, which fires the
+   * rail's own `freezer-toggle` — so the naive listener credited the press to
+   * `leftRail` and archived chats never appeared in the sheet at all.
+   */
+  it('credits archived chats to sessions, not to the left rail', () => {
+    const usage = createShortcutUsage(document);
+    harness({ usage, liveDock: true });
+    escape();
+    press({ key: 'r' });
+    expect(usage.ranked()).toEqual([{ id: 'sessions', count: 1 }]);
+    usage.dispose();
+  });
+
+  it('still counts a rail toggle the user actually clicked', () => {
+    const usage = createShortcutUsage(document);
+    const { freezer } = harness({ usage, liveDock: true });
+    freezer.dispatchEvent(
+      new CustomEvent('freezer-toggle', { detail: { open: true }, bubbles: true })
+    );
+    expect(usage.ranked()).toEqual([{ id: 'leftRail', count: 1 }]);
+    usage.dispose();
   });
 
   it('forgets an overlay that dismissed itself', () => {

--- a/packages/webcomponents/CLAUDE.md
+++ b/packages/webcomponents/CLAUDE.md
@@ -50,11 +50,12 @@ Co-located `src/**/<name>.stories.ts` (dist-excluded) + `tests/**/<name>.test.ts
 - **Public API:** export the class; expose attributes (reflected to properties), `::part` hooks, named slots, `CustomEvent`s (composed + bubbling) — never reach into another component's internals.
 - **Theming:** reference prototype tokens (`var(--canvas)`, `--ink`, `--ctx`, `--rainbow`, …); they inherit through shadow roots — don't re-declare. Light default; dark is `body.dark`/`.dark`/`[data-theme="dark"]`.
 
-Four specialized components carry non-obvious host contracts — full tables/rules in `docs/webcomponents-details.md`:
+Five specialized components carry non-obvious host contracts — full tables/rules in `docs/webcomponents-details.md`:
 
 - **Agent-avatar expression kit** (`<slicc-agent-avatar activity>`): shape/brows/lids/gaze over four channels (point/scalar/event; grammar in `switcher/avatar-expression.ts`). No `activity` = legacy pointer-tracking face; static outranks every channel; brows paint OUTSIDE the tile crop, so hosts must not clip the avatar.
 - **Monitor meter markers**: a `MonitorVital` `ratio` also takes `markers` (`MonitorMeterMarker[]`), one dot each; `color` is a resolved CSS color the HOST supplies (webapp passes `scoopColor()`). Deep-copied by the `model` getter.
 - **Keyboard-mode HUD** (`<slicc-key-hud>`): pins itself to the bottom of the nearest positioned ancestor — the shell makes that `<slicc-chatpane>`, the COLUMN, so it survives a read-only unit hiding the composer band (#2312). A `.slicc-shell` `::after` bleed matches the composer's full-bleed band under an open tool pane (z-index 2, under chrome tiles); panel-layouts skip it. `hint` takes a `[x]` cap notation so the host names the keys its live keymap binds; `slicc-composer[keys]` is the band's half (everything but the HUD recedes).
+- **Keyboard-mode key caps** (`<slicc-keycap>`): floats a key legend on a control, `aria-hidden` + `pointer-events: none` (never a hit target) and self-gated to `(pointer: fine)` — desktop only. Pins to the nearest positioned ancestor; hover PRESSES the cap, watched on the anchor because the cap cannot see its own `:hover` and `:host-context(:hover)` is true whenever the pointer is in the window. A host that cannot make the cap a child of the control (shadow default slots, clipping parents) floats it over a measured ghost and sets `anchor` to the real control. Three variants (`chiclet` default / `deck` / `holo`); `stagger` seeds the entry sweep.
 - **Composer push-to-talk** (`<slicc-composer ptt>`): owns the hold-to-dictate gesture, not the audio stack — hosts inject a `ComposerSpeech` via `speech` (DOM-free subpath `.../composer/speech`); dictated submits carry `detail.source === 'dictation'`.
 
 ## Tests + Stories

--- a/packages/webcomponents/src/composer/slicc-key-hud.ts
+++ b/packages/webcomponents/src/composer/slicc-key-hud.ts
@@ -1,6 +1,7 @@
 import { define } from '../internal/define.js';
 import { append, type HChild, h, sheet } from '../internal/dom.js';
 import { hasIcon, iconEl } from '../internal/icons.js';
+import { CAP_ICONS } from '../internal/key-caps.js';
 
 /**
  * One press, as the HUD draws it: the caps of a single keystroke (modifiers
@@ -34,26 +35,6 @@ const DEFAULT_LINGER_MS = 1600;
  * it). A shell that has rebound either key passes its own hint instead.
  */
 const DEFAULT_HINT = '[?] help · [i] or [⏎] to type';
-
-/**
- * Caps whose key is a SHAPE rather than a letter, drawn as the lucide glyph
- * instead of the character. A `⏎` typed into a font is whatever that font
- * thinks a return is — at 11px, usually a smudge; the icon is the same stroke
- * weight as every other glyph in the app, at the size we asked for.
- *
- * Modifiers (`⌘`, `⇧`, `⌥`) stay text: those characters ARE the keys' legends,
- * and every Mac keyboard prints them exactly so.
- */
-const CAP_ICONS: Readonly<Record<string, string>> = {
-  '⏎': 'corner-down-left',
-  '↵': 'corner-down-left',
-  Enter: 'corner-down-left',
-  '←': 'arrow-left',
-  '→': 'arrow-right',
-  '↑': 'arrow-up',
-  '↓': 'arrow-down',
-  '⇥': 'arrow-right-to-line',
-};
 
 /** One key cap: a glyph where the key is a shape, the character otherwise. */
 function capNode(text: string, hint: boolean): HTMLElement {

--- a/packages/webcomponents/src/index.ts
+++ b/packages/webcomponents/src/index.ts
@@ -214,6 +214,11 @@ export { type FollowerHudRow, SliccFollowerHud } from './primitives/slicc-follow
 export { SliccGooglyEyes } from './primitives/slicc-googly-eyes.js';
 export { SliccIconButton } from './primitives/slicc-icon-button.js';
 export { SliccImagePreview } from './primitives/slicc-image-preview.js';
+export {
+  SliccKeycap,
+  type SliccKeycapPlacement,
+  type SliccKeycapVariant,
+} from './primitives/slicc-keycap.js';
 export { SliccPane } from './primitives/slicc-pane.js';
 export { SliccPressButton } from './primitives/slicc-press-button.js';
 export { SliccSendButton } from './primitives/slicc-send-button.js';

--- a/packages/webcomponents/src/internal/key-caps.ts
+++ b/packages/webcomponents/src/internal/key-caps.ts
@@ -1,0 +1,25 @@
+/**
+ * How a key prints on a cap — shared by every surface that draws one, so the
+ * HUD strip (`<slicc-key-hud>`) and the floating hints (`<slicc-keycap>`) can
+ * never name the same key two different ways.
+ */
+
+/**
+ * Caps whose key is a SHAPE rather than a letter, drawn as the lucide glyph
+ * instead of the character. A `⏎` typed into a font is whatever that font
+ * thinks a return is — at 11px, usually a smudge; the icon is the same stroke
+ * weight as every other glyph in the app, at the size we asked for.
+ *
+ * Modifiers (`⌘`, `⇧`, `⌥`) stay text: those characters ARE the keys' legends,
+ * and every Mac keyboard prints them exactly so.
+ */
+export const CAP_ICONS: Readonly<Record<string, string>> = {
+  '⏎': 'corner-down-left',
+  '↵': 'corner-down-left',
+  Enter: 'corner-down-left',
+  '←': 'arrow-left',
+  '→': 'arrow-right',
+  '↑': 'arrow-up',
+  '↓': 'arrow-down',
+  '⇥': 'arrow-right-to-line',
+};

--- a/packages/webcomponents/src/primitives/slicc-keycap.stories.ts
+++ b/packages/webcomponents/src/primitives/slicc-keycap.stories.ts
@@ -1,0 +1,497 @@
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import '../add-menu/slicc-add-menu.js';
+import '../composer/slicc-composer-meta.js';
+import '../composer/slicc-composer.js';
+import '../composer/slicc-input-card.js';
+import '../composer/slicc-key-hud.js';
+import '../dock/slicc-dock-item.js';
+import './slicc-send-button.js';
+import type { SliccKeycapPlacement, SliccKeycapVariant } from './slicc-keycap.js';
+import './slicc-keycap.js';
+
+interface KeycapArgs {
+  variant?: SliccKeycapVariant;
+  placement?: SliccKeycapPlacement;
+  dim?: boolean;
+}
+
+const meta: Meta<KeycapArgs> = {
+  title: 'Primitives/Keycap',
+  component: 'slicc-keycap',
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+  argTypes: {
+    variant: {
+      control: 'inline-radio',
+      options: ['chiclet', 'deck', 'holo'],
+      description: 'Which of the three looks',
+    },
+    placement: {
+      control: 'select',
+      options: ['top-end', 'top-start', 'bottom-end', 'bottom-start', 'end', 'start'],
+      description: 'Which corner of the target the cap overhangs',
+    },
+    dim: { control: 'boolean', description: 'Bound, but its surface is not on this screen' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<KeycapArgs>;
+
+const DEMO_EMAIL = 'lars@trieloff.net';
+const PLACEHOLDER = 'Ask sliccy, or describe a change…';
+
+/** The shipped keymap, as the shell would hand it to the caps. */
+const DOCK_KEYS = [
+  { id: 'files', icon: 'folder', tip: 'Files', cap: 'f' },
+  { id: 'terminal', icon: 'square-terminal', tip: 'Terminal', cap: 't' },
+  { id: 'browser', icon: 'globe', tip: 'Tabs', cap: 'b' },
+  { id: 'memory', icon: 'brain', tip: 'Memory', cap: 'm' },
+  { id: 'monitor', icon: 'activity', tip: 'Monitor', cap: 'g' },
+  { id: 'sprinkles', icon: 'sparkles', tip: 'Sprinkles', cap: 'e' },
+] as const;
+
+function keycap(
+  cap: string,
+  options: {
+    variant?: SliccKeycapVariant;
+    placement?: SliccKeycapPlacement;
+    i?: number;
+    dim?: boolean;
+    hot?: boolean;
+  } = {}
+): HTMLElement {
+  const el = document.createElement('slicc-keycap');
+  el.setAttribute('cap', cap);
+  if (options.variant) el.setAttribute('variant', options.variant);
+  if (options.placement) el.setAttribute('placement', options.placement);
+  if (options.i !== undefined) el.setAttribute('stagger', String(options.i));
+  if (options.dim) el.setAttribute('dim', '');
+  // Normally the cap sets this itself while its anchor is hovered; forced here
+  // so a still frame (and the screenshot CI, which cannot hover) can show it.
+  if (options.hot) el.setAttribute('hot', '');
+  return el;
+}
+
+/**
+ * A target that can host a cap: the cap pins to the nearest positioned
+ * ancestor, so the shell either positions the control itself or wraps it —
+ * which is exactly what this does.
+ */
+function anchored(target: HTMLElement, cap: HTMLElement | null): HTMLElement {
+  const box = document.createElement('div');
+  box.style.cssText = 'position:relative;display:inline-flex;';
+  box.append(target);
+  if (cap) box.append(cap);
+  return box;
+}
+
+function dockItem(spec: (typeof DOCK_KEYS)[number], active: boolean): HTMLElement {
+  const el = document.createElement('slicc-dock-item');
+  el.setAttribute('item-id', spec.id);
+  el.setAttribute('icon', spec.icon);
+  el.setAttribute('tip', spec.tip);
+  if (active) el.toggleAttribute('active', true);
+  return el;
+}
+
+/** The dock rail, capped — six launchers, six letters, one sweep. */
+function rail(variant: SliccKeycapVariant | undefined, capped: boolean): HTMLElement {
+  const col = document.createElement('div');
+  col.style.cssText =
+    'display:flex;flex-direction:column;gap:10px;padding:14px 12px;background:var(--desk);border-right:1px solid var(--line);';
+  DOCK_KEYS.forEach((spec, i) => {
+    col.append(
+      anchored(
+        dockItem(spec, spec.id === 'files'),
+        capped ? keycap(spec.cap, { variant, i }) : null
+      )
+    );
+  });
+  return col;
+}
+
+function tab(name: string, hue: string, active: boolean): HTMLElement {
+  const el = document.createElement('div');
+  el.textContent = name;
+  el.style.cssText = `display:flex;align-items:center;gap:6px;height:26px;padding:0 12px;border-radius:8px;font:600 12px/1 var(--ui);white-space:nowrap;color:${active ? 'var(--ink)' : 'var(--txt-2)'};background:${active ? 'var(--canvas)' : 'transparent'};border:1px solid ${active ? 'var(--line)' : 'transparent'};box-shadow:${active ? 'var(--shadow-pane)' : 'none'};`;
+  const dot = document.createElement('span');
+  dot.style.cssText = `width:6px;height:6px;border-radius:50%;background:${hue};flex:0 0 auto;`;
+  el.prepend(dot);
+  return el;
+}
+
+/**
+ * The tab strip, named ONCE rather than per segment.
+ *
+ * The digits would be the precise answer and cannot be drawn:
+ * `<slicc-agent-tabs>` clips its own track — that is how overflowing tabs hide
+ * behind the "more" button — so a cap overhanging a segment is cut in half.
+ * The arrows beside the track say the same thing better anyway: once for the
+ * strip instead of nine times, and the digits are the one binding a user
+ * already expects.
+ *
+ * One cap with TWO legends, because they are one affordance and sit adjacent
+ * on a real keyboard — which is exactly what the pair looks like here.
+ */
+function tabStrip(variant: SliccKeycapVariant | undefined, capped: boolean): HTMLElement {
+  const strip = document.createElement('div');
+  strip.style.cssText =
+    'display:flex;align-items:center;gap:8px;padding:12px 20px 10px;border-bottom:1px solid var(--line);background:var(--bg);';
+  const tabs: Array<[string, string]> = [
+    ['sliccy', 'var(--waffle)'],
+    ['reviewer', 'var(--violet)'],
+    ['scribe', 'var(--cyan)'],
+  ];
+  const track = document.createElement('div');
+  track.style.cssText = 'position:relative;display:flex;align-items:center;gap:8px;';
+  tabs.forEach(([name, hue], i) => {
+    track.append(tab(name, hue, i === 0));
+  });
+  if (capped) track.append(keycap('← →', { variant, placement: 'end', i: 0 }));
+
+  const spacer = document.createElement('div');
+  spacer.style.flex = '1';
+  strip.append(track, spacer);
+  return strip;
+}
+
+function transcript(variant: SliccKeycapVariant | undefined, capped: boolean): HTMLElement {
+  const thread = document.createElement('div');
+  thread.style.cssText =
+    'flex:1 1 auto;overflow:auto;padding:22px 24px 8px;color:var(--txt-2);font:14px/1.55 var(--ui);';
+  for (const [tone, text] of [
+    ['ink', 'Make the landing hero feel warmer.'],
+    [
+      'mute',
+      'Auditing the cold hero now, then redesigning it in a live sprinkle. I will verify the before/after in the browser and open a PR.',
+    ],
+  ] as const) {
+    const p = document.createElement('p');
+    p.textContent = text;
+    p.style.cssText = tone === 'ink' ? 'margin:0 0 12px;color:var(--ink);' : 'margin:0 0 14px;';
+    thread.append(p);
+  }
+
+  /*
+   * The copy row, deliberately UNCAPPED even in the mode — this is the shipped
+   * shape, not an omission.
+   *
+   * `y` / `Y` are bound and reachable; the transcript is just the one part of
+   * the shell that mutates on every streamed token, and keeping a cap glued to
+   * a row that moves under it would put an observer on the hot path for two of
+   * the most guessable bindings in the map. The HUD and the help sheet still
+   * name both keys.
+   */
+  const row = document.createElement('div');
+  row.style.cssText = 'display:flex;gap:10px;align-items:center;margin:4px 0 10px;';
+  for (const label of ['Copy reply', 'Copy chat']) {
+    const button = document.createElement('button');
+    button.textContent = label;
+    button.style.cssText =
+      'height:26px;padding:0 11px;border-radius:8px;border:1px solid var(--line);background:var(--canvas);color:var(--txt-2);font:500 11.5px/1 var(--ui);cursor:pointer;';
+    row.append(button);
+  }
+  thread.append(row);
+  return thread;
+}
+
+function composerBand(variant: SliccKeycapVariant | undefined, capped: boolean): HTMLElement {
+  const composer = document.createElement('slicc-composer');
+  const card = document.createElement('slicc-input-card');
+  card.setAttribute('placeholder', PLACEHOLDER);
+
+  const addWrap = anchored(
+    document.createElement('slicc-add-menu'),
+    capped ? keycap('u', { variant, placement: 'top-start', i: 0 }) : null
+  );
+  addWrap.setAttribute('slot', 'toolbar');
+
+  const spacer = document.createElement('div');
+  spacer.setAttribute('slot', 'toolbar');
+  spacer.style.flex = '1';
+
+  const send = document.createElement('slicc-send-button');
+  send.setAttribute('email', DEMO_EMAIL);
+  // `s` stops the running turn, and the send button IS the stop button while
+  // one runs — the same control, so the same cap.
+  const sendWrap = anchored(send, capped ? keycap('s', { variant, i: 1 }) : null);
+  sendWrap.setAttribute('slot', 'toolbar');
+
+  card.append(addWrap, spacer, sendWrap);
+
+  const metaRow = document.createElement('slicc-composer-meta');
+  metaRow.setAttribute('model', 'Opus 4.8');
+  metaRow.setAttribute('thinking', 'max');
+
+  /*
+   * The way back to typing, at the caret's own corner — the most important key
+   * in a mode that is the RESTING state. "How do I type again?" is the question
+   * it has to answer, and the corner of the text answers it better than a strip
+   * at the bottom of the column does.
+   *
+   * The shell anchors it to the textarea itself. Here the cap goes on a box
+   * around the card, because `<slicc-input-card>` is a shadow component and a
+   * child appended to one lands in its light DOM and is never rendered — the
+   * very reason the shell floats its caps in a layer instead of parenting them
+   * to the controls they name.
+   */
+  const band = document.createElement('div');
+  band.style.cssText = 'position:relative;display:block;';
+  band.append(card);
+  if (capped) {
+    const home = keycap('i', { variant, placement: 'top-start', i: 0 });
+    // Nudged in from the card's corner to the TEXT's corner, which is where
+    // the shell's measured anchor puts it.
+    home.style.cssText = 'top:.6em;left:1.5em;';
+    band.append(home);
+  }
+
+  composer.append(band, metaRow);
+  if (capped) composer.setAttribute('keys', '');
+  return composer;
+}
+
+/**
+ * The whole point of the affordance, so every story renders it: a shell with
+ * enough real chrome that you can judge whether a screenful of caps helps or
+ * shouts.
+ */
+function shell(options: {
+  variant?: SliccKeycapVariant;
+  capped?: boolean;
+  height?: string;
+}): HTMLElement {
+  const capped = options.capped !== false;
+  const frame = document.createElement('div');
+  frame.style.cssText = `display:flex;height:${options.height ?? '100vh'};background:var(--bg);font-family:var(--ui);overflow:hidden;`;
+
+  frame.append(rail(options.variant, capped));
+
+  const column = document.createElement('div');
+  column.style.cssText =
+    'position:relative;display:flex;flex-direction:column;flex:1 1 auto;min-width:0;';
+  column.append(tabStrip(options.variant, capped), transcript(options.variant, capped));
+  column.append(composerBand(options.variant, capped));
+
+  // The HUD the mode already ships. Both are on screen at once in the real
+  // shell, so both are on screen here: the caps say what is reachable, the
+  // strip says what was pressed.
+  if (capped) {
+    const hud = document.createElement('slicc-key-hud');
+    column.append(hud);
+  }
+
+  frame.append(column);
+  return frame;
+}
+
+/**
+ * **Chiclet** — the laptop key. A single low face with a thin lip, tilted 16°
+ * so it catches light from the same direction as the rest of the chrome, and
+ * bobbing a pixel and a half above its own shadow on a long, staggered cycle.
+ *
+ * The quietest of the three, and the one that survives a screenful: twenty of
+ * these read as a legend, not as a rash.
+ */
+export const Chiclet: Story = {
+  args: { variant: 'chiclet' },
+  render: () => shell({ variant: 'chiclet' }),
+};
+
+/**
+ * **Deck** — the mechanical key. A five-layer hard-shadow extrusion swivelled
+ * on both axes, tinted with the context accent and moulded with an inner
+ * highlight and an underlit lower lip. It lands with a punch-and-rebound and
+ * then holds still, because a lump of moulded plastic that floated would be
+ * lying about what it is.
+ *
+ * The most fun and the most expensive: it is physically taller than the
+ * controls it labels, so a dense rail starts to look like a keyboard someone
+ * spilled onto the app.
+ */
+export const Deck: Story = {
+  args: { variant: 'deck' },
+  render: () => shell({ variant: 'deck' }),
+};
+
+/**
+ * **Holo** — the HUD key. No moulding at all: a pane of tinted glass standing
+ * off the surface at 14°, backdrop-blurred, with the app's own `--rainbow`
+ * sweeping across it. Swings in edge-on and sways.
+ *
+ * The only one of the three that stays legible over a photo, a terminal or a
+ * diff — the surfaces the caps have to survive — and the only one that reads
+ * as software rather than as hardware, which cuts both ways.
+ */
+export const Holo: Story = {
+  args: { variant: 'holo' },
+  render: () => shell({ variant: 'holo' }),
+};
+
+/** The three, on the same rail, at the same moment. This is the comparison. */
+export const ThreeVariants: Story = {
+  args: {},
+  render: () => {
+    const row = document.createElement('div');
+    row.style.cssText =
+      'display:flex;gap:0;min-height:100vh;background:var(--bg);font-family:var(--ui);align-items:center;';
+    for (const variant of ['chiclet', 'deck', 'holo'] as const) {
+      const cell = document.createElement('div');
+      cell.style.cssText =
+        'flex:1;display:flex;flex-direction:column;align-items:center;gap:14px;padding:22px 10px 26px;border-right:1px solid var(--line);';
+      const title = document.createElement('div');
+      title.textContent = variant;
+      title.style.cssText =
+        'font:600 11px/1 var(--ui);letter-spacing:.08em;text-transform:uppercase;color:var(--txt-3);';
+      cell.append(title, rail(variant, true));
+      row.append(cell);
+    }
+    return row;
+  },
+};
+
+/**
+ * **Before / after.** The same shell with the mode off and on — the honest
+ * test of whether the caps are a legend or a mess.
+ */
+export const ModeOffVsOn: Story = {
+  args: { variant: 'chiclet' },
+  render: ({ variant }) => {
+    const wrap = document.createElement('div');
+    wrap.style.cssText = 'display:flex;flex-direction:column;';
+    wrap.append(shell({ variant, capped: false, height: '360px' }));
+    wrap.append(shell({ variant, capped: true, height: '360px' }));
+    return wrap;
+  },
+};
+
+/**
+ * Every corner a cap can hang off, plus `dim` — the state for a key that is
+ * bound but whose surface is not on this screen (a read-only unit's send
+ * button, a follower's tab strip). Shown faded rather than dropped, for the
+ * same reason the HUD shows an unbound press: a cap that vanishes reads as a
+ * broken keyboard.
+ */
+export const Placements: Story = {
+  args: { variant: 'chiclet' },
+  render: ({ variant, dim }) => {
+    const grid = document.createElement('div');
+    grid.style.cssText =
+      'display:grid;grid-template-columns:repeat(3,150px);gap:34px 46px;padding:52px;min-height:100vh;align-content:center;background:var(--bg);font-family:var(--ui);justify-content:center;';
+    const places: SliccKeycapPlacement[] = [
+      'top-start',
+      'top-end',
+      'bottom-start',
+      'bottom-end',
+      'start',
+      'end',
+    ];
+    places.forEach((placement, i) => {
+      const target = document.createElement('div');
+      target.textContent = placement;
+      target.style.cssText =
+        'display:grid;place-items:center;width:110px;height:44px;border-radius:10px;border:1px solid var(--line);background:var(--canvas);color:var(--txt-2);font:500 11px/1 var(--ui);';
+      const box = anchored(target, keycap('f', { variant, placement, i, dim }));
+      box.style.margin = '0 auto';
+      grid.append(box);
+    });
+    return grid;
+  },
+};
+
+/**
+ * **The press, held still.** Hovering a control presses its cap: the key
+ * travels down, its lip collapses under it — the lip going away is what sells
+ * the key bottoming out, the travel alone reads as a slide — and it rebounds
+ * with a wobble that damps out over two swings. One press per hover, not a
+ * loop: hovering asks "what does this do?", and the honest answer is the key
+ * doing what your finger is about to make it do.
+ *
+ * The cap has no hit area of its own, so what it actually watches is the
+ * ANCHOR it is pinned inside — meaning the affordance costs the host nothing.
+ * Hover the rail here to see it live; the bottom row is the mid-press frame,
+ * forced, because a screenshot cannot hover.
+ */
+export const HoverPress: Story = {
+  args: { variant: 'chiclet' },
+  render: ({ variant }) => {
+    const wrap = document.createElement('div');
+    wrap.style.cssText =
+      'display:flex;flex-direction:column;align-items:center;justify-content:center;gap:38px;min-height:100vh;padding:40px;background:var(--bg);font-family:var(--ui);';
+
+    /*
+     * Holding the bottom of the press still, from OUTSIDE the shadow root:
+     * `hot` runs the press once and it ends, by design, on the resting frame —
+     * so a forced attribute alone would show nothing. `::part(key)` is the
+     * component's own hook, and a negative delay plus a paused play state
+     * parks the animation at the 26% mark, which is the bottom of the travel.
+     */
+    const style = document.createElement('style');
+    style.textContent =
+      '.frozen slicc-keycap[hot]::part(key){animation-delay:-.11s;animation-play-state:paused;}';
+    wrap.append(style);
+
+    for (const [caption, hot] of [
+      ['hover these — the cap presses', false],
+      ['the bottom of the press, held', true],
+    ] as const) {
+      const label = document.createElement('div');
+      label.textContent = caption;
+      label.style.cssText =
+        'font:600 11px/1 var(--ui);letter-spacing:.08em;text-transform:uppercase;color:var(--txt-3);';
+
+      const row = document.createElement('div');
+      row.style.cssText = 'display:flex;gap:26px;';
+      DOCK_KEYS.forEach((spec, i) => {
+        row.append(anchored(dockItem(spec, false), keycap(spec.cap, { variant, i, hot })));
+      });
+
+      const cell = document.createElement('div');
+      cell.className = hot ? 'frozen' : '';
+      cell.style.cssText = 'display:flex;flex-direction:column;align-items:center;gap:16px;';
+      cell.append(label, row);
+      wrap.append(cell);
+    }
+    return wrap;
+  },
+};
+
+/**
+ * **Live.** Press `Escape` to enter keyboard mode and watch the sweep land;
+ * press it again to leave. Click the canvas first so it has focus.
+ *
+ * The staggered entry is the part to judge here: the caps arrive as a wave
+ * across the shell rather than as one flat pop, which is what makes twenty of
+ * them read as one gesture.
+ */
+export const Live: Story = {
+  args: { variant: 'chiclet' },
+  render: ({ variant }) => {
+    const host = document.createElement('div');
+    host.tabIndex = 0;
+    host.style.cssText = 'outline:none;';
+    let on = false;
+    const draw = (): void => {
+      host.replaceChildren(shell({ variant, capped: on }));
+      if (!on) {
+        const nudge = document.createElement('div');
+        nudge.textContent = 'Press Esc for keyboard mode';
+        nudge.style.cssText =
+          'position:absolute;left:50%;bottom:96px;transform:translateX(-50%);padding:6px 12px;border-radius:20px;background:var(--canvas);border:1px solid var(--line);color:var(--txt-2);font:600 11px/1 var(--ui);';
+        host.firstElementChild?.lastElementChild?.append(nudge);
+      }
+    };
+    host.addEventListener('keydown', (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      on = !on;
+      draw();
+    });
+    draw();
+    // Storybook renders a fresh canvas per story, so the listener dies with
+    // the node — no teardown hook needed.
+    queueMicrotask(() => host.focus());
+    return host;
+  },
+};

--- a/packages/webcomponents/src/primitives/slicc-keycap.ts
+++ b/packages/webcomponents/src/primitives/slicc-keycap.ts
@@ -1,0 +1,580 @@
+import { define } from '../internal/define.js';
+import { h, sheet } from '../internal/dom.js';
+import { hasIcon, iconEl } from '../internal/icons.js';
+import { CAP_ICONS } from '../internal/key-caps.js';
+
+/** The three looks. `chiclet` is the default — the quietest of the three. */
+const VARIANTS = ['chiclet', 'deck', 'holo'] as const;
+export type SliccKeycapVariant = (typeof VARIANTS)[number];
+const VARIANT_SET = new Set<string>(VARIANTS);
+
+/** Where the cap floats relative to the box it is pinned inside. */
+const PLACEMENTS = ['top-end', 'top-start', 'bottom-end', 'bottom-start', 'end', 'start'] as const;
+export type SliccKeycapPlacement = (typeof PLACEMENTS)[number];
+const PLACEMENT_SET = new Set<string>(PLACEMENTS);
+
+const PREFIX = 'slicc-keycap';
+
+const STYLE = `
+/*
+ * The cap floats OVER its target: it pins to the nearest positioned ancestor,
+ * which the host makes the target's own box (dock item, tab, toolbar button)
+ * or a wrapper around it. Absolute rather than anchor-positioned because a
+ * cap has to work inside the extension's shadow trees and inside Cherry's
+ * iframe, where an anchor-name on somebody else's element is not ours to set.
+ *
+ * Never a hit target: the key is the affordance, the cap only names it, and a
+ * badge that ate the click on the button it labels would be the worst
+ * possible reading of "here is another way to do this".
+ */
+:host{
+  position:absolute;
+  z-index:6;
+  display:block;
+  pointer-events:none;
+  font-family:var(--ui);
+  /* Stagger seed. The host sets --i per cap so a screenful lands as a sweep
+     rather than as one flat pop; unset is simply "first". */
+  --i:0;
+  --lag:calc(var(--i) * 26ms);
+  /* Every variant is a 3D body, so the perspective belongs on the host —
+     inside .cap it would be reset by the cap's own transform. */
+  perspective:420px;
+  perspective-origin:50% 120%;
+}
+:host([hidden]){display:none;}
+
+/*
+ * Desktop only, and enforced HERE rather than trusted to the host: a hint
+ * that names a key is a lie on a device with no keyboard, and the touch
+ * floats (iOS, the phone-width web app) mount the very same shell markup.
+ * A hover-capable fine pointer is the honest test for "there is a keyboard
+ * attached", and it is the one media query that stays true when a laptop is
+ * docked to a touchscreen.
+ */
+@media (pointer:coarse),(hover:none){
+  :host{display:none;}
+}
+
+.cap{
+  display:flex;
+  align-items:center;
+  gap:2px;
+  transform-style:preserve-3d;
+}
+
+/* One legend. Sized in ems off the host font-size so a host can shrink a
+   whole cluster with one declaration. */
+.key{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  box-sizing:border-box;
+  min-width:1.65em;
+  height:1.65em;
+  padding:0 .38em;
+  border-radius:.42em;
+  font:700 1em/1 var(--mono,ui-monospace,monospace);
+  letter-spacing:.01em;
+  white-space:nowrap;
+}
+.key svg{display:block;}
+
+:host{font-size:11px;}
+
+/* Placement. The cap overhangs its target's corner by design — a badge fully
+   inside the box would cover the icon it is labelling. */
+:host([placement='top-end']),:host(:not([placement])){top:-.55em;right:-.75em;}
+:host([placement='top-start']){top:-.55em;left:-.75em;}
+:host([placement='bottom-end']){bottom:-.55em;right:-.75em;}
+:host([placement='bottom-start']){bottom:-.55em;left:-.75em;}
+/* The side placements clear the control instead of overhanging it, so they
+   are anchored by the EDGE THEY START AT — 'left:100%' plus a gap, not a
+   fixed inset from the far edge. An inset would have to know the cap's width
+   to leave it outside the box, and it does not: a single legend cleared the
+   control, a two-legend pair (the tab strip's arrows) landed back on top of
+   the label it was meant to sit beside. */
+:host([placement='end']){top:50%;left:100%;margin-left:.5em;transform:translateY(-50%);}
+:host([placement='start']){top:50%;right:100%;margin-right:.5em;transform:translateY(-50%);}
+
+/*
+ * 'dim' is "the key is bound, the surface it drives is not here" — a read-only
+ * unit's send button, a follower's tab strip. Shown, not dropped, for the same
+ * reason the HUD shows an unbound press: a cap that vanishes reads as a broken
+ * keyboard, and a faded one reads as "not right now".
+ */
+:host([dim]) .cap{opacity:.42;filter:saturate(.35);}
+
+/* Hover, without motion. 'hot' is set while the pointer is over the cap's
+   ANCHOR (see #watchAnchor) — the cap itself has no hit area. The press is in
+   the motion block below; this is the part a reduced-motion user still gets,
+   because the point of the hover is "this control is the one this key drives"
+   and that has to survive the animation being off. */
+:host([hot]) .key{border-color:color-mix(in srgb,var(--ctx) 62%,var(--line));}
+
+/* ─── chiclet ─────────────────────────────────────────────────────────────
+   The laptop key: one low face, a thin lip, tilted back a few degrees so it
+   catches the light from the same direction as the rest of the chrome, and
+   floating a hair above its own cast shadow. */
+:host([variant='chiclet']) .key,:host(:not([variant])) .key{
+  color:var(--ink);
+  background:linear-gradient(180deg,color-mix(in srgb,var(--canvas) 92%,#fff) 0%,var(--canvas) 62%,color-mix(in srgb,var(--canvas) 88%,var(--ink)) 100%);
+  border:1px solid color-mix(in srgb,var(--ctx) 26%,var(--line));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb,#fff 70%,transparent),
+    0 1.5px 0 color-mix(in srgb,var(--ink) 16%,var(--line)),
+    0 3px 0 color-mix(in srgb,var(--ink) 8%,var(--line)),
+    0 6px 10px -4px color-mix(in srgb,var(--ink) 30%,transparent);
+  transform:rotateX(16deg);
+}
+
+/* ─── deck ────────────────────────────────────────────────────────────────
+   The mechanical key: a tall extrusion built from a stack of hard 1px
+   shadows (cheaper and crisper than four rotated wall faces, and it survives
+   a subpixel-scaled layout), swivelled on both axes so you read the depth.
+   The tinted top face is what makes it look moulded rather than drawn. */
+:host([variant='deck']) .key{
+  /* NOT --ink: the moulded face is amber in both themes, so a legend that
+     followed the theme would go near-white on amber in dark. The legend is
+     printed ON the plastic, and printed legends do not invert. */
+  color:color-mix(in srgb,var(--waffle,#b07823) 34%,#150d02);
+  background:
+    radial-gradient(120% 140% at 50% 8%,color-mix(in srgb,#fff 62%,transparent) 0%,transparent 58%),
+    linear-gradient(180deg,color-mix(in srgb,var(--ctx) 22%,var(--canvas)) 0%,color-mix(in srgb,var(--ctx) 42%,var(--canvas)) 100%);
+  border:1px solid color-mix(in srgb,var(--ctx) 55%,var(--line));
+  box-shadow:
+    inset 0 1px 1px color-mix(in srgb,#fff 75%,transparent),
+    inset 0 -2px 3px color-mix(in srgb,var(--waffle,#b07823) 30%,transparent),
+    0 1px 0 var(--kc-edge),0 2px 0 var(--kc-edge),0 3px 0 var(--kc-edge),
+    0 4px 0 var(--kc-edge),0 5px 0 var(--kc-edge-deep),
+    0 9px 14px -5px color-mix(in srgb,var(--ink) 45%,transparent);
+  transform:rotateX(20deg) rotateY(-13deg);
+}
+:host([variant='deck']){
+  --kc-edge:color-mix(in srgb,var(--ctx) 58%,var(--line));
+  --kc-edge-deep:color-mix(in srgb,var(--ink) 42%,var(--ctx));
+}
+/* A chord reads as one moulded row, so the caps lean together instead of each
+   swivelling about its own centre. */
+:host([variant='deck']) .cap{gap:3px;transform:rotateY(4deg);}
+
+/* ─── holo ────────────────────────────────────────────────────────────────
+   The HUD key: no moulding at all — a pane of tinted glass standing off the
+   surface, with the app's own rainbow sweeping across it. The one variant
+   that reads as software rather than hardware, and the only one that stays
+   legible over a photo, a terminal or a diff. */
+:host([variant='holo']) .key{
+  position:relative;
+  overflow:hidden;
+  isolation:isolate;
+  color:color-mix(in srgb,var(--ctx) 26%,var(--ink));
+  background:linear-gradient(158deg,color-mix(in srgb,var(--ctx) 24%,transparent) 0%,color-mix(in srgb,var(--ctx) 7%,transparent) 100%);
+  border:1px solid color-mix(in srgb,var(--ctx) 58%,transparent);
+  backdrop-filter:blur(9px) saturate(1.7);
+  -webkit-backdrop-filter:blur(9px) saturate(1.7);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb,#fff 55%,transparent),
+    inset 0 0 12px color-mix(in srgb,var(--ctx) 20%,transparent),
+    0 0 0 3px color-mix(in srgb,var(--ctx) 11%,transparent),
+    0 10px 22px -10px color-mix(in srgb,var(--ctx) 80%,transparent);
+  transform:rotateY(-16deg);
+}
+/* The tint behind the glass: the app's own rainbow, at a whisper. Its own
+   layer rather than a blend mode on the face, because 'overlay' over a dark
+   canvas collapses the whole ramp to one muddy hue — the dark theme is where
+   this variant has to work hardest. */
+:host([variant='holo']) .key::before{
+  content:'';
+  position:absolute;
+  inset:0;
+  z-index:-1;
+  background:var(--rainbow);
+  opacity:.14;
+  pointer-events:none;
+}
+/* The sheen: one narrow raked highlight, wider than the cap and slid across
+   it. A band, not a wash — a full-face gradient reads as a loading bar. */
+:host([variant='holo']) .key::after{
+  content:'';
+  position:absolute;
+  inset:0;
+  z-index:-1;
+  background:linear-gradient(102deg,transparent 34%,color-mix(in srgb,#fff 78%,transparent) 50%,transparent 66%);
+  background-size:260% 100%;
+  background-position:0% 0;
+  opacity:.5;
+  pointer-events:none;
+}
+
+/*
+ * Motion. Everything above is the resting frame, so a reduced-motion user
+ * gets the same three looks with none of the movement — the caps are a
+ * legend, and a legend that only makes sense once it has finished animating
+ * is not a legend.
+ */
+@media (prefers-reduced-motion:no-preference){
+  /* Entry, per variant: the chiclet drops onto the surface, the deck is
+     pushed in from above and rebounds, the glass swings in edge-on. The
+     stagger makes a screenful land as a sweep across the shell. */
+  :host([variant='chiclet']) .cap,:host(:not([variant])) .cap{
+    animation:${PREFIX}-drop .34s cubic-bezier(.2,1.5,.4,1) both var(--lag);
+  }
+  :host([variant='deck']) .cap{
+    animation:${PREFIX}-punch .42s cubic-bezier(.16,1.44,.36,1) both var(--lag);
+  }
+  :host([variant='holo']) .cap{
+    animation:${PREFIX}-swing .46s cubic-bezier(.2,1.1,.3,1) both var(--lag);
+  }
+
+  /* Idle. Only the two weightless variants keep moving; the deck is a moulded
+     lump of plastic and floating it would be a lie about what it is. */
+  :host([variant='chiclet']) .key,:host(:not([variant])) .key{
+    animation:${PREFIX}-bob 3.6s ease-in-out infinite alternate;
+    animation-delay:calc(var(--i) * -280ms);
+  }
+  :host([variant='holo']) .key{
+    animation:${PREFIX}-sway 5.2s ease-in-out infinite alternate;
+    animation-delay:calc(var(--i) * -420ms);
+  }
+  /* Held still on the resting frame while nothing sweeps, so a rail of caps
+     is not a rail of blinking lights. */
+  :host([variant='holo']) .key::after{
+    animation:${PREFIX}-sheen 3.4s ease-in-out infinite;
+    animation-delay:calc(var(--i) * 180ms);
+  }
+
+  /* Hover: one press, per variant, and ONE — not a loop. Hovering is how you
+     ask "what does this do?", and the honest answer is the key going down and
+     coming back, the same thing your finger is about to do. A cap that
+     wobbled for as long as the pointer sat on it would be answering a
+     question nobody asked twice.
+
+     These override the idle animation above rather than composing with it, so
+     the key stops bobbing for the length of the press and picks it back up
+     after — which is also why every press ENDS on the idle resting frame. */
+  :host([hot][variant='chiclet']) .key,:host([hot]:not([variant])) .key{
+    animation:${PREFIX}-press .42s cubic-bezier(.3,1.3,.5,1) both;
+  }
+  :host([hot][variant='deck']) .key{
+    animation:${PREFIX}-press-deck .38s cubic-bezier(.3,1.2,.5,1) both;
+  }
+  :host([hot][variant='holo']) .key{
+    animation:${PREFIX}-press-holo .5s ease-out both;
+  }
+  :host([hot][variant='holo']) .key::after{
+    animation:${PREFIX}-sheen .5s ease-out both;
+  }
+}
+
+@keyframes ${PREFIX}-drop{
+  from{opacity:0;transform:translate3d(0,-7px,0) scale(.82);}
+  to{opacity:1;transform:none;}
+}
+@keyframes ${PREFIX}-punch{
+  0%{opacity:0;transform:translate3d(0,-14px,0) rotateX(-34deg) scale(1.14);}
+  62%{opacity:1;transform:translate3d(0,2px,0) rotateX(6deg) scale(.97);}
+  100%{opacity:1;transform:rotateY(4deg);}
+}
+@keyframes ${PREFIX}-swing{
+  from{opacity:0;transform:rotateY(-96deg) translate3d(6px,0,0);}
+  to{opacity:1;transform:none;}
+}
+@keyframes ${PREFIX}-bob{
+  from{transform:rotateX(16deg) translateY(0);}
+  to{transform:rotateX(16deg) translateY(-1.6px);}
+}
+@keyframes ${PREFIX}-sway{
+  from{transform:rotateY(-14deg);}
+  to{transform:rotateY(-2deg) translateY(-1.4px);}
+}
+@keyframes ${PREFIX}-sheen{
+  0%,58%,100%{background-position:0% 0;opacity:0;}
+  62%{opacity:.62;}
+  92%{background-position:100% 0;opacity:0;}
+}
+
+/*
+ * The chiclet press. Down onto the surface with the lip collapsing under it
+ * (the travel alone reads as a slide, not a key — it is the lip going away
+ * that sells the key BOTTOMING OUT), then a rebound overshoot and a wobble
+ * that damps out over two swings.
+ *
+ * Every stop carries all four shadows in the same order so the list
+ * interpolates; a keyframe that dropped one would snap.
+ */
+@keyframes ${PREFIX}-press{
+  0%{
+    transform:rotateX(16deg) translateY(0) rotate(0deg);
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb,#fff 70%,transparent),
+      0 1.5px 0 color-mix(in srgb,var(--ink) 16%,var(--line)),
+      0 3px 0 color-mix(in srgb,var(--ink) 8%,var(--line)),
+      0 6px 10px -4px color-mix(in srgb,var(--ink) 30%,transparent);
+  }
+  26%{
+    transform:rotateX(23deg) translateY(3.2px) rotate(-3deg);
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb,#fff 40%,transparent),
+      0 0 0 color-mix(in srgb,var(--ink) 16%,var(--line)),
+      0 0 0 color-mix(in srgb,var(--ink) 8%,var(--line)),
+      0 2px 5px -3px color-mix(in srgb,var(--ink) 42%,transparent);
+  }
+  54%{
+    transform:rotateX(11deg) translateY(-2px) rotate(2.2deg);
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb,#fff 78%,transparent),
+      0 2.5px 0 color-mix(in srgb,var(--ink) 16%,var(--line)),
+      0 4.5px 0 color-mix(in srgb,var(--ink) 8%,var(--line)),
+      0 9px 14px -4px color-mix(in srgb,var(--ink) 26%,transparent);
+  }
+  78%{
+    transform:rotateX(17deg) translateY(.6px) rotate(-.9deg);
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb,#fff 70%,transparent),
+      0 1.5px 0 color-mix(in srgb,var(--ink) 16%,var(--line)),
+      0 3px 0 color-mix(in srgb,var(--ink) 8%,var(--line)),
+      0 6px 10px -4px color-mix(in srgb,var(--ink) 30%,transparent);
+  }
+  100%{
+    transform:rotateX(16deg) translateY(0) rotate(0deg);
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb,#fff 70%,transparent),
+      0 1.5px 0 color-mix(in srgb,var(--ink) 16%,var(--line)),
+      0 3px 0 color-mix(in srgb,var(--ink) 8%,var(--line)),
+      0 6px 10px -4px color-mix(in srgb,var(--ink) 30%,transparent);
+  }
+}
+
+/* The deck has five layers of extrusion to fall into, so its press is the
+   travel down that stack and back — no wobble, because a mechanical key on a
+   stem does not swing sideways. */
+@keyframes ${PREFIX}-press-deck{
+  0%,100%{transform:rotateX(20deg) rotateY(-13deg) translateY(0) scale(1);}
+  34%{transform:rotateX(27deg) rotateY(-13deg) translateY(4px) scale(.96);}
+  70%{transform:rotateX(18deg) rotateY(-13deg) translateY(-1.2px) scale(1.02);}
+}
+
+/* Glass has nothing to bottom out on, so it answers with light: the cap turns
+   to face you and the sheen wipes across on cue. */
+@keyframes ${PREFIX}-press-holo{
+  0%{transform:rotateY(-16deg) scale(1);}
+  40%{transform:rotateY(-2deg) scale(1.09);}
+  100%{transform:rotateY(-16deg) scale(1);}
+}
+`;
+
+const SHEET = sheet(STYLE);
+
+/** Split `"⌘ ⇧ P"` into its legends; a lone `" "` still means the space bar. */
+function legends(cap: string): string[] {
+  const trimmed = cap.trim();
+  if (trimmed === '') return cap === '' ? [] : [cap];
+  return trimmed.split(/\s+/);
+}
+
+/**
+ * `<slicc-keycap>` — the floating hint keyboard mode puts next to everything
+ * it can reach.
+ *
+ * The HUD (`<slicc-key-hud>`) answers "did that keystroke go anywhere?" after
+ * the fact, and the help sheet answers "what is there?" in a list you have to
+ * open. Neither answers the question the mode actually leaves you with, which
+ * is "what can I press *at this thing I am looking at*". A cap on the surface
+ * itself is that answer, and it is why the mode can be discovered without ever
+ * reading the sheet.
+ *
+ * Purely decorative: `aria-hidden`, no hit area. A screen reader gets the
+ * button's own accessible name and the help sheet's list; a cap read out per
+ * control would turn every rail into a spelling bee.
+ *
+ * The host pins it by making the target's box the positioned ancestor (or
+ * wrapping the target in one) and setting `--i` through `stagger` so a
+ * screenful of caps lands as a sweep rather than a flat pop.
+ *
+ * @attr cap - the legend(s); space-separated for a chord (`"⌘ ⇧ P"`)
+ * @attr variant - `chiclet` (default) | `deck` | `holo`
+ * @attr placement - which corner it overhangs (default `top-end`)
+ * @attr dim - the key is bound but its surface is unavailable here
+ * @attr hot - the anchor is hovered; set by the cap itself, and settable by
+ *             a host or a story that needs the pressed frame to hold still
+ * @attr stagger - position in the sweep; sets the `--i` animation seed
+ * @csspart cap - the row of legends
+ * @csspart key - one legend
+ */
+export class SliccKeycap extends HTMLElement {
+  static readonly observedAttributes = ['cap', 'variant', 'placement', 'stagger'];
+
+  readonly #root: ShadowRoot;
+
+  /**
+   * The box the cap is pinned inside — its anchor, and the thing whose hover
+   * the cap answers. Held so the listeners can come off the SAME node they
+   * went on: the dock-tree moves surfaces rather than cloning them, so by the
+   * time we are disconnected `parentElement` may already be somebody else.
+   */
+  #anchor: HTMLElement | null = null;
+
+  /**
+   * An anchor named by the host, overriding `parentElement`.
+   *
+   * Set when the cap cannot BE a child of the control it labels — a shadow
+   * component whose default slot means something else, or one whose parent
+   * clips. There the shell floats the cap in a layer of its own and points it
+   * at the real control, so the hover still belongs to the thing the key
+   * drives rather than to the ghost box the cap happens to sit in.
+   */
+  #pinned: HTMLElement | null = null;
+
+  readonly #onEnter = (): void => {
+    this.toggleAttribute('hot', true);
+  };
+  readonly #onLeave = (): void => {
+    this.toggleAttribute('hot', false);
+  };
+
+  constructor() {
+    super();
+    this.#root = this.attachShadow({ mode: 'open' });
+    this.#root.adoptedStyleSheets = [SHEET];
+  }
+
+  connectedCallback(): void {
+    // Decoration, and the one thing the mode must not do is narrate itself.
+    if (!this.hasAttribute('aria-hidden')) this.setAttribute('aria-hidden', 'true');
+    this.#render();
+    this.#watchAnchor();
+  }
+
+  disconnectedCallback(): void {
+    this.#unwatchAnchor();
+    // A node yanked out from under the pointer never gets its `pointerleave`,
+    // so a cap that came back would come back mid-press.
+    this.removeAttribute('hot');
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this.#render();
+  }
+
+  /**
+   * Follow the anchor's hover.
+   *
+   * The cap cannot answer its own `:hover` — it is `pointer-events: none`, and
+   * that is not negotiable (a badge that ate the click on the button it labels
+   * would be the worst possible reading of the feature). Nor can the sheet ask
+   * whether an ancestor is hovered: `:host-context(:hover)` matches when ANY
+   * ancestor is, and `body` is hovered whenever the pointer is in the window,
+   * so it is true essentially always.
+   *
+   * So the cap watches the box it is pinned inside, which is the control (or
+   * the wrapper around it) by the host contract — meaning the affordance
+   * arrives with no wiring at the host at all.
+   */
+  #watchAnchor(): void {
+    const anchor = this.#pinned ?? this.parentElement;
+    if (!anchor || anchor === this.#anchor) return;
+    this.#unwatchAnchor();
+    this.#anchor = anchor;
+    // `pointerenter`/`leave` rather than `over`/`out`: they do not bubble, so
+    // moving between the control's own children is not a run of key presses.
+    anchor.addEventListener('pointerenter', this.#onEnter);
+    anchor.addEventListener('pointerleave', this.#onLeave);
+  }
+
+  #unwatchAnchor(): void {
+    this.#anchor?.removeEventListener('pointerenter', this.#onEnter);
+    this.#anchor?.removeEventListener('pointerleave', this.#onLeave);
+    this.#anchor = null;
+  }
+
+  /** The legend(s), reflected to the `cap` attribute. */
+  get cap(): string {
+    return this.getAttribute('cap') ?? '';
+  }
+
+  set cap(value: string) {
+    this.setAttribute('cap', value);
+  }
+
+  /** The look, reflected to `variant`. Unknown values fall back to `chiclet`. */
+  get variant(): SliccKeycapVariant {
+    const value = this.getAttribute('variant');
+    return value && VARIANT_SET.has(value) ? (value as SliccKeycapVariant) : 'chiclet';
+  }
+
+  set variant(value: SliccKeycapVariant) {
+    this.setAttribute('variant', value);
+  }
+
+  /** Which corner the cap overhangs, reflected to `placement`. */
+  get placement(): SliccKeycapPlacement {
+    const value = this.getAttribute('placement');
+    return value && PLACEMENT_SET.has(value) ? (value as SliccKeycapPlacement) : 'top-end';
+  }
+
+  set placement(value: SliccKeycapPlacement) {
+    this.setAttribute('placement', value);
+  }
+
+  /** Bound, but not reachable on this screen — drawn faded rather than dropped. */
+  get dim(): boolean {
+    return this.hasAttribute('dim');
+  }
+
+  set dim(value: boolean) {
+    this.toggleAttribute('dim', value);
+  }
+
+  /**
+   * The element whose hover this cap answers. Defaults to `parentElement` —
+   * the zero-wiring case, where the cap simply lives inside the control it
+   * labels.
+   *
+   * A host sets it when the cap cannot be a child of that control: a shadow
+   * component whose default slot already means something (`<slicc-icon-button>`
+   * replaces its glyph), or one inside a container that clips. The shell then
+   * floats the cap over a measured ghost of the control and points it here, so
+   * the press still belongs to the thing the key actually drives.
+   *
+   * A property rather than an attribute: it is an element reference, and one
+   * that a document-order attribute selector could not name anyway.
+   */
+  get anchor(): HTMLElement | null {
+    return this.#pinned;
+  }
+
+  set anchor(value: HTMLElement | null) {
+    if (value === this.#pinned) return;
+    this.#pinned = value;
+    // Live re-point: the shell re-resolves its targets whenever the chrome
+    // rebuilds, and the cap has to follow the new node, not the dead one.
+    this.#unwatchAnchor();
+    this.removeAttribute('hot');
+    if (this.isConnected) this.#watchAnchor();
+  }
+
+  #render(): void {
+    // The seed lives in an inline custom property rather than in the sheet:
+    // one shared constructable stylesheet cannot carry a per-instance value.
+    const stagger = Number.parseInt(this.getAttribute('stagger') ?? '', 10);
+    this.style.setProperty('--i', String(Number.isFinite(stagger) ? stagger : 0));
+
+    const row = h('span', { class: 'cap', part: 'cap' });
+    for (const legend of legends(this.cap)) {
+      const key = h('kbd', { class: 'key', part: 'key' });
+      const icon = CAP_ICONS[legend];
+      if (icon && hasIcon(icon)) key.append(iconEl(icon, { size: 12, strokeWidth: 2.4 }));
+      else key.textContent = legend;
+      row.append(key);
+    }
+    this.#root.replaceChildren(row);
+  }
+}
+
+define('slicc-keycap', SliccKeycap);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'slicc-keycap': SliccKeycap;
+  }
+}

--- a/packages/webcomponents/src/register.ts
+++ b/packages/webcomponents/src/register.ts
@@ -48,6 +48,7 @@ import './primitives/slicc-follower-hud.js';
 import './primitives/slicc-googly-eyes.js';
 import './primitives/slicc-icon-button.js';
 import './primitives/slicc-image-preview.js';
+import './primitives/slicc-keycap.js';
 import './primitives/slicc-pane.js';
 import './primitives/slicc-press-button.js';
 import './primitives/slicc-send-button.js';

--- a/packages/webcomponents/tests/primitives/slicc-keycap.test.ts
+++ b/packages/webcomponents/tests/primitives/slicc-keycap.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SliccKeycap } from '../../src/primitives/slicc-keycap.js';
+import { ensureGlobalTokens } from '../../src/theme/tokens.js';
+
+function makeKeycap(cap: string): SliccKeycap {
+  const el = document.createElement('slicc-keycap') as SliccKeycap;
+  el.cap = cap;
+  return el;
+}
+
+function keys(el: SliccKeycap): HTMLElement[] {
+  return [...(el.shadowRoot?.querySelectorAll('.key') ?? [])] as HTMLElement[];
+}
+
+describe('slicc-keycap', () => {
+  beforeEach(() => {
+    ensureGlobalTokens();
+    document.body.replaceChildren();
+  });
+
+  it('registers the custom element', () => {
+    expect(customElements.get('slicc-keycap')).toBe(SliccKeycap);
+  });
+
+  it('renders one legend per cap with the cap/key parts', () => {
+    const el = makeKeycap('f');
+    document.body.appendChild(el);
+    expect(el.shadowRoot?.querySelector('.cap')?.getAttribute('part')).toBe('cap');
+    const [key] = keys(el);
+    expect(key?.getAttribute('part')).toBe('key');
+    expect(key?.tagName).toBe('KBD');
+    expect(key?.textContent).toBe('f');
+  });
+
+  it('splits a chord on whitespace, modifiers first', () => {
+    const el = makeKeycap('⌘ ⇧ P');
+    document.body.appendChild(el);
+    expect(keys(el).map((k) => k.textContent)).toEqual(['⌘', '⇧', 'P']);
+  });
+
+  /**
+   * A key that is a SHAPE draws as the lucide glyph, not the character — at
+   * 11px a font's idea of `⏎` is a smudge. The glyph is the whole reason the
+   * cap table is shared with the HUD.
+   */
+  it('draws a shape key as a glyph rather than as text', () => {
+    const el = makeKeycap('⏎');
+    document.body.appendChild(el);
+    const [key] = keys(el);
+    expect(key?.querySelector('svg')).not.toBeNull();
+    expect(key?.textContent).toBe('');
+  });
+
+  it('leaves a modifier character as text', () => {
+    const el = makeKeycap('⌘');
+    document.body.appendChild(el);
+    const [key] = keys(el);
+    expect(key?.querySelector('svg')).toBeNull();
+    expect(key?.textContent).toBe('⌘');
+  });
+
+  it('reflects variant and placement, normalizing unknown values', () => {
+    const el = makeKeycap('f');
+    document.body.appendChild(el);
+    expect(el.variant).toBe('chiclet');
+    expect(el.placement).toBe('top-end');
+
+    el.variant = 'deck';
+    expect(el.getAttribute('variant')).toBe('deck');
+    el.setAttribute('variant', 'brutalist');
+    expect(el.variant).toBe('chiclet');
+
+    el.placement = 'bottom-start';
+    expect(el.getAttribute('placement')).toBe('bottom-start');
+    el.setAttribute('placement', 'sideways');
+    expect(el.placement).toBe('top-end');
+  });
+
+  it('reflects dim as a boolean attribute', () => {
+    const el = makeKeycap('f');
+    document.body.appendChild(el);
+    expect(el.dim).toBe(false);
+    el.dim = true;
+    expect(el.hasAttribute('dim')).toBe(true);
+    el.dim = false;
+    expect(el.hasAttribute('dim')).toBe(false);
+  });
+
+  /**
+   * The stagger seed cannot live in the shared constructable stylesheet — one
+   * sheet, every instance — so it is written inline per cap.
+   */
+  it('writes the stagger seed to --i, defaulting to 0', () => {
+    const el = makeKeycap('f');
+    document.body.appendChild(el);
+    expect(el.style.getPropertyValue('--i')).toBe('0');
+    el.setAttribute('stagger', '4');
+    expect(el.style.getPropertyValue('--i')).toBe('4');
+    el.setAttribute('stagger', 'later');
+    expect(el.style.getPropertyValue('--i')).toBe('0');
+  });
+
+  /** Decoration: the button's own name and the help sheet are the a11y path. */
+  it('is hidden from assistive technology and never a hit target', () => {
+    const el = makeKeycap('f');
+    document.body.appendChild(el);
+    expect(el.getAttribute('aria-hidden')).toBe('true');
+    expect(getComputedStyle(el).pointerEvents).toBe('none');
+  });
+
+  it('positions itself against the nearest positioned ancestor', () => {
+    const box = document.createElement('div');
+    box.style.cssText = 'position:relative;width:120px;height:40px;';
+    const el = makeKeycap('f');
+    box.append(el);
+    document.body.appendChild(box);
+    expect(getComputedStyle(el).position).toBe('absolute');
+    // Overhangs the corner: the cap's right edge is past the box's.
+    expect(el.getBoundingClientRect().right).toBeGreaterThan(box.getBoundingClientRect().right);
+  });
+
+  it('re-renders when the cap changes', () => {
+    const el = makeKeycap('f');
+    document.body.appendChild(el);
+    el.cap = 'j';
+    expect(keys(el).map((k) => k.textContent)).toEqual(['j']);
+  });
+
+  /**
+   * The cap cannot answer its own `:hover` (no hit area) and cannot ask the
+   * sheet whether an ancestor is hovered (`:host-context(:hover)` is true
+   * whenever the pointer is in the window, via `body`). So it watches the box
+   * it is pinned inside — which means the press arrives with no host wiring.
+   */
+  describe('anchor hover', () => {
+    function mount(): { anchor: HTMLElement; el: SliccKeycap } {
+      const anchor = document.createElement('div');
+      anchor.style.cssText = 'position:relative;width:120px;height:40px;';
+      const el = makeKeycap('f');
+      anchor.append(el);
+      document.body.appendChild(anchor);
+      return { anchor, el };
+    }
+
+    it('goes hot while the pointer is over its anchor', () => {
+      const { anchor, el } = mount();
+      expect(el.hasAttribute('hot')).toBe(false);
+      anchor.dispatchEvent(new PointerEvent('pointerenter'));
+      expect(el.hasAttribute('hot')).toBe(true);
+      anchor.dispatchEvent(new PointerEvent('pointerleave'));
+      expect(el.hasAttribute('hot')).toBe(false);
+    });
+
+    /**
+     * `pointerenter` does not bubble, so crossing between the control's own
+     * children cannot re-fire it — one hover is one press, not a run of them.
+     */
+    it('does not re-press when the pointer crosses the anchor’s children', () => {
+      const { anchor, el } = mount();
+      const child = document.createElement('span');
+      anchor.append(child);
+      anchor.dispatchEvent(new PointerEvent('pointerenter'));
+      child.dispatchEvent(new PointerEvent('pointerenter', { bubbles: false }));
+      expect(el.hasAttribute('hot')).toBe(true);
+    });
+
+    /** A node yanked out mid-hover never gets its `pointerleave`. */
+    it('drops hot and unbinds when it is detached', () => {
+      const { anchor, el } = mount();
+      anchor.dispatchEvent(new PointerEvent('pointerenter'));
+      expect(el.hasAttribute('hot')).toBe(true);
+
+      el.remove();
+      expect(el.hasAttribute('hot')).toBe(false);
+      // The old anchor is no longer wired to it.
+      anchor.dispatchEvent(new PointerEvent('pointerenter'));
+      expect(el.hasAttribute('hot')).toBe(false);
+    });
+
+    /**
+     * A host that cannot make the cap a child of the control it names — a
+     * shadow component whose default slot means something else, or one inside
+     * a clipping parent — floats the cap elsewhere and points it at the real
+     * control instead. The press has to follow the pointer THERE, not to the
+     * box the cap happens to sit in.
+     */
+    it('follows an explicit anchor instead of its parent', () => {
+      const { anchor, el } = mount();
+      const real = document.createElement('button');
+      document.body.append(real);
+      el.anchor = real;
+      expect(el.anchor).toBe(real);
+
+      real.dispatchEvent(new PointerEvent('pointerenter'));
+      expect(el.hasAttribute('hot')).toBe(true);
+      real.dispatchEvent(new PointerEvent('pointerleave'));
+      expect(el.hasAttribute('hot')).toBe(false);
+
+      // And the parent it is sitting in is no longer the one that presses it.
+      anchor.dispatchEvent(new PointerEvent('pointerenter'));
+      expect(el.hasAttribute('hot')).toBe(false);
+    });
+
+    /** The shell re-resolves its targets whenever the chrome rebuilds. */
+    it('re-points a live anchor, dropping the press with the old one', () => {
+      const { el } = mount();
+      const first = document.createElement('button');
+      const second = document.createElement('button');
+      document.body.append(first, second);
+
+      el.anchor = first;
+      first.dispatchEvent(new PointerEvent('pointerenter'));
+      expect(el.hasAttribute('hot')).toBe(true);
+
+      // Re-pointed mid-hover: the old node will never send its `pointerleave`.
+      el.anchor = second;
+      expect(el.hasAttribute('hot')).toBe(false);
+      first.dispatchEvent(new PointerEvent('pointerenter'));
+      expect(el.hasAttribute('hot')).toBe(false);
+      second.dispatchEvent(new PointerEvent('pointerenter'));
+      expect(el.hasAttribute('hot')).toBe(true);
+    });
+
+    it('re-pointing to the same anchor is a no-op', () => {
+      const { el } = mount();
+      const real = document.createElement('button');
+      document.body.append(real);
+      el.anchor = real;
+      real.dispatchEvent(new PointerEvent('pointerenter'));
+
+      el.anchor = real;
+      expect(el.hasAttribute('hot')).toBe(true);
+    });
+
+    it('falls back to the parent when an explicit anchor is cleared', () => {
+      const { anchor, el } = mount();
+      const real = document.createElement('button');
+      document.body.append(real);
+      el.anchor = real;
+      el.anchor = null;
+
+      expect(el.anchor).toBeNull();
+      anchor.dispatchEvent(new PointerEvent('pointerenter'));
+      expect(el.hasAttribute('hot')).toBe(true);
+    });
+
+    /** The dock-tree MOVES surfaces rather than cloning them. */
+    it('re-binds to its new anchor after a move', () => {
+      const { anchor, el } = mount();
+      const next = document.createElement('div');
+      next.style.cssText = 'position:relative;width:120px;height:40px;';
+      document.body.appendChild(next);
+
+      next.append(el);
+      next.dispatchEvent(new PointerEvent('pointerenter'));
+      expect(el.hasAttribute('hot')).toBe(true);
+
+      next.dispatchEvent(new PointerEvent('pointerleave'));
+      anchor.dispatchEvent(new PointerEvent('pointerenter'));
+      expect(el.hasAttribute('hot')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Keyboard mode gains a floating key cap on every control it can reach, and its help sheet
becomes a personalised cheat sheet instead of one long list.

Before: the mode could tell you what you pressed (the HUD) and what exists (a 31-row
alphabetical sheet), but never what you can press *at the thing you are looking at*.
Now: `f` sits on the folder icon, `i` at the corner of the composer's text, `← →` beside
the tab strip — and the sheet leads with the shortcuts for whatever you have been clicking.

## Why

`f` opening the file rail is unguessable from a folder icon. That is the question the mode
actually leaves you with, and it decides whether the mode is ever discovered at all — the
HUD answers it after the fact, and the help sheet answers it in a list you have to open and
remember.

## Approach / Implementation notes

**`<slicc-keycap>`** (`packages/webcomponents/src/primitives/`) — `aria-hidden`,
`pointer-events: none`, self-gated to a fine hover-capable pointer (desktop only; a hint
naming a key is a lie on a device with no keyboard, and the touch floats mount the same
shell markup). Three CSS-3D variants; `chiclet` ships. Hovering the control presses its
cap once — not a loop, because hovering asks "what does this do?" and the answer is the key
doing what your finger is about to make it do.

The cap cannot see its own `:hover` (no hit area) and the sheet cannot ask whether an
ancestor is hovered — `:host-context(:hover)` matches whenever the pointer is anywhere in
the window, via `body`. So it watches the box it is pinned inside, which means the press
costs a host no wiring.

**Caps float in a layer** (`wc-shortcut-caps.ts`) rather than living inside the controls.
Every control worth capping is a shadow component: an appended child replaces
`<slicc-icon-button>`'s glyph and `<slicc-dock>` discards it on the next `replaceChildren`.
Wrapping is worse — moving a *slotted* composer toolbar button into a wrapper unassigns it
from its slot and it stops rendering entirely. So each cap sits on a measured ghost of its
control in one fixed click-through layer, with `keycap.anchor` pointing the hover press back
at the real control. Nobody's DOM is touched and a re-render cannot break a cap.

Which corner a cap hangs off is **measured, not written down**: the dock rail is flush with
the window edge, so a fixed corner hangs its caps off the screen — and which edge the rail
is on is a layout choice (`panelizeShell` can put it in any zone).

**Deliberately not capped.** The transcript (`y`, `Y`, `a`): it is the one subtree that
mutates on every streamed token, and gluing a cap to a moving row would put an observer on
the hot path for two of the most guessable bindings in the map. The tab strip's *digits*:
`<slicc-agent-tabs>` clips its own track (how overflowing tabs hide behind the "more"
button), so a cap overhanging a segment is cut in half — the two arrows beside the track say
"this strip moves" once instead of nine times. The model/thinking pills: inside
`<slicc-composer-meta>`'s shadow root, where `::part` can style a part but not add a child.

**Help sheet.** Sections come from a new `Command.group` — the groups `DEFAULT_KEYMAP`'s
comments have named all along — so a rebind never reshuffles the sheet. One, two or three
columns by viewport.

**Personalisation** (`wc-shortcut-usage.ts`) counts what you do this session off the
*surfaces'* own events, so a click counts exactly as much as the key. That is the point: a
list of the shortcuts you already use is worthless, and the useful sheet says "you opened
Files seven times — press `f`". Keyboard mode's doctrine makes it cheap, since every command
already reaches its surface through the event a click produces. Session-scoped and
unpersisted — "since you started" is the honest window, and a record of every panel you open
is not something to write to disk for a cheat sheet.

## Cross-cutting impact

- **Floats**: the caps and the usage log are supplied by `wireShellKeyboard`, so any float
  that wires the WC shell gets them. Both deps are optional on `ShortcutDeps` — a float that
  passes neither keeps the HUD and the reference sheet exactly as before.
- **Layering**: `wc-shortcuts.ts` stays markup-ignorant. The DOM lookups live in
  `wc-shortcut-surfaces.ts` / `wc-shortcut-caps.ts`, as that file already insists. The one
  fact the caps need from the command table — which rail item a letter opens — is now
  `commandSurfaceId()` rather than a second copy of the dock ids that could drift.
- **Persisted state**: none. The usage log is in-memory and dies with the session.
- **Async lifecycle**: the caps layer holds a `ResizeObserver`, a `MutationObserver` (on the
  rail and the input card — never the transcript), and window `resize` / `scroll`, all
  released on `hide()`; the usage log removes its two document listeners on `dispose()`.
  Both are torn down by the mode's own `dispose`.
- **Bundle size**: `npm run bundle-size` and the first-load delta gate both pass.
- **Security**: no `innerHTML`; caps are `aria-hidden` decoration with no hit area.

## Test plan

- [x] `npm run verify` — exit 0 (the pre-push hook's 8 checks also pass)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs`
- [x] `npm run typecheck`
- [x] `npm run test` — 20,065 passing
- [x] `npm run test -w @slicc/webcomponents` — 2,253 passing
- [x] `npm run test:coverage` — webapp and webcomponents floors pass
- [x] `npm run build` / `npm run build -w @slicc/chrome-extension` / `npm run bundle-size`
- [x] **New behavior covered by unit tests**: `wc-shortcut-caps.test.ts` (20),
      `wc-shortcut-usage.test.ts` (9), `slicc-keycap.test.ts` (19), plus 6 new help-sheet
      tests in `wc-shortcuts.test.ts`
- [x] **Manual smoke (CLI)**: isolated harness on `:5715` over CDP. Verified all 9 caps
      anchored and on screen; mode off when the composer takes focus (layer removed) and
      back on `Esc`; `f` still opens the files panel and every cap tracked the reflow; no
      switcher cap with one unit; help sheet at 700 / 1000 / 1400 px → 1 / 2 / 3 columns,
      with `f ×2` from *clicking* the rail and `? ×1` from the keyboard. Console clean.
- [ ] Manual smoke (extension) — not run; the extension mounts the same shell and both deps
      are optional, but a reviewer with the unpacked build should confirm.

**Screenshots**: Storybook PR screenshots run automatically for the `packages/webcomponents/**`
change (`Primitives/Keycap` — three variants, hover press, placements, before/after).

**Pre-existing failures** (verified against `origin/main`, unrelated):

- `packages/dev-tools/tools/check-touched-exemptions.test.mjs` › "passes when the changed
  file is NOT on the float-probe debt list" — fails identically on `origin/main`.
- `packages/chrome-extension/tests/service-worker-mount-sign-and-forward-port.test.ts` —
  flaky under the full coverage run, passes on repeated isolated runs. No
  `chrome-extension` file is touched by this PR.
- `slicc-input-card` › "switches the border to the violet token on focus-within" — a
  focus-dependent browser test that fails whenever another window steals OS focus.

## Documentation

- [x] `packages/webcomponents/CLAUDE.md` — the `<slicc-keycap>` host contract
- [x] `packages/webapp/CLAUDE.md` — where the caps and the usage log are wired, and what is
      deliberately not capped

## Review

This is a UI change — **please do not enqueue it on my behalf.** It is mergeable and green;
it is waiting on visual sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
