### PR TITLE
fix(webapp): read VFS-picked image bytes as binary, not utf-8

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -472,6 +472,35 @@ All paths in VirtualFS must follow these rules:
 
 **Normalization**: Use `normalizePath(path)` from `packages/webapp/src/fs/path-utils.ts` before any VFS operation.
 
+## `readFile` Defaults to utf-8 — Binary Callers Must Ask
+
+**Files**: `packages/webapp/src/fs/virtual-fs.ts` (`readFile`),
+`packages/webapp/src/kernel/local-vfs-client.ts`,
+`packages/webapp/src/ui/wc/wc-attach.ts`.
+
+`VirtualFS.readFile(path)` with no options returns a **`string`**: the encoding
+defaults to `'utf-8'` and the bytes go through a non-fatal `TextDecoder`, so
+every byte that is not valid UTF-8 collapses to U+FFFD. Nothing throws. Bytes
+you need as bytes must ask for them:
+
+```ts
+const bytes = (await fs.readFile(path, { encoding: 'binary' })) as Uint8Array;
+```
+
+`LocalVfsClient.readFile` declares `Promise<string | Uint8Array>` and the
+`encoding` option is what discriminates the two, so a caller that omits it and
+then narrows with `typeof raw === 'string'` compiles fine and is wrong at
+runtime — the string branch is the one production takes.
+
+**Never re-encode the decoded string.** `new TextEncoder().encode(raw)` does not
+undo the decode; it bakes it in. The composer's VFS image pick did exactly this
+and handed vision a JPEG whose `FF D8 FF` magic had become `EF BF BD …`, 9 bytes
+grown to 21 (#2884). It was silent: the chip rendered, the `path` still pointed
+at the good file on disk, and only the model saw the mojibake.
+
+If a reader answers a binary read with a string anyway, the bytes are already
+gone. Log and degrade to a path-only reference — do not inline the round-trip.
+
 ## Stat Identity: A File Is Not Its Path
 
 **Files**: `packages/webapp/src/fs/types.ts` (`Stats.ino`),

--- a/packages/webapp/src/ui/wc/wc-attach.ts
+++ b/packages/webapp/src/ui/wc/wc-attach.ts
@@ -705,30 +705,68 @@ async function persistStagedUpload(
   return { ...attachment, error: 'could not be saved to the virtual filesystem' };
 }
 
-/** Stage a VFS file pick by reference — the pick already HAS a canonical path,
- *  so link it directly instead of reading + inlining its contents. */
-async function stageVfsFile(
+/**
+ * RAW bytes of a VFS image, for the inline vision copy.
+ *
+ * The read MUST pass `encoding: 'binary'`. `VirtualFS.readFile` defaults to
+ * `'utf-8'` and runs the file through a non-fatal `TextDecoder`, so every byte
+ * that isn't valid UTF-8 collapses to U+FFFD; re-encoding that string handed
+ * the model a JPEG whose `FF D8 FF` magic had become `EF BF BD …` (#2884).
+ *
+ * A reader that answers a binary read with a string has ALREADY lost the
+ * bytes. There is no recovering them, so log and return `null` — the caller
+ * falls back to a path-only reference instead of inlining mojibake.
+ */
+async function readVfsImageBytes(
   id: string,
   openReader: () => Promise<LocalVfsClient>,
-  stage: WcAttachmentStage
-) {
-  const name = id.split('/').pop() ?? id;
-  if (IMAGE_EXT.test(name)) {
-    // Images keep an inline copy for vision alongside the existing path.
-    const reader = await openReader();
-    const raw = await reader.readFile(id);
-    const bytes = typeof raw === 'string' ? new TextEncoder().encode(raw) : raw;
-    const attachment = attachmentFromBytes(name, bytes);
-    stage.add({ ...attachment, error: undefined, path: id });
-    return;
-  }
+  log: WireWcAttachDeps['log']
+): Promise<Uint8Array | null> {
+  const reader = await openReader();
+  const raw = await reader.readFile(id, { encoding: 'binary' });
+  if (typeof raw !== 'string') return raw;
+  log.error('VFS image pick returned text, not bytes — skipping the inline copy', id);
+  return null;
+}
+
+/** Path-only attachment for a VFS pick: no inline content, `stat` for the
+ *  size so the chip and the prompt line read right. */
+async function referenceVfsFile(
+  id: string,
+  name: string,
+  openReader: () => Promise<LocalVfsClient>
+): Promise<MessageAttachment> {
   let size = 0;
   try {
     size = (await (await openReader()).stat(id)).size;
   } catch {
     // Stat failure leaves size at 0 — the reference line still renders.
   }
-  stage.add({ id: uid(), name, mimeType: mimeFor(name), size, kind: 'file', path: id });
+  return { id: uid(), name, mimeType: mimeFor(name), size, kind: 'file', path: id };
+}
+
+/** Stage a VFS file pick by reference — the pick already HAS a canonical path,
+ *  so link it directly instead of reading + inlining its contents. Images are
+ *  the one exception: they also carry an inline base64 copy for vision. */
+async function stageVfsFile(
+  id: string,
+  openReader: () => Promise<LocalVfsClient>,
+  stage: WcAttachmentStage,
+  log: WireWcAttachDeps['log']
+) {
+  const name = id.split('/').pop() ?? id;
+  if (IMAGE_EXT.test(name)) {
+    // Images keep an inline copy for vision alongside the existing path.
+    const bytes = await readVfsImageBytes(id, openReader, log);
+    if (bytes) {
+      const attachment = attachmentFromBytes(name, bytes);
+      stage.add({ ...attachment, error: undefined, path: id });
+      return;
+    }
+    // No bytes to inline: the file on disk is still good, so keep the path
+    // reference (the agent can `read` it) rather than staging garbage.
+  }
+  stage.add(await referenceVfsFile(id, name, openReader));
 }
 
 /** Append a skill mention to the composer's draft. */
@@ -757,7 +795,7 @@ async function handleAdd(
     await stageCapture(detail, deps, stage);
   } else if (detail.kind === 'file' && typeof detail.id === 'string' && deps.openReader) {
     // VFS file picks only exist when the float has a reader (leader, not follower).
-    await stageVfsFile(detail.id, deps.openReader, stage);
+    await stageVfsFile(detail.id, deps.openReader, stage, deps.log);
   } else if (detail.kind === 'skill' && typeof detail.label === 'string') {
     insertSkillMention(detail.label, deps.inputCard);
   } else if (detail.kind === 'conversation' && typeof detail.id === 'string') {

--- a/packages/webapp/tests/ui/wc/wc-attach.test.ts
+++ b/packages/webapp/tests/ui/wc/wc-attach.test.ts
@@ -446,6 +446,70 @@ describe('wireWcAttach action routing', () => {
     expect(item.path).toBe('/workspace/notes.md');
   });
 
+  // Two probes that a utf-8 hop cannot survive: the full 0x00..0xFF ramp
+  // (128 invalid single bytes) and the JPEG SOI from #2818. `TextDecoder`
+  // (non-fatal) folds each high byte to U+FFFD and `TextEncoder` re-expands it
+  // to `EF BF BD`, so both the bytes AND the length change (#2884).
+  const BYTE_RAMP = new Uint8Array(256).map((_, i) => i);
+  const JPEG_SOI = new Uint8Array([0xff, 0xd8, 0xff, 0x98, 0x00, 0x41, 0x7f, 0x80, 0xfe]);
+
+  it.each<[string, Uint8Array]>([
+    ['ramp.png', BYTE_RAMP],
+    ['probe.jpg', JPEG_SOI],
+  ])('inlines VFS-picked %s byte-for-byte for vision', async (name, bytes) => {
+    const { fs, inputCard, stage } = await setup();
+    await fs.writeFile(`/shared/${name}`, bytes);
+    emitAdd(inputCard, { kind: 'file', id: `/shared/${name}`, label: name });
+    await vi.waitFor(() => {
+      expect(stage.items.map((a) => a.name)).toEqual([name]);
+    });
+    const item = stage.items[0];
+    expect(item.kind).toBe('image');
+    // The path still points at the good file — the inline copy must agree.
+    expect(item.path).toBe(`/shared/${name}`);
+    expect(item.error).toBeUndefined();
+    expect(item.size).toBe(bytes.length);
+    expect(Array.from(atob(item.data as string), (c) => c.charCodeAt(0))).toEqual(
+      Array.from(bytes)
+    );
+  });
+
+  it('keeps a VFS image path-only (and logs) when the reader hands back text', async () => {
+    // A reader that ignores `encoding:'binary'` has already destroyed the
+    // bytes; re-encoding its string would ship EF BF BD to vision. Fail loud.
+    const fs = await seededFs();
+    await fs.writeFile('/shared/probe.png', JPEG_SOI);
+    const errLog = vi.fn();
+    const inputCard = document.createElement('slicc-input-card');
+    const freezer = document.createElement('slicc-freezer');
+    document.body.append(inputCard, freezer);
+    const stage = wireWcAttach({
+      inputCard,
+      freezer,
+      openReader: async () => ({
+        readDir: (path: string) => fs.readDir(path),
+        stat: (path: string) => fs.stat(path),
+        readFile: async () => new TextDecoder().decode(JPEG_SOI),
+      }),
+      listConversations: async () => [],
+      log: { error: errLog },
+    });
+    inputCard.dispatchEvent(
+      new CustomEvent('slicc-add', {
+        bubbles: true,
+        detail: { kind: 'file', id: '/shared/probe.png', label: 'probe.png' },
+      })
+    );
+    await vi.waitFor(() => {
+      expect(stage.items).toHaveLength(1);
+    });
+    const item = stage.items[0];
+    expect(item.data).toBeUndefined();
+    expect(item.path).toBe('/shared/probe.png');
+    expect(item.size).toBe(JPEG_SOI.length);
+    expect(errLog).toHaveBeenCalled();
+  });
+
   it('inserts a skill mention into the composer value', async () => {
     const { inputCard } = await setup();
     inputCard.setAttribute('value', 'please');


### PR DESCRIPTION
Closes #2884.

## Summary

Picking an image from the composer add-menu (the VFS file section) read it with `VirtualFS.readFile`'s **default `'utf-8'`** encoding and then `TextEncoder`-encoded that string into the inline vision `data` field. Before: the model got a JPEG/PNG whose every high byte had become `EF BF BD` — the chip rendered, the `path` still pointed at the good file, and nothing errored. Now: the read passes `{ encoding: 'binary' }` and the bytes reach `attachmentFromBytes` untouched, so the inline copy is byte-identical to the file.

## Why

`VirtualFS.readFile` with no options runs the file through a **non-fatal** `TextDecoder`, so every byte that isn't valid UTF-8 collapses to U+FFFD. `TextEncoder` does not undo that — it bakes it in.

This survived #1031, which stopped inlining *non-image* files as `kind:'text'`; the image branch kept the hop for the vision copy. Same codec class as #2818 and #2878.

**Repro** (`packages/webapp/src/ui/wc/wc-attach.ts`, `stageVfsFile`)

1. Write a JPEG into `/shared` — the SOI probe from #2818: `FF D8 FF 98 00 41 7F 80 FE`.
2. Pick it from the composer add-menu (do **not** drag-drop).
3. Base64-decode the staged attachment's `data`.

Expected: 9 bytes, `FF D8 FF 98 00 41 7F 80 FE`.
Actual (before): 21 bytes — `EF BF BD` x4, `00 41 7F`, `EF BF BD` x2.

The 256-byte `0x00..0xFF` ramp is the wider probe: 128 low bytes survive, the 128 high bytes each triple, so 256 bytes arrived as 512.

Silent by construction. The path reference still resolves, so a later `read` of that path returns the real image and the two views of the same file disagree with no diagnostic. The reported symptom is "the model can't see the screenshot I picked from `/shared`".

## Approach / Implementation notes

- `stageVfsFile` now reads through a new `readVfsImageBytes(id, openReader, log)` that passes `{ encoding: 'binary' }`. **No `TextEncoder` on file bytes anywhere on this path.**
- **Fail loudly, don't substitute U+FFFD.** `LocalVfsClient.readFile` is typed `Promise<string | Uint8Array>`, and only the `encoding` option discriminates the two — a reader that still answers a binary read with a string has *already* destroyed the bytes and there is nothing to recover. That branch does not re-encode: it `log.error`s and returns `null`, and the pick degrades to a path-only reference (the file on disk is fine, so the agent can still `read` it) instead of staging garbage. Throwing outright was the alternative; it would have dropped the user's pick entirely and lost the still-good path.
- The path-only tail of `stageVfsFile` moved into `referenceVfsFile` so both the non-image branch and the degraded-image branch build the same shape (`stat` for the size, `kind:'file'`, `path`).
- `handleAdd` threads `deps.log` in — no new dependency, no signature change on the public `wireWcAttach` surface.

## Cross-cutting impact

- **Other attach paths are untouched and still covered by their existing tests**: dropped/pasted `File`s go through `file.arrayBuffer()` (`attachmentFromFile`), camera + screen captures go through a canvas data URL (`attachmentFromCapture`), recorded video goes through `blob.arrayBuffer()`. None of them ever called `readFile`.
- **Non-image VFS picks stay path-only** — no read at all, unchanged behavior; the existing `notes.md` test still passes.
- **Floats**: VFS picks are leader-only (a follower ships no `openReader`, so the add-menu shows only the built-in quick-actions). CLI / extension / Electron / Sliccstart share the one leader code path; nothing follower-side changes.
- **Other callers**: `readVfsImageBytes` and `referenceVfsFile` are new module-private helpers with no other callers. `attachmentFromBytes` is unchanged.
- No persisted state, no wire format, no bundle change (`+0.0 kB` on both first-load graphs).

## Test plan

- [x] `npm run verify` — all 8 checks passed (biome, prettier, custom-lints, boy-scout-debt, manifest, deadcode, deadcode-prod, autofix-drift)
- [x] `node packages/dev-tools/tools/check-touched-exemptions.mjs` — clean
- [x] `npm run typecheck` — all 9 projects
- [x] `npm run test` — 20025 passing; failures below are pre-existing / environmental
- [x] `npm run test:coverage:webapp` — floors held (exit 0)
- [x] `npm run build` — every JS/TS workspace built (Swift note below)
- [x] `npm run build -w @slicc/chrome-extension` — built as part of the root build
- [x] `npm run bundle-size` — first-load `+0.0 kB` on both page and worker graphs vs merge-base `f18a7ad2`; size-limit budgets under
- [x] **New behavior is covered**: `npx vitest run --project webapp packages/webapp/tests/ui/wc/wc-attach.test.ts` — 45 passing
  - `inlines VFS-picked ramp.png byte-for-byte for vision` (256-byte `0x00..0xFF` ramp)
  - `inlines VFS-picked probe.jpg byte-for-byte for vision` (the #2818 JPEG SOI)
  - `keeps a VFS image path-only (and logs) when the reader hands back text`
- [x] **Guard verified by reverting the fix**: with the old `readFile(id)` + `TextEncoder` restored, exactly those 3 new tests fail and the other 42 still pass. The tests fail for the right reason and nothing else was pinned by accident.
- [ ] N/A for UI screencast — no visual change. The chip, thumbnail, and remove button render identically; only the base64 behind them changed.

**Pre-existing / environmental failures** (not caused by this PR):

- `check-touched-exemptions.test.mjs > passes when the changed file is NOT on the float-probe debt list` — the test writes a fake entry into the real `float-probe-baseline.json`, which trips the gate's separate "list must not grow vs base ref" check locally. Reproduced by hand with a clean working tree; this PR does not touch that baseline.
- `check-skill-router-sync.test.mjs` (7) and `service-worker-secrets.test.ts` (1) — pass on re-run outside the agent sandbox; they are `mktemp`/tmp-dir artifacts of the sandbox, not real failures.
- `npm run build -w @slicc/swift-server` cannot run in the agent sandbox (`sandbox-exec: sandbox_apply: Operation not permitted` from SwiftPM's own nested sandbox). No Swift file is touched by this PR.

## Documentation

- [x] `docs/` — new `docs/pitfalls.md` section "`readFile` Defaults to utf-8 — Binary Callers Must Ask": the default encoding, why `typeof raw === 'string'` narrowing compiles but is wrong at runtime, why re-encoding the decoded string cannot undo it, and the degrade-don't-inline rule.
- [x] No `README.md` change — no user-facing behavior change beyond "the picked image now works".
- [x] No `CLAUDE.md` change — `packages/webapp/CLAUDE.md` is near its size cap and this is a subsystem detail, so it went to `docs/`.

## Risk & rollback

- Blast radius: one branch of `stageVfsFile`, leader floats only. The failure mode it replaces was total (unusable image bytes), so the new path is strictly better; the worst regression would be an image that now degrades to path-only, which is still a working attachment.
- No feature flag, no persisted state, no migration. Revert this PR cleanly to roll back.
- **CI cannot catch the live pick.** The unit tests drive a real `VirtualFS`, which is the same `readFile` production takes, but the end-to-end confirmation is: put a real screenshot in `/shared`, pick it from the add-menu, and check the model actually describes it.

## Checklist

- [x] Commits are focused and package-local where possible
- [x] No hand-edited files under `dist/`
- [x] No secrets, credentials, or tokens in the diff
- [x] No public API / tool / shell-command / lick-channel change — `wireWcAttach`'s signature is unchanged
- [x] Follower path checked: no `openReader` means no VFS pick, so nothing to mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)
